### PR TITLE
Update Readme with some links to the wiki and forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@ rpcs3
 =====
 
 PS3 emulator/debugger
+
+The [FAQ](https://github.com/DHrpcs3/rpcs3/wiki/FAQ) has some basic information.
+
+For discussion about the emulator and PS3 emulation please visit the [official forums](http://www.emunewz.net/forum/forumdisplay.php?fid=162).
+
+If you want to contribute please take a took at the [Coding Style](https://github.com/DHrpcs3/rpcs3/wiki/Coding-Style) and [Roadmap](https://github.com/DHrpcs3/rpcs3/wiki/Roadmap) pages.
+


### PR DESCRIPTION
Some basic stuff, I was too stupid to find the forum via google, so I assume other people are similarly retarded.

Anyway, sadly there doesn't seem to be a way to link to the wiki in a non-absolute way but them's the brakes.
