### PR TITLE
fix stepping a little better than last time

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -52,11 +52,12 @@ void ThreadBase::Start()
 		});
 }
 
-void ThreadBase::Stop(bool wait)
+void ThreadBase::Stop(bool wait, bool send_destroy)
 {
 	std::lock_guard<std::mutex> lock(m_main_mutex);
 
-	m_destroy = true;
+	if (send_destroy)
+		m_destroy = true;
 
 	if(!m_executor)
 		return;

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -41,7 +41,7 @@ protected:
 
 public:
 	void Start();
-	void Stop(bool wait = true);
+	void Stop(bool wait = true, bool send_destroy = true);
 
 	bool Join() const;
 	bool IsAlive() const;

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -284,8 +284,10 @@ void CPUThread::ExecOnce()
 #ifndef QT_UI
 	wxGetApp().SendDbgCommand(DID_EXEC_THREAD, this);
 #endif
+	m_status = Running;
 	ThreadBase::Start();
-	ThreadBase::Stop();
+	ThreadBase::Stop(true,false);
+	m_status = Paused;
 #ifndef QT_UI
 	wxGetApp().SendDbgCommand(DID_PAUSE_THREAD, this);
 	wxGetApp().SendDbgCommand(DID_PAUSED_THREAD, this);


### PR DESCRIPTION
Ok, so this is the one thing I can do without touching the rest of the code.

The whole emulation- and threadstate thing is still a little wobbly but this doesn't make things worse. The only remaining Issue I found was running something, then pausing the main thread, then pausing and resuming the emulator, this results in a unrecoverable pause state for the emulation thread. 
