### PR TITLE
Use Push instead of AddCpy in CallStackBranch.

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -226,7 +226,7 @@ public:
 		new_item.branch_pc = pc;
 		new_item.pc = PC;
 
-		m_call_stack.AddCpy(new_item);
+		m_call_stack.Push(new_item);
 	}
 
 	virtual u64 CallStackGetNextPC(u64 pc)


### PR DESCRIPTION
Same thing really, only semantically more descriptive.

Just some things I saw that are peculiar though, in CallStackBranch and CallStackToString, there is just arbitrary looping of the stack. Isn't it incorrect design to allow iteration of a stack without popping the contents? If I'm wrong, just tell me; genuinely curious.
