### PR TITLE
Fix a hang after failing to run an *.elf file and stopping emulator

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -30,7 +30,7 @@ CPUThread::~CPUThread()
 
 void CPUThread::Close()
 {
-	ThreadBase::Stop();
+	ThreadBase::Stop(m_sync_wait);
 	DoStop();
 
 	delete m_dec;


### PR DESCRIPTION
This function is called on the stop button to kill the CPU thread. The default parameter for the ThreadBase::Stop() takes a wait parameter that is set to true, causing the thread to deadlock (presumably) on a join. 
