### PR TITLE
Minor code and memory initialization fixes

### DIFF
--- a/rpcs3/Emu/Memory/Memory.cpp
+++ b/rpcs3/Emu/Memory/Memory.cpp
@@ -535,7 +535,7 @@ template<> __forceinline u64 MemoryBase::ReverseData<2>(u64 val) { return Revers
 template<> __forceinline u64 MemoryBase::ReverseData<4>(u64 val) { return Reverse32(val); }
 template<> __forceinline u64 MemoryBase::ReverseData<8>(u64 val) { return Reverse64(val); }
 
-VirtualMemoryBlock::VirtualMemoryBlock() : MemoryBlock()
+VirtualMemoryBlock::VirtualMemoryBlock() : MemoryBlock(), m_reserve_size(0)
 {
 }
 

--- a/rpcs3/Emu/Memory/MemoryBlock.h
+++ b/rpcs3/Emu/Memory/MemoryBlock.h
@@ -13,7 +13,7 @@ struct MemInfo
 	{
 	}
 
-	MemInfo()
+	MemInfo() : addr(0), size(0)
 	{
 	}
 };


### PR DESCRIPTION
- Explicitly initialize member variables in SELFDecrypter, MemInfo, and
  VirtualMemoryBlock
- Zero out memory used for counter/nonce in aes-ctr
- Fix use of a ControlInfo pointer after it is added to an Array via
  Array::Move (which makes it an invalid pointer) in
  SELFDecrypter::LoadHeaders
