### PR TITLE
Fixes invalid conversion from wxStringConst, to std::string under gcc-4-8

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/cellSysutil_SaveData.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSysutil_SaveData.cpp
@@ -102,7 +102,7 @@ int cellSaveDataListSave2(u32 version, mem_ptr_t<CellSaveDataSetList> setList, m
 	if(!dir.IsOpened())
 		return CELL_SAVEDATA_ERROR_INTERNAL;
 
-	std::string dirNamePrefix = Memory.ReadString(setList->dirNamePrefix_addr).mb_str();
+	std::string dirNamePrefix = std::string(Memory.ReadString(setList->dirNamePrefix_addr).mb_str());
 	std::vector<SaveDataListEntry> saveEntries;
 	for(const DirEntryInfo* entry = dir.Read(); entry; entry = dir.Read())
 	{
@@ -165,7 +165,7 @@ int cellSaveDataListLoad2(u32 version, mem_ptr_t<CellSaveDataSetList> setList, m
 	if(!dir.IsOpened())
 		return CELL_SAVEDATA_ERROR_INTERNAL;
 
-	std::string dirNamePrefix = Memory.ReadString(setList->dirNamePrefix_addr).mb_str();
+	std::string dirNamePrefix = std::string(Memory.ReadString(setList->dirNamePrefix_addr).mb_str());
 	std::vector<SaveDataListEntry> saveEntries;
 	for(const DirEntryInfo* entry = dir.Read(); entry; entry = dir.Read())
 	{


### PR DESCRIPTION
Probably a bit of hack - I don't understand why this won't be done implicitly. Would appreciate someone explaining that, if they don't mind. Should be win-tested, too.
