### PR TITLE
Memset the ringbuffer in m_fs_config by the size of the actual ringbuffer struct, not FsRingBufferConfig's size..

### DIFF
--- a/rpcs3/Emu/SysCalls/lv2/SC_FileSystem.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_FileSystem.cpp
@@ -33,12 +33,12 @@ struct FsRingBufferConfig
 		, m_alloc_mem_size(0)
 		, m_current_addr(0)
 	{
-		memset(&m_ring_buffer, 0, sizeof(FsRingBufferConfig));
+		memset(&m_ring_buffer, 0, sizeof(FsRingBuffer));
 	}
 
 	~FsRingBufferConfig()
 	{
-		memset(&m_ring_buffer, 0, sizeof(FsRingBufferConfig));
+		memset(&m_ring_buffer, 0, sizeof(FsRingBuffer));
 	}
 } m_fs_config;
 


### PR DESCRIPTION
Would be an overflow otherwise.
