### PR TITLE
Make GLFragmentDecompilerThread not overwrite the given size in it's constructor arguments.

### DIFF
--- a/rpcs3/Emu/GS/GL/GLFragmentProgram.h
+++ b/rpcs3/Emu/GS/GL/GLFragmentProgram.h
@@ -118,7 +118,6 @@ struct GLFragmentDecompilerThread : public ThreadBase
 		, m_location(0)
 		, m_ctrl(ctrl)
 	{
-		m_size = 0;
 	}
 
 	std::string GetMask();


### PR DESCRIPTION
Seems kind of fishy that m_size takes the given size in the initializer list, but resets it back to zero in the constructor.

This will require input from someone who is doing work in the GS/GL stuff. As far as I know, this is wrong, since the given program's size is just ignored.
