### PR TITLE
Various warning fixes and devirtualization

### DIFF
--- a/Utilities/Array.h
+++ b/Utilities/Array.h
@@ -142,9 +142,9 @@ public:
 		return m_array[num];
 	}
 
-	virtual u32 GetCount() const { return m_count; }
+	u32 GetCount() const { return m_count; }
 
-	virtual void SetCount(const u32 count, bool memzero = true)
+	void SetCount(const u32 count, bool memzero = true)
 	{
 		if(m_count >= count) return;
 
@@ -196,96 +196,6 @@ protected:
 
 		m_array = m_count ? (T*)realloc(m_array, sizeof(T) * (m_count + size)) : (T*)malloc(sizeof(T) * size);
 		m_count += size;
-	}
-};
-
-class ArrayString : public Array<char>
-{
-public:
-	ArrayString() : Array()
-	{
-	}
-
-	ArrayString(const wxString& value) : Array()
-	{
-		*this = value;
-	}
-
-	ArrayString(const char* value) : Array()
-	{
-		*this = value;
-	}
-
-	virtual u32 GetCount() const
-	{
-		return m_array ? strlen(m_array) : 0;
-	}
-
-	virtual void SetCount(const u32 count, bool memzero = true)
-	{
-		if(m_count && count < m_count - 1)
-		{
-			m_array[count] = '\0';
-		}
-		else
-		{
-			Array::SetCount(count + 1, memzero);
-		}
-	}
-
-	ArrayString& operator = (const char* right)
-	{
-		Clear();
-
-		if(right)
-		{
-			size_t len = strlen(right);
-
-			if(len)
-			{
-				SetCount(len);
-				memcpy(m_array, right, len * sizeof(char));
-				m_array[len] = '\0';
-			}
-		}
-
-		return *this;
-	}
-
-	ArrayString& operator = (const ArrayString& right)
-	{
-		Clear();
-
-		if(size_t len = right.GetCount())
-		{
-			SetCount(len);
-			memcpy(m_array, right.GetPtr(), len * sizeof(char));
-			m_array[len] = '\0';
-		}
-
-		return *this;
-	}
-
-	ArrayString& operator = (const wxString& right)
-	{
-		Clear();
-
-		if(size_t len = right.Len())
-		{
-			SetCount(len);
-			memcpy(m_array, right.c_str(), len * sizeof(char));
-			m_array[len] = '\0';
-		}
-
-		return *this;
-	}
-
-	ArrayString* Clone() const
-	{
-		ArrayString* new_array = new ArrayString();
-		(*new_array) = m_array;
-
-		return new_array;
 	}
 };
 

--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -1,20 +1,20 @@
 #include "stdafx.h"
 #include "StrFmt.h"
 
-static const std::string fmt::placeholder = "???";
+extern const std::string fmt::placeholder = "???";
 
 
 //wrapper to deal with advance sprintf formating options with automatic length finding
 //can't take strings by reference because of "va_start", so overload it with char *
 std::string fmt::FormatV(const char *fmt, va_list args)
 {
-	int length = 256;
+	size_t length = 256;
 	std::string str;
 
 	for (;;)
 	{
 		std::vector<char> buffptr(length);
-		size_t printlen = vsnprintf(buffptr.data(), length, fmt, args);
+		int printlen = vsnprintf(buffptr.data(), length, fmt, args);
 		if (printlen >= 0 && printlen < length)
 		{
 			str = std::string(buffptr.data(), printlen);

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -78,13 +78,13 @@ namespace fmt{
 	template<typename  ... Args>
 	string Format(const string &fmt, Args&& ... parameters)
 	{
-		int length = 256;
+		size_t length = 256;
 		string str;
 
 		for (;;)
 		{
 			std::vector<char> buffptr(length);
-			size_t printlen = snprintf(buffptr.data(), length, fmt.c_str(), std::forward<Args>(parameters)...);
+			int printlen = snprintf(buffptr.data(), length, fmt.c_str(), std::forward<Args>(parameters)...);
 			if (printlen >= 0 && printlen < length)
 			{
 				str = string(buffptr.data(), printlen);

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -622,8 +622,6 @@ bool CheckDebugSelf(const std::string& self, const std::string& elf)
 		s.Seek(0);
 		return false;
 	}
-
-	s.Close();
 }
 
 bool DecryptSelf(const std::string& elf, const std::string& self)

--- a/rpcs3/Gui/ConLog.h
+++ b/rpcs3/Gui/ConLog.h
@@ -11,7 +11,7 @@ class LogWriter
 	//wxString m_prefix;
 	//wxString m_value;
 
-	virtual void WriteToLog(const std::string& prefix, const std::string& value, u8 lvl);
+	void WriteToLog(const std::string& prefix, const std::string& value, u8 lvl);
 
 public:
 	LogWriter();

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -25,19 +25,19 @@ protected:
 	wxConfigBase* m_Config;
 
 	Ini();
-	virtual void Save(const wxString& key, int value);
-	virtual void Save(const wxString& key, bool value);
-	virtual void Save(const wxString& key, wxSize value);
-	virtual void Save(const wxString& key, wxPoint value);
-	virtual void Save(const wxString& key, const std::string& value);
-	virtual void Save(const wxString& key, WindowInfo value);
+	void Save(const wxString& key, int value);
+	void Save(const wxString& key, bool value);
+	void Save(const wxString& key, wxSize value);
+	void Save(const wxString& key, wxPoint value);
+	void Save(const wxString& key, const std::string& value);
+	void Save(const wxString& key, WindowInfo value);
 
-	virtual int Load(const wxString& key, const int def_value);
-	virtual bool Load(const wxString& key, const bool def_value);
-	virtual wxSize Load(const wxString& key, const wxSize def_value);
-	virtual wxPoint Load(const wxString& key, const wxPoint def_value);
-	virtual std::string Load(const wxString& key, const std::string& def_value);
-	virtual WindowInfo Load(const wxString& key, const WindowInfo& def_value);
+	int Load(const wxString& key, const int def_value);
+	bool Load(const wxString& key, const bool def_value);
+	wxSize Load(const wxString& key, const wxSize def_value);
+	wxPoint Load(const wxString& key, const wxPoint def_value);
+	std::string Load(const wxString& key, const std::string& def_value);
+	WindowInfo Load(const wxString& key, const WindowInfo& def_value);
 };
 
 template<typename T> struct IniEntry : public Ini
@@ -95,7 +95,7 @@ public:
 	IniEntry<u8> CPUDecoderMode;
 	IniEntry<bool> CPUIgnoreRWErrors;
 	IniEntry<u8> GSRenderMode;
-	IniEntry<int> GSResolution;
+	IniEntry<u8> GSResolution;
 	IniEntry<u8> GSAspectRatio;
 	IniEntry<bool> GSVSyncEnable;
 	IniEntry<bool> GSLogPrograms;


### PR DESCRIPTION
- Remove ArrayString (not used anymore, replaced by vectorstd::string everywhere)
- devirtualize GetCount and SetCount, they're no longer needed
- set storage duration of fmt::placeholder to extern to be consistent
- make length unsigned and the return value of sprintf signed
- remove dead code "s.Close()" is never reached
- devirtualize WrteToLog()
- devirtualize Ini functions
