### PR TITLE
RSX Bugfixes and plugging memory leaks

### DIFF
--- a/Utilities/IdManager.h
+++ b/Utilities/IdManager.h
@@ -50,6 +50,14 @@ struct ID
 	{
 	}
 
+	ID(ID&& other)
+	{
+		m_name = other.m_name;
+		m_attr = other.m_attr;
+		m_data = other.m_data;
+		other.m_data = nullptr;
+	}
+
 	void Kill()
 	{
 		delete m_data;

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -35,6 +35,8 @@ ThreadBase::~ThreadBase()
 {
 	if(IsAlive())
 		Stop(false);
+
+	safe_delete(m_executor);
 }
 
 void ThreadBase::Start()

--- a/rpcs3.sln
+++ b/rpcs3.sln
@@ -1,5 +1,5 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
+# Visual Studio Express 2013 for Windows Desktop
 VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rpcs3", "rpcs3\rpcs3.vcxproj", "{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}"
@@ -82,12 +82,18 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wxscintilla", "wxWidgets\bu
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug - MemLeak|Win32 = Debug - MemLeak|Win32
+		Debug - MemLeak|x64 = Debug - MemLeak|x64
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Debug|Win32.ActiveCfg = Debug|Win32
 		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Debug|Win32.Build.0 = Debug|Win32
 		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Debug|x64.ActiveCfg = Debug|x64
@@ -96,6 +102,10 @@ Global
 		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Release|Win32.Build.0 = Release|Win32
 		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Release|x64.ActiveCfg = Release|x64
 		{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}.Release|x64.Build.0 = Release|x64
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Debug|Win32.ActiveCfg = Debug|Win32
 		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Debug|Win32.Build.0 = Debug|Win32
 		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Debug|x64.ActiveCfg = Debug|x64
@@ -104,6 +114,10 @@ Global
 		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Release|Win32.Build.0 = Release|Win32
 		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Release|x64.ActiveCfg = Release|x64
 		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}.Release|x64.Build.0 = Release|x64
+		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Debug|Win32.ActiveCfg = Debug|Win32
 		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Debug|Win32.Build.0 = Debug|Win32
 		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Debug|x64.ActiveCfg = Debug|x64
@@ -112,6 +126,10 @@ Global
 		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Release|Win32.Build.0 = Release|Win32
 		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Release|x64.ActiveCfg = Release|x64
 		{7047EE97-7F80-A70D-6147-BC11102DB6F4}.Release|x64.Build.0 = Release|x64
+		{3111D679-7796-23C4-BA0C-271F1145DA24}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{3111D679-7796-23C4-BA0C-271F1145DA24}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{3111D679-7796-23C4-BA0C-271F1145DA24}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{3111D679-7796-23C4-BA0C-271F1145DA24}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{3111D679-7796-23C4-BA0C-271F1145DA24}.Debug|Win32.ActiveCfg = Debug|Win32
 		{3111D679-7796-23C4-BA0C-271F1145DA24}.Debug|Win32.Build.0 = Debug|Win32
 		{3111D679-7796-23C4-BA0C-271F1145DA24}.Debug|x64.ActiveCfg = Debug|x64
@@ -120,6 +138,10 @@ Global
 		{3111D679-7796-23C4-BA0C-271F1145DA24}.Release|Win32.Build.0 = Release|Win32
 		{3111D679-7796-23C4-BA0C-271F1145DA24}.Release|x64.ActiveCfg = Release|x64
 		{3111D679-7796-23C4-BA0C-271F1145DA24}.Release|x64.Build.0 = Release|x64
+		{067D9406-2A93-DACA-9449-93A2D356357D}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{067D9406-2A93-DACA-9449-93A2D356357D}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{067D9406-2A93-DACA-9449-93A2D356357D}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{067D9406-2A93-DACA-9449-93A2D356357D}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{067D9406-2A93-DACA-9449-93A2D356357D}.Debug|Win32.ActiveCfg = Debug|Win32
 		{067D9406-2A93-DACA-9449-93A2D356357D}.Debug|Win32.Build.0 = Debug|Win32
 		{067D9406-2A93-DACA-9449-93A2D356357D}.Debug|x64.ActiveCfg = Debug|x64
@@ -128,6 +150,10 @@ Global
 		{067D9406-2A93-DACA-9449-93A2D356357D}.Release|Win32.Build.0 = Release|Win32
 		{067D9406-2A93-DACA-9449-93A2D356357D}.Release|x64.ActiveCfg = Release|x64
 		{067D9406-2A93-DACA-9449-93A2D356357D}.Release|x64.Build.0 = Release|x64
+		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Debug|Win32.ActiveCfg = Debug|Win32
 		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Debug|Win32.Build.0 = Debug|Win32
 		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Debug|x64.ActiveCfg = Debug|x64
@@ -136,6 +162,10 @@ Global
 		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Release|Win32.Build.0 = Release|Win32
 		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Release|x64.ActiveCfg = Release|x64
 		{9ED1866B-D4AE-3440-24E4-7A9475B163B2}.Release|x64.Build.0 = Release|x64
+		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Debug|Win32.ActiveCfg = Debug|Win32
 		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Debug|Win32.Build.0 = Debug|Win32
 		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Debug|x64.ActiveCfg = Debug|x64
@@ -144,6 +174,10 @@ Global
 		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Release|Win32.Build.0 = Release|Win32
 		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Release|x64.ActiveCfg = Release|x64
 		{99C9EB95-DB4C-1996-490E-5212EFBF07C3}.Release|x64.Build.0 = Release|x64
+		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Debug|Win32.ActiveCfg = Debug|Win32
 		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Debug|Win32.Build.0 = Debug|Win32
 		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Debug|x64.ActiveCfg = Debug|x64
@@ -152,6 +186,10 @@ Global
 		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Release|Win32.Build.0 = Release|Win32
 		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Release|x64.ActiveCfg = Release|x64
 		{6EDC3B79-D217-F11A-406F-F11D856493F9}.Release|x64.Build.0 = Release|x64
+		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Debug|Win32.ActiveCfg = Debug|Win32
 		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Debug|Win32.Build.0 = Debug|Win32
 		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Debug|x64.ActiveCfg = Debug|x64
@@ -160,6 +198,10 @@ Global
 		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Release|Win32.Build.0 = Release|Win32
 		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Release|x64.ActiveCfg = Release|x64
 		{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}.Release|x64.Build.0 = Release|x64
+		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Debug|Win32.ActiveCfg = Debug|Win32
 		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Debug|Win32.Build.0 = Debug|Win32
 		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Debug|x64.ActiveCfg = Debug|x64
@@ -168,6 +210,10 @@ Global
 		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Release|Win32.Build.0 = Release|Win32
 		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Release|x64.ActiveCfg = Release|x64
 		{CD478F02-7550-58A5-E085-CE4BC0C0AD23}.Release|x64.Build.0 = Release|x64
+		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Debug|Win32.ActiveCfg = Debug|Win32
 		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Debug|Win32.Build.0 = Debug|Win32
 		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Debug|x64.ActiveCfg = Debug|x64
@@ -176,6 +222,10 @@ Global
 		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Release|Win32.Build.0 = Release|Win32
 		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Release|x64.ActiveCfg = Release|x64
 		{22B14659-C5B6-B775-868D-A49198FEAD4A}.Release|x64.Build.0 = Release|x64
+		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Debug|Win32.ActiveCfg = Debug|Win32
 		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Debug|Win32.Build.0 = Debug|Win32
 		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Debug|x64.ActiveCfg = Debug|x64
@@ -184,6 +234,10 @@ Global
 		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Release|Win32.Build.0 = Release|Win32
 		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Release|x64.ActiveCfg = Release|x64
 		{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}.Release|x64.Build.0 = Release|x64
+		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Debug|Win32.ActiveCfg = Debug|Win32
 		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Debug|Win32.Build.0 = Debug|Win32
 		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Debug|x64.ActiveCfg = Debug|x64
@@ -192,6 +246,10 @@ Global
 		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Release|Win32.Build.0 = Release|Win32
 		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Release|x64.ActiveCfg = Release|x64
 		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}.Release|x64.Build.0 = Release|x64
+		{5C363C34-4741-7036-861C-2E2279CF552E}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{5C363C34-4741-7036-861C-2E2279CF552E}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{5C363C34-4741-7036-861C-2E2279CF552E}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{5C363C34-4741-7036-861C-2E2279CF552E}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{5C363C34-4741-7036-861C-2E2279CF552E}.Debug|Win32.ActiveCfg = Debug|Win32
 		{5C363C34-4741-7036-861C-2E2279CF552E}.Debug|Win32.Build.0 = Debug|Win32
 		{5C363C34-4741-7036-861C-2E2279CF552E}.Debug|x64.ActiveCfg = Debug|x64
@@ -200,6 +258,10 @@ Global
 		{5C363C34-4741-7036-861C-2E2279CF552E}.Release|Win32.Build.0 = Release|Win32
 		{5C363C34-4741-7036-861C-2E2279CF552E}.Release|x64.ActiveCfg = Release|x64
 		{5C363C34-4741-7036-861C-2E2279CF552E}.Release|x64.Build.0 = Release|x64
+		{76169FE8-0814-4F36-6409-699EF1A23001}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{76169FE8-0814-4F36-6409-699EF1A23001}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{76169FE8-0814-4F36-6409-699EF1A23001}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{76169FE8-0814-4F36-6409-699EF1A23001}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{76169FE8-0814-4F36-6409-699EF1A23001}.Debug|Win32.ActiveCfg = Debug|Win32
 		{76169FE8-0814-4F36-6409-699EF1A23001}.Debug|Win32.Build.0 = Debug|Win32
 		{76169FE8-0814-4F36-6409-699EF1A23001}.Debug|x64.ActiveCfg = Debug|x64
@@ -208,6 +270,10 @@ Global
 		{76169FE8-0814-4F36-6409-699EF1A23001}.Release|Win32.Build.0 = Release|Win32
 		{76169FE8-0814-4F36-6409-699EF1A23001}.Release|x64.ActiveCfg = Release|x64
 		{76169FE8-0814-4F36-6409-699EF1A23001}.Release|x64.Build.0 = Release|x64
+		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Debug|Win32.ActiveCfg = Debug|Win32
 		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Debug|Win32.Build.0 = Debug|Win32
 		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Debug|x64.ActiveCfg = Debug|x64
@@ -216,6 +282,10 @@ Global
 		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Release|Win32.Build.0 = Release|Win32
 		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Release|x64.ActiveCfg = Release|x64
 		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01}.Release|x64.Build.0 = Release|x64
+		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Debug|Win32.ActiveCfg = Debug|Win32
 		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Debug|Win32.Build.0 = Debug|Win32
 		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Debug|x64.ActiveCfg = Debug|x64
@@ -224,6 +294,10 @@ Global
 		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Release|Win32.Build.0 = Release|Win32
 		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Release|x64.ActiveCfg = Release|x64
 		{B87216CD-6C64-1DB0-D900-BC6E745C1DF9}.Release|x64.Build.0 = Release|x64
+		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Debug|Win32.ActiveCfg = Debug|Win32
 		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Debug|Win32.Build.0 = Debug|Win32
 		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Debug|x64.ActiveCfg = Debug|x64
@@ -232,6 +306,10 @@ Global
 		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Release|Win32.Build.0 = Release|Win32
 		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Release|x64.ActiveCfg = Release|x64
 		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}.Release|x64.Build.0 = Release|x64
+		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Debug|Win32.ActiveCfg = Debug|Win32
 		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Debug|Win32.Build.0 = Debug|Win32
 		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Debug|x64.ActiveCfg = Debug|x64
@@ -240,6 +318,10 @@ Global
 		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Release|Win32.Build.0 = Release|Win32
 		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Release|x64.ActiveCfg = Release|x64
 		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}.Release|x64.Build.0 = Release|x64
+		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Debug|Win32.ActiveCfg = Debug|Win32
 		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Debug|Win32.Build.0 = Debug|Win32
 		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Debug|x64.ActiveCfg = Debug|x64
@@ -248,6 +330,10 @@ Global
 		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Release|Win32.Build.0 = Release|Win32
 		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Release|x64.ActiveCfg = Release|x64
 		{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}.Release|x64.Build.0 = Release|x64
+		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Debug|Win32.ActiveCfg = Debug|Win32
 		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Debug|Win32.Build.0 = Debug|Win32
 		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Debug|x64.ActiveCfg = Debug|x64
@@ -256,6 +342,10 @@ Global
 		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Release|Win32.Build.0 = Release|Win32
 		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Release|x64.ActiveCfg = Release|x64
 		{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}.Release|x64.Build.0 = Release|x64
+		{23E1C437-A951-5943-8639-A17F3CF2E606}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{23E1C437-A951-5943-8639-A17F3CF2E606}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{23E1C437-A951-5943-8639-A17F3CF2E606}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{23E1C437-A951-5943-8639-A17F3CF2E606}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{23E1C437-A951-5943-8639-A17F3CF2E606}.Debug|Win32.ActiveCfg = Debug|Win32
 		{23E1C437-A951-5943-8639-A17F3CF2E606}.Debug|Win32.Build.0 = Debug|Win32
 		{23E1C437-A951-5943-8639-A17F3CF2E606}.Debug|x64.ActiveCfg = Debug|x64
@@ -264,6 +354,10 @@ Global
 		{23E1C437-A951-5943-8639-A17F3CF2E606}.Release|Win32.Build.0 = Release|Win32
 		{23E1C437-A951-5943-8639-A17F3CF2E606}.Release|x64.ActiveCfg = Release|x64
 		{23E1C437-A951-5943-8639-A17F3CF2E606}.Release|x64.Build.0 = Release|x64
+		{74827EBD-93DC-5110-BA95-3F2AB029B6B0}.Debug - MemLeak|Win32.ActiveCfg = Debug - MemLeak|Win32
+		{74827EBD-93DC-5110-BA95-3F2AB029B6B0}.Debug - MemLeak|Win32.Build.0 = Debug - MemLeak|Win32
+		{74827EBD-93DC-5110-BA95-3F2AB029B6B0}.Debug - MemLeak|x64.ActiveCfg = Debug - MemLeak|x64
+		{74827EBD-93DC-5110-BA95-3F2AB029B6B0}.Debug - MemLeak|x64.Build.0 = Debug - MemLeak|x64
 		{74827EBD-93DC-5110-BA95-3F2AB029B6B0}.Debug|Win32.ActiveCfg = Debug|Win32
 		{74827EBD-93DC-5110-BA95-3F2AB029B6B0}.Debug|Win32.Build.0 = Debug|Win32
 		{74827EBD-93DC-5110-BA95-3F2AB029B6B0}.Debug|x64.ActiveCfg = Debug|x64

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -26,6 +26,7 @@ CPUThread::CPUThread(CPUThreadType type)
 
 CPUThread::~CPUThread()
 {
+	safe_delete(m_dec);
 }
 
 void CPUThread::Close()

--- a/rpcs3/Emu/Cell/PPCDecoder.h
+++ b/rpcs3/Emu/Cell/PPCDecoder.h
@@ -8,6 +8,8 @@ public:
 	virtual void Decode(const u32 code)=0;
 
 	virtual u8 DecodeMemory(const u64 address);
+
+	virtual ~PPCDecoder() = default;
 };
 
 

--- a/rpcs3/Emu/Cell/PPUDecoder.h
+++ b/rpcs3/Emu/Cell/PPUDecoder.h
@@ -9,11 +9,11 @@ class PPUDecoder : public PPCDecoder
 	PPUOpcodes* m_op;
 
 public:
-	PPUDecoder(PPUOpcodes& op) : m_op(&op)
+	PPUDecoder(PPUOpcodes* op) : m_op(op)
 	{
 	}
 
-	~PPUDecoder()
+	virtual ~PPUDecoder()
 	{
 		delete m_op;
 	}

--- a/rpcs3/Emu/Cell/PPUInstrTable.h
+++ b/rpcs3/Emu/Cell/PPUInstrTable.h
@@ -203,7 +203,9 @@ namespace PPU_instr
 
 	static CodeField<9, 10> STRM;
 
-	static auto main_list = new_list(OPCD, instr_bind(&PPUOpcodes::UNK, GetCode, OPCD, OPCD));
+	//static auto main_list = new_list(OPCD, instr_bind(&PPUOpcodes::UNK, GetCode, OPCD, OPCD));
+	static InstrList<1 << CodeField<0, 5>::size, ::PPUOpcodes> main_list_obj(OPCD, instr_bind(&PPUOpcodes::UNK, GetCode, OPCD, OPCD));
+	static auto main_list = &main_list_obj;
 	static auto g04_list = new_list(main_list, PPU_opcodes::G_04, GD_04);
 	static auto g04_0_list = new_list(g04_list, GD_04_0, instr_bind(&PPUOpcodes::UNK, GetCode, OPCD, GD_04_0));
 	static auto g13_list = new_list(main_list, PPU_opcodes::G_13, GD_13, instr_bind(&PPUOpcodes::UNK, GetCode, OPCD, GD_13));

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -150,7 +150,8 @@ void PPUThread::DoRun()
 
 	case 1:
 	case 2:
-		m_dec = new PPUDecoder(*new PPUInterpreter(*this));
+		auto ppui = new PPUInterpreter(*this);
+		m_dec = new PPUDecoder(ppui);
 	break;
 	}
 }

--- a/rpcs3/Emu/Cell/SPUInstrTable.h
+++ b/rpcs3/Emu/Cell/SPUInstrTable.h
@@ -39,7 +39,9 @@ namespace SPU_instr
 	static CodeField<18, 31> L_18_31;
 	static CodeField<11> L_11;
 
-	static auto rrr_list = new_list<SPUOpcodes>(RRR);
+	// static auto rrr_list = new_list<SPUOpcodes>(RRR);
+	static InstrList<1 << CodeField<0, 3>::size, SPUOpcodes> rrr_list_obj(RRR, nullptr);
+	static auto rrr_list = &rrr_list_obj;
 	static auto ri18_list = new_list(rrr_list, RI18);
 	static auto ri10_list = new_list(ri18_list, RI10);
 	static auto ri16_list = new_list(ri10_list, RI16);

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -1180,7 +1180,7 @@ public:
 					reg_value0 = std::stoull(value.substr(16, 31), 0, 16);
 					reg_value1 = std::stoull(value.substr(0, 15), 0, 16);
 				}
-				catch (std::invalid_argument& e)
+				catch (std::invalid_argument& /*e*/)
 				{
 					return false;
 				}

--- a/rpcs3/Emu/DbgConsole.cpp
+++ b/rpcs3/Emu/DbgConsole.cpp
@@ -26,6 +26,11 @@ DbgConsole::~DbgConsole()
 {
 	ThreadBase::Stop();
 	m_dbg_buffer.Flush();
+
+	safe_delete(m_console);
+	safe_delete(m_color_white);
+	safe_delete(m_color_red);
+	safe_delete(m_output);
 }
 
 void DbgConsole::Write(int ch, const std::string& text)

--- a/rpcs3/Emu/FS/VFS.cpp
+++ b/rpcs3/Emu/FS/VFS.cpp
@@ -14,6 +14,11 @@ int sort_devices(const void* _a, const void* _b)
 	return 0;
 }
 
+VFS::~VFS()
+{
+	UnMountAll();
+}
+
 void VFS::Mount(const std::string& ps3_path, const std::string& local_path, vfsDevice* device)
 {
 	UnMount(ps3_path);
@@ -46,8 +51,9 @@ void VFS::UnMountAll()
 	for(u32 i=0; i<m_devices.size(); ++i)
 	{
 		delete m_devices[i];
-		m_devices.erase(m_devices.begin() +i);
 	}
+
+	m_devices.clear();
 }
 
 vfsFileBase* VFS::OpenFile(const std::string& ps3_path, vfsOpenMode mode) const

--- a/rpcs3/Emu/FS/VFS.h
+++ b/rpcs3/Emu/FS/VFS.h
@@ -41,8 +41,13 @@ struct VFSManagerEntry
 
 struct VFS
 {
+	~VFS();
+
 	//TODO: find out where these are supposed to be deleted or just make it shared_ptr
 	//and also make GetDevice and GetDeviceLocal return shared_ptr then.
+	// A vfsDevice will be deleted when they're unmounted or the VFS struct is destroyed.
+	// This will cause problems if other code stores the pointer returned by GetDevice/GetDeviceLocal
+	// and tries to use it after the device is unmounted.
 	std::vector<vfsDevice *> m_devices;
 	void Mount(const std::string& ps3_path, const std::string& local_path, vfsDevice* device);
 	void UnMount(const std::string& ps3_path);

--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -397,12 +397,11 @@ bool GLGSRender::LoadProgram()
 	{
 		ConLog.Warning("FP not found in buffer!");
 		m_shader_prog.Decompile(*m_cur_shader_prog);
-		m_shader_prog.Wait();
 		m_shader_prog.Compile();
 		checkForGlError("m_shader_prog.Compile");
 
 		wxFile f(wxGetCwd() + "/FragmentProgram.txt", wxFile::write);
-		f.Write(m_shader_prog.shader);
+		f.Write(m_shader_prog.GetShaderText());
 	}
 
 	if(m_vp_buf_num == -1)
@@ -433,7 +432,7 @@ bool GLGSRender::LoadProgram()
 				{
 					// TODO: This isn't working perfectly. Is there any better/shorter way to update the program
 					m_vertex_prog.shader = program.vp_shader;
-					m_shader_prog.shader = program.fp_shader;
+					m_shader_prog.SetShaderText(program.fp_shader);
 					m_vertex_prog.Wait();
 					m_vertex_prog.Compile();
 					checkForGlError("m_vertex_prog.Compile");
@@ -441,13 +440,13 @@ bool GLGSRender::LoadProgram()
 					m_shader_prog.Compile();
 					checkForGlError("m_shader_prog.Compile");
 					glAttachShader(m_program.id, m_vertex_prog.id);
-					glAttachShader(m_program.id, m_shader_prog.id);
+					glAttachShader(m_program.id, m_shader_prog.GetId());
 					glLinkProgram(m_program.id);
 					checkForGlError("glLinkProgram");
 					glDetachShader(m_program.id, m_vertex_prog.id);
-					glDetachShader(m_program.id, m_shader_prog.id);
+					glDetachShader(m_program.id, m_shader_prog.GetId());
 					program.vp_id = m_vertex_prog.id;
-					program.fp_id = m_shader_prog.id;
+					program.fp_id = m_shader_prog.GetId();
 					program.modified = false;
 				}
 			}
@@ -456,7 +455,7 @@ bool GLGSRender::LoadProgram()
 	}
 	else
 	{
-		m_program.Create(m_vertex_prog.id, m_shader_prog.id);
+		m_program.Create(m_vertex_prog.id, m_shader_prog.GetId());
 		checkForGlError("m_program.Create");
 		m_prog_buffer.Add(m_program, m_shader_prog, *m_cur_shader_prog, m_vertex_prog, *m_cur_vertex_prog);
 		checkForGlError("m_prog_buffer.Add");
@@ -468,9 +467,9 @@ bool GLGSRender::LoadProgram()
 			RSXDebuggerProgram program;
 			program.id = m_program.id;
 			program.vp_id = m_vertex_prog.id;
-			program.fp_id = m_shader_prog.id;
+			program.fp_id = m_shader_prog.GetId();
 			program.vp_shader = m_vertex_prog.shader;
-			program.fp_shader = m_shader_prog.shader;
+			program.fp_shader = m_shader_prog.GetShaderText();
 			m_debug_programs.push_back(program);
 		}
 	}

--- a/rpcs3/Emu/GS/GL/GLProgramBuffer.cpp
+++ b/rpcs3/Emu/GS/GL/GLProgramBuffer.cpp
@@ -7,8 +7,8 @@ int GLProgramBuffer::SearchFp(const RSXShaderProgram& rsx_fp, GLShaderProgram& g
 	{
 		if(memcmp(&m_buf[i].fp_data[0], &Memory[rsx_fp.addr], m_buf[i].fp_data.size()) != 0) continue;
 
-		gl_fp.id = m_buf[i].fp_id;
-		gl_fp.shader = m_buf[i].fp_shader;
+		gl_fp.SetId(m_buf[i].fp_id);
+		gl_fp.SetShaderText(m_buf[i].fp_shader);
 
 		return i;
 	}
@@ -89,23 +89,23 @@ void GLProgramBuffer::Add(GLProgram& prog, GLShaderProgram& gl_fp, RSXShaderProg
 	ConLog.Write("Add program (%d):", m_buf.size());
 	ConLog.Write("*** prog id = %d", prog.id);
 	ConLog.Write("*** vp id = %d", gl_vp.id);
-	ConLog.Write("*** fp id = %d", gl_fp.id);
+	ConLog.Write("*** fp id = %d", gl_fp.GetId());
 	ConLog.Write("*** vp data size = %d", rsx_vp.data.size() * 4);
 	ConLog.Write("*** fp data size = %d", rsx_fp.size);
 
 	ConLog.Write("*** vp shader = \n%s", gl_vp.shader.c_str());
-	ConLog.Write("*** fp shader = \n%s", gl_fp.shader.c_str());
+	ConLog.Write("*** fp shader = \n%s", gl_fp.GetShaderText().c_str());
 	
 
 	new_buf.prog_id = prog.id;
 	new_buf.vp_id = gl_vp.id;
-	new_buf.fp_id = gl_fp.id;
+	new_buf.fp_id = gl_fp.GetId();
 
 	new_buf.fp_data.insert(new_buf.fp_data.end(),&Memory[rsx_fp.addr], &Memory[rsx_fp.addr] + rsx_fp.size);
 	new_buf.vp_data = rsx_vp.data;
 
 	new_buf.vp_shader = gl_vp.shader;
-	new_buf.fp_shader = gl_fp.shader;
+	new_buf.fp_shader = gl_fp.GetShaderText();
 
 	m_buf.push_back(new_buf);
 }

--- a/rpcs3/Emu/GS/RSXThread.cpp
+++ b/rpcs3/Emu/GS/RSXThread.cpp
@@ -181,6 +181,8 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 
 	u32 index = 0;
 
+	m_used_gcm_commands.insert(cmd);
+
 	//static u32 draw_array_count = 0;
 
 	switch(cmd)
@@ -299,7 +301,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		u32 a0 = ARGS(0);
 		u32 pitch = a0 & 0xFFFFF;
 		u16 depth = a0 >> 20;
-		tex.SetControl3(pitch, depth);
+		tex.SetControl3(depth, pitch);
 	}
 	break;
 
@@ -325,6 +327,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case_16(NV4097_SET_TEXTURE_BORDER_COLOR,0x20):
 	{
 	}
+	break;
 
 	case NV4097_SET_SURFACE_FORMAT:
 	{

--- a/rpcs3/Emu/GS/RSXThread.h
+++ b/rpcs3/Emu/GS/RSXThread.h
@@ -6,6 +6,7 @@
 #include "Emu/SysCalls/Callback.h"
 
 #include <stack>
+#include <set> // For tracking a list of used gcm commands
 
 enum Method
 {
@@ -384,6 +385,8 @@ public:
 	u8 m_begin_end;
 	bool m_read_buffer;
 
+	std::set<u32> m_used_gcm_commands;
+
 protected:
 	RSXThread()
 		: ThreadBase("RSXThread")
@@ -537,6 +540,8 @@ public:
 		m_cur_vertex_prog = nullptr;
 		m_cur_shader_prog = nullptr;
 		m_cur_shader_prog_num = 0;
+
+		m_used_gcm_commands.clear();
 
 		OnInit();
 		ThreadBase::Start();

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -204,6 +204,7 @@ protected:
 public:
 	virtual void Init(const u32 max_connect)=0;
 	virtual void Close()=0;
+	virtual ~PadHandlerBase() = default;
 
 	void Key(const u32 code, bool pressed)
 	{

--- a/rpcs3/Emu/Memory/MemoryBlock.h
+++ b/rpcs3/Emu/Memory/MemoryBlock.h
@@ -43,6 +43,7 @@ struct MemBlockInfo : public MemInfo
 	MemBlockInfo& operator =(MemBlockInfo &&other){
 		this->addr = other.addr;
 		this->size = other.size;
+		if (this->mem) _aligned_free(mem);
 		this->mem = other.mem;
 		other.mem = nullptr;
 		return *this;

--- a/rpcs3/Emu/SysCalls/Modules.h
+++ b/rpcs3/Emu/SysCalls/Modules.h
@@ -1,8 +1,4 @@
 #pragma once
-#include "Modules/cellResc.h"
-#include "Modules/cellPngDec.h"
-#include "Modules/cellJpgDec.h"
-#include "Modules/cellGifDec.h"
 
 #define declCPU PPUThread& CPU = GetCurrentPPUThread
 
@@ -17,6 +13,11 @@ struct ModuleFunc
 		: id(id)
 		, func(func)
 	{
+	}
+
+	~ModuleFunc()
+	{
+		safe_delete(func);
 	}
 };
 
@@ -34,6 +35,11 @@ struct SFunc
 	std::vector<SFuncOp> ops;
 	u64 group;
 	u32 found;
+
+	~SFunc()
+	{
+		safe_delete(func);
+	}
 };
 
 extern std::vector<SFunc *> g_static_funcs_list;
@@ -47,11 +53,13 @@ class Module
 	void (*m_unload_func)();
 
 public:
-	std::vector<ModuleFunc> m_funcs_list;
+	std::vector<ModuleFunc*> m_funcs_list;
 
 	Module(u16 id, const char* name);
 	Module(const char* name, void (*init)(), void (*load)() = nullptr, void (*unload)() = nullptr);
 	Module(u16 id, void (*init)(), void (*load)() = nullptr, void (*unload)() = nullptr);
+
+	~Module();
 
 	void Load();
 	void UnLoad();
@@ -115,7 +123,7 @@ public:
 template<typename T>
 __forceinline void Module::AddFunc(u32 id, T func)
 {
-	m_funcs_list.emplace_back(id, bind_func(func));
+	m_funcs_list.emplace_back(new ModuleFunc(id, bind_func(func)));
 }
 
 template<typename T>

--- a/rpcs3/Emu/SysCalls/Modules/cellFont.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellFont.cpp
@@ -5,8 +5,9 @@
 #include "stblib/stb_truetype.h"
 
 void cellFont_init();
+void cellFont_load();
 void cellFont_unload();
-Module cellFont(0x0019, cellFont_init, nullptr, cellFont_unload);
+Module cellFont(0x0019, cellFont_init, cellFont_load, cellFont_unload);
 
 // Font Set Types
 enum
@@ -226,7 +227,7 @@ struct CCellFontInternal      //Module cellFont
 	}
 };
 
-CCellFontInternal* s_fontInternalInstance = new CCellFontInternal();
+CCellFontInternal* s_fontInternalInstance = nullptr;
 
 // Functions
 int cellFontInitializeWithRevision(u64 revisionFlags, mem_ptr_t<CellFontConfig> config)
@@ -899,8 +900,14 @@ void cellFont_init()
 	cellFont.AddFunc(0xb015a84e, cellFontGetRevisionFlags);
 }
 
+void cellFont_load()
+{
+	s_fontInternalInstance = new CCellFontInternal();
+}
+
 void cellFont_unload()
 {
-	s_fontInternalInstance->m_bInitialized = false;
-	s_fontInternalInstance->m_bFontGcmInitialized = false;
+	// s_fontInternalInstance->m_bInitialized = false;
+	// s_fontInternalInstance->m_bFontGcmInitialized = false;
+	delete s_fontInternalInstance;
 }

--- a/rpcs3/Emu/SysCalls/Modules/cellFontFT.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellFontFT.cpp
@@ -4,7 +4,9 @@
 #include "cellFont.h"
 
 void cellFontFT_init();
-Module cellFontFT(0x001a, cellFontFT_init);
+void cellFontFT_load();
+void cellFontFT_unload();
+Module cellFontFT(0x001a, cellFontFT_init, cellFontFT_load, cellFontFT_unload);
 
 struct CellFontLibraryConfigFT
 {
@@ -33,7 +35,7 @@ struct CCellFontFTInternal
 	}
 };
 
-CCellFontFTInternal* s_fontFtInternalInstance = new CCellFontFTInternal();
+CCellFontFTInternal* s_fontFtInternalInstance = nullptr;
 
 int cellFontInitLibraryFreeTypeWithRevision(u64 revisionFlags, mem_ptr_t<CellFontLibraryConfigFT> config, u32 lib_addr_addr)
 {
@@ -67,4 +69,14 @@ void cellFontFT_init()
 	cellFontFT.AddFunc(0x7a0a83c4, cellFontInitLibraryFreeTypeWithRevision);
 	cellFontFT.AddFunc(0xec89a187, cellFontFTGetRevisionFlags);
 	cellFontFT.AddFunc(0xfa0c2de0, cellFontFTGetInitializedRevisionFlags);
+}
+
+void cellFontFT_load()
+{
+	s_fontFtInternalInstance = new CCellFontFTInternal();
+}
+
+void cellFontFT_unload()
+{
+	delete s_fontFtInternalInstance;
 }

--- a/rpcs3/Emu/SysCalls/Modules/cellResc.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellResc.cpp
@@ -5,8 +5,9 @@
 #include "cellResc.h"
 
 void cellResc_init();
+void cellResc_load();
 void cellResc_unload();
-Module cellResc(0x001f, cellResc_init, nullptr, cellResc_unload);
+Module cellResc(0x001f, cellResc_init, cellResc_load, cellResc_unload);
 
 // Error Codes
 enum
@@ -71,7 +72,7 @@ struct CCellRescInternal
 };
 
 
-CCellRescInternal* s_rescInternalInstance = new CCellRescInternal();
+CCellRescInternal* s_rescInternalInstance = nullptr;
 
 // Extern Functions
 extern int cellGcmSetFlipMode(u32 mode);
@@ -810,7 +811,13 @@ void cellResc_init()
 	//cellResc.AddFunc(0xe0cef79e, cellRescCreateInterlaceTable);
 }
 
+void cellResc_load()
+{
+	s_rescInternalInstance = new CCellRescInternal();
+}
+
 void cellResc_unload()
 {
-	s_rescInternalInstance->m_bInitialized = false;
+	// s_rescInternalInstance->m_bInitialized = false;
+	delete s_rescInternalInstance;
 }

--- a/rpcs3/Emu/SysCalls/Modules/cellUserInfo.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellUserInfo.cpp
@@ -30,6 +30,7 @@ int cellUserInfoGetStat(u32 id, mem_ptr_t<CellUserInfoUserStat> stat)
 	memset(name, 0, CELL_USERINFO_USERNAME_SIZE);
 	stream->Read(name, CELL_USERINFO_USERNAME_SIZE);
 	stream->Close();
+	delete stream;
 
 	stat->id = id;
 	memcpy(stat->name, name, CELL_USERINFO_USERNAME_SIZE);

--- a/rpcs3/Emu/SysCalls/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellVdec.cpp
@@ -148,7 +148,7 @@ u32 vdecOpen(VideoDecoder* data)
 				continue;
 			}
 
-			if (vdec.frames.GetSize() >= 50)
+			if (vdec.frames.GetCount() >= 50)
 			{
 				Sleep(1);
 				continue;

--- a/rpcs3/Emu/SysCalls/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sceNpTrophy.cpp
@@ -24,6 +24,18 @@ struct sceNpTrophyInternalContext
 	vfsStream* trp_stream;
 
 	TROPUSRLoader* tropusr;
+
+	sceNpTrophyInternalContext()
+		: trp_stream(nullptr),
+		tropusr(nullptr)
+	{
+	}
+
+	~sceNpTrophyInternalContext()
+	{
+		safe_delete(trp_stream);
+		safe_delete(tropusr);
+	}
 };
 
 struct sceNpTrophyInternal
@@ -132,8 +144,10 @@ int sceNpTrophyRegisterContext(u32 context, u32 handle, u32 statusCb_addr, u32 a
 		return SCE_NP_TROPHY_ERROR_ILLEGAL_UPDATE;
 
 	// Rename or discard certain entries based on the files found
-	char target [32];
-	sprintf(target, "TROP_%02d.SFM", Ini.SysLanguage.GetValue());
+	const size_t kTargetBufferLength = 31;
+	char target[kTargetBufferLength+1];
+	target[kTargetBufferLength] = 0;
+	snprintf(target, kTargetBufferLength, "TROP_%02d.SFM", Ini.SysLanguage.GetValue());
 
 	if (trp.ContainsEntry(target)) {
 		trp.RemoveEntry("TROPCONF.SFM");
@@ -150,7 +164,7 @@ int sceNpTrophyRegisterContext(u32 context, u32 handle, u32 statusCb_addr, u32 a
 
 	// Discard unnecessary TROP_XX.SFM files
 	for (int i=0; i<=18; i++) {
-		sprintf(target, "TROP_%02d.SFM", i);
+		snprintf(target, kTargetBufferLength, "TROP_%02d.SFM", i);
 		if (i != Ini.SysLanguage.GetValue())
 			trp.RemoveEntry(target);
 	}
@@ -288,7 +302,7 @@ int sceNpTrophyUnlockTrophy(u32 context, u32 handle, s32 trophyId, mem32_t plati
 	// TODO: There are other possible errors
 
 	sceNpTrophyInternalContext& ctxt = s_npTrophyInstance.contexts[context];
-	if (trophyId >= ctxt.tropusr->GetTrophiesCount())
+	if (trophyId >= (s32)ctxt.tropusr->GetTrophiesCount())
 		return SCE_NP_TROPHY_ERROR_INVALID_TROPHY_ID;
 	if (ctxt.tropusr->GetTrophyUnlockState(trophyId))
 		return SCE_NP_TROPHY_ERROR_ALREADY_UNLOCKED;

--- a/rpcs3/Emu/SysCalls/lv2/SC_FileSystem.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_FileSystem.cpp
@@ -94,7 +94,8 @@ int cellFsOpen(u32 path_addr, int flags, mem32_t fd, mem32_t arg, u64 size)
 		{
 			_oflags &= ~CELL_O_TRUNC;
 			//truncate file before opening it as read/write
-			Emu.GetVFS().OpenFile(ppath, vfsWrite);
+			auto filePtr = Emu.GetVFS().OpenFile(ppath, vfsWrite);
+			delete filePtr;
 		}
 		o_mode = vfsReadWrite;
 	break;
@@ -110,6 +111,7 @@ int cellFsOpen(u32 path_addr, int flags, mem32_t fd, mem32_t arg, u64 size)
 
 	if(!stream || !stream->IsOpened())
 	{
+		delete stream;
 		sys_fs.Error("\"%s\" not found! flags: 0x%08x", ppath.c_str(), flags);
 		return CELL_ENOENT;
 	}

--- a/rpcs3/Gui/DisAsmFrame.cpp
+++ b/rpcs3/Gui/DisAsmFrame.cpp
@@ -143,9 +143,9 @@ public:
 		}
 		else
 		{
-			PPUDisAsm& dis_asm = *new PPUDisAsm(CPUDisAsm_DumpMode);
+			PPUDisAsm* dis_asm = new PPUDisAsm(CPUDisAsm_DumpMode);
 			decoder = new PPUDecoder(dis_asm);
-			disasm = &dis_asm;
+			disasm = dis_asm;
 		}
 	}
 
@@ -347,9 +347,9 @@ void DisAsmFrame::Dump(wxCommandEvent& WXUNUSED(event))
 	{
 	case CPU_THREAD_PPU:
 	{
-		PPUDisAsm& dis_asm = *new PPUDisAsm(CPUDisAsm_DumpMode);
+		PPUDisAsm* dis_asm = new PPUDisAsm(CPUDisAsm_DumpMode);
 		decoder = new PPUDecoder(dis_asm);
-		disasm = &dis_asm;
+		disasm = dis_asm;
 	}
 	break;
 

--- a/rpcs3/Gui/InterpreterDisAsm.cpp
+++ b/rpcs3/Gui/InterpreterDisAsm.cpp
@@ -127,9 +127,9 @@ void InterpreterDisAsmFrame::OnSelectUnit(wxCommandEvent& event)
 		{
 		case CPU_THREAD_PPU:
 		{
-			PPUDisAsm& dis_asm = *new PPUDisAsm(CPUDisAsm_InterpreterMode);
+			PPUDisAsm* dis_asm = new PPUDisAsm(CPUDisAsm_InterpreterMode);
 			decoder = new PPUDecoder(dis_asm);
-			disasm = &dis_asm;
+			disasm = dis_asm;
 		}
 		break;
 

--- a/rpcs3/Ini.cpp
+++ b/rpcs3/Ini.cpp
@@ -159,6 +159,11 @@ Ini::Ini()
 #endif
 }
 
+Ini::~Ini()
+{
+	safe_delete(m_Config);
+}
+
 void Ini::Save(const wxString& key, int value)
 {
 	m_Config->Write(key, value);

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -21,10 +21,14 @@ struct WindowInfo
 
 class Ini
 {
+public:
+	virtual ~Ini();
+
 protected:
 	wxConfigBase* m_Config;
 
 	Ini();
+
 	void Save(const wxString& key, int value);
 	void Save(const wxString& key, bool value);
 	void Save(const wxString& key, wxSize value);

--- a/rpcs3/Loader/ELF.h
+++ b/rpcs3/Loader/ELF.h
@@ -48,7 +48,7 @@ public:
 	Elf_Ehdr ehdr;
 
 	ELFLoader(vfsStream& f);
-	~ELFLoader() {Close();}
+	virtual ~ELFLoader() {Close();}
 
 	virtual bool LoadInfo();
 	virtual bool LoadData(u64 offset = 0);

--- a/rpcs3/Loader/Loader.h
+++ b/rpcs3/Loader/Loader.h
@@ -191,6 +191,8 @@ protected:
 	}
 
 public:
+	virtual ~LoaderBase() = default;
+
 	virtual bool LoadInfo() { return false; }
 	virtual bool LoadData(u64 offset = 0) { return false; }
 	Elf_Machine GetMachine() const { return machine; }
@@ -208,7 +210,7 @@ class Loader : public LoaderBase
 public:
 	Loader();
 	Loader(vfsFileBase& stream);
-	~Loader();
+	virtual ~Loader();
 
 	void Open(const std::string& path);
 	void Open(vfsFileBase& stream);

--- a/rpcs3/Loader/TROPUSR.cpp
+++ b/rpcs3/Loader/TROPUSR.cpp
@@ -28,8 +28,7 @@ bool TROPUSRLoader::Load(const std::string& filepath, const std::string& configp
 	LoadTableHeaders();
 	LoadTables();
 
-	m_file->Close();
-	m_file = NULL;
+	Close();
 	return true;
 }
 
@@ -206,7 +205,7 @@ bool TROPUSRLoader::Close()
 {
 	if (m_file && m_file->Close())
 	{
-		m_file = NULL;
+		safe_delete(m_file);
 		return true;
 	}
 	return false;

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -1,6 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug - MemLeak|Win32">
+      <Configuration>Debug - MemLeak</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug - MemLeak|x64">
+      <Configuration>Debug - MemLeak</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -30,7 +38,19 @@
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
@@ -58,7 +78,13 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -74,7 +100,19 @@
     <LibraryPath>..\libs\$(Configuration)\;$(LibraryPath)</LibraryPath>
     <TargetName>$(ProjectName)-$(PlatformShortName)-dbg</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|Win32'">
+    <IncludePath>.\;..\wxWidgets\include;..\SDL-1.3.0-5538\include;..\SDL_image-1.2.10;..\pthreads-2.8.0;..\;..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\x86\Include;.\OpenAL\include;$(IncludePath)</IncludePath>
+    <OutDir>$(SolutionDir)bin\</OutDir>
+    <LibraryPath>..\libs\$(Configuration)\;$(LibraryPath)</LibraryPath>
+    <TargetName>$(ProjectName)-$(PlatformShortName)-dbg</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>.\;..\wxWidgets\include;..\SDL-1.3.0-5538\include;..\SDL_image-1.2.10;..\pthreads-2.8.0;..\;..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\x86_64\Include;.\OpenAL\include;$(IncludePath)</IncludePath>
+    <OutDir>$(SolutionDir)bin\</OutDir>
+    <LibraryPath>..\libs\$(Configuration)\;$(LibraryPath)</LibraryPath>
+    <TargetName>$(ProjectName)-$(PlatformShortName)-dbg</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'">
     <IncludePath>.\;..\wxWidgets\include;..\SDL-1.3.0-5538\include;..\SDL_image-1.2.10;..\pthreads-2.8.0;..\;..\ffmpeg\WindowsInclude;..\ffmpeg\Windows\x86_64\Include;.\OpenAL\include;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)bin\</OutDir>
     <LibraryPath>..\libs\$(Configuration)\;$(LibraryPath)</LibraryPath>
@@ -119,6 +157,27 @@
       </Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>wxmsw31ud_adv.lib;wxbase31ud.lib;wxmsw31ud_core.lib;wxmsw31ud_aui.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;odbc32.lib;odbccp32.lib;comctl32.lib;ws2_32.lib;shlwapi.lib;winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;OpenAL32.lib;EFX-Util.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <DataExecutionPrevention>false</DataExecutionPrevention>
+      <AdditionalLibraryDirectories>..\wxWidgets\lib\vc_lib;..\ffmpeg\Windows\x86\lib;..\OpenAL\Win32</AdditionalLibraryDirectories>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -126,6 +185,29 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <AdditionalIncludeDirectories>..\wxWidgets\include\msvc</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>wxmsw31ud_adv.lib;wxbase31ud.lib;wxmsw31ud_core.lib;wxmsw31ud_aui.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;odbc32.lib;odbccp32.lib;comctl32.lib;ws2_32.lib;shlwapi.lib;winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;OpenAL32.lib;EFX-Util.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <DataExecutionPrevention>false</DataExecutionPrevention>
+      <AdditionalLibraryDirectories>..\wxWidgets\lib\vc_x64_lib;..\ffmpeg\Windows\x86_64\lib;..\OpenAL\Win64</AdditionalLibraryDirectories>
+    </Link>
+    <PreBuildEvent>
+      <Command>"$(SolutionDir)\Utilities\git-version-gen.cmd"</Command>
+    </PreBuildEvent>
+    <ProjectReference>
+      <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <AdditionalIncludeDirectories>..\wxWidgets\include\msvc</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;MSVC_CRT_MEMLEAK_DETECTION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -187,6 +269,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <ExceptionHandling>Sync</ExceptionHandling>
       <EnablePREfast>false</EnablePREfast>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -352,7 +435,9 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -400,6 +485,7 @@
     <ClInclude Include="Emu\Cell\RawSPUThread.h" />
     <ClInclude Include="Emu\Cell\SPUDecoder.h" />
     <ClInclude Include="Emu\Cell\SPUDisAsm.h" />
+    <ClInclude Include="Emu\Cell\SPUInstrTable.h" />
     <ClInclude Include="Emu\Cell\SPUInterpreter.h" />
     <ClInclude Include="Emu\Cell\SPUOpcodes.h" />
     <ClInclude Include="Emu\Cell\SPURSManager.h" />

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Emu">
@@ -977,6 +977,9 @@
     </ClInclude>
     <ClInclude Include="Emu\SysCalls\Modules\cellUserInfo.h">
       <Filter>Emu\SysCalls\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Cell\SPUInstrTable.h">
+      <Filter>Emu\Cell</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpcs3/rpcs3.vcxproj.user
+++ b/rpcs3/rpcs3.vcxproj.user
@@ -4,6 +4,10 @@
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
@@ -12,8 +16,15 @@
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|Win32'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ShowAllFiles>false</ShowAllFiles>
   </PropertyGroup>
 </Project>

--- a/rpcs3/stdafx.h
+++ b/rpcs3/stdafx.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#ifdef MSVC_CRT_MEMLEAK_DETECTION
+	#define _CRTDBG_MAP_ALLOC
+	#include <stdlib.h>
+	#include <crtdbg.h>
+#endif
+
 #define NOMINMAX
 
 #ifndef QT_UI
@@ -33,6 +39,15 @@
 
 #include <wx/wxprec.h>
 #endif
+
+#ifdef MSVC_CRT_MEMLEAK_DETECTION
+	#ifdef _DEBUG
+		#ifndef DBG_NEW
+			#define DBG_NEW new ( _NORMAL_BLOCK , __FILE__ , __LINE__ )
+			#define new DBG_NEW
+		#endif
+	#endif  // _DEBUG
+#endif // MSVC_CRT_MEMLEAK_DETECTION
 
 #ifndef _WIN32
 //hack, disabled


### PR DESCRIPTION
BUGFIX: Add break after NV4097_SET_TEXTURE_BORDER_COLOR in RSXThread.cpp
BUGFIX: Fix parameters passed to RSXTexture::SetControl3 (they were being
passed in reverse order)
BUGFIX: Remove invalid, non-sensical call to glPixelStorei in GLGSRender.h
BUGFIX: Fix signed/unsigned comparison compiler warnings in GLGSRender.h
CHANGE: Make GLFragmentProgram::Decompiler synchronous by default
CHANGE: Update wxWidgets submodule to latest commit
BUGFIX: Fix several memory leaks
ADDED: Created a new MSVC debug configuration to output locations
  of allocations that end up leaking after the program
  is closed.
BUGFIX: Fix the stupid PadHandler crash due to the lack of a virtual d'tor
