### PR TITLE
fix copying class with pointers as member

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sceNpTrophy.cpp
@@ -27,7 +27,7 @@ struct sceNpTrophyInternalContext
 
 //TODO: remove the following code when Visual C++ no longer generates
 //compiler errors for it. All of this should be auto-generated
-#if _MSC_VER <= 1800
+#if defined(_MSC_VER) && _MSC_VER <= 1800
 	sceNpTrophyInternalContext()
 		: trp_stream(),
 		tropusr()


### PR DESCRIPTION
copying class with pointers as member when deleting them in the desctructor is danger zone.
