### PR TITLE
Fix crash on quit

### DIFF
--- a/rpcs3/Ini.cpp
+++ b/rpcs3/Ini.cpp
@@ -161,7 +161,8 @@ Ini::Ini()
 
 Ini::~Ini()
 {
-	safe_delete(m_Config);
+	// FIXME: Fix wxConfig deconstructor
+	// safe_delete(m_Config);
 }
 
 void Ini::Save(const wxString& key, int value)


### PR DESCRIPTION
TODO: Actually fix deconstructor

Just leak memory which will be reclaimed by the OS when the app exits regardless.
We should really fix the deconstructor though.
