### PR TITLE
Set build independent binary output dir

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -27,7 +27,8 @@ Else()
 EndIf()
 
 set(CMAKE_MODULE_PATH "${RPCS3_SRC_DIR}/cmake_modules")
-set(EXECUTABLE_OUTPUT_PATH "${RPCS3_SRC_DIR}/../bin") # TODO: do real installation, including copying directory structure
+# TODO: do real installation, including copying directory structure
+set(EXECUTABLE_OUTPUT_PATH "${PROJECT_BINARY_DIR}/../bin")
 #include(cotire)
 
 add_definitions(-DGL_GLEXT_PROTOTYPES)


### PR DESCRIPTION
That way we can create multiple build directories and have independent rpcs binaries.
Useful for testing different options/settings.
