### PR TITLE
match project dependencies for wxStuff from their *.sln

### DIFF
--- a/rpcs3.sln
+++ b/rpcs3.sln
@@ -31,26 +31,63 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "wxWidgets", "wxWidgets", "{5812E712-6213-4372-B095-9EB9BAA1F2DF}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "adv", "wxWidgets\build\msw\wx_vc10_adv.vcxproj", "{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "aui", "wxWidgets\build\msw\wx_vc10_aui.vcxproj", "{7047EE97-7F80-A70D-6147-BC11102DB6F4}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+		{6EDC3B79-D217-F11A-406F-F11D856493F9} = {6EDC3B79-D217-F11A-406F-F11D856493F9}
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82} = {6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "base", "wxWidgets\build\msw\wx_vc10_base.vcxproj", "{3111D679-7796-23C4-BA0C-271F1145DA24}"
+	ProjectSection(ProjectDependencies) = postProject
+		{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA} = {AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}
+		{949C6DB8-E638-6EC6-AB31-BCCFD1379E01} = {949C6DB8-E638-6EC6-AB31-BCCFD1379E01}
+		{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2} = {46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "core", "wxWidgets\build\msw\wx_vc10_core.vcxproj", "{067D9406-2A93-DACA-9449-93A2D356357D}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "propgrid", "wxWidgets\build\msw\wx_vc10_propgrid.vcxproj", "{9ED1866B-D4AE-3440-24E4-7A9475B163B2}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82} = {6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "gl", "wxWidgets\build\msw\wx_vc10_gl.vcxproj", "{99C9EB95-DB4C-1996-490E-5212EFBF07C3}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "html", "wxWidgets\build\msw\wx_vc10_html.vcxproj", "{6EDC3B79-D217-F11A-406F-F11D856493F9}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "media", "wxWidgets\build\msw\wx_vc10_media.vcxproj", "{A9AC9CF5-8E6C-0BA2-0769-6E42EDB88E25}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "net", "wxWidgets\build\msw\wx_vc10_net.vcxproj", "{CD478F02-7550-58A5-E085-CE4BC0C0AD23}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3111D679-7796-23C4-BA0C-271F1145DA24} = {3111D679-7796-23C4-BA0C-271F1145DA24}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qa", "wxWidgets\build\msw\wx_vc10_qa.vcxproj", "{22B14659-C5B6-B775-868D-A49198FEAD4A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF} = {6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "richtext", "wxWidgets\build\msw\wx_vc10_richtext.vcxproj", "{FAF0CB93-F7CE-A6B8-8342-19CE99BAF774}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82} = {6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}
+		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF} = {6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wxexpat", "wxWidgets\build\msw\wx_vc10_wxexpat.vcxproj", "{46333DC3-B4A5-3DCC-E8BF-A3F20ADC56D2}"
 EndProject
@@ -65,8 +102,15 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wxzlib", "wxWidgets\build\msw\wx_vc10_wxzlib.vcxproj", "{AFF2C68B-B867-DD50-6AC5-74B09D41F8EA}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xml", "wxWidgets\build\msw\wx_vc10_xml.vcxproj", "{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3111D679-7796-23C4-BA0C-271F1145DA24} = {3111D679-7796-23C4-BA0C-271F1145DA24}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xrc", "wxWidgets\build\msw\wx_vc10_xrc.vcxproj", "{8BECCA95-C7D7-CFF8-FDB1-4950E9F8E8E6}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82} = {6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}
+		{6FDC76D5-CB44-B9F8-5EF6-C59B020719DF} = {6FDC76D5-CB44-B9F8-5EF6-C59B020719DF}
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stblib", "stblib", "{9D839DFB-76E6-4F10-8EED-BA2AC7CC3FB6}"
 	ProjectSection(SolutionItems) = preProject
@@ -75,8 +119,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stblib", "stblib", "{9D839D
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ribbon", "wxWidgets\build\msw\wx_vc10_ribbon.vcxproj", "{87B42A9C-3F5C-53D7-9017-2B1CAE39457D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+		{6FCB55A5-563F-4039-1D79-1EB6ED8AAB82} = {6FCB55A5-563F-4039-1D79-1EB6ED8AAB82}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "stc", "wxWidgets\build\msw\wx_vc10_stc.vcxproj", "{23E1C437-A951-5943-8639-A17F3CF2E606}"
+	ProjectSection(ProjectDependencies) = postProject
+		{067D9406-2A93-DACA-9449-93A2D356357D} = {067D9406-2A93-DACA-9449-93A2D356357D}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wxscintilla", "wxWidgets\build\msw\wx_vc10_wxscintilla.vcxproj", "{74827EBD-93DC-5110-BA95-3F2AB029B6B0}"
 EndProject


### PR DESCRIPTION
This should fix having to run build twice sometimes to get it to link properly

Maybe this'll fix the buildbot.
