### PR TITLE
Fix CELL_GCM_TEXTURE_B8 opengl error 0x0500

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.h
+++ b/rpcs3/Emu/GS/GL/GLGSRender.h
@@ -165,7 +165,7 @@ public:
 			checkForGlError("GLTexture::Init() -> glTexImage2D");
 
 			GLint swizzleMask[] = { GL_ONE, GL_ONE, GL_ONE, GL_RED };
-			glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, swizzleMask);
+			glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask);
 			checkForGlError("GLTexture::Init() -> glTexParameteriv");
 		}
 		break;


### PR DESCRIPTION
Seen in Disgaea 3: Absence of Justice
[E : RSXThread]: GLTexture::Init() -> glTexParameteri: opengl error 0x0500
