### PR TITLE
Correct various texture formats in OpenGL

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.h
+++ b/rpcs3/Emu/GS/GL/GLGSRender.h
@@ -64,7 +64,7 @@ public:
 
 	inline static u8 Convert4To8(u8 v)
 	{
-		// Swizzle bits: 00012345 -> 12345123
+		// Swizzle bits: 00001234 -> 12341234
 		return (v << 4) | (v);
 	}
 


### PR DESCRIPTION
This, along with the PNG fix, generally passes this test (so far):
https://github.com/DHrpcs3/rpcs3/commit/d745a7bb4ebd974523506655de5b2071cbf47932#commitcomment-6359180

It corrects mainly byteswapping and swizzling, but also a couple of the missing texture formats.  Did not really test any formats not present in that test, though.

-[Unknown]
