### PR TITLE
virtual memory block reads/writes properly fail if address is out of bounds

### DIFF
--- a/rpcs3/Emu/GS/RSXThread.cpp
+++ b/rpcs3/Emu/GS/RSXThread.cpp
@@ -11,7 +11,10 @@ u32 GetAddress(u32 offset, u8 location)
 	switch(location)
 	{
 	case CELL_GCM_LOCATION_LOCAL: return Memory.RSXFBMem.GetStartAddr() + offset;
-	case CELL_GCM_LOCATION_MAIN: return Memory.RSXIOMem.getRealAddr(Memory.RSXIOMem.GetStartAddr() + offset);
+	case CELL_GCM_LOCATION_MAIN: 
+		u64 realAddr;
+		Memory.RSXIOMem.getRealAddr(Memory.RSXIOMem.GetStartAddr() + offset, realAddr); // TODO: Error Check?
+		return realAddr;
 	}
 
 	ConLog.Error("GetAddress(offset=0x%x, location=0x%x)", location);

--- a/rpcs3/Emu/Memory/Memory.cpp
+++ b/rpcs3/Emu/Memory/Memory.cpp
@@ -614,21 +614,25 @@ u32 VirtualMemoryBlock::UnmapAddress(u64 addr)
 bool VirtualMemoryBlock::Read8(const u64 addr, u8* value)
 {
 	u64 realAddr;
-	*value = Memory.Read8(realAddr = getRealAddr(addr));
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	*value = Memory.Read8(realAddr);
+	return true;
 }
 
 bool VirtualMemoryBlock::Read16(const u64 addr, u16* value)
 {
 	u64 realAddr;
-	*value = Memory.Read16(realAddr = getRealAddr(addr));
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	*value = Memory.Read16(realAddr);
+	return true;
 }
 
 bool VirtualMemoryBlock::Read32(const u64 addr, u32* value)
 {
-	u64 realAddr = getRealAddr(addr);
-	if (realAddr == 0)
+	u64 realAddr;
+	if (!getRealAddr(addr, realAddr))
 		return false;
 	*value = Memory.Read32(realAddr);
 	return true;
@@ -637,63 +641,78 @@ bool VirtualMemoryBlock::Read32(const u64 addr, u32* value)
 bool VirtualMemoryBlock::Read64(const u64 addr, u64* value)
 {
 	u64 realAddr;
-	*value = Memory.Read64(realAddr = getRealAddr(addr));
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	*value = Memory.Read64(realAddr);
+	return true;
 }
 
 bool VirtualMemoryBlock::Read128(const u64 addr, u128* value)
 {
 	u64 realAddr;
-	*value = Memory.Read128(realAddr = getRealAddr(addr));
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	*value = Memory.Read128(realAddr);
+	return true;
 }
 
 bool VirtualMemoryBlock::Write8(const u64 addr, const u8 value)
 {
 	u64 realAddr;
-	Memory.Write8(realAddr = getRealAddr(addr), value);
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	Memory.Write8(realAddr, value);
+	return true;
 }
 
 bool VirtualMemoryBlock::Write16(const u64 addr, const u16 value)
 {
 	u64 realAddr;
-	Memory.Write16(realAddr = getRealAddr(addr), value);
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	Memory.Write16(realAddr, value);
+	return true;
 }
 
 bool VirtualMemoryBlock::Write32(const u64 addr, const u32 value)
 {
 	u64 realAddr;
-	Memory.Write32(realAddr = getRealAddr(addr), value);
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	Memory.Write32(realAddr, value);
+	return true;
 }
 
 bool VirtualMemoryBlock::Write64(const u64 addr, const u64 value)
 {
 	u64 realAddr;
-	Memory.Write64(realAddr = getRealAddr(addr), value);
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	Memory.Write64(realAddr, value);
+	return true;
 }
 
 bool VirtualMemoryBlock::Write128(const u64 addr, const u128 value)
 {
 	u64 realAddr;
-	Memory.Write128(realAddr = getRealAddr(addr), value);
-	return realAddr != 0;
+	if(!getRealAddr(addr, realAddr))
+		return false;
+	Memory.Write128(realAddr, value);
+	return true;
 }
 
-u64 VirtualMemoryBlock::getRealAddr(u64 addr)
+bool VirtualMemoryBlock::getRealAddr(u64 addr, u64& result)
 {
 	for(u32 i=0; i<m_mapped_memory.size(); ++i)
 	{
 		if(addr >= m_mapped_memory[i].addr && addr < m_mapped_memory[i].addr + m_mapped_memory[i].size)
 		{
-			return m_mapped_memory[i].realAddress + (addr - m_mapped_memory[i].addr);
+			result = m_mapped_memory[i].realAddress + (addr - m_mapped_memory[i].addr);
+			return true;
 		}
 	}
 
-	return 0;
+	return false;
 }
 
 u64 VirtualMemoryBlock::getMappedAddress(u64 realAddress)

--- a/rpcs3/Emu/Memory/MemoryBlock.h
+++ b/rpcs3/Emu/Memory/MemoryBlock.h
@@ -281,8 +281,9 @@ public:
 	virtual bool Write64(const u64 addr, const u64 value);
 	virtual bool Write128(const u64 addr, const u128 value);
 
-	// return the real address given a mapped address, if not mapped return 0
-	u64 getRealAddr(u64 addr);
+	// try to get the real address given a mapped address
+	// return true for success
+	bool getRealAddr(u64 addr, u64& result);
 
 	// return the mapped address given a real address, if not mapped return 0
 	u64 getMappedAddress(u64 realAddress);

--- a/rpcs3/Emu/SysCalls/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellGcmSys.cpp
@@ -339,16 +339,16 @@ int cellGcmSetPrepareFlip(mem_ptr_t<CellGcmContextData> ctxt, u32 id)
 	{
 		ConLog.Warning("bad flip!");
 		//cellGcmCallback(ctxt.GetAddr(), current + 8 - end);
- 		//copied:
+		//copied:
  
- 		CellGcmControl& ctrl = (CellGcmControl&)Memory[gcm_info.control_addr];
+		CellGcmControl& ctrl = (CellGcmControl&)Memory[gcm_info.control_addr];
  
- 		const s32 res = ctxt->current - ctxt->begin - ctrl.put;
+		const s32 res = ctxt->current - ctxt->begin - ctrl.put;
  
- 		if(res > 0) Memory.Copy(ctxt->begin, ctxt->current - res, res);
- 		ctxt->current = ctxt->begin + res;
- 		ctrl.put = res;
- 		ctrl.get = 0;
+		if(res > 0) Memory.Copy(ctxt->begin, ctxt->current - res, res);
+		ctxt->current = ctxt->begin + res;
+		ctrl.put = res;
+		ctrl.get = 0;
 	}
 
 	current = ctxt->current;
@@ -575,9 +575,7 @@ int32_t cellGcmIoOffsetToAddress(u32 ioOffset, u64 address)
 {
 	u64 realAddr;
 
-	realAddr = Memory.RSXIOMem.getRealAddr(Memory.RSXIOMem.GetStartAddr() + ioOffset);
-
-	if (!realAddr)
+	if (!Memory.RSXIOMem.getRealAddr(Memory.RSXIOMem.GetStartAddr() + ioOffset, realAddr)) 
 		return CELL_GCM_ERROR_FAILURE;
 
 	Memory.Write64(address, realAddr);

--- a/rpcs3/Gui/RSXDebugger.cpp
+++ b/rpcs3/Gui/RSXDebugger.cpp
@@ -322,20 +322,28 @@ void RSXDebugger::GoToGet(wxCommandEvent& event)
 {
 	if (!RSXReady()) return;
 	CellGcmControl* ctrl = (CellGcmControl*)&Memory[Emu.GetGSManager().GetRender().m_ctrlAddress];
-	m_addr = Memory.RSXIOMem.getRealAddr(Memory.RSXIOMem.GetStartAddr() + ctrl->get);
-	t_addr->SetValue(wxString::Format("%08x", m_addr));
-	UpdateInformation();
-	event.Skip();
+	u64 realAddr;
+	if (Memory.RSXIOMem.getRealAddr(Memory.RSXIOMem.GetStartAddr() + ctrl->get, realAddr)) {
+		m_addr = realAddr; // WARNING: Potential Truncation? Cast from u64 to u32
+		t_addr->SetValue(wxString::Format("%08x", m_addr));
+		UpdateInformation();
+		event.Skip();
+	}
+	// TODO: We should probably throw something? 
 }
 
 void RSXDebugger::GoToPut(wxCommandEvent& event)
 {
 	if (!RSXReady()) return;
 	CellGcmControl* ctrl = (CellGcmControl*)&Memory[Emu.GetGSManager().GetRender().m_ctrlAddress];
-	m_addr = Memory.RSXIOMem.getRealAddr(Memory.RSXIOMem.GetStartAddr() + ctrl->put);
-	t_addr->SetValue(wxString::Format("%08x", m_addr));
-	UpdateInformation();
-	event.Skip();
+	u64 realAddr;
+	if (Memory.RSXIOMem.getRealAddr(Memory.RSXIOMem.GetStartAddr() + ctrl->put, realAddr)) {
+		m_addr = realAddr; // WARNING: Potential Truncation? Cast from u64 to u32
+		t_addr->SetValue(wxString::Format("%08x", m_addr));
+		UpdateInformation();
+		event.Skip();
+	}
+	// TODO: We should probably throw something? 
 }
 
 void RSXDebugger::UpdateInformation()


### PR DESCRIPTION
Comparing getRealAddr's results to zero seemed ugly so I opted to return success/fail and use an out parameter (result).  Of course, you probably won't ever have a virtual address resolve to zero so this is more  a style/nitpick thing.

Fixes Solar v2.1 http://puu.sh/8ScXK.jpg
