### PR TITLE
Add support for m_surface_depth_format 0

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -719,6 +719,10 @@ void GLGSRender::ExecCMD()
 
 		switch(m_surface_depth_format)
 		{
+		// case 0 found in BLJM60410-[Suzukaze no Melt - Days in the Sanctuary]  
+		// [E : RSXThread]: Bad depth format! (0)
+		// [E : RSXThread]: glEnable: opengl error 0x0506
+		// [E : RSXThread]: glDrawArrays: opengl error 0x0506
 		case 0:
 			m_rbo.Storage(GL_DEPTH_COMPONENT, RSXThread::m_width, RSXThread::m_height);
 			checkForGlError("m_rbo.Storage(GL_DEPTH_COMPONENT)");


### PR DESCRIPTION
Some games failed to request m_surface_depth_format case 0 and popup 0x0506 error.

[E : RSXThread]: Bad depth format! (0)
[E : RSXThread]: glEnable: opengl error 0x0506

(or internal format probably GL_DEPTH_COMPONENT32 ? )
