### PR TITLE
Add 960x540 native resolution support

### DIFF
--- a/rpcs3/Emu/GS/sysutil_video.h
+++ b/rpcs3/Emu/GS/sysutil_video.h
@@ -232,6 +232,7 @@ static const CellVideoOutResolution ResolutionTable[] =
 	{1440, 1080},       //11 - 6
 	{1280, 1080},       //12 - 7
 	{960, 1080},        //13 - 8
+	{960, 540},         //14 - 9
 };
 
 inline static u32 ResolutionIdToNum(u32 id)
@@ -252,9 +253,10 @@ inline static u32 ResolutionIdToNum(u32 id)
 		6, //11
 		7, //12
 		8, //13
+		9, //14
 	};
 
-	return id <= 13 ? res[id] : 0;
+	return id <= 14 ? res[id] : 0;
 }
 
 inline static u32 ResolutionNumToId(u32 num)
@@ -270,7 +272,8 @@ inline static u32 ResolutionNumToId(u32 num)
 		11,
 		12,
 		13,
+		14,
 	};
 
-	return num <= 8 ? res[num] : 0;
+	return num <= 9 ? res[num] : 0;
 }


### PR DESCRIPTION
This can be found in Ghostbusters and Terraria . Terriraria is now rendering correctly by using this resolution.

It would be good to have AUTO resolution setting based on native in the future.

![1](https://cloud.githubusercontent.com/assets/3000282/3068773/49deda48-e292-11e3-8543-747aed42812a.jpg)
![2](https://cloud.githubusercontent.com/assets/3000282/3068774/49e061ce-e292-11e3-9d3e-cee42acd5ab7.jpg)
![3](https://cloud.githubusercontent.com/assets/3000282/3068775/49e1499a-e292-11e3-9391-849f6c364098.jpg)
![4](https://cloud.githubusercontent.com/assets/3000282/3068776/49e95496-e292-11e3-8135-6cff9ff99666.jpg)
