### PR TITLE
Basic XInput support

### DIFF
--- a/rpcs3/Emu/Io/Pad.cpp
+++ b/rpcs3/Emu/Io/Pad.cpp
@@ -2,6 +2,9 @@
 #include "Pad.h"
 #include "Null/NullPadHandler.h"
 #include "Windows/WindowsPadHandler.h"
+#if defined(_WIN32)
+#include "XInput/XInputPadHandler.h"
+#endif
 
 PadManager::PadManager()
 	: m_pad_handler(nullptr)
@@ -24,6 +27,12 @@ void PadManager::Init(const u32 max_connect)
 	case 1:
 		m_pad_handler.reset(new WindowsPadHandler());
 		break;
+
+#if defined(_WIN32)
+	case 2:
+		m_pad_handler.reset(new XInputPadHandler());
+		break;
+#endif
 
 	default:
 	case 0:

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -220,7 +220,7 @@ public:
 	virtual ~PadHandlerBase() = default;
 
 	//Set value to set pressure/axi to certain level, otherwise 0/255 default
-	void Key(const u32 code, bool pressed, u16 value=256)
+	void Key(const u32 code, bool pressed, u16 value=255)
 	{
 		for(Pad& pad : m_pads)
 		{

--- a/rpcs3/Emu/Io/XInput/XInputPadHandler.cpp
+++ b/rpcs3/Emu/Io/XInput/XInputPadHandler.cpp
@@ -1,0 +1,181 @@
+#include "stdafx.h"
+#if defined (_WIN32)
+#include "XInputPadHandler.h"
+#include <cstring>
+
+namespace {
+	const DWORD THREAD_TIMEOUT = 1000;
+	const DWORD THREAD_SLEEP = 10;
+	const DWORD THREAD_SLEEP_INACTIVE = 100;
+	const DWORD MAX_GAMEPADS = 4;
+	const DWORD XINPUT_GAMEPAD_GUIDE = 0x0400;
+	const DWORD XINPUT_GAMEPAD_BUTTONS = 16;
+	const LPCWSTR LIBRARY_FILENAMES[] = {
+		L"xinput1_4.dll",
+		L"xinput1_3.dll",
+		L"xinput1_2.dll",
+		L"xinput9_1_0.dll"
+	};
+
+	inline u16 ConvertAxis(SHORT value)
+	{
+		return static_cast<u16>((value + 32768l) >> 8);
+	}
+}
+
+XInputPadHandler::XInputPadHandler() : active(false), thread(nullptr), library(nullptr), xinputGetState(nullptr), xinputEnable(nullptr)
+{
+}
+
+XInputPadHandler::~XInputPadHandler()
+{
+	Close();
+}
+
+void XInputPadHandler::Init(const u32 max_connect)
+{
+	for (auto it : LIBRARY_FILENAMES)
+	{
+		library = LoadLibrary(it);
+		if (library)
+		{
+			xinputEnable = reinterpret_cast<PFN_XINPUTENABLE>(GetProcAddress(library, "XInputEnable"));
+			xinputGetState = reinterpret_cast<PFN_XINPUTGETSTATE>(GetProcAddress(library, reinterpret_cast<LPCSTR>(100)));
+			if (!xinputGetState)
+			{
+				xinputGetState = reinterpret_cast<PFN_XINPUTGETSTATE>(GetProcAddress(library, "XInputGetState"));
+			}
+
+			if (xinputEnable && xinputGetState)
+			{
+				break;
+			}
+
+			FreeLibrary(library);
+			library = nullptr;
+			xinputEnable = nullptr;
+			xinputGetState = nullptr;
+		}
+	}
+
+	if (library)
+	{
+		std::memset(&m_info, 0, sizeof m_info);
+		m_info.max_connect = max_connect;
+
+		for (u32 i = 0, max = std::min(max_connect, u32(MAX_GAMEPADS)); i != max; ++i)
+		{
+			m_pads.emplace_back(
+				CELL_PAD_STATUS_ASSIGN_CHANGES,
+				CELL_PAD_SETTING_PRESS_OFF | CELL_PAD_SETTING_SENSOR_OFF,
+				CELL_PAD_CAPABILITY_PS3_CONFORMITY | CELL_PAD_CAPABILITY_PRESS_MODE,
+				CELL_PAD_DEV_TYPE_STANDARD
+			);
+			auto & pad = m_pads.back();
+
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, XINPUT_GAMEPAD_DPAD_UP, CELL_PAD_CTRL_UP);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, XINPUT_GAMEPAD_DPAD_DOWN, CELL_PAD_CTRL_DOWN);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, XINPUT_GAMEPAD_DPAD_LEFT, CELL_PAD_CTRL_LEFT);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, XINPUT_GAMEPAD_DPAD_RIGHT, CELL_PAD_CTRL_RIGHT);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, XINPUT_GAMEPAD_START, CELL_PAD_CTRL_START);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, XINPUT_GAMEPAD_BACK, CELL_PAD_CTRL_SELECT);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, XINPUT_GAMEPAD_LEFT_THUMB, CELL_PAD_CTRL_L3);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, XINPUT_GAMEPAD_RIGHT_THUMB, CELL_PAD_CTRL_R3);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, XINPUT_GAMEPAD_LEFT_SHOULDER, CELL_PAD_CTRL_L1);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, XINPUT_GAMEPAD_RIGHT_SHOULDER, CELL_PAD_CTRL_R1);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, XINPUT_GAMEPAD_GUIDE, 0x100/*CELL_PAD_CTRL_PS*/);// TODO: PS button support
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0, 0x0); // Reserved
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, XINPUT_GAMEPAD_A, CELL_PAD_CTRL_CROSS);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, XINPUT_GAMEPAD_B, CELL_PAD_CTRL_CIRCLE);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, XINPUT_GAMEPAD_X, CELL_PAD_CTRL_SQUARE);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, XINPUT_GAMEPAD_Y, CELL_PAD_CTRL_TRIANGLE);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0, CELL_PAD_CTRL_L2);
+			pad.m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0, CELL_PAD_CTRL_R2);
+
+			pad.m_sticks.emplace_back(CELL_PAD_BTN_OFFSET_ANALOG_LEFT_X, 0, 0);
+			pad.m_sticks.emplace_back(CELL_PAD_BTN_OFFSET_ANALOG_LEFT_Y, 0, 0);
+			pad.m_sticks.emplace_back(CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_X, 0, 0);
+			pad.m_sticks.emplace_back(CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_Y, 0, 0);
+		}
+
+		active = true;
+		thread = CreateThread(NULL, 0, &XInputPadHandler::ThreadProcProxy, this, 0, NULL);
+	}
+}
+
+void XInputPadHandler::Close()
+{
+	if (library)
+	{
+		if (thread)
+		{
+			active = false;
+			if (WaitForSingleObject(thread, THREAD_TIMEOUT) != WAIT_OBJECT_0)
+				ConLog.Error("XInput thread could not stop within %d milliseconds", THREAD_TIMEOUT);
+			thread = nullptr;
+		}
+
+		FreeLibrary(library);
+		library = nullptr;
+		xinputGetState = nullptr;
+		xinputEnable = nullptr;
+	}
+
+	m_pads.clear();
+}
+
+DWORD XInputPadHandler::ThreadProcedure()
+{
+	while (active)
+	{
+		XINPUT_STATE state;
+		DWORD result;
+		DWORD online = 0;
+
+		for (DWORD i = 0; i != m_pads.size(); ++i)
+		{
+			auto & pad = m_pads[i];
+
+			result = (* xinputGetState)(i, &state);
+			switch (result)
+			{
+			case ERROR_DEVICE_NOT_CONNECTED:
+				pad.m_port_status &= ~CELL_PAD_STATUS_CONNECTED;
+				break;
+
+			case ERROR_SUCCESS:
+				++online;
+				pad.m_port_status |= CELL_PAD_STATUS_CONNECTED;
+				for (DWORD j = 0; j != XINPUT_GAMEPAD_BUTTONS; ++j)
+				{
+					bool pressed = state.Gamepad.wButtons & (1 << j);
+					pad.m_buttons[j].m_pressed = pressed;
+					pad.m_buttons[j].m_value = pressed ? 255 : 0;
+				}
+
+				pad.m_buttons[XINPUT_GAMEPAD_BUTTONS].m_pressed = state.Gamepad.bLeftTrigger > 0;
+				pad.m_buttons[XINPUT_GAMEPAD_BUTTONS].m_value = state.Gamepad.bLeftTrigger;
+				pad.m_buttons[XINPUT_GAMEPAD_BUTTONS + 1].m_pressed = state.Gamepad.bRightTrigger > 0;
+				pad.m_buttons[XINPUT_GAMEPAD_BUTTONS + 1].m_value = state.Gamepad.bRightTrigger;
+
+				pad.m_sticks[0].m_value = ConvertAxis(state.Gamepad.sThumbLX);
+				pad.m_sticks[1].m_value = ConvertAxis(state.Gamepad.sThumbLY);
+				pad.m_sticks[2].m_value = ConvertAxis(state.Gamepad.sThumbRX);
+				pad.m_sticks[3].m_value = ConvertAxis(state.Gamepad.sThumbRY);
+				break;
+			}
+		}
+
+		Sleep((online > 0) ? THREAD_SLEEP : THREAD_SLEEP_INACTIVE);
+		m_info.now_connect = online;
+	}
+
+	return 0;
+}
+
+DWORD WINAPI XInputPadHandler::ThreadProcProxy(LPVOID parameter)
+{
+	return reinterpret_cast<XInputPadHandler *>(parameter)->ThreadProcedure();
+}
+
+#endif

--- a/rpcs3/Emu/Io/XInput/XInputPadHandler.h
+++ b/rpcs3/Emu/Io/XInput/XInputPadHandler.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Emu/Io/PadHandler.h"
+#include <Xinput.h>
+
+class XInputPadHandler : public PadHandlerBase
+{
+public:
+	XInputPadHandler();
+	~XInputPadHandler();
+
+	void Init(const u32 max_connect) override;
+	void Close() override;
+
+private:
+	typedef void (WINAPI * PFN_XINPUTENABLE)(BOOL);
+	typedef DWORD (WINAPI * PFN_XINPUTGETSTATE)(DWORD, XINPUT_STATE *);
+
+private:
+	DWORD ThreadProcedure();
+	static DWORD WINAPI ThreadProcProxy(LPVOID parameter);
+
+private:
+	mutable bool active;
+	HANDLE thread;
+	HMODULE library;
+	PFN_XINPUTGETSTATE xinputGetState;
+	PFN_XINPUTENABLE xinputEnable;
+
+};

--- a/rpcs3/Gui/MainFrame.cpp
+++ b/rpcs3/Gui/MainFrame.cpp
@@ -401,6 +401,9 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 
 	cbox_pad_handler->Append("Null");
 	cbox_pad_handler->Append("Windows");
+#if defined (_WIN32)
+	cbox_pad_handler->Append("XInput");
+#endif
 	//cbox_pad_handler->Append("DirectInput");
 
 	cbox_keyboard_handler->Append("Null");

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -350,6 +350,7 @@
     <ClCompile Include="Emu\Io\Keyboard.cpp" />
     <ClCompile Include="Emu\Io\Mouse.cpp" />
     <ClCompile Include="Emu\Io\Pad.cpp" />
+    <ClCompile Include="Emu\Io\XInput\XInputPadHandler.cpp" />
     <ClCompile Include="Emu\Memory\Memory.cpp" />
     <ClCompile Include="Emu\SysCalls\Callback.cpp" />
     <ClCompile Include="Emu\SysCalls\FuncList.cpp" />
@@ -544,6 +545,7 @@
     <ClInclude Include="Emu\Io\Windows\WindowsKeyboardHandler.h" />
     <ClInclude Include="Emu\Io\Windows\WindowsMouseHandler.h" />
     <ClInclude Include="Emu\Io\Windows\WindowsPadHandler.h" />
+    <ClInclude Include="Emu\Io\XInput\XInputPadHandler.h" />
     <ClInclude Include="Emu\Memory\Memory.h" />
     <ClInclude Include="Emu\Memory\MemoryBlock.h" />
     <ClInclude Include="Emu\SysCalls\Callback.h" />

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -71,6 +71,9 @@
     <Filter Include="Emu\Io\Windows">
       <UniqueIdentifier>{899523fa-c26a-44ea-b272-73c4585e3821}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Emu\Io\XInput">
+      <UniqueIdentifier>{a77ab520-4399-4c95-a7ee-985c9a5ad694}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="rpcs3.cpp">
@@ -504,6 +507,9 @@
     </ClCompile>
     <ClCompile Include="Crypto\lz.cpp">
       <Filter>Crypto</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\Io\XInput\XInputPadHandler.cpp">
+      <Filter>Emu\Io\XInput</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -989,6 +995,9 @@
     </ClInclude>
     <ClInclude Include="Gui\AboutDialog.h">
       <Filter>Gui</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Io\XInput\XInputPadHandler.h">
+      <Filter>Emu\Io\XInput</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds a new pad handler named XInput. State polling is done in its own internal thread as XInput doesn't have an event-based mechanism.

Mapped:
- D-pad
- Left/right sticks
- Start
- Select: back
- Triangle: Y
- Square: X
- Circle: B
- Cross: A
- L1/R1: left/right shoulder
- L2/R2: left/right trigger (0 to 255)
- L3/R3: left/right thumb

The hidden XInputGetState variant is used when available, which will make it possible to use the Xbox 360 gamepad's guide button for the PS3 gamepad's PS button.

Tested with an Xbox 360 wired gamepad.
