### PR TITLE
Set default log level to Error

### DIFF
--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -288,7 +288,7 @@ public:
 		HLEHookStFunc.Load(false);
 		HLESaveTTY.Load(false);
 		HLEExitOnStop.Load(false);
-		HLELogLvl.Load(0);
+		HLELogLvl.Load(3);
 		HLEHideDebugConsole.Load(false);
 		HLEAlwaysStart.Load(false);
 


### PR DESCRIPTION
I think our user deserve better speed with lower log level here .All/Warning are too spamming (even during debug) .Error log level should still give our user report any errors they seen at least.
