### PR TITLE
add primitive InterlockedOr64 implementation

### DIFF
--- a/Utilities/GNU.h
+++ b/Utilities/GNU.h
@@ -19,7 +19,17 @@
 #define _CRT_ALIGN(x) __attribute__((aligned(x)))
 #define InterlockedCompareExchange(ptr,new_val,old_val)  __sync_val_compare_and_swap(ptr,old_val,new_val)
 #define InterlockedCompareExchange64(ptr,new_val,old_val)  __sync_val_compare_and_swap(ptr,old_val,new_val)
-
+int64_t InterlockedOr64(int64_t *dest,int64_t val)
+{
+	int64_t olderval;
+	int64_t oldval = *dest;
+	do
+	{
+		olderval = oldval;
+		oldval = InterlockedCompareExchange64(dest,olderval | val, olderval);
+	}while(olderval!=oldval);
+	return oldval;
+}
 #ifndef __APPLE__
 #define _aligned_malloc(size,alignment) memalign(alignment,size)
 #else


### PR DESCRIPTION
well minigw doesn't do it better so why should we :P

Didn't test this btw. was to lazy to do it on my linux machine
