### PR TITLE
Speedup write color buffers

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -485,6 +485,9 @@ void GLGSRender::WriteDepthBuffer()
 		return;
 	}
 
+	// Reset the flag
+	m_set_context_dma_z = false;
+
 	u32 address = GetAddress(m_surface_offset_z, m_context_dma_z - 0xfeed0000);
 	if(!Memory.IsGoodAddr(address))
 	{
@@ -509,6 +512,9 @@ void GLGSRender::WriteColourBufferA()
 		return;
 	}
 
+	// Reset the flag
+	m_set_context_dma_color_a = false;
+
 	u32 address = GetAddress(m_surface_offset_a, m_context_dma_color_a - 0xfeed0000);
 	if(!Memory.IsGoodAddr(address))
 	{
@@ -528,6 +534,9 @@ void GLGSRender::WriteColourBufferB()
 	{
 		return;
 	}
+
+	// Reset the flag
+	m_set_context_dma_color_b = false;
 
 	u32 address = GetAddress(m_surface_offset_b, m_context_dma_color_b - 0xfeed0000);
 	if(!Memory.IsGoodAddr(address))
@@ -549,6 +558,9 @@ void GLGSRender::WriteColourBufferC()
 		return;
 	}
 
+	// Reset the flag
+	m_set_context_dma_color_c = false;
+
 	u32 address = GetAddress(m_surface_offset_c, m_context_dma_color_c - 0xfeed0000);
 	if(!Memory.IsGoodAddr(address))
 	{
@@ -568,6 +580,9 @@ void GLGSRender::WriteColourBufferD()
 	{
 		return;
 	}
+
+	// Reset the flag
+	m_set_context_dma_color_d = false;
 
 	u32 address = GetAddress(m_surface_offset_d, m_context_dma_color_d - 0xfeed0000);
 	if(!Memory.IsGoodAddr(address))


### PR DESCRIPTION
This should allow us to enable write color buffers without significant performance impact overall as some games require this mode to render graphics like street puzzle fighter .It renders only using color buffers when required .

For example Disgaea 3 , 'now loading' renders much faster than before with special effect now while come to title screen , write color buffer will turn off itself .

Next to check would be texture and position update.
