### PR TITLE
Regression fix : restore point size functionality

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -843,7 +843,7 @@ void GLGSRender::ExecCMD()
 	Enable(m_set_poly_offset_fill, GL_POLYGON_OFFSET_FILL);
 	Enable(m_set_poly_offset_line, GL_POLYGON_OFFSET_LINE);
 	Enable(m_set_poly_offset_point, GL_POLYGON_OFFSET_POINT);
-	Enable(m_set_restart_index, GL_PRIMITIVE_RESTART); // Requires OpenGL 3.1+
+	Enable(m_set_restart_index, GL_PRIMITIVE_RESTART);
 
 	if(m_set_clip_plane)
 	{
@@ -870,6 +870,12 @@ void GLGSRender::ExecCMD()
 	{
 		glPolygonMode(GL_BACK, m_back_polygon_mode);
 		checkForGlError("glPolygonMode(Back)");
+	}
+
+	if (m_set_point_size)
+	{
+		glPointSize(m_point_size);
+		checkForGlError("glPointSize");
 	}
 
 	if (m_set_poly_offset_mode)

--- a/rpcs3/Emu/GS/RSXThread.cpp
+++ b/rpcs3/Emu/GS/RSXThread.cpp
@@ -1149,7 +1149,9 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	// Point 
 	case NV4097_SET_POINT_SIZE:
 	{
-		// Done in Vertex Shader
+		m_set_point_size = true;
+		const u32 a0 = ARGS(0);
+		m_point_size = (float&)a0;
 	}
 	break;
 

--- a/rpcs3/Emu/GS/RSXThread.h
+++ b/rpcs3/Emu/GS/RSXThread.h
@@ -181,7 +181,9 @@ public:
 	u32 m_restart_index;
 
 	// Point 
+	bool m_set_point_size;
 	bool m_set_point_sprite_control;
+	u32 m_point_size;
 	u16 m_point_x;
 	u16 m_point_y;
 
@@ -426,6 +428,7 @@ protected:
 		m_set_scissor_vertical = false;
 		m_set_line_smooth = false;
 		m_set_poly_smooth = false;
+		m_set_point_size = false;
 		m_set_two_sided_stencil_test_enable = false;
 		m_set_surface_clip_horizontal = false;
 		m_set_surface_clip_vertical = false;
@@ -454,6 +457,7 @@ protected:
 
 		m_point_x = 0;
 		m_point_y = 0;
+		m_point_size = 0;
 
 		// Construct Textures
 		for(int i=0; i<16; i++)


### PR DESCRIPTION
Works okay again with primitives autotest
