### PR TITLE
Drop off  scissor test enable on OnInitThread()

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -615,7 +615,6 @@ void GLGSRender::OnInitThread()
 	InitProcTable();
 
 	glEnable(GL_TEXTURE_2D);
-	glEnable(GL_SCISSOR_TEST);
 	glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
 	glGenTextures(1, &g_depth_tex);
 	glGenTextures(1, &g_flip_tex);


### PR DESCRIPTION
This fixes the render-to-texture sample background 

Before (with glEnable(GL_SCISSOR_TEST))
![1](https://cloud.githubusercontent.com/assets/3000282/3282186/2d92f466-f4dd-11e3-8140-ddc9809dc508.jpg)

-After (without glEnable(GL_SCISSOR_TEST))
![2](https://cloud.githubusercontent.com/assets/3000282/3282189/5de1cee4-f4dd-11e3-92d3-b63308063c1b.jpg)
