### PR TITLE
Remove glDetachShader for vp and fp

### DIFF
--- a/rpcs3/Emu/GS/GL/GLProgram.cpp
+++ b/rpcs3/Emu/GS/GL/GLProgram.cpp
@@ -79,9 +79,6 @@ void GLProgram::Create(const u32 vp, const u32 fp)
 			return;
 		}
 	}
-
-	glDetachShader(id, vp);
-	glDetachShader(id, fp);
 }
 
 void GLProgram::UnUse()


### PR DESCRIPTION
We're still pending [DH] to confirm whether it is okay to remove this glDetachShader for vp and fp .

It fixes cube_mrt.elf as well as missing sprities in Disgaea 3 that i tested so far.
