### PR TITLE
don't use two sets of logging functions

### DIFF
--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -11,21 +11,12 @@
 
 //#define BUFFERED_LOGGING 1
 
-//another msvc bug makes these not work, uncomment these and replace it with the one at the bottom when it's fixed
-//#define LOG_MESSAGE(logType, severity, text) Log::LogManager::getInstance().log({logType, severity, text})
-
 //first parameter is of type Log::LogType and text is of type std::string
-#define LOG_MESSAGE(logType, severity, text) do{Log::LogMessage msg{logType, severity, text}; Log::LogManager::getInstance().log(msg);}while(0)
 
-#define LOG_SUCCESS(logType, text)           LOG_MESSAGE(logType, Log::Success, text)
-#define LOG_NOTICE(logType, text)            LOG_MESSAGE(logType, Log::Notice,  text) 
-#define LOG_WARNING(logType, text)           LOG_MESSAGE(logType, Log::Warning, text) 
-#define LOG_ERROR(logType, text)             LOG_MESSAGE(logType, Log::Error,   text)
-
-#define LOGF_SUCCESS(logType, fmtstring, ...)  LOG_SUCCESS(logType, fmt::Format(fmtstring, ##__VA_ARGS__ ))
-#define LOGF_NOTICE(logType, fmtstring, ...)   LOG_NOTICE(logType, fmt::Format(fmtstring, ##__VA_ARGS__ ))
-#define LOGF_WARNING(logType, fmtstring, ...)  LOG_WARNING(logType, fmt::Format(fmtstring, ##__VA_ARGS__ ))
-#define LOGF_ERROR(logType, fmtstring, ...)    LOG_ERROR(logType, fmt::Format(fmtstring, ##__VA_ARGS__ ))
+#define LOG_SUCCESS(logType, text, ...)           log_message(logType, Log::Success, text, ##__VA_ARGS__)
+#define LOG_NOTICE(logType, text, ...)            log_message(logType, Log::Notice,  text, ##__VA_ARGS__) 
+#define LOG_WARNING(logType, text, ...)           log_message(logType, Log::Warning, text, ##__VA_ARGS__) 
+#define LOG_ERROR(logType, text, ...)             log_message(logType, Log::Error,   text, ##__VA_ARGS__)
 
 namespace Log
 {
@@ -139,3 +130,19 @@ static struct { inline operator Log::LogType() { return Log::LogType::HLE; } } H
 static struct { inline operator Log::LogType() { return Log::LogType::PPU; } } PPU;
 static struct { inline operator Log::LogType() { return Log::LogType::SPU; } } SPU;
 static struct { inline operator Log::LogType() { return Log::LogType::TTY; } } TTY;
+
+inline void log_message(Log::LogType type, Log::LogSeverity sev, std::string text)
+{
+	//another msvc bug makes this not work, uncomment this and delete everything else in this function when it's fixed
+	//Log::LogManager::getInstance().log({logType, severity, text})
+
+	Log::LogMessage msg{type, sev, text};
+	Log::LogManager::getInstance().log(msg);
+}
+
+template<typename T, typename ...Ts> 
+inline void log_message(Log::LogType type, Log::LogSeverity sev, std::string text, T arg, Ts... args)
+{
+	Log::LogMessage msg{type, sev, fmt::Format(text,arg,args...)};
+	Log::LogManager::getInstance().log(msg);
+}

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -275,8 +275,8 @@ int decrypt_data(rFile *in, rFile *out, EDAT_SDAT_HEADER *edat, NPD_HEADER *npd,
 			
 			if (verbose)
 			{
-				LOGF_NOTICE(LOADER, "EDAT: Compressed block size: %d\n", pad_length);
-				LOGF_NOTICE(LOADER, "EDAT: Decompressed block size: %d\n", res);
+				LOG_NOTICE(LOADER, "EDAT: Compressed block size: %d\n", pad_length);
+				LOG_NOTICE(LOADER, "EDAT: Decompressed block size: %d\n", res);
 			}
 
 			edat->file_size -= res;
@@ -337,7 +337,7 @@ static bool check_flags(EDAT_SDAT_HEADER *edat, NPD_HEADER *npd)
 	}
 	else if (npd->version > 4)
 	{
-		LOGF_ERROR(LOADER, "EDAT: Unknown version - %d\n", npd->version);
+		LOG_ERROR(LOADER, "EDAT: Unknown version - %d\n", npd->version);
 		return false;
 	}
 
@@ -418,7 +418,7 @@ int check_data(unsigned char *key, EDAT_SDAT_HEADER *edat, NPD_HEADER *npd, rFil
 		if (!crypto(hash_mode, crypto_mode, (npd->version == 4), data, tmp, block_size, header_key, header_iv, key, hash_result))
 		{
 			if (verbose)
-				LOGF_WARNING(LOADER, "EDAT: Metadata hash from block 0x%08x is invalid!\n", metadata_offset + bytes_read);
+				LOG_WARNING(LOADER, "EDAT: Metadata hash from block 0x%08x is invalid!\n", metadata_offset + bytes_read);
 		}
 
 		// Adjust sizes.
@@ -535,14 +535,14 @@ bool extract_data(rFile *input, rFile *output, const char* input_file_name, unsi
 	if (verbose)
 	{
 		LOG_NOTICE(LOADER, "NPD HEADER\n");
-		LOGF_NOTICE(LOADER, "NPD version: %d\n", NPD->version);
-		LOGF_NOTICE(LOADER, "NPD license: %d\n", NPD->license);
-		LOGF_NOTICE(LOADER, "NPD type: %d\n", NPD->type);
+		LOG_NOTICE(LOADER, "NPD version: %d\n", NPD->version);
+		LOG_NOTICE(LOADER, "NPD license: %d\n", NPD->license);
+		LOG_NOTICE(LOADER, "NPD type: %d\n", NPD->type);
 		LOG_NOTICE(LOADER, "\n");
 		LOG_NOTICE(LOADER, "EDAT HEADER\n");
-		LOGF_NOTICE(LOADER, "EDAT flags: 0x%08X\n", EDAT->flags);
-		LOGF_NOTICE(LOADER, "EDAT block size: 0x%08X\n", EDAT->block_size);
-		LOGF_NOTICE(LOADER, "EDAT file size: 0x%08X\n", EDAT->file_size);
+		LOG_NOTICE(LOADER, "EDAT flags: 0x%08X\n", EDAT->flags);
+		LOG_NOTICE(LOADER, "EDAT block size: 0x%08X\n", EDAT->block_size);
+		LOG_NOTICE(LOADER, "EDAT file size: 0x%08X\n", EDAT->file_size);
 		LOG_NOTICE(LOADER, "\n");
 	}
 

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -17,7 +17,7 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 	// Check SCE magic.
 	if (!sce_hdr.CheckMagic())
 	{
-		LOGF_ERROR(LOADER, "SELF: Not a SELF file!");
+		LOG_ERROR(LOADER, "SELF: Not a SELF file!");
 		return false;
 	}
 
@@ -41,7 +41,7 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 		phdr32_arr.clear();
 		if(elf32_hdr.e_phoff == 0 && elf32_hdr.e_phnum)
 		{
-			LOGF_ERROR(LOADER, "SELF: ELF program header offset is null!");
+			LOG_ERROR(LOADER, "SELF: ELF program header offset is null!");
 			return false;
 		}
 		self_f.Seek(self_hdr.se_phdroff);
@@ -56,7 +56,7 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 		phdr64_arr.clear();
 		if(elf64_hdr.e_phoff == 0 && elf64_hdr.e_phnum)
 		{
-			LOGF_ERROR(LOADER, "SELF: ELF program header offset is null!");
+			LOG_ERROR(LOADER, "SELF: ELF program header offset is null!");
 			return false;
 		}
 		self_f.Seek(self_hdr.se_phdroff);
@@ -101,7 +101,7 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 		shdr32_arr.clear();
 		if(elf32_hdr.e_shoff == 0 && elf32_hdr.e_shnum)
 		{
-			LOGF_WARNING(LOADER, "SELF: ELF section header offset is null!");
+			LOG_WARNING(LOADER, "SELF: ELF section header offset is null!");
 			return true;
 		}
 		self_f.Seek(self_hdr.se_shdroff);
@@ -116,7 +116,7 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 		shdr64_arr.clear();
 		if(elf64_hdr.e_shoff == 0 && elf64_hdr.e_shnum)
 		{
-			LOGF_WARNING(LOADER, "SELF: ELF section header offset is null!");
+			LOG_WARNING(LOADER, "SELF: ELF section header offset is null!");
 			return true;
 		}
 		self_f.Seek(self_hdr.se_shdroff);
@@ -132,46 +132,46 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 
 void SELFDecrypter::ShowHeaders(bool isElf32)
 {
-	LOGF_NOTICE(LOADER, "SCE header");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "SCE header");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	sce_hdr.Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
-	LOGF_NOTICE(LOADER, "SELF header");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "SELF header");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	self_hdr.Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
-	LOGF_NOTICE(LOADER, "APP INFO");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "APP INFO");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	app_info.Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
-	LOGF_NOTICE(LOADER, "ELF header");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "ELF header");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	isElf32 ? elf32_hdr.Show() : elf64_hdr.Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
-	LOGF_NOTICE(LOADER, "ELF program headers");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "ELF program headers");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	for(unsigned int i = 0; i < ((isElf32) ? phdr32_arr.size() : phdr64_arr.size()); i++)
 		isElf32 ? phdr32_arr[i].Show() : phdr64_arr[i].Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
-	LOGF_NOTICE(LOADER, "Section info");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "Section info");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	for(unsigned int i = 0; i < secinfo_arr.size(); i++)
 		secinfo_arr[i].Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
-	LOGF_NOTICE(LOADER, "SCE version info");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "SCE version info");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	scev_info.Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
-	LOGF_NOTICE(LOADER, "Control info");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "Control info");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	for(unsigned int i = 0; i < ctrlinfo_arr.size(); i++)
 		ctrlinfo_arr[i].Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
-	LOGF_NOTICE(LOADER, "ELF section headers");
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "ELF section headers");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 	for(unsigned int i = 0; i < ((isElf32) ? shdr32_arr.size() : shdr64_arr.size()); i++)
 		isElf32 ? shdr32_arr[i].Show() : shdr64_arr[i].Show();
-	LOGF_NOTICE(LOADER, "----------------------------------------------------");
+	LOG_NOTICE(LOADER, "----------------------------------------------------");
 }
 
 bool SELFDecrypter::DecryptNPDRM(u8 *metadata, u32 metadata_size)
@@ -195,7 +195,7 @@ bool SELFDecrypter::DecryptNPDRM(u8 *metadata, u32 metadata_size)
 	// If not, the data has no NPDRM layer.
 	if (!ctrl)
 	{
-		LOGF_WARNING(LOADER, "SELF: No NPDRM control info found!");
+		LOG_WARNING(LOADER, "SELF: No NPDRM control info found!");
 		return true;
 	}
 
@@ -208,7 +208,7 @@ bool SELFDecrypter::DecryptNPDRM(u8 *metadata, u32 metadata_size)
 
 	if (ctrl->npdrm.license == 1)  // Network license.
 	{
-		LOGF_ERROR(LOADER, "SELF: Can't decrypt network NPDRM!");
+		LOG_ERROR(LOADER, "SELF: Can't decrypt network NPDRM!");
 		return false;
 	}
 	else if (ctrl->npdrm.license == 2)  // Local license.
@@ -216,7 +216,7 @@ bool SELFDecrypter::DecryptNPDRM(u8 *metadata, u32 metadata_size)
 		// Try to find a RAP file to get the key.
 		if (!GetKeyFromRap(ctrl->npdrm.content_id, npdrm_key))
 		{
-			LOGF_ERROR(LOADER, "SELF: Can't find RAP file for NPDRM decryption!");
+			LOG_ERROR(LOADER, "SELF: Can't find RAP file for NPDRM decryption!");
 			return false;
 		}
 	}
@@ -227,7 +227,7 @@ bool SELFDecrypter::DecryptNPDRM(u8 *metadata, u32 metadata_size)
 	}
 	else
 	{
-		LOGF_ERROR(LOADER, "SELF: Invalid NPDRM license type!");
+		LOG_ERROR(LOADER, "SELF: Invalid NPDRM license type!");
 		return false;
 	}
 
@@ -290,7 +290,7 @@ bool SELFDecrypter::LoadMetadata()
 	if ((meta_info.key_pad[0] != 0x00) ||
 		(meta_info.iv_pad[0] != 0x00))
 	{
-		LOGF_ERROR(LOADER, "SELF: Failed to decrypt metadata info!");
+		LOG_ERROR(LOADER, "SELF: Failed to decrypt metadata info!");
 		return false;
 	}
 
@@ -392,7 +392,7 @@ bool SELFDecrypter::MakeElf(const std::string& elf, bool isElf32)
 	rFile e(elf.c_str(), rFile::write);
 	if(!e.IsOpened())
 	{
-		LOGF_ERROR(LOADER, "Could not create ELF file! (%s)", elf.c_str());
+		LOG_ERROR(LOADER, "Could not create ELF file! (%s)", elf.c_str());
 		return false;
 	}
 
@@ -510,7 +510,7 @@ bool SELFDecrypter::GetKeyFromRap(u8 *content_id, u8 *npdrm_key)
 	// Check if we have a valid RAP file.
 	if (!rFile::Exists(rap_path))
 	{
-		LOGF_ERROR(LOADER, "This application requires a valid RAP file for decryption!");
+		LOG_ERROR(LOADER, "This application requires a valid RAP file for decryption!");
 		return false;
 	}
 
@@ -519,11 +519,11 @@ bool SELFDecrypter::GetKeyFromRap(u8 *content_id, u8 *npdrm_key)
 
 	if (!rap_file.IsOpened())
 	{
-		LOGF_ERROR(LOADER, "Failed to load RAP file!");
+		LOG_ERROR(LOADER, "Failed to load RAP file!");
 		return false;
 	}
 
-	LOGF_NOTICE(LOADER, "Loading RAP file %s", (ci_str + ".rap").c_str());
+	LOG_NOTICE(LOADER, "Loading RAP file %s", (ci_str + ".rap").c_str());
 	rap_file.Read(rap_key, 0x10);
 	rap_file.Close();
 
@@ -573,7 +573,7 @@ bool CheckDebugSelf(const std::string& self, const std::string& elf)
 
 	if(!s.IsOpened())
 	{
-		LOGF_ERROR(LOADER, "Could not open SELF file! (%s)", self.c_str());
+		LOG_ERROR(LOADER, "Could not open SELF file! (%s)", self.c_str());
 		return false;
 	}
 
@@ -585,7 +585,7 @@ bool CheckDebugSelf(const std::string& self, const std::string& elf)
 	// Check for DEBUG version.
 	if(swap16(key_version) == 0x8000)
 	{
-		LOGF_WARNING(LOADER, "Debug SELF detected! Removing fake header...");
+		LOG_WARNING(LOADER, "Debug SELF detected! Removing fake header...");
 
 		// Get the real elf offset.
 		s.Seek(0x10);
@@ -600,7 +600,7 @@ bool CheckDebugSelf(const std::string& self, const std::string& elf)
 		rFile e(elf, rFile::write);
 		if(!e.IsOpened())
 		{
-			LOGF_ERROR(LOADER, "Could not create ELF file! (%s)", elf.c_str());
+			LOG_ERROR(LOADER, "Could not create ELF file! (%s)", elf.c_str());
 			return false;
 		}
 
@@ -640,28 +640,28 @@ bool DecryptSelf(const std::string& elf, const std::string& self)
 		// Load the SELF file headers.
 		if (!self_dec.LoadHeaders(isElf32))
 		{
-			LOGF_ERROR(LOADER, "SELF: Failed to load SELF file headers!");
+			LOG_ERROR(LOADER, "SELF: Failed to load SELF file headers!");
 			return false;
 		}
 		
 		// Load and decrypt the SELF file metadata.
 		if (!self_dec.LoadMetadata())
 		{
-			LOGF_ERROR(LOADER, "SELF: Failed to load SELF file metadata!");
+			LOG_ERROR(LOADER, "SELF: Failed to load SELF file metadata!");
 			return false;
 		}
 		
 		// Decrypt the SELF file data.
 		if (!self_dec.DecryptData())
 		{
-			LOGF_ERROR(LOADER, "SELF: Failed to decrypt SELF file data!");
+			LOG_ERROR(LOADER, "SELF: Failed to decrypt SELF file data!");
 			return false;
 		}
 		
 		// Make a new ELF file from this SELF.
 		if (!self_dec.MakeElf(elf, isElf32))
 		{
-			LOGF_ERROR(LOADER, "SELF: Failed to make ELF file from SELF!");
+			LOG_ERROR(LOADER, "SELF: Failed to make ELF file from SELF!");
 			return false;
 		}
 	}

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -25,10 +25,10 @@ struct AppInfo
 
   void Show()
   {
-	  LOGF_NOTICE(LOADER, "AuthID: 0x%llx",	   authid);
-	  LOGF_NOTICE(LOADER, "VendorID: 0x%08x",  vendor_id);
-	  LOGF_NOTICE(LOADER, "SELF type: 0x%08x", self_type);
-	  LOGF_NOTICE(LOADER, "Version: 0x%llx",   version);
+	  LOG_NOTICE(LOADER, "AuthID: 0x%llx",	   authid);
+	  LOG_NOTICE(LOADER, "VendorID: 0x%08x",  vendor_id);
+	  LOG_NOTICE(LOADER, "SELF type: 0x%08x", self_type);
+	  LOG_NOTICE(LOADER, "Version: 0x%llx",   version);
   }
 };
 
@@ -53,12 +53,12 @@ struct SectionInfo
 
   void Show()
   {
-	  LOGF_NOTICE(LOADER, "Offset: 0x%llx",     offset);
-	  LOGF_NOTICE(LOADER, "Size: 0x%llx",       size);
-	  LOGF_NOTICE(LOADER, "Compressed: 0x%08x", compressed);
-	  LOGF_NOTICE(LOADER, "Unknown1: 0x%08x",   unknown1);
-	  LOGF_NOTICE(LOADER, "Unknown2: 0x%08x",   unknown2);
-	  LOGF_NOTICE(LOADER, "Encrypted: 0x%08x",  encrypted);
+	  LOG_NOTICE(LOADER, "Offset: 0x%llx",     offset);
+	  LOG_NOTICE(LOADER, "Size: 0x%llx",       size);
+	  LOG_NOTICE(LOADER, "Compressed: 0x%08x", compressed);
+	  LOG_NOTICE(LOADER, "Unknown1: 0x%08x",   unknown1);
+	  LOG_NOTICE(LOADER, "Unknown2: 0x%08x",   unknown2);
+	  LOG_NOTICE(LOADER, "Encrypted: 0x%08x",  encrypted);
   }
 };
 
@@ -79,10 +79,10 @@ struct SCEVersionInfo
 
   void Show()
   {
-	  LOGF_NOTICE(LOADER, "Sub-header type: 0x%08x", subheader_type);
-	  LOGF_NOTICE(LOADER, "Present: 0x%08x",         present);
-	  LOGF_NOTICE(LOADER, "Size: 0x%08x",            size);
-	  LOGF_NOTICE(LOADER, "Unknown: 0x%08x",         unknown);
+	  LOG_NOTICE(LOADER, "Sub-header type: 0x%08x", subheader_type);
+	  LOG_NOTICE(LOADER, "Present: 0x%08x",         present);
+	  LOG_NOTICE(LOADER, "Size: 0x%08x",            size);
+	  LOG_NOTICE(LOADER, "Unknown: 0x%08x",         unknown);
   }
 };
 
@@ -181,20 +181,20 @@ struct ControlInfo
 
   void Show()
   {
-	  LOGF_NOTICE(LOADER, "Type: 0x%08x", type);
-	  LOGF_NOTICE(LOADER, "Size: 0x%08x", size);
-	  LOGF_NOTICE(LOADER, "Next: 0x%llx", next);
+	  LOG_NOTICE(LOADER, "Type: 0x%08x", type);
+	  LOG_NOTICE(LOADER, "Size: 0x%08x", size);
+	  LOG_NOTICE(LOADER, "Next: 0x%llx", next);
 
 	  if (type == 1)
 	  {
-		  LOGF_NOTICE(LOADER, "Control flag 1: 0x%08x",	control_flags.ctrl_flag1);
-		  LOGF_NOTICE(LOADER, "Unknown1: 0x%08x",       control_flags.unknown1);
-		  LOGF_NOTICE(LOADER, "Unknown2: 0x%08x",       control_flags.unknown2);
-		  LOGF_NOTICE(LOADER, "Unknown3: 0x%08x",       control_flags.unknown3);
-		  LOGF_NOTICE(LOADER, "Unknown4: 0x%08x",       control_flags.unknown4);
-		  LOGF_NOTICE(LOADER, "Unknown5: 0x%08x",       control_flags.unknown5);
-		  LOGF_NOTICE(LOADER, "Unknown6: 0x%08x",       control_flags.unknown6);
-		  LOGF_NOTICE(LOADER, "Unknown7: 0x%08x",       control_flags.unknown7);
+		  LOG_NOTICE(LOADER, "Control flag 1: 0x%08x",	control_flags.ctrl_flag1);
+		  LOG_NOTICE(LOADER, "Unknown1: 0x%08x",       control_flags.unknown1);
+		  LOG_NOTICE(LOADER, "Unknown2: 0x%08x",       control_flags.unknown2);
+		  LOG_NOTICE(LOADER, "Unknown3: 0x%08x",       control_flags.unknown3);
+		  LOG_NOTICE(LOADER, "Unknown4: 0x%08x",       control_flags.unknown4);
+		  LOG_NOTICE(LOADER, "Unknown5: 0x%08x",       control_flags.unknown5);
+		  LOG_NOTICE(LOADER, "Unknown6: 0x%08x",       control_flags.unknown6);
+		  LOG_NOTICE(LOADER, "Unknown7: 0x%08x",       control_flags.unknown7);
 	  }
 	  else if (type == 2)
 	  {
@@ -204,8 +204,8 @@ struct ControlInfo
 			  for (int i = 0; i < 20; i++)
 				  digest_str += fmt::Format("%02x", file_digest_30.digest[i]);
 
-			  LOGF_NOTICE(LOADER, "Digest: %s",         digest_str.c_str());
-			  LOGF_NOTICE(LOADER, "Unknown: 0x%llx",    file_digest_30.unknown);
+			  LOG_NOTICE(LOADER, "Digest: %s",         digest_str.c_str());
+			  LOG_NOTICE(LOADER, "Unknown: 0x%llx",    file_digest_30.unknown);
 		  }
 		  else if (size == 0x40)
 		  {
@@ -217,9 +217,9 @@ struct ControlInfo
 				  digest_str2 += fmt::Format("%02x", file_digest_40.digest2[i]);
 			  }
 			  
-			  LOGF_NOTICE(LOADER, "Digest1: %s",     digest_str1.c_str());
-			  LOGF_NOTICE(LOADER, "Digest2: %s",     digest_str2.c_str());
-			  LOGF_NOTICE(LOADER, "Unknown: 0x%llx", file_digest_40.unknown);
+			  LOG_NOTICE(LOADER, "Digest1: %s",     digest_str1.c_str());
+			  LOG_NOTICE(LOADER, "Digest2: %s",     digest_str2.c_str());
+			  LOG_NOTICE(LOADER, "Unknown: 0x%llx", file_digest_40.unknown);
 		  }
 	  }
 	  else if (type == 3)
@@ -237,16 +237,16 @@ struct ControlInfo
 			  xordigest_str += fmt::Format("%02x", npdrm.xordigest[i]);
 		  }
 
-		  LOGF_NOTICE(LOADER, "Magic: 0x%08x",      npdrm.magic);
-		  LOGF_NOTICE(LOADER, "Unknown1: 0x%08x",   npdrm.unknown1);
-		  LOGF_NOTICE(LOADER, "License: 0x%08x",    npdrm.license);
-		  LOGF_NOTICE(LOADER, "Type: 0x%08x",       npdrm.type);
-		  LOGF_NOTICE(LOADER, "ContentID: %s",      contentid_str.c_str());
-		  LOGF_NOTICE(LOADER, "Digest: %s",         digest_str.c_str());
-		  LOGF_NOTICE(LOADER, "Inverse digest: %s", invdigest_str.c_str());
-		  LOGF_NOTICE(LOADER, "XOR digest: %s",     xordigest_str.c_str());
-		  LOGF_NOTICE(LOADER, "Unknown2: 0x%llx",   npdrm.unknown2);
-		  LOGF_NOTICE(LOADER, "Unknown3: 0x%llx",   npdrm.unknown3);
+		  LOG_NOTICE(LOADER, "Magic: 0x%08x",      npdrm.magic);
+		  LOG_NOTICE(LOADER, "Unknown1: 0x%08x",   npdrm.unknown1);
+		  LOG_NOTICE(LOADER, "License: 0x%08x",    npdrm.license);
+		  LOG_NOTICE(LOADER, "Type: 0x%08x",       npdrm.type);
+		  LOG_NOTICE(LOADER, "ContentID: %s",      contentid_str.c_str());
+		  LOG_NOTICE(LOADER, "Digest: %s",         digest_str.c_str());
+		  LOG_NOTICE(LOADER, "Inverse digest: %s", invdigest_str.c_str());
+		  LOG_NOTICE(LOADER, "XOR digest: %s",     xordigest_str.c_str());
+		  LOG_NOTICE(LOADER, "Unknown2: 0x%llx",   npdrm.unknown2);
+		  LOG_NOTICE(LOADER, "Unknown3: 0x%llx",   npdrm.unknown3);
 	  }
   }
 };
@@ -281,10 +281,10 @@ struct MetadataInfo
 		  iv_pad_str += fmt::Format("%02x", iv_pad[i]);
 	  }
 	  
-	  LOGF_NOTICE(LOADER, "Key: %s",     key_str.c_str());
-	  LOGF_NOTICE(LOADER, "Key pad: %s", key_pad_str.c_str());
-	  LOGF_NOTICE(LOADER, "IV: %s",      iv_str.c_str());
-	  LOGF_NOTICE(LOADER, "IV pad: %s",  iv_pad_str.c_str());
+	  LOG_NOTICE(LOADER, "Key: %s",     key_str.c_str());
+	  LOG_NOTICE(LOADER, "Key pad: %s", key_pad_str.c_str());
+	  LOG_NOTICE(LOADER, "IV: %s",      iv_str.c_str());
+	  LOG_NOTICE(LOADER, "IV pad: %s",  iv_pad_str.c_str());
   }
 };
 
@@ -320,13 +320,13 @@ struct MetadataHeader
 
   void Show()
   {
-	  LOGF_NOTICE(LOADER, "Signature input length: 0x%llx", signature_input_length);
-	  LOGF_NOTICE(LOADER, "Unknown1: 0x%08x",               unknown1);
-	  LOGF_NOTICE(LOADER, "Section count: 0x%08x",          section_count);
-	  LOGF_NOTICE(LOADER, "Key count: 0x%08x",              key_count);
-	  LOGF_NOTICE(LOADER, "Optional header size: 0x%08x",   opt_header_size);
-	  LOGF_NOTICE(LOADER, "Unknown2: 0x%08x",               unknown2);
-	  LOGF_NOTICE(LOADER, "Unknown3: 0x%08x",               unknown3);
+	  LOG_NOTICE(LOADER, "Signature input length: 0x%llx", signature_input_length);
+	  LOG_NOTICE(LOADER, "Unknown1: 0x%08x",               unknown1);
+	  LOG_NOTICE(LOADER, "Section count: 0x%08x",          section_count);
+	  LOG_NOTICE(LOADER, "Key count: 0x%08x",              key_count);
+	  LOG_NOTICE(LOADER, "Optional header size: 0x%08x",   opt_header_size);
+	  LOG_NOTICE(LOADER, "Unknown2: 0x%08x",               unknown2);
+	  LOG_NOTICE(LOADER, "Unknown3: 0x%08x",               unknown3);
   }
 };
 
@@ -371,16 +371,16 @@ struct MetadataSectionHeader
 
   void Show()
   {
-	  LOGF_NOTICE(LOADER, "Data offset: 0x%llx",   data_offset);
-	  LOGF_NOTICE(LOADER, "Data size: 0x%llx",     data_size);
-	  LOGF_NOTICE(LOADER, "Type: 0x%08x",          type);
-	  LOGF_NOTICE(LOADER, "Program index: 0x%08x", program_idx);
-	  LOGF_NOTICE(LOADER, "Hashed: 0x%08x",        hashed);
-	  LOGF_NOTICE(LOADER, "SHA1 index: 0x%08x",    sha1_idx);
-	  LOGF_NOTICE(LOADER, "Encrypted: 0x%08x",     encrypted);
-	  LOGF_NOTICE(LOADER, "Key index: 0x%08x",     key_idx);
-	  LOGF_NOTICE(LOADER, "IV index: 0x%08x",      iv_idx);
-	  LOGF_NOTICE(LOADER, "Compressed: 0x%08x",    compressed);
+	  LOG_NOTICE(LOADER, "Data offset: 0x%llx",   data_offset);
+	  LOG_NOTICE(LOADER, "Data size: 0x%llx",     data_size);
+	  LOG_NOTICE(LOADER, "Type: 0x%08x",          type);
+	  LOG_NOTICE(LOADER, "Program index: 0x%08x", program_idx);
+	  LOG_NOTICE(LOADER, "Hashed: 0x%08x",        hashed);
+	  LOG_NOTICE(LOADER, "SHA1 index: 0x%08x",    sha1_idx);
+	  LOG_NOTICE(LOADER, "Encrypted: 0x%08x",     encrypted);
+	  LOG_NOTICE(LOADER, "Key index: 0x%08x",     key_idx);
+	  LOG_NOTICE(LOADER, "IV index: 0x%08x",      iv_idx);
+	  LOG_NOTICE(LOADER, "Compressed: 0x%08x",    compressed);
   }
 };
 

--- a/rpcs3/Emu/ARMv7/ARMv7Interpreter.h
+++ b/rpcs3/Emu/ARMv7/ARMv7Interpreter.h
@@ -316,7 +316,7 @@ protected:
 
 	void UNK(const u16 code0, const u16 code1)
 	{
-		LOGF_ERROR(HLE, "Unknown/Illegal opcode! (0x%04x : 0x%04x)", code0, code1);
+		LOG_ERROR(HLE, "Unknown/Illegal opcode! (0x%04x : 0x%04x)", code0, code1);
 		Emu.Pause();
 	}
 };

--- a/rpcs3/Emu/Audio/AL/OpenALThread.cpp
+++ b/rpcs3/Emu/Audio/AL/OpenALThread.cpp
@@ -18,7 +18,7 @@ void printAlError(ALenum err, const char* situation)
 {
 	if(err != AL_NO_ERROR)
 	{
-		LOGF_ERROR(HLE, "%s: OpenAL error 0x%04x", situation, err);
+		LOG_ERROR(HLE, "%s: OpenAL error 0x%04x", situation, err);
 		Emu.Pause();
 	}
 }
@@ -27,7 +27,7 @@ void printAlcError(ALCenum err, const char* situation)
 {
 	if(err != ALC_NO_ERROR)
 	{
-		LOGF_ERROR(HLE, "%s: OpenALC error 0x%04x", situation, err);
+		LOG_ERROR(HLE, "%s: OpenALC error 0x%04x", situation, err);
 		Emu.Pause();
 	}
 }
@@ -137,7 +137,7 @@ void OpenALThread::AddData(const void* src, ALsizei size)
 
 		int bsize = size < m_buffer_size ? size : m_buffer_size;
 		if (!AddBlock(buffer, bsize, bsrc))
-			LOGF_ERROR(HLE, "OpenALThread::AddBlock: invalid block size: %d", bsize);
+			LOG_ERROR(HLE, "OpenALThread::AddBlock: invalid block size: %d", bsize);
 
 		alSourceQueueBuffers(m_source, 1, &buffer);
 		checkForAlError("alSourceQueueBuffers");

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -149,7 +149,7 @@ void CPUThread::SetBranch(const u64 pc, bool record_branch)
 {
 	if(!Memory.IsGoodAddr(m_offset + pc))
 	{
-		LOGF_ERROR(PPU, "%s branch error: bad address 0x%llx #pc: 0x%llx", GetFName().c_str(), m_offset + pc, m_offset + PC);
+		LOG_ERROR(PPU, "%s branch error: bad address 0x%llx #pc: 0x%llx", GetFName().c_str(), m_offset + pc, m_offset + PC);
 		Emu.Pause();
 	}
 
@@ -282,7 +282,7 @@ void CPUThread::ExecOnce()
 
 void CPUThread::Task()
 {
-	if (Ini.HLELogging.GetValue()) LOGF_NOTICE(PPU, "%s enter", CPUThread::GetFName().c_str());
+	if (Ini.HLELogging.GetValue()) LOG_NOTICE(PPU, "%s enter", CPUThread::GetFName().c_str());
 
 	const std::vector<u64>& bp = Emu.GetBreakPoints();
 
@@ -333,18 +333,18 @@ void CPUThread::Task()
 	}
 	catch(const std::string& e)
 	{
-		LOGF_ERROR(PPU, "Exception: %s", e.c_str());
+		LOG_ERROR(PPU, "Exception: %s", e.c_str());
 	}
 	catch(const char* e)
 	{
-		LOGF_ERROR(PPU, "Exception: %s", e);
+		LOG_ERROR(PPU, "Exception: %s", e);
 	}
 	catch(int exitcode)
 	{
-		LOGF_SUCCESS(PPU, "Exit Code: %d", exitcode);
+		LOG_SUCCESS(PPU, "Exit Code: %d", exitcode);
 	}
 
-	if (Ini.HLELogging.GetValue()) LOGF_NOTICE(PPU, "%s leave", CPUThread::GetFName().c_str());
+	if (Ini.HLELogging.GetValue()) LOG_NOTICE(PPU, "%s leave", CPUThread::GetFName().c_str());
 }
 
 s64 CPUThread::ExecAsCallback(u64 pc, bool wait, u64 a1, u64 a2, u64 a3, u64 a4) // not multithread-safe
@@ -353,7 +353,7 @@ s64 CPUThread::ExecAsCallback(u64 pc, bool wait, u64 a1, u64 a2, u64 a3, u64 a4)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(PPU, "ExecAsCallback() aborted");
+			LOG_WARNING(PPU, "ExecAsCallback() aborted");
 			return CELL_ECANCELED; // doesn't mean anything
 		}
 		Sleep(1);
@@ -379,7 +379,7 @@ s64 CPUThread::ExecAsCallback(u64 pc, bool wait, u64 a1, u64 a2, u64 a3, u64 a4)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(PPU, "ExecAsCallback(wait=%s) aborted", wait ? "true" : "false");
+			LOG_WARNING(PPU, "ExecAsCallback(wait=%s) aborted", wait ? "true" : "false");
 			return CELL_EABORT; // doesn't mean anything
 		}
 		Sleep(1);

--- a/rpcs3/Emu/Cell/MFC.h
+++ b/rpcs3/Emu/Cell/MFC.h
@@ -183,7 +183,7 @@ struct DMAC
 		return true;
 
 		default:
-			LOGF_ERROR(HLE, "DMAC::ProcessCmd(): Unknown DMA cmd.");
+			LOG_ERROR(HLE, "DMAC::ProcessCmd(): Unknown DMA cmd.");
 		return true;
 		}
 	}
@@ -268,11 +268,11 @@ struct DMAC
 				u16 tag = (u16)size_tag;
 				u16 size = size_tag >> 16;
 
-				LOGF_WARNING(HLE, "RawSPU DMA %s:", op == MFC_PUT_CMD ? "PUT" : "GET");
-				LOGF_WARNING(HLE, "*** lsa  = 0x%x", lsa);
-				LOGF_WARNING(HLE, "*** ea   = 0x%llx", ea);
-				LOGF_WARNING(HLE, "*** tag  = 0x%x", tag);
-				LOGF_WARNING(HLE, "*** size = 0x%x", size);
+				LOG_WARNING(HLE, "RawSPU DMA %s:", op == MFC_PUT_CMD ? "PUT" : "GET");
+				LOG_WARNING(HLE, "*** lsa  = 0x%x", lsa);
+				LOG_WARNING(HLE, "*** ea   = 0x%llx", ea);
+				LOG_WARNING(HLE, "*** tag  = 0x%x", tag);
+				LOG_WARNING(HLE, "*** size = 0x%x", size);
 				LOG_WARNING(HLE, " ");
 
 				MFC_CMDStatus.SetValue(dmac.Cmd(cmd, tag, lsa, ea, size));
@@ -280,7 +280,7 @@ struct DMAC
 			break;
 
 			default:
-				LOGF_ERROR(HLE, "Unknown MFC cmd. (opcode=0x%x, cmd=0x%x)", op, cmd);
+				LOG_ERROR(HLE, "Unknown MFC cmd. (opcode=0x%x, cmd=0x%x)", op, cmd);
 			break;
 			}
 		}

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -70,16 +70,16 @@ private:
 
 		if(Ini.HLELogging.GetValue())
 		{
-			LOGF_WARNING(PPU, "SysCall[0x%llx ('%s')] done with code [0x%llx]! #pc: 0x%llx", CPU.GPR[11], SysCalls::GetHLEFuncName(CPU.GPR[11]).c_str(), CPU.GPR[3], CPU.PC);
+			LOG_WARNING(PPU, "SysCall[0x%llx ('%s')] done with code [0x%llx]! #pc: 0x%llx", CPU.GPR[11], SysCalls::GetHLEFuncName(CPU.GPR[11]).c_str(), CPU.GPR[3], CPU.PC);
 		}
 		/*else if ((s64)CPU.GPR[3] < 0) // probably, error code
 		{
-			LOGF_ERROR(PPU, "SysCall[0x%llx] done with code [0x%llx]! #pc: 0x%llx", CPU.GPR[11], CPU.GPR[3], CPU.PC);
+			LOG_ERROR(PPU, "SysCall[0x%llx] done with code [0x%llx]! #pc: 0x%llx", CPU.GPR[11], CPU.GPR[3], CPU.PC);
 			if(CPU.GPR[11] > 1024)
 				SysCalls::DoFunc(CPU.GPR[11]);
 		}*/
 #ifdef HLE_CALL_DEBUG
-		LOGF_NOTICE(PPU, "SysCall[%lld] done with code [0x%llx]! #pc: 0x%llx", CPU.GPR[11], CPU.GPR[3], CPU.PC);
+		LOG_NOTICE(PPU, "SysCall[%lld] done with code [0x%llx]! #pc: 0x%llx", CPU.GPR[11], CPU.GPR[3], CPU.PC);
 #endif
 	}
 
@@ -2097,7 +2097,7 @@ private:
 			Emu.GetSFuncManager().StaticExecute(CPU.GPR[11]);
 			if (Ini.HLELogging.GetValue())
 			{
-				LOGF_NOTICE(PPU, "'%s' done with code[0x%llx]! #pc: 0x%llx",
+				LOG_NOTICE(PPU, "'%s' done with code[0x%llx]! #pc: 0x%llx",
 					Emu.GetSFuncManager()[CPU.GPR[11]]->name, CPU.GPR[3], CPU.PC);
 			}
 			break;
@@ -3995,20 +3995,20 @@ private:
 
 	void UNK(const std::string& err, bool pause = true)
 	{
-		LOGF_ERROR(PPU, err + fmt::Format(" #pc: 0x%llx", CPU.PC));
+		LOG_ERROR(PPU, err + fmt::Format(" #pc: 0x%llx", CPU.PC));
 
 		if(!pause) return;
 
 		Emu.Pause();
 
-		for(uint i=0; i<32; ++i) LOGF_NOTICE(PPU, "r%d = 0x%llx", i, CPU.GPR[i]);
-		for(uint i=0; i<32; ++i) LOGF_NOTICE(PPU, "f%d = %llf", i, CPU.FPR[i]);
-		for(uint i=0; i<32; ++i) LOGF_NOTICE(PPU, "v%d = 0x%s [%s]", i, CPU.VPR[i].ToString(true).c_str(), CPU.VPR[i].ToString().c_str());
-		LOGF_NOTICE(PPU, "CR = 0x%08x", CPU.CR);
-		LOGF_NOTICE(PPU, "LR = 0x%llx", CPU.LR);
-		LOGF_NOTICE(PPU, "CTR = 0x%llx", CPU.CTR);
-		LOGF_NOTICE(PPU, "XER = 0x%llx [CA=%lld | OV=%lld | SO=%lld]", CPU.XER, fmt::by_value(CPU.XER.CA), fmt::by_value(CPU.XER.OV), fmt::by_value(CPU.XER.SO));
-		LOGF_NOTICE(PPU, "FPSCR = 0x%x "
+		for(uint i=0; i<32; ++i) LOG_NOTICE(PPU, "r%d = 0x%llx", i, CPU.GPR[i]);
+		for(uint i=0; i<32; ++i) LOG_NOTICE(PPU, "f%d = %llf", i, CPU.FPR[i]);
+		for(uint i=0; i<32; ++i) LOG_NOTICE(PPU, "v%d = 0x%s [%s]", i, CPU.VPR[i].ToString(true).c_str(), CPU.VPR[i].ToString().c_str());
+		LOG_NOTICE(PPU, "CR = 0x%08x", CPU.CR);
+		LOG_NOTICE(PPU, "LR = 0x%llx", CPU.LR);
+		LOG_NOTICE(PPU, "CTR = 0x%llx", CPU.CTR);
+		LOG_NOTICE(PPU, "XER = 0x%llx [CA=%lld | OV=%lld | SO=%lld]", CPU.XER, fmt::by_value(CPU.XER.CA), fmt::by_value(CPU.XER.OV), fmt::by_value(CPU.XER.SO));
+		LOG_NOTICE(PPU, "FPSCR = 0x%x "
 			"[RN=%d | NI=%d | XE=%d | ZE=%d | UE=%d | OE=%d | VE=%d | "
 			"VXCVI=%d | VXSQRT=%d | VXSOFT=%d | FPRF=%d | "
 			"FI=%d | FR=%d | VXVC=%d | VXIMZ=%d | "

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -163,7 +163,7 @@ void PPUThread::DoRun()
 	break;
 
 	default:
-		LOGF_ERROR(PPU, "Invalid CPU decoder mode: %d", Ini.CPUDecoderMode.GetValue());
+		LOG_ERROR(PPU, "Invalid CPU decoder mode: %d", Ini.CPUDecoderMode.GetValue());
 		Emu.Pause();
 	}
 }

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -38,7 +38,7 @@ bool RawSPUThread::Read8(const u64 addr, u8* value)
 	}
 
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
-	LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Read8(0x%x)", m_index, offset);
+	LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Read8(0x%x)", m_index, offset);
 	Emu.Pause();
 	return false;
 }
@@ -51,7 +51,7 @@ bool RawSPUThread::Read16(const u64 addr, u16* value)
 	}
 
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
-	LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Read16(0x%x)", m_index, offset);
+	LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Read16(0x%x)", m_index, offset);
 	Emu.Pause();
 	return false;
 }
@@ -66,39 +66,39 @@ bool RawSPUThread::Read32(const u64 addr, u32* value)
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
 	switch(offset)
 	{
-	case MFC_LSA_offs:          LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_LSA)", m_index);           *value = MFC2.LSA.GetValue(); break;
-	case MFC_EAH_offs:          LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_EAH)", m_index);           *value = MFC2.EAH.GetValue(); break;
-	case MFC_EAL_offs:          LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_EAL)", m_index);           *value = MFC2.EAL.GetValue(); break;
-	case MFC_Size_Tag_offs:     LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_Size_Tag)", m_index);      *value = MFC2.Size_Tag.GetValue(); break;
-	case MFC_CMDStatus_offs:    LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_CMDStatus)", m_index);     *value = MFC2.CMDStatus.GetValue(); break;
+	case MFC_LSA_offs:          LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_LSA)", m_index);           *value = MFC2.LSA.GetValue(); break;
+	case MFC_EAH_offs:          LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_EAH)", m_index);           *value = MFC2.EAH.GetValue(); break;
+	case MFC_EAL_offs:          LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_EAL)", m_index);           *value = MFC2.EAL.GetValue(); break;
+	case MFC_Size_Tag_offs:     LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_Size_Tag)", m_index);      *value = MFC2.Size_Tag.GetValue(); break;
+	case MFC_CMDStatus_offs:    LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_CMDStatus)", m_index);     *value = MFC2.CMDStatus.GetValue(); break;
 	case MFC_QStatus_offs:
-		LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_QStatus)", m_index);
+		LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(MFC_QStatus)", m_index);
 		*value = MFC2.QStatus.GetValue(); 
 	break;
-	case Prxy_QueryType_offs:   LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(Prxy_QueryType)", m_index);    *value = Prxy.QueryType.GetValue(); break;
-	case Prxy_QueryMask_offs:   LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(Prxy_QueryMask)", m_index);    *value = Prxy.QueryMask.GetValue(); break;
-	case Prxy_TagStatus_offs:   LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(Prxy_TagStatus)", m_index);    *value = Prxy.TagStatus.GetValue(); break;
+	case Prxy_QueryType_offs:   LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(Prxy_QueryType)", m_index);    *value = Prxy.QueryType.GetValue(); break;
+	case Prxy_QueryMask_offs:   LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(Prxy_QueryMask)", m_index);    *value = Prxy.QueryMask.GetValue(); break;
+	case Prxy_TagStatus_offs:   LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(Prxy_TagStatus)", m_index);    *value = Prxy.TagStatus.GetValue(); break;
 	case SPU_Out_MBox_offs:
-		//LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_Out_MBox)", m_index);
+		//LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_Out_MBox)", m_index);
 		SPU.Out_MBox.PopUncond(*value); //if Out_MBox is empty yet, the result will be undefined 
 	break;
-	case SPU_In_MBox_offs:      LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_In_MBox)", m_index);       while(!SPU.In_MBox.Pop(*value)  && !Emu.IsStopped()) Sleep(1); break;
-	case SPU_MBox_Status_offs: //LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_MBox_Status)", m_index);
+	case SPU_In_MBox_offs:      LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_In_MBox)", m_index);       while(!SPU.In_MBox.Pop(*value)  && !Emu.IsStopped()) Sleep(1); break;
+	case SPU_MBox_Status_offs: //LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_MBox_Status)", m_index);
 		//SPU.MBox_Status.SetValue(SPU.Out_MBox.GetCount() ? SPU.MBox_Status.GetValue() | 1 : SPU.MBox_Status.GetValue() & ~1);
 		SPU.MBox_Status.SetValue((SPU.Out_MBox.GetCount() & 0xff) | (SPU.In_MBox.GetFreeCount() << 8));
 		*value = SPU.MBox_Status.GetValue();
 		break;
-	case SPU_RunCntl_offs:      LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_RunCntl)", m_index);       *value = SPU.RunCntl.GetValue(); break;
+	case SPU_RunCntl_offs:      LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_RunCntl)", m_index);       *value = SPU.RunCntl.GetValue(); break;
 	case SPU_Status_offs:
-		//LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_Status)", m_index);
+		//LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_Status)", m_index);
 		*value = SPU.Status.GetValue();
 		break;
-	case SPU_NPC_offs:          LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_NPC)", m_index);           *value = SPU.NPC.GetValue(); break;
-	case SPU_RdSigNotify1_offs: LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_RdSigNotify1)", m_index);  *value = SPU.SNR[0].GetValue(); break;
-	case SPU_RdSigNotify2_offs: LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_RdSigNotify2)", m_index);  *value = SPU.SNR[1].GetValue(); break;
+	case SPU_NPC_offs:          LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_NPC)", m_index);           *value = SPU.NPC.GetValue(); break;
+	case SPU_RdSigNotify1_offs: LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_RdSigNotify1)", m_index);  *value = SPU.SNR[0].GetValue(); break;
+	case SPU_RdSigNotify2_offs: LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Read32(SPU_RdSigNotify2)", m_index);  *value = SPU.SNR[1].GetValue(); break;
 
 	default:
-		LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Read32(0x%x)", m_index, offset);
+		LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Read32(0x%x)", m_index, offset);
 		Emu.Pause();
 	break;
 	}
@@ -114,7 +114,7 @@ bool RawSPUThread::Read64(const u64 addr, u64* value)
 	}
 
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
-	LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Read64(0x%x)", m_index, offset);
+	LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Read64(0x%x)", m_index, offset);
 	Emu.Pause();
 	return false;
 }
@@ -127,7 +127,7 @@ bool RawSPUThread::Read128(const u64 addr, u128* value)
 	}
 
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
-	LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Read128(0x%x)", m_index, offset);
+	LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Read128(0x%x)", m_index, offset);
 	Emu.Pause();
 	return false;
 }
@@ -140,7 +140,7 @@ bool RawSPUThread::Write8(const u64 addr, const u8 value)
 	}
 
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
-	LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Write8(0x%x, 0x%x)", m_index, offset, value);
+	LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Write8(0x%x, 0x%x)", m_index, offset, value);
 	Emu.Pause();
 	return false;
 }
@@ -153,7 +153,7 @@ bool RawSPUThread::Write16(const u64 addr, const u16 value)
 	}
 
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
-	LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Write16(0x%x, 0x%x)", m_index, offset, value);
+	LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Write16(0x%x, 0x%x)", m_index, offset, value);
 	Emu.Pause();
 	return false;
 }
@@ -177,20 +177,20 @@ bool RawSPUThread::Write32(const u64 addr, const u32 value)
 		MFC2.CMDStatus.SetValue(value);
 		EnqMfcCmd(MFC2);
 	break;
-	case MFC_QStatus_offs:			LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(MFC_QStatus, 0x%x)", m_index, value);			MFC2.QStatus.SetValue(value); break;
+	case MFC_QStatus_offs:			LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(MFC_QStatus, 0x%x)", m_index, value);			MFC2.QStatus.SetValue(value); break;
 	case Prxy_QueryType_offs:
 	{
-		LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(Prxy_QueryType, 0x%x)", m_index, value);
+		LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(Prxy_QueryType, 0x%x)", m_index, value);
 		Prxy.QueryType.SetValue(value);
 
 		switch(value)
 		{
 		case 2:
-			LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Prxy Query Immediate.", m_index);
+			LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Prxy Query Immediate.", m_index);
 		break;
 
 		default:
-			LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Unknown Prxy Query Type. (prxy_query=0x%x)", m_index, value);
+			LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Unknown Prxy Query Type. (prxy_query=0x%x)", m_index, value);
 		break;
 		}
 
@@ -198,22 +198,22 @@ bool RawSPUThread::Write32(const u64 addr, const u32 value)
 		MFC2.QStatus.SetValue(Prxy.QueryMask.GetValue());
 	}
 	break;
-	case Prxy_QueryMask_offs:   LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(Prxy_QueryMask, 0x%x)", m_index, value);      Prxy.QueryMask.SetValue(value); break;
-	case Prxy_TagStatus_offs:   LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(Prxy_TagStatus, 0x%x)", m_index, value);      Prxy.TagStatus.SetValue(value); break;
-	case SPU_Out_MBox_offs:     LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_Out_MBox, 0x%x)", m_index, value);        while(!SPU.Out_MBox.Push(value) && !Emu.IsStopped()) Sleep(1); break;
+	case Prxy_QueryMask_offs:   LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(Prxy_QueryMask, 0x%x)", m_index, value);      Prxy.QueryMask.SetValue(value); break;
+	case Prxy_TagStatus_offs:   LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(Prxy_TagStatus, 0x%x)", m_index, value);      Prxy.TagStatus.SetValue(value); break;
+	case SPU_Out_MBox_offs:     LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_Out_MBox, 0x%x)", m_index, value);        while(!SPU.Out_MBox.Push(value) && !Emu.IsStopped()) Sleep(1); break;
 	case SPU_In_MBox_offs:
-		//LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_In_MBox, 0x%x)", m_index, value);
+		//LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_In_MBox, 0x%x)", m_index, value);
 		SPU.In_MBox.PushUncond(value); //if In_MBox is already full, the last message will be overwritten  
 	break;
-	case SPU_MBox_Status_offs:  LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_MBox_Status, 0x%x)", m_index, value);     SPU.MBox_Status.SetValue(value); break;
-	case SPU_RunCntl_offs:      LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_RunCntl, 0x%x)", m_index, value);         SPU.RunCntl.SetValue(value); break;
-	case SPU_Status_offs:       LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_Status, 0x%x)", m_index, value);          SPU.Status.SetValue(value); break;
-	case SPU_NPC_offs:          LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_NPC, 0x%x)", m_index, value);             SPU.NPC.SetValue(value); break;
-	case SPU_RdSigNotify1_offs: LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_RdSigNotify1, 0x%x)", m_index, value);    SPU.SNR[0].SetValue(value); break;
-	case SPU_RdSigNotify2_offs: LOGF_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_RdSigNotify2, 0x%x)", m_index, value);    SPU.SNR[1].SetValue(value); break;
+	case SPU_MBox_Status_offs:  LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_MBox_Status, 0x%x)", m_index, value);     SPU.MBox_Status.SetValue(value); break;
+	case SPU_RunCntl_offs:      LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_RunCntl, 0x%x)", m_index, value);         SPU.RunCntl.SetValue(value); break;
+	case SPU_Status_offs:       LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_Status, 0x%x)", m_index, value);          SPU.Status.SetValue(value); break;
+	case SPU_NPC_offs:          LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_NPC, 0x%x)", m_index, value);             SPU.NPC.SetValue(value); break;
+	case SPU_RdSigNotify1_offs: LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_RdSigNotify1, 0x%x)", m_index, value);    SPU.SNR[0].SetValue(value); break;
+	case SPU_RdSigNotify2_offs: LOG_WARNING(Log::SPU, "RawSPUThread[%d]: Write32(SPU_RdSigNotify2, 0x%x)", m_index, value);    SPU.SNR[1].SetValue(value); break;
 
 	default:
-		LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Write32(0x%x, 0x%x)", m_index, offset, value);
+		LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Write32(0x%x, 0x%x)", m_index, offset, value);
 		Emu.Pause();
 	break;
 	}
@@ -229,7 +229,7 @@ bool RawSPUThread::Write64(const u64 addr, const u64 value)
 	}
 
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
-	LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Write64(0x%x, 0x%llx)", m_index, offset, value);
+	LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Write64(0x%x, 0x%llx)", m_index, offset, value);
 	Emu.Pause();
 	return false;
 }
@@ -242,7 +242,7 @@ bool RawSPUThread::Write128(const u64 addr, const u128 value)
 	}
 
 	u32 offset = addr - GetStartAddr() - RAW_SPU_PROB_OFFSET;
-	LOGF_ERROR(Log::SPU, "RawSPUThread[%d]: Write128(0x%x, 0x%llx_%llx)", m_index, offset, value._u64[1], value._u64[0]);
+	LOG_ERROR(Log::SPU, "RawSPUThread[%d]: Write128(0x%x, 0x%llx_%llx)", m_index, offset, value._u64[1], value._u64[0]);
 	Emu.Pause();
 	return false;
 }
@@ -260,7 +260,7 @@ u32 RawSPUThread::GetIndex() const
 
 void RawSPUThread::Task()
 {
-	if (Ini.HLELogging.GetValue()) LOGF_NOTICE(Log::SPU, "%s enter", PPCThread::GetFName().c_str());
+	if (Ini.HLELogging.GetValue()) LOG_NOTICE(Log::SPU, "%s enter", PPCThread::GetFName().c_str());
 
 	const std::vector<u64>& bp = Emu.GetBreakPoints();
 
@@ -312,7 +312,7 @@ void RawSPUThread::Task()
 				is_last_paused = false;
 				PC = SPU.NPC.GetValue();
 				SPU.Status.SetValue(SPU_STATUS_RUNNING);
-				LOGF_WARNING(Log::SPU, "Starting RawSPU...");
+				LOG_WARNING(Log::SPU, "Starting RawSPU...");
 			}
 
 			Step();
@@ -336,12 +336,12 @@ void RawSPUThread::Task()
 	}
 	catch(const std::string& e)
 	{
-		LOGF_ERROR(Log::SPU, "Exception: %s", e.c_str());
+		LOG_ERROR(Log::SPU, "Exception: %s", e.c_str());
 	}
 	catch(const char* e)
 	{
-		LOGF_ERROR(Log::SPU, "Exception: %s", e);
+		LOG_ERROR(Log::SPU, "Exception: %s", e);
 	}
 
-	if (Ini.HLELogging.GetValue()) LOGF_NOTICE(Log::SPU, "%s leave", PPCThread::GetFName().c_str());
+	if (Ini.HLELogging.GetValue()) LOG_NOTICE(Log::SPU, "%s leave", PPCThread::GetFName().c_str());
 }

--- a/rpcs3/Emu/Cell/SPUInterpreter.h
+++ b/rpcs3/Emu/Cell/SPUInterpreter.h
@@ -18,9 +18,9 @@
 #define MEM_AND_REG_HASH() \
 	unsigned char mem_h[20]; sha1(&Memory[CPU.dmac.ls_offset], 256*1024, mem_h); \
 	unsigned char reg_h[20]; sha1((const unsigned char*)CPU.GPR, sizeof(CPU.GPR), reg_h); \
-	LOGF_NOTICE(Log::SPU, "Mem hash: 0x%llx, reg hash: 0x%llx", *(u64*)mem_h, *(u64*)reg_h);
+	LOG_NOTICE(Log::SPU, "Mem hash: 0x%llx, reg hash: 0x%llx", *(u64*)mem_h, *(u64*)reg_h);
 
-#define LOG2_OPCODE(...) //MEM_AND_REG_HASH(); LOGF_NOTICE(Log::SPU, __FUNCTION__ "(): " __VA_ARGS__)
+#define LOG2_OPCODE(...) //MEM_AND_REG_HASH(); LOG_NOTICE(Log::SPU, __FUNCTION__ "(): " __VA_ARGS__)
 
 #define LOG5_OPCODE(...) ///
 
@@ -339,7 +339,7 @@ private:
 		u32 lsa = (CPU.GPR[ra]._u32[3] + CPU.GPR[rb]._u32[3]) & 0x3fff0;
 		if(!CPU.IsGoodLSA(lsa))
 		{
-			LOGF_ERROR(Log::SPU, "STQX: bad lsa (0x%x)", lsa);
+			LOG_ERROR(Log::SPU, "STQX: bad lsa (0x%x)", lsa);
 			Emu.Pause();
 			return;
 		}
@@ -438,7 +438,7 @@ private:
 
 		if(!CPU.IsGoodLSA(lsa))
 		{
-			LOGF_ERROR(Log::SPU, "LQX: bad lsa (0x%x)", lsa);
+			LOG_ERROR(Log::SPU, "LQX: bad lsa (0x%x)", lsa);
 			Emu.Pause();
 			return;
 		}
@@ -1126,7 +1126,7 @@ private:
 		u32 lsa = (i16 << 2) & 0x3fff0;
 		if(!CPU.IsGoodLSA(lsa))
 		{
-			LOGF_ERROR(Log::SPU, "STQA: bad lsa (0x%x)", lsa);
+			LOG_ERROR(Log::SPU, "STQA: bad lsa (0x%x)", lsa);
 			Emu.Pause();
 			return;
 		}
@@ -1177,7 +1177,7 @@ private:
 		u32 lsa = branchTarget(CPU.PC, i16) & 0x3fff0; 
 		if(!CPU.IsGoodLSA(lsa))
 		{
-			LOGF_ERROR(Log::SPU, "STQR: bad lsa (0x%x)", lsa);
+			LOG_ERROR(Log::SPU, "STQR: bad lsa (0x%x)", lsa);
 			Emu.Pause();
 			return;
 		}
@@ -1195,7 +1195,7 @@ private:
 		u32 lsa = (i16 << 2) & 0x3fff0;
 		if(!CPU.IsGoodLSA(lsa))
 		{
-			LOGF_ERROR(Log::SPU, "LQA: bad lsa (0x%x)", lsa);
+			LOG_ERROR(Log::SPU, "LQA: bad lsa (0x%x)", lsa);
 			Emu.Pause();
 			return;
 		}
@@ -1245,7 +1245,7 @@ private:
 		u32 lsa = branchTarget(CPU.PC, i16) & 0x3fff0;
 		if(!CPU.IsGoodLSA(lsa))
 		{
-			LOGF_ERROR(Log::SPU, "LQR: bad lsa (0x%x)", lsa);
+			LOG_ERROR(Log::SPU, "LQR: bad lsa (0x%x)", lsa);
 			Emu.Pause();
 			return;
 		}
@@ -1334,11 +1334,11 @@ private:
 		const u32 lsa = (CPU.GPR[ra]._i32[3] + i10) & 0x3fff0;
 		if(!CPU.IsGoodLSA(lsa))
 		{
-			LOGF_ERROR(Log::SPU, "STQD: bad lsa (0x%x)", lsa);
+			LOG_ERROR(Log::SPU, "STQD: bad lsa (0x%x)", lsa);
 			Emu.Pause();
 			return;
 		}
-		//LOGF_NOTICE(Log::SPU, "STQD(lsa=0x%x): GPR[%d] (0x%llx%llx)", lsa, rt, CPU.GPR[rt]._u64[1], CPU.GPR[rt]._u64[0]);
+		//LOG_NOTICE(Log::SPU, "STQD(lsa=0x%x): GPR[%d] (0x%llx%llx)", lsa, rt, CPU.GPR[rt]._u64[1], CPU.GPR[rt]._u64[0]);
 		CPU.WriteLS128(lsa, CPU.GPR[rt]._u128);
 	}
 	void LQD(u32 rt, s32 i10, u32 ra) //i10 is shifted left by 4 while decoding
@@ -1346,7 +1346,7 @@ private:
 		const u32 lsa = (CPU.GPR[ra]._i32[3] + i10) & 0x3fff0;
 		if(!CPU.IsGoodLSA(lsa))
 		{
-			LOGF_ERROR(Log::SPU, "LQD: bad lsa (0x%x)", lsa);
+			LOG_ERROR(Log::SPU, "LQD: bad lsa (0x%x)", lsa);
 			Emu.Pause();
 			return;
 		}
@@ -1540,8 +1540,8 @@ private:
 
 	void UNK(const std::string& err)
 	{
-		LOGF_ERROR(Log::SPU, err + fmt::Format(" #pc: 0x%x", CPU.PC));
+		LOG_ERROR(Log::SPU, err + fmt::Format(" #pc: 0x%x", CPU.PC));
 		Emu.Pause();
-		for(uint i=0; i<128; ++i) LOGF_NOTICE(Log::SPU, "r%d = 0x%s", i, CPU.GPR[i].ToString().c_str());
+		for(uint i=0; i<128; ++i) LOG_NOTICE(Log::SPU, "r%d = 0x%s", i, CPU.GPR[i].ToString().c_str());
 	}
 };

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -3845,7 +3845,7 @@ private:
 
 	void UNK(const std::string& err)
 	{
-		LOGF_ERROR(Log::SPU, err + fmt::Format(" #pc: 0x%x", CPU.PC));
+		LOG_ERROR(Log::SPU, err + fmt::Format(" #pc: 0x%x", CPU.PC));
 		c.mov(cpu_qword(PC), (u32)CPU.PC);
 		do_finalize = true;
 		Emu.Pause();

--- a/rpcs3/Emu/Cell/SPURecompilerCore.cpp
+++ b/rpcs3/Emu/Cell/SPURecompilerCore.cpp
@@ -164,7 +164,7 @@ u8 SPURecompilerCore::DecodeMemory(const u64 address)
 
 	if (!pos)
 	{
-		LOGF_ERROR(Log::SPU, "SPURecompilerCore::DecodeMemory(): ls_addr = 0");
+		LOG_ERROR(Log::SPU, "SPURecompilerCore::DecodeMemory(): ls_addr = 0");
 		Emu.Pause();
 		return 0;
 	}
@@ -185,7 +185,7 @@ u8 SPURecompilerCore::DecodeMemory(const u64 address)
 		if (!is_valid)
 		{
 			// TODO
-			LOGF_ERROR(Log::SPU, "SPURecompilerCore::DecodeMemory(ls_addr=0x%x): code has changed", pos * sizeof(u32));
+			LOG_ERROR(Log::SPU, "SPURecompilerCore::DecodeMemory(ls_addr=0x%x): code has changed", pos * sizeof(u32));
 			Emu.Pause();
 			return 0;
 		}
@@ -198,7 +198,7 @@ u8 SPURecompilerCore::DecodeMemory(const u64 address)
 		did_compile = true;
 		if (entry[pos].valid == 0)
 		{
-			LOGF_ERROR(Log::SPU, "SPURecompilerCore::Compile(ls_addr=0x%x): branch to 0x0 opcode", pos * sizeof(u32));
+			LOG_ERROR(Log::SPU, "SPURecompilerCore::Compile(ls_addr=0x%x): branch to 0x0 opcode", pos * sizeof(u32));
 			Emu.Pause();
 			return 0;
 		}
@@ -206,7 +206,7 @@ u8 SPURecompilerCore::DecodeMemory(const u64 address)
 
 	if (!entry[pos].pointer)
 	{
-		LOGF_ERROR(Log::SPU, "SPURecompilerCore::DecodeMemory(ls_addr=0x%x): compilation failed", pos * sizeof(u32));
+		LOG_ERROR(Log::SPU, "SPURecompilerCore::DecodeMemory(ls_addr=0x%x): compilation failed", pos * sizeof(u32));
 		Emu.Pause();
 		return 0;
 	}
@@ -223,7 +223,7 @@ u8 SPURecompilerCore::DecodeMemory(const u64 address)
 		//if (pos == 0x19c >> 2)
 		{
 			//Emu.Pause();
-			//for (uint i = 0; i < 128; ++i) LOGF_NOTICE(Log::SPU, "r%d = 0x%s", i, CPU.GPR[i].ToString().c_str());
+			//for (uint i = 0; i < 128; ++i) LOG_NOTICE(Log::SPU, "r%d = 0x%s", i, CPU.GPR[i].ToString().c_str());
 		}
 	}
 
@@ -243,7 +243,7 @@ u8 SPURecompilerCore::DecodeMemory(const u64 address)
 		//if (pos == 0x340 >> 2)
 		{
 			//Emu.Pause();
-			//for (uint i = 0; i < 128; ++i) LOGF_NOTICE(Log::SPU, "r%d = 0x%s", i, CPU.GPR[i].ToString().c_str());
+			//for (uint i = 0; i < 128; ++i) LOG_NOTICE(Log::SPU, "r%d = 0x%s", i, CPU.GPR[i].ToString().c_str());
 		}
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -86,7 +86,7 @@ void SPUThread::DoRun()
 	break;
 
 	default:
-		LOGF_ERROR(Log::SPU, "Invalid SPU decoder mode: %d", Ini.SPUDecoderMode.GetValue());
+		LOG_ERROR(Log::SPU, "Invalid SPU decoder mode: %d", Ini.SPUDecoderMode.GetValue());
 		Emu.Pause();
 	}
 }

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -211,7 +211,7 @@ public:
 			return this->low >> 22 & 0x3;
 
 		default:
-			LOGF_ERROR(SPU, "Unexpected slice value in FPSCR::checkSliceRounding(): %d", slice);
+			LOG_ERROR(SPU, "Unexpected slice value in FPSCR::checkSliceRounding(): %d", slice);
 			return 0;
 		}
 	}
@@ -599,7 +599,7 @@ public:
 				u32 num = (ea & SYS_SPU_THREAD_BASE_MASK) / SYS_SPU_THREAD_OFFSET; // thread number in group
 				if (num >= group->list.size() || !group->list[num])
 				{
-					LOGF_ERROR(Log::SPU, "DMAC::ProcessCmd(): SPU Thread Group MMIO Access (ea=0x%llx): invalid thread", ea);
+					LOG_ERROR(Log::SPU, "DMAC::ProcessCmd(): SPU Thread Group MMIO Access (ea=0x%llx): invalid thread", ea);
 					return false;
 				}
 
@@ -618,13 +618,13 @@ public:
 				}
 				else
 				{
-					LOGF_ERROR(Log::SPU, "DMAC::ProcessCmd(): SPU Thread Group MMIO Access (ea=0x%llx, size=%d, cmd=0x%x): invalid command", ea, size, cmd);
+					LOG_ERROR(Log::SPU, "DMAC::ProcessCmd(): SPU Thread Group MMIO Access (ea=0x%llx, size=%d, cmd=0x%x): invalid command", ea, size, cmd);
 					return false;
 				}
 			}
 			else
 			{
-				LOGF_ERROR(Log::SPU, "DMAC::ProcessCmd(): SPU Thread Group MMIO Access (ea=0x%llx): group not set", ea);
+				LOG_ERROR(Log::SPU, "DMAC::ProcessCmd(): SPU Thread Group MMIO Access (ea=0x%llx): group not set", ea);
 				return false;
 			}
 		}
@@ -664,7 +664,7 @@ public:
 			}
 			else
 			{
-				LOGF_ERROR(Log::SPU, "DMAC::ProcessCmd(): PUT* cmd failed (ea=0x%llx, lsa=0x%x, size=%d)", ea, lsa, size);
+				LOG_ERROR(Log::SPU, "DMAC::ProcessCmd(): PUT* cmd failed (ea=0x%llx, lsa=0x%x, size=%d)", ea, lsa, size);
 				return false; // TODO: page fault (?)
 			}
 		}
@@ -677,7 +677,7 @@ public:
 			}
 			else
 			{
-				LOGF_ERROR(Log::SPU, "DMAC::ProcessCmd(): GET* cmd failed (ea=0x%llx, lsa=0x%x, size=%d)", ea, lsa, size);
+				LOG_ERROR(Log::SPU, "DMAC::ProcessCmd(): GET* cmd failed (ea=0x%llx, lsa=0x%x, size=%d)", ea, lsa, size);
 				return false; // TODO: page fault (?)
 			}
 		}
@@ -725,7 +725,7 @@ public:
 			u32 size = rec->ts;
 			if (size < 16 && size != 1 && size != 2 && size != 4 && size != 8)
 			{
-				LOGF_ERROR(Log::SPU, "DMA List: invalid transfer size(%d)", size);
+				LOG_ERROR(Log::SPU, "DMA List: invalid transfer size(%d)", size);
 				return;
 			}
 
@@ -737,7 +737,7 @@ public:
 			}
 
 			if (Ini.HLELogging.GetValue() || rec->s)
-				LOGF_NOTICE(Log::SPU, "*** list element(%d/%d): s = 0x%x, ts = 0x%x, low ea = 0x%x (lsa = 0x%x)",
+				LOG_NOTICE(Log::SPU, "*** list element(%d/%d): s = 0x%x, ts = 0x%x, low ea = 0x%x (lsa = 0x%x)",
 					i, list_size, (u16)rec->s, (u16)rec->ts, (u32)rec->ea, lsa | (addr & 0xf));
 
 			lsa += std::max(size, (u32)16);
@@ -748,7 +748,7 @@ public:
 
 				if (StallList[tag].MFCArgs)
 				{
-					LOGF_ERROR(Log::SPU, "DMA List: existing stalled list found (tag=%d)", tag);
+					LOG_ERROR(Log::SPU, "DMA List: existing stalled list found (tag=%d)", tag);
 				}
 				StallList[tag].MFCArgs = &MFCArgs;
 				StallList[tag].cmd = cmd;
@@ -780,7 +780,7 @@ public:
 		case MFC_PUTR_CMD: // ???
 		case MFC_GET_CMD:
 		{
-			if (Ini.HLELogging.GetValue()) LOGF_NOTICE(Log::SPU, "DMA %s%s%s%s: lsa = 0x%x, ea = 0x%llx, tag = 0x%x, size = 0x%x, cmd = 0x%x", 
+			if (Ini.HLELogging.GetValue()) LOG_NOTICE(Log::SPU, "DMA %s%s%s%s: lsa = 0x%x, ea = 0x%llx, tag = 0x%x, size = 0x%x, cmd = 0x%x", 
 				(op & MFC_PUT_CMD ? "PUT" : "GET"),
 				(op & MFC_RESULT_MASK ? "R" : ""),
 				(op & MFC_BARRIER_MASK ? "B" : ""),
@@ -795,7 +795,7 @@ public:
 		case MFC_PUTRL_CMD: // ???
 		case MFC_GETL_CMD:
 		{
-			if (Ini.HLELogging.GetValue()) LOGF_NOTICE(Log::SPU, "DMA %s%s%s%s: lsa = 0x%x, list = 0x%llx, tag = 0x%x, size = 0x%x, cmd = 0x%x",
+			if (Ini.HLELogging.GetValue()) LOG_NOTICE(Log::SPU, "DMA %s%s%s%s: lsa = 0x%x, list = 0x%llx, tag = 0x%x, size = 0x%x, cmd = 0x%x",
 				(op & MFC_PUT_CMD ? "PUT" : "GET"),
 				(op & MFC_RESULT_MASK ? "RL" : "L"),
 				(op & MFC_BARRIER_MASK ? "B" : ""),
@@ -811,7 +811,7 @@ public:
 		case MFC_PUTLLUC_CMD:
 		case MFC_PUTQLLUC_CMD:
 		{
-			if (Ini.HLELogging.GetValue() || size != 128) LOGF_NOTICE(Log::SPU, "DMA %s: lsa=0x%x, ea = 0x%llx, (tag) = 0x%x, (size) = 0x%x, cmd = 0x%x",
+			if (Ini.HLELogging.GetValue() || size != 128) LOG_NOTICE(Log::SPU, "DMA %s: lsa=0x%x, ea = 0x%llx, (tag) = 0x%x, (size) = 0x%x, cmd = 0x%x",
 				(op == MFC_GETLLAR_CMD ? "GETLLAR" :
 				op == MFC_PUTLLC_CMD ? "PUTLLC" :
 				op == MFC_PUTLLUC_CMD ? "PUTLLUC" : "PUTQLLUC"),
@@ -885,7 +885,7 @@ public:
 								}
 								else // full 64 bit
 								{
-									LOGF_ERROR(Log::SPU, "MFC_PUTLLC_CMD: TODO: 64bit compare and swap");
+									LOG_ERROR(Log::SPU, "MFC_PUTLLC_CMD: TODO: 64bit compare and swap");
 									Emu.Pause();
 									Prxy.AtomicStat.PushUncond(MFC_PUTLLC_SUCCESS);
 								}*/
@@ -894,7 +894,7 @@ public:
 						else
 						{
 							ProcessCmd(MFC_PUT_CMD, tag, lsa, ea, 128);
-							LOGF_ERROR(Log::SPU, "MFC_PUTLLC_CMD: Reservation Error: impossibru (~ 16x%d (mask=0x%x)) (opcode=0x%x, cmd=0x%x, lsa = 0x%x, ea = 0x%llx, tag = 0x%x, size = 0x%x)",
+							LOG_ERROR(Log::SPU, "MFC_PUTLLC_CMD: Reservation Error: impossibru (~ 16x%d (mask=0x%x)) (opcode=0x%x, cmd=0x%x, lsa = 0x%x, ea = 0x%llx, tag = 0x%x, size = 0x%x)",
 								changed, mask, op, cmd, lsa, ea, tag, size);
 							Emu.Pause();
 							Prxy.AtomicStat.PushUncond(MFC_PUTLLC_SUCCESS);
@@ -929,7 +929,7 @@ public:
 		break;
 
 		default:
-			LOGF_ERROR( Log::SPU, "Unknown MFC cmd. (opcode=0x%x, cmd=0x%x, lsa = 0x%x, ea = 0x%llx, tag = 0x%x, size = 0x%x)", 
+			LOG_ERROR( Log::SPU, "Unknown MFC cmd. (opcode=0x%x, cmd=0x%x, lsa = 0x%x, ea = 0x%llx, tag = 0x%x, size = 0x%x)", 
 				op, cmd, lsa, ea, tag, size);
 		break;
 		}
@@ -949,7 +949,7 @@ public:
 			return count;
 
 		case SPU_WrOutIntrMbox:
-			LOGF_WARNING(Log::SPU, "GetChannelCount(%s) = 0", spu_ch_name[ch]);
+			LOG_WARNING(Log::SPU, "GetChannelCount(%s) = 0", spu_ch_name[ch]);
 			return 0;
 
 		case MFC_RdTagStat:
@@ -971,7 +971,7 @@ public:
 			return Prxy.AtomicStat.GetCount();
 
 		default:
-			LOGF_ERROR(Log::SPU, "%s error: unknown/illegal channel (%d [%s]).",
+			LOG_ERROR(Log::SPU, "%s error: unknown/illegal channel (%d [%s]).",
 				__FUNCTION__, ch, spu_ch_name[ch]);
 		break;
 		}
@@ -988,7 +988,7 @@ public:
 		case SPU_WrOutIntrMbox:
 			if (!group) // if RawSPU
 			{
-				if (Ini.HLELogging.GetValue()) LOGF_NOTICE(Log::SPU, "SPU_WrOutIntrMbox: interrupt(v=0x%x)", v);
+				if (Ini.HLELogging.GetValue()) LOG_NOTICE(Log::SPU, "SPU_WrOutIntrMbox: interrupt(v=0x%x)", v);
 				SPU.Out_IntrMBox.PushUncond(v);
 				m_intrtag[2].stat |= 1;
 				if (CPUThread* t = Emu.GetCPU().GetThread(m_intrtag[2].thread))
@@ -998,7 +998,7 @@ public:
 						Sleep(1);
 						if (Emu.IsStopped())
 						{
-							LOGF_WARNING(Log::SPU, "%s(%s) aborted", __FUNCTION__, spu_ch_name[ch]);
+							LOG_WARNING(Log::SPU, "%s(%s) aborted", __FUNCTION__, spu_ch_name[ch]);
 							return;
 						}
 					}
@@ -1019,20 +1019,20 @@ public:
 					u32 data;
 					if (!SPU.Out_MBox.Pop(data))
 					{
-						LOGF_ERROR(Log::SPU, "sys_spu_thread_send_event(v=0x%x, spup=%d): Out_MBox is empty", v, spup);
+						LOG_ERROR(Log::SPU, "sys_spu_thread_send_event(v=0x%x, spup=%d): Out_MBox is empty", v, spup);
 						return;
 					}
 
 					if (SPU.In_MBox.GetCount())
 					{
-						LOGF_ERROR(Log::SPU, "sys_spu_thread_send_event(v=0x%x, spup=%d): In_MBox is not empty", v, spup);
+						LOG_ERROR(Log::SPU, "sys_spu_thread_send_event(v=0x%x, spup=%d): In_MBox is not empty", v, spup);
 						SPU.In_MBox.PushUncond(CELL_EBUSY); // ???
 						return;
 					}
 
 					if (Ini.HLELogging.GetValue())
 					{
-						LOGF_NOTICE(Log::SPU, "sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x)", spup, v & 0x00ffffff, data);
+						LOG_NOTICE(Log::SPU, "sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x)", spup, v & 0x00ffffff, data);
 					}
 
 					EventPort& port = SPUPs[spup];
@@ -1042,7 +1042,7 @@ public:
 					if (!port.eq)
 					{
 						// spu_printf fails there
-						LOGF_WARNING(Log::SPU, "sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x): event queue not connected", spup, (v & 0x00ffffff), data);
+						LOG_WARNING(Log::SPU, "sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x): event queue not connected", spup, (v & 0x00ffffff), data);
 						SPU.In_MBox.PushUncond(CELL_ENOTCONN); // TODO: check error passing
 						return;
 					}
@@ -1064,25 +1064,25 @@ public:
 					u32 data;
 					if (!SPU.Out_MBox.Pop(data))
 					{
-						LOGF_ERROR(Log::SPU, "sys_event_flag_set_bit(v=0x%x (flag=%d)): Out_MBox is empty", v, flag);
+						LOG_ERROR(Log::SPU, "sys_event_flag_set_bit(v=0x%x (flag=%d)): Out_MBox is empty", v, flag);
 						return;
 					}
 
 					if (flag > 63)
 					{
-						LOGF_ERROR(Log::SPU, "sys_event_flag_set_bit(id=%d, v=0x%x): flag > 63", data, v, flag);
+						LOG_ERROR(Log::SPU, "sys_event_flag_set_bit(id=%d, v=0x%x): flag > 63", data, v, flag);
 						return;
 					}
 
 					//if (Ini.HLELogging.GetValue())
 					{
-						LOGF_WARNING(Log::SPU, "sys_event_flag_set_bit(id=%d, v=0x%x (flag=%d))", data, v, flag);
+						LOG_WARNING(Log::SPU, "sys_event_flag_set_bit(id=%d, v=0x%x (flag=%d))", data, v, flag);
 					}
 
 					EventFlag* ef;
 					if (!Emu.GetIdManager().GetIDData(data, ef))
 					{
-						LOGF_ERROR(Log::SPU, "sys_event_flag_set_bit(id=%d, v=0x%x (flag=%d)): EventFlag not found", data, v, flag);
+						LOG_ERROR(Log::SPU, "sys_event_flag_set_bit(id=%d, v=0x%x (flag=%d)): EventFlag not found", data, v, flag);
 						SPU.In_MBox.PushUncond(CELL_ESRCH);
 						return;
 					}
@@ -1110,11 +1110,11 @@ public:
 					u32 data;
 					if (SPU.Out_MBox.Pop(data))
 					{
-						LOGF_ERROR(Log::SPU, "SPU_WrOutIntrMbox: unknown data (v=0x%x); Out_MBox = 0x%x", v, data);
+						LOG_ERROR(Log::SPU, "SPU_WrOutIntrMbox: unknown data (v=0x%x); Out_MBox = 0x%x", v, data);
 					}
 					else
 					{
-						LOGF_ERROR(Log::SPU, "SPU_WrOutIntrMbox: unknown data (v=0x%x)", v);
+						LOG_ERROR(Log::SPU, "SPU_WrOutIntrMbox: unknown data (v=0x%x)", v);
 					}
 					SPU.In_MBox.PushUncond(CELL_EINVAL); // ???
 					return;
@@ -1166,13 +1166,13 @@ public:
 		{
 			if (v >= 32)
 			{
-				LOGF_ERROR(Log::SPU, "MFC_WrListStallAck error: invalid tag(%d)", v);
+				LOG_ERROR(Log::SPU, "MFC_WrListStallAck error: invalid tag(%d)", v);
 				return;
 			}
 			StalledList temp = StallList[v];
 			if (!temp.MFCArgs)
 			{
-				LOGF_ERROR(Log::SPU, "MFC_WrListStallAck error: empty tag(%d)", v);
+				LOG_ERROR(Log::SPU, "MFC_WrListStallAck error: empty tag(%d)", v);
 				return;
 			}
 			StallList[v].MFCArgs = nullptr;
@@ -1181,11 +1181,11 @@ public:
 		break;
 
 		default:
-			LOGF_ERROR(Log::SPU, "%s error: unknown/illegal channel (%d [%s]).", __FUNCTION__, ch, spu_ch_name[ch]);
+			LOG_ERROR(Log::SPU, "%s error: unknown/illegal channel (%d [%s]).", __FUNCTION__, ch, spu_ch_name[ch]);
 		break;
 		}
 
-		if (Emu.IsStopped()) LOGF_WARNING(Log::SPU, "%s(%s) aborted", __FUNCTION__, spu_ch_name[ch]);
+		if (Emu.IsStopped()) LOG_WARNING(Log::SPU, "%s(%s) aborted", __FUNCTION__, spu_ch_name[ch]);
 	}
 
 	void ReadChannel(SPU_GPR_hdr& r, u32 ch)
@@ -1224,11 +1224,11 @@ public:
 		break;
 
 		default:
-			LOGF_ERROR(Log::SPU, "%s error: unknown/illegal channel (%d [%s]).", __FUNCTION__, ch, spu_ch_name[ch]);
+			LOG_ERROR(Log::SPU, "%s error: unknown/illegal channel (%d [%s]).", __FUNCTION__, ch, spu_ch_name[ch]);
 		break;
 		}
 
-		if (Emu.IsStopped()) LOGF_WARNING(Log::SPU, "%s(%s) aborted", __FUNCTION__, spu_ch_name[ch]);
+		if (Emu.IsStopped()) LOG_WARNING(Log::SPU, "%s(%s) aborted", __FUNCTION__, spu_ch_name[ch]);
 	}
 
 	void DoStop(u32 code)
@@ -1249,14 +1249,14 @@ public:
 
 			if (SPU.In_MBox.GetCount())
 			{
-				LOGF_ERROR(Log::SPU, "sys_spu_thread_receive_event(spuq=0x%x): In_MBox is not empty", spuq);
+				LOG_ERROR(Log::SPU, "sys_spu_thread_receive_event(spuq=0x%x): In_MBox is not empty", spuq);
 				SPU.In_MBox.PushUncond(CELL_EBUSY); // ???
 				return;
 			}
 
 			if (Ini.HLELogging.GetValue())
 			{
-				LOGF_NOTICE(Log::SPU, "sys_spu_thread_receive_event(spuq=0x%x)", spuq);
+				LOG_NOTICE(Log::SPU, "sys_spu_thread_receive_event(spuq=0x%x)", spuq);
 			}
 
 			EventQueue* eq;
@@ -1307,7 +1307,7 @@ public:
 				Sleep(1);
 				if (Emu.IsStopped())
 				{
-					LOGF_WARNING(Log::SPU, "sys_spu_thread_receive_event(spuq=0x%x) aborted", spuq);
+					LOG_WARNING(Log::SPU, "sys_spu_thread_receive_event(spuq=0x%x) aborted", spuq);
 					eq->sq.invalidate(tid);
 					return;
 				}
@@ -1322,7 +1322,7 @@ public:
 			else if (Ini.HLELogging.GetValue())
 			{
 				// the real exit status
-				LOGF_NOTICE(Log::SPU, "sys_spu_thread_exit (status=0x%x)", SPU.Out_MBox.GetValue());
+				LOG_NOTICE(Log::SPU, "sys_spu_thread_exit (status=0x%x)", SPU.Out_MBox.GetValue());
 			}
 			SPU.Status.SetValue(SPU_STATUS_STOPPED_BY_STOP);
 			Stop();
@@ -1330,11 +1330,11 @@ public:
 		default:
 			if (!SPU.Out_MBox.GetCount())
 			{
-				LOGF_ERROR(Log::SPU, "Unknown STOP code: 0x%x (no message)", code);
+				LOG_ERROR(Log::SPU, "Unknown STOP code: 0x%x (no message)", code);
 			}
 			else
 			{
-				LOGF_ERROR(Log::SPU, "Unknown STOP code: 0x%x (message=0x%x)", code, SPU.Out_MBox.GetValue());
+				LOG_ERROR(Log::SPU, "Unknown STOP code: 0x%x (message=0x%x)", code, SPU.Out_MBox.GetValue());
 			}
 			SPU.Status.SetValue(SPU_STATUS_STOPPED_BY_STOP);
 			Stop();

--- a/rpcs3/Emu/FS/vfsLocalFile.cpp
+++ b/rpcs3/Emu/FS/vfsLocalFile.cpp
@@ -53,7 +53,7 @@ bool vfsLocalFile::Open(const std::string& path, vfsOpenMode mode)
 
 bool vfsLocalFile::Create(const std::string& path)
 {
-	LOGF_WARNING(HLE, "vfsLocalFile::Create('%s')", path.c_str());
+	LOG_WARNING(HLE, "vfsLocalFile::Create('%s')", path.c_str());
 	for(uint p=1; p < path.length() && path[p] != '\0' ; p++)
 	{
 		for(; p < path.length() && path[p] != '\0'; p++)
@@ -65,7 +65,7 @@ bool vfsLocalFile::Create(const std::string& path)
 		const std::string& dir = path.substr(0, p);
 		if(!rDirExists(dir))
 		{
-			LOGF_NOTICE(HLE, "create dir: %s", dir.c_str());
+			LOG_NOTICE(HLE, "create dir: %s", dir.c_str());
 			rMkdir(dir);
 		}
 	}

--- a/rpcs3/Emu/GS/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/GS/GL/GLFragmentProgram.cpp
@@ -19,7 +19,7 @@ void GLFragmentDecompilerThread::SetDst(std::string code, bool append_mask)
 	case 7: code = "(" + code + " / 8.0)"; break;
 
 	default:
-		LOGF_ERROR(RSX, "Bad scale: %d", fmt::by_value(src1.scale));
+		LOG_ERROR(RSX, "Bad scale: %d", fmt::by_value(src1.scale));
 		Emu.Pause();
 	break;
 	}
@@ -210,7 +210,7 @@ template<typename T> std::string GLFragmentDecompilerThread::GetSRC(T src)
 			}
 			else
 			{
-				LOGF_ERROR(RSX, "Bad src reg num: %d", fmt::by_value(dst.src_attr_reg_num));
+				LOG_ERROR(RSX, "Bad src reg num: %d", fmt::by_value(dst.src_attr_reg_num));
 				ret += m_parr.AddParam(PARAM_IN, "vec4", "unk");
 				Emu.Pause();
 			}
@@ -224,7 +224,7 @@ template<typename T> std::string GLFragmentDecompilerThread::GetSRC(T src)
 	break;
 
 	default:
-		LOGF_ERROR(RSX, "Bad src type %d", fmt::by_value(src.reg_type));
+		LOG_ERROR(RSX, "Bad src type %d", fmt::by_value(src.reg_type));
 		Emu.Pause();
 	break;
 	}
@@ -416,7 +416,7 @@ void GLFragmentDecompilerThread::Task()
 		//case 0x45: SetDst("return"); break; //RET
 
 		default:
-			LOGF_ERROR(RSX, "Unknown fp opcode 0x%x (inst %d)", opcode, m_size / (4 * 4));
+			LOG_ERROR(RSX, "Unknown fp opcode 0x%x (inst %d)", opcode, m_size / (4 * 4));
 			//Emu.Pause();
 		break;
 		}
@@ -515,7 +515,7 @@ void GLShaderProgram::Compile()
 			char* buf = new char[infoLength]; // Buffer to store infoLog
 
 			glGetShaderInfoLog(m_id, infoLength, &len, buf); // Retrieve the shader info log into our buffer
-			LOGF_ERROR(RSX, "Failed to compile shader: %s", buf); // Write log to the console
+			LOG_ERROR(RSX, "Failed to compile shader: %s", buf); // Write log to the console
 
 			delete[] buf;
 		}
@@ -540,7 +540,7 @@ void GLShaderProgram::Delete()
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(RSX, "GLShaderProgram::Delete(): glDeleteShader(%d) avoided", m_id);
+			LOG_WARNING(RSX, "GLShaderProgram::Delete(): glDeleteShader(%d) avoided", m_id);
 		}
 		else
 		{

--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -9,7 +9,7 @@
 #define DUMP_VERTEX_DATA 0
 
 #if CMD_DEBUG
-	#define CMD_LOG(...) LOGF_NOTICE(RSX, __VA_ARGS__)
+	#define CMD_LOG(...) LOG_NOTICE(RSX, __VA_ARGS__)
 #else
 	#define CMD_LOG(...)
 #endif
@@ -27,7 +27,7 @@ void printGlError(GLenum err, const char* situation)
 {
 	if(err != GL_NO_ERROR)
 	{
-		LOGF_ERROR(RSX, "%s: opengl error 0x%04x", situation, err);
+		LOG_ERROR(RSX, "%s: opengl error 0x%04x", situation, err);
 		Emu.Pause();
 	}
 }
@@ -180,7 +180,7 @@ void GLGSRender::EnableVertexData(bool indexed_draw)
 		break;
 
 		default:
-			LOGF_ERROR(HLE, "Bad cv type! %d", m_vertex_data[i].type);
+			LOG_ERROR(HLE, "Bad cv type! %d", m_vertex_data[i].type);
 		return;
 		}
 
@@ -309,7 +309,7 @@ void GLGSRender::InitFragmentData()
 {
 	if(!m_cur_shader_prog)
 	{
-		LOGF_ERROR(RSX, "InitFragmentData: m_cur_shader_prog == NULL");
+		LOG_ERROR(RSX, "InitFragmentData: m_cur_shader_prog == NULL");
 		return;
 	}
 
@@ -337,13 +337,13 @@ bool GLGSRender::LoadProgram()
 {
 	if(!m_cur_shader_prog)
 	{
-		LOGF_WARNING(RSX, "LoadProgram: m_cur_shader_prog == NULL");
+		LOG_WARNING(RSX, "LoadProgram: m_cur_shader_prog == NULL");
 		return false;
 	}
 
 	if(!m_cur_vertex_prog)
 	{
-		LOGF_WARNING(RSX, "LoadProgram: m_cur_vertex_prog == NULL");
+		LOG_WARNING(RSX, "LoadProgram: m_cur_vertex_prog == NULL");
 		return false;
 	}
 
@@ -354,7 +354,7 @@ bool GLGSRender::LoadProgram()
 
 	if(m_fp_buf_num == -1)
 	{
-		LOGF_WARNING(RSX, "FP not found in buffer!");
+		LOG_WARNING(RSX, "FP not found in buffer!");
 		m_shader_prog.DecompileAsync(*m_cur_shader_prog);
 		m_shader_prog.Wait();
 		m_shader_prog.Compile();
@@ -366,7 +366,7 @@ bool GLGSRender::LoadProgram()
 
 	if(m_vp_buf_num == -1)
 	{
-		LOGF_WARNING(RSX, "VP not found in buffer!");
+		LOG_WARNING(RSX, "VP not found in buffer!");
 		m_vertex_prog.DecompileAsync(*m_cur_vertex_prog);
 		m_vertex_prog.Wait();
 		m_vertex_prog.Compile();
@@ -450,7 +450,7 @@ void GLGSRender::WriteDepthBuffer()
 	u32 address = GetAddress(m_surface_offset_z, m_context_dma_z - 0xfeed0000);
 	if (!Memory.IsGoodAddr(address))
 	{
-		LOGF_WARNING(RSX, "Bad depth address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_z, m_context_dma_z);
+		LOG_WARNING(RSX, "Bad depth address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_z, m_context_dma_z);
 		return;
 	}
 
@@ -484,7 +484,7 @@ void GLGSRender::WriteColourBufferA()
 	u32 address = GetAddress(m_surface_offset_a, m_context_dma_color_a - 0xfeed0000);
 	if (!Memory.IsGoodAddr(address))
 	{
-		LOGF_WARNING(RSX, "Bad colour buffer a address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_a, m_context_dma_color_a);
+		LOG_WARNING(RSX, "Bad colour buffer a address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_a, m_context_dma_color_a);
 		return;
 	}
 
@@ -513,7 +513,7 @@ void GLGSRender::WriteColourBufferB()
 	u32 address = GetAddress(m_surface_offset_b, m_context_dma_color_b - 0xfeed0000);
 	if (!Memory.IsGoodAddr(address))
 	{
-		LOGF_WARNING(RSX, "Bad colour buffer b address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_b, m_context_dma_color_b);
+		LOG_WARNING(RSX, "Bad colour buffer b address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_b, m_context_dma_color_b);
 		return;
 	}
 
@@ -543,7 +543,7 @@ void GLGSRender::WriteColourBufferC()
 	u32 address = GetAddress(m_surface_offset_c, m_context_dma_color_c - 0xfeed0000);
 	if (!Memory.IsGoodAddr(address))
 	{
-		LOGF_WARNING(RSX, "Bad colour buffer c address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_c, m_context_dma_color_c);
+		LOG_WARNING(RSX, "Bad colour buffer c address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_c, m_context_dma_color_c);
 		return;
 	}
 
@@ -572,7 +572,7 @@ void GLGSRender::WriteColourBufferD()
 	u32 address = GetAddress(m_surface_offset_d, m_context_dma_color_d - 0xfeed0000);
 	if (!Memory.IsGoodAddr(address))
 	{
-		LOGF_WARNING(RSX, "Bad colour buffer d address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_d, m_context_dma_color_d);
+		LOG_WARNING(RSX, "Bad colour buffer d address: address=0x%x, offset=0x%x, dma=0x%x", address, m_surface_offset_d, m_context_dma_color_d);
 		return;
 	}
 
@@ -703,14 +703,14 @@ void GLGSRender::ExecCMD()
 	//return;
 	if(!LoadProgram())
 	{
-		LOGF_ERROR(RSX, "LoadProgram failed.");
+		LOG_ERROR(RSX, "LoadProgram failed.");
 		Emu.Pause();
 		return;
 	}
 
 	if(!m_fbo.IsCreated() || RSXThread::m_width != last_width || RSXThread::m_height != last_height || last_depth_format != m_surface_depth_format)
 	{
-		LOGF_WARNING(RSX, "New FBO (%dx%d)", RSXThread::m_width, RSXThread::m_height);
+		LOG_WARNING(RSX, "New FBO (%dx%d)", RSXThread::m_width, RSXThread::m_height);
 		last_width = RSXThread::m_width;
 		last_height = RSXThread::m_height;
 		last_depth_format = m_surface_depth_format;
@@ -753,7 +753,7 @@ void GLGSRender::ExecCMD()
 		break;
 
 		default:
-			LOGF_ERROR(RSX, "Bad depth format! (%d)", m_surface_depth_format);
+			LOG_ERROR(RSX, "Bad depth format! (%d)", m_surface_depth_format);
 			assert(0);
 		break;
 		}
@@ -821,7 +821,7 @@ void GLGSRender::ExecCMD()
 	break;
 
 	default:
-		LOGF_ERROR(RSX, "Bad surface colour target: %d", m_surface_colour_target);
+		LOG_ERROR(RSX, "Bad surface colour target: %d", m_surface_colour_target);
 	break;
 	}
 
@@ -1099,7 +1099,7 @@ void GLGSRender::ExecCMD()
 
 	if(m_indexed_array.m_count && m_draw_array_count)
 	{
-		LOGF_WARNING(RSX, "m_indexed_array.m_count && draw_array_count");
+		LOG_WARNING(RSX, "m_indexed_array.m_count && draw_array_count");
 	}
 
 	for(u32 i=0; i<m_textures_count; ++i)
@@ -1142,7 +1142,7 @@ void GLGSRender::ExecCMD()
 		break;
 
 		default:
-			LOGF_ERROR(RSX, "Bad indexed array type (%d)", m_indexed_array.m_type);
+			LOG_ERROR(RSX, "Bad indexed array type (%d)", m_indexed_array.m_type);
 		break;
 		}
 

--- a/rpcs3/Emu/GS/GL/GLGSRender.h
+++ b/rpcs3/Emu/GS/GL/GLGSRender.h
@@ -57,7 +57,7 @@ public:
 		case 8: return GL_MIRROR_CLAMP_EXT;
 		}
 
-		LOGF_ERROR(RSX, "Texture wrap error: bad wrap (%d).", wrap);
+		LOG_ERROR(RSX, "Texture wrap error: bad wrap (%d).", wrap);
 		return GL_REPEAT;
 	}
 
@@ -89,7 +89,7 @@ public:
 		const u64 texaddr = GetAddress(tex.GetOffset(), tex.GetLocation());
 		if (!Memory.IsGoodAddr(texaddr))
 		{
-			LOGF_ERROR(RSX, "Bad texture address=0x%x", texaddr);
+			LOG_ERROR(RSX, "Bad texture address=0x%x", texaddr);
 			return;
 		}
 		//ConLog.Warning("texture addr = 0x%x, width = %d, height = %d, max_aniso=%d, mipmap=%d, remap=0x%x, zfunc=0x%x, wraps=0x%x, wrapt=0x%x, wrapr=0x%x, minlod=0x%x, maxlod=0x%x", 
@@ -420,7 +420,7 @@ public:
 		}
 		break;
 
-		default: LOGF_ERROR(RSX, "Init tex error: Bad tex format (0x%x | %s | 0x%x)", format,
+		default: LOG_ERROR(RSX, "Init tex error: Bad tex format (0x%x | %s | 0x%x)", format,
 					 (is_swizzled ? "swizzled" : "linear"), tex.GetFormat() & 0x40); break;
 		}
 

--- a/rpcs3/Emu/GS/GL/GLProgram.cpp
+++ b/rpcs3/Emu/GS/GL/GLProgram.cpp
@@ -54,13 +54,13 @@ void GLProgram::Create(const u32 vp, const u32 fp)
 			char* buf = new char[bufLength+1];
 			memset(buf, 0, bufLength+1);
 			glGetProgramInfoLog(id, bufLength, NULL, buf);
-			LOGF_ERROR(RSX, "Could not link program: %s", buf);
+			LOG_ERROR(RSX, "Could not link program: %s", buf);
 			delete[] buf;
 
 			return;
 		}
 	}
-	//else LOGF_NOTICE(HLE, "program linked!");
+	//else LOG_NOTICE(HLE, "program linked!");
 
 	glGetProgramiv(id, GL_VALIDATE_STATUS, &linkStatus);
 	if(linkStatus != GL_TRUE)
@@ -73,7 +73,7 @@ void GLProgram::Create(const u32 vp, const u32 fp)
 			char* buf = new char[bufLength];
 			memset(buf, 0, bufLength);
 			glGetProgramInfoLog(id, bufLength, NULL, buf);
-			LOGF_ERROR(RSX, "Could not link program: %s", buf);
+			LOG_ERROR(RSX, "Could not link program: %s", buf);
 			delete[] buf;
 
 			return;

--- a/rpcs3/Emu/GS/GL/GLProgramBuffer.cpp
+++ b/rpcs3/Emu/GS/GL/GLProgramBuffer.cpp
@@ -52,13 +52,13 @@ u32 GLProgramBuffer::GetProg(u32 fp, u32 vp) const
 	if(fp == vp)
 	{
 		/*
-		LOGF_NOTICE(RSX, "Get program (%d):", fp);
-		LOGF_NOTICE(RSX, "*** prog id = %d", m_buf[fp].prog_id);
-		LOGF_NOTICE(RSX, "*** vp id = %d", m_buf[fp].vp_id);
-		LOGF_NOTICE(RSX, "*** fp id = %d", m_buf[fp].fp_id);
+		LOG_NOTICE(RSX, "Get program (%d):", fp);
+		LOG_NOTICE(RSX, "*** prog id = %d", m_buf[fp].prog_id);
+		LOG_NOTICE(RSX, "*** vp id = %d", m_buf[fp].vp_id);
+		LOG_NOTICE(RSX, "*** fp id = %d", m_buf[fp].fp_id);
 
-		LOGF_NOTICE(RSX, "*** vp shader = \n%s", m_buf[fp].vp_shader.wx_str());
-		LOGF_NOTICE(RSX, "*** fp shader = \n%s", m_buf[fp].fp_shader.wx_str());
+		LOG_NOTICE(RSX, "*** vp shader = \n%s", m_buf[fp].vp_shader.wx_str());
+		LOG_NOTICE(RSX, "*** fp shader = \n%s", m_buf[fp].fp_shader.wx_str());
 		*/
 		return m_buf[fp].prog_id;
 	}
@@ -70,13 +70,13 @@ u32 GLProgramBuffer::GetProg(u32 fp, u32 vp) const
 		if(CmpVP(vp, i) && CmpFP(fp, i))
 		{
 			/*
-			LOGF_NOTICE(RSX, "Get program (%d):", i);
-			LOGF_NOTICE(RSX, "*** prog id = %d", m_buf[i].prog_id);
-			LOGF_NOTICE(RSX, "*** vp id = %d", m_buf[i].vp_id);
-			LOGF_NOTICE(RSX, "*** fp id = %d", m_buf[i].fp_id);
+			LOG_NOTICE(RSX, "Get program (%d):", i);
+			LOG_NOTICE(RSX, "*** prog id = %d", m_buf[i].prog_id);
+			LOG_NOTICE(RSX, "*** vp id = %d", m_buf[i].vp_id);
+			LOG_NOTICE(RSX, "*** fp id = %d", m_buf[i].fp_id);
 
-			LOGF_NOTICE(RSX, "*** vp shader = \n%s", m_buf[i].vp_shader.wx_str());
-			LOGF_NOTICE(RSX, "*** fp shader = \n%s", m_buf[i].fp_shader.wx_str());
+			LOG_NOTICE(RSX, "*** vp shader = \n%s", m_buf[i].vp_shader.wx_str());
+			LOG_NOTICE(RSX, "*** fp shader = \n%s", m_buf[i].fp_shader.wx_str());
 			*/
 			return m_buf[i].prog_id;
 		}
@@ -89,15 +89,15 @@ void GLProgramBuffer::Add(GLProgram& prog, GLShaderProgram& gl_fp, RSXShaderProg
 {
 	GLBufferInfo new_buf;
 
-	LOGF_NOTICE(RSX, "Add program (%d):", m_buf.size());
-	LOGF_NOTICE(RSX, "*** prog id = %d", prog.id);
-	LOGF_NOTICE(RSX, "*** vp id = %d", gl_vp.id);
-	LOGF_NOTICE(RSX, "*** fp id = %d", gl_fp.GetId());
-	LOGF_NOTICE(RSX, "*** vp data size = %d", rsx_vp.data.size() * 4);
-	LOGF_NOTICE(RSX, "*** fp data size = %d", rsx_fp.size);
+	LOG_NOTICE(RSX, "Add program (%d):", m_buf.size());
+	LOG_NOTICE(RSX, "*** prog id = %d", prog.id);
+	LOG_NOTICE(RSX, "*** vp id = %d", gl_vp.id);
+	LOG_NOTICE(RSX, "*** fp id = %d", gl_fp.GetId());
+	LOG_NOTICE(RSX, "*** vp data size = %d", rsx_vp.data.size() * 4);
+	LOG_NOTICE(RSX, "*** fp data size = %d", rsx_fp.size);
 
-	LOGF_NOTICE(RSX, "*** vp shader = \n%s", gl_vp.shader.c_str());
-	LOGF_NOTICE(RSX, "*** fp shader = \n%s", gl_fp.GetShaderText().c_str());
+	LOG_NOTICE(RSX, "*** vp shader = \n%s", gl_vp.shader.c_str());
+	LOG_NOTICE(RSX, "*** fp shader = \n%s", gl_fp.GetShaderText().c_str());
 	
 
 	new_buf.prog_id = prog.id;

--- a/rpcs3/Emu/GS/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/GS/GL/GLVertexProgram.cpp
@@ -49,7 +49,7 @@ std::string GLVertexDecompilerThread::GetDST(bool isSca)
 
 	default:
 		if (d3.dst > 15)
-			LOGF_ERROR(RSX, "dst index out of range: %u", d3.dst);
+			LOG_ERROR(RSX, "dst index out of range: %u", d3.dst);
 		ret += m_parr.AddParam(PARAM_NONE, "vec4", std::string("dst_reg") + std::to_string(d3.dst), d3.dst == 0 ? "vec4(0.0f, 0.0f, 0.0f, 1.0f)" : "vec4(0.0)");
 	break;
 	}
@@ -83,7 +83,7 @@ std::string GLVertexDecompilerThread::GetSRC(const u32 n)
 		}
 		else
 		{
-			LOGF_ERROR(RSX, "Bad input src num: %d", fmt::by_value(d1.input_src));
+			LOG_ERROR(RSX, "Bad input src num: %d", fmt::by_value(d1.input_src));
 			ret += m_parr.AddParam(PARAM_IN, "vec4", "in_unk", d1.input_src);
 		}
 	break;
@@ -93,7 +93,7 @@ std::string GLVertexDecompilerThread::GetSRC(const u32 n)
 	break;
 
 	default:
-		LOGF_ERROR(RSX, "Bad src%u reg type: %d", n, fmt::by_value(src[n].reg_type));
+		LOG_ERROR(RSX, "Bad src%u reg type: %d", n, fmt::by_value(src[n].reg_type));
 		Emu.Pause();
 	break;
 	}
@@ -510,7 +510,7 @@ void GLVertexDecompilerThread::Task()
 
 		default:
 			m_body.push_back(fmt::Format("//Unknown vp sca_opcode 0x%x", fmt::by_value(d1.sca_opcode)));
-			LOGF_ERROR(RSX, "Unknown vp sca_opcode 0x%x", fmt::by_value(d1.sca_opcode));
+			LOG_ERROR(RSX, "Unknown vp sca_opcode 0x%x", fmt::by_value(d1.sca_opcode));
 			Emu.Pause();
 		break;
 		}
@@ -543,7 +543,7 @@ void GLVertexDecompilerThread::Task()
 
 		default:
 			m_body.push_back(fmt::Format("//Unknown vp opcode 0x%x", fmt::by_value(d1.vec_opcode)));
-			LOGF_ERROR(RSX, "Unknown vp opcode 0x%x", fmt::by_value(d1.vec_opcode));
+			LOG_ERROR(RSX, "Unknown vp opcode 0x%x", fmt::by_value(d1.vec_opcode));
 			Emu.Pause();
 		break;
 		}
@@ -647,14 +647,14 @@ void GLVertexProgram::Compile()
 			GLsizei len;
 			memset(buf, 0, r+1);
 			glGetShaderInfoLog(id, r, &len, buf);
-			LOGF_ERROR(RSX, "Failed to compile vertex shader: %s", buf);
+			LOG_ERROR(RSX, "Failed to compile vertex shader: %s", buf);
 			delete[] buf;
 		}
 
 		LOG_NOTICE(RSX, shader);
 		Emu.Pause();
 	}
-	//else LOGF_WARNING(RSX, "Vertex shader compiled successfully!");
+	//else LOG_WARNING(RSX, "Vertex shader compiled successfully!");
 
 }
 
@@ -667,7 +667,7 @@ void GLVertexProgram::Delete()
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(RSX, "GLVertexProgram::Delete(): glDeleteShader(%d) avoided", id);
+			LOG_WARNING(RSX, "GLVertexProgram::Delete(): glDeleteShader(%d) avoided", id);
 		}
 		else
 		{

--- a/rpcs3/Emu/GS/RSXThread.cpp
+++ b/rpcs3/Emu/GS/RSXThread.cpp
@@ -20,7 +20,7 @@ u32 GetAddress(u32 offset, u8 location)
 		return realAddr;
 	}
 
-	LOGF_ERROR(RSX, "GetAddress(offset=0x%x, location=0x%x)", location);
+	LOG_ERROR(RSX, "GetAddress(offset=0x%x, location=0x%x)", location);
 	assert(0);
 	return 0;
 }
@@ -97,7 +97,7 @@ u32 RSXVertexData::GetTypeSize()
 	case 7: return 1;
 	}
 
-	LOGF_ERROR(RSX, "Bad vertex data type! %d", type);
+	LOG_ERROR(RSX, "Bad vertex data type! %d", type);
 	return 1;
 }
 
@@ -115,7 +115,7 @@ u32 RSXThread::OutOfArgsCount(const uint x, const u32 cmd, const u32 count)
 	debug += "(";
 	for(u32 i=0; i<count; ++i) debug += (i ? ", " : "") + fmt::Format("0x%x", ARGS(i));
 	debug += ")";
-	LOGF_NOTICE(RSX, "OutOfArgsCount(x=%u, count=%u): " + debug, x, count);
+	LOG_NOTICE(RSX, "OutOfArgsCount(x=%u, count=%u): " + debug, x, count);
 
 	return 0;
 }
@@ -214,7 +214,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 
 	case NV4097_NO_OPERATION:
 	{
-		LOGF_WARNING(RSX, "NV4097_NO_OPERATION");
+		LOG_WARNING(RSX, "NV4097_NO_OPERATION");
 	}
 	break;
 
@@ -274,7 +274,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 
 	case_16(NV4097_SET_TEX_COORD_CONTROL, 4) :
 	{
-		LOGF_WARNING(RSX, "NV4097_SET_TEX_COORD_CONTROL");
+		LOG_WARNING(RSX, "NV4097_SET_TEX_COORD_CONTROL");
 	}
 	break;
 
@@ -304,7 +304,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		m_vertex_data[index].data.push_back(v1);
 		m_vertex_data[index].data.push_back(v2);
 		m_vertex_data[index].data.push_back(v3);
-		//LOGF_WARNING(RSX, "index = %d, v0 = 0x%x, v1 = 0x%x, v2 = 0x%x, v3 = 0x%x", index, v0, v1, v2, v3);
+		//LOG_WARNING(RSX, "index = %d, v0 = 0x%x, v1 = 0x%x, v2 = 0x%x, v3 = 0x%x", index, v0, v1, v2, v3);
 	}
 	break;
 
@@ -323,7 +323,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		(float&)m_vertex_data[index].data[sizeof(float)*0] = v0;
 		(float&)m_vertex_data[index].data[sizeof(float)*1] = v1;
 
-		//LOGF_WARNING(RSX, "index = %d, v0 = %f, v1 = %f", index, v0, v1);
+		//LOG_WARNING(RSX, "index = %d, v0 = %f, v1 = %f", index, v0, v1);
 	}
 	break;
 
@@ -348,7 +348,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		(float&)m_vertex_data[index].data[sizeof(float)*2] = v2;
 		(float&)m_vertex_data[index].data[sizeof(float)*3] = v3;
 
-		//LOGF_WARNING(RSX, "index = %d, v0 = %f, v1 = %f, v2 = %f, v3 = %f", index, v0, v1, v2, v3);
+		//LOG_WARNING(RSX, "index = %d, v0 = %f, v1 = %f, v2 = %f, v3 = %f", index, v0, v1, v2, v3);
 	}
 	break;
 
@@ -383,7 +383,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_VERTEX_ATTRIB_INPUT_MASK:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_VERTEX_ATTRIB_INPUT_MASK: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_VERTEX_ATTRIB_INPUT_MASK: %x", ARGS(0));
 
 		//VertexData[0].prog.attributeInputMask = ARGS(0);
 	}
@@ -392,7 +392,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK: %x", ARGS(0));
 
 		//VertexData[0].prog.attributeOutputMask = ARGS(0);
 		//FragmentData.prog.attributeInputMask = ARGS(0)/* & ~0x20*/;
@@ -415,7 +415,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_COLOR_MASK_MRT:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_COLOR_MASK_MRT: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_COLOR_MASK_MRT: %x", ARGS(0));
 	}
 	break;
 
@@ -479,7 +479,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_BLEND_ENABLE_MRT:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_BLEND_ENABLE_MRT: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_BLEND_ENABLE_MRT: %x", ARGS(0));
 	}
 	break;
 
@@ -519,7 +519,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_BLEND_COLOR2:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_BLEND_COLOR2: 0x % x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_BLEND_COLOR2: 0x % x", ARGS(0));
 	}
 	break;
 
@@ -534,7 +534,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_REDUCE_DST_COLOR:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_REDUCE_DST_COLOR: 0x % x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_REDUCE_DST_COLOR: 0x % x", ARGS(0));
 	}
 	break;
 
@@ -608,7 +608,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_CLIP_MAX:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_CLIP_MAX: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_CLIP_MAX: %x", ARGS(0));
 	}
 	break;
 
@@ -734,14 +734,14 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_CLEAR_RECT_HORIZONTAL:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_CLEAR_RECT_HORIZONTAL: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_CLEAR_RECT_HORIZONTAL: %x", ARGS(0));
 	}
 	break;
 
 	case NV4097_SET_CLEAR_RECT_VERTICAL:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_CLEAR_RECT_VERTICAL: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_CLEAR_RECT_VERTICAL: %x", ARGS(0));
 	}
 	break;
 
@@ -754,7 +754,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 			const u32 first = ac & 0xffffff;
 			const u32 _count = (ac >> 24) + 1;
 
-			//LOGF_WARNING(RSX, "NV4097_DRAW_ARRAYS: %d - %d", first, _count);
+			//LOG_WARNING(RSX, "NV4097_DRAW_ARRAYS: %d - %d", first, _count);
 
 			LoadVertexData(first, _count);
 
@@ -791,7 +791,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 						m_indexed_array.m_data.resize(m_indexed_array.m_data.size() + 4);
 						index = Memory.Read32(m_indexed_array.m_addr + i * 4);
 						*(u32*)&m_indexed_array.m_data[pos] = index;
-						//LOGF_WARNING(RSX, "index 4: %d", *(u32*)&m_indexed_array.m_data[pos]);
+						//LOG_WARNING(RSX, "index 4: %d", *(u32*)&m_indexed_array.m_data[pos]);
 					}
 					break;
 
@@ -800,7 +800,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 						int pos = m_indexed_array.m_data.size();
 						m_indexed_array.m_data.resize(m_indexed_array.m_data.size() + 2);
 						index = Memory.Read16(m_indexed_array.m_addr + i * 2);
-						//LOGF_WARNING(RSX, "index 2: %d", index);
+						//LOG_WARNING(RSX, "index 2: %d", index);
 						*(u16*)&m_indexed_array.m_data[pos] = index;
 					}
 					break;
@@ -819,7 +819,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	{
 		const u32 a0 = ARGS(0);
 
-		//LOGF_WARNING(RSX, "NV4097_SET_BEGIN_END: %x", a0);
+		//LOG_WARNING(RSX, "NV4097_SET_BEGIN_END: %x", a0);
 
 		m_read_buffer = false;
 
@@ -850,7 +850,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	{
 		if(!m_cur_shader_prog)
 		{
-			LOGF_ERROR(RSX, "NV4097_SET_SHADER_CONTROL: m_cur_shader_prog == NULL");
+			LOG_ERROR(RSX, "NV4097_SET_SHADER_CONTROL: m_cur_shader_prog == NULL");
 			break;
 		}
 
@@ -877,7 +877,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	// Transform 
 	case NV4097_SET_TRANSFORM_PROGRAM_LOAD:
 	{
-		//LOGF_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM_LOAD: prog = %d", ARGS(0));
+		//LOG_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM_LOAD: prog = %d", ARGS(0));
 
 		m_cur_vertex_prog = &m_vertex_progs[ARGS(0)];
 		m_cur_vertex_prog->data.clear();
@@ -886,7 +886,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		{
 			const u32 start = ARGS(1);
 			if(start)
-				LOGF_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM_LOAD: start = %d", start);
+				LOG_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM_LOAD: start = %d", start);
 		}
 	}
 	break;
@@ -894,17 +894,17 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_TRANSFORM_PROGRAM_START:
 	{
 		if (ARGS(0)) 
-			LOGF_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM_START: 0x%x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM_START: 0x%x", ARGS(0));
 	}
 	break;
 
 	case_32(NV4097_SET_TRANSFORM_PROGRAM, 4):
 	{
-		//LOGF_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM[%d](%d)", index, count);
+		//LOG_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM[%d](%d)", index, count);
 
 		if(!m_cur_vertex_prog)
 		{
-			LOGF_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM: m_cur_vertex_prog == NULL");
+			LOG_WARNING(RSX, "NV4097_SET_TRANSFORM_PROGRAM: m_cur_vertex_prog == NULL");
 			break;
 		}
 
@@ -916,7 +916,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 
 		if(!m_cur_vertex_prog)
 		{
-			LOGF_WARNING(RSX, "NV4097_SET_TRANSFORM_TIMEOUT: m_cur_vertex_prog == NULL");
+			LOG_WARNING(RSX, "NV4097_SET_TRANSFORM_TIMEOUT: m_cur_vertex_prog == NULL");
 			break;
 		}
 
@@ -950,28 +950,28 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_INVALIDATE_L2:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_INVALIDATE_L2: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_INVALIDATE_L2: %x", ARGS(0));
 	}
 	break;
 
 	case NV4097_INVALIDATE_VERTEX_CACHE_FILE:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_INVALIDATE_VERTEX_CACHE_FILE: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_INVALIDATE_VERTEX_CACHE_FILE: %x", ARGS(0));
 	}
 	break;
 
 	case NV4097_INVALIDATE_VERTEX_FILE:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_INVALIDATE_VERTEX_FILE: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_INVALIDATE_VERTEX_FILE: %x", ARGS(0));
 	}
 	break;
 
 	case NV4097_INVALIDATE_ZCULL:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_INVALIDATE_ZCULL: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_INVALIDATE_ZCULL: %x", ARGS(0));
 	}
 	break;
 
@@ -1235,7 +1235,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV406E_SEMAPHORE_ACQUIRE:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV406E_SEMAPHORE_ACQUIRE: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV406E_SEMAPHORE_ACQUIRE: %x", ARGS(0));
 	}
 	break;
 
@@ -1347,7 +1347,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	{
 		if (count != 4)
 		{
-			LOGF_WARNING(RSX, "NV4097_SET_SURFACE_PITCH_C: Bad count (%d)", count);
+			LOG_WARNING(RSX, "NV4097_SET_SURFACE_PITCH_C: Bad count (%d)", count);
 			break;
 		}
 
@@ -1361,7 +1361,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_SURFACE_PITCH_D:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_SURFACE_PITCH_D: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_SURFACE_PITCH_D: %x", ARGS(0));
 	}
 	break;
 
@@ -1401,7 +1401,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_CONTEXT_DMA_COLOR_D:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_CONTEXT_DMA_COLOR_D: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_CONTEXT_DMA_COLOR_D: %x", ARGS(0));
 	}
 	break;
 
@@ -1443,7 +1443,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_ANTI_ALIASING_CONTROL:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_ANTI_ALIASING_CONTROL: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_ANTI_ALIASING_CONTROL: %x", ARGS(0));
 	}
 	break;
 
@@ -1498,7 +1498,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_ZCULL_CONTROL0:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_ZCULL_CONTROL0: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_ZCULL_CONTROL0: %x", ARGS(0));
 
 		//m_set_depth_func = true;
 		//m_depth_func = ARGS(0) >> 4;
@@ -1508,7 +1508,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_ZCULL_CONTROL1:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_ZCULL_CONTROL1: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_ZCULL_CONTROL1: %x", ARGS(0));
 
 		//m_set_depth_func = true;
 		//m_depth_func = ARGS(0) >> 4;
@@ -1531,12 +1531,12 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		case CELL_GCM_ZCULL_STATS2:
 		case CELL_GCM_ZCULL_STATS3:
 			value = 0;
-			LOGF_WARNING(RSX, "NV4097_GET_REPORT: Unimplemented type %d", type);
+			LOG_WARNING(RSX, "NV4097_GET_REPORT: Unimplemented type %d", type);
 		break;
 
 		default:
 			value = 0;
-			LOGF_WARNING(RSX, "NV4097_GET_REPORT: Bad type %d", type);
+			LOG_WARNING(RSX, "NV4097_GET_REPORT: Bad type %d", type);
 		break;
 		}
 
@@ -1586,7 +1586,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_ZMIN_MAX_CONTROL:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_ZMIN_MAX_CONTROL: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_ZMIN_MAX_CONTROL: %x", ARGS(0));
 	}
 	break;
 
@@ -1594,28 +1594,28 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	case NV4097_SET_WINDOW_OFFSET:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_WINDOW_OFFSET: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_WINDOW_OFFSET: %x", ARGS(0));
 	}
 	break;
 
 	case NV4097_SET_WINDOW_CLIP_TYPE:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_WINDOW_CLIP_TYPE: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_WINDOW_CLIP_TYPE: %x", ARGS(0));
 	}
 	break;
 
 	case NV4097_SET_WINDOW_CLIP_HORIZONTAL:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_WINDOW_CLIP_HORIZONTAL: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_WINDOW_CLIP_HORIZONTAL: %x", ARGS(0));
 	}
 	break;
 
 	case NV4097_SET_WINDOW_CLIP_VERTICAL:
 	{
 		if (ARGS(0))
-			LOGF_WARNING(RSX, "NV4097_SET_WINDOW_CLIP_VERTICAL: %x", ARGS(0));
+			LOG_WARNING(RSX, "NV4097_SET_WINDOW_CLIP_VERTICAL: %x", ARGS(0));
 	}
 	break;
 
@@ -1638,7 +1638,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		}
 		else
 		{
-			LOGF_WARNING(RSX, "NV0039_SET_CONTEXT_DMA_BUFFER_IN: TODO: srcContext=0x%x, dstContext=0x%x", srcContext, dstContext);
+			LOG_WARNING(RSX, "NV0039_SET_CONTEXT_DMA_BUFFER_IN: TODO: srcContext=0x%x, dstContext=0x%x", srcContext, dstContext);
 		}
 	}
 	break;
@@ -1662,7 +1662,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		}
 		else
 		{
-			LOGF_WARNING(RSX, "NV0039_OFFSET_IN: TODO: offset(in=0x%x, out=0x%x), pitch(in=0x%x, out=0x%x), line(len=0x%x, cnt=0x%x), fmt(in=0x%x, out=0x%x), notify=0x%x",
+			LOG_WARNING(RSX, "NV0039_OFFSET_IN: TODO: offset(in=0x%x, out=0x%x), pitch(in=0x%x, out=0x%x), line(len=0x%x, cnt=0x%x), fmt(in=0x%x, out=0x%x), notify=0x%x",
 				inOffset, outOffset, inPitch, outPitch, lineLength, lineCount, inFormat, outFormat, notify);
 		}
 	}
@@ -1677,7 +1677,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		}
 		else
 		{
-			LOGF_WARNING(RSX, "NV0039_OFFSET_OUT: TODO: offset=0x%x", offset);
+			LOG_WARNING(RSX, "NV0039_OFFSET_OUT: TODO: offset=0x%x", offset);
 		}
 	}
 	break;
@@ -1723,10 +1723,10 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 
 		if(count >= 5)
 		{
-			LOGF_WARNING(RSX, "NV308A_COLOR: count = %d", count);
+			LOG_WARNING(RSX, "NV308A_COLOR: count = %d", count);
 		}
 
-		//LOGF_WARNING(RSX, "NV308A_COLOR: [%d]: %f, %f, %f, %f", c.id, c.x, c.y, c.z, c.w);
+		//LOG_WARNING(RSX, "NV308A_COLOR: [%d]: %f, %f, %f, %f", c.id, c.x, c.y, c.z, c.w);
 		m_fragment_constants.push_back(c);
 	}
 	break;
@@ -1810,7 +1810,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	{
 		if (ARGS(0) != CELL_GCM_CONTEXT_SURFACE2D)
 		{
-			LOGF_WARNING(RSX, "NV3089_SET_CONTEXT_SURFACE: Unsupported surface (0x%x)", ARGS(0));
+			LOG_WARNING(RSX, "NV3089_SET_CONTEXT_SURFACE: Unsupported surface (0x%x)", ARGS(0));
 		}
 	}
 	break;
@@ -1866,7 +1866,7 @@ void RSXThread::End()
 void RSXThread::Task()
 {
 	u8 inc;
-	LOGF_NOTICE(RSX, "RSX thread started");
+	LOG_NOTICE(RSX, "RSX thread started");
 
 	OnInitThread();
 
@@ -1874,7 +1874,7 @@ void RSXThread::Task()
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(RSX, "RSX thread aborted");
+			LOG_WARNING(RSX, "RSX thread aborted");
 			return;
 		}
 		std::lock_guard<std::mutex> lock(m_cs_main);
@@ -1912,7 +1912,7 @@ void RSXThread::Task()
 		if(cmd & CELL_GCM_METHOD_FLAG_JUMP)
 		{
 			u32 addr = cmd & ~(CELL_GCM_METHOD_FLAG_JUMP | CELL_GCM_METHOD_FLAG_NON_INCREMENT);
-			//LOGF_WARNING(RSX, "rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", addr, m_ioAddress + get, cmd, get, put);
+			//LOG_WARNING(RSX, "rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", addr, m_ioAddress + get, cmd, get, put);
 			m_ctrl->get = addr;
 			continue;
 		}
@@ -1921,22 +1921,22 @@ void RSXThread::Task()
 			m_call_stack.push(get + 4);
 			u32 offs = cmd & ~CELL_GCM_METHOD_FLAG_CALL;
 			u32 addr = Memory.RSXIOMem.GetStartAddr() + offs;
-			//LOGF_WARNING(RSX, "rsx call(0x%x) #0x%x - 0x%x - 0x%x", offs, addr, cmd, get);
+			//LOG_WARNING(RSX, "rsx call(0x%x) #0x%x - 0x%x - 0x%x", offs, addr, cmd, get);
 			m_ctrl->get = offs;
 			continue;
 		}
 		if(cmd == CELL_GCM_METHOD_FLAG_RETURN)
 		{
-			//LOGF_WARNING(RSX, "rsx return!");
+			//LOG_WARNING(RSX, "rsx return!");
 			u32 get = m_call_stack.top();
 			m_call_stack.pop();
-			//LOGF_WARNING(RSX, "rsx return(0x%x)", get);
+			//LOG_WARNING(RSX, "rsx return(0x%x)", get);
 			m_ctrl->get = get;
 			continue;
 		}
 		if(cmd & CELL_GCM_METHOD_FLAG_NON_INCREMENT)
 		{
-			//LOGF_WARNING(RSX, "non increment cmd! 0x%x", cmd);
+			//LOG_WARNING(RSX, "non increment cmd! 0x%x", cmd);
 			inc=0;
 		}
 
@@ -1961,7 +1961,7 @@ void RSXThread::Task()
 		//memset(Memory.GetMemFromAddr(p.m_ioAddress + get), 0, (count + 1) * 4);
 	}
 
-	LOGF_NOTICE(RSX, "RSX thread ended");
+	LOG_NOTICE(RSX, "RSX thread ended");
 
 	OnExitThread();
 }

--- a/rpcs3/Emu/HDD/HDD.h
+++ b/rpcs3/Emu/HDD/HDD.h
@@ -486,7 +486,7 @@ public:
 
 	int OpenDir(const std::string& name)
 	{
-		LOGF_WARNING(HLE, "OpenDir(%s)", name.c_str());
+		LOG_WARNING(HLE, "OpenDir(%s)", name.c_str());
 		u64 entry_block;
 		if(!SearchEntry(name, entry_block))
 			return -1;
@@ -594,7 +594,7 @@ public:
 			return false;
 		}
 
-		LOGF_NOTICE(HLE, "CREATING ENTRY AT 0x%llx", new_block);
+		LOG_NOTICE(HLE, "CREATING ENTRY AT 0x%llx", new_block);
 		WriteBlock(new_block, g_used_block);
 
 		{
@@ -744,7 +744,7 @@ public:
 			return false;
 		}
 
-		LOGF_NOTICE(HLE, "ENTRY FOUND AT 0x%llx", file_block);
+		LOG_NOTICE(HLE, "ENTRY FOUND AT 0x%llx", file_block);
 		m_file.Open(file_block);
 
 		return vfsFileBase::Open(path, mode);
@@ -774,7 +774,7 @@ public:
 
 			if(entry.type == vfsHDD_Entry_Dir && name != "." && name != "..")
 			{
-				LOGF_WARNING(HLE, "Removing sub folder '%s'", name.c_str());
+				LOG_WARNING(HLE, "Removing sub folder '%s'", name.c_str());
 				RemoveBlocksDir(entry.data_block);
 			}
 			else if(entry.type == vfsHDD_Entry_File)

--- a/rpcs3/Emu/Io/XInput/XInputPadHandler.cpp
+++ b/rpcs3/Emu/Io/XInput/XInputPadHandler.cpp
@@ -113,7 +113,7 @@ void XInputPadHandler::Close()
 		{
 			active = false;
 			if (WaitForSingleObject(thread, THREAD_TIMEOUT) != WAIT_OBJECT_0)
-				LOGF_ERROR(HLE, "XInput thread could not stop within %d milliseconds", THREAD_TIMEOUT);
+				LOG_ERROR(HLE, "XInput thread could not stop within %d milliseconds", THREAD_TIMEOUT);
 			thread = nullptr;
 		}
 

--- a/rpcs3/Emu/Memory/DynamicMemoryBlockBase.h
+++ b/rpcs3/Emu/Memory/DynamicMemoryBlockBase.h
@@ -212,10 +212,10 @@ bool DynamicMemoryBlockBase<PT>::Free(u64 addr)
 		}
 	}
 
-	LOGF_ERROR(MEMORY, "DynamicMemoryBlock::Free(addr=0x%llx): failed", addr);
+	LOG_ERROR(MEMORY, "DynamicMemoryBlock::Free(addr=0x%llx): failed", addr);
 	for (u32 i = 0; i < m_allocated.size(); i++)
 	{
-		LOGF_NOTICE(MEMORY, "*** Memory Block: addr = 0x%llx, size = 0x%x", m_allocated[i].addr, m_allocated[i].size);
+		LOG_NOTICE(MEMORY, "*** Memory Block: addr = 0x%llx, size = 0x%x", m_allocated[i].addr, m_allocated[i].size);
 	}
 	return false;
 }
@@ -233,7 +233,7 @@ u8* DynamicMemoryBlockBase<PT>::GetMem(u64 addr) const // lock-free, addr is fix
 		}
 	}
 
-	LOGF_ERROR(MEMORY, "GetMem(%llx) from not allocated address.", addr);
+	LOG_ERROR(MEMORY, "GetMem(%llx) from not allocated address.", addr);
 	assert(0);
 	return nullptr;
 }

--- a/rpcs3/Emu/Memory/Memory.cpp
+++ b/rpcs3/Emu/Memory/Memory.cpp
@@ -331,7 +331,7 @@ bool MemoryBlockLE::Write128(const u64 addr, const u128 value)
 //NullMemoryBlock
 bool NullMemoryBlock::Read8(const u64 addr, u8* )
 {
-	LOGF_ERROR(MEMORY, "Read8 from null block: [%08llx]", addr);
+	LOG_ERROR(MEMORY, "Read8 from null block: [%08llx]", addr);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -339,7 +339,7 @@ bool NullMemoryBlock::Read8(const u64 addr, u8* )
 
 bool NullMemoryBlock::Read16(const u64 addr, u16* )
 {
-	LOGF_ERROR(MEMORY, "Read16 from null block: [%08llx]", addr);
+	LOG_ERROR(MEMORY, "Read16 from null block: [%08llx]", addr);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -347,7 +347,7 @@ bool NullMemoryBlock::Read16(const u64 addr, u16* )
 
 bool NullMemoryBlock::Read32(const u64 addr, u32* )
 {
-	LOGF_ERROR(MEMORY, "Read32 from null block: [%08llx]", addr);
+	LOG_ERROR(MEMORY, "Read32 from null block: [%08llx]", addr);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -355,7 +355,7 @@ bool NullMemoryBlock::Read32(const u64 addr, u32* )
 
 bool NullMemoryBlock::Read64(const u64 addr, u64* )
 {
-	LOGF_ERROR(MEMORY, "Read64 from null block: [%08llx]", addr);
+	LOG_ERROR(MEMORY, "Read64 from null block: [%08llx]", addr);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -363,7 +363,7 @@ bool NullMemoryBlock::Read64(const u64 addr, u64* )
 
 bool NullMemoryBlock::Read128(const u64 addr, u128* )
 {
-	LOGF_ERROR(MEMORY, "Read128 from null block: [%08llx]", addr);
+	LOG_ERROR(MEMORY, "Read128 from null block: [%08llx]", addr);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -371,7 +371,7 @@ bool NullMemoryBlock::Read128(const u64 addr, u128* )
 
 bool NullMemoryBlock::Write8(const u64 addr, const u8 value)
 {
-	LOGF_ERROR(MEMORY, "Write8 to null block: [%08llx]: %x", addr, value);
+	LOG_ERROR(MEMORY, "Write8 to null block: [%08llx]: %x", addr, value);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -379,7 +379,7 @@ bool NullMemoryBlock::Write8(const u64 addr, const u8 value)
 
 bool NullMemoryBlock::Write16(const u64 addr, const u16 value)
 {
-	LOGF_ERROR(MEMORY, "Write16 to null block: [%08llx]: %x", addr, value);
+	LOG_ERROR(MEMORY, "Write16 to null block: [%08llx]: %x", addr, value);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -387,7 +387,7 @@ bool NullMemoryBlock::Write16(const u64 addr, const u16 value)
 
 bool NullMemoryBlock::Write32(const u64 addr, const u32 value)
 {
-	LOGF_ERROR(MEMORY, "Write32 to null block: [%08llx]: %x", addr, value);
+	LOG_ERROR(MEMORY, "Write32 to null block: [%08llx]: %x", addr, value);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -395,7 +395,7 @@ bool NullMemoryBlock::Write32(const u64 addr, const u32 value)
 
 bool NullMemoryBlock::Write64(const u64 addr, const u64 value)
 {
-	LOGF_ERROR(MEMORY, "Write64 to null block: [%08llx]: %llx", addr, value);
+	LOG_ERROR(MEMORY, "Write64 to null block: [%08llx]: %llx", addr, value);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;
@@ -403,7 +403,7 @@ bool NullMemoryBlock::Write64(const u64 addr, const u64 value)
 
 bool NullMemoryBlock::Write128(const u64 addr, const u128 value)
 {
-	LOGF_ERROR(MEMORY, "Write128 to null block: [%08llx]: %llx_%llx", addr, value.hi, value.lo);
+	LOG_ERROR(MEMORY, "Write128 to null block: [%08llx]: %llx_%llx", addr, value.hi, value.lo);
 	if (!Ini.CPUIgnoreRWErrors.GetValue())
 		Emu.Pause();
 	return false;

--- a/rpcs3/Emu/Memory/Memory.h
+++ b/rpcs3/Emu/Memory/Memory.h
@@ -405,7 +405,7 @@ public:
 
 		if(mem.IsNULL())
 		{
-			LOGF_ERROR(MEMORY, "ReadLeft[%d] from null block (0x%llx)", size, addr);
+			LOG_ERROR(MEMORY, "ReadLeft[%d] from null block (0x%llx)", size, addr);
 			return;
 		}
 
@@ -418,7 +418,7 @@ public:
 
 		if(mem.IsNULL())
 		{
-			LOGF_ERROR(MEMORY, "WriteLeft[%d] to null block (0x%llx)", size, addr);
+			LOG_ERROR(MEMORY, "WriteLeft[%d] to null block (0x%llx)", size, addr);
 			return;
 		}
 
@@ -431,7 +431,7 @@ public:
 
 		if(mem.IsNULL())
 		{
-			LOGF_ERROR(MEMORY, "ReadRight[%d] from null block (0x%llx)", size, addr);
+			LOG_ERROR(MEMORY, "ReadRight[%d] from null block (0x%llx)", size, addr);
 			return;
 		}
 
@@ -444,7 +444,7 @@ public:
 
 		if(mem.IsNULL())
 		{
-			LOGF_ERROR(MEMORY, "WriteRight[%d] to null block (0x%llx)", size, addr);
+			LOG_ERROR(MEMORY, "WriteRight[%d] to null block (0x%llx)", size, addr);
 			return;
 		}
 
@@ -477,7 +477,7 @@ public:
 	{
 		if(!IsGoodAddr(addr, str.length()))
 		{
-			LOGF_ERROR(MEMORY,"Memory::WriteString error: bad address (0x%llx)", addr);
+			LOG_ERROR(MEMORY,"Memory::WriteString error: bad address (0x%llx)", addr);
 			return;
 		}
 
@@ -527,7 +527,7 @@ public:
 		}
 
 		MemoryBlocks.push_back((new MemoryMirror())->SetRange(GetMemFromAddr(src_addr), dst_addr, size));
-		LOGF_WARNING(MEMORY, "memory mapped 0x%llx to 0x%llx size=0x%x", src_addr, dst_addr, size);
+		LOG_WARNING(MEMORY, "memory mapped 0x%llx to 0x%llx size=0x%x", src_addr, dst_addr, size);
 		return true;
 	}
 

--- a/rpcs3/Emu/SysCalls/Modules/cellAdec.h
+++ b/rpcs3/Emu/SysCalls/Modules/cellAdec.h
@@ -1133,14 +1133,14 @@ public:
 		AVCodec* codec = avcodec_find_decoder(AV_CODEC_ID_ATRAC3P);
 		if (!codec)
 		{
-			LOGF_ERROR(HLE, "AudioDecoder(): avcodec_find_decoder(ATRAC3P) failed");
+			LOG_ERROR(HLE, "AudioDecoder(): avcodec_find_decoder(ATRAC3P) failed");
 			Emu.Pause();
 			return;
 		}
 		fmt = avformat_alloc_context();
 		if (!fmt)
 		{
-			LOGF_ERROR(HLE, "AudioDecoder(): avformat_alloc_context failed");
+			LOG_ERROR(HLE, "AudioDecoder(): avformat_alloc_context failed");
 			Emu.Pause();
 			return;
 		}
@@ -1148,7 +1148,7 @@ public:
 		fmt->pb = avio_alloc_context(io_buf, 4096, 0, this, adecRead, NULL, NULL);
 		if (!fmt->pb)
 		{
-			LOGF_ERROR(HLE, "AudioDecoder(): avio_alloc_context failed");
+			LOG_ERROR(HLE, "AudioDecoder(): avio_alloc_context failed");
 			Emu.Pause();
 			return;
 		}

--- a/rpcs3/Emu/SysCalls/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellAudio.cpp
@@ -50,11 +50,11 @@ int cellAudioInit()
 		
 			if (do_dump && !m_dump.Init())
 			{
-				LOGF_ERROR(HLE, "cellAudioInit(): AudioDumper::Init() failed");
+				LOG_ERROR(HLE, "cellAudioInit(): AudioDumper::Init() failed");
 				return;
 			}
 
-			LOGF_NOTICE(HLE, "Audio thread started");
+			LOG_NOTICE(HLE, "Audio thread started");
 
 			if (Ini.AudioDumpToFile.GetValue())
 				m_dump.WriteHeader();
@@ -146,7 +146,7 @@ int cellAudioInit()
 			{
 				if (Emu.IsStopped())
 				{
-					LOGF_WARNING(HLE, "Audio thread aborted");
+					LOG_WARNING(HLE, "Audio thread aborted");
 					goto abort;
 				}
 
@@ -426,7 +426,7 @@ int cellAudioInit()
 					{
 						if (m_dump.WriteData(&buf8ch, sizeof(buf8ch)) != sizeof(buf8ch)) // write file data
 						{
-							LOGF_ERROR(HLE, "cellAudioInit(): AudioDumper::WriteData() failed");
+							LOG_ERROR(HLE, "cellAudioInit(): AudioDumper::WriteData() failed");
 							goto abort;
 						}
 					}
@@ -434,21 +434,21 @@ int cellAudioInit()
 					{
 						if (m_dump.WriteData(&buf2ch, sizeof(buf2ch)) != sizeof(buf2ch)) // write file data
 						{
-							LOGF_ERROR(HLE, "cellAudioInit(): AudioDumper::WriteData() failed");
+							LOG_ERROR(HLE, "cellAudioInit(): AudioDumper::WriteData() failed");
 							goto abort;
 						}
 					}
 					else
 					{
-						LOGF_ERROR(HLE, "cellAudioInit(): unknown AudioDumper::GetCh() value (%d)", m_dump.GetCh());
+						LOG_ERROR(HLE, "cellAudioInit(): unknown AudioDumper::GetCh() value (%d)", m_dump.GetCh());
 						goto abort;
 					}
 				}
 
-				//LOGF_NOTICE(HLE, "Audio perf: start=%d (access=%d, AddData=%d, events=%d, dump=%d)",
+				//LOG_NOTICE(HLE, "Audio perf: start=%d (access=%d, AddData=%d, events=%d, dump=%d)",
 					//stamp0 - m_config.start_time, stamp1 - stamp0, stamp2 - stamp1, stamp3 - stamp2, get_system_time() - stamp3);
 			}
-			LOGF_NOTICE(HLE, "Audio thread ended");
+			LOG_NOTICE(HLE, "Audio thread ended");
 abort:
 			queue.Push(nullptr);
 			queue_float.Push(nullptr);
@@ -480,7 +480,7 @@ abort:
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "cellAudioInit() aborted");
+			LOG_WARNING(HLE, "cellAudioInit() aborted");
 			return CELL_OK;
 		}
 		Sleep(1);
@@ -505,7 +505,7 @@ int cellAudioQuit()
 		Sleep(1);
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "cellAudioQuit(): aborted");
+			LOG_WARNING(HLE, "cellAudioQuit(): aborted");
 			return CELL_OK;
 		}
 	}

--- a/rpcs3/Emu/SysCalls/Modules/cellDmux.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellDmux.cpp
@@ -47,7 +47,7 @@ u32 dmuxOpen(Demuxer* data)
 
 	thread t("Demuxer[" + std::to_string(dmux_id) + "] Thread", [&]()
 	{
-		LOGF_NOTICE(HLE, "Demuxer thread started (mem=0x%x, size=0x%x, cb=0x%x, arg=0x%x)", dmux.memAddr, dmux.memSize, dmux.cbFunc, dmux.cbArg);
+		LOG_NOTICE(HLE, "Demuxer thread started (mem=0x%x, size=0x%x, cb=0x%x, arg=0x%x)", dmux.memAddr, dmux.memSize, dmux.cbFunc, dmux.cbArg);
 
 		DemuxerTask task;
 		DemuxerStream stream;
@@ -134,7 +134,7 @@ u32 dmuxOpen(Demuxer* data)
 
 						if (!pes.new_au) // temporarily
 						{
-							LOGF_ERROR(HLE, "No pts info found");
+							LOG_ERROR(HLE, "No pts info found");
 						}
 
 						// read additional header:
@@ -149,7 +149,7 @@ u32 dmuxOpen(Demuxer* data)
 							{
 								if (Emu.IsStopped())
 								{
-									LOGF_WARNING(HLE, "esATX[%d] was full, waiting aborted", ch);
+									LOG_WARNING(HLE, "esATX[%d] was full, waiting aborted", ch);
 									return;
 								}
 								Sleep(1);
@@ -166,7 +166,7 @@ u32 dmuxOpen(Demuxer* data)
 
 							es.push(stream, len - pes.size - 3, pes);
 							es.finish(stream);
-							//LOGF_NOTICE(HLE, "*** AT3+ AU sent (len=0x%x, pts=0x%llx)", len - pes.size - 3, pes.pts);
+							//LOG_NOTICE(HLE, "*** AT3+ AU sent (len=0x%x, pts=0x%llx)", len - pes.size - 3, pes.pts);
 							
 							mem_ptr_t<CellDmuxEsMsg> esMsg(a128(dmux.memAddr) + (cb_add ^= 16));
 							esMsg->msgType = CELL_DMUX_ES_MSG_TYPE_AU_FOUND;
@@ -198,7 +198,7 @@ u32 dmuxOpen(Demuxer* data)
 							{
 								if (Emu.IsStopped())
 								{
-									LOGF_WARNING(HLE, "esAVC[%d] was full, waiting aborted", ch);
+									LOG_WARNING(HLE, "esAVC[%d] was full, waiting aborted", ch);
 									return;
 								}
 								Sleep(1);
@@ -236,7 +236,7 @@ u32 dmuxOpen(Demuxer* data)
 
 							if (pes.new_au)
 							{
-								//LOGF_NOTICE(HLE, "*** AVC AU detected (pts=0x%llx, dts=0x%llx)", pes.pts, pes.dts);
+								//LOG_NOTICE(HLE, "*** AVC AU detected (pts=0x%llx, dts=0x%llx)", pes.pts, pes.dts);
 							}
 
 							if (es.isfull())
@@ -268,7 +268,7 @@ u32 dmuxOpen(Demuxer* data)
 				case 0x1dc: case 0x1dd: case 0x1de: case 0x1df:
 					{
 						// unknown
-						LOGF_WARNING(HLE, "Unknown MPEG stream found");
+						LOG_WARNING(HLE, "Unknown MPEG stream found");
 						stream.skip(4);
 						stream.get(len);
 						stream.skip(len);
@@ -277,7 +277,7 @@ u32 dmuxOpen(Demuxer* data)
 
 				case USER_DATA_START_CODE:
 					{
-						LOGF_ERROR(HLE, "USER_DATA_START_CODE found");
+						LOG_ERROR(HLE, "USER_DATA_START_CODE found");
 						return;
 					}
 
@@ -304,7 +304,7 @@ u32 dmuxOpen(Demuxer* data)
 				{
 					if (task.stream.discontinuity)
 					{
-						LOGF_WARNING(HLE, "dmuxSetStream (beginning)");
+						LOG_WARNING(HLE, "dmuxSetStream (beginning)");
 						for (u32 i = 0; i < 192; i++)
 						{
 							if (esALL[i])
@@ -318,13 +318,13 @@ u32 dmuxOpen(Demuxer* data)
 
 					if (updates_count != updates_signaled)
 					{
-						LOGF_ERROR(HLE, "dmuxSetStream: stream update inconsistency (input=%d, signaled=%d)", updates_count, updates_signaled);
+						LOG_ERROR(HLE, "dmuxSetStream: stream update inconsistency (input=%d, signaled=%d)", updates_count, updates_signaled);
 						return;
 					}
 
 					updates_count++;
 					stream = task.stream;
-					//LOGF_NOTICE(HLE, "*** stream updated(addr=0x%x, size=0x%x, discont=%d, userdata=0x%llx)",
+					//LOG_NOTICE(HLE, "*** stream updated(addr=0x%x, size=0x%x, discont=%d, userdata=0x%llx)",
 						//stream.addr, stream.size, stream.discontinuity, stream.userdata);
 
 					dmux.is_running = true;
@@ -357,7 +357,7 @@ u32 dmuxOpen(Demuxer* data)
 			case dmuxClose:
 				{
 					dmux.is_finished = true;
-					LOGF_NOTICE(HLE, "Demuxer thread ended");
+					LOG_NOTICE(HLE, "Demuxer thread ended");
 					return;
 				}
 
@@ -381,7 +381,7 @@ u32 dmuxOpen(Demuxer* data)
 					}
 					else
 					{
-						LOGF_WARNING(HLE, "dmuxEnableEs: (TODO) unsupported filter (0x%x, 0x%x, 0x%x, 0x%x)", es.fidMajor, es.fidMinor, es.sup1, es.sup2);
+						LOG_WARNING(HLE, "dmuxEnableEs: (TODO) unsupported filter (0x%x, 0x%x, 0x%x, 0x%x)", es.fidMajor, es.fidMinor, es.sup1, es.sup2);
 					}
 					es.dmux = &dmux;
 				}
@@ -392,7 +392,7 @@ u32 dmuxOpen(Demuxer* data)
 					ElementaryStream& es = *task.es.es_ptr;
 					if (es.dmux != &dmux)
 					{
-						LOGF_WARNING(HLE, "dmuxDisableEs: invalid elementary stream");
+						LOG_WARNING(HLE, "dmuxDisableEs: invalid elementary stream");
 						break;
 					}
 					for (u32 i = 0; i < 192; i++)
@@ -450,11 +450,11 @@ u32 dmuxOpen(Demuxer* data)
 				break;
 
 			default:
-				LOGF_ERROR(HLE, "Demuxer thread error: unknown task(%d)", task.type);
+				LOG_ERROR(HLE, "Demuxer thread error: unknown task(%d)", task.type);
 				return;
 			}
 		}
-		LOGF_WARNING(HLE, "Demuxer thread aborted");
+		LOG_WARNING(HLE, "Demuxer thread aborted");
 	});
 
 	t.detach();
@@ -598,7 +598,7 @@ int cellDmuxClose(u32 demuxerHandle)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "cellDmuxClose(%d) aborted", demuxerHandle);
+			LOG_WARNING(HLE, "cellDmuxClose(%d) aborted", demuxerHandle);
 			return CELL_OK;
 		}
 
@@ -630,7 +630,7 @@ int cellDmuxSetStream(u32 demuxerHandle, const u32 streamAddress, u32 streamSize
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "cellDmuxSetStream(%d) aborted (waiting)", demuxerHandle);
+			LOG_WARNING(HLE, "cellDmuxSetStream(%d) aborted (waiting)", demuxerHandle);
 			return CELL_OK;
 		}
 		Sleep(1);
@@ -649,12 +649,12 @@ int cellDmuxSetStream(u32 demuxerHandle, const u32 streamAddress, u32 streamSize
 	u32 addr;
 	if (!dmux->fbSetStream.Pop(addr))
 	{
-		LOGF_WARNING(HLE, "cellDmuxSetStream(%d) aborted (fbSetStream.Pop())", demuxerHandle);
+		LOG_WARNING(HLE, "cellDmuxSetStream(%d) aborted (fbSetStream.Pop())", demuxerHandle);
 		return CELL_OK;
 	}
 	if (addr != info.addr)
 	{
-		LOGF_ERROR(HLE, "cellDmuxSetStream(%d): wrong stream queued (right=0x%x, queued=0x%x)", demuxerHandle, info.addr, addr);
+		LOG_ERROR(HLE, "cellDmuxSetStream(%d): wrong stream queued (right=0x%x, queued=0x%x)", demuxerHandle, info.addr, addr);
 		Emu.Pause();
 	}
 	return CELL_OK;
@@ -690,12 +690,12 @@ int cellDmuxResetStreamAndWaitDone(u32 demuxerHandle)
 	u32 addr;
 	if (!dmux->fbSetStream.Pop(addr))
 	{
-		LOGF_WARNING(HLE, "cellDmuxResetStreamAndWaitDone(%d) aborted (fbSetStream.Pop())", demuxerHandle);
+		LOG_WARNING(HLE, "cellDmuxResetStreamAndWaitDone(%d) aborted (fbSetStream.Pop())", demuxerHandle);
 		return CELL_OK;
 	}
 	if (addr != 0)
 	{
-		LOGF_ERROR(HLE, "cellDmuxResetStreamAndWaitDone(%d): wrong stream queued (0x%x)", demuxerHandle, addr);
+		LOG_ERROR(HLE, "cellDmuxResetStreamAndWaitDone(%d): wrong stream queued (0x%x)", demuxerHandle, addr);
 		Emu.Pause();
 	}
 	return CELL_OK;

--- a/rpcs3/Emu/SysCalls/Modules/cellSync.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSync.cpp
@@ -93,7 +93,7 @@ int cellSyncMutexLock(mem_ptr_t<CellSyncMutex> mutex)
 		Sleep(1);
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "cellSyncMutexLock(mutex=0x%x) aborted", mutex.GetAddr());
+			LOG_WARNING(HLE, "cellSyncMutexLock(mutex=0x%x) aborted", mutex.GetAddr());
 			break;
 		}
 	}

--- a/rpcs3/Emu/SysCalls/Modules/cellSysutil_SaveData.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSysutil_SaveData.cpp
@@ -230,7 +230,7 @@ s32 modifySaveDataFiles(mem_func_ptr_t<CellSaveDataFileCallback>& funcFile, mem_
 	{
 		funcFile(result.GetAddr(), fileGet.GetAddr(), fileSet.GetAddr());
 		if (result->result < 0)	{
-			LOGF_ERROR(HLE, "modifySaveDataFiles: CellSaveDataFileCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+			LOG_ERROR(HLE, "modifySaveDataFiles: CellSaveDataFileCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 			return CELL_SAVEDATA_ERROR_CBRESULT;
 		}
 		if (result->result == CELL_SAVEDATA_CBRESULT_OK_LAST) {
@@ -251,7 +251,7 @@ s32 modifySaveDataFiles(mem_func_ptr_t<CellSaveDataFileCallback>& funcFile, mem_
 		case CELL_SAVEDATA_FILETYPE_CONTENT_SND0:   filepath += "SND0.AT3";  break;
 
 		default:
-			LOGF_ERROR(HLE, "modifySaveDataFiles: Unknown fileType! Aborting...");
+			LOG_ERROR(HLE, "modifySaveDataFiles: Unknown fileType! Aborting...");
 			return CELL_SAVEDATA_ERROR_PARAM;
 		}
 
@@ -274,11 +274,11 @@ s32 modifySaveDataFiles(mem_func_ptr_t<CellSaveDataFileCallback>& funcFile, mem_
 			break;
 
 		case CELL_SAVEDATA_FILEOP_WRITE_NOTRUNC:
-			LOGF_WARNING(HLE, "modifySaveDataFiles: File operation CELL_SAVEDATA_FILEOP_WRITE_NOTRUNC not yet implemented");
+			LOG_WARNING(HLE, "modifySaveDataFiles: File operation CELL_SAVEDATA_FILEOP_WRITE_NOTRUNC not yet implemented");
 			break;
 
 		default:
-			LOGF_ERROR(HLE, "modifySaveDataFiles: Unknown fileOperation! Aborting...");
+			LOG_ERROR(HLE, "modifySaveDataFiles: Unknown fileOperation! Aborting...");
 			return CELL_SAVEDATA_ERROR_PARAM;
 		}
 
@@ -339,7 +339,7 @@ int cellSaveDataListSave2(u32 version, mem_ptr_t<CellSaveDataSetList> setList, m
 
 	funcList(result.GetAddr(), listGet.GetAddr(), listSet.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataListSave2: CellSaveDataListCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataListSave2: CellSaveDataListCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	if (!listSet->fixedList.IsGood())
@@ -349,7 +349,7 @@ int cellSaveDataListSave2(u32 version, mem_ptr_t<CellSaveDataSetList> setList, m
 	if (listSet->newData.IsGood())
 		addNewSaveDataEntry(saveEntries, (u32)listSet->newData.GetAddr());
 	if (saveEntries.size() == 0) {
-		LOGF_WARNING(HLE, "cellSaveDataListSave2: No save entries found!"); // TODO: Find a better way to handle this error
+		LOG_WARNING(HLE, "cellSaveDataListSave2: No save entries found!"); // TODO: Find a better way to handle this error
 		return CELL_SAVEDATA_RET_OK;
 	}
 
@@ -362,7 +362,7 @@ int cellSaveDataListSave2(u32 version, mem_ptr_t<CellSaveDataSetList> setList, m
 	funcStat(result.GetAddr(), statGet.GetAddr(), statSet.GetAddr());
 	Memory.Free(statGet->fileList.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataListLoad2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataListLoad2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	/*if (statSet->setParam.IsGood())
@@ -424,7 +424,7 @@ int cellSaveDataListLoad2(u32 version, mem_ptr_t<CellSaveDataSetList> setList, m
 
 	funcList(result.GetAddr(), listGet.GetAddr(), listSet.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataListLoad2: CellSaveDataListCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataListLoad2: CellSaveDataListCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	if (!listSet->fixedList.IsGood())
@@ -434,7 +434,7 @@ int cellSaveDataListLoad2(u32 version, mem_ptr_t<CellSaveDataSetList> setList, m
 	if (listSet->newData.IsGood())
 		addNewSaveDataEntry(saveEntries, (u32)listSet->newData.GetAddr());
 	if (saveEntries.size() == 0) {
-		LOGF_WARNING(HLE, "cellSaveDataListLoad2: No save entries found!"); // TODO: Find a better way to handle this error
+		LOG_WARNING(HLE, "cellSaveDataListLoad2: No save entries found!"); // TODO: Find a better way to handle this error
 		return CELL_SAVEDATA_RET_OK;
 	}
 
@@ -447,7 +447,7 @@ int cellSaveDataListLoad2(u32 version, mem_ptr_t<CellSaveDataSetList> setList, m
 	funcStat(result.GetAddr(), statGet.GetAddr(), statSet.GetAddr());
 	Memory.Free(statGet->fileList.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataListLoad2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataListLoad2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	/*if (statSet->setParam.IsGood())
@@ -508,7 +508,7 @@ int cellSaveDataFixedSave2(u32 version,  mem_ptr_t<CellSaveDataSetList> setList,
 	}
 	funcFixed(result.GetAddr(), listGet.GetAddr(), fixedSet.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataFixedSave2: CellSaveDataFixedCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataFixedSave2: CellSaveDataFixedCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	setSaveDataFixed(saveEntries, fixedSet.GetAddr());
@@ -519,7 +519,7 @@ int cellSaveDataFixedSave2(u32 version,  mem_ptr_t<CellSaveDataSetList> setList,
 	funcStat(result.GetAddr(), statGet.GetAddr(), statSet.GetAddr());
 	Memory.Free(statGet->fileList.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataFixedSave2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataFixedSave2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	/*if (statSet->setParam.IsGood())
@@ -580,7 +580,7 @@ int cellSaveDataFixedLoad2(u32 version,  mem_ptr_t<CellSaveDataSetList> setList,
 	}
 	funcFixed(result.GetAddr(), listGet.GetAddr(), fixedSet.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataFixedLoad2: CellSaveDataFixedCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataFixedLoad2: CellSaveDataFixedCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	setSaveDataFixed(saveEntries, fixedSet.GetAddr());
@@ -591,7 +591,7 @@ int cellSaveDataFixedLoad2(u32 version,  mem_ptr_t<CellSaveDataSetList> setList,
 	funcStat(result.GetAddr(), statGet.GetAddr(), statSet.GetAddr());
 	Memory.Free(statGet->fileList.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataFixedLoad2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataFixedLoad2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	/*if (statSet->setParam.IsGood())
@@ -647,7 +647,7 @@ int cellSaveDataAutoSave2(u32 version, u32 dirName_addr, u32 errDialog, mem_ptr_
 
 	Memory.Free(statGet->fileList.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataAutoSave2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataAutoSave2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	/*if (statSet->setParam.IsGood())
@@ -690,7 +690,7 @@ int cellSaveDataAutoLoad2(u32 version, u32 dirName_addr, u32 errDialog, mem_ptr_
 
 	// The target entry does not exist
 	if (saveEntries.size() == 0) {
-		LOGF_WARNING(HLE, "cellSaveDataAutoLoad2: Couldn't find save entry (%s)", dirName.c_str());
+		LOG_WARNING(HLE, "cellSaveDataAutoLoad2: Couldn't find save entry (%s)", dirName.c_str());
 		return CELL_OK; // TODO: Can anyone check the actual behaviour of a PS3 when saves are not found?
 	}
 
@@ -700,7 +700,7 @@ int cellSaveDataAutoLoad2(u32 version, u32 dirName_addr, u32 errDialog, mem_ptr_
 
 	Memory.Free(statGet->fileList.GetAddr());
 	if (result->result < 0)	{
-		LOGF_ERROR(HLE, "cellSaveDataAutoLoad2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
+		LOG_ERROR(HLE, "cellSaveDataAutoLoad2: CellSaveDataStatCallback failed."); // TODO: Once we verify that the entire SysCall is working, delete this debug error message.
 		return CELL_SAVEDATA_ERROR_CBRESULT;
 	}
 	/*if (statSet->setParam.IsGood())

--- a/rpcs3/Emu/SysCalls/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellVdec.cpp
@@ -35,7 +35,7 @@ next:
 		{
 			if (Emu.IsStopped())
 			{
-				LOGF_WARNING(HLE, "vdecRead(): aborted");
+				LOG_WARNING(HLE, "vdecRead(): aborted");
 				return 0;
 			}
 			Sleep(1);
@@ -52,7 +52,7 @@ next:
 			{
 				if (!Memory.CopyToReal(buf, vdec.reader.addr, vdec.reader.size))
 				{
-					LOGF_ERROR(HLE, "vdecRead(): data reading failed (reader.size=0x%x)", vdec.reader.size);
+					LOG_ERROR(HLE, "vdecRead(): data reading failed (reader.size=0x%x)", vdec.reader.size);
 					Emu.Pause();
 					return 0;
 				}
@@ -71,11 +71,11 @@ next:
 
 				vdec.reader.addr = vdec.task.addr;
 				vdec.reader.size = vdec.task.size;
-				//LOGF_NOTICE(HLE, "Video AU: size = 0x%x, pts = 0x%llx, dts = 0x%llx", vdec.task.size, vdec.task.pts, vdec.task.dts);
+				//LOG_NOTICE(HLE, "Video AU: size = 0x%x, pts = 0x%llx, dts = 0x%llx", vdec.task.size, vdec.task.pts, vdec.task.dts);
 			}
 			break;
 		default:
-			LOGF_ERROR(HLE, "vdecRead(): sequence error (task %d)", vdec.job.Peek().type);
+			LOG_ERROR(HLE, "vdecRead(): sequence error (task %d)", vdec.job.Peek().type);
 			return 0;
 		}
 		
@@ -92,7 +92,7 @@ next:
 	}
 	else if (!Memory.CopyToReal(buf, vdec.reader.addr, buf_size))
 	{
-		LOGF_ERROR(HLE, "vdecRead(): data reading failed (buf_size=0x%x)", buf_size);
+		LOG_ERROR(HLE, "vdecRead(): data reading failed (buf_size=0x%x)", buf_size);
 		Emu.Pause();
 		return 0;
 	}
@@ -136,7 +136,7 @@ u32 vdecOpen(VideoDecoder* data)
 
 	thread t("Video Decoder[" + std::to_string(vdec_id) + "] Thread", [&]()
 	{
-		LOGF_NOTICE(HLE, "Video Decoder thread started");
+		LOG_NOTICE(HLE, "Video Decoder thread started");
 
 		VdecTask& task = vdec.task;
 
@@ -169,7 +169,7 @@ u32 vdecOpen(VideoDecoder* data)
 			case vdecStartSeq:
 				{
 					// TODO: reset data
-					LOGF_WARNING(HLE, "vdecStartSeq:");
+					LOG_WARNING(HLE, "vdecStartSeq:");
 
 					vdec.reader.addr = 0;
 					vdec.reader.size = 0;
@@ -181,7 +181,7 @@ u32 vdecOpen(VideoDecoder* data)
 			case vdecEndSeq:
 				{
 					// TODO: finalize
-					LOGF_WARNING(HLE, "vdecEndSeq:");
+					LOG_WARNING(HLE, "vdecEndSeq:");
 
 					vdec.vdecCb->ExecAsCallback(vdec.cbFunc, false, vdec.id, CELL_VDEC_MSG_TYPE_SEQDONE, CELL_OK, vdec.cbArg);
 					/*Callback cb;
@@ -202,13 +202,13 @@ u32 vdecOpen(VideoDecoder* data)
 
 					if (task.mode != CELL_VDEC_DEC_MODE_NORMAL)
 					{
-						LOGF_ERROR(HLE, "vdecDecodeAu: unsupported decoding mode(%d)", task.mode);
+						LOG_ERROR(HLE, "vdecDecodeAu: unsupported decoding mode(%d)", task.mode);
 						break;
 					}
 
 					vdec.reader.addr = task.addr;
 					vdec.reader.size = task.size;
-					//LOGF_NOTICE(HLE, "Video AU: size = 0x%x, pts = 0x%llx, dts = 0x%llx", task.size, task.pts, task.dts);
+					//LOG_NOTICE(HLE, "Video AU: size = 0x%x, pts = 0x%llx, dts = 0x%llx", task.size, task.pts, task.dts);
 
 					if (vdec.just_started)
 					{
@@ -249,33 +249,33 @@ u32 vdecOpen(VideoDecoder* data)
 						err = avformat_open_input(&vdec.fmt, NULL, av_find_input_format("mpeg"), NULL);
 						if (err)
 						{
-							LOGF_ERROR(HLE, "vdecDecodeAu: avformat_open_input() failed");
+							LOG_ERROR(HLE, "vdecDecodeAu: avformat_open_input() failed");
 							Emu.Pause();
 							break;
 						}
 						AVCodec* codec = avcodec_find_decoder(AV_CODEC_ID_H264); // ???
 						if (!codec)
 						{
-							LOGF_ERROR(HLE, "vdecDecodeAu: avcodec_find_decoder() failed");
+							LOG_ERROR(HLE, "vdecDecodeAu: avcodec_find_decoder() failed");
 							Emu.Pause();
 							break;
 						}
 						/*err = avformat_find_stream_info(vdec.fmt, NULL);
 						if (err)
 						{
-							LOGF_ERROR(HLE, "vdecDecodeAu: avformat_find_stream_info() failed");
+							LOG_ERROR(HLE, "vdecDecodeAu: avformat_find_stream_info() failed");
 							Emu.Pause();
 							break;
 						}
 						if (!vdec.fmt->nb_streams)
 						{
-							LOGF_ERROR(HLE, "vdecDecodeAu: no stream found");
+							LOG_ERROR(HLE, "vdecDecodeAu: no stream found");
 							Emu.Pause();
 							break;
 						}*/
 						if (!avformat_new_stream(vdec.fmt, codec))
 						{
-							LOGF_ERROR(HLE, "vdecDecodeAu: avformat_new_stream() failed");
+							LOG_ERROR(HLE, "vdecDecodeAu: avformat_new_stream() failed");
 							Emu.Pause();
 							break;
 						}
@@ -290,7 +290,7 @@ u32 vdecOpen(VideoDecoder* data)
 						}
 						if (err)
 						{
-							LOGF_ERROR(HLE, "vdecDecodeAu: avcodec_open2() failed");
+							LOG_ERROR(HLE, "vdecDecodeAu: avcodec_open2() failed");
 							Emu.Pause();
 							break;
 						}
@@ -305,7 +305,7 @@ u32 vdecOpen(VideoDecoder* data)
 					{
 						if (Emu.IsStopped())
 						{
-							LOGF_WARNING(HLE, "vdecDecodeAu: aborted");
+							LOG_WARNING(HLE, "vdecDecodeAu: aborted");
 							return;
 						}
 
@@ -338,7 +338,7 @@ u32 vdecOpen(VideoDecoder* data)
 
 						if (!frame.data)
 						{
-							LOGF_ERROR(HLE, "vdecDecodeAu: av_frame_alloc() failed");
+							LOG_ERROR(HLE, "vdecDecodeAu: av_frame_alloc() failed");
 							Emu.Pause();
 							break;
 						}
@@ -351,7 +351,7 @@ u32 vdecOpen(VideoDecoder* data)
 						{
 							if (!last_frame && decode < 0)
 							{
-								LOGF_ERROR(HLE, "vdecDecodeAu: AU decoding error(0x%x)", decode);
+								LOG_ERROR(HLE, "vdecDecodeAu: AU decoding error(0x%x)", decode);
 							}
 							if (!got_picture && vdec.reader.size == 0) break; // video end?
 						}
@@ -374,7 +374,7 @@ u32 vdecOpen(VideoDecoder* data)
 							frame.dts = (frame.pts - vdec.first_pts) + vdec.first_dts;
 							frame.userdata = task.userData;
 
-							//LOGF_NOTICE(HLE, "got picture (pts=0x%llx, dts=0x%llx)", frame.pts, frame.dts);
+							//LOG_NOTICE(HLE, "got picture (pts=0x%llx, dts=0x%llx)", frame.pts, frame.dts);
 
 							vdec.frames.Push(frame); // !!!!!!!!
 							frame.data = nullptr; // to prevent destruction
@@ -398,23 +398,23 @@ u32 vdecOpen(VideoDecoder* data)
 			case vdecClose:
 				{
 					vdec.is_finished = true;
-					LOGF_NOTICE(HLE, "Video Decoder thread ended");
+					LOG_NOTICE(HLE, "Video Decoder thread ended");
 					return;
 				}
 
 			case vdecSetFrameRate:
 				{
-					LOGF_ERROR(HLE, "TODO: vdecSetFrameRate(%d)", task.frc);
+					LOG_ERROR(HLE, "TODO: vdecSetFrameRate(%d)", task.frc);
 				}
 				break;
 
 			default:
-				LOGF_ERROR(HLE, "Video Decoder thread error: unknown task(%d)", task.type);
+				LOG_ERROR(HLE, "Video Decoder thread error: unknown task(%d)", task.type);
 			}
 		}
 
 		vdec.is_finished = true;
-		LOGF_WARNING(HLE, "Video Decoder thread aborted");
+		LOG_WARNING(HLE, "Video Decoder thread aborted");
 	});
 
 	t.detach();
@@ -502,7 +502,7 @@ int cellVdecClose(u32 handle)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "cellVdecClose(%d) aborted", handle);
+			LOG_WARNING(HLE, "cellVdecClose(%d) aborted", handle);
 			break;
 		}
 		Sleep(1);
@@ -553,7 +553,7 @@ int cellVdecEndSeq(u32 handle)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "cellVdecEndSeq(%d) aborted", handle);
+			LOG_WARNING(HLE, "cellVdecEndSeq(%d) aborted", handle);
 			return CELL_OK;
 		}
 		Sleep(1);
@@ -751,13 +751,13 @@ int cellVdecGetPicItem(u32 handle, mem32_t picItem_ptr)
 		}
 		else
 		{
-			LOGF_ERROR(HLE, "cellVdecGetPicItem: unsupported time_base.den (%d)", vdec->ctx->time_base.den);
+			LOG_ERROR(HLE, "cellVdecGetPicItem: unsupported time_base.den (%d)", vdec->ctx->time_base.den);
 			Emu.Pause();
 		}
 	}
 	else
 	{
-		LOGF_ERROR(HLE, "cellVdecGetPicItem: unsupported time_base.num (%d)", vdec->ctx->time_base.num);
+		LOG_ERROR(HLE, "cellVdecGetPicItem: unsupported time_base.num (%d)", vdec->ctx->time_base.num);
 		Emu.Pause();
 	}
 	avc->fixed_frame_rate_flag = true;

--- a/rpcs3/Emu/SysCalls/Modules/cellVdec.h
+++ b/rpcs3/Emu/SysCalls/Modules/cellVdec.h
@@ -741,14 +741,14 @@ public:
 		AVCodec* codec = avcodec_find_decoder(AV_CODEC_ID_H264);
 		if (!codec)
 		{
-			LOGF_ERROR(HLE, "VideoDecoder(): avcodec_find_decoder(H264) failed");
+			LOG_ERROR(HLE, "VideoDecoder(): avcodec_find_decoder(H264) failed");
 			Emu.Pause();
 			return;
 		}
 		fmt = avformat_alloc_context();
 		if (!fmt)
 		{
-			LOGF_ERROR(HLE, "VideoDecoder(): avformat_alloc_context failed");
+			LOG_ERROR(HLE, "VideoDecoder(): avformat_alloc_context failed");
 			Emu.Pause();
 			return;
 		}
@@ -756,7 +756,7 @@ public:
 		fmt->pb = avio_alloc_context(io_buf, 4096, 0, this, vdecRead, NULL, NULL);
 		if (!fmt->pb)
 		{
-			LOGF_ERROR(HLE, "VideoDecoder(): avio_alloc_context failed");
+			LOG_ERROR(HLE, "VideoDecoder(): avio_alloc_context failed");
 			Emu.Pause();
 			return;
 		}

--- a/rpcs3/Emu/SysCalls/Modules/cellVpost.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellVpost.cpp
@@ -38,7 +38,7 @@ u32 vpostOpen(VpostInstance* data)
 {
 	u32 id = cellVpost->GetNewId(data);
 
-	LOGF_NOTICE(HLE, "*** Vpost instance created (to_rgba=%d): id = %d", data->to_rgba, id);
+	LOG_NOTICE(HLE, "*** Vpost instance created (to_rgba=%d): id = %d", data->to_rgba, id);
 
 	return id;
 }
@@ -123,15 +123,15 @@ int cellVpostExec(u32 handle, const u32 inPicBuff_addr, const mem_ptr_t<CellVpos
 	}
 
 	ctrlParam->inWindow; // ignored
-	if (ctrlParam->inWindow.x) LOGF_WARNING(HLE, "*** inWindow.x = %d", (u32)ctrlParam->inWindow.x);
-	if (ctrlParam->inWindow.y) LOGF_WARNING(HLE, "*** inWindow.y = %d", (u32)ctrlParam->inWindow.y);
-	if (ctrlParam->inWindow.width != w) LOGF_WARNING(HLE, "*** inWindow.width = %d", (u32)ctrlParam->inWindow.width);
-	if (ctrlParam->inWindow.height != h) LOGF_WARNING(HLE, "*** inWindow.height = %d", (u32)ctrlParam->inWindow.height);
+	if (ctrlParam->inWindow.x) LOG_WARNING(HLE, "*** inWindow.x = %d", (u32)ctrlParam->inWindow.x);
+	if (ctrlParam->inWindow.y) LOG_WARNING(HLE, "*** inWindow.y = %d", (u32)ctrlParam->inWindow.y);
+	if (ctrlParam->inWindow.width != w) LOG_WARNING(HLE, "*** inWindow.width = %d", (u32)ctrlParam->inWindow.width);
+	if (ctrlParam->inWindow.height != h) LOG_WARNING(HLE, "*** inWindow.height = %d", (u32)ctrlParam->inWindow.height);
 	ctrlParam->outWindow; // ignored
-	if (ctrlParam->outWindow.x) LOGF_WARNING(HLE, "*** outWindow.x = %d", (u32)ctrlParam->outWindow.x);
-	if (ctrlParam->outWindow.y) LOGF_WARNING(HLE, "*** outWindow.y = %d", (u32)ctrlParam->outWindow.y);
-	if (ctrlParam->outWindow.width != ow) LOGF_WARNING(HLE, "*** outWindow.width = %d", (u32)ctrlParam->outWindow.width);
-	if (ctrlParam->outWindow.height != oh) LOGF_WARNING(HLE, "*** outWindow.height = %d", (u32)ctrlParam->outWindow.height);
+	if (ctrlParam->outWindow.x) LOG_WARNING(HLE, "*** outWindow.x = %d", (u32)ctrlParam->outWindow.x);
+	if (ctrlParam->outWindow.y) LOG_WARNING(HLE, "*** outWindow.y = %d", (u32)ctrlParam->outWindow.y);
+	if (ctrlParam->outWindow.width != ow) LOG_WARNING(HLE, "*** outWindow.width = %d", (u32)ctrlParam->outWindow.width);
+	if (ctrlParam->outWindow.height != oh) LOG_WARNING(HLE, "*** outWindow.height = %d", (u32)ctrlParam->outWindow.height);
 	ctrlParam->execType; // ignored
 	ctrlParam->scalerType; // ignored
 	ctrlParam->ipcType; // ignored

--- a/rpcs3/Emu/SysCalls/Modules/sys_fs.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sys_fs.cpp
@@ -209,7 +209,7 @@ void fsAioRead(u32 fd, mem_ptr_t<CellFsAio> aio, int xid, mem_func_ptr_t<void (*
 fin:
 	file.Seek(old_pos);
 
-	LOGF_WARNING(HLE, "*** fsAioRead(fd=%d, offset=0x%llx, buf_addr=0x%x, size=0x%x, error=0x%x, res=0x%x, xid=0x%x [%s])",
+	LOG_WARNING(HLE, "*** fsAioRead(fd=%d, offset=0x%llx, buf_addr=0x%x, size=0x%x, error=0x%x, res=0x%x, xid=0x%x [%s])",
 		fd, (u64)aio->offset, buf_addr, (u64)aio->size, error, res, xid, orig_file->GetPath().c_str());
 
 	if (func) // start callback thread
@@ -223,7 +223,7 @@ fin:
 		Sleep(1);
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "fsAioRead() aborted");
+			LOG_WARNING(HLE, "fsAioRead() aborted");
 			break;
 		}
 	}*/

--- a/rpcs3/Emu/SysCalls/Static.cpp
+++ b/rpcs3/Emu/SysCalls/Static.cpp
@@ -54,14 +54,14 @@ void StaticFuncManager::StaticAnalyse(void* ptr, u32 size, u32 base)
 							k--;
 							if (can_skip) // cannot define this behaviour properly
 							{
-								LOGF_WARNING(LOADER, "StaticAnalyse(): can_skip = %d (unchanged)", can_skip);
+								LOG_WARNING(LOADER, "StaticAnalyse(): can_skip = %d (unchanged)", can_skip);
 							}
 						}
 						else
 						{
 							if (can_skip) // cannot define this behaviour properly
 							{
-								LOGF_WARNING(LOADER, "StaticAnalyse(): can_skip = %d (set to 0)", can_skip);
+								LOG_WARNING(LOADER, "StaticAnalyse(): can_skip = %d (set to 0)", can_skip);
 								can_skip = 0;
 							}
 						}
@@ -85,7 +85,7 @@ void StaticFuncManager::StaticAnalyse(void* ptr, u32 size, u32 base)
 				}
 				if (found)
 				{
-					LOGF_NOTICE(LOADER, "Function '%s' hooked (addr=0x%x)", m_static_funcs_list[j]->name, i * 4 + base);
+					LOG_NOTICE(LOADER, "Function '%s' hooked (addr=0x%x)", m_static_funcs_list[j]->name, i * 4 + base);
 					m_static_funcs_list[j]->found++;
 					data[i+0] = re32(0x39600000 | j); // li r11, j
 					data[i+1] = se32(0x44000003); // sc 3
@@ -129,7 +129,7 @@ void StaticFuncManager::StaticAnalyse(void* ptr, u32 size, u32 base)
 					if (count == 0)
 					{
 						res |= GSR_MISSING;
-						LOGF_ERROR(LOADER, "Function '%s' not found", m_static_funcs_list[j]->name);
+						LOG_ERROR(LOADER, "Function '%s' not found", m_static_funcs_list[j]->name);
 					}
 					else if (count > 1)
 					{
@@ -146,7 +146,7 @@ void StaticFuncManager::StaticAnalyse(void* ptr, u32 size, u32 base)
 							if (m_static_funcs_list[k]->found)
 							{
 								res |= GSR_EXCESS;
-								LOGF_ERROR(LOADER, "Function '%s' hooked twice", m_static_funcs_list[j]->name);
+								LOG_ERROR(LOADER, "Function '%s' hooked twice", m_static_funcs_list[j]->name);
 							}
 						}
 					}
@@ -154,7 +154,7 @@ void StaticFuncManager::StaticAnalyse(void* ptr, u32 size, u32 base)
 				else
 				{
 					res |= GSR_EXCESS;
-					LOGF_ERROR(LOADER, "Function '%s' hooked twice", m_static_funcs_list[j]->name);
+					LOG_ERROR(LOADER, "Function '%s' hooked twice", m_static_funcs_list[j]->name);
 				}
 			}
 
@@ -170,11 +170,11 @@ void StaticFuncManager::StaticAnalyse(void* ptr, u32 size, u32 base)
 
 			if (res == GSR_SUCCESS)
 			{
-				LOGF_SUCCESS(LOADER, "Function group [%s] successfully hooked", std::string(name, 9).c_str());
+				LOG_SUCCESS(LOADER, "Function group [%s] successfully hooked", std::string(name, 9).c_str());
 			}
 			else
 			{
-				LOGF_ERROR(LOADER, "Function group [%s] failed:%s%s", std::string(name, 9).c_str(),
+				LOG_ERROR(LOADER, "Function group [%s] failed:%s%s", std::string(name, 9).c_str(),
 					(res & GSR_MISSING ? " missing;" : ""),
 					(res & GSR_EXCESS ? " excess;" : ""));
 			}
@@ -190,7 +190,7 @@ void StaticFuncManager::StaticExecute(u32 code)
 	}
 	else
 	{
-		LOGF_ERROR(LOADER, "StaticExecute(%d): unknown function or illegal opcode", code);
+		LOG_ERROR(LOADER, "StaticExecute(%d): unknown function or illegal opcode", code);
 	}
 }
 

--- a/rpcs3/Emu/SysCalls/SysCalls.cpp
+++ b/rpcs3/Emu/SysCalls/SysCalls.cpp
@@ -553,7 +553,7 @@ void default_syscall()
 	{
 		//tty
 		case 988:
-			LOGF_WARNING(HLE, "SysCall 988! r3: 0x%llx, r4: 0x%llx, pc: 0x%llx",
+			LOG_WARNING(HLE, "SysCall 988! r3: 0x%llx, r4: 0x%llx, pc: 0x%llx",
 				CPU.GPR[3], CPU.GPR[4], CPU.PC);
 			RESULT(0);
 		return;
@@ -561,16 +561,16 @@ void default_syscall()
 		case 999:
 			dump_enable = !dump_enable;
 			Emu.Pause();
-			LOGF_WARNING(HLE, "Dump %s", (dump_enable ? "enabled" : "disabled"));
+			LOG_WARNING(HLE, "Dump %s", (dump_enable ? "enabled" : "disabled"));
 		return;
 
 		case 1000:
 			Ini.HLELogging.SetValue(!Ini.HLELogging.GetValue());
-			LOGF_WARNING(HLE, "Log %s", (Ini.HLELogging.GetValue() ? "enabled" : "disabled"));
+			LOG_WARNING(HLE, "Log %s", (Ini.HLELogging.GetValue() ? "enabled" : "disabled"));
 		return;
 	}
 
-	LOGF_ERROR(HLE, "Unknown syscall: %d - %08x", code, code);
+	LOG_ERROR(HLE, "Unknown syscall: %d - %08x", code, code);
 	RESULT(0);
 	return;
 }
@@ -589,7 +589,7 @@ void SysCalls::DoSyscall(u32 code)
 	}
 
 
-	LOGF_ERROR(HLE, "TODO: %s", GetHLEFuncName(code).c_str());
+	LOG_ERROR(HLE, "TODO: %s", GetHLEFuncName(code).c_str());
 	declCPU();
 	RESULT(0);
 }

--- a/rpcs3/Emu/SysCalls/lv2/SC_Condition.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Condition.cpp
@@ -85,7 +85,7 @@ int sys_cond_signal(u32 cond_id)
 
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_cond_signal(id=%d) aborted", cond_id);
+			LOG_WARNING(HLE, "sys_cond_signal(id=%d) aborted", cond_id);
 		}
 	}
 
@@ -113,7 +113,7 @@ int sys_cond_signal_all(u32 cond_id)
 
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_cond_signal_all(id=%d) aborted", cond_id);
+			LOG_WARNING(HLE, "sys_cond_signal_all(id=%d) aborted", cond_id);
 			break;
 		}
 	}
@@ -153,7 +153,7 @@ int sys_cond_signal_to(u32 cond_id, u32 thread_id)
 
 	if (Emu.IsStopped())
 	{
-		LOGF_WARNING(HLE, "sys_cond_signal_to(id=%d, to=%d) aborted", cond_id, thread_id);
+		LOG_WARNING(HLE, "sys_cond_signal_to(id=%d, to=%d) aborted", cond_id, thread_id);
 	}
 
 	return CELL_OK;
@@ -236,6 +236,6 @@ int sys_cond_wait(u32 cond_id, u64 timeout)
 	}
 
 abort:
-	LOGF_WARNING(HLE, "sys_cond_wait(id=%d) aborted", cond_id);
+	LOG_WARNING(HLE, "sys_cond_wait(id=%d) aborted", cond_id);
 	return CELL_OK;
 }

--- a/rpcs3/Emu/SysCalls/lv2/SC_Event.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Event.cpp
@@ -95,7 +95,7 @@ int sys_event_queue_destroy(u32 equeue_id, int mode)
 		Sleep(1);
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_event_queue_destroy(equeue=%d) aborted", equeue_id);
+			LOG_WARNING(HLE, "sys_event_queue_destroy(equeue=%d) aborted", equeue_id);
 			break;
 		}
 	}
@@ -223,7 +223,7 @@ int sys_event_queue_receive(u32 equeue_id, mem_ptr_t<sys_event_data> event, u64 
 		Sleep(1);
 		if (counter++ > timeout || Emu.IsStopped())
 		{
-			if (Emu.IsStopped()) LOGF_WARNING(HLE, "sys_event_queue_receive(equeue=%d) aborted", equeue_id);
+			if (Emu.IsStopped()) LOG_WARNING(HLE, "sys_event_queue_receive(equeue=%d) aborted", equeue_id);
 			eq->sq.invalidate(tid);
 			return CELL_ETIMEDOUT;
 		}

--- a/rpcs3/Emu/SysCalls/lv2/SC_Event_flag.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Event_flag.cpp
@@ -197,7 +197,7 @@ int sys_event_flag_wait(u32 eflag_id, u64 bitptn, u32 mode, mem64_t result, u64 
 		}
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_event_flag_wait(id=%d) aborted", eflag_id);
+			LOG_WARNING(HLE, "sys_event_flag_wait(id=%d) aborted", eflag_id);
 			return CELL_OK;
 		}
 	}
@@ -324,7 +324,7 @@ int sys_event_flag_cancel(u32 eflag_id, mem32_t num)
 
 	if (Emu.IsStopped())
 	{
-		LOGF_WARNING(HLE, "sys_event_flag_cancel(id=%d) aborted", eflag_id);
+		LOG_WARNING(HLE, "sys_event_flag_cancel(id=%d) aborted", eflag_id);
 		return CELL_OK;
 	}
 

--- a/rpcs3/Emu/SysCalls/lv2/SC_FileSystem.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_FileSystem.cpp
@@ -126,7 +126,7 @@ int cellFsOpen(u32 path_addr, int flags, mem32_t fd, mem32_t arg, u64 size)
 	}
 
 	fd = sys_fs->GetNewId(stream, IDFlag_File);
-	LOGF_WARNING(HLE, "*** cellFsOpen(path=\"%s\"): fd = %d", path.c_str(), fd.GetValue());
+	LOG_WARNING(HLE, "*** cellFsOpen(path=\"%s\"): fd = %d", path.c_str(), fd.GetValue());
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/SysCalls/lv2/SC_Lwcond.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Lwcond.cpp
@@ -95,7 +95,7 @@ int sys_lwcond_signal(mem_ptr_t<sys_lwcond_t> lwcond)
 
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_lwcond_signal(id=%d) aborted", (u32)lwcond->lwcond_queue);
+			LOG_WARNING(HLE, "sys_lwcond_signal(id=%d) aborted", (u32)lwcond->lwcond_queue);
 			return CELL_OK;
 		}
 	}
@@ -126,7 +126,7 @@ int sys_lwcond_signal_all(mem_ptr_t<sys_lwcond_t> lwcond)
 
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_lwcond_signal_all(id=%d) aborted", (u32)lwcond->lwcond_queue);
+			LOG_WARNING(HLE, "sys_lwcond_signal_all(id=%d) aborted", (u32)lwcond->lwcond_queue);
 			return CELL_OK;
 		}
 	}
@@ -165,7 +165,7 @@ int sys_lwcond_signal_to(mem_ptr_t<sys_lwcond_t> lwcond, u32 ppu_thread_id)
 
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_lwcond_signal_to(id=%d, to=%d) aborted", (u32)lwcond->lwcond_queue, ppu_thread_id);
+			LOG_WARNING(HLE, "sys_lwcond_signal_to(id=%d, to=%d) aborted", (u32)lwcond->lwcond_queue, ppu_thread_id);
 			return CELL_OK;
 		}
 	}
@@ -260,6 +260,6 @@ int sys_lwcond_wait(mem_ptr_t<sys_lwcond_t> lwcond, u64 timeout)
 	}
 
 abort:
-	LOGF_WARNING(HLE, "sys_lwcond_wait(id=%d) aborted", (u32)lwcond->lwcond_queue);
+	LOG_WARNING(HLE, "sys_lwcond_wait(id=%d) aborted", (u32)lwcond->lwcond_queue);
 	return CELL_OK;
 }

--- a/rpcs3/Emu/SysCalls/lv2/SC_Lwmutex.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Lwmutex.cpp
@@ -251,7 +251,7 @@ int sys_lwmutex_t::trylock(be_t<u32> tid)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "(hack) sys_lwmutex_t::(try)lock aborted (waiting for recursive attribute, attr=0x%x)", (u32)attribute);
+			LOG_WARNING(HLE, "(hack) sys_lwmutex_t::(try)lock aborted (waiting for recursive attribute, attr=0x%x)", (u32)attribute);
 			return CELL_ESRCH;
 		}
 		Sleep(1);
@@ -340,7 +340,7 @@ int sys_lwmutex_t::lock(be_t<u32> tid, u64 timeout)
 	case SMR_TIMEOUT:
 		sq->invalidate(tid); return CELL_ETIMEDOUT;
 	case SMR_ABORT:
-		if (Emu.IsStopped()) LOGF_WARNING(HLE, "sys_lwmutex_t::lock(sq=%d) aborted", (u32)sleep_queue);
+		if (Emu.IsStopped()) LOG_WARNING(HLE, "sys_lwmutex_t::lock(sq=%d) aborted", (u32)sleep_queue);
 	default:
 		sq->invalidate(tid); return CELL_EINVAL;
 	}

--- a/rpcs3/Emu/SysCalls/lv2/SC_Mutex.h
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Mutex.h
@@ -39,14 +39,14 @@ struct Mutex
 	{
 		if (u32 owner = m_mutex.GetOwner())
 		{
-			LOGF_NOTICE(HLE, "Mutex(%d) was owned by thread %d (recursive=%d)", id, owner, recursive);
+			LOG_NOTICE(HLE, "Mutex(%d) was owned by thread %d (recursive=%d)", id, owner, recursive);
 		}
 
 		if (!m_queue.m_mutex.try_lock()) return;
 
 		for (u32 i = 0; i < m_queue.list.size(); i++)
 		{
-			if (u32 owner = m_queue.list[i]) LOGF_NOTICE(HLE, "Mutex(%d) was waited by thread %d", id, owner);
+			if (u32 owner = m_queue.list[i]) LOG_NOTICE(HLE, "Mutex(%d) was waited by thread %d", id, owner);
 		}
 
 		m_queue.m_mutex.unlock();

--- a/rpcs3/Emu/SysCalls/lv2/SC_PPU_Thread.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_PPU_Thread.cpp
@@ -32,7 +32,7 @@ void sys_ppu_thread_exit(u64 errorcode)
 
 	if (thr.owned_mutexes)
 	{
-		LOGF_ERROR(PPU, "Owned mutexes found (%d)", thr.owned_mutexes);
+		LOG_ERROR(PPU, "Owned mutexes found (%d)", thr.owned_mutexes);
 		thr.owned_mutexes = 0;
 	}
 
@@ -58,7 +58,7 @@ int sys_ppu_thread_join(u64 thread_id, mem64_t vptr)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(PPU, "sys_ppu_thread_join(%d) aborted", thread_id);
+			LOG_WARNING(PPU, "sys_ppu_thread_join(%d) aborted", thread_id);
 			return CELL_OK;
 		}
 		Sleep(1);
@@ -204,7 +204,7 @@ int sys_ppu_thread_create(mem64_t thread_id, u32 entry, u64 arg, int prio, u32 s
 	new_thread.m_is_interrupt = is_interrupt;
 	new_thread.SetName(threadname);
 
-	LOGF_NOTICE(PPU, "*** New PPU Thread [%s] (flags=0x%llx, entry=0x%x): id = %d", new_thread.GetName().c_str(), flags, entry, new_thread.GetId());
+	LOG_NOTICE(PPU, "*** New PPU Thread [%s] (flags=0x%llx, entry=0x%x): id = %d", new_thread.GetName().c_str(), flags, entry, new_thread.GetId());
 
 	if (!is_interrupt)
 	{

--- a/rpcs3/Emu/SysCalls/lv2/SC_Rwlock.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Rwlock.cpp
@@ -69,7 +69,7 @@ int sys_rwlock_rlock(u32 rw_lock_id, u64 timeout)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_rwlock_rlock(rw_lock_id=%d, ...) aborted", rw_lock_id);
+			LOG_WARNING(HLE, "sys_rwlock_rlock(rw_lock_id=%d, ...) aborted", rw_lock_id);
 			return CELL_ETIMEDOUT;
 		}
 		Sleep(1);
@@ -132,7 +132,7 @@ int sys_rwlock_wlock(u32 rw_lock_id, u64 timeout)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_rwlock_wlock(rw_lock_id=%d, ...) aborted", rw_lock_id);
+			LOG_WARNING(HLE, "sys_rwlock_wlock(rw_lock_id=%d, ...) aborted", rw_lock_id);
 			return CELL_ETIMEDOUT;
 		}
 		Sleep(1);

--- a/rpcs3/Emu/SysCalls/lv2/SC_SPU_Thread.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_SPU_Thread.cpp
@@ -346,7 +346,7 @@ int sys_spu_thread_group_join(u32 id, mem32_t cause, mem32_t status)
 			}
 			if (Emu.IsStopped())
 			{
-				LOGF_WARNING(Log::SPU, "sys_spu_thread_group_join(id=%d, ...) aborted", id);
+				LOG_WARNING(Log::SPU, "sys_spu_thread_group_join(id=%d, ...) aborted", id);
 				return CELL_OK;
 			}
 			Sleep(1);

--- a/rpcs3/Emu/SysCalls/lv2/SC_Semaphore.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Semaphore.cpp
@@ -39,7 +39,7 @@ int sys_semaphore_create(mem32_t sem, mem_ptr_t<sys_semaphore_attribute> attr, i
 	}
 
 	sem = sys_sem.GetNewId(new Semaphore(initial_count, max_count, attr->protocol, attr->name_u64));
-	LOGF_NOTICE(HLE, "*** semaphore created [%s] (protocol=0x%x): id = %d",
+	LOG_NOTICE(HLE, "*** semaphore created [%s] (protocol=0x%x): id = %d",
 		std::string(attr->name, 8).c_str(), (u32)attr->protocol, sem.GetValue());
 
 	return CELL_OK;
@@ -91,7 +91,7 @@ int sys_semaphore_wait(u32 sem_id, u64 timeout)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_semaphore_wait(%d) aborted", sem_id);
+			LOG_WARNING(HLE, "sys_semaphore_wait(%d) aborted", sem_id);
 			return CELL_OK;
 		}
 
@@ -165,7 +165,7 @@ int sys_semaphore_post(u32 sem_id, int count)
 	{
 		if (Emu.IsStopped())
 		{
-			LOGF_WARNING(HLE, "sys_semaphore_post(%d) aborted", sem_id);
+			LOG_WARNING(HLE, "sys_semaphore_post(%d) aborted", sem_id);
 			return CELL_OK;
 		}
 

--- a/rpcs3/Emu/SysCalls/lv2/SC_Spinlock.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_Spinlock.cpp
@@ -22,8 +22,8 @@ void sys_spinlock_lock(mem_ptr_t<spinlock> lock)
 	be_t<u32> tid = GetCurrentPPUThread().GetId();
 	switch (lock->mutex.lock(tid))
 	{
-	case SMR_ABORT: LOGF_WARNING(HLE, "sys_spinlock_lock(0x%x) aborted", lock.GetAddr()); break;
-	case SMR_DEADLOCK: LOGF_ERROR(HLE, "sys_spinlock_lock(0x%x) reached deadlock", lock.GetAddr()); break; // ???
+	case SMR_ABORT: LOG_WARNING(HLE, "sys_spinlock_lock(0x%x) aborted", lock.GetAddr()); break;
+	case SMR_DEADLOCK: LOG_ERROR(HLE, "sys_spinlock_lock(0x%x) reached deadlock", lock.GetAddr()); break; // ???
 	default: break;
 	}
 }
@@ -36,8 +36,8 @@ int sys_spinlock_trylock(mem_ptr_t<spinlock> lock)
 	switch (lock->mutex.trylock(tid))
 	{
 	case SMR_FAILED: return CELL_EBUSY;
-	case SMR_ABORT: LOGF_WARNING(HLE, "sys_spinlock_trylock(0x%x) aborted", lock.GetAddr()); break;
-	case SMR_DEADLOCK: LOGF_ERROR(HLE, "sys_spinlock_trylock(0x%x) reached deadlock", lock.GetAddr()); break;
+	case SMR_ABORT: LOG_WARNING(HLE, "sys_spinlock_trylock(0x%x) aborted", lock.GetAddr()); break;
+	case SMR_DEADLOCK: LOG_ERROR(HLE, "sys_spinlock_trylock(0x%x) reached deadlock", lock.GetAddr()); break;
 	default: break;
 	}
 

--- a/rpcs3/Emu/SysCalls/lv2/SC_TTY.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/SC_TTY.cpp
@@ -7,7 +7,7 @@
 int sys_tty_read(u32 ch, u64 buf_addr, u32 len, u64 preadlen_addr)
 {
 	//we currently do not support reading from the Console
-	LOGF_WARNING(HLE, "sys_tty_read: ch: %d, buf addr: %llx, len: %d", ch, buf_addr, len);
+	LOG_WARNING(HLE, "sys_tty_read: ch: %d, buf addr: %llx, len: %d", ch, buf_addr, len);
 	Memory.Write32NN(preadlen_addr, len);
 	Emu.Pause();
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -153,7 +153,7 @@ void Emulator::Load()
 		m_path = elf_path;
 	}
 
-	LOGF_NOTICE(LOADER, "Loading '%s'...", m_path.c_str());
+	LOG_NOTICE(LOADER, "Loading '%s'...", m_path.c_str());
 	GetInfo().Reset();
 	m_vfs.Init(m_path);
 
@@ -161,7 +161,7 @@ void Emulator::Load()
 	LOG_NOTICE(LOADER, "Mount info:");
 	for(uint i=0; i<m_vfs.m_devices.size(); ++i)
 	{
-		LOGF_NOTICE(LOADER, "%s -> %s", m_vfs.m_devices[i]->GetPs3Path().c_str(), m_vfs.m_devices[i]->GetLocalPath().c_str());
+		LOG_NOTICE(LOADER, "%s -> %s", m_vfs.m_devices[i]->GetPs3Path().c_str(), m_vfs.m_devices[i]->GetLocalPath().c_str());
 	}
 	LOG_NOTICE(LOADER, " ");//used to be skip_line
 
@@ -174,7 +174,7 @@ void Emulator::Load()
 
 	if(!f.IsOpened())
 	{
-		LOGF_ERROR(LOADER, "Elf not found! (%s - %s)", m_path.c_str(), m_elf_path.c_str());
+		LOG_ERROR(LOADER, "Elf not found! (%s - %s)", m_path.c_str(), m_elf_path.c_str());
 		return;
 	}
 
@@ -247,8 +247,8 @@ void Emulator::Load()
 	switch(l.GetMachine())
 	{
 	case MACHINE_SPU:
-		LOGF_NOTICE(LOADER, "offset = 0x%llx", Memory.MainMem.GetStartAddr());
-		LOGF_NOTICE(LOADER, "max addr = 0x%x", l.GetMaxAddr());
+		LOG_NOTICE(LOADER, "offset = 0x%llx", Memory.MainMem.GetStartAddr());
+		LOG_NOTICE(LOADER, "max addr = 0x%x", l.GetMaxAddr());
 		thread.SetOffset(Memory.MainMem.GetStartAddr());
 		Memory.MainMem.AllocFixed(Memory.MainMem.GetStartAddr() + l.GetMaxAddr(), 0xFFFFED - l.GetMaxAddr());
 		thread.SetEntry(l.GetEntry() - Memory.MainMem.GetStartAddr());
@@ -375,7 +375,7 @@ void Emulator::Stop()
 		Sleep(1);
 		if (counter++ > 3000)
 		{
-			LOGF_ERROR(HLE, "%d threads not stopped (timeout)", (u32)(g_thread_count - uncounted));
+			LOG_ERROR(HLE, "%d threads not stopped (timeout)", (u32)(g_thread_count - uncounted));
 			break;
 		}
 	}
@@ -448,7 +448,7 @@ void Emulator::LoadPoints(const std::string& path)
 	if(version != bpdb_version ||
 		(sizeof(u16) + break_count * sizeof(u64) + sizeof(u32) + marked_count * sizeof(u64) + sizeof(u32)) != length)
 	{
-		LOGF_ERROR(LOADER, "'%s' is broken", path.c_str());
+		LOG_ERROR(LOADER, "'%s' is broken", path.c_str());
 		return;
 	}
 

--- a/rpcs3/Gui/DisAsmFrame.cpp
+++ b/rpcs3/Gui/DisAsmFrame.cpp
@@ -152,7 +152,7 @@ public:
 
 	virtual void Task()
 	{
-		LOGF_NOTICE(HLE, "Start dump in thread %d!", (int)id);
+		LOG_NOTICE(HLE, "Start dump in thread %d!", (int)id);
 		const u32 max_value = prog_dial->GetMaxValue(id);
 		const u32 shdr_count = ElfType64 ? shdr_arr_64->size() : shdr_arr_32->size();
 
@@ -180,14 +180,14 @@ public:
 			}
 		}
 
-		LOGF_NOTICE(HLE, "Finish dump in thread %d!", (int)id);
+		LOG_NOTICE(HLE, "Finish dump in thread %d!", (int)id);
 
 		*done = true;
 	}
 
 	void OnExit()
 	{
-		LOGF_NOTICE(HLE, "CleanUp dump thread (%d)!", (int)id);
+		LOG_NOTICE(HLE, "CleanUp dump thread (%d)!", (int)id);
 		safe_delete(decoder);
 	}
 };
@@ -223,7 +223,7 @@ struct WaitDumperThread : public ThreadBase
 			while(done[i] == false) Sleep(1);
 		}
 
-		LOGF_NOTICE(HLE, "Saving dump is started!");
+		LOG_NOTICE(HLE, "Saving dump is started!");
 		const uint length_for_core = prog_dial.GetMaxValue(0);
 		const uint length = length_for_core * cores;
 		prog_dial.Close();
@@ -266,7 +266,7 @@ struct WaitDumperThread : public ThreadBase
 			fd.Write(wxString::Format("End of section header %d\n\n", sh));
 		}
 		
-		LOGF_NOTICE(HLE, "CleanUp dump saving!");
+		LOG_NOTICE(HLE, "CleanUp dump saving!");
 
 		for(uint c=0; c<cores; ++c)
 		{
@@ -298,13 +298,13 @@ void DisAsmFrame::Dump(wxCommandEvent& WXUNUSED(event))
 	vfsLocalFile& f_elf = *new vfsLocalFile(nullptr);
 	f_elf.Open(Emu.m_path);
 
-	LOGF_NOTICE(HLE, "path: %s", Emu.m_path.c_str());
+	LOG_NOTICE(HLE, "path: %s", Emu.m_path.c_str());
 	Elf_Ehdr ehdr;
 	ehdr.Load(f_elf);
 
 	if(!ehdr.CheckMagic())
 	{
-		LOGF_ERROR(HLE, "Corrupted ELF!");
+		LOG_ERROR(HLE, "Corrupted ELF!");
 		return;
 	}
 	std::vector<std::string> name_arr;
@@ -338,7 +338,7 @@ void DisAsmFrame::Dump(wxCommandEvent& WXUNUSED(event))
 		if(l_elf32->shdr_arr.size() <= 0) return;
 	break;
 
-	default: LOGF_ERROR(HLE, "Corrupted ELF!"); return;
+	default: LOG_ERROR(HLE, "Corrupted ELF!"); return;
 	}
 
 	PPCDisAsm* disasm;

--- a/rpcs3/Gui/FnIdGenerator.cpp
+++ b/rpcs3/Gui/FnIdGenerator.cpp
@@ -82,7 +82,7 @@ void FnIdGenerator::PrintId()
 		m_func_name.push_back(func_name);
 		m_func_id.push_back(result);
 
-		LOGF_NOTICE(HLE, "Function: %s, Id: 0x%08x ", func_name.c_str(), result);
+		LOG_NOTICE(HLE, "Function: %s, Id: 0x%08x ", func_name.c_str(), result);
 		UpdateInformation();
 	}
 

--- a/rpcs3/Gui/GameViewer.cpp
+++ b/rpcs3/Gui/GameViewer.cpp
@@ -39,7 +39,7 @@ public:
 	virtual wxDirTraverseResult OnFile(const wxString& filename)
 	{
 		if (!wxRemoveFile(filename)){
-			LOGF_ERROR(HLE, "Couldn't delete File: %s", fmt::ToUTF8(filename).c_str());
+			LOG_ERROR(HLE, "Couldn't delete File: %s", fmt::ToUTF8(filename).c_str());
 		}
 		return wxDIR_CONTINUE;
 	}
@@ -103,7 +103,7 @@ void GameViewer::OnColClick(wxListEvent& event)
 void GameViewer::LoadGames()
 {
 	vfsDir dir(m_path);
-	LOGF_NOTICE(HLE, "path: %s", m_path.c_str());
+	LOG_NOTICE(HLE, "path: %s", m_path.c_str());
 	if(!dir.IsOpened()) return;
 
 	m_games.clear();
@@ -207,7 +207,7 @@ void GameViewer::DClick(wxListEvent& event)
 	std::string local_path;
 	if(Emu.GetVFS().GetDevice(path, local_path) && !Emu.BootGame(local_path))
 	{
-		LOGF_ERROR(HLE, "Boot error: elf not found! [%s]", path.c_str());
+		LOG_ERROR(HLE, "Boot error: elf not found! [%s]", path.c_str());
 		return;
 	}
 	Emu.Run();

--- a/rpcs3/Gui/GameViewer.h
+++ b/rpcs3/Gui/GameViewer.h
@@ -134,7 +134,7 @@ public:
 
 			if(!col)
 			{
-				LOGF_ERROR(HLE, "Columns loaded with error!");
+				LOG_ERROR(HLE, "Columns loaded with error!");
 				return;
 			}
 
@@ -191,7 +191,7 @@ public:
 				{
 					if(m_columns[c1].pos == m_columns[c2].pos)
 					{
-						LOGF_ERROR(HLE, "Columns loaded with error!");
+						LOG_ERROR(HLE, "Columns loaded with error!");
 						Init();
 						return;
 					}
@@ -210,7 +210,7 @@ public:
 
 				if(!ishas)
 				{
-					LOGF_ERROR(HLE, "Columns loaded with error!");
+					LOG_ERROR(HLE, "Columns loaded with error!");
 					Init();
 					return;
 				}

--- a/rpcs3/Gui/MainFrame.cpp
+++ b/rpcs3/Gui/MainFrame.cpp
@@ -201,7 +201,7 @@ void MainFrame::BootGame(wxCommandEvent& WXUNUSED(event))
 	}
 	else
 	{
-		LOGF_ERROR(HLE, "PS3 executable not found in selected folder (%s)", ctrl.GetPath().wx_str());
+		LOG_ERROR(HLE, "PS3 executable not found in selected folder (%s)", ctrl.GetPath().wx_str());
 	}
 }
 
@@ -231,7 +231,7 @@ void MainFrame::BootGameAndRun(wxCommandEvent& WXUNUSED(event))
 	}
 	else
 	{
-		LOGF_ERROR(HLE, "PS3 executable not found in selected folder (%s)", ctrl.GetPath().wx_str());
+		LOG_ERROR(HLE, "PS3 executable not found in selected folder (%s)", ctrl.GetPath().wx_str());
 	}
 
 	if (Emu.IsReady())

--- a/rpcs3/Gui/PADManager.cpp
+++ b/rpcs3/Gui/PADManager.cpp
@@ -289,7 +289,7 @@ void PADManager::OnKeyDown(wxKeyEvent &keyEvent)
 	case id_pad_rstick_up: Ini.PadHandlerRStickUp.SetValue(keyEvent.GetKeyCode()); break;
 
 	case 0: break;
-	default: LOGF_ERROR(HLE, "Unknown button ID: %d", m_button_id); break;
+	default: LOG_ERROR(HLE, "Unknown button ID: %d", m_button_id); break;
 	}
 
 	UpdateLabel();
@@ -323,7 +323,7 @@ void PADManager::OnButtonClicked(wxCommandEvent &event)
 		case wxID_OK: Ini.Save(); break;
 		case wxID_CANCEL: break;
 
-		default: LOGF_ERROR(HLE, "Unknown button ID: %d", event.GetId()); break;
+		default: LOG_ERROR(HLE, "Unknown button ID: %d", event.GetId()); break;
 		}
 	}
 
@@ -509,7 +509,7 @@ void PADManager::UpdateTimerLabel(const u32 id)
 	case id_pad_rstick_right: b_right_rstick->SetLabel(static_cast<char>(m_seconds + 47)); break;
 	case id_pad_rstick_up: b_up_rstick->SetLabel(static_cast<char>(m_seconds + 47)); break;
 	
-	default: LOGF_ERROR(HLE, "Unknown button ID: %d", id); break;
+	default: LOG_ERROR(HLE, "Unknown button ID: %d", id); break;
 	}
 }
 

--- a/rpcs3/Gui/Plugins.h
+++ b/rpcs3/Gui/Plugins.h
@@ -314,7 +314,7 @@ struct PluginsManager
 
 		for(u32 i=0; i<res.GetCount(); ++i)
 		{
-			LOGF_NOTICE(HLE, "loading " + res[i] + "...");
+			LOG_NOTICE(HLE, "loading " + res[i] + "...");
 			Ps3EmuPlugin l(res[i]);
 			if(!l.Test()) continue;
 

--- a/rpcs3/Gui/VHDDManager.cpp
+++ b/rpcs3/Gui/VHDDManager.cpp
@@ -33,7 +33,7 @@ wxDragResult VHDDListDropTarget::OnData(wxCoord x, wxCoord y, wxDragResult def)
 {	
 	int flags = 0;
 	int dst_indx = m_parent->HitTest(wxPoint(x, y), flags);
-	LOGF_NOTICE(HLE, "OnData(%d -> %d)", m_src_indx, dst_indx);
+	LOG_NOTICE(HLE, "OnData(%d -> %d)", m_src_indx, dst_indx);
 	return def;
 }
 
@@ -189,7 +189,7 @@ void VHDDExplorer::OnDropFiles(wxDropFilesEvent& event)
 
 	for(int i=0; i<count; ++i)
 	{
-		LOGF_NOTICE(HLE, "Importing '%s'", dropped[i].wx_str());
+		LOG_NOTICE(HLE, "Importing '%s'", dropped[i].wx_str());
 		Import(fmt::ToUTF8(dropped[i]), fmt::ToUTF8(wxFileName(dropped[i]).GetFullName()));
 	}
 

--- a/rpcs3/Loader/ELF32.cpp
+++ b/rpcs3/Loader/ELF32.cpp
@@ -106,7 +106,7 @@ bool ELF32Loader::LoadEhdrInfo()
 
 	default:
 		machine = MACHINE_Unknown;
-		LOGF_ERROR(LOADER, "Unknown elf32 machine: 0x%x", ehdr.e_machine);
+		LOG_ERROR(LOADER, "Unknown elf32 machine: 0x%x", ehdr.e_machine);
 		return false;
 	}
 
@@ -149,7 +149,7 @@ bool ELF32Loader::LoadPhdrInfo()
 			if(phdr_arr[i].p_paddr >= entry && entry < phdr_arr[i].p_paddr + phdr_arr[i].p_memsz)
 			{
 				entry += phdr_arr[i].p_vaddr;
-				LOGF_WARNING(LOADER, "virtual entry = 0x%x", entry);
+				LOG_WARNING(LOADER, "virtual entry = 0x%x", entry);
 				break;
 			}
 		}
@@ -226,7 +226,7 @@ bool ELF32Loader::LoadPhdrData(u64 _offset)
 
 			if(phdr_arr[i].p_vaddr != phdr_arr[i].p_paddr)
 			{
-				LOGF_WARNING
+				LOG_WARNING
 				(
 					LOADER, 
 					"LoadPhdr32 different load addrs: paddr=0x%8.8x, vaddr=0x%8.8x", 
@@ -256,19 +256,19 @@ bool ELF32Loader::LoadPhdrData(u64 _offset)
 
 			if(note.type != 1)
 			{
-				LOGF_ERROR(LOADER, "ELF32: Bad NOTE type (%d)", note.type);
+				LOG_ERROR(LOADER, "ELF32: Bad NOTE type (%d)", note.type);
 				break;
 			}
 
 			if(note.namesz != sizeof(note.name))
 			{
-				LOGF_ERROR(LOADER, "ELF32: Bad NOTE namesz (%d)", note.namesz);
+				LOG_ERROR(LOADER, "ELF32: Bad NOTE namesz (%d)", note.namesz);
 				break;
 			}
 
 			if(note.descsz != sizeof(note.desc) && note.descsz != 32)
 			{
-				LOGF_ERROR(LOADER, "ELF32: Bad NOTE descsz (%d)", note.descsz);
+				LOG_ERROR(LOADER, "ELF32: Bad NOTE descsz (%d)", note.descsz);
 				break;
 			}
 
@@ -280,13 +280,13 @@ bool ELF32Loader::LoadPhdrData(u64 _offset)
 
 			if(note.descsz == sizeof(note.desc))
 			{
-				LOGF_WARNING(LOADER, "name = %s", std::string((const char *)note.name, 8).c_str());
-				LOGF_WARNING(LOADER, "ls_size = %d", note.desc.ls_size);
-				LOGF_WARNING(LOADER, "stack_size = %d", note.desc.stack_size);
+				LOG_WARNING(LOADER, "name = %s", std::string((const char *)note.name, 8).c_str());
+				LOG_WARNING(LOADER, "ls_size = %d", note.desc.ls_size);
+				LOG_WARNING(LOADER, "stack_size = %d", note.desc.stack_size);
 			}
 			else
 			{
-				LOGF_WARNING(LOADER, "desc = '%s'", std::string(note.desc_text, 32).c_str());
+				LOG_WARNING(LOADER, "desc = '%s'", std::string(note.desc_text, 32).c_str());
 			}
 		}
 #ifdef LOADER_DEBUG
@@ -304,7 +304,7 @@ bool ELF32Loader::LoadShdrData(u64 offset)
 		Elf32_Shdr& shdr = shdr_arr[i];
 
 #ifdef LOADER_DEBUG
-		if(i < shdr_name_arr.size()) LOGF_NOTICE(LOADER, "Name: %s", shdr_name_arr[i].c_str());
+		if(i < shdr_name_arr.size()) LOG_NOTICE(LOADER, "Name: %s", shdr_name_arr[i].c_str());
 		shdr.Show();
 		LOG_NOTICE(LOADER, "");
 #endif

--- a/rpcs3/Loader/ELF32.h
+++ b/rpcs3/Loader/ELF32.h
@@ -26,25 +26,25 @@ struct Elf32_Ehdr
 	void Show()
 	{
 #ifdef LOADER_DEBUG
-		LOGF_NOTICE(LOADER, "Magic: %08x",                           e_magic);
-		LOGF_NOTICE(LOADER, "Class: %s",                             "ELF32");
-		LOGF_NOTICE(LOADER, "Data: %s",                              Ehdr_DataToString(e_data).c_str());
-		LOGF_NOTICE(LOADER, "Current Version: %d",                   e_curver);
-		LOGF_NOTICE(LOADER, "OS/ABI: %s",                            Ehdr_OS_ABIToString(e_os_abi).c_str());
-		LOGF_NOTICE(LOADER, "ABI version: %lld",                     e_abi_ver);
-		LOGF_NOTICE(LOADER, "Type: %s",                              Ehdr_TypeToString(e_type).c_str());
-		LOGF_NOTICE(LOADER, "Machine: %s",                           Ehdr_MachineToString(e_machine).c_str());
-		LOGF_NOTICE(LOADER, "Version: %d",                           e_version);
-		LOGF_NOTICE(LOADER, "Entry point address: 0x%x",             e_entry);
-		LOGF_NOTICE(LOADER, "Program headers offset: 0x%08x",        e_phoff);
-		LOGF_NOTICE(LOADER, "Section headers offset: 0x%08x",        e_shoff);
-		LOGF_NOTICE(LOADER, "Flags: 0x%x",                           e_flags);
-		LOGF_NOTICE(LOADER, "Size of this header: %d",               e_ehsize);
-		LOGF_NOTICE(LOADER, "Size of program headers: %d",           e_phentsize);
-		LOGF_NOTICE(LOADER, "Number of program headers: %d",         e_phnum);
-		LOGF_NOTICE(LOADER, "Size of section headers: %d",           e_shentsize);
-		LOGF_NOTICE(LOADER, "Number of section headers: %d",         e_shnum);
-		LOGF_NOTICE(LOADER, "Section header string table index: %d", e_shstrndx);
+		LOG_NOTICE(LOADER, "Magic: %08x",                           e_magic);
+		LOG_NOTICE(LOADER, "Class: %s",                             "ELF32");
+		LOG_NOTICE(LOADER, "Data: %s",                              Ehdr_DataToString(e_data).c_str());
+		LOG_NOTICE(LOADER, "Current Version: %d",                   e_curver);
+		LOG_NOTICE(LOADER, "OS/ABI: %s",                            Ehdr_OS_ABIToString(e_os_abi).c_str());
+		LOG_NOTICE(LOADER, "ABI version: %lld",                     e_abi_ver);
+		LOG_NOTICE(LOADER, "Type: %s",                              Ehdr_TypeToString(e_type).c_str());
+		LOG_NOTICE(LOADER, "Machine: %s",                           Ehdr_MachineToString(e_machine).c_str());
+		LOG_NOTICE(LOADER, "Version: %d",                           e_version);
+		LOG_NOTICE(LOADER, "Entry point address: 0x%x",             e_entry);
+		LOG_NOTICE(LOADER, "Program headers offset: 0x%08x",        e_phoff);
+		LOG_NOTICE(LOADER, "Section headers offset: 0x%08x",        e_shoff);
+		LOG_NOTICE(LOADER, "Flags: 0x%x",                           e_flags);
+		LOG_NOTICE(LOADER, "Size of this header: %d",               e_ehsize);
+		LOG_NOTICE(LOADER, "Size of program headers: %d",           e_phentsize);
+		LOG_NOTICE(LOADER, "Number of program headers: %d",         e_phnum);
+		LOG_NOTICE(LOADER, "Size of section headers: %d",           e_shentsize);
+		LOG_NOTICE(LOADER, "Number of section headers: %d",         e_shnum);
+		LOG_NOTICE(LOADER, "Section header string table index: %d", e_shstrndx);
 #endif
 	}
 
@@ -216,16 +216,16 @@ struct Elf32_Shdr
 	void Show()
 	{
 #ifdef LOADER_DEBUG
-		LOGF_NOTICE(LOADER, "Name offset: %x",   sh_name);
-		LOGF_NOTICE(LOADER, "Type: %d",          sh_type);
-		LOGF_NOTICE(LOADER, "Addr: %x",          sh_addr);
-		LOGF_NOTICE(LOADER, "Offset: %x",        sh_offset);
-		LOGF_NOTICE(LOADER, "Size: %x",          sh_size);
-		LOGF_NOTICE(LOADER, "EntSize: %d",       sh_entsize);
-		LOGF_NOTICE(LOADER, "Flags: %x",         sh_flags);
-		LOGF_NOTICE(LOADER, "Link: %x",          sh_link);
-		LOGF_NOTICE(LOADER, "Info: %d",          sh_info);
-		LOGF_NOTICE(LOADER, "Address align: %x", sh_addralign);
+		LOG_NOTICE(LOADER, "Name offset: %x",   sh_name);
+		LOG_NOTICE(LOADER, "Type: %d",          sh_type);
+		LOG_NOTICE(LOADER, "Addr: %x",          sh_addr);
+		LOG_NOTICE(LOADER, "Offset: %x",        sh_offset);
+		LOG_NOTICE(LOADER, "Size: %x",          sh_size);
+		LOG_NOTICE(LOADER, "EntSize: %d",       sh_entsize);
+		LOG_NOTICE(LOADER, "Flags: %x",         sh_flags);
+		LOG_NOTICE(LOADER, "Link: %x",          sh_link);
+		LOG_NOTICE(LOADER, "Info: %d",          sh_info);
+		LOG_NOTICE(LOADER, "Address align: %x", sh_addralign);
 #endif
 	}
 };
@@ -268,14 +268,14 @@ struct Elf32_Phdr
 	void Show()
 	{
 #ifdef LOADER_DEBUG
-		LOGF_NOTICE(LOADER, "Type: %s",                 Phdr_TypeToString(p_type).c_str());
-		LOGF_NOTICE(LOADER, "Offset: 0x%08x",           p_offset);
-		LOGF_NOTICE(LOADER, "Virtual address: 0x%08x",  p_vaddr);
-		LOGF_NOTICE(LOADER, "Physical address: 0x%08x", p_paddr);
-		LOGF_NOTICE(LOADER, "File size: 0x%08x",        p_filesz);
-		LOGF_NOTICE(LOADER, "Memory size: 0x%08x",      p_memsz);
-		LOGF_NOTICE(LOADER, "Flags: %s",                Phdr_FlagsToString(p_flags).c_str());
-		LOGF_NOTICE(LOADER, "Align: 0x%x",              p_align);
+		LOG_NOTICE(LOADER, "Type: %s",                 Phdr_TypeToString(p_type).c_str());
+		LOG_NOTICE(LOADER, "Offset: 0x%08x",           p_offset);
+		LOG_NOTICE(LOADER, "Virtual address: 0x%08x",  p_vaddr);
+		LOG_NOTICE(LOADER, "Physical address: 0x%08x", p_paddr);
+		LOG_NOTICE(LOADER, "File size: 0x%08x",        p_filesz);
+		LOG_NOTICE(LOADER, "Memory size: 0x%08x",      p_memsz);
+		LOG_NOTICE(LOADER, "Flags: %s",                Phdr_FlagsToString(p_flags).c_str());
+		LOG_NOTICE(LOADER, "Align: 0x%x",              p_align);
 #endif
 	}
 };

--- a/rpcs3/Loader/ELF64.cpp
+++ b/rpcs3/Loader/ELF64.cpp
@@ -104,13 +104,13 @@ bool ELF64Loader::LoadEhdrInfo(s64 offset)
 
 	if(ehdr.e_phentsize != sizeof(Elf64_Phdr))
 	{
-		LOGF_ERROR(LOADER, "elf64 error:  e_phentsize[0x%x] != sizeof(Elf64_Phdr)[0x%x]", ehdr.e_phentsize, sizeof(Elf64_Phdr));
+		LOG_ERROR(LOADER, "elf64 error:  e_phentsize[0x%x] != sizeof(Elf64_Phdr)[0x%x]", ehdr.e_phentsize, sizeof(Elf64_Phdr));
 		return false;
 	}
 
 	if(ehdr.e_shentsize != sizeof(Elf64_Shdr))
 	{
-		LOGF_ERROR(LOADER, "elf64 error: e_shentsize[0x%x] != sizeof(Elf64_Shdr)[0x%x]", ehdr.e_shentsize, sizeof(Elf64_Shdr));
+		LOG_ERROR(LOADER, "elf64 error: e_shentsize[0x%x] != sizeof(Elf64_Shdr)[0x%x]", ehdr.e_shentsize, sizeof(Elf64_Shdr));
 		return false;
 	}
 
@@ -123,7 +123,7 @@ bool ELF64Loader::LoadEhdrInfo(s64 offset)
 
 	default:
 		machine = MACHINE_Unknown;
-		LOGF_ERROR(LOADER, "Unknown elf64 type: 0x%x", ehdr.e_machine);
+		LOG_ERROR(LOADER, "Unknown elf64 type: 0x%x", ehdr.e_machine);
 		return false;
 	}
 
@@ -226,7 +226,7 @@ bool ELF64Loader::LoadPhdrData(u64 offset)
 
 		if(phdr_arr[i].p_vaddr != phdr_arr[i].p_paddr)
 		{
-			LOGF_WARNING
+			LOG_WARNING
 			(
 				LOADER,
 				"ElfProgram different load addrs: paddr=0x%8.8x, vaddr=0x%8.8x", 
@@ -271,12 +271,12 @@ bool ELF64Loader::LoadPhdrData(u64 offset)
 
 				if(re(proc_param.size) < sizeof(sys_process_param))
 				{
-					LOGF_WARNING(LOADER, "Bad proc param size! [0x%x : 0x%x]", re(proc_param.size), sizeof(sys_process_param));
+					LOG_WARNING(LOADER, "Bad proc param size! [0x%x : 0x%x]", re(proc_param.size), sizeof(sys_process_param));
 				}
 	
 				if(re(proc_param.magic) != 0x13bcc5f6)
 				{
-					LOGF_ERROR(LOADER, "Bad magic! [0x%x]", Memory.Reverse32(proc_param.magic));
+					LOG_ERROR(LOADER, "Bad magic! [0x%x]", Memory.Reverse32(proc_param.magic));
 				}
 				else
 				{
@@ -288,12 +288,12 @@ bool ELF64Loader::LoadPhdrData(u64 offset)
 					info.ppc_seg = re(proc_param.info.ppc_seg);
 					//info.crash_dump_param_addr = re(proc_param.info.crash_dump_param_addr);
 #ifdef LOADER_DEBUG
-					LOGF_NOTICE(LOADER, "*** sdk version: 0x%x", info.sdk_version);
-					LOGF_NOTICE(LOADER, "*** primary prio: %d", info.primary_prio);
-					LOGF_NOTICE(LOADER, "*** primary stacksize: 0x%x", info.primary_stacksize);
-					LOGF_NOTICE(LOADER, "*** malloc pagesize: 0x%x", info.malloc_pagesize);
-					LOGF_NOTICE(LOADER, "*** ppc seg: 0x%x", info.ppc_seg);
-					//LOGF_NOTICE(LOADER, "*** crash dump param addr: 0x%x", info.crash_dump_param_addr);
+					LOG_NOTICE(LOADER, "*** sdk version: 0x%x", info.sdk_version);
+					LOG_NOTICE(LOADER, "*** primary prio: %d", info.primary_prio);
+					LOG_NOTICE(LOADER, "*** primary stacksize: 0x%x", info.primary_stacksize);
+					LOG_NOTICE(LOADER, "*** malloc pagesize: 0x%x", info.malloc_pagesize);
+					LOG_NOTICE(LOADER, "*** ppc seg: 0x%x", info.ppc_seg);
+					//LOG_NOTICE(LOADER, "*** crash dump param addr: 0x%x", info.crash_dump_param_addr);
 #endif
 				}
 			}
@@ -315,19 +315,19 @@ bool ELF64Loader::LoadPhdrData(u64 offset)
 				proc_prx_param.ver = re(proc_prx_param.ver);
 
 #ifdef LOADER_DEBUG
-				LOGF_NOTICE(LOADER, "*** size: 0x%x", proc_prx_param.size);
-				LOGF_NOTICE(LOADER, "*** magic: 0x%x", proc_prx_param.magic);
-				LOGF_NOTICE(LOADER, "*** version: 0x%x", proc_prx_param.version);
-				LOGF_NOTICE(LOADER, "*** libentstart: 0x%x", proc_prx_param.libentstart);
-				LOGF_NOTICE(LOADER, "*** libentend: 0x%x", proc_prx_param.libentend);
-				LOGF_NOTICE(LOADER, "*** libstubstart: 0x%x", proc_prx_param.libstubstart);
-				LOGF_NOTICE(LOADER, "*** libstubend: 0x%x", proc_prx_param.libstubend);
-				LOGF_NOTICE(LOADER, "*** ver: 0x%x", proc_prx_param.ver);
+				LOG_NOTICE(LOADER, "*** size: 0x%x", proc_prx_param.size);
+				LOG_NOTICE(LOADER, "*** magic: 0x%x", proc_prx_param.magic);
+				LOG_NOTICE(LOADER, "*** version: 0x%x", proc_prx_param.version);
+				LOG_NOTICE(LOADER, "*** libentstart: 0x%x", proc_prx_param.libentstart);
+				LOG_NOTICE(LOADER, "*** libentend: 0x%x", proc_prx_param.libentend);
+				LOG_NOTICE(LOADER, "*** libstubstart: 0x%x", proc_prx_param.libstubstart);
+				LOG_NOTICE(LOADER, "*** libstubend: 0x%x", proc_prx_param.libstubend);
+				LOG_NOTICE(LOADER, "*** ver: 0x%x", proc_prx_param.ver);
 #endif
 
 				if(proc_prx_param.magic != 0x1b434cec)
 				{
-					LOGF_ERROR(LOADER, "Bad magic! (0x%x)", proc_prx_param.magic);
+					LOG_ERROR(LOADER, "Bad magic! (0x%x)", proc_prx_param.magic);
 				}
 				else
 				{
@@ -352,19 +352,19 @@ bool ELF64Loader::LoadPhdrData(u64 offset)
 						}
 						else
 						{
-							LOGF_WARNING(LOADER, "Unknown module '%s'", module_name.c_str());
+							LOG_WARNING(LOADER, "Unknown module '%s'", module_name.c_str());
 						}
 
 #ifdef LOADER_DEBUG
 						LOG_NOTICE(LOADER, "");
-						LOGF_NOTICE(LOADER, "*** size: 0x%x", stub.s_size);
-						LOGF_NOTICE(LOADER, "*** version: 0x%x", stub.s_version);
-						LOGF_NOTICE(LOADER, "*** unk0: 0x%x", stub.s_unk0);
-						LOGF_NOTICE(LOADER, "*** unk1: 0x%x", stub.s_unk1);
-						LOGF_NOTICE(LOADER, "*** imports: %d", stub.s_imports);
-						LOGF_NOTICE(LOADER, "*** module name: %s [0x%x]", module_name.c_str(), stub.s_modulename);
-						LOGF_NOTICE(LOADER, "*** nid: 0x%x", stub.s_nid);
-						LOGF_NOTICE(LOADER, "*** text: 0x%x", stub.s_text);
+						LOG_NOTICE(LOADER, "*** size: 0x%x", stub.s_size);
+						LOG_NOTICE(LOADER, "*** version: 0x%x", stub.s_version);
+						LOG_NOTICE(LOADER, "*** unk0: 0x%x", stub.s_unk0);
+						LOG_NOTICE(LOADER, "*** unk1: 0x%x", stub.s_unk1);
+						LOG_NOTICE(LOADER, "*** imports: %d", stub.s_imports);
+						LOG_NOTICE(LOADER, "*** module name: %s [0x%x]", module_name.c_str(), stub.s_modulename);
+						LOG_NOTICE(LOADER, "*** nid: 0x%x", stub.s_nid);
+						LOG_NOTICE(LOADER, "*** text: 0x%x", stub.s_text);
 #endif
 						static const u32 section = 4 * 3;
 						u64 tbl = Memory.MainMem.AllocAlign(stub.s_imports * 4 * 2);
@@ -379,13 +379,13 @@ bool ELF64Loader::LoadPhdrData(u64 offset)
 							{
 								if(!module->Load(nid))
 								{
-									LOGF_WARNING(LOADER, "Unimplemented function '%s' in '%s' module", SysCalls::GetHLEFuncName(nid).c_str(), module_name.c_str());
+									LOG_WARNING(LOADER, "Unimplemented function '%s' in '%s' module", SysCalls::GetHLEFuncName(nid).c_str(), module_name.c_str());
 								}
 							}
 #ifdef LOADER_DEBUG
-							LOGF_NOTICE(LOADER, "import %d:", i+1);
-							LOGF_NOTICE(LOADER, "*** nid: 0x%x (0x%x)", nid, stub.s_nid + i*4);
-							LOGF_NOTICE(LOADER, "*** text: 0x%x (0x%x)", text, stub.s_text + i*4);
+							LOG_NOTICE(LOADER, "import %d:", i+1);
+							LOG_NOTICE(LOADER, "*** nid: 0x%x (0x%x)", nid, stub.s_nid + i*4);
+							LOG_NOTICE(LOADER, "*** text: 0x%x (0x%x)", text, stub.s_text + i*4);
 #endif
 							Memory.Write32(stub.s_text + i*4, tbl + i*8);
 
@@ -407,7 +407,7 @@ bool ELF64Loader::LoadPhdrData(u64 offset)
 			break;
 		}
 #ifdef LOADER_DEBUG
-		LOGF_NOTICE(LOADER, " ");
+		LOG_NOTICE(LOADER, " ");
 #endif
 	}
 
@@ -425,13 +425,13 @@ bool ELF64Loader::LoadShdrData(u64 offset)
 		if(i < shdr_name_arr.size())
 		{
 #ifdef LOADER_DEBUG
-			LOGF_NOTICE(LOADER, "Name: %s", shdr_name_arr[i].c_str());
+			LOG_NOTICE(LOADER, "Name: %s", shdr_name_arr[i].c_str());
 #endif
 		}
 
 #ifdef LOADER_DEBUG
 		shdr.Show();
-		LOGF_NOTICE(LOADER, " ");
+		LOG_NOTICE(LOADER, " ");
 #endif
 		if(shdr.sh_addr + shdr.sh_size > max_addr) max_addr = shdr.sh_addr + shdr.sh_size;
 

--- a/rpcs3/Loader/ELF64.h
+++ b/rpcs3/Loader/ELF64.h
@@ -49,25 +49,25 @@ struct Elf64_Ehdr
 	void Show()
 	{
 #ifdef LOADER_DEBUG
-		LOGF_NOTICE(LOADER, "Magic: %08x",                           e_magic);
-		LOGF_NOTICE(LOADER, "Class: %s",                             "ELF64");
-		LOGF_NOTICE(LOADER, "Data: %s",                              Ehdr_DataToString(e_data).c_str());
-		LOGF_NOTICE(LOADER, "Current Version: %d",                   e_curver);
-		LOGF_NOTICE(LOADER, "OS/ABI: %s",                            Ehdr_OS_ABIToString(e_os_abi).c_str());
-		LOGF_NOTICE(LOADER, "ABI version: %lld",                     e_abi_ver);
-		LOGF_NOTICE(LOADER, "Type: %s",                              Ehdr_TypeToString(e_type).c_str());
-		LOGF_NOTICE(LOADER, "Machine: %s",                           Ehdr_MachineToString(e_machine).c_str());
-		LOGF_NOTICE(LOADER, "Version: %d",                           e_version);
-		LOGF_NOTICE(LOADER, "Entry point address: 0x%08llx",         e_entry);
-		LOGF_NOTICE(LOADER, "Program headers offset: 0x%08llx",      e_phoff);
-		LOGF_NOTICE(LOADER, "Section headers offset: 0x%08llx",      e_shoff);
-		LOGF_NOTICE(LOADER, "Flags: 0x%x",                           e_flags);
-		LOGF_NOTICE(LOADER, "Size of this header: %d",               e_ehsize);
-		LOGF_NOTICE(LOADER, "Size of program headers: %d",           e_phentsize);
-		LOGF_NOTICE(LOADER, "Number of program headers: %d",         e_phnum);
-		LOGF_NOTICE(LOADER, "Size of section headers: %d",           e_shentsize);
-		LOGF_NOTICE(LOADER, "Number of section headers: %d",         e_shnum);
-		LOGF_NOTICE(LOADER, "Section header string table index: %d", e_shstrndx);
+		LOG_NOTICE(LOADER, "Magic: %08x",                           e_magic);
+		LOG_NOTICE(LOADER, "Class: %s",                             "ELF64");
+		LOG_NOTICE(LOADER, "Data: %s",                              Ehdr_DataToString(e_data).c_str());
+		LOG_NOTICE(LOADER, "Current Version: %d",                   e_curver);
+		LOG_NOTICE(LOADER, "OS/ABI: %s",                            Ehdr_OS_ABIToString(e_os_abi).c_str());
+		LOG_NOTICE(LOADER, "ABI version: %lld",                     e_abi_ver);
+		LOG_NOTICE(LOADER, "Type: %s",                              Ehdr_TypeToString(e_type).c_str());
+		LOG_NOTICE(LOADER, "Machine: %s",                           Ehdr_MachineToString(e_machine).c_str());
+		LOG_NOTICE(LOADER, "Version: %d",                           e_version);
+		LOG_NOTICE(LOADER, "Entry point address: 0x%08llx",         e_entry);
+		LOG_NOTICE(LOADER, "Program headers offset: 0x%08llx",      e_phoff);
+		LOG_NOTICE(LOADER, "Section headers offset: 0x%08llx",      e_shoff);
+		LOG_NOTICE(LOADER, "Flags: 0x%x",                           e_flags);
+		LOG_NOTICE(LOADER, "Size of this header: %d",               e_ehsize);
+		LOG_NOTICE(LOADER, "Size of program headers: %d",           e_phentsize);
+		LOG_NOTICE(LOADER, "Number of program headers: %d",         e_phnum);
+		LOG_NOTICE(LOADER, "Size of section headers: %d",           e_shentsize);
+		LOG_NOTICE(LOADER, "Number of section headers: %d",         e_shnum);
+		LOG_NOTICE(LOADER, "Section header string table index: %d", e_shstrndx);
 #endif
 	}
 
@@ -105,16 +105,16 @@ struct Elf64_Shdr
 	void Show()
 	{
 #ifdef LOADER_DEBUG
-		LOGF_NOTICE(LOADER, "Name offset: %x",     sh_name);
-		LOGF_NOTICE(LOADER, "Type: %d",            sh_type);
-		LOGF_NOTICE(LOADER, "Addr: %llx",          sh_addr);
-		LOGF_NOTICE(LOADER, "Offset: %llx",        sh_offset);
-		LOGF_NOTICE(LOADER, "Size: %llx",          sh_size);
-		LOGF_NOTICE(LOADER, "EntSize: %lld",       sh_entsize);
-		LOGF_NOTICE(LOADER, "Flags: %llx",         sh_flags);
-		LOGF_NOTICE(LOADER, "Link: %x",            sh_link);
-		LOGF_NOTICE(LOADER, "Info: %x",            sh_info);
-		LOGF_NOTICE(LOADER, "Address align: %llx", sh_addralign);
+		LOG_NOTICE(LOADER, "Name offset: %x",     sh_name);
+		LOG_NOTICE(LOADER, "Type: %d",            sh_type);
+		LOG_NOTICE(LOADER, "Addr: %llx",          sh_addr);
+		LOG_NOTICE(LOADER, "Offset: %llx",        sh_offset);
+		LOG_NOTICE(LOADER, "Size: %llx",          sh_size);
+		LOG_NOTICE(LOADER, "EntSize: %lld",       sh_entsize);
+		LOG_NOTICE(LOADER, "Flags: %llx",         sh_flags);
+		LOG_NOTICE(LOADER, "Link: %x",            sh_link);
+		LOG_NOTICE(LOADER, "Info: %x",            sh_info);
+		LOG_NOTICE(LOADER, "Address align: %llx", sh_addralign);
 #endif
 	}
 };
@@ -145,14 +145,14 @@ struct Elf64_Phdr
 	void Show()
 	{
 #ifdef LOADER_DEBUG
-		LOGF_NOTICE(LOADER, "Type: %s",                   Phdr_TypeToString(p_type).c_str());
-		LOGF_NOTICE(LOADER, "Offset: 0x%08llx",           p_offset);
-		LOGF_NOTICE(LOADER, "Virtual address: 0x%08llx",  p_vaddr);
-		LOGF_NOTICE(LOADER, "Physical address: 0x%08llx", p_paddr);
-		LOGF_NOTICE(LOADER, "File size: 0x%08llx",        p_filesz);
-		LOGF_NOTICE(LOADER, "Memory size: 0x%08llx",      p_memsz);
-		LOGF_NOTICE(LOADER, "Flags: %s",                  Phdr_FlagsToString(p_flags).c_str());
-		LOGF_NOTICE(LOADER, "Align: 0x%llx",              p_align);
+		LOG_NOTICE(LOADER, "Type: %s",                   Phdr_TypeToString(p_type).c_str());
+		LOG_NOTICE(LOADER, "Offset: 0x%08llx",           p_offset);
+		LOG_NOTICE(LOADER, "Virtual address: 0x%08llx",  p_vaddr);
+		LOG_NOTICE(LOADER, "Physical address: 0x%08llx", p_paddr);
+		LOG_NOTICE(LOADER, "File size: 0x%08llx",        p_filesz);
+		LOG_NOTICE(LOADER, "Memory size: 0x%08llx",      p_memsz);
+		LOG_NOTICE(LOADER, "Flags: %s",                  Phdr_FlagsToString(p_flags).c_str());
+		LOG_NOTICE(LOADER, "Align: 0x%llx",              p_align);
 #endif
 	}
 };

--- a/rpcs3/Loader/PKG.cpp
+++ b/rpcs3/Loader/PKG.cpp
@@ -27,15 +27,15 @@ bool PKGLoader::Install(std::string dest)
 	if (rDirExists(dest+titleID)) {
 		rMessageDialog d_overwrite(NULL, "Another installation was found. Do you want to overwrite it?", "PKG Decrypter / Installer", rYES_NO|rCENTRE);
 		if (d_overwrite.ShowModal() != rID_YES) {
-			LOGF_ERROR(LOADER, "PKG Loader: Another installation found in: %s", titleID.c_str());
+			LOG_ERROR(LOADER, "PKG Loader: Another installation found in: %s", titleID.c_str());
 			return false;
 		}
 		// TODO: Remove the following two lines and remove the folder dest+titleID
-		LOGF_ERROR(LOADER, "PKG Loader: Another installation found in: %s", titleID.c_str());
+		LOG_ERROR(LOADER, "PKG Loader: Another installation found in: %s", titleID.c_str());
 		return false;
 	}
 	if (!rMkdir(dest+titleID)) {
-		LOGF_ERROR(LOADER, "PKG Loader: Could not make the installation directory: %s", titleID.c_str());
+		LOG_ERROR(LOADER, "PKG Loader: Could not make the installation directory: %s", titleID.c_str());
 		return false;
 	}
 
@@ -47,7 +47,7 @@ bool PKGLoader::Install(std::string dest)
 	}
 	else
 	{
-		LOGF_NOTICE(LOADER, "PKG Loader: Package successfully installed in: /dev_hdd0/game/%s", titleID.c_str());
+		LOG_NOTICE(LOADER, "PKG Loader: Package successfully installed in: /dev_hdd0/game/%s", titleID.c_str());
 		return true;
 	}
 }

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -43,7 +43,7 @@ bool PSFLoader::LoadHeader()
 	if(!m_header.CheckMagic())
 		return false;
 
-	if(m_show_log) LOGF_NOTICE(LOADER, "PSF version: %x", m_header.psf_version);
+	if(m_show_log) LOG_NOTICE(LOADER, "PSF version: %x", m_header.psf_version);
 
 	m_psfindxs.clear();
 	m_entries.clear();

--- a/rpcs3/Loader/SELF.h
+++ b/rpcs3/Loader/SELF.h
@@ -24,14 +24,14 @@ struct SceHeader
 
 	void Show()
 	{
-		LOGF_NOTICE(LOADER, "Magic: %08x",   se_magic);
-		LOGF_NOTICE(LOADER, "Class: %s",     "SELF");
-		LOGF_NOTICE(LOADER, "hver: 0x%08x",  se_hver);
-		LOGF_NOTICE(LOADER, "flags: 0x%04x", se_flags);
-		LOGF_NOTICE(LOADER, "type: 0x%04x",  se_type);
-		LOGF_NOTICE(LOADER, "meta: 0x%08x",  se_meta);
-		LOGF_NOTICE(LOADER, "hsize: 0x%llx", se_hsize);
-		LOGF_NOTICE(LOADER, "esize: 0x%llx", se_esize);
+		LOG_NOTICE(LOADER, "Magic: %08x",   se_magic);
+		LOG_NOTICE(LOADER, "Class: %s",     "SELF");
+		LOG_NOTICE(LOADER, "hver: 0x%08x",  se_hver);
+		LOG_NOTICE(LOADER, "flags: 0x%04x", se_flags);
+		LOG_NOTICE(LOADER, "type: 0x%04x",  se_type);
+		LOG_NOTICE(LOADER, "meta: 0x%08x",  se_meta);
+		LOG_NOTICE(LOADER, "hsize: 0x%llx", se_hsize);
+		LOG_NOTICE(LOADER, "esize: 0x%llx", se_esize);
 	}
 
 	bool CheckMagic() const { return se_magic == 0x53434500; }
@@ -66,15 +66,15 @@ struct SelfHeader
 
 	void Show()
 	{
-		LOGF_NOTICE(LOADER, "header type: 0x%llx",           se_htype);
-		LOGF_NOTICE(LOADER, "app info offset: 0x%llx",       se_appinfooff);
-		LOGF_NOTICE(LOADER, "elf offset: 0x%llx",            se_elfoff);
-		LOGF_NOTICE(LOADER, "program header offset: 0x%llx", se_phdroff);
-		LOGF_NOTICE(LOADER, "section header offset: 0x%llx", se_shdroff);
-		LOGF_NOTICE(LOADER, "section info offset: 0x%llx",   se_secinfoff);
-		LOGF_NOTICE(LOADER, "sce version offset: 0x%llx",    se_sceveroff);
-		LOGF_NOTICE(LOADER, "control info offset: 0x%llx",   se_controloff);
-		LOGF_NOTICE(LOADER, "control info size: 0x%llx",     se_controlsize);
+		LOG_NOTICE(LOADER, "header type: 0x%llx",           se_htype);
+		LOG_NOTICE(LOADER, "app info offset: 0x%llx",       se_appinfooff);
+		LOG_NOTICE(LOADER, "elf offset: 0x%llx",            se_elfoff);
+		LOG_NOTICE(LOADER, "program header offset: 0x%llx", se_phdroff);
+		LOG_NOTICE(LOADER, "section header offset: 0x%llx", se_shdroff);
+		LOG_NOTICE(LOADER, "section info offset: 0x%llx",   se_secinfoff);
+		LOG_NOTICE(LOADER, "sce version offset: 0x%llx",    se_sceveroff);
+		LOG_NOTICE(LOADER, "control info offset: 0x%llx",   se_controloff);
+		LOG_NOTICE(LOADER, "control info size: 0x%llx",     se_controlsize);
 	}
 };
 

--- a/rpcs3/Loader/TROPUSR.cpp
+++ b/rpcs3/Loader/TROPUSR.cpp
@@ -177,7 +177,7 @@ u32 TROPUSRLoader::GetTrophiesCount()
 u32 TROPUSRLoader::GetTrophyUnlockState(u32 id)
 {
 	if (id >=  m_table6.size())
-		LOGF_WARNING(LOADER, "TROPUSRLoader::GetUnlockState: Invalid id=%d", id);
+		LOG_WARNING(LOADER, "TROPUSRLoader::GetUnlockState: Invalid id=%d", id);
 
 	return m_table6[id].trophy_state; // Let's assume the trophies are stored ordered
 }
@@ -185,7 +185,7 @@ u32 TROPUSRLoader::GetTrophyUnlockState(u32 id)
 u32 TROPUSRLoader::GetTrophyTimestamp(u32 id)
 {
 	if (id >=  m_table6.size())
-		LOGF_WARNING(LOADER, "TROPUSRLoader::GetTrophyTimestamp: Invalid id=%d", id);
+		LOG_WARNING(LOADER, "TROPUSRLoader::GetTrophyTimestamp: Invalid id=%d", id);
 
 	// TODO: What timestamp does sceNpTrophyGetTrophyInfo want, timestamp1 or timestamp2? 
 	return m_table6[id].timestamp2; // Let's assume the trophies are stored ordered

--- a/rpcs3/Loader/TRP.cpp
+++ b/rpcs3/Loader/TRP.cpp
@@ -51,7 +51,7 @@ bool TRPLoader::LoadHeader(bool show)
 		return false;
 
 	if (show)
-		LOGF_NOTICE(LOADER, "TRP version: %x", m_header.trp_version);
+		LOG_NOTICE(LOADER, "TRP version: %x", m_header.trp_version);
 
 	m_entries.clear();
 	m_entries.resize(m_header.trp_files_count);
@@ -62,7 +62,7 @@ bool TRPLoader::LoadHeader(bool show)
 			return false;
 
 		if (show)
-			LOGF_NOTICE(LOADER, "TRP entry #%d: %s", m_entries[i].name);
+			LOG_NOTICE(LOADER, "TRP entry #%d: %s", m_entries[i].name);
 	}
 
 	return true;


### PR DESCRIPTION
I didn't really think about it the first time around
- use only one set of logging macros instead of two
- don't use free() as a function name (clashes with msvc memory debugging)
