### PR TITLE
RSX: sanity check m_alpha_func

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -1083,7 +1083,7 @@ void GLGSRender::ExecCMD()
 		checkForGlError("glFrontFace");
 	}
 
-	if(m_set_alpha_func && m_set_alpha_ref)
+	if(m_set_alpha_func && m_set_alpha_ref && m_alpha_func)
 	{
 		glAlphaFunc(m_alpha_func, m_alpha_ref);
 		checkForGlError("glAlphaFunc");


### PR DESCRIPTION
Add sanity check for non-zero m_alpha_func and fix glAlphaFunc: opengl error 0x0500 in Resident Evil 4 .

RSX: W RSXThreadNew FBO (1280x720)
RSX: E RSXThreadm_alpha_func = 0x0 , m_alpha_ref = 0.00
RSX: E RSXThreadglAlphaFunc: opengl error 0x0500
RSX: W RSXThreadRSX thread aborted
