### PR TITLE
RSX : add rescale support for native 960x1080 & 1024x768

### DIFF
--- a/rpcs3/Emu/GS/RSXThread.cpp
+++ b/rpcs3/Emu/GS/RSXThread.cpp
@@ -1373,7 +1373,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 		{
 			switch (Ini.GSResolution.GetValue())
 			{
-			case 1:// 1920x1080 window size
+			case 1: // 1920x1080 window size
 				m_width_scale = m_height_scale = 4.0f;
 				m_width = 1980;
 				m_height = 1080;
@@ -1386,6 +1386,58 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 			case 4: // 720x480 window size
 				m_width_scale = 1.5f;
 				m_height_scale = 1.77f;
+				m_width = 720;
+				m_height = 480;
+				break;
+			}
+		}
+
+		// Rescale native 960x1080 to fit 1080p/720p/480p window size
+		if (m_buffer_width == 960 && m_buffer_height == 1080)
+		{
+			switch (Ini.GSResolution.GetValue())
+			{
+			case 1: // 1920x1080 window size
+				m_width_scale = 4.0f;
+				m_height_scale = 2.0f;
+				m_width = 1980;
+				m_height = 1080;
+				break;
+			case 2: // 1280x720 window size
+				m_width_scale = 2.66f;
+				m_height_scale = 1.33f;
+				m_width = 1280;
+				m_height = 720;
+				break;
+			case 4: // 720x480 window size
+				m_width_scale = 1.5f;
+				m_height_scale = 0.88f;
+				m_width = 720;
+				m_height = 480;
+				break;
+			}
+		}
+
+		// Rescale native 1024x768 to fit 1080p/720p/480p window size
+		if (m_buffer_width == 1024 && m_buffer_height == 768)
+		{
+			switch (Ini.GSResolution.GetValue())
+			{
+			case 1: // 1920x1080 window size
+				m_width_scale = 3.75f;
+				m_height_scale = 2.81f;
+				m_width = 1980;
+				m_height = 1080;
+				break;
+			case 2: // 1280x720 window size
+				m_width_scale = 2.5f;
+				m_height_scale = 1.87f;
+				m_width = 1280;
+				m_height = 720;
+				break;
+			case 4: // 720x480 window size
+				m_width_scale = 1.4f;
+				m_height_scale = 1.25f;
 				m_width = 720;
 				m_height = 480;
 				break;

--- a/rpcs3/Emu/GS/sysutil_video.h
+++ b/rpcs3/Emu/GS/sysutil_video.h
@@ -231,9 +231,6 @@ static const CellVideoOutResolution ResolutionTable[] =
 	{1600, 1080},       //10 - 5
 	{1440, 1080},       //11 - 6
 	{1280, 1080},       //12 - 7
-	{960, 1080},        //13 - 8
-	{960, 540},         //14 - 9 (Terraria [BLES01938])
-	{1024,768},         //15 - 10 (Eskiss Homebrew)
 };
 
 inline static u32 ResolutionIdToNum(u32 id)
@@ -253,30 +250,24 @@ inline static u32 ResolutionIdToNum(u32 id)
 		5, //10
 		6, //11
 		7, //12
-		8, //13
-		9, //14
-		10, //15
 	};
 
-	return id <= 15 ? res[id] : 0;
+	return id <= 12 ? res[id] : 0;
 }
 
 inline static u32 ResolutionNumToId(u32 num)
 {
 	static const u32 res[] = 
 	{
-		0,
-		1,
-		2,
-		4,
-		5,
-		10,
-		11,
-		12,
-		13,
-		14,
-		15,
+		0,  //0
+		1,  //1
+		2,  //2
+		4,  //3
+		5,  //4
+		10, //5
+		11, //6
+		12, //7
 	};
 
-	return num <= 10 ? res[num] : 0;
+	return num <= 7 ? res[num] : 0;
 }


### PR DESCRIPTION
Beer Pong should be now rescaled correctly in 480p/720p/1080p with its strange native 960x1080 res

![untitled](https://cloud.githubusercontent.com/assets/3000282/3494433/d691bfae-05c5-11e4-8f68-0633a54c1ada.jpg)

(I will simplify this urgy code shortly)
