### PR TITLE
RSX : set default values using opengl one.

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -1016,21 +1016,18 @@ void GLGSRender::ExecCMD()
 
 	if(m_set_depth_func)
 	{
-		//ConLog.Warning("glDepthFunc(0x%x)", m_depth_func);
 		glDepthFunc(m_depth_func);
 		checkForGlError("glDepthFunc");
 	}
 
 	if(m_set_depth_bounds)
 	{
-		//ConLog.Warning("glDepthBounds(%f, %f)", m_depth_bounds_min, m_depth_bounds_max);
 		glDepthBoundsEXT(m_depth_bounds_min, m_depth_bounds_max);
 		checkForGlError("glDepthBounds");
 	}
 
 	if(m_set_clip)
 	{
-		//ConLog.Warning("glDepthRangef(%f, %f)", m_clip_min, m_clip_max);
 		glDepthRangef(m_clip_min, m_clip_max);
 		checkForGlError("glDepthRangef");
 	}

--- a/rpcs3/Emu/GS/RSXThread.cpp
+++ b/rpcs3/Emu/GS/RSXThread.cpp
@@ -1287,7 +1287,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	}
 	break;
 
-	// Point 
+	// Point size
 	case NV4097_SET_POINT_SIZE:
 	{
 		m_set_point_size = true;
@@ -1296,10 +1296,11 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	}
 	break;
 
+	// Point sprite
 	case NV4097_SET_POINT_PARAMS_ENABLE:
 	{
 		if (ARGS(0))
-			LOG_ERROR(RSX, "NV4097_SET_POINT_PARAMS_ENABLE");
+			LOG_ERROR(RSX, "NV4097_SET_POINT_PARAMS_ENABLE: %x", ARGS(0));
 	}
 	break;
 
@@ -1343,7 +1344,7 @@ void RSXThread::DoCmd(const u32 fcmd, const u32 cmd, mem32_ptr_t& args, const u3
 	}
 	break;
 
-	// Depth/ Color buffer usage 
+	// Depth/Color buffer usage 
 	case NV4097_SET_SURFACE_FORMAT:
 	{
 		const u32 a0 = ARGS(0);

--- a/rpcs3/Emu/GS/RSXThread.h
+++ b/rpcs3/Emu/GS/RSXThread.h
@@ -466,24 +466,39 @@ protected:
 		m_set_line_stipple = false;
 		m_set_polygon_stipple = false;
 
+		// Default value 
+		// TODO: Check against the default value on PS3 
 		m_clear_color_r = 0;
 		m_clear_color_g = 0;
 		m_clear_color_b = 0;
 		m_clear_color_a = 0;
 		m_clear_z = 0xffffff;
 		m_clear_s = 0;
-
 		m_poly_offset_scale_factor = 0.0;
 		m_poly_offset_bias = 0.0;
-
 		m_depth_bounds_min = 0.0;
 		m_depth_bounds_max = 1.0;
 		m_restart_index = 0xffffffff;
-
 		m_front_polygon_mode = 0x1b02; // GL_FILL
 		m_back_polygon_mode = 0x1b02; // GL_FILL
-		m_front_face = 0x0901;
-
+		m_front_face = 0x0901; // GL_CCW
+		m_cull_face = 0x0405; // GL_BACK
+		m_alpha_func = 0x0207; // GL_ALWAYS
+		m_alpha_ref = 0; 
+		m_logic_op = 0x1503; // GL_COPY
+		m_shade_mode = 0x1D01; // GL_SMOOTH
+		m_depth_mask = 1;
+		m_depth_func = 0x0201; // GL_LESS
+		m_depth_bounds_min = 0.0;
+		m_depth_bounds_max = 1.0;
+		m_clip_min = 0.0;
+		m_clip_max = 1.0;
+		m_blend_equation_rgb = 0x8006; // GL_FUNC_ADD
+		m_blend_equation_alpha = 0x8006; // GL_FUNC_ADD
+		m_blend_sfactor_rgb = 1; // GL_ONE
+		m_blend_dfactor_rgb = 0; // GL_ZERO
+		m_blend_sfactor_alpha = 1; // GL_ONE
+		m_blend_dfactor_alpha = 0; // GL_ZERO
 		m_point_x = 0;
 		m_point_y = 0;
 		m_point_size = 1.0;
@@ -492,7 +507,6 @@ protected:
 		m_line_stipple_factor = 1;
 		for (size_t i = 0; i < 32; i++)
 		{
-			// TODO: Check if the polygon stipple pattern is really "all ones"
 			m_polygon_stipple_pattern[i] = 0xFFFFFFFF;
 		}
 


### PR DESCRIPTION
This fixes the glCullFace: opengl error 0x0500 in NovaStrike.

TODO : check against PS3 for real default values.
