### PR TITLE
Warnings: Fix several warnings.

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -9,10 +9,9 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7.0)
 		message(FATAL_ERROR "GCC ${CMAKE_CXX_COMPILER_VERSION} is too old.")
 	endif()
-	#add_definitions(-D__WXGTK__)
-	#add_definitions(-Wfatal-errors)
-	add_definitions(-w) # TODO: remove me
-	add_definitions(-fpermissive) # TODO: remove me
+	# Warnings
+	add_definitions(-Wno-attributes -Wno-enum-compare)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	# TODO: stdlib?
 endif()

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -318,7 +318,7 @@ class SPUThread : public PPCThread
 public:
 	SPU_GPR_hdr GPR[128]; //General-Purpose Register
 	SPU_SPR_hdr SPR[128]; //Special-Purpose Registers
-	FPSCR FPSCR;
+//	FPSCR fpscr; //Unused
 	SPU_SNRConfig_hdr cfg; //Signal Notification Registers Configuration (OR-mode enabled: 0x1 for SNR1, 0x2 for SNR2)
 
 	EventPort SPUPs[64]; // SPU Thread Event Ports

--- a/rpcs3/Emu/GS/GL/GLBuffers.cpp
+++ b/rpcs3/Emu/GS/GL/GLBuffers.cpp
@@ -67,11 +67,11 @@ void GLBufferObject::SetData(const void* data, u32 size, u32 usage)
 	SetData(m_type, data, size, usage);
 }
 
-void GLBufferObject::SetAttribPointer(int location, int size, int type, int pointer, int stride, bool normalized)
+void GLBufferObject::SetAttribPointer(int location, int size, int type, GLvoid* pointer, int stride, bool normalized)
 {
 	if(location < 0) return;
 
-	glVertexAttribPointer(location, size, type, normalized ? GL_TRUE : GL_FALSE, stride, (const GLvoid*)pointer);
+	glVertexAttribPointer(location, size, type, normalized ? GL_TRUE : GL_FALSE, stride, pointer);
 	glEnableVertexAttribArray(location);
 }
 

--- a/rpcs3/Emu/GS/GL/GLBuffers.h
+++ b/rpcs3/Emu/GS/GL/GLBuffers.h
@@ -21,7 +21,7 @@ public:
 	void UnBind();
 	void SetData(u32 type, const void* data, u32 size, u32 usage = GL_DYNAMIC_DRAW);
 	void SetData(const void* data, u32 size, u32 usage = GL_DYNAMIC_DRAW);
-	void SetAttribPointer(int location, int size, int type, int pointer, int stride, bool normalized = false);
+	void SetAttribPointer(int location, int size, int type, GLvoid* pointer, int stride, bool normalized = false);
 	bool IsCreated() const;
 };
 

--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -54,7 +54,7 @@ GLGSRender::GLGSRender()
 GLGSRender::~GLGSRender()
 {
 	m_frame->Close();
-	delete m_context;
+//	delete m_context; // This won't do anything (deleting void* instead of wglContext*)
 }
 
 void GLGSRender::Enable(bool enable, const u32 cap)
@@ -249,7 +249,7 @@ void GLGSRender::EnableVertexData(bool indexed_draw)
 
 				glEnableVertexAttribArray(i);
 				checkForGlError("glEnableVertexAttribArray");
-				glVertexAttribPointer(i, m_vertex_data[i].size, gltype, normalized, 0, (void*)offset_list[i]);
+				glVertexAttribPointer(i, m_vertex_data[i].size, gltype, normalized, 0, reinterpret_cast<void*>(offset_list[i]));
 				checkForGlError("glVertexAttribPointer");
 			}
 		}

--- a/rpcs3/Emu/SysCalls/Modules/cellAdec.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellAdec.cpp
@@ -21,7 +21,7 @@ extern "C"
 
 //void cellAdec_init();
 //Module cellAdec(0x0006, cellAdec_init);
-extern Module *cellAdec=nullptr;
+Module *cellAdec = nullptr;
 
 int adecRawRead(void* opaque, u8* buf, int buf_size)
 {

--- a/rpcs3/Emu/SysCalls/Modules/cellAtrac.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellAtrac.cpp
@@ -7,7 +7,7 @@
 #include "Emu/SysCalls/Modules.h"
 #include "Emu/SysCalls/SysCalls.h"
 
-extern Module *cellAtrac = nullptr;
+Module *cellAtrac = nullptr;
 
 #include "cellAtrac.h"
 

--- a/rpcs3/Emu/SysCalls/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellAudio.cpp
@@ -13,7 +13,7 @@
 
 //void cellAudio_init();
 //Module cellAudio(0x0011, cellAudio_init);
-extern Module *cellAudio = nullptr;
+Module *cellAudio = nullptr;
 
 static std::mutex audioMutex;
 

--- a/rpcs3/Emu/SysCalls/Modules/cellFontFT.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellFontFT.cpp
@@ -12,7 +12,7 @@
 //void cellFontFT_load();
 //void cellFontFT_unload();
 //Module cellFontFT(0x001a, cellFontFT_init, cellFontFT_load, cellFontFT_unload);
-extern Module *cellFontFT = nullptr;
+Module *cellFontFT = nullptr;
 
 struct CellFontLibraryConfigFT
 {

--- a/rpcs3/Emu/SysCalls/Modules/cellGame.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellGame.cpp
@@ -14,7 +14,7 @@
 
 //void cellGame_init();
 //Module cellGame(0x003e, cellGame_init);
-extern Module *cellGame = nullptr;
+Module *cellGame = nullptr;
 
 std::string contentInfo = "";
 std::string usrdir = "";

--- a/rpcs3/Emu/SysCalls/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellGcmSys.cpp
@@ -12,7 +12,7 @@
 //void cellGcmSys_load();
 //void cellGcmSys_unload();
 //Module cellGcmSys(0x0010, cellGcmSys_init, cellGcmSys_load, cellGcmSys_unload);
-extern Module *cellGcmSys = nullptr;
+Module *cellGcmSys = nullptr;
 
 u32 local_size = 0;
 u32 local_addr = 0;

--- a/rpcs3/Emu/SysCalls/Modules/cellGifDec.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellGifDec.cpp
@@ -13,7 +13,7 @@
 
 //void cellGifDec_init();
 //Module cellGifDec(0xf010, cellGifDec_init);
-extern Module *cellGifDec = nullptr;
+Module *cellGifDec = nullptr;
 
 int cellGifDecCreate(u32 mainHandle, u32 threadInParam, u32 threadOutParam)
 {
@@ -174,7 +174,8 @@ int cellGifDecDecodeData(u32 mainHandle, u32 subHandle, mem8_ptr_t data, const m
 	//Decode GIF file. (TODO: Is there any faster alternative? Can we do it without external libraries?)
 	int width, height, actual_components;
 	std::shared_ptr<unsigned char> image(stbi_load_from_memory(gif, fileSize, &width, &height, &actual_components, 4));
-	if (!image)	return CELL_GIFDEC_ERROR_STREAM_FORMAT;
+	if (!image)
+		return CELL_GIFDEC_ERROR_STREAM_FORMAT;
 
 	uint image_size = width * height * 4;
 

--- a/rpcs3/Emu/SysCalls/Modules/cellJpgDec.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellJpgDec.cpp
@@ -10,7 +10,7 @@
 
 //void cellJpgDec_init();
 //Module cellJpgDec(0x000f, cellJpgDec_init);
-extern Module *cellJpgDec = nullptr;
+Module *cellJpgDec = nullptr;
 
 int cellJpgDecCreate(u32 mainHandle, u32 threadInParam, u32 threadOutParam)
 {
@@ -155,7 +155,8 @@ int cellJpgDecDecodeData(u32 mainHandle, u32 subHandle, mem8_ptr_t data, const m
 	int width, height, actual_components;
 	std::shared_ptr<unsigned char> image(stbi_load_from_memory(jpg, fileSize, &width, &height, &actual_components, 4));
 
-	if (!image) return CELL_JPGDEC_ERROR_STREAM_FORMAT;
+	if (!image)
+		return CELL_JPGDEC_ERROR_STREAM_FORMAT;
 
 	uint image_size = width * height;
 	switch((u32)current_outParam.outputColorSpace)

--- a/rpcs3/Emu/SysCalls/Modules/cellPngDec.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellPngDec.cpp
@@ -11,7 +11,7 @@
 
 //void cellPngDec_init();
 //Module cellPngDec(0x0018, cellPngDec_init);
-extern Module *cellPngDec = nullptr;
+Module *cellPngDec = nullptr;
 
 static std::map<u32, CellPngDecMainHandle *> cellPngDecMap;
 

--- a/rpcs3/Emu/SysCalls/Modules/cellResc.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellResc.cpp
@@ -456,10 +456,10 @@ void InitMembers()
 {
 	s_rescInternalInstance->m_dstMode = (CellRescBufferMode)0;
 	s_rescInternalInstance->m_interlaceElement = CELL_RESC_ELEMENT_FLOAT;
-	s_rescInternalInstance->m_colorBuffersEA = NULL;
-	s_rescInternalInstance->m_vertexArrayEA = NULL;
-	s_rescInternalInstance->m_fragmentUcodeEA = NULL;
-	s_rescInternalInstance->m_interlaceTableEA = NULL;
+	s_rescInternalInstance->m_colorBuffersEA = 0;
+	s_rescInternalInstance->m_vertexArrayEA = 0;
+	s_rescInternalInstance->m_fragmentUcodeEA = 0;
+	s_rescInternalInstance->m_interlaceTableEA = 0;
 	s_rescInternalInstance->m_bufIdFront = 0;
 	s_rescInternalInstance->m_dstWidth = 0;
 	s_rescInternalInstance->m_dstHeight = 0;
@@ -668,7 +668,7 @@ void cellRescExit()
 	if (IsPalTemporal())
 	{
 		cellGcmSetSecondVFrequency(CELL_GCM_DISPLAY_FREQUENCY_DISABLE);
-		cellGcmSetVBlankHandler(NULL);
+		cellGcmSetVBlankHandler(0);
 		//GcmSysTypePrefix::cellGcmSetSecondVHandler(NULL);
 
 		if (IsPalInterpolate())
@@ -756,12 +756,12 @@ void SetVBlankHandler(u32 handler)
 	if (IsNotPalTemporal()) 
 	{
 		cellGcmSetVBlankHandler(handler);
-		s_rescInternalInstance->s_applicationVBlankHandler = NULL;
+		s_rescInternalInstance->s_applicationVBlankHandler = 0;
 	}
 	else if (IsPal60Hsync()) 
 	{
 		//cellGcmSetSecondVHandler(handler);
-		s_rescInternalInstance->s_applicationVBlankHandler = NULL;
+		s_rescInternalInstance->s_applicationVBlankHandler = 0;
 	}
 	else 
 	{
@@ -782,7 +782,7 @@ void SetFlipHandler(u32 handler)
 	if (IsGcmFlip()) 
 	{
 		cellGcmSetFlipHandler(handler);
-		s_rescInternalInstance->s_applicationFlipHandler = NULL;
+		s_rescInternalInstance->s_applicationFlipHandler = 0;
 	}
 	else 
 	{
@@ -857,20 +857,20 @@ int cellRescSetDisplayMode(u32 displayMode)
 		cellGcmSetSecondVFrequency(CELL_GCM_DISPLAY_FREQUENCY_59_94HZ);
 		//cellGcmSetVBlankHandler(IntrHandler50);
 		//cellGcmSetSecondVHandler(IntrHandler60);
-		cellGcmSetFlipHandler(NULL);
+		cellGcmSetFlipHandler(0);
 	}
 	else if (IsPalDrop())
 	{
 		//InitLabels();
 		cellGcmSetSecondVFrequency(CELL_GCM_DISPLAY_FREQUENCY_59_94HZ);
-		cellGcmSetVBlankHandler(NULL);
+		cellGcmSetVBlankHandler(0);
 		//cellGcmSetSecondVHandler(IntrHandler60Drop);
-		cellGcmSetFlipHandler(NULL);
+		cellGcmSetFlipHandler(0);
 	} 
 	else if (IsPal60Hsync())
 	{
 		cellGcmSetSecondVFrequency(CELL_GCM_DISPLAY_FREQUENCY_59_94HZ);
-		cellGcmSetVBlankHandler(NULL);
+		cellGcmSetVBlankHandler(0);
 	}
 
 	if (s_rescInternalInstance->s_applicationVBlankHandler) SetVBlankHandler(s_rescInternalInstance->s_applicationVBlankHandler);
@@ -1323,7 +1323,7 @@ int cellRescCreateInterlaceTable(u32 ea_addr, float srcH, CellRescTableElement d
 		return CELL_RESC_ERROR_NOT_INITIALIZED;
 	}
 
-	if ((ea_addr == NULL) || (srcH <= 0.f) || (!(depth == CELL_RESC_ELEMENT_HALF || depth == CELL_RESC_ELEMENT_FLOAT)) || (length <= 0))
+	if ((ea_addr == 0) || (srcH <= 0.f) || (!(depth == CELL_RESC_ELEMENT_HALF || depth == CELL_RESC_ELEMENT_FLOAT)) || (length <= 0))
 	{
 		cellResc->Error("cellRescCreateInterlaceTable : CELL_RESC_ERROR_NOT_INITIALIZED");
 		return CELL_RESC_ERROR_BAD_ARGUMENT;

--- a/rpcs3/Emu/SysCalls/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSysutil.cpp
@@ -20,7 +20,7 @@ typedef void (*CellHddGameStatCallback)(mem_ptr_t<CellHddGameCBResult> cbResult,
 
 //void cellSysutil_init();
 //Module cellSysutil(0x0015, cellSysutil_init);
-Module *cellSysutil;
+Module *cellSysutil = nullptr;
 
 int cellSysutilGetSystemParamInt(int id, mem32_t value)
 {

--- a/rpcs3/Emu/SysCalls/Modules/cellSysutilAp.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSysutilAp.cpp
@@ -8,7 +8,7 @@
 
 //void cellSysutilAp_init();
 //Module cellSysutilAp(0x0039, cellSysutilAp_init);
-extern Module *cellSysutilAp = nullptr;
+Module *cellSysutilAp = nullptr;
 
 // Return Codes
 enum

--- a/rpcs3/Emu/SysCalls/Modules/cellUserInfo.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellUserInfo.cpp
@@ -10,7 +10,7 @@
 
 //void cellUserInfo_init();
 //Module cellUserInfo(0x0032, cellUserInfo_init);
-extern Module *cellUserInfo = nullptr;
+Module *cellUserInfo = nullptr;
 
 int cellUserInfoGetStat(u32 id, mem_ptr_t<CellUserInfoUserStat> stat)
 {


### PR DESCRIPTION
Deleting a void\* (which won't do anything on c++0x) replaced with comment.
Comparing int to NULL or nullptr.
Setting ints to NULL;
Passing int to a function expecting a pointer.
Initialising externs and having two externs instead of a definition.
Having a class member with the same name as another class. It was unused anyway.
Remove some 'TODO: remove me' such as -fpermissive and -w in CMake.
