### PR TITLE
Use a standard config dir on non-Windows. Fixes #192

### DIFF
--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "rPlatform.h"
 #include "Log.h"
 #include <iostream>
 #include <string>
@@ -98,7 +99,7 @@ struct FileListener : LogListener
 	bool mPrependChannelName;
 
 	FileListener(const std::string& name = _PRGNAME_, bool prependChannel = true)
-		: mFile(name + ".log", rFile::write),
+		: mFile(std::string(rPlatform::getConfigDir() + name + ".log").c_str(), rFile::write),
 		mPrependChannelName(prependChannel)
 	{
 		if (!mFile.IsOpened())

--- a/Utilities/rPlatform.cpp
+++ b/Utilities/rPlatform.cpp
@@ -15,6 +15,10 @@
 #include "Emu/Io/XInput/XInputPadHandler.h"
 #endif
 
+#ifndef _WIN32
+#include <dirent.h>
+#endif
+
 
 rCanvas::rCanvas(void *parent)
 {
@@ -133,6 +137,27 @@ KeyboardHandlerBase *rPlatform::getKeyboardHandler(int i)
 int rPlatform::getMouseHandlerCount()
 {
 	return 2;
+}
+
+std::string rPlatform::getConfigDir()
+{
+	static std::string dir = ".";
+	if (dir == ".") {
+#ifdef _WIN32
+		dir = "";
+		//mkdir(dir.c_str());
+#else
+		if (getenv("XDG_CONFIG_HOME") != NULL)
+			dir = getenv("XDG_CONFIG_HOME");
+		else if (getenv("HOME") != NULL)
+			dir = getenv("HOME") + std::string("/.config");
+		else // Just in case
+			dir = "./config";
+		dir = dir + "/rpcs3/";
+		mkdir(dir.c_str());
+#endif
+	}
+	return dir;
 }
 
 

--- a/Utilities/rPlatform.h
+++ b/Utilities/rPlatform.h
@@ -46,6 +46,7 @@ struct rPlatform
 	static MouseHandlerBase *getMouseHandler(int i);
 	static int getPadHandlerCount();
 	static PadHandlerBase *getPadHandler(int i);
+	static std::string getConfigDir();
 };
 
 /**********************************************************************

--- a/rpcs3/Ini.cpp
+++ b/rpcs3/Ini.cpp
@@ -2,6 +2,7 @@
 #include "Ini.h"
 
 #include "Utilities/StrFmt.h"
+#include "Utilities/rPlatform.h"
 
 #include <algorithm>
 #include <cctype>
@@ -16,7 +17,7 @@ CSimpleIniCaseA *getIniFile()
 	if (inited == false)
 	{
 		ini.SetUnicode(true);
-		ini.LoadFile(DEF_CONFIG_NAME);
+		ini.LoadFile(std::string(rPlatform::getConfigDir() + DEF_CONFIG_NAME).c_str());
 		inited = true;
 	}
 	return &ini;
@@ -24,7 +25,7 @@ CSimpleIniCaseA *getIniFile()
 
 void saveIniFile()
 {
-	getIniFile()->SaveFile(DEF_CONFIG_NAME);
+	getIniFile()->SaveFile(std::string(rPlatform::getConfigDir() + DEF_CONFIG_NAME).c_str());
 }
 
 Inis Ini;
@@ -77,14 +78,14 @@ static WindowInfo StringToWindowInfo(const std::string& str)
 			vec.push_back(std::stoi(str.substr(start, found == std::string::npos ? found : found - start)));
 		}
 		catch (const std::invalid_argument& e) {
-			return WindowInfo::GetDefault();
+			return WindowInfo();
 		}
 		if (found == std::string::npos)
 			break;
 		start = found + 1;
 	}
 	if (vec.size() < 4 || vec[0] <= 0 || vec[1] <= 0 || vec[2] < 0 || vec[3] < 0)
-		return WindowInfo::GetDefault();
+		return WindowInfo();
 
 	return WindowInfo(std::make_pair(vec[0], vec[1]), std::make_pair(vec[2], vec[3]));
 }

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -18,12 +18,6 @@ struct WindowInfo
 		, position(_position)
 	{
 	}
-
-	//TODO: remove
-	static WindowInfo GetDefault()
-	{
-		return WindowInfo({ -1, -1 }, { -1, -1 });
-	}
 };
 
 class Ini


### PR DESCRIPTION
Also remove WindowInfo::GetDefault which was redundant.
