### PR TITLE
Revert "Fix a dst_reg typo for tc9"

### DIFF
--- a/rpcs3/Emu/GS/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/GS/GL/GLVertexProgram.cpp
@@ -353,7 +353,7 @@ std::string GLVertexDecompilerThread::BuildCode()
 		{ "tc6", true, "dst_reg13", "", false },
 		{ "tc7", true, "dst_reg14", "", false },
 		{ "tc8", true, "dst_reg15", "", false },
-		{ "tc9", true, "dst_reg16", "", false }
+		{ "tc9", true, "dst_reg6", "", false }
 	};
 
 	std::string f;


### PR DESCRIPTION
Reverts DHrpcs3/rpcs3#579

Comments from DH:

> this is not a typo ;)
> dst_reg6 can be used for point size, clip distance or tc9
