### PR TITLE
use a include directory relative to the lists file

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/rpcs3/cmake_modules")
+set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake_modules")
 include(cotire)
 
 project(rpcs3)


### PR DESCRIPTION
This is supposed to make `rpcs3/CMakeLists.txt` usable without being included by `./CMakeLists.txt` like #590 tried.

Let the buildbot check it before merging
