### PR TITLE
Fix flip control gcm sample

### DIFF
--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -896,6 +896,7 @@ void GLGSRender::ExecCMD()
 	Enable(m_set_alpha_test, GL_ALPHA_TEST);
 	Enable(m_set_depth_bounds_test, GL_DEPTH_BOUNDS_TEST_EXT);
 	Enable(m_set_blend || m_set_blend_mrt1 || m_set_blend_mrt2 || m_set_blend_mrt3, GL_BLEND);
+	Enable(m_set_scissor_horizontal && m_set_scissor_vertical, GL_SCISSOR_TEST);
 	Enable(m_set_logic_op, GL_LOGIC_OP);
 	Enable(m_set_cull_face, GL_CULL_FACE);
 	Enable(m_set_dither, GL_DITHER);
@@ -955,6 +956,12 @@ void GLGSRender::ExecCMD()
 		checkForGlError("glLogicOp");
 	}
 
+	if (m_set_scissor_horizontal && m_set_scissor_vertical)
+	{
+		glScissor(m_scissor_x, m_scissor_y, m_scissor_w, m_scissor_h);
+		checkForGlError("glScissor");
+	}
+	
 	if(m_set_two_sided_stencil_test_enable)
 	{
 		if(m_set_stencil_fail && m_set_stencil_zfail && m_set_stencil_zpass)


### PR DESCRIPTION
Flip control gcm sample should be more correct now .

![after](https://cloud.githubusercontent.com/assets/3000282/3699919/f1a3377e-13d9-11e4-8d47-12c55817492f.jpg)
