### PR TITLE
Fix debugger startup error

### DIFF
--- a/rpcs3/Gui/RSXDebugger.cpp
+++ b/rpcs3/Gui/RSXDebugger.cpp
@@ -443,7 +443,9 @@ void RSXDebugger::GetBuffers()
 
 		wxImage img(width, height, buffer);
 		wxClientDC dc_canvas(pnl);
-		dc_canvas.DrawBitmap(img.Scale(m_panel_width, m_panel_height), 0, 0, false);
+		
+		if (img.IsOk())
+			dc_canvas.DrawBitmap(img.Scale(m_panel_width, m_panel_height), 0, 0, false);
 	}
 
 	// Draw Texture


### PR DESCRIPTION
Sometimes wxWidgets would give an error, when you tried to open debugger. (for example: when trying to debug Minecraft PS3 Edition)
