### PR TITLE
More rFile cleanups and fixes.

### DIFF
--- a/Utilities/rFile.h
+++ b/Utilities/rFile.h
@@ -2,6 +2,24 @@
 
 #include <string>
 
+struct FileInfo {
+	std::string name;
+	std::string fullName;
+	bool exists;
+	bool isDirectory;
+	bool isWritable;
+	uint64_t size;
+};
+
+bool getFileInfo(const char *path, FileInfo *fileInfo);
+bool rIsDir(const std::string& filename);
+bool rRmdir(const std::string& dir);
+bool rMkdir(const std::string& dir);
+bool rMkpath(const std::string& path);
+bool rRename(const std::string &from, const std::string &to);
+bool rExists(const std::string &path);
+bool rRemoveFile(const std::string &path);
+
 enum rSeekMode
 {
 	rFromStart,
@@ -40,20 +58,6 @@ public:
 
 	void *handle;
 };
-
-std::string rGetCwd();
-bool rRmdir(const std::string& dir);
-bool rMkdir(const std::string& dir);
-bool rMkpath(const std::string& path);
-bool rRename(const std::string &from, const std::string &to);
-bool rExists(const std::string &path);
-bool rDirExists(const std::string &path);
-bool rFileExists(const std::string &path);
-bool rRemoveFile(const std::string &path);
-
-bool rIsWritable(const std::string& path);
-bool rIsReadable(const std::string& path);
-bool rIsExecutable(const std::string& path);
 
 struct rDir
 {

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -191,7 +191,8 @@ int Unpack(rFile& pkg_f, std::string src, std::string dst)
 	PKGHeader* m_header = (PKGHeader*) malloc (sizeof(PKGHeader));
 
 	rFile dec_pkg_f;
-	std::string decryptedFile = rGetCwd() + "/dev_hdd1/" + src + ".dec";
+	// TODO: This shouldn't use current dir
+	std::string decryptedFile = "./dev_hdd1/" + src + ".dec";
 
 	dec_pkg_f.Create(decryptedFile, true);
 	

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -505,10 +505,11 @@ bool SELFDecrypter::GetKeyFromRap(u8 *content_id, u8 *npdrm_key)
 
 	// Try to find a matching RAP file under dev_usb000.
 	std::string ci_str((const char *)content_id);
-	std::string rap_path(rGetCwd() + "/dev_usb000/" + ci_str + ".rap");
+	// TODO: This shouldn't use current dir
+	std::string rap_path("./dev_usb000/" + ci_str + ".rap");
 
 	// Check if we have a valid RAP file.
-	if (!rFile::Exists(rap_path))
+	if (!rExists(rap_path))
 	{
 		LOG_ERROR(LOADER, "This application requires a valid RAP file for decryption!");
 		return false;

--- a/rpcs3/Emu/FS/VFS.cpp
+++ b/rpcs3/Emu/FS/VFS.cpp
@@ -291,7 +291,8 @@ void VFS::Init(const std::string& path)
 		}
 		
 		std::string mpath = entry.path;
-		fmt::Replace(mpath,"$(EmulatorDir)", rGetCwd());
+		// TODO: This shouldn't use current dir
+		fmt::Replace(mpath,"$(EmulatorDir)", ".");
 		fmt::Replace(mpath,"$(GameDir)", vfsDevice::GetRoot(path));
 		Mount(entry.mount, mpath, dev);
 	}

--- a/rpcs3/Emu/FS/vfsDirBase.cpp
+++ b/rpcs3/Emu/FS/vfsDirBase.cpp
@@ -32,7 +32,7 @@ bool vfsDirBase::IsOpened() const
 
 bool vfsDirBase::IsExists(const std::string& path) const
 {
-	return rDirExists(path);
+	return rExists(path);
 }
 
 const std::vector<DirEntryInfo>& vfsDirBase::GetEntries() const

--- a/rpcs3/Emu/FS/vfsLocalDir.cpp
+++ b/rpcs3/Emu/FS/vfsLocalDir.cpp
@@ -26,13 +26,18 @@ bool vfsLocalDir::Open(const std::string& path)
 		std::string dir_path = path + name;
 
 		m_entries.emplace_back();
+		// TODO: Use same info structure as fileinfo?
 		DirEntryInfo& info = m_entries.back();
 		info.name = name;
 
-		info.flags |= dir.Exists(dir_path) ? DirEntry_TypeDir : DirEntry_TypeFile;
-		if(rIsWritable(dir_path)) info.flags |= DirEntry_PermWritable;
-		if(rIsReadable(dir_path)) info.flags |= DirEntry_PermReadable;
-		if(rIsExecutable(dir_path)) info.flags |= DirEntry_PermExecutable;
+		FileInfo fileinfo;
+		getFileInfo(dir_path.c_str(), &fileinfo);
+
+		// Not sure of purpose for below. I hope these don't need to be correct
+		info.flags |= rIsDir(dir_path) ? DirEntry_TypeDir : DirEntry_TypeFile;
+		if(fileinfo.isWritable) info.flags |= DirEntry_PermWritable;
+		info.flags |= DirEntry_PermReadable; // Always?
+		info.flags |= DirEntry_PermExecutable; // Always?
 	}
 
 	return true;

--- a/rpcs3/Emu/FS/vfsLocalFile.cpp
+++ b/rpcs3/Emu/FS/vfsLocalFile.cpp
@@ -63,7 +63,7 @@ bool vfsLocalFile::Create(const std::string& path)
 			break;
 
 		const std::string& dir = path.substr(0, p);
-		if(!rDirExists(dir))
+		if(!rExists(dir))
 		{
 			LOG_NOTICE(HLE, "create dir: %s", dir.c_str());
 			rMkdir(dir);
@@ -72,7 +72,7 @@ bool vfsLocalFile::Create(const std::string& path)
 
 	//create file
 	const char m = path[path.length() - 1];
-	if(m != '/' && m != '\\' && !rFileExists(path)) // ???
+	if(m != '/' && m != '\\' && !rExists(path)) // ???
 	{
 		rFile f;
 		return f.Create(path);
@@ -118,5 +118,5 @@ bool vfsLocalFile::IsOpened() const
 
 bool vfsLocalFile::Exists(const std::string& path)
 {
-	return rFileExists(path);
+	return rExists(path);
 }

--- a/rpcs3/Emu/GS/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/GS/GL/GLGSRender.cpp
@@ -359,7 +359,8 @@ bool GLGSRender::LoadProgram()
 		m_shader_prog.Compile();
 		checkForGlError("m_shader_prog.Compile");
 
-		rFile f(rGetCwd() + "/FragmentProgram.txt", rFile::write);
+		// TODO: This shouldn't use current dir
+		rFile f("./FragmentProgram.txt", rFile::write);
 		f.Write(m_shader_prog.GetShaderText());
 	}
 
@@ -372,7 +373,8 @@ bool GLGSRender::LoadProgram()
 		m_vertex_prog.Compile();
 		checkForGlError("m_vertex_prog.Compile");
 
-		rFile f(rGetCwd() + "/VertexProgram.txt", rFile::write);
+		// TODO: This shouldn't use current dir
+		rFile f("./VertexProgram.txt", rFile::write);
 		f.Write(m_vertex_prog.shader);
 	}
 

--- a/rpcs3/Emu/GS/GL/GLGSRender.h
+++ b/rpcs3/Emu/GS/GL/GLGSRender.h
@@ -593,10 +593,10 @@ public:
 		static const std::string& dir_path = "textures";
 		static const std::string& file_fmt = dir_path + "/" + "tex[%d].png";
 
-		if(!rDirExists(dir_path)) rMkdir(dir_path);
+		if(!rExists(dir_path)) rMkdir(dir_path);
 
 		u32 count = 0;
-		while(rFileExists(fmt::Format(file_fmt, count))) count++;
+		while(rExists(fmt::Format(file_fmt, count))) count++;
 		Save(tex, fmt::Format(file_fmt, count));
 	}
 

--- a/rpcs3/Emu/SysCalls/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSysutil.cpp
@@ -660,7 +660,7 @@ int cellSysCacheClear(void)
 	Emu.GetVFS().GetDevice(std::string("/dev_hdd1/cache/"), localPath);
 	
 	//TODO: implement
-	//if (rDirExists(localPath)){
+	//if (rIsDir(localPath)){
 	//	WxDirDeleteTraverser deleter;
 	//	wxString f = wxFindFirstFile(fmt::FromUTF8(localPath+"\\*"),wxDIR);
 	//	while (!f.empty())

--- a/rpcs3/Emu/SysCalls/Modules/sceNp.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sceNp.cpp
@@ -53,10 +53,12 @@ int sceNpDrmIsAvailable(u32 k_licensee_addr, u32 drm_path_addr)
 	//make more explicit what this actually does (currently everything after the third slash and before the fourth slash)
 	std::string titleID = fmt::BeforeFirst(fmt::AfterFirst(fmt::AfterFirst(fmt::AfterFirst(drm_path,'/'),'/'),'/'),'/');
 
-	std::string enc_drm_path = rGetCwd() + drm_path;
-	std::string dec_drm_path = rGetCwd() + "/dev_hdd1/" + titleID + "/" + drm_file_name;
+	// TODO: These shouldn't use current dir
+	std::string enc_drm_path = drm_path;
+	drm_path.insert(0, 1, '.');
+	std::string dec_drm_path = "./dev_hdd1/" + titleID + "/" + drm_file_name;
 
-	std::string rap_dir_path = rGetCwd() + "/dev_usb000/";
+	std::string rap_dir_path = "./dev_usb000/";
 	std::string rap_file_path = rap_dir_path;
 	
 	// Search dev_usb000 for a compatible RAP file. 
@@ -77,9 +79,10 @@ int sceNpDrmIsAvailable(u32 k_licensee_addr, u32 drm_path_addr)
 	}
 
 	// Create a new directory under dev_hdd1/titleID to hold the decrypted data.
-	std::string tmp_dir = rGetCwd() + "/dev_hdd1/" + titleID;
-	if (!rDir::Exists(tmp_dir))
-		rMkdir(rGetCwd() + "/dev_hdd1/" + titleID);
+	// TODO: These shouldn't use current dir
+	std::string tmp_dir = "./dev_hdd1/" + titleID;
+	if (!rExists(tmp_dir))
+		rMkdir("./dev_hdd1/" + titleID);
 
 	// Decrypt this EDAT using the supplied k_licensee and matching RAP file.
 	DecryptEDAT(enc_drm_path, dec_drm_path, 8, rap_file_path, k_licensee, false);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -133,7 +133,7 @@ void Emulator::Load()
 {
 	GetModuleManager().init();
 
-	if(!rFileExists(m_path)) return;
+	if(!rExists(m_path)) return;
 
 	if(IsSelf(m_path))
 	{

--- a/rpcs3/Gui/GameViewer.cpp
+++ b/rpcs3/Gui/GameViewer.cpp
@@ -241,7 +241,7 @@ void GameViewer::RemoveGame(wxCommandEvent& event)
 
 	Emu.GetVFS().UnMountAll();
 
-	if (!rFile::Exists(localPath))
+	if (!rExists(localPath))
 		return;
 	//TODO: Replace wxWidgetsSpecific filesystem stuff?
 	WxDirDeleteTraverser deleter;

--- a/rpcs3/Loader/PKG.cpp
+++ b/rpcs3/Loader/PKG.cpp
@@ -13,7 +13,8 @@ bool PKGLoader::Install(std::string dest)
 	if (!pkg_f.IsOpened())
 		return false;
 
-	dest = rGetCwd() + dest;
+	// TODO: This shouldn't use current dir
+	dest.insert(0, 1, '.');
 	if (!dest.empty() && dest.back() != '/')
 		dest += '/';
 
@@ -24,7 +25,7 @@ bool PKGLoader::Install(std::string dest)
 	
 	std::string titleID = std::string(title_id).substr(7, 9);
 
-	if (rDirExists(dest+titleID)) {
+	if (rExists(dest+titleID)) {
 		rMessageDialog d_overwrite(NULL, "Another installation was found. Do you want to overwrite it?", "PKG Decrypter / Installer", rYES_NO|rCENTRE);
 		if (d_overwrite.ShowModal() != rID_YES) {
 			LOG_ERROR(LOADER, "PKG Loader: Another installation found in: %s", titleID.c_str());


### PR DESCRIPTION
Was using fileExists/dirExists before when really should have just been exists. File or Dir doesn't matter and would only create false negatives.
Current working directory shouldn't really be used at all. This is just the folder the application is run from (not even where the .exe resides).
Some of the infos required by vfsLocalDir such as executable may not be portable. Not sure of their intended function as they are never used.
