### PR TITLE
Remove duplicate

### DIFF
--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -155,7 +155,6 @@
     <ClCompile Include="Emu\SysCalls\Modules\cellResc.cpp" />
     <ClCompile Include="Emu\SysCalls\Modules\cellRtc.cpp" />
     <ClCompile Include="Emu\SysCalls\Modules\cellRudp.cpp" />
-    <ClCompile Include="Emu\SysCalls\Modules\cellSail.cpp" />
     <ClCompile Include="Emu\SysCalls\Modules\cellSailRec.cpp" />
     <ClCompile Include="Emu\SysCalls\Modules\cellScreenshot.cpp" />
     <ClCompile Include="Emu\SysCalls\Modules\cellSearch.cpp" />


### PR DESCRIPTION
Fix compilation warning

C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.CppBuild.targets(935,5): warning MSB8027: Two or more files with the name of cellSail.cpp will produce outputs to the same location. This can lead to an incorrect b
