### PR TITLE
Log name of syscall, when access violation occurs

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Emu/SysCalls/ErrorCodes.h"
+#include "Emu/SysCalls/SysCalls.h"
 #include "Utilities/Log.h"
 #include "Emu/Memory/Memory.h"
 #include "Emu/System.h"
@@ -285,8 +286,8 @@ void _se_translator(unsigned int u, EXCEPTION_POINTERS* pExp)
 		// TODO: allow recovering from a page fault
 		//GetCurrentPPUThread().Stop();
 		Emu.Pause();
-		throw fmt::Format("Access violation: addr = 0x%x (last_syscall=0x%llx)",
-			(u32)addr, (u64)GetCurrentCPUThread()->m_last_syscall);
+		throw fmt::Format("Access violation: addr = 0x%x (last_syscall=0x%llx (%s))",
+			(u32)addr, (u64)GetCurrentCPUThread()->m_last_syscall, SysCalls::GetHLEFuncName((u64)GetCurrentCPUThread()->m_last_syscall).c_str());
 	}
 	else
 	{


### PR DESCRIPTION
Also logs the name of syscall (when known) upon an access violation.
