### PR TITLE
Add build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@
 *.dump
 *.wav
 
+/build
+
 /libs
 /ipch
 /rpcs3/Debug


### PR DESCRIPTION
Many people prefer to build out-of-source, especially in the ./build directory. This prevents it from being tracked by git.
