### PR TITLE
Don't set game's size info in Patch and Data check

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/cellGame.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellGame.cpp
@@ -93,12 +93,15 @@ int cellGamePatchCheck(mem_ptr_t<CellGameContentSize> size, u32 reserved_addr)
 		return CELL_GAME_ERROR_PARAM;
 	}
 
-	// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
-	size->hddFreeSizeKB = 40000000; // 40 GB
+	if (size)
+	{
+		// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
+		size->hddFreeSizeKB = 40000000; // 40 GB
 
-	// TODO: Calculate data size for patch data, if necessary.
-	size->sizeKB = CELL_GAME_SIZEKB_NOTCALC;
-	size->sysSizeKB = 0;
+		// TODO: Calculate data size for patch data, if necessary.
+		size->sizeKB = CELL_GAME_SIZEKB_NOTCALC;
+		size->sysSizeKB = 0;
+	}
 
 	vfsFile f("/app_home/PARAM.SFO");
 	if (!f.IsOpened())
@@ -138,12 +141,15 @@ int cellGameDataCheck(u32 type, const mem_list_ptr_t<u8> dirName, mem_ptr_t<Cell
 		return CELL_GAME_ERROR_PARAM;
 	}
 
-	// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
-	size->hddFreeSizeKB = 40000000; //40 GB
+	if (size)
+	{
+		// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
+		size->hddFreeSizeKB = 40000000; //40 GB
 
-	// TODO: Calculate data size for game data, if necessary.
-	size->sizeKB = CELL_GAME_SIZEKB_NOTCALC;
-	size->sysSizeKB = 0;
+		// TODO: Calculate data size for game data, if necessary.
+		size->sizeKB = CELL_GAME_SIZEKB_NOTCALC;
+		size->sysSizeKB = 0;
+	}
 
 	if (type == CELL_GAME_GAMETYPE_DISC)
 	{


### PR DESCRIPTION
Apparently size pointer isn't provided for other functions too, this fixes 2 access violations.
