### PR TITLE
Auto-Pause At Function Call and System Call

### DIFF
--- a/Utilities/AutoPause.cpp
+++ b/Utilities/AutoPause.cpp
@@ -1,0 +1,130 @@
+#include "stdafx.h"
+#include "AutoPause.h"
+
+using namespace Debug;
+
+//Even different from those tutorials on webpages, i use the method similiar from Log.h
+//TODO:: Question: Does such a Singleton struct get fully deallocated after its pointer?
+AutoPause* gAutoPause = nullptr;
+
+AutoPause& AutoPause::getInstance(void)
+{
+	if (!gAutoPause)
+	{
+		gAutoPause = new AutoPause();
+	}
+	return *gAutoPause;
+}
+
+//Still use binary format. Default Setting should be "disable all auto-pause".
+AutoPause::AutoPause(void)
+{
+	m_pause_function.reserve(16);
+	m_pause_syscall.reserve(16);
+	initialized = false;
+	//Reload(false, false);
+	Reload(true, true);	//Temporarily use auto enable
+}
+
+//Notice: I would not allow to write the binary to file in this command.
+AutoPause::~AutoPause(void)
+{
+	initialized = false;
+	m_pause_function.clear();
+	m_pause_syscall.clear();
+	m_pause_function_enable = false;
+	m_pause_syscall_enable = false;
+}
+
+//Load Auto-Pause Configuration from file "pause.bin"
+//This would be able to create in a GUI window.
+void AutoPause::Reload(void)
+{
+	if (rExists("pause.bin"))
+	{
+		m_pause_function.clear();
+		m_pause_function.reserve(16);
+		m_pause_syscall.clear();
+		m_pause_syscall.reserve(16);
+
+		rFile list;
+		list.Open("pause.bin", rFile::read);
+		//System calls ID and Function calls ID are all u32 iirc.
+		u32 num;
+		size_t fmax = list.Length();
+		size_t fcur = 0;
+		list.Seek(0);
+		while (fcur <= fmax - sizeof(u32))
+		{
+			list.Read(&num, sizeof(u32));
+			fcur += sizeof(u32);
+			if (num == 0xFFFFFFFF) break;
+			
+			if (num < 1024)
+			{
+				//Less than 1024 - be regarded as a system call.
+				//emplace_back may not cause reductant move/copy operation.
+				m_pause_syscall.emplace_back(num);
+				LOG_WARNING(HLE, "Auto-Pause: Find System Call ID %x", num);
+			}
+			else
+			{
+				m_pause_function.emplace_back(num);
+				LOG_WARNING(HLE, "Auto-Pause: Find Function Call ID %x", num);
+			}
+		}
+		list.Close();
+	}
+	else
+	{
+		LOG_WARNING(HLE, "No Pause ID specified in pause.bin, Auto-Pause would not act.");
+	}
+
+	initialized = true;
+}
+
+void AutoPause::Reload(bool enable_pause_syscall, bool enable_pause_function)
+{
+	Reload();
+	m_pause_syscall_enable = enable_pause_syscall;
+	m_pause_function_enable = enable_pause_function;
+}
+
+void AutoPause::TryPause(u32 code) {
+	if (code < 1024)
+	{
+		//Would first check Enable setting. Then the list length.
+		if ((!m_pause_syscall_enable)
+			|| (m_pause_syscall.size() <= 0))
+		{
+			return;
+		}
+
+		for (u32 i = 0; i < m_pause_syscall.size(); ++i)
+		{
+			if (code == m_pause_syscall[i])
+			{
+				Emu.Pause();
+				LOG_ERROR(HLE, "Auto-Pause Triggered: System call %x", code);	//Used Error
+			}
+		}
+	}
+	else
+	{
+		//Well similiar.. Seperate the list caused by possible setting difference.
+		if ((!m_pause_function_enable)
+			|| (m_pause_function.size() <= 0))
+		{
+			return;
+		}
+
+		for (u32 i = 0; i < m_pause_function.size(); ++i)
+		{
+			if (code == m_pause_function[i])
+			{
+				Emu.Pause();
+				LOG_ERROR(HLE, "Auto-Pause Triggered: Function call %x", code);	//Used Error
+			}
+		}
+	}
+}

--- a/Utilities/AutoPause.h
+++ b/Utilities/AutoPause.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "Utilities/Log.h"
+#include "Utilities/rFile.h"
+#include "Emu/System.h"
+
+//Regarded as a Debugger Enchantment
+namespace Debug {
+	//To store the pause function/call id, and let those pause there.
+	//Would be with a GUI to configure those.
+	struct AutoPause
+	{
+		std::vector<u32> m_pause_syscall;
+		std::vector<u32> m_pause_function;
+		bool initialized;
+		bool m_pause_syscall_enable;
+		bool m_pause_function_enable;
+
+		AutoPause();
+		~AutoPause();
+	public:
+		static AutoPause& getInstance(void);
+
+		void Reload(bool enable_pause_syscall, bool enable_pause_function);
+
+		void Reload(void);
+
+		void TryPause(u32 code);
+	};
+}

--- a/rpcs3/Emu/SysCalls/ModuleManager.h
+++ b/rpcs3/Emu/SysCalls/ModuleManager.h
@@ -10,7 +10,6 @@ class ModuleManager
 	std::vector<ModuleFunc *> m_modules_funcs_list;
 	std::vector<Module> m_mod_init;
 	bool initialized;
-	std::vector<u32> m_funcs_pause_funcs;
 public:
 	ModuleManager();
 	~ModuleManager();
@@ -25,5 +24,4 @@ public:
 	u32 GetFuncNumById(u32 id);
 	Module* GetModuleByName(const std::string& name);
 	Module* GetModuleById(u16 id);
-	void LoadFuncPauses(void);
 };

--- a/rpcs3/Emu/SysCalls/SysCalls.cpp
+++ b/rpcs3/Emu/SysCalls/SysCalls.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Utilities/Log.h"
+#include "Utilities/AutoPause.h"
 #include "Emu/Memory/Memory.h"
 #include "Emu/System.h"
 #include "Emu/Cell/PPUThread.h"
@@ -919,6 +920,9 @@ void default_syscall()
 
 void SysCalls::DoSyscall(u32 code)
 {
+	//Auto-Pause using simple singleton.
+	Debug::AutoPause::getInstance().TryPause(code);
+
 	if(code < 1024)
 	{
 		(*sc_table[code])();

--- a/rpcs3/Gui/GameViewer.cpp
+++ b/rpcs3/Gui/GameViewer.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "Utilities/AutoPause.h"
 #include "Utilities/Log.h"
 #include "Emu/Memory/Memory.h"
 #include "Emu/System.h"
@@ -204,6 +205,9 @@ void GameViewer::DClick(wxListEvent& event)
 	const std::string& path = m_path + m_game_data[i].root;
 
 	Emu.Stop();
+
+	Debug::AutoPause::getInstance().Reload();
+
 	Emu.GetVFS().Init(path);
 	std::string local_path;
 	if (Emu.GetVFS().GetDevice(path, local_path) && !Emu.BootGame(local_path)) {

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -27,6 +27,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\Utilities\AutoPause.cpp" />
     <ClCompile Include="..\Utilities\Log.cpp" />
     <ClCompile Include="..\Utilities\SMutex.cpp" />
     <ClCompile Include="..\Utilities\SSemaphore.cpp" />
@@ -211,6 +212,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\Utilities\AutoPause.h" />
     <ClInclude Include="..\Utilities\BEType.h" />
     <ClInclude Include="..\Utilities\IdManager.h" />
     <ClInclude Include="..\Utilities\MTRingbuffer.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -590,6 +590,9 @@
     <ClCompile Include="Emu\SysCalls\lv2\sys_event_flag.cpp">
       <Filter>Emu\SysCalls\lv2</Filter>
     </ClCompile>
+    <ClCompile Include="..\Utilities\AutoPause.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -1122,6 +1125,9 @@
     </ClInclude>
     <ClInclude Include="Emu\SysCalls\lv2\sys_event_flag.h">
       <Filter>Emu\SysCalls\lv2</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utilities\AutoPause.h">
+      <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Would have a configuration window for this. No GUI now.
Moved the code to Debug::AutoPause in AutoPause.cpp and AutoPause.h
It triggers Reload() of list currently in GameViewer (DClick), and might finally been changed.
Well and now it is all enabled (Function call + System call) by default.
If you wanna try it out. make a new pause.bin like what you did in #738.
Or you can wait for a graphical configuration window for this (load/save)
