### PR TITLE
Typo fix for Auto-Pause GUI.

### DIFF
--- a/rpcs3/Gui/AutoPauseManager.cpp
+++ b/rpcs3/Gui/AutoPauseManager.cpp
@@ -287,16 +287,14 @@ void AutoPauseSettingsDialog::OnUpdateValue(wxCommandEvent& event)
 
 	m_entry_convert.clear();
 	m_entry_convert.str("");
-	m_entry_convert << "Currently it gets an id of \""
-		<< std::hex << std::setw(8) << std::setfill('0') << m_entry;
+	m_entry_convert << std::hex << /*std::setw(8) << std::setfill('0') <<*/ m_entry;
 	m_entry_convert.clear();
-	m_entry_convert << "\".";
 	if (m_entry_convert.str() == m_id->GetValue())
 	{
-		m_entry_convert << " SAME.";
+		m_current_converted->SetLabelText("Currently it gets an id of \"" + m_entry_convert.str() + "\" - SAME.");
 	}
-
-	m_current_converted->SetLabelText(m_entry_convert.str());
-
+	else {
+		m_current_converted->SetLabelText("Currently it gets an id of \"" + m_entry_convert.str() + "\".");
+	}
 	event.Skip();
 }


### PR DESCRIPTION
This is a minor fix for auto-pause. You can use Auto-Pause to set a call ID.
Had decided not to use regex to check the user input for the call ID (which should be a hex number), I set up a check for input against the result that would be prepared to store into pause.bin.
But i made a mistake and it wasn't doing the check properly.
Sorry for not commit in time. @Hykem, i'm so sorry for this.
