### PR TITLE
unix preprocessor define typo fixed

### DIFF
--- a/rpcs3/Emu/RSX/GL/OpenGL.cpp
+++ b/rpcs3/Emu/RSX/GL/OpenGL.cpp
@@ -11,7 +11,7 @@ void InitProcTable()
 #undef OPENGL_PROC
 #undef OPENGL_PROC2
 #endif
-#ifdef __UNIX__
+#ifdef __unix__
 	glewExperimental = true;
 	glewInit();
 #endif

--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -31,7 +31,7 @@
 #include <wx/msw/wrapwin.h>
 #endif
 
-#ifdef __UNIX__
+#ifdef __unix__
 #include <X11/Xlib.h>
 #endif
 
@@ -180,7 +180,7 @@ void Rpcs3App::SendDbgCommand(DbgCommand id, CPUThread* thr)
 
 Rpcs3App::Rpcs3App()
 {
-	#if defined(__UNIX__) && !defined(__APPLE__)
+	#if defined(__unix__) && !defined(__APPLE__)
 	XInitThreads();
 	#endif
 }


### PR DESCRIPTION
Well this is pretty self explanatory `__unix__` is the right one `__UNIX__` is just something wx uses internally apparently. fixes the "crash on every elf under linux"
