### PR TITLE
Fix compile errors in Debug - MemLeak.

### DIFF
--- a/Utilities/rMsgBox.cpp
+++ b/Utilities/rMsgBox.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
+#include "restore_new.h"
 #include <wx/msgdlg.h>
+#include "define_new_memleakdetect.h"
 #include "rMsgBox.h"
 
 #ifndef QT_UI

--- a/Utilities/rPlatform.cpp
+++ b/Utilities/rPlatform.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
+#include "restore_new.h"
 #include <wx/image.h>
+#include "define_new_memleakdetect.h"
 
 #ifndef _WIN32
 #include <dirent.h>

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -4,7 +4,9 @@
 #include "sha1.h"
 #include "key_vault.h"
 #include "unpkg.h"
+#include "restore_new.h"
 #include <wx/progdlg.h>
+#include "define_new_memleakdetect.h"
 
 #include "Utilities/Log.h"
 #include "Utilities/rFile.h"

--- a/rpcs3/define_new_memleakdetect.h
+++ b/rpcs3/define_new_memleakdetect.h
@@ -1,0 +1,6 @@
+//Override the new operator to use the memory leak detection from visual studio
+//Does not work with placement new
+#if defined(MSVC_CRT_MEMLEAK_DETECTION) && defined(_DEBUG) && defined(DBG_NEW)
+	#pragma push_macro("new")
+	#define new DBG_NEW
+#endif

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -250,6 +250,7 @@
     <ClInclude Include="Crypto\unpkg.h" />
     <ClInclude Include="Crypto\unself.h" />
     <ClInclude Include="Crypto\utils.h" />
+    <ClInclude Include="define_new_memleakdetect.h" />
     <ClInclude Include="Emu\ARMv7\ARMv7Decoder.h" />
     <ClInclude Include="Emu\ARMv7\ARMv7DisAsm.h" />
     <ClInclude Include="Emu\ARMv7\ARMv7Interpreter.h" />
@@ -416,6 +417,7 @@
     <ClInclude Include="Loader\SELF.h" />
     <ClInclude Include="Loader\TROPUSR.h" />
     <ClInclude Include="Loader\TRP.h" />
+    <ClInclude Include="restore_new.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1204,5 +1204,11 @@
     <ClInclude Include="Emu\SysCalls\Modules\cellSaveData.h">
       <Filter>Emu\SysCalls\Modules</Filter>
     </ClInclude>
+    <ClInclude Include="restore_new.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="define_new_memleakdetect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpcs3/restore_new.h
+++ b/rpcs3/restore_new.h
@@ -1,0 +1,5 @@
+//Restore the new operator if previously saved before overriding
+//Allow the use of placement new
+#if defined(MSVC_CRT_MEMLEAK_DETECTION) && defined(_DEBUG) && defined(DBG_NEW)
+	#pragma pop_macro("new")
+#endif

--- a/rpcs3/stdafx.h
+++ b/rpcs3/stdafx.h
@@ -10,7 +10,7 @@
 
 #if defined(MSVC_CRT_MEMLEAK_DETECTION) && defined(_DEBUG) && !defined(DBG_NEW)
 	#define DBG_NEW new ( _NORMAL_BLOCK , __FILE__ , __LINE__ )
-	#define new DBG_NEW
+	#include "define_new_memleakdetect.h"
 #endif
 
 // This header should be frontend-agnostic, so don't assume wx includes everything


### PR DESCRIPTION
Add rpcs3/define_new_memleakdetect.h to save and replace new operator with Visual Studio Memory Leak Detection's operator.
Add rpcs3/restore_new.h to restore new operator to a previous saved state.
