### PR TITLE
Implemented sys_get_random_number

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/sysPrxForUser.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sysPrxForUser.cpp
@@ -153,7 +153,10 @@ int sys_get_random_number(u32 addr, u64 size)
 {
 	sysPrxForUser->Warning("sys_get_random_number(addr=0x%x, size=%d)", addr, size);
 
-	addr = rand() % size;
+	if (size > 4096)
+		size = 4096;
+
+	vm::write32(addr, rand() % size);
 
 	return CELL_OK;
 }


### PR DESCRIPTION
Battlefield 4 Beta uses it. Does not let it load any further though.
NOTE: This is not that random, but it seems to be OK.
