### PR TITLE
Added sceNpTrophyTerm and proofed some unloadings

### DIFF
--- a/rpcs3/Emu/SysCalls/ModuleManager.cpp
+++ b/rpcs3/Emu/SysCalls/ModuleManager.cpp
@@ -5,6 +5,7 @@ extern void cellAdec_init(Module* pxThis);
 extern void cellAtrac_init(Module* pxThis);
 extern void cellAudio_init(Module* pxThis);
 extern void cellCamera_init(Module* pxThis);
+extern void cellCamera_unload();
 extern void cellDmux_init(Module *pxThis);
 extern void cellFiber_init(Module *pxThis);
 extern void cellFont_init(Module *pxThis);
@@ -18,10 +19,12 @@ extern void cellGcmSys_init(Module *pxThis);
 extern void cellGcmSys_load();
 extern void cellGcmSys_unload();
 extern void cellGem_init(Module *pxThis);
+extern void cellGem_unload();
 extern void cellJpgDec_init(Module *pxThis);
 extern void cellGifDec_init(Module *pxThis);
 extern void cellL10n_init(Module *pxThis);
 extern void cellNetCtl_init(Module *pxThis);
+extern void cellNetCtl_unload();
 extern void cellOvis_init(Module *pxThis);
 extern void cellPamf_init(Module *pxThis);
 extern void cellPngDec_init(Module *pxThis);
@@ -43,6 +46,7 @@ extern void cellVdec_init(Module *pxThis);
 extern void cellVpost_init(Module *pxThis);
 extern void libmixer_init(Module *pxThis);
 extern void sceNp_init(Module *pxThis);
+extern void sceNp_unload();
 extern void sceNpClans_init(Module *pxThis);
 extern void sceNpClans_unload();
 extern void sceNpCommerce2_init(Module *pxThis);
@@ -90,9 +94,9 @@ static const g_modules_list[] =
 	{ 0x0011, "cellAudio", cellAudio_init, nullptr, nullptr },
 	{ 0x0012, "cellPamf", cellPamf_init, nullptr, nullptr },
 	{ 0x0013, "cellAtrac", cellAtrac_init, nullptr, nullptr },
-	{ 0x0014, "cellNetCtl", cellNetCtl_init, nullptr, nullptr },
+	{ 0x0014, "cellNetCtl", cellNetCtl_init, nullptr, cellNetCtl_unload },
 	{ 0x0015, "cellSysutil", cellSysutil_init, cellSysutil_load, nullptr },
-	{ 0x0016, "sceNp", sceNp_init, nullptr, nullptr },
+	{ 0x0016, "sceNp", sceNp_init, nullptr, sceNp_unload },
 	{ 0x0017, "sys_io", sys_io_init, nullptr, nullptr },
 	{ 0x0018, "cellPngDec", cellPngDec_init, nullptr, nullptr },
 	{ 0x0019, "cellFont", cellFont_init, cellFont_load, cellFont_unload },
@@ -105,7 +109,7 @@ static const g_modules_list[] =
 	{ 0x0020, "cellDaisy", nullptr, nullptr, nullptr },
 	{ 0x0021, "cellKey2char", nullptr, nullptr, nullptr },
 	{ 0x0022, "cellMic", nullptr, nullptr, nullptr },
-	{ 0x0023, "cellCamera", cellCamera_init, nullptr, nullptr },
+	{ 0x0023, "cellCamera", cellCamera_init, nullptr, cellCamera_unload },
 	{ 0x0024, "cellVdecMpeg2", nullptr, nullptr, nullptr },
 	{ 0x0025, "cellVdecAvc", nullptr, nullptr, nullptr },
 	{ 0x0026, "cellAdecLpcm", nullptr, nullptr, nullptr },
@@ -150,7 +154,7 @@ static const g_modules_list[] =
 	{ 0x0056, "cellNpUtil", nullptr, nullptr, nullptr },
 	{ 0x0057, "cellRudp", nullptr, nullptr, nullptr },
 	{ 0x0059, "cellNpSns", sceNpSns_init, nullptr, sceNpSns_unload },
-	{ 0x005a, "cellGem", cellGem_init, nullptr, nullptr },
+	{ 0x005a, "cellGem", cellGem_init, nullptr, cellGem_unload },
 	{ 0xf00a, "cellCelpEnc", nullptr, nullptr, nullptr },
 	{ 0xf010, "cellGifDec", cellGifDec_init, nullptr, nullptr },
 	{ 0xf019, "cellAdecCelp", nullptr, nullptr, nullptr },

--- a/rpcs3/Emu/SysCalls/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellCamera.cpp
@@ -221,6 +221,11 @@ int cellCameraRemoveNotifyEventQueue2()
 	return CELL_OK;
 }
 
+void cellCamera_unload()
+{
+	cellCameraInstance.m_bInitialized = false;
+}
+
 void cellCamera_init(Module* pxThis)
 {
 	cellCamera = pxThis;

--- a/rpcs3/Emu/SysCalls/Modules/cellGem.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellGem.cpp
@@ -251,6 +251,11 @@ int cellGemWriteExternalPort()
 	return CELL_OK;
 }
 
+void cellGem_unload()
+{
+	cellGemInstance.m_bInitialized = false;
+}
+
 void cellGem_init(Module *pxThis)
 {
 	cellGem = pxThis;

--- a/rpcs3/Emu/SysCalls/Modules/cellNetCtl.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellNetCtl.cpp
@@ -111,6 +111,11 @@ int cellNetCtlGetNatInfo(vm::ptr<CellNetCtlNatInfo> natInfo)
 	return CELL_OK;
 }
 
+void cellNetCtl_unload()
+{
+	cellNetCtlInstance.m_bInitialized = false;
+}
+
 void cellNetCtl_init(Module *pxThis)
 {
 	cellNetCtl = pxThis;

--- a/rpcs3/Emu/SysCalls/Modules/sceNp.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sceNp.cpp
@@ -1522,6 +1522,13 @@ int	_sceNpSysutilClientFree()
 	return CELL_OK;
 }
 
+void sceNp_unload()
+{
+	sceNpInstance.m_bSceNpInitialized = false;
+	sceNpInstance.m_bSceNp2Initialized = false;
+	sceNpInstance.m_bScoreInitialized = false;
+}
+
 void sceNp_init(Module *pxThis)
 {
 	sceNp = pxThis;

--- a/rpcs3/Emu/SysCalls/Modules/sceNpCommerce2.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sceNpCommerce2.cpp
@@ -314,7 +314,7 @@ int sceNpCommerce2DestroyReq()
 
 void sceNpCommerce2_unload()
 {
-	// TODO: Unload SNS module
+	sceNpCommerce2Instance.m_bSceNpCommerce2Initialized = false;
 }
 
 void sceNpCommerce2_init(Module *pxThis)

--- a/rpcs3/Emu/SysCalls/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sceNpTrophy.cpp
@@ -67,19 +67,20 @@ struct sceNpTrophyInternal
 	}
 };
 
-sceNpTrophyInternal s_npTrophyInstance;
+sceNpTrophyInternal sceNpTrophyInstance;
 
 // Functions
 int sceNpTrophyInit(u32 pool_addr, u32 poolSize, u32 containerId, u64 options)
 {
 	sceNpTrophy->Log("sceNpTrophyInit(pool_addr=0x%x, poolSize=%d, containerId=%d, options=0x%llx)", pool_addr, poolSize, containerId, options);
 
-	if (s_npTrophyInstance.m_bInitialized)
+	if (sceNpTrophyInstance.m_bInitialized)
 		return SCE_NP_TROPHY_ERROR_ALREADY_INITIALIZED;
 	if (options)
 		return SCE_NP_TROPHY_ERROR_NOT_SUPPORTED;
 
-	s_npTrophyInstance.m_bInitialized = true;
+	sceNpTrophyInstance.m_bInitialized = true;
+
 	return CELL_OK;
 }
 
@@ -88,7 +89,7 @@ int sceNpTrophyCreateContext(vm::ptr<be_t<u32>> context, vm::ptr<SceNpCommunicat
 	sceNpTrophy->Warning("sceNpTrophyCreateContext(context_addr=0x%x, commID_addr=0x%x, commSign_addr=0x%x, options=0x%llx)",
 		context.addr(), commID.addr(), commSign.addr(), options);
 
-	if (!s_npTrophyInstance.m_bInitialized)
+	if (!sceNpTrophyInstance.m_bInitialized)
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 	if (options & (~(u64)1))
 		return SCE_NP_TROPHY_ERROR_NOT_SUPPORTED;
@@ -108,8 +109,8 @@ int sceNpTrophyCreateContext(vm::ptr<be_t<u32>> context, vm::ptr<SceNpCommunicat
 
 			if (stream && stream->IsOpened())
 			{
-				s_npTrophyInstance.contexts.emplace_back();
-				sceNpTrophyInternalContext& ctxt = s_npTrophyInstance.contexts.back();
+				sceNpTrophyInstance.contexts.emplace_back();
+				sceNpTrophyInternalContext& ctxt = sceNpTrophyInstance.contexts.back();
 				ctxt.trp_stream.reset(stream);
 				ctxt.trp_name = entry->name;
 				stream = nullptr;
@@ -125,7 +126,7 @@ int sceNpTrophyCreateHandle(vm::ptr<be_t<u32>> handle)
 {
 	sceNpTrophy->Warning("sceNpTrophyCreateHandle(handle_addr=0x%x)", handle.addr());
 
-	if (!s_npTrophyInstance.m_bInitialized)
+	if (!sceNpTrophyInstance.m_bInitialized)
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 	// TODO: There are other possible errors
 
@@ -139,15 +140,15 @@ int sceNpTrophyRegisterContext(u32 context, u32 handle, vm::ptr<SceNpTrophyStatu
 	sceNpTrophy->Warning("sceNpTrophyRegisterContext(context=%d, handle=%d, statusCb_addr=0x%x, arg_addr=0x%x, options=0x%llx)",
 		context, handle, statusCb.addr(), arg_addr, options);
 
-	if (!(s_npTrophyInstance.m_bInitialized))
+	if (!(sceNpTrophyInstance.m_bInitialized))
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 	if (options & (~(u64)1))
 		return SCE_NP_TROPHY_ERROR_NOT_SUPPORTED;
-	if (context >= s_npTrophyInstance.contexts.size())
+	if (context >= sceNpTrophyInstance.contexts.size())
 		return SCE_NP_TROPHY_ERROR_UNKNOWN_CONTEXT;
 	// TODO: There are other possible errors
 
-	sceNpTrophyInternalContext& ctxt = s_npTrophyInstance.contexts[context];
+	sceNpTrophyInternalContext& ctxt = sceNpTrophyInstance.contexts[context];
 	if (!ctxt.trp_stream)
 		return SCE_NP_TROPHY_ERROR_CONF_DOES_NOT_EXIST;
 
@@ -216,13 +217,13 @@ int sceNpTrophyGetRequiredDiskSpace(u32 context, u32 handle, vm::ptr<be_t<u64>> 
 	sceNpTrophy->Warning("sceNpTrophyGetRequiredDiskSpace(context=%d, handle=%d, reqspace_addr=0x%x, options=0x%llx)",
 		context, handle, reqspace.addr(), options);
 
-	if (!s_npTrophyInstance.m_bInitialized)
+	if (!sceNpTrophyInstance.m_bInitialized)
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
-	if (context >= s_npTrophyInstance.contexts.size())
+	if (context >= sceNpTrophyInstance.contexts.size())
 		return SCE_NP_TROPHY_ERROR_UNKNOWN_CONTEXT;
 	// TODO: There are other possible errors
 
-	sceNpTrophyInternalContext& ctxt = s_npTrophyInstance.contexts[context];
+	sceNpTrophyInternalContext& ctxt = sceNpTrophyInstance.contexts[context];
 	if (!ctxt.trp_stream)
 		return SCE_NP_TROPHY_ERROR_CONF_DOES_NOT_EXIST;
 
@@ -247,13 +248,13 @@ int sceNpTrophyGetGameInfo(u32 context, u32 handle, vm::ptr<SceNpTrophyGameDetai
 	sceNpTrophy->Warning("sceNpTrophyGetGameInfo(context=%d, handle=%d, details_addr=0x%x, data_addr=0x%x)",
 		context, handle, details.addr(), data.addr());
 
-	if (!s_npTrophyInstance.m_bInitialized)
+	if (!sceNpTrophyInstance.m_bInitialized)
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 	// TODO: There are other possible errors
 
 	std::string path;
 	rXmlDocument doc;
-	sceNpTrophyInternalContext& ctxt = s_npTrophyInstance.contexts[context];
+	sceNpTrophyInternalContext& ctxt = sceNpTrophyInstance.contexts[context];
 	Emu.GetVFS().GetDevice("/dev_hdd0/home/00000001/trophy/" + ctxt.trp_name + "/TROPCONF.SFM", path);  // TODO: Get the path of the current user
 	doc.Load(path);
 
@@ -305,11 +306,11 @@ int sceNpTrophyUnlockTrophy(u32 context, u32 handle, s32 trophyId, vm::ptr<be_t<
 	sceNpTrophy->Warning("sceNpTrophyUnlockTrophy(context=%d, handle=%d, trophyId=%d, platinumId_addr=0x%x)",
 		context, handle, trophyId, platinumId.addr());
 	
-	if (!s_npTrophyInstance.m_bInitialized)
+	if (!sceNpTrophyInstance.m_bInitialized)
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 	// TODO: There are other possible errors
 
-	sceNpTrophyInternalContext& ctxt = s_npTrophyInstance.contexts[context];
+	sceNpTrophyInternalContext& ctxt = sceNpTrophyInstance.contexts[context];
 	if (trophyId >= (s32)ctxt.tropusr->GetTrophiesCount())
 		return SCE_NP_TROPHY_ERROR_INVALID_TROPHY_ID;
 	if (ctxt.tropusr->GetTrophyUnlockState(trophyId))
@@ -327,7 +328,13 @@ int sceNpTrophyUnlockTrophy(u32 context, u32 handle, s32 trophyId, vm::ptr<be_t<
 
 int sceNpTrophyTerm()
 {
-	UNIMPLEMENTED_FUNC(sceNpTrophy);
+	sceNpTrophy->Warning("sceNpTrophyTerm()");
+
+	if (!sceNpTrophyInstance.m_bInitialized)
+		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
+
+	sceNpTrophyInstance.m_bInitialized = false;
+
 	return CELL_OK;
 }
 
@@ -336,11 +343,11 @@ int sceNpTrophyGetTrophyUnlockState(u32 context, u32 handle, vm::ptr<SceNpTrophy
 	sceNpTrophy->Warning("sceNpTrophyGetTrophyUnlockState(context=%d, handle=%d, flags_addr=0x%x, count_addr=0x%x)",
 		context, handle, flags.addr(), count.addr());
 
-	if (!s_npTrophyInstance.m_bInitialized)
+	if (!sceNpTrophyInstance.m_bInitialized)
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 	// TODO: There are other possible errors
 
-	sceNpTrophyInternalContext& ctxt = s_npTrophyInstance.contexts[context];
+	sceNpTrophyInternalContext& ctxt = sceNpTrophyInstance.contexts[context];
 	*count = ctxt.tropusr->GetTrophiesCount();
 	if (*count > 128)
 		sceNpTrophy->Warning("sceNpTrophyGetTrophyUnlockState: More than 128 trophies detected!");
@@ -368,13 +375,13 @@ int sceNpTrophyGetTrophyInfo(u32 context, u32 handle, s32 trophyId, vm::ptr<SceN
 	sceNpTrophy->Warning("sceNpTrophyGetTrophyInfo(context=%u, handle=%u, trophyId=%d, details_addr=0x%x, data_addr=0x%x)",
 		context, handle, trophyId, details.addr(), data.addr());
 
-	if (!s_npTrophyInstance.m_bInitialized)
+	if (!sceNpTrophyInstance.m_bInitialized)
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 	// TODO: There are other possible errors
 	
 	std::string path;
 	rXmlDocument doc;
-	sceNpTrophyInternalContext& ctxt = s_npTrophyInstance.contexts[context];
+	sceNpTrophyInternalContext& ctxt = sceNpTrophyInstance.contexts[context];
 	Emu.GetVFS().GetDevice("/dev_hdd0/home/00000001/trophy/" + ctxt.trp_name + "/TROPCONF.SFM", path);  // TODO: Get the path of the current user
 	doc.Load(path);
 
@@ -420,7 +427,7 @@ int sceNpTrophyGetGameIcon()
 
 void sceNpTrophy_unload()
 {
-	s_npTrophyInstance.m_bInitialized = false;
+	sceNpTrophyInstance.m_bInitialized = false;
 }
 
 void sceNpTrophy_init(Module *pxThis)


### PR DESCRIPTION
Made cellNetCtl, cellGem, cellCamera, sceNp, sceNpCommerce2 and sceNpTrophy properly unload if termination function wasn't called. (Some games might unload the module and not call the termination function at all)
