### PR TITLE
change initial value of sys_lwmutex_t::waiter

### DIFF
--- a/rpcs3/Emu/SysCalls/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/sys_lwmutex.cpp
@@ -33,7 +33,8 @@ s32 sys_lwmutex_create(vm::ptr<sys_lwmutex_t> lwmutex, vm::ptr<sys_lwmutex_attri
 	}
 
 	lwmutex->attribute = attr->attr_protocol | attr->attr_recursive;
-	lwmutex->waiter = 0;
+	//waiter is currently unused by the emulator but some games apparently directly read this value
+	lwmutex->waiter = ~0;
 	lwmutex->mutex.initialize();
 	//lwmutex->waiter = lwmutex->owner.GetOwner();
 	lwmutex->pad = 0;


### PR DESCRIPTION
fixes #826 , for liberal definitions of "fix".

This value should not be read by games but maybe there's some SCE static libs that directly read this value. We definitely need to reverse that sometime in the future.
