### PR TITLE
WIN32: set timer resolution clock to 1 ms

### DIFF
--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -165,6 +165,10 @@ void Rpcs3App::Exit()
 	Ini.Save();
 
 	wxApp::Exit();
+
+#ifdef _WIN32
+	timeEndPeriod(1);
+#endif
 }
 
 void Rpcs3App::SendDbgCommand(DbgCommand id, CPUThread* thr)
@@ -176,6 +180,10 @@ void Rpcs3App::SendDbgCommand(DbgCommand id, CPUThread* thr)
 
 Rpcs3App::Rpcs3App()
 {
+#ifdef _WIN32
+	timeBeginPeriod(1);
+#endif
+
 	#if defined(__unix__) && !defined(__APPLE__)
 	XInitThreads();
 	#endif


### PR DESCRIPTION
It should resolve some intermittent slow down on windows platform .

http://www.emunewz.net/forum/showthread.php?tid=164112
