### PR TITLE
Fixes segmentation fault on exiting rpcs3

### DIFF
--- a/rpcs3/Emu/CPU/CPUDecoder.h
+++ b/rpcs3/Emu/CPU/CPUDecoder.h
@@ -333,6 +333,17 @@ public:
 				});
 	}
 
+	InstrBase(const InstrBase &source)
+		: InstrCaller<TO>(source)
+		, m_name(source.m_name)
+		, m_opcode(source.m_opcode)
+		, m_args_count(source.m_args_count)
+		, m_args(source.m_args_count ? new CodeFieldBase*[source.m_args_count] : nullptr)
+	{
+		for(int i = 0; i < source.m_args_count; ++i)
+			m_args[i] = source.m_args[i];
+	}
+
 	virtual ~InstrBase()
 	{
 		if (m_args) {


### PR DESCRIPTION
Fixes a segmentation fault on exiting rpcs3 by adding copy constructor
for `class InstrBase`.

A copy constructor is necessarry for `class InstrBase`, as the implicit
copy constructor simply copies the pointer `m_args`. This results in
a double delete of the same memory region, causing a segmentation
fault when rpcs3 exits.
