### PR TITLE
Fixes build in Debug mode on linux

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -81,7 +81,11 @@ ${LLVM_INCLUDE_DIRS}
 
 add_definitions(${LLVM_DEFINITIONS})
 add_definitions(-DLLVM_AVAILABLE)
-llvm_map_components_to_libnames(LLVM_LIBS jit vectorize x86codegen x86disassembler)
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+	llvm_map_components_to_libnames(LLVM_LIBS jit vectorize x86codegen x86disassembler)
+else()
+	llvm_map_components_to_libnames(LLVM_LIBS jit vectorize x86codegen x86disassembler mcdisassembler)
+endif()
 
 link_directories("${RPCS3_SRC_DIR}/../ffmpeg/${PLATFORM_ARCH}/lib")
 


### PR DESCRIPTION
The changes introduced in commit 80294e1 makes the mcdisassembler
component of LLVM necessary in debug mode to successfully link rpcs3.
