### PR TITLE
Fix for TB SPR and disable writing to TB SPR

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -147,7 +147,7 @@ private:
 		case 0x008: return CPU.LR;
 		case 0x009: return CPU.CTR;
 		case 0x100: return CPU.USPRG0;
-		case 0x10C: return CPU.TBL;
+		case 0x10C: return get_time();
 		}
 
 		UNK(fmt::Format("ReadSPR error: Unknown SPR 0x%x!", n));
@@ -164,7 +164,7 @@ private:
 		case 0x008: CPU.LR = value; return;
 		case 0x009: CPU.CTR = value; return;
 		case 0x100: CPU.USPRG0 = value; return;
-		case 0x10C: CPU.TBL = value; return;
+		case 0x10C: UNK("WriteSPR: Write to time-based SPR. Report this to a developer!"); return;
 		}
 
 		UNK(fmt::Format("WriteSPR error: Unknown SPR 0x%x!", n));


### PR DESCRIPTION
Now uses get_time() like MFTB instead of reading directly from the time-based SPR.
