### PR TITLE
Remove pause that happens on null command

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2270,7 +2270,7 @@ void RSXThread::Task()
 		if(cmd == 0)
 		{
 			LOG_ERROR(Log::RSX, "null cmd: cmd=0x%x, put=0x%x, get=0x%x (addr=0x%x)", cmd, put, get, (u32)Memory.RSXIOMem.RealAddr(get));
-			Emu.Pause();
+			//Emu.Pause();
 			//HACK! We shouldn't be here
 			m_ctrl->get = get + (count + 1) * 4;
 			continue;


### PR DESCRIPTION
Doesn't seem to be really necessary.
