### PR TITLE
Revert "Implement CELL_SAVEDATA_FILEOP_WRITE_NOTRUNC"

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSaveData.cpp
@@ -279,10 +279,7 @@ s32 modifySaveDataFiles(vm::ptr<CellSaveDataFileCallback> funcFile, vm::ptr<Cell
 			break;
 
 		case CELL_SAVEDATA_FILEOP_WRITE_NOTRUNC:
-			// Does it really write without trunctation?
-			Emu.GetVFS().CreateFile(filepath);
-			file = Emu.GetVFS().OpenFile(filepath, vfsWrite);
-			fileGet->excSize = (u32)file->Write(buf, (u32)std::min(fileSet->fileSize, fileSet->fileBufSize)); // TODO: This may fail for big files because of the dest pointer.
+			cellSysutil->Warning("modifySaveDataFiles: File operation CELL_SAVEDATA_FILEOP_WRITE_NOTRUNC not yet implemented");
 			break;
 
 		default:


### PR DESCRIPTION
Apparently Sony's definition of truncation is completely different than what you would expect.
