### PR TITLE
Revert "Check address is not null for cellGcmAddressToOffset"

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellGcmSys.cpp
@@ -805,8 +805,7 @@ s32 cellGcmAddressToOffset(u64 address, vm::ptr<be_t<u32>> offset)
 	cellGcmSys->Log("cellGcmAddressToOffset(address=0x%x,offset_addr=0x%x)", address, offset.addr());
 
 	// Address not on main memory or local memory
-	if (!address || address >= 0xD0000000) {
-		cellGcmSys->Error("cellGcmAddressToOffset(address=0x%x,offset_addr=0x%x)", address, offset.addr());
+	if (address >= 0xD0000000) {
 		return CELL_GCM_ERROR_FAILURE;
 	}
 


### PR DESCRIPTION
This is a hack previously and probably wrong .
