### PR TITLE
remove lwmutex::const_be_u32_t::value

### DIFF
--- a/rpcs3/Emu/SysCalls/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/SysCalls/lv2/sys_lwmutex.h
@@ -25,11 +25,9 @@ namespace lwmutex
 	template<u32 _value>
 	struct const_be_u32_t
 	{
-		static const u32 value = _value;
-
 		operator const be_t<u32>() const
 		{
-			return be_t<u32>::make(value);
+			return be_t<u32>::make(_value);
 		}
 	};
 


### PR DESCRIPTION
remove the publicly accessible version of the template parameter in lwmutex::const_be_u32_t because it's never used and causes linker errors in clang 3.4 (and allegedly gcc 4.8.4)

pertains to #1048 and #1050