### PR TITLE
Travis Enabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ before_install:
     aria2c -x 16 http://www.cmake.org/files/v3.0/cmake-3.0.0-Linux-i386.sh &&
     chmod a+x cmake-3.0.0-Linux-i386.sh &&
     sudo ./cmake-3.0.0-Linux-i386.sh --skip-license --prefix=/usr;
+# Add coverall for C++ so coverity could be triggered. Even it should be --coverage and gcov.
+  - sudo pip install cpp-coveralls
 
 before_script:
  - git submodule update --init asmjit ffmpeg llvm
@@ -51,5 +53,12 @@ addons:
     build_command:   "make -j 4"
     branch_pattern: coverity_scan
 
+# These modifys are from https://github.com/devernay/cminpack/blob/master/.travis.yml
+# It passed but when coverall it failed.
 script:
- - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then make -j 4; fi
+# Add a command to show all the variables now. maybe only useful for debugging travis.
+ - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--"
+ - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then make -j 4; fi
+after_success:
+ - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then coveralls --extension .c --extension .cpp --extension .h; fi
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RPCS3
 =====
 
-[![Build Status](https://travis-ci.org/DHrpcs3/rpcs3.svg?branch=master)](https://travis-ci.org/DHrpcs3/rpcs3)
+[![Build Status](https://travis-ci.org/RPCS3/rpcs3.svg?branch=master)](https://travis-ci.org/RPCS3/rpcs3)
 
 <a href="https://scan.coverity.com/projects/3960">
   <img alt="Coverity Scan Build Status"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@ RPCS3
 =====
 
 [![Build Status](https://travis-ci.org/RPCS3/rpcs3.svg?branch=master)](https://travis-ci.org/RPCS3/rpcs3)
-
-<a href="https://scan.coverity.com/projects/3960">
-  <img alt="Coverity Scan Build Status"
-       src="https://scan.coverity.com/projects/3960/badge.svg"/>
-</a>
-
+[![Coverity Status](https://scan.coverity.com/projects/3960/badge.svg)](https://scan.coverity.com/projects/3960)
 [![Coverage Status](https://coveralls.io/repos/DHrpcs3/rpcs3/badge.svg)](https://coveralls.io/r/DHrpcs3/rpcs3)
 
 An open-source PlayStation 3 emulator/debugger written in C++.

--- a/Utilities/git-version-gen.cmd
+++ b/Utilities/git-version-gen.cmd
@@ -25,7 +25,7 @@ call %GIT% describe > NUL 2> NUL
 if errorlevel 1 (
 	echo Git not on path, trying default Msysgit paths
 	set GIT="%ProgramFiles(x86)%\Git\bin\git.exe"
-	call %GIT% describe > NUL 2> NUL
+	call !GIT! describe > NUL 2> NUL
 	if errorlevel 1 (
 		set GIT="%ProgramFiles%\Git\bin\git.exe"
 	)

--- a/Utilities/git-version-gen.cmd
+++ b/Utilities/git-version-gen.cmd
@@ -13,7 +13,7 @@ rem // A copy of the GPL 2.0 should have been included with the program.
 rem // If not, see http://www.gnu.org/licenses/
 
 rem // Official git repository and contact information can be found at
-rem // https://github.com/DHrpcs3/rpcs3 and http://rpcs3.net/.
+rem // https://github.com/RPCS3/rpcs3 and http://rpcs3.net/.
 
 setlocal ENABLEDELAYEDEXPANSION
 
@@ -25,7 +25,7 @@ call %GIT% describe > NUL 2> NUL
 if errorlevel 1 (
 	echo Git not on path, trying default Msysgit paths
 	set GIT="%ProgramFiles(x86)%\Git\bin\git.exe"
-	call !GIT! describe > NUL 2> NUL
+	call %GIT% describe > NUL 2> NUL
 	if errorlevel 1 (
 		set GIT="%ProgramFiles%\Git\bin\git.exe"
 	)


### PR DESCRIPTION
Modified `.travis.yml` to ensure rpcs3 is built dueing the Travis build.
Fix the master git repo name in Github, also the one in `git-version-gen.cmd`.
Display Shell Export List to help debugging our Travis Build.

All the commits merged into one, original in #1051.

Since i know little about it, only `cpp-coverall` added which is useful for `coveralls.io`.
After open this pull i would close the old one and delete the old branch.

Github sometimes reject your push just cause you merged those. lol.