### PR TITLE
(please merge #1054 before this)use clang 3.6 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,30 @@ git:
 before_install:
   - echo "yes" | sudo apt-key adv --fetch-keys http://repos.codelite.org/CodeLite.asc
   - echo "yes" | sudo apt-add-repository 'deb http://repos.codelite.org/wx3.0/ubuntu/ precise universe'
+# Add later version of Clang, apt from llvm.org. the repository link is for development version.
+  - echo "yes" | wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -;
+    sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main';
+    sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main';
+# And the libstdc++4.8 of GCC from ppa
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install libwxgtk3.0-dev libopenal-dev freeglut3-dev libglew-dev libc6-dev
   - sudo apt-get install aria2 -qq
   - download_extract() { aria2c -x 16 $1 -o $2 && tar -xf $2; }
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; export CXX="g++-4.8" CC="gcc-4.8"; else sudo apt-get install libstdc++-4.8-dev; fi
+  - if [ "$CXX" = "g++" ]; then
+      sudo apt-get install -qq g++-4.8;
+      export CXX="g++-4.8" CC="gcc-4.8";
+    else
+      sudo apt-get install -qq --allow-unauthenticated llvm-3.6 llvm-3.6-dev clang-3.6 libstdc++-4.8-dev;
+      export CXX="clang++-3.6" CC="clang-3.6";
+    fi
 # Travis uses CMake 2.8.7. We require 2.8.8. Grab latest
   - sudo apt-get install lib32stdc++6 -qq &&
     aria2c -x 16 http://www.cmake.org/files/v3.0/cmake-3.0.0-Linux-i386.sh &&
     chmod a+x cmake-3.0.0-Linux-i386.sh &&
     sudo ./cmake-3.0.0-Linux-i386.sh --skip-license --prefix=/usr;
+# Add coverall for C++ so coverall.io could be triggered. Even it should be --coverage and gcov.
+  - sudo pip install cpp-coveralls
 
 before_script:
  - git submodule update --init asmjit ffmpeg llvm
@@ -52,4 +65,12 @@ addons:
     branch_pattern: coverity_scan
 
 script:
- - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then make -j 4; fi
+# Add a command to show all the variables now. maybe only useful for debugging travis.
+ - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--";
+# And to ensure the versions of toolchain
+   echo "--CXX version?"; if [ "$CXX" = "g++" ]; then g++ --version; else clang++ --version; fi; echo "--CXX version confirmed";
+# From https://github.com/devernay/cminpack/blob/master/.travis.yml: that is $COVERITY_SCAN_BRANCH not ${COVERITY_SCAN_BRANCH}
+ - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then make -j 4; fi
+after_success:
+ - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then coveralls --extension .c --extension .cpp --extension .h; fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 # Add later version of Clang, apt from llvm.org. the repository link is for development version.
   - echo "yes" | wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -;
     sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main';
-    sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main';
+    sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main'
 # And the libstdc++4.8 of GCC from ppa
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
@@ -66,9 +66,9 @@ addons:
 
 script:
 # Add a command to show all the variables now. maybe only useful for debugging travis.
- - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--";
+ - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--"
 # And to ensure the versions of toolchain
-   echo "--CXX version?"; if [ "$CXX" = "g++" ]; then g++ --version; else clang++ --version; fi; echo "--CXX version confirmed";
+   echo "--CXX version?"; if [ "$CXX" = "g++" ]; then g++ --version; else clang++ --version; fi; echo "--CXX version confirmed"
 # From https://github.com/devernay/cminpack/blob/master/.travis.yml: that is $COVERITY_SCAN_BRANCH not ${COVERITY_SCAN_BRANCH}
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then make -j 4; fi
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 # Add later version of Clang, apt from llvm.org. the repository link is for development version.
   - echo "yes" | wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -;
     sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main';
-    sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main'
+    sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main';
 # And the libstdc++4.8 of GCC from ppa
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
@@ -34,7 +34,7 @@ before_install:
     else
       sudo apt-get install -qq --allow-unauthenticated llvm-3.6 llvm-3.6-dev clang-3.6 libstdc++-4.8-dev;
       export CXX="clang++-3.6" CC="clang-3.6";
-    fi
+    fi;
 # Travis uses CMake 2.8.7. We require 2.8.8. Grab latest
   - sudo apt-get install lib32stdc++6 -qq &&
     aria2c -x 16 http://www.cmake.org/files/v3.0/cmake-3.0.0-Linux-i386.sh &&
@@ -66,9 +66,9 @@ addons:
 
 script:
 # Add a command to show all the variables now. maybe only useful for debugging travis.
- - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--"
+ - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--";
 # And to ensure the versions of toolchain
-   echo "--CXX version?"; if [ "$CXX" = "g++" ]; then g++ --version; else clang++ --version; fi; echo "--CXX version confirmed"
+ - echo "--CXX version?"; if [ "$CXX" = "g++" ]; then g++ --version; else clang++ --version; fi; echo "--CXX version confirmed";
 # From https://github.com/devernay/cminpack/blob/master/.travis.yml: that is $COVERITY_SCAN_BRANCH not ${COVERITY_SCAN_BRANCH}
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then make -j 4; fi
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_install:
   - echo "yes" | sudo apt-key adv --fetch-keys http://repos.codelite.org/CodeLite.asc
   - echo "yes" | sudo apt-add-repository 'deb http://repos.codelite.org/wx3.0/ubuntu/ precise universe'
 # Add later version of Clang, apt from llvm.org. the repository link is for development version.
-  - echo "yes" | wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -;
-    sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main';
-    sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main';
+  - echo "yes" | sudo add-apt-repository 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main';
+    echo "yes" | sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main';
+    wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -;
 # And the libstdc++4.8 of GCC from ppa
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
@@ -68,7 +68,7 @@ script:
 # Add a command to show all the variables now. maybe only useful for debugging travis.
  - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--";
 # And to ensure the versions of toolchain
- - echo "--CXX version?"; if [ "$CXX" = "g++" ]; then g++ --version; else clang++ --version; fi; echo "--CXX version confirmed";
+ - echo "--CXX version?"; "$CXX" --version; echo "--CXX version confirmed";
 # From https://github.com/devernay/cminpack/blob/master/.travis.yml: that is $COVERITY_SCAN_BRANCH not ${COVERITY_SCAN_BRANCH}
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then make -j 4; fi
 after_success:


### PR DESCRIPTION
Cause the Travis build with Clang would fail after re-enable it really (See #1054).
The version bundled with Travis is 3.4 which seems to cause some problems.
I searched the web and wanna test how it would be if using `clang++-3.6`.
Since #1054 haven't been merged yet, i picked `.travis.yml` seperately.

**Clang version confirmed**, script had taken effect.

Note: **Please merge #1054 first cause this pull only contains the `.travis.yml`.**
So, recommended merge sequence is #1054, #1053, #1052, #1057(this).

Edit: If you wanna change the clang version (to those version llvm.org provides), just replace those contains `-3.6` to the target string, and should be in Lines 23,35,36 in `.travis.yml`.