### PR TITLE
Custom EmulationDir

### DIFF
--- a/rpcs3/Emu/FS/VFS.cpp
+++ b/rpcs3/Emu/FS/VFS.cpp
@@ -5,6 +5,7 @@
 #include "vfsDeviceLocalFile.h"
 #include "Ini.h"
 #include "Emu/System.h"
+#include "Utilities/Log.h"
 
 #undef CreateFile
 
@@ -429,7 +430,11 @@ void VFS::Init(const std::string& path)
 		
 		std::string mpath = entry.path;
 		// TODO: This shouldn't use current dir
-		fmt::Replace(mpath, "$(EmulatorDir)", Emu.GetEmulatorPath());
+		// If no value assigned to SysEmulationDirPath in INI, use the path that with executable.
+		if (Ini.SysEmulationDirPath.GetValue().empty())
+			Ini.SysEmulationDirPath.SetValue(Emu.GetEmulatorPath());
+		LOG_NOTICE(GENERAL, "$(EmulatorDir) binded to %s.", Ini.SysEmulationDirPath.GetValue());
+		fmt::Replace(mpath, "$(EmulatorDir)", Ini.SysEmulationDirPath.GetValue());
 		fmt::Replace(mpath, "$(GameDir)", cwd);
 		Mount(entry.mount, mpath, dev);
 	}

--- a/rpcs3/Emu/FS/VFS.cpp
+++ b/rpcs3/Emu/FS/VFS.cpp
@@ -6,6 +6,7 @@
 #include "Ini.h"
 #include "Emu/System.h"
 #include "Utilities/Log.h"
+#include <sys/stat.h> // To check whether directory exists
 
 #undef CreateFile
 
@@ -477,17 +478,34 @@ void VFS::SaveLoadDevices(std::vector<VFSManagerEntry>& res, bool is_load)
 		entries_count.SaveValue(count);
 	}
 
-	//Custom EmulationDir. should check if that is a valid directory.
+	// Custom EmulationDir.
+	// TODO:: should have a better log that would show results before loading a game?
 	if (Ini.SysEmulationDirPathEnable.GetValue())
 	{
-		if (Ini.SysEmulationDirPath.GetValue().empty())
+		std::string EmulationDir = Ini.SysEmulationDirPath.GetValue();
+		if (EmulationDir.empty())
 			Ini.SysEmulationDirPath.SetValue(Emu.GetEmulatorPath());
-		LOG_NOTICE(GENERAL, "EmualtionDir: Custom EmulationDir is On, Binded $(EmulatorDir) to %s.", Ini.SysEmulationDirPath.GetValue());
+		struct stat fstatinfo;
+		if ((stat(EmulationDir.c_str(), &fstatinfo)))
+		{
+			LOG_NOTICE(GENERAL, "Custom EmualtionDir: Tried %s but it doesn't exists. Maybe you add some not needed chars like '\"'?");
+			Ini.SysEmulationDirPathEnable.SetValue(false);
+		}
+		else if (fstatinfo.st_mode & S_IFDIR)
+			LOG_NOTICE(GENERAL, "Custom EmualtionDir: On, Binded $(EmulatorDir) to %s.", EmulationDir);
+		else
+		{
+			// If that is not directory turn back to use original one.
+			LOG_NOTICE(GENERAL, "Custom EmulationDir: Cause path %s is not a valid directory.", EmulationDir);
+			Ini.SysEmulationDirPathEnable.SetValue(false);
+		}
 	}
-	else
+	// I left this to check again just to catch those failed in directory checks.
+	if (!Ini.SysEmulationDirPathEnable.GetValue())
 	{
-		LOG_NOTICE(GENERAL, "EmualtionDir: Custom EmulationDir is Off, Binded $(EmulatorDir) to %s.", Emu.GetEmulatorPath());
+		LOG_NOTICE(GENERAL, "Custom EmualtionDir: Off, Binded $(EmulatorDir) to %s.", Emu.GetEmulatorPath());
 	}
+
 	for(int i=0; i<count; ++i)
 	{
 		IniEntry<std::string> entry_path;

--- a/rpcs3/Emu/FS/VFS.cpp
+++ b/rpcs3/Emu/FS/VFS.cpp
@@ -433,15 +433,10 @@ void VFS::Init(const std::string& path)
 		// If no value assigned to SysEmulationDirPath in INI, use the path that with executable.
 		if (Ini.SysEmulationDirPathEnable.GetValue())
 		{
-			if (Ini.SysEmulationDirPath.GetValue().empty())
-				Ini.SysEmulationDirPath.SetValue(Emu.GetEmulatorPath());
-			LOG_NOTICE(GENERAL, "EmualtionDir: Custom EmulationDir is On, Binded $(EmulatorDir) to %s.",
-				Ini.SysEmulationDirPath.GetValue());
 			fmt::Replace(mpath, "$(EmulatorDir)", Ini.SysEmulationDirPath.GetValue());
 		}
 		else
 		{
-			LOG_NOTICE(GENERAL, "EmualtionDir: Custom EmulationDir is Off, Binded $(EmulatorDir) to %s.", Emu.GetEmulatorPath());
 			fmt::Replace(mpath, "$(EmulatorDir)", Emu.GetEmulatorPath());
 		}
 		fmt::Replace(mpath, "$(GameDir)", cwd);
@@ -482,6 +477,17 @@ void VFS::SaveLoadDevices(std::vector<VFSManagerEntry>& res, bool is_load)
 		entries_count.SaveValue(count);
 	}
 
+	//Custom EmulationDir. should check if that is a valid directory.
+	if (Ini.SysEmulationDirPathEnable.GetValue())
+	{
+		if (Ini.SysEmulationDirPath.GetValue().empty())
+			Ini.SysEmulationDirPath.SetValue(Emu.GetEmulatorPath());
+		LOG_NOTICE(GENERAL, "EmualtionDir: Custom EmulationDir is On, Binded $(EmulatorDir) to %s.", Ini.SysEmulationDirPath.GetValue());
+	}
+	else
+	{
+		LOG_NOTICE(GENERAL, "EmualtionDir: Custom EmulationDir is Off, Binded $(EmulatorDir) to %s.", Emu.GetEmulatorPath());
+	}
 	for(int i=0; i<count; ++i)
 	{
 		IniEntry<std::string> entry_path;

--- a/rpcs3/Emu/FS/VFS.cpp
+++ b/rpcs3/Emu/FS/VFS.cpp
@@ -431,10 +431,19 @@ void VFS::Init(const std::string& path)
 		std::string mpath = entry.path;
 		// TODO: This shouldn't use current dir
 		// If no value assigned to SysEmulationDirPath in INI, use the path that with executable.
-		if (Ini.SysEmulationDirPath.GetValue().empty())
-			Ini.SysEmulationDirPath.SetValue(Emu.GetEmulatorPath());
-		LOG_NOTICE(GENERAL, "$(EmulatorDir) binded to %s.", Ini.SysEmulationDirPath.GetValue());
-		fmt::Replace(mpath, "$(EmulatorDir)", Ini.SysEmulationDirPath.GetValue());
+		if (Ini.SysEmulationDirPathEnable.GetValue())
+		{
+			if (Ini.SysEmulationDirPath.GetValue().empty())
+				Ini.SysEmulationDirPath.SetValue(Emu.GetEmulatorPath());
+			LOG_NOTICE(GENERAL, "EmualtionDir: Custom EmulationDir is On, Binded $(EmulatorDir) to %s.",
+				Ini.SysEmulationDirPath.GetValue());
+			fmt::Replace(mpath, "$(EmulatorDir)", Ini.SysEmulationDirPath.GetValue());
+		}
+		else
+		{
+			LOG_NOTICE(GENERAL, "EmualtionDir: Custom EmulationDir is Off, Binded $(EmulatorDir) to %s.", Emu.GetEmulatorPath());
+			fmt::Replace(mpath, "$(EmulatorDir)", Emu.GetEmulatorPath());
+		}
 		fmt::Replace(mpath, "$(GameDir)", cwd);
 		Mount(entry.mount, mpath, dev);
 	}

--- a/rpcs3/Gui/MainFrame.cpp
+++ b/rpcs3/Gui/MainFrame.cpp
@@ -436,6 +436,10 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 	wxCheckBox* chbox_dbg_ap_systemcall   = new wxCheckBox(p_hle, wxID_ANY, "Auto Pause at System Call");
 	wxCheckBox* chbox_dbg_ap_functioncall = new wxCheckBox(p_hle, wxID_ANY, "Auto Pause at Function Call");
 
+	//Custom EmulationDir
+	wxCheckBox* chbox_emulationdir_enable = new wxCheckBox(p_system, wxID_ANY, "Use Custom EmulationDir Path?");
+	wxTextCtrl* txt_emulationdir_path     = new wxTextCtrl(p_system, wxID_ANY, "EmulationDir Path, Need Restart");
+
 	cbox_cpu_decoder->Append("PPU Interpreter");
 	cbox_cpu_decoder->Append("PPU Interpreter 2");
 	cbox_cpu_decoder->Append("PPU JIT (LLVM)");
@@ -533,6 +537,10 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 	chbox_dbg_ap_systemcall  ->SetValue(Ini.DBGAutoPauseSystemCall.GetValue());
 	chbox_dbg_ap_functioncall->SetValue(Ini.DBGAutoPauseFunctionCall.GetValue());
 
+	//Custom EmulationDir
+	chbox_emulationdir_enable->SetValue(Ini.SysEmulationDirPathEnable.GetValue());
+	txt_emulationdir_path    ->SetValue(Ini.SysEmulationDirPath.GetValue());
+
 	cbox_cpu_decoder     ->SetSelection(Ini.CPUDecoderMode.GetValue() ? Ini.CPUDecoderMode.GetValue() : 0);
 	cbox_spu_decoder     ->SetSelection(Ini.SPUDecoderMode.GetValue() ? Ini.SPUDecoderMode.GetValue() : 0);
 	cbox_gs_render       ->SetSelection(Ini.GSRenderMode.GetValue());
@@ -614,6 +622,10 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 
 	// System
 	s_subpanel_system->Add(s_round_sys_lang, wxSizerFlags().Border(wxALL, 5).Expand());
+
+	//Custom EmulationDir
+	s_subpanel_system->Add(chbox_emulationdir_enable, wxSizerFlags().Border(wxALL, 5).Expand());
+	s_subpanel_system->Add(txt_emulationdir_path, wxSizerFlags().Border(wxALL, 5).Expand());
 	
 	// Buttons
 	wxBoxSizer* s_b_panel(new wxBoxSizer(wxHORIZONTAL));
@@ -666,6 +678,10 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 		//Auto Pause
 		Ini.DBGAutoPauseFunctionCall.SetValue(chbox_dbg_ap_functioncall->GetValue());
 		Ini.DBGAutoPauseSystemCall.SetValue(chbox_dbg_ap_systemcall->GetValue());
+
+		//Custom EmulationDir
+		Ini.SysEmulationDirPathEnable.SetValue(chbox_emulationdir_enable->GetValue());
+		Ini.SysEmulationDirPath.SetValue(txt_emulationdir_path->GetValue().ToStdString());
 
 		Ini.Save();
 	}

--- a/rpcs3/Gui/MainFrame.cpp
+++ b/rpcs3/Gui/MainFrame.cpp
@@ -437,8 +437,8 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 	wxCheckBox* chbox_dbg_ap_functioncall = new wxCheckBox(p_hle, wxID_ANY, "Auto Pause at Function Call");
 
 	//Custom EmulationDir
-	wxCheckBox* chbox_emulationdir_enable = new wxCheckBox(p_system, wxID_ANY, "Use Custom EmulationDir Path?");
-	wxTextCtrl* txt_emulationdir_path     = new wxTextCtrl(p_system, wxID_ANY, "EmulationDir Path, Need Restart");
+	wxCheckBox* chbox_emulationdir_enable = new wxCheckBox(p_system, wxID_ANY, "Use Path Below as EmulationDir ? (Need Restart)");
+	wxTextCtrl* txt_emulationdir_path     = new wxTextCtrl(p_system, wxID_ANY, Emu.GetEmulatorPath());
 
 	cbox_cpu_decoder->Append("PPU Interpreter");
 	cbox_cpu_decoder->Append("PPU Interpreter 2");

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -403,6 +403,7 @@ public:
 
 		// Customed EmulationDir
 		SysEmulationDirPath.Save();
+		SysEmulationDirPathEnable.Save();
 	}
 };
 

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -165,6 +165,7 @@ public:
 
 	//Customed EmulationDir
 	IniEntry<std::string> SysEmulationDirPath;
+	IniEntry<bool> SysEmulationDirPathEnable;
 
 	// Language
 	IniEntry<u8> SysLanguage;
@@ -245,6 +246,7 @@ public:
 
 		// Customed EmulationDir
 		SysEmulationDirPath.Init("System_EmulationDir", path);
+		SysEmulationDirPathEnable.Init("System_EmulationDirEnable", path);
 
 		// Language
 		SysLanguage.Init("Sytem_SysLanguage", path);
@@ -324,6 +326,7 @@ public:
 
 		// Customed EmulationDir
 		SysEmulationDirPath.Load("");
+		SysEmulationDirPathEnable.Load(false);
 	}
 
 	void Save()

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -163,6 +163,9 @@ public:
 	IniEntry<bool> DBGAutoPauseSystemCall;
 	IniEntry<bool> DBGAutoPauseFunctionCall;
 
+	//Customed EmulationDir
+	IniEntry<std::string> SysEmulationDirPath;
+
 	// Language
 	IniEntry<u8> SysLanguage;
 
@@ -240,6 +243,9 @@ public:
 		DBGAutoPauseFunctionCall.Init("DBG_AutoPauseFunctionCall", path);
 		DBGAutoPauseSystemCall.Init("DBG_AutoPauseSystemCall", path);
 
+		// Customed EmulationDir
+		SysEmulationDirPath.Init("System_EmulationDir", path);
+
 		// Language
 		SysLanguage.Init("Sytem_SysLanguage", path);
 	}
@@ -316,6 +322,8 @@ public:
 		// Language
 		SysLanguage.Load(1);
 
+		// Customed EmulationDir
+		SysEmulationDirPath.Load("");
 	}
 
 	void Save()
@@ -389,6 +397,9 @@ public:
 
 		// Language
 		SysLanguage.Save();
+
+		// Customed EmulationDir
+		SysEmulationDirPath.Save();
 	}
 };
 


### PR DESCRIPTION
Duang! OK the settings for EmulationDir has already done. Hope this solves #972.
`$(EmulationDir)` is where rpcs3 thinks `dev_hdd0`,`dev_flash` and others are, also it determines where the PKGs' content is installed. Though there is still somewhere to be improved, it works now.
To use the feature, you would have to make such changes:
* Make sure that the version you used have this feature. If not you may try build it yourself.
* Open Emulator Setting turn to System(Panel) there would be a `Checkbox` and a `TextCtrl`.
* Fill where you would like the `$(EmulationDir)` to be into the `TextCtrl`, and tick on the `Checkbox`.
* Close rpcs3 and open it again. It should take effects now.

If you assigned a path which it can not access, or path not exists, or is not a directory, **it would automatically switch off** and use the path where rpcs3 executable is. And, i can not make its log show before tried to load any game, so **please load some test elfs to check when you tried to switch**.
Well enjoy your days.. *and.. don't hesitate to improve rpcs3 ha.*

Plus: since i'm using Windows, and patches for Travis isn't merged yet, I can not tell that is completely working or not. If facing problem linking the executable, try edit the `B_IFDIR` in [rpcs3/Emu/FS/VFS.cpp](https://github.com/Syphurith/rpcs3/commit/ea17e08ae65d7c8605fab45070b01183ffccf84f#diff-f91b94c5ca151b72ed3b221bde36b6a8R494) line 494 to what your platform supports (, such as `B_IFDIR()`?)