### PR TITLE
Obsolete read/write depth and color buffers options

### DIFF
--- a/rpcs3/Gui/MainFrame.cpp
+++ b/rpcs3/Gui/MainFrame.cpp
@@ -418,9 +418,6 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 	wxComboBox* cbox_sys_lang         = new wxComboBox(p_system, wxID_ANY);
 
 	wxCheckBox* chbox_gs_log_prog         = new wxCheckBox(p_graphics, wxID_ANY, "Log vertex/fragment programs");
-	wxCheckBox* chbox_gs_dump_depth       = new wxCheckBox(p_graphics, wxID_ANY, "Write Depth Buffer");
-	wxCheckBox* chbox_gs_dump_color       = new wxCheckBox(p_graphics, wxID_ANY, "Write Color Buffers");
-	wxCheckBox* chbox_gs_read_color       = new wxCheckBox(p_graphics, wxID_ANY, "Read Color Buffer");
 	wxCheckBox* chbox_gs_vsync            = new wxCheckBox(p_graphics, wxID_ANY, "VSync");
 	wxCheckBox* chbox_gs_3dmonitor        = new wxCheckBox(p_graphics, wxID_ANY, "3D Monitor");
 	wxCheckBox* chbox_audio_dump          = new wxCheckBox(p_audio, wxID_ANY, "Dump to file");
@@ -514,9 +511,6 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 
 	// Get values from .ini
 	chbox_gs_log_prog        ->SetValue(Ini.GSLogPrograms.GetValue());
-	chbox_gs_dump_depth      ->SetValue(Ini.GSDumpDepthBuffer.GetValue());
-	chbox_gs_dump_color      ->SetValue(Ini.GSDumpColorBuffers.GetValue());
-	chbox_gs_read_color      ->SetValue(Ini.GSReadColorBuffer.GetValue());
 	chbox_gs_vsync           ->SetValue(Ini.GSVSyncEnable.GetValue());
 	chbox_gs_3dmonitor       ->SetValue(Ini.GS3DTV.GetValue());
 	chbox_audio_dump         ->SetValue(Ini.AudioDumpToFile.GetValue());
@@ -578,9 +572,6 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 	s_subpanel_graphics->Add(s_round_gs_aspect, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_graphics->Add(s_round_gs_frame_limit, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_graphics->Add(chbox_gs_log_prog, wxSizerFlags().Border(wxALL, 5).Expand());
-	s_subpanel_graphics->Add(chbox_gs_dump_depth, wxSizerFlags().Border(wxALL, 5).Expand());
-	s_subpanel_graphics->Add(chbox_gs_dump_color, wxSizerFlags().Border(wxALL, 5).Expand());
-	s_subpanel_graphics->Add(chbox_gs_read_color, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_graphics->Add(chbox_gs_vsync, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_graphics->Add(chbox_gs_3dmonitor, wxSizerFlags().Border(wxALL, 5).Expand());
 
@@ -640,9 +631,6 @@ void MainFrame::Config(wxCommandEvent& WXUNUSED(event))
 		Ini.GSAspectRatio.SetValue(cbox_gs_aspect->GetSelection() + 1);
 		Ini.GSFrameLimit.SetValue(cbox_gs_frame_limit->GetSelection());
 		Ini.GSLogPrograms.SetValue(chbox_gs_log_prog->GetValue());
-		Ini.GSDumpDepthBuffer.SetValue(chbox_gs_dump_depth->GetValue());
-		Ini.GSDumpColorBuffers.SetValue(chbox_gs_dump_color->GetValue());
-		Ini.GSReadColorBuffer.SetValue(chbox_gs_read_color->GetValue());
 		Ini.GSVSyncEnable.SetValue(chbox_gs_vsync->GetValue());
 		Ini.GS3DTV.SetValue(chbox_gs_3dmonitor->GetValue());
 		Ini.PadHandlerMode.SetValue(cbox_pad_handler->GetSelection());

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -106,9 +106,6 @@ public:
 	IniEntry<u8> GSAspectRatio;
 	IniEntry<u8> GSFrameLimit;
 	IniEntry<bool> GSLogPrograms;
-	IniEntry<bool> GSDumpColorBuffers;
-	IniEntry<bool> GSDumpDepthBuffer;
-	IniEntry<bool> GSReadColorBuffer;
 	IniEntry<bool> GSVSyncEnable;
 	IniEntry<bool> GS3DTV;
 
@@ -183,9 +180,6 @@ public:
 		GSAspectRatio.Init("GS_AspectRatio", path);
 		GSFrameLimit.Init("GS_FrameLimit", path);
 		GSLogPrograms.Init("GS_LogPrograms", path);
-		GSDumpColorBuffers.Init("GS_DumpColorBuffers", path);
-		GSDumpDepthBuffer.Init("GS_DumpDepthBuffer", path);
-		GSReadColorBuffer.Init("GS_GSReadColorBuffer", path);
 		GSVSyncEnable.Init("GS_VSyncEnable", path);
 		GS3DTV.Init("GS_3DTV", path);
 
@@ -256,9 +250,6 @@ public:
 		GSAspectRatio.Load(2);
 		GSFrameLimit.Load(0);
 		GSLogPrograms.Load(false);
-		GSDumpColorBuffers.Load(false);
-		GSDumpDepthBuffer.Load(false);
-		GSReadColorBuffer.Load(false);
 		GSVSyncEnable.Load(false);
 		GS3DTV.Load(false);
 
@@ -330,9 +321,6 @@ public:
 		GSAspectRatio.Save();
 		GSFrameLimit.Save();
 		GSLogPrograms.Save();
-		GSDumpColorBuffers.Save();
-		GSDumpDepthBuffer.Save();
-		GSReadColorBuffer.Save();
 		GSVSyncEnable.Save();
 		GS3DTV.Save();
 


### PR DESCRIPTION
This is for rsx branch .Read/ write depth and color buffers are now always on and required to turn on for accuracy