### PR TITLE
Update travis to use gcc 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,15 @@ before_install:
   - echo "yes" | sudo add-apt-repository 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main'
   - echo "yes" | sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main'
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -;
-# And the libstdc++4.8 of GCC from ppa
+# And the libstdc++4.9 of GCC from ppa
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install libwxgtk3.0-dev libopenal-dev freeglut3-dev libglew-dev libc6-dev
   - sudo apt-get install aria2 -qq
   - download_extract() { aria2c -x 16 $1 -o $2 && tar -xf $2; }
   - if [ "$CXX" = "g++" ]; then
-      sudo apt-get install -qq g++-4.8;
-      export CXX="g++-4.8" CC="gcc-4.8";
+      sudo apt-get install -qq g++-4.9;
+      export CXX="g++-4.9" CC="gcc-4.9";
     else
       sudo apt-get install -qq --allow-unauthenticated llvm-3.6 llvm-3.6-dev clang-3.6 libstdc++-4.8-dev;
       export CXX="clang++-3.6" CC="clang-3.6";


### PR DESCRIPTION
Due to this change: https://github.com/RPCS3/rpcs3/commit/de9a2fd556123a3bcde4752a9d419db045b10d00#commitcomment-12110160