### PR TITLE
Enable travis-ci for all branches and colorize gcc output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ compiler:
 env:
   global:
    - secure: "jA29KvTCTR7q4BMzPPUBGazjJwrIWa7k4fo5ZSMlyxh2NbztZTKQYwodgDcXBoptCd1KJ9H3FXwBnNdMNVnTkvoPL9uWnN4K/3D1D20FCag1kmlBwnaVqVei5cRiZ9TOMuaxhjkdg8pcrQLTlXEEdMZf6A2OW0VgoBGDVSX9nYc="
+
 branches:
-  only:
-    - master
+  except:
+    - ppu_recompiler
 
 git:
   submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
   - if [ "$CXX" = "g++" ]; then
       sudo apt-get install -qq g++-4.9;
       export CXX="g++-4.9" CC="gcc-4.9";
+      export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
     else
       sudo apt-get install -qq --allow-unauthenticated llvm-3.6 llvm-3.6-dev clang-3.6 libstdc++-4.8-dev;
       export CXX="clang++-3.6" CC="clang-3.6";


### PR DESCRIPTION
except ppu_recompiler (dead branch).
That way it's much easier to setup travis on forks without messing with master yml.
I see no reason to run travis on master only anyway.

Also enabled colorized output on gcc (like on travis). Should be easier to debug it now.