### PR TITLE
Travis warning fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - download_extract() { aria2c -x 16 $1 -o $2 && tar -xf $2; }
   - if [ "$CXX" = "g++" ]; then
       sudo apt-get install -qq g++-4.9;
-      export CXX="g++-4.9" CC="gcc-4.9";
+      export CXX="g++-4.9" CC="gcc-4.9" CXXFLAGS="-Wno-format-security";
       export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
     else
       sudo apt-get install -qq --allow-unauthenticated clang-3.6 libstdc++-4.8-dev;

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -104,10 +104,10 @@ namespace fmt
 		{
 			std::vector<char> buffptr(length);
 #if !defined(_MSC_VER)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 			size_t printlen = snprintf(buffptr.data(), length, fmt, std::forward<Args>(parameters)...);
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #else
 			size_t printlen = _snprintf_s(buffptr.data(), length, length - 1, fmt, std::forward<Args>(parameters)...);
 #endif

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -4390,7 +4390,7 @@ private:
 		else
 		{
 			CPU.SetFPSCR_FI(1);
-			CPU.FPSCR.FR = abs(bfi) > abs(bi);
+			CPU.FPSCR.FR = std::abs(bfi) > std::abs(bi);
 		}
 
 		CPU.FPR[frd] = bf;

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.h
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.h
@@ -1228,7 +1228,7 @@ namespace ppu_recompiler_llvm {
 		{}
 		~CustomSectionMemoryManager() override {}
 
-		virtual uint64_t getSymbolAddress(const std::string &Name)
+		virtual uint64_t getSymbolAddress(const std::string &Name) override
 		{
 			std::unordered_map<std::string, Executable>::const_iterator It = executableMap.find(Name);
 			if (It != executableMap.end())

--- a/rpcs3/Emu/FS/vfsDevice.h
+++ b/rpcs3/Emu/FS/vfsDevice.h
@@ -12,6 +12,7 @@ class vfsDevice
 public:
 	vfsDevice(const std::string& ps3_path, const std::string& local_path);
 	vfsDevice() {}
+	virtual ~vfsDevice() {}
 
 	virtual vfsFileBase* GetNewFileStream()=0;
 	virtual vfsDirBase* GetNewDirStream()=0;

--- a/rpcs3/Emu/SysCalls/Modules/cellRtc.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellRtc.cpp
@@ -429,10 +429,10 @@ s32 cellRtcCheckValid(vm::ptr<CellRtcDateTime> pTime)
 	if ((pTime->year < 1) || (pTime->year > 9999)) return CELL_RTC_ERROR_INVALID_YEAR;
 	else if ((pTime->month < 1) || (pTime->month > 12)) return CELL_RTC_ERROR_INVALID_MONTH;
 	else if ((pTime->day < 1) || (pTime->day > 31)) return CELL_RTC_ERROR_INVALID_DAY;
-	else if ((pTime->hour < 0) || (pTime->hour > 23)) return CELL_RTC_ERROR_INVALID_HOUR;
-	else if ((pTime->minute < 0) || (pTime->minute > 59)) return CELL_RTC_ERROR_INVALID_MINUTE;
-	else if ((pTime->second < 0) || (pTime->second > 59)) return CELL_RTC_ERROR_INVALID_SECOND;
-	else if ((pTime->microsecond < 0) || (pTime->microsecond > 999999)) return CELL_RTC_ERROR_INVALID_MICROSECOND;
+	else if (pTime->hour > 23) return CELL_RTC_ERROR_INVALID_HOUR;
+	else if (pTime->minute > 59) return CELL_RTC_ERROR_INVALID_MINUTE;
+	else if (pTime->second > 59) return CELL_RTC_ERROR_INVALID_SECOND;
+	else if (pTime->microsecond > 999999) return CELL_RTC_ERROR_INVALID_MICROSECOND;
 	else return CELL_OK;
 }
 

--- a/rpcs3/Emu/SysCalls/Modules/cellVpost.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellVpost.cpp
@@ -76,19 +76,19 @@ s32 cellVpostExec(u32 handle, vm::cptr<u8> inPicBuff, vm::cptr<CellVpostCtrlPara
 	u32 ow = ctrlParam->outWidth;
 	u32 oh = ctrlParam->outHeight;
 
-	ctrlParam->inWindow; // ignored
+	//ctrlParam->inWindow; // ignored
 	if (ctrlParam->inWindow.x) cellVpost.Notice("*** inWindow.x = %d", (u32)ctrlParam->inWindow.x);
 	if (ctrlParam->inWindow.y) cellVpost.Notice("*** inWindow.y = %d", (u32)ctrlParam->inWindow.y);
 	if (ctrlParam->inWindow.width != w) cellVpost.Notice("*** inWindow.width = %d", (u32)ctrlParam->inWindow.width);
 	if (ctrlParam->inWindow.height != h) cellVpost.Notice("*** inWindow.height = %d", (u32)ctrlParam->inWindow.height);
-	ctrlParam->outWindow; // ignored
+	//ctrlParam->outWindow; // ignored
 	if (ctrlParam->outWindow.x) cellVpost.Notice("*** outWindow.x = %d", (u32)ctrlParam->outWindow.x);
 	if (ctrlParam->outWindow.y) cellVpost.Notice("*** outWindow.y = %d", (u32)ctrlParam->outWindow.y);
 	if (ctrlParam->outWindow.width != ow) cellVpost.Notice("*** outWindow.width = %d", (u32)ctrlParam->outWindow.width);
 	if (ctrlParam->outWindow.height != oh) cellVpost.Notice("*** outWindow.height = %d", (u32)ctrlParam->outWindow.height);
-	ctrlParam->execType; // ignored
-	ctrlParam->scalerType; // ignored
-	ctrlParam->ipcType; // ignored
+	//ctrlParam->execType; // ignored
+	//ctrlParam->scalerType; // ignored
+	//ctrlParam->ipcType; // ignored
 
 	picInfo->inWidth = w; // copy
 	picInfo->inHeight = h; // copy

--- a/rpcs3/Emu/SysCalls/Modules/sceNpSns.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/sceNpSns.cpp
@@ -9,7 +9,7 @@ std::unique_ptr<SceNpSnsInternal> g_sceNpSns;
 
 s32 sceNpSnsFbInit(/*const SceNpSnsFbInitParams params*/)
 {
-	sceNpSns.Todo("sceNpSnsFbInit(params=???)"/*, params*/);
+	sceNpSns.Todo("sceNpSnsFbInit(params=?)"/*, params*/);
 
 	if (g_sceNpSns->m_bSceNpSnsInitialized)
 	{

--- a/rpcs3/Gui/KernelExplorer.cpp
+++ b/rpcs3/Gui/KernelExplorer.cpp
@@ -86,7 +86,7 @@ void KernelExplorer::Update()
 		for (const auto id : Emu.GetIdManager().get_IDs(SYS_SEMAPHORE_OBJECT))
 		{
 			const auto sem = Emu.GetIdManager().get<lv2_sema_t>(id);
-			sprintf(name, "Semaphore: ID = 0x%x '%s', Count = %d, Max Count = %d, Waiters = %lld", id, &name64(sem->name), sem->value.load(), sem->max, sem->sq.size());
+			sprintf(name, "Semaphore: ID = 0x%x '%s', Count = %d, Max Count = %d, Waiters = %#llx", id, &name64(sem->name), sem->value.load(), sem->max, sem->sq.size());
 			m_tree->AppendItem(node, name);
 		}
 	}


### PR DESCRIPTION
I think that `StrFmt.h` didn't work because of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
(though I'm not sure this is the one, I came across similar bugs that may be the cause).
Because of that I had to disable this warning for whole project. I'm not 100% sure that `CXXFLAGS` appends and not replaces but it seems to do so.
Anyway, this PR get rids of majority of errors so travis logs are again convenient to read and useful to debug, yay :cake: !