### PR TITLE
Add debug options for llvm compiler

### DIFF
--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.h
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.h
@@ -1103,8 +1103,10 @@ namespace ppu_recompiler_llvm {
 		/// Lock for modifying address mutex table
 		std::mutex m_address_locks_lock;
 
-		/// (function, module containing function, times hit, mutex for access).
-		typedef std::tuple<Executable, std::unique_ptr<llvm::ExecutionEngine>, u32> ExecutableStorage;
+		int m_currentId;
+
+		/// (function, module containing function, times hit, id).
+		typedef std::tuple<Executable, std::unique_ptr<llvm::ExecutionEngine>, u32, u32> ExecutableStorage;
 		/// Address to ordinal cahce. Key is address.
 		std::unordered_map<u32, ExecutableStorage> m_address_to_function;
 		std::unordered_map<u32, std::pair<std::mutex, std::atomic<int> > > m_address_locks;

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -92,6 +92,10 @@ private:
 public:
 	// Core
 	IniEntry<u8> CPUDecoderMode;
+	IniEntry<bool> LLVMExclusionRange;
+	IniEntry<int> LLVMMinId;
+	IniEntry<int> LLVMMaxId;
+	IniEntry<int> LLVMThreshold;
 	IniEntry<u8> SPUDecoderMode;
 	IniEntry<bool> HookStFunc;
 	IniEntry<bool> LoadLibLv2;
@@ -176,6 +180,10 @@ public:
 
 		// Core
 		CPUDecoderMode.Init("CORE_DecoderMode", path);
+		LLVMExclusionRange.Init("LLVM_Exclusion_Range", path);
+		LLVMMinId.Init("LLVM_Min_ID", path);
+		LLVMMaxId.Init("LLVM_Max_ID", path);
+		LLVMThreshold.Init("LLVM_Threshold", path);
 		SPUDecoderMode.Init("CORE_SPUDecoderMode", path);
 		HookStFunc.Init("CORE_HookStFunc", path);
 		LoadLibLv2.Init("CORE_LoadLibLv2", path);
@@ -256,6 +264,10 @@ public:
 	{
 		// Core
 		CPUDecoderMode.Load(0);
+		LLVMExclusionRange.Load(false);
+		LLVMMinId.Load(200);
+		LLVMMaxId.Load(250);
+		LLVMThreshold.Load(1000);
 		SPUDecoderMode.Load(0);
 		HookStFunc.Load(false);
 		LoadLibLv2.Load(false);
@@ -336,6 +348,10 @@ public:
 	{
 		// Core
 		CPUDecoderMode.Save();
+		LLVMExclusionRange.Save();
+		LLVMMinId.Save();
+		LLVMMaxId.Save();
+		LLVMThreshold.Save();
 		SPUDecoderMode.Save();
 		HookStFunc.Save();
 		LoadLibLv2.Save();


### PR DESCRIPTION
I used binary search to find the compiled block that breaks the music in Sonic CD, I think having an option in the UI to make this easier may benefit everyone working on llvm recompiler.