### PR TITLE
d3d12: Fix wrong index being used for sampler descriptor heap

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -641,7 +641,7 @@ void D3D12GSRender::Draw()
 		getCurrentResourceStorage().m_currentCommandList->SetDescriptorHeaps(1, getCurrentResourceStorage().m_samplerDescriptorHeap[getCurrentResourceStorage().m_samplerDescriptorHeapIndex].GetAddressOf());
 		getCurrentResourceStorage().m_currentCommandList->SetGraphicsRootDescriptorTable(3,
 			getGPUDescriptorHandle(getCurrentResourceStorage().m_samplerDescriptorHeap[getCurrentResourceStorage().m_samplerDescriptorHeapIndex].Get(),
-				getCurrentResourceStorage().m_currentTextureIndex * g_descriptorStrideSamplers)
+				getCurrentResourceStorage().m_currentSamplerIndex * g_descriptorStrideSamplers)
 			);
 
 		getCurrentResourceStorage().m_currentTextureIndex += usedTexture;


### PR DESCRIPTION
Fix a crash in Disgaea 3 with debug output enabled.