### PR TITLE
Llvm36: Simplify trace management

### DIFF
--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
@@ -318,14 +318,6 @@ const Executable *RecompilationEngine::GetExecutable(u32 address, bool isFunctio
 	return isFunction ? &executeFunc : &executeUntilReturn;
 }
 
-std::pair<std::mutex, std::atomic<int> >* RecompilationEngine::GetMutexAndCounterForAddress(u32 address) {
-	std::lock_guard<std::mutex> lock(m_address_locks_lock);
-	std::unordered_map<u32, std::pair<std::mutex, std::atomic<int>> >::iterator It = m_address_locks.find(address);
-	if (It == m_address_locks.end())
-		return nullptr;
-	return &(It->second);
-}
-
 bool RecompilationEngine::isAddressCommited(u32 address) const
 {
 	size_t offset = address * sizeof(Executable);
@@ -361,22 +353,6 @@ const Executable RecompilationEngine::GetCompiledExecutableIfAvailable(u32 addre
 	return std::get<0>(It->second);
 }
 
-void RecompilationEngine::RemoveUnusedEntriesFromCache() {
-	auto now = std::chrono::high_resolution_clock::now();
-	if (std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_cache_clear_time).count() > 10000) {
-		for (auto i = m_address_to_function.begin(); i != m_address_to_function.end();) {
-			auto tmp = i;
-			i++;
-			if (std::get<2>(tmp->second) == 0)
-				m_address_to_function.erase(tmp);
-			else
-				std::get<2>(tmp->second) = 0;
-		}
-
-		m_last_cache_clear_time = now;
-	}
-}
-
 void RecompilationEngine::NotifyTrace(ExecutionTrace * execution_trace) {
 	{
 		std::lock_guard<std::mutex> lock(m_pending_execution_traces_lock);
@@ -402,7 +378,6 @@ raw_fd_ostream & RecompilationEngine::Log() {
 }
 
 void RecompilationEngine::Task() {
-	bool                     is_idling = false;
 	std::chrono::nanoseconds idling_time(0);
 	std::chrono::nanoseconds recompiling_time(0);
 
@@ -423,46 +398,11 @@ void RecompilationEngine::Task() {
 
 		if (execution_trace) {
 			ProcessExecutionTrace(*execution_trace);
-			delete execution_trace;
 			work_done_this_iteration = true;
+			delete execution_trace;
 		}
 
 		if (!work_done_this_iteration) {
-			// TODO: Reduce the priority of the recompilation engine thread if its set to high priority
-		}
-		else {
-			is_idling = false;
-		}
-
-		if (is_idling) {
-			auto recompiling_start = std::chrono::high_resolution_clock::now();
-
-			// Recompile the function whose CFG has changed the most since the last time it was compiled
-			auto   candidate = (BlockEntry *)nullptr;
-			size_t max_diff = 0;
-			for (auto block : m_block_table) {
-				if (block->IsFunction() && block->is_compiled) {
-					auto diff = block->cfg.GetSize() - block->last_compiled_cfg_size;
-					if (diff > max_diff) {
-						candidate = block;
-						max_diff = diff;
-					}
-				}
-			}
-
-			if (candidate != nullptr) {
-				Log() << "Recompiling: " << candidate->ToString() << "\n";
-				CompileBlock(*candidate);
-				work_done_this_iteration = true;
-			}
-
-			auto recompiling_end = std::chrono::high_resolution_clock::now();
-			recompiling_time += std::chrono::duration_cast<std::chrono::nanoseconds>(recompiling_end - recompiling_start);
-		}
-
-		if (!work_done_this_iteration) {
-			is_idling = true;
-
 			// Wait a few ms for something to happen
 			auto idling_start = std::chrono::high_resolution_clock::now();
 			std::unique_lock<std::mutex> lock(mutex);
@@ -584,7 +524,7 @@ void RecompilationEngine::CompileBlock(BlockEntry & block_entry) {
 	Log() << "CFG: " << block_entry.cfg.ToString() << "\n";
 
 	const std::pair<Executable, llvm::ExecutionEngine *> &compileResult =
-		m_compiler.Compile(fmt::format("fn_0x%08X_%u", block_entry.cfg.start_address, block_entry.revision++), block_entry.cfg,
+		m_compiler.Compile(fmt::format("fn_0x%08X", block_entry.cfg.start_address), block_entry.cfg,
 			block_entry.IsFunction() ? true : false /*generate_linkable_exits*/);
 
 	// If entry doesn't exist, create it (using lock)
@@ -595,24 +535,6 @@ void RecompilationEngine::CompileBlock(BlockEntry & block_entry) {
 		std::get<1>(m_address_to_function[block_entry.cfg.start_address]) = nullptr;
 		if (!isAddressCommited(block_entry.cfg.start_address / 4))
 			commitAddress(block_entry.cfg.start_address / 4);
-	}
-
-	std::unordered_map<u32, std::pair<std::mutex, std::atomic<int>> >::iterator It2 = m_address_locks.find(block_entry.cfg.start_address);
-	if (It2 == m_address_locks.end())
-	{
-		std::lock_guard<std::mutex> lock(m_address_locks_lock);
-		(void)m_address_locks[block_entry.cfg.start_address];
-		m_address_locks[block_entry.cfg.start_address].second.store(0);
-	}
-
-	std::lock_guard<std::mutex> lock(m_address_locks[block_entry.cfg.start_address].first);
-
-	int loopiteration = 0;
-	while (m_address_locks[block_entry.cfg.start_address].second.load() > 0)
-	{
-		std::this_thread::yield();
-		if (loopiteration++ > 10000000)
-			return;
 	}
 
 	std::get<1>(m_address_to_function[block_entry.cfg.start_address]) = std::unique_ptr<llvm::ExecutionEngine>(compileResult.second);
@@ -769,24 +691,15 @@ u32 ppu_recompiler_llvm::CPUHybridDecoderRecompiler::ExecuteTillReturn(PPUThread
 		execution_engine->m_tracer.Trace(Tracer::TraceType::ExitFromCompiledFunction, context >> 32, context & 0xFFFFFFFF);
 
 	while (PollStatus(ppu_state) == false) {
-		std::pair<std::mutex, std::atomic<int>> *mut = execution_engine->m_recompilation_engine->GetMutexAndCounterForAddress(ppu_state->PC);
-		if (mut) {
-			{
-				std::lock_guard<std::mutex> lock(mut->first);
-				mut->second.fetch_add(1);
-			}
-			const Executable executable = execution_engine->m_recompilation_engine->GetCompiledExecutableIfAvailable(ppu_state->PC);
-			if (executable)
-			{
-				auto entry = ppu_state->PC;
-				u32 exit = (u32)executable(ppu_state, 0);
-				mut->second.fetch_sub(1);
-				execution_engine->m_tracer.Trace(Tracer::TraceType::ExitFromCompiledBlock, entry, exit);
-				if (exit == 0)
-					return 0;
-				continue;
-			}
-			mut->second.fetch_add(1);
+		const Executable executable = execution_engine->m_recompilation_engine->GetCompiledExecutableIfAvailable(ppu_state->PC);
+		if (executable)
+		{
+			auto entry = ppu_state->PC;
+			u32 exit = (u32)executable(ppu_state, 0);
+			execution_engine->m_tracer.Trace(Tracer::TraceType::ExitFromCompiledBlock, entry, exit);
+			if (exit == 0)
+				return 0;
+			continue;
 		}
 		execution_engine->m_tracer.Trace(Tracer::TraceType::Instruction, ppu_state->PC, 0);
 		u32 instruction = vm::ps3::read32(ppu_state->PC);

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.h
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.h
@@ -71,7 +71,7 @@ namespace ppu_recompiler_llvm {
 		 * Compile a code fragment described by a cfg and return an executable and the ExecutionEngine storing it
 		 * Pointer to function can be retrieved with getPointerToFunction
 		 */
-		std::pair<Executable, llvm::ExecutionEngine *> Compile(const std::string & name, u32 start_address, u32 instruction_count, bool generate_linkable_exits);
+		std::pair<Executable, llvm::ExecutionEngine *> Compile(const std::string & name, u32 start_address, u32 instruction_count);
 
 		/// Retrieve compiler stats
 		Stats GetStats();
@@ -506,9 +506,6 @@ namespace ppu_recompiler_llvm {
 			/// This is set to false at the start of compilation of an instruction.
 			/// If a branch instruction is encountered, this is set to true by the decode function.
 			bool hit_branch_instruction;
-
-			/// Create code such that exit points can be linked to other blocks
-			bool generate_linkable_exits;
 		};
 
 		/// Recompilation engine
@@ -745,9 +742,6 @@ namespace ppu_recompiler_llvm {
 			return m_ir_builder->CreateCall(fn, fn_args);
 		}
 
-		/// Indirect call
-		llvm::Value * IndirectCall(u32 address, llvm::Value * context_i64, bool is_function);
-
 		/// Test an instruction against the interpreter
 		template <class... Args>
 		void VerifyInstructionAgainstInterpreter(const char * name, void (Compiler::*recomp_fn)(Args...), void (PPUInterpreter::*interp_fn)(Args...), PPUState & input_state, Args... args);
@@ -780,13 +774,6 @@ namespace ppu_recompiler_llvm {
 		friend class CPUHybridDecoderRecompiler;
 	public:
 		virtual ~RecompilationEngine() override;
-
-		/**
-		 * Get the executable for the specified address
-		 * The pointer is always valid during the lifetime of RecompilationEngine
-		 * but the function pointed to can be updated.
-		 **/
-		const Executable *GetExecutable(u32 address, bool isFunction);
 
 		/**
 		 * Get the executable for the specified address if a compiled version is

--- a/rpcs3/Gui/SettingsDialog.cpp
+++ b/rpcs3/Gui/SettingsDialog.cpp
@@ -404,11 +404,11 @@ SettingsDialog::SettingsDialog(wxWindow *parent)
 		txt_dbg_range_min->GetValue().ToLong(&minllvmid);
 		txt_dbg_range_max->GetValue().ToLong(&maxllvmid);
 		Ini.LLVMExclusionRange.SetValue(chbox_core_llvm_exclud->GetValue());
-		Ini.LLVMMinId.SetValue(minllvmid);
-		Ini.LLVMMaxId.SetValue(maxllvmid);
+		Ini.LLVMMinId.SetValue((u32)minllvmid);
+		Ini.LLVMMaxId.SetValue((u32)maxllvmid);
 		long llvmthreshold;
 		txt_llvm_threshold->GetValue().ToLong(&llvmthreshold);
-		Ini.LLVMThreshold.SetValue(llvmthreshold);
+		Ini.LLVMThreshold.SetValue((u32)llvmthreshold);
 		Ini.SPUDecoderMode.SetValue(rbox_spu_decoder->GetSelection());
 		Ini.HookStFunc.SetValue(chbox_core_hook_stfunc->GetValue());
 		Ini.LoadLibLv2.SetValue(chbox_core_load_liblv2->GetValue());

--- a/rpcs3/Ini.cpp
+++ b/rpcs3/Ini.cpp
@@ -121,6 +121,12 @@ void Ini::Save(const std::string& section, const std::string& key, int value)
 	saveIniFile();
 }
 
+void Ini::Save(const std::string& section, const std::string& key, unsigned int value)
+{
+	static_cast<CSimpleIniCaseA*>(m_config)->SetLongValue(section.c_str(), key.c_str(), value);
+	saveIniFile();
+}
+
 void Ini::Save(const std::string& section, const std::string& key, bool value)
 {
 	static_cast<CSimpleIniCaseA*>(m_config)->SetBoolValue(section.c_str(), key.c_str(), value);
@@ -146,6 +152,11 @@ void Ini::Save(const std::string& section, const std::string& key, WindowInfo va
 }
 
 int Ini::Load(const std::string& section, const std::string& key, const int def_value)
+{
+	return static_cast<CSimpleIniCaseA*>(m_config)->GetLongValue(section.c_str(), key.c_str(), def_value);
+}
+
+unsigned int Ini::Load(const std::string& section, const std::string& key, const unsigned int def_value)
 {
 	return static_cast<CSimpleIniCaseA*>(m_config)->GetLongValue(section.c_str(), key.c_str(), def_value);
 }

--- a/rpcs3/Ini.h
+++ b/rpcs3/Ini.h
@@ -25,12 +25,14 @@ protected:
 	Ini();
 
 	void Save(const std::string& section, const std::string& key, int value);
+	void Save(const std::string& section, const std::string& key, unsigned int value);
 	void Save(const std::string& section, const std::string& key, bool value);
 	void Save(const std::string& section, const std::string& key, std::pair<int, int> value);
 	void Save(const std::string& section, const std::string& key, const std::string& value);
 	void Save(const std::string& section, const std::string& key, WindowInfo value);
 
 	int Load(const std::string& section, const std::string& key, const int def_value);
+	unsigned int Load(const std::string& section, const std::string& key, const unsigned int def_value);
 	bool Load(const std::string& section, const std::string& key, const bool def_value);
 	std::pair<int, int> Load(const std::string& section, const std::string& key, const std::pair<int, int> def_value);
 	std::string Load(const std::string& section, const std::string& key, const std::string& def_value);
@@ -93,9 +95,9 @@ public:
 	// Core
 	IniEntry<u8> CPUDecoderMode;
 	IniEntry<bool> LLVMExclusionRange;
-	IniEntry<int> LLVMMinId;
-	IniEntry<int> LLVMMaxId;
-	IniEntry<int> LLVMThreshold;
+	IniEntry<u32> LLVMMinId;
+	IniEntry<u32> LLVMMaxId;
+	IniEntry<u32> LLVMThreshold;
 	IniEntry<u8> SPUDecoderMode;
 	IniEntry<bool> HookStFunc;
 	IniEntry<bool> LoadLibLv2;


### PR DESCRIPTION
Reduce amount of trace data and use block analysis instead.
This should reduce memory consumption by a wide margin in most game, and improve performances.