### PR TITLE
Small appveyor fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,8 @@ branches:
    - ppu_recompiler
 
 before_build:
- - git submodule update --init --depth 3 asmjit minidx9
  # until git for win 2.5 release with commit checkout
- - git submodule update --init ffmpeg
+ - git submodule update --init ffmpeg asmjit minidx9
  - 7z x wxWidgets.7z -aos -oC:\rpcs3\wxWidgets > null
  - if %configuration%==Release (cmake -G "Visual Studio 14 Win64")
    else (7z x llvmlibs.7z -aos -oC:\rpcs3 > null && cmake -G "Visual Studio 14 Win64" -DLLVM_DIR=C:/rpcs3/llvm_build/share/llvm/cmake)


### PR DESCRIPTION
clone depth isn't very reliable for submodules. Still waiting for appveyor to update to 2.5.0 git.