### PR TITLE
Llvm36: Fix and performance improvement

### DIFF
--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
@@ -351,7 +351,7 @@ void RecompilationEngine::Task() {
 			// Wait a few ms for something to happen
 			auto idling_start = std::chrono::high_resolution_clock::now();
 			std::unique_lock<std::mutex> lock(mutex);
-			cv.wait_for(lock, std::chrono::milliseconds(250));
+			cv.wait_for(lock, std::chrono::milliseconds(10));
 			auto idling_end = std::chrono::high_resolution_clock::now();
 			idling_time += std::chrono::duration_cast<std::chrono::nanoseconds>(idling_end - idling_start);
 		}

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
@@ -344,7 +344,7 @@ void RecompilationEngine::Task() {
 
 		if (!m_current_execution_traces.empty()) {
 			for (u32 address : m_current_execution_traces)
-				work_done_this_iteration |= ProcessExecutionTrace(address);
+				work_done_this_iteration |= IncreaseHitCounterAndBuild(address);
 		}
 
 		if (!work_done_this_iteration) {
@@ -374,7 +374,7 @@ void RecompilationEngine::Task() {
 	s_the_instance = nullptr; // Can cause deadlock if this is the last instance. Need to fix this.
 }
 
-bool RecompilationEngine::ProcessExecutionTrace(u32 address) {
+bool RecompilationEngine::IncreaseHitCounterAndBuild(u32 address) {
 	auto It = m_block_table.find(address);
 	if (It == m_block_table.end())
 		It = m_block_table.emplace(address, BlockEntry(address)).first;

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.h
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.h
@@ -890,9 +890,9 @@ namespace ppu_recompiler_llvm {
 		RecompilationEngine & operator = (const RecompilationEngine & other) = delete;
 		RecompilationEngine & operator = (RecompilationEngine && other) = delete;
 
-		/// Process an execution trace.
-		/// Returns true if a block was compiled
-		bool ProcessExecutionTrace(u32);
+		/// Increase usage counter for block starting at addr and compile it if threshold was reached.
+		/// Returns true if block was compiled
+		bool IncreaseHitCounterAndBuild(u32 addr);
 
 		/**
 		* Analyse block to get useful info (function called, has indirect branch...)

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.h
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.h
@@ -24,6 +24,13 @@
 #endif
 
 namespace ppu_recompiler_llvm {
+	enum ExecutionStatus
+	{
+		ExecutionStatusReturn = 0, ///< Block has hit a return, caller can continue execution
+		ExecutionStatusBlockEnded, ///< Block has been executed but no return was hit, at least another block must be executed before caller can continue
+		ExecutionStatusPropagateException, ///< an exception was thrown
+	};
+
 	class Compiler;
 	class RecompilationEngine;
 	class ExecutionEngine;

--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.h
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.h
@@ -786,7 +786,7 @@ namespace ppu_recompiler_llvm {
 		 * Get the executable for the specified address if a compiled version is
 		 * available, otherwise returns nullptr.
 		 **/
-		const Executable GetCompiledExecutableIfAvailable(u32 address);
+		const Executable GetCompiledExecutableIfAvailable(u32 address) const;
 
 		/// Notify the recompilation engine about a newly detected block start.
 		void NotifyBlockStart(u32 address);
@@ -855,15 +855,16 @@ namespace ppu_recompiler_llvm {
 		/// Block table
 		std::unordered_map<u32, BlockEntry> m_block_table;
 
-		/// Lock for accessing m_address_to_function.
-		std::mutex m_address_to_function_lock;
-
 		int m_currentId;
 
-		// Store pointer to every compiled function/block.
-		// We need to map every instruction in PS3 Ram so it's a big table
-		// But a lot of it won't be accessed. Fortunatly virtual memory help here...
-		Executable *FunctionCache;
+		/// (function, id).
+		typedef std::pair<Executable, u32> ExecutableStorageType;
+
+		/// Virtual memory allocated array.
+		/// Store pointer to every compiled function/block and a unique Id.
+		/// We need to map every instruction in PS3 Ram so it's a big table
+		/// But a lot of it won't be accessed. Fortunatly virtual memory help here...
+		ExecutableStorageType* FunctionCache;
 
 		// Bitfield recording page status in FunctionCache reserved memory.
 		char *FunctionCachePagesCommited;
@@ -871,10 +872,8 @@ namespace ppu_recompiler_llvm {
 		bool isAddressCommited(u32) const;
 		void commitAddress(u32);
 
-		/// (function, module containing function, times hit, id).
-		typedef std::tuple<Executable, std::unique_ptr<llvm::ExecutionEngine>, u32, u32> ExecutableStorage;
-		/// Address to ordinal cahce. Key is address.
-		std::unordered_map<u32, ExecutableStorage> m_address_to_function;
+		/// vector storing all exec engine
+		std::vector<std::unique_ptr<llvm::ExecutionEngine> > m_executable_storage;
 
 		/// The time at which the m_address_to_ordinal cache was last cleared
 		std::chrono::high_resolution_clock::time_point m_last_cache_clear_time;

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -536,6 +536,11 @@ public:
 
 	std::function<void(PPUThread& CPU)> custom_task;
 
+	/// When a thread has met an exception, this variable is used to retro propagate it through stack call.
+	/// Note that exception_ptr is similar to shared_ptr and doesn't need to be freed, but need a nullptr
+	/// to be assigned.
+	std::exception_ptr pending_exception;
+
 public:
 	PPUThread(const std::string& name);
 	virtual ~PPUThread() override;


### PR DESCRIPTION
The first commit fixes Retro City Rampage. It basically wrap exec_ppu_func_by_index inside a function that catches CPUThreadExit exception, and it propagates it through return values to Decode function which can safely crash since there is no llvm code.
I tried to do a catch-all code with exception_ptr but it didn't work, I suspect support in VS 2015 is still not mature enough atm...

The 2nd, 4th and 5th commit increase performance of llvm recompiler. It allows to reach 60 fps in Retro City Rampage and Metal Slug 3, as long as llvm threshold is set to 10 (and that recompiler thread has recompiled every necessary block).