### PR TITLE
D3d12: Fix for harem tengoku game.

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -318,7 +318,8 @@ D3D12GSRender::D3D12GSRender()
 	m_vertexIndexData.Init(m_device.Get(), 1024 * 1024 * 384, D3D12_HEAP_TYPE_UPLOAD, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS);
 	m_textureUploadData.Init(m_device.Get(), 1024 * 1024 * 256, D3D12_HEAP_TYPE_UPLOAD, D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS);
 
-	InitD2DStructures();
+	if (Ini.GSOverlay.GetValue())
+		InitD2DStructures();
 }
 
 D3D12GSRender::~D3D12GSRender()

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -326,6 +326,15 @@ D3D12GSRender::~D3D12GSRender()
 {
 	getNonCurrentResourceStorage().WaitAndClean();
 
+	{
+		std::lock_guard<std::mutex> lock(mut);
+		for (auto &protectedTexture : m_protectedTextures)
+		{
+			u32 protectedRangeStart = std::get<1>(protectedTexture), protectedRangeSize = std::get<2>(protectedTexture);
+			vm::page_protect(protectedRangeStart, protectedRangeSize, 0, vm::page_writable, 0);
+		}
+	}
+
 	gfxHandler = [this](u32) { return false; };
 	m_constantsData.Release();
 	m_vertexIndexData.Release();

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -307,8 +307,7 @@ private:
 		// Pointer to device, not owned by ResourceStorage
 		ID3D12Device *m_device;
 		ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-		std::vector<ComPtr<ID3D12GraphicsCommandList> > m_availableCommandLists;
-		size_t m_nextAvailableCommandListIndex;
+		ComPtr<ID3D12GraphicsCommandList> m_commandList;
 
 		// Constants storage
 		ComPtr<ID3D12DescriptorHeap> m_constantsBufferDescriptorsHeap;
@@ -328,7 +327,6 @@ private:
 		// List of resources that can be freed after frame is flipped
 		std::vector<ComPtr<ID3D12Resource> > m_singleFrameLifetimeResources;
 
-		ID3D12GraphicsCommandList *m_currentCommandList;
 
 		void Reset();
 		void Init(ID3D12Device *device);

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -13,15 +13,20 @@ void Shader::Compile(const std::string &code, SHADER_TYPE st)
 {
 	HRESULT hr;
 	ComPtr<ID3DBlob> errorBlob;
+	UINT compileFlags;
+	if (Ini.GSDebugOutputEnable.GetValue())
+		compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+	else
+		compileFlags = 0;
 	switch (st)
 	{
 	case SHADER_TYPE::SHADER_TYPE_VERTEX:
-		hr = D3DCompile(code.c_str(), code.size(), "VertexProgram.hlsl", nullptr, nullptr, "main", "vs_5_0", 0, 0, &bytecode, errorBlob.GetAddressOf());
+		hr = D3DCompile(code.c_str(), code.size(), "VertexProgram.hlsl", nullptr, nullptr, "main", "vs_5_0", compileFlags, 0, &bytecode, errorBlob.GetAddressOf());
 		if (hr != S_OK)
 			LOG_ERROR(RSX, "VS build failed:%s", errorBlob->GetBufferPointer());
 		break;
 	case SHADER_TYPE::SHADER_TYPE_FRAGMENT:
-		hr = D3DCompile(code.c_str(), code.size(), "FragmentProgram.hlsl", nullptr, nullptr, "main", "ps_5_0", 0, 0, &bytecode, errorBlob.GetAddressOf());
+		hr = D3DCompile(code.c_str(), code.size(), "FragmentProgram.hlsl", nullptr, nullptr, "main", "ps_5_0", compileFlags, 0, &bytecode, errorBlob.GetAddressOf());
 		if (hr != S_OK)
 			LOG_ERROR(RSX, "FS build failed:%s", errorBlob->GetBufferPointer());
 		break;

--- a/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
@@ -796,26 +796,48 @@ size_t D3D12GSRender::UploadTextures(ID3D12GraphicsCommandList *cmdlist)
 			break;
 		case CELL_GCM_TEXTURE_A8R8G8B8:
 		{
-			const int RemapValue[4] =
-			{
-				D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_1,
-				D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_2,
-				D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_3,
-				D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_0
-			};
+
 
 			u8 remap_a = m_textures[i].GetRemap() & 0x3;
 			u8 remap_r = (m_textures[i].GetRemap() >> 2) & 0x3;
 			u8 remap_g = (m_textures[i].GetRemap() >> 4) & 0x3;
 			u8 remap_b = (m_textures[i].GetRemap() >> 6) & 0x3;
 			if (isRenderTarget)
-				srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-			else
+			{
+				// ARGB format
+				// Data comes from RTT, stored as RGBA already
+				const int RemapValue[4] =
+				{
+					D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_3,
+					D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_0,
+					D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_1,
+					D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_2
+				};
+
 				srvDesc.Shader4ComponentMapping = D3D12_ENCODE_SHADER_4_COMPONENT_MAPPING(
-					RemapValue[remap_a],
 					RemapValue[remap_r],
 					RemapValue[remap_g],
-					RemapValue[remap_b]);
+					RemapValue[remap_b],
+					RemapValue[remap_a]);
+			}
+			else
+			{
+				// ARGB format
+				// Data comes from RSX mem, stored as ARGB already
+				const int RemapValue[4] =
+				{
+					D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_0,
+					D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_1,
+					D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_2,
+					D3D12_SHADER_COMPONENT_MAPPING_FROM_MEMORY_COMPONENT_3
+				};
+
+				srvDesc.Shader4ComponentMapping = D3D12_ENCODE_SHADER_4_COMPONENT_MAPPING(
+					RemapValue[remap_r],
+					RemapValue[remap_g],
+					RemapValue[remap_b],
+					RemapValue[remap_a]);
+			}
 
 			break;
 		}


### PR DESCRIPTION
These fixes make easier to debug d3d12 commands and fix harem tengoku except for colors.
Others games are likely to be impacted.