### PR TITLE
PPU/LLVM: Fix for most of the remaining crashes on exit with jit

### DIFF
--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
@@ -609,7 +609,7 @@ bool ppu_recompiler_llvm::CPUHybridDecoderRecompiler::PollStatus(PPUThread * ppu
 	catch (...)
 	{
 		ppu_state->pending_exception = std::current_exception();
-		return ExecutionStatus::ExecutionStatusPropagateException;
+		return true;
 	}
 }
 #endif // LLVM_AVAILABLE


### PR DESCRIPTION
Proof of concept. Seems to work fine.
There is rare chance that rpcs3 will hang on game exit in cpu thread destructor (in a loop with g_thread_count or something) but I'm not sure it's related.