### PR TITLE
PPU/LLVM: Remove useless call to NotifyBlockStart

### DIFF
--- a/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/PPULLVMRecompiler.cpp
@@ -560,7 +560,6 @@ u32 ppu_recompiler_llvm::CPUHybridDecoderRecompiler::ExecuteTillReturn(PPUThread
 				return ExecutionStatus::ExecutionStatusReturn;
 			if (exit == ExecutionStatus::ExecutionStatusPropagateException)
 				return ExecutionStatus::ExecutionStatusPropagateException;
-			execution_engine->m_recompilation_engine->NotifyBlockStart(ppu_state->PC);
 			previousInstContigousAndInterp = false;
 			continue;
 		}


### PR DESCRIPTION
Likely a rebase error, with this Metal Slug can run at 60 fps again.