### PR TITLE
Little fix correct path for Game Data

### DIFF
--- a/rpcs3/Gui/GameViewer.cpp
+++ b/rpcs3/Gui/GameViewer.cpp
@@ -189,7 +189,7 @@ void GameViewer::LoadPSF()
 		else if (game.category.substr(0, 2) == "GD")
 		{
 			game.category = "Game Data";
-			game.icon_path = local_path + "/" + m_games[i] + "/PS3_GAME/ICON0.PNG";
+			game.icon_path = local_path + "/" + m_games[i] + "/ICON0.PNG";
 		}
 			
 		m_game_data.push_back(game);


### PR DESCRIPTION
![capture d ecran 2015-09-28 16 38 35](https://cloud.githubusercontent.com/assets/5261759/10138582/802fb83c-65ff-11e5-85e2-e31e37c46a3f.png)
Game Data is not on PS3_GAMES folder, it is obligatory in the 
e.g. :
>BLES01585/USRDIR 

is the same as for HDD Games.
This is the same as it is for the DLC and updated.