### PR TITLE
Fix a save data access violation

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSaveData.cpp
@@ -309,7 +309,10 @@ never_inline s32 savedata_op(PPUThread& ppu, u32 operation, u32 version, vm::cpt
 
 			if (selected == -1)
 			{
-				save_entry.dirName = fixedSet->dirName.get_ptr();
+				if (fixedSet->dirName)
+				{
+					save_entry.dirName = fixedSet->dirName.get_ptr();
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes The Awakened Fate: Ultimatum and probably a couple other games, which were reported with save data problems on the forums.

Thanks to @B1ackDaemon for providing a lead necessary for developing the fix.