### PR TITLE
D3d12: Perf and compat improvements

### DIFF
--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -26,6 +26,21 @@ union alignas(2) f16
 {
 	u16 _u16;
 	u8 _u8[2];
+
+	explicit f16(u16 raw)
+	{
+		_u16 = raw;
+	}
+
+	explicit operator float() const
+	{
+		// See http://stackoverflow.com/a/26779139
+		// The conversion doesn't handle NaN/Inf
+		u32 raw = ((_u16 & 0x8000) << 16) | // Sign (just moved)
+			(((_u16 & 0x7c00) + 0x1C000) << 13) | // Exponent ( exp - 15 + 127)
+			((_u16 & 0x03FF) << 13); // Mantissa
+		return (float&)raw;
+	}
 };
 
 using f32 = float;

--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -35,6 +35,13 @@ bool isNativePrimitiveMode(unsigned m_draw_mode);
 size_t getIndexCount(unsigned m_draw_mode, unsigned initial_index_count);
 
 /*
- * Write index information to bufferMap
+ * Write count indexes starting at first to dst buffer.
+ * Returns min/max index found during the process.
+ * The function expands index buffer for non native primitive type.
  */
-void uploadIndexData(unsigned m_draw_mode, unsigned index_type, void* indexBuffer, void* bufferMap, unsigned element_count);
+void write_index_array_data_to_buffer(char* dst, unsigned m_draw_mode, unsigned first, unsigned count, unsigned &min_index, unsigned &max_index);
+
+/*
+* Write index data needed to emulate non indexed non native primitive mode.
+*/
+void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst, unsigned m_draw_mode, unsigned first, unsigned count);

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -434,7 +434,7 @@ void D3D12GSRender::end()
 	std::chrono::time_point<std::chrono::system_clock> programLoadEnd = std::chrono::system_clock::now();
 	m_timers.m_programLoadDuration += std::chrono::duration_cast<std::chrono::microseconds>(programLoadEnd - programLoadStart).count();
 
-	getCurrentResourceStorage().m_commandList->SetGraphicsRootSignature(m_rootSignatures[m_PSO->second].Get());
+	getCurrentResourceStorage().m_commandList->SetGraphicsRootSignature(m_rootSignatures[std::get<2>(*m_PSO)].Get());
 	getCurrentResourceStorage().m_commandList->OMSetStencilRef(rsx::method_registers[NV4097_SET_STENCIL_FUNC_REF]);
 
 	std::chrono::time_point<std::chrono::system_clock> constantsDurationStart = std::chrono::system_clock::now();
@@ -448,15 +448,15 @@ void D3D12GSRender::end()
 	std::chrono::time_point<std::chrono::system_clock> constantsDurationEnd = std::chrono::system_clock::now();
 	m_timers.m_constantsDuration += std::chrono::duration_cast<std::chrono::microseconds>(constantsDurationEnd - constantsDurationStart).count();
 
-	getCurrentResourceStorage().m_commandList->SetPipelineState(m_PSO->first);
+	getCurrentResourceStorage().m_commandList->SetPipelineState(std::get<0>(*m_PSO));
 
 	std::chrono::time_point<std::chrono::system_clock> textureDurationStart = std::chrono::system_clock::now();
-	if (m_PSO->second > 0)
+	if (std::get<2>(*m_PSO) > 0)
 	{
 		size_t usedTexture = UploadTextures(getCurrentResourceStorage().m_commandList.Get(), currentDescriptorIndex + 3);
 
 		// Fill empty slots
-		for (; usedTexture < m_PSO->second; usedTexture++)
+		for (; usedTexture < std::get<2>(*m_PSO); usedTexture++)
 		{
 			D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
 			srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -244,7 +244,7 @@ D3D12GSRender::D3D12GSRender()
 	m_rtts.Init(m_device.Get());
 
 	m_constantsData.Init(m_device.Get(), 1024 * 1024 * 64, D3D12_HEAP_TYPE_UPLOAD, D3D12_HEAP_FLAG_NONE);
-	m_vertexIndexData.Init(m_device.Get(), 1024 * 1024 * 256, D3D12_HEAP_TYPE_UPLOAD, D3D12_HEAP_FLAG_NONE);
+	m_vertexIndexData.Init(m_device.Get(), 1024 * 1024 * 384, D3D12_HEAP_TYPE_UPLOAD, D3D12_HEAP_FLAG_NONE);
 	m_textureUploadData.Init(m_device.Get(), 1024 * 1024 * 512, D3D12_HEAP_TYPE_UPLOAD, D3D12_HEAP_FLAG_NONE);
 
 	if (rpcs3::config.rsx.d3d12.overlay.value())

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -309,7 +309,7 @@ private:
 
 	RSXFragmentProgram fragment_program;
 	PipelineStateObjectCache m_cachePSO;
-	std::pair<ID3D12PipelineState *, size_t> *m_PSO;
+	std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t> *m_PSO;
 	std::unordered_map<u32, color4f> local_transform_constants;
 
 	struct

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -405,13 +405,13 @@ private:
 	ResourceStorage &getNonCurrentResourceStorage();
 
 	// Constants storage
-	DataHeap<ID3D12Resource, 256> m_constantsData;
+	DataHeap<ID3D12Resource, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT> m_constantsData;
 	// Vertex storage
-	DataHeap<ID3D12Resource, 256> m_vertexIndexData;
+	DataHeap<ID3D12Resource, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT> m_vertexIndexData;
 	// Texture storage
-	DataHeap<ID3D12Resource, 65536> m_textureUploadData;
-	DataHeap<ID3D12Heap, 65536> m_UAVHeap;
-	DataHeap<ID3D12Heap, 65536> m_readbackResources;
+	DataHeap<ID3D12Resource, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT> m_textureUploadData;
+	DataHeap<ID3D12Heap, D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT> m_UAVHeap;
+	DataHeap<ID3D12Heap, D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT> m_readbackResources;
 
 	struct
 	{

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -417,7 +417,6 @@ private:
 	{
 		bool m_indexed; /*<! is draw call using an index buffer */
 		size_t m_count; /*<! draw call vertex count */
-		size_t m_baseVertex; /*<! Starting vertex for draw call */
 	} m_renderingInfo;
 
 	RenderTargets m_rtts;
@@ -458,19 +457,19 @@ private:
 
 	bool LoadProgram();
 
+	/**
+	* Create vertex and index buffers (if needed) and set them to cmdlist.
+	* Non native primitive type are emulated by index buffers expansion.
+	*/
+	void upload_vertex_index_data(ID3D12GraphicsCommandList *cmdlist);
+
 	std::vector<std::pair<u32, u32> > m_first_count_pairs;
 	/**
-	 * Upload all vertex attribute whose (first, count) info were previously accumulated.
+	 * Upload all enabled vertex attributes for vertex in ranges described by vertex_ranges.
+	 * A range in vertex_range is a pair whose first element is the index of the beginning of the
+	 * range, and whose second element is the number of vertex in this range.
 	 */
-	void upload_vertex_attributes();
-
-	/**
-	 * Create index buffer for indexed rendering and non native primitive format if nedded, and
-	 * update m_renderingInfo member accordingly. If m_renderingInfo::m_indexed is true,
-	 * returns an index buffer view that can be passed to a command list.
-	 */
-	D3D12_INDEX_BUFFER_VIEW uploadIndexBuffers(bool indexed_draw = false);
-
+	void upload_vertex_attributes(const std::vector<std::pair<u32, u32> > &vertex_ranges);
 
 	void setScaleOffset(size_t descriptorIndex);
 	void FillVertexShaderConstantsBuffer(size_t descriptorIndex);
@@ -504,4 +503,5 @@ protected:
 	virtual void flip(int buffer) override;
 
 	virtual void load_vertex_data(u32 first, u32 count) override;
+	virtual void load_vertex_index_data(u32 first, u32 count) override;
 };

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -292,6 +292,9 @@ bool D3D12GSRender::LoadProgram()
 		prop.Blend.RenderTarget[i].RenderTargetWriteMask = mask;
 
 	prop.IASet = m_IASet;
+	if (!!rsx::method_registers[NV4097_SET_RESTART_INDEX_ENABLE])
+		prop.CutValue = ((rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4) == CELL_GCM_DRAW_INDEX_ARRAY_TYPE_32) ?
+			D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFFFFFF : D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFF;
 
 	m_PSO = m_cachePSO.getGraphicPipelineState(&vertex_program, &fragment_program, prop, std::make_pair(m_device.Get(), m_rootSignatures));
 	return m_PSO != nullptr;

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.h
@@ -16,6 +16,7 @@ struct D3D12PipelineProperties
 	unsigned numMRT : 3;
 	D3D12_DEPTH_STENCIL_DESC DepthStencil;
 	D3D12_RASTERIZER_DESC Rasterization;
+	D3D12_INDEX_BUFFER_STRIP_CUT_VALUE CutValue;
 
 	bool operator==(const D3D12PipelineProperties &in) const
 	{
@@ -218,6 +219,8 @@ struct D3D12Traits
 		graphicPipelineStateDesc.SampleDesc.Count = 1;
 		graphicPipelineStateDesc.SampleMask = UINT_MAX;
 		graphicPipelineStateDesc.NodeMask = 1;
+
+		graphicPipelineStateDesc.IBStripCutValue = pipelineProperties.CutValue;
 
 		extraData.first->CreateGraphicsPipelineState(&graphicPipelineStateDesc, IID_PPV_ARGS(&std::get<0>(*result)));
 		std::get<1>(*result) = vertexProgramData.vertex_shader_inputs;

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.h
@@ -90,6 +90,7 @@ public:
 
 	u32 id;
 	ComPtr<ID3DBlob> bytecode;
+	std::vector<size_t> vertex_shader_inputs;
 	std::vector<size_t> FragmentConstantOffsetCache;
 	size_t m_textureCount;
 
@@ -103,11 +104,40 @@ public:
 	void Compile(const std::string &code, enum class SHADER_TYPE st);
 };
 
+static
+bool has_attribute(size_t attribute, const std::vector<D3D12_INPUT_ELEMENT_DESC> &desc)
+{
+	for (const auto &attribute_desc : desc)
+	{
+		if (attribute_desc.SemanticIndex == attribute)
+			return true;
+	}
+	return false;
+}
+
+static
+std::vector<D3D12_INPUT_ELEMENT_DESC> completes_IA_desc(const std::vector<D3D12_INPUT_ELEMENT_DESC> &desc, const std::vector<size_t> &inputs)
+{
+	std::vector<D3D12_INPUT_ELEMENT_DESC> result(desc);
+	for (size_t attribute : inputs)
+	{
+		if (has_attribute(attribute, desc))
+			continue;
+		D3D12_INPUT_ELEMENT_DESC extra_ia_desc = {};
+		extra_ia_desc.SemanticIndex = (UINT)attribute;
+		extra_ia_desc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+		extra_ia_desc.SemanticName = "TEXCOORD";
+		extra_ia_desc.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
+		result.push_back(extra_ia_desc);
+	}
+	return result;
+}
+
 struct D3D12Traits
 {
 	typedef Shader VertexProgramData;
 	typedef Shader FragmentProgramData;
-	typedef std::pair<ID3D12PipelineState *, size_t> PipelineData;
+	typedef std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t> PipelineData;
 	typedef D3D12PipelineProperties PipelineProperties;
 	typedef std::pair<ID3D12Device *, ComPtr<ID3D12RootSignature> *> ExtraData;
 
@@ -144,7 +174,7 @@ struct D3D12Traits
 		D3D12VertexProgramDecompiler VS(RSXVP->data);
 		std::string shaderCode = VS.Decompile();
 		vertexProgramData.Compile(shaderCode, Shader::SHADER_TYPE::SHADER_TYPE_VERTEX);
-
+		vertexProgramData.vertex_shader_inputs = VS.input_slots;
 		// TODO: This shouldn't use current dir
 		std::string filename = "./VertexProgram" + std::to_string(ID) + ".hlsl";
 		fs::file(filename, fom::write | fom::create | fom::trunc).write(shaderCode.c_str(), shaderCode.size());
@@ -155,7 +185,7 @@ struct D3D12Traits
 	PipelineData *BuildProgram(VertexProgramData &vertexProgramData, FragmentProgramData &fragmentProgramData, const PipelineProperties &pipelineProperties, const ExtraData& extraData)
 	{
 
-		std::pair<ID3D12PipelineState *, size_t> *result = new std::pair<ID3D12PipelineState *, size_t>();
+		std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t> *result = new std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t>();
 		D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicPipelineStateDesc = {};
 
 		if (vertexProgramData.bytecode == nullptr)
@@ -169,7 +199,7 @@ struct D3D12Traits
 		graphicPipelineStateDesc.PS.pShaderBytecode = fragmentProgramData.bytecode->GetBufferPointer();
 
 		graphicPipelineStateDesc.pRootSignature = extraData.second[fragmentProgramData.m_textureCount].Get();
-		result->second = fragmentProgramData.m_textureCount;
+		std::get<2>(*result) = fragmentProgramData.m_textureCount;
 
 		graphicPipelineStateDesc.BlendState = pipelineProperties.Blend;
 		graphicPipelineStateDesc.DepthStencilState = pipelineProperties.DepthStencil;
@@ -181,20 +211,23 @@ struct D3D12Traits
 			graphicPipelineStateDesc.RTVFormats[i] = pipelineProperties.RenderTargetsFormat;
 		graphicPipelineStateDesc.DSVFormat = pipelineProperties.DepthStencilFormat;
 
-		graphicPipelineStateDesc.InputLayout.pInputElementDescs = pipelineProperties.IASet.data();
-		graphicPipelineStateDesc.InputLayout.NumElements = (UINT)pipelineProperties.IASet.size();
+		const std::vector<D3D12_INPUT_ELEMENT_DESC> &completed_IA_desc = completes_IA_desc(pipelineProperties.IASet, vertexProgramData.vertex_shader_inputs);
+
+		graphicPipelineStateDesc.InputLayout.pInputElementDescs = completed_IA_desc.data();
+		graphicPipelineStateDesc.InputLayout.NumElements = (UINT)completed_IA_desc.size();
 		graphicPipelineStateDesc.SampleDesc.Count = 1;
 		graphicPipelineStateDesc.SampleMask = UINT_MAX;
 		graphicPipelineStateDesc.NodeMask = 1;
 
-		extraData.first->CreateGraphicsPipelineState(&graphicPipelineStateDesc, IID_PPV_ARGS(&result->first));
+		extraData.first->CreateGraphicsPipelineState(&graphicPipelineStateDesc, IID_PPV_ARGS(&std::get<0>(*result)));
+		std::get<1>(*result) = vertexProgramData.vertex_shader_inputs;
 		return result;
 	}
 
 	static
 	void DeleteProgram(PipelineData *ptr)
 	{
-		ptr->first->Release();
+		std::get<0>(*ptr)->Release();
 		delete ptr;
 	}
 };

--- a/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
@@ -130,7 +130,7 @@ ComPtr<ID3D12Resource> uploadSingleTexture(
 	const rsx::texture &texture,
 	ID3D12Device *device,
 	ID3D12GraphicsCommandList *commandList,
-	DataHeap<ID3D12Resource, 65536> &textureBuffersHeap)
+	DataHeap<ID3D12Resource, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT> &textureBuffersHeap)
 {
 	ComPtr<ID3D12Resource> vramTexture;
 	size_t w = texture.width(), h = texture.height();
@@ -181,7 +181,7 @@ static
 void updateExistingTexture(
 	const rsx::texture &texture,
 	ID3D12GraphicsCommandList *commandList,
-	DataHeap<ID3D12Resource, 65536> &textureBuffersHeap,
+	DataHeap<ID3D12Resource, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT> &textureBuffersHeap,
 	ID3D12Resource *existingTexture)
 {
 	size_t w = texture.width(), h = texture.height();

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
@@ -43,9 +43,13 @@ void D3D12VertexProgramDecompiler::insertInputs(std::stringstream & OS, const st
 	for (const ParamType PT : inputs)
 	{
 		for (const ParamItem &PI : PT.items)
+		{
 			OS << "	" << PT.type << " " << PI.name << ": TEXCOORD" << PI.location << ";" << std::endl;
+			input_slots.push_back(PI.location);
+		}
 	}
 	OS << "};" << std::endl;
+
 }
 
 void D3D12VertexProgramDecompiler::insertConstants(std::stringstream & OS, const std::vector<ParamType> & constants)
@@ -132,6 +136,8 @@ void D3D12VertexProgramDecompiler::insertMainStart(std::stringstream & OS)
 			OS << "	" << PT.type << " " << PI.name;
 			if (!PI.value.empty())
 				OS << " = " << PI.value;
+			else
+				OS << " = " << "float4(0., 0., 0., 0.);";
 			OS << ";" << std::endl;
 		}
 	}

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.h
@@ -19,5 +19,6 @@ protected:
 	virtual void insertMainStart(std::stringstream &OS);
 	virtual void insertMainEnd(std::stringstream &OS);
 public:
+	std::vector<size_t> input_slots;
 	D3D12VertexProgramDecompiler(std::vector<u32>& data);
 };

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -144,9 +144,9 @@ namespace rsx
 		return (method_registers[NV4097_SET_TEXTURE_CONTROL1 + (m_index * 8)]);
 	}
 
-	u16 texture::bias() const
+	float texture::bias() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff);
+		return float(f16((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff));
 	}
 
 	u8  texture::min_filter() const

--- a/rpcs3/Emu/RSX/RSXTexture.h
+++ b/rpcs3/Emu/RSX/RSXTexture.h
@@ -44,7 +44,7 @@ namespace rsx
 		u32 remap() const;
 
 		// Filter
-		u16 bias() const;
+		float bias() const;
 		u8  min_filter() const;
 		u8  mag_filter() const;
 		u8  convolution_filter() const;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -164,7 +164,7 @@ namespace rsx
 		u32 transform_program[512 * 4] = {};
 
 		virtual void load_vertex_data(u32 first, u32 count);
-		void load_vertex_index_data(u32 first, u32 count);
+		virtual void load_vertex_index_data(u32 first, u32 count);
 
 	public:
 		u32 ioAddress, ioSize;


### PR DESCRIPTION
This PR avoid an extra copy of index buffers. It also makes several fixes in Braid, which is still not playable but at least doesn't crash.