### PR TITLE
Fix FPS counter bug

### DIFF
--- a/rpcs3/Gui/GSFrame.cpp
+++ b/rpcs3/Gui/GSFrame.cpp
@@ -19,6 +19,7 @@ GSFrame::GSFrame(const wxString& title) : wxFrame(nullptr, wxID_ANY, "GSFrame[" 
 {
 	SetIcon(wxICON(frame_icon));
 
+	m_frames = 0;
 	CellVideoOutResolution res = ResolutionTable[ResolutionIdToNum((u32)rpcs3::state.config.rsx.resolution.value())];
 	SetClientSize(res.width, res.height);
 	wxGetApp().Bind(wxEVT_KEY_DOWN, &GSFrame::OnKeyDown, this);


### PR DESCRIPTION
A silly bug is often followed by a silly fix. The frame counter was not initialized.