### PR TITLE
Rsx: Factorise d3d12 constant loading code

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -277,3 +277,9 @@ void write_index_array_data_to_buffer(char* dst, unsigned m_draw_mode, unsigned 
 		}
 	}
 }
+
+void stream_vector(void *dst, u32 x, u32 y, u32 z, u32 w) noexcept
+{
+	__m128i vector = _mm_set_epi32(w, z, y, x);
+	_mm_stream_si128((__m128i*)dst, vector);
+}

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -283,3 +283,9 @@ void stream_vector(void *dst, u32 x, u32 y, u32 z, u32 w) noexcept
 	__m128i vector = _mm_set_epi32(w, z, y, x);
 	_mm_stream_si128((__m128i*)dst, vector);
 }
+
+void stream_vector_from_memory(void *dst, void *src) noexcept
+{
+	const __m128i &vector = _mm_loadu_si128((__m128i*)src);
+	_mm_stream_si128((__m128i*)dst, vector);
+}

--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -48,3 +48,8 @@ void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst,
  * Stream a 128 bits vector to dst.
  */
 void stream_vector(void *dst, u32 x, u32 y, u32 z, u32 w) noexcept;
+
+/**
+ * Stream a 128 bits vector from src to dst.
+ */
+void stream_vector_from_memory(void *dst, void *src) noexcept;

--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -43,3 +43,8 @@ void write_index_array_data_to_buffer(char* dst, unsigned m_draw_mode, unsigned 
  * Write index data needed to emulate non indexed non native primitive mode.
  */
 void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst, unsigned m_draw_mode, unsigned first, unsigned count) noexcept;
+
+/**
+ * Stream a 128 bits vector to dst.
+ */
+void stream_vector(void *dst, u32 x, u32 y, u32 z, u32 w) noexcept;

--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -167,9 +167,6 @@ void D3D12GSRender::upload_and_bind_scale_offset_matrix(size_t descriptorIndex)
 
 void D3D12GSRender::upload_and_bind_vertex_shader_constants(size_t descriptor_index)
 {
-	for (const auto &entry : transform_constants)
-		local_transform_constants[entry.first] = entry.second;
-
 	size_t buffer_size = 512 * 4 * sizeof(float);
 
 	assert(m_constantsData.can_alloc(buffer_size));
@@ -177,16 +174,7 @@ void D3D12GSRender::upload_and_bind_vertex_shader_constants(size_t descriptor_in
 
 	void *mapped_buffer;
 	ThrowIfFailed(m_constantsData.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), &mapped_buffer));
-	for (const auto &entry : local_transform_constants)
-	{
-		float data[4] = {
-			entry.second.x,
-			entry.second.y,
-			entry.second.z,
-			entry.second.w
-		};
-		streamToBuffer((char*)mapped_buffer + heap_offset + entry.first * 4 * sizeof(float), data, 4 * sizeof(float));
-	}
+	fill_vertex_program_constants_data((char*)mapped_buffer + heap_offset);
 	m_constantsData.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 
 	D3D12_CONSTANT_BUFFER_VIEW_DESC constant_buffer_view_desc = {

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -672,7 +672,6 @@ void D3D12GSRender::flip(int buffer)
 	storage.uav_heap_get_pos = m_UAVHeap.get_current_put_pos_minus_one();
 
 	// Flush
-	local_transform_constants.clear();
 	m_texturesRTTs.clear();
 
 	// Now get ready for next frame

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -72,7 +72,6 @@ private:
 	RSXFragmentProgram fragment_program;
 	PipelineStateObjectCache m_cachePSO;
 	std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t> *m_PSO;
-	std::unordered_map<u32, color4f> local_transform_constants;
 
 	struct
 	{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -586,6 +586,7 @@ namespace rsx
 
 		std::this_thread::sleep_for(std::chrono::milliseconds((s64)(1000.0 / limit - rsx->timer_sync.GetElapsedTimeInMilliSec())));
 		rsx->timer_sync.Start();
+		rsx->local_transform_constants.clear();
 	}
 
 	void user_command(thread* rsx, u32 arg)
@@ -1046,6 +1047,18 @@ namespace rsx
 		stream_vector((char*)buffer + 16, 0, (u32&)scale_y, 0, (u32&)offset_y);
 		stream_vector((char*)buffer + 32, 0, 0, (u32&)scale_z, (u32&)offset_z);
 		stream_vector((char*)buffer + 48, 0, 0, 0, (u32&)one);
+	}
+
+	/**
+	* Fill buffer with vertex program constants.
+	* Buffer must be at least 512 float4 wide.
+	*/
+	void thread::fill_vertex_program_constants_data(void *buffer) noexcept
+	{
+		for (const auto &entry : transform_constants)
+			local_transform_constants[entry.first] = entry.second;
+		for (const auto &entry : local_transform_constants)
+			stream_vector_from_memory((char*)buffer + entry.first * 4 * sizeof(float), (void*)entry.second.rgba);
 	}
 
 	u64 thread::timestamp() const

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1024,6 +1024,30 @@ namespace rsx
 		onexit_thread();
 	}
 
+	void thread::fill_scale_offset_data(void *buffer) const noexcept
+	{
+		int clip_w = rsx::method_registers[NV4097_SET_SURFACE_CLIP_HORIZONTAL] >> 16;
+		int clip_h = rsx::method_registers[NV4097_SET_SURFACE_CLIP_VERTICAL] >> 16;
+
+		float scale_x = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE] / (clip_w / 2.f);
+		float offset_x = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET] - (clip_w / 2.f);
+		offset_x /= clip_w / 2.f;
+
+		float scale_y = -(float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE + 1] / (clip_h / 2.f);
+		float offset_y = -((float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET + 1] - (clip_h / 2.f));
+		offset_y /= clip_h / 2.f;
+
+		float scale_z = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE + 2];
+		float offset_z = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET + 2];
+
+		float one = 1.f;
+
+		stream_vector(buffer, (u32&)scale_x, 0, 0, (u32&)offset_x);
+		stream_vector((char*)buffer + 16, 0, (u32&)scale_y, 0, (u32&)offset_y);
+		stream_vector((char*)buffer + 32, 0, 0, (u32&)scale_z, (u32&)offset_z);
+		stream_vector((char*)buffer + 48, 0, 0, 0, (u32&)one);
+	}
+
 	u64 thread::timestamp() const
 	{
 		// Get timestamp, and convert it from microseconds to nanoseconds

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -161,6 +161,9 @@ namespace rsx
 
 		std::unordered_map<u32, color4_base<f32>> transform_constants;
 
+		// Constant stored for whole frame
+		std::unordered_map<u32, color4f> local_transform_constants;
+
 		u32 transform_program[512 * 4] = {};
 
 		virtual void load_vertex_data(u32 first, u32 count);
@@ -223,6 +226,12 @@ namespace rsx
 		 * Vertex shader's position is to be multiplied by this matrix.
 		 */
 		void fill_scale_offset_data(void *buffer) const noexcept;
+
+		/**
+		* Fill buffer with vertex program constants.
+		* Buffer must be at least 512 float4 wide.
+		*/
+		void fill_vertex_program_constants_data(void *buffer) noexcept;
 
 	public:
 		void reset();

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -218,6 +218,12 @@ namespace rsx
 
 		void task();
 
+		/**
+		 * Fill buffer with 4x4 scale offset matrix.
+		 * Vertex shader's position is to be multiplied by this matrix.
+		 */
+		void fill_scale_offset_data(void *buffer) const noexcept;
+
 	public:
 		void reset();
 		void init(const u32 ioAddress, const u32 ioSize, const u32 ctrlAddress, const u32 localAddress);


### PR DESCRIPTION
This PR factorise the d3d12 code that write constants data to buffer into rsx::thread.
A future PR will make GL use these new members. It's a first step to get more code shared between backends, I intend to do that very slowly to ensure as little regression as possible.