### PR TITLE
Install cmake from packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,8 @@ git:
 before_install:
 # shutdown services on Travis, which may have a memory impact
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      service mysql stop;
-      service couchdb stop;
-      service redis-server stop;
-
       echo "yes" | sudo apt-add-repository 'deb http://repos.codelite.org/wx3.0/ubuntu/ precise universe';
       sudo apt-get install libwxgtk3.0-dev;
-      download_extract() { aria2c -x 16 $1 -o $2 && tar -xf $2; };
     fi;
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CXX" = "g++" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" CXXFLAGS="-Wno-format-security";
@@ -47,12 +42,8 @@ before_install:
     elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
       export CXX="clang++-3.6" CC="clang-3.6";
     fi;
-# Travis uses CMake 2.8.7. We require 2.8.8. Grab latest
 # Add coverall for C++ so coverall.io could be triggered. Even it should be --coverage and gcov.
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      aria2c -x 16 http://www.cmake.org/files/v3.0/cmake-3.0.0-Linux-i386.sh && 
-      chmod a+x cmake-3.0.0-Linux-i386.sh &&
-      sudo ./cmake-3.0.0-Linux-i386.sh --skip-license --prefix=/usr;
       sudo pip install cpp-coveralls requests[security];
     else
       brew update; brew update;
@@ -77,7 +68,9 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.6
+    - kubuntu-backports
     packages:
+    - cmake
     - libopenal-dev
     - freeglut3-dev
     - libglew-dev
@@ -85,7 +78,6 @@ addons:
     - llvm-3.6
     - llvm-3.6-dev
     - libedit-dev
-    - aria2
     - g++-4.9
     - clang-3.6
     - libstdc++-4.8-dev


### PR DESCRIPTION
It should be at least 2.8.12
Fixes travis build errors on linux (it failed to manually install it from cmake.org).
Removed aria2 package since we don't need it anymore.