### PR TITLE
d3d12: Clean rtt related code

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -131,7 +131,7 @@ private:
 		size_t m_count; /*<! draw call vertex count */
 	} m_renderingInfo;
 
-	RenderTargets m_rtts;
+	render_targets m_rtts;
 
 	std::vector<D3D12_INPUT_ELEMENT_DESC> m_IASet;
 	std::vector<D3D12_VERTEX_BUFFER_VIEW> m_vertex_buffer_views;
@@ -158,6 +158,8 @@ private:
 	void release_d2d_structures();
 
 	bool load_program();
+
+	void set_rtt_and_ds(ID3D12GraphicsCommandList *command_list);
 
 	/**
 	* Create vertex and index buffers (if needed) and set them to cmdlist.

--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.h
@@ -2,29 +2,32 @@
 
 #include <d3d12.h>
 
-struct RenderTargets
+struct render_targets
 {
-	std::unordered_map<u32, ID3D12Resource* > m_renderTargets;
-	ID3D12Resource *m_currentlyBoundRenderTargets[4];
-	u32 m_currentlyBoundRenderTargetsAddress[4];
-	std::unordered_map<u32, ComPtr<ID3D12Resource> > m_depthStencil;
-	ID3D12Resource *m_currentlyBoundDepthStencil;
-	u32 m_currentlyBoundDepthStencilAddress;
-	ID3D12DescriptorHeap *m_renderTargetsDescriptorsHeap;
-	ID3D12DescriptorHeap *m_depthStencilDescriptorHeap;
+	INT g_descriptor_stride_rtv;
+	std::unordered_map<u32, ComPtr<ID3D12Resource> > render_targets_storage;
+	ID3D12Resource *bound_render_targets[4];
+	u32 bound_render_targets_address[4];
+	std::unordered_map<u32, ComPtr<ID3D12Resource> > depth_stencil_storage;
+	ID3D12Resource *bound_depth_stencil;
+	u32 bound_depth_stencil_address;
+	ComPtr<ID3D12DescriptorHeap> render_targets_descriptors_heap;
+	ComPtr<ID3D12DescriptorHeap> depth_stencil_descriptor_heap;
+
+	size_t bind_render_targets(ID3D12Device *, u32 color_format, D3D12_CPU_DESCRIPTOR_HANDLE);
+	size_t bind_depth_stencil(ID3D12Device *, u32 depth_format, D3D12_CPU_DESCRIPTOR_HANDLE);
 
 	/**
 	 * If render target already exists at address, issue state change operation on cmdList.
 	 * Otherwise create one with width, height, clearColor info.
 	 * returns the corresponding render target resource.
 	 */
-	ID3D12Resource *bindAddressAsRenderTargets(ID3D12Device *device, ID3D12GraphicsCommandList *cmdList, size_t slot, u32 address,
+	ID3D12Resource *bind_address_as_render_targets(ID3D12Device *device, ID3D12GraphicsCommandList *cmdList, u32 address,
 		size_t width, size_t height, u8 surfaceColorFormat, const std::array<float, 4> &clearColor);
 
-	ID3D12Resource *bindAddressAsDepthStencil(ID3D12Device *device, ID3D12GraphicsCommandList *cmdList, u32 address,
+	ID3D12Resource *bind_address_as_depth_stencil(ID3D12Device *device, ID3D12GraphicsCommandList *cmdList, u32 address,
 		size_t width, size_t height, u8 surfaceDepthFormat, float depthClear, u8 stencilClear, ComPtr<ID3D12Resource> &dirtyDS);
 
-	void Init(ID3D12Device *device);
-	void Release();
+	void init(ID3D12Device *device);
 };
 

--- a/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
@@ -140,12 +140,12 @@ void D3D12GSRender::upload_and_bind_textures(ID3D12GraphicsCommandList *command_
 		bool is_swizzled = !(textures[i].format() & CELL_GCM_TEXTURE_LN);
 
 		ID3D12Resource *vram_texture;
-		std::unordered_map<u32, ID3D12Resource* >::const_iterator ItRTT = m_rtts.m_renderTargets.find(texaddr);
+		std::unordered_map<u32, ComPtr<ID3D12Resource> >::const_iterator ItRTT = m_rtts.render_targets_storage.find(texaddr);
 		std::pair<texture_entry, ComPtr<ID3D12Resource> > *cached_texture = m_textureCache.find_data_if_available(texaddr);
 		bool isRenderTarget = false;
-		if (ItRTT != m_rtts.m_renderTargets.end())
+		if (ItRTT != m_rtts.render_targets_storage.end())
 		{
-			vram_texture = ItRTT->second;
+			vram_texture = ItRTT->second.Get();
 			isRenderTarget = true;
 		}
 		else if (cached_texture != nullptr && (cached_texture->first == texture_entry(format, w, h, textures[i].mipmap())))

--- a/rpcs3/Emu/RSX/D3D12/D3D12Utils.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Utils.cpp
@@ -6,6 +6,7 @@
 #include <d3dcompiler.h>
 #include "D3D12GSRender.h"
 #include "d3dx12.h"
+#include "Utilities/Log.h"
 #define STRINGIFY(x) #x
 
 extern PFN_D3D12_SERIALIZE_ROOT_SIGNATURE wrapD3D12SerializeRootSignature;
@@ -265,6 +266,7 @@ void D3D12GSRender::initConvertShader()
 
 void unreachable_internal(const char *msg, const char *file, unsigned line)
 {
+	LOG_ERROR(RSX, "file %s line %d : %s", file, line, msg);
 	abort();
 	#ifdef LLVM_BUILTIN_UNREACHABLE
 		LLVM_BUILTIN_UNREACHABLE;

--- a/rpcs3/Emu/RSX/D3D12/D3D12Utils.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Utils.h
@@ -58,8 +58,8 @@ LLVM_ATTRIBUTE_NORETURN void unreachable_internal(const char *msg = nullptr, con
 #ifndef NDEBUG
 #define unreachable(msg) \
 	unreachable_internal(msg, __FILE__, __LINE__)
-#elif defined(LLVM_BUILTIN_UNREACHABLE)
-#define unreachable(msg) LLVM_BUILTIN_UNREACHABLE
+//#elif defined(LLVM_BUILTIN_UNREACHABLE)
+//#define unreachable(msg) LLVM_BUILTIN_UNREACHABLE
 #else
 #define unreachable(msg) unreachable_internal()
 #endif


### PR DESCRIPTION
This PR moves some code from D3D12GSRender.cpp to D3D12RenderTargets.cpp and do the usual cleaning there (a_b_c format, anonymous namespace...)