### PR TITLE
Disable cellSpursEventFlagWait is not implemented.

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellSpurs.cpp
@@ -2951,7 +2951,7 @@ s32 cellSpursEventFlagWait(PPUThread& ppu, vm::ptr<CellSpursEventFlag> eventFlag
 {
 	cellSpurs.Warning("cellSpursEventFlagWait(eventFlag=*0x%x, mask=*0x%x, mode=%d)", eventFlag, mask, mode);
 
-	return _spurs::event_flag_wait(ppu, eventFlag, mask, mode, 1);
+	return _spurs::event_flag_wait(ppu, eventFlag, mask, mode, 0);
 }
 
 /// Check SPURS event flag


### PR DESCRIPTION
This causes problem on a lot of games.
See here https://github.com/RPCS3/rpcs3/issues/1294, https://github.com/RPCS3/rpcs3/issues/1293
This is just waiting for this function is implemented.
It allows to works much more games.
The function is activated here, so it is disabled elsewhere and is not implemented, so the game was blocking it.