### PR TITLE
Fix crash on exit in some tests

### DIFF
--- a/rpcs3/Emu/Io/KeyboardHandler.h
+++ b/rpcs3/Emu/Io/KeyboardHandler.h
@@ -265,6 +265,7 @@ protected:
 public:
 	virtual void Init(const u32 max_connect)=0;
 	virtual void Close()=0;
+	virtual ~KeyboardHandlerBase() = default;
 
 	void Key(const u32 code, bool pressed)
 	{

--- a/rpcs3/Emu/Io/MouseHandler.h
+++ b/rpcs3/Emu/Io/MouseHandler.h
@@ -106,6 +106,7 @@ protected:
 public:
 	virtual void Init(const u32 max_connect)=0;
 	virtual void Close()=0;
+	virtual ~MouseHandlerBase() = default;
 
 	void Button(u8 button, bool pressed)
 	{


### PR DESCRIPTION
It started occurring recently though the problem seems to be old.
Only KeyboardHandlerBase is the fix, the MouseHandler one is to be safe.

Emu crashed on exit on https://github.com/RPCS3/rpcs3/blob/master/rpcs3/Emu/System.cpp#L472 in dice elf test