### PR TITLE
d3d12: Use a_b_c style for D3D12GSRender.h members

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -57,28 +57,28 @@ void D3D12GSRender::upload_vertex_attributes(const std::vector<std::pair<u32, u3
 		u32 element_size = type_size * info.size;
 
 		size_t buffer_size = element_size * vertex_count;
-		assert(m_vertexIndexData.can_alloc(buffer_size));
-		size_t heap_offset = m_vertexIndexData.alloc(buffer_size);
+		assert(m_vertex_index_data.can_alloc(buffer_size));
+		size_t heap_offset = m_vertex_index_data.alloc(buffer_size);
 
 		void *buffer;
-		ThrowIfFailed(m_vertexIndexData.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), (void**)&buffer));
+		ThrowIfFailed(m_vertex_index_data.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), (void**)&buffer));
 		void *mapped_buffer = (char*)buffer + heap_offset;
 		for (const auto &range : vertex_ranges)
 		{
 			write_vertex_array_data_to_buffer(mapped_buffer, range.first, range.second, index, info);
 			mapped_buffer = (char*)mapped_buffer + range.second * element_size;
 		}
-		m_vertexIndexData.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
+		m_vertex_index_data.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 
 		D3D12_VERTEX_BUFFER_VIEW vertex_buffer_view =
 		{
-			m_vertexIndexData.m_heap->GetGPUVirtualAddress() + heap_offset,
+			m_vertex_index_data.m_heap->GetGPUVirtualAddress() + heap_offset,
 			(UINT)buffer_size,
 			(UINT)element_size
 		};
 		m_vertex_buffer_views.push_back(vertex_buffer_view);
 
-		m_timers.m_bufferUploadSize += buffer_size;
+		m_timers.m_buffer_upload_size += buffer_size;
 
 		D3D12_INPUT_ELEMENT_DESC IAElement = {};
 		IAElement.SemanticName = "TEXCOORD";
@@ -107,17 +107,17 @@ void D3D12GSRender::upload_vertex_attributes(const std::vector<std::pair<u32, u3
 		u32 element_size = type_size * info.size;
 
 		size_t buffer_size = data.size();
-		assert(m_vertexIndexData.can_alloc(buffer_size));
-		size_t heap_offset = m_vertexIndexData.alloc(buffer_size);
+		assert(m_vertex_index_data.can_alloc(buffer_size));
+		size_t heap_offset = m_vertex_index_data.alloc(buffer_size);
 
 		void *buffer;
-		ThrowIfFailed(m_vertexIndexData.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), (void**)&buffer));
+		ThrowIfFailed(m_vertex_index_data.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), (void**)&buffer));
 		void *mapped_buffer = (char*)buffer + heap_offset;
 		memcpy(mapped_buffer, data.data(), data.size());
-		m_vertexIndexData.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
+		m_vertex_index_data.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 
 		D3D12_VERTEX_BUFFER_VIEW vertex_buffer_view = {
-			m_vertexIndexData.m_heap->GetGPUVirtualAddress() + heap_offset,
+			m_vertex_index_data.m_heap->GetGPUVirtualAddress() + heap_offset,
 			(UINT)buffer_size,
 			(UINT)element_size
 		};
@@ -137,88 +137,88 @@ void D3D12GSRender::upload_vertex_attributes(const std::vector<std::pair<u32, u3
 
 void D3D12GSRender::load_vertex_index_data(u32 first, u32 count)
 {
-	m_renderingInfo.m_indexed = true;
+	m_rendering_info.m_indexed = true;
 }
 
 void D3D12GSRender::upload_and_bind_scale_offset_matrix(size_t descriptorIndex)
 {
-	assert(m_constantsData.can_alloc(256));
-	size_t heap_offset = m_constantsData.alloc(256);
+	assert(m_constants_data.can_alloc(256));
+	size_t heap_offset = m_constants_data.alloc(256);
 
 	// Scale offset buffer
 	// Separate constant buffer
 	void *mapped_buffer;
-	ThrowIfFailed(m_constantsData.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + 256), &mapped_buffer));
+	ThrowIfFailed(m_constants_data.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + 256), &mapped_buffer));
 	fill_scale_offset_data((char*)mapped_buffer + heap_offset);
 	int is_alpha_tested = !!(rsx::method_registers[NV4097_SET_ALPHA_TEST_ENABLE]);
 	float alpha_ref = (float&)rsx::method_registers[NV4097_SET_ALPHA_REF];
 	memcpy((char*)mapped_buffer + heap_offset + 16 * sizeof(float), &is_alpha_tested, sizeof(int));
 	memcpy((char*)mapped_buffer + heap_offset + 17 * sizeof(float), &alpha_ref, sizeof(float));
-	m_constantsData.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + 256));
+	m_constants_data.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + 256));
 
 	D3D12_CONSTANT_BUFFER_VIEW_DESC constant_buffer_view_desc = {
-		m_constantsData.m_heap->GetGPUVirtualAddress() + heap_offset,
+		m_constants_data.m_heap->GetGPUVirtualAddress() + heap_offset,
 		256
 	};
 	m_device->CreateConstantBufferView(&constant_buffer_view_desc,
-		CD3DX12_CPU_DESCRIPTOR_HANDLE(getCurrentResourceStorage().descriptors_heap->GetCPUDescriptorHandleForHeapStart())
-		.Offset((INT)descriptorIndex, g_descriptorStrideSRVCBVUAV));
+		CD3DX12_CPU_DESCRIPTOR_HANDLE(get_current_resource_storage().descriptors_heap->GetCPUDescriptorHandleForHeapStart())
+		.Offset((INT)descriptorIndex, g_descriptor_stride_srv_cbv_uav));
 }
 
 void D3D12GSRender::upload_and_bind_vertex_shader_constants(size_t descriptor_index)
 {
 	size_t buffer_size = 512 * 4 * sizeof(float);
 
-	assert(m_constantsData.can_alloc(buffer_size));
-	size_t heap_offset = m_constantsData.alloc(buffer_size);
+	assert(m_constants_data.can_alloc(buffer_size));
+	size_t heap_offset = m_constants_data.alloc(buffer_size);
 
 	void *mapped_buffer;
-	ThrowIfFailed(m_constantsData.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), &mapped_buffer));
+	ThrowIfFailed(m_constants_data.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), &mapped_buffer));
 	fill_vertex_program_constants_data((char*)mapped_buffer + heap_offset);
-	m_constantsData.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
+	m_constants_data.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 
 	D3D12_CONSTANT_BUFFER_VIEW_DESC constant_buffer_view_desc = {
-		m_constantsData.m_heap->GetGPUVirtualAddress() + heap_offset,
+		m_constants_data.m_heap->GetGPUVirtualAddress() + heap_offset,
 		(UINT)buffer_size
 	};
 	m_device->CreateConstantBufferView(&constant_buffer_view_desc,
-		CD3DX12_CPU_DESCRIPTOR_HANDLE(getCurrentResourceStorage().descriptors_heap->GetCPUDescriptorHandleForHeapStart())
-		.Offset((INT)descriptor_index, g_descriptorStrideSRVCBVUAV));
+		CD3DX12_CPU_DESCRIPTOR_HANDLE(get_current_resource_storage().descriptors_heap->GetCPUDescriptorHandleForHeapStart())
+		.Offset((INT)descriptor_index, g_descriptor_stride_srv_cbv_uav));
 }
 
 void D3D12GSRender::upload_and_bind_fragment_shader_constants(size_t descriptor_index)
 {
 	// Get constant from fragment program
-	size_t buffer_size = m_cachePSO.get_fragment_constants_buffer_size(&fragment_program);
+	size_t buffer_size = m_pso_cache.get_fragment_constants_buffer_size(&fragment_program);
 	// Multiple of 256 never 0
 	buffer_size = (buffer_size + 255) & ~255;
 
-	assert(m_constantsData.can_alloc(buffer_size));
-	size_t heap_offset = m_constantsData.alloc(buffer_size);
+	assert(m_constants_data.can_alloc(buffer_size));
+	size_t heap_offset = m_constants_data.alloc(buffer_size);
 
 	size_t offset = 0;
 	void *mapped_buffer;
-	ThrowIfFailed(m_constantsData.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), &mapped_buffer));
-	m_cachePSO.fill_fragment_constans_buffer((char*)mapped_buffer + heap_offset, &fragment_program);
-	m_constantsData.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
+	ThrowIfFailed(m_constants_data.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), &mapped_buffer));
+	m_pso_cache.fill_fragment_constans_buffer((char*)mapped_buffer + heap_offset, &fragment_program);
+	m_constants_data.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 
 	D3D12_CONSTANT_BUFFER_VIEW_DESC constant_buffer_view_desc = {
-		m_constantsData.m_heap->GetGPUVirtualAddress() + heap_offset,
+		m_constants_data.m_heap->GetGPUVirtualAddress() + heap_offset,
 		(UINT)buffer_size
 	};
 	m_device->CreateConstantBufferView(&constant_buffer_view_desc,
-		CD3DX12_CPU_DESCRIPTOR_HANDLE(getCurrentResourceStorage().descriptors_heap->GetCPUDescriptorHandleForHeapStart())
-		.Offset((INT)descriptor_index, g_descriptorStrideSRVCBVUAV));
+		CD3DX12_CPU_DESCRIPTOR_HANDLE(get_current_resource_storage().descriptors_heap->GetCPUDescriptorHandleForHeapStart())
+		.Offset((INT)descriptor_index, g_descriptor_stride_srv_cbv_uav));
 }
 
 void D3D12GSRender::upload_and_set_vertex_index_data(ID3D12GraphicsCommandList *command_list)
 {
 	// Index count
-	m_renderingInfo.m_count = 0;
+	m_rendering_info.m_count = 0;
 	for (const auto &pair : m_first_count_pairs)
-		m_renderingInfo.m_count += get_index_count(draw_mode, pair.second);
+		m_rendering_info.m_count += get_index_count(draw_mode, pair.second);
 
-	if (!m_renderingInfo.m_indexed)
+	if (!m_rendering_info.m_indexed)
 	{
 		// Non indexed
 		upload_vertex_attributes(m_first_count_pairs);
@@ -228,12 +228,12 @@ void D3D12GSRender::upload_and_set_vertex_index_data(ID3D12GraphicsCommandList *
 		// Handle non native primitive
 
 		// Alloc
-		size_t buffer_size = align(m_renderingInfo.m_count * sizeof(u16), 64);
-		assert(m_vertexIndexData.can_alloc(buffer_size));
-		size_t heap_offset = m_vertexIndexData.alloc(buffer_size);
+		size_t buffer_size = align(m_rendering_info.m_count * sizeof(u16), 64);
+		assert(m_vertex_index_data.can_alloc(buffer_size));
+		size_t heap_offset = m_vertex_index_data.alloc(buffer_size);
 
 		void *buffer;
-		ThrowIfFailed(m_vertexIndexData.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), (void**)&buffer));
+		ThrowIfFailed(m_vertex_index_data.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), (void**)&buffer));
 		void *mapped_buffer = (char*)buffer + heap_offset;
 		size_t first = 0;
 		for (const auto &pair : m_first_count_pairs)
@@ -243,14 +243,14 @@ void D3D12GSRender::upload_and_set_vertex_index_data(ID3D12GraphicsCommandList *
 			mapped_buffer = (char*)mapped_buffer + element_count * sizeof(u16);
 			first += pair.second;
 		}
-		m_vertexIndexData.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
+		m_vertex_index_data.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 		D3D12_INDEX_BUFFER_VIEW index_buffer_view = {
-			m_vertexIndexData.m_heap->GetGPUVirtualAddress() + heap_offset,
+			m_vertex_index_data.m_heap->GetGPUVirtualAddress() + heap_offset,
 			(UINT)buffer_size,
 			DXGI_FORMAT_R16_UINT
 		};
 		command_list->IASetIndexBuffer(&index_buffer_view);
-		m_renderingInfo.m_indexed = true;
+		m_rendering_info.m_indexed = true;
 	}
 	else
 	{
@@ -260,12 +260,12 @@ void D3D12GSRender::upload_and_set_vertex_index_data(ID3D12GraphicsCommandList *
 		size_t index_size = get_index_type_size(indexed_type);
 
 		// Alloc
-		size_t buffer_size = align(m_renderingInfo.m_count * index_size, 64);
-		assert(m_vertexIndexData.can_alloc(buffer_size));
-		size_t heap_offset = m_vertexIndexData.alloc(buffer_size);
+		size_t buffer_size = align(m_rendering_info.m_count * index_size, 64);
+		assert(m_vertex_index_data.can_alloc(buffer_size));
+		size_t heap_offset = m_vertex_index_data.alloc(buffer_size);
 
 		void *buffer;
-		ThrowIfFailed(m_vertexIndexData.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), (void**)&buffer));
+		ThrowIfFailed(m_vertex_index_data.m_heap->Map(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size), (void**)&buffer));
 		void *mapped_buffer = (char*)buffer + heap_offset;
 		u32 min_index = (u32)-1, max_index = 0;
 		for (const auto &pair : m_first_count_pairs)
@@ -274,15 +274,15 @@ void D3D12GSRender::upload_and_set_vertex_index_data(ID3D12GraphicsCommandList *
 			write_index_array_data_to_buffer((char*)mapped_buffer, draw_mode, pair.first, pair.second, min_index, max_index);
 			mapped_buffer = (char*)mapped_buffer + element_count * index_size;
 		}
-		m_vertexIndexData.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
+		m_vertex_index_data.m_heap->Unmap(0, &CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 		D3D12_INDEX_BUFFER_VIEW index_buffer_view = {
-			m_vertexIndexData.m_heap->GetGPUVirtualAddress() + heap_offset,
+			m_vertex_index_data.m_heap->GetGPUVirtualAddress() + heap_offset,
 			(UINT)buffer_size,
 			get_index_type(indexed_type)
 		};
-		m_timers.m_bufferUploadSize += buffer_size;
+		m_timers.m_buffer_upload_size += buffer_size;
 		command_list->IASetIndexBuffer(&index_buffer_view);
-		m_renderingInfo.m_indexed = true;
+		m_rendering_info.m_indexed = true;
 
 		upload_vertex_attributes({ std::make_pair(0, max_index + 1) });
 		command_list->IASetVertexBuffers(0, (UINT)m_vertex_buffer_views.size(), m_vertex_buffer_views.data());

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -51,39 +51,36 @@ private:
 	/** D3D12 structures.
 	 * Note: they should be declared in reverse order of destruction
 	 */
-	D3D12DLLManagement m_D3D12Lib;
+	D3D12DLLManagement m_d3d12_lib;
 	ComPtr<ID3D12Device> m_device;
-	ComPtr<ID3D12CommandQueue> m_commandQueueGraphic;
-	ComPtr<struct IDXGISwapChain3> m_swapChain;
-	ComPtr<ID3D12Resource> m_backBuffer[2];
-	ComPtr<ID3D12DescriptorHeap> m_backbufferAsRendertarget[2];
+	ComPtr<ID3D12CommandQueue> m_command_queue;
+	ComPtr<struct IDXGISwapChain3> m_swap_chain;
+	ComPtr<ID3D12Resource> m_backbuffer[2];
+	ComPtr<ID3D12DescriptorHeap> m_backbuffer_descriptor_heap[2];
 	// m_rootSignatures[N] is RS with N texture/sample
-	ComPtr<ID3D12RootSignature> m_rootSignatures[17];
+	ComPtr<ID3D12RootSignature> m_root_signatures[17];
 
 	// TODO: Use a tree structure to parse more efficiently
-	data_cache m_textureCache;
-	bool invalidateAddress(u32 addr);
-
-	// Copy of RTT to be used as texture
-	std::unordered_map<u32, ID3D12Resource* > m_texturesRTTs;
+	data_cache m_texture_cache;
+	bool invalidate_address(u32 addr);
 
 	rsx::surface_info m_surface;
 
 	RSXFragmentProgram fragment_program;
-	PipelineStateObjectCache m_cachePSO;
-	std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t> *m_PSO;
+	PipelineStateObjectCache m_pso_cache;
+	std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t> *m_current_pso;
 
 	struct
 	{
-		size_t m_drawCallDuration;
-		size_t m_drawCallCount;
-		size_t m_rttDuration;
-		size_t m_vertexIndexDuration;
-		size_t m_bufferUploadSize;
-		size_t m_programLoadDuration;
-		size_t m_constantsDuration;
-		size_t m_textureDuration;
-		size_t m_flipDuration;
+		size_t m_draw_calls_duration;
+		size_t m_draw_calls_count;
+		size_t m_prepare_rtt_duration;
+		size_t m_vertex_index_duration;
+		size_t m_buffer_upload_size;
+		size_t m_program_load_duration;
+		size_t m_constants_duration;
+		size_t m_texture_duration;
+		size_t m_flip_duration;
 	} m_timers;
 
 	void reset_timer();
@@ -103,7 +100,7 @@ private:
 	 * Stores data related to the scaling pass that turns internal
 	 * render targets into presented buffers.
 	 */
-	Shader m_outputScalingPass;
+	Shader m_output_scaling_pass;
 
 	/**
 	 * Data used when depth buffer is converted to uchar textures.
@@ -112,37 +109,37 @@ private:
 	ID3D12RootSignature *m_convertRootSignature;
 	void initConvertShader();
 
-	resource_storage m_perFrameStorage[2];
-	resource_storage &getCurrentResourceStorage();
-	resource_storage &getNonCurrentResourceStorage();
+	resource_storage m_per_frame_storage[2];
+	resource_storage &get_current_resource_storage();
+	resource_storage &get_non_current_resource_storage();
 
 	// Constants storage
-	data_heap<ID3D12Resource, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT> m_constantsData;
+	data_heap<ID3D12Resource, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT> m_constants_data;
 	// Vertex storage
-	data_heap<ID3D12Resource, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT> m_vertexIndexData;
+	data_heap<ID3D12Resource, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT> m_vertex_index_data;
 	// Texture storage
-	data_heap<ID3D12Resource, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT> m_textureUploadData;
-	data_heap<ID3D12Heap, D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT> m_UAVHeap;
-	data_heap<ID3D12Heap, D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT> m_readbackResources;
+	data_heap<ID3D12Resource, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT> m_texture_upload_data;
+	data_heap<ID3D12Heap, D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT> m_uav_heap;
+	data_heap<ID3D12Heap, D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT> m_readback_resources;
 
 	struct
 	{
 		bool m_indexed; /*<! is draw call using an index buffer */
 		size_t m_count; /*<! draw call vertex count */
-	} m_renderingInfo;
+	} m_rendering_info;
 
 	render_targets m_rtts;
 
 	std::vector<D3D12_INPUT_ELEMENT_DESC> m_IASet;
 	std::vector<D3D12_VERTEX_BUFFER_VIEW> m_vertex_buffer_views;
 
-	INT g_descriptorStrideSRVCBVUAV;
-	INT g_descriptorStrideDSV;
-	INT g_descriptorStrideRTV;
-	INT g_descriptorStrideSamplers;
+	INT g_descriptor_stride_srv_cbv_uav;
+	INT g_descriptor_stride_dsv;
+	INT g_descriptor_stride_rtv;
+	INT g_descriptor_stride_samplers;
 
 	// Used to fill unused texture slot
-	ID3D12Resource *m_dummyTexture;
+	ID3D12Resource *m_dummy_texture;
 
 	// Store previous fbo addresses to detect RTT config changes.
 	u32 m_previous_address_a;

--- a/rpcs3/Emu/RSX/D3D12/D3D12Overlay.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Overlay.cpp
@@ -65,7 +65,7 @@ void D3D12GSRender::init_d2d_structures()
 		D3D11_CREATE_DEVICE_BGRA_SUPPORT,
 		nullptr,
 		0,
-		reinterpret_cast<IUnknown**>(m_commandQueueGraphic.GetAddressOf()),
+		reinterpret_cast<IUnknown**>(m_command_queue.GetAddressOf()),
 		1,
 		0,
 		&g_d3d11_device,
@@ -98,7 +98,7 @@ void D3D12GSRender::init_d2d_structures()
 	{
 		D3D11_RESOURCE_FLAGS d3d11Flags = { D3D11_BIND_RENDER_TARGET };
 		g_d3d11on12_device->CreateWrappedResource(
-			m_backBuffer[i].Get(),
+			m_backbuffer[i].Get(),
 			&d3d11Flags,
 			D3D12_RESOURCE_STATE_RENDER_TARGET,
 			D3D12_RESOURCE_STATE_PRESENT,
@@ -150,23 +150,23 @@ void D3D12GSRender::release_d2d_structures()
 
 void D3D12GSRender::render_overlay()
 {
-	D2D1_SIZE_F rtSize = g_d2d_render_targets[m_swapChain->GetCurrentBackBufferIndex()]->GetSize();
-	std::wstring duration = L"Draw duration : " + std::to_wstring(m_timers.m_drawCallDuration) + L" us";
-	float vtxIdxPercent = (float)m_timers.m_vertexIndexDuration / (float)m_timers.m_drawCallDuration;
-	std::wstring vertexIndexDuration = L"Vtx/Idx upload : " + std::to_wstring(m_timers.m_vertexIndexDuration) + L" us (" + std::to_wstring(100.f * vtxIdxPercent) + L" %)";
-	std::wstring size = L"Upload size : " + std::to_wstring(m_timers.m_bufferUploadSize) + L" Bytes";
-	float texPercent = (float)m_timers.m_textureDuration / (float)m_timers.m_drawCallDuration;
-	std::wstring texDuration = L"Textures : " + std::to_wstring(m_timers.m_textureDuration) + L" us (" + std::to_wstring(100.f * texPercent) + L" %)";
-	float programPercent = (float)m_timers.m_programLoadDuration / (float)m_timers.m_drawCallDuration;
-	std::wstring programDuration = L"Program : " + std::to_wstring(m_timers.m_programLoadDuration) + L" us (" + std::to_wstring(100.f * programPercent) + L" %)";
-	float constantsPercent = (float)m_timers.m_constantsDuration / (float)m_timers.m_drawCallDuration;
-	std::wstring constantDuration = L"Constants : " + std::to_wstring(m_timers.m_constantsDuration) + L" us (" + std::to_wstring(100.f * constantsPercent) + L" %)";
-	float rttPercent = (float)m_timers.m_rttDuration / (float)m_timers.m_drawCallDuration;
-	std::wstring rttDuration = L"RTT : " + std::to_wstring(m_timers.m_rttDuration) + L" us (" + std::to_wstring(100.f * rttPercent) + L" %)";
-	std::wstring flipDuration = L"Flip : " + std::to_wstring(m_timers.m_flipDuration) + L" us";
+	D2D1_SIZE_F rtSize = g_d2d_render_targets[m_swap_chain->GetCurrentBackBufferIndex()]->GetSize();
+	std::wstring duration = L"Draw duration : " + std::to_wstring(m_timers.m_draw_calls_duration) + L" us";
+	float vtxIdxPercent = (float)m_timers.m_vertex_index_duration / (float)m_timers.m_draw_calls_duration;
+	std::wstring vertexIndexDuration = L"Vtx/Idx upload : " + std::to_wstring(m_timers.m_vertex_index_duration) + L" us (" + std::to_wstring(100.f * vtxIdxPercent) + L" %)";
+	std::wstring size = L"Upload size : " + std::to_wstring(m_timers.m_buffer_upload_size) + L" Bytes";
+	float texPercent = (float)m_timers.m_texture_duration / (float)m_timers.m_draw_calls_duration;
+	std::wstring texDuration = L"Textures : " + std::to_wstring(m_timers.m_texture_duration) + L" us (" + std::to_wstring(100.f * texPercent) + L" %)";
+	float programPercent = (float)m_timers.m_program_load_duration / (float)m_timers.m_draw_calls_duration;
+	std::wstring programDuration = L"Program : " + std::to_wstring(m_timers.m_program_load_duration) + L" us (" + std::to_wstring(100.f * programPercent) + L" %)";
+	float constantsPercent = (float)m_timers.m_constants_duration / (float)m_timers.m_draw_calls_duration;
+	std::wstring constantDuration = L"Constants : " + std::to_wstring(m_timers.m_constants_duration) + L" us (" + std::to_wstring(100.f * constantsPercent) + L" %)";
+	float rttPercent = (float)m_timers.m_prepare_rtt_duration / (float)m_timers.m_draw_calls_duration;
+	std::wstring rttDuration = L"RTT : " + std::to_wstring(m_timers.m_prepare_rtt_duration) + L" us (" + std::to_wstring(100.f * rttPercent) + L" %)";
+	std::wstring flipDuration = L"Flip : " + std::to_wstring(m_timers.m_flip_duration) + L" us";
 
-	std::wstring count = L"Draw count : " + std::to_wstring(m_timers.m_drawCallCount);
-	draw_strings(rtSize, m_swapChain->GetCurrentBackBufferIndex(),
+	std::wstring count = L"Draw count : " + std::to_wstring(m_timers.m_draw_calls_count);
+	draw_strings(rtSize, m_swap_chain->GetCurrentBackBufferIndex(),
 		{
 			duration,
 			count,

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -241,7 +241,7 @@ bool D3D12GSRender::load_program()
 		prop.CutValue = ((rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4) == CELL_GCM_DRAW_INDEX_ARRAY_TYPE_32) ?
 			D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFFFFFF : D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFF;
 
-	m_PSO = m_cachePSO.getGraphicPipelineState(&vertex_program, &fragment_program, prop, std::make_pair(m_device.Get(), m_rootSignatures));
-	return m_PSO != nullptr;
+	m_current_pso = m_pso_cache.getGraphicPipelineState(&vertex_program, &fragment_program, prop, std::make_pair(m_device.Get(), m_root_signatures));
+	return m_current_pso != nullptr;
 }
 #endif


### PR DESCRIPTION
This PR fixes coding style in D3D12GSRender.h (which hold all member declarations). It should make the D3D12GSRender code follows the code conventions adopted in rpcs3 (maybe some bits are still left there and there).