### PR TITLE
NV3089 and misc fixes

### DIFF
--- a/rpcs3/Emu/SysCalls/Modules/cellUserInfo.cpp
+++ b/rpcs3/Emu/SysCalls/Modules/cellUserInfo.cpp
@@ -13,10 +13,16 @@ s32 cellUserInfoGetStat(u32 id, vm::ptr<CellUserInfoUserStat> stat)
 {
 	cellUserInfo.Warning("cellUserInfoGetStat(id=%d, stat=*0x%x)", id, stat);
 
-	if (id > CELL_USERINFO_USER_MAX)
+	if (id > CELL_SYSUTIL_USERID_MAX)
 		return CELL_USERINFO_ERROR_NOUSER;
 
-	char path [256];
+	if (id == CELL_SYSUTIL_USERID_CURRENT)
+	{
+		// TODO: Return current user/profile when that is implemented
+		id = 1;
+	}
+
+	char path[256];
 	sprintf(path, "/dev_hdd0/home/%08d", id);
 	if (!Emu.GetVFS().ExistsDir(path))
 		return CELL_USERINFO_ERROR_NOUSER;

--- a/rpcs3/Emu/SysCalls/Modules/cellUserInfo.h
+++ b/rpcs3/Emu/SysCalls/Modules/cellUserInfo.h
@@ -27,6 +27,12 @@ enum  CellUserInfoListType
 	CELL_USERINFO_LISTTYPE_NOCURRENT = 1,
 };
 
+enum
+{
+	CELL_SYSUTIL_USERID_CURRENT  = 0,
+	CELL_SYSUTIL_USERID_MAX      = 99999999,
+};
+
 // Structs
 struct CellUserInfoUserStat
 {

--- a/rpcs3/Emu/SysCalls/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/SysCalls/lv2/sys_mmapper.cpp
@@ -33,6 +33,14 @@ s32 sys_mmapper_allocate_address(u64 size, u64 flags, u64 alignment, vm::ptr<u32
 		return CELL_ENOMEM;
 	}
 
+	// This is a 'hack' / workaround for psl1ght, which gives us an alignment of 0, which is technically invalid, 
+	//  but apparently is allowed on actual ps3
+	//  https://github.com/ps3dev/PSL1GHT/blob/534e58950732c54dc6a553910b653c99ba6e9edc/ppu/librt/sbrk.c#L71 
+	if (!alignment && size == 0x10000000)
+	{
+		alignment = 0x10000000;
+	}
+
 	switch (alignment)
 	{
 	case 0x10000000:
@@ -317,7 +325,7 @@ s32 sys_mmapper_search_and_map(u32 start_addr, u32 mem_id, u64 flags, vm::ptr<u3
 
 	*alloc_addr = addr;
 
-	return CELL_ENOMEM;
+	return CELL_OK;
 }
 
 s32 sys_mmapper_unmap_memory(u32 addr, vm::ptr<u32> mem_id)


### PR DESCRIPTION
This mainly should fix the nv3089_image_in regressions brought in by my last PR, which were reported in #1334 (Braid crash) and #1335 (Jet Set Radio textures)

This also adds a workaround fix for booting of Psl1ght v2 homebrew elf's, and a small fix for cellUserInfoGetStat