### PR TITLE
By definition, malloc() is available in stdlib.h. malloc.h is deprecated.

### DIFF
--- a/Utilities/GNU.h
+++ b/Utilities/GNU.h
@@ -35,10 +35,6 @@
 #include <stdlib.h>
 #include <cstdint>
 
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
-
 #define _fpclass(x) std::fpclassify(x)
 #define INFINITE 0xFFFFFFFF
 


### PR DESCRIPTION
Even non‐Apple platforms make malloc() available from stdlib.h, because that’s what the C standard requires.