### PR TITLE
Include cstdarg for the definition of va_list.

### DIFF
--- a/rpcs3/stdafx.h
+++ b/rpcs3/stdafx.h
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <cassert>
 #include <cstdint>
+#include <cstdarg>
 #include <climits>
 #include <cmath>
 #include <atomic>


### PR DESCRIPTION
Without this include, on my platform rpcs3/Emu/ARMv7/Modules/sceFios.cpp complains that va_list is not a type.