### PR TITLE
D3d12: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12CommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12CommonDecompiler.cpp
@@ -45,9 +45,9 @@ std::string getFunctionImp(FUNCTION f)
 	case FUNCTION::FUNCTION_TEXTURE_SAMPLE:
 		return "$t.Sample($tsampler, $0.xy * $t_scale)";
 	case FUNCTION::FUNCTION_TEXTURE_SAMPLE_PROJ:
-		return "$t.Sample($tsampler, ($0.xy / $0.z) * $t_scale)";
+		return "$t.Sample($tsampler, ($0.xy / $0.w) * $t_scale)";
 	case FUNCTION::FUNCTION_TEXTURE_SAMPLE_LOD:
-		return "$t.SampleLevel($tsampler, ($0.xy / $0.z) * $t_scale, $1)";
+		return "$t.SampleLevel($tsampler, ($0.xy / $0.w) * $t_scale, $1)";
 	case FUNCTION::FUNCTION_TEXTURE_CUBE_SAMPLE:
 		return "$t.Sample($tsampler, $0.xyz)";
 	case FUNCTION::FUNCTION_TEXTURE_CUBE_SAMPLE_PROJ:

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -222,21 +222,21 @@ void D3D12FragmentDecompiler::insertMainEnd(std::stringstream & OS)
 		{ "ocol3", m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS ? "r4" : "h8" },
 	};
 
-	size_t num_output = 0;
+	std::string first_output_name;
 	OS << "	PixelOutput Out = (PixelOutput)0;" << std::endl;
 	for (int i = 0; i < sizeof(table) / sizeof(*table); ++i)
 	{
 		if (m_parr.HasParam(PF_PARAM_NONE, "float4", table[i].second))
 		{
 			OS << "	Out." << table[i].first << " = " << table[i].second << ";" << std::endl;
-			num_output++;
+			if (first_output_name.empty()) first_output_name = table[i].first;
 		}
 	}
 	if (m_ctrl & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT)
 		OS << "	Out.depth = " << ((m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) ? "r1.z;" : "h0.z;") << std::endl;
 	// Shaders don't always output colors (for instance if they write to depth only)
-	if (num_output > 0)
-		OS << "	if (isAlphaTested && Out.ocol0.a <= alphaRef) discard;" << std::endl;
+	if (!first_output_name.empty())
+		OS << "	if (isAlphaTested && Out." << first_output_name << ".a <= alphaRef) discard;\n";
 	OS << "	return Out;" << std::endl;
 	OS << "}" << std::endl;
 }

--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
@@ -257,9 +257,8 @@ void D3D12GSRender::prepare_render_targets(ID3D12GraphicsCommandList *copycmdlis
 void D3D12GSRender::set_rtt_and_ds(ID3D12GraphicsCommandList *command_list)
 {
 	UINT num_rtt = get_num_rtt(to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET]));
-	D3D12_CPU_DESCRIPTOR_HANDLE* rtt_handle = (num_rtt > 0) ? &m_rtts.current_rtts_handle : nullptr;
 	D3D12_CPU_DESCRIPTOR_HANDLE* ds_handle = (std::get<1>(m_rtts.m_bound_depth_stencil) != nullptr) ? &m_rtts.current_ds_handle : nullptr;
-	command_list->OMSetRenderTargets((UINT)num_rtt, rtt_handle, true, ds_handle);
+	command_list->OMSetRenderTargets((UINT)num_rtt, &m_rtts.current_rtts_handle, true, ds_handle);
 }
 
 void render_targets::init(ID3D12Device *device)

--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
@@ -246,7 +246,7 @@ void D3D12GSRender::prepare_render_targets(ID3D12GraphicsCommandList *copycmdlis
 	if (std::get<1>(m_rtts.m_bound_depth_stencil) == nullptr)
 		return;
 	m_rtts.current_ds_handle = CD3DX12_CPU_DESCRIPTOR_HANDLE(get_current_resource_storage().depth_stencil_descriptor_heap->GetCPUDescriptorHandleForHeapStart())
-		.Offset((INT)get_current_resource_storage().depth_stencil_descriptor_heap_index * g_descriptor_stride_rtv);
+		.Offset((INT)get_current_resource_storage().depth_stencil_descriptor_heap_index * g_descriptor_stride_dsv);
 	get_current_resource_storage().depth_stencil_descriptor_heap_index += 1;
 	D3D12_DEPTH_STENCIL_VIEW_DESC depth_stencil_view_desc = {};
 	depth_stencil_view_desc.Format = get_depth_stencil_surface_format(m_surface.depth_format);


### PR DESCRIPTION
Fixes textureProj which fixes shadow in Naruto 2 (and probably in other games too).
Fix nullptr indirection detected by VS static analysis and dsv increment size which made Intel driver crash.