### PR TITLE
rsx-debug/d3d12: Support all rtt formats.

### DIFF
--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -152,7 +152,7 @@ public:
 	const vertex_program_type& get_transform_program(const RSXVertexProgram& rsx_vp) const
 	{
 		auto I = m_vertex_shader_cache.find(rsx_vp.data);
-		if (I == m_vertex_shader_cache.end())
+		if (I != m_vertex_shader_cache.end())
 			return I->second;
 		throw new EXCEPTION("Trying to get unknow transform program");
 	}

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -200,8 +200,7 @@ protected:
 	virtual void end() override;
 	virtual void flip(int buffer) override;
 
-	virtual void copy_render_targets_to_memory(void *buffer, u8 rtt) override;
-	virtual void copy_depth_buffer_to_memory(void *buffer) override;
-	virtual void copy_stencil_buffer_to_memory(void *buffer) override;
+	virtual std::array<std::vector<gsl::byte>, 4> copy_render_targets_to_memory() override;
+	virtual std::array<std::vector<gsl::byte>, 2> copy_depth_stencil_buffer_to_memory() override;
 	virtual std::pair<std::string, std::string> get_programs() const override;
 };

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -15,19 +15,16 @@ extern u64 get_system_time();
 
 struct frame_capture_data
 {
-	struct buffer
-	{
-		std::vector<u8> data;
-		size_t width = 0, height = 0;
-	};
 
 	struct draw_state
 	{
 		std::string name;
 		std::pair<std::string, std::string> programs;
-		buffer color_buffer[4];
-		buffer depth;
-		buffer stencil;
+		size_t width = 0, height = 0;
+		Surface_color_format surface_color_format;
+		std::array<std::vector<gsl::byte>, 4> color_buffer;
+		Surface_depth_format surface_depth_format;
+		std::array<std::vector<gsl::byte>, 2> depth_stencil;
 	};
 	std::vector<std::pair<u32, u32> > command_queue;
 	std::vector<draw_state> draw_calls;
@@ -347,19 +344,17 @@ namespace rsx
 		 * Copy rtt values to buffer.
 		 * TODO: It's more efficient to combine multiple call of this function into one.
 		 */
-		virtual void copy_render_targets_to_memory(void *buffer, u8 rtt) {};
+		virtual std::array<std::vector<gsl::byte>, 4> copy_render_targets_to_memory() {
+			return  std::array<std::vector<gsl::byte>, 4>();
+		};
 
 		/**
-		* Copy depth content to buffer.
+		* Copy depth and stencil content to buffers.
 		* TODO: It's more efficient to combine multiple call of this function into one.
 		*/
-		virtual void copy_depth_buffer_to_memory(void *buffer) {};
-
-		/**
-		* Copy stencil content to buffer.
-		* TODO: It's more efficient to combine multiple call of this function into one.
-		*/
-		virtual void copy_stencil_buffer_to_memory(void *buffer) {};
+		virtual std::array<std::vector<gsl::byte>, 2> copy_depth_stencil_buffer_to_memory() {
+			return std::array<std::vector<gsl::byte>, 2>();
+		};
 
 		virtual std::pair<std::string, std::string> get_programs() const { return std::make_pair("", ""); };
 	public:

--- a/rpcs3/Gui/RSXDebugger.h
+++ b/rpcs3/Gui/RSXDebugger.h
@@ -29,6 +29,8 @@ class RSXDebugger : public wxDialog
 	wxPanel* p_buffer_tex;
 
 	wxImage buffer_img[4];
+	wxImage depth_img;
+	wxImage stencil_img;
 
 	wxTextCtrl* m_text_transform_program;
 	wxTextCtrl *m_text_shader_program;


### PR DESCRIPTION
This PR improves reliability of rtt/ds capture. It supports all format and put code in the to-be-shared template struct.
Not all format can be displayed by RSXDebugger though.