### PR TITLE
Rework OGL texture swizzles

### DIFF
--- a/rpcs3/Emu/RSX/GL/rsx_gl_texture.h
+++ b/rpcs3/Emu/RSX/GL/rsx_gl_texture.h
@@ -35,6 +35,20 @@ namespace rsx
 			}
 
 			void init(int index, rsx::texture& tex);
+			
+			/**
+			* If a format is marked as mandating expansion, any request to have the data uploaded to the GPU shall require that the pixel data
+			* be decoded/expanded fully, regardless of whether the input is swizzled. This is because some formats behave differently when swizzled pixel data
+			* is decoded and when data is fed directly, usually byte order is not the same. Forcing decoding/expanding fixes this but slows performance.
+			*/
+			static bool mandates_expansion(u32 format);
+			
+			/**
+			* The pitch modifier changes the pitch value supplied by the rsx::texture by supplying a suitable divisor or 0 if no change is needed.
+			* The modified value, if any, is then used to supply to GL the UNPACK_ROW_LENGTH for the texture data to be supplied.
+			*/
+			static u16  get_pitch_modifier(u32 format);
+			
 			void bind();
 			void unbind();
 			void remove();


### PR DESCRIPTION
Implements swizzling for some texture formats. Fixes rendering glitches when using OGL backend in some games e.g Terraria. Removes references to malloc and free and replaces mem allocation with std::vector.