### PR TITLE
D3d12: Drop IAInputLayout and use SV_VertexID + SRV instead

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -123,7 +123,7 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (ParamItem PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "Texture2D " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
+				OS << "Texture2D " << PI.name << " : register(t" << textureIndex + 16 << ");" << std::endl;
 				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
 			}
 		}
@@ -141,7 +141,7 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "TextureCube " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
+				OS << "TextureCube " << PI.name << " : register(t" << textureIndex + 16 << ");" << std::endl;
 				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
 			}
 		}

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -56,7 +56,7 @@ private:
 	ComPtr<ID3D12Resource> m_backbuffer[2];
 	ComPtr<ID3D12DescriptorHeap> m_backbuffer_descriptor_heap[2];
 	// m_rootSignatures[N] is RS with N texture/sample
-	ComPtr<ID3D12RootSignature> m_root_signatures[17];
+	ComPtr<ID3D12RootSignature> m_root_signatures[17][17]; // indexed by [texture count][vertex count]
 
 	// TODO: Use a tree structure to parse more efficiently
 	data_cache m_texture_cache;
@@ -67,7 +67,7 @@ private:
 	RSXVertexProgram m_vertex_program;
 	RSXFragmentProgram m_fragment_program;
 	PipelineStateObjectCache m_pso_cache;
-	std::tuple<ComPtr<ID3D12PipelineState>, std::vector<size_t>, size_t> m_current_pso;
+	std::tuple<ComPtr<ID3D12PipelineState>, size_t, size_t> m_current_pso;
 
 	struct
 	{
@@ -115,10 +115,9 @@ private:
 	// Textures, constants, index and vertex buffers storage
 	data_heap m_buffer_data;
 	data_heap m_readback_resources;
+	ComPtr<ID3D12Resource> m_vertex_buffer_data;
 
 	rsx::render_targets m_rtts;
-
-	std::vector<D3D12_INPUT_ELEMENT_DESC> m_ia_set;
 
 	INT m_descriptor_stride_srv_cbv_uav;
 	INT m_descriptor_stride_dsv;
@@ -145,16 +144,15 @@ private:
 	 * Non native primitive type are emulated by index buffers expansion.
 	 * Returns whether the draw call is indexed or not and the vertex count to draw.
 	*/
-	std::tuple<bool, size_t> upload_and_set_vertex_index_data(ID3D12GraphicsCommandList *command_list);
+	std::tuple<bool, size_t, std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC> > upload_and_set_vertex_index_data(ID3D12GraphicsCommandList *command_list);
 
 	/**
 	 * Upload all enabled vertex attributes for vertex in ranges described by vertex_ranges.
 	 * A range in vertex_range is a pair whose first element is the index of the beginning of the
 	 * range, and whose second element is the number of vertex in this range.
 	 */
-	std::vector<D3D12_VERTEX_BUFFER_VIEW> upload_vertex_attributes(const std::vector<std::pair<u32, u32> > &vertex_ranges);
-
-	std::tuple<D3D12_VERTEX_BUFFER_VIEW, size_t> upload_inlined_vertex_array();
+	std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC> upload_vertex_attributes(const std::vector<std::pair<u32, u32> > &vertex_ranges,
+		gsl::not_null<ID3D12GraphicsCommandList*> command_list);
 
 	std::tuple<D3D12_INDEX_BUFFER_VIEW, size_t> generate_index_buffer_for_emulated_primitives_array(const std::vector<std::pair<u32, u32> > &vertex_ranges);
 

--- a/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.cpp
@@ -4,10 +4,10 @@
 #include "D3D12MemoryHelpers.h"
 
 
-void data_cache::store_and_protect_data(u64 key, u32 start, size_t size, u8 format, size_t w, size_t h, size_t m, ComPtr<ID3D12Resource> data)
+void data_cache::store_and_protect_data(u64 key, u32 start, size_t size, u8 format, size_t w, size_t h, size_t d, size_t m, ComPtr<ID3D12Resource> data)
 {
 	std::lock_guard<std::mutex> lock(m_mut);
-	m_address_to_data[key] = std::make_pair(texture_entry(format, w, h, m), data);
+	m_address_to_data[key] = std::make_pair(texture_entry(format, w, h, d, m), data);
 	protect_data(key, start, size);
 }
 

--- a/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.cpp
@@ -106,7 +106,7 @@ void resource_storage::init(ID3D12Device *device)
 	CHECK_HRESULT(m_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, command_allocator.Get(), nullptr, IID_PPV_ARGS(command_list.GetAddressOf())));
 	CHECK_HRESULT(command_list->Close());
 
-	D3D12_DESCRIPTOR_HEAP_DESC descriptor_heap_desc = { D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 10000, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE };
+	D3D12_DESCRIPTOR_HEAP_DESC descriptor_heap_desc = { D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 50000, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE };
 	CHECK_HRESULT(device->CreateDescriptorHeap(&descriptor_heap_desc, IID_PPV_ARGS(&descriptors_heap)));
 
 	D3D12_DESCRIPTOR_HEAP_DESC sampler_heap_desc = { D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER , 2048, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE };

--- a/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.h
@@ -47,6 +47,11 @@ class data_heap
 	size_t m_put_pos; // Start of free space
 	ComPtr<ID3D12Resource> m_heap;
 public:
+	data_heap() = default;
+	~data_heap() = default;
+	data_heap(const data_heap&) = delete;
+	data_heap(data_heap&&) = delete;
+
 	size_t m_get_pos; // End of free space
 
 	template <typename... arg_type>
@@ -164,6 +169,11 @@ private:
 	std::unordered_map<u64, std::pair<texture_entry, ComPtr<ID3D12Resource>> > m_address_to_data; // Storage
 	std::list <std::tuple<u64, u32, u32> > m_protected_ranges; // address, start of protected range, size of protected range
 public:
+	data_cache() = default;
+	~data_cache() = default;
+	data_cache(const data_cache&) = delete;
+	data_cache(data_cache&&) = delete;
+
 	void store_and_protect_data(u64 key, u32 start, size_t size, u8 format, size_t w, size_t h, size_t d, size_t m, ComPtr<ID3D12Resource> data);
 
 	/**
@@ -195,6 +205,11 @@ public:
 */
 struct resource_storage
 {
+	resource_storage() = default;
+	~resource_storage() = default;
+	resource_storage(const resource_storage&) = delete;
+	resource_storage(resource_storage&&) = delete;
+
 	bool in_use; // False until command list has been populated at least once
 	ComPtr<ID3D12Fence> frame_finished_fence;
 	UINT64 fence_value;

--- a/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.h
@@ -134,16 +134,17 @@ struct texture_entry
 	size_t m_width;
 	size_t m_height;
 	size_t m_mipmap;
+	size_t m_depth;
 
-	texture_entry() : m_format(0), m_width(0), m_height(0), m_is_dirty(true)
+	texture_entry() : m_format(0), m_width(0), m_height(0), m_depth(0), m_is_dirty(true)
 	{}
 
-	texture_entry(u8 f, size_t w, size_t h, size_t m) : m_format(f), m_width(w), m_height(h), m_is_dirty(false)
+	texture_entry(u8 f, size_t w, size_t h, size_t d, size_t m) : m_format(f), m_width(w), m_height(h), m_depth(d), m_is_dirty(false), m_mipmap(m)
 	{}
 
 	bool operator==(const texture_entry &other)
 	{
-		return (m_format == other.m_format && m_width == other.m_width && m_height == other.m_height);
+		return (m_format == other.m_format && m_width == other.m_width && m_height == other.m_height && m_mipmap == other.m_mipmap && m_depth == other.m_depth);
 	}
 };
 
@@ -163,7 +164,7 @@ private:
 	std::unordered_map<u64, std::pair<texture_entry, ComPtr<ID3D12Resource>> > m_address_to_data; // Storage
 	std::list <std::tuple<u64, u32, u32> > m_protected_ranges; // address, start of protected range, size of protected range
 public:
-	void store_and_protect_data(u64 key, u32 start, size_t size, u8 format, size_t w, size_t h, size_t m, ComPtr<ID3D12Resource> data);
+	void store_and_protect_data(u64 key, u32 start, size_t size, u8 format, size_t w, size_t h, size_t d, size_t m, ComPtr<ID3D12Resource> data);
 
 	/**
 	* Make memory from start to start + size write protected.

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -241,7 +241,6 @@ void D3D12GSRender::load_program()
 	for (unsigned i = 0; i < prop.numMRT; i++)
 		prop.Blend.RenderTarget[i].RenderTargetWriteMask = mask;
 
-	prop.IASet = m_ia_set;
 	if (!!rsx::method_registers[NV4097_SET_RESTART_INDEX_ENABLE])
 	{
 		rsx::index_array_type index_type = rsx::to_index_array_type(rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.h
@@ -10,7 +10,6 @@ struct D3D12PipelineProperties
 	D3D12_PRIMITIVE_TOPOLOGY_TYPE Topology;
 	DXGI_FORMAT DepthStencilFormat;
 	DXGI_FORMAT RenderTargetsFormat;
-	std::vector<D3D12_INPUT_ELEMENT_DESC> IASet;
 	D3D12_BLEND_DESC Blend;
 	unsigned numMRT : 3;
 	D3D12_DEPTH_STENCIL_DESC DepthStencil;
@@ -19,23 +18,6 @@ struct D3D12PipelineProperties
 
 	bool operator==(const D3D12PipelineProperties &in) const
 	{
-		if (IASet.size() != in.IASet.size())
-			return false;
-		for (unsigned i = 0; i < IASet.size(); i++)
-		{
-			const D3D12_INPUT_ELEMENT_DESC &a = IASet[i], &b = in.IASet[i];
-			if (a.AlignedByteOffset != b.AlignedByteOffset)
-				return false;
-			if (a.Format != b.Format)
-				return false;
-			if (a.InputSlot != b.InputSlot)
-				return false;
-			if (a.InstanceDataStepRate != b.InstanceDataStepRate)
-				return false;
-			if (a.SemanticIndex != b.SemanticIndex)
-				return false;
-		}
-
 		if (memcmp(&DepthStencil, &in.DepthStencil, sizeof(D3D12_DEPTH_STENCIL_DESC)))
 			return false;
 		if (memcmp(&Blend, &in.Blend, sizeof(D3D12_BLEND_DESC)))
@@ -93,7 +75,7 @@ public:
 	ComPtr<ID3DBlob> bytecode;
 	// For debugging
 	std::string content;
-	std::vector<size_t> vertex_shader_inputs;
+	size_t vertex_shader_input_count;
 	std::vector<size_t> FragmentConstantOffsetCache;
 	size_t m_textureCount;
 
@@ -118,29 +100,11 @@ bool has_attribute(size_t attribute, const std::vector<D3D12_INPUT_ELEMENT_DESC>
 	return false;
 }
 
-static
-std::vector<D3D12_INPUT_ELEMENT_DESC> completes_IA_desc(const std::vector<D3D12_INPUT_ELEMENT_DESC> &desc, const std::vector<size_t> &inputs)
-{
-	std::vector<D3D12_INPUT_ELEMENT_DESC> result(desc);
-	for (size_t attribute : inputs)
-	{
-		if (has_attribute(attribute, desc))
-			continue;
-		D3D12_INPUT_ELEMENT_DESC extra_ia_desc = {};
-		extra_ia_desc.SemanticIndex = (UINT)attribute;
-		extra_ia_desc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
-		extra_ia_desc.SemanticName = "TEXCOORD";
-		extra_ia_desc.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
-		result.push_back(extra_ia_desc);
-	}
-	return result;
-}
-
 struct D3D12Traits
 {
 	using vertex_program_type = Shader;
 	using fragment_program_type  = Shader;
-	using pipeline_storage_type = std::tuple<ComPtr<ID3D12PipelineState>, std::vector<size_t>, size_t>;
+	using pipeline_storage_type = std::tuple<ComPtr<ID3D12PipelineState>, size_t, size_t>;
 	using pipeline_properties  = D3D12PipelineProperties;
 
 	static
@@ -176,15 +140,15 @@ struct D3D12Traits
 		D3D12VertexProgramDecompiler VS(RSXVP);
 		std::string shaderCode = VS.Decompile();
 		vertexProgramData.Compile(shaderCode, Shader::SHADER_TYPE::SHADER_TYPE_VERTEX);
-		vertexProgramData.vertex_shader_inputs = VS.input_slots;
+		vertexProgramData.vertex_shader_input_count = RSXVP.rsx_vertex_inputs.size();
 		fs::file(fs::get_config_dir() + "VertexProgram" + std::to_string(ID) + ".hlsl", fom::rewrite).write(shaderCode);
 		vertexProgramData.id = (u32)ID;
 	}
 
 	static
-		pipeline_storage_type build_pipeline(
-			const vertex_program_type &vertexProgramData, const fragment_program_type &fragmentProgramData, const pipeline_properties &pipelineProperties,
-			ID3D12Device *device, gsl::span<ComPtr<ID3D12RootSignature>, 17> root_signatures)
+	pipeline_storage_type build_pipeline(
+		const vertex_program_type &vertexProgramData, const fragment_program_type &fragmentProgramData, const pipeline_properties &pipelineProperties,
+		ID3D12Device *device, gsl::span<ComPtr<ID3D12RootSignature>, 17, 17> root_signatures)
 	{
 		std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t> result = {};
 		D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicPipelineStateDesc = {};
@@ -199,7 +163,7 @@ struct D3D12Traits
 		graphicPipelineStateDesc.PS.BytecodeLength = fragmentProgramData.bytecode->GetBufferSize();
 		graphicPipelineStateDesc.PS.pShaderBytecode = fragmentProgramData.bytecode->GetBufferPointer();
 
-		graphicPipelineStateDesc.pRootSignature = root_signatures[fragmentProgramData.m_textureCount].Get();
+		graphicPipelineStateDesc.pRootSignature = root_signatures[fragmentProgramData.m_textureCount][vertexProgramData.vertex_shader_input_count].Get();
 
 		graphicPipelineStateDesc.BlendState = pipelineProperties.Blend;
 		graphicPipelineStateDesc.DepthStencilState = pipelineProperties.DepthStencil;
@@ -211,10 +175,6 @@ struct D3D12Traits
 			graphicPipelineStateDesc.RTVFormats[i] = pipelineProperties.RenderTargetsFormat;
 		graphicPipelineStateDesc.DSVFormat = pipelineProperties.DepthStencilFormat;
 
-		const std::vector<D3D12_INPUT_ELEMENT_DESC> &completed_IA_desc = completes_IA_desc(pipelineProperties.IASet, vertexProgramData.vertex_shader_inputs);
-
-		graphicPipelineStateDesc.InputLayout.pInputElementDescs = completed_IA_desc.data();
-		graphicPipelineStateDesc.InputLayout.NumElements = (UINT)completed_IA_desc.size();
 		graphicPipelineStateDesc.SampleDesc.Count = 1;
 		graphicPipelineStateDesc.SampleMask = UINT_MAX;
 		graphicPipelineStateDesc.NodeMask = 1;
@@ -226,7 +186,7 @@ struct D3D12Traits
 
 		std::wstring name = L"PSO_" + std::to_wstring(vertexProgramData.id) + L"_" + std::to_wstring(fragmentProgramData.id);
 		pso->SetName(name.c_str());
-		return std::make_tuple(pso, vertexProgramData.vertex_shader_inputs, fragmentProgramData.m_textureCount);
+		return std::make_tuple(pso, vertexProgramData.vertex_shader_input_count, fragmentProgramData.m_textureCount);
 	}
 };
 

--- a/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
@@ -193,7 +193,7 @@ void D3D12GSRender::upload_and_bind_textures(ID3D12GraphicsCommandList *command_
 		{
 			is_depth_stencil_texture = true;
 		}
-		else if (cached_texture != nullptr && (cached_texture->first == texture_entry(format, w, h, textures[i].mipmap())))
+		else if (cached_texture != nullptr && (cached_texture->first == texture_entry(format, w, h, textures[i].depth(), textures[i].mipmap())))
 		{
 			if (cached_texture->first.m_is_dirty)
 			{
@@ -210,7 +210,7 @@ void D3D12GSRender::upload_and_bind_textures(ID3D12GraphicsCommandList *command_
 			std::wstring name = L"texture_@" + std::to_wstring(texaddr);
 			tex->SetName(name.c_str());
 			vram_texture = tex.Get();
-			m_texture_cache.store_and_protect_data(texaddr, texaddr, get_texture_size(textures[i]), format, w, h, textures[i].mipmap(), tex);
+			m_texture_cache.store_and_protect_data(texaddr, texaddr, get_texture_size(textures[i]), format, w, h, textures[i].depth(), textures[i].mipmap(), tex);
 		}
 
 		D3D12_SHADER_RESOURCE_VIEW_DESC shared_resource_view_desc = {};

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.h
@@ -18,7 +18,8 @@ protected:
 	virtual void insertOutputs(std::stringstream &OS, const std::vector<ParamType> &outputs);
 	virtual void insertMainStart(std::stringstream &OS);
 	virtual void insertMainEnd(std::stringstream &OS);
+
+	const RSXVertexProgram &rsx_vertex_program;
 public:
-	std::vector<size_t> input_slots;
 	D3D12VertexProgramDecompiler(const RSXVertexProgram &prog);
 };


### PR DESCRIPTION
This PR uses IAInputLayout mechanism (GL's equivalent is VAO) and use vertex ID + texture1d holding vertex data in vertex shader instead.

This allows to support RSX instancing implementation which relies on vertex id arithmetic operation which is more flexible that GL/D3D instancing method.
This shouldn't bring any performance penalty however since under the hood modern GPU already load vertex data in vertex program this way.

Resogun menu is properly displayed with this PR.