### PR TITLE
rsx/common: Make RSXFragmentProgram key and not just pointer.

### DIFF
--- a/rpcs3/Emu/RSX/CgBinaryProgram.h
+++ b/rpcs3/Emu/RSX/CgBinaryProgram.h
@@ -335,7 +335,7 @@ public:
 				u32 ctrl = (vmfprog.outputFromH0 ? 0 : 0x40) | (vmfprog.depthReplace ? 0xe : 0);
 				std::vector<texture_dimension> td;
 				RSXFragmentProgram prog;
-				prog.size = 0, prog.addr = ptr + vmprog.ucode, prog.offset = 0, prog.ctrl = ctrl;
+				prog.size = 0, prog.addr = vm::base(ptr + vmprog.ucode), prog.offset = 0, prog.ctrl = ctrl;
 				GLFragmentDecompilerThread(m_glsl_shader, param_array, prog, size).Task();
 				vm::close();
 			}

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -113,7 +113,7 @@ std::string FragmentProgramDecompiler::AddConst()
 		return name;
 	}
 
-	auto data = vm::ps3::ptr<u32>::make(m_prog.addr + m_size + 4 * SIZE_32(u32));
+	auto data = (be_t<u32>*) ((char*)m_prog.addr + m_size + 4 * SIZE_32(u32));
 
 	m_offset = 2 * 4 * sizeof(u32);
 	u32 x = GetData(data[0]);
@@ -493,7 +493,7 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 
 std::string FragmentProgramDecompiler::Decompile()
 {
-	auto data = vm::ps3::ptr<u32>::make(m_prog.addr);
+	auto data = (be_t<u32>*) m_prog.addr;
 	m_size = 0;
 	m_location = 0;
 	m_loop_count = 0;

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
@@ -26,7 +26,6 @@ class FragmentProgramDecompiler
 
 	std::string main;
 	u32& m_size;
-	const RSXFragmentProgram &m_prog;
 	u32 m_const_index;
 	u32 m_offset;
 	u32 m_location;
@@ -75,6 +74,7 @@ class FragmentProgramDecompiler
 	*/
 	bool handle_tex_srb(u32 opcode);
 protected:
+	const RSXFragmentProgram &m_prog;
 	u32 m_ctrl;
 	/** returns the type name of float vectors.
 	 */

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -74,11 +74,11 @@ size_t fragment_program_utils::get_fragment_program_ucode_size(void *ptr)
 	}
 }
 
-size_t fragment_program_hash::operator()(const void *program) const
+size_t fragment_program_hash::operator()(const RSXFragmentProgram& program) const
 {
 	// 64-bit Fowler/Noll/Vo FNV-1a hash code
 	size_t hash = 0xCBF29CE484222325ULL;
-	const qword *instbuffer = (const qword*)program;
+	const qword *instbuffer = (const qword*)program.addr;
 	size_t instIndex = 0;
 	while (true)
 	{
@@ -101,10 +101,13 @@ size_t fragment_program_hash::operator()(const void *program) const
 	return 0;
 }
 
-bool fragment_program_compare::operator()(const void *binary1, const void *binary2) const
+bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, const RSXFragmentProgram& binary2) const
 {
-	const qword *instBuffer1 = (const qword*)binary1;
-	const qword *instBuffer2 = (const qword*)binary2;
+	if (binary1.texture_dimensions != binary2.texture_dimensions || binary1.unnormalized_coords != binary2.unnormalized_coords ||
+		binary1.height != binary2.height || binary1.origin_mode != binary2.origin_mode || binary1.pixel_center_mode != binary2.pixel_center_mode)
+		return false;
+	const qword *instBuffer1 = (const qword*)binary1.addr;
+	const qword *instBuffer2 = (const qword*)binary2.addr;
 	size_t instIndex = 0;
 	while (true)
 	{

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -42,7 +42,7 @@ void D3D12GSRender::load_program()
 
 	u32 shader_program = rsx::method_registers[NV4097_SET_SHADER_PROGRAM];
 	m_fragment_program.offset = shader_program & ~0x3;
-	m_fragment_program.addr = rsx::get_address(m_fragment_program.offset, (shader_program & 0x3) - 1);
+	m_fragment_program.addr = vm::base(rsx::get_address(m_fragment_program.offset, (shader_program & 0x3) - 1));
 	m_fragment_program.ctrl = rsx::method_registers[NV4097_SET_SHADER_CONTROL];
 
 	std::array<texture_dimension, 16> texture_dimensions;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -741,7 +741,7 @@ bool GLGSRender::load_program()
 	RSXFragmentProgram fragment_program;
 	u32 shader_program = rsx::method_registers[NV4097_SET_SHADER_PROGRAM];
 	fragment_program.offset = shader_program & ~0x3;
-	fragment_program.addr = rsx::get_address(fragment_program.offset, (shader_program & 0x3) - 1);
+	fragment_program.addr = vm::base(rsx::get_address(fragment_program.offset, (shader_program & 0x3) - 1));
 	fragment_program.ctrl = rsx::method_registers[NV4097_SET_SHADER_CONTROL];
 
 	std::array<texture_dimension, 16> texture_dimensions;

--- a/rpcs3/Emu/RSX/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/RSXFragmentProgram.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "GCM.h"
 
 enum
 {
@@ -214,11 +215,14 @@ enum class texture_dimension : u8
 struct RSXFragmentProgram
 {
 	u32 size;
-	u32 addr;
+	void *addr;
 	u32 offset;
 	u32 ctrl;
 	u16 unnormalized_coords;
 	u32 texture_dimensions;
+	rsx::window_origin origin_mode;
+	rsx::window_pixel_center pixel_center_mode;
+	u16 height;
 
 	texture_dimension get_texture_dimension(u8 id) const
 	{


### PR DESCRIPTION
Currently RSXFragmentProgram hash/equality is based only on the fragment microcode. This means that ProgramStateCache ignores input changes. It mostly works since inputs (ie varying and texture) doesn't change that often but it's safer to check. Moreover the FragmentDecompiler can more safely rely on non microcode data like texture dimension or normalisation without relying on fits-them-all dynamic branched solution.