### PR TITLE
D3d12: Fix and improvement

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -212,22 +212,6 @@ void D3D12GSRender::upload_and_bind_scale_offset_matrix(size_t descriptorIndex)
 	float alpha_ref = (float&)rsx::method_registers[NV4097_SET_ALPHA_REF];
 	memcpy((char*)mapped_buffer + 16 * sizeof(float), &is_alpha_tested, sizeof(int));
 	memcpy((char*)mapped_buffer + 17 * sizeof(float), &alpha_ref, sizeof(float));
-
-	size_t tex_idx = 0;
-	for (u32 i = 0; i < rsx::limits::textures_count; ++i)
-	{
-		if (!textures[i].enabled())
-		{
-			int is_unorm = false;
-			memcpy((char*)mapped_buffer + (18 + tex_idx++) * sizeof(int), &is_unorm, sizeof(int));
-			continue;
-		}
-		size_t w = textures[i].width(), h = textures[i].height();
-//		if (!w || !h) continue;
-
-		int is_unorm = (textures[i].format() & CELL_GCM_TEXTURE_UN);
-		memcpy((char*)mapped_buffer + (18 + tex_idx++) * sizeof(int), &is_unorm, sizeof(int));
-	}
 	m_buffer_data.unmap(CD3DX12_RANGE(heap_offset, heap_offset + 256));
 
 	D3D12_CONSTANT_BUFFER_VIEW_DESC constant_buffer_view_desc = {

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -39,22 +39,6 @@ void D3D12FragmentDecompiler::insertHeader(std::stringstream & OS)
 	OS << "	float4x4 scaleOffsetMat;" << std::endl;
 	OS << "	int isAlphaTested;" << std::endl;
 	OS << "	float alphaRef;" << std::endl;
-	OS << "	int tex0_is_unorm;" << std::endl;
-	OS << "	int tex1_is_unorm;" << std::endl;
-	OS << "	int tex2_is_unorm;" << std::endl;
-	OS << "	int tex3_is_unorm;" << std::endl;
-	OS << "	int tex4_is_unorm;" << std::endl;
-	OS << "	int tex5_is_unorm;" << std::endl;
-	OS << "	int tex6_is_unorm;" << std::endl;
-	OS << "	int tex7_is_unorm;" << std::endl;
-	OS << "	int tex8_is_unorm;" << std::endl;
-	OS << "	int tex9_is_unorm;" << std::endl;
-	OS << "	int tex10_is_unorm;" << std::endl;
-	OS << "	int tex11_is_unorm;" << std::endl;
-	OS << "	int tex12_is_unorm;" << std::endl;
-	OS << "	int tex13_is_unorm;" << std::endl;
-	OS << "	int tex14_is_unorm;" << std::endl;
-	OS << "	int tex15_is_unorm;" << std::endl;
 	OS << "};" << std::endl;
 }
 
@@ -209,9 +193,15 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 		for (const ParamItem& PI : PT.items)
 		{
 			size_t textureIndex = atoi(PI.name.data() + 3);
+			bool is_unorm = !!(m_prog.unnormalized_coords & (1 << textureIndex));
+			if (!is_unorm)
+			{
+				OS << "	float2  " << PI.name << "_scale = float2(1., 1.);" << std::endl;
+				continue;
+			}
 			OS << "	float2  " << PI.name << "_dim;" << std::endl;
 			OS << "	" << PI.name << ".GetDimensions(" << PI.name << "_dim.x, " << PI.name << "_dim.y);" << std::endl;
-			OS << "	float2  " << PI.name << "_scale = (!!" << PI.name << "_is_unorm) ? float2(1., 1.) / " << PI.name << "_dim : float2(1., 1.);" << std::endl;
+			OS << "	float2  " << PI.name << "_scale = float2(1., 1.) / " << PI.name << "_dim;" << std::endl;
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -191,6 +191,8 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 	}
 	// A bit unclean, but works.
 	OS << "	" << "float4 gl_Position = In.Position;" << std::endl;
+	if (m_prog.origin_mode == rsx::window_origin::bottom)
+		OS << "	gl_Position.y = (" << std::to_string(m_prog.height) << " - gl_Position.y);\n";
 	// Declare output
 	for (const ParamType &PT : m_parr.params[PF_PARAM_NONE])
 	{

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
@@ -33,22 +33,6 @@ void D3D12VertexProgramDecompiler::insertHeader(std::stringstream &OS)
 	OS << "	float4x4 scaleOffsetMat;" << std::endl;
 	OS << "	int isAlphaTested;" << std::endl;
 	OS << "	float alphaRef;" << std::endl;
-	OS << "	int tex0_is_unorm;" << std::endl;
-	OS << "	int tex1_is_unorm;" << std::endl;
-	OS << "	int tex2_is_unorm;" << std::endl;
-	OS << "	int tex3_is_unorm;" << std::endl;
-	OS << "	int tex4_is_unorm;" << std::endl;
-	OS << "	int tex5_is_unorm;" << std::endl;
-	OS << "	int tex6_is_unorm;" << std::endl;
-	OS << "	int tex7_is_unorm;" << std::endl;
-	OS << "	int tex8_is_unorm;" << std::endl;
-	OS << "	int tex9_is_unorm;" << std::endl;
-	OS << "	int tex10_is_unorm;" << std::endl;
-	OS << "	int tex11_is_unorm;" << std::endl;
-	OS << "	int tex12_is_unorm;" << std::endl;
-	OS << "	int tex13_is_unorm;" << std::endl;
-	OS << "	int tex14_is_unorm;" << std::endl;
-	OS << "	int tex15_is_unorm;" << std::endl;
 	OS << "};" << std::endl;
 }
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -665,6 +665,10 @@ namespace rsx
 		result.addr = vm::base(rsx::get_address(result.offset, (shader_program & 0x3) - 1));
 		result.ctrl = rsx::method_registers[NV4097_SET_SHADER_CONTROL];
 		result.unnormalized_coords = 0;
+		u32 shader_window = rsx::method_registers[NV4097_SET_SHADER_WINDOW];
+		result.origin_mode = rsx::to_window_origin((shader_window >> 12) & 0xF);
+		result.pixel_center_mode = rsx::to_window_pixel_center((shader_window >> 16) & 0xF);
+		result.height = shader_window & 0xFFF;
 
 		std::array<texture_dimension, 16> texture_dimensions;
 		for (u32 i = 0; i < rsx::limits::textures_count; ++i)


### PR DESCRIPTION
This PR brings support for the shader window setting : now the "gl_Position" value will have correct vertical origin in d3d12 fragment shader. It fixes After Burner Climax heat effect but probably a lot more apps will benefit from the commit too.

The PR also uses "static" value in fragment shader for normalisation parameter, ie the backend won't fill a bool constant buffer to signal whether a sampler should read coordinate as texel value (instead of values between 0 and 1).