### PR TITLE
Fragment position is given as gl_FragCoord not gl_Position

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -274,7 +274,7 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 	{
 		static const std::string reg_table[] =
 		{
-			"gl_Position",
+			"gl_FragCoord",
 			"diff_color", "spec_color",
 			"fogc",
 			"tc0", "tc1", "tc2", "tc3", "tc4", "tc5", "tc6", "tc7", "tc8", "tc9",

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -173,9 +173,9 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 		}
 	}
 	// A bit unclean, but works.
-	OS << "	" << "float4 gl_Position = In.Position;" << std::endl;
+	OS << "	" << "float4 gl_FragCoord = In.Position;" << std::endl;
 	if (m_prog.origin_mode == rsx::window_origin::bottom)
-		OS << "	gl_Position.y = (" << std::to_string(m_prog.height) << " - gl_Position.y);\n";
+		OS << "	gl_FragCoord.y = (" << std::to_string(m_prog.height) << " - gl_FragCoord.y);\n";
 	// Declare output
 	for (const ParamType &PT : m_parr.params[PF_PARAM_NONE])
 	{


### PR DESCRIPTION
References to gl_Position in fragment shaders is illegal. Use gl_FragCoord instead.