### PR TITLE
rsx/common/d3d12/gl: Use gsl::span in TextureUtils.cpp

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -8,7 +8,7 @@ struct MipmapLevelInfo
 	u16 width;
 	u16 height;
 	u16 depth;
-	u16 rowPitch;
+	u32 rowPitch;
 };
 
 /**
@@ -22,7 +22,7 @@ size_t get_placed_texture_storage_size(const rsx::texture &texture, size_t rowPi
 * Data are not packed, they are stored per rows using rowPitchAlignement.
 * Similarly, offset for every mipmaplevel is aligned to rowPitchAlignement boundary.
 */
-std::vector<MipmapLevelInfo> upload_placed_texture(const rsx::texture &texture, size_t rowPitchAlignement, void* textureData);
+std::vector<MipmapLevelInfo> upload_placed_texture(gsl::span<gsl::byte> mapped_buffer, const rsx::texture &texture, size_t rowPitchAlignement);
 
 /**
 * Get number of bytes occupied by texture in RSX mem

--- a/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
@@ -79,8 +79,9 @@ ComPtr<ID3D12Resource> upload_single_texture(
 	size_t buffer_size = get_placed_texture_storage_size(texture, 256);
 	size_t heap_offset = texture_buffer_heap.alloc<D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT>(buffer_size);
 
-	void *mapped_buffer = texture_buffer_heap.map<void>(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
-	std::vector<MipmapLevelInfo> mipInfos = upload_placed_texture(texture, 256, mapped_buffer);
+	void *mapped_buffer_ptr = texture_buffer_heap.map<void>(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
+	gsl::span<gsl::byte> mapped_buffer{ (gsl::byte*)mapped_buffer_ptr, gsl::narrow<int>(buffer_size) };
+	std::vector<MipmapLevelInfo> mipInfos = upload_placed_texture(mapped_buffer, texture, 256);
 	texture_buffer_heap.unmap(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 
 	ComPtr<ID3D12Resource> result;
@@ -124,8 +125,9 @@ void update_existing_texture(
 	size_t buffer_size = get_placed_texture_storage_size(texture, 256);
 	size_t heap_offset = texture_buffer_heap.alloc<D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT>(buffer_size);
 
-	void *mapped_buffer = texture_buffer_heap.map<void>(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
-	std::vector<MipmapLevelInfo> mipInfos = upload_placed_texture(texture, 256, mapped_buffer);
+	void *mapped_buffer_ptr = texture_buffer_heap.map<void>(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
+	gsl::span<gsl::byte> mapped_buffer{ (gsl::byte*)mapped_buffer_ptr, gsl::narrow<int>(buffer_size) };
+	std::vector<MipmapLevelInfo> mipInfos = upload_placed_texture(mapped_buffer, texture, 256);
 	texture_buffer_heap.unmap(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 
 	command_list->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(existing_texture, D3D12_RESOURCE_STATE_GENERIC_READ, D3D12_RESOURCE_STATE_COPY_DEST));

--- a/rpcs3/Emu/RSX/GL/rsx_gl_texture.cpp
+++ b/rpcs3/Emu/RSX/GL/rsx_gl_texture.cpp
@@ -185,7 +185,7 @@ namespace rsx
 			if (is_swizzled || mandates_expansion(format))
 			{
 				aligned_pitch = align(aligned_pitch, 256);
-				upload_placed_texture(tex, 256, texture_data);
+				upload_placed_texture({ reinterpret_cast<gsl::byte*>(texture_data), gsl::narrow<int>(texture_data_sz) }, tex, 256);
 				glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 			}
 			else

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -88,7 +88,13 @@
     <ClCompile Include="Emu\RSX\Common\ProgramStateCache.cpp" />
     <ClCompile Include="Emu\RSX\Common\ShaderParam.cpp" />
     <ClCompile Include="Emu\RSX\Common\surface_store.cpp" />
-    <ClCompile Include="Emu\RSX\Common\TextureUtils.cpp" />
+    <ClCompile Include="Emu\RSX\Common\TextureUtils.cpp">
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'">true</TreatWarningAsError>
+    </ClCompile>
     <ClCompile Include="Emu\RSX\Common\VertexProgramDecompiler.cpp" />
     <ClCompile Include="Emu\RSX\GCM.cpp" />
     <ClCompile Include="Emu\RSX\Null\NullGSRender.cpp" />


### PR DESCRIPTION
* get_placed_texture_storage_size returns more accurate result (fix crash in Outrun)
* Factors lot of code and use integer type more carrefully
* Treat warning as error in TextureUtils.cpp