### PR TITLE
D3d12: Tweak root signature and improves HRESULT message

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -252,7 +252,7 @@ void D3D12GSRender::upload_and_bind_vertex_shader_constants(size_t descriptor_in
 		.Offset((INT)descriptor_index, m_descriptor_stride_srv_cbv_uav));
 }
 
-void D3D12GSRender::upload_and_bind_fragment_shader_constants(size_t descriptor_index)
+D3D12_CONSTANT_BUFFER_VIEW_DESC D3D12GSRender::upload_fragment_shader_constants()
 {
 	// Get constant from fragment program
 	size_t buffer_size = m_pso_cache.get_fragment_constants_buffer_size(m_fragment_program);
@@ -266,13 +266,10 @@ void D3D12GSRender::upload_and_bind_fragment_shader_constants(size_t descriptor_
 	m_pso_cache.fill_fragment_constans_buffer({ mapped_buffer, gsl::narrow<int>(buffer_size) }, m_fragment_program);
 	m_buffer_data.unmap(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 
-	D3D12_CONSTANT_BUFFER_VIEW_DESC constant_buffer_view_desc = {
+	return {
 		m_buffer_data.get_heap()->GetGPUVirtualAddress() + heap_offset,
 		(UINT)buffer_size
 	};
-	m_device->CreateConstantBufferView(&constant_buffer_view_desc,
-		CD3DX12_CPU_DESCRIPTOR_HANDLE(get_current_resource_storage().descriptors_heap->GetCPUDescriptorHandleForHeapStart())
-		.Offset((INT)descriptor_index, m_descriptor_stride_srv_cbv_uav));
 }
 
 

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -107,7 +107,7 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "Texture1D " << PI.name << " : register(t" << textureIndex + 16 << ");" << std::endl;
+				OS << "Texture1D " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
 				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
 			}
 		}
@@ -116,7 +116,7 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "Texture2D " << PI.name << " : register(t" << textureIndex + 16 << ");" << std::endl;
+				OS << "Texture2D " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
 				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
 			}
 		}
@@ -125,7 +125,7 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "Texture3D " << PI.name << " : register(t" << textureIndex + 16 << ");" << std::endl;
+				OS << "Texture3D " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
 				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
 			}
 		}
@@ -134,7 +134,7 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "TextureCube " << PI.name << " : register(t" << textureIndex + 16 << ");" << std::endl;
+				OS << "TextureCube " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
 				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
 			}
 		}

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -55,8 +55,8 @@ private:
 	ComPtr<struct IDXGISwapChain3> m_swap_chain;
 	ComPtr<ID3D12Resource> m_backbuffer[2];
 	ComPtr<ID3D12DescriptorHeap> m_backbuffer_descriptor_heap[2];
-	// m_rootSignatures[N] is RS with N texture/sample
-	ComPtr<ID3D12RootSignature> m_root_signatures[17][17]; // indexed by [texture count][vertex count]
+
+	ComPtr<ID3D12RootSignature> m_shared_root_signature;
 
 	// TODO: Use a tree structure to parse more efficiently
 	data_cache m_texture_cache;
@@ -161,14 +161,14 @@ private:
 
 	void upload_and_bind_scale_offset_matrix(size_t descriptor_index);
 	void upload_and_bind_vertex_shader_constants(size_t descriptor_index);
-	void upload_and_bind_fragment_shader_constants(size_t descriptorIndex);
+	D3D12_CONSTANT_BUFFER_VIEW_DESC upload_fragment_shader_constants();
 	/**
 	 * Fetch all textures recorded in the state in the render target cache and in the texture cache.
 	 * If a texture is not cached, populate cmdlist with uploads command.
 	 * Create necessary resource view/sampler descriptors in the per frame storage struct.
 	 * If the count of enabled texture is below texture_count, fills with dummy texture and sampler.
 	 */
-	void upload_and_bind_textures(ID3D12GraphicsCommandList *command_list, size_t texture_count);
+	void upload_textures(ID3D12GraphicsCommandList *command_list, size_t texture_count);
 
 	/**
 	 * Creates render target if necessary.

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -236,7 +236,7 @@ void D3D12GSRender::load_program()
 		}
 	}
 
-	m_current_pso = m_pso_cache.getGraphicPipelineState(m_vertex_program, m_fragment_program, prop, m_device.Get(), m_root_signatures);
+	m_current_pso = m_pso_cache.getGraphicPipelineState(m_vertex_program, m_fragment_program, prop, m_device.Get(), m_shared_root_signature.Get());
 	return;
 }
 

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.h
@@ -148,7 +148,7 @@ struct D3D12Traits
 	static
 	pipeline_storage_type build_pipeline(
 		const vertex_program_type &vertexProgramData, const fragment_program_type &fragmentProgramData, const pipeline_properties &pipelineProperties,
-		ID3D12Device *device, gsl::span<ComPtr<ID3D12RootSignature>, 17, 17> root_signatures)
+		ID3D12Device *device, ID3D12RootSignature* root_signatures)
 	{
 		std::tuple<ID3D12PipelineState *, std::vector<size_t>, size_t> result = {};
 		D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicPipelineStateDesc = {};
@@ -163,7 +163,7 @@ struct D3D12Traits
 		graphicPipelineStateDesc.PS.BytecodeLength = fragmentProgramData.bytecode->GetBufferSize();
 		graphicPipelineStateDesc.PS.pShaderBytecode = fragmentProgramData.bytecode->GetBufferPointer();
 
-		graphicPipelineStateDesc.pRootSignature = root_signatures[fragmentProgramData.m_textureCount][vertexProgramData.vertex_shader_input_count].Get();
+		graphicPipelineStateDesc.pRootSignature = root_signatures;
 
 		graphicPipelineStateDesc.BlendState = pipelineProperties.Blend;
 		graphicPipelineStateDesc.DepthStencilState = pipelineProperties.DepthStencil;

--- a/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
@@ -173,9 +173,9 @@ D3D12_SHADER_RESOURCE_VIEW_DESC get_srv_descriptor_with_dimensions(const rsx::te
 }
 }
 
-void D3D12GSRender::upload_and_bind_textures(ID3D12GraphicsCommandList *command_list, size_t texture_count)
+void D3D12GSRender::upload_textures(ID3D12GraphicsCommandList *command_list, size_t texture_count)
 {
-	for (u32 i = 0; i < 16; ++i)
+	for (u32 i = 0; i < texture_count; ++i)
 	{
 		if (!m_textures_dirty[i])
 			continue;

--- a/rpcs3/Emu/RSX/D3D12/D3D12Utils.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Utils.h
@@ -5,11 +5,24 @@
 #include <wrl/client.h>
 #include "Emu/Memory/vm.h"
 #include "Emu/RSX/GCM.h"
+#include <locale>
+#include <comdef.h>
 
 
 using namespace Microsoft::WRL;
 
-#define CHECK_HRESULT(expr) { HRESULT hr = (expr); if (FAILED(hr)) throw EXCEPTION("HRESULT = 0x%x", hr); }
+inline std::string get_hresult_message(HRESULT hr)
+{
+	_com_error error(hr);
+#ifndef UNICODE
+	return error.ErrorMessage();
+#else
+	using convert_type = std::codecvt<wchar_t, char, mbstate_t>;
+	return std::wstring_convert<convert_type>().to_bytes(error.ErrorMessage());
+#endif
+}
+
+#define CHECK_HRESULT(expr) { HRESULT hr = (expr); if (FAILED(hr)) throw EXCEPTION("HRESULT = %s", get_hresult_message(hr)); }
 
 /**
  * Send data to dst pointer without polluting cache.


### PR DESCRIPTION
Only small adjustement in this PR. I'm making some experiments with dx12 binding model and I found using a single "expanded" root signature is slightly more efficient.