### PR TITLE
rsx/common: Track transform constant update.

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -280,6 +280,7 @@ namespace rsx
 		};
 		m_rtts_dirty = true;
 		memset(m_textures_dirty, -1, sizeof(m_textures_dirty));
+		m_transform_constants_dirty = true;
 	}
 
 	thread::~thread()

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -289,6 +289,7 @@ namespace rsx
 		std::vector<u32> inline_vertex_array;
 
 		bool m_rtts_dirty;
+		bool m_transform_constants_dirty;
 		bool m_textures_dirty[16];
 	protected:
 		std::array<u32, 4> get_color_surface_addresses() const;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -197,6 +197,7 @@ namespace rsx
 				size_t subreg = index % 4;
 
 				memcpy(rsxthr->transform_constants[load + reg].rgba + subreg, method_registers + NV4097_SET_TRANSFORM_CONSTANT + reg * count + subreg, sizeof(f32));
+				rsxthr->m_transform_constants_dirty = true;
 			}
 		};
 


### PR DESCRIPTION
This allows backend not to update transform constant buffers when unnecessary.