### PR TITLE
D3d12: Tweaks

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -319,11 +319,17 @@ void D3D12GSRender::end()
 		.Offset((INT)currentDescriptorIndex + vertex_buffer_count, m_descriptor_stride_srv_cbv_uav)
 		);
 
-	upload_and_bind_vertex_shader_constants(currentDescriptorIndex + 1 + vertex_buffer_count);
-	get_current_resource_storage().command_list->SetGraphicsRootDescriptorTable(VERTEX_CONSTANT_BUFFERS_SLOT,
-		CD3DX12_GPU_DESCRIPTOR_HANDLE(get_current_resource_storage().descriptors_heap->GetGPUDescriptorHandleForHeapStart())
-		.Offset((INT)currentDescriptorIndex + 1 + vertex_buffer_count, m_descriptor_stride_srv_cbv_uav)
-		);
+	if (m_transform_constants_dirty)
+	{
+		m_current_transform_constants_buffer_descriptor_id = (u32)currentDescriptorIndex + 1 + vertex_buffer_count;
+		upload_and_bind_vertex_shader_constants(currentDescriptorIndex + 1 + vertex_buffer_count);
+		m_transform_constants_dirty = false;
+		get_current_resource_storage().command_list->SetGraphicsRootDescriptorTable(VERTEX_CONSTANT_BUFFERS_SLOT,
+			CD3DX12_GPU_DESCRIPTOR_HANDLE(get_current_resource_storage().descriptors_heap->GetGPUDescriptorHandleForHeapStart())
+			.Offset(m_current_transform_constants_buffer_descriptor_id, m_descriptor_stride_srv_cbv_uav)
+			);
+	}
+
 
 	std::chrono::time_point<std::chrono::system_clock> constants_duration_end = std::chrono::system_clock::now();
 	m_timers.constants_duration += std::chrono::duration_cast<std::chrono::microseconds>(constants_duration_end - constants_duration_start).count();

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -197,7 +197,6 @@ D3D12GSRender::D3D12GSRender()
 	m_per_frame_storage[1].init(m_device.Get());
 	m_per_frame_storage[1].reset();
 
-	init_convert_shader();
 	m_output_scaling_pass.init(m_device.Get(), m_command_queue.Get());
 
 	CHECK_HRESULT(
@@ -236,8 +235,6 @@ D3D12GSRender::~D3D12GSRender()
 	m_texture_cache.unprotect_all();
 
 	m_dummy_texture->Release();
-	m_convert_pso->Release();
-	m_convert_root_signature->Release();
 	m_per_frame_storage[0].release();
 	m_per_frame_storage[1].release();
 	m_output_scaling_pass.release();

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -129,8 +129,8 @@ private:
 
 	// Currently used shader resources / samplers descriptor
 	u32 m_current_transform_constants_buffer_descriptor_id;
-	std::array<std::tuple<ID3D12Resource*, D3D12_SHADER_RESOURCE_VIEW_DESC>, 16> m_current_shader_resources = {};
-	std::array<D3D12_SAMPLER_DESC, 16> m_current_samplers = {};
+	ComPtr<ID3D12DescriptorHeap> m_current_texture_descriptors;
+	ComPtr<ID3D12DescriptorHeap> m_current_sampler_descriptors;
 public:
 	D3D12GSRender();
 	virtual ~D3D12GSRender();

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -101,13 +101,6 @@ private:
 	 */
 	shader m_output_scaling_pass;
 
-	/**
-	 * Data used when depth buffer is converted to uchar textures.
-	 */
-	ID3D12PipelineState *m_convert_pso;
-	ID3D12RootSignature *m_convert_root_signature;
-	void init_convert_shader();
-
 	resource_storage m_per_frame_storage[2];
 	resource_storage &get_current_resource_storage();
 	resource_storage &get_non_current_resource_storage();

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -128,6 +128,7 @@ private:
 	ID3D12Resource *m_dummy_texture;
 
 	// Currently used shader resources / samplers descriptor
+	u32 m_current_transform_constants_buffer_descriptor_id;
 	std::array<std::tuple<ID3D12Resource*, D3D12_SHADER_RESOURCE_VIEW_DESC>, 16> m_current_shader_resources = {};
 	std::array<D3D12_SAMPLER_DESC, 16> m_current_samplers = {};
 public:


### PR DESCRIPTION
This PR adds some small improvement to the backend : The first commit avoid unnecessary vertex constant upload, the second use descriptor copies instead of recreating them each draw call, and the last remove a couple of unneeded processing which was almost never used.

I didn't notice performance improvement but adopting good practice doesn't hurt, especially since the descriptor tweak is a first step into caching descriptors as well as the texture they point to which could save ~0.8 ms in some demanding scenario.