### PR TITLE
Rsx: Vertex attribute format fixes + ssa variable support

### DIFF
--- a/rpcs3-tests/ps3-rsx-common.cpp
+++ b/rpcs3-tests/ps3-rsx-common.cpp
@@ -1,0 +1,15 @@
+#include "stdafx.h"
+#include "Emu\RSX\Common\BufferUtils.h"
+
+
+TEST_CLASS(rsx_common)
+{
+	// Check UB256 size is correctly set in write_vertex_array_data_to_buffer
+	TEST_METHOD(ub256_upload)
+	{
+		std::vector<gsl::byte> dest_buffer(2200);
+		std::vector<gsl::byte> src_buffer(100000); // Big enough
+
+		write_vertex_array_data_to_buffer(gsl::span<gsl::byte>(dest_buffer), src_buffer.data(), 0, 550, rsx::vertex_base_type::ub256, 4, 20);
+	}
+};

--- a/rpcs3-tests/rpcs3-tests.vcxproj
+++ b/rpcs3-tests/rpcs3-tests.vcxproj
@@ -56,7 +56,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;..\OpenAL\libs\Win64;..\ffmpeg\Windows\x86_64\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-   </Link>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -76,6 +76,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ps3-rsx-common.cpp" />
     <ClCompile Include="ps3_ppu_llvm.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/rpcs3-tests/rpcs3-tests.vcxproj.filters
+++ b/rpcs3-tests/rpcs3-tests.vcxproj.filters
@@ -17,6 +17,9 @@
     <ClCompile Include="ps3_ppu_llvm.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ps3-rsx-common.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -66,13 +66,13 @@ void write_vertex_array_data_to_buffer(gsl::span<gsl::byte> raw_dst_span, const 
 	}
 	case rsx::vertex_base_type::s1:
 	case rsx::vertex_base_type::sf:
+	case rsx::vertex_base_type::s32k:
 	{
 		gsl::span<u16> dst_span = as_span_workaround<u16>(raw_dst_span);
 		copy_whole_attribute_array<be_t<u16>>(dst_span, src_ptr, vector_element_count, element_size, attribute_src_stride, first, count);
 		return;
 	}
 	case rsx::vertex_base_type::f:
-	case rsx::vertex_base_type::s32k:
 	{
 		gsl::span<u32> dst_span = as_span_workaround<u32>(raw_dst_span);
 		copy_whole_attribute_array<be_t<u32>>(dst_span, src_ptr, vector_element_count, element_size, attribute_src_stride, first, count);

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -58,6 +58,7 @@ void write_vertex_array_data_to_buffer(gsl::span<gsl::byte> raw_dst_span, const 
 	switch (type)
 	{
 	case rsx::vertex_base_type::ub:
+	case rsx::vertex_base_type::ub256:
 	{
 		gsl::span<u8> dst_span = as_span_workaround<u8>(raw_dst_span);
 		copy_whole_attribute_array<u8>(dst_span, src_ptr, vector_element_count, element_size, attribute_src_stride, first, count);
@@ -72,7 +73,6 @@ void write_vertex_array_data_to_buffer(gsl::span<gsl::byte> raw_dst_span, const 
 	}
 	case rsx::vertex_base_type::f:
 	case rsx::vertex_base_type::s32k:
-	case rsx::vertex_base_type::ub256:
 	{
 		gsl::span<u32> dst_span = as_span_workaround<u32>(raw_dst_span);
 		copy_whole_attribute_array<be_t<u32>>(dst_span, src_ptr, vector_element_count, element_size, attribute_src_stride, first, count);

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -295,6 +295,8 @@ std::vector<MipmapLevelInfo> upload_placed_texture(gsl::span<gsl::byte> mapped_b
 			return copy_texture_data<copy_unmodified_block_swizzled, false, 1>(as_span_workaround<u8>(mapped_buffer), reinterpret_cast<const u8*>(pixels), w, h, depth, layer, texture.mipmap(), texture.pitch());
 		else
 			return copy_texture_data<copy_unmodified_block, true, 1>(as_span_workaround<u8>(mapped_buffer), reinterpret_cast<const u8*>(pixels), w, h, depth, layer, texture.mipmap(), texture.pitch());
+	case CELL_GCM_TEXTURE_DEPTH24_D8: // Opaque type ; ATM do not copy anything
+		return std::vector<MipmapLevelInfo>();
 	}
 	throw EXCEPTION("Wrong format %d", format);
 }

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -169,6 +169,8 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 					continue;
 				}
 			}
+			if (PI.name == "ssa")
+				continue;
 			OS << "	" << PT.type << " " << PI.name << " = In." << PI.name << ";" << std::endl;
 		}
 	}
@@ -176,6 +178,7 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 	OS << "	" << "float4 gl_FragCoord = In.Position;" << std::endl;
 	if (m_prog.origin_mode == rsx::window_origin::bottom)
 		OS << "	gl_FragCoord.y = (" << std::to_string(m_prog.height) << " - gl_FragCoord.y);\n";
+	OS << "	float4 ssa = is_front_face ? float4(1., 1., 1., 1.) : float4(-1., -1., -1., -1.);\n";
 	// Declare output
 	for (const ParamType &PT : m_parr.params[PF_PARAM_NONE])
 	{

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
@@ -44,7 +44,7 @@ namespace
 		{
 			if (static_cast<size_t>(real_input.location) != std::get<0>(attribute))
 				continue;
-			OS << "Buffer<float4> " << std::get<1>(attribute) << "_buffer : register(t" << reg++ << ");\n";
+			OS << "Buffer<" << (real_input.int_type ? "int4" : "float4") << "> " << std::get<1>(attribute) << "_buffer : register(t" << reg++ << ");\n";
 			return true;
 		}
 		return false;

--- a/rpcs3/Emu/RSX/GCM.cpp
+++ b/rpcs3/Emu/RSX/GCM.cpp
@@ -1124,11 +1124,11 @@ namespace
 	{
 		switch (rsx::to_vertex_base_type(type))
 		{
-		case rsx::vertex_base_type::s1: return "Short";
+		case rsx::vertex_base_type::s1: return "Signed short normalized";
 		case rsx::vertex_base_type::f: return "Float";
 		case rsx::vertex_base_type::sf: return "Half float";
 		case rsx::vertex_base_type::ub: return "Unsigned byte normalized";
-		case rsx::vertex_base_type::s32k: return "Signed int";
+		case rsx::vertex_base_type::s32k: return "Signed short unormalized";
 		case rsx::vertex_base_type::cmp: return "CMP";
 		case rsx::vertex_base_type::ub256: return "Unsigned byte unormalized";
 		}

--- a/rpcs3/Emu/RSX/GCM.cpp
+++ b/rpcs3/Emu/RSX/GCM.cpp
@@ -1127,10 +1127,10 @@ namespace
 		case rsx::vertex_base_type::s1: return "Short";
 		case rsx::vertex_base_type::f: return "Float";
 		case rsx::vertex_base_type::sf: return "Half float";
-		case rsx::vertex_base_type::ub: return "Unsigned byte";
+		case rsx::vertex_base_type::ub: return "Unsigned byte normalized";
 		case rsx::vertex_base_type::s32k: return "Signed int";
 		case rsx::vertex_base_type::cmp: return "CMP";
-		case rsx::vertex_base_type::ub256: return "UB256";
+		case rsx::vertex_base_type::ub256: return "Unsigned byte unormalized";
 		}
 	}
 

--- a/rpcs3/Emu/RSX/GCM.h
+++ b/rpcs3/Emu/RSX/GCM.h
@@ -30,10 +30,10 @@ namespace rsx
 		s1, ///< signed byte
 		f, ///< float
 		sf, ///< half float
-		ub, ///< unsigned byte
+		ub, ///< unsigned byte interpreted as 0.f and 1.f
 		s32k, ///< signed 32bits int
 		cmp, ///< compressed aka X11G11Z10 and always 1. W.
-		ub256,
+		ub256, ///< unsigned byte interpreted as between 0 and 255.
 	};
 
 	vertex_base_type to_vertex_base_type(u8 in);

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -116,6 +116,8 @@ void GLFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 			OS << ";" << std::endl;
 		}
 	}
+
+	OS << "	vec4 ssa = gl_FrontFacing ? vec4(1.) : vec4(-1.);\n";
 }
 
 void GLFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -37,10 +37,10 @@ namespace
 		 * The buffer texture spec only allows fetches aligned to 8, 16, 32, etc...
 		 * This rules out most 3-component formats, except for the 32-wide RGB32F, RGB32I, RGB32UI
 		 */
-		const u32 vec1_types[] = { GL_R16, GL_R32F, GL_R16F, GL_R8, GL_R32I, GL_R16, GL_R8UI };
-		const u32 vec2_types[] = { GL_RG16, GL_RG32F, GL_RG16F, GL_RG8, GL_RG32I, GL_RG16, GL_RG8UI };
-		const u32 vec3_types[] = { GL_RGBA16, GL_RGB32F, GL_RGBA16F, GL_RGBA8, GL_RGB32I, GL_RGBA16, GL_RGBA8UI };	//VEC3 COMPONENTS NOT SUPPORTED!
-		const u32 vec4_types[] = { GL_RGBA16, GL_RGBA32F, GL_RGBA16F, GL_RGBA8, GL_RGBA32I, GL_RGBA16, GL_RGBA8UI };
+		const u32 vec1_types[] = { GL_R16, GL_R32F, GL_R16F, GL_R8, GL_R16I, GL_R16, GL_R8UI };
+		const u32 vec2_types[] = { GL_RG16, GL_RG32F, GL_RG16F, GL_RG8, GL_RG16I, GL_RG16, GL_RG8UI };
+		const u32 vec3_types[] = { GL_RGBA16, GL_RGB32F, GL_RGBA16F, GL_RGBA8, GL_RGBA16I, GL_RGBA16, GL_RGBA8UI };	//VEC3 COMPONENTS NOT SUPPORTED!
+		const u32 vec4_types[] = { GL_RGBA16, GL_RGBA32F, GL_RGBA16F, GL_RGBA8, GL_RGBA16I, GL_RGBA16, GL_RGBA8UI };
 
 		const u32* vec_selectors[] = { 0, vec1_types, vec2_types, vec3_types, vec4_types };
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -127,6 +127,7 @@ namespace rsx
 		switch (type)
 		{
 		case vertex_base_type::s1:
+		case vertex_base_type::s32k:
 			switch (size)
 			{
 			case 1:
@@ -160,7 +161,6 @@ namespace rsx
 				return sizeof(u8) * 4;
 			}
 			throw EXCEPTION("Wrong vector size");
-		case vertex_base_type::s32k: return sizeof(u32) * size;
 		case vertex_base_type::cmp: return sizeof(u16) * 4;
 		case vertex_base_type::ub256: Expects(size == 4); return sizeof(u8) * 4;
 		}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -136,8 +136,8 @@ namespace rsx
 			case 3:
 				return sizeof(u16) * 4;
 			}
-			throw new EXCEPTION("Wrong vector size");
-		case vertex_base_type::f:     return sizeof(f32) * size;
+			throw EXCEPTION("Wrong vector size");
+		case vertex_base_type::f: return sizeof(f32) * size;
 		case vertex_base_type::sf:
 			switch (size)
 			{
@@ -148,7 +148,7 @@ namespace rsx
 			case 3:
 				return sizeof(f16) * 4;
 			}
-			throw new EXCEPTION("Wrong vector size");
+			throw EXCEPTION("Wrong vector size");
 		case vertex_base_type::ub:
 			switch (size)
 			{
@@ -159,15 +159,12 @@ namespace rsx
 			case 3:
 				return sizeof(u8) * 4;
 			}
-			throw new EXCEPTION("Wrong vector size");
-		case vertex_base_type::s32k:  return sizeof(u32) * size;
-		case vertex_base_type::cmp:   return sizeof(u16) * 4;
-		case vertex_base_type::ub256: return sizeof(u8) * 4;
-
-		default:
-			throw new EXCEPTION("RSXVertexData::GetTypeSize: Bad vertex data type (%d)!", type);
-			return 0;
+			throw EXCEPTION("Wrong vector size");
+		case vertex_base_type::s32k: return sizeof(u32) * size;
+		case vertex_base_type::cmp: return sizeof(u16) * 4;
+		case vertex_base_type::ub256: Expects(size == 4); return sizeof(u8) * 4;
 		}
+		throw EXCEPTION("RSXVertexData::GetTypeSize: Bad vertex data type (%d)!", type);
 	}
 
 	void tiled_region::write(const void *src, u32 width, u32 height, u32 pitch)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -568,6 +568,25 @@ namespace rsx
 		}
 	}
 
+	namespace
+	{
+		bool is_int_type(rsx::vertex_base_type type)
+		{
+			switch (type)
+			{
+			case rsx::vertex_base_type::s32k:
+			case rsx::vertex_base_type::ub256:
+				return true;
+			case rsx::vertex_base_type::f:
+			case rsx::vertex_base_type::cmp:
+			case rsx::vertex_base_type::sf:
+			case rsx::vertex_base_type::s1:
+			case rsx::vertex_base_type::ub:
+				return false;
+			}
+		}
+	}
+
 	std::array<u32, 4> thread::get_color_surface_addresses() const
 	{
 		u32 offset_color[] =
@@ -636,7 +655,8 @@ namespace rsx
 					vertex_arrays_info[index].size,
 					vertex_arrays_info[index].frequency,
 					!!((modulo_mask >> index) & 0x1),
-					true
+					true,
+					is_int_type(vertex_arrays_info[index].type)
 				}
 				);
 			}
@@ -648,7 +668,8 @@ namespace rsx
 					register_vertex_info[index].size,
 					register_vertex_info[index].frequency,
 					!!((modulo_mask >> index) & 0x1),
-					false
+					false,
+					is_int_type(vertex_arrays_info[index].type)
 				}
 				);
 			}

--- a/rpcs3/Emu/RSX/RSXVertexProgram.h
+++ b/rpcs3/Emu/RSX/RSXVertexProgram.h
@@ -197,10 +197,11 @@ struct rsx_vertex_input
 	u16 frequency;
 	bool is_modulo; // either modulo frequency or divide frequency
 	bool is_array; // false if "reg value"
+	bool int_type;
 
 	bool operator==(const rsx_vertex_input other) const
 	{
-		return location == other.location && size == other.size && frequency == other.frequency && is_modulo == other.is_modulo && is_array == other.is_array;
+		return location == other.location && size == other.size && frequency == other.frequency && is_modulo == other.is_modulo && is_array == other.is_array && int_type == other.int_type;
 	}
 };
 


### PR DESCRIPTION
This PR fixes integer format support for vertex attributes, namely ub256 and s32k.
It actually fixes the upload callback in rsx and types d3d12 vertex shader input (as it looks like Buffer<float4> is not reading integer value at all).
Not sure if gl requires a fix though since TextureBuffer are not typed.


SSA is fragment shader semantic for front facing boolean value and is also supported with this PR on both gl and dx12.


Burgertime World Tour should work up to the menu. It displays a black screen although the scene is rendered (but uncorrectly lit) according to RSXDebugger.