### PR TITLE
Rsx: Fix fog (Fixes #1535)

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -152,22 +152,22 @@ namespace
 		switch (mode)
 		{
 		case rsx::fog_mode::linear:
-			OS << "	float4 fogc = fog_param1 * In.fogc + (fog_param0 - 1.);\n";
+			OS << "	float4 fogc = float4(fog_param1 * In.fogc + (fog_param0 - 1.), fog_param1 * In.fogc + (fog_param0 - 1.), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::exponential:
-			OS << "	float4 fogc = exp(11.084 * (fog_param1 * In.fogc + fog_param0 - 1.5));\n";
+			OS << "	float4 fogc = float4(11.084 * (fog_param1 * In.fogc + fog_param0 - 1.5), exp(11.084 * (fog_param1 * In.fogc + fog_param0 - 1.5)), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::exponential2:
-			OS << "	float4 fogc = exp(-pow(4.709 * (fog_param1 * In.fogc + fog_param0 - 1.5)), 2.);\n";
+			OS << "	float4 fogc = float4(4.709 * (fog_param1 * In.fogc + fog_param0 - 1.5), exp(-pow(4.709 * (fog_param1 * In.fogc + fog_param0 - 1.5)), 2.)), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::linear_abs:
-			OS << "	float4 fogc = fog_param1 * abs(In.fogc) + (fog_param0 - 1.);\n";
+			OS << "	float4 fogc = float4(fog_param1 * abs(In.fogc) + (fog_param0 - 1.), fog_param1 * abs(In.fogc) + (fog_param0 - 1.), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::exponential_abs:
-			OS << "	float4 fogc = exp(11.084 * (fog_param1 * abs(In.fogc) + fog_param0 - 1.5));\n";
+			OS << "	float4 fogc = float4(11.084 * (fog_param1 * abs(In.fogc) + fog_param0 - 1.5), exp(11.084 * (fog_param1 * abs(In.fogc) + fog_param0 - 1.5)), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::exponential2_abs:
-			OS << "	float4 fogc = exp(-pow(4.709 * (fog_param1 * abs(In.fogc) + fog_param0 - 1.5)), 2.);\n";
+			OS << "	float4 fogc = float4(4.709 * (fog_param1 * abs(In.fogc) + fog_param0 - 1.5), exp(-pow(4.709 * (fog_param1 * abs(In.fogc) + fog_param0 - 1.5)), 2.)), 0., 0.);\n";
 			return;
 		}
 	}

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -122,22 +122,22 @@ namespace
 		switch (mode)
 		{
 		case rsx::fog_mode::linear:
-			OS << "	vec4 fogc = fog_param1 * fog_c + (fog_param0 - 1.);\n";
+			OS << "	vec4 fogc = vec4(fog_param1 * fog_c.x + (fog_param0 - 1.), fog_param1 * fog_c.x + (fog_param0 - 1.), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::exponential:
-			OS << "	vec4 fogc = exp(11.084 * (fog_param1 * fog_c + fog_param0 - 1.5));\n";
+			OS << "	vec4 fogc = vec4(11.084 * (fog_param1 * fog_c.x + fog_param0 - 1.5), exp(11.084 * (fog_param1 * fog_c.x + fog_param0 - 1.5)), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::exponential2:
-			OS << "	vec4 fogc = exp(-pow(4.709 * (fog_param1 * fog_c + fog_param0 - 1.5)), 2.);\n";
+			OS << "	vec4 fogc = vec4(4.709 * (fog_param1 * fog_c.x + fog_param0 - 1.5), exp(-pow(4.709 * (fog_param1 * fog_c.x + fog_param0 - 1.5)), 2.), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::linear_abs:
-			OS << "	vec4 fogc = fog_param1 * abs(fog_c) + (fog_param0 - 1.);\n";
+			OS << "	vec4 fogc = vec4(fog_param1 * abs(fog_c.x) + (fog_param0 - 1.), fog_param1 * abs(fog_c.x) + (fog_param0 - 1.), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::exponential_abs:
-			OS << "	vec4 fogc = exp(11.084 * (fog_param1 * abs(fog_c) + fog_param0 - 1.5));\n";
+			OS << "	vec4 fogc = vec4(11.084 * (fog_param1 * abs(fog_c.x) + fog_param0 - 1.5), exp(11.084 * (fog_param1 * abs(fog_c.x) + fog_param0 - 1.5)), 0., 0.);\n";
 			return;
 		case rsx::fog_mode::exponential2_abs:
-			OS << "	vec4 fogc = exp(-pow(4.709 * (fog_param1 * abs(fog_c) + fog_param0 - 1.5)), 2.);\n";
+			OS << "	vec4 fogc = vec4(4.709 * (fog_param1 * abs(fog_c.x) + fog_param0 - 1.5), exp(-pow(4.709 * (fog_param1 * abs(fog_c.x) + fog_param0 - 1.5)), 2.), 0., 0.);\n";
 			return;
 		}
 	}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -768,7 +768,10 @@ namespace rsx
 
 		method_registers[NV4097_SET_LINE_WIDTH] = 1 << 3;
 
-		method_registers[NV4097_SET_FOG_MODE] = 0x0800; // rsx::fog_mode::exponential;
+		// These defaults were found using After Burner Climax (which never set fog mode despite using fog input)
+		method_registers[NV4097_SET_FOG_MODE] = 0x2601; // rsx::fog_mode::linear;
+		(f32&)method_registers[NV4097_SET_FOG_PARAMS] = 1.;
+		(f32&)method_registers[NV4097_SET_FOG_PARAMS + 1] = 1.;
 
 		method_registers[NV4097_SET_DEPTH_FUNC] = CELL_GCM_LESS;
 		method_registers[NV4097_SET_DEPTH_MASK] = CELL_GCM_TRUE;


### PR DESCRIPTION
This PR fixes fog in After Burner Climax by setting linear mode as default ; it also split fog distance and fog fraction in the fog input declaration.

