### PR TITLE
Vulkan: Uses d24_s8 or d32_s8 depending on availability.

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -1,0 +1,42 @@
+#include "stdafx.h"
+#include "VKFormats.h"
+
+namespace vk
+{
+
+gpu_formats_support get_optimal_tiling_supported_formats(VkPhysicalDevice physical_device)
+{
+	gpu_formats_support result = {};
+
+	VkFormatProperties props;
+	vkGetPhysicalDeviceFormatProperties(physical_device, VK_FORMAT_D24_UNORM_S8_UINT, &props);
+
+	result.d24_unorm_s8 = !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)
+		&& !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+		&& !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT)
+		&& !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT);
+
+	vkGetPhysicalDeviceFormatProperties(physical_device, VK_FORMAT_D32_SFLOAT_S8_UINT, &props);
+	result.d32_sfloat_s8 = !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)
+		&& !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
+		&& !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT);
+
+	return result;
+}
+
+VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support, rsx::surface_depth_format format)
+{
+	switch (format)
+	{
+	case rsx::surface_depth_format::z16: return VK_FORMAT_D16_UNORM;
+	case rsx::surface_depth_format::z24s8:
+	{
+		if (support.d24_unorm_s8) return VK_FORMAT_D24_UNORM_S8_UINT;
+		if (support.d32_sfloat_s8) return VK_FORMAT_D32_SFLOAT_S8_UINT;
+		throw EXCEPTION("No hardware support for z24s8");
+	}
+	}
+	throw EXCEPTION("Invalid format (0x%x)", format);
+}
+
+}

--- a/rpcs3/Emu/RSX/VK/VKFormats.h
+++ b/rpcs3/Emu/RSX/VK/VKFormats.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "VKHelpers.h"
+
+namespace vk
+{
+	struct gpu_formats_support
+	{
+		bool d24_unorm_s8 : 1;
+		bool d32_sfloat_s8 : 1;
+	};
+
+	gpu_formats_support get_optimal_tiling_supported_formats(VkPhysicalDevice physical_device);
+	VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support, rsx::surface_depth_format format);
+}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -3,6 +3,7 @@
 #include "VKHelpers.h"
 #include "VKTextureCache.h"
 #include "VKRenderTargets.h"
+#include "VKFormats.h"
 
 #define RSX_DEBUG 1
 
@@ -26,6 +27,8 @@ private:
 	
 	vk::texture_cache m_texture_cache;
 	rsx::vk_render_targets m_rtts;
+
+	vk::gpu_formats_support m_optimal_tiling_supported_formats;
 
 public:
 	//vk::fbo draw_fbo;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -11,11 +11,9 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include "Emu/state.h"
 #include "VulkanAPI.h"
 #include "../GCM.h"
-
-//Set to 9 to enable all debug layers. Will cause significant slowdowns. Eventually to be replaced with GUI checkbox
-#define VK_ENABLED_LAYER_COUNT 0
 
 namespace rsx
 {
@@ -166,22 +164,18 @@ namespace vk
 				"VK_KHR_swapchain"
 			};
 
-			const char *validation_layers[] =
-			{
-				"VK_LAYER_LUNARG_threading",      "VK_LAYER_LUNARG_mem_tracker",
-				"VK_LAYER_LUNARG_object_tracker", "VK_LAYER_LUNARG_draw_state",
-				"VK_LAYER_LUNARG_param_checker",  "VK_LAYER_LUNARG_swapchain",
-				"VK_LAYER_LUNARG_device_limits",  "VK_LAYER_LUNARG_image",
-				"VK_LAYER_GOOGLE_unique_objects",
-			};
+			std::vector<const char *> layers;
+
+			if (rpcs3::config.rsx.d3d12.debug_output.value())
+				layers.push_back("VK_LAYER_LUNARG_standard_validation");
 
 			VkDeviceCreateInfo device;
 			device.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 			device.pNext = NULL;
 			device.queueCreateInfoCount = 1;
 			device.pQueueCreateInfos = &queue;
-			device.enabledLayerCount = VK_ENABLED_LAYER_COUNT;
-			device.ppEnabledLayerNames = validation_layers;
+			device.enabledLayerCount = layers.size();
+			device.ppEnabledLayerNames = layers.data();
 			device.enabledExtensionCount = 1;
 			device.ppEnabledExtensionNames = requested_extensions;
 			device.pEnabledFeatures = nullptr;
@@ -1011,21 +1005,17 @@ namespace vk
 				"VK_EXT_debug_report",
 			};
 
-			const char *validation_layers[] =
-			{
-				"VK_LAYER_LUNARG_threading",      "VK_LAYER_LUNARG_mem_tracker",
-				"VK_LAYER_LUNARG_object_tracker", "VK_LAYER_LUNARG_draw_state",
-				"VK_LAYER_LUNARG_param_checker",  "VK_LAYER_LUNARG_swapchain",
-				"VK_LAYER_LUNARG_device_limits",  "VK_LAYER_LUNARG_image",
-				"VK_LAYER_GOOGLE_unique_objects",
-			};
+			std::vector<const char *> layers;
+
+			if (rpcs3::config.rsx.d3d12.debug_output.value())
+				layers.push_back("VK_LAYER_LUNARG_standard_validation");
 
 			VkInstanceCreateInfo instance_info;
 			instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
 			instance_info.pNext = nullptr;
 			instance_info.pApplicationInfo = &app;
-			instance_info.enabledLayerCount = VK_ENABLED_LAYER_COUNT;
-			instance_info.ppEnabledLayerNames = validation_layers;
+			instance_info.enabledLayerCount = layers.size();
+			instance_info.ppEnabledLayerNames = layers.data();
 			instance_info.enabledExtensionCount = 3;
 			instance_info.ppEnabledExtensionNames = requested_extensions;
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -68,7 +68,6 @@ namespace vk
 
 	VkFormat get_compatible_sampler_format(u32 format, VkComponentMapping& mapping, u8 swizzle_mask=0);
 	VkFormat get_compatible_surface_format(rsx::surface_color_format color_format);
-	VkFormat get_compatible_depth_surface_format(rsx::surface_depth_format depth_format);
 
 	class physical_device
 	{

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -4,6 +4,7 @@
 #include "VKHelpers.h"
 #include "../GCM.h"
 #include "../Common/surface_store.h"
+#include "VKFormats.h"
 
 namespace rsx
 {
@@ -14,7 +15,7 @@ namespace rsx
 		using command_list_type = vk::command_buffer*;
 		using download_buffer_object = void*;
 
-		static vk::texture create_new_surface(u32 address, surface_color_format format, size_t width, size_t height, vk::render_device &device, vk::command_buffer *cmd)
+		static vk::texture create_new_surface(u32 address, surface_color_format format, size_t width, size_t height, vk::render_device &device, vk::command_buffer *cmd, const vk::gpu_formats_support &support)
 		{
 			VkFormat requested_format = vk::get_compatible_surface_format(format);
 			
@@ -37,9 +38,9 @@ namespace rsx
 			return rtt;
 		}
 
-		static vk::texture create_new_surface(u32 address, surface_depth_format format, size_t width, size_t height, vk::render_device &device, vk::command_buffer *cmd)
+		static vk::texture create_new_surface(u32 address, surface_depth_format format, size_t width, size_t height, vk::render_device &device, vk::command_buffer *cmd, const vk::gpu_formats_support &support)
 		{
-			VkFormat requested_format = vk::get_compatible_depth_surface_format(format);
+			VkFormat requested_format = vk::get_compatible_depth_surface_format(support, format);
 
 			vk::texture rtt;
 			rtt.create(device, requested_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT|VK_IMAGE_USAGE_SAMPLED_BIT, width, height, 1, true);
@@ -101,10 +102,11 @@ namespace rsx
 
 		static bool ds_has_format_width_height(const vk::texture &ds, surface_depth_format format, size_t width, size_t height)
 		{
-			VkFormat fmt = vk::get_compatible_depth_surface_format(format);
+			// TODO: check format
+			//VkFormat fmt = vk::get_compatible_depth_surface_format(format);
 			vk::texture &tex = const_cast<vk::texture&>(ds);
 
-			if (tex.get_format() == fmt &&
+			if (//tex.get_format() == fmt &&
 				tex.width() == width &&
 				tex.height() == height)
 				return true;

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Emu\RSX\VK\VKCommonDecompiler.h" />
+    <ClInclude Include="Emu\RSX\VK\VKFormats.h" />
     <ClInclude Include="Emu\RSX\VK\VKFragmentProgram.h" />
     <ClInclude Include="Emu\RSX\VK\VKGSRender.h" />
     <ClInclude Include="Emu\RSX\VK\VKHelpers.h" />
@@ -35,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Emu\RSX\VK\VKCommonDecompiler.cpp" />
+    <ClCompile Include="Emu\RSX\VK\VKFormats.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKFragmentProgram.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKGSRender.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKHelpers.cpp" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClInclude Include="Emu\RSX\VK\VulkanAPI.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\VKFormats.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Emu\RSX\VK\VKGSRender.cpp">
@@ -61,6 +64,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Emu\RSX\VK\VKVertexBuffers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\RSX\VK\VKFormats.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Radeon cards don't support d24_unorm_s8 format for depth stencil buffer.
With DX12/OGL the driver emulates with 2 buffers (a d32 for depth and a r8 for stencil) but on Vulkan it's up to the app to query for format support.

This commit makes Vulkan backend uses d24_u8 format if supported, otherwise it uses d32_u8.
Unfortunatly the later case is less accurate wrt RSX emulation but hopefully it won't matter in practice.

There's also a commit that make debug output option respect the setting in the settings menu.