### PR TITLE
Vulkan: Remove buffer_deprecated

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -473,25 +473,13 @@ void VKGSRender::set_viewport()
 void VKGSRender::on_init_thread()
 {
 	GSRender::on_init_thread();
-
-	for (auto &attrib_buffer : m_attrib_buffers)
-	{
-		attrib_buffer.create((*m_device), 65536, VK_FORMAT_R8_UNORM, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
-		
-		u8 *data = static_cast<u8*>(attrib_buffer.map(0, 65536));
-		memset(data, 0, 65536);
-		attrib_buffer.unmap();
-	}
+	m_attrib_ring_info.init(8 * RING_BUFFER_SIZE);
+	m_attrib_buffers.reset(new vk::buffer(*m_device, 8 * RING_BUFFER_SIZE, m_memory_type_mapping.host_visible_coherent, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, 0));
 }
 
 void VKGSRender::on_exit()
 {
 	m_texture_cache.destroy();
-	
-	for (auto &attrib_buffer : m_attrib_buffers)
-	{
-		attrib_buffer.destroy();
-	}
 }
 
 void VKGSRender::clear_surface(u32 mask)
@@ -1023,6 +1011,7 @@ void VKGSRender::flip(int buffer)
 
 		m_uniform_buffer_ring_info.m_get_pos = m_uniform_buffer_ring_info.get_current_put_pos_minus_one();
 		m_index_buffer_ring_info.m_get_pos = m_index_buffer_ring_info.get_current_put_pos_minus_one();
+		m_attrib_ring_info.m_get_pos = m_attrib_ring_info.get_current_put_pos_minus_one();
 		if (m_present_semaphore)
 		{
 			vkDestroySemaphore((*m_device), m_present_semaphore, nullptr);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -104,7 +104,8 @@ private:
 
 	rsx::surface_info m_surface;
 
-	vk::buffer_deprecated m_attrib_buffers[rsx::limits::vertex_count];
+	vk::data_heap m_attrib_ring_info;
+	std::unique_ptr<vk::buffer> m_attrib_buffers;
 	
 	vk::texture_cache m_texture_cache;
 	rsx::vk_render_targets m_rtts;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -43,7 +43,7 @@ namespace vk
 		result.device_local = VK_MAX_MEMORY_TYPES;
 		result.host_visible_coherent = VK_MAX_MEMORY_TYPES;
 
-		for (int i = 0; i < VK_MAX_MEMORY_TYPES; i++)
+		for (int i = 0; i < memory_properties.memoryTypeCount; i++)
 		{
 			bool is_device_local = !!(memory_properties.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 			if (is_device_local)

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -6,7 +6,6 @@ namespace vk
 	context *g_current_vulkan_ctx = nullptr;
 	render_device g_current_renderer;
 
-	buffer_deprecated g_null_buffer;
 	texture g_null_texture;
 
 	VkSampler g_null_sampler = nullptr;
@@ -147,15 +146,6 @@ namespace vk
 		return callbacks;
 	}
 
-	VkBuffer null_buffer()
-	{
-		if (g_null_buffer.size())
-			return g_null_buffer;
-
-		g_null_buffer.create(g_current_renderer, 32, VK_FORMAT_R32_SFLOAT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
-		return g_null_buffer;
-	}
-
 	VkSampler null_sampler()
 	{
 		if (g_null_sampler)
@@ -192,18 +182,8 @@ namespace vk
 		return g_null_image_view;
 	}
 
-	VkBufferView null_buffer_view()
-	{
-		if (g_null_buffer.size())
-			return g_null_buffer;
-
-		g_null_buffer.create(g_current_renderer, 32, VK_FORMAT_R32_SFLOAT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
-		return g_null_buffer;
-	}
-
 	void destroy_global_resources()
 	{
-		g_null_buffer.destroy();
 		g_null_texture.destroy();
 
 		if (g_null_sampler)

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -328,13 +328,13 @@ VKGSRender::upload_vertex_data()
 				throw EXCEPTION("Unknown base type %d", vertex_info.type);
 			}
 
-			auto &buffer = m_attrib_buffers[index];
-
-			buffer.sub_data(0, data_size, vertex_arrays_data.data());
-			buffer.set_format(format);
+			size_t offset_in_attrib_buffer = m_attrib_ring_info.alloc<256>(data_size);
+			void* buf = m_attrib_buffers->map(offset_in_attrib_buffer, data_size);
+			memcpy(buf, vertex_arrays_data.data(), data_size);
+			m_attrib_buffers->unmap();
 
 			//Link texture to uniform location
-			m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], buffer, true);
+			m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], m_attrib_buffers->value, offset_in_attrib_buffer, data_size, format);
 		}
 	}
 
@@ -419,11 +419,13 @@ VKGSRender::upload_vertex_data()
 				const VkFormat format = vk::get_suitable_vk_format(vertex_info.type, vertex_info.size);
 				const u32 data_size = vk::get_suitable_vk_size(vertex_info.type, vertex_info.size) * num_stored_verts;
 
-				auto &buffer = m_attrib_buffers[index];
 
-				buffer.sub_data(0, data_size, data_ptr);
-				buffer.set_format(format);
-				m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], buffer, true);
+				size_t offset_in_attrib_buffer = m_attrib_ring_info.alloc<256>(data_size);
+				void* buf = m_attrib_buffers->map(offset_in_attrib_buffer, data_size);
+				memcpy(buf, data_ptr, data_size);
+				m_attrib_buffers->unmap();
+
+				m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], m_attrib_buffers->value, offset_in_attrib_buffer, data_size, format);
 			}
 			else if (register_vertex_info[index].size > 0)
 			{
@@ -457,12 +459,13 @@ VKGSRender::upload_vertex_data()
 						data_size = converted_buffer.size();
 					}
 
-					auto &buffer = m_attrib_buffers[index];
 
-					buffer.sub_data(0, data_size, data_ptr);
-					buffer.set_format(format);
+					size_t offset_in_attrib_buffer = m_attrib_ring_info.alloc<256>(data_size);
+					void* buf = m_attrib_buffers->map(offset_in_attrib_buffer, data_size);
+					memcpy(buf, data_ptr, data_size);
+					m_attrib_buffers->unmap();
 
-					m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], buffer, true);
+					m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], m_attrib_buffers->value, offset_in_attrib_buffer, data_size, format);
 					break;
 				}
 				default:


### PR DESCRIPTION
Use the simpler buffer class for attrib buffer now. Fix a bug when detecting memory types too.