### PR TITLE
Fixes #1584 (Vulkan not being usable in non-w10 systems)

### DIFF
--- a/rpcs3/Gui/SettingsDialog.cpp
+++ b/rpcs3/Gui/SettingsDialog.cpp
@@ -229,6 +229,7 @@ SettingsDialog::SettingsDialog(wxWindow *parent, rpcs3::config_t* cfg)
 
 	cbox_gs_render->Append("Null");
 	cbox_gs_render->Append("OpenGL");
+	cbox_gs_render->Append("Vulkan");
 
 #ifdef _MSC_VER
 	Microsoft::WRL::ComPtr<IDXGIFactory4> dxgiFactory;
@@ -251,7 +252,6 @@ SettingsDialog::SettingsDialog(wxWindow *parent, rpcs3::config_t* cfg)
 		chbox_gs_overlay->Enable(false);
 	}
 
-	cbox_gs_render->Append("Vulkan");
 #endif
 
 	for (int i = 1; i < WXSIZEOF(ResolutionTable); ++i)
@@ -503,7 +503,16 @@ SettingsDialog::SettingsDialog(wxWindow *parent, rpcs3::config_t* cfg)
 		cfg->core.hook_st_func = chbox_core_hook_stfunc->GetValue();
 		cfg->core.load_liblv2 = chbox_core_load_liblv2->GetValue();
 
-		cfg->rsx.renderer = cbox_gs_render->GetSelection();
+		// Translates renderer string to enum class for config.h
+		if (cbox_gs_render->GetString(cbox_gs_render->GetSelection()) == "Null")
+			cfg->rsx.renderer = rsx_renderer_type::Null;
+		if (cbox_gs_render->GetString(cbox_gs_render->GetSelection()) == "OpenGL")
+			cfg->rsx.renderer = rsx_renderer_type::OpenGL;
+		if (cbox_gs_render->GetString(cbox_gs_render->GetSelection()) == "Vulkan")
+			cfg->rsx.renderer = rsx_renderer_type::Vulkan;
+		if (cbox_gs_render->GetString(cbox_gs_render->GetSelection()) == "DirectX 12")
+			cfg->rsx.renderer = rsx_renderer_type::DX12;
+		
 		cfg->rsx.d3d12.adaptater = cbox_gs_d3d_adaptater->GetSelection();
 		cfg->rsx.resolution = ResolutionNumToId(cbox_gs_resolution->GetSelection() + 1);
 		cfg->rsx.aspect_ratio = cbox_gs_aspect->GetSelection() + 1;

--- a/rpcs3/config.h
+++ b/rpcs3/config.h
@@ -50,8 +50,8 @@ enum class rsx_renderer_type
 {
 	Null,
 	OpenGL,
-	DX12,
-	Vulkan
+	Vulkan,
+	DX12
 };
 
 enum class rsx_aspect_ratio
@@ -93,8 +93,8 @@ namespace convert
 			{
 			case rsx_renderer_type::Null: return "Null";
 			case rsx_renderer_type::OpenGL: return "OpenGL";
-			case rsx_renderer_type::DX12: return "DX12";
 			case rsx_renderer_type::Vulkan: return "Vulkan";
+			case rsx_renderer_type::DX12: return "DX12";
 			}
 
 			return "Unknown";
@@ -112,11 +112,11 @@ namespace convert
 			if (value == "OpenGL")
 				return rsx_renderer_type::OpenGL;
 
-			if (value == "DX12")
-				return rsx_renderer_type::DX12;
-
 			if (value == "Vulkan")
 				return rsx_renderer_type::Vulkan;
+
+			if (value == "DX12")
+				return rsx_renderer_type::DX12;
 
 			return rsx_renderer_type::Null;
 		}


### PR DESCRIPTION
Hotfix for #1584

In the settings window, if another value isn't appended before Vulkan, the emulator will try to use DX12 when set to Vulkan in the Settings window

In W10: Null, OpenGL, DirectX 12, Vulkan
Not in W10: Null, OpenGL, Vulkan

When DirectX 12 is missing and Vulkan is set, the emulator tries to run DirectX 12. As is isn't compatible with the host OS, it crashed the emulator with an unhandled exception.