### PR TITLE
Vulkan: Use a common descriptor layout for all program

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -32,7 +32,7 @@ void VKFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 	OS << "#version 420" << std::endl;
 	OS << "#extension GL_ARB_separate_shader_objects: enable" << std::endl << std::endl;
 
-	OS << "layout(std140, set=1, binding = 0) uniform ScaleOffsetBuffer" << std::endl;
+	OS << "layout(std140, set=0, binding = 0) uniform ScaleOffsetBuffer" << std::endl;
 	OS << "{" << std::endl;
 	OS << "	mat4 scaleOffsetMat;" << std::endl;
 	OS << "	float fog_param0;" << std::endl;
@@ -110,11 +110,11 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 			inputs.push_back(in);
 
-			OS << "layout(set=1, binding=" << location++ << ") uniform " << samplerType << " " << PI.name << ";" << std::endl;
+			OS << "layout(set=0, binding=" << 19 + location++ << ") uniform " << samplerType << " " << PI.name << ";" << std::endl;
 		}
 	}
 
-	OS << "layout(std140, set=1, binding = 1) uniform FragmentConstantsBuffer" << std::endl;
+	OS << "layout(std140, set = 0, binding = 2) uniform FragmentConstantsBuffer" << std::endl;
 	OS << "{" << std::endl;
 
 	for (const ParamType& PT : m_parr.params[PF_PARAM_UNIFORM])

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -44,7 +44,7 @@ namespace vk
 		result.device_local = VK_MAX_MEMORY_TYPES;
 		result.host_visible_coherent = VK_MAX_MEMORY_TYPES;
 
-		for (int i = 0; i < VK_MAX_MEMORY_TYPES; i++)
+		for (int i = 0; i < memory_properties.memoryTypeCount; i++)
 		{
 			bool is_device_local = !!(memory_properties.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 			if (is_device_local)

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1346,8 +1346,8 @@ namespace vk
 				VkShaderModule vs, fs;
 				VkPipeline pipeline_handle = nullptr;
 
-				VkDescriptorSetLayout descriptor_layouts[2];;
-				VkDescriptorSet descriptor_sets[2];
+				VkDescriptorSetLayout descriptor_layouts;
+				VkDescriptorSet descriptor_sets;
 				VkPipelineLayout pipeline_layout;
 
 				int num_targets = 1;
@@ -1395,7 +1395,6 @@ namespace vk
 			void set_primitive_restart(VkBool32 state);
 			
 			void init_descriptor_layout();
-			void update_descriptors();
 			void destroy_descriptors();
 
 			void set_draw_buffer_count(u8 draw_buffers);
@@ -1404,12 +1403,15 @@ namespace vk
 
 			void use(vk::command_buffer& commands, VkRenderPass pass, u32 subpass);
 
-			bool has_uniform(program_domain domain, std::string uniform_name);
-			bool bind_uniform(program_domain domain, std::string uniform_name);
-			bool bind_uniform(program_domain domain, std::string uniform_name, vk::texture &_texture);
-			bool bind_uniform(program_domain domain, std::string uniform_name, VkBuffer _buffer, VkDeviceSize offset, VkDeviceSize size);
-			bool bind_uniform(program_domain domain, std::string uniform_name, vk::buffer_deprecated &_buffer);
-			bool bind_uniform(program_domain domain, std::string uniform_name, vk::buffer_deprecated &_buffer, bool is_texel_store);
+			bool has_uniform(std::string uniform_name);
+#define VERTEX_BUFFERS_FIRST_BIND_SLOT 3
+#define FRAGMENT_CONSTANT_BUFFERS_BIND_SLOT 2
+#define VERTEX_CONSTANT_BUFFERS_BIND_SLOT 1
+#define TEXTURES_FIRST_BIND_SLOT 19
+#define SCALE_OFFSET_BIND_SLOT 0
+			void bind_uniform(VkDescriptorImageInfo image_descriptor, std::string uniform_name);
+			void bind_uniform(VkDescriptorBufferInfo buffer_descriptor, uint32_t binding_point);
+			void bind_uniform(const VkBufferView &buffer_view, const std::string &binding_name);
 
 			program& operator = (const program&) = delete;
 			program& operator = (program&& other);

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -280,12 +280,11 @@ VKGSRender::upload_vertex_data()
 		{
 			auto &vertex_info = vertex_arrays_info[index];
 
-			if (!m_program->has_uniform(vk::glsl::glsl_vertex_program, reg_table[index]))
+			if (!m_program->has_uniform(reg_table[index]))
 				continue;
 
 			if (!vertex_info.size) // disabled
 			{
-				m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index]);
 				continue;
 			}
 
@@ -334,7 +333,7 @@ VKGSRender::upload_vertex_data()
 			buffer.set_format(format);
 
 			//Link texture to uniform location
-			m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], buffer, true);
+			m_program->bind_uniform(buffer, reg_table[index]);
 		}
 	}
 
@@ -350,14 +349,13 @@ VKGSRender::upload_vertex_data()
 	{
 		for (int index = 0; index < rsx::limits::vertex_count; ++index)
 		{
-			if (!m_program->has_uniform(vk::glsl::glsl_vertex_program, reg_table[index]))
-				continue;
-		
 			bool enabled = !!(input_mask & (1 << index));
+
+			if (!m_program->has_uniform(reg_table[index]))
+				continue;
 
 			if (!enabled)
 			{
-				m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index]);
 				continue;
 			}
 
@@ -423,7 +421,7 @@ VKGSRender::upload_vertex_data()
 
 				buffer.sub_data(0, data_size, data_ptr);
 				buffer.set_format(format);
-				m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], buffer, true);
+				m_program->bind_uniform(buffer, reg_table[index]);
 			}
 			else if (register_vertex_info[index].size > 0)
 			{
@@ -462,7 +460,7 @@ VKGSRender::upload_vertex_data()
 					buffer.sub_data(0, data_size, data_ptr);
 					buffer.set_format(format);
 
-					m_program->bind_uniform(vk::glsl::glsl_vertex_program, reg_table[index], buffer, true);
+					m_program->bind_uniform(buffer, reg_table[index]);
 					break;
 				}
 				default:

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -30,7 +30,7 @@ void VKVertexDecompilerThread::insertHeader(std::stringstream &OS)
 {
 	OS << "#version 450" << std::endl << std::endl;
 	OS << "#extension GL_ARB_separate_shader_objects : enable" << std::endl;
-	OS << "layout(std140, set=0, binding = 0) uniform ScaleOffsetBuffer" << std::endl;
+	OS << "layout(std140, set = 0, binding = 0) uniform ScaleOffsetBuffer" << std::endl;
 	OS << "{" << std::endl;
 	OS << "	mat4 scaleOffsetMat;" << std::endl;
 	OS << "	float fog_param0;\n";
@@ -81,7 +81,7 @@ void VKVertexDecompilerThread::insertInputs(std::stringstream & OS, const std::v
 
 					this->inputs.push_back(in);
 
-					OS << "layout(set=0, binding=" << location++ << ")" << "	uniform samplerBuffer" << " " << PI.name << "_buffer;" << std::endl;
+					OS << "layout(set = 0, binding=" << 3 + location++ << ")" << "	uniform samplerBuffer" << " " << PI.name << "_buffer;" << std::endl;
 				}
 			}
 		}


### PR DESCRIPTION
This PR uses a common descriptor layout for all shader.
Binding 0 is for scale offset buffer, 1 for vertex constant buffer, 2 for fragment constant buffer,
3 to 18 for vertex buffer, and 19 to 34 to texture buffer.

A common descriptor allow to avoid rebinding descriptors when not necessary. It's also closer to these low level APIs philosophy too.