### PR TITLE
vk: Indexing into mipmap lod is scalar not vector

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
@@ -48,19 +48,19 @@ namespace vk
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE1D_PROJ:
 			return "textureProj($t, $0.x, $1.x)"; // Note: $1.x is bias
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE1D_LOD:
-			return "textureLod($t, $0.x, $1)";
+			return "textureLod($t, $0.x, $1.x)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE2D:
 			return "texture($t, $0.xy)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE2D_PROJ:
 			return "textureProj($t, $0.xyz, $1.x)"; // Note: $1.x is bias
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE2D_LOD:
-			return "textureLod($t, $0.xy, $1)";
+			return "textureLod($t, $0.xy, $1.x)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLECUBE:
 			return "texture($t, $0.xyz)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLECUBE_PROJ:
 			return "textureProj($t, $0.xyzw, $1.x)"; // Note: $1.x is bias
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLECUBE_LOD:
-			return "textureLod($t, $0.xyz, $1)";
+			return "textureLod($t, $0.xyz, $1.x)";
 		case FUNCTION::FUNCTION_DFDX:
 			return "dFdx($0)";
 		case FUNCTION::FUNCTION_DFDY:


### PR DESCRIPTION
Should fix shader generation on vulkan for textureLod calls. This was fixed previously on GL.