### PR TITLE
Vulkan: Avoid recreating render pass and descriptor set

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -89,6 +89,63 @@ namespace vk
 		}
 	}
 
+	/** Maps color_format, depth_stencil_format and color count to an int as below :
+	 * idx = color_count + 5 * depth_stencil_idx + 15 * color_format_idx
+	 * This should perform a 1:1 mapping
+	 */
+
+	size_t get_render_pass_location(VkFormat color_format, VkFormat depth_stencil_format, u8 color_count)
+	{
+		size_t color_format_idx = 0;
+		size_t depth_format_idx = 0;
+
+		Expects(color_count < 5);
+
+		switch (color_format)
+		{
+		case VK_FORMAT_R5G6B5_UNORM_PACK16:
+			color_format_idx = 0;
+			break;
+		case VK_FORMAT_B8G8R8A8_UNORM:
+			color_format_idx = 1;
+			break;
+		case VK_FORMAT_R16G16B16A16_SFLOAT:
+			color_format_idx = 2;
+			break;
+		case VK_FORMAT_R32G32B32A32_SFLOAT:
+			color_format_idx = 3;
+			break;
+		case VK_FORMAT_R8_UINT:
+			color_format_idx = 4;
+			break;
+		case VK_FORMAT_R8G8_UINT:
+			color_format_idx = 5;
+			break;
+		case VK_FORMAT_A1R5G5B5_UNORM_PACK16:
+			color_format_idx = 6;
+			break;
+		case VK_FORMAT_R32_SFLOAT:
+			color_format_idx = 7;
+			break;
+		}
+
+		switch (depth_stencil_format)
+		{
+		case VK_FORMAT_D16_UNORM:
+			depth_format_idx = 0;
+			break;
+		case VK_FORMAT_D24_UNORM_S8_UINT:
+		case VK_FORMAT_D32_SFLOAT_S8_UINT:
+			depth_format_idx = 1;
+			break;
+		case VK_FORMAT_UNDEFINED:
+			depth_format_idx = 2;
+			break;
+		}
+
+		return color_count + 5 * depth_format_idx + 5 * 3 * color_format_idx;
+	}
+
 	std::vector<u8> get_draw_buffers(rsx::surface_target fmt)
 	{
 		switch (fmt)
@@ -146,6 +203,87 @@ namespace vk
 		default:
 			throw EXCEPTION("Unknown blend op: 0x%X", op);
 		}
+	}
+}
+
+
+namespace
+{
+	VkRenderPass precompute_render_pass(VkDevice dev, VkFormat color_format, u8 number_of_color_surface, VkFormat depth_format)
+	{
+		/* Describe a render pass and framebuffer attachments */
+		std::vector<VkAttachmentDescription> attachments = {};
+		std::vector<VkAttachmentReference> attachment_references;
+
+		VkAttachmentDescription color_attachement_description = {};
+		color_attachement_description.format = color_format;
+		color_attachement_description.samples = VK_SAMPLE_COUNT_1_BIT;
+		color_attachement_description.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+		color_attachement_description.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+		color_attachement_description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+		color_attachement_description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+		color_attachement_description.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		color_attachement_description.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		for (u32 i = 0; i < number_of_color_surface; ++i)
+		{
+			attachments.push_back(color_attachement_description);
+			attachment_references.push_back({ i, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL });
+		}
+
+		if (depth_format != VK_FORMAT_UNDEFINED)
+		{
+			VkAttachmentDescription depth_attachement_description = {};
+			depth_attachement_description.format = depth_format;
+			depth_attachement_description.samples = VK_SAMPLE_COUNT_1_BIT;
+			depth_attachement_description.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+			depth_attachement_description.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+			depth_attachement_description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+			depth_attachement_description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
+			depth_attachement_description.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+			depth_attachement_description.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+			attachments.push_back(depth_attachement_description);
+
+			attachment_references.push_back({ number_of_color_surface, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL });
+		}
+
+		VkSubpassDescription subpass = {};
+		subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+		subpass.colorAttachmentCount = number_of_color_surface;
+		subpass.pColorAttachments = number_of_color_surface > 0 ? attachment_references.data() : nullptr;
+		subpass.pDepthStencilAttachment = depth_format != VK_FORMAT_UNDEFINED ? &attachment_references.back() : nullptr;
+
+		VkRenderPassCreateInfo rp_info = {};
+		rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+		rp_info.attachmentCount = attachments.size();
+		rp_info.pAttachments = attachments.data();
+		rp_info.subpassCount = 1;
+		rp_info.pSubpasses = &subpass;
+
+		VkRenderPass result;
+		CHECK_RESULT(vkCreateRenderPass(dev, &rp_info, NULL, &result));
+		return result;
+	}
+
+	std::array<VkRenderPass, 120> get_precomputed_render_passes(VkDevice dev, const vk::gpu_formats_support &gpu_format_support)
+	{
+		std::array<VkRenderPass, 120> result = {};
+
+		const std::array<VkFormat, 3> depth_format_list = { VK_FORMAT_UNDEFINED, VK_FORMAT_D16_UNORM, gpu_format_support.d24_unorm_s8 ? VK_FORMAT_D24_UNORM_S8_UINT : VK_FORMAT_D32_SFLOAT_S8_UINT };
+		const std::array<VkFormat, 8> color_format_list = { VK_FORMAT_R5G6B5_UNORM_PACK16, VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R16G16B16A16_SFLOAT, VK_FORMAT_R32G32B32A32_SFLOAT, VK_FORMAT_R8_UINT, VK_FORMAT_R8G8_UINT, VK_FORMAT_A1R5G5B5_UNORM_PACK16, VK_FORMAT_R32_SFLOAT };
+
+
+		for (const VkFormat &color_format : color_format_list)
+		{
+			for (const VkFormat &depth_stencil_format : depth_format_list)
+			{
+				for (u8 number_of_draw_buffer = 0; number_of_draw_buffer <= 4; number_of_draw_buffer++)
+				{
+					size_t idx = vk::get_render_pass_location(color_format, depth_stencil_format, number_of_draw_buffer);
+					result[idx] = precompute_render_pass(dev, color_format, number_of_draw_buffer, depth_stencil_format);
+				}
+			}
+		}
+		return result;
 	}
 }
 
@@ -213,6 +351,8 @@ VKGSRender::VKGSRender() : GSRender(frame_type::Vulkan)
 	m_uniform_buffer.reset(new vk::buffer(*m_device, RING_BUFFER_SIZE, m_memory_type_mapping.host_visible_coherent, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0));
 	m_index_buffer_ring_info.init(RING_BUFFER_SIZE);
 	m_index_buffer.reset(new vk::buffer(*m_device, RING_BUFFER_SIZE, m_memory_type_mapping.host_visible_coherent, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, 0));
+
+	m_render_passes = get_precomputed_render_passes(*m_device, m_optimal_tiling_supported_formats);
 }
 
 VKGSRender::~VKGSRender()
@@ -235,8 +375,9 @@ VKGSRender::~VKGSRender()
 	//TODO: Properly destroy shader modules instead of calling clear...
 	m_prog_buffer.clear();
 
-	if (m_render_pass)
-		destroy_render_pass();
+	for (auto &render_pass : m_render_passes)
+		if (render_pass)
+			vkDestroyRenderPass(*m_device, render_pass, nullptr);
 
 	m_command_buffer.destroy();
 	m_command_buffer_pool.destroy();
@@ -375,9 +516,15 @@ namespace
 
 void VKGSRender::end()
 {
+	size_t idx = vk::get_render_pass_location(
+		vk::get_compatible_surface_format(m_surface.color_format),
+		vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, m_surface.depth_format),
+		(u8)vk::get_draw_buffers(rsx::to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET])).size());
+	VkRenderPass current_render_pass = m_render_passes[idx];
+
 	VkRenderPassBeginInfo rp_begin = {};
 	rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-	rp_begin.renderPass = m_render_pass;
+	rp_begin.renderPass = current_render_pass;
 	rp_begin.framebuffer = m_framebuffer;
 	rp_begin.renderArea.offset.x = 0;
 	rp_begin.renderArea.offset.y = 0;
@@ -406,7 +553,7 @@ void VKGSRender::end()
 	auto upload_info = upload_vertex_data();
 
 	m_program->set_primitive_topology(std::get<0>(upload_info));
-	m_program->use(m_command_buffer, m_render_pass, 0);
+	m_program->use(m_command_buffer, current_render_pass, 0);
 	
 	if (!std::get<1>(upload_info))
 		vkCmdDraw(m_command_buffer, vertex_draw_count, 1, 0, 0);
@@ -600,74 +747,6 @@ bool VKGSRender::do_method(u32 cmd, u32 arg)
 	default:
 		return false;
 	}
-}
-
-void VKGSRender::init_render_pass(VkFormat surface_format, VkFormat depth_format, u8 num_draw_buffers, u8 *draw_buffers)
-{
-	//TODO: Create buffers as requested by the game. Render to swapchain for now..
-	/* Describe a render pass and framebuffer attachments */
-	std::array<VkAttachmentDescription, 2> attachments;
-
-	attachments[0].format = surface_format;
-	attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
-	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;							//Set to clear removes warnings about empty contents after flip; overwrites previous calls
-	attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-	attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[0].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;	//PRESENT_SRC_KHR??
-	attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-	attachments[1].format = depth_format;								/* Depth buffer format. Should be more elegant than this */
-	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-	VkAttachmentReference template_color_reference = {};
-	template_color_reference.attachment = VK_ATTACHMENT_UNUSED;
-	template_color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-	VkAttachmentReference depth_reference = {};
-	depth_reference.attachment = num_draw_buffers;
-	depth_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-	//Fill in draw_buffers information...
-	std::array<VkAttachmentDescription, 4> real_attachments;
-	std::array<VkAttachmentReference, 4> color_references;
-
-	for (int i = 0; i < num_draw_buffers; ++i)
-	{
-		real_attachments[i] = attachments[0];
-		
-		color_references[i] = template_color_reference;
-		color_references[i].attachment = (draw_buffers)? draw_buffers[i]: i;
-	}
-
-	real_attachments[num_draw_buffers] = attachments[1];
-
-	VkSubpassDescription subpass = {};
-	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-	subpass.colorAttachmentCount = num_draw_buffers;
-	subpass.pColorAttachments = num_draw_buffers? color_references.data() : nullptr;
-	subpass.pDepthStencilAttachment = &depth_reference;
-
-	VkRenderPassCreateInfo rp_info = {};
-	rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-	rp_info.attachmentCount = num_draw_buffers + 1;
-	rp_info.pAttachments = real_attachments.data();
-	rp_info.subpassCount = 1;
-	rp_info.pSubpasses = &subpass;
-
-	CHECK_RESULT(vkCreateRenderPass((*m_device), &rp_info, NULL, &m_render_pass));
-}
-
-void VKGSRender::destroy_render_pass()
-{
-	vkDestroyRenderPass((*m_device), m_render_pass, nullptr);
-	m_render_pass = nullptr;
 }
 
 bool VKGSRender::load_program()
@@ -874,21 +953,10 @@ void VKGSRender::prepare_rtts()
 		fbo_images.push_back(depth_image);
 	}
 
-	if (reconfigure_render_pass)
-	{
-		//Create render pass with draw_buffers information
-		//Somewhat simliar to glDrawBuffers
+	size_t idx = vk::get_render_pass_location(vk::get_compatible_surface_format(m_surface.color_format), vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, m_surface.depth_format), (u8)draw_buffers.size());
+	VkRenderPass current_render_pass = m_render_passes[idx];
 
-		if (m_render_pass)
-			destroy_render_pass();
-
-		init_render_pass(vk::get_compatible_surface_format(m_surface.color_format),
-			vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, m_surface.depth_format),
-			(u8)draw_buffers.size(),
-			draw_buffers.data());
-	}
-
-	m_framebuffer.create((*m_device), m_render_pass, fbo_images.data(), fbo_images.size(),
+	m_framebuffer.create((*m_device), current_render_pass, fbo_images.data(), fbo_images.size(),
 						clip_width, clip_height);
 
 	m_draw_buffers_count = draw_buffers.size();
@@ -971,62 +1039,59 @@ void VKGSRender::flip(int buffer)
 	present.pWaitSemaphores = &m_present_semaphore;
 	present.waitSemaphoreCount = 1;
 
-	if (m_render_pass)
+	begin_command_buffer_recording();
+
+	if (m_present_semaphore)
 	{
-		begin_command_buffer_recording();
+		//Blit contents to screen..
+		VkImage image_to_flip = nullptr;
 
-		if (m_present_semaphore)
-		{
-			//Blit contents to screen..
-			VkImage image_to_flip = nullptr;
-
-			if (std::get<1>(m_rtts.m_bound_render_targets[0]) != nullptr)
-				image_to_flip = (*std::get<1>(m_rtts.m_bound_render_targets[0]));
-			else
-				image_to_flip = (*std::get<1>(m_rtts.m_bound_render_targets[1]));
-
-			VkImage target_image = m_swap_chain->get_swap_chain_image(m_current_present_image);
-			vk::copy_scaled_image(m_command_buffer, image_to_flip, target_image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-									buffer_width, buffer_height, aspect_ratio.width, aspect_ratio.height, 1, VK_IMAGE_ASPECT_COLOR_BIT);
-		}
+		if (std::get<1>(m_rtts.m_bound_render_targets[0]) != nullptr)
+			image_to_flip = (*std::get<1>(m_rtts.m_bound_render_targets[0]));
 		else
-		{
-			//No draw call was issued!
-			//TODO: Properly clear the background to rsx value
-			m_swap_chain->acquireNextImageKHR((*m_device), (*m_swap_chain), ~0ULL, VK_NULL_HANDLE, VK_NULL_HANDLE, &next_image_temp);
+			image_to_flip = (*std::get<1>(m_rtts.m_bound_render_targets[1]));
 
-			VkImageSubresourceRange range = vk::default_image_subresource_range();
-			VkClearColorValue clear_black = { 0 };
-			vkCmdClearColorImage(m_command_buffer, m_swap_chain->get_swap_chain_image(next_image_temp), VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, &clear_black, 1, &range);
-			
-			present.pImageIndices = &next_image_temp;
-			present.waitSemaphoreCount = 0;
-		}
+		VkImage target_image = m_swap_chain->get_swap_chain_image(m_current_present_image);
+		vk::copy_scaled_image(m_command_buffer, image_to_flip, target_image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+			buffer_width, buffer_height, aspect_ratio.width, aspect_ratio.height, 1, VK_IMAGE_ASPECT_COLOR_BIT);
+	}
+	else
+	{
+		//No draw call was issued!
+		//TODO: Properly clear the background to rsx value
+		m_swap_chain->acquireNextImageKHR((*m_device), (*m_swap_chain), ~0ULL, VK_NULL_HANDLE, VK_NULL_HANDLE, &next_image_temp);
 
-		end_command_buffer_recording();
-		execute_command_buffer(false);
+		VkImageSubresourceRange range = vk::default_image_subresource_range();
+		VkClearColorValue clear_black = { 0 };
+		vkCmdClearColorImage(m_command_buffer, m_swap_chain->get_swap_chain_image(next_image_temp), VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, &clear_black, 1, &range);
 
-		//Check if anything is waiting in queue and wait for it if possible..
-		if (m_submit_fence)
-		{
-			CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
+		present.pImageIndices = &next_image_temp;
+		present.waitSemaphoreCount = 0;
+	}
 
-			vkDestroyFence((*m_device), m_submit_fence, nullptr);
-			m_submit_fence = nullptr;
+	end_command_buffer_recording();
+	execute_command_buffer(false);
 
-			CHECK_RESULT(vkResetCommandBuffer(m_command_buffer, 0));
-		}
+	//Check if anything is waiting in queue and wait for it if possible..
+	if (m_submit_fence)
+	{
+		CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
 
-		CHECK_RESULT(m_swap_chain->queuePresentKHR(m_swap_chain->get_present_queue(), &present));
-		CHECK_RESULT(vkQueueWaitIdle(m_swap_chain->get_present_queue()));
+		vkDestroyFence((*m_device), m_submit_fence, nullptr);
+		m_submit_fence = nullptr;
 
-		m_uniform_buffer_ring_info.m_get_pos = m_uniform_buffer_ring_info.get_current_put_pos_minus_one();
-		m_index_buffer_ring_info.m_get_pos = m_index_buffer_ring_info.get_current_put_pos_minus_one();
-		if (m_present_semaphore)
-		{
-			vkDestroySemaphore((*m_device), m_present_semaphore, nullptr);
-			m_present_semaphore = nullptr;
-		}
+		CHECK_RESULT(vkResetCommandBuffer(m_command_buffer, 0));
+	}
+
+	CHECK_RESULT(m_swap_chain->queuePresentKHR(m_swap_chain->get_present_queue(), &present));
+	CHECK_RESULT(vkQueueWaitIdle(m_swap_chain->get_present_queue()));
+
+	m_uniform_buffer_ring_info.m_get_pos = m_uniform_buffer_ring_info.get_current_put_pos_minus_one();
+	m_index_buffer_ring_info.m_get_pos = m_index_buffer_ring_info.get_current_put_pos_minus_one();
+	if (m_present_semaphore)
+	{
+		vkDestroySemaphore((*m_device), m_present_semaphore, nullptr);
+		m_present_semaphore = nullptr;
 	}
 
 	//Feed back damaged resources to the main texture cache for management...

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -141,6 +141,10 @@ private:
 
 
 	std::array<VkRenderPass, 120> m_render_passes;
+	VkDescriptorSetLayout descriptor_layouts;
+	VkDescriptorSet descriptor_sets;
+	VkPipelineLayout pipeline_layout;
+	vk::descriptor_pool descriptor_pool;
 
 	u32 m_draw_calls = 0;
 	

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -139,9 +139,9 @@ private:
 	bool recording = false;
 	bool dirty_frame = true;
 
-	//Single render pass
-	VkRenderPass m_render_pass = nullptr;
-	
+
+	std::array<VkRenderPass, 120> m_render_passes;
+
 	u32 m_draw_calls = 0;
 	
 	u8 m_draw_buffers_count = 0;
@@ -153,8 +153,6 @@ public:
 
 private:
 	void clear_surface(u32 mask);
-	void init_render_pass(VkFormat surface_format, VkFormat depth_format, u8 num_draw_buffers, u8 *draw_buffers);
-	void destroy_render_pass();
 	void execute_command_buffer(bool wait);
 	void begin_command_buffer_recording();
 	void end_command_buffer_recording();

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -68,6 +68,7 @@ namespace vk
 
 	VkFormat get_compatible_sampler_format(u32 format, VkComponentMapping& mapping, u8 swizzle_mask=0);
 	VkFormat get_compatible_surface_format(rsx::surface_color_format color_format);
+	size_t get_render_pass_location(VkFormat color_surface_format, VkFormat depth_stencil_format, u8 color_surface_count);
 
 	struct memory_type_mapping
 	{

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1347,10 +1347,6 @@ namespace vk
 				VkShaderModule vs, fs;
 				VkPipeline pipeline_handle = nullptr;
 
-				VkDescriptorSetLayout descriptor_layouts;
-				VkDescriptorSet descriptor_sets;
-				VkPipelineLayout pipeline_layout;
-
 				int num_targets = 1;
 
 				bool dirty;
@@ -1362,7 +1358,6 @@ namespace vk
 
 			vk::render_device *device = nullptr;
 			std::vector<program_input> uniforms;			
-			vk::descriptor_pool descriptor_pool;
 
 			void init_pipeline();
 
@@ -1394,15 +1389,12 @@ namespace vk
 			void set_blend_op(int num_targets, u8* targets, VkBlendOp* color_ops, VkBlendOp* alpha_ops);
 			void set_blend_op(int num_targets, u8 * targets, VkBlendOp color_op, VkBlendOp alpha_op);
 			void set_primitive_restart(VkBool32 state);
-			
-			void init_descriptor_layout();
-			void destroy_descriptors();
 
 			void set_draw_buffer_count(u8 draw_buffers);
 
 			program& load_uniforms(program_domain domain, std::vector<program_input>& inputs);
 
-			void use(vk::command_buffer& commands, VkRenderPass pass, u32 subpass);
+			void use(vk::command_buffer& commands, VkRenderPass pass, VkPipelineLayout pipeline_layout, VkDescriptorSet descriptor_set);
 
 			bool has_uniform(std::string uniform_name);
 #define VERTEX_BUFFERS_FIRST_BIND_SLOT 3
@@ -1410,9 +1402,9 @@ namespace vk
 #define VERTEX_CONSTANT_BUFFERS_BIND_SLOT 1
 #define TEXTURES_FIRST_BIND_SLOT 19
 #define SCALE_OFFSET_BIND_SLOT 0
-			void bind_uniform(VkDescriptorImageInfo image_descriptor, std::string uniform_name);
-			void bind_uniform(VkDescriptorBufferInfo buffer_descriptor, uint32_t binding_point);
-			void bind_uniform(const VkBufferView &buffer_view, const std::string &binding_name);
+			void bind_uniform(VkDescriptorImageInfo image_descriptor, std::string uniform_name, VkDescriptorSet &descriptor_set);
+			void bind_uniform(VkDescriptorBufferInfo buffer_descriptor, uint32_t binding_point, VkDescriptorSet &descriptor_set);
+			void bind_uniform(const VkBufferView &buffer_view, const std::string &binding_name, VkDescriptorSet &descriptor_set);
 
 			program& operator = (const program&) = delete;
 			program& operator = (program&& other);

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -333,7 +333,7 @@ VKGSRender::upload_vertex_data()
 			buffer.set_format(format);
 
 			//Link texture to uniform location
-			m_program->bind_uniform(buffer, reg_table[index]);
+			m_program->bind_uniform(buffer, reg_table[index], descriptor_sets);
 		}
 	}
 
@@ -421,7 +421,7 @@ VKGSRender::upload_vertex_data()
 
 				buffer.sub_data(0, data_size, data_ptr);
 				buffer.set_format(format);
-				m_program->bind_uniform(buffer, reg_table[index]);
+				m_program->bind_uniform(buffer, reg_table[index], descriptor_sets);
 			}
 			else if (register_vertex_info[index].size > 0)
 			{
@@ -460,7 +460,7 @@ VKGSRender::upload_vertex_data()
 					buffer.sub_data(0, data_size, data_ptr);
 					buffer.set_format(format);
 
-					m_program->bind_uniform(buffer, reg_table[index]);
+					m_program->bind_uniform(buffer, reg_table[index], descriptor_sets);
 					break;
 				}
 				default:


### PR DESCRIPTION
This PR creates all possible render pass combinaison (it sounds like a lot but there's actually 120 combinaisons possible : there's 2 (+ 1 for disabled) depth format and 8 color format, and there can be between 0 and 4 color format enabled.

It also moves descriptor set storage/creation/... in VKGSRender instead of program which avoid recreating them each time a program is used.

As a side effect https://github.com/RPCS3/rpcs3/issues/1581 seems to be fixed although I need confirmation.