### PR TITLE
Removing wx dependencies from Crypto/unself.cpp.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
 # Auto detect text files and perform LF normalization
-# * text=auto
+* text=auto
 
 # Source files
 *.c text
-# *.cpp text
+*.cpp text
 *.h text
 
 # Windows CRLF files

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,10 +7,10 @@
 *.h text
 
 # Windows CRLF files
-*.sln text eol=crlf
-*.vcxproj text eol=crlf
-*.vcxproj.filters text eol=crlf
-*.vcxproj.user text eol=crlf
+*.sln text eol=lf
+*.vcxproj text eol=lf
+*.vcxproj.filters text eol=lf
+*.vcxproj.user text eol=lf
 
 
 # Custom for Visual Studio

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 
 # Source files
 *.c text
-*.cpp text
+# *.cpp text
 *.h text
 
 # Windows CRLF files

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,10 +7,10 @@
 *.h text
 
 # Windows CRLF files
-*.sln text eol=crlf
-*.vcxproj text eol=crlf
-*.vcxproj.filters text eol=crlf
-*.vcxproj.user text eol=crlf
+#*.sln text eol=crlf
+#*.vcxproj text eol=crlf
+#*.vcxproj.filters text eol=crlf
+#*.vcxproj.user text eol=crlf
 
 
 # Custom for Visual Studio

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+# * text=auto
 
 # Source files
 *.c text
@@ -7,10 +7,10 @@
 *.h text
 
 # Windows CRLF files
-*.sln text eol=lf
-*.vcxproj text eol=lf
-*.vcxproj.filters text eol=lf
-*.vcxproj.user text eol=lf
+*.sln text eol=crlf
+*.vcxproj text eol=crlf
+*.vcxproj.filters text eol=crlf
+*.vcxproj.user text eol=crlf
 
 
 # Custom for Visual Studio

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,10 +7,10 @@
 *.h text
 
 # Windows CRLF files
-#*.sln text eol=crlf
-#*.vcxproj text eol=crlf
-#*.vcxproj.filters text eol=crlf
-#*.vcxproj.user text eol=crlf
+*.sln text eol=crlf
+*.vcxproj text eol=crlf
+*.vcxproj.filters text eol=crlf
+*.vcxproj.user text eol=crlf
 
 
 # Custom for Visual Studio

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,13 @@
 *.cpp text
 *.h text
 
+# Windows CRLF files
+*.sln text eol=crlf
+*.vcxproj text eol=crlf
+*.vcxproj.filters text eol=crlf
+*.vcxproj.user text eol=crlf
+
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,11 +7,6 @@
 *.h text
 
 # Windows CRLF files
-*.sln text eol=crlf
-*.vcxproj text eol=crlf
-*.vcxproj.filters text eol=crlf
-*.vcxproj.user text eol=crlf
-
 
 # Custom for Visual Studio
 *.cs     diff=csharp

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Source files
+*.c text
+*.cpp text
+*.h text
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -1152,6 +1152,7 @@ bool SELFDecrypter::MakeElf(const std::string& elf, bool isElf32)
 				if (meta_shdr[i].compressed == 2)
 				{
 					/// Removed all wxWidget dependent code. Replaced with zlib functions.
+					/// Also changed local mallocs to unique_ptrs.
 
 					// Store the length in writeable memory space.
 					std::unique_ptr<uLongf> decomp_buf_length(new uLongf);

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -9,7 +9,7 @@
 #pragma warning(disable : 4996)
 
 // TODO: Still reliant on wxWidgets for zlib functions. Alternative solutions?
-#include <wxWidgets/src/zlib/zlib.h>
+#include "wxWidgets/src/zlib/zlib.h"
 #pragma warning(pop)
 
 force_inline u8 Read8(vfsStream& f)


### PR DESCRIPTION
A few concerns to bring up:

- [ ] Still includes zlib from within wxWidgets, but at least the wxStream references are gone.
- [ ] Changed type of one variable way down below - not sure what effect this has.
- [ ] Accidentally included my gitattributes file. Oops! Need to know how to remove that from the PR.
- [ ] Initial test on MakeElf seems to work, but might need more rigorous tests.
- [ ] Code review from devs.

Other than that, it should be good to go.
