### PR TITLE
Slims down minidx9 to keep XAudio2_7 files only

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 	path = llvm
 	url = https://github.com/llvm-mirror/llvm
 	branch = release_36
-[submodule "minidx9"]
-	path = 3rdparty/minidx9
-	url = https://github.com/hrydgard/minidx9.git
 [submodule "rsx_program_decompiler"]
 	path = rsx_program_decompiler
 	url = https://github.com/RPCS3/rsx_program_decompiler

--- a/3rdparty/XAudio2_7/XAudio2.h
+++ b/3rdparty/XAudio2_7/XAudio2.h
@@ -1,0 +1,1282 @@
+/**************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * File:    xaudio2.h
+ * Content: Declarations for the XAudio2 game audio API.
+ *
+ **************************************************************************/
+
+#ifndef __XAUDIO2_INCLUDED__
+#define __XAUDIO2_INCLUDED__
+
+
+/**************************************************************************
+ *
+ * XAudio2 COM object class and interface IDs.
+ *
+ **************************************************************************/
+
+#include <comdecl.h>        // For DEFINE_CLSID and DEFINE_IID
+
+// XAudio 2.0 (March 2008 SDK)
+//DEFINE_CLSID(XAudio2, fac23f48, 31f5, 45a8, b4, 9b, 52, 25, d6, 14, 01, aa);
+//DEFINE_CLSID(XAudio2_Debug, fac23f48, 31f5, 45a8, b4, 9b, 52, 25, d6, 14, 01, db);
+
+// XAudio 2.1 (June 2008 SDK)
+//DEFINE_CLSID(XAudio2, e21a7345, eb21, 468e, be, 50, 80, 4d, b9, 7c, f7, 08);
+//DEFINE_CLSID(XAudio2_Debug, f7a76c21, 53d4, 46bb, ac, 53, 8b, 45, 9c, ae, 46, bd);
+
+// XAudio 2.2 (August 2008 SDK)
+//DEFINE_CLSID(XAudio2, b802058a, 464a, 42db, bc, 10, b6, 50, d6, f2, 58, 6a);
+//DEFINE_CLSID(XAudio2_Debug, 97dfb7e7, 5161, 4015, 87, a9, c7, 9e, 6a, 19, 52, cc);
+
+// XAudio 2.3 (November 2008 SDK)
+//DEFINE_CLSID(XAudio2, 4c5e637a, 16c7, 4de3, 9c, 46, 5e, d2, 21, 81, 96, 2d);
+//DEFINE_CLSID(XAudio2_Debug, ef0aa05d, 8075, 4e5d, be, ad, 45, be, 0c, 3c, cb, b3);
+
+// XAudio 2.4 (March 2009 SDK)
+//DEFINE_CLSID(XAudio2, 03219e78, 5bc3, 44d1, b9, 2e, f6, 3d, 89, cc, 65, 26);
+//DEFINE_CLSID(XAudio2_Debug, 4256535c, 1ea4, 4d4b, 8a, d5, f9, db, 76, 2e, ca, 9e);
+
+// XAudio 2.5 (August 2009 SDK)
+//DEFINE_CLSID(XAudio2, 4c9b6dde, 6809, 46e6, a2, 78, 9b, 6a, 97, 58, 86, 70);
+//DEFINE_CLSID(XAudio2_Debug, 715bdd1a, aa82, 436b, b0, fa, 6a, ce, a3, 9b, d0, a1);
+
+// XAudio 2.6 (February 2010 SDK)
+//DEFINE_CLSID(XAudio2, 3eda9b49, 2085, 498b, 9b, b2, 39, a6, 77, 84, 93, de);
+//DEFINE_CLSID(XAudio2_Debug, 47199894, 7cc2, 444d, 98, 73, ce, d2, 56, 2c, c6, 0e);
+
+// XAudio 2.7 (June 2010 SDK)
+DEFINE_CLSID(XAudio2, 5a508685, a254, 4fba, 9b, 82, 9a, 24, b0, 03, 06, af);
+DEFINE_CLSID(XAudio2_Debug, db05ea35, 0329, 4d4b, a5, 3a, 6d, ea, d0, 3d, 38, 52);
+DEFINE_IID(IXAudio2, 8bcf1f58, 9fe7, 4583, 8a, c6, e2, ad, c4, 65, c8, bb);
+
+
+// Ignore the rest of this header if only the GUID definitions were requested
+#ifndef GUID_DEFS_ONLY
+
+#ifdef _XBOX
+    #include <xobjbase.h>   // Xbox COM declarations (IUnknown, etc)
+#else
+    #include <objbase.h>    // Windows COM declarations
+#endif
+
+#include <sal.h>            // Markers for documenting API semantics
+#include <audiodefs.h>      // Basic audio data types and constants
+#include <xma2defs.h>       // Data types and constants for XMA2 audio
+
+// All structures defined in this file use tight field packing
+#pragma pack(push, 1)
+
+
+/**************************************************************************
+ *
+ * XAudio2 constants, flags and error codes.
+ *
+ **************************************************************************/
+
+// Numeric boundary values
+#define XAUDIO2_MAX_BUFFER_BYTES        0x80000000    // Maximum bytes allowed in a source buffer
+#define XAUDIO2_MAX_QUEUED_BUFFERS      64            // Maximum buffers allowed in a voice queue
+#define XAUDIO2_MAX_BUFFERS_SYSTEM      2             // Maximum buffers allowed for system threads (Xbox 360 only)
+#define XAUDIO2_MAX_AUDIO_CHANNELS      64            // Maximum channels in an audio stream
+#define XAUDIO2_MIN_SAMPLE_RATE         1000          // Minimum audio sample rate supported
+#define XAUDIO2_MAX_SAMPLE_RATE         200000        // Maximum audio sample rate supported
+#define XAUDIO2_MAX_VOLUME_LEVEL        16777216.0f   // Maximum acceptable volume level (2^24)
+#define XAUDIO2_MIN_FREQ_RATIO          (1/1024.0f)   // Minimum SetFrequencyRatio argument
+#define XAUDIO2_MAX_FREQ_RATIO          1024.0f       // Maximum MaxFrequencyRatio argument
+#define XAUDIO2_DEFAULT_FREQ_RATIO      2.0f          // Default MaxFrequencyRatio argument
+#define XAUDIO2_MAX_FILTER_ONEOVERQ     1.5f          // Maximum XAUDIO2_FILTER_PARAMETERS.OneOverQ
+#define XAUDIO2_MAX_FILTER_FREQUENCY    1.0f          // Maximum XAUDIO2_FILTER_PARAMETERS.Frequency
+#define XAUDIO2_MAX_LOOP_COUNT          254           // Maximum non-infinite XAUDIO2_BUFFER.LoopCount
+#define XAUDIO2_MAX_INSTANCES           8             // Maximum simultaneous XAudio2 objects on Xbox 360
+
+// For XMA voices on Xbox 360 there is an additional restriction on the MaxFrequencyRatio
+// argument and the voice's sample rate: the product of these numbers cannot exceed 600000
+// for one-channel voices or 300000 for voices with more than one channel.
+#define XAUDIO2_MAX_RATIO_TIMES_RATE_XMA_MONO         600000
+#define XAUDIO2_MAX_RATIO_TIMES_RATE_XMA_MULTICHANNEL 300000
+
+// Numeric values with special meanings
+#define XAUDIO2_COMMIT_NOW              0             // Used as an OperationSet argument
+#define XAUDIO2_COMMIT_ALL              0             // Used in IXAudio2::CommitChanges
+#define XAUDIO2_INVALID_OPSET           (UINT32)(-1)  // Not allowed for OperationSet arguments
+#define XAUDIO2_NO_LOOP_REGION          0             // Used in XAUDIO2_BUFFER.LoopCount
+#define XAUDIO2_LOOP_INFINITE           255           // Used in XAUDIO2_BUFFER.LoopCount
+#define XAUDIO2_DEFAULT_CHANNELS        0             // Used in CreateMasteringVoice
+#define XAUDIO2_DEFAULT_SAMPLERATE      0             // Used in CreateMasteringVoice
+
+// Flags
+#define XAUDIO2_DEBUG_ENGINE            0x0001        // Used in XAudio2Create on Windows only
+#define XAUDIO2_VOICE_NOPITCH           0x0002        // Used in IXAudio2::CreateSourceVoice
+#define XAUDIO2_VOICE_NOSRC             0x0004        // Used in IXAudio2::CreateSourceVoice
+#define XAUDIO2_VOICE_USEFILTER         0x0008        // Used in IXAudio2::CreateSource/SubmixVoice
+#define XAUDIO2_VOICE_MUSIC             0x0010        // Used in IXAudio2::CreateSourceVoice
+#define XAUDIO2_PLAY_TAILS              0x0020        // Used in IXAudio2SourceVoice::Stop
+#define XAUDIO2_END_OF_STREAM           0x0040        // Used in XAUDIO2_BUFFER.Flags
+#define XAUDIO2_SEND_USEFILTER          0x0080        // Used in XAUDIO2_SEND_DESCRIPTOR.Flags
+
+// Default parameters for the built-in filter
+#define XAUDIO2_DEFAULT_FILTER_TYPE     LowPassFilter
+#define XAUDIO2_DEFAULT_FILTER_FREQUENCY XAUDIO2_MAX_FILTER_FREQUENCY
+#define XAUDIO2_DEFAULT_FILTER_ONEOVERQ 1.0f
+
+// Internal XAudio2 constants
+#ifdef _XBOX
+    #define XAUDIO2_QUANTUM_NUMERATOR   2             // On Xbox 360, XAudio2 processes audio
+    #define XAUDIO2_QUANTUM_DENOMINATOR 375           //  in 5.333ms chunks (= 2/375 seconds)
+#else
+    #define XAUDIO2_QUANTUM_NUMERATOR   1             // On Windows, XAudio2 processes audio
+    #define XAUDIO2_QUANTUM_DENOMINATOR 100           //  in 10ms chunks (= 1/100 seconds)
+#endif
+#define XAUDIO2_QUANTUM_MS (1000.0f * XAUDIO2_QUANTUM_NUMERATOR / XAUDIO2_QUANTUM_DENOMINATOR)
+
+// XAudio2 error codes
+#define FACILITY_XAUDIO2 0x896
+#define XAUDIO2_E_INVALID_CALL          0x88960001    // An API call or one of its arguments was illegal
+#define XAUDIO2_E_XMA_DECODER_ERROR     0x88960002    // The XMA hardware suffered an unrecoverable error
+#define XAUDIO2_E_XAPO_CREATION_FAILED  0x88960003    // XAudio2 failed to initialize an XAPO effect
+#define XAUDIO2_E_DEVICE_INVALIDATED    0x88960004    // An audio device became unusable (unplugged, etc)
+
+
+/**************************************************************************
+ *
+ * Forward declarations for the XAudio2 interfaces.
+ *
+ **************************************************************************/
+
+#ifdef __cplusplus
+    #define FWD_DECLARE(x) interface x
+#else
+    #define FWD_DECLARE(x) typedef interface x x
+#endif
+
+FWD_DECLARE(IXAudio2);
+FWD_DECLARE(IXAudio2Voice);
+FWD_DECLARE(IXAudio2SourceVoice);
+FWD_DECLARE(IXAudio2SubmixVoice);
+FWD_DECLARE(IXAudio2MasteringVoice);
+FWD_DECLARE(IXAudio2EngineCallback);
+FWD_DECLARE(IXAudio2VoiceCallback);
+
+
+/**************************************************************************
+ *
+ * XAudio2 structures and enumerations.
+ *
+ **************************************************************************/
+
+// Used in IXAudio2::Initialize
+#ifdef _XBOX
+    typedef enum XAUDIO2_XBOX_HWTHREAD_SPECIFIER
+    {
+        XboxThread0 = 0x01,
+        XboxThread1 = 0x02,
+        XboxThread2 = 0x04,
+        XboxThread3 = 0x08,
+        XboxThread4 = 0x10,
+        XboxThread5 = 0x20,
+        XAUDIO2_ANY_PROCESSOR = XboxThread4,
+        XAUDIO2_DEFAULT_PROCESSOR = XAUDIO2_ANY_PROCESSOR
+    } XAUDIO2_XBOX_HWTHREAD_SPECIFIER, XAUDIO2_PROCESSOR;
+#else
+    typedef enum XAUDIO2_WINDOWS_PROCESSOR_SPECIFIER
+    {
+        Processor1  = 0x00000001,
+        Processor2  = 0x00000002,
+        Processor3  = 0x00000004,
+        Processor4  = 0x00000008,
+        Processor5  = 0x00000010,
+        Processor6  = 0x00000020,
+        Processor7  = 0x00000040,
+        Processor8  = 0x00000080,
+        Processor9  = 0x00000100,
+        Processor10 = 0x00000200,
+        Processor11 = 0x00000400,
+        Processor12 = 0x00000800,
+        Processor13 = 0x00001000,
+        Processor14 = 0x00002000,
+        Processor15 = 0x00004000,
+        Processor16 = 0x00008000,
+        Processor17 = 0x00010000,
+        Processor18 = 0x00020000,
+        Processor19 = 0x00040000,
+        Processor20 = 0x00080000,
+        Processor21 = 0x00100000,
+        Processor22 = 0x00200000,
+        Processor23 = 0x00400000,
+        Processor24 = 0x00800000,
+        Processor25 = 0x01000000,
+        Processor26 = 0x02000000,
+        Processor27 = 0x04000000,
+        Processor28 = 0x08000000,
+        Processor29 = 0x10000000,
+        Processor30 = 0x20000000,
+        Processor31 = 0x40000000,
+        Processor32 = 0x80000000,
+        XAUDIO2_ANY_PROCESSOR = 0xffffffff,
+        XAUDIO2_DEFAULT_PROCESSOR = XAUDIO2_ANY_PROCESSOR
+    } XAUDIO2_WINDOWS_PROCESSOR_SPECIFIER, XAUDIO2_PROCESSOR;
+#endif
+
+// Used in XAUDIO2_DEVICE_DETAILS below to describe the types of applications
+// that the user has specified each device as a default for.  0 means that the
+// device isn't the default for any role.
+typedef enum XAUDIO2_DEVICE_ROLE
+{
+    NotDefaultDevice            = 0x0,
+    DefaultConsoleDevice        = 0x1,
+    DefaultMultimediaDevice     = 0x2,
+    DefaultCommunicationsDevice = 0x4,
+    DefaultGameDevice           = 0x8,
+    GlobalDefaultDevice         = 0xf,
+    InvalidDeviceRole = ~GlobalDefaultDevice
+} XAUDIO2_DEVICE_ROLE;
+
+// Returned by IXAudio2::GetDeviceDetails
+typedef struct XAUDIO2_DEVICE_DETAILS
+{
+    WCHAR DeviceID[256];                // String identifier for the audio device.
+    WCHAR DisplayName[256];             // Friendly name suitable for display to a human.
+    XAUDIO2_DEVICE_ROLE Role;           // Roles that the device should be used for.
+    WAVEFORMATEXTENSIBLE OutputFormat;  // The device's native PCM audio output format.
+} XAUDIO2_DEVICE_DETAILS;
+
+// Returned by IXAudio2Voice::GetVoiceDetails
+typedef struct XAUDIO2_VOICE_DETAILS
+{
+    UINT32 CreationFlags;               // Flags the voice was created with.
+    UINT32 InputChannels;               // Channels in the voice's input audio.
+    UINT32 InputSampleRate;             // Sample rate of the voice's input audio.
+} XAUDIO2_VOICE_DETAILS;
+
+// Used in XAUDIO2_VOICE_SENDS below
+typedef struct XAUDIO2_SEND_DESCRIPTOR
+{
+    UINT32 Flags;                       // Either 0 or XAUDIO2_SEND_USEFILTER.
+    IXAudio2Voice* pOutputVoice;        // This send's destination voice.
+} XAUDIO2_SEND_DESCRIPTOR;
+
+// Used in the voice creation functions and in IXAudio2Voice::SetOutputVoices
+typedef struct XAUDIO2_VOICE_SENDS
+{
+    UINT32 SendCount;                   // Number of sends from this voice.
+    XAUDIO2_SEND_DESCRIPTOR* pSends;    // Array of SendCount send descriptors.
+} XAUDIO2_VOICE_SENDS;
+
+// Used in XAUDIO2_EFFECT_CHAIN below
+typedef struct XAUDIO2_EFFECT_DESCRIPTOR
+{
+    IUnknown* pEffect;                  // Pointer to the effect object's IUnknown interface.
+    BOOL InitialState;                  // TRUE if the effect should begin in the enabled state.
+    UINT32 OutputChannels;              // How many output channels the effect should produce.
+} XAUDIO2_EFFECT_DESCRIPTOR;
+
+// Used in the voice creation functions and in IXAudio2Voice::SetEffectChain
+typedef struct XAUDIO2_EFFECT_CHAIN
+{
+    UINT32 EffectCount;                 // Number of effects in this voice's effect chain.
+    XAUDIO2_EFFECT_DESCRIPTOR* pEffectDescriptors; // Array of effect descriptors.
+} XAUDIO2_EFFECT_CHAIN;
+
+// Used in XAUDIO2_FILTER_PARAMETERS below
+typedef enum XAUDIO2_FILTER_TYPE
+{
+    LowPassFilter,                      // Attenuates frequencies above the cutoff frequency.
+    BandPassFilter,                     // Attenuates frequencies outside a given range.
+    HighPassFilter,                     // Attenuates frequencies below the cutoff frequency.
+    NotchFilter                         // Attenuates frequencies inside a given range.
+} XAUDIO2_FILTER_TYPE;
+
+// Used in IXAudio2Voice::Set/GetFilterParameters and Set/GetOutputFilterParameters
+typedef struct XAUDIO2_FILTER_PARAMETERS
+{
+    XAUDIO2_FILTER_TYPE Type;           // Low-pass, band-pass or high-pass.
+    float Frequency;                    // Radian frequency (2 * sin(pi*CutoffFrequency/SampleRate));
+                                        //  must be >= 0 and <= XAUDIO2_MAX_FILTER_FREQUENCY
+                                        //  (giving a maximum CutoffFrequency of SampleRate/6).
+    float OneOverQ;                     // Reciprocal of the filter's quality factor Q;
+                                        //  must be > 0 and <= XAUDIO2_MAX_FILTER_ONEOVERQ.
+} XAUDIO2_FILTER_PARAMETERS;
+
+// Used in IXAudio2SourceVoice::SubmitSourceBuffer
+typedef struct XAUDIO2_BUFFER
+{
+    UINT32 Flags;                       // Either 0 or XAUDIO2_END_OF_STREAM.
+    UINT32 AudioBytes;                  // Size of the audio data buffer in bytes.
+    const BYTE* pAudioData;             // Pointer to the audio data buffer.
+    UINT32 PlayBegin;                   // First sample in this buffer to be played.
+    UINT32 PlayLength;                  // Length of the region to be played in samples,
+                                        //  or 0 to play the whole buffer.
+    UINT32 LoopBegin;                   // First sample of the region to be looped.
+    UINT32 LoopLength;                  // Length of the desired loop region in samples,
+                                        //  or 0 to loop the entire buffer.
+    UINT32 LoopCount;                   // Number of times to repeat the loop region,
+                                        //  or XAUDIO2_LOOP_INFINITE to loop forever.
+    void* pContext;                     // Context value to be passed back in callbacks.
+} XAUDIO2_BUFFER;
+
+// Used in IXAudio2SourceVoice::SubmitSourceBuffer when submitting XWMA data.
+// NOTE: If an XWMA sound is submitted in more than one buffer, each buffer's
+// pDecodedPacketCumulativeBytes[PacketCount-1] value must be subtracted from
+// all the entries in the next buffer's pDecodedPacketCumulativeBytes array.
+// And whether a sound is submitted in more than one buffer or not, the final
+// buffer of the sound should use the XAUDIO2_END_OF_STREAM flag, or else the
+// client must call IXAudio2SourceVoice::Discontinuity after submitting it.
+typedef struct XAUDIO2_BUFFER_WMA
+{
+    const UINT32* pDecodedPacketCumulativeBytes; // Decoded packet's cumulative size array.
+                                                 //  Each element is the number of bytes accumulated
+                                                 //  when the corresponding XWMA packet is decoded in
+                                                 //  order.  The array must have PacketCount elements.
+    UINT32 PacketCount;                          // Number of XWMA packets submitted. Must be >= 1 and
+                                                 //  divide evenly into XAUDIO2_BUFFER.AudioBytes.
+} XAUDIO2_BUFFER_WMA;
+
+// Returned by IXAudio2SourceVoice::GetState
+typedef struct XAUDIO2_VOICE_STATE
+{
+    void* pCurrentBufferContext;        // The pContext value provided in the XAUDIO2_BUFFER
+                                        //  that is currently being processed, or NULL if
+                                        //  there are no buffers in the queue.
+    UINT32 BuffersQueued;               // Number of buffers currently queued on the voice
+                                        //  (including the one that is being processed).
+    UINT64 SamplesPlayed;               // Total number of samples produced by the voice since
+                                        //  it began processing the current audio stream.
+} XAUDIO2_VOICE_STATE;
+
+// Returned by IXAudio2::GetPerformanceData
+typedef struct XAUDIO2_PERFORMANCE_DATA
+{
+    // CPU usage information
+    UINT64 AudioCyclesSinceLastQuery;   // CPU cycles spent on audio processing since the
+                                        //  last call to StartEngine or GetPerformanceData.
+    UINT64 TotalCyclesSinceLastQuery;   // Total CPU cycles elapsed since the last call
+                                        //  (only counts the CPU XAudio2 is running on).
+    UINT32 MinimumCyclesPerQuantum;     // Fewest CPU cycles spent processing any one
+                                        //  audio quantum since the last call.
+    UINT32 MaximumCyclesPerQuantum;     // Most CPU cycles spent processing any one
+                                        //  audio quantum since the last call.
+
+    // Memory usage information
+    UINT32 MemoryUsageInBytes;          // Total heap space currently in use.
+
+    // Audio latency and glitching information
+    UINT32 CurrentLatencyInSamples;     // Minimum delay from when a sample is read from a
+                                        //  source buffer to when it reaches the speakers.
+    UINT32 GlitchesSinceEngineStarted;  // Audio dropouts since the engine was started.
+
+    // Data about XAudio2's current workload
+    UINT32 ActiveSourceVoiceCount;      // Source voices currently playing.
+    UINT32 TotalSourceVoiceCount;       // Source voices currently existing.
+    UINT32 ActiveSubmixVoiceCount;      // Submix voices currently playing/existing.
+
+    UINT32 ActiveResamplerCount;        // Resample xAPOs currently active.
+    UINT32 ActiveMatrixMixCount;        // MatrixMix xAPOs currently active.
+
+    // Usage of the hardware XMA decoder (Xbox 360 only)
+    UINT32 ActiveXmaSourceVoices;       // Number of source voices decoding XMA data.
+    UINT32 ActiveXmaStreams;            // A voice can use more than one XMA stream.
+} XAUDIO2_PERFORMANCE_DATA;
+
+// Used in IXAudio2::SetDebugConfiguration
+typedef struct XAUDIO2_DEBUG_CONFIGURATION
+{
+    UINT32 TraceMask;                   // Bitmap of enabled debug message types.
+    UINT32 BreakMask;                   // Message types that will break into the debugger.
+    BOOL LogThreadID;                   // Whether to log the thread ID with each message.
+    BOOL LogFileline;                   // Whether to log the source file and line number.
+    BOOL LogFunctionName;               // Whether to log the function name.
+    BOOL LogTiming;                     // Whether to log message timestamps.
+} XAUDIO2_DEBUG_CONFIGURATION;
+
+// Values for the TraceMask and BreakMask bitmaps.  Only ERRORS and WARNINGS
+// are valid in BreakMask.  WARNINGS implies ERRORS, DETAIL implies INFO, and
+// FUNC_CALLS implies API_CALLS.  By default, TraceMask is ERRORS and WARNINGS
+// and all the other settings are zero.
+#define XAUDIO2_LOG_ERRORS     0x0001   // For handled errors with serious effects.
+#define XAUDIO2_LOG_WARNINGS   0x0002   // For handled errors that may be recoverable.
+#define XAUDIO2_LOG_INFO       0x0004   // Informational chit-chat (e.g. state changes).
+#define XAUDIO2_LOG_DETAIL     0x0008   // More detailed chit-chat.
+#define XAUDIO2_LOG_API_CALLS  0x0010   // Public API function entries and exits.
+#define XAUDIO2_LOG_FUNC_CALLS 0x0020   // Internal function entries and exits.
+#define XAUDIO2_LOG_TIMING     0x0040   // Delays detected and other timing data.
+#define XAUDIO2_LOG_LOCKS      0x0080   // Usage of critical sections and mutexes.
+#define XAUDIO2_LOG_MEMORY     0x0100   // Memory heap usage information.
+#define XAUDIO2_LOG_STREAMING  0x1000   // Audio streaming information.
+
+
+/**************************************************************************
+ *
+ * IXAudio2: Top-level XAudio2 COM interface.
+ *
+ **************************************************************************/
+
+// Use default arguments if compiling as C++
+#ifdef __cplusplus
+    #define X2DEFAULT(x) =x
+#else
+    #define X2DEFAULT(x)
+#endif
+
+#undef INTERFACE
+#define INTERFACE IXAudio2
+DECLARE_INTERFACE_(IXAudio2, IUnknown)
+{
+    // NAME: IXAudio2::QueryInterface
+    // DESCRIPTION: Queries for a given COM interface on the XAudio2 object.
+    //              Only IID_IUnknown and IID_IXAudio2 are supported.
+    //
+    // ARGUMENTS:
+    //  riid - IID of the interface to be obtained.
+    //  ppvInterface - Returns a pointer to the requested interface.
+    //
+    STDMETHOD(QueryInterface) (THIS_ REFIID riid, __deref_out void** ppvInterface) PURE;
+
+    // NAME: IXAudio2::AddRef
+    // DESCRIPTION: Adds a reference to the XAudio2 object.
+    //
+    STDMETHOD_(ULONG, AddRef) (THIS) PURE;
+
+    // NAME: IXAudio2::Release
+    // DESCRIPTION: Releases a reference to the XAudio2 object.
+    //
+    STDMETHOD_(ULONG, Release) (THIS) PURE;
+
+    // NAME: IXAudio2::GetDeviceCount
+    // DESCRIPTION: Returns the number of audio output devices available.
+    //
+    // ARGUMENTS:
+    //  pCount - Returns the device count.
+    //
+    STDMETHOD(GetDeviceCount) (THIS_ __out UINT32* pCount) PURE;
+
+    // NAME: IXAudio2::GetDeviceDetails
+    // DESCRIPTION: Returns information about the device with the given index.
+    //
+    // ARGUMENTS:
+    //  Index - Index of the device to be queried.
+    //  pDeviceDetails - Returns the device details.
+    //
+    STDMETHOD(GetDeviceDetails) (THIS_ UINT32 Index, __out XAUDIO2_DEVICE_DETAILS* pDeviceDetails) PURE;
+
+    // NAME: IXAudio2::Initialize
+    // DESCRIPTION: Sets global XAudio2 parameters and prepares it for use.
+    //
+    // ARGUMENTS:
+    //  Flags - Flags specifying the XAudio2 object's behavior.  Currently unused.
+    //  XAudio2Processor - An XAUDIO2_PROCESSOR enumeration value that specifies
+    //  the hardware thread (Xbox) or processor (Windows) that XAudio2 will use.
+    //  The enumeration values are platform-specific; platform-independent code
+    //  can use XAUDIO2_DEFAULT_PROCESSOR to use the default on each platform.
+    //
+    STDMETHOD(Initialize) (THIS_ UINT32 Flags X2DEFAULT(0),
+                           XAUDIO2_PROCESSOR XAudio2Processor X2DEFAULT(XAUDIO2_DEFAULT_PROCESSOR)) PURE;
+
+    // NAME: IXAudio2::RegisterForCallbacks
+    // DESCRIPTION: Adds a new client to receive XAudio2's engine callbacks.
+    //
+    // ARGUMENTS:
+    //  pCallback - Callback interface to be called during each processing pass.
+    //
+    STDMETHOD(RegisterForCallbacks) (__in IXAudio2EngineCallback* pCallback) PURE;
+
+    // NAME: IXAudio2::UnregisterForCallbacks
+    // DESCRIPTION: Removes an existing receiver of XAudio2 engine callbacks.
+    //
+    // ARGUMENTS:
+    //  pCallback - Previously registered callback interface to be removed.
+    //
+    STDMETHOD_(void, UnregisterForCallbacks) (__in IXAudio2EngineCallback* pCallback) PURE;
+
+    // NAME: IXAudio2::CreateSourceVoice
+    // DESCRIPTION: Creates and configures a source voice.
+    //
+    // ARGUMENTS:
+    //  ppSourceVoice - Returns the new object's IXAudio2SourceVoice interface.
+    //  pSourceFormat - Format of the audio that will be fed to the voice.
+    //  Flags - XAUDIO2_VOICE flags specifying the source voice's behavior.
+    //  MaxFrequencyRatio - Maximum SetFrequencyRatio argument to be allowed.
+    //  pCallback - Optional pointer to a client-provided callback interface.
+    //  pSendList - Optional list of voices this voice should send audio to.
+    //  pEffectChain - Optional list of effects to apply to the audio data.
+    //
+    STDMETHOD(CreateSourceVoice) (THIS_ __deref_out IXAudio2SourceVoice** ppSourceVoice,
+                                  __in const WAVEFORMATEX* pSourceFormat,
+                                  UINT32 Flags X2DEFAULT(0),
+                                  float MaxFrequencyRatio X2DEFAULT(XAUDIO2_DEFAULT_FREQ_RATIO),
+                                  __in_opt IXAudio2VoiceCallback* pCallback X2DEFAULT(NULL),
+                                  __in_opt const XAUDIO2_VOICE_SENDS* pSendList X2DEFAULT(NULL),
+                                  __in_opt const XAUDIO2_EFFECT_CHAIN* pEffectChain X2DEFAULT(NULL)) PURE;
+
+    // NAME: IXAudio2::CreateSubmixVoice
+    // DESCRIPTION: Creates and configures a submix voice.
+    //
+    // ARGUMENTS:
+    //  ppSubmixVoice - Returns the new object's IXAudio2SubmixVoice interface.
+    //  InputChannels - Number of channels in this voice's input audio data.
+    //  InputSampleRate - Sample rate of this voice's input audio data.
+    //  Flags - XAUDIO2_VOICE flags specifying the submix voice's behavior.
+    //  ProcessingStage - Arbitrary number that determines the processing order.
+    //  pSendList - Optional list of voices this voice should send audio to.
+    //  pEffectChain - Optional list of effects to apply to the audio data.
+    //
+    STDMETHOD(CreateSubmixVoice) (THIS_ __deref_out IXAudio2SubmixVoice** ppSubmixVoice,
+                                  UINT32 InputChannels, UINT32 InputSampleRate,
+                                  UINT32 Flags X2DEFAULT(0), UINT32 ProcessingStage X2DEFAULT(0),
+                                  __in_opt const XAUDIO2_VOICE_SENDS* pSendList X2DEFAULT(NULL),
+                                  __in_opt const XAUDIO2_EFFECT_CHAIN* pEffectChain X2DEFAULT(NULL)) PURE;
+
+
+    // NAME: IXAudio2::CreateMasteringVoice
+    // DESCRIPTION: Creates and configures a mastering voice.
+    //
+    // ARGUMENTS:
+    //  ppMasteringVoice - Returns the new object's IXAudio2MasteringVoice interface.
+    //  InputChannels - Number of channels in this voice's input audio data.
+    //  InputSampleRate - Sample rate of this voice's input audio data.
+    //  Flags - XAUDIO2_VOICE flags specifying the mastering voice's behavior.
+    //  DeviceIndex - Identifier of the device to receive the output audio.
+    //  pEffectChain - Optional list of effects to apply to the audio data.
+    //
+    STDMETHOD(CreateMasteringVoice) (THIS_ __deref_out IXAudio2MasteringVoice** ppMasteringVoice,
+                                     UINT32 InputChannels X2DEFAULT(XAUDIO2_DEFAULT_CHANNELS),
+                                     UINT32 InputSampleRate X2DEFAULT(XAUDIO2_DEFAULT_SAMPLERATE),
+                                     UINT32 Flags X2DEFAULT(0), UINT32 DeviceIndex X2DEFAULT(0),
+                                     __in_opt const XAUDIO2_EFFECT_CHAIN* pEffectChain X2DEFAULT(NULL)) PURE;
+
+    // NAME: IXAudio2::StartEngine
+    // DESCRIPTION: Creates and starts the audio processing thread.
+    //
+    STDMETHOD(StartEngine) (THIS) PURE;
+
+    // NAME: IXAudio2::StopEngine
+    // DESCRIPTION: Stops and destroys the audio processing thread.
+    //
+    STDMETHOD_(void, StopEngine) (THIS) PURE;
+
+    // NAME: IXAudio2::CommitChanges
+    // DESCRIPTION: Atomically applies a set of operations previously tagged
+    //              with a given identifier.
+    //
+    // ARGUMENTS:
+    //  OperationSet - Identifier of the set of operations to be applied.
+    //
+    STDMETHOD(CommitChanges) (THIS_ UINT32 OperationSet) PURE;
+
+    // NAME: IXAudio2::GetPerformanceData
+    // DESCRIPTION: Returns current resource usage details: memory, CPU, etc.
+    //
+    // ARGUMENTS:
+    //  pPerfData - Returns the performance data structure.
+    //
+    STDMETHOD_(void, GetPerformanceData) (THIS_ __out XAUDIO2_PERFORMANCE_DATA* pPerfData) PURE;
+
+    // NAME: IXAudio2::SetDebugConfiguration
+    // DESCRIPTION: Configures XAudio2's debug output (in debug builds only).
+    //
+    // ARGUMENTS:
+    //  pDebugConfiguration - Structure describing the debug output behavior.
+    //  pReserved - Optional parameter; must be NULL.
+    //
+    STDMETHOD_(void, SetDebugConfiguration) (THIS_ __in_opt const XAUDIO2_DEBUG_CONFIGURATION* pDebugConfiguration,
+                                             __in_opt __reserved void* pReserved X2DEFAULT(NULL)) PURE;
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2Voice: Base voice management interface.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2Voice
+DECLARE_INTERFACE(IXAudio2Voice)
+{
+    // These methods are declared in a macro so that the same declarations
+    // can be used in the derived voice types (IXAudio2SourceVoice, etc).
+
+    #define Declare_IXAudio2Voice_Methods() \
+    \
+    /* NAME: IXAudio2Voice::GetVoiceDetails
+    // DESCRIPTION: Returns the basic characteristics of this voice.
+    //
+    // ARGUMENTS:
+    //  pVoiceDetails - Returns the voice's details.
+    */\
+    STDMETHOD_(void, GetVoiceDetails) (THIS_ __out XAUDIO2_VOICE_DETAILS* pVoiceDetails) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetOutputVoices
+    // DESCRIPTION: Replaces the set of submix/mastering voices that receive
+    //              this voice's output.
+    //
+    // ARGUMENTS:
+    //  pSendList - Optional list of voices this voice should send audio to.
+    */\
+    STDMETHOD(SetOutputVoices) (THIS_ __in_opt const XAUDIO2_VOICE_SENDS* pSendList) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetEffectChain
+    // DESCRIPTION: Replaces this voice's current effect chain with a new one.
+    //
+    // ARGUMENTS:
+    //  pEffectChain - Structure describing the new effect chain to be used.
+    */\
+    STDMETHOD(SetEffectChain) (THIS_ __in_opt const XAUDIO2_EFFECT_CHAIN* pEffectChain) PURE; \
+    \
+    /* NAME: IXAudio2Voice::EnableEffect
+    // DESCRIPTION: Enables an effect in this voice's effect chain.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(EnableEffect) (THIS_ UINT32 EffectIndex, \
+                             UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::DisableEffect
+    // DESCRIPTION: Disables an effect in this voice's effect chain.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(DisableEffect) (THIS_ UINT32 EffectIndex, \
+                              UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetEffectState
+    // DESCRIPTION: Returns the running state of an effect.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  pEnabled - Returns the enabled/disabled state of the given effect.
+    */\
+    STDMETHOD_(void, GetEffectState) (THIS_ UINT32 EffectIndex, __out BOOL* pEnabled) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetEffectParameters
+    // DESCRIPTION: Sets effect-specific parameters.
+    //
+    // REMARKS: Unlike IXAPOParameters::SetParameters, this method may
+    //          be called from any thread.  XAudio2 implements
+    //          appropriate synchronization to copy the parameters to the
+    //          realtime audio processing thread.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  pParameters - Pointer to an effect-specific parameters block.
+    //  ParametersByteSize - Size of the pParameters array  in bytes.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetEffectParameters) (THIS_ UINT32 EffectIndex, \
+                                    __in_bcount(ParametersByteSize) const void* pParameters, \
+                                    UINT32 ParametersByteSize, \
+                                    UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetEffectParameters
+    // DESCRIPTION: Obtains the current effect-specific parameters.
+    //
+    // ARGUMENTS:
+    //  EffectIndex - Index of an effect within this voice's effect chain.
+    //  pParameters - Returns the current values of the effect-specific parameters.
+    //  ParametersByteSize - Size of the pParameters array in bytes.
+    */\
+    STDMETHOD(GetEffectParameters) (THIS_ UINT32 EffectIndex, \
+                                    __out_bcount(ParametersByteSize) void* pParameters, \
+                                    UINT32 ParametersByteSize) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetFilterParameters
+    // DESCRIPTION: Sets this voice's filter parameters.
+    //
+    // ARGUMENTS:
+    //  pParameters - Pointer to the filter's parameter structure.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetFilterParameters) (THIS_ __in const XAUDIO2_FILTER_PARAMETERS* pParameters, \
+                                    UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetFilterParameters
+    // DESCRIPTION: Returns this voice's current filter parameters.
+    //
+    // ARGUMENTS:
+    //  pParameters - Returns the filter parameters.
+    */\
+    STDMETHOD_(void, GetFilterParameters) (THIS_ __out XAUDIO2_FILTER_PARAMETERS* pParameters) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetOutputFilterParameters
+    // DESCRIPTION: Sets the filter parameters on one of this voice's sends.
+    //
+    // ARGUMENTS:
+    //  pDestinationVoice - Destination voice of the send whose filter parameters will be set.
+    //  pParameters - Pointer to the filter's parameter structure.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetOutputFilterParameters) (THIS_ __in_opt IXAudio2Voice* pDestinationVoice, \
+                                          __in const XAUDIO2_FILTER_PARAMETERS* pParameters, \
+                                          UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetOutputFilterParameters
+    // DESCRIPTION: Returns the filter parameters from one of this voice's sends.
+    //
+    // ARGUMENTS:
+    //  pDestinationVoice - Destination voice of the send whose filter parameters will be read.
+    //  pParameters - Returns the filter parameters.
+    */\
+    STDMETHOD_(void, GetOutputFilterParameters) (THIS_ __in_opt IXAudio2Voice* pDestinationVoice, \
+                                                 __out XAUDIO2_FILTER_PARAMETERS* pParameters) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetVolume
+    // DESCRIPTION: Sets this voice's overall volume level.
+    //
+    // ARGUMENTS:
+    //  Volume - New overall volume level to be used, as an amplitude factor.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetVolume) (THIS_ float Volume, \
+                          UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetVolume
+    // DESCRIPTION: Obtains this voice's current overall volume level.
+    //
+    // ARGUMENTS:
+    //  pVolume: Returns the voice's current overall volume level.
+    */\
+    STDMETHOD_(void, GetVolume) (THIS_ __out float* pVolume) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetChannelVolumes
+    // DESCRIPTION: Sets this voice's per-channel volume levels.
+    //
+    // ARGUMENTS:
+    //  Channels - Used to confirm the voice's channel count.
+    //  pVolumes - Array of per-channel volume levels to be used.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetChannelVolumes) (THIS_ UINT32 Channels, __in_ecount(Channels) const float* pVolumes, \
+                                  UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetChannelVolumes
+    // DESCRIPTION: Returns this voice's current per-channel volume levels.
+    //
+    // ARGUMENTS:
+    //  Channels - Used to confirm the voice's channel count.
+    //  pVolumes - Returns an array of the current per-channel volume levels.
+    */\
+    STDMETHOD_(void, GetChannelVolumes) (THIS_ UINT32 Channels, __out_ecount(Channels) float* pVolumes) PURE; \
+    \
+    /* NAME: IXAudio2Voice::SetOutputMatrix
+    // DESCRIPTION: Sets the volume levels used to mix from each channel of this
+    //              voice's output audio to each channel of a given destination
+    //              voice's input audio.
+    //
+    // ARGUMENTS:
+    //  pDestinationVoice - The destination voice whose mix matrix to change.
+    //  SourceChannels - Used to confirm this voice's output channel count
+    //   (the number of channels produced by the last effect in the chain).
+    //  DestinationChannels - Confirms the destination voice's input channels.
+    //  pLevelMatrix - Array of [SourceChannels * DestinationChannels] send
+    //   levels.  The level used to send from source channel S to destination
+    //   channel D should be in pLevelMatrix[S + SourceChannels * D].
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    */\
+    STDMETHOD(SetOutputMatrix) (THIS_ __in_opt IXAudio2Voice* pDestinationVoice, \
+                                UINT32 SourceChannels, UINT32 DestinationChannels, \
+                                __in_ecount(SourceChannels * DestinationChannels) const float* pLevelMatrix, \
+                                UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE; \
+    \
+    /* NAME: IXAudio2Voice::GetOutputMatrix
+    // DESCRIPTION: Obtains the volume levels used to send each channel of this
+    //              voice's output audio to each channel of a given destination
+    //              voice's input audio.
+    //
+    // ARGUMENTS:
+    //  pDestinationVoice - The destination voice whose mix matrix to obtain.
+    //  SourceChannels - Used to confirm this voice's output channel count
+    //   (the number of channels produced by the last effect in the chain).
+    //  DestinationChannels - Confirms the destination voice's input channels.
+    //  pLevelMatrix - Array of send levels, as above.
+    */\
+    STDMETHOD_(void, GetOutputMatrix) (THIS_ __in_opt IXAudio2Voice* pDestinationVoice, \
+                                       UINT32 SourceChannels, UINT32 DestinationChannels, \
+                                       __out_ecount(SourceChannels * DestinationChannels) float* pLevelMatrix) PURE; \
+    \
+    /* NAME: IXAudio2Voice::DestroyVoice
+    // DESCRIPTION: Destroys this voice, stopping it if necessary and removing
+    //              it from the XAudio2 graph.
+    */\
+    STDMETHOD_(void, DestroyVoice) (THIS) PURE
+
+    Declare_IXAudio2Voice_Methods();
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2SourceVoice: Source voice management interface.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2SourceVoice
+DECLARE_INTERFACE_(IXAudio2SourceVoice, IXAudio2Voice)
+{
+    // Methods from IXAudio2Voice base interface
+    Declare_IXAudio2Voice_Methods();
+
+    // NAME: IXAudio2SourceVoice::Start
+    // DESCRIPTION: Makes this voice start consuming and processing audio.
+    //
+    // ARGUMENTS:
+    //  Flags - Flags controlling how the voice should be started.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    //
+    STDMETHOD(Start) (THIS_ UINT32 Flags X2DEFAULT(0), UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE;
+
+    // NAME: IXAudio2SourceVoice::Stop
+    // DESCRIPTION: Makes this voice stop consuming audio.
+    //
+    // ARGUMENTS:
+    //  Flags - Flags controlling how the voice should be stopped.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    //
+    STDMETHOD(Stop) (THIS_ UINT32 Flags X2DEFAULT(0), UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE;
+
+    // NAME: IXAudio2SourceVoice::SubmitSourceBuffer
+    // DESCRIPTION: Adds a new audio buffer to this voice's input queue.
+    //
+    // ARGUMENTS:
+    //  pBuffer - Pointer to the buffer structure to be queued.
+    //  pBufferWMA - Additional structure used only when submitting XWMA data.
+    //
+    STDMETHOD(SubmitSourceBuffer) (THIS_ __in const XAUDIO2_BUFFER* pBuffer, __in_opt const XAUDIO2_BUFFER_WMA* pBufferWMA X2DEFAULT(NULL)) PURE;
+
+    // NAME: IXAudio2SourceVoice::FlushSourceBuffers
+    // DESCRIPTION: Removes all pending audio buffers from this voice's queue.
+    //
+    STDMETHOD(FlushSourceBuffers) (THIS) PURE;
+
+    // NAME: IXAudio2SourceVoice::Discontinuity
+    // DESCRIPTION: Notifies the voice of an intentional break in the stream of
+    //              audio buffers (e.g. the end of a sound), to prevent XAudio2
+    //              from interpreting an empty buffer queue as a glitch.
+    //
+    STDMETHOD(Discontinuity) (THIS) PURE;
+
+    // NAME: IXAudio2SourceVoice::ExitLoop
+    // DESCRIPTION: Breaks out of the current loop when its end is reached.
+    //
+    // ARGUMENTS:
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    //
+    STDMETHOD(ExitLoop) (THIS_ UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE;
+
+    // NAME: IXAudio2SourceVoice::GetState
+    // DESCRIPTION: Returns the number of buffers currently queued on this voice,
+    //              the pContext value associated with the currently processing
+    //              buffer (if any), and other voice state information.
+    //
+    // ARGUMENTS:
+    //  pVoiceState - Returns the state information.
+    //
+    STDMETHOD_(void, GetState) (THIS_ __out XAUDIO2_VOICE_STATE* pVoiceState) PURE;
+
+    // NAME: IXAudio2SourceVoice::SetFrequencyRatio
+    // DESCRIPTION: Sets this voice's frequency adjustment, i.e. its pitch.
+    //
+    // ARGUMENTS:
+    //  Ratio - Frequency change, expressed as source frequency / target frequency.
+    //  OperationSet - Used to identify this call as part of a deferred batch.
+    //
+    STDMETHOD(SetFrequencyRatio) (THIS_ float Ratio,
+                                  UINT32 OperationSet X2DEFAULT(XAUDIO2_COMMIT_NOW)) PURE;
+
+    // NAME: IXAudio2SourceVoice::GetFrequencyRatio
+    // DESCRIPTION: Returns this voice's current frequency adjustment ratio.
+    //
+    // ARGUMENTS:
+    //  pRatio - Returns the frequency adjustment.
+    //
+    STDMETHOD_(void, GetFrequencyRatio) (THIS_ __out float* pRatio) PURE;
+
+    // NAME: IXAudio2SourceVoice::SetSourceSampleRate
+    // DESCRIPTION: Reconfigures this voice to treat its source data as being
+    //              at a different sample rate than the original one specified
+    //              in CreateSourceVoice's pSourceFormat argument.
+    //
+    // ARGUMENTS:
+    //  UINT32 - The intended sample rate of further submitted source data.
+    //
+    STDMETHOD(SetSourceSampleRate) (THIS_ UINT32 NewSourceSampleRate) PURE;
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2SubmixVoice: Submixing voice management interface.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2SubmixVoice
+DECLARE_INTERFACE_(IXAudio2SubmixVoice, IXAudio2Voice)
+{
+    // Methods from IXAudio2Voice base interface
+    Declare_IXAudio2Voice_Methods();
+
+    // There are currently no methods specific to submix voices.
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2MasteringVoice: Mastering voice management interface.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2MasteringVoice
+DECLARE_INTERFACE_(IXAudio2MasteringVoice, IXAudio2Voice)
+{
+    // Methods from IXAudio2Voice base interface
+    Declare_IXAudio2Voice_Methods();
+
+    // There are currently no methods specific to mastering voices.
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2EngineCallback: Client notification interface for engine events.
+ *
+ * REMARKS: Contains methods to notify the client when certain events happen
+ *          in the XAudio2 engine.  This interface should be implemented by
+ *          the client.  XAudio2 will call these methods via the interface
+ *          pointer provided by the client when it calls XAudio2Create or
+ *          IXAudio2::Initialize.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2EngineCallback
+DECLARE_INTERFACE(IXAudio2EngineCallback)
+{
+    // Called by XAudio2 just before an audio processing pass begins.
+    STDMETHOD_(void, OnProcessingPassStart) (THIS) PURE;
+
+    // Called just after an audio processing pass ends.
+    STDMETHOD_(void, OnProcessingPassEnd) (THIS) PURE;
+
+    // Called in the event of a critical system error which requires XAudio2
+    // to be closed down and restarted.  The error code is given in Error.
+    STDMETHOD_(void, OnCriticalError) (THIS_ HRESULT Error) PURE;
+};
+
+
+/**************************************************************************
+ *
+ * IXAudio2VoiceCallback: Client notification interface for voice events.
+ *
+ * REMARKS: Contains methods to notify the client when certain events happen
+ *          in an XAudio2 voice.  This interface should be implemented by the
+ *          client.  XAudio2 will call these methods via an interface pointer
+ *          provided by the client in the IXAudio2::CreateSourceVoice call.
+ *
+ **************************************************************************/
+
+#undef INTERFACE
+#define INTERFACE IXAudio2VoiceCallback
+DECLARE_INTERFACE(IXAudio2VoiceCallback)
+{
+    // Called just before this voice's processing pass begins.
+    STDMETHOD_(void, OnVoiceProcessingPassStart) (THIS_ UINT32 BytesRequired) PURE;
+
+    // Called just after this voice's processing pass ends.
+    STDMETHOD_(void, OnVoiceProcessingPassEnd) (THIS) PURE;
+
+    // Called when this voice has just finished playing a buffer stream
+    // (as marked with the XAUDIO2_END_OF_STREAM flag on the last buffer).
+    STDMETHOD_(void, OnStreamEnd) (THIS) PURE;
+
+    // Called when this voice is about to start processing a new buffer.
+    STDMETHOD_(void, OnBufferStart) (THIS_ void* pBufferContext) PURE;
+
+    // Called when this voice has just finished processing a buffer.
+    // The buffer can now be reused or destroyed.
+    STDMETHOD_(void, OnBufferEnd) (THIS_ void* pBufferContext) PURE;
+
+    // Called when this voice has just reached the end position of a loop.
+    STDMETHOD_(void, OnLoopEnd) (THIS_ void* pBufferContext) PURE;
+
+    // Called in the event of a critical error during voice processing,
+    // such as a failing xAPO or an error from the hardware XMA decoder.
+    // The voice may have to be destroyed and re-created to recover from
+    // the error.  The callback arguments report which buffer was being
+    // processed when the error occurred, and its HRESULT code.
+    STDMETHOD_(void, OnVoiceError) (THIS_ void* pBufferContext, HRESULT Error) PURE;
+};
+
+
+/**************************************************************************
+ *
+ * Macros to make it easier to use the XAudio2 COM interfaces in C code.
+ *
+ **************************************************************************/
+
+#ifndef __cplusplus
+
+// IXAudio2
+#define IXAudio2_QueryInterface(This,riid,ppvInterface) ((This)->lpVtbl->QueryInterface(This,riid,ppvInterface))
+#define IXAudio2_AddRef(This) ((This)->lpVtbl->AddRef(This))
+#define IXAudio2_Release(This) ((This)->lpVtbl->Release(This))
+#define IXAudio2_GetDeviceCount(This,puCount) ((This)->lpVtbl->GetDeviceCount(This,puCount))
+#define IXAudio2_GetDeviceDetails(This,Index,pDeviceDetails) ((This)->lpVtbl->GetDeviceDetails(This,Index,pDeviceDetails))
+#define IXAudio2_Initialize(This,Flags,XAudio2Processor) ((This)->lpVtbl->Initialize(This,Flags,XAudio2Processor))
+#define IXAudio2_CreateSourceVoice(This,ppSourceVoice,pSourceFormat,Flags,MaxFrequencyRatio,pCallback,pSendList,pEffectChain) ((This)->lpVtbl->CreateSourceVoice(This,ppSourceVoice,pSourceFormat,Flags,MaxFrequencyRatio,pCallback,pSendList,pEffectChain))
+#define IXAudio2_CreateSubmixVoice(This,ppSubmixVoice,InputChannels,InputSampleRate,Flags,ProcessingStage,pSendList,pEffectChain) ((This)->lpVtbl->CreateSubmixVoice(This,ppSubmixVoice,InputChannels,InputSampleRate,Flags,ProcessingStage,pSendList,pEffectChain))
+#define IXAudio2_CreateMasteringVoice(This,ppMasteringVoice,InputChannels,InputSampleRate,Flags,DeviceIndex,pEffectChain) ((This)->lpVtbl->CreateMasteringVoice(This,ppMasteringVoice,InputChannels,InputSampleRate,Flags,DeviceIndex,pEffectChain))
+#define IXAudio2_StartEngine(This) ((This)->lpVtbl->StartEngine(This))
+#define IXAudio2_StopEngine(This) ((This)->lpVtbl->StopEngine(This))
+#define IXAudio2_CommitChanges(This,OperationSet) ((This)->lpVtbl->CommitChanges(This,OperationSet))
+#define IXAudio2_GetPerformanceData(This,pPerfData) ((This)->lpVtbl->GetPerformanceData(This,pPerfData))
+#define IXAudio2_SetDebugConfiguration(This,pDebugConfiguration,pReserved) ((This)->lpVtbl->SetDebugConfiguration(This,pDebugConfiguration,pReserved))
+
+// IXAudio2Voice
+#define IXAudio2Voice_GetVoiceDetails(This,pVoiceDetails) ((This)->lpVtbl->GetVoiceDetails(This,pVoiceDetails))
+#define IXAudio2Voice_SetOutputVoices(This,pSendList) ((This)->lpVtbl->SetOutputVoices(This,pSendList))
+#define IXAudio2Voice_SetEffectChain(This,pEffectChain) ((This)->lpVtbl->SetEffectChain(This,pEffectChain))
+#define IXAudio2Voice_EnableEffect(This,EffectIndex,OperationSet) ((This)->lpVtbl->EnableEffect(This,EffectIndex,OperationSet))
+#define IXAudio2Voice_DisableEffect(This,EffectIndex,OperationSet) ((This)->lpVtbl->DisableEffect(This,EffectIndex,OperationSet))
+#define IXAudio2Voice_GetEffectState(This,EffectIndex,pEnabled) ((This)->lpVtbl->GetEffectState(This,EffectIndex,pEnabled))
+#define IXAudio2Voice_SetEffectParameters(This,EffectIndex,pParameters,ParametersByteSize, OperationSet) ((This)->lpVtbl->SetEffectParameters(This,EffectIndex,pParameters,ParametersByteSize,OperationSet))
+#define IXAudio2Voice_GetEffectParameters(This,EffectIndex,pParameters,ParametersByteSize) ((This)->lpVtbl->GetEffectParameters(This,EffectIndex,pParameters,ParametersByteSize))
+#define IXAudio2Voice_SetFilterParameters(This,pParameters,OperationSet) ((This)->lpVtbl->SetFilterParameters(This,pParameters,OperationSet))
+#define IXAudio2Voice_GetFilterParameters(This,pParameters) ((This)->lpVtbl->GetFilterParameters(This,pParameters))
+#define IXAudio2Voice_SetOutputFilterParameters(This,pDestinationVoice,pParameters,OperationSet) ((This)->lpVtbl->SetOutputFilterParameters(This,pDestinationVoice,pParameters,OperationSet))
+#define IXAudio2Voice_GetOutputFilterParameters(This,pDestinationVoice,pParameters) ((This)->lpVtbl->GetOutputFilterParameters(This,pDestinationVoice,pParameters))
+#define IXAudio2Voice_SetVolume(This,Volume,OperationSet) ((This)->lpVtbl->SetVolume(This,Volume,OperationSet))
+#define IXAudio2Voice_GetVolume(This,pVolume) ((This)->lpVtbl->GetVolume(This,pVolume))
+#define IXAudio2Voice_SetChannelVolumes(This,Channels,pVolumes,OperationSet) ((This)->lpVtbl->SetChannelVolumes(This,Channels,pVolumes,OperationSet))
+#define IXAudio2Voice_GetChannelVolumes(This,Channels,pVolumes) ((This)->lpVtbl->GetChannelVolumes(This,Channels,pVolumes))
+#define IXAudio2Voice_SetOutputMatrix(This,pDestinationVoice,SourceChannels,DestinationChannels,pLevelMatrix,OperationSet) ((This)->lpVtbl->SetOutputMatrix(This,pDestinationVoice,SourceChannels,DestinationChannels,pLevelMatrix,OperationSet))
+#define IXAudio2Voice_GetOutputMatrix(This,pDestinationVoice,SourceChannels,DestinationChannels,pLevelMatrix) ((This)->lpVtbl->GetOutputMatrix(This,pDestinationVoice,SourceChannels,DestinationChannels,pLevelMatrix))
+#define IXAudio2Voice_DestroyVoice(This) ((This)->lpVtbl->DestroyVoice(This))
+
+// IXAudio2SourceVoice
+#define IXAudio2SourceVoice_GetVoiceDetails IXAudio2Voice_GetVoiceDetails
+#define IXAudio2SourceVoice_SetOutputVoices IXAudio2Voice_SetOutputVoices
+#define IXAudio2SourceVoice_SetEffectChain IXAudio2Voice_SetEffectChain
+#define IXAudio2SourceVoice_EnableEffect IXAudio2Voice_EnableEffect
+#define IXAudio2SourceVoice_DisableEffect IXAudio2Voice_DisableEffect
+#define IXAudio2SourceVoice_GetEffectState IXAudio2Voice_GetEffectState
+#define IXAudio2SourceVoice_SetEffectParameters IXAudio2Voice_SetEffectParameters
+#define IXAudio2SourceVoice_GetEffectParameters IXAudio2Voice_GetEffectParameters
+#define IXAudio2SourceVoice_SetFilterParameters IXAudio2Voice_SetFilterParameters
+#define IXAudio2SourceVoice_GetFilterParameters IXAudio2Voice_GetFilterParameters
+#define IXAudio2SourceVoice_SetOutputFilterParameters IXAudio2Voice_SetOutputFilterParameters
+#define IXAudio2SourceVoice_GetOutputFilterParameters IXAudio2Voice_GetOutputFilterParameters
+#define IXAudio2SourceVoice_SetVolume IXAudio2Voice_SetVolume
+#define IXAudio2SourceVoice_GetVolume IXAudio2Voice_GetVolume
+#define IXAudio2SourceVoice_SetChannelVolumes IXAudio2Voice_SetChannelVolumes
+#define IXAudio2SourceVoice_GetChannelVolumes IXAudio2Voice_GetChannelVolumes
+#define IXAudio2SourceVoice_SetOutputMatrix IXAudio2Voice_SetOutputMatrix
+#define IXAudio2SourceVoice_GetOutputMatrix IXAudio2Voice_GetOutputMatrix
+#define IXAudio2SourceVoice_DestroyVoice IXAudio2Voice_DestroyVoice
+#define IXAudio2SourceVoice_Start(This,Flags,OperationSet) ((This)->lpVtbl->Start(This,Flags,OperationSet))
+#define IXAudio2SourceVoice_Stop(This,Flags,OperationSet) ((This)->lpVtbl->Stop(This,Flags,OperationSet))
+#define IXAudio2SourceVoice_SubmitSourceBuffer(This,pBuffer,pBufferWMA) ((This)->lpVtbl->SubmitSourceBuffer(This,pBuffer,pBufferWMA))
+#define IXAudio2SourceVoice_FlushSourceBuffers(This) ((This)->lpVtbl->FlushSourceBuffers(This))
+#define IXAudio2SourceVoice_Discontinuity(This) ((This)->lpVtbl->Discontinuity(This))
+#define IXAudio2SourceVoice_ExitLoop(This,OperationSet) ((This)->lpVtbl->ExitLoop(This,OperationSet))
+#define IXAudio2SourceVoice_GetState(This,pVoiceState) ((This)->lpVtbl->GetState(This,pVoiceState))
+#define IXAudio2SourceVoice_SetFrequencyRatio(This,Ratio,OperationSet) ((This)->lpVtbl->SetFrequencyRatio(This,Ratio,OperationSet))
+#define IXAudio2SourceVoice_GetFrequencyRatio(This,pRatio) ((This)->lpVtbl->GetFrequencyRatio(This,pRatio))
+#define IXAudio2SourceVoice_SetSourceSampleRate(This,NewSourceSampleRate) ((This)->lpVtbl->SetSourceSampleRate(This,NewSourceSampleRate))
+
+// IXAudio2SubmixVoice
+#define IXAudio2SubmixVoice_GetVoiceDetails IXAudio2Voice_GetVoiceDetails
+#define IXAudio2SubmixVoice_SetOutputVoices IXAudio2Voice_SetOutputVoices
+#define IXAudio2SubmixVoice_SetEffectChain IXAudio2Voice_SetEffectChain
+#define IXAudio2SubmixVoice_EnableEffect IXAudio2Voice_EnableEffect
+#define IXAudio2SubmixVoice_DisableEffect IXAudio2Voice_DisableEffect
+#define IXAudio2SubmixVoice_GetEffectState IXAudio2Voice_GetEffectState
+#define IXAudio2SubmixVoice_SetEffectParameters IXAudio2Voice_SetEffectParameters
+#define IXAudio2SubmixVoice_GetEffectParameters IXAudio2Voice_GetEffectParameters
+#define IXAudio2SubmixVoice_SetFilterParameters IXAudio2Voice_SetFilterParameters
+#define IXAudio2SubmixVoice_GetFilterParameters IXAudio2Voice_GetFilterParameters
+#define IXAudio2SubmixVoice_SetOutputFilterParameters IXAudio2Voice_SetOutputFilterParameters
+#define IXAudio2SubmixVoice_GetOutputFilterParameters IXAudio2Voice_GetOutputFilterParameters
+#define IXAudio2SubmixVoice_SetVolume IXAudio2Voice_SetVolume
+#define IXAudio2SubmixVoice_GetVolume IXAudio2Voice_GetVolume
+#define IXAudio2SubmixVoice_SetChannelVolumes IXAudio2Voice_SetChannelVolumes
+#define IXAudio2SubmixVoice_GetChannelVolumes IXAudio2Voice_GetChannelVolumes
+#define IXAudio2SubmixVoice_SetOutputMatrix IXAudio2Voice_SetOutputMatrix
+#define IXAudio2SubmixVoice_GetOutputMatrix IXAudio2Voice_GetOutputMatrix
+#define IXAudio2SubmixVoice_DestroyVoice IXAudio2Voice_DestroyVoice
+
+// IXAudio2MasteringVoice
+#define IXAudio2MasteringVoice_GetVoiceDetails IXAudio2Voice_GetVoiceDetails
+#define IXAudio2MasteringVoice_SetOutputVoices IXAudio2Voice_SetOutputVoices
+#define IXAudio2MasteringVoice_SetEffectChain IXAudio2Voice_SetEffectChain
+#define IXAudio2MasteringVoice_EnableEffect IXAudio2Voice_EnableEffect
+#define IXAudio2MasteringVoice_DisableEffect IXAudio2Voice_DisableEffect
+#define IXAudio2MasteringVoice_GetEffectState IXAudio2Voice_GetEffectState
+#define IXAudio2MasteringVoice_SetEffectParameters IXAudio2Voice_SetEffectParameters
+#define IXAudio2MasteringVoice_GetEffectParameters IXAudio2Voice_GetEffectParameters
+#define IXAudio2MasteringVoice_SetFilterParameters IXAudio2Voice_SetFilterParameters
+#define IXAudio2MasteringVoice_GetFilterParameters IXAudio2Voice_GetFilterParameters
+#define IXAudio2MasteringVoice_SetOutputFilterParameters IXAudio2Voice_SetOutputFilterParameters
+#define IXAudio2MasteringVoice_GetOutputFilterParameters IXAudio2Voice_GetOutputFilterParameters
+#define IXAudio2MasteringVoice_SetVolume IXAudio2Voice_SetVolume
+#define IXAudio2MasteringVoice_GetVolume IXAudio2Voice_GetVolume
+#define IXAudio2MasteringVoice_SetChannelVolumes IXAudio2Voice_SetChannelVolumes
+#define IXAudio2MasteringVoice_GetChannelVolumes IXAudio2Voice_GetChannelVolumes
+#define IXAudio2MasteringVoice_SetOutputMatrix IXAudio2Voice_SetOutputMatrix
+#define IXAudio2MasteringVoice_GetOutputMatrix IXAudio2Voice_GetOutputMatrix
+#define IXAudio2MasteringVoice_DestroyVoice IXAudio2Voice_DestroyVoice
+
+#endif // #ifndef __cplusplus
+
+
+/**************************************************************************
+ *
+ * Utility functions used to convert from pitch in semitones and volume
+ * in decibels to the frequency and amplitude ratio units used by XAudio2.
+ * These are only defined if the client #defines XAUDIO2_HELPER_FUNCTIONS
+ * prior to #including xaudio2.h.
+ *
+ **************************************************************************/
+
+#ifdef XAUDIO2_HELPER_FUNCTIONS
+
+#define _USE_MATH_DEFINES   // Make math.h define M_PI
+#include <math.h>           // For powf, log10f, sinf and asinf
+
+// Calculate the argument to SetVolume from a decibel value
+__inline float XAudio2DecibelsToAmplitudeRatio(float Decibels)
+{
+    return powf(10.0f, Decibels / 20.0f);
+}
+
+// Recover a volume in decibels from an amplitude factor
+__inline float XAudio2AmplitudeRatioToDecibels(float Volume)
+{
+    if (Volume == 0)
+    {
+        return -3.402823466e+38f; // Smallest float value (-FLT_MAX)
+    }
+    return 20.0f * log10f(Volume);
+}
+
+// Calculate the argument to SetFrequencyRatio from a semitone value
+__inline float XAudio2SemitonesToFrequencyRatio(float Semitones)
+{
+    // FrequencyRatio = 2 ^ Octaves
+    //                = 2 ^ (Semitones / 12)
+    return powf(2.0f, Semitones / 12.0f);
+}
+
+// Recover a pitch in semitones from a frequency ratio
+__inline float XAudio2FrequencyRatioToSemitones(float FrequencyRatio)
+{
+    // Semitones = 12 * log2(FrequencyRatio)
+    //           = 12 * log2(10) * log10(FrequencyRatio)
+    return 39.86313713864835f * log10f(FrequencyRatio);
+}
+
+// Convert from filter cutoff frequencies expressed in Hertz to the radian
+// frequency values used in XAUDIO2_FILTER_PARAMETERS.Frequency.  Note that
+// the highest CutoffFrequency supported is SampleRate/6.  Higher values of
+// CutoffFrequency will return XAUDIO2_MAX_FILTER_FREQUENCY.
+__inline float XAudio2CutoffFrequencyToRadians(float CutoffFrequency, UINT32 SampleRate)
+{
+    if ((UINT32)(CutoffFrequency * 6.0f) >= SampleRate)
+    {
+        return XAUDIO2_MAX_FILTER_FREQUENCY;
+    }
+    return 2.0f * sinf((float)M_PI * CutoffFrequency / SampleRate);
+}
+
+// Convert from radian frequencies back to absolute frequencies in Hertz
+__inline float XAudio2RadiansToCutoffFrequency(float Radians, float SampleRate)
+{
+    return SampleRate * asinf(Radians / 2.0f) / (float)M_PI;
+}
+#endif // #ifdef XAUDIO2_HELPER_FUNCTIONS
+
+
+/**************************************************************************
+ *
+ * XAudio2Create: Top-level function that creates an XAudio2 instance.
+ *
+ * On Windows this is just an inline function that calls CoCreateInstance
+ * and Initialize.  The arguments are described above, under Initialize,
+ * except that the XAUDIO2_DEBUG_ENGINE flag can be used here to select
+ * the debug version of XAudio2.
+ *
+ * On Xbox, this function is implemented in the XAudio2 library, and the
+ * XAUDIO2_DEBUG_ENGINE flag has no effect; the client must explicitly
+ * link with the debug version of the library to obtain debug behavior.
+ *
+ **************************************************************************/
+
+#ifdef _XBOX
+
+STDAPI XAudio2Create(__deref_out IXAudio2** ppXAudio2, UINT32 Flags X2DEFAULT(0),
+                     XAUDIO2_PROCESSOR XAudio2Processor X2DEFAULT(XAUDIO2_DEFAULT_PROCESSOR));
+
+#else // Windows
+
+__inline HRESULT XAudio2Create(__deref_out IXAudio2** ppXAudio2, UINT32 Flags X2DEFAULT(0),
+                               XAUDIO2_PROCESSOR XAudio2Processor X2DEFAULT(XAUDIO2_DEFAULT_PROCESSOR))
+{
+    // Instantiate the appropriate XAudio2 engine
+    IXAudio2* pXAudio2;
+
+    #ifdef __cplusplus
+
+        HRESULT hr = CoCreateInstance((Flags & XAUDIO2_DEBUG_ENGINE) ? __uuidof(XAudio2_Debug) : __uuidof(XAudio2),
+                                      NULL, CLSCTX_INPROC_SERVER, __uuidof(IXAudio2), (void**)&pXAudio2);
+        if (SUCCEEDED(hr))
+        {
+            hr = pXAudio2->Initialize(Flags, XAudio2Processor);
+
+            if (SUCCEEDED(hr))
+            {
+                *ppXAudio2 = pXAudio2;
+            }
+            else
+            {
+                pXAudio2->Release();
+            }
+        }
+
+    #else
+
+        HRESULT hr = CoCreateInstance((Flags & XAUDIO2_DEBUG_ENGINE) ? &CLSID_XAudio2_Debug : &CLSID_XAudio2,
+                                      NULL, CLSCTX_INPROC_SERVER, &IID_IXAudio2, (void**)&pXAudio2);
+        if (SUCCEEDED(hr))
+        {
+            hr = pXAudio2->lpVtbl->Initialize(pXAudio2, Flags, XAudio2Processor);
+
+            if (SUCCEEDED(hr))
+            {
+                *ppXAudio2 = pXAudio2;
+            }
+            else
+            {
+                pXAudio2->lpVtbl->Release(pXAudio2);
+            }
+        }
+
+    #endif // #ifdef __cplusplus
+
+    return hr;
+}
+
+#endif // #ifdef _XBOX
+
+
+// Undo the #pragma pack(push, 1) directive at the top of this file
+#pragma pack(pop)
+
+#endif // #ifndef GUID_DEFS_ONLY
+#endif // #ifndef __XAUDIO2_INCLUDED__

--- a/3rdparty/XAudio2_7/audiodefs.h
+++ b/3rdparty/XAudio2_7/audiodefs.h
@@ -1,0 +1,263 @@
+/***************************************************************************
+ *
+ *  Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ *  File:     audiodefs.h
+ *  Content:  Basic constants and data types for audio work.
+ *
+ *  Remarks:  This header file defines all of the audio format constants and
+ *            structures required for XAudio2 and XACT work.  Providing these
+ *            in a single location avoids certain dependency problems in the
+ *            legacy audio headers (mmreg.h, mmsystem.h, ksmedia.h).
+ *
+ *            NOTE: Including the legacy headers after this one may cause a
+ *            compilation error, because they define some of the same types
+ *            defined here without preprocessor guards to avoid multiple
+ *            definitions.  If a source file needs one of the old headers,
+ *            it must include it before including audiodefs.h.
+ *
+ ***************************************************************************/
+
+#ifndef __AUDIODEFS_INCLUDED__
+#define __AUDIODEFS_INCLUDED__
+
+#include <windef.h>  // For WORD, DWORD, etc.
+
+#pragma pack(push, 1)  // Pack structures to 1-byte boundaries
+
+
+/**************************************************************************
+ *
+ *  WAVEFORMATEX: Base structure for many audio formats.  Format-specific
+ *  extensions can be defined for particular formats by using a non-zero
+ *  cbSize value and adding extra fields to the end of this structure.
+ *
+ ***************************************************************************/
+
+#ifndef _WAVEFORMATEX_
+
+    #define _WAVEFORMATEX_
+    typedef struct tWAVEFORMATEX
+    {
+        WORD wFormatTag;        // Integer identifier of the format
+        WORD nChannels;         // Number of audio channels
+        DWORD nSamplesPerSec;   // Audio sample rate
+        DWORD nAvgBytesPerSec;  // Bytes per second (possibly approximate)
+        WORD nBlockAlign;       // Size in bytes of a sample block (all channels)
+        WORD wBitsPerSample;    // Size in bits of a single per-channel sample
+        WORD cbSize;            // Bytes of extra data appended to this struct
+    } WAVEFORMATEX;
+
+#endif
+
+// Defining pointer types outside of the #if block to make sure they are
+// defined even if mmreg.h or mmsystem.h is #included before this file
+
+typedef WAVEFORMATEX *PWAVEFORMATEX, *NPWAVEFORMATEX, *LPWAVEFORMATEX;
+typedef const WAVEFORMATEX *PCWAVEFORMATEX, *LPCWAVEFORMATEX;
+
+
+/**************************************************************************
+ *
+ *  WAVEFORMATEXTENSIBLE: Extended version of WAVEFORMATEX that should be
+ *  used as a basis for all new audio formats.  The format tag is replaced
+ *  with a GUID, allowing new formats to be defined without registering a
+ *  format tag with Microsoft.  There are also new fields that can be used
+ *  to specify the spatial positions for each channel and the bit packing
+ *  used for wide samples (e.g. 24-bit PCM samples in 32-bit containers).
+ *
+ ***************************************************************************/
+
+#ifndef _WAVEFORMATEXTENSIBLE_
+
+    #define _WAVEFORMATEXTENSIBLE_
+    typedef struct
+    {
+        WAVEFORMATEX Format;          // Base WAVEFORMATEX data
+        union
+        {
+            WORD wValidBitsPerSample; // Valid bits in each sample container
+            WORD wSamplesPerBlock;    // Samples per block of audio data; valid
+                                      // if wBitsPerSample=0 (but rarely used).
+            WORD wReserved;           // Zero if neither case above applies.
+        } Samples;
+        DWORD dwChannelMask;          // Positions of the audio channels
+        GUID SubFormat;               // Format identifier GUID
+    } WAVEFORMATEXTENSIBLE;
+
+#endif
+
+typedef WAVEFORMATEXTENSIBLE *PWAVEFORMATEXTENSIBLE, *LPWAVEFORMATEXTENSIBLE;
+typedef const WAVEFORMATEXTENSIBLE *PCWAVEFORMATEXTENSIBLE, *LPCWAVEFORMATEXTENSIBLE;
+
+
+
+/**************************************************************************
+ *
+ *  Define the most common wave format tags used in WAVEFORMATEX formats.
+ *
+ ***************************************************************************/
+
+#ifndef WAVE_FORMAT_PCM  // Pulse Code Modulation
+
+    // If WAVE_FORMAT_PCM is not defined, we need to define some legacy types
+    // for compatibility with the Windows mmreg.h / mmsystem.h header files.
+
+    // Old general format structure (information common to all formats)
+    typedef struct waveformat_tag
+    {
+        WORD wFormatTag;
+        WORD nChannels;
+        DWORD nSamplesPerSec;
+        DWORD nAvgBytesPerSec;
+        WORD nBlockAlign;
+    } WAVEFORMAT, *PWAVEFORMAT, NEAR *NPWAVEFORMAT, FAR *LPWAVEFORMAT;
+
+    // Specific format structure for PCM data
+    typedef struct pcmwaveformat_tag
+    {
+        WAVEFORMAT wf;
+        WORD wBitsPerSample;
+    } PCMWAVEFORMAT, *PPCMWAVEFORMAT, NEAR *NPPCMWAVEFORMAT, FAR *LPPCMWAVEFORMAT;
+
+    #define WAVE_FORMAT_PCM 0x0001
+
+#endif
+
+#ifndef WAVE_FORMAT_ADPCM  // Microsoft Adaptive Differental PCM
+
+    // Replicate the Microsoft ADPCM type definitions from mmreg.h.
+
+    typedef struct adpcmcoef_tag
+    {
+        short iCoef1;
+        short iCoef2;
+    } ADPCMCOEFSET;
+
+    #pragma warning(push)
+    #pragma warning(disable:4200)  // Disable zero-sized array warnings
+
+    typedef struct adpcmwaveformat_tag {
+        WAVEFORMATEX wfx;
+        WORD wSamplesPerBlock;
+        WORD wNumCoef;
+        ADPCMCOEFSET aCoef[];  // Always 7 coefficient pairs for MS ADPCM
+    } ADPCMWAVEFORMAT;
+
+    #pragma warning(pop)
+
+    #define WAVE_FORMAT_ADPCM 0x0002
+
+#endif
+
+// Other frequently used format tags
+
+#ifndef WAVE_FORMAT_UNKNOWN
+    #define WAVE_FORMAT_UNKNOWN         0x0000 // Unknown or invalid format tag
+#endif
+
+#ifndef WAVE_FORMAT_IEEE_FLOAT
+    #define WAVE_FORMAT_IEEE_FLOAT      0x0003 // 32-bit floating-point
+#endif
+
+#ifndef WAVE_FORMAT_MPEGLAYER3
+    #define WAVE_FORMAT_MPEGLAYER3      0x0055 // ISO/MPEG Layer3
+#endif
+
+#ifndef WAVE_FORMAT_DOLBY_AC3_SPDIF
+    #define WAVE_FORMAT_DOLBY_AC3_SPDIF 0x0092 // Dolby Audio Codec 3 over S/PDIF
+#endif
+
+#ifndef WAVE_FORMAT_WMAUDIO2
+    #define WAVE_FORMAT_WMAUDIO2        0x0161 // Windows Media Audio
+#endif
+
+#ifndef WAVE_FORMAT_WMAUDIO3
+    #define WAVE_FORMAT_WMAUDIO3        0x0162 // Windows Media Audio Pro
+#endif
+
+#ifndef WAVE_FORMAT_WMASPDIF
+    #define WAVE_FORMAT_WMASPDIF        0x0164 // Windows Media Audio over S/PDIF
+#endif
+
+#ifndef WAVE_FORMAT_EXTENSIBLE
+    #define WAVE_FORMAT_EXTENSIBLE      0xFFFE // All WAVEFORMATEXTENSIBLE formats
+#endif
+
+
+/**************************************************************************
+ *
+ *  Define the most common wave format GUIDs used in WAVEFORMATEXTENSIBLE
+ *  formats.  Note that including the Windows ksmedia.h header after this
+ *  one will cause build problems; this cannot be avoided, since ksmedia.h
+ *  defines these macros without preprocessor guards.
+ *
+ ***************************************************************************/
+
+#ifdef __cplusplus // uuid() and __uuidof() are only available in C++
+
+    #ifndef KSDATAFORMAT_SUBTYPE_PCM
+        struct __declspec(uuid("00000001-0000-0010-8000-00aa00389b71")) KSDATAFORMAT_SUBTYPE_PCM_STRUCT;
+        #define KSDATAFORMAT_SUBTYPE_PCM __uuidof(KSDATAFORMAT_SUBTYPE_PCM_STRUCT)
+    #endif
+
+    #ifndef KSDATAFORMAT_SUBTYPE_ADPCM
+        struct __declspec(uuid("00000002-0000-0010-8000-00aa00389b71")) KSDATAFORMAT_SUBTYPE_ADPCM_STRUCT;
+        #define KSDATAFORMAT_SUBTYPE_ADPCM __uuidof(KSDATAFORMAT_SUBTYPE_ADPCM_STRUCT)
+    #endif
+
+    #ifndef KSDATAFORMAT_SUBTYPE_IEEE_FLOAT
+        struct __declspec(uuid("00000003-0000-0010-8000-00aa00389b71")) KSDATAFORMAT_SUBTYPE_IEEE_FLOAT_STRUCT;
+        #define KSDATAFORMAT_SUBTYPE_IEEE_FLOAT __uuidof(KSDATAFORMAT_SUBTYPE_IEEE_FLOAT_STRUCT)
+    #endif
+
+#endif
+
+
+/**************************************************************************
+ *
+ *  Speaker positions used in the WAVEFORMATEXTENSIBLE dwChannelMask field.
+ *
+ ***************************************************************************/
+
+#ifndef SPEAKER_FRONT_LEFT
+    #define SPEAKER_FRONT_LEFT            0x00000001
+    #define SPEAKER_FRONT_RIGHT           0x00000002
+    #define SPEAKER_FRONT_CENTER          0x00000004
+    #define SPEAKER_LOW_FREQUENCY         0x00000008
+    #define SPEAKER_BACK_LEFT             0x00000010
+    #define SPEAKER_BACK_RIGHT            0x00000020
+    #define SPEAKER_FRONT_LEFT_OF_CENTER  0x00000040
+    #define SPEAKER_FRONT_RIGHT_OF_CENTER 0x00000080
+    #define SPEAKER_BACK_CENTER           0x00000100
+    #define SPEAKER_SIDE_LEFT             0x00000200
+    #define SPEAKER_SIDE_RIGHT            0x00000400
+    #define SPEAKER_TOP_CENTER            0x00000800
+    #define SPEAKER_TOP_FRONT_LEFT        0x00001000
+    #define SPEAKER_TOP_FRONT_CENTER      0x00002000
+    #define SPEAKER_TOP_FRONT_RIGHT       0x00004000
+    #define SPEAKER_TOP_BACK_LEFT         0x00008000
+    #define SPEAKER_TOP_BACK_CENTER       0x00010000
+    #define SPEAKER_TOP_BACK_RIGHT        0x00020000
+    #define SPEAKER_RESERVED              0x7FFC0000
+    #define SPEAKER_ALL                   0x80000000
+    #define _SPEAKER_POSITIONS_
+#endif
+
+#ifndef SPEAKER_STEREO
+    #define SPEAKER_MONO             (SPEAKER_FRONT_CENTER)
+    #define SPEAKER_STEREO           (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT)
+    #define SPEAKER_2POINT1          (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_LOW_FREQUENCY)
+    #define SPEAKER_SURROUND         (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_FRONT_CENTER | SPEAKER_BACK_CENTER)
+    #define SPEAKER_QUAD             (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT)
+    #define SPEAKER_4POINT1          (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_LOW_FREQUENCY | SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT)
+    #define SPEAKER_5POINT1          (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_FRONT_CENTER | SPEAKER_LOW_FREQUENCY | SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT)
+    #define SPEAKER_7POINT1          (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_FRONT_CENTER | SPEAKER_LOW_FREQUENCY | SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT | SPEAKER_FRONT_LEFT_OF_CENTER | SPEAKER_FRONT_RIGHT_OF_CENTER)
+    #define SPEAKER_5POINT1_SURROUND (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_FRONT_CENTER | SPEAKER_LOW_FREQUENCY | SPEAKER_SIDE_LEFT | SPEAKER_SIDE_RIGHT)
+    #define SPEAKER_7POINT1_SURROUND (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT | SPEAKER_FRONT_CENTER | SPEAKER_LOW_FREQUENCY | SPEAKER_BACK_LEFT | SPEAKER_BACK_RIGHT | SPEAKER_SIDE_LEFT  | SPEAKER_SIDE_RIGHT)
+#endif
+
+
+#pragma pack(pop)
+
+#endif // #ifndef __AUDIODEFS_INCLUDED__

--- a/3rdparty/XAudio2_7/comdecl.h
+++ b/3rdparty/XAudio2_7/comdecl.h
@@ -1,0 +1,59 @@
+// comdecl.h: Macros to facilitate COM interface and GUID declarations.
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+#ifndef _COMDECL_H_
+#define _COMDECL_H_
+
+#ifndef _XBOX
+    #include <basetyps.h>   // For standard COM interface macros
+#else
+    #pragma warning(push)
+    #pragma warning(disable:4061)
+    #include <xtl.h>        // Required by xobjbase.h
+    #include <xobjbase.h>   // Special definitions for Xbox build
+    #pragma warning(pop)
+#endif
+
+// The DEFINE_CLSID() and DEFINE_IID() macros defined below allow COM GUIDs to
+// be declared and defined in such a way that clients can obtain the GUIDs using
+// either the __uuidof() extension or the old-style CLSID_Foo / IID_IFoo names.
+// If using the latter approach, the client can also choose whether to get the
+// GUID definitions by defining the INITGUID preprocessor constant or by linking
+// to a GUID library.  This works in either C or C++.
+
+#ifdef __cplusplus
+
+    #define DECLSPEC_UUID_WRAPPER(x) __declspec(uuid(#x))
+    #ifdef INITGUID
+
+        #define DEFINE_CLSID(className, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
+            class DECLSPEC_UUID_WRAPPER(l##-##w1##-##w2##-##b1##b2##-##b3##b4##b5##b6##b7##b8) className; \
+            EXTERN_C const GUID DECLSPEC_SELECTANY CLSID_##className = __uuidof(className)
+
+        #define DEFINE_IID(interfaceName, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
+            interface DECLSPEC_UUID_WRAPPER(l##-##w1##-##w2##-##b1##b2##-##b3##b4##b5##b6##b7##b8) interfaceName; \
+            EXTERN_C const GUID DECLSPEC_SELECTANY IID_##interfaceName = __uuidof(interfaceName)
+
+    #else // INITGUID
+
+        #define DEFINE_CLSID(className, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
+            class DECLSPEC_UUID_WRAPPER(l##-##w1##-##w2##-##b1##b2##-##b3##b4##b5##b6##b7##b8) className; \
+            EXTERN_C const GUID CLSID_##className
+
+        #define DEFINE_IID(interfaceName, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
+            interface DECLSPEC_UUID_WRAPPER(l##-##w1##-##w2##-##b1##b2##-##b3##b4##b5##b6##b7##b8) interfaceName; \
+            EXTERN_C const GUID IID_##interfaceName
+
+    #endif // INITGUID
+
+#else // __cplusplus
+
+    #define DEFINE_CLSID(className, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
+        DEFINE_GUID(CLSID_##className, 0x##l, 0x##w1, 0x##w2, 0x##b1, 0x##b2, 0x##b3, 0x##b4, 0x##b5, 0x##b6, 0x##b7, 0x##b8)
+
+    #define DEFINE_IID(interfaceName, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
+        DEFINE_GUID(IID_##interfaceName, 0x##l, 0x##w1, 0x##w2, 0x##b1, 0x##b2, 0x##b3, 0x##b4, 0x##b5, 0x##b6, 0x##b7, 0x##b8)
+
+#endif // __cplusplus
+
+#endif // #ifndef _COMDECL_H_

--- a/3rdparty/XAudio2_7/dxsdkver.h
+++ b/3rdparty/XAudio2_7/dxsdkver.h
@@ -1,0 +1,18 @@
+/*==========================================================================;
+ *
+ *
+ *  File:   dxsdkver.h
+ *  Content:    DirectX SDK Version Include File
+ *
+ ****************************************************************************/
+
+#ifndef _DXSDKVER_H_
+#define _DXSDKVER_H_
+
+#define _DXSDK_PRODUCT_MAJOR  9     
+#define _DXSDK_PRODUCT_MINOR  29        
+#define _DXSDK_BUILD_MAJOR    1962        
+#define _DXSDK_BUILD_MINOR    0        
+
+#endif // _DXSDKVER_H_
+

--- a/3rdparty/XAudio2_7/xma2defs.h
+++ b/3rdparty/XAudio2_7/xma2defs.h
@@ -1,0 +1,718 @@
+/***************************************************************************
+ *
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * File:     xma2defs.h
+ * Content:  Constants, data types and functions for XMA2 compressed audio.
+ *
+ ***************************************************************************/
+
+#ifndef __XMA2DEFS_INCLUDED__
+#define __XMA2DEFS_INCLUDED__
+
+#include <sal.h>        // Markers for documenting API semantics
+#include <winerror.h>   // For S_OK, E_FAIL
+#include <audiodefs.h>  // Basic data types and constants for audio work
+
+
+/***************************************************************************
+ *  Overview
+ ***************************************************************************/
+
+// A typical XMA2 file contains these RIFF chunks:
+//
+// 'fmt' or 'XMA2' chunk (or both): A description of the XMA data's structure
+// and characteristics (length, channels, sample rate, loops, block size, etc).
+//
+// 'seek' chunk: A seek table to help navigate the XMA data.
+//
+// 'data' chunk: The encoded XMA2 data.
+//
+// The encoded XMA2 data is structured as a set of BLOCKS, which contain PACKETS,
+// which contain FRAMES, which contain SUBFRAMES (roughly speaking).  The frames
+// in a file may also be divided into several subsets, called STREAMS.
+//
+// FRAME: A variable-sized segment of XMA data that decodes to exactly 512 mono
+//      or stereo PCM samples.  This is the smallest unit of XMA data that can
+//      be decoded in isolation.  Frames are an arbitrary number of bits in
+//      length, and need not be byte-aligned.  See "XMA frame structure" below.
+//
+// SUBFRAME: A region of bits in an XMA frame that decodes to 128 mono or stereo
+//      samples.  The XMA decoder cannot decode a subframe in isolation; it needs
+//      a whole frame to work with.  However, it can begin emitting the frame's
+//      decoded samples at any one of the four subframe boundaries.  Subframes
+//      can be addressed for seeking and looping purposes.
+//
+// PACKET: A 2Kb region containing a 32-bit header and some XMA frames.  Frames
+//      can (and usually do) span packets.  A packet's header includes the offset
+//      in bits of the first frame that begins within that packet.  All of the
+//      frames that begin in a given packet belong to the same "stream" (see the
+//      Multichannel Audio section below).
+//
+// STREAM: A set of packets within an XMA file that all contain data for the
+//      same mono or stereo component of a PCM file with more than two channels.
+//      The packets comprising a given stream may be interleaved with each other
+//      more or less arbitrarily; see Multichannel Audio.
+//
+// BLOCK: An array of XMA packets; or, to break it down differently, a series of
+//      consecutive XMA frames, padded at the end with reserved data.  A block
+//      must contain at least one 2Kb packet per stream, and it can hold up to
+//      4095 packets (8190Kb), but its size is typically in the 32Kb-128Kb range.
+//      (The size chosen involves a trade-off between memory use and efficiency
+//      of reading from permanent storage.)
+//
+//      XMA frames do not span blocks, so a block is guaranteed to begin with a
+//      set of complete frames, one per stream.  Also, a block in a multi-stream
+//      XMA2 file always contains the same number of samples for each stream;
+//      see Multichannel Audio.
+//
+// The 'data' chunk in an XMA2 file is an array of XMA2WAVEFORMAT.BlockCount XMA
+// blocks, all the same size (as specified in XMA2WAVEFORMAT.BlockSizeInBytes)
+// except for the last one, which may be shorter.
+
+
+// MULTICHANNEL AUDIO: the XMA decoder can only decode raw XMA data into either
+// mono or stereo PCM data.  In order to encode a 6-channel file (say), the file
+// must be deinterleaved into 3 stereo streams that are encoded independently,
+// producing 3 encoded XMA data streams.  Then the packets in these 3 streams
+// are interleaved to produce a single XMA2 file, and some information is added
+// to the file so that the original 6-channel audio can be reconstructed at
+// decode time.  This works using the concept of an XMA stream (see above).
+//
+// The frames for all the streams in an XMA file are interleaved in an arbitrary
+// order.  To locate a frame that belongs to a given stream in a given XMA block,
+// you must examine the first few packets in the block.  Here (and only here) the
+// packets are guaranteed to be presented in stream order, so that all frames
+// beginning in packet 0 belong to stream 0 (the first stereo pair), etc.
+//
+// (This means that when decoding multi-stream XMA files, only entire XMA blocks
+// should be submitted to the decoder; otherwise it cannot know which frames
+// belong to which stream.)
+//
+// Once you have one frame that belongs to a given stream, you can find the next
+// one by looking at the frame's 'NextFrameOffsetBits' value (which is stored in
+// its first 15 bits; see XMAFRAME below).  The GetXmaFrameBitPosition function
+// uses this technique.
+
+
+// SEEKING IN XMA2 FILES: Here is some pseudocode to find the byte position and
+// subframe in an XMA2 file which will contain sample S when decoded.
+//
+// 1. Traverse the seek table to find the XMA2 block containing sample S. The
+//    seek table is an array of big-endian DWORDs, one per block in the file.
+//    The Nth DWORD is the total number of PCM samples that would be obtained
+//    by decoding the entire XMA file up to the end of block N.  Hence, the
+//    block we want is the first one whose seek table entry is greater than S.
+//    (See the GetXmaBlockContainingSample helper function.)
+//
+// 2. Calculate which frame F within the block found above contains sample S.
+//    Since each frame decodes to 512 samples, this is straightforward.  The
+//    first frame in the block produces samples X to X + 512, where X is the
+//    seek table entry for the prior block.  So F is (S - X) / 512.
+//
+// 3. Find the bit offset within the block where frame F starts.  Since frames
+//    are variable-sized, this can only be done by traversing all the frames in
+//    the block until we reach frame F.  (See GetXmaFrameBitPosition.)
+//
+// 4. Frame F has four 128-sample subframes.  To find the subframe containing S,
+//    we can use the formula (S % 512) / 128.
+//
+// In the case of multi-stream XMA files, sample S is a multichannel sample with
+// parts coming from several frames, one per stream.  To find all these frames,
+// steps 2-4 need to be repeated for each stream N, using the knowledge that the
+// first packets in a block are presented in stream order.  The frame traversal
+// in step 3 must be started at the first frame in the Nth packet of the block,
+// which will be the first frame for stream N.  (And the packet header will tell
+// you the first frame's start position within the packet.)
+//
+// Step 1 can be performed using the GetXmaBlockContainingSample function below,
+// and steps 2-4 by calling GetXmaDecodePositionForSample once for each stream.
+
+
+
+/***************************************************************************
+ *  XMA constants
+ ***************************************************************************/
+
+// Size of the PCM samples produced by the XMA decoder
+#define XMA_OUTPUT_SAMPLE_BYTES         2u
+#define XMA_OUTPUT_SAMPLE_BITS          (XMA_OUTPUT_SAMPLE_BYTES * 8u)
+
+// Size of an XMA packet
+#define XMA_BYTES_PER_PACKET            2048u
+#define XMA_BITS_PER_PACKET             (XMA_BYTES_PER_PACKET * 8u)
+
+// Size of an XMA packet header
+#define XMA_PACKET_HEADER_BYTES         4u
+#define XMA_PACKET_HEADER_BITS          (XMA_PACKET_HEADER_BYTES * 8u)
+
+// Sample blocks in a decoded XMA frame
+#define XMA_SAMPLES_PER_FRAME           512u
+
+// Sample blocks in a decoded XMA subframe
+#define XMA_SAMPLES_PER_SUBFRAME        128u
+
+// Maximum encoded data that can be submitted to the XMA decoder at a time
+#define XMA_READBUFFER_MAX_PACKETS      4095u
+#define XMA_READBUFFER_MAX_BYTES        (XMA_READBUFFER_MAX_PACKETS * XMA_BYTES_PER_PACKET)
+
+// Maximum size allowed for the XMA decoder's output buffers
+#define XMA_WRITEBUFFER_MAX_BYTES       (31u * 256u)
+
+// Required byte alignment of the XMA decoder's output buffers
+#define XMA_WRITEBUFFER_BYTE_ALIGNMENT  256u
+
+// Decode chunk sizes for the XMA_PLAYBACK_INIT.subframesToDecode field
+#define XMA_MIN_SUBFRAMES_TO_DECODE     1u
+#define XMA_MAX_SUBFRAMES_TO_DECODE     8u
+#define XMA_OPTIMAL_SUBFRAMES_TO_DECODE 4u
+
+// LoopCount<255 means finite repetitions; LoopCount=255 means infinite looping
+#define XMA_MAX_LOOPCOUNT               254u
+#define XMA_INFINITE_LOOP               255u
+
+
+
+/***************************************************************************
+ *  XMA format structures
+ ***************************************************************************/
+
+// The currently recommended way to express format information for XMA2 files
+// is the XMA2WAVEFORMATEX structure.  This structure is fully compliant with
+// the WAVEFORMATEX standard and contains all the information needed to parse
+// and manage XMA2 files in a compact way.
+
+#define WAVE_FORMAT_XMA2 0x166
+
+typedef struct XMA2WAVEFORMATEX
+{
+    WAVEFORMATEX wfx;
+    // Meaning of the WAVEFORMATEX fields here:
+    //    wFormatTag;        // Audio format type; always WAVE_FORMAT_XMA2
+    //    nChannels;         // Channel count of the decoded audio
+    //    nSamplesPerSec;    // Sample rate of the decoded audio
+    //    nAvgBytesPerSec;   // Used internally by the XMA encoder
+    //    nBlockAlign;       // Decoded sample size; channels * wBitsPerSample / 8
+    //    wBitsPerSample;    // Bits per decoded mono sample; always 16 for XMA
+    //    cbSize;            // Size in bytes of the rest of this structure (34)
+
+    WORD  NumStreams;        // Number of audio streams (1 or 2 channels each)
+    DWORD ChannelMask;       // Spatial positions of the channels in this file,
+                             // stored as SPEAKER_xxx values (see audiodefs.h)
+    DWORD SamplesEncoded;    // Total number of PCM samples the file decodes to
+    DWORD BytesPerBlock;     // XMA block size (but the last one may be shorter)
+    DWORD PlayBegin;         // First valid sample in the decoded audio
+    DWORD PlayLength;        // Length of the valid part of the decoded audio
+    DWORD LoopBegin;         // Beginning of the loop region in decoded sample terms
+    DWORD LoopLength;        // Length of the loop region in decoded sample terms
+    BYTE  LoopCount;         // Number of loop repetitions; 255 = infinite
+    BYTE  EncoderVersion;    // Version of XMA encoder that generated the file
+    WORD  BlockCount;        // XMA blocks in file (and entries in its seek table)
+} XMA2WAVEFORMATEX, *PXMA2WAVEFORMATEX;
+
+
+// The legacy XMA format structures are described here for reference, but they
+// should not be used in new content.  XMAWAVEFORMAT was the structure used in
+// XMA version 1 files.  XMA2WAVEFORMAT was used in early XMA2 files; it is not
+// placed in the usual 'fmt' RIFF chunk but in its own 'XMA2' chunk.
+
+#ifndef WAVE_FORMAT_XMA
+#define WAVE_FORMAT_XMA 0x0165
+
+// Values used in the ChannelMask fields below.  Similar to the SPEAKER_xxx
+// values defined in audiodefs.h, but modified to fit in a single byte.
+#ifndef XMA_SPEAKER_LEFT
+    #define XMA_SPEAKER_LEFT            0x01
+    #define XMA_SPEAKER_RIGHT           0x02
+    #define XMA_SPEAKER_CENTER          0x04
+    #define XMA_SPEAKER_LFE             0x08
+    #define XMA_SPEAKER_LEFT_SURROUND   0x10
+    #define XMA_SPEAKER_RIGHT_SURROUND  0x20
+    #define XMA_SPEAKER_LEFT_BACK       0x40
+    #define XMA_SPEAKER_RIGHT_BACK      0x80
+#endif
+
+
+// Used in XMAWAVEFORMAT for per-stream data
+typedef struct XMASTREAMFORMAT
+{
+    DWORD PsuedoBytesPerSec; // Used by the XMA encoder (typo preserved for legacy reasons)
+    DWORD SampleRate;        // The stream's decoded sample rate (in XMA2 files,
+                             // this is the same for all streams in the file).
+    DWORD LoopStart;         // Bit offset of the frame containing the loop start
+                             // point, relative to the beginning of the stream.
+    DWORD LoopEnd;           // Bit offset of the frame containing the loop end.
+    BYTE  SubframeData;      // Two 4-bit numbers specifying the exact location of
+                             // the loop points within the frames that contain them.
+                             //   SubframeEnd: Subframe of the loop end frame where
+                             //                the loop ends.  Ranges from 0 to 3.
+                             //   SubframeSkip: Subframes to skip in the start frame to
+                             //                 reach the loop.  Ranges from 0 to 4.
+    BYTE  Channels;          // Number of channels in the stream (1 or 2)
+    WORD  ChannelMask;       // Spatial positions of the channels in the stream
+} XMASTREAMFORMAT;
+
+// Legacy XMA1 format structure
+typedef struct XMAWAVEFORMAT
+{
+    WORD FormatTag;          // Audio format type (always WAVE_FORMAT_XMA)
+    WORD BitsPerSample;      // Bit depth (currently required to be 16)
+    WORD EncodeOptions;      // Options for XMA encoder/decoder
+    WORD LargestSkip;        // Largest skip used in interleaving streams
+    WORD NumStreams;         // Number of interleaved audio streams
+    BYTE LoopCount;          // Number of loop repetitions; 255 = infinite
+    BYTE Version;            // XMA encoder version that generated the file.
+                             // Always 3 or higher for XMA2 files.
+    XMASTREAMFORMAT XmaStreams[1]; // Per-stream format information; the actual
+                                   // array length is in the NumStreams field.
+} XMAWAVEFORMAT;
+
+
+// Used in XMA2WAVEFORMAT for per-stream data
+typedef struct XMA2STREAMFORMAT
+{
+    BYTE Channels;           // Number of channels in the stream (1 or 2)
+    BYTE RESERVED;           // Reserved for future use
+    WORD ChannelMask;        // Spatial positions of the channels in the stream
+} XMA2STREAMFORMAT;
+
+// Legacy XMA2 format structure (big-endian byte ordering)
+typedef struct XMA2WAVEFORMAT
+{
+    BYTE  Version;           // XMA encoder version that generated the file.
+                             // Always 3 or higher for XMA2 files.
+    BYTE  NumStreams;        // Number of interleaved audio streams
+    BYTE  RESERVED;          // Reserved for future use
+    BYTE  LoopCount;         // Number of loop repetitions; 255 = infinite
+    DWORD LoopBegin;         // Loop begin point, in samples
+    DWORD LoopEnd;           // Loop end point, in samples
+    DWORD SampleRate;        // The file's decoded sample rate
+    DWORD EncodeOptions;     // Options for the XMA encoder/decoder
+    DWORD PsuedoBytesPerSec; // Used internally by the XMA encoder
+    DWORD BlockSizeInBytes;  // Size in bytes of this file's XMA blocks (except
+                             // possibly the last one).  Always a multiple of
+                             // 2Kb, since XMA blocks are arrays of 2Kb packets.
+    DWORD SamplesEncoded;    // Total number of PCM samples encoded in this file
+    DWORD SamplesInSource;   // Actual number of PCM samples in the source
+                             // material used to generate this file
+    DWORD BlockCount;        // Number of XMA blocks in this file (and hence
+                             // also the number of entries in its seek table)
+    XMA2STREAMFORMAT Streams[1]; // Per-stream format information; the actual
+                                 // array length is in the NumStreams field.
+} XMA2WAVEFORMAT;
+
+#endif // #ifndef WAVE_FORMAT_XMA
+
+
+
+/***************************************************************************
+ *  XMA packet structure (in big-endian form)
+ ***************************************************************************/
+
+typedef struct XMA2PACKET
+{
+    int FrameCount        :  6;  // Number of XMA frames that begin in this packet
+    int FrameOffsetInBits : 15;  // Bit of XmaData where the first complete frame begins
+    int PacketMetaData    :  3;  // Metadata stored in the packet (always 1 for XMA2)
+    int PacketSkipCount   :  8;  // How many packets belonging to other streams must be
+                                 // skipped to find the next packet belonging to this one
+    BYTE XmaData[XMA_BYTES_PER_PACKET - sizeof(DWORD)];  // XMA encoded data
+} XMA2PACKET;
+
+// E.g. if the first DWORD of a packet is 0x30107902:
+//
+// 001100 000001000001111 001 00000010
+//    |          |         |      |____ Skip 2 packets to find the next one for this stream
+//    |          |         |___________ XMA2 signature (always 001)
+//    |          |_____________________ First frame starts 527 bits into packet
+//    |________________________________ Packet contains 12 frames
+
+
+// Helper functions to extract the fields above from an XMA packet.  (Note that
+// the bitfields cannot be read directly on little-endian architectures such as
+// the Intel x86, as they are laid out in big-endian form.)
+
+__inline DWORD GetXmaPacketFrameCount(__in_bcount(1) const BYTE* pPacket)
+{
+    return (DWORD)(pPacket[0] >> 2);
+}
+
+__inline DWORD GetXmaPacketFirstFrameOffsetInBits(__in_bcount(3) const BYTE* pPacket)
+{
+    return ((DWORD)(pPacket[0] & 0x3) << 13) |
+           ((DWORD)(pPacket[1]) << 5) |
+           ((DWORD)(pPacket[2]) >> 3);
+}
+
+__inline DWORD GetXmaPacketMetadata(__in_bcount(3) const BYTE* pPacket)
+{
+    return (DWORD)(pPacket[2] & 0x7);
+}
+
+__inline DWORD GetXmaPacketSkipCount(__in_bcount(4) const BYTE* pPacket)
+{
+    return (DWORD)(pPacket[3]);
+}
+
+
+
+/***************************************************************************
+ *  XMA frame structure
+ ***************************************************************************/
+
+// There is no way to represent the XMA frame as a C struct, since it is a
+// variable-sized string of bits that need not be stored at a byte-aligned
+// position in memory.  This is the layout:
+//
+// XMAFRAME
+// {
+//    LengthInBits: A 15-bit number representing the length of this frame.
+//    XmaData: Encoded XMA data; its size in bits is (LengthInBits - 15).
+// }
+
+// Size in bits of the frame's initial LengthInBits field
+#define XMA_BITS_IN_FRAME_LENGTH_FIELD 15
+
+// Special LengthInBits value that marks an invalid final frame
+#define XMA_FINAL_FRAME_MARKER 0x7FFF
+
+
+
+/***************************************************************************
+ *  XMA helper functions
+ ***************************************************************************/
+
+// We define a local ASSERT macro to equal the global one if it exists.
+// You can define XMA2DEFS_ASSERT in advance to override this default.
+#ifndef XMA2DEFS_ASSERT
+    #ifdef ASSERT
+        #define XMA2DEFS_ASSERT ASSERT
+    #else
+        #define XMA2DEFS_ASSERT(a) /* No-op by default */
+    #endif
+#endif
+
+
+// GetXmaBlockContainingSample: Use a given seek table to find the XMA block
+// containing a given decoded sample.  Note that the seek table entries in an
+// XMA file are stored in big-endian form and may need to be converted prior
+// to calling this function.
+
+__inline HRESULT GetXmaBlockContainingSample
+(
+    DWORD nBlockCount,                      // Blocks in the file (= seek table entries)
+    __in_ecount(nBlockCount) const DWORD* pSeekTable,  // Pointer to the seek table data
+    DWORD nDesiredSample,                   // Decoded sample to locate
+    __out DWORD* pnBlockContainingSample,   // Index of the block containing the sample
+    __out DWORD* pnSampleOffsetWithinBlock  // Position of the sample in this block
+)
+{
+    DWORD nPreviousTotalSamples = 0;
+    DWORD nBlock;
+    DWORD nTotalSamplesSoFar;
+
+    XMA2DEFS_ASSERT(pSeekTable);
+    XMA2DEFS_ASSERT(pnBlockContainingSample);
+    XMA2DEFS_ASSERT(pnSampleOffsetWithinBlock);
+
+    for (nBlock = 0; nBlock < nBlockCount; ++nBlock)
+    {
+        nTotalSamplesSoFar = pSeekTable[nBlock];
+        if (nTotalSamplesSoFar > nDesiredSample)
+        {
+            *pnBlockContainingSample = nBlock;
+            *pnSampleOffsetWithinBlock = nDesiredSample - nPreviousTotalSamples;
+            return S_OK;
+        }
+        nPreviousTotalSamples = nTotalSamplesSoFar;
+    }
+
+    return E_FAIL;
+}
+
+
+// GetXmaFrameLengthInBits: Reads a given frame's LengthInBits field.
+
+__inline DWORD GetXmaFrameLengthInBits
+(
+    __in_bcount(nBitPosition / 8 + 3)
+    __in const BYTE* pPacket,  // Pointer to XMA packet[s] containing the frame
+    DWORD nBitPosition         // Bit offset of the frame within this packet
+)
+{
+    DWORD nRegion;
+    DWORD nBytePosition = nBitPosition / 8;
+    DWORD nBitOffset = nBitPosition % 8;
+
+    if (nBitOffset < 2) // Only need to read 2 bytes (and might not be safe to read more)
+    {
+        nRegion = (DWORD)(pPacket[nBytePosition+0]) << 8 |
+                  (DWORD)(pPacket[nBytePosition+1]);
+        return (nRegion >> (1 - nBitOffset)) & 0x7FFF;  // Last 15 bits
+    }
+    else // Need to read 3 bytes
+    {
+        nRegion = (DWORD)(pPacket[nBytePosition+0]) << 16 |
+                  (DWORD)(pPacket[nBytePosition+1]) << 8 |
+                  (DWORD)(pPacket[nBytePosition+2]);
+        return (nRegion >> (9 - nBitOffset)) & 0x7FFF;  // Last 15 bits
+    }
+}
+
+
+// GetXmaFrameBitPosition: Calculates the bit offset of a given frame within
+// an XMA block or set of blocks.  Returns 0 on failure.
+
+__inline DWORD GetXmaFrameBitPosition
+(
+    __in_bcount(nXmaDataBytes) const BYTE* pXmaData,  // Pointer to XMA block[s]
+    DWORD nXmaDataBytes,                              // Size of pXmaData in bytes
+    DWORD nStreamIndex,                               // Stream within which to seek
+    DWORD nDesiredFrame                               // Frame sought
+)
+{
+    const BYTE* pCurrentPacket;
+    DWORD nPacketsExamined = 0;
+    DWORD nFrameCountSoFar = 0;
+    DWORD nFramesToSkip;
+    DWORD nFrameBitOffset;
+
+    XMA2DEFS_ASSERT(pXmaData);
+    XMA2DEFS_ASSERT(nXmaDataBytes % XMA_BYTES_PER_PACKET == 0);
+
+    // Get the first XMA packet belonging to the desired stream, relying on the
+    // fact that the first packets for each stream are in consecutive order at
+    // the beginning of an XMA block.
+
+    pCurrentPacket = pXmaData + nStreamIndex * XMA_BYTES_PER_PACKET;
+    for (;;)
+    {
+        // If we have exceeded the size of the XMA data, return failure
+        if (pCurrentPacket + XMA_BYTES_PER_PACKET > pXmaData + nXmaDataBytes)
+        {
+            return 0;
+        }
+
+        // If the current packet contains the frame we are looking for...
+        if (nFrameCountSoFar + GetXmaPacketFrameCount(pCurrentPacket) > nDesiredFrame)
+        {
+            // See how many frames in this packet we need to skip to get to it
+            XMA2DEFS_ASSERT(nDesiredFrame >= nFrameCountSoFar);
+            nFramesToSkip = nDesiredFrame - nFrameCountSoFar;
+
+            // Get the bit offset of the first frame in this packet
+            nFrameBitOffset = XMA_PACKET_HEADER_BITS + GetXmaPacketFirstFrameOffsetInBits(pCurrentPacket);
+
+            // Advance nFrameBitOffset to the frame of interest
+            while (nFramesToSkip--)
+            {
+                nFrameBitOffset += GetXmaFrameLengthInBits(pCurrentPacket, nFrameBitOffset);
+            }
+
+            // The bit offset to return is the number of bits from pXmaData to
+            // pCurrentPacket plus the bit offset of the frame of interest
+            return (DWORD)(pCurrentPacket - pXmaData) * 8 + nFrameBitOffset;
+        }
+
+        // If we haven't found the right packet yet, advance our counters
+        ++nPacketsExamined;
+        nFrameCountSoFar += GetXmaPacketFrameCount(pCurrentPacket);
+
+        // And skip to the next packet belonging to the same stream
+        pCurrentPacket += XMA_BYTES_PER_PACKET * (GetXmaPacketSkipCount(pCurrentPacket) + 1);
+    }
+}
+
+
+// GetLastXmaFrameBitPosition: Calculates the bit offset of the last complete
+// frame in an XMA block or set of blocks.
+
+__inline DWORD GetLastXmaFrameBitPosition
+(
+    __in_bcount(nXmaDataBytes) const BYTE* pXmaData,  // Pointer to XMA block[s]
+    DWORD nXmaDataBytes,                              // Size of pXmaData in bytes
+    DWORD nStreamIndex                                // Stream within which to seek
+)
+{
+    const BYTE* pLastPacket;
+    DWORD nBytesToNextPacket;
+    DWORD nFrameBitOffset;
+    DWORD nFramesInLastPacket;
+
+    XMA2DEFS_ASSERT(pXmaData);
+    XMA2DEFS_ASSERT(nXmaDataBytes % XMA_BYTES_PER_PACKET == 0);
+    XMA2DEFS_ASSERT(nXmaDataBytes >= XMA_BYTES_PER_PACKET * (nStreamIndex + 1));
+
+    // Get the first XMA packet belonging to the desired stream, relying on the
+    // fact that the first packets for each stream are in consecutive order at
+    // the beginning of an XMA block.
+    pLastPacket = pXmaData + nStreamIndex * XMA_BYTES_PER_PACKET;
+
+    // Search for the last packet belonging to the desired stream
+    for (;;)
+    {
+        nBytesToNextPacket = XMA_BYTES_PER_PACKET * (GetXmaPacketSkipCount(pLastPacket) + 1);
+        XMA2DEFS_ASSERT(nBytesToNextPacket);
+        if (pLastPacket + nBytesToNextPacket + XMA_BYTES_PER_PACKET > pXmaData + nXmaDataBytes)
+        {
+            break;  // The next packet would extend beyond the end of pXmaData
+        }
+        pLastPacket += nBytesToNextPacket;
+    }
+
+    // The last packet can sometimes have no seekable frames, in which case we
+    // have to use the previous one
+    if (GetXmaPacketFrameCount(pLastPacket) == 0)
+    {
+        pLastPacket -= nBytesToNextPacket;
+    }
+
+    // Found the last packet.  Get the bit offset of its first frame.
+    nFrameBitOffset = XMA_PACKET_HEADER_BITS + GetXmaPacketFirstFrameOffsetInBits(pLastPacket);
+
+    // Traverse frames until we reach the last one
+    nFramesInLastPacket = GetXmaPacketFrameCount(pLastPacket);
+    while (--nFramesInLastPacket)
+    {
+        nFrameBitOffset += GetXmaFrameLengthInBits(pLastPacket, nFrameBitOffset);
+    }
+
+    // The bit offset to return is the number of bits from pXmaData to
+    // pLastPacket plus the offset of the last frame in this packet.
+    return (DWORD)(pLastPacket - pXmaData) * 8 + nFrameBitOffset;
+}
+
+
+// GetXmaDecodePositionForSample: Obtains the information needed to make the
+// decoder generate audio starting at a given sample position relative to the
+// beginning of the given XMA block: the bit offset of the appropriate frame,
+// and the right subframe within that frame.  This data can be passed directly
+// to the XMAPlaybackSetDecodePosition function.
+
+__inline HRESULT GetXmaDecodePositionForSample
+(
+    __in_bcount(nXmaDataBytes) const BYTE* pXmaData,  // Pointer to XMA block[s]
+    DWORD nXmaDataBytes,                              // Size of pXmaData in bytes
+    DWORD nStreamIndex,                               // Stream within which to seek
+    DWORD nDesiredSample,                             // Sample sought
+    __out DWORD* pnBitOffset,                         // Returns the bit offset within pXmaData of
+                                                      // the frame containing the sample sought
+    __out DWORD* pnSubFrame                           // Returns the subframe containing the sample
+)
+{
+    DWORD nDesiredFrame = nDesiredSample / XMA_SAMPLES_PER_FRAME;
+    DWORD nSubFrame = (nDesiredSample % XMA_SAMPLES_PER_FRAME) / XMA_SAMPLES_PER_SUBFRAME;
+    DWORD nBitOffset = GetXmaFrameBitPosition(pXmaData, nXmaDataBytes, nStreamIndex, nDesiredFrame);
+
+    XMA2DEFS_ASSERT(pnBitOffset);
+    XMA2DEFS_ASSERT(pnSubFrame);
+
+    if (nBitOffset)
+    {
+        *pnBitOffset = nBitOffset;
+        *pnSubFrame = nSubFrame;
+        return S_OK;
+    }
+    else
+    {
+        return E_FAIL;
+    }
+}
+
+
+// GetXmaSampleRate: Obtains the legal XMA sample rate (24, 32, 44.1 or 48Khz)
+// corresponding to a generic sample rate.
+
+__inline DWORD GetXmaSampleRate(DWORD dwGeneralRate)
+{
+    DWORD dwXmaRate = 48000; // Default XMA rate for all rates above 44100Hz
+
+    if (dwGeneralRate <= 24000)      dwXmaRate = 24000;
+    else if (dwGeneralRate <= 32000) dwXmaRate = 32000;
+    else if (dwGeneralRate <= 44100) dwXmaRate = 44100;
+
+    return dwXmaRate;
+}
+
+
+// Functions to convert between WAVEFORMATEXTENSIBLE channel masks (combinations
+// of the SPEAKER_xxx flags defined in audiodefs.h) and XMA channel masks (which
+// are limited to eight possible speaker positions: left, right, center, low
+// frequency, side left, side right, back left and back right).
+
+__inline DWORD GetStandardChannelMaskFromXmaMask(BYTE bXmaMask)
+{
+    DWORD dwStandardMask = 0;
+
+    if (bXmaMask & XMA_SPEAKER_LEFT)           dwStandardMask |= SPEAKER_FRONT_LEFT;
+    if (bXmaMask & XMA_SPEAKER_RIGHT)          dwStandardMask |= SPEAKER_FRONT_RIGHT;
+    if (bXmaMask & XMA_SPEAKER_CENTER)         dwStandardMask |= SPEAKER_FRONT_CENTER;
+    if (bXmaMask & XMA_SPEAKER_LFE)            dwStandardMask |= SPEAKER_LOW_FREQUENCY;
+    if (bXmaMask & XMA_SPEAKER_LEFT_SURROUND)  dwStandardMask |= SPEAKER_SIDE_LEFT;
+    if (bXmaMask & XMA_SPEAKER_RIGHT_SURROUND) dwStandardMask |= SPEAKER_SIDE_RIGHT;
+    if (bXmaMask & XMA_SPEAKER_LEFT_BACK)      dwStandardMask |= SPEAKER_BACK_LEFT;
+    if (bXmaMask & XMA_SPEAKER_RIGHT_BACK)     dwStandardMask |= SPEAKER_BACK_RIGHT;
+
+    return dwStandardMask;
+}
+
+__inline BYTE GetXmaChannelMaskFromStandardMask(DWORD dwStandardMask)
+{
+    BYTE bXmaMask = 0;
+
+    if (dwStandardMask & SPEAKER_FRONT_LEFT)    bXmaMask |= XMA_SPEAKER_LEFT;
+    if (dwStandardMask & SPEAKER_FRONT_RIGHT)   bXmaMask |= XMA_SPEAKER_RIGHT;
+    if (dwStandardMask & SPEAKER_FRONT_CENTER)  bXmaMask |= XMA_SPEAKER_CENTER;
+    if (dwStandardMask & SPEAKER_LOW_FREQUENCY) bXmaMask |= XMA_SPEAKER_LFE;
+    if (dwStandardMask & SPEAKER_SIDE_LEFT)     bXmaMask |= XMA_SPEAKER_LEFT_SURROUND;
+    if (dwStandardMask & SPEAKER_SIDE_RIGHT)    bXmaMask |= XMA_SPEAKER_RIGHT_SURROUND;
+    if (dwStandardMask & SPEAKER_BACK_LEFT)     bXmaMask |= XMA_SPEAKER_LEFT_BACK;
+    if (dwStandardMask & SPEAKER_BACK_RIGHT)    bXmaMask |= XMA_SPEAKER_RIGHT_BACK;
+
+    return bXmaMask;
+}
+
+
+// LocalizeXma2Format: Modifies a XMA2WAVEFORMATEX structure in place to comply
+// with the current platform's byte-ordering rules (little- or big-endian).
+
+__inline HRESULT LocalizeXma2Format(__inout XMA2WAVEFORMATEX* pXma2Format)
+{
+    #define XMASWAP2BYTES(n) ((WORD)(((n) >> 8) | (((n) & 0xff) << 8)))
+    #define XMASWAP4BYTES(n) ((DWORD)((n) >> 24 | (n) << 24 | ((n) & 0xff00) << 8 | ((n) & 0xff0000) >> 8))
+
+    if (pXma2Format->wfx.wFormatTag == WAVE_FORMAT_XMA2)
+    {
+        return S_OK;
+    }
+    else if (XMASWAP2BYTES(pXma2Format->wfx.wFormatTag) == WAVE_FORMAT_XMA2)
+    {
+        pXma2Format->wfx.wFormatTag      = XMASWAP2BYTES(pXma2Format->wfx.wFormatTag);
+        pXma2Format->wfx.nChannels       = XMASWAP2BYTES(pXma2Format->wfx.nChannels);
+        pXma2Format->wfx.nSamplesPerSec  = XMASWAP4BYTES(pXma2Format->wfx.nSamplesPerSec);
+        pXma2Format->wfx.nAvgBytesPerSec = XMASWAP4BYTES(pXma2Format->wfx.nAvgBytesPerSec);
+        pXma2Format->wfx.nBlockAlign     = XMASWAP2BYTES(pXma2Format->wfx.nBlockAlign);
+        pXma2Format->wfx.wBitsPerSample  = XMASWAP2BYTES(pXma2Format->wfx.wBitsPerSample);
+        pXma2Format->wfx.cbSize          = XMASWAP2BYTES(pXma2Format->wfx.cbSize);
+        pXma2Format->NumStreams          = XMASWAP2BYTES(pXma2Format->NumStreams);
+        pXma2Format->ChannelMask         = XMASWAP4BYTES(pXma2Format->ChannelMask);
+        pXma2Format->SamplesEncoded      = XMASWAP4BYTES(pXma2Format->SamplesEncoded);
+        pXma2Format->BytesPerBlock       = XMASWAP4BYTES(pXma2Format->BytesPerBlock);
+        pXma2Format->PlayBegin           = XMASWAP4BYTES(pXma2Format->PlayBegin);
+        pXma2Format->PlayLength          = XMASWAP4BYTES(pXma2Format->PlayLength);
+        pXma2Format->LoopBegin           = XMASWAP4BYTES(pXma2Format->LoopBegin);
+        pXma2Format->LoopLength          = XMASWAP4BYTES(pXma2Format->LoopLength);
+        pXma2Format->BlockCount          = XMASWAP2BYTES(pXma2Format->BlockCount);
+        return S_OK;
+    }
+    else
+    {
+        return E_FAIL; // Not a recognizable XMA2 format
+    }
+
+    #undef XMASWAP2BYTES
+    #undef XMASWAP4BYTES
+}
+
+
+#endif // #ifndef __XMA2DEFS_INCLUDED__

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ branches:
 
 before_build:
  # until git for win 2.5 release with commit checkout
- - git submodule update --init 3rdparty/ffmpeg asmjit 3rdparty/minidx9 rsx_program_decompiler 3rdparty/GSL 3rdparty/libpng Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
+ - git submodule update --init 3rdparty/ffmpeg asmjit rsx_program_decompiler 3rdparty/GSL 3rdparty/libpng Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
  - 7z x wxWidgets.7z -aos -oC:\rpcs3\wxWidgets > null
  - 7z x zlib.7z -aos -oC:\rpcs3\ > null
  - if %configuration%==Release (cmake -G "Visual Studio 14 Win64" -DZLIB_ROOT=C:/rpcs3/zlib/)

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -124,7 +124,7 @@ ${LLVM_INCLUDE_DIRS}
 "${RPCS3_SRC_DIR}/../3rdparty/stblib"
 )
 if(WIN32)
-	include_directories(BEFORE "${RPCS3_SRC_DIR}/../3rdparty/minidx9/Include")
+	include_directories(BEFORE "${RPCS3_SRC_DIR}/../3rdparty/XAudio2_7") # Slimmed down version of minidx9 for XAudio2_7 only
 	include_directories(BEFORE "${RPCS3_SRC_DIR}/../3rdparty/minidx12/Include")
 endif()
 

--- a/rpcs3/Emu/Audio/XAudio2/XAudio2Thread.h
+++ b/rpcs3/Emu/Audio/XAudio2/XAudio2Thread.h
@@ -6,7 +6,7 @@
 #pragma push_macro("_WIN32_WINNT")
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601 // This is to be sure that correct (2.7) header is included
-#include "XAudio2.h" // XAudio2 2.8 available only on Win8+, used XAudio2 2.7 from dxsdk
+#include "3rdparty/XAudio2_7/XAudio2.h" // XAudio2 2.8 available only on Win8+, used XAudio2 2.7 from dxsdk
 #pragma pop_macro("_WIN32_WINNT")
 
 class XAudio2Thread : public AudioThread

--- a/rpcs3/Emu/Audio/XAudio2/XAudio2Thread.h
+++ b/rpcs3/Emu/Audio/XAudio2/XAudio2Thread.h
@@ -6,7 +6,7 @@
 #pragma push_macro("_WIN32_WINNT")
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601 // This is to be sure that correct (2.7) header is included
-#include "3rdparty/minidx9/Include/XAudio2.h" // XAudio2 2.8 available only on Win8+, used XAudio2 2.7 from dxsdk
+#include "XAudio2.h" // XAudio2 2.8 available only on Win8+, used XAudio2 2.7 from dxsdk
 #pragma pop_macro("_WIN32_WINNT")
 
 class XAudio2Thread : public AudioThread

--- a/rpcs3/XAudio.vcxproj
+++ b/rpcs3/XAudio.vcxproj
@@ -63,7 +63,7 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\3rdparty\minidx9\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\3rdparty\XAudio2_7;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -91,7 +91,7 @@
       <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
     </ProjectReference>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\3rdparty\minidx9\Include;..\Vulkan\Vulkan-LoaderAndValidationLayers\include;..\Vulkan\glslang\glslang\Public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\3rdparty\XAudio2_7;..\Vulkan\Vulkan-LoaderAndValidationLayers\include;..\Vulkan\glslang\glslang\Public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'">..\Vulkan\glslang-build\SPIRV\Debug;..\Vulkan\glslang-build\OGLCompilersDLL\Debug;..\Vulkan\glslang-build\glslang\OSDependent\Windows\Debug;..\Vulkan\Vulkan-build\loader\Debug;..\Vulkan\glslang-build\glslang\Debug;..\3rdparty\OpenAL\libs\Win64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION
Removes minidx9 as a submodule
Slims down minidx9 in order to only keep the files XAudio2 (2.7) needs. The other dx9 related files weren't being used.

~~Don't merge yet as requested by Nekotekina.~~