### PR TITLE
Rsx: Slight interface changes.

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -23,7 +23,7 @@ size_t get_placed_texture_storage_size(const rsx::texture &texture, size_t rowPi
  */
 std::vector<rsx_subresource_layout> get_subresources_layout(const rsx::texture &texture);
 
-void upload_texture_subresource(gsl::span<gsl::byte> dst_buffer, const rsx_subresource_layout &src_layout, int format, bool is_swizzled, size_t dst_row_alignment);
+void upload_texture_subresource(gsl::span<gsl::byte> dst_buffer, const rsx_subresource_layout &src_layout, int format, bool is_swizzled, size_t dst_row_pitch_multiple_of);
 
 u8 get_format_block_size_in_bytes(int format);
 u8 get_format_block_size_in_texel(int format);

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -58,7 +58,7 @@ namespace rsx
 			}
 		}
 
-	private:
+	protected:
 		using surface_storage_type = typename Traits::surface_storage_type;
 		using surface_type = typename Traits::surface_type;
 		using command_list_type = typename Traits::command_list_type;
@@ -76,7 +76,7 @@ namespace rsx
 		surface_store() = default;
 		~surface_store() = default;
 		surface_store(const surface_store&) = delete;
-	private:
+	protected:
 		/**
 		* If render target already exists at address, issue state change operation on cmdList.
 		* Otherwise create one with width, height, clearColor info.


### PR DESCRIPTION
This PR changes some private into protected and make TextureUtils interpret dst_pitch as a multiplicity constraints instead of an alignment one (which is stricter).