### PR TITLE
vulkan: Use simpler image object

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -39,6 +39,32 @@ VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support,
 	throw EXCEPTION("Invalid format (0x%x)", format);
 }
 
+std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(u8 min_filter)
+{
+	switch (min_filter)
+	{
+	case CELL_GCM_TEXTURE_NEAREST: return std::make_tuple(VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST);
+	case CELL_GCM_TEXTURE_LINEAR: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
+	case CELL_GCM_TEXTURE_NEAREST_NEAREST: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
+	case CELL_GCM_TEXTURE_LINEAR_NEAREST: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
+	case CELL_GCM_TEXTURE_NEAREST_LINEAR: return std::make_tuple(VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_LINEAR);
+	case CELL_GCM_TEXTURE_LINEAR_LINEAR: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR);
+	case CELL_GCM_TEXTURE_CONVOLUTION_MIN: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR);
+	}
+	throw EXCEPTION("Invalid max filter (0x%x)", min_filter);
+}
+
+VkFilter get_mag_filter(u8 mag_filter)
+{
+	switch (mag_filter)
+	{
+	case CELL_GCM_TEXTURE_NEAREST: return VK_FILTER_NEAREST;
+	case CELL_GCM_TEXTURE_LINEAR: return VK_FILTER_LINEAR;
+	case CELL_GCM_TEXTURE_CONVOLUTION_MAG: return VK_FILTER_LINEAR;
+	}
+	throw EXCEPTION("Invalid mag filter (0x%x)", mag_filter);
+}
+
 VkSamplerAddressMode vk_wrap_mode(u32 gcm_wrap)
 {
 	switch (gcm_wrap)

--- a/rpcs3/Emu/RSX/VK/VKFormats.h
+++ b/rpcs3/Emu/RSX/VK/VKFormats.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "VKHelpers.h"
+#include <tuple>
 
 namespace vk
 {
@@ -11,6 +12,9 @@ namespace vk
 
 	gpu_formats_support get_optimal_tiling_supported_formats(VkPhysicalDevice physical_device);
 	VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support, rsx::surface_depth_format format);
+
+	std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(u8 min_filter);
+	VkFilter get_mag_filter(u8 mag_filter);
 	VkSamplerAddressMode vk_wrap_mode(u32 gcm_wrap);
 	float max_aniso(u32 gcm_aniso);
 	VkComponentMapping get_component_mapping(u32 format, u8 swizzle_mask);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -12,87 +12,6 @@
 
 #pragma comment(lib, "VKstatic.1.lib")
 
-namespace vk
-{
-// TODO: factorize between backends
-class data_heap
-{
-	/**
-	* Does alloc cross get position ?
-	*/
-	template<int Alignement>
-	bool can_alloc(size_t size) const
-	{
-		size_t alloc_size = align(size, Alignement);
-		size_t aligned_put_pos = align(m_put_pos, Alignement);
-		if (aligned_put_pos + alloc_size < m_size)
-		{
-			// range before get
-			if (aligned_put_pos + alloc_size < m_get_pos)
-				return true;
-			// range after get
-			if (aligned_put_pos > m_get_pos)
-				return true;
-			return false;
-		}
-		else
-		{
-			// ..]....[..get..
-			if (aligned_put_pos < m_get_pos)
-				return false;
-			// ..get..]...[...
-			// Actually all resources extending beyond heap space starts at 0
-			if (alloc_size > m_get_pos)
-				return false;
-			return true;
-		}
-	}
-
-	size_t m_size;
-	size_t m_put_pos; // Start of free space
-public:
-	data_heap() = default;
-	~data_heap() = default;
-	data_heap(const data_heap&) = delete;
-	data_heap(data_heap&&) = delete;
-
-	size_t m_get_pos; // End of free space
-
-	void init(size_t heap_size)
-	{
-		m_size = heap_size;
-		m_put_pos = 0;
-		m_get_pos = heap_size - 1;
-	}
-
-	template<int Alignement>
-	size_t alloc(size_t size)
-	{
-		if (!can_alloc<Alignement>(size)) throw EXCEPTION("Working buffer not big enough");
-		size_t alloc_size = align(size, Alignement);
-		size_t aligned_put_pos = align(m_put_pos, Alignement);
-		if (aligned_put_pos + alloc_size < m_size)
-		{
-			m_put_pos = aligned_put_pos + alloc_size;
-			return aligned_put_pos;
-		}
-		else
-		{
-			m_put_pos = alloc_size;
-			return 0;
-		}
-	}
-
-	/**
-	* return current putpos - 1
-	*/
-	size_t get_current_put_pos_minus_one() const
-	{
-		return (m_put_pos - 1 > 0) ? m_put_pos - 1 : m_size - 1;
-	}
-};
-}
-
 class VKGSRender : public GSRender
 {
 private:
@@ -130,6 +49,8 @@ private:
 	std::unique_ptr<vk::buffer> m_uniform_buffer;
 	vk::data_heap m_index_buffer_ring_info;
 	std::unique_ptr<vk::buffer> m_index_buffer;
+	vk::data_heap m_texture_upload_buffer_ring_info;
+	std::unique_ptr<vk::buffer> m_texture_upload_buffer;
 
 	//Vulkan internals
 	u32 m_current_present_image = 0xFFFF;
@@ -152,6 +73,7 @@ private:
 
 	std::vector<std::unique_ptr<vk::buffer_view> > m_buffer_view_to_clean;
 	std::vector<std::unique_ptr<vk::framebuffer> > m_framebuffer_to_clean;
+	std::vector<std::unique_ptr<vk::sampler> > m_sampler_to_clean;
 
 	u32 m_draw_calls = 0;
 	

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -10,41 +10,49 @@ namespace rsx
 {
 	struct vk_render_target_traits
 	{
-		using surface_storage_type = vk::texture ;
-		using surface_type = vk::texture*;
+		using surface_storage_type = std::unique_ptr<vk::image>;
+		using surface_type = vk::image*;
 		using command_list_type = vk::command_buffer*;
 		using download_buffer_object = void*;
 
-		static vk::texture create_new_surface(u32 address, surface_color_format format, size_t width, size_t height, vk::render_device &device, vk::command_buffer *cmd, const vk::gpu_formats_support &support)
+		static std::unique_ptr<vk::image> create_new_surface(u32 address, surface_color_format format, size_t width, size_t height, vk::render_device &device, vk::command_buffer *cmd, const vk::gpu_formats_support &support, const vk::memory_type_mapping &mem_mapping)
 		{
 			VkFormat requested_format = vk::get_compatible_surface_format(format);
-			
-			vk::texture rtt;
-			rtt.create(device, requested_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT|VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_SAMPLED_BIT, width, height, 1, true);
-			rtt.change_layout(*cmd, VK_IMAGE_LAYOUT_GENERAL);
 
+			std::unique_ptr<vk::image> rtt;
+			rtt.reset(new vk::image(device, mem_mapping.device_local,
+				VK_IMAGE_TYPE_2D,
+				requested_format,
+				width, height, 1, 1, 1,
+				VK_SAMPLE_COUNT_1_BIT,
+				VK_IMAGE_LAYOUT_UNDEFINED,
+				VK_IMAGE_TILING_OPTIMAL,
+				VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT|VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_SAMPLED_BIT,
+				0));
+			change_image_layout(*cmd, rtt->value, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
 			//Clear new surface
 			VkClearColorValue clear_color;
 			VkImageSubresourceRange range = vk::default_image_subresource_range();
-		
+
 			clear_color.float32[0] = 0.f;
 			clear_color.float32[1] = 0.f;
 			clear_color.float32[2] = 0.f;
 			clear_color.float32[3] = 0.f;
 
-			vkCmdClearColorImage(*cmd, rtt, rtt.get_layout(), &clear_color, 1, &range);
-			rtt.change_layout(*cmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+			vkCmdClearColorImage(*cmd, rtt->value, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
+			change_image_layout(*cmd, rtt->value, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_ASPECT_COLOR_BIT);
 
 			return rtt;
 		}
 
-		static vk::texture create_new_surface(u32 address, surface_depth_format format, size_t width, size_t height, vk::render_device &device, vk::command_buffer *cmd, const vk::gpu_formats_support &support)
+		static std::unique_ptr<vk::image> create_new_surface(u32 address, surface_depth_format format, size_t width, size_t height, vk::render_device &device, vk::command_buffer *cmd, const vk::gpu_formats_support &support, const vk::memory_type_mapping &mem_mapping)
 		{
 			VkFormat requested_format = vk::get_compatible_depth_surface_format(support, format);
 
-			vk::texture rtt;
-			rtt.create(device, requested_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT|VK_IMAGE_USAGE_SAMPLED_BIT, width, height, 1, true);
-			rtt.change_layout(*cmd, VK_IMAGE_LAYOUT_GENERAL);
+			std::unique_ptr<vk::image> ds;
+			ds.reset(new vk::image(device, mem_mapping.device_local,
+				VK_IMAGE_TYPE_2D, requested_format, width, height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT|VK_IMAGE_USAGE_SAMPLED_BIT, 0));
+			change_image_layout(*cmd, ds->value, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
 			//Clear new surface..
 			VkClearDepthStencilValue clear_depth = {};
@@ -61,54 +69,52 @@ namespace rsx
 			clear_depth.depth = 1.f;
 			clear_depth.stencil = 0;
 
-			vkCmdClearDepthStencilImage(*cmd, rtt, rtt.get_layout(), &clear_depth, 1, &range);
-			rtt.change_layout(*cmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-			
-			return rtt;
+			vkCmdClearDepthStencilImage(*cmd, ds->value, VK_IMAGE_LAYOUT_GENERAL, &clear_depth, 1, &range);
+			change_image_layout(*cmd, ds->value, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+
+			return ds;
 		}
 
-		static void prepare_rtt_for_drawing(vk::command_buffer* pcmd, vk::texture *surface)
+		static void prepare_rtt_for_drawing(vk::command_buffer* pcmd, vk::image *surface)
 		{
-			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+//			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 		}
 
-		static void prepare_rtt_for_sampling(vk::command_buffer* pcmd, vk::texture *surface)
+		static void prepare_rtt_for_sampling(vk::command_buffer* pcmd, vk::image *surface)
 		{
-			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+//			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 		}
 
-		static void prepare_ds_for_drawing(vk::command_buffer* pcmd, vk::texture *surface)
+		static void prepare_ds_for_drawing(vk::command_buffer* pcmd, vk::image *surface)
 		{
-			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+//			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 		}
 
-		static void prepare_ds_for_sampling(vk::command_buffer* pcmd, vk::texture *surface)
+		static void prepare_ds_for_sampling(vk::command_buffer* pcmd, vk::image *surface)
 		{
-			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+//			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 		}
 
-		static bool rtt_has_format_width_height(const vk::texture &rtt, surface_color_format format, size_t width, size_t height)
+		static bool rtt_has_format_width_height(const std::unique_ptr<vk::image> &rtt, surface_color_format format, size_t width, size_t height)
 		{
 			VkFormat fmt = vk::get_compatible_surface_format(format);
-			vk::texture &tex = const_cast<vk::texture&>(rtt);
-			
-			if (tex.get_format() == fmt &&
-				tex.width() == width &&
-				tex.height() == height)
+
+			if (rtt->info.format == fmt &&
+				rtt->info.extent.width == width &&
+				rtt->info.extent.height == height)
 				return true;
 
 			return false;
 		}
 
-		static bool ds_has_format_width_height(const vk::texture &ds, surface_depth_format format, size_t width, size_t height)
+		static bool ds_has_format_width_height(const std::unique_ptr<vk::image> &ds, surface_depth_format format, size_t width, size_t height)
 		{
 			// TODO: check format
 			//VkFormat fmt = vk::get_compatible_depth_surface_format(format);
-			vk::texture &tex = const_cast<vk::texture&>(ds);
 
 			if (//tex.get_format() == fmt &&
-				tex.width() == width &&
-				tex.height() == height)
+				ds->info.extent.width == width &&
+				ds->info.extent.height == height)
 				return true;
 
 			return false;
@@ -138,13 +144,19 @@ namespace rsx
 		{
 		}
 
-		static vk::texture *get(const vk::texture &tex)
+		static vk::image *get(const std::unique_ptr<vk::image> &tex)
 		{
-			return const_cast<vk::texture*>(&tex);
+			return tex.get();
 		}
 	};
 
 	struct vk_render_targets : public rsx::surface_store<vk_render_target_traits>
 	{
+
+		void destroy()
+		{
+			m_render_targets_storage.clear();
+			m_depth_stencil_storage.clear();
+		}
 	};
 }


### PR DESCRIPTION
This PR uses a new struct, image, holding texture data.

It may fix https://github.com/RPCS3/rpcs3/issues/1597 (on my computer it does). The backend uses a staging texture everytime so the limitation on linear tiling are less important.

It fixes the green hue in Hitman 2 opening credits too.