### PR TITLE
gl: Expand index for quads/quad_strip/triangle_fan

### DIFF
--- a/rpcs3/Emu/RSX/GL/gl_helpers.cpp
+++ b/rpcs3/Emu/RSX/GL/gl_helpers.cpp
@@ -16,9 +16,9 @@ namespace gl
 		case rsx::primitive_type::triangles: return GL_TRIANGLES;
 		case rsx::primitive_type::triangle_strip: return GL_TRIANGLE_STRIP;
 		case rsx::primitive_type::triangle_fan: return GL_TRIANGLE_FAN;
-		case rsx::primitive_type::quads: return GL_QUADS;
-		case rsx::primitive_type::quad_strip: return GL_QUAD_STRIP;
-		case rsx::primitive_type::polygon: return GL_POLYGON;
+		case rsx::primitive_type::quads: return GL_TRIANGLES;
+		case rsx::primitive_type::quad_strip: return GL_TRIANGLES;
+		case rsx::primitive_type::polygon: return GL_TRIANGLES;
 		}
 		throw new EXCEPTION("unknow primitive type");
 	}


### PR DESCRIPTION
This PR makes gl uses the same codepath as DX12 and Vulkan renderer for indexing.
Indexing doesn't use deprecated QUADS or POLYGON mode.

This should allow the backend to use core context.