### PR TITLE
gl: Fix RTT clamp mode; Fix vertex winding for emulated QUAD_STRIP triangles

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -333,8 +333,8 @@ void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst,
 			typedDst[6 * i + 2] = 2 * i + 2 + first;
 			// Second triangle
 			typedDst[6 * i + 3] = 2 * i + 2 + first;
-			typedDst[6 * i + 4] = 2 * i + 3 + first;
-			typedDst[6 * i + 5] = 2 * i + 1 + first;
+			typedDst[6 * i + 4] = 2 * i + 1 + first;
+			typedDst[6 * i + 5] = 2 * i + 3 + first;
 		}
 		return;
 	case rsx::primitive_type::points:

--- a/rpcs3/Emu/RSX/GL/gl_render_targets.h
+++ b/rpcs3/Emu/RSX/GL/gl_render_targets.h
@@ -94,6 +94,7 @@ struct gl_render_target_traits
 			.type(format.type)
 			.format(format.format)
 			.swizzle(format.swizzle.r, format.swizzle.g, format.swizzle.b, format.swizzle.a)
+			.wrap(gl::texture::wrap::clamp_to_border, gl::texture::wrap::clamp_to_border, gl::texture::wrap::clamp_to_border)
 			.apply();
 
 		__glcheck result->pixel_pack_settings().swap_bytes(format.swap_bytes).aligment(1);
@@ -120,6 +121,7 @@ struct gl_render_target_traits
 			.type(format.type)
 			.format(format.format)
 			.internal_format(format.internal_format)
+			.wrap(gl::texture::wrap::clamp_to_border, gl::texture::wrap::clamp_to_border, gl::texture::wrap::clamp_to_border)
 			.apply();
 
 		__glcheck result->pixel_pack_settings().aligment(1);


### PR DESCRIPTION
Fix repeating shadows due to incorrect sampling mode. https://github.com/RPCS3/rpcs3/issues/1568

Index winding for quad strips was broken, but somehow worked on NV (DX12) for some reason. Should fix quad strip emulation for AMD gpus, both AMD and NVIDIA. Vulkan did not enable culling, hence verts are rendered even with incorrect winding.