### PR TITLE
Vulkan: Fix some cleaning behavior.

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -613,7 +613,6 @@ void VKGSRender::end()
 
 	vkCmdEndRenderPass(m_command_buffer);
 
-	m_texture_cache.flush(m_command_buffer);
 
 	end_command_buffer_recording();
 	execute_command_buffer(false);
@@ -1246,6 +1245,7 @@ void VKGSRender::flip(int buffer)
 	//Feed back damaged resources to the main texture cache for management...
 //	m_texture_cache.merge_dirty_textures(m_rtts.invalidated_resources);
 	m_rtts.invalidated_resources.clear();
+	m_texture_cache.flush();
 
 	m_buffer_view_to_clean.clear();
 	m_sampler_to_clean.clear();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1249,6 +1249,7 @@ void VKGSRender::flip(int buffer)
 
 	m_buffer_view_to_clean.clear();
 	m_sampler_to_clean.clear();
+	m_framebuffer_to_clean.clear();
 
 	m_draw_calls = 0;
 	dirty_frame = true;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -30,7 +30,6 @@ namespace vk
 	{
 	private:
 		std::vector<cached_texture_object> m_cache;
-		u32 num_dirty_textures = 0;
 
 		std::vector<std::unique_ptr<vk::image_view> > m_temporary_image_view;
 
@@ -138,8 +137,6 @@ namespace vk
 					tex.exists = false;
 				}
 			}
-
-			num_dirty_textures = 0;
 		}
 
 	public:
@@ -154,15 +151,6 @@ namespace vk
 
 		vk::image_view* upload_texture(command_buffer cmd, rsx::texture &tex, rsx::vk_render_targets &m_rtts, const vk::memory_type_mapping &memory_type_mapping, data_heap& upload_heap, vk::buffer* upload_buffer)
 		{
-			if (num_dirty_textures > 32)
-			{
-				/**
-				 * Should actually reuse available dirty textures whenever possible.
-				 * For now, just remove them, from vram
-				 */
-				purge_dirty_textures();
-			}
-
 			const u32 texaddr = rsx::get_address(tex.offset(), tex.location());
 			const u32 range = (u32)get_texture_size(tex);
 
@@ -237,7 +225,6 @@ namespace vk
 				{
 					unlock_object(tex);
 
-					num_dirty_textures++;
 					tex.native_rsx_address = 0;
 					tex.dirty = true;
 
@@ -248,7 +235,7 @@ namespace vk
 			return false;
 		}
 
-		void flush(vk::command_buffer &cmd)
+		void flush()
 		{
 			m_temporary_image_view.clear();
 		}


### PR DESCRIPTION
This PR clean framebuffer after flip (the change slipped from a previous PR) and flush texture cache only at flip, not inside a draw call.