### PR TITLE
build: Upload vulkan loader to tag sdk-1.0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ __Windows__
 * [Visual C++ Redistributable Packages for Visual Studio 2015](http://www.microsoft.com/en-us/download/details.aspx?id=48145)
 * [Cmake 3.1.0+](http://www.cmake.org/download/) (required; add to PATH)
 * [Python 3.3+](https://www.python.org/downloads/) (required; add to PATH)
+* [Vulkan SDK 1.0.5.0](https://vulkan.lunarg.com/signin) (optional; needed for debug layers)
 
 __Linux__
 * GCC 5.1+ or Clang 3.5.0+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
  - ps: Start-FileDownload 'https://402331b94f8e4b87ae2ef4677347f7956cf3861f.googledrive.com/host/0B6v_qtb9hkicfmt0NG0wTTRtUmF4X3VTQk5Oc2JidEVKVnUteDA1dXdrYlNsVW9kREpsSHc/zlib.7z'
  - set WXWIN=C:\rpcs3\wxWidgets
  - set OPENALDIR=C:\rpcs3\3rdparty\OpenAL
- - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;C:\wxWidgets;%PATH%
+ - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;C:\wxWidgets;C:\Python35-x64;%PATH%
  - set COMMIT_SHA=%APPVEYOR_REPO_COMMIT:~0,8%
 
 artifacts:


### PR DESCRIPTION
This allows to use the latest Vulkan SDK (which has improved debug layers)