### PR TITLE
Don't build rsx_program_decompiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
     fi;
 
 before_script:
- - git submodule update --init asmjit 3rdparty/ffmpeg rsx_program_decompiler 3rdparty/GSL 3rdparty/libpng Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
+ - git submodule update --init asmjit 3rdparty/ffmpeg 3rdparty/GSL 3rdparty/libpng Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
  - mkdir build
  - cd build
  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cmake ..; else cmake .. -DLLVM_DIR=/usr/local/opt/llvm36/lib/llvm-3.6/share/llvm/cmake; fi


### PR DESCRIPTION
To cut down on warning noise (6500+ -> ~1800 lines in travis clang build). We don't use it anywhere afaik (and newer sha with fixed warnings has conflicts with rpcs3).