### PR TITLE
d3d12: Move sampler DescriptorHeap selection in D3D12GSRender

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -345,6 +345,19 @@ void D3D12GSRender::end()
 	size_t texture_count = std::get<2>(m_current_pso);
 	if (texture_count > 0)
 	{
+		if (get_current_resource_storage().current_sampler_index + 16 > 2048)
+		{
+			get_current_resource_storage().sampler_descriptors_heap_index = 1;
+			get_current_resource_storage().current_sampler_index = 0;
+
+			ID3D12DescriptorHeap *descriptors[] =
+			{
+				get_current_resource_storage().descriptors_heap.Get(),
+				get_current_resource_storage().sampler_descriptor_heap[get_current_resource_storage().sampler_descriptors_heap_index].Get(),
+			};
+			get_current_resource_storage().command_list->SetDescriptorHeaps(2, descriptors);
+		}
+
 		upload_textures(get_current_resource_storage().command_list.Get(), texture_count);
 
 		m_device->CopyDescriptorsSimple(16,

--- a/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
@@ -361,19 +361,6 @@ void D3D12GSRender::upload_textures(ID3D12GraphicsCommandList *command_list, siz
 			.Offset((UINT)i, m_descriptor_stride_srv_cbv_uav)
 			);
 
-		if (get_current_resource_storage().current_sampler_index + 16 > 2048)
-		{
-			get_current_resource_storage().sampler_descriptors_heap_index = 1;
-			get_current_resource_storage().current_sampler_index = 0;
-
-			ID3D12DescriptorHeap *descriptors[] =
-			{
-				get_current_resource_storage().descriptors_heap.Get(),
-				get_current_resource_storage().sampler_descriptor_heap[get_current_resource_storage().sampler_descriptors_heap_index].Get(),
-			};
-			command_list->SetDescriptorHeaps(2, descriptors);
-		}
-
 		m_device->CreateSampler(&get_sampler_desc(textures[i]),
 			CD3DX12_CPU_DESCRIPTOR_HANDLE(m_current_sampler_descriptors->GetCPUDescriptorHandleForHeapStart())
 			.Offset((UINT)i, m_descriptor_stride_samplers));


### PR DESCRIPTION
Avoid sampler descriptor being stored on 2 heaps inside a single draw
call. Fix somes crashes.