### PR TITLE
gl: Specify buffer to read for blitting during flip; Remove some deprecated gl from core

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -156,13 +156,11 @@ void GLGSRender::begin()
 		}
 	}
 
-	__glcheck glShadeModel(rsx::method_registers[NV4097_SET_SHADE_MODE]);
-
 	if (u32 blend_mrt = rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT])
 	{
-		__glcheck enable(blend_mrt & 2, GL_BLEND, GL_COLOR_ATTACHMENT1);
-		__glcheck enable(blend_mrt & 4, GL_BLEND, GL_COLOR_ATTACHMENT2);
-		__glcheck enable(blend_mrt & 8, GL_BLEND, GL_COLOR_ATTACHMENT3);
+		__glcheck enable(blend_mrt & 2, GL_BLEND, 1);
+		__glcheck enable(blend_mrt & 4, GL_BLEND, 2);
+		__glcheck enable(blend_mrt & 8, GL_BLEND, 3);
 	}
 	
 	if (__glcheck enable(rsx::method_registers[NV4097_SET_LOGIC_OP_ENABLE], GL_COLOR_LOGIC_OP))

--- a/rpcs3/Emu/RSX/GL/gl_helpers.cpp
+++ b/rpcs3/Emu/RSX/GL/gl_helpers.cpp
@@ -122,6 +122,14 @@ namespace gl
 		__glcheck glDrawBuffers((GLsizei)ids.size(), ids.data());
 	}
 
+	void fbo::read_buffer(const attachment& buffer) const
+	{
+		save_binding_state save(*this);
+		GLenum buf = buffer.id();
+
+		__glcheck glReadBuffer(buf);
+	}
+
 	void fbo::draw_arrays(rsx::primitive_type mode, GLsizei count, GLint first) const
 	{
 		save_binding_state save(*this);

--- a/rpcs3/Emu/RSX/GL/gl_helpers.h
+++ b/rpcs3/Emu/RSX/GL/gl_helpers.h
@@ -1550,6 +1550,8 @@ namespace gl
 		void recreate();
 		void draw_buffer(const attachment& buffer) const;
 		void draw_buffers(const std::initializer_list<attachment>& indexes) const;
+		
+		void read_buffer(const attachment& buffer) const;
 
 		void draw_arrays(rsx::primitive_type mode, GLsizei count, GLint first = 0) const;
 		void draw_arrays(const buffer& buffer, rsx::primitive_type mode, GLsizei count, GLint first = 0) const;

--- a/rpcs3/Emu/RSX/GL/gl_render_targets.cpp
+++ b/rpcs3/Emu/RSX/GL/gl_render_targets.cpp
@@ -76,6 +76,7 @@ void GLGSRender::init_buffers(bool skip_reading)
 
 	if (draw_fbo && !m_rtts_dirty)
 		return;
+
 	m_rtts_dirty = false;
 
 	m_rtts.prepare_render_target(nullptr, surface_format, clip_horizontal, clip_vertical, rsx::to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET]),
@@ -88,9 +89,12 @@ void GLGSRender::init_buffers(bool skip_reading)
 		if (std::get<0>(m_rtts.m_bound_render_targets[i]) != 0)
 			__glcheck draw_fbo.color[i] = *std::get<1>(m_rtts.m_bound_render_targets[i]);
 	}
+
 	if (std::get<0>(m_rtts.m_bound_depth_stencil) != 0)
 		__glcheck draw_fbo.depth = *std::get<1>(m_rtts.m_bound_depth_stencil);
+
 	__glcheck draw_fbo.check();
+	__glcheck draw_fbo.read_buffer(draw_fbo.color[0]);
 
 
 	switch (rsx::to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET]))
@@ -102,8 +106,11 @@ void GLGSRender::init_buffers(bool skip_reading)
 		break;
 
 	case rsx::surface_target::surface_b:
+	{
 		__glcheck draw_fbo.draw_buffer(draw_fbo.color[1]);
+		__glcheck draw_fbo.read_buffer(draw_fbo.color[1]);
 		break;
+	}
 
 	case rsx::surface_target::surfaces_a_b:
 		__glcheck draw_fbo.draw_buffers({ draw_fbo.color[0], draw_fbo.color[1] });

--- a/rpcs3/Emu/RSX/GL/rsx_gl_texture.cpp
+++ b/rpcs3/Emu/RSX/GL/rsx_gl_texture.cpp
@@ -213,7 +213,7 @@ namespace rsx
 			case rsx::texture_wrap_mode::mirror: return GL_MIRRORED_REPEAT;
 			case rsx::texture_wrap_mode::clamp_to_edge: return GL_CLAMP_TO_EDGE;
 			case rsx::texture_wrap_mode::border: return GL_CLAMP_TO_BORDER;
-			case rsx::texture_wrap_mode::clamp: return GL_CLAMP;
+			case rsx::texture_wrap_mode::clamp: return GL_CLAMP_TO_BORDER;
 			case rsx::texture_wrap_mode::mirror_once_clamp_to_edge: return GL_MIRROR_CLAMP_TO_EDGE_EXT;
 			case rsx::texture_wrap_mode::mirror_once_border: return GL_MIRROR_CLAMP_TO_BORDER_EXT;
 			case rsx::texture_wrap_mode::mirror_once_clamp: return GL_MIRROR_CLAMP_EXT;


### PR DESCRIPTION
glBlitFramebuffer needs to be directed to the right buffer to read pixels from in case we arent drawing to the first attachment (COLOR_ATTACHMENT0).
Should fix black screens when using OpenGL https://github.com/RPCS3/rpcs3/issues/1658

glShadeModel and GL_CLAMP are deprecated in core.
The index used to enable MRT blending is zero based in core according to debug validation for both AMD and NVIDIA