### PR TITLE
Speculative fix for OpenGL crash

### DIFF
--- a/rpcs3/Emu/RSX/GL/vertex_buffer.cpp
+++ b/rpcs3/Emu/RSX/GL/vertex_buffer.cpp
@@ -319,7 +319,7 @@ void GLGSRender::set_vertex_buffer()
 
 					for (const auto &first_count : first_count_commands)
 					{
-						write_vertex_array_data_to_buffer(dest_span.subspan(offset), src_ptr, first_count.first, first_count.second, vertex_info.type, vertex_info.size, vertex_info.stride, rsx::get_vertex_type_size_on_host(vertex_info.type, vertex_info.stride));
+						write_vertex_array_data_to_buffer(dest_span.subspan(offset), src_ptr, first_count.first, first_count.second, vertex_info.type, vertex_info.size, vertex_info.stride, rsx::get_vertex_type_size_on_host(vertex_info.type, vertex_info.size));
 						offset += first_count.second * element_size;
 					}
 				}
@@ -329,7 +329,7 @@ void GLGSRender::set_vertex_buffer()
 					gsl::span<gsl::byte> dest_span(vertex_array);
 					prepare_buffer_for_writing(vertex_array.data(), vertex_info.type, vertex_info.size, vertex_draw_count);
 
-					write_vertex_array_data_to_buffer(dest_span, src_ptr, 0, max_index + 1, vertex_info.type, vertex_info.size, vertex_info.stride, rsx::get_vertex_type_size_on_host(vertex_info.type, vertex_info.stride));
+					write_vertex_array_data_to_buffer(dest_span, src_ptr, 0, max_index + 1, vertex_info.type, vertex_info.size, vertex_info.stride, rsx::get_vertex_type_size_on_host(vertex_info.type, vertex_info.size));
 				}
 
 				size_t size = vertex_array.size();


### PR DESCRIPTION
Looks like a typo from https://github.com/RPCS3/rpcs3/commit/3a3d264cb506febff60409ed5176207e8cb6f856 was causing the crash.
I'm currently unable to compile due to master build being broken with VS, but this should fix #1667 (and #1666).