### PR TITLE
Fix build on linux

### DIFF
--- a/rpcs3/Gui/GameViewer.cpp
+++ b/rpcs3/Gui/GameViewer.cpp
@@ -335,10 +335,16 @@ void ColumnsArr::Update(const std::vector<GameInfo>& game_data)
 		{
 			wxLogNull logNo; // temporary disable wx warnings ("iCCP: known incorrect sRGB profile" spamming)
 			if (game_icon.LoadFile(fmt::FromUTF8(path), wxBITMAP_TYPE_PNG))
+			{
 				game_icon.Rescale(80, 44, wxIMAGE_QUALITY_HIGH);
+				m_icon_indexes.push_back(m_img_list->Add(game_icon));
+			}
+			else
+			{
+				LOG_ERROR(GENERAL, "Error loading image %s", path);
+				m_icon_indexes.push_back(-1);
+			}
 		}
-
-		m_icon_indexes.push_back(m_img_list->Add(game_icon));
 	}
 }
 
@@ -376,7 +382,8 @@ void ColumnsArr::ShowData(wxListView* list)
 				list->SetItemData(i, i);
 			}
 			list->SetItem(i, c, fmt::FromUTF8(col->data[i]));
-			list->SetItemColumnImage(i, 0, m_icon_indexes[i]);
+			if (m_icon_indexes[i] >= 0)
+				list->SetItemColumnImage(i, 0, m_icon_indexes[i]);
 		}
 	}
 }


### PR DESCRIPTION
Fix compilation on linux when using clang-3.5 and libpng12-0.

When using a system-supplied wxWidgets library and the PNG library that comes with the project, there can be a version mismatch that causes a runtime error.

There was a small API change in libpng12-5 so the changes also deal with that.