### PR TITLE
Replace math macros by function calls from cmath.

### DIFF
--- a/rpcs3/Emu/Cell/Modules/libmixer.cpp
+++ b/rpcs3/Emu/Cell/Modules/libmixer.cpp
@@ -5,6 +5,7 @@
 
 #include "cellAudio.h"
 #include "libmixer.h"
+#include <cmath>
 
 LOG_CHANNEL(libmixer);
 
@@ -355,7 +356,7 @@ s32 cellSurMixerCreate(vm::cptr<CellSurMixerConfig> config)
 						auto v = vm::ptrl<s16>::make(p.m_addr); // 16-bit LE audio data
 						float left = 0.0f;
 						float right = 0.0f;
-						float speed = fabs(p.m_speed);
+						float speed = std::fabs(p.m_speed);
 						float fpos = 0.0f;
 						for (s32 i = 0; i < 256; i++) if (p.m_active)
 						{

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -2,6 +2,7 @@
 #include "Emu/System.h"
 #include "PPUThread.h"
 #include "PPUInterpreter.h"
+#include <cmath>
 
 // TODO: fix rol8 and rol16 for __GNUG__ (probably with __asm__)
 inline u8 rol8(const u8 x, const u8 n) { return x << n | x >> (8 - n); }
@@ -135,7 +136,7 @@ public:
 	{
 		for (s32 i = -31; i < 32; i++)
 		{
-			m_data[i + 31] = _mm_set1_ps(static_cast<float>(exp2(i)));
+			m_data[i + 31] = _mm_set1_ps(static_cast<float>(std::exp2(i)));
 		}
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -4,6 +4,7 @@
 #include "Emu/CPU/CPUThread.h"
 #include "Emu/Cell/SPUInterpreter.h"
 #include "MFC.h"
+#include <cmath>
 
 class lv2_event_queue_t;
 struct lv2_spu_group_t;
@@ -383,7 +384,7 @@ struct spu_imm_table_t
 		{
 			for (s32 i = -155; i < 174; i++)
 			{
-				m_data[i + 155] = _mm_set1_ps(static_cast<float>(exp2(i)));
+				m_data[i + 155] = _mm_set1_ps(static_cast<float>(std::exp2(i)));
 			}
 		}
 

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -5,6 +5,8 @@ extern "C"
 #include <libavutil/pixfmt.h>
 }
 
+#include <cmath>
+
 namespace rsx
 {
 	template<typename T>
@@ -32,8 +34,8 @@ namespace rsx
 	template<typename T>
 	void convert_linear_swizzle(void* input_pixels, void* output_pixels, u16 width, u16 height, bool input_is_swizzled)
 	{
-		u16 log2width = ::narrow<u16>(ceil(log2(width)));
-		u16 log2height = ::narrow<u16>(ceil(log2(height)));
+		u16 log2width = ::narrow<u16>(ceil(std::log2(width)));
+		u16 log2height = ::narrow<u16>(ceil(std::log2(height)));
 
 		// Max mask possible for square texture
 		u32 x_mask = 0x55555555;


### PR DESCRIPTION
…library header of the same name. This replaces the old macros by function calls when building with GCC 6 or greater.

If this is not the proper coding style I am happy to change it accordingly.