### PR TITLE
GL/Vulkan: write shader program log as .glsl and .spirv

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
+++ b/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
@@ -17,7 +17,7 @@ struct GLTraits
 		fragmentProgramData.Compile();
 		//checkForGlError("m_fragment_prog.Compile");
 
-		fs::file(fs::get_config_dir() + "FragmentProgram.txt", fs::rewrite).write(fragmentProgramData.shader);
+		fs::file(fs::get_config_dir() + "FragmentProgram.glsl", fs::rewrite).write(fragmentProgramData.shader);
 	}
 
 	static
@@ -27,7 +27,7 @@ struct GLTraits
 		vertexProgramData.Compile();
 		//checkForGlError("m_vertex_prog.Compile");
 
-		fs::file(fs::get_config_dir() + "VertexProgram.txt", fs::rewrite).write(vertexProgramData.shader);
+		fs::file(fs::get_config_dir() + "VertexProgram.glsl", fs::rewrite).write(vertexProgramData.shader);
 	}
 
 	static

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -276,7 +276,7 @@ void VKFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 
 void VKFragmentProgram::Compile()
 {
-	fs::file(fs::get_config_dir() + "FragmentProgram.frag", fs::rewrite).write(shader);
+	fs::file(fs::get_config_dir() + "FragmentProgram.spirv", fs::rewrite).write(shader);
 
 	std::vector<u32> spir_v;
 	if (!vk::compile_glsl_to_spv(shader, vk::glsl::glsl_fragment_program, spir_v))

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -253,7 +253,7 @@ void VKVertexProgram::Decompile(const RSXVertexProgram& prog)
 
 void VKVertexProgram::Compile()
 {
-	fs::file(fs::get_config_dir() + "VertexProgram.vert", fs::rewrite).write(shader);
+	fs::file(fs::get_config_dir() + "VertexProgram.spirv", fs::rewrite).write(shader);
 
 	std::vector<u32> spir_v;
 	if (!vk::compile_glsl_to_spv(shader, vk::glsl::glsl_vertex_program, spir_v))


### PR DESCRIPTION
Just keep it simple instead of just writing them as .txt or .vert/frag which difficult to identify from renderer.