### PR TITLE
Remove some llvm packages from travis CI and switch to ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: cpp
+sudo: required
+dist: trusty
 
 os:
  - linux
@@ -33,16 +35,11 @@ git:
 before_install:
 # shutdown services on Travis, which may have a memory impact
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      sudo apt-get install libwxgtk3.0-dev;
-      sudo apt-add-repository -y ppa:libreoffice/ppa;
-      sudo apt-get update;
-      sudo apt-get install libglew-dev;
+      sudo apt-get install -y libwxgtk3.0-dev;
     fi;
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CXX" = "g++" ]; then
       export CXX="g++-5" CC="gcc-5" CXXFLAGS="-Wno-format-security";
       export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
-    elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      export CXX="clang++-3.6" CC="clang-3.6";
     fi;
 # Add coverall for C++ so coverall.io could be triggered. Even it should be --coverage and gcov.
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
@@ -69,21 +66,20 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.6
-    - kubuntu-backports
+#    - llvm-toolchain-trusty-3.6 temporarily disabled
     packages:
     - cmake
     - libopenal-dev
     - freeglut3-dev
-#    - libglew-dev apt version is too old
+    - libglew-dev
     - libc6-dev
-    - llvm-3.6
-    - llvm-3.6-dev
+#    - llvm-3.6
+#    - llvm-3.6-dev
     - libedit-dev
     - g++-5
     - gcc-5
-    - clang-3.6
-    - libstdc++-4.8-dev
+#    - clang-3.6
+    - libstdc++-5-dev
     - lib32stdc++6
     - zlib1g-dev
   coverity_scan:


### PR DESCRIPTION
Trusty has good enough clang (3.5) to build rpcs3, as fo llvm:
we don't use it currently and travis fails due to: http://lists.llvm.org/pipermail/llvm-dev/2016-May/100303.html so just remove it for now.