### PR TITLE
Modified Vulkan only appear in Linux, Win (#1749)

### DIFF
--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -97,6 +97,8 @@ cfg::map_entry<std::function<std::shared_ptr<GSRender>()>> g_cfg_gs_render(cfg::
 	{ "OpenGL", PURE_EXPR(std::make_shared<GLGSRender>()) },
 #ifdef _MSC_VER
 	{ "DX12", PURE_EXPR(std::make_shared<D3D12GSRender>()) },
+#endif
+#ifndef __WXOSX__
 	{ "Vulkan", PURE_EXPR(std::make_shared<VKGSRender>()) },
 #endif
 });


### PR DESCRIPTION
As from the issue #1749, Vulkan cannot be used in Ubuntu, but it should work in Ubuntu. The code blocked to only appear the "Vulkan" setting in Windows only, messing up with DirectX together.

Besides this also prevent the "Vulkan" setting to appear to Macs, by seeing whether ```__WXOSX__``` is not defined in ```platform.h```, as Vulkan provides no support with Macs.