### PR TITLE
DX12 : add remaining constant color/alpha blending

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
@@ -38,10 +38,13 @@ D3D12_BLEND get_blend_factor(u16 factor)
 	case CELL_GCM_DST_COLOR: return D3D12_BLEND_DEST_COLOR;
 	case CELL_GCM_ONE_MINUS_DST_COLOR: return D3D12_BLEND_INV_DEST_COLOR;
 	case CELL_GCM_SRC_ALPHA_SATURATE: return D3D12_BLEND_SRC_ALPHA_SAT;
+	
+	// The following constant color/alpha blending are hack/wrong since it is no matching one in D3D12 
+	// therefore we workaround using approx one until we find better solution .
 	case CELL_GCM_CONSTANT_COLOR: return D3D12_BLEND_DEST_COLOR;
 	case CELL_GCM_ONE_MINUS_CONSTANT_COLOR: return D3D12_BLEND_INV_DEST_COLOR;
-	case CELL_GCM_CONSTANT_ALPHA:
-	case CELL_GCM_ONE_MINUS_CONSTANT_ALPHA:
+	case CELL_GCM_CONSTANT_ALPHA: return D3D12_BLEND_DEST_ALPHA;
+	case CELL_GCM_ONE_MINUS_CONSTANT_ALPHA: return D3D12_BLEND_INV_DEST_ALPHA;
 		break;
 	}
 	throw EXCEPTION("Invalid or unsupported blend factor (0x%x)", factor);
@@ -62,10 +65,13 @@ D3D12_BLEND get_blend_factor_alpha(u16 factor)
 	case CELL_GCM_DST_COLOR: return D3D12_BLEND_DEST_ALPHA;
 	case CELL_GCM_ONE_MINUS_DST_COLOR: return D3D12_BLEND_INV_DEST_ALPHA;
 	case CELL_GCM_SRC_ALPHA_SATURATE: return D3D12_BLEND_SRC_ALPHA_SAT;
-	case CELL_GCM_CONSTANT_COLOR:
-	case CELL_GCM_ONE_MINUS_CONSTANT_COLOR:
-	case CELL_GCM_CONSTANT_ALPHA:
-	case CELL_GCM_ONE_MINUS_CONSTANT_ALPHA:
+	
+	// The following constant color/alpha blending are hack/wrong since it is no matching one in D3D12 
+	// therefore we workaround using approx one until we find better solution .
+	case CELL_GCM_CONSTANT_COLOR: return D3D12_BLEND_DEST_ALPHA;
+	case CELL_GCM_ONE_MINUS_CONSTANT_COLOR: return D3D12_BLEND_INV_DEST_ALPHA;
+	case CELL_GCM_CONSTANT_ALPHA: return D3D12_BLEND_DEST_ALPHA;
+	case CELL_GCM_ONE_MINUS_CONSTANT_ALPHA: return D3D12_BLEND_INV_DEST_ALPHA;
 		break;
 	}
 	throw EXCEPTION("Invalid or unsupported blend alpha factor (0x%x)", factor);


### PR DESCRIPTION
Please see the inline comment . This make some games (like Outrun Arcade) go more further when hits {rsx::thread} Exception: Invalid or unsupported blend alpha factor (0x8001)