### PR TITLE
Add optimal build options to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,17 @@ if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
 	message( FATAL_ERROR "RPCS3 can only be compiled on 64-bit platforms." )
 endif()
 
+add_definitions(-DCMAKE_BUILD)
+
 # We use libpng's static library and don't need to build the shared library and run the tests
 set(PNG_SHARED OFF CACHE BOOL "Build shared lib." FORCE)
 set(PNG_TESTS  OFF CACHE BOOL "Build tests." FORCE)
 
-add_definitions(-DCMAKE_BUILD)
+# Select the version of libpng to use, default is builtin
+if (NOT USE_SYSTEM_LIBPNG)
+	add_subdirectory( 3rdparty/libpng )
+endif()
 
-add_subdirectory( 3rdparty/libpng )
 # TODO: do real installation, including copying directory structure
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${PROJECT_BINARY_DIR}/bin")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${PROJECT_BINARY_DIR}/bin")

--- a/README.md
+++ b/README.md
@@ -48,5 +48,13 @@ If you want to build with LLVM, then LLVM 3.8 is required.
 If you are on OSX and want to build with llvm don't forget to add `-DLLVM_DIR=...` (or wherever llvm brew was installed) to cmake invocation.
 When using GDB, configure it to ignore SIGSEGV signal (`handle SIGSEGV nostop noprint`).
 
+##### CMake Build Options (Linux & Mac OSX)
+
+- ```-DUSE_SYSTEM_LIBPNG=ON/OFF``` (default = *OFF*) </br>
+Build against the shared libpng instead of using the builtin one. libpng 1.6+ highly recommended. Try this option if you get version conflict errors or only see black game icons.
+
+- ```-DUSE_SYSTEM_FFMPEG=ON/OFF``` (default = *OFF*) </br>
+Build against the shared ffmpeg libraries instead of using the builtin patched version. Try this if the builtin version breaks the OpenGL renderer for you.
+
 ### Support
 * [Donate by PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MPJ3S9XQXCE3G)

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -105,6 +105,26 @@ else()
 	set(PLATFORM_ARCH "linux/x86_64")
 endif()
 
+# Select the version of libpng to use, default is builtin
+if(USE_SYSTEM_LIBPNG)
+	message("-- RPCS3: using shared libpng")
+	find_package(PNG REQUIRED)
+	include_directories("${PNG_INCLUDE_DIRS}")
+else()
+	message("-- RPCS3: using builtin libpng")
+	include_directories("${RPCS3_SRC_DIR}/../3rdparty/libpng")
+endif()
+
+# Select the version of ffmpeg to use, default is builtin
+if(USE_SYSTEM_FFMPEG)
+	message("-- RPCS3: using shared ffmpeg")
+	find_package(FFMPEG REQUIRED)
+	include_directories("${FFMPEG_INCLUDE_DIR}")
+else()
+	message("-- RPCS3: using builtin ffmpeg")
+	include_directories("${RPCS3_SRC_DIR}/../3rdparty/ffmpeg/${PLATFORM_ARCH}/include")
+endif()
+
 include_directories(
 ${GLEW_INCLUDE_DIR}
 ${wxWidgets_INCLUDE_DIRS}
@@ -112,14 +132,12 @@ ${ZLIB_INCLUDE_DIR}
 ${OPENAL_INCLUDE_DIR}
 ${LLVM_INCLUDE_DIRS}
 "${RPCS3_SRC_DIR}/../3rdparty/pugixml/src"
-"${RPCS3_SRC_DIR}/../3rdparty/ffmpeg/${PLATFORM_ARCH}/include"
 "${RPCS3_SRC_DIR}"
 "${RPCS3_SRC_DIR}/Loader"
 "${RPCS3_SRC_DIR}/Crypto"
 "${RPCS3_SRC_DIR}/.."
 "${RPCS3_SRC_DIR}/../Utilities/yaml-cpp/include"
 "${RPCS3_SRC_DIR}/../asmjit/src/asmjit"
-"${RPCS3_SRC_DIR}/../3rdparty/libpng"
 "${RPCS3_SRC_DIR}/../3rdparty/GSL/include"
 "${RPCS3_SRC_DIR}/../rsx_program_decompiler/rsx_decompiler"
 "${RPCS3_SRC_DIR}/../rsx_program_decompiler/shader_code"
@@ -155,8 +173,10 @@ link_directories(
 "${RPCS3_SRC_DIR}/../3rdparty/minidx12/"
 )
 
-if(MSVC OR NOT WIN32)
-	link_directories("${RPCS3_SRC_DIR}/../3rdparty/ffmpeg/${PLATFORM_ARCH}/lib")
+if(NOT USE_SYSTEM_FFMPEG)
+	if(MSVC OR NOT WIN32)
+		link_directories("${RPCS3_SRC_DIR}/../3rdparty/ffmpeg/${PLATFORM_ARCH}/lib")
+	endif()
 endif()
 
 get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
@@ -201,7 +221,18 @@ if(WIN32)
 	target_link_libraries(rpcs3  avformat.lib avcodec.lib avutil.lib swresample.lib swscale.lib png16_static ${wxWidgets_LIBRARIES} ${OPENAL_LIBRARY} ${ADDITIONAL_LIBS})
 else()
 	target_link_libraries(rpcs3  ${wxWidgets_LIBRARIES} ${OPENAL_LIBRARY} ${GLEW_LIBRARY} ${OPENGL_LIBRARIES})
-	target_link_libraries(rpcs3  libavformat.a libavcodec.a libavutil.a libswresample.a libswscale.a -ldl png16_static ${ZLIB_LIBRARIES} ${ADDITIONAL_LIBS})
+	target_link_libraries(rpcs3  ${ZLIB_LIBRARIES} ${ADDITIONAL_LIBS})
+	if (USE_SYSTEM_FFMPEG)
+		link_libraries(${FFMPEG_LIBRARY_DIR})
+		target_link_libraries(rpcs3  libavformat.so libavcodec.so libavutil.so libswresample.so libswscale.so)
+	else()
+		target_link_libraries(rpcs3  libavformat.a libavcodec.a libavutil.a libswresample.a libswscale.a -ldl)
+	endif()
+	if (USE_SYSTEM_LIBPNG)
+		target_link_libraries(rpcs3  ${PNG_LIBRARIES})
+	else()
+		target_link_libraries(rpcs3  png16_static)
+	endif()
 	if (NOT APPLE)
 		target_link_libraries(rpcs3  vulkan glslang OSDependent OGLCompiler SPIRV)
 	endif()


### PR DESCRIPTION
Provides two options when building RPCS3

- **USE_SYSTEM_FFMPEG** BOOL (default: OFF)
- **USE_SYSTEM_LIBPNG** BOOL (default: OFF)

These options lets the user select between the system provided and builtin libraries of ffmpeg and libpng to overcome possible system issues.

Also adds support for older libpng releases if the user doesn't have libpng 1.5 or higher when building with ```USE_SYSTEM_LIBPNG```.

---

This PR continues #1825 and has some minor improvements.