### PR TITLE
GUI: Add bulk decryption of LLE modules

### DIFF
--- a/rpcs3/Gui/MainFrame.h
+++ b/rpcs3/Gui/MainFrame.h
@@ -44,6 +44,7 @@ private:
 	void OpenRSXDebugger(wxCommandEvent& evt);
 	void OpenStringSearch(wxCommandEvent& evt);
 	void OpenCgDisasm(wxCommandEvent& evt);
+	void DecryptSPRXLibraries(wxCommandEvent& event);
 	void AboutDialogHandler(wxCommandEvent& event);
 	void UpdateUI(wxCommandEvent& event);
 	void OnKeyDown(wxKeyEvent& event);


### PR DESCRIPTION
Adds a new menu to **Tools** called **Decrypt &LLE modules** which opens a dialog to select multiple ```*.sprx``` files, which are than decrypted all at once.
This speeds up the LLE module decryption and saves users a lot of time and headache :smile: 

--

![screenshot_20160630_230507](https://cloud.githubusercontent.com/assets/13280758/16504220/242ae1b4-3f17-11e6-930f-00621d3ea3de.png)
![screenshot_20160630_041450](https://cloud.githubusercontent.com/assets/13280758/16474713/4cd8ea6e-3e79-11e6-994b-2eb190483a2a.png)

