### PR TITLE
CMake: improve compiler checks

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -12,21 +12,8 @@ add_custom_command(OUTPUT something_that_never_exists
 	COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
 		-P ${CMAKE_CURRENT_SOURCE_DIR}/git-version.cmake)
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0) # TODO: the same for (apple) clang
-		message(FATAL_ERROR "GCC ${CMAKE_CXX_COMPILER_VERSION} is too old.")
-	endif()
-	# Warnings
-	add_compile_options(-Wno-attributes -Wno-enum-compare -Wno-invalid-offsetof)
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-	add_compile_options(-ftemplate-depth=1024)
-	if(APPLE)
-		add_compile_options(-stdlib=libc++)
-	endif()
-	if(WIN32)
-		add_compile_options(-pthread)
-	endif()
-endif()
+# Check for a sufficient compiler and set build options
+include(ConfigureCompiler)
 
 if(WIN32)
 	add_definitions(-DUNICODE)

--- a/rpcs3/cmake_modules/ConfigureCompiler.cmake
+++ b/rpcs3/cmake_modules/ConfigureCompiler.cmake
@@ -1,0 +1,48 @@
+# Check and configure compiler options for RPCS3
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+	# Get GCC version
+	execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
+					OUTPUT_VARIABLE GCC_VERSION)
+	string(REGEX MATCHALL "[0-9]+" GCC_VERSION_COMPONENTS ${GCC_VERSION})
+	list(GET GCC_VERSION_COMPONENTS 0 GCC_MAJOR)
+	list(GET GCC_VERSION_COMPONENTS 1 GCC_MINOR)
+
+	# GCC 4.9 and lower are too old
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
+		message(FATAL_ERROR
+			"GCC ${CMAKE_CXX_COMPILER_VERSION} is too old.")
+	endif()
+
+	# FIXME: do we really need this?
+	# GCC 6.1 is insufficient to compile, because of a regression bug
+	#if(GCC_MAJOR EQUAL "6" AND GCC_MINOR EQUAL "1")
+	#	message(FATAL_ERROR
+	#		"GCC ${CMAKE_C_COMPILER_VERSION} is insufficient to build this project! "
+	#		"If you need to compile with GCC, use GCC 5.4 or lower or GCC 6.2 or higher "
+	#		"to build the project, or use CLANG instead. "
+	#		"See this regression bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70869")
+	#endif()
+
+	# Set compiler options here
+
+	# Warnings
+	add_compile_options(-Wno-attributes -Wno-enum-compare -Wno-invalid-offsetof)
+
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+	# Clang 3.4 and lower are too old
+	if(CLANG_VERSION_MAJOR LESS "3" AND CLANG_VERSION_MINOR LESS "4")
+		message(FATAL_ERROR
+			"Clang ${CLANG_VERSION_MAJOR}.${CLANG_VERSION_MINOR} is too old.")
+	endif()
+
+	# Set compiler options here
+
+	add_compile_options(-ftemplate-depth=1024)
+	if(APPLE)
+		add_compile_options(-stdlib=libc++)
+	endif()
+	if(WIN32)
+		add_compile_options(-pthread)
+	endif()
+endif()


### PR DESCRIPTION
Moves the compiler check out of ```rpcs3/CMakeLists.txt``` and adds them into ```rpcs3/cmake_modules/CheckCompiler.cmake```
Add better compiler checks and eliminate a TODO

Also fixes #1802 by telling the user GCC 6.1 is insufficient to build RPCS3.