### PR TITLE
Factorize rsx state

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -347,16 +347,16 @@ void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst,
 template<typename T>
 std::tuple<T, T> write_index_array_data_to_buffer_impl(gsl::span<T, gsl::dynamic_range> dst, rsx::primitive_type draw_mode, const std::vector<std::pair<u32, u32> > &first_count_arguments)
 {
-	u32 address = rsx::get_address(rsx::method_registers[NV4097_SET_INDEX_ARRAY_ADDRESS], rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] & 0xf);
-	rsx::index_array_type type = rsx::to_index_array_type(rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);
+	u32 address = rsx::get_address(rsx::method_registers.index_array_address(), rsx::method_registers.index_array_location());
+	rsx::index_array_type type = rsx::method_registers.index_type();
 
 	u32 type_size = gsl::narrow<u32>(get_index_type_size(type));
 
 
-	EXPECTS(rsx::method_registers[NV4097_SET_VERTEX_DATA_BASE_INDEX] == 0);
+	EXPECTS(rsx::method_registers.vertex_data_base_index() == 0);
 
-	bool is_primitive_restart_enabled = !!rsx::method_registers[NV4097_SET_RESTART_INDEX_ENABLE];
-	u32 primitive_restart_index = rsx::method_registers[NV4097_SET_RESTART_INDEX];
+	bool is_primitive_restart_enabled = rsx::method_registers.restart_index_enabled();
+	u32 primitive_restart_index = rsx::method_registers.restart_index();
 
 	// Disjoint first_counts ranges not supported atm
 	for (int i = 0; i < first_count_arguments.size() - 1; i++)
@@ -403,12 +403,12 @@ std::tuple<u32, u32> write_index_array_data_to_buffer(gsl::span<gsl::byte> dst, 
 
 std::tuple<u32, u32> write_index_array_data_to_buffer_untouched(gsl::span<u32, gsl::dynamic_range> dst, const std::vector<std::pair<u32, u32> > &first_count_arguments)
 {
-	u32 address = rsx::get_address(rsx::method_registers[NV4097_SET_INDEX_ARRAY_ADDRESS], rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] & 0xf);
-	rsx::index_array_type type = rsx::to_index_array_type(rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);
+	u32 address = rsx::get_address(rsx::method_registers.index_array_address(), rsx::method_registers.index_array_location());
+	rsx::index_array_type type = rsx::method_registers.index_type();
 
 	u32 type_size = gsl::narrow<u32>(get_index_type_size(type));
-	bool is_primitive_restart_enabled = !!rsx::method_registers[NV4097_SET_RESTART_INDEX_ENABLE];
-	u32 primitive_restart_index = rsx::method_registers[NV4097_SET_RESTART_INDEX];
+	bool is_primitive_restart_enabled = rsx::method_registers.restart_index_enabled();
+	u32 primitive_restart_index = rsx::method_registers.restart_index();
 
 	// Disjoint first_counts ranges not supported atm
 	for (int i = 0; i < first_count_arguments.size() - 1; i++)
@@ -426,12 +426,12 @@ std::tuple<u32, u32> write_index_array_data_to_buffer_untouched(gsl::span<u32, g
 
 std::tuple<u16, u16> write_index_array_data_to_buffer_untouched(gsl::span<u16, gsl::dynamic_range> dst, const std::vector<std::pair<u32, u32> > &first_count_arguments)
 {
-	u32 address = rsx::get_address(rsx::method_registers[NV4097_SET_INDEX_ARRAY_ADDRESS], rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] & 0xf);
-	rsx::index_array_type type = rsx::to_index_array_type(rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);
+	u32 address = rsx::get_address(rsx::method_registers.index_array_address(), rsx::method_registers.index_array_location());
+	rsx::index_array_type type = rsx::method_registers.index_type();
 
 	u32 type_size = gsl::narrow<u32>(get_index_type_size(type));
-	bool is_primitive_restart_enabled = !!rsx::method_registers[NV4097_SET_RESTART_INDEX_ENABLE];
-	u16 primitive_restart_index = rsx::method_registers[NV4097_SET_RESTART_INDEX];
+	bool is_primitive_restart_enabled = rsx::method_registers.restart_index_enabled();
+	u16 primitive_restart_index = rsx::method_registers.restart_index();
 
 	// Disjoint first_counts ranges not supported atm
 	for (int i = 0; i < first_count_arguments.size() - 1; i++)

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -141,19 +141,16 @@ namespace rsx
 		template <typename ...Args>
 		void prepare_render_target(
 			command_list_type command_list,
-			u32 set_surface_format_reg,
+			surface_color_format color_format, surface_depth_format depth_format,
 			u32 clip_horizontal_reg, u32 clip_vertical_reg,
 			surface_target set_surface_target,
 			const std::array<u32, 4> &surface_addresses, u32 address_z,
 			Args&&... extra_params)
 		{
-			u32 clip_width = clip_horizontal_reg >> 16;
-			u32 clip_height = clip_vertical_reg >> 16;
-			u32 clip_x = clip_horizontal_reg;
-			u32 clip_y = clip_vertical_reg;
-
-			surface_color_format color_format = to_surface_color_format(set_surface_format_reg & 0x1f);
-			surface_depth_format depth_format = to_surface_depth_format((set_surface_format_reg >> 5) & 0x7);
+			u32 clip_width = clip_horizontal_reg;
+			u32 clip_height = clip_vertical_reg;
+//			u32 clip_x = clip_horizontal_reg;
+//			u32 clip_y = clip_vertical_reg;
 
 			// Make previous RTTs sampleable
 			for (std::tuple<u32, surface_type> &rtt : m_bound_render_targets)

--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -77,8 +77,8 @@ std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC> D3D12GSRender::upload_vertex_attrib
 
 	u32 vertex_count = get_vertex_count(vertex_ranges);
 	size_t offset_in_vertex_buffers_buffer = 0;
-	u32 input_mask = rsx::method_registers[NV4097_SET_VERTEX_ATTRIB_INPUT_MASK];
-	EXPECTS(rsx::method_registers[NV4097_SET_VERTEX_DATA_BASE_INDEX] == 0);
+	u32 input_mask = rsx::method_registers.vertex_attrib_input_mask();
+	EXPECTS(rsx::method_registers.vertex_data_base_index() == 0);
 
 	for (int index = 0; index < rsx::limits::vertex_count; ++index)
 	{
@@ -86,17 +86,17 @@ std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC> D3D12GSRender::upload_vertex_attrib
 		if (!enabled)
 			continue;
 
-		if (vertex_arrays_info[index].size > 0)
+		if (rsx::method_registers.vertex_arrays_info[index].size > 0)
 		{
 			// Active vertex array
-			const rsx::data_array_format_info &info = vertex_arrays_info[index];
+			const rsx::data_array_format_info &info = rsx::method_registers.vertex_arrays_info[index];
 
 			u32 element_size = rsx::get_vertex_type_size_on_host(info.type, info.size);
 			UINT buffer_size = element_size * vertex_count;
 			size_t heap_offset = m_buffer_data.alloc<D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT>(buffer_size);
 
-			u32 base_offset = rsx::method_registers[NV4097_SET_VERTEX_DATA_BASE_OFFSET];
-			u32 offset = rsx::method_registers[NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + index];
+			u32 base_offset = rsx::method_registers.vertex_data_base_offset();
+			u32 offset = rsx::method_registers.vertex_arrays_info[index].offset();
 			u32 address = base_offset + rsx::get_address(offset & 0x7fffffff, offset >> 31);
 			const gsl::byte *src_ptr = gsl::narrow_cast<const gsl::byte*>(vm::base(address));
 
@@ -117,11 +117,11 @@ std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC> D3D12GSRender::upload_vertex_attrib
 			m_timers.buffer_upload_size += buffer_size;
 
 		}
-		else if (register_vertex_info[index].size > 0)
+		else if (rsx::method_registers.register_vertex_info[index].size > 0)
 		{
 			// In register vertex attribute
-			const rsx::data_array_format_info &info = register_vertex_info[index];
-			const std::vector<u8> &data = register_vertex_data[index];
+			const rsx::data_array_format_info &info = rsx::method_registers.register_vertex_info[index];
+			const std::vector<u8> &data = rsx::method_registers.register_vertex_data[index];
 
 			u32 element_size = rsx::get_vertex_type_size_on_host(info.type, info.size);
 			UINT buffer_size = gsl::narrow<UINT>(data.size());
@@ -224,13 +224,15 @@ void D3D12GSRender::upload_and_bind_scale_offset_matrix(size_t descriptorIndex)
 	// Separate constant buffer
 	void *mapped_buffer = m_buffer_data.map<void>(CD3DX12_RANGE(heap_offset, heap_offset + 256));
 	fill_scale_offset_data(mapped_buffer);
-	int is_alpha_tested = !!(rsx::method_registers[NV4097_SET_ALPHA_TEST_ENABLE]);
-	u8 alpha_ref_raw = (u8)(rsx::method_registers[NV4097_SET_ALPHA_REF] & 0xFF);
+	int is_alpha_tested = rsx::method_registers.alpha_test_enabled();
+	u8 alpha_ref_raw = rsx::method_registers.alpha_ref();
 	float alpha_ref = alpha_ref_raw / 255.f;
 	memcpy((char*)mapped_buffer + 16 * sizeof(float), &is_alpha_tested, sizeof(int));
 	memcpy((char*)mapped_buffer + 17 * sizeof(float), &alpha_ref, sizeof(float));
-	memcpy((char*)mapped_buffer + 18 * sizeof(float), &rsx::method_registers[NV4097_SET_FOG_PARAMS], sizeof(float));
-	memcpy((char*)mapped_buffer + 19 * sizeof(float), &rsx::method_registers[NV4097_SET_FOG_PARAMS + 1], sizeof(float));
+	f32 fogp0 = rsx::method_registers.fog_params_0();
+	f32 fogp1 = rsx::method_registers.fog_params_1();
+	memcpy((char*)mapped_buffer + 18 * sizeof(float), &fogp0, sizeof(float));
+	memcpy((char*)mapped_buffer + 19 * sizeof(float), &fogp1, sizeof(float));
 
 	m_buffer_data.unmap(CD3DX12_RANGE(heap_offset, heap_offset + 256));
 
@@ -321,7 +323,7 @@ std::tuple<bool, size_t, std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC>> D3D12GSRe
 		size_t vertex_count;
 		std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC> vertex_buffer_view;
 		std::tie(vertex_buffer_view, vertex_count) = upload_inlined_vertex_array(
-			vertex_arrays_info,
+			rsx::method_registers.vertex_arrays_info,
 			{ (const gsl::byte*) inline_vertex_array.data(), gsl::narrow<int>(inline_vertex_array.size() * sizeof(uint)) },
 			m_buffer_data, m_vertex_buffer_data.Get(), command_list);
 
@@ -355,7 +357,7 @@ std::tuple<bool, size_t, std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC>> D3D12GSRe
 	// Index count
 	size_t index_count = get_index_count(draw_mode, gsl::narrow<int>(get_vertex_count(first_count_commands)));
 
-	rsx::index_array_type indexed_type = rsx::to_index_array_type(rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);
+	rsx::index_array_type indexed_type = rsx::method_registers.index_type();
 	size_t index_size = get_index_type_size(indexed_type);
 
 	// Alloc

--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
@@ -6,79 +6,79 @@
 #include "Emu/RSX/GCM.h"
 
 
-D3D12_BLEND_OP get_blend_op(u16 op)
+D3D12_BLEND_OP get_blend_op(rsx::blend_equation op)
 {
 	switch (op)
 	{
-	case CELL_GCM_FUNC_ADD: return D3D12_BLEND_OP_ADD;
-	case CELL_GCM_FUNC_SUBTRACT: return D3D12_BLEND_OP_SUBTRACT;
-	case CELL_GCM_FUNC_REVERSE_SUBTRACT: return D3D12_BLEND_OP_REV_SUBTRACT;
-	case CELL_GCM_MIN: return D3D12_BLEND_OP_MIN;
-	case CELL_GCM_MAX: return D3D12_BLEND_OP_MAX;
-	case CELL_GCM_FUNC_ADD_SIGNED:
-	case CELL_GCM_FUNC_REVERSE_ADD_SIGNED:
-	case CELL_GCM_FUNC_REVERSE_SUBTRACT_SIGNED:
+	case rsx::blend_equation::add: return D3D12_BLEND_OP_ADD;
+	case rsx::blend_equation::substract: return D3D12_BLEND_OP_SUBTRACT;
+	case rsx::blend_equation::reverse_substract: return D3D12_BLEND_OP_REV_SUBTRACT;
+	case rsx::blend_equation::min: return D3D12_BLEND_OP_MIN;
+	case rsx::blend_equation::max: return D3D12_BLEND_OP_MAX;
+	case rsx::blend_equation::add_signed:
+	case rsx::blend_equation::reverse_add_signed:
+	case rsx::blend_equation::reverse_substract_signed:
 		break;
 	}
 	throw EXCEPTION("Invalid or unsupported blend op (0x%x)", op);
 }
 
-D3D12_BLEND get_blend_factor(u16 factor)
+D3D12_BLEND get_blend_factor(rsx::blend_factor factor)
 {
 	switch (factor)
 	{
-	case CELL_GCM_ZERO: return D3D12_BLEND_ZERO;
-	case CELL_GCM_ONE: return D3D12_BLEND_ONE;
-	case CELL_GCM_SRC_COLOR: return D3D12_BLEND_SRC_COLOR;
-	case CELL_GCM_ONE_MINUS_SRC_COLOR: return D3D12_BLEND_INV_SRC_COLOR;
-	case CELL_GCM_SRC_ALPHA: return D3D12_BLEND_SRC_ALPHA;
-	case CELL_GCM_ONE_MINUS_SRC_ALPHA: return D3D12_BLEND_INV_SRC_ALPHA;
-	case CELL_GCM_DST_ALPHA: return D3D12_BLEND_DEST_ALPHA;
-	case CELL_GCM_ONE_MINUS_DST_ALPHA: return D3D12_BLEND_INV_DEST_ALPHA;
-	case CELL_GCM_DST_COLOR: return D3D12_BLEND_DEST_COLOR;
-	case CELL_GCM_ONE_MINUS_DST_COLOR: return D3D12_BLEND_INV_DEST_COLOR;
-	case CELL_GCM_SRC_ALPHA_SATURATE: return D3D12_BLEND_SRC_ALPHA_SAT;
-	case CELL_GCM_CONSTANT_COLOR:
-	case CELL_GCM_CONSTANT_ALPHA:
+	case rsx::blend_factor::zero: return D3D12_BLEND_ZERO;
+	case rsx::blend_factor::one: return D3D12_BLEND_ONE;
+	case rsx::blend_factor::src_color: return D3D12_BLEND_SRC_COLOR;
+	case rsx::blend_factor::one_minus_src_color: return D3D12_BLEND_INV_SRC_COLOR;
+	case rsx::blend_factor::src_alpha: return D3D12_BLEND_SRC_ALPHA;
+	case rsx::blend_factor::one_minus_src_alpha: return D3D12_BLEND_INV_SRC_ALPHA;
+	case rsx::blend_factor::dst_alpha: return D3D12_BLEND_DEST_ALPHA;
+	case rsx::blend_factor::one_minus_dst_alpha: return D3D12_BLEND_INV_DEST_ALPHA;
+	case rsx::blend_factor::dst_color: return D3D12_BLEND_DEST_COLOR;
+	case rsx::blend_factor::one_minus_dst_color: return D3D12_BLEND_INV_DEST_COLOR;
+	case rsx::blend_factor::src_alpha_saturate: return D3D12_BLEND_SRC_ALPHA_SAT;
+	case rsx::blend_factor::constant_color:
+	case rsx::blend_factor::constant_alpha:
 	{
-		LOG_ERROR(RSX,"Constant blend factor not supported. Using ONE instead");
+		LOG_ERROR(RSX, "Constant blend factor not supported. Using ONE instead");
 		return D3D12_BLEND_ONE;
 	}
-	case CELL_GCM_ONE_MINUS_CONSTANT_COLOR:
-	case CELL_GCM_ONE_MINUS_CONSTANT_ALPHA: 
+	case rsx::blend_factor::one_minus_constant_color:
+	case rsx::blend_factor::one_minus_constant_alpha:
 	{
-		LOG_ERROR(RSX,"Inv Constant blend factor not supported. Using ZERO instead");
+		LOG_ERROR(RSX, "Inv Constant blend factor not supported. Using ZERO instead");
 		return D3D12_BLEND_ZERO;
 	}
 	}
 	throw EXCEPTION("Invalid blend factor (0x%x)", factor);
 }
 
-D3D12_BLEND get_blend_factor_alpha(u16 factor)
+D3D12_BLEND get_blend_factor_alpha(rsx::blend_factor factor)
 {
 	switch (factor)
 	{
-	case CELL_GCM_ZERO: return D3D12_BLEND_ZERO;
-	case CELL_GCM_ONE: return D3D12_BLEND_ONE;
-	case CELL_GCM_SRC_COLOR: return D3D12_BLEND_SRC_ALPHA;
-	case CELL_GCM_ONE_MINUS_SRC_COLOR: return D3D12_BLEND_INV_SRC_ALPHA;
-	case CELL_GCM_SRC_ALPHA: return D3D12_BLEND_SRC_ALPHA;
-	case CELL_GCM_ONE_MINUS_SRC_ALPHA: return D3D12_BLEND_INV_SRC_ALPHA;
-	case CELL_GCM_DST_ALPHA: return D3D12_BLEND_DEST_ALPHA;
-	case CELL_GCM_ONE_MINUS_DST_ALPHA: return D3D12_BLEND_INV_DEST_ALPHA;
-	case CELL_GCM_DST_COLOR: return D3D12_BLEND_DEST_ALPHA;
-	case CELL_GCM_ONE_MINUS_DST_COLOR: return D3D12_BLEND_INV_DEST_ALPHA;
-	case CELL_GCM_SRC_ALPHA_SATURATE: return D3D12_BLEND_SRC_ALPHA_SAT;
-	case CELL_GCM_CONSTANT_COLOR:
-	case CELL_GCM_CONSTANT_ALPHA:
+	case rsx::blend_factor::zero: return D3D12_BLEND_ZERO;
+	case rsx::blend_factor::one: return D3D12_BLEND_ONE;
+	case rsx::blend_factor::src_color: return D3D12_BLEND_SRC_ALPHA;
+	case rsx::blend_factor::one_minus_src_color: return D3D12_BLEND_INV_SRC_ALPHA;
+	case rsx::blend_factor::src_alpha: return D3D12_BLEND_SRC_ALPHA;
+	case rsx::blend_factor::one_minus_src_alpha: return D3D12_BLEND_INV_SRC_ALPHA;
+	case rsx::blend_factor::dst_alpha: return D3D12_BLEND_DEST_ALPHA;
+	case rsx::blend_factor::one_minus_dst_alpha: return D3D12_BLEND_INV_DEST_ALPHA;
+	case rsx::blend_factor::dst_color: return D3D12_BLEND_DEST_ALPHA;
+	case rsx::blend_factor::one_minus_dst_color: return D3D12_BLEND_INV_DEST_ALPHA;
+	case rsx::blend_factor::src_alpha_saturate: return D3D12_BLEND_SRC_ALPHA_SAT;
+	case rsx::blend_factor::constant_color:
+	case rsx::blend_factor::constant_alpha:
 	{
-		LOG_ERROR(RSX,"Constant blend factor not supported. Using ONE instead");
+		LOG_ERROR(RSX, "Constant blend factor not supported. Using ONE instead");
 		return D3D12_BLEND_ONE;
 	}
-	case CELL_GCM_ONE_MINUS_CONSTANT_COLOR:
-	case CELL_GCM_ONE_MINUS_CONSTANT_ALPHA: 
+	case rsx::blend_factor::one_minus_constant_color:
+	case rsx::blend_factor::one_minus_constant_alpha:
 	{
-		LOG_ERROR(RSX,"Inv Constant blend factor not supported. Using ZERO instead");
+		LOG_ERROR(RSX, "Inv Constant blend factor not supported. Using ZERO instead");
 		return D3D12_BLEND_ZERO;
 	}
 	}
@@ -88,25 +88,25 @@ D3D12_BLEND get_blend_factor_alpha(u16 factor)
 /**
 * Convert GCM logic op code to D3D12 one
 */
-D3D12_LOGIC_OP get_logic_op(u32 op)
+D3D12_LOGIC_OP get_logic_op(rsx::logic_op op)
 {
 	switch (op)
 	{
-	case CELL_GCM_CLEAR: return D3D12_LOGIC_OP_CLEAR;
-	case CELL_GCM_AND: return D3D12_LOGIC_OP_AND;
-	case CELL_GCM_AND_REVERSE: return D3D12_LOGIC_OP_AND_REVERSE;
-	case CELL_GCM_COPY: return D3D12_LOGIC_OP_COPY;
-	case CELL_GCM_AND_INVERTED: return D3D12_LOGIC_OP_AND_INVERTED;
-	case CELL_GCM_NOOP: return D3D12_LOGIC_OP_NOOP;
-	case CELL_GCM_XOR: return D3D12_LOGIC_OP_XOR;
-	case CELL_GCM_OR: return D3D12_LOGIC_OP_OR;
-	case CELL_GCM_NOR: return D3D12_LOGIC_OP_NOR;
-	case CELL_GCM_EQUIV: return D3D12_LOGIC_OP_EQUIV;
-	case CELL_GCM_INVERT: return D3D12_LOGIC_OP_INVERT;
-	case CELL_GCM_OR_REVERSE: return D3D12_LOGIC_OP_OR_REVERSE;
-	case CELL_GCM_COPY_INVERTED: return D3D12_LOGIC_OP_COPY_INVERTED;
-	case CELL_GCM_OR_INVERTED: return D3D12_LOGIC_OP_OR_INVERTED;
-	case CELL_GCM_NAND: return D3D12_LOGIC_OP_NAND;
+	case rsx::logic_op::logic_clear: return D3D12_LOGIC_OP_CLEAR;
+	case rsx::logic_op::logic_and: return D3D12_LOGIC_OP_AND;
+	case rsx::logic_op::logic_and_reverse: return D3D12_LOGIC_OP_AND_REVERSE;
+	case rsx::logic_op::logic_copy: return D3D12_LOGIC_OP_COPY;
+	case rsx::logic_op::logic_and_inverted: return D3D12_LOGIC_OP_AND_INVERTED;
+	case rsx::logic_op::logic_noop: return D3D12_LOGIC_OP_NOOP;
+	case rsx::logic_op::logic_xor: return D3D12_LOGIC_OP_XOR;
+	case rsx::logic_op::logic_or: return D3D12_LOGIC_OP_OR;
+	case rsx::logic_op::logic_nor: return D3D12_LOGIC_OP_NOR;
+	case rsx::logic_op::logic_equiv: return D3D12_LOGIC_OP_EQUIV;
+	case rsx::logic_op::logic_invert: return D3D12_LOGIC_OP_INVERT;
+	case rsx::logic_op::logic_or_reverse: return D3D12_LOGIC_OP_OR_REVERSE;
+	case rsx::logic_op::logic_copy_inverted: return D3D12_LOGIC_OP_COPY_INVERTED;
+	case rsx::logic_op::logic_or_inverted: return D3D12_LOGIC_OP_OR_INVERTED;
+	case rsx::logic_op::logic_nand: return D3D12_LOGIC_OP_NAND;
 	}
 	throw EXCEPTION("Invalid logic op (0x%x)", op);
 }
@@ -114,34 +114,34 @@ D3D12_LOGIC_OP get_logic_op(u32 op)
 /**
 * Convert GCM stencil op code to D3D12 one
 */
-D3D12_STENCIL_OP get_stencil_op(u32 op)
+D3D12_STENCIL_OP get_stencil_op(rsx::stencil_op op)
 {
 	switch (op)
 	{
-	case CELL_GCM_KEEP: return D3D12_STENCIL_OP_KEEP;
-	case CELL_GCM_ZERO: return D3D12_STENCIL_OP_ZERO;
-	case CELL_GCM_REPLACE: return D3D12_STENCIL_OP_REPLACE;
-	case CELL_GCM_INCR: return D3D12_STENCIL_OP_INCR_SAT;
-	case CELL_GCM_DECR: return D3D12_STENCIL_OP_DECR_SAT;
-	case CELL_GCM_INVERT: return D3D12_STENCIL_OP_INVERT;
-	case CELL_GCM_INCR_WRAP: return D3D12_STENCIL_OP_INCR;
-	case CELL_GCM_DECR_WRAP: return D3D12_STENCIL_OP_DECR;
+	case rsx::stencil_op::keep: return D3D12_STENCIL_OP_KEEP;
+	case rsx::stencil_op::zero: return D3D12_STENCIL_OP_ZERO;
+	case rsx::stencil_op::replace: return D3D12_STENCIL_OP_REPLACE;
+	case rsx::stencil_op::incr: return D3D12_STENCIL_OP_INCR_SAT;
+	case rsx::stencil_op::decr: return D3D12_STENCIL_OP_DECR_SAT;
+	case rsx::stencil_op::invert: return D3D12_STENCIL_OP_INVERT;
+	case rsx::stencil_op::incr_wrap: return D3D12_STENCIL_OP_INCR;
+	case rsx::stencil_op::decr_wrap: return D3D12_STENCIL_OP_DECR;
 	}
 	throw EXCEPTION("Invalid stencil op (0x%x)", op);
 }
 
-D3D12_COMPARISON_FUNC get_compare_func(u32 op)
+D3D12_COMPARISON_FUNC get_compare_func(rsx::comparaison_function op)
 {
 	switch (op)
 	{
-	case CELL_GCM_NEVER: return D3D12_COMPARISON_FUNC_NEVER;
-	case CELL_GCM_LESS: return D3D12_COMPARISON_FUNC_LESS;
-	case CELL_GCM_EQUAL: return D3D12_COMPARISON_FUNC_EQUAL;
-	case CELL_GCM_LEQUAL: return D3D12_COMPARISON_FUNC_LESS_EQUAL;
-	case CELL_GCM_GREATER: return D3D12_COMPARISON_FUNC_GREATER;
-	case CELL_GCM_NOTEQUAL: return D3D12_COMPARISON_FUNC_NOT_EQUAL;
-	case CELL_GCM_GEQUAL: return D3D12_COMPARISON_FUNC_GREATER_EQUAL;
-	case CELL_GCM_ALWAYS: return D3D12_COMPARISON_FUNC_ALWAYS;
+	case rsx::comparaison_function::never: return D3D12_COMPARISON_FUNC_NEVER;
+	case rsx::comparaison_function::less: return D3D12_COMPARISON_FUNC_LESS;
+	case rsx::comparaison_function::equal: return D3D12_COMPARISON_FUNC_EQUAL;
+	case rsx::comparaison_function::less_or_equal: return D3D12_COMPARISON_FUNC_LESS_EQUAL;
+	case rsx::comparaison_function::greater: return D3D12_COMPARISON_FUNC_GREATER;
+	case rsx::comparaison_function::not_equal: return D3D12_COMPARISON_FUNC_NOT_EQUAL;
+	case rsx::comparaison_function::greater_or_equal: return D3D12_COMPARISON_FUNC_GREATER_EQUAL;
+	case rsx::comparaison_function::always: return D3D12_COMPARISON_FUNC_ALWAYS;
 	}
 	throw EXCEPTION("Invalid or unsupported compare func (0x%x)", op);
 }
@@ -371,24 +371,23 @@ DXGI_FORMAT get_depth_samplable_surface_format(rsx::surface_depth_format format)
 	throw EXCEPTION("Invalid format (0x%x)", format);
 }
 
-BOOL get_front_face_ccw(u32 ffv)
+BOOL get_front_face_ccw(rsx::front_face ffv)
 {
 	switch (ffv)
 	{
-	default: // Disgaea 3 pass some garbage value at startup, this is needed to survive.
-	case CELL_GCM_CW: return FALSE;
-	case CELL_GCM_CCW: return TRUE;
+	case rsx::front_face::cw: return FALSE;
+	case rsx::front_face::ccw: return TRUE;
 	}
 	throw EXCEPTION("Invalid front face value (0x%x)", ffv);
 }
 
-D3D12_CULL_MODE get_cull_face(u32 cfv) 
+D3D12_CULL_MODE get_cull_face(rsx::cull_face cfv)
 {
 	switch (cfv)
 	{
-	case CELL_GCM_FRONT: return D3D12_CULL_MODE_FRONT;
-	case CELL_GCM_BACK:  return D3D12_CULL_MODE_BACK;
-	default: return D3D12_CULL_MODE_NONE;
+		case rsx::cull_face::front: return D3D12_CULL_MODE_FRONT;
+		case rsx::cull_face::back: return D3D12_CULL_MODE_BACK;
+		case rsx::cull_face::front_and_back: return D3D12_CULL_MODE_NONE;
 	}
 	throw EXCEPTION("Invalid cull face value (0x%x)", cfv);
 }
@@ -489,13 +488,13 @@ DXGI_FORMAT get_vertex_attribute_format(rsx::vertex_base_type type, u8 size)
 	throw EXCEPTION("Invalid or unsupported type or size (type=0x%x, size=0x%x)", type, size);
 }
 
-D3D12_RECT get_scissor(u32 horizontal, u32 vertical)
+D3D12_RECT get_scissor(u16 clip_origin_x, u16 clip_origin_y, u16 clip_w, u16 clip_h)
 {
 	return{
-		horizontal & 0xFFFF,
-		vertical & 0xFFFF,
-		(horizontal & 0xFFFF) + (horizontal >> 16),
-		(vertical & 0xFFFF) + (vertical >> 16)
+		clip_origin_x,
+		clip_origin_y,
+		clip_w,
+		clip_h,
 	};
 }
 #endif

--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.h
@@ -5,32 +5,32 @@
 /**
  * Convert GCM blend operator code to D3D12 one
  */
-D3D12_BLEND_OP get_blend_op(u16 op);
+D3D12_BLEND_OP get_blend_op(rsx::blend_equation op);
 
 /**
  * Convert GCM blend factor code to D3D12 one
  */
-D3D12_BLEND get_blend_factor(u16 factor);
+D3D12_BLEND get_blend_factor(rsx::blend_factor factor);
 
 /**
  * Convert GCM blend factor code to D3D12 one for alpha component
  */
-D3D12_BLEND get_blend_factor_alpha(u16 factor);
+D3D12_BLEND get_blend_factor_alpha(rsx::blend_factor factor);
 
 /**
 * Convert GCM logic op code to D3D12 one
 */
-D3D12_LOGIC_OP get_logic_op(u32 op);
+D3D12_LOGIC_OP get_logic_op(rsx::logic_op op);
 
 /**
  * Convert GCM stencil op code to D3D12 one
  */
-D3D12_STENCIL_OP get_stencil_op(u32 op);
+D3D12_STENCIL_OP get_stencil_op(rsx::stencil_op op);
 
 /**
  * Convert GCM comparison function code to D3D12 one.
  */
-D3D12_COMPARISON_FUNC get_compare_func(u32 op);
+D3D12_COMPARISON_FUNC get_compare_func(rsx::comparaison_function op);
 
 /**
  * Convert GCM texture format to an equivalent one supported by D3D12.
@@ -91,12 +91,12 @@ DXGI_FORMAT get_depth_samplable_surface_format(rsx::surface_depth_format format)
 /**
  * Convert front face value to bool value telling wheter front face is counterclockwise or not
  */
-BOOL get_front_face_ccw(u32 set_front_face_value);
+BOOL get_front_face_ccw(rsx::front_face set_front_face_value);
 
 /**
 * Convert cull face value to a D3D12_CULL_MODE telling wheter cull face is front or back
 */
-D3D12_CULL_MODE get_cull_face(u32 set_cull_face_value);
+D3D12_CULL_MODE get_cull_face(rsx::cull_face set_cull_face_value);
 
 /**
  * Convert index type to DXGI_FORMAT
@@ -111,4 +111,4 @@ DXGI_FORMAT get_vertex_attribute_format(rsx::vertex_base_type type, u8 size);
 /**
  * Convert scissor register value to D3D12_RECT
  */
-D3D12_RECT get_scissor(u32 horizontal, u32 vertical);
+D3D12_RECT get_scissor(u16 clip_origin_x, u16 clip_origin_y, u16 clip_w, u16 clip_h);

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -61,8 +61,6 @@ private:
 	data_cache m_texture_cache;
 	bool invalidate_address(u32 addr);
 
-	rsx::surface_info m_surface;
-
 	RSXVertexProgram m_vertex_program;
 	RSXFragmentProgram m_fragment_program;
 	PipelineStateObjectCache m_pso_cache;

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -60,72 +60,72 @@ void D3D12GSRender::load_program()
 	};
 	prop.Blend = CD3D12_BLEND_DESC;
 
-	if (rsx::method_registers[NV4097_SET_BLEND_ENABLE])
+	if (rsx::method_registers.blend_enabled())
 	{
 		prop.Blend.RenderTarget[0].BlendEnable = true;
 
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x2)
+		if (rsx::method_registers.blend_enabled_surface_1())
 			prop.Blend.RenderTarget[1].BlendEnable = true;
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x4)
+		if (rsx::method_registers.blend_enabled_surface_2())
 			prop.Blend.RenderTarget[2].BlendEnable = true;
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x8)
+		if (rsx::method_registers.blend_enabled_surface_3())
 			prop.Blend.RenderTarget[3].BlendEnable = true;
 
-		prop.Blend.RenderTarget[0].BlendOp = get_blend_op(rsx::method_registers[NV4097_SET_BLEND_EQUATION] & 0xFFFF);
-		prop.Blend.RenderTarget[0].BlendOpAlpha = get_blend_op(rsx::method_registers[NV4097_SET_BLEND_EQUATION] >> 16);
+		prop.Blend.RenderTarget[0].BlendOp = get_blend_op(rsx::method_registers.blend_equation_rgb());
+		prop.Blend.RenderTarget[0].BlendOpAlpha = get_blend_op(rsx::method_registers.blend_equation_a());
 
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x2)
+		if (rsx::method_registers.blend_enabled_surface_1())
 		{
-			prop.Blend.RenderTarget[1].BlendOp = get_blend_op(rsx::method_registers[NV4097_SET_BLEND_EQUATION] & 0xFFFF);
-			prop.Blend.RenderTarget[1].BlendOpAlpha = get_blend_op(rsx::method_registers[NV4097_SET_BLEND_EQUATION] >> 16);
+			prop.Blend.RenderTarget[1].BlendOp = get_blend_op(rsx::method_registers.blend_equation_rgb());
+			prop.Blend.RenderTarget[1].BlendOpAlpha = get_blend_op(rsx::method_registers.blend_equation_a());
 		}
 
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x4)
+		if (rsx::method_registers.blend_enabled_surface_2())
 		{
-			prop.Blend.RenderTarget[2].BlendOp = get_blend_op(rsx::method_registers[NV4097_SET_BLEND_EQUATION] & 0xFFFF);
-			prop.Blend.RenderTarget[2].BlendOpAlpha = get_blend_op(rsx::method_registers[NV4097_SET_BLEND_EQUATION] >> 16);
+			prop.Blend.RenderTarget[2].BlendOp = get_blend_op(rsx::method_registers.blend_equation_rgb());
+			prop.Blend.RenderTarget[2].BlendOpAlpha = get_blend_op(rsx::method_registers.blend_equation_a());
 		}
 
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x8)
+		if (rsx::method_registers.blend_enabled_surface_3())
 		{
-			prop.Blend.RenderTarget[3].BlendOp = get_blend_op(rsx::method_registers[NV4097_SET_BLEND_EQUATION] & 0xFFFF);
-			prop.Blend.RenderTarget[3].BlendOpAlpha = get_blend_op(rsx::method_registers[NV4097_SET_BLEND_EQUATION] >> 16);
+			prop.Blend.RenderTarget[3].BlendOp = get_blend_op(rsx::method_registers.blend_equation_rgb());
+			prop.Blend.RenderTarget[3].BlendOpAlpha = get_blend_op(rsx::method_registers.blend_equation_a());
 		}
 
-		prop.Blend.RenderTarget[0].SrcBlend = get_blend_factor(rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] & 0xFFFF);
-		prop.Blend.RenderTarget[0].DestBlend = get_blend_factor(rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] & 0xFFFF);
-		prop.Blend.RenderTarget[0].SrcBlendAlpha = get_blend_factor_alpha(rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] >> 16);
-		prop.Blend.RenderTarget[0].DestBlendAlpha = get_blend_factor_alpha(rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] >> 16);
+		prop.Blend.RenderTarget[0].SrcBlend = get_blend_factor(rsx::method_registers.blend_func_sfactor_rgb());
+		prop.Blend.RenderTarget[0].DestBlend = get_blend_factor(rsx::method_registers.blend_func_dfactor_rgb());
+		prop.Blend.RenderTarget[0].SrcBlendAlpha = get_blend_factor_alpha(rsx::method_registers.blend_func_sfactor_a());
+		prop.Blend.RenderTarget[0].DestBlendAlpha = get_blend_factor_alpha(rsx::method_registers.blend_func_dfactor_a());
 
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x2)
+		if (rsx::method_registers.blend_enabled_surface_1())
 		{
-			prop.Blend.RenderTarget[1].SrcBlend = get_blend_factor(rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] & 0xFFFF);
-			prop.Blend.RenderTarget[1].DestBlend = get_blend_factor(rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] & 0xFFFF);
-			prop.Blend.RenderTarget[1].SrcBlendAlpha = get_blend_factor_alpha(rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] >> 16);
-			prop.Blend.RenderTarget[1].DestBlendAlpha = get_blend_factor_alpha(rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] >> 16);
+			prop.Blend.RenderTarget[1].SrcBlend = get_blend_factor(rsx::method_registers.blend_func_sfactor_rgb());
+			prop.Blend.RenderTarget[1].DestBlend = get_blend_factor(rsx::method_registers.blend_func_dfactor_rgb());
+			prop.Blend.RenderTarget[1].SrcBlendAlpha = get_blend_factor_alpha(rsx::method_registers.blend_func_sfactor_a());
+			prop.Blend.RenderTarget[1].DestBlendAlpha = get_blend_factor_alpha(rsx::method_registers.blend_func_dfactor_a());
 		}
 
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x4)
+		if (rsx::method_registers.blend_enabled_surface_2())
 		{
-			prop.Blend.RenderTarget[2].SrcBlend = get_blend_factor(rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] & 0xFFFF);
-			prop.Blend.RenderTarget[2].DestBlend = get_blend_factor(rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] & 0xFFFF);
-			prop.Blend.RenderTarget[2].SrcBlendAlpha = get_blend_factor_alpha(rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] >> 16);
-			prop.Blend.RenderTarget[2].DestBlendAlpha = get_blend_factor_alpha(rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] >> 16);
+			prop.Blend.RenderTarget[2].SrcBlend = get_blend_factor(rsx::method_registers.blend_func_sfactor_rgb());
+			prop.Blend.RenderTarget[2].DestBlend = get_blend_factor(rsx::method_registers.blend_func_dfactor_rgb());
+			prop.Blend.RenderTarget[2].SrcBlendAlpha = get_blend_factor_alpha(rsx::method_registers.blend_func_sfactor_a());
+			prop.Blend.RenderTarget[2].DestBlendAlpha = get_blend_factor_alpha(rsx::method_registers.blend_func_dfactor_a());
 		}
 
-		if (rsx::method_registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x8)
+		if (rsx::method_registers.blend_enabled_surface_3())
 		{
-			prop.Blend.RenderTarget[3].SrcBlend = get_blend_factor(rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] & 0xFFFF);
-			prop.Blend.RenderTarget[3].DestBlend = get_blend_factor(rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] & 0xFFFF);
-			prop.Blend.RenderTarget[3].SrcBlendAlpha = get_blend_factor_alpha(rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] >> 16);
-			prop.Blend.RenderTarget[3].DestBlendAlpha = get_blend_factor_alpha(rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] >> 16);
+			prop.Blend.RenderTarget[3].SrcBlend = get_blend_factor(rsx::method_registers.blend_func_sfactor_rgb());
+			prop.Blend.RenderTarget[3].DestBlend = get_blend_factor(rsx::method_registers.blend_func_dfactor_rgb());
+			prop.Blend.RenderTarget[3].SrcBlendAlpha = get_blend_factor_alpha(rsx::method_registers.blend_func_sfactor_a());
+			prop.Blend.RenderTarget[3].DestBlendAlpha = get_blend_factor_alpha(rsx::method_registers.blend_func_dfactor_a());
 		}
 	}
 
-	if (rsx::method_registers[NV4097_SET_LOGIC_OP_ENABLE])
+	if (rsx::method_registers.logic_op_enabled())
 	{
 		prop.Blend.RenderTarget[0].LogicOpEnable = true;
-		prop.Blend.RenderTarget[0].LogicOp = get_logic_op(rsx::method_registers[NV4097_SET_LOGIC_OP]);
+		prop.Blend.RenderTarget[0].LogicOp = get_logic_op(rsx::method_registers.logic_operation());
 	}
 
 //	if (m_set_blend_color)
@@ -133,10 +133,10 @@ void D3D12GSRender::load_program()
 		// glBlendColor(m_blend_color_r, m_blend_color_g, m_blend_color_b, m_blend_color_a);
 		// checkForGlError("glBlendColor");
 	}
-	prop.DepthStencilFormat = get_depth_stencil_surface_format(m_surface.depth_format);
-	prop.RenderTargetsFormat = get_color_surface_format(m_surface.color_format);
+	prop.DepthStencilFormat = get_depth_stencil_surface_format(rsx::method_registers.surface_depth_fmt());
+	prop.RenderTargetsFormat = get_color_surface_format(rsx::method_registers.surface_color());
 
-	switch (rsx::to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET]))
+	switch (rsx::method_registers.surface_color_target())
 	{
 	case rsx::surface_target::surface_a:
 	case rsx::surface_target::surface_b:
@@ -154,36 +154,36 @@ void D3D12GSRender::load_program()
 	default:
 		break;
 	}
-	if (!!(rsx::method_registers[NV4097_SET_DEPTH_TEST_ENABLE]))
+	if (rsx::method_registers.depth_test_enabled())
 	{
 		prop.DepthStencil.DepthEnable = TRUE;
-		prop.DepthStencil.DepthFunc = get_compare_func(rsx::method_registers[NV4097_SET_DEPTH_FUNC]);
+		prop.DepthStencil.DepthFunc = get_compare_func(rsx::method_registers.depth_func());
 	}
 	else
 		prop.DepthStencil.DepthEnable = FALSE;
 
-	prop.DepthStencil.DepthWriteMask = !!(rsx::method_registers[NV4097_SET_DEPTH_MASK]) ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
-	prop.DepthStencil.StencilEnable = !!(rsx::method_registers[NV4097_SET_STENCIL_TEST_ENABLE]);
-	prop.DepthStencil.StencilReadMask = rsx::method_registers[NV4097_SET_STENCIL_FUNC_MASK];
-	prop.DepthStencil.StencilWriteMask = rsx::method_registers[NV4097_SET_STENCIL_MASK];
-	prop.DepthStencil.FrontFace.StencilPassOp = get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_ZPASS]);
-	prop.DepthStencil.FrontFace.StencilDepthFailOp = get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_ZFAIL]);
-	prop.DepthStencil.FrontFace.StencilFailOp = get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_FAIL]);
-	prop.DepthStencil.FrontFace.StencilFunc = get_compare_func(rsx::method_registers[NV4097_SET_STENCIL_FUNC]);
+	prop.DepthStencil.DepthWriteMask = rsx::method_registers.depth_write_enabled() ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
+	prop.DepthStencil.StencilEnable = rsx::method_registers.stencil_test_enabled();
+	prop.DepthStencil.StencilReadMask = rsx::method_registers.stencil_func_mask();
+	prop.DepthStencil.StencilWriteMask = rsx::method_registers.stencil_mask();
+	prop.DepthStencil.FrontFace.StencilPassOp = get_stencil_op(rsx::method_registers.stencil_op_zpass());
+	prop.DepthStencil.FrontFace.StencilDepthFailOp = get_stencil_op(rsx::method_registers.stencil_op_zfail());
+	prop.DepthStencil.FrontFace.StencilFailOp = get_stencil_op(rsx::method_registers.stencil_op_fail());
+	prop.DepthStencil.FrontFace.StencilFunc = get_compare_func(rsx::method_registers.stencil_func());
 
-	if (rsx::method_registers[NV4097_SET_TWO_SIDED_STENCIL_TEST_ENABLE])
+	if (rsx::method_registers.two_sided_stencil_test_enabled())
 	{
-		prop.DepthStencil.BackFace.StencilFailOp = get_stencil_op(rsx::method_registers[NV4097_SET_BACK_STENCIL_OP_FAIL]);
-		prop.DepthStencil.BackFace.StencilFunc = get_compare_func(rsx::method_registers[NV4097_SET_BACK_STENCIL_FUNC]);
-		prop.DepthStencil.BackFace.StencilPassOp = get_stencil_op(rsx::method_registers[NV4097_SET_BACK_STENCIL_OP_ZPASS]);
-		prop.DepthStencil.BackFace.StencilDepthFailOp = get_stencil_op(rsx::method_registers[NV4097_SET_BACK_STENCIL_OP_ZFAIL]);
+		prop.DepthStencil.BackFace.StencilFailOp = get_stencil_op(rsx::method_registers.back_stencil_op_fail());
+		prop.DepthStencil.BackFace.StencilFunc = get_compare_func(rsx::method_registers.back_stencil_func());
+		prop.DepthStencil.BackFace.StencilPassOp = get_stencil_op(rsx::method_registers.back_stencil_op_zpass());
+		prop.DepthStencil.BackFace.StencilDepthFailOp = get_stencil_op(rsx::method_registers.back_stencil_op_zfail());
 	}
 	else
 	{
-		prop.DepthStencil.BackFace.StencilPassOp = get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_ZPASS]);
-		prop.DepthStencil.BackFace.StencilDepthFailOp = get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_ZFAIL]);
-		prop.DepthStencil.BackFace.StencilFailOp = get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_FAIL]);
-		prop.DepthStencil.BackFace.StencilFunc = get_compare_func(rsx::method_registers[NV4097_SET_STENCIL_FUNC]);
+		prop.DepthStencil.BackFace.StencilPassOp = get_stencil_op(rsx::method_registers.stencil_op_zpass());
+		prop.DepthStencil.BackFace.StencilDepthFailOp = get_stencil_op(rsx::method_registers.stencil_op_zfail());
+		prop.DepthStencil.BackFace.StencilFailOp = get_stencil_op(rsx::method_registers.stencil_op_fail());
+		prop.DepthStencil.BackFace.StencilFunc = get_compare_func(rsx::method_registers.stencil_func());
 	}
 
 	// Sensible default value
@@ -202,25 +202,25 @@ void D3D12GSRender::load_program()
 		D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF,
 	};
 	prop.Rasterization = CD3D12_RASTERIZER_DESC;
-	
-	if (!!rsx::method_registers[NV4097_SET_CULL_FACE_ENABLE])
+
+	if (rsx::method_registers.cull_face_enabled())
 	{
-		prop.Rasterization.CullMode = get_cull_face(rsx::method_registers[NV4097_SET_CULL_FACE]);
+		prop.Rasterization.CullMode = get_cull_face(rsx::method_registers.cull_face_mode());
 	}
 
-	prop.Rasterization.FrontCounterClockwise = get_front_face_ccw(rsx::method_registers[NV4097_SET_FRONT_FACE]);
+	prop.Rasterization.FrontCounterClockwise = get_front_face_ccw(rsx::method_registers.front_face_mode());
 
 	UINT8 mask = 0;
-	mask |= (rsx::method_registers[NV4097_SET_COLOR_MASK] >> 16) & 0xFF ? D3D12_COLOR_WRITE_ENABLE_RED : 0;
-	mask |= (rsx::method_registers[NV4097_SET_COLOR_MASK] >> 8) & 0xFF ? D3D12_COLOR_WRITE_ENABLE_GREEN : 0;
-	mask |= rsx::method_registers[NV4097_SET_COLOR_MASK] & 0xFF ? D3D12_COLOR_WRITE_ENABLE_BLUE : 0;
-	mask |= (rsx::method_registers[NV4097_SET_COLOR_MASK] >> 24) & 0xFF ? D3D12_COLOR_WRITE_ENABLE_ALPHA : 0;
+	mask |= rsx::method_registers.color_mask_r() ? D3D12_COLOR_WRITE_ENABLE_RED : 0;
+	mask |= rsx::method_registers.color_mask_g() ? D3D12_COLOR_WRITE_ENABLE_GREEN : 0;
+	mask |= rsx::method_registers.color_mask_b() ? D3D12_COLOR_WRITE_ENABLE_BLUE : 0;
+	mask |= rsx::method_registers.color_mask_a() ? D3D12_COLOR_WRITE_ENABLE_ALPHA : 0;
 	for (unsigned i = 0; i < prop.numMRT; i++)
 		prop.Blend.RenderTarget[i].RenderTargetWriteMask = mask;
 
-	if (!!rsx::method_registers[NV4097_SET_RESTART_INDEX_ENABLE])
+	if (rsx::method_registers.restart_index_enabled())
 	{
-		rsx::index_array_type index_type = rsx::to_index_array_type(rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);
+		rsx::index_array_type index_type = rsx::method_registers.index_type();
 		if (index_type == rsx::index_array_type::u32)
 		{
 			prop.CutValue = D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_0xFFFFFFFF;

--- a/rpcs3/Emu/RSX/GCM.cpp
+++ b/rpcs3/Emu/RSX/GCM.cpp
@@ -1036,6 +1036,260 @@ rsx::surface_color_format rsx::to_surface_color_format(u8 in)
 	throw EXCEPTION("unknow surface color format %x", in);
 }
 
+rsx::stencil_op rsx::to_stencil_op(u16 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_KEEP: return rsx::stencil_op::keep;
+	case CELL_GCM_REPLACE: return rsx::stencil_op::replace;
+	case CELL_GCM_INCR: return rsx::stencil_op::incr;
+	case CELL_GCM_DECR: return rsx::stencil_op::decr;
+	case CELL_GCM_INCR_WRAP: return rsx::stencil_op::incr_wrap;
+	case CELL_GCM_DECR_WRAP: return rsx::stencil_op::decr_wrap;
+	case CELL_GCM_ZERO: return rsx::stencil_op::zero;
+	}
+	throw EXCEPTION("unknow stencil op %x", in);
+}
+
+rsx::blend_equation rsx::to_blend_equation(u16 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_FUNC_ADD: return rsx::blend_equation::add;
+	case CELL_GCM_MIN: return rsx::blend_equation::min;
+	case CELL_GCM_MAX: return rsx::blend_equation::max;
+	case CELL_GCM_FUNC_SUBTRACT: return rsx::blend_equation::substract;
+	case CELL_GCM_FUNC_REVERSE_SUBTRACT: return rsx::blend_equation::reverse_substract;
+	case CELL_GCM_FUNC_REVERSE_SUBTRACT_SIGNED: return rsx::blend_equation::reverse_substract_signed;
+	case CELL_GCM_FUNC_ADD_SIGNED: return rsx::blend_equation::add_signed;
+	case CELL_GCM_FUNC_REVERSE_ADD_SIGNED: return rsx::blend_equation::reverse_add_signed;
+	}
+	throw EXCEPTION("unknow blend eq %x", in);
+}
+
+rsx::blend_factor rsx::to_blend_factor(u16 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_ZERO: return rsx::blend_factor::zero;
+	case CELL_GCM_ONE: return rsx::blend_factor::one;
+	case CELL_GCM_SRC_COLOR: return rsx::blend_factor::src_color;
+	case CELL_GCM_ONE_MINUS_SRC_COLOR: return rsx::blend_factor::one_minus_src_color;
+	case CELL_GCM_SRC_ALPHA: return rsx::blend_factor::src_alpha;
+	case CELL_GCM_ONE_MINUS_SRC_ALPHA: return rsx::blend_factor::one_minus_src_alpha;
+	case CELL_GCM_DST_ALPHA: return rsx::blend_factor::dst_alpha;
+	case CELL_GCM_ONE_MINUS_DST_ALPHA: return rsx::blend_factor::one_minus_dst_alpha;
+	case CELL_GCM_DST_COLOR: return rsx::blend_factor::dst_color;
+	case CELL_GCM_ONE_MINUS_DST_COLOR: return rsx::blend_factor::one_minus_dst_color;
+	case CELL_GCM_SRC_ALPHA_SATURATE: return rsx::blend_factor::src_alpha_saturate;
+	case CELL_GCM_CONSTANT_COLOR: return rsx::blend_factor::constant_color;
+	case CELL_GCM_ONE_MINUS_CONSTANT_COLOR: return rsx::blend_factor::one_minus_constant_color;
+	case CELL_GCM_CONSTANT_ALPHA: return rsx::blend_factor::constant_alpha;
+	case CELL_GCM_ONE_MINUS_CONSTANT_ALPHA: return rsx::blend_factor::one_minus_constant_alpha;
+	}
+	throw EXCEPTION("unknow blend factor %x", in);
+}
+
+rsx::logic_op rsx::to_logic_op(u16 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_CLEAR: return rsx::logic_op::logic_clear;
+	case CELL_GCM_AND: return rsx::logic_op::logic_and;
+	case CELL_GCM_AND_REVERSE: return rsx::logic_op::logic_and_reverse;
+	case CELL_GCM_COPY: return rsx::logic_op::logic_copy;
+	case CELL_GCM_AND_INVERTED: return rsx::logic_op::logic_and_inverted;
+	case CELL_GCM_NOOP: return rsx::logic_op::logic_noop;
+	case CELL_GCM_XOR: return rsx::logic_op::logic_xor;
+	case CELL_GCM_OR: return rsx::logic_op::logic_or;
+	case CELL_GCM_NOR: return rsx::logic_op::logic_nor;
+	case CELL_GCM_EQUIV: return rsx::logic_op::logic_equiv;
+	case CELL_GCM_INVERT: return rsx::logic_op::logic_invert;
+	case CELL_GCM_OR_REVERSE: return rsx::logic_op::logic_or_reverse;
+	case CELL_GCM_COPY_INVERTED: return rsx::logic_op::logic_copy_inverted;
+	case CELL_GCM_OR_INVERTED: return rsx::logic_op::logic_or_inverted;
+	case CELL_GCM_NAND: return rsx::logic_op::logic_nand;
+	case CELL_GCM_SET: return rsx::logic_op::logic_set;
+	}
+	throw EXCEPTION("unknow logic op %x", in);
+}
+
+rsx::front_face rsx::to_front_face(u16 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_CW: return rsx::front_face::cw;
+	case CELL_GCM_CCW: return rsx::front_face::ccw;
+	}
+	throw EXCEPTION("unknow front face %x", in);
+}
+
+rsx::cull_face rsx::to_cull_face(u16 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_FRONT_AND_BACK: return rsx::cull_face::front_and_back;
+	case CELL_GCM_FRONT: return rsx::cull_face::front;
+	case CELL_GCM_BACK: return rsx::cull_face::back;
+	}
+	throw EXCEPTION("unknow cull face %x", in);
+}
+
+enum
+{
+	CELL_GCM_TRANSFER_ORIGIN_CENTER = 1,
+	CELL_GCM_TRANSFER_ORIGIN_CORNER = 2,
+
+	CELL_GCM_TRANSFER_INTERPOLATOR_ZOH = 0,
+	CELL_GCM_TRANSFER_INTERPOLATOR_FOH = 1,
+};
+
+rsx::blit_engine::transfer_origin rsx::blit_engine::to_transfer_origin(u8 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TRANSFER_ORIGIN_CENTER: return rsx::blit_engine::transfer_origin::center;
+	case CELL_GCM_TRANSFER_ORIGIN_CORNER: return rsx::blit_engine::transfer_origin::corner;
+	}
+	throw EXCEPTION("unknow tranfer origin %x", in);
+}
+
+rsx::blit_engine::transfer_interpolator rsx::blit_engine::to_transfer_interpolator(u8 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TRANSFER_INTERPOLATOR_ZOH: return rsx::blit_engine::transfer_interpolator::zoh;
+	case CELL_GCM_TRANSFER_INTERPOLATOR_FOH: return rsx::blit_engine::transfer_interpolator::foh;
+	}
+	throw EXCEPTION("unknow tranfer interpolator %x", in);
+}
+
+enum
+{
+	CELL_GCM_TRANSFER_OPERATION_SRCCOPY_AND = 0,
+	CELL_GCM_TRANSFER_OPERATION_ROP_AND = 1,
+	CELL_GCM_TRANSFER_OPERATION_BLEND_AND = 2,
+	CELL_GCM_TRANSFER_OPERATION_SRCCOPY = 3,
+	CELL_GCM_TRANSFER_OPERATION_SRCCOPY_PREMULT = 4,
+	CELL_GCM_TRANSFER_OPERATION_BLEND_PREMULT = 5,
+};
+
+rsx::blit_engine::transfer_operation rsx::blit_engine::to_transfer_operation(u8 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TRANSFER_OPERATION_SRCCOPY_AND: return rsx::blit_engine::transfer_operation::srccopy_and;
+	case CELL_GCM_TRANSFER_OPERATION_ROP_AND: return rsx::blit_engine::transfer_operation::rop_and;
+	case CELL_GCM_TRANSFER_OPERATION_BLEND_AND: return rsx::blit_engine::transfer_operation::blend_and;
+	case CELL_GCM_TRANSFER_OPERATION_SRCCOPY: return rsx::blit_engine::transfer_operation::srccopy;
+	case CELL_GCM_TRANSFER_OPERATION_SRCCOPY_PREMULT: return rsx::blit_engine::transfer_operation::srccopy_premult;
+	case CELL_GCM_TRANSFER_OPERATION_BLEND_PREMULT: return rsx::blit_engine::transfer_operation::blend_premult;
+	}
+	throw EXCEPTION("unknow tranfer operation %x", in);
+}
+
+enum
+{
+	CELL_GCM_TRANSFER_SCALE_FORMAT_A1R5G5B5 = 1,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_X1R5G5B5 = 2,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_A8R8G8B8 = 3,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_X8R8G8B8 = 4,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_CR8YB8CB8YA8 = 5,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_YB8CR8YA8CB8 = 6,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_R5G6B5 = 7,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_Y8 = 8,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_AY8 = 9,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_EYB8ECR8EYA8ECB8 = 10,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_ECR8EYB8ECB8EYA8 = 11,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_A8B8G8R8 = 12,
+	CELL_GCM_TRANSFER_SCALE_FORMAT_X8B8G8R8 = 13,
+};
+
+rsx::blit_engine::transfer_source_format rsx::blit_engine::to_transfer_source_format(u8 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_A1R5G5B5: return rsx::blit_engine::transfer_source_format::a1r5g5b5;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_X1R5G5B5: return rsx::blit_engine::transfer_source_format::x1r5g5b5;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_A8R8G8B8: return rsx::blit_engine::transfer_source_format::a8r8g8b8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_X8R8G8B8: return rsx::blit_engine::transfer_source_format::x8r8g8b8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_CR8YB8CB8YA8: return rsx::blit_engine::transfer_source_format::cr8yb8cb8ya8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_YB8CR8YA8CB8: return rsx::blit_engine::transfer_source_format::yb8cr8ya8cb8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_R5G6B5: return rsx::blit_engine::transfer_source_format::r5g6b5;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_Y8: return rsx::blit_engine::transfer_source_format::y8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_AY8: return rsx::blit_engine::transfer_source_format::ay8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_EYB8ECR8EYA8ECB8: return rsx::blit_engine::transfer_source_format::eyb8ecr8eya8ecb8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_ECR8EYB8ECB8EYA8: return rsx::blit_engine::transfer_source_format::ecr8eyb8ecb8eya8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_A8B8G8R8: return rsx::blit_engine::transfer_source_format::a8b8g8r8;
+	case CELL_GCM_TRANSFER_SCALE_FORMAT_X8B8G8R8: return rsx::blit_engine::transfer_source_format::x8b8g8r8;
+	}
+	throw EXCEPTION("unknow transfer source format %x", in);
+}
+
+enum
+{
+	// Destination Format conversions
+	CELL_GCM_TRANSFER_SURFACE_FORMAT_R5G6B5 = 4,
+	CELL_GCM_TRANSFER_SURFACE_FORMAT_A8R8G8B8 = 10,
+	CELL_GCM_TRANSFER_SURFACE_FORMAT_Y32 = 11,
+};
+
+rsx::blit_engine::transfer_destination_format rsx::blit_engine::to_transfer_destination_format(u8 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TRANSFER_SURFACE_FORMAT_R5G6B5: return rsx::blit_engine::transfer_destination_format::r5g6b5;
+	case CELL_GCM_TRANSFER_SURFACE_FORMAT_A8R8G8B8: return rsx::blit_engine::transfer_destination_format::a8r8g8b8;
+	case CELL_GCM_TRANSFER_SURFACE_FORMAT_Y32: return rsx::blit_engine::transfer_destination_format::y32;
+	}
+	throw EXCEPTION("unknow transfer destination format %x", in);
+}
+
+enum
+{
+	CELL_GCM_CONTEXT_SURFACE2D = 0x313371C3,
+	CELL_GCM_CONTEXT_SWIZZLE2D = 0x31337A73,
+};
+
+rsx::blit_engine::context_surface rsx::blit_engine::to_context_surface(u32 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_CONTEXT_SURFACE2D: return rsx::blit_engine::context_surface::surface2d;
+	case CELL_GCM_CONTEXT_SWIZZLE2D: return rsx::blit_engine::context_surface::swizzle2d;
+	}
+	throw EXCEPTION("unknow context surface %x", in);
+}
+
+rsx::blit_engine::context_dma rsx::blit_engine::to_context_dma(u32 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_CONTEXT_DMA_TO_MEMORY_GET_REPORT: return rsx::blit_engine::context_dma::to_memory_get_report;
+	case CELL_GCM_CONTEXT_DMA_REPORT_LOCATION_MAIN: return rsx::blit_engine::context_dma::report_location_main;
+	}
+	throw EXCEPTION("unknow context dma %x", in);
+}
+
+enum
+{
+	CELL_GCM_USER_CLIP_PLANE_DISABLE = 0,
+	CELL_GCM_USER_CLIP_PLANE_ENABLE_LT = 1,
+	CELL_GCM_USER_CLIP_PLANE_ENABLE_GE = 2,
+};
+
+rsx::user_clip_plane_op rsx::to_user_clip_plane_op(u8 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_USER_CLIP_PLANE_DISABLE: return rsx::user_clip_plane_op::disable;
+	case CELL_GCM_USER_CLIP_PLANE_ENABLE_LT: return rsx::user_clip_plane_op::less_than;
+	case CELL_GCM_USER_CLIP_PLANE_ENABLE_GE: return rsx::user_clip_plane_op::greather_or_equal;
+	}
+	throw EXCEPTION("unknow user clip plane %x", in);
+}
+
+
 // Various parameter pretty printing function
 namespace
 {

--- a/rpcs3/Emu/RSX/GCM.h
+++ b/rpcs3/Emu/RSX/GCM.h
@@ -212,6 +212,178 @@ namespace rsx
 	};
 
 	texture_magnify_filter to_texture_magnify_filter(u8 in);
+
+	enum class stencil_op : u8
+	{
+		keep,
+		zero,
+		replace,
+		incr,
+		decr,
+		invert,
+		incr_wrap,
+		decr_wrap,
+	};
+
+	stencil_op to_stencil_op(u16 in);
+
+	enum class blend_equation : u8
+	{
+		add,
+		min,
+		max,
+		substract,
+		reverse_substract,
+		reverse_substract_signed,
+		add_signed,
+		reverse_add_signed,
+	};
+
+	blend_equation to_blend_equation(u16 in);
+
+	enum class blend_factor : u8
+	{
+		zero,
+		one,
+		src_color,
+		one_minus_src_color,
+		dst_color,
+		one_minus_dst_color,
+		src_alpha,
+		one_minus_src_alpha,
+		dst_alpha,
+		one_minus_dst_alpha,
+		src_alpha_saturate,
+		constant_color,
+		one_minus_constant_color,
+		constant_alpha,
+		one_minus_constant_alpha,
+	};
+
+	blend_factor to_blend_factor(u16 in);
+
+	enum class logic_op : u8
+	{
+		logic_clear,
+		logic_and,
+		logic_and_reverse,
+		logic_copy,
+		logic_and_inverted,
+		logic_noop,
+		logic_xor,
+		logic_or,
+		logic_nor,
+		logic_equiv,
+		logic_invert,
+		logic_or_reverse,
+		logic_copy_inverted,
+		logic_or_inverted,
+		logic_nand,
+		logic_set,
+	};
+
+	logic_op to_logic_op(u16 in);
+
+	enum class front_face : u8
+	{
+		cw, /// clockwise
+		ccw /// counter clockwise
+	};
+
+	front_face to_front_face(u16 in);
+
+	enum class cull_face : u8
+	{
+		front,
+		back,
+		front_and_back,
+	};
+
+	cull_face to_cull_face(u16 in);
+
+	enum class user_clip_plane_op : u8
+	{
+		disable,
+		less_than,
+		greather_or_equal,
+	};
+
+	user_clip_plane_op to_user_clip_plane_op(u8 in);
+
+	namespace blit_engine
+	{
+		enum class transfer_origin : u8
+		{
+			center,
+			corner,
+		};
+
+		transfer_origin to_transfer_origin(u8 in);
+
+		enum class transfer_interpolator : u8
+		{
+			zoh,
+			foh,
+		};
+
+		transfer_interpolator to_transfer_interpolator(u8 in);
+
+		enum class transfer_operation : u8
+		{
+			srccopy_and,
+			rop_and,
+			blend_and,
+			srccopy,
+			srccopy_premult,
+			blend_premult,
+		};
+
+		transfer_operation to_transfer_operation(u8 in);
+
+		enum class transfer_source_format : u8
+		{
+			a1r5g5b5,
+			x1r5g5b5,
+			a8r8g8b8,
+			x8r8g8b8,
+			cr8yb8cb8ya8,
+			yb8cr8ya8cb8,
+			r5g6b5,
+			y8,
+			ay8,
+			eyb8ecr8eya8ecb8,
+			ecr8eyb8ecb8eya8,
+			a8b8g8r8,
+			x8b8g8r8,
+		};
+
+		transfer_source_format to_transfer_source_format(u8 in);
+
+		enum class transfer_destination_format : u8
+		{
+			r5g6b5,
+			a8r8g8b8,
+			y32,
+		};
+
+		transfer_destination_format to_transfer_destination_format(u8 in);
+
+		enum class context_surface : u8
+		{
+			surface2d,
+			swizzle2d,
+		};
+
+		context_surface to_context_surface(u32 in);
+
+		enum class context_dma : u8
+		{
+			to_memory_get_report,
+			report_location_main,
+		};
+
+		context_dma to_context_dma(u32 in);
+	}
 }
 
 enum
@@ -296,43 +468,6 @@ enum
 	// Surface type
 	CELL_GCM_SURFACE_PITCH    = 1,
 	CELL_GCM_SURFACE_SWIZZLE  = 2,
-};
-
-enum
-{
-	// Transfer operations
-	CELL_GCM_TRANSFER_OPERATION_SRCCOPY_AND     = 0,
-	CELL_GCM_TRANSFER_OPERATION_ROP_AND         = 1,
-	CELL_GCM_TRANSFER_OPERATION_BLEND_AND       = 2,
-	CELL_GCM_TRANSFER_OPERATION_SRCCOPY         = 3,
-	CELL_GCM_TRANSFER_OPERATION_SRCCOPY_PREMULT = 4,
-	CELL_GCM_TRANSFER_OPERATION_BLEND_PREMULT   = 5,
-
-	CELL_GCM_TRANSFER_ORIGIN_CENTER = 1,
-	CELL_GCM_TRANSFER_ORIGIN_CORNER = 2,
-
-	CELL_GCM_TRANSFER_INTERPOLATOR_ZOH = 0,
-	CELL_GCM_TRANSFER_INTERPOLATOR_FOH = 1,
-
-	// Destination Format conversions
-	CELL_GCM_TRANSFER_SURFACE_FORMAT_R5G6B5   = 4,
-	CELL_GCM_TRANSFER_SURFACE_FORMAT_A8R8G8B8 = 10,
-	CELL_GCM_TRANSFER_SURFACE_FORMAT_Y32      = 11,
-
-	// Source Format conversions
-	CELL_GCM_TRANSFER_SCALE_FORMAT_A1R5G5B5         = 1,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_X1R5G5B5         = 2,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_A8R8G8B8         = 3,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_X8R8G8B8         = 4,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_CR8YB8CB8YA8     = 5,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_YB8CR8YA8CB8     = 6,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_R5G6B5           = 7,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_Y8               = 8,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_AY8              = 9,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_EYB8ECR8EYA8ECB8 = 10,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_ECR8EYB8ECB8EYA8 = 11,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_A8B8G8R8         = 12,
-	CELL_GCM_TRANSFER_SCALE_FORMAT_X8B8G8R8         = 13,
 };
 
 enum
@@ -567,10 +702,6 @@ enum
 
 	CELL_GCM_TRUE = 1,
 	CELL_GCM_FALSE = 0,
-
-	CELL_GCM_USER_CLIP_PLANE_DISABLE = 0,
-	CELL_GCM_USER_CLIP_PLANE_ENABLE_LT = 1,
-	CELL_GCM_USER_CLIP_PLANE_ENABLE_GE = 2,
 };
 
 enum
@@ -594,10 +725,8 @@ enum
 {
 	CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER   = 0xFEED0000, // Local memory
 	CELL_GCM_CONTEXT_DMA_MEMORY_HOST_BUFFER    = 0xFEED0001, // Main memory
-	CELL_GCM_CONTEXT_SURFACE2D                 = 0x313371C3,
-	CELL_GCM_CONTEXT_SWIZZLE2D                 = 0x31337A73,
-	CELL_GCM_CONTEXT_DMA_TO_MEMORY_GET_REPORT  = 0x66626660,
-	CELL_GCM_CONTEXT_DMA_REPORT_LOCATION_MAIN  = 0xBAD68000,
+	CELL_GCM_CONTEXT_DMA_TO_MEMORY_GET_REPORT = 0x66626660,
+	CELL_GCM_CONTEXT_DMA_REPORT_LOCATION_MAIN = 0xBAD68000,
 	CELL_GCM_CONTEXT_DMA_NOTIFY_MAIN_0         = 0x6660420F,
 };
 

--- a/rpcs3/Emu/RSX/GL/gl_render_targets.h
+++ b/rpcs3/Emu/RSX/GL/gl_render_targets.h
@@ -42,30 +42,6 @@ namespace rsx
 		color_format surface_color_format_to_gl(rsx::surface_color_format color_format);
 		depth_format surface_depth_format_to_gl(rsx::surface_depth_format depth_format);
 		u8 get_pixel_size(rsx::surface_depth_format format);
-
-		const u32 mr_color_offset[rsx::limits::color_buffers_count] =
-		{
-			NV4097_SET_SURFACE_COLOR_AOFFSET,
-			NV4097_SET_SURFACE_COLOR_BOFFSET,
-			NV4097_SET_SURFACE_COLOR_COFFSET,
-			NV4097_SET_SURFACE_COLOR_DOFFSET
-		};
-
-		const u32 mr_color_dma[rsx::limits::color_buffers_count] =
-		{
-			NV4097_SET_CONTEXT_DMA_COLOR_A,
-			NV4097_SET_CONTEXT_DMA_COLOR_B,
-			NV4097_SET_CONTEXT_DMA_COLOR_C,
-			NV4097_SET_CONTEXT_DMA_COLOR_D
-		};
-
-		const u32 mr_color_pitch[rsx::limits::color_buffers_count] =
-		{
-			NV4097_SET_SURFACE_PITCH_A,
-			NV4097_SET_SURFACE_PITCH_B,
-			NV4097_SET_SURFACE_PITCH_C,
-			NV4097_SET_SURFACE_PITCH_D
-		};
 	}
 }
 

--- a/rpcs3/Emu/RSX/GL/vertex_buffer.cpp
+++ b/rpcs3/Emu/RSX/GL/vertex_buffer.cpp
@@ -164,7 +164,7 @@ u32 GLGSRender::set_vertex_buffer()
 
 	std::chrono::time_point<std::chrono::system_clock> then = std::chrono::system_clock::now();
 
-	u32 input_mask = rsx::method_registers[NV4097_SET_VERTEX_ATTRIB_INPUT_MASK];
+	u32 input_mask = rsx::method_registers.vertex_attrib_input_mask();
 	u32 min_index = 0, max_index = 0;
 	u32 max_vertex_attrib_size = 0;
 	u32 offset_in_index_buffer = 0;
@@ -176,7 +176,7 @@ u32 GLGSRender::set_vertex_buffer()
 	
 	for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 	{
-		if (vertex_arrays_info[index].size || register_vertex_info[index].size)
+		if (rsx::method_registers.vertex_arrays_info[index].size || rsx::method_registers.register_vertex_info[index].size)
 		{
 			max_vertex_attrib_size += 16;
 		}
@@ -184,7 +184,7 @@ u32 GLGSRender::set_vertex_buffer()
 
 	if (draw_command == rsx::draw_command::indexed)
 	{
-		rsx::index_array_type type = rsx::to_index_array_type(rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);
+		rsx::index_array_type type = rsx::method_registers.index_type();
 		u32 type_size = gsl::narrow<u32>(get_index_type_size(type));
 		for (const auto& first_count : first_count_commands)
 		{
@@ -212,7 +212,7 @@ u32 GLGSRender::set_vertex_buffer()
 
 		for (u32 i = 0; i < rsx::limits::vertex_count; ++i)
 		{
-			const auto &info = vertex_arrays_info[i];
+			const auto &info = rsx::method_registers.vertex_arrays_info[i];
 			if (!info.size) continue;
 
 			offsets[i] = stride;
@@ -224,7 +224,7 @@ u32 GLGSRender::set_vertex_buffer()
 
 		for (int index = 0; index < rsx::limits::vertex_count; ++index)
 		{
-			auto &vertex_info = vertex_arrays_info[index];
+			auto &vertex_info = rsx::method_registers.vertex_arrays_info[index];
 
 			int location;
 			if (!m_program->uniforms.has_location(rsx::vertex_program::input_attrib_names[index] + "_buffer", &location))
@@ -307,9 +307,9 @@ u32 GLGSRender::set_vertex_buffer()
 				continue;
 			}
 
-			if (vertex_arrays_info[index].size > 0)
+			if (rsx::method_registers.vertex_arrays_info[index].size > 0)
 			{
-				auto &vertex_info = vertex_arrays_info[index];
+				auto &vertex_info = rsx::method_registers.vertex_arrays_info[index];
 
 				// Fill vertex_array
 				u32 element_size = rsx::get_vertex_type_size_on_host(vertex_info.type, vertex_info.size);
@@ -322,8 +322,8 @@ u32 GLGSRender::set_vertex_buffer()
 				u32 buffer_offset = 0;
 
 				// Get source pointer
-				u32 base_offset = rsx::method_registers[NV4097_SET_VERTEX_DATA_BASE_OFFSET];
-				u32 offset = rsx::method_registers[NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + index];
+				u32 base_offset = rsx::method_registers.vertex_data_base_offset();
+				u32 offset = rsx::method_registers.vertex_arrays_info[index].offset();
 				u32 address = base_offset + rsx::get_address(offset & 0x7fffffff, offset >> 31);
 				const gsl::byte *src_ptr = gsl::narrow_cast<const gsl::byte*>(vm::base(address));
 
@@ -361,10 +361,10 @@ u32 GLGSRender::set_vertex_buffer()
 				//Link texture to uniform
 				m_program->uniforms.texture(location, index + texture_index_offset, texture);
 			}
-			else if (register_vertex_info[index].size > 0)
+			else if (rsx::method_registers.register_vertex_info[index].size > 0)
 			{
-				auto &vertex_data = register_vertex_data[index];
-				auto &vertex_info = register_vertex_info[index];
+				auto &vertex_data = rsx::method_registers.register_vertex_data[index];
+				auto &vertex_info = rsx::method_registers.register_vertex_info[index];
 
 				switch (vertex_info.type)
 				{

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -6,63 +6,68 @@
 
 namespace rsx
 {
+	texture::texture(u8 idx, std::array<u32, 0x10000 / 4> &r) : m_index(idx), registers(r)
+	{
+
+	}
+
 	void texture::init(u8 index)
 	{
 		m_index = index;
 
 		// Offset
-		method_registers[NV4097_SET_TEXTURE_OFFSET + (m_index * 8)] = 0;
+		registers[NV4097_SET_TEXTURE_OFFSET + (m_index * 8)] = 0;
 
 		// Format
-		method_registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] = 0;
+		registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] = 0;
 
 		// Address
-		method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] =
+		registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] =
 			((/*wraps*/1) | ((/*anisoBias*/0) << 4) | ((/*wrapt*/1) << 8) | ((/*unsignedRemap*/0) << 12) |
 			((/*wrapr*/3) << 16) | ((/*gamma*/0) << 20) | ((/*signedRemap*/0) << 24) | ((/*zfunc*/0) << 28));
 
 		// Control0
-		method_registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] =
+		registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] =
 			(((/*alphakill*/0) << 2) | (/*maxaniso*/0) << 4) | ((/*maxlod*/0xc00) << 7) | ((/*minlod*/0) << 19) | ((/*enable*/0) << 31);
 
 		// Control1
-		method_registers[NV4097_SET_TEXTURE_CONTROL1 + (m_index * 8)] = 0xE4;
+		registers[NV4097_SET_TEXTURE_CONTROL1 + (m_index * 8)] = 0xE4;
 
 		// Filter
-		method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] =
+		registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] =
 			((/*bias*/0) | ((/*conv*/1) << 13) | ((/*min*/5) << 16) | ((/*mag*/2) << 24)
 			| ((/*as*/0) << 28) | ((/*rs*/0) << 29) | ((/*gs*/0) << 30) | ((/*bs*/0) << 31));
 
 		// Image Rect
-		method_registers[NV4097_SET_TEXTURE_IMAGE_RECT + (m_index * 8)] = (/*height*/1) | ((/*width*/1) << 16);
+		registers[NV4097_SET_TEXTURE_IMAGE_RECT + (m_index * 8)] = (/*height*/1) | ((/*width*/1) << 16);
 
 		// Border Color
-		method_registers[NV4097_SET_TEXTURE_BORDER_COLOR + (m_index * 8)] = 0;
+		registers[NV4097_SET_TEXTURE_BORDER_COLOR + (m_index * 8)] = 0;
 	}
 
 	u32 texture::offset() const
 	{
-		return method_registers[NV4097_SET_TEXTURE_OFFSET + (m_index * 8)];
+		return registers[NV4097_SET_TEXTURE_OFFSET + (m_index * 8)];
 	}
 
 	u8 texture::location() const
 	{
-		return (method_registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] & 0x3) - 1;
+		return (registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] & 0x3) - 1;
 	}
 
 	bool texture::cubemap() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 2) & 0x1);
+		return ((registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 2) & 0x1);
 	}
 
 	u8 texture::border_type() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 3) & 0x1);
+		return ((registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 3) & 0x1);
 	}
 
 	rsx::texture_dimension texture::dimension() const
 	{
-		return rsx::to_texture_dimension((method_registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 4) & 0xf);
+		return rsx::to_texture_dimension((registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 4) & 0xf);
 	}
 
 	rsx::texture_dimension_extended texture::get_extended_texture_dimension() const
@@ -79,7 +84,7 @@ namespace rsx
 
 	u8 texture::format() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 8) & 0xff);
+		return ((registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 8) & 0xff);
 	}
 
 	bool texture::is_compressed_format() const
@@ -94,7 +99,7 @@ namespace rsx
 
 	u16 texture::mipmap() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 16) & 0xffff);
+		return ((registers[NV4097_SET_TEXTURE_FORMAT + (m_index * 8)] >> 16) & 0xffff);
 	}
 
 	u16 texture::get_exact_mipmap_count() const
@@ -112,137 +117,142 @@ namespace rsx
 
 	rsx::texture_wrap_mode texture::wrap_s() const
 	{
-		return rsx::to_texture_wrap_mode((method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)]) & 0xf);
+		return rsx::to_texture_wrap_mode((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)]) & 0xf);
 	}
 
 	rsx::texture_wrap_mode texture::wrap_t() const
 	{
-		return rsx::to_texture_wrap_mode((method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 8) & 0xf);
+		return rsx::to_texture_wrap_mode((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 8) & 0xf);
 	}
 
 	rsx::texture_wrap_mode texture::wrap_r() const
 	{
-		return rsx::to_texture_wrap_mode((method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 16) & 0xf);
+		return rsx::to_texture_wrap_mode((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 16) & 0xf);
 	}
 
 	u8 texture::unsigned_remap() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 12) & 0xf);
+		return ((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 12) & 0xf);
 	}
 
 	u8 texture::zfunc() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 28) & 0xf);
+		return ((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 28) & 0xf);
 	}
 
 	u8 texture::gamma() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 20) & 0xf);
+		return ((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 20) & 0xf);
 	}
 
 	u8 texture::aniso_bias() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 4) & 0xf);
+		return ((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 4) & 0xf);
 	}
 
 	u8 texture::signed_remap() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 24) & 0xf);
+		return ((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 24) & 0xf);
 	}
 
 	bool texture::enabled() const
 	{
-		return location() <= 1 && ((method_registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 31) & 0x1);
+		return location() <= 1 && ((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 31) & 0x1);
 	}
 
 	u16  texture::min_lod() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 19) & 0xfff);
+		return ((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 19) & 0xfff);
 	}
 
 	u16  texture::max_lod() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 7) & 0xfff);
+		return ((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 7) & 0xfff);
 	}
 
 	rsx::texture_max_anisotropy   texture::max_aniso() const
 	{
-		return rsx::to_texture_max_anisotropy((method_registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 4) & 0x7);
+		return rsx::to_texture_max_anisotropy((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 4) & 0x7);
 	}
 
 	bool texture::alpha_kill_enabled() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 2) & 0x1);
+		return ((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 2) & 0x1);
 	}
 
 	u32 texture::remap() const
 	{
-		return (method_registers[NV4097_SET_TEXTURE_CONTROL1 + (m_index * 8)]);
+		return (registers[NV4097_SET_TEXTURE_CONTROL1 + (m_index * 8)]);
 	}
 
 	float texture::bias() const
 	{
-		return float(f16((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff));
+		return float(f16((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff));
 	}
 
 	rsx::texture_minify_filter texture::min_filter() const
 	{
-		return rsx::to_texture_minify_filter((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 16) & 0x7);
+		return rsx::to_texture_minify_filter((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 16) & 0x7);
 	}
 
 	rsx::texture_magnify_filter texture::mag_filter() const
 	{
-		return rsx::to_texture_magnify_filter((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 24) & 0x7);
+		return rsx::to_texture_magnify_filter((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 24) & 0x7);
 	}
 
 	u8 texture::convolution_filter() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 13) & 0xf);
+		return ((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 13) & 0xf);
 	}
 
 	bool texture::a_signed() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 28) & 0x1);
+		return ((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 28) & 0x1);
 	}
 
 	bool texture::r_signed() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 29) & 0x1);
+		return ((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 29) & 0x1);
 	}
 
 	bool texture::g_signed() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 30) & 0x1);
+		return ((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 30) & 0x1);
 	}
 
 	bool texture::b_signed() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 31) & 0x1);
+		return ((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] >> 31) & 0x1);
 	}
 
 	u16 texture::width() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_IMAGE_RECT + (m_index * 8)] >> 16) & 0xffff);
+		return ((registers[NV4097_SET_TEXTURE_IMAGE_RECT + (m_index * 8)] >> 16) & 0xffff);
 	}
 
 	u16 texture::height() const
 	{
-		return ((method_registers[NV4097_SET_TEXTURE_IMAGE_RECT + (m_index * 8)]) & 0xffff);
+		return ((registers[NV4097_SET_TEXTURE_IMAGE_RECT + (m_index * 8)]) & 0xffff);
 	}
 
 	u32 texture::border_color() const
 	{
-		return method_registers[NV4097_SET_TEXTURE_BORDER_COLOR + (m_index * 8)];
+		return registers[NV4097_SET_TEXTURE_BORDER_COLOR + (m_index * 8)];
 	}
 
 	u16 texture::depth() const
 	{
-		return method_registers[NV4097_SET_TEXTURE_CONTROL3 + m_index] >> 20;
+		return registers[NV4097_SET_TEXTURE_CONTROL3 + m_index] >> 20;
 	}
 
 	u32 texture::pitch() const
 	{
-		return method_registers[NV4097_SET_TEXTURE_CONTROL3 + m_index] & 0xfffff;
+		return registers[NV4097_SET_TEXTURE_CONTROL3 + m_index] & 0xfffff;
+	}
+
+	vertex_texture::vertex_texture(u8 idx, std::array<u32, 0x10000 / 4> &r) : m_index(idx), registers(r)
+	{
+
 	}
 
 	void vertex_texture::init(u8 index)
@@ -250,58 +260,58 @@ namespace rsx
 		m_index = index;
 
 		// Offset
-		method_registers[NV4097_SET_VERTEX_TEXTURE_OFFSET + (m_index * 8)] = 0;
+		registers[NV4097_SET_VERTEX_TEXTURE_OFFSET + (m_index * 8)] = 0;
 
 		// Format
-		method_registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] = 0;
+		registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] = 0;
 
 		// Address
-		method_registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] =
+		registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] =
 			((/*wraps*/1) | ((/*anisoBias*/0) << 4) | ((/*wrapt*/1) << 8) | ((/*unsignedRemap*/0) << 12) |
 			((/*wrapr*/3) << 16) | ((/*gamma*/0) << 20) | ((/*signedRemap*/0) << 24) | ((/*zfunc*/0) << 28));
 
 		// Control0
-		method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] =
+		registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] =
 			(((/*alphakill*/0) << 2) | (/*maxaniso*/0) << 4) | ((/*maxlod*/0xc00) << 7) | ((/*minlod*/0) << 19) | ((/*enable*/0) << 31);
 
 		// Control1
-		//method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL1 + (m_index * 8)] = 0xE4;
+		//registers[NV4097_SET_VERTEX_TEXTURE_CONTROL1 + (m_index * 8)] = 0xE4;
 
 		// Filter
-		method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] =
+		registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] =
 			((/*bias*/0) | ((/*conv*/1) << 13) | ((/*min*/5) << 16) | ((/*mag*/2) << 24)
 			| ((/*as*/0) << 28) | ((/*rs*/0) << 29) | ((/*gs*/0) << 30) | ((/*bs*/0) << 31));
 
 		// Image Rect
-		method_registers[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT + (m_index * 8)] = (/*height*/1) | ((/*width*/1) << 16);
+		registers[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT + (m_index * 8)] = (/*height*/1) | ((/*width*/1) << 16);
 
 		// Border Color
-		method_registers[NV4097_SET_VERTEX_TEXTURE_BORDER_COLOR + (m_index * 8)] = 0;
+		registers[NV4097_SET_VERTEX_TEXTURE_BORDER_COLOR + (m_index * 8)] = 0;
 	}
 
 	u32 vertex_texture::offset() const
 	{
-		return method_registers[NV4097_SET_VERTEX_TEXTURE_OFFSET + (m_index * 8)];
+		return registers[NV4097_SET_VERTEX_TEXTURE_OFFSET + (m_index * 8)];
 	}
 
 	u8 vertex_texture::location() const
 	{
-		return (method_registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] & 0x3) - 1;
+		return (registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] & 0x3) - 1;
 	}
 
 	bool vertex_texture::cubemap() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 2) & 0x1);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 2) & 0x1);
 	}
 
 	u8 vertex_texture::border_type() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 3) & 0x1);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 3) & 0x1);
 	}
 
 	rsx::texture_dimension vertex_texture::dimension() const
 	{
-		return rsx::to_texture_dimension((method_registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 4) & 0xf);
+		return rsx::to_texture_dimension((registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 4) & 0xf);
 	}
 
 	rsx::texture_dimension_extended vertex_texture::get_extended_texture_dimension() const
@@ -318,12 +328,12 @@ namespace rsx
 
 	u8 vertex_texture::format() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 8) & 0xff);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 8) & 0xff);
 	}
 
 	u16 vertex_texture::mipmap() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 16) & 0xffff);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (m_index * 8)] >> 16) & 0xffff);
 	}
 
 	u16 vertex_texture::get_exact_mipmap_count() const
@@ -334,116 +344,116 @@ namespace rsx
 
 	u8 vertex_texture::unsigned_remap() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 12) & 0xf);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 12) & 0xf);
 	}
 
 	u8 vertex_texture::zfunc() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 28) & 0xf);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 28) & 0xf);
 	}
 
 	u8 vertex_texture::gamma() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 20) & 0xf);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 20) & 0xf);
 	}
 
 	u8 vertex_texture::aniso_bias() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 4) & 0xf);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 4) & 0xf);
 	}
 
 	u8 vertex_texture::signed_remap() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 24) & 0xf);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_ADDRESS + (m_index * 8)] >> 24) & 0xf);
 	}
 
 	bool vertex_texture::enabled() const
 	{
-		return location() <= 1 && ((method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 31) & 0x1);
+		return location() <= 1 && ((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 31) & 0x1);
 	}
 
 	u16 vertex_texture::min_lod() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 19) & 0xfff);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 19) & 0xfff);
 	}
 
 	u16 vertex_texture::max_lod() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 7) & 0xfff);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 7) & 0xfff);
 	}
 
 	rsx::texture_max_anisotropy vertex_texture::max_aniso() const
 	{
-		return rsx::to_texture_max_anisotropy((method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 4) & 0x7);
+		return rsx::to_texture_max_anisotropy((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 4) & 0x7);
 	}
 
 	bool vertex_texture::alpha_kill_enabled() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 2) & 0x1);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 2) & 0x1);
 	}
 
 	u16 vertex_texture::bias() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff);
 	}
 
 	rsx::texture_minify_filter vertex_texture::min_filter() const
 	{
-		return rsx::to_texture_minify_filter((method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 16) & 0x7);
+		return rsx::to_texture_minify_filter((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 16) & 0x7);
 	}
 
 	rsx::texture_magnify_filter vertex_texture::mag_filter() const
 	{
-		return rsx::to_texture_magnify_filter((method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 24) & 0x7);
+		return rsx::to_texture_magnify_filter((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 24) & 0x7);
 	}
 
 	u8 vertex_texture::convolution_filter() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 13) & 0xf);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 13) & 0xf);
 	}
 
 	bool vertex_texture::a_signed() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 28) & 0x1);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 28) & 0x1);
 	}
 
 	bool vertex_texture::r_signed() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 29) & 0x1);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 29) & 0x1);
 	}
 
 	bool vertex_texture::g_signed() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 30) & 0x1);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 30) & 0x1);
 	}
 
 	bool vertex_texture::b_signed() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 31) & 0x1);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)] >> 31) & 0x1);
 	}
 
 	u16 vertex_texture::width() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT + (m_index * 8)] >> 16) & 0xffff);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT + (m_index * 8)] >> 16) & 0xffff);
 	}
 
 	u16 vertex_texture::height() const
 	{
-		return ((method_registers[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT + (m_index * 8)]) & 0xffff);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT + (m_index * 8)]) & 0xffff);
 	}
 
 	u32 vertex_texture::border_color() const
 	{
-		return method_registers[NV4097_SET_VERTEX_TEXTURE_BORDER_COLOR + (m_index * 8)];
+		return registers[NV4097_SET_VERTEX_TEXTURE_BORDER_COLOR + (m_index * 8)];
 	}
 
 	u16 vertex_texture::depth() const
 	{
-		return method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL3 + (m_index * 8)] >> 20;
+		return registers[NV4097_SET_VERTEX_TEXTURE_CONTROL3 + (m_index * 8)] >> 20;
 	}
 
 	u32 vertex_texture::pitch() const
 	{
-		return method_registers[NV4097_SET_VERTEX_TEXTURE_CONTROL3 + (m_index * 8)] & 0xfffff;
+		return registers[NV4097_SET_VERTEX_TEXTURE_CONTROL3 + (m_index * 8)] & 0xfffff;
 	}
 }

--- a/rpcs3/Emu/RSX/RSXTexture.h
+++ b/rpcs3/Emu/RSX/RSXTexture.h
@@ -18,8 +18,12 @@ namespace rsx
 	{
 	protected:
 		u8 m_index;
+		std::array<u32, 0x10000 / 4> &registers;
 
 	public:
+		texture(u8 idx, std::array<u32, 0x10000 / 4> &r);
+		texture() = delete;
+
 		//initialize texture registers with default values
 		void init(u8 index);
 
@@ -90,8 +94,12 @@ namespace rsx
 	{
 	protected:
 		u8 m_index;
+		std::array<u32, 0x10000 / 4> &registers;
 
 	public:
+		vertex_texture(u8 idx, std::array<u32, 0x10000 / 4> &r);
+		vertex_texture() = delete;
+
 		//initialize texture registers with default values
 		void init(u8 index);
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -303,15 +303,13 @@ namespace rsx
 	{
 		frame_capture_data::draw_state draw_state = {};
 
-		int clip_w = rsx::method_registers[NV4097_SET_SURFACE_CLIP_HORIZONTAL] >> 16;
-		int clip_h = rsx::method_registers[NV4097_SET_SURFACE_CLIP_VERTICAL] >> 16;
-		rsx::surface_info surface = {};
-		surface.unpack(rsx::method_registers[NV4097_SET_SURFACE_FORMAT]);
+		int clip_w = rsx::method_registers.surface_clip_width();
+		int clip_h = rsx::method_registers.surface_clip_height();
 		draw_state.width = clip_w;
 		draw_state.height = clip_h;
-		draw_state.color_format = surface.color_format;
+		draw_state.color_format = rsx::method_registers.surface_color();
 		draw_state.color_buffer = std::move(copy_render_targets_to_memory());
-		draw_state.depth_format = surface.depth_format;
+		draw_state.depth_format = rsx::method_registers.surface_depth_fmt();
 		draw_state.depth_stencil = std::move(copy_depth_stencil_buffer_to_memory());
 
 		if (draw_command == rsx::draw_command::indexed)
@@ -321,7 +319,7 @@ namespace rsx
 			{
 				draw_state.vertex_count += range.second;
 			}
-			draw_state.index_type = rsx::to_index_array_type(rsx::method_registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);
+			draw_state.index_type = rsx::method_registers.index_type();
 
 			if (draw_state.index_type == rsx::index_array_type::u16)
 			{
@@ -346,17 +344,17 @@ namespace rsx
 		inline_vertex_array.clear();
 		first_count_commands.clear();
 		draw_command = rsx::draw_command::none;
-		draw_mode = to_primitive_type(method_registers[NV4097_SET_BEGIN_END]);
+		draw_mode = method_registers.primitive_mode();
 	}
 
 	void thread::end()
 	{
-		transform_constants.clear();
+		rsx::method_registers.transform_constants.clear();
 
 		for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 		{
-			register_vertex_info[index].size = 0;
-			register_vertex_data[index].clear();
+			rsx::method_registers.register_vertex_info[index].size = 0;
+			rsx::method_registers.register_vertex_data[index].clear();
 		}
 
 		if (capture_current_frame)
@@ -494,21 +492,21 @@ namespace rsx
 
 	void thread::fill_scale_offset_data(void *buffer, bool is_d3d) const
 	{
-		int clip_w = rsx::method_registers[NV4097_SET_SURFACE_CLIP_HORIZONTAL] >> 16;
-		int clip_h = rsx::method_registers[NV4097_SET_SURFACE_CLIP_VERTICAL] >> 16;
+		int clip_w = rsx::method_registers.surface_clip_width();
+		int clip_h = rsx::method_registers.surface_clip_height();
 
-		float scale_x = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE] / (clip_w / 2.f);
-		float offset_x = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET] - (clip_w / 2.f);
+		float scale_x = rsx::method_registers.viewport_scale_x() / (clip_w / 2.f);
+		float offset_x = rsx::method_registers.viewport_offset_x() - (clip_w / 2.f);
 		offset_x /= clip_w / 2.f;
 
-		float scale_y = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE + 1] / (clip_h / 2.f);
-		float offset_y = ((float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET + 1] - (clip_h / 2.f));
+		float scale_y = rsx::method_registers.viewport_scale_y() / (clip_h / 2.f);
+		float offset_y = (rsx::method_registers.viewport_offset_y() - (clip_h / 2.f));
 		offset_y /= clip_h / 2.f;
 		if (is_d3d) scale_y *= -1;
 		if (is_d3d) offset_y *= -1;
 
-		float scale_z = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE + 2];
-		float offset_z = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET + 2];
+		float scale_z = rsx::method_registers.viewport_scale_z();
+		float offset_z = rsx::method_registers.viewport_offset_z();
 		if (!is_d3d) offset_z -= .5;
 
 		float one = 1.f;
@@ -525,7 +523,7 @@ namespace rsx
 	*/
 	void thread::fill_vertex_program_constants_data(void *buffer)
 	{
-		for (const auto &entry : transform_constants)
+		for (const auto &entry : rsx::method_registers.transform_constants)
 			local_transform_constants[entry.first] = entry.second;
 		for (const auto &entry : local_transform_constants)
 			stream_vector_from_memory((char*)buffer + entry.first * 4 * sizeof(float), (void*)entry.second.rgba);
@@ -541,7 +539,7 @@ namespace rsx
 		{
 			for (int index = 0; index < rsx::limits::vertex_count; ++index)
 			{
-				const auto &info = vertex_arrays_info[index];
+				const auto &info = rsx::method_registers.vertex_arrays_info[index];
 
 				if (!info.size) // disabled
 					continue;
@@ -642,17 +640,17 @@ namespace rsx
 	{
 		u32 offset_color[] =
 		{
-			rsx::method_registers[NV4097_SET_SURFACE_COLOR_AOFFSET],
-			rsx::method_registers[NV4097_SET_SURFACE_COLOR_BOFFSET],
-			rsx::method_registers[NV4097_SET_SURFACE_COLOR_COFFSET],
-			rsx::method_registers[NV4097_SET_SURFACE_COLOR_DOFFSET]
+			rsx::method_registers.surface_a_offset(),
+			rsx::method_registers.surface_b_offset(),
+			rsx::method_registers.surface_c_offset(),
+			rsx::method_registers.surface_d_offset(),
 		};
 		u32 context_dma_color[] =
 		{
-			rsx::method_registers[NV4097_SET_CONTEXT_DMA_COLOR_A],
-			rsx::method_registers[NV4097_SET_CONTEXT_DMA_COLOR_B],
-			rsx::method_registers[NV4097_SET_CONTEXT_DMA_COLOR_C],
-			rsx::method_registers[NV4097_SET_CONTEXT_DMA_COLOR_D]
+			rsx::method_registers.surface_a_dma(),
+			rsx::method_registers.surface_b_dma(),
+			rsx::method_registers.surface_c_dma(),
+			rsx::method_registers.surface_d_dma(),
 		};
 		return
 		{
@@ -665,32 +663,32 @@ namespace rsx
 
 	u32 thread::get_zeta_surface_address() const
 	{
-		u32 m_context_dma_z = rsx::method_registers[NV4097_SET_CONTEXT_DMA_ZETA];
-		u32 offset_zeta = rsx::method_registers[NV4097_SET_SURFACE_ZETA_OFFSET];
+		u32 m_context_dma_z = rsx::method_registers.surface_z_dma();
+		u32 offset_zeta = rsx::method_registers.surface_z_offset();
 		return rsx::get_address(offset_zeta, m_context_dma_z);
 	}
 
 	RSXVertexProgram thread::get_current_vertex_program() const
 	{
 		RSXVertexProgram result = {};
-		u32 transform_program_start = rsx::method_registers[NV4097_SET_TRANSFORM_PROGRAM_START];
+		u32 transform_program_start = rsx::method_registers.transform_program_start();
 		result.data.reserve((512 - transform_program_start) * 4);
 
 		for (int i = transform_program_start; i < 512; ++i)
 		{
 			result.data.resize((i - transform_program_start) * 4 + 4);
-			memcpy(result.data.data() + (i - transform_program_start) * 4, transform_program + i * 4, 4 * sizeof(u32));
+			memcpy(result.data.data() + (i - transform_program_start) * 4, rsx::method_registers.transform_program.data() + i * 4, 4 * sizeof(u32));
 
 			D3 d3;
-			d3.HEX = transform_program[i * 4 + 3];
+			d3.HEX = rsx::method_registers.transform_program[i * 4 + 3];
 
 			if (d3.end)
 				break;
 		}
-		result.output_mask = rsx::method_registers[NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK];
+		result.output_mask = rsx::method_registers.vertex_attrib_output_mask();
 
-		u32 input_mask = rsx::method_registers[NV4097_SET_VERTEX_ATTRIB_INPUT_MASK];
-		u32 modulo_mask = rsx::method_registers[NV4097_SET_FREQUENCY_DIVIDER_OPERATION];
+		u32 input_mask = rsx::method_registers.vertex_attrib_input_mask();
+		u32 modulo_mask = rsx::method_registers.frequency_divider_operation_mask();
 		result.rsx_vertex_inputs.clear();
 		for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 		{
@@ -698,29 +696,29 @@ namespace rsx
 			if (!enabled)
 				continue;
 
-			if (vertex_arrays_info[index].size > 0)
+			if (rsx::method_registers.vertex_arrays_info[index].size > 0)
 			{
 				result.rsx_vertex_inputs.push_back(
 				{
 					index,
-					vertex_arrays_info[index].size,
-					vertex_arrays_info[index].frequency,
+					rsx::method_registers.vertex_arrays_info[index].size,
+					rsx::method_registers.vertex_arrays_info[index].frequency,
 					!!((modulo_mask >> index) & 0x1),
 					true,
-					is_int_type(vertex_arrays_info[index].type)
+					is_int_type(rsx::method_registers.vertex_arrays_info[index].type)
 				}
 				);
 			}
-			else if (register_vertex_info[index].size > 0)
+			else if (rsx::method_registers.register_vertex_info[index].size > 0)
 			{
 				result.rsx_vertex_inputs.push_back(
 				{
 					index,
-					register_vertex_info[index].size,
-					register_vertex_info[index].frequency,
+					rsx::method_registers.register_vertex_info[index].size,
+					rsx::method_registers.register_vertex_info[index].frequency,
 					!!((modulo_mask >> index) & 0x1),
 					false,
-					is_int_type(vertex_arrays_info[index].type)
+					is_int_type(rsx::method_registers.vertex_arrays_info[index].type)
 				}
 				);
 			}
@@ -732,29 +730,28 @@ namespace rsx
 	RSXFragmentProgram thread::get_current_fragment_program() const
 	{
 		RSXFragmentProgram result = {};
-		u32 shader_program = rsx::method_registers[NV4097_SET_SHADER_PROGRAM];
+		u32 shader_program = rsx::method_registers.shader_program_address();
 		result.offset = shader_program & ~0x3;
 		result.addr = vm::base(rsx::get_address(result.offset, (shader_program & 0x3) - 1));
-		result.ctrl = rsx::method_registers[NV4097_SET_SHADER_CONTROL];
+		result.ctrl = rsx::method_registers.shader_control();
 		result.unnormalized_coords = 0;
-		result.front_back_color_enabled = !rsx::method_registers[NV4097_SET_TWO_SIDE_LIGHT_EN];
-		result.back_color_diffuse_output = !!(rsx::method_registers[NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK] & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE);
-		result.back_color_specular_output = !!(rsx::method_registers[NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK] & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR);
-		result.alpha_func = to_comparaison_function(rsx::method_registers[NV4097_SET_ALPHA_FUNC]);
-		result.fog_equation = rsx::to_fog_mode(rsx::method_registers[NV4097_SET_FOG_MODE]);
-		u32 shader_window = rsx::method_registers[NV4097_SET_SHADER_WINDOW];
-		result.origin_mode = rsx::to_window_origin((shader_window >> 12) & 0xF);
-		result.pixel_center_mode = rsx::to_window_pixel_center((shader_window >> 16) & 0xF);
-		result.height = shader_window & 0xFFF;
+		result.front_back_color_enabled = !rsx::method_registers.two_side_light_en();
+		result.back_color_diffuse_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE);
+		result.back_color_specular_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR);
+		result.alpha_func = rsx::method_registers.alpha_func();
+		result.fog_equation = rsx::method_registers.fog_equation();
+		result.origin_mode = rsx::method_registers.shader_window_origin();
+		result.pixel_center_mode = rsx::method_registers.shader_window_pixel();
+		result.height = rsx::method_registers.shader_window_height();
 
 		std::array<texture_dimension_extended, 16> texture_dimensions;
 		for (u32 i = 0; i < rsx::limits::textures_count; ++i)
 		{
-			if (!textures[i].enabled())
+			if (!rsx::method_registers.fragment_textures[i].enabled())
 				texture_dimensions[i] = texture_dimension_extended::texture_dimension_2d;
 			else
-				texture_dimensions[i] = textures[i].get_extended_texture_dimension();
-			if (textures[i].enabled() && (textures[i].format() & CELL_GCM_TEXTURE_UN))
+				texture_dimensions[i] = rsx::method_registers.fragment_textures[i].get_extended_texture_dimension();
+			if (rsx::method_registers.fragment_textures[i].enabled() && (rsx::method_registers.fragment_textures[i].format() & CELL_GCM_TEXTURE_UN))
 				result.unnormalized_coords |= (1 << i);
 		}
 		result.set_texture_dimension(texture_dimensions);
@@ -766,29 +763,29 @@ namespace rsx
 	{
 		raw_program result{};
 
-		u32 fp_info = rsx::method_registers[NV4097_SET_SHADER_PROGRAM];
+		u32 fp_info = rsx::method_registers.shader_program_address();
 
-		result.state.input_attributes = rsx::method_registers[NV4097_SET_VERTEX_ATTRIB_INPUT_MASK];
-		result.state.output_attributes = rsx::method_registers[NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK];
-		result.state.ctrl = rsx::method_registers[NV4097_SET_SHADER_CONTROL];
-		result.state.divider_op = rsx::method_registers[NV4097_SET_FREQUENCY_DIVIDER_OPERATION];
-		result.state.alpha_func = rsx::method_registers[NV4097_SET_ALPHA_FUNC];
-		result.state.fog_mode = (u32)rsx::to_fog_mode(rsx::method_registers[NV4097_SET_FOG_MODE]);
+		result.state.input_attributes = rsx::method_registers.vertex_attrib_input_mask();
+		result.state.output_attributes = rsx::method_registers.vertex_attrib_output_mask();
+		result.state.ctrl = rsx::method_registers.shader_control();
+		result.state.divider_op = rsx::method_registers.frequency_divider_operation_mask();
+		result.state.alpha_func = (u32)rsx::method_registers.alpha_func();
+		result.state.fog_mode = (u32)rsx::method_registers.fog_equation();
 		result.state.is_int = 0;
 
 		for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 		{
 			bool is_int = false;
 
-			if (vertex_arrays_info[index].size > 0)
+			if (rsx::method_registers.vertex_arrays_info[index].size > 0)
 			{
-				is_int = is_int_type(vertex_arrays_info[index].type);
-				result.state.frequency[index] = vertex_arrays_info[index].frequency;
+				is_int = is_int_type(rsx::method_registers.vertex_arrays_info[index].type);
+				result.state.frequency[index] = rsx::method_registers.vertex_arrays_info[index].frequency;
 			}
-			else if (register_vertex_info[index].size > 0)
+			else if (rsx::method_registers.register_vertex_info[index].size > 0)
 			{
-				is_int = is_int_type(register_vertex_info[index].type);
-				result.state.frequency[index] = register_vertex_info[index].frequency;
+				is_int = is_int_type(rsx::method_registers.register_vertex_info[index].type);
+				result.state.frequency[index] = rsx::method_registers.register_vertex_info[index].frequency;
 			}
 			else
 			{
@@ -803,7 +800,7 @@ namespace rsx
 
 		for (u8 index = 0; index < rsx::limits::textures_count; ++index)
 		{
-			if (!textures[index].enabled())
+			if (!rsx::method_registers.fragment_textures[index].enabled())
 			{
 				result.state.textures_alpha_kill[index] = 0;
 				result.state.textures_zfunc[index] = 0;
@@ -811,10 +808,10 @@ namespace rsx
 				continue;
 			}
 
-			result.state.textures_alpha_kill[index] = textures[index].alpha_kill_enabled() ? 1 : 0;
-			result.state.textures_zfunc[index] = textures[index].zfunc();
+			result.state.textures_alpha_kill[index] = rsx::method_registers.fragment_textures[index].alpha_kill_enabled() ? 1 : 0;
+			result.state.textures_zfunc[index] = rsx::method_registers.fragment_textures[index].zfunc();
 
-			switch (textures[index].get_extended_texture_dimension())
+			switch (rsx::method_registers.fragment_textures[index].get_extended_texture_dimension())
 			{
 			case rsx::texture_dimension_extended::texture_dimension_1d: result.state.textures[index] = rsx::texture_target::_1; break;
 			case rsx::texture_dimension_extended::texture_dimension_2d: result.state.textures[index] = rsx::texture_target::_2; break;
@@ -829,13 +826,13 @@ namespace rsx
 
 		for (u8 index = 0; index < rsx::limits::vertex_textures_count; ++index)
 		{
-			if (!textures[index].enabled())
+			if (!rsx::method_registers.fragment_textures[index].enabled())
 			{
 				result.state.vertex_textures[index] = rsx::texture_target::none;
 				continue;
 			}
 
-			switch (textures[index].get_extended_texture_dimension())
+			switch (rsx::method_registers.fragment_textures[index].get_extended_texture_dimension())
 			{
 			case rsx::texture_dimension_extended::texture_dimension_1d: result.state.vertex_textures[index] = rsx::texture_target::_1; break;
 			case rsx::texture_dimension_extended::texture_dimension_2d: result.state.vertex_textures[index] = rsx::texture_target::_2; break;
@@ -848,8 +845,8 @@ namespace rsx
 			}
 		}
 
-		result.vertex_shader.ucode_ptr = transform_program;
-		result.vertex_shader.offset = rsx::method_registers[NV4097_SET_TRANSFORM_PROGRAM_START];
+		result.vertex_shader.ucode_ptr = rsx::method_registers.transform_program.data();
+		result.vertex_shader.offset = rsx::method_registers.transform_program_start();
 
 		result.fragment_shader.ucode_ptr = vm::base(rsx::get_address(fp_info & ~0x3, (fp_info & 0x3) - 1));
 		result.fragment_shader.offset = 0;
@@ -859,90 +856,7 @@ namespace rsx
 
 	void thread::reset()
 	{
-		//setup method registers
-		std::memset(method_registers, 0, sizeof(method_registers));
-
-		method_registers[NV4097_SET_COLOR_MASK] = CELL_GCM_COLOR_MASK_R | CELL_GCM_COLOR_MASK_G | CELL_GCM_COLOR_MASK_B | CELL_GCM_COLOR_MASK_A;
-		method_registers[NV4097_SET_SCISSOR_HORIZONTAL] = (4096 << 16) | 0;
-		method_registers[NV4097_SET_SCISSOR_VERTICAL] = (4096 << 16) | 0;
-
-		method_registers[NV4097_SET_ALPHA_FUNC] = CELL_GCM_ALWAYS;
-		method_registers[NV4097_SET_ALPHA_REF] = 0;
-
-		method_registers[NV4097_SET_BLEND_FUNC_SFACTOR] = (CELL_GCM_ONE << 16) | CELL_GCM_ONE;
-		method_registers[NV4097_SET_BLEND_FUNC_DFACTOR] = (CELL_GCM_ZERO << 16) | CELL_GCM_ZERO;
-		method_registers[NV4097_SET_BLEND_COLOR] = 0;
-		method_registers[NV4097_SET_BLEND_COLOR2] = 0;
-		method_registers[NV4097_SET_BLEND_EQUATION] = (CELL_GCM_FUNC_ADD << 16) | CELL_GCM_FUNC_ADD;
-
-		method_registers[NV4097_SET_STENCIL_MASK] = 0xff;
-		method_registers[NV4097_SET_STENCIL_FUNC] = CELL_GCM_ALWAYS;
-		method_registers[NV4097_SET_STENCIL_FUNC_REF] = 0x00;
-		method_registers[NV4097_SET_STENCIL_FUNC_MASK] = 0xff;
-		method_registers[NV4097_SET_STENCIL_OP_FAIL] = CELL_GCM_KEEP;
-		method_registers[NV4097_SET_STENCIL_OP_ZFAIL] = CELL_GCM_KEEP;
-		method_registers[NV4097_SET_STENCIL_OP_ZPASS] = CELL_GCM_KEEP;
-
-		method_registers[NV4097_SET_BACK_STENCIL_MASK] = 0xff;
-		method_registers[NV4097_SET_BACK_STENCIL_FUNC] = CELL_GCM_ALWAYS;
-		method_registers[NV4097_SET_BACK_STENCIL_FUNC_REF] = 0x00;
-		method_registers[NV4097_SET_BACK_STENCIL_FUNC_MASK] = 0xff;
-		method_registers[NV4097_SET_BACK_STENCIL_OP_FAIL] = CELL_GCM_KEEP;
-		method_registers[NV4097_SET_BACK_STENCIL_OP_ZFAIL] = CELL_GCM_KEEP;
-		method_registers[NV4097_SET_BACK_STENCIL_OP_ZPASS] = CELL_GCM_KEEP;
-
-		method_registers[NV4097_SET_SHADE_MODE] = CELL_GCM_SMOOTH;
-
-		method_registers[NV4097_SET_LOGIC_OP] = CELL_GCM_COPY;
-
-		(f32&)method_registers[NV4097_SET_DEPTH_BOUNDS_MIN] = 0.f;
-		(f32&)method_registers[NV4097_SET_DEPTH_BOUNDS_MAX] = 1.f;
-
-		(f32&)method_registers[NV4097_SET_CLIP_MIN] = 0.f;
-		(f32&)method_registers[NV4097_SET_CLIP_MAX] = 1.f;
-
-		method_registers[NV4097_SET_LINE_WIDTH] = 1 << 3;
-
-		// These defaults were found using After Burner Climax (which never set fog mode despite using fog input)
-		method_registers[NV4097_SET_FOG_MODE] = 0x2601; // rsx::fog_mode::linear;
-		(f32&)method_registers[NV4097_SET_FOG_PARAMS] = 1.;
-		(f32&)method_registers[NV4097_SET_FOG_PARAMS + 1] = 1.;
-
-		method_registers[NV4097_SET_DEPTH_FUNC] = CELL_GCM_LESS;
-		method_registers[NV4097_SET_DEPTH_MASK] = CELL_GCM_TRUE;
-		(f32&)method_registers[NV4097_SET_POLYGON_OFFSET_SCALE_FACTOR] = 0.f;
-		(f32&)method_registers[NV4097_SET_POLYGON_OFFSET_BIAS] = 0.f;
-		method_registers[NV4097_SET_FRONT_POLYGON_MODE] = CELL_GCM_POLYGON_MODE_FILL;
-		method_registers[NV4097_SET_BACK_POLYGON_MODE] = CELL_GCM_POLYGON_MODE_FILL;
-		method_registers[NV4097_SET_CULL_FACE] = CELL_GCM_BACK;
-		method_registers[NV4097_SET_FRONT_FACE] = CELL_GCM_CCW;
-		method_registers[NV4097_SET_RESTART_INDEX] = -1;
-
-		method_registers[NV4097_SET_CLEAR_RECT_HORIZONTAL] = (4096 << 16) | 0;
-		method_registers[NV4097_SET_CLEAR_RECT_VERTICAL] = (4096 << 16) | 0;
-
-		method_registers[NV4097_SET_ZSTENCIL_CLEAR_VALUE] = 0xffffffff;
-
-		method_registers[NV4097_SET_CONTEXT_DMA_REPORT] = CELL_GCM_CONTEXT_DMA_TO_MEMORY_GET_REPORT;
-		rsx::method_registers[NV4097_SET_TWO_SIDE_LIGHT_EN] = true;
-		rsx::method_registers[NV4097_SET_ALPHA_FUNC] = CELL_GCM_ALWAYS;
-
-		// Reset vertex attrib array
-		for (int i = 0; i < limits::vertex_count; i++)
-		{
-			vertex_arrays_info[i].size = 0;
-		}
-
-		// Construct Textures
-		for (int i = 0; i < limits::textures_count; i++)
-		{
-			textures[i].init(i);
-		}
-
-		for (int i = 0; i < limits::vertex_textures_count; i++)
-		{
-			vertex_textures[i].init(i);
-		}
+		rsx::method_registers.reset();
 	}
 
 	void thread::init(const u32 ioAddress, const u32 ioSize, const u32 ctrlAddress, const u32 localAddress)

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -179,22 +179,6 @@ namespace rsx
 		}
 	};
 
-	struct data_array_format_info
-	{
-		u16 frequency = 0;
-		u8 stride = 0;
-		u8 size = 0;
-		vertex_base_type type = vertex_base_type::f;
-
-		void unpack_array(u32 data_array_format)
-		{
-			frequency = data_array_format >> 16;
-			stride = (data_array_format >> 8) & 0xff;
-			size = (data_array_format >> 4) & 0xf;
-			type = to_vertex_base_type(data_array_format & 0xf);
-		}
-	};
-
 	enum class draw_command
 	{
 		none,
@@ -219,32 +203,7 @@ namespace rsx
 		GcmTileInfo tiles[limits::tiles_count];
 		GcmZcullInfo zculls[limits::zculls_count];
 
-		rsx::texture textures[limits::textures_count];
-		rsx::vertex_texture vertex_textures[limits::vertex_textures_count];
-
-
-		/**
-		 * RSX can sources vertex attributes from 2 places:
-		 * - Immediate values passed by NV4097_SET_VERTEX_DATA*_M + ARRAY_ID write.
-		 * For a given ARRAY_ID the last command of this type defines the actual type of the immediate value.
-		 * Since there can be only a single value per ARRAY_ID passed this way, all vertex in the draw call
-		 * shares it.
-		 * - Vertex array values passed by offset/stride/size/format description.
-		 *
-		 * A given ARRAY_ID can have both an immediate value and a vertex array enabled at the same time
-		 * (See After Burner Climax intro cutscene). In such case the vertex array has precedence over the
-		 * immediate value. As soon as the vertex array is disabled (size set to 0) the immediate value
-		 * must be used if the vertex attrib mask request it.
-		 *
-		 * Note that behavior when both vertex array and immediate value system are disabled but vertex attrib mask
-		 * request inputs is unknow.
-		 */
-		data_array_format_info register_vertex_info[limits::vertex_count];
-		std::vector<u8> register_vertex_data[limits::vertex_count];
-		data_array_format_info vertex_arrays_info[limits::vertex_count];
 		u32 vertex_draw_count = 0;
-
-		std::unordered_map<u32, color4_base<f32>> transform_constants;
 
 		/**
 		* Stores the first and count argument from draw/draw indexed parameters between begin/end clauses.
@@ -253,8 +212,6 @@ namespace rsx
 
 		// Constant stored for whole frame
 		std::unordered_map<u32, color4f> local_transform_constants;
-
-		u32 transform_program[512 * 4] = {};
 
 		bool capture_current_frame = false;
 		void capture_frame(const std::string &name);

--- a/rpcs3/Emu/RSX/VK/VKFormats.h
+++ b/rpcs3/Emu/RSX/VK/VKFormats.h
@@ -12,9 +12,9 @@ namespace vk
 
 	gpu_formats_support get_optimal_tiling_supported_formats(VkPhysicalDevice physical_device);
 	VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support, rsx::surface_depth_format format);
-	VkStencilOp get_stencil_op(u32 op);
-	VkLogicOp get_logic_op(u32 op);
-	VkFrontFace get_front_face_ccw(u32 ffv);
+	VkStencilOp get_stencil_op(rsx::stencil_op op);
+	VkLogicOp get_logic_op(rsx::logic_op op);
+	VkFrontFace get_front_face_ccw(rsx::front_face ffv);
 	VkCullModeFlags get_cull_face(u32 cfv);
 	VkBorderColor get_border_color(u8 color);
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -31,26 +31,26 @@ namespace
 
 namespace vk
 {
-	VkCompareOp compare_op(u32 gl_name)
+	VkCompareOp compare_op(rsx::comparaison_function op)
 	{
-		switch (gl_name)
+		switch (op)
 		{
-		case CELL_GCM_NEVER:
+		case rsx::comparaison_function::never:
 			return VK_COMPARE_OP_NEVER;
-		case CELL_GCM_GREATER:
+		case rsx::comparaison_function::greater:
 			return VK_COMPARE_OP_GREATER;
-		case CELL_GCM_LESS:
+		case rsx::comparaison_function::less:
 			return VK_COMPARE_OP_LESS;
-		case CELL_GCM_LEQUAL:
+		case rsx::comparaison_function::less_or_equal:
 			return VK_COMPARE_OP_LESS_OR_EQUAL;
-		case CELL_GCM_GEQUAL:
+		case rsx::comparaison_function::greater_or_equal:
 			return VK_COMPARE_OP_GREATER_OR_EQUAL;
-		case CELL_GCM_EQUAL:
+		case rsx::comparaison_function::equal:
 			return VK_COMPARE_OP_EQUAL;
-		case CELL_GCM_ALWAYS:
+		case rsx::comparaison_function::always:
 			return VK_COMPARE_OP_ALWAYS;
 		default:
-			throw EXCEPTION("Unsupported compare op: 0x%X", gl_name);
+			throw EXCEPTION("Unsupported compare op: 0x%X", op);
 		}
 	}
 
@@ -181,93 +181,94 @@ namespace vk
 		}
 	}
 
-	VkLogicOp get_logic_op(u32 op)
+	VkLogicOp get_logic_op(rsx::logic_op op)
 	{
 		switch (op)
 		{
-		case CELL_GCM_CLEAR: return VK_LOGIC_OP_CLEAR;
-		case CELL_GCM_AND: return VK_LOGIC_OP_AND;
-		case CELL_GCM_AND_REVERSE: return VK_LOGIC_OP_AND_REVERSE;
-		case CELL_GCM_COPY: return VK_LOGIC_OP_COPY;
-		case CELL_GCM_AND_INVERTED: return VK_LOGIC_OP_AND_INVERTED;
-		case CELL_GCM_NOOP: return VK_LOGIC_OP_NO_OP;
-		case CELL_GCM_XOR: return VK_LOGIC_OP_XOR;
-		case CELL_GCM_OR: return VK_LOGIC_OP_OR;
-		case CELL_GCM_NOR: return VK_LOGIC_OP_NOR;
-		case CELL_GCM_EQUIV: return VK_LOGIC_OP_EQUIVALENT;
-		case CELL_GCM_INVERT: return VK_LOGIC_OP_INVERT;
-		case CELL_GCM_OR_REVERSE: return VK_LOGIC_OP_OR_REVERSE;
-		case CELL_GCM_COPY_INVERTED: return VK_LOGIC_OP_COPY_INVERTED;
-		case CELL_GCM_OR_INVERTED: return VK_LOGIC_OP_OR_INVERTED;
-		case CELL_GCM_NAND: return VK_LOGIC_OP_NAND;
+		case rsx::logic_op::logic_clear: return VK_LOGIC_OP_CLEAR;
+		case rsx::logic_op::logic_and: return VK_LOGIC_OP_AND;
+		case rsx::logic_op::logic_and_reverse: return VK_LOGIC_OP_AND_REVERSE;
+		case rsx::logic_op::logic_copy: return VK_LOGIC_OP_COPY;
+		case rsx::logic_op::logic_and_inverted: return VK_LOGIC_OP_AND_INVERTED;
+		case rsx::logic_op::logic_noop: return VK_LOGIC_OP_NO_OP;
+		case rsx::logic_op::logic_xor: return VK_LOGIC_OP_XOR;
+		case rsx::logic_op::logic_or : return VK_LOGIC_OP_OR;
+		case rsx::logic_op::logic_nor: return VK_LOGIC_OP_NOR;
+		case rsx::logic_op::logic_equiv: return VK_LOGIC_OP_EQUIVALENT;
+		case rsx::logic_op::logic_invert: return VK_LOGIC_OP_INVERT;
+		case rsx::logic_op::logic_or_reverse: return VK_LOGIC_OP_OR_REVERSE;
+		case rsx::logic_op::logic_copy_inverted: return VK_LOGIC_OP_COPY_INVERTED;
+		case rsx::logic_op::logic_or_inverted: return VK_LOGIC_OP_OR_INVERTED;
+		case rsx::logic_op::logic_nand: return VK_LOGIC_OP_NAND;
 		default:
 			throw EXCEPTION("Unknown logic op 0x%X", op);
 		}
 	}
 
-	VkBlendFactor get_blend_factor(u16 factor)
+	VkBlendFactor get_blend_factor(rsx::blend_factor factor)
 	{
 		switch (factor)
 		{
-		case CELL_GCM_ONE: return VK_BLEND_FACTOR_ONE;
-		case CELL_GCM_ZERO: return VK_BLEND_FACTOR_ZERO;
-		case CELL_GCM_SRC_ALPHA: return VK_BLEND_FACTOR_SRC_ALPHA;
-		case CELL_GCM_DST_ALPHA: return VK_BLEND_FACTOR_DST_ALPHA;
-		case CELL_GCM_SRC_COLOR: return VK_BLEND_FACTOR_SRC_COLOR;
-		case CELL_GCM_DST_COLOR: return VK_BLEND_FACTOR_DST_COLOR;
-		case CELL_GCM_CONSTANT_COLOR: return VK_BLEND_FACTOR_CONSTANT_COLOR;
-		case CELL_GCM_CONSTANT_ALPHA: return VK_BLEND_FACTOR_CONSTANT_ALPHA;
-		case CELL_GCM_ONE_MINUS_SRC_COLOR: return VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
-		case CELL_GCM_ONE_MINUS_DST_COLOR: return VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR;
-		case CELL_GCM_ONE_MINUS_SRC_ALPHA: return VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-		case CELL_GCM_ONE_MINUS_DST_ALPHA: return VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA;
-		case CELL_GCM_ONE_MINUS_CONSTANT_ALPHA: return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
-		case CELL_GCM_ONE_MINUS_CONSTANT_COLOR: return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR;
+		case rsx::blend_factor::one: return VK_BLEND_FACTOR_ONE;
+		case rsx::blend_factor::zero: return VK_BLEND_FACTOR_ZERO;
+		case rsx::blend_factor::src_alpha: return VK_BLEND_FACTOR_SRC_ALPHA;
+		case rsx::blend_factor::dst_alpha: return VK_BLEND_FACTOR_DST_ALPHA;
+		case rsx::blend_factor::src_color: return VK_BLEND_FACTOR_SRC_COLOR;
+		case rsx::blend_factor::dst_color: return VK_BLEND_FACTOR_DST_COLOR;
+		case rsx::blend_factor::constant_color: return VK_BLEND_FACTOR_CONSTANT_COLOR;
+		case rsx::blend_factor::constant_alpha: return VK_BLEND_FACTOR_CONSTANT_ALPHA;
+		case rsx::blend_factor::one_minus_src_color: return VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
+		case rsx::blend_factor::one_minus_dst_color: return VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+		case rsx::blend_factor::one_minus_src_alpha: return VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+		case rsx::blend_factor::one_minus_dst_alpha: return VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA;
+		case rsx::blend_factor::one_minus_constant_alpha: return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
+		case rsx::blend_factor::one_minus_constant_color: return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR;
 		default:
 			throw EXCEPTION("Unknown blend factor 0x%X", factor);
 		}
 	};
 
-	VkBlendOp get_blend_op(u16 op)
+	VkBlendOp get_blend_op(rsx::blend_equation op)
 	{
 		switch (op)
 		{
-		case CELL_GCM_FUNC_ADD: return VK_BLEND_OP_ADD;
-		case CELL_GCM_FUNC_SUBTRACT: return VK_BLEND_OP_SUBTRACT;
-		case CELL_GCM_FUNC_REVERSE_SUBTRACT: return VK_BLEND_OP_REVERSE_SUBTRACT;
-		case CELL_GCM_MIN: return VK_BLEND_OP_MIN;
-		case CELL_GCM_MAX: return VK_BLEND_OP_MAX;
+		case rsx::blend_equation::add: return VK_BLEND_OP_ADD;
+		case rsx::blend_equation::substract: return VK_BLEND_OP_SUBTRACT;
+		case rsx::blend_equation::reverse_substract: return VK_BLEND_OP_REVERSE_SUBTRACT;
+		case rsx::blend_equation::min: return VK_BLEND_OP_MIN;
+		case rsx::blend_equation::max: return VK_BLEND_OP_MAX;
 		default:
 			throw EXCEPTION("Unknown blend op: 0x%X", op);
 		}
 	}
 	
-	VkStencilOp get_stencil_op(u32 op)
+
+	VkStencilOp get_stencil_op(rsx::stencil_op op)
 	{
 		switch (op)
 		{
-		case CELL_GCM_KEEP: return VK_STENCIL_OP_KEEP;
-		case CELL_GCM_ZERO: return VK_STENCIL_OP_ZERO;
-		case CELL_GCM_REPLACE: return VK_STENCIL_OP_REPLACE;
-		case CELL_GCM_INCR: return VK_STENCIL_OP_INCREMENT_AND_CLAMP;
-		case CELL_GCM_DECR: return VK_STENCIL_OP_DECREMENT_AND_CLAMP;
-		case CELL_GCM_INVERT: return VK_STENCIL_OP_INVERT;
-		case CELL_GCM_INCR_WRAP: return VK_STENCIL_OP_INCREMENT_AND_WRAP;
-		case CELL_GCM_DECR_WRAP: return VK_STENCIL_OP_DECREMENT_AND_WRAP;
+		case rsx::stencil_op::keep: return VK_STENCIL_OP_KEEP;
+		case rsx::stencil_op::zero: return VK_STENCIL_OP_ZERO;
+		case rsx::stencil_op::replace: return VK_STENCIL_OP_REPLACE;
+		case rsx::stencil_op::incr: return VK_STENCIL_OP_INCREMENT_AND_CLAMP;
+		case rsx::stencil_op::decr: return VK_STENCIL_OP_DECREMENT_AND_CLAMP;
+		case rsx::stencil_op::invert: return VK_STENCIL_OP_INVERT;
+		case rsx::stencil_op::incr_wrap: return VK_STENCIL_OP_INCREMENT_AND_WRAP;
+		case rsx::stencil_op::decr_wrap: return VK_STENCIL_OP_DECREMENT_AND_WRAP;
 		default:
 			throw EXCEPTION("Unknown stencil op: 0x%X", op);
 		}
 	}
-	
-	VkFrontFace get_front_face_ccw(u32 ffv)
+
+	VkFrontFace get_front_face_ccw(rsx::front_face ffv)
 	{
 		switch (ffv)
 		{
-		default: // Disgaea 3 pass some garbage value at startup, this is needed to survive.
-		case CELL_GCM_CW: return VK_FRONT_FACE_CLOCKWISE;
-		case CELL_GCM_CCW: return VK_FRONT_FACE_COUNTER_CLOCKWISE;
+		case rsx::front_face::cw: return VK_FRONT_FACE_CLOCKWISE;
+		case rsx::front_face::ccw: return VK_FRONT_FACE_COUNTER_CLOCKWISE;
+		default:
+			throw EXCEPTION("Unknown front face value: 0x%X", ffv);
 		}
-		throw EXCEPTION("Unknown front face value: 0x%X", ffv);
 	}
 
 	VkCullModeFlags get_cull_face(u32 cfv)
@@ -607,8 +608,7 @@ void VKGSRender::begin()
 	if (!load_program())
 		return;
 
-	u32 line_width = rsx::method_registers[NV4097_SET_LINE_WIDTH];
-	float actual_line_width = (line_width >> 3) + (line_width & 7) / 8.f;
+	float actual_line_width = rsx::method_registers.line_width();
 
 	vkCmdSetLineWidth(m_command_buffer, actual_line_width);
 
@@ -639,35 +639,34 @@ namespace
 }
 
 
-
 void VKGSRender::end()
 {
 	size_t idx = vk::get_render_pass_location(
-		vk::get_compatible_surface_format(m_surface.color_format).first,
-		vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, m_surface.depth_format),
-		(u8)vk::get_draw_buffers(rsx::to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET])).size());
+		vk::get_compatible_surface_format(rsx::method_registers.surface_color()).first,
+		vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, rsx::method_registers.surface_depth_fmt()),
+		(u8)vk::get_draw_buffers(rsx::method_registers.surface_color_target()).size());
 	VkRenderPass current_render_pass = m_render_passes[idx];
 
 	for (int i = 0; i < rsx::limits::textures_count; ++i)
 	{
 		if (m_program->has_uniform("tex" + std::to_string(i)))
 		{
-			if (!textures[i].enabled())
+			if (!rsx::method_registers.fragment_textures[i].enabled())
 			{
 				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "tex" + std::to_string(i), descriptor_sets);
 				continue;
 			}
-			vk::image_view  *texture0 = m_texture_cache.upload_texture(m_command_buffer, textures[i], m_rtts, m_memory_type_mapping, m_texture_upload_buffer_ring_info, m_texture_upload_buffer_ring_info.heap.get());
+			vk::image_view  *texture0 = m_texture_cache.upload_texture(m_command_buffer, rsx::method_registers.fragment_textures[i], m_rtts, m_memory_type_mapping, m_texture_upload_buffer_ring_info, m_texture_upload_buffer_ring_info.heap.get());
 
 			VkFilter min_filter;
 			VkSamplerMipmapMode mip_mode;
-			std::tie(min_filter, mip_mode) = vk::get_min_filter_and_mip(textures[i].min_filter());
+			std::tie(min_filter, mip_mode) = vk::get_min_filter_and_mip(rsx::method_registers.fragment_textures[i].min_filter());
 			m_sampler_to_clean.push_back(std::make_unique<vk::sampler>(
 				*m_device,
-				vk::vk_wrap_mode(textures[i].wrap_s()), vk::vk_wrap_mode(textures[i].wrap_t()), vk::vk_wrap_mode(textures[i].wrap_r()),
-				!!(textures[i].format() & CELL_GCM_TEXTURE_UN),
-				textures[i].bias(), vk::max_aniso(textures[i].max_aniso()), textures[i].min_lod(), textures[i].max_lod(),
-				min_filter, vk::get_mag_filter(textures[i].mag_filter()), mip_mode, vk::get_border_color(textures[i].border_color())
+				vk::vk_wrap_mode(rsx::method_registers.fragment_textures[i].wrap_s()), vk::vk_wrap_mode(rsx::method_registers.fragment_textures[i].wrap_t()), vk::vk_wrap_mode(rsx::method_registers.fragment_textures[i].wrap_r()),
+				!!(rsx::method_registers.fragment_textures[i].format() & CELL_GCM_TEXTURE_UN),
+				rsx::method_registers.fragment_textures[i].bias(), vk::max_aniso(rsx::method_registers.fragment_textures[i].max_aniso()), rsx::method_registers.fragment_textures[i].min_lod(), rsx::method_registers.fragment_textures[i].max_lod(),
+				min_filter, vk::get_mag_filter(rsx::method_registers.fragment_textures[i].mag_filter()), mip_mode, vk::get_border_color(rsx::method_registers.fragment_textures[i].border_color())
 				));
 			m_program->bind_uniform({ m_sampler_to_clean.back()->value, texture0->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "tex" + std::to_string(i), descriptor_sets);
 		}
@@ -710,23 +709,18 @@ void VKGSRender::end()
 
 void VKGSRender::set_viewport()
 {
-	u32 viewport_horizontal = rsx::method_registers[NV4097_SET_VIEWPORT_HORIZONTAL];
-	u32 viewport_vertical = rsx::method_registers[NV4097_SET_VIEWPORT_VERTICAL];
+	u16 viewport_x = rsx::method_registers.viewport_origin_x();
+	u16 viewport_y = rsx::method_registers.viewport_origin_y();
+	u16 viewport_w = rsx::method_registers.viewport_width();
+	u16 viewport_h = rsx::method_registers.viewport_height();
 
-	u16 viewport_x = viewport_horizontal & 0xffff;
-	u16 viewport_y = viewport_vertical & 0xffff;
-	u16 viewport_w = viewport_horizontal >> 16;
-	u16 viewport_h = viewport_vertical >> 16;
+	u16 scissor_x = rsx::method_registers.scissor_origin_x();
+	u16 scissor_w = rsx::method_registers.scissor_width();
+	u16 scissor_y = rsx::method_registers.scissor_origin_y();
+	u16 scissor_h = rsx::method_registers.scissor_height();
 
-	u32 scissor_horizontal = rsx::method_registers[NV4097_SET_SCISSOR_HORIZONTAL];
-	u32 scissor_vertical = rsx::method_registers[NV4097_SET_SCISSOR_VERTICAL];
-	u16 scissor_x = scissor_horizontal;
-	u16 scissor_w = scissor_horizontal >> 16;
-	u16 scissor_y = scissor_vertical;
-	u16 scissor_h = scissor_vertical >> 16;
-
-//	u32 shader_window = rsx::method_registers[NV4097_SET_SHADER_WINDOW];
-//	rsx::window_origin shader_window_origin = rsx::to_window_origin((shader_window >> 12) & 0xf);
+	//	u32 shader_window = rsx::method_registers[NV4097_SET_SHADER_WINDOW];
+	//	rsx::window_origin shader_window_origin = rsx::to_window_origin((shader_window >> 12) & 0xf);
 
 	VkViewport viewport = {};
 	viewport.x = viewport_x;
@@ -763,8 +757,7 @@ void VKGSRender::clear_surface(u32 mask)
 {
 	//TODO: Build clear commands into current renderpass descriptor set
 	if (!(mask & 0xF3)) return;
-	if (m_current_present_image== 0xFFFF) return;
-	if (!rsx::method_registers[NV4097_SET_SURFACE_FORMAT]) return;
+	if (m_current_present_image == 0xFFFF) return;
 
 	init_buffers();
 
@@ -774,13 +767,13 @@ void VKGSRender::clear_surface(u32 mask)
 	VkClearValue depth_stencil_clear_values, color_clear_values;
 	VkImageSubresourceRange depth_range = vk::get_image_subresource_range(0, 0, 1, 1, 0);
 
-	rsx::surface_depth_format surface_depth_format = rsx::to_surface_depth_format((rsx::method_registers[NV4097_SET_SURFACE_FORMAT] >> 5) & 0x7);
+	rsx::surface_depth_format surface_depth_format = rsx::method_registers.surface_depth_fmt();
 
 	if (mask & 0x1)
 	{
 		u32 max_depth_value = get_max_depth_value(surface_depth_format);
 
-		u32 clear_depth = rsx::method_registers[NV4097_SET_ZSTENCIL_CLEAR_VALUE] >> 8;
+		u32 clear_depth = rsx::method_registers.z_clear_value();
 		float depth_clear = (float)clear_depth / max_depth_value;
 
 		depth_range.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
@@ -790,8 +783,8 @@ void VKGSRender::clear_surface(u32 mask)
 
 	if (mask & 0x2)
 	{
-		u8 clear_stencil = rsx::method_registers[NV4097_SET_ZSTENCIL_CLEAR_VALUE] & 0xff;
-		u32 stencil_mask = rsx::method_registers[NV4097_SET_STENCIL_MASK];
+		u8 clear_stencil = rsx::method_registers.stencil_clear_value();
+		u32 stencil_mask = rsx::method_registers.stencil_mask();
 
 		//TODO set stencil mask
 		depth_range.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
@@ -800,11 +793,10 @@ void VKGSRender::clear_surface(u32 mask)
 
 	if (mask & 0xF0)
 	{
-		u32 clear_color = rsx::method_registers[NV4097_SET_COLOR_CLEAR_VALUE];
-		u8 clear_a = clear_color >> 24;
-		u8 clear_r = clear_color >> 16;
-		u8 clear_g = clear_color >> 8;
-		u8 clear_b = clear_color;
+		u8 clear_a = rsx::method_registers.clear_color_a();
+		u8 clear_r = rsx::method_registers.clear_color_r();
+		u8 clear_g = rsx::method_registers.clear_color_g();
+		u8 clear_b = rsx::method_registers.clear_color_b();
 
 		//TODO set color mask
 		/*VkBool32 clear_red = (VkBool32)!!(mask & 0x20);
@@ -878,12 +870,12 @@ bool VKGSRender::load_program()
 	bool unused;
 	properties.ia.topology = vk::get_appropriate_topology(draw_mode, unused);
 
-	if (rsx::method_registers[NV4097_SET_RESTART_INDEX_ENABLE])
+	if (rsx::method_registers.restart_index_enabled())
 	{
-		if (rsx::method_registers[NV4097_SET_RESTART_INDEX] != 0xFFFF &&
-			rsx::method_registers[NV4097_SET_RESTART_INDEX] != 0xFFFFFFFF)
+		if (rsx::method_registers.restart_index() != 0xFFFF &&
+			rsx::method_registers.restart_index() != 0xFFFFFFFF)
 		{
-			LOG_ERROR(RSX, "Custom primitive restart index 0x%X. Should rewrite index buffer with proper value!", rsx::method_registers[NV4097_SET_RESTART_INDEX]);
+			LOG_ERROR(RSX, "Custom primitive restart index 0x%X. Should rewrite index buffer with proper value!", rsx::method_registers.restart_index());
 		}
 		properties.ia.primitiveRestartEnable = VK_TRUE;
 	}
@@ -897,17 +889,11 @@ bool VKGSRender::load_program()
 		properties.att_state[i].blendEnable = VK_FALSE;
 	}
 
-	u32 color_mask = rsx::method_registers[NV4097_SET_COLOR_MASK];
-	bool color_mask_b = !!(color_mask & 0xff);
-	bool color_mask_g = !!((color_mask >> 8) & 0xff);
-	bool color_mask_r = !!((color_mask >> 16) & 0xff);
-	bool color_mask_a = !!((color_mask >> 24) & 0xff);
-
 	VkColorComponentFlags mask = 0;
-	if (color_mask_a) mask |= VK_COLOR_COMPONENT_A_BIT;
-	if (color_mask_b) mask |= VK_COLOR_COMPONENT_B_BIT;
-	if (color_mask_g) mask |= VK_COLOR_COMPONENT_G_BIT;
-	if (color_mask_r) mask |= VK_COLOR_COMPONENT_R_BIT;
+	if (rsx::method_registers.color_mask_a()) mask |= VK_COLOR_COMPONENT_A_BIT;
+	if (rsx::method_registers.color_mask_b()) mask |= VK_COLOR_COMPONENT_B_BIT;
+	if (rsx::method_registers.color_mask_g()) mask |= VK_COLOR_COMPONENT_G_BIT;
+	if (rsx::method_registers.color_mask_r()) mask |= VK_COLOR_COMPONENT_R_BIT;
 
 	VkColorComponentFlags color_masks[4] = { mask };
 
@@ -918,19 +904,15 @@ bool VKGSRender::load_program()
 		properties.att_state[render_targets[idx]].colorWriteMask = mask;
 	}
 
-	if (rsx::method_registers[NV4097_SET_BLEND_ENABLE])
+	if (rsx::method_registers.blend_enabled())
 	{
-		u32 sfactor = rsx::method_registers[NV4097_SET_BLEND_FUNC_SFACTOR];
-		u32 dfactor = rsx::method_registers[NV4097_SET_BLEND_FUNC_DFACTOR];
+		VkBlendFactor sfactor_rgb = vk::get_blend_factor(rsx::method_registers.blend_func_sfactor_rgb());
+		VkBlendFactor sfactor_a = vk::get_blend_factor(rsx::method_registers.blend_func_sfactor_a());
+		VkBlendFactor dfactor_rgb = vk::get_blend_factor(rsx::method_registers.blend_func_dfactor_rgb());
+		VkBlendFactor dfactor_a = vk::get_blend_factor(rsx::method_registers.blend_func_dfactor_a());
 
-		VkBlendFactor sfactor_rgb = vk::get_blend_factor(sfactor);
-		VkBlendFactor sfactor_a = vk::get_blend_factor(sfactor >> 16);
-		VkBlendFactor dfactor_rgb = vk::get_blend_factor(dfactor);
-		VkBlendFactor dfactor_a = vk::get_blend_factor(dfactor >> 16);
-
-		u32 equation = rsx::method_registers[NV4097_SET_BLEND_EQUATION];
-		VkBlendOp equation_rgb = vk::get_blend_op(equation);
-		VkBlendOp equation_a = vk::get_blend_op(equation >> 16);
+		VkBlendOp equation_rgb = vk::get_blend_op(rsx::method_registers.blend_equation_rgb());
+		VkBlendOp equation_a = vk::get_blend_op(rsx::method_registers.blend_equation_a());
 
 		//TODO: Separate target blending
 		for (u8 idx = 0; idx < m_draw_buffers_count; ++idx)
@@ -952,67 +934,83 @@ bool VKGSRender::load_program()
 		}
 	}
 
-	if (rsx::method_registers[NV4097_SET_LOGIC_OP_ENABLE])
+	if (rsx::method_registers.logic_op_enabled())
 	{
 		properties.cs.logicOpEnable = true;
-		properties.cs.logicOp = vk::get_logic_op(rsx::method_registers[NV4097_SET_LOGIC_OP]);
+		properties.cs.logicOp = vk::get_logic_op(rsx::method_registers.logic_operation());
 	}
 
 	properties.ds.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-	properties.ds.depthWriteEnable = (!!rsx::method_registers[NV4097_SET_DEPTH_MASK]) ? VK_TRUE : VK_FALSE;
+	properties.ds.depthWriteEnable = rsx::method_registers.depth_write_enabled() ? VK_TRUE : VK_FALSE;
 
-	if (rsx::method_registers[NV4097_SET_DEPTH_BOUNDS_TEST_ENABLE])
+	if (rsx::method_registers.depth_bounds_test_enabled())
 	{
 		properties.ds.depthBoundsTestEnable = VK_TRUE;
-		properties.ds.minDepthBounds = (f32&)rsx::method_registers[NV4097_SET_DEPTH_BOUNDS_MIN];
-		properties.ds.maxDepthBounds = (f32&)rsx::method_registers[NV4097_SET_DEPTH_BOUNDS_MAX];
+		properties.ds.minDepthBounds = rsx::method_registers.depth_bounds_min();
+		properties.ds.maxDepthBounds = rsx::method_registers.depth_bounds_max();
 	}
 	else
 		properties.ds.depthBoundsTestEnable = VK_FALSE;
 
-	if (rsx::method_registers[NV4097_SET_STENCIL_TEST_ENABLE])
+	if (rsx::method_registers.stencil_test_enabled())
 	{
 		properties.ds.stencilTestEnable = VK_TRUE;
-		properties.ds.front.writeMask = rsx::method_registers[NV4097_SET_STENCIL_MASK];
-		properties.ds.front.compareMask = rsx::method_registers[NV4097_SET_STENCIL_FUNC_MASK];
-		properties.ds.front.reference = rsx::method_registers[NV4097_SET_STENCIL_FUNC_REF];
-		properties.ds.front.failOp = vk::get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_FAIL]);
-		properties.ds.front.passOp = vk::get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_ZPASS]);
-		properties.ds.front.depthFailOp = vk::get_stencil_op(rsx::method_registers[NV4097_SET_STENCIL_OP_ZFAIL]);
-		properties.ds.front.compareOp = vk::compare_op(rsx::method_registers[NV4097_SET_STENCIL_FUNC]);
+		properties.ds.front.writeMask = rsx::method_registers.stencil_mask();
+		properties.ds.front.compareMask = rsx::method_registers.stencil_func_mask();
+		properties.ds.front.reference = rsx::method_registers.stencil_func_ref();
+		properties.ds.front.failOp = vk::get_stencil_op(rsx::method_registers.stencil_op_fail());
+		properties.ds.front.passOp = vk::get_stencil_op(rsx::method_registers.stencil_op_zpass());
+		properties.ds.front.depthFailOp = vk::get_stencil_op(rsx::method_registers.stencil_op_zfail());
+		properties.ds.front.compareOp = vk::compare_op(rsx::method_registers.stencil_func());
 
-		if (rsx::method_registers[NV4097_SET_TWO_SIDED_STENCIL_TEST_ENABLE])
+		if (rsx::method_registers.two_sided_stencil_test_enabled())
 		{
-			properties.ds.back.failOp = vk::get_stencil_op(rsx::method_registers[NV4097_SET_BACK_STENCIL_OP_FAIL]);
-			properties.ds.back.passOp = vk::get_stencil_op(rsx::method_registers[NV4097_SET_BACK_STENCIL_OP_ZPASS]);
-			properties.ds.back.depthFailOp = vk::get_stencil_op(rsx::method_registers[NV4097_SET_BACK_STENCIL_OP_ZFAIL]);
-			properties.ds.back.compareOp = vk::compare_op(rsx::method_registers[NV4097_SET_BACK_STENCIL_FUNC]);
+			properties.ds.back.failOp = vk::get_stencil_op(rsx::method_registers.back_stencil_op_fail());
+			properties.ds.back.passOp = vk::get_stencil_op(rsx::method_registers.back_stencil_op_zpass());
+			properties.ds.back.depthFailOp = vk::get_stencil_op(rsx::method_registers.back_stencil_op_zfail());
+			properties.ds.back.compareOp = vk::compare_op(rsx::method_registers.back_stencil_func());
 		}
 		else
 			properties.ds.back = properties.ds.front;
 	}
 	else
 		properties.ds.stencilTestEnable = VK_FALSE;
-		
-	if (!!rsx::method_registers[NV4097_SET_DEPTH_TEST_ENABLE])
+
+	if (rsx::method_registers.depth_test_enabled())
 	{
 		properties.ds.depthTestEnable = VK_TRUE;
-		properties.ds.depthCompareOp = vk::compare_op(rsx::method_registers[NV4097_SET_DEPTH_FUNC]);
+		properties.ds.depthCompareOp = vk::compare_op(rsx::method_registers.depth_func());
 	}
 	else
 		properties.ds.depthTestEnable = VK_FALSE;
 
-	if (!!rsx::method_registers[NV4097_SET_CULL_FACE_ENABLE])
+	if (rsx::method_registers.cull_face_enabled())
 	{
-		properties.rs.cullMode = vk::get_cull_face(rsx::method_registers[NV4097_SET_CULL_FACE]);
+		switch (rsx::method_registers.cull_face_mode())
+		{
+		case rsx::cull_face::front:
+			properties.rs.cullMode = VK_CULL_MODE_FRONT_BIT;
+			break;
+		case rsx::cull_face::back:
+			properties.rs.cullMode = VK_CULL_MODE_BACK_BIT;
+			break;
+		case rsx::cull_face::front_and_back:
+			properties.rs.cullMode = VK_CULL_MODE_FRONT_AND_BACK;
+			break;
+		default:
+			properties.rs.cullMode = VK_CULL_MODE_NONE;
+			break;
+		}
 	}
-	
-	properties.rs.frontFace = vk::get_front_face_ccw(rsx::method_registers[NV4097_SET_FRONT_FACE]);
-	
+	else
+		properties.rs.cullMode = VK_CULL_MODE_NONE;
+
+	properties.rs.frontFace = vk::get_front_face_ccw(rsx::method_registers.front_face_mode());
+
 	size_t idx = vk::get_render_pass_location(
-		vk::get_compatible_surface_format(m_surface.color_format).first,
-		vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, m_surface.depth_format),
-		(u8)vk::get_draw_buffers(rsx::to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET])).size());
+		vk::get_compatible_surface_format(rsx::method_registers.surface_color()).first,
+		vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, rsx::method_registers.surface_depth_fmt()),
+		(u8)vk::get_draw_buffers(rsx::method_registers.surface_color_target()).size());
 	properties.render_pass = m_render_passes[idx];
 
 	properties.num_targets = m_draw_buffers_count;
@@ -1030,23 +1028,23 @@ bool VKGSRender::load_program()
 
 	//TODO: Add case for this in RSXThread
 	/**
-	 * NOTE: While VK's coord system resembles GLs, the clip volume is no longer symetrical in z
-	 * Its like D3D without the flip in y (depending on how you build the spir-v)
-	 */
+	* NOTE: While VK's coord system resembles GLs, the clip volume is no longer symetrical in z
+	* Its like D3D without the flip in y (depending on how you build the spir-v)
+	*/
 	{
-		int clip_w = rsx::method_registers[NV4097_SET_SURFACE_CLIP_HORIZONTAL] >> 16;
-		int clip_h = rsx::method_registers[NV4097_SET_SURFACE_CLIP_VERTICAL] >> 16;
+		int clip_w = rsx::method_registers.surface_clip_width();
+		int clip_h = rsx::method_registers.surface_clip_height();
 
-		float scale_x = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE] / (clip_w / 2.f);
-		float offset_x = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET] - (clip_w / 2.f);
+		float scale_x = rsx::method_registers.viewport_scale_x() / (clip_w / 2.f);
+		float offset_x = rsx::method_registers.viewport_offset_x() - (clip_w / 2.f);
 		offset_x /= clip_w / 2.f;
 
-		float scale_y = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE + 1] / (clip_h / 2.f);
-		float offset_y = ((float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET + 1] - (clip_h / 2.f));
+		float scale_y = rsx::method_registers.viewport_scale_y() / (clip_h / 2.f);
+		float offset_y = (rsx::method_registers.viewport_offset_y() - (clip_h / 2.f));
 		offset_y /= clip_h / 2.f;
 
-		float scale_z = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_SCALE + 2];
-		float offset_z = (float&)rsx::method_registers[NV4097_SET_VIEWPORT_OFFSET + 2];
+		float scale_z = rsx::method_registers.viewport_scale_z();
+		float offset_z = rsx::method_registers.viewport_offset_z();
 
 		float one = 1.f;
 
@@ -1056,12 +1054,14 @@ bool VKGSRender::load_program()
 		stream_vector((char*)buf + 48, 0, 0, 0, (u32&)one);
 	}
 
-	u32 is_alpha_tested = !!(rsx::method_registers[NV4097_SET_ALPHA_TEST_ENABLE]);
-	u8 alpha_ref_raw = (u8)(rsx::method_registers[NV4097_SET_ALPHA_REF] & 0xFF);
+	u32 is_alpha_tested = rsx::method_registers.alpha_test_enabled();
+	u8 alpha_ref_raw = rsx::method_registers.alpha_ref();
 	float alpha_ref = alpha_ref_raw / 255.f;
 
-	memcpy((char*)buf + 64, &rsx::method_registers[NV4097_SET_FOG_PARAMS], sizeof(float));
-	memcpy((char*)buf + 68, &rsx::method_registers[NV4097_SET_FOG_PARAMS + 1], sizeof(float));
+	f32 fog0 = rsx::method_registers.fog_params_0();
+	f32 fog1 = rsx::method_registers.fog_params_1();
+	memcpy((char*)buf + 64, &fog0, sizeof(float));
+	memcpy((char*)buf + 68, &fog1, sizeof(float));
 	memcpy((char*)buf + 72, &is_alpha_tested, sizeof(u32));
 	memcpy((char*)buf + 76, &alpha_ref, sizeof(float));
 	m_uniform_buffer_ring_info.unmap();
@@ -1161,37 +1161,29 @@ void VKGSRender::open_command_buffer()
 
 void VKGSRender::prepare_rtts()
 {
-	u32 surface_format = rsx::method_registers[NV4097_SET_SURFACE_FORMAT];
-
 	if (!m_rtts_dirty)
 		return;
 
 	m_rtts_dirty = false;
 
-	if (m_surface.format != surface_format)
-		m_surface.unpack(surface_format);
-
-	u32 clip_horizontal = rsx::method_registers[NV4097_SET_SURFACE_CLIP_HORIZONTAL];
-	u32 clip_vertical = rsx::method_registers[NV4097_SET_SURFACE_CLIP_VERTICAL];
-
-	u32 clip_width = clip_horizontal >> 16;
-	u32 clip_height = clip_vertical >> 16;
-	u32 clip_x = clip_horizontal;
-	u32 clip_y = clip_vertical;
+	u32 clip_width = rsx::method_registers.surface_clip_width();
+	u32 clip_height = rsx::method_registers.surface_clip_height();
+	u32 clip_x = rsx::method_registers.surface_clip_origin_x();
+	u32 clip_y = rsx::method_registers.surface_clip_origin_y();
 
 	m_rtts.prepare_render_target(&m_command_buffer,
-		surface_format,
-		clip_horizontal, clip_vertical,
-		rsx::to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET]),
+		rsx::method_registers.surface_color(), rsx::method_registers.surface_depth_fmt(),
+		rsx::method_registers.surface_clip_width(), rsx::method_registers.surface_clip_height(),
+		rsx::method_registers.surface_color_target(),
 		get_color_surface_addresses(), get_zeta_surface_address(),
 		(*m_device), &m_command_buffer, m_optimal_tiling_supported_formats, m_memory_type_mapping);
 
 	//Bind created rtts as current fbo...
-	std::vector<u8> draw_buffers = vk::get_draw_buffers(rsx::to_surface_target(rsx::method_registers[NV4097_SET_SURFACE_COLOR_TARGET]));
+	std::vector<u8> draw_buffers = vk::get_draw_buffers(rsx::method_registers.surface_color_target());
 
 	std::vector<std::unique_ptr<vk::image_view>> fbo_images;
 
-	for (u8 index: draw_buffers)
+	for (u8 index : draw_buffers)
 	{
 		vk::image *raw = std::get<1>(m_rtts.m_bound_render_targets[index]);
 
@@ -1212,7 +1204,7 @@ void VKGSRender::prepare_rtts()
 		vk::image *raw = (std::get<1>(m_rtts.m_bound_depth_stencil));
 
 		VkImageSubresourceRange subres = {};
-		subres.aspectMask = (m_surface.depth_format == rsx::surface_depth_format::z24s8) ? (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT) : VK_IMAGE_ASPECT_DEPTH_BIT;
+		subres.aspectMask = (rsx::method_registers.surface_depth_fmt() == rsx::surface_depth_format::z24s8) ? (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT) : VK_IMAGE_ASPECT_DEPTH_BIT;
 		subres.baseArrayLayer = 0;
 		subres.baseMipLevel = 0;
 		subres.layerCount = 1;
@@ -1221,7 +1213,7 @@ void VKGSRender::prepare_rtts()
 		fbo_images.push_back(std::make_unique<vk::image_view>(*m_device, raw->value, VK_IMAGE_VIEW_TYPE_2D, raw->info.format, vk::default_component_map(), subres));
 	}
 
-	size_t idx = vk::get_render_pass_location(vk::get_compatible_surface_format(m_surface.color_format).first, vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, m_surface.depth_format), (u8)draw_buffers.size());
+	size_t idx = vk::get_render_pass_location(vk::get_compatible_surface_format(rsx::method_registers.surface_color()).first, vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, rsx::method_registers.surface_depth_fmt()), (u8)draw_buffers.size());
 	VkRenderPass current_render_pass = m_render_passes[idx];
 
 	m_framebuffer_to_clean.push_back(std::make_unique<vk::framebuffer>(*m_device, current_render_pass, clip_width, clip_height, std::move(fbo_images)));

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -21,8 +21,6 @@ private:
 	vk::glsl::program *m_program;
 	vk::context m_thread_context;
 
-	rsx::surface_info m_surface;
-
 	vk::vk_data_heap m_attrib_ring_info;
 	
 	vk::texture_cache m_texture_cache;

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <array>
+#include <vector>
+
+#include "GCM.h"
+#include "RSXTexture.h"
+#include "rsx_vertex_data.h"
+#include "Utilities/geometry.h"
+
 namespace rsx
 {
 	//TODO
@@ -63,7 +71,1111 @@ namespace rsx
 		}
 	};
 
+	template<typename T, size_t... N, typename Args>
+	std::array<T, sizeof...(N)> fill_array(Args&& arg, std::index_sequence<N...> seq)
+	{
+		return{ T(N, std::forward<Args>(arg))... };
+	}
+
+	struct rsx_state
+	{
+	private:
+		std::array<u32, 0x10000 / 4> registers;
+
+	public:
+		std::array<texture, 16> fragment_textures;
+		std::array<vertex_texture, 4> vertex_textures;
+
+		std::array<u32, 512 * 4> transform_program;
+
+		std::unordered_map<u32, color4_base<f32>> transform_constants;
+
+		/**
+		* RSX can sources vertex attributes from 2 places:
+		* - Immediate values passed by NV4097_SET_VERTEX_DATA*_M + ARRAY_ID write.
+		* For a given ARRAY_ID the last command of this type defines the actual type of the immediate value.
+		* Since there can be only a single value per ARRAY_ID passed this way, all vertex in the draw call
+		* shares it.
+		* - Vertex array values passed by offset/stride/size/format description.
+		*
+		* A given ARRAY_ID can have both an immediate value and a vertex array enabled at the same time
+		* (See After Burner Climax intro cutscene). In such case the vertex array has precedence over the
+		* immediate value. As soon as the vertex array is disabled (size set to 0) the immediate value
+		* must be used if the vertex attrib mask request it.
+		*
+		* Note that behavior when both vertex array and immediate value system are disabled but vertex attrib mask
+		* request inputs is unknow.
+		*/
+		std::array<data_array_format_info, 16> register_vertex_info;
+		std::array<std::vector<u8>, 16> register_vertex_data;
+		std::array<data_array_format_info, 16> vertex_arrays_info;
+
+		rsx_state() :
+			// unfortunatly there is no other way to fill an array with objects without default initializer
+			// except by using templates.
+			fragment_textures(fill_array<texture>(registers, std::make_index_sequence<16>())),
+			vertex_textures(fill_array<vertex_texture>(registers, std::make_index_sequence<4>())),
+			register_vertex_info(fill_array<data_array_format_info>(registers, std::make_index_sequence<16>())),
+			vertex_arrays_info(fill_array<data_array_format_info>(registers, std::make_index_sequence<16>()))
+		{
+
+		}
+
+		u32& operator[](size_t idx)
+		{
+			return registers[idx];
+		}
+
+		const u32& operator[](size_t idx) const
+		{
+			return registers[idx];
+		}
+
+		void reset()
+		{
+			//setup method registers
+			std::memset(registers.data(), 0, registers.size() * sizeof(u32));
+
+			registers[NV4097_SET_COLOR_MASK] = CELL_GCM_COLOR_MASK_R | CELL_GCM_COLOR_MASK_G | CELL_GCM_COLOR_MASK_B | CELL_GCM_COLOR_MASK_A;
+			registers[NV4097_SET_SCISSOR_HORIZONTAL] = (4096 << 16) | 0;
+			registers[NV4097_SET_SCISSOR_VERTICAL] = (4096 << 16) | 0;
+
+			registers[NV4097_SET_ALPHA_FUNC] = CELL_GCM_ALWAYS;
+			registers[NV4097_SET_ALPHA_REF] = 0;
+
+			registers[NV4097_SET_BLEND_FUNC_SFACTOR] = (CELL_GCM_ONE << 16) | CELL_GCM_ONE;
+			registers[NV4097_SET_BLEND_FUNC_DFACTOR] = (CELL_GCM_ZERO << 16) | CELL_GCM_ZERO;
+			registers[NV4097_SET_BLEND_COLOR] = 0;
+			registers[NV4097_SET_BLEND_COLOR2] = 0;
+			registers[NV4097_SET_BLEND_EQUATION] = (CELL_GCM_FUNC_ADD << 16) | CELL_GCM_FUNC_ADD;
+
+			registers[NV4097_SET_STENCIL_MASK] = 0xff;
+			registers[NV4097_SET_STENCIL_FUNC] = CELL_GCM_ALWAYS;
+			registers[NV4097_SET_STENCIL_FUNC_REF] = 0x00;
+			registers[NV4097_SET_STENCIL_FUNC_MASK] = 0xff;
+			registers[NV4097_SET_STENCIL_OP_FAIL] = CELL_GCM_KEEP;
+			registers[NV4097_SET_STENCIL_OP_ZFAIL] = CELL_GCM_KEEP;
+			registers[NV4097_SET_STENCIL_OP_ZPASS] = CELL_GCM_KEEP;
+
+			registers[NV4097_SET_BACK_STENCIL_MASK] = 0xff;
+			registers[NV4097_SET_BACK_STENCIL_FUNC] = CELL_GCM_ALWAYS;
+			registers[NV4097_SET_BACK_STENCIL_FUNC_REF] = 0x00;
+			registers[NV4097_SET_BACK_STENCIL_FUNC_MASK] = 0xff;
+			registers[NV4097_SET_BACK_STENCIL_OP_FAIL] = CELL_GCM_KEEP;
+			registers[NV4097_SET_BACK_STENCIL_OP_ZFAIL] = CELL_GCM_KEEP;
+			registers[NV4097_SET_BACK_STENCIL_OP_ZPASS] = CELL_GCM_KEEP;
+
+			registers[NV4097_SET_SHADE_MODE] = CELL_GCM_SMOOTH;
+
+			registers[NV4097_SET_LOGIC_OP] = CELL_GCM_COPY;
+
+			(f32&)registers[NV4097_SET_DEPTH_BOUNDS_MIN] = 0.f;
+			(f32&)registers[NV4097_SET_DEPTH_BOUNDS_MAX] = 1.f;
+
+			(f32&)registers[NV4097_SET_CLIP_MIN] = 0.f;
+			(f32&)registers[NV4097_SET_CLIP_MAX] = 1.f;
+
+			registers[NV4097_SET_LINE_WIDTH] = 1 << 3;
+
+			// These defaults were found using After Burner Climax (which never set fog mode despite using fog input)
+			registers[NV4097_SET_FOG_MODE] = 0x2601; // rsx::fog_mode::linear;
+			(f32&)registers[NV4097_SET_FOG_PARAMS] = 1.;
+			(f32&)registers[NV4097_SET_FOG_PARAMS + 1] = 1.;
+
+			registers[NV4097_SET_DEPTH_FUNC] = CELL_GCM_LESS;
+			registers[NV4097_SET_DEPTH_MASK] = CELL_GCM_TRUE;
+			(f32&)registers[NV4097_SET_POLYGON_OFFSET_SCALE_FACTOR] = 0.f;
+			(f32&)registers[NV4097_SET_POLYGON_OFFSET_BIAS] = 0.f;
+			registers[NV4097_SET_FRONT_POLYGON_MODE] = CELL_GCM_POLYGON_MODE_FILL;
+			registers[NV4097_SET_BACK_POLYGON_MODE] = CELL_GCM_POLYGON_MODE_FILL;
+			registers[NV4097_SET_CULL_FACE] = CELL_GCM_BACK;
+			registers[NV4097_SET_FRONT_FACE] = CELL_GCM_CCW;
+			registers[NV4097_SET_RESTART_INDEX] = -1;
+
+			registers[NV4097_SET_CLEAR_RECT_HORIZONTAL] = (4096 << 16) | 0;
+			registers[NV4097_SET_CLEAR_RECT_VERTICAL] = (4096 << 16) | 0;
+
+			registers[NV4097_SET_ZSTENCIL_CLEAR_VALUE] = 0xffffffff;
+
+			registers[NV4097_SET_CONTEXT_DMA_REPORT] = CELL_GCM_CONTEXT_DMA_TO_MEMORY_GET_REPORT;
+			registers[NV4097_SET_TWO_SIDE_LIGHT_EN] = true;
+			registers[NV4097_SET_ALPHA_FUNC] = CELL_GCM_ALWAYS;
+
+			// Reset vertex attrib array
+			for (int i = 0; i < 16; i++)
+			{
+				vertex_arrays_info[i].size = 0;
+			}
+
+			// Construct Textures
+			for (int i = 0; i < 16; i++)
+			{
+				fragment_textures[i].init(i);
+			}
+
+			for (int i = 0; i < 4; i++)
+			{
+				vertex_textures[i].init(i);
+			}
+		}
+
+		u16 viewport_width() const
+		{
+			return registers[NV4097_SET_VIEWPORT_HORIZONTAL] >> 16;
+		}
+
+		u16 viewport_origin_x() const
+		{
+			return registers[NV4097_SET_VIEWPORT_HORIZONTAL] & 0xffff;
+		}
+
+		u16 viewport_height() const
+		{
+			return registers[NV4097_SET_VIEWPORT_VERTICAL] >> 16;
+		}
+
+		u16 viewport_origin_y() const
+		{
+			return registers[NV4097_SET_VIEWPORT_VERTICAL] & 0xffff;
+		}
+
+		u16 scissor_origin_x() const
+		{
+			return registers[NV4097_SET_SCISSOR_HORIZONTAL] & 0xffff;
+		}
+
+		u16 scissor_width() const
+		{
+			return registers[NV4097_SET_SCISSOR_HORIZONTAL] >> 16;
+		}
+
+		u16 scissor_origin_y() const
+		{
+			return registers[NV4097_SET_SCISSOR_VERTICAL] & 0xffff;
+		}
+
+		u16 scissor_height() const
+		{
+			return registers[NV4097_SET_SCISSOR_VERTICAL] >> 16;
+		}
+
+		rsx::window_origin shader_window_origin() const
+		{
+			return rsx::to_window_origin((registers[NV4097_SET_SHADER_WINDOW] >> 12) & 0xf);
+		}
+
+		rsx::window_pixel_center shader_window_pixel() const
+		{
+			return rsx::to_window_pixel_center((registers[NV4097_SET_SHADER_WINDOW] >> 16) & 0xf);
+		}
+
+		u16 shader_window_height() const
+		{
+			return registers[NV4097_SET_SHADER_WINDOW] & 0xfff;
+		}
+
+		u32 shader_window_offset_x() const
+		{
+			return registers[NV4097_SET_WINDOW_OFFSET] & 0xffff;
+		}
+
+		u32 shader_window_offset_y() const
+		{
+			return registers[NV4097_SET_WINDOW_OFFSET] >> 16;
+		}
+
+		bool depth_test_enabled() const
+		{
+			return !!registers[NV4097_SET_DEPTH_TEST_ENABLE];
+		}
+
+		bool depth_write_enabled() const
+		{
+			return !!registers[NV4097_SET_DEPTH_MASK];
+		}
+
+		bool alpha_test_enabled() const
+		{
+			return !!registers[NV4097_SET_ALPHA_TEST_ENABLE];
+		}
+
+		bool stencil_test_enabled() const
+		{
+			return !!registers[NV4097_SET_STENCIL_TEST_ENABLE];
+		}
+
+		bool restart_index_enabled() const
+		{
+			return !!registers[NV4097_SET_RESTART_INDEX_ENABLE];
+		}
+
+		u32 restart_index() const
+		{
+			return registers[NV4097_SET_RESTART_INDEX];
+		}
+
+		u32 z_clear_value() const
+		{
+			return registers[NV4097_SET_ZSTENCIL_CLEAR_VALUE] >> 8;
+		}
+
+		u8 stencil_clear_value() const
+		{
+			return registers[NV4097_SET_ZSTENCIL_CLEAR_VALUE] & 0xff;
+		}
+
+		f32 fog_params_0() const
+		{
+			return (f32&)registers[NV4097_SET_FOG_PARAMS];
+		}
+
+		f32 fog_params_1() const
+		{
+			return (f32&)registers[NV4097_SET_FOG_PARAMS + 1];
+		}
+
+		rsx::index_array_type index_type() const
+		{
+			return rsx::to_index_array_type(registers[NV4097_SET_INDEX_ARRAY_DMA] >> 4);
+		}
+
+		bool color_mask_b() const
+		{
+			return !!(registers[NV4097_SET_COLOR_MASK] & 0xff);
+		}
+
+		bool color_mask_g() const
+		{
+			return !!((registers[NV4097_SET_COLOR_MASK] >> 8) & 0xff);
+		}
+
+		bool color_mask_r() const
+		{
+			return !!((registers[NV4097_SET_COLOR_MASK] >> 16) & 0xff);
+		}
+
+		bool color_mask_a() const
+		{
+			return !!((registers[NV4097_SET_COLOR_MASK] >> 24) & 0xff);
+		}
+
+		u8 clear_color_b() const
+		{
+			return registers[NV4097_SET_COLOR_CLEAR_VALUE] & 0xff;
+		}
+
+		u8 clear_color_r() const
+		{
+			return (registers[NV4097_SET_COLOR_CLEAR_VALUE] >> 16) & 0xff;
+		}
+
+		u8 clear_color_g() const
+		{
+			return (registers[NV4097_SET_COLOR_CLEAR_VALUE] >> 8) & 0xff;
+		}
+
+		u8 clear_color_a() const
+		{
+			return (registers[NV4097_SET_COLOR_CLEAR_VALUE] >> 24) & 0xff;
+		}
+
+		bool depth_bounds_test_enabled() const
+		{
+			return !!registers[NV4097_SET_DEPTH_BOUNDS_TEST_ENABLE];
+		}
+
+		f32 depth_bounds_min() const
+		{
+			return (f32&)registers[NV4097_SET_DEPTH_BOUNDS_MIN];
+		}
+
+		f32 depth_bounds_max() const
+		{
+			return (f32&)registers[NV4097_SET_DEPTH_BOUNDS_MAX];
+		}
+
+		f32 clip_min() const
+		{
+			return (f32&)registers[NV4097_SET_CLIP_MIN];
+		}
+
+		f32 clip_max() const
+		{
+			return (f32&)registers[NV4097_SET_CLIP_MAX];
+		}
+
+		bool logic_op_enabled() const
+		{
+			return !!registers[NV4097_SET_LOGIC_OP_ENABLE];
+		}
+
+		u8 stencil_mask() const
+		{
+			return registers[NV4097_SET_STENCIL_MASK] & 0xff;
+		}
+
+		u8 back_stencil_mask() const
+		{
+			return registers[NV4097_SET_BACK_STENCIL_MASK];
+		}
+
+		bool dither_enabled() const
+		{
+			return !!registers[NV4097_SET_DITHER_ENABLE];
+		}
+
+		bool blend_enabled() const
+		{
+			return !!registers[NV4097_SET_BLEND_ENABLE];
+		}
+
+		bool blend_enabled_surface_1() const
+		{
+			return !!(registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x2);
+		}
+
+		bool blend_enabled_surface_2() const
+		{
+			return !!(registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x4);
+		}
+
+		bool blend_enabled_surface_3() const
+		{
+			return !!(registers[NV4097_SET_BLEND_ENABLE_MRT] & 0x8);
+		}
+
+		bool line_smooth_enabled() const
+		{
+			return !!registers[NV4097_SET_LINE_SMOOTH_ENABLE];
+		}
+
+		bool poly_offset_point_enabled() const
+		{
+			return !!registers[NV4097_SET_POLY_OFFSET_POINT_ENABLE];
+		}
+
+		bool poly_offset_line_enabled() const
+		{
+			return !!registers[NV4097_SET_POLY_OFFSET_LINE_ENABLE];
+		}
+
+		bool poly_offset_fill_enabled() const
+		{
+			return !!registers[NV4097_SET_POLY_OFFSET_FILL_ENABLE];
+		}
+
+		f32 poly_offset_scale() const
+		{
+			return (f32&)registers[NV4097_SET_POLYGON_OFFSET_SCALE_FACTOR];
+		}
+
+		f32 poly_offset_bias() const
+		{
+			return (f32&)registers[NV4097_SET_POLYGON_OFFSET_BIAS];
+		}
+
+		bool cull_face_enabled() const
+		{
+			return !!registers[NV4097_SET_CULL_FACE_ENABLE];
+		}
+
+		bool poly_smooth_enabled() const
+		{
+			return !!registers[NV4097_SET_POLY_SMOOTH_ENABLE];
+		}
+
+		bool two_sided_stencil_test_enabled() const
+		{
+			return !!registers[NV4097_SET_TWO_SIDED_STENCIL_TEST_ENABLE];
+		}
+
+		comparaison_function depth_func() const
+		{
+			return to_comparaison_function(registers[NV4097_SET_DEPTH_FUNC] & 0xffff);
+		}
+
+		comparaison_function stencil_func() const
+		{
+			return to_comparaison_function(registers[NV4097_SET_STENCIL_FUNC] & 0xffff);
+		}
+
+		comparaison_function back_stencil_func() const
+		{
+			return to_comparaison_function(registers[NV4097_SET_BACK_STENCIL_FUNC] & 0xffff);
+		}
+
+		u8 stencil_func_ref() const
+		{
+			return registers[NV4097_SET_STENCIL_FUNC_REF];
+		}
+
+		u8 back_stencil_func_ref() const
+		{
+			return registers[NV4097_SET_BACK_STENCIL_FUNC_REF];
+		}
+
+		u8 stencil_func_mask() const
+		{
+			return registers[NV4097_SET_STENCIL_FUNC_MASK];
+		}
+
+		u8 back_stencil_func_mask() const
+		{
+			return registers[NV4097_SET_BACK_STENCIL_FUNC_MASK];
+		}
+
+		rsx::stencil_op stencil_op_fail() const
+		{
+			return to_stencil_op(registers[NV4097_SET_STENCIL_OP_FAIL] & 0xffff);
+		}
+
+		rsx::stencil_op stencil_op_zfail() const
+		{
+			return to_stencil_op(registers[NV4097_SET_STENCIL_OP_ZFAIL] & 0xffff);
+		}
+
+		rsx::stencil_op stencil_op_zpass() const
+		{
+			return to_stencil_op(registers[NV4097_SET_STENCIL_OP_ZPASS] & 0xffff);
+		}
+
+		rsx::stencil_op back_stencil_op_fail() const
+		{
+			return to_stencil_op(registers[NV4097_SET_BACK_STENCIL_OP_FAIL] & 0xffff);
+		}
+
+		rsx::stencil_op back_stencil_op_zfail() const
+		{
+			return to_stencil_op(registers[NV4097_SET_BACK_STENCIL_OP_ZFAIL] & 0xffff);
+		}
+
+		rsx::stencil_op back_stencil_op_zpass() const
+		{
+			return to_stencil_op(registers[NV4097_SET_BACK_STENCIL_OP_ZPASS] & 0xffff);
+		}
+
+		u8 blend_color_8b_r() const
+		{
+			return registers[NV4097_SET_BLEND_COLOR] & 0xff;
+		}
+
+		u8 blend_color_8b_g() const
+		{
+			return (registers[NV4097_SET_BLEND_COLOR] >> 8) & 0xff;
+		}
+
+		u8 blend_color_8b_b() const
+		{
+			return (registers[NV4097_SET_BLEND_COLOR] >> 16) & 0xff;
+		}
+
+		u8 blend_color_8b_a() const
+		{
+			return (registers[NV4097_SET_BLEND_COLOR] >> 24) & 0xff;
+		}
+
+		u16 blend_color_16b_r() const
+		{
+			return registers[NV4097_SET_BLEND_COLOR] & 0xffff;
+		}
+
+		u16 blend_color_16b_g() const
+		{
+			return (registers[NV4097_SET_BLEND_COLOR] >> 16) & 0xffff;
+		}
+
+		u16 blend_color_16b_b() const
+		{
+			return registers[NV4097_SET_BLEND_COLOR2] & 0xffff;
+		}
+
+		u16 blend_color_16b_a() const
+		{
+			return (registers[NV4097_SET_BLEND_COLOR2] >> 16) & 0xffff;
+		}
+
+		blend_equation blend_equation_rgb() const
+		{
+			return to_blend_equation(registers[NV4097_SET_BLEND_EQUATION] & 0xffff);
+		}
+
+		blend_equation blend_equation_a() const
+		{
+			return to_blend_equation((registers[NV4097_SET_BLEND_EQUATION] >> 16) & 0xffff);
+		}
+
+		blend_factor blend_func_sfactor_rgb() const
+		{
+			return to_blend_factor(registers[NV4097_SET_BLEND_FUNC_SFACTOR] & 0xffff);
+		}
+
+		blend_factor blend_func_sfactor_a() const
+		{
+			return to_blend_factor((registers[NV4097_SET_BLEND_FUNC_SFACTOR] >> 16) & 0xffff);
+		}
+
+		blend_factor blend_func_dfactor_rgb() const
+		{
+			return to_blend_factor(registers[NV4097_SET_BLEND_FUNC_DFACTOR] & 0xffff);
+		}
+
+		blend_factor blend_func_dfactor_a() const
+		{
+			return to_blend_factor((registers[NV4097_SET_BLEND_FUNC_DFACTOR] >> 16) & 0xffff);
+		}
+
+		logic_op logic_operation() const
+		{
+			return to_logic_op(registers[NV4097_SET_LOGIC_OP]);
+		}
+
+		user_clip_plane_op clip_plane_0_enabled() const
+		{
+			return to_user_clip_plane_op(registers[NV4097_SET_USER_CLIP_PLANE_CONTROL] & 0xf);
+		}
+
+		user_clip_plane_op clip_plane_1_enabled() const
+		{
+			return to_user_clip_plane_op((registers[NV4097_SET_USER_CLIP_PLANE_CONTROL] >> 4) & 0xf);
+		}
+
+		user_clip_plane_op clip_plane_2_enabled() const
+		{
+			return to_user_clip_plane_op((registers[NV4097_SET_USER_CLIP_PLANE_CONTROL] >> 8) & 0xf);
+		}
+
+		user_clip_plane_op clip_plane_3_enabled() const
+		{
+			return to_user_clip_plane_op((registers[NV4097_SET_USER_CLIP_PLANE_CONTROL] >> 12) & 0xf);
+		}
+
+		user_clip_plane_op clip_plane_4_enabled() const
+		{
+			return to_user_clip_plane_op((registers[NV4097_SET_USER_CLIP_PLANE_CONTROL] >> 16) & 0xf);
+		}
+
+		user_clip_plane_op clip_plane_5_enabled() const
+		{
+			return to_user_clip_plane_op((registers[NV4097_SET_USER_CLIP_PLANE_CONTROL] >> 20) & 0xf);
+		}
+
+		front_face front_face_mode() const
+		{
+			return to_front_face(registers[NV4097_SET_FRONT_FACE] & 0xffff);
+		}
+
+		cull_face cull_face_mode() const
+		{
+			return to_cull_face(registers[NV4097_SET_CULL_FACE] & 0xffff);
+		}
+
+		f32 line_width() const
+		{
+			u32 line_width = registers[NV4097_SET_LINE_WIDTH];
+			return (line_width >> 3) + (line_width & 7) / 8.f;
+		}
+
+		u8 alpha_ref() const
+		{
+			return registers[NV4097_SET_ALPHA_REF] & 0xff;
+		}
+
+		surface_target surface_color_target()
+		{
+			return rsx::to_surface_target(registers[NV4097_SET_SURFACE_COLOR_TARGET] & 0xff);
+		}
+
+		u16 surface_clip_origin_x() const
+		{
+			return (registers[NV4097_SET_SURFACE_CLIP_HORIZONTAL] & 0xffff);
+		}
+
+		u16 surface_clip_width() const
+		{
+			return ((registers[NV4097_SET_SURFACE_CLIP_HORIZONTAL] >> 16) & 0xffff);
+		}
+
+		u16 surface_clip_origin_y() const
+		{
+			return (registers[NV4097_SET_SURFACE_CLIP_VERTICAL] & 0xffff);
+		}
+
+		u16 surface_clip_height() const
+		{
+			return ((registers[NV4097_SET_SURFACE_CLIP_VERTICAL] >> 16) & 0xffff);
+		}
+
+		u32 surface_a_offset() const
+		{
+			return registers[NV4097_SET_SURFACE_COLOR_AOFFSET];
+		}
+
+		u32 surface_b_offset() const
+		{
+			return registers[NV4097_SET_SURFACE_COLOR_BOFFSET];
+		}
+
+		u32 surface_c_offset() const
+		{
+			return registers[NV4097_SET_SURFACE_COLOR_COFFSET];
+		}
+
+		u32 surface_d_offset() const
+		{
+			return registers[NV4097_SET_SURFACE_COLOR_DOFFSET];
+		}
+
+		u32 surface_a_pitch() const
+		{
+			return registers[NV4097_SET_SURFACE_PITCH_A];
+		}
+
+		u32 surface_b_pitch() const
+		{
+			return registers[NV4097_SET_SURFACE_PITCH_B];
+		}
+
+		u32 surface_c_pitch() const
+		{
+			return registers[NV4097_SET_SURFACE_PITCH_C];
+		}
+
+		u32 surface_d_pitch() const
+		{
+			return registers[NV4097_SET_SURFACE_PITCH_D];
+		}
+
+		u32 surface_a_dma() const
+		{
+			return registers[NV4097_SET_CONTEXT_DMA_COLOR_A];
+		}
+
+		u32 surface_b_dma() const
+		{
+			return registers[NV4097_SET_CONTEXT_DMA_COLOR_B];
+		}
+
+		u32 surface_c_dma() const
+		{
+			return registers[NV4097_SET_CONTEXT_DMA_COLOR_C];
+		}
+
+		u32 surface_d_dma() const
+		{
+			return registers[NV4097_SET_CONTEXT_DMA_COLOR_D];
+		}
+
+		u32 surface_z_offset() const
+		{
+			return registers[NV4097_SET_SURFACE_ZETA_OFFSET];
+		}
+
+		u32 surface_z_pitch() const
+		{
+			return registers[NV4097_SET_SURFACE_PITCH_Z];
+		}
+
+		u32 surface_z_dma() const
+		{
+			return registers[NV4097_SET_CONTEXT_DMA_ZETA];
+		}
+
+		f32 viewport_scale_x() const
+		{
+			return (f32&)registers[NV4097_SET_VIEWPORT_SCALE];
+		}
+
+		f32 viewport_scale_y() const
+		{
+			return (f32&)registers[NV4097_SET_VIEWPORT_SCALE + 1];
+		}
+
+		f32 viewport_scale_z() const
+		{
+			return (f32&)registers[NV4097_SET_VIEWPORT_SCALE + 2];
+		}
+
+		f32 viewport_scale_w() const
+		{
+			return (f32&)registers[NV4097_SET_VIEWPORT_SCALE + 3];
+		}
+
+		f32 viewport_offset_x() const
+		{
+			return (f32&)registers[NV4097_SET_VIEWPORT_OFFSET];
+		}
+
+		f32 viewport_offset_y() const
+		{
+			return (f32&)registers[NV4097_SET_VIEWPORT_OFFSET + 1];
+		}
+
+		f32 viewport_offset_z() const
+		{
+			return (f32&)registers[NV4097_SET_VIEWPORT_OFFSET + 2];
+		}
+
+		f32 viewport_offset_w() const
+		{
+			return (f32&)registers[NV4097_SET_VIEWPORT_OFFSET + 3];
+		}
+
+		bool two_side_light_en() const
+		{
+			return !!registers[NV4097_SET_TWO_SIDE_LIGHT_EN];
+		}
+
+		rsx::fog_mode fog_equation() const
+		{
+			return rsx::to_fog_mode(registers[NV4097_SET_FOG_MODE]);
+		}
+
+		rsx::comparaison_function alpha_func() const
+		{
+			return to_comparaison_function(registers[NV4097_SET_ALPHA_FUNC]);
+		}
+
+		u16 vertex_attrib_input_mask() const
+		{
+			return registers[NV4097_SET_VERTEX_ATTRIB_INPUT_MASK] & 0xffff;
+		}
+
+		u16 frequency_divider_operation_mask() const
+		{
+			return registers[NV4097_SET_FREQUENCY_DIVIDER_OPERATION] & 0xffff;
+		}
+
+		u32 vertex_attrib_output_mask() const
+		{
+			return registers[NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK];
+		}
+
+		// Quite opaque
+		u32 shader_control() const
+		{
+			return registers[NV4097_SET_SHADER_CONTROL];
+		}
+
+		surface_color_format surface_color() const
+		{
+			return to_surface_color_format(registers[NV4097_SET_SURFACE_FORMAT] & 0x1f);
+		}
+
+		surface_depth_format surface_depth_fmt() const
+		{
+			return to_surface_depth_format((registers[NV4097_SET_SURFACE_FORMAT] >> 5) & 0x7);
+		}
+
+		surface_antialiasing surface_antialias() const
+		{
+			return  to_surface_antialiasing((registers[NV4097_SET_SURFACE_FORMAT] >> 12) & 0xf);
+		}
+
+		u8 surface_log2_height() const
+		{
+			return (registers[NV4097_SET_SURFACE_FORMAT] >> 24) & 0xff;
+		}
+
+		u8 surface_log2_width() const
+		{
+			return (registers[NV4097_SET_SURFACE_FORMAT] >> 16) & 0xff;
+		}
+
+		u32 vertex_data_base_offset() const
+		{
+			return registers[NV4097_SET_VERTEX_DATA_BASE_OFFSET];
+		}
+
+		u32 index_array_address() const
+		{
+			return registers[NV4097_SET_INDEX_ARRAY_ADDRESS];
+		}
+
+		u8 index_array_location() const
+		{
+			return registers[NV4097_SET_INDEX_ARRAY_DMA] & 0xf;
+		}
+
+		u32 vertex_data_base_index() const
+		{
+			return registers[NV4097_SET_VERTEX_DATA_BASE_INDEX];
+		}
+
+		u32 shader_program_address() const
+		{
+			return registers[NV4097_SET_SHADER_PROGRAM];
+		}
+
+		u32 transform_program_start() const
+		{
+			return registers[NV4097_SET_TRANSFORM_PROGRAM_START];
+		}
+
+		primitive_type primitive_mode() const
+		{
+			return to_primitive_type(registers[NV4097_SET_BEGIN_END]);
+		}
+
+		u32 semaphore_offset_406e() const
+		{
+			return registers[NV406E_SEMAPHORE_OFFSET];
+		}
+
+		u32 semaphore_offset_4097() const
+		{
+			return registers[NV4097_SET_SEMAPHORE_OFFSET];
+		}
+
+		blit_engine::context_dma context_dma_report() const
+		{
+			return blit_engine::to_context_dma(registers[NV4097_SET_CONTEXT_DMA_REPORT]);
+		}
+
+		blit_engine::transfer_operation blit_engine_operation() const
+		{
+			return blit_engine::to_transfer_operation(registers[NV3089_SET_OPERATION]);
+		}
+
+		/// TODO: find the purpose vs in/out equivalents
+		u16 blit_engine_clip_x() const
+		{
+			return registers[NV3089_CLIP_POINT] & 0xffff;
+		}
+
+		u16 blit_engine_clip_y() const
+		{
+			return registers[NV3089_CLIP_POINT] >> 16;
+		}
+
+		u16 blit_engine_clip_width() const
+		{
+			return registers[NV3089_CLIP_SIZE] & 0xffff;
+		}
+
+		u16 blit_engine_clip_height() const
+		{
+			return registers[NV3089_CLIP_SIZE] >> 16;
+		}
+
+		u16 blit_engine_output_x() const
+		{
+			return registers[NV3089_IMAGE_OUT_POINT] & 0xffff;
+		}
+
+		u16 blit_engine_output_y() const
+		{
+			return registers[NV3089_IMAGE_OUT_POINT] >> 16;
+		}
+
+		u16 blit_engine_output_width() const
+		{
+			return registers[NV3089_IMAGE_OUT_SIZE] & 0xffff;
+		}
+
+		u16 blit_engine_output_height() const
+		{
+			return registers[NV3089_IMAGE_OUT_SIZE] >> 16;
+		}
+
+		// there is no x/y ?
+		u16 blit_engine_input_width() const
+		{
+			return registers[NV3089_IMAGE_IN_SIZE] & 0xffff;
+		}
+
+		u16 blit_engine_input_height() const
+		{
+			return registers[NV3089_IMAGE_IN_SIZE] >> 16;
+		}
+
+		u16 blit_engine_input_pitch() const
+		{
+			return registers[NV3089_IMAGE_IN_FORMAT] & 0xffff;
+		}
+
+		blit_engine::transfer_origin blit_engine_input_origin() const
+		{
+			return blit_engine::to_transfer_origin((registers[NV3089_IMAGE_IN_FORMAT] >> 16) & 0xff);
+		}
+
+		blit_engine::transfer_interpolator blit_engine_input_inter() const
+		{
+			return blit_engine::to_transfer_interpolator((registers[NV3089_IMAGE_IN_FORMAT] >> 24) & 0xff);
+		}
+
+		blit_engine::transfer_source_format blit_engine_src_color_format() const
+		{
+			return blit_engine::to_transfer_source_format(registers[NV3089_SET_COLOR_FORMAT]);
+		}
+
+		// ???
+		f32 blit_engine_in_x() const
+		{
+			return (registers[NV3089_IMAGE_IN] & 0xffff) / 16.f;
+		}
+
+		// ???
+		f32 blit_engine_in_y() const
+		{
+			return (registers[NV3089_IMAGE_IN] >> 16) / 16.f;
+		}
+
+		u32 blit_engine_input_offset() const
+		{
+			return registers[NV3089_IMAGE_IN_OFFSET];
+		}
+
+		u32 blit_engine_input_location() const
+		{
+			return registers[NV3089_SET_CONTEXT_DMA_IMAGE];
+		}
+
+		blit_engine::context_surface blit_engine_context_surface() const
+		{
+			return blit_engine::to_context_surface(registers[NV3089_SET_CONTEXT_SURFACE]);
+		}
+
+		u32 blit_engine_output_location_nv3062() const
+		{
+			return registers[NV3062_SET_CONTEXT_DMA_IMAGE_DESTIN];
+		}
+
+		u32 blit_engine_output_offset_nv3062() const
+		{
+			return registers[NV3062_SET_OFFSET_DESTIN];
+		}
+
+		blit_engine::transfer_destination_format blit_engine_nv3062_color_format() const
+		{
+			return rsx::blit_engine::to_transfer_destination_format(registers[NV3062_SET_COLOR_FORMAT]);
+		}
+
+		u16 blit_engine_output_alignment_nv3062() const
+		{
+			return registers[NV3062_SET_PITCH] & 0xffff;
+		}
+
+		u16 blit_engine_output_pitch_nv3062() const
+		{
+			return registers[NV3062_SET_PITCH] >> 16;
+		}
+
+		u32 blit_engine_nv309E_location() const
+		{
+			return registers[NV309E_SET_CONTEXT_DMA_IMAGE];
+		}
+
+		u32 blit_engine_nv309E_offset() const
+		{
+			return registers[NV309E_SET_OFFSET];
+		}
+
+		blit_engine::transfer_destination_format blit_engine_output_format_nv309E() const
+		{
+			return rsx::blit_engine::to_transfer_destination_format(registers[NV309E_SET_FORMAT]);
+		}
+
+		u32 blit_engine_ds_dx() const
+		{
+			return registers[NV3089_DS_DX];
+		}
+
+		u32 blit_engine_dt_dy() const
+		{
+			return registers[NV3089_DT_DY];
+		}
+
+		u8 nv309e_sw_width_log2() const
+		{
+			return (registers[NV309E_SET_FORMAT] >> 16) & 0xff;
+		}
+
+		u8 nv309e_sw_height_log2() const
+		{
+			return (registers[NV309E_SET_FORMAT] >> 24) & 0xff;
+		}
+
+		u32 nv0039_input_pitch() const
+		{
+			return registers[NV0039_PITCH_IN];
+		}
+
+		u32 nv0039_output_pitch() const
+		{
+			return registers[NV0039_PITCH_OUT];
+		}
+
+		u32 nv0039_line_length() const
+		{
+			return registers[NV0039_LINE_LENGTH_IN];
+		}
+
+		u32 nv0039_line_count() const
+		{
+			return registers[NV0039_LINE_COUNT];
+		}
+
+		u8 nv0039_output_format() const
+		{
+			return (registers[NV0039_FORMAT] >> 8) & 0xff;
+		}
+
+		u8 nv0039_input_format() const
+		{
+			return registers[NV0039_FORMAT] & 0xff;
+		}
+
+		u32 nv0039_output_offset() const
+		{
+			return registers[NV0039_OFFSET_OUT];
+		}
+
+		u32 nv0039_output_location()
+		{
+			return registers[NV0039_SET_CONTEXT_DMA_BUFFER_OUT];
+		}
+
+		u32 nv0039_input_offset() const
+		{
+			return registers[NV0039_OFFSET_IN];
+		}
+
+		u32 nv0039_input_location() const
+		{
+			return registers[NV0039_SET_CONTEXT_DMA_BUFFER_IN];
+		}
+
+		void commit_4_transform_program_instructions(u32 index)
+		{
+			u32& load =registers[NV4097_SET_TRANSFORM_PROGRAM_LOAD];
+
+			transform_program[load * 4] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4];
+			transform_program[load * 4 + 1] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 1];
+			transform_program[load * 4 + 2] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 2];
+			transform_program[load * 4 + 3] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 3];
+			load++;
+		}
+
+		void set_transform_constant(u32 index, u32 constant)
+		{
+			u32 load = registers[NV4097_SET_TRANSFORM_CONSTANT_LOAD];
+			u32 reg = index / 4;
+			u32 subreg = index % 4;
+			transform_constants[load + reg].rgba[subreg] = (f32&)constant;
+		}
+
+		u16 nv308a_x() const
+		{
+			return registers[NV308A_POINT] & 0xffff;
+		}
+
+		u16 nv308a_y() const
+		{
+			return registers[NV308A_POINT] >> 16;
+		}
+	};
+
 	using rsx_method_t = void(*)(class thread*, u32);
-	extern u32 method_registers[0x10000 >> 2];
+	extern rsx_state method_registers;
 	extern rsx_method_t methods[0x10000 >> 2];
 }

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -70,14 +70,12 @@ namespace rsx
 
 	void fill_window_matrix(void *dest, bool transpose)
 	{
-		u32 shader_window = method_registers[NV4097_SET_SHADER_WINDOW];
+		u16 height = method_registers.shader_window_height();
+		window_origin origin = method_registers.shader_window_origin();
+		window_pixel_center pixelCenter = method_registers.shader_window_pixel();
 
-		u16 height = shader_window & 0xfff;
-		window_origin origin = to_window_origin((shader_window >> 12) & 0xf);
-		window_pixel_center pixelCenter = to_window_pixel_center(shader_window >> 16);
-
-		f32 offset_x = f32(method_registers[NV4097_SET_WINDOW_OFFSET] & 0xffff);
-		f32 offset_y = f32(method_registers[NV4097_SET_WINDOW_OFFSET] >> 16);
+		f32 offset_x = f32(method_registers.shader_window_offset_x());
+		f32 offset_y = f32(method_registers.shader_window_offset_y());
 		f32 scale_y = 1.0;
 
 		if (origin == window_origin::bottom)
@@ -97,13 +95,13 @@ namespace rsx
 
 	void fill_viewport_matrix(void *buffer, bool transpose)
 	{
-		f32 offset_x = (f32&)method_registers[NV4097_SET_VIEWPORT_OFFSET + 0];
-		f32 offset_y = (f32&)method_registers[NV4097_SET_VIEWPORT_OFFSET + 1];
-		f32 offset_z = (f32&)method_registers[NV4097_SET_VIEWPORT_OFFSET + 2];
+		f32 offset_x = method_registers.viewport_offset_x();
+		f32 offset_y = method_registers.viewport_offset_y();
+		f32 offset_z = method_registers.viewport_offset_z();
 
-		f32 scale_x = (f32&)method_registers[NV4097_SET_VIEWPORT_SCALE + 0];
-		f32 scale_y = (f32&)method_registers[NV4097_SET_VIEWPORT_SCALE + 1];
-		f32 scale_z = (f32&)method_registers[NV4097_SET_VIEWPORT_SCALE + 2];
+		f32 scale_x = method_registers.viewport_scale_x();
+		f32 scale_y = method_registers.viewport_scale_y();
+		f32 scale_z = method_registers.viewport_scale_z();
 
 		fill_scale_offset_matrix(buffer, transpose, offset_x, offset_y, offset_z, scale_x, scale_y, scale_z);
 	}

--- a/rpcs3/Emu/RSX/rsx_vertex_data.h
+++ b/rpcs3/Emu/RSX/rsx_vertex_data.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "GCM.h"
+#include "Utilities/types.h"
+
+namespace rsx
+{
+
+struct data_array_format_info
+{
+private:
+	u8 index;
+	std::array<u32, 0x10000 / 4> &registers;
+public:
+	u16 frequency = 0;
+	u8 stride = 0;
+	u8 size = 0;
+	vertex_base_type type = vertex_base_type::f;
+
+
+	data_array_format_info(u8 idx, std::array<u32, 0x10000 / 4> &r) : index(idx), registers(r)
+	{}
+
+	data_array_format_info() = delete;
+
+	void unpack_array(u32 data_array_format)
+	{
+		frequency = data_array_format >> 16;
+		stride = (data_array_format >> 8) & 0xff;
+		size = (data_array_format >> 4) & 0xf;
+		type = to_vertex_base_type(data_array_format & 0xf);
+	}
+
+	u32 offset() const
+	{
+		return registers[NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + index];
+	}
+};
+
+}

--- a/rpcs3/Gui/RSXDebugger.cpp
+++ b/rpcs3/Gui/RSXDebugger.cpp
@@ -370,13 +370,13 @@ void RSXDebugger::OnClickBuffer(wxMouseEvent& event)
 	if (event.GetId() == p_buffer_stencil->GetId()) display_buffer(this, stencil_img);
 	if (event.GetId() == p_buffer_tex->GetId())
 	{
-		u8 location = render->textures[m_cur_texture].location();
+/*		u8 location = render->textures[m_cur_texture].location();
 		if(location <= 1 && vm::check_addr(rsx::get_address(render->textures[m_cur_texture].offset(), location))
 			&& render->textures[m_cur_texture].width() && render->textures[m_cur_texture].height())
 			MemoryViewerPanel::ShowImage(this,
 				rsx::get_address(render->textures[m_cur_texture].offset(), location), 1,
 				render->textures[m_cur_texture].width(),
-				render->textures[m_cur_texture].height(), false);
+				render->textures[m_cur_texture].height(), false);*/
 	}
 
 #undef SHOW_BUFFER
@@ -725,7 +725,7 @@ void RSXDebugger::GetBuffers()
 	}
 
 	// Draw Texture
-	if(!render->textures[m_cur_texture].enabled())
+/*	if(!render->textures[m_cur_texture].enabled())
 		return;
 
 	u32 offset = render->textures[m_cur_texture].offset();
@@ -752,7 +752,7 @@ void RSXDebugger::GetBuffers()
 
 	wxImage img(width, height, buffer);
 	wxClientDC dc_canvas(p_buffer_tex);
-	dc_canvas.DrawBitmap(img.Scale(m_text_width, m_text_height), 0, 0, false);
+	dc_canvas.DrawBitmap(img.Scale(m_text_width, m_text_height), 0, 0, false);*/
 }
 
 void RSXDebugger::GetFlags()
@@ -823,7 +823,7 @@ void RSXDebugger::GetTexture()
 
 	for(uint i=0; i<rsx::limits::textures_count; ++i)
 	{
-		if(render->textures[i].enabled())
+/*		if(render->textures[i].enabled())
 		{
 			m_list_texture->InsertItem(i, wxString::Format("%d", i));
 			u8 location = render->textures[i].location();
@@ -848,7 +848,7 @@ void RSXDebugger::GetTexture()
 				render->textures[i].height()));
 
 			m_list_texture->SetItemBackgroundColour(i, wxColour(m_cur_texture == i ? "Wheat" : "White"));
-		}
+		}*/
 	}
 }
 

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -600,6 +600,7 @@
     <ClInclude Include="Emu\DbgCommand.h" />
     <ClInclude Include="Emu\Memory\wait_engine.h" />
     <ClInclude Include="Emu\RSX\rsx_cache.h" />
+    <ClInclude Include="Emu\RSX\rsx_vertex_data.h" />
     <ClInclude Include="Emu\VFS.h" />
     <ClInclude Include="Emu\GameInfo.h" />
     <ClInclude Include="Emu\IdManager.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1687,5 +1687,8 @@
     <ClInclude Include="..\Utilities\JIT.h">
       <Filter>Utilities</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\rsx_vertex_data.h">
+      <Filter>Emu\GPU\RSX</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR factorises hides rsx::method_registers array inside a new rsx_state struct that exposes state through function member in a higher level way and more strongly typed. It basically removes all the bit shift, bit mask, reinterpret cast that were spread throughout backends.

While it improves code maintainability the longterm goal is to have a proper complete rsx state structure that can be copied and serialised for debug purpose. Having a single structure were every piece of rendering code interacts is a first step in this direction.
 The next one is to replace the array inside rsx_state with discrete data member to directly store the decoded data instead of storing the register value and then decode it when retrieving the data. This should translate to a more compact structure.