### PR TITLE
GUI: improve prx library selection

### DIFF
--- a/rpcs3/Gui/SettingsDialog.cpp
+++ b/rpcs3/Gui/SettingsDialog.cpp
@@ -16,6 +16,7 @@
 
 #include <set>
 #include <unordered_set>
+#include <algorithm>
 
 // Node location
 using cfg_location = std::vector<const char*>;
@@ -313,7 +314,14 @@ SettingsDialog::SettingsDialog(wxWindow* parent)
 
 	std::vector<std::string> lle_module_list;
 	{
+		// Sort string vector alphabetically
+		static const auto sort_string_vector = [](std::vector<std::string>& vec)
+		{
+			std::sort(vec.begin(), vec.end(), [](const std::string &str1, const std::string &str2) { return str1 < str2; });
+		};
+
 		auto&& data = loaded["Core"]["Load libraries"].as<std::vector<std::string>, std::initializer_list<std::string>>({});
+		sort_string_vector(data);
 
 		// List selected modules first
 		for (const auto& unk : data)
@@ -325,16 +333,26 @@ SettingsDialog::SettingsDialog(wxWindow* parent)
 		const std::string& lle_dir = vfs::get("/dev_flash/sys/external/"); // TODO
 
 		std::unordered_set<std::string> set(data.begin(), data.end());
+		std::vector<std::string> lle_module_list_unselected;
 
 		for (const auto& prxf : fs::dir(lle_dir))
 		{
 			// List found unselected modules
 			if (!prxf.is_directory && ppu_prx_loader(fs::file(lle_dir + prxf.name)) == elf_error::ok && !set.count(prxf.name))
 			{
-				chbox_list_core_lle->Check(chbox_list_core_lle->Append(prxf.name), false);
-				lle_module_list.push_back(prxf.name);
+				lle_module_list_unselected.push_back(prxf.name);
 			}
 		}
+
+		sort_string_vector(lle_module_list_unselected);
+
+		for (const auto& prxf : lle_module_list_unselected)
+		{
+			chbox_list_core_lle->Check(chbox_list_core_lle->Append(prxf), false);
+			lle_module_list.push_back(prxf);
+		}
+
+		lle_module_list_unselected.clear();
 	}
 
 	radiobox_pad_helper ppu_decoder_modes({ "Core", "PPU Decoder" });
@@ -364,7 +382,7 @@ SettingsDialog::SettingsDialog(wxWindow* parent)
 	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "Video", "Debug output" }, chbox_gs_debug_output));
 	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "Video", "3D Monitor" }, chbox_gs_3dmonitor));
 	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "Video", "Debug overlay" }, chbox_gs_overlay));
-	
+
 	pads.emplace_back(std::make_unique<combobox_pad>(cfg_location{ "Audio", "Renderer" }, cbox_audio_out));
 	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "Audio", "Dump to file" }, chbox_audio_dump));
 	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "Audio", "Convert to 16 bit" }, chbox_audio_conv));
@@ -493,7 +511,7 @@ SettingsDialog::SettingsDialog(wxWindow* parent)
 	s_b_panel->Add(new wxButton(this, wxID_OK), wxSizerFlags().Border(wxALL, 5).Bottom());
 	s_b_panel->Add(new wxButton(this, wxID_CANCEL), wxSizerFlags().Border(wxALL, 5).Bottom());
 
-	// Resize panels 
+	// Resize panels
 	SetSizerAndFit(s_subpanel_core, false);
 	SetSizerAndFit(s_subpanel_graphics, false);
 	SetSizerAndFit(s_subpanel_io, false);

--- a/rpcs3/Gui/SettingsDialog.h
+++ b/rpcs3/Gui/SettingsDialog.h
@@ -4,4 +4,11 @@ class SettingsDialog : public wxDialog
 {
 public:
 	SettingsDialog(wxWindow* parent);
+
+private:
+	wxCheckListBox* chbox_list_core_lle;
+
+	void OnModuleListItemToggled(wxCommandEvent& event);
+	void OnSearchBoxTextChanged(wxCommandEvent& event);
+	std::map<std::string, bool> lle_module_list;
 };


### PR DESCRIPTION
Sorts the libraries in the settings dialog alphabetically, so they are easier to find.
Sorts selected and unselected modules alphabetically seperatly.

Also adds a search box, finally. :smile: 

EDIT: The per game config was removed from this PR.

--

This code makes sure that all the libraries are always sorted in alphabetically order on all operating systems and filesystems.

--

![screenshot_20160705_000513](https://cloud.githubusercontent.com/assets/13280758/16570389/4d3d7974-4244-11e6-938d-f1dcafad2a00.png)
![screenshot_20160705_000522](https://cloud.githubusercontent.com/assets/13280758/16570391/4e19da2c-4244-11e6-8fc7-ca2633416c37.png)
![screenshot_20160705_000534](https://cloud.githubusercontent.com/assets/13280758/16570393/4f60a794-4244-11e6-968c-d71ef227c244.png)
