### PR TITLE
Emu: per game/ELF file configuration and cache functionality

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1,4 +1,5 @@
 #include "File.h"
+#include "Hash.h"
 #include "StrFmt.h"
 #include "Macro.h"
 #include "SharedMutex.h"
@@ -1156,6 +1157,45 @@ const std::string& fs::get_config_dir()
 	}();
 
 	return s_dir;
+}
+
+std::string fs::get_data_dir(const std::string& elf_path, const std::string& title_id)
+{
+	static const std::string s_dir = []
+	{
+		std::string dir = get_config_dir();
+		dir += "/data/";
+
+		if (!is_dir(dir) && !create_path(dir))
+		{
+			return get_config_dir();
+		}
+
+		return dir;
+	}();
+
+	std::string base_dir = "/" + hash::GetPathHashWithFilename(elf_path, 20) + "/";
+
+	if (!title_id.empty())
+	{
+		// ensure the title id has no dash, the IDs from the GameViewer for example have a dashes in it
+		std::string _title_id = title_id;
+		_title_id.erase(std::remove(_title_id.begin(), _title_id.end(), '-'), _title_id.end());
+
+		base_dir = "/" + _title_id + base_dir;
+		_title_id.clear();
+	}
+
+	base_dir = s_dir + "/" + base_dir;
+
+	create_path(base_dir);
+
+	// create a text file which holds the location of the source file
+	fs::file file(base_dir + "/info.txt", fs::read + fs::write + fs::create);
+	file.write(elf_path);
+	file.close();
+
+	return base_dir;
 }
 
 const std::string& fs::get_executable_dir()

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -436,6 +436,9 @@ namespace fs
 	// Get configuration directory
 	const std::string& get_config_dir();
 
+	// Get data directory of given ELF file, optimally include the title id in that path
+	std::string get_data_dir(const std::string& elf_path, const std::string& title_id = std::string());
+
 	// Get executable directory
 	const std::string& get_executable_dir();
 

--- a/Utilities/Hash.cpp
+++ b/Utilities/Hash.cpp
@@ -1,0 +1,89 @@
+#include "stdafx.h"
+#include "Hash.h"
+#include <sstream>
+#include <iomanip>
+
+#include "../rpcs3/Crypto/sha1.h"
+#include <iostream>
+namespace hash
+{
+
+std::string SHA1(const std::string& str)
+{
+	int len = str.size();
+
+	unsigned char hash[20];
+
+	std::unique_ptr<unsigned char[]> input(new unsigned char[len+1]);
+	::memcpy(input.get(), str.c_str(), len);
+
+	sha1(input.get(), len, hash);
+
+	std::stringstream res;
+	res << std::hex;
+	for (int i = 0; i < 20; ++i)
+	{
+		res << ((hash[i] & 0x000000F0) >> 4)
+		    << (hash[i] & 0x0000000F);
+	}
+
+	return res.str();
+}
+
+std::string GetPathHashWithFilename(const std::string& file_path, std::size_t len)
+{
+	std::size_t path_end_pos = file_path.find_last_of('/');
+
+	// no path detected, hash filename itself instead
+	if (path_end_pos == std::string::npos)
+	{
+		std::size_t str_size = file_path.size();
+
+		if (len != 0)
+		{
+			if (str_size < len)
+			{
+				len = str_size;
+			}
+		}
+
+		return SHA1(file_path.substr(str_size - len)) + '-' + file_path;
+	}
+
+	// filename found, extract path for hashing
+	else
+	{
+		std::string path = file_path.substr(0, path_end_pos);
+		std::string file;
+
+		if (path_end_pos < file_path.size())
+		{
+			file = file_path.substr(path_end_pos + 1);
+		}
+
+		else
+		{
+			file = file_path.substr(path_end_pos);
+		}
+
+		std::size_t str_size = path.size();
+
+		// only path was given, set filename to unknown
+		if (file.empty())
+		{
+			file = "UNKNOWN";
+		}
+
+		if (len != 0)
+		{
+			if (str_size < len)
+			{
+				len = str_size;
+			}
+		}
+
+		return SHA1(path.substr(str_size - len)) + '-' + file;
+	}
+}
+
+}

--- a/Utilities/Hash.h
+++ b/Utilities/Hash.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace hash
+{
+	std::string SHA1(const std::string& str);
+
+	// Get a unique path hash in SHA-1 format with the original filename appended.
+	// len defines the length from the end to the beginning of the path which should be hashed.
+	// A length of zero means hash the whole file path.
+	std::string GetPathHashWithFilename(const std::string& file_path, std::size_t len = 0);
+}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -204,6 +204,15 @@ void Emulator::Load()
 			LOG_NOTICE(LOADER, "Serial: %s", GetTitleID());
 			LOG_NOTICE(LOADER, "");
 
+			// Load game configuration if available
+			std::string game_config = fs::get_data_dir(m_path, m_title_id) + "/config.yml";
+			if (fs::file cfg_file{ game_config })
+			{
+				LOG_NOTICE(LOADER, "Game config: %s", game_config);
+				cfg::root.from_string(cfg_file.to_string());
+			}
+			game_config.clear();
+
 			LOG_NOTICE(LOADER, "Used configuration:\n%s\n", cfg::root.to_string());
 
 			// Mount /dev_bdvd/


### PR DESCRIPTION
Adds a per game and ELF file configuration and cache functionality to the emulator. The SHA-1 hash of the last 20 characters of the file path or game path (including the game id, if any) is used to generate a relative path, the original filename is appended to it.

**Usage**
```
  fs::get_data_dir(file path, title id = optimal)
```

Returns the absolute path where the configuration or cache for the current ELF file or game is stored. The used configuration file is logged in the emulator and works the same way as the current override ```ELF file path + .yml``` method. The main difference is that the configuration is stored in the config directory where it belongs too.

The cache directory function allows to keep cached content (```LLVM.obj```, Shader, and other stuff) for every game to reuse it.

---

**NOTE:** If we ever need to change the character count of 20, this can be easily done by changing just a function call.