### PR TITLE
gl: Fix register attribute access

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -786,6 +786,7 @@ namespace rsx
 			{
 				is_int = is_int_type(rsx::method_registers.register_vertex_info[index].type);
 				result.state.frequency[index] = rsx::method_registers.register_vertex_info[index].frequency;
+				result.state.divider_op |= (1 << index);
 			}
 			else
 			{


### PR DESCRIPTION
Fix for shader access to variables stored in registers.
Fixes https://github.com/RPCS3/rpcs3/issues/1887

This implementation is hacky but I don't want to have to submit changes to the rsx_program_decompiler subproject just to fix a simple flag. It would be better to just have a separate flag that shows a variable is a register value and not an array.