### PR TITLE
gl: bug fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -23,17 +23,6 @@ namespace
 		}
 		throw EXCEPTION("Unknown depth format");
 	}
-	
-	u32 get_front_face_ccw(u32 ffv)
-	{
-		switch (ffv)
-		{
-		default: // Disgaea 3 pass some garbage value at startup, this is needed to survive.
-		case CELL_GCM_CW: return GL_CW;
-		case CELL_GCM_CCW: return GL_CCW;
-		}
-		throw EXCEPTION("Unknown front face value: 0x%X", ffv);
-	}
 }
 
 GLGSRender::GLGSRender() : GSRender(frame_type::OpenGL)
@@ -170,10 +159,14 @@ namespace
 
 	GLenum front_face(rsx::front_face op)
 	{
+		GLenum mask = 0;
+		if (rsx::to_window_origin((rsx::method_registers[NV4097_SET_SHADER_WINDOW] >> 12) & 0xf) == rsx::window_origin::bottom)
+			mask = 1;
+
 		switch (op)
 		{
-		case rsx::front_face::cw: return GL_CW;
-		case rsx::front_face::ccw: return GL_CCW;
+		case rsx::front_face::cw: return GL_CW ^ mask;
+		case rsx::front_face::ccw: return GL_CCW ^ mask;
 		}
 		throw;
 	}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -425,6 +425,11 @@ void GLGSRender::end()
 
 						glProgramUniform4f(m_program->id(), location, 1.f / width, 1.f / height, 1.f / depth, 1.0f);
 					}
+					else
+					{
+						//This shader may have been re-used with a different texture config. Have to reset this
+						glProgramUniform4f(m_program->id(), location, 1.f, 1.f, 1.f, 1.f);
+					}
 				}
 			}
 		}
@@ -457,6 +462,11 @@ void GLGSRender::end()
 						u32 depth = std::max<u32>(rsx::method_registers.fragment_textures[i].depth(), 1);
 
 						glProgramUniform4f(m_program->id(), location, 1.f / width, 1.f / height, 1.f / depth, 1.0f);
+					}
+					else
+					{
+						//This shader may have been re-used with a different texture config. Have to reset this
+						glProgramUniform4f(m_program->id(), location, 1.f, 1.f, 1.f, 1.f);
 					}
 				}
 			}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -497,7 +497,7 @@ void GLGSRender::end()
 			throw std::logic_error("bad index array type");
 		}
 	}
-	else if (!is_primitive_native(draw_mode))
+	else if (!gl::is_primitive_native(draw_mode))
 	{
 		__glcheck glDrawElements(gl::draw_mode(draw_mode), vertex_draw_count, GL_UNSIGNED_SHORT, (GLvoid *)(std::ptrdiff_t)offset_in_index_buffer);
 	}

--- a/rpcs3/Emu/RSX/GL/gl_helpers.cpp
+++ b/rpcs3/Emu/RSX/GL/gl_helpers.cpp
@@ -518,4 +518,24 @@ namespace gl
 	{
 		settings_.apply(*this);
 	}
+
+	bool is_primitive_native(rsx::primitive_type in)
+	{
+		switch (in)
+		{
+		case rsx::primitive_type::points:
+		case rsx::primitive_type::lines:
+		case rsx::primitive_type::line_loop:
+		case rsx::primitive_type::line_strip:
+		case rsx::primitive_type::triangles:
+		case rsx::primitive_type::triangle_strip:
+		case rsx::primitive_type::triangle_fan:
+			return true;
+		case rsx::primitive_type::quads:
+		case rsx::primitive_type::quad_strip:
+		case rsx::primitive_type::polygon:
+			return false;
+		}
+		throw EXCEPTION("unknown primitive type");
+	}
 }

--- a/rpcs3/Emu/RSX/GL/gl_helpers.h
+++ b/rpcs3/Emu/RSX/GL/gl_helpers.h
@@ -1509,6 +1509,7 @@ namespace gl
 	};
 
 	GLenum draw_mode(rsx::primitive_type in);
+	bool   is_primitive_native(rsx::primitive_type in);
 
 	enum class indices_type
 	{


### PR DESCRIPTION
Fixes a few bugs

* Fix face winding when shader origin is flipped (thanks to DHRpcs3 for pointing this out)
* Reset texture coordinate scale in case the same shader was used with a different configuration before
* Native primitive formats vary between backends. (GL and vulkan support triangle fan in the driver while DX12 does not, vulkan does not support line loop)