### PR TITLE
gl: Fix fragment constants streaming

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -780,16 +780,8 @@ static void fill_fragment_state_buffer(glsl_fragment_state_buffer *buffer)
 
 bool GLGSRender::load_program()
 {
-	if (0)
-	{
-		RSXVertexProgram vertex_program = get_current_vertex_program();
-		RSXFragmentProgram fragment_program = get_current_fragment_program();
-
-		GLProgramBuffer prog_buffer;
-		__glcheck prog_buffer.getGraphicPipelineState(vertex_program, fragment_program, nullptr);
-	}
-
-	rsx::program_info info = programs_cache.get(get_raw_program(), rsx::decompile_language::glsl);
+	rsx::raw_program prog = get_raw_program();
+	rsx::program_info info = programs_cache.get(prog, rsx::decompile_language::glsl);
 	m_program = (gl::glsl::program*)info.program;
 	m_program->use();
 
@@ -838,7 +830,9 @@ bool GLGSRender::load_program()
 			0x6, 0x7, 0x4, 0x5,
 			0x2, 0x3, 0x0, 0x1);
 
-		auto ucode = (const rsx::fragment_program::ucode_instr *)info.fragment_shader.decompiled->raw->ucode_ptr;
+		//The shader may be the same, but the value of the constants (and the shader location in memory) may have changed
+		//Point to the current shader location, not the cached version
+		auto ucode = (const rsx::fragment_program::ucode_instr *)prog.fragment_shader.ucode_ptr;
 
 		auto dst = (const rsx::fragment_program::ucode_instr *)mapping.first;
 


### PR DESCRIPTION
~~Fragment program constants are set in the shader code (from what I can gather) and are supposed to be true constants (unlike vertex shader constants which seem to change at times). When investigating issue https://github.com/RPCS3/rpcs3/issues/1906, I realized that the contents at the decompiled ucode_ptr address can change at runtime. I'm not sure why since I haven't had time to properly go through the new rsx cache and decompiler, but It becomes quite obvious that this is not supposed to be happening.~~

~~TL;DR This changeset only sets the fragment shader constants once when the program is first created and uses the data with subsequent use. I'll need advice here from members who have better understanding of the rsx internals.~~

This PR now sets the ucode_ptr to the correct location.