### PR TITLE
cellGame: unknown category temporary fix (hack)

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -207,7 +207,11 @@ ppu_error_code cellGameBootCheck(vm::ptr<u32> type, vm::ptr<u32> attributes, vm:
 	}
 	else
 	{
-		throw fmt::exception("cellGameBootCheck(): Unknown CATEGORY: %s", category);
+		// Hack: When there is no (or unknown) CATEGORY returned, instead of throwing an exception
+		// we assume it's a disk game.
+		*type = CELL_GAME_GAMETYPE_DISC;
+		*attributes = 0;
+		cellGame.error("cellGameBootCheck(): Unknown CATEGORY: %s", category);
 	}
 
 	return CELL_GAME_RET_OK;


### PR DESCRIPTION
All the games I've been trying to load from outside RPCS3's bin directory are returning me empty categories
```
{PPU[0x3] Thread (main_thread) [0x011223d8]} class fmt::exception thrown: cellGameBootCheck(): Unknown CATEGORY: 
```

This is a hack for when the category is empty or unknown. 
We assume it's a disk game and proceed with the emulation, instead of throwing an exception.