### PR TITLE
dx12: Constant color/alpha blending

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
@@ -40,16 +40,10 @@ D3D12_BLEND get_blend_factor(rsx::blend_factor factor)
 	case rsx::blend_factor::src_alpha_saturate: return D3D12_BLEND_SRC_ALPHA_SAT;
 	case rsx::blend_factor::constant_color:
 	case rsx::blend_factor::constant_alpha:
-	{
-		LOG_ERROR(RSX, "Constant blend factor not supported. Using ZERO instead");
-		return D3D12_BLEND_ZERO;
-	}
+		return D3D12_BLEND_BLEND_FACTOR;
 	case rsx::blend_factor::one_minus_constant_color:
 	case rsx::blend_factor::one_minus_constant_alpha:
-	{
-		LOG_ERROR(RSX, "Inv Constant blend factor not supported. Using ONE instead");
-		return D3D12_BLEND_ONE;
-	}
+		return D3D12_BLEND_INV_BLEND_FACTOR;
 	}
 	throw EXCEPTION("Invalid blend factor (0x%x)", factor);
 }
@@ -71,16 +65,10 @@ D3D12_BLEND get_blend_factor_alpha(rsx::blend_factor factor)
 	case rsx::blend_factor::src_alpha_saturate: return D3D12_BLEND_SRC_ALPHA_SAT;
 	case rsx::blend_factor::constant_color:
 	case rsx::blend_factor::constant_alpha:
-	{
-		LOG_ERROR(RSX, "Constant blend factor not supported. Using ONE instead");
-		return D3D12_BLEND_ONE;
-	}
+		return D3D12_BLEND_BLEND_FACTOR;
 	case rsx::blend_factor::one_minus_constant_color:
 	case rsx::blend_factor::one_minus_constant_alpha:
-	{
-		LOG_ERROR(RSX, "Inv Constant blend factor not supported. Using ZERO instead");
-		return D3D12_BLEND_ZERO;
-	}
+		return D3D12_BLEND_INV_BLEND_FACTOR;
 	}
 	throw EXCEPTION("Invalid blend alpha factor (0x%x)", factor);
 }

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -102,21 +102,8 @@ void D3D12GSRender::load_program()
 			else
 			{
 				//All components are alpha.
-				float constant_color_as_alpha = (BlendColor[0] + BlendColor[1] + BlendColor[2]) / 3.f;
+				//If an alpha factor refers to constant_color, it only refers to the alpha component, so no need to replace it
 				BlendColor[0] = BlendColor[1] = BlendColor[2] = BlendColor[3];
-
-				if (sfactor_a == rsx::blend_factor::constant_color ||
-					dfactor_a == rsx::blend_factor::constant_color)
-				{
-					//Alpha information is about to be destroyed. Check that no alpha key requires it...
-					if (sfactor_a == rsx::blend_factor::constant_alpha ||
-						dfactor_a == rsx::blend_factor::constant_alpha)
-					{
-						color_blend_possible = false;
-					}
-					else
-						BlendColor[3] = constant_color_as_alpha;
-				}
 			}
 		}
 


### PR DESCRIPTION
This PR introduces simple heuristics to try and get color blending working on d3d12. The idea is basic, but I'm making several assumptions here:

My assumption is that if a stage has its factor set to D3D12_BLEND_BLEND_FACTOR
1. The alpha component will be multiplied only by the alpha component of the blend factor
2. RGB components are only multiplied by the RGB components of the blend factor
3. The blend_blend_factor is in RGBA (0-1-2-3) format

I haven't coded for d3d in years, so if i'm wrong please feel free to correct me. Also, I may have messed up the heuristics so please double-check it if you understand it. Basically, it separates the blend factor (treated as RGBA) into the RGB and A components and replaces the components if required.