### PR TITLE
rsx: Use register_decoder for vertex attributes.

### DIFF
--- a/rpcs3/Emu/RSX/GL/vertex_buffer.cpp
+++ b/rpcs3/Emu/RSX/GL/vertex_buffer.cpp
@@ -388,7 +388,6 @@ u32 GLGSRender::set_vertex_buffer()
 			}
 			else if (rsx::method_registers.register_vertex_info[index].size > 0)
 			{
-				auto &vertex_data = rsx::method_registers.register_vertex_data[index];
 				auto &vertex_info = rsx::method_registers.register_vertex_info[index];
 
 				switch (vertex_info.type)
@@ -397,14 +396,14 @@ u32 GLGSRender::set_vertex_buffer()
 				{
 					const u32 element_size = rsx::get_vertex_type_size_on_host(vertex_info.type, vertex_info.size);
 					const u32 gl_type = to_gl_internal_type(vertex_info.type, vertex_info.size);
-					const size_t data_size = vertex_data.size();
+					const size_t data_size = element_size;
 
 					auto &texture = m_gl_attrib_buffers[index];
 
 					auto mapping = m_attrib_ring_buffer.alloc_from_reserve(data_size, m_min_texbuffer_alignment);
 					u8 *dst = static_cast<u8*>(mapping.first);
 
-					memcpy(dst, vertex_data.data(), data_size);
+					memcpy(dst, vertex_info.data.data(), element_size);
 					texture.copy_from(m_attrib_ring_buffer, gl_type, mapping.second, data_size);
 
 					//Link texture to uniform

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -354,7 +354,6 @@ namespace rsx
 		for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 		{
 			rsx::method_registers.register_vertex_info[index].size = 0;
-			rsx::method_registers.register_vertex_data[index].clear();
 		}
 
 		if (capture_current_frame)

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -508,18 +508,17 @@ VKGSRender::upload_vertex_data()
 			else if (rsx::method_registers.register_vertex_info[index].size > 0)
 			{
 				//Untested!
-				auto &vertex_data = rsx::method_registers.register_vertex_data[index];
 				auto &vertex_info = rsx::method_registers.register_vertex_info[index];
 
 				switch (vertex_info.type)
 				{
 				case rsx::vertex_base_type::f:
 				{
-					size_t data_size = vertex_data.size();
+					size_t data_size = rsx::get_vertex_type_size_on_host(vertex_info.type, vertex_info.size);
 					const VkFormat format = vk::get_suitable_vk_format(vertex_info.type, vertex_info.size);
 
 					u32 offset_in_attrib_buffer = 0;
-					void *data_ptr = vertex_data.data();
+					void *data_ptr = vertex_info.data.data();
 
 					if (vk::requires_component_expansion(vertex_info.type, vertex_info.size))
 					{
@@ -530,14 +529,14 @@ VKGSRender::upload_vertex_data()
 						offset_in_attrib_buffer = m_attrib_ring_info.alloc<256>(data_size);
 						void *dst = m_attrib_ring_info.map(offset_in_attrib_buffer, data_size);
 
-						vk::expand_array_components<float, 3, 4, 1>(reinterpret_cast<float*>(vertex_data.data()), dst, num_stored_verts);
+						vk::expand_array_components<float, 3, 4, 1>(reinterpret_cast<float*>(vertex_info.data.data()), dst, num_stored_verts);
 						m_attrib_ring_info.unmap();
 					}
 					else
 					{
 						offset_in_attrib_buffer = m_attrib_ring_info.alloc<256>(data_size);
 						void *dst = m_attrib_ring_info.map(offset_in_attrib_buffer, data_size);
-						memcpy(dst, vertex_data.data(), data_size);
+						memcpy(dst, vertex_info.data.data(), data_size);
 						m_attrib_ring_info.unmap();
 					}
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -101,22 +101,11 @@ namespace rsx
 		* Note that behavior when both vertex array and immediate value system are disabled but vertex attrib mask
 		* request inputs is unknown.
 		*/
-		std::array<data_array_format_info, 16> register_vertex_info;
-		std::array<std::vector<u8>, 16> register_vertex_data;
+		std::array<register_vertex_data_info, 16> register_vertex_info;
 		std::array<data_array_format_info, 16> vertex_arrays_info;
 
 		rsx_state();
 		~rsx_state();
-
-		u32& operator[](size_t idx)
-		{
-			return registers[idx];
-		}
-
-		const u32& operator[](size_t idx) const
-		{
-			return registers[idx];
-		}
 
 		void decode(u32 reg, u32 value);
 

--- a/rpcs3/Emu/RSX/rsx_vertex_data.h
+++ b/rpcs3/Emu/RSX/rsx_vertex_data.h
@@ -8,33 +8,30 @@ namespace rsx
 
 struct data_array_format_info
 {
-private:
-	u8 index;
-	std::array<u32, 0x10000 / 4> &registers;
-public:
+	u16 frequency = 0;
+	u8 stride = 0;
+	u8 size = 0;
+	vertex_base_type type = vertex_base_type::f;
+	u32 m_offset;
+
+	data_array_format_info() {}
+
+	u32 offset() const
+	{
+		return m_offset;
+	}
+};
+
+struct register_vertex_data_info
+{
 	u16 frequency = 0;
 	u8 stride = 0;
 	u8 size = 0;
 	vertex_base_type type = vertex_base_type::f;
 
+	register_vertex_data_info() {}
+	std::array<u32, 4> data;
 
-	data_array_format_info(u8 idx, std::array<u32, 0x10000 / 4> &r) : index(idx), registers(r)
-	{}
-
-	data_array_format_info() = delete;
-
-	void unpack_array(u32 data_array_format)
-	{
-		frequency = data_array_format >> 16;
-		stride = (data_array_format >> 8) & 0xff;
-		size = (data_array_format >> 4) & 0xf;
-		type = to_vertex_base_type(data_array_format & 0xf);
-	}
-
-	u32 offset() const
-	{
-		return registers[NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + index];
-	}
 };
 
 }


### PR DESCRIPTION
vertex attributes were already handled with specific functions, this PR just moves these functions inside rsx::register_decoders.