### PR TITLE
rsx: textures use register_decoders.

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -18,23 +18,23 @@ struct rsx_subresource_layout
 * Get size to store texture in a linear fashion.
 * Storage is assumed to use a rowPitchAlignement boundary for every row of texture.
 */
-size_t get_placed_texture_storage_size(const rsx::texture &texture, size_t row_pitch_alignement, size_t mipmap_alignment = 0x200);
-size_t get_placed_texture_storage_size(const rsx::vertex_texture &texture, size_t row_pitch_alignement, size_t mipmap_alignment = 0x200);
+size_t get_placed_texture_storage_size(const rsx::texture_t &texture, size_t row_pitch_alignement, size_t mipmap_alignment = 0x200);
+size_t get_placed_texture_storage_size(const rsx::vertex_texture_t &texture, size_t row_pitch_alignement, size_t mipmap_alignment = 0x200);
 
 /**
  * get all rsx_subresource_layout for texture.
  * The subresources are ordered per layer then per mipmap level (as in rsx memory).
  */
-std::vector<rsx_subresource_layout> get_subresources_layout(const rsx::texture &texture);
-std::vector<rsx_subresource_layout> get_subresources_layout(const rsx::vertex_texture &texture);
+std::vector<rsx_subresource_layout> get_subresources_layout(const rsx::texture_t &texture);
+std::vector<rsx_subresource_layout> get_subresources_layout(const rsx::vertex_texture_t &texture);
 
-void upload_texture_subresource(gsl::span<gsl::byte> dst_buffer, const rsx_subresource_layout &src_layout, int format, bool is_swizzled, size_t dst_row_pitch_multiple_of);
+void upload_texture_subresource(gsl::span<gsl::byte> dst_buffer, const rsx_subresource_layout &src_layout, rsx::texture::format format, bool is_swizzled, size_t dst_row_pitch_multiple_of);
 
-u8 get_format_block_size_in_bytes(int format);
-u8 get_format_block_size_in_texel(int format);
+u8 get_format_block_size_in_bytes(rsx::texture::format format);
+u8 get_format_block_size_in_texel(rsx::texture::format format);
 
 /**
 * Get number of bytes occupied by texture in RSX mem
 */
-size_t get_texture_size(const rsx::texture &texture);
-size_t get_texture_size(const rsx::vertex_texture &texture);
+size_t get_texture_size(const rsx::texture_t &texture);
+size_t get_texture_size(const rsx::vertex_texture_t &texture);

--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
@@ -134,107 +134,104 @@ D3D12_COMPARISON_FUNC get_compare_func(rsx::comparison_function op)
 	throw EXCEPTION("Invalid or unsupported compare func (0x%x)", op);
 }
 
-DXGI_FORMAT get_texture_format(u8 format)
+DXGI_FORMAT get_texture_format(rsx::texture::format format)
 {
 	switch (format)
 	{
-	case CELL_GCM_TEXTURE_B8: return DXGI_FORMAT_R8_UNORM;
-	case CELL_GCM_TEXTURE_A1R5G5B5: return DXGI_FORMAT_B5G5R5A1_UNORM;
-	case CELL_GCM_TEXTURE_A4R4G4B4: return DXGI_FORMAT_B4G4R4A4_UNORM;
-	case CELL_GCM_TEXTURE_R5G6B5: return DXGI_FORMAT_B5G6R5_UNORM;
-	case CELL_GCM_TEXTURE_A8R8G8B8: return DXGI_FORMAT_R8G8B8A8_UNORM;
-	case CELL_GCM_TEXTURE_COMPRESSED_DXT1: return DXGI_FORMAT_BC1_UNORM;
-	case CELL_GCM_TEXTURE_COMPRESSED_DXT23: return DXGI_FORMAT_BC2_UNORM;
-	case CELL_GCM_TEXTURE_COMPRESSED_DXT45: return DXGI_FORMAT_BC3_UNORM;
-	case CELL_GCM_TEXTURE_G8B8: return DXGI_FORMAT_G8R8_G8B8_UNORM;
-	case CELL_GCM_TEXTURE_R6G5B5: return DXGI_FORMAT_B5G6R5_UNORM;
-	case CELL_GCM_TEXTURE_DEPTH24_D8: return DXGI_FORMAT_R32_UINT; // Untested
-	case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:	return DXGI_FORMAT_R32_FLOAT; // Untested
-	case CELL_GCM_TEXTURE_DEPTH16: return DXGI_FORMAT_R16_UINT; // Untested
-	case CELL_GCM_TEXTURE_DEPTH16_FLOAT: return DXGI_FORMAT_R16_FLOAT; // Untested
-	case CELL_GCM_TEXTURE_X16: return DXGI_FORMAT_R16_UNORM;
-	case CELL_GCM_TEXTURE_Y16_X16: return DXGI_FORMAT_R16G16_UNORM;
-	case CELL_GCM_TEXTURE_Y16_X16_FLOAT: return DXGI_FORMAT_R16G16_FLOAT;
-	case CELL_GCM_TEXTURE_X32_FLOAT: return DXGI_FORMAT_R32_FLOAT;
-	case CELL_GCM_TEXTURE_R5G5B5A1: return DXGI_FORMAT_B5G5R5A1_UNORM;
-	case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT: return DXGI_FORMAT_R16G16B16A16_FLOAT;
-	case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT: return DXGI_FORMAT_R32G32B32A32_FLOAT;
-	case CELL_GCM_TEXTURE_D1R5G5B5: return DXGI_FORMAT_B5G5R5A1_UNORM;
-	case CELL_GCM_TEXTURE_D8R8G8B8: return DXGI_FORMAT_R8G8B8A8_UNORM;
-	case CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8: return DXGI_FORMAT_G8R8_G8B8_UNORM;
-	case CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8: return DXGI_FORMAT_R8G8_B8G8_UNORM;
-	case CELL_GCM_TEXTURE_COMPRESSED_HILO8: return DXGI_FORMAT_G8R8_G8B8_UNORM;
-	case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8: return DXGI_FORMAT_R8G8_SNORM;
-	case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8: return DXGI_FORMAT_G8R8_G8B8_UNORM;
-	case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8: return DXGI_FORMAT_R8G8_B8G8_UNORM;
-		break;
+	case rsx::texture::format::b8: return DXGI_FORMAT_R8_UNORM;
+	case rsx::texture::format::a1r5g5b5: return DXGI_FORMAT_B5G5R5A1_UNORM;
+	case rsx::texture::format::a4r4g4b4: return DXGI_FORMAT_B4G4R4A4_UNORM;
+	case rsx::texture::format::r5g6b5: return DXGI_FORMAT_B5G6R5_UNORM;
+	case rsx::texture::format::a8r8g8b8: return DXGI_FORMAT_R8G8B8A8_UNORM;
+	case rsx::texture::format::compressed_dxt1: return DXGI_FORMAT_BC1_UNORM;
+	case rsx::texture::format::compressed_dxt23: return DXGI_FORMAT_BC2_UNORM;
+	case rsx::texture::format::compressed_dxt45: return DXGI_FORMAT_BC3_UNORM;
+	case rsx::texture::format::g8b8: return DXGI_FORMAT_G8R8_G8B8_UNORM;
+	case rsx::texture::format::r6g5b5: return DXGI_FORMAT_B5G6R5_UNORM;
+	case rsx::texture::format::d24_8: return DXGI_FORMAT_R32_UINT; // Untested
+	case rsx::texture::format::d24_8_float:	return DXGI_FORMAT_R32_FLOAT; // Untested
+	case rsx::texture::format::d16: return DXGI_FORMAT_R16_UINT; // Untested
+	case rsx::texture::format::d16_float: return DXGI_FORMAT_R16_FLOAT; // Untested
+	case rsx::texture::format::x16: return DXGI_FORMAT_R16_UNORM;
+	case rsx::texture::format::y16x16: return DXGI_FORMAT_R16G16_UNORM;
+	case rsx::texture::format::y16x16_float: return DXGI_FORMAT_R16G16_FLOAT;
+	case rsx::texture::format::x32float: return DXGI_FORMAT_R32_FLOAT;
+	case rsx::texture::format::r5g5b5a1: return DXGI_FORMAT_B5G5R5A1_UNORM;
+	case rsx::texture::format::w16z16y16x16_float: return DXGI_FORMAT_R16G16B16A16_FLOAT;
+	case rsx::texture::format::w32z32y32x32_float: return DXGI_FORMAT_R32G32B32A32_FLOAT;
+	case rsx::texture::format::d1r5g5b5: return DXGI_FORMAT_B5G5R5A1_UNORM;
+	case rsx::texture::format::d8r8g8b8: return DXGI_FORMAT_R8G8B8A8_UNORM;
+	case rsx::texture::format::compressed_b8r8_g8r8: return DXGI_FORMAT_G8R8_G8B8_UNORM;
+	case rsx::texture::format::compressed_r8b8_r8g8: return DXGI_FORMAT_R8G8_B8G8_UNORM;
+	case rsx::texture::format::compressed_hilo_8: return DXGI_FORMAT_G8R8_G8B8_UNORM;
+	case rsx::texture::format::compressed_hilo_s8: return DXGI_FORMAT_R8G8_SNORM;
 	}
 	throw EXCEPTION("Invalid or unsupported texture format (0x%x)", format);
 }
 
-UINT get_texture_max_aniso(rsx::texture_max_anisotropy aniso)
+UINT get_texture_max_aniso(rsx::texture::max_anisotropy aniso)
 {
 	switch (aniso)
 	{
-	case rsx::texture_max_anisotropy::x1: return 1;
-	case rsx::texture_max_anisotropy::x2: return 2;
-	case rsx::texture_max_anisotropy::x4: return 4;
-	case rsx::texture_max_anisotropy::x6: return 6;
-	case rsx::texture_max_anisotropy::x8: return 8;
-	case rsx::texture_max_anisotropy::x10: return 10;
-	case rsx::texture_max_anisotropy::x12: return 12;
-	case rsx::texture_max_anisotropy::x16: return 16;
+	case rsx::texture::max_anisotropy::x1: return 1;
+	case rsx::texture::max_anisotropy::x2: return 2;
+	case rsx::texture::max_anisotropy::x4: return 4;
+	case rsx::texture::max_anisotropy::x6: return 6;
+	case rsx::texture::max_anisotropy::x8: return 8;
+	case rsx::texture::max_anisotropy::x10: return 10;
+	case rsx::texture::max_anisotropy::x12: return 12;
+	case rsx::texture::max_anisotropy::x16: return 16;
 	}
 	throw EXCEPTION("Invalid texture max aniso (0x%x)", aniso);
 }
 
-D3D12_TEXTURE_ADDRESS_MODE get_texture_wrap_mode(rsx::texture_wrap_mode wrap)
+D3D12_TEXTURE_ADDRESS_MODE get_texture_wrap_mode(rsx::texture::wrap_mode wrap)
 {
 	switch (wrap)
 	{
-	case rsx::texture_wrap_mode::wrap: return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-	case rsx::texture_wrap_mode::mirror: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR;
-	case rsx::texture_wrap_mode::clamp_to_edge: return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-	case rsx::texture_wrap_mode::border: return D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-	case rsx::texture_wrap_mode::clamp: return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-	case rsx::texture_wrap_mode::mirror_once_clamp_to_edge: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
-	case rsx::texture_wrap_mode::mirror_once_border: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
-	case rsx::texture_wrap_mode::mirror_once_clamp: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
+	case rsx::texture::wrap_mode::wrap: return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+	case rsx::texture::wrap_mode::mirror: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR;
+	case rsx::texture::wrap_mode::clamp_to_edge: return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	case rsx::texture::wrap_mode::border: return D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+	case rsx::texture::wrap_mode::clamp: return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	case rsx::texture::wrap_mode::mirror_once_clamp_to_edge: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
+	case rsx::texture::wrap_mode::mirror_once_border: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
+	case rsx::texture::wrap_mode::mirror_once_clamp: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
 	}
 	throw EXCEPTION("Invalid texture wrap mode (0x%x)", wrap);
 }
 
 namespace
 {
-	void get_min_filter(rsx::texture_minify_filter min_filter, D3D12_FILTER_TYPE &min, D3D12_FILTER_TYPE &mip)
+	void get_min_filter(rsx::texture::minify_filter min_filter, D3D12_FILTER_TYPE &min, D3D12_FILTER_TYPE &mip)
 	{
 		switch (min_filter)
 		{
-		case rsx::texture_minify_filter::nearest:
+		case rsx::texture::minify_filter::nearest:
 			min = D3D12_FILTER_TYPE_POINT;
 			mip = D3D12_FILTER_TYPE_POINT;
 			return;
-		case rsx::texture_minify_filter::linear:
+		case rsx::texture::minify_filter::linear:
 			min = D3D12_FILTER_TYPE_LINEAR;
 			mip = D3D12_FILTER_TYPE_POINT;
 			return;
-		case rsx::texture_minify_filter::nearest_nearest:
+		case rsx::texture::minify_filter::nearest_nearest:
 			min = D3D12_FILTER_TYPE_POINT;
 			mip = D3D12_FILTER_TYPE_POINT;
 			return;
-		case rsx::texture_minify_filter::linear_nearest:
+		case rsx::texture::minify_filter::linear_nearest:
 			min = D3D12_FILTER_TYPE_LINEAR;
 			mip = D3D12_FILTER_TYPE_POINT;
 			return;
-		case rsx::texture_minify_filter::nearest_linear:
+		case rsx::texture::minify_filter::nearest_linear:
 			min = D3D12_FILTER_TYPE_POINT;
 			mip = D3D12_FILTER_TYPE_LINEAR;
 			return;
-		case rsx::texture_minify_filter::linear_linear:
+		case rsx::texture::minify_filter::linear_linear:
 			min = D3D12_FILTER_TYPE_LINEAR;
 			mip = D3D12_FILTER_TYPE_LINEAR;
 			return;
-		case rsx::texture_minify_filter::convolution_min:
+		case rsx::texture::minify_filter::convolution_min:
 			min = D3D12_FILTER_TYPE_LINEAR;
 			mip = D3D12_FILTER_TYPE_POINT;
 			return;
@@ -242,19 +239,19 @@ namespace
 		throw EXCEPTION("Invalid max filter");
 	}
 
-	D3D12_FILTER_TYPE get_mag_filter(rsx::texture_magnify_filter mag_filter)
+	D3D12_FILTER_TYPE get_mag_filter(rsx::texture::magnify_filter mag_filter)
 	{
 		switch (mag_filter)
 		{
-		case rsx::texture_magnify_filter::nearest: return D3D12_FILTER_TYPE_POINT;
-		case rsx::texture_magnify_filter::linear: return D3D12_FILTER_TYPE_LINEAR;
-		case rsx::texture_magnify_filter::convolution_mag: return D3D12_FILTER_TYPE_LINEAR;
+		case rsx::texture::magnify_filter::nearest: return D3D12_FILTER_TYPE_POINT;
+		case rsx::texture::magnify_filter::linear: return D3D12_FILTER_TYPE_LINEAR;
+		case rsx::texture::magnify_filter::convolution_mag: return D3D12_FILTER_TYPE_LINEAR;
 		}
 		throw EXCEPTION("Invalid mag filter");
 	}
 }
 
-D3D12_FILTER get_texture_filter(rsx::texture_minify_filter min_filter, rsx::texture_magnify_filter mag_filter)
+D3D12_FILTER get_texture_filter(rsx::texture::minify_filter min_filter, rsx::texture::magnify_filter mag_filter)
 {
 	D3D12_FILTER_TYPE min, mip;
 	get_min_filter(min_filter, min, mip);

--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.h
@@ -36,22 +36,22 @@ D3D12_COMPARISON_FUNC get_compare_func(rsx::comparison_function op);
  * Convert GCM texture format to an equivalent one supported by D3D12.
  * Destination format may require a byte swap or data conversion.
  */
-DXGI_FORMAT get_texture_format(u8 format);
+DXGI_FORMAT get_texture_format(rsx::texture::format format);
 
 /**
  * Convert texture aniso value to UINT.
  */
-UINT get_texture_max_aniso(rsx::texture_max_anisotropy aniso);
+UINT get_texture_max_aniso(rsx::texture::max_anisotropy aniso);
 
 /**
  * Convert texture wrap mode to D3D12_TEXTURE_ADDRESS_MODE
  */
-D3D12_TEXTURE_ADDRESS_MODE get_texture_wrap_mode(rsx::texture_wrap_mode wrap);
+D3D12_TEXTURE_ADDRESS_MODE get_texture_wrap_mode(rsx::texture::wrap_mode wrap);
 
 /**
  * Convert minify and magnify filter to D3D12_FILTER
  */
-D3D12_FILTER get_texture_filter(rsx::texture_minify_filter min_filter, rsx::texture_magnify_filter mag_filter);
+D3D12_FILTER get_texture_filter(rsx::texture::minify_filter min_filter, rsx::texture::magnify_filter mag_filter);
 
 /**
  * Convert draw mode to D3D12_PRIMITIVE_TOPOLOGY

--- a/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.cpp
@@ -4,7 +4,7 @@
 #include "D3D12MemoryHelpers.h"
 
 
-void data_cache::store_and_protect_data(u64 key, u32 start, size_t size, u8 format, size_t w, size_t h, size_t d, size_t m, ComPtr<ID3D12Resource> data)
+void data_cache::store_and_protect_data(u64 key, u32 start, size_t size, rsx::texture::format format, size_t w, size_t h, size_t d, size_t m, ComPtr<ID3D12Resource> data)
 {
 	std::lock_guard<std::mutex> lock(m_mut);
 	m_address_to_data[key] = std::make_pair(texture_entry(format, w, h, d, m), data);

--- a/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12MemoryHelpers.h
@@ -68,17 +68,17 @@ public:
 
 struct texture_entry
 {
-	u8 m_format;
+	rsx::texture::format m_format;
 	bool m_is_dirty;
 	size_t m_width;
 	size_t m_height;
 	size_t m_mipmap;
 	size_t m_depth;
 
-	texture_entry() : m_format(0), m_width(0), m_height(0), m_depth(0), m_is_dirty(true)
+	texture_entry() : m_format(rsx::texture::format::b8), m_width(0), m_height(0), m_depth(0), m_is_dirty(true)
 	{}
 
-	texture_entry(u8 f, size_t w, size_t h, size_t d, size_t m) : m_format(f), m_width(w), m_height(h), m_depth(d), m_is_dirty(false), m_mipmap(m)
+	texture_entry(rsx::texture::format f, size_t w, size_t h, size_t d, size_t m) : m_format(f), m_width(w), m_height(h), m_depth(d), m_is_dirty(false), m_mipmap(m)
 	{}
 
 	bool operator==(const texture_entry &other)
@@ -108,7 +108,7 @@ public:
 	data_cache(const data_cache&) = delete;
 	data_cache(data_cache&&) = delete;
 
-	void store_and_protect_data(u64 key, u32 start, size_t size, u8 format, size_t w, size_t h, size_t d, size_t m, ComPtr<ID3D12Resource> data);
+	void store_and_protect_data(u64 key, u32 start, size_t size, rsx::texture::format format, size_t w, size_t h, size_t d, size_t m, ComPtr<ID3D12Resource> data);
 
 	/**
 	* Make memory from start to start + size write protected.

--- a/rpcs3/Emu/RSX/GCM.cpp
+++ b/rpcs3/Emu/RSX/GCM.cpp
@@ -832,17 +832,6 @@ rsx::fog_mode rsx::to_fog_mode(u32 in)
 	throw EXCEPTION("Unknown fog mode 0x%x", in);
 }
 
-rsx::texture_dimension rsx::to_texture_dimension(u8 in)
-{
-	switch (in)
-	{
-	case 1: return rsx::texture_dimension::dimension1d;
-	case 2: return rsx::texture_dimension::dimension2d;
-	case 3: return rsx::texture_dimension::dimension3d;
-	}
-	throw EXCEPTION("Unknown texture dimension %d", in);
-}
-
 namespace rsx
 {
 std::string print_boolean(bool b)
@@ -1210,6 +1199,172 @@ std::string print_polygon_mode(polygon_mode op)
 	throw;
 }
 
+std::string to_string(texture::format format)
+{
+	switch (format)
+	{
+	case texture::format::compressed_hilo_8: return "CELL_GCM_TEXTURE_COMPRESSED_HILO8";
+	case texture::format::compressed_hilo_s8: return "CELL_GCM_TEXTURE_COMPRESSED_HILO_S8";
+	case texture::format::b8: return "CELL_GCM_TEXTURE_B8";
+	case texture::format::a1r5g5b5: return "CELL_GCM_TEXTURE_A1R5G5B5";
+	case texture::format::a4r4g4b4: return "CELL_GCM_TEXTURE_A4R4G4B4";
+	case texture::format::r5g6b5: return "CELL_GCM_TEXTURE_R5G6B5";
+	case texture::format::a8r8g8b8: return "CELL_GCM_TEXTURE_A8R8G8B8";
+	case texture::format::compressed_dxt1: return "CELL_GCM_TEXTURE_COMPRESSED_DXT1";
+	case texture::format::compressed_dxt23: return "CELL_GCM_TEXTURE_COMPRESSED_DXT23";
+	case texture::format::compressed_dxt45: return "CELL_GCM_TEXTURE_COMPRESSED_DXT45";
+	case texture::format::g8b8: return "CELL_GCM_TEXTURE_G8B8";
+	case texture::format::r6g5b5: return "CELL_GCM_TEXTURE_R6G5B5";
+	case texture::format::d24_8: return "CELL_GCM_TEXTURE_DEPTH24_D8";
+	case texture::format::d24_8_float: return "CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT";
+	case texture::format::d16: return "CELL_GCM_TEXTURE_DEPTH16";
+	case texture::format::d16_float: return "CELL_GCM_TEXTURE_DEPTH16_FLOAT";
+	case texture::format::x16: return "CELL_GCM_TEXTURE_X16";
+	case texture::format::y16x16: return "CELL_GCM_TEXTURE_Y16_X16";
+	case texture::format::r5g5b5a1: return "CELL_GCM_TEXTURE_R5G5B5A1";
+	case texture::format::w16z16y16x16_float: return "CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT";
+	case texture::format::w32z32y32x32_float: return "CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT";
+	case texture::format::x32float: return "CELL_GCM_TEXTURE_X32_FLOAT";
+	case texture::format::d1r5g5b5: return "CELL_GCM_TEXTURE_D1R5G5B5";
+	case texture::format::d8r8g8b8: return "CELL_GCM_TEXTURE_D8R8G8B8";
+	case texture::format::y16x16_float: return "CELL_GCM_TEXTURE_Y16_X16_FLOAT";
+	case texture::format::compressed_b8r8_g8r8: return "CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8";
+	case texture::format::compressed_r8b8_r8g8: return "CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8";
+	}
+	throw;
+}
+
+std::string to_string(texture::border_type in)
+{
+	switch (in)
+	{
+	case texture::border_type::color: return "color";
+	case texture::border_type::texture: return "texture";
+	}
+	throw;
+}
+
+std::string to_string(texture::layout in)
+{
+	switch (in)
+	{
+	case texture::layout::linear: return "linear";
+	case texture::layout::swizzled: return "swizzled";
+	}
+	throw;
+}
+
+std::string to_string(texture::coordinates in)
+{
+	switch (in)
+	{
+	case texture::coordinates::normalized: return "normalized";
+	case texture::coordinates::unnormalized: return "unormalized";
+	}
+	throw;
+}
+
+std::string to_string(texture::dimension in)
+{
+	switch (in)
+	{
+	case texture::dimension::dimension1d: return "1D";
+	case texture::dimension::dimension2d: return "2D";
+	case texture::dimension::dimension3d: return "3D";
+	}
+	throw;
+}
+
+std::string to_string(texture::wrap_mode wrap)
+{
+	switch (wrap)
+	{
+	case texture::wrap_mode::wrap: return "WRAP";
+	case texture::wrap_mode::mirror: return "MIRROR";
+	case texture::wrap_mode::clamp_to_edge: return "CLAMP_TO_EDGE";
+	case texture::wrap_mode::border: return "BORDER";
+	case texture::wrap_mode::clamp: return "CLAMP";
+	case texture::wrap_mode::mirror_once_clamp_to_edge: return "MIRROR_ONCE_CLAMP_TO_EDGE";
+	case texture::wrap_mode::mirror_once_border: return "MIRROR_ONCE_BORDER";
+	case texture::wrap_mode::mirror_once_clamp: return "MIRROR_ONCE_CLAMP";
+	}
+	throw;
+}
+
+std::string to_string(texture::zfunc op)
+{
+	switch (op)
+	{
+	case texture::zfunc::never: return "Never";
+	case texture::zfunc::less: return "Less";
+	case texture::zfunc::equal: return "Equal";
+	case texture::zfunc::lequal: return "LEqual";
+	case texture::zfunc::greater: return "Greater";
+	case texture::zfunc::notequal: return "NotEqual";
+	case texture::zfunc::gequal: return "GreaterOrEqual";
+	case texture::zfunc::always: return "Always";
+	}
+	throw;
+}
+
+std::string to_string(texture::unsigned_remap op)
+{
+	switch (op)
+	{
+	case texture::unsigned_remap::biased: return "biased";
+	case texture::unsigned_remap::normal: return "normal";
+	}
+	throw;
+}
+
+std::string to_string(texture::signed_remap op)
+{
+	switch (op)
+	{
+	case texture::signed_remap::clamped: return "clamped";
+	case texture::signed_remap::normal: return "normal";
+	}
+	throw;
+}
+
+std::string to_string(texture::minify_filter op)
+{
+	switch (op)
+	{
+	case texture::minify_filter::linear: return "linear";
+	case texture::minify_filter::linear_linear: return "linear_linear";
+	case texture::minify_filter::linear_nearest: return "linear_nearest";
+	case texture::minify_filter::nearest: return "nearest";
+	case texture::minify_filter::nearest_linear: return "nearest_linear";
+	case texture::minify_filter::nearest_nearest: return "nearest";
+	case texture::minify_filter::convolution_min: return "convolution min";
+	}
+	throw;
+}
+
+std::string to_string(texture::magnify_filter op)
+{
+	switch (op)
+	{
+	case texture::magnify_filter::linear: return "linear";
+	case texture::magnify_filter::nearest: return "nearest";
+	case texture::magnify_filter::convolution_mag: return "linear";
+	}
+	throw;
+}
+
+std::string to_string(texture::component_remap op)
+{
+	switch (op)
+	{
+	case texture::component_remap::A: return "A";
+	case texture::component_remap::R: return "R";
+	case texture::component_remap::G: return "G";
+	case texture::component_remap::B: return "B";
+	}
+	throw;
+}
+
 } // end namespace rsx
 
 enum
@@ -1279,64 +1434,216 @@ enum
 	CELL_GCM_TEXTURE_CONVOLUTION_MAG = 4,
 };
 
-rsx::texture_wrap_mode rsx::to_texture_wrap_mode(u8 in)
+namespace rsx
+{
+namespace texture
+{
+dimension to_texture_dimension(u8 in)
 {
 	switch (in)
 	{
-	case CELL_GCM_TEXTURE_WRAP: return rsx::texture_wrap_mode::wrap;
-	case CELL_GCM_TEXTURE_MIRROR: return rsx::texture_wrap_mode::mirror;
-	case CELL_GCM_TEXTURE_CLAMP_TO_EDGE: return rsx::texture_wrap_mode::clamp_to_edge;
-	case CELL_GCM_TEXTURE_BORDER: return rsx::texture_wrap_mode::border;
-	case CELL_GCM_TEXTURE_CLAMP: return rsx::texture_wrap_mode::clamp;
-	case CELL_GCM_TEXTURE_MIRROR_ONCE_CLAMP_TO_EDGE: return rsx::texture_wrap_mode::mirror_once_clamp_to_edge;
-	case CELL_GCM_TEXTURE_MIRROR_ONCE_BORDER: return rsx::texture_wrap_mode::mirror_once_border;
-	case CELL_GCM_TEXTURE_MIRROR_ONCE_CLAMP: return rsx::texture_wrap_mode::mirror_once_clamp;
+	case 1: return dimension::dimension1d;
+	case 2: return dimension::dimension2d;
+	case 3: return dimension::dimension3d;
+	}
+	throw EXCEPTION("Wrong texture dimension %d", in);
+}
+
+wrap_mode to_texture_wrap_mode(u8 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TEXTURE_WRAP: return wrap_mode::wrap;
+	case CELL_GCM_TEXTURE_MIRROR: return wrap_mode::mirror;
+	case CELL_GCM_TEXTURE_CLAMP_TO_EDGE: return wrap_mode::clamp_to_edge;
+	case CELL_GCM_TEXTURE_BORDER: return wrap_mode::border;
+	case CELL_GCM_TEXTURE_CLAMP: return wrap_mode::clamp;
+	case CELL_GCM_TEXTURE_MIRROR_ONCE_CLAMP_TO_EDGE: return wrap_mode::mirror_once_clamp_to_edge;
+	case CELL_GCM_TEXTURE_MIRROR_ONCE_BORDER: return wrap_mode::mirror_once_border;
+	case CELL_GCM_TEXTURE_MIRROR_ONCE_CLAMP: return wrap_mode::mirror_once_clamp;
 	}
 	throw EXCEPTION("Unknown wrap mode 0x%x", in);
 }
 
-rsx::texture_max_anisotropy rsx::to_texture_max_anisotropy(u8 in)
+max_anisotropy to_texture_max_anisotropy(u8 in)
 {
 	switch (in)
 	{
-	case CELL_GCM_TEXTURE_MAX_ANISO_1: return rsx::texture_max_anisotropy::x1;
-	case CELL_GCM_TEXTURE_MAX_ANISO_2: return rsx::texture_max_anisotropy::x2;
-	case CELL_GCM_TEXTURE_MAX_ANISO_4: return rsx::texture_max_anisotropy::x4;
-	case CELL_GCM_TEXTURE_MAX_ANISO_6: return rsx::texture_max_anisotropy::x6;
-	case CELL_GCM_TEXTURE_MAX_ANISO_8: return rsx::texture_max_anisotropy::x8;
-	case CELL_GCM_TEXTURE_MAX_ANISO_10: return rsx::texture_max_anisotropy::x10;
-	case CELL_GCM_TEXTURE_MAX_ANISO_12: return rsx::texture_max_anisotropy::x12;
-	case CELL_GCM_TEXTURE_MAX_ANISO_16: return rsx::texture_max_anisotropy::x16;
+	case CELL_GCM_TEXTURE_MAX_ANISO_1: return max_anisotropy::x1;
+	case CELL_GCM_TEXTURE_MAX_ANISO_2: return max_anisotropy::x2;
+	case CELL_GCM_TEXTURE_MAX_ANISO_4: return max_anisotropy::x4;
+	case CELL_GCM_TEXTURE_MAX_ANISO_6: return max_anisotropy::x6;
+	case CELL_GCM_TEXTURE_MAX_ANISO_8: return max_anisotropy::x8;
+	case CELL_GCM_TEXTURE_MAX_ANISO_10: return max_anisotropy::x10;
+	case CELL_GCM_TEXTURE_MAX_ANISO_12: return max_anisotropy::x12;
+	case CELL_GCM_TEXTURE_MAX_ANISO_16: return max_anisotropy::x16;
 	}
 	throw EXCEPTION("Unknown anisotropy max mode 0x%x", in);
 }
 
-rsx::texture_minify_filter rsx::to_texture_minify_filter(u8 in)
+minify_filter to_texture_minify_filter(u8 in)
 {
 	switch (in)
 	{
-	case CELL_GCM_TEXTURE_NEAREST: return rsx::texture_minify_filter::nearest;
-	case CELL_GCM_TEXTURE_LINEAR: return rsx::texture_minify_filter::linear;
-	case CELL_GCM_TEXTURE_NEAREST_NEAREST: return rsx::texture_minify_filter::nearest_nearest;
-	case CELL_GCM_TEXTURE_LINEAR_NEAREST: return rsx::texture_minify_filter::linear_nearest;
-	case CELL_GCM_TEXTURE_NEAREST_LINEAR: return rsx::texture_minify_filter::nearest_linear;
-	case CELL_GCM_TEXTURE_LINEAR_LINEAR: return rsx::texture_minify_filter::linear_linear;
-	case CELL_GCM_TEXTURE_CONVOLUTION_MIN: return rsx::texture_minify_filter::linear_linear;
+	case CELL_GCM_TEXTURE_NEAREST: return minify_filter::nearest;
+	case CELL_GCM_TEXTURE_LINEAR: return minify_filter::linear;
+	case CELL_GCM_TEXTURE_NEAREST_NEAREST: return minify_filter::nearest_nearest;
+	case CELL_GCM_TEXTURE_LINEAR_NEAREST: return minify_filter::linear_nearest;
+	case CELL_GCM_TEXTURE_NEAREST_LINEAR: return minify_filter::nearest_linear;
+	case CELL_GCM_TEXTURE_LINEAR_LINEAR: return minify_filter::linear_linear;
+	case CELL_GCM_TEXTURE_CONVOLUTION_MIN: return minify_filter::linear_linear;
 	}
 	throw EXCEPTION("Unknown minify filter 0x%x", in);
 }
 
 
-rsx::texture_magnify_filter rsx::to_texture_magnify_filter(u8 in)
+magnify_filter to_texture_magnify_filter(u8 in)
 {
 	switch (in)
 	{
-	case CELL_GCM_TEXTURE_NEAREST: return rsx::texture_magnify_filter::nearest;
-	case CELL_GCM_TEXTURE_LINEAR: return rsx::texture_magnify_filter::linear;
-	case CELL_GCM_TEXTURE_CONVOLUTION_MAG: return rsx::texture_magnify_filter::convolution_mag;
+	case CELL_GCM_TEXTURE_NEAREST: return magnify_filter::nearest;
+	case CELL_GCM_TEXTURE_LINEAR: return magnify_filter::linear;
+	case CELL_GCM_TEXTURE_CONVOLUTION_MAG: return magnify_filter::convolution_mag;
 	}
 	throw EXCEPTION("Unknown magnify filter 0x%x", in);
 }
+
+// Note : this needs more test
+border_type to_border_type(u32 in)
+{
+	switch (in)
+	{
+	case 0: return border_type::color;
+	case 1: return border_type::texture;
+	}
+	throw EXCEPTION("unknow border type %x", in);
+}
+
+enum
+{
+	// Swizzle Flag
+	CELL_GCM_TEXTURE_SZ = 0x00,
+	CELL_GCM_TEXTURE_LN = 0x20,
+
+	// Normalization Flag
+	CELL_GCM_TEXTURE_NR = 0x00,
+	CELL_GCM_TEXTURE_UN = 0x40,
+};
+
+std::tuple<format, layout, coordinates> to_texture_format(u32 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8: return std::make_tuple(format::compressed_b8r8_g8r8, layout::swizzled, coordinates::normalized);
+	case CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8: return std::make_tuple(format::compressed_b8r8_g8r8, layout::swizzled, coordinates::normalized);
+	}
+
+	coordinates coordinates = !!(in & CELL_GCM_TEXTURE_UN) ? coordinates::unnormalized : coordinates::normalized;
+	layout layout = !!(in & CELL_GCM_TEXTURE_LN) ? layout::linear : layout::swizzled;
+	u32 purged_format = in & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
+	switch (purged_format)
+	{
+	case CELL_GCM_TEXTURE_B8: return std::make_tuple(format::b8, layout, coordinates);
+	case CELL_GCM_TEXTURE_A1R5G5B5: return std::make_tuple(format::a1r5g5b5, layout, coordinates);
+	case CELL_GCM_TEXTURE_A4R4G4B4: return std::make_tuple(format::a4r4g4b4, layout, coordinates);
+	case CELL_GCM_TEXTURE_R5G6B5: return std::make_tuple(format::r5g6b5, layout, coordinates);
+	case CELL_GCM_TEXTURE_A8R8G8B8: return std::make_tuple(format::a8r8g8b8, layout, coordinates);
+	case CELL_GCM_TEXTURE_COMPRESSED_DXT1: return std::make_tuple(format::compressed_dxt1, layout, coordinates);
+	case CELL_GCM_TEXTURE_COMPRESSED_DXT23: return std::make_tuple(format::compressed_dxt23, layout, coordinates);
+	case CELL_GCM_TEXTURE_COMPRESSED_DXT45: return std::make_tuple(format::compressed_dxt45, layout, coordinates);
+	case CELL_GCM_TEXTURE_G8B8: return std::make_tuple(format::g8b8, layout, coordinates);
+	case CELL_GCM_TEXTURE_R6G5B5: return std::make_tuple(format::r6g5b5, layout, coordinates);
+	case CELL_GCM_TEXTURE_DEPTH24_D8: return std::make_tuple(format::d24_8, layout, coordinates);
+	case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT: return std::make_tuple(format::d24_8_float, layout, coordinates);
+	case CELL_GCM_TEXTURE_DEPTH16: return std::make_tuple(format::d16, layout, coordinates);
+	case CELL_GCM_TEXTURE_DEPTH16_FLOAT: return std::make_tuple(format::d16_float, layout, coordinates);
+	case CELL_GCM_TEXTURE_X16: return std::make_tuple(format::x16, layout, coordinates);
+	case CELL_GCM_TEXTURE_Y16_X16: return std::make_tuple(format::y16x16, layout, coordinates);
+	case CELL_GCM_TEXTURE_R5G5B5A1: return std::make_tuple(format::r5g5b5a1, layout, coordinates);
+	case CELL_GCM_TEXTURE_COMPRESSED_HILO8: return std::make_tuple(format::compressed_hilo_8, layout, coordinates);
+	case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8: return std::make_tuple(format::compressed_hilo_s8, layout, coordinates);
+	case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT: return std::make_tuple(format::w16z16y16x16_float, layout, coordinates);
+	case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT: return std::make_tuple(format::w32z32y32x32_float, layout, coordinates);
+	case CELL_GCM_TEXTURE_X32_FLOAT: return std::make_tuple(format::x32float, layout, coordinates);
+	case CELL_GCM_TEXTURE_D1R5G5B5: return std::make_tuple(format::d1r5g5b5, layout, coordinates);
+	case CELL_GCM_TEXTURE_D8R8G8B8: return std::make_tuple(format::d8r8g8b8, layout, coordinates);
+	case CELL_GCM_TEXTURE_Y16_X16_FLOAT: return std::make_tuple(format::y16x16_float, layout, coordinates);
+	}
+	throw EXCEPTION("unknow texture format %x", in);
+}
+
+enum
+{
+	CELL_GCM_TEXTURE_ZFUNC_NEVER = 0,
+	CELL_GCM_TEXTURE_ZFUNC_LESS = 1,
+	CELL_GCM_TEXTURE_ZFUNC_EQUAL = 2,
+	CELL_GCM_TEXTURE_ZFUNC_LEQUAL = 3,
+	CELL_GCM_TEXTURE_ZFUNC_GREATER = 4,
+	CELL_GCM_TEXTURE_ZFUNC_NOTEQUAL = 5,
+	CELL_GCM_TEXTURE_ZFUNC_GEQUAL = 6,
+	CELL_GCM_TEXTURE_ZFUNC_ALWAYS = 7,
+};
+
+zfunc to_texture_zfunc(u32 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TEXTURE_ZFUNC_NEVER: return zfunc::never;
+	case CELL_GCM_TEXTURE_ZFUNC_LESS: return zfunc::less;
+	case CELL_GCM_TEXTURE_ZFUNC_EQUAL: return zfunc::equal;
+	case CELL_GCM_TEXTURE_ZFUNC_LEQUAL: return zfunc::lequal;
+	case CELL_GCM_TEXTURE_ZFUNC_GREATER: return zfunc::greater;
+	case CELL_GCM_TEXTURE_ZFUNC_NOTEQUAL: return zfunc::notequal;
+	case CELL_GCM_TEXTURE_ZFUNC_GEQUAL: return zfunc::gequal;
+	case CELL_GCM_TEXTURE_ZFUNC_ALWAYS: return zfunc::always;
+	}
+	throw EXCEPTION("unknow zfunc %x", in);
+}
+
+enum
+{
+	CELL_GCM_TEXTURE_UNSIGNED_REMAP_NORMAL = 0,
+	CELL_GCM_TEXTURE_UNSIGNED_REMAP_BIASED = 1,
+
+	CELL_GCM_TEXTURE_SIGNED_REMAP_NORMAL = 0x0,
+	CELL_GCM_TEXTURE_SIGNED_REMAP_CLAMPED = 0x3,
+};
+
+unsigned_remap to_unsigned_remap(u32 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TEXTURE_UNSIGNED_REMAP_NORMAL: return unsigned_remap::normal;
+	case CELL_GCM_TEXTURE_UNSIGNED_REMAP_BIASED: return unsigned_remap::biased;
+	}
+	throw EXCEPTION("unknow unsigned remap %x", in);
+}
+
+signed_remap to_signed_remap(u32 in)
+{
+	switch (in)
+	{
+	case CELL_GCM_TEXTURE_SIGNED_REMAP_NORMAL: return signed_remap::normal;
+	case CELL_GCM_TEXTURE_SIGNED_REMAP_CLAMPED: return signed_remap::clamped;
+	}
+	throw EXCEPTION("unknow signed remap %x", in);
+}
+
+component_remap to_component_remap(u32 in)
+{
+	switch (in)
+	{
+	case 0: return component_remap::A;
+	case 1: return component_remap::R;
+	case 2: return component_remap::G;
+	case 3: return component_remap::B;
+	}
+	throw EXCEPTION("unknow component remap %x", in);
+}
+
+
+} // end namespace texture
+} // end namespace rsx
 
 rsx::surface_target rsx::to_surface_target(u8 in)
 {
@@ -1758,244 +2065,7 @@ rsx::polygon_mode rsx::to_polygon_mode(u32 in)
 // Various parameter pretty printing function
 namespace
 {
-	std::string ptr_to_string(u32 ptr)
-	{
-		return fmt::format("0x%08x", ptr);
-	}
 
-	std::string dma_mode(u32 arg)
-	{
-		switch (arg)
-		{
-		case CELL_GCM_LOCATION_LOCAL:
-		case CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER: return "Local memory";
-		case CELL_GCM_LOCATION_MAIN:
-		case CELL_GCM_CONTEXT_DMA_MEMORY_HOST_BUFFER: return "Main memory";
-		}
-		return "Error";
-	}
-
-	std::string texture_dimension(u8 dim)
-	{
-		switch (rsx::to_texture_dimension(dim))
-		{
-		case rsx::texture_dimension::dimension1d: return "1D";
-		case rsx::texture_dimension::dimension2d: return "2D";
-		case rsx::texture_dimension::dimension3d: return "3D";
-		}
-		return "";
-	}
-
-	std::string get_vertex_attribute_format(u8 type)
-	{
-		switch (rsx::to_vertex_base_type(type))
-		{
-		case rsx::vertex_base_type::s1: return "Signed short normalized";
-		case rsx::vertex_base_type::f: return "Float";
-		case rsx::vertex_base_type::sf: return "Half float";
-		case rsx::vertex_base_type::ub: return "Unsigned byte normalized";
-		case rsx::vertex_base_type::s32k: return "Signed short unormalized";
-		case rsx::vertex_base_type::cmp: return "CMP";
-		case rsx::vertex_base_type::ub256: return "Unsigned byte unormalized";
-		}
-	}
-
-	std::string unpack_vertex_format(u32 arg)
-	{
-		u32 frequency = arg >> 16;
-		u32 stride = (arg >> 8) & 0xff;
-		u32 size = (arg >> 4) & 0xf;
-		u32 type = arg & 0xf;
-		if (size == 0)
-			return "(disabled)";
-
-		return "Type = " + get_vertex_attribute_format(type) + " size = " + std::to_string(size) + " stride = " + std::to_string(stride) + " frequency = " + std::to_string(frequency);
-	}
-
-	std::string transform_constant(size_t index, u32 arg)
-	{
-		return "Transform constant " + std::to_string(index) + ": " + std::to_string(arg) + "/" + std::to_string((float&)arg);
-	}
-
-	std::string texture_offset(size_t index, u32 arg)
-	{
-		return "Texture " + std::to_string(index) + ": Offset @" + ptr_to_string(arg);
-	}
-
-	std::string texture_size(size_t index, u32 arg)
-	{
-		return "Texture " + std::to_string(index) + ": width = " + std::to_string(arg & 0xffff) + " height = " + std::to_string(arg >> 16);
-	}
-
-	static std::string get_texture_format_name(u32 format)
-	{
-		switch (format)
-		{
-		case CELL_GCM_TEXTURE_COMPRESSED_HILO8: return "CELL_GCM_TEXTURE_COMPRESSED_HILO8";
-		case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8: return "CELL_GCM_TEXTURE_COMPRESSED_HILO_S8";
-		case CELL_GCM_TEXTURE_B8: return "CELL_GCM_TEXTURE_B8";
-		case CELL_GCM_TEXTURE_A1R5G5B5: return "CELL_GCM_TEXTURE_A1R5G5B5";
-		case CELL_GCM_TEXTURE_A4R4G4B4: return "CELL_GCM_TEXTURE_A4R4G4B4";
-		case CELL_GCM_TEXTURE_R5G6B5: return "CELL_GCM_TEXTURE_R5G6B5";
-		case CELL_GCM_TEXTURE_A8R8G8B8: return "CELL_GCM_TEXTURE_A8R8G8B8";
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT1: return "CELL_GCM_TEXTURE_COMPRESSED_DXT1";
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT23: return "CELL_GCM_TEXTURE_COMPRESSED_DXT23";
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT45: return "CELL_GCM_TEXTURE_COMPRESSED_DXT45";
-		case CELL_GCM_TEXTURE_G8B8: return "CELL_GCM_TEXTURE_G8B8";
-		case CELL_GCM_TEXTURE_R6G5B5: return "CELL_GCM_TEXTURE_R6G5B5";
-		case CELL_GCM_TEXTURE_DEPTH24_D8: return "CELL_GCM_TEXTURE_DEPTH24_D8";
-		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT: return "CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT";
-		case CELL_GCM_TEXTURE_DEPTH16: return "CELL_GCM_TEXTURE_DEPTH16";
-		case CELL_GCM_TEXTURE_DEPTH16_FLOAT: return "CELL_GCM_TEXTURE_DEPTH16_FLOAT";
-		case CELL_GCM_TEXTURE_X16: return "CELL_GCM_TEXTURE_X16";
-		case CELL_GCM_TEXTURE_Y16_X16: return "CELL_GCM_TEXTURE_Y16_X16";
-		case CELL_GCM_TEXTURE_R5G5B5A1: return "CELL_GCM_TEXTURE_R5G5B5A1";
-		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT: return "CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT";
-		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT: return "CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT";
-		case CELL_GCM_TEXTURE_X32_FLOAT: return "CELL_GCM_TEXTURE_X32_FLOAT";
-		case CELL_GCM_TEXTURE_D1R5G5B5: return "CELL_GCM_TEXTURE_D1R5G5B5";
-		case CELL_GCM_TEXTURE_D8R8G8B8: return "CELL_GCM_TEXTURE_D8R8G8B8";
-		case CELL_GCM_TEXTURE_Y16_X16_FLOAT: return "CELL_GCM_TEXTURE_Y16_X16_FLOAT";
-		case CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8: return "CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8";
-		case CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8: return "CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8";
-		}
-		return "Error";
-	}
-
-	std::string texture_format(size_t index, u32 arg)
-	{
-		int format = ((arg >> 8) & 0xFF);
-		return "Texture " + std::to_string(index) + ": location = " + ptr_to_string((arg & 0x3) - 1) +
-			(((arg >> 2) & 0x1) ? " cubemap " : "") +
-			" border type = " + std::to_string((arg >> 3) & 0x1) +
-			" dimension = " + std::to_string((arg >> 4) & 0xF) +
-			" format = " + get_texture_format_name(format & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN)) +
-			((format & CELL_GCM_TEXTURE_LN) ? "" : " swizzled") +
-			((format & CELL_GCM_TEXTURE_UN) ? " unormalized coordinates" : "") +
-			" mipmap levels = " + std::to_string((arg >> 16) & 0xFFFF);
-	}
-
-	std::string get_texture_wrap_mode(u8 wrap)
-	{
-		switch (rsx::to_texture_wrap_mode(wrap))
-		{
-		case rsx::texture_wrap_mode::wrap: return "WRAP";
-		case rsx::texture_wrap_mode::mirror: return "MIRROR";
-		case rsx::texture_wrap_mode::clamp_to_edge: return "CLAMP_TO_EDGE";
-		case rsx::texture_wrap_mode::border: return "BORDER";
-		case rsx::texture_wrap_mode::clamp: return "CLAMP";
-		case rsx::texture_wrap_mode::mirror_once_clamp_to_edge: return "MIRROR_ONCE_CLAMP_TO_EDGE";
-		case rsx::texture_wrap_mode::mirror_once_border: return "MIRROR_ONCE_BORDER";
-		case rsx::texture_wrap_mode::mirror_once_clamp: return "MIRROR_ONCE_CLAMP";
-		}
-		return "Error";
-	}
-
-	std::string get_zfunc_name(u8 op)
-	{
-		switch (op)
-		{
-		case 0: return "Never";
-		case 1: return "Less";
-		case 2: return "Equal";
-		case 3: return "LEqual";
-		case 4: return "Greater";
-		case 5: return "NotEqual";
-		case 6: return "GreaterOrEqual";
-		case 7: return "Always";
-		}
-		return "Error";
-	}
-
-	std::string texture_address(size_t index, u32 arg)
-	{
-		return "Texture " + std::to_string(index) + ": wrap_s = " + get_texture_wrap_mode(arg & 0xF) +
-			" wrap_t = " + get_texture_wrap_mode((arg >> 8) & 0xF) +
-			" wrap_r = " + get_texture_wrap_mode((arg >> 16) & 0xF) +
-			" unsigned remap = " + std::to_string((arg >> 12) & 0xF) +
-			" zfunc = " + get_zfunc_name((arg >> 28) & 0xF) +
-			" gamma = " + std::to_string((arg >> 20) & 0xF) +
-			" aniso bias = " + std::to_string((arg >> 4) & 0xF) +
-			" signed remap = " + std::to_string((arg >> 24) & 0xF);
-	}
-
-	std::string get_texture_max_aniso_name(u8 aniso)
-	{
-		switch (rsx::to_texture_max_anisotropy(aniso))
-		{
-		case rsx::texture_max_anisotropy::x1: return "1";
-		case rsx::texture_max_anisotropy::x2: return "2";
-		case rsx::texture_max_anisotropy::x4: return "4";
-		case rsx::texture_max_anisotropy::x6: return "6";
-		case rsx::texture_max_anisotropy::x8: return "8";
-		case rsx::texture_max_anisotropy::x10: return "10";
-		case rsx::texture_max_anisotropy::x12: return "12";
-		case rsx::texture_max_anisotropy::x16: return "16";
-		}
-		return "Error";
-	}
-
-	std::string texture_control0(size_t index, u32 arg)
-	{
-		std::string result = "Texture " + std::to_string(index);
-		if ((arg >> 31) & 0x1)
-		{
-			result += " min lod = " + std::to_string((arg >> 19) & 0xFFF) +
-				" max lod = " + std::to_string((arg >> 7) & 0xFFF) +
-				" max aniso = " + get_texture_max_aniso_name((arg >> 4) & 0x7) +
-				" alpha kill = " + (((arg >> 2) & 0x1) ? "true" : "false");
-		}
-		else
-			result += " (disabled)";
-		return result;
-	}
-
-	std::string get_remap_channel(u8 op) noexcept
-	{
-		switch (op)
-		{
-		case 0: return "A";
-		case 1: return "R";
-		case 2: return "G";
-		case 3: return "B";
-		}
-		return "Error";
-	}
-
-	std::string texture_control1(size_t index, u32 arg) noexcept
-	{
-		return "Texture " + std::to_string(index) +
-			" Component 0 = " + get_remap_channel(arg & 0x3) +
-			" Component 1 = " + get_remap_channel((arg >> 2) & 0x3) +
-			" Component 2 = " + get_remap_channel((arg >> 4) & 0x3) +
-			" Component 3 = " + get_remap_channel((arg >> 6) & 0x3);
-	}
-
-	std::string texture_control3(size_t index, u32 arg)
-	{
-		return "Texture " + std::to_string(index) +
-			" depth = " + std::to_string(arg >> 20) +
-			" pitch = " + std::to_string(arg & 0xFFFFF);
-	}
-
-	std::string texture_border_color(size_t index, u32 arg)
-	{
-		return "Texture " + std::to_string(index) +
-			" border color = " + std::to_string(arg);
-	}
-
-	std::string texture_filter(size_t index, u32 arg)
-	{
-		return "Texture " + std::to_string(index) +
-			" bias = " + std::to_string(arg & 0x1fff) +
-			" min_filter = " + std::to_string((arg >> 16) & 0x7) +
-			" mag_filter = " + std::to_string((arg >> 24) & 0x7) +
-			" convolution_filter = " + std::to_string((arg >> 13) & 0xF) +
-			" a_signed = " + std::to_string((arg >> 28) & 0x1) +
-			" r_signed = " + std::to_string((arg >> 29) & 0x1) +
-			" g_signed = " + std::to_string((arg >> 30) & 0x1) +
-			" b_signed = " + std::to_string((arg >> 31) & 0x1);
-	}
 
 	namespace
 	{

--- a/rpcs3/Emu/RSX/GCM.h
+++ b/rpcs3/Emu/RSX/GCM.h
@@ -155,65 +155,6 @@ namespace rsx
 
 	fog_mode to_fog_mode(u32 in);
 
-	enum class texture_dimension : u8
-	{
-		dimension1d,
-		dimension2d,
-		dimension3d,
-	};
-
-	texture_dimension to_texture_dimension(u8 in);
-
-	enum class texture_wrap_mode : u8
-	{
-		wrap,
-		mirror,
-		clamp_to_edge,
-		border,
-		clamp,
-		mirror_once_clamp_to_edge,
-		mirror_once_border,
-		mirror_once_clamp,
-	};
-
-	texture_wrap_mode to_texture_wrap_mode(u8 in);
-
-	enum class texture_max_anisotropy : u8
-	{
-		x1,
-		x2,
-		x4,
-		x6,
-		x8,
-		x10,
-		x12,
-		x16,
-	};
-
-	texture_max_anisotropy to_texture_max_anisotropy(u8 in);
-
-	enum class texture_minify_filter : u8
-	{
-		nearest, ///< no filtering, mipmap base level
-		linear, ///< linear filtering, mipmap base level
-		nearest_nearest, ///< no filtering, closest mipmap level
-		linear_nearest, ///< linear filtering, closest mipmap level
-		nearest_linear, ///< no filtering, linear mix between closest mipmap levels
-		linear_linear, ///< linear filtering, linear mix between closest mipmap levels
-		convolution_min, ///< Unknown mode but looks close to linear_linear
-	};
-
-	texture_minify_filter to_texture_minify_filter(u8 in);
-
-	enum class texture_magnify_filter : u8
-	{
-		nearest, ///< no filtering
-		linear, ///< linear filtering
-		convolution_mag, ///< Unknown mode but looks close to linear
-	};
-
-	texture_magnify_filter to_texture_magnify_filter(u8 in);
-
 	enum class stencil_op : u8
 	{
 		keep,
@@ -327,6 +268,161 @@ namespace rsx
 	};
 
 	polygon_mode to_polygon_mode(u32 in);
+
+	namespace texture
+	{
+		enum class dimension : u8
+		{
+			dimension1d,
+			dimension2d,
+			dimension3d,
+		};
+
+		dimension to_texture_dimension(u8 in);
+
+		enum class wrap_mode : u8
+		{
+			wrap,
+			mirror,
+			clamp_to_edge,
+			border,
+			clamp,
+			mirror_once_clamp_to_edge,
+			mirror_once_border,
+			mirror_once_clamp,
+		};
+
+		wrap_mode to_texture_wrap_mode(u8 in);
+
+		enum class max_anisotropy : u8
+		{
+			x1,
+			x2,
+			x4,
+			x6,
+			x8,
+			x10,
+			x12,
+			x16,
+		};
+
+		max_anisotropy to_texture_max_anisotropy(u8 in);
+
+		enum class minify_filter : u8
+		{
+			nearest, ///< no filtering, mipmap base level
+			linear, ///< linear filtering, mipmap base level
+			nearest_nearest, ///< no filtering, closest mipmap level
+			linear_nearest, ///< linear filtering, closest mipmap level
+			nearest_linear, ///< no filtering, linear mix between closest mipmap levels
+			linear_linear, ///< linear filtering, linear mix between closest mipmap levels
+			convolution_min, ///< Unknow mode but looks close to linear_linear
+		};
+
+		minify_filter to_texture_minify_filter(u8 in);
+
+		enum class magnify_filter : u8
+		{
+			nearest, ///< no filtering
+			linear, ///< linear filtering
+			convolution_mag, ///< Unknow mode but looks close to linear
+		};
+
+		magnify_filter to_texture_magnify_filter(u8 in);
+
+		enum class border_type : u8
+		{
+			texture,
+			color,
+		};
+
+		border_type to_border_type(u32 in);
+
+		enum class format : u8
+		{
+			b8,
+			a1r5g5b5,
+			a4r4g4b4,
+			r5g6b5,
+			a8r8g8b8,
+			compressed_dxt1,
+			compressed_dxt23,
+			compressed_dxt45,
+			g8b8,
+			r6g5b5,
+			d24_8,
+			d24_8_float,
+			d16,
+			d16_float,
+			x16,
+			y16x16,
+			r5g5b5a1,
+			compressed_hilo_8,
+			compressed_hilo_s8,
+			w16z16y16x16_float,
+			w32z32y32x32_float,
+			x32float,
+			d1r5g5b5,
+			d8r8g8b8,
+			y16x16_float,
+			compressed_b8r8_g8r8,
+			compressed_r8b8_r8g8,
+		};
+
+		enum class layout : u8
+		{
+			linear,
+			swizzled,
+		};
+
+		enum class coordinates : u8
+		{
+			normalized,
+			unnormalized,
+		};
+
+		std::tuple<format, layout, coordinates> to_texture_format(u32 in);
+
+		enum class zfunc : u8
+		{
+			never,
+			less,
+			equal,
+			lequal,
+			greater,
+			notequal,
+			gequal,
+			always,
+		};
+
+		zfunc to_texture_zfunc(u32 in);
+
+		enum class unsigned_remap : u8
+		{
+			normal,
+			biased,
+		};
+
+		unsigned_remap to_unsigned_remap(u32 in);
+
+		enum class signed_remap : u8
+		{
+			normal,
+			clamped,
+		};
+
+		signed_remap to_signed_remap(u32 in);
+
+		enum class component_remap : u8
+		{
+			A,
+			R,
+			G,
+			B
+		};
+
+		component_remap to_component_remap(u32 in);
+	}
 
 	namespace blit_engine
 	{
@@ -464,14 +560,6 @@ enum
 	CELL_GCM_TEXTURE_Y16_X16_FLOAT          = 0x9F,
 	CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8   = 0xAD,
 	CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8   = 0xAE,
-
-	// Swizzle Flag
-	CELL_GCM_TEXTURE_SZ = 0x00,
-	CELL_GCM_TEXTURE_LN = 0x20,
-	
-	// Normalization Flag
-	CELL_GCM_TEXTURE_NR = 0x00,
-	CELL_GCM_TEXTURE_UN = 0x40,
 };
 
 // GCM Surface
@@ -484,21 +572,6 @@ enum
 
 enum
 {
-	CELL_GCM_TEXTURE_UNSIGNED_REMAP_NORMAL = 0,
-	CELL_GCM_TEXTURE_UNSIGNED_REMAP_BIASED = 1,
-
-	CELL_GCM_TEXTURE_SIGNED_REMAP_NORMAL = 0x0,
-	CELL_GCM_TEXTURE_SIGNED_REMAP_CLAMPED = 0x3,
-
-	CELL_GCM_TEXTURE_ZFUNC_NEVER = 0,
-	CELL_GCM_TEXTURE_ZFUNC_LESS = 1,
-	CELL_GCM_TEXTURE_ZFUNC_EQUAL = 2,
-	CELL_GCM_TEXTURE_ZFUNC_LEQUAL = 3,
-	CELL_GCM_TEXTURE_ZFUNC_GREATER = 4,
-	CELL_GCM_TEXTURE_ZFUNC_NOTEQUAL = 5,
-	CELL_GCM_TEXTURE_ZFUNC_GEQUAL = 6,
-	CELL_GCM_TEXTURE_ZFUNC_ALWAYS = 7,
-
 	CELL_GCM_TEXTURE_GAMMA_R = 1 << 0,
 	CELL_GCM_TEXTURE_GAMMA_G = 1 << 1,
 	CELL_GCM_TEXTURE_GAMMA_B = 1 << 2,

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -314,7 +314,7 @@ void GLGSRender::begin()
 
 namespace
 {
-	GLenum get_gl_target_for_texture(const rsx::texture& tex)
+	GLenum get_gl_target_for_texture(const rsx::texture_t& tex)
 	{
 		switch (tex.get_extended_texture_dimension())
 		{
@@ -326,7 +326,7 @@ namespace
 		throw EXCEPTION("Unknown texture target");
 	}
 
-	GLenum get_gl_target_for_texture(const rsx::vertex_texture& tex)
+	GLenum get_gl_target_for_texture(const rsx::vertex_texture_t& tex)
 	{
 		switch (tex.get_extended_texture_dimension())
 		{
@@ -417,7 +417,7 @@ void GLGSRender::end()
 
 				if (m_program->uniforms.has_location("ftexture" + std::to_string(i) + "_cm", &location))
 				{
-					if (rsx::method_registers.fragment_textures[i].format() & CELL_GCM_TEXTURE_UN)
+					if (rsx::method_registers.fragment_textures[i].normalization() == rsx::texture::coordinates::unnormalized)
 					{
 						u32 width = std::max<u32>(rsx::method_registers.fragment_textures[i].width(), 1);
 						u32 height = std::max<u32>(rsx::method_registers.fragment_textures[i].height(), 1);
@@ -455,7 +455,7 @@ void GLGSRender::end()
 
 				if (m_program->uniforms.has_location("vtexture" + std::to_string(i) + "_cm", &location))
 				{
-					if (rsx::method_registers.fragment_textures[i].format() & CELL_GCM_TEXTURE_UN)
+					if (rsx::method_registers.fragment_textures[i].normalization() == rsx::texture::coordinates::unnormalized)
 					{
 						u32 width = std::max<u32>(rsx::method_registers.fragment_textures[i].width(), 1);
 						u32 height = std::max<u32>(rsx::method_registers.fragment_textures[i].height(), 1);

--- a/rpcs3/Emu/RSX/GL/rsx_gl_texture.cpp
+++ b/rpcs3/Emu/RSX/GL/rsx_gl_texture.cpp
@@ -9,94 +9,94 @@
 
 namespace
 {
-	GLenum get_sized_internal_format(u32 texture_format)
+	GLenum get_sized_internal_format(rsx::texture::format texture_format)
 	{
 		switch (texture_format)
 		{
-		case CELL_GCM_TEXTURE_B8: return GL_R8;
-		case CELL_GCM_TEXTURE_A1R5G5B5: return GL_RGB5_A1;
-		case CELL_GCM_TEXTURE_A4R4G4B4: return GL_RGBA4;
-		case CELL_GCM_TEXTURE_R5G6B5: return GL_RGB565;
-		case CELL_GCM_TEXTURE_A8R8G8B8: return GL_RGBA8;
-		case CELL_GCM_TEXTURE_G8B8: return GL_RG8;
-		case CELL_GCM_TEXTURE_R6G5B5: return GL_RGB565;
-		case CELL_GCM_TEXTURE_DEPTH24_D8: return GL_DEPTH_COMPONENT24;
-		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT: return GL_DEPTH_COMPONENT24;
-		case CELL_GCM_TEXTURE_DEPTH16: return GL_DEPTH_COMPONENT16;
-		case CELL_GCM_TEXTURE_DEPTH16_FLOAT: return GL_DEPTH_COMPONENT16;
-		case CELL_GCM_TEXTURE_X16: return GL_R16;
-		case CELL_GCM_TEXTURE_Y16_X16: return GL_RG16;
-		case CELL_GCM_TEXTURE_R5G5B5A1: return GL_RGB5_A1;
-		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT: return GL_RGBA16F;
-		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT: return GL_RGBA32F;
-		case CELL_GCM_TEXTURE_X32_FLOAT: return GL_R32F;
-		case CELL_GCM_TEXTURE_D1R5G5B5: return GL_RGB5_A1;
-		case CELL_GCM_TEXTURE_D8R8G8B8: return GL_RGBA8;
-		case CELL_GCM_TEXTURE_Y16_X16_FLOAT: return GL_RG16F;
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT1: return GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT23: return GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT45: return GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+		case rsx::texture::format::b8: return GL_R8;
+		case rsx::texture::format::a1r5g5b5: return GL_RGB5_A1;
+		case rsx::texture::format::a4r4g4b4: return GL_RGBA4;
+		case rsx::texture::format::r5g6b5: return GL_RGB565;
+		case rsx::texture::format::a8r8g8b8: return GL_RGBA8;
+		case rsx::texture::format::g8b8: return GL_RG8;
+		case rsx::texture::format::r6g5b5: return GL_RGB565;
+		case rsx::texture::format::d24_8: return GL_DEPTH_COMPONENT24;
+		case rsx::texture::format::d24_8_float: return GL_DEPTH_COMPONENT24;
+		case rsx::texture::format::d16: return GL_DEPTH_COMPONENT16;
+		case rsx::texture::format::d16_float: return GL_DEPTH_COMPONENT16;
+		case rsx::texture::format::x16: return GL_R16;
+		case rsx::texture::format::y16x16: return GL_RG16;
+		case rsx::texture::format::r5g5b5a1: return GL_RGB5_A1;
+		case rsx::texture::format::w16z16y16x16_float: return GL_RGBA16F;
+		case rsx::texture::format::w32z32y32x32_float: return GL_RGBA32F;
+		case rsx::texture::format::x32float: return GL_R32F;
+		case rsx::texture::format::d1r5g5b5: return GL_RGB5_A1;
+		case rsx::texture::format::d8r8g8b8: return GL_RGBA8;
+		case rsx::texture::format::y16x16_float: return GL_RG16F;
+		case rsx::texture::format::compressed_dxt1: return GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
+		case rsx::texture::format::compressed_dxt23: return GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
+		case rsx::texture::format::compressed_dxt45: return GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
 		}
 		throw EXCEPTION("Compressed or unknown texture format %x", texture_format);
 	}
 
 
-	std::tuple<GLenum, GLenum> get_format_type(u32 texture_format)
+	std::tuple<GLenum, GLenum> get_format_type(rsx::texture::format texture_format)
 	{
 		switch (texture_format)
 		{
-		case CELL_GCM_TEXTURE_B8: return std::make_tuple(GL_RED, GL_UNSIGNED_BYTE);
-		case CELL_GCM_TEXTURE_A1R5G5B5: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_1_5_5_5_REV);
-		case CELL_GCM_TEXTURE_A4R4G4B4: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_4_4_4_4);
-		case CELL_GCM_TEXTURE_R5G6B5: return std::make_tuple(GL_RGB, GL_UNSIGNED_SHORT_5_6_5);
-		case CELL_GCM_TEXTURE_A8R8G8B8: return std::make_tuple(GL_BGRA, GL_UNSIGNED_INT_8_8_8_8);
-		case CELL_GCM_TEXTURE_G8B8: return std::make_tuple(GL_RG, GL_UNSIGNED_BYTE);
-		case CELL_GCM_TEXTURE_R6G5B5: return std::make_tuple(GL_RGBA, GL_UNSIGNED_BYTE);
-		case CELL_GCM_TEXTURE_DEPTH24_D8: return std::make_tuple(GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE);
-		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT: return std::make_tuple(GL_DEPTH_COMPONENT, GL_FLOAT);
-		case CELL_GCM_TEXTURE_DEPTH16: return std::make_tuple(GL_DEPTH_COMPONENT, GL_SHORT);
-		case CELL_GCM_TEXTURE_DEPTH16_FLOAT: return std::make_tuple(GL_DEPTH_COMPONENT, GL_FLOAT);
-		case CELL_GCM_TEXTURE_X16: return std::make_tuple(GL_RED, GL_UNSIGNED_SHORT);
-		case CELL_GCM_TEXTURE_Y16_X16: return std::make_tuple(GL_RG, GL_UNSIGNED_SHORT);
-		case CELL_GCM_TEXTURE_R5G5B5A1: return std::make_tuple(GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1);
-		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT: return std::make_tuple(GL_RGBA, GL_HALF_FLOAT);
-		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT: return std::make_tuple(GL_RGBA, GL_FLOAT);
-		case CELL_GCM_TEXTURE_X32_FLOAT: return std::make_tuple(GL_RED, GL_FLOAT);
-		case CELL_GCM_TEXTURE_D1R5G5B5: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_1_5_5_5_REV);
-		case CELL_GCM_TEXTURE_D8R8G8B8: return std::make_tuple(GL_BGRA, GL_UNSIGNED_INT_8_8_8_8);
-		case CELL_GCM_TEXTURE_Y16_X16_FLOAT: return std::make_tuple(GL_RG, GL_HALF_FLOAT);
+		case rsx::texture::format::b8: return std::make_tuple(GL_RED, GL_UNSIGNED_BYTE);
+		case rsx::texture::format::a1r5g5b5: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_1_5_5_5_REV);
+		case rsx::texture::format::a4r4g4b4: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_4_4_4_4);
+		case rsx::texture::format::r5g6b5: return std::make_tuple(GL_RGB, GL_UNSIGNED_SHORT_5_6_5);
+		case rsx::texture::format::a8r8g8b8: return std::make_tuple(GL_BGRA, GL_UNSIGNED_INT_8_8_8_8);
+		case rsx::texture::format::g8b8: return std::make_tuple(GL_RG, GL_UNSIGNED_BYTE);
+		case rsx::texture::format::r6g5b5: return std::make_tuple(GL_RGBA, GL_UNSIGNED_BYTE);
+		case rsx::texture::format::d24_8: return std::make_tuple(GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE);
+		case rsx::texture::format::d24_8_float: return std::make_tuple(GL_DEPTH_COMPONENT, GL_FLOAT);
+		case rsx::texture::format::d16: return std::make_tuple(GL_DEPTH_COMPONENT, GL_SHORT);
+		case rsx::texture::format::d16_float: return std::make_tuple(GL_DEPTH_COMPONENT, GL_FLOAT);
+		case rsx::texture::format::x16: return std::make_tuple(GL_RED, GL_UNSIGNED_SHORT);
+		case rsx::texture::format::y16x16: return std::make_tuple(GL_RG, GL_UNSIGNED_SHORT);
+		case rsx::texture::format::r5g5b5a1: return std::make_tuple(GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1);
+		case rsx::texture::format::w16z16y16x16_float: return std::make_tuple(GL_RGBA, GL_HALF_FLOAT);
+		case rsx::texture::format::w32z32y32x32_float: return std::make_tuple(GL_RGBA, GL_FLOAT);
+		case rsx::texture::format::x32float: return std::make_tuple(GL_RED, GL_FLOAT);
+		case rsx::texture::format::d1r5g5b5: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_1_5_5_5_REV);
+		case rsx::texture::format::d8r8g8b8: return std::make_tuple(GL_BGRA, GL_UNSIGNED_INT_8_8_8_8);
+		case rsx::texture::format::y16x16_float: return std::make_tuple(GL_RG, GL_HALF_FLOAT);
 		}
 		throw EXCEPTION("Compressed or unknown texture format %x", texture_format);
 	}
 
-	bool is_compressed_format(u32 texture_format)
+	bool is_compressed_format(rsx::texture::format texture_format)
 	{
 		switch (texture_format)
 		{
-		case CELL_GCM_TEXTURE_B8:
-		case CELL_GCM_TEXTURE_A1R5G5B5:
-		case CELL_GCM_TEXTURE_A4R4G4B4:
-		case CELL_GCM_TEXTURE_R5G6B5:
-		case CELL_GCM_TEXTURE_A8R8G8B8:
-		case CELL_GCM_TEXTURE_G8B8:
-		case CELL_GCM_TEXTURE_R6G5B5:
-		case CELL_GCM_TEXTURE_DEPTH24_D8:
-		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
-		case CELL_GCM_TEXTURE_DEPTH16:
-		case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-		case CELL_GCM_TEXTURE_X16:
-		case CELL_GCM_TEXTURE_Y16_X16:
-		case CELL_GCM_TEXTURE_R5G5B5A1:
-		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
-		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
-		case CELL_GCM_TEXTURE_X32_FLOAT:
-		case CELL_GCM_TEXTURE_D1R5G5B5:
-		case CELL_GCM_TEXTURE_D8R8G8B8:
-		case CELL_GCM_TEXTURE_Y16_X16_FLOAT:
+		case rsx::texture::format::b8:
+		case rsx::texture::format::a1r5g5b5:
+		case rsx::texture::format::a4r4g4b4:
+		case rsx::texture::format::r5g6b5:
+		case rsx::texture::format::a8r8g8b8:
+		case rsx::texture::format::g8b8:
+		case rsx::texture::format::r6g5b5:
+		case rsx::texture::format::d24_8:
+		case rsx::texture::format::d24_8_float:
+		case rsx::texture::format::d16:
+		case rsx::texture::format::d16_float:
+		case rsx::texture::format::x16:
+		case rsx::texture::format::y16x16:
+		case rsx::texture::format::r5g5b5a1:
+		case rsx::texture::format::w16z16y16x16_float:
+		case rsx::texture::format::w32z32y32x32_float:
+		case rsx::texture::format::x32float:
+		case rsx::texture::format::d1r5g5b5:
+		case rsx::texture::format::d8r8g8b8:
+		case rsx::texture::format::y16x16_float:
 			return false;
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT1:
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT23:
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT45:
+		case rsx::texture::format::compressed_dxt1:
+		case rsx::texture::format::compressed_dxt23:
+		case rsx::texture::format::compressed_dxt45:
 			return true;
 		}
 		throw EXCEPTION("Unknown format %x", texture_format);
@@ -119,64 +119,59 @@ namespace
 		return false;
 	}
 
-	std::array<GLenum, 4> get_swizzle_remap(u32 texture_format)
+	std::array<GLenum, 4> get_swizzle_remap(rsx::texture::format texture_format)
 	{
 		// NOTE: This must be in ARGB order in all forms below.
 		switch (texture_format)
 		{
-		case CELL_GCM_TEXTURE_A1R5G5B5:
-		case CELL_GCM_TEXTURE_R5G5B5A1:
-		case CELL_GCM_TEXTURE_R6G5B5:
-		case CELL_GCM_TEXTURE_R5G6B5:
-		case CELL_GCM_TEXTURE_A8R8G8B8: // TODO
-		case CELL_GCM_TEXTURE_DEPTH24_D8:
-		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
-		case CELL_GCM_TEXTURE_DEPTH16:
-		case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT1:
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT23:
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT45:
-		case CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8:
-		case CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8:
+		case rsx::texture::format::a1r5g5b5:
+		case rsx::texture::format::r5g5b5a1:
+		case rsx::texture::format::r6g5b5:
+		case rsx::texture::format::r5g6b5:
+		case rsx::texture::format::a8r8g8b8: // TODO
+		case rsx::texture::format::d24_8:
+		case rsx::texture::format::d24_8_float:
+		case rsx::texture::format::d16:
+		case rsx::texture::format::d16_float:
+		case rsx::texture::format::w32z32y32x32_float:
+		case rsx::texture::format::compressed_dxt1:
+		case rsx::texture::format::compressed_dxt23:
+		case rsx::texture::format::compressed_dxt45:
+		case rsx::texture::format::compressed_b8r8_g8r8:
+		case rsx::texture::format::compressed_r8b8_r8g8:
 			return { GL_ALPHA, GL_RED, GL_GREEN, GL_BLUE };
 
-		case CELL_GCM_TEXTURE_B8: 
+		case rsx::texture::format::b8:
 			return { GL_RED, GL_RED, GL_RED, GL_RED };
 
-		case CELL_GCM_TEXTURE_A4R4G4B4: 
+		case rsx::texture::format::a4r4g4b4:
 			return { GL_BLUE, GL_ALPHA, GL_RED, GL_GREEN };
 
-		case CELL_GCM_TEXTURE_G8B8: 
+		case rsx::texture::format::g8b8:
 			return { GL_GREEN, GL_RED, GL_GREEN, GL_RED};
 
-		case CELL_GCM_TEXTURE_X16: 
+		case rsx::texture::format::x16:
 			return { GL_RED, GL_ONE, GL_RED, GL_ONE };
 
-		case CELL_GCM_TEXTURE_Y16_X16: 
+		case rsx::texture::format::y16x16:
 			return { GL_RED, GL_GREEN, GL_RED, GL_GREEN};
 
-		case CELL_GCM_TEXTURE_X32_FLOAT: 
+		case rsx::texture::format::x32float:
 			return { GL_RED, GL_ONE, GL_ONE, GL_ONE };
 
-		case CELL_GCM_TEXTURE_Y16_X16_FLOAT: 
+		case rsx::texture::format::y16x16_float:
 			return { GL_GREEN, GL_RED, GL_GREEN, GL_RED };
 
-		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
+		case rsx::texture::format::w16z16y16x16_float:
 			return { GL_RED, GL_ALPHA, GL_BLUE, GL_GREEN };
 
-		case CELL_GCM_TEXTURE_D1R5G5B5:
-		case CELL_GCM_TEXTURE_D8R8G8B8: 
+		case rsx::texture::format::d1r5g5b5:
+		case rsx::texture::format::d8r8g8b8:
 			return { GL_ONE, GL_RED, GL_GREEN, GL_BLUE };
 
-		case CELL_GCM_TEXTURE_COMPRESSED_HILO8:
-		case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8: 
+		case rsx::texture::format::compressed_hilo_8:
+		case rsx::texture::format::compressed_hilo_s8:
 			return { GL_RED, GL_GREEN, GL_RED, GL_GREEN };
-
-		case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8:
-		case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8:
-			return { GL_ZERO, GL_GREEN, GL_BLUE, GL_RED };
-
 		}
 		throw EXCEPTION("Unknown format %x", texture_format);
 	}
@@ -186,28 +181,28 @@ namespace rsx
 {
 	namespace gl
 	{
-		int gl_tex_min_filter(rsx::texture_minify_filter min_filter)
+		int gl_tex_min_filter(rsx::texture::minify_filter min_filter)
 		{
 			switch (min_filter)
 			{
-			case rsx::texture_minify_filter::nearest: return GL_NEAREST;
-			case rsx::texture_minify_filter::linear: return GL_LINEAR;
-			case rsx::texture_minify_filter::nearest_nearest: return GL_NEAREST_MIPMAP_NEAREST;
-			case rsx::texture_minify_filter::linear_nearest: return GL_LINEAR_MIPMAP_NEAREST;
-			case rsx::texture_minify_filter::nearest_linear: return GL_NEAREST_MIPMAP_LINEAR;
-			case rsx::texture_minify_filter::linear_linear: return GL_LINEAR_MIPMAP_LINEAR;
-			case rsx::texture_minify_filter::convolution_min: return GL_LINEAR_MIPMAP_LINEAR;
+			case rsx::texture::minify_filter::nearest: return GL_NEAREST;
+			case rsx::texture::minify_filter::linear: return GL_LINEAR;
+			case rsx::texture::minify_filter::nearest_nearest: return GL_NEAREST_MIPMAP_NEAREST;
+			case rsx::texture::minify_filter::linear_nearest: return GL_LINEAR_MIPMAP_NEAREST;
+			case rsx::texture::minify_filter::nearest_linear: return GL_NEAREST_MIPMAP_LINEAR;
+			case rsx::texture::minify_filter::linear_linear: return GL_LINEAR_MIPMAP_LINEAR;
+			case rsx::texture::minify_filter::convolution_min: return GL_LINEAR_MIPMAP_LINEAR;
 			}
 			throw EXCEPTION("Unknow min filter");
 		}
 
-		int gl_tex_mag_filter(rsx::texture_magnify_filter mag_filter)
+		int gl_tex_mag_filter(rsx::texture::magnify_filter mag_filter)
 		{
 			switch (mag_filter)
 			{
-			case rsx::texture_magnify_filter::nearest: return GL_NEAREST;
-			case rsx::texture_magnify_filter::linear: return GL_LINEAR;
-			case rsx::texture_magnify_filter::convolution_mag: return GL_LINEAR;
+			case rsx::texture::magnify_filter::nearest: return GL_NEAREST;
+			case rsx::texture::magnify_filter::linear: return GL_LINEAR;
+			case rsx::texture::magnify_filter::convolution_mag: return GL_LINEAR;
 			}
 			throw EXCEPTION("Unknow mag filter");
 		}
@@ -234,84 +229,81 @@ namespace rsx
 			glGenTextures(1, &m_id);
 		}
 
-		int texture::gl_wrap(rsx::texture_wrap_mode wrap)
+		int texture::gl_wrap(rsx::texture::wrap_mode wrap)
 		{
 			switch (wrap)
 			{
-			case rsx::texture_wrap_mode::wrap: return GL_REPEAT;
-			case rsx::texture_wrap_mode::mirror: return GL_MIRRORED_REPEAT;
-			case rsx::texture_wrap_mode::clamp_to_edge: return GL_CLAMP_TO_EDGE;
-			case rsx::texture_wrap_mode::border: return GL_CLAMP_TO_BORDER;
-			case rsx::texture_wrap_mode::clamp: return GL_CLAMP_TO_BORDER;
-			case rsx::texture_wrap_mode::mirror_once_clamp_to_edge: return GL_MIRROR_CLAMP_TO_EDGE_EXT;
-			case rsx::texture_wrap_mode::mirror_once_border: return GL_MIRROR_CLAMP_TO_BORDER_EXT;
-			case rsx::texture_wrap_mode::mirror_once_clamp: return GL_MIRROR_CLAMP_EXT;
+			case rsx::texture::wrap_mode::wrap: return GL_REPEAT;
+			case rsx::texture::wrap_mode::mirror: return GL_MIRRORED_REPEAT;
+			case rsx::texture::wrap_mode::clamp_to_edge: return GL_CLAMP_TO_EDGE;
+			case rsx::texture::wrap_mode::border: return GL_CLAMP_TO_BORDER;
+			case rsx::texture::wrap_mode::clamp: return GL_CLAMP_TO_BORDER;
+			case rsx::texture::wrap_mode::mirror_once_clamp_to_edge: return GL_MIRROR_CLAMP_TO_EDGE_EXT;
+			case rsx::texture::wrap_mode::mirror_once_border: return GL_MIRROR_CLAMP_TO_BORDER_EXT;
+			case rsx::texture::wrap_mode::mirror_once_clamp: return GL_MIRROR_CLAMP_EXT;
 			}
 
 			LOG_ERROR(RSX, "Texture wrap error: bad wrap (%d).", wrap);
 			return GL_REPEAT;
 		}
 
-		float texture::max_aniso(rsx::texture_max_anisotropy aniso)
+		float texture::max_aniso(rsx::texture::max_anisotropy aniso)
 		{
 			switch (aniso)
 			{
-			case rsx::texture_max_anisotropy::x1: return 1.0f;
-			case rsx::texture_max_anisotropy::x2: return 2.0f;
-			case rsx::texture_max_anisotropy::x4: return 4.0f;
-			case rsx::texture_max_anisotropy::x6: return 6.0f;
-			case rsx::texture_max_anisotropy::x8: return 8.0f;
-			case rsx::texture_max_anisotropy::x10: return 10.0f;
-			case rsx::texture_max_anisotropy::x12: return 12.0f;
-			case rsx::texture_max_anisotropy::x16: return 16.0f;
+			case rsx::texture::max_anisotropy::x1: return 1.0f;
+			case rsx::texture::max_anisotropy::x2: return 2.0f;
+			case rsx::texture::max_anisotropy::x4: return 4.0f;
+			case rsx::texture::max_anisotropy::x6: return 6.0f;
+			case rsx::texture::max_anisotropy::x8: return 8.0f;
+			case rsx::texture::max_anisotropy::x10: return 10.0f;
+			case rsx::texture::max_anisotropy::x12: return 12.0f;
+			case rsx::texture::max_anisotropy::x16: return 16.0f;
 			}
 
 			LOG_ERROR(RSX, "Texture anisotropy error: bad max aniso (%d).", aniso);
 			return 1.0f;
 		}
 
-		u16 texture::get_pitch_modifier(u32 format)
+		u16 texture::get_pitch_modifier(rsx::texture::format format)
 		{
 			switch (format)
 			{
-			case CELL_GCM_TEXTURE_COMPRESSED_HILO8:
-			case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8:
+			case rsx::texture::format::compressed_hilo_8:
+			case rsx::texture::format::compressed_hilo_s8:
 			default:
 				LOG_ERROR(RSX, "Unimplemented pitch modifier for texture format: 0x%x", format);
 				return 0;
-			case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8:
-			case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8:
-				return 4;
-			case CELL_GCM_TEXTURE_B8:
+			case rsx::texture::format::b8:
 				return 1;
-			case CELL_GCM_TEXTURE_COMPRESSED_DXT1:
-			case CELL_GCM_TEXTURE_COMPRESSED_DXT23:
-			case CELL_GCM_TEXTURE_COMPRESSED_DXT45:
+			case rsx::texture::format::compressed_dxt1:
+			case rsx::texture::format::compressed_dxt23:
+			case rsx::texture::format::compressed_dxt45:
 				return 0;
-			case CELL_GCM_TEXTURE_A1R5G5B5:
-			case CELL_GCM_TEXTURE_A4R4G4B4:
-			case CELL_GCM_TEXTURE_R5G6B5:
-			case CELL_GCM_TEXTURE_G8B8:
-			case CELL_GCM_TEXTURE_R6G5B5:
-			case CELL_GCM_TEXTURE_DEPTH16:
-			case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-			case CELL_GCM_TEXTURE_X16:
-			case CELL_GCM_TEXTURE_R5G5B5A1:
-			case CELL_GCM_TEXTURE_D1R5G5B5:
+			case rsx::texture::format::a1r5g5b5:
+			case rsx::texture::format::a4r4g4b4:
+			case rsx::texture::format::r5g6b5:
+			case rsx::texture::format::g8b8:
+			case rsx::texture::format::r6g5b5:
+			case rsx::texture::format::d16:
+			case rsx::texture::format::d16_float:
+			case rsx::texture::format::x16:
+			case rsx::texture::format::r5g5b5a1:
+			case rsx::texture::format::d1r5g5b5:
 				return 2;
-			case CELL_GCM_TEXTURE_A8R8G8B8:
-			case CELL_GCM_TEXTURE_X32_FLOAT:
-			case CELL_GCM_TEXTURE_Y16_X16_FLOAT:
-			case CELL_GCM_TEXTURE_D8R8G8B8:
-			case CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8:
-			case CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8:
-			case CELL_GCM_TEXTURE_DEPTH24_D8:
-			case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
-			case CELL_GCM_TEXTURE_Y16_X16:
+			case rsx::texture::format::a8r8g8b8:
+			case rsx::texture::format::x32float:
+			case rsx::texture::format::y16x16_float:
+			case rsx::texture::format::d8r8g8b8:
+			case rsx::texture::format::compressed_r8b8_r8g8:
+			case rsx::texture::format::compressed_b8r8_g8r8:
+			case rsx::texture::format::d24_8:
+			case rsx::texture::format::d24_8_float:
+			case rsx::texture::format::y16x16:
 				return 4;
-			case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
+			case rsx::texture::format::w16z16y16x16_float:
 				return 8;
-			case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
+			case rsx::texture::format::w32z32y32x32_float:
 				return 16;
 			}
 		}
@@ -319,7 +311,7 @@ namespace rsx
 		namespace
 		{
 			void create_and_fill_texture(rsx::texture_dimension_extended dim,
-				u16 mipmap_count, int format, u16 width, u16 height, u16 depth, const std::vector<rsx_subresource_layout> &input_layouts, bool is_swizzled,
+				u16 mipmap_count, rsx::texture::format format, u16 width, u16 height, u16 depth, const std::vector<rsx_subresource_layout> &input_layouts, bool is_swizzled,
 				std::vector<gsl::byte> staging_buffer)
 			{
 				int mip_level = 0;
@@ -339,7 +331,7 @@ namespace rsx
 					{
 						for (const rsx_subresource_layout &layout : input_layouts)
 						{
-							u32 size = layout.width_in_block * ((format == CELL_GCM_TEXTURE_COMPRESSED_DXT1) ? 8 : 16);
+							u32 size = layout.width_in_block * ((format == rsx::texture::format::compressed_dxt1) ? 8 : 16);
 							__glcheck glCompressedTexSubImage1D(GL_TEXTURE_1D, mip_level++, 0, layout.width_in_block * 4, get_sized_internal_format(format), size, layout.data.data());
 						}
 					}
@@ -362,7 +354,7 @@ namespace rsx
 					{
 						for (const rsx_subresource_layout &layout : input_layouts)
 						{
-							u32 size = layout.width_in_block * layout.height_in_block * ((format == CELL_GCM_TEXTURE_COMPRESSED_DXT1) ? 8 : 16);
+							u32 size = layout.width_in_block * layout.height_in_block * ((format == rsx::texture::format::compressed_dxt1) ? 8 : 16);
 							__glcheck glCompressedTexSubImage2D(GL_TEXTURE_2D, mip_level++, 0, 0, layout.width_in_block * 4, layout.height_in_block * 4, get_sized_internal_format(format), size, layout.data.data());
 						}
 					}
@@ -389,7 +381,7 @@ namespace rsx
 					{
 						for (const rsx_subresource_layout &layout : input_layouts)
 						{
-							u32 size = layout.width_in_block * layout.height_in_block * ((format == CELL_GCM_TEXTURE_COMPRESSED_DXT1) ? 8 : 16);
+							u32 size = layout.width_in_block * layout.height_in_block * ((format == rsx::texture::format::compressed_dxt1) ? 8 : 16);
 							__glcheck glCompressedTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + mip_level / mipmap_count, mip_level % mipmap_count, 0, 0, layout.width_in_block * 4, layout.height_in_block * 4, get_sized_internal_format(format), size, layout.data.data());
 							mip_level++;
 						}
@@ -413,7 +405,7 @@ namespace rsx
 					{
 						for (const rsx_subresource_layout &layout : input_layouts)
 						{
-							u32 size = layout.width_in_block * layout.height_in_block * layout.depth * ((format == CELL_GCM_TEXTURE_COMPRESSED_DXT1) ? 8 : 16);
+							u32 size = layout.width_in_block * layout.height_in_block * layout.depth * ((format == rsx::texture::format::compressed_dxt1) ? 8 : 16);
 							__glcheck glCompressedTexSubImage3D(GL_TEXTURE_3D, mip_level++, 0, 0, 0, layout.width_in_block * 4, layout.height_in_block * 4, layout.depth, get_sized_internal_format(format), size, layout.data.data());
 						}
 					}
@@ -433,23 +425,23 @@ namespace rsx
 			return false;
 		}
 
-		void texture::init(int index, rsx::texture& tex)
+		void texture::init(int index, rsx::texture_t& tex)
 		{
 			switch (tex.dimension())
 			{
-			case rsx::texture_dimension::dimension3d:
+			case rsx::texture::dimension::dimension3d:
 				if (!tex.depth())
 				{
 					return;
 				}
 
-			case rsx::texture_dimension::dimension2d:
+			case rsx::texture::dimension::dimension2d:
 				if (!tex.height())
 				{
 					return;
 				}
 
-			case rsx::texture_dimension::dimension1d:
+			case rsx::texture::dimension::dimension1d:
 				if (!tex.width())
 				{
 					return;
@@ -470,10 +462,8 @@ namespace rsx
 			__glcheck glActiveTexture(GL_TEXTURE0 + index);
 			bind();
 
-			u32 full_format = tex.format();
-
-			u32 format = full_format & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
-			bool is_swizzled = !!(~full_format & CELL_GCM_TEXTURE_LN);
+			rsx::texture::format format = tex.format();
+			bool is_swizzled = tex.layout() == rsx::texture::layout::swizzled;
 
 			__glcheck ::gl::pixel_pack_settings().apply();
 			__glcheck ::gl::pixel_unpack_settings().apply();
@@ -492,17 +482,23 @@ namespace rsx
 
 			glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, tex.get_exact_mipmap_count() - 1);
 
-			if (format != CELL_GCM_TEXTURE_B8 && format != CELL_GCM_TEXTURE_X16 && format != CELL_GCM_TEXTURE_X32_FLOAT)
+			if (format != rsx::texture::format::b8 && format != rsx::texture::format::x16 && format != rsx::texture::format::x32float)
 			{
-				u8 remap_a = tex.remap() & 0x3;
-				u8 remap_r = (tex.remap() >> 2) & 0x3;
-				u8 remap_g = (tex.remap() >> 4) & 0x3;
-				u8 remap_b = (tex.remap() >> 6) & 0x3;
+				auto remap_lambda = [](rsx::texture::component_remap op) {
+					switch (op)
+					{
+					case rsx::texture::component_remap::A: return 0;
+					case rsx::texture::component_remap::R: return 1;
+					case rsx::texture::component_remap::G: return 2;
+					case rsx::texture::component_remap::B: return 3;
+					}
+					throw;
+				};
 
-				__glcheck glTexParameteri(m_target, GL_TEXTURE_SWIZZLE_A, glRemap[remap_a]);
-				__glcheck glTexParameteri(m_target, GL_TEXTURE_SWIZZLE_R, glRemap[remap_r]);
-				__glcheck glTexParameteri(m_target, GL_TEXTURE_SWIZZLE_G, glRemap[remap_g]);
-				__glcheck glTexParameteri(m_target, GL_TEXTURE_SWIZZLE_B, glRemap[remap_b]);
+				__glcheck glTexParameteri(m_target, GL_TEXTURE_SWIZZLE_A, glRemap[remap_lambda(tex.remap_0())]);
+				__glcheck glTexParameteri(m_target, GL_TEXTURE_SWIZZLE_R, glRemap[remap_lambda(tex.remap_1())]);
+				__glcheck glTexParameteri(m_target, GL_TEXTURE_SWIZZLE_G, glRemap[remap_lambda(tex.remap_2())]);
+				__glcheck glTexParameteri(m_target, GL_TEXTURE_SWIZZLE_B, glRemap[remap_lambda(tex.remap_3())]);
 			}
 			else
 			{
@@ -536,23 +532,23 @@ namespace rsx
 			__glcheck glTexParameterf(m_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, max_aniso(tex.max_aniso()));
 		}
 
-		void texture::init(int index, rsx::vertex_texture& tex)
+		void texture::init(int index, rsx::vertex_texture_t& tex)
 		{
 			switch (tex.dimension())
 			{
-			case rsx::texture_dimension::dimension3d:
+			case rsx::texture::dimension::dimension3d:
 				if (!tex.depth())
 				{
 					return;
 				}
 
-			case rsx::texture_dimension::dimension2d:
+			case rsx::texture::dimension::dimension2d:
 				if (!tex.height())
 				{
 					return;
 				}
 
-			case rsx::texture_dimension::dimension1d:
+			case rsx::texture::dimension::dimension1d:
 				if (!tex.width())
 				{
 					return;
@@ -573,10 +569,8 @@ namespace rsx
 			__glcheck glActiveTexture(GL_TEXTURE0 + index);
 			bind();
 
-			u32 full_format = tex.format();
-
-			u32 format = full_format & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
-			bool is_swizzled = !!(~full_format & CELL_GCM_TEXTURE_LN);
+			rsx::texture::format format = tex.format();
+			bool is_swizzled = tex.layout() == rsx::texture::layout::swizzled;
 
 			__glcheck::gl::pixel_pack_settings().apply();
 			__glcheck::gl::pixel_unpack_settings().apply();

--- a/rpcs3/Emu/RSX/GL/rsx_gl_texture.h
+++ b/rpcs3/Emu/RSX/GL/rsx_gl_texture.h
@@ -3,8 +3,8 @@
 
 namespace rsx
 {
-	class vertex_texture;
-	class texture;
+	class vertex_texture_t;
+	class texture_t;
 
 	namespace gl
 	{
@@ -16,9 +16,9 @@ namespace rsx
 		public:
 			void create();
 
-			int gl_wrap(rsx::texture_wrap_mode in);
+			int gl_wrap(rsx::texture::wrap_mode in);
 
-			float max_aniso(rsx::texture_max_anisotropy aniso);
+			float max_aniso(rsx::texture::max_anisotropy aniso);
 
 			inline static u8 convert_4_to_8(u8 v)
 			{
@@ -38,8 +38,8 @@ namespace rsx
 				return (v << 2) | (v >> 4);
 			}
 
-			void init(int index, rsx::texture& tex);
-			void init(int index, rsx::vertex_texture& tex);
+			void init(int index, rsx::texture_t& tex);
+			void init(int index, rsx::vertex_texture_t& tex);
 			
 			/**
 			* If a format is marked as mandating expansion, any request to have the data uploaded to the GPU shall require that the pixel data
@@ -52,7 +52,7 @@ namespace rsx
 			* The pitch modifier changes the pitch value supplied by the rsx::texture by supplying a suitable divisor or 0 if no change is needed.
 			* The modified value, if any, is then used to supply to GL the UNPACK_ROW_LENGTH for the texture data to be supplied.
 			*/
-			static u16  get_pitch_modifier(u32 format);
+			static u16  get_pitch_modifier(rsx::texture::format format);
 			
 			void bind();
 			void unbind();

--- a/rpcs3/Emu/RSX/RSXTexture.h
+++ b/rpcs3/Emu/RSX/RSXTexture.h
@@ -14,18 +14,66 @@ namespace rsx
 		texture_dimension_3d = 3,
 	};
 
-	class texture
+	class texture_t
 	{
-	protected:
-		u8 m_index;
-		std::array<u32, 0x10000 / 4> &registers;
-
 	public:
-		texture(u8 idx, std::array<u32, 0x10000 / 4> &r);
-		texture() = delete;
-
 		//initialize texture registers with default values
-		void init(u8 index);
+		void init();
+
+		u32 m_offset;
+		u8 m_location : 2;
+		bool m_cubemap : 1;
+		rsx::texture::border_type m_border_type;
+		rsx::texture::dimension m_dimension : 2;
+		rsx::texture::format m_format;
+		rsx::texture::layout m_layout : 1;
+		rsx::texture::coordinates m_normalization : 1;
+		u16 m_mipmap;
+		rsx::texture::wrap_mode m_wrap_r : 3;
+		rsx::texture::wrap_mode m_wrap_s : 3;
+		rsx::texture::wrap_mode m_wrap_t : 3;
+		rsx::texture::zfunc m_zfunc : 3;
+		rsx::texture::unsigned_remap m_unsigned_remap: 1;
+		rsx::texture::signed_remap m_signed_remap: 1;
+		u8 m_aniso_bias : 4;
+		bool m_gamma_r : 1;
+		bool m_gamma_g : 1;
+		bool m_gamma_b : 1;
+		bool m_gamma_a : 1;
+
+		u16 m_bias : 13;
+		rsx::texture::minify_filter m_min_filter : 3;
+		rsx::texture::magnify_filter m_mag_filter : 2;
+		u8 m_convolution_filter : 3;
+		bool m_a_signed : 1;
+		bool m_r_signed : 1;
+		bool m_g_signed : 1;
+		bool m_b_signed : 1;
+
+		bool m_enabled : 1;
+
+		u16 m_width;
+		u16 m_height;
+
+		u16 m_depth : 12;
+		u32 m_pitch : 20;
+
+		bool m_alpha_kill_enabled : 1;
+		u16 m_min_lod : 12;
+		u16 m_max_lod : 12;
+		rsx::texture::max_anisotropy m_max_aniso : 3;
+
+		// border color
+		u8 m_border_color_r;
+		u8 m_border_color_g;
+		u8 m_border_color_b;
+		u8 m_border_color_a;
+
+		// remap
+		rsx::texture::component_remap m_remap_0 : 2;
+		rsx::texture::component_remap m_remap_1 : 2;
+		rsx::texture::component_remap m_remap_2 : 2;
+		rsx::texture::component_remap m_remap_3 : 2;
 
 		// Offset
 		u32 offset() const;
@@ -33,15 +81,17 @@ namespace rsx
 		// Format
 		u8   location() const;
 		bool cubemap() const;
-		u8   border_type() const;
-		rsx::texture_dimension   dimension() const;
+		rsx::texture::border_type   border_type() const;
+		rsx::texture::dimension   dimension() const;
+		rsx::texture::coordinates normalization() const;
+		rsx::texture::layout layout() const;
 		/**
 		 * 2d texture can be either plane or cubemap texture depending on cubemap bit.
 		 * Since cubemap is a format per se in all gfx API this function directly returns
 		 * cubemap as a separate dimension.
 		 */
 		rsx::texture_dimension_extended get_extended_texture_dimension() const;
-		u8   format() const;
+		rsx::texture::format   format() const;
 		bool is_compressed_format() const;
 		u16  mipmap() const;
 		/**
@@ -51,29 +101,31 @@ namespace rsx
 		u16 get_exact_mipmap_count() const;
 
 		// Address
-		rsx::texture_wrap_mode wrap_s() const;
-		rsx::texture_wrap_mode wrap_t() const;
-		rsx::texture_wrap_mode wrap_r() const;
-		u8 unsigned_remap() const;
-		u8 zfunc() const;
-		u8 gamma() const;
+		rsx::texture::wrap_mode wrap_s() const;
+		rsx::texture::wrap_mode wrap_t() const;
+		rsx::texture::wrap_mode wrap_r() const;
+		rsx::texture::unsigned_remap unsigned_remap() const;
+		rsx::texture::zfunc zfunc() const;
 		u8 aniso_bias() const;
-		u8 signed_remap() const;
+		rsx::texture::signed_remap signed_remap() const;
 
 		// Control0
 		bool enabled() const;
 		u16  min_lod() const;
 		u16  max_lod() const;
-		rsx::texture_max_anisotropy   max_aniso() const;
+		rsx::texture::max_anisotropy   max_aniso() const;
 		bool alpha_kill_enabled() const;
 
 		// Control1
-		u32 remap() const;
+		rsx::texture::component_remap remap_0() const;
+		rsx::texture::component_remap remap_1() const;
+		rsx::texture::component_remap remap_2() const;
+		rsx::texture::component_remap remap_3() const;
 
 		// Filter
 		float bias() const;
-		rsx::texture_minify_filter  min_filter() const;
-		rsx::texture_magnify_filter  mag_filter() const;
+		rsx::texture::minify_filter  min_filter() const;
+		rsx::texture::magnify_filter  mag_filter() const;
 		u8  convolution_filter() const;
 		bool a_signed() const;
 		bool r_signed() const;
@@ -85,23 +137,75 @@ namespace rsx
 		u16 height() const;
 
 		// Border Color
-		u32 border_color() const;
+		u8 border_color_a() const;
+		u8 border_color_r() const;
+		u8 border_color_g() const;
+		u8 border_color_b() const;
+
 		u16 depth() const;
 		u32 pitch() const;
 	};
 
-	class vertex_texture
+	class vertex_texture_t
 	{
-	protected:
-		u8 m_index;
-		std::array<u32, 0x10000 / 4> &registers;
-
 	public:
-		vertex_texture(u8 idx, std::array<u32, 0x10000 / 4> &r);
-		vertex_texture() = delete;
+		vertex_texture_t();
 
 		//initialize texture registers with default values
-		void init(u8 index);
+		void init();
+
+		u32 m_offset;
+		u8 m_location : 2;
+
+		bool m_enabled : 1;
+
+		u16 m_mipmap;
+		rsx::texture::zfunc m_zfunc : 3;
+		rsx::texture::unsigned_remap m_unsigned_remap : 1;
+		rsx::texture::signed_remap m_signed_remap : 1;
+		u8 m_aniso_bias : 4;
+		bool m_gamma_r : 1;
+		bool m_gamma_g : 1;
+		bool m_gamma_b : 1;
+		bool m_gamma_a : 1;
+
+		u16 m_bias : 13;
+		rsx::texture::minify_filter m_min_filter : 3;
+		rsx::texture::magnify_filter m_mag_filter : 2;
+		u8 m_convolution_filter : 3;
+		bool m_a_signed : 1;
+		bool m_r_signed : 1;
+		bool m_g_signed : 1;
+		bool m_b_signed : 1;
+
+		bool m_cubemap : 1;
+		rsx::texture::border_type m_border_type;
+		rsx::texture::dimension m_dimension : 2;
+		rsx::texture::format m_format;
+		rsx::texture::layout m_layout;
+
+		u16 m_width;
+		u16 m_height;
+
+		u16 m_depth : 12;
+		u32 m_pitch : 20;
+
+		bool m_alpha_kill_enabled : 1;
+		u16 m_min_lod : 12;
+		u16 m_max_lod : 12;
+		rsx::texture::max_anisotropy m_max_aniso : 3;
+
+		// border color
+		u8 m_border_color_r;
+		u8 m_border_color_g;
+		u8 m_border_color_b;
+		u8 m_border_color_a;
+
+		// remap
+		rsx::texture::component_remap m_remap_0 : 2;
+		rsx::texture::component_remap m_remap_1 : 2;
+		rsx::texture::component_remap m_remap_2 : 2;
+		rsx::texture::component_remap m_remap_3 : 2;
 
 		// Offset
 		u32 offset() const;
@@ -109,29 +213,31 @@ namespace rsx
 		// Format
 		u8 location() const;
 		bool cubemap() const;
-		u8 border_type() const;
-		rsx::texture_dimension dimension() const;
-		u8 format() const;
+		rsx::texture::border_type border_type() const;
+		rsx::texture::dimension dimension() const;
+		rsx::texture::format format() const;
+		rsx::texture::layout layout() const;
+		rsx::texture::coordinates normalization() const;
 		u16 mipmap() const;
 
 		// Address
-		u8 unsigned_remap() const;
-		u8 zfunc() const;
+		rsx::texture::unsigned_remap unsigned_remap() const;
+		rsx::texture::zfunc zfunc() const;
 		u8 gamma() const;
 		u8 aniso_bias() const;
-		u8 signed_remap() const;
+		rsx::texture::signed_remap signed_remap() const;
 
 		// Control0
 		bool enabled() const;
 		u16 min_lod() const;
 		u16 max_lod() const;
-		rsx::texture_max_anisotropy max_aniso() const;
+		rsx::texture::max_anisotropy max_aniso() const;
 		bool alpha_kill_enabled() const;
 
 		// Filter
 		u16 bias() const;
-		rsx::texture_minify_filter min_filter() const;
-		rsx::texture_magnify_filter mag_filter() const;
+		rsx::texture::minify_filter min_filter() const;
+		rsx::texture::magnify_filter mag_filter() const;
 		u8 convolution_filter() const;
 		bool a_signed() const;
 		bool r_signed() const;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -752,7 +752,7 @@ namespace rsx
 				texture_dimensions[i] = texture_dimension_extended::texture_dimension_2d;
 			else
 				texture_dimensions[i] = rsx::method_registers.fragment_textures[i].get_extended_texture_dimension();
-			if (rsx::method_registers.fragment_textures[i].enabled() && (rsx::method_registers.fragment_textures[i].format() & CELL_GCM_TEXTURE_UN))
+			if (rsx::method_registers.fragment_textures[i].enabled() && (rsx::method_registers.fragment_textures[i].normalization() == rsx::texture::coordinates::unnormalized))
 				result.unnormalized_coords |= (1 << i);
 		}
 		result.set_texture_dimension(texture_dimensions);
@@ -811,7 +811,7 @@ namespace rsx
 			}
 
 			result.state.textures_alpha_kill[index] = rsx::method_registers.fragment_textures[index].alpha_kill_enabled() ? 1 : 0;
-			result.state.textures_zfunc[index] = rsx::method_registers.fragment_textures[index].zfunc();
+//			result.state.textures_zfunc[index] = rsx::method_registers.fragment_textures[index].zfunc();
 
 			switch (rsx::method_registers.fragment_textures[index].get_extended_texture_dimension())
 			{

--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -39,28 +39,28 @@ VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support,
 	throw EXCEPTION("Invalid format (0x%x)", format);
 }
 
-std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(rsx::texture_minify_filter min_filter)
+std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(rsx::texture::minify_filter min_filter)
 {
 	switch (min_filter)
 	{
-	case rsx::texture_minify_filter::nearest: return std::make_tuple(VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-	case rsx::texture_minify_filter::linear: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-	case rsx::texture_minify_filter::nearest_nearest: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-	case rsx::texture_minify_filter::linear_nearest: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-	case rsx::texture_minify_filter::nearest_linear: return std::make_tuple(VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_LINEAR);
-	case rsx::texture_minify_filter::linear_linear: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR);
-	case rsx::texture_minify_filter::convolution_min: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR);
+	case rsx::texture::minify_filter::nearest: return std::make_tuple(VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST);
+	case rsx::texture::minify_filter::linear: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
+	case rsx::texture::minify_filter::nearest_nearest: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
+	case rsx::texture::minify_filter::linear_nearest: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
+	case rsx::texture::minify_filter::nearest_linear: return std::make_tuple(VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_LINEAR);
+	case rsx::texture::minify_filter::linear_linear: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR);
+	case rsx::texture::minify_filter::convolution_min: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR);
 	}
 	throw EXCEPTION("Invalid max filter");
 }
 
-VkFilter get_mag_filter(rsx::texture_magnify_filter mag_filter)
+VkFilter get_mag_filter(rsx::texture::magnify_filter mag_filter)
 {
 	switch (mag_filter)
 	{
-	case rsx::texture_magnify_filter::nearest: return VK_FILTER_NEAREST;
-	case rsx::texture_magnify_filter::linear: return VK_FILTER_LINEAR;
-	case rsx::texture_magnify_filter::convolution_mag: return VK_FILTER_LINEAR;
+	case rsx::texture::magnify_filter::nearest: return VK_FILTER_NEAREST;
+	case rsx::texture::magnify_filter::linear: return VK_FILTER_LINEAR;
+	case rsx::texture::magnify_filter::convolution_mag: return VK_FILTER_LINEAR;
 	}
 	throw EXCEPTION("Invalid mag filter (0x%x)", mag_filter);
 }
@@ -75,112 +75,116 @@ VkBorderColor get_border_color(u8 color)
 	// TODO: VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK
 }
 
-VkSamplerAddressMode vk_wrap_mode(rsx::texture_wrap_mode gcm_wrap)
+VkSamplerAddressMode vk_wrap_mode(rsx::texture::wrap_mode gcm_wrap)
 {
 	switch (gcm_wrap)
 	{
-	case rsx::texture_wrap_mode::wrap: return VK_SAMPLER_ADDRESS_MODE_REPEAT;
-	case rsx::texture_wrap_mode::mirror: return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-	case rsx::texture_wrap_mode::clamp_to_edge: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	case rsx::texture_wrap_mode::border: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-	case rsx::texture_wrap_mode::clamp: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-	case rsx::texture_wrap_mode::mirror_once_clamp_to_edge: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-	case rsx::texture_wrap_mode::mirror_once_border: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-	case rsx::texture_wrap_mode::mirror_once_clamp: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
+	case rsx::texture::wrap_mode::wrap: return VK_SAMPLER_ADDRESS_MODE_REPEAT;
+	case rsx::texture::wrap_mode::mirror: return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
+	case rsx::texture::wrap_mode::clamp_to_edge: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	case rsx::texture::wrap_mode::border: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+	case rsx::texture::wrap_mode::clamp: return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	case rsx::texture::wrap_mode::mirror_once_clamp_to_edge: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
+	case rsx::texture::wrap_mode::mirror_once_border: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
+	case rsx::texture::wrap_mode::mirror_once_clamp: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
 	}
 	throw EXCEPTION("unhandled texture clamp mode");
 }
 
-float max_aniso(rsx::texture_max_anisotropy gcm_aniso)
+float max_aniso(rsx::texture::max_anisotropy gcm_aniso)
 {
 	switch (gcm_aniso)
 	{
-	case rsx::texture_max_anisotropy::x1: return 1.0f;
-	case rsx::texture_max_anisotropy::x2: return 2.0f;
-	case rsx::texture_max_anisotropy::x4: return 4.0f;
-	case rsx::texture_max_anisotropy::x6: return 6.0f;
-	case rsx::texture_max_anisotropy::x8: return 8.0f;
-	case rsx::texture_max_anisotropy::x10: return 10.0f;
-	case rsx::texture_max_anisotropy::x12: return 12.0f;
-	case rsx::texture_max_anisotropy::x16: return 16.0f;
+	case rsx::texture::max_anisotropy::x1: return 1.0f;
+	case rsx::texture::max_anisotropy::x2: return 2.0f;
+	case rsx::texture::max_anisotropy::x4: return 4.0f;
+	case rsx::texture::max_anisotropy::x6: return 6.0f;
+	case rsx::texture::max_anisotropy::x8: return 8.0f;
+	case rsx::texture::max_anisotropy::x10: return 10.0f;
+	case rsx::texture::max_anisotropy::x12: return 12.0f;
+	case rsx::texture::max_anisotropy::x16: return 16.0f;
 	}
 
 	throw EXCEPTION("Texture anisotropy error: bad max aniso (%d).", gcm_aniso);
 }
 
 
-VkComponentMapping get_component_mapping(u32 format, u8 swizzle_mask)
+VkComponentMapping get_component_mapping(rsx::texture::format format, rsx::texture::component_remap remap0, rsx::texture::component_remap remap1, rsx::texture::component_remap remap2, rsx::texture::component_remap remap3)
 {
-	const u8 remap_a = swizzle_mask & 0x3;
-	const u8 remap_r = (swizzle_mask >> 2) & 0x3;
-	const u8 remap_g = (swizzle_mask >> 4) & 0x3;
-	const u8 remap_b = (swizzle_mask >> 6) & 0x3;
+	auto remap_lambda = [](rsx::texture::component_remap op) {
+		switch (op)
+		{
+		case rsx::texture::component_remap::A: return 0;
+		case rsx::texture::component_remap::R: return 1;
+		case rsx::texture::component_remap::G: return 2;
+		case rsx::texture::component_remap::B: return 3;
+		}
+		throw;
+	};
 
 	switch (format)
 	{
-	case CELL_GCM_TEXTURE_A1R5G5B5:
-	case CELL_GCM_TEXTURE_R5G5B5A1:
-	case CELL_GCM_TEXTURE_R6G5B5:
-	case CELL_GCM_TEXTURE_R5G6B5:
-	case CELL_GCM_TEXTURE_DEPTH24_D8:
-	case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
-	case CELL_GCM_TEXTURE_DEPTH16:
-	case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-	case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
-	case CELL_GCM_TEXTURE_COMPRESSED_DXT1:
-	case CELL_GCM_TEXTURE_COMPRESSED_DXT23:
-	case CELL_GCM_TEXTURE_COMPRESSED_DXT45:
-	case CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8:
-	case CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8:
+	case rsx::texture::format::a1r5g5b5:
+	case rsx::texture::format::r5g5b5a1:
+	case rsx::texture::format::r6g5b5:
+	case rsx::texture::format::r5g6b5:
+	case rsx::texture::format::d24_8:
+	case rsx::texture::format::d24_8_float:
+	case rsx::texture::format::d16:
+	case rsx::texture::format::d16_float:
+	case rsx::texture::format::w32z32y32x32_float:
+	case rsx::texture::format::compressed_dxt1:
+	case rsx::texture::format::compressed_dxt23:
+	case rsx::texture::format::compressed_dxt45:
 		return { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
 
-	case CELL_GCM_TEXTURE_B8:
+	case rsx::texture::format::b8:
 		return { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
 
-	case CELL_GCM_TEXTURE_G8B8:
+	case rsx::texture::format::g8b8:
 	{
 		VkComponentSwizzle map_table[] = { VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R };
-		return{ map_table[remap_r], map_table[remap_g], map_table[remap_b], map_table[remap_a] };
+		return{ map_table[remap_lambda(remap3)], map_table[remap_lambda(remap2)], map_table[remap_lambda(remap1)], map_table[remap_lambda(remap0)] };
 	}
 
-	case CELL_GCM_TEXTURE_X16:
+	case rsx::texture::format::x16:
 		return { VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_R };
 
-	case CELL_GCM_TEXTURE_Y16_X16:
+	case rsx::texture::format::y16x16:
 		return { VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R };
 
-	case CELL_GCM_TEXTURE_Y16_X16_FLOAT:
+	case rsx::texture::format::y16x16_float:
 		return { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G };
 
-	case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
+	case rsx::texture::format::w16z16y16x16_float:
 		return { VK_COMPONENT_SWIZZLE_A, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R };
 		
-	case CELL_GCM_TEXTURE_X32_FLOAT:
+	case rsx::texture::format::x32float:
 		return { VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_R };
 		
-	case CELL_GCM_TEXTURE_A4R4G4B4:
+	case rsx::texture::format::a4r4g4b4:
 	{
 		VkComponentSwizzle map_table[] = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
-		return { map_table[remap_r], map_table[remap_g], map_table[remap_b], map_table[remap_a] };
+		return { map_table[remap_lambda(remap3)], map_table[remap_lambda(remap2)], map_table[remap_lambda(remap1)], map_table[remap_lambda(remap0)] };
 	}
 		
-	case CELL_GCM_TEXTURE_D8R8G8B8:
-	case CELL_GCM_TEXTURE_D1R5G5B5:
+	case rsx::texture::format::d8r8g8b8:
+	case rsx::texture::format::d1r5g5b5:
 		return { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_ONE };
 
-	case CELL_GCM_TEXTURE_COMPRESSED_HILO8:
-	case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8:
+	case rsx::texture::format::compressed_hilo_8:
+	case rsx::texture::format::compressed_hilo_s8:
 		return { VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R };
 
-	case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8:
-	case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8:
+	case rsx::texture::format::compressed_b8r8_g8r8:
+	case rsx::texture::format::compressed_r8b8_r8g8:
 		return { VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_ZERO };
 
 
-	case CELL_GCM_TEXTURE_A8R8G8B8:
+	case rsx::texture::format::a8r8g8b8:
 	{
 		VkComponentSwizzle map_table[] = { VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_A };
-		return { map_table[remap_r], map_table[remap_g], map_table[remap_b], map_table[remap_a] };
+		return { map_table[remap_lambda(remap3)], map_table[remap_lambda(remap2)], map_table[remap_lambda(remap1)], map_table[remap_lambda(remap0)] };
 	}
 	}
 	throw EXCEPTION("Invalid or unsupported component mapping for texture format (0x%x)", format);

--- a/rpcs3/Emu/RSX/VK/VKFormats.h
+++ b/rpcs3/Emu/RSX/VK/VKFormats.h
@@ -18,10 +18,10 @@ namespace vk
 	VkCullModeFlags get_cull_face(u32 cfv);
 	VkBorderColor get_border_color(u8 color);
 
-	std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(rsx::texture_minify_filter min_filter);
-	VkFilter get_mag_filter(rsx::texture_magnify_filter mag_filter);
-	VkSamplerAddressMode vk_wrap_mode(rsx::texture_wrap_mode gcm_wrap);
-	float max_aniso(rsx::texture_max_anisotropy gcm_aniso);
-	VkComponentMapping get_component_mapping(u32 format, u8 swizzle_mask);
+	std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(rsx::texture::minify_filter min_filter);
+	VkFilter get_mag_filter(rsx::texture::magnify_filter mag_filter);
+	VkSamplerAddressMode vk_wrap_mode(rsx::texture::wrap_mode gcm_wrap);
+	float max_aniso(rsx::texture::max_anisotropy gcm_aniso);
+	VkComponentMapping get_component_mapping(rsx::texture::format format, rsx::texture::component_remap remap_0, rsx::texture::component_remap remap_1, rsx::texture::component_remap remap_2, rsx::texture::component_remap remap_3);
 	VkPrimitiveTopology get_appropriate_topology(rsx::primitive_type& mode, bool &requires_modification);
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -667,9 +667,9 @@ void VKGSRender::end()
 			m_sampler_to_clean.push_back(std::make_unique<vk::sampler>(
 				*m_device,
 				vk::vk_wrap_mode(rsx::method_registers.fragment_textures[i].wrap_s()), vk::vk_wrap_mode(rsx::method_registers.fragment_textures[i].wrap_t()), vk::vk_wrap_mode(rsx::method_registers.fragment_textures[i].wrap_r()),
-				!!(rsx::method_registers.fragment_textures[i].format() & CELL_GCM_TEXTURE_UN),
+				rsx::method_registers.fragment_textures[i].normalization() == rsx::texture::coordinates::unnormalized,
 				rsx::method_registers.fragment_textures[i].bias(), vk::max_aniso(rsx::method_registers.fragment_textures[i].max_aniso()), rsx::method_registers.fragment_textures[i].min_lod(), rsx::method_registers.fragment_textures[i].max_lod(),
-				min_filter, vk::get_mag_filter(rsx::method_registers.fragment_textures[i].mag_filter()), mip_mode, vk::get_border_color(rsx::method_registers.fragment_textures[i].border_color())
+				min_filter, vk::get_mag_filter(rsx::method_registers.fragment_textures[i].mag_filter()), mip_mode, vk::get_border_color(rsx::method_registers.fragment_textures[i].border_color_a())
 				));
 			m_program->bind_uniform({ m_sampler_to_clean.back()->value, texture0->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "tex" + std::to_string(i), descriptor_sets);
 		}

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -82,39 +82,37 @@ namespace vk
 		return result;
 	}
 
-	VkFormat get_compatible_sampler_format(u32 format)
+	VkFormat get_compatible_sampler_format(rsx::texture::format format)
 	{
 		switch (format)
 		{
-		case CELL_GCM_TEXTURE_B8: return VK_FORMAT_R8_UNORM;
-		case CELL_GCM_TEXTURE_A1R5G5B5: return VK_FORMAT_A1R5G5B5_UNORM_PACK16;
-		case CELL_GCM_TEXTURE_A4R4G4B4: return VK_FORMAT_R4G4B4A4_UNORM_PACK16;
-		case CELL_GCM_TEXTURE_R5G6B5: return VK_FORMAT_R5G6B5_UNORM_PACK16;
-		case CELL_GCM_TEXTURE_A8R8G8B8: return VK_FORMAT_B8G8R8A8_UNORM;
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT1: return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT23: return VK_FORMAT_BC2_UNORM_BLOCK;
-		case CELL_GCM_TEXTURE_COMPRESSED_DXT45: return VK_FORMAT_BC3_UNORM_BLOCK;
-		case CELL_GCM_TEXTURE_G8B8: return VK_FORMAT_R8G8_UNORM;
-		case CELL_GCM_TEXTURE_R6G5B5: return VK_FORMAT_R5G6B5_UNORM_PACK16; // Expand, discard high bit?
-		case CELL_GCM_TEXTURE_DEPTH24_D8: return VK_FORMAT_R32_UINT;
-		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:	return VK_FORMAT_R32_SFLOAT;
-		case CELL_GCM_TEXTURE_DEPTH16: return VK_FORMAT_R16_UINT;
-		case CELL_GCM_TEXTURE_DEPTH16_FLOAT: return VK_FORMAT_R16_SFLOAT;
-		case CELL_GCM_TEXTURE_X16: return VK_FORMAT_R16_UNORM;
-		case CELL_GCM_TEXTURE_Y16_X16: return VK_FORMAT_R16G16_UNORM;
-		case CELL_GCM_TEXTURE_Y16_X16_FLOAT: return VK_FORMAT_R16G16_UNORM;
-		case CELL_GCM_TEXTURE_R5G5B5A1: return VK_FORMAT_R5G5B5A1_UNORM_PACK16;
-		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT: return VK_FORMAT_R16G16B16A16_SFLOAT;
-		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT: return VK_FORMAT_R32G32B32A32_SFLOAT;
-		case CELL_GCM_TEXTURE_X32_FLOAT: return VK_FORMAT_R32_SFLOAT;
-		case CELL_GCM_TEXTURE_D1R5G5B5: return VK_FORMAT_A1R5G5B5_UNORM_PACK16;
-		case CELL_GCM_TEXTURE_D8R8G8B8: return VK_FORMAT_B8G8R8A8_UNORM;
-		case CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8: return VK_FORMAT_A8B8G8R8_UNORM_PACK32;	// Expand
-		case CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8: return VK_FORMAT_R8G8B8A8_UNORM; // Expand
-		case CELL_GCM_TEXTURE_COMPRESSED_HILO8: return VK_FORMAT_R8G8_UNORM;
-		case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8: return VK_FORMAT_R8G8_SNORM;
-		case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8: return VK_FORMAT_R8G8_UNORM; // Not right
-		case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8: return VK_FORMAT_R8G8_UNORM; // Not right
+		case rsx::texture::format::b8: return VK_FORMAT_R8_UNORM;
+		case rsx::texture::format::a1r5g5b5: return VK_FORMAT_A1R5G5B5_UNORM_PACK16;
+		case rsx::texture::format::a4r4g4b4: return VK_FORMAT_R4G4B4A4_UNORM_PACK16;
+		case rsx::texture::format::r5g6b5: return VK_FORMAT_R5G6B5_UNORM_PACK16;
+		case rsx::texture::format::a8r8g8b8: return VK_FORMAT_B8G8R8A8_UNORM;
+		case rsx::texture::format::compressed_dxt1: return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+		case rsx::texture::format::compressed_dxt23: return VK_FORMAT_BC2_UNORM_BLOCK;
+		case rsx::texture::format::compressed_dxt45: return VK_FORMAT_BC3_UNORM_BLOCK;
+		case rsx::texture::format::g8b8: return VK_FORMAT_R8G8_UNORM;
+		case rsx::texture::format::r6g5b5: return VK_FORMAT_R5G6B5_UNORM_PACK16; // Expand, discard high bit?
+		case rsx::texture::format::d24_8: return VK_FORMAT_R32_UINT;
+		case rsx::texture::format::d24_8_float:	return VK_FORMAT_R32_SFLOAT;
+		case rsx::texture::format::d16: return VK_FORMAT_R16_UINT;
+		case rsx::texture::format::d16_float: return VK_FORMAT_R16_SFLOAT;
+		case rsx::texture::format::x16: return VK_FORMAT_R16_UNORM;
+		case rsx::texture::format::y16x16: return VK_FORMAT_R16G16_UNORM;
+		case rsx::texture::format::y16x16_float: return VK_FORMAT_R16G16_UNORM;
+		case rsx::texture::format::r5g5b5a1: return VK_FORMAT_R5G5B5A1_UNORM_PACK16;
+		case rsx::texture::format::w16z16y16x16_float: return VK_FORMAT_R16G16B16A16_SFLOAT;
+		case rsx::texture::format::w32z32y32x32_float: return VK_FORMAT_R32G32B32A32_SFLOAT;
+		case rsx::texture::format::x32float: return VK_FORMAT_R32_SFLOAT;
+		case rsx::texture::format::d1r5g5b5: return VK_FORMAT_A1R5G5B5_UNORM_PACK16;
+		case rsx::texture::format::d8r8g8b8: return VK_FORMAT_B8G8R8A8_UNORM;
+		case rsx::texture::format::compressed_r8b8_r8g8: return VK_FORMAT_A8B8G8R8_UNORM_PACK32;	// Expand
+		case rsx::texture::format::compressed_b8r8_g8r8: return VK_FORMAT_R8G8B8A8_UNORM; // Expand
+		case rsx::texture::format::compressed_hilo_8: return VK_FORMAT_R8G8_UNORM;
+		case rsx::texture::format::compressed_hilo_s8: return VK_FORMAT_R8G8_SNORM;
 		}
 		throw EXCEPTION("Invalid or unsupported sampler format for texture format (0x%x)", format);
 	}

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -19,7 +19,7 @@ extern cfg::bool_entry g_cfg_rsx_debug_output;
 
 namespace rsx
 {
-	class texture;
+	class texture_t;
 }
 
 namespace vk
@@ -66,7 +66,7 @@ namespace vk
 	void copy_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout, u32 width, u32 height, u32 mipmaps, VkImageAspectFlagBits aspect);
 	void copy_scaled_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout, u32 src_width, u32 src_height, u32 dst_width, u32 dst_height, u32 mipmaps, VkImageAspectFlagBits aspect);
 
-	VkFormat get_compatible_sampler_format(u32 format);
+	VkFormat get_compatible_sampler_format(rsx::texture::format format);
 	std::pair<VkFormat, VkComponentMapping> get_compatible_surface_format(rsx::surface_color_format color_format);
 	size_t get_render_pass_location(VkFormat color_surface_format, VkFormat depth_stencil_format, u8 color_surface_count);
 
@@ -451,7 +451,7 @@ namespace vk
 		void create(vk::render_device &device, VkFormat format, VkImageUsageFlags usage, u32 width, u32 height, u32 mipmaps = 1, bool gpu_only = false, VkComponentMapping swizzle = default_component_map());
 		void destroy();
 
-		void init(rsx::texture &tex, vk::command_buffer &cmd, bool ignore_checks = false);
+		void init(rsx::texture_t &tex, vk::command_buffer &cmd, bool ignore_checks = false);
 		void flush(vk::command_buffer & cmd);
 
 		//Fill with debug color 0xFF
@@ -1331,6 +1331,6 @@ namespace vk
 	* dst_image must be in TRANSFER_DST_OPTIMAL layout and upload_buffer have TRANSFER_SRC_BIT usage flag.
 	*/
 	void copy_mipmaped_image_using_buffer(VkCommandBuffer cmd, VkImage dst_image,
-		const std::vector<rsx_subresource_layout> subresource_layout, int format, bool is_swizzled, u16 mipmap_count,
+		const std::vector<rsx_subresource_layout> subresource_layout, rsx::texture::format format, bool is_swizzled, u16 mipmap_count,
 		vk::vk_data_heap &upload_heap, vk::buffer* upload_buffer);
 }

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -129,7 +129,7 @@ namespace vk
 	}
 
 	void copy_mipmaped_image_using_buffer(VkCommandBuffer cmd, VkImage dst_image,
-		const std::vector<rsx_subresource_layout> subresource_layout, int format, bool is_swizzled, u16 mipmap_count,
+		const std::vector<rsx_subresource_layout> subresource_layout, rsx::texture::format format, bool is_swizzled, u16 mipmap_count,
 		vk::vk_data_heap &upload_heap, vk::buffer* upload_buffer)
 	{
 		u32 mipmap_level = 0;
@@ -275,7 +275,7 @@ namespace vk
 		create(device, format, usage, tiling, width, height, mipmaps, gpu_only, swizzle);
 	}
 
-	void texture::init(rsx::texture& tex, vk::command_buffer &cmd, bool ignore_checks)
+	void texture::init(rsx::texture_t& tex, vk::command_buffer &cmd, bool ignore_checks)
 	{
 		VkImageViewType best_type = VK_IMAGE_VIEW_TYPE_2D;
 		
@@ -368,7 +368,7 @@ namespace vk
 				const std::vector<rsx_subresource_layout> &subresources_layout = get_subresources_layout(tex);
 				for (const rsx_subresource_layout &layout : subresources_layout)
 				{
-					upload_texture_subresource(mapped, layout, tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN), !(tex.format() & CELL_GCM_TEXTURE_LN), layout_alignment[0].first);
+					upload_texture_subresource(mapped, layout, tex.format(), tex.layout() == rsx::texture::layout::swizzled, layout_alignment[0].first);
 				}
 				vkUnmapMemory((*owner), vram_allocation);
 			}
@@ -401,7 +401,7 @@ namespace vk
 				for (const rsx_subresource_layout &layout : subresources_layout)
 				{
 					const auto &dst_layout = layout_offset_info[idx++];
-					upload_texture_subresource(mapped.subspan(dst_layout.first), layout, tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN), !(tex.format() & CELL_GCM_TEXTURE_LN), dst_layout.second);
+					upload_texture_subresource(mapped.subspan(dst_layout.first), layout, tex.format(), tex.layout() == rsx::texture::layout::swizzled, dst_layout.second);
 				}
 				vkUnmapMemory((*owner), vram_allocation);
 			}

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -649,15 +649,9 @@ namespace rsx
 		}
 	}
 
-	template<typename T, size_t... N, typename Args>
-	std::array<T, sizeof...(N)> fill_array(Args&& arg, std::index_sequence<N...> seq)
-	{
-		return{ T(N, std::forward<Args>(arg))... };
-	}
-
 	rsx_state::rsx_state() :
-		fragment_textures(fill_array<texture>(registers, std::make_index_sequence<16>())),
-		vertex_textures(fill_array<vertex_texture>(registers, std::make_index_sequence<4>()))
+		fragment_textures({}),
+		vertex_textures({})
 	{
 
 	}
@@ -669,9 +663,6 @@ namespace rsx
 
 	void rsx_state::reset()
 	{
-		//setup method registers
-		std::memset(registers.data(), 0, registers.size() * sizeof(u32));
-
 		m_primitive_type = primitive_type::triangles;
 		m_transform_program_pointer = 0;
 
@@ -777,15 +768,8 @@ namespace rsx
 		}
 
 		// Construct Textures
-		for (int i = 0; i < 16; i++)
-		{
-			fragment_textures[i].init(i);
-		}
-
-		for (int i = 0; i < 4; i++)
-		{
-			vertex_textures[i].init(i);
-		}
+		std::for_each(fragment_textures.begin(), fragment_textures.end(), [](auto &tex) { tex.init(); });
+		std::for_each(vertex_textures.begin(), vertex_textures.end(), [](auto &tex) { tex.init(); });
 	}
 
 namespace
@@ -804,8 +788,6 @@ namespace
 		const auto &It = reg_decoder.find(reg);
 		if (It != reg_decoder.end())
 			(It->second)(*this, value);
-		else
-			registers[reg] = value;
 	}
 
 	struct __rsx_methods_t

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -73,12 +73,8 @@ namespace rsx
 
 	struct rsx_state
 	{
-	private:
-		std::array<u32, 0x10000 / 4> registers;
-
-	public:
-		std::array<texture, 16> fragment_textures;
-		std::array<vertex_texture, 4> vertex_textures;
+		std::array<texture_t, 16> fragment_textures;
+		std::array<vertex_texture_t, 4> vertex_textures;
 
 		u32 m_transform_program_pointer;
 


### PR DESCRIPTION
The last PR that exposes explicit members for rsx_state data.
It's bigger since I added some new enum class to enhance type self definition. Another namespace (rsx::texture) is used to wrap all of them.

Hopefully I didn't introduce typo especially in the texture swizzle management.

Vertex texture command dump is supported.