### PR TITLE
D3D12: revert heap size back to 896M

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -167,7 +167,6 @@ D3D12GSRender::D3D12GSRender()
 		// Adapter with specified name
 		if (adapter_name == desc.Description)
 		{
-			vram_size = desc.DedicatedVideoMemory != 0 ? desc.DedicatedVideoMemory : desc.DedicatedSystemMemory;
 			break;
 		}
 
@@ -245,7 +244,7 @@ D3D12GSRender::D3D12GSRender()
 
 	m_rtts.init(m_device.Get());
 	m_readback_resources.init(m_device.Get(), 1024 * 1024 * 128, D3D12_HEAP_TYPE_READBACK, D3D12_RESOURCE_STATE_COPY_DEST);
-	m_buffer_data.init(m_device.Get(), std::min((size_t)(1024 * 1024 * 896), (size_t)(vram_size - (1024 * 1024 * 128))), D3D12_HEAP_TYPE_UPLOAD, D3D12_RESOURCE_STATE_GENERIC_READ);
+	m_buffer_data.init(m_device.Get(), 1024 * 1024 * 896, D3D12_HEAP_TYPE_UPLOAD, D3D12_RESOURCE_STATE_GENERIC_READ);
 
 	CHECK_HRESULT(
 		m_device->CreateCommittedResource(

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -121,7 +121,6 @@ private:
 	u32 m_current_transform_constants_buffer_descriptor_id;
 	ComPtr<ID3D12DescriptorHeap> m_current_texture_descriptors;
 	ComPtr<ID3D12DescriptorHeap> m_current_sampler_descriptors;
-	size_t vram_size;
 
 public:
 	D3D12GSRender();


### PR DESCRIPTION
Looks like it breaks lots of games that leads to "Working buffer not enough" .Revert it back the original and find out better solution.