### PR TITLE
rsx: Use bitfield template to decode values.

### DIFF
--- a/rpcs3/Emu/RSX/GCM.cpp
+++ b/rpcs3/Emu/RSX/GCM.cpp
@@ -854,7 +854,7 @@ std::string print_boolean(bool b)
 	}
 }
 
-std::string print_comparison_function(comparison_function f)
+std::string to_string(comparison_function f)
 {
 	switch (f)
 	{
@@ -870,7 +870,7 @@ std::string print_comparison_function(comparison_function f)
 	throw;
 }
 
-std::string print_stencil_op(stencil_op op)
+std::string to_string(stencil_op op)
 {
 	switch (op)
 	{
@@ -885,7 +885,7 @@ std::string print_stencil_op(stencil_op op)
 	throw;
 }
 
-std::string print_fog_mode(fog_mode op)
+std::string to_string(fog_mode op)
 {
 	switch (op)
 	{
@@ -899,7 +899,7 @@ std::string print_fog_mode(fog_mode op)
 	throw;
 }
 
-std::string print_logic_op(logic_op op)
+std::string to_string(logic_op op)
 {
 	switch (op)
 	{
@@ -922,7 +922,7 @@ std::string print_logic_op(logic_op op)
 	throw;
 }
 
-std::string print_front_face(front_face op)
+std::string to_string(front_face op)
 {
 	switch (op)
 	{
@@ -932,7 +932,7 @@ std::string print_front_face(front_face op)
 	throw;
 }
 
-std::string print_cull_face(cull_face op)
+std::string to_string(cull_face op)
 {
 	switch (op)
 	{
@@ -943,7 +943,7 @@ std::string print_cull_face(cull_face op)
 	throw;
 }
 
-std::string print_surface_target(surface_target target)
+std::string to_string(surface_target target)
 {
 	switch (target)
 	{
@@ -957,7 +957,7 @@ std::string print_surface_target(surface_target target)
 	throw;
 }
 
-std::string print_primitive_mode(primitive_type draw_mode)
+std::string to_string(primitive_type draw_mode)
 {
 	switch (draw_mode)
 	{
@@ -976,7 +976,7 @@ std::string print_primitive_mode(primitive_type draw_mode)
 	throw;
 }
 
-std::string print_transfer_operation(blit_engine::transfer_operation op)
+std::string to_string(blit_engine::transfer_operation op)
 {
 	switch (op)
 	{
@@ -990,7 +990,7 @@ std::string print_transfer_operation(blit_engine::transfer_operation op)
 	throw;
 }
 
-std::string print_transfer_source_format(blit_engine::transfer_source_format op)
+std::string to_string(blit_engine::transfer_source_format op)
 {
 	switch (op)
 	{
@@ -1011,7 +1011,7 @@ std::string print_transfer_source_format(blit_engine::transfer_source_format op)
 	throw;
 }
 
-std::string print_context_surface(blit_engine::context_surface op)
+std::string to_string(blit_engine::context_surface op)
 {
 	switch (op)
 	{
@@ -1021,7 +1021,7 @@ std::string print_context_surface(blit_engine::context_surface op)
 	throw;
 }
 
-std::string print_transfer_destination_format(blit_engine::transfer_destination_format op)
+std::string to_string(blit_engine::transfer_destination_format op)
 {
 	switch (op)
 	{
@@ -1033,7 +1033,7 @@ std::string print_transfer_destination_format(blit_engine::transfer_destination_
 }
 
 
-std::string print_blend_op(blend_equation op)
+std::string to_string(blend_equation op)
 {
 	switch (op)
 	{
@@ -1049,7 +1049,7 @@ std::string print_blend_op(blend_equation op)
 	throw;
 }
 
-std::string print_blend_factor(blend_factor factor)
+std::string to_string(blend_factor factor)
 {
 	switch (factor)
 	{
@@ -1072,7 +1072,7 @@ std::string print_blend_factor(blend_factor factor)
 	throw;
 }
 
-std::string print_origin_mode(window_origin origin)
+std::string to_string(window_origin origin)
 {
 	switch (origin)
 	{
@@ -1082,7 +1082,7 @@ std::string print_origin_mode(window_origin origin)
 	throw;
 }
 
-std::string print_pixel_center_mode(window_pixel_center in)
+std::string to_string(window_pixel_center in)
 {
 	switch (in)
 	{
@@ -1092,7 +1092,7 @@ std::string print_pixel_center_mode(window_pixel_center in)
 	throw;
 }
 
-std::string print_user_clip_plane_op(user_clip_plane_op op)
+std::string to_string(user_clip_plane_op op)
 {
 	switch (op)
 	{
@@ -1105,7 +1105,7 @@ std::string print_user_clip_plane_op(user_clip_plane_op op)
 
 
 
-std::string print_depth_stencil_surface_format(surface_depth_format format)
+std::string to_string(surface_depth_format format)
 {
 	switch (format)
 	{
@@ -1115,7 +1115,7 @@ std::string print_depth_stencil_surface_format(surface_depth_format format)
 	throw;
 }
 
-std::string print_surface_antialiasing(surface_antialiasing format)
+std::string to_string(surface_antialiasing format)
 {
 	switch (format)
 	{
@@ -1127,7 +1127,7 @@ std::string print_surface_antialiasing(surface_antialiasing format)
 	throw;
 }
 
-std::string print_surface_color_format(surface_color_format format)
+std::string to_string(surface_color_format format)
 {
 	switch (format)
 	{
@@ -1149,7 +1149,7 @@ std::string print_surface_color_format(surface_color_format format)
 	throw;
 }
 
-std::string print_index_type(index_array_type arg)
+std::string to_string(index_array_type arg)
 {
 	switch (arg)
 	{
@@ -1159,7 +1159,7 @@ std::string print_index_type(index_array_type arg)
 	throw;
 }
 
-std::string print_context_dma(blit_engine::context_dma op)
+std::string to_string(blit_engine::context_dma op)
 {
 	switch (op)
 	{
@@ -1169,7 +1169,7 @@ std::string print_context_dma(blit_engine::context_dma op)
 	throw;
 }
 
-std::string print_transfer_origin(blit_engine::transfer_origin op)
+std::string to_string(blit_engine::transfer_origin op)
 {
 	switch (op)
 	{
@@ -1179,7 +1179,7 @@ std::string print_transfer_origin(blit_engine::transfer_origin op)
 	throw;
 }
 
-std::string print_transfer_interpolator(blit_engine::transfer_interpolator op)
+std::string to_string(blit_engine::transfer_interpolator op)
 {
 	switch (op)
 	{
@@ -1189,7 +1189,7 @@ std::string print_transfer_interpolator(blit_engine::transfer_interpolator op)
 	throw;
 }
 
-std::string print_shading_mode(shading_mode op)
+std::string to_string(shading_mode op)
 {
 	switch (op)
 	{
@@ -1199,7 +1199,7 @@ std::string print_shading_mode(shading_mode op)
 	throw;
 }
 
-std::string print_polygon_mode(polygon_mode op)
+std::string to_string(polygon_mode op)
 {
 	switch (op)
 	{
@@ -1999,10 +1999,17 @@ namespace
 
 	namespace
 	{
+		template<u32 opcode>
+		auto register_pretty_printing(u32 arg)
+		{
+			typename rsx::registers_decoder<opcode>::decoded_type decoded_value(arg);
+			return rsx::registers_decoder<opcode>::dump(std::move(arg));
+		}
+
 		template<u32... opcode>
 		auto create_printing_table(const std::integer_sequence<u32, opcode...> &)
 		{
-			return std::unordered_map<uint32_t, std::string(*)(u32)>{ {opcode, rsx::print_register_value<opcode>}... };
+			return std::unordered_map<uint32_t, std::string(*)(u32)>{ {opcode, register_pretty_printing<opcode>}... };
 		}
 	}
 

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -11,10 +11,8 @@ namespace rsx
 
 	}
 
-	void texture::init(u8 index)
+	void texture::init()
 	{
-		m_index = index;
-
 		// Offset
 		registers[NV4097_SET_TEXTURE_OFFSET + (m_index * 8)] = 0;
 
@@ -255,10 +253,8 @@ namespace rsx
 
 	}
 
-	void vertex_texture::init(u8 index)
+	void vertex_texture::init()
 	{
-		m_index = index;
-
 		// Offset
 		registers[NV4097_SET_VERTEX_TEXTURE_OFFSET + (m_index * 8)] = 0;
 

--- a/rpcs3/Emu/RSX/RSXTexture.h
+++ b/rpcs3/Emu/RSX/RSXTexture.h
@@ -17,7 +17,7 @@ namespace rsx
 	class texture
 	{
 	protected:
-		u8 m_index;
+		const u8 m_index;
 		std::array<u32, 0x10000 / 4> &registers;
 
 	public:
@@ -25,7 +25,7 @@ namespace rsx
 		texture() = delete;
 
 		//initialize texture registers with default values
-		void init(u8 index);
+		void init();
 
 		// Offset
 		u32 offset() const;
@@ -93,7 +93,7 @@ namespace rsx
 	class vertex_texture
 	{
 	protected:
-		u8 m_index;
+		const u8 m_index;
 		std::array<u32, 0x10000 / 4> &registers;
 
 	public:
@@ -101,7 +101,7 @@ namespace rsx
 		vertex_texture() = delete;
 
 		//initialize texture registers with default values
-		void init(u8 index);
+		void init();
 
 		// Offset
 		u32 offset() const;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -477,9 +477,10 @@ namespace rsx
 					frame_debug.command_queue.push_back(std::make_pair(reg, value));
 				}
 
-				if (auto method = methods[reg])
+				const auto& It = methods.find(reg);
+				if (It != methods.end())
 				{
-					method(this, value);
+					It->second(this, value);
 				}
 			}
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "GCM.h"
+#include "rsx_decode.h"
 #include "RSXTexture.h"
 #include "rsx_vertex_data.h"
 #include "Utilities/geometry.h"
@@ -76,6 +77,16 @@ namespace rsx
 	private:
 		std::array<u32, 0x10000 / 4> registers;
 
+		template<u32 opcode>
+		using decoded_type = typename registers_decoder<opcode>::decoded_type;
+
+		template<u32 opcode>
+		decoded_type<opcode> decode() const
+		{
+			u32 register_value = registers[opcode];
+			return decoded_type<opcode>(register_value);
+		}
+
 	public:
 		std::array<texture, 16> fragment_textures;
 		std::array<vertex_texture, 4> vertex_textures;
@@ -111,1176 +122,958 @@ namespace rsx
 
 		void reset();
 
-		u16 m_viewport_origin_x;
-		u16 m_viewport_origin_y;
-
-		u16 m_viewport_width;
-		u16 m_viewport_height;
-
-		u16 m_scissor_origin_x;
-		u16 m_scissor_origin_y;
-
-		u16 m_scissor_width;
-		u16 m_scissor_height;
-
-		u16 m_clear_rect_origin_x;
-		u16 m_clear_rect_origin_y;
-		u16 m_clear_rect_width;
-		u16 m_clear_rect_height;
-
-		window_origin m_shader_window_origin : 1;
-		window_pixel_center m_shader_window_pixel : 1;
-		u16 m_shader_window_height : 12;
-
-		u16 m_shader_window_offset_x;
-		u16 m_shader_window_offset_y;
-
-		bool m_dither_enabled : 1;
-		bool m_line_smooth_enabled : 1;
-		bool m_poly_offset_point_enabled : 1;
-		bool m_offset_line_enabled : 1;
-		bool m_poly_offset_fill_enabled : 1;
-		bool m_poly_smooth_enabled : 1;
-		bool m_cull_face_enabled : 1;
-		bool m_two_sided_stencil_test_enabled : 1;
-		bool m_color_mask_b : 1;
-		bool m_color_mask_g : 1;
-		bool m_color_mask_r : 1;
-		bool m_color_mask_a : 1;
-
-		rsx::shading_mode m_shading_mode : 1;
-
-		rsx::polygon_mode m_front_polygon_mode : 2;
-		rsx::polygon_mode m_back_polygon_mode : 2;
-
-		bool m_alpha_test_enabled : 1;
-		u8 m_alpha_ref;
-		comparison_function m_alpha_func : 3;
-
-		bool m_restart_index_enabled : 1;
-		u32 m_restart_index;
-
-		u8 m_stencil_clear_value;
-		u32 m_z_clear_value : 24;
-
-		fog_mode m_fog_equation : 3;
-		f32 m_fog_params_0;
-		f32 m_fog_params_1;
-
-		u8 m_index_array_location : 4;
-		rsx::index_array_type m_index_type : 1;
-		u32 m_index_array_address;
-
-		u8 m_clear_color_b;
-		u8 m_clear_color_r;
-		u8 m_clear_color_g;
-		u8 m_clear_color_a;
-
-		f32 m_poly_offset_scale;
-		f32 m_poly_offset_bias;
-
-		bool m_depth_bounds_test_enabled : 1;
-		bool m_depth_test_enabled : 1;
-		bool m_depth_write_enabled : 1;
-		comparison_function m_depth_func : 3;
-		f32 m_depth_bounds_min;
-		f32 m_depth_bounds_max;
-		f32 m_clip_min;
-		f32 m_clip_max;
-
-		bool m_stencil_test_enabled : 1;
-		u8 m_stencil_mask;
-		u8 m_back_stencil_mask;
-		u8 m_stencil_func_ref;
-		u8 m_back_stencil_func_ref;
-		u8 m_stencil_func_mask;
-		u8 m_back_stencil_func_mask;
-		comparison_function m_stencil_func : 3;
-		comparison_function m_back_stencil_func : 3;
-		stencil_op m_stencil_op_fail : 3;
-		stencil_op m_stencil_op_zfail : 3;
-		stencil_op m_stencil_op_zpass : 3;
-		stencil_op m_back_stencil_op_fail : 3;
-		stencil_op m_back_stencil_op_zfail : 3;
-		stencil_op m_back_stencil_op_zpass : 3;
-
-		bool m_blend_enabled : 1;
-		bool m_blend_enabled_surface_1 : 1;
-		bool m_blend_enabled_surface_2 : 1;
-		bool m_blend_enabled_surface_3 : 1;
-		// Can be interpreted as 4 x 8 or 2 x 16 color
-		u32 m_blend_color;
-		u16 m_blend_color_16b_b;
-		u16 m_blend_color_16b_a;
-		blend_equation m_blend_equation_rgb : 3;
-		blend_equation m_blend_equation_a : 3;
-		blend_factor m_blend_func_sfactor_rgb : 4;
-		blend_factor m_blend_func_sfactor_a : 4;
-		blend_factor m_blend_func_dfactor_rgb : 4;
-		blend_factor m_blend_func_dfactor_a : 4;
-
-		bool m_logic_op_enabled : 1;
-		logic_op m_logic_operation : 4;
-
-		user_clip_plane_op m_clip_plane_0_enabled : 1;
-		user_clip_plane_op m_clip_plane_1_enabled : 1;
-		user_clip_plane_op m_clip_plane_2_enabled : 1;
-		user_clip_plane_op m_clip_plane_3_enabled : 1;
-		user_clip_plane_op m_clip_plane_4_enabled : 1;
-		user_clip_plane_op m_clip_plane_5_enabled : 1;
-
-		front_face m_front_face_mode : 1;
-
-		cull_face m_cull_face_mode : 2;
-
-		f32 m_line_width;
-
-		surface_target m_surface_color_target : 3;
-
-		u16 m_surface_clip_origin_x;
-		u16 m_surface_clip_width;
-		u16 m_surface_clip_origin_y;
-		u16 m_surface_clip_height;
-
-		u32 m_surface_a_offset;
-		u32 m_surface_a_pitch;
-		u32 m_surface_a_dma;
-		u32 m_surface_b_offset;
-		u32 m_surface_b_pitch;
-		u32 m_surface_b_dma;
-		u32 m_surface_c_offset;
-		u32 m_surface_c_pitch;
-		u32 m_surface_c_dma;
-		u32 m_surface_d_offset;
-		u32 m_surface_d_pitch;
-		u32 m_surface_d_dma;
-		u32 m_surface_z_offset;
-		u32 m_surface_z_pitch;
-		u32 m_surface_z_dma;
-
-		f32 m_viewport_scale_x;
-		f32 m_viewport_scale_y;
-		f32 m_viewport_scale_z;
-		f32 m_viewport_scale_w;
-		f32 m_viewport_offset_x;
-		f32 m_viewport_offset_y;
-		f32 m_viewport_offset_z;
-		f32 m_viewport_offset_w;
-
-		bool m_two_side_light_enabled : 1;
-
-		u16 m_vertex_attrib_input_mask;
-		u16 m_frequency_divider_operation_mask;
-		u32 m_vertex_attrib_output_mask;
-
-		// Quite opaque
-		u32 m_shader_control;
-
-		surface_color_format m_surface_color : 4;
-		surface_depth_format m_surface_depth_format : 1;
-		surface_antialiasing m_surface_antialias : 2;
-		u8 m_surface_log2_height;
-		u8 m_surface_log2_width;
-
-		bool m_msaa_enabled : 1;
-		bool m_msaa_alpha_to_coverage : 1;
-		bool m_msaa_alpha_to_one : 1;
-		u16 m_msaa_sample_mask;
-
-		u32 m_vertex_data_base_offset;
-		u32 m_vertex_data_base_index;
-		u32 m_shader_program_address;
-		u32 m_transform_program_start;
-
-		primitive_type m_primitive_type : 4;
-		u32 m_semaphore_offset_406e;
-		u32 m_semaphore_offset_4097;
-
-
-		u32 m_transform_constant_file_pointer;
-
-		blit_engine::context_dma m_context_dma_report : 1;
-		blit_engine::transfer_operation m_blit_engine_operation : 3;
-		u16 m_blit_engine_clip_x;
-		u16 m_blit_engine_clip_y;
-		u16 m_blit_engine_width;
-		u16 m_blit_engine_height;
-		u16 m_blit_engine_output_x;
-		u16 m_blit_engine_output_y;
-		u16 m_blit_engine_output_width;
-		u16 m_blit_engine_output_height;
-		u16 m_blit_engine_input_width;
-		u16 m_blit_engine_input_height;
-		u16 m_blit_engine_input_pitch;
-		blit_engine::transfer_origin m_blit_engine_input_origin : 1;
-		blit_engine::transfer_interpolator m_blit_engine_input_inter : 1;
-		blit_engine::transfer_source_format m_blit_engine_src_color_format : 4;
-		u16 m_blit_engine_in_x;
-		u16 m_blit_engine_in_y;
-		u32 m_blit_engine_input_offset;
-		u32 m_blit_engine_input_location;
-		blit_engine::context_surface m_blit_engine_context_surface : 1;
-		u32 m_blit_engine_output_location_nv3062;
-		blit_engine::transfer_destination_format m_blit_engine_nv3062_color_format : 2;
-		u32 m_blit_engine_output_offset_nv3062;
-		u16 m_blit_engine_output_alignement_nv3062;
-		u16 m_blit_engine_output_pitch_nv3062;
-		u32 m_blit_engine_nv309E_location;
-		u32 m_blit_engine_nv309E_offset;
-		blit_engine::transfer_destination_format m_blit_engine_output_format_nv309E : 2;
-		u32 m_blit_engine_ds_dx;
-		u32 m_blit_engine_dt_dy;
-		u8 m_nv309e_sw_width_log2;
-		u8 m_nv309e_sw_height_log2;
-		u32 m_nv0039_input_pitch;
-		u32 m_nv0039_output_pitch;
-		u32 m_nv0039_line_length;
-		u32 m_nv0039_line_count;
-		u8 m_nv0039_input_format;
-		u8 m_nv0039_output_format;
-		u32 m_nv0039_output_offset;
-		u32 m_nv0039_output_location;
-		u32 m_nv0039_input_offset;
-		u32 m_nv0039_input_location;
-		u16 m_nv308a_x;
-		u16 m_nv308a_y;
-
 		u16 viewport_width() const
 		{
-			return m_viewport_width;
+			return decode<NV4097_SET_VIEWPORT_HORIZONTAL>().width();
 		}
 
 		u16 viewport_origin_x() const
 		{
-			return m_viewport_origin_x;
+			return decode<NV4097_SET_VIEWPORT_HORIZONTAL>().origin_x();
 		}
 
 		u16 viewport_height() const
 		{
-			return m_viewport_height;
+			return decode<NV4097_SET_VIEWPORT_VERTICAL>().height();
 		}
 
 		u16 viewport_origin_y() const
 		{
-			return m_viewport_origin_y;
+			return decode<NV4097_SET_VIEWPORT_VERTICAL>().origin_y();
 		}
 
 		u16 scissor_origin_x() const
 		{
-			return m_scissor_origin_x;
+			return decode<NV4097_SET_SCISSOR_HORIZONTAL>().origin_x();
 		}
 
 		u16 scissor_width() const
 		{
-			return m_scissor_width;
+			return decode<NV4097_SET_SCISSOR_HORIZONTAL>().width();
 		}
 
 		u16 scissor_origin_y() const
 		{
-			return m_scissor_origin_y;
+			return decode<NV4097_SET_SCISSOR_VERTICAL>().origin_y();
 		}
 
 		u16 scissor_height() const
 		{
-			return m_scissor_height;
+			return decode<NV4097_SET_SCISSOR_VERTICAL>().height();
 		}
 
 		window_origin shader_window_origin() const
 		{
-			return m_shader_window_origin;
+			return decode<NV4097_SET_SHADER_WINDOW>().window_shader_origin();
 		}
 
 		window_pixel_center shader_window_pixel() const
 		{
-			return m_shader_window_pixel;
+			return decode<NV4097_SET_SHADER_WINDOW>().window_shader_pixel_center();
 		}
 
 		u16 shader_window_height() const
 		{
-			return m_shader_window_height;
+			return decode<NV4097_SET_SHADER_WINDOW>().window_shader_height();
 		}
 
 		u16 shader_window_offset_x() const
 		{
-			return m_shader_window_offset_x;
+			return decode<NV4097_SET_WINDOW_OFFSET>().window_offset_x();
 		}
 
 		u16 shader_window_offset_y() const
 		{
-			return m_shader_window_offset_y;
+			return decode<NV4097_SET_WINDOW_OFFSET>().window_offset_y();
 		}
 
 		bool depth_test_enabled() const
 		{
-			return m_depth_test_enabled;
+			return decode<NV4097_SET_DEPTH_TEST_ENABLE>().depth_test_enabled();
 		}
 
 		bool depth_write_enabled() const
 		{
-			return m_depth_write_enabled;
+			return decode<NV4097_SET_DEPTH_MASK>().depth_write_enabled();
 		}
 
 		bool alpha_test_enabled() const
 		{
-			return m_alpha_test_enabled;
+			return decode<NV4097_SET_ALPHA_TEST_ENABLE>().alpha_test_enabled();
 		}
 
 		bool stencil_test_enabled() const
 		{
-			return m_stencil_test_enabled;
+			return decode<NV4097_SET_STENCIL_TEST_ENABLE>().stencil_test_enabled();
 		}
 
 		bool restart_index_enabled() const
 		{
-			return m_restart_index_enabled;
+			return decode<NV4097_SET_RESTART_INDEX_ENABLE>().restart_index_enabled();
 		}
 
 		u32 restart_index() const
 		{
-			return m_restart_index;
+			return decode<NV4097_SET_RESTART_INDEX>().restart_index();
 		}
 
 		u32 z_clear_value() const
 		{
-			return m_z_clear_value;
+			return decode<NV4097_SET_ZSTENCIL_CLEAR_VALUE>().clear_z();
 		}
 
 		u8 stencil_clear_value() const
 		{
-			return m_stencil_clear_value;
+			return decode<NV4097_SET_ZSTENCIL_CLEAR_VALUE>().clear_stencil();
 		}
 
 		f32 fog_params_0() const
 		{
-			return m_fog_params_0;
+			return decode<NV4097_SET_FOG_PARAMS>().fog_param_0();
 		}
 
 		f32 fog_params_1() const
 		{
-			return m_fog_params_1;
+			return decode<NV4097_SET_FOG_PARAMS + 1>().fog_param_1();
 		}
 
 		u8 index_array_location() const
 		{
-			return m_index_array_location;
+			return decode<NV4097_SET_INDEX_ARRAY_DMA>().index_dma();
 		}
 
 		rsx::index_array_type index_type() const
 		{
-			return m_index_type;
+			return decode<NV4097_SET_INDEX_ARRAY_DMA>().type();
 		}
 
 		bool color_mask_b() const
 		{
-			return m_color_mask_b;
+			return decode<NV4097_SET_COLOR_MASK>().color_b();
 		}
 
 		bool color_mask_g() const
 		{
-			return m_color_mask_g;
+			return decode<NV4097_SET_COLOR_MASK>().color_g();
 		}
 
 		bool color_mask_r() const
 		{
-			return m_color_mask_r;
+			return decode<NV4097_SET_COLOR_MASK>().color_r();
 		}
 
 		bool color_mask_a() const
 		{
-			return m_color_mask_a;
+			return decode<NV4097_SET_COLOR_MASK>().color_a();
 		}
 
 		u8 clear_color_b() const
 		{
-			return m_clear_color_b;
+			return decode<NV4097_SET_COLOR_CLEAR_VALUE>().blue();
 		}
 
 		u8 clear_color_r() const
 		{
-			return m_clear_color_r;
+			return decode<NV4097_SET_COLOR_CLEAR_VALUE>().red();
 		}
 
 		u8 clear_color_g() const
 		{
-			return m_clear_color_g;
+			return decode<NV4097_SET_COLOR_CLEAR_VALUE>().green();
 		}
 
 		u8 clear_color_a() const
 		{
-			return m_clear_color_a;
+			return decode<NV4097_SET_COLOR_CLEAR_VALUE>().alpha();
 		}
 
 		bool depth_bounds_test_enabled() const
 		{
-			return m_depth_bounds_test_enabled;
+			return decode<NV4097_SET_DEPTH_BOUNDS_TEST_ENABLE>().depth_bound_enabled();
 		}
 
 		f32 depth_bounds_min() const
 		{
-			return m_depth_bounds_min;
+			return decode<NV4097_SET_DEPTH_BOUNDS_MIN>().depth_bound_min();
 		}
 
 		f32 depth_bounds_max() const
 		{
-			return m_depth_bounds_max;
+			return decode<NV4097_SET_DEPTH_BOUNDS_MAX>().depth_bound_max();
 		}
 
 		f32 clip_min() const
 		{
-			return m_clip_min;
+			return decode<NV4097_SET_CLIP_MIN>().clip_min();
 		}
 
 		f32 clip_max() const
 		{
-			return m_clip_max;
+			return decode<NV4097_SET_CLIP_MAX>().clip_max();
 		}
 
 		bool logic_op_enabled() const
 		{
-			return m_logic_op_enabled;
+			return decode<NV4097_SET_LOGIC_OP_ENABLE>().logic_op_enabled();
 		}
 
 		u8 stencil_mask() const
 		{
-			return m_stencil_mask;
+			return decode<NV4097_SET_STENCIL_MASK>().stencil_mask();
 		}
 
 		u8 back_stencil_mask() const
 		{
-			return m_back_stencil_mask;
+			return decode<NV4097_SET_BACK_STENCIL_MASK>().back_stencil_mask();
 		}
 
 		bool dither_enabled() const
 		{
-			return m_dither_enabled;
+			return decode<NV4097_SET_DITHER_ENABLE>().dither_enabled();
 		}
 
 		bool blend_enabled() const
 		{
-			return m_blend_enabled;
+			return decode<NV4097_SET_BLEND_ENABLE>().blend_enabled();
 		}
 
 		bool blend_enabled_surface_1() const
 		{
-			return m_blend_enabled_surface_1;
+			return decode<NV4097_SET_BLEND_ENABLE_MRT>().blend_surface_b();
 		}
 
 		bool blend_enabled_surface_2() const
 		{
-			return m_blend_enabled_surface_2;
+			return decode<NV4097_SET_BLEND_ENABLE_MRT>().blend_surface_c();
 		}
 
 		bool blend_enabled_surface_3() const
 		{
-			return m_blend_enabled_surface_3;
+			return decode<NV4097_SET_BLEND_ENABLE_MRT>().blend_surface_d();
 		}
 
 		bool line_smooth_enabled() const
 		{
-			return m_line_smooth_enabled;
+			return decode<NV4097_SET_LINE_SMOOTH_ENABLE>().line_smooth_enabled();
 		}
 
 		bool poly_offset_point_enabled() const
 		{
-			return m_poly_offset_point_enabled;
+			return decode<NV4097_SET_POLY_OFFSET_POINT_ENABLE>().poly_offset_point_enabled();
 		}
 
 		bool poly_offset_line_enabled() const
 		{
-			return m_offset_line_enabled;
+			return decode<NV4097_SET_POLY_OFFSET_LINE_ENABLE>().poly_offset_line_enabled();
 		}
 
 		bool poly_offset_fill_enabled() const
 		{
-			return m_poly_offset_fill_enabled;
+			return decode<NV4097_SET_POLY_OFFSET_FILL_ENABLE>().poly_offset_fill_enabled();
 		}
 
 		f32 poly_offset_scale() const
 		{
-			return m_poly_offset_scale;
+			return decode<NV4097_SET_POLYGON_OFFSET_SCALE_FACTOR>().polygon_offset_scale_factor();
 		}
 
 		f32 poly_offset_bias() const
 		{
-			return m_poly_offset_bias;
+			return decode<NV4097_SET_POLYGON_OFFSET_BIAS>().polygon_offset_scale_bias();
 		}
 
 		bool cull_face_enabled() const
 		{
-			return m_cull_face_enabled;
+			return decode<NV4097_SET_CULL_FACE_ENABLE>().cull_face_enabled();
 		}
 
 		bool poly_smooth_enabled() const
 		{
-			return m_poly_smooth_enabled;
+			return decode<NV4097_SET_POLY_SMOOTH_ENABLE>().poly_smooth_enabled();
 		}
 
 		bool two_sided_stencil_test_enabled() const
 		{
-			return m_two_sided_stencil_test_enabled;
+			return decode<NV4097_SET_TWO_SIDED_STENCIL_TEST_ENABLE>().two_sided_stencil_test_enabled();
 		}
 
 		comparison_function depth_func() const
 		{
-			return m_depth_func;
+			return decode<NV4097_SET_DEPTH_FUNC>().depth_func();
 		}
 
 		comparison_function stencil_func() const
 		{
-			return m_stencil_func;
+			return decode<NV4097_SET_STENCIL_FUNC>().stencil_func();
 		}
 
 		comparison_function back_stencil_func() const
 		{
-			return m_back_stencil_func;
+			return decode<NV4097_SET_BACK_STENCIL_FUNC>().back_stencil_func();
 		}
 
 		u8 stencil_func_ref() const
 		{
-			return m_stencil_func_ref;
+			return decode<NV4097_SET_STENCIL_FUNC_REF>().stencil_func_ref();
 		}
 
 		u8 back_stencil_func_ref() const
 		{
-			return m_back_stencil_func_ref;
+			return decode<NV4097_SET_BACK_STENCIL_FUNC_REF>().back_stencil_func_ref();
 		}
 
 		u8 stencil_func_mask() const
 		{
-			return m_stencil_func_mask;
+			return decode<NV4097_SET_STENCIL_FUNC_MASK>().stencil_func_mask();
 		}
 
 		u8 back_stencil_func_mask() const
 		{
-			return m_back_stencil_func_mask;
+			return decode<NV4097_SET_BACK_STENCIL_FUNC_MASK>().back_stencil_func_mask();
 		}
 
 		stencil_op stencil_op_fail() const
 		{
-			return m_stencil_op_fail;
+			return decode<NV4097_SET_STENCIL_OP_FAIL>().fail();
 		}
 
 		stencil_op stencil_op_zfail() const
 		{
-			return m_stencil_op_zfail;
+			return decode<NV4097_SET_STENCIL_OP_ZFAIL>().zfail();
 		}
 
 		stencil_op stencil_op_zpass() const
 		{
-			return m_stencil_op_zpass;
+			return decode<NV4097_SET_STENCIL_OP_ZPASS>().zpass();
 		}
 
 		stencil_op back_stencil_op_fail() const
 		{
-			return m_back_stencil_op_fail;
+			return decode<NV4097_SET_BACK_STENCIL_OP_FAIL>().back_fail();
 		}
 
 		rsx::stencil_op back_stencil_op_zfail() const
 		{
-			return m_back_stencil_op_zfail;
+			return decode<NV4097_SET_BACK_STENCIL_OP_ZFAIL>().back_zfail();
 		}
 
 		rsx::stencil_op back_stencil_op_zpass() const
 		{
-			return m_back_stencil_op_zpass;
+			return decode<NV4097_SET_BACK_STENCIL_OP_ZPASS>().back_zpass();
 		}
 
 		u8 blend_color_8b_r() const
 		{
-			return m_blend_color & 0xff;
+			return decode<NV4097_SET_BLEND_COLOR>().red8();
 		}
 
 		u8 blend_color_8b_g() const
 		{
-			return (m_blend_color >> 8) & 0xff;
+			return decode<NV4097_SET_BLEND_COLOR>().green8();
 		}
 
 		u8 blend_color_8b_b() const
 		{
-			return (m_blend_color >> 16) & 0xff;
+			return decode<NV4097_SET_BLEND_COLOR>().blue8();
 		}
 
 		u8 blend_color_8b_a() const
 		{
-			return (m_blend_color >> 24) & 0xff;
+			return decode<NV4097_SET_BLEND_COLOR>().alpha8();
 		}
 
 		u16 blend_color_16b_r() const
 		{
-			return m_blend_color & 0xffff;
+			return decode<NV4097_SET_BLEND_COLOR>().red16();
 		}
 
 		u16 blend_color_16b_g() const
 		{
-			return (m_blend_color >> 16) & 0xffff;
+			return decode<NV4097_SET_BLEND_COLOR>().green16();
 		}
 
 		u16 blend_color_16b_b() const
 		{
-			return m_blend_color_16b_b;
+			return decode<NV4097_SET_BLEND_COLOR2>().blue();
 		}
 
 		u16 blend_color_16b_a() const
 		{
-			return m_blend_color_16b_a;
+			return decode<NV4097_SET_BLEND_COLOR2>().alpha();
 		}
 
 		blend_equation blend_equation_rgb() const
 		{
-			return m_blend_equation_rgb;
+			return decode<NV4097_SET_BLEND_EQUATION>().blend_rgb();
 		}
 
 		blend_equation blend_equation_a() const
 		{
-			return m_blend_equation_a;
+			return decode<NV4097_SET_BLEND_EQUATION>().blend_a();
 		}
 
 		blend_factor blend_func_sfactor_rgb() const
 		{
-			return m_blend_func_sfactor_rgb;
+			return decode<NV4097_SET_BLEND_FUNC_SFACTOR>().src_blend_rgb();
 		}
 
 		blend_factor blend_func_sfactor_a() const
 		{
-			return m_blend_func_sfactor_a;
+			return decode<NV4097_SET_BLEND_FUNC_SFACTOR>().src_blend_a();
 		}
 
 		blend_factor blend_func_dfactor_rgb() const
 		{
-			return m_blend_func_dfactor_rgb;
+			return decode<NV4097_SET_BLEND_FUNC_DFACTOR>().dst_blend_rgb();
 		}
 
 		blend_factor blend_func_dfactor_a() const
 		{
-			return m_blend_func_dfactor_a;
+			return decode<NV4097_SET_BLEND_FUNC_DFACTOR>().dst_blend_a();
 		}
 
 		logic_op logic_operation() const
 		{
-			return m_logic_operation;
+			return decode<NV4097_SET_LOGIC_OP>().logic_operation();
 		}
 
 		user_clip_plane_op clip_plane_0_enabled() const
 		{
-			return m_clip_plane_0_enabled;
+			return decode<NV4097_SET_USER_CLIP_PLANE_CONTROL>().clip_plane0();
 		}
 
 		user_clip_plane_op clip_plane_1_enabled() const
 		{
-			return m_clip_plane_1_enabled;
+			return decode<NV4097_SET_USER_CLIP_PLANE_CONTROL>().clip_plane1();
 		}
 
 		user_clip_plane_op clip_plane_2_enabled() const
 		{
-			return m_clip_plane_2_enabled;
+			return decode<NV4097_SET_USER_CLIP_PLANE_CONTROL>().clip_plane2();
 		}
 
 		user_clip_plane_op clip_plane_3_enabled() const
 		{
-			return m_clip_plane_3_enabled;
+			return decode<NV4097_SET_USER_CLIP_PLANE_CONTROL>().clip_plane3();
 		}
 
 		user_clip_plane_op clip_plane_4_enabled() const
 		{
-			return m_clip_plane_4_enabled;
+			return decode<NV4097_SET_USER_CLIP_PLANE_CONTROL>().clip_plane4();
 		}
 
 		user_clip_plane_op clip_plane_5_enabled() const
 		{
-			return m_clip_plane_5_enabled;
+			return decode<NV4097_SET_USER_CLIP_PLANE_CONTROL>().clip_plane5();
 		}
 
 		front_face front_face_mode() const
 		{
-			return m_front_face_mode;
+			return decode<NV4097_SET_FRONT_FACE>().front_face_mode();
 		}
 
 		cull_face cull_face_mode() const
 		{
-			return m_cull_face_mode;
+			return decode<NV4097_SET_CULL_FACE>().cull_face_mode();
 		}
 
 		f32 line_width() const
 		{
-			return m_line_width;
+			return decode<NV4097_SET_LINE_WIDTH>().line_width();
 		}
 
 		u8 alpha_ref() const
 		{
-			return m_alpha_ref;
+			return decode<NV4097_SET_ALPHA_REF>().alpha_ref();
 		}
 
 		surface_target surface_color_target()
 		{
-			return m_surface_color_target;
+			return decode<NV4097_SET_SURFACE_COLOR_TARGET>().target();
 		}
 
 		u16 surface_clip_origin_x() const
 		{
-			return m_surface_clip_origin_x;
+			return decode<NV4097_SET_SURFACE_CLIP_HORIZONTAL>().origin_x();
 		}
 
 		u16 surface_clip_width() const
 		{
-			return m_surface_clip_width;
+			return decode<NV4097_SET_SURFACE_CLIP_HORIZONTAL>().width();
 		}
 
 		u16 surface_clip_origin_y() const
 		{
-			return m_surface_clip_origin_y;
+			return decode<NV4097_SET_SURFACE_CLIP_VERTICAL>().origin_y();
 		}
 
 		u16 surface_clip_height() const
 		{
-			return m_surface_clip_height;
+			return decode<NV4097_SET_SURFACE_CLIP_VERTICAL>().height();
 		}
 
 		u32 surface_a_offset() const
 		{
-			return m_surface_a_offset;
+			return decode<NV4097_SET_SURFACE_COLOR_AOFFSET>().surface_a_offset();
 		}
 
 		u32 surface_b_offset() const
 		{
-			return m_surface_b_offset;
+			return decode<NV4097_SET_SURFACE_COLOR_BOFFSET>().surface_b_offset();
 		}
 
 		u32 surface_c_offset() const
 		{
-			return m_surface_c_offset;
+			return decode<NV4097_SET_SURFACE_COLOR_COFFSET>().surface_c_offset();
 		}
 
 		u32 surface_d_offset() const
 		{
-			return m_surface_d_offset;
+			return decode<NV4097_SET_SURFACE_COLOR_DOFFSET>().surface_d_offset();
 		}
 
 		u32 surface_a_pitch() const
 		{
-			return m_surface_a_pitch;
+			return decode<NV4097_SET_SURFACE_PITCH_A>().surface_a_pitch();
 		}
 
 		u32 surface_b_pitch() const
 		{
-			return m_surface_b_pitch;
+			return decode<NV4097_SET_SURFACE_PITCH_B>().surface_b_pitch();
 		}
 
 		u32 surface_c_pitch() const
 		{
-			return m_surface_c_pitch;
+			return decode<NV4097_SET_SURFACE_PITCH_C>().surface_c_pitch();
 		}
 
 		u32 surface_d_pitch() const
 		{
-			return m_surface_d_pitch;
+			return decode<NV4097_SET_SURFACE_PITCH_D>().surface_d_pitch();
 		}
 
 		u32 surface_a_dma() const
 		{
-			return m_surface_a_dma;
+			return decode<NV4097_SET_CONTEXT_DMA_COLOR_A>().dma_surface_a();
 		}
 
 		u32 surface_b_dma() const
 		{
-			return m_surface_b_dma;
+			return decode<NV4097_SET_CONTEXT_DMA_COLOR_B>().dma_surface_b();
 		}
 
 		u32 surface_c_dma() const
 		{
-			return m_surface_c_dma;
+			return decode<NV4097_SET_CONTEXT_DMA_COLOR_C>().dma_surface_c();
 		}
 
 		u32 surface_d_dma() const
 		{
-			return m_surface_d_dma;
+			return decode<NV4097_SET_CONTEXT_DMA_COLOR_D>().dma_surface_d();
 		}
 
 		u32 surface_z_offset() const
 		{
-			return m_surface_z_offset;
+			return decode<NV4097_SET_SURFACE_ZETA_OFFSET>().surface_z_offset();
 		}
 
 		u32 surface_z_pitch() const
 		{
-			return m_surface_z_pitch;
+			return decode<NV4097_SET_SURFACE_PITCH_Z>().surface_z_pitch();
 		}
 
 		u32 surface_z_dma() const
 		{
-			return m_surface_z_dma;
+			return decode<NV4097_SET_CONTEXT_DMA_ZETA>().dma_surface_z();
 		}
 
 		f32 viewport_scale_x() const
 		{
-			return m_viewport_scale_x;
+			return decode<NV4097_SET_VIEWPORT_SCALE>().viewport_scale_x();
 		}
 
 		f32 viewport_scale_y() const
 		{
-			return m_viewport_scale_y;
+			return decode<NV4097_SET_VIEWPORT_SCALE + 1>().viewport_scale_y();
 		}
 
 		f32 viewport_scale_z() const
 		{
-			return m_viewport_scale_z;
+			return decode<NV4097_SET_VIEWPORT_SCALE + 2>().viewport_scale_z();
 		}
 
 		f32 viewport_scale_w() const
 		{
-			return m_viewport_scale_w;
+			return decode<NV4097_SET_VIEWPORT_SCALE + 3>().viewport_scale_w();
 		}
 
 		f32 viewport_offset_x() const
 		{
-			return m_viewport_offset_x;
+			return decode<NV4097_SET_VIEWPORT_OFFSET>().viewport_offset_x();
 		}
 
 		f32 viewport_offset_y() const
 		{
-			return m_viewport_offset_y;
+			return decode<NV4097_SET_VIEWPORT_OFFSET + 1>().viewport_offset_y();
 		}
 
 		f32 viewport_offset_z() const
 		{
-			return m_viewport_offset_z;
+			return decode<NV4097_SET_VIEWPORT_OFFSET + 2>().viewport_offset_z();
 		}
 
 		f32 viewport_offset_w() const
 		{
-			return m_viewport_offset_w;
+			return decode<NV4097_SET_VIEWPORT_OFFSET + 3>().viewport_offset_w();
 		}
 
 		bool two_side_light_en() const
 		{
-			return m_two_side_light_enabled;
+			return decode<NV4097_SET_TWO_SIDE_LIGHT_EN>().two_sided_lighting_enabled();
 		}
 
 		fog_mode fog_equation() const
 		{
-			return m_fog_equation;
+			return decode<NV4097_SET_FOG_MODE>().fog_equation();
 		}
 
 		comparison_function alpha_func() const
 		{
-			return m_alpha_func;
+			return decode<NV4097_SET_ALPHA_FUNC>().alpha_func();
 		}
 
 		u16 vertex_attrib_input_mask() const
 		{
-			return m_vertex_attrib_input_mask;
+			return decode<NV4097_SET_VERTEX_ATTRIB_INPUT_MASK>().mask();
 		}
 
 		u16 frequency_divider_operation_mask() const
 		{
-			return m_frequency_divider_operation_mask;
+			return decode<NV4097_SET_FREQUENCY_DIVIDER_OPERATION>().frequency_divider_operation_mask();
 		}
 
 		u32 vertex_attrib_output_mask() const
 		{
-			return m_vertex_attrib_output_mask;
+			return decode<NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK>().output_mask();
 		}
 
 		u32 shader_control() const
 		{
-			return m_shader_control;
+			return decode<NV4097_SET_SHADER_CONTROL>().shader_ctrl();
 		}
 
 		surface_color_format surface_color() const
 		{
-			return m_surface_color;
+			return decode<NV4097_SET_SURFACE_FORMAT>().color_fmt();
 		}
 
 		surface_depth_format surface_depth_fmt() const
 		{
-			return m_surface_depth_format;
+			return decode<NV4097_SET_SURFACE_FORMAT>().depth_fmt();
 		}
 
 		surface_antialiasing surface_antialias() const
 		{
-			return m_surface_antialias;
+			return decode<NV4097_SET_SURFACE_FORMAT>().antialias();
 		}
 
 		u8 surface_log2_height() const
 		{
-			return m_surface_log2_height;
+			return decode<NV4097_SET_SURFACE_FORMAT>().log2height();
 		}
 
 		u8 surface_log2_width() const
 		{
-			return m_surface_log2_width;
+			return decode<NV4097_SET_SURFACE_FORMAT>().log2width();
 		}
 
 		u32 vertex_data_base_offset() const
 		{
-			return m_vertex_data_base_offset;
+			return decode<NV4097_SET_VERTEX_DATA_BASE_OFFSET>().vertex_data_base_offset();
 		}
 
 		u32 index_array_address() const
 		{
-			return m_index_array_address;
+			return decode<NV4097_SET_INDEX_ARRAY_ADDRESS>().index_array_offset();
 		}
 
 		u32 vertex_data_base_index() const
 		{
-			return m_vertex_data_base_index;
+			return decode<NV4097_SET_VERTEX_DATA_BASE_INDEX>().vertex_data_base_index();
 		}
 
 		u32 shader_program_address() const
 		{
-			return m_shader_program_address;
+			return decode<NV4097_SET_SHADER_PROGRAM>().shader_program_address();
 		}
 
 		u32 transform_program_start() const
 		{
-			return m_transform_program_start;
+			return decode<NV4097_SET_TRANSFORM_PROGRAM_START>().transform_program_start();
 		}
 
 		primitive_type primitive_mode() const
 		{
-			return m_primitive_type;
+			return decode<NV4097_SET_BEGIN_END>().primitive();
 		}
 
 		u32 semaphore_offset_406e() const
 		{
-			return m_semaphore_offset_406e;
+			return decode<NV406E_SEMAPHORE_OFFSET>().semaphore_offset();
 		}
 
 		u32 semaphore_offset_4097() const
 		{
-			return m_semaphore_offset_4097;
+			return decode<NV4097_SET_SEMAPHORE_OFFSET>().semaphore_offset();
 		}
 
 		blit_engine::context_dma context_dma_report() const
 		{
-			return m_context_dma_report;
+			return decode<NV4097_SET_CONTEXT_DMA_REPORT>().context_dma_report();
 		}
 
 		blit_engine::transfer_operation blit_engine_operation() const
 		{
-			return m_blit_engine_operation;
+			return decode<NV3089_SET_OPERATION>().transfer_op();
 		}
 
 		/// TODO: find the purpose vs in/out equivalents
 		u16 blit_engine_clip_x() const
 		{
-			return m_blit_engine_clip_x;
+			return decode<NV3089_CLIP_POINT>().clip_x();
 		}
 
 		u16 blit_engine_clip_y() const
 		{
-			return m_blit_engine_clip_y;
+			return decode<NV3089_CLIP_POINT>().clip_y();
 		}
 
 		u16 blit_engine_clip_width() const
 		{
-			return m_blit_engine_width;
+			return decode<NV3089_CLIP_SIZE>().clip_width();
 		}
 
 		u16 blit_engine_clip_height() const
 		{
-			return m_blit_engine_height;
+			return decode<NV3089_CLIP_SIZE>().clip_height();
 		}
 
 		u16 blit_engine_output_x() const
 		{
-			return m_blit_engine_output_x;
+			return decode<NV3089_IMAGE_OUT_POINT>().x();
 		}
 
 		u16 blit_engine_output_y() const
 		{
-			return m_blit_engine_output_y;
+			return decode<NV3089_IMAGE_OUT_POINT>().y();
 		}
 
 		u16 blit_engine_output_width() const
 		{
-			return m_blit_engine_output_width;
+			return decode<NV3089_IMAGE_OUT_SIZE>().width();
 		}
 
 		u16 blit_engine_output_height() const
 		{
-			return m_blit_engine_output_height;
+			return decode<NV3089_IMAGE_OUT_SIZE>().height();
 		}
 
 		// there is no x/y ?
 		u16 blit_engine_input_width() const
 		{
-			return m_blit_engine_input_width;
+			return decode<NV3089_IMAGE_IN_SIZE>().width();
 		}
 
 		u16 blit_engine_input_height() const
 		{
-			return m_blit_engine_input_height;
+			return decode<NV3089_IMAGE_IN_SIZE>().height();
 		}
 
 		u16 blit_engine_input_pitch() const
 		{
-			return m_blit_engine_input_pitch;
+			return decode<NV3089_IMAGE_IN_FORMAT>().format();
 		}
 
 		blit_engine::transfer_origin blit_engine_input_origin() const
 		{
-			return m_blit_engine_input_origin;
+			return decode<NV3089_IMAGE_IN_FORMAT>().transfer_origin();
 		}
 
 		blit_engine::transfer_interpolator blit_engine_input_inter() const
 		{
-			return m_blit_engine_input_inter;
+			return decode<NV3089_IMAGE_IN_FORMAT>().transfer_interpolator();
 		}
 
 		blit_engine::transfer_source_format blit_engine_src_color_format() const
 		{
-			return m_blit_engine_src_color_format;
+			return decode<NV3089_SET_COLOR_FORMAT>().transfer_source_fmt();
 		}
 
 		// ???
 		f32 blit_engine_in_x() const
 		{
-			return m_blit_engine_in_x / 16.f;
+			return decode<NV3089_IMAGE_IN>().x();
 		}
 
 		// ???
 		f32 blit_engine_in_y() const
 		{
-			return m_blit_engine_in_y / 16.f;
+			return decode<NV3089_IMAGE_IN>().y();
 		}
 
 		u32 blit_engine_input_offset() const
 		{
-			return m_blit_engine_input_offset;
+			return decode<NV3089_IMAGE_IN_OFFSET>().input_offset();
 		}
 
 		u32 blit_engine_input_location() const
 		{
-			return m_blit_engine_input_location;
+			return decode<NV3089_SET_CONTEXT_DMA_IMAGE>().context_dma();
 		}
 
 		blit_engine::context_surface blit_engine_context_surface() const
 		{
-			return m_blit_engine_context_surface;
+			return decode<NV3089_SET_CONTEXT_SURFACE>().ctx_surface();
 		}
 
 		u32 blit_engine_output_location_nv3062() const
 		{
-			return m_blit_engine_output_location_nv3062;
+			return decode<NV3062_SET_CONTEXT_DMA_IMAGE_DESTIN>().output_dma();
 		}
 
 		u32 blit_engine_output_offset_nv3062() const
 		{
-			return m_blit_engine_output_offset_nv3062;
+			return decode<NV3062_SET_OFFSET_DESTIN>().output_offset();
 		}
 
 		blit_engine::transfer_destination_format blit_engine_nv3062_color_format() const
 		{
-			return m_blit_engine_nv3062_color_format;
+			return decode<NV3062_SET_COLOR_FORMAT>().transfer_dest_fmt();
 		}
 
 		u16 blit_engine_output_alignment_nv3062() const
 		{
-			return m_blit_engine_output_alignement_nv3062;
+			return decode<NV3062_SET_PITCH>().alignment();
 		}
 
 		u16 blit_engine_output_pitch_nv3062() const
 		{
-			return m_blit_engine_output_pitch_nv3062;
+			return decode<NV3062_SET_PITCH>().pitch();
 		}
 
 		u32 blit_engine_nv309E_location() const
 		{
-			return m_blit_engine_nv309E_location;
+			return decode<NV309E_SET_CONTEXT_DMA_IMAGE>().context_dma();
 		}
 
 		u32 blit_engine_nv309E_offset() const
 		{
-			return m_blit_engine_nv309E_offset;
+			return decode<NV309E_SET_OFFSET>().offset();
 		}
 
 		blit_engine::transfer_destination_format blit_engine_output_format_nv309E() const
 		{
-			return m_blit_engine_output_format_nv309E;
+			return decode<NV309E_SET_FORMAT>().format();
 		}
 
 		u32 blit_engine_ds_dx() const
 		{
-			return m_blit_engine_ds_dx;
+			return decode<NV3089_DS_DX>().ds_dx();
 		}
 
 		u32 blit_engine_dt_dy() const
 		{
-			return m_blit_engine_dt_dy;
+			return decode<NV3089_DT_DY>().dt_dy();
 		}
 
 		u8 nv309e_sw_width_log2() const
 		{
-			return m_nv309e_sw_width_log2;
+			return decode<NV309E_SET_FORMAT>().sw_width_log2();
 		}
 
 		u8 nv309e_sw_height_log2() const
 		{
-			return m_nv309e_sw_height_log2;
+			return decode<NV309E_SET_FORMAT>().sw_height_log2();
 		}
 
 		u32 nv0039_input_pitch() const
 		{
-			return m_nv0039_input_pitch;
+			return decode<NV0039_PITCH_IN>().input_pitch();
 		}
 
 		u32 nv0039_output_pitch() const
 		{
-			return m_nv0039_output_pitch;
+			return decode<NV0039_PITCH_OUT>().output_pitch();
 		}
 
 		u32 nv0039_line_length() const
 		{
-			return m_nv0039_line_length;
+			return decode<NV0039_LINE_LENGTH_IN>().input_line_length();
 		}
 
 		u32 nv0039_line_count() const
 		{
-			return m_nv0039_line_count;
+			return decode<NV0039_LINE_COUNT>().line_count();
 		}
 
 		u8 nv0039_output_format() const
 		{
-			return m_nv0039_output_format;
+			return decode<NV0039_FORMAT>().output_format();
 		}
 
 		u8 nv0039_input_format() const
 		{
-			return m_nv0039_input_format;
+			return decode<NV0039_FORMAT>().input_format();
 		}
 
 		u32 nv0039_output_offset() const
 		{
-			return m_nv0039_output_offset;
+			return decode<NV0039_OFFSET_OUT>().output_offset();
 		}
 
 		u32 nv0039_output_location()
 		{
-			return m_nv0039_output_location;
+			return decode<NV0039_SET_CONTEXT_DMA_BUFFER_OUT>().output_dma();
 		}
 
 		u32 nv0039_input_offset() const
 		{
-			return m_nv0039_input_offset;
+			return decode<NV0039_OFFSET_IN>().input_offset();
 		}
 
 		u32 nv0039_input_location() const
 		{
-			return m_nv0039_input_location;
+			return decode<NV0039_SET_CONTEXT_DMA_BUFFER_IN>().input_dma();
 		}
 
 		u16 nv308a_x() const
 		{
-			return m_nv308a_x;
+			return decode<NV308A_POINT>().x();
 		}
 
 		u16 nv308a_y() const
 		{
-			return m_nv308a_y;
+			return decode<NV308A_POINT>().y();
+		}
+
+		void commit_4_transform_program_instructions(u32 index)
+		{
+			u32& load = registers[NV4097_SET_TRANSFORM_PROGRAM_LOAD];
+
+			transform_program[load * 4] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4];
+			transform_program[load * 4 + 1] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 1];
+			transform_program[load * 4 + 2] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 2];
+			transform_program[load * 4 + 3] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 3];
+			load++;
+		}
+
+		u32 transform_constant_load()
+		{
+			return decode<NV4097_SET_TRANSFORM_CONSTANT_LOAD>().transform_constant_load();
 		}
 	};
 
 	using rsx_method_t = void(*)(class thread*, u32);
 	extern rsx_state method_registers;
-	extern rsx_method_t methods[0x10000 >> 2];
+	extern std::unordered_map<u32, rsx_method_t> methods;
 }

--- a/rpcs3/Emu/RSX/rsx_vertex_data.h
+++ b/rpcs3/Emu/RSX/rsx_vertex_data.h
@@ -8,17 +8,20 @@ namespace rsx
 
 struct data_array_format_info
 {
+private:
+	u32& m_offset_register;
+public:
 	u16 frequency = 0;
 	u8 stride = 0;
 	u8 size = 0;
 	vertex_base_type type = vertex_base_type::f;
-	u32 m_offset;
 
-	data_array_format_info() {}
+	data_array_format_info(int id, std::array<u32, 0x10000 / 4> &registers)
+		: m_offset_register(registers[NV4097_SET_VERTEX_DATA_ARRAY_OFFSET + id]) {}
 
 	u32 offset() const
 	{
-		return m_offset;
+		return m_offset_register;
 	}
 };
 


### PR DESCRIPTION
This PR reverts the explicit assignment of member in rsx_state. It uses bitfield class instead of explicit << and &.