### PR TITLE
rsx: Copy state in capture frame call

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -29,7 +29,7 @@ cfg::bool_entry g_cfg_rsx_debug_output(cfg::root.video, "Debug output");
 cfg::bool_entry g_cfg_rsx_overlay(cfg::root.video, "Debug overlay");
 
 bool user_asked_for_frame_capture = false;
-frame_capture_data frame_debug;
+rsx::frame_capture_data frame_debug;
 
 namespace vm { using namespace ps3; }
 
@@ -307,11 +307,8 @@ namespace rsx
 
 		int clip_w = rsx::method_registers.surface_clip_width();
 		int clip_h = rsx::method_registers.surface_clip_height();
-		draw_state.width = clip_w;
-		draw_state.height = clip_h;
-		draw_state.color_format = rsx::method_registers.surface_color();
+		draw_state.state = rsx::method_registers;
 		draw_state.color_buffer = std::move(copy_render_targets_to_memory());
-		draw_state.depth_format = rsx::method_registers.surface_depth_fmt();
 		draw_state.depth_stencil = std::move(copy_depth_stencil_buffer_to_memory());
 
 		if (draw_command == rsx::draw_command::indexed)
@@ -321,18 +318,17 @@ namespace rsx
 			{
 				draw_state.vertex_count += range.second;
 			}
-			draw_state.index_type = rsx::method_registers.index_type();
 
-			if (draw_state.index_type == rsx::index_array_type::u16)
+			if (draw_state.state.index_type() == rsx::index_array_type::u16)
 			{
 				draw_state.index.resize(2 * draw_state.vertex_count);
 			}
-			if (draw_state.index_type == rsx::index_array_type::u32)
+			if (draw_state.state.index_type() == rsx::index_array_type::u32)
 			{
 				draw_state.index.resize(4 * draw_state.vertex_count);
 			}
 			gsl::span<gsl::byte> dst = { (gsl::byte*)draw_state.index.data(), gsl::narrow<int>(draw_state.index.size()) };
-			write_index_array_data_to_buffer(dst, draw_state.index_type, draw_mode, first_count_commands);
+			write_index_array_data_to_buffer(dst, draw_state.state.index_type(), draw_mode, first_count_commands);
 		}
 
 		draw_state.programs = get_programs();

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -9,6 +9,8 @@
 #include "RSXTexture.h"
 #include "RSXVertexProgram.h"
 #include "RSXFragmentProgram.h"
+#include "rsx_methods.h"
+#include "rsx_trace.h"
 
 #include "Utilities/Thread.h"
 #include "Utilities/Timer.h"
@@ -16,33 +18,8 @@
 
 extern u64 get_system_time();
 
-struct frame_capture_data
-{
-	struct draw_state
-	{
-		std::string name;
-		std::pair<std::string, std::string> programs;
-		size_t width = 0, height = 0;
-		rsx::surface_color_format color_format;
-		std::array<std::vector<gsl::byte>, 4> color_buffer;
-		rsx::surface_depth_format depth_format;
-		std::array<std::vector<gsl::byte>, 2> depth_stencil;
-		rsx::index_array_type index_type;
-		std::vector<gsl::byte> index;
-		u32 vertex_count;
-	};
-	std::vector<std::pair<u32, u32> > command_queue;
-	std::vector<draw_state> draw_calls;
-
-	void reset()
-	{
-		command_queue.clear();
-		draw_calls.clear();
-	}
-};
-
 extern bool user_asked_for_frame_capture;
-extern frame_capture_data frame_debug;
+extern rsx::frame_capture_data frame_debug;
 
 namespace rsx
 {

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -770,6 +770,22 @@ namespace rsx
 		return{ T(N, std::forward<Args>(arg))... };
 	}
 
+	rsx_state & rsx_state::operator=(const rsx_state & in)
+	{
+		registers = in.registers;
+		transform_program = in.transform_program;
+		transform_constants = in.transform_constants;
+		register_vertex_info = in.register_vertex_info;
+		for (int i = 0; i < 16; i++)
+		{
+			vertex_arrays_info[i].size = in.vertex_arrays_info[i].size;
+			vertex_arrays_info[i].stride = in.vertex_arrays_info[i].stride;
+			vertex_arrays_info[i].frequency = in.vertex_arrays_info[i].frequency;
+			vertex_arrays_info[i].type = in.vertex_arrays_info[i].type;
+		}
+		return *this;
+	}
+
 	rsx_state::rsx_state() :
 		fragment_textures(fill_array<texture>(registers, std::make_index_sequence<16>())),
 		vertex_textures(fill_array<vertex_texture>(registers, std::make_index_sequence<4>())),

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -88,10 +88,11 @@ namespace rsx
 		}
 
 	public:
+		rsx_state &operator=(const rsx_state& in);
+
 		std::array<texture, 16> fragment_textures;
 		std::array<vertex_texture, 4> vertex_textures;
 
-		u32 m_transform_program_pointer;
 
 		std::array<u32, 512 * 4> transform_program;
 		std::unordered_map<u32, color4_base<f32>> transform_constants;

--- a/rpcs3/Emu/RSX/rsx_trace.h
+++ b/rpcs3/Emu/RSX/rsx_trace.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <string>
+#include <array>
+#include <vector>
+#include "Utilities/types.h"
+#include "rsx_methods.h"
+
+namespace rsx
+{
+struct frame_capture_data
+{
+	struct draw_state
+	{
+		std::string name;
+		std::pair<std::string, std::string> programs;
+		rsx::rsx_state state;
+		std::array<std::vector<gsl::byte>, 4> color_buffer;
+		std::array<std::vector<gsl::byte>, 2> depth_stencil;
+		std::vector<gsl::byte> index;
+		u32 vertex_count;
+	};
+	std::vector<std::pair<u32, u32> > command_queue;
+	std::vector<draw_state> draw_calls;
+
+	void reset()
+	{
+		command_queue.clear();
+		draw_calls.clear();
+	}
+};
+}

--- a/rpcs3/Gui/RSXDebugger.cpp
+++ b/rpcs3/Gui/RSXDebugger.cpp
@@ -471,14 +471,14 @@ void RSXDebugger::OnClickDrawCalls(wxMouseEvent& event)
 		p_buffer_colorD,
 	};
 
-	size_t width = draw_call.width;
-	size_t height = draw_call.height;
+	size_t width = draw_call.state.surface_clip_width();
+	size_t height = draw_call.state.surface_clip_height();
 
 	for (size_t i = 0; i < 4; i++)
 	{
 		if (width && height && !draw_call.color_buffer[i].empty())
 		{
-			buffer_img[i] = wxImage(width, height, convert_to_wximage_buffer(draw_call.color_format, draw_call.color_buffer[i], width, height));
+			buffer_img[i] = wxImage(width, height, convert_to_wximage_buffer(draw_call.state.surface_color(), draw_call.color_buffer[i], width, height));
 			wxClientDC dc_canvas(p_buffers[i]);
 
 			if (buffer_img[i].IsOk())
@@ -493,7 +493,7 @@ void RSXDebugger::OnClickDrawCalls(wxMouseEvent& event)
 			gsl::span<const gsl::byte> orig_buffer = draw_call.depth_stencil[0];
 			unsigned char *buffer = (unsigned char *)malloc(width * height * 3);
 
-			if (draw_call.depth_format == rsx::surface_depth_format::z24s8)
+			if (draw_call.state.surface_depth_fmt() == rsx::surface_depth_format::z24s8)
 			{
 				for (u32 row = 0; row < height; row++)
 				{
@@ -564,7 +564,7 @@ void RSXDebugger::OnClickDrawCalls(wxMouseEvent& event)
 
 	m_list_index_buffer->ClearAll();
 	m_list_index_buffer->InsertColumn(0, "Index", 0, 700);
-	if (frame_debug.draw_calls[draw_id].index_type == rsx::index_array_type::u16)
+	if (frame_debug.draw_calls[draw_id].state.index_type() == rsx::index_array_type::u16)
 	{
 		u16 *index_buffer = (u16*)frame_debug.draw_calls[draw_id].index.data();
 		for (u32 i = 0; i < frame_debug.draw_calls[draw_id].vertex_count; ++i)
@@ -572,7 +572,7 @@ void RSXDebugger::OnClickDrawCalls(wxMouseEvent& event)
 			m_list_index_buffer->InsertItem(i, std::to_string(index_buffer[i]));
 		}
 	}
-	if (frame_debug.draw_calls[draw_id].index_type == rsx::index_array_type::u32)
+	if (frame_debug.draw_calls[draw_id].state.index_type() == rsx::index_array_type::u32)
 	{
 		u32 *index_buffer = (u32*)frame_debug.draw_calls[draw_id].index.data();
 		for (u32 i = 0; i < frame_debug.draw_calls[draw_id].vertex_count; ++i)

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -601,6 +601,7 @@
     <ClInclude Include="Emu\Memory\wait_engine.h" />
     <ClInclude Include="Emu\RSX\rsx_cache.h" />
     <ClInclude Include="Emu\RSX\rsx_decode.h" />
+    <ClInclude Include="Emu\RSX\rsx_trace.h" />
     <ClInclude Include="Emu\RSX\rsx_vertex_data.h" />
     <ClInclude Include="Emu\VFS.h" />
     <ClInclude Include="Emu\GameInfo.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1693,5 +1693,8 @@
     <ClInclude Include="Emu\RSX\rsx_decode.h">
       <Filter>Emu\GPU\RSX</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\rsx_trace.h">
+      <Filter>Emu\GPU\RSX</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR copies rsx::methode_register in frame_debug to allow better state inspection in debug tools.