### PR TITLE
Rsx refactor: Implement serialisation of debug data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,6 @@
 [submodule "3rdparty/pugixml"]
 	path = 3rdparty/pugixml
 	url = https://github.com/RPCS3/pugixml
+[submodule "3rdparty/cereal"]
+	path = 3rdparty/cereal
+	url = https://github.com/USCiLab/cereal.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
     fi;
 
 before_script:
- - git submodule update --init rsx_program_decompiler asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng Utilities/yaml-cpp
+ - git submodule update --init rsx_program_decompiler asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng Utilities/yaml-cpp 3rdparty/cereal
  - mkdir build
  - cd build
  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cmake ..; else cmake .. -DLLVM_DIR=/usr/local/opt/llvm36/lib/llvm-3.6/share/llvm/cmake; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ test: off
 
 before_build:
  # until git for win 2.5 release with commit checkout
- - git submodule update --init 3rdparty/ffmpeg 3rdparty/pugixml asmjit 3rdparty/GSL 3rdparty/libpng Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers Utilities/yaml-cpp rsx_program_decompiler
+ - git submodule update --init 3rdparty/ffmpeg 3rdparty/pugixml asmjit 3rdparty/GSL 3rdparty/libpng Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers Utilities/yaml-cpp rsx_program_decompiler 3rdparty/cereal
  - 7z x wxWidgets.7z -aos -oC:\rpcs3\wxWidgets > null
  - 7z x zlib.7z -aos -oC:\rpcs3\ > null
  - 7z x vulkan.7z -aos -oC:\rpcs3\Vulkan > null

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -135,6 +135,7 @@ ${LLVM_INCLUDE_DIRS}
 "${RPCS3_SRC_DIR}/../3rdparty/stblib"
 "${RPCS3_SRC_DIR}/../rsx_program_decompiler/rsx_decompiler"
 "${RPCS3_SRC_DIR}/../rsx_program_decompiler/shader_code"
+"${RPCS3_SRC_DIR}/../3rdparty/cereal/include"
 )
 if(WIN32)
 	include_directories(BEFORE "${RPCS3_SRC_DIR}/../3rdparty/XAudio2_7") # Slimmed down version of minidx9 for XAudio2_7 only

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <map>
+#include <functional>
+#include <memory>
 
 class thread_ctrl;
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -15,6 +15,7 @@
 #include "Utilities/Thread.h"
 #include "Utilities/Timer.h"
 #include "Utilities/geometry.h"
+#include "rsx_trace.h"
 
 extern u64 get_system_time();
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -8,6 +8,9 @@
 #include "rsx_decode.h"
 #include "Emu/Cell/PPUCallback.h"
 
+#include <sstream>
+#include <cereal/archives/binary.hpp>
+
 #include <thread>
 #include <cassert>
 #include <algorithm>
@@ -723,6 +726,13 @@ namespace rsx
 		else if (rsx->capture_current_frame)
 		{
 			rsx->capture_current_frame = false;
+			std::stringstream os;
+			cereal::BinaryOutputArchive archive(os);
+			archive(frame_debug);
+			{
+				fs::file f(fs::get_config_dir() + "capture.txt", fs::rewrite);
+				f.write(os.str());
+			}
 			Emu.Pause();
 		}
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -9,6 +9,9 @@
 #include "rsx_vertex_data.h"
 #include "Utilities/geometry.h"
 
+#include <cereal/types/array.hpp>
+#include <cereal/types/unordered_map.hpp>
+
 namespace rsx
 {
 	//TODO
@@ -122,6 +125,15 @@ namespace rsx
 		void decode(u32 reg, u32 value);
 
 		void reset();
+
+		template<typename Archive>
+		void serialize(Archive & ar)
+		{
+			ar(transform_program,
+//				transform_constants,
+				registers
+				);
+		}
 
 		u16 viewport_width() const
 		{

--- a/rpcs3/Emu/RSX/rsx_trace.h
+++ b/rpcs3/Emu/RSX/rsx_trace.h
@@ -5,6 +5,11 @@
 #include "Utilities/types.h"
 #include "rsx_methods.h"
 
+#include <cereal/types/vector.hpp>
+#include <cereal/types/array.hpp>
+#include <cereal/types/string.hpp>
+#include <cereal/types/utility.hpp>
+
 namespace rsx
 {
 struct frame_capture_data
@@ -18,9 +23,28 @@ struct frame_capture_data
 		std::array<std::vector<gsl::byte>, 2> depth_stencil;
 		std::vector<gsl::byte> index;
 		u32 vertex_count;
+
+		template<typename Archive>
+		void serialize(Archive & ar)
+		{
+			ar(name);
+			ar(programs);
+			ar(state);
+			ar(color_buffer);
+			ar(depth_stencil);
+			ar(index);
+		}
+
 	};
 	std::vector<std::pair<u32, u32> > command_queue;
 	std::vector<draw_state> draw_calls;
+
+	template<typename Archive>
+	void serialize(Archive & ar)
+	{
+		ar(command_queue);
+		ar(draw_calls);
+	}
 
 	void reset()
 	{

--- a/rpcs3_default.props
+++ b/rpcs3_default.props
@@ -3,7 +3,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IncludePath>.\;..\;..\asmjit\src\asmjit;..\Utilities\yaml-cpp\include;..\wxWidgets\src\zlib;..\3rdparty\ffmpeg\WindowsInclude;..\3rdparty\ffmpeg\Windows\x86_64\Include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(UniversalCRT_IncludePath);..\3rdparty\minidx12\Include;..\3rdparty\GSL\include;..\3rdparty\libpng;..\3rdparty\GL;..\3rdparty\stblib;..\3rdparty\OpenAL\include;..\3rdparty\pugixml\src</IncludePath>
+    <IncludePath>.\;..\;..\asmjit\src\asmjit;..\Utilities\yaml-cpp\include;..\wxWidgets\src\zlib;..\3rdparty\ffmpeg\WindowsInclude;..\3rdparty\cereal\include;..\3rdparty\ffmpeg\Windows\x86_64\Include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(UniversalCRT_IncludePath);..\3rdparty\minidx12\Include;..\3rdparty\GSL\include;..\3rdparty\libpng;..\3rdparty\GL;..\3rdparty\stblib;..\3rdparty\OpenAL\include;..\3rdparty\pugixml\src</IncludePath>
     <OutDir>$(SolutionDir)lib\$(Configuration)-$(Platform)\</OutDir>
     <LibraryPath>$(SolutionDir)lib\$(Configuration)-$(Platform)\;$(UniversalCRT_LibraryPath_x64);$(LibraryPath)</LibraryPath>
     <IntDir>$(SolutionDir)tmp\$(ProjectName)-$(Configuration)-$(Platform)\</IntDir>


### PR DESCRIPTION
This PR adds cereal dependency and use it to serialize part of frame debug structure. Frame debug are now dumped on disk when a capture is occuring. While I use json the generated file is not intended to be readable atm.