### PR TITLE
RSX: minor refactoring

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -478,7 +478,7 @@ namespace rsx
 
 				if (auto method = methods[reg])
 				{
-					method(this, value);
+					method(this, reg, value);
 				}
 			}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -476,10 +476,9 @@ namespace rsx
 					frame_debug.command_queue.push_back(std::make_pair(reg, value));
 				}
 
-				const auto& It = methods.find(reg);
-				if (It != methods.end())
+				if (auto method = methods[reg])
 				{
-					It->second(this, value);
+					method(this, value);
 				}
 			}
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -12,8 +12,6 @@
 #include <cereal/archives/binary.hpp>
 
 #include <thread>
-#include <cassert>
-#include <algorithm>
 
 cfg::map_entry<double> g_cfg_rsx_frame_limit(cfg::root.video, "Frame limit",
 {
@@ -29,7 +27,7 @@ namespace rsx
 {
 	rsx_state method_registers;
 	using rsx_method_t = void(*)(class thread*, u32);
-	std::unordered_map<u32, rsx_method_t> methods{};
+	std::array<rsx_method_t, 0x10000 / 4> methods{};
 
 	template<typename Type> struct vertex_data_type_from_element_type;
 	template<> struct vertex_data_type_from_element_type<float> { static const vertex_base_type type = vertex_base_type::f; };
@@ -802,21 +800,21 @@ namespace rsx
 		registers[NV4097_SET_STENCIL_FUNC] = CELL_GCM_ALWAYS;
 		registers[NV4097_SET_STENCIL_FUNC_REF] = 0x00;
 		registers[NV4097_SET_STENCIL_FUNC_MASK] = 0xff;
-/*		registers[NV4097_SET_STENCIL_OP_FAIL] = CELL_GCM_KEEP;
-		registers[NV4097_SET_STENCIL_OP_ZFAIL] = CELL_GCM_KEEP;
-		registers[NV4097_SET_STENCIL_OP_ZPASS] = CELL_GCM_KEEP;*/
+		//registers[NV4097_SET_STENCIL_OP_FAIL] = CELL_GCM_KEEP;
+		//registers[NV4097_SET_STENCIL_OP_ZFAIL] = CELL_GCM_KEEP;
+		//registers[NV4097_SET_STENCIL_OP_ZPASS] = CELL_GCM_KEEP;
 
 		registers[NV4097_SET_BACK_STENCIL_MASK] = 0xff;
 		registers[NV4097_SET_BACK_STENCIL_FUNC] = CELL_GCM_ALWAYS;
 		registers[NV4097_SET_BACK_STENCIL_FUNC_REF] = 0x00;
 		registers[NV4097_SET_BACK_STENCIL_FUNC_MASK] = 0xff;
-/*		registers[NV4097_SET_BACK_STENCIL_OP_FAIL] = CELL_GCM_KEEP;
-		registers[NV4097_SET_BACK_STENCIL_OP_ZFAIL] = CELL_GCM_KEEP;
-		registers[NV4097_SET_BACK_STENCIL_OP_ZPASS] = CELL_GCM_KEEP;*/
+		//registers[NV4097_SET_BACK_STENCIL_OP_FAIL] = CELL_GCM_KEEP;
+		//registers[NV4097_SET_BACK_STENCIL_OP_ZFAIL] = CELL_GCM_KEEP;
+		//registers[NV4097_SET_BACK_STENCIL_OP_ZPASS] = CELL_GCM_KEEP;
 
-//		registers[NV4097_SET_SHADE_MODE] = CELL_GCM_SMOOTH;
+		//registers[NV4097_SET_SHADE_MODE] = CELL_GCM_SMOOTH;
 
-//		registers[NV4097_SET_LOGIC_OP] = CELL_GCM_COPY;
+		//registers[NV4097_SET_LOGIC_OP] = CELL_GCM_COPY;
 
 		(f32&)registers[NV4097_SET_DEPTH_BOUNDS_MIN] = 0.f;
 		(f32&)registers[NV4097_SET_DEPTH_BOUNDS_MAX] = 1.f;
@@ -835,8 +833,8 @@ namespace rsx
 		registers[NV4097_SET_DEPTH_MASK] = CELL_GCM_TRUE;
 		(f32&)registers[NV4097_SET_POLYGON_OFFSET_SCALE_FACTOR] = 0.f;
 		(f32&)registers[NV4097_SET_POLYGON_OFFSET_BIAS] = 0.f;
-//		registers[NV4097_SET_FRONT_POLYGON_MODE] = CELL_GCM_POLYGON_MODE_FILL;
-//		registers[NV4097_SET_BACK_POLYGON_MODE] = CELL_GCM_POLYGON_MODE_FILL;
+		//registers[NV4097_SET_FRONT_POLYGON_MODE] = CELL_GCM_POLYGON_MODE_FILL;
+		//registers[NV4097_SET_BACK_POLYGON_MODE] = CELL_GCM_POLYGON_MODE_FILL;
 		registers[NV4097_SET_CULL_FACE] = CELL_GCM_BACK;
 		registers[NV4097_SET_FRONT_FACE] = CELL_GCM_CCW;
 		registers[NV4097_SET_RESTART_INDEX] = -1;
@@ -848,9 +846,9 @@ namespace rsx
 
 		registers[NV4097_SET_ZSTENCIL_CLEAR_VALUE] = 0xffffffff;
 
-		std::for_each(vertex_arrays_info.begin(), vertex_arrays_info.end(), [](auto &info) { info.size = 0; });
-		std::for_each(fragment_textures.begin(), fragment_textures.end(), [](auto &tex) { tex.init(); });
-		std::for_each(vertex_textures.begin(), vertex_textures.end(), [](auto &tex) { tex.init(); });
+		for (auto& info : vertex_arrays_info) info.size = 0;
+		for (auto& tex : fragment_textures) tex.init();
+		for (auto& tex : vertex_textures) tex.init();
 	}
 
 	void rsx_state::decode(u32 reg, u32 value)

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -29,6 +29,11 @@ namespace rsx
 	
 	std::array<rsx_method_t, 0x10000 / 4> methods{};
 
+	[[noreturn]] void invalid_method(thread*, u32 _reg, u32 arg)
+	{
+		throw fmt::exception("Invalid RSX method 0x%x (arg=0x%x)" HERE, _reg << 2, arg);
+	}
+
 	template<typename Type> struct vertex_data_type_from_element_type;
 	template<> struct vertex_data_type_from_element_type<float> { static const vertex_base_type type = vertex_base_type::f; };
 	template<> struct vertex_data_type_from_element_type<f16> { static const vertex_base_type type = vertex_base_type::sf; };
@@ -66,7 +71,7 @@ namespace rsx
 		void clear(thread* rsx, u32 _reg, u32 arg)
 		{
 			// TODO: every backend must override method table to insert its own handlers
-			if (!rsx->do_method(/* reg << 2 */ NV4097_CLEAR_SURFACE, arg))
+			if (!rsx->do_method(NV4097_CLEAR_SURFACE, arg))
 			{
 				//
 			}
@@ -79,7 +84,7 @@ namespace rsx
 
 		void texture_read_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
-			if (!rsx->do_method(/* reg << 2 */ NV4097_TEXTURE_READ_SEMAPHORE_RELEASE, arg))
+			if (!rsx->do_method(NV4097_TEXTURE_READ_SEMAPHORE_RELEASE, arg))
 			{
 				//
 			}
@@ -90,7 +95,7 @@ namespace rsx
 
 		void back_end_write_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
-			if (!rsx->do_method(/* reg << 2 */ NV4097_BACK_END_WRITE_SEMAPHORE_RELEASE, arg))
+			if (!rsx->do_method(NV4097_BACK_END_WRITE_SEMAPHORE_RELEASE, arg))
 			{
 				//
 			}
@@ -911,12 +916,339 @@ namespace rsx
 		{
 			methods[Id] = Func;
 		}
+
+		template<int Id, int Step, int Count, rsx_method_t Func>
+		static void bind_array()
+		{
+			for (int i = Id; i < Id + Count * Step; i += Step)
+			{
+				methods[i] = Func;
+			}
+		}
 	}
 
 	// TODO: implement this as virtual function: rsx::thread::init_methods() or something
 	static const bool s_methods_init = []() -> bool
 	{
 		using namespace method_detail;
+
+		methods.fill(&invalid_method);
+
+		// NV40_CHANNEL_DMA (NV406E)
+		methods[NV406E_SET_REFERENCE]                     = nullptr;
+		methods[NV406E_SET_CONTEXT_DMA_SEMAPHORE]         = nullptr;
+		methods[NV406E_SEMAPHORE_OFFSET]                  = nullptr;
+		methods[NV406E_SEMAPHORE_ACQUIRE]                 = nullptr;
+		methods[NV406E_SEMAPHORE_RELEASE]                 = nullptr;
+
+		// NV40_CURIE_PRIMITIVE	(NV4097)
+		methods[NV4097_SET_OBJECT]                        = nullptr;
+		methods[NV4097_NO_OPERATION]                      = nullptr;
+		methods[NV4097_NOTIFY]                            = nullptr;
+		methods[NV4097_WAIT_FOR_IDLE]                     = nullptr;
+		methods[NV4097_PM_TRIGGER]                        = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_NOTIFIES]          = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_A]                 = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_B]                 = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_COLOR_B]           = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_STATE]             = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_COLOR_A]           = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_ZETA]              = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_VERTEX_A]          = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_VERTEX_B]          = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_SEMAPHORE]         = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_REPORT]            = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_CLIP_ID]           = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_CULL_DATA]         = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_COLOR_C]           = nullptr;
+		methods[NV4097_SET_CONTEXT_DMA_COLOR_D]           = nullptr;
+		methods[NV4097_SET_SURFACE_CLIP_HORIZONTAL]       = nullptr;
+		methods[NV4097_SET_SURFACE_CLIP_VERTICAL]         = nullptr;
+		methods[NV4097_SET_SURFACE_FORMAT]                = nullptr;
+		methods[NV4097_SET_SURFACE_PITCH_A]               = nullptr;
+		methods[NV4097_SET_SURFACE_COLOR_AOFFSET]         = nullptr;
+		methods[NV4097_SET_SURFACE_ZETA_OFFSET]           = nullptr;
+		methods[NV4097_SET_SURFACE_COLOR_BOFFSET]         = nullptr;
+		methods[NV4097_SET_SURFACE_PITCH_B]               = nullptr;
+		methods[NV4097_SET_SURFACE_COLOR_TARGET]          = nullptr;
+		methods[NV4097_SET_SURFACE_PITCH_Z]               = nullptr;
+		methods[NV4097_INVALIDATE_ZCULL]                  = nullptr;
+		methods[NV4097_SET_CYLINDRICAL_WRAP]              = nullptr;
+		methods[NV4097_SET_CYLINDRICAL_WRAP1]             = nullptr;
+		methods[NV4097_SET_SURFACE_PITCH_C]               = nullptr;
+		methods[NV4097_SET_SURFACE_PITCH_D]               = nullptr;
+		methods[NV4097_SET_SURFACE_COLOR_COFFSET]         = nullptr;
+		methods[NV4097_SET_SURFACE_COLOR_DOFFSET]         = nullptr;
+		methods[NV4097_SET_WINDOW_OFFSET]                 = nullptr;
+		methods[NV4097_SET_WINDOW_CLIP_TYPE]              = nullptr;
+		methods[NV4097_SET_WINDOW_CLIP_HORIZONTAL]        = nullptr;
+		methods[NV4097_SET_WINDOW_CLIP_VERTICAL]          = nullptr;
+		methods[NV4097_SET_DITHER_ENABLE]                 = nullptr;
+		methods[NV4097_SET_ALPHA_TEST_ENABLE]             = nullptr;
+		methods[NV4097_SET_ALPHA_FUNC]                    = nullptr;
+		methods[NV4097_SET_ALPHA_REF]                     = nullptr;
+		methods[NV4097_SET_BLEND_ENABLE]                  = nullptr;
+		methods[NV4097_SET_BLEND_FUNC_SFACTOR]            = nullptr;
+		methods[NV4097_SET_BLEND_FUNC_DFACTOR]            = nullptr;
+		methods[NV4097_SET_BLEND_COLOR]                   = nullptr;
+		methods[NV4097_SET_BLEND_EQUATION]                = nullptr;
+		methods[NV4097_SET_COLOR_MASK]                    = nullptr;
+		methods[NV4097_SET_STENCIL_TEST_ENABLE]           = nullptr;
+		methods[NV4097_SET_STENCIL_MASK]                  = nullptr;
+		methods[NV4097_SET_STENCIL_FUNC]                  = nullptr;
+		methods[NV4097_SET_STENCIL_FUNC_REF]              = nullptr;
+		methods[NV4097_SET_STENCIL_FUNC_MASK]             = nullptr;
+		methods[NV4097_SET_STENCIL_OP_FAIL]               = nullptr;
+		methods[NV4097_SET_STENCIL_OP_ZFAIL]              = nullptr;
+		methods[NV4097_SET_STENCIL_OP_ZPASS]              = nullptr;
+		methods[NV4097_SET_TWO_SIDED_STENCIL_TEST_ENABLE] = nullptr;
+		methods[NV4097_SET_BACK_STENCIL_MASK]             = nullptr;
+		methods[NV4097_SET_BACK_STENCIL_FUNC]             = nullptr;
+		methods[NV4097_SET_BACK_STENCIL_FUNC_REF]         = nullptr;
+		methods[NV4097_SET_BACK_STENCIL_FUNC_MASK]        = nullptr;
+		methods[NV4097_SET_BACK_STENCIL_OP_FAIL]          = nullptr;
+		methods[NV4097_SET_BACK_STENCIL_OP_ZFAIL]         = nullptr;
+		methods[NV4097_SET_BACK_STENCIL_OP_ZPASS]         = nullptr;
+		methods[NV4097_SET_SHADE_MODE]                    = nullptr;
+		methods[NV4097_SET_BLEND_ENABLE_MRT]              = nullptr;
+		methods[NV4097_SET_COLOR_MASK_MRT]                = nullptr;
+		methods[NV4097_SET_LOGIC_OP_ENABLE]               = nullptr;
+		methods[NV4097_SET_LOGIC_OP]                      = nullptr;
+		methods[NV4097_SET_BLEND_COLOR2]                  = nullptr;
+		methods[NV4097_SET_DEPTH_BOUNDS_TEST_ENABLE]      = nullptr;
+		methods[NV4097_SET_DEPTH_BOUNDS_MIN]              = nullptr;
+		methods[NV4097_SET_DEPTH_BOUNDS_MAX]              = nullptr;
+		methods[NV4097_SET_CLIP_MIN]                      = nullptr;
+		methods[NV4097_SET_CLIP_MAX]                      = nullptr;
+		methods[NV4097_SET_CONTROL0]                      = nullptr;
+		methods[NV4097_SET_LINE_WIDTH]                    = nullptr;
+		methods[NV4097_SET_LINE_SMOOTH_ENABLE]            = nullptr;
+		methods[NV4097_SET_ANISO_SPREAD]                  = nullptr;
+		methods[NV4097_SET_SCISSOR_HORIZONTAL]            = nullptr;
+		methods[NV4097_SET_SCISSOR_VERTICAL]              = nullptr;
+		methods[NV4097_SET_FOG_MODE]                      = nullptr;
+		methods[NV4097_SET_FOG_PARAMS]                    = nullptr;
+		methods[NV4097_SET_FOG_PARAMS + 1]                = nullptr;
+		methods[NV4097_SET_SHADER_PROGRAM]                = nullptr;
+		methods[NV4097_SET_VERTEX_TEXTURE_OFFSET]         = nullptr;
+		methods[NV4097_SET_VERTEX_TEXTURE_FORMAT]         = nullptr;
+		methods[NV4097_SET_VERTEX_TEXTURE_ADDRESS]        = nullptr;
+		methods[NV4097_SET_VERTEX_TEXTURE_CONTROL0]       = nullptr;
+		methods[NV4097_SET_VERTEX_TEXTURE_CONTROL3]       = nullptr;
+		methods[NV4097_SET_VERTEX_TEXTURE_FILTER]         = nullptr;
+		methods[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT]     = nullptr;
+		methods[NV4097_SET_VERTEX_TEXTURE_BORDER_COLOR]   = nullptr;
+		methods[NV4097_SET_VIEWPORT_HORIZONTAL]           = nullptr;
+		methods[NV4097_SET_VIEWPORT_VERTICAL]             = nullptr;
+		methods[NV4097_SET_POINT_CENTER_MODE]             = nullptr;
+		methods[NV4097_ZCULL_SYNC]                        = nullptr;
+		methods[NV4097_SET_VIEWPORT_OFFSET]               = nullptr;
+		methods[NV4097_SET_VIEWPORT_OFFSET + 1]           = nullptr;
+		methods[NV4097_SET_VIEWPORT_OFFSET + 2]           = nullptr;
+		methods[NV4097_SET_VIEWPORT_OFFSET + 3]           = nullptr;
+		methods[NV4097_SET_VIEWPORT_SCALE]                = nullptr;
+		methods[NV4097_SET_VIEWPORT_SCALE + 1]            = nullptr;
+		methods[NV4097_SET_VIEWPORT_SCALE + 2]            = nullptr;
+		methods[NV4097_SET_VIEWPORT_SCALE + 3]            = nullptr;
+		methods[NV4097_SET_POLY_OFFSET_POINT_ENABLE]      = nullptr;
+		methods[NV4097_SET_POLY_OFFSET_LINE_ENABLE]       = nullptr;
+		methods[NV4097_SET_POLY_OFFSET_FILL_ENABLE]       = nullptr;
+		methods[NV4097_SET_DEPTH_FUNC]                    = nullptr;
+		methods[NV4097_SET_DEPTH_MASK]                    = nullptr;
+		methods[NV4097_SET_DEPTH_TEST_ENABLE]             = nullptr;
+		methods[NV4097_SET_POLYGON_OFFSET_SCALE_FACTOR]   = nullptr;
+		methods[NV4097_SET_POLYGON_OFFSET_BIAS]           = nullptr;
+		methods[NV4097_SET_VERTEX_DATA_SCALED4S_M]        = nullptr;
+		methods[NV4097_SET_TEXTURE_CONTROL2]              = nullptr;
+		methods[NV4097_SET_TEX_COORD_CONTROL]             = nullptr;
+		methods[NV4097_SET_TRANSFORM_PROGRAM]             = nullptr;
+		methods[NV4097_SET_SPECULAR_ENABLE]               = nullptr;
+		methods[NV4097_SET_TWO_SIDE_LIGHT_EN]             = nullptr;
+		methods[NV4097_CLEAR_ZCULL_SURFACE]               = nullptr;
+		methods[NV4097_SET_PERFORMANCE_PARAMS]            = nullptr;
+		methods[NV4097_SET_FLAT_SHADE_OP]                 = nullptr;
+		methods[NV4097_SET_EDGE_FLAG]                     = nullptr;
+		methods[NV4097_SET_USER_CLIP_PLANE_CONTROL]       = nullptr;
+		methods[NV4097_SET_POLYGON_STIPPLE]               = nullptr;
+		methods[NV4097_SET_POLYGON_STIPPLE_PATTERN]       = nullptr;
+		methods[NV4097_SET_VERTEX_DATA3F_M]               = nullptr;
+		methods[NV4097_SET_VERTEX_DATA_ARRAY_OFFSET]      = nullptr;
+		methods[NV4097_INVALIDATE_VERTEX_CACHE_FILE]      = nullptr;
+		methods[NV4097_INVALIDATE_VERTEX_FILE]            = nullptr;
+		methods[NV4097_PIPE_NOP]                          = nullptr;
+		methods[NV4097_SET_VERTEX_DATA_BASE_OFFSET]       = nullptr;
+		methods[NV4097_SET_VERTEX_DATA_BASE_INDEX]        = nullptr;
+		methods[NV4097_SET_VERTEX_DATA_ARRAY_FORMAT]      = nullptr;
+		methods[NV4097_CLEAR_REPORT_VALUE]                = nullptr;
+		methods[NV4097_SET_ZPASS_PIXEL_COUNT_ENABLE]      = nullptr;
+		methods[NV4097_GET_REPORT]                        = nullptr;
+		methods[NV4097_SET_ZCULL_STATS_ENABLE]            = nullptr;
+		methods[NV4097_SET_BEGIN_END]                     = nullptr;
+		methods[NV4097_ARRAY_ELEMENT16]                   = nullptr;
+		methods[NV4097_ARRAY_ELEMENT32]                   = nullptr;
+		methods[NV4097_DRAW_ARRAYS]                       = nullptr;
+		methods[NV4097_INLINE_ARRAY]                      = nullptr;
+		methods[NV4097_SET_INDEX_ARRAY_ADDRESS]           = nullptr;
+		methods[NV4097_SET_INDEX_ARRAY_DMA]               = nullptr;
+		methods[NV4097_DRAW_INDEX_ARRAY]                  = nullptr;
+		methods[NV4097_SET_FRONT_POLYGON_MODE]            = nullptr;
+		methods[NV4097_SET_BACK_POLYGON_MODE]             = nullptr;
+		methods[NV4097_SET_CULL_FACE]                     = nullptr;
+		methods[NV4097_SET_FRONT_FACE]                    = nullptr;
+		methods[NV4097_SET_POLY_SMOOTH_ENABLE]            = nullptr;
+		methods[NV4097_SET_CULL_FACE_ENABLE]              = nullptr;
+		methods[NV4097_SET_TEXTURE_CONTROL3]              = nullptr;
+		methods[NV4097_SET_VERTEX_DATA2F_M]               = nullptr;
+		methods[NV4097_SET_VERTEX_DATA2S_M]               = nullptr;
+		methods[NV4097_SET_VERTEX_DATA4UB_M]              = nullptr;
+		methods[NV4097_SET_VERTEX_DATA4S_M]               = nullptr;
+		methods[NV4097_SET_TEXTURE_OFFSET]                = nullptr;
+		methods[NV4097_SET_TEXTURE_FORMAT]                = nullptr;
+		methods[NV4097_SET_TEXTURE_ADDRESS]               = nullptr;
+		methods[NV4097_SET_TEXTURE_CONTROL0]              = nullptr;
+		methods[NV4097_SET_TEXTURE_CONTROL1]              = nullptr;
+		methods[NV4097_SET_TEXTURE_FILTER]                = nullptr;
+		methods[NV4097_SET_TEXTURE_IMAGE_RECT]            = nullptr;
+		methods[NV4097_SET_TEXTURE_BORDER_COLOR]          = nullptr;
+		methods[NV4097_SET_VERTEX_DATA4F_M]               = nullptr;
+		methods[NV4097_SET_COLOR_KEY_COLOR]               = nullptr;
+		methods[NV4097_SET_SHADER_CONTROL]                = nullptr;
+		methods[NV4097_SET_INDEXED_CONSTANT_READ_LIMITS]  = nullptr;
+		methods[NV4097_SET_SEMAPHORE_OFFSET]              = nullptr;
+		methods[NV4097_BACK_END_WRITE_SEMAPHORE_RELEASE]  = nullptr;
+		methods[NV4097_TEXTURE_READ_SEMAPHORE_RELEASE]    = nullptr;
+		methods[NV4097_SET_ZMIN_MAX_CONTROL]              = nullptr;
+		methods[NV4097_SET_ANTI_ALIASING_CONTROL]         = nullptr;
+		methods[NV4097_SET_SURFACE_COMPRESSION]           = nullptr;
+		methods[NV4097_SET_ZCULL_EN]                      = nullptr;
+		methods[NV4097_SET_SHADER_WINDOW]                 = nullptr;
+		methods[NV4097_SET_ZSTENCIL_CLEAR_VALUE]          = nullptr;
+		methods[NV4097_SET_COLOR_CLEAR_VALUE]             = nullptr;
+		methods[NV4097_CLEAR_SURFACE]                     = nullptr;
+		methods[NV4097_SET_CLEAR_RECT_HORIZONTAL]         = nullptr;
+		methods[NV4097_SET_CLEAR_RECT_VERTICAL]           = nullptr;
+		methods[NV4097_SET_CLIP_ID_TEST_ENABLE]           = nullptr;
+		methods[NV4097_SET_RESTART_INDEX_ENABLE]          = nullptr;
+		methods[NV4097_SET_RESTART_INDEX]                 = nullptr;
+		methods[NV4097_SET_LINE_STIPPLE]                  = nullptr;
+		methods[NV4097_SET_LINE_STIPPLE_PATTERN]          = nullptr;
+		methods[NV4097_SET_VERTEX_DATA1F_M]               = nullptr;
+		methods[NV4097_SET_TRANSFORM_EXECUTION_MODE]      = nullptr;
+		methods[NV4097_SET_RENDER_ENABLE]                 = nullptr;
+		methods[NV4097_SET_TRANSFORM_PROGRAM_LOAD]        = nullptr;
+		methods[NV4097_SET_TRANSFORM_PROGRAM_START]       = nullptr;
+		methods[NV4097_SET_ZCULL_CONTROL0]                = nullptr;
+		methods[NV4097_SET_ZCULL_CONTROL1]                = nullptr;
+		methods[NV4097_SET_SCULL_CONTROL]                 = nullptr;
+		methods[NV4097_SET_POINT_SIZE]                    = nullptr;
+		methods[NV4097_SET_POINT_PARAMS_ENABLE]           = nullptr;
+		methods[NV4097_SET_POINT_SPRITE_CONTROL]          = nullptr;
+		methods[NV4097_SET_TRANSFORM_TIMEOUT]             = nullptr;
+		methods[NV4097_SET_TRANSFORM_CONSTANT_LOAD]       = nullptr;
+		methods[NV4097_SET_TRANSFORM_CONSTANT]            = nullptr;
+		methods[NV4097_SET_FREQUENCY_DIVIDER_OPERATION]   = nullptr;
+		methods[NV4097_SET_ATTRIB_COLOR]                  = nullptr;
+		methods[NV4097_SET_ATTRIB_TEX_COORD]              = nullptr;
+		methods[NV4097_SET_ATTRIB_TEX_COORD_EX]           = nullptr;
+		methods[NV4097_SET_ATTRIB_UCLIP0]                 = nullptr;
+		methods[NV4097_SET_ATTRIB_UCLIP1]                 = nullptr;
+		methods[NV4097_INVALIDATE_L2]                     = nullptr;
+		methods[NV4097_SET_REDUCE_DST_COLOR]              = nullptr;
+		methods[NV4097_SET_NO_PARANOID_TEXTURE_FETCHES]   = nullptr;
+		methods[NV4097_SET_SHADER_PACKER]                 = nullptr;
+		methods[NV4097_SET_VERTEX_ATTRIB_INPUT_MASK]      = nullptr;
+		methods[NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK]     = nullptr;
+		methods[NV4097_SET_TRANSFORM_BRANCH_BITS]         = nullptr;
+
+		// NV03_MEMORY_TO_MEMORY_FORMAT	(NV0039)
+		methods[NV0039_SET_OBJECT]                        = nullptr;
+		methods[NV0039_SET_CONTEXT_DMA_NOTIFIES]          = nullptr;
+		methods[NV0039_SET_CONTEXT_DMA_BUFFER_IN]         = nullptr;
+		methods[NV0039_SET_CONTEXT_DMA_BUFFER_OUT]        = nullptr;
+		methods[NV0039_OFFSET_IN]                         = nullptr;
+		methods[NV0039_OFFSET_OUT]                        = nullptr;
+		methods[NV0039_PITCH_IN]                          = nullptr;
+		methods[NV0039_PITCH_OUT]                         = nullptr;
+		methods[NV0039_LINE_LENGTH_IN]                    = nullptr;
+		methods[NV0039_LINE_COUNT]                        = nullptr;
+		methods[NV0039_FORMAT]                            = nullptr;
+		methods[NV0039_BUFFER_NOTIFY]                     = nullptr;
+
+		// NV30_CONTEXT_SURFACES_2D	(NV3062)
+		methods[NV3062_SET_OBJECT]                        = nullptr;
+		methods[NV3062_SET_CONTEXT_DMA_NOTIFIES]          = nullptr;
+		methods[NV3062_SET_CONTEXT_DMA_IMAGE_SOURCE]      = nullptr;
+		methods[NV3062_SET_CONTEXT_DMA_IMAGE_DESTIN]      = nullptr;
+		methods[NV3062_SET_COLOR_FORMAT]                  = nullptr;
+		methods[NV3062_SET_PITCH]                         = nullptr;
+		methods[NV3062_SET_OFFSET_SOURCE]                 = nullptr;
+		methods[NV3062_SET_OFFSET_DESTIN]                 = nullptr;
+
+		// NV30_CONTEXT_SURFACE_SWIZZLED (NV309E)
+		methods[NV309E_SET_OBJECT]                        = nullptr;
+		methods[NV309E_SET_CONTEXT_DMA_NOTIFIES]          = nullptr;
+		methods[NV309E_SET_CONTEXT_DMA_IMAGE]             = nullptr;
+		methods[NV309E_SET_FORMAT]                        = nullptr;
+		methods[NV309E_SET_OFFSET]                        = nullptr;
+
+		// NV30_IMAGE_FROM_CPU (NV308A)
+		methods[NV308A_SET_OBJECT]                        = nullptr;
+		methods[NV308A_SET_CONTEXT_DMA_NOTIFIES]          = nullptr;
+		methods[NV308A_SET_CONTEXT_COLOR_KEY]             = nullptr;
+		methods[NV308A_SET_CONTEXT_CLIP_RECTANGLE]        = nullptr;
+		methods[NV308A_SET_CONTEXT_PATTERN]               = nullptr;
+		methods[NV308A_SET_CONTEXT_ROP]                   = nullptr;
+		methods[NV308A_SET_CONTEXT_BETA1]                 = nullptr;
+		methods[NV308A_SET_CONTEXT_BETA4]                 = nullptr;
+		methods[NV308A_SET_CONTEXT_SURFACE]               = nullptr;
+		methods[NV308A_SET_COLOR_CONVERSION]              = nullptr;
+		methods[NV308A_SET_OPERATION]                     = nullptr;
+		methods[NV308A_SET_COLOR_FORMAT]                  = nullptr;
+		methods[NV308A_POINT]                             = nullptr;
+		methods[NV308A_SIZE_OUT]                          = nullptr;
+		methods[NV308A_SIZE_IN]                           = nullptr;
+		methods[NV308A_COLOR]                             = nullptr;
+
+		// NV30_SCALED_IMAGE_FROM_MEMORY (NV3089)
+		methods[NV3089_SET_OBJECT]                        = nullptr;
+		methods[NV3089_SET_CONTEXT_DMA_NOTIFIES]          = nullptr;
+		methods[NV3089_SET_CONTEXT_DMA_IMAGE]             = nullptr;
+		methods[NV3089_SET_CONTEXT_PATTERN]               = nullptr;
+		methods[NV3089_SET_CONTEXT_ROP]                   = nullptr;
+		methods[NV3089_SET_CONTEXT_BETA1]                 = nullptr;
+		methods[NV3089_SET_CONTEXT_BETA4]                 = nullptr;
+		methods[NV3089_SET_CONTEXT_SURFACE]               = nullptr;
+		methods[NV3089_SET_COLOR_CONVERSION]              = nullptr;
+		methods[NV3089_SET_COLOR_FORMAT]                  = nullptr;
+		methods[NV3089_SET_OPERATION]                     = nullptr;
+		methods[NV3089_CLIP_POINT]                        = nullptr;
+		methods[NV3089_CLIP_SIZE]                         = nullptr;
+		methods[NV3089_IMAGE_OUT_POINT]                   = nullptr;
+		methods[NV3089_IMAGE_OUT_SIZE]                    = nullptr;
+		methods[NV3089_DS_DX]                             = nullptr;
+		methods[NV3089_DT_DY]                             = nullptr;
+		methods[NV3089_IMAGE_IN_SIZE]                     = nullptr;
+		methods[NV3089_IMAGE_IN_FORMAT]                   = nullptr;
+		methods[NV3089_IMAGE_IN_OFFSET]                   = nullptr;
+		methods[NV3089_IMAGE_IN]                          = nullptr;
+
+		bind_array<NV4097_SET_ANISO_SPREAD, 1, 16, nullptr>();
+		bind_array<NV4097_SET_VERTEX_TEXTURE_OFFSET, 1, 8 * 4, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA_SCALED4S_M, 1, 32, nullptr>();
+		bind_array<NV4097_SET_TEXTURE_CONTROL2, 1, 16, nullptr>();
+		bind_array<NV4097_SET_TEX_COORD_CONTROL, 1, 10, nullptr>();
+		bind_array<NV4097_SET_TRANSFORM_PROGRAM, 1, 32, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA3F_M, 1, 48, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA_ARRAY_OFFSET, 1, 16, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA_ARRAY_FORMAT, 1, 16, nullptr>();
+		bind_array<NV4097_SET_TEXTURE_CONTROL3, 1, 16, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA2F_M, 1, 32, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA2S_M, 1, 16, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA4UB_M, 1, 16, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA4S_M, 1, 32, nullptr>();
+		bind_array<NV4097_SET_TEXTURE_OFFSET, 1, 8 * 16, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA4F_M, 1, 64, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA1F_M, 1, 16, nullptr>();
 
 		// NV406E
 		bind<NV406E_SET_REFERENCE, nv406e::set_reference>();

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1116,5 +1116,5 @@ namespace rsx
 
 	using rsx_method_t = void(*)(class thread*, u32);
 	extern rsx_state method_registers;
-	extern std::unordered_map<u32, rsx_method_t> methods;
+	extern std::array<rsx_method_t, 0x10000 / 4> methods;
 }

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -14,6 +14,8 @@
 
 namespace rsx
 {
+	using rsx_method_t = void(*)(class thread*, u32 reg, u32 arg);
+
 	//TODO
 	union alignas(4) method_registers_t
 	{
@@ -1114,7 +1116,6 @@ namespace rsx
 		}
 	};
 
-	using rsx_method_t = void(*)(class thread*, u32);
 	extern rsx_state method_registers;
 	extern std::array<rsx_method_t, 0x10000 / 4> methods;
 }


### PR DESCRIPTION
1) `std::unordered_map` is slower than lookup table but this is not the main problem. Changing it back to `std::array` fixed extreme memory consumption and compilation time for clang-3.8. Could be affecting Travis too, but this is speculation. This is only the simplest fix.
2) Fixed comment style, `std::for_each` usage seems unjustified.
3) `rsx_method_t` extended to accept `reg` argument, all methods also modified to use function type `rsx_method_t`. All methods are bound directly to method table.
4) Compilation time of rsx_methods.cpp significantly improved for both MSVC and Clang.