### PR TITLE
rsx-debug: Add a separate qt app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,6 @@
 [submodule "3rdparty/cereal"]
 	path = 3rdparty/cereal
 	url = https://github.com/USCiLab/cereal.git
+[submodule "rsx-debugger"]
+	path = rsx-debugger
+	url = https://github.com/RPCS3/rsx-debugger.git


### PR DESCRIPTION
This commit adds a qml app that display rsx trace content in a more friendly maneer.
It's aimed at replacing the built-in rsx-debugger however at the moment it shows neither saved surface content nor command dump.

In the future I'd like to make this app able to regenerate more and more info from captured data by using the method in RSX/Commons and backends code. For instance instead of saving transform and shader programs code as string, I'd like the app to be able to query backend for translated shader dump when passed native rsx opcodes.
The longterm goal is to capture enough data to be able to "replay" a trace outside of rpcs3 by using as much code from rpcs3 as possible (like FIFO Log/FIFOCI in Dolphin). By using rsx-debugger to display rsx state and another gfx debugger like DXCapture or Nvidia Nsight or GPU Perf Studio 2 to display what is fed to the API it should be easier spot mismatch and understand what happens.