### PR TITLE
IdManager improved

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAdec.cpp
@@ -558,9 +558,9 @@ s32 cellAdecOpen(vm::ptr<CellAdecType> type, vm::ptr<CellAdecResource> res, vm::
 		return CELL_ADEC_ERROR_ARG;
 	}
 
-	auto&& adec = std::make_shared<AudioDecoder>(type->audioCodecType, res->startAddr, res->totalMemSize, cb->cbFunc, cb->cbArg);
+	auto&& adec = idm::make_ptr<ppu_thread, AudioDecoder>(type->audioCodecType, res->startAddr, res->totalMemSize, cb->cbFunc, cb->cbArg);
 
-	*handle = idm::import_existing<ppu_thread>(adec);
+	*handle = adec->id;
 
 	adec->run();
 
@@ -576,9 +576,9 @@ s32 cellAdecOpenEx(vm::ptr<CellAdecType> type, vm::ptr<CellAdecResourceEx> res, 
 		return CELL_ADEC_ERROR_ARG;
 	}
 
-	auto&& adec = std::make_shared<AudioDecoder>(type->audioCodecType, res->startAddr, res->totalMemSize, cb->cbFunc, cb->cbArg);
+	auto&& adec = idm::make_ptr<ppu_thread, AudioDecoder>(type->audioCodecType, res->startAddr, res->totalMemSize, cb->cbFunc, cb->cbArg);
 
-	*handle = idm::import_existing<ppu_thread>(adec);
+	*handle = adec->id;
 
 	adec->run();
 

--- a/rpcs3/Emu/Cell/Modules/cellDmux.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellDmux.cpp
@@ -976,9 +976,9 @@ s32 cellDmuxOpen(vm::cptr<CellDmuxType> type, vm::cptr<CellDmuxResource> res, vm
 	}
 
 	// TODO: check demuxerResource and demuxerCb arguments
-	auto&& dmux = std::make_shared<Demuxer>(res->memAddr, res->memSize, cb->cbMsgFunc, cb->cbArg);
+	auto&& dmux = idm::make_ptr<ppu_thread, Demuxer>(res->memAddr, res->memSize, cb->cbMsgFunc, cb->cbArg);
 
-	*handle = idm::import_existing<ppu_thread>(dmux);
+	*handle = dmux->id;
 
 	dmux->run();
 
@@ -995,9 +995,9 @@ s32 cellDmuxOpenEx(vm::cptr<CellDmuxType> type, vm::cptr<CellDmuxResourceEx> res
 	}
 
 	// TODO: check demuxerResourceEx and demuxerCb arguments
-	auto&& dmux = std::make_shared<Demuxer>(resEx->memAddr, resEx->memSize, cb->cbMsgFunc, cb->cbArg);
+	auto&& dmux = idm::make_ptr<ppu_thread, Demuxer>(resEx->memAddr, resEx->memSize, cb->cbMsgFunc, cb->cbArg);
 
-	*handle = idm::import_existing<ppu_thread>(dmux);
+	*handle = dmux->id;
 
 	dmux->run();
 
@@ -1021,9 +1021,9 @@ s32 cellDmuxOpen2(vm::cptr<CellDmuxType2> type2, vm::cptr<CellDmuxResource2> res
 	}
 
 	// TODO: check demuxerType2, demuxerResource2 and demuxerCb arguments
-	auto&& dmux = std::make_shared<Demuxer>(res2->memAddr, res2->memSize, cb->cbMsgFunc, cb->cbArg);
+	auto&& dmux = idm::make_ptr<ppu_thread, Demuxer>(res2->memAddr, res2->memSize, cb->cbMsgFunc, cb->cbArg);
 
-	*handle = idm::import_existing<ppu_thread>(dmux);
+	*handle = dmux->id;
 
 	dmux->run();
 

--- a/rpcs3/Emu/Cell/Modules/cellFs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellFs.cpp
@@ -737,12 +737,12 @@ struct fs_aio_thread : ppu_thread
 
 struct fs_aio_manager
 {
-	std::shared_ptr<fs_aio_thread> t = std::make_shared<fs_aio_thread>("FS AIO Thread", 500);
+	std::shared_ptr<fs_aio_thread> thread;
 
 	fs_aio_manager()
+		: thread(idm::make_ptr<ppu_thread, fs_aio_thread>("FS AIO Thread", 500))
 	{
-		idm::import_existing<ppu_thread>(t);
-		t->run();
+		thread->run();
 	}
 };
 
@@ -779,13 +779,13 @@ s32 cellFsAioRead(vm::ptr<CellFsAio> aio, vm::ptr<s32> id, fs_aio_cb_t func)
 
 	const auto m = fxm::get_always<fs_aio_manager>();
 
-	m->t->cmd_list
+	m->thread->cmd_list
 	({
 		{ 1, xid },
 		{ aio, func },
 	});
 
-	m->t->lock_notify();
+	m->thread->lock_notify();
 
 	return CELL_OK;
 }
@@ -800,13 +800,13 @@ s32 cellFsAioWrite(vm::ptr<CellFsAio> aio, vm::ptr<s32> id, fs_aio_cb_t func)
 
 	const auto m = fxm::get_always<fs_aio_manager>();
 
-	m->t->cmd_list
+	m->thread->cmd_list
 	({
 		{ 2, xid },
 		{ aio, func },
 	});
 
-	m->t->lock_notify();
+	m->thread->lock_notify();
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -607,9 +607,9 @@ s32 _spurs::create_handler(vm::ptr<CellSpurs> spurs, u32 ppuPriority)
 		}
 	};
 
-	auto&& eht = std::make_shared<handler_thread>(std::string(spurs->prefix, spurs->prefixSize) + "SpursHdlr0", ppuPriority, 0x4000);
+	auto&& eht = idm::make_ptr<ppu_thread, handler_thread>(std::string(spurs->prefix, spurs->prefixSize) + "SpursHdlr0", ppuPriority, 0x4000);
 
-	spurs->ppu0 = idm::import_existing<ppu_thread>(eht);
+	spurs->ppu0 = eht->id;
 
 	eht->gpr[3] = spurs.addr();
 	eht->run();
@@ -804,11 +804,9 @@ s32 _spurs::create_event_helper(ppu_thread& ppu, vm::ptr<CellSpurs> spurs, u32 p
 		}
 	};
 
-	auto&& eht = std::make_shared<event_helper_thread>(std::string(spurs->prefix, spurs->prefixSize) + "SpursHdlr1", ppuPriority, 0x8000);
+	auto&& eht = idm::make_ptr<ppu_thread, event_helper_thread>(std::string(spurs->prefix, spurs->prefixSize) + "SpursHdlr1", ppuPriority, 0x8000);
 
-	const u32 tid = idm::import_existing<ppu_thread>(eht);
-
-	if (tid == 0)
+	if (!eht)
 	{
 		sys_event_port_disconnect(spurs->eventPort);
 		sys_event_port_destroy(spurs->eventPort);
@@ -825,7 +823,7 @@ s32 _spurs::create_event_helper(ppu_thread& ppu, vm::ptr<CellSpurs> spurs, u32 p
 	eht->gpr[3] = spurs.addr();
 	eht->run();
 
-	spurs->ppu1 = tid;
+	spurs->ppu1 = eht->id;
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -399,10 +399,10 @@ s32 cellVdecOpen(vm::cptr<CellVdecType> type, vm::cptr<CellVdecResource> res, vm
 	cellVdec.warning("cellVdecOpen(type=*0x%x, res=*0x%x, cb=*0x%x, handle=*0x%x)", type, res, cb, handle);
 
 	// Create decoder thread
-	auto&& vdec = std::make_shared<vdec_thread>(type->codecType, type->profileLevel, res->memAddr, res->memSize, cb->cbFunc, cb->cbArg);
+	auto&& vdec = idm::make_ptr<ppu_thread, vdec_thread>(type->codecType, type->profileLevel, res->memAddr, res->memSize, cb->cbFunc, cb->cbArg);
 
 	// Hack: store thread id (normally it should be pointer)
-	*handle = idm::import_existing<ppu_thread>(vdec);
+	*handle = vdec->id;
 
 	vdec->run();
 
@@ -414,10 +414,10 @@ s32 cellVdecOpenEx(vm::cptr<CellVdecTypeEx> type, vm::cptr<CellVdecResourceEx> r
 	cellVdec.warning("cellVdecOpenEx(type=*0x%x, res=*0x%x, cb=*0x%x, handle=*0x%x)", type, res, cb, handle);
 
 	// Create decoder thread
-	auto&& vdec = std::make_shared<vdec_thread>(type->codecType, type->profileLevel, res->memAddr, res->memSize, cb->cbFunc, cb->cbArg);
+	auto&& vdec = idm::make_ptr<ppu_thread, vdec_thread>(type->codecType, type->profileLevel, res->memAddr, res->memSize, cb->cbFunc, cb->cbArg);
 
 	// Hack: store thread id (normally it should be pointer)
-	*handle = idm::import_existing<ppu_thread>(vdec);
+	*handle = vdec->id;
 
 	vdec->run();
 
@@ -428,7 +428,7 @@ s32 cellVdecClose(u32 handle)
 {
 	cellVdec.warning("cellVdecClose(handle=0x%x)", handle);
 
-	const auto vdec = std::dynamic_pointer_cast<vdec_thread>(idm::get<ppu_thread>(handle)); // TODO: avoid RTTI
+	const auto vdec = idm::get<ppu_thread, vdec_thread>(handle);
 
 	if (!vdec)
 	{
@@ -446,7 +446,7 @@ s32 cellVdecStartSeq(u32 handle)
 {
 	cellVdec.trace("cellVdecStartSeq(handle=0x%x)", handle);
 
-	const auto vdec = std::dynamic_pointer_cast<vdec_thread>(idm::get<ppu_thread>(handle)); // TODO: avoid RTTI
+	const auto vdec = idm::get<ppu_thread, vdec_thread>(handle);
 
 	if (!vdec)
 	{
@@ -462,7 +462,7 @@ s32 cellVdecEndSeq(u32 handle)
 {
 	cellVdec.warning("cellVdecEndSeq(handle=0x%x)", handle);
 
-	const auto vdec = std::dynamic_pointer_cast<vdec_thread>(idm::get<ppu_thread>(handle)); // TODO: avoid RTTI
+	const auto vdec = idm::get<ppu_thread, vdec_thread>(handle);
 
 	if (!vdec)
 	{
@@ -478,7 +478,7 @@ s32 cellVdecDecodeAu(u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVdecAuInf
 {
 	cellVdec.trace("cellVdecDecodeAu(handle=0x%x, mode=%d, auInfo=*0x%x)", handle, mode, auInfo);
 
-	const auto vdec = std::dynamic_pointer_cast<vdec_thread>(idm::get<ppu_thread>(handle)); // TODO: avoid RTTI
+	const auto vdec = idm::get<ppu_thread, vdec_thread>(handle);
 
 	if (mode > CELL_VDEC_DEC_MODE_PB_SKIP || !vdec)
 	{
@@ -509,7 +509,7 @@ s32 cellVdecGetPicture(u32 handle, vm::cptr<CellVdecPicFormat> format, vm::ptr<u
 {
 	cellVdec.trace("cellVdecGetPicture(handle=0x%x, format=*0x%x, outBuff=*0x%x)", handle, format, outBuff);
 
-	const auto vdec = std::dynamic_pointer_cast<vdec_thread>(idm::get<ppu_thread>(handle)); // TODO: avoid RTTI
+	const auto vdec = idm::get<ppu_thread, vdec_thread>(handle);
 
 	if (!format || !vdec)
 	{
@@ -629,7 +629,7 @@ s32 cellVdecGetPicItem(u32 handle, vm::pptr<CellVdecPicItem> picItem)
 {
 	cellVdec.trace("cellVdecGetPicItem(handle=0x%x, picItem=**0x%x)", handle, picItem);
 
-	const auto vdec = std::dynamic_pointer_cast<vdec_thread>(idm::get<ppu_thread>(handle)); // TODO: avoid RTTI
+	const auto vdec = idm::get<ppu_thread, vdec_thread>(handle);
 
 	if (!vdec)
 	{
@@ -824,7 +824,7 @@ s32 cellVdecSetFrameRate(u32 handle, CellVdecFrameRate frc)
 {
 	cellVdec.trace("cellVdecSetFrameRate(handle=0x%x, frc=0x%x)", handle, frc);
 
-	const auto vdec = std::dynamic_pointer_cast<vdec_thread>(idm::get<ppu_thread>(handle)); // TODO: avoid RTTI
+	const auto vdec = idm::get<ppu_thread, vdec_thread>(handle);
 
 	if (!vdec)
 	{

--- a/rpcs3/Emu/Cell/Modules/libmixer.cpp
+++ b/rpcs3/Emu/Cell/Modules/libmixer.cpp
@@ -489,9 +489,7 @@ s32 cellSurMixerCreate(vm::cptr<CellSurMixerConfig> config)
 
 	libmixer.warning("*** surMixer created (ch1=%d, ch2=%d, ch6=%d, ch8=%d)", config->chStrips1, config->chStrips2, config->chStrips6, config->chStrips8);
 
-	auto&& thread = std::make_shared<surmixer_thread>("Surmixer Thread");
-
-	idm::import_existing<ppu_thread>(thread);
+	auto&& thread = idm::make_ptr<ppu_thread, surmixer_thread>("Surmixer Thread");
 
 	thread->run();
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -80,6 +80,7 @@ std::string ppu_thread::dump() const
 {
 	std::string ret;
 
+	ret += fmt::format("Type: %s\n", typeid(*this).name());
 	ret += fmt::format("State: 0x%08x\n", state.load());
 	ret += fmt::format("Priority: %d\n", prio);
 	

--- a/rpcs3/Emu/IdManager.cpp
+++ b/rpcs3/Emu/IdManager.cpp
@@ -24,7 +24,7 @@ u32 id_manager::typeinfo::add_type()
 	return ::size32(list) - 1;
 }
 
-idm::map_type::pointer idm::allocate_id(u32 tag, u32 min, u32 max)
+id_manager::id_map::pointer idm::allocate_id(u32 tag, u32 min, u32 max)
 {
 	// Check all IDs starting from "next id"
 	for (u32 i = 0; i <= max - min; i++)
@@ -58,7 +58,7 @@ std::shared_ptr<void> idm::deallocate_id(u32 tag, u32 id)
 	return ptr;
 }
 
-idm::map_type::pointer idm::find_id(u32 type, u32 id)
+id_manager::id_map::pointer idm::find_id(u32 type, u32 id)
 {
 	const auto found = g_map[type].find(id);
 

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -260,7 +260,7 @@
     <ClCompile Include="Emu\RSX\Common\VertexProgramDecompiler.cpp" />
     <ClCompile Include="Emu\RSX\GCM.cpp" />
     <ClCompile Include="Emu\RSX\gcm_enums.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="Emu\RSX\Null\NullGSRender.cpp" />
     <ClCompile Include="Emu\RSX\rsx_cache.cpp" />


### PR DESCRIPTION
Objects in IdManager can have slightly different (derived) type. Now it's possible to explicitly check this type with low overhead, just like `dynamic_cast<T*>` would do, but without using C++ RTTI. This is less powerful than true RTTI: only type equality can be checked.