### PR TITLE
Fix gcm_enums.cpp build on Windows

### DIFF
--- a/rpcs3/Emu/RSX/gcm_enums.cpp
+++ b/rpcs3/Emu/RSX/gcm_enums.cpp
@@ -1,3 +1,4 @@
+#include "stdafx.h"
 #include "gcm_enums.h"
 #include "Utilities/StrFmt.h"
 


### PR DESCRIPTION
During some experiments in my Windows 10 Virtual Machine I found a compilation problem in ```gcm_enums.cpp```. Visual Studio told me something about missing ```stdafx.h```, so I added it.

--

![windows 10 pro-2016-08-01-02-43-45](https://cloud.githubusercontent.com/assets/13280758/17280596/1af0b2e2-5793-11e6-9d98-78e5a07945b3.png)
