### PR TITLE
rsx: Move index pointer generation in rsx::thread 

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -30,16 +30,11 @@ size_t get_index_type_size(rsx::index_array_type type);
 /**
  * Write count indexes using (first, first + count) ranges.
  * Returns min/max index found during the process.
- * The function expands index buffer for non native primitive type.
+ * The function expands index buffer for non native primitive type if expands(draw_mode) return true.
  */
-std::tuple<u32, u32> write_index_array_data_to_buffer(gsl::span<gsl::byte> dst, rsx::index_array_type, rsx::primitive_type draw_mode, const std::vector<std::pair<u32, u32> > &first_count_arguments);
-
-
-/**
- * Doesn't expand index
- */
-std::tuple<u32, u32> write_index_array_data_to_buffer_untouched(gsl::span<u32, gsl::dynamic_range> dst, const std::vector<std::pair<u32, u32> > &first_count_arguments);
-std::tuple<u16, u16> write_index_array_data_to_buffer_untouched(gsl::span<u16, gsl::dynamic_range> dst, const std::vector<std::pair<u32, u32> > &first_count_arguments);
+std::tuple<u32, u32> write_index_array_data_to_buffer(gsl::span<gsl::byte> dst, gsl::span<const gsl::byte> src,
+	rsx::index_array_type, rsx::primitive_type draw_mode, bool restart_index_enabled, u32 restart_index, const std::vector<std::pair<u32, u32> > &first_count_arguments,
+	std::function<bool(rsx::primitive_type)> expands);
 
 /**
  * Write index data needed to emulate non indexed non native primitive mode.

--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -380,7 +380,9 @@ std::tuple<bool, size_t, std::vector<D3D12_SHADER_RESOURCE_VIEW_DESC>> D3D12GSRe
 	u32 min_index, max_index;
 	gsl::span<gsl::byte> dst{ reinterpret_cast<gsl::byte*>(mapped_buffer), gsl::narrow<u32>(buffer_size) };
 
-	std::tie(min_index, max_index) = write_index_array_data_to_buffer(dst, indexed_type, draw_mode, first_count_commands);
+	std::tie(min_index, max_index) = write_index_array_data_to_buffer(dst, get_raw_index_array(first_count_commands),
+		indexed_type, draw_mode, rsx::method_registers.restart_index_enabled(), rsx::method_registers.restart_index(), first_count_commands,
+		[](auto prim) { return !is_primitive_native(prim); });
 
 	m_buffer_data.unmap(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 	D3D12_INDEX_BUFFER_VIEW index_buffer_view = {

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -11,6 +11,7 @@
 #include "RSXFragmentProgram.h"
 #include "rsx_methods.h"
 #include "rsx_trace.h"
+#include <Utilities/GSL.h>
 
 #include "Utilities/Thread.h"
 #include "Utilities/Timer.h"
@@ -251,6 +252,8 @@ namespace rsx
 		virtual void flip(int buffer) = 0;
 		virtual u64 timestamp() const;
 		virtual bool on_access_violation(u32 address, bool is_writing) { return false; }
+
+		gsl::span<const gsl::byte> get_raw_index_array(const std::vector<std::pair<u32, u32> >& draw_indexed_clause) const;
 
 	private:
 		std::mutex m_mtx_task;


### PR DESCRIPTION
This PR removes references to rsx::method_registers related to index buffer generation. It also unifies API for expanded and non expanded case so that the same function could be used by backend (which sometimes needs to expand indexes) and by rsx-debugger.

Since it's a rather invasive change I'd like some testing for regression, that's why I'm opening a PR before implementing complete support from rsx-debugger side.