### PR TITLE
rsx: Use a "draw clause" object in rsx_state.

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -442,7 +442,7 @@ void D3D12GSRender::end()
 	get_current_resource_storage().command_list->RSSetScissorRects(1, &get_scissor(rsx::method_registers.scissor_origin_x(), rsx::method_registers.scissor_origin_y(),
 		rsx::method_registers.scissor_width(), rsx::method_registers.scissor_height()));
 
-	get_current_resource_storage().command_list->IASetPrimitiveTopology(get_primitive_topology(draw_mode));
+	get_current_resource_storage().command_list->IASetPrimitiveTopology(get_primitive_topology(rsx::method_registers.current_draw_clause.primitive));
 
 	if (indexed_draw)
 		get_current_resource_storage().command_list->DrawIndexedInstanced((UINT)vertex_count, 1, 0, 0, 0);

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -44,7 +44,7 @@ void D3D12GSRender::load_program()
 	m_fragment_program = get_current_fragment_program();
 
 	D3D12PipelineProperties prop = {};
-	prop.Topology = get_primitive_topology_type(draw_mode);
+	prop.Topology = get_primitive_topology_type(rsx::method_registers.current_draw_clause.primitive);
 
 	static D3D12_BLEND_DESC CD3D12_BLEND_DESC =
 	{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -497,30 +497,30 @@ void GLGSRender::end()
 		m_program->validate();
 	}
 
-	if (draw_command == rsx::draw_command::indexed)
+	if (rsx::method_registers.current_draw_clause.command == rsx::draw_command::indexed)
 	{
 		rsx::index_array_type indexed_type = rsx::method_registers.index_type();
 
 		if (indexed_type == rsx::index_array_type::u32)
 		{
-			__glcheck glDrawElements(gl::draw_mode(draw_mode), vertex_draw_count, GL_UNSIGNED_INT, (GLvoid *)(std::ptrdiff_t)offset_in_index_buffer);
+			__glcheck glDrawElements(gl::draw_mode(rsx::method_registers.current_draw_clause.primitive), vertex_draw_count, GL_UNSIGNED_INT, (GLvoid *)(std::ptrdiff_t)offset_in_index_buffer);
 		}
 		else if (indexed_type == rsx::index_array_type::u16)
 		{
-			__glcheck glDrawElements(gl::draw_mode(draw_mode), vertex_draw_count, GL_UNSIGNED_SHORT, (GLvoid *)(std::ptrdiff_t)offset_in_index_buffer);
+			__glcheck glDrawElements(gl::draw_mode(rsx::method_registers.current_draw_clause.primitive), vertex_draw_count, GL_UNSIGNED_SHORT, (GLvoid *)(std::ptrdiff_t)offset_in_index_buffer);
 		}
 		else
 		{
 			throw std::logic_error("bad index array type");
 		}
 	}
-	else if (!gl::is_primitive_native(draw_mode))
+	else if (!gl::is_primitive_native(rsx::method_registers.current_draw_clause.primitive))
 	{
-		__glcheck glDrawElements(gl::draw_mode(draw_mode), vertex_draw_count, GL_UNSIGNED_SHORT, (GLvoid *)(std::ptrdiff_t)offset_in_index_buffer);
+		__glcheck glDrawElements(gl::draw_mode(rsx::method_registers.current_draw_clause.primitive), vertex_draw_count, GL_UNSIGNED_SHORT, (GLvoid *)(std::ptrdiff_t)offset_in_index_buffer);
 	}
 	else
 	{
-		draw_fbo.draw_arrays(draw_mode, vertex_draw_count);
+		draw_fbo.draw_arrays(rsx::method_registers.current_draw_clause.primitive, vertex_draw_count);
 	}
 
 	std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -143,14 +143,6 @@ namespace rsx
 		}
 	};
 
-	enum class draw_command
-	{
-		none,
-		array,
-		inlined_array,
-		indexed,
-	};
-
 	class thread : public named_thread
 	{
 		std::shared_ptr<thread_ctrl> m_vblank_thread;
@@ -170,11 +162,6 @@ namespace rsx
 		GcmZcullInfo zculls[limits::zculls_count];
 
 		u32 vertex_draw_count = 0;
-
-		/**
-		* Stores the first and count argument from draw/draw indexed parameters between begin/end clauses.
-		*/
-		std::vector<std::pair<u32, u32> > first_count_commands;
 
 		// Constant stored for whole frame
 		std::unordered_map<u32, color4f> local_transform_constants;
@@ -198,8 +185,6 @@ namespace rsx
 		u32 gcm_current_buffer;
 		u32 ctxt_addr;
 		u32 label_addr;
-		rsx::draw_command draw_command;
-		primitive_type draw_mode;
 
 		u32 local_mem_addr, main_mem_addr;
 		bool strict_ordering[0x1000];

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -854,7 +854,7 @@ bool VKGSRender::load_program()
 
 	properties.ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
 	bool unused;
-	properties.ia.topology = vk::get_appropriate_topology(draw_mode, unused);
+	properties.ia.topology = vk::get_appropriate_topology(rsx::method_registers.current_draw_clause.primitive, unused);
 
 	if (rsx::method_registers.restart_index_enabled())
 	{


### PR DESCRIPTION
This PR moves draw_command and first_command_count in a separate structure.
It's a rather simple change so there shouldn't be regression.