### PR TITLE
XAudio : reorder versioning 2.9>2.7>2.8

### DIFF
--- a/rpcs3/Emu/Audio/XAudio2/XAudio2Thread.cpp
+++ b/rpcs3/Emu/Audio/XAudio2/XAudio2Thread.cpp
@@ -13,21 +13,6 @@ XAudio2Thread::XAudio2Thread()
 		LOG_ERROR(GENERAL, "XAudio: failed to increase thread priority");
 	}
 
-	if (auto lib2_7 = LoadLibraryExW(L"XAudio2_7.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32))
-	{
-		xa27_init(lib2_7);
-
-		m_funcs.destroy = &xa27_destroy;
-		m_funcs.play    = &xa27_play;
-		m_funcs.flush   = &xa27_flush;
-		m_funcs.stop    = &xa27_stop;
-		m_funcs.open    = &xa27_open;
-		m_funcs.add     = &xa27_add;
-
-		LOG_SUCCESS(GENERAL, "XAudio 2.7 initialized");
-		return;
-	}
-	
 	if (auto lib2_9 = LoadLibraryExW(L"XAudio2_9.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32))
 	{
 		// xa28* implementation is fully compatible with library 2.9
@@ -44,6 +29,21 @@ XAudio2Thread::XAudio2Thread()
 		return;
 	}
 
+	if (auto lib2_7 = LoadLibraryExW(L"XAudio2_7.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32))
+	{
+		xa27_init(lib2_7);
+
+		m_funcs.destroy = &xa27_destroy;
+		m_funcs.play    = &xa27_play;
+		m_funcs.flush   = &xa27_flush;
+		m_funcs.stop    = &xa27_stop;
+		m_funcs.open    = &xa27_open;
+		m_funcs.add     = &xa27_add;
+
+		LOG_SUCCESS(GENERAL, "XAudio 2.7 initialized");
+		return;
+	}
+	
 	if (auto lib2_8 = LoadLibraryExW(L"XAudio2_8.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32))
 	{
 		xa28_init(lib2_8);


### PR DESCRIPTION
Having distributed for wider testing in other forums and confirmed it did resolve the audio device switching issue on windows 10 platform specifially . 

Windows 7/8/8.1 should remain unchanged that load up 2.7 as usual .