### PR TITLE
Vulkan: set ColorBlendState info (used by logicOp)

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -923,7 +923,7 @@ bool VKGSRender::load_program()
 		}
 	}
 
-	properties.cs.attachmentCount = 1;
+	properties.cs.attachmentCount = m_draw_buffers_count;
 	properties.cs.pAttachments = properties.att_state;
 	
 	if (rsx::method_registers.logic_op_enabled())

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -923,6 +923,9 @@ bool VKGSRender::load_program()
 		}
 	}
 
+	properties.cs.attachmentCount = 1;
+	properties.cs.pAttachments = properties.att_state;
+	
 	if (rsx::method_registers.logic_op_enabled())
 	{
 		properties.cs.logicOpEnable = true;

--- a/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
@@ -57,6 +57,7 @@ namespace std
 			seed ^= hash_struct(pipelineProperties.ia);
 			seed ^= hash_struct(pipelineProperties.ds);
 			seed ^= hash_struct(pipelineProperties.rs);
+			seed ^= hash_struct(pipelineProperties.cs);
 			seed ^= hash_struct(pipelineProperties.att_state[0]);
 			return hash<size_t>()(seed);
 		}
@@ -122,18 +123,13 @@ struct VKTraits
 		ms.pSampleMask = NULL;
 		ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-		VkPipelineColorBlendStateCreateInfo cb = {};
-		cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-		cb.attachmentCount = 1;
-		cb.pAttachments = pipelineProperties.att_state;
-
 		VkPipeline pipeline;
 		VkGraphicsPipelineCreateInfo info = {};
 		info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
 		info.pVertexInputState = &vi;
 		info.pInputAssemblyState = &pipelineProperties.ia;
 		info.pRasterizationState = &pipelineProperties.rs;
-		info.pColorBlendState = &cb;
+		info.pColorBlendState = &pipelineProperties.cs;
 		info.pMultisampleState = &ms;
 		info.pViewportState = &vp;
 		info.pDepthStencilState = &pipelineProperties.ds;


### PR DESCRIPTION
We have colorblendstate used in LogicOp

	if (rsx::method_registers.logic_op_enabled())
	{
		properties.cs.logicOpEnable = true;
		properties.cs.logicOp = vk::get_logic_op(rsx::method_registers.logic_operation());
	}