### PR TITLE
D3D12: fix invalid format (0x1)

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
@@ -302,6 +302,7 @@ DXGI_FORMAT get_color_surface_format(rsx::surface_color_format format)
 {
 	switch (format)
 	{
+	case rsx::surface_color_format::x1r5g5b5_o1r5g5b5: return DXGI_FORMAT_B5G5R5A1_UNORM;
 	case rsx::surface_color_format::r5g6b5: return DXGI_FORMAT_B5G6R5_UNORM;
 	case rsx::surface_color_format::x8b8g8r8_o8b8g8r8:
 	case rsx::surface_color_format::x8b8g8r8_z8b8g8r8:
@@ -309,7 +310,8 @@ DXGI_FORMAT get_color_surface_format(rsx::surface_color_format format)
 	case rsx::surface_color_format::a8b8g8r8: return DXGI_FORMAT_B8G8R8A8_UNORM;
 	case rsx::surface_color_format::x8r8g8b8_o8r8g8b8:
 	case rsx::surface_color_format::x8r8g8b8_z8r8g8b8:
-	case rsx::surface_color_format::a8r8g8b8: return DXGI_FORMAT_R8G8B8A8_UNORM;
+	case rsx::surface_color_format::a8r8g8b8: 
+		return DXGI_FORMAT_R8G8B8A8_UNORM;
 	case rsx::surface_color_format::b8: return DXGI_FORMAT_R8_UNORM;
 	case rsx::surface_color_format::g8b8: return DXGI_FORMAT_R8G8_UNORM;
 	case rsx::surface_color_format::w16z16y16x16: return DXGI_FORMAT_R16G16B16A16_FLOAT;


### PR DESCRIPTION
F {rsx::thread} class std::runtime_error thrown: Invalid format (0x1)
(in file Emu\RSX\D3D12\D3D12Formats.cpp:320)
