### PR TITLE
gl: Use driver error reporting, not crash report with release build

### DIFF
--- a/rpcs3/Emu/RSX/GL/gl_helpers.h
+++ b/rpcs3/Emu/RSX/GL/gl_helpers.h
@@ -14,7 +14,7 @@
 
 namespace gl
 {
-#if 1//def _DEBUG
+#ifdef _DEBUG
 	struct __glcheck_impl_t
 	{
 		const char* file;


### PR DESCRIPTION
For release builds, debug error reporting by the driver makes more sense since developers don't always have access to the games that trigger these errors. Driver report gives more information about why an error is being raised than a line number and file.