### PR TITLE
gl/vk: Mirror wpos based on window origin

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -276,7 +276,7 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 	{
 		static const std::string reg_table[] =
 		{
-			"gl_FragCoord",
+			"wpos",
 			"diff_color", "spec_color",
 			"fogc",
 			"tc0", "tc1", "tc2", "tc3", "tc4", "tc5", "tc6", "tc7", "tc8", "tc9",

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -228,9 +228,9 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 		}
 	}
 	// A bit unclean, but works.
-	OS << "	" << "float4 gl_FragCoord = In.Position;" << std::endl;
+	OS << "	" << "float4 wpos = In.Position;" << std::endl;
 	if (m_prog.origin_mode == rsx::window_origin::bottom)
-		OS << "	gl_FragCoord.y = (" << std::to_string(m_prog.height) << " - gl_FragCoord.y);\n";
+		OS << "	wpos.y = (" << std::to_string(m_prog.height) << " - wpos.y);\n";
 	OS << "	float4 ssa = is_front_face ? float4(1., 1., 1., 1.) : float4(-1., -1., -1., -1.);\n";
 
 	// Declare output

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -250,6 +250,12 @@ void GLFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 	}
 
 	OS << "	vec4 ssa = gl_FrontFacing ? vec4(1.) : vec4(-1.);\n";
+	OS << "	vec4 wpos = gl_FragCoord;\n";
+
+	//Flip wpos in Y
+	//We could optionally export wpos from the VS, but this is so much easier
+	if (m_prog.origin_mode == rsx::window_origin::bottom)
+		OS << "	wpos.y = " << std::to_string(m_prog.height) << " - wpos.y;\n";
 
 	for (const ParamType& PT : m_parr.params[PF_PARAM_UNIFORM])
 	{

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -268,6 +268,12 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 	}
 
 	OS << "	vec4 ssa = gl_FrontFacing ? vec4(1.) : vec4(-1.);\n";
+	OS << "	vec4 wpos = gl_FragCoord;\n";
+
+	//Flip wpos in Y
+	//We could optionally export wpos from the VS, but this is so much easier
+	if (m_prog.origin_mode == rsx::window_origin::bottom)
+		OS << "	wpos.y = " << std::to_string(m_prog.height) << " - wpos.y;\n";
 
 	bool two_sided_enabled = m_prog.front_back_color_enabled && (m_prog.back_color_diffuse_output || m_prog.back_color_specular_output);
 


### PR DESCRIPTION
There are numerous games with this issue, most notably naruto titles and afterburner climax. Usually characterized by an upside-down "mirror" effect showing up usually during a post-process pass.

https://github.com/RPCS3/rpcs3/issues/2149
https://github.com/RPCS3/rpcs3/issues/1631