### PR TITLE
gl/vk/dx12: Fix depth reconstruction bug; Fix sampler parameters

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -51,6 +51,9 @@ void D3D12GSRender::load_program()
 			const u32 texaddr = rsx::get_address(tex.offset(), tex.location());
 			if (m_rtts.get_texture_from_depth_stencil_if_applicable(texaddr))
 			{
+				if (m_rtts.get_texture_from_render_target_if_applicable(texaddr))
+					continue;
+
 				u32 format = tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 				if (format == CELL_GCM_TEXTURE_A8R8G8B8 || format == CELL_GCM_TEXTURE_D8R8G8B8)
 				{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -661,6 +661,10 @@ bool GLGSRender::load_program()
 			const u32 texaddr = rsx::get_address(tex.offset(), tex.location());
 			if (m_rtts.get_texture_from_depth_stencil_if_applicable(texaddr))
 			{
+				//Ignore this rtt since we have an aloasing color texture that will be used
+				if (m_rtts.get_texture_from_render_target_if_applicable(texaddr))
+					continue;
+
 				u32 format = tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 				if (format == CELL_GCM_TEXTURE_A8R8G8B8 || format == CELL_GCM_TEXTURE_D8R8G8B8)
 				{


### PR DESCRIPTION
https://github.com/RPCS3/rpcs3/issues/2178
https://github.com/RPCS3/rpcs3/issues/2093

- Fixes broken sampling redirection when resampling a DSV as RGBA8.
- Disables all mipmapping parameters when a texture has 1 only mipmap level for GL and Vulkan