### PR TITLE
Bind SET_POLYGON_STIPPLE_PATTERN

### DIFF
--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1228,6 +1228,7 @@ namespace rsx
 		bind_array<NV4097_SET_TEXTURE_CONTROL2, 1, 16, nullptr>();
 		bind_array<NV4097_SET_TEX_COORD_CONTROL, 1, 10, nullptr>();
 		bind_array<NV4097_SET_TRANSFORM_PROGRAM, 1, 32, nullptr>();
+		bind_array<NV4097_SET_POLYGON_STIPPLE_PATTERN, 1, 32, nullptr>();
 		bind_array<NV4097_SET_VERTEX_DATA3F_M, 1, 48, nullptr>();
 		bind_array<NV4097_SET_VERTEX_DATA_ARRAY_OFFSET, 1, 16, nullptr>();
 		bind_array<NV4097_SET_VERTEX_DATA_ARRAY_FORMAT, 1, 16, nullptr>();


### PR DESCRIPTION
Causes MGS4 to boot a little bit further.
MGS4 now actually does some stuff, mostly filesystem related, and then softlocks(progress! :P). No display output on any backend unfortunately. Doesn't seem to respond to inputs either.
The information was gotten from the MESA implementation of nv30/40.
Sorry for the small commit, I am still learning the architecture of both the PS3 and the emulator.
Am I correct in using bind_array here instead of bind_range? Can anyone explain the difference?