### PR TITLE
Update LLVM on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ before_install:
       sudo pip install cpp-coveralls requests[security];
     else
       brew update; brew update;
-      brew install glew wxwidgets llvm36;
+      brew install glew wxwidgets llvm38;
     fi;
 
 before_script:
  - git submodule update --init rsx_program_decompiler asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng Utilities/yaml-cpp 3rdparty/cereal
  - mkdir build
  - cd build
- - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cmake ..; else cmake .. -DLLVM_DIR=/usr/local/opt/llvm36/lib/llvm-3.6/share/llvm/cmake; fi
+ - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cmake ..; else cmake .. -DLLVM_DIR=/usr/local/opt/llvm38/lib/llvm-3.8/share/llvm/cmake; fi
 
 script:
 # Add a command to show all the variables. May be useful for debugging Travis.
@@ -62,15 +62,15 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-#    - llvm-toolchain-trusty-3.6 temporarily disabled
+#    - llvm-toolchain-trusty-3.8 temporarily disabled
     packages:
     - cmake
     - libopenal-dev
     - freeglut3-dev
     - libglew-dev
     - libc6-dev
-#    - llvm-3.6
-#    - llvm-3.6-dev
+#    - llvm-3.8
+#    - llvm-3.8-dev
     - libedit-dev
     - g++-5
     - gcc-5


### PR DESCRIPTION
Should fix the issue with Travis (No available formula with the name "llvm36") on OSX.
We're using 3.8 so there's no reason for Travis to use 3.6.

If this doesn't work we can just remove LLVM from the OSX part and it will compile without LLVM like it did before.