### PR TITLE
Decrypt ELF objects (SELF, SPRX, etc.) on the fly

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -989,7 +989,7 @@ fs::file::file(const void* ptr, std::size_t size, bs_t<open_mode> mode)
 	m_file = std::make_unique<memory_stream>(ptr, size, mode);
 }
 
-fs::file::file(std::vector<u8> vec, bs_t<open_mode> mode)
+fs::file::file(const std::vector<u8> &vec, bs_t<open_mode> mode)
 {
 	class memory_stream : public file_base
 	{
@@ -999,7 +999,7 @@ fs::file::file(std::vector<u8> vec, bs_t<open_mode> mode)
 		bs_t<open_mode> m_mode;
 
 	public:
-		memory_stream(std::vector<u8> vec, bs_t<open_mode> mode)
+		memory_stream(const std::vector<u8> &vec, bs_t<open_mode> mode)
 			: m_vector(vec),
 			  m_mode(mode)
 		{

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -84,6 +84,7 @@ static fs::error to_error(DWORD e)
 	{
 	case ERROR_FILE_NOT_FOUND: return fs::error::noent;
 	case ERROR_PATH_NOT_FOUND: return fs::error::noent;
+	case ERROR_ACCESS_DENIED: return fs::error::inval;
 	case ERROR_ALREADY_EXISTS: return fs::error::exist;
 	case ERROR_FILE_EXISTS: return fs::error::exist;
 	case ERROR_NEGATIVE_SEEK: return fs::error::inval;

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -161,11 +161,8 @@ namespace fs
 		// Open memory for read || write, dont take ownership of memory
 		explicit file(const void* ptr, std::size_t size, bs_t<open_mode> mode = ::fs::read);
 
-		// Open memory for read || write, take ownership of memory
-		explicit file(std::unique_ptr<u8[]> ptr, std::size_t size, bs_t<open_mode> mode = ::fs::read);
-
-		// Open memory for read || write, allocate own memory of 'size' size
-		explicit file(std::size_t size, bs_t<open_mode> mode = ::fs::read + ::fs::write) : file(std::unique_ptr<u8[]>(nullptr), size, mode) {};
+		// Open memory for read || write, use vector as backing memory
+		explicit file(std::vector<u8> vec, bs_t<open_mode> mode = ::fs::read + ::fs::write);
 
 		// Open file with specified args (forward to constructor)
 		template <typename... Args>

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -162,7 +162,7 @@ namespace fs
 		explicit file(const void* ptr, std::size_t size, bs_t<open_mode> mode = ::fs::read);
 
 		// Open memory for read || write, use vector as backing memory
-		explicit file(std::vector<u8> vec, bs_t<open_mode> mode = ::fs::read + ::fs::write);
+		explicit file(const std::vector<u8> &vec, bs_t<open_mode> mode = ::fs::read + ::fs::write);
 
 		// Open file with specified args (forward to constructor)
 		template <typename... Args>

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -158,8 +158,14 @@ namespace fs
 		// Open file with specified mode
 		explicit file(const std::string& path, bs_t<open_mode> mode = ::fs::read);		
 
-		// Open memory for read
-		explicit file(const void* ptr, std::size_t size);
+		// Open memory for read || write, dont take ownership of memory
+		explicit file(const void* ptr, std::size_t size, bs_t<open_mode> mode = ::fs::read);
+
+		// Open memory for read || write, take ownership of memory
+		explicit file(std::unique_ptr<u8[]> ptr, std::size_t size, bs_t<open_mode> mode = ::fs::read);
+
+		// Open memory for read || write, allocate own memory of 'size' size
+		explicit file(std::size_t size, bs_t<open_mode> mode = ::fs::read + ::fs::write) : file(std::unique_ptr<u8[]>(nullptr), size, mode) {};
 
 		// Open file with specified args (forward to constructor)
 		template <typename... Args>

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -1331,9 +1331,16 @@ bool CheckDebugSelf(const fs::file& self, fs::file& elf)
 }
 
 // Decrypt self and write it to elf.
-// If passed nullptr for elf, it will make elf point to file in memory.
-bool DecryptSelf(fs::file& elf, const fs::file& self)
+// If passed empty / invalid file for elf, it will make elf point to file in memory.
+bool DecryptSelf(fs::file& elf, fs::file& self)
 {
+	if (!IsSelf(self))
+	{
+		LOG_NOTICE(LOADER, "No decryption necessary or not a valid SELF.");
+		elf.reset(self.release());
+		return (bool)elf;
+	}
+
 	LOG_NOTICE(LOADER, "Decrypting SELF");
 
 	// Check for a debug SELF first.

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -391,4 +391,4 @@ public:
 extern bool IsSelf(const fs::file& elf);
 extern bool IsSelfElf32(const fs::file& elf);
 extern bool CheckDebugSelf(const fs::file& self, const fs::file& elf);
-extern bool DecryptSelf(fs::file& elf, const fs::file& self);
+extern bool DecryptSelf(fs::file& elf, fs::file& self);

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -379,7 +379,7 @@ class SELFDecrypter
 
 public:
 	SELFDecrypter(const fs::file& s);
-	bool MakeElf(fs::file*& elf, bool isElf32);
+	bool MakeElf(fs::file& elf, bool isElf32);
 	bool LoadHeaders(bool isElf32);
 	void ShowHeaders(bool isElf32);
 	bool LoadMetadata();
@@ -391,4 +391,4 @@ public:
 extern bool IsSelf(const fs::file& elf);
 extern bool IsSelfElf32(const fs::file& elf);
 extern bool CheckDebugSelf(const fs::file& self, const fs::file& elf);
-extern bool DecryptSelf(fs::file*& elf, const fs::file& self);
+extern bool DecryptSelf(fs::file& elf, const fs::file& self);

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -379,7 +379,7 @@ class SELFDecrypter
 
 public:
 	SELFDecrypter(const fs::file& s);
-	bool MakeElf(const std::string& elf, bool isElf32);
+	bool MakeElf(fs::file*& elf, bool isElf32);
 	bool LoadHeaders(bool isElf32);
 	void ShowHeaders(bool isElf32);
 	bool LoadMetadata();
@@ -388,7 +388,7 @@ public:
 	bool GetKeyFromRap(u8 *content_id, u8 *npdrm_key);
 };
 
-extern bool IsSelf(const std::string& path);
-extern bool IsSelfElf32(const std::string& path);
-extern bool CheckDebugSelf(const std::string& self, const std::string& elf);
-extern bool DecryptSelf(const std::string& elf, const std::string& self);
+extern bool IsSelf(const fs::file& elf);
+extern bool IsSelfElf32(const fs::file& elf);
+extern bool CheckDebugSelf(const fs::file& self, const fs::file& elf);
+extern bool DecryptSelf(fs::file*& elf, const fs::file& self);

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1122,7 +1122,8 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	if (g_cfg_load_liblv2)
 	{
 		fs::file lvl2_file;
-		DecryptSelf(lvl2_file, fs::file(lle_dir + "/liblv2.sprx"));
+		fs::file temp = fs::file(lle_dir + "/liblv2.sprx");
+		DecryptSelf(lvl2_file, temp);
 
 		const ppu_prx_object obj = lvl2_file;
 
@@ -1140,7 +1141,8 @@ void ppu_load_exec(const ppu_exec_object& elf)
 		for (const auto& name : g_cfg_load_libs.get_set())
 		{
 			fs::file ppu_file;
-			DecryptSelf(ppu_file, fs::file(lle_dir + '/' + name));
+			fs::file temp = fs::file(lle_dir + '/' + name);
+			DecryptSelf(ppu_file, temp);
 
 			const ppu_prx_object obj = ppu_file;
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -2,6 +2,7 @@
 #include "Utilities/Config.h"
 #include "Utilities/AutoPause.h"
 #include "Crypto/sha1.h"
+#include "Crypto/unself.h"
 #include "Loader/ELF.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -1120,7 +1121,10 @@ void ppu_load_exec(const ppu_exec_object& elf)
 
 	if (g_cfg_load_liblv2)
 	{
-		const ppu_prx_object obj = fs::file(lle_dir + "/liblv2.sprx");
+		fs::file lvl2_file;
+		DecryptSelf(lvl2_file, fs::file(lle_dir + "/liblv2.sprx"));
+
+		const ppu_prx_object obj = lvl2_file;
 
 		if (obj == elf_error::ok)
 		{
@@ -1135,7 +1139,10 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	{
 		for (const auto& name : g_cfg_load_libs.get_set())
 		{
-			const ppu_prx_object obj = fs::file(lle_dir + '/' + name);
+			fs::file ppu_file;
+			DecryptSelf(ppu_file, fs::file(lle_dir + '/' + name));
+
+			const ppu_prx_object obj = ppu_file;
 
 			if (obj == elf_error::ok)
 			{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -19,7 +19,8 @@ s32 prx_load_module(std::string path, u64 flags, vm::ptr<sys_prx_load_module_opt
 	sys_prx.warning("prx_load_module(path='%s', flags=0x%llx, pOpt=*0x%x)", path.c_str(), flags, pOpt);
 
 	fs::file ppu_file;
-	DecryptSelf(ppu_file, fs::file(vfs::get(path)));
+	fs::file temp = fs::file(vfs::get(path));
+	DecryptSelf(ppu_file, temp);
 
 	const ppu_prx_object obj = ppu_file;
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -18,7 +18,10 @@ s32 prx_load_module(std::string path, u64 flags, vm::ptr<sys_prx_load_module_opt
 {
 	sys_prx.warning("prx_load_module(path='%s', flags=0x%llx, pOpt=*0x%x)", path.c_str(), flags, pOpt);
 
-	const ppu_prx_object obj = fs::file(vfs::get(path));
+	fs::file ppu_file;
+	DecryptSelf(ppu_file, fs::file(vfs::get(path)));
+
+	const ppu_prx_object obj = ppu_file;
 
 	if (obj != elf_error::ok)
 	{

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -161,7 +161,8 @@ void Emulator::Load()
 		const std::string& elf_dir = fs::get_parent_dir(m_path);
 
 		fs::file elf_file;
-		if (!DecryptSelf(elf_file, fs::file(m_path))) 
+		fs::file temp = fs::file(m_path);
+		if (!DecryptSelf(elf_file, temp))
 		{
 			const std::string& elf_name = m_path.substr(elf_dir.size());
 			LOG_ERROR(LOADER, "Failed to decrypt %s", elf_dir + elf_name);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -160,23 +160,12 @@ void Emulator::Load()
 
 		const std::string& elf_dir = fs::get_parent_dir(m_path);
 
-		fs::file file(m_path);
 		fs::file elf_file;
-
-		if (IsSelf(file))
+		if (!DecryptSelf(elf_file, fs::file(m_path))) 
 		{
-			if (!DecryptSelf(elf_file, file)) 
-			{
-				const std::string& elf_name = m_path.substr(elf_dir.size());
-				LOG_ERROR(LOADER, "Failed to decrypt %s", elf_dir + elf_name);
-				return;
-			}
-
-			file.close();
-		}
-		else
-		{
-			elf_file = std::move(file); //We are not a SELF, so just use the file itself
+			const std::string& elf_name = m_path.substr(elf_dir.size());
+			LOG_ERROR(LOADER, "Failed to decrypt %s", elf_dir + elf_name);
+			return;
 		}
 
 		SetCPUThreadStop(0);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -160,37 +160,19 @@ void Emulator::Load()
 
 		const std::string& elf_dir = fs::get_parent_dir(m_path);
 
-		fs::file* file = new fs::file(m_path);
-		fs::file *elf_file = nullptr;
+		fs::file file(m_path);
+		fs::file elf_file;
 
-		if (IsSelf(*file))
+		if (IsSelf(file))
 		{
-			const std::size_t elf_ext_pos = m_path.find_last_of('.');
-			const std::string& elf_ext = fmt::to_upper(m_path.substr(elf_ext_pos != -1 ? elf_ext_pos : m_path.size()));
-			const std::string& elf_name = m_path.substr(elf_dir.size());
-
-			/*if (elf_name.compare(elf_name.find_last_of("/\\", -1, 2) + 1, 9, "EBOOT.BIN", 9) == 0)
+			if (!DecryptSelf(elf_file, file)) 
 			{
-				m_path.erase(m_path.size() - 9, 1); // change EBOOT.BIN to BOOT.BIN
-			}
-			else if (elf_ext == ".SELF" || elf_ext == ".SPRX")
-			{
-				m_path.erase(m_path.size() - 4, 1); // change *.self to *.elf, *.sprx to *.prx
-			}
-			else
-			{
-				m_path += ".decrypted.elf";
-			}*/
-
-			//If we pass elf_file as a nullptr, it is changed to a pointer pointing to a memory file
-			if (!DecryptSelf(elf_file, *file)) 
-			{
+				const std::string& elf_name = m_path.substr(elf_dir.size());
 				LOG_ERROR(LOADER, "Failed to decrypt %s", elf_dir + elf_name);
 				return;
 			}
 
-			file->close();
-			delete file;
+			file.close();
 		}
 		else
 		{
@@ -218,7 +200,7 @@ void Emulator::Load()
 			LOG_ERROR(LOADER, "Failed to open %s", m_path);
 			return;
 		}
-		else if (ppu_exec.open(*elf_file) == elf_error::ok)
+		else if (ppu_exec.open(elf_file) == elf_error::ok)
 		{
 			// PS3 executable
 			g_system = system_type::ps3;
@@ -287,7 +269,7 @@ void Emulator::Load()
 
 			fxm::import<GSRender>(Emu.GetCallbacks().get_gs_render); // TODO: must be created in appropriate sys_rsx syscall
 		}
-		else if (ppu_prx.open(*elf_file) == elf_error::ok)
+		else if (ppu_prx.open(elf_file) == elf_error::ok)
 		{
 			// PPU PRX (experimental)
 			g_system = system_type::ps3;
@@ -295,7 +277,7 @@ void Emulator::Load()
 			vm::ps3::init();
 			ppu_load_prx(ppu_prx);
 		}
-		else if (spu_exec.open(*elf_file) == elf_error::ok)
+		else if (spu_exec.open(elf_file) == elf_error::ok)
 		{
 			// SPU executable (experimental)
 			g_system = system_type::ps3;
@@ -303,7 +285,7 @@ void Emulator::Load()
 			vm::ps3::init();
 			spu_load_exec(spu_exec);
 		}
-		else if (arm_exec.open(*elf_file) == elf_error::ok)
+		else if (arm_exec.open(elf_file) == elf_error::ok)
 		{
 			// ARMv7 executable
 			g_system = system_type::psv;
@@ -324,9 +306,6 @@ void Emulator::Load()
 
 		debug::autopause::reload();
 		if (g_cfg_autostart) Run();
-
-		elf_file->close();
-		if (elf_file != nullptr) { delete elf_file; }
 	}
 	catch (const std::exception& e)
 	{

--- a/rpcs3/Gui/MainFrame.cpp
+++ b/rpcs3/Gui/MainFrame.cpp
@@ -374,9 +374,9 @@ void MainFrame::DecryptSPRXLibraries(wxCommandEvent& WXUNUSED(event))
 		std::string prx_path = fmt::ToUTF8(module);
 		const std::string& prx_dir = fs::get_parent_dir(prx_path);
 
-		fs::file* prx = new fs::file(prx_path);
+		fs::file prx(prx_path);
 
-		if (IsSelf(*prx))
+		if (IsSelf(prx))
 		{
 			const std::size_t prx_ext_pos = prx_path.find_last_of('.');
 			const std::string& prx_ext = fmt::to_upper(prx_path.substr(prx_ext_pos != -1 ? prx_ext_pos : prx_path.size()));
@@ -384,13 +384,12 @@ void MainFrame::DecryptSPRXLibraries(wxCommandEvent& WXUNUSED(event))
 
 			prx_path.erase(prx_path.size() - 4, 1); // change *.sprx to *.prx
 
-			fs::file prx_dec(prx_dir + prx_name, fs::rewrite);
+			fs::file prx_dec(prx_path, fs::rewrite);
 
-			if (DecryptSelf(prx, prx_dec))
+			if (DecryptSelf(prx_dec, prx))
 			{
 				LOG_SUCCESS(GENERAL, "Decrypted %s", prx_dir + prx_name);
 			}
-
 			else
 			{
 				LOG_ERROR(GENERAL, "Failed to decrypt %s", prx_dir + prx_name);

--- a/rpcs3/Gui/MainFrame.cpp
+++ b/rpcs3/Gui/MainFrame.cpp
@@ -374,7 +374,9 @@ void MainFrame::DecryptSPRXLibraries(wxCommandEvent& WXUNUSED(event))
 		std::string prx_path = fmt::ToUTF8(module);
 		const std::string& prx_dir = fs::get_parent_dir(prx_path);
 
-		if (IsSelf(prx_path))
+		fs::file* prx = new fs::file(prx_path);
+
+		if (IsSelf(*prx))
 		{
 			const std::size_t prx_ext_pos = prx_path.find_last_of('.');
 			const std::string& prx_ext = fmt::to_upper(prx_path.substr(prx_ext_pos != -1 ? prx_ext_pos : prx_path.size()));
@@ -382,7 +384,9 @@ void MainFrame::DecryptSPRXLibraries(wxCommandEvent& WXUNUSED(event))
 
 			prx_path.erase(prx_path.size() - 4, 1); // change *.sprx to *.prx
 
-			if (DecryptSelf(prx_path, prx_dir + prx_name))
+			fs::file prx_dec(prx_dir + prx_name, fs::rewrite);
+
+			if (DecryptSelf(prx, prx_dec))
 			{
 				LOG_SUCCESS(GENERAL, "Decrypted %s", prx_dir + prx_name);
 			}

--- a/rpcs3/Gui/SettingsDialog.cpp
+++ b/rpcs3/Gui/SettingsDialog.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "stdafx_gui.h"
+#include "Crypto/unself.h"
 #include "Utilities/Config.h"
 #include "Loader/ELF.h"
 #include "Emu/System.h"
@@ -339,8 +340,10 @@ SettingsDialog::SettingsDialog(wxWindow* parent)
 
 		for (const auto& prxf : fs::dir(lle_dir))
 		{
+			fs::file prx_file;
+			DecryptSelf(prx_file, fs::file(lle_dir + prxf.name));
 			// List found unselected modules
-			if (!prxf.is_directory && ppu_prx_object(fs::file(lle_dir + prxf.name)) == elf_error::ok && !set.count(prxf.name))
+			if (!prxf.is_directory && ppu_prx_object(prx_file) == elf_error::ok && !set.count(prxf.name))
 			{
 				lle_module_list_unselected.push_back(prxf.name);
 			}

--- a/rpcs3/Gui/SettingsDialog.cpp
+++ b/rpcs3/Gui/SettingsDialog.cpp
@@ -341,7 +341,8 @@ SettingsDialog::SettingsDialog(wxWindow* parent)
 		for (const auto& prxf : fs::dir(lle_dir))
 		{
 			fs::file prx_file;
-			DecryptSelf(prx_file, fs::file(lle_dir + prxf.name));
+			fs::file temp = fs::file(lle_dir + prxf.name);
+			DecryptSelf(prx_file, temp);
 			// List found unselected modules
 			if (!prxf.is_directory && ppu_prx_object(prx_file) == elf_error::ok && !set.count(prxf.name))
 			{


### PR DESCRIPTION
~~I'm just putting this pull request here for comments and to prevent work duplication by others, it's a good (hopefully) proof of concept, but not entirely ready to be merged yet. As of yet RPCS3 crashes because of the issues below.~~

These changes allow for the booting and decrypting of any elf object without intermediary or temporary files. This also overhauls the memory_stream fs::file class to enable writing and make it use unique_ptr and shared_ptr. This allows for fs::files which reside entirely in memory.

Only three issues left:
~~As of now the code just guesses how big the decrypted elf object will be. As of now we just take data_buf_length*5 as fs::file size, but we need to calculate it exactly to prevent memory waste, and corruption when we load a spu file from memory.~~

Do we want the SPRXes to be decrypted on the fly on each boot? It takes time and memory. Should we make this the default behavior, but use the .prx equivalents from "Decrypt SPRX Libraries" if they are present? Probably should make it a GUI option for developers.

I'm not sure some files in memory get deleted fast enough, to reduce memory usage. Unique_ptr ensures no leaks but we can close files manually to free the memory earlier. Please note any such cases.