### PR TITLE
Fix RPCS3's Qt App Compilation

### DIFF
--- a/rpcs3/rpcs3qt/glviewer.cpp
+++ b/rpcs3/rpcs3qt/glviewer.cpp
@@ -1,13 +1,15 @@
 #ifdef QT_UI
-#include "glviewer.h"
 #include <QQuickWindow>
 #include <QOpenGLContext>
 #include <QCoreApplication>
 
+#include "glviewer.h"
+
 // This class hooks beforeRendering and allows us to draw a scene and reset GL state.
 // In future, we will likely want to manually control the update rate.
 
-void GLRenderer::paint() {
+void GLRenderer::paint()
+{
 	// Do GL here
 	glViewport(0, 0, m_viewportSize.width(), m_viewportSize.height());
 
@@ -48,7 +50,8 @@ void GLViewer::sync()
 	m_renderer->setViewportSize(window()->size() * window()->devicePixelRatio());
 }
 
-void GLViewer::cleanup() {
+void GLViewer::cleanup()
+{
 	if (m_renderer) {
 		delete m_renderer;
 		m_renderer = 0;

--- a/rpcs3/rpcs3qt/glviewer.h
+++ b/rpcs3/rpcs3qt/glviewer.h
@@ -2,18 +2,19 @@
 
 #include <QQuickItem>
 
-class GLRenderer : public QObject {
-    Q_OBJECT
+class GLRenderer : public QObject
+{
+	Q_OBJECT
 public:
-    GLRenderer() { }
+	GLRenderer() { }
 
-    void setViewportSize(const QSize &size) { m_viewportSize = size; }
+	void setViewportSize(const QSize &size) { m_viewportSize = size; }
 
 public slots:
-    void paint();
+	void paint();
 
 private:
-    QSize m_viewportSize;
+	QSize m_viewportSize;
 };
 
 class GLViewer : public QQuickItem

--- a/rpcs3/rpcs3qt/main.cpp
+++ b/rpcs3/rpcs3qt/main.cpp
@@ -3,6 +3,7 @@
 #ifdef QT_UI
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
 #include "glviewer.h"
 
 int main(int argc, char *argv[])
@@ -13,6 +14,5 @@ int main(int argc, char *argv[])
 	QQmlApplicationEngine engine(QUrl("qrc:/qml/main.qml"));
 
 	return app.exec();
-	Q_UNUSED(engine)
 }
 #endif

--- a/rpcs3/rpcs3qt/qml/main.qml
+++ b/rpcs3/rpcs3qt/qml/main.qml
@@ -8,6 +8,7 @@ ApplicationWindow {
 	title: qsTr("RPCS3 Qt")
 	width: Screen.desktopAvailableWidth / 2
 	height: Screen.desktopAvailableHeight / 2
+
 	menuBar: MenuBar {
 		Menu {
 			title: qsTr("&Boot")
@@ -46,7 +47,9 @@ ApplicationWindow {
 			MenuItem { text: qsTr("&About...") }
 		}
 	}
+
 	GLViewer {}
+
 	Rectangle {
 		color: Qt.rgba(0, 0.5, 0.35);
 		height: Math.round(parent.height / 2)

--- a/rpcs3/rpcs3qt/rpcs3qt.pro
+++ b/rpcs3/rpcs3qt/rpcs3qt.pro
@@ -2,6 +2,8 @@
 QT += gui opengl quick
 CONFIG += c++11
 
+TARGET = rpcs3-qt
+
 # Qt UI
 SOURCES += $$P/rpcs3qt/*.cpp
 HEADERS += $$P/rpcs3qt/*.h
@@ -19,4 +21,4 @@ OTHER_FILES += $$P/rpcs3qt/qml/*
 RESOURCES += $$P/rpcs3qt/qml.qrc
 
 # This line is needed for Qt 5.5 or higher
-LIBS += opengl32.lib
+win32:LIBS += opengl32.lib


### PR DESCRIPTION
Chnges from #2330 breaks rpcs3qt's compilation on any non-Windows platform b/c they doesnt have `opengl32.lib` library.
This PR fix this issue by passing `opengl32.lib` into LIBS only for win32 targets. Also this PR contains some code cleanups like indentation and some code formatting.