### PR TITLE
Some changes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutilAvc2.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutilAvc2.cpp
@@ -89,7 +89,8 @@ s32 cellSysutilAvc2SetWindowString()
 
 s32 cellSysutilAvc2EstimateMemoryContainerSize()
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	UNIMPLEMENTED_FUNC(cellSysutilAvc2); 
+  	return CELL_OK;
 }
 
 s32 cellSysutilAvc2SetVideoMuting()
@@ -304,7 +305,8 @@ s32 cellSysutilAvc2HideWindow()
 
 s32 cellSysutilAvc2GetVoiceMuting()
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	UNIMPLEMENTED_FUNC(cellSysutilAvc2); 
+  	return CELL_OK;
 }
 
 s32 cellSysutilAvc2GetScreenShowStatus()


### PR DESCRIPTION
cellSysutilAvc2: Use UNIMPLEMENTED_FUNC macro instead of fmt::throw_exception.

```
[NPJB90576]
E {PPU[0x1000000] Thread (main_thread) [0x002dfd80]} cellSysutilAvc2: Unknown media type 0x0
E {PPU[0x1000000] Thread (main_thread) [0x002dfd20]} PPU: 'cellSysutilAvc2EstimateMemoryContainerSize' aborted
F {PPU[0x1000000] Thread (main_thread) [0x002dfd20]} class std::runtime_error thrown: Unimplemented
(in file C:\rpcs3\rpcs3\Emu\Cell\Modules\cellSysutilAvc2.cpp:92)
```
```
[BLAS50770]
E {PPU[0x1000000] Thread (main_thread) [0x00a09a68]} PPU: 'cellSysutilAvc2GetVoiceMuting' aborted
F {PPU[0x1000000] Thread (main_thread) [0x00a09a68]} class std::runtime_error thrown: Unimplemented
(in file C:\rpcs3\rpcs3\Emu\Cell\Modules\cellSysutilAvc2.cpp:307)
```
