### PR TITLE
d3d12: add x1r5g5b5_z1r5g5b5 for fix Splatterhouse

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -392,7 +392,7 @@ namespace
 		case rsx::primitive_type::quads:
 			return expand_indexed_quads<T>(src.subspan(first), dst, restart_index_enabled, restart_index);
 		}
-		fmt::throw_exception("Don't know how to expand draw mode" HERE);
+		fmt::throw_exception("Unknown draw mode (0x%x)" HERE, (u32)draw_mode);
 	}
 }
 

--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
@@ -132,7 +132,7 @@ D3D12_COMPARISON_FUNC get_compare_func(rsx::comparison_function op)
 	case rsx::comparison_function::greater_or_equal: return D3D12_COMPARISON_FUNC_GREATER_EQUAL;
 	case rsx::comparison_function::always: return D3D12_COMPARISON_FUNC_ALWAYS;
 	}
-	fmt::throw_exception("Invalid or unsupported compare func (0x%x)" HERE, (u32)op);
+	fmt::throw_exception("Invalid compare func (0x%x)" HERE, (u32)op);
 }
 
 DXGI_FORMAT get_texture_format(u8 format)
@@ -168,9 +168,8 @@ DXGI_FORMAT get_texture_format(u8 format)
 	case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8: return DXGI_FORMAT_R8G8_SNORM;
 	case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_B8R8_G8R8: return DXGI_FORMAT_G8R8_G8B8_UNORM;
 	case ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN) & CELL_GCM_TEXTURE_COMPRESSED_R8B8_R8G8: return DXGI_FORMAT_R8G8_B8G8_UNORM;
-		break;
 	}
-	fmt::throw_exception("Invalid or unsupported texture format (0x%x)" HERE, (u32)format);
+	fmt::throw_exception("Invalid texture format (0x%x)" HERE, (u32)format);
 }
 
 UINT get_texture_max_aniso(rsx::texture_max_anisotropy aniso)
@@ -296,14 +295,16 @@ D3D12_PRIMITIVE_TOPOLOGY_TYPE get_primitive_topology_type(rsx::primitive_type dr
 	case rsx::primitive_type::polygon: return D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
 	case rsx::primitive_type::line_loop: return D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE;
 	}
-	fmt::throw_exception("Invalid or unsupported draw mode (0x%x)" HERE, (u32)draw_mode);
+	fmt::throw_exception("Invalid draw mode (0x%x)" HERE, (u32)draw_mode);
 }
 
 DXGI_FORMAT get_color_surface_format(rsx::surface_color_format format)
 {
 	switch (format)
 	{
-	case rsx::surface_color_format::x1r5g5b5_o1r5g5b5: return DXGI_FORMAT_B5G5R5A1_UNORM;
+	case rsx::surface_color_format::x1r5g5b5_z1r5g5b5: 
+	case rsx::surface_color_format::x1r5g5b5_o1r5g5b5:
+		return DXGI_FORMAT_B5G5R5A1_UNORM;
 	case rsx::surface_color_format::r5g6b5: return DXGI_FORMAT_B5G6R5_UNORM;
 	case rsx::surface_color_format::x8b8g8r8_o8b8g8r8:
 	case rsx::surface_color_format::x8b8g8r8_z8b8g8r8:


### PR DESCRIPTION
Thx @kd-11 for verifying fix.
d3d12: add x1r5g5b5_z1r5g5b5 for fix in-game SplatterHouse in DirectX 12.
d3d12: Little Cleanup old code forgotten removed.
Add info in BufferUtils for log for find and add draw mode Unknown, actually found with this Kung Fuu Rider value missing added later by @kd-11 

Tell me if I need to change something.