### PR TITLE
Fix nv3089_image_in

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -28,12 +28,12 @@ void Shader::Compile(const std::string &code, SHADER_TYPE st)
 	case SHADER_TYPE::SHADER_TYPE_VERTEX:
 		hr = wrapD3DCompile(code.c_str(), code.size(), "VertexProgram.hlsl", nullptr, nullptr, "main", "vs_5_0", compileFlags, 0, &bytecode, errorBlob.GetAddressOf());
 		if (hr != S_OK)
-			LOG_ERROR(RSX, "VS build failed:%s", errorBlob->GetBufferPointer());
+			LOG_ERROR(RSX, "VS build failed:%s", (char*)errorBlob->GetBufferPointer());
 		break;
 	case SHADER_TYPE::SHADER_TYPE_FRAGMENT:
 		hr = wrapD3DCompile(code.c_str(), code.size(), "FragmentProgram.hlsl", nullptr, nullptr, "main", "ps_5_0", compileFlags, 0, &bytecode, errorBlob.GetAddressOf());
 		if (hr != S_OK)
-			LOG_ERROR(RSX, "FS build failed:%s", errorBlob->GetBufferPointer());
+			LOG_ERROR(RSX, "FS build failed:%s", (char*)errorBlob->GetBufferPointer());
 		break;
 	}
 }


### PR DESCRIPTION
The main changes are:
- To restrict the clip y/x to `(in_x/y + in_w - 1)` as per docs
- Remove double addition of out_offset when clipping/converting

Also rearranged a bit to get some things as const to make the function a bit easier to work with. 

This makes #2166 create the correct shaders now and looks a bit better, as cg loader uses image_in to blit the shaders to rsx memory, and gave some invalid clip values

