### PR TITLE
libnet: recvfrom() fix

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_net.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_net.cpp
@@ -432,6 +432,12 @@ namespace sys_net
 
 		memcpy(&_addr, addr.get_ptr(), sizeof(::sockaddr));
 		_addr.sa_family = addr->sa_family;
+
+		if (s <= 0) {
+			libnet.error("recvfrom(): invalid socket %d", s);
+			return SYS_NET_EBADF;
+		}
+
 		s32 ret = ::recvfrom(sock->s, buf.get_ptr(), len, flags, &_addr, &_paddrlen);
 		*paddrlen = _paddrlen;
 


### PR DESCRIPTION
Prevents emulator crash when invalid socket is provided to the function
Fixes crash on One Piece Pirate Warriors Menu