### PR TITLE
cellGame: Fix cellDiscGameGetBootDiscInfo

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -760,13 +760,19 @@ s32 cellGameThemeInstallFromBuffer()
 s32 cellDiscGameGetBootDiscInfo(vm::ptr<CellDiscGameSystemFileParam> getParam)
 {
 	cellGame.warning("cellDiscGameGetBootDiscInfo(getParam=*0x%x)", getParam);
-	//this should only appear in disc games
+
+	// This is also called by non-disc games, see NPUB90029
 	const std::string dir = "/dev_bdvd/PS3_GAME"s;
 
 	if (!fs::is_dir(vfs::get(dir)))
 	{
+		// Not a disc game. TODO: Fetch PARAM.SFO from proper game dir
 		cellGame.warning("cellDiscGameGetBootDiscInfo(): directory '%s' not found", dir);
+		getParam->parentalLevel = 0;
+		strcpy_trunc(getParam->titleId, "0");
+		return CELL_OK;
 	}
+
 	const auto& psf = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
 
 	if (psf.count("PARENTAL_LEVEL") != 0) getParam->parentalLevel = psf.at("PARENTAL_LEVEL").as_integer();


### PR DESCRIPTION
cellDiscGameGetBootDiscInfo is called by non-disc games for some reason.
That wasn't accounted for and therefore it would try to read PARAM.SFO from an unmounted path and throw an access violation.

Tested with NBA Live 08 Demo [NPUB90029] which now shows Intros, should fix similar games as well.