### PR TITLE
Implement AES-NI (AES Hardware Acceleration)

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT MSVC)
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O1") # fix for travis gcc OoM crash. Might be fixed with the move to containers.
 	endif()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fexceptions")
-	add_compile_options(-msse -msse2 -mcx16 -mssse3)
+	add_compile_options(-msse -msse2 -mcx16 -mssse3 -maes)
 else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:throwingNew /D _CRT_SECURE_NO_DEPRECATE=1 /D _CRT_NON_CONFORMING_SWPRINTFS=1 /D _SCL_SECURE_NO_WARNINGS=1")
 endif()

--- a/rpcs3/Crypto/aes.h
+++ b/rpcs3/Crypto/aes.h
@@ -35,6 +35,15 @@ typedef UINT32 uint32_t;
 #include <inttypes.h>
 #endif
 
+#if defined(_MSC_VER) && (defined(_WIN32) || defined(_WIN64))
+#include <intrin.h>
+#define AESNI AESNI
+#elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
+#include <x86intrin.h>
+#include <cpuid.h>
+#define AESNI AESNI
+#endif
+
 #define AES_ENCRYPT     1
 #define AES_DECRYPT     0
 
@@ -49,7 +58,10 @@ typedef UINT32 uint32_t;
  */
 typedef struct
 {
-    int nr;                     /*!<  number of rounds  */
+#ifdef AESNI
+	alignas(16) __m128i roundkey[15]; // AES-NI round keys
+#endif
+	int nr;                     /*!<  number of rounds  */
     uint32_t *rk;               /*!<  AES round keys    */
     uint32_t buf[68];           /*!<  unaligned data    */
 }


### PR DESCRIPTION
Including runtime CPUID check for x86/64 and compile time check to disable for other archs.

Unfortunately the performance improvement on my computer is only about 2x at best, but it is still something.

As nothing uses it, 192 bit mode is untested.
Please test for regressions/decryption failures.