### PR TITLE
Edat / Sdata: On the fly decryption for edat + misc fixes

### DIFF
--- a/rpcs3/Crypto/utils.cpp
+++ b/rpcs3/Crypto/utils.cpp
@@ -10,7 +10,7 @@
 
 // Auxiliary functions (endian swap, xor and prng).
 
-void xor_key(unsigned char *dest, unsigned char *src1, unsigned char *src2)
+void xor_key(unsigned char *dest, const u8* src1, const u8* src2)
 {
 	for(int i = 0; i < 0x10; i++)
 	{

--- a/rpcs3/Crypto/utils.h
+++ b/rpcs3/Crypto/utils.h
@@ -42,7 +42,7 @@ inline u64 swap64(u64 i)
 #endif
 }
 
-void xor_key(unsigned char *dest, unsigned char *src1, unsigned char *src2);
+void xor_key(unsigned char *dest, const u8* src1, const u8* src2);
 inline void xor_key_sse(u8* dest, const u8* src1, const u8* src2)
 {
 	_mm_storeu_si128(&(((__m128i*)dest)[0]),

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -269,7 +269,7 @@ s32 cellMsgDialogProgressBarSetMsg(u32 progressBarIndex, vm::cptr<char> msgStrin
 		return CELL_MSGDIALOG_ERROR_DIALOG_NOT_OPENED;
 	}
 
-	if (progressBarIndex >= dlg->type.progress_bar_count)
+	if (progressBarIndex >= dlg->type.progress_bar_count || !msgString)
 	{
 		return CELL_MSGDIALOG_ERROR_PARAM;
 	}

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -12,15 +12,12 @@ s32 cellPadInit(u32 max_connect)
 {
 	sys_io.warning("cellPadInit(max_connect=%d)", max_connect);
 
-	if (max_connect > CELL_PAD_MAX_PORT_NUM)
-		return CELL_PAD_ERROR_INVALID_PARAMETER;
-
 	const auto handler = fxm::import<PadHandlerBase>(Emu.GetCallbacks().get_pad_handler);
 
 	if (!handler)
 		return CELL_PAD_ERROR_ALREADY_INITIALIZED;
 
-	handler->Init(max_connect);
+	handler->Init(std::min(max_connect, CELL_PAD_MAX_PORT_NUM));
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/sceNp.h
+++ b/rpcs3/Emu/Cell/Modules/sceNp.h
@@ -119,6 +119,25 @@ enum
 
 	// DRM
 	SCE_NP_DRM_ERROR_LICENSE_NOT_FOUND                  = 0x80029521,
+	SCE_NP_DRM_ERROR_OUT_OF_MEMORY                      = 0x80029501,
+	SCE_NP_DRM_ERROR_INVALID_PARAM                      = 0x80029502,
+	SCE_NP_DRM_ERROR_SERVER_RESPONSE                    = 0x80029509,
+	SCE_NP_DRM_ERROR_NO_ENTITLEMENT                     = 0x80029513,
+	SCE_NP_DRM_ERROR_BAD_ACT                            = 0x80029514,
+	SCE_NP_DRM_ERROR_BAD_FORMAT                         = 0x80029515,
+	SCE_NP_DRM_ERROR_NO_LOGIN                           = 0x80029516,
+	SCE_NP_DRM_ERROR_INTERNAL                           = 0x80029517,
+	SCE_NP_DRM_ERROR_BAD_PERM                           = 0x80029519,
+	SCE_NP_DRM_ERROR_UNKNOWN_VERSION                    = 0x8002951a,
+	SCE_NP_DRM_ERROR_TIME_LIMIT                         = 0x8002951b,
+	SCE_NP_DRM_ERROR_DIFFERENT_ACCOUNT_ID               = 0x8002951c,
+	SCE_NP_DRM_ERROR_DIFFERENT_DRM_TYPE                 = 0x8002951d,
+	SCE_NP_DRM_ERROR_SERVICE_NOT_STARTED                = 0x8002951e,
+	SCE_NP_DRM_ERROR_BUSY                               = 0x80029520,
+	SCE_NP_DRM_ERROR_IO                                 = 0x80029525,
+	SCE_NP_DRM_ERROR_FORMAT                             = 0x80029530,
+	SCE_NP_DRM_ERROR_FILENAME                           = 0x80029533,
+	SCE_NP_DRM_ERROR_K_LICENSEE                         = 0x80029534,
 };
 
 using SceNpBasicEventHandler = s32(s32 event, s32 retCode, u32 reqId, vm::ptr<void> arg);


### PR DESCRIPTION
- This adds support for 'on the fly' decryption of edat files, like the previous sdata/mself implementation
- It also fixes the decryption error that happened with some sdata/edat files
- cellPad fix per docs, allows prince of persia to progress past first menu
- cellMsgDialog arg check to allow crazy taxi to boot and play