### PR TITLE
Use sys_vm_memory_map plus add default value for sys_allocate_memory

### DIFF
--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -203,6 +203,7 @@ extern std::string ppu_get_syscall_name(u64 code)
 	case 310: return "sys_vm_sync";
 	case 311: return "sys_vm_test";
 	case 312: return "sys_vm_get_statistics";
+	case 313: return "sys_vm_memory_map_different";
 	case 324: return "sys_memory_container_create";
 	case 325: return "sys_memory_container_destroy";
 	case 326: return "sys_mmapper_allocate_fixed_address";

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -325,7 +325,7 @@ std::array<ppu_function_t, 1024> g_ppu_syscall_table
 	BIND_FUNC(sys_vm_sync),                                 //310 (0x136)
 	BIND_FUNC(sys_vm_test),                                 //311 (0x137)
 	BIND_FUNC(sys_vm_get_statistics),                       //312 (0x138)
-	null_func,//BIND_FUNC(sys_vm_memory_map (different))    //313 (0x139)
+	BIND_FUNC(sys_vm_memory_map_different),				    //313 (0x139) //BIND_FUNC(sys_vm_memory_map (different)) 
 	null_func,//BIND_FUNC(sys_...)                          //314 (0x13A)
 	null_func,//BIND_FUNC(sys_...)                          //315 (0x13B)
 	

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -12,6 +12,7 @@ error_code sys_memory_allocate(u32 size, u64 flags, vm::ptr<u32> alloc_addr)
 	// Check allocation size
 	switch (flags)
 	{
+	case 0:		//handle "default" value, issue 2510
 	case SYS_MEMORY_PAGE_SIZE_1M:
 	{
 		if (size % 0x100000)

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -38,6 +38,14 @@ error_code sys_vm_memory_map(u32 vsize, u32 psize, u32 cid, u64 flag, u64 policy
 	return CELL_ENOMEM;
 }
 
+error_code sys_vm_memory_map_different(u32 vsize, u32 psize, u32 cid, u64 flag, u64 policy, vm::ptr<u32> addr)
+{
+	sys_vm.warning("sys_vm_memory_map_different(vsize=0x%x, psize=0x%x, cid=0x%x, flags=0x%llx, policy=0x%llx, addr=*0x%x)", vsize, psize, cid, flag, policy, addr);
+	// TODO: if needed implement different way to map memory, unconfirmed.
+
+	return sys_vm_memory_map(vsize, psize, cid, flag, policy, addr);
+}
+
 error_code sys_vm_unmap(u32 addr)
 {
 	sys_vm.warning("sys_vm_unmap(addr=0x%x)", addr);

--- a/rpcs3/Emu/Cell/lv2/sys_vm.h
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.h
@@ -27,6 +27,7 @@ struct sys_vm_statistics_t
 
 // SysCalls
 error_code sys_vm_memory_map(u32 vsize, u32 psize, u32 cid, u64 flag, u64 policy, vm::ps3::ptr<u32> addr);
+error_code sys_vm_memory_map_different(u32 vsize, u32 psize, u32 cid, u64 flag, u64 policy, vm::ps3::ptr<u32> addr);
 error_code sys_vm_unmap(u32 addr);
 error_code sys_vm_append_memory(u32 addr, u32 size);
 error_code sys_vm_return_memory(u32 addr, u32 size);


### PR DESCRIPTION
for different memory map(unconfirmed).
Adds default flag value for sys_allocate_memory
Fixes unknown syscall 313 error
Issue #2510 