### PR TITLE
gl/vk: Stencil fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -210,7 +210,10 @@ void GLGSRender::init_buffers(bool skip_reading)
 
 	if (std::get<0>(m_rtts.m_bound_depth_stencil))
 	{
-		__glcheck draw_fbo.depth = *std::get<1>(m_rtts.m_bound_depth_stencil);
+		if (depth_format == rsx::surface_depth_format::z24s8)
+			__glcheck draw_fbo.depth_stencil = *std::get<1>(m_rtts.m_bound_depth_stencil);
+		else
+			__glcheck draw_fbo.depth = *std::get<1>(m_rtts.m_bound_depth_stencil);
 
 		const u32 depth_surface_pitch = rsx::method_registers.surface_z_pitch();
 		std::get<1>(m_rtts.m_bound_depth_stencil)->set_rsx_pitch(rsx::method_registers.surface_z_pitch());

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -898,9 +898,8 @@ void VKGSRender::clear_surface(u32 mask)
 		if (surface_depth_format == rsx::surface_depth_format::z24s8)
 		{
 			u8 clear_stencil = rsx::method_registers.stencil_clear_value();
-			u32 stencil_mask = rsx::method_registers.stencil_mask();
 
-			depth_stencil_clear_values.depthStencil.stencil = stencil_mask;
+			depth_stencil_clear_values.depthStencil.stencil = clear_stencil;
 
 			depth_stencil_mask |= VK_IMAGE_ASPECT_STENCIL_BIT;
 		}

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -14,7 +14,6 @@ namespace vk
 
 		program::~program()
 		{
-			LOG_ERROR(RSX, "Program destructor invoked!");
 			vkDestroyPipeline(m_device, pipeline, nullptr);
 		}
 


### PR DESCRIPTION
- Fix an old bug with shared surface store where RTTs were relocated when any individual buffer was changed.
- Actually bind a stencil attachment on fbo creation for ogl