### PR TITLE
Fix copy_setup_h.vcxproj for building with VS2017

### DIFF
--- a/rpcs3/copy_setup_h.vcxproj
+++ b/rpcs3/copy_setup_h.vcxproj
@@ -19,6 +19,8 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
     <ProjectGuid>{00D36322-6188-4A66-B514-3B3F183E998D}</ProjectGuid>
     <RootNamespace>copy_setup_h</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>

--- a/rpcs3/copy_setup_h.vcxproj
+++ b/rpcs3/copy_setup_h.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>


### PR DESCRIPTION
With the VS2017, the copy_setup project will cause a error "could not found the toolset=v100"