### PR TITLE
rsx: Add support for immediate mode rendering

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
@@ -125,8 +125,9 @@ void D3D12GSRender::clear_surface(u32 arg)
 
 		if (arg & 0x1)
 		{
-			u32 clear_depth = rsx::method_registers.z_clear_value();
-			u32 max_depth_value = get_max_depth_value(rsx::method_registers.surface_depth_fmt());
+			auto depth_format = rsx::method_registers.surface_depth_fmt();
+			u32 clear_depth = rsx::method_registers.z_clear_value(depth_format == rsx::surface_depth_format::z24s8);
+			u32 max_depth_value = get_max_depth_value(depth_format);
 			get_current_resource_storage().command_list->ClearDepthStencilView(m_rtts.current_ds_handle, D3D12_CLEAR_FLAG_DEPTH, clear_depth / (float)max_depth_value, 0,
 				1, &get_scissor(rsx::method_registers.scissor_origin_x(), rsx::method_registers.scissor_origin_y(), rsx::method_registers.scissor_width(), rsx::method_registers.scissor_height()));
 		}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -635,8 +635,7 @@ void GLGSRender::clear_surface(u32 arg)
 	if (arg & 0x1)
 	{
 		u32 max_depth_value = get_max_depth_value(surface_depth_format);
-
-		u32 clear_depth = rsx::method_registers.z_clear_value();
+		u32 clear_depth = rsx::method_registers.z_clear_value(surface_depth_format == rsx::surface_depth_format::z24s8);
 
 		glDepthMask(GL_TRUE);
 		glClearDepth(double(clear_depth) / max_depth_value);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -276,45 +276,6 @@ void GLGSRender::begin()
 	//NV4097_SET_FLAT_SHADE_OP
 	//NV4097_SET_EDGE_FLAG
 
-	auto set_clip_plane_control = [&](int index, rsx::user_clip_plane_op control)
-	{
-		int value = 0;
-		int location;
-
-		if (m_program->uniforms.has_location("uc_m" + std::to_string(index), &location))
-		{
-			switch (control)
-			{
-			default:
-				LOG_ERROR(RSX, "bad clip plane control (0x%x)", (u8)control);
-
-			case rsx::user_clip_plane_op::disable:
-				value = 0;
-				break;
-
-			case rsx::user_clip_plane_op::greater_or_equal:
-				value = 1;
-				break;
-
-			case rsx::user_clip_plane_op::less_than:
-				value = -1;
-				break;
-			}
-
-			__glcheck m_program->uniforms[location] = value;
-		}
-
-		__glcheck enable(value, GL_CLIP_DISTANCE0 + index);
-	};
-
-	load_program();
-	set_clip_plane_control(0, rsx::method_registers.clip_plane_0_enabled());
-	set_clip_plane_control(1, rsx::method_registers.clip_plane_1_enabled());
-	set_clip_plane_control(2, rsx::method_registers.clip_plane_2_enabled());
-	set_clip_plane_control(3, rsx::method_registers.clip_plane_3_enabled());
-	set_clip_plane_control(4, rsx::method_registers.clip_plane_4_enabled());
-	set_clip_plane_control(5, rsx::method_registers.clip_plane_5_enabled());
-
 	if (__glcheck enable(rsx::method_registers.cull_face_enabled(), GL_CULL_FACE))
 	{
 		__glcheck glCullFace(cull_face(rsx::method_registers.cull_face_mode()));
@@ -368,6 +329,56 @@ void GLGSRender::end()
 		rsx::thread::end();
 		return;
 	}
+
+	std::chrono::time_point<steady_clock> program_start = steady_clock::now();
+
+	//Load program here since it is dependent on vertex state
+	load_program();
+
+	std::chrono::time_point<steady_clock> program_stop = steady_clock::now();
+	m_begin_time += (u32)std::chrono::duration_cast<std::chrono::microseconds>(program_stop - program_start).count();
+
+	//Set active user clip planes
+	const rsx::user_clip_plane_op clip_plane_control[6] =
+	{
+		rsx::method_registers.clip_plane_0_enabled(),
+		rsx::method_registers.clip_plane_1_enabled(),
+		rsx::method_registers.clip_plane_2_enabled(),
+		rsx::method_registers.clip_plane_3_enabled(),
+		rsx::method_registers.clip_plane_4_enabled(),
+		rsx::method_registers.clip_plane_5_enabled(),
+	};
+
+	for (int index = 0; index < 6; ++index)
+	{
+		int value = 0;
+		int location;
+
+		if (m_program->uniforms.has_location("uc_m" + std::to_string(index), &location))
+		{
+			switch (clip_plane_control[index])
+			{
+			default:
+				LOG_ERROR(RSX, "bad clip plane control (0x%x)", (u8)clip_plane_control[index]);
+
+			case rsx::user_clip_plane_op::disable:
+				value = 0;
+				break;
+
+			case rsx::user_clip_plane_op::greater_or_equal:
+				value = 1;
+				break;
+
+			case rsx::user_clip_plane_op::less_than:
+				value = -1;
+				break;
+			}
+
+			__glcheck m_program->uniforms[location] = value;
+		}
+
+		__glcheck enable(value, GL_CLIP_DISTANCE0 + index);
+	};
 
 	if (manually_flush_ring_buffers)
 	{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -329,16 +329,38 @@ namespace rsx
 	void thread::begin()
 	{
 		rsx::method_registers.current_draw_clause.inline_vertex_array.clear();
+		in_begin_end = true;
+	}
+
+	void thread::append_to_push_buffer(u32 attribute, u32 size, u32 subreg_index, u32 value)
+	{
+		vertex_push_buffers[attribute].size = size;
+		vertex_push_buffers[attribute].append_vertex_data(subreg_index, value);
+	}
+
+	u32 thread::get_push_buffer_vertex_count()
+	{
+		//There's no restriction on which attrib shall hold vertex data, so we check them all
+		u32 max_vertex_count = 0;
+		for (auto &buf: vertex_push_buffers)
+		{
+			max_vertex_count = std::max(max_vertex_count, buf.vertex_count);
+		}
+
+		return max_vertex_count;
 	}
 
 	void thread::end()
 	{
 		rsx::method_registers.transform_constants.clear();
+		in_begin_end = false;
 
 		for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 		{
 			//Disabled, see https://github.com/RPCS3/rpcs3/issues/1932
 			//rsx::method_registers.register_vertex_info[index].size = 0;
+
+			vertex_push_buffers[index].clear();
 		}
 
 		if (capture_current_frame)
@@ -670,7 +692,8 @@ namespace rsx
 		return {ptr + first * vertex_array_info.stride(), count * vertex_array_info.stride() + element_size};
 	}
 
-	std::vector<std::variant<vertex_array_buffer, vertex_array_register, empty_vertex_array>> thread::get_vertex_buffers(const rsx::rsx_state& state, const std::vector<std::pair<u32, u32>>& vertex_ranges) const
+	std::vector<std::variant<vertex_array_buffer, vertex_array_register, empty_vertex_array>>
+	thread::get_vertex_buffers(const rsx::rsx_state& state, const std::vector<std::pair<u32, u32>>& vertex_ranges) const
 	{
 		std::vector<std::variant<vertex_array_buffer, vertex_array_register, empty_vertex_array>> result;
 		result.reserve(rsx::limits::vertex_count);
@@ -687,6 +710,16 @@ namespace rsx
 				const rsx::data_array_format_info& info = state.vertex_arrays_info[index];
 				result.push_back(vertex_array_buffer{info.type(), info.size(), info.stride(),
 				    get_raw_vertex_buffer(info, state.vertex_data_base_offset(), vertex_ranges), index});
+				continue;
+			}
+
+			if (vertex_push_buffers[index].vertex_count > 1)
+			{
+				const rsx::register_vertex_data_info& info = state.register_vertex_info[index];
+				const u8 element_size = info.size * sizeof(u32);
+
+				gsl::span<const gsl::byte> vertex_src = { (const gsl::byte*)vertex_push_buffers[index].data.data(), vertex_push_buffers[index].vertex_count * element_size };
+				result.push_back(vertex_array_buffer{ info.type, info.size, element_size, vertex_src, index });
 				continue;
 			}
 
@@ -827,7 +860,7 @@ namespace rsx
 	RSXVertexProgram thread::get_current_vertex_program() const
 	{
 		RSXVertexProgram result = {};
-		u32 transform_program_start = rsx::method_registers.transform_program_start();
+		const u32 transform_program_start = rsx::method_registers.transform_program_start();
 		result.data.reserve((512 - transform_program_start) * 4);
 
 		for (int i = transform_program_start; i < 512; ++i)
@@ -843,8 +876,8 @@ namespace rsx
 		}
 		result.output_mask = rsx::method_registers.vertex_attrib_output_mask();
 
-		u32 input_mask = rsx::method_registers.vertex_attrib_input_mask();
-		u32 modulo_mask = rsx::method_registers.frequency_divider_operation_mask();
+		const u32 input_mask = rsx::method_registers.vertex_attrib_input_mask();
+		const u32 modulo_mask = rsx::method_registers.frequency_divider_operation_mask();
 		result.rsx_vertex_inputs.clear();
 		for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 		{
@@ -861,6 +894,16 @@ namespace rsx
 				        !!((modulo_mask >> index) & 0x1),
 				        true,
 				        is_int_type(rsx::method_registers.vertex_arrays_info[index].type()), 0});
+			}
+			else if (vertex_push_buffers[index].vertex_count > 1)
+			{
+				result.rsx_vertex_inputs.push_back(
+				{ index,
+					rsx::method_registers.register_vertex_info[index].size,
+					1,
+					false,
+					true,
+					is_int_type(rsx::method_registers.vertex_arrays_info[index].type()), 0 });
 			}
 			else if (rsx::method_registers.register_vertex_info[index].size > 0)
 			{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -332,10 +332,10 @@ namespace rsx
 		in_begin_end = true;
 	}
 
-	void thread::append_to_push_buffer(u32 attribute, u32 size, u32 subreg_index, u32 value)
+	void thread::append_to_push_buffer(u32 attribute, u32 size, u32 subreg_index, vertex_base_type type, u32 value)
 	{
 		vertex_push_buffers[attribute].size = size;
-		vertex_push_buffers[attribute].append_vertex_data(subreg_index, value);
+		vertex_push_buffers[attribute].append_vertex_data(subreg_index, type, value);
 	}
 
 	u32 thread::get_push_buffer_vertex_count()

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -168,6 +168,7 @@ namespace rsx
 
 	protected:
 		std::stack<u32> m_call_stack;
+		std::array<push_buffer_vertex_info, 16> vertex_push_buffers;
 
 	public:
 		old_shaders_cache::shaders_cache shaders_cache;
@@ -233,6 +234,7 @@ namespace rsx
 	public:
 		std::set<u32> m_used_gcm_commands;
 		bool invalid_command_interrupt_raised = false;
+		bool in_begin_end = false;
 
 	protected:
 		thread();
@@ -265,9 +267,18 @@ namespace rsx
 		gsl::span<const gsl::byte> get_raw_index_array(const std::vector<std::pair<u32, u32> >& draw_indexed_clause) const;
 		gsl::span<const gsl::byte> get_raw_vertex_buffer(const rsx::data_array_format_info&, u32 base_offset, const std::vector<std::pair<u32, u32>>& vertex_ranges) const;
 
-		std::vector<std::variant<vertex_array_buffer, vertex_array_register, empty_vertex_array>> get_vertex_buffers(const rsx::rsx_state& state, const std::vector<std::pair<u32, u32>>& vertex_ranges) const;
+		std::vector<std::variant<vertex_array_buffer, vertex_array_register, empty_vertex_array>>
+		get_vertex_buffers(const rsx::rsx_state& state, const std::vector<std::pair<u32, u32>>& vertex_ranges) const;
+		
 		std::variant<draw_array_command, draw_indexed_array_command, draw_inlined_array>
 		get_draw_command(const rsx::rsx_state& state) const;
+
+		/*
+		* Immediate mode rendering requires a temp push buffer to hold attrib values
+		* Appends a value to the push buffer (currently only supports 32-wide types)
+		*/
+		void append_to_push_buffer(u32 attribute, u32 size, u32 subreg_index, u32 value);
+		u32 get_push_buffer_vertex_count();
 
 	private:
 		std::mutex m_mtx_task;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -277,7 +277,7 @@ namespace rsx
 		* Immediate mode rendering requires a temp push buffer to hold attrib values
 		* Appends a value to the push buffer (currently only supports 32-wide types)
 		*/
-		void append_to_push_buffer(u32 attribute, u32 size, u32 subreg_index, u32 value);
+		void append_to_push_buffer(u32 attribute, u32 size, u32 subreg_index, vertex_base_type type, u32 value);
 		u32 get_push_buffer_vertex_count();
 
 	private:

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -658,9 +658,6 @@ void VKGSRender::begin()
 
 	init_buffers();
 
-	if (!load_program())
-		return;
-
 	float actual_line_width = rsx::method_registers.line_width();
 
 	vkCmdSetLineWidth(m_command_buffer, actual_line_width);
@@ -681,6 +678,14 @@ void VKGSRender::end()
 		vk::get_compatible_depth_surface_format(m_optimal_tiling_supported_formats, rsx::method_registers.surface_depth_fmt()),
 		(u8)vk::get_draw_buffers(rsx::method_registers.surface_color_target()).size());
 	VkRenderPass current_render_pass = m_render_passes[idx];
+
+	std::chrono::time_point<steady_clock> program_start = steady_clock::now();
+
+	//Load program here since it is dependent on vertex state
+	load_program();
+
+	std::chrono::time_point<steady_clock> program_stop = steady_clock::now();
+	m_setup_time += (u32)std::chrono::duration_cast<std::chrono::microseconds>(program_stop - program_start).count();
 
 	std::chrono::time_point<steady_clock> textures_start = steady_clock::now();
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -889,7 +889,7 @@ void VKGSRender::clear_surface(u32 mask)
 	{
 		u32 max_depth_value = get_max_depth_value(surface_depth_format);
 
-		u32 clear_depth = rsx::method_registers.z_clear_value();
+		u32 clear_depth = rsx::method_registers.z_clear_value(surface_depth_format == rsx::surface_depth_format::z24s8);
 		float depth_clear = (float)clear_depth / max_depth_value;
 
 		depth_stencil_clear_values.depthStencil.depth = depth_clear;

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -64,7 +64,7 @@ namespace vk
 				}
 			}
 
-			fmt::throw_exception("texture not found" HERE);
+			LOG_NOTICE(RSX, "texture not found in program: %s", uniform_name.c_str());
 		}
 
 		void program::bind_uniform(VkDescriptorBufferInfo buffer_descriptor, uint32_t binding_point, VkDescriptorSet &descriptor_set)
@@ -100,7 +100,8 @@ namespace vk
 					return;
 				}
 			}
-			fmt::throw_exception("vertex buffer not found" HERE);
+			
+			LOG_NOTICE(RSX, "vertex buffer not found in program: %s", binding_name.c_str());
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -375,7 +375,7 @@ namespace
 			u32 min_index =
 				rsx::method_registers.current_draw_clause.first_count_commands.front().first;
 			u32 max_index =
-				rsx::method_registers.current_draw_clause.get_elements_count() + min_index;
+				rsx::method_registers.current_draw_clause.get_elements_count() + min_index - 1;
 
 			if (primitives_emulated) {
 				std::tie(index_count, index_info) =

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3410,7 +3410,8 @@ struct registers_decoder<NV4097_SET_ZSTENCIL_CLEAR_VALUE>
 		union
 		{
 			u32 raw_value;
-			bitfield_decoder_t<8, 24> clear_z;
+			bitfield_decoder_t<0, 16> clear_z16;
+			bitfield_decoder_t<8, 24> clear_z24;
 			bitfield_decoder_t<0, 8> clear_stencil;
 		} m_data;
 	public:
@@ -3421,15 +3422,19 @@ struct registers_decoder<NV4097_SET_ZSTENCIL_CLEAR_VALUE>
 			return m_data.clear_stencil;
 		}
 
-		u32 clear_z() const
+		u32 clear_z(bool is_depth_stencil) const
 		{
-			return m_data.clear_z;
+			if (is_depth_stencil)
+				return m_data.clear_z24;
+			
+			return m_data.clear_z16;
 		}
 	};
 
 	static std::string dump(decoded_type &&decoded_values)
 	{
-		return "Clear: Z = " + std::to_string(decoded_values.clear_z()) +
+		return "Clear: Z24 = " + std::to_string(decoded_values.clear_z(true)) +
+			" z16 = " + std::to_string(decoded_values.clear_z(false)) +
 			" Stencil = " + std::to_string(decoded_values.clear_stencil());
 	}
 };

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -116,12 +116,14 @@ namespace rsx
 			static const size_t attribute_index = index / increment_per_array_index;
 			static const size_t vertex_subreg = index % increment_per_array_index;
 
+			const auto vtype = vertex_data_type_from_element_type<type>::type;
+
 			if (rsx->in_begin_end)
-				rsx->append_to_push_buffer(attribute_index, count, vertex_subreg, arg);
+				rsx->append_to_push_buffer(attribute_index, count, vertex_subreg, vtype, arg);
 
 			auto& info = rsx::method_registers.register_vertex_info[attribute_index];
 
-			info.type = vertex_data_type_from_element_type<type>::type;
+			info.type = vtype;
 			info.size = count;
 			info.frequency = 0;
 			info.stride = 0;
@@ -187,6 +189,16 @@ namespace rsx
 		{
 			static void impl(thread* rsx, u32 _reg, u32 arg)
 			{
+				set_vertex_data_impl<NV4097_SET_VERTEX_DATA4S_M, index, 4, u16>(rsx, arg);
+			}
+		};
+
+		template<u32 index>
+		struct set_vertex_data_scaled4s_m
+		{
+			static void impl(thread* rsx, u32 _reg, u32 arg)
+			{
+				LOG_ERROR(RSX, "SCALED_4S vertex data format is not properly implemented");
 				set_vertex_data_impl<NV4097_SET_VERTEX_DATA4S_M, index, 4, u16>(rsx, arg);
 			}
 		};
@@ -1278,6 +1290,7 @@ namespace rsx
 		bind<NV4097_DRAW_ARRAYS, nv4097::draw_arrays>();
 		bind<NV4097_DRAW_INDEX_ARRAY, nv4097::draw_index_array>();
 		bind<NV4097_INLINE_ARRAY, nv4097::draw_inline_array>();
+		bind_range<NV4097_SET_VERTEX_DATA_SCALED4S_M, 1, 32, nv4097::set_vertex_data_scaled4s_m>();
 		bind_range<NV4097_SET_VERTEX_DATA4UB_M, 1, 16, nv4097::set_vertex_data4ub_m>();
 		bind_range<NV4097_SET_VERTEX_DATA1F_M, 1, 16, nv4097::set_vertex_data1f_m>();
 		bind_range<NV4097_SET_VERTEX_DATA2F_M, 1, 32, nv4097::set_vertex_data2f_m>();

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -287,9 +287,9 @@ namespace rsx
 			return decode<NV4097_SET_RESTART_INDEX>().restart_index();
 		}
 
-		u32 z_clear_value() const
+		u32 z_clear_value(bool is_depth_stencil) const
 		{
-			return decode<NV4097_SET_ZSTENCIL_CLEAR_VALUE>().clear_z();
+			return decode<NV4097_SET_ZSTENCIL_CLEAR_VALUE>().clear_z(is_depth_stencil);
 		}
 
 		u8 stencil_clear_value() const

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -153,12 +153,13 @@ namespace rsx
 
 		/**
 		* RSX can sources vertex attributes from 2 places:
-		* - Immediate values passed by NV4097_SET_VERTEX_DATA*_M + ARRAY_ID write.
+		* 1. Immediate values passed by NV4097_SET_VERTEX_DATA*_M + ARRAY_ID write.
 		* For a given ARRAY_ID the last command of this type defines the actual type of the immediate value.
-		* Since there can be only a single value per ARRAY_ID passed this way, all vertex in the draw call
+		* If there is only a single value on an ARRAY_ID passed this way, all vertex in the draw call
 		* shares it.
-		* - Vertex array values passed by offset/stride/size/format description.
+		* Immediate mode rendering uses this method as well to upload vertex data.
 		*
+		* 2. Vertex array values passed by offset/stride/size/format description.
 		* A given ARRAY_ID can have both an immediate value and a vertex array enabled at the same time
 		* (See After Burner Climax intro cutscene). In such case the vertex array has precedence over the
 		* immediate value. As soon as the vertex array is disabled (size set to 0) the immediate value

--- a/rpcs3/Emu/RSX/rsx_vertex_data.h
+++ b/rpcs3/Emu/RSX/rsx_vertex_data.h
@@ -2,6 +2,7 @@
 
 #include "GCM.h"
 #include "Utilities/types.h"
+#include "Utilities/BEType.h"
 
 namespace rsx
 {
@@ -54,6 +55,39 @@ public:
 	void reset()
 	{
 		registers[NV4097_SET_VERTEX_DATA_ARRAY_FORMAT + index] = 0x2;
+	}
+};
+
+struct push_buffer_vertex_info
+{
+	u8 size;
+	vertex_base_type type;
+
+	u32 vertex_count = 0;
+	u32 attribute_mask = ~0;
+	std::vector<u32> data;
+
+	void clear()
+	{
+		data.resize(0);
+		attribute_mask = ~0;
+		vertex_count = 0;
+	}
+
+	void append_vertex_data(u32 sub_index, u32 arg)
+	{
+		const u32 element_mask = (1 << sub_index);
+		if (attribute_mask & element_mask)
+		{
+			attribute_mask = 0;
+
+			vertex_count++;
+			data.resize(vertex_count * size);
+		}
+
+		attribute_mask |= element_mask;
+		u32* dst = data.data() + ((vertex_count - 1) * size) + sub_index;
+		*dst = se_storage<u32>::swap(arg);
 	}
 };
 


### PR DESCRIPTION
Adds in support for immediate mode rendering between begin/end command pairs
Fixes missing draw calls in most homebew games
Tested games
- Sketch fight
- Hero city
- Super pixel jumper
- Dont get crushed

Also fixes gsl::span errors with vulkan as well as not throwing an exception if an attribute/texture is enabled, but not active in the shader.