### PR TITLE
gl: Fix legacy clamp mode

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -238,7 +238,7 @@ namespace rsx
 			case rsx::texture_wrap_mode::mirror: return GL_MIRRORED_REPEAT;
 			case rsx::texture_wrap_mode::clamp_to_edge: return GL_CLAMP_TO_EDGE;
 			case rsx::texture_wrap_mode::border: return GL_CLAMP_TO_BORDER;
-			case rsx::texture_wrap_mode::clamp: return GL_CLAMP_TO_BORDER;
+			case rsx::texture_wrap_mode::clamp: return GL_CLAMP_TO_EDGE;
 			case rsx::texture_wrap_mode::mirror_once_clamp_to_edge: return GL_MIRROR_CLAMP_TO_EDGE_EXT;
 			case rsx::texture_wrap_mode::mirror_once_border: return GL_MIRROR_CLAMP_TO_BORDER_EXT;
 			case rsx::texture_wrap_mode::mirror_once_clamp: return GL_MIRROR_CLAMP_EXT;


### PR DESCRIPTION
The meaning of texture border has changed starting with GL 3+ due to the resulting confusion from broken and incomplete implementations on hardware of the GL 1.x era. As such, legacy clamp is closer to the modern edge clamp than border clamp as it once was.

Border pixels in textures are not supported on newer hardware and never truly worked in the past either, especially on NV cards.

Should hopefully fix any games showing visible grid lines in OpenGL