### PR TITLE
Only pass absolute values to sqrt and log2 in the fragment program.

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -173,7 +173,7 @@ std::string FragmentProgramDecompiler::NotZero(const std::string& code)
 
 std::string FragmentProgramDecompiler::NotZeroPositive(const std::string& code)
 {
-	return "max(" + code + ", 1.E-10)";
+	return "max(abs(" + code + "), 1.E-10)";
 }
 
 std::string FragmentProgramDecompiler::NoOverflow(const std::string& code)


### PR DESCRIPTION
I assume that the intention of the exisiting code was to do exactly what the title says. But it also replaced all negative input values with the "not 0" value. Now negative values are allowed but inverted.

Existing code caused some pixels to have saturated color components (brightly colored spots of one pure color) in Metro Last Light:
![mll](https://cloud.githubusercontent.com/assets/1445782/24587445/f6f4673c-17b6-11e7-9a62-9bc267d09e56.png)


Maybe this is also what causes the colored spots in Resident Evil 5. I cannot verify because I don't have the game.