### PR TITLE
rsx/vk: Re-enable layout transitions in vulkan, Other minor fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -304,8 +304,8 @@ void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst,
 	{
 	case rsx::primitive_type::line_loop:
 		for (unsigned i = 0; i < count; ++i)
-			dst[i] = i;
-		dst[count] = 0;
+			typedDst[i] = i;
+		typedDst[count] = 0;
 		return;
 	case rsx::primitive_type::triangle_fan:
 	case rsx::primitive_type::polygon:

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -12,6 +12,7 @@ namespace vk
 	struct render_target : public image
 	{
 		u16 native_pitch = 0;
+		VkImageAspectFlags attachment_aspect_flag = VK_IMAGE_ASPECT_COLOR_BIT;
 
 		render_target(vk::render_device &dev,
 			uint32_t memory_type_index,
@@ -110,27 +111,33 @@ namespace rsx
 			if (format == rsx::surface_depth_format::z24s8)
 				ds->native_pitch *= 2;
 
+			ds->attachment_aspect_flag = range.aspectMask;
+
 			return ds;
 		}
 
 		static void prepare_rtt_for_drawing(vk::command_buffer* pcmd, vk::render_target *surface)
 		{
-//			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+			VkImageSubresourceRange range = vk::get_image_subresource_range(0, 0, 1, 1, surface->attachment_aspect_flag);
+			change_image_layout(*pcmd, surface->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, range);
 		}
 
 		static void prepare_rtt_for_sampling(vk::command_buffer* pcmd, vk::render_target *surface)
 		{
-//			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+			VkImageSubresourceRange range = vk::get_image_subresource_range(0, 0, 1, 1, surface->attachment_aspect_flag);
+			change_image_layout(*pcmd, surface->value, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, range);
 		}
 
 		static void prepare_ds_for_drawing(vk::command_buffer* pcmd, vk::render_target *surface)
 		{
-//			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+			VkImageSubresourceRange range = vk::get_image_subresource_range(0, 0, 1, 1, surface->attachment_aspect_flag);
+			change_image_layout(*pcmd, surface->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, range);
 		}
 
 		static void prepare_ds_for_sampling(vk::command_buffer* pcmd, vk::render_target *surface)
 		{
-//			surface->change_layout(*pcmd, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+			VkImageSubresourceRange range = vk::get_image_subresource_range(0, 0, 1, 1, surface->attachment_aspect_flag);
+			change_image_layout(*pcmd, surface->value, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, range);
 		}
 
 		static bool rtt_has_format_width_height(const std::unique_ptr<vk::render_target> &rtt, surface_color_format format, size_t width, size_t height)

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -1001,7 +1001,7 @@ enum
 	NV3089_IMAGE_IN = 0x0000C40C >> 2,
 
 	//lv1 hypervisor commands
-	GCM_SET_DRIVER_OBJECT = 0x0000E0000 >> 2,
+	GCM_SET_DRIVER_OBJECT = 0x0000E000 >> 2,
 	GCM_FLIP_HEAD = 0X0000E920 >> 2,          //0xE920:0xE924: Flip head 0 or 1
 	GCM_DRIVER_QUEUE = 0X0000E940 >> 2,       //0XE940:0xE95C: First two indices prepare display buffers, rest unknown
 	GCM_SET_USER_COMMAND = 0x0000EB00 >> 2,   //0xEB00:0xEB04: User interrupt


### PR DESCRIPTION
Image layout transitions were disabled at some point during code refactoring. The impact on Nvidia drivers is not too bad, but horrible moire artefacts appear on AMD, especially newer cards.

Also includes a fix for https://github.com/RPCS3/rpcs3/issues/2628

Added a fix for LINE_LOOP rendering using vulkan (fixes Tetris).
NOTE: DX12 removed the LINE_LIST topology from D3D11 meaning DX12 does not support line_strip or line_loop. Line rendering with DX12 will have to use a different path than the others.