### PR TITLE
Precise SPU intepreter: Fix isdenormal() on Windows

### DIFF
--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -1372,22 +1372,12 @@ inline float ldexpf_extended(float x, int exp)  // ldexpf() for extended values,
 
 inline bool isdenormal(float x)
 {
-	const int fpc = std::fpclassify(x);
-#ifdef __GNUG__
-	return fpc == FP_SUBNORMAL;
-#else
-	return (fpc & (_FPCLASS_PD | _FPCLASS_ND)) != 0;
-#endif
+	return std::fpclassify(x) == FP_SUBNORMAL;
 }
 
 inline bool isdenormal(double x)
 {
-	const int fpc = std::fpclassify(x);
-#ifdef __GNUG__
-	return fpc == FP_SUBNORMAL;
-#else
-	return (fpc & (_FPCLASS_PD | _FPCLASS_ND)) != 0;
-#endif
+	return std::fpclassify(x) == FP_SUBNORMAL;
 }
 
 void spu_interpreter_precise::FREST(SPUThread& spu, spu_opcode_t op)


### PR DESCRIPTION
On MS VC the isdenormal() function in the PSU interpreter is broken because it always returns true (value for "normal" is -1, so the bitcheck always evaluates true). I don't know what kind of compiler needs the #else path, so I just extended the #ifdef.

Observable improvements fromt this are: Wolfenstein goes ingame without destroying the physics objects and the Trine Demo has working collision/physics and plays sound (before the precise interpreter would play no sound but go ingame with broken collision and the fast interprester plays sound but crashes before going ingame).