### PR TITLE
GL: fix wireframe in Catherine

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -283,8 +283,6 @@ void GLGSRender::begin()
 
 	__glcheck glFrontFace(front_face(rsx::method_registers.front_face_mode()));
 
-	__glcheck enable(rsx::method_registers.poly_smooth_enabled(), GL_POLYGON_SMOOTH);
-
 	//NV4097_SET_COLOR_KEY_COLOR
 	//NV4097_SET_SHADER_CONTROL
 	//NV4097_SET_ZMIN_MAX_CONTROL


### PR DESCRIPTION
I don't think we need this obsolete function that do the anti-aliasing.

fix https://github.com/RPCS3/rpcs3/issues/2241