### PR TITLE
spu: Check exponent bits in FMA ops

### DIFF
--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -1297,17 +1297,50 @@ void spu_interpreter::MPYA(SPUThread& spu, spu_opcode_t op)
 
 void spu_interpreter_fast::FNMS(SPUThread& spu, spu_opcode_t op)
 {
-	spu.gpr[op.rt4].vf = _mm_sub_ps(spu.gpr[op.rc].vf, _mm_mul_ps(spu.gpr[op.ra].vf, spu.gpr[op.rb].vf));
+	const u32 test_bits = 0x7f800000;
+	auto mask = _mm_set1_ps((f32&)test_bits);
+
+	auto test_a = _mm_and_ps(spu.gpr[op.ra].vf, mask);
+	auto mask_a = _mm_cmpneq_ps(test_a, mask);
+	auto test_b = _mm_and_ps(spu.gpr[op.rb].vf, mask);
+	auto mask_b = _mm_cmpneq_ps(test_b, mask);
+
+	auto a = _mm_and_ps(spu.gpr[op.ra].vf, mask_a);
+	auto b = _mm_and_ps(spu.gpr[op.rb].vf, mask_b);
+
+	spu.gpr[op.rt4].vf = _mm_sub_ps(spu.gpr[op.rc].vf, _mm_mul_ps(a, b));
 }
 
 void spu_interpreter_fast::FMA(SPUThread& spu, spu_opcode_t op)
 {
-	spu.gpr[op.rt4].vf = _mm_add_ps(_mm_mul_ps(spu.gpr[op.ra].vf, spu.gpr[op.rb].vf), spu.gpr[op.rc].vf);
+	const u32 test_bits = 0x7f800000;
+	auto mask = _mm_set1_ps((f32&)test_bits);
+
+	auto test_a = _mm_and_ps(spu.gpr[op.ra].vf, mask);
+	auto mask_a = _mm_cmpneq_ps(test_a, mask);
+	auto test_b = _mm_and_ps(spu.gpr[op.rb].vf, mask);
+	auto mask_b = _mm_cmpneq_ps(test_b, mask);
+
+	auto a = _mm_and_ps(spu.gpr[op.ra].vf, mask_a);
+	auto b = _mm_and_ps(spu.gpr[op.rb].vf, mask_b);
+
+	spu.gpr[op.rt4].vf = _mm_add_ps(_mm_mul_ps(a, b), spu.gpr[op.rc].vf);
 }
 
 void spu_interpreter_fast::FMS(SPUThread& spu, spu_opcode_t op)
 {
-	spu.gpr[op.rt4].vf = _mm_sub_ps(_mm_mul_ps(spu.gpr[op.ra].vf, spu.gpr[op.rb].vf), spu.gpr[op.rc].vf);
+	const u32 test_bits = 0x7f800000;
+	auto mask = _mm_set1_ps((f32&)test_bits);
+
+	auto test_a = _mm_and_ps(spu.gpr[op.ra].vf, mask);
+	auto mask_a = _mm_cmpneq_ps(test_a, mask);
+	auto test_b = _mm_and_ps(spu.gpr[op.rb].vf, mask);
+	auto mask_b = _mm_cmpneq_ps(test_b, mask);
+
+	auto a = _mm_and_ps(spu.gpr[op.ra].vf, mask_a);
+	auto b = _mm_and_ps(spu.gpr[op.rb].vf, mask_b);
+
+	spu.gpr[op.rt4].vf = _mm_sub_ps(_mm_mul_ps(a, b), spu.gpr[op.rc].vf);
 }
 
 static void SetHostRoundingMode(u32 rn)


### PR DESCRIPTION
This PR modifies the result of SPU FMA if exponents in a or b are at max and discards the value. This is by no means even close to accurate handling of corner cases in the SPU, but rather a fast workaround.
Discards the result of (a * b) if either a or b has extended exp bits (usually inf) without degrading performance too much.
Should fix some cases reported in https://github.com/RPCS3/rpcs3/issues/2670
