### PR TITLE
Update sys_ss.h

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_ss.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.h
@@ -11,3 +11,4 @@ struct CellSsOpenPSID
 
 s32 sys_ss_get_console_id(vm::ps3::ptr<u8> buf);
 s32 sys_ss_get_open_psid(vm::ps3::ptr<CellSsOpenPSID> ptr);
+s32 sys_ss_get_open_psid(vm::_ptr_base<CellSsOpenPSID, unsigned int>);


### PR DESCRIPTION
Hot-Fix for linux build

Got this error:
```
CMakeFiles/rpcs3.dir/Emu/Cell/lv2/lv2.cpp.o: In Funktion {lambda(ppu_thread&)#230}::_FUN(ppu_thread&)':
lv2.cpp:(.text+0xdf): Nicht definierter Verweis aufsys_ss_get_open_psid(vm::_ptr_base<CellSsOpenPSID, unsigned int>)'
CMakeFiles/rpcs3.dir/Emu/Cell/lv2/lv2.cpp.o: In Funktion {lambda(ppu_thread&)#229}::_FUN(ppu_thread&)':
lv2.cpp:(.text+0x12f): Nicht definierter Verweis aufsys_ss_get_console_id(vm::_ptr_base<unsigned char, unsigned int>)'
collect2: error: ld returned 1 exit status
rpcs3/CMakeFiles/rpcs3.dir/build.make:11323: die Regel für Ziel „bin/rpcs3“ scheiterte
make[2]:  [bin/rpcs3] Fehler 1
CMakeFiles/Makefile2:233: die Regel für Ziel „rpcs3/CMakeFiles/rpcs3.dir/all“ scheiterte
make[1]:  [rpcs3/CMakeFiles/rpcs3.dir/all] Fehler 2
Makefile:127: die Regel für Ziel „all“ scheiterte
make: *** [all] Fehler 2
```