### PR TITLE
Avoid a segfault if the GPU is not fully supported

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -647,11 +647,11 @@ void GLGSRender::on_exit()
 		sampler.remove();
 	}
 
-	m_attrib_ring_buffer->remove();
-	m_transform_constants_buffer->remove();
-	m_fragment_constants_buffer->remove();
-	m_scale_offset_buffer->remove();
-	m_index_ring_buffer->remove();
+	if (m_attrib_ring_buffer) m_attrib_ring_buffer->remove();
+	if (m_transform_constants_buffer) m_transform_constants_buffer->remove();
+	if (m_fragment_constants_buffer) m_fragment_constants_buffer->remove();
+	if (m_scale_offset_buffer) m_scale_offset_buffer->remove();
+	if (m_index_ring_buffer) m_index_ring_buffer->remove();
 
 	m_text_printer.close();
 	m_gl_texture_cache.close();


### PR DESCRIPTION
Before this, if the GPU setup `GLGSRender.cpp` failed, `on_exit` would crash because nothing was ever fully initialized. Nobody would be able to see that something was unsupported (unless you viewed the log); it would just flat-out crash.