### PR TITLE
Fix crash on linux when opening the settings dialog in debug mode

### DIFF
--- a/rpcs3/Gui/SettingsDialog.cpp
+++ b/rpcs3/Gui/SettingsDialog.cpp
@@ -440,12 +440,14 @@ SettingsDialog::SettingsDialog(wxWindow* parent, const std::string& path)
 		pads.emplace_back(std::make_unique<combobox_pad>(cfg_location{ "Video", "D3D12", "Adapter" }, cbox_gs_d3d_adapter));
 	}
 	else
-#endif
 	{
 		// Removes D3D12 from Render list when the system doesn't support it
 		cbox_gs_render->Delete(cbox_gs_render->FindString("D3D12"));
 		cbox_gs_d3d_adapter->Enable(false);
 	}
+#else
+	cbox_gs_d3d_adapter->Enable(false);
+#endif
 
 	// Core
 	s_round_core_lle->Add(chbox_list_core_lle, wxSizerFlags().Border(wxALL, 5).Expand());


### PR DESCRIPTION
D3D12 is not in the list of supported renderers on platforms other than windows.
Deleting an item, that can't be found, triggers an assert in debug builds, so let's
avoid that.

Fix #2662