### PR TITLE
lib_loader_mode set to automatic

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -128,7 +128,7 @@ enum class lib_loader_mode
 	liblv2only
 };
 
-cfg::map_entry<lib_loader_mode> g_cfg_lib_loader(cfg::root.core, "Lib Loader", 3,
+cfg::map_entry<lib_loader_mode> g_cfg_lib_loader(cfg::root.core, "Lib Loader", 0,
 {
 	{ "Automatically load required libraries", lib_loader_mode::automatic },
 	{ "Manually load selected libraries", lib_loader_mode::manual },


### PR DESCRIPTION
Some person used liblv2 mode to get error at first using rpcs3 and not understood change the loading mode.