### PR TITLE
vulkan/cell: Implement synchronized buffers for vulkan; SPU speed hacks

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1750,6 +1750,7 @@ void named_thread::start_thread(const std::shared_ptr<void>& _this)
 		try
 		{
 			LOG_TRACE(GENERAL, "Thread started");
+			on_spawn();
 			on_task();
 			LOG_TRACE(GENERAL, "Thread ended");
 		}

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -258,6 +258,9 @@ protected:
 	// Thread finalization (called after on_task)
 	virtual void on_exit() {}
 
+	// Called once upon thread spawn within the thread's own context
+	virtual void on_spawn() {}
+
 public:
 	// ID initialization
 	virtual void on_init(const std::shared_ptr<void>& _this)

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -4,6 +4,11 @@
 #include "CPUThread.h"
 #include "Emu/IdManager.h"
 #include "Utilities/GDBDebugServer.h"
+#include "Utilities/Config.h"
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif
 
 DECLARE(cpu_thread::g_threads_created){0};
 DECLARE(cpu_thread::g_threads_deleted){0};
@@ -177,4 +182,35 @@ void cpu_thread::run()
 std::string cpu_thread::dump() const
 {
 	return fmt::format("Type: %s\n" "State: %s\n", typeid(*this).name(), state.load());
+}
+
+void cpu_thread::set_native_priority(int priority)
+{
+#ifdef _WIN32
+	HANDLE _this_thread = GetCurrentThread();
+	INT native_priority = THREAD_PRIORITY_NORMAL;
+
+	switch (priority)
+	{
+	default:
+	case 0:
+		break;
+	case 1:
+		native_priority = THREAD_PRIORITY_ABOVE_NORMAL;
+		break;
+	case -1:
+		native_priority = THREAD_PRIORITY_BELOW_NORMAL;
+		break;
+	}
+
+	SetThreadPriority(_this_thread, native_priority);
+#endif // _WIN32
+}
+
+void cpu_thread::set_ideal_processor_core(int core)
+{
+#ifdef _WIN32
+	HANDLE _this_thread = GetCurrentThread();
+	SetThreadIdealProcessor(_this_thread, core);
+#endif
 }

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -65,6 +65,10 @@ public:
 
 	// Callback for cpu_flag::suspend
 	virtual void cpu_sleep() {}
+
+	//native scheduler tweaks
+	void set_native_priority(int priority);
+	void set_ideal_processor_core(int core);
 };
 
 inline cpu_thread* get_current_cpu_thread() noexcept

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -504,6 +504,7 @@ public:
 class SPUThread : public cpu_thread
 {
 public:
+	virtual void on_spawn() override;
 	virtual void on_init(const std::shared_ptr<void>&) override;
 	virtual std::string get_name() const override;
 	virtual std::string dump() const override;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -9,6 +9,7 @@
 #include "define_new_memleakdetect.h"
 #include "GLProgramBuffer.h"
 #include "GLTextOut.h"
+#include "../rsx_utils.h"
 #include "../rsx_cache.h"
 
 #pragma comment(lib, "opengl32.lib")
@@ -24,30 +25,6 @@ struct work_item
 	volatile bool processed = false;
 	volatile bool result = false;
 	volatile bool received = false;
-};
-
-struct gcm_buffer_info
-{
-	u32 address = 0;
-	u32 pitch = 0;
-
-	bool is_depth_surface;
-
-	rsx::surface_color_format color_format;
-	rsx::surface_depth_format depth_format;
-
-	u16 width;
-	u16 height;
-
-	gcm_buffer_info()
-	{
-		address = 0;
-		pitch = 0;
-	}
-
-	gcm_buffer_info(const u32 address_, const u32 pitch_, bool is_depth_, const rsx::surface_color_format fmt_, const rsx::surface_depth_format dfmt_, const u16 w, const u16 h)
-		:address(address_), pitch(pitch_), is_depth_surface(is_depth_), color_format(fmt_), depth_format(dfmt_), width(w), height(h)
-	{}
 };
 
 class GLGSRender : public GSRender
@@ -93,8 +70,8 @@ private:
 	std::mutex queue_guard;
 	std::list<work_item> work_queue;
 
-	gcm_buffer_info surface_info[rsx::limits::color_buffers_count];
-	gcm_buffer_info depth_surface_info;
+	rsx::gcm_framebuffer_info surface_info[rsx::limits::color_buffers_count];
+	rsx::gcm_framebuffer_info depth_surface_info;
 
 	bool flush_draw_buffers = false;
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -28,7 +28,7 @@ cfg::bool_entry g_cfg_rsx_vsync(cfg::root.video, "VSync");
 cfg::bool_entry g_cfg_rsx_debug_output(cfg::root.video, "Debug output");
 cfg::bool_entry g_cfg_rsx_overlay(cfg::root.video, "Debug overlay");
 cfg::bool_entry g_cfg_rsx_gl_legacy_buffers(cfg::root.video, "Use Legacy OpenGL Buffers (Debug)");
-cfg::bool_entry g_cfg_rsx_use_gpu_texture_scaling(cfg::root.video, "Use GPU texture scaling");
+cfg::bool_entry g_cfg_rsx_use_gpu_texture_scaling(cfg::root.video, "Use GPU texture scaling", true);
 
 bool user_asked_for_frame_capture = false;
 rsx::frame_capture_data frame_debug;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -676,9 +676,7 @@ void VKGSRender::begin()
 	{
 		std::chrono::time_point<steady_clock> submit_start = steady_clock::now();
 
-		//??Should we wait for the queue to actually render to the GPU? or just flush the queue?
-		//Needs investigation to determine what drivers expect here, bottom_of_pipe is guaranteed to work, but will be too slow
-		close_and_submit_command_buffer({}, m_submit_fence, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+		close_and_submit_command_buffer({}, m_submit_fence);
 		CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
 
 		vkResetDescriptorPool(*m_device, descriptor_pool, 0);
@@ -1057,7 +1055,7 @@ void VKGSRender::copy_render_targets_to_dma_location()
 		}
 	}
 
-	close_and_submit_command_buffer({}, m_submit_fence, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+	close_and_submit_command_buffer({}, m_submit_fence);
 	CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
 
 	CHECK_RESULT(vkResetFences(*m_device, 1, &m_submit_fence));
@@ -1069,7 +1067,7 @@ void VKGSRender::do_local_task()
 {
 	if (m_flush_commands)
 	{
-		close_and_submit_command_buffer({}, m_submit_fence, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+		close_and_submit_command_buffer({}, m_submit_fence);
 		CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
 
 		CHECK_RESULT(vkResetFences(*m_device, 1, &m_submit_fence));

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -493,6 +493,11 @@ VKGSRender::VKGSRender() : GSRender(frame_type::Vulkan)
 	//create command buffer...
 	m_command_buffer_pool.create((*m_device));
 	m_command_buffer.create(m_command_buffer_pool);
+	
+	//Create secondar command_buffer for parallel operations
+	m_secondary_command_buffer_pool.create((*m_device));
+	m_secondary_command_buffer.create(m_secondary_command_buffer_pool);
+	
 	open_command_buffer();
 
 	for (u32 i = 0; i < m_swap_chain->get_swap_image_count(); ++i)
@@ -620,6 +625,9 @@ VKGSRender::~VKGSRender()
 	m_command_buffer.destroy();
 	m_command_buffer_pool.destroy();
 
+	m_secondary_command_buffer.destroy();
+	m_secondary_command_buffer_pool.destroy();
+
 	//Device handles/contexts
 	m_swap_chain->destroy();
 	m_thread_context.close();
@@ -632,7 +640,29 @@ bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 	if (is_writing)
 		return m_texture_cache.invalidate_address(address);
 	else
-		return m_texture_cache.flush_address(address, *m_device, m_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+	{
+		if (!m_texture_cache.address_is_flushable(address))
+			return false;
+
+		if (std::this_thread::get_id() != rsx_thread)
+		{
+			//TODO: Guard this when the renderer is flushing the command queue, might deadlock otherwise
+			m_flush_commands = true;
+			m_queued_threads++;
+
+			//This is awful!
+			while (m_flush_commands);
+
+			std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
+			bool status = m_texture_cache.flush_address(address, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+
+			m_queued_threads--;
+			return status;
+		}
+
+		std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
+		return m_texture_cache.flush_address(address, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+	}
 
 	return false;
 }
@@ -646,7 +676,9 @@ void VKGSRender::begin()
 	{
 		std::chrono::time_point<steady_clock> submit_start = steady_clock::now();
 
-		close_and_submit_command_buffer({}, m_submit_fence);
+		//??Should we wait for the queue to actually render to the GPU? or just flush the queue?
+		//Needs investigation to determine what drivers expect here, bottom_of_pipe is guaranteed to work, but will be too slow
+		close_and_submit_command_buffer({}, m_submit_fence, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
 		CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
 
 		vkResetDescriptorPool(*m_device, descriptor_pool, 0);
@@ -833,9 +865,9 @@ void VKGSRender::end()
 	std::chrono::time_point<steady_clock> draw_end = steady_clock::now();
 	m_draw_time += std::chrono::duration_cast<std::chrono::microseconds>(draw_end - vertex_end).count();
 
-	rsx::thread::end();
-
 	copy_render_targets_to_dma_location();
+
+	rsx::thread::end();
 }
 
 void VKGSRender::set_viewport()
@@ -875,6 +907,8 @@ void VKGSRender::on_init_thread()
 	GSRender::on_init_thread();
 	m_attrib_ring_info.init(8 * RING_BUFFER_SIZE);
 	m_attrib_ring_info.heap.reset(new vk::buffer(*m_device, 8 * RING_BUFFER_SIZE, m_memory_type_mapping.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, 0));
+
+	rsx_thread = std::this_thread::get_id();
 }
 
 void VKGSRender::on_exit()
@@ -987,13 +1021,6 @@ void VKGSRender::clear_surface(u32 mask)
 
 void VKGSRender::sync_at_semaphore_release()
 {
-	close_and_submit_command_buffer({}, m_submit_fence);
-	CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
-
-	CHECK_RESULT(vkResetFences(*m_device, 1, &m_submit_fence));
-	CHECK_RESULT(vkResetCommandPool(*m_device, m_command_buffer_pool, 0));
-	open_command_buffer();
-
 	m_flush_draw_buffers = true;
 }
 
@@ -1001,6 +1028,13 @@ void VKGSRender::copy_render_targets_to_dma_location()
 {
 	if (!m_flush_draw_buffers)
 		return;
+
+	if (!g_cfg_rsx_write_color_buffers && !g_cfg_rsx_write_depth_buffer)
+		return;
+
+	//TODO: Make this asynchronous. Should be similar to a glFlush() but in this case its similar to glFinish
+	//This is due to all the hard waits for fences
+	//TODO: Use a command buffer array to allow explicit draw command tracking
 
 	if (g_cfg_rsx_write_color_buffers)
 	{
@@ -1023,7 +1057,28 @@ void VKGSRender::copy_render_targets_to_dma_location()
 		}
 	}
 
-	m_flush_draw_buffers = false;
+	close_and_submit_command_buffer({}, m_submit_fence, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+	CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
+
+	CHECK_RESULT(vkResetFences(*m_device, 1, &m_submit_fence));
+	CHECK_RESULT(vkResetCommandPool(*m_device, m_command_buffer_pool, 0));
+	open_command_buffer();
+}
+
+void VKGSRender::do_local_task()
+{
+	if (m_flush_commands)
+	{
+		close_and_submit_command_buffer({}, m_submit_fence, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+		CHECK_RESULT(vkWaitForFences((*m_device), 1, &m_submit_fence, VK_TRUE, ~0ULL));
+
+		CHECK_RESULT(vkResetFences(*m_device, 1, &m_submit_fence));
+		CHECK_RESULT(vkResetCommandPool(*m_device, m_command_buffer_pool, 0));
+		open_command_buffer();
+
+		m_flush_commands = false;
+		while (m_queued_threads);
+	}
 }
 
 bool VKGSRender::do_method(u32 cmd, u32 arg)
@@ -1294,17 +1349,16 @@ void VKGSRender::write_buffers()
 {
 }
 
-void VKGSRender::close_and_submit_command_buffer(const std::vector<VkSemaphore> &semaphores, VkFence fence)
+void VKGSRender::close_and_submit_command_buffer(const std::vector<VkSemaphore> &semaphores, VkFence fence, VkPipelineStageFlags pipeline_stage_flags)
 {
 	CHECK_RESULT(vkEndCommandBuffer(m_command_buffer));
 
-	VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
 	VkCommandBuffer cmd = m_command_buffer;
 
 	VkSubmitInfo infos = {};
 	infos.commandBufferCount = 1;
 	infos.pCommandBuffers = &cmd;
-	infos.pWaitDstStageMask = &pipe_stage_flags;
+	infos.pWaitDstStageMask = &pipeline_stage_flags;
 	infos.pWaitSemaphores = semaphores.data();
 	infos.waitSemaphoreCount = static_cast<uint32_t>(semaphores.size());
 	infos.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -644,49 +644,57 @@ bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 		return m_texture_cache.invalidate_address(address);
 	else
 	{
-		bool flushable, synchronized;
-		
-		std::tie(flushable, synchronized) = m_texture_cache.address_is_flushable(address);
-		if (!flushable)
-			return false;
-
-		if (synchronized)
+		if (g_cfg_rsx_write_color_buffers || g_cfg_rsx_write_depth_buffer)
 		{
-			if (m_last_flushable_cb >= 0)
+			bool flushable, synchronized;
+			std::tie(flushable, synchronized) = m_texture_cache.address_is_flushable(address);
+			
+			if (!flushable)
+				return false;
+
+			if (synchronized)
 			{
-				if (m_primary_cb_list[m_last_flushable_cb].pending)
-					m_primary_cb_list[m_last_flushable_cb].wait();
-			}
+				if (m_last_flushable_cb >= 0)
+				{
+					if (m_primary_cb_list[m_last_flushable_cb].pending)
+						m_primary_cb_list[m_last_flushable_cb].wait();
+				}
 
-			m_last_flushable_cb = -1;
-		}
-		else
-		{
-			//This region is buffered, but no previous sync point has been put in place to start sync efforts
-			//Just stall and get what we have at this point
-			if (std::this_thread::get_id() != rsx_thread)
-			{
-				//TODO: Guard this when the renderer is flushing the command queue, might deadlock otherwise
-				m_flush_commands = true;
-				m_queued_threads++;
-
-				//This is awful!
-				while (m_flush_commands);
-
-				std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
-				bool status = m_texture_cache.flush_address(address, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
-
-				m_queued_threads--;
-				return status;
+				m_last_flushable_cb = -1;
 			}
 			else
 			{
-				//NOTE: If the rsx::thread is trampling its own data, we have an operation that should be moved to the GPU
-				//We should never interrupt our own cb recording since some operations are not interruptible
-				if (!vk::is_uninterruptible())
-					//TODO: Investigate driver behaviour to determine if we need a hard sync or a soft flush
-					flush_command_queue();
+				//This region is buffered, but no previous sync point has been put in place to start sync efforts
+				//Just stall and get what we have at this point
+				if (std::this_thread::get_id() != rsx_thread)
+				{
+					//TODO: Guard this when the renderer is flushing the command queue, might deadlock otherwise
+					m_flush_commands = true;
+					m_queued_threads++;
+
+					//This is awful!
+					while (m_flush_commands) _mm_pause();
+
+					std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
+					bool status = m_texture_cache.flush_address(address, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+
+					m_queued_threads--;
+					return status;
+				}
+				else
+				{
+					//NOTE: If the rsx::thread is trampling its own data, we have an operation that should be moved to the GPU
+					//We should never interrupt our own cb recording since some operations are not interruptible
+					if (!vk::is_uninterruptible())
+						//TODO: Investigate driver behaviour to determine if we need a hard sync or a soft flush
+						flush_command_queue();
+				}
 			}
+		}
+		else
+		{
+			//If we aren't managing buffer sync, dont bother checking the cache
+			return false;
 		}
 
 		std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
@@ -1201,7 +1209,7 @@ void VKGSRender::do_local_task()
 		flush_command_queue();
 
 		m_flush_commands = false;
-		while (m_queued_threads);
+		while (m_queued_threads) _mm_pause();
 	}
 }
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -8,11 +8,9 @@
 #include "restore_new.h"
 #include <Utilities/optional.hpp>
 #include "define_new_memleakdetect.h"
-
-#define RSX_DEBUG 1
-
 #include "VKProgramBuffer.h"
 #include "../GCM.h"
+#include "../rsx_utils.h"
 
 #pragma comment(lib, "VKstatic.1.lib")
 
@@ -86,6 +84,10 @@ private:
 	u32 m_used_descriptors = 0;
 	u8 m_draw_buffers_count = 0;
 
+	rsx::gcm_framebuffer_info m_surface_info[rsx::limits::color_buffers_count];
+	rsx::gcm_framebuffer_info m_depth_surface_info;
+	bool m_flush_draw_buffers = false;
+
 public:
 	VKGSRender();
 	~VKGSRender();
@@ -96,6 +98,7 @@ private:
 	void open_command_buffer();
 	void sync_at_semaphore_release();
 	void prepare_rtts();
+	void copy_render_targets_to_dma_location();
 	/// returns primitive topology, is_indexed, index_count, offset in index buffer, index type
 	std::tuple<VkPrimitiveTopology, u32, std::optional<std::tuple<VkDeviceSize, VkIndexType> > > upload_vertex_data();
 public:

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -11,6 +11,8 @@ namespace vk
 	VkSampler g_null_sampler      = nullptr;
 	VkImageView g_null_image_view = nullptr;
 
+	bool g_cb_no_interrupt_flag = false;
+
 	VKAPI_ATTR void* VKAPI_CALL mem_realloc(void* pUserData, void* pOriginal, size_t size, size_t alignment, VkSystemAllocationScope allocationScope)
 	{
 #ifdef _MSC_VER
@@ -251,6 +253,21 @@ namespace vk
 		}
 
 		vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+	}
+
+	void enter_uninterruptible()
+	{
+		g_cb_no_interrupt_flag = true;
+	}
+
+	void leave_uninterruptible()
+	{
+		g_cb_no_interrupt_flag = false;
+	}
+
+	bool is_uninterruptible()
+	{
+		return g_cb_no_interrupt_flag;
 	}
 
 	VKAPI_ATTR VkBool32 VKAPI_CALL dbgFunc(VkFlags msgFlags, VkDebugReportObjectTypeEXT objType,

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -993,6 +993,11 @@ namespace vk
 			vkFreeCommandBuffers(pool->get_owner(), (*pool), 1, &commands);
 		}
 
+		vk::command_pool& get_command_pool() const
+		{
+			return *pool;
+		}
+
 		operator VkCommandBuffer()
 		{
 			return commands;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -941,7 +941,7 @@ namespace vk
 		{
 			owner = &dev;
 			VkCommandPoolCreateInfo infos = {};
-			infos.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+			infos.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 			infos.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
 
 			CHECK_RESULT(vkCreateCommandPool(dev, &infos, nullptr, &pool));
@@ -969,6 +969,7 @@ namespace vk
 
 	class command_buffer
 	{
+	protected:
 		vk::command_pool *pool = nullptr;
 		VkCommandBuffer commands = nullptr;
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -32,7 +32,7 @@ namespace rsx
 
 namespace vk
 {
-#define CHECK_RESULT(expr) do { VkResult _res = (expr); if (_res != VK_SUCCESS) fmt::throw_exception("Assertion failed! Result is %Xh", (s32)_res); } while (0)
+#define CHECK_RESULT(expr) { VkResult _res = (expr); if (_res != VK_SUCCESS) fmt::throw_exception("Assertion failed! Result is %Xh" HERE, (s32)_res); }
 
 	VKAPI_ATTR void *VKAPI_CALL mem_realloc(void *pUserData, void *pOriginal, size_t size, size_t alignment, VkSystemAllocationScope allocationScope);
 	VKAPI_ATTR void *VKAPI_CALL mem_alloc(void *pUserData, size_t size, size_t alignment, VkSystemAllocationScope allocationScope);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -78,6 +78,10 @@ namespace vk
 	std::pair<VkFormat, VkComponentMapping> get_compatible_surface_format(rsx::surface_color_format color_format);
 	size_t get_render_pass_location(VkFormat color_surface_format, VkFormat depth_stencil_format, u8 color_surface_count);
 
+	void enter_uninterruptible();
+	void leave_uninterruptible();
+	bool is_uninterruptible();
+
 	struct memory_type_mapping
 	{
 		uint32_t host_visible_coherent;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -507,10 +507,15 @@ namespace vk
 				mapping,
 				subresource_range);
 
+			//We cannot split mipmap uploads across multiple command buffers (must explicitly open and close operations on the same cb)
+			vk::enter_uninterruptible();
+
 			copy_mipmaped_image_using_buffer(cmd, image->value, get_subresources_layout(tex), format, !(tex.format() & CELL_GCM_TEXTURE_LN), tex.get_exact_mipmap_count(),
 				upload_heap, upload_buffer);
 
 			change_image_layout(cmd, image->value, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, subresource_range);
+
+			vk::leave_uninterruptible();
 
 			region.reset(texaddr, range);
 			region.create(tex.width(), height, depth, tex.get_exact_mipmap_count(), view, image);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -8,19 +8,27 @@ namespace vk
 {
 	class cached_texture_section : public rsx::buffered_section
 	{
+		u16 pitch;
 		u16 width;
 		u16 height;
 		u16 depth;
 		u16 mipmaps;
 
 		std::unique_ptr<vk::image_view> uploaded_image_view;
-		std::unique_ptr<vk::image> uploaded_texture;
+		std::unique_ptr<vk::image> managed_texture = nullptr;
+
+		//DMA relevant data
+		u16 native_pitch;
+		VkFence dma_fence = VK_NULL_HANDLE;
+		vk::render_device* m_device = nullptr;
+		vk::image *vram_texture = nullptr;
+		std::unique_ptr<vk::buffer> dma_buffer;
 
 	public:
 	
 		cached_texture_section() {}
 
-		void create(u16 w, u16 h, u16 depth, u16 mipmaps, vk::image_view *view, vk::image *image)
+		void create(const u16 w, const u16 h, const u16 depth, const u16 mipmaps, vk::image_view *view, vk::image *image, const u32 native_pitch = 0, bool managed=true)
 		{
 			width = w;
 			height = h;
@@ -28,7 +36,28 @@ namespace vk
 			this->mipmaps = mipmaps;
 
 			uploaded_image_view.reset(view);
-			uploaded_texture.reset(image);
+			vram_texture = image;
+
+			if (managed)
+				managed_texture.reset(image);
+
+			//TODO: Properly compute these values
+			this->native_pitch = native_pitch;
+			pitch = cpu_address_range / height;
+		}
+
+		void release_dma_resources()
+		{
+			if (dma_buffer.get() != nullptr)
+			{
+				dma_buffer.reset();
+
+				if (dma_fence != nullptr)
+				{
+					vkDestroyFence(*m_device, dma_fence, nullptr);
+					dma_fence = VK_NULL_HANDLE;
+				}
+			}
 		}
 
 		bool matches(u32 rsx_address, u32 rsx_size) const
@@ -51,7 +80,7 @@ namespace vk
 
 		bool exists() const
 		{
-			return (uploaded_texture.get() != nullptr);
+			return (vram_texture != nullptr);
 		}
 
 		u16 get_width() const
@@ -71,7 +100,185 @@ namespace vk
 
 		std::unique_ptr<vk::image>& get_texture()
 		{
-			return uploaded_texture;
+			return managed_texture;
+		}
+
+		bool is_flushable() const
+		{
+			if (protection == utils::protection::ro || protection == utils::protection::no)
+				return true;
+
+			if (uploaded_image_view.get() == nullptr && vram_texture != nullptr)
+				return true;
+
+			return false;
+		}
+
+		void copy_texture(vk::command_buffer& cmd, u32 heap_index, VkQueue submit_queue, VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+		{
+			if (m_device == nullptr)
+			{
+				m_device = &cmd.get_command_pool().get_owner();
+			}
+
+			if (dma_fence == VK_NULL_HANDLE)
+			{
+				VkFenceCreateInfo createInfo = {};
+				createInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+				vkCreateFence(*m_device, &createInfo, nullptr, &dma_fence);
+			}
+
+			if (dma_buffer.get() == nullptr)
+			{
+				dma_buffer.reset(new vk::buffer(*m_device, native_pitch * height, heap_index, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0));
+			}
+
+			VkBufferImageCopy copyRegion = {};
+			copyRegion.bufferOffset = 0;
+			copyRegion.bufferRowLength = width;
+			copyRegion.bufferImageHeight = height;
+			copyRegion.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+			copyRegion.imageOffset = {};
+			copyRegion.imageExtent = {width, height, 1};
+
+			VkImageSubresourceRange subresource_range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+			
+			change_image_layout(cmd, vram_texture->value, layout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, subresource_range);
+			vkCmdCopyImageToBuffer(cmd, vram_texture->value, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dma_buffer->value, 1, &copyRegion);
+			change_image_layout(cmd, vram_texture->value, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, layout, subresource_range);
+
+			CHECK_RESULT(vkEndCommandBuffer(cmd));
+
+			VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+			VkCommandBuffer command_buffer = cmd;
+
+			VkSubmitInfo infos = {};
+			infos.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+			infos.commandBufferCount = 1;
+			infos.pCommandBuffers = &command_buffer;
+			infos.pWaitDstStageMask = &pipe_stage_flags;
+			infos.pWaitSemaphores = nullptr;
+			infos.waitSemaphoreCount = 0;
+
+			CHECK_RESULT(vkQueueSubmit(submit_queue, 1, &infos, dma_fence));
+
+			//Now we need to restart the command-buffer to restore it to the way it was before...
+			CHECK_RESULT(vkWaitForFences(*m_device, 1, &dma_fence, VK_TRUE, UINT64_MAX));
+			CHECK_RESULT(vkResetCommandPool(*m_device, cmd.get_command_pool(), 0));
+			CHECK_RESULT(vkResetFences(*m_device, 1, &dma_fence));
+
+			VkCommandBufferInheritanceInfo inheritance_info = {};
+			inheritance_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO;
+
+			VkCommandBufferBeginInfo begin_infos = {};
+			begin_infos.pInheritanceInfo = &inheritance_info;
+			begin_infos.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+			begin_infos.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+			CHECK_RESULT(vkBeginCommandBuffer(cmd, &begin_infos));
+		}
+
+		template<typename T>
+		void do_memory_transfer(void *pixels_dst, void *pixels_src)
+		{
+			if (pitch == native_pitch)
+			{
+				if (sizeof T == 1)
+					memcpy(pixels_dst, pixels_src, native_pitch * height);
+				else
+				{
+					const u32 block_size = native_pitch * height / sizeof T;
+					
+					auto typed_dst = (be_t<T> *)pixels_dst;
+					auto typed_src = (T *)pixels_src;
+
+					for (u8 n = 0; n < block_size; ++n)
+						typed_dst[n] = typed_src[n];
+				}
+			}
+			else
+			{
+				if (sizeof T == 1)
+				{
+					u8 *typed_dst = (u8 *)pixels_dst;
+					u8 *typed_src = (u8 *)pixels_src;
+
+					//TODO: Scaling
+					for (int row = 0; row < height; ++row)
+					{
+						memcpy(typed_dst, typed_src, native_pitch);
+						typed_dst += pitch;
+						typed_src += native_pitch;
+					}
+				}
+				else
+				{
+					const u32 src_step = native_pitch / sizeof T;
+					const u32 dst_step = pitch / sizeof T;
+
+					auto typed_dst = (be_t<T> *)pixels_dst;
+					auto typed_src = (T *)pixels_src;
+
+					for (int row = 0; row < height; ++row)
+					{
+						for (int px = 0; px < width; ++px)
+						{
+							typed_dst[px] = typed_src[px];
+						}
+
+						typed_dst += dst_step;
+						typed_src += src_step;
+					}
+				}
+			}
+		}
+
+		void flush(vk::render_device& dev, vk::command_buffer& cmd, u32 heap_index, VkQueue submit_queue)
+		{
+			if (m_device == nullptr)
+				m_device = &dev;
+
+			if (dma_fence == VK_NULL_HANDLE || dma_buffer.get() == nullptr)
+			{
+				LOG_WARNING(RSX, "Cache miss at address 0x%X. This is gonna hurt...", cpu_address_base);
+				copy_texture(cmd, heap_index, submit_queue, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+				verify (HERE), (dma_fence != VK_NULL_HANDLE && dma_buffer.get());
+			}
+
+			protect(utils::protection::rw);
+
+			//TODO: Image scaling, etc
+			void* pixels_src = dma_buffer->map(0, VK_WHOLE_SIZE);
+			void* pixels_dst = vm::base(cpu_address_base);
+
+			//We have to do our own byte swapping since the driver doesnt do it for us
+			const u8 bpp = native_pitch / width;
+
+			switch (bpp)
+			{
+			default:
+				LOG_ERROR(RSX, "Invalid bpp %d", bpp);
+			case 1:
+				do_memory_transfer<u8>(pixels_dst, pixels_src);
+				break;
+			case 2:
+				do_memory_transfer<u16>(pixels_dst, pixels_src);
+				break;
+			case 4:
+				do_memory_transfer<u32>(pixels_dst, pixels_src);
+				break;
+			case 8:
+				do_memory_transfer<u64>(pixels_dst, pixels_src);
+				break;
+			}
+
+			dma_buffer->unmap();
+
+			//Cleanup
+			//These sections are usually one-use only so we destroy system resources
+			//TODO: Recycle dma buffers
+			release_dma_resources();
+			vram_texture = nullptr;	//Let m_rtts handle lifetime management
 		}
 	};
 
@@ -111,6 +318,7 @@ namespace vk
 						m_temporary_image_view.push_back(std::move(tex.get_view()));
 					}
 
+					tex.release_dma_resources();
 					return tex;
 				}
 			}
@@ -118,6 +326,20 @@ namespace vk
 			m_cache.push_back(cached_texture_section());
 
 			return m_cache[m_cache.size() - 1];
+		}
+
+		cached_texture_section* find_flushable_section(const u32 address, const u32 range)
+		{
+			for (auto &tex : m_cache)
+			{
+				if (tex.is_dirty()) continue;
+				if (!tex.is_flushable()) continue;
+
+				if (tex.matches(address, range))
+					return &tex;
+			}
+
+			return nullptr;
 		}
 
 		void purge_cache()
@@ -132,6 +354,8 @@ namespace vk
 
 				if (tex.is_locked())
 					tex.unprotect();
+
+				tex.release_dma_resources();
 			}
 
 			m_temporary_image_view.clear();
@@ -300,6 +524,73 @@ namespace vk
 
 			texture_cache_range = region.get_min_max(texture_cache_range);
 			return view;
+		}
+
+		void lock_memory_region(vk::render_target* image, const u32 memory_address, const u32 memory_size, const u32 width, const u32 height)
+		{
+			cached_texture_section& region = find_cached_texture(memory_address, memory_size, true, width, height, 1);
+			region.create(width, height, 1, 1, nullptr, image, image->native_pitch, false);
+			
+			if (!region.is_locked())
+			{
+				region.reset(memory_address, memory_size);
+				region.protect(utils::protection::no);
+				region.set_dirty(false);
+				texture_cache_range = region.get_min_max(texture_cache_range);
+			}
+		}
+
+		void flush_memory_to_cache(const u32 memory_address, const u32 memory_size, vk::command_buffer&cmd, vk::memory_type_mapping& memory_types, VkQueue submit_queue)
+		{
+			cached_texture_section* region = find_flushable_section(memory_address, memory_size);
+			
+			//TODO: Make this an assertion
+			if (region == nullptr)
+			{
+				LOG_ERROR(RSX, "Failed to find section for render target 0x%X + 0x%X", memory_address, memory_size);
+				return;
+			}
+
+			region->copy_texture(cmd, memory_types.host_visible_coherent, submit_queue);
+		}
+
+		bool flush_address(u32 address, vk::render_device& dev, vk::command_buffer& cmd, vk::memory_type_mapping& memory_types, VkQueue submit_queue)
+		{
+			if (address < texture_cache_range.first ||
+				address > texture_cache_range.second)
+				return false;
+
+			bool response = false;
+			std::pair<u32, u32> trampled_range = std::make_pair(0xffffffff, 0x0);
+
+			for (int i = 0; i < m_cache.size(); ++i)
+			{
+				auto &tex = m_cache[i];
+
+				if (tex.is_dirty()) continue;
+				if (!tex.is_flushable()) continue;
+
+				auto overlapped = tex.overlaps_page(trampled_range, address);
+				if (std::get<0>(overlapped))
+				{
+					auto &new_range = std::get<1>(overlapped);
+
+					if (new_range.first != trampled_range.first ||
+						new_range.second != trampled_range.second)
+					{
+						trampled_range = new_range;
+						i = 0;
+					}
+
+					//TODO: Map basic host_visible memory without coherent constraint
+					tex.flush(dev, cmd, memory_types.host_visible_coherent, submit_queue);
+					tex.set_dirty(true);
+
+					response = true;
+				}
+			}
+
+			return response;
 		}
 
 		bool invalidate_address(u32 address)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -189,7 +189,7 @@ namespace vk
 
 				//Now we need to restart the command-buffer to restore it to the way it was before...
 				CHECK_RESULT(vkWaitForFences(*m_device, 1, &dma_fence, VK_TRUE, UINT64_MAX));
-				CHECK_RESULT(vkResetCommandPool(*m_device, cmd.get_command_pool(), 0));
+				CHECK_RESULT(vkResetCommandBuffer(cmd, 0));
 				CHECK_RESULT(vkResetFences(*m_device, 1, &dma_fence));
 			}
 		}

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -136,12 +136,13 @@ namespace rsx
 			locked_address_range = align(base + length, 4096) - locked_address_base;
 
 			protection = utils::protection::rw;
-
 			locked = false;
 		}
 
 		void protect(utils::protection prot)
 		{
+			if (prot == protection) return;
+
 			utils::memory_protect(vm::base(locked_address_base), locked_address_range, prot);
 			protection = prot;
 			locked = prot != utils::protection::rw;
@@ -149,7 +150,8 @@ namespace rsx
 
 		void unprotect()
 		{
-			return protect(utils::protection::rw);
+			protect(utils::protection::rw);
+			locked = false;
 		}
 
 		bool overlaps(std::pair<u32, u32> range)

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -145,7 +145,7 @@ namespace rsx
 		u32 dst_offset = 0;
 		u32 src_offset = 0;
 
-		u32 padding = (dst_pitch - (src_pitch * samples)) / sizeof T;
+		u32 padding = (dst_pitch - (src_pitch * samples)) / sizeof(T);
 
 		for (u16 h = 0; h < src_height; ++h)
 		{

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -132,4 +132,203 @@ namespace rsx
 			return { blend_color_r / 255.f, blend_color_g / 255.f, blend_color_b / 255.f, blend_color_a / 255.f };
 		}
 	}
+
+	/* Fast image scaling routines
+	* Only uses fast nearest scaling and integral scaling factors
+	* T - Dst type
+	* U - Src type
+	* N - Sample count
+	*/
+	template <typename T, typename U>
+	void scale_image_fallback_impl(T* dst, const U* src, u16 src_width, u16 src_height, u16 dst_pitch, u16 src_pitch, u8 pixel_size, u8 samples)
+	{
+		u32 dst_offset = 0;
+		u32 src_offset = 0;
+
+		u32 padding = (dst_pitch - (src_pitch * samples)) / sizeof T;
+
+		for (u16 h = 0; h < src_height; ++h)
+		{
+			for (u16 w = 0; w < src_width; ++w)
+			{
+				for (u8 n = 0; n < samples; ++n)
+				{
+					dst[dst_offset++] = src[src_offset];
+				}
+
+				src_offset++;
+			}
+
+			dst_offset += padding;
+		}
+	}
+
+	void scale_image_fallback(void* dst, const void* src, u16 src_width, u16 src_height, u16 dst_pitch, u16 src_pitch, u8 pixel_size, u8 samples)
+	{
+		switch (pixel_size)
+		{
+		case 1:
+			scale_image_fallback_impl<u8, u8>((u8*)dst, (const u8*)src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			break;
+		case 2:
+			scale_image_fallback_impl<u16, u16>((u16*)dst, (const u16*)src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			break;
+		case 4:
+			scale_image_fallback_impl<u32, u32>((u32*)dst, (const u32*)src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			break;
+		case 8:
+			scale_image_fallback_impl<u64, u64>((u64*)dst, (const u64*)src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			break;
+		default:
+			fmt::throw_exception("unsupported pixel size %d" HERE, pixel_size);
+		}
+	}
+
+	void scale_image_fallback_with_byte_swap(void* dst, const void* src, u16 src_width, u16 src_height, u16 dst_pitch, u16 src_pitch, u8 pixel_size, u8 samples)
+	{
+		switch (pixel_size)
+		{
+		case 1:
+			scale_image_fallback_impl<u8, u8>((u8*)dst, (const u8*)src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			break;
+		case 2:
+			scale_image_fallback_impl<u16, be_t<u16>>((u16*)dst, (const be_t<u16>*)src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			break;
+		case 4:
+			scale_image_fallback_impl<u32, be_t<u32>>((u32*)dst, (const be_t<u32>*)src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			break;
+		case 8:
+			scale_image_fallback_impl<u64, be_t<u64>>((u64*)dst, (const be_t<u64>*)src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			break;
+		default:
+			fmt::throw_exception("unsupported pixel size %d" HERE, pixel_size);
+		}
+	}
+
+	template <typename T, typename U, int N>
+	void scale_image_impl(T* dst, const U* src, u16 src_width, u16 src_height, u16 padding)
+	{
+		u32 dst_offset = 0;
+		u32 src_offset = 0;
+
+		for (u16 h = 0; h < src_height; ++h)
+		{
+			for (u16 w = 0; w < src_width; ++w)
+			{
+				for (u8 n = 0; n < N; ++n)
+				{
+					dst[dst_offset++] = src[src_offset];
+				}
+
+				//Fetch next pixel
+				src_offset++;
+			}
+
+			//Pad this row
+			dst_offset += padding;
+		}
+	}
+
+	template <int N>
+	void scale_image_fast(void *dst, const void *src, u8 pixel_size, u16 src_width, u16 src_height, u16 padding)
+	{
+		switch (pixel_size)
+		{
+		case 1:
+			scale_image_impl<u8, u8, N>((u8*)dst, (const u8*)src, src_width, src_height, padding);
+			break;
+		case 2:
+			scale_image_impl<u16, u16, N>((u16*)dst, (const u16*)src, src_width, src_height, padding);
+			break;
+		case 4:
+			scale_image_impl<u32, u32, N>((u32*)dst, (const u32*)src, src_width, src_height, padding);
+			break;
+		case 8:
+			scale_image_impl<u64, u64, N>((u64*)dst, (const u64*)src, src_width, src_height, padding);
+			break;
+		default:
+			fmt::throw_exception("unsupported pixel size %d" HERE, pixel_size);
+		}
+	}
+
+	template <int N>
+	void scale_image_fast_with_byte_swap(void *dst, const void *src, u8 pixel_size, u16 src_width, u16 src_height, u16 padding)
+	{
+		switch (pixel_size)
+		{
+		case 1:
+			scale_image_impl<u8, u8, N>((u8*)dst, (const u8*)src, src_width, src_height, padding);
+			break;
+		case 2:
+			scale_image_impl<u16, be_t<u16>, N>((u16*)dst, (const be_t<u16>*)src, src_width, src_height, padding);
+			break;
+		case 4:
+			scale_image_impl<u32, be_t<u32>, N>((u32*)dst, (const be_t<u32>*)src, src_width, src_height, padding);
+			break;
+		case 8:
+			scale_image_impl<u64, be_t<u64>, N>((u64*)dst, (const be_t<u64>*)src, src_width, src_height, padding);
+			break;
+		default:
+			fmt::throw_exception("unsupported pixel size %d" HERE, pixel_size);
+		}
+	}
+
+	void scale_image_nearest(void* dst, const void* src, u16 src_width, u16 src_height, u16 dst_pitch, u16 src_pitch, u8 pixel_size, u8 samples, bool swap_bytes)
+	{
+		//Scale this image by repeating pixel data n times
+		//n = expected_pitch / real_pitch
+		//Use of fixed argument templates for performance reasons
+
+		const u16 dst_width = dst_pitch / pixel_size;
+		const u16 padding = dst_width - (src_width * samples);
+
+		if (!swap_bytes)
+		{
+			switch (samples)
+			{
+			case 2:
+				scale_image_fast<2>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			case 3:
+				scale_image_fast<3>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			case 4:
+				scale_image_fast<4>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			case 8:
+				scale_image_fast<8>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			case 16:
+				scale_image_fast<16>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			default:
+				LOG_ERROR(RSX, "Unsupported RTT scaling factor: dst_pitch=%d src_pitch=%d", dst_pitch, src_pitch);
+				scale_image_fallback(dst, src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			}
+		}
+		else
+		{
+			switch (samples)
+			{
+			case 2:
+				scale_image_fast_with_byte_swap<2>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			case 3:
+				scale_image_fast_with_byte_swap<3>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			case 4:
+				scale_image_fast_with_byte_swap<4>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			case 8:
+				scale_image_fast_with_byte_swap<8>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			case 16:
+				scale_image_fast_with_byte_swap<16>(dst, src, pixel_size, src_width, src_height, padding);
+				break;
+			default:
+				LOG_ERROR(RSX, "Unsupported RTT scaling factor: dst_pitch=%d src_pitch=%d", dst_pitch, src_pitch);
+				scale_image_fallback_with_byte_swap(dst, src, src_width, src_height, dst_pitch, src_pitch, pixel_size, samples);
+			}
+		}
+	}
 }

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -133,6 +133,8 @@ namespace rsx
 		}
 	}
 
+	void scale_image_nearest(void* dst, const void* src, u16 src_width, u16 src_height, u16 dst_pitch, u16 src_pitch, u8 pixel_size, u8 samples, bool swap_bytes = false);
+
 	void convert_scale_image(u8 *dst, AVPixelFormat dst_format, int dst_width, int dst_height, int dst_pitch,
 		const u8 *src, AVPixelFormat src_format, int src_width, int src_height, int src_pitch, int src_slice_h, bool bilinear);
 

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "gcm_enums.h"
+
 extern "C"
 {
 #include <libavutil/pixfmt.h>
@@ -7,6 +9,31 @@ extern "C"
 
 namespace rsx
 {
+	//Holds information about a framebuffer
+	struct gcm_framebuffer_info
+	{
+		u32 address = 0;
+		u32 pitch = 0;
+
+		bool is_depth_surface;
+
+		rsx::surface_color_format color_format;
+		rsx::surface_depth_format depth_format;
+
+		u16 width;
+		u16 height;
+
+		gcm_framebuffer_info()
+		{
+			address = 0;
+			pitch = 0;
+		}
+
+		gcm_framebuffer_info(const u32 address_, const u32 pitch_, bool is_depth_, const rsx::surface_color_format fmt_, const rsx::surface_depth_format dfmt_, const u16 w, const u16 h)
+			:address(address_), pitch(pitch_), is_depth_surface(is_depth_), color_format(fmt_), depth_format(dfmt_), width(w), height(h)
+		{}
+	};
+
 	template<typename T>
 	void pad_texture(void* input_pixels, void* output_pixels, u16 input_width, u16 input_height, u16 output_width, u16 output_height)
 	{

--- a/rpcs3/Gui/SettingsDialog.cpp
+++ b/rpcs3/Gui/SettingsDialog.cpp
@@ -226,7 +226,7 @@ SettingsDialog::SettingsDialog(wxWindow* parent, const std::string& path)
 
 	std::vector<std::unique_ptr<cfg_adapter>> pads;
 
-	static const u32 width  = 458;
+	static const u32 width  = 512;
 	static const u32 height = 400;
 
 	// Settings panels
@@ -310,6 +310,8 @@ SettingsDialog::SettingsDialog(wxWindow* parent, const std::string& path)
 	wxComboBox* cbox_sys_lang = new wxComboBox(p_system, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_READONLY);
 
 	wxCheckBox* chbox_core_hook_stfunc = new wxCheckBox(p_core, wxID_ANY, "Hook static functions");
+	wxCheckBox* chbox_core_bind_spu_threads = new wxCheckBox(p_core, wxID_ANY, "Bind SPU threads to secondary cores");
+	wxCheckBox* chbox_core_lower_spu_priority = new wxCheckBox(p_core, wxID_ANY, "Lower SPU thread priority");
 	wxCheckBox* chbox_vfs_enable_host_root = new wxCheckBox(p_system, wxID_ANY, "Enable /host_root/");
 	wxCheckBox* chbox_gs_log_prog = new wxCheckBox(p_graphics, wxID_ANY, "Log Shader Programs");
 	wxCheckBox* chbox_gs_dump_depth = new wxCheckBox(p_graphics, wxID_ANY, "Write Depth Buffer");
@@ -391,6 +393,8 @@ SettingsDialog::SettingsDialog(wxWindow* parent, const std::string& path)
 	EnableModuleList(rbox_lib_loader->GetSelection());
 
 	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "Core", "Hook static functions" }, chbox_core_hook_stfunc));
+	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "Core", "Bind SPU threads to secondary cores" }, chbox_core_bind_spu_threads));
+	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "Core", "Lower SPU thread priority" }, chbox_core_lower_spu_priority));
 	pads.emplace_back(std::make_unique<checkbox_pad>(cfg_location{ "VFS", "Enable /host_root/" }, chbox_vfs_enable_host_root));
 
 	pads.emplace_back(std::make_unique<combobox_pad>(cfg_location{ "Video", "Renderer" }, cbox_gs_render));
@@ -482,6 +486,8 @@ SettingsDialog::SettingsDialog(wxWindow* parent, const std::string& path)
 	s_subpanel_core1->Add(rbox_ppu_decoder, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_core1->Add(rbox_spu_decoder, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_core1->Add(chbox_core_hook_stfunc, wxSizerFlags().Border(wxALL, 5).Expand());
+	s_subpanel_core1->Add(chbox_core_bind_spu_threads, wxSizerFlags().Border(wxALL, 5).Expand());
+	s_subpanel_core1->Add(chbox_core_lower_spu_priority, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_core2->Add(rbox_lib_loader, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_core2->Add(s_round_core_lle, wxSizerFlags().Border(wxALL, 5).Expand());
 	s_subpanel_core->Add(s_subpanel_core1);


### PR DESCRIPTION
- Implements synchronized framebuffer r/w for vulkan. Still missing some important pieces such as hw accelerated image_in, but that will get merged in later.
- Adds a simple hack for SPU priority and ideal core binding (only works on windows for now)

Alot more remains, from vertex fetch rewrites, sync fixes for ogl and dx12, GPU acceleration for image_in on all backends, etc. Most of it is partially done with the remaining pieces to come later.