### PR TITLE
rsx: Vertex program output fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Common/ShaderParam.h
@@ -245,3 +245,17 @@ public:
 		return name + "." + fmt::merge({ swizzles }, ".");
 	}
 };
+
+struct vertex_reg_info
+{
+	std::string name;           //output name
+	bool need_declare;          //needs explicit declaration as output (not language in-built)
+	std::string src_reg;        //reg to get data from
+	std::string src_reg_mask;   //input swizzle mask
+	bool need_cast;             //needs casting
+	std::string cond;           //update on condition
+	std::string default_val;    //fallback value on cond fail
+	std::string dst_alias;      //output name override
+	bool check_mask;            //check program output control mask for this output
+	u32  check_mask_value;      //program output control mask for testing
+};

--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -89,8 +89,7 @@ void D3D12GSRender::upload_and_bind_scale_offset_matrix(size_t descriptorIndex)
 	void *mapped_buffer = m_buffer_data.map<void>(CD3DX12_RANGE(heap_offset, heap_offset + 512));
 	fill_scale_offset_data(mapped_buffer, true, false);
 	fill_user_clip_data((char*)mapped_buffer + 64);
-
-	fill_fragment_state_buffer((char *)mapped_buffer + 96, m_fragment_program);
+	fill_fragment_state_buffer((char *)mapped_buffer + 128, m_fragment_program);
 	m_buffer_data.unmap(CD3DX12_RANGE(heap_offset, heap_offset + 512));
 
 	D3D12_CONSTANT_BUFFER_VIEW_DESC constant_buffer_view_desc = {

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -38,7 +38,8 @@ void D3D12FragmentDecompiler::insertHeader(std::stringstream & OS)
 	OS << "cbuffer SCALE_OFFSET : register(b0)" << std::endl;
 	OS << "{" << std::endl;
 	OS << "	float4x4 scaleOffsetMat;" << std::endl;
-	OS << "	float4 userClip[2];" << std::endl;
+	OS << "	int4 userClipEnabled[2];" << std::endl;
+	OS << "	float4 userClipFactor[2];" << std::endl;
 	OS << "	float fog_param0;\n";
 	OS << "	float fog_param1;\n";
 	OS << "	int isAlphaTested;" << std::endl;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -289,13 +289,6 @@ void GLGSRender::begin()
 	//NV4097_SET_ANTI_ALIASING_CONTROL
 	//NV4097_SET_CLIP_ID_TEST_ENABLE
 
-	__glcheck enable(true, GL_CLIP_DISTANCE0 + 0);
-	__glcheck enable(true, GL_CLIP_DISTANCE0 + 1);
-	__glcheck enable(true, GL_CLIP_DISTANCE0 + 2);
-	__glcheck enable(true, GL_CLIP_DISTANCE0 + 3);
-	__glcheck enable(true, GL_CLIP_DISTANCE0 + 4);
-	__glcheck enable(true, GL_CLIP_DISTANCE0 + 5);
-
 	std::chrono::time_point<steady_clock> now = steady_clock::now();
 	m_begin_time += (u32)std::chrono::duration_cast<std::chrono::microseconds>(now - then).count();
 }
@@ -572,6 +565,14 @@ void GLGSRender::on_init_thread()
 		m_gl_sampler_states[i].create();
 		m_gl_sampler_states[i].bind(i);
 	}
+
+	//Clip planes are shader controlled; enable all planes driver-side
+	glEnable(GL_CLIP_DISTANCE0 + 0);
+	glEnable(GL_CLIP_DISTANCE0 + 1);
+	glEnable(GL_CLIP_DISTANCE0 + 2);
+	glEnable(GL_CLIP_DISTANCE0 + 3);
+	glEnable(GL_CLIP_DISTANCE0 + 4);
+	glEnable(GL_CLIP_DISTANCE0 + 5);
 
 	m_gl_texture_cache.initialize(this);
 }

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -129,6 +129,33 @@ namespace gl
 				}
 			}
 
+			//Workaround for intel drivers which have terrible capability reporting
+			std::string vendor_string = (const char*)glGetString(GL_VENDOR);
+			std::transform(vendor_string.begin(), vendor_string.end(), vendor_string.begin(), ::tolower);
+
+			if (vendor_string.find("intel"))
+			{
+				int version_major = 0;
+				int version_minor = 0;
+
+				glGetIntegerv(GL_MAJOR_VERSION, &version_major);
+				glGetIntegerv(GL_MINOR_VERSION, &version_minor);
+
+				//Texture buffers moved into core at GL 3.3
+				if (version_major > 3 || (version_major == 3 && version_minor >= 3))
+					ARB_texture_buffer_supported = true;
+
+				//Check for expected library entry-points for some required functions
+				if (!ARB_buffer_storage_supported && glBufferStorage && glMapBufferRange)
+					ARB_buffer_storage_supported = true;
+
+				if (!ARB_dsa_supported && glGetTextureImage && glTextureBufferRange)
+					ARB_dsa_supported = true;
+
+				if (!EXT_dsa_supported && glGetTextureImageEXT && glTextureBufferRangeEXT)
+					EXT_dsa_supported = true;
+			}
+
 			initialized = true;
 		}
 	};

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -34,7 +34,8 @@ void GLVertexDecompilerThread::insertHeader(std::stringstream &OS)
 	OS << "layout(std140, binding = 0) uniform ScaleOffsetBuffer" << std::endl;
 	OS << "{" << std::endl;
 	OS << "	mat4 scaleOffsetMat;" << std::endl;
-	OS << "	vec4 userClip[2];" << std::endl;
+	OS << "	ivec4 userClipEnabled[2];" << std::endl;
+	OS << "	vec4 userClipFactor[2];" << std::endl;
 	OS << "};" << std::endl;
 }
 
@@ -81,11 +82,6 @@ void GLVertexDecompilerThread::insertInputs(std::stringstream & OS, const std::v
 			}
 		}
 	}
-
-	for (int i = 0; i <= 5; i++)
-	{
-		OS << "uniform int uc_m" + std::to_string(i) + "= 0;\n";
-	}
 }
 
 void GLVertexDecompilerThread::insertConstants(std::stringstream & OS, const std::vector<ParamType> & constants)
@@ -108,30 +104,22 @@ void GLVertexDecompilerThread::insertConstants(std::stringstream & OS, const std
 	}
 }
 
-struct reg_info
-{
-	std::string name;
-	bool need_declare;
-	std::string src_reg;
-	std::string src_reg_mask;
-	bool need_cast;
-};
-
-static const reg_info reg_table[] =
+static const vertex_reg_info reg_table[] =
 {
 	{ "gl_Position", false, "dst_reg0", "", false },
 	{ "diff_color", true, "dst_reg1", "", false },
 	{ "spec_color", true, "dst_reg2", "", false },
 	{ "front_diff_color", true, "dst_reg3", "", false },
 	{ "front_spec_color", true, "dst_reg4", "", false },
-	{ "fog_c", true, "dst_reg5", ".xxxx", true },
-	{ "gl_ClipDistance[0]", false, "dst_reg5", ".y * userClip[0].x", false },
-	{ "gl_ClipDistance[1]", false, "dst_reg5", ".z * userClip[0].y", false },
-	{ "gl_ClipDistance[2]", false, "dst_reg5", ".w * userClip[0].z", false },
+	{ "fog_c", true, "dst_reg5", ".xxxx", true, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FOG },
+	//Warning: Always define all 3 clip plane groups together to avoid flickering with openGL
+	{ "gl_ClipDistance[0]", false, "dst_reg5", ".y * userClipFactor[0].x", false, "userClipEnabled[0].x > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC0 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC1 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC2 },
+	{ "gl_ClipDistance[1]", false, "dst_reg5", ".z * userClipFactor[0].y", false, "userClipEnabled[0].y > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC0 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC1 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC2 },
+	{ "gl_ClipDistance[2]", false, "dst_reg5", ".w * userClipFactor[0].z", false, "userClipEnabled[0].z > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC0 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC1 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC2 },
 	{ "gl_PointSize", false, "dst_reg6", ".x", false },
-	{ "gl_ClipDistance[3]", false, "dst_reg6", ".y * userClip[0].w", false },
-	{ "gl_ClipDistance[4]", false, "dst_reg6", ".z * userClip[1].x", false },
-	{ "gl_ClipDistance[5]", false, "dst_reg6", ".w * userClip[1].y", false },
+	{ "gl_ClipDistance[3]", false, "dst_reg6", ".y * userClipFactor[0].w", false, "userClipEnabled[0].w > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
+	{ "gl_ClipDistance[4]", false, "dst_reg6", ".z * userClipFactor[1].x", false, "userClipEnabled[1].x > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
+	{ "gl_ClipDistance[5]", false, "dst_reg6", ".w * userClipFactor[1].y", false, "userClipEnabled[1].y > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
 	{ "tc0", true, "dst_reg7", "", false },
 	{ "tc1", true, "dst_reg8", "", false },
 	{ "tc2", true, "dst_reg9", "", false },
@@ -141,7 +129,7 @@ static const reg_info reg_table[] =
 	{ "tc6", true, "dst_reg13", "", false },
 	{ "tc7", true, "dst_reg14", "", false },
 	{ "tc8", true, "dst_reg15", "", false },
-	{ "tc9", true, "dst_reg6", "", false }  // In this line, dst_reg6 is correct since dst_reg goes from 0 to 15.
+	{ "tc9", true, "dst_reg6", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX9 }  // In this line, dst_reg6 is correct since dst_reg goes from 0 to 15.
 };
 
 void GLVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::vector<ParamType> & outputs)
@@ -159,6 +147,9 @@ void GLVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::
 	{
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", i.src_reg) && i.need_declare)
 		{
+			if (i.check_mask && (rsx_vertex_program.output_mask & i.check_mask_value) == 0)
+				continue;
+
 			if (i.name == "front_diff_color")
 				insert_front_diffuse = false;
 
@@ -333,6 +324,9 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 	{
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", i.src_reg))
 		{
+			if (i.check_mask && (rsx_vertex_program.output_mask & i.check_mask_value) == 0)
+				continue;
+
 			if (i.name == "front_diff_color")
 				insert_front_diffuse = false;
 
@@ -340,6 +334,7 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 				insert_front_specular = false;
 
 			std::string name = i.name;
+			std::string condition = (!i.cond.empty()) ? "(" + i.cond + ") " : "";
 
 			if (front_back_diffuse && name == "diff_color")
 				name = "back_diff_color";
@@ -347,7 +342,16 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 			if (front_back_specular && name == "spec_color")
 				name = "back_spec_color";
 
-			OS << "	" << name << " = " << i.src_reg << i.src_reg_mask << ";" << std::endl;
+			if (condition.empty() || i.default_val.empty())
+			{
+				if (!condition.empty()) condition = "if " + condition;
+				OS << "	" << condition << name << " = " << i.src_reg << i.src_reg_mask << ";" << std::endl;
+			}
+			else
+			{
+				//Insert if-else condition
+				OS << "	" << name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";" << std::endl;
+			}
 		}
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -120,15 +120,15 @@ static const vertex_reg_info reg_table[] =
 	{ "gl_ClipDistance[3]", false, "dst_reg6", ".y * userClipFactor[0].w", false, "userClipEnabled[0].w > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
 	{ "gl_ClipDistance[4]", false, "dst_reg6", ".z * userClipFactor[1].x", false, "userClipEnabled[1].x > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
 	{ "gl_ClipDistance[5]", false, "dst_reg6", ".w * userClipFactor[1].y", false, "userClipEnabled[1].y > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
-	{ "tc0", true, "dst_reg7", "", false },
-	{ "tc1", true, "dst_reg8", "", false },
-	{ "tc2", true, "dst_reg9", "", false },
-	{ "tc3", true, "dst_reg10", "", false },
-	{ "tc4", true, "dst_reg11", "", false },
-	{ "tc5", true, "dst_reg12", "", false },
-	{ "tc6", true, "dst_reg13", "", false },
-	{ "tc7", true, "dst_reg14", "", false },
-	{ "tc8", true, "dst_reg15", "", false },
+	{ "tc0", true, "dst_reg7", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX0 },
+	{ "tc1", true, "dst_reg8", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX1 },
+	{ "tc2", true, "dst_reg9", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX2 },
+	{ "tc3", true, "dst_reg10", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX3 },
+	{ "tc4", true, "dst_reg11", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX4 },
+	{ "tc5", true, "dst_reg12", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX5 },
+	{ "tc6", true, "dst_reg13", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX6 },
+	{ "tc7", true, "dst_reg14", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX7 },
+	{ "tc8", true, "dst_reg15", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX8 },
 	{ "tc9", true, "dst_reg6", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX9 }  // In this line, dst_reg6 is correct since dst_reg goes from 0 to 15.
 };
 
@@ -165,6 +165,15 @@ void GLVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::
 				name = "back_spec_color";
 
 			OS << "out vec4 " << name << ";" << std::endl;
+		}
+		else
+		{
+			//Mesa drivers are very strict on shader-stage matching
+			//Force some outputs to be declared even if unused
+            if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
+			{
+                OS << "out vec4 " << i.name << ";" << std::endl;
+			}
 		}
 	}
 
@@ -218,7 +227,7 @@ void add_input(std::stringstream & OS, const ParamItem &PI, const std::vector<rs
 	}
 
 	LOG_WARNING(RSX, "Vertex input %s does not have a matching vertex_input declaration", PI.name.c_str());
-	
+
 	OS << "	vec4 " << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID);" << std::endl;
 }
 
@@ -284,7 +293,7 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 	OS << "{" << std::endl;
 
 	std::string parameters = "";
-	
+
 	if (ParamType *vec4Types = m_parr.SearchParam(PF_PARAM_NONE, "vec4"))
 	{
 		for (int i = 0; i < 16; ++i)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -601,32 +601,35 @@ namespace rsx
 			rsx::method_registers.clip_plane_5_enabled(),
 		};
 
-		std::array<f32, 8> tmp{};
+		s32 clip_enabled_flags[8] = {};
+		f32 clip_distance_factors[8] = {};
+
 		for (int index = 0; index < 6; ++index)
 		{
-			f32 value = 0;
 			switch (clip_plane_control[index])
 			{
 			default:
 				LOG_ERROR(RSX, "bad clip plane control (0x%x)", (u8)clip_plane_control[index]);
 
 			case rsx::user_clip_plane_op::disable:
-				value = 0.f;
+				clip_enabled_flags[index] = 0;
+				clip_distance_factors[index] = 0.f;
 				break;
 
 			case rsx::user_clip_plane_op::greater_or_equal:
-				value = 1.f;
+				clip_enabled_flags[index] = 1;
+				clip_distance_factors[index] = 1.f;
 				break;
 
 			case rsx::user_clip_plane_op::less_than:
-				value = -1.f;
+				clip_enabled_flags[index] = 1;
+				clip_distance_factors[index] = -1.f;
 				break;
 			}
-
-			tmp[index] = value;
 		}
-		stream_vector_from_memory((char*)buffer, tmp.data());
-		stream_vector_from_memory((char*)buffer + 16, &tmp[4]);
+
+		memcpy(buffer, clip_enabled_flags, 32);
+		memcpy((char*)buffer + 32, clip_distance_factors, 32);
 	}
 
 	/**


### PR DESCRIPTION
Reimplements vertex shader output control; adding in options for more complex conditions.
Should fix remaining user clipping
 - Note: OpenGL requires all clip planes that may be enabled via glEnable be defined otherwise risk undefined results. This is the only case where it seems necessary to enable more than one plane even when not needed.
 - A value of 0.5 seems to work well as a default value. 1.0 does not, probably because it would be clipped as falling on the edge of typical clip volumes [-1, 1]
- Include strict vertex shader output declaration for compatibility with mesa drivers which are very strict
- Added a workaround for intel drivers which don't report their capabilities via extensions for some reason