### PR TITLE
Img deployement time and snr_config init changes

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Utilities/Config.h"
 #include "Utilities/lockless.h"
 #include "Emu/Memory/Memory.h"
@@ -209,7 +209,8 @@ void SPUThread::cpu_init()
 	ch_out_mbox.data.store({});
 	ch_out_intr_mbox.data.store({});
 
-	snr_config = 0;
+	//Now set in sys_spu_thread_initialize
+	//snr_config = 0;
 
 	ch_snr1.data.store({});
 	ch_snr2.data.store({});

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -209,8 +209,7 @@ void SPUThread::cpu_init()
 	ch_out_mbox.data.store({});
 	ch_out_intr_mbox.data.store({});
 
-	//Now set in sys_spu_thread_initialize
-	//snr_config = 0;
+	snr_config = 0;
 
 	ch_snr1.data.store({});
 	ch_snr2.data.store({});

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/Memory.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -210,6 +210,11 @@ error_code sys_spu_thread_initialize(vm::ptr<u32> thread, u32 group_id, u32 spu_
 		group->run_state = SPU_THREAD_GROUP_STATUS_INITIALIZED;
 	}
 
+	//Deploy the image and set snr_config
+	img->deploy(group->threads[spu_num]->offset);
+	group->threads[spu_num]->pc = img->entry_point;
+	group->threads[spu_num]->snr_config = 0;
+
 	return CELL_OK;
 }
 
@@ -343,11 +348,12 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 		if (thread)
 		{
 			auto& args = group->args[thread->index];
-			auto& img = group->imgs[thread->index];
+			//auto& img = group->imgs[thread->index];
 
-			img->deploy(thread->offset);
+			//Now deploying in sys_spu_thread_initialize
+			//img->deploy(thread->offset);
 
-			thread->pc = img->entry_point;
+			//thread->pc = img->entry_point;
 			thread->cpu_init();
 			thread->gpr[3] = v128::from64(0, args[0]);
 			thread->gpr[4] = v128::from64(0, args[1]);

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -348,12 +348,12 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 		if (thread)
 		{
 			auto& args = group->args[thread->index];
-			//auto& img = group->imgs[thread->index];
+			auto& img = group->imgs[thread->index];
 
 			//Now deploying in sys_spu_thread_initialize
-			//img->deploy(thread->offset);
+			img->deploy(thread->offset);
 
-			//thread->pc = img->entry_point;
+			thread->pc = img->entry_point;
 			thread->cpu_init();
 			thread->gpr[3] = v128::from64(0, args[0]);
 			thread->gpr[4] = v128::from64(0, args[1]);


### PR DESCRIPTION
Fixes some games that seem to lose img content before sys_spu_thread_group_start. They also use sys_spu_thread_get_spu_cfg before snr_config is set.