### PR TITLE
Earlier deploy and snr_config init

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Utilities/Config.h"
 #include "Utilities/VirtualMemory.h"
 #include "Crypto/sha1.h"
@@ -659,7 +659,7 @@ void ppu_thread::fast_call(u32 addr, u32 rtoc)
 	{
 		const auto _this = static_cast<ppu_thread*>(get_current_cpu_thread());
 
-		return fmt::format("%s [0x%08x]", _this->get_name(), _this->cia);
+		return fmt::format("%s [0x%08x LR:0x%x]", _this->get_name(), _this->cia, _this->lr);
 	};
 
 	auto at_ret = gsl::finally([&]()

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Utilities/Config.h"
 #include "Utilities/lockless.h"
 #include "Emu/Memory/Memory.h"
@@ -209,7 +209,8 @@ void SPUThread::cpu_init()
 	ch_out_mbox.data.store({});
 	ch_out_intr_mbox.data.store({});
 
-	snr_config = 0;
+	//Now set in sys_spu_thread_initialize
+	//snr_config = 0;
 
 	ch_snr1.data.store({});
 	ch_snr2.data.store({});

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "Emu/Memory/Memory.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/Memory.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -210,6 +210,10 @@ error_code sys_spu_thread_initialize(vm::ptr<u32> thread, u32 group_id, u32 spu_
 		group->run_state = SPU_THREAD_GROUP_STATUS_INITIALIZED;
 	}
 
+	//Deploy the image and set snr_config
+	img->deploy(group->threads[spu_num]->offset);
+	group->threads[spu_num]->snr_config = 0;
+
 	return CELL_OK;
 }
 
@@ -345,7 +349,8 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 			auto& args = group->args[thread->index];
 			auto& img = group->imgs[thread->index];
 
-			img->deploy(thread->offset);
+			//Now deploying in sys_spu_thread_initialize
+			//img->deploy(thread->offset);
 
 			thread->pc = img->entry_point;
 			thread->cpu_init();


### PR DESCRIPTION
Fixes some games that seem to lose img segment content before sys_spu_thread_group_start. They also use sys_spu_thread_get_spu_cfg before snr_config is set.

Games fixed:
Rune Factory: Oceans
And presumably(from random logs):
Dragon Ball Z budokai HD
Hakuoki Stories of the Shinsengumi
And I imagine a few other games that use criware could now work.