### PR TITLE
Force order of initialization for utils::version

### DIFF
--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -1,9 +1,10 @@
-﻿#include "Log.h"
+﻿#include "rpcs3_version.h"
+#include "Log.h"
 #include "File.h"
 #include "StrFmt.h"
 #include "sema.h"
 
-#include "rpcs3_version.h"
+
 #include <string>
 #include <unordered_map>
 
@@ -64,7 +65,7 @@ namespace logs
 			: file_writer(name)
 			, listener()
 		{
-			const std::string& start = fmt::format("\xEF\xBB\xBF" "RPCS3 v%s\n", rpcs3::version.to_string());
+			const std::string& start = fmt::format("\xEF\xBB\xBF" "RPCS3 v%s\n", rpcs3::version().to_string());
 			file_writer::log(start.data(), start.size());
 		}
 

--- a/rpcs3/Gui/AboutDialog.h
+++ b/rpcs3/Gui/AboutDialog.h
@@ -32,7 +32,7 @@ public:
 		t_descr->SetForegroundColour(wxColor(255, 255, 255));
 		t_descr->SetPosition(wxPoint(12, 50));
 
-		wxStaticText* t_version = new wxStaticText(this, wxID_ANY, "RPCS3 Version: " + rpcs3::version.to_string());
+		wxStaticText* t_version = new wxStaticText(this, wxID_ANY, "RPCS3 Version: " + rpcs3::version().to_string());
 		t_version->SetBackgroundColour(wxColor(100, 100, 100));
 		t_version->SetForegroundColour(wxColor(200, 200, 200));
 		t_version->SetPosition(wxPoint(12, 66));

--- a/rpcs3/Gui/ConLogFrame.cpp
+++ b/rpcs3/Gui/ConLogFrame.cpp
@@ -35,7 +35,9 @@ struct gui_listener : logs::listener
 		read = new packet;
 		last = new packet;
 		read->next = last.load();
-		last->msg = fmt::format("RPCS3 v%s\n", rpcs3::version.to_string());
+		//last->msg = fmt::format("RPCS3 v%s\n", rpcs3::version.to_string());
+
+		last->msg = "RSPC";
 
 		// Self-registration
 		logs::listener::add(this);

--- a/rpcs3/Gui/MainFrame.cpp
+++ b/rpcs3/Gui/MainFrame.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "stdafx_gui.h"
 #include "rpcs3.h"
 #include "MainFrame.h"
@@ -74,7 +74,7 @@ MainFrame::MainFrame()
 	, m_sys_menu_opened(false)
 {
 
-	SetLabel("RPCS3 v" + rpcs3::version.to_string());
+	SetLabel("RPCS3 v" + rpcs3::version().to_string());
 
 	wxMenuBar* menubar = new wxMenuBar();
 

--- a/rpcs3/rpcs3_api.cpp
+++ b/rpcs3/rpcs3_api.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "ps3emu_api_enums.h"
 #include "ps3emu_api_structs.h"
 #include "rpcs3_version.h"
@@ -65,7 +65,7 @@ UTILS_DLL_C_EXPORT ps3emu_api_error_code ps3emu_api_get_version_string(char *des
 		dest_buffer_size = ps3emu_api_max_version_length;
 	}
 
-	const std::string version_string = rpcs3::version.to_string();
+	const std::string version_string = rpcs3::version().to_string();
 
 	if (dest_buffer_size > version_string.length())
 	{
@@ -89,7 +89,7 @@ UTILS_DLL_C_EXPORT ps3emu_api_error_code ps3emu_api_get_version_number(int *vers
 		return ps3emu_api_bad_argument;
 	}
 
-	*version_number = rpcs3::version.to_hex();
+	*version_number = rpcs3::version().to_hex();
 	return ps3emu_api_ok;
 }
 

--- a/rpcs3/rpcs3_version.cpp
+++ b/rpcs3/rpcs3_version.cpp
@@ -1,8 +1,13 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "rpcs3_version.h"
 #include "git-version.h"
 
 namespace rpcs3
 {
-	const extern utils::version version{ 0, 0, 2, utils::version_type::alpha, 1, RPCS3_GIT_VERSION };
+	const utils::version& version() {
+		const static utils::version version{ 0, 0, 2, utils::version_type::alpha, 1, RPCS3_GIT_VERSION };
+
+		return version;
+	}
+	
 }

--- a/rpcs3/rpcs3_version.h
+++ b/rpcs3/rpcs3_version.h
@@ -1,9 +1,11 @@
-#pragma once
+﻿#pragma once
 #include <string>
 #include <cstdint>
 #include <Utilities/version.h>
 
 namespace rpcs3
 {
-	extern const utils::version version;
+	//warning this solves the order of initializatiob problem but not the order of deinitalization
+	//see https://isocpp.org/wiki/faq/ctors#static-init-order for more info
+	const utils::version& version();
 }


### PR DESCRIPTION
Because s_gui_listener depends on rpcs3::version it is possible for
s_gui_listener to be initialized before rpcs3::version causing a null
pointer dereference.
Replacing with a function call that has a local static
variable guarantees correct order of initialization.