### PR TITLE
Add option to select Vulkan device

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -470,7 +470,23 @@ VKGSRender::VKGSRender() : GSRender()
 		return;
 	}
 
-	m_swap_chain = m_thread_context.createSwapChain(hInstance, hWnd, gpus[0]);
+	bool gpu_found = false;
+	std::string adapter_name = g_cfg.video.vk.adapter;
+	for (auto &gpu : gpus)
+	{
+		if (gpu.name() == adapter_name)
+		{
+			m_swap_chain = m_thread_context.createSwapChain(hInstance, hWnd, gpu);
+			gpu_found = true;
+			break;
+		}
+	}
+
+	if (!gpu_found || adapter_name.empty())
+	{
+		m_swap_chain = m_thread_context.createSwapChain(hInstance, hWnd, gpus[0]);
+	}
+
 #endif
 
 	m_device = (vk::render_device *)(&m_swap_chain->get_device());

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -315,6 +315,14 @@ struct cfg_root : cfg::node
 
 		} d3d12{this};
 
+		struct node_vk : cfg::node
+		{
+			node_vk(cfg::node* _this) : cfg::node(_this, "Vulkan") {}
+
+			cfg::string adapter{this, "Adapter"};
+
+		} vk{this};
+
 	} video{this};
 
 	struct node_audio : cfg::node


### PR DESCRIPTION
I have both an Nvidia card and an AMD card in my PC, and regardless of which display is currently active, Vulkan defaults to the Nvidia card.

This commit allows the user to select the Vulkan device similar to selecting the Direct3D12 device.

This may make the configuration dialog slightly slower when opening.