### PR TITLE
GUI: Add recent games menu

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -345,6 +345,7 @@ void game_list_frame::doubleClickedSlot(const QModelIndex& index)
 	{
 		const std::string& path = Emu.GetGameDir() + m_game_data[i].root;
 		emit RequestIconPathSet(path);
+		emit RequestAddRecentGame(qstr(path), qstr("[" + m_game_data[i].serial + "] " + m_game_data[i].name));
 
 		Emu.Stop();
 
@@ -352,8 +353,6 @@ void game_list_frame::doubleClickedSlot(const QModelIndex& index)
 		{
 			LOG_ERROR(LOADER, "Failed to boot /dev_hdd0/game/%s", m_game_data[i].root);
 		}
-
-		emit RequestAddRecentGame(qstr(path), qstr("[" + m_game_data[i].serial + "] " + m_game_data[i].name));
 	}
 	else
 	{
@@ -440,6 +439,7 @@ void game_list_frame::Boot(int row)
 {
 	const std::string& path = Emu.GetGameDir() + m_game_data[row].root;
 	emit RequestIconPathSet(path);
+	emit RequestAddRecentGame(qstr(path), qstr("[" + m_game_data[row].serial + "] " + m_game_data[row].name));
 
 	Emu.Stop();
 
@@ -448,8 +448,6 @@ void game_list_frame::Boot(int row)
 		QMessageBox::warning(this, tr("Warning!"), tr("Failed to boot ") + qstr(m_game_data[row].root));
 		LOG_ERROR(LOADER, "Failed to boot /dev_hdd0/game/%s", m_game_data[row].root);
 	}
-
-	emit RequestAddRecentGame(qstr(path), qstr("[" + m_game_data[row].serial + "] " + m_game_data[row].name));
 }
 
 void game_list_frame::RemoveCustomConfiguration(int row)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -352,6 +352,8 @@ void game_list_frame::doubleClickedSlot(const QModelIndex& index)
 		{
 			LOG_ERROR(LOADER, "Failed to boot /dev_hdd0/game/%s", m_game_data[i].root);
 		}
+
+		emit RequestAddRecentGame(qstr(path), qstr("[" + m_game_data[i].serial + "] " + m_game_data[i].name));
 	}
 	else
 	{
@@ -446,6 +448,8 @@ void game_list_frame::Boot(int row)
 		QMessageBox::warning(this, tr("Warning!"), tr("Failed to boot ") + qstr(m_game_data[row].root));
 		LOG_ERROR(LOADER, "Failed to boot /dev_hdd0/game/%s", m_game_data[row].root);
 	}
+
+	emit RequestAddRecentGame(qstr(path), qstr("[" + m_game_data[row].serial + "] " + m_game_data[row].name));
 }
 
 void game_list_frame::RemoveCustomConfiguration(int row)

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -109,6 +109,7 @@ private slots:
 signals:
 	void game_list_frameClosed();
 	void RequestIconPathSet(const std::string path);
+	void RequestAddRecentGame(const QString path, const QString name);
 protected:
 	/** Override inherited method from Qt to allow signalling when close happened.*/
 	void closeEvent(QCloseEvent* event);

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -45,6 +45,10 @@ namespace GUI
 	const QString logger      = "Logger";
 	const QString meta        = "Meta";
 
+	const GUI_SAVE rg_freeze = GUI_SAVE(main_window, "recentGamesFrozen", false);
+	const GUI_SAVE rg_names  = GUI_SAVE(main_window, "recentGamesNames", QStringList());
+	const GUI_SAVE rg_paths  = GUI_SAVE(main_window, "recentGamesPaths", QStringList());
+
 	const GUI_SAVE ib_pkg_success = GUI_SAVE( main_window, "infoBoxEnabledInstallPKG", true );
 	const GUI_SAVE ib_pup_success = GUI_SAVE( main_window, "infoBoxEnabledInstallPUP", true );
 	const GUI_SAVE ib_show_welcome = GUI_SAVE(main_window, "infoBoxEnabledWelcome", true);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -731,6 +731,15 @@ void main_window::OnEmuStop()
 		sysPauseAct->setText(Emu.IsReady() ? tr("&Start\tCtrl+E") : tr("&Resume\tCtrl+E"));
 		sysPauseAct->setIcon(icon_play);
 	}
+
+	// Enable Recent Games
+	for (auto act : m_bootRecentMenu->actions())
+	{
+		if (act != freezeRecentAct && act != clearRecentAct)
+		{
+			act->setEnabled(true);
+		}
+	}
 }
 
 void main_window::OnEmuReady()
@@ -939,6 +948,15 @@ void main_window::AddRecentAction(const QString path, QString name)
 
 	guiSettings->SetValue(GUI::rg_names, m_rg_names);
 	guiSettings->SetValue(GUI::rg_paths, m_rg_paths);
+
+	// Disable Recent Games
+	for (auto act : m_bootRecentMenu->actions())
+	{
+		if (act != freezeRecentAct && act != clearRecentAct)
+		{
+			act->setEnabled(false);
+		}
+	}
 }
 
 void main_window::CreateActions()
@@ -1056,6 +1074,7 @@ void main_window::CreateConnects()
 	connect(bootElfAct, &QAction::triggered, this, &main_window::BootElf);
 	connect(bootGameAct, &QAction::triggered, this, &main_window::BootGame);
 	connect(clearRecentAct, &QAction::triggered, [this](){
+		if (freezeRecentAct->isChecked()) { return; }
 		m_rg_names.clear();
 		m_rg_paths.clear();
 		for (auto act : m_recentGameActs)

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -796,7 +796,7 @@ void main_window::BootRecentAction(const QAction* act)
 	const QString pth = act->data().toString();
 
 	// path is invalid: remove action from list return
-	if (!QFileInfo(pth).isFile())
+	if (!QFileInfo(pth).isDir() && !QFileInfo(pth).isFile())
 	{
 		if (m_rg_paths.contains(pth))
 		{
@@ -850,7 +850,7 @@ void main_window::BootRecentAction(const QAction* act)
 QAction* main_window::CreateRecentAction(const QString& path, const QString& name, const uint& sc_idx)
 {
 	// if path is not valid remove from list
-	if (!QFileInfo(path).isFile())
+	if (!QFileInfo(path).isDir() && !QFileInfo(path).isFile())
 	{
 		if (m_rg_paths.contains(path))
 		{

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -92,6 +92,7 @@ private:
 	QAction* CreateRecentAction(const QString path, const QString name, const uint sc_idx);
 	void BootRecentAction(const QAction* act);
 	void AddRecentAction(const QString path, QString name);
+	bool InvalidRecentAction(const QAction* act);
 
 	QStringList m_rg_names;
 	QStringList m_rg_paths;

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -89,10 +89,9 @@ private:
 	void EnableMenus(bool enabled);
 	void keyPressEvent(QKeyEvent *keyEvent);
 
-	QAction* CreateRecentAction(const QString path, const QString name, const uint sc_idx);
+	QAction* CreateRecentAction(const QString& path, const QString& name, const uint& sc_idx);
 	void BootRecentAction(const QAction* act);
 	void AddRecentAction(const QString path, QString name);
-	bool InvalidRecentAction(const QAction* act);
 
 	QStringList m_rg_names;
 	QStringList m_rg_paths;

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -89,10 +89,21 @@ private:
 	void EnableMenus(bool enabled);
 	void keyPressEvent(QKeyEvent *keyEvent);
 
+	QAction* CreateRecentAction(const QString path, const QString name, const uint sc_idx);
+	void BootRecentAction(const QAction* act);
+	void AddRecentAction(const QString path, QString name);
+
+	QStringList m_rg_names;
+	QStringList m_rg_paths;
+	QMenu* m_bootRecentMenu;
+	QList<QAction*> m_recentGameActs;
+
 	QActionGroup* iconSizeActGroup;
 
 	QAction *bootElfAct;
 	QAction *bootGameAct;
+	QAction *clearRecentAct;
+	QAction *freezeRecentAct;
 	QAction *bootInstallPkgAct;
 	QAction *bootInstallPupAct;
 	QAction *sysPauseAct;


### PR DESCRIPTION
adds a submenu to boot "Boot Recent"
- submenu contains functions "clear list" and "freeze list"
- activated "freeze list" will prevent changes to the list
- successfull boots will be added to the top of the list
- when the list contains 9 items the last will be removed on new addition
- every item has a boot shortcut from Ctrl+1 to Ctrl+9
- games can only be bootet from mainwindow and if emu is not running
- if names are too long they will be shortened like this "This name is waaa(....)aaaay to long"
- on mouse hover you will see a tooltip with the full name
- if the game title is a path it will be shown only as filename while the tooltip remains the path
- remove invalid paths from list on start or boot