### PR TITLE
Dx12/Vulk: Fix KernelBase.dll crash

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1163,7 +1163,9 @@ namespace vk
 				return gpus;
 
 			uint32_t num_gpus;
-			CHECK_RESULT(vkEnumeratePhysicalDevices(m_instance, &num_gpus, nullptr));
+			// This may fail on unsupported drivers, so just assume no devices
+			if (vkEnumeratePhysicalDevices(m_instance, &num_gpus, nullptr) != VK_SUCCESS)
+				return gpus;
 
 			if (gpus.size() != num_gpus)
 			{

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -119,27 +119,30 @@ Render_Creator::Render_Creator()
 {
 	// check for dx12 adapters
 #ifdef _MSC_VER
-	Microsoft::WRL::ComPtr<IDXGIFactory4> dxgi_factory;
-	supportsD3D12 = SUCCEEDED(CreateDXGIFactory(IID_PPV_ARGS(&dxgi_factory)));
+	HMODULE D3D12Module = LoadLibrary(L"d3d12.dll");
 
-	if (supportsD3D12)
+	if (D3D12Module != NULL)
 	{
-		supportsD3D12 = false;
-		IDXGIAdapter1* pAdapter = nullptr;
-
-		for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != dxgi_factory->EnumAdapters1(adapterIndex, &pAdapter); ++adapterIndex)
+		Microsoft::WRL::ComPtr<IDXGIAdapter1> pAdapter;
+		Microsoft::WRL::ComPtr<IDXGIFactory1> dxgi_factory;
+		if (SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&dxgi_factory))))
 		{
-			HMODULE D3D12Module = verify("d3d12.dll", LoadLibrary(L"d3d12.dll"));
 			PFN_D3D12_CREATE_DEVICE wrapD3D12CreateDevice = (PFN_D3D12_CREATE_DEVICE)GetProcAddress(D3D12Module, "D3D12CreateDevice");
-
-			if (SUCCEEDED(wrapD3D12CreateDevice(pAdapter, D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+			if (wrapD3D12CreateDevice != nullptr)
 			{
-				//A device with D3D12 support found. Init data
-				supportsD3D12 = true;
+				for (UINT adapterIndex = 0; DXGI_ERROR_NOT_FOUND != dxgi_factory->EnumAdapters1(adapterIndex, pAdapter.ReleaseAndGetAddressOf()); ++adapterIndex)
+				{
+					if (SUCCEEDED(wrapD3D12CreateDevice(pAdapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
+					{
+						//A device with D3D12 support found. Init data
+						supportsD3D12 = true;
 
-				DXGI_ADAPTER_DESC desc;
-				pAdapter->GetDesc(&desc);
-				D3D12Adapters.append(QString::fromWCharArray(desc.Description));
+						DXGI_ADAPTER_DESC desc;
+						if (SUCCEEDED(pAdapter->GetDesc(&desc)))
+							D3D12Adapters.append(QString::fromWCharArray(desc.Description));
+					}
+				}
+				
 			}
 		}
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -49,9 +49,6 @@ main_window::main_window(QWidget *parent) : QMainWindow(parent), m_sys_menu_open
 
 	setDockNestingEnabled(true);
 
-	// Get Render Adapters
-	m_Render_Creator = Render_Creator();
-
 	//Load Icons: This needs to happen before any actions or buttons are created
 	icon_play = QIcon(":/Icons/play.png");
 	icon_pause = QIcon(":/Icons/pause.png");


### PR DESCRIPTION
This should hopefully fix the crash that was happening with fermi / nvidia cards.

I think the main issue was the vulkan throw happening in enumerateDevices, but ive also rewrote the dx12 check code slightly as well to hopefully be a bit 'safer'