### PR TITLE
Fix inconsistent selection in gamelist/grid

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -418,9 +418,7 @@ void game_list_frame::Refresh(bool fromDrive)
 
 	if (m_isListLayout)
 	{
-		int row = gameList->currentRow();
-
-		PopulateGameList();
+		int row = PopulateGameList(gameList->currentRow() >= 0 ? m_game_data.at(gameList->item(gameList->currentRow(), 0)->data(Qt::UserRole).toInt()).info.icon_path : "");
 		FilterData();
 		gameList->selectRow(row);
 		gameList->sortByColumn(m_sortColumn, m_colSortOrder);
@@ -734,8 +732,10 @@ void game_list_frame::resizeEvent(QResizeEvent *event)
 /**
  Cleans and readds entries to table widget in UI.
 */
-void game_list_frame::PopulateGameList()
+int game_list_frame::PopulateGameList(const std::string& selected)
 {
+	int result = -1;
+
 	// Hack to delete everything without removing the headers.
 	gameList->setRowCount(0);
 
@@ -745,8 +745,7 @@ void game_list_frame::PopulateGameList()
 	{
 		QTableWidgetItem* curr = new QTableWidgetItem;
 		curr->setFlags(curr->flags() & ~Qt::ItemIsEditable);
-		QString qtext = qstr(text);
-		curr->setText(qtext);
+		curr->setText(qstr(text));
 		return curr;
 	};
 
@@ -774,8 +773,12 @@ void game_list_frame::PopulateGameList()
 		gameList->setItem(row, 5, l_GetItem(game.info.category));
 		gameList->setItem(row, 6, l_GetItem(game.info.root));
 
+		if (selected == game.info.icon_path) result = row;
+
 		row++;
 	}
+
+	return result;
 }
 
 game_list_grid* game_list_frame::MakeGrid(uint maxCols, const QSize& image_size)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -428,6 +428,7 @@ void game_list_frame::Refresh(bool fromDrive)
 		gameList->verticalHeader()->setMaximumSectionSize(m_Icon_Size.height());
 		gameList->resizeRowsToContents();
 		gameList->resizeColumnToContents(0);
+		gameList->scrollTo(gameList->currentIndex());
 	}
 	else
 	{
@@ -445,6 +446,7 @@ void game_list_frame::Refresh(bool fromDrive)
 		connect(m_xgrid, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
 		m_Central_Widget->addWidget(m_xgrid);
 		m_Central_Widget->setCurrentWidget(m_xgrid);
+		m_xgrid->scrollTo(m_xgrid->currentIndex());
 	}
 }
 
@@ -892,16 +894,18 @@ bool game_list_frame::SearchMatchesApp(const std::string& name, const std::strin
 
 std::string game_list_frame::CurrentSelectionIconPath()
 {
+	std::string selection = "";
+
 	if (m_oldLayoutIsList && gameList->currentRow() >= 0)
 	{
-		return m_game_data.at(gameList->item(gameList->currentRow(), 0)->data(Qt::UserRole).toInt()).info.icon_path;
+		selection = m_game_data.at(gameList->item(gameList->currentRow(), 0)->data(Qt::UserRole).toInt()).info.icon_path;
 	}
 	else if (!m_oldLayoutIsList && m_xgrid->currentItem() != nullptr)
 	{
-		return m_game_data.at(m_xgrid->currentItem()->data(Qt::UserRole).toInt()).info.icon_path;
+		selection = m_game_data.at(m_xgrid->currentItem()->data(Qt::UserRole).toInt()).info.icon_path;
 	}
-	else
-	{
-		return "";
-	}
+
+	m_oldLayoutIsList = m_isListLayout;
+
+	return selection;
 }

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -156,7 +156,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> settings, Render_
 	gameList->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
 	gameList->setContextMenuPolicy(Qt::CustomContextMenu);
 
-	gameList->setColumnCount(8);
+	gameList->setColumnCount(7);
 	gameList->setHorizontalHeaderItem(0, new QTableWidgetItem(tr("Icon")));
 	gameList->setHorizontalHeaderItem(1, new QTableWidgetItem(tr("Name")));
 	gameList->setHorizontalHeaderItem(2, new QTableWidgetItem(tr("Serial")));
@@ -164,9 +164,6 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> settings, Render_
 	gameList->setHorizontalHeaderItem(4, new QTableWidgetItem(tr("App version")));
 	gameList->setHorizontalHeaderItem(5, new QTableWidgetItem(tr("Category")));
 	gameList->setHorizontalHeaderItem(6, new QTableWidgetItem(tr("Path")));
-	gameList->setHorizontalHeaderItem(7, new QTableWidgetItem(tr("Missingno"))); // Holds index which points back to original array
-
-	gameList->setColumnHidden(7, true); // Comment this if your sorting ever for whatever reason messes up.
 
 	m_Central_Widget = new QStackedWidget(this);
 	m_Central_Widget->addWidget(gameList);
@@ -427,7 +424,6 @@ void game_list_frame::Refresh(bool fromDrive)
 		FilterData();
 		gameList->selectRow(row);
 		gameList->sortByColumn(m_sortColumn, m_colSortOrder);
-		gameList->setColumnHidden(7, true);
 		gameList->verticalHeader()->setMinimumSectionSize(m_Icon_Size.height());
 		gameList->verticalHeader()->setMaximumSectionSize(m_Icon_Size.height());
 		gameList->resizeRowsToContents();
@@ -493,7 +489,7 @@ void game_list_frame::doubleClickedSlot(const QModelIndex& index)
 
 	if (m_isListLayout)
 	{
-		i = gameList->item(index.row(), 7)->text().toInt();
+		i = gameList->item(index.row(), 0)->data(Qt::UserRole).toInt();
 	}
 	else
 	{
@@ -533,9 +529,9 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	if (m_isListLayout)
 	{
 		int row = gameList->indexAt(pos).row();
-		QTableWidgetItem* item = gameList->item(row, 7);
+		QTableWidgetItem* item = gameList->item(row, 0);
 		if (item == nullptr) return;  // null happens if you are double clicking in dockwidget area on nothing.
-		index = item->text().toInt();
+		index = item->data(Qt::UserRole).toInt();
 	}
 	else
 	{
@@ -768,6 +764,7 @@ void game_list_frame::PopulateGameList()
 		QTableWidgetItem* iconItem = new QTableWidgetItem;
 		iconItem->setFlags(iconItem->flags() & ~Qt::ItemIsEditable);
 		iconItem->setData(Qt::DecorationRole, game.pxmap);
+		iconItem->setData(Qt::UserRole, row);
 		gameList->setItem(row, 0, iconItem);
 
 		gameList->setItem(row, 1, l_GetItem(game.info.name));
@@ -776,12 +773,6 @@ void game_list_frame::PopulateGameList()
 		gameList->setItem(row, 4, l_GetItem(game.info.app_ver));
 		gameList->setItem(row, 5, l_GetItem(game.info.category));
 		gameList->setItem(row, 6, l_GetItem(game.info.root));
-
-		// A certain magical index which points back to the original game index. 
-		// Essentially, this column makes the tablewidget's row into a map, accomplishing what columns did but much simpler.
-		QTableWidgetItem* index = new QTableWidgetItem;
-		index->setText(QString::number(row));
-		gameList->setItem(row, 7, index);
 
 		row++;
 	}

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -85,11 +85,13 @@ protected:
 	void closeEvent(QCloseEvent* event);
 	void resizeEvent(QResizeEvent *event);
 private:
-	game_list_grid* MakeGrid(uint maxCols, const QSize& image_size);
+	void PopulateGameGrid(uint maxCols, const QSize& image_size);
 	void FilterData();
 
-	int PopulateGameList(const std::string& selected);
+	int PopulateGameList();
 	bool SearchMatchesApp(const std::string& name, const std::string& serial);
+
+	std::string CurrentSelectionIconPath();
 
 	// Which widget we are displaying depends on if we are in grid or list mode.
 	QMainWindow* m_Game_Dock;
@@ -98,7 +100,7 @@ private:
 	QLineEdit* m_Search_Bar;
 	QSlider* m_Slider_Size;
 	QTableWidget *gameList;
-	std::unique_ptr<game_list_grid> m_xgrid;
+	game_list_grid* m_xgrid;
 
 	// Actions regarding showing/hiding columns
 	QAction* showIconColAct;
@@ -135,6 +137,7 @@ private:
 	int m_sortColumn;
 	Qt::SortOrder m_colSortOrder;
 	bool m_isListLayout = true;
+	bool m_oldLayoutIsList = true;
 	bool m_showToolBar = true;
 	std::vector<GUI_GameInfo> m_game_data;
 	QSize m_Icon_Size;

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -88,7 +88,7 @@ private:
 	game_list_grid* MakeGrid(uint maxCols, const QSize& image_size);
 	void FilterData();
 
-	void PopulateGameList();
+	int PopulateGameList(const std::string& selected);
 	bool SearchMatchesApp(const std::string& name, const std::string& serial);
 
 	// Which widget we are displaying depends on if we are in grid or list mode.

--- a/rpcs3/rpcs3qt/graphics_tab.cpp
+++ b/rpcs3/rpcs3qt/graphics_tab.cpp
@@ -94,6 +94,11 @@ graphics_tab::graphics_tab(std::shared_ptr<emu_settings> xSettings, Render_Creat
 			// D3D Adapter
 			if (m_isD3D12)
 			{
+				// Reset other adapters to old config
+				if (supportsVulkan)
+				{
+					xemu_settings->SetSetting(emu_settings::VulkanAdapter, sstr(old_Vulkan));
+				}
 				// Fill combobox
 				graphicsAdapterBox->clear();
 				for (auto adapter : D3D12Adapters)
@@ -101,19 +106,31 @@ graphics_tab::graphics_tab(std::shared_ptr<emu_settings> xSettings, Render_Creat
 					graphicsAdapterBox->addItem(adapter);
 				}
 				// Reset Adapter to old config
-				xemu_settings->SetSetting(emu_settings::D3D12Adapter, sstr(old_D3D12));
 				int idx = graphicsAdapterBox->findText(old_D3D12);
 				if (idx == -1)
 				{
 					idx = 0;
-					LOG_WARNING(RSX, "Current %s adapter not available: resetting to default!", sstr(r_D3D12));
+					if (old_D3D12.isEmpty())
+					{
+						LOG_WARNING(RSX, "%s adapter config empty: setting to default!", sstr(r_D3D12));
+					}
+					else
+					{
+						LOG_WARNING(RSX, "Last used %s adapter not found: setting to default!", sstr(r_D3D12));
+					}
 				}
 				graphicsAdapterBox->setCurrentIndex(idx);
+				xemu_settings->SetSetting(emu_settings::D3D12Adapter, sstr(graphicsAdapterBox->currentText()));
 			}
 
 			// Vulkan Adapter
 			else if (m_isVulkan)
 			{
+				// Reset other adapters to old config
+				if (supportsD3D12)
+				{
+					xemu_settings->SetSetting(emu_settings::D3D12Adapter, sstr(old_D3D12));
+				}
 				// Fill combobox
 				graphicsAdapterBox->clear();
 				for (auto adapter : vulkanAdapters)
@@ -121,14 +138,21 @@ graphics_tab::graphics_tab(std::shared_ptr<emu_settings> xSettings, Render_Creat
 					graphicsAdapterBox->addItem(adapter);
 				}
 				// Reset Adapter to old config
-				xemu_settings->SetSetting(emu_settings::VulkanAdapter, sstr(old_Vulkan));
 				int idx = graphicsAdapterBox->findText(old_Vulkan);
 				if (idx == -1)
 				{
 					idx = 0;
-					LOG_WARNING(RSX, "Current %s adapter not available: resetting to default!", sstr(r_Vulkan));
+					if (old_Vulkan.isEmpty())
+					{
+						LOG_WARNING(RSX, "%s adapter config empty: setting to default!", sstr(r_Vulkan));
+					}
+					else
+					{
+						LOG_WARNING(RSX, "Last used %s adapter not found: setting to default!", sstr(r_Vulkan));
+					}
 				}
 				graphicsAdapterBox->setCurrentIndex(idx);
+				xemu_settings->SetSetting(emu_settings::VulkanAdapter, sstr(graphicsAdapterBox->currentText()));
 			}
 
 			// Other Adapter


### PR DESCRIPTION
On current builds the selected item jumps randomly on any kind of list refresh.
Now the selection will stay on the same game, even when switching list/grid mode.
The view will scroll to the selection and not to some other place anymore.

This PR also exchanges the mysterious and rare missingno for something more suitable

- fix adapter saving to config