### PR TITLE
Reimplement debugger resize & disassembly

### DIFF
--- a/rpcs3/rpcs3qt/cg_disasm_window.cpp
+++ b/rpcs3/rpcs3qt/cg_disasm_window.cpp
@@ -2,6 +2,9 @@
 
 #include "cg_disasm_window.h"
 #include "Emu/System.h"
+#include "Emu/RSX/CgBinaryProgram.h"
+
+#include <QSplitter>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
@@ -11,40 +14,35 @@
 #include <QDockWidget>
 #include <QCoreApplication>
 #include <QFontDatabase>
-#include "Emu/RSX/CgBinaryProgram.h"
 
 inline QString qstr(const std::string& _in) { return QString::fromUtf8(_in.data(), _in.size()); }
 inline std::string sstr(const QString& _in) { return _in.toUtf8().toStdString(); }
 
-cg_disasm_window::cg_disasm_window(QWidget* parent): QTabWidget()
+cg_disasm_window::cg_disasm_window(QWidget* parent): QWidget()
 {
 	setWindowTitle(tr("Cg Disasm"));
 	setAttribute(Qt::WA_DeleteOnClose);
-	setMinimumSize(200, 150); // seems fine on win 10
+	setMinimumSize(QSize(200, 150)); // seems fine on win 10
 	resize(QSize(620, 395));
 	
-	tab_disasm = new QWidget(this);
-	tab_glsl = new QWidget(this);
-	addTab(tab_disasm, "ASM");
-	addTab(tab_glsl, "GLSL");
-	
-	QVBoxLayout* layout_disasm = new QVBoxLayout();
-	m_disasm_text = new QTextEdit();
-	m_disasm_text->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+	m_disasm_text = new QTextEdit(this);
 	m_disasm_text->setReadOnly(true);
 	m_disasm_text->setWordWrapMode(QTextOption::NoWrap);
 	m_disasm_text->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	layout_disasm->addWidget(m_disasm_text);
-	tab_disasm->setLayout(layout_disasm);
 	
-	QVBoxLayout* layout_glsl = new QVBoxLayout();
-	m_glsl_text = new QTextEdit();
-	m_glsl_text->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+	m_glsl_text = new QTextEdit(this);
 	m_glsl_text->setReadOnly(true);
 	m_glsl_text->setWordWrapMode(QTextOption::NoWrap);
 	m_glsl_text->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	layout_glsl->addWidget(m_glsl_text);
-	tab_glsl->setLayout(layout_glsl);
+
+	QSplitter* splitter = new QSplitter();
+	splitter->addWidget(m_disasm_text);
+	splitter->addWidget(m_glsl_text);
+
+	QHBoxLayout* layout = new QHBoxLayout();
+	layout->addWidget(splitter);
+
+	setLayout(layout);
 
 	m_disasm_text->setContextMenuPolicy(Qt::CustomContextMenu);
 	m_glsl_text->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -52,10 +50,9 @@ cg_disasm_window::cg_disasm_window(QWidget* parent): QTabWidget()
 	connect(m_glsl_text, &QWidget::customContextMenuRequested, this, &cg_disasm_window::ShowContextMenu);
 }
 
-void cg_disasm_window::ShowContextMenu(const QPoint &pos) // this is a slot
+void cg_disasm_window::ShowContextMenu(const QPoint &pos)
 {
 	QMenu myMenu;
-	QPoint globalPos = mapToGlobal(pos);
 	QAction* clear = new QAction(tr("&Clear"));
 	QAction* open = new QAction(tr("Open &Cg binary program"));
 
@@ -76,5 +73,5 @@ void cg_disasm_window::ShowContextMenu(const QPoint &pos) // this is a slot
 		m_glsl_text->setText(qstr(disasm.GetGlslShader()));
 	});
 
-	myMenu.exec(globalPos);
+	myMenu.exec(QCursor::pos());
 }

--- a/rpcs3/rpcs3qt/cg_disasm_window.cpp
+++ b/rpcs3/rpcs3qt/cg_disasm_window.cpp
@@ -1,8 +1,6 @@
 #include "stdafx.h"
 
 #include "cg_disasm_window.h"
-#include "Emu/System.h"
-#include "Emu/RSX/CgBinaryProgram.h"
 
 #include <QSplitter>
 #include <QMenu>
@@ -14,6 +12,8 @@
 #include <QDockWidget>
 #include <QCoreApplication>
 #include <QFontDatabase>
+
+#include "Emu/RSX/CgBinaryProgram.h"
 
 inline QString qstr(const std::string& _in) { return QString::fromUtf8(_in.data(), _in.size()); }
 inline std::string sstr(const QString& _in) { return _in.toUtf8().toStdString(); }

--- a/rpcs3/rpcs3qt/cg_disasm_window.h
+++ b/rpcs3/rpcs3qt/cg_disasm_window.h
@@ -2,6 +2,10 @@
 #define CGDISASMWINDOW_H
 
 #include <QTextEdit>
+#include <QDropEvent>
+
+#include "stdafx.h"
+#include "gui_settings.h"
 
 class cg_disasm_window : public QWidget
 {
@@ -9,16 +13,27 @@ class cg_disasm_window : public QWidget
 
 private slots:
 	void ShowContextMenu(const QPoint &pos);
+	void ShowDisasm();
+	bool IsValidFile(const QMimeData& md, bool save = false);
 
 private:
 	QString m_path_last;
 	QTextEdit* m_disasm_text;
 	QTextEdit* m_glsl_text;
+	QList<QUrl> m_urls;
 
 	QAction *openCgBinaryProgram;
 
+	std::shared_ptr<gui_settings> xgui_settings;
+
 public:
-	explicit cg_disasm_window(QWidget *parent);
+	explicit cg_disasm_window(std::shared_ptr<gui_settings> xSettings, QWidget *parent);
+
+protected:
+	void dropEvent(QDropEvent* ev);
+	void dragEnterEvent(QDragEnterEvent* ev);
+	void dragMoveEvent(QDragMoveEvent* ev);
+	void dragLeaveEvent(QDragLeaveEvent* ev);
 };
 
 #endif	// CGDISASMWINDOW_H

--- a/rpcs3/rpcs3qt/cg_disasm_window.h
+++ b/rpcs3/rpcs3qt/cg_disasm_window.h
@@ -2,20 +2,18 @@
 #define CGDISASMWINDOW_H
 
 #include <QTextEdit>
-#include <QMainWindow>
 
-class cg_disasm_window : public QTabWidget
+class cg_disasm_window : public QWidget
 {
 	Q_OBJECT
 
 private slots:
 	void ShowContextMenu(const QPoint &pos);
+
 private:
 	QString m_path_last;
 	QTextEdit* m_disasm_text;
 	QTextEdit* m_glsl_text;
-	QWidget* tab_disasm;
-	QWidget* tab_glsl;
 
 	QAction *openCgBinaryProgram;
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -538,9 +538,14 @@ void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
 		{
 			RemoveBreakPoint(pc);
 		}
-		else if (vm::check_addr(pc))
+		else
 		{
-			AddBreakPoint(pc);
+			const auto cpu = m_debugFrame->cpu.lock();
+
+			if (g_system == system_type::ps3 && cpu->id_type() == 1 && vm::check_addr(pc))
+			{
+				AddBreakPoint(pc);
+			}
 		}
 
 		ShowAddr(start_pc);

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -197,12 +197,15 @@ void debugger_frame::UpdateUnitList()
 		return;
 	}
 
+	QVariant old_cpu = m_choice_units->currentData();
+
 	m_choice_units->clear();
 
 	const auto on_select = [&](u32, cpu_thread& cpu)
 	{
 		QVariant var_cpu = qVariantFromValue((void *)&cpu);
 		m_choice_units->addItem(qstr(cpu.get_name()), var_cpu);
+		if (old_cpu == var_cpu) m_choice_units->setCurrentIndex(m_choice_units->count() - 1);
 	};
 
 	{
@@ -345,7 +348,7 @@ void debugger_frame::Show_Val()
 	connect(button_ok, &QAbstractButton::clicked, diag, &QDialog::accept);
 	connect(button_cancel, &QAbstractButton::clicked, diag, &QDialog::reject);
 
-	diag->move(mapFromGlobal(QCursor::pos()) + QPoint(0, diag->sizeHint().height()));
+	diag->move(QCursor::pos());
 
 	if (diag->exec() == QDialog::Accepted)
 	{

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -34,7 +34,7 @@ debugger_frame::debugger_frame(QWidget *parent) : QDockWidget(tr("Debugger"), pa
 	m_btn_run = new QPushButton(tr("Run"), this);
 	m_btn_pause = new QPushButton(tr("Pause"), this);
 
-	EnableButtons(Emu.IsRunning() || Emu.IsPaused());
+	EnableButtons(!Emu.IsStopped());
 
 	hbox_b_main->addWidget(m_go_to_addr);
 	hbox_b_main->addWidget(m_go_to_pc);
@@ -525,7 +525,7 @@ void debugger_list::keyPressEvent(QKeyEvent* event)
 
 void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
 {
-	if (event->button() == Qt::LeftButton && (Emu.IsRunning() || Emu.IsPaused()))
+	if (event->button() == Qt::LeftButton && !Emu.IsStopped())
 	{
 		long i = currentRow();
 		if (i < 0) return;
@@ -538,7 +538,7 @@ void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
 		{
 			RemoveBreakPoint(pc);
 		}
-		else
+		else if (vm::check_addr(pc))
 		{
 			AddBreakPoint(pc);
 		}

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -19,16 +19,12 @@
 #include "instruction_editor_dialog.h"
 #include "register_editor_dialog.h"
 
-#include <QApplication>
 #include <QDockWidget>
 #include <QListWidget>
 #include <QPushButton>
-#include <QLineEdit>
 #include <QComboBox>
 #include <QKeyEvent>
 #include <QWheelEvent>
-#include <QInputDialog>
-#include <QFontDatabase>
 #include <QTimer>
 #include <QTextEdit>
 
@@ -49,6 +45,7 @@ class debugger_frame : public QDockWidget
 	QPushButton* m_btn_run;
 	QPushButton* m_btn_pause;
 	QComboBox* m_choice_units;
+	QString m_current_choice;
 
 	u64 m_threads_created = 0;
 	u64 m_threads_deleted = 0;
@@ -69,7 +66,6 @@ public:
 
 	u32 GetPc() const;
 	u32 CentrePc(u32 pc) const;
-	//void resizeEvent(QResizeEvent* event);
 	void DoUpdate();
 	void WriteRegs();
 	void EnableButtons(bool enable);
@@ -114,6 +110,7 @@ protected:
 	void keyPressEvent(QKeyEvent* event);
 	void mouseDoubleClickEvent(QMouseEvent* event);
 	void wheelEvent(QWheelEvent* event);
+	void resizeEvent(QResizeEvent* event);
 };
 
 #endif // DEBUGGERFRAME_H

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -63,6 +63,7 @@ namespace GUI
 	const GUI_SAVE fd_boot_elf     = GUI_SAVE( main_window, "lastExplorePathELF",  "" );
 	const GUI_SAVE fd_boot_game    = GUI_SAVE( main_window, "lastExplorePathGAME", "" );
 	const GUI_SAVE fd_decrypt_sprx = GUI_SAVE( main_window, "lastExplorePathSPRX", "" );
+	const GUI_SAVE fd_cg_disasm    = GUI_SAVE( main_window, "lastExplorePathCGD",  "" );
 
 	const GUI_SAVE mw_debugger    = GUI_SAVE( main_window, "debuggerVisible", false );
 	const GUI_SAVE mw_logger      = GUI_SAVE( main_window, "loggerVisible",   true );

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1154,7 +1154,7 @@ void main_window::CreateConnects()
 		sdid->show();
 	});
 	connect(toolsCgDisasmAct, &QAction::triggered, [=](){
-		cg_disasm_window* cgdw = new cg_disasm_window(this);
+		cg_disasm_window* cgdw = new cg_disasm_window(guiSettings, this);
 		cgdw->show();
 	});
 	connect(toolskernel_explorerAct, &QAction::triggered, [=](){

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -741,6 +741,7 @@ void main_window::OnEmuStop()
 
 void main_window::OnEmuReady()
 {
+	debuggerFrame->EnableButtons(true);
 #ifdef _WIN32
 	thumb_playPause->setToolTip(Emu.IsReady() ? tr("Start") : tr("Resume"));
 	thumb_playPause->setIcon(icon_play);


### PR DESCRIPTION
Debugger:
- add splitter to resize address list vs. Regs
- resize now adjusts listsize again
- fix interrupt on select
- prevent setting breakpoints on invalid addresses

CgDisasm:
- use side by side instead of tabs
- add splitter similar as in Debugger
- add drag & drop to cg_disasm for fpo and vpo files