### PR TITLE
GUI: List SPRX modules only

### DIFF
--- a/rpcs3/rpcs3qt/core_tab.cpp
+++ b/rpcs3/rpcs3qt/core_tab.cpp
@@ -128,7 +128,7 @@ core_tab::core_tab(std::shared_ptr<emu_settings> settings, QWidget *parent) : QW
 	for (const auto& prxf : fs::dir(lle_dir))
 	{
 		// List found unselected modules
-		if (prxf.is_directory || (prxf.name.substr(std::max<size_t>(size_t(3), prxf.name.length()) - 3)) != "prx")
+		if (prxf.is_directory || (prxf.name.substr(std::max<size_t>(size_t(3), prxf.name.length()) - 4)) != "sprx")
 			continue;
 		if (verify_npdrm_self_headers(fs::file(lle_dir + prxf.name)) && !set.count(prxf.name))
 		{


### PR DESCRIPTION
Excludes .prx modules from being listed, which prevents users from downloading random folders from the web that only have .prx modules and break auto library load.

In the future it's probably a good idea to let users have the ability to list and load custom .prx files, but even in that case they shouldn't be inside dev_flash/sys/externals anyways. 

_(You can still load custom .prx files if you manually edit the config file, but this shouldn't be needed unless you're modding the game or something along those lines. All firmware modules are .sprx, and game specific .prx get loaded automatically using liblv2 option)._

