### PR TITLE
Sprx/reloc/misc

### DIFF
--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -1081,7 +1081,7 @@ bool SELFDecrypter::DecryptNPDRM(u8 *metadata, u32 metadata_size)
 	// If not, the data has no NPDRM layer.
 	if (!ctrl)
 	{
-		LOG_WARNING(LOADER, "SELF: No NPDRM control info found!");
+		LOG_NOTICE(LOADER, "SELF: No NPDRM control info found!");
 		return true;
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -131,6 +131,7 @@ s32 cellGemGetInfo(vm::ptr<CellGemInfo> info)
 	for (int i = 0; i < CELL_GEM_MAX_NUM; i++)
 	{
 		info->status[i] = CELL_GEM_STATUS_DISCONNECTED;
+		info->port[i] = 0;
 	}
 
 	return CELL_OK;
@@ -160,10 +161,18 @@ s32 cellGemGetRumble()
 	return CELL_OK;
 }
 
-s32 cellGemGetState()
+s32 cellGemGetState(u32 gem_num, u32 flag, u64 time_parameter, vm::ptr<CellGemState> gem_state)
 {
-	UNIMPLEMENTED_FUNC(cellGem);
-	return CELL_OK;
+	cellGem.todo("cellGemGetState(gem_num=%d, flag=0x%x, time=0x%llx, gem_state=*0x%x)", gem_num, flag, time_parameter, gem_state);
+	const auto gem = fxm::get<gem_t>();
+   
+	if (!gem)
+		return CELL_GEM_ERROR_UNINITIALIZED;
+
+	// clear out gem_state so no games get any funny ideas about them being connected...
+	std::memset(gem_state.get_ptr(), 0, sizeof(CellGemState));
+
+	return CELL_GEM_NOT_CONNECTED;
 }
 
 s32 cellGemGetStatusFlags()

--- a/rpcs3/Emu/Cell/Modules/cellGem.h
+++ b/rpcs3/Emu/Cell/Modules/cellGem.h
@@ -96,10 +96,10 @@ struct CellGemAttribute
 struct CellGemCameraState
 {
 	be_t<s32> exposure;
-	float exposure_time;
-	float gain;
-	float pitch_angle;
-	float pitch_angle_estimate;
+	be_t<f32> exposure_time;
+	be_t<f32> gain;
+	be_t<f32> pitch_angle;
+	be_t<f32> pitch_angle_estimate;
 };
 
 struct CellGemExtPortData
@@ -116,14 +116,14 @@ struct CellGemExtPortData
 
 struct CellGemImageState
 {
-	//system_time_t frame_timestamp; // TODO: Figure what to use for them
-	//system_time_t timestamp;
-	float u;
-	float v;
-	float r;
-	float projectionx;
-	float projectiony;
-	float distance;
+	be_t<u64> frame_timestamp;
+	be_t<u64> timestamp;
+	be_t<f32> u;
+	be_t<f32> v;
+	be_t<f32> r;
+	be_t<f32> projectionx;
+	be_t<f32> projectiony;
+	be_t<f32> distance;
 	u8 visible;
 	u8 r_valid;
 };
@@ -136,15 +136,15 @@ struct CellGemPadData
 
 struct CellGemInertialState
 {
-	//vec_float4 accelerometer; // TODO: Figure what to use as replacement for vec_float4
-	//vec_float4 gyro;
-	//vec_float4 accelerometer_bias;
-	//vec_float4 gyro_bias;
+	be_t<f32> accelerometer[4];
+	be_t<f32> gyro[4];
+	be_t<f32> accelerometer_bias[4];
+	be_t<f32> gyro_bias[4];
 	CellGemPadData pad;
 	CellGemExtPortData ext;
-	//system_time_t timestamp;
+	be_t<u64> timestamp;
 	be_t<s32> counter;
-	float temperature;
+	be_t<f32> temperature;
 };
 
 struct CellGemInfo
@@ -157,20 +157,20 @@ struct CellGemInfo
 
 struct CellGemState
 {
-	//vec_float4 pos;
-	//vec_float4 vel;
-	//vec_float4 accel;
-	//vec_float4 quat;
-	//vec_float4 angvel;
-	//vec_float4 angaccel;
-	//vec_float4 handle_pos;
-	//vec_float4 handle_vel;
-	//vec_float4 handle_accel;
+	be_t<f32> pos[4];
+	be_t<f32> vel[4];
+	be_t<f32> accel[4];
+	be_t<f32> quat[4];
+	be_t<f32> angvel[4];
+	be_t<f32> angaccel[4];
+	be_t<f32> handle_pos[4];
+	be_t<f32> handle_vel[4];
+	be_t<f32> handle_accel[4];
 	CellGemPadData pad;
 	CellGemExtPortData ext;
-	//system_time_t timestamp;
-	float temperature;
-	float camera_pitch_angle;
+	be_t<u64> timestamp;
+	be_t<f32> temperature;
+	be_t<f32> camera_pitch_angle;
 	be_t<u32> tracking_flags;
 };
 
@@ -179,10 +179,10 @@ struct CellGemVideoConvertAttribute
 	be_t<s32> version;
 	be_t<s32> output_format;
 	be_t<s32> conversion_flags;
-	float gain;
-	float red_gain;
-	float green_gain;
-	float blue_gain;
+	be_t<f32> gain;
+	be_t<f32> red_gain;
+	be_t<f32> green_gain;
+	be_t<f32> blue_gain;
 	be_t<u32> buffer_memory;
 	be_t<u32> video_data_out;
 	u8 alpha;

--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -35,15 +35,12 @@ error_code cellKbInit(u32 max_connect)
 {
 	sys_io.warning("cellKbInit(max_connect=%d)", max_connect);
 
-	if (max_connect > 7)
-		return CELL_KB_ERROR_INVALID_PARAMETER;
-
 	const auto handler = fxm::import<KeyboardHandlerBase>(Emu.GetCallbacks().get_kb_handler);
 
 	if (!handler)
 		return CELL_KB_ERROR_ALREADY_INITIALIZED;
 
-	handler->Init(max_connect);
+	handler->Init(std::min(max_connect, 7u));
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -12,11 +12,6 @@ s32 cellMouseInit(u32 max_connect)
 {
 	sys_io.warning("cellMouseInit(max_connect=%d)", max_connect);
 
-	if (max_connect > 7)
-	{
-		return CELL_MOUSE_ERROR_INVALID_PARAMETER;
-	}
-
 	const auto handler = fxm::import<MouseHandlerBase>(Emu.GetCallbacks().get_mouse_handler);
 
 	if (!handler)
@@ -24,7 +19,7 @@ s32 cellMouseInit(u32 max_connect)
 		return CELL_MOUSE_ERROR_ALREADY_INITIALIZED;
 	}
 
-	handler->Init(max_connect);
+	handler->Init(std::min(max_connect, 7u));
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -347,8 +347,8 @@ error_code sceNpTrophyGetRequiredDiskSpace(u32 context, u32 handle, vm::ptr<u64>
 	// TODO: This is not accurate. It's just an approximation of the real value
 	//       The real value can be obtained in TRP.cpp:
 	//		 m_headers.trp_file_size - sizeof(m_headers) - (m_headers.trp_files_count * m_headers.trp_element_size);
-	//*reqspace = ctxt->trp_stream.size();
-	*reqspace = 0; // Since we currently just say the trophys are installed, there's no required disk space
+	// TODO: eventually this should be set to 0 when trophys are detected as already installed, setting to 0 now causes some games to not call registerContext, which leads to trophys never getting installed
+	*reqspace = ctxt->trp_stream.size();
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -576,6 +576,16 @@ extern std::string ppu_get_syscall_name(u64 code)
 // Get function name by FNID
 extern std::string ppu_get_function_name(const std::string& module, u32 fnid)
 {
+	if (module == "") switch (fnid)
+	{
+	// these arent the actual hash, but its close enough 
+	case 0x0D10FD3F: return "module_prologue";
+	case 0x330F7005: return "module_epilogue";
+	case 0x3ab9a95e: return "module_exit";
+	case 0xBC9A0086: return "module_start";
+	case 0xAB779874: return "module_stop";
+	}
+
 	// Check known FNIDs
 	if (module == "sys_libc" || module == "sys_libm") switch (fnid)
 	{
@@ -2363,6 +2373,78 @@ extern std::string ppu_get_function_name(const std::string& module, u32 fnid)
 // Get variable name by VNID
 extern std::string ppu_get_variable_name(const std::string& module, u32 vnid)
 {
+	if (module == "") switch (vnid)
+	{
+	// these arent the actual hash, but its close enough
+	case 0xD7F43016: return "module_info";
+	}
+	// Check known FNIDs
+	if (module == "sys_libc") switch (vnid)
+	{
+	case 0x071928B0: return "_LNan";
+	case 0x0A331920: return "_Clocale";
+	case 0x0B2E15ED: return "_malloc_limit";
+	case 0x0FBC732D: return "_Zero";
+	case 0x17667744: return "_LInf";
+	case 0x210B2F6E: return "_FNan";
+	case 0x2418F6C0: return "__TT800";
+	case 0x2470D3BC: return "_Hugeval";
+	case 0x26A34F81: return "_Flt";
+	case 0x277A84BB: return "_Mutex_attr";
+	case 0x29E76A6D: return "_LXbig";
+	case 0x2CF8B5D1: return "_Wctrans";
+	case 0x32E56B1A: return "_Stdin";
+	case 0x3916A06A: return "_FILE_P_Head";
+	case 0x45EC2DF6: return "_LEps";
+	case 0x529D4301: return "_Denorm";
+	case 0x57DBCF27: return "_Inf";
+	case 0x5FF11EB4: return "_FZero";
+	case 0x620967C9: return "_Mbcurmax";
+	case 0x6524499E: return "_FInf";
+	case 0x67D1406B: return "__ctype_ptr";
+	case 0x6A09DF41: return "_LRteps";
+	case 0x73898DB8: return "environ";
+	case 0x76628EFB: return "_FSnan";
+	case 0x790B0082: return "_Xbig";
+	case 0x7AFF3242: return "_Snan";
+	case 0x7BC88211: return "_Tolotab";
+	case 0x7F456AF2: return "_Rteps";
+	case 0x81ACF7C1: return "_LZero";
+	case 0x8F87ED0C: return "_Times";
+	case 0x92C43F6D: return "_Eps";
+	case 0x96E1E748: return "tls_mutex_attr";
+	case 0x985FC057: return "_Dbl";
+	case 0x9C8454C9: return "_LSnan";
+	case 0xAA860D4C: return "_Wctype";
+	case 0xB5B84F80: return "_LDenorm";
+	case 0xB5D2F53B: return "_Touptab";
+	case 0xB6F5F98C: return "_FRteps";
+	case 0xD59C193C: return "_Nan";
+	case 0xD698385D: return "_Ldbl";
+	case 0xD97B0687: return "_Ctype";
+	case 0xE0BC8D86: return "_Loctab";
+	case 0xEACE53D6: return "_FDenorm";
+	case 0xECA056DF: return "_Locale";
+	case 0xEF25075B: return "_FXbig";
+	case 0xFB2BD688: return "_Stdout";
+	case 0xFEFBE065: return "_Stderr";
+	case 0xFF2F0CC7: return "_FEps";
+	}
+
+	if (module == "sys_libm") switch (vnid)
+	{
+	case 0x1CF745BC: return "_LErf_one";
+	case 0x2259EF96: return "_LGamma_big";
+	case 0x3ACAD7F1: return "_Erf_small";
+	case 0x3FB8629D: return "_FErf_one";
+	case 0x42EB9508: return "_Fenv0";
+	case 0x4AF28F31: return "_FErf_small";
+	case 0xA8D907FF: return "_LErf_small";
+	case 0xAD443E79: return "_Erf_one";
+	case 0xE9892674: return "_FGamma_big";
+	case 0xF39005FC: return "_Gamma_big";
+	}
+
 	// Check registered variables
 	if (const auto sm = ppu_module_manager::get_module(module))
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -196,7 +196,7 @@ error_code _sys_prx_start_module(u32 id, u64 flags, vm::ptr<sys_prx_start_stop_m
 
 	//prx->is_started = true;
 	pOpt->entry.set(prx->start ? prx->start.addr() : ~0ull);
-
+	pOpt->entry2.set(prx->prologue ? prx->prologue.addr() : ~0ull);
 	return CELL_OK;
 }
 
@@ -216,6 +216,7 @@ error_code _sys_prx_stop_module(u32 id, u64 flags, vm::ptr<sys_prx_start_stop_mo
 
 	//prx->is_started = false;
 	pOpt->entry.set(prx->stop ? prx->stop.addr() : ~0ull);
+	pOpt->entry2.set(prx->epilogue ? prx->epilogue.addr() : ~0ull);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -118,6 +118,8 @@ struct lv2_prx final : lv2_obj, ppu_module
 
 	vm::ps3::ptr<s32(u32 argc, vm::ps3::ptr<void> argv)> start = vm::null;
 	vm::ps3::ptr<s32(u32 argc, vm::ps3::ptr<void> argv)> stop = vm::null;
+	vm::ps3::ptr<s32(u64 callback, u64 argc, vm::ps3::ptr<void, u64> argv)> prologue = vm::null;
+	vm::ps3::ptr<s32(u64 callback, u64 argc, vm::ps3::ptr<void, u64> argv)> epilogue = vm::null;
 	vm::ps3::ptr<s32()> exit = vm::null;
 };
 


### PR DESCRIPTION
This fixes loading of 'statically linked c++ sprx' files, sdk sample now runs and loads, and okami at least shows a loading screen before it crashes. I've also added in some variable / function names to help out.

The kb/mouse change is the same as cellpad, which fixes games expecting it to init when given a large value

The trophy size im adding back in, i was thought a game would always still call RegisterContext, but it won't, which will lead to issues for other trophy calls later, so for now they should be installed until more is done with trophy