### PR TITLE
Qt Build Adjustments

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -166,9 +166,6 @@
     </ResourceCompile>
     <PostBuildEvent>
       <Command>
-        xcopy "$(QTDIR)\bin\Qt5Core.dll" "$(OutDir)" /d
-        xcopy "$(QTDIR)\bin\Qt5Gui.dll" "$(OutDir)" /d
-        xcopy "$(QTDIR)\bin\Qt5Widgets.dll" "$(OutDir)" /d
       </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -220,9 +217,6 @@
     </ResourceCompile>
     <PostBuildEvent>
       <Command>
-        xcopy "$(QTDIR)\bin\Qt5Core.dll" "$(OutDir)" /d
-        xcopy "$(QTDIR)\bin\Qt5Gui.dll" "$(OutDir)" /d
-        xcopy "$(QTDIR)\bin\Qt5Widgets.dll" "$(OutDir)" /d
       </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -274,11 +268,7 @@
       <PreprocessorDefinitions>_WINDOWS;UNICODE;WIN32;WIN64;QT_UI;QT_OPENGL_LIB;QT_WIDGETS_LIB;QT_QUICK_LIB;QT_GUI_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CORE_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>
-        xcopy "$(QTDIR)\bin\Qt5Cored.dll" "$(OutDir)" /d
-        xcopy "$(QTDIR)\bin\Qt5Guid.dll" "$(OutDir)" /d
-        xcopy "$(QTDIR)\bin\Qt5Widgetsd.dll" "$(OutDir)" /d
-      </Command>
+      <Command>xcopy "$(QTDIR)\plugins\platforms\qwindowsd.dll" $(OUTDIR)\platforms\ /d</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>
@@ -329,11 +319,7 @@
       <PreprocessorDefinitions>_WINDOWS;UNICODE;WIN32;WIN64;QT_UI;QT_OPENGL_LIB;QT_WIDGETS_LIB;QT_QUICK_LIB;QT_GUI_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CORE_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>
-        xcopy "$(QTDIR)\bin\Qt5Cored.dll" "$(OutDir)" /d
-        xcopy "$(QTDIR)\bin\Qt5Guid.dll" "$(OutDir)" /d
-        xcopy "$(QTDIR)\bin\Qt5Widgetsd.dll" "$(OutDir)" /d
-      </Command>
+      <Command>xcopy "$(QTDIR)\plugins\platforms\qwindowsd.dll" $(OUTDIR)\platforms\ /d</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>

--- a/rpcs3/rpcs3.vcxproj.user
+++ b/rpcs3/rpcs3.vcxproj.user
@@ -3,34 +3,34 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3bC:\Qt\5.8\msvc2015_64\bin%3b$(PATH)</LocalDebuggerEnvironment>
     <QTDIR>C:\Qt\5.8\msvc2015_64</QTDIR>
+    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3b$(PATH)</LocalDebuggerEnvironment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3bC:\Qt\5.8\msvc2015_64\bin%3b$(PATH)</LocalDebuggerEnvironment>
     <QTDIR>C:\Qt\5.8\msvc2015_64</QTDIR>
+    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3b$(PATH)</LocalDebuggerEnvironment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug - MemLeak|x64'">
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3bC:\Qt\5.8\msvc2015_64\bin%3b$(PATH)</LocalDebuggerEnvironment>
     <QTDIR>C:\Qt\5.8\msvc2015_64</QTDIR>
+    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3b$(PATH)</LocalDebuggerEnvironment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerCommandArguments>1&gt; stdout.log 2&gt; stderr.log</LocalDebuggerCommandArguments>
-    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3bC:\Qt\5.8\msvc2015_64\bin%3b$(PATH)</LocalDebuggerEnvironment>
     <QTDIR>C:\Qt\5.8\msvc2015_64</QTDIR>
+    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3b$(PATH)</LocalDebuggerEnvironment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerCommandArguments>1&gt; stdout.log 2&gt; stderr.log</LocalDebuggerCommandArguments>
-    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3bC:\Qt\5.8\msvc2015_64\bin%3b$(PATH)</LocalDebuggerEnvironment>
     <QTDIR>C:\Qt\5.8\msvc2015_64</QTDIR>
+    <LocalDebuggerEnvironment>PATH=$(QTDIR)\bin%3b$(PATH)</LocalDebuggerEnvironment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LocalDebuggerWorkingDirectory>$(SolutionDir)bin\</LocalDebuggerWorkingDirectory>


### PR DESCRIPTION
Things I did:

1) Reordered <QTDIR> thing in project file because visual studio would create debug environment without parsing that variable first.  Result is it wouldn't work.

2) Removed hard coding of qt dir in the debug environment

3) Modified xcopy to only copy qwindowsd.dll in debug mode.  Running outside of VS with debug mode already wouldn't work since winextras wasn't copied.  So, no one should notice this change.  I copied qwindowsd.dll so I wouldn't have to modify the debug environment to include the plugins/platform folder. This felt a bit cleaner to me. (There's no need to copy in release mode because they're already in the bin folder)