### PR TITLE
rsx: Bug fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
@@ -199,7 +199,7 @@ error_code cellVideoOutGetDeviceInfo(u32 videoOut, u32 deviceIndex, vm::ptr<Cell
 	info->colorInfo.gamma = 100;
 	info->availableModes[0].aspect = g_video_out_aspect_id.at(g_cfg.video.aspect_ratio);
 	info->availableModes[0].conversion = CELL_VIDEO_OUT_DISPLAY_CONVERSION_NONE;
-	info->availableModes[0].refreshRates =  CELL_VIDEO_OUT_REFRESH_RATE_60HZ;
+	info->availableModes[0].refreshRates =  CELL_VIDEO_OUT_REFRESH_RATE_60HZ | CELL_VIDEO_OUT_REFRESH_RATE_59_94HZ;
 	info->availableModes[0].resolutionId = g_video_out_resolution_id.at(g_cfg.video.resolution);
 	info->availableModes[0].scanMode = CELL_VIDEO_OUT_SCAN_MODE_PROGRESSIVE;
 	return CELL_OK;

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -648,7 +648,7 @@ u32 get_index_type_size(rsx::index_array_type type)
 	fmt::throw_exception("Wrong index type" HERE);
 }
 
-void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst, rsx::primitive_type draw_mode, unsigned first, unsigned count)
+void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst, rsx::primitive_type draw_mode, unsigned count)
 {
 	unsigned short *typedDst = (unsigned short *)(dst);
 	switch (draw_mode)

--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -39,7 +39,7 @@ std::tuple<u32, u32> write_index_array_data_to_buffer(gsl::span<gsl::byte> dst, 
 /**
  * Write index data needed to emulate non indexed non native primitive mode.
  */
-void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst, rsx::primitive_type draw_mode, unsigned first, unsigned count);
+void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst, rsx::primitive_type draw_mode, unsigned count);
 
 /**
  * Stream a 128 bits vector to dst.

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -553,10 +553,14 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 			SetDst(getFunction(FUNCTION::FUNCTION_TEXTURE_SAMPLE1D_PROJ));
 			return true;
 		case rsx::texture_dimension_extended::texture_dimension_2d:
-			SetDst(getFunction(FUNCTION::FUNCTION_TEXTURE_SAMPLE2D_PROJ));
 			//Note shadow comparison only returns a true/false result!
 			if (DstExpectsSca() && (m_prog.shadow_textures & (1 << dst.tex_num)))
+			{
 				m_shadow_sampled_textures |= (1 << dst.tex_num);
+				SetDst(getFunction(FUNCTION::FUNCTION_TEXTURE_SAMPLE2D_PROJ), false);	//No swizzle mask on shadow lookup
+			}
+			else
+				SetDst(getFunction(FUNCTION::FUNCTION_TEXTURE_SAMPLE2D_PROJ));
 			return true;
 		case rsx::texture_dimension_extended::texture_dimension_cubemap:
 			SetDst(getFunction(FUNCTION::FUNCTION_TEXTURE_SAMPLECUBE_PROJ));

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -26,9 +26,11 @@ bool vertex_program_compare::operator()(const RSXVertexProgram &binary1, const R
 {
 	if (binary1.output_mask != binary2.output_mask)
 		return false;
+	if (binary1.data.size() != binary2.data.size())
+		return false;
 	if (binary1.rsx_vertex_inputs != binary2.rsx_vertex_inputs)
 		return false;
-	if (binary1.data.size() != binary2.data.size()) return false;
+
 	const qword *instBuffer1 = (const qword*)binary1.data.data();
 	const qword *instBuffer2 = (const qword*)binary2.data.data();
 	size_t instIndex = 0;
@@ -40,6 +42,7 @@ bool vertex_program_compare::operator()(const RSXVertexProgram &binary1, const R
 			return false;
 		instIndex++;
 	}
+
 	return true;
 }
 
@@ -109,6 +112,7 @@ bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, con
 		binary1.front_back_color_enabled != binary2.front_back_color_enabled || binary1.alpha_func != binary2.alpha_func || 
 		binary1.shadow_textures != binary2.shadow_textures || binary1.redirected_textures != binary2.redirected_textures)
 		return false;
+
 	const qword *instBuffer1 = (const qword*)binary1.addr;
 	const qword *instBuffer2 = (const qword*)binary2.addr;
 	size_t instIndex = 0;
@@ -119,6 +123,7 @@ bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, con
 
 		if (inst1.dword[0] != inst2.dword[0] || inst1.dword[1] != inst2.dword[1])
 			return false;
+
 		instIndex++;
 		// Skip constants
 		if (fragment_program_utils::is_constant(inst1.word[1]) ||

--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -235,15 +235,13 @@ namespace
 
 		void* mapped_buffer =
 			m_buffer_data.map<void>(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
-		size_t first = 0;
-		for (const auto& pair : vertex_ranges) {
-			size_t element_count =
-				get_index_count(rsx::method_registers.current_draw_clause.primitive, pair.second);
-			write_index_array_for_non_indexed_non_native_primitive_to_buffer((char*)mapped_buffer,
-				rsx::method_registers.current_draw_clause.primitive, (u32)first, (u32)pair.second);
-			mapped_buffer = (char*)mapped_buffer + element_count * sizeof(u16);
-			first += pair.second;
-		}
+
+		size_t vertex_count = 0;
+		for (const auto& pair : vertex_ranges)
+			vertex_count += pair.second;
+
+		write_index_array_for_non_indexed_non_native_primitive_to_buffer((char *)mapped_buffer, rsx::method_registers.current_draw_clause.primitive, vertex_count);
+
 		m_buffer_data.unmap(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 		D3D12_INDEX_BUFFER_VIEW index_buffer_view = {
 			m_buffer_data.get_heap()->GetGPUVirtualAddress() + heap_offset, (UINT)buffer_size,

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -35,48 +35,48 @@ std::string D3D12FragmentDecompiler::compareFunction(COMPARE f, const std::strin
 
 void D3D12FragmentDecompiler::insertHeader(std::stringstream & OS)
 {
-	OS << "cbuffer SCALE_OFFSET : register(b0)" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	float4x4 scaleOffsetMat;" << std::endl;
-	OS << "	int4 userClipEnabled[2];" << std::endl;
-	OS << "	float4 userClipFactor[2];" << std::endl;
+	OS << "cbuffer SCALE_OFFSET : register(b0)\n";
+	OS << "{\n";
+	OS << "	float4x4 scaleOffsetMat;\n";
+	OS << "	int4 userClipEnabled[2];\n";
+	OS << "	float4 userClipFactor[2];\n";
 	OS << "	float fog_param0;\n";
 	OS << "	float fog_param1;\n";
-	OS << "	int isAlphaTested;" << std::endl;
-	OS << "	float alphaRef;" << std::endl;
+	OS << "	int isAlphaTested;\n";
+	OS << "	float alphaRef;\n";
 	OS << "	float4 texture_parameters[16];\n";
-	OS << "};" << std::endl;
+	OS << "};\n";
 }
 
 void D3D12FragmentDecompiler::insertIntputs(std::stringstream & OS)
 {
-	OS << "struct PixelInput" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	float4 Position : SV_POSITION;" << std::endl;
-	OS << "	float4 diff_color : COLOR0;" << std::endl;
-	OS << "	float4 spec_color : COLOR1;" << std::endl;
-	OS << "	float4 dst_reg3 : COLOR2;" << std::endl;
-	OS << "	float4 dst_reg4 : COLOR3;" << std::endl;
-	OS << "	float4 fogc : FOG;" << std::endl;
-	OS << "	float4 tc9 : TEXCOORD9;" << std::endl;
-	OS << "	float4 tc0 : TEXCOORD0;" << std::endl;
-	OS << "	float4 tc1 : TEXCOORD1;" << std::endl;
-	OS << "	float4 tc2 : TEXCOORD2;" << std::endl;
-	OS << "	float4 tc3 : TEXCOORD3;" << std::endl;
-	OS << "	float4 tc4 : TEXCOORD4;" << std::endl;
-	OS << "	float4 tc5 : TEXCOORD5;" << std::endl;
-	OS << "	float4 tc6 : TEXCOORD6;" << std::endl;
-	OS << "	float4 tc7 : TEXCOORD7;" << std::endl;
-	OS << "	float4 tc8 : TEXCOORD8;" << std::endl;
-	OS << "	float4 dst_userClip0 : SV_ClipDistance0;" << std::endl;
-	OS << "	float4 dst_userClip1 : SV_ClipDistance1;" << std::endl;
-	OS << "};" << std::endl;
+	OS << "struct PixelInput\n";
+	OS << "{\n";
+	OS << "	float4 Position : SV_POSITION;\n";
+	OS << "	float4 diff_color : COLOR0;\n";
+	OS << "	float4 spec_color : COLOR1;\n";
+	OS << "	float4 dst_reg3 : COLOR2;\n";
+	OS << "	float4 dst_reg4 : COLOR3;\n";
+	OS << "	float4 fogc : FOG;\n";
+	OS << "	float4 tc9 : TEXCOORD9;\n";
+	OS << "	float4 tc0 : TEXCOORD0;\n";
+	OS << "	float4 tc1 : TEXCOORD1;\n";
+	OS << "	float4 tc2 : TEXCOORD2;\n";
+	OS << "	float4 tc3 : TEXCOORD3;\n";
+	OS << "	float4 tc4 : TEXCOORD4;\n";
+	OS << "	float4 tc5 : TEXCOORD5;\n";
+	OS << "	float4 tc6 : TEXCOORD6;\n";
+	OS << "	float4 tc7 : TEXCOORD7;\n";
+	OS << "	float4 tc8 : TEXCOORD8;\n";
+	OS << "	float4 dst_userClip0 : SV_ClipDistance0;\n";
+	OS << "	float4 dst_userClip1 : SV_ClipDistance1;\n";
+	OS << "};\n";
 }
 
 void D3D12FragmentDecompiler::insertOutputs(std::stringstream & OS)
 {
-	OS << "struct PixelOutput" << std::endl;
-	OS << "{" << std::endl;
+	OS << "struct PixelOutput\n";
+	OS << "{\n";
 	const std::pair<std::string, std::string> table[] =
 	{
 		{ "ocol0", m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS ? "r0" : "h0" },
@@ -88,25 +88,25 @@ void D3D12FragmentDecompiler::insertOutputs(std::stringstream & OS)
 	for (int i = 0; i < sizeof(table) / sizeof(*table); ++i)
 	{
 		if (m_parr.HasParam(PF_PARAM_NONE, "float4", table[i].second))
-			OS << "	" << "float4" << " " << table[i].first << " : SV_TARGET" << idx++ << ";" << std::endl;
+			OS << "	" << "float4" << " " << table[i].first << " : SV_TARGET" << idx++ << ";\n";
 	}
 	if (m_ctrl & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT)
-		OS << "	float depth : SV_Depth;" << std::endl;
-	OS << "};" << std::endl;
+		OS << "	float depth : SV_Depth;\n";
+	OS << "};\n";
 }
 
 void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 {
-	OS << "cbuffer CONSTANT : register(b2)" << std::endl;
-	OS << "{" << std::endl;
+	OS << "cbuffer CONSTANT : register(b2)\n";
+	OS << "{\n";
 	for (const ParamType &PT : m_parr.params[PF_PARAM_UNIFORM])
 	{
 		if (PT.type == "sampler1D" || PT.type == "sampler2D" || PT.type == "samplerCube" || PT.type == "sampler3D")
 			continue;
 		for (const ParamItem &PI : PT.items)
-			OS << "	" << PT.type << " " << PI.name << ";" << std::endl;
+			OS << "	" << PT.type << " " << PI.name << ";\n";
 	}
-	OS << "};" << std::endl << std::endl;
+	OS << "};\n\n";
 
 	for (const ParamType &PT : m_parr.params[PF_PARAM_UNIFORM])
 	{
@@ -115,8 +115,8 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "Texture1D " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
-				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
+				OS << "Texture1D " << PI.name << " : register(t" << textureIndex << ");\n";
+				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");\n";
 			}
 		}
 		else if (PT.type == "sampler2D")
@@ -124,8 +124,8 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "Texture2D " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
-				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
+				OS << "Texture2D " << PI.name << " : register(t" << textureIndex << ");\n";
+				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");\n";
 			}
 		}
 		else if (PT.type == "sampler3D")
@@ -133,8 +133,8 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "Texture3D " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
-				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
+				OS << "Texture3D " << PI.name << " : register(t" << textureIndex << ");\n";
+				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");\n";
 			}
 		}
 		else if (PT.type == "samplerCube")
@@ -142,8 +142,8 @@ void D3D12FragmentDecompiler::insertConstants(std::stringstream & OS)
 			for (const ParamItem &PI : PT.items)
 			{
 				size_t textureIndex = atoi(PI.name.data() + 3);
-				OS << "TextureCube " << PI.name << " : register(t" << textureIndex << ");" << std::endl;
-				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");" << std::endl;
+				OS << "TextureCube " << PI.name << " : register(t" << textureIndex << ");\n";
+				OS << "sampler " << PI.name << "sampler : register(s" << textureIndex << ");\n";
 			}
 		}
 	}
@@ -210,8 +210,8 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 		"r0", "r1", "r2", "r3", "r4",
 		"h0", "h2", "h4", "h6", "h8"
 	};
-	OS << "void ps_impl(bool is_front_face, PixelInput In, inout float4 r0, inout float4 h0, inout float4 r1, inout float4 h2, inout float4 r2, inout float4 h4, inout float4 r3, inout float4 h6, inout float4 r4, inout float4 h8)" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void ps_impl(bool is_front_face, PixelInput In, inout float4 r0, inout float4 h0, inout float4 r1, inout float4 h2, inout float4 r2, inout float4 h4, inout float4 r3, inout float4 h6, inout float4 r4, inout float4 h8)\n";
+	OS << "{\n";
 	for (const ParamType &PT : m_parr.params[PF_PARAM_IN])
 	{
 		for (const ParamItem &PI : PT.items)
@@ -236,11 +236,11 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 			}
 			if (PI.name == "ssa")
 				continue;
-			OS << "	" << PT.type << " " << PI.name << " = In." << PI.name << ";" << std::endl;
+			OS << "	" << PT.type << " " << PI.name << " = In." << PI.name << ";\n";
 		}
 	}
 	// A bit unclean, but works.
-	OS << "	" << "float4 wpos = In.Position;" << std::endl;
+	OS << "	" << "float4 wpos = In.Position;\n";
 	if (m_prog.origin_mode == rsx::window_origin::bottom)
 		OS << "	wpos.y = (" << std::to_string(m_prog.height) << " - wpos.y);\n";
 	OS << "	float4 ssa = is_front_face ? float4(1., 1., 1., 1.) : float4(-1., -1., -1., -1.);\n";
@@ -250,7 +250,7 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 	{
 		for (const ParamItem &PI : PT.items)
 			if (output_value.find(PI.name) == output_value.end())
-				OS << "	" << PT.type << " " << PI.name << " = float4(0., 0., 0., 0.);" << std::endl;
+				OS << "	" << PT.type << " " << PI.name << " = float4(0., 0., 0., 0.);\n";
 	}
 	// Declare texture coordinate scaling component (to handle unormalized texture coordinates)
 
@@ -264,34 +264,34 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 			bool is_unorm = !!(m_prog.unnormalized_coords & (1 << textureIndex));
 			if (!is_unorm)
 			{
-				OS << "	float2  " << PI.name << "_scale = float2(1., 1.);" << std::endl;
+				OS << "	float2  " << PI.name << "_scale = float2(1., 1.);\n";
 				continue;
 			}
 
-			OS << "	float2  " << PI.name << "_dim;" << std::endl;
-			OS << "	" << PI.name << ".GetDimensions(" << PI.name << "_dim.x, " << PI.name << "_dim.y);" << std::endl;
-			OS << "	float2  " << PI.name << "_scale = texture_parameters[" << textureIndex << "] / " << PI.name << "_dim;" << std::endl;
+			OS << "	float2  " << PI.name << "_dim;\n";
+			OS << "	" << PI.name << ".GetDimensions(" << PI.name << "_dim.x, " << PI.name << "_dim.y);\n";
+			OS << "	float2  " << PI.name << "_scale = texture_parameters[" << textureIndex << "] / " << PI.name << "_dim;\n";
 		}
 	}
 }
 
 void D3D12FragmentDecompiler::insertMainEnd(std::stringstream & OS)
 {
-	OS << "}" << std::endl;
-	OS << std::endl;
-	OS << "PixelOutput main(PixelInput In, bool is_front_face : SV_IsFrontFace)" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	float4 r0 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 r1 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 r2 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 r3 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 r4 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 h0 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 h2 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 h4 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 h6 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	float4 h8 = float4(0., 0., 0., 0.);" << std::endl;
-	OS << "	ps_impl(is_front_face, In, r0, h0, r1, h2, r2, h4, r3, h6, r4, h8);" << std::endl;
+	OS << "}\n";
+	OS << "\n";
+	OS << "PixelOutput main(PixelInput In, bool is_front_face : SV_IsFrontFace)\n";
+	OS << "{\n";
+	OS << "	float4 r0 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 r1 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 r2 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 r3 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 r4 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 h0 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 h2 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 h4 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 h6 = float4(0., 0., 0., 0.);\n";
+	OS << "	float4 h8 = float4(0., 0., 0., 0.);\n";
+	OS << "	ps_impl(is_front_face, In, r0, h0, r1, h2, r2, h4, r3, h6, r4, h8);\n";
 
 	const std::pair<std::string, std::string> table[] =
 	{
@@ -302,12 +302,12 @@ void D3D12FragmentDecompiler::insertMainEnd(std::stringstream & OS)
 	};
 
 	std::string first_output_name;
-	OS << "	PixelOutput Out = (PixelOutput)0;" << std::endl;
+	OS << "	PixelOutput Out = (PixelOutput)0;\n";
 	for (int i = 0; i < sizeof(table) / sizeof(*table); ++i)
 	{
 		if (m_parr.HasParam(PF_PARAM_NONE, "float4", table[i].second))
 		{
-			OS << "	Out." << table[i].first << " = " << table[i].second << ";" << std::endl;
+			OS << "	Out." << table[i].first << " = " << table[i].second << ";\n";
 			if (first_output_name.empty()) first_output_name = table[i].first;
 		}
 	}
@@ -320,7 +320,7 @@ void D3D12FragmentDecompiler::insertMainEnd(std::stringstream & OS)
 			 * but it writes depth in r1.z and not h2.z.
 			 * Maybe there's a different flag for depth ?
 			 */
-			 //		OS << "	Out.depth = " << ((m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) ? "r1.z;" : "h2.z;") << std::endl;
+			 //		OS << "	Out.depth = " << ((m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) ? "r1.z;" : "h2.z;") << "\n";
 			OS << "	Out.depth = r1.z;\n";
 		}
 		else
@@ -366,7 +366,7 @@ void D3D12FragmentDecompiler::insertMainEnd(std::stringstream & OS)
 		OS << make_comparison_test(m_prog.alpha_func, "isAlphaTested && ", "Out." + first_output_name + ".a", "alphaRef");
 		
 	}
-	OS << "	return Out;" << std::endl;
-	OS << "}" << std::endl;
+	OS << "	return Out;\n";
+	OS << "}\n";
 }
 #endif

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -21,6 +21,8 @@ PFN_D3D12_SERIALIZE_ROOT_SIGNATURE wrapD3D12SerializeRootSignature;
 PFN_D3D11ON12_CREATE_DEVICE wrapD3D11On12CreateDevice;
 pD3DCompile wrapD3DCompile;
 
+ID3D12Device* g_d3d12_device = nullptr;
+
 #define VERTEX_BUFFERS_SLOT 0
 #define FRAGMENT_CONSTANT_BUFFERS_SLOT 1
 #define VERTEX_CONSTANT_BUFFERS_SLOT 2
@@ -180,6 +182,8 @@ D3D12GSRender::D3D12GSRender()
 			return;
 		}
 	}
+
+	g_d3d12_device = m_device.Get();
 
 	// Queues
 	D3D12_COMMAND_QUEUE_DESC graphic_queue_desc = { D3D12_COMMAND_LIST_TYPE_DIRECT };

--- a/rpcs3/Emu/RSX/D3D12/D3D12Overlay.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Overlay.cpp
@@ -14,7 +14,6 @@ namespace
 ComPtr<ID3D11Device> g_d3d11_device;
 ComPtr<ID3D11DeviceContext> g_d3d11_device_context;
 ComPtr<ID3D11On12Device> g_d3d11on12_device;
-ComPtr<ID3D12Device> g_d3d12_device;
 ComPtr<IDWriteFactory> g_dwrite_factory;
 ComPtr<ID2D1Factory3> g_d2d_factory;
 ComPtr<ID2D1Device2> g_d2d_device;
@@ -136,7 +135,6 @@ void D3D12GSRender::release_d2d_structures()
 	g_d3d11_device.Reset();
 	g_d3d11_device_context.Reset();
 	g_d3d11on12_device.Reset();
-	g_d3d12_device.Reset();
 	g_dwrite_factory.Reset();
 	g_d2d_factory.Reset();
 	g_d2d_device.Reset();

--- a/rpcs3/Emu/RSX/D3D12/D3D12Utils.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Utils.h
@@ -10,14 +10,21 @@
 
 
 using namespace Microsoft::WRL;
+extern ID3D12Device* g_d3d12_device;
 
 inline std::string get_hresult_message(HRESULT hr)
 {
+	if (hr == DXGI_ERROR_DEVICE_REMOVED)
+	{
+		hr = g_d3d12_device->GetDeviceRemovedReason();
+		return fmt::format("D3D12 device was removed with error status 0x%X", hr);
+	}
+
 	_com_error error(hr);
 #ifndef UNICODE
 	return error.ErrorMessage();
 #else
-	using convert_type = std::codecvt<wchar_t, char, mbstate_t>;
+	using convert_type = std::codecvt<wchar_t, char, std::mbstate_t>;
 	return std::wstring_convert<convert_type>().to_bytes(error.ErrorMessage());
 #endif
 }

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
@@ -28,17 +28,17 @@ std::string D3D12VertexProgramDecompiler::compareFunction(COMPARE f, const std::
 
 void D3D12VertexProgramDecompiler::insertHeader(std::stringstream &OS)
 {
-	OS << "cbuffer SCALE_OFFSET : register(b0)" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	float4x4 scaleOffsetMat;" << std::endl;
-	OS << "	int4 userClipEnabled[2];" << std::endl;
-	OS << "	float4 userClipFactor[2];" << std::endl;
-	OS << "	float fog_param0;" << std::endl;
-	OS << "	float fog_param1;" << std::endl;
-	OS << "	int isAlphaTested;" << std::endl;
-	OS << "	float alphaRef;" << std::endl;
-	OS << "	float4 texture_parameters[16];" << std::endl;
-	OS << "};" << std::endl;
+	OS << "cbuffer SCALE_OFFSET : register(b0)\n";
+	OS << "{\n";
+	OS << "	float4x4 scaleOffsetMat;\n";
+	OS << "	int4 userClipEnabled[2];\n";
+	OS << "	float4 userClipFactor[2];\n";
+	OS << "	float fog_param0;\n";
+	OS << "	float fog_param1;\n";
+	OS << "	int isAlphaTested;\n";
+	OS << "	float alphaRef;\n";
+	OS << "	float4 texture_parameters[16];\n";
+	OS << "};\n";
 }
 
 namespace
@@ -79,36 +79,36 @@ void D3D12VertexProgramDecompiler::insertInputs(std::stringstream & OS, const st
 
 void D3D12VertexProgramDecompiler::insertConstants(std::stringstream & OS, const std::vector<ParamType> & constants)
 {
-	OS << "cbuffer CONSTANT_BUFFER : register(b1)" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	float4 vc[468];" << std::endl;
-	OS << "	uint transform_branch_bits;" << std::endl;
-	OS << "};" << std::endl;
+	OS << "cbuffer CONSTANT_BUFFER : register(b1)\n";
+	OS << "{\n";
+	OS << "	float4 vc[468];\n";
+	OS << "	uint transform_branch_bits;\n";
+	OS << "};\n";
 }
 
 void D3D12VertexProgramDecompiler::insertOutputs(std::stringstream & OS, const std::vector<ParamType> & outputs)
 {
-	OS << "struct PixelInput" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	float4 dst_reg0 : SV_POSITION;" << std::endl;
-	OS << "	float4 dst_reg1 : COLOR0;" << std::endl;
-	OS << "	float4 dst_reg2 : COLOR1;" << std::endl;
-	OS << "	float4 dst_reg3 : COLOR2;" << std::endl;
-	OS << "	float4 dst_reg4 : COLOR3;" << std::endl;
-	OS << "	float4 dst_reg5 : FOG;" << std::endl;
-	OS << "	float4 dst_reg6 : TEXCOORD9;" << std::endl;
-	OS << "	float4 dst_reg7 : TEXCOORD0;" << std::endl;
-	OS << "	float4 dst_reg8 : TEXCOORD1;" << std::endl;
-	OS << "	float4 dst_reg9 : TEXCOORD2;" << std::endl;
-	OS << "	float4 dst_reg10 : TEXCOORD3;" << std::endl;
-	OS << "	float4 dst_reg11 : TEXCOORD4;" << std::endl;
-	OS << "	float4 dst_reg12 : TEXCOORD5;" << std::endl;
-	OS << "	float4 dst_reg13 : TEXCOORD6;" << std::endl;
-	OS << "	float4 dst_reg14 : TEXCOORD7;" << std::endl;
-	OS << "	float4 dst_reg15 : TEXCOORD8;" << std::endl;
-	OS << "	float4 dst_userClip0 : SV_ClipDistance0;" << std::endl;
-	OS << "	float4 dst_userClip1 : SV_ClipDistance1;" << std::endl;
-	OS << "};" << std::endl;
+	OS << "struct PixelInput\n";
+	OS << "{\n";
+	OS << "	float4 dst_reg0 : SV_POSITION;\n";
+	OS << "	float4 dst_reg1 : COLOR0;\n";
+	OS << "	float4 dst_reg2 : COLOR1;\n";
+	OS << "	float4 dst_reg3 : COLOR2;\n";
+	OS << "	float4 dst_reg4 : COLOR3;\n";
+	OS << "	float4 dst_reg5 : FOG;\n";
+	OS << "	float4 dst_reg6 : TEXCOORD9;\n";
+	OS << "	float4 dst_reg7 : TEXCOORD0;\n";
+	OS << "	float4 dst_reg8 : TEXCOORD1;\n";
+	OS << "	float4 dst_reg9 : TEXCOORD2;\n";
+	OS << "	float4 dst_reg10 : TEXCOORD3;\n";
+	OS << "	float4 dst_reg11 : TEXCOORD4;\n";
+	OS << "	float4 dst_reg12 : TEXCOORD5;\n";
+	OS << "	float4 dst_reg13 : TEXCOORD6;\n";
+	OS << "	float4 dst_reg14 : TEXCOORD7;\n";
+	OS << "	float4 dst_reg15 : TEXCOORD8;\n";
+	OS << "	float4 dst_userClip0 : SV_ClipDistance0;\n";
+	OS << "	float4 dst_userClip1 : SV_ClipDistance1;\n";
+	OS << "};\n";
 }
 
 static const vertex_reg_info reg_table[] =
@@ -172,8 +172,8 @@ void D3D12VertexProgramDecompiler::insertMainStart(std::stringstream & OS)
 {
 	insert_d3d12_legacy_function(OS, false);
 
-	OS << "PixelInput main(uint vertex_id : SV_VertexID)" << std::endl;
-	OS << "{" << std::endl;
+	OS << "PixelInput main(uint vertex_id : SV_VertexID)\n";
+	OS << "{\n";
 
 	// Declare inside main function
 	for (const ParamType PT : m_parr.params[PF_PARAM_NONE])
@@ -185,7 +185,7 @@ void D3D12VertexProgramDecompiler::insertMainStart(std::stringstream & OS)
 				OS << " = " << PI.value;
 			else
 				OS << " = " << "float4(0., 0., 0., 0.);";
-			OS << ";" << std::endl;
+			OS << ";\n";
 		}
 	}
 
@@ -201,7 +201,7 @@ void D3D12VertexProgramDecompiler::insertMainStart(std::stringstream & OS)
 
 void D3D12VertexProgramDecompiler::insertMainEnd(std::stringstream & OS)
 {
-	OS << "	PixelInput Out = (PixelInput)0;" << std::endl;
+	OS << "	PixelInput Out = (PixelInput)0;\n";
 
 	bool insert_front_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE) != 0;
 	bool insert_front_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR) != 0;
@@ -226,12 +226,12 @@ void D3D12VertexProgramDecompiler::insertMainEnd(std::stringstream & OS)
 			if (condition.empty() || i.default_val.empty())
 			{
 				if (!condition.empty()) condition = "if " + condition;
-				OS << "	" << condition << output_name << " = " << i.src_reg << i.src_reg_mask << ";" << std::endl;
+				OS << "	" << condition << output_name << " = " << i.src_reg << i.src_reg_mask << ";\n";
 			}
 			else
 			{
 				//Condition and fallback values provided
-				OS << "	" << output_name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";" << std::endl;
+				OS << "	" << output_name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";\n";
 			}
 		}
 	}
@@ -245,9 +245,9 @@ void D3D12VertexProgramDecompiler::insertMainEnd(std::stringstream & OS)
 		if (m_parr.HasParam(PF_PARAM_NONE, "float4", "dst_reg2"))
 			OS << "	Out.dst_reg4 = dst_reg2;\n";
 
-	OS << "	Out.dst_reg0 = mul(Out.dst_reg0, scaleOffsetMat);" << std::endl;
-	OS << "	return Out;" << std::endl;
-	OS << "}" << std::endl;
+	OS << "	Out.dst_reg0 = mul(Out.dst_reg0, scaleOffsetMat);\n";
+	OS << "	return Out;\n";
+	OS << "}\n";
 }
 
 D3D12VertexProgramDecompiler::D3D12VertexProgramDecompiler(const RSXVertexProgram &prog) :

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -29,7 +29,7 @@ std::string GLFragmentDecompilerThread::compareFunction(COMPARE f, const std::st
 
 void GLFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 {
-	OS << "#version 420" << std::endl;
+	OS << "#version 420\n";
 }
 
 void GLFragmentDecompilerThread::insertIntputs(std::stringstream & OS)
@@ -57,7 +57,7 @@ void GLFragmentDecompilerThread::insertIntputs(std::stringstream & OS)
 			if (var_name == "fogc")
 				var_name = "fog_c";
 
-			OS << "in " << PT.type << " " << var_name << ";" << std::endl;
+			OS << "in " << PT.type << " " << var_name << ";\n";
 		}
 	}
 
@@ -65,12 +65,12 @@ void GLFragmentDecompilerThread::insertIntputs(std::stringstream & OS)
 	{
 		if (m_prog.front_color_diffuse_output && m_prog.back_color_diffuse_output)
 		{
-			OS << "in vec4 front_diff_color;" << std::endl;
+			OS << "in vec4 front_diff_color;\n";
 		}
 
 		if (m_prog.front_color_specular_output && m_prog.back_color_specular_output)
 		{
-			OS << "in vec4 front_spec_color;" << std::endl;
+			OS << "in vec4 front_spec_color;\n";
 		}
 	}
 }
@@ -88,7 +88,7 @@ void GLFragmentDecompilerThread::insertOutputs(std::stringstream & OS)
 	for (int i = 0; i < sizeof(table) / sizeof(*table); ++i)
 	{
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", table[i].second))
-			OS << "out vec4 " << table[i].first << ";" << std::endl;
+			OS << "out vec4 " << table[i].first << ";\n";
 	}
 }
 
@@ -120,13 +120,13 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 				}
 			}
 
-			OS << "uniform " << samplerType << " " << PI.name << ";" << std::endl;
+			OS << "uniform " << samplerType << " " << PI.name << ";\n";
 		}
 	}
 
-	OS << std::endl;
-	OS << "layout(std140, binding = 2) uniform FragmentConstantsBuffer" << std::endl;
-	OS << "{" << std::endl;
+	OS << "\n";
+	OS << "layout(std140, binding = 2) uniform FragmentConstantsBuffer\n";
+	OS << "{\n";
 
 	for (const ParamType& PT : m_parr.params[PF_PARAM_UNIFORM])
 	{
@@ -137,7 +137,7 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 			continue;
 
 		for (const ParamItem& PI : PT.items)
-			OS << "	" << PT.type << " " << PI.name << ";" << std::endl;
+			OS << "	" << PT.type << " " << PI.name << ";\n";
 	}
 
 	// Fragment state parameters
@@ -146,7 +146,7 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 	OS << "	uint alpha_test;\n";
 	OS << "	float alpha_ref;\n";
 	OS << "	vec4 texture_parameters[16];\n";	//sampling: x,y scaling and (unused) offsets data
-	OS << "};" << std::endl;
+	OS << "};\n";
 }
 
 
@@ -241,8 +241,8 @@ void GLFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 		}
 	}
 
-	OS << "void fs_main(" << parameters << ")" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void fs_main(" << parameters << ")\n";
+	OS << "{\n";
 
 	for (const ParamType& PT : m_parr.params[PF_PARAM_NONE])
 	{
@@ -255,7 +255,7 @@ void GLFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 			if (!PI.value.empty())
 				OS << " = " << PI.value;
 
-			OS << ";" << std::endl;
+			OS << ";\n";
 		}
 	}
 
@@ -397,10 +397,10 @@ void GLFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 		OS << make_comparison_test(m_prog.alpha_func, "alpha_test != 0 && ", first_output_name + ".a", "alpha_ref");
 	}
 
-	OS << "}" << std::endl << std::endl;
+	OS << "}\n\n";
 
-	OS << "void main()" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void main()\n";
+	OS << "{\n";
 
 	std::string parameters = "";
 	for (auto &reg_name : output_values)
@@ -411,11 +411,11 @@ void GLFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 				parameters += ", ";
 
 			parameters += reg_name;
-			OS << "	vec4 " << reg_name << " = vec4(0.);" << std::endl;
+			OS << "	vec4 " << reg_name << " = vec4(0.);\n";
 		}
 	}
 
-	OS << std::endl << "	fs_main(" + parameters + ");" << std::endl << std::endl;
+	OS << "\n" << "	fs_main(" + parameters + ");\n\n";
 
 	//Append the color output assignments
 	OS << color_output_block;
@@ -428,7 +428,7 @@ void GLFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 			* but it writes depth in r1.z and not h2.z.
 			* Maybe there's a different flag for depth ?
 			*/
-			//OS << ((m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) ? "\tgl_FragDepth = r1.z;\n" : "\tgl_FragDepth = h0.z;\n") << std::endl;
+			//OS << ((m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) ? "\tgl_FragDepth = r1.z;\n" : "\tgl_FragDepth = h0.z;\n") << "\n";
 			OS << "	gl_FragDepth = r1.z;\n";
 		}
 		else
@@ -438,7 +438,7 @@ void GLFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 		}
 	}
 
-	OS << "}" << std::endl;
+	OS << "}\n";
 }
 
 void GLFragmentDecompilerThread::Task()

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -781,10 +781,23 @@ namespace gl
 							LOG_WARNING(RSX, "Surface blit from a compressed texture");
 						}
 
-						if (!rsc.is_bound)
+						if (!rsc.is_bound || !g_cfg.video.strict_rendering_mode)
 						{
 							if (rsc.w == tex_width && rsc.h == tex_height)
+							{
+								if (rsc.is_bound)
+								{
+									LOG_WARNING(RSX, "Sampling from a currently bound render target @ 0x%x", texaddr);
+
+									auto &caps = gl::get_driver_caps();
+									if (caps.ARB_texture_barrier_supported)
+										glTextureBarrier();
+									else if (caps.NV_texture_barrier_supported)
+										glTextureBarrierNV();
+								}
+
 								rsc.surface->bind();
+							}
 							else
 								bound_index = create_temporary_subresource(rsc.surface->id(), (GLenum)rsc.surface->get_compatible_internal_format(), rsc.x, rsc.y, rsc.w, rsc.h);
 						}

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -122,17 +122,19 @@ namespace gl
 
 				glGenBuffers(1, &pbo_id);
 
+				const u32 buffer_size = align(cpu_address_range, 4096);
 				glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo_id);
-				glBufferStorage(GL_PIXEL_PACK_BUFFER, locked_address_range, nullptr, GL_MAP_READ_BIT);
+				glBufferStorage(GL_PIXEL_PACK_BUFFER, buffer_size, nullptr, GL_MAP_READ_BIT);
 
-				pbo_size = locked_address_range;
+				pbo_size = buffer_size;
 			}
 
 		public:
 
 			void reset(const u32 base, const u32 size, const bool flushable)
 			{
-				rsx::buffered_section::reset(base, size);
+				rsx::protection_policy policy = g_cfg.video.strict_rendering_mode ? rsx::protection_policy::protect_policy_full_range : rsx::protection_policy::protect_policy_one_page;
+				rsx::buffered_section::reset(base, size, policy);
 	
 				if (flushable)
 					init_buffer();

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -146,19 +146,19 @@ namespace
 	// return vertex count if primitive type is not native (empty array otherwise)
 	std::tuple<u32, u32> get_index_array_for_emulated_non_indexed_draw(const std::vector<std::pair<u32, u32>> &first_count_commands, rsx::primitive_type primitive_mode, gl::ring_buffer &dst)
 	{
+		//This is an emulated buffer, so our indices only range from 0->original_vertex_array_length
+		u32 vertex_count = 0;
 		u32 element_count = 0;
 		verify(HERE), !gl::is_primitive_native(primitive_mode);
 
 		for (const auto &pair : first_count_commands)
+		{
 			element_count += (u32)get_index_count(primitive_mode, pair.second);
+			vertex_count += pair.second;
+		}
 
 		auto mapping = dst.alloc_from_heap(element_count * sizeof(u16), 256);
 		char *mapped_buffer = (char *)mapping.first;
-
-		//This is an emulated buffer, so our indices only range from 0->original_vertex_array_length
-		u32 vertex_count = 0;
-		for (auto &first_count : first_count_commands)
-			vertex_count += first_count.second;
 
 		write_index_array_for_non_indexed_non_native_primitive_to_buffer(mapped_buffer, primitive_mode, vertex_count);
 		return std::make_tuple(element_count, mapping.second);

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -146,27 +146,22 @@ namespace
 	// return vertex count if primitive type is not native (empty array otherwise)
 	std::tuple<u32, u32> get_index_array_for_emulated_non_indexed_draw(const std::vector<std::pair<u32, u32>> &first_count_commands, rsx::primitive_type primitive_mode, gl::ring_buffer &dst)
 	{
-		u32 vertex_draw_count = 0;
+		u32 element_count = 0;
 		verify(HERE), !gl::is_primitive_native(primitive_mode);
 
 		for (const auto &pair : first_count_commands)
-		{
-			vertex_draw_count += (u32)get_index_count(primitive_mode, pair.second);
-		}
+			element_count += (u32)get_index_count(primitive_mode, pair.second);
 
-		u32 first = 0;
-		auto mapping = dst.alloc_from_heap(vertex_draw_count * sizeof(u16), 256);
+		auto mapping = dst.alloc_from_heap(element_count * sizeof(u16), 256);
 		char *mapped_buffer = (char *)mapping.first;
 
-		for (const auto &pair : first_count_commands)
-		{
-			size_t element_count = get_index_count(primitive_mode, pair.second);
-			write_index_array_for_non_indexed_non_native_primitive_to_buffer(mapped_buffer, primitive_mode, first, pair.second);
-			mapped_buffer = (char*)mapped_buffer + element_count * sizeof(u16);
-			first += pair.second;
-		}
+		//This is an emulated buffer, so our indices only range from 0->original_vertex_array_length
+		u32 vertex_count = 0;
+		for (auto &first_count : first_count_commands)
+			vertex_count += first_count.second;
 
-		return std::make_tuple(vertex_draw_count, mapping.second);
+		write_index_array_for_non_indexed_non_native_primitive_to_buffer(mapped_buffer, primitive_mode, vertex_count);
+		return std::make_tuple(element_count, mapping.second);
 	}
 
 	std::tuple<u32, u32, u32> upload_index_buffer(gsl::span<const gsl::byte> raw_index_buffer, void *ptr, rsx::index_array_type type, rsx::primitive_type draw_mode, const std::vector<std::pair<u32, u32>> first_count_commands, u32 initial_vertex_count)

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -30,13 +30,13 @@ std::string GLVertexDecompilerThread::compareFunction(COMPARE f, const std::stri
 
 void GLVertexDecompilerThread::insertHeader(std::stringstream &OS)
 {
-	OS << "#version 430" << std::endl << std::endl;
-	OS << "layout(std140, binding = 0) uniform ScaleOffsetBuffer" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	mat4 scaleOffsetMat;" << std::endl;
-	OS << "	ivec4 userClipEnabled[2];" << std::endl;
-	OS << "	vec4 userClipFactor[2];" << std::endl;
-	OS << "};" << std::endl;
+	OS << "#version 430\n\n";
+	OS << "layout(std140, binding = 0) uniform ScaleOffsetBuffer\n";
+	OS << "{\n";
+	OS << "	mat4 scaleOffsetMat;\n";
+	OS << "	ivec4 userClipEnabled[2];\n";
+	OS << "	vec4 userClipFactor[2];\n";
+	OS << "};\n";
 }
 
 void GLVertexDecompilerThread::insertInputs(std::stringstream & OS, const std::vector<ParamType>& inputs)
@@ -77,7 +77,7 @@ void GLVertexDecompilerThread::insertInputs(std::stringstream & OS, const std::v
 					}
 
 					std::string samplerType = is_int ? "isamplerBuffer" : "samplerBuffer";
-					OS << "layout(location=" << location++ << ")" << "	uniform " << samplerType << " " << PI.name << "_buffer;" << std::endl;
+					OS << "layout(location=" << location++ << ")" << "	uniform " << samplerType << " " << PI.name << "_buffer;\n";
 				}
 			}
 		}
@@ -86,11 +86,11 @@ void GLVertexDecompilerThread::insertInputs(std::stringstream & OS, const std::v
 
 void GLVertexDecompilerThread::insertConstants(std::stringstream & OS, const std::vector<ParamType> & constants)
 {
-	OS << "layout(std140, binding = 1) uniform VertexConstantsBuffer" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	vec4 vc[468];" << std::endl;
-	OS << "	uint transform_branch_bits;" << std::endl;
-	OS << "};" << std::endl << std::endl;
+	OS << "layout(std140, binding = 1) uniform VertexConstantsBuffer\n";
+	OS << "{\n";
+	OS << "	vec4 vc[468];\n";
+	OS << "	uint transform_branch_bits;\n";
+	OS << "};\n\n";
 
 	for (const ParamType &PT: constants)
 	{
@@ -99,7 +99,7 @@ void GLVertexDecompilerThread::insertConstants(std::stringstream & OS, const std
 			if (PI.name == "vc[468]")
 				continue;
 
-			OS << "uniform " << PT.type << " " << PI.name << ";" << std::endl;
+			OS << "uniform " << PT.type << " " << PI.name << ";\n";
 		}
 	}
 }
@@ -166,7 +166,7 @@ void GLVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::
 			if (front_back_specular && name == "spec_color")
 				name = "back_spec_color";
 
-			OS << "out vec4 " << name << ";" << std::endl;
+			OS << "out vec4 " << name << ";\n";
 		}
 		else
 		{
@@ -174,16 +174,16 @@ void GLVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::
 			//Force some outputs to be declared even if unused
             if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
 			{
-                OS << "out vec4 " << i.name << ";" << std::endl;
+                OS << "out vec4 " << i.name << ";\n";
 			}
 		}
 	}
 
 	if (insert_back_diffuse && insert_front_diffuse)
-		OS << "out vec4 front_diff_color;" << std::endl;
+		OS << "out vec4 front_diff_color;\n";
 
 	if (insert_back_specular && insert_front_specular)
-		OS << "out vec4 front_spec_color;" << std::endl;
+		OS << "out vec4 front_spec_color;\n";
 }
 
 namespace
@@ -228,7 +228,7 @@ namespace
 
 			if (!real_input.is_array)
 			{
-				OS << vecType << PI.name << " = texelFetch(" << PI.name << "_buffer, 0)" << scale << ";" << std::endl;
+				OS << vecType << PI.name << " = texelFetch(" << PI.name << "_buffer, 0)" << scale << ";\n";
 				return;
 			}
 
@@ -236,21 +236,21 @@ namespace
 			{
 				if (real_input.is_modulo)
 				{
-					OS << vecType << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID %" << real_input.frequency << ")" << scale << ";" << std::endl;
+					OS << vecType << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID %" << real_input.frequency << ")" << scale << ";\n";
 					return;
 				}
 
-				OS << vecType << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID /" << real_input.frequency << ")" << scale << ";" << std::endl;
+				OS << vecType << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID /" << real_input.frequency << ")" << scale << ";\n";
 				return;
 			}
 
-			OS << vecType << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID)" << scale << ";" << std::endl;
+			OS << vecType << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID)" << scale << ";\n";
 			return;
 		}
 
 		LOG_WARNING(RSX, "Vertex input %s does not have a matching vertex_input declaration", PI.name.c_str());
 
-		OS << "	vec4 " << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID);" << std::endl;
+		OS << "	vec4 " << PI.name << "= texelFetch(" << PI.name << "_buffer, gl_VertexID);\n";
 	}
 }
 
@@ -271,8 +271,8 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 		}
 	}
 
-	OS << "void vs_main(" << parameters << ")" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void vs_main(" << parameters << ")\n";
+	OS << "{\n";
 
 	//Declare temporary registers, ignoring those mapped to outputs
 	for (const ParamType PT : m_parr.params[PF_PARAM_NONE])
@@ -286,7 +286,7 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 			if (!PI.value.empty())
 				OS << " = " << PI.value;
 
-			OS << ";" << std::endl;
+			OS << ";\n";
 		}
 	}
 
@@ -302,7 +302,7 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 		{
 			for (const ParamItem &PI : PT.items)
 			{
-				OS << "	vec2 " << PI.name << "_coord_scale = vec2(1.);" << std::endl;
+				OS << "	vec2 " << PI.name << "_coord_scale = vec2(1.);\n";
 			}
 		}
 	}
@@ -310,10 +310,10 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 
 void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 {
-	OS << "}" << std::endl << std::endl;
+	OS << "}\n\n";
 
-	OS << "void main ()" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void main ()\n";
+	OS << "{\n";
 
 	std::string parameters = "";
 
@@ -335,13 +335,13 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 					if (!PI.value.empty())
 						OS << "= " << PI.value;
 
-					OS << ";" << std::endl;
+					OS << ";\n";
 				}
 			}
 		}
 	}
 
-	OS << std::endl << "	vs_main(" << parameters << ");" << std::endl << std::endl;
+	OS << "\n" << "	vs_main(" << parameters << ");\n\n";
 
 	bool insert_front_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE) != 0;
 	bool insert_front_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR) != 0;
@@ -377,19 +377,19 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 			if (condition.empty() || i.default_val.empty())
 			{
 				if (!condition.empty()) condition = "if " + condition;
-				OS << "	" << condition << name << " = " << i.src_reg << i.src_reg_mask << ";" << std::endl;
+				OS << "	" << condition << name << " = " << i.src_reg << i.src_reg_mask << ";\n";
 			}
 			else
 			{
 				//Insert if-else condition
-				OS << "	" << name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";" << std::endl;
+				OS << "	" << name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";\n";
 			}
 		}
 		else if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
 		{
 			//An output was declared but nothing was written to it
 			//Set it to all ones (Atelier Escha)
-			OS << "	" << i.name << " = vec4(1.);" << std::endl;
+			OS << "	" << i.name << " = vec4(1.);\n";
 		}
 	}
 
@@ -401,7 +401,7 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "dst_reg2"))
 			OS << "	front_spec_color = dst_reg2;\n";
 
-	OS << "	gl_Position = gl_Position * scaleOffsetMat;" << std::endl;
+	OS << "	gl_Position = gl_Position * scaleOffsetMat;\n";
 
 	//Since our clip_space is symetrical [-1, 1] we map it to linear space using the eqn:
 	//ln = (clip * 2) - 1 to fully utilize the 0-1 range of the depth buffer
@@ -413,10 +413,10 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 	//It is therefore critical that this step is done post-transform and the result re-scaled by w
 	//SEE Naruto: UNS
 	
-	OS << "	float ndc_z = gl_Position.z / gl_Position.w;" << std::endl;
-	OS << "	ndc_z = (ndc_z * 2.) - 1.;" << std::endl;
-	OS << "	gl_Position.z = ndc_z * gl_Position.w;" << std::endl;
-	OS << "}" << std::endl;
+	OS << "	float ndc_z = gl_Position.z / gl_Position.w;\n";
+	OS << "	ndc_z = (ndc_z * 2.) - 1.;\n";
+	OS << "	gl_Position.z = ndc_z * gl_Position.w;\n";
+	OS << "}\n";
 }
 
 

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -385,6 +385,12 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 				OS << "	" << name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";" << std::endl;
 			}
 		}
+		else if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
+		{
+			//An output was declared but nothing was written to it
+			//Set it to all ones (Atelier Escha)
+			OS << "	" << i.name << " = vec4(1.);" << std::endl;
+		}
 	}
 
 	if (insert_back_diffuse && insert_front_diffuse)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -273,7 +273,7 @@ namespace rsx
 
 	void thread::begin()
 	{
-		rsx::method_registers.current_draw_clause.inline_vertex_array.clear();
+		rsx::method_registers.current_draw_clause.inline_vertex_array.resize(0);
 		in_begin_end = true;
 	}
 
@@ -865,6 +865,7 @@ namespace rsx
 		RSXVertexProgram result = {};
 		const u32 transform_program_start = rsx::method_registers.transform_program_start();
 		result.data.reserve((512 - transform_program_start) * 4);
+		result.rsx_vertex_inputs.reserve(rsx::limits::vertex_count);
 
 		for (int i = transform_program_start; i < 512; ++i)
 		{
@@ -881,7 +882,7 @@ namespace rsx
 
 		const u32 input_mask = rsx::method_registers.vertex_attrib_input_mask();
 		const u32 modulo_mask = rsx::method_registers.frequency_divider_operation_mask();
-		result.rsx_vertex_inputs.clear();
+
 		for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 		{
 			bool enabled = !!(input_mask & (1 << index));

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -91,18 +91,12 @@ void VKFragmentDecompilerThread::insertOutputs(std::stringstream & OS)
 		{ "ocol3", m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS ? "r4" : "h8" },
 	};
 
-	//We always bind the first usable image to index 0, even if surface type is surface_type::b
-	//If only surface 1 is being written to, redirect to output 0
-
-	if (m_parr.HasParam(PF_PARAM_NONE, "vec4", table[1].second) && !m_parr.HasParam(PF_PARAM_NONE, "vec4", table[0].second))
-		OS << "layout(location=0) out vec4 " << table[1].first << ";" << std::endl;
-	else
+	//NOTE: We do not skip outputs, the only possible combinations are a(0), b(0), ab(0,1), abc(0,1,2), abcd(0,1,2,3)
+	u8 output_index = 0;
+	for (int i = 0; i < sizeof(table) / sizeof(*table); ++i)
 	{
-		for (int i = 0; i < sizeof(table) / sizeof(*table); ++i)
-		{
-			if (m_parr.HasParam(PF_PARAM_NONE, "vec4", table[i].second))
-				OS << "layout(location=" << i << ") " << "out vec4 " << table[i].first << ";" << std::endl;
-		}
+		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", table[i].second))
+			OS << "layout(location=" << std::to_string(output_index++) << ") " << "out vec4 " << table[i].first << ";" << std::endl;
 	}
 }
 

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -29,8 +29,8 @@ std::string VKFragmentDecompilerThread::compareFunction(COMPARE f, const std::st
 
 void VKFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 {
-	OS << "#version 420" << std::endl;
-	OS << "#extension GL_ARB_separate_shader_objects: enable" << std::endl << std::endl;
+	OS << "#version 420\n";
+	OS << "#extension GL_ARB_separate_shader_objects: enable\n\n";
 }
 
 void VKFragmentDecompilerThread::insertIntputs(std::stringstream & OS)
@@ -60,7 +60,7 @@ void VKFragmentDecompilerThread::insertIntputs(std::stringstream & OS)
 			if (var_name == "fogc")
 				var_name = "fog_c";
 
-			OS << "layout(location=" << reg.reg_location << ") in " << PT.type << " " << var_name << ";" << std::endl;
+			OS << "layout(location=" << reg.reg_location << ") in " << PT.type << " " << var_name << ";\n";
 		}
 	}
 
@@ -70,13 +70,13 @@ void VKFragmentDecompilerThread::insertIntputs(std::stringstream & OS)
 		if (m_prog.front_color_diffuse_output && m_prog.back_color_diffuse_output)
 		{
 			const vk::varying_register_t &reg = vk::get_varying_register("front_diff_color");
-			OS << "layout(location=" << reg.reg_location << ") in vec4 front_diff_color;" << std::endl;
+			OS << "layout(location=" << reg.reg_location << ") in vec4 front_diff_color;\n";
 		}
 
 		if (m_prog.front_color_specular_output && m_prog.back_color_specular_output)
 		{
 			const vk::varying_register_t &reg = vk::get_varying_register("front_spec_color");
-			OS << "layout(location=" << reg.reg_location << ") in vec4 front_spec_color;" << std::endl;
+			OS << "layout(location=" << reg.reg_location << ") in vec4 front_spec_color;\n";
 		}
 	}
 }
@@ -96,7 +96,7 @@ void VKFragmentDecompilerThread::insertOutputs(std::stringstream & OS)
 	for (int i = 0; i < sizeof(table) / sizeof(*table); ++i)
 	{
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", table[i].second))
-			OS << "layout(location=" << std::to_string(output_index++) << ") " << "out vec4 " << table[i].first << ";" << std::endl;
+			OS << "layout(location=" << std::to_string(output_index++) << ") " << "out vec4 " << table[i].first << ";\n";
 	}
 }
 
@@ -142,12 +142,12 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 			inputs.push_back(in);
 
-			OS << "layout(set=0, binding=" << 19 + location++ << ") uniform " << samplerType << " " << PI.name << ";" << std::endl;
+			OS << "layout(set=0, binding=" << 19 + location++ << ") uniform " << samplerType << " " << PI.name << ";\n";
 		}
 	}
 
-	OS << "layout(std140, set = 0, binding = 2) uniform FragmentConstantsBuffer" << std::endl;
-	OS << "{" << std::endl;
+	OS << "layout(std140, set = 0, binding = 2) uniform FragmentConstantsBuffer\n";
+	OS << "{\n";
 
 	for (const ParamType& PT : m_parr.params[PF_PARAM_UNIFORM])
 	{
@@ -158,15 +158,15 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 			continue;
 
 		for (const ParamItem& PI : PT.items)
-			OS << "	" << PT.type << " " << PI.name << ";" << std::endl;
+			OS << "	" << PT.type << " " << PI.name << ";\n";
 	}
 
-	OS << "	float fog_param0;" << std::endl;
-	OS << "	float fog_param1;" << std::endl;
-	OS << "	uint alpha_test;" << std::endl;
-	OS << "	float alpha_ref;" << std::endl;
-	OS << "	vec4 texture_parameters[16];" << std::endl;
-	OS << "};" << std::endl;
+	OS << "	float fog_param0;\n";
+	OS << "	float fog_param1;\n";
+	OS << "	uint alpha_test;\n";
+	OS << "	float alpha_ref;\n";
+	OS << "	vec4 texture_parameters[16];\n";
+	OS << "};\n";
 
 	vk::glsl::program_input in;
 	in.location = 1;
@@ -250,8 +250,8 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 		}
 	}
 
-	OS << "void fs_main(" << parameters << ")" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void fs_main(" << parameters << ")\n";
+	OS << "{\n";
 
 	for (const ParamType& PT : m_parr.params[PF_PARAM_NONE])
 	{
@@ -264,7 +264,7 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 			if (!PI.value.empty())
 				OS << " = " << PI.value;
 
-			OS << ";" << std::endl;
+			OS << ";\n";
 		}
 	}
 
@@ -395,10 +395,10 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 		OS << make_comparison_test(m_prog.alpha_func, "bool(alpha_test) && ", first_output_name + ".a", "alpha_ref");
 	}
 
-	OS << "}" << std::endl << std::endl;
+	OS << "}\n\n";
 
-	OS << "void main()" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void main()\n";
+	OS << "{\n";
 
 	std::string parameters = "";
 	for (auto &reg_name : output_values)
@@ -409,11 +409,11 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 				parameters += ", ";
 
 			parameters += reg_name;
-			OS << "	vec4 " << reg_name << " = vec4(0.);" << std::endl;
+			OS << "	vec4 " << reg_name << " = vec4(0.);\n";
 		}
 	}
 
-	OS << std::endl << "	fs_main(" + parameters + ");" << std::endl << std::endl;
+	OS << "\n" << "	fs_main(" + parameters + ");\n\n";
 
 	//Append the color output assignments
 	OS << color_output_block;
@@ -426,7 +426,7 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 			* but it writes depth in r1.z and not h2.z.
 			* Maybe there's a different flag for depth ?
 			*/
-			//OS << ((m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) ? "\tgl_FragDepth = r1.z;\n" : "\tgl_FragDepth = h0.z;\n") << std::endl;
+			//OS << ((m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) ? "\tgl_FragDepth = r1.z;\n" : "\tgl_FragDepth = h0.z;\n") << "\n";
 			OS << "	gl_FragDepth = r1.z;\n";
 		}
 		else
@@ -436,7 +436,7 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 		}
 	}
 
-	OS << "}" << std::endl;
+	OS << "}\n";
 }
 
 void VKFragmentDecompilerThread::Task()

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -36,7 +36,8 @@ namespace vk
 			if (length > cpu_address_range)
 				release_dma_resources();
 
-			rsx::buffered_section::reset(base, length);
+			rsx::protection_policy policy = g_cfg.video.strict_rendering_mode ? rsx::protection_policy::protect_policy_full_range : rsx::protection_policy::protect_policy_one_page;
+			rsx::buffered_section::reset(base, length, policy);
 		}
 
 		void create(const u16 w, const u16 h, const u16 depth, const u16 mipmaps, vk::image_view *view, vk::image *image, const u32 native_pitch = 0, bool managed=true)

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -240,7 +240,7 @@ namespace
 		void* buf = m_index_buffer_ring_info.map(offset_in_index_buffer, upload_size);
 
 		write_index_array_for_non_indexed_non_native_primitive_to_buffer(
-			reinterpret_cast<char*>(buf), clause.primitive, 0, vertex_count);
+			reinterpret_cast<char*>(buf), clause.primitive, vertex_count);
 
 		m_index_buffer_ring_info.unmap();
 		return std::make_tuple(

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -349,6 +349,12 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 				OS << "	" << i.name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";" << std::endl;
 			}
 		}
+		else if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
+		{
+			//An output was declared but nothing was written to it
+			//Set it to all ones (Atelier Escha)
+			OS << "	" << i.name << " = vec4(1.);" << std::endl;
+		}
 	}
 
 	if (insert_back_diffuse && insert_front_diffuse)

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -28,14 +28,14 @@ std::string VKVertexDecompilerThread::compareFunction(COMPARE f, const std::stri
 
 void VKVertexDecompilerThread::insertHeader(std::stringstream &OS)
 {
-	OS << "#version 450" << std::endl << std::endl;
-	OS << "#extension GL_ARB_separate_shader_objects : enable" << std::endl;
-	OS << "layout(std140, set = 0, binding = 0) uniform ScaleOffsetBuffer" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	mat4 scaleOffsetMat;" << std::endl;
-	OS << "	ivec4 userClipEnabled[2];" << std::endl;
-	OS << "	vec4 userClipFactor[2];" << std::endl;
-	OS << "};" << std::endl;
+	OS << "#version 450\n\n";
+	OS << "#extension GL_ARB_separate_shader_objects : enable\n";
+	OS << "layout(std140, set = 0, binding = 0) uniform ScaleOffsetBuffer\n";
+	OS << "{\n";
+	OS << "	mat4 scaleOffsetMat;\n";
+	OS << "	ivec4 userClipEnabled[2];\n";
+	OS << "	vec4 userClipFactor[2];\n";
+	OS << "};\n";
 
 	vk::glsl::program_input in;
 	in.location = 0;
@@ -92,7 +92,7 @@ void VKVertexDecompilerThread::insertInputs(std::stringstream & OS, const std::v
 					}
 
 					std::string samplerType = is_int ? "isamplerBuffer" : "samplerBuffer";
-					OS << "layout(set = 0, binding=" << 3 + location++ << ")" << "	uniform " << samplerType << " " << PI.name << "_buffer;" << std::endl;
+					OS << "layout(set = 0, binding=" << 3 + location++ << ")" << "	uniform " << samplerType << " " << PI.name << "_buffer;\n";
 				}
 			}
 		}
@@ -101,11 +101,11 @@ void VKVertexDecompilerThread::insertInputs(std::stringstream & OS, const std::v
 
 void VKVertexDecompilerThread::insertConstants(std::stringstream & OS, const std::vector<ParamType> & constants)
 {
-	OS << "layout(std140, set=0, binding = 1) uniform VertexConstantsBuffer" << std::endl;
-	OS << "{" << std::endl;
-	OS << "	vec4 vc[468];" << std::endl;
-	OS << "	uint transform_branch_bits;" << std::endl;
-	OS << "};" << std::endl << std::endl;
+	OS << "layout(std140, set=0, binding = 1) uniform VertexConstantsBuffer\n";
+	OS << "{\n";
+	OS << "	vec4 vc[468];\n";
+	OS << "	uint transform_branch_bits;\n";
+	OS << "};\n\n";
 
 	vk::glsl::program_input in;
 	in.location = 1;
@@ -137,7 +137,7 @@ void VKVertexDecompilerThread::insertConstants(std::stringstream & OS, const std
 
 				inputs.push_back(in);
 
-				OS << "layout(set = 0, binding=" << 19 + location++ << ") uniform " << PT.type << " " << PI.name << ";" << std::endl;
+				OS << "layout(set = 0, binding=" << 19 + location++ << ") uniform " << PT.type << " " << PI.name << ";\n";
 			}
 		}
 	}
@@ -193,15 +193,15 @@ void VKVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::
 				insert_front_specular = false;
 
 			const vk::varying_register_t &reg = vk::get_varying_register(i.name);
-			OS << "layout(location=" << reg.reg_location << ") out vec4 " << i.name << ";" << std::endl;
+			OS << "layout(location=" << reg.reg_location << ") out vec4 " << i.name << ";\n";
 		}
 	}
 
 	if (insert_back_diffuse && insert_front_diffuse)
-		OS << "layout(location=" << vk::get_varying_register("front_diff_color").reg_location << ") out vec4 front_diff_color;" << std::endl;
+		OS << "layout(location=" << vk::get_varying_register("front_diff_color").reg_location << ") out vec4 front_diff_color;\n";
 
 	if (insert_back_specular && insert_front_specular)
-		OS << "layout(location=" << vk::get_varying_register("front_spec_color").reg_location << ") out vec4 front_spec_color;" << std::endl;
+		OS << "layout(location=" << vk::get_varying_register("front_spec_color").reg_location << ") out vec4 front_spec_color;\n";
 }
 
 namespace vk
@@ -215,7 +215,7 @@ namespace vk
 
 			if (!real_input.is_array)
 			{
-				OS << "	vec4 " << PI.name << " = vec4(texelFetch(" << PI.name << "_buffer, 0));" << std::endl;
+				OS << "	vec4 " << PI.name << " = vec4(texelFetch(" << PI.name << "_buffer, 0));\n";
 				return;
 			}
 
@@ -223,19 +223,19 @@ namespace vk
 			{
 				if (real_input.is_modulo)
 				{
-					OS << "	vec4 " << PI.name << "= vec4(texelFetch(" << PI.name << "_buffer, gl_VertexIndex %" << real_input.frequency << "));" << std::endl;
+					OS << "	vec4 " << PI.name << "= vec4(texelFetch(" << PI.name << "_buffer, gl_VertexIndex %" << real_input.frequency << "));\n";
 					return;
 				}
 
-				OS << "	vec4 " << PI.name << "= vec4(texelFetch(" << PI.name << "_buffer, gl_VertexIndex /" << real_input.frequency << "));" << std::endl;
+				OS << "	vec4 " << PI.name << "= vec4(texelFetch(" << PI.name << "_buffer, gl_VertexIndex /" << real_input.frequency << "));\n";
 				return;
 			}
 
-			OS << "	vec4 " << PI.name << "= vec4(texelFetch(" << PI.name << "_buffer, gl_VertexIndex).rgba);" << std::endl;
+			OS << "	vec4 " << PI.name << "= vec4(texelFetch(" << PI.name << "_buffer, gl_VertexIndex).rgba);\n";
 			return;
 		}
 
-		OS << "	vec4 " << PI.name << "= vec4(texelFetch(" << PI.name << "_buffer, gl_VertexIndex).rgba);" << std::endl;
+		OS << "	vec4 " << PI.name << "= vec4(texelFetch(" << PI.name << "_buffer, gl_VertexIndex).rgba);\n";
 	}
 }
 
@@ -256,8 +256,8 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 		}
 	}
 
-	OS << "void vs_main(" << parameters << ")" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void vs_main(" << parameters << ")\n";
+	OS << "{\n";
 
 	//Declare temporary registers, ignoring those mapped to outputs
 	for (const ParamType PT : m_parr.params[PF_PARAM_NONE])
@@ -271,7 +271,7 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 			if (!PI.value.empty())
 				OS << " = " << PI.value;
 
-			OS << ";" << std::endl;
+			OS << ";\n";
 		}
 	}
 
@@ -284,10 +284,10 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 
 void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 {
-	OS << "}" << std::endl << std::endl;
+	OS << "}\n\n";
 
-	OS << "void main ()" << std::endl;
-	OS << "{" << std::endl;
+	OS << "void main ()\n";
+	OS << "{\n";
 
 	std::string parameters = "";
 
@@ -309,13 +309,13 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 					if (!PI.value.empty())
 						OS << "= " << PI.value;
 
-					OS << ";" << std::endl;
+					OS << ";\n";
 				}
 			}
 		}
 	}
 
-	OS << std::endl << "	vs_main(" << parameters << ");" << std::endl << std::endl;
+	OS << "\n" << "	vs_main(" << parameters << ");\n\n";
 
 	bool insert_front_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE) != 0;
 	bool insert_front_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR) != 0;
@@ -341,19 +341,19 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 			if (condition.empty() || i.default_val.empty())
 			{
 				if (!condition.empty()) condition = "if " + condition;
-				OS << "	" << condition << i.name << " = " << i.src_reg << i.src_reg_mask << ";" << std::endl;
+				OS << "	" << condition << i.name << " = " << i.src_reg << i.src_reg_mask << ";\n";
 			}
 			else
 			{
 				//Insert if-else condition
-				OS << "	" << i.name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";" << std::endl;
+				OS << "	" << i.name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";\n";
 			}
 		}
 		else if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
 		{
 			//An output was declared but nothing was written to it
 			//Set it to all ones (Atelier Escha)
-			OS << "	" << i.name << " = vec4(1.);" << std::endl;
+			OS << "	" << i.name << " = vec4(1.);\n";
 		}
 	}
 
@@ -365,8 +365,8 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "dst_reg2"))
 			OS << "	front_spec_color = dst_reg2;\n";
 
-	OS << "	gl_Position = gl_Position * scaleOffsetMat;" << std::endl;
-	OS << "}" << std::endl;
+	OS << "	gl_Position = gl_Position * scaleOffsetMat;\n";
+	OS << "}\n";
 }
 
 


### PR DESCRIPTION
- Fix a regression when emulating index buffers for generated primitives. Removes the 'first' parameter since rpcs3 does not support disjoint vertex ranges at the moment anyway. https://github.com/RPCS3/rpcs3/issues/2917
- Adds in a very old bugfix that makes DX12 crash properly instead of throwing a cryptic range error. This DOES NOT fix DX12 crashing, merely generates a more useful fatal error message.
- Includes fixes for some 'blue' games
- Added a 'speed hack' - not really a hack - for games that share memory regions between textures and other GPU resources such as shaders. Significantly boosts perf in games where the cache is invalidated often. Can be disabled by setting 'Strict Rendering Mode' to true.
- Add 59.94 Hz support required by some games
- Fix a rare vulkan shader compiler bug
- Fix a rare openGL crash when trying to capture traces with renderdoc
- A minor behaviour fix for openGL when strict mode is not enabled. Makes behaviour alot more reliable to debug now.
- Small to moderate speedup on games with many draw calls due to some minor tweaks to c++ object management