### PR TITLE
Relax qt dependency to qt 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ If you want to contribute please take a look at the [Coding Style](https://githu
 * [Visual C++ Redistributable Packages for Visual Studio 2015](http://www.microsoft.com/en-us/download/details.aspx?id=48145)
 * [Cmake 3.1.0+](https://www.cmake.org/download/) (required; add to PATH)
 * [Python 3.3+](https://www.python.org/downloads/) (required; add to PATH)
-* [Qt 5.8+](https://www.qt.io/download-open-source/) (required; add QTDIR `<QtInstallFolder>\5.8\msvc2015_64\` environment variable if you do not want to use the Visual Studio Qt Plugin)
+* [Qt 5.7+](https://www.qt.io/download-open-source/) (required; add QTDIR `<QtInstallFolder>\5.7\msvc2015_64\` environment variable if you do not want to use the Visual Studio Qt Plugin)
 * [Visual Studio Qt Plugin](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools2015) (optional; see above)
 
 ### Linux
-* [Qt 5.8+](https://www.qt.io/download-open-source/)
+* [Qt 5.7+](https://www.qt.io/download-open-source/)
 * GCC 5.1+ or Clang 3.5.0+ ([not GCC 6.1](https://github.com/RPCS3/rpcs3/issues/1691))
 * Debian & Ubuntu: `sudo apt-get install cmake build-essential libasound2-dev libopenal-dev libglew-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git qt5-default`
 * Arch: `sudo pacman -S glew openal cmake llvm qt5-base`
@@ -46,12 +46,12 @@ To initialize the repository don't forget to execute `git submodule update --ini
 ### Configuring Qt
 
 *If you're using Visual Studio 2017 without Qt plugin support (or simply dont want to use it):* 
-1) Add `QTDIR` environment variable and set it to `<QtInstallFolder>\5.8\msvc2015_64\` </br>
+1) Add `QTDIR` environment variable and set it to `<QtInstallFolder>\5.7\msvc2015_64\` </br>
 *OR* </br>
-open the SLN, wait for projects to load, in explorer open `rpcs3qt/rpcs3qt.vcxproj.user` and set `<QTDIR>QtInstallFolder/5.8/msvc2015_64</QTDIR>`
+open the SLN, wait for projects to load, in explorer open `rpcs3qt/rpcs3qt.vcxproj.user` and set `<QTDIR>QtInstallFolder/5.7/msvc2015_64</QTDIR>`
 
 *If you wish to use the Visual Studio plugin for Qt:* </br>
-1) Go to the Qt5 menu and edit Qt5 options. Add the path to your Qt installation with compiler e.g. `C:\Qt\5.8\msvc2015_64`. </br>
+1) Go to the Qt5 menu and edit Qt5 options. Add the path to your Qt installation with compiler e.g. `C:\Qt\5.7\msvc2015_64`. </br>
 2) While selecting the rpcs3qt project, go to Qt5->Project Setting and select the version you added. 
 
 ### Building the projects

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -5,7 +5,7 @@ set(RES_FILES "")
 set(CMAKE_CXX_STANDARD 14)
 
 # Qt section
-find_package(Qt5 5.8 COMPONENTS Widgets)
+find_package(Qt5 5.7 COMPONENTS Widgets)
 if (WIN32)
     find_package(Qt5WinExtras REQUIRED)
     set(RPCS3_QT_LIBS Qt5::Widgets Qt5::WinExtras)
@@ -17,8 +17,8 @@ endif()
 
 # Let's make sure we have Qt before we continue
 if (NOT Qt5Widgets_FOUND)
-	if (Qt5Widgets_VERSION VERSION_LESS 5.8.0)
-		message("Minimum supported Qt5 version is 5.8! You have version ${Qt5Widgets_VERSION} installed, please upgrade!")
+	if (Qt5Widgets_VERSION VERSION_LESS 5.7.0)
+		message("Minimum supported Qt5 version is 5.7! You have version ${Qt5Widgets_VERSION} installed, please upgrade!")
 		if ("${CMAKE_SYSTEM}" MATCHES "Linux")
 			message(FATAL_ERROR "Most distros do not provide an up-to-date version of Qt.
 If you're on Ubuntu or Linux Mint, there are PPAs you can use to install an up-to-date qt5 version.


### PR DESCRIPTION
First off, great work with the transition to qt!

It seems the project doesn't use any qt 5.8 specific features, and relaxing the check some would make the project more approachable.

With this change, I successfully compiled rpcs3 on Fedora 25, which is on qt 5.7.1