### PR TITLE
Small Save Manager Patch

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -317,7 +317,8 @@ static NEVER_INLINE s32 savedata_op(ppu_thread& ppu, u32 operation, u32 version,
 				}
 				else
 				{
-					return CELL_OK; // ???
+					// This happens if someone tries to load but there is no data selected.  Some games will throw errors (Akiba) if cell_ok is returned
+					return CELL_CANCEL;
 				}
 			}
 			// Cancel selected in UI

--- a/rpcs3/rpcs3qt/save_data_utility.cpp
+++ b/rpcs3/rpcs3qt/save_data_utility.cpp
@@ -85,7 +85,11 @@ save_data_list_dialog::save_data_list_dialog(const std::vector<SaveDataEntry>& e
 	// Button Layout
 	QHBoxLayout* hbox_action = new QHBoxLayout();
 	QPushButton *push_cancel = new QPushButton(tr("&Cancel"), this);
+	push_cancel->setAutoDefault(false);
 	QPushButton *push_select = new QPushButton(tr("&Select Entry"), this);
+	push_select->setAutoDefault(true);
+	push_select->setDefault(true);
+
 	connect(push_select, &QAbstractButton::clicked, this, &save_data_list_dialog::accept);
 	hbox_action->addWidget(push_select);
 	setWindowTitle(tr("Save Data Chooser"));


### PR DESCRIPTION
Some games like Akiba throw an error if you return cell_ok when loading but no data is selected.  Others, like Miku will start a new game.

Returning cell_cancel fixes this.