### PR TITLE
Fix Lost Dimension ingame

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -33,6 +33,7 @@ static const std::unordered_map<std::string, int> s_prx_ignore
 	{ "/dev_flash/sys/external/libmic.sprx", 0 },
 	{ "/dev_flash/sys/external/libnet.sprx", 0 },
 	{ "/dev_flash/sys/external/libnetctl.sprx", 0 },
+	{ "/dev_flash/sys/external/libpamf.sprx", 0 },
 	{ "/dev_flash/sys/external/librudp.sprx", 0 },
 	{ "/dev_flash/sys/external/libssl.sprx", 0 },
 	{ "/dev_flash/sys/external/libsysutil.sprx", 0 },


### PR DESCRIPTION
remove libpamf.sprx in lv2

If anyone user can test for see if have impact with other game ussing video pamf in lv2 only mode