### PR TITLE
Remove compiler warning & stub module functions

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellHttp.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellHttp.cpp
@@ -317,6 +317,24 @@ s32 cellHttpClientSetConnectionWaitStatus()
 	return CELL_OK;
 }
 
+s32 cellHttpClientGetConnectionWaitStatus()
+{
+	UNIMPLEMENTED_FUNC(cellHttp);
+	return CELL_OK;
+}
+
+s32 cellHttpClientSetConnectionWaitTimeout()
+{
+	UNIMPLEMENTED_FUNC(cellHttp);
+	return CELL_OK;
+}
+
+s32 cellHttpClientGetConnectionWaitTimeout()
+{
+	UNIMPLEMENTED_FUNC(cellHttp);
+	return CELL_OK;
+}
+
 s32 cellHttpClientSetRecvTimeout()
 {
 	UNIMPLEMENTED_FUNC(cellHttp);
@@ -641,6 +659,18 @@ s32 cellHttpTransactionGetSslId()
 	return CELL_OK;
 }
 
+s32 cellHttpClientSetMinSslVersion()
+{
+	UNIMPLEMENTED_FUNC(cellHttp);
+	return CELL_OK;
+}
+
+s32 cellHttpClientGetMinSslVersion()
+{
+	UNIMPLEMENTED_FUNC(cellHttp);
+	return CELL_OK;
+}
+
 s32 cellHttpClientSetSslVersion()
 {
 	UNIMPLEMENTED_FUNC(cellHttp);
@@ -719,7 +749,10 @@ DECLARE(ppu_module_manager::cellHttp)("cellHttp", []()
 	REG_FUNC(cellHttp, cellHttpClientPollConnections);
 
 	REG_FUNC(cellHttp, cellHttpClientSetConnectionStateCallback);
+	REG_FUNC(cellHttp, cellHttpClientGetConnectionWaitStatus);
 	REG_FUNC(cellHttp, cellHttpClientSetConnectionWaitStatus);
+	REG_FUNC(cellHttp, cellHttpClientGetConnectionWaitTimeout);
+	REG_FUNC(cellHttp, cellHttpClientSetConnectionWaitTimeout);
 	REG_FUNC(cellHttp, cellHttpClientSetRecvTimeout);
 	REG_FUNC(cellHttp, cellHttpClientGetRecvTimeout);
 	REG_FUNC(cellHttp, cellHttpClientSetSendTimeout);
@@ -781,6 +814,8 @@ DECLARE(ppu_module_manager::cellHttp)("cellHttp", []()
 	REG_FUNC(cellHttp, cellHttpTransactionGetSslVersion);
 	REG_FUNC(cellHttp, cellHttpTransactionGetSslId);
 
+	REG_FUNC(cellHttp, cellHttpClientSetMinSslVersion);
+	REG_FUNC(cellHttp, cellHttpClientGetMinSslVersion);
 	REG_FUNC(cellHttp, cellHttpClientSetSslVersion);
 	REG_FUNC(cellHttp, cellHttpClientGetSslVersion);
 	REG_FUNC(cellHttp, cellHttpClientSetSslIdDestroyCallback);

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -1717,6 +1717,18 @@ s32 sceNpSignalingGetPeerNetInfoResult()
 	return CELL_OK;
 }
 
+s32 sceNpUtilCanonicalizeNpIdForPs3()
+{
+	UNIMPLEMENTED_FUNC(sceNp);
+	return CELL_OK;
+}
+
+s32 sceNpUtilCanonicalizeNpIdForPsp()
+{
+	UNIMPLEMENTED_FUNC(sceNp);
+	return CELL_OK;
+}
+
 s32 sceNpUtilCmpNpId(vm::ptr<SceNpId> id1, vm::ptr<SceNpId> id2)
 {
 	sceNp.warning("sceNpUtilCmpNpId(id1=*0x%x, id2=*0x%x)", id1, id2);
@@ -2032,11 +2044,13 @@ DECLARE(ppu_module_manager::sceNp)("sceNp", []()
 	REG_FUNC(sceNp, sceNpSignalingGetPeerNetInfo);
 	REG_FUNC(sceNp, sceNpSignalingCancelPeerNetInfo);
 	REG_FUNC(sceNp, sceNpSignalingGetPeerNetInfoResult);
+	REG_FUNC(sceNp, sceNpUtilCanonicalizeNpIdForPs3);
+	REG_FUNC(sceNp, sceNpUtilCanonicalizeNpIdForPsp);
 	REG_FUNC(sceNp, sceNpUtilCmpNpId);
 	REG_FUNC(sceNp, sceNpUtilCmpNpIdInOrder);
-	REG_FUNC(sceNp, sceNpUtilCmpOnlineId); // 0x8C760B52
-	REG_FUNC(sceNp, sceNpUtilGetPlatformType); // 0xC611029A
-	REG_FUNC(sceNp, sceNpUtilSetPlatformType); // 0xAFC62605
+	REG_FUNC(sceNp, sceNpUtilCmpOnlineId);
+	REG_FUNC(sceNp, sceNpUtilGetPlatformType);
+	REG_FUNC(sceNp, sceNpUtilSetPlatformType);
 	REG_FUNC(sceNp, _sceNpSysutilClientMalloc);
 	REG_FUNC(sceNp, _sceNpSysutilClientFree);
 	REG_FUNC(sceNp, _Z33_sce_np_sysutil_send_empty_packetiPN16sysutil_cxmlutil11FixedMemoryEPKcS3_);

--- a/rpcs3/Emu/Cell/Modules/sceNp2.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp2.cpp
@@ -445,6 +445,29 @@ s32 sceNpMatching2RegisterRoomMessageCallback()
 	return CELL_OK;
 }
 
+s32 sceNpMatching2SignalingCancelPeerNetInfo()
+{
+	UNIMPLEMENTED_FUNC(sceNp2);
+	return CELL_OK;
+}
+
+s32 sceNpMatching2SignalingGetLocalNetInfo()
+{
+	UNIMPLEMENTED_FUNC(sceNp2);
+	return CELL_OK;
+}
+
+s32 sceNpMatching2SignalingGetPeerNetInfo()
+{
+	UNIMPLEMENTED_FUNC(sceNp2);
+	return CELL_OK;
+}
+
+s32 sceNpMatching2SignalingGetPeerNetInfoResult()
+{
+	UNIMPLEMENTED_FUNC(sceNp2);
+	return CELL_OK;
+}
 
 DECLARE(ppu_module_manager::sceNp2)("sceNp2", []()
 {
@@ -517,4 +540,8 @@ DECLARE(ppu_module_manager::sceNp2)("sceNp2", []()
 	REG_FUNC(sceNp2, sceNpMatching2Init2);
 	REG_FUNC(sceNp2, sceNpMatching2SetLobbyMemberDataInternal);
 	REG_FUNC(sceNp2, sceNpMatching2RegisterRoomMessageCallback);
+	REG_FUNC(sceNp2, sceNpMatching2SignalingCancelPeerNetInfo);
+	REG_FUNC(sceNp2, sceNpMatching2SignalingGetLocalNetInfo);
+	REG_FUNC(sceNp2, sceNpMatching2SignalingGetPeerNetInfo);
+	REG_FUNC(sceNp2, sceNpMatching2SignalingGetPeerNetInfoResult);
 });

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
@@ -1,7 +1,4 @@
-#pragma once
-
 #include "stdafx.h"
-
 #include "GLGSRender.h"
 #include "GLTextureCache.h"
 


### PR DESCRIPTION
**Before**
! LDR: **** cellHttp export: [0x431E1407] at 0x167808
! LDR: **** cellHttp export: [0xB7CB7D05] at 0x167858
! LDR: **** cellHttp export: [0x1249C1D1] at 0x167830
! LDR: **** cellHttp export: [0xE6C7D333] at 0x1678e0
! LDR: **** cellHttp export: [0x98CE061C] at 0x1678d0
! LDR: **** sceNp export: [0x91840669] at 0x40c100
! LDR: **** sceNp export: [0xBE3AF96E] at 0x40c0f8
! LDR: **** sceNp2 export: [0x944B28E8] at 0x40d120
! LDR: **** sceNp2 export: [0x98F74C9A] at 0x40d158
! LDR: **** sceNp2 export: [0xDBE84071] at 0x40d178
! LDR: **** sceNp2 export: [0x2E42F94A] at 0x40d150

**After**
! LDR: **** cellHttp export: [cellHttpClientGetConnectionWaitStatus] at 0x167808
! LDR: **** cellHttp export: [cellHttpClientSetConnectionWaitTimeout] at 0x167858
! LDR: **** cellHttp export: [cellHttpClientGetConnectionWaitTimeout] at 0x167830
! LDR: **** cellHttp export: [cellHttpClientSetMinSslVersion] at 0x1678e0
! LDR: **** cellHttp export: [cellHttpClientGetMinSslVersion] at 0x1678d0
! LDR: **** sceNp export: [sceNpUtilCanonicalizeNpIdForPs3] at 0x40c100
! LDR: **** sceNp export: [sceNpUtilCanonicalizeNpIdForPsp] at 0x40c0f8
! LDR: **** sceNp2 export: [sceNpMatching2SignalingCancelPeerNetInfo] at 0x40d120
! LDR: **** sceNp2 export: [sceNpMatching2SignalingGetLocalNetInfo] at 0x40d158
! LDR: **** sceNp2 export: [sceNpMatching2SignalingGetPeerNetInfo] at 0x40d178
! LDR: **** sceNp2 export: [sceNpMatching2SignalingGetPeerNetInfoResult] at 0x40d150
