### PR TITLE
Correct typo in viewport settings

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1192,7 +1192,7 @@
                  <item>
                   <widget class="QGroupBox" name="groupBox_5">
                    <property name="title">
-                    <string>Heigth</string>
+                    <string>Height</string>
                    </property>
                    <layout class="QVBoxLayout" name="verticalLayout_48">
                     <item>


### PR DESCRIPTION
No classes or names or any of that poop are being changed here, only a text string.