### PR TITLE
Log marking.  Alt+L

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -39,6 +39,9 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 	{
 		switch (keyEvent->key())
 		{
+		case Qt::Key_L:
+			if (keyEvent->modifiers() == Qt::AltModifier) { static int count = 0; LOG_SUCCESS(GENERAL, "Made forced mark %d in log", ++count); }
+			break;
 		case Qt::Key_Return:
 			if (keyEvent->modifiers() == Qt::AltModifier) { OnFullScreen(); return; }
 			break;


### PR DESCRIPTION
Adds the ability to force a log comment while a game is running. I used it to pinpoint when game events happened in the log recently for debugging.  Figured it may help others too. Maybe use LOG_NOTICE instead of LOG_SUCCESS?