### PR TITLE
KH2/Roxas Fix

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_timer.h
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.h
@@ -25,7 +25,7 @@ struct lv2_timer final : public lv2_obj, public named_thread
 	void on_stop() override;
 
 	semaphore<> mutex;
-	atomic_t<u32> state{SYS_TIMER_STATE_RUN};
+	atomic_t<u32> state{SYS_TIMER_STATE_STOP};
 
 	std::weak_ptr<lv2_event_queue> port;
 	u64 source;

--- a/rpcs3/Emu/RSX/CgBinaryVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/CgBinaryVertexProgram.cpp
@@ -63,6 +63,9 @@ std::string CgBinaryDisasm::GetDSTDisasm(bool isSca)
 			LOG_ERROR(RSX, "dst index out of range: %u", d3.dst);
 
 		ret += fmt::format("o[%d]", d3.dst) + GetVecMaskDisasm();
+		// Vertex Program supports double destinations, notably in MOV
+		if (d0.dst_tmp != 0x3f)
+			ret += fmt::format(" R%d", d0.dst_tmp) + GetVecMaskDisasm();
 		break;
 	}
 

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -41,16 +41,21 @@ std::string VertexProgramDecompiler::GetDST(bool isSca)
 {
 	std::string ret;
 
+	std::string mask = GetMask(isSca);
+
 	switch (isSca ? 0x1f : d3.dst)
 	{
 	case 0x1f:
-		ret += m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), std::string("tmp") + std::to_string(isSca ? d3.sca_dst_tmp : d0.dst_tmp));
+		ret += m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), std::string("tmp") + std::to_string(isSca ? d3.sca_dst_tmp : d0.dst_tmp)) + mask;
 		break;
 
 	default:
 		if (d3.dst > 15)
 			LOG_ERROR(RSX, "dst index out of range: %u", d3.dst);
-		ret += m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), std::string("dst_reg") + std::to_string(d3.dst), d3.dst == 0 ? getFloatTypeName(4) + "(0.0f, 0.0f, 0.0f, 1.0f)" : getFloatTypeName(4) + "(0.0, 0.0, 0.0, 0.0)");
+		ret += m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), std::string("dst_reg") + std::to_string(d3.dst), d3.dst == 0 ? getFloatTypeName(4) + "(0.0f, 0.0f, 0.0f, 1.0f)" : getFloatTypeName(4) + "(0.0, 0.0, 0.0, 0.0)") + mask;
+		// Handle double destination register as 'dst_reg = tmp'
+		if (d0.dst_tmp != 0x3f)
+			ret += " = " + m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), std::string("tmp") + std::to_string(d0.dst_tmp)) + mask;
 		break;
 	}
 
@@ -157,7 +162,7 @@ void VertexProgramDecompiler::SetDST(bool is_sca, std::string value)
 	}
 	else if (d3.dst != 0x1f || (is_sca ? d3.sca_dst_tmp != 0x3f : d0.dst_tmp != 0x3f))
 	{
-		dest = GetDST(is_sca) + mask;
+		dest = GetDST(is_sca);
 	}
 
 	//std::string code;


### PR DESCRIPTION
sys_timer: Fix initial set state. Fixes KH2 ( and rest of kh series) booting up

vertex decompiler: fixes weird oddity of rsx which allows double destination registers set. Fixes roxas render and cutscene rendering in kh

edit: this *may* also require lle-gcm, didnt test without