### PR TITLE
Finalize AppImage - Fix libpng issue, fix LLVM issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,24 @@ before_install:
       export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01';
     fi;
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y;
-      sudo apt-get update;
-      sudo apt-get install qt59base -y --allow-unauthenticated;
+      wget http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run ;
+      chmod a+x ./qt-unified-linux-x64-online.run ;
+      export QT_QPA_PLATFORM=minimal ;
+      ./qt-unified-linux-x64-online.run --script qt-installer-noninteractive.qs --no-force-installations ;
     fi;
+  - # We need to build patchelf from source because ubuntu doesn't package it in 14.04 yet
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      cd ~/;
+      git clone https://github.com/NixOS/patchelf/ ;
+      cd patchelf ;
+      git checkout 29c085fd9d3fc972f75b3961905d6b4ecce7eb2b ;
+      ./bootstrap.sh ;
+      ./configure ;
+      make ;
+      sudo make install ;
+      cd $TRAVIS_BUILD_DIR ;
+    fi;
+  
   # Add coverall for C++ so coverall.io could be triggered. Even it should be --coverage and gcov.
   # Install updated libglew-dev since the version provided by trusty is outdated
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
@@ -67,9 +81,9 @@ before_install:
 
 before_script:
   - git submodule update --init asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng Utilities/yaml-cpp 3rdparty/cereal 3rdparty/hidapi Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
-  - source /opt/qt59/bin/qt59-env.sh
   - mkdir build
   - cd build
+  - export CMAKE_PREFIX_PATH=~/Qt/5.9.1/gcc_64/lib/cmake
   - if [ -z "$WITHOUT_LLVM" ]; then
       cmake .. -DCMAKE_INSTALL_PREFIX=/usr;
     else
@@ -78,14 +92,19 @@ before_script:
   - make -j 3
   - # AppImage generation
   - if [ "$TRAVIS_BRANCH" = "master" ] && [ "$CC" = "clang-4.0" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
-      export LD_LIBRARY_PATH=${PWD}/3rdparty/libpng:/opt/qt59/lib/:$LD_LIBRARY_PATH ;
+      export LD_LIBRARY_PATH=~/Qt/5.9.1/gcc_64/lib;
       make DESTDIR=appdir install ; find appdir/ ;
       find ../bin ;
       wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" ; 
       chmod a+x linuxdeployqt*.AppImage ;
-      unset QTDIR; unset QT_PLUGIN_PATH ;
+      export PATH=~/Qt/5.9.1/gcc_64/bin/:${PATH} ;
+      ./linuxdeployqt*.AppImage --appimage-extract ;
       ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs ;
-      ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage ;
+      cp ~/Qt/5.9.1/gcc_64/plugins/platforms/* ./appdir/usr/plugins/platforms/ ;
+      sudo rm -f ./appdir/usr/lib/libLLVM* ;
+      patchelf --replace-needed libLLVM-4.0.so.1 libLLVM-4.0.so ./appdir/usr/bin/rpcs3;
+      export PATH=${TRAVIS_BUILD_DIR}/build/squashfs-root/usr/bin/:${PATH} ;
+      ./squashfs-root/usr/bin/appimagetool ${TRAVIS_BUILD_DIR}/build/appdir ;
       find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq ;
       if [ -z "$WITHOUT_LLVM" ]; then
         export LLVM="-LLVM";

--- a/qt-installer-noninteractive.qs
+++ b/qt-installer-noninteractive.qs
@@ -1,0 +1,60 @@
+// http://stackoverflow.com/a/34032216/78204
+
+function Controller() {
+    installer.autoRejectMessageBoxes();
+    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    })
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.TargetDirectoryPageCallback = function()
+{
+    gui.currentPageWidget().TargetDirectoryLineEdit.setText(installer.value("HomeDir") + "/Qt");
+    //gui.currentPageWidget().TargetDirectoryLineEdit.setText(installer.value("InstallerDirPath") + "/Qt");
+    //gui.currentPageWidget().TargetDirectoryLineEdit.setText("/scratch/Qt");
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    widget.deselectAll();
+    widget.selectComponent("qt.591.gcc_64");
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    gui.currentPageWidget().AcceptLicenseRadioButton.setChecked(true);
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.StartMenuDirectoryPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+var checkBoxForm = gui.currentPageWidget().LaunchQtCreatorCheckBoxForm
+if (checkBoxForm && checkBoxForm.launchQtCreatorCheckBox) {
+    checkBoxForm.launchQtCreatorCheckBox.checked = false;
+}
+    gui.clickButton(buttons.FinishButton);
+}


### PR DESCRIPTION
Summary of changes:
- Moved from Ubuntu PPA to official pre-built Qt libs to avoid libpng issue (PPA was linking against libpng 1.2, official Qt links against 1.6)
- Make sure that LLVM 4.x is taken from system libs, and not bundled with the AppImage
- Updated from Qt 5.9 to 5.9.1
- Make sure to request linking against libLLVM-4.0.so not libLLVM-4.0.so.1, which some distros (Arch Linux, notably) don't have.
- Build and install `patchelf` for the above issue and because Ubuntu 14.04 doesn't provide it and the version that linuxdeployqt provides is too old.

@probonopd Would appreciate if you checked this out, and make sure it looks OK.

Alright, here is the guide for using AppImages:

---
**If you want the simple care-free approach, download the non-llvm AppImage**
Warning! LLVM has huge performance benefits! 

**If you want the extra preformance improvements that LLVM has, make sure you have**

*either*

An NVIDIA Graphics card running the latest binary drivers.
You'll also need LLVM 4 installed, use Google to find out how to install LLVM 4 for your distro.

**OR**

A distribution that builds mesa with LLVM 4.0.