### PR TITLE
Allow overlapping ranges in cellGcmMapEaIoAdress with coherency check

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -221,7 +221,6 @@ bool gs_frame::event(QEvent* ev)
 	if (ev->type()==QEvent::Close)
 	{
 		close();
-		return true;
 	}
-	return false;
+	return QWindow::event(ev);
 }


### PR DESCRIPTION
Deduced from booting BCES01584 - the last of us and analysing RSX memory mapping pattern. 
This prevent the trap instruction at boot but the game still freeze almost right after. 
![tlou_past_tw](https://user-images.githubusercontent.com/18249536/28495004-b4e2783a-6f3f-11e7-8d05-4084ff0139be.png)

Might need to reconsider/tweak the change if VirtualMemoryBlock is used for something else than the RSX one day.

