### PR TITLE
[WIP] CellSysutilBgmPlaybackExtraParam and sys_rwlock_trywlock

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -332,7 +332,11 @@ s32 cellSysutilEnableBgmPlaybackEx(vm::ptr<CellSysutilBgmPlaybackExtraParam> par
 	cellSysutil.warning("cellSysutilEnableBgmPlaybackEx(param=*0x%x)", param);
 
 	// TODO
-	g_bgm_playback_enabled = true; 
+	g_bgm_playback_enabled = true;
+	param->systemBgmFadeInTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->systemBgmFadeOutTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->gameBgmFadeInTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->gameBgmFadeOutTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
 
 	return CELL_OK;
 }
@@ -353,6 +357,10 @@ s32 cellSysutilDisableBgmPlaybackEx(vm::ptr<CellSysutilBgmPlaybackExtraParam> pa
 
 	// TODO
 	g_bgm_playback_enabled = false;
+	param->systemBgmFadeInTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->systemBgmFadeOutTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->gameBgmFadeInTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->gameBgmFadeOutTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
 
 	return CELL_OK;
 }
@@ -382,9 +390,16 @@ s32 cellSysutilGetBgmPlaybackStatus2(vm::ptr<CellSysutilBgmPlaybackStatus2> stat
 	return CELL_OK;
 }
 
-s32 cellSysutilSetBgmPlaybackExtraParam()
+s32 cellSysutilSetBgmPlaybackExtraParam(vm::ptr<CellSysutilBgmPlaybackExtraParam> param)
 {
-	cellSysutil.todo("cellSysutilSetBgmPlaybackExtraParam()");
+	cellSysutil.warning("cellSysutilSetBgmPlaybackExtraParam(param=*0x%x)", param);
+
+	// TODO
+	param->systemBgmFadeInTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->systemBgmFadeOutTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->gameBgmFadeInTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+	param->gameBgmFadeOutTime = CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID;
+
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.h
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.h
@@ -165,6 +165,11 @@ enum CellSysutilBgmPlaybackStatusEnabled
 	CELL_SYSUTIL_BGMPLAYBACK_STATUS_DISABLE = 1
 };
 
+enum
+{
+	CELL_SYSUTIL_BGMPLAYBACK_FADE_INVALID = -1
+};
+
 struct CellSysutilBgmPlaybackStatus
 {
 	u8 playerState;

--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -123,7 +123,7 @@ extern std::string ppu_get_syscall_name(u64 code)
 	case 145: return "sys_time_get_current_time";
 	case 146: return "sys_time_get_system_time";
 	case 147: return "sys_time_get_timebase_frequency";
-	case 148: return "_sys_rwlock_trywlock";
+	case 148: return "sys_rwlock_trywlock";
 	case 150: return "sys_raw_spu_create_interrupt_tag";
 	case 151: return "sys_raw_spu_set_int_mask";
 	case 152: return "sys_raw_spu_get_int_mask";

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -195,7 +195,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	BIND_FUNC(sys_time_get_current_time),                   //145 (0x091)
 	null_func,//BIND_FUNC(sys_time_get_system_time),        //146 (0x092)  ROOT
 	BIND_FUNC(sys_time_get_timebase_frequency),             //147 (0x093)
-	null_func,//BIND_FUNC(_sys_rwlock_trywlock)             //148 (0x094)
+	BIND_FUNC(sys_rwlock_trywlock),                         //148 (0x094)
 	null_func,                                              //149 (0x095)  UNS
 	BIND_FUNC(sys_raw_spu_create_interrupt_tag),            //150 (0x096)
 	BIND_FUNC(sys_raw_spu_set_int_mask),                    //151 (0x097)


### PR DESCRIPTION
Please let me know if
- You notice audio regressions or improvements while running games which use functions `cellSysutilEnableBgmPlaybackEx`, `cellSysutilDisableBgmPlaybackEx` or `cellSysutilSetBgmPlaybackExtraParam`
- You see any changes when running games which use write lock (`sys_rwlock_trywlock`, `sys_rwlock_wlock`)