### PR TITLE
rsx: Improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -125,8 +125,13 @@ namespace
 		u32 min_block_size = std::min(src_stride, dst_stride);
 		if (min_block_size == 0) min_block_size = dst_stride;
 
-		const u32 remainder = is_128_aligned? 0:  (16 - min_block_size) / min_block_size;
-		const u32 iterations = is_128_aligned? vertex_count: vertex_count - remainder;
+		u32 iterations = 0;
+		u32 remainder = is_128_aligned ? 0 : 1 + ((16 - min_block_size) / min_block_size);
+
+		if (vertex_count > remainder)
+			iterations = vertex_count - remainder;
+		else
+			remainder = vertex_count;
 
 		for (u32 i = 0; i < iterations; ++i)
 		{
@@ -168,8 +173,13 @@ namespace
 		u32 min_block_size = std::min(src_stride, dst_stride);
 		if (min_block_size == 0) min_block_size = dst_stride;
 
-		const u32 remainder = is_128_aligned ? 0 : (16 - min_block_size) / min_block_size;
-		const u32 iterations = is_128_aligned ? vertex_count : vertex_count - remainder;
+		u32 iterations = 0;
+		u32 remainder = is_128_aligned ? 0 : 1 + ((16 - min_block_size) / min_block_size);
+
+		if (vertex_count > remainder)
+			iterations = vertex_count - remainder;
+		else
+			remainder = vertex_count;
 
 		for (u32 i = 0; i < iterations; ++i)
 		{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -838,9 +838,14 @@ bool GLGSRender::do_method(u32 cmd, u32 arg)
 	{
 	case NV4097_CLEAR_SURFACE:
 	{
-		init_buffers(true);
-		synchronize_buffers();
-		clear_surface(arg);
+		if (arg & 0xF3)
+		{
+			//Only do all this if we have actual work to do
+			init_buffers(true);
+			synchronize_buffers();
+			clear_surface(arg);
+		}
+
 		return true;
 	}
 	case NV4097_TEXTURE_READ_SEMAPHORE_RELEASE:

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -169,6 +169,7 @@ void GLGSRender::init_buffers(bool skip_reading)
 	{
 		LOG_ERROR(RSX, "Invalid framebuffer setup, w=%d, h=%d", clip_horizontal, clip_vertical);
 		framebuffer_status_valid = false;
+		return;
 	}
 
 	const auto pitchs = get_pitchs();

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -537,15 +537,18 @@ namespace rsx
 			m_vblank_thread.reset();
 		}
 
-		if (m_vertex_streaming_task.processing_threads.size() > 0)
+		if (m_vertex_streaming_task.available_threads > 0)
 		{
-			for (auto &thr : m_vertex_streaming_task.processing_threads)
+			for (auto &task : m_vertex_streaming_task.worker_threads)
 			{
-				thr->join();
-				thr.reset();
+				if (!task.worker_thread)
+					break;
+
+				task.worker_thread->join();
+				task.worker_thread.reset();
 			}
 
-			m_vertex_streaming_task.processing_threads.resize(0);
+			m_vertex_streaming_task.available_threads = 0;
 		}
 	}
 
@@ -1131,7 +1134,8 @@ namespace rsx
 		}
 	}
 
-	void thread::post_vertex_stream_to_upload(gsl::span<const gsl::byte> src, gsl::span<gsl::byte> dst, rsx::vertex_base_type type, u32 vector_element_count, u32 attribute_src_stride, u8 dst_stride, std::function<void(void *, rsx::vertex_base_type, u8, u32)> callback)
+	void thread::post_vertex_stream_to_upload(gsl::span<const gsl::byte> src, gsl::span<gsl::byte> dst, rsx::vertex_base_type type, u32 vector_element_count,
+			u32 attribute_src_stride, u8 dst_stride, u32 vertex_count, std::function<void(void *, rsx::vertex_base_type, u8, u32)> callback)
 	{
 		upload_stream_packet packet;
 		packet.dst_span = dst;
@@ -1141,92 +1145,95 @@ namespace rsx
 		packet.dst_stride = dst_stride;
 		packet.vector_width = vector_element_count;
 		packet.post_upload_func = callback;
+		packet.vertex_count = vertex_count;
 
-		m_vertex_streaming_task.packets.push_back(packet);
-	}
-
-	void thread::start_vertex_upload_task(u32 vertex_count)
-	{
-		if (m_vertex_streaming_task.processing_threads.size() == 0)
+		if (m_vertex_streaming_task.available_threads == 0)
 		{
 			const u32 streaming_thread_count = (u32)g_cfg.video.vertex_upload_threads;
-			m_vertex_streaming_task.processing_threads.resize(streaming_thread_count);
+			m_vertex_streaming_task.available_threads = streaming_thread_count;
 
 			for (u32 n = 0; n < streaming_thread_count; ++n)
 			{
-				thread_ctrl::spawn(m_vertex_streaming_task.processing_threads[n], "Vertex Stream " + std::to_string(n), [this, n]()
+				thread_ctrl::spawn(m_vertex_streaming_task.worker_threads[n].worker_thread, "Vertex Stream " + std::to_string(n), [this, n]()
 				{
-					auto &task = m_vertex_streaming_task;
+					auto &owner = m_vertex_streaming_task;
+					auto &task = m_vertex_streaming_task.worker_threads[n];
 					const u32 index = n;
 
 					while (!Emu.IsStopped())
 					{
-						if (task.remaining_packets != 0)
+						if (task.thread_status.load(std::memory_order_consume) != 0)
 						{
-							//Wait for me!
-							task.ready_threads--;
-
-							const size_t step = task.processing_threads.size();
-							const size_t job_count = task.packets.size();
-							//Process every nth packet
-
-							size_t current_job = index;
-
-							while (true)
+							for (auto &packet: task.packets)
 							{
-								if (current_job >= job_count)
-									break;
-
-								auto &packet = task.packets[current_job];
-
-								write_vertex_array_data_to_buffer(packet.dst_span, packet.src_span, task.vertex_count, packet.type, packet.vector_width, packet.src_stride, packet.dst_stride);
+								write_vertex_array_data_to_buffer(packet.dst_span, packet.src_span, packet.vertex_count, packet.type, packet.vector_width, packet.src_stride, packet.dst_stride);
 
 								if (packet.post_upload_func)
-									packet.post_upload_func(packet.dst_span.data(), packet.type, (u8)packet.vector_width, task.vertex_count);
+									packet.post_upload_func(packet.dst_span.data(), packet.type, (u8)packet.vector_width, packet.vertex_count);
 
-								task.remaining_packets--;
-								current_job += step;
-								_mm_sfence();
+								owner.remaining_tasks--;
 							}
 
-							_mm_mfence();
-
-							while (task.remaining_packets > 0 && !Emu.IsStopped())
-							{
-								std::this_thread::yield();
-								_mm_lfence();
-							}
-							
-							task.ready_threads++;
+							task.packets.resize(0);
+							task.thread_status.store(0);
 							_mm_sfence();
 						}
-						else
-						{
-							std::this_thread::yield();
-						}
+
+						std::this_thread::yield();
 					}
 				});
 			}
 		}
 
-		while (m_vertex_streaming_task.ready_threads != 0 && !Emu.IsStopped())
+		//Increment job counter..
+		m_vertex_streaming_task.remaining_tasks++;
+
+		//Assign this packet to a thread
+		//Simple round robin based on first available thread
+		upload_stream_worker *best_fit = nullptr;
+		for (auto &worker : m_vertex_streaming_task.worker_threads)
 		{
-			_mm_pause();
+			if (!worker.worker_thread)
+				break;
+
+			if (worker.thread_status.load(std::memory_order_consume) == 0)
+			{
+				if (worker.packets.size() == 0)
+				{
+					worker.packets.push_back(packet);
+					return;
+				}
+
+				if (best_fit == nullptr)
+					best_fit = &worker;
+				else if (best_fit->packets.size() > worker.packets.size())
+					best_fit = &worker;
+			}
 		}
 
-		m_vertex_streaming_task.vertex_count = vertex_count;
-		m_vertex_streaming_task.ready_threads = 0;
-		m_vertex_streaming_task.remaining_packets = (int)m_vertex_streaming_task.packets.size();
+		best_fit->packets.push_back(packet);
+	}
+
+	void thread::start_vertex_upload_task()
+	{
+		for (auto &worker : m_vertex_streaming_task.worker_threads)
+		{
+			if (!worker.worker_thread)
+				break;
+
+			if (worker.thread_status.load(std::memory_order_consume) == 0 && worker.packets.size() > 0)
+			{
+				worker.thread_status.store(1);
+			}
+		}
 	}
 
 	void thread::wait_for_vertex_upload_task()
 	{
-		while (m_vertex_streaming_task.remaining_packets > 0 && !Emu.IsStopped())
+		while (m_vertex_streaming_task.remaining_tasks.load(std::memory_order_consume) != 0 && !Emu.IsStopped())
 		{
 			_mm_pause();
 		}
-
-		m_vertex_streaming_task.packets.resize(0);
 	}
 
 	bool thread::vertex_upload_task_ready()
@@ -1234,7 +1241,12 @@ namespace rsx
 		if (g_cfg.video.vertex_upload_threads < 2)
 			return false;
 
-		return (m_vertex_streaming_task.remaining_packets == 0 && m_vertex_streaming_task.ready_threads == 0);
+		//Not initialized
+		if (m_vertex_streaming_task.available_threads == 0)
+			return true;
+
+		//At least two threads are available
+		return (m_vertex_streaming_task.remaining_tasks < (m_vertex_streaming_task.available_threads - 1));
 	}
 
 	void thread::flip(int buffer)

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -244,25 +244,30 @@ namespace rsx
 			gsl::span<gsl::byte> dst_span;
 			rsx::vertex_base_type type;
 			u32 vector_width;
+			u32 vertex_count;
 			u32 src_stride;
 			u8 dst_stride;
 		};
 
+		struct upload_stream_worker
+		{
+			std::shared_ptr<thread_ctrl> worker_thread;
+			std::vector<upload_stream_packet> packets;
+			std::atomic<int> thread_status = { 0 };
+		};
+
 		struct upload_stream_task
 		{
-			std::vector<upload_stream_packet> packets;
-			std::atomic<int> remaining_packets = { 0 };
-			std::atomic<int> ready_threads = { 0 };
-			std::atomic<u32> vertex_count;
-
-			std::vector<std::shared_ptr<thread_ctrl>> processing_threads;
+			std::array<upload_stream_worker, 16> worker_threads;
+			int available_threads = 0;
+			std::atomic<int> remaining_tasks = {0};
 		};
 
 		upload_stream_task m_vertex_streaming_task;
 		void post_vertex_stream_to_upload(gsl::span<const gsl::byte> src, gsl::span<gsl::byte> dst, rsx::vertex_base_type type,
-				u32 vector_element_count, u32 attribute_src_stride, u8 dst_stride,
+				u32 vector_element_count, u32 attribute_src_stride, u8 dst_stride, u32 vertex_count,
 			std::function<void(void *, rsx::vertex_base_type, u8, u32)> callback);
-		void start_vertex_upload_task(u32 vertex_count);
+		void start_vertex_upload_task();
 		void wait_for_vertex_upload_task();
 		bool vertex_upload_task_ready();
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -809,6 +809,7 @@ void VKGSRender::begin()
 		std::chrono::time_point<steady_clock> submit_start = steady_clock::now();
 
 		flush_command_queue(true);
+		m_vertex_cache.purge();
 
 		CHECK_RESULT(vkResetDescriptorPool(*m_device, descriptor_pool, 0));
 		m_last_descriptor_set = VK_NULL_HANDLE;
@@ -1533,6 +1534,8 @@ void VKGSRender::process_swap_request()
 	{
 		m_text_writer->reset_descriptors();
 	}
+
+	m_vertex_cache.purge();
 
 	m_swap_command_buffer = nullptr;
 }

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -251,9 +251,11 @@ namespace
 	{
 		vertex_buffer_visitor(u32 vtx_cnt, VkDevice dev, vk::vk_data_heap& heap,
 			vk::glsl::program* prog, VkDescriptorSet desc_set,
-			std::vector<std::unique_ptr<vk::buffer_view>>& buffer_view_to_clean)
+			std::vector<std::unique_ptr<vk::buffer_view>>& buffer_view_to_clean,
+			weak_vertex_cache& vertex_cache)
 			: vertex_count(vtx_cnt), m_attrib_ring_info(heap), device(dev), m_program(prog),
-			  descriptor_sets(desc_set), m_buffer_view_to_clean(buffer_view_to_clean)
+			  descriptor_sets(desc_set), m_buffer_view_to_clean(buffer_view_to_clean),
+			  vertex_cache(&vertex_cache)
 		{
 		}
 
@@ -280,6 +282,9 @@ namespace
 
 			m_attrib_ring_info.unmap();
 			const VkFormat format = vk::get_suitable_vk_format(vertex_array.type, vertex_array.attribute_size);
+
+			const uintptr_t local_addr = (uintptr_t)vertex_array.data.data();
+			vertex_cache->store_range(local_addr, format, upload_size, (u32)offset_in_attrib_buffer);
 
 			m_buffer_view_to_clean.push_back(std::make_unique<vk::buffer_view>(device, m_attrib_ring_info.heap->value, format, offset_in_attrib_buffer, upload_size));
 			m_program->bind_uniform(m_buffer_view_to_clean.back()->value, s_reg_table[vertex_array.index], descriptor_sets);
@@ -336,6 +341,7 @@ namespace
 		vk::glsl::program* m_program;
 		VkDescriptorSet descriptor_sets;
 		std::vector<std::unique_ptr<vk::buffer_view>>& m_buffer_view_to_clean;
+		weak_vertex_cache* vertex_cache;
 	};
 
 	using attribute_storage = std::vector<std::variant<rsx::vertex_array_buffer,
@@ -464,7 +470,7 @@ namespace
 			const u32 vertex_count = vertex_max_index - min_index + 1;
 
 			vertex_buffer_visitor visitor(vertex_count, m_device,
-				m_attrib_ring_info, m_program, m_descriptor_sets, m_buffer_view_to_clean);
+				m_attrib_ring_info, m_program, m_descriptor_sets, m_buffer_view_to_clean, rsxthr->m_vertex_cache);
 
 			const auto& vertex_buffers = get_vertex_buffers(
 				rsx::method_registers, {{min_index, vertex_max_index - min_index + 1}});
@@ -483,26 +489,38 @@ namespace
 				const auto &vbo = vertex_buffers[i];
 				bool can_multithread = false;
 
-				if (vbo.which() == 0 && vertex_count >= (u32)g_cfg.video.mt_vertex_upload_threshold && rsxthr->vertex_upload_task_ready())
+				if (vbo.which() == 0)
 				{
 					//vertex array buffer. We can thread this thing heavily
 					const auto& v = vbo.get<rsx::vertex_array_buffer>();
+
+					const u32 element_size = rsx::get_vertex_type_size_on_host(v.type, v.attribute_size);
+					const u32 real_element_size = vk::get_suitable_vk_size(v.type, v.attribute_size);
+					const u32 upload_size = real_element_size * vertex_count;
+					const VkFormat format = vk::get_suitable_vk_format(v.type, v.attribute_size);
+					const uintptr_t local_addr = (uintptr_t)v.data.data();
+
+					const auto cached = rsxthr->m_vertex_cache.find_vertex_range(local_addr, format, upload_size);
+					if (cached)
+					{
+						m_buffer_view_to_clean.push_back(std::make_unique<vk::buffer_view>(m_device, m_attrib_ring_info.heap->value, format, cached->offset_in_heap, upload_size));
+						m_program->bind_uniform(m_buffer_view_to_clean.back()->value, s_reg_table[v.index], m_descriptor_sets);
+
+						continue;
+					}
 					
-					if (v.attribute_size > 1)
+					if (v.attribute_size > 1 && vertex_count >= (u32)g_cfg.video.mt_vertex_upload_threshold && rsxthr->vertex_upload_task_ready())
 					{
 						can_multithread = true;
 					
-						u32 element_size = rsx::get_vertex_type_size_on_host(v.type, v.attribute_size);
-						u32 real_element_size = vk::get_suitable_vk_size(v.type, v.attribute_size);
-
-						u32 upload_size = real_element_size * vertex_count;
 						size_t offset = m_attrib_ring_info.alloc<256>(upload_size);
 
 						memory_allocations.push_back(offset);
 						allocated_sizes.push_back(upload_size);
 						upload_jobs.push_back(i);
 
-						const VkFormat format = vk::get_suitable_vk_format(v.type, v.attribute_size);
+						const uintptr_t local_addr = (uintptr_t)v.data.data();
+						rsxthr->m_vertex_cache.store_range(local_addr, format, upload_size, (u32)offset);
 
 						m_buffer_view_to_clean.push_back(std::make_unique<vk::buffer_view>(m_device, m_attrib_ring_info.heap->value, format, offset, upload_size));
 						m_program->bind_uniform(m_buffer_view_to_clean.back()->value, s_reg_table[v.index], m_descriptor_sets);

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -561,13 +561,13 @@ namespace
 								const u32 real_element_size = vk::get_suitable_vk_size(vertex_array.type, vertex_array.attribute_size);
 								
 								gsl::span<gsl::byte> dest_span(dst + (memory_allocations[n] - offset_base), allocated_sizes[n]);
-								rsxthr->post_vertex_stream_to_upload(vertex_array.data, dest_span, vertex_array.type, vertex_array.attribute_size, vertex_array.stride, real_element_size, vk::prepare_buffer_for_writing);
+								rsxthr->post_vertex_stream_to_upload(vertex_array.data, dest_span, vertex_array.type, vertex_array.attribute_size, vertex_array.stride, real_element_size, vertex_count, vk::prepare_buffer_for_writing);
 
 								space_remaining -= allocated_sizes[n];
 								n++;
 							}
 
-							rsxthr->start_vertex_upload_task(vertex_count);
+							rsxthr->start_vertex_upload_task();
 						}
 					}
 				}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -325,7 +325,7 @@ struct cfg_root : cfg::node
 
 		cfg::_bool batch_instanced_geometry{this, "Batch Instanced Geometry", false}; //Avoid re-uploading geometry if the same draw command is repeated
 		cfg::_int<1, 16> vertex_upload_threads{ this, "Vertex Upload Threads", 1 }; //Max number of threads to use for parallel vertex processing
-		cfg::_int<32, 65536> mt_vertex_upload_threshold{ this, "Multithreaded Vertex Upload Threshold", 4096}; //Minimum vertex count to parallelize
+		cfg::_int<32, 65536> mt_vertex_upload_threshold{ this, "Multithreaded Vertex Upload Threshold", 512}; //Minimum vertex count to parallelize
 
 		cfg::_bool frame_skip_enabled{this, "Enable Frame Skip"};
 		cfg::_int<1, 8> consequtive_frames_to_draw{this, "Consecutive Frames Drawn", 1};


### PR DESCRIPTION
Minor tweaks for performance and improved stability

- Fix buffer overrun crash (LBP Karting, Ridge Racer 7)
- Fix opengl bug when initializing framebuffers (Removes the 'fbo check failed' spam)
- Vulkan: improvements to multithreaded vertex processing
- Vulkan: volatile vertex cache implemented to help performance in geometry heavy scenes
- Vulkan: pre-emptive framebuffer flushing to lower the penalty of a cache miss