### PR TITLE
Vulkan : Fix for Dead Space 1/2

### DIFF
--- a/rpcs3/Emu/RSX/Common/ring_buffer_helper.h
+++ b/rpcs3/Emu/RSX/Common/ring_buffer_helper.h
@@ -54,7 +54,7 @@ public:
 
 	size_t m_get_pos; // End of free space
 
-	void init(size_t heap_size, size_t min_guard_size=0x10000)
+	void init(size_t heap_size, size_t min_guard_size=0x200000)
 	{
 		m_size = heap_size;
 		m_put_pos = 0;


### PR DESCRIPTION
@kd-11 

*Before
```
F {rsx::thread} class std::runtime_error thrown: Working buffer not big enough, buffer_length=268435456 allocated=268121088 requested=402152 guard=65536 largest_pool=804864
(in file c:\rpcs3\rpcs3\emu\rsx\d3d12\../Common/ring_buffer_helper.h:74)
```

*Now
![bez tytulu](https://user-images.githubusercontent.com/13681488/28538362-53c65934-70ae-11e7-8e69-ae697a552674.png)