### PR TITLE
Fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -26,6 +26,11 @@ GLGSRender::GLGSRender() : GSRender()
 {
 	//TODO
 	//shaders_cache.load(rsx::old_shaders_cache::shader_language::glsl);
+
+	if (g_cfg.video.disable_vertex_cache)
+		m_vertex_cache.reset(new gl::null_vertex_cache());
+	else
+		m_vertex_cache.reset(new gl::weak_vertex_cache());
 }
 
 u32 GLGSRender::enable(u32 condition, u32 cap)
@@ -1090,6 +1095,8 @@ void GLGSRender::flip(int buffer)
 
 	if (g_cfg.video.invalidate_surface_cache_every_frame)
 		m_rtts.invalidate_surface_cache_data(nullptr);
+
+	m_vertex_cache->purge();
 
 	//If we are skipping the next frame, fo not reset perf counters
 	if (skip_frame) return;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -14,6 +14,13 @@
 
 #pragma comment(lib, "opengl32.lib")
 
+namespace gl
+{
+	using vertex_cache = rsx::vertex_cache::default_vertex_cache<rsx::vertex_cache::uploaded_range<GLenum>, GLenum>;
+	using weak_vertex_cache = rsx::vertex_cache::weak_vertex_cache<GLenum>;
+	using null_vertex_cache = vertex_cache;
+}
+
 struct work_item
 {
 	std::condition_variable cv;
@@ -57,8 +64,7 @@ private:
 	s64 m_vertex_upload_time = 0;
 	s64 m_textures_upload_time = 0;
 
-	//Compare to see if transform matrix have changed
-	size_t m_transform_buffer_hash = 0;
+	std::unique_ptr<gl::vertex_cache> m_vertex_cache;
 
 	GLint m_min_texbuffer_alignment = 256;
 	GLint m_uniform_buffer_offset_align = 256;

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -198,12 +198,13 @@ namespace
 
 	struct vertex_buffer_visitor
 	{
-		vertex_buffer_visitor(u32 vtx_cnt, gl::ring_buffer& heap, gl::glsl::program* prog, gl::texture* attrib_buffer, u32 min_texbuffer_offset)
+		vertex_buffer_visitor(u32 vtx_cnt, gl::ring_buffer& heap, gl::glsl::program* prog, gl::texture* attrib_buffer, u32 min_texbuffer_offset, gl::vertex_cache* vertex_cache)
 		    : vertex_count(vtx_cnt)
 		    , m_attrib_ring_info(heap)
 		    , m_program(prog)
 		    , m_gl_attrib_buffers(attrib_buffer)
 		    , m_min_texbuffer_alignment(min_texbuffer_offset)
+			, m_vertex_cache(vertex_cache)
 		{
 		}
 
@@ -213,21 +214,30 @@ namespace
 			if (!m_program->uniforms.has_location(s_reg_table[vertex_array.index], &location))
 				return;
 
-			// Fill vertex_array
-			u32 element_size = rsx::get_vertex_type_size_on_host(vertex_array.type, vertex_array.attribute_size);
-
-			u32 data_size = vertex_count * element_size;
-			u32 gl_type   = to_gl_internal_type(vertex_array.type, vertex_array.attribute_size);
+			GLenum gl_type = to_gl_internal_type(vertex_array.type, vertex_array.attribute_size);
 			auto& texture = m_gl_attrib_buffers[vertex_array.index];
+			const u32 element_size = rsx::get_vertex_type_size_on_host(vertex_array.type, vertex_array.attribute_size);
+			const u32 data_size = vertex_count * element_size;
 
+			const uintptr_t local_addr = (uintptr_t)vertex_array.data.data();
 			u32 buffer_offset = 0;
-			auto mapping      = m_attrib_ring_info.alloc_from_heap(data_size, m_min_texbuffer_alignment);
-			gsl::byte* dst    = static_cast<gsl::byte*>(mapping.first);
-			buffer_offset     = mapping.second;
-			gsl::span<gsl::byte> dest_span(dst, data_size);
 
-			write_vertex_array_data_to_buffer(dest_span, vertex_array.data, vertex_count, vertex_array.type, vertex_array.attribute_size, vertex_array.stride, rsx::get_vertex_type_size_on_host(vertex_array.type, vertex_array.attribute_size));
-			prepare_buffer_for_writing(dst, vertex_array.type, vertex_array.attribute_size, vertex_count);
+			if (auto uploaded = m_vertex_cache->find_vertex_range(local_addr, gl_type, data_size))
+			{
+				buffer_offset = uploaded->offset_in_heap;
+			}
+			else
+			{
+				// Fill vertex_array
+				auto mapping = m_attrib_ring_info.alloc_from_heap(data_size, m_min_texbuffer_alignment);
+				gsl::byte* dst = static_cast<gsl::byte*>(mapping.first);
+				buffer_offset = mapping.second;
+				gsl::span<gsl::byte> dest_span(dst, data_size);
+
+				m_vertex_cache->store_range(local_addr, gl_type, data_size, buffer_offset);
+				write_vertex_array_data_to_buffer(dest_span, vertex_array.data, vertex_count, vertex_array.type, vertex_array.attribute_size, vertex_array.stride, rsx::get_vertex_type_size_on_host(vertex_array.type, vertex_array.attribute_size));
+				prepare_buffer_for_writing(dst, vertex_array.type, vertex_array.attribute_size, vertex_count);
+			}
 
 			texture.copy_from(m_attrib_ring_info, gl_type, buffer_offset, data_size);
 		}
@@ -263,6 +273,7 @@ namespace
 		gl::glsl::program* m_program;
 		gl::texture* m_gl_attrib_buffers;
 		GLint m_min_texbuffer_alignment;
+		gl::vertex_cache* m_vertex_cache;
 	};
 
 	struct draw_command_visitor
@@ -272,6 +283,7 @@ namespace
 
 		draw_command_visitor(gl::ring_buffer& index_ring_buffer, gl::ring_buffer& attrib_ring_buffer,
 		    gl::texture* gl_attrib_buffers, gl::glsl::program* program, GLint min_texbuffer_alignment,
+			gl::vertex_cache* vertex_cache,
 		    std::function<attribute_storage(rsx::rsx_state, std::vector<std::pair<u32, u32>>)> gvb)
 		    : m_index_ring_buffer(index_ring_buffer)
 		    , m_attrib_ring_buffer(attrib_ring_buffer)
@@ -279,6 +291,7 @@ namespace
 		    , m_program(program)
 		    , m_min_texbuffer_alignment(min_texbuffer_alignment)
 		    , get_vertex_buffers(gvb)
+			, m_vertex_cache(vertex_cache)
 		{
 			for (u8 index = 0; index < rsx::limits::vertex_count; ++index) {
 				if (rsx::method_registers.vertex_arrays_info[index].size() ||
@@ -368,7 +381,7 @@ namespace
 		gl::ring_buffer& m_index_ring_buffer;
 		gl::ring_buffer& m_attrib_ring_buffer;
 		gl::texture* m_gl_attrib_buffers;
-
+		gl::vertex_cache* m_vertex_cache;
 		gl::glsl::program* m_program;
 		GLint m_min_texbuffer_alignment;
 		std::function<attribute_storage(rsx::rsx_state, std::vector<std::pair<u32, u32>>)>
@@ -379,7 +392,7 @@ namespace
 			u32 verts_allocated = max_index - min_index + 1;
 
 			vertex_buffer_visitor visitor(verts_allocated, m_attrib_ring_buffer,
-			    m_program, m_gl_attrib_buffers, m_min_texbuffer_alignment);
+			    m_program, m_gl_attrib_buffers, m_min_texbuffer_alignment, m_vertex_cache);
 			const auto& vertex_buffers =
 			    get_vertex_buffers(rsx::method_registers, {{min_index, verts_allocated}});
 			for (const auto& vbo : vertex_buffers) std::apply_visitor(visitor, vbo);
@@ -452,11 +465,12 @@ std::tuple<u32, std::optional<std::tuple<GLenum, u32>>> GLGSRender::set_vertex_b
 {
 	std::chrono::time_point<steady_clock> then = steady_clock::now();
 	auto result = std::apply_visitor(draw_command_visitor(*m_index_ring_buffer, *m_attrib_ring_buffer,
-	                              m_gl_attrib_buffers, m_program, m_min_texbuffer_alignment,
-	                              [this](const auto& state, const auto& list) {
-		                              return this->get_vertex_buffers(state, list, 0);
-		                             }),
-	    get_draw_command(rsx::method_registers));
+		m_gl_attrib_buffers, m_program, m_min_texbuffer_alignment,
+		m_vertex_cache.get(),
+		[this](const auto& state, const auto& list) {
+			return this->get_vertex_buffers(state, list, 0);
+		}),
+		get_draw_command(rsx::method_registers));
 
 	std::chrono::time_point<steady_clock> now = steady_clock::now();
 	m_vertex_upload_time += std::chrono::duration_cast<std::chrono::microseconds>(now - then).count();

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -406,6 +406,9 @@ namespace rsx
 			}
 		});
 
+		// Raise priority above other threads
+		thread_ctrl::set_native_priority(1);
+
 		// TODO: exit condition
 		while (!Emu.IsStopped())
 		{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2178,18 +2178,18 @@ void VKGSRender::flip(int buffer)
 		CHECK_RESULT(vkAcquireNextImageKHR((*m_device), (*m_swap_chain), 0, m_present_semaphore, VK_NULL_HANDLE, &m_current_present_image));
 
 		//Blit contents to screen..
-		VkImage image_to_flip = nullptr;
+		vk::image* image_to_flip = nullptr;
 
 		if (std::get<1>(m_rtts.m_bound_render_targets[0]) != nullptr)
-			image_to_flip = std::get<1>(m_rtts.m_bound_render_targets[0])->value;
+			image_to_flip = std::get<1>(m_rtts.m_bound_render_targets[0]);
 		else if (std::get<1>(m_rtts.m_bound_render_targets[1]) != nullptr)
-			image_to_flip = std::get<1>(m_rtts.m_bound_render_targets[1])->value;
+			image_to_flip = std::get<1>(m_rtts.m_bound_render_targets[1]);
 
 		VkImage target_image = m_swap_chain->get_swap_chain_image(m_current_present_image);
 		if (image_to_flip)
 		{
-			vk::copy_scaled_image(*m_current_command_buffer, image_to_flip, target_image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-				0, 0, buffer_width, buffer_height, aspect_ratio.x, aspect_ratio.y, aspect_ratio.width, aspect_ratio.height, 1, VK_IMAGE_ASPECT_COLOR_BIT);
+			vk::copy_scaled_image(*m_current_command_buffer, image_to_flip->value, target_image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+				0, 0, image_to_flip->width(), image_to_flip->height(), aspect_ratio.x, aspect_ratio.y, aspect_ratio.width, aspect_ratio.height, 1, VK_IMAGE_ASPECT_COLOR_BIT);
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -628,9 +628,9 @@ VKGSRender::VKGSRender() : GSRender()
 	}
 
 	if (g_cfg.video.disable_vertex_cache)
-		m_vertex_cache.reset(new null_vertex_cache());
+		m_vertex_cache.reset(new vk::null_vertex_cache());
 	else
-		m_vertex_cache.reset(new vk::vertex_cache::weak_vertex_cache());
+		m_vertex_cache.reset(new vk::weak_vertex_cache());
 }
 
 VKGSRender::~VKGSRender()
@@ -1269,8 +1269,6 @@ void VKGSRender::on_init_thread()
 
 	GSRender::on_init_thread();
 	rsx_thread = std::this_thread::get_id();
-
-	thread_ctrl::set_native_priority(1);
 }
 
 void VKGSRender::on_exit()

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -16,8 +16,12 @@
 
 #pragma comment(lib, "VKstatic.1.lib")
 
-using namespace vk::vertex_cache;
-using null_vertex_cache = rsx::vertex_cache<uploaded_range, VkFormat>;
+namespace vk
+{
+	using vertex_cache = rsx::vertex_cache::default_vertex_cache<rsx::vertex_cache::uploaded_range<VkFormat>, VkFormat>;
+	using weak_vertex_cache = rsx::vertex_cache::weak_vertex_cache<VkFormat>;
+	using null_vertex_cache = vertex_cache;
+}
 
 //Heap allocation sizes in MB
 #define VK_ATTRIB_RING_BUFFER_SIZE_M 256
@@ -117,7 +121,7 @@ private:
 
 public:
 	//vk::fbo draw_fbo;
-	std::unique_ptr<null_vertex_cache> m_vertex_cache;
+	std::unique_ptr<vk::vertex_cache> m_vertex_cache;
 
 private:
 	VKProgramBuffer m_prog_buffer;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1457,54 +1457,6 @@ namespace vk
 		}
 	};
 
-	namespace vertex_cache
-	{
-		struct uploaded_range
-		{
-			uintptr_t local_address;
-			VkFormat buffer_format;
-			u32 offset_in_heap;
-			u32 data_length;
-		};
-
-		// A weak vertex cache with no data checks or memory range locks
-		// Of limited use since contents are only guaranteed to be valid once per frame
-		// TODO: Strict vertex cache with range locks
-		class weak_vertex_cache: public rsx::vertex_cache<uploaded_range, VkFormat>
-		{
-		private:
-			std::unordered_map<uintptr_t, std::vector<uploaded_range>> vertex_ranges;
-		public:
-
-			uploaded_range* find_vertex_range(uintptr_t local_addr, VkFormat fmt, u32 data_length) override
-			{
-				for (auto &v : vertex_ranges[local_addr])
-				{
-					if (v.buffer_format == fmt && v.data_length == data_length)
-						return &v;
-				}
-
-				return nullptr;
-			}
-
-			void store_range(uintptr_t local_addr, VkFormat fmt, u32 data_length, u32 offset_in_heap) override
-			{
-				uploaded_range v = {};
-				v.buffer_format = fmt;
-				v.data_length = data_length;
-				v.local_address = local_addr;
-				v.offset_in_heap = offset_in_heap;
-
-				vertex_ranges[local_addr].push_back(v);
-			}
-
-			void purge() override
-			{
-				vertex_ranges.clear();
-			}
-		};
-	}
-
 	/**
 	* Allocate enough space in upload_buffer and write all mipmap/layer data into the subbuffer.
 	* Then copy all layers into dst_image.

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -17,6 +17,7 @@
 #include "../GCM.h"
 #include "../Common/TextureUtils.h"
 #include "../Common/ring_buffer_helper.h"
+#include "../rsx_cache.h"
 
 #define DESCRIPTOR_MAX_DRAW_CALLS 4096
 
@@ -1455,6 +1456,54 @@ namespace vk
 			heap->unmap();
 		}
 	};
+
+	namespace vertex_cache
+	{
+		struct uploaded_range
+		{
+			uintptr_t local_address;
+			VkFormat buffer_format;
+			u32 offset_in_heap;
+			u32 data_length;
+		};
+
+		// A weak vertex cache with no data checks or memory range locks
+		// Of limited use since contents are only guaranteed to be valid once per frame
+		// TODO: Strict vertex cache with range locks
+		class weak_vertex_cache: public rsx::vertex_cache<uploaded_range, VkFormat>
+		{
+		private:
+			std::unordered_map<uintptr_t, std::vector<uploaded_range>> vertex_ranges;
+		public:
+
+			uploaded_range* find_vertex_range(uintptr_t local_addr, VkFormat fmt, u32 data_length) override
+			{
+				for (auto &v : vertex_ranges[local_addr])
+				{
+					if (v.buffer_format == fmt && v.data_length == data_length)
+						return &v;
+				}
+
+				return nullptr;
+			}
+
+			void store_range(uintptr_t local_addr, VkFormat fmt, u32 data_length, u32 offset_in_heap) override
+			{
+				uploaded_range v = {};
+				v.buffer_format = fmt;
+				v.data_length = data_length;
+				v.local_address = local_addr;
+				v.offset_in_heap = offset_in_heap;
+
+				vertex_ranges[local_addr].push_back(v);
+			}
+
+			void purge() override
+			{
+				vertex_ranges.clear();
+			}
+		};
+	}
 
 	/**
 	* Allocate enough space in upload_buffer and write all mipmap/layer data into the subbuffer.

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -191,7 +191,7 @@ namespace rsx
 			change_image_layout(*pcmd, surface, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, range);
 		}
 
-		static void invalidate_rtt_surface_contents(vk::command_buffer* pcmd, vk::render_target *rtt, vk::render_target *old_surface, bool forced)
+		static void invalidate_rtt_surface_contents(vk::command_buffer* /*pcmd*/, vk::render_target *rtt, vk::render_target *old_surface, bool forced)
 		{
 			if (forced)
 			{

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -5,6 +5,7 @@
 #include "Emu/System.h"
 #include "../Common/TextureUtils.h"
 #include "../rsx_utils.h"
+#include "Utilities/mutex.h"
 
 namespace vk
 {
@@ -292,9 +293,34 @@ namespace vk
 
 	class texture_cache
 	{
+		struct ranged_storage
+		{
+			std::vector<cached_texture_section> data;  //Stored data
+			std::atomic_int valid_count = { 0 };  //Number of usable (non-dirty) blocks
+			u32 max_range = 0;  //Largest stored block
+
+			void notify(u32 data_size)
+			{
+				max_range = std::max(data_size, max_range);
+				valid_count++;
+			}
+
+			void add(cached_texture_section& section, u32 data_size)
+			{
+				max_range = std::max(data_size, max_range);
+				valid_count++;
+
+				data.push_back(std::move(section));
+			}
+		};
+
 	private:
-		std::vector<cached_texture_section> m_cache;
-		std::pair<u32, u32> texture_cache_range = std::make_pair(0xFFFFFFFF, 0);
+		shared_mutex m_cache_mutex;
+		std::unordered_map<u32, ranged_storage> m_cache;
+
+		std::pair<u32, u32> read_only_range = std::make_pair(0xFFFFFFFF, 0);
+		std::pair<u32, u32> no_access_range = std::make_pair(0xFFFFFFFF, 0);
+		
 		std::vector<std::unique_ptr<vk::image_view> > m_temporary_image_view;
 		std::vector<std::unique_ptr<vk::image>> m_dirty_textures;
 
@@ -310,51 +336,71 @@ namespace vk
 
 		cached_texture_section& find_cached_texture(u32 rsx_address, u32 rsx_size, bool confirm_dimensions = false, u16 width = 0, u16 height = 0, u16 mipmaps = 0)
 		{
-			for (auto &tex : m_cache)
 			{
-				if (tex.matches(rsx_address, rsx_size) && !tex.is_dirty())
-				{
-					if (!confirm_dimensions) return tex;
+				reader_lock lock(m_cache_mutex);
 
-					if (tex.matches(rsx_address, width, height, mipmaps))
-						return tex;
-					else
+				auto found = m_cache.find(rsx_address);
+				if (found != m_cache.end())
+				{
+					auto &range_data = found->second;
+
+					for (auto &tex : range_data.data)
 					{
-						LOG_ERROR(RSX, "Cached object for address 0x%X was found, but it does not match stored parameters.", rsx_address);
-						LOG_ERROR(RSX, "%d x %d vs %d x %d", width, height, tex.get_width(), tex.get_height());
+						if (tex.matches(rsx_address, rsx_size) && !tex.is_dirty())
+						{
+							if (!confirm_dimensions) return tex;
+
+							if (tex.matches(rsx_address, width, height, mipmaps))
+								return tex;
+							else
+							{
+								LOG_ERROR(RSX, "Cached object for address 0x%X was found, but it does not match stored parameters.", rsx_address);
+								LOG_ERROR(RSX, "%d x %d vs %d x %d", width, height, tex.get_width(), tex.get_height());
+							}
+						}
+					}
+
+					for (auto &tex : range_data.data)
+					{
+						if (tex.is_dirty())
+						{
+							if (tex.exists())
+							{
+								m_dirty_textures.push_back(std::move(tex.get_texture()));
+								m_temporary_image_view.push_back(std::move(tex.get_view()));
+							}
+
+							tex.release_dma_resources();
+							range_data.notify(rsx_size);
+							return tex;
+						}
 					}
 				}
 			}
 
-			for (auto &tex : m_cache)
-			{
-				if (tex.is_dirty())
-				{
-					if (tex.exists())
-					{
-						m_dirty_textures.push_back(std::move(tex.get_texture()));
-						m_temporary_image_view.push_back(std::move(tex.get_view()));
-					}
+			writer_lock lock(m_cache_mutex);
 
-					tex.release_dma_resources();
-					return tex;
-				}
-			}
-
-			m_cache.push_back(cached_texture_section());
-
-			return m_cache[m_cache.size() - 1];
+			cached_texture_section tmp;
+			m_cache[rsx_address].add(tmp, rsx_size);
+			return m_cache[rsx_address].data.back();
 		}
 
 		cached_texture_section* find_flushable_section(const u32 address, const u32 range)
 		{
-			for (auto &tex : m_cache)
-			{
-				if (tex.is_dirty()) continue;
-				if (!tex.is_flushable() && !tex.is_flushed()) continue;
+			reader_lock lock(m_cache_mutex);
 
-				if (tex.matches(address, range))
-					return &tex;
+			auto found = m_cache.find(address);
+			if (found != m_cache.end())
+			{
+				auto &range_data = found->second;
+				for (auto &tex : range_data.data)
+				{
+					if (tex.is_dirty()) continue;
+					if (!tex.is_flushable() && !tex.is_flushed()) continue;
+
+					if (tex.matches(address, range))
+						return &tex;
+				}
 			}
 
 			return nullptr;
@@ -362,24 +408,28 @@ namespace vk
 
 		void purge_cache()
 		{
-			for (auto &tex : m_cache)
+			for (auto &address_range : m_cache)
 			{
-				if (tex.exists())
+				auto &range_data = address_range.second;
+				for (auto &tex : range_data.data)
 				{
-					m_dirty_textures.push_back(std::move(tex.get_texture()));
-					m_temporary_image_view.push_back(std::move(tex.get_view()));
+					if (tex.exists())
+					{
+						m_dirty_textures.push_back(std::move(tex.get_texture()));
+						m_temporary_image_view.push_back(std::move(tex.get_view()));
+					}
+
+					if (tex.is_locked())
+						tex.unprotect();
+
+					tex.release_dma_resources();
 				}
 
-				if (tex.is_locked())
-					tex.unprotect();
-
-				tex.release_dma_resources();
+				range_data.data.resize(0);
 			}
 
 			m_temporary_image_view.clear();
 			m_dirty_textures.clear();
-
-			m_cache.resize(0);
 		}
 
 		//Helpers
@@ -611,13 +661,14 @@ namespace vk
 			change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, subresource_range);
 
 			vk::leave_uninterruptible();
+			writer_lock lock(m_cache_mutex);
 
 			region.reset(texaddr, range);
 			region.create(tex.width(), height, depth, tex.get_exact_mipmap_count(), view, image);
 			region.protect(utils::protection::ro);
 			region.set_dirty(false);
 
-			texture_cache_range = region.get_min_max(texture_cache_range);
+			read_only_range = region.get_min_max(read_only_range);
 			return view;
 		}
 
@@ -625,11 +676,13 @@ namespace vk
 		{
 			cached_texture_section& region = find_cached_texture(memory_address, memory_size, true, width, height, 1);
 			
+			writer_lock lock(m_cache_mutex);
+
 			if (!region.is_locked())
 			{
 				region.reset(memory_address, memory_size);
 				region.set_dirty(false);
-				texture_cache_range = region.get_min_max(texture_cache_range);
+				no_access_range = region.get_min_max(no_access_range);
 			}
 
 			region.protect(utils::protection::no);
@@ -656,17 +709,48 @@ namespace vk
 
 		std::tuple<bool, bool> address_is_flushable(u32 address)
 		{
-			if (address < texture_cache_range.first ||
-				address > texture_cache_range.second)
+			if (address < no_access_range.first ||
+				address > no_access_range.second)
 				return std::make_tuple(false, false);
 
-			for (auto &tex : m_cache)
-			{
-				if (tex.is_dirty()) continue;
-				if (!tex.is_flushable()) continue;
+			reader_lock lock(m_cache_mutex);
 
-				if (tex.overlaps(address))
-					return std::make_tuple(true, tex.is_synchronized());
+			auto found = m_cache.find(address);
+			if (found != m_cache.end())
+			{
+				auto &range_data = found->second;
+				for (auto &tex : range_data.data)
+				{
+					if (tex.is_dirty()) continue;
+					if (!tex.is_flushable()) continue;
+
+					if (tex.overlaps(address))
+						return std::make_tuple(true, tex.is_synchronized());
+				}
+			}
+
+			for (auto &address_range : m_cache)
+			{
+				if (address_range.first == address)
+					continue;
+
+				auto &range_data = address_range.second;
+				
+				//Quickly discard range
+				const u32 lock_base = address_range.first & ~0xfff;
+				const u32 lock_limit = align(range_data.max_range + address_range.first, 4096);
+
+				if (address < lock_base || address >= lock_limit)
+					continue;
+
+				for (auto &tex : range_data.data)
+				{
+					if (tex.is_dirty()) continue;
+					if (!tex.is_flushable()) continue;
+
+					if (tex.overlaps(address))
+						return std::make_tuple(true, tex.is_synchronized());
+				}
 			}
 
 			return std::make_tuple(false, false);
@@ -674,42 +758,75 @@ namespace vk
 
 		bool flush_address(u32 address, vk::render_device& dev, vk::command_buffer& cmd, vk::memory_type_mapping& memory_types, VkQueue submit_queue)
 		{
-			if (address < texture_cache_range.first ||
-				address > texture_cache_range.second)
+			if (address < no_access_range.first ||
+				address > no_access_range.second)
 				return false;
 
 			bool response = false;
 			std::pair<u32, u32> trampled_range = std::make_pair(0xffffffff, 0x0);
+			std::unordered_map<u32, bool> processed_ranges;
 
-			for (int i = 0; i < m_cache.size(); ++i)
+			reader_lock lock(m_cache_mutex);
+
+			for (auto It = m_cache.begin(); It != m_cache.end(); It++)
 			{
-				auto &tex = m_cache[i];
+				auto &range_data = It->second;
+				const u32 base = It->first;
+				bool range_reset = false;
 
-				if (tex.is_dirty()) continue;
-				if (!tex.is_flushable()) continue;
+				if (processed_ranges[base] || range_data.valid_count == 0)
+					continue;
 
-				auto overlapped = tex.overlaps_page(trampled_range, address);
-				if (std::get<0>(overlapped))
+				//Quickly discard range
+				const u32 lock_base = base & ~0xfff;
+				const u32 lock_limit = align(range_data.max_range + base, 4096);
+				
+				if ((trampled_range.first >= lock_limit || lock_base >= trampled_range.second) &&
+					(lock_base > address || lock_limit <= address))
 				{
-					auto &new_range = std::get<1>(overlapped);
-
-					if (new_range.first != trampled_range.first ||
-						new_range.second != trampled_range.second)
-					{
-						trampled_range = new_range;
-						i = 0;
-					}
-
-					//TODO: Map basic host_visible memory without coherent constraint
-					if (!tex.flush(dev, cmd, memory_types.host_visible_coherent, submit_queue))
-					{
-						//Missed address, note this
-						//TODO: Lower severity when successful to keep the cache from overworking
-						record_cache_miss(tex);
-					}
-
-					response = true;
+					processed_ranges[base] = true;
+					continue;
 				}
+
+				for (int i = 0; i < range_data.data.size(); i++)
+				{
+					auto &tex = range_data.data[i];
+
+					if (tex.is_dirty()) continue;
+					if (!tex.is_flushable()) continue;
+
+					auto overlapped = tex.overlaps_page(trampled_range, address);
+					if (std::get<0>(overlapped))
+					{
+						auto &new_range = std::get<1>(overlapped);
+
+						if (new_range.first != trampled_range.first ||
+							new_range.second != trampled_range.second)
+						{
+							i = 0;
+							trampled_range = new_range;
+							range_reset = true;
+						}
+
+						//TODO: Map basic host_visible memory without coherent constraint
+						if (!tex.flush(dev, cmd, memory_types.host_visible_coherent, submit_queue))
+						{
+							//Missed address, note this
+							//TODO: Lower severity when successful to keep the cache from overworking
+							record_cache_miss(tex);
+						}
+
+						response = true;
+					}
+				}
+
+				if (range_reset)
+				{
+					processed_ranges.clear();
+					It = m_cache.begin();
+				}
+
+				processed_ranges[base] = true;
 			}
 
 			return response;
@@ -717,37 +834,79 @@ namespace vk
 
 		bool invalidate_address(u32 address)
 		{
-			if (address < texture_cache_range.first ||
-				address > texture_cache_range.second)
-				return false;
+			if (address < read_only_range.first ||
+				address > read_only_range.second)
+			{
+				//Doesnt fall in the read_only textures range; check render targets
+				if (address < no_access_range.first ||
+					address > no_access_range.second)
+					return false;
+			}
 
 			bool response = false;
 			std::pair<u32, u32> trampled_range = std::make_pair(0xffffffff, 0x0);
+			std::unordered_map<u32, bool> processed_ranges;
 
-			for (int i = 0; i < m_cache.size(); ++i)
+			reader_lock lock(m_cache_mutex);
+
+			for (auto It = m_cache.begin(); It != m_cache.end(); It++)
 			{
-				auto &tex = m_cache[i];
+				auto &range_data = It->second;
+				const u32 base = It->first;
+				bool range_reset = false;
 
-				if (tex.is_dirty()) continue;
-				if (!tex.is_locked()) continue;	//flushable sections can be 'clean' but unlocked. TODO: Handle this better
+				if (processed_ranges[base] || range_data.valid_count == 0)
+					continue;
 
-				auto overlapped = tex.overlaps_page(trampled_range, address);
-				if (std::get<0>(overlapped))
+				//Quickly discard range
+				const u32 lock_base = base & ~0xfff;
+				const u32 lock_limit = align(range_data.max_range + base, 4096);
+
+				if ((trampled_range.first >= lock_limit || lock_base >= trampled_range.second) &&
+					(lock_base > address || lock_limit <= address))
 				{
-					auto &new_range = std::get<1>(overlapped);
-
-					if (new_range.first != trampled_range.first ||
-						new_range.second != trampled_range.second)
-					{
-						trampled_range = new_range;
-						i = 0;
-					}
-
-					tex.set_dirty(true);
-					tex.unprotect();
-
-					response = true;
+					processed_ranges[base] = true;
+					continue;
 				}
+
+				for (int i = 0; i < range_data.data.size(); i++)
+				{
+					auto &tex = range_data.data[i];
+
+					if (tex.is_dirty()) continue;
+					if (!tex.is_locked()) continue;	//flushable sections can be 'clean' but unlocked. TODO: Handle this better
+
+					auto overlapped = tex.overlaps_page(trampled_range, address);
+					if (std::get<0>(overlapped))
+					{
+						auto &new_range = std::get<1>(overlapped);
+
+						if (new_range.first != trampled_range.first ||
+							new_range.second != trampled_range.second)
+						{
+							i = 0;
+							trampled_range = new_range;
+							range_reset = true;
+						}
+
+						// Upgrade to writer lock
+						lock.upgrade();
+
+						tex.set_dirty(true);
+						tex.unprotect();
+
+						range_data.valid_count--;
+						response = true;
+					}
+				}
+
+				if (range_reset)
+				{
+					processed_ranges.clear();
+					It = m_cache.begin();
+				}
+
+				processed_ranges[base] = true;
 			}
 
 			return response;

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -252,10 +252,10 @@ namespace
 		vertex_buffer_visitor(u32 vtx_cnt, VkDevice dev, vk::vk_data_heap& heap,
 			vk::glsl::program* prog, VkDescriptorSet desc_set,
 			std::vector<std::unique_ptr<vk::buffer_view>>& buffer_view_to_clean,
-			weak_vertex_cache& vertex_cache)
+			rsx::vertex_cache<uploaded_range, VkFormat>* vertex_cache)
 			: vertex_count(vtx_cnt), m_attrib_ring_info(heap), device(dev), m_program(prog),
 			  descriptor_sets(desc_set), m_buffer_view_to_clean(buffer_view_to_clean),
-			  vertex_cache(&vertex_cache)
+			  vertex_cache(vertex_cache)
 		{
 		}
 
@@ -341,7 +341,7 @@ namespace
 		vk::glsl::program* m_program;
 		VkDescriptorSet descriptor_sets;
 		std::vector<std::unique_ptr<vk::buffer_view>>& m_buffer_view_to_clean;
-		weak_vertex_cache* vertex_cache;
+		rsx::vertex_cache<uploaded_range, VkFormat>* vertex_cache;
 	};
 
 	using attribute_storage = std::vector<std::variant<rsx::vertex_array_buffer,
@@ -470,7 +470,7 @@ namespace
 			const u32 vertex_count = vertex_max_index - min_index + 1;
 
 			vertex_buffer_visitor visitor(vertex_count, m_device,
-				m_attrib_ring_info, m_program, m_descriptor_sets, m_buffer_view_to_clean, rsxthr->m_vertex_cache);
+				m_attrib_ring_info, m_program, m_descriptor_sets, m_buffer_view_to_clean, rsxthr->m_vertex_cache.get());
 
 			const auto& vertex_buffers = get_vertex_buffers(
 				rsx::method_registers, {{min_index, vertex_max_index - min_index + 1}});
@@ -500,7 +500,7 @@ namespace
 					const VkFormat format = vk::get_suitable_vk_format(v.type, v.attribute_size);
 					const uintptr_t local_addr = (uintptr_t)v.data.data();
 
-					const auto cached = rsxthr->m_vertex_cache.find_vertex_range(local_addr, format, upload_size);
+					const auto cached = rsxthr->m_vertex_cache->find_vertex_range(local_addr, format, upload_size);
 					if (cached)
 					{
 						m_buffer_view_to_clean.push_back(std::make_unique<vk::buffer_view>(m_device, m_attrib_ring_info.heap->value, format, cached->offset_in_heap, upload_size));
@@ -520,7 +520,7 @@ namespace
 						upload_jobs.push_back(i);
 
 						const uintptr_t local_addr = (uintptr_t)v.data.data();
-						rsxthr->m_vertex_cache.store_range(local_addr, format, upload_size, (u32)offset);
+						rsxthr->m_vertex_cache->store_range(local_addr, format, upload_size, (u32)offset);
 
 						m_buffer_view_to_clean.push_back(std::make_unique<vk::buffer_view>(m_device, m_attrib_ring_info.heap->value, format, offset, upload_size));
 						m_program->bind_uniform(m_buffer_view_to_clean.back()->value, s_reg_table[v.index], m_descriptor_sets);

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -252,7 +252,7 @@ namespace
 		vertex_buffer_visitor(u32 vtx_cnt, VkDevice dev, vk::vk_data_heap& heap,
 			vk::glsl::program* prog, VkDescriptorSet desc_set,
 			std::vector<std::unique_ptr<vk::buffer_view>>& buffer_view_to_clean,
-			rsx::vertex_cache<uploaded_range, VkFormat>* vertex_cache)
+			vk::vertex_cache* vertex_cache)
 			: vertex_count(vtx_cnt), m_attrib_ring_info(heap), device(dev), m_program(prog),
 			  descriptor_sets(desc_set), m_buffer_view_to_clean(buffer_view_to_clean),
 			  vertex_cache(vertex_cache)
@@ -341,7 +341,7 @@ namespace
 		vk::glsl::program* m_program;
 		VkDescriptorSet descriptor_sets;
 		std::vector<std::unique_ptr<vk::buffer_view>>& m_buffer_view_to_clean;
-		rsx::vertex_cache<uploaded_range, VkFormat>* vertex_cache;
+		vk::vertex_cache* vertex_cache;
 	};
 
 	using attribute_storage = std::vector<std::variant<rsx::vertex_array_buffer,

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -194,4 +194,13 @@ namespace rsx
 			return std::make_pair(min, max);
 		}
 	};
+
+	template <typename storage_type, typename upload_format>
+	class vertex_cache
+	{
+	public:
+		virtual storage_type* find_vertex_range(uintptr_t /*local_addr*/, upload_format, u32 /*data_length*/) { return nullptr;  }
+		virtual void store_range(uintptr_t /*local_addr*/, upload_format, u32 /*data_length*/, u32 /*offset_in_heap*/) {}
+		virtual void purge() {}
+	};
 }

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -277,7 +277,7 @@ struct cfg_root : cfg::node
 		cfg::_int<32, 16384> max_spu_immediate_write_size{this, "Maximum immediate DMA write size", 16384}; // Maximum size that an SPU thread can write directly without posting to MFC
 		cfg::_int<0, 6> preferred_spu_threads{this, "Preferred SPU Threads", 0}; //Numnber of hardware threads dedicated to heavy simultaneous spu tasks
 		cfg::_int<0, 16> spu_delay_penalty{this, "SPU delay penalty", 3}; //Number of milliseconds to block a thread if a virtual 'core' isn't free
-		cfg::_bool spu_loop_detection{this, "SPU loop detection", false}; //Try to detect wait loops and trigger thread yield
+		cfg::_bool spu_loop_detection{this, "SPU loop detection", true}; //Try to detect wait loops and trigger thread yield
 
 		cfg::_enum<lib_loading_type> lib_loading{this, "Lib Loader", lib_loading_type::automatic};
 		cfg::_bool hook_functions{this, "Hook static functions"};
@@ -326,6 +326,7 @@ struct cfg_root : cfg::node
 		cfg::_bool invalidate_surface_cache_every_frame{this, "Invalidate Cache Every Frame", true};
 		cfg::_bool strict_rendering_mode{this, "Strict Rendering Mode"};
 
+		cfg::_bool disable_vertex_cache{this, "Disable Vertex Cache", false};
 		cfg::_bool batch_instanced_geometry{this, "Batch Instanced Geometry", false}; //Avoid re-uploading geometry if the same draw command is repeated
 		cfg::_int<1, 16> vertex_upload_threads{ this, "Vertex Upload Threads", 1 }; //Max number of threads to use for parallel vertex processing
 		cfg::_int<32, 65536> mt_vertex_upload_threshold{ this, "Multithreaded Vertex Upload Threshold", 512}; //Minimum vertex count to parallelize

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -27,10 +27,10 @@
 			"hookStFunc": "Allows to hook some functions like 'memcpy' replacing them with high-level implementations. May do nothing or break things. Experimental.",
 			"bindSPUThreads": "If your CPU has SMT (Hyper-Threading) SPU threads will run on these logical cores instead.\nUsually faster on an i3, possibly slower or no difference on an i7 or Ryzen.",
 			"lowerSPUThrPrio": "Runs SPU threads with lower priority than PPU threads.\nUsually faster on an i3 or i5, possibly slower or no difference on an i7 or Ryzen.",
-			"spuLoopDetection": ""
+			"spuLoopDetection": "Try to detect loop conditions in SPU kernels and use them as scheduling hints.\nImproves performance and reduces CPU usage"
 		},
 		"comboboxes": {
-			"preferredSPUThreads": ""
+			"preferredSPUThreads": "Preferred number of threads allowed to enter some sensitive SPU stages.\nSome SPU stages are sensitive to race conditions and allowing a limited number at a time helps alleviate performance stalls.\nSetting this to a smaller value might improve performance and reduce stuttering in some games.\nLeave this on auto if performance is negatively affected when setting a small value"
 		}
 	},
 	"debug": {
@@ -38,7 +38,6 @@
 		"dumpDepth": "Never use this.",
 		"readDepth": "Never use this.",
 		"glLegacyBuffers": "Enables use of classic OpenGL buffers which allows capturing tools to work with RPCS3 e.g RenderDoc.\nIf unsure, don't use this option.",
-		"scrictModeRendering": "Enforces strict compliance to the API specification.\nMight result in degraded performance in some games.\nCan resolve rare cases of missing graphics and flickering.\nIf unsure, don't use this option.",
 		"forceHighpZ": "Only useful when debugging differences in GPU hardware.\nNot necessary for average users.\nIf unsure, don't use this option.",
 		"debugOutput": "Enables the selected API's inbuilt debugging functionality.\nWill cause severe performance degradation especially with Vulkan.\nOnly useful for developers.\nIf unsure, don't use this option.",
 		"debugOverlay": "Provides a graphical overlay of various debugging information.\nIf unsure, don't use this option.",
@@ -70,6 +69,8 @@
 			"vsync": "By having this off you might obtain a higher frame rate at the cost of tearing artifacts in the game.",
 			"autoInvalidateCache": "Enable this option if the game has broken shadows. May slightly degrade performance.",
 			"gpuTextureScaling": "Small to significant performance boost in most games and rarely with side effects.\nMay cause texture corruption in rare cases.\nOnly works with OpenGL for now.",
+			"scrictModeRendering": "Enforces strict compliance to the API specification.\nMight result in degraded performance in some games.\nCan resolve rare cases of missing graphics and flickering.\nIf unsure, don't use this option.",
+			"disableVertexCache": "Disables the vertex cache.\nMight resolve missing or flickering graphics output.\nMay degrade performance.",
 			"stretchToDisplayArea": "Overrides the aspect ratio and stretches the image to the full display area."
 		}
 	},

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -68,6 +68,7 @@ public:
 		ForceHighpZ,
 		AutoInvalidateCache,
 		StrictRenderingMode,
+		DisableVertexCache,
 
 		// Audio
 		AudioRenderer,
@@ -162,6 +163,7 @@ private:
 		{ ForceHighpZ,      { "Video", "Force High Precision Z buffer"}},
 		{ AutoInvalidateCache, { "Video", "Invalidate Cache Every Frame"}},
 		{ StrictRenderingMode, { "Video", "Strict Rendering Mode"}},
+		{ DisableVertexCache, { "Video", "Disable Vertex Cache"}},
 		{ D3D12Adapter,        { "Video", "D3D12", "Adapter"}},
 		{ VulkanAdapter,       { "Video", "Vulkan", "Adapter"}},
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -401,6 +401,12 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> xSettings, const 
 	xemu_settings->EnhanceCheckBox(ui->stretchToDisplayArea, emu_settings::StretchToDisplayArea);
 	ui->stretchToDisplayArea->setToolTip(json_gpu_main["stretchToDisplayArea"].toString());
 
+	xemu_settings->EnhanceCheckBox(ui->scrictModeRendering, emu_settings::StrictRenderingMode);
+	ui->scrictModeRendering->setToolTip(json_gpu_main["scrictModeRendering"].toString());
+
+	xemu_settings->EnhanceCheckBox(ui->disableVertexCache, emu_settings::DisableVertexCache);
+	ui->disableVertexCache->setToolTip(json_gpu_main["disableVertexCache"].toString());
+
 	// Graphics Adapter
 	QStringList D3D12Adapters = r_Creator.D3D12Adapters;
 	QStringList vulkanAdapters = r_Creator.vulkanAdapters;
@@ -818,9 +824,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> xSettings, const 
 	// Checkboxes: debug options
 	xemu_settings->EnhanceCheckBox(ui->glLegacyBuffers, emu_settings::LegacyBuffers);
 	ui->glLegacyBuffers->setToolTip(json_debug["glLegacyBuffers"].toString());
-
-	xemu_settings->EnhanceCheckBox(ui->scrictModeRendering, emu_settings::StrictRenderingMode);
-	ui->scrictModeRendering->setToolTip(json_debug["scrictModeRendering"].toString());
 
 	xemu_settings->EnhanceCheckBox(ui->forceHighpZ, emu_settings::ForceHighpZ);
 	ui->forceHighpZ->setToolTip(json_debug["forceHighpZ"].toString());

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -36,7 +36,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="coreTab">
       <attribute name="title">
@@ -470,6 +470,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="scrictModeRendering">
+              <property name="text">
+               <string>Strict Rendering Mode</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QCheckBox" name="vsync">
               <property name="text">
                <string>VSync</string>
@@ -480,6 +487,13 @@
              <widget class="QCheckBox" name="stretchToDisplayArea">
               <property name="text">
                <string>Stretch To Display Area</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="disableVertexCache">
+              <property name="text">
+               <string>Disable Vertex Cache</string>
               </property>
              </widget>
             </item>
@@ -1302,13 +1316,6 @@
              <widget class="QCheckBox" name="debugOverlay">
               <property name="text">
                <string>Debug Overlay</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="scrictModeRendering">
-              <property name="text">
-               <string>Strict Rendering Mode</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
- Reimplements the weak vertex cache using unordered_map for faster search performance
- Reimplements the texture cache also using unordered_map for faster search as well
- Properly synchronize the texture cache to avoid random rsx lockup
- Reimplements timing in the SPU concurrency watchdog code. It is now possible to set a hint number of threads with little performance loss, e.g it is now possible to set 'preferred threads' to something like 2 and set a penalty of 0 to significantly improve smoothness if running a low end CPU. Note that games which run better with low 'preferred threads' values still need a delay penalty greater than 0 (leave it at 3)
- Also added an option to disable the vertex cache in case it causes problems
- Implements a weak vertex cache for opengl as well
- Restore 'Strict mode rendering' checkbox as it is needed for some games

With these changes and 4 SPU threads + 0 delay penaly, demon's souls runs without the spiky framerates on an i3. Its still not a locked 30 fps but it feels much much better now.