### PR TITLE
Make config loading more forgiving to errors.

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -191,7 +191,15 @@ void Emulator::Init()
 	g_cfg_defaults = g_cfg.to_string();
 
 	// Reload global configuration
-	g_cfg.from_string(fs::file(fs::get_config_dir() + "/config.yml", fs::read + fs::create).to_string());
+	try
+	{
+		g_cfg.from_string(fs::file(fs::get_config_dir() + "/config.yml", fs::read + fs::create).to_string());
+	}
+	catch(...)
+	{
+		LOG_ERROR(GENERAL, "Failed to load config.yml.  Using default configuration!");
+		g_cfg.from_default();
+	}
 
 	// Create directories
 	const std::string emu_dir_ = g_cfg.vfs.emulator_dir;

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -182,13 +182,30 @@ emu_settings::emu_settings(const std::string& path) : QObject()
 
 	// Add global config
 	config = fs::file(fs::get_config_dir() + "/config.yml", fs::read + fs::write + fs::create);
-	currentSettings += YAML::Load(config.to_string());
+	try
+	{
+		currentSettings += YAML::Load(config.to_string());
+	}
+	catch(...)
+	{
+		LOG_ERROR(GENERAL, "Failed to load global config.yml.  Using g_cfg!");
+		currentSettings += YAML::Load(g_cfg.to_string());
+	}
+
 
 	// Add game config
 	if (!path.empty())
 	{
 		config = fs::file(fs::get_config_dir() + path + "/config.yml", fs::read + fs::write + fs::create);
-		currentSettings += YAML::Load(config.to_string());
+		try
+		{
+			currentSettings += YAML::Load(config.to_string());
+		}
+		catch (...)
+		{
+			LOG_ERROR(GENERAL, "Failed to load the game's custom config.yml.  Using g_cfg!");
+			currentSettings += YAML::Load(g_cfg.to_string());
+		}
 	}
 }
 


### PR DESCRIPTION
Currently any mistakes in yaml file crash emulator.  Not ideal.

This won't override their files but it'll let the user know something is wrong.  Note, the first Emu.Init happens before the log frame is created.  So, naturally, if the config has issues on application start, it won't show in the log *frame*.  Adding a "Emu.CallAfter" to this message would fix this probably, but seems a bit clumsy, so I didn't do it.