### PR TITLE
Allow building with ALSA on BSDs

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -127,7 +127,7 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	#on some Linux distros shm_unlink and similar functions are in librt only
-	set(ADDITIONAL_LIBS "rt" "X11" "asound")
+	set(ADDITIONAL_LIBS "rt" "X11")
 elseif(NOT MSVC AND NOT CMAKE_CXX_FLAGS MATCHES "LIBICONV_PLUG")
 	#it seems like glibc includes the iconv functions we use but other libc
 	#implementations like the one on OSX don't seem implement them
@@ -158,9 +158,19 @@ elseif(WIN32)
 	set(PLATFORM_ARCH "Windows/x86_64")
 else()
 	set(PLATFORM_ARCH "linux/x86_64")
+	option(USE_ALSA "ALSA audio backend" ON)
 	option(USE_LIBEVDEV "libevdev-based joystick support" ON)
 endif()
 
+if(USE_ALSA)
+	find_package(PkgConfig)
+	pkg_check_modules(ALSA alsa)
+	if(ALSA_FOUND)
+		add_definitions(-DHAVE_ALSA)
+		include_directories(SYSTEM ${ALSA_INCLUDE_DIRS})
+		list(APPEND ADDITIONAL_LIBS ${ALSA_LDFLAGS})
+	endif()
+endif()
 if(USE_LIBEVDEV)
 	find_package(PkgConfig)
 	pkg_check_modules(LIBEVDEV libevdev)

--- a/rpcs3/Emu/Audio/ALSA/ALSAThread.cpp
+++ b/rpcs3/Emu/Audio/ALSA/ALSAThread.cpp
@@ -4,7 +4,7 @@
 
 #include "ALSAThread.h"
 
-#ifdef __linux__
+#ifdef HAVE_ALSA
 
 #include <alsa/asoundlib.h>
 

--- a/rpcs3/Emu/Audio/ALSA/ALSAThread.h
+++ b/rpcs3/Emu/Audio/ALSA/ALSAThread.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef __linux__
+#ifdef HAVE_ALSA
 
 #include "Emu/Audio/AudioThread.h"
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -166,7 +166,7 @@ void fmt_class_string<audio_renderer>::format(std::string& out, u64 arg)
 		case audio_renderer::null: return "Null";
 #ifdef _WIN32
 		case audio_renderer::xaudio: return "XAudio2";
-#elif __linux__
+#elif defined(HAVE_ALSA)
 		case audio_renderer::alsa: return "ALSA";
 #endif
 		case audio_renderer::openal: return "OpenAL";

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -88,7 +88,7 @@ enum class audio_renderer
 	null,
 #ifdef _WIN32
 	xaudio,
-#elif __linux__
+#elif defined(HAVE_ALSA)
 	alsa,
 #endif
 	openal,

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -45,7 +45,7 @@
 #ifdef _WIN32
 #include "Emu/Audio/XAudio2/XAudio2Thread.h"
 #endif
-#ifdef __linux__
+#ifdef HAVE_ALSA
 #include "Emu/Audio/ALSA/ALSAThread.h"
 #endif
 
@@ -199,7 +199,7 @@ void rpcs3_app::InitializeCallbacks()
 		case audio_renderer::null: return std::make_shared<NullAudioThread>();
 #ifdef _WIN32
 		case audio_renderer::xaudio: return std::make_shared<XAudio2Thread>();
-#elif __linux__
+#elif defined(HAVE_ALSA)
 		case audio_renderer::alsa: return std::make_shared<ALSAThread>();
 #endif
 		case audio_renderer::openal: return std::make_shared<OpenALThread>();


### PR DESCRIPTION
DragonFly, FreeBSD and NetBSD support ALSA (via OSS plugin). ALSA, unlike OpenAL, doesn't suffer from audio crackling/noise in some games e.g., Persona 5.

Example build log: http://sprunge.us/KiAM
