### PR TITLE
Better evdev joystick axis scaling

### DIFF
--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -356,7 +356,7 @@ void evdev_joystick_handler::thread_func()
                 }
                 else if (axistrigger && (evt.code == ABS_Z || evt.code == ABS_RZ))
                 {
-                    // For Xbox 360 controllers, a third axis represent the left/right triggers.
+                    // For Xbox controllers, a third axis represent the left/right triggers.
                     int which_trigger=0;
 
                     if (evt.code == ABS_Z)
@@ -383,7 +383,7 @@ void evdev_joystick_handler::thread_func()
                     }
 
                     int value = scale_axis(evt.code, evt.value);
-                    which_button->m_pressed = value == 255;
+                    which_button->m_pressed = value > 0;
                     which_button->m_value = value;
                 }
                 else if (evt.code >= ABS_X && evt.code <= ABS_RZ)

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -229,6 +229,14 @@ int evdev_joystick_handler::scale_axis(int axis, int value)
     // Check if scaling is needed.
     if (range.first != 0 || range.second != 255)
     {
+        if (range.first < 0)
+        {
+            // Move the ranges up to make the following calculation actually *work*
+            value += -range.first;
+            range.second += -range.first;
+            range.first = 0;
+        }
+
         return (static_cast<float>(value - range.first) / range.second) * 255;
     }
     else

--- a/rpcs3/evdev_joystick_handler.h
+++ b/rpcs3/evdev_joystick_handler.h
@@ -44,7 +44,6 @@ struct evdev_joystick_config final : cfg::node
     cfg::_bool lxreverse{this, "Reverse left stick X axis", false};
     cfg::_bool lyreverse{this, "Reverse left stick Y axis", false};
 
-    cfg::_bool needscale{this, "Axis scaling", true};
     cfg::_bool axistrigger{this, "Z axis triggers", true};
 
     bool load()
@@ -76,6 +75,7 @@ public:
 private:
     void update_devs();
     bool try_open_dev(u32 index);
+    int scale_axis(int axis, int value);
     void thread_func();
 
     std::unique_ptr<std::thread> joy_thread;
@@ -85,6 +85,7 @@ private:
     std::vector<std::vector<int>> joy_button_maps;
     std::vector<std::vector<int>> joy_axis_maps;
     std::vector<int> joy_hat_ids;
-    bool needscale, axistrigger;
+    bool axistrigger;
+    std::map<int, std::pair<int, int>> axis_ranges;
     std::vector<bool> revaxis;
 };


### PR DESCRIPTION
Fixes #3179 and removes the now-unnecessary *Axis scaling* option. @HollowSoldier Try this one to see if it fixes your problems.