### PR TITLE
GUI Figs

### DIFF
--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -174,6 +174,8 @@ Render_Creator::Render_Creator()
 
 emu_settings::emu_settings(const std::string& path) : QObject()
 {
+	m_path = path;
+
 	// Create config path if necessary
 	fs::create_path(fs::get_config_dir() + path);
 
@@ -185,9 +187,9 @@ emu_settings::emu_settings(const std::string& path) : QObject()
 	currentSettings += YAML::Load(config.to_string());
 
 	// Add game config
-	if (!path.empty())
+	if (!path.empty() && fs::is_file(fs::get_config_dir() + path + "/config.yml"))
 	{
-		config = fs::file(fs::get_config_dir() + path + "/config.yml", fs::read + fs::write + fs::create);
+		config = fs::file(fs::get_config_dir() + path + "/config.yml", fs::read + fs::write);
 		currentSettings += YAML::Load(config.to_string());
 	}
 }
@@ -200,7 +202,12 @@ void emu_settings::SaveSettings()
  {
 	YAML::Emitter out;
 	emitData(out, currentSettings);
-	
+
+	if (!m_path.empty())
+	{
+		config = fs::file(fs::get_config_dir() + m_path + "/config.yml", fs::read + fs::write + fs::create);
+	}
+
 	// Save config
 	config.seek(0);
 	config.trunc(0);

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -205,4 +205,5 @@ private:
 
 	YAML::Node currentSettings; // The current settings as a YAML node.
 	fs::file config; //! File to read/write the config settings.
+	std::string m_path;
 };

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -352,7 +352,7 @@ void game_list_frame::SortGameList()
 	gameList->resizeColumnToContents(0);
 }
 
-void game_list_frame::Refresh(bool fromDrive)
+void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 {
 	if (fromDrive)
 	{
@@ -471,7 +471,11 @@ void game_list_frame::Refresh(bool fromDrive)
 		int row = PopulateGameList();
 		gameList->selectRow(row);
 		SortGameList();
-		gameList->scrollTo(gameList->currentIndex(), QAbstractItemView::PositionAtCenter);
+
+		if (scrollAfter)
+		{
+			gameList->scrollTo(gameList->currentIndex(), QAbstractItemView::PositionAtCenter);
+		}
 	}
 	else
 	{
@@ -489,7 +493,11 @@ void game_list_frame::Refresh(bool fromDrive)
 		connect(m_xgrid, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
 		m_Central_Widget->addWidget(m_xgrid);
 		m_Central_Widget->setCurrentWidget(m_xgrid);
-		m_xgrid->scrollTo(m_xgrid->currentIndex());
+
+		if (scrollAfter)
+		{
+			m_xgrid->scrollTo(m_xgrid->currentIndex());
+		}
 	}
 }
 
@@ -623,7 +631,7 @@ void game_list_frame::ShowSpecifiedContextMenu(const QPoint &pos, int row)
 	});
 	connect(configure, &QAction::triggered, [=]() {
 		settings_dialog (xgui_settings, m_Render_Creator, 0, this, &currGame).exec();
-		Refresh(true);
+		Refresh(true, false);
 	});
 	connect(removeGame, &QAction::triggered, [=]()
 	{
@@ -634,7 +642,7 @@ void game_list_frame::ShowSpecifiedContextMenu(const QPoint &pos, int row)
 			Refresh();
 		}
 	});
-	connect(removeConfig, &QAction::triggered, [=]() {RemoveCustomConfiguration(row); Refresh(true); });
+	connect(removeConfig, &QAction::triggered, [=]() {RemoveCustomConfiguration(row); Refresh(true, false); });
 	connect(openGameFolder, &QAction::triggered, [=]() {open_dir(currGame.path); });
 	connect(openConfig, &QAction::triggered, [=]() {open_dir(fs::get_config_dir() + "data/" + currGame.serial); });
 	connect(checkCompat, &QAction::triggered, [=]() {

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -185,7 +185,7 @@ public:
 	~game_list_frame();
 
 	/** Refresh the gamelist with/without loading game data from files. Public so that main frame can refresh after vfs or install */
-	void Refresh(const bool fromDrive = false);
+	void Refresh(const bool fromDrive = false, const bool scrollAfter = true);
 
 	/** Adds/removes categories that should be shown on gamelist. Public so that main frame menu actions can apply them */
 	void ToggleCategoryFilter(const QStringList& categories, bool show);


### PR DESCRIPTION
Prevent scroll after game config interactions to keep Talkashie from booting the wrong game.

Also fix custom config creation. It created the yml file on opening of dialog already. Now it creates it only on saving.