### PR TITLE
Patch cellVideoOutConfigure (Fixes beowulf)

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
@@ -134,10 +134,10 @@ error_code cellVideoOutConfigure(u32 videoOut, vm::ptr<CellVideoOutConfiguration
 	{
 	case CELL_VIDEO_OUT_PRIMARY:
 		if (config->resolutionId != g_video_out_resolution_id.at(g_cfg.video.resolution)
-			|| (config->format != CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8R8G8B8 &&
-				config->format != CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8B8G8R8 &&
-				config->format != CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_R16G16B16X16_FLOAT) 
-			|| (config->aspect != CELL_VIDEO_OUT_ASPECT_AUTO && config->aspect != g_video_out_aspect_id.at(g_cfg.video.aspect_ratio)))
+			|| ((config->format & 0x3) != CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8R8G8B8 &&
+				(config->format & 0x3) != CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8B8G8R8 &&
+				(config->format & 0x3) != CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_R16G16B16X16_FLOAT)
+			|| ((config->aspect & 0x3) != CELL_VIDEO_OUT_ASPECT_AUTO && config->aspect != g_video_out_aspect_id.at(g_cfg.video.aspect_ratio)))
 		{
 			return CELL_VIDEO_OUT_ERROR_ILLEGAL_CONFIGURATION;
 		}


### PR DESCRIPTION
Beowulf hardcodes the value of format to 8. So, the real ps3 most likely &s the value with 0x3.  This makes beowulf go from nothing to ingame on Vulkan.