### PR TITLE
Linux evdev controller backend fixes (and misc linux fixes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,13 @@ before_install:
       brew update; brew update;
       brew install ccache glew llvm40;
     fi;
+  # We need to update binutils to a newer version to link against the ffmpeg libs on.
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      sudo add-apt-repository ppa:jonathonf/binutils -y ;
+      sudo apt-get update ; 
+      sudo apt-get install binutils -y;
+      ld --version ;
+    fi;
 
 before_script:
   - git submodule update --init asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng Utilities/yaml-cpp 3rdparty/cereal 3rdparty/hidapi Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -59,8 +59,11 @@ void evdev_joystick_handler::Init(const u32 max_connect)
                     LOG_WARNING(GENERAL, "Failed to connect to device at %s, the error was: %s", "/dev/input/" + et.name, strerror(-rc));
                 continue;
             }
-            if (libevdev_get_id_bustype(dev) == JOYSTICK_BUSTYPE)
+            if (libevdev_has_event_type(dev, EV_KEY) &&
+                libevdev_has_event_code(dev, EV_ABS, ABS_X) &&
+                libevdev_has_event_code(dev, EV_ABS, ABS_Y))
             {
+                // It's a joystick.
                 joy_paths.emplace_back(fmt::format("/dev/input/%s", et.name));
             }
         }

--- a/rpcs3/evdev_joystick_handler.h
+++ b/rpcs3/evdev_joystick_handler.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <thread>
 
+#define JOYSTICK_BUSTYPE 3
 
 enum { EVDEV_DPAD_HAT_AXIS_X = -1, EVDEV_DPAD_HAT_AXIS_Y = -2 };
 
@@ -45,6 +46,8 @@ struct evdev_joystick_config final : cfg::node
     cfg::_bool lyreverse{this, "Reverse left stick Y axis", false};
 
     cfg::_bool axistrigger{this, "Z axis triggers", true};
+    cfg::_bool squirclejoysticks{this, "Squircle Joysticks", true};
+    cfg::int32 squirclefactor{this, "Squircle Factor", 5000};
 
     bool load()
     {
@@ -74,6 +77,7 @@ public:
 
 private:
     void update_devs();
+    std::tuple<u16, u16> ConvertToSquirclePoint(u16 inX, u16 inY);
     bool try_open_dev(u32 index);
     int scale_axis(int axis, int value);
     void thread_func();
@@ -84,6 +88,8 @@ private:
     std::vector<libevdev*> joy_devs;
     std::vector<std::vector<int>> joy_button_maps;
     std::vector<std::vector<int>> joy_axis_maps;
+    // joy_axis is only used for squircling
+    std::vector<std::vector<int>> joy_axis;
     std::vector<int> joy_hat_ids;
     bool axistrigger;
     std::map<int, std::pair<int, int>> axis_ranges;

--- a/rpcs3/evdev_joystick_handler.h
+++ b/rpcs3/evdev_joystick_handler.h
@@ -8,8 +8,6 @@
 #include <vector>
 #include <thread>
 
-#define JOYSTICK_BUSTYPE 3
-
 enum { EVDEV_DPAD_HAT_AXIS_X = -1, EVDEV_DPAD_HAT_AXIS_Y = -2 };
 
 struct evdev_joystick_config final : cfg::node

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -116,7 +116,7 @@ void main_window::Init()
 	fs::stat_t st;
 	if (!fs::stat(fs::get_config_dir() + "rpcs3.pdb", st) || st.is_directory || st.size < 1024 * 1024 * 100)
 #else
-	if (true)
+	if (false)
 #endif
 	{
 		QMessageBox msg;


### PR DESCRIPTION
This PR includes
- Improved evdev controller detection, this fixes detection of the Steam Controller when used with [sc-controller](https://github.com/kozec/sc-controller)
- Adds joystick squircling, which makes running in Persona 5 nicer, same implementation as xinput and dualshock 4 backends.
- Adds a quick fix for developer builds and standard linux builds (for example, the Arch AUR), to no longer give experimental build warning.
- Updates ffmpeg again, to fix the issue here: http://www.emunewz.net/forum/showthread.php?tid=174368&pid=285178#pid285178 again.

Requesting review from @kirbyfan64 @kozek

Requesting testing from @gasinvein @gadzook @ghost and @toccata10

---

pre-compiled AppImage link for testing: https://transfer.sh/pwI71/eb22e4e-178_linux64
(will expire in 14 days)
To run AppImage:
```shell
wget https://transfer.sh/pwI71/eb22e4e-178_linux64
chmod a+x ./eb22e4e-178_linux64
./eb22e4e-178_linux64
```