### PR TITLE
RSX Fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -248,7 +248,7 @@ s32 cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 	}
 	data->button[0] = 0x0; // always 0
 	// bits 15-8 reserved, 7-4 = 0x7, 3-0: data->len/2;
-	data->button[1] = (0x7 << 4) | std::min(data->len / 2, 15) & 0xF;
+	data->button[1] = (0x7 << 4) | std::min(data->len / 2, 15);
 	//lets still send new data anyway, not sure whats expected still
 	data->button[CELL_PAD_BTN_OFFSET_DIGITAL1]       = pad.m_digital_1;
 	data->button[CELL_PAD_BTN_OFFSET_DIGITAL2]       = pad.m_digital_2;

--- a/rpcs3/Emu/RSX/CgBinaryVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/CgBinaryVertexProgram.cpp
@@ -51,21 +51,22 @@ std::string CgBinaryDisasm::GetScaMaskDisasm()
 std::string CgBinaryDisasm::GetDSTDisasm(bool isSca)
 {
 	std::string ret;
+	std::string mask = GetMaskDisasm(isSca);
 
-	switch (isSca ? 0x1f : d3.dst)
+	switch ((isSca && d3.sca_dst_tmp != 0x3f) ? 0x1f : d3.dst)
 	{
 	case 0x1f:
-		ret += isSca ? fmt::format("R%d", d3.sca_dst_tmp) + GetScaMaskDisasm() : fmt::format("R%d", d0.dst_tmp) + GetVecMaskDisasm();
+		ret += (isSca ? fmt::format("R%d", d3.sca_dst_tmp) : fmt::format("R%d", d0.dst_tmp)) + mask;
 		break;
 
 	default:
 		if (d3.dst > 15)
 			LOG_ERROR(RSX, "dst index out of range: %u", d3.dst);
 
-		ret += fmt::format("o[%d]", d3.dst) + GetVecMaskDisasm();
+		ret += fmt::format("o[%d]", d3.dst) + mask;
 		// Vertex Program supports double destinations, notably in MOV
 		if (d0.dst_tmp != 0x3f)
-			ret += fmt::format(" R%d", d0.dst_tmp) + GetVecMaskDisasm();
+			ret += fmt::format(" R%d", d0.dst_tmp) + mask;
 		break;
 	}
 

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -43,7 +43,7 @@ std::string VertexProgramDecompiler::GetDST(bool isSca)
 
 	std::string mask = GetMask(isSca);
 
-	switch (isSca ? 0x1f : d3.dst)
+	switch ((isSca && d3.sca_dst_tmp != 0x3f) ? 0x1f : d3.dst)
 	{
 	case 0x1f:
 		ret += m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), std::string("tmp") + std::to_string(isSca ? d3.sca_dst_tmp : d0.dst_tmp)) + mask;

--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
@@ -298,6 +298,9 @@ void D3D12GSRender::copy_render_target_to_dma_location()
 	int clip_w = rsx::method_registers.surface_clip_width();
 	int clip_h = rsx::method_registers.surface_clip_height();
 
+	if (clip_w == 0 || clip_h == 0)
+		return;
+
 	size_t depth_row_pitch = align(clip_w * 4, 256);
 	size_t depth_buffer_offset_in_heap = 0;
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -100,13 +100,14 @@ namespace rsx
 
 		void texture_read_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
-			if (!rsx->do_method(NV4097_TEXTURE_READ_SEMAPHORE_RELEASE, arg))
+			const u32 index = method_registers.semaphore_offset_4097() >> 4;
+			// lle-gcm likes to inject system reserved semaphores, presumably for system/vsh usage
+			// Avoid calling render to avoid any havoc(flickering) they may cause from invalid flush/write
+
+			if (index > 63 && !rsx->do_method(NV4097_TEXTURE_READ_SEMAPHORE_RELEASE, arg))
 			{
 				//
 			}
-
-			const u32 index = method_registers.semaphore_offset_4097() >> 4;
-
 			auto& sema = vm::ps3::_ref<RsxReports>(rsx->label_addr);
 			sema.semaphore[index].val = arg;
 			sema.semaphore[index].pad = 0;
@@ -115,12 +116,11 @@ namespace rsx
 
 		void back_end_write_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
-			if (!rsx->do_method(NV4097_BACK_END_WRITE_SEMAPHORE_RELEASE, arg))
+			const u32 index = method_registers.semaphore_offset_4097() >> 4;
+			if (index > 63 && !rsx->do_method(NV4097_BACK_END_WRITE_SEMAPHORE_RELEASE, arg))
 			{
 				//
 			}
-
-			const u32 index = method_registers.semaphore_offset_4097() >> 4;
 			u32 val = (arg & 0xff00ff00) | ((arg & 0xff) << 16) | ((arg >> 16) & 0xff);
 
 			auto& sema = vm::ps3::_ref<RsxReports>(rsx->label_addr);


### PR DESCRIPTION
-Ignore sending system reserved semaphores to renderer. 
This should help with some lle-gcm regressions, fixes flickering shadows in kh which weren't present with hle

-rsx: Vertex Decompiler, fix sca register assignment
Fixes some vertex shaders: Text in little big planet and chunks of graphics in alteir games


