### PR TITLE
Respect the controller setting when returning data from cellPadGetData.

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPad.h
+++ b/rpcs3/Emu/Cell/Modules/cellPad.h
@@ -27,6 +27,15 @@ enum
 	CELL_PAD_PCLASS_TYPE_NAVIGATION = 0x05,
 };
 
+// Length returned in CellPadData struct
+enum
+{
+	CELL_PAD_LEN_NO_CHANGE = 0,
+	CELL_PAD_LEN_CHANGE_DEFAULT = 8,
+	CELL_PAD_LEN_CHANGE_PRESS_ON = 20,
+	CELL_PAD_LEN_CHANGE_SENSOR_ON = 24,
+};
+
 struct CellPadData
 {
 	be_t<s32> len;


### PR DESCRIPTION
I did some tests on a PS3 regarding the behaviour of cellPadGetData. Depending on the setting, more or less data is returned as indicated in the "length" field. If there is no change, 0 is returned as length. Enabling the motion control seems to disable this mechanism and always returns the whole buffer. I don't know if this is because the motion input alway jitters in the LSB (and therefore always changes) or if this is by design. I guess the latter because the analog inputs also jitter but have a deadzone and don't trigger a continous update.

This fixes issue #1280 (input problem in the Silent Hill HD collection).