### PR TITLE
[Roadmap] Simple thread pool

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -22,6 +22,8 @@
 #include <sys/resource.h>
 #endif
 
+#include <queue>
+
 #include "sync.h"
 
 thread_local u64 g_tls_fault_all = 0;
@@ -1505,6 +1507,9 @@ extern atomic_t<u32> g_thread_count(0);
 thread_local DECLARE(thread_ctrl::g_tls_this_thread) = nullptr;
 
 extern thread_local std::string(*g_tls_log_prefix)();
+
+static std::queue<thread_ctrl*> g_available_threads;
+static semaphore<> g_queue_mutex;
 
 void thread_ctrl::start(const std::shared_ptr<thread_ctrl>& ctrl, task_stack task)
 {

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -115,6 +115,9 @@ class thread_ctrl final
 	// Fixed name
 	std::string m_name;
 
+	// Condition variable to wait on work
+	cond_variable m_task_cond;
+
 	// Start thread
 	static void start(const std::shared_ptr<thread_ctrl>&, task_stack);
 

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -10,6 +10,8 @@
 #include "sema.h"
 #include "cond.h"
 
+#include "optional.hpp"
+
 // Will report exception and call std::abort() if put in catch(...)
 [[noreturn]] void catch_all_exceptions();
 
@@ -68,9 +70,9 @@ public:
 		_top->next.reset(_next);
 	}
 
-	void reset()
+	bool empty()
 	{
-		m_stack.reset();
+		return !m_stack;
 	}
 
 	void invoke() const
@@ -110,7 +112,7 @@ class thread_ctrl final
 	std::exception_ptr m_exception;
 
 	// Thread initial task or atexit task
-	task_stack m_task;
+	std::optional<task_stack> m_task;
 
 	// Fixed name
 	std::string m_name;

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -121,7 +121,7 @@ class thread_ctrl final
 	cond_variable m_task_cond;
 
 	// Start thread
-	static void start(const std::shared_ptr<thread_ctrl>&, task_stack);
+	static void start(std::shared_ptr<thread_ctrl>&, task_stack);
 
 	// Called at the thread start
 	void initialize();
@@ -215,6 +215,8 @@ public:
 	template<typename F>
 	static inline void atexit(F&& func)
 	{
+		extern semaphore<> g_queue_mutex;
+		semaphore_lock{g_queue_mutex};
 		_push(std::forward<F>(func));
 	}
 

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -125,7 +125,7 @@ class thread_ctrl final
 	void initialize();
 
 	// Called at the thread end
-	void finalize(std::exception_ptr) noexcept;
+	void finalize(std::exception_ptr, bool) noexcept;
 
 	// Add task (atexit)
 	static void _push(task_stack);


### PR DESCRIPTION
The aim of this PR is to implement "simple threadpool" from the roadmap. The overall approach is to avoid touching the existing code too much. What I'm looking for is comments on this particular approach and if it looks reasonable, review on the actual implementation.

First some caveats of this approach:

- **Names are not guaranteed to take effect** Code might call `thread_ctrl::start` with a named thread_ctrl, but the point of the thread pool is to not spawn a new thread on each call. So there is no guarantee that the executing thread has the desired name
- **Multiple pieces of code can own a thread and control it** Arguably that's just the semantics of `shared_ptr`, but it's worth keeping in mind that the `shared_ptr` you give to `thread_ctrl::start` can be redirected to an existing thread, and that thread could also be controlled elsewhere

Now some notes / questions:

- There is no bound on the number of threads created (as before). Should there be?
- Safe shutdown of all the threads in the pool is not yet implemented

Steps (aka what the code is (meant to be) doing):
1. add queue of threads waiting for work
1a. add a cond var to each thread to wait on work

2. update thread_ctrl::finalize
2a. don't decrement thread counter or release self reference in finalize, unless the thread is dead
2b. reset thread-local state when calling finalize on a live thread, since we'll be reusing it for a different task

3. update thread entry point
3a. introduce the concept of an empty task to signal the thread to die
3b. call initialize on thread_ctrl
3c. call invoke or go to step 3d. When invoke returns, call finalize. Add self to queue from step 1 and wait on cond var from step 1a. Pop self from queue. Go to step 3c
3d. an empty task (or an exception) signals the thread to break the loop and call finalize (kill thread)

4. make thread_ctrl::start reuse threads
4a. take a non-const shared_ptr instead of the current const
4b. check the queue for a non-busy thread
4c. if one is found, redirect the shared_ptr to the found thread. Then move the given task_stack into m_task and notify the cond var on the thread. Also reset m_signal and m_exception.
4d. if one is not found, start a new thread without redirecting the given shared_ptr

I've split the work into 4 commits to ease review, but of course they can be squashed and given proper commit messages later.