### PR TITLE
rsx: Minor fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -343,8 +343,12 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 		zcull.height = (((a4 & 0xFFFFFFFF) >> 6) & 0xFF) << 6;
 		zcull.cullStart = (a5 >> 32);
 		zcull.offset = (a5 & 0xFFFFFFFF);
+		zcull.zcullDir = ((a6 >> 32) >> 1) & 0x1;
+		zcull.zcullFormat = ((a6 >> 32) >> 2) & 0x3FF;
+		zcull.sFunc = ((a6 >> 32) >> 12) & 0xF;
+		zcull.sRef = ((a6 >> 32) >> 16) & 0xFF;
+		zcull.sMask = ((a6 >> 32) >> 24) & 0xFF;
 		zcull.binded = (a6 & 0xFFFFFFFF) != 0;
-		//TODO: Set zculldir, format, sfunc, sref, smask
 	}
 	break;
 

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -641,8 +641,6 @@ u32 get_index_count(rsx::primitive_type draw_mode, u32 initial_index_count)
 		return (initial_index_count - 2) * 3;
 	case rsx::primitive_type::quads:
 		return (6 * initial_index_count) / 4;
-	case rsx::primitive_type::quad_strip:
-		return (6 * (initial_index_count - 2)) / 2;
 	default:
 		return 0;
 	}
@@ -691,18 +689,6 @@ void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst,
 		}
 		return;
 	case rsx::primitive_type::quad_strip:
-		for (unsigned i = 0; i < (count - 2) / 2; i++)
-		{
-			// First triangle
-			typedDst[6 * i] = 2 * i;
-			typedDst[6 * i + 1] = 2 * i + 1;
-			typedDst[6 * i + 2] = 2 * i + 2;
-			// Second triangle
-			typedDst[6 * i + 3] = 2 * i + 2;
-			typedDst[6 * i + 4] = 2 * i + 1;
-			typedDst[6 * i + 5] = 2 * i + 3;
-		}
-		return;
 	case rsx::primitive_type::points:
 	case rsx::primitive_type::lines:
 	case rsx::primitive_type::line_strip:

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -610,12 +610,12 @@ bool is_primitive_native(rsx::primitive_type draw_mode)
 	case rsx::primitive_type::line_strip:
 	case rsx::primitive_type::triangles:
 	case rsx::primitive_type::triangle_strip:
+	case rsx::primitive_type::quad_strip:
 		return true;
 	case rsx::primitive_type::line_loop:
 	case rsx::primitive_type::polygon:
 	case rsx::primitive_type::triangle_fan:
 	case rsx::primitive_type::quads:
-	case rsx::primitive_type::quad_strip:
 		return false;
 	}
 	fmt::throw_exception("Wrong primitive type" HERE);

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -107,9 +107,8 @@ size_t fragment_program_hash::operator()(const RSXFragmentProgram& program) cons
 bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, const RSXFragmentProgram& binary2) const
 {
 	if (binary1.texture_dimensions != binary2.texture_dimensions || binary1.unnormalized_coords != binary2.unnormalized_coords ||
-		binary1.height != binary2.height || binary1.origin_mode != binary2.origin_mode || binary1.pixel_center_mode != binary2.pixel_center_mode ||
 		binary1.back_color_diffuse_output != binary2.back_color_diffuse_output || binary1.back_color_specular_output != binary2.back_color_specular_output ||
-		binary1.front_back_color_enabled != binary2.front_back_color_enabled || binary1.alpha_func != binary2.alpha_func || binary1.fog_equation != binary2.fog_equation ||
+		binary1.front_back_color_enabled != binary2.front_back_color_enabled ||
 		binary1.shadow_textures != binary2.shadow_textures || binary1.redirected_textures != binary2.redirected_textures)
 		return false;
 

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -209,6 +209,7 @@ std::string VertexProgramDecompiler::Format(const std::string& code)
 		{ "$awm", std::bind(std::mem_fn(&VertexProgramDecompiler::AddAddrRegWithoutMask), this) },
 		{ "$am", std::bind(std::mem_fn(&VertexProgramDecompiler::AddAddrMask), this) },
 		{ "$a", std::bind(std::mem_fn(&VertexProgramDecompiler::AddAddrReg), this) },
+		{ "$vm", std::bind(std::mem_fn(&VertexProgramDecompiler::GetVecMask), this) },
 
 		{ "$t", std::bind(std::mem_fn(&VertexProgramDecompiler::GetTex), this) },
 
@@ -606,8 +607,9 @@ std::string VertexProgramDecompiler::Decompile()
 		case RSX_VEC_OPCODE_MAX: SetDSTVec("max($0, $1)"); break;
 		case RSX_VEC_OPCODE_SLT: SetDSTVec(getFloatTypeName(4) + "(" + compareFunction(COMPARE::FUNCTION_SLT, "$0", "$1") + ")"); break;
 		case RSX_VEC_OPCODE_SGE: SetDSTVec(getFloatTypeName(4) + "(" + compareFunction(COMPARE::FUNCTION_SGE, "$0", "$1") + ")"); break;
-			// Note: It looks like ARL opcode ignore input/output swizzle mask (SH3)
-		case RSX_VEC_OPCODE_ARL: AddCode("$ifcond $awm = " + getIntTypeName(4) + "($0);");  break;
+			// Note: ARL uses the vec mask to determine channels and ignores the src input mask
+			// Tested with SH3, BLES00574 (G-Force) and NPUB90415 (Dead Space 2 Demo)
+		case RSX_VEC_OPCODE_ARL: AddCode("$ifcond $awm$vm = " + getIntTypeName(4) + "($0)$vm;");  break;
 		case RSX_VEC_OPCODE_FRC: SetDSTVec(getFunction(FUNCTION::FUNCTION_FRACT)); break;
 		case RSX_VEC_OPCODE_FLR: SetDSTVec("floor($0)"); break;
 		case RSX_VEC_OPCODE_SEQ: SetDSTVec(getFloatTypeName(4) + "(" + compareFunction(COMPARE::FUNCTION_SEQ, "$0", "$1") + ")"); break;

--- a/rpcs3/Emu/RSX/D3D12/D3D12CommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12CommonDecompiler.cpp
@@ -124,6 +124,8 @@ void insert_d3d12_legacy_function(std::ostream& OS, bool is_fragment_program)
 	if (!is_fragment_program)
 		return;
 
+	program_common::insert_compare_op(OS);
+
 	OS << "uint packSnorm2x16(float2 val)";
 	OS << "{\n";
 	OS << "	uint high_bits = round(clamp(val.x, -1., 1.) * 32767.);\n";

--- a/rpcs3/Emu/RSX/D3D12/D3D12CommonDecompiler.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12CommonDecompiler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../Common/ShaderParam.h"
+#include "../Common/GLSLCommon.h"
 
 std::string getFloatTypeNameImp(size_t elementCount);
 std::string getFunctionImp(FUNCTION f);

--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
@@ -304,7 +304,7 @@ D3D12_PRIMITIVE_TOPOLOGY get_primitive_topology(rsx::primitive_type draw_mode)
 	case rsx::primitive_type::triangle_strip: return D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
 	case rsx::primitive_type::triangle_fan: return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
 	case rsx::primitive_type::quads: return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
-	case rsx::primitive_type::quad_strip: return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+	case rsx::primitive_type::quad_strip: return D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
 	case rsx::primitive_type::polygon: return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
 	}
 	fmt::throw_exception("Invalid draw mode (0x%x)" HERE, (u32)draw_mode);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -873,10 +873,8 @@ bool GLGSRender::do_method(u32 cmd, u32 arg)
 	}
 	case NV4097_CLEAR_ZCULL_SURFACE:
 	{
-		//TODO
-		init_buffers(true);
-		clear_surface(0x3);
-
+		// NOP
+		// Clearing zcull memory does not modify depth/stencil buffers 'bound' to the zcull region
 		return true;
 	}
 	case NV4097_TEXTURE_READ_SEMAPHORE_RELEASE:

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -187,6 +187,21 @@ void GLGSRender::begin()
 	if (gl_state.enable(rsx::method_registers.depth_test_enabled(), GL_DEPTH_TEST))
 	{
 		gl_state.depth_func(comparison_op(rsx::method_registers.depth_func()));
+
+		float range_near = rsx::method_registers.clip_min();
+		float range_far = rsx::method_registers.clip_max();
+
+		if (g_cfg.video.strict_rendering_mode)
+			gl_state.depth_range(range_near, range_far);
+		else
+		{
+			//Workaround to preserve depth precision but respect z direction
+			//Ni no Kuni sets a very restricted z range (0.9x - 1.) and depth reads / tests are broken
+			if (range_near <= range_far)
+				gl_state.depth_range(0.f, 1.f);
+			else
+				gl_state.depth_range(1.f, 0.f);
+		}
 	}
 
 	if (glDepthBoundsEXT && (gl_state.enable(rsx::method_registers.depth_bounds_test_enabled(), GL_DEPTH_BOUNDS_TEST_EXT)))
@@ -194,7 +209,6 @@ void GLGSRender::begin()
 		gl_state.depth_bounds(rsx::method_registers.depth_bounds_min(), rsx::method_registers.depth_bounds_max());
 	}
 
-	gl_state.depth_range(rsx::method_registers.clip_min(), rsx::method_registers.clip_max());
 	gl_state.enable(rsx::method_registers.dither_enabled(), GL_DITHER);
 
 	if (gl_state.enable(rsx::method_registers.blend_enabled(), GL_BLEND))

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -937,7 +937,7 @@ void GLGSRender::load_program(u32 vertex_base, u32 vertex_count)
 	u32 fragment_constants_offset;
 
 	const u32 fragment_constants_size = (const u32)m_prog_buffer.get_fragment_constants_buffer_size(fragment_program);
-	const u32 fragment_buffer_size = fragment_constants_size + (17 * 4 * sizeof(float));
+	const u32 fragment_buffer_size = fragment_constants_size + (18 * 4 * sizeof(float));
 
 	if (manually_flush_ring_buffers)
 	{

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -19,7 +19,7 @@ namespace gl
 		case rsx::primitive_type::triangle_strip: return GL_TRIANGLE_STRIP;
 		case rsx::primitive_type::triangle_fan: return GL_TRIANGLE_FAN;
 		case rsx::primitive_type::quads: return GL_TRIANGLES;
-		case rsx::primitive_type::quad_strip: return GL_TRIANGLES;
+		case rsx::primitive_type::quad_strip: return GL_TRIANGLE_STRIP;
 		case rsx::primitive_type::polygon: return GL_TRIANGLES;
 		}
 		fmt::throw_exception("unknow primitive type" HERE);
@@ -543,9 +543,9 @@ namespace gl
 		case rsx::primitive_type::triangles:
 		case rsx::primitive_type::triangle_strip:
 		case rsx::primitive_type::triangle_fan:
+		case rsx::primitive_type::quad_strip:
 			return true;
 		case rsx::primitive_type::quads:
-		case rsx::primitive_type::quad_strip:
 		case rsx::primitive_type::polygon:
 			return false;
 		}

--- a/rpcs3/Emu/RSX/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/RSXFragmentProgram.h
@@ -223,17 +223,12 @@ struct RSXFragmentProgram
 	u16 unnormalized_coords;
 	u16 redirected_textures;
 	u16 shadow_textures;
-	rsx::comparison_function alpha_func;
 	bool front_back_color_enabled : 1;
 	bool back_color_diffuse_output : 1;
 	bool back_color_specular_output : 1;
 	bool front_color_diffuse_output : 1;
 	bool front_color_specular_output : 1;
 	u32 texture_dimensions;
-	rsx::window_origin origin_mode;
-	rsx::window_pixel_center pixel_center_mode;
-	rsx::fog_mode fog_equation;
-	u16 height;
 
 	float texture_pitch_scale[16];
 	u8 textures_alpha_kill[16];

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -598,17 +598,22 @@ namespace rsx
 
 	void thread::fill_fragment_state_buffer(void *buffer, const RSXFragmentProgram &fragment_program)
 	{
-		u32 *dst = static_cast<u32*>(buffer);
-
 		const u32 is_alpha_tested = rsx::method_registers.alpha_test_enabled();
 		const float alpha_ref = rsx::method_registers.alpha_ref() / 255.f;
 		const f32 fog0 = rsx::method_registers.fog_params_0();
 		const f32 fog1 = rsx::method_registers.fog_params_1();
+		const u32 alpha_func = static_cast<u32>(rsx::method_registers.alpha_func());
+		const u32 fog_mode = static_cast<u32>(rsx::method_registers.fog_equation());
+		const u32 window_origin = static_cast<u32>(rsx::method_registers.shader_window_origin());
+		const u32 window_height = rsx::method_registers.shader_window_height();
 		const float one = 1.f;
 
-		stream_vector(dst, (u32&)fog0, (u32&)fog1, is_alpha_tested, (u32&)alpha_ref);
+		u32 *dst = static_cast<u32*>(buffer);
 
-		size_t offset = 4;
+		stream_vector(dst, (u32&)fog0, (u32&)fog1, is_alpha_tested, (u32&)alpha_ref);
+		stream_vector(dst + 4, alpha_func, fog_mode, window_origin, window_height);
+
+		size_t offset = 8;
 		for (int index = 0; index < 16; ++index)
 		{
 			stream_vector(&dst[offset], (u32&)fragment_program.texture_pitch_scale[index], (u32&)one, 0U, 0U);
@@ -1097,11 +1102,6 @@ namespace rsx
 		result.back_color_specular_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR);
 		result.front_color_diffuse_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE);
 		result.front_color_specular_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR);
-		result.alpha_func = rsx::method_registers.alpha_func();
-		result.fog_equation = rsx::method_registers.fog_equation();
-		result.origin_mode = rsx::method_registers.shader_window_origin();
-		result.pixel_center_mode = rsx::method_registers.shader_window_pixel();
-		result.height = rsx::method_registers.shader_window_height();
 		result.redirected_textures = 0;
 		result.shadow_textures = 0;
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -259,7 +259,7 @@ namespace rsx
 		//zcull
 		virtual void notify_zcull_info_changed() {}
 		virtual void clear_zcull_stats(u32 /*type*/) {}
-		virtual u32 get_zcull_stats(u32 /*type*/) { return UINT32_MAX; }
+		virtual u32 get_zcull_stats(u32 /*type*/) { return UINT16_MAX; }
 
 		gsl::span<const gsl::byte> get_raw_index_array(const std::vector<std::pair<u32, u32> >& draw_indexed_clause) const;
 		gsl::span<const gsl::byte> get_raw_vertex_buffer(const rsx::data_array_format_info&, u32 base_offset, const std::vector<std::pair<u32, u32>>& vertex_ranges) const;

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -164,6 +164,10 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 	OS << "	float fog_param1;\n";
 	OS << "	uint alpha_test;\n";
 	OS << "	float alpha_ref;\n";
+	OS << "	uint alpha_func;\n";
+	OS << "	uint fog_mode;\n";
+	OS << "	uint window_origin;\n";
+	OS << "	uint window_height;\n";
 	OS << "	vec4 texture_parameters[16];\n";
 	OS << "};\n";
 
@@ -178,38 +182,6 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 namespace vk
 {
-	// Note: It's not clear whether fog is computed per pixel or per vertex.
-	// But it makes more sense to compute exp of interpoled value than to interpolate exp values.
-	void insert_fog_declaration(std::stringstream & OS, rsx::fog_mode mode)
-	{
-		switch (mode)
-		{
-		case rsx::fog_mode::linear:
-			OS << "	vec4 fogc = vec4(fog_param1 * fog_c.x + (fog_param0 - 1.), fog_param1 * fog_c.x + (fog_param0 - 1.), 0., 0.);\n";
-			break;
-		case rsx::fog_mode::exponential:
-			OS << "	vec4 fogc = vec4(11.084 * (fog_param1 * fog_c.x + fog_param0 - 1.5), exp(11.084 * (fog_param1 * fog_c.x + fog_param0 - 1.5)), 0., 0.);\n";
-			break;
-		case rsx::fog_mode::exponential2:
-			OS << "	vec4 fogc = vec4(4.709 * (fog_param1 * fog_c.x + fog_param0 - 1.5), exp(-pow(4.709 * (fog_param1 * fog_c.x + fog_param0 - 1.5), 2.)), 0., 0.);\n";
-			break;
-		case rsx::fog_mode::linear_abs:
-			OS << "	vec4 fogc = vec4(fog_param1 * abs(fog_c.x) + (fog_param0 - 1.), fog_param1 * abs(fog_c.x) + (fog_param0 - 1.), 0., 0.);\n";
-			break;
-		case rsx::fog_mode::exponential_abs:
-			OS << "	vec4 fogc = vec4(11.084 * (fog_param1 * abs(fog_c.x) + fog_param0 - 1.5), exp(11.084 * (fog_param1 * abs(fog_c.x) + fog_param0 - 1.5)), 0., 0.);\n";
-			break;
-		case rsx::fog_mode::exponential2_abs:
-			OS << "	vec4 fogc = vec4(4.709 * (fog_param1 * abs(fog_c.x) + fog_param0 - 1.5), exp(-pow(4.709 * (fog_param1 * abs(fog_c.x) + fog_param0 - 1.5), 2.)), 0., 0.);\n";
-			break;
-		default:
-			OS << "	vec4 fogc = vec4(0.);\n";
-			return;
-		}
-
-		OS << "	fogc.y = clamp(fogc.y, 0., 1.);\n";
-	}
-
 	std::string insert_texture_fetch(const RSXFragmentProgram& prog, int index)
 	{
 		std::string tex_name = "tex" + std::to_string(index);
@@ -230,6 +202,19 @@ namespace vk
 void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 {
 	glsl::insert_glsl_legacy_function(OS, glsl::glsl_fragment_program);
+
+	//TODO: Generate input mask during parse stage to avoid this
+	for (const ParamType& PT : m_parr.params[PF_PARAM_IN])
+	{
+		for (const ParamItem& PI : PT.items)
+		{
+			if (PI.name == "fogc")
+			{
+				glsl::insert_fog_declaration(OS);
+				break;
+			}
+		}
+	}
 
 	const std::set<std::string> output_values =
 	{
@@ -269,11 +254,7 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 
 	OS << "	vec4 ssa = gl_FrontFacing ? vec4(1.) : vec4(-1.);\n";
 	OS << "	vec4 wpos = gl_FragCoord;\n";
-
-	//Flip wpos in Y
-	//We could optionally export wpos from the VS, but this is so much easier
-	if (m_prog.origin_mode == rsx::window_origin::bottom)
-		OS << "	wpos.y = " << std::to_string(m_prog.height) << " - wpos.y;\n";
+	OS << "	if (window_origin != 0) wpos.y = window_height - wpos.y;\n";
 
 	bool two_sided_enabled = m_prog.front_back_color_enabled && (m_prog.back_color_diffuse_output || m_prog.back_color_specular_output);
 
@@ -323,7 +304,7 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 
 			if (PI.name == "fogc")
 			{
-				vk::insert_fog_declaration(OS, m_prog.fog_equation);
+				OS << "	vec4 fogc = fetch_fog_value(fog_mode);\n";
 				continue;
 			}
 		}
@@ -391,7 +372,7 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 			}
 		}
 
-		OS << make_comparison_test(m_prog.alpha_func, "bool(alpha_test) && ", first_output_name + ".a", "alpha_ref");
+		OS << "	if (alpha_test != 0 && !comparison_passes(" << first_output_name << ".a, alpha_ref, alpha_func)) discard;\n";
 	}
 
 	OS << "}\n\n";

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2242,8 +2242,14 @@ void VKGSRender::flip(int buffer)
 	}
 	else if (m_current_frame->swap_command_buffer)
 	{
-		//Unreachable
-		fmt::throw_exception("Possible data corruption on frame context storage detected");
+		if (m_draw_calls > 0)
+		{
+			//Unreachable
+			fmt::throw_exception("Possible data corruption on frame context storage detected");
+		}
+
+		//There were no draws and back-to-back flips happened
+		process_swap_request(m_current_frame, true);
 	}
 
 	if (!resize_screen)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1842,7 +1842,7 @@ void VKGSRender::load_program(u32 vertex_count, u32 vertex_base)
 	auto &fragment_program = current_fragment_program;
 
 	const size_t fragment_constants_sz = m_prog_buffer->get_fragment_constants_buffer_size(fragment_program);
-	const size_t fragment_buffer_sz = fragment_constants_sz + (17 * 4 * sizeof(float));
+	const size_t fragment_buffer_sz = fragment_constants_sz + (18 * 4 * sizeof(float));
 	const size_t required_mem = 512 + 8192 + fragment_buffer_sz;
 
 	const size_t vertex_state_offset = m_uniform_buffer_ring_info.alloc<256>(required_mem);

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -25,11 +25,11 @@ namespace vk
 		case rsx::primitive_type::triangles:
 			return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 		case rsx::primitive_type::triangle_strip:
+		case rsx::primitive_type::quad_strip:
 			return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
 		case rsx::primitive_type::triangle_fan:
 			return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN;
 		case rsx::primitive_type::quads:
-		case rsx::primitive_type::quad_strip:
 		case rsx::primitive_type::polygon:
 			requires_modification = true;
 			return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -409,11 +409,6 @@ namespace rsx
 			fp.ctrl = data.fp_ctrl;
 			fp.texture_dimensions = data.fp_texture_dimensions;
 			fp.unnormalized_coords = data.fp_unnormalized_coords;
-			fp.height = data.fp_height;
-			fp.pixel_center_mode = (rsx::window_pixel_center)(data.fp_pixel_layout & 0x3);
-			fp.origin_mode = (rsx::window_origin)((data.fp_pixel_layout >> 2) & 0x1);
-			fp.alpha_func = (rsx::comparison_function)((data.fp_pixel_layout >> 3) & 0xF);
-			fp.fog_equation = (rsx::fog_mode)((data.fp_pixel_layout >> 7) & 0xF);
 			fp.front_back_color_enabled = (data.fp_lighting_flags & 0x1) != 0;
 			fp.back_color_diffuse_output = ((data.fp_lighting_flags >> 1) & 0x1) != 0;
 			fp.back_color_specular_output = ((data.fp_lighting_flags >> 2) & 0x1) != 0;
@@ -444,8 +439,6 @@ namespace rsx
 			data_block.fp_ctrl = fp.ctrl;
 			data_block.fp_texture_dimensions = fp.texture_dimensions;
 			data_block.fp_unnormalized_coords = fp.unnormalized_coords;
-			data_block.fp_height = fp.height;
-			data_block.fp_pixel_layout = (u16)fp.pixel_center_mode | (u16)fp.origin_mode << 2 | (u16)fp.alpha_func << 3;
 			data_block.fp_lighting_flags = (u16)fp.front_back_color_enabled | (u16)fp.back_color_diffuse_output << 1 |
 				(u16)fp.back_color_specular_output << 2 | (u16)fp.front_color_diffuse_output << 3 | (u16)fp.front_color_specular_output << 4;
 			data_block.fp_shadow_textures = fp.shadow_textures;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -98,6 +98,16 @@ namespace rsx
 			}
 		}
 
+		void clear_zcull(thread* rsx, u32 _reg, u32 arg)
+		{
+			rsx->do_method(NV4097_CLEAR_ZCULL_SURFACE, arg);
+
+			if (rsx->capture_current_frame)
+			{
+				rsx->capture_frame("clear zcull memory");
+			}
+		}
+
 		void texture_read_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
 			const u32 index = method_registers.semaphore_offset_4097() >> 4;
@@ -1534,6 +1544,7 @@ namespace rsx
 		bind<NV4097_SET_ZCULL_EN, nv4097::set_zcull_render_enable>();
 		bind<NV4097_SET_ZCULL_STATS_ENABLE, nv4097::set_zcull_stats_enable>();
 		bind<NV4097_SET_ZPASS_PIXEL_COUNT_ENABLE, nv4097::set_zcull_pixel_count_enable>();
+		bind<NV4097_CLEAR_ZCULL_SURFACE, nv4097::clear_zcull>();
 
 		//NV308A
 		bind_range<NV308A_COLOR, 1, 256, nv308a::color>();


### PR DESCRIPTION
- Fix a zcull corner case (openGL)
- Minor improvements to shader cache to reduce first time compile stutter and number of pipeline objects (WIP)
- Fix VP ARL opcode: Respect the vector write mask
- Implement QUAD_STRIP by redirecting to TRIANGLE_STRIP. This can fail in some rare cases, but that's not something that can be fixed with indexing anyway. Quads are planar, but adjacent triangles need not be.