### PR TITLE
Correct some wrong FS errors

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -197,11 +197,6 @@ error_code sys_fs_open(vm::cptr<char> path, s32 flags, vm::ptr<u32> fd, s32 mode
 
 	const std::string& local_path = vfs::get(path.get_ptr());
 
-	if (local_path.empty())
-	{
-		return {CELL_ENOENT, path};
-	}
-
 	// TODO: other checks for path
 
 	if (fs::is_dir(local_path))
@@ -419,11 +414,6 @@ error_code sys_fs_opendir(vm::cptr<char> path, vm::ptr<u32> fd)
 
 	const std::string& local_path = vfs::get(path.get_ptr());
 
-	if (local_path.empty())
-	{
-		return {CELL_ENOENT, path};
-	}
-
 	// TODO: other checks for path
 
 	if (fs::is_file(local_path))
@@ -497,11 +487,6 @@ error_code sys_fs_stat(vm::cptr<char> path, vm::ptr<CellFsStat> sb)
 	sys_fs.warning("sys_fs_stat(path=%s, sb=*0x%x)", path, sb);
 
 	const std::string& local_path = vfs::get(path.get_ptr());
-
-	if (local_path.empty())
-	{
-		return {CELL_ENOENT, path};
-	}
 
 	fs::stat_t info;
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -199,7 +199,7 @@ error_code sys_fs_open(vm::cptr<char> path, s32 flags, vm::ptr<u32> fd, s32 mode
 
 	if (local_path.empty())
 	{
-		return {CELL_ENOTMOUNTED, path};
+		return {CELL_ENOENT, path};
 	}
 
 	// TODO: other checks for path
@@ -421,7 +421,7 @@ error_code sys_fs_opendir(vm::cptr<char> path, vm::ptr<u32> fd)
 
 	if (local_path.empty())
 	{
-		return {CELL_ENOTMOUNTED, path};
+		return {CELL_ENOENT, path};
 	}
 
 	// TODO: other checks for path
@@ -500,7 +500,7 @@ error_code sys_fs_stat(vm::cptr<char> path, vm::ptr<CellFsStat> sb)
 
 	if (local_path.empty())
 	{
-		return {CELL_ENOTMOUNTED, path};
+		return {CELL_ENOENT, path};
 	}
 
 	fs::stat_t info;


### PR DESCRIPTION
Detailed issue report: https://github.com/RPCS3/rpcs3/issues/3327

Fixes some games which try to access a non-existing file,
and hang caused by CELL_ENOTMOUNTED being returned wrongly.

Uncharted 2 and TLOU demos get further now.