### PR TITLE
Various fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_net.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_net.cpp
@@ -581,7 +581,7 @@ namespace sys_net
 #ifdef _WIN32
 			case OP_SO_NBIO:
 			{
-				unsigned long mode = *(unsigned long*)optval.get_ptr();
+				u_long mode = *static_cast<const be_t<u32>*>(optval.get_ptr());
 				ret = ioctlsocket(sock->s, FIONBIO, &mode);
 				break;
 			}
@@ -606,38 +606,38 @@ namespace sys_net
 #endif
 			case OP_SO_SNDBUF:
 			{
-				u32 sendbuff = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_SNDBUF, (const char*)&sendbuff, sizeof(sendbuff));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_SNDBUF, (const char*)&param, sizeof(param));
 				break;
 			}
 			case OP_SO_RCVBUF:
 			{
-				u32 recvbuff = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_RCVBUF, (const char*)&recvbuff, sizeof(recvbuff));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_RCVBUF, (const char*)&param, sizeof(param));
 				break;
 			}
 			case OP_SO_SNDTIMEO:
 			{
-				u32 sendtimeout = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_SNDTIMEO, (char*)&sendtimeout, sizeof(sendtimeout));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_SNDTIMEO, (const char*)&param, sizeof(param));
 				break;
 			}
 			case OP_SO_RCVTIMEO:
 			{
-				u32 recvtimeout = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_RCVTIMEO, (char*)&recvtimeout, sizeof(recvtimeout));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_RCVTIMEO, (const char*)&param, sizeof(param));
 				break;
 			}
 			case OP_SO_SNDLOWAT:
 			{
-				u32 sendlowmark = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_SNDLOWAT, (char*)&sendlowmark, sizeof(sendlowmark));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_SNDLOWAT, (const char*)&param, sizeof(param));
 				break;
 			}
 			case OP_SO_RCVLOWAT:
 			{
-				u32 recvlowmark = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_RCVLOWAT, (char*)&recvlowmark, sizeof(recvlowmark));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_RCVLOWAT, (const char*)&param, sizeof(param));
 				break;
 			}
 			case  OP_SO_USECRYPTO:
@@ -654,14 +654,14 @@ namespace sys_net
 			}
 			case OP_SO_BROADCAST:
 			{
-				u32 enablebroadcast = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_BROADCAST, (char*)&enablebroadcast, sizeof(enablebroadcast));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_BROADCAST, (const char*)&param, sizeof(param));
 				break;
 			}
 			case OP_SO_REUSEADDR:
 			{
-				u32 reuseaddr = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_REUSEADDR, (char*)&reuseaddr, sizeof(reuseaddr));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, SOL_SOCKET, SO_REUSEADDR, (const char*)&param, sizeof(param));
 				break;
 			}
 			default:
@@ -675,11 +675,11 @@ namespace sys_net
 			case OP_TCP_NODELAY:
 			{
 #ifdef _WIN32
-				const char delay = *(char*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, IPPROTO_TCP, TCP_NODELAY, &delay, sizeof(delay));
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, IPPROTO_TCP, TCP_NODELAY, (const char*)&param, sizeof(param));
 #else
-				u32 delay = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, IPPROTO_TCP, TCP_NODELAY, &delay, optlen);
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, IPPROTO_TCP, TCP_NODELAY, (const char*)&param, sizeof(param));
 #endif
 				break;
 			}
@@ -689,8 +689,8 @@ namespace sys_net
 #ifdef _WIN32
 				libnet.warning("TCP_MAXSEG can't be set on Windows.");
 #else
-				u32 maxseg = *(u32*)optval.get_ptr();
-				ret = ::setsockopt(sock->s, IPPROTO_TCP, TCP_MAXSEG, &maxseg, optlen);
+				const u32 param = *static_cast<const be_t<u32>*>(optval.get_ptr());
+				ret = ::setsockopt(sock->s, IPPROTO_TCP, TCP_MAXSEG, (const char*)&param, sizeof(param));
 #endif
 				break;
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_tty.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_tty.cpp
@@ -23,20 +23,20 @@ error_code sys_tty_write(s32 ch, vm::cptr<char> buf, u32 len, vm::ptr<u32> pwrit
 	{
 		return CELL_EINVAL;
 	}
+	
+	const u32 written_len = static_cast<s32>(len) > 0 ? len : 0;
 
-	if (static_cast<s32>(len) <= 0)
-	{
-		*pwritelen = 0;
-
-		return CELL_OK;
-	}
-
-	if (g_tty)
+	if (written_len > 0 && g_tty)
 	{
 		g_tty.write(buf.get_ptr(), len);
 	}
+	
+	if (!pwritelen)
+	{
+		return CELL_EFAULT;
+	}
 
-	*pwritelen = len;
-
+	*pwritelen = written_len;
+	
 	return CELL_OK;
 }


### PR DESCRIPTION
- Fix crash in sys_tty_write() if the return buffer for the written length is NULL. Resident Evil 5 demo does this.

- ~~On Windows, pass the given file access modifiers like the Linux code. Dark Souls II creates a temporary file with write and append modifier, then tries to truncate the file. This needs GENERIC_WRITE.~~ Obsoleted by #3391.

- Endianess for the parameter buffer in setsockopt was not converted before passing the value on to the native function. Actually I don't know if converting the endianess is really necessary or if a true/false check with conversion to 1/0 would be enough or better. The value of these parameters can only be 0 or 1. This might break some games not because it is wrong but because they might not error out of the net code as early as now.