### PR TITLE
GUI: Fix "recent games" layout bug

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -712,7 +712,7 @@ bool game_list_frame::Boot(const GameInfo& game)
 	}
 	else
 	{
-		Q_EMIT RequestAddRecentGame(q_string_pair(qstr(Emu.GetBoot()), qstr("[" + game.serial + "] " + game.name)));
+		Q_EMIT RequestAddRecentGame(GUI::Recent_Game(qstr(Emu.GetBoot()), qstr("[" + game.serial + "] " + game.name)));
 		Refresh(true);
 		return true;
 	}
@@ -939,8 +939,7 @@ int game_list_frame::PopulateGameList()
 	auto l_GetItem = [](const std::string& text)
 	{
 		// force single line text ("hack" used instead of Qt shenanigans like Qt::TextSingleLine)
-		QString formattedText = qstr(text);
-		formattedText.replace("\n", " - ");
+		QString formattedText = GUI::get_Single_Line(qstr(text));
 
 		QTableWidgetItem* curr = new QTableWidgetItem;
 		curr->setFlags(curr->flags() & ~Qt::ItemIsEditable);
@@ -1053,8 +1052,7 @@ void game_list_frame::PopulateGameGrid(uint maxCols, const QSize& image_size, co
 
 		if (category == category::hdd_Game || category == category::disc_Game)
 		{
-			QString title = qstr(m_game_data[i].info.name);
-			title.replace("\n", " - ");
+			QString title = GUI::get_Single_Line(qstr(m_game_data[i].info.name));
 
 			m_xgrid->addItem(m_game_data[i].pxmap, title, i, r, c);
 

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -63,6 +63,18 @@ namespace GUI
 		return dummy_color.palette().color(colorRole);
 	};
 
+	inline QString get_Single_Line(const QString& multi_line_string)
+	{
+		QString single_line_string = multi_line_string;
+		single_line_string.replace("\n"," ");
+		return single_line_string;
+	}
+
+	inline q_string_pair Recent_Game(const QString& path, const QString& title)
+	{
+		return q_string_pair(path, get_Single_Line(title));
+	}
+
 	const QString Default     = QObject::tr("default");
 	const QString main_window = "main_window";
 	const QString game_list   = "GameList";

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -273,7 +273,7 @@ void main_window::BootElf()
 		LOG_SUCCESS(LOADER, "(S)ELF: boot done.");
 
 		const std::string serial = Emu.GetTitleID().empty() ? "" : "[" + Emu.GetTitleID() + "] ";
-		AddRecentAction(q_string_pair(qstr(Emu.GetBoot()), qstr(serial + Emu.GetTitle())));
+		AddRecentAction(GUI::Recent_Game(qstr(Emu.GetBoot()), qstr(serial + Emu.GetTitle())));
 		gameListFrame->Refresh(true);
 	}
 }
@@ -310,7 +310,7 @@ void main_window::BootGame()
 		LOG_SUCCESS(LOADER, "Boot Game: boot done.");
 
 		const std::string serial = Emu.GetTitleID().empty() ? "" : "[" + Emu.GetTitleID() + "] ";
-		AddRecentAction(q_string_pair(qstr(Emu.GetBoot()), qstr(serial + Emu.GetTitle())));
+		AddRecentAction(GUI::Recent_Game(qstr(Emu.GetBoot()), qstr(serial + Emu.GetTitle())));
 		gameListFrame->Refresh(true);
 	}
 }
@@ -936,7 +936,7 @@ void main_window::BootRecentAction(const QAction* act)
 	else
 	{
 		LOG_SUCCESS(LOADER, "Boot from Recent List: done");
-		AddRecentAction(q_string_pair(qstr(Emu.GetBoot()), nam));
+		AddRecentAction(GUI::Recent_Game(qstr(Emu.GetBoot()), nam));
 		gameListFrame->Refresh(true);
 	}
 };
@@ -1447,6 +1447,9 @@ void main_window::ConfigureGuiFromSettings(bool configureAll)
 	// Fill the recent games menu
 	for (int i = 0; i < m_rg_entries.count(); i++)
 	{
+		// adjust old unformatted entries (avoid duplication)
+		m_rg_entries[i] = GUI::Recent_Game(m_rg_entries[i].first, m_rg_entries[i].second);
+
 		// create new action
 		QAction* act = CreateRecentAction(m_rg_entries[i], i + 1);
 


### PR DESCRIPTION
use single line titles in gamelist and recent games menu

before:

![image](https://user-images.githubusercontent.com/23019877/30150163-a29b7cd2-93aa-11e7-9d9f-032d3aa2845b.png)

after:

![image](https://user-images.githubusercontent.com/23019877/30150133-8f838644-93aa-11e7-87d8-69dbea9e618f.png)