### PR TITLE
[Qt/OpenGL/AMD]: fix gamepad settings layout issue, add refresh button / fix amd openGL Emu stop bug

### DIFF
--- a/rpcs3/keyboard_pad_handler.cpp
+++ b/rpcs3/keyboard_pad_handler.cpp
@@ -20,7 +20,7 @@ keyboard_pad_handler::keyboard_pad_handler() : QObject()
 
 void keyboard_pad_handler::ConfigController(std::string device)
 {
-	pad_settings_dialog dlg(this);
+	pad_settings_dialog dlg;
 	dlg.exec();
 }
 

--- a/rpcs3/rpcs3qt/gamepads_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/gamepads_settings_dialog.cpp
@@ -54,7 +54,34 @@ gamepads_settings_dialog::gamepads_settings_dialog(QWidget* parent)
 		resizeComboBoxView(combo);
 	};
 
-	for (int i = 0; i < 7; i++)
+	auto configure_combos = [=]
+	{
+		//Set the values from config
+		for (int i = 0; i < MAX_PLAYERS; i++)
+		{
+			for (int j = 0; j < co_inputtype[i]->count(); j++)
+			{
+				if (co_inputtype[i]->itemText(j).toStdString() == input_cfg.player_input[i].to_string())
+				{
+					co_inputtype[i]->setCurrentIndex(j);
+					ChangeInputType(i);
+					break;
+				}
+			}
+
+			for (int j = 0; j < co_deviceID[i]->count(); j++)
+			{
+				if (co_deviceID[i]->itemText(j).toStdString() == input_cfg.player_device[i]->to_string())
+				{
+					co_deviceID[i]->setCurrentIndex(j);
+					ChangeDevice(i);
+					break;
+				}
+			}
+		}
+	};
+
+	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
 		QGroupBox *grp_player = new QGroupBox(QString(tr("Player %1").arg(i+1)));
 
@@ -101,8 +128,10 @@ gamepads_settings_dialog::gamepads_settings_dialog(QWidget* parent)
 
 	QHBoxLayout *buttons_layout = new QHBoxLayout();
 	QPushButton *ok_button = new QPushButton(tr("OK"));
-	buttons_layout->addWidget(ok_button);
 	QPushButton *cancel_button = new QPushButton(tr("Cancel"));
+	QPushButton *refresh_button = new QPushButton(tr("Refresh"));
+	buttons_layout->addWidget(ok_button);
+	buttons_layout->addWidget(refresh_button);
 	buttons_layout->addWidget(cancel_button);
 	buttons_layout->addStretch();
 	dialog_layout->addLayout(buttons_layout);
@@ -110,31 +139,9 @@ gamepads_settings_dialog::gamepads_settings_dialog(QWidget* parent)
 	setLayout(dialog_layout);
 	layout()->setSizeConstraint(QLayout::SetFixedSize);
 
-	//Set the values from config
-	for (int i = 0; i < 7; i++)
-	{
-		for (int j = 0; j < co_inputtype[i]->count(); j++)
-		{
-			if (co_inputtype[i]->itemText(j).toStdString() == input_cfg.player_input[i].to_string())
-			{
-				co_inputtype[i]->setCurrentIndex(j);
-				ChangeInputType(i);
-				break;
-			}
-		}
+	configure_combos();
 
-		for (int j = 0; j < co_deviceID[i]->count(); j++)
-		{
-			if (co_deviceID[i]->itemText(j).toStdString() == input_cfg.player_device[i]->to_string())
-			{
-				co_deviceID[i]->setCurrentIndex(j);
-				ChangeDevice(i);
-				break;
-			}
-		}
-	}
-
-	for (int i = 0; i < 7; i++)
+	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
 		connect(co_inputtype[i], &QComboBox::currentTextChanged, [=] { ChangeInputType(i); });
 		connect(co_deviceID[i], &QComboBox::currentTextChanged, [=] { ChangeDevice(i); });
@@ -142,12 +149,13 @@ gamepads_settings_dialog::gamepads_settings_dialog(QWidget* parent)
 	}
 	connect(ok_button, &QPushButton::pressed, this, &gamepads_settings_dialog::SaveExit);
 	connect(cancel_button, &QPushButton::pressed, this, &gamepads_settings_dialog::CancelExit);
+	connect(refresh_button, &QPushButton::pressed, [=] { configure_combos(); });
 }
 
 void gamepads_settings_dialog::SaveExit()
 {
 	//Check for invalid selection
-	for (int i = 0; i < 7; i++)
+	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
 		if (co_deviceID[i]->currentData() == -1)
 		{

--- a/rpcs3/rpcs3qt/gamepads_settings_dialog.h
+++ b/rpcs3/rpcs3qt/gamepads_settings_dialog.h
@@ -5,6 +5,7 @@
 #include <QGroupBox>
 #include <QComboBox>
 #include <QPushButton>
+#include <QListView>
 
 #include "../Emu/System.h"
 #include "../../Utilities/Config.h"

--- a/rpcs3/rpcs3qt/gamepads_settings_dialog.h
+++ b/rpcs3/rpcs3qt/gamepads_settings_dialog.h
@@ -60,6 +60,8 @@ extern input_config input_cfg;
 
 class gamepads_settings_dialog : public QDialog
 {
+	const int MAX_PLAYERS = 7;
+
 protected:
 	std::shared_ptr<PadHandlerBase> GetHandler(pad_handler type);
 	void ChangeInputType(int player);

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -42,7 +42,7 @@ void gl_gs_frame::set_current(draw_context_t ctx)
 
 void gl_gs_frame::delete_context(void* ctx)
 {
-	delete (QOpenGLContext*)ctx;
+	((QOpenGLContext*)ctx)->deleteLater();
 }
 
 void gl_gs_frame::flip(draw_context_t context, bool skip_frame)

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -15,7 +15,6 @@
 #include "debugger_frame.h"
 #include "log_frame.h"
 #include "settings_dialog.h"
-#include "pad_settings_dialog.h"
 #include "auto_pause_settings_dialog.h"
 #include "cg_disasm_window.h"
 #include "memory_string_searcher.h"

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -18,7 +18,7 @@ static const int PadButtonWidth = 60;
 
 extern keyboard_pad_config g_kbpad_config;
 
-pad_settings_dialog::pad_settings_dialog(keyboard_pad_handler *keyhandler, QWidget *parent) : QDialog(parent), ui(new Ui::pad_settings_dialog)
+pad_settings_dialog::pad_settings_dialog(QWidget *parent) : QDialog(parent), ui(new Ui::pad_settings_dialog)
 {
 	ui->setupUi(this);
 
@@ -62,15 +62,17 @@ pad_settings_dialog::pad_settings_dialog(keyboard_pad_handler *keyhandler, QWidg
 	padButtons->addButton(ui->b_ok, 26);
 	padButtons->addButton(ui->b_cancel, 27);
 
-	connect(padButtons, SIGNAL(buttonClicked(int)), this, SLOT(OnPadButtonClicked(int)));
+	connect(padButtons, static_cast<void(QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), this, &pad_settings_dialog::OnPadButtonClicked);
 
 	g_kbpad_config.load();
 	UpdateLabel();
 
 	gui_settings settings(this);
 
+	// repaint and resize controller image
 	ui->l_controller->setPixmap(settings.colorizedPixmap(*ui->l_controller->pixmap(), QColor(), GUI::get_Label_Color("l_controller"), false, true));
 	ui->l_controller->setMaximumSize(ui->gb_description->sizeHint().width(), ui->l_controller->maximumHeight() * ui->gb_description->sizeHint().width() / ui->l_controller->maximumWidth());
+
 	layout()->setSizeConstraint(QLayout::SetFixedSize);
 }
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -65,12 +65,10 @@ private:
 	u32 m_seconds;
 	u32 m_button_id;
 	bool m_key_pressed;
-	QAction *onButtonClickedAct;
 	Ui::pad_settings_dialog *ui;
-	keyboard_pad_handler* keyhdlr;
 
 public:
-	explicit pad_settings_dialog(keyboard_pad_handler* keyhandler, QWidget *parent = nullptr);
+	explicit pad_settings_dialog(QWidget *parent = nullptr);
 	~pad_settings_dialog();
 	void keyPressEvent(QKeyEvent *keyEvent) override;
 	void UpdateLabel();


### PR DESCRIPTION
should fix this:

![image](https://user-images.githubusercontent.com/23019877/30238117-167cc95c-9541-11e7-8894-23c922026a11.png)

It cuts off the last part though. I hope it is okay. (as in: DragonRise Inc. Gene...)

![image](https://user-images.githubusercontent.com/23019877/30238711-86f4e1dc-954c-11e7-8e41-0563c371890c.png)
