### PR TITLE
VS build: copy Qt5WinExtras.dll to bin directory

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -169,6 +169,7 @@
         xcopy "$(QTDIR)\bin\Qt5Core.dll" "$(OutDir)" /d
         xcopy "$(QTDIR)\bin\Qt5Gui.dll" "$(OutDir)" /d
         xcopy "$(QTDIR)\bin\Qt5Widgets.dll" "$(OutDir)" /d
+        xcopy "$(QTDIR)\bin\Qt5WinExtras.dll" "$(OutDir)" /d
       </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -223,6 +224,7 @@
         xcopy "$(QTDIR)\bin\Qt5Core.dll" "$(OutDir)" /d
         xcopy "$(QTDIR)\bin\Qt5Gui.dll" "$(OutDir)" /d
         xcopy "$(QTDIR)\bin\Qt5Widgets.dll" "$(OutDir)" /d
+        xcopy "$(QTDIR)\bin\Qt5WinExtras.dll" "$(OutDir)" /d
       </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -278,6 +280,7 @@
         xcopy "$(QTDIR)\bin\Qt5Cored.dll" "$(OutDir)" /d
         xcopy "$(QTDIR)\bin\Qt5Guid.dll" "$(OutDir)" /d
         xcopy "$(QTDIR)\bin\Qt5Widgetsd.dll" "$(OutDir)" /d
+        xcopy "$(QTDIR)\bin\Qt5WinExtrasd.dll" "$(OutDir)" /d
       </Command>
     </PostBuildEvent>
     <PostBuildEvent>
@@ -333,6 +336,7 @@
         xcopy "$(QTDIR)\bin\Qt5Cored.dll" "$(OutDir)" /d
         xcopy "$(QTDIR)\bin\Qt5Guid.dll" "$(OutDir)" /d
         xcopy "$(QTDIR)\bin\Qt5Widgetsd.dll" "$(OutDir)" /d
+        xcopy "$(QTDIR)\bin\Qt5WinExtrasd.dll" "$(OutDir)" /d
       </Command>
     </PostBuildEvent>
     <PostBuildEvent>


### PR DESCRIPTION
When building RPCS3 on Visual Studio, there's some DLLs that are copied
from the local QT installation to the RPCS3's output directory using a
post-build script. However, one of these DLL was missing, which is
required for running the program on debug mode (for release versions,
the file is already present on git).

This commit just add the additional command that is needed to copy the
file.