### PR TITLE
LLVM:: If the loop is never entered, then the JIT is null.

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1239,10 +1239,10 @@ extern void ppu_initialize(const ppu_module& info)
 		return;
 	}
 
-	if (jit_mod.vars.empty())
-	{
+	// Jit can be null if the loop doesn't ever enter.
+	if (jit && jit_mod.vars.empty())
+	{	
 		jit->fin();
-
 		// Get and install function addresses
 		for (const auto& func : info.funcs)
 		{


### PR DESCRIPTION
I'm not sure if it's correct to surround the ->fin call with an if block, or to do as I done.

But, this should prevent the crashes that happens with many games with LLVM.