### PR TITLE
Fix Hamilton's Great Adventure

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -230,6 +230,12 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 
 	auto m_sysrsx = fxm::get<SysRsxConfig>();
 
+	if (!m_sysrsx)
+	{
+		sys_rsx.error("sys_rsx_context_attribute called before sys_rsx_context_allocate: context_id=0x%x, package_id=0x%x, a3=0x%llx, a4=0x%llx, a5=0x%llx, a6=0x%llx)", context_id, package_id, a3, a4, a5, a6);
+		return CELL_EINVAL;
+	}
+
 	auto &driverInfo = vm::_ref<RsxDriverInfo>(m_sysrsx->driverInfo);
 	switch (package_id)
 	{


### PR DESCRIPTION
This game calls sys_rsx_context_attribute before sys_rsx_memory_allocate.  This inevitably causes a crash.  So, I return that the resource doesn't exist.  Doesn't seem like a race condition because the main thread asks for the context before the rendering thread is even created. Could be wrong though so I left that in as a comment.