### PR TITLE
Added an error for if the user attempts to open two instances of rpcs3

### DIFF
--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -287,6 +287,7 @@ void logs::message::broadcast(const char* fmt, const fmt_type_info* sup, const u
 }
 
 [[noreturn]] extern void catch_all_exceptions();
+extern void basic_error(const std::string& msg);
 
 logs::file_writer::file_writer(const std::string& name)
 	: m_name(fs::get_config_dir() + name)
@@ -311,6 +312,11 @@ logs::file_writer::file_writer(const std::string& name)
 
 		// Rotate backups (TODO)
 		fs::rename(m_name + ".gz", m_name + "1.gz", true);
+	}
+	//This will catch if RPCS3.log is already open
+	catch (const std::runtime_error& e)
+	{
+		basic_error("A runtime error occured.\nEither RPCS3.log is write-protected or an instance of RPCS3.exe is already running.");
 	}
 	catch (...)
 	{

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -54,6 +54,21 @@ static void report_fatal_error(const std::string& msg)
 #endif
 }
 
+void basic_error(const std::string& msg)
+{
+#ifdef _WIN32
+	const std::size_t buf_size = msg.size() + 1;
+	const int size = static_cast<int>(buf_size);
+	std::unique_ptr<wchar_t[]> buffer(new wchar_t[buf_size]);
+	MultiByteToWideChar(CP_UTF8, 0, msg.c_str(), size, buffer.get(), size);
+
+	if (MessageBoxW(0, buffer.get(), L"Error", MB_ICONERROR | MB_OK))
+	{}
+#else
+	std::printf("Error: \n%s", _msg.c_str());
+#endif
+}
+
 [[noreturn]] void catch_all_exceptions()
 {
 	try


### PR DESCRIPTION
Currently opening RPCS3 twice will give a fatal error as Log.cpp will not be able to access RPCS3.log , as it's in use by the other instance. This is expected behaviour though, so I added a less alarming error which just tells the user what the issue is, without suggesting they ask for help.

I do need feedback on this pr though, I'm quite unsure about basic_errors placement.
