### PR TITLE
Vulkan: use pkg-config instead of checking for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,20 +76,23 @@ When using GDB, configure it to ignore SIGSEGV signal (`handle SIGSEGV nostop no
 
 ## CMake Build Options (Linux & Mac OS)
 
-- ```-DUSE_SYSTEM_LIBPNG=ON/OFF``` (default = *OFF*) </br>
+- ```-DUSE_SYSTEM_LIBPNG=ON/OFF``` (default = *OFF*)  
 Build against the shared libpng instead of using the builtin one. libpng 1.6+ highly recommended. Try this option if you get version conflict errors or only see black game icons.
 
-- ```-DUSE_SYSTEM_FFMPEG=ON/OFF``` (default = *OFF*) </br>
+- ```-DUSE_SYSTEM_FFMPEG=ON/OFF``` (default = *OFF*)  
 Build against the shared ffmpeg libraries instead of using the builtin patched version. Try this if the builtin version breaks the OpenGL renderer for you.
 
-- ```-DUSE_SHARED_LLVM_LIBS=ON/OFF``` (default = *OFF*) </br>
+- ```-DUSE_SHARED_LLVM_LIBS=ON/OFF``` (default = *OFF*)  
 This builds against the shared LLVM libs, rather than the static ones. This may interfere with Mesa and render RPCS3 non-functional. Only recommended on gentoo.
 
-- ```-DWITHOUT_LLVM=ON/OFF``` (default = *OFF*) </br>
+- ```-DWITHOUT_LLVM=ON/OFF``` (default = *OFF*)  
 This forces RPCS3 to build without LLVM, not recommended.
 
-- ```-DWITH_GDB=ON/OFF``` (default = *OFF*) </br>
-This Builds RPCS3 with support for debugging PS3 games using gdb."
+- ```-DWITH_GDB=ON/OFF``` (default = *OFF*)  
+This Builds RPCS3 with support for debugging PS3 games using gdb.
+
+- ```-DUSE_VULKAN=ON/OFF``` (default = *ON*)  
+This builds RPCS3 with Vulkan support.
 
 ## License
 

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -140,15 +140,17 @@ else()
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS /DYNAMICBASE:NO /BASE:0x10000 /FIXED")
 endif()
 
+set(ADDITIONAL_LIBS "")
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	#on some Linux distros shm_unlink and similar functions are in librt only
-	set(ADDITIONAL_LIBS "rt" "X11")
+	set(ADDITIONAL_LIBS ${ADDITIONAL_LIBS} "rt")
 elseif(NOT MSVC AND NOT CMAKE_CXX_FLAGS MATCHES "LIBICONV_PLUG")
 	#it seems like glibc includes the iconv functions we use but other libc
 	#implementations like the one on OSX don't seem implement them
-	set(ADDITIONAL_LIBS "iconv")
-else()
-	set(ADDITIONAL_LIBS "")
+	set(ADDITIONAL_LIBS ${ADDITIONAL_LIBS} "iconv")
+endif()
+if(UNIX AND NOT APPLE)
+	set(ADDITIONAL_LIBS ${ADDITIONAL_LIBS} "X11")
 endif()
 
 if(NOT RPCS3_SRC_DIR)
@@ -176,6 +178,7 @@ else()
 	option(USE_ALSA "ALSA audio backend" ON)
   option(USE_PULSE "PulseAudio audio backend" ON)
 	option(USE_LIBEVDEV "libevdev-based joystick support" ON)
+	option(USE_VULKAN "Vulkan render backend" ON)
 endif()
 
 if(USE_ALSA)
@@ -203,6 +206,15 @@ if(USE_LIBEVDEV)
 		add_definitions(-DHAVE_LIBEVDEV)
 		include_directories(SYSTEM ${LIBEVDEV_INCLUDE_DIRS})
 		list(APPEND ADDITIONAL_LIBS ${LIBEVDEV_LDFLAGS})
+	endif()
+endif()
+if(NOT WIN32 AND USE_VULKAN)
+	find_package(Vulkan)
+	if(VULKAN_FOUND)
+		add_definitions(-DHAVE_VULKAN)
+		list(APPEND ADDITIONAL_LIBS ${VULKAN_LIBRARY})
+	else()
+		message("WARNING! USE_VULKAN was enabled, but libvulkan was not found. RPCS3 will be compiled without Vulkan support.")
 	endif()
 endif()
 
@@ -304,7 +316,7 @@ RPCS3_SRC
 "${RPCS3_SRC_DIR}/../asmjit/src/asmjit/*.cpp"
 )
 
-if (NOT WIN32 AND "${CMAKE_SYSTEM}" MATCHES "Linux")
+if (NOT WIN32 AND VULKAN_FOUND)
 # Compile glslang and SPIRV modules needed for glsl compilation
 	file(
 	GLOB_RECURSE
@@ -322,8 +334,7 @@ endif()
 
 #File exclusion section
 
-#Ignore vulkan if not on windows or linux
-if(NOT WIN32 AND NOT "${CMAKE_SYSTEM}" MATCHES "Linux")
+if(NOT WIN32 AND NOT VULKAN_FOUND)
 	set (EXCLUDE_FILES "/RSX/VK/")
 endif()
 
@@ -366,9 +377,12 @@ else()
 	if(APPLE)
 		target_link_libraries(rpcs3 hidapi-mac "-framework CoreFoundation" "-framework IOKit")
 	elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-		target_link_libraries(rpcs3 hidapi-hidraw udev vulkan)
+		target_link_libraries(rpcs3 hidapi-hidraw udev)
 	else()
 		target_link_libraries(rpcs3 hidapi-libusb usb)
+	endif()
+	if(VULKAN_FOUND)
+		target_link_libraries(rpcs3 ${VULKAN_LIBRARIES})
 	endif()
 	target_link_libraries(rpcs3 ${CMAKE_DL_LIBS} -lpthread ${ZLIB_LIBRARIES} ${ADDITIONAL_LIBS})
 	if (USE_SYSTEM_FFMPEG)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -500,7 +500,7 @@ VKGSRender::VKGSRender() : GSRender()
 		m_swap_chain = m_thread_context.createSwapChain(hInstance, hWnd, gpus[0]);
 	}
 	
-#elif __linux__
+#elif HAVE_VULKAN
 
 	Window window = (Window)m_frame->handle();
 	Display *display = XOpenDisplay(0);
@@ -722,7 +722,7 @@ VKGSRender::~VKGSRender()
 
 	delete m_swap_chain;
 	
-#ifdef __linux__
+#if !defined(_WIN32) && defined(HAVE_VULKAN)
 	if (m_display_handle)
 		XCloseDisplay(m_display_handle);
 #endif

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -249,7 +249,7 @@ private:
 	//Vertex layout
 	rsx::vertex_input_layout m_vertex_layout;
 	
-#ifdef __linux__
+#if !defined(_WIN32) && defined(HAVE_VULKAN)
 	Display *m_display_handle = nullptr;
 #endif
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1247,7 +1247,7 @@ namespace vk
 
 			VkSurfaceKHR surface;
 			CHECK_RESULT(vkCreateWin32SurfaceKHR(m_instance, &createInfo, NULL, &surface));
-#elif __linux__
+#elif HAVE_VULKAN
 		
 		vk::swap_chain* createSwapChain(Display *display, Window window, vk::physical_device &dev)
 		{

--- a/rpcs3/cmake_modules/FindVulkan.cmake
+++ b/rpcs3/cmake_modules/FindVulkan.cmake
@@ -1,0 +1,18 @@
+# Find Vulkan
+
+find_package(PkgConfig)
+pkg_check_modules(PC_VULKAN vulkan)
+
+# RPCS3 ships with the SDK headers
+# find_path(VULKAN_INCLUDE_DIR
+#   NAMES vulkan/vulkan.h
+#   HINTS ${PC_VULKAN_INCLUDE_DIR} ${PC_VULKAN_INCLUDE_DIRS})
+
+find_library(VULKAN_LIBRARY
+  NAMES vulkan
+  HINTS ${PC_VULKAN_LIBRARY} ${PC_VULKAN_LIBRARY_DIRS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Vulkan DEFAULT_MSG VULKAN_LIBRARY)
+
+mark_as_advanced(VULKAN_LIBRARY VULKAN_INCLUDE_DIR)

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -41,7 +41,7 @@
 #ifdef _MSC_VER
 #include "Emu/RSX/D3D12/D3D12GSRender.h"
 #endif
-#if defined(_WIN32) || defined(__linux__)
+#if defined(_WIN32) || defined(HAVE_VULKAN)
 #include "Emu/RSX/VK/VKGSRender.h"
 #endif
 #ifdef _WIN32
@@ -201,7 +201,7 @@ void rpcs3_app::InitializeCallbacks()
 		{
 		case video_renderer::null: return std::make_shared<NullGSRender>();
 		case video_renderer::opengl: return std::make_shared<GLGSRender>();
-#if defined(_WIN32) || defined(__linux__)
+#if defined(_WIN32) || defined(HAVE_VULKAN)
 		case video_renderer::vulkan: return std::make_shared<VKGSRender>();
 #endif
 #ifdef _MSC_VER

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -12,7 +12,7 @@
 #include <dxgi1_4.h>
 #endif
 
-#if defined(_WIN32) || defined(__linux__)
+#if defined(_WIN32) || defined(HAVE_VULKAN)
 #include "Emu/RSX/VK/VKHelpers.h"
 #endif
 
@@ -143,7 +143,7 @@ Render_Creator::Render_Creator()
 	}
 #endif
 
-#if defined(WIN32) || defined(__linux__)
+#if defined(WIN32) || defined(HAVE_VULKAN)
 	// check for vulkan adapters
 	vk::context device_enum_context;
 	u32 instance_handle = device_enum_context.createInstance("RPCS3", true);


### PR DESCRIPTION
Makes Vulkan optional on Linux / makes it possible on FreeBSD. When the `USE_VULKAN` flag is on, finds the Vulkan loader using pkg-config, and uses it if it's been found.

Also `libX11` is now linked on any non-Apple Unix. It was necessary on FreeBSD.

![screen_2017-09-10-20 59 19](https://user-images.githubusercontent.com/208340/30394039-8fe3b800-98ca-11e7-8c92-6a920d4e00b8.png)

^^^ my FreeBSD desktop running Crazy Taxi, with RADV/amdgpu. ([drm-next-kmod](https://www.freshports.org/graphics/drm-next-kmod), ports patches: [Vulkan Mesa drivers](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=221540) + [Vulkan loader](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=222175), hopefully will be merged soon :D)