### PR TITLE
[Qt] graphixes

### DIFF
--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -19,6 +19,7 @@ struct Render_Creator
 	bool supportsVulkan = false;
 	QStringList D3D12Adapters;
 	QStringList vulkanAdapters;
+	QString render_Null = QObject::tr("Null");
 	QString render_Vulkan = QObject::tr("Vulkan");
 	QString render_D3D12 = QObject::tr("D3D12[DO NOT USE]");
 	QString render_OpenGL = QObject::tr("OpenGL");

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -376,26 +376,28 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> xSettings, const 
 	ui->scrictModeRendering->setToolTip(json_gpu_main["scrictModeRendering"].toString());
 
 	// Graphics Adapter
-	QStringList D3D12Adapters = r_Creator.D3D12Adapters;
-	QStringList vulkanAdapters = r_Creator.vulkanAdapters;
-	bool supportsD3D12 = r_Creator.supportsD3D12;
-	bool supportsVulkan = r_Creator.supportsVulkan;
-	QString r_D3D12 = r_Creator.render_D3D12;
-	QString r_Vulkan = r_Creator.render_Vulkan;
-	QString r_OpenGL = r_Creator.render_OpenGL;
-	QString old_D3D12;
-	QString old_Vulkan;
+	m_D3D12 = Render_Info(r_Creator.render_D3D12, r_Creator.D3D12Adapters, r_Creator.supportsD3D12, emu_settings::D3D12Adapter);
+	m_Vulkan = Render_Info(r_Creator.render_Vulkan, r_Creator.vulkanAdapters, r_Creator.supportsVulkan, emu_settings::VulkanAdapter);
+	m_OpenGL = Render_Info(r_Creator.render_OpenGL);
+	m_NullRender = Render_Info(r_Creator.render_Null);
 
-	if (supportsD3D12)
+	std::vector<Render_Info*> Render_List = { &m_D3D12, &m_Vulkan, &m_OpenGL, &m_NullRender };
+
+	// Remove renderers from the renderer Combobox if not supported
+	for (auto renderer : Render_List)
 	{
-		old_D3D12 = qstr(xemu_settings->GetSetting(emu_settings::D3D12Adapter));
-	}
-	else
-	{
-		// Remove D3D12 option from render combobox
+		if (renderer->supported)
+		{
+			if (renderer->has_adapters)
+			{
+				renderer->old_adapter = qstr(xemu_settings->GetSetting(renderer->type));
+			}
+			continue;
+		}
+
 		for (int i = 0; i < ui->renderBox->count(); i++)
 		{
-			if (ui->renderBox->itemText(i) == r_D3D12)
+			if (ui->renderBox->itemText(i) == renderer->name)
 			{
 				ui->renderBox->removeItem(i);
 				break;
@@ -403,112 +405,60 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> xSettings, const 
 		}
 	}
 
-	if (supportsVulkan)
-	{
-		old_Vulkan = qstr(xemu_settings->GetSetting(emu_settings::VulkanAdapter));
-	}
-	else
-	{
-		// Remove Vulkan option from render combobox
-		for (int i = 0; i < ui->renderBox->count(); i++)
-		{
-			if (ui->renderBox->itemText(i) == r_Vulkan)
-			{
-				ui->renderBox->removeItem(i);
-				break;
-			}
-		}
-	}
+	m_oldRender = ui->renderBox->currentText();
 
-	QString oldRender = ui->renderBox->itemText(ui->renderBox->currentIndex());
-
-	auto switchGraphicsAdapter = [=](int index)
+	auto setRenderer = [=](QString text)
 	{
-		QString render = ui->renderBox->itemText(index);
-		m_isD3D12 = render == r_D3D12;
-		m_isVulkan = render == r_Vulkan;
-		ui->graphicsAdapterBox->setEnabled(m_isD3D12 || m_isVulkan);
+		if (text.isEmpty()) return;
 
-		// D3D Adapter
-		if (m_isD3D12)
+		auto switchTo = [=](Render_Info renderer)
 		{
 			// Reset other adapters to old config
-			if (supportsVulkan)
+			for (const auto& render : Render_List)
 			{
-				xemu_settings->SetSetting(emu_settings::VulkanAdapter, sstr(old_Vulkan));
+				if (renderer.name != render->name && render->has_adapters && render->supported)
+				{
+					xemu_settings->SetSetting(render->type, sstr(render->old_adapter));
+				}
+			}
+			// Fill combobox with placeholder if no adapters needed
+			if (!renderer.has_adapters)
+			{
+				ui->graphicsAdapterBox->clear();
+				ui->graphicsAdapterBox->addItem(tr("Not needed for %1 renderer").arg(text));
+				return;
 			}
 			// Fill combobox
 			ui->graphicsAdapterBox->clear();
-			for (const auto& adapter : D3D12Adapters)
+			for (const auto& adapter : renderer.adapters)
 			{
 				ui->graphicsAdapterBox->addItem(adapter);
 			}
 			// Reset Adapter to old config
-			int idx = ui->graphicsAdapterBox->findText(old_D3D12);
+			int idx = ui->graphicsAdapterBox->findText(renderer.old_adapter);
 			if (idx == -1)
 			{
 				idx = 0;
-				if (old_D3D12.isEmpty())
+				if (renderer.old_adapter.isEmpty())
 				{
-					LOG_WARNING(RSX, "%s adapter config empty: setting to default!", sstr(r_D3D12));
+					LOG_WARNING(RSX, "%s adapter config empty: setting to default!", sstr(renderer.name));
 				}
 				else
 				{
-					LOG_WARNING(RSX, "Last used %s adapter not found: setting to default!", sstr(r_D3D12));
+					LOG_WARNING(RSX, "Last used %s adapter not found: setting to default!", sstr(renderer.name));
 				}
 			}
 			ui->graphicsAdapterBox->setCurrentIndex(idx);
-			xemu_settings->SetSetting(emu_settings::D3D12Adapter, sstr(ui->graphicsAdapterBox->currentText()));
-		}
+			xemu_settings->SetSetting(renderer.type, sstr(ui->graphicsAdapterBox->currentText()));
+		};
 
-		// Vulkan Adapter
-		else if (m_isVulkan)
+		for (auto render : Render_List)
 		{
-			// Reset other adapters to old config
-			if (supportsD3D12)
+			if (render->name == text)
 			{
-				xemu_settings->SetSetting(emu_settings::D3D12Adapter, sstr(old_D3D12));
+				switchTo(*render);
+				ui->graphicsAdapterBox->setEnabled(render->has_adapters);
 			}
-			// Fill combobox
-			ui->graphicsAdapterBox->clear();
-			for (const auto& adapter : vulkanAdapters)
-			{
-				ui->graphicsAdapterBox->addItem(adapter);
-			}
-			// Reset Adapter to old config
-			int idx = ui->graphicsAdapterBox->findText(old_Vulkan);
-			if (idx == -1)
-			{
-				idx = 0;
-				if (old_Vulkan.isEmpty())
-				{
-					LOG_WARNING(RSX, "%s adapter config empty: setting to default!", sstr(r_Vulkan));
-				}
-				else
-				{
-					LOG_WARNING(RSX, "Last used %s adapter not found: setting to default!", sstr(r_Vulkan));
-				}
-			}
-			ui->graphicsAdapterBox->setCurrentIndex(idx);
-			xemu_settings->SetSetting(emu_settings::VulkanAdapter, sstr(ui->graphicsAdapterBox->currentText()));
-		}
-
-		// Other Adapter
-		else
-		{
-			// Reset Adapters to old config
-			if (supportsD3D12)
-			{
-				xemu_settings->SetSetting(emu_settings::D3D12Adapter, sstr(old_D3D12));
-			}
-			if (supportsVulkan)
-			{
-				xemu_settings->SetSetting(emu_settings::VulkanAdapter, sstr(old_Vulkan));
-			}
-
-			// Fill combobox with placeholder
-			ui->graphicsAdapterBox->clear();
-			ui->graphicsAdapterBox->addItem(tr("Not needed for %1 renderer").arg(render));
 		}
 	};
 
@@ -517,35 +467,33 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> xSettings, const 
 		if (text.isEmpty()) return;
 
 		// don't set adapter if signal was created by switching render
-		QString newRender = ui->renderBox->itemText(ui->renderBox->currentIndex());
-		if (m_oldRender == newRender)
-		{
-			if (m_isD3D12 && D3D12Adapters.contains(text))
-			{
-				xemu_settings->SetSetting(emu_settings::D3D12Adapter, sstr(text));
-			}
-			else if (m_isVulkan && vulkanAdapters.contains(text))
-			{
-				xemu_settings->SetSetting(emu_settings::VulkanAdapter, sstr(text));
-			}
-		}
-		else
+		QString newRender = ui->renderBox->currentText();
+		if (m_oldRender != newRender)
 		{
 			m_oldRender = newRender;
+			return;
+		}
+		for (const auto& render : Render_List)
+		{
+			if (render->name == newRender && render->has_adapters && render->adapters.contains(text))
+			{
+				xemu_settings->SetSetting(render->type, sstr(text));
+				break;
+			}
 		}
 	};
 
 	// Init
+	setRenderer(ui->renderBox->currentText());
 	setAdapter(ui->graphicsAdapterBox->currentText());
-	switchGraphicsAdapter(ui->renderBox->currentIndex());
 
 	// Events
 	connect(ui->graphicsAdapterBox, &QComboBox::currentTextChanged, setAdapter);
-	connect(ui->renderBox, static_cast<void (QComboBox::*)(int index)>(&QComboBox::currentIndexChanged), switchGraphicsAdapter);
+	connect(ui->renderBox, &QComboBox::currentTextChanged, setRenderer);
 
 	auto fixGLLegacy = [=](const QString& text)
 	{
-		ui->glLegacyBuffers->setEnabled(text == r_OpenGL);
+		ui->glLegacyBuffers->setEnabled(text == m_OpenGL.name);
 	};
 
 	// Handle connects to disable specific checkboxes that depend on GUI state.

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -15,6 +15,21 @@ namespace Ui
 	class settings_dialog;
 }
 
+struct Render_Info
+{
+	QString name;
+	QString old_adapter;
+	QStringList adapters;
+	emu_settings::SettingsType type;
+	bool supported = true;
+	bool has_adapters = true;
+
+	Render_Info(){};
+	Render_Info(const QString& name) : name(name), has_adapters(false){};
+	Render_Info(const QString& name, const QStringList& adapters, bool supported, const emu_settings::SettingsType& type)
+		: name(name), adapters(adapters), supported(supported), type(type) {};
+};
+
 class settings_dialog : public QDialog
 {
 	Q_OBJECT
@@ -40,8 +55,11 @@ private:
 	QString m_currentConfig;
 	//gpu tab
 	QString m_oldRender = "";
-	bool m_isD3D12 = false;
-	bool m_isVulkan = false;
+
+	Render_Info m_D3D12;
+	Render_Info m_Vulkan;
+	Render_Info m_OpenGL;
+	Render_Info m_NullRender;
 
 	int m_tab_Index;
 	Ui::settings_dialog *ui;


### PR DESCRIPTION
kd-11 noticed some strange behaviour with vulkan adapters not saving.
As I looked into it I found that oldRender was initiated instead of m_oldRender before the first render switch and then never used. So m_oldRender was only ever set after two render switches which also meant saving worked only then.

Then I was annoyed by having to check for every renderer manually so I just went and made it more generalized for any renderers to come (may there ever be more than those we currently have)

I hope I didn't miss anything in the procedure since I'm so tired xD