### PR TITLE
[Qt] fix settings dialog layout shenanigans

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -11,6 +11,7 @@
 #include <QSpinBox>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QTimer>
 
 #include "settings_dialog.h"
 
@@ -985,10 +986,10 @@ void settings_dialog::OnApplyStylesheet()
 
 int settings_dialog::exec()
 {
-	for (int i = 0; i < ui->tabWidget->count(); i++)
-	{
-		ui->tabWidget->setCurrentIndex(i);
-	}
-	ui->tabWidget->setCurrentIndex(m_tab_Index);
+	// singleShot Hack to fix following bug:
+	// If we use setCurrentIndex now we will miraculously see a resize of the dialog as soon as we
+	// switch to the cpu tab after conjuring the settings_dialog with another tab opened first.
+	// Weirdly enough this won't happen if we change the tab order so that anything else is at index 0.
+	QTimer::singleShot(0, [=]{ ui->tabWidget->setCurrentIndex(m_tab_Index); });
 	return QDialog::exec();
 }

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -30,7 +30,7 @@
       <bool>true</bool>
      </property>
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -46,7 +46,7 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_8">
+          <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,0,1">
            <item>
             <widget class="QGroupBox" name="ppu">
              <property name="title">


### PR DESCRIPTION
should fix #3453

also prevents some minor layout glitch:
![image](https://user-images.githubusercontent.com/23019877/30515257-8eeee1fc-9b24-11e7-8f8c-2ac8b4eb12c8.png)
