### PR TITLE
rsx: More Fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/ring_buffer_helper.h
+++ b/rpcs3/Emu/RSX/Common/ring_buffer_helper.h
@@ -114,4 +114,17 @@ public:
 		m_largest_allocated_pool = 0;
 		m_get_pos = get_current_put_pos_minus_one();
 	}
+
+	// Updates the current_allocated_size metrics
+	void notify()
+	{
+		if (m_get_pos == UINT64_MAX)
+			m_current_allocated_size = 0;
+		else if (m_get_pos < m_put_pos)
+			m_current_allocated_size = (m_put_pos - m_get_pos - 1);
+		else if (m_get_pos > m_put_pos)
+			m_current_allocated_size = (m_put_pos + (m_size - m_get_pos - 1));
+		else
+			fmt::throw_exception("m_put_pos == m_get_pos!" HERE);
+	}
 };

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1201,5 +1201,10 @@ namespace rsx
 			blitter.scale_image(vram_texture, dest_texture, src_area, dst_area, interpolate, is_depth_blit);
 			return true;
 		}
+
+		virtual const u32 get_unreleased_textures_count() const
+		{
+			return m_unreleased_texture_objects;
+		}
 	};
 }

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1121,14 +1121,19 @@ namespace rsx
 			{
 				if (dest_texture)
 				{
-					if (dst_is_render_target && !dst_subres.is_depth_surface)
+					if (dst_is_render_target)
 					{
-						LOG_ERROR(RSX, "Depth->RGBA blit requested but not supported");
-						return true;
+						if (!dst_subres.is_depth_surface)
+						{
+							LOG_ERROR(RSX, "Depth->RGBA blit requested but not supported");
+							return true;
+						}
 					}
-
-					if (!cached_dest->has_compatible_format(src_subres.surface))
-						format_mismatch = true;
+					else
+					{
+						if (!cached_dest->has_compatible_format(src_subres.surface))
+							format_mismatch = true;
+					}
 				}
 
 				is_depth_blit = true;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1159,6 +1159,9 @@ void GLGSRender::flip(int buffer)
 		m_text_printer.print_text(0, 36, m_frame->client_width(), m_frame->client_height(), "vertex upload time: " + std::to_string(m_vertex_upload_time) + "us");
 		m_text_printer.print_text(0, 54, m_frame->client_width(), m_frame->client_height(), "textures upload time: " + std::to_string(m_textures_upload_time) + "us");
 		m_text_printer.print_text(0, 72, m_frame->client_width(), m_frame->client_height(), "draw call execution: " + std::to_string(m_draw_time) + "us");
+
+		auto num_dirty_textures = m_gl_texture_cache.get_unreleased_textures_count();
+		m_text_printer.print_text(0, 108, m_frame->client_width(), m_frame->client_height(), "Unreleased textures: " + std::to_string(num_dirty_textures));
 	}
 
 	m_frame->flip(m_context);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1078,7 +1078,7 @@ void VKGSRender::end()
 		{
 			if (!rsx::method_registers.fragment_textures[i].enabled())
 			{
-				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "tex" + std::to_string(i), m_current_frame->descriptor_set);
+				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "tex" + std::to_string(i), m_current_frame->descriptor_set);
 				continue;
 			}
 
@@ -1087,7 +1087,7 @@ void VKGSRender::end()
 			if (!texture0)
 			{
 				LOG_ERROR(RSX, "Texture upload failed to texture index %d. Binding null sampler.", i);
-				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "tex" + std::to_string(i), m_current_frame->descriptor_set);
+				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "tex" + std::to_string(i), m_current_frame->descriptor_set);
 				continue;
 			}
 
@@ -1132,7 +1132,7 @@ void VKGSRender::end()
 		{
 			if (!rsx::method_registers.vertex_textures[i].enabled())
 			{
-				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "vtex" + std::to_string(i), m_current_frame->descriptor_set);
+				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "vtex" + std::to_string(i), m_current_frame->descriptor_set);
 				continue;
 			}
 
@@ -1141,7 +1141,7 @@ void VKGSRender::end()
 			if (!texture0)
 			{
 				LOG_ERROR(RSX, "Texture upload failed to vtexture index %d. Binding null sampler.", i);
-				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "vtex" + std::to_string(i), m_current_frame->descriptor_set);
+				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL }, "vtex" + std::to_string(i), m_current_frame->descriptor_set);
 				continue;
 			}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1589,6 +1589,8 @@ void VKGSRender::advance_queued_frames()
 
 	m_current_queue_index = (m_current_queue_index + 1) % VK_MAX_ASYNC_FRAMES;
 	m_current_frame = &frame_context_storage[m_current_queue_index];
+
+	vk::advance_frame_counter();
 }
 
 void VKGSRender::present(frame_context_t *ctx)
@@ -1606,6 +1608,8 @@ void VKGSRender::present(frame_context_t *ctx)
 
 	//Presentation image released; reset value
 	ctx->present_image = UINT32_MAX;
+
+	vk::advance_completed_frame_counter();
 }
 
 void VKGSRender::queue_swap_request()

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -238,15 +238,6 @@ private:
 
 	// Draw call stats
 	u32 m_draw_calls = 0;
-	u32 m_instanced_draws = 0;
-
-	// Vertex buffer usage stats
-	u32 m_uploads_small = 0;
-	u32 m_uploads_1k = 0;
-	u32 m_uploads_2k = 0;
-	u32 m_uploads_4k = 0;
-	u32 m_uploads_8k = 0;
-	u32 m_uploads_16k = 0;
 
 	// Timers
 	s64 m_setup_time = 0;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -80,13 +80,15 @@ struct command_buffer_chunk: public vk::command_buffer
 		vkResetCommandBuffer(commands, 0);
 	}
 
-	void poke()
+	bool poke()
 	{
 		if (vkGetFenceStatus(m_device, submit_fence) == VK_SUCCESS)
 		{
 			vkResetFences(m_device, 1, &submit_fence);
 			pending = false;
 		}
+
+		return !pending;
 	}
 
 	void wait()

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -211,19 +211,20 @@ namespace vk
 		return g_null_sampler;
 	}
 
-	VkImageView null_image_view()
+	VkImageView null_image_view(vk::command_buffer &cmd)
 	{
 		if (g_null_image_view)
 			return g_null_image_view->value;
 
 		g_null_texture.reset(new image(g_current_renderer, get_memory_mapping(g_current_renderer.gpu()).device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-			VK_IMAGE_TYPE_2D, VK_FORMAT_B8G8R8A8_UNORM, 4, 4, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+			VK_IMAGE_TYPE_2D, VK_FORMAT_B8G8R8A8_UNORM, 4, 4, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_SAMPLED_BIT, 0));
 
 		g_null_image_view.reset(new image_view(g_current_renderer, g_null_texture->value, VK_IMAGE_VIEW_TYPE_2D,
 			VK_FORMAT_B8G8R8A8_UNORM, {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A},
 			{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}));
 
+		change_image_layout(cmd, g_null_texture.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
 		return g_null_image_view->value;
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -13,6 +13,9 @@ namespace vk
 
 	bool g_cb_no_interrupt_flag = false;
 
+	u64 g_num_processed_frames = 0;
+	u64 g_num_total_frames = 0;
+
 	VKAPI_ATTR void* VKAPI_CALL mem_realloc(void* pUserData, void* pOriginal, size_t size, size_t alignment, VkSystemAllocationScope allocationScope)
 	{
 #ifdef _MSC_VER
@@ -346,6 +349,27 @@ namespace vk
 	bool is_uninterruptible()
 	{
 		return g_cb_no_interrupt_flag;
+	}
+
+	void advance_completed_frame_counter()
+	{
+		g_num_processed_frames++;
+	}
+
+	void advance_frame_counter()
+	{
+		verify(HERE), g_num_processed_frames <= g_num_total_frames;
+		g_num_total_frames++;
+	}
+
+	const u64 get_current_frame_id()
+	{
+		return g_num_total_frames;
+	}
+
+	const u64 get_last_completed_frame_id()
+	{
+		return (g_num_processed_frames > 0)? g_num_processed_frames - 1: 0;
 	}
 
 	VKAPI_ATTR VkBool32 VKAPI_CALL dbgFunc(VkFlags msgFlags, VkDebugReportObjectTypeEXT objType,

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -89,6 +89,11 @@ namespace vk
 	void leave_uninterruptible();
 	bool is_uninterruptible();
 
+	void advance_completed_frame_counter();
+	void advance_frame_counter();
+	const u64 get_current_frame_id();
+	const u64 get_last_completed_frame_id();
+
 	struct memory_type_mapping
 	{
 		uint32_t host_visible_coherent;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -71,7 +71,7 @@ namespace vk
 	VkImageSubresourceRange get_image_subresource_range(uint32_t base_layer, uint32_t base_mip, uint32_t layer_count, uint32_t level_count, VkImageAspectFlags aspect);
 
 	VkSampler null_sampler();
-	VkImageView null_image_view();
+	VkImageView null_image_view(vk::command_buffer&);
 
 	void destroy_global_resources();
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -392,6 +392,7 @@ namespace vk
 				const rsx::texture_upload_context context, const rsx::texture_dimension_extended type, const rsx::texture_create_flags flags,
 				std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
 		{
+			const u16 section_depth = depth;
 			const bool is_cubemap = type == rsx::texture_dimension_extended::texture_dimension_cubemap;
 			VkFormat vk_format;
 			VkComponentMapping mapping;
@@ -494,9 +495,9 @@ namespace vk
 
 			change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, { aspect_flags, 0, mipmaps, 0, layer });
 
-			cached_texture_section& region = find_cached_texture(rsx_address, rsx_size, true, width, height, 0);
+			cached_texture_section& region = find_cached_texture(rsx_address, rsx_size, true, width, height, section_depth);
 			region.reset(rsx_address, rsx_size);
-			region.create(width, height, depth, mipmaps, view, image);
+			region.create(width, height, section_depth, mipmaps, view, image);
 			region.set_dirty(false);
 			region.set_context(context);
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -706,5 +706,10 @@ namespace vk
 
 			return upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper, *m_device, cmd, m_memory_types, m_submit_queue);
 		}
+
+		const u32 get_unreleased_textures_count() const override
+		{
+			return m_unreleased_texture_objects + m_discardable_storage.size();
+		}
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -572,6 +572,8 @@ namespace vk
 
 				view.reset(new_view);
 			}
+
+			section.set_view_flags(expected_flags);
 		}
 
 		void insert_texture_barrier() override

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -272,6 +272,40 @@ namespace vk
 		}
 	};
 	
+	struct discarded_storage
+	{
+		std::unique_ptr<vk::image_view> view;
+		std::unique_ptr<vk::image> img;
+
+		const u64 frame_tag = vk::get_current_frame_id();
+
+		discarded_storage(std::unique_ptr<vk::image_view>& _view)
+		{
+			view = std::move(_view);
+		}
+
+		discarded_storage(std::unique_ptr<vk::image>& _img)
+		{
+			img = std::move(_img);
+		}
+
+		discarded_storage(std::unique_ptr<vk::image>& _img, std::unique_ptr<vk::image_view>& _view)
+		{
+			img = std::move(_img);
+			view = std::move(_view);
+		}
+
+		discarded_storage(cached_texture_section& tex)
+		{
+			view = std::move(tex.get_view());
+			img = std::move(tex.get_texture());
+		}
+
+		const bool test(u64 ref_frame) const
+		{
+			return ref_frame > 0 && frame_tag <= ref_frame;
+		}
+	};
 
 	class texture_cache : public rsx::texture_cache<vk::command_buffer, cached_texture_section, vk::image*, vk::image_view*, vk::image, VkFormat>
 	{
@@ -285,12 +319,7 @@ namespace vk
 		vk::buffer* m_texture_upload_buffer;
 
 		//Stuff that has been dereferenced goes into these
-		std::vector<std::unique_ptr<vk::image_view> > m_temporary_image_view;
-		std::vector<std::unique_ptr<vk::image>> m_dirty_textures;
-
-		//Stuff that has been dereferenced twice goes here. Contents are evicted before new ones are added
-		std::vector<std::unique_ptr<vk::image_view>> m_image_views_to_purge;
-		std::vector<std::unique_ptr<vk::image>> m_images_to_purge;
+		std::list<discarded_storage> m_discardable_storage;
 		
 		void purge_cache()
 		{
@@ -301,8 +330,7 @@ namespace vk
 				{
 					if (tex.exists())
 					{
-						m_dirty_textures.push_back(std::move(tex.get_texture()));
-						m_temporary_image_view.push_back(std::move(tex.get_view()));
+						m_discardable_storage.push_back(tex);
 					}
 
 					if (tex.is_locked())
@@ -314,12 +342,7 @@ namespace vk
 				range_data.data.resize(0);
 			}
 
-			m_temporary_image_view.clear();
-			m_dirty_textures.clear();
-
-			m_image_views_to_purge.clear();
-			m_images_to_purge.clear();
-
+			m_discardable_storage.clear();
 			m_unreleased_texture_objects = 0;
 		}
 		
@@ -327,8 +350,7 @@ namespace vk
 
 		void free_texture_section(cached_texture_section& tex) override
 		{
-			m_dirty_textures.push_back(std::move(tex.get_texture()));
-			m_temporary_image_view.push_back(std::move(tex.get_view()));
+			m_discardable_storage.push_back(tex);
 			tex.release_dma_resources();
 		}
 
@@ -377,10 +399,8 @@ namespace vk
 			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, subresource_range);
 			vk::change_image_layout(cmd, source, old_src_layout, subresource_range);
 
-			m_dirty_textures.push_back(std::move(image));
-			m_temporary_image_view.push_back(std::move(view));
-
-			return m_temporary_image_view.back().get();
+			m_discardable_storage.push_back({ image, view });
+			return m_discardable_storage.back().view.get();
 		}
 
 		vk::image_view* create_temporary_subresource_view(vk::command_buffer& cmd, vk::image** source, u32 gcm_format, u16 x, u16 y, u16 w, u16 h) override
@@ -642,11 +662,8 @@ namespace vk
 				purge_dirty();
 			}
 
-			m_image_views_to_purge.clear();
-			m_images_to_purge.clear();
-
-			m_image_views_to_purge = std::move(m_temporary_image_view);
-			m_images_to_purge = std::move(m_dirty_textures);
+			const u64 last_complete_frame = vk::get_last_completed_frame_id();
+			m_discardable_storage.remove_if([&](const discarded_storage& o) {return o.test(last_complete_frame);});
 		}
 
 		bool blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, rsx::vk_render_targets& m_rtts, vk::command_buffer& cmd)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -709,7 +709,7 @@ namespace vk
 
 		const u32 get_unreleased_textures_count() const override
 		{
-			return m_unreleased_texture_objects + m_discardable_storage.size();
+			return std::max(m_unreleased_texture_objects, 0) + (u32)m_discardable_storage.size();
 		}
 	};
 }


### PR DESCRIPTION
- Fixes a crash in some games when using GPU texture scaling (Torque Engine)
- Mark cube map and 3D textures as separate from 2D surfaces in the cache. Also adds an error if a type mismatch is detected.
- Optimize frame storage and minimize hard sync point occurrence (vulkan). Improves framerates and makes frametimes alot more consistent.
- (Vulkan) Mark resources with frameIDs to keep drivers that buffer up frames from crashing (Mostly Nvidia)