### PR TITLE
AppVeyor git branch in title fix #2

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -22,7 +22,7 @@ gs_frame::gs_frame(const QString& title, int w, int h, QIcon appIcon, bool disab
 	version = version.substr(0 , version.find_last_of("-"));
 
 	//Add branch to version on frame , unless it's master.
-	if (rpcs3::get_branch() != "master")
+	if (rpcs3::get_branch() != "master" || rpcs3::get_branch() != "HEAD")
 	{
 		version = version + "-" + rpcs3::get_branch();
 	}
@@ -133,7 +133,7 @@ void gs_frame::show()
 {
 	Emu.CallAfter([=]()
 	{
-		QWindow::show(); 
+		QWindow::show();
 		if (g_cfg.misc.start_fullscreen)
 		{
 			setVisibility(FullScreen);


### PR DESCRIPTION
This fixes the annoying `HEAD` git branch in master AppVeyor builds.