### PR TITLE
Add Deadzones for evdev gamepads

### DIFF
--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -168,6 +168,30 @@ void evdev_joystick_handler::Close()
     }
 }
 
+inline int Deadzone(f32 input)
+{
+	int	deadzone=g_evdev_joystick_config.deadzone;
+	float deadzone_a=128.0/(128.0-float(deadzone));
+	float deadzone_b=255.0*(1.0-deadzone_a);
+	if (input>=128-deadzone&&input<=128+deadzone)
+	{
+		input=128;
+	}
+	else
+	{
+		if (input>128+deadzone)
+		{
+			input=deadzone_a*(float)input+deadzone_b;
+		}
+		if (input<128-deadzone)
+		{
+			input=(128.0/(128.0-(float)deadzone))*input;
+		}
+	}
+    return static_cast<int>(input);
+}
+
+
 int evdev_joystick_handler::scale_axis(int axis, int value)
 {
     auto range = axis_ranges[axis];
@@ -182,7 +206,7 @@ int evdev_joystick_handler::scale_axis(int axis, int value)
             range.first = 0;
         }
 
-        return (static_cast<float>(value - range.first) / range.second) * 255;
+		return (static_cast<float>(Deadzone((((float)value - (float)range.first) / (float)range.second) * 255)));
     }
     else
     {

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -210,7 +210,7 @@ int evdev_joystick_handler::scale_axis(int axis, int value)
     }
     else
     {
-        return value;
+        return (static_cast<float>(Deadzone((float)value)));
     }
 }
 

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -205,11 +205,11 @@ int evdev_joystick_handler::scale_axis(int axis, int value)
             range.second += -range.first;
             range.first = 0;
         }
-        return (deadzone((((float)value - range.first) / range.second) * 255));
+        return (deadzone(((static_cast<float>(value) - range.first) / range.second) * 255));
     }
     else
     {
-        return (deadzone((float)value));
+        return (deadzone(static_cast<float>(value)));
     }
 }
 

--- a/rpcs3/evdev_joystick_handler.h
+++ b/rpcs3/evdev_joystick_handler.h
@@ -46,6 +46,7 @@ struct evdev_joystick_config final : cfg::node
     cfg::_bool axistrigger{this, "Z axis triggers", true};
     cfg::_bool squirclejoysticks{this, "Squircle Joysticks", true};
     cfg::int32 squirclefactor{this, "Squircle Factor", 5000};
+	cfg::int32 deadzone{this, "Deadzone", 10};
 
     bool load()
     {


### PR DESCRIPTION
This is for the linux evdev gamepads. I had to deal with gamepads sending -32767 to 32767 or 0 to 255. So, Deadzone is in the 0-128 range (default is 10). There’s a new parameter in the config_linuxjoystick.yml file, which is : Deadzone: 20. About the code : I wanted to discover cpp programming while doing something useful and easy. Feel free to critize. The conversion between int and float feels dirty, but my 2 test gamepads (xbox360 and a DragonRise custom stick) have different behaviours (ranges). Maybe someone will come with a cleaner code. Tested with a xbox360 and a custom stick on ArchLinux.