### PR TITLE
[Qt] fix experimental build warning layout and smoothen gamelist scrolling

### DIFF
--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -12,7 +12,7 @@ class game_list : public QTableWidget
 private:
 	void mousePressEvent(QMouseEvent *event)
 	{
-		if (!indexAt(event->pos()).isValid())
+		if (!indexAt(event->pos()).isValid() || itemAt(event->pos())->data(Qt::UserRole) < 0)
 		{
 			clearSelection();
 		}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -153,6 +153,9 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> settings, const R
 	m_gameList->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_gameList->setSelectionMode(QAbstractItemView::SingleSelection);
 	m_gameList->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_gameList->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_gameList->verticalScrollBar()->setSingleStep(20);
+	m_gameList->horizontalScrollBar()->setSingleStep(20);
 	m_gameList->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);	
 	m_gameList->verticalHeader()->setMinimumSectionSize(m_Icon_Size.height());
 	m_gameList->verticalHeader()->setMaximumSectionSize(m_Icon_Size.height());
@@ -951,7 +954,7 @@ void game_list_frame::resizeEvent(QResizeEvent *event)
 {
 	if (!m_isListLayout)
 	{
-		Refresh();
+		Refresh(false, m_xgrid->selectedItems().count());
 	}
 	QDockWidget::resizeEvent(event);
 }

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1082,10 +1082,7 @@ void game_list_frame::PopulateGameGrid(uint maxCols, const QSize& image_size, co
 		{
 			continue;
 		}
-
-		QString category = qstr(m_game_data[i].info.category);
-
-		if (category == category::hdd_Game || category == category::disc_Game)
+		if (category::CategoryInMap(m_game_data[i].info.category, category::cat_boot))
 		{
 			QString title = GUI::get_Single_Line(qstr(m_game_data[i].info.name));
 

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -100,6 +100,16 @@ namespace category // (see PARAM.SFO in psdevwiki.com) TODO: Disc Categories
 	const QStringList media = { app_Photo, app_Video, bc_Video, app_Music, app_TV, web_TV };
 	const QStringList data = { ps3_Data, ps2_Data, ps3_Save, psp_Save };
 	const QStringList others = { network, store_FE, trophy, other };
+
+	inline bool CategoryInMap(const std::string& cat, const q_from_char& map)
+	{
+		auto map_contains_category = [cat](std::pair<std::string, const QString> p)
+		{
+			return p.second == qstr(cat);
+		};
+
+		return std::find_if(map.begin(), map.end(), map_contains_category) != map.end();
+	}
 }
 
 namespace parental

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -3,6 +3,7 @@
 
 #include <QHeaderView>
 #include <QLabel>
+#include <QScrollBar>
 
 game_list_grid::game_list_grid(const QSize& icon_size, const QColor& icon_color, const qreal& margin_factor, const qreal& text_factor, const bool& showText)
 	: game_list(), m_icon_size(icon_size), m_icon_color(icon_color), m_margin_factor(margin_factor), m_text_factor(text_factor), m_text_enabled(showText)
@@ -30,6 +31,8 @@ game_list_grid::game_list_grid(const QSize& icon_size, const QColor& icon_color,
 	setSelectionMode(QAbstractItemView::SingleSelection);
 	setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
 	setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+	verticalScrollBar()->setSingleStep(20);
+	horizontalScrollBar()->setSingleStep(20);
 	setContextMenuPolicy(Qt::CustomContextMenu);
 	verticalHeader()->setVisible(false);
 	horizontalHeader()->setVisible(false);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -132,9 +132,20 @@ void main_window::Init()
 		msg.setWindowIcon(m_appIcon);
 		msg.setIcon(QMessageBox::Critical);
 		msg.setTextFormat(Qt::RichText);
-		msg.setText("Please understand that this build is not an official RPCS3 release.<br>This build contains changes that may break games, or even <b>damage</b> your data.<br>It's recommended to download and use the official build from <a href='https://rpcs3.net/download'>RPCS3 website</a>.<br><br>Build origin: " STRINGIZE(BRANCH) "<br>Do you wish to use this build anyway?");
 		msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
 		msg.setDefaultButton(QMessageBox::No);
+		msg.setText(QString(
+			R"(
+				<p style="white-space: nowrap;">
+					Please understand that this build is not an official RPCS3 release.<br>
+					This build contains changes that may break games, or even <b>damage</b> your data.<br>
+					We recommend to download and use the official build from the <a href='https://rpcs3.net/download'>RPCS3 website</a>.<br><br>
+					Build origin: %1<br>
+					Do you wish to use this build anyway?
+				</p>
+			)"
+		).arg(STRINGIZE(BRANCH)));
+		msg.layout()->setSizeConstraint(QLayout::SetFixedSize);
 
 		if (msg.exec() == QMessageBox::No)
 		{

--- a/rpcs3/rpcs3qt/welcome_dialog.ui
+++ b/rpcs3/rpcs3qt/welcome_dialog.ui
@@ -152,7 +152,6 @@
        </layout>
       </item>
      </layout>
-     <zorder></zorder>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
The layout was squished with windows scaling.
Let me know if it looks fine.

Scrolling on the gamelist (horizontally and vertically) resulted in very annoying jumps, so I set a specific value that seemed fine on my machine. Please let me know how you feel about it.
FYI you can always increase the scroll speed by holding down the ctrl button.

especially ***LINUX*** users are asked to test these things

now shows all bootable categories in gamegrid, since networking is being added