### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -193,17 +193,12 @@ void GLGSRender::begin()
 		float range_near = rsx::method_registers.clip_min();
 		float range_far = rsx::method_registers.clip_max();
 
-		if (g_cfg.video.strict_rendering_mode)
-			gl_state.depth_range(range_near, range_far);
+		//Workaround to preserve depth precision but respect z direction
+		//Ni no Kuni sets a very restricted z range (0.9x - 1.) and depth reads / tests are broken
+		if (range_near <= range_far)
+			gl_state.depth_range(0.f, 1.f);
 		else
-		{
-			//Workaround to preserve depth precision but respect z direction
-			//Ni no Kuni sets a very restricted z range (0.9x - 1.) and depth reads / tests are broken
-			if (range_near <= range_far)
-				gl_state.depth_range(0.f, 1.f);
-			else
-				gl_state.depth_range(1.f, 0.f);
-		}
+			gl_state.depth_range(1.f, 0.f);
 	}
 
 	if (glDepthBoundsEXT && (gl_state.enable(rsx::method_registers.depth_bounds_test_enabled(), GL_DEPTH_BOUNDS_TEST_EXT)))

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -193,7 +193,7 @@ namespace gl
 
 		void reset(const u32 base, const u32 size, const bool flushable=false)
 		{
-			rsx::protection_policy policy = g_cfg.video.strict_rendering_mode ? rsx::protection_policy::protect_policy_full_range : rsx::protection_policy::protect_policy_one_page;
+			rsx::protection_policy policy = g_cfg.video.strict_rendering_mode ? rsx::protection_policy::protect_policy_full_range : rsx::protection_policy::protect_policy_conservative;
 			rsx::buffered_section::reset(base, size, policy);
 
 			if (flushable)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -289,6 +289,7 @@ private:
 	void process_swap_request(frame_context_t *ctx, bool free_resources = false);
 	void advance_queued_frames();
 	void present(frame_context_t *ctx);
+	void reinitialize_swapchain();
 
 	void begin_render_pass();
 	void close_render_pass();

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -373,6 +373,104 @@ namespace vk
 		return (g_num_processed_frames > 0)? g_num_processed_frames - 1: 0;
 	}
 
+	void die_with_error(std::string faulting_addr, VkResult error_code)
+	{
+		std::string error_message;
+		int severity = 0; //0 - die, 1 - warn, 2 - nothing
+
+		switch (error_code)
+		{
+		case VK_SUCCESS:
+		case VK_EVENT_SET:
+		case VK_EVENT_RESET:
+		case VK_INCOMPLETE:
+			return;
+		case VK_SUBOPTIMAL_KHR:
+			error_message = "Present surface is suboptimal (VK_SUBOPTIMAL_KHR)";
+			severity = 1;
+			break;
+		case VK_NOT_READY:
+			error_message = "Device or resource busy (VK_NOT_READY)";
+			break;
+		case VK_TIMEOUT:
+			error_message = "Timeout event (VK_TIMEOUT)";
+			break;
+		case VK_ERROR_OUT_OF_HOST_MEMORY:
+			error_message = "Out of host memory (system RAM) (VK_ERROR_OUT_OF_HOST_MEMORY)";
+			break;
+		case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+			error_message = "Out of video memory (VRAM) (VK_ERROR_OUT_OF_DEVICE_MEMORY)";
+			break;
+		case VK_ERROR_INITIALIZATION_FAILED:
+			error_message = "Initialization failed (VK_ERROR_INITIALIZATION_FAILED)";
+			break;
+		case VK_ERROR_DEVICE_LOST:
+			error_message = "Device lost (Driver crashed with unspecified error or stopped responding and recovered) (VK_ERROR_DEVICE_LOST)";
+			break;
+		case VK_ERROR_MEMORY_MAP_FAILED:
+			error_message = "Memory map failed (VK_ERROR_MEMORY_MAP_FAILED)";
+			break;
+		case VK_ERROR_LAYER_NOT_PRESENT:
+			error_message = "Requested layer is not available (Try disabling debug output or install vulkan SDK) (VK_ERROR_LAYER_NOT_PRESENT)";
+			break;
+		case VK_ERROR_EXTENSION_NOT_PRESENT:
+			error_message = "Requested extension not available (VK_ERROR_EXTENSION_NOT_PRESENT)";
+			break;
+		case VK_ERROR_FEATURE_NOT_PRESENT:
+			error_message = "Requested feature not available (VK_ERROR_FEATURE_NOT_PRESENT)";
+			break;
+		case VK_ERROR_INCOMPATIBLE_DRIVER:
+			error_message = "Incompatible driver (VK_ERROR_INCOMPATIBLE_DRIVER)";
+			break;
+		case VK_ERROR_TOO_MANY_OBJECTS:
+			error_message = "Too many objects created (Out of handles) (VK_ERROR_TOO_MANY_OBJECTS)";
+			break;
+		case VK_ERROR_FORMAT_NOT_SUPPORTED:
+			error_message = "Format not supported (VK_ERROR_FORMAT_NOT_SUPPORTED)";
+			break;
+		case VK_ERROR_FRAGMENTED_POOL:
+			error_message = "Fragmented pool (VK_ERROR_FRAGMENTED_POOL)";
+			break;
+		case VK_ERROR_SURFACE_LOST_KHR:
+			error_message = "Surface lost (VK_ERROR_SURFACE_LOST)";
+			break;
+		case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
+			error_message = "Native window in use (VK_ERROR_NATIVE_WINDOW_IN_USE_KHR)";
+			break;
+		case VK_ERROR_OUT_OF_DATE_KHR:
+			error_message = "Present surface is out of date (VK_ERROR_OUT_OF_DATE_KHR)";
+			severity = 1;
+			break;
+		case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
+			error_message = "Incompatible display (VK_ERROR_INCOMPATIBLE_DISPLAY_KHR)";
+			break;
+		case VK_ERROR_VALIDATION_FAILED_EXT:
+			error_message = "Validation failed (VK_ERROR_INCOMPATIBLE_DISPLAY_KHR)";
+			break;
+		case VK_ERROR_INVALID_SHADER_NV:
+			error_message = "Invalid shader code (VK_ERROR_INVALID_SHADER_NV)";
+			break;
+		case VK_ERROR_OUT_OF_POOL_MEMORY_KHR:
+			error_message = "Out of pool memory (VK_ERROR_OUT_OF_POOL_MEMORY_KHR)";
+			break;
+		case VK_ERROR_INVALID_EXTERNAL_HANDLE_KHX:
+			error_message = "Invalid external handle (VK_ERROR_INVALID_EXTERNAL_HANDLE_KHX)";
+			break;
+		default:
+			error_message = fmt::format("Unknown Code (%Xh, %d)", (s32)error_code, (s32&)error_code);
+			break;
+		}
+
+		switch (severity)
+		{
+		case 0:
+			fmt::throw_exception("Assertion Failed! Vulkan API call failed with unrecoverable error: %s", (error_message + faulting_addr).c_str());
+		case 1:
+			LOG_ERROR(RSX, "Vulkan API call has failed with an error but will continue: %s", (error_message + faulting_addr).c_str());
+			break;
+		}
+	}
+
 	VKAPI_ATTR VkBool32 VKAPI_CALL dbgFunc(VkFlags msgFlags, VkDebugReportObjectTypeEXT objType,
 											uint64_t srcObject, size_t location, int32_t msgCode,
 											const char *pLayerPrefix, const char *pMsg, void *pUserData)

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -36,7 +36,7 @@ namespace rsx
 
 namespace vk
 {
-#define CHECK_RESULT(expr) { VkResult _res = (expr); if (_res != VK_SUCCESS) fmt::throw_exception("Assertion failed! Result is %Xh" HERE, (s32)_res); }
+#define CHECK_RESULT(expr) { VkResult _res = (expr); if (_res != VK_SUCCESS) vk::die_with_error(HERE, _res); }
 
 	VKAPI_ATTR void *VKAPI_CALL mem_realloc(void *pUserData, void *pOriginal, size_t size, size_t alignment, VkSystemAllocationScope allocationScope);
 	VKAPI_ATTR void *VKAPI_CALL mem_alloc(void *pUserData, size_t size, size_t alignment, VkSystemAllocationScope allocationScope);
@@ -93,6 +93,8 @@ namespace vk
 	void advance_frame_counter();
 	const u64 get_current_frame_id();
 	const u64 get_last_completed_frame_id();
+
+	void die_with_error(std::string faulting_addr, VkResult error_code);
 
 	struct memory_type_mapping
 	{

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -35,7 +35,7 @@ namespace vk
 			if (length > cpu_address_range)
 				release_dma_resources();
 
-			rsx::protection_policy policy = g_cfg.video.strict_rendering_mode ? rsx::protection_policy::protect_policy_full_range : rsx::protection_policy::protect_policy_one_page;
+			rsx::protection_policy policy = g_cfg.video.strict_rendering_mode ? rsx::protection_policy::protect_policy_full_range : rsx::protection_policy::protect_policy_conservative;
 			rsx::buffered_section::reset(base, length, policy);
 		}
 


### PR DESCRIPTION
- Improve memory protection behavior when strict mode is off. Use full range protection without trampling shared pages instead of only checking a single page. This fixes some missing graphics in some games without requiring strict mode (id tech 5)
- Remove the broken strict mode behavior of depth range using GL
- Improve error handling, recovery and display when running vulkan (nvidia fullscreen & window resize woes)