### PR TITLE
vulkan: Fix vsync

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -836,34 +836,33 @@ namespace vk
 			CHECK_RESULT(vkGetPhysicalDeviceSurfacePresentModesKHR(gpu, m_surface, &nb_available_modes, present_modes.data()));
 
 			VkPresentModeKHR swapchain_present_mode = VK_PRESENT_MODE_FIFO_KHR;
-			VkPresentModeKHR preferred_mode = (g_cfg.video.vsync) ? VK_PRESENT_MODE_FIFO_RELAXED_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR;
-			bool mailbox_exists = false;
+			std::vector<VkPresentModeKHR> preferred_modes;
 
-			for (VkPresentModeKHR mode : present_modes)
+			//List of preferred modes in decreasing desirability
+			if (g_cfg.video.vsync)
+				preferred_modes = { VK_PRESENT_MODE_MAILBOX_KHR };
+			else
+				preferred_modes = { VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR, VK_PRESENT_MODE_MAILBOX_KHR };
+
+			bool mode_found = false;
+			for (VkPresentModeKHR preferred_mode : preferred_modes)
 			{
-				if (mode == VK_PRESENT_MODE_MAILBOX_KHR)
+				//Search for this mode in supported modes
+				for (VkPresentModeKHR mode : present_modes)
 				{
-					mailbox_exists = true;
-					continue;
+					if (mode == preferred_mode)
+					{
+						swapchain_present_mode = mode;
+						mode_found = true;
+						break;
+					}
 				}
 
-				if (mode == preferred_mode)
-				{
-					swapchain_present_mode = mode;
+				if (mode_found)
 					break;
-				}
 			}
 
-			if (preferred_mode != swapchain_present_mode)
-			{
-				//Preferred video mode was not found. Fall back to mailbox if it exists
-				LOG_WARNING(RSX, "Swapchain: Could not set the preferred present mode 0x%X. Falling back to mailbox if supported (supported=%d)", (u32)preferred_mode, mailbox_exists);
-
-				if (mailbox_exists)
-				{
-					swapchain_present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
-				}
-			}
+			LOG_NOTICE(RSX, "Swapchain: present mode %d in use.", (s32&)swapchain_present_mode);
 
 			uint32_t nb_swap_images = surface_descriptors.minImageCount + 1;
 			if (surface_descriptors.maxImageCount > 0)


### PR DESCRIPTION
- Tightens vsync control to not accept any modes that would allow tearing - including adaptive vsync.

The reason for this is that gcm is timed to control the virtual graphics controller instead of running uncapped and letting the display limit the framerate. This causes slight judder where the overhead of threads getting scheduled around means we might miss a present window. While the adaptive vsync does a good job allowing consistent frametimes, it does allow tearing to prevent judder. This PR forces true vsync. If you experience frame judder, disable the vsync option.