### PR TITLE
Qt/ui/vk: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -301,6 +301,12 @@ void D3D12GSRender::on_exit()
 	return GSRender::on_exit();
 }
 
+void D3D12GSRender::do_local_task()
+{
+	//TODO
+	m_frame->clear_wm_events();
+}
+
 bool D3D12GSRender::do_method(u32 cmd, u32 arg)
 {
 	switch (cmd)

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -173,6 +173,7 @@ private:
 protected:
 	virtual void on_init_thread() override;
 	virtual void on_exit() override;
+	virtual void do_local_task() override;
 	virtual bool do_method(u32 cmd, u32 arg) override;
 	virtual void end() override;
 	virtual void flip(int buffer) override;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1231,6 +1231,8 @@ void GLGSRender::on_notify_memory_unmapped(u32 address_base, u32 size)
 
 void GLGSRender::do_local_task()
 {
+	m_frame->clear_wm_events();
+
 	std::lock_guard<std::mutex> lock(queue_guard);
 
 	work_queue.remove_if([](work_item &q) { return q.received; });

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -403,6 +403,9 @@ namespace rsx
 		std::vector<u32> deferred_stack;
 		bool has_deferred_call = false;
 
+		// Track register address faults
+		u32 mem_faults_count = 0;
+
 		auto flush_command_queue = [&]()
 		{
 			const auto num_draws = (u32)method_registers.current_draw_clause.first_count_commands.size();
@@ -494,6 +497,17 @@ namespace rsx
 			{
 				LOG_ERROR(RSX, "Invalid FIFO queue get/put registers found, get=0x%X, put=0x%X", get, put);
 
+				if (mem_faults_count >= 3)
+				{
+					LOG_ERROR(RSX, "Application has failed to recover, discarding FIFO queue");
+					ctrl->get = put;
+				}
+				else
+				{
+					mem_faults_count++;
+					std::this_thread::sleep_for(1ms);
+				}
+
 				invalid_command_interrupt_raised = true;
 				continue;
 			}
@@ -544,9 +558,23 @@ namespace rsx
 			{
 				LOG_ERROR(RSX, "Invalid FIFO queue args ptr found, get=0x%X, cmd=0x%X, count=%d", get, cmd, count);
 
+				if (mem_faults_count >= 3)
+				{
+					LOG_ERROR(RSX, "Application has failed to recover, discarding FIFO queue");
+					ctrl->get = put;
+				}
+				else
+				{
+					mem_faults_count++;
+					std::this_thread::sleep_for(1ms);
+				}
+
 				invalid_command_interrupt_raised = true;
 				continue;
 			}
+
+			// All good on valid memory ptrs
+			mem_faults_count = 0;
 
 			auto args = vm::ptr<u32>::make(args_address);
 			invalid_command_interrupt_raised = false;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -495,7 +495,6 @@ namespace rsx
 				LOG_ERROR(RSX, "Invalid FIFO queue get/put registers found, get=0x%X, put=0x%X", get, put);
 
 				invalid_command_interrupt_raised = true;
-				ctrl->get = put;
 				continue;
 			}
 
@@ -546,7 +545,6 @@ namespace rsx
 				LOG_ERROR(RSX, "Invalid FIFO queue args ptr found, get=0x%X, cmd=0x%X, count=%d", get, cmd, count);
 
 				invalid_command_interrupt_raised = true;
-				ctrl->get = put;
 				continue;
 			}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -159,6 +159,8 @@ private:
 
 	std::unique_ptr<vk::framebuffer_holder> m_draw_fbo;
 
+	bool present_surface_dirty_flag = false;
+
 	u64 m_last_heap_sync_time = 0;
 	vk::vk_data_heap m_attrib_ring_info;
 	vk::vk_data_heap m_uniform_buffer_ring_info;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -373,7 +373,7 @@ namespace vk
 		return (g_num_processed_frames > 0)? g_num_processed_frames - 1: 0;
 	}
 
-	void die_with_error(std::string faulting_addr, VkResult error_code)
+	void die_with_error(const char* faulting_addr, VkResult error_code)
 	{
 		std::string error_message;
 		int severity = 0; //0 - die, 1 - warn, 2 - nothing
@@ -457,16 +457,16 @@ namespace vk
 			error_message = "Invalid external handle (VK_ERROR_INVALID_EXTERNAL_HANDLE_KHX)";
 			break;
 		default:
-			error_message = fmt::format("Unknown Code (%Xh, %d)", (s32)error_code, (s32&)error_code);
+			error_message = fmt::format("Unknown Code (%Xh, %d)%s", (s32)error_code, (s32&)error_code, faulting_addr);
 			break;
 		}
 
 		switch (severity)
 		{
 		case 0:
-			fmt::throw_exception("Assertion Failed! Vulkan API call failed with unrecoverable error: %s", (error_message + faulting_addr).c_str());
+			fmt::throw_exception("Assertion Failed! Vulkan API call failed with unrecoverable error: %s%s", error_message.c_str(), faulting_addr);
 		case 1:
-			LOG_ERROR(RSX, "Vulkan API call has failed with an error but will continue: %s", (error_message + faulting_addr).c_str());
+			LOG_ERROR(RSX, "Vulkan API call has failed with an error but will continue: %s%s", error_message.c_str(), faulting_addr);
 			break;
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -94,7 +94,7 @@ namespace vk
 	const u64 get_current_frame_id();
 	const u64 get_last_completed_frame_id();
 
-	void die_with_error(std::string faulting_addr, VkResult error_code);
+	void die_with_error(const char* faulting_addr, VkResult error_code);
 
 	struct memory_type_mapping
 	{

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -12,6 +12,10 @@
 
 #include "rpcs3_version.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 constexpr auto qstr = QString::fromStdString;
 
 gs_frame::gs_frame(const QString& title, int w, int h, QIcon appIcon, bool disableMouse)
@@ -237,4 +241,89 @@ bool gs_frame::event(QEvent* ev)
 		close();
 	}
 	return QWindow::event(ev);
+}
+
+bool gs_frame::nativeEvent(const QByteArray &eventType, void *message, long *result)
+{
+#ifdef _WIN32
+	//Wait for consumer to clear notification pending flag
+	while (wm_event_raised.load(std::memory_order_consume));
+
+	{
+		std::lock_guard<std::mutex> lock(wm_event_lock);
+		MSG* msg = static_cast<MSG*>(message);
+		switch (msg->message)
+		{
+		case WM_WINDOWPOSCHANGING:
+		{
+			const auto flags = reinterpret_cast<LPWINDOWPOS>(msg->lParam)->flags & SWP_NOSIZE;
+			if (m_in_sizing_event || flags != 0)
+				break;
+
+			//About to resize
+			m_in_sizing_event = true;
+			m_interactive_resize = false;
+			m_raised_event = wm_event::geometry_change_notice;
+			wm_event_raised.store(true);
+			break;
+		}
+		case WM_WINDOWPOSCHANGED:
+		{
+			const auto flags = reinterpret_cast<LPWINDOWPOS>(msg->lParam)->flags & (SWP_NOSIZE | SWP_NOMOVE);
+			if (!m_in_sizing_event || m_user_interaction_active || flags == (SWP_NOSIZE | SWP_NOMOVE))
+				break;
+
+			if (flags & SWP_NOSIZE)
+				m_raised_event = wm_event::window_moved;
+			else
+				m_raised_event = wm_event::window_resized;
+
+			//Just finished resizing using maximize or SWP
+			m_in_sizing_event = false;
+			wm_event_raised.store(true);
+			break;
+		}
+		case WM_ENTERSIZEMOVE:
+			m_user_interaction_active = true;
+			break;
+		case WM_EXITSIZEMOVE:
+			m_user_interaction_active = false;
+			if (m_in_sizing_event && !m_user_interaction_active)
+			{
+				//Just finished resizing using manual interaction. The corresponding WM_SIZE is consumed before this event fires
+				m_raised_event = m_interactive_resize ? wm_event::window_resized : wm_event::window_moved;
+				m_in_sizing_event = false;
+				wm_event_raised.store(true);
+			}
+			break;
+		case WM_SIZE:
+		{
+			if (m_user_interaction_active)
+			{
+				//Interaction is a resize not a move
+				m_interactive_resize = true;
+			}
+			else if (m_in_sizing_event)
+			{
+				//Any other unexpected resize mode will give an unconsumed WM_SIZE event
+				m_raised_event = wm_event::window_resized;
+				m_in_sizing_event = false;
+				wm_event_raised.store(true);
+			}
+			break;
+		}
+		}
+	}
+
+	//Do not enter DefWndProc until the consumer has consumed the message
+	while (wm_event_raised.load(std::memory_order_consume));
+#endif
+
+	//Let the default handler deal with this. Only the notification is required
+	return false;
+}
+
+wm_event gs_frame::get_default_wm_event() const
+{
+	return (m_user_interaction_active) ? wm_event::geometry_change_in_progress : wm_event::none;
 }

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -14,8 +14,14 @@ class gs_frame : public QWindow, public GSFrameBase
 	bool m_show_fps;
 	bool m_disable_mouse;
 
+	bool m_in_sizing_event = false; //a signal that the window is about to be resized was received
+	bool m_user_interaction_active = false; //a signal indicating the window is being manually moved/resized was received
+	bool m_interactive_resize = false; //resize signal received while dragging window
+
 public:
 	gs_frame(const QString& title, int w, int h, QIcon appIcon, bool disableMouse);
+
+	wm_event get_default_wm_event() const override;
 protected:
 	virtual void paintEvent(QPaintEvent *event);
 
@@ -37,6 +43,8 @@ protected:
 	void flip(draw_context_t context, bool skip_frame=false) override;
 	int client_width() override;
 	int client_height() override;
+
+	bool nativeEvent(const QByteArray &eventType, void *message, long *result) override;
 
 	bool event(QEvent* ev) override;
 private Q_SLOTS:


### PR DESCRIPTION
- Implements notifications from the GSFrame QWindow to the vulkan renderer thread. It is important as the renderer should pause until resizing is complete to keep some drivers from crashing when the native window suddenly changes size in the middle of drawing/presenting
- When encountering corrupt put/get registers do not discard entire commandbuffers in case there are semaphores held