### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -835,7 +835,7 @@ namespace rsx
 
 		const auto window_origin = rsx::method_registers.shader_window_origin();
 		const u32 window_height = rsx::method_registers.shader_window_height();
-		const f32 resolution_scale = (window_height <= g_cfg.video.min_scalable_dimension)? 1.f : rsx::get_resolution_scale();
+		const f32 resolution_scale = (window_height <= (u32)g_cfg.video.min_scalable_dimension)? 1.f : rsx::get_resolution_scale();
 		const f32 wpos_scale = (window_origin == rsx::window_origin::top) ? (1.f / resolution_scale) : (-1.f / resolution_scale);
 		const f32 wpos_bias = (window_origin == rsx::window_origin::top) ? 0.f : window_height;
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -665,7 +665,7 @@ namespace rsx
 				dst_info.max_tile_h = static_cast<u16>((dst_region.tile->size - dst_region.base) / out_pitch);
 			}
 
-			if (dst_dma == CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER)
+			if (!g_cfg.video.force_cpu_blit_processing && dst_dma == CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER)
 			{
 				//For now, only use this for actual scaled images, there are use cases that should not go through 3d engine, e.g program ucode transfer
 				//TODO: Figure out more instances where we can use this without problems

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -328,7 +328,8 @@ struct cfg_root : cfg::node
 		cfg::_bool strict_rendering_mode{this, "Strict Rendering Mode"};
 		cfg::_bool disable_zcull_queries{this, "Disable ZCull Occlusion Queries", false};
 		cfg::_bool disable_vertex_cache{this, "Disable Vertex Cache", false};
-		cfg::_bool frame_skip_enabled{this, "Enable Frame Skip"};
+		cfg::_bool frame_skip_enabled{this, "Enable Frame Skip", false};
+		cfg::_bool force_cpu_blit_processing{this, "Force CPU Blit", false}; //Debugging option
 		cfg::_int<1, 8> consequtive_frames_to_draw{this, "Consecutive Frames To Draw", 1};
 		cfg::_int<1, 8> consequtive_frames_to_skip{this, "Consecutive Frames To Skip", 1};
 		cfg::_int<50, 800> resolution_scale_percent{this, "Resolution Scale", 100};

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -45,7 +45,8 @@
 		"debugOverlay": "Provides a graphical overlay of various debugging information.\nIf unsure, don't use this option.",
 		"logProg": "Dump game shaders to file. Only useful to developers.\nIf unsure, don't use this option.",
 		"disableOcclusionQueries": "Disables running occlusion queries. Minor to moderate performance boost.\nMight introduce issues with broken occlusion e.g missing geometry and extreme pop-in.",
-		"disableVertexCache": "Disables the vertex cache.\nMight resolve missing or flickering graphics output.\nMay degrade performance."
+		"disableVertexCache": "Disables the vertex cache.\nMight resolve missing or flickering graphics output.\nMay degrade performance.",
+		"forceCpuBlitEmulation": "Forces emulation of all blit and image manipulation operations on the cpu.\nRequires 'Write Color Buffers' option to also be enabled in most cases to avoid missing graphics.\nSignificatly degrades performance but is more accurate in some cases.\nThis setting overrides the 'GPU texture scaling' option."
 	},
 	"emulator": {
 		"gui": {

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -63,6 +63,7 @@ public:
 		AnisotropicFilterOverride,
 		ResolutionScale,
 		MinimumScalableDimension,
+		ForceCPUBlitEmulation,
 
 		// Audio
 		AudioRenderer,
@@ -212,6 +213,7 @@ private:
 		{ StrictRenderingMode,      { "Video", "Strict Rendering Mode"}},
 		{ DisableVertexCache,       { "Video", "Disable Vertex Cache"}},
 		{ DisableOcclusionQueries,  { "Video", "Disable ZCull Occlusion Queries" }},
+		{ ForceCPUBlitEmulation,    { "Video", "Force CPU Blit" }},
 		{ AnisotropicFilterOverride,{ "Video", "Anisotropic Filter Override" }},
 		{ ResolutionScale,          { "Video", "Resolution Scale" }},
 		{ MinimumScalableDimension, { "Video", "Minimum Scalable Dimension" }},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -937,6 +937,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xemu_settings->EnhanceCheckBox(ui->disableHwOcclusionQueries, emu_settings::DisableOcclusionQueries);
 	ui->disableHwOcclusionQueries->setToolTip(json_debug["disableOcclusionQueries"].toString());
 
+	xemu_settings->EnhanceCheckBox(ui->forceCpuBlitEmulation, emu_settings::ForceCPUBlitEmulation);
+	ui->forceCpuBlitEmulation->setToolTip(json_debug["forceCpuBlitEmulation"].toString());
+
 	// Checkboxes: core debug options
 	xemu_settings->EnhanceCheckBox(ui->ppuDebug, emu_settings::PPUDebug);
 	ui->ppuDebug->setToolTip(json_debug["ppuDebug"].toString());

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1554,6 +1554,13 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QCheckBox" name="forceCpuBlitEmulation">
+              <property name="text">
+               <string>Force CPU blit emulation</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>


### PR DESCRIPTION
- Fixes memory protection checks when strict mode is disabled. Should help prevent WCB from hanging the emulator
- Add a CPU-only mode for debugging texture management operations. While it is quite accurate, it is not perfect and is as expected is slow. Should only be used for debugging.