### PR TITLE
[Qt] Fix uninitialised values before usage

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -37,6 +37,8 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 	m_Text_Factor     = xgui_settings->GetValue(GUI::gl_textFactor).toReal();
 	m_showToolBar     = xgui_settings->GetValue(GUI::gl_toolBarVisible).toBool();
 	m_Icon_Color      = xgui_settings->GetValue(GUI::gl_iconColor).value<QColor>();
+	m_colSortOrder    = xgui_settings->GetValue(GUI::gl_sortAsc).toBool() ? Qt::AscendingOrder : Qt::DescendingOrder;
+	m_sortColumn      = xgui_settings->GetValue(GUI::gl_sortCol).toInt();
 
 	m_oldLayoutIsList = m_isListLayout;
 


### PR DESCRIPTION
The first call to the function `SortGameList` is done before the first call of `LoadSettings` or `OnColClicked` which set values for `m_sortColumn` and `m_colSortOrder`. As such, these variables are undefined and the execution of `m_gameList->sortByColumn(m_sortColumn, m_colSortOrder);` inside the `SortGameList` function uses uninitialised values.

The solution I am offering in this PR is to initialise the member variables `m_sortColumn` and `m_colSortOrder` in the constructor, before any method is called.
