### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/ring_buffer_helper.h
+++ b/rpcs3/Emu/RSX/Common/ring_buffer_helper.h
@@ -46,6 +46,8 @@ struct data_heap
 	size_t m_min_guard_size; //If an allocation touches the guard region, reset the heap to avoid going over budget
 	size_t m_current_allocated_size;
 	size_t m_largest_allocated_pool;
+
+	char* m_name;
 public:
 	data_heap() = default;
 	~data_heap() = default;
@@ -54,8 +56,10 @@ public:
 
 	size_t m_get_pos; // End of free space
 
-	void init(size_t heap_size, size_t min_guard_size=0x10000)
+	void init(size_t heap_size, const char* buffer_name = "unnamed", size_t min_guard_size=0x10000)
 	{
+		m_name = const_cast<char*>(buffer_name);
+
 		m_size = heap_size;
 		m_put_pos = 0;
 		m_get_pos = heap_size - 1;
@@ -71,8 +75,8 @@ public:
 	{
 		if (!can_alloc<Alignement>(size))
 		{
-			fmt::throw_exception("Working buffer not big enough, buffer_length=%d allocated=%d requested=%d guard=%d largest_pool=%d" HERE,
-					m_size, m_current_allocated_size, size, m_min_guard_size, m_largest_allocated_pool);
+			fmt::throw_exception("[%s] Working buffer not big enough, buffer_length=%d allocated=%d requested=%d guard=%d largest_pool=%d" HERE,
+					m_name, m_size, m_current_allocated_size, size, m_min_guard_size, m_largest_allocated_pool);
 		}
 
 		size_t alloc_size = align(size, Alignement);

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -616,6 +616,9 @@ namespace rsx
 					if (info.rsx_pitch != requested_pitch)
 						return false;
 
+					if (requested_width == 0 || requested_height == 0)
+						return true;
+
 					u16 real_width = requested_width;
 
 					if (scale_to_fit)
@@ -646,7 +649,7 @@ namespace rsx
 							return true;
 						}
 
-						if (info.surface_width >= requested_width && info.surface_height >= requested_height)
+						if (info.surface_width >= real_width && info.surface_height >= requested_height)
 						{
 							LOG_WARNING(RSX, "Overlapping surface exceeds bounds; returning full surface region");
 							w = real_width;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1019,8 +1019,13 @@ namespace rsx
 			//RSX only handles 512x512 tiles so texture 'stitching' will eventually be needed to be completely accurate
 			//Sections will be submitted as (512x512 + 512x512 + 256x512 + 512x208 + 512x208 + 256x208) to blit a 720p surface to the backbuffer for example
 			size2i dst_dimensions = { dst.pitch / (dst_is_argb8 ? 4 : 2), dst.height };
-			if (dst.max_tile_h > dst.height && src_is_render_target)
-				dst_dimensions.height = std::min((s32)dst.max_tile_h, 1024);
+			if (src_is_render_target)
+			{
+				if (dst_dimensions.width == src_subres.surface->get_surface_width())
+					dst_dimensions.height = std::max(src_subres.surface->get_surface_height(), dst.height);
+				else if (dst.max_tile_h > dst.height)
+					dst_dimensions.height = std::min((s32)dst.max_tile_h, 1024);
+			}
 
 			section_storage_type* cached_dest = nullptr;
 			bool invalidate_dst_range = false;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -165,7 +165,7 @@ namespace rsx
 		bool blit_engine_incompatibility_warning_raised = false;
 		
 		//Memory usage
-		const s32 m_max_zombie_objects = 128; //Limit on how many texture objects to keep around for reuse after they are invalidated
+		const s32 m_max_zombie_objects = 64; //Limit on how many texture objects to keep around for reuse after they are invalidated
 		std::atomic<s32> m_unreleased_texture_objects = { 0 }; //Number of invalidated objects not yet freed from memory
 		std::atomic<u32> m_texture_memory_in_use = { 0 };
 		
@@ -1239,7 +1239,7 @@ namespace rsx
 			return m_unreleased_texture_objects;
 		}
 
-		const u32 get_texture_memory_in_use() const
+		virtual const u32 get_texture_memory_in_use() const
 		{
 			return m_texture_memory_in_use;
 		}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2,6 +2,7 @@
 
 #include "../rsx_cache.h"
 #include "../rsx_utils.h"
+#include "TextureUtils.h"
 
 #include <atomic>
 
@@ -189,7 +190,6 @@ namespace rsx
 		std::vector<std::pair<section_storage_type*, ranged_storage*>> get_intersecting_set(u32 address, u32 range, bool check_whole_size)
 		{
 			std::vector<std::pair<section_storage_type*, ranged_storage*>> result;
-			bool response = false;
 			u64 cache_tag = get_system_time();
 			u32 last_dirty_block = UINT32_MAX;
 			std::pair<u32, u32> trampled_range = std::make_pair(address, address + range);
@@ -771,8 +771,11 @@ namespace rsx
 
 			u16 depth = 0;
 			u16 tex_height = (u16)tex.height();
+			u16 tex_pitch = tex.pitch();
 			const u16 tex_width = tex.width();
-			const u16 tex_pitch = is_compressed_format? (tex_size / tex_height) : tex.pitch(); //NOTE: Compressed textures dont have a real pitch (tex_size = (w*h)/6)
+
+			tex_pitch = is_compressed_format? (tex_size / tex_height) : tex_pitch; //NOTE: Compressed textures dont have a real pitch (tex_size = (w*h)/6)
+			if (tex_pitch == 0) tex_pitch = tex_width * get_format_block_size_in_bytes(format);
 
 			switch (extended_dimension)
 			{

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -250,7 +250,7 @@ namespace rsx
 		//2. A vector of all sections that should be flushed if the caller did not set the allow_flush method. That way the caller can make preparations on how to deal with sections that require flushing
 		//   Note that the sections will be unlocked regardless of the allow_flush flag
 		template <typename ...Args>
-		std::pair<bool, std::vector<section_storage_type*>> invalidate_range_impl_base(u32 address, u32 range, bool discard_only, bool rebuild_cache, bool allow_flush, Args&... extras)
+		std::pair<bool, std::vector<section_storage_type*>> invalidate_range_impl_base(u32 address, u32 range, bool discard_only, bool rebuild_cache, bool allow_flush, Args&&... extras)
 		{
 			auto trampled_set = get_intersecting_set(address, range, allow_flush);
 
@@ -324,7 +324,7 @@ namespace rsx
 		}
 
 		template <typename ...Args>
-		std::pair<bool, std::vector<section_storage_type*>> invalidate_range_impl(u32 address, u32 range, bool discard, bool allow_flush, Args&... extras)
+		std::pair<bool, std::vector<section_storage_type*>> invalidate_range_impl(u32 address, u32 range, bool discard, bool allow_flush, Args&&... extras)
 		{
 			return invalidate_range_impl_base(address, range, discard, false, allow_flush, std::forward<Args>(extras)...);
 		}
@@ -565,19 +565,19 @@ namespace rsx
 		}
 
 		template <typename ...Args>
-		std::pair<bool, std::vector<section_storage_type*>> invalidate_address(u32 address, bool allow_flush, Args&... extras)
+		std::pair<bool, std::vector<section_storage_type*>> invalidate_address(u32 address, bool allow_flush, Args&&... extras)
 		{
 			return invalidate_range(address, 4096 - (address & 4095), false, allow_flush, std::forward<Args>(extras)...);
 		}
 
 		template <typename ...Args>
-		std::pair<bool, std::vector<section_storage_type*>> flush_address(u32 address, Args&... extras)
+		std::pair<bool, std::vector<section_storage_type*>> flush_address(u32 address, Args&&... extras)
 		{
 			return invalidate_range(address, 4096 - (address & 4095), false, true, std::forward<Args>(extras)...);
 		}
 
 		template <typename ...Args>
-		std::pair<bool, std::vector<section_storage_type*>> invalidate_range(u32 address, u32 range, bool discard, bool allow_flush, Args&... extras)
+		std::pair<bool, std::vector<section_storage_type*>> invalidate_range(u32 address, u32 range, bool discard, bool allow_flush, Args&&... extras)
 		{
 			std::pair<u32, u32> trampled_range = std::make_pair(address, address + range);
 
@@ -595,7 +595,7 @@ namespace rsx
 		}
 
 		template <typename ...Args>
-		bool flush_all(std::vector<section_storage_type*>& sections_to_flush, Args&... extras)
+		bool flush_all(std::vector<section_storage_type*>& sections_to_flush, Args&&... extras)
 		{
 			reader_lock lock(m_cache_mutex);
 			for (const auto &tex: sections_to_flush)
@@ -701,7 +701,7 @@ namespace rsx
 		}
 
 		template <typename RsxTextureType, typename surface_store_type, typename ...Args>
-		image_view_type upload_texture(commandbuffer_type& cmd, RsxTextureType& tex, surface_store_type& m_rtts, Args&... extras)
+		image_view_type upload_texture(commandbuffer_type& cmd, RsxTextureType& tex, surface_store_type& m_rtts, Args&&... extras)
 		{
 			const u32 texaddr = rsx::get_address(tex.offset(), tex.location());
 			const u32 tex_size = (u32)get_texture_size(tex);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1210,7 +1210,7 @@ u64 GLGSRender::timestamp() const
 bool GLGSRender::on_access_violation(u32 address, bool is_writing)
 {
 	bool can_flush = (std::this_thread::get_id() == m_thread_id);
-	auto result = m_gl_texture_cache.invalidate_address(address, can_flush);
+	auto result = m_gl_texture_cache.invalidate_address(address, is_writing, can_flush);
 
 	if (!result.first)
 		return false;
@@ -1235,7 +1235,7 @@ bool GLGSRender::on_access_violation(u32 address, bool is_writing)
 void GLGSRender::on_notify_memory_unmapped(u32 address_base, u32 size)
 {
 	//Discard all memory in that range without bothering with writeback (Force it for strict?)
-	if (std::get<0>(m_gl_texture_cache.invalidate_range(address_base, size, true, false)))
+	if (std::get<0>(m_gl_texture_cache.invalidate_range(address_base, size, true, true, false)))
 		m_gl_texture_cache.purge_dirty();
 }
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -365,16 +365,21 @@ void GLGSRender::end()
 	//If ds is not initialized clear it; it seems new depth textures should have depth cleared
 	auto copy_rtt_contents = [](gl::render_target *surface)
 	{
-		//Copy data from old contents onto this one
-		//1. Clip a rectangular region defning the data
-		//2. Perform a GPU blit
-		u16 parent_w = surface->old_contents->width();
-		u16 parent_h = surface->old_contents->height();
-		u16 copy_w, copy_h;
+		if (surface->get_compatible_internal_format() == surface->old_contents->get_compatible_internal_format())
+		{
+			//Copy data from old contents onto this one
+			//1. Clip a rectangular region defning the data
+			//2. Perform a GPU blit
+			u16 parent_w = surface->old_contents->width();
+			u16 parent_h = surface->old_contents->height();
+			u16 copy_w, copy_h;
 
-		std::tie(std::ignore, std::ignore, copy_w, copy_h) = rsx::clip_region<u16>(parent_w, parent_h, 0, 0, surface->width(), surface->height(), true);
-		glCopyImageSubData(surface->old_contents->id(), GL_TEXTURE_2D, 0, 0, 0, 0, surface->id(), GL_TEXTURE_2D, 0, 0, 0, 0, copy_w, copy_h, 1);
-		surface->set_cleared();
+			std::tie(std::ignore, std::ignore, copy_w, copy_h) = rsx::clip_region<u16>(parent_w, parent_h, 0, 0, surface->width(), surface->height(), true);
+			glCopyImageSubData(surface->old_contents->id(), GL_TEXTURE_2D, 0, 0, 0, 0, surface->id(), GL_TEXTURE_2D, 0, 0, 0, 0, copy_w, copy_h, 1);
+			surface->set_cleared();
+		}
+		//TODO: download image contents and reupload them or do a memory cast to copy memory contents if not compatible
+
 		surface->old_contents = nullptr;
 	};
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1204,7 +1204,7 @@ u64 GLGSRender::timestamp() const
 
 bool GLGSRender::on_access_violation(u32 address, bool is_writing)
 {
-	bool can_flush = (std::this_thread::get_id() != m_thread_id);
+	bool can_flush = (std::this_thread::get_id() == m_thread_id);
 	auto result = m_gl_texture_cache.invalidate_address(address, can_flush);
 
 	if (!result.first)
@@ -1224,7 +1224,7 @@ bool GLGSRender::on_access_violation(u32 address, bool is_writing)
 		return true;
 	}
 
-	return false;
+	return true;
 }
 
 void GLGSRender::on_notify_memory_unmapped(u32 address_base, u32 size)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -28,7 +28,7 @@ struct work_item
 	std::mutex guard_mutex;
 
 	u32  address_to_flush = 0;
-	gl::cached_texture_section *section_to_flush = nullptr;
+	std::vector<gl::cached_texture_section*> sections_to_flush;
 
 	volatile bool processed = false;
 	volatile bool result = false;
@@ -428,7 +428,7 @@ public:
 	void set_viewport();
 
 	void synchronize_buffers();
-	work_item& post_flush_request(u32 address, gl::cached_texture_section *section);
+	work_item& post_flush_request(u32 address, std::vector<gl::cached_texture_section*>& sections);
 
 	bool scaled_image_from_memory(rsx::blit_src_info& src_info, rsx::blit_dst_info& dst_info, bool interpolate) override;
 	

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -403,7 +403,7 @@ void GLGSRender::read_buffers()
 					}
 					else
 					{
-						m_gl_texture_cache.invalidate_range(texaddr, range);
+						m_gl_texture_cache.invalidate_range(texaddr, range, false, true);
 
 						std::unique_ptr<u8[]> buffer(new u8[pitch * height]);
 						color_buffer.read(buffer.get(), width, height, pitch);

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -403,7 +403,7 @@ void GLGSRender::read_buffers()
 					}
 					else
 					{
-						m_gl_texture_cache.invalidate_range(texaddr, range, false, true);
+						m_gl_texture_cache.invalidate_range(texaddr, range, false, false, true);
 
 						std::unique_ptr<u8[]> buffer(new u8[pitch * height]);
 						color_buffer.read(buffer.get(), width, height, pitch);

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -473,6 +473,7 @@ namespace gl
 
 		glBindTexture(target, id);
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+		glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 		glTexParameteri(target, GL_TEXTURE_BASE_LEVEL, 0);
 		glTexParameteri(target, GL_TEXTURE_MAX_LEVEL, mipmaps - 1);
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -443,21 +443,20 @@ namespace gl
 			{
 				//Read-only texture, destroy texture memory
 				glDeleteTextures(1, &vram_texture);
-				vram_texture = 0;
 			}
 			else
 			{
 				//Destroy pbo cache since vram texture is managed elsewhere
 				glDeleteBuffers(1, &pbo_id);
-				pbo_id = 0;
-				pbo_size = 0;
 
 				if (scaled_texture)
-				{
 					glDeleteTextures(1, &scaled_texture);
-					scaled_texture = 0;
-				}
 			}
+
+			vram_texture = 0;
+			scaled_texture = 0;
+			pbo_id = 0;
+			pbo_size = 0;
 
 			if (!m_fence.is_empty())
 				m_fence.destroy();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -739,8 +739,11 @@ VKGSRender::~VKGSRender()
 
 bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 {
-	std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
-	auto result = m_texture_cache.invalidate_address(address, is_writing, false, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+	std::pair<bool, std::vector<vk::cached_texture_section*>> result;
+	{
+		std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
+		result = std::move(m_texture_cache.invalidate_address(address, is_writing, false, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue()));
+	}
 
 	if (!result.first)
 		return false;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1076,7 +1076,7 @@ void VKGSRender::end()
 				continue;
 			}
 
-			vk::image_view *texture0 = m_texture_cache.upload_texture(*m_current_command_buffer, rsx::method_registers.fragment_textures[i], m_rtts);
+			vk::image_view *texture0 = m_texture_cache._upload_texture(*m_current_command_buffer, rsx::method_registers.fragment_textures[i], m_rtts);
 
 			if (!texture0)
 			{
@@ -1131,7 +1131,7 @@ void VKGSRender::end()
 				continue;
 			}
 
-			vk::image_view *texture0 = m_texture_cache.upload_texture(*m_current_command_buffer, rsx::method_registers.vertex_textures[i], m_rtts);
+			vk::image_view *texture0 = m_texture_cache._upload_texture(*m_current_command_buffer, rsx::method_registers.vertex_textures[i], m_rtts);
 
 			if (!texture0)
 			{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -740,7 +740,7 @@ VKGSRender::~VKGSRender()
 bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 {
 	std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
-	auto result = m_texture_cache.invalidate_address(address, false, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+	auto result = m_texture_cache.invalidate_address(address, is_writing, false, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
 
 	if (!result.first)
 		return false;
@@ -831,7 +831,7 @@ bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 void VKGSRender::on_notify_memory_unmapped(u32 address_base, u32 size)
 {
 	std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
-	if (std::get<0>(m_texture_cache.invalidate_range(address_base, size, false, false,
+	if (std::get<0>(m_texture_cache.invalidate_range(address_base, size, true, true, false,
 		*m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue())))
 	{
 		m_texture_cache.purge_dirty();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -583,13 +583,13 @@ VKGSRender::VKGSRender() : GSRender()
 	semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
 
 	//VRAM allocation
-	m_attrib_ring_info.init(VK_ATTRIB_RING_BUFFER_SIZE_M * 0x100000, 0x400000);
+	m_attrib_ring_info.init(VK_ATTRIB_RING_BUFFER_SIZE_M * 0x100000, "attrib buffer", 0x400000);
 	m_attrib_ring_info.heap.reset(new vk::buffer(*m_device, VK_ATTRIB_RING_BUFFER_SIZE_M * 0x100000, m_memory_type_mapping.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, 0));
-	m_uniform_buffer_ring_info.init(VK_UBO_RING_BUFFER_SIZE_M * 0x100000);
+	m_uniform_buffer_ring_info.init(VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "uniform buffer");
 	m_uniform_buffer_ring_info.heap.reset(new vk::buffer(*m_device, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, m_memory_type_mapping.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0));
-	m_index_buffer_ring_info.init(VK_INDEX_RING_BUFFER_SIZE_M * 0x100000);
+	m_index_buffer_ring_info.init(VK_INDEX_RING_BUFFER_SIZE_M * 0x100000, "index buffer");
 	m_index_buffer_ring_info.heap.reset(new vk::buffer(*m_device, VK_INDEX_RING_BUFFER_SIZE_M * 0x100000, m_memory_type_mapping.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, 0));
-	m_texture_upload_buffer_ring_info.init(VK_TEXTURE_UPLOAD_RING_BUFFER_SIZE_M * 0x100000);
+	m_texture_upload_buffer_ring_info.init(VK_TEXTURE_UPLOAD_RING_BUFFER_SIZE_M * 0x100000, "texture upload buffer", 0x400000);
 	m_texture_upload_buffer_ring_info.heap.reset(new vk::buffer(*m_device, VK_TEXTURE_UPLOAD_RING_BUFFER_SIZE_M * 0x100000, m_memory_type_mapping.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0));
 
 	for (auto &ctx : frame_context_storage)
@@ -739,105 +739,90 @@ VKGSRender::~VKGSRender()
 
 bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 {
-	if (is_writing)
-		return m_texture_cache.invalidate_address(address);
-	else
+	std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
+	auto result = m_texture_cache.invalidate_address(address, false, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+
+	if (!result.first)
+		return false;
+
+	if (result.second.size() > 0)
 	{
-		if (g_cfg.video.write_color_buffers || g_cfg.video.write_depth_buffer)
+		const bool is_rsxthr = std::this_thread::get_id() == rsx_thread;
+		bool has_queue_ref = false;
+
+		u64 sync_timestamp = 0ull;
+		for (const auto& tex : result.second)
+			sync_timestamp = std::max(sync_timestamp, tex->get_sync_timestamp());
+
+		if (!is_rsxthr)
 		{
-			bool flushable;
-			vk::cached_texture_section* section;
+			vm::temporary_unlock();
+		}
 
-			std::tie(flushable, section) = m_texture_cache.address_is_flushable(address);
-			
-			if (!flushable)
-				return false;
-				
-			const u64 sync_timestamp = section->get_sync_timestamp();
-			const bool is_rsxthr = std::this_thread::get_id() == rsx_thread;
-
-			if (section->is_synchronized())
+		if (sync_timestamp > 0)
+		{
+			//Wait for any cb submitted after the sync timestamp to finish
+			while (true)
 			{
-				//Wait for any cb submitted after the sync timestamp to finish
-				while (true)
-				{
-					u32 pending = 0;
+				u32 pending = 0;
 
-					if (m_last_flushable_cb < 0)
+				if (m_last_flushable_cb < 0)
+					break;
+
+				for (auto &cb : m_primary_cb_list)
+				{
+					if (!cb.pending && cb.last_sync >= sync_timestamp)
+					{
+						pending = 0;
 						break;
-
-					for (auto &cb : m_primary_cb_list)
-					{
-						if (!cb.pending && cb.last_sync >= sync_timestamp)
-						{
-							pending = 0;
-							break;
-						}
-
-						if (cb.pending)
-						{
-							pending++;
-
-							if (is_rsxthr)
-								cb.poke();
-						}
 					}
 
-					if (!pending)
-						break;
+					if (cb.pending)
+					{
+						pending++;
 
-					std::this_thread::yield();
+						if (is_rsxthr)
+							cb.poke();
+					}
 				}
 
-				if (is_rsxthr)
-					m_last_flushable_cb = -1;
+				if (!pending)
+					break;
+
+				std::this_thread::yield();
 			}
-			else
-			{
-				//This region is buffered, but no previous sync point has been put in place to start sync efforts
-				//Just stall and get what we have at this point
-				if (!is_rsxthr)
-				{
-					{
-						std::lock_guard<std::mutex> lock(m_flush_queue_mutex);
 
-						m_flush_commands = true;
-						m_queued_threads++;
-					}
-
-					//Wait for the RSX thread to process
-					while (m_flush_commands)
-					{
-						_mm_lfence();
-						_mm_pause();
-					}
-
-					std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
-					bool status = m_texture_cache.flush_address(address, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
-
-					m_queued_threads--;
-					_mm_sfence();
-
-					return status;
-				}
-				else
-				{
-					//NOTE: If the rsx::thread is trampling its own data, we have an operation that should be moved to the GPU
-					//We should never interrupt our own cb recording since some operations are not interruptible
-					if (!vk::is_uninterruptible())
-						//TODO: Investigate driver behaviour to determine if we need a hard sync or a soft flush
-						flush_command_queue();
-				}
-			}
+			if (is_rsxthr)
+				m_last_flushable_cb = -1;
 		}
 		else
 		{
-			//If we aren't managing buffer sync, dont bother checking the cache
-			return false;
+			if (!is_rsxthr)
+			{
+				{
+					std::lock_guard<std::mutex> lock(m_flush_queue_mutex);
+
+					m_flush_commands = true;
+					m_queued_threads++;
+				}
+
+				//Wait for the RSX thread to process
+				while (m_flush_commands)
+				{
+					_mm_lfence();
+					_mm_pause();
+				}
+
+				has_queue_ref = true;
+			}
 		}
 
-		std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
-		return m_texture_cache.flush_address(address, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+		m_texture_cache.flush_all(result.second, *m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue());
+
+		if (has_queue_ref)
+		{
+			m_queued_threads--;
+		}
 	}
 
 	return false;
@@ -845,8 +830,12 @@ bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 
 void VKGSRender::on_notify_memory_unmapped(u32 address_base, u32 size)
 {
-	if (m_texture_cache.invalidate_range(address_base, size, false))
+	std::lock_guard<std::mutex> lock(m_secondary_cb_guard);
+	if (std::get<0>(m_texture_cache.invalidate_range(address_base, size, false, false,
+		*m_device, m_secondary_command_buffer, m_memory_type_mapping, m_swap_chain->get_present_queue())))
+	{
 		m_texture_cache.purge_dirty();
+	}
 }
 
 void VKGSRender::begin()
@@ -2651,7 +2640,9 @@ void VKGSRender::flip(int buffer)
 		m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 90, direct_fbo->width(), direct_fbo->height(), "submit and flip: " + std::to_string(m_flip_time) + "us");
 
 		auto num_dirty_textures = m_texture_cache.get_unreleased_textures_count();
+		auto texture_memory_size = m_texture_cache.get_texture_memory_in_use() / (1024 * 1024);
 		m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 126, direct_fbo->width(), direct_fbo->height(), "Unreleased textures: " + std::to_string(num_dirty_textures));
+		m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 144, direct_fbo->width(), direct_fbo->height(), "Texture memory: " + std::to_string(texture_memory_size) + "M");
 
 		vk::change_image_layout(*m_current_command_buffer, target_image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, subres);
 		m_framebuffers_to_clean.push_back(std::move(direct_fbo));

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -679,8 +679,7 @@ namespace vk
 		template<typename RsxTextureType>
 		image_view* _upload_texture(vk::command_buffer& cmd, RsxTextureType& tex, rsx::vk_render_targets& m_rtts)
 		{
-			const VkQueue& queue = m_submit_queue;
-			return upload_texture(cmd, tex, m_rtts, *m_device, cmd, m_memory_types, queue);
+			return upload_texture(cmd, tex, m_rtts, *m_device, cmd, m_memory_types, const_cast<const VkQueue>(m_submit_queue));
 		}
 
 		bool blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, rsx::vk_render_targets& m_rtts, vk::command_buffer& cmd)
@@ -721,8 +720,7 @@ namespace vk
 			}
 			helper(&cmd);
 
-			const VkQueue& queue = m_submit_queue;
-			return upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper, *m_device, cmd, m_memory_types, queue);
+			return upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper, *m_device, cmd, m_memory_types, const_cast<const VkQueue>(m_submit_queue));
 		}
 
 		const u32 get_unreleased_textures_count() const override

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -347,6 +347,7 @@ namespace vk
 
 			m_discardable_storage.clear();
 			m_unreleased_texture_objects = 0;
+			m_texture_memory_in_use = 0;
 		}
 		
 	protected:
@@ -707,12 +708,13 @@ namespace vk
 			}
 			helper(&cmd);
 
-			return upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper, *m_device, cmd, m_memory_types, m_submit_queue);
+			const VkQueue& queue = m_submit_queue;
+			return upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper, *m_device, cmd, m_memory_types, queue);
 		}
 
 		const u32 get_unreleased_textures_count() const override
 		{
-			return std::max(m_unreleased_texture_objects, 0) + (u32)m_discardable_storage.size();
+			return m_unreleased_texture_objects + (u32)m_discardable_storage.size();
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -676,6 +676,13 @@ namespace vk
 			m_discardable_storage.remove_if([&](const discarded_storage& o) {return o.test(last_complete_frame);});
 		}
 
+		template<typename RsxTextureType>
+		image_view* _upload_texture(vk::command_buffer& cmd, RsxTextureType& tex, rsx::vk_render_targets& m_rtts)
+		{
+			const VkQueue& queue = m_submit_queue;
+			return upload_texture(cmd, tex, m_rtts, *m_device, cmd, m_memory_types, queue);
+		}
+
 		bool blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, rsx::vk_render_targets& m_rtts, vk::command_buffer& cmd)
 		{
 			struct blit_helper

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -80,6 +80,12 @@ namespace vk
 			}
 		}
 
+		void destroy()
+		{
+			vram_texture = nullptr;
+			release_dma_resources();
+		}
+
 		bool exists() const
 		{
 			return (vram_texture != nullptr);
@@ -355,7 +361,7 @@ namespace vk
 		void free_texture_section(cached_texture_section& tex) override
 		{
 			m_discardable_storage.push_back(tex);
-			tex.release_dma_resources();
+			tex.destroy();
 		}
 
 		vk::image_view* create_temporary_subresource_view(vk::command_buffer& cmd, vk::image* source, u32 /*gcm_format*/, u16 x, u16 y, u16 w, u16 h) override
@@ -394,7 +400,7 @@ namespace vk
 
 			VkImageCopy copy_rgn;
 			copy_rgn.srcOffset = { (s32)x, (s32)y, 0 };
-			copy_rgn.dstOffset = { (s32)x, (s32)y, 0 };
+			copy_rgn.dstOffset = { (s32)0, (s32)0, 0 };
 			copy_rgn.dstSubresource = { aspect, 0, 0, 1 };
 			copy_rgn.srcSubresource = { aspect, 0, 0, 1 };
 			copy_rgn.extent = { w, h, 1 };

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -238,6 +238,11 @@ namespace rsx
 
 			return std::make_pair(min, max);
 		}
+
+		utils::protection get_protection()
+		{
+			return protection;
+		}
 	};
 
 	template <typename pipeline_storage_type, typename backend_storage>


### PR DESCRIPTION
Fixes the remaining regressions with the new texture cache. Also adds a few improvements elsewhere
- Fix clipping bug when using vulkan + gpu texture scaling
- Restructures the texture cache to contain section manipulation to one function
- Fix debug counters for texture cache. Also track texture memory usage
- Fix some leaking memory sections
- Fix surface subsection sampling ("Turbo: Super Stunt Squad)
- Fix crashing due to 0 pitch (VirtualMemory.cpp crash)
- Add buffer names to vulkan heaps to help debug OOM crashes ("Working buffer not enough" crash)
- Better detection of situations that would require memory stitching (framebuffer blit operations). Should fix black screen regressions in some games