### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -31,7 +31,7 @@ GLGSRender::GLGSRender() : GSRender()
 	else
 		m_vertex_cache.reset(new gl::weak_vertex_cache());
 
-	supports_multidraw = true;
+	supports_multidraw = !g_cfg.video.strict_rendering_mode;
 }
 
 extern CellGcmContextData current_context;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1571,6 +1571,7 @@ namespace rsx
 		u32 volatile_offset = 0;
 		u32 persistent_offset = 0;
 
+		//NOTE: Order is important! Transient ayout is always push_buffers followed by register data
 		if (rsx::method_registers.current_draw_clause.is_immediate_draw)
 		{
 			for (const auto &info : layout.volatile_blocks)
@@ -1765,12 +1766,7 @@ namespace rsx
 				return;
 			}
 
-			for (const u8 index : layout.referenced_registers)
-			{
-				memcpy(transient, rsx::method_registers.register_vertex_info[index].data.data(), 16);
-				transient += 16;
-			}
-
+			//NOTE: Order is important! Transient ayout is always push_buffers followed by register data
 			if (draw_call.is_immediate_draw)
 			{
 				//NOTE: It is possible for immediate draw to only contain index data, so vertex data can be in persistent memory
@@ -1779,6 +1775,12 @@ namespace rsx
 					memcpy(transient, vertex_push_buffers[info.first].data.data(), info.second);
 					transient += info.second;
 				}
+			}
+
+			for (const u8 index : layout.referenced_registers)
+			{
+				memcpy(transient, rsx::method_registers.register_vertex_info[index].data.data(), 16);
+				transient += 16;
 			}
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -641,7 +641,7 @@ VKGSRender::VKGSRender() : GSRender()
 	m_texture_cache.initialize((*m_device), m_memory_type_mapping, m_optimal_tiling_supported_formats, m_swap_chain->get_present_queue(),
 			m_texture_upload_buffer_ring_info, m_texture_upload_buffer_ring_info.heap.get());
 
-	supports_multidraw = true;
+	supports_multidraw = !g_cfg.video.strict_rendering_mode;
 }
 
 VKGSRender::~VKGSRender()


### PR DESCRIPTION
- Disable draw call batching when strict mode is enabled. Strict mode should always use the safest option and the batching solution has been shown to fail in rare cases (Okami HD)
- Fix a critical bug in volatile attribute layouts that was introduced during vertex rewrite but went unnoticed. Likely fixes corrupt graphics or black screen in some games, probably only affects 2D elements since it requires immediate-mode drawing plus at least one referenced data register to trigger this condition.