### PR TITLE
Revert Qt requirements to version 5.7 on Linux in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to contribute please take a look at the [Coding Style](https://githu
 * [Visual Studio Qt Plugin](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools2015) (optional; see above)
 
 ### Linux
-* [Qt 5.8+](https://www.qt.io/download-open-source/)
+* [Qt 5.7+](https://www.qt.io/download-open-source/)
 * GCC 5.1+ or Clang 3.5.0+ ([not GCC 6.1](https://github.com/RPCS3/rpcs3/issues/1691))
 * Debian & Ubuntu: `sudo apt-get install cmake build-essential libasound2-dev libopenal-dev libglew-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git qt5-default`
 * Arch: `sudo pacman -S glew openal cmake llvm qt5-base`

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -29,8 +29,8 @@ if (NOT Qt5Widgets_FOUND)
 		if ("${CMAKE_SYSTEM}" MATCHES "Linux")
 			message(FATAL_ERROR "Most distros do not provide an up-to-date version of Qt.
 If you're on Ubuntu or Linux Mint, there are PPAs you can use to install an up-to-date qt5 version.
-        https://launchpad.net/~beineri/+archive/ubuntu/opt-qt591-xenial
-        https://launchpad.net/~beineri/+archive/ubuntu/opt-qt591-trusty
+        https://launchpad.net/~beineri/+archive/ubuntu/opt-qt592-xenial
+        https://launchpad.net/~beineri/+archive/ubuntu/opt-qt592-trusty
 just make sure to run
     source /opt/qt59/bin/qt59-env.sh
 before re-running cmake")


### PR DESCRIPTION
- Partially revert dbf1573e890d5d0ae18ecda7e5cdc81e4dcefaa7 to bring back Qt 5.7 as the minimum requirement for Linux in the README.md file
- Update the PPA urls displayed by CMake when Qt is missing