### PR TITLE
Small rsx/spu fixes

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -999,6 +999,7 @@ u32 SPUThread::get_ch_count(u32 ch)
 	case SPU_RdSigNotify2:    return ch_snr2.get_count();
 	case MFC_RdAtomicStat:    return ch_atomic_stat.get_count();
 	case SPU_RdEventStat:     return get_events() != 0;
+	case MFC_Cmd:             return std::max(16 - mfc_queue.size(), (u32)0);
 	}
 
 	fmt::throw_exception("Unknown/illegal channel (ch=%d [%s])" HERE, ch, ch < 128 ? spu_ch_name[ch] : "???");

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1435,8 +1435,9 @@ bool SPUThread::set_ch_value(u32 ch, u32 value)
 	case MFC_Cmd:
 	{
 		ch_mfc_cmd.cmd = MFC(value & 0xff);
+		auto cmd = ch_mfc_cmd; // save and restore previous command arguments
 		process_mfc_cmd();
-		ch_mfc_cmd = {}; // clear non-persistent data
+		ch_mfc_cmd = cmd;
 		return true;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -323,6 +323,12 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 		//a5 low bits = ret.format = base | ((base + ((size - 1) / 0x10000)) << 13) | (comp << 26) | (1 << 30);
 
 		auto& tile = render->tiles[a3];
+		
+		// When tile is going to be unbinded, we can use it as a hint that the address will no longer be used as a surface and can be removed/invalidated 
+		// Todo: There may be more checks such as format/size/width can could be done
+		if (tile.binded && a5 == 0)
+			render->notify_tile_unbound(a3);
+
 		tile.location = ((a4 >> 32) & 0xF) - 1;
 		tile.offset = ((((a4 >> 32) & 0xFFFFFFFF) >> 16) * 0x10000);
 		tile.size = ((((a4 & 0x7FFFFFFF) >> 16) + 1) * 0x10000) - tile.offset;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -242,6 +242,7 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 	case 0x001: // FIFO
 		render->ctrl->get = a3;
 		render->ctrl->put = a4;
+		render->internal_get = a3;
 		break;
 
 	case 0x100: // Display mode set

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -518,6 +518,31 @@ namespace rsx
 		}
 
 		/**
+		 * Invalidates surface that exists at an address
+		 */
+		void invalidate_surface_address(u32 addr, bool depth)
+		{
+			if (!depth)
+			{
+				auto It = m_render_targets_storage.find(addr);
+				if (It != m_render_targets_storage.end())
+				{
+					invalidated_resources.push_back(std::move(It->second));
+					m_render_targets_storage.erase(It);
+				}
+			}
+			else
+			{
+				auto It = m_depth_stencil_storage.find(addr);
+				if (It != m_depth_stencil_storage.end())
+				{
+					invalidated_resources.push_back(std::move(It->second));
+					m_depth_stencil_storage.erase(It);
+				}
+			}
+		}
+
+		/**
 		 * Clipping and fitting lookup funcrions
 		 * surface_overlaps - returns true if surface overlaps a given surface address and returns the relative x and y position of the surface address within the surface
 		 * address_is_bound - returns true if the surface at a given address is actively bound

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -183,4 +183,5 @@ protected:
 	virtual std::array<std::vector<gsl::byte>, 4> copy_render_targets_to_memory() override;
 	virtual std::array<std::vector<gsl::byte>, 2> copy_depth_stencil_buffer_to_memory() override;
 	virtual std::pair<std::string, std::string> get_programs() const override;
+	virtual void notify_tile_unbound(u32 tile) override;
 };

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -316,4 +316,10 @@ std::pair<std::string, std::string> D3D12GSRender::get_programs() const
 {
 	return std::make_pair(m_pso_cache.get_transform_program(current_vertex_program).content, m_pso_cache.get_shader_program(current_fragment_program).content);
 }
+
+void D3D12GSRender::notify_tile_unbound(u32 tile)
+{
+	u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
+	m_rtts.invalidate_surface_address(addr, false);
+}
 #endif

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1286,6 +1286,12 @@ bool GLGSRender::scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst
 	return m_gl_texture_cache.blit(src, dst, interpolate, m_rtts);
 }
 
+void GLGSRender::notify_tile_unbound(u32 tile)
+{
+	u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
+	m_rtts.invalidate_surface_address(addr, false);
+}
+
 void GLGSRender::check_zcull_status(bool framebuffer_swap, bool force_read)
 {
 	if (g_cfg.video.disable_zcull_queries)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -453,6 +453,7 @@ protected:
 
 	bool on_access_violation(u32 address, bool is_writing) override;
 	void on_notify_memory_unmapped(u32 address_base, u32 size) override;
+	void notify_tile_unbound(u32 tile) override;
 
 	virtual std::array<std::vector<gsl::byte>, 4> copy_render_targets_to_memory() override;
 	virtual std::array<std::vector<gsl::byte>, 2> copy_depth_stencil_buffer_to_memory() override;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -477,10 +477,10 @@ namespace rsx
 			//Execute backend-local tasks first
 			do_local_task();
 
-			const u32 get = ctrl->get;
+			ctrl->get.store(internal_get.load());
 			const u32 put = ctrl->put;
 
-			if (put == get || !Emu.IsRunning())
+			if (put == internal_get || !Emu.IsRunning())
 			{
 				if (has_deferred_call)
 					flush_command_queue();
@@ -491,16 +491,16 @@ namespace rsx
 
 			//Validate put and get registers
 			//TODO: Who should handle graphics exceptions??
-			const u32 get_address = RSXIOMem.RealAddr(get);
+			const u32 get_address = RSXIOMem.RealAddr(internal_get);
 			
 			if (!get_address)
 			{
-				LOG_ERROR(RSX, "Invalid FIFO queue get/put registers found, get=0x%X, put=0x%X", get, put);
+				LOG_ERROR(RSX, "Invalid FIFO queue get/put registers found, get=0x%X, put=0x%X", internal_get.load(), put);
 
 				if (mem_faults_count >= 3)
 				{
 					LOG_ERROR(RSX, "Application has failed to recover, discarding FIFO queue");
-					ctrl->get = put;
+					internal_get = put;
 				}
 				else
 				{
@@ -512,29 +512,29 @@ namespace rsx
 				continue;
 			}
 
-			const u32 cmd = ReadIO32(get);
+			const u32 cmd = ReadIO32(internal_get);
 			const u32 count = (cmd >> 18) & 0x7ff;
 
 			if ((cmd & RSX_METHOD_OLD_JUMP_CMD_MASK) == RSX_METHOD_OLD_JUMP_CMD)
 			{
 				u32 offs = cmd & 0x1ffffffc;
 				//LOG_WARNING(RSX, "rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", offs, m_ioAddress + get, cmd, get, put);
-				ctrl->get = offs;
+				internal_get = offs;
 				continue;
 			}
 			if ((cmd & RSX_METHOD_NEW_JUMP_CMD_MASK) == RSX_METHOD_NEW_JUMP_CMD)
 			{
 				u32 offs = cmd & 0xfffffffc;
 				//LOG_WARNING(RSX, "rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", offs, m_ioAddress + get, cmd, get, put);
-				ctrl->get = offs;
+				internal_get = offs;
 				continue;
 			}
 			if ((cmd & RSX_METHOD_CALL_CMD_MASK) == RSX_METHOD_CALL_CMD)
 			{
-				m_call_stack.push(get + 4);
+				m_call_stack.push(internal_get + 4);
 				u32 offs = cmd & ~3;
 				//LOG_WARNING(RSX, "rsx call(0x%x) #0x%x - 0x%x", offs, cmd, get);
-				ctrl->get = offs;
+				internal_get = offs;
 				continue;
 			}
 			if (cmd == RSX_METHOD_RETURN_CMD)
@@ -542,26 +542,26 @@ namespace rsx
 				u32 get = m_call_stack.top();
 				m_call_stack.pop();
 				//LOG_WARNING(RSX, "rsx return(0x%x)", get);
-				ctrl->get = get;
+				internal_get = get;
 				continue;
 			}
 			if (cmd == 0) //nop
 			{
-				ctrl->get = get + 4;
+				internal_get += 4;
 				continue;
 			}
 
 			//Validate the args ptr if the command attempts to read from it
-			const u32 args_address = RSXIOMem.RealAddr(get + 4);
+			const u32 args_address = RSXIOMem.RealAddr(internal_get + 4);
 
 			if (!args_address && count)
 			{
-				LOG_ERROR(RSX, "Invalid FIFO queue args ptr found, get=0x%X, cmd=0x%X, count=%d", get, cmd, count);
+				LOG_ERROR(RSX, "Invalid FIFO queue args ptr found, get=0x%X, cmd=0x%X, count=%d", internal_get.load(), cmd, count);
 
 				if (mem_faults_count >= 3)
 				{
 					LOG_ERROR(RSX, "Application has failed to recover, discarding FIFO queue");
-					ctrl->get = put;
+					internal_get = put;
 				}
 				else
 				{
@@ -706,6 +706,7 @@ namespace rsx
 				if (invalid_command_interrupt_raised)
 				{
 					//Skip the rest of this command
+					internal_get = put;
 					break;
 				}
 			}
@@ -714,11 +715,11 @@ namespace rsx
 			{
 				//This is almost guaranteed to be heap corruption at this point
 				//Ignore the rest of the chain
-				ctrl->get = put;
+				internal_get = put;
 				continue;
 			}
 
-			ctrl->get = get + (count + 1) * 4;
+			internal_get += (count + 1) * 4;
 		}
 	}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -706,7 +706,6 @@ namespace rsx
 				if (invalid_command_interrupt_raised)
 				{
 					//Skip the rest of this command
-					internal_get = put;
 					break;
 				}
 			}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -258,6 +258,7 @@ namespace rsx
 		virtual u64 timestamp() const;
 		virtual bool on_access_violation(u32 /*address*/, bool /*is_writing*/) { return false; }
 		virtual void on_notify_memory_unmapped(u32 /*address_base*/, u32 /*size*/) {}
+		virtual void notify_tile_unbound(u32 tile) {}
 
 		//zcull
 		virtual void notify_zcull_info_changed() {}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -151,6 +151,7 @@ namespace rsx
 
 	public:
 		RsxDmaControl* ctrl = nullptr;
+		atomic_t<u32> internal_get{ 0 };
 
 		Timer timer_sync;
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2685,3 +2685,9 @@ bool VKGSRender::scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst
 
 	return result;
 }
+
+void VKGSRender::notify_tile_unbound(u32 tile)
+{
+	u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
+	m_rtts.invalidate_surface_address(addr, false);
+}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -316,6 +316,7 @@ protected:
 
 	void do_local_task() override;
 	bool scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate) override;
+	void notify_tile_unbound(u32 tile) override;
 
 	bool on_access_violation(u32 address, bool is_writing) override;
 	void on_notify_memory_unmapped(u32 address_base, u32 size) override;


### PR DESCRIPTION
- Invalidate surface store address when tile unbound
Fixes #3134 and LBP karting

- Implement readch(mfc_cmd) 
Fixes #2819

- Make dmactrl get 'readonly' 
rsx accuracy change, currently its possible to edit the get ptr from the game side and cause the rsxthread to freak out. It should only be able to be changed from the syscall, so we use an internal variable to keep track of command buffer position and write it to get ptr now

- Save and restore mfc cmd
spu accuracy change, docs state registers are in an 'undefined state' after writing to mfc_cmd, but in practice though, they are just left alone
