### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -947,15 +947,17 @@ bool GLGSRender::check_program_state()
 		if (!is_depth)
 			surface = m_rtts.get_texture_from_render_target_if_applicable(texaddr);
 		else
-		{
 			surface = m_rtts.get_texture_from_depth_stencil_if_applicable(texaddr);
 
-			if (!surface && m_gl_texture_cache.is_depth_texture(texaddr, (u32)get_texture_size(tex)))
-				return std::make_tuple(true, 0);
-		}
-
-		if (!surface)
+		const bool dirty_framebuffer = (surface != nullptr && !m_gl_texture_cache.test_framebuffer(texaddr));
+		if (dirty_framebuffer || !surface)
 		{
+			if (is_depth && m_gl_texture_cache.is_depth_texture(texaddr, (u32)get_texture_size(tex)))
+				return std::make_tuple(true, 0);
+
+			if (dirty_framebuffer)
+				return std::make_tuple(false, 0);
+
 			auto rsc = m_rtts.get_surface_subresource_if_applicable(texaddr, 0, 0, tex.pitch());
 			if (!rsc.surface || rsc.is_depth_surface != is_depth)
 				return std::make_tuple(false, 0);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -28,7 +28,7 @@ struct work_item
 	std::mutex guard_mutex;
 
 	u32  address_to_flush = 0;
-	std::vector<gl::cached_texture_section*> sections_to_flush;
+	gl::texture_cache::thrashed_set section_data;
 
 	volatile bool processed = false;
 	volatile bool result = false;
@@ -428,7 +428,7 @@ public:
 	void set_viewport();
 
 	void synchronize_buffers();
-	work_item& post_flush_request(u32 address, std::vector<gl::cached_texture_section*>& sections);
+	work_item& post_flush_request(u32 address, gl::texture_cache::thrashed_set& flush_data);
 
 	bool scaled_image_from_memory(rsx::blit_src_info& src_info, rsx::blit_dst_info& dst_info, bool interpolate) override;
 	

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -224,7 +224,7 @@ void GLGSRender::init_buffers(bool skip_reading)
 
 			//Verify pitch given is correct if pitch <= 64 (especially 64)
 			if (pitchs[i] <= 64)
-			{	
+			{
 				const u16 native_pitch = std::get<1>(m_rtts.m_bound_render_targets[i])->get_native_pitch();
 				if (native_pitch > pitchs[i])
 				{
@@ -236,6 +236,8 @@ void GLGSRender::init_buffers(bool skip_reading)
 					surface_info[i].pitch = 0;
 				}
 			}
+
+			m_gl_texture_cache.tag_framebuffer(surface_addresses[i]);
 		}
 		else
 			surface_info[i] = {};
@@ -266,6 +268,8 @@ void GLGSRender::init_buffers(bool skip_reading)
 				depth_surface_info.pitch = 0;
 			}
 		}
+
+		m_gl_texture_cache.tag_framebuffer(depth_address);
 	}
 	else
 		depth_surface_info = {};

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -386,6 +386,8 @@ namespace gl
 
 		bool flush()
 		{
+			if (flushed) return true; //Already written, ignore
+
 			if (!copied)
 			{
 				LOG_WARNING(RSX, "Cache miss at address 0x%X. This is gonna hurt...", cpu_address_base);
@@ -399,7 +401,6 @@ namespace gl
 				}
 			}
 
-			protect(utils::protection::rw);
 			m_fence.wait_for_signal();
 			flushed = true;
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -761,6 +761,11 @@ bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 		{
 			vm::temporary_unlock();
 		}
+		else
+		{
+			//Flush primary cb queue to sync pending changes (e.g image transitions!)
+			flush_command_queue();
+		}
 
 		if (sync_timestamp > 0)
 		{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -567,6 +567,7 @@ VKGSRender::VKGSRender() : GSRender()
 	//Create secondary command_buffer for parallel operations
 	m_secondary_command_buffer_pool.create((*m_device));
 	m_secondary_command_buffer.create(m_secondary_command_buffer_pool);
+	m_secondary_command_buffer.access_hint = vk::command_buffer::access_type_hint::all;
 	
 	//Precalculated stuff
 	m_render_passes = get_precomputed_render_passes(*m_device, m_optimal_tiling_supported_formats);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1014,6 +1014,14 @@ namespace vk
 		VkCommandBuffer commands = nullptr;
 
 	public:
+		enum access_type_hint
+		{
+			flush_only, //Only to be submitted/opened/closed via command flush
+			all         //Auxilliary, can be sumitted/opened/closed at any time
+		}
+		access_hint = flush_only;
+
+	public:
 		command_buffer() {}
 		~command_buffer() {}
 

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -239,7 +239,7 @@ namespace rsx
 			return std::make_pair(min, max);
 		}
 
-		utils::protection get_protection()
+		utils::protection get_protection() const
 		{
 			return protection;
 		}


### PR DESCRIPTION
1. Texture cache fixes
 - Tag framebuffer memory when strict mode is enabled to check if content has been written to. This way, framebuffer contents can be ignored if they are known to be incorrect.
- Rework memory protection and ignore flush requests if the data has already been written to the CPU. Speedup when using WCB
2. Stability fixes (See https://github.com/RPCS3/rpcs3/issues/3649)
- Vulkan: Flush command queue before attempting to perform texture writeback to guarantee draw order
- Vulkan: Tag primary command buffers with a flush_only access hint to ensure they are always reopened if submitted outside flush_command_queue such as when dealing with access violations