### PR TITLE
rsx/qt: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -6,6 +6,8 @@
 
 #include <atomic>
 
+extern u64 get_system_time();
+
 namespace rsx
 {
 	enum texture_create_flags
@@ -156,6 +158,8 @@ namespace rsx
 		shared_mutex m_cache_mutex;
 		std::unordered_map<u32, ranged_storage> m_cache;
 
+		std::atomic<u64> m_cache_update_tag = {};
+
 		std::pair<u32, u32> read_only_range = std::make_pair(0xFFFFFFFF, 0);
 		std::pair<u32, u32> no_access_range = std::make_pair(0xFFFFFFFF, 0);
 
@@ -183,6 +187,11 @@ namespace rsx
 		constexpr u32 get_block_size() const { return 0x1000000; }
 		inline u32 get_block_address(u32 address) const { return (address & ~0xFFFFFF); }
 
+		inline void update_cache_tag()
+		{
+			m_cache_update_tag = get_system_time();
+		}
+
 	public:
 		//Struct to hold data on sections to be paged back onto cpu memory
 		struct thrashed_set
@@ -190,6 +199,9 @@ namespace rsx
 			bool violation_handled = false;
 			std::vector<section_storage_type*> affected_sections; //Always laid out with flushable sections first then other affected sections last
 			int num_flushable = 0;
+			u64 cache_tag = 0;
+			u32 address_base = 0;
+			u32 address_range = 0;
 		};
 
 	private:
@@ -368,6 +380,9 @@ namespace rsx
 				{
 					result.num_flushable = static_cast<int>(sections_to_flush.size());
 					result.affected_sections = std::move(sections_to_flush);
+					result.address_base = address;
+					result.address_range = range;
+					result.cache_tag = m_cache_update_tag.load(std::memory_order_consume);
 				}
 
 				for (auto It = to_reprotect; It != trampled_set.end(); It++)
@@ -390,12 +405,6 @@ namespace rsx
 			}
 
 			return {};
-		}
-
-		template <typename ...Args>
-		thrashed_set invalidate_range_impl(u32 address, u32 range, bool is_writing, bool discard, bool allow_flush, Args&&... extras)
-		{
-			return invalidate_range_impl_base(address, range, is_writing, discard, true, allow_flush, std::forward<Args>(extras)...);
 		}
 
 		bool is_hw_blit_engine_compatible(const u32 format) const
@@ -546,6 +555,7 @@ namespace rsx
 			region.protect(utils::protection::no);
 			region.create(width, height, 1, 1, nullptr, image, pitch, false, std::forward<Args>(extras)...);
 			region.set_context(texture_upload_context::framebuffer_storage);
+			update_cache_tag();
 		}
 
 		template <typename ...Args>
@@ -636,7 +646,13 @@ namespace rsx
 		template <typename ...Args>
 		thrashed_set invalidate_address(u32 address, bool is_writing, bool allow_flush, Args&&... extras)
 		{
-			return invalidate_range(address, 4096 - (address & 4095), is_writing, false, allow_flush, std::forward<Args>(extras)...);
+			//Test before trying to acquire the lock
+			const auto range = 4096 - (address & 4095);
+			if (!region_intersects_cache(address, range, is_writing))
+				return{};
+
+			writer_lock lock(m_cache_mutex);
+			return invalidate_range_impl_base(address, range, is_writing, false, true, allow_flush, std::forward<Args>(extras)...);
 		}
 
 		template <typename ...Args>
@@ -647,7 +663,7 @@ namespace rsx
 				return {};
 
 			writer_lock lock(m_cache_mutex);
-			return invalidate_range_impl(address, range, is_writing, discard, allow_flush, std::forward<Args>(extras)...);
+			return invalidate_range_impl_base(address, range, is_writing, discard, false, allow_flush, std::forward<Args>(extras)...);
 		}
 
 		template <typename ...Args>
@@ -655,29 +671,55 @@ namespace rsx
 		{
 			writer_lock lock(m_cache_mutex);
 
-			std::vector<utils::protection> old_protections;
-			for (int n = data.num_flushable; n < data.affected_sections.size(); ++n)
+			if (data.cache_tag == m_cache_update_tag.load(std::memory_order_consume))
 			{
-				old_protections.push_back(data.affected_sections[n]->get_protection());
-				data.affected_sections[n]->unprotect();
-			}
-
-			for (int n = 0, i = 0; n < data.affected_sections.size(); ++n)
-			{
-				if (n < data.num_flushable)
+				std::vector<utils::protection> old_protections;
+				for (int n = data.num_flushable; n < data.affected_sections.size(); ++n)
 				{
-					if (!data.affected_sections[n]->flush(std::forward<Args>(extras)...))
+					old_protections.push_back(data.affected_sections[n]->get_protection());
+					data.affected_sections[n]->unprotect();
+				}
+
+				for (int n = 0, i = 0; n < data.affected_sections.size(); ++n)
+				{
+					if (n < data.num_flushable)
 					{
-						//Missed address, note this
-						//TODO: Lower severity when successful to keep the cache from overworking
-						record_cache_miss(*data.affected_sections[n]);
+						if (!data.affected_sections[n]->flush(std::forward<Args>(extras)...))
+						{
+							//Missed address, note this
+							//TODO: Lower severity when successful to keep the cache from overworking
+							record_cache_miss(*data.affected_sections[n]);
+						}
+					}
+					else
+					{
+						//Restore protection on the remaining sections
+						data.affected_sections[n]->protect(old_protections[i++]);
 					}
 				}
-				else
+			}
+			else
+			{
+				//The cache contents have changed between the two readings. This means the data held is useless
+				//Restore memory protection for the scan to work properly
+				for (int n = 0; n < data.num_flushable; n++)
 				{
-					//Restore protection on the remaining sections
-					data.affected_sections[n]->protect(old_protections[i++]);
+					if (data.affected_sections[n]->get_protection() == utils::protection::rw)
+					{
+						const u32 address = data.affected_sections[n]->get_section_base();
+						const u32 size = data.affected_sections[n]->get_section_size();
+
+						data.affected_sections[n]->protect(utils::protection::no);
+						m_cache[get_block_address(address)].notify(address, size);
+					}
+					else
+					{
+						LOG_WARNING(RSX, "Texture Cache: Section at address 0x%X was lost", data.affected_sections[n]->get_section_base());
+					}
 				}
+
+				update_cache_tag();
+				invalidate_range_impl_base(data.address_base, data.address_range, true, false, true, true, std::forward<Args>(extras)...);
 			}
 
 			return true;
@@ -1080,8 +1122,8 @@ namespace rsx
 					const u32 memcpy_bytes_length = dst.clip_width * bpp * dst.clip_height;
 
 					lock.upgrade();
-					invalidate_range_impl(src_address, memcpy_bytes_length, false, false, true, std::forward<Args>(extras)...);
-					invalidate_range_impl(dst_address, memcpy_bytes_length, true, false, true, std::forward<Args>(extras)...);
+					invalidate_range_impl_base(src_address, memcpy_bytes_length, false, false, false, true, std::forward<Args>(extras)...);
+					invalidate_range_impl_base(dst_address, memcpy_bytes_length, true, false, false, true, std::forward<Args>(extras)...);
 					memcpy(dst.pixels, src.pixels, memcpy_bytes_length);
 					return true;
 				}
@@ -1188,7 +1230,7 @@ namespace rsx
 				{
 					lock.upgrade();
 
-					invalidate_range_impl(src_address, src.pitch * src.slice_h, false, false, true, std::forward<Args>(extras)...);
+					invalidate_range_impl_base(src_address, src.pitch * src.slice_h, false, false, false, true, std::forward<Args>(extras)...);
 
 					const u16 pitch_in_block = src_is_argb8 ? src.pitch >> 2 : src.pitch >> 1;
 					std::vector<rsx_subresource_layout> subresource_layout;
@@ -1260,7 +1302,7 @@ namespace rsx
 			if (format_mismatch)
 			{
 				lock.upgrade();
-				invalidate_range_impl(cached_dest->get_section_base(), cached_dest->get_section_size(), true, false, true, std::forward<Args>(extras)...);
+				invalidate_range_impl_base(cached_dest->get_section_base(), cached_dest->get_section_size(), true, false, false, true, std::forward<Args>(extras)...);
 
 				dest_texture = 0;
 				cached_dest = nullptr;
@@ -1268,7 +1310,7 @@ namespace rsx
 			else if (invalidate_dst_range)
 			{
 				lock.upgrade();
-				invalidate_range_impl(dst_address, dst.pitch * dst.height, true, false, true, std::forward<Args>(extras)...);
+				invalidate_range_impl_base(dst_address, dst.pitch * dst.height, true, false, false, true, std::forward<Args>(extras)...);
 			}
 
 			//Validate clipping region

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1296,8 +1296,10 @@ bool GLGSRender::scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst
 
 void GLGSRender::notify_tile_unbound(u32 tile)
 {
-	u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
-	m_rtts.invalidate_surface_address(addr, false);
+	//TODO: Handle texture writeback
+	//u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
+	//on_notify_memory_unmapped(addr, tiles[tile].size);
+	//m_rtts.invalidate_surface_address(addr, false);
 }
 
 void GLGSRender::check_zcull_status(bool framebuffer_swap, bool force_read)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -631,6 +631,9 @@ void GLGSRender::on_init_thread()
 {
 	GSRender::on_init_thread();
 
+	m_frame->disable_wm_event_queue();
+	m_frame->hide();
+
 	gl::init();
 
 	//Enable adaptive vsync if vsync is requested
@@ -771,6 +774,9 @@ void GLGSRender::on_init_thread()
 	m_thread_id = std::this_thread::get_id();
 
 	m_shaders_cache->load();
+
+	m_frame->enable_wm_event_queue();
+	m_frame->show();
 }
 
 void GLGSRender::on_exit()

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -673,7 +673,10 @@ namespace gl
 
 			//Its not necessary to lock blit dst textures as they are just reused as necessary
 			if (context != rsx::texture_upload_context::blit_engine_dst || g_cfg.video.strict_rendering_mode)
+			{
 				cached.protect(utils::protection::ro);
+				update_cache_tag();
+			}
 
 			return &cached;
 		}

--- a/rpcs3/Emu/RSX/GSRender.h
+++ b/rpcs3/Emu/RSX/GSRender.h
@@ -24,7 +24,10 @@ enum wm_event
 	geometry_change_notice, //about to start resizing and/or moving the window
 	geometry_change_in_progress, //window being resized and/or moved
 	window_resized, //window was resized
-	window_moved //window moved without resize
+	window_minimized, //window was minimized
+	window_restored, //window was restored from a minimized state
+	window_moved, //window moved without resize
+	window_visibility_changed
 };
 
 using RSXDebuggerPrograms = std::vector<RSXDebuggerProgram>;
@@ -58,6 +61,7 @@ protected:
 	//window manager event management
 	wm_event m_raised_event;
 	std::atomic_bool wm_event_raised = {};
+	std::atomic_bool wm_event_queue_enabled = {};
 
 public:
 	//synchronize native window access
@@ -82,6 +86,16 @@ public:
 		}
 
 		return get_default_wm_event();
+	}
+
+	void disable_wm_event_queue()
+	{
+		wm_event_queue_enabled.store(false);
+	}
+
+	void enable_wm_event_queue()
+	{
+		wm_event_queue_enabled.store(true);
 	}
 };
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2716,6 +2716,8 @@ bool VKGSRender::scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst
 
 void VKGSRender::notify_tile_unbound(u32 tile)
 {
-	u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
-	m_rtts.invalidate_surface_address(addr, false);
+	//TODO: Handle texture writeback
+	//u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
+	//on_notify_memory_unmapped(addr, tiles[tile].size);
+	//m_rtts.invalidate_surface_address(addr, false);
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1332,7 +1332,13 @@ void VKGSRender::on_init_thread()
 	GSRender::on_init_thread();
 	rsx_thread = std::this_thread::get_id();
 
+	m_frame->disable_wm_event_queue();
+	m_frame->hide();
+
 	m_shaders_cache->load(*m_device, pipeline_layout);
+
+	m_frame->enable_wm_event_queue();
+	m_frame->show();
 }
 
 void VKGSRender::on_exit()
@@ -1747,11 +1753,14 @@ void VKGSRender::do_local_task()
 				handled = true;
 				present_surface_dirty_flag = true;
 				break;
-			case wm_event::window_moved:
-				handled = true;
-				break;
 			case wm_event::geometry_change_in_progress:
 				timeout += 10; //extend timeout to wait for user to finish resizing
+				break;
+			case wm_event::window_visibility_changed:
+			case wm_event::window_minimized:
+			case wm_event::window_restored:
+			case wm_event::window_moved:
+				handled = true; //ignore these events as they do not alter client area
 				break;
 			}
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -809,7 +809,7 @@ namespace vk
 			}
 		}
 
-		void init_swapchain(u32 width, u32 height)
+		bool init_swapchain(u32 width, u32 height)
 		{
 			VkSwapchainKHR old_swapchain = m_vk_swapchain;
 			vk::physical_device& gpu = const_cast<vk::physical_device&>(dev.gpu());
@@ -817,8 +817,16 @@ namespace vk
 			VkSurfaceCapabilitiesKHR surface_descriptors = {};
 			CHECK_RESULT(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(gpu, m_surface, &surface_descriptors));
 
-			VkExtent2D swapchainExtent;
+			if (surface_descriptors.maxImageExtent.width < width ||
+				surface_descriptors.maxImageExtent.height < height)
+			{
+				LOG_ERROR(RSX, "Swapchain: Swapchain creation failed because dimensions cannot fit. Max = %d, %d, Requested = %d, %d",
+					surface_descriptors.maxImageExtent.width, surface_descriptors.maxImageExtent.height, width, height);
 
+				return false;
+			}
+
+			VkExtent2D swapchainExtent;
 			if (surface_descriptors.currentExtent.width == (uint32_t)-1)
 			{
 				swapchainExtent.width = width;
@@ -826,6 +834,12 @@ namespace vk
 			}
 			else
 			{
+				if (surface_descriptors.currentExtent.width == 0 || surface_descriptors.currentExtent.height == 0)
+				{
+					LOG_WARNING(RSX, "Swapchain: Current surface extent is a null region. Is the window minimized?");
+					return false;
+				}
+
 				swapchainExtent = surface_descriptors.currentExtent;
 				width = surface_descriptors.currentExtent.width;
 				height = surface_descriptors.currentExtent.height;
@@ -932,6 +946,8 @@ namespace vk
 			{
 				m_swap_images[i].create(dev, swap_images[i], m_surface_format);
 			}
+
+			return true;
 		}
 
 		u32 get_swap_image_count()

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -547,7 +547,10 @@ namespace vk
 
 			//Its not necessary to lock blit dst textures as they are just reused as necessary
 			if (context != rsx::texture_upload_context::blit_engine_dst || g_cfg.video.strict_rendering_mode)
+			{
 				region.protect(utils::protection::ro);
+				update_cache_tag();
+			}
 
 			read_only_range = region.get_min_max(read_only_range);
 			return &region;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -246,10 +246,10 @@ bool gs_frame::event(QEvent* ev)
 bool gs_frame::nativeEvent(const QByteArray &eventType, void *message, long *result)
 {
 #ifdef _WIN32
-	if (wm_event_queue_enabled.load(std::memory_order_consume))
+	if (wm_event_queue_enabled.load(std::memory_order_consume) && !Emu.IsStopped())
 	{
 		//Wait for consumer to clear notification pending flag
-		while (wm_event_raised.load(std::memory_order_consume));
+		while (wm_event_raised.load(std::memory_order_consume) && !Emu.IsStopped());
 
 		{
 			std::lock_guard<std::mutex> lock(wm_event_lock);
@@ -337,7 +337,7 @@ bool gs_frame::nativeEvent(const QByteArray &eventType, void *message, long *res
 		}
 
 		//Do not enter DefWndProc until the consumer has consumed the message
-		while (wm_event_raised.load(std::memory_order_consume));
+		while (wm_event_raised.load(std::memory_order_consume) && !Emu.IsStopped());
 	}
 #endif
 

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -17,6 +17,7 @@ class gs_frame : public QWindow, public GSFrameBase
 	bool m_in_sizing_event = false; //a signal that the window is about to be resized was received
 	bool m_user_interaction_active = false; //a signal indicating the window is being manually moved/resized was received
 	bool m_interactive_resize = false; //resize signal received while dragging window
+	bool m_minimized = false;
 
 public:
 	gs_frame(const QString& title, int w, int h, QIcon appIcon, bool disableMouse);


### PR DESCRIPTION
### GsFrame improvements
- Identify minimize/restore events as separate from regular resize and do not react to them
- Enable message queue consumption after loading the shaders cache. Also hides the frame during this step. This fixes the 'start fullscreen' bug when running vulkan

### Texture cache improvements
- Prevent recursive access violations that cause hanging when WCB is enabled
- Partially reverts Jarves' invalidate unbound tiled regions as it causes driver crashes and hanging in corner cases. I'll submit a more complete version soon.

Fixes https://github.com/RPCS3/rpcs3/issues/3613 and https://github.com/RPCS3/rpcs3/issues/3641