### PR TITLE
Handle device not ready in fs::error. Solves #3592

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -96,6 +96,7 @@ static fs::error to_error(DWORD e)
 	case ERROR_INVALID_NAME: return fs::error::inval;
 	case ERROR_SHARING_VIOLATION: return fs::error::acces;
 	case ERROR_DIR_NOT_EMPTY: return fs::error::notempty;
+	case ERROR_NOT_READY: return fs::error::noent;
 	default: fmt::throw_exception("Unknown Win32 error: %u.", e);
 	}
 }


### PR DESCRIPTION
Fixes issue where having paths on games.yml that point to NOT_READY drives such as empty physical/virtual disc drives returns ERROR_NOT_READY (Win32 error code 21) which was not handled in fs::error, therefore throwing an exception and crashing RPCS3.

Solves #3592 