### PR TITLE
[RSX] Fix uninitialized value before usage

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -35,7 +35,7 @@ namespace rsx
 		u16 real_pitch;
 		u16 rsx_pitch;
 
-		u64 cache_tag;
+		u64 cache_tag = 0;
 
 		rsx::texture_create_flags view_flags = rsx::texture_create_flags::default_component_order;
 		rsx::texture_upload_context context = rsx::texture_upload_context::shader_read;


### PR DESCRIPTION
The member `cache_tag` from the `cached_texture_section` structure is currently used at two different places:
- https://github.com/RPCS3/rpcs3/blob/4aa89132d7cf19ce486c9b36c65a82b45fc234d1/rpcs3/Emu/RSX/Common/texture_cache.h#L278 The first time, the value of  `tex.cache_tag` is uninitialized and used to do a comparison.
- https://github.com/RPCS3/rpcs3/blob/4aa89132d7cf19ce486c9b36c65a82b45fc234d1/rpcs3/Emu/RSX/Common/texture_cache.h#L294 Later, the variable `tex.cache_tag` is set, no problem for the next comparisons.

In this PR, I set a default value (`0`) to the member `cache_tag` of the `cached_texture_section` structure so it will fix the uninitialized value before to do the first comparison.