### PR TITLE
PPUTranslator minor changes

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -133,7 +133,7 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 	const u64 base = m_reloc ? m_reloc->addr : 0;
 	m_addr = info.addr - base;
 
-	m_thread = &*m_function->getArgumentList().begin();
+	m_thread = &*m_function->arg_begin();
 	m_base_loaded = m_ir->CreateLoad(m_base);
 
 	m_body = BasicBlock::Create(m_context, "__body", m_function);
@@ -290,7 +290,7 @@ Value* PPUTranslator::RegInit(Value*& local)
 
 Value* PPUTranslator::RegLoad(Value*& local)
 {
-	const uint index = ::narrow<uint>(&local - m_locals);
+	const auto index = ::narrow<uint>(&local - m_locals);
 
 	if (local)
 	{
@@ -315,7 +315,7 @@ void PPUTranslator::FlushRegisters()
 
 	for (auto& local : m_locals)
 	{
-		const uint index = static_cast<uint>(&local - m_locals);
+		const auto index = ::narrow<uint>(&local - m_locals);
 
 		// Store value if necessary
 		if (local && m_globals[index])


### PR DESCRIPTION
Minor changes which include:
- Usage of `arg_begin()` instead of `getArgumentList().begin()`. As it can be seen [here](https://github.com/llvm-mirror/llvm/blob/release_40/include/llvm/IR/Function.h#L550), the difference between these two calls is very small in LLVM 4. However, this change will help for the move to LLVM 5+ because the function `getArgumentList()` will not be here anymore (see https://reviews.llvm.org/rL298010 for more details). Also, this change was originally included in the LLVM 5 PR (#3410)  by @hcorion
- Add consistency for the following lines
https://github.com/RPCS3/rpcs3/blob/6782b2263785bc50ca175cc8afdd7896e7384e5f/rpcs3/Emu/Cell/PPUTranslator.cpp#L278
https://github.com/RPCS3/rpcs3/blob/6782b2263785bc50ca175cc8afdd7896e7384e5f/rpcs3/Emu/Cell/PPUTranslator.cpp#L293
https://github.com/RPCS3/rpcs3/blob/6782b2263785bc50ca175cc8afdd7896e7384e5f/rpcs3/Emu/Cell/PPUTranslator.cpp#L318
by using the same code: `const auto index = ::narrow<uint>(&local - m_locals);`