### PR TITLE
Fix cond timeout overflow [Windows]

### DIFF
--- a/Utilities/cond.cpp
+++ b/Utilities/cond.cpp
@@ -22,7 +22,7 @@ bool cond_variable::imp_wait(u32 _old, u64 _timeout) noexcept
 	}
 
 	LARGE_INTEGER timeout;
-	timeout.QuadPart = _timeout * -10;
+	timeout.QuadPart = _timeout;
 
 	if (HRESULT rc = NtWaitForKeyedEvent(nullptr, &m_value, false, _timeout == -1 ? nullptr : &timeout))
 	{

--- a/Utilities/cond.cpp
+++ b/Utilities/cond.cpp
@@ -12,6 +12,15 @@ bool cond_variable::imp_wait(u32 _old, u64 _timeout) noexcept
 	verify(HERE), _old != -1; // Very unlikely: it requires 2^32 distinct threads to wait simultaneously
 
 #ifdef _WIN32
+	if (_timeout > INTMAX_MAX / 10) // If it overflows, make it endless
+	{
+		_timeout = -1; // Won't ever finish anyway
+	}
+	else
+	{
+		_timeout *= -10;
+	}
+
 	LARGE_INTEGER timeout;
 	timeout.QuadPart = _timeout * -10;
 

--- a/Utilities/cond.cpp
+++ b/Utilities/cond.cpp
@@ -12,7 +12,7 @@ bool cond_variable::imp_wait(u32 _old, u64 _timeout) noexcept
 	verify(HERE), _old != -1; // Very unlikely: it requires 2^32 distinct threads to wait simultaneously
 
 #ifdef _WIN32
-	if (_timeout > INTMAX_MAX / 10) // If it overflows, make it endless
+	if (_timeout > INT64_MAX / 10) // If it overflows, make it endless
 	{
 		_timeout = -1; // Won't ever finish anyway
 	}


### PR DESCRIPTION
Fixes an overflow in which if a game requested a large enough timeout on Windows, it would expire immediately, resulting in race conditions. (Dead Island should advance a bit more)

Please report regressions if you find any.