### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -735,21 +735,12 @@ std::string FragmentProgramDecompiler::Decompile()
 			if (SIP()) break;
 			if (handle_tex_srb(opcode)) break;
 
-			if (forced_unit == FORCE_NONE)
-			{
-				if (handle_sct(opcode)) break;
-				if (handle_scb(opcode)) break;
-			}
-			else if (forced_unit == FORCE_SCT)
-			{
-				forced_unit = FORCE_NONE;
-				if (handle_sct(opcode)) break;
-			}
-			else if (forced_unit == FORCE_SCB)
-			{
-				forced_unit = FORCE_NONE;
-				if (handle_scb(opcode)) break;
-			}
+			//FENCT/FENCB do not actually reject instructions if they dont match the forced unit
+			//Tested with Dark Souls II where the repecting FENCX instruction will result in empty luminance averaging shaders
+			//TODO: More reasearch is needed to determine what real HW does
+			if (handle_sct(opcode)) break;
+			if (handle_scb(opcode)) break;
+			forced_unit = FORCE_NONE;
 
 			LOG_ERROR(RSX, "Unknown/illegal instruction: 0x%x (forced unit %d)", opcode, prev_force_unit);
 			break;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -24,7 +24,7 @@ namespace
 
 GLGSRender::GLGSRender() : GSRender()
 {
-	m_shaders_cache.reset(new gl::shader_cache(m_prog_buffer, "opengl", "v1"));
+	m_shaders_cache.reset(new gl::shader_cache(m_prog_buffer, "opengl", "v1.1"));
 
 	if (g_cfg.video.disable_vertex_cache)
 		m_vertex_cache.reset(new gl::null_vertex_cache());

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -623,7 +623,7 @@ VKGSRender::VKGSRender() : GSRender()
 	else
 		m_vertex_cache.reset(new vk::weak_vertex_cache());
 
-	m_shaders_cache.reset(new vk::shader_cache(*m_prog_buffer.get(), "vulkan", "v1"));
+	m_shaders_cache.reset(new vk::shader_cache(*m_prog_buffer.get(), "vulkan", "v1.1"));
 
 	open_command_buffer();
 

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -333,10 +333,14 @@ namespace rsx
 				dlg->Create("Preloading cached shaders from disk.\nPlease wait...");
 			});
 
+			const auto prefix_length = version_prefix.length();
 			u32 processed = 0;
 			while (root.read(tmp) && !Emu.IsStopped())
 			{
 				if (tmp.name == "." || tmp.name == "..")
+					continue;
+
+				if (tmp.name.compare(0, prefix_length, version_prefix) != 0)
 					continue;
 
 				std::vector<u8> bytes;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -636,6 +636,12 @@ namespace rsx
 			u32 convert_w = (u32)(scale_x * in_w);
 			u32 convert_h = (u32)(scale_y * in_h);
 
+			if (convert_w == 0 || convert_h == 0)
+			{
+				LOG_ERROR(RSX, "NV3089_IMAGE_IN: Invalid dimensions or scaling factor. Request ignored");
+				return;
+			}
+
 			u32 slice_h = clip_h;
 			blit_src_info src_info = {};
 			blit_dst_info dst_info = {};


### PR DESCRIPTION
#3710 broke github (detects no changes, 0 commits)

- Disables blit operations if the target will have a size of 0 in any dimension. Fixes blit engine crashing when GPU texture scaling is disabled.
- Bumps shader cache ver to 1.1. Vertex input declarations (unused since vertex rewrite) and texture sampling coord type (unnormalized vs normalized) no longer affect shader state and do not generate new shaders. Shader cache should generate fewer shaders in affected titles.
- Do not respect FENCx instructions as they seem to be an optimization hint. Respecting FENCx instructions can result in some hilariously broken shaders including entire shaders that are one big NOP