### PR TITLE
Stub sceNpSnsFbCheckConfig

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
@@ -147,7 +147,7 @@ s32 sceNpSnsFbCheckThrottle()
 
 s32 sceNpSnsFbCheckConfig()
 {
-	sceNpSns.warning("sceNpSnsFbCheckConfig()");
+	sceNpSns.todo("sceNpSnsFbCheckConfig()");
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
@@ -147,7 +147,8 @@ s32 sceNpSnsFbCheckThrottle()
 
 s32 sceNpSnsFbCheckConfig()
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	sceNpSns.warning("sceNpSnsFbCheckConfig()");
+	return CELL_OK;
 }
 
 s32 sceNpSnsFbLoadThrottle()


### PR DESCRIPTION
Allows Dead Island to progress further, and potentially any other games that get stuck on this.

![image](https://user-images.githubusercontent.com/26035046/32678264-4bda7a88-c627-11e7-980b-5d340f7659ed.png)

Dead Island now no longer dies during the intro. However, for some reason, it doesn't respond to controller inputs on the gamma slider screen, so it never gets past this point.