### PR TITLE
Correct two typos and a couple of other nitpicky things

### DIFF
--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -47,7 +47,7 @@
 		"logProg": "Dump game shaders to file. Only useful to developers.\nIf unsure, don't use this option.",
 		"disableOcclusionQueries": "Disables running occlusion queries. Minor to moderate performance boost.\nMight introduce issues with broken occlusion e.g missing geometry and extreme pop-in.",
 		"disableVertexCache": "Disables the vertex cache.\nMight resolve missing or flickering graphics output.\nMay degrade performance.",
-		"forceCpuBlitEmulation": "Forces emulation of all blit and image manipulation operations on the cpu.\nRequires 'Write Color Buffers' option to also be enabled in most cases to avoid missing graphics.\nSignificatly degrades performance but is more accurate in some cases.\nThis setting overrides the 'GPU texture scaling' option."
+		"forceCpuBlitEmulation": "Forces emulation of all blit and image manipulation operations on the CPU.\nRequires 'Write Color Buffers' option to also be enabled in most cases to avoid missing graphics.\nSignificantly degrades performance but is more accurate in some cases.\nThis setting overrides the 'GPU texture scaling' option."
 	},
 	"emulator": {
 		"gui": {

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Configure keyboard</string>
+   <string>Configure Keyboard</string>
   </property>
   <property name="windowIcon">
    <iconset resource="../resources.qrc">
@@ -1161,7 +1161,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>Sixaixs</string>
+           <string>Sixaxis</string>
           </property>
           <property name="checkable">
            <bool>true</bool>


### PR DESCRIPTION
"Significantly" was misspelled as "Significatly" in the debug tab.
"Sixaxis" was misspelled as "Sixaixs" in the pad settings.
Changed "cpu" to "CPU" because it is an acronym and should be capitalised.
Changed "keyboard" to "Keyboard" to match other window titles in RPCS3.