### PR TITLE
Fixes commit count on GIT-VERSION | RPCS3 v0.0.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 #---------------------------------#
 
 # version format
-version: '0.0.3-{build}'
+version: '0.0.4-{build}'
 
 #---------------------------------#
 #    environment configuration    #
@@ -79,4 +79,4 @@ test: off
 # pushing entire folder as a zip archive
 artifacts:
  - path: bin
-   name: 'rpcs3-v0.0.3-$(COMMIT_DATE)-$(COMMIT_SHA)_win64'
+   name: 'rpcs3-v0.0.4-$(COMMIT_DATE)-$(COMMIT_SHA)_win64'

--- a/bin/GuiConfigs/Kuroi (Dark) by Ani.qss
+++ b/bin/GuiConfigs/Kuroi (Dark) by Ani.qss
@@ -174,10 +174,10 @@ QMenuBar::item:selected {
 	background: #444444;
 }
 QMenu::item {
-	padding-left: 1em;
+	padding-left: 1.5em;
 	padding-right: 0.75em;
-	padding-top: 0.2em;
-	padding-bottom: 0.2em;
+	padding-top: 0.25em;
+	padding-bottom: 0.25em;
 }
 QMenu::item:selected {
 	background: #444444;

--- a/rpcs3/rpcs3_version.cpp
+++ b/rpcs3/rpcs3_version.cpp
@@ -9,5 +9,5 @@ namespace rpcs3
 		return RPCS3_GIT_BRANCH;
 	}
 
-	const extern utils::version version{ 0, 0, 3, utils::version_type::alpha, 1, RPCS3_GIT_VERSION };
+	const extern utils::version version{ 0, 0, 4, utils::version_type::alpha, 1, RPCS3_GIT_VERSION };
 }


### PR DESCRIPTION
If we're in AppVeyor and building for master:
- Fetches commit count from unshallowed upstream instead of fetching from HEAD (will always be 3 since we clone with depth of 3)

Solves #3693