### PR TITLE
Bump CMake requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1)
 
 option(WITH_GDB "WITH_GDB" OFF)
 option(WITHOUT_LLVM "WITHOUT_LLVM" OFF)

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake_modules")
 set(RES_FILES "")


### PR DESCRIPTION
In the file `rpcs3/CMakeLists.txt`, the variable `CMAKE_CXX_STANDARD` is used:
https://github.com/RPCS3/rpcs3/blob/c435b328c7349b7f353ec10b247eb1c45311d460/rpcs3/CMakeLists.txt#L5

This variable was introduced by CMake 3.1.0 (https://cmake.org/cmake/help/v3.1/release/3.1.0.html#properties).
The file `CMakeLists.txt` is also updated to keep the same requirement.
