### PR TITLE
cellGameBootCheck temp fix

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -255,7 +255,7 @@ error_code cellGameBootCheck(vm::ptr<u32> type, vm::ptr<u32> attributes, vm::ptr
 	{
 		*type = CELL_GAME_GAMETYPE_DISC;
 		*attributes = 0; // TODO
-		if (dirName) strcpy_trunc(*dirName, ""); // ???
+		// TODO: dirName might be a read only string when BootCheck is called on a disc game. (e.g. Ben 10 Ultimate Alien: Cosmic Destruction)
 
 		if (!fxm::make<content_permission>("", std::move(sfo)))
 		{


### PR DESCRIPTION
Ben 10 Ultimate Alien: Cosmic Destruction AVs during cellGameBootCheck, as data is written to read only memory (dirName), which contains the string "app_home".
The functionality isn't known yet, AFAIK, so this is a temp fix for the game, as data definitely shouldn't be written to that pointer

Thanks to emulator team for the report