### PR TITLE
rsx: Stuff

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -334,6 +334,7 @@ void FragmentProgramDecompiler::AddCodeCond(const std::string& dst, const std::s
 template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 {
 	std::string ret;
+	bool apply_precision_modifier = !!src1.input_prec_mod;
 
 	switch (src.reg_type)
 	{
@@ -351,6 +352,8 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 			"tc0", "tc1", "tc2", "tc3", "tc4", "tc5", "tc6", "tc7", "tc8", "tc9",
 			"ssa"
 		};
+
+		//TODO: Investigate effect of input modifier on this type
 
 		switch (dst.src_attr_reg_num)
 		{
@@ -373,6 +376,7 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 
 	case RSX_FP_REGISTER_TYPE_CONSTANT:
 		ret += AddConst();
+		apply_precision_modifier = false;
 		break;
 
 	case RSX_FP_REGISTER_TYPE_UNKNOWN: // ??? Used by a few games, what is it?
@@ -380,6 +384,7 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 				dst.opcode, dst.HEX, src0.HEX, src1.HEX, src2.HEX);
 
 		ret += AddType3();
+		apply_precision_modifier = false;
 		break;
 
 	default:
@@ -400,7 +405,7 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 
 	//Warning: Modifier order matters. e.g neg should be applied after precision clamping (tested with Naruto UNS)
 	if (src.abs) ret = "abs(" + ret + ")";
-	if (src1.input_prec_mod) ret = ClampValue(ret, src1.input_prec_mod);
+	if (apply_precision_modifier) ret = ClampValue(ret, src1.input_prec_mod);
 	if (src.neg) ret = "-" + ret;
 
 	return ret;

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -494,10 +494,10 @@ bool FragmentProgramDecompiler::handle_scb(u32 opcode)
 	case RSX_FP_OPCODE_MIN: SetDst("min($0, $1)"); return true;
 	case RSX_FP_OPCODE_MOV: SetDst("$0"); return true;
 	case RSX_FP_OPCODE_MUL: SetDst("($0 * $1)"); return true;
-	case RSX_FP_OPCODE_PK2: SetDst(getFloatTypeName(4) + "(packSnorm2x16($0.xy))"); return true;
-	case RSX_FP_OPCODE_PK4: SetDst(getFloatTypeName(4) + "(packSnorm4x8($0))"); return true;
-	case RSX_FP_OPCODE_PK16: SetDst(getFloatTypeName(4) + "(packHalf2x16($0.xy))"); return true;
-	case RSX_FP_OPCODE_PKB: SetDst(getFloatTypeName(4) + "(packUnorm4x8($0 / 255.))"); return true;
+	case RSX_FP_OPCODE_PK2: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packSnorm2x16($0.xy)))"); return true;
+	case RSX_FP_OPCODE_PK4: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packSnorm4x8($0)))"); return true;
+	case RSX_FP_OPCODE_PK16: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packHalf2x16($0.xy)))"); return true;
+	case RSX_FP_OPCODE_PKB: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packUnorm4x8($0)))"); return true;
 	case RSX_FP_OPCODE_PKG: LOG_ERROR(RSX, "Unimplemented SCB instruction: PKG"); return true;
 	case RSX_FP_OPCODE_SEQ: SetDst(getFloatTypeName(4) + "(" + compareFunction(COMPARE::FUNCTION_SEQ, "$0", "$1") + ")"); return true;
 	case RSX_FP_OPCODE_SFL: SetDst(getFunction(FUNCTION::FUNCTION_SFL)); return true;
@@ -614,10 +614,10 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 			return true;
 		}
 		return false;
-	case RSX_FP_OPCODE_UP2: SetDst("unpackSnorm2x16(uint($0.x)).xyxy"); return true; // TODO: More testing (Sonic The Hedgehog (NPUB-30442/NPEB-00478))
-	case RSX_FP_OPCODE_UP4: SetDst("unpackSnorm4x8(uint($0.x))"); return true; // TODO: More testing (Sonic The Hedgehog (NPUB-30442/NPEB-00478))
-	case RSX_FP_OPCODE_UP16: SetDst("unpackHalf2x16(uint($0.x)).xyxy"); return true;
-	case RSX_FP_OPCODE_UPB: SetDst("(unpackUnorm4x8(uint($0.x)) * 255.)"); return true;
+	case RSX_FP_OPCODE_UP2: SetDst("unpackSnorm2x16(floatBitsToUint($0.x)).xyxy"); return true; // TODO: More testing (Sonic The Hedgehog (NPUB-30442/NPEB-00478))
+	case RSX_FP_OPCODE_UP4: SetDst("unpackSnorm4x8(floatBitsToUint($0.x))"); return true; // TODO: More testing (Sonic The Hedgehog (NPUB-30442/NPEB-00478))
+	case RSX_FP_OPCODE_UP16: SetDst("unpackHalf2x16(floatBitsToUint($0.x)).xyxy"); return true;
+	case RSX_FP_OPCODE_UPB: SetDst("(unpackUnorm4x8(floatBitsToUint($0.x)))"); return true;
 	case RSX_FP_OPCODE_UPG: LOG_ERROR(RSX, "Unimplemented TEX_SRB instruction: UPG"); return true;
 	}
 	return false;

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -542,11 +542,13 @@ bool FragmentProgramDecompiler::handle_scb(u32 opcode)
 	case RSX_FP_OPCODE_MIN: SetDst("min($0, $1)"); return true;
 	case RSX_FP_OPCODE_MOV: SetDst("$0"); return true;
 	case RSX_FP_OPCODE_MUL: SetDst("($0 * $1)"); return true;
-	case RSX_FP_OPCODE_PK2: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packSnorm2x16($0.xy)))"); return true;
+	//Pack operations. See https://www.khronos.org/registry/OpenGL/extensions/NV/NV_fragment_program.txt
+	case RSX_FP_OPCODE_PK2: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packHalf2x16($0.xy)))"); return true;
 	case RSX_FP_OPCODE_PK4: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packSnorm4x8($0)))"); return true;
-	case RSX_FP_OPCODE_PK16: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packHalf2x16($0.xy)))"); return true;
+	case RSX_FP_OPCODE_PK16: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packSnorm2x16($0.xy)))"); return true;
+	case RSX_FP_OPCODE_PKG:
+	//Should be similar to PKB but with gamma correction, see description of PK4UBG in khronos page
 	case RSX_FP_OPCODE_PKB: SetDst(getFloatTypeName(4) + "(uintBitsToFloat(packUnorm4x8($0)))"); return true;
-	case RSX_FP_OPCODE_PKG: LOG_ERROR(RSX, "Unimplemented SCB instruction: PKG"); return true;
 	case RSX_FP_OPCODE_SEQ: SetDst(getFloatTypeName(4) + "(" + compareFunction(COMPARE::FUNCTION_SEQ, "$0", "$1") + ")"); return true;
 	case RSX_FP_OPCODE_SFL: SetDst(getFunction(FUNCTION::FUNCTION_SFL)); return true;
 	case RSX_FP_OPCODE_SGE: SetDst(getFloatTypeName(4) + "(" + compareFunction(COMPARE::FUNCTION_SGE, "$0", "$1") + ")"); return true;
@@ -662,11 +664,13 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 			return true;
 		}
 		return false;
-	case RSX_FP_OPCODE_UP2: SetDst("unpackSnorm2x16(floatBitsToUint($0.x)).xyxy"); return true; // TODO: More testing (Sonic The Hedgehog (NPUB-30442/NPEB-00478))
-	case RSX_FP_OPCODE_UP4: SetDst("unpackSnorm4x8(floatBitsToUint($0.x))"); return true; // TODO: More testing (Sonic The Hedgehog (NPUB-30442/NPEB-00478))
-	case RSX_FP_OPCODE_UP16: SetDst("unpackHalf2x16(floatBitsToUint($0.x)).xyxy"); return true;
+	//Unpack operations. See https://www.khronos.org/registry/OpenGL/extensions/NV/NV_fragment_program.txt
+	case RSX_FP_OPCODE_UP2: SetDst("unpackHalf2x16(floatBitsToUint($0.x)).xyxy"); return true;
+	case RSX_FP_OPCODE_UP4: SetDst("unpackSnorm4x8(floatBitsToUint($0.x))"); return true;
+	case RSX_FP_OPCODE_UP16: SetDst("unpackSnormx16(floatBitsToUint($0.x)).xyxy"); return true;
+	case RSX_FP_OPCODE_UPG:
+	//Same as UPB with gamma correction
 	case RSX_FP_OPCODE_UPB: SetDst("(unpackUnorm4x8(floatBitsToUint($0.x)))"); return true;
-	case RSX_FP_OPCODE_UPG: LOG_ERROR(RSX, "Unimplemented TEX_SRB instruction: UPG"); return true;
 	}
 	return false;
 };

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -106,7 +106,7 @@ size_t fragment_program_hash::operator()(const RSXFragmentProgram& program) cons
 
 bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, const RSXFragmentProgram& binary2) const
 {
-	if (binary1.texture_dimensions != binary2.texture_dimensions || binary1.unnormalized_coords != binary2.unnormalized_coords ||
+	if (binary1.ctrl != binary2.ctrl || binary1.texture_dimensions != binary2.texture_dimensions || binary1.unnormalized_coords != binary2.unnormalized_coords ||
 		binary1.back_color_diffuse_output != binary2.back_color_diffuse_output || binary1.back_color_specular_output != binary2.back_color_specular_output ||
 		binary1.front_back_color_enabled != binary2.front_back_color_enabled ||
 		binary1.shadow_textures != binary2.shadow_textures || binary1.redirected_textures != binary2.redirected_textures)

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -459,10 +459,16 @@ static size_t get_texture_size(u32 w, u32 h, u8 format)
 	case CELL_GCM_TEXTURE_R5G6B5:
 		return w * h * 2;
 	case CELL_GCM_TEXTURE_COMPRESSED_DXT1:
+		w = align(w, 4);
+		h = align(h, 4);
 		return w * h / 6;
 	case CELL_GCM_TEXTURE_COMPRESSED_DXT23:
+		w = align(w, 4);
+		h = align(h, 4);
 		return w * h / 4;
 	case CELL_GCM_TEXTURE_COMPRESSED_DXT45:
+		w = align(w, 4);
+		h = align(h, 4);
 		return w * h / 4;
 	case CELL_GCM_TEXTURE_DEPTH16:
 		return w * h * 2;

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -153,12 +153,14 @@ namespace rsx
 			surface_storage_type new_surface_storage;
 			surface_type old_surface = nullptr;
 			surface_type new_surface = nullptr;
+			surface_type convert_surface = nullptr;
 
 			// Remove any depth surfaces occupying this memory address (TODO: Discard all overlapping range)
 			auto aliased_depth_surface = m_depth_stencil_storage.find(address);
 			if (aliased_depth_surface != m_depth_stencil_storage.end())
 			{
 				Traits::notify_surface_invalidated(aliased_depth_surface->second);
+				convert_surface = Traits::get(aliased_depth_surface->second);
 				invalidated_resources.push_back(std::move(aliased_depth_surface->second));
 				m_depth_stencil_storage.erase(aliased_depth_surface);
 			}
@@ -178,7 +180,10 @@ namespace rsx
 				m_render_targets_storage.erase(address);
 			}
 
-			//Search invalidated resources for a suitable surface
+			// Select source of original data if any
+			auto contents_to_copy = old_surface == nullptr ? convert_surface : old_surface;
+
+			// Search invalidated resources for a suitable surface
 			for (auto It = invalidated_resources.begin(); It != invalidated_resources.end(); It++)
 			{
 				auto &rtt = *It;
@@ -197,7 +202,7 @@ namespace rsx
 						invalidated_resources.erase(It);
 
 					new_surface = Traits::get(new_surface_storage);
-					Traits::invalidate_rtt_surface_contents(command_list, new_surface, old_surface, true);
+					Traits::invalidate_rtt_surface_contents(command_list, new_surface, contents_to_copy, true);
 					Traits::prepare_rtt_for_drawing(command_list, new_surface);
 					break;
 				}
@@ -217,7 +222,7 @@ namespace rsx
 				return new_surface;
 			}
 
-			m_render_targets_storage[address] = Traits::create_new_surface(address, color_format, width, height, old_surface, std::forward<Args>(extra_params)...);
+			m_render_targets_storage[address] = Traits::create_new_surface(address, color_format, width, height, contents_to_copy, std::forward<Args>(extra_params)...);
 			return Traits::get(m_render_targets_storage[address]);
 		}
 
@@ -232,12 +237,14 @@ namespace rsx
 			surface_storage_type new_surface_storage;
 			surface_type old_surface = nullptr;
 			surface_type new_surface = nullptr;
+			surface_type convert_surface = nullptr;
 
 			// Remove any color surfaces occupying this memory range (TODO: Discard all overlapping surfaces)
 			auto aliased_rtt_surface = m_render_targets_storage.find(address);
 			if (aliased_rtt_surface != m_render_targets_storage.end())
 			{
 				Traits::notify_surface_invalidated(aliased_rtt_surface->second);
+				convert_surface = Traits::get(aliased_rtt_surface->second);
 				invalidated_resources.push_back(std::move(aliased_rtt_surface->second));
 				m_render_targets_storage.erase(aliased_rtt_surface);
 			}
@@ -256,6 +263,9 @@ namespace rsx
 				old_surface_storage = std::move(ds);
 				m_depth_stencil_storage.erase(address);
 			}
+
+			// Select source of original data if any
+			auto contents_to_copy = old_surface == nullptr ? convert_surface : old_surface;
 
 			//Search invalidated resources for a suitable surface
 			for (auto It = invalidated_resources.begin(); It != invalidated_resources.end(); It++)
@@ -276,7 +286,7 @@ namespace rsx
 
 					new_surface = Traits::get(new_surface_storage);
 					Traits::prepare_ds_for_drawing(command_list, new_surface);
-					Traits::invalidate_depth_surface_contents(command_list, new_surface, old_surface, true);
+					Traits::invalidate_depth_surface_contents(command_list, new_surface, contents_to_copy, true);
 					break;
 				}
 			}
@@ -295,7 +305,7 @@ namespace rsx
 				return new_surface;
 			}
 
-			m_depth_stencil_storage[address] = Traits::create_new_surface(address, depth_format, width, height, old_surface, std::forward<Args>(extra_params)...);
+			m_depth_stencil_storage[address] = Traits::create_new_surface(address, depth_format, width, height, contents_to_copy, std::forward<Args>(extra_params)...);
 			return Traits::get(m_depth_stencil_storage[address]);
 		}
 	public:

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1209,7 +1209,7 @@ namespace rsx
 
 			if (!texaddr || !tex_size)
 			{
-				LOG_ERROR(RSX, "Texture upload requested but texture not found, (address=0x%X, size=0x%X)", texaddr, tex_size);
+				LOG_ERROR(RSX, "Texture upload requested but texture not found, (address=0x%X, size=0x%X, w=%d, h=%d, p=%d, format=0x%X)", texaddr, tex_size, tex.width(), tex.height(), tex.pitch(), tex.format());
 				return {};
 			}
 
@@ -1310,7 +1310,7 @@ namespace rsx
 						get_native_dimensions(internal_width, internal_height, rsc.surface);
 						if (!rsc.is_bound || !g_cfg.video.strict_rendering_mode)
 						{
-							if (rsc.w == internal_width && rsc.h == internal_height)
+							if (!rsc.x && !rsc.y && rsc.w == internal_width && rsc.h == internal_height)
 							{
 								if (rsc.is_bound)
 								{

--- a/rpcs3/Emu/RSX/D3D12/D3D12CommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12CommonDecompiler.cpp
@@ -184,12 +184,12 @@ void insert_d3d12_legacy_function(std::ostream& OS, bool is_fragment_program)
 	**/
 	OS << "uint packHalf2x16(float2 val)";
 	OS << "{\n";
-	OS << "	return packSnorm2x16(val / 6.1E+5);\n";
+	OS << "	return packSnorm2x16(val / 65504.);\n";
 	OS << "}\n\n";
 
 	OS << "float2 unpackHalf2x16(uint val)";
 	OS << "{\n";
-	OS << "	return unpackSnorm2x16(val) * 6.1E+5;\n";
+	OS << "	return unpackSnorm2x16(val) * 65504.;\n";
 	OS << "}\n\n";
 
 	OS << "float read_value(float4 src, uint remap_index)\n";

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -35,6 +35,9 @@ std::string D3D12FragmentDecompiler::compareFunction(COMPARE f, const std::strin
 
 void D3D12FragmentDecompiler::insertHeader(std::stringstream & OS)
 {
+	OS << "#define floatBitsToUint as_uint\n";
+	OS << "#define uintBitsToFloat as_float\n\n";
+
 	OS << "cbuffer SCALE_OFFSET : register(b0)\n";
 	OS << "{\n";
 	OS << "	float4x4 scaleOffsetMat;\n";

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -473,14 +473,13 @@ void GLGSRender::end()
 
 	if (g_cfg.video.strict_rendering_mode)
 	{
-		if (ds->old_contents != nullptr)
+		if (ds && ds->old_contents != nullptr)
 			copy_rtt_contents(ds);
 
 		for (auto &rtt : m_rtts.m_bound_render_targets)
 		{
-			if (std::get<0>(rtt) != 0)
+			if (auto surface = std::get<1>(rtt))
 			{
-				auto surface = std::get<1>(rtt);
 				if (surface->old_contents != nullptr)
 					copy_rtt_contents(surface);
 			}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -174,7 +174,7 @@ void GLGSRender::begin()
 	if (conditional_render_enabled && conditional_render_test_failed)
 		return;
 
-	init_buffers();
+	init_buffers(rsx::framebuffer_creation_context::context_draw);
 }
 
 namespace
@@ -927,7 +927,11 @@ bool GLGSRender::do_method(u32 cmd, u32 arg)
 		if (arg & 0xF3)
 		{
 			//Only do all this if we have actual work to do
-			init_buffers(true);
+			u8 ctx = rsx::framebuffer_creation_context::context_draw;
+			if (arg & 0xF0) ctx |= rsx::framebuffer_creation_context::context_clear_color;
+			if (arg & 0x3) ctx |= rsx::framebuffer_creation_context::context_clear_depth;
+
+			init_buffers((rsx::framebuffer_creation_context)ctx, true);
 			synchronize_buffers();
 			clear_surface(arg);
 		}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -140,24 +140,24 @@ namespace
 
 	GLenum front_face(rsx::front_face op)
 	{
-		bool invert = (rsx::method_registers.shader_window_origin() == rsx::window_origin::bottom);
-
+		//NOTE: RSX face winding is always based off of upper-left corner like vulkan, but GL is bottom left
+		//shader_window_origin register does not affect this
+		//verified with Outrun Online Arcade (window_origin::top) and DS2 (window_origin::bottom)
+		//correctness of face winding checked using stencil test (GOW collection shadows)
 		switch (op)
 		{
-		case rsx::front_face::cw: return (invert ? GL_CCW : GL_CW);
-		case rsx::front_face::ccw: return (invert ? GL_CW : GL_CCW);
+		case rsx::front_face::cw: return GL_CCW;
+		case rsx::front_face::ccw: return GL_CW;
 		}
 		fmt::throw_exception("Unsupported front face 0x%X" HERE, (u32)op);
 	}
 
 	GLenum cull_face(rsx::cull_face op)
 	{
-		bool invert = (rsx::method_registers.shader_window_origin() == rsx::window_origin::top);
-
 		switch (op)
 		{
-		case rsx::cull_face::front: return (invert ? GL_BACK : GL_FRONT);
-		case rsx::cull_face::back: return (invert ? GL_FRONT : GL_BACK);
+		case rsx::cull_face::front: return GL_FRONT;
+		case rsx::cull_face::back: return GL_BACK;
 		case rsx::cull_face::front_and_back: return GL_FRONT_AND_BACK;
 		}
 		fmt::throw_exception("Unsupported cull face 0x%X" HERE, (u32)op);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -8,6 +8,7 @@
 #include "define_new_memleakdetect.h"
 #include "GLProgramBuffer.h"
 #include "GLTextOut.h"
+#include "GLOverlays.h"
 #include "../rsx_utils.h"
 #include "../rsx_cache.h"
 
@@ -348,6 +349,7 @@ private:
 	bool manually_flush_ring_buffers = false;
 
 	gl::text_writer m_text_printer;
+	gl::depth_convert_pass m_depth_converter;
 
 	std::mutex queue_guard;
 	std::list<work_item> work_queue;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -398,7 +398,7 @@ private:
 	rsx::vertex_input_layout m_vertex_layout = {};
 
 	void clear_surface(u32 arg);
-	void init_buffers(bool skip_reading = false);
+	void init_buffers(rsx::framebuffer_creation_context context, bool skip_reading = false);
 
 	bool check_program_state();
 	void load_program(u32 vertex_base, u32 vertex_count);

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -2260,22 +2260,16 @@ namespace gl
 					return m_location;
 				}
 
-				void operator = (int rhs) const { m_program.use(); glUniform1i(location(), rhs); }
-				void operator = (float rhs) const { m_program.use(); glUniform1f(location(), rhs); }
-				//void operator = (double rhs) const { m_program.use(); glUniform1d(location(), rhs); }
-
-				void operator = (const color1i& rhs) const { m_program.use(); glUniform1i(location(), rhs.r); }
-				void operator = (const color1f& rhs) const { m_program.use(); glUniform1f(location(), rhs.r); }
-				//void operator = (const color1d& rhs) const { m_program.use(); glUniform1d(location(), rhs.r); }
-				void operator = (const color2i& rhs) const { m_program.use(); glUniform2i(location(), rhs.r, rhs.g); }
-				void operator = (const color2f& rhs) const { m_program.use(); glUniform2f(location(), rhs.r, rhs.g); }
-				//void operator = (const color2d& rhs) const { m_program.use(); glUniform2d(location(), rhs.r, rhs.g); }
-				void operator = (const color3i& rhs) const { m_program.use(); glUniform3i(location(), rhs.r, rhs.g, rhs.b); }
-				void operator = (const color3f& rhs) const { m_program.use(); glUniform3f(location(), rhs.r, rhs.g, rhs.b); }
-				//void operator = (const color3d& rhs) const { m_program.use(); glUniform3d(location(), rhs.r, rhs.g, rhs.b); }
-				void operator = (const color4i& rhs) const { m_program.use(); glUniform4i(location(), rhs.r, rhs.g, rhs.b, rhs.a); }
-				void operator = (const color4f& rhs) const { m_program.use(); glUniform4f(location(), rhs.r, rhs.g, rhs.b, rhs.a); }
-				//void operator = (const color4d& rhs) const { m_program.use(); glUniform4d(location(), rhs.r, rhs.g, rhs.b, rhs.a); }
+				void operator = (int rhs) const { glProgramUniform1i(m_program.id(), location(), rhs); }
+				void operator = (float rhs) const { glProgramUniform1f(m_program.id(), location(), rhs); }
+				void operator = (const color1i& rhs) const { glProgramUniform1i(m_program.id(), location(), rhs.r); }
+				void operator = (const color1f& rhs) const { glProgramUniform1f(m_program.id(), location(), rhs.r); }
+				void operator = (const color2i& rhs) const { glProgramUniform2i(m_program.id(), location(), rhs.r, rhs.g); }
+				void operator = (const color2f& rhs) const { glProgramUniform2f(m_program.id(), location(), rhs.r, rhs.g); }
+				void operator = (const color3i& rhs) const { glProgramUniform3i(m_program.id(), location(), rhs.r, rhs.g, rhs.b); }
+				void operator = (const color3f& rhs) const { glProgramUniform3f(m_program.id(), location(), rhs.r, rhs.g, rhs.b); }
+				void operator = (const color4i& rhs) const { glProgramUniform4i(m_program.id(), location(), rhs.r, rhs.g, rhs.b, rhs.a); }
+				void operator = (const color4f& rhs) const { glProgramUniform4f(m_program.id(), location(), rhs.r, rhs.g, rhs.b, rhs.a); }
 			};
 
 			class attrib_t

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -185,7 +185,9 @@ namespace gl
 				"void main()\n"
 				"{\n"
 				"	vec4 rgba_in = texture(fs0, tc0);\n"
-				"	gl_FragDepth = rgba_in.r * 0.99609 + rgba_in.g * 0.00389 + rgba_in.b * 0.00002;\n"
+				"	uint raw_value = uint(rgba_in.b * 255.) | (uint(rgba_in.g * 255.) << 8) | (uint(rgba_in.r * 255.) << 16);\n"
+				"	gl_FragDepth = float(raw_value) / 16777215.;\n"
+				"	//gl_FragDepth = rgba_in.r * 0.99609 + rgba_in.g * 0.00389 + rgba_in.b * 0.00002;\n"
 				"}\n"
 			};
 		}

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -185,9 +185,7 @@ namespace gl
 				"void main()\n"
 				"{\n"
 				"	vec4 rgba_in = texture(fs0, tc0);\n"
-				"	uint raw_value = uint(rgba_in.b * 255.) | (uint(rgba_in.g * 255.) << 8) | (uint(rgba_in.r * 255.) << 16);\n"
-				"	gl_FragDepth = float(raw_value) / 16777215.;\n"
-				"	//gl_FragDepth = rgba_in.r * 0.99609 + rgba_in.g * 0.00389 + rgba_in.b * 0.00002;\n"
+				"	gl_FragDepth = rgba_in.w * 0.99609 + rgba_in.x * 0.00389 + rgba_in.y * 0.00002;\n"
 				"}\n"
 			};
 		}

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -116,7 +116,7 @@ namespace gl
 				glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 				glDepthMask(depth_target ? GL_TRUE : GL_FALSE);
 
-				// AMD driver bug, disabling depth test doesnt work when doing depth replace (gl_FragDepth writes still go through the depth test)
+				// Disabling depth test will also disable depth writes which is not desired
 				glDepthFunc(GL_ALWAYS);
 				glEnable(GL_DEPTH_TEST);
 

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -1,0 +1,201 @@
+#pragma once
+
+#include "stdafx.h"
+#include "GLHelpers.h"
+
+namespace gl
+{
+	struct overlay_pass
+	{
+		std::string fs_src;
+		std::string vs_src;
+
+		gl::glsl::program program_handle;
+		gl::glsl::shader vs;
+		gl::glsl::shader fs;
+
+		gl::fbo fbo;
+
+		bool compiled = false;
+
+		void create()
+		{
+			if (!compiled)
+			{
+				fs.create(gl::glsl::shader::type::fragment);
+				fs.source(fs_src);
+				fs.compile();
+
+				vs.create(gl::glsl::shader::type::vertex);
+				vs.source(vs_src);
+				vs.compile();
+
+				program_handle.create();
+				program_handle.attach(vs);
+				program_handle.attach(fs);
+				program_handle.make();
+
+				fbo.create();
+
+				compiled = true;
+			}
+		}
+
+		void destroy()
+		{
+			if (compiled)
+			{
+				program_handle.remove();
+				vs.remove();
+				fs.remove();
+
+				fbo.remove();
+
+				compiled = false;
+			}
+		}
+
+		virtual void on_load() {}
+		virtual void on_unload() {}
+
+		virtual void bind_resources() {}
+		virtual void cleanup_resources() {}
+
+		virtual void emit_geometry()
+		{
+			glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+		}
+
+		virtual void run(u16 w, u16 h, GLuint target_texture, bool depth_target)
+		{
+			if (!compiled)
+			{
+				LOG_ERROR(RSX, "You must initialize overlay passes with create() before calling run()");
+				return;
+			}
+
+			GLint program;
+			GLint old_fbo;
+			GLint depth_func;
+			GLint viewport[4];
+			GLboolean color_writes[4];
+			GLboolean depth_write;
+
+			glGetIntegerv(GL_FRAMEBUFFER_BINDING, &old_fbo);
+			glBindFramebuffer(GL_FRAMEBUFFER, fbo.id());
+
+			if (depth_target)
+			{
+				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, target_texture, 0);
+				glDrawBuffer(GL_NONE);
+			}
+			else
+			{
+				GLenum buffer = GL_COLOR_ATTACHMENT0;
+				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, target_texture, 0);
+				glDrawBuffers(1, &buffer);
+			}
+
+			if (glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE)
+			{
+				// Push rasterizer state
+				glGetIntegerv(GL_VIEWPORT, viewport);
+				glGetBooleanv(GL_COLOR_WRITEMASK, color_writes);
+				glGetBooleanv(GL_DEPTH_WRITEMASK, &depth_write);
+				glGetIntegerv(GL_CURRENT_PROGRAM, &program);
+				glGetIntegerv(GL_DEPTH_FUNC, &depth_func);
+
+				GLboolean scissor_enabled = glIsEnabled(GL_SCISSOR_TEST);
+				GLboolean depth_test_enabled = glIsEnabled(GL_DEPTH_TEST);
+				GLboolean cull_face_enabled = glIsEnabled(GL_CULL_FACE);
+				GLboolean blend_enabled = glIsEnabled(GL_BLEND);
+				GLboolean stencil_test_enabled = glIsEnabled(GL_STENCIL_TEST);
+
+				// Set initial state
+				glViewport(0, 0, w, h);
+				glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+				glDepthMask(depth_target ? GL_TRUE : GL_FALSE);
+
+				// AMD driver bug, disabling depth test doesnt work when doing depth replace (gl_FragDepth writes still go through the depth test)
+				glDepthFunc(GL_ALWAYS);
+				glEnable(GL_DEPTH_TEST);
+
+				if (scissor_enabled) glDisable(GL_SCISSOR_TEST);
+				if (cull_face_enabled) glDisable(GL_CULL_FACE);
+				if (blend_enabled) glDisable(GL_BLEND);
+				if (stencil_test_enabled) glDisable(GL_STENCIL_TEST);
+
+				// Render
+				program_handle.use();
+				on_load();
+				bind_resources();
+				emit_geometry();
+
+				// Clean up
+				if (depth_target)
+					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+				else
+					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+
+				glBindFramebuffer(GL_FRAMEBUFFER, old_fbo);
+				glUseProgram((GLuint)program);
+
+				glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
+				glColorMask(color_writes[0], color_writes[1], color_writes[2], color_writes[3]);
+				glDepthMask(depth_write);
+				glDepthFunc(depth_func);
+
+				if (!depth_test_enabled) glDisable(GL_DEPTH_TEST);
+				if (scissor_enabled) glEnable(GL_SCISSOR_TEST);
+				if (cull_face_enabled) glEnable(GL_CULL_FACE);
+				if (blend_enabled) glEnable(GL_BLEND);
+				if (stencil_test_enabled) glEnable(GL_STENCIL_TEST);
+			}
+			else
+			{
+				LOG_ERROR(RSX, "Overlay pass failed because framebuffer was not complete. Run with debug output enabled to diagnose the problem");
+			}
+		}
+	};
+
+	struct depth_convert_pass : public overlay_pass
+	{
+		depth_convert_pass()
+		{
+			vs_src =
+			{
+				"#version 420\n\n"
+				"out vec2 tc0;\n"
+				"\n"
+				"void main()\n"
+				"{\n"
+				"	vec2 positions[] = {vec2(-1., -1.), vec2(1., -1.), vec2(-1., 1.), vec2(1., 1.)};\n"
+				"	vec2 coords[] = {vec2(0., 0.), vec2(1., 0.), vec2(0., 1.), vec2(1., 1.)};\n"
+				"	gl_Position = vec4(positions[gl_VertexID % 4], 0., 1.);\n"
+				"	tc0 = coords[gl_VertexID % 4];\n"
+				"}\n"
+			};
+
+			fs_src =
+			{
+				"#version 420\n\n"
+				"in vec2 tc0;\n"
+				"layout(binding=31) uniform sampler2D fs0;\n"
+				"\n"
+				"void main()\n"
+				"{\n"
+				"	vec4 rgba_in = texture(fs0, tc0);\n"
+				"	gl_FragDepth = rgba_in.r * 0.99609 + rgba_in.g * 0.00389 + rgba_in.b * 0.00002;\n"
+				"}\n"
+			};
+		}
+
+		void run(u16 w, u16 h, GLuint target, GLuint source)
+		{
+			glActiveTexture(GL_TEXTURE31);
+			glBindTexture(GL_TEXTURE_2D, source);
+
+			overlay_pass::run(w, h, target, true);
+		}
+	};
+}

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -198,4 +198,47 @@ namespace gl
 			overlay_pass::run(w, h, target, true);
 		}
 	};
+
+	struct rgba8_rg16_convert_pass : public overlay_pass
+	{
+		rgba8_rg16_convert_pass()
+		{
+			vs_src =
+			{
+				"#version 420\n\n"
+				"\n"
+				"void main()\n"
+				"{\n"
+				"	vec2 positions[] = {vec2(-1., -1.), vec2(1., -1.), vec2(-1., 1.), vec2(1., 1.)};\n"
+				"	gl_Position = vec4(positions[gl_VertexID % 4], 0., 1.);\n"
+				"}\n"
+			};
+
+			fs_src =
+			{
+				"#version 420\n\n"
+				"layout(binding=31) uniform sampler2D fs0;\n"
+				"layout(location=0) out vec4 ocol;\n"
+				"\n"
+				"void main()\n"
+				"{\n"
+				"	uvec4 rgba_in = uvec4(texelFetch(fs0, ivec2(gl_FragCoord.xy), 0) * 255. + vec4(0.5)).wyzx;\n"
+				"	uint value = rgba_in.x | rgba_in.y << 8 | rgba_in.z << 16 | rgba_in.w << 24;\n"
+				"	ocol.xy = unpackHalf2x16(value);\n"
+				"	if (isnan(ocol.x)) ocol.x = 1.;\n"
+				"	if (isnan(ocol.y)) ocol.y = 1.;\n"
+				"	if (isinf(ocol.x)) ocol.x = 65504.;\n"
+				"	if (isinf(ocol.y)) ocol.y = 65504.;\n"
+				"}\n"
+			};
+		}
+
+		void run(u16 w, u16 h, GLuint target, GLuint source)
+		{
+			glActiveTexture(GL_TEXTURE31);
+			glBindTexture(GL_TEXTURE_2D, source);
+
+			overlay_pass::run(w, h, target, false);
+		}
+	};
 }

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -199,9 +199,10 @@ namespace gl
 		}
 	};
 
-	struct rgba8_rg16_convert_pass : public overlay_pass
+	struct rgba8_unorm_rg16_sfloat_convert_pass : public overlay_pass
 	{
-		rgba8_rg16_convert_pass()
+		//Not really needed since directly copying data via ARB_copy_image works out fine
+		rgba8_unorm_rg16_sfloat_convert_pass()
 		{
 			vs_src =
 			{
@@ -222,13 +223,8 @@ namespace gl
 				"\n"
 				"void main()\n"
 				"{\n"
-				"	uvec4 rgba_in = uvec4(texelFetch(fs0, ivec2(gl_FragCoord.xy), 0) * 255. + vec4(0.5)).wyzx;\n"
-				"	uint value = rgba_in.x | rgba_in.y << 8 | rgba_in.z << 16 | rgba_in.w << 24;\n"
+				"	uint value = packUnorm4x8(texelFetch(fs0, ivec2(gl_FragCoord.xy), 0).zyxw);\n"
 				"	ocol.xy = unpackHalf2x16(value);\n"
-				"	if (isnan(ocol.x)) ocol.x = 1.;\n"
-				"	if (isnan(ocol.y)) ocol.y = 1.;\n"
-				"	if (isinf(ocol.x)) ocol.x = 65504.;\n"
-				"	if (isinf(ocol.y)) ocol.y = 65504.;\n"
 				"}\n"
 			};
 		}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -185,7 +185,7 @@ void GLGSRender::init_buffers(bool skip_reading)
 	const auto depth_format = rsx::method_registers.surface_depth_fmt();
 
 	const auto required_color_pitch = rsx::utility::get_packed_pitch(surface_format, clip_horizontal);
-	const auto required_z_pitch = depth_format == rsx::surface_depth_format::z16 ? clip_horizontal * 2 : clip_horizontal * 4;
+	const u32 required_z_pitch = depth_format == rsx::surface_depth_format::z16 ? clip_horizontal * 2 : clip_horizontal * 4;
 
 	if (depth_address && zeta_pitch < required_z_pitch)
 		depth_address = 0;
@@ -207,8 +207,9 @@ void GLGSRender::init_buffers(bool skip_reading)
 		if (surface_addresses[index] == depth_address &&
 			zeta_pitch >= required_z_pitch)
 		{
-			LOG_ERROR(RSX, "Some game dev set up the MRT to write to the same address as depth and color attachment. Not sure how to deal with that so the draw is discarded.");
-			framebuffer_status_valid = false;
+			//LOG_ERROR(RSX, "Some game dev set up the MRT to write to the same address as depth and color attachment. Not sure how to deal with that so the draw is discarded.");
+			//framebuffer_status_valid = false;
+			depth_address = 0;
 			break;
 		}
 	}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -149,7 +149,7 @@ namespace
 	}
 }
 
-void GLGSRender::init_buffers(bool skip_reading)
+void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool skip_reading)
 {
 	if (draw_fbo && !m_rtts_dirty)
 	{
@@ -209,9 +209,10 @@ void GLGSRender::init_buffers(bool skip_reading)
 			zeta_pitch >= required_z_pitch)
 		{
 			LOG_TRACE(RSX, "Framebuffer at 0x%X has aliasing color/depth targets, zeta_pitch = %d, color_pitch=%d", depth_address, zeta_pitch, pitchs[index]);
-			m_framebuffer_state_contested = true;
-
-			if (rsx::method_registers.depth_test_enabled() ||
+			//TODO: Research clearing both depth AND color
+			//TODO: If context is creation_draw, deal with possibility of a lost buffer clear
+			if (context == rsx::framebuffer_creation_context::context_clear_depth ||
+				rsx::method_registers.depth_test_enabled() ||
 				(!rsx::method_registers.color_write_enabled() && rsx::method_registers.depth_write_enabled()) ||
 				!!(rsx::method_registers.shader_control() & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT))
 			{
@@ -222,6 +223,7 @@ void GLGSRender::init_buffers(bool skip_reading)
 			{
 				// Use address for color data
 				depth_address = 0;
+				m_framebuffer_state_contested = true;
 				break;
 			}
 		}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -248,6 +248,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 	const auto color_locations = get_locations();
 	const auto aa_mode = rsx::method_registers.surface_antialias();
 	const auto bpp = get_format_block_size_in_bytes(surface_format);
+	const u32 aa_factor = (aa_mode == rsx::surface_antialiasing::center_1_sample || aa_mode == rsx::surface_antialiasing::diagonal_centered_2_samples) ? 1 : 2;
 
 	for (int i = 0; i < rsx::limits::color_buffers_count; ++i)
 	{
@@ -354,7 +355,6 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		{
 			if (!m_surface_info[i].address || !m_surface_info[i].pitch) continue;
 
-			const u32 aa_factor = (aa_mode == rsx::surface_antialiasing::center_1_sample || aa_mode == rsx::surface_antialiasing::diagonal_centered_2_samples) ? 1 : 2;
 			const u32 range = m_surface_info[i].pitch * m_surface_info[i].height * aa_factor;
 			m_gl_texture_cache.lock_memory_region(std::get<1>(m_rtts.m_bound_render_targets[i]), m_surface_info[i].address, range, m_surface_info[i].width, m_surface_info[i].height, m_surface_info[i].pitch,
 			color_format.format, color_format.type, color_format.swap_bytes);
@@ -370,7 +370,6 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 			u32 pitch = m_depth_surface_info.width * 2;
 			if (m_depth_surface_info.depth_format != rsx::surface_depth_format::z16) pitch *= 2;
 
-			const u32 aa_factor = (aa_mode == rsx::surface_antialiasing::center_1_sample || aa_mode == rsx::surface_antialiasing::diagonal_centered_2_samples) ? 1 : 2;
 			const u32 range = pitch * m_depth_surface_info.height * aa_factor;
 			m_gl_texture_cache.lock_memory_region(std::get<1>(m_rtts.m_bound_depth_stencil), m_depth_surface_info.address, range, m_depth_surface_info.width, m_depth_surface_info.height, pitch,
 				depth_format_gl.format, depth_format_gl.type, true);

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -354,7 +354,8 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		{
 			if (!m_surface_info[i].address || !m_surface_info[i].pitch) continue;
 
-			const u32 range = m_surface_info[i].pitch * m_surface_info[i].height;
+			const u32 aa_factor = (aa_mode == rsx::surface_antialiasing::center_1_sample || aa_mode == rsx::surface_antialiasing::diagonal_centered_2_samples) ? 1 : 2;
+			const u32 range = m_surface_info[i].pitch * m_surface_info[i].height * aa_factor;
 			m_gl_texture_cache.lock_memory_region(std::get<1>(m_rtts.m_bound_render_targets[i]), m_surface_info[i].address, range, m_surface_info[i].width, m_surface_info[i].height, m_surface_info[i].pitch,
 			color_format.format, color_format.type, color_format.swap_bytes);
 		}
@@ -369,7 +370,8 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 			u32 pitch = m_depth_surface_info.width * 2;
 			if (m_depth_surface_info.depth_format != rsx::surface_depth_format::z16) pitch *= 2;
 
-			const u32 range = pitch * m_depth_surface_info.height;
+			const u32 aa_factor = (aa_mode == rsx::surface_antialiasing::center_1_sample || aa_mode == rsx::surface_antialiasing::diagonal_centered_2_samples) ? 1 : 2;
+			const u32 range = pitch * m_depth_surface_info.height * aa_factor;
 			m_gl_texture_cache.lock_memory_region(std::get<1>(m_rtts.m_bound_depth_stencil), m_depth_surface_info.address, range, m_depth_surface_info.width, m_depth_surface_info.height, pitch,
 				depth_format_gl.format, depth_format_gl.type, true);
 		}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -184,8 +184,7 @@ struct gl_render_target_traits
 		__glcheck result->pixel_pack_settings().swap_bytes(format.swap_bytes).aligment(1);
 		__glcheck result->pixel_unpack_settings().swap_bytes(format.swap_bytes).aligment(1);
 
-		if (old_surface != nullptr && old_surface->get_compatible_internal_format() == internal_fmt)
-			result->old_contents = old_surface;
+		result->old_contents = old_surface;
 
 		result->set_cleared();
 		result->update_surface();
@@ -227,8 +226,7 @@ struct gl_render_target_traits
 		result->set_native_pitch(native_pitch);
 		result->set_compatible_format(format.internal_format);
 
-		if (old_surface != nullptr && old_surface->get_compatible_internal_format() == format.internal_format)
-			result->old_contents = old_surface;
+		result->old_contents = old_surface;
 
 		result->update_surface();
 		return result;

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -580,7 +580,6 @@ namespace gl
 	private:
 
 		blitter m_hw_blitter;
-		gl::rgba8_rg16_convert_pass m_rgba8_rg16_converter;
 		std::vector<u32> m_temporary_surfaces;
 
 		cached_texture_section& create_texture(u32 id, u32 texaddr, u32 texsize, u32 w, u32 h, u32 depth, u32 mipmaps)
@@ -653,16 +652,6 @@ namespace gl
 
 			//Empty GL_ERROR
 			glGetError();
-
-			if (ifmt != sized_internal_fmt)
-			{
-				if (sized_internal_fmt == GL_RG16F && ifmt == GL_RGBA8_EXT)
-				{
-					//TODO: Better sized internal format detection
-					m_rgba8_rg16_converter.run(width, height, dst_id, src_id);
-					return dst_id;
-				}
-			}
 
 			glCopyImageSubData(src_id, GL_TEXTURE_2D, 0, x, y, 0,
 				dst_id, dst_type, 0, 0, 0, 0, width, height, 1);
@@ -833,8 +822,6 @@ namespace gl
 		{
 			m_hw_blitter.init();
 			g_hw_blitter = &m_hw_blitter;
-
-			m_rgba8_rg16_converter.create();
 		}
 
 		void destroy() override
@@ -842,8 +829,6 @@ namespace gl
 			clear();
 			g_hw_blitter = nullptr;
 			m_hw_blitter.destroy();
-
-			m_rgba8_rg16_converter.destroy();
 		}
 
 		bool is_depth_texture(const u32 rsx_address, const u32 rsx_size) override

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -442,12 +442,10 @@ namespace gl
 			}
 			else
 			{
-				//TODO: Use compression hint from the gcm tile information
-				//TODO: Fall back to bilinear filtering if samples > 2
-
 				const u8 pixel_size = get_pixel_size(format, type);
-				const u8 samples = rsx_pitch / real_pitch;
-				rsx::scale_image_nearest(dst, const_cast<const void*>(data), width, height, rsx_pitch, real_pitch, pixel_size, samples);
+				const u8 samples_u = (aa_mode == rsx::surface_antialiasing::center_1_sample) ? 1 : 2;
+				const u8 samples_v = (aa_mode == rsx::surface_antialiasing::square_centered_4_samples || aa_mode == rsx::surface_antialiasing::square_rotated_4_samples) ? 2 : 1;
+				rsx::scale_image_nearest(dst, const_cast<const void*>(data), width, height, rsx_pitch, real_pitch, pixel_size, samples_u, samples_v);
 			}
 
 /*			switch (gcm_format)

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -306,12 +306,14 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 	//It is therefore critical that this step is done post-transform and the result re-scaled by w
 	//SEE Naruto: UNS
 	
-	OS << "	float ndc_z = gl_Position.z / gl_Position.w;\n";
-	OS << "	ndc_z = (ndc_z * 2.) - 1.;\n";
-	OS << "	gl_Position.z = ndc_z * gl_Position.w;\n";
+	//NOTE: On GPUs, poor fp32 precision means dividing z by w, then multiplying by w again gives slightly incorrect results
+	//This equation is simplified algebraically to an addition and subreaction which gives more accurate results (Fixes flickering skybox in Dark Souls 2)
+	//OS << "	float ndc_z = gl_Position.z / gl_Position.w;\n";
+	//OS << "	ndc_z = (ndc_z * 2.) - 1.;\n";
+	//OS << "	gl_Position.z = ndc_z * gl_Position.w;\n";
+	OS << "	gl_Position.z = (gl_Position.z + gl_Position.z) - gl_Position.w;\n";
 	OS << "}\n";
 }
-
 
 void GLVertexDecompilerThread::Task()
 {

--- a/rpcs3/Emu/RSX/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/RSXFragmentProgram.h
@@ -230,7 +230,7 @@ struct RSXFragmentProgram
 	bool front_color_specular_output : 1;
 	u32 texture_dimensions;
 
-	std::array<float, 2> texture_scale[16];
+	std::array<float, 4> texture_scale[16];
 	u8 textures_alpha_kill[16];
 	u8 textures_zfunc[16];
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1338,7 +1338,7 @@ namespace rsx
 		result.offset = program_offset;
 		result.addr = vm::base(rsx::get_address(program_offset, program_location));
 		result.valid = true;
-		result.ctrl = rsx::method_registers.shader_control();
+		result.ctrl = rsx::method_registers.shader_control() & (CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS | CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT);
 		result.unnormalized_coords = 0;
 		result.front_back_color_enabled = !rsx::method_registers.two_side_light_en();
 		result.back_color_diffuse_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE);
@@ -1430,7 +1430,7 @@ namespace rsx
 		result.offset = program_offset;
 		result.addr = vm::base(rsx::get_address(program_offset, program_location));
 		result.valid = true;
-		result.ctrl = rsx::method_registers.shader_control();
+		result.ctrl = rsx::method_registers.shader_control() & (CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS | CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT);
 		result.unnormalized_coords = 0;
 		result.front_back_color_enabled = !rsx::method_registers.two_side_light_en();
 		result.back_color_diffuse_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1417,6 +1417,16 @@ namespace rsx
 		}
 
 		result.set_texture_dimension(texture_dimensions);
+
+		//Sanity checks
+		if (result.ctrl & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT)
+		{
+			//Check that the depth stage is not disabled
+			if (!rsx::method_registers.depth_test_enabled())
+			{
+				LOG_ERROR(RSX, "FS exports depth component but depth test is disabled (INVALID_OPERATION)");
+			}
+		}
 	}
 
 	void thread::get_current_fragment_program_legacy(std::function<std::tuple<bool, u16>(u32, fragment_texture&, bool)> get_surface_info)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -343,6 +343,9 @@ namespace rsx
 
 		element_push_buffer.resize(0);
 
+		if (zcull_task_queue.active_query && zcull_task_queue.active_query->active)
+			zcull_task_queue.active_query->num_draws++;
+
 		if (capture_current_frame)
 		{
 			u32 element_count = rsx::method_registers.current_draw_clause.get_elements_count();
@@ -1924,5 +1927,180 @@ namespace rsx
 
 			skip_frame = (m_skip_frame_ctr < 0);
 		}
+	}
+
+	void thread::check_zcull_status(bool framebuffer_swap, bool force_read)
+	{
+		if (g_cfg.video.disable_zcull_queries)
+			return;
+
+		bool testing_enabled = zcull_pixel_cnt_enabled || zcull_stats_enabled;
+
+		if (framebuffer_swap)
+		{
+			zcull_surface_active = false;
+			const u32 zeta_address = m_depth_surface_info.address;
+
+			if (zeta_address)
+			{
+				//Find zeta address in bound zculls
+				for (int i = 0; i < rsx::limits::zculls_count; i++)
+				{
+					if (zculls[i].binded)
+					{
+						const u32 rsx_address = rsx::get_address(zculls[i].offset, CELL_GCM_LOCATION_LOCAL);
+						if (rsx_address == zeta_address)
+						{
+							zcull_surface_active = true;
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		occlusion_query_info* query = nullptr;
+
+		if (zcull_task_queue.task_stack.size() > 0)
+			query = zcull_task_queue.active_query;
+
+		if (query && query->active)
+		{
+			if (force_read || (!zcull_rendering_enabled || !testing_enabled || !zcull_surface_active))
+			{
+				end_occlusion_query(query);
+				query->active = false;
+				query->pending = true;
+			}
+		}
+		else
+		{
+			if (zcull_rendering_enabled && testing_enabled && zcull_surface_active)
+			{
+				//Find query
+				u32 free_index = synchronize_zcull_stats();
+				query = &occlusion_query_data[free_index];
+				zcull_task_queue.add(query);
+
+				begin_occlusion_query(query);
+				query->active = true;
+				query->result = 0;
+				query->num_draws = 0;
+			}
+		}
+	}
+
+	void thread::clear_zcull_stats(u32 type)
+	{
+		if (g_cfg.video.disable_zcull_queries)
+			return;
+
+		if (type == CELL_GCM_ZPASS_PIXEL_CNT)
+		{
+			if (zcull_task_queue.active_query &&
+				zcull_task_queue.active_query->active &&
+				zcull_task_queue.active_query->num_draws > 0)
+			{
+				//discard active query results
+				check_zcull_status(false, true);
+				zcull_task_queue.active_query->pending = false;
+
+				//re-enable cull stats if stats are enabled
+				check_zcull_status(false, false);
+				zcull_task_queue.active_query->num_draws = 0;
+			}
+
+			current_zcull_stats.clear();
+		}
+	}
+
+	u32 thread::get_zcull_stats(u32 type)
+	{
+		if (g_cfg.video.disable_zcull_queries)
+			return 0u;
+
+		if (zcull_task_queue.active_query &&
+			zcull_task_queue.active_query->active &&
+			current_zcull_stats.zpass_pixel_cnt == 0 &&
+			type == CELL_GCM_ZPASS_PIXEL_CNT)
+		{
+			//The zcull unit is still bound as the read is happening and there are no results ready
+			check_zcull_status(false, true);  //close current query
+			check_zcull_status(false, false); //start new query since stat counting is still active
+		}
+
+		switch (type)
+		{
+		case CELL_GCM_ZPASS_PIXEL_CNT:
+		{
+			if (current_zcull_stats.zpass_pixel_cnt > 0)
+				return UINT16_MAX;
+
+			synchronize_zcull_stats(true);
+			return (current_zcull_stats.zpass_pixel_cnt > 0) ? UINT16_MAX : 0;
+		}
+		case CELL_GCM_ZCULL_STATS:
+		case CELL_GCM_ZCULL_STATS1:
+		case CELL_GCM_ZCULL_STATS2:
+			//TODO
+			return UINT16_MAX;
+		case CELL_GCM_ZCULL_STATS3:
+		{
+			//Some kind of inverse value
+			if (current_zcull_stats.zpass_pixel_cnt > 0)
+				return 0;
+
+			synchronize_zcull_stats(true);
+			return (current_zcull_stats.zpass_pixel_cnt > 0) ? 0 : UINT16_MAX;
+		}
+		default:
+			LOG_ERROR(RSX, "Unknown zcull stat type %d", type);
+			return 0;
+		}
+	}
+
+	u32 thread::synchronize_zcull_stats(bool hard_sync)
+	{
+		if (!zcull_rendering_enabled || zcull_task_queue.pending == 0)
+			return 0;
+
+		u32 result = UINT16_MAX;
+
+		for (auto &query : zcull_task_queue.task_stack)
+		{
+			if (query == nullptr || query->active)
+				continue;
+
+			bool status = check_occlusion_query_status(query);
+			if (status == false && !hard_sync)
+				continue;
+
+			get_occlusion_query_result(query);
+			current_zcull_stats.zpass_pixel_cnt += query->result;
+
+			query->pending = false;
+			query = nullptr;
+			zcull_task_queue.pending--;
+		}
+
+		for (u32 i = 0; i < occlusion_query_count; ++i)
+		{
+			auto &query = occlusion_query_data[i];
+			if (!query.pending && !query.active)
+			{
+				result = i;
+				break;
+			}
+		}
+
+		if (result == UINT16_MAX && !hard_sync)
+			return synchronize_zcull_stats(true);
+
+		return result;
+	}
+
+	void thread::notify_zcull_info_changed()
+	{
+		check_zcull_status(false, false);
 	}
 }

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -854,7 +854,10 @@ namespace rsx
 		size_t offset = 8;
 		for (int index = 0; index < 16; ++index)
 		{
-			stream_vector(&dst[offset], (u32&)fragment_program.texture_scale[index][0], (u32&)fragment_program.texture_scale[index][1], 0U, 0U);
+			stream_vector(&dst[offset],
+				(u32&)fragment_program.texture_scale[index][0], (u32&)fragment_program.texture_scale[index][1],
+				(u32&)fragment_program.texture_scale[index][2], (u32&)fragment_program.texture_scale[index][3]);
+
 			offset += 4;
 		}
 	}
@@ -1396,8 +1399,12 @@ namespace rsx
 					case CELL_GCM_TEXTURE_D8R8G8B8:
 					case CELL_GCM_TEXTURE_A4R4G4B4:
 					case CELL_GCM_TEXTURE_R5G6B5:
+					{
+						u32 remap = tex.remap();
 						result.redirected_textures |= (1 << i);
+						result.texture_scale[i][2] = (f32&)remap;
 						break;
+					}
 					case CELL_GCM_TEXTURE_DEPTH16:
 					case CELL_GCM_TEXTURE_DEPTH24_D8:
 					case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
@@ -1520,8 +1527,12 @@ namespace rsx
 						case CELL_GCM_TEXTURE_D8R8G8B8:
 						case CELL_GCM_TEXTURE_A4R4G4B4:
 						case CELL_GCM_TEXTURE_R5G6B5:
+						{
+							u32 remap = tex.remap();
 							result.redirected_textures |= (1 << i);
+							result.texture_scale[i][2] = (f32&)remap;
 							break;
+						}
 						case CELL_GCM_TEXTURE_DEPTH16:
 						case CELL_GCM_TEXTURE_DEPTH24_D8:
 						case CELL_GCM_TEXTURE_DEPTH16_FLOAT:

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -545,6 +545,13 @@ namespace rsx
 			}
 			if (cmd == RSX_METHOD_RETURN_CMD)
 			{
+				if (m_call_stack.size() == 0)
+				{
+					LOG_ERROR(RSX, "FIFO: RET found without corresponding CALL. Discarding queue");
+					internal_get = put;
+					continue;
+				}
+
 				u32 get = m_call_stack.top();
 				m_call_stack.pop();
 				//LOG_WARNING(RSX, "rsx return(0x%x)", get);

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -188,6 +188,7 @@ namespace rsx
 		bool m_transform_constants_dirty;
 		bool m_textures_dirty[16];
 		bool m_vertex_textures_dirty[4];
+		bool m_framebuffer_state_contested = false;
 
 	protected:
 		std::array<u32, 4> get_color_surface_addresses() const;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -44,6 +44,14 @@ namespace rsx
 		};
 	}
 
+	enum framebuffer_creation_context : u8
+	{
+		context_draw = 0,
+		context_clear_color = 1,
+		context_clear_depth = 2,
+		context_clear_all = context_clear_color | context_clear_depth
+	};
+
 	u32 get_vertex_type_size_on_host(vertex_base_type type, u32 size);
 
 	u32 get_address(u32 offset, u32 location);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2546,16 +2546,17 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 
 		for (u8 index : draw_buffers)
 		{
-			vk::image *raw = std::get<1>(m_rtts.m_bound_render_targets[index]);
+			if (vk::image *raw = std::get<1>(m_rtts.m_bound_render_targets[index]))
+			{
+				VkImageSubresourceRange subres = {};
+				subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+				subres.baseArrayLayer = 0;
+				subres.baseMipLevel = 0;
+				subres.layerCount = 1;
+				subres.levelCount = 1;
 
-			VkImageSubresourceRange subres = {};
-			subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			subres.baseArrayLayer = 0;
-			subres.baseMipLevel = 0;
-			subres.layerCount = 1;
-			subres.levelCount = 1;
-
-			fbo_images.push_back(std::make_unique<vk::image_view>(*m_device, raw->value, VK_IMAGE_VIEW_TYPE_2D, raw->info.format, vk::default_component_map(), subres));
+				fbo_images.push_back(std::make_unique<vk::image_view>(*m_device, raw->value, VK_IMAGE_VIEW_TYPE_2D, raw->info.format, vk::default_component_map(), subres));
+			}
 		}
 
 		if (std::get<1>(m_rtts.m_bound_depth_stencil) != nullptr)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2423,20 +2423,20 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	const auto color_fmt = rsx::method_registers.surface_color();
 	const auto depth_fmt = rsx::method_registers.surface_depth_fmt();
 
-	//TODO: Verify that buffers <= 16 pixels in X (pitch=64) cannot have a depth buffer
-	const auto required_z_pitch = 64;//depth_fmt == rsx::surface_depth_format::z16 ? clip_width * 2 : clip_width * 4;
+	const auto required_z_pitch = depth_fmt == rsx::surface_depth_format::z16 ? clip_width * 2 : clip_width * 4;
 	const auto required_color_pitch = std::max<u32>(rsx::utility::get_packed_pitch(color_fmt, clip_width), 64u);
 
 	if (zeta_address)
 	{
-		if (zeta_pitch < required_z_pitch)
+		//TODO: Verify that buffers <= 16 pixels in X (pitch=64) cannot have a depth buffer
+		if (zeta_pitch < required_z_pitch || zeta_pitch <= 64)
 		{
 			zeta_address = 0;
 		}
 		else if (!rsx::method_registers.depth_test_enabled())
 		{
 			//Disable depth buffer if depth testing is not enabled, unless a clear command is targeting the depth buffer
-			const bool is_depth_clear = rsx::method_registers.depth_write_enabled() && !!(context & rsx::framebuffer_creation_context::context_clear_depth);
+			const bool is_depth_clear = !!(context & rsx::framebuffer_creation_context::context_clear_depth);
 			if (!is_depth_clear)
 			{
 				zeta_address = 0;
@@ -2465,8 +2465,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 			LOG_TRACE(RSX, "Framebuffer at 0x%X has aliasing color/depth targets, zeta_pitch = %d, color_pitch=%d", zeta_address, zeta_pitch, surface_pitchs[index]);
 			if (context == rsx::framebuffer_creation_context::context_clear_depth ||
 				rsx::method_registers.depth_test_enabled() ||
-				(!rsx::method_registers.color_write_enabled() && rsx::method_registers.depth_write_enabled()) ||
-				!!(rsx::method_registers.shader_control() & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT))
+				(!rsx::method_registers.color_write_enabled() && rsx::method_registers.depth_write_enabled()))
 			{
 				// Use address for depth data
 				// TODO: create a temporary render buffer for this to keep MRT outputs aligned

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1383,10 +1383,8 @@ void VKGSRender::end()
 		//Prepare surfaces if needed
 		for (auto &rtt : m_rtts.m_bound_render_targets)
 		{
-			if (std::get<0>(rtt) != 0)
+			if (auto surface = std::get<1>(rtt))
 			{
-				auto surface = std::get<1>(rtt);
-
 				if (surface->old_contents != nullptr)
 					copy_rtt_contents(surface);
 			}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2354,8 +2354,9 @@ void VKGSRender::prepare_rtts()
 		if (surface_addresses[index] == zeta_address &&
 			zeta_pitch >= required_z_pitch)
 		{
-			LOG_ERROR(RSX, "Some game dev set up the MRT to write to the same address as depth and color attachment. Not sure how to deal with that so the draw is discarded.");
-			framebuffer_status_valid = false;
+			//LOG_ERROR(RSX, "Some game dev set up the MRT to write to the same address as depth and color attachment. Not sure how to deal with that so the draw is discarded.");
+			//framebuffer_status_valid = false;
+			zeta_address = 0;
 			break;
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2916,7 +2916,7 @@ void VKGSRender::flip(int buffer)
 	if (image_to_flip)
 	{
 		vk::copy_scaled_image(*m_current_command_buffer, image_to_flip->value, target_image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-			0, 0, image_to_flip->width(), image_to_flip->height(), aspect_ratio.x, aspect_ratio.y, aspect_ratio.width, aspect_ratio.height, 1, VK_IMAGE_ASPECT_COLOR_BIT);
+			0, 0, image_to_flip->width(), image_to_flip->height(), aspect_ratio.x, aspect_ratio.y, aspect_ratio.width, aspect_ratio.height, 1, VK_IMAGE_ASPECT_COLOR_BIT, false);
 	}
 	else
 	{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2423,10 +2423,27 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	const auto color_fmt = rsx::method_registers.surface_color();
 	const auto depth_fmt = rsx::method_registers.surface_depth_fmt();
 
-	const auto required_z_pitch = depth_fmt == rsx::surface_depth_format::z16 ? clip_width * 2 : clip_width * 4;
+	//TODO: Verify that buffers <= 16 pixels in X (pitch=64) cannot have a depth buffer
+	const auto required_z_pitch = 64;//depth_fmt == rsx::surface_depth_format::z16 ? clip_width * 2 : clip_width * 4;
+	const auto required_color_pitch = std::max<u32>(rsx::utility::get_packed_pitch(color_fmt, clip_width), 64u);
 
-	if (zeta_address && zeta_pitch < required_z_pitch)
-		zeta_address = 0;
+	if (zeta_address)
+	{
+		if (zeta_pitch < required_z_pitch)
+		{
+			zeta_address = 0;
+		}
+		else if (!rsx::method_registers.depth_test_enabled())
+		{
+			//Disable depth buffer if depth testing is not enabled, unless a clear command is targeting the depth buffer
+			const bool is_depth_clear = rsx::method_registers.depth_write_enabled() && !!(context & rsx::framebuffer_creation_context::context_clear_depth);
+			if (!is_depth_clear)
+			{
+				zeta_address = 0;
+				m_framebuffer_state_contested = true;
+			}
+		}
+	}
 
 	for (const auto &addr: surface_addresses)
 	{
@@ -2439,7 +2456,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 
 	for (const auto &index : rsx::utility::get_rtt_indexes(rsx::method_registers.surface_color_target()))
 	{
-		if (surface_pitchs[index] < 64)
+		if (surface_pitchs[index] < required_color_pitch)
 			surface_addresses[index] = 0;
 
 		if (surface_addresses[index] == zeta_address &&
@@ -2474,6 +2491,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	const auto fbo_width = rsx::apply_resolution_scale(clip_width, true);
 	const auto fbo_height = rsx::apply_resolution_scale(clip_height, true);
 	const auto aa_mode = rsx::method_registers.surface_antialias();
+	const auto bpp = get_format_block_size_in_bytes(color_fmt);
 
 	if (m_draw_fbo)
 	{
@@ -2539,8 +2557,6 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 
 	std::vector<vk::image*> bound_images;
 	bound_images.reserve(5);
-
-	const auto bpp = get_format_block_size_in_bytes(color_fmt);
 
 	for (u8 index : draw_buffers)
 	{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2481,6 +2481,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	const auto fbo_height = rsx::apply_resolution_scale(clip_height, true);
 	const auto aa_mode = rsx::method_registers.surface_antialias();
 	const auto bpp = get_format_block_size_in_bytes(color_fmt);
+	const u32 aa_factor = (aa_mode == rsx::surface_antialiasing::center_1_sample || aa_mode == rsx::surface_antialiasing::diagonal_centered_2_samples) ? 1 : 2;
 
 	if (m_draw_fbo)
 	{
@@ -2588,8 +2589,8 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		for (u8 index : draw_buffers)
 		{
 			if (!m_surface_info[index].address || !m_surface_info[index].pitch) continue;
-			const u32 range = m_surface_info[index].pitch * m_surface_info[index].height;
 
+			const u32 range = m_surface_info[index].pitch * m_surface_info[index].height * aa_factor;
 			m_texture_cache.lock_memory_region(std::get<1>(m_rtts.m_bound_render_targets[index]), m_surface_info[index].address, range,
 				m_surface_info[index].width, m_surface_info[index].height, m_surface_info[index].pitch, color_fmt_info.first, color_fmt_info.second);
 		}
@@ -2608,7 +2609,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 				pitch *= 2;
 			}
 
-			const u32 range = pitch * m_depth_surface_info.height;
+			const u32 range = pitch * m_depth_surface_info.height * aa_factor;
 			m_texture_cache.lock_memory_region(std::get<1>(m_rtts.m_bound_depth_stencil), m_depth_surface_info.address, range,
 				m_depth_surface_info.width, m_depth_surface_info.height, m_depth_surface_info.pitch, gcm_format, true);
 		}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -295,7 +295,7 @@ private:
 	void close_and_submit_command_buffer(const std::vector<VkSemaphore> &semaphores, VkFence fence, VkPipelineStageFlags pipeline_stage_flags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 	void open_command_buffer();
 	void sync_at_semaphore_release();
-	void prepare_rtts();
+	void prepare_rtts(rsx::framebuffer_creation_context context);
 	void copy_render_targets_to_dma_location();
 
 	void flush_command_queue(bool hard_sync = false);
@@ -315,7 +315,7 @@ private:
 public:
 	bool check_program_status();
 	void load_program(u32 vertex_count, u32 vertex_base);
-	void init_buffers(bool skip_reading = false);
+	void init_buffers(rsx::framebuffer_creation_context context, bool skip_reading = false);
 	void read_buffers();
 	void write_buffers();
 	void set_viewport();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -5,6 +5,7 @@
 #include "VKRenderTargets.h"
 #include "VKFormats.h"
 #include "VKTextOut.h"
+#include "VKOverlays.h"
 #include "restore_new.h"
 #include "define_new_memleakdetect.h"
 #include "VKProgramBuffer.h"
@@ -134,6 +135,7 @@ private:
 	std::unique_ptr<vk::buffer_view> null_buffer_view;
 
 	std::unique_ptr<vk::text_writer> m_text_writer;
+	std::unique_ptr<vk::depth_convert_pass> m_depth_converter;
 
 	std::mutex m_sampler_mutex;
 	u64 surface_store_tag = 0;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -277,6 +277,7 @@ private:
 	std::atomic<u64> m_last_sync_event = { 0 };
 
 	bool render_pass_open = false;
+	size_t m_current_renderpass_id = 0;
 
 	//Vertex layout
 	rsx::vertex_input_layout m_vertex_layout;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1450,6 +1450,113 @@ namespace vk
 		}
 	};
 
+	class occlusion_query_pool
+	{
+		VkQueryPool query_pool = VK_NULL_HANDLE;
+		vk::render_device* owner = nullptr;
+
+		std::vector<bool> query_active_status;
+
+	public:
+
+		void create(vk::render_device &dev, u32 num_entries)
+		{
+			VkQueryPoolCreateInfo info = {};
+			info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+			info.queryType = VK_QUERY_TYPE_OCCLUSION;
+			info.queryCount = num_entries;
+
+			CHECK_RESULT(vkCreateQueryPool(dev, &info, nullptr, &query_pool));
+			owner = &dev;
+
+			query_active_status.resize(num_entries, false);
+		}
+
+		void destroy()
+		{
+			if (query_pool)
+			{
+				vkDestroyQueryPool(*owner, query_pool, nullptr);
+
+				owner = nullptr;
+				query_pool = VK_NULL_HANDLE;
+			}
+		}
+
+		void begin_query(vk::command_buffer &cmd, u32 index)
+		{
+			if (query_active_status[index])
+			{
+				//Synchronization must be done externally
+				vkCmdResetQueryPool(cmd, query_pool, index, 1);
+			}
+
+			vkCmdBeginQuery(cmd, query_pool, index, 0);//VK_QUERY_CONTROL_PRECISE_BIT);
+			query_active_status[index] = true;
+		}
+
+		void end_query(vk::command_buffer &cmd, u32 index)
+		{
+			vkCmdEndQuery(cmd, query_pool, index);
+		}
+
+		bool check_query_status(u32 index)
+		{
+			u32 result[2] = {0, 0};
+			switch (VkResult status = vkGetQueryPoolResults(*owner, query_pool, index, 1, 8, result, 8, VK_QUERY_RESULT_WITH_AVAILABILITY_BIT))
+			{
+			case VK_SUCCESS:
+				break;
+			case VK_NOT_READY:
+				return false;
+			default:
+				vk::die_with_error(HERE, status);
+			}
+
+			return result[1] != 0;
+		}
+
+		u32 get_query_result(u32 index)
+		{
+			u32 result = 0;
+			CHECK_RESULT(vkGetQueryPoolResults(*owner, query_pool, index, 1, 4, &result, 4, VK_QUERY_RESULT_WAIT_BIT));
+
+			return result == 0u? 0u: 1u;
+		}
+
+		void reset_query(vk::command_buffer &cmd, u32 index)
+		{
+			vkCmdResetQueryPool(cmd, query_pool, index, 1);
+			query_active_status[index] = false;
+		}
+
+		void reset_queries(vk::command_buffer &cmd, std::vector<u32> &list)
+		{
+			for (const auto index : list)
+				reset_query(cmd, index);
+		}
+
+		void reset_all(vk::command_buffer &cmd)
+		{
+			for (u32 n = 0; n < query_active_status.size(); n++)
+			{
+				if (query_active_status[n])
+					reset_query(cmd, n);
+			}
+		}
+
+		u32 find_free_slot()
+		{
+			for (u32 n = 0; n < query_active_status.size(); n++)
+			{
+				if (query_active_status[n] == false)
+					return n;
+			}
+
+			return UINT32_MAX;
+		}
+	};
+
 	namespace glsl
 	{
 		enum program_input_type

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -80,7 +80,7 @@ namespace vk
 	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range);
 	void change_image_layout(VkCommandBuffer cmd, vk::image *image, VkImageLayout new_layout, VkImageSubresourceRange range);
 	void copy_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout, u32 width, u32 height, u32 mipmaps, VkImageAspectFlagBits aspect);
-	void copy_scaled_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout, u32 src_x_offset, u32 src_y_offset, u32 src_width, u32 src_height, u32 dst_x_offset, u32 dst_y_offset, u32 dst_width, u32 dst_height, u32 mipmaps, VkImageAspectFlagBits aspect);
+	void copy_scaled_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout, u32 src_x_offset, u32 src_y_offset, u32 src_width, u32 src_height, u32 dst_x_offset, u32 dst_y_offset, u32 dst_width, u32 dst_height, u32 mipmaps, VkImageAspectFlagBits aspect, bool compatible_formats);
 
 	VkFormat get_compatible_sampler_format(u32 format);
 	u8 get_format_texel_width(const VkFormat format);

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "VKHelpers.h"
+#include "VKVertexProgram.h"
+#include "VKFragmentProgram.h"
+
+namespace vk
+{
+	struct overlay_pass
+	{
+		//TODO
+	};
+}

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -334,9 +334,7 @@ namespace vk
 				"void main()\n"
 				"{\n"
 				"	vec4 rgba_in = texture(fs0, tc0);\n"
-				"	uint raw_value = uint(rgba_in.b * 255.) | (uint(rgba_in.g * 255.) << 8) | (uint(rgba_in.r * 255.) << 16);\n"
-				"	gl_FragDepth = float(raw_value) / 16777215.;\n"
-				"	//gl_FragDepth = rgba_in.r * 0.99609 + rgba_in.g * 0.00389 + rgba_in.b * 0.00002;\n"
+				"	gl_FragDepth = rgba_in.w * 0.99609 + rgba_in.x * 0.00389 + rgba_in.y * 0.00002;\n"
 				"}\n"
 			};
 

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -2,11 +2,348 @@
 #include "VKHelpers.h"
 #include "VKVertexProgram.h"
 #include "VKFragmentProgram.h"
+#include "VKRenderTargets.h"
 
 namespace vk
 {
+	//TODO: Refactor text print class to inherit from this base class
 	struct overlay_pass
 	{
-		//TODO
+		VKVertexProgram m_vertex_shader;
+		VKFragmentProgram m_fragment_shader;
+
+		vk::descriptor_pool m_descriptor_pool;
+		VkDescriptorSet m_descriptor_set = nullptr;
+		VkDescriptorSetLayout m_descriptor_layout = nullptr;
+		VkPipelineLayout m_pipeline_layout = nullptr;
+		u32 m_used_descriptors = 0;
+
+		std::unordered_map<VkRenderPass, std::unique_ptr<vk::glsl::program>> m_program_cache;
+		std::unique_ptr<vk::sampler> m_sampler;
+		std::unique_ptr<vk::framebuffer> m_draw_fbo;
+		vk::render_device* m_device = nullptr;
+
+		std::string vs_src;
+		std::string fs_src;
+
+		struct
+		{
+			int color_attachments = 0;
+			bool write_color = true;
+			bool write_depth = true;
+			bool no_depth_test = true;
+		}
+		renderpass_config;
+
+		bool initialized = false;
+		bool compiled = false;
+
+		void init_descriptors()
+		{
+			VkDescriptorPoolSize descriptor_pools[1] =
+			{
+				{ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 120 },
+			};
+
+			//Reserve descriptor pools
+			m_descriptor_pool.create(*m_device, descriptor_pools, 1);
+
+			VkDescriptorSetLayoutBinding bindings[1] = {};
+
+			bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			bindings[0].descriptorCount = 1;
+			bindings[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+			bindings[0].binding = 0;
+
+			VkDescriptorSetLayoutCreateInfo infos = {};
+			infos.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+			infos.pBindings = bindings;
+			infos.bindingCount = 1;
+
+			CHECK_RESULT(vkCreateDescriptorSetLayout(*m_device, &infos, nullptr, &m_descriptor_layout));
+
+			VkPipelineLayoutCreateInfo layout_info = {};
+			layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+			layout_info.setLayoutCount = 1;
+			layout_info.pSetLayouts = &m_descriptor_layout;
+
+			CHECK_RESULT(vkCreatePipelineLayout(*m_device, &layout_info, nullptr, &m_pipeline_layout));
+		}
+
+		vk::glsl::program* build_pipeline(VkRenderPass render_pass)
+		{
+			if (!compiled)
+			{
+				m_vertex_shader.shader = vs_src;
+				m_vertex_shader.Compile();
+
+				m_fragment_shader.shader = fs_src;
+				m_fragment_shader.Compile();
+
+				compiled = true;
+			}
+
+			VkPipelineShaderStageCreateInfo shader_stages[2] = {};
+			shader_stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+			shader_stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+			shader_stages[0].module = m_vertex_shader.handle;
+			shader_stages[0].pName = "main";
+
+			shader_stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+			shader_stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+			shader_stages[1].module = m_fragment_shader.handle;
+			shader_stages[1].pName = "main";
+
+			VkDynamicState dynamic_state_descriptors[VK_DYNAMIC_STATE_RANGE_SIZE] = {};
+			VkPipelineDynamicStateCreateInfo dynamic_state_info = {};
+			dynamic_state_info.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+			dynamic_state_descriptors[dynamic_state_info.dynamicStateCount++] = VK_DYNAMIC_STATE_VIEWPORT;
+			dynamic_state_descriptors[dynamic_state_info.dynamicStateCount++] = VK_DYNAMIC_STATE_SCISSOR;
+			dynamic_state_info.pDynamicStates = dynamic_state_descriptors;
+
+			VkPipelineVertexInputStateCreateInfo vi = {};
+			vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+			VkPipelineViewportStateCreateInfo vp = {};
+			vp.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+			vp.scissorCount = 1;
+			vp.viewportCount = 1;
+
+			VkPipelineMultisampleStateCreateInfo ms = {};
+			ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+			ms.pSampleMask = NULL;
+			ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+			VkPipelineInputAssemblyStateCreateInfo ia = {};
+			ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+			ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
+
+			VkPipelineRasterizationStateCreateInfo rs = {};
+			rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+			rs.lineWidth = 1.f;
+			rs.polygonMode = VK_POLYGON_MODE_FILL;
+
+			VkPipelineColorBlendAttachmentState att = {};
+			if (renderpass_config.write_color)
+				att.colorWriteMask = 0xf;
+
+			VkPipelineColorBlendStateCreateInfo cs = {};
+			cs.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+			cs.attachmentCount = renderpass_config.color_attachments;
+			cs.pAttachments = &att;
+
+			VkPipelineDepthStencilStateCreateInfo ds = {};
+			ds.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+			ds.depthWriteEnable = renderpass_config.write_depth? VK_TRUE: VK_FALSE;
+			ds.depthTestEnable = VK_TRUE;
+			ds.depthCompareOp = VK_COMPARE_OP_ALWAYS;
+
+			VkPipeline pipeline;
+			VkGraphicsPipelineCreateInfo info = {};
+			info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+			info.pVertexInputState = &vi;
+			info.pInputAssemblyState = &ia;
+			info.pRasterizationState = &rs;
+			info.pColorBlendState = &cs;
+			info.pMultisampleState = &ms;
+			info.pViewportState = &vp;
+			info.pDepthStencilState = &ds;
+			info.stageCount = 2;
+			info.pStages = shader_stages;
+			info.pDynamicState = &dynamic_state_info;
+			info.layout = m_pipeline_layout;
+			info.basePipelineIndex = -1;
+			info.basePipelineHandle = VK_NULL_HANDLE;
+			info.renderPass = render_pass;
+
+			CHECK_RESULT(vkCreateGraphicsPipelines(*m_device, nullptr, 1, &info, NULL, &pipeline));
+
+			const std::vector<vk::glsl::program_input> unused;
+			std::vector<vk::glsl::program_input> fs_inputs;
+			fs_inputs.push_back({ ::glsl::program_domain::glsl_fragment_program, vk::glsl::program_input_type::input_type_texture, {}, {}, 0, "fs0"});
+			auto program = std::make_unique<vk::glsl::program>(*m_device, pipeline, unused, fs_inputs);
+			auto result = program.get();
+			m_program_cache[render_pass] = std::move(program);
+
+			return result;
+		}
+
+		void load_program(vk::command_buffer cmd, VkRenderPass pass, vk::image_view *src)
+		{
+			vk::glsl::program *program = nullptr;
+			auto found = m_program_cache.find(pass);
+			if (found != m_program_cache.end())
+				program = found->second.get();
+			else
+				program = build_pipeline(pass);
+
+			verify(HERE), m_used_descriptors < 120;
+
+			VkDescriptorSetAllocateInfo alloc_info = {};
+			alloc_info.descriptorPool = m_descriptor_pool;
+			alloc_info.descriptorSetCount = 1;
+			alloc_info.pSetLayouts = &m_descriptor_layout;
+			alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+
+			CHECK_RESULT(vkAllocateDescriptorSets(*m_device, &alloc_info, &m_descriptor_set));
+			m_used_descriptors++;
+
+			if (!m_sampler)
+			{
+				m_sampler = std::make_unique<vk::sampler>(*m_device,
+					VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+					VK_FALSE, 0.f, 1.f, 0.f, 0.f, VK_FILTER_LINEAR, VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK);
+			}
+
+			VkDescriptorImageInfo info = { m_sampler->value, src->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+			program->bind_uniform(info, "fs0", m_descriptor_set);
+
+			vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, program->pipeline);
+			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline_layout, 0, 1, &m_descriptor_set, 0, nullptr);
+		}
+
+		void create(vk::render_device &dev)
+		{
+			if (!initialized)
+			{
+				m_device = &dev;
+				init_descriptors();
+
+				initialized = true;
+			}
+		}
+
+		void destroy()
+		{
+			if (initialized)
+			{
+				m_program_cache.clear();
+				m_sampler.reset();
+
+				vkDestroyDescriptorSetLayout(*m_device, m_descriptor_layout, nullptr);
+				vkDestroyPipelineLayout(*m_device, m_pipeline_layout, nullptr);
+				m_descriptor_pool.destroy();
+
+				initialized = false;
+			}
+		}
+
+		void free_resources()
+		{
+			if (m_used_descriptors == 0)
+				return;
+
+			vkResetDescriptorPool(*m_device, m_descriptor_pool, 0);
+			m_used_descriptors = 0;
+		}
+
+		vk::framebuffer* get_framebuffer(vk::image* target, VkRenderPass render_pass, std::list<std::unique_ptr<vk::framebuffer_holder>>& framebuffer_resources)
+		{
+			std::vector<vk::image*> test = {target};
+			for (auto It = framebuffer_resources.begin(); It != framebuffer_resources.end(); It++)
+			{
+				auto fbo = It->get();
+				if (fbo->matches(test, target->width(), target->height()))
+				{
+					fbo->deref_count = 0;
+					return fbo;
+				}
+			}
+
+			//No match, create new fbo and add to the list
+			std::vector<std::unique_ptr<vk::image_view>> views;
+			VkComponentMapping mapping = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
+			VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+
+			switch (target->info.format)
+			{
+			case VK_FORMAT_D16_UNORM:
+			case VK_FORMAT_D24_UNORM_S8_UINT:
+			case VK_FORMAT_D32_SFLOAT_S8_UINT:
+				range.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT; //We are only writing to depth
+				break;
+			}
+
+			auto view = std::make_unique<vk::image_view>(*m_device, target->value, VK_IMAGE_VIEW_TYPE_2D, target->info.format, mapping, range);
+			views.push_back(std::move(view));
+
+			auto fbo = std::make_unique<vk::framebuffer_holder>(*m_device, render_pass, target->width(), target->height(), std::move(views));
+			auto result = fbo.get();
+			framebuffer_resources.push_back(std::move(fbo));
+
+			return result;
+		}
+
+		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::image* target, vk::image_view* src, VkRenderPass render_pass, std::list<std::unique_ptr<vk::framebuffer_holder>>& framebuffer_resources)
+		{
+			vk::framebuffer *fbo = get_framebuffer(target, render_pass, framebuffer_resources);
+
+			VkViewport vp{};
+			vp.width = (f32)w;
+			vp.height = (f32)h;
+			vp.minDepth = 0.f;
+			vp.maxDepth = 1.f;
+			vkCmdSetViewport(cmd, 0, 1, &vp);
+
+			VkRect2D vs = { { 0, 0 },{ 0u + w, 0u + h } };
+			vkCmdSetScissor(cmd, 0, 1, &vs);
+
+			load_program(cmd, render_pass, src);
+
+			VkRenderPassBeginInfo rp_begin = {};
+			rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+			rp_begin.renderPass = render_pass;
+			rp_begin.framebuffer = fbo->value;
+			rp_begin.renderArea.offset.x = 0;
+			rp_begin.renderArea.offset.y = 0;
+			rp_begin.renderArea.extent.width = w;
+			rp_begin.renderArea.extent.height = h;
+
+			vkCmdBeginRenderPass(cmd, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+			vkCmdDraw(cmd, 4, 1, 0, 0);
+			vkCmdEndRenderPass(cmd);
+		}
+	};
+
+	struct depth_convert_pass : public overlay_pass
+	{
+		depth_convert_pass()
+		{
+			vs_src =
+			{
+				"#version 450\n"
+				"#extension GL_ARB_separate_shader_objects : enable\n"
+				"layout(location=0) out vec2 tc0;\n"
+				"\n"
+				"void main()\n"
+				"{\n"
+				"	vec2 positions[] = {vec2(-1., -1.), vec2(1., -1.), vec2(-1., 1.), vec2(1., 1.)};\n"
+				"	vec2 coords[] = {vec2(0., 0.), vec2(1., 0.), vec2(0., 1.), vec2(1., 1.)};\n"
+				"	gl_Position = vec4(positions[gl_VertexIndex % 4], 0., 1.);\n"
+				"	tc0 = coords[gl_VertexIndex % 4];\n"
+				"}\n"
+			};
+
+			fs_src =
+			{
+				"#version 420\n"
+				"#extension GL_ARB_separate_shader_objects : enable\n"
+				"layout(set=0, binding=0) uniform sampler2D fs0;\n"
+				"layout(location=0) in vec2 tc0;\n"
+				"\n"
+				"void main()\n"
+				"{\n"
+				"	vec4 rgba_in = texture(fs0, tc0);\n"
+				"	uint raw_value = uint(rgba_in.b * 255.) | (uint(rgba_in.g * 255.) << 8) | (uint(rgba_in.r * 255.) << 16);\n"
+				"	gl_FragDepth = float(raw_value) / 16777215.;\n"
+				"	//gl_FragDepth = rgba_in.r * 0.99609 + rgba_in.g * 0.00389 + rgba_in.b * 0.00002;\n"
+				"}\n"
+			};
+
+			renderpass_config.write_color = false;
+
+			m_vertex_shader.id = 100002;
+			m_fragment_shader.id = 100003;
+		}
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -278,6 +278,8 @@ namespace vk
 		{
 			vk::framebuffer *fbo = get_framebuffer(target, render_pass, framebuffer_resources);
 
+			load_program(cmd, render_pass, src);
+
 			VkViewport vp{};
 			vp.width = (f32)w;
 			vp.height = (f32)h;
@@ -287,8 +289,6 @@ namespace vk
 
 			VkRect2D vs = { { 0, 0 },{ 0u + w, 0u + h } };
 			vkCmdSetScissor(cmd, 0, 1, &vs);
-
-			load_program(cmd, render_pass, src);
 
 			VkRenderPassBeginInfo rp_begin = {};
 			rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -103,9 +103,11 @@ namespace vk
 			};
 
 			m_vertex_shader.shader = vs;
+			m_vertex_shader.id = 100000;
 			m_vertex_shader.Compile();
 
 			m_fragment_shader.shader = fs;
+			m_fragment_shader.id = 100001;
 			m_fragment_shader.Compile();
 
 			VkPipelineShaderStageCreateInfo shader_stages[2] = {};

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -86,7 +86,7 @@ namespace vk
 			VkImageLayout srcLayout, VkImageLayout dstLayout,
 			u32 src_x_offset, u32 src_y_offset, u32 src_width, u32 src_height,
 			u32 dst_x_offset, u32 dst_y_offset, u32 dst_width, u32 dst_height,
-			u32 mipmaps, VkImageAspectFlagBits aspect)
+			u32 mipmaps, VkImageAspectFlagBits aspect, bool compatible_formats)
 	{
 		VkImageSubresourceLayers a_src = {}, a_dst = {};
 		a_src.aspectMask = aspect;
@@ -103,7 +103,7 @@ namespace vk
 		if (dstLayout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
 			change_image_layout(cmd, dst, dstLayout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, vk::get_image_subresource_range(0, 0, 1, 1, aspect));
 
-		if (src_width != dst_width || src_height != dst_height || mipmaps > 1)
+		if (src_width != dst_width || src_height != dst_height || mipmaps > 1 || !compatible_formats)
 		{
 			if ((aspect & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) != 0)
 			{

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -899,7 +899,7 @@ namespace vk
 					}
 
 					copy_scaled_image(*commands, src->value, dst->value, src->current_layout, dst->current_layout, src_area.x1, src_area.y1, src_area.x2 - src_area.x1, src_area.y2 - src_area.y1,
-						dst_area.x1, dst_area.y1, dst_area.x2 - dst_area.x1, dst_area.y2 - dst_area.y1, 1, aspect);
+						dst_area.x1, dst_area.y1, dst_area.x2 - dst_area.x1, dst_area.y2 - dst_area.y1, 1, aspect, src->info.format == dst->info.format);
 
 					change_image_layout(*commands, dst, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, {(VkImageAspectFlags)aspect, 0, dst->info.mipLevels, 0, dst->info.arrayLayers});
 				}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -308,9 +308,20 @@ namespace vk
 			{
 				//Scale image to fit
 				//usually we can just get away with nearest filtering
-				const u8 samples = rsx_pitch / real_pitch;
+				u8 samples_u = 1, samples_v = 1;
+				switch (static_cast<vk::render_target*>(vram_texture)->aa_mode)
+				{
+				case rsx::surface_antialiasing::diagonal_centered_2_samples:
+					samples_u = 2;
+					break;
+				case rsx::surface_antialiasing::square_centered_4_samples:
+				case rsx::surface_antialiasing::square_rotated_4_samples:
+					samples_u = 2;
+					samples_v = 2;
+					break;
+				}
 
-				rsx::scale_image_nearest(pixels_dst, pixels_src, width, height, rsx_pitch, real_pitch, bpp, samples, pack_unpack_swap_bytes);
+				rsx::scale_image_nearest(pixels_dst, pixels_src, width, height, rsx_pitch, real_pitch, bpp, samples_u, samples_v, pack_unpack_swap_bytes);
 			}
 
 			dma_buffer->unmap();

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -465,7 +465,7 @@ namespace vk
 			tex.destroy();
 		}
 
-		vk::image_view* create_temporary_subresource_view_impl(vk::command_buffer& cmd, vk::image* source, VkImageType image_type, VkImageViewType view_type, u16 x, u16 y, u16 w, u16 h)
+		vk::image_view* create_temporary_subresource_view_impl(vk::command_buffer& cmd, vk::image* source, VkImageType image_type, VkImageViewType view_type, u32 gcm_format, u16 x, u16 y, u16 w, u16 h)
 		{
 			VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT;
 
@@ -480,6 +480,13 @@ namespace vk
 				break;
 			}
 
+			VkFormat dst_format = vk::get_compatible_sampler_format(gcm_format);
+			if (aspect & VK_IMAGE_ASPECT_DEPTH_BIT ||
+				vk::get_format_texel_width(dst_format) != vk::get_format_texel_width(source->info.format))
+			{
+				dst_format = source->info.format;
+			}
+
 			VkImageSubresourceRange subresource_range = { aspect, 0, 1, 0, 1 };
 
 			std::unique_ptr<vk::image> image;
@@ -487,12 +494,12 @@ namespace vk
 
 			image.reset(new vk::image(*vk::get_current_renderer(), m_memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 				image_type,
-				source->info.format,
+				dst_format,
 				w, h, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, source->info.flags));
 
 			VkImageSubresourceRange view_range = { aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 1, 0, 1 };
-			view.reset(new vk::image_view(*vk::get_current_renderer(), image->value, view_type, source->info.format, source->native_component_map, view_range));
+			view.reset(new vk::image_view(*vk::get_current_renderer(), image->value, view_type, dst_format, source->native_component_map, view_range));
 
 			VkImageLayout old_src_layout = source->current_layout;
 
@@ -518,9 +525,9 @@ namespace vk
 			return m_discardable_storage.back().view.get();
 		}
 
-		vk::image_view* create_temporary_subresource_view(vk::command_buffer& cmd, vk::image* source, u32 /*gcm_format*/, u16 x, u16 y, u16 w, u16 h) override
+		vk::image_view* create_temporary_subresource_view(vk::command_buffer& cmd, vk::image* source, u32 gcm_format, u16 x, u16 y, u16 w, u16 h) override
 		{
-			return create_temporary_subresource_view_impl(cmd, source, source->info.imageType, VK_IMAGE_VIEW_TYPE_2D, x, y, w, h);
+			return create_temporary_subresource_view_impl(cmd, source, source->info.imageType, VK_IMAGE_VIEW_TYPE_2D, gcm_format, x, y, w, h);
 		}
 
 		vk::image_view* create_temporary_subresource_view(vk::command_buffer& cmd, vk::image** source, u32 gcm_format, u16 x, u16 y, u16 w, u16 h) override

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3196,6 +3196,11 @@ struct registers_decoder<NV4097_SET_COLOR_MASK>
 		{
 			return bool(m_data.color_a);
 		}
+
+		bool color_write_enabled() const
+		{
+			return m_data.raw_data != 0;
+		}
 	};
 
 	static std::string dump(decoded_type &&decoded_values)

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -471,6 +471,12 @@ namespace rsx
 			rsx->m_rtts_dirty = true;
 		}
 
+		void set_surface_options_dirty_bit(thread* rsx, u32, u32)
+		{
+			if (rsx->m_framebuffer_state_contested)
+				rsx->m_rtts_dirty = true;
+		}
+
 		template<u32 index>
 		struct set_texture_dirty_bit
 		{
@@ -1598,6 +1604,9 @@ namespace rsx
 		bind<NV4097_SET_ZCULL_STATS_ENABLE, nv4097::set_zcull_stats_enable>();
 		bind<NV4097_SET_ZPASS_PIXEL_COUNT_ENABLE, nv4097::set_zcull_pixel_count_enable>();
 		bind<NV4097_CLEAR_ZCULL_SURFACE, nv4097::clear_zcull>();
+		bind<NV4097_SET_DEPTH_TEST_ENABLE, nv4097::set_surface_options_dirty_bit>();
+		bind<NV4097_SET_DEPTH_MASK, nv4097::set_surface_options_dirty_bit>();
+		bind<NV4097_SET_COLOR_MASK, nv4097::set_surface_options_dirty_bit>();
 
 		//NV308A
 		bind_range<NV308A_COLOR, 1, 256, nv308a::color>();

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -50,7 +50,7 @@ namespace rsx
 	template<> struct vertex_data_type_from_element_type<float> { static const vertex_base_type type = vertex_base_type::f; };
 	template<> struct vertex_data_type_from_element_type<f16> { static const vertex_base_type type = vertex_base_type::sf; };
 	template<> struct vertex_data_type_from_element_type<u8> { static const vertex_base_type type = vertex_base_type::ub; };
-	template<> struct vertex_data_type_from_element_type<u16> { static const vertex_base_type type = vertex_base_type::s1; };
+	template<> struct vertex_data_type_from_element_type<u16> { static const vertex_base_type type = vertex_base_type::s32k; };
 
 	namespace nv406e
 	{
@@ -203,7 +203,8 @@ namespace rsx
 		{
 			static void impl(thread* rsx, u32 _reg, u32 arg)
 			{
-				set_vertex_data_impl<NV4097_SET_VERTEX_DATA3F_M, index, 3, f32>(rsx, arg);
+				//NOTE: attributes are 16-byte aligned (Rachet & Clank 2)
+				set_vertex_data_impl<NV4097_SET_VERTEX_DATA3F_M, index, 4, f32>(rsx, arg);
 			}
 		};
 
@@ -1527,7 +1528,7 @@ namespace rsx
 		bind_array<NV4097_SET_TEX_COORD_CONTROL, 1, 10, nullptr>();
 		bind_array<NV4097_SET_TRANSFORM_PROGRAM, 1, 32, nullptr>();
 		bind_array<NV4097_SET_POLYGON_STIPPLE_PATTERN, 1, 32, nullptr>();
-		bind_array<NV4097_SET_VERTEX_DATA3F_M, 1, 48, nullptr>();
+		bind_array<NV4097_SET_VERTEX_DATA3F_M, 1, 64, nullptr>();
 		bind_array<NV4097_SET_VERTEX_DATA_ARRAY_OFFSET, 1, 16, nullptr>();
 		bind_array<NV4097_SET_VERTEX_DATA_ARRAY_FORMAT, 1, 16, nullptr>();
 		bind_array<NV4097_SET_TEXTURE_CONTROL3, 1, 16, nullptr>();
@@ -1560,7 +1561,7 @@ namespace rsx
 		bind_range<NV4097_SET_VERTEX_DATA4UB_M, 1, 16, nv4097::set_vertex_data4ub_m>();
 		bind_range<NV4097_SET_VERTEX_DATA1F_M, 1, 16, nv4097::set_vertex_data1f_m>();
 		bind_range<NV4097_SET_VERTEX_DATA2F_M, 1, 32, nv4097::set_vertex_data2f_m>();
-		bind_range<NV4097_SET_VERTEX_DATA3F_M, 1, 48, nv4097::set_vertex_data3f_m>();
+		bind_range<NV4097_SET_VERTEX_DATA3F_M, 1, 64, nv4097::set_vertex_data3f_m>();
 		bind_range<NV4097_SET_VERTEX_DATA4F_M, 1, 64, nv4097::set_vertex_data4f_m>();
 		bind_range<NV4097_SET_VERTEX_DATA2S_M, 1, 16, nv4097::set_vertex_data2s_m>();
 		bind_range<NV4097_SET_VERTEX_DATA4S_M, 1, 32, nv4097::set_vertex_data4s_m>();

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1581,6 +1581,11 @@ namespace rsx
 		bind<NV4097_SET_CONTEXT_DMA_COLOR_D, nv4097::set_surface_dirty_bit>();
 		bind<NV4097_SET_CONTEXT_DMA_ZETA, nv4097::set_surface_dirty_bit>();
 		bind<NV4097_SET_SURFACE_FORMAT, nv4097::set_surface_dirty_bit>();
+		bind<NV4097_SET_SURFACE_PITCH_A, nv4097::set_surface_dirty_bit>();
+		bind<NV4097_SET_SURFACE_PITCH_B, nv4097::set_surface_dirty_bit>();
+		bind<NV4097_SET_SURFACE_PITCH_C, nv4097::set_surface_dirty_bit>();
+		bind<NV4097_SET_SURFACE_PITCH_D, nv4097::set_surface_dirty_bit>();
+		bind<NV4097_SET_SURFACE_PITCH_Z, nv4097::set_surface_dirty_bit>();
 		bind_range<NV4097_SET_TEXTURE_OFFSET, 8, 16, nv4097::set_texture_dirty_bit>();
 		bind_range<NV4097_SET_TEXTURE_FORMAT, 8, 16, nv4097::set_texture_dirty_bit>();
 		bind_range<NV4097_SET_TEXTURE_ADDRESS, 8, 16, nv4097::set_texture_dirty_bit>();

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -345,6 +345,11 @@ namespace rsx
 			return decode<NV4097_SET_COLOR_MASK>().color_a();
 		}
 
+		bool color_write_enabled() const
+		{
+			return decode<NV4097_SET_COLOR_MASK>().color_write_enabled();
+		}
+
 		u8 clear_color_b() const
 		{
 			return decode<NV4097_SET_COLOR_CLEAR_VALUE>().blue();

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -143,7 +143,7 @@ namespace rsx
 		}
 	}
 
-	void scale_image_nearest(void* dst, const void* src, u16 src_width, u16 src_height, u16 dst_pitch, u16 src_pitch, u8 pixel_size, u8 samples, bool swap_bytes = false);
+	void scale_image_nearest(void* dst, const void* src, u16 src_width, u16 src_height, u16 dst_pitch, u16 src_pitch, u8 pixel_size, u8 samples_u, u8 samples_v, bool swap_bytes = false);
 
 	void convert_scale_image(u8 *dst, AVPixelFormat dst_format, int dst_width, int dst_height, int dst_pitch,
 		const u8 *src, AVPixelFormat src_format, int src_width, int src_height, int src_pitch, int src_slice_h, bool bilinear);

--- a/rpcs3/GLGSRender.vcxproj
+++ b/rpcs3/GLGSRender.vcxproj
@@ -63,6 +63,7 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">
     <ClCompile />
+    <ClCompile />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ProjectReference Include="emucore.vcxproj">
@@ -70,6 +71,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Emu\RSX\GL\GLOverlays.h" />
     <ClInclude Include="Emu\RSX\GL\GLTextOut.h" />
     <ClInclude Include="Emu\RSX\GL\GLCommonDecompiler.h" />
     <ClInclude Include="Emu\RSX\GL\GLFragmentProgram.h" />

--- a/rpcs3/GLGSRender.vcxproj.filters
+++ b/rpcs3/GLGSRender.vcxproj.filters
@@ -24,5 +24,6 @@
     <ClInclude Include="Emu\RSX\GL\GLTextureCache.h" />
     <ClInclude Include="Emu\RSX\GL\GLRenderTargets.h" />
     <ClInclude Include="Emu\RSX\GL\GLTextOut.h" />
+    <ClInclude Include="Emu\RSX\GL\GLOverlays.h" />
   </ItemGroup>
 </Project>

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -28,6 +28,7 @@
     <ClInclude Include="Emu\RSX\VK\VKFragmentProgram.h" />
     <ClInclude Include="Emu\RSX\VK\VKGSRender.h" />
     <ClInclude Include="Emu\RSX\VK\VKHelpers.h" />
+    <ClInclude Include="Emu\RSX\VK\VKOverlays.h" />
     <ClInclude Include="Emu\RSX\VK\VKProgramBuffer.h" />
     <ClInclude Include="Emu\RSX\VK\VKRenderTargets.h" />
     <ClInclude Include="Emu\RSX\VK\VKTextOut.h" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -40,6 +40,9 @@
     <ClInclude Include="Emu\RSX\VK\VKTextOut.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\VKOverlays.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Emu\RSX\VK\VKGSRender.cpp">


### PR DESCRIPTION
- Work on depth/color address resolve when address contention happens
- Vulkan zcull
- Shader overlay implementation allowing all kinds of transforms and passes
-- Implement binding color data for depth access for example using a RGBA->depth casting pass
- Fix precision modifier broken in last commit
- Fixed face winding on openGL
- Fragment program decompiler fixes for pack/unpack with optional register gathering implemented
- Several general texture cache fixes