### PR TITLE
Update Qt to 5.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
   - git submodule update --init asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng Utilities/yaml-cpp 3rdparty/cereal 3rdparty/hidapi 3rdparty/Optional Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
   - mkdir build
   - cd build
-  - export CMAKE_PREFIX_PATH=~/Qt/5.9.2/gcc_64/lib/cmake
+  - export CMAKE_PREFIX_PATH=~/Qt/5.9.3/gcc_64/lib/cmake
   - if [ "$TRAVIS_PULL_REQUEST" = false ]; then
       export CXXFLAGS="$CXXFLAGS -DBRANCH=$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH";
     else
@@ -64,20 +64,20 @@ before_script:
   - make -j 3
   - # AppImage generation
   - if [ -n "$UPLOAD_URL" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$CC" = "clang-4.0" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
-      export LD_LIBRARY_PATH=~/Qt/5.9.2/gcc_64/lib;
+      export LD_LIBRARY_PATH=~/Qt/5.9.3/gcc_64/lib;
       make DESTDIR=appdir install ; find appdir/ ;
       find ../bin ;
       wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" ; 
       chmod a+x linuxdeployqt*.AppImage ;
-      export PATH=~/Qt/5.9.2/gcc_64/bin/:${PATH} ;
+      export PATH=~/Qt/5.9.3/gcc_64/bin/:${PATH} ;
       ./linuxdeployqt*.AppImage --appimage-extract ;
       ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs ;
       mkdir ./appdir/usr/plugins/xcbglintegrations/ ; 
       mkdir ./appdir/usr/plugins/imageformats/ ;
-      cp ~/Qt/5.9.2/gcc_64/lib/libQt5Svg.so.5 ./appdir/usr/lib/ ;
-      cp ~/Qt/5.9.2/gcc_64/plugins/xcbglintegrations/* ./appdir/usr/plugins/xcbglintegrations/ ;
-      cp ~/Qt/5.9.2/gcc_64/plugins/imageformats/* ./appdir/usr/plugins/imageformats/ ;
-      cp ~/Qt/5.9.2/gcc_64/plugins/platforms/* ./appdir/usr/plugins/platforms/ ;
+      cp ~/Qt/5.9.3/gcc_64/lib/libQt5Svg.so.5 ./appdir/usr/lib/ ;
+      cp ~/Qt/5.9.3/gcc_64/plugins/xcbglintegrations/* ./appdir/usr/plugins/xcbglintegrations/ ;
+      cp ~/Qt/5.9.3/gcc_64/plugins/imageformats/* ./appdir/usr/plugins/imageformats/ ;
+      cp ~/Qt/5.9.3/gcc_64/plugins/platforms/* ./appdir/usr/plugins/platforms/ ;
       export PATH=${TRAVIS_BUILD_DIR}/build/squashfs-root/usr/bin/:${PATH} ;
       ./squashfs-root/usr/bin/appimagetool ${TRAVIS_BUILD_DIR}/build/appdir ;
       find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq ;
@@ -115,7 +115,7 @@ addons:
       - libstdc++-5-dev
       - lib32stdc++6
       - zlib1g-dev
-      # We need to install qt 5.9.2 manually because the version trusty provides is too old.
+      # We need to install qt 5.9.3 manually because the version trusty provides is too old.
       #- qtbase5-dev
       - libudev-dev
       - libevdev-dev

--- a/qt-installer-noninteractive.qs
+++ b/qt-installer-noninteractive.qs
@@ -32,7 +32,7 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
     widget.deselectAll();
-    widget.selectComponent("qt.592.gcc_64");
+    widget.selectComponent("qt.593.gcc_64");
 
     gui.clickButton(buttons.NextButton);
 }

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -27,8 +27,8 @@ if(NOT Qt5Widgets_FOUND)
 		if("${CMAKE_SYSTEM}" MATCHES "Linux")
 			message(FATAL_ERROR "Most distros do not provide an up-to-date version of Qt.
 If you're on Ubuntu or Linux Mint, there are PPAs you can use to install an up-to-date qt5 version.
-        https://launchpad.net/~beineri/+archive/ubuntu/opt-qt592-xenial
-        https://launchpad.net/~beineri/+archive/ubuntu/opt-qt592-trusty
+        https://launchpad.net/~beineri/+archive/ubuntu/opt-qt593-xenial
+        https://launchpad.net/~beineri/+archive/ubuntu/opt-qt593-trusty
 just make sure to run
     source /opt/qt59/bin/qt59-env.sh
 before re-running cmake")


### PR DESCRIPTION
- Travis will now use Qt 5.9.3 when building
- AppVeyor will switch automatically on this release when available on their servers
- Update CMake comment to recommend the Qt 5.9.3 PPA 

For more information about Qt 5.9.3: https://blog.qt.io/blog/2017/11/22/qt-5-9-3-released/
