### PR TITLE
rsx: image_in swizzle crash fix

### DIFF
--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -837,21 +837,25 @@ namespace rsx
 				u8* linear_pixels = pixels_src;
 				u8* swizzled_pixels = temp2.get();
 
+				// restrict output to size of swizzle
+				const u16 sw_in_w = std::min(out_w, sw_width);
+				const u16 sw_in_h = std::min(out_h, sw_height);
+
 				// Check and pad texture out if we are given non square texture for swizzle to be correct
-				if (sw_width != out_w || sw_height != out_h)
+				if (sw_width != sw_in_w || sw_height != sw_in_h)
 				{
 					sw_temp.reset(new u8[out_bpp * sw_width * sw_height]);
 
 					switch (out_bpp)
 					{
 					case 1:
-						pad_texture<u8>(linear_pixels, sw_temp.get(), out_w, out_h, sw_width, sw_height);
+						pad_texture<u8>(linear_pixels, sw_temp.get(), sw_in_w, sw_in_h, sw_width, sw_height);
 						break;
 					case 2:
-						pad_texture<u16>(linear_pixels, sw_temp.get(), out_w, out_h, sw_width, sw_height);
+						pad_texture<u16>(linear_pixels, sw_temp.get(), sw_in_w, sw_in_h, sw_width, sw_height);
 						break;
 					case 4:
-						pad_texture<u32>(linear_pixels, sw_temp.get(), out_w, out_h, sw_width, sw_height);
+						pad_texture<u32>(linear_pixels, sw_temp.get(), sw_in_w, sw_in_h, sw_width, sw_height);
 						break;
 					}
 

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -670,8 +670,8 @@ int ds4_pad_handler::SendVibrateData(const std::shared_ptr<DS4Device>& device)
 		// alternating blink states with values 0-255: only setting both to zero disables blinking
 		// 255 is roughly 2 seconds, so setting both values to 255 results in a 4 second interval
 		// using something like (0,10) will heavily blink, while using (0, 255) will be slow. you catch the drift
-		outputBuf[9] = device->led_delay_on;
-		outputBuf[10] = device->led_delay_off;
+		outputBuf[11] = device->led_delay_on;
+		outputBuf[12] = device->led_delay_off;
 
 		const u8 btHdr = 0xA2;
 		const u32 crcHdr = CRCPP::CRC::Calculate(&btHdr, 1, crcTable);


### PR DESCRIPTION
- Fixes potential crash in image_in when using cpu blit, or when unable to gpu scale the texture, found in #3905 
  Also fixes phantom breaker: extra

- Also fixes led for ds4 when connected by bluetooth

