### PR TITLE
Misc: Version adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ matrix:
 
 git:
   submodules: false
+  # Unshallow clone to obtain proper GIT_VERSION 
+  # There's no variable to disable depth, so we just have to set it to a huge number
+  # https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+  depth: 100000
 
 before_install:
   - if [ "$CC" = "clang" ]; then

--- a/Utilities/git-version-gen.cmd
+++ b/Utilities/git-version-gen.cmd
@@ -13,7 +13,7 @@ rem // A copy of the GPL 2.0 should have been included with the program.
 rem // If not, see http://www.gnu.org/licenses/
 
 rem // Official git repository and contact information can be found at
-rem // https://github.com/RPCS3/rpcs3 and http://rpcs3.net/.
+rem // https://github.com/RPCS3/rpcs3 and https://rpcs3.net/.
 
 setlocal ENABLEDELAYEDEXPANSION
 setlocal ENABLEEXTENSIONS
@@ -55,32 +55,29 @@ if errorlevel 1 (
 	goto done
 )
 
-rem // Get commit count from HEAD by default
-for /F %%I IN ('call %GIT% rev-list HEAD --count') do set GIT_VERSION=%%I
-
-rem // If we're in AppVeyor and we're building for master: Get commit count from unshallowed upstream
-if defined APPVEYOR (
-	if not defined APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH (
-		call %GIT% remote add upstream https://github.com/RPCS3/RPCS3.git
-		call %GIT% fetch --unshallow upstream
-		for /F %%I IN ('call %GIT% rev-list --count upstream/master') do set GIT_VERSION=%%I
-	)
-)
-
+rem // If we're in AppVeyor, building a non-master, pull request artifact
 if defined APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH (
+
 	if "%APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%"=="master" (
+		rem // If pull request comes from a master branch, GIT_BRANCH = username/branch in order to distinguish from upstream/master
 		for /f "tokens=1* delims=/" %%a in ("%APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME%") do set user=%%a
 		set "GIT_BRANCH=!user!/%APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%"
 	) else (
+		rem // Otherwise, GIT_BRANCH=branch
 		set GIT_BRANCH=%APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%
 	)
 	
+	rem // Make GIT_VERSION the last commit (shortened); Don't include commit count on non-master builds
+	for /F %%I IN ('call %GIT% rev-parse --short HEAD') do set GIT_VERSION=%%I
+	
 ) else (
+	rem // Get commit count from (unshallowed) HEAD
+	for /F %%I IN ('call %GIT% rev-list HEAD --count') do set GIT_VERSION=%%I
+	rem // Get last commit (shortened) and concat after commit count in GIT_VERSION
+	for /F %%I IN ('call %GIT% rev-parse --short HEAD') do set GIT_VERSION=%GIT_VERSION%-%%I
+	
 	for /F %%I IN ('call %GIT% rev-parse --abbrev-ref HEAD') do set GIT_BRANCH=%%I
 )
-
-rem // Get last commit (shortened) and concat after commit count in GIT_VERSION
-for /F %%I IN ('call %GIT% rev-parse --short HEAD') do set GIT_VERSION=%GIT_VERSION%-%%I
 
 rem // Echo obtained GIT_VERSION for debug purposes if needed
 echo %GIT_VERSION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,6 @@ image: Visual Studio 2015
 # clone directory
 clone_folder: c:\projects\rpcs3
 
-# set clone depth
-clone_depth: 3                    # clone entire repository history if not defined
-
 # environment variables
 environment:
   QTDIR: C:\Qt\5.9\msvc2015_64

--- a/rpcs3/git-version.cmake
+++ b/rpcs3/git-version.cmake
@@ -19,18 +19,20 @@ if(GIT_FOUND AND EXISTS "${SOURCE_DIR}/../.git/")
 	if(NOT ${exit_code} EQUAL 0)
 		message(WARNING "git rev-parse failed, unable to include version.")
 	endif()
-        # Hack fix for AppVeyor (Pull Requests don't generate a branch name)
-        if(NOT DEFINED ENV{APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH})
-		execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-		  WORKING_DIRECTORY ${SOURCE_DIR}
-		  RESULT_VARIABLE exit_code
-		  OUTPUT_VARIABLE GIT_BRANCH)
-		if(NOT ${exit_code} EQUAL 0)
-			message(WARNING "git rev-parse failed, unable to include git branch.")
-		endif()
-	else()
-		set(GIT_BRANCH $ENV{APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH})
-	endif()
+	# (Unused code, we're currently building with MSVC on AppVeyor)
+	# Hack fix for AppVeyor (Pull Requests don't generate a branch name)
+	#
+	# if(NOT DEFINED ENV{APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH})
+	#	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+	#		WORKING_DIRECTORY ${SOURCE_DIR}
+	#		RESULT_VARIABLE exit_code
+	#		OUTPUT_VARIABLE GIT_BRANCH)
+	#	if(NOT ${exit_code} EQUAL 0)
+	#		message(WARNING "git rev-parse failed, unable to include git branch.")
+	#	endif()
+	# else()
+	#	set(GIT_BRANCH $ENV{APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH})
+	# endif()
 	string(STRIP ${GIT_VERSION} GIT_VERSION)
 	string(STRIP ${GIT_VERSION_} GIT_VERSION_)
 	string(STRIP ${GIT_VERSION}-${GIT_VERSION_} GIT_VERSION)


### PR DESCRIPTION
Addendum to #3728 

- Removes GIT_VERSION's incorrect commit count on non-master Pull Request builds - make GIT_VERSION only be the Commit ID in those cases (e.g: 0.0.4-abcdefgh instead of 0.0.4-3-abcdefgh)
![image](https://user-images.githubusercontent.com/10283761/33788328-7706c498-dc69-11e7-9552-c7a571a1c3c8.png)


- Unshallows AppVeyor (current depth: 3) and TravisCI clones (current depth: 50) in order to obtain proper GIT_VERSION
» Replaces previous approach of fetching upstream and obtaining its commit count on AppVeyor builds
» Fixes commit count on AppImage (TravisCI) builds

- Comment out unused unreachable code (AppVeyor) in git-version.cmake, as we build with MSVC on AppVeyor instead of CMake currently

**TravisCI clone time comparison** 
Before: ~2s  (w/ depth=50)
After: ~5.5s  (w/o depth)
