### PR TITLE
Hotfix #3919

### DIFF
--- a/Utilities/git-version-gen.cmd
+++ b/Utilities/git-version-gen.cmd
@@ -55,6 +55,9 @@ if errorlevel 1 (
 	goto done
 )
 
+rem // Get commit count from (unshallowed) HEAD
+for /F %%I IN ('call %GIT% rev-list HEAD --count') do set COMMIT_COUNT=%%I
+
 rem // If we're in AppVeyor, building a non-master, pull request artifact
 if defined APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH (
 
@@ -71,10 +74,8 @@ if defined APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH (
 	for /F %%I IN ('call %GIT% rev-parse --short HEAD') do set GIT_VERSION=%%I
 	
 ) else (
-	rem // Get commit count from (unshallowed) HEAD
-	for /F %%I IN ('call %GIT% rev-list HEAD --count') do set GIT_VERSION=%%I
 	rem // Get last commit (shortened) and concat after commit count in GIT_VERSION
-	for /F %%I IN ('call %GIT% rev-parse --short HEAD') do set GIT_VERSION=%GIT_VERSION%-%%I
+	for /F %%I IN ('call %GIT% rev-parse --short HEAD') do set GIT_VERSION=%COMMIT_COUNT%-%%I
 	
 	for /F %%I IN ('call %GIT% rev-parse --abbrev-ref HEAD') do set GIT_BRANCH=%%I
 )

--- a/rpcs3/git-version.cmake
+++ b/rpcs3/git-version.cmake
@@ -19,20 +19,13 @@ if(GIT_FOUND AND EXISTS "${SOURCE_DIR}/../.git/")
 	if(NOT ${exit_code} EQUAL 0)
 		message(WARNING "git rev-parse failed, unable to include version.")
 	endif()
-	# (Unused code, we're currently building with MSVC on AppVeyor)
-	# Hack fix for AppVeyor (Pull Requests don't generate a branch name)
-	#
-	# if(NOT DEFINED ENV{APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH})
-	#	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-	#		WORKING_DIRECTORY ${SOURCE_DIR}
-	#		RESULT_VARIABLE exit_code
-	#		OUTPUT_VARIABLE GIT_BRANCH)
-	#	if(NOT ${exit_code} EQUAL 0)
-	#		message(WARNING "git rev-parse failed, unable to include git branch.")
-	#	endif()
-	# else()
-	#	set(GIT_BRANCH $ENV{APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH})
-	# endif()
+	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+		WORKING_DIRECTORY ${SOURCE_DIR}
+		RESULT_VARIABLE exit_code
+		OUTPUT_VARIABLE GIT_BRANCH)
+	if(NOT ${exit_code} EQUAL 0)
+		message(WARNING "git rev-parse failed, unable to include git branch.")
+	endif()
 	string(STRIP ${GIT_VERSION} GIT_VERSION)
 	string(STRIP ${GIT_VERSION_} GIT_VERSION_)
 	string(STRIP ${GIT_VERSION}-${GIT_VERSION_} GIT_VERSION)


### PR DESCRIPTION
- Restore GIT_BRANCH removed by mistake from git-version.cmake (for AppImage builds)
- Fix commit count on Windows builds