### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -240,9 +240,11 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 	switch (package_id)
 	{
 	case 0x001: // FIFO
+		render->pause();
 		render->ctrl->get = a3;
 		render->ctrl->put = a4;
 		render->internal_get = a3;
+		render->unpause();
 		break;
 
 	case 0x100: // Display mode set

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -598,7 +598,7 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 	case RSX_FP_OPCODE_TEXBEM:
 		//Untested, should be x2d followed by TEX
 		AddX2d();
-		AddCode(Format("x2d = $0.xyxy + $1.xxxx * $2.xzxz + $1.yyyy * $2.ywyw", true));
+		AddCode(Format("x2d = $0.xyxy + $1.xxxx * $2.xzxz + $1.yyyy * $2.ywyw;", true));
 	case RSX_FP_OPCODE_TEX:
 		switch (m_prog.get_texture_dimension(dst.tex_num))
 		{
@@ -629,7 +629,7 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 	case RSX_FP_OPCODE_TXPBEM:
 		//Untested, should be x2d followed by TXP
 		AddX2d();
-		AddCode(Format("x2d = $0.xyxy + $1.xxxx * $2.xzxz + $1.yyyy * $2.ywyw", true));
+		AddCode(Format("x2d = $0.xyxy + $1.xxxx * $2.xzxz + $1.yyyy * $2.ywyw;", true));
 	case RSX_FP_OPCODE_TXP:
 		switch (m_prog.get_texture_dimension(dst.tex_num))
 		{

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -694,7 +694,7 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 	//Unpack operations. See https://www.khronos.org/registry/OpenGL/extensions/NV/NV_fragment_program.txt
 	case RSX_FP_OPCODE_UP2: SetDst("unpackHalf2x16(floatBitsToUint($0.x)).xyxy"); return true;
 	case RSX_FP_OPCODE_UP4: SetDst("unpackSnorm4x8(floatBitsToUint($0.x))"); return true;
-	case RSX_FP_OPCODE_UP16: SetDst("unpackSnormx16(floatBitsToUint($0.x)).xyxy"); return true;
+	case RSX_FP_OPCODE_UP16: SetDst("unpackSnorm2x16(floatBitsToUint($0.x)).xyxy"); return true;
 	case RSX_FP_OPCODE_UPG:
 	//Same as UPB with gamma correction
 	case RSX_FP_OPCODE_UPB: SetDst("(unpackUnorm4x8(floatBitsToUint($0.x)))"); return true;

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -263,7 +263,10 @@ std::string FragmentProgramDecompiler::Format(const std::string& code, bool igno
 	if (!ignore_redirects)
 	{
 		//Special processing redirects
-		if (dst.opcode == RSX_FP_OPCODE_TEXBEM)
+		switch (dst.opcode)
+		{
+		case RSX_FP_OPCODE_TEXBEM:
+		case RSX_FP_OPCODE_TXPBEM:
 		{
 			//Redirect parameter 0 to the x2d temp register for TEXBEM
 			//TODO: Organize this a little better
@@ -271,6 +274,7 @@ std::string FragmentProgramDecompiler::Format(const std::string& code, bool igno
 			std::string result = fmt::replace_all(code, repl);
 
 			return fmt::replace_all(code, repl_list);
+		}
 		}
 	}
 
@@ -623,8 +627,9 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 		}
 		return false;
 	case RSX_FP_OPCODE_TXPBEM:
-		//Treat as TXP for now
-		LOG_ERROR(RSX, "Unimplemented TEX_SRB instruction: TXPBEM");
+		//Untested, should be x2d followed by TXP
+		AddX2d();
+		AddCode(Format("x2d = $0.xyxy + $1.xxxx * $2.xzxz + $1.yyyy * $2.ywyw", true));
 	case RSX_FP_OPCODE_TXP:
 		switch (m_prog.get_texture_dimension(dst.tex_num))
 		{

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -538,7 +538,7 @@ bool FragmentProgramDecompiler::handle_scb(u32 opcode)
 	case RSX_FP_OPCODE_LIT: SetDst("lit_legacy($0)"); return true;
 	case RSX_FP_OPCODE_LIF: SetDst(getFloatTypeName(4) + "(1.0, $0.y, ($0.y > 0 ? pow(2.0, $0.w) : 0.0), 1.0)"); return true;
 	case RSX_FP_OPCODE_LRP: SetDst(getFloatTypeName(4) + "($2 * (1 - $0) + $1 * $0)"); return true;
-	case RSX_FP_OPCODE_LG2: SetDst("log2($0.xxxx)"); return true;
+	case RSX_FP_OPCODE_LG2: SetDst("log2(" + NotZeroPositive("$0.x") + ").xxxx"); return true;
 	case RSX_FP_OPCODE_MAD: SetDst("($0 * $1 + $2)"); return true;
 	case RSX_FP_OPCODE_MAX: SetDst("max($0, $1)"); return true;
 	case RSX_FP_OPCODE_MIN: SetDst("min($0, $1)"); return true;
@@ -571,7 +571,7 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 	case RSX_FP_OPCODE_DDX: SetDst(getFunction(FUNCTION::FUNCTION_DFDX)); return true;
 	case RSX_FP_OPCODE_DDY: SetDst(getFunction(FUNCTION::FUNCTION_DFDY)); return true;
 	case RSX_FP_OPCODE_NRM: SetDst("normalize($0.xyz)"); return true;
-	case RSX_FP_OPCODE_BEM: LOG_ERROR(RSX, "Unimplemented TEX_SRB instruction: BEM"); return true;
+	case RSX_FP_OPCODE_BEM: SetDst("$0.xyxy + $1.xxxx * $2.xzxz + $1.yyyy * $2.ywyw"); return true;
 	case RSX_FP_OPCODE_TEXBEM:
 		//treat as TEX for now
 		LOG_ERROR(RSX, "Unimplemented TEX_SRB instruction: TEXBEM");

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -273,7 +273,7 @@ std::string FragmentProgramDecompiler::Format(const std::string& code, bool igno
 			std::pair<std::string, std::string> repl[] = { { "$0", "x2d" } };
 			std::string result = fmt::replace_all(code, repl);
 
-			return fmt::replace_all(code, repl_list);
+			return fmt::replace_all(result, repl_list);
 		}
 		}
 	}

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
@@ -126,10 +126,13 @@ class FragmentProgramDecompiler
 	std::string AddConst();
 	std::string AddTex();
 	void AddFlowOp(std::string code);
-	std::string Format(const std::string& code);
+	std::string Format(const std::string& code, bool ignore_redirects = false);
 
 	//Technically a temporary workaround until we know what type3 is
 	std::string AddType3();
+
+	//Support the transform-2d temp result for use with TEXBEM
+	std::string AddX2d();
 
 	//Prevent division by zero by catching denormals
 	//Simpler variant where input and output are expected to be positive

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -5,6 +5,27 @@
 #include <vector>
 #include "Utilities/GSL.h"
 
+namespace rsx
+{
+	enum texture_upload_context
+	{
+		shader_read = 0,
+		blit_engine_src = 1,
+		blit_engine_dst = 2,
+		framebuffer_storage = 3
+	};
+
+	//Sampled image descriptor
+	struct sampled_image_descriptor_base
+	{
+		texture_upload_context upload_context = texture_upload_context::shader_read;
+		rsx::texture_dimension_extended image_type = texture_dimension_extended::texture_dimension_2d;
+		bool is_depth_texture = false;
+		f32 scale_x = 1.f;
+		f32 scale_y = 1.f;
+	};
+}
+
 struct rsx_subresource_layout
 {
 	gsl::span<const gsl::byte> data;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1297,7 +1297,7 @@ namespace rsx
 		sampled_image_descriptor upload_texture(commandbuffer_type& cmd, RsxTextureType& tex, surface_store_type& m_rtts, Args&&... extras)
 		{
 			const u32 texaddr = rsx::get_address(tex.offset(), tex.location());
-			const u32 tex_size = (u32)get_texture_size(tex);
+			const u32 tex_size = (u32)get_placed_texture_storage_size(tex, 1, 256);
 			const u32 format = tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 			const bool is_compressed_format = (format == CELL_GCM_TEXTURE_COMPRESSED_DXT1 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT23 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT45);
 
@@ -1361,7 +1361,7 @@ namespace rsx
 				}
 			}
 
-			tex_pitch = is_compressed_format? (tex_size / tex_height) : tex_pitch; //NOTE: Compressed textures dont have a real pitch (tex_size = (w*h)/6)
+			tex_pitch = is_compressed_format? (u16)(get_texture_size(tex) / tex_height) : tex_pitch; //NOTE: Compressed textures dont have a real pitch (tex_size = (w*h)/6)
 			if (tex_pitch == 0) tex_pitch = tex_width * get_format_block_size_in_bytes(format);
 
 			const bool unnormalized = (tex.format() & CELL_GCM_TEXTURE_UN) != 0;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -302,11 +302,11 @@ namespace rsx
 		virtual image_view_type create_temporary_subresource_view(commandbuffer_type&, image_resource_type* src, u32 gcm_format, u16 x, u16 y, u16 w, u16 h) = 0;
 		virtual image_view_type create_temporary_subresource_view(commandbuffer_type&, image_storage_type* src, u32 gcm_format, u16 x, u16 y, u16 w, u16 h) = 0;
 		virtual section_storage_type* create_new_texture(commandbuffer_type&, u32 rsx_address, u32 rsx_size, u16 width, u16 height, u16 depth, u16 mipmaps, const u32 gcm_format,
-				const rsx::texture_upload_context context, const rsx::texture_dimension_extended type, const texture_create_flags flags, std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) = 0;
+				const rsx::texture_upload_context context, const rsx::texture_dimension_extended type, const texture_create_flags flags, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) = 0;
 		virtual section_storage_type* upload_image_from_cpu(commandbuffer_type&, u32 rsx_address, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, const u32 gcm_format, const texture_upload_context context,
-				std::vector<rsx_subresource_layout>& subresource_layout, const rsx::texture_dimension_extended type, const bool swizzled, std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) = 0;
+				std::vector<rsx_subresource_layout>& subresource_layout, const rsx::texture_dimension_extended type, const bool swizzled, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) = 0;
 		virtual void enforce_surface_creation_type(section_storage_type& section, const u32 gcm_format, const texture_create_flags expected) = 0;
-		virtual void set_up_remap_vector(section_storage_type& section, std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) = 0;
+		virtual void set_up_remap_vector(section_storage_type& section, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) = 0;
 		virtual void insert_texture_barrier() = 0;
 		virtual image_view_type generate_cubemap_from_images(commandbuffer_type&, const u32 gcm_format, u16 size, std::array<image_resource_type, 6>& sources) = 0;
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1297,7 +1297,7 @@ namespace rsx
 		sampled_image_descriptor upload_texture(commandbuffer_type& cmd, RsxTextureType& tex, surface_store_type& m_rtts, Args&&... extras)
 		{
 			const u32 texaddr = rsx::get_address(tex.offset(), tex.location());
-			const u32 tex_size = (u32)get_placed_texture_storage_size(tex, 1, 256);
+			const u32 tex_size = (u32)get_placed_texture_storage_size(tex, 256, 512);
 			const u32 format = tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 			const bool is_compressed_format = (format == CELL_GCM_TEXTURE_COMPRESSED_DXT1 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT23 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT45);
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -17,28 +17,10 @@ namespace rsx
 		swapped_native_component_order = 2,
 	};
 
-	enum texture_upload_context
-	{
-		shader_read = 0,
-		blit_engine_src = 1,
-		blit_engine_dst = 2,
-		framebuffer_storage = 3
-	};
-
 	enum texture_sampler_status
 	{
 		status_uninitialized = 0,
 		status_ready = 1
-	};
-
-	//Sampled image descriptor
-	struct sampled_image_descriptor_base
-	{
-		texture_upload_context upload_context = texture_upload_context::shader_read;
-		rsx::texture_dimension_extended image_type = texture_dimension_extended::texture_dimension_2d;
-		bool is_depth_texture = false;
-		f32 scale_x = 1.f;
-		f32 scale_y = 1.f;
 	};
 
 	struct cached_texture_section : public rsx::buffered_section

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1844,7 +1844,10 @@ namespace rsx
 			if (cached_dest)
 			{
 				//Prep surface
-				auto channel_order = src_is_render_target ? rsx::texture_create_flags::native_component_order : rsx::texture_create_flags::default_component_order;
+				auto channel_order = src_is_render_target ? rsx::texture_create_flags::native_component_order :
+					dst_is_argb8 ? rsx::texture_create_flags::default_component_order :
+					rsx::texture_create_flags::swapped_native_component_order;
+
 				enforce_surface_creation_type(*cached_dest, gcm_format, channel_order);
 			}
 
@@ -1871,7 +1874,7 @@ namespace rsx
 				dest_texture = create_new_texture(cmd, dst.rsx_address, dst.pitch * dst_dimensions.height,
 					dst_dimensions.width, dst_dimensions.height, 1, 1,
 					gcm_format, rsx::texture_upload_context::blit_engine_dst, rsx::texture_dimension_extended::texture_dimension_2d,
-					rsx::texture_create_flags::default_component_order,
+					dst_is_argb8? rsx::texture_create_flags::default_component_order : rsx::texture_create_flags::swapped_native_component_order,
 					default_remap_vector)->get_raw_texture();
 
 				m_texture_memory_in_use += dst.pitch * dst_dimensions.height;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -252,7 +252,7 @@ void GLGSRender::end()
 					*sampler_state = m_gl_texture_cache.upload_texture(unused, rsx::method_registers.fragment_textures[i], m_rtts);
 
 					if (m_textures_dirty[i])
-						m_gl_sampler_states[i].apply(rsx::method_registers.fragment_textures[i]);
+						m_gl_sampler_states[i].apply(rsx::method_registers.fragment_textures[i], fs_sampler_state[i].get());
 				}
 				else
 				{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1000,6 +1000,7 @@ void GLGSRender::load_program(u32 vertex_base, u32 vertex_count)
 	fill_user_clip_data(buf + 64);
 	*(reinterpret_cast<u32*>(buf + 128)) = rsx::method_registers.transform_branch_bits();
 	*(reinterpret_cast<u32*>(buf + 132)) = vertex_base;
+	*(reinterpret_cast<f32*>(buf + 136)) = rsx::method_registers.point_size();
 	fill_vertex_layout_state(m_vertex_layout, vertex_count, reinterpret_cast<s32*>(buf + 144));
 
 	if (m_transform_constants_dirty)

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -133,7 +133,7 @@ namespace gl
 	}
 
 	//Apply sampler state settings
-	void sampler_state::apply(rsx::fragment_texture& tex)
+	void sampler_state::apply(rsx::fragment_texture& tex, const rsx::sampled_image_descriptor_base* sampled_image)
 	{
 		const f32 border_color = (f32)tex.border_color() / 255;
 		const f32 border_color_array[] = { border_color, border_color, border_color, border_color };
@@ -143,7 +143,8 @@ namespace gl
 		glSamplerParameteri(samplerHandle, GL_TEXTURE_WRAP_R, wrap_mode(tex.wrap_r()));
 		glSamplerParameterfv(samplerHandle, GL_TEXTURE_BORDER_COLOR, border_color_array);
 
-		if (tex.get_exact_mipmap_count() <= 1)
+		if (sampled_image->upload_context != rsx::texture_upload_context::shader_read ||
+			tex.get_exact_mipmap_count() <= 1)
 		{
 			GLint min_filter = tex_min_filter(tex.min_filter());
 

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -478,7 +478,7 @@ namespace gl
 	}
 
 	void upload_texture(const GLuint id, const u32 texaddr, const u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, bool is_swizzled, rsx::texture_dimension_extended type,
-			std::vector<rsx_subresource_layout>& subresources_layout, std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap, bool static_state)
+			std::vector<rsx_subresource_layout>& subresources_layout, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap, bool static_state)
 	{
 		const bool is_cubemap = type == rsx::texture_dimension_extended::texture_dimension_cubemap;
 		

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -27,7 +27,7 @@ namespace gl
 	 * static_state - set up the texture without consideration for sampler state (useful for vertex textures which have no real sampler state on RSX)
 	 */
 	void upload_texture(const GLuint id, const u32 texaddr, const u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, bool is_swizzled, rsx::texture_dimension_extended type,
-		std::vector<rsx_subresource_layout>& subresources_layout, std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap, bool static_state);
+		std::vector<rsx_subresource_layout>& subresources_layout, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap, bool static_state);
 
 	void apply_swizzle_remap(const GLenum target, const std::array<GLenum, 4>& swizzle_remap, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap);
 

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -28,6 +28,8 @@ namespace gl
 	void upload_texture(const GLuint id, const u32 texaddr, const u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, bool is_swizzled, rsx::texture_dimension_extended type,
 		std::vector<rsx_subresource_layout>& subresources_layout, std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap, bool static_state);
 
+	void apply_swizzle_remap(const GLenum target, const std::array<GLenum, 4>& swizzle_remap, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap);
+
 	class sampler_state
 	{
 		GLuint samplerHandle = 0;

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -52,6 +52,6 @@ namespace gl
 			glBindSampler(index, samplerHandle);
 		}
 
-		void apply(rsx::fragment_texture& tex);
+		void apply(rsx::fragment_texture& tex, const rsx::sampled_image_descriptor_base* sampled_image);
 	};
 }

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -14,6 +14,7 @@ namespace gl
 	std::tuple<GLenum, GLenum> get_format_type(u32 texture_format);
 	GLenum wrap_mode(rsx::texture_wrap_mode wrap);
 	float max_aniso(rsx::texture_max_anisotropy aniso);
+	std::array<GLenum, 4> get_swizzle_remap(u32 texture_format);
 
 	GLuint create_texture(u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, rsx::texture_dimension_extended type);
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -763,7 +763,7 @@ namespace gl
 
 		cached_texture_section* create_new_texture(void*&, u32 rsx_address, u32 rsx_size, u16 width, u16 height, u16 depth, u16 mipmaps, const u32 gcm_format,
 				const rsx::texture_upload_context context, const rsx::texture_dimension_extended type, const rsx::texture_create_flags flags,
-				std::pair<std::array<u8, 4>, std::array<u8, 4>>& /*remap_vector*/) override
+				const std::pair<std::array<u8, 4>, std::array<u8, 4>>& /*remap_vector*/) override
 		{
 			u32 vram_texture = gl::create_texture(gcm_format, width, height, depth, mipmaps, type);
 			bool depth_flag = false;
@@ -799,7 +799,7 @@ namespace gl
 
 		cached_texture_section* upload_image_from_cpu(void*&, u32 rsx_address, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, const u32 gcm_format,
 			const rsx::texture_upload_context context, std::vector<rsx_subresource_layout>& subresource_layout, const rsx::texture_dimension_extended type, const bool swizzled,
-			std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
+			const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
 		{
 			void* unused = nullptr;
 			auto section = create_new_texture(unused, rsx_address, pitch * height, width, height, depth, mipmaps, gcm_format, context, type,
@@ -834,7 +834,7 @@ namespace gl
 			section.set_sampler_status(rsx::texture_sampler_status::status_uninitialized);
 		}
 
-		void set_up_remap_vector(cached_texture_section& section, std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
+		void set_up_remap_vector(cached_texture_section& section, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
 		{
 			std::array<GLenum, 4> swizzle_remap;
 			glBindTexture(GL_TEXTURE_2D, section.get_raw_texture());

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -38,6 +38,7 @@ void GLVertexDecompilerThread::insertHeader(std::stringstream &OS)
 	OS << "	vec4 user_clip_factor[2];\n";
 	OS << "	uint transform_branch_bits;\n";
 	OS << "	uint vertex_base_index;\n";
+	OS << "	float point_size;\n";
 	OS << "	ivec4 input_attributes[16];\n";
 	OS << "};\n\n";
 }
@@ -294,6 +295,7 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "dst_reg2"))
 			OS << "	front_spec_color = dst_reg2;\n";
 
+	OS << "	gl_PointSize = point_size;\n";
 	OS << "	gl_Position = gl_Position * scale_offset_mat;\n";
 
 	//Since our clip_space is symetrical [-1, 1] we map it to linear space using the eqn:

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -233,6 +233,8 @@ namespace rsx
 	public:
 		RsxDmaControl* ctrl = nullptr;
 		atomic_t<u32> internal_get{ 0 };
+		atomic_t<bool> external_interrupt_lock{ false };
+		atomic_t<bool> external_interrupt_ack{ false };
 
 		GcmTileInfo tiles[limits::tiles_count];
 		GcmZcullInfo zculls[limits::zculls_count];
@@ -477,5 +479,8 @@ namespace rsx
 
 		u32 ReadIO32(u32 addr);
 		void WriteIO32(u32 addr, u32 value);
+
+		void pause();
+		void unpause();
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1149,7 +1149,8 @@ void VKGSRender::end()
 
 					std::tie(min_filter, mip_mode) = vk::get_min_filter_and_mip(rsx::method_registers.fragment_textures[i].min_filter());
 
-					if (rsx::method_registers.fragment_textures[i].get_exact_mipmap_count() > 1)
+					if (sampler_state->upload_context == rsx::texture_upload_context::shader_read &&
+						rsx::method_registers.fragment_textures[i].get_exact_mipmap_count() > 1)
 					{
 						min_lod = (float)(rsx::method_registers.fragment_textures[i].min_lod() >> 8);
 						max_lod = (float)(rsx::method_registers.fragment_textures[i].max_lod() >> 8);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2289,6 +2289,7 @@ void VKGSRender::load_program(u32 vertex_count, u32 vertex_base)
 	fill_user_clip_data(buf + 64);
 	*(reinterpret_cast<u32*>(buf + 128)) = rsx::method_registers.transform_branch_bits();
 	*(reinterpret_cast<u32*>(buf + 132)) = vertex_base;
+	*(reinterpret_cast<f32*>(buf + 136)) = rsx::method_registers.point_size();
 	fill_vertex_layout_state(m_vertex_layout, vertex_count, reinterpret_cast<s32*>(buf + 144));
 
 	//Vertex constants

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -663,7 +663,7 @@ namespace vk
 
 		cached_texture_section* create_new_texture(vk::command_buffer& cmd, u32 rsx_address, u32 rsx_size, u16 width, u16 height, u16 depth, u16 mipmaps, const u32 gcm_format,
 				const rsx::texture_upload_context context, const rsx::texture_dimension_extended type, const rsx::texture_create_flags flags,
-				std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
+				const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
 		{
 			const u16 section_depth = depth;
 			const bool is_cubemap = type == rsx::texture_dimension_extended::texture_dimension_cubemap;
@@ -753,7 +753,7 @@ namespace vk
 
 		cached_texture_section* upload_image_from_cpu(vk::command_buffer& cmd, u32 rsx_address, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, const u32 gcm_format,
 			const rsx::texture_upload_context context, std::vector<rsx_subresource_layout>& subresource_layout, const rsx::texture_dimension_extended type, const bool swizzled,
-			std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
+			const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
 		{
 			auto section = create_new_texture(cmd, rsx_address, pitch * height, width, height, depth, mipmaps, gcm_format, context, type,
 					rsx::texture_create_flags::default_component_order, remap_vector);
@@ -822,7 +822,7 @@ namespace vk
 			section.set_sampler_status(rsx::texture_sampler_status::status_uninitialized);
 		}
 
-		void set_up_remap_vector(cached_texture_section& section, std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
+		void set_up_remap_vector(cached_texture_section& section, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
 		{
 			auto& view = section.get_view();
 			auto& original_remap = view->info.components;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -500,7 +500,7 @@ namespace vk
 			}
 			case rsx::texture_create_flags::swapped_native_component_order:
 			{
-				mapping = { VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_A };
+				mapping = { VK_COMPONENT_SWIZZLE_A, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B };
 				break;
 			}
 			default:

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -457,6 +457,31 @@ namespace vk
 			m_texture_memory_in_use = 0;
 			m_discarded_memory_size = 0;
 		}
+
+		VkComponentMapping apply_swizzle_remap(const std::array<VkComponentSwizzle, 4>& base_remap, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector)
+		{
+			VkComponentSwizzle final_mapping[4] = {};
+
+			for (u8 channel = 0; channel < 4; ++channel)
+			{
+				switch (remap_vector.second[channel])
+				{
+				case CELL_GCM_TEXTURE_REMAP_ONE:
+					final_mapping[channel] = VK_COMPONENT_SWIZZLE_ONE;
+					break;
+				case CELL_GCM_TEXTURE_REMAP_ZERO:
+					final_mapping[channel] = VK_COMPONENT_SWIZZLE_ZERO;
+					break;
+				case CELL_GCM_TEXTURE_REMAP_REMAP:
+					final_mapping[channel] = base_remap[remap_vector.first[channel]];
+					break;
+				default:
+					LOG_ERROR(RSX, "Unknown remap lookup value %d", remap_vector.second[channel]);
+				}
+			}
+
+			return { final_mapping[1], final_mapping[2], final_mapping[3], final_mapping[0] };
+		}
 		
 	protected:
 
@@ -677,28 +702,7 @@ namespace vk
 			{
 			case rsx::texture_create_flags::default_component_order:
 			{
-				auto native_mapping = vk::get_component_mapping(gcm_format);
-				VkComponentSwizzle final_mapping[4] = {};
-
-				for (u8 channel = 0; channel < 4; ++channel)
-				{
-					switch (remap_vector.second[channel])
-					{
-					case CELL_GCM_TEXTURE_REMAP_ONE:
-						final_mapping[channel] = VK_COMPONENT_SWIZZLE_ONE;
-						break;
-					case CELL_GCM_TEXTURE_REMAP_ZERO:
-						final_mapping[channel] = VK_COMPONENT_SWIZZLE_ZERO;
-						break;
-					case CELL_GCM_TEXTURE_REMAP_REMAP:
-						final_mapping[channel] = native_mapping[remap_vector.first[channel]];
-						break;
-					default:
-						LOG_ERROR(RSX, "Unknown remap lookup value %d", remap_vector.second[channel]);
-					}
-				}
-
-				mapping = { final_mapping[1], final_mapping[2], final_mapping[3], final_mapping[0] };
+				mapping = apply_swizzle_remap(vk::get_component_mapping(gcm_format), remap_vector);
 				break;
 			}
 			case rsx::texture_create_flags::native_component_order:
@@ -721,6 +725,7 @@ namespace vk
 			region.create(width, height, section_depth, mipmaps, view, image, 0, true, gcm_format);
 			region.set_dirty(false);
 			region.set_context(context);
+			region.set_sampler_status(rsx::texture_sampler_status::status_uninitialized);
 			region.set_image_type(type);
 
 			//Its not necessary to lock blit dst textures as they are just reused as necessary
@@ -756,8 +761,18 @@ namespace vk
 
 			vk::enter_uninterruptible();
 
-			//Swizzling is ignored for blit engine copy and emulated using a swapped order image view
-			bool input_swizzled = (context == rsx::texture_upload_context::blit_engine_src) ? false : swizzled;
+			bool input_swizzled = swizzled;
+			if (context == rsx::texture_upload_context::blit_engine_src)
+			{
+				//Swizzling is ignored for blit engine copy and emulated using remapping
+				input_swizzled = false;
+				section->set_sampler_status(rsx::texture_sampler_status::status_uninitialized);
+			}
+			else
+			{
+				//Generic upload - sampler status will be set on upload
+				section->set_sampler_status(rsx::texture_sampler_status::status_ready);
+			}
 
 			vk::copy_mipmaped_image_using_buffer(cmd, image->value, subresource_layout, gcm_format, input_swizzled, mipmaps, subres_range.aspectMask,
 				*m_texture_upload_heap, m_texture_upload_buffer);
@@ -800,6 +815,20 @@ namespace vk
 			}
 
 			section.set_view_flags(expected_flags);
+		}
+
+		void set_up_remap_vector(cached_texture_section& section, std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector) override
+		{
+			auto& view = section.get_view();
+			auto& original_remap = section.get_view()->info.components;
+			std::array<VkComponentSwizzle, 4> base_remap = {original_remap.a, original_remap.r, original_remap.g, original_remap.b};
+
+			auto final_remap = apply_swizzle_remap(base_remap, remap_vector);
+			vk::image_view *new_view = new vk::image_view(*m_device, view->info.image, view->info.viewType, view->info.format,
+				final_remap, view->info.subresourceRange);
+
+			view.reset(new_view);
+			section.set_sampler_status(rsx::texture_sampler_status::status_ready);
 		}
 
 		void insert_texture_barrier() override

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -36,6 +36,7 @@ void VKVertexDecompilerThread::insertHeader(std::stringstream &OS)
 	OS << "	vec4 user_clip_factor[2];\n";
 	OS << "	uint transform_branch_bits;\n";
 	OS << "	uint vertex_base_index;\n";
+	OS << "	float point_size;\n";
 	OS << "	ivec4 input_attributes[16];\n";
 	OS << "};\n";
 
@@ -309,6 +310,7 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "dst_reg2"))
 			OS << "	front_spec_color = dst_reg2;\n";
 
+	OS << "	gl_PointSize = point_size;\n";
 	OS << "	gl_Position = gl_Position * scale_offset_mat;\n";
 	OS << "}\n";
 }

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3380,6 +3380,31 @@ struct registers_decoder<NV4097_SET_LINE_WIDTH>
 };
 
 template<>
+struct registers_decoder<NV4097_SET_POINT_SIZE>
+{
+	struct decoded_type
+	{
+	private:
+		union
+		{
+			u32 raw_data;
+		} m_data;
+	public:
+		decoded_type(u32 raw_value) { m_data.raw_data = raw_value; }
+
+		f32 point_size() const
+		{
+			return (f32&)m_data.raw_data;
+		}
+	};
+
+	static std::string dump(decoded_type &&decoded_values)
+	{
+		return "Point size: " + std::to_string(decoded_values.point_size());
+	}
+};
+
+template<>
 struct registers_decoder<NV4097_SET_SURFACE_FORMAT>
 {
 	struct decoded_type

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -75,9 +75,9 @@ namespace rsx
 				if (Emu.IsStopped())
 					break;
 
-				if ((get_system_time() - start) > 33000)
+				if ((get_system_time() - start) > 1000000)
 				{
-					//If longer than 33ms force exit (1 frame)
+					//If longer than 1s force exit
 					LOG_ERROR(RSX, "nv406e::semaphore_acquire has timed out. semaphore_address=0x%X", addr);
 					break;
 				}

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -677,6 +677,11 @@ namespace rsx
 			return decode<NV4097_SET_LINE_WIDTH>().line_width();
 		}
 
+		f32 point_size() const
+		{
+			return decode<NV4097_SET_POINT_SIZE>().point_size();
+		}
+
 		u8 alpha_ref() const
 		{
 			return decode<NV4097_SET_ALPHA_REF>().alpha_ref();

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -341,7 +341,7 @@ struct cfg_root : cfg::node
 		cfg::_int<1, 8> consequtive_frames_to_skip{this, "Consecutive Frames To Skip", 1};
 		cfg::_int<50, 800> resolution_scale_percent{this, "Resolution Scale", 100};
 		cfg::_int<0, 16> anisotropic_level_override{this, "Anisotropic Filter Override", 0};
-		cfg::_int<1, 1024> min_scalable_dimension{this, "Minimum Scalable Dimension", 128};
+		cfg::_int<1, 1024> min_scalable_dimension{this, "Minimum Scalable Dimension", 16};
 
 		struct node_d3d12 : cfg::node
 		{


### PR DESCRIPTION
- Implement deferred swizzle remaps for twice-remapped resources
- Fix blit engine operations on RGB565
- Add a timeout on nv406e::semaphore_acquire. Requires further inevstigations why some semaphore addresses always lock up
- Fix WCB causing hanging due to incorrect memory range approximation
- Properly synchronize FIFO ctrl updates. Can improve stability in some cases. The issue still happens if the SPUs lag too far behind RSX
- Implement variable point size https://github.com/RPCS3/rpcs3/issues/3740
- Implement FP instructions BEM, TEXBEM, TXPBEM (untested, rarely used)
- Fix for LG2 fp instruction processing invalid values. Thanks to @MaikelChan for assistance narrowing down the broken shader
- Framebuffer setup fixes to avoid lost draw calls

https://github.com/RPCS3/rpcs3/issues/3913
https://github.com/RPCS3/rpcs3/issues/3740
https://github.com/RPCS3/rpcs3/issues/3829
https://github.com/RPCS3/rpcs3/issues/3768
https://github.com/RPCS3/rpcs3/issues/2194
https://github.com/RPCS3/rpcs3/issues/3905