### PR TITLE
fix clang warning: logical-op-parentheses

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
@@ -58,7 +58,7 @@ class FragmentProgramDecompiler
 		{
 			//Data fetched from the single precision register requires merging of the two half registers
 			//TODO: Check individual swizzle channels
-			if (aliased_h0 && xy || aliased_h1 && zw)
+			if ((aliased_h0 && xy) || (aliased_h1 && zw))
 				return last_write_half;
 
 			return false;


### PR DESCRIPTION
Removes a clang warning + improves readability