### PR TITLE
[gui] Show total number of llvm compilation dialogs

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -84,6 +84,7 @@ public:
 	virtual ~MsgDialogBase();
 	virtual void Create(const std::string& msg) = 0;
 	virtual void CreateOsk(const std::string& msg, char16_t* osk_text, u32 charlimit) = 0;
+	virtual void SetMsg(const std::string& msg) = 0;
 	virtual void ProgressBarSetMsg(u32 progressBarIndex, const std::string& msg) = 0;
 	virtual void ProgressBarReset(u32 progressBarIndex) = 0;
 	virtual void ProgressBarInc(u32 progressBarIndex, u32 delta) = 0;

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -339,6 +339,14 @@ msg_dialog_frame::~msg_dialog_frame()
 	}
 }
 
+void msg_dialog_frame::SetMsg(const std::string& msg)
+{
+	if (m_dialog)
+	{
+		m_text->setText(qstr(msg));
+	}
+}
+
 void msg_dialog_frame::ProgressBarSetMsg(u32 index, const std::string& msg)
 {
 	if (m_dialog)

--- a/rpcs3/rpcs3qt/msg_dialog_frame.h
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.h
@@ -63,6 +63,7 @@ public:
 	~msg_dialog_frame();
 	virtual void Create(const std::string& msg) override;
 	virtual void CreateOsk(const std::string& msg, char16_t* osk_text, u32 charlimit) override;
+	virtual void SetMsg(const std::string& msg) override;
 	virtual void ProgressBarSetMsg(u32 progressBarIndex, const std::string& msg) override;
 	virtual void ProgressBarReset(u32 progressBarIndex) override;
 	virtual void ProgressBarInc(u32 progressBarIndex, u32 delta) override;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6632271/33990000-2ec10b2c-e0d2-11e7-8861-f2ed9af2fb35.png)

Resolves #3935.

---
Drawbacks:

1) Doesn't account for dynamic libraries loaded after the fact, but _usually_ good enough since:
   * They usually only have about 1 or 2 module fragments (# of dialogs) each.
   * They aren't even present in some games.
   * It will stop happening once compilation all libraries automatically upon installation of the firmware is implemented (on the Roadmap for this month).

2) ~~Doesn't account for when _some_ fragments are loaded from disk from a previous compile interruption.~~