### PR TITLE
small fix to restore local multiplayer on evdev

### DIFF
--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -506,7 +506,7 @@ int evdev_joystick_handler::add_device(const std::string& device, bool in_settin
 				{
 					libevdev_free(dev);
 					close(fd);
-					return std::distance(devices.begin(), it);
+					continue;
 				}
 
 				// Alright, now that we've confirmed we haven't added this joystick yet, les do dis.


### PR DESCRIPTION
All credit goes to @Megamouse . There's a big #3817, but it might take some time before it's ready.
Since the nice gui configuration, only one evdev gamepad is usable on master. So, it's a regression.
I believe it would be very nice to restore the local multiplayer ability on Linux (without waiting for the #3817).
It's a very small fix. 
Maybe @Megamouse wants to push this under his own name ?
