### PR TITLE
Fix MSELF files

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -53,6 +53,8 @@ bool verify_mself(u32 fd, fs::file const& mself_file)
 		return false;
 	}
 
+	mself_file.seek(0);
+
 	return true;
 }
 


### PR DESCRIPTION
fs_open on mself files would move the file pointer, but not reset it.
Should fix some games using mself files, fixed access violation on NPEB01152