### PR TITLE
improve cellPadSetPortSetting

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -524,11 +524,12 @@ s32 cellPadSetPortSetting(u32 port_no, u32 port_setting)
 
 	if (port_no >= rinfo.max_connect)
 		return CELL_PAD_ERROR_INVALID_PARAMETER;
-	if (port_no >= rinfo.now_connect)
-		return CELL_PAD_ERROR_NO_DEVICE;
 
 	auto& pads = handler->GetPads();
 	pads[port_no]->m_port_setting = port_setting;
+
+	if (port_no >= rinfo.now_connect)
+		return CELL_PAD_ERROR_NO_DEVICE;
 
 	return CELL_OK;
 }

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -723,7 +723,7 @@ bool ds4_pad_handler::Init()
 			if (dev)
 				CheckAddDevice(dev, devInfo);
 			else
-				LOG_ERROR(HLE, "[DS4] hid_open_path failed! Reason: %S", hid_error(dev));
+				LOG_ERROR(HLE, "[DS4] hid_open_path failed! Reason: %s", hid_error(dev));
 			devInfo = devInfo->next;
 		}
 		hid_free_enumeration(head);


### PR DESCRIPTION
and fix DS4 error message

This should fix a bug where Catherine and other games don't receive some buttons' input.
The bug was introduced when changing the initial connection count in PadThread.cpp.
Catherine sets the port setting on boot. but because no controller was connected this was actually skipped

Here you can see that it is called once before we connect the pads
![image](https://user-images.githubusercontent.com/23019877/34325749-7201335a-e89b-11e7-8286-5aeebdab6c28.png)