### PR TITLE
Set lv2_socket id_base

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net.h
@@ -307,7 +307,7 @@ struct lv2_socket final
 	using socket_type = int;
 #endif
 
-	static const u32 id_base = 1;
+	static const u32 id_base = 0x40000000;
 	static const u32 id_step = 1;
 	static const u32 id_count = 1024;
 

--- a/rpcs3/Emu/Cell/lv2/sys_net.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net.h
@@ -307,7 +307,7 @@ struct lv2_socket final
 	using socket_type = int;
 #endif
 
-	static const u32 id_base = 0;
+	static const u32 id_base = 1;
 	static const u32 id_step = 1;
 	static const u32 id_count = 1024;
 


### PR DESCRIPTION
Another tiny PR. Apparently, a socket with fd == 0 is invalid, at least according to Rage (NPEB90391).
Rage now goes ingame (from intro).