### PR TITLE
rsx: Minor fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -195,12 +195,12 @@ std::string FragmentProgramDecompiler::AddX2d()
 //Failure to catch causes infinite values since theres alot of rcp(0)
 std::string FragmentProgramDecompiler::NotZero(const std::string& code)
 {
-	return "(max(abs(" + code + "), 1.E-10) * sign(" + code + "))";
+	return "(max(abs(" + code + "), 0.000001) * sign(" + code + "))";
 }
 
 std::string FragmentProgramDecompiler::NotZeroPositive(const std::string& code)
 {
-	return "max(abs(" + code + "), 1.E-10)";
+	return "max(abs(" + code + "), 0.000001)";
 }
 
 std::string FragmentProgramDecompiler::ClampValue(const std::string& code, u32 precision)

--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -337,7 +337,7 @@ namespace glsl
 		OS << "	result.x = 1.;\n";
 		OS << "	result.w = 1.;\n";
 		OS << "	result.y = clamped_val.x;\n";
-		OS << "	result.z = clamped_val.x > 0. ? exp(clamped_val.w * log(max(clamped_val.y, 1.E-10))) : 0.;\n";
+		OS << "	result.z = clamped_val.x > 0. ? exp(clamped_val.w * log(max(clamped_val.y, 0.000001))) : 0.;\n";
 		OS << "	return result;\n";
 		OS << "}\n\n";
 

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -376,7 +376,7 @@ void VertexProgramDecompiler::SetDSTSca(const std::string& code)
 
 std::string VertexProgramDecompiler::NotZeroPositive(const std::string& code)
 {
-	return "max(" + code + ", 1.E-10)";
+	return "max(" + code + ", 0.000001)";
 }
 
 std::string VertexProgramDecompiler::BuildFuncBody(const FuncInfo& func)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -318,11 +318,6 @@ void GLGSRender::end()
 		if (m_program->uniforms.has_location("tex" + std::to_string(i), &unused_location))
 		{
 			auto sampler_state = static_cast<gl::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
-
-			if (sampler_state->flag)
-				continue;
-
-			sampler_state->flag = true;
 			auto &tex = rsx::method_registers.fragment_textures[i];
 
 			glActiveTexture(GL_TEXTURE0 + i);
@@ -338,7 +333,6 @@ void GLGSRender::end()
 				{
 					void *unused = nullptr;
 					glBindTexture(target, m_gl_texture_cache.create_temporary_subresource(unused, sampler_state->external_subresource_desc));
-					sampler_state->flag = false;
 				}
 				else
 				{
@@ -357,11 +351,6 @@ void GLGSRender::end()
 		if (m_program->uniforms.has_location("vtex" + std::to_string(i), &unused_location))
 		{
 			auto sampler_state = static_cast<gl::texture_cache::sampled_image_descriptor*>(vs_sampler_state[i].get());
-
-			if (sampler_state->flag)
-				continue;
-
-			sampler_state->flag = true;
 			glActiveTexture(GL_TEXTURE0 + rsx::limits::fragment_textures_count + i);
 
 			if (sampler_state->image_handle)
@@ -372,7 +361,6 @@ void GLGSRender::end()
 			{
 				void *unused = nullptr;
 				glBindTexture(GL_TEXTURE_2D, m_gl_texture_cache.create_temporary_subresource(unused, sampler_state->external_subresource_desc));
-				sampler_state->flag = false;
 			}
 			else
 			{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1039,6 +1039,8 @@ void GLGSRender::update_draw_state()
 	gl_state.depth_mask(rsx::method_registers.depth_write_enabled());
 	gl_state.stencil_mask(rsx::method_registers.stencil_mask());
 
+	gl_state.enable(rsx::method_registers.depth_clamp_enabled(), GL_DEPTH_CLAMP);
+
 	if (gl_state.enable(rsx::method_registers.depth_test_enabled(), GL_DEPTH_TEST))
 	{
 		gl_state.depth_func(comparison_op(rsx::method_registers.depth_func()));

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2243,7 +2243,7 @@ void VKGSRender::load_program(u32 vertex_count, u32 vertex_base)
 
 	properties.rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 	properties.rs.polygonMode = VK_POLYGON_MODE_FILL;
-	properties.rs.depthClampEnable = VK_FALSE;
+	properties.rs.depthClampEnable = rsx::method_registers.depth_clamp_enabled();
 	properties.rs.rasterizerDiscardEnable = VK_FALSE;
 
 	//Disabled by setting factors to 0 as needed

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "VKHelpers.h"
 
+#include <mutex>
+
 namespace vk
 {
 	context* g_current_vulkan_ctx = nullptr;
@@ -9,13 +11,16 @@ namespace vk
 	std::unique_ptr<image> g_null_texture;
 	std::unique_ptr<image_view> g_null_image_view;
 
-	VkSampler g_null_sampler      = nullptr;
+	VkSampler g_null_sampler = nullptr;
 
 	bool g_cb_no_interrupt_flag = false;
 	bool g_drv_no_primitive_restart_flag = false;
 
 	u64 g_num_processed_frames = 0;
 	u64 g_num_total_frames = 0;
+
+	//global submit guard to prevent race condition on queue submit
+	std::mutex g_submit_mutex;
 
 	VKAPI_ATTR void* VKAPI_CALL mem_realloc(void* pUserData, void* pOriginal, size_t size, size_t alignment, VkSystemAllocationScope allocationScope)
 	{
@@ -219,7 +224,7 @@ namespace vk
 
 		g_null_texture.reset(new image(g_current_renderer, get_memory_mapping(g_current_renderer.gpu()).device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 			VK_IMAGE_TYPE_2D, VK_FORMAT_B8G8R8A8_UNORM, 4, 4, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_SAMPLED_BIT, 0));
+			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0));
 
 		g_null_image_view.reset(new image_view(g_current_renderer, g_null_texture->value, VK_IMAGE_VIEW_TYPE_2D,
 			VK_FORMAT_B8G8R8A8_UNORM, {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A},
@@ -234,6 +239,16 @@ namespace vk
 		// Prep for shader access
 		change_image_layout(cmd, g_null_texture.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, range);
 		return g_null_image_view->value;
+	}
+
+	void acquire_global_submit_lock()
+	{
+		g_submit_mutex.lock();
+	}
+
+	void release_global_submit_lock()
+	{
+		g_submit_mutex.unlock();
 	}
 
 	void destroy_global_resources()

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -75,6 +75,10 @@ namespace vk
 	VkSampler null_sampler();
 	VkImageView null_image_view(vk::command_buffer&);
 
+	//Sync helpers around vkQueueSubmit
+	void acquire_global_submit_lock();
+	void release_global_submit_lock();
+
 	void destroy_global_resources();
 
 	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range);
@@ -1127,7 +1131,9 @@ namespace vk
 			infos.waitSemaphoreCount = static_cast<uint32_t>(semaphores.size());
 			infos.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
+			acquire_global_submit_lock();
 			CHECK_RESULT(vkQueueSubmit(queue, 1, &infos, fence));
+			release_global_submit_lock();
 		}
 	};
 

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -702,6 +702,32 @@ struct registers_decoder<NV4097_SET_DEPTH_MASK>
 };
 
 template<>
+struct registers_decoder<NV4097_SET_ZMIN_MAX_CONTROL>
+{
+	struct decoded_type
+	{
+	private:
+		union
+		{
+			u32 raw_value;
+			bitfield_decoder_t<4, 4> depth_clamp_enabled;
+		} m_data;
+	public:
+		decoded_type(u32 raw_value) { m_data.raw_value = raw_value; }
+
+		bool depth_clamp_enabled() const
+		{
+			return bool(m_data.depth_clamp_enabled);
+		}
+	};
+
+	static std::string dump(decoded_type &&decoded_values)
+	{
+		return "Depth: clamp " + print_boolean(decoded_values.depth_clamp_enabled());
+	}
+};
+
+template<>
 struct registers_decoder<NV4097_SET_ALPHA_TEST_ENABLE>
 {
 	struct decoded_type

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1652,6 +1652,7 @@ namespace rsx
 		bind<NV4097_SET_ZPASS_PIXEL_COUNT_ENABLE, nv4097::set_zcull_pixel_count_enable>();
 		bind<NV4097_CLEAR_ZCULL_SURFACE, nv4097::clear_zcull>();
 		bind<NV4097_SET_DEPTH_TEST_ENABLE, nv4097::set_surface_options_dirty_bit>();
+		bind<NV4097_SET_STENCIL_TEST_ENABLE, nv4097::set_surface_options_dirty_bit>();
 		bind<NV4097_SET_DEPTH_MASK, nv4097::set_surface_options_dirty_bit>();
 		bind<NV4097_SET_COLOR_MASK, nv4097::set_surface_options_dirty_bit>();
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1201,6 +1201,11 @@ namespace rsx
 		{
 			return decode<NV4097_SET_ANTI_ALIASING_CONTROL>().msaa_alpha_to_one();
 		}
+
+		bool depth_clamp_enabled()
+		{
+			return decode<NV4097_SET_ZMIN_MAX_CONTROL>().depth_clamp_enabled();
+		}
 	};
 
 	extern rsx_state method_registers;


### PR DESCRIPTION
- Fix GL texture flickering due to broken optimization path when wcb is enabled
- Synchronize access to the present/graphics queue during submit. Its simpler to just use a global lock in this case since at the moment we only use one queue and contention only happens during submit. Should fix some cases of device_lost when running nvidia + wcb
- Implement depth clamp
- Fixes for stencil surface configuration when address is contested
- Workaround for nvidia linux bug