### PR TITLE
Initial sys_overlay

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -15,6 +15,7 @@
 #include "sys_memory.h"
 #include "sys_mmapper.h"
 #include "sys_net.h"
+#include "sys_overlay.h"
 #include "sys_ppu_thread.h"
 #include "sys_process.h"
 #include "sys_prx.h"
@@ -422,8 +423,8 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, //430-439  UNS
 	uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, //440-449  UNS
 
-	null_func,//BIND_FUNC(sys_overlay_load_module)          //450 (0x1C2)
-	null_func,//BIND_FUNC(sys_overlay_unload_module)        //451 (0x1C3)
+	BIND_FUNC(sys_overlay_load_module),                     //450 (0x1C2)
+	BIND_FUNC(sys_overlay_unload_module),                   //451 (0x1C3)
 	null_func,//BIND_FUNC(sys_overlay_get_module_list)      //452 (0x1C4)
 	null_func,//BIND_FUNC(sys_overlay_get_module_info)      //453 (0x1C5)
 	null_func,//BIND_FUNC(sys_overlay_load_module_by_fd)    //454 (0x1C6)

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -1,0 +1,60 @@
+#include "stdafx.h"
+#include "Emu/Memory/vm.h"
+#include "Emu/System.h"
+#include "Emu/IdManager.h"
+#include "Crypto/unself.h"
+#include "Crypto/unedat.h"
+#include "Loader/ELF.h"
+
+#include "sys_overlay.h"
+
+extern std::shared_ptr<lv2_overlay> ppu_load_overlay(const ppu_exec_object&, const std::string& path);
+
+extern void ppu_initialize(const ppu_module&);
+
+LOG_CHANNEL(sys_overlay);
+
+error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path2, u64 flags, vm::ptr<u32> entry)
+{
+	sys_overlay.warning("sys_overlay_load_module(ovlmid=*0x%x, path=%s, flags=0x%x, entry=*0x%x)", ovlmid, path2, flags, entry);
+
+	const std::string path = path2.get_ptr();
+	const auto name = path.substr(path.find_last_of('/') + 1);
+
+	const ppu_exec_object obj = decrypt_self(fs::file(vfs::get(path)), fxm::get_always<LoadedNpdrmKeys_t>()->devKlic.data());
+
+	if (obj != elf_error::ok)
+	{
+		return {CELL_ENOEXEC, obj.operator elf_error()};
+	}
+
+	const auto ovlm = ppu_load_overlay(obj, path);
+
+	ppu_initialize(*ovlm);
+
+	sys_overlay.success("Loaded overlay: %s", path);
+
+	*ovlmid = idm::last_id();
+	*entry  = ovlm->entry;
+
+	return CELL_OK;
+}
+
+error_code sys_overlay_unload_module(u32 ovlmid)
+{
+	sys_overlay.warning("sys_overlay_unload_module(ovlmid=0x%x)", ovlmid);
+
+	const auto _main = idm::withdraw<lv2_obj, lv2_overlay>(ovlmid);
+
+	if (!_main)
+	{
+		return CELL_ESRCH;
+	}
+
+	for (auto& seg : _main->segs)
+	{
+		vm::dealloc(seg.addr);
+	}
+
+	return CELL_OK;
+}

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.h
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Emu/Cell/PPUAnalyser.h"
+#include "sys_sync.h"
+#include "Emu/Cell/ErrorCodes.h"
+
+struct lv2_overlay final : lv2_obj, ppu_module
+{
+	static const u32 id_base = 0x25000000;
+
+	u32 entry;
+};
+
+error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry);
+error_code sys_overlay_unload_module(u32 ovlmid);
+//error_code sys_overlay_get_module_list(sys_pid_t pid, size_t ovlmids_num, sys_overlay_t * ovlmids, size_t * num_of_modules);
+//error_code sys_overlay_get_module_info(sys_pid_t pid, sys_overlay_t ovlmid, sys_overlay_module_info_t * info);
+//error_code sys_overlay_load_module_by_fd(sys_overlay_t * ovlmid, int fd, u64 offset, uint64_t flags, sys_addr_t * entry);
+//error_code sys_overlay_get_module_info2(sys_pid_t pid, sys_overlay_t ovlmid, sys_overlay_module_info2_t * info);//
+//error_code sys_overlay_get_sdk_version(); //2 params
+//error_code sys_overlay_get_module_dbg_info(); //3 params?
+
+//error_code _sys_prx_load_module(vm::ps3::cptr<char> path, u64 flags, vm::ps3::ptr<sys_prx_load_module_option_t> pOpt);

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -16,6 +16,7 @@
 #include "sys_memory.h"
 #include "sys_mmapper.h"
 #include "sys_prx.h"
+#include "sys_overlay.h"
 #include "sys_rwlock.h"
 #include "sys_semaphore.h"
 #include "sys_timer.h"
@@ -71,6 +72,7 @@ s32 sys_process_get_number_of_object(u32 object, vm::ptr<u32> nump)
 	case SYS_SPUIMAGE_OBJECT: fmt::throw_exception("SYS_SPUIMAGE_OBJECT" HERE);
 	case SYS_PRX_OBJECT: *nump = idm_get_count<lv2_obj, lv2_prx>(); break;
 	case SYS_SPUPORT_OBJECT: fmt::throw_exception("SYS_SPUPORT_OBJECT" HERE);
+	case SYS_OVERLAY_OBJECT: *nump = idm_get_count<lv2_obj, lv2_overlay>(); break;
 	case SYS_LWMUTEX_OBJECT: *nump = idm_get_count<lv2_obj, lv2_lwmutex>(); break;
 	case SYS_TIMER_OBJECT: *nump = idm_get_count<lv2_obj, lv2_timer>(); break;
 	case SYS_SEMAPHORE_OBJECT: *nump = idm_get_count<lv2_obj, lv2_sema>(); break;
@@ -118,6 +120,7 @@ s32 sys_process_get_id(u32 object, vm::ptr<u32> buffer, u32 size, vm::ptr<u32> s
 	case SYS_SPUIMAGE_OBJECT: fmt::throw_exception("SYS_SPUIMAGE_OBJECT" HERE);
 	case SYS_PRX_OBJECT: idm_get_set<lv2_obj, lv2_prx>(objects); break;
 	case SYS_SPUPORT_OBJECT: fmt::throw_exception("SYS_SPUPORT_OBJECT" HERE);
+	case SYS_OVERLAY_OBJECT: idm_get_set<lv2_obj, lv2_overlay>(objects); break;
 	case SYS_LWMUTEX_OBJECT: idm_get_set<lv2_obj, lv2_lwmutex>(objects); break;
 	case SYS_TIMER_OBJECT: idm_get_set<lv2_obj, lv2_timer>(objects); break;
 	case SYS_SEMAPHORE_OBJECT: idm_get_set<lv2_obj, lv2_sema>(objects); break;

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -15,6 +15,7 @@ enum : u32
 	SYS_SPUIMAGE_OBJECT              = 0x22,
 	SYS_PRX_OBJECT                   = 0x23,
 	SYS_SPUPORT_OBJECT               = 0x24,
+	SYS_OVERLAY_OBJECT               = 0x25,
 	SYS_LWMUTEX_OBJECT               = 0x95,
 	SYS_TIMER_OBJECT                 = 0x11,
 	SYS_SEMAPHORE_OBJECT             = 0x96,

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="Emu\Cell\lv2\sys_gpio.cpp" />
     <ClCompile Include="Emu\Cell\lv2\sys_net.cpp" />
     <ClCompile Include="Emu\Cell\Modules\StaticHLE.cpp" />
+    <ClCompile Include="Emu\Cell\lv2\sys_overlay.cpp" />
     <ClCompile Include="Emu\Cell\PPUAnalyser.cpp" />
     <ClCompile Include="Emu\Cell\PPUTranslator.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -408,6 +409,7 @@
     <ClInclude Include="Emu\Cell\Modules\cellHttp.h" />
     <ClInclude Include="Emu\Cell\Modules\cellHttpUtil.h" />
     <ClInclude Include="Emu\Cell\Modules\cellJpgEnc.h" />
+    <ClInclude Include="Emu\Cell\lv2\sys_overlay.h" />
     <ClInclude Include="Emu\Cell\Modules\cellOskDialog.h" />
     <ClInclude Include="Emu\Cell\Modules\cellVoice.h" />
     <ClInclude Include="Emu\Cell\Modules\StaticHLE.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -779,6 +779,9 @@
     <ClCompile Include="Emu\RSX\Overlays\overlay_osk.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\Cell\lv2\sys_overlay.cpp">
+      <Filter>Emu\Cell\lv2</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -1421,6 +1424,9 @@
       <Filter>Emu\Cell\Modules</Filter>
     </ClInclude>
     <ClInclude Include="Emu\Cell\lv2\sys_net.h">
+      <Filter>Emu\Cell\lv2</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Cell\lv2\sys_overlay.h">
       <Filter>Emu\Cell\lv2</Filter>
     </ClInclude>
     <ClInclude Include="Emu\Cell\lv2\sys_gpio.h">

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -15,6 +15,7 @@
 #include "Emu/Cell/lv2/sys_event_flag.h"
 #include "Emu/Cell/lv2/sys_rwlock.h"
 #include "Emu/Cell/lv2/sys_prx.h"
+#include "Emu/Cell/lv2/sys_overlay.h"
 #include "Emu/Cell/lv2/sys_memory.h"
 #include "Emu/Cell/lv2/sys_mmapper.h"
 #include "Emu/Cell/lv2/sys_spu.h"
@@ -125,8 +126,9 @@ void kernel_explorer::Update()
 	lv2_types[SYS_EVENT_PORT_OBJECT] =					l_addTreeChild(root, "Event Ports");
 	lv2_types[SYS_TRACE_OBJECT] =								l_addTreeChild(root, "Traces");
 	lv2_types[SYS_SPUIMAGE_OBJECT] =						l_addTreeChild(root, "SPU Images");
-	lv2_types[SYS_PRX_OBJECT] =									l_addTreeChild(root, "Modules");
+	lv2_types[SYS_PRX_OBJECT] =									l_addTreeChild(root, "PRX Modules");
 	lv2_types[SYS_SPUPORT_OBJECT] =							l_addTreeChild(root, "SPU Ports");
+	lv2_types[SYS_OVERLAY_OBJECT] =						 l_addTreeChild(root, "Overlay Modules");
 	lv2_types[SYS_LWMUTEX_OBJECT] =							l_addTreeChild(root, "Light Weight Mutexes");
 	lv2_types[SYS_TIMER_OBJECT] =								l_addTreeChild(root, "Timers");
 	lv2_types[SYS_SEMAPHORE_OBJECT] =						l_addTreeChild(root, "Semaphores");
@@ -210,6 +212,12 @@ void kernel_explorer::Update()
 		case SYS_SPUPORT_OBJECT:
 		{
 			l_addTreeChild(node, qstr(fmt::format("SPU Port: ID = 0x%08x", id)));
+			break;
+		}
+		case SYS_OVERLAY_OBJECT:
+		{
+			auto& ovl = static_cast<lv2_overlay&>(obj);
+			l_addTreeChild(node, qstr(fmt::format("OVL: ID = 0x%08x '%s'", id, ovl.name)));
 			break;
 		}
 		case SYS_LWMUTEX_OBJECT:


### PR DESCRIPTION
Most likely needs a lot more changes, but i don't know where to look for more answers.
I suggest not merging it yet.

- [x] Unknown error codes for sys_overlay - Error codes seem to be the same as ppu module loading

- [ ] ppu_load_overlay_exec is almost the same as ppu_load_exec with minor changes(header in elf, and initialization)

- [x] There are no imports or exports in overlay elfs, but there stubs which look like an import - look changes in PPUAnalyser. Seem to be analysed properly, I was afraid there might be something wrong with TOC.

- [x] Arbitrarily picked id_base for id manager. while at any one time only one overlay elf(they use the same address space 0x3...) is loaded there are overlay ids for some reason.

