### PR TITLE
rsx: Robustness fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -244,6 +244,7 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 		render->ctrl->get = a3;
 		render->ctrl->put = a4;
 		render->internal_get = a3;
+		render->restore_point = a3;
 		render->unpause();
 		break;
 

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -134,6 +134,12 @@ namespace
 			    command.raw_index_buffer, ptr, type, rsx::method_registers.current_draw_clause.primitive,
 			    rsx::method_registers.current_draw_clause.first_count_commands, vertex_count);
 
+			if (min_index >= max_index)
+			{
+				//empty set, do not draw
+				return{ 0, 0, 0, 0, std::make_tuple(get_index_type(type), offset_in_index_buffer) };
+			}
+
 			//check for vertex arrays with frquency modifiers
 			for (auto &block : m_vertex_layout.interleaved_blocks)
 			{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -233,6 +233,7 @@ namespace rsx
 	public:
 		RsxDmaControl* ctrl = nullptr;
 		atomic_t<u32> internal_get{ 0 };
+		atomic_t<u32> restore_point{ 0 };
 		atomic_t<bool> external_interrupt_lock{ false };
 		atomic_t<bool> external_interrupt_ack{ false };
 
@@ -309,6 +310,7 @@ namespace rsx
 	public:
 		std::set<u32> m_used_gcm_commands;
 		bool invalid_command_interrupt_raised = false;
+		bool sync_point_request = false;
 		bool in_begin_end = false;
 
 		bool conditional_render_test_failed = false;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -62,6 +62,7 @@ namespace rsx
 
 		void semaphore_acquire(thread* rsx, u32 _reg, u32 arg)
 		{
+			rsx->sync_point_request = true;
 			const u32 addr = get_address(method_registers.semaphore_offset_406e(), method_registers.semaphore_context_dma_406e());
 			if (vm::ps3::read32(addr) == arg) return;
 
@@ -109,6 +110,7 @@ namespace rsx
 
 		void semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
+			rsx->sync_point_request = true;
 			const u32 addr = get_address(method_registers.semaphore_offset_406e(), method_registers.semaphore_context_dma_406e());
 
 			if (addr >> 28 == 0x4)


### PR DESCRIPTION
- Track last working state and reset to it if RSX starts to desync.
  This is especially useful when running vulkan since the renderer will easily outpace the rest of the system when merely recording draw commands
- Ignore empty index buffer sets.
  Mark empty/invalid IB sets as having 0 element counts.

This should allow RSX state to recover if invalid FIFO state is encountered. If the state causes the backend to crash this will still not catch it, but at least should help make it less common. Alot of these issues happen when RSX runs "too fast" because rpcs3 is not cycle accurate and the game isn't properly synchronized.