### PR TITLE
Remove _mxr000 hack

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -6,7 +6,6 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 #include "sys_ppu_thread.h"
-#include "sys_event.h"
 #include "sys_mmapper.h"
 
 namespace vm { using namespace ps3; }
@@ -348,22 +347,6 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 	else
 	{
 		thread->notify();
-
-		// Dirty hack for sound: confirm the creation of _mxr000 event queue
-		if (thread->m_name == "_cellsurMixerMain")
-		{
-			lv2_obj::sleep(ppu);
-
-			while (!idm::select<lv2_obj, lv2_event_queue>([](u32, lv2_event_queue& eq)
-			{
-				return eq.name == "_mxr000\0"_u64;
-			}))
-			{
-				thread_ctrl::wait_for(50000);
-			}
-
-			ppu.test_state();
-		}
 	}
 
 	return CELL_OK;


### PR DESCRIPTION
Allows Sonic the Hedgehog [BLES00028] to go further without LLE libaudio, also avoid instantly crash when run the game.
https://forums.rpcs3.net/thread-178905.html
![sonic1](https://user-images.githubusercontent.com/16824659/34506868-a6925670-f017-11e7-8b3e-f8d088077c03.jpg)

![sonic2](https://user-images.githubusercontent.com/16824659/34506884-c4685852-f017-11e7-8ccc-076495e82b2f.jpg)

(!) Please ignore this PR if the hack is still needed in RPCS3 (!)