### PR TITLE
.travis.yml: set git depth to false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,8 @@ matrix:
       compiler: gcc
 
 git:
+  depth: false # Unshallow clone to obtain proper GIT_VERSION
   submodules: false
-  # Unshallow clone to obtain proper GIT_VERSION
-  # There's no variable to disable depth, so we just have to set it to a huge number
-  # https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
-  depth: 100000
 
 before_install:
   - if [ "$CC" = "clang" ]; then


### PR DESCRIPTION
We can now use
```
git:
  depth: false
```
instead of
```
git:
  depth: 100000
```
for an unshallow clone.

Official documentation: https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth