### PR TITLE
Implement hardware breakpoints

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1362,16 +1362,16 @@ static bool is_leaf_function(u64 rip)
 
 // Can't alter thread context while it inside an exception handler because
 // once it leaves the handler the context gets flushed
-extern thread_local bool g_inside_exception_handler = false;
+extern thread_local bool g_tls_inside_exception_handler = false;
 
 #ifdef _WIN32
 
 static LONG exception_handler_impl(PEXCEPTION_POINTERS pExp);
 static LONG exception_handler(PEXCEPTION_POINTERS pExp)
 {
-	g_inside_exception_handler = true;
+	g_tls_inside_exception_handler = true;
 	auto result = exception_handler_impl(pExp);
-	g_inside_exception_handler = false;
+	g_tls_inside_exception_handler = false;
 	return result;
 }
 

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -6,6 +6,7 @@
 #include "Emu/Cell/lv2/sys_mmapper.h"
 #include "Emu/Cell/lv2/sys_event.h"
 #include "Thread.h"
+#include "hardware_breakpoint/hardware_breakpoint_manager.h"
 #include "sysinfo.h"
 #include <typeinfo>
 #include <thread>
@@ -1359,9 +1360,22 @@ static bool is_leaf_function(u64 rip)
 #endif
 }
 
+// Can't alter thread context while it inside an exception handler because
+// once it leaves the handler the context gets flushed
+extern thread_local bool g_inside_exception_handler = false;
+
 #ifdef _WIN32
 
+static LONG exception_handler_impl(PEXCEPTION_POINTERS pExp);
 static LONG exception_handler(PEXCEPTION_POINTERS pExp)
+{
+	g_inside_exception_handler = true;
+	auto result = exception_handler_impl(pExp);
+	g_inside_exception_handler = false;
+	return result;
+}
+
+static LONG exception_handler_impl(PEXCEPTION_POINTERS pExp)
 {
 	const u64 addr64 = pExp->ExceptionRecord->ExceptionInformation[1] - (u64)vm::g_base_addr;
 	const u64 exec64 = pExp->ExceptionRecord->ExceptionInformation[1] - (u64)vm::g_exec_addr;
@@ -1381,6 +1395,68 @@ static LONG exception_handler(PEXCEPTION_POINTERS pExp)
 		{
 			return EXCEPTION_CONTINUE_EXECUTION;
 		}
+	}
+
+	if (pExp->ExceptionRecord->ExceptionCode == EXCEPTION_SINGLE_STEP)
+	{
+		// Handle hardware breakpoint
+		bool any_hit = false;
+		const auto cpu = get_current_cpu_thread();
+		auto& breakpoints = hardware_breakpoint_manager::get_breakpoints((thread_handle)(cpu->get()->get_native_handle()));
+
+		for (u32 i = 0; i < 4; ++i)
+		{
+			// Low bits of dr6 indicate which breakpoint was triggered
+			if (!(pExp->ContextRecord->Dr6 & (1 << i)))
+				continue;
+
+			// Get accessed address
+			u64 accessed_address;
+			switch (i)
+			{
+			case 0:
+				accessed_address = pExp->ContextRecord->Dr0;
+				break;
+			case 1:
+				accessed_address = pExp->ContextRecord->Dr1;
+				break;
+			case 2:
+				accessed_address = pExp->ContextRecord->Dr2;
+				break;
+			case 3:
+				accessed_address = pExp->ContextRecord->Dr3;
+				break;
+			}
+
+			logs::GENERAL.success("Hardware breakpoint hit at: 0x%08X", accessed_address);
+
+			if (!any_hit)
+			{
+				any_hit = true;
+
+				if (cpu)
+				{
+					cpu->state += cpu_flag::dbg_pause;
+				}
+			}
+
+			auto found_breakpoint = std::find_if(breakpoints.begin(), breakpoints.end(), [&](auto x) { return x->get_index() == i; });
+			if (found_breakpoint != breakpoints.end())
+			{
+				auto breakpoint = found_breakpoint->get();
+
+				auto handler = breakpoint->get_handler();
+				if (handler != nullptr)
+				{
+					handler(*breakpoint);
+				}
+			}
+		}
+
+		// Clear DR6 -- status register
+		pExp->ContextRecord->Dr6 = 0;
+
+		return EXCEPTION_CONTINUE_EXECUTION;
 	}
 
 	return EXCEPTION_CONTINUE_SEARCH;
@@ -1483,7 +1559,7 @@ const bool s_exception_handler_set = []() -> bool
 
 #else
 
-static void signal_handler(int sig, siginfo_t* info, void* uct)
+static void segfault_signal_handler(int sig, siginfo_t* info, void* uct)
 {
 	x64_context* context = (ucontext_t*)uct;
 
@@ -1524,16 +1600,93 @@ static void signal_handler(int sig, siginfo_t* info, void* uct)
 	report_fatal_error(fmt::format("Segfault %s location %p at %p.", cause, info->si_addr, RIP(context)));
 }
 
+static void trap_signal_handler(int sig, siginfo_t* info, void* uct)
+{
+	auto context = static_cast<ucontext_t*>(uct);
+
+	// Handle hardware breakpoint
+	bool any_hit = false;
+	const auto cpu = get_current_cpu_thread();
+	auto& breakpoints = hardware_breakpoint_manager::get_breakpoints((thread_handle)(cpu->get()->get_native_handle()));
+
+	for (u32 i = 0; i < 4; ++i)
+	{
+		// Todo
+		//// Low bits of dr6 indicate which breakpoint was triggered
+		//if (!(pExp->ContextRecord->Dr6 & (1 << i)))
+		//	continue;
+
+		//// Get accessed address
+		//u64 accessed_address;
+		//switch (i)
+		//{
+		//case 0:
+		//	accessed_address = pExp->ContextRecord->Dr0;
+		//	break;
+		//case 1:
+		//	accessed_address = pExp->ContextRecord->Dr1;
+		//	break;
+		//case 2:
+		//	accessed_address = pExp->ContextRecord->Dr2;
+		//	break;
+		//case 3:
+		//	accessed_address = pExp->ContextRecord->Dr3;
+		//	break;
+		//}
+
+		//logs::GENERAL.success("Hardware breakpoint hit at: 0x%08X", accessed_address);
+
+		if (!any_hit)
+		{
+			any_hit = true;
+
+			if (cpu)
+			{
+				cpu->state += cpu_flag::dbg_pause;
+			}
+		}
+
+		auto found_breakpoint = std::find_if(breakpoints.begin(), breakpoints.end(), [&](auto x) { return x->get_index() == i; });
+		if (found_breakpoint != breakpoints.end())
+		{
+			auto breakpoint = found_breakpoint->get();
+
+			auto handler = breakpoint->get_handler();
+			if (handler != nullptr)
+			{
+				handler(*breakpoint);
+			}
+		}
+	}
+
+	// Todo
+	// Clear DR6
+	//pExp->ContextRecord->Dr6 = 0;
+}
+
 const bool s_exception_handler_set = []() -> bool
 {
-	struct ::sigaction sa;
-	sa.sa_flags = SA_SIGINFO;
-	sigemptyset(&sa.sa_mask);
-	sa.sa_sigaction = signal_handler;
+	// Set segfault handler
+	struct ::sigaction segfault_action;
+	segfault_action.sa_flags = SA_SIGINFO;
+	sigemptyset(&segfault_action.sa_mask);
+	segfault_action.sa_sigaction = segfault_signal_handler;
 
-	if (::sigaction(SIGSEGV, &sa, NULL) == -1)
+	if (::sigaction(SIGSEGV, &segfault_action, NULL) == -1)
 	{
 		std::printf("sigaction(SIGSEGV) failed (0x%x).", errno);
+		std::abort();
+	}
+
+	// Set trap handler
+	struct ::sigaction trap_action;
+	trap_action.sa_flags = SA_SIGINFO;
+	sigemptyset(&trap_action.sa_mask);
+	trap_action.sa_sigaction = trap_signal_handler;
+
+	if (::sigaction(SIGTRAP, &trap_action, NULL) == -1)
+	{
+		std::printf("sigaction(SIGTRAP) failed (0x%x).", errno);
 		std::abort();
 	}
 

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -172,6 +172,12 @@ public:
 		return m_name;
 	}
 
+	// Get platform native thread handle.
+	const std::uintptr_t get_native_handle() const
+	{
+		return m_thread.load();
+	}
+
 	// Get exception
 	std::exception_ptr get_exception() const;
 

--- a/Utilities/hardware_breakpoint/hardware_breakpoint_manager.cpp
+++ b/Utilities/hardware_breakpoint/hardware_breakpoint_manager.cpp
@@ -38,7 +38,7 @@ thread_breakpoints& hardware_breakpoint_manager::lookup_or_create_thread_breakpo
 	}
 }
 
-u32 hardware_breakpoint_manager::get_next_breakpoint_index(thread_breakpoints& breakpoints)
+u32 hardware_breakpoint_manager::get_next_breakpoint_index(const thread_breakpoints& breakpoints)
 {
 	u32 index = 0;
 	while (true)
@@ -68,8 +68,8 @@ u32 hardware_breakpoint_manager::get_next_breakpoint_index(thread_breakpoints& b
 
 extern thread_local bool g_inside_exception_handler;
 
-std::shared_ptr<hardware_breakpoint> hardware_breakpoint_manager::set(const thread_handle thread, const hardware_breakpoint_type type, 
-    const hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler)
+std::shared_ptr<hardware_breakpoint> hardware_breakpoint_manager::set(thread_handle thread, hardware_breakpoint_type type, 
+    hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler)
 {
 	if (g_inside_exception_handler)
 	{
@@ -99,7 +99,7 @@ std::shared_ptr<hardware_breakpoint> hardware_breakpoint_manager::set(const thre
 
 bool hardware_breakpoint_manager::remove(hardware_breakpoint& handle)
 {
-	auto& breakpoints = get_breakpoints(handle.get_thread());
+	auto& breakpoints = s_hardware_breakpoints[handle.get_thread()];
 	if (breakpoints.size() > 0)
 	{
 		breakpoints.erase(std::remove_if(breakpoints.begin(), breakpoints.end(), [&](std::shared_ptr<hardware_breakpoint> x) { return x.get()->get_index() == handle.get_index(); }), breakpoints.end());

--- a/Utilities/hardware_breakpoint/hardware_breakpoint_manager.cpp
+++ b/Utilities/hardware_breakpoint/hardware_breakpoint_manager.cpp
@@ -1,0 +1,129 @@
+
+#include "stdafx.h"
+#include "hardware_breakpoint_manager.h"
+#include "Utilities/Thread.h"
+#include <thread>
+#include <chrono>
+
+#ifdef _WIN32
+#include "windows_hardware_breakpoint_manager.h"
+#elif __linux__ 
+#include "linux_hardware_breakpoint_manager.h"
+#else
+#include "null_hardware_breakpoint_manager.h"
+#endif
+
+#ifdef _WIN32
+std::unique_ptr<hardware_breakpoint_manager_impl> hardware_breakpoint_manager::s_impl = std::make_unique<windows_hardware_breakpoint_manager>();
+#elif __linux__
+std::unique_ptr<hardware_breakpoint_manager_impl> hardware_breakpoint_manager::s_impl = std::make_unique<linux_hardware_breakpoint_manager>();
+#else
+std::unique_ptr<hardware_breakpoint_manager_impl> hardware_breakpoint_manager::s_impl = std::make_unique<null_hardware_breakpoint_manager>();
+#endif
+
+thread_breakpoints_lookup hardware_breakpoint_manager::s_hardware_breakpoints{};
+
+thread_breakpoints& hardware_breakpoint_manager::lookup_or_create_thread_breakpoints(thread_handle thread)
+{
+	auto found = s_hardware_breakpoints.find(thread);
+	if (found == s_hardware_breakpoints.end())
+	{
+		// Make new entry for thread
+		s_hardware_breakpoints[thread] = thread_breakpoints();
+		return s_hardware_breakpoints[thread];
+	}
+	else
+	{
+		return found->second;
+	}
+}
+
+u32 hardware_breakpoint_manager::get_next_breakpoint_index(thread_breakpoints& breakpoints)
+{
+	u32 index = 0;
+	while (true)
+	{
+		bool found_next_index = true;
+		for (auto breakpoint : breakpoints)
+		{
+			if (breakpoint->get_index() == index)
+			{
+				found_next_index = false;
+				break;
+			}
+		}
+
+		if (found_next_index)
+		{
+			break;
+		}
+		else
+		{
+			++index;
+		}
+	}
+
+	return index;
+}
+
+extern thread_local bool g_inside_exception_handler;
+
+std::shared_ptr<hardware_breakpoint> hardware_breakpoint_manager::set(const thread_handle thread, const hardware_breakpoint_type type, 
+    const hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler)
+{
+	if (g_inside_exception_handler)
+	{
+		// Can't set context (registers) inside exception handler
+		return nullptr;
+	}
+
+	auto& breakpoints = lookup_or_create_thread_breakpoints(thread);
+
+	// Max amount of hw breakpoints is 4
+	if (breakpoints.size() >= 4)
+	{
+		return nullptr;
+	}
+
+	// Find next available index
+	u32 index = get_next_breakpoint_index(breakpoints);
+
+	auto handle = s_impl->set(index, thread, type, size, address, handler);
+	if (handle != nullptr)
+	{
+		breakpoints.push_back(handle);
+	}
+
+	return handle;
+};
+
+bool hardware_breakpoint_manager::remove(hardware_breakpoint& handle)
+{
+	auto& breakpoints = get_breakpoints(handle.get_thread());
+	if (breakpoints.size() > 0)
+	{
+		breakpoints.erase(std::remove_if(breakpoints.begin(), breakpoints.end(), [&](std::shared_ptr<hardware_breakpoint> x) { return x.get()->get_index() == handle.get_index(); }), breakpoints.end());
+	}
+
+	if (g_inside_exception_handler)
+	{
+		// We're inside an exception handler, so we can't change the debug registers
+		// so just spawn a thread that disables the breakpoint when we've left the exception
+		// handler
+		bool* inside_exception_handler = &g_inside_exception_handler;
+
+		thread_ctrl::spawn("hardware_breakpoint_remover", [&]()
+		{
+			while (*inside_exception_handler)
+				std::this_thread::sleep_for(std::chrono::nanoseconds(100));
+
+			s_impl->remove(handle);
+		});
+
+		return true;
+	}
+	else
+	{
+		return s_impl->remove(handle);
+	}
+};

--- a/Utilities/hardware_breakpoint/hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/hardware_breakpoint_manager.h
@@ -43,7 +43,6 @@ using thread_handle = int;
 #endif
 
 class hardware_breakpoint;
-//typedef void(*hardware_breakpoint_handler)(hardware_breakpoint&);
 using hardware_breakpoint_handler = std::function<void(hardware_breakpoint&)>;
 
 // Represents a hardware breakpoint, read only.
@@ -69,22 +68,22 @@ protected:
 
 public:
 	// Gets the index of the breakpoint (out of 4)
-	inline const u32 get_index() { return m_index; }
+	inline u32 get_index() const { return m_index; }
 
 	// Gets the thread the breakpoint applies to.
-	inline const thread_handle get_thread() { return m_thread; }
+	inline thread_handle get_thread() const { return m_thread; }
 
     // Gets the type of breakpoint.
-	inline const hardware_breakpoint_type get_type() { return m_type; }
+	inline hardware_breakpoint_type get_type() const { return m_type; }
 
     // Gets the size of the breakpoint.
-	inline const hardware_breakpoint_size get_size() { return m_size; }
+	inline hardware_breakpoint_size get_size() const { return m_size; }
 
     // Gets the address of the breakpoint.
-	inline const u64 get_address() { return m_address; }
+	inline u64 get_address() const { return m_address; }
 
     // Gets the handler of the breakpoint.
-	inline const hardware_breakpoint_handler& get_handler() { return m_handler; }
+	inline const hardware_breakpoint_handler& get_handler() const { return m_handler; }
 };
 
 class hardware_breakpoint_manager_impl;
@@ -101,15 +100,15 @@ private:
 	static thread_breakpoints_lookup s_hardware_breakpoints;
 
 	static thread_breakpoints& lookup_or_create_thread_breakpoints(thread_handle thread);
-	static u32 get_next_breakpoint_index(thread_breakpoints& breakpoints);
+	static u32 get_next_breakpoint_index(const thread_breakpoints& breakpoints);
 
 public:
 
 	// Gets the map containing all of the breakpoints for all threads. Unused entries are null.
-	inline static thread_breakpoints_lookup& get_breakpoints() { return s_hardware_breakpoints; }
+	inline static const thread_breakpoints_lookup& get_breakpoints() { return s_hardware_breakpoints; }
 
 	// Gets the array of breakpoints assigned to the given thread. Unused entries are null.
-	inline static thread_breakpoints& get_breakpoints(thread_handle thread)
+	inline static const thread_breakpoints& get_breakpoints(thread_handle thread) 
 	{
 		return s_hardware_breakpoints[thread];
 	}
@@ -121,5 +120,6 @@ public:
 		const hardware_breakpoint_handler& handler);
 
     // Removes a hardware breakpoint previously set.
-    static bool remove(hardware_breakpoint& handle);
+	// The breakpoint is considered invalid after this function has been called.
+    static bool remove(hardware_breakpoint& breakpoint);
 };

--- a/Utilities/hardware_breakpoint/hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/hardware_breakpoint_manager.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "stdafx.h"
+
+// Represents the type of hardware breakpoint.
+enum class hardware_breakpoint_type
+{
+    // Breaks when the CPU tries to execute instructions
+    // at the address.
+	// Only valid in combination with hardware_breakpoint_size::size_1.
+    executable = 0,
+
+    // Breaks when the memory at the address is written to.
+    write = 1,
+
+	// Breaks when the memory at the address is read or
+	// written to.
+	read_write = 3,
+};
+
+// Represents the size of a hardware breakpoint.
+// The 'size' refers to the range of bytes watched at
+// the address.
+enum class hardware_breakpoint_size
+{
+    // 1 byte.
+    size_1 = 0,
+
+    // 2 bytes.
+    size_2 = 1,
+
+    // 4 bytes.
+    size_4 = 3,
+
+    // 8 bytes.
+    size_8 = 2
+};
+
+#ifdef _WIN32
+using thread_handle = void*;
+#else
+using thread_handle = int;
+#endif
+
+class hardware_breakpoint;
+//typedef void(*hardware_breakpoint_handler)(hardware_breakpoint&);
+using hardware_breakpoint_handler = std::function<void(hardware_breakpoint&)>;
+
+// Represents a hardware breakpoint, read only.
+class hardware_breakpoint
+{
+    friend class windows_hardware_breakpoint_manager;
+    friend class linux_hardware_breakpoint_manager;
+
+private:
+	u32 m_index;
+	thread_handle m_thread;
+    hardware_breakpoint_type m_type;
+    hardware_breakpoint_size m_size;
+    u64 m_address;
+    const hardware_breakpoint_handler m_handler;
+
+protected:
+    hardware_breakpoint(const u32 index, const thread_handle thread, const hardware_breakpoint_type type,
+		const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler)
+        : m_index(index), m_thread(thread), m_type(type), m_size(size), m_address(address), m_handler(handler)
+    {
+    }
+
+public:
+	// Gets the index of the breakpoint (out of 4)
+	inline const u32 get_index() { return m_index; }
+
+	// Gets the thread the breakpoint applies to.
+	inline const thread_handle get_thread() { return m_thread; }
+
+    // Gets the type of breakpoint.
+	inline const hardware_breakpoint_type get_type() { return m_type; }
+
+    // Gets the size of the breakpoint.
+	inline const hardware_breakpoint_size get_size() { return m_size; }
+
+    // Gets the address of the breakpoint.
+	inline const u64 get_address() { return m_address; }
+
+    // Gets the handler of the breakpoint.
+	inline const hardware_breakpoint_handler& get_handler() { return m_handler; }
+};
+
+class hardware_breakpoint_manager_impl;
+using thread_breakpoints = std::vector<std::shared_ptr<hardware_breakpoint>>;
+using thread_breakpoints_lookup = std::unordered_map<thread_handle, thread_breakpoints>;
+
+// Static utility class for setting and removing hardware breakpoints.
+class hardware_breakpoint_manager final
+{
+private:
+	hardware_breakpoint_manager() {}
+
+    static std::unique_ptr<hardware_breakpoint_manager_impl> s_impl;
+	static thread_breakpoints_lookup s_hardware_breakpoints;
+
+	static thread_breakpoints& lookup_or_create_thread_breakpoints(thread_handle thread);
+	static u32 get_next_breakpoint_index(thread_breakpoints& breakpoints);
+
+public:
+
+	// Gets the map containing all of the breakpoints for all threads. Unused entries are null.
+	inline static thread_breakpoints_lookup& get_breakpoints() { return s_hardware_breakpoints; }
+
+	// Gets the array of breakpoints assigned to the given thread. Unused entries are null.
+	inline static thread_breakpoints& get_breakpoints(thread_handle thread)
+	{
+		return s_hardware_breakpoints[thread];
+	}
+
+    // Sets a hardware breakpoint for the given thread. Only up to 4 hardware breakpoints are supported.
+    // Returns nullptr on failure.
+    static std::shared_ptr<hardware_breakpoint> set(const thread_handle thread,
+		const hardware_breakpoint_type type, const hardware_breakpoint_size size, const u64 address,
+		const hardware_breakpoint_handler& handler);
+
+    // Removes a hardware breakpoint previously set.
+    static bool remove(hardware_breakpoint& handle);
+};

--- a/Utilities/hardware_breakpoint/hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/hardware_breakpoint_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "stdafx.h"
+#include <mutex>
 
 // Represents the type of hardware breakpoint.
 enum class hardware_breakpoint_type
@@ -98,6 +99,7 @@ private:
 
     static std::unique_ptr<hardware_breakpoint_manager_impl> s_impl;
 	static thread_breakpoints_lookup s_hardware_breakpoints;
+	static std::mutex s_mutex;
 
 	static thread_breakpoints& lookup_or_create_thread_breakpoints(thread_handle thread);
 	static u32 get_next_breakpoint_index(const thread_breakpoints& breakpoints);
@@ -108,7 +110,7 @@ public:
 	inline static const thread_breakpoints_lookup& get_breakpoints() { return s_hardware_breakpoints; }
 
 	// Gets the array of breakpoints assigned to the given thread. Unused entries are null.
-	inline static const thread_breakpoints& get_breakpoints(thread_handle thread) 
+	inline static const thread_breakpoints& get_breakpoints(thread_handle thread)
 	{
 		return s_hardware_breakpoints[thread];
 	}

--- a/Utilities/hardware_breakpoint/hardware_breakpoint_manager_impl.h
+++ b/Utilities/hardware_breakpoint/hardware_breakpoint_manager_impl.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "hardware_breakpoint_manager.h"
+
+// Abstract interface for hardware breakpoints
+class hardware_breakpoint_manager_impl
+{
+    friend class hardware_breakpoint_manager;
+
+protected:
+    virtual std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread, const hardware_breakpoint_type type, 
+        const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler) = 0;
+
+    virtual bool remove(hardware_breakpoint& handle) = 0;
+
+public:
+	// Todo: move to general utility?
+	inline static void set_bits(u64* value, u32 start_index, u32 bit_count, u32 new_value)
+	{
+		u64 mask = (1 << bit_count) - 1;
+		*value = (*value & ~(mask << start_index)) | (new_value << start_index);
+	}
+
+	inline static void set_debug_control_register(u64* reg, u32 index, hardware_breakpoint_type type, hardware_breakpoint_size size, bool enable)
+	{
+		set_bits(reg, (index * 2), 1, static_cast<u32>(enable));
+		set_bits(reg, 16 + index * 4, 2, static_cast<u32>(type));
+		set_bits(reg, 18 + index * 4, 2, static_cast<u32>(size));
+	}
+};
+

--- a/Utilities/hardware_breakpoint/hardware_breakpoint_manager_impl.h
+++ b/Utilities/hardware_breakpoint/hardware_breakpoint_manager_impl.h
@@ -8,8 +8,8 @@ class hardware_breakpoint_manager_impl
     friend class hardware_breakpoint_manager;
 
 protected:
-    virtual std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread, const hardware_breakpoint_type type, 
-        const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler) = 0;
+    virtual std::shared_ptr<hardware_breakpoint> set(u32 index, thread_handle thread, hardware_breakpoint_type type, 
+        hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler) = 0;
 
     virtual bool remove(hardware_breakpoint& handle) = 0;
 

--- a/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.cpp
+++ b/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.cpp
@@ -1,0 +1,89 @@
+
+#include "stdafx.h"
+
+#ifdef __linux__
+#include "linux_hardware_breakpoint_manager.h"
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/ptrace.h>
+#include <sys/user.h>
+#include <sys/prctl.h>
+#include <cstddef>
+
+// based on https://github.com/whh8b/hwbp_lib/blob/master/hwbp_lib.c
+// untested
+bool linux_hardware_breakpoint_manager::set_debug_register_values(u32 index, pid_t thread, hardware_breakpoint_type type, hardware_breakpoint_size size, u32 address, bool enable)
+{
+	s32 child_status = 0;
+
+	pid_t child;
+	if (!(child = fork()))
+	{
+		// Child process
+		s32 parent_status;
+		if (ptrace(PTRACE_ATTACH, thread, nullptr, nullptr))
+		{
+			_exit(1);
+		}
+
+		while (!WIFSTOPPED(parent_status))
+			waitpid(thread, &parent_status, 0);
+
+		// Set the breakpoint address.
+		if (ptrace(PTRACE_POKEUSER, thread, offsetof(struct user, u_debugreg[index]), address))
+		{
+			_exit(1);
+		}
+
+		// Fetch control register data
+		s64 control_register = ptrace(PTRACE_PEEKUSER, thread, offsetof(struct user, u_debugreg[7]));
+		if (control_register == -1)
+			_exit(1);
+
+		// Set control flags
+		hardware_breakpoint_manager_impl::set_debug_control_register(reinterpret_cast<u64*>(&control_register), index,
+			type, size, enable);
+
+		// Set control register value
+		if (ptrace(PTRACE_POKEUSER, thread, offsetof(struct user, u_debugreg[7]), control_register))
+		{
+			_exit(1);
+		}
+
+		if (ptrace(PTRACE_DETACH, thread, nullptr, nullptr))
+		{
+			_exit(1);
+		}
+
+		_exit(0);
+	}
+
+	waitpid(child, &child_status, 0);
+
+	if (WIFEXITED(child_status) && !WEXITSTATUS(child_status))
+	{
+		return true;
+	}
+
+	return false;
+}
+
+std::shared_ptr<hardware_breakpoint> linux_hardware_breakpoint_manager::set(const u32 index, const thread_handle thread,
+	const hardware_breakpoint_type type, const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler)
+{
+	if (!set_debug_register_values(index, static_cast<pid_t>(thread), type, size, address, true))
+	{
+		return nullptr;
+	}
+
+	return std::shared_ptr<hardware_breakpoint>(new hardware_breakpoint(index, thread, type, size, address, handler));
+}
+
+bool linux_hardware_breakpoint_manager::remove(hardware_breakpoint& handle)
+{
+	return set_debug_register_values(handle.get_index(), static_cast<pid_t>(handle.get_thread()), static_cast<hardware_breakpoint_type>(0),
+		static_cast<hardware_breakpoint_size>(0), 0, false);
+}
+
+#endif // #ifdef __linux__

--- a/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.cpp
+++ b/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.cpp
@@ -69,8 +69,8 @@ bool linux_hardware_breakpoint_manager::set_debug_register_values(u32 index, pid
 	return false;
 }
 
-std::shared_ptr<hardware_breakpoint> linux_hardware_breakpoint_manager::set(const u32 index, const thread_handle thread,
-	const hardware_breakpoint_type type, const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler)
+std::shared_ptr<hardware_breakpoint> linux_hardware_breakpoint_manager::set(u32 index, thread_handle thread,
+	hardware_breakpoint_type type, hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler)
 {
 	if (!set_debug_register_values(index, static_cast<pid_t>(thread), type, size, address, true))
 	{

--- a/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.cpp
+++ b/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.cpp
@@ -10,9 +10,9 @@
 #include <sys/user.h>
 #include <sys/prctl.h>
 #include <cstddef>
+#include <unistd.h>
 
 // based on https://github.com/whh8b/hwbp_lib/blob/master/hwbp_lib.c
-// untested
 bool linux_hardware_breakpoint_manager::set_debug_register_values(u32 index, pid_t thread, hardware_breakpoint_type type, hardware_breakpoint_size size, u32 address, bool enable)
 {
 	s32 child_status = 0;
@@ -72,6 +72,9 @@ bool linux_hardware_breakpoint_manager::set_debug_register_values(u32 index, pid
 std::shared_ptr<hardware_breakpoint> linux_hardware_breakpoint_manager::set(u32 index, thread_handle thread,
 	hardware_breakpoint_type type, hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler)
 {
+	// todo: doesn't work properly but don't have a linux debugging environment to fix it
+	return nullptr;
+
 	if (!set_debug_register_values(index, static_cast<pid_t>(thread), type, size, address, true))
 	{
 		return nullptr;
@@ -82,6 +85,9 @@ std::shared_ptr<hardware_breakpoint> linux_hardware_breakpoint_manager::set(u32 
 
 bool linux_hardware_breakpoint_manager::remove(hardware_breakpoint& handle)
 {
+	// todo
+	return false;
+
 	return set_debug_register_values(handle.get_index(), static_cast<pid_t>(handle.get_thread()), static_cast<hardware_breakpoint_type>(0),
 		static_cast<hardware_breakpoint_size>(0), 0, false);
 }

--- a/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#ifdef __linux__
+
+#include "hardware_breakpoint_manager_impl.h"
+
+class linux_hardware_breakpoint_manager : public hardware_breakpoint_manager_impl
+{
+protected:
+	std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread, const hardware_breakpoint_type type,
+		const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler) final;
+
+	bool remove(hardware_breakpoint& handle) final;
+
+	bool set_debug_register_values(u32 index, pid_t thread, hardware_breakpoint_type type, hardware_breakpoint_size size, u32 address, bool enable);
+};
+
+#endif // #ifdef __linux__

--- a/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/linux_hardware_breakpoint_manager.h
@@ -4,11 +4,11 @@
 
 #include "hardware_breakpoint_manager_impl.h"
 
-class linux_hardware_breakpoint_manager : public hardware_breakpoint_manager_impl
+class linux_hardware_breakpoint_manager final : public hardware_breakpoint_manager_impl
 {
 protected:
-	std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread, const hardware_breakpoint_type type,
-		const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler) final;
+	std::shared_ptr<hardware_breakpoint> set(u32 index, thread_handle thread, hardware_breakpoint_type type,
+		hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler) final;
 
 	bool remove(hardware_breakpoint& handle) final;
 

--- a/Utilities/hardware_breakpoint/null_hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/null_hardware_breakpoint_manager.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "hardware_breakpoint_manager_impl.h"
+
+class null_hardware_breakpoint_manager : public hardware_breakpoint_manager_impl
+{
+protected:
+    std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread, const hardware_breakpoint_type type,
+        const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler) 
+    { 
+        return nullptr;
+    };
+
+    bool remove(hardware_breakpoint& handle) { return false; };
+};

--- a/Utilities/hardware_breakpoint/null_hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/null_hardware_breakpoint_manager.h
@@ -2,11 +2,11 @@
 
 #include "hardware_breakpoint_manager_impl.h"
 
-class null_hardware_breakpoint_manager : public hardware_breakpoint_manager_impl
+class null_hardware_breakpoint_manager final : public hardware_breakpoint_manager_impl
 {
 protected:
-    std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread, const hardware_breakpoint_type type,
-        const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler) 
+    std::shared_ptr<hardware_breakpoint> set(u32 index, thread_handle thread, hardware_breakpoint_type type,
+        hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler)
     { 
         return nullptr;
     };

--- a/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.cpp
+++ b/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.cpp
@@ -1,0 +1,138 @@
+
+#include "stdafx.h"
+
+#ifdef _WIN32
+
+#include "windows_hardware_breakpoint_manager.h"
+#include <Windows.h>
+
+static DWORD WINAPI thread_proc(LPVOID lpParameter);
+
+std::shared_ptr<hardware_breakpoint> windows_hardware_breakpoint_manager::set(const u32 index,
+	const thread_handle thread, hardware_breakpoint_type type, hardware_breakpoint_size size,
+	u64 address, const hardware_breakpoint_handler& handler)
+{
+	auto handle = new hardware_breakpoint(index, thread, type, size, address, handler);
+	auto context = std::make_unique<windows_hardware_breakpoint_context>();
+	context->m_handle = handle;
+	context->m_is_setting = true;
+	context->m_success = false;
+
+	bool should_close_thread = false;
+    if (thread == GetCurrentThread())
+    {
+        auto pid = GetCurrentThreadId();
+		handle->m_thread = OpenThread(THREAD_ALL_ACCESS, 0, pid);
+		should_close_thread = true;
+    }
+
+    auto handler_thread_handle = CreateThread(0, 0, thread_proc, static_cast<LPVOID>(context.get()), 0, 0);
+    WaitForSingleObject(handler_thread_handle, INFINITE);
+    CloseHandle(handler_thread_handle);
+
+    if (should_close_thread)
+    {
+        CloseHandle(handle->m_thread);
+    }
+
+	handle->m_thread = thread;
+
+    if (!context->m_success)
+    {
+		delete handle;
+        return nullptr;
+    }
+
+	return std::shared_ptr<hardware_breakpoint>(handle);
+};
+
+// Removes a hardware breakpoint previously set.
+bool windows_hardware_breakpoint_manager::remove(hardware_breakpoint& handle)
+{
+	bool should_close_thread = false;
+	if (handle.m_thread == GetCurrentThread())
+	{
+		auto pid = GetCurrentThreadId();
+		handle.m_thread = OpenThread(THREAD_ALL_ACCESS, 0, pid);
+		should_close_thread = true;
+	}
+
+	auto context = std::make_unique<windows_hardware_breakpoint_context>();
+	context->m_handle = &handle;
+	context->m_is_setting = false;
+	context->m_success = false;
+
+	auto handler_thread_handle = CreateThread(0, 0, thread_proc, static_cast<LPVOID>(context.get()), 0, 0);
+	WaitForSingleObject(handler_thread_handle, INFINITE);
+	CloseHandle(handler_thread_handle);
+
+	if (should_close_thread)
+	{
+		CloseHandle(handle.m_thread);
+	}
+
+	return context->m_success;
+};
+
+inline static void set_debug_register_value(CONTEXT* context, u32 index, u64 value)
+{
+	if (index == 0)
+	{
+		context->Dr0 = value;
+	}
+	else if (index == 1)
+	{
+		context->Dr1 = value;
+	}
+	else if (index == 2)
+	{
+		context->Dr2 = value;
+	}
+	else if (index == 3)
+	{
+		context->Dr3 = value;
+	}
+}
+
+static DWORD WINAPI thread_proc(LPVOID lpParameter)
+{
+    auto context = static_cast<windows_hardware_breakpoint_context*>(lpParameter);
+	auto handle = context->m_handle;
+	auto other_thread = handle->get_thread();
+
+    SuspendThread(other_thread);
+
+	// Get debug registers from other thread
+    CONTEXT thread_context = {0};
+    thread_context.ContextFlags = CONTEXT_DEBUG_REGISTERS;
+    GetThreadContext(other_thread, &thread_context);
+
+    if (context->m_is_setting)
+    {
+		// Set breakpoint address
+		set_debug_register_value(&thread_context, handle->get_index(), handle->get_address());
+
+		// Set control flags
+		hardware_breakpoint_manager_impl::set_debug_control_register(&thread_context.Dr7, handle->get_index(),
+			handle->get_type(), handle->get_size(), true);
+    }
+    else
+    {
+		// Clear breakpoint address
+		set_debug_register_value(&thread_context, handle->get_index(), 0);
+
+		// Set control flags
+		hardware_breakpoint_manager_impl::set_debug_control_register(&thread_context.Dr7, handle->get_index(),
+			static_cast<hardware_breakpoint_type>(0), static_cast<hardware_breakpoint_size>(0), false);
+    }
+
+	// Set debug registers
+    thread_context.ContextFlags = CONTEXT_DEBUG_REGISTERS;
+    SetThreadContext(other_thread, &thread_context);
+
+    context->m_success = true;
+    ResumeThread(other_thread);
+    return 0;
+}
+
+#endif // #ifdef _WIN32

--- a/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.cpp
+++ b/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.cpp
@@ -8,8 +8,8 @@
 
 static DWORD WINAPI thread_proc(LPVOID lpParameter);
 
-std::shared_ptr<hardware_breakpoint> windows_hardware_breakpoint_manager::set(const u32 index,
-	const thread_handle thread, hardware_breakpoint_type type, hardware_breakpoint_size size,
+std::shared_ptr<hardware_breakpoint> windows_hardware_breakpoint_manager::set(u32 index,
+	thread_handle thread, hardware_breakpoint_type type, hardware_breakpoint_size size,
 	u64 address, const hardware_breakpoint_handler& handler)
 {
 	auto handle = new hardware_breakpoint(index, thread, type, size, address, handler);

--- a/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include "hardware_breakpoint_manager_impl.h"
+
+struct windows_hardware_breakpoint_context
+{
+	hardware_breakpoint* m_handle;
+	bool m_is_setting;
+	bool m_success;
+};
+
+class windows_hardware_breakpoint_manager : public hardware_breakpoint_manager_impl
+{
+protected:
+    std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread,
+        const hardware_breakpoint_type type, const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler) final;
+
+    bool remove(hardware_breakpoint& handle) final;
+};
+
+#endif // #ifdef _WIN32

--- a/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.h
@@ -11,7 +11,7 @@ struct windows_hardware_breakpoint_context
 	bool m_success;
 };
 
-class windows_hardware_breakpoint_manager : public hardware_breakpoint_manager_impl
+class windows_hardware_breakpoint_manager final : public hardware_breakpoint_manager_impl
 {
 protected:
     std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread,

--- a/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.h
+++ b/Utilities/hardware_breakpoint/windows_hardware_breakpoint_manager.h
@@ -14,8 +14,8 @@ struct windows_hardware_breakpoint_context
 class windows_hardware_breakpoint_manager final : public hardware_breakpoint_manager_impl
 {
 protected:
-    std::shared_ptr<hardware_breakpoint> set(const u32 index, const thread_handle thread,
-        const hardware_breakpoint_type type, const hardware_breakpoint_size size, const u64 address, const hardware_breakpoint_handler& handler) final;
+    std::shared_ptr<hardware_breakpoint> set(u32 index, thread_handle thread,
+        hardware_breakpoint_type type, hardware_breakpoint_size size, u64 address, const hardware_breakpoint_handler& handler) final;
 
     bool remove(hardware_breakpoint& handle) final;
 };

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -82,6 +82,9 @@
     <ClCompile Include="..\Utilities\GDBDebugServer.cpp">
       <PrecompiledHeader>Use</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\Utilities\hardware_breakpoint\hardware_breakpoint_manager.cpp" />
+    <ClCompile Include="..\Utilities\hardware_breakpoint\linux_hardware_breakpoint_manager.cpp" />
+    <ClCompile Include="..\Utilities\hardware_breakpoint\windows_hardware_breakpoint_manager.cpp" />
     <ClCompile Include="..\Utilities\JIT.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
@@ -429,6 +432,11 @@
     <ClInclude Include="..\Utilities\GDBDebugServer.h" />
     <ClInclude Include="..\Utilities\geometry.h" />
     <ClInclude Include="..\Utilities\GSL.h" />
+    <ClInclude Include="..\Utilities\hardware_breakpoint\hardware_breakpoint_manager.h" />
+    <ClInclude Include="..\Utilities\hardware_breakpoint\hardware_breakpoint_manager_impl.h" />
+    <ClInclude Include="..\Utilities\hardware_breakpoint\linux_hardware_breakpoint_manager.h" />
+    <ClInclude Include="..\Utilities\hardware_breakpoint\null_hardware_breakpoint_manager.h" />
+    <ClInclude Include="..\Utilities\hardware_breakpoint\windows_hardware_breakpoint_manager.h" />
     <ClInclude Include="..\Utilities\hash.h" />
     <ClInclude Include="..\Utilities\JIT.h" />
     <ClInclude Include="..\Utilities\lockless.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -69,6 +69,9 @@
     <Filter Include="Emu\PSP2\Modules">
       <UniqueIdentifier>{1d9e6fc4-9a79-4329-a8b5-081e24822aaa}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Utilities\hardware_breakpoint">
+      <UniqueIdentifier>{9d54d112-0440-44b2-ab6f-5dab86a2c687}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Crypto\aes.cpp">
@@ -937,6 +940,16 @@
     </ClCompile>
     <ClCompile Include="Emu\Io\PadHandler.cpp">
       <Filter>Emu\Io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Utilities\hardware_breakpoint\hardware_breakpoint_manager.cpp">
+      <Filter>Utilities\hardware_breakpoint</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Utilities\hardware_breakpoint\linux_hardware_breakpoint_manager.cpp">
+      <Filter>Utilities\hardware_breakpoint</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Utilities\hardware_breakpoint\windows_hardware_breakpoint_manager.cpp">
+      <Filter>Utilities\hardware_breakpoint</Filter>
+    </ClCompile>
 	</ClCompile>
     <ClCompile Include="Emu\RSX\overlays.cpp">
       <Filter>Emu\GPU\RSX</Filter>
@@ -1812,6 +1825,21 @@
     </ClInclude>
     <ClInclude Include="Emu\Cell\lv2\sys_net.h">
       <Filter>Emu\Cell\lv2</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utilities\hardware_breakpoint\hardware_breakpoint_manager.h">
+      <Filter>Utilities\hardware_breakpoint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utilities\hardware_breakpoint\linux_hardware_breakpoint_manager.h">
+      <Filter>Utilities\hardware_breakpoint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utilities\hardware_breakpoint\null_hardware_breakpoint_manager.h">
+      <Filter>Utilities\hardware_breakpoint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utilities\hardware_breakpoint\windows_hardware_breakpoint_manager.h">
+      <Filter>Utilities\hardware_breakpoint</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utilities\hardware_breakpoint\hardware_breakpoint_manager_impl.h">
+      <Filter>Utilities\hardware_breakpoint</Filter>
     </ClInclude>
     <ClInclude Include="Emu\RSX\overlay_controls.h">
       <Filter>Emu\GPU\RSX</Filter>


### PR DESCRIPTION
Commonly used for memory breakpoints. Will be integrated into GUI debugger later.
Linux implementation is WIP and untested as I'm on Windows 10. Should build & work at least though.
Edit: Linux implementation doesn't work as intended but I can't debug it myself, so I left it in as dead code.

Usage:
```
auto native_handle = (thread_handle)thread.get()->get_native_handle();
auto handle = hardware_breakpoint_manager::set(native_handle, hardware_breakpoint_type::read_write, hardware_breakpoint_size::size_4, (u64)vm::g_base_addr + 0x1166B14, [](hardware_breakpoint& breakpoint)
{
    logs::GENERAL::success("memory breakpoint hit at %s", breakpoint.get_address());
    hardware_breakpoint_manager::remove(breakpoint);
});
```