### PR TITLE
None shader preloading

### DIFF
--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -290,6 +290,11 @@ namespace rsx
 		template <typename... Args>
 		void load(Args&& ...args)
 		{
+			if (g_cfg.video.disable_on_disk_shader_cache)
+			{
+				return;
+			}
+
 			std::string directory_path = root_path + "/pipelines/" + pipeline_class_name;
 
 			if (!fs::is_dir(directory_path))
@@ -378,6 +383,11 @@ namespace rsx
 
 		void store(pipeline_storage_type &pipeline, RSXVertexProgram &vp, RSXFragmentProgram &fp)
 		{
+			if (g_cfg.video.disable_on_disk_shader_cache)
+			{
+				return;
+			}
+
 			pipeline_data data = pack(pipeline, vp, fp);
 			std::string fp_name = root_path + "/raw/" + fmt::format("%llX.fp", data.fragment_program_hash);
 			std::string vp_name = root_path + "/raw/" + fmt::format("%llX.vp", data.vertex_program_hash);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -342,6 +342,7 @@ struct cfg_root : cfg::node
 		cfg::_bool strict_rendering_mode{this, "Strict Rendering Mode"};
 		cfg::_bool disable_zcull_queries{this, "Disable ZCull Occlusion Queries", false};
 		cfg::_bool disable_vertex_cache{this, "Disable Vertex Cache", false};
+		cfg::_bool disable_on_disk_shader_cache{this, "Disable On-Disk Shader Cache", false};
 		cfg::_bool frame_skip_enabled{this, "Enable Frame Skip", false};
 		cfg::_bool force_cpu_blit_processing{this, "Force CPU Blit", false}; //Debugging option
 		cfg::_int<1, 8> consequtive_frames_to_draw{this, "Consecutive Frames To Draw", 1};

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -342,9 +342,9 @@ struct cfg_root : cfg::node
 		cfg::_bool strict_rendering_mode{this, "Strict Rendering Mode"};
 		cfg::_bool disable_zcull_queries{this, "Disable ZCull Occlusion Queries", false};
 		cfg::_bool disable_vertex_cache{this, "Disable Vertex Cache", false};
-		cfg::_bool disable_on_disk_shader_cache{this, "Disable On-Disk Shader Cache", false};
 		cfg::_bool frame_skip_enabled{this, "Enable Frame Skip", false};
-		cfg::_bool force_cpu_blit_processing{this, "Force CPU Blit", false}; //Debugging option
+		cfg::_bool force_cpu_blit_processing{this, "Force CPU Blit", false}; // Debugging option
+		cfg::_bool disable_on_disk_shader_cache{this, "Disable On-Disk Shader Cache", false};
 		cfg::_int<1, 8> consequtive_frames_to_draw{this, "Consecutive Frames To Draw", 1};
 		cfg::_int<1, 8> consequtive_frames_to_skip{this, "Consecutive Frames To Skip", 1};
 		cfg::_int<50, 800> resolution_scale_percent{this, "Resolution Scale", 100};

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -46,7 +46,8 @@
 		"debugOverlay": "Provides a graphical overlay of various debugging information.\nIf unsure, don't use this option.",
 		"logProg": "Dump game shaders to file. Only useful to developers.\nIf unsure, don't use this option.",
 		"disableOcclusionQueries": "Disables running occlusion queries. Minor to moderate performance boost.\nMight introduce issues with broken occlusion e.g missing geometry and extreme pop-in.",
-		"forceCpuBlitEmulation": "Forces emulation of all blit and image manipulation operations on the CPU.\nRequires 'Write Color Buffers' option to also be enabled in most cases to avoid missing graphics.\nSignificantly degrades performance but is more accurate in some cases.\nThis setting overrides the 'GPU texture scaling' option."
+		"forceCpuBlitEmulation": "Forces emulation of all blit and image manipulation operations on the CPU.\nRequires 'Write Color Buffers' option to also be enabled in most cases to avoid missing graphics.\nSignificantly degrades performance but is more accurate in some cases.\nThis setting overrides the 'GPU texture scaling' option.",
+		"disableOnDiskShaderCache": "Disables the loading and saving of shaders from and to the shader cache in the data directory."
 	},
 	"emulator": {
 		"gui": {

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -63,6 +63,7 @@ public:
 		ResolutionScale,
 		MinimumScalableDimension,
 		ForceCPUBlitEmulation,
+		DisableOnDiskShaderCache,
 
 		// Audio
 		AudioRenderer,
@@ -213,6 +214,7 @@ private:
 		{ DisableVertexCache,       { "Video", "Disable Vertex Cache"}},
 		{ DisableOcclusionQueries,  { "Video", "Disable ZCull Occlusion Queries" }},
 		{ ForceCPUBlitEmulation,    { "Video", "Force CPU Blit" }},
+		{ DisableOnDiskShaderCache, { "Video", "Disable On-Disk Shader Cache"}},
 		{ AnisotropicFilterOverride,{ "Video", "Anisotropic Filter Override" }},
 		{ ResolutionScale,          { "Video", "Resolution Scale" }},
 		{ MinimumScalableDimension, { "Video", "Minimum Scalable Dimension" }},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -954,6 +954,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xemu_settings->EnhanceCheckBox(ui->forceCpuBlitEmulation, emu_settings::ForceCPUBlitEmulation);
 	SubscribeTooltip(ui->forceCpuBlitEmulation, json_debug["forceCpuBlitEmulation"].toString());
 
+	xemu_settings->EnhanceCheckBox(ui->disableOnDiskShaderCache, emu_settings::DisableOnDiskShaderCache);
+	SubscribeTooltip(ui->disableOnDiskShaderCache, json_debug["disableOnDiskShaderCache"].toString());
+
 	// Checkboxes: core debug options
 	xemu_settings->EnhanceCheckBox(ui->ppuDebug, emu_settings::PPUDebug);
 	SubscribeTooltip(ui->ppuDebug, json_debug["ppuDebug"].toString());

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -36,7 +36,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>7</number>
      </property>
      <widget class="QWidget" name="coreTab">
       <attribute name="title">
@@ -1663,6 +1663,13 @@
              <widget class="QCheckBox" name="forceCpuBlitEmulation">
               <property name="text">
                <string>Force CPU blit emulation</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="disableOnDiskShaderCache">
+              <property name="text">
+               <string>Disable On-Disk Shader Cache</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Added a config option to disable shader preloading, useful for debugging/testing purposes.
Initially tried to make a 'null' shader cache but templates and inheritance don't like each very much so I gave up. 🐱 