### PR TITLE
GUI/Themes: Fix GameList Icon Backgrounds + Toolbar Icon Color

### DIFF
--- a/bin/GuiConfigs/Darker Style by TheMitoSan.qss
+++ b/bin/GuiConfigs/Darker Style by TheMitoSan.qss
@@ -68,13 +68,13 @@ QCheckBox::indicator {
 	margin-top: 0.0625em;
 }
 QCheckBox::indicator:checked {
-	background-color: #FFF; /* Green */
+	background-color: #FFF; /* White */
 }
 QCheckBox::indicator:unchecked {
-	background-color: #000; /* Red */
+	background-color: #000; /* Black */
 }
 QCheckBox::indicator::disabled {
-	background-color: #af4949; /* Gray */
+	background-color: #af4949; /* Red */
 }
 
 /* Radio Buttons */
@@ -245,7 +245,7 @@ QLabel#gamelist_icon_background_color {
 	color: transparent;
 }
 QLabel#gamelist_toolbar_icon_color {
-	background-color: #252525;
+	color: #828790;
 }
 
 /* Set Windows Taskbar Thumbnail colors */
@@ -313,11 +313,11 @@ QLabel#memory_viewer_address_panel {
 	background-color: #131313;
 }
 QLabel#memory_viewer_hex_panel {
-	color: #FFF; /* Font Color: Grey */
+	color: #FFF; /* Font Color: White */
 	background-color: #131313;
 }
 QLabel#memory_viewer_ascii_panel {
-	color: #FFF; /* Font Color: Grey */
+	color: #FFF; /* Font Color: White */
 	background-color: #131313;
 }
 

--- a/bin/GuiConfigs/Darker Style by TheMitoSan.qss
+++ b/bin/GuiConfigs/Darker Style by TheMitoSan.qss
@@ -242,7 +242,7 @@ QToolButton::hover {
 
 /* Set Theme UI colors */
 QLabel#gamelist_icon_background_color {
-	background-color: #262626;
+	color: transparent;
 }
 QLabel#gamelist_toolbar_icon_color {
 	background-color: #252525;

--- a/bin/GuiConfigs/Kuroi (Dark) by Ani.qss
+++ b/bin/GuiConfigs/Kuroi (Dark) by Ani.qss
@@ -241,7 +241,7 @@ QToolButton::hover {
 
 /* Set Theme UI colors */
 QLabel#gamelist_icon_background_color {
-	background-color: #323232;
+	color: transparent;
 }
 QLabel#gamelist_toolbar_icon_color {
 	background-color: #e3e3e3;

--- a/bin/GuiConfigs/Kuroi (Dark) by Ani.qss
+++ b/bin/GuiConfigs/Kuroi (Dark) by Ani.qss
@@ -244,7 +244,7 @@ QLabel#gamelist_icon_background_color {
 	color: transparent;
 }
 QLabel#gamelist_toolbar_icon_color {
-	background-color: #e3e3e3;
+	color: #828790;
 }
 
 /* Set Windows Taskbar Thumbnail colors */

--- a/bin/GuiConfigs/ModernBlue Theme by TheMitoSan.qss
+++ b/bin/GuiConfigs/ModernBlue Theme by TheMitoSan.qss
@@ -242,7 +242,7 @@ QLabel#gamelist_icon_background_color {
 	color: transparent;
 }
 QLabel#gamelist_toolbar_icon_color {
-	background-color: #252525;
+	color: #828790;
 }
 
 /* Set Windows Taskbar Thumbnail colors */

--- a/bin/GuiConfigs/ModernBlue Theme by TheMitoSan.qss
+++ b/bin/GuiConfigs/ModernBlue Theme by TheMitoSan.qss
@@ -239,7 +239,7 @@ QToolButton::hover {
 
 /* Set Theme UI colors */
 QLabel#gamelist_icon_background_color {
-	background-color: #262626;
+	color: transparent;
 }
 QLabel#gamelist_toolbar_icon_color {
 	background-color: #252525;


### PR DESCRIPTION
Current approach was incorrectly using the background-color property instead of color.
Using transparent color, allowing for the icon's background to be the theme's background works with darker colors, as PS3 game icons are generally made for these kind of backgrounds.

_Applies to: Kuroi, Darker Style, ModernBlue_


Before
![screenshot_175](https://user-images.githubusercontent.com/10283761/34899899-a1b28efc-f7f3-11e7-983a-2b6b18d468cd.png)

After
![screenshot_173](https://user-images.githubusercontent.com/10283761/34899907-a7171f2a-f7f3-11e7-9409-b6699b809ef7.png) ![screenshot_174](https://user-images.githubusercontent.com/10283761/34899933-cb66155c-f7f3-11e7-94e8-e90923ce2fcf.png) ![screenshot_172](https://user-images.githubusercontent.com/10283761/34899916-af258698-f7f3-11e7-9625-6deb19ff735a.png)
