### PR TITLE
Fix #3950

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -196,7 +196,8 @@ s32 cellHddGameGetSizeKB(vm::ptr<u32> size)
 
 s32 cellHddGameSetSystemVer()
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	UNIMPLEMENTED_FUNC(cellGame);
+	return CELL_OK;
 }
 
 s32 cellHddGameExitBroken()
@@ -223,7 +224,8 @@ s32 cellGameDataGetSizeKB(vm::ptr<u32> size)
 
 s32 cellGameDataSetSystemVer()
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	UNIMPLEMENTED_FUNC(cellGame);
+	return CELL_OK;
 }
 
 s32 cellGameDataExitBroken()


### PR DESCRIPTION
Allows Burnout Paradise which uses `cellHddGameSetSystemVer` and `cellGameDataSetSystemVer` to go ingame (but it is reaaally slooow...)

Fix #3950 

![screenshot from 2018-01-15 14-00-23](https://user-images.githubusercontent.com/25406440/34944224-14f14360-f9ff-11e7-96c9-f2548db1c5ce.png)

![screenshot from 2018-01-15 14-06-20](https://user-images.githubusercontent.com/25406440/34944228-1865ae3c-f9ff-11e7-9f52-08acf6c9d958.png)

![screenshot from 2018-01-15 14-13-06](https://user-images.githubusercontent.com/25406440/34944230-1b4a58be-f9ff-11e7-95cb-db5ce8030404.png)

![screenshot from 2018-01-15 14-14-55](https://user-images.githubusercontent.com/25406440/34944238-2095567a-f9ff-11e7-8a3f-992eab2d96c3.png)

![screenshot from 2018-01-15 14-16-43](https://user-images.githubusercontent.com/25406440/34944242-2455b430-f9ff-11e7-8e95-e5e29317a72b.png)