### PR TITLE
Fixes

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -16,6 +16,23 @@
 // Will report exception and call std::abort() if put in catch(...)
 [[noreturn]] void catch_all_exceptions();
 
+// Hardware core layout
+enum class native_core_arrangement : u32
+{
+	undefined,
+	generic,
+	intel_ht,
+	amd_ccx
+};
+
+enum class thread_class : u32
+{
+	general,
+	rsx,
+	spu,
+	ppu
+};
+
 // Simple list of void() functors
 class task_stack
 {
@@ -90,6 +107,9 @@ class thread_ctrl final
 {
 	// Current thread
 	static thread_local thread_ctrl* g_tls_this_thread;
+
+	// Target cpu core layout
+	static atomic_t<native_core_arrangement> g_native_core_layout;
 
 	// Self pointer
 	std::shared_ptr<thread_ctrl> m_self;
@@ -234,8 +254,17 @@ public:
 		thread_ctrl::start(out, std::forward<F>(func));
 	}
 
+	// Detect layout
+	static void detect_cpu_layout();
+
+	// Returns a core affinity mask. Set whether to generate the high priority set or not
+	static u16 get_affinity_mask(thread_class group);
+
+	// Sets the native thread priority
 	static void set_native_priority(int priority);
-	static void set_ideal_processor_core(int core);
+
+	// Sets the preferred affinity mask for this thread
+	static void set_thread_affinity_mask(u16 mask);
 };
 
 class named_thread

--- a/rpcs3/Emu/Cell/MFC.cpp
+++ b/rpcs3/Emu/Cell/MFC.cpp
@@ -3,6 +3,7 @@
 #include "Emu/Memory/vm.h"
 #include "Emu/Cell/SPUThread.h"
 #include "Emu/Cell/lv2/sys_sync.h"
+#include "Emu/System.h"
 #include "MFC.h"
 
 const bool s_use_rtm = utils::has_rtm();
@@ -374,4 +375,13 @@ void mfc_thread::add_spu(spu_ptr _spu)
 	}
 
 	run();
+}
+
+void mfc_thread::on_spawn()
+{
+	if (g_cfg.core.thread_scheduler_enabled)
+	{
+		// Bind to same set with the SPUs
+		thread_ctrl::set_thread_affinity_mask(thread_ctrl::get_affinity_mask(thread_class::spu));
+	}
 }

--- a/rpcs3/Emu/Cell/MFC.h
+++ b/rpcs3/Emu/Cell/MFC.h
@@ -113,4 +113,6 @@ public:
 	virtual void cpu_task() override;
 
 	virtual void add_spu(spu_ptr _spu);
+
+	virtual void on_spawn() override;
 };

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -334,6 +334,15 @@ extern void ppu_breakpoint(u32 addr)
 	}
 }
 
+void ppu_thread::on_spawn()
+{
+	if (g_cfg.core.thread_scheduler_enabled)
+	{
+		// Bind to primary set
+		thread_ctrl::set_thread_affinity_mask(thread_ctrl::get_affinity_mask(thread_class::ppu));
+	}
+}
+
 void ppu_thread::on_init(const std::shared_ptr<void>& _this)
 {
 	if (!stack_addr)

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -30,6 +30,7 @@ public:
 	static const u32 id_step = 1;
 	static const u32 id_count = 2048;
 
+	virtual void on_spawn() override;
 	virtual void on_init(const std::shared_ptr<void>&) override;
 	virtual std::string get_name() const override;
 	virtual std::string dump() const override;

--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -341,6 +341,20 @@ namespace glsl
 		OS << "	return result;\n";
 		OS << "}\n\n";
 
+		OS << "vec4 apply_zclip_xform(vec4 pos, float near_plane, float far_plane)\n";
+		OS << "{\n";
+		OS << "	float d = pos.z / pos.w;\n";
+		OS << "	if (d < 0.f && d >= near_plane)\n";
+		OS << "		d = 0.f;\n";
+		OS << "	else if (d > 1.f && d <= far_plane)\n";
+		OS << "		d = 1.f;\n";
+		OS << "	else\n";
+		OS << "		return pos;\n";
+		OS << "\n";
+		OS << "	pos.z = d * pos.w;\n";
+		OS << "	return pos;\n";
+		OS << "}\n\n";
+
 		if (domain == glsl::program_domain::glsl_vertex_program)
 			return;
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1525,8 +1525,6 @@ namespace rsx
 			const u32 src_address = (u32)((u64)src.pixels - (u64)vm::base(0));
 			const u32 dst_address = (u32)((u64)dst.pixels - (u64)vm::base(0));
 
-			u32 framebuffer_src_address = src_address;
-
 			float scale_x = dst.scale_x;
 			float scale_y = dst.scale_y;
 
@@ -1534,17 +1532,6 @@ namespace rsx
 			//Reproject final clip onto source...
 			const u16 src_w = (const u16)((f32)dst.clip_width / scale_x);
 			const u16 src_h = (const u16)((f32)dst.clip_height / scale_y);
-
-			//Correct for tile compression
-			//TODO: Investigate whether DST compression also affects alignment
-			if (src.compressed_x || src.compressed_y)
-			{
-				const u32 x_bytes = src_is_argb8 ? (src.offset_x * 4) : (src.offset_x * 2);
-				const u32 y_bytes = src.pitch * src.offset_y;
-
-				if (src.offset_x <= 16 && src.offset_y <= 16)
-					framebuffer_src_address -= (x_bytes + y_bytes);
-			}
 
 			//Check if src/dst are parts of render targets
 			auto dst_subres = m_rtts.get_surface_subresource_if_applicable(dst_address, dst.width, dst.clip_height, dst.pitch, true, false, false);
@@ -1559,7 +1546,7 @@ namespace rsx
 			}
 
 			//TODO: Handle cases where src or dst can be a depth texture while the other is a color texture - requires a render pass to emulate
-			auto src_subres = m_rtts.get_surface_subresource_if_applicable(framebuffer_src_address, src_w, src_h, src.pitch, true, false, false);
+			auto src_subres = m_rtts.get_surface_subresource_if_applicable(src_address, src_w, src_h, src.pitch, true, false, false);
 			src_is_render_target = src_subres.surface != nullptr;
 
 			if (src_is_render_target && src_subres.surface->get_native_pitch() != src.pitch)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1057,7 +1057,9 @@ void GLGSRender::load_program(u32 vertex_base, u32 vertex_count)
 	*(reinterpret_cast<u32*>(buf + 128)) = rsx::method_registers.transform_branch_bits();
 	*(reinterpret_cast<u32*>(buf + 132)) = vertex_base;
 	*(reinterpret_cast<f32*>(buf + 136)) = rsx::method_registers.point_size();
-	fill_vertex_layout_state(m_vertex_layout, vertex_count, reinterpret_cast<s32*>(buf + 144));
+	*(reinterpret_cast<f32*>(buf + 140)) = rsx::method_registers.clip_min();
+	*(reinterpret_cast<f32*>(buf + 144)) = rsx::method_registers.clip_max();
+	fill_vertex_layout_state(m_vertex_layout, vertex_count, reinterpret_cast<s32*>(buf + 160));
 
 	if (m_transform_constants_dirty)
 	{
@@ -1107,7 +1109,7 @@ void GLGSRender::update_draw_state()
 	gl_state.depth_mask(rsx::method_registers.depth_write_enabled());
 	gl_state.stencil_mask(rsx::method_registers.stencil_mask());
 
-	gl_state.enable(rsx::method_registers.depth_clamp_enabled(), GL_DEPTH_CLAMP);
+	gl_state.enable(rsx::method_registers.depth_clamp_enabled() || !rsx::method_registers.depth_clip_enabled(), GL_DEPTH_CLAMP);
 
 	if (gl_state.enable(rsx::method_registers.depth_test_enabled(), GL_DEPTH_TEST))
 	{

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -39,6 +39,8 @@ void GLVertexDecompilerThread::insertHeader(std::stringstream &OS)
 	OS << "	uint transform_branch_bits;\n";
 	OS << "	uint vertex_base_index;\n";
 	OS << "	float point_size;\n";
+	OS << "	float z_near;\n";
+	OS << "	float z_far;\n";
 	OS << "	ivec4 input_attributes[16];\n";
 	OS << "};\n\n";
 }
@@ -297,6 +299,7 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	OS << "	gl_PointSize = point_size;\n";
 	OS << "	gl_Position = gl_Position * scale_offset_mat;\n";
+	OS << "	gl_Position = apply_zclip_xform(gl_Position, z_near, z_far);\n";
 
 	//Since our clip_space is symetrical [-1, 1] we map it to linear space using the eqn:
 	//ln = (clip * 2) - 1 to fully utilize the 0-1 range of the depth buffer

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -398,7 +398,11 @@ namespace rsx
 
 		// Raise priority above other threads
 		thread_ctrl::set_native_priority(1);
-		thread_ctrl::set_ideal_processor_core(0);
+
+		if (g_cfg.core.thread_scheduler_enabled)
+		{
+			thread_ctrl::set_thread_affinity_mask(thread_ctrl::get_affinity_mask(thread_class::rsx));
+		}
 
 		// Round to nearest to deal with forward/reverse scaling
 		fesetround(FE_TONEAREST);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -799,14 +799,8 @@ namespace rsx
 		if (flip_y) scale_y *= -1;
 		if (flip_y) offset_y *= -1;
 
-		float clip_min = rsx::method_registers.clip_min();
-		float clip_max = rsx::method_registers.clip_max();
-
-		float z_clip_scale = (clip_max + clip_min) == 0.f ? 1.f : (clip_max + clip_min);
-		float z_offset_scale = (clip_max - clip_min) == 0.f ? 1.f : (clip_max - clip_min);
-
-		float scale_z = rsx::method_registers.viewport_scale_z() / z_clip_scale;
-		float offset_z = rsx::method_registers.viewport_offset_z() / z_offset_scale;
+		float scale_z = rsx::method_registers.viewport_scale_z();
+		float offset_z = rsx::method_registers.viewport_offset_z();
 		float one = 1.f;
 
 		stream_vector(buffer, (u32&)scale_x, 0, 0, (u32&)offset_x);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2277,7 +2277,7 @@ void VKGSRender::load_program(u32 vertex_count, u32 vertex_base)
 
 	properties.rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 	properties.rs.polygonMode = VK_POLYGON_MODE_FILL;
-	properties.rs.depthClampEnable = rsx::method_registers.depth_clamp_enabled();
+	properties.rs.depthClampEnable = rsx::method_registers.depth_clamp_enabled() || !rsx::method_registers.depth_clip_enabled();
 	properties.rs.rasterizerDiscardEnable = VK_FALSE;
 
 	//Disabled by setting factors to 0 as needed
@@ -2338,7 +2338,9 @@ void VKGSRender::load_program(u32 vertex_count, u32 vertex_base)
 	*(reinterpret_cast<u32*>(buf + 128)) = rsx::method_registers.transform_branch_bits();
 	*(reinterpret_cast<u32*>(buf + 132)) = vertex_base;
 	*(reinterpret_cast<f32*>(buf + 136)) = rsx::method_registers.point_size();
-	fill_vertex_layout_state(m_vertex_layout, vertex_count, reinterpret_cast<s32*>(buf + 144));
+	*(reinterpret_cast<f32*>(buf + 140)) = rsx::method_registers.clip_min();
+	*(reinterpret_cast<f32*>(buf + 144)) = rsx::method_registers.clip_max();
+	fill_vertex_layout_state(m_vertex_layout, vertex_count, reinterpret_cast<s32*>(buf + 160));
 
 	//Vertex constants
 	buf = buf + 512;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -43,6 +43,7 @@ struct command_buffer_chunk: public vk::command_buffer
 
 	std::atomic_bool pending = { false };
 	std::atomic<u64> last_sync = { 0 };
+	std::mutex guard_mutex;
 
 	command_buffer_chunk()
 	{}
@@ -84,8 +85,13 @@ struct command_buffer_chunk: public vk::command_buffer
 	{
 		if (vkGetFenceStatus(m_device, submit_fence) == VK_SUCCESS)
 		{
-			vkResetFences(m_device, 1, &submit_fence);
-			pending = false;
+			std::lock_guard<std::mutex> lock(guard_mutex);
+
+			if (pending)
+			{
+				vkResetFences(m_device, 1, &submit_fence);
+				pending = false;
+			}
 		}
 
 		return !pending;
@@ -93,6 +99,8 @@ struct command_buffer_chunk: public vk::command_buffer
 
 	void wait()
 	{
+		std::lock_guard<std::mutex> lock(guard_mutex);
+
 		if (!pending)
 			return;
 
@@ -114,6 +122,114 @@ struct occlusion_data
 {
 	std::vector<u32> indices;
 	command_buffer_chunk* command_buffer_to_wait = nullptr;
+};
+
+struct frame_context_t
+{
+	VkSemaphore present_semaphore = VK_NULL_HANDLE;
+	VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
+	vk::descriptor_pool descriptor_pool;
+	u32 used_descriptors = 0;
+
+	std::vector<std::unique_ptr<vk::buffer_view>> buffer_views_to_clean;
+	std::vector<std::unique_ptr<vk::sampler>> samplers_to_clean;
+
+	u32 present_image = UINT32_MAX;
+	command_buffer_chunk* swap_command_buffer = nullptr;
+
+	//Heap pointers
+	s64 attrib_heap_ptr = 0;
+	s64 ubo_heap_ptr = 0;
+	s64 index_heap_ptr = 0;
+	s64 texture_upload_heap_ptr = 0;
+
+	u64 last_frame_sync_time = 0;
+
+	//Copy shareable information
+	void grab_resources(frame_context_t &other)
+	{
+		present_semaphore = other.present_semaphore;
+		descriptor_set = other.descriptor_set;
+		descriptor_pool = other.descriptor_pool;
+		used_descriptors = other.used_descriptors;
+
+		attrib_heap_ptr = other.attrib_heap_ptr;
+		ubo_heap_ptr = other.attrib_heap_ptr;
+		index_heap_ptr = other.attrib_heap_ptr;
+		texture_upload_heap_ptr = other.texture_upload_heap_ptr;
+	}
+
+	//Exchange storage (non-copyable)
+	void swap_storage(frame_context_t &other)
+	{
+		std::swap(buffer_views_to_clean, other.buffer_views_to_clean);
+		std::swap(samplers_to_clean, other.samplers_to_clean);
+	}
+
+	void tag_frame_end(s64 attrib_loc, s64 ubo_loc, s64 index_loc, s64 texture_loc)
+	{
+		attrib_heap_ptr = attrib_loc;
+		ubo_heap_ptr = ubo_loc;
+		index_heap_ptr = index_loc;
+		texture_upload_heap_ptr = texture_loc;
+
+		last_frame_sync_time = get_system_time();
+	}
+
+	void reset_heap_ptrs()
+	{
+		last_frame_sync_time = 0;
+	}
+};
+
+struct flush_request_task
+{
+	atomic_t<bool> pending_state{ false };  //Flush request status; true if rsx::thread is yet to service this request
+	atomic_t<int> num_waiters{ 0 };  //Number of threads waiting for this request to be serviced
+	bool hard_sync = false;
+
+	flush_request_task(){}
+
+	void post(bool _hard_sync)
+	{
+		hard_sync = (hard_sync || _hard_sync);
+		pending_state = true;
+		num_waiters++;
+	}
+
+	void remove_one()
+	{
+		num_waiters--;
+	}
+
+	void clear_pending_flag()
+	{
+		hard_sync = false;
+		pending_state.store(false);
+	}
+
+	bool pending() const
+	{
+		return pending_state.load();
+	}
+
+	void consumer_wait() const
+	{
+		while (num_waiters.load() != 0)
+		{
+			_mm_lfence();
+			_mm_pause();
+		}
+	}
+
+	void producer_wait() const
+	{
+		while (pending_state.load())
+		{
+			_mm_lfence();
+			_mm_pause();
+		}
+	}
 };
 
 class VKGSRender : public GSRender
@@ -191,64 +307,6 @@ private:
 	vk::vk_data_heap m_index_buffer_ring_info;
 	vk::vk_data_heap m_texture_upload_buffer_ring_info;
 
-	struct frame_context_t
-	{
-		VkSemaphore present_semaphore = VK_NULL_HANDLE;
-		VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
-		vk::descriptor_pool descriptor_pool;
-		u32 used_descriptors = 0;
-
-		std::vector<std::unique_ptr<vk::buffer_view>> buffer_views_to_clean;
-		std::vector<std::unique_ptr<vk::sampler>> samplers_to_clean;
-
-		u32 present_image = UINT32_MAX;
-		command_buffer_chunk* swap_command_buffer = nullptr;
-
-		//Heap pointers
-		s64 attrib_heap_ptr = 0;
-		s64 ubo_heap_ptr = 0;
-		s64 index_heap_ptr = 0;
-		s64 texture_upload_heap_ptr = 0;
-
-		u64 last_frame_sync_time = 0;
-
-		//Copy shareable information
-		void grab_resources(frame_context_t &other)
-		{
-			present_semaphore = other.present_semaphore;
-			descriptor_set = other.descriptor_set;
-			descriptor_pool = other.descriptor_pool;
-			used_descriptors = other.used_descriptors;
-
-			attrib_heap_ptr = other.attrib_heap_ptr;
-			ubo_heap_ptr = other.attrib_heap_ptr;
-			index_heap_ptr = other.attrib_heap_ptr;
-			texture_upload_heap_ptr = other.texture_upload_heap_ptr;
-		}
-
-		//Exchange storage (non-copyable)
-		void swap_storage(frame_context_t &other)
-		{
-			std::swap(buffer_views_to_clean, other.buffer_views_to_clean);
-			std::swap(samplers_to_clean, other.samplers_to_clean);
-		}
-
-		void tag_frame_end(s64 attrib_loc, s64 ubo_loc, s64 index_loc, s64 texture_loc)
-		{
-			attrib_heap_ptr = attrib_loc;
-			ubo_heap_ptr = ubo_loc;
-			index_heap_ptr = index_loc;
-			texture_upload_heap_ptr = texture_loc;
-
-			last_frame_sync_time = get_system_time();
-		}
-
-		void reset_heap_ptrs()
-		{
-			last_frame_sync_time = 0;
-		}
-	};
-
 	std::array<frame_context_t, VK_MAX_ASYNC_FRAMES> frame_context_storage;
 	//Temp frame context to use if the real frame queue is overburdened. Only used for storage
 	frame_context_t m_aux_frame_context;
@@ -277,8 +335,7 @@ private:
 	std::atomic<int> m_last_flushable_cb = {-1 };
 	
 	std::mutex m_flush_queue_mutex;
-	std::atomic<bool> m_flush_commands = { false };
-	std::atomic<int> m_queued_threads = { 0 };
+	flush_request_task m_flush_requests;
 
 	std::thread::id rsx_thread;
 	std::atomic<u64> m_last_sync_event = { 0 };

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -13,8 +13,8 @@ namespace vk
 
 	VkSampler g_null_sampler = nullptr;
 
-	bool g_cb_no_interrupt_flag = false;
-	bool g_drv_no_primitive_restart_flag = false;
+	atomic_t<bool> g_cb_no_interrupt_flag { false };
+	atomic_t<bool> g_drv_no_primitive_restart_flag { false };
 
 	u64 g_num_processed_frames = 0;
 	u64 g_num_total_frames = 0;

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -532,7 +532,7 @@ namespace vk
 			const VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
 
 			auto tex = std::make_unique<vk::image>(dev, memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				VK_IMAGE_TYPE_2D, format, w, h, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
+				VK_IMAGE_TYPE_2D, format, std::max(w, 1), std::max(h, 1), 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
 				0);
 

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -37,6 +37,8 @@ void VKVertexDecompilerThread::insertHeader(std::stringstream &OS)
 	OS << "	uint transform_branch_bits;\n";
 	OS << "	uint vertex_base_index;\n";
 	OS << "	float point_size;\n";
+	OS << "	float z_near;\n";
+	OS << "	float z_far;\n";
 	OS << "	ivec4 input_attributes[16];\n";
 	OS << "};\n";
 
@@ -312,6 +314,7 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	OS << "	gl_PointSize = point_size;\n";
 	OS << "	gl_Position = gl_Position * scale_offset_mat;\n";
+	OS << "	gl_Position = apply_zclip_xform(gl_Position, z_near, z_far);\n";
 	OS << "}\n";
 }
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -286,8 +286,13 @@ struct cfg_root : cfg::node
 		cfg::_bool llvm_logs{this, "Save LLVM logs"};
 		cfg::string llvm_cpu{this, "Use LLVM CPU"};
 
+#ifdef _WIN32
+		cfg::_bool thread_scheduler_enabled{ this, "Enable thread scheduler", true };
+#else
+		cfg::_bool thread_scheduler_enabled{ this, "Enable thread scheduler", false };
+#endif
+
 		cfg::_enum<spu_decoder_type> spu_decoder{this, "SPU Decoder", spu_decoder_type::asmjit};
-		cfg::_bool bind_spu_cores{this, "Bind SPU threads to secondary cores"};
 		cfg::_bool lower_spu_priority{this, "Lower SPU thread priority"};
 		cfg::_bool spu_debug{this, "SPU Debug"};
 		cfg::_int<0, 16384> max_spu_immediate_write_size{this, "Maximum immediate DMA write size", 16384}; // Maximum size that an SPU thread can write directly without posting to MFC

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -26,7 +26,7 @@
 		},
 		"checkboxes": {
 			"hookStFunc": "Allows to hook some functions like 'memcpy' replacing them with high-level implementations. May do nothing or break things. Experimental.",
-			"bindSPUThreads": "If your CPU has SMT (Hyper-Threading) SPU threads will run on these logical cores instead.\nUsually faster on an i3, possibly slower or no difference on an i7 or Ryzen.",
+			"enableThreadScheduler": "Allows rpcs3 to manually schedule physical cores to run specific tasks on, instead of letting the OS handle it.\nVery useful on windows, especially for AMD Ryzen systems where it can give huge performance gains.",
 			"lowerSPUThrPrio": "Runs SPU threads with lower priority than PPU threads.\nUsually faster on an i3 or i5, possibly slower or no difference on an i7 or Ryzen.",
 			"spuLoopDetection": "Try to detect loop conditions in SPU kernels and use them as scheduling hints.\nImproves performance and reduces CPU usage.\nMay cause severe audio stuttering in rare cases."
 		},

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -30,7 +30,7 @@ public:
 		SPUDecoder,
 		LibLoadOptions,
 		HookStaticFuncs,
-		BindSPUThreads,
+		EnableThreadScheduler,
 		LowerSPUThreadPrio,
 		SPULoopDetection,
 		PreferredSPUThreads,
@@ -183,16 +183,16 @@ private:
 	const QMap<SettingsType, cfg_location> SettingsLoc =
 	{
 		// Core Tab
-		{ PPUDecoder,          { "Core", "PPU Decoder"}},
-		{ SPUDecoder,          { "Core", "SPU Decoder"}},
-		{ LibLoadOptions,      { "Core", "Lib Loader"}},
-		{ HookStaticFuncs,     { "Core", "Hook static functions"}},
-		{ BindSPUThreads,      { "Core", "Bind SPU threads to secondary cores"}},
-		{ LowerSPUThreadPrio,  { "Core", "Lower SPU thread priority"}},
-		{ SPULoopDetection,    { "Core", "SPU loop detection"}},
-		{ PreferredSPUThreads, { "Core", "Preferred SPU Threads"}},
-		{ PPUDebug,            { "Core", "PPU Debug"}},
-		{ SPUDebug,            { "Core", "SPU Debug"}},
+		{ PPUDecoder,               { "Core", "PPU Decoder"}},
+		{ SPUDecoder,               { "Core", "SPU Decoder"}},
+		{ LibLoadOptions,           { "Core", "Lib Loader"}},
+		{ HookStaticFuncs,          { "Core", "Hook static functions"}},
+		{ EnableThreadScheduler,    { "Core", "Enable thread scheduler"}},
+		{ LowerSPUThreadPrio,       { "Core", "Lower SPU thread priority"}},
+		{ SPULoopDetection,         { "Core", "SPU loop detection"}},
+		{ PreferredSPUThreads,      { "Core", "Preferred SPU Threads"}},
+		{ PPUDebug,                 { "Core", "PPU Debug"}},
+		{ SPUDebug,                 { "Core", "SPU Debug"}},
 
 		// Graphics Tab
 		{ Renderer,                 { "Video", "Renderer"}},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -129,8 +129,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xemu_settings->EnhanceCheckBox(ui->hookStFunc, emu_settings::HookStaticFuncs);
 	SubscribeTooltip(ui->hookStFunc, json_cpu_cbs["hookStFunc"].toString());
 
-	xemu_settings->EnhanceCheckBox(ui->bindSPUThreads, emu_settings::BindSPUThreads);
-	SubscribeTooltip(ui->bindSPUThreads, json_cpu_cbs["bindSPUThreads"].toString());
+	xemu_settings->EnhanceCheckBox(ui->enableScheduler, emu_settings::EnableThreadScheduler);
+	SubscribeTooltip(ui->enableScheduler, json_cpu_cbs["enableThreadScheduler"].toString());
 
 	xemu_settings->EnhanceCheckBox(ui->lowerSPUThrPrio, emu_settings::LowerSPUThreadPrio);
 	SubscribeTooltip(ui->lowerSPUThrPrio, json_cpu_cbs["lowerSPUThrPrio"].toString());

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -207,9 +207,9 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_4">
               <item>
-               <widget class="QCheckBox" name="bindSPUThreads">
+               <widget class="QCheckBox" name="enableScheduler">
                 <property name="text">
-                 <string>Bind SPU threads to secondary cores</string>
+                 <string>Enable thread scheduler</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
- emu: Add option to manage thread placement. Makes an impact on windows when using ryzen processors, most other cpus should be unaffected. Linux does a better job on its own so the option is not recommended on linux.
- vulkan: Flush command queue on access violation event before attempting to touch texture cache in the event of access violations. This makes the device internal state consistent before texture operations. Fixes VK_ERROR_DEVICE_LOST in some cases when WCB is in use
- Fixes for native overlay. Add fallback path in dev_flash for glyphs and fix vulkan freeze if icons are non-existent.
- Fix Z clipping using selective z clamping.
- Texture cache (blit engine) fix - Remove a conditional guess that has been properly REd

https://github.com/RPCS3/rpcs3/issues/4072
https://github.com/RPCS3/rpcs3/issues/4062