### PR TITLE
[HLE] Add callbacks for cellRec, cellVideoExport and cellVideoUpload

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellRec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRec.cpp
@@ -1,9 +1,21 @@
 #include "stdafx.h"
 #include "Emu/Cell/PPUModule.h"
+#include "Emu/IdManager.h"
+#include "cellSysutil.h"
 
 namespace vm { using namespace ps3; }
 
 logs::channel cellRec("cellRec");
+
+enum
+{
+	CELL_REC_STATUS_UNLOAD = 0,
+	CELL_REC_STATUS_OPEN = 1,
+	CELL_REC_STATUS_START = 2,
+	CELL_REC_STATUS_STOP = 3,
+	CELL_REC_STATUS_CLOSE = 4,
+	CELL_REC_STATUS_ERR = 10
+};
 
 struct CellRecSpursParam
 {
@@ -46,15 +58,40 @@ struct CellRecParam
 
 using CellRecCallback = void(s32 recStatus, s32 recError, vm::ptr<void> userdata);
 
-s32 cellRecOpen(vm::cptr<char> pDirName, vm::cptr<char> pFileName, vm::cptr<CellRecParam> pParam, u32 container, vm::ptr<CellRecCallback> cb, vm::ptr<void> cbUserData)
+struct rec_t
+{
+	vm::ptr<CellRecCallback> cb;
+	vm::ptr<void> cbUserData;
+};
+
+error_code cellRecOpen(vm::cptr<char> pDirName, vm::cptr<char> pFileName, vm::cptr<CellRecParam> pParam, u32 container, vm::ptr<CellRecCallback> cb, vm::ptr<void> cbUserData)
 {
 	cellRec.todo("cellRecOpen(pDirName=%s, pFileName=%s, pParam=*0x%x, container=0x%x, cb=*0x%x, cbUserData=*0x%x)", pDirName, pFileName, pParam, container, cb, cbUserData);
+
+	const auto rec = fxm::make_always<rec_t>();
+	rec->cb = cb;
+	rec->cbUserData = cbUserData;
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		cb(ppu, CELL_REC_STATUS_OPEN, CELL_OK, cbUserData);
+		return CELL_OK;
+	});
+
 	return CELL_OK;
 }
 
-s32 cellRecClose(s32 isDiscard)
+error_code cellRecClose(s32 isDiscard)
 {
 	cellRec.todo("cellRecClose(isDiscard=0x%x)", isDiscard);
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		const auto rec = fxm::get_always<rec_t>();
+		rec->cb(ppu, CELL_REC_STATUS_CLOSE, CELL_OK, rec->cbUserData);
+		return CELL_OK;
+	});
+
 	return CELL_OK;
 }
 
@@ -63,15 +100,31 @@ void cellRecGetInfo(s32 info, vm::ptr<u64> pValue)
 	cellRec.todo("cellRecGetInfo(info=0x%x, pValue=*0x%x)", info, pValue);
 }
 
-s32 cellRecStop()
+error_code cellRecStop()
 {
 	cellRec.todo("cellRecStop()");
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		const auto rec = fxm::get_always<rec_t>();
+		rec->cb(ppu, CELL_REC_STATUS_STOP, CELL_OK, rec->cbUserData);
+		return CELL_OK;
+	});
+
 	return CELL_OK;
 }
 
-s32 cellRecStart()
+error_code cellRecStart()
 {
 	cellRec.todo("cellRecStart()");
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		const auto rec = fxm::get_always<rec_t>();
+		rec->cb(ppu, CELL_REC_STATUS_START, CELL_OK, rec->cbUserData);
+		return CELL_OK;
+	});
+
 	return CELL_OK;
 }
 
@@ -81,7 +134,7 @@ u32 cellRecQueryMemSize(vm::cptr<CellRecParam> pParam)
 	return 1 * 1024 * 1024; // dummy memory size
 }
 
-s32 cellRecSetInfo(s32 setInfo, u64 value)
+error_code cellRecSetInfo(s32 setInfo, u64 value)
 {
 	cellRec.todo("cellRecSetInfo(setInfo=0x%x, value=0x%x)", setInfo, value);
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellVideoExport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoExport.cpp
@@ -1,36 +1,99 @@
 #include "stdafx.h"
 #include "Emu/Cell/PPUModule.h"
 
+#include "cellSysutil.h"
+
+namespace vm { using namespace ps3; }
+
 logs::channel cellVideoExport("cellVideoExport");
 
-s32 cellVideoExportProgress()
+struct CellVideoExportSetParam
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	vm::bptr<char> title;
+	vm::bptr<char> game_title;
+	vm::bptr<char> game_comment;
+	be_t<s32> editable;
+	vm::bptr<void> reserved2;
+};
+
+using CellVideoExportUtilFinishCallback = void(s32 result, vm::ptr<void> userdata);
+
+error_code cellVideoExportProgress(vm::ptr<CellVideoExportUtilFinishCallback> funcFinish, vm::ptr<void> userdata)
+{
+	cellVideoExport.todo("cellVideoExportProgress(funcFinish=*0x%x, userdata=*0x%x)", funcFinish, userdata);
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		funcFinish(ppu, 0xFFFF, userdata); // 0-0xFFFF where 0xFFFF = 100%
+		return CELL_OK;
+	});
+
+	return CELL_OK;
 }
 
-s32 cellVideoExportInitialize2()
+error_code cellVideoExportInitialize2(u32 version, vm::ptr<CellVideoExportUtilFinishCallback> funcFinish, vm::ptr<void> userdata)
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	cellVideoExport.todo("cellVideoExportInitialize2(version=0x%x, funcFinish=*0x%x, userdata=*0x%x)", version, funcFinish, userdata);
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		funcFinish(ppu, CELL_OK, userdata);
+		return CELL_OK;
+	});
+
+	return CELL_OK;
 }
 
-s32 cellVideoExportInitialize()
+error_code cellVideoExportInitialize(u32 version, u32 container, vm::ptr<CellVideoExportUtilFinishCallback> funcFinish, vm::ptr<void> userdata)
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	cellVideoExport.todo("cellVideoExportInitialize(version=0x%x, container=0x%x, funcFinish=*0x%x, userdata=*0x%x)", version, container, funcFinish, userdata);
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		funcFinish(ppu, CELL_OK, userdata);
+		return CELL_OK;
+	});
+
+	return CELL_OK;
 }
 
-s32 cellVideoExportFromFileWithCopy()
+error_code cellVideoExportFromFileWithCopy(vm::cptr<char> srcHddDir, vm::cptr<char> srcHddFile, vm::ptr<CellVideoExportSetParam> param, vm::ptr<CellVideoExportUtilFinishCallback> funcFinish, vm::ptr<void> userdata)
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	cellVideoExport.todo("cellVideoExportFromFileWithCopy(srcHddDir=%s, srcHddFile=%s, param=*0x%x, funcFinish=*0x%x, userdata=*0x%x)", srcHddDir, srcHddFile, param, funcFinish, userdata);
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		funcFinish(ppu, CELL_OK, userdata);
+		return CELL_OK;
+	});
+
+	return CELL_OK;
 }
 
-s32 cellVideoExportFromFile()
+error_code cellVideoExportFromFile(vm::cptr<char> srcHddDir, vm::cptr<char> srcHddFile, vm::ptr<CellVideoExportSetParam> param, vm::ptr<CellVideoExportUtilFinishCallback> funcFinish, vm::ptr<void> userdata)
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	cellVideoExport.todo("cellVideoExportFromFile(srcHddDir=%s, srcHddFile=%s, param=*0x%x, funcFinish=*0x%x, userdata=*0x%x)", srcHddDir, srcHddFile, param, funcFinish, userdata);
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		funcFinish(ppu, CELL_OK, userdata);
+		return CELL_OK;
+	});
+
+	return CELL_OK;
 }
 
-s32 cellVideoExportFinalize()
+error_code cellVideoExportFinalize(vm::ptr<CellVideoExportUtilFinishCallback> funcFinish, vm::ptr<void> userdata)
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	cellVideoExport.todo("cellVideoExportFinalize(funcFinish=*0x%x, userdata=*0x%x)", funcFinish, userdata);
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		funcFinish(ppu, CELL_OK, userdata);
+		return CELL_OK;
+	});
+
+	return CELL_OK;
 }
 
 

--- a/rpcs3/Emu/Cell/Modules/cellVideoUpload.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoUpload.cpp
@@ -2,12 +2,23 @@
 #include "Emu/Cell/PPUModule.h"
 
 #include "cellVideoUpload.h"
+#include "cellSysutil.h"
 
 logs::channel cellVideoUpload("cellVideoUpload");
 
-s32 cellVideoUploadInitialize(vm::cptr<CellVideoUploadParam> pParam, vm::ptr<CellVideoUploadCallback> cb, vm::ptr<void> userdata)
+error_code cellVideoUploadInitialize(vm::cptr<CellVideoUploadParam> pParam, vm::ptr<CellVideoUploadCallback> cb, vm::ptr<void> userdata)
 {
 	cellVideoUpload.todo("cellVideoUploadInitialize(pParam=*0x%x, cb=*0x%x, userdata=*0x%x)", pParam, cb, userdata);
+
+	sysutil_register_cb([=](ppu_thread& ppu) -> s32
+	{
+		vm::var<char[]> pResultURL(128);
+
+		cb(ppu, CELL_VIDEO_UPLOAD_STATUS_INITIALIZED, CELL_OK, pResultURL, userdata);
+		cb(ppu, CELL_VIDEO_UPLOAD_STATUS_FINALIZED, CELL_OK, pResultURL, userdata);
+
+		return CELL_OK;
+	});
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellVideoUpload.h
+++ b/rpcs3/Emu/Cell/Modules/cellVideoUpload.h
@@ -1,7 +1,5 @@
 #pragma once
 
-namespace vm { using namespace ps3; }
-
 struct CellVideoUploadOption
 {
 	be_t<s32> type;
@@ -11,27 +9,27 @@ struct CellVideoUploadOption
 struct CellVideoUploadParam
 {
 	be_t<s32> siteID;
-	vm::bcptr<char> pFilePath;
+	vm::ps3::bcptr<char> pFilePath;
 	union
 	{
 		struct
 		{
-			vm::bcptr<char> pClientId;
-			vm::bcptr<char> pDeveloperKey;
-			vm::bcptr<char> pTitle_UTF8;
-			vm::bcptr<char> pDescription_UTF8;
-			vm::bcptr<char> pKeyword_1_UTF8;
-			vm::bcptr<char> pKeyword_2_UTF8;
-			vm::bcptr<char> pKeyword_3_UTF8;
+			vm::ps3::bcptr<char> pClientId;
+			vm::ps3::bcptr<char> pDeveloperKey;
+			vm::ps3::bcptr<char> pTitle_UTF8;
+			vm::ps3::bcptr<char> pDescription_UTF8;
+			vm::ps3::bcptr<char> pKeyword_1_UTF8;
+			vm::ps3::bcptr<char> pKeyword_2_UTF8;
+			vm::ps3::bcptr<char> pKeyword_3_UTF8;
 			u8 isPrivate;
 			u8 rating;
 		} youtube;
 	} u;
 	be_t<s32> numOfOption;
-	vm::bptr<CellVideoUploadOption> pOption;
+	vm::ps3::bptr<CellVideoUploadOption> pOption;
 };
 
-typedef void(CellVideoUploadCallback)(s32 status, s32 errorCode, vm::cptr<char> pResultURL, vm::ptr<void> userdata);
+using CellVideoUploadCallback = void(s32 status, s32 errorCode, vm::ps3::cptr<char> pResultURL, vm::ps3::ptr<void> userdata);
 
 enum
 {
@@ -58,4 +56,10 @@ enum
 	CELL_VIDEO_UPLOAD_ERROR_INVALID_VALUE       = 0x8002d022,
 	CELL_VIDEO_UPLOAD_ERROR_FILE_OPEN           = 0x8002d023,
 	CELL_VIDEO_UPLOAD_ERROR_INVALID_STATE       = 0x8002d024
+};
+
+enum
+{
+	CELL_VIDEO_UPLOAD_STATUS_INITIALIZED = 1,
+	CELL_VIDEO_UPLOAD_STATUS_FINALIZED = 2
 };


### PR DESCRIPTION
Improved games in specific cases like video recording, exporting or uploading. Please note this pull request doesn't add any of these features but instead reduce possibilities of crash or freeze when using the related functions.

Sample games tested:
- [X] CAPCOM ARCARDE CABINET (View Replays)
- [X] Comet Crash (Settings > Video Record)
- [X] Just Cause 2 (Video Capture)
- [X] My Aquarium (Record > Movies)
- [X] PixelJunk™ Shooter (Options > Video Recording)