### PR TITLE
WIP: gcm_enums.cpp optimization

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <sstream>
 
+#include "../gcm_enums.h"
 #include "ShaderParam.h"
 
 namespace program_common
@@ -202,14 +203,14 @@ namespace glsl
 		OS << "\n";
 		OS << "		switch (desc.type)\n";
 		OS << "		{\n";
-		OS << "		case 0:\n";
+		OS << "		case " << static_cast<std::underlying_type<rsx::vertex_base_type>::type>(rsx::vertex_base_type::s1) << ":\n";
 		OS << "			//signed normalized 16-bit\n";
 		OS << "			tmp.x = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			tmp.y = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			mov(result, n, get_s16(tmp.xy, desc.swap_bytes));\n";
 		OS << "			mov(scale, n, 32767.);\n";
 		OS << "			break;\n";
-		OS << "		case 1:\n";
+		OS << "		case " << static_cast<std::underlying_type<rsx::vertex_base_type>::type>(rsx::vertex_base_type::f) << ":\n";
 		OS << "			//float\n";
 		OS << "			tmp.x = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			tmp.y = texelFetch(input_stream, first_byte++).x;\n";
@@ -217,25 +218,25 @@ namespace glsl
 		OS << "			tmp.w = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			mov(result, n, uintBitsToFloat(get_bits(tmp, desc.swap_bytes)));\n";
 		OS << "			break;\n";
-		OS << "		case 2:\n";
+		OS << "		case " << static_cast<std::underlying_type<rsx::vertex_base_type>::type>(rsx::vertex_base_type::sf) << ":\n";
 		OS << "			//half\n";
 		OS << "			tmp.x = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			tmp.y = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			mov(result, n, unpackHalf2x16(uint(get_bits(tmp.xy, desc.swap_bytes))).x);\n";
 		OS << "			break;\n";
-		OS << "		case 3:\n";
+		OS << "		case " << static_cast<std::underlying_type<rsx::vertex_base_type>::type>(rsx::vertex_base_type::ub) << ":\n";
 		OS << "			//unsigned byte\n";
 		OS << "			mov(result, n, texelFetch(input_stream, first_byte++).x);\n";
 		OS << "			mov(scale, n, 255.);\n";
 		OS << "			reverse_order = (desc.swap_bytes != 0);\n";
 		OS << "			break;\n";
-		OS << "		case 4:\n";
+		OS << "		case " << static_cast<std::underlying_type<rsx::vertex_base_type>::type>(rsx::vertex_base_type::s32k) << ":\n";
 		OS << "			//signed word\n";
 		OS << "			tmp.x = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			tmp.y = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			mov(result, n, get_s16(tmp.xy, desc.swap_bytes));\n";
 		OS << "			break;\n";
-		OS << "		case 5:\n";
+		OS << "		case " << static_cast<std::underlying_type<rsx::vertex_base_type>::type>(rsx::vertex_base_type::cmp) << ":\n";
 		OS << "			//cmp\n";
 		OS << "			tmp.x = texelFetch(input_stream, first_byte++).x;\n";
 		OS << "			tmp.y = texelFetch(input_stream, first_byte++).x;\n";
@@ -248,7 +249,7 @@ namespace glsl
 		OS << "			result.w = 1.;\n";
 		OS << "			scale = vec4(32767., 32767., 32767., 1.);\n";
 		OS << "			break;\n";
-		OS << "		case 6:\n";
+		OS << "		case " << static_cast<std::underlying_type<rsx::vertex_base_type>::type>(rsx::vertex_base_type::ub256) << ":\n";
 		OS << "			//ub256\n";
 		OS << "			mov(result, n, float(texelFetch(input_stream, first_byte++).x));\n";
 		OS << "			reverse_order = (desc.swap_bytes != 0);\n";

--- a/rpcs3/Emu/RSX/gcm_enums.cpp
+++ b/rpcs3/Emu/RSX/gcm_enums.cpp
@@ -1,21 +1,6 @@
 ﻿#include "gcm_enums.h"
 #include "Utilities/StrFmt.h"
 
-rsx::vertex_base_type rsx::to_vertex_base_type(u8 in)
-{
-	switch (in)
-	{
-	case 1: return rsx::vertex_base_type::s1;
-	case 2: return rsx::vertex_base_type::f;
-	case 3: return rsx::vertex_base_type::sf;
-	case 4: return rsx::vertex_base_type::ub;
-	case 5: return rsx::vertex_base_type::s32k;
-	case 6: return rsx::vertex_base_type::cmp;
-	case 7: return rsx::vertex_base_type::ub256;
-	}
-	fmt::throw_exception("Unknown vertex base type %d" HERE, in);
-}
-
 rsx::index_array_type rsx::to_index_array_type(u8 in)
 {
 	switch (in)

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -1,20 +1,29 @@
 ﻿#pragma once
 #include "Utilities/types.h"
 
+enum
+{
+	CELL_GCM_VERTEX_S1 = 1,
+	CELL_GCM_VERTEX_F = 2,
+	CELL_GCM_VERTEX_SF = 3,
+	CELL_GCM_VERTEX_UB = 4,
+	CELL_GCM_VERTEX_S32K = 5,
+	CELL_GCM_VERTEX_CMP = 6,
+	CELL_GCM_VERTEX_UB256 = 7,
+};
+
 namespace rsx
 {
-	enum class vertex_base_type : u8
+	enum class vertex_base_type : u32
 	{
-		s1, ///< signed normalized 16-bit int
-		f, ///< float
-		sf, ///< half float
-		ub, ///< unsigned byte interpreted as 0.f and 1.f
-		s32k, ///< signed 16bits int
-		cmp, ///< compressed aka X11G11Z10 and always 1. W.
-		ub256, ///< unsigned byte interpreted as between 0 and 255.
+		s1 = CELL_GCM_VERTEX_S1, ///< signed normalized 16-bit int
+		f = CELL_GCM_VERTEX_F, ///< float
+		sf = CELL_GCM_VERTEX_SF, ///< half float
+		ub = CELL_GCM_VERTEX_UB, ///< unsigned byte interpreted as 0.f and 1.f
+		s32k = CELL_GCM_VERTEX_S32K, ///< signed 16bits int
+		cmp = CELL_GCM_VERTEX_CMP, ///< compressed aka X11G11Z10 and always 1. W.
+		ub256 = CELL_GCM_VERTEX_UB256, ///< unsigned byte interpreted as between 0 and 255.
 	};
-
-	vertex_base_type to_vertex_base_type(u8 in);
 
 	enum class index_array_type : u8
 	{

--- a/rpcs3/Emu/RSX/gcm_printing.cpp
+++ b/rpcs3/Emu/RSX/gcm_printing.cpp
@@ -758,9 +758,9 @@ namespace
 		return "";
 	}
 
-	std::string get_vertex_attribute_format(u8 type)
+	std::string get_vertex_attribute_format(u32 type)
 	{
-		switch (rsx::to_vertex_base_type(type))
+		switch (static_cast<rsx::vertex_base_type>(type))
 		{
 		case rsx::vertex_base_type::s1: return "Signed short normalized";
 		case rsx::vertex_base_type::f: return "Float";

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -4523,7 +4523,7 @@ struct vertex_array_helper
 
 		rsx::vertex_base_type type() const
 		{
-			return rsx::to_vertex_base_type(m_data.type);
+			return static_cast<rsx::vertex_base_type>(static_cast<std::underlying_type<rsx::vertex_base_type>::type>(m_data.type));
 		}
 	};
 


### PR DESCRIPTION
Attempt to take care of the issue #2123 

I removed the function `rsx::to_vertex_base_type` to use static_cast instead and added some CELL_GCM_* constants.
I would like to validate this first before to consider the same pattern for the other functions like `rsx::to_index_array_type`, `rsx::to_primitive_type`, etc...

Feedbacks welcome :slightly_smiling_face: