### PR TITLE
Rsx: fix emulated primitive restart and hang on crash

### DIFF
--- a/rpcs3/Emu/RSX/GSRender.cpp
+++ b/rpcs3/Emu/RSX/GSRender.cpp
@@ -41,6 +41,8 @@ void GSRender::on_exit()
 {
 	if (m_frame)
 	{
+		m_frame->disable_wm_event_queue();
+		m_frame->clear_wm_events();
 		m_frame->delete_context(m_context);
 		m_context = nullptr;
 	}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -368,7 +368,7 @@ namespace rsx
 			vblank_count = 0;
 
 			// TODO: exit condition
-			while (!Emu.IsStopped())
+			while (!Emu.IsStopped() && !m_rsx_thread_exiting)
 			{
 				if (get_system_time() - start_time > vblank_count * 1000000 / 60)
 				{
@@ -389,7 +389,7 @@ namespace rsx
 					continue;
 				}
 
-				while (Emu.IsPaused())
+				while (Emu.IsPaused() && !m_rsx_thread_exiting)
 					std::this_thread::sleep_for(10ms);
 
 				std::this_thread::sleep_for(1ms); // hack
@@ -772,6 +772,7 @@ namespace rsx
 
 	void thread::on_exit()
 	{
+		m_rsx_thread_exiting = true;
 		if (m_vblank_thread)
 		{
 			m_vblank_thread->join();
@@ -1618,7 +1619,7 @@ namespace rsx
 
 		memset(display_buffers, 0, sizeof(display_buffers));
 
-		m_used_gcm_commands.clear();
+		m_rsx_thread_exiting = false;
 
 		on_init_rsx();
 		start_thread(fxm::get<GSRender>());

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -209,6 +209,7 @@ namespace rsx
 		std::shared_ptr<thread_ctrl> m_vblank_thread;
 
 	protected:
+		atomic_t<bool> m_rsx_thread_exiting{false};
 		std::stack<u32> m_call_stack;
 		std::array<push_buffer_vertex_info, 16> vertex_push_buffers;
 		std::vector<u32> element_push_buffer;
@@ -316,7 +317,6 @@ namespace rsx
 		u64 vblank_count;
 
 	public:
-		std::set<u32> m_used_gcm_commands;
 		bool invalid_command_interrupt_raised = false;
 		bool sync_point_request = false;
 		bool in_begin_end = false;

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -299,7 +299,7 @@ namespace rsx
 
 		for (int i = 0; i < index_count; ++i)
 		{
-			if (indices[i] == UINT16_MAX)
+			if (indices[i] == restart_index)
 			{
 				if (last_start >= 0)
 				{


### PR DESCRIPTION
- Fixes typo in emulated primitive restart, fixing graphics with some amd cards
- Fixes emu hang that could happen when rsx thread crashes/throws/exits, making sure the event queue is cleared and disabled and the vblank thread is shut down