### PR TITLE
Improved check for cellsurmixer event queue

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -356,7 +356,8 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 
 			while (!idm::select<lv2_obj, lv2_event_queue>([](u32, lv2_event_queue& eq)
 			{
-				return eq.name == "_mxr000\0"_u64;
+				//some games do not set event queue name, though key seems constant for them
+				return (eq.name == "_mxr000\0"_u64) || (eq.key == 0x8000cafe02460300);
 			}))
 			{
 				thread_ctrl::wait_for(50000);


### PR DESCRIPTION
Some games do not set mixer event queue name, which causes RPCS3 to get stuck indefinitely when creating mixer thread.

Contains magic event queue key, which at this point seems to be constant.