### PR TITLE
[WIP] SPU performance optimizations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,8 +7,8 @@
 	ignore = dirty
 [submodule "llvm"]
 	path = llvm
-	url = https://github.com/llvm-mirror/llvm
-	branch = release_40
+	url = https://github.com/RPCS3/llvm
+	branch = release_60
 [submodule "GSL"]
 	path = 3rdparty/GSL
 	url = https://github.com/Microsoft/GSL.git
@@ -35,6 +35,7 @@
 	path = 3rdparty/hidapi
 	url = https://github.com/RPCS3/hidapi
 	branch = master
+	ignore = dirty
 [submodule "3rdparty/Optional"]
 	path = 3rdparty/Optional
 	url = https://github.com/akrzemi1/Optional.git

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -32,13 +32,23 @@ void patch_engine::append(const std::string& patch)
 {
 	if (fs::file f{patch})
 	{
-		auto root = YAML::Load(f.to_string());
+		YAML::Node root;
+
+		try
+		{
+			root = YAML::Load(f.to_string());
+		}
+		catch (const std::exception& e)
+		{
+			LOG_FATAL(GENERAL, "Failed to load patch file %s\n%s thrown: %s", patch, typeid(e).name(), e.what());
+			return;
+		}
 
 		for (auto pair : root)
 		{
 			auto& name = pair.first.Scalar();
 			auto& data = m_map[name];
-			
+
 			for (auto patch : pair.second)
 			{
 				u64 type64 = 0;
@@ -91,7 +101,7 @@ void patch_engine::append(const std::string& patch)
 					break;
 				}
 				}
-				
+
 				data.emplace_back(info);
 			}
 		}

--- a/Utilities/mutex.cpp
+++ b/Utilities/mutex.cpp
@@ -14,7 +14,10 @@ void shared_mutex::imp_lock_shared(s64 _old)
 
 	for (int i = 0; i < 10; i++)
 	{
-		busy_wait();
+		if (i != 0)
+		{
+			busy_wait();
+		}
 
 		const s64 value = m_value.load();
 
@@ -173,7 +176,10 @@ void shared_mutex::imp_lock(s64 _old)
 
 	for (int i = 0; i < 10; i++)
 	{
-		busy_wait();
+		if (i != 0)
+		{
+			busy_wait();
+		}
 
 		const s64 value = m_value.load();
 
@@ -236,6 +242,10 @@ void shared_mutex::imp_lock_degrade()
 
 bool shared_mutex::try_lock_shared()
 {
+	if (m_value < c_min) // Fast path
+	{
+		return false;
+	}
 	// Conditional decrement
 	return m_value.fetch_op([](s64& value) { if (value >= c_min) value -= c_min; }) >= c_min;
 }

--- a/Utilities/sysinfo.cpp
+++ b/Utilities/sysinfo.cpp
@@ -39,6 +39,12 @@ bool utils::has_512()
 	return g_value;
 }
 
+bool utils::has_xop()
+{
+	static const bool g_value = has_avx() && get_cpuid(0x80000001, 0)[2] & 0x800;
+	return g_value;
+}
+
 std::string utils::get_system_info()
 {
 	std::string result;
@@ -91,6 +97,11 @@ std::string utils::get_system_info()
 		if (has_512())
 		{
 			result += '+';
+		}
+
+		if (has_xop())
+		{
+			result += 'x';
 		}
 	}
 

--- a/Utilities/sysinfo.h
+++ b/Utilities/sysinfo.h
@@ -26,6 +26,8 @@ namespace utils
 
 	bool has_512();
 
+	bool has_xop();
+
 	inline bool transaction_enter()
 	{
 		while (true)

--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -1,1 +1,13 @@
+#ifdef LLVM_AVAILABLE
+
 #include "CPUTranslator.h"
+
+cpu_translator::cpu_translator(llvm::LLVMContext& context, llvm::Module* module, bool is_be)
+    : m_context(context)
+	, m_module(module)
+	, m_is_be(is_be)
+{
+
+}
+
+#endif

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -1,1 +1,750 @@
 #pragma once
+
+#ifdef LLVM_AVAILABLE
+
+#include "restore_new.h"
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+#include "define_new_memleakdetect.h"
+
+#include "../Utilities/types.h"
+#include "../Utilities/StrFmt.h"
+#include "../Utilities/BEType.h"
+#include "../Utilities/BitField.h"
+
+#include <unordered_map>
+#include <map>
+#include <unordered_set>
+#include <set>
+#include <array>
+#include <vector>
+
+template <typename T = void>
+struct llvm_value_t
+{
+	static_assert(std::is_same<T, void>::value, "llvm_value_t<> error: unknown type");
+
+	using type = void;
+	static constexpr uint esize      = 0;
+	static constexpr bool is_int     = false;
+	static constexpr bool is_sint    = false;
+	static constexpr bool is_uint    = false;
+	static constexpr bool is_float   = false;
+	static constexpr uint is_vector  = false;
+	static constexpr uint is_pointer = false;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getVoidTy(context);
+	}
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		return value;
+	}
+
+	llvm::Value* value;
+
+	// llvm_value_t() = default;
+
+	// llvm_value_t(llvm::Value* value)
+	// 	: value(value)
+	// {
+	// }
+};
+
+template <>
+struct llvm_value_t<bool> : llvm_value_t<void>
+{
+	using type = bool;
+	using base = llvm_value_t<void>;
+	using base::base;
+
+	static constexpr uint esize  = 1;
+	static constexpr uint is_int = true;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getInt1Ty(context);
+	}
+};
+
+template <>
+struct llvm_value_t<char> : llvm_value_t<void>
+{
+	using type = char;
+	using base = llvm_value_t<void>;
+	using base::base;
+
+	static constexpr uint esize  = 8;
+	static constexpr bool is_int = true;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getInt8Ty(context);
+	}
+};
+
+template <>
+struct llvm_value_t<s8> : llvm_value_t<char>
+{
+	using type = s8;
+	using base = llvm_value_t<char>;
+	using base::base;
+
+	static constexpr bool is_sint = true;
+};
+
+template <>
+struct llvm_value_t<u8> : llvm_value_t<char>
+{
+	using type = u8;
+	using base = llvm_value_t<char>;
+	using base::base;
+
+	static constexpr bool is_uint = true;
+};
+
+template <>
+struct llvm_value_t<s16> : llvm_value_t<s8>
+{
+	using type = s16;
+	using base = llvm_value_t<s8>;
+	using base::base;
+
+	static constexpr uint esize = 16;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getInt16Ty(context);
+	}
+};
+
+template <>
+struct llvm_value_t<u16> : llvm_value_t<s16>
+{
+	using type = u16;
+	using base = llvm_value_t<s16>;
+	using base::base;
+
+	static constexpr bool is_sint = false;
+	static constexpr bool is_uint = true;
+};
+
+template <>
+struct llvm_value_t<s32> : llvm_value_t<s8>
+{
+	using type = s32;
+	using base = llvm_value_t<s8>;
+	using base::base;
+
+	static constexpr uint esize = 32;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getInt32Ty(context);
+	}
+};
+
+template <>
+struct llvm_value_t<u32> : llvm_value_t<s32>
+{
+	using type = u32;
+	using base = llvm_value_t<s32>;
+	using base::base;
+
+	static constexpr bool is_sint = false;
+	static constexpr bool is_uint = true;
+};
+
+template <>
+struct llvm_value_t<s64> : llvm_value_t<s8>
+{
+	using type = s64;
+	using base = llvm_value_t<s8>;
+	using base::base;
+
+	static constexpr uint esize = 64;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getInt64Ty(context);
+	}
+};
+
+template <>
+struct llvm_value_t<u64> : llvm_value_t<s64>
+{
+	using type = u64;
+	using base = llvm_value_t<s64>;
+	using base::base;
+
+	static constexpr bool is_sint = false;
+	static constexpr bool is_uint = true;
+};
+
+template <>
+struct llvm_value_t<s128> : llvm_value_t<s8>
+{
+	using type = s128;
+	using base = llvm_value_t<s8>;
+	using base::base;
+
+	static constexpr uint esize = 128;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getIntNTy(context, 128);
+	}
+};
+
+template <>
+struct llvm_value_t<u128> : llvm_value_t<s128>
+{
+	using type = u128;
+	using base = llvm_value_t<s128>;
+	using base::base;
+
+	static constexpr bool is_sint = false;
+	static constexpr bool is_uint = true;
+};
+
+template <>
+struct llvm_value_t<f32> : llvm_value_t<void>
+{
+	using type = f32;
+	using base = llvm_value_t<void>;
+	using base::base;
+
+	static constexpr uint esize    = 32;
+	static constexpr bool is_float = true;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getFloatTy(context);
+	}
+};
+
+template <>
+struct llvm_value_t<f64> : llvm_value_t<void>
+{
+	using type = f64;
+	using base = llvm_value_t<void>;
+	using base::base;
+
+	static constexpr uint esize    = 64;
+	static constexpr bool is_float = true;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::Type::getDoubleTy(context);
+	}
+};
+
+template <typename T>
+struct llvm_value_t<T*> : llvm_value_t<T>
+{
+	static_assert(!std::is_void<T>::value, "llvm_value_t<> error: invalid pointer to void type");
+
+	using type = T*;
+	using base = llvm_value_t<T>;
+	using base::base;
+
+	static constexpr uint is_pointer = llvm_value_t<T>::is_pointer + 1;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm_value_t<T>::get_type(context)->getPointerTo();
+	}
+};
+
+template <typename T, uint N>
+struct llvm_value_t<T[N]> : llvm_value_t<T>
+{
+	static_assert(!llvm_value_t<T>::is_vector, "llvm_value_t<> error: invalid multidimensional vector");
+	static_assert(!llvm_value_t<T>::is_pointer, "llvm_value_t<>: vector of pointers is not allowed");
+
+	using type = T[N];
+	using base = llvm_value_t<T>;
+	using base::base;
+
+	static constexpr uint is_vector  = N;
+	static constexpr uint is_pointer = 0;
+
+	static llvm::Type* get_type(llvm::LLVMContext& context)
+	{
+		return llvm::VectorType::get(llvm_value_t<T>::get_type(context), N);
+	}
+};
+
+template <typename T, typename A1, typename A2>
+struct llvm_add_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_sint || llvm_value_t<T>::is_uint || llvm_value_t<T>::is_float, "llvm_add_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_int)
+		{
+			return ir->CreateAdd(v1, v2);
+		}
+
+		if (llvm_value_t<T>::is_float)
+		{
+			return ir->CreateFAdd(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_add_t<typename T1::type, T1, T2> operator +(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T, typename A1, typename A2>
+struct llvm_sub_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_sint || llvm_value_t<T>::is_uint || llvm_value_t<T>::is_float, "llvm_sub_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_int)
+		{
+			return ir->CreateSub(v1, v2);
+		}
+
+		if (llvm_value_t<T>::is_float)
+		{
+			return ir->CreateFSub(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_sub_t<typename T1::type, T1, T2> operator -(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T, typename A1, typename A2>
+struct llvm_mul_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_sint || llvm_value_t<T>::is_uint || llvm_value_t<T>::is_float, "llvm_mul_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_int)
+		{
+			return ir->CreateMul(v1, v2);
+		}
+
+		if (llvm_value_t<T>::is_float)
+		{
+			return ir->CreateFMul(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_mul_t<typename T1::type, T1, T2> operator *(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T, typename A1, typename A2>
+struct llvm_div_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_sint || llvm_value_t<T>::is_uint || llvm_value_t<T>::is_float, "llvm_div_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_sint)
+		{
+			return ir->CreateSDiv(v1, v2);
+		}
+
+		if (llvm_value_t<T>::is_uint)
+		{
+			return ir->CreateUDiv(v1, v2);
+		}
+
+		if (llvm_value_t<T>::is_float)
+		{
+			return ir->CreateFDiv(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_div_t<typename T1::type, T1, T2> operator /(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T, typename A1>
+struct llvm_neg_t
+{
+	using type = T;
+
+	A1 a1;
+
+	static_assert(llvm_value_t<T>::is_sint || llvm_value_t<T>::is_uint || llvm_value_t<T>::is_float, "llvm_neg_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+
+		if (llvm_value_t<T>::is_int)
+		{
+			return ir->CreateNeg(v1);
+		}
+
+		if (llvm_value_t<T>::is_float)
+		{
+			return ir->CreateFNeg(v1);
+		}
+	}
+};
+
+template <typename T1, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<llvm_value_t<typename T1::type>::esize>>
+inline llvm_neg_t<typename T1::type, T1> operator -(T1 a1)
+{
+	return {a1};
+}
+
+// Constant int helper
+struct llvm_int_t
+{
+	u64 value;
+
+	u64 eval(llvm::IRBuilder<>*) const
+	{
+		return value;
+	}
+};
+
+template <typename T, typename A1, typename A2>
+struct llvm_shl_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_sint || llvm_value_t<T>::is_uint, "llvm_shl_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_sint)
+		{
+			return ir->CreateShl(v1, v2);
+		}
+
+		if (llvm_value_t<T>::is_uint)
+		{
+			return ir->CreateShl(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_shl_t<typename T1::type, T1, T2> operator <<(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T1, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<llvm_value_t<typename T1::type>::is_int>>
+inline llvm_shl_t<typename T1::type, T1, llvm_int_t> operator <<(T1 a1, u64 a2)
+{
+	return {a1, llvm_int_t{a2}};
+}
+
+template <typename T, typename A1, typename A2>
+struct llvm_shr_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_sint || llvm_value_t<T>::is_uint, "llvm_shr_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_sint)
+		{
+			return ir->CreateAShr(v1, v2);
+		}
+
+		if (llvm_value_t<T>::is_uint)
+		{
+			return ir->CreateLShr(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_shr_t<typename T1::type, T1, T2> operator >>(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T1, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<llvm_value_t<typename T1::type>::is_int>>
+inline llvm_shr_t<typename T1::type, T1, llvm_int_t> operator >>(T1 a1, u64 a2)
+{
+	return {a1, llvm_int_t{a2}};
+}
+
+template <typename T, typename A1, typename A2>
+struct llvm_and_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_int, "llvm_and_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_int)
+		{
+			return ir->CreateAnd(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_and_t<typename T1::type, T1, T2> operator &(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T1, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<llvm_value_t<typename T1::type>::is_int>>
+inline llvm_and_t<typename T1::type, T1, llvm_int_t> operator &(T1 a1, u64 a2)
+{
+	return {a1, llvm_int_t{a2}};
+}
+
+template <typename T, typename A1, typename A2>
+struct llvm_or_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_int, "llvm_or_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_int)
+		{
+			return ir->CreateOr(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_or_t<typename T1::type, T1, T2> operator |(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T1, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<llvm_value_t<typename T1::type>::is_int>>
+inline llvm_or_t<typename T1::type, T1, llvm_int_t> operator |(T1 a1, u64 a2)
+{
+	return {a1, llvm_int_t{a2}};
+}
+
+template <typename T, typename A1, typename A2>
+struct llvm_xor_t
+{
+	using type = T;
+
+	A1 a1;
+	A2 a2;
+
+	static_assert(llvm_value_t<T>::is_int, "llvm_xor_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+		const auto v2 = a2.eval(ir);
+
+		if (llvm_value_t<T>::is_int)
+		{
+			return ir->CreateXor(v1, v2);
+		}
+	}
+};
+
+template <typename T1, typename T2, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<std::is_same<typename T1::type, typename T2::type>::value>>
+inline llvm_xor_t<typename T1::type, T1, T2> operator ^(T1 a1, T2 a2)
+{
+	return {a1, a2};
+}
+
+template <typename T1, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<llvm_value_t<typename T1::type>::is_int>>
+inline llvm_xor_t<typename T1::type, T1, llvm_int_t> operator ^(T1 a1, u64 a2)
+{
+	return {a1, llvm_int_t{a2}};
+}
+
+template <typename T, typename A1>
+struct llvm_not_t
+{
+	using type = T;
+
+	A1 a1;
+
+	static_assert(llvm_value_t<T>::is_int, "llvm_not_t<>: invalid type");
+
+	llvm::Value* eval(llvm::IRBuilder<>* ir) const
+	{
+		const auto v1 = a1.eval(ir);
+
+		if (llvm_value_t<T>::is_int)
+		{
+			return ir->CreateNot(v1);
+		}
+	}
+};
+
+template <typename T1, typename = decltype(std::declval<T1>().eval(0)), typename = std::enable_if_t<llvm_value_t<typename T1::type>::is_int>>
+inline llvm_not_t<typename T1::type, T1> operator ~(T1 a1)
+{
+	return {a1};
+}
+
+class cpu_translator
+{
+protected:
+	cpu_translator(llvm::LLVMContext& context, llvm::Module* module, bool is_be);
+
+	// LLVM context
+	llvm::LLVMContext& m_context;
+
+	// Module to which all generated code is output to
+	llvm::Module* const m_module;
+
+	// Endianness, affects vector element numbering (TODO)
+	const bool m_is_be;
+
+	// IR builder
+	llvm::IRBuilder<>* m_ir;
+
+public:
+	// Convert a C++ type to an LLVM type (TODO: remove)
+	template <typename T>
+	llvm::Type* GetType()
+	{
+		return llvm_value_t<T>::get_type(m_context);
+	}
+
+	template <typename T>
+	llvm::Type* get_type()
+	{
+		return llvm_value_t<T>::get_type(m_context);
+	}
+
+	template <typename T>
+	using value_t = llvm_value_t<T>;
+
+	template <typename T>
+	auto eval(T expr)
+	{
+		value_t<typename T::type> result;
+		result.value = expr.eval(m_ir);
+		return result;
+	}
+
+	// Get unsigned addition carry into the sign bit (s = a + b)
+	template <typename T>
+	static inline auto ucarry(T a, T b, T s)
+	{
+		return ((a ^ b) & ~s) | (a & b);
+	}
+
+	// Get signed addition overflow into the sign bit (s = a + b)
+	template <typename T>
+	static inline auto scarry(T a, T b, T s)
+	{
+		return (b ^ s) & ~(a ^ b);
+	}
+
+	// Get signed subtraction overflow into the sign bit (d = a - b)
+	template <typename T>
+	static inline auto sborrow(T a, T b, T d)
+	{
+		return (a ^ b) & (a ^ d);
+	}
+
+	// Bitwise select (c ? a : b)
+	template <typename T>
+	static inline auto merge(T c, T a, T b)
+	{
+		return (a & c) | (b & ~c);
+	}
+
+	// Average: (a + b + 1) >> 1
+	template <typename T>
+	static inline auto avg(T a, T b)
+	{
+		return (a >> 1) + (b >> 1) + ((a | b) & 1);
+	}
+};
+
+#endif

--- a/rpcs3/Emu/Cell/MFC.cpp
+++ b/rpcs3/Emu/Cell/MFC.cpp
@@ -176,14 +176,16 @@ void mfc_thread::cpu_task()
 
 							data = to_write;
 							vm::reservation_update(cmd.eal, 128);
-							vm::notify(cmd.eal, 128);
 							_xend();
+							vm::notify(cmd.eal, 128);
 						}
 						else
 						{
-							vm::writer_lock lock(0);
-							data = to_write;
-							vm::reservation_update(cmd.eal, 128);
+							{
+								vm::writer_lock lock(0);
+								data = to_write;
+								vm::reservation_update(cmd.eal, 128);
+							}
 							vm::notify(cmd.eal, 128);
 						}
 					}
@@ -356,7 +358,6 @@ void mfc_thread::cpu_task()
 			}
 			else
 			{
-				vm::reader_lock lock;
 				vm::notify_all();
 			}
 		}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -961,14 +961,18 @@ extern bool ppu_stwcx(ppu_thread& ppu, u32 addr, u32 reg_value)
 		return result;
 	}
 
-	vm::writer_lock lock(0);
-
-	const bool result = ppu.rtime == vm::reservation_acquire(addr, sizeof(u32)) && data.compare_and_swap_test(static_cast<u32>(ppu.rdata), reg_value);
-
-	if (result)
+	bool result;
 	{
-		vm::reservation_update(addr, sizeof(u32));
-		vm::notify(addr, sizeof(u32));
+		vm::writer_lock lock(0);
+
+		result = ppu.rtime == vm::reservation_acquire(addr, sizeof(u32)) && data.compare_and_swap_test(static_cast<u32>(ppu.rdata), reg_value);
+
+		if (result)
+		{
+			vm::reservation_update(addr, sizeof(u32));
+			lock.unlock();
+			vm::notify(addr, sizeof(u32));
+		}
 	}
 
 	ppu.raddr = 0;
@@ -1005,14 +1009,18 @@ extern bool ppu_stdcx(ppu_thread& ppu, u32 addr, u64 reg_value)
 		return result;
 	}
 
-	vm::writer_lock lock(0);
-
-	const bool result = ppu.rtime == vm::reservation_acquire(addr, sizeof(u64)) && data.compare_and_swap_test(ppu.rdata, reg_value);
-
-	if (result)
+	bool result;
 	{
-		vm::reservation_update(addr, sizeof(u64));
-		vm::notify(addr, sizeof(u64));
+		vm::writer_lock lock(0);
+
+		result = ppu.rtime == vm::reservation_acquire(addr, sizeof(u64)) && data.compare_and_swap_test(ppu.rdata, reg_value);
+
+		if (result)
+		{
+			vm::reservation_update(addr, sizeof(u64));
+			lock.unlock();
+			vm::notify(addr, sizeof(u64));
+		}
 	}
 
 	ppu.raddr = 0;

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -12,9 +12,7 @@ using namespace llvm;
 const ppu_decoder<PPUTranslator> s_ppu_decoder;
 
 PPUTranslator::PPUTranslator(LLVMContext& context, Module* module, const ppu_module& info)
-	: m_context(context)
-	, m_module(module)
-	, m_is_be(false)
+	: cpu_translator(context, module, false)
 	, m_info(info)
 	, m_pure_attr(AttributeSet::get(m_context, AttributeSet::FunctionIndex, {Attribute::NoUnwind, Attribute::ReadNone}))
 {
@@ -564,136 +562,156 @@ void PPUTranslator::MTVSCR(ppu_opcode_t op)
 
 void PPUTranslator::VADDCUW(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi32, op.va, op.vb);
-	SetVr(op.vd, ZExt(m_ir->CreateICmpULT(m_ir->CreateAdd(ab[0], ab[1]), ab[0]), GetType<u32[4]>()));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(ucarry(a, b, eval(a + b)) >> 31));
 }
 
 void PPUTranslator::VADDFP(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vf, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateFAdd(ab[0], ab[1]));
+	const auto a = get_vr<f32[4]>(op.va);
+	const auto b = get_vr<f32[4]>(op.vb);
+	set_vr(op.vd, eval(a + b));
 }
 
 void PPUTranslator::VADDSBS(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi8, op.va, op.vb));
-	const auto result = m_ir->CreateAdd(ab[0], ab[1]);
-	const auto saturated = SaturateSigned(result, -0x80, 0x7f);
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s8[16]>(op.va);
+	const auto b = get_vr<s8[16]>(op.vb);
+	const auto s = eval(a + b);
+	const auto z = eval((a >> 7) ^ 0x7f);
+	const auto x = eval(scarry(a, b, s) >> 7);
+	set_vr(op.vd, eval(merge(x, z, s)));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VADDSHS(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi16, op.va, op.vb));
-	const auto result = m_ir->CreateAdd(ab[0], ab[1]);
-	const auto saturated = SaturateSigned(result, -0x8000, 0x7fff);
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s16[8]>(op.va);
+	const auto b = get_vr<s16[8]>(op.vb);
+	const auto s = eval(a + b);
+	const auto z = eval((a >> 15) ^ 0x7fff);
+	const auto x = eval(scarry(a, b, s) >> 15);
+	set_vr(op.vd, eval(merge(x, z, s)));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VADDSWS(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi32, op.va, op.vb));
-	const auto result = m_ir->CreateAdd(ab[0], ab[1]);
-	const auto saturated = SaturateSigned(result, -0x80000000ll, 0x7fffffff);
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s32[4]>(op.va);
+	const auto b = get_vr<s32[4]>(op.vb);
+	const auto s = eval(a + b);
+	const auto z = eval((a >> 31) ^ 0x7fffffff);
+	const auto x = eval(scarry(a, b, s) >> 31);
+	set_vr(op.vd, eval(merge(x, z, s)));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VADDUBM(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi8, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateAdd(ab[0], ab[1]));
+	const auto a = get_vr<u8[16]>(op.va);
+	const auto b = get_vr<u8[16]>(op.vb);
+	set_vr(op.vd, eval(a + b));
 }
 
 void PPUTranslator::VADDUBS(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi8, op.va, op.vb));
-	const auto result = m_ir->CreateAdd(ab[0], ab[1]);
-	const auto saturated = Saturate(result, ICmpInst::ICMP_UGT, m_ir->getInt16(0xff));
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s8[16]>(op.va);
+	const auto b = get_vr<s8[16]>(op.vb);
+	const auto s = eval(a + b);
+	const auto x = eval(ucarry(a, b, s) >> 7);
+	set_vr(op.vd, eval(s | x));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VADDUHM(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi16, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateAdd(ab[0], ab[1]));
+	const auto a = get_vr<u16[8]>(op.va);
+	const auto b = get_vr<u16[8]>(op.vb);
+	set_vr(op.vd, eval(a + b));
 }
 
 void PPUTranslator::VADDUHS(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi16, op.va, op.vb));
-	const auto result = m_ir->CreateAdd(ab[0], ab[1]);
-	const auto saturated = Saturate(result, ICmpInst::ICMP_UGT, m_ir->getInt32(0xffff));
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s16[8]>(op.va);
+	const auto b = get_vr<s16[8]>(op.vb);
+	const auto s = eval(a + b);
+	const auto x = eval(ucarry(a, b, s) >> 15);
+	set_vr(op.vd, eval(s | x));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VADDUWM(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi32, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateAdd(ab[0], ab[1]));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(a + b));
 }
 
 void PPUTranslator::VADDUWS(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi32, op.va, op.vb));
-	const auto result = m_ir->CreateAdd(ab[0], ab[1]);
-	const auto saturated = Saturate(result, ICmpInst::ICMP_UGT, m_ir->getInt64(0xffffffff));
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s32[4]>(op.va);
+	const auto b = get_vr<s32[4]>(op.vb);
+	const auto s = eval(a + b);
+	const auto x = eval(ucarry(a, b, s) >> 31);
+	set_vr(op.vd, eval(s | x));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VAND(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi32, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateAnd(ab[0], ab[1]));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(a & b));
 }
 
 void PPUTranslator::VANDC(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi32, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateAnd(ab[0], m_ir->CreateNot(ab[1])));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(a & ~b));
 }
-
-#define AVG_OP(a, b) m_ir->CreateLShr(m_ir->CreateSub(a, m_ir->CreateNot(b)), 1) /* (a + b + 1) >> 1 */
 
 void PPUTranslator::VAVGSB(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi8, op.va, op.vb));
-	SetVr(op.vd, AVG_OP(ab[0], ab[1]));
+	const auto a = get_vr<s8[16]>(op.va);
+	const auto b = get_vr<s8[16]>(op.vb);
+	set_vr(op.vd, eval(avg(a, b)));
 }
 
 void PPUTranslator::VAVGSH(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi16, op.va, op.vb));
-	SetVr(op.vd, AVG_OP(ab[0], ab[1]));
+	const auto a = get_vr<s16[8]>(op.va);
+	const auto b = get_vr<s16[8]>(op.vb);
+	set_vr(op.vd, eval(avg(a, b)));
 }
 
 void PPUTranslator::VAVGSW(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi32, op.va, op.vb));
-	SetVr(op.vd, AVG_OP(ab[0], ab[1]));
+	const auto a = get_vr<s32[4]>(op.va);
+	const auto b = get_vr<s32[4]>(op.vb);
+	set_vr(op.vd, eval(avg(a, b)));
 }
 
 void PPUTranslator::VAVGUB(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi8, op.va, op.vb));
-	SetVr(op.vd, AVG_OP(ab[0], ab[1]));
+	const auto a = get_vr<u8[16]>(op.va);
+	const auto b = get_vr<u8[16]>(op.vb);
+	set_vr(op.vd, eval(avg(a, b)));
 }
 
 void PPUTranslator::VAVGUH(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi16, op.va, op.vb));
-	SetVr(op.vd, AVG_OP(ab[0], ab[1]));
+	const auto a = get_vr<u16[8]>(op.va);
+	const auto b = get_vr<u16[8]>(op.vb);
+	set_vr(op.vd, eval(avg(a, b)));
 }
 
 void PPUTranslator::VAVGUW(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi32, op.va, op.vb));
-	SetVr(op.vd, AVG_OP(ab[0], ab[1]));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(avg(a, b)));
 }
 
 void PPUTranslator::VCFSX(ppu_opcode_t op)
@@ -1134,14 +1152,16 @@ void PPUTranslator::VNMSUBFP(ppu_opcode_t op)
 
 void PPUTranslator::VNOR(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi32, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateNot(m_ir->CreateOr(ab[0], ab[1])));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(~(a | b)));
 }
 
 void PPUTranslator::VOR(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi32, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateOr(ab[0], ab[1]));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(a | b));
 }
 
 void PPUTranslator::VPERM(ppu_opcode_t op)
@@ -1424,86 +1444,100 @@ void PPUTranslator::VSRW(ppu_opcode_t op)
 
 void PPUTranslator::VSUBCUW(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi32, op.va, op.vb);
-	SetVr(op.vd, ZExt(m_ir->CreateICmpUGE(ab[0], ab[1]), GetType<u32[4]>()));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(~ucarry(b, eval(a - b), a) >> 31));
 }
 
 void PPUTranslator::VSUBFP(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vf, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateFSub(ab[0], ab[1]));
+	const auto a = get_vr<f32[4]>(op.va);
+	const auto b = get_vr<f32[4]>(op.vb);
+	set_vr(op.vd, eval(a - b));
 }
 
 void PPUTranslator::VSUBSBS(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi8, op.va, op.vb));
-	const auto result = m_ir->CreateSub(ab[0], ab[1]);
-	const auto saturated = SaturateSigned(result, -0x80, 0x7f);
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s8[16]>(op.va);
+	const auto b = get_vr<s8[16]>(op.vb);
+	const auto d = eval(a - b);
+	const auto z = eval((a >> 7) ^ 0x7f);
+	const auto x = eval(sborrow(a, b, d) >> 7);
+	set_vr(op.vd, eval(merge(x, z, d)));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VSUBSHS(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi16, op.va, op.vb));
-	const auto result = m_ir->CreateSub(ab[0], ab[1]);
-	const auto saturated = SaturateSigned(result, -0x8000, 0x7fff);
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s16[8]>(op.va);
+	const auto b = get_vr<s16[8]>(op.vb);
+	const auto d = eval(a - b);
+	const auto z = eval((a >> 15) ^ 0x7fff);
+	const auto x = eval(sborrow(a, b, d) >> 15);
+	set_vr(op.vd, eval(merge(x, z, d)));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VSUBSWS(ppu_opcode_t op)
 {
-	const auto ab = SExt(GetVrs(VrType::vi32, op.va, op.vb));
-	const auto result = m_ir->CreateSub(ab[0], ab[1]);
-	const auto saturated = SaturateSigned(result, -0x80000000ll, 0x7fffffff);
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s32[4]>(op.va);
+	const auto b = get_vr<s32[4]>(op.vb);
+	const auto d = eval(a - b);
+	const auto z = eval((a >> 31) ^ 0x7fffffff);
+	const auto x = eval(sborrow(a, b, d) >> 31);
+	set_vr(op.vd, eval(merge(x, z, d)));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VSUBUBM(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi8, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateSub(ab[0], ab[1]));
+	const auto a = get_vr<u8[16]>(op.va);
+	const auto b = get_vr<u8[16]>(op.vb);
+	set_vr(op.vd, eval(a - b));
 }
 
 void PPUTranslator::VSUBUBS(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi8, op.va, op.vb));
-	const auto result = m_ir->CreateSub(ab[0], ab[1]);
-	const auto saturated = Saturate(result, ICmpInst::ICMP_SLT, m_ir->getInt16(0));
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s8[16]>(op.va);
+	const auto b = get_vr<s8[16]>(op.vb);
+	const auto d = eval(a - b);
+	const auto x = eval(ucarry(b, d, a) >> 7);
+	set_vr(op.vd, eval(d & ~x));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VSUBUHM(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi16, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateSub(ab[0], ab[1]));
+	const auto a = get_vr<u16[8]>(op.va);
+	const auto b = get_vr<u16[8]>(op.vb);
+	set_vr(op.vd, eval(a - b));
 }
 
 void PPUTranslator::VSUBUHS(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi16, op.va, op.vb));
-	const auto result = m_ir->CreateSub(ab[0], ab[1]);
-	const auto saturated = Saturate(result, ICmpInst::ICMP_SLT, m_ir->getInt32(0));
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s16[8]>(op.va);
+	const auto b = get_vr<s16[8]>(op.vb);
+	const auto d = eval(a - b);
+	const auto x = eval(ucarry(b, d, a) >> 15);
+	set_vr(op.vd, eval(d & ~x));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VSUBUWM(ppu_opcode_t op)
 {
-	const auto ab = GetVrs(VrType::vi32, op.va, op.vb);
-	SetVr(op.vd, m_ir->CreateSub(ab[0], ab[1]));
+	const auto a = get_vr<u32[4]>(op.va);
+	const auto b = get_vr<u32[4]>(op.vb);
+	set_vr(op.vd, eval(a - b));
 }
 
 void PPUTranslator::VSUBUWS(ppu_opcode_t op)
 {
-	const auto ab = ZExt(GetVrs(VrType::vi32, op.va, op.vb));
-	const auto result = m_ir->CreateSub(ab[0], ab[1]);
-	const auto saturated = Saturate(result, ICmpInst::ICMP_SLT, m_ir->getInt64(0));
-	SetVr(op.vd, saturated.first);
-	SetSat(IsNotZero(saturated.second));
+	const auto a = get_vr<s32[4]>(op.va);
+	const auto b = get_vr<s32[4]>(op.vb);
+	const auto d = eval(a - b);
+	const auto x = eval(ucarry(b, d, a) >> 31);
+	set_vr(op.vd, eval(d & ~x));
+	SetSat(IsNotZero(x.value));
 }
 
 void PPUTranslator::VSUMSWS(ppu_opcode_t op)

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -2,117 +2,12 @@
 
 #ifdef LLVM_AVAILABLE
 
-#include <unordered_map>
-#include <map>
-#include <unordered_set>
-#include <set>
-#include <array>
-#include <vector>
-
+#include "../rpcs3/Emu/CPU/CPUTranslator.h"
 #include "../rpcs3/Emu/Cell/PPUOpcodes.h"
 #include "../rpcs3/Emu/Cell/PPUAnalyser.h"
 
-#include "restore_new.h"
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-#include "define_new_memleakdetect.h"
-
-#include "../Utilities/types.h"
-#include "../Utilities/StrFmt.h"
-#include "../Utilities/BEType.h"
-
-template<typename T, typename = void>
-struct TypeGen
+class PPUTranslator final : public cpu_translator
 {
-	static_assert(!sizeof(T), "GetType<>() error: unknown type");
-};
-
-template<typename T>
-struct TypeGen<T, std::enable_if_t<std::is_void<T>::value>>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getVoidTy(context); }
-};
-
-template<typename T>
-struct TypeGen<T, std::enable_if_t<std::is_same<T, s64>::value || std::is_same<T, u64>::value || std::is_same<T, uptr>::value>>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getInt64Ty(context); }
-};
-
-template<typename T>
-struct TypeGen<T, std::enable_if_t<std::is_same<T, s32>::value || std::is_same<T, u32>::value>>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getInt32Ty(context); }
-};
-
-template<typename T>
-struct TypeGen<T, std::enable_if_t<std::is_same<T, s16>::value || std::is_same<T, u16>::value>>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getInt16Ty(context); }
-};
-
-template<typename T>
-struct TypeGen<T, std::enable_if_t<std::is_same<T, s8>::value || std::is_same<T, u8>::value || std::is_same<T, char>::value>>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getInt8Ty(context); }
-};
-
-template<>
-struct TypeGen<f32, void>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getFloatTy(context); }
-};
-
-template<>
-struct TypeGen<f64, void>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getDoubleTy(context); }
-};
-
-template<>
-struct TypeGen<bool, void>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getInt1Ty(context); }
-};
-
-template<>
-struct TypeGen<u128, void>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::Type::getIntNTy(context, 128); }
-};
-
-// Pointer type
-template<typename T>
-struct TypeGen<T*, void>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return TypeGen<T>::get(context)->getPointerTo(); }
-};
-
-// Vector type
-template<typename T, int N>
-struct TypeGen<T[N], void>
-{
-	static llvm::Type* get(llvm::LLVMContext& context) { return llvm::VectorType::get(TypeGen<T>::get(context), N); }
-};
-
-class PPUTranslator final //: public CPUTranslator
-{
-	// LLVM context
-	llvm::LLVMContext& m_context;
-
-	// Module to which all generated code is output to
-	llvm::Module* const m_module;
-
-	// Endianness, affects vector element numbering (TODO)
-	const bool m_is_be;
-
 	// PPU Module
 	const ppu_module& m_info;
 
@@ -121,9 +16,6 @@ class PPUTranslator final //: public CPUTranslator
 
 	// Attributes for function calls which are "pure" and may be optimized away if their results are unused
 	const llvm::AttributeSet m_pure_attr;
-
-	// IR builder
-	llvm::IRBuilder<>* m_ir;
 
 	// LLVM function
 	llvm::Function* m_function;
@@ -190,6 +82,20 @@ class PPUTranslator final //: public CPUTranslator
 
 #undef DEF_VALUE
 public:
+
+	template <typename T>
+	value_t<T> get_vr(u32 vr)
+	{
+		value_t<T> result;
+		result.value = m_ir->CreateBitCast(GetVr(vr, VrType::vi32), value_t<T>::get_type(m_context));
+		return result;
+	}
+
+	template <typename T>
+	void set_vr(u32 vr, value_t<T> v)
+	{
+		return SetVr(vr, v.value);
+	}
 
 	// Get current instruction address
 	llvm::Value* GetAddr(u64 _add = 0);
@@ -381,19 +287,6 @@ public:
 
 	// Write to memory
 	void WriteMemory(llvm::Value* addr, llvm::Value* value, bool is_be = true, u32 align = 1);
-
-	// Convert a C++ type to an LLVM type
-	template<typename T>
-	llvm::Type* GetType()
-	{
-		return TypeGen<T>::get(m_context);
-	}
-
-	template<typename T>
-	llvm::PointerType* GetPtrType()
-	{
-		return TypeGen<T>::get(m_context)->getPointerTo();
-	}
 
 	// Get an undefined value with specified type
 	template<typename T>

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -151,8 +151,9 @@ bool spu_recompiler::compile(spu_function_contents_t* f)
 
 	// Start compilation
 	m_pos = f->addr;
-
+  
 	for (const u32 op : f->data)
+
 	{
 		// Bind label if initialized
 		if (pos_labels[m_pos / 4].isValid())
@@ -623,6 +624,16 @@ void spu_recompiler::ROT(spu_opcode_t op)
 		return;
 	}
 
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		c->vprotd(vt, va, vb);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
 	auto body = [](u32* t, const u32* a, const s32* b) noexcept
 	{
 		for (u32 i = 0; i < 4; i++)
@@ -658,6 +669,22 @@ void spu_recompiler::ROTM(spu_opcode_t op)
 		c->psubd(vb, XmmConst(_mm_set1_epi32(1)));
 		c->pandn(vb, XmmConst(_mm_set1_epi32(0x3f)));
 		c->vpsrlvd(vt, va, vb);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		c->psubd(vb, XmmConst(_mm_set1_epi32(1)));
+		c->pandn(vb, XmmConst(_mm_set1_epi32(0x3f)));
+		c->pxor(vt, vt);
+		c->psubd(vt, vb);
+		c->pcmpgtd(vb, XmmConst(_mm_set1_epi32(31)));
+		c->vpshld(vt, va, vt);
+		c->vpandn(vt, vb, vt);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
 		return;
 	}
@@ -702,6 +729,21 @@ void spu_recompiler::ROTMA(spu_opcode_t op)
 		return;
 	}
 
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		c->psubd(vb, XmmConst(_mm_set1_epi32(1)));
+		c->pandn(vb, XmmConst(_mm_set1_epi32(0x3f)));
+		c->pxor(vt, vt);
+		c->pminud(vb, XmmConst(_mm_set1_epi32(31)));
+		c->psubd(vt, vb);
+		c->vpshad(vt, va, vt);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
 	auto body = [](s32* t, const s32* a, const u32* b) noexcept
 	{
 		for (u32 i = 0; i < 4; i++)
@@ -737,6 +779,19 @@ void spu_recompiler::SHL(spu_opcode_t op)
 		const XmmLink& vt = XmmAlloc();
 		c->pand(vb, XmmConst(_mm_set1_epi32(0x3f)));
 		c->vpsllvd(vt, va, vb);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		c->pand(vb, XmmConst(_mm_set1_epi32(0x3f)));
+		c->vpcmpgtd(vt, vb, XmmConst(_mm_set1_epi32(31)));
+		c->vpshld(vb, va, vb);
+		c->pandn(vt, vb);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
 		return;
 	}
@@ -785,6 +840,16 @@ void spu_recompiler::ROTH(spu_opcode_t op) //nf
 		return;
 	}
 
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		c->vprotw(vt, va, vb);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
 	auto body = [](u16* t, const u16* a, const u16* b) noexcept
 	{
 		for (u32 i = 0; i < 8; i++)
@@ -820,6 +885,42 @@ void spu_recompiler::ROTHM(spu_opcode_t op)
 		c->psubw(vb, XmmConst(_mm_set1_epi16(1)));
 		c->pandn(vb, XmmConst(_mm_set1_epi16(0x1f)));
 		c->vpsrlvw(vt, va, vb);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
+	if (utils::has_avx2())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		const XmmLink& v4 = XmmAlloc();
+		const XmmLink& v5 = XmmAlloc();
+		c->psubw(vb, XmmConst(_mm_set1_epi16(1)));
+		c->pandn(vb, XmmConst(_mm_set1_epi16(0x1f)));
+		c->movdqa(vt, XmmConst(_mm_set1_epi32(0xffff0000))); // mask: select high words
+		c->vpsrld(v4, vb, 16);
+		c->vpsubusw(v5, vb, vt); // clear high words (using saturation sub for throughput)
+		c->vpandn(vb, vt, va); // clear high words
+		c->vpsrlvd(va, va, v4);
+		c->vpsrlvd(vb, vb, v5);
+		c->vpblendw(vt, vb, va, 0xaa); // can use vpblendvb with 0xffff0000 mask (vt)
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		c->psubw(vb, XmmConst(_mm_set1_epi16(1)));
+		c->pandn(vb, XmmConst(_mm_set1_epi16(0x1f)));
+		c->pxor(vt, vt);
+		c->psubw(vt, vb);
+		c->pcmpgtw(vb, XmmConst(_mm_set1_epi16(15)));
+		c->vpshlw(vt, va, vt);
+		c->vpandn(vt, vb, vt);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
 		return;
 	}
@@ -864,6 +965,43 @@ void spu_recompiler::ROTMAH(spu_opcode_t op)
 		return;
 	}
 
+	if (utils::has_avx2())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		const XmmLink& v4 = XmmAlloc();
+		const XmmLink& v5 = XmmAlloc();
+		c->psubw(vb, XmmConst(_mm_set1_epi16(1)));
+		c->movdqa(vt, XmmConst(_mm_set1_epi16(0x1f)));
+		c->vpandn(v4, vb, vt);
+		c->vpand(v5, vb, vt);
+		c->movdqa(vt, XmmConst(_mm_set1_epi32(0x2f)));
+		c->vpsrld(v4, v4, 16);
+		c->vpsubusw(v5, vt, v5); // clear high word and add 16 to low word
+		c->vpslld(vb, va, 16);
+		c->vpsravd(va, va, v4);
+		c->vpsravd(vb, vb, v5);
+		c->vpblendw(vt, vb, va, 0xaa);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		c->psubw(vb, XmmConst(_mm_set1_epi16(1)));
+		c->pandn(vb, XmmConst(_mm_set1_epi16(0x1f)));
+		c->pxor(vt, vt);
+		c->pminuw(vb, XmmConst(_mm_set1_epi16(15)));
+		c->psubw(vt, vb);
+		c->vpshaw(vt, va, vt);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
 	auto body = [](s16* t, const s16* a, const u16* b) noexcept
 	{
 		for (u32 i = 0; i < 8; i++)
@@ -903,6 +1041,38 @@ void spu_recompiler::SHLH(spu_opcode_t op)
 		return;
 	}
 
+	if (utils::has_avx2())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		const XmmLink& v4 = XmmAlloc();
+		const XmmLink& v5 = XmmAlloc();
+		c->pand(vb, XmmConst(_mm_set1_epi16(0x1f)));
+		c->movdqa(vt, XmmConst(_mm_set1_epi32(0xffff0000))); // mask: select high words
+		c->vpsrld(v4, vb, 16);
+		c->vpsubusw(v5, vb, vt); // clear high words (using saturation sub for throughput)
+		c->vpand(vb, vt, va); // clear low words
+		c->vpsllvd(va, va, v5);
+		c->vpsllvd(vb, vb, v4);
+		c->vpblendw(vt, vb, va, 0x55);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+		const XmmLink& vt = XmmAlloc();
+		c->pand(vb, XmmConst(_mm_set1_epi16(0x1f)));
+		c->vpcmpgtw(vt, vb, XmmConst(_mm_set1_epi16(15)));
+		c->vpshlw(vb, va, vb);
+		c->pandn(vt, vb);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+
 	auto body = [](u16* t, const u16* a, const u16* b) noexcept
 	{
 		for (u32 i = 0; i < 8; i++)
@@ -937,6 +1107,14 @@ void spu_recompiler::ROTI(spu_opcode_t op)
 	{
 		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
 		c->vprold(va, va, s);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), va);
+		return;
+	}
+
+	if (utils::has_xop())
+	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		c->vprotd(va, va, s);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), va);
 		return;
 	}
@@ -1682,16 +1860,14 @@ void spu_recompiler::SHLQBY(spu_opcode_t op)
 
 void spu_recompiler::ORX(spu_opcode_t op)
 {
-	c->mov(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, 0));
-	c->or_(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, 1));
-	c->or_(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, 2));
-	c->or_(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, 3));
-	c->mov(SPU_OFF_32(gpr, op.rt, &v128::_u32, 3), *addr);
-	c->xor_(*addr, *addr);
-	c->mov(SPU_OFF_32(gpr, op.rt, &v128::_u32, 0), *addr);
-	c->mov(SPU_OFF_32(gpr, op.rt, &v128::_u32, 1), *addr);
-	c->mov(SPU_OFF_32(gpr, op.rt, &v128::_u32, 2), *addr);
-	c->unuse(*addr);
+	const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+	const XmmLink& v1 = XmmAlloc();
+	c->pshufd(v1, va, 0xb1);
+	c->por(va, v1);
+	c->pshufd(v1, va, 0x4e);
+	c->por(va, v1);
+	c->pslldq(va, 12);
+	c->movdqa(SPU_OFF_128(gpr, op.rt), va);
 }
 
 void spu_recompiler::CBD(spu_opcode_t op)
@@ -3298,6 +3474,13 @@ void spu_recompiler::SELB(spu_opcode_t op)
 		return;
 	}
 
+	if (utils::has_xop())
+	{
+		c->vpcmov(vc, vb, SPU_OFF_128(gpr, op.ra), vc);
+		c->movdqa(SPU_OFF_128(gpr, op.rt4), vc);
+		return;
+	}
+
 	c->pand(vb, vc);
 	c->pandn(vc, SPU_OFF_128(gpr, op.ra));
 	c->por(vb, vc);
@@ -3421,6 +3604,10 @@ void spu_recompiler::SHUFB(spu_opcode_t op)
 	if (utils::has_512())
 	{
 		c->vpternlogd(vc, va, vb, 0xca /* A?B:C */);
+	}
+	else if (utils::has_xop())
+	{
+		c->vpcmov(vc, va, vb, vc);
 	}
 	else
 	{

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -10,11 +10,6 @@
 
 #include <cmath>
 
-#define ASMJIT_STATIC
-#define ASMJIT_DEBUG
-
-#include "asmjit.h"
-
 #define SPU_OFF_128(x, ...) asmjit::x86::oword_ptr(*cpu, offset32(&SPUThread::x, ##__VA_ARGS__))
 #define SPU_OFF_64(x, ...) asmjit::x86::qword_ptr(*cpu, offset32(&SPUThread::x, ##__VA_ARGS__))
 #define SPU_OFF_32(x, ...) asmjit::x86::dword_ptr(*cpu, offset32(&SPUThread::x, ##__VA_ARGS__))

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
@@ -21,7 +21,7 @@ class spu_recompiler : public spu_recompiler_base
 public:
 	spu_recompiler();
 
-	virtual void compile(spu_function_t& f) override;
+	virtual bool compile(std::shared_ptr<spu_function_contents_t> f) override;
 
 private:
 	// emitter:
@@ -41,7 +41,7 @@ private:
 	std::array<asmjit::X86Xmm*, 6> vec;
 
 	// labels:
-	asmjit::Label* labels; // array[0x10000]
+	std::unique_ptr<asmjit::Label[]> labels; // array[0x10000]
 	asmjit::Label* jt; // jump table resolver (uses *addr)
 	asmjit::Label* end; // function end (return *addr)
 

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
@@ -1,17 +1,11 @@
 #pragma once
 
-#include "SPURecompiler.h"
+#define ASMJIT_STATIC
+#define ASMJIT_DEBUG
 
-namespace asmjit
-{
-	struct JitRuntime;
-	struct CodeHolder;
-	struct X86Compiler;
-	struct X86Gp;
-	struct X86Xmm;
-	struct X86Mem;
-	struct Label;
-}
+#include "asmjit.h"
+
+#include "SPURecompiler.h"
 
 // SPU ASMJIT Recompiler
 class spu_recompiler : public spu_recompiler_base

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
@@ -15,7 +15,7 @@ class spu_recompiler : public spu_recompiler_base
 public:
 	spu_recompiler();
 
-	virtual bool compile(std::shared_ptr<spu_function_contents_t> f) override;
+	virtual bool compile(spu_function_contents_t* f) override;
 
 private:
 	// emitter:

--- a/rpcs3/Emu/Cell/SPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/SPUAnalyser.cpp
@@ -72,16 +72,6 @@ spu_function_contents_t* SPUDatabase::analyse(const be_t<u32>* ls, u32 entry, vo
 		}
 	}
 
-	/*{
-		writer_lock lock(m_mutex);
-
-		// Double-check
-		if (auto func = find(base, key, block_sz))
-		{
-			return func;
-		}
-	}*/
-
 	// Initialize block entries with the function entry point
 	std::set<u32> blocks{ entry };
 
@@ -397,7 +387,7 @@ spu_function_contents_t* SPUDatabase::analyse(const be_t<u32>* ls, u32 entry, vo
 		m_db.emplace(key, func);
 	}
 
-	LOG_FATAL(SPU, "Function detected [0x%05x-0x%05x] (size=0x%x)", func->addr, func->addr + func->size, func->size);
+	LOG_NOTICE(SPU, "Function detected [0x%05x-0x%05x] (size=0x%x)", func->addr, func->addr + func->size, func->size);
 
 	return func;
 }

--- a/rpcs3/Emu/Cell/SPUAnalyser.h
+++ b/rpcs3/Emu/Cell/SPUAnalyser.h
@@ -265,6 +265,9 @@ struct spu_function_contents_t
 	// Basic blocks (start addresses)
 	std::set<u32> blocks;
 
+	// Basic blocks size
+	std::vector<u32> blocks_size;
+
 	// Functions possibly called by this function (may not be available)
 	std::set<u32> adjacent;
 
@@ -288,7 +291,7 @@ struct spu_function_contents_t
 union spu_function_t
 {
 	// The function itself and its data
-	std::shared_ptr<spu_function_contents_t> contents;
+	spu_function_contents_t * contents;
 
 	// Whether pages the function is in were written to since its last execution
 	bool dirty_bit : 1;
@@ -299,7 +302,7 @@ union spu_function_t
 	}
 
 	spu_function_t() : contents(nullptr) {};
-	~spu_function_t() {dirty_bit = false; contents.reset();};
+	~spu_function_t() {};
 };
 
 // SPU Function Database (must be global or PS3 process-local)
@@ -308,15 +311,15 @@ class SPUDatabase final : spu_itype
 	shared_mutex m_mutex;
 
 	// All registered functions (uses addr and first instruction as a key)
-	std::unordered_multimap<u64, std::shared_ptr<spu_function_contents_t>> m_db;
+	std::unordered_multimap<u64, spu_function_contents_t*> m_db;
 
 	// For internal use
-	std::shared_ptr<spu_function_contents_t> find(const be_t<u32>* data, u64 key, u32 max_size, void* ignore = nullptr);
+	spu_function_contents_t* find(const be_t<u32>* data, u64 key, u32 max_size, void* ignore = nullptr);
 
 public:
 	SPUDatabase();
 	~SPUDatabase();
 
 	// Try to retrieve SPU function information
-	std::shared_ptr<spu_function_contents_t> analyse(const be_t<u32>* ls, u32 entry, void * ignore=nullptr);
+	spu_function_contents_t* analyse(const be_t<u32>* ls, u32 entry, void * ignore=nullptr);
 };

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -102,7 +102,7 @@ void spu_interpreter::RDCH(SPUThread& spu, spu_opcode_t op)
 	else
 	{
 		memset(&spu.gpr[op.rt], 0, 3*sizeof(u32));
-		spu.gpr[op.rt]._u32[3] = result; v128::from32r(result);
+		spu.gpr[op.rt]._u32[3] = result;
 	}
 }
 

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -101,7 +101,8 @@ void spu_interpreter::RDCH(SPUThread& spu, spu_opcode_t op)
 	}
 	else
 	{
-		spu.gpr[op.rt] = v128::from32r(result);
+		memset(&spu.gpr[op.rt], 0, 3*sizeof(u32));
+		spu.gpr[op.rt]._u32[3] = result; v128::from32r(result);
 	}
 }
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -25,7 +25,9 @@ void spu_recompiler_base::enter(SPUThread& spu)
 
 	// Search if cached data matches
 	auto & func = spu.compiled_cache[spu.pc / 4];
-	if (func.dirty_bit)
+
+	// func.contents is there only as a temporary test, to see if SPU codfe not getting invalidated is the reason for the crashes
+	if (func.contents || func.dirty_bit)
 	{
 		func.dirty_bit = false;
 		

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -24,39 +24,48 @@ void spu_recompiler_base::enter(SPUThread& spu)
 	const auto _ls = vm::ps3::_ptr<u32>(spu.offset);
 
 	// Search if cached data matches
-	auto func = spu.compiled_cache[spu.pc / 4];
-
-	// Check shared db if we dont have a match
-	if (!func || !std::equal(func->data.begin(), func->data.end(), _ls + spu.pc / 4, [](const be_t<u32>& l, const be_t<u32>& r) { return *(u32*)(u8*)&l == *(u32*)(u8*)&r; }))
+	auto & func = spu.compiled_cache[spu.pc / 4];
+	if (func.dirty_bit)
 	{
-		func = spu.spu_db->analyse(_ls, spu.pc);
-		spu.compiled_cache[spu.pc / 4] = func;
+		func.dirty_bit = false;
+		
+		// This memcmp acts as a fast path instead of finding it again in analyse.
+		if (memcmp(func.contents->data.data(), _ls + (spu.pc / 4), func.contents->size) != 0)
+		{
+			func.contents = spu.spu_db->analyse(_ls, spu.pc, func.contents.get());
+		}
+	}
+	else if (!func)
+	{
+		func.contents = spu.spu_db->analyse(_ls, spu.pc);
+		spu.compiled_functions.push_back(&func);
 	}
 
 	// Reset callstack if necessary
-	if ((func->does_reset_stack && spu.recursion_level) || spu.recursion_level >= 128)
+	if ((func.contents->does_reset_stack && spu.recursion_level) || spu.recursion_level >= 128)
 	{
 		spu.state += cpu_flag::ret;
 		return;
 	}
 
 	// Compile if needed
-	if (!func->compiled)
+	if (!func.contents->compiled)
 	{
 		if (!spu.spu_rec)
 		{
 			spu.spu_rec = fxm::get_always<spu_recompiler>();
 		}
 
-		spu.spu_rec->compile(*func);
+		spu.spu_rec->compile(func.contents);
 
-		if (!func->compiled) fmt::throw_exception("Compilation failed" HERE);
+		if (!func.contents->compiled) fmt::throw_exception("Compilation failed" HERE);
 	}
 
-	const u32 res = func->compiled(&spu, _ls);
+	const u32 res = func.contents->compiled(&spu, _ls);
 
-	if (const auto exception = spu.pending_exception)
+	if (spu.pending_exception)
 	{
+		const auto exception = spu.pending_exception;
 		spu.pending_exception = nullptr;
 		std::rethrow_exception(exception);
 	}

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -26,8 +26,8 @@ void spu_recompiler_base::enter(SPUThread& spu)
 	// Search if cached data matches
 	auto func_ptr = spu.compiled_cache[spu.pc / 4];
 
-	// func.contents is there only as a temporary test, to see if SPU code not getting invalidated is the reason for the crashes
-	if (func_ptr && func_ptr->dirty_bit)
+	// Dirty bit check commented out until another code invalidation is found - SYNC, SYNCC, DSYNC and DMAs aren't covering everything
+	if (func_ptr/* && func_ptr->dirty_bit*/)
 	{
 		auto & func = *func_ptr;
 		func.dirty_bit = false;

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -24,46 +24,53 @@ void spu_recompiler_base::enter(SPUThread& spu)
 	const auto _ls = vm::ps3::_ptr<u32>(spu.offset);
 
 	// Search if cached data matches
-	auto & func = spu.compiled_cache[spu.pc / 4];
+	auto func_ptr = spu.compiled_cache[spu.pc / 4];
 
-	// func.contents is there only as a temporary test, to see if SPU codfe not getting invalidated is the reason for the crashes
-	if (func.contents || func.dirty_bit)
+	// func.contents is there only as a temporary test, to see if SPU code not getting invalidated is the reason for the crashes
+	if (func_ptr && func_ptr->dirty_bit)
 	{
+		auto & func = *func_ptr;
 		func.dirty_bit = false;
-		
-		// This memcmp acts as a fast path instead of finding it again in analyse.
-		if (memcmp(func.contents->data.data(), _ls + (spu.pc / 4), func.contents->size) != 0)
+		u32 index = (reinterpret_cast<size_t>(func_ptr) - reinterpret_cast<size_t>(&spu.compiled_functions[0])) / sizeof(func);
+		spu.first_clean_func_index = std::min<u32>(index, spu.first_clean_func_index);
+		spu.last_clean_func_index = std::max<u32>(index + 1, spu.last_clean_func_index);
+
+		if (!spu.same_function(func.contents, _ls + (spu.pc / 4)))
 		{
-			func.contents = spu.spu_db->analyse(_ls, spu.pc, func.contents.get());
+			func.contents = spu.spu_db->analyse(_ls, spu.pc, func.contents);
 		}
 	}
-	else if (!func)
+	else if (!func_ptr)
 	{
+		auto & func = spu.compiled_functions[++spu.next_compiled_func_index];
 		func.contents = spu.spu_db->analyse(_ls, spu.pc);
-		spu.compiled_functions.push_back(&func);
+		func_ptr = &func;
+		spu.compiled_cache[spu.pc / 4] = func_ptr;
+		spu.last_clean_func_index = spu.next_compiled_func_index + 1;
+		spu.first_clean_func_index = std::min<u32>(spu.first_clean_func_index, spu.next_compiled_func_index);
 	}
 
 	// Reset callstack if necessary
-	if ((func.contents->does_reset_stack && spu.recursion_level) || spu.recursion_level >= 128)
+	if ((func_ptr->contents->does_reset_stack && spu.recursion_level) || spu.recursion_level >= 128)
 	{
 		spu.state += cpu_flag::ret;
 		return;
 	}
 
 	// Compile if needed
-	if (!func.contents->compiled)
+	if (!func_ptr->contents->compiled)
 	{
 		if (!spu.spu_rec)
 		{
 			spu.spu_rec = fxm::get_always<spu_recompiler>();
 		}
 
-		spu.spu_rec->compile(func.contents);
+		spu.spu_rec->compile(func_ptr->contents);
 
-		if (!func.contents->compiled) fmt::throw_exception("Compilation failed" HERE);
+		if (!func_ptr->contents->compiled) fmt::throw_exception("Compilation failed" HERE);
 	}
 
-	const u32 res = func.contents->compiled(&spu, _ls);
+	const u32 res = func_ptr->contents->compiled(&spu, _ls);
 
 	if (spu.pending_exception)
 	{

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -10,7 +10,7 @@ class spu_recompiler_base
 protected:
 	std::mutex m_mutex; // must be locked in compile()
 
-	const spu_function_t* m_func; // current function
+	std::shared_ptr<const spu_function_contents_t> m_func; // current function
 
 	u32 m_pos; // current position
 
@@ -18,7 +18,7 @@ public:
 	virtual ~spu_recompiler_base();
 
 	// Compile specified function
-	virtual void compile(spu_function_t& f) = 0;
+	virtual bool compile(std::shared_ptr<spu_function_contents_t>) = 0;
 
 	// Run
 	static void enter(class SPUThread&);

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -10,7 +10,7 @@ class spu_recompiler_base
 protected:
 	std::mutex m_mutex; // must be locked in compile()
 
-	std::shared_ptr<const spu_function_contents_t> m_func; // current function
+	const spu_function_contents_t* m_func; // current function
 
 	u32 m_pos; // current position
 
@@ -18,7 +18,7 @@ public:
 	virtual ~spu_recompiler_base();
 
 	// Compile specified function
-	virtual bool compile(std::shared_ptr<spu_function_contents_t>) = 0;
+	virtual bool compile(spu_function_contents_t*) = 0;
 
 	// Run
 	static void enter(class SPUThread&);

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -563,7 +563,7 @@ void SPUThread::do_dma_transfer(const spu_mfc_cmd& args, bool from_mfc)
 			auto faddr = func.contents->addr;
 			auto fsize = func.contents->size;
 
-			if (faddr >= eal && faddr + fsize < eal + args.size)
+			if (fsize + faddr > eal && eal + args.size > faddr)
 			{
 				func.dirty_bit = true;
 			}

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -215,8 +215,7 @@ public:
 	{
 		const auto old = data.fetch_op([](sync_var_t& data)
 		{
-			sync_var_t t;
-			*reinterpret_cast<u64*>(&t) = 0;
+			sync_var_t t{};
 			t.wait = !data.count;
 			data = t;
 		});
@@ -582,8 +581,13 @@ public:
 
 	// No need for shared_ptr in the following two, as whenever something is removed or added to one,
 	// the same goes for the other.
-	std::array<spu_function_t, 65536> compiled_cache{};
-	std::vector<spu_function_t*> compiled_functions{};
+	std::array<spu_function_t*, 65536> compiled_cache{};
+	std::array<spu_function_t, 65536> compiled_functions{};
+	u32 next_compiled_func_index = -1;
+	u32 first_clean_func_index = 0;
+	u32 last_clean_func_index = 0;
+
+
 	std::shared_ptr<class SPUDatabase> spu_db;
 	std::shared_ptr<class spu_recompiler_base> spu_rec;
 	u32 recursion_level = 0;
@@ -599,6 +603,7 @@ public:
 	bool get_ch_value(u32 ch, u32& out);
 	bool set_ch_value(u32 ch, u32 value);
 	bool stop_and_signal(u32 code);
+	bool same_function(const spu_function_contents_t * func, const void * addr);
 	void halt();
 
 	void fast_call(u32 ls_addr);

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -775,6 +775,12 @@ error_code sys_spu_thread_write_ls(u32 id, u32 lsa, u64 value, u32 type)
 	default: return CELL_EINVAL;
 	}
 
+	auto func = thread->compiled_cache[lsa / 4];
+	if (func)
+	{
+		func->dirty_bit = true;
+	}
+
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_time.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_time.cpp
@@ -131,25 +131,20 @@ u64 get_timebased_time()
 // Returns some relative time in microseconds, don't change this fact
 u64 get_system_time()
 {
+#ifdef _WIN32
+	// Pull the time directly from Windows shared page (Constant location on all Windows machines)
+	return *reinterpret_cast<u64*>(0x7ffe0014) / 10;
+#else
 	while (true)
 	{
-#ifdef _WIN32
-		LARGE_INTEGER count;
-		verify(HERE), QueryPerformanceCounter(&count);
-
-		const u64 time = count.QuadPart;
-		const u64 freq = s_time_aux_info.perf_freq;
-
-		const u64 result = time / freq * 1000000u + (time % freq) * 1000000u / freq;
-#else
 		struct timespec ts;
 		verify(HERE), ::clock_gettime(CLOCK_MONOTONIC, &ts) == 0;
 
 		const u64 result = static_cast<u64>(ts.tv_sec) * 1000000u + static_cast<u64>(ts.tv_nsec) / 1000u;
-#endif
 
 		if (result) return result;
 	}
+#endif
 }
 
 // Functions

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -8,16 +8,15 @@
 #include "Emu/Cell/lv2/sys_memory.h"
 #include "Emu/RSX/GSRender.h"
 
-#include <atomic>
-#include <deque>
-
 namespace vm
 {
-	static u8* memory_reserve_4GiB(std::uintptr_t _addr = 0)
+	std::array<memory_page, 0x100000000 / 4096> g_pages{};
+
+	static u8* memory_reserve_4GiB(const std::uintptr_t _addr = 0)
 	{
-		for (u64 addr = _addr + 0x100000000;; addr += 0x100000000)
+		for (auto addr = _addr + 0x100000000;; addr += 0x100000000)
 		{
-			if (auto ptr = utils::memory_reserve(0x100000000, (void*)addr))
+			if (const auto ptr = utils::memory_reserve(0x100000000, reinterpret_cast<void*>(addr)))
 			{
 				return static_cast<u8*>(ptr);
 			}
@@ -39,11 +38,12 @@ namespace vm
 	// Memory locations
 	std::vector<std::shared_ptr<block_t>> g_locations;
 
-	// Reservations (lock lines) in a single memory page
-	using reservation_info = std::array<std::atomic<u64>, 4096 / 128>;
-
 	// Registered waiters
-	std::deque<vm::waiter*> g_waiters;
+	std::vector<vm::waiter*> g_waiters;
+
+	// Waiters which will be removed once the lock is freed
+	std::mutex g_waiters_to_remove_lock;
+	std::vector<vm::waiter*> g_waiters_to_remove;
 
 	// Memory mutex core
 	shared_mutex g_mutex;
@@ -201,78 +201,52 @@ namespace vm
 	{
 	}
 
-	writer_lock::~writer_lock()
+	void writer_lock::unlock()
 	{
 		if (locked)
 		{
-			g_mutex.unlock();
-		}
-	}
-
-	// Page information
-	struct memory_page
-	{
-		// Memory flags
-		atomic_t<u8> flags;
-
-		atomic_t<u32> waiters;
-
-		// Reservations
-		atomic_t<reservation_info*> reservations;
-
-		// Access reservation info
-		std::atomic<u64>& operator [](u32 addr)
-		{
-			auto ptr = reservations.load();
-
-			if (!ptr)
+			if (!g_waiters_to_remove.empty())
 			{
-				// Opportunistic memory allocation
-				ptr = new reservation_info{};
-
-				if (auto old_ptr = reservations.compare_and_swap(nullptr, ptr))
+				std::lock_guard<std::mutex> lock(g_waiters_to_remove_lock);
+				for (auto ptr : g_waiters_to_remove)
 				{
+					const auto found = std::find(g_waiters.cbegin(), g_waiters.cend(), ptr);
+					if (found != g_waiters.cend())
+					{
+						g_waiters.erase(found);
+					}
 					delete ptr;
-					ptr = old_ptr;
 				}
+				g_waiters_to_remove.clear();
 			}
 
-			return (*ptr)[(addr & 0xfff) >> 7];
+			g_mutex.unlock();
+
+			locked = false;
 		}
-	};
-
-	// Memory pages
-	std::array<memory_page, 0x100000000 / 4096> g_pages{};
-
-	u64 reservation_acquire(u32 addr, u32 _size)
-	{
-		// Access reservation info: stamp and the lock bit
-		return g_pages[addr >> 12][addr].load(std::memory_order_acquire);
 	}
 
-	void reservation_update(u32 addr, u32 _size)
+	writer_lock::~writer_lock()
 	{
-		// Update reservation info with new timestamp (unsafe, assume allocated)
-		(*g_pages[addr >> 12].reservations)[(addr & 0xfff) >> 7].store(__rdtsc(), std::memory_order_release);
+		unlock();
 	}
 
 	void waiter::init()
 	{
 		// Register waiter
 		writer_lock lock(0);
-
 		g_waiters.emplace_back(this);
 	}
 
 	void waiter::test() const
 	{
-		if (std::memcmp(data, vm::base(addr), size) == 0)
+		const auto owner_copy = owner;
+		if (!owner_copy)
 		{
 			return;
 		}
 
 		memory_page& page = g_pages[addr >> 12];
-
 		if (page.reservations == nullptr)
 		{
 			return;
@@ -283,23 +257,40 @@ namespace vm
 			return;
 		}
 
-		if (owner)
+		if (memcmp(data, vm::base(addr), size) == 0)
 		{
-			owner->notify();
+			return;
 		}
+
+		owner_copy->notify();
 	}
 
-	waiter::~waiter()
+	void waiter::remove()
 	{
+
 		// Unregister waiter
-		writer_lock lock(0);
+		const writer_lock lock(try_to_lock);
 
-		// Find waiter
-		const auto found = std::find(g_waiters.cbegin(), g_waiters.cend(), this);
-
-		if (found != g_waiters.cend())
+		if (lock.locked)
 		{
-			g_waiters.erase(found);
+			// Find waiter
+			const auto found = std::find(g_waiters.cbegin(), g_waiters.cend(), this);
+
+			if (found != g_waiters.cend())
+			{
+				g_waiters.erase(found);
+				delete this;
+			}
+			else
+			{
+				verify("Waiter not found during removal"), false;
+			}
+		}
+		else
+		{
+			this->owner = nullptr; // Iterations of the object will ignore it from now on
+			std::lock_guard<std::mutex> lock(g_waiters_to_remove_lock);
+			g_waiters_to_remove.push_back(this);
 		}
 	}
 
@@ -369,8 +360,8 @@ namespace vm
 
 		const u8 flags_both = flags_set & flags_clear;
 
-		flags_test  |= page_allocated;
-		flags_set   &= ~flags_both;
+		flags_test |= page_allocated;
+		flags_set &= ~flags_both;
 		flags_clear &= ~flags_both;
 
 		for (u32 i = addr / 4096; i < addr / 4096 + size / 4096; i++)
@@ -736,7 +727,7 @@ namespace vm
 	{
 		writer_lock lock(0);
 
-		for (auto it = g_locations.begin(); it != g_locations.end(); it++)
+		for (auto it = g_locations.begin(); it != g_locations.end(); ++it)
 		{
 			if (*it && (*it)->addr == addr)
 			{
@@ -866,7 +857,7 @@ void fmt_class_string<vm::_ptr_base<const char>>::format(std::string& out, u64 a
 
 	out += u8"“";
 
-	for (vm::_ptr_base<const volatile char> ptr = vm::cast(arg);; ptr++)
+	for (vm::_ptr_base<const volatile char> ptr = vm::cast(arg);; ++ptr)
 	{
 		if (!vm::check_addr(ptr.addr()))
 		{

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -42,7 +42,6 @@ namespace vm
 	{
 		named_thread* owner;
 		u32 addr;
-		bool inserted = false;
 		u64 stamp;
 		const void* data;
 		static const u32 size = 128; // Always 128 currently

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <map>
-#include <functional>
 #include <memory>
+#include <atomic>
 
 class named_thread;
 class cpu_thread;
@@ -42,9 +42,10 @@ namespace vm
 	{
 		named_thread* owner;
 		u32 addr;
-		u32 size;
+		bool inserted = false;
 		u64 stamp;
 		const void* data;
+		static const u32 size = 128; // Always 128 currently
 
 		waiter() = default;
 
@@ -53,7 +54,7 @@ namespace vm
 		void init();
 		void test() const;
 
-		~waiter();
+		void remove();
 	};
 
 	// Address type
@@ -90,21 +91,64 @@ namespace vm
 
 	struct writer_lock final
 	{
-		const bool locked;
+		bool locked;
 
 		writer_lock(const writer_lock&) = delete;
 		writer_lock(int full = 1);
 		writer_lock(const try_to_lock_t&);
+		void unlock();
 		~writer_lock();
 
 		explicit operator bool() const { return locked; }
 	};
 
-	// Get reservation status for further atomic update: last update timestamp
-	u64 reservation_acquire(u32 addr, u32 size);
+	// Reservations (lock lines) in a single memory page
+	using reservation_info = std::array<std::atomic<u64>, 4096 / 128>;
 
-	// End atomic update
-	void reservation_update(u32 addr, u32 size);
+	// Page information
+	struct memory_page
+	{
+		// Reservations
+		atomic_t<reservation_info*> reservations;
+		//atomic_t<u32> waiters;
+		// Memory flags
+		atomic_t<u8> flags;
+
+		// Access reservation info
+		FORCE_INLINE std::atomic<u64>& operator [](const u32 addr)
+		{
+			auto ptr = reservations.load();
+
+			if (!ptr)
+			{
+				ptr = new reservation_info();
+				// Opportunistic memory allocation
+
+				if (const auto old_ptr = reservations.compare_and_swap(nullptr, ptr))
+				{
+					delete ptr;
+					ptr = old_ptr;
+				}
+			}
+
+			return (*ptr)[(addr & 0xfff) >> 7];
+		}
+	};
+
+	// Memory pages
+	extern std::array<memory_page, 0x100000000 / 4096> g_pages;
+
+	FORCE_INLINE u64 reservation_acquire(u32 addr, u32 _size)
+	{
+		// Access reservation info: stamp and the lock bit
+		return g_pages[addr >> 12][addr].load(std::memory_order_acquire);
+	}
+
+	FORCE_INLINE void reservation_update(u32 addr, u32 _size)
+	{
+		// Update reservation info with new timestamp (unsafe, assume allocated)
+		(*g_pages[addr >> 12].reservations)[(addr & 0xfff) >> 7].store(__rdtsc(), std::memory_order_release);
+	}
 
 	// Check and notify memory changes at address
 	void notify(u32 addr, u32 size);

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -532,7 +532,7 @@ std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::spa
 
 	verify(HERE), (dst.size_bytes() >= src.size_bytes());
 
-	u32 dst_idx = 0;
+	u32 dst_idx = -1;
 	for (T index : src)
 	{
 		if (is_primitive_restart_enabled && index == primitive_restart_index)
@@ -549,9 +549,9 @@ std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::spa
 			min_index = std::min(min_index, index);
 		}
 
-		dst[dst_idx++] = index;
+		dst[++dst_idx] = index;
 	}
-	return std::make_tuple(min_index, max_index, dst_idx);
+	return std::make_tuple(min_index, max_index, dst_idx + 1);
 }
 
 template<typename T>

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -120,7 +120,6 @@ namespace rsx
 				return;
 			}
 
-			vm::reader_lock lock;
 			vm::ps3::write32(addr, arg);
 			vm::notify(addr, 4);
 		}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -144,7 +144,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 	m_gameList->verticalScrollBar()->installEventFilter(this);
 	m_gameList->verticalScrollBar()->setSingleStep(20);
 	m_gameList->horizontalScrollBar()->setSingleStep(20);
-	m_gameList->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);	
+	m_gameList->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
 	m_gameList->verticalHeader()->setMinimumSectionSize(m_Icon_Size.height());
 	m_gameList->verticalHeader()->setMaximumSectionSize(m_Icon_Size.height());
 	m_gameList->verticalHeader()->setVisible(false);
@@ -170,7 +170,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 	m_gameList->setHorizontalHeaderItem(gui::column_parental,   new QTableWidgetItem(tr("Parental Level")));
 	m_gameList->setHorizontalHeaderItem(gui::column_compat,     new QTableWidgetItem(tr("Compatibility")));
 
-	// since this won't work somehow: gameList->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);	
+	// since this won't work somehow: gameList->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
 	for (int i = 0; i < m_gameList->horizontalHeader()->count(); i++)
 	{
 		m_gameList->horizontalHeaderItem(i)->setTextAlignment(Qt::AlignLeft);
@@ -424,7 +424,7 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 		}
 
 		// std::set is used to remove duplicates from the list
-		for (const auto& dir : std::set<std::string>(std::make_move_iterator(path_list.begin()), std::make_move_iterator(path_list.end())))
+		for (const auto& dir : std::set<std::string>(std::make_move_iterator(path_list.begin()), std::make_move_iterator(path_list.end()))) { try
 		{
 			const std::string sfb = dir + "/PS3_DISC.SFB";
 			const std::string sfo = dir + (fs::is_file(sfb) ? "/PS3_GAME/PARAM.SFO" : "/PARAM.SFO");
@@ -435,7 +435,7 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 				continue;
 			}
 
-			const auto& psf = psf::load_object(sfo_file);
+			const auto psf = psf::load_object(sfo_file);
 
 			GameInfo game;
 			game.path         = dir;
@@ -493,6 +493,12 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 
 			m_game_data.push_back({ game, m_game_compat->GetCompatibility(game.serial), img, pxmap, true, bootable, hasCustomConfig });
 		}
+		catch (const std::exception& e)
+		{
+			LOG_FATAL(GENERAL, "Failed to update game list at %s\n%s thrown: %s", dir, typeid(e).name(), e.what());
+			continue;
+			// Blame MSVC for double }}
+		}}
 
 		auto op = [](const GUI_GameInfo& game1, const GUI_GameInfo& game2)
 		{
@@ -597,7 +603,7 @@ void game_list_frame::doubleClickedSlot(const QModelIndex& index)
 	{
 		i = m_xgrid->item(index.row(), index.column())->data(Qt::ItemDataRole::UserRole).toInt();
 	}
-	
+
 	if (1)
 	{
 		if (Boot(m_game_data[i].info))


### PR DESCRIPTION
WIP for stability reasons

This PR includes some optimizations, mostly to the SPU, being the current bottleneck of the emulator:
- vm::waiters are removed lazily if a lock can't be achieved at the moment of destruction to prevent the threads from locking up too much
- Rewrote some heavily used stub so the compiled assembly would be faster (Best example would be try_pop)
- Added fast path to try_lock
- Code invalidation is only checked if a SYNC instruction was executed
- SPU function DB is only searched once (instead of twice). It almost never caught a new function, yet it added quite the long search
- Aggressive inlining of some function. While considered bad practice, the compiler didn't do it by itself, and, at worse, the epilogue and prologue of the function took 0.9% runtime while the function itself took 0.1%
- Releasing locks earlier when processing mfc commands should reduce the time SPU threads are waiting on locks.
- DMA's are now done by a REP MOVSQ, which, at least on Ivy Bridge processors, is faster (Maybe because of the instruction cache having an easier time, idk)
- Probably some other stuff I forgot


So, now for the bad parts:

1. Performance gains may vary - while some reported almost double the FPS, some reported no change at all. Can't think of a reason for that yet.
2. Some parts were written before kd11 explained some of the SPU stuff to me, so take them with a grain of salt, might affect stability, so if you can, please test and report crashes and the likes.
3. As TSX has a different flow in some of the edited areas, I couldn't really test it

Thanks to whymsical, haico1992, digitaldude555 and Ani for helping me test this.