### PR TITLE
Fix native UI save_dialog when there are no saves

### DIFF
--- a/rpcs3/Emu/RSX/overlay_controls.h
+++ b/rpcs3/Emu/RSX/overlay_controls.h
@@ -1331,6 +1331,8 @@ namespace rsx
 			s16 m_selected_entry = -1;
 			u16 m_elements_count = 0;
 
+			bool m_cancel_only = false;
+
 		public:
 			list_view(u16 width, u16 height)
 			{
@@ -1461,6 +1463,16 @@ namespace rsx
 				return m_items[m_selected_entry]->text;
 			}
 
+			void set_cancel_only(bool cancel_only)
+			{
+				if (cancel_only)
+					m_cancel_btn->set_pos(x + 30, y + h + 20);
+				else
+					m_cancel_btn->set_pos(x + 180, y + h + 20);
+				m_cancel_only = cancel_only;
+				is_compiled = false;
+			}
+
 			void translate(s16 _x, s16 _y) override
 			{
 				layout_container::translate(_x, _y);
@@ -1478,8 +1490,10 @@ namespace rsx
 					compiled.add(m_highlight_box->get_compiled());
 					compiled.add(m_scroll_indicator_top->get_compiled());
 					compiled.add(m_scroll_indicator_bottom->get_compiled());
-					compiled.add(m_accept_btn->get_compiled());
 					compiled.add(m_cancel_btn->get_compiled());
+
+					if (!m_cancel_only)
+						compiled.add(m_accept_btn->get_compiled());
 
 					compiled_resources = compiled;
 				}

--- a/rpcs3/Emu/RSX/overlay_controls.h
+++ b/rpcs3/Emu/RSX/overlay_controls.h
@@ -1469,6 +1469,7 @@ namespace rsx
 					m_cancel_btn->set_pos(x + 30, y + h + 20);
 				else
 					m_cancel_btn->set_pos(x + 180, y + h + 20);
+
 				m_cancel_only = cancel_only;
 				is_compiled = false;
 			}

--- a/rpcs3/Emu/RSX/overlays.h
+++ b/rpcs3/Emu/RSX/overlays.h
@@ -254,6 +254,7 @@ namespace rsx
 			std::unique_ptr<list_view> m_list;
 			std::unique_ptr<label> m_description;
 			std::unique_ptr<label> m_time_thingy;
+			std::unique_ptr<label> m_no_saves_text;
 
 			std::string current_time()
 			{
@@ -263,6 +264,8 @@ namespace rsx
 
 				return buf;
 			}
+
+			bool m_no_saves = false;
 
 		public:
 			save_dialog()
@@ -297,10 +300,8 @@ namespace rsx
 				switch (button_press)
 				{
 				case pad_button::cross:
-					if (!m_list->m_items.size())
-					{
+					if (m_no_saves)
 						break;
-					}
 					return_code = m_list->get_selected_index();
 					//Fall through
 				case pad_button::circle:
@@ -324,6 +325,8 @@ namespace rsx
 				result.add(m_list->get_compiled());
 				result.add(m_description->get_compiled());
 				result.add(m_time_thingy->get_compiled());
+				if (m_no_saves)
+					result.add(m_no_saves_text->get_compiled());
 				return result;
 			}
 
@@ -351,6 +354,20 @@ namespace rsx
 					m_description->text = "Create Save";
 					std::unique_ptr<overlay_element> new_stub = std::make_unique<save_dialog_entry>("Create New", "Select to create a new entry", resource_config::standard_image_resource::new_entry, null_icon);
 					m_list->add_entry(new_stub);
+				}
+
+				if (!m_list->m_items.size())
+				{
+					m_no_saves_text = std::make_unique<label>();
+					m_no_saves_text->set_font("Arial", 20);
+					m_no_saves_text->align_text(overlay_element::text_align::center);
+					m_no_saves_text->set_pos(m_list->x, m_list->y + m_list->h / 2);
+					m_no_saves_text->set_size(m_list->w, 30);
+					m_no_saves_text->set_text("There is no saved data.");
+					m_no_saves_text->back_color.a = 0;
+					
+					m_no_saves = true;
+					m_list->set_cancel_only(true);
 				}
 
 				static_cast<label*>(m_description.get())->auto_resize();

--- a/rpcs3/Emu/RSX/overlays.h
+++ b/rpcs3/Emu/RSX/overlays.h
@@ -325,8 +325,10 @@ namespace rsx
 				result.add(m_list->get_compiled());
 				result.add(m_description->get_compiled());
 				result.add(m_time_thingy->get_compiled());
+
 				if (m_no_saves)
 					result.add(m_no_saves_text->get_compiled());
+
 				return result;
 			}
 

--- a/rpcs3/Emu/RSX/overlays.h
+++ b/rpcs3/Emu/RSX/overlays.h
@@ -297,6 +297,10 @@ namespace rsx
 				switch (button_press)
 				{
 				case pad_button::cross:
+					if (!m_list->m_items.size())
+					{
+						break;
+					}
 					return_code = m_list->get_selected_index();
 					//Fall through
 				case pad_button::circle:


### PR DESCRIPTION
Disallow you from selecting a save to load when there are no saves. This is more in line with how the QT save dialog works and fixes fatal access violation in Ratchet & Clank 3 (and probably in more games).