### PR TITLE
Use clang 5.0 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ git:
   submodules: false
 
 before_install:
-  - if [ "$CC" = "clang" ]; then
-      export CXX="clang++-5.0" CC="clang-5.0";
-    fi;
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CXX" = "g++" ]; then
       export CXX="g++-5" CC="gcc-5" CXXFLAGS="-Wno-format-security";
     fi;
@@ -65,7 +62,7 @@ before_script:
   - cmake .. -DCMAKE_INSTALL_PREFIX=/usr -G Ninja;
   - ninja
   - # AppImage generation
-  - if [ -n "$UPLOAD_URL" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$CC" = "clang-5.0" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
+  - if [ -n "$UPLOAD_URL" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$CC" = "clang" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
       export LD_LIBRARY_PATH=~/Qt/5.10.0/gcc_64/lib;
       DESTDIR=appdir ninja install ; find appdir/ ;
       find ../bin ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ git:
 
 before_install:
   - if [ "$CC" = "clang" ]; then
-      export CXX="clang++-4.0" CC="clang-4.0";
+      export CXX="clang++-5.0" CC="clang-5.0";
     fi;
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CXX" = "g++" ]; then
       export CXX="g++-5" CC="gcc-5" CXXFLAGS="-Wno-format-security";
@@ -65,7 +65,7 @@ before_script:
   - cmake .. -DCMAKE_INSTALL_PREFIX=/usr -G Ninja;
   - ninja
   - # AppImage generation
-  - if [ -n "$UPLOAD_URL" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$CC" = "clang-4.0" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
+  - if [ -n "$UPLOAD_URL" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$CC" = "clang-5.0" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
       export LD_LIBRARY_PATH=~/Qt/5.10.0/gcc_64/lib;
       DESTDIR=appdir ninja install ; find appdir/ ;
       find ../bin ;
@@ -111,7 +111,8 @@ addons:
       - libc6-dev
       - llvm-4.0
       - llvm-4.0-dev
-      - clang-4.0
+      # Clang 5.0 is now bundled in travis, so we no longer need the ppa version.
+      #- clang-4.0
       - libedit-dev
       - g++-5
       - gcc-5


### PR DESCRIPTION
Turns out the latest version of travis now has clang 5.0 builtin, so let's use that instead for AppImages and such.