### PR TITLE
Fix to B8 format render target swizzling. Fixes VF5 red objects.

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -32,7 +32,7 @@ color_format rsx::internals::surface_color_format_to_gl(rsx::surface_color_forma
 
 	case rsx::surface_color_format::b8:
 		return{ ::gl::texture::type::ubyte, ::gl::texture::format::r, false, 1, 1,
-		{ ::gl::texture::channel::r, ::gl::texture::channel::r, ::gl::texture::channel::r, ::gl::texture::channel::r } };
+		{ ::gl::texture::channel::one, ::gl::texture::channel::r, ::gl::texture::channel::r, ::gl::texture::channel::r } };
 
 	case rsx::surface_color_format::g8b8:
 		return{ ::gl::texture::type::ubyte, ::gl::texture::format::rg, false, 2, 1 };

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -31,7 +31,8 @@ color_format rsx::internals::surface_color_format_to_gl(rsx::surface_color_forma
 		return{ ::gl::texture::type::f32, ::gl::texture::format::rgba, true, 4, 4 };
 
 	case rsx::surface_color_format::b8:
-		return{ ::gl::texture::type::ubyte, ::gl::texture::format::r, false, 1, 1 };
+		return{ ::gl::texture::type::ubyte, ::gl::texture::format::r, false, 1, 1,
+		{ ::gl::texture::channel::r, ::gl::texture::channel::r, ::gl::texture::channel::r, ::gl::texture::channel::r } };
 
 	case rsx::surface_color_format::g8b8:
 		return{ ::gl::texture::type::ubyte, ::gl::texture::format::rg, false, 2, 1 };

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -84,7 +84,10 @@ namespace vk
 		}
 
 		case rsx::surface_color_format::b8:
-			return std::make_pair(VK_FORMAT_R8_UNORM, vk::default_component_map());
+		{
+			VkComponentMapping no_alpha = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
+			return std::make_pair(VK_FORMAT_R8_UNORM, no_alpha);
+		}
 		
 		case rsx::surface_color_format::g8b8:
 			return std::make_pair(VK_FORMAT_R8G8_UNORM, vk::default_component_map());

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -85,7 +85,7 @@ namespace vk
 
 		case rsx::surface_color_format::b8:
 		{
-			VkComponentMapping no_alpha = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
+			VkComponentMapping no_alpha = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_ONE };
 			return std::make_pair(VK_FORMAT_R8_UNORM, no_alpha);
 		}
 		


### PR DESCRIPTION
B8 render targets were not swizzled. Those fixes address it.

RRR1 (VK) and 1RRR (OGL) at the recommendation of KD-11. This is now consistent with B8 textures swizzling, since RRRR created alpha issues in Persona.

Image with fix

![image](https://user-images.githubusercontent.com/35616470/35488128-8ad9c01e-0438-11e8-882e-062a0db1d940.png)

Image without fix

![image](https://user-images.githubusercontent.com/35616470/35488229-138afd5a-043a-11e8-8a80-d93171b59194.png)
