### PR TITLE
[WIP] Add compatibility database file inside Appveyor and Travis artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ before_script:
       export LD_LIBRARY_PATH=~/Qt/5.10.0/gcc_64/lib;
       DESTDIR=appdir ninja install ; find appdir/ ;
       find ../bin ;
+      curl -fsS -o appdir/usr/share/rpcs3/GuiConfigs/compat_database.dat "https://rpcs3.net/compatibility?api=v1&export" ;
       wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" ;
       chmod a+x linuxdeployqt*.AppImage ;
       export PATH=~/Qt/5.10.0/gcc_64/bin/:${PATH} ;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ before_build:
 
 # scripts to run *after* solution is built and *before* automatic packaging occurs (web apps, NuGet packages, Azure Cloud Services)
 before_package:
+  - curl -fsS -o %APPVEYOR_BUILD_FOLDER%\bin\GuiConfigs\compat_database.dat "https://rpcs3.net/compatibility?api=v1&export"
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.exp
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.lib
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.pdb


### PR DESCRIPTION
I hope it could reduce the number of people having trouble to download the compatibility database file by providing the file directly bundled in the artifacts.

@hcorion Would you mind checking the change for Travis? I am not 100% sure about where the folder "GuiConfigs" is, before building the AppImage. I am relying on your experience 😉