### PR TITLE
Compatiblity fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -176,21 +176,6 @@ void GLGSRender::begin()
 	init_buffers(rsx::framebuffer_creation_context::context_draw);
 }
 
-namespace
-{
-	GLenum get_gl_target_for_texture(const rsx::texture_dimension_extended type)
-	{
-		switch (type)
-		{
-		case rsx::texture_dimension_extended::texture_dimension_1d: return GL_TEXTURE_1D;
-		case rsx::texture_dimension_extended::texture_dimension_2d: return GL_TEXTURE_2D;
-		case rsx::texture_dimension_extended::texture_dimension_cubemap: return GL_TEXTURE_CUBE_MAP;
-		case rsx::texture_dimension_extended::texture_dimension_3d: return GL_TEXTURE_3D;
-		}
-		fmt::throw_exception("Unknown texture target" HERE);
-	}
-}
-
 void GLGSRender::end()
 {
 	std::chrono::time_point<steady_clock> state_check_start = steady_clock::now();
@@ -321,7 +306,7 @@ void GLGSRender::end()
 
 			if (tex.enabled())
 			{
-				GLenum target = get_gl_target_for_texture(sampler_state->image_type);
+				GLenum target = gl::get_target(sampler_state->image_type);
 				if (sampler_state->image_handle)
 				{
 					glBindTexture(target, sampler_state->image_handle);

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -365,6 +365,8 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		break;
 	}
 
+	m_gl_texture_cache.clear_ro_tex_invalidate_intr();
+
 	//Mark buffer regions as NO_ACCESS on Cell visible side
 	if (g_cfg.video.write_color_buffers)
 	{
@@ -393,6 +395,12 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 			m_gl_texture_cache.lock_memory_region(std::get<1>(m_rtts.m_bound_depth_stencil), m_depth_surface_info.address, range, m_depth_surface_info.width, m_depth_surface_info.height, pitch,
 				depth_format_gl.format, depth_format_gl.type, true);
 		}
+	}
+
+	if (m_gl_texture_cache.get_ro_tex_invalidate_intr())
+	{
+		//Invalidate cached sampler state
+		m_samplers_dirty.store(true);
 	}
 }
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -189,10 +189,14 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 
 	//NOTE: Its is possible that some renders are done on a swizzled context. Pitch is meaningless in that case
 	//Seen in Nier (color) and GT HD concept (z buffer)
-	//Restriction is that the RTT is always a square region for that dimensions are powers of 2
+	//Restriction is that the dimensions are powers of 2. Also, dimensions are passed via log2w and log2h entries
 	const auto required_zeta_pitch = std::max<u32>((u32)(depth_format == rsx::surface_depth_format::z16 ? clip_horizontal * 2 : clip_horizontal * 4), 64u);
 	const auto required_color_pitch = std::max<u32>((u32)rsx::utility::get_packed_pitch(surface_format, clip_horizontal), 64u);
 	const bool stencil_test_enabled = depth_format == rsx::surface_depth_format::z24s8 && rsx::method_registers.stencil_test_enabled();
+	const auto lg2w = rsx::method_registers.surface_log2_width();
+	const auto lg2h = rsx::method_registers.surface_log2_height();
+	const auto clipw_log2 = (u32)floor(log2(clip_horizontal));
+	const auto cliph_log2 = (u32)floor(log2(clip_vertical));
 
 	if (depth_address)
 	{
@@ -211,8 +215,21 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 
 		if (depth_address && zeta_pitch < required_zeta_pitch)
 		{
-			if (zeta_pitch < 64 || clip_vertical != clip_horizontal)
+			if (lg2w < clipw_log2 || lg2h < cliph_log2)
+			{
+				//Cannot fit
 				depth_address = 0;
+
+				if (lg2w > 0 || lg2h > 0)
+				{
+					//Something was actually declared for the swizzle context dimensions
+					LOG_ERROR(RSX, "Invalid swizzled context depth surface dims, LG2W=%d, LG2H=%d, clip_w=%d, clip_h=%d", lg2w, lg2h, clip_horizontal, clip_vertical);
+				}
+			}
+			else
+			{
+				LOG_TRACE(RSX, "Swizzled context depth surface, LG2W=%d, LG2H=%d, clip_w=%d, clip_h=%d", lg2w, lg2h, clip_horizontal, clip_vertical);
+			}
 		}
 	}
 
@@ -220,8 +237,20 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 	{
 		if (pitchs[index] < required_color_pitch)
 		{
-			if (pitchs[index] < 64 || clip_vertical != clip_horizontal)
+			if (lg2w < clipw_log2 || lg2h < cliph_log2)
+			{
 				surface_addresses[index] = 0;
+
+				if (lg2w > 0 || lg2h > 0)
+				{
+					//Something was actually declared for the swizzle context dimensions
+					LOG_ERROR(RSX, "Invalid swizzled context color surface dims, LG2W=%d, LG2H=%d, clip_w=%d, clip_h=%d", lg2w, lg2h, clip_horizontal, clip_vertical);
+				}
+			}
+			else
+			{
+				LOG_TRACE(RSX, "Swizzled context color surface, LG2W=%d, LG2H=%d, clip_w=%d, clip_h=%d", lg2w, lg2h, clip_horizontal, clip_vertical);
+			}
 		}
 
 		if (surface_addresses[index] == depth_address)

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -8,6 +8,18 @@
 
 namespace gl
 {
+	GLenum get_target(rsx::texture_dimension_extended type)
+	{
+		switch (type)
+		{
+		case rsx::texture_dimension_extended::texture_dimension_1d: return GL_TEXTURE_1D;
+		case rsx::texture_dimension_extended::texture_dimension_2d: return GL_TEXTURE_2D;
+		case rsx::texture_dimension_extended::texture_dimension_cubemap: return GL_TEXTURE_CUBE_MAP;
+		case rsx::texture_dimension_extended::texture_dimension_3d: return GL_TEXTURE_3D;
+		}
+		fmt::throw_exception("Unknown texture target" HERE);
+	}
+
 	GLenum get_sized_internal_format(u32 texture_format)
 	{
 		switch (texture_format)

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -10,6 +10,7 @@ namespace rsx
 
 namespace gl
 {
+	GLenum get_target(rsx::texture_dimension_extended type);
 	GLenum get_sized_internal_format(u32 gcm_format);
 	std::tuple<GLenum, GLenum> get_format_type(u32 texture_format);
 	GLenum wrap_mode(rsx::texture_wrap_mode wrap);

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -765,8 +765,9 @@ namespace gl
 				break;
 			}
 
-			glBindTexture(GL_TEXTURE_2D, vram_texture);
-			apply_component_mapping_flags(GL_TEXTURE_2D, gcm_format, flags);
+			auto target = gl::get_target(type);
+			glBindTexture(target, vram_texture);
+			apply_component_mapping_flags(target, gcm_format, flags);
 
 			auto& cached = create_texture(vram_texture, rsx_address, rsx_size, width, height, depth, mipmaps);
 			cached.set_dirty(false);

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -837,7 +837,7 @@ namespace gl
 			section.set_sampler_status(rsx::texture_sampler_status::status_ready);
 		}
 
-		void insert_texture_barrier() override
+		void insert_texture_barrier(void*&, gl::texture*) override
 		{
 			auto &caps = gl::get_driver_caps();
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2487,10 +2487,14 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 
 	//NOTE: Its is possible that some renders are done on a swizzled context. Pitch is meaningless in that case
 	//Seen in Nier (color) and GT HD concept (z buffer)
-	//Restriction is that the RTT is always a square region for that dimensions are powers of 2
+	//Restriction is that the dimensions are powers of 2. Also, dimensions are passed via log2w and log2h entries
 	const auto required_zeta_pitch = std::max<u32>((u32)(depth_fmt == rsx::surface_depth_format::z16 ? clip_width * 2 : clip_width * 4), 64u);
 	const auto required_color_pitch = std::max<u32>((u32)rsx::utility::get_packed_pitch(color_fmt, clip_width), 64u);
 	const bool stencil_test_enabled = depth_fmt == rsx::surface_depth_format::z24s8 && rsx::method_registers.stencil_test_enabled();
+	const auto lg2w = rsx::method_registers.surface_log2_width();
+	const auto lg2h = rsx::method_registers.surface_log2_height();
+	const auto clipw_log2 = (u32)floor(log2(clip_width));
+	const auto cliph_log2 = (u32)floor(log2(clip_height));
 
 	if (zeta_address)
 	{
@@ -2509,8 +2513,21 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 
 		if (zeta_address && zeta_pitch < required_zeta_pitch)
 		{
-			if (zeta_pitch < 64 || clip_width != clip_height)
+			if (lg2w < clipw_log2 || lg2h < cliph_log2)
+			{
+				//Cannot fit
 				zeta_address = 0;
+
+				if (lg2w > 0 || lg2h > 0)
+				{
+					//Something was actually declared for the swizzle context dimensions
+					LOG_ERROR(RSX, "Invalid swizzled context depth surface dims, LG2W=%d, LG2H=%d, clip_w=%d, clip_h=%d", lg2w, lg2h, clip_width, clip_height);
+				}
+			}
+			else
+			{
+				LOG_TRACE(RSX, "Swizzled context depth surface, LG2W=%d, LG2H=%d, clip_w=%d, clip_h=%d", lg2w, lg2h, clip_width, clip_height);
+			}
 		}
 	}
 
@@ -2518,8 +2535,20 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	{
 		if (surface_pitchs[index] < required_color_pitch)
 		{
-			if (surface_pitchs[index] < 64 || clip_width != clip_height)
+			if (lg2w < clipw_log2 || lg2h < cliph_log2)
+			{
 				surface_addresses[index] = 0;
+
+				if (lg2w > 0 || lg2h > 0)
+				{
+					//Something was actually declared for the swizzle context dimensions
+					LOG_ERROR(RSX, "Invalid swizzled context color surface dims, LG2W=%d, LG2H=%d, clip_w=%d, clip_h=%d", lg2w, lg2h, clip_width, clip_height);
+				}
+			}
+			else
+			{
+				LOG_TRACE(RSX, "Swizzled context color surface, LG2W=%d, LG2H=%d, clip_w=%d, clip_h=%d", lg2w, lg2h, clip_width, clip_height);
+			}
 		}
 
 		if (surface_addresses[index] == zeta_address)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3028,7 +3028,7 @@ void VKGSRender::flip(int buffer)
 		VkImageLayout target_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 		VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
 
-		if (aspect_ratio.x)
+		if (aspect_ratio.x || aspect_ratio.y)
 		{
 			VkClearColorValue clear_black {};
 			vk::change_image_layout(*m_current_command_buffer, target_image, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, range);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -388,6 +388,45 @@ namespace vk
 		image->current_layout = new_layout;
 	}
 
+	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout layout, VkImageSubresourceRange range)
+	{
+		VkImageMemoryBarrier barrier = {};
+		barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+		barrier.newLayout = layout;
+		barrier.oldLayout = layout;
+		barrier.image = image;
+		barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.subresourceRange = range;
+		barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+		VkPipelineStageFlags src_stage;
+		if (range.aspectMask == VK_IMAGE_ASPECT_COLOR_BIT)
+		{
+			barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+			src_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		}
+		else
+		{
+			barrier.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+			src_stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+		}
+
+		vkCmdPipelineBarrier(cmd, src_stage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+	}
+
+	void insert_texture_barrier(VkCommandBuffer cmd, vk::image *image)
+	{
+		if (image->info.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
+		{
+			insert_texture_barrier(cmd, image->value, image->current_layout, { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 });
+		}
+		else
+		{
+			insert_texture_barrier(cmd, image->value, image->current_layout, { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 });
+		}
+	}
+
 	void enter_uninterruptible()
 	{
 		g_cb_no_interrupt_flag = true;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -90,6 +90,10 @@ namespace vk
 	std::pair<VkFormat, VkComponentMapping> get_compatible_surface_format(rsx::surface_color_format color_format);
 	size_t get_render_pass_location(VkFormat color_surface_format, VkFormat depth_stencil_format, u8 color_surface_count);
 
+	//Texture barrier applies to a texture to ensure writes to it are finished before any reads are attempted to avoid RAW hazards
+	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout layout, VkImageSubresourceRange range);
+	void insert_texture_barrier(VkCommandBuffer cmd, vk::image *image);
+
 	void enter_uninterruptible();
 	void leave_uninterruptible();
 	bool is_uninterruptible();

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -831,8 +831,10 @@ namespace vk
 			section.set_sampler_status(rsx::texture_sampler_status::status_ready);
 		}
 
-		void insert_texture_barrier() override
-		{}
+		void insert_texture_barrier(vk::command_buffer& cmd, vk::image* tex) override
+		{
+			vk::insert_texture_barrier(cmd, tex);
+		}
 
 	public:
 


### PR DESCRIPTION
- gl: Use correct target for type when creating new textures. They are not always 2D
- gl: Track stale cache entries for deleted textures. Avoids invalid texture getting bound to the pipeline when wcb is enabled
- vk: Implement texture barrier for framebuffer feedback situations if strict mode is disabled. Strict mode bypasses all of this and just makes a duplicate copy which is the safest way to avoid the memory access hazard.
- rsx: Improve framebuffer setup code. If pitch is 64, check the log2 dimension bits instead to determine size.

https://github.com/RPCS3/rpcs3/issues/4132