### PR TITLE
AppVeyor Overhaul

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,14 +15,12 @@ cache:
 - compat_database.dat
 
 install:
-- ps: | # set version env vars, update appveyor build version accordingly
+- ps: | # set env vars for versioning
     $commDate = $env:APPVEYOR_REPO_COMMIT_TIMESTAMP.Substring(0,10)
     $commSha = $env:APPVEYOR_REPO_COMMIT.Substring(0,8)
     $commTag = $(git describe --tags $(git rev-list --tags --max-count=1))
     
-    $av = "{0}-{1}" -f $commTag.TrimStart("v"), $env:APPVEYOR_BUILD_NUMBER
-    Update-AppveyorBuild -Version $av
-    
+    $env:AVVER = "{0}-{1}" -f $commTag.TrimStart("v"), $env:APPVEYOR_BUILD_NUMBER
     $env:BUILD = "rpcs3-{0}-{1}-{2}_win64.7z" -f $commTag, $commDate, $commSha
 
 - ps: | # used for experimental build warnings for pr builds
@@ -88,3 +86,7 @@ artifacts:
   name: rpcs3
 - path: openssl_win64.7z
   name: openssl
+
+on_finish: 
+- ps: | # update appveyor build version, done last to prevent webhook breakage
+    update-appveyorbuild -version $env:AVVER

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ version: '{build}'
 image: Visual Studio 2015
 
 environment:
-  QTDIR: C:\Qt\5.9\msvc2015_64
+  QTDIR: C:\Qt\5.10.0\msvc2015_64
   LLVMLIBS: https://drive.google.com/uc?export=download&id=0B8A6NaxhQAGRY2k3Q2Yya05lcm8
   VULKAN: https://drive.google.com/uc?export=download&id=1A2eOMmCO714i0U7J0qI4aEMKnuWl8l_R
   COMPATDB: https://rpcs3.net/compatibility?api=v1&export

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,8 +77,9 @@ after_build:
     copy-item compat_database.dat .\bin\GuiConfigs\compat_database.dat
 
 - ps: | # package artifacts
-    7z a $env:BUILD .\bin\*
-    7z a openssl_win64.7z C:\OpenSSL-Win64\bin\libeay32.dll C:\OpenSSL-Win64\bin\ssleay32.dll
+    7z a -m0=LZMA2 -mx9 $env:BUILD .\bin\*
+    7z a -m0=LZMA2 -mx9 openssl_win64.7z C:\OpenSSL-Win64\bin\libeay32.dll `
+      C:\OpenSSL-Win64\bin\ssleay32.dll
 
 test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,9 @@ install:
       $env:APPVEYOR_REPO_BRANCH, $env:APPVEYOR_PULL_REQUEST_NUMBER
     $env:BRANCH = $env:BRANCH -replace "/#$"
 
-- ps: $env:PATH += $env:QTDIR
+- ps: | # misc global settings
+    $env:PATH += $env:QTDIR
+    [net.servicepointmanager]::securityprotocol = "tls12, tls11, tls"
 
 - ps: | # update and init submodules
     git submodule -q update --init `
@@ -68,10 +70,9 @@ after_build:
     rm .\bin\rpcs3.exp, .\bin\rpcs3.lib, .\bin\rpcs3.pdb
 
 - ps: | # prepare compatibility database for packaging
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    $db = irm $env:COMPATDB -ea SilentlyContinue
+    $db = irm $env:COMPATDB -erroraction silentlycontinue
     if ($db -and $db.return_code -eq 0) {
-      $db | convertto-json -compress | out-file -encoding utf8 compat_database.dat
+      $db | convertto-json -compress | out-file compat_database.dat -encoding utf8
     }
     copy-item compat_database.dat .\bin\GuiConfigs\compat_database.dat
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,27 @@ cache:
  - vulkan.7z -> appveyor.yml
 
 install:
- - git submodule update --init 3rdparty/cereal 3rdparty/ffmpeg 3rdparty/GSL 3rdparty/hidapi 3rdparty/libpng 3rdparty/Optional 3rdparty/pugixml 3rdparty/zlib asmjit Utilities/yaml-cpp Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
+- ps: | # used for experimental build warnings for pr builds
+    $env:BRANCH = "{0}/{1}/#{2}" -f $env:APPVEYOR_REPO_NAME, `
+      $env:APPVEYOR_REPO_BRANCH, $env:APPVEYOR_PULL_REQUEST_NUMBER
+    $env:BRANCH = $env:BRANCH -replace "/#$"
+
+- ps: $env:PATH += $env:QTDIR
+
+- ps: | # update and init submodules
+    git submodule -q update --init `
+      3rdparty/cereal `
+      3rdparty/ffmpeg `
+      3rdparty/GSL `
+      3rdparty/hidapi `
+      3rdparty/libpng `
+      3rdparty/Optional `
+      3rdparty/pugixml `
+      3rdparty/zlib `
+      asmjit `
+      Utilities/yaml-cpp `
+      Vulkan/glslang `
+      Vulkan/Vulkan-LoaderAndValidationLayers
 
 platform: x64
 
@@ -25,9 +45,6 @@ build:
   verbosity: normal
 
 before_build:
-- set BRANCH=%APPVEYOR_REPO_NAME%/%APPVEYOR_REPO_BRANCH%/#%APPVEYOR_PULL_REQUEST_NUMBER%
-- if "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (set BRANCH=%APPVEYOR_REPO_NAME%/%APPVEYOR_REPO_BRANCH%)
-- set PATH=%PATH%;%QTDIR%
 - cmd: | # fetch precompiled build dependencies
     if not exist llvmlibs.7z appveyor DownloadFile %LLVMLIBS% -FileName llvmlibs.7z
     7z x llvmlibs.7z -aos -o"." > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,13 +62,11 @@ before_build:
     7z x vulkan.7z -aos -o".\lib\%CONFIGURATION%-%PLATFORM%" > nul
 
 after_build:
+- ps: | # remove unnecessary files
+    rm .\bin\rpcs3.exp, .\bin\rpcs3.lib, .\bin\rpcs3.pdb
+
 - ps: | # package artifacts
     7z a $env:BUILD .\bin\*
-
-before_package:
-  - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.exp
-  - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.lib
-  - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.pdb
 
 test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,11 +57,11 @@ build:
   verbosity: normal
 
 before_build:
-- cmd: | # fetch precompiled build dependencies
-    if not exist llvmlibs.7z appveyor DownloadFile %LLVMLIBS% -FileName llvmlibs.7z
-    7z x llvmlibs.7z -aos -o"." > nul
-    if not exist vulkan.7z appveyor DownloadFile %VULKAN% -FileName vulkan.7z
-    7z x vulkan.7z -aos -o".\lib\%CONFIGURATION%-%PLATFORM%" > nul
+- ps: | # fetch precompiled build dependencies
+    if (!(test-path llvmlibs.7z)) { irm $env:LLVMLIBS -outfile llvmlibs.7z }
+    if (!(test-path vulkan.7z)) { irm $env:VULKAN -outfile vulkan.7z }
+    7z x llvmlibs.7z -aos -o"." | out-null
+    7z x vulkan.7z -aos -o".\lib\$env:CONFIGURATION-$env:PLATFORM" | out-null
 
 after_build:
 - ps: | # remove unnecessary files

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 
-version: '0.0.4-{build}'
+version: '{build}'
 
 image: Visual Studio 2015
 
@@ -13,6 +13,16 @@ cache:
  - vulkan.7z -> appveyor.yml
 
 install:
+- ps: | # set version env vars, update appveyor build version accordingly
+    $commDate = $env:APPVEYOR_REPO_COMMIT_TIMESTAMP.Substring(0,10)
+    $commSha = $env:APPVEYOR_REPO_COMMIT.Substring(0,8)
+    $commTag = $(git describe --tags $(git rev-list --tags --max-count=1))
+    
+    $av = "{0}-{1}" -f $commTag.TrimStart("v"), $env:APPVEYOR_BUILD_NUMBER
+    Update-AppveyorBuild -Version $av
+    
+    $env:BUILD = "rpcs3-{0}-{1}-{2}_win64.7z" -f $commTag, $commDate, $commSha
+
 - ps: | # used for experimental build warnings for pr builds
     $env:BRANCH = "{0}/{1}/#{2}" -f $env:APPVEYOR_REPO_NAME, `
       $env:APPVEYOR_REPO_BRANCH, $env:APPVEYOR_PULL_REQUEST_NUMBER
@@ -51,15 +61,17 @@ before_build:
     if not exist vulkan.7z appveyor DownloadFile %VULKAN% -FileName vulkan.7z
     7z x vulkan.7z -aos -o".\lib\%CONFIGURATION%-%PLATFORM%" > nul
 
+after_build:
+- ps: | # package artifacts
+    7z a $env:BUILD .\bin\*
+
 before_package:
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.exp
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.lib
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.pdb
-  - set COMMIT_DATE=%APPVEYOR_REPO_COMMIT_TIMESTAMP:~0,10%
-  - set COMMIT_SHA=%APPVEYOR_REPO_COMMIT:~0,8%
 
 test: off
 
 artifacts:
- - path: bin
-   name: 'rpcs3-v0.0.4-$(COMMIT_DATE)-$(COMMIT_SHA)_win64'
+- path: $(BUILD)
+  name: rpcs3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ image: Visual Studio 2015
 
 environment:
   QTDIR: C:\Qt\5.9\msvc2015_64
+  LLVMLIBS: https://drive.google.com/uc?export=download&id=0B8A6NaxhQAGRY2k3Q2Yya05lcm8
+  VULKAN: https://drive.google.com/uc?export=download&id=1A2eOMmCO714i0U7J0qI4aEMKnuWl8l_R
 
 cache:
  - llvmlibs.7z -> appveyor.yml
@@ -23,13 +25,14 @@ build:
   verbosity: normal
 
 before_build:
- - set BRANCH=%APPVEYOR_REPO_NAME%/%APPVEYOR_REPO_BRANCH%/#%APPVEYOR_PULL_REQUEST_NUMBER%
- - if "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (set BRANCH=%APPVEYOR_REPO_NAME%/%APPVEYOR_REPO_BRANCH%)
- - set PATH=%PATH%;%QTDIR%
- - if not exist llvmlibs.7z appveyor DownloadFile "https://drive.google.com/uc?export=download&id=0B8A6NaxhQAGRY2k3Q2Yya05lcm8" -FileName llvmlibs.7z
- - 7z x llvmlibs.7z -aos -o%APPVEYOR_BUILD_FOLDER% > null
- - if not exist vulkan.7z appveyor DownloadFile "https://drive.google.com/uc?export=download&id=1A2eOMmCO714i0U7J0qI4aEMKnuWl8l_R" -FileName vulkan.7z
- - 7z x vulkan.7z -aos -o"%APPVEYOR_BUILD_FOLDER%\lib\%CONFIGURATION%-%PLATFORM%" > null
+- set BRANCH=%APPVEYOR_REPO_NAME%/%APPVEYOR_REPO_BRANCH%/#%APPVEYOR_PULL_REQUEST_NUMBER%
+- if "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (set BRANCH=%APPVEYOR_REPO_NAME%/%APPVEYOR_REPO_BRANCH%)
+- set PATH=%PATH%;%QTDIR%
+- cmd: | # fetch precompiled build dependencies
+    if not exist llvmlibs.7z appveyor DownloadFile %LLVMLIBS% -FileName llvmlibs.7z
+    7z x llvmlibs.7z -aos -o"." > nul
+    if not exist vulkan.7z appveyor DownloadFile %VULKAN% -FileName vulkan.7z
+    7z x vulkan.7z -aos -o".\lib\%CONFIGURATION%-%PLATFORM%" > nul
 
 before_package:
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.exp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,50 +1,27 @@
-#---------------------------------#
-#      general configuration      #
-#---------------------------------#
 
-# version format
 version: '0.0.4-{build}'
 
-#---------------------------------#
-#    environment configuration    #
-#---------------------------------#
-
-# Build worker image (VM template)
 image: Visual Studio 2015
 
-# clone directory
-clone_folder: c:\projects\rpcs3
-
-# environment variables
 environment:
   QTDIR: C:\Qt\5.9\msvc2015_64
 
-# build cache to preserve files/folders between builds
 cache:
  - llvmlibs.7z -> appveyor.yml
  - vulkan.7z -> appveyor.yml
 
-# scripts that run after cloning repository
 install:
  - git submodule update --init 3rdparty/cereal 3rdparty/ffmpeg 3rdparty/GSL 3rdparty/hidapi 3rdparty/libpng 3rdparty/Optional 3rdparty/pugixml 3rdparty/zlib asmjit Utilities/yaml-cpp Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
 
-#---------------------------------#
-#       build configuration       #
-#---------------------------------#
-
-# build platform, i.e. x86, x64, Any CPU. This setting is optional.
 platform: x64
 
-# build Configuration, i.e. Debug, Release, etc.
 configuration: Release - LLVM
 
 build:
-  parallel: true                  # enable MSBuild parallel builds
-  project: rpcs3.sln              # path to Visual Studio solution or project
-  # MSBuild verbosity level
+  parallel: true
+  project: rpcs3.sln
   verbosity: normal
 
-# scripts to run before build
 before_build:
  - set BRANCH=%APPVEYOR_REPO_NAME%/%APPVEYOR_REPO_BRANCH%/#%APPVEYOR_PULL_REQUEST_NUMBER%
  - if "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (set BRANCH=%APPVEYOR_REPO_NAME%/%APPVEYOR_REPO_BRANCH%)
@@ -54,7 +31,6 @@ before_build:
  - if not exist vulkan.7z appveyor DownloadFile "https://drive.google.com/uc?export=download&id=1A2eOMmCO714i0U7J0qI4aEMKnuWl8l_R" -FileName vulkan.7z
  - 7z x vulkan.7z -aos -o"%APPVEYOR_BUILD_FOLDER%\lib\%CONFIGURATION%-%PLATFORM%" > null
 
-# scripts to run *after* solution is built and *before* automatic packaging occurs (web apps, NuGet packages, Azure Cloud Services)
 before_package:
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.exp
   - rm %APPVEYOR_BUILD_FOLDER%\bin\rpcs3.lib
@@ -62,18 +38,8 @@ before_package:
   - set COMMIT_DATE=%APPVEYOR_REPO_COMMIT_TIMESTAMP:~0,10%
   - set COMMIT_SHA=%APPVEYOR_REPO_COMMIT:~0,8%
 
-#---------------------------------#
-#       tests configuration       #
-#---------------------------------#
-
-# to disable automatic tests
 test: off
 
-#---------------------------------#
-#      artifacts configuration    #
-#---------------------------------#
-
-# pushing entire folder as a zip archive
 artifacts:
  - path: bin
    name: 'rpcs3-v0.0.4-$(COMMIT_DATE)-$(COMMIT_SHA)_win64'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,12 @@ environment:
   QTDIR: C:\Qt\5.9\msvc2015_64
   LLVMLIBS: https://drive.google.com/uc?export=download&id=0B8A6NaxhQAGRY2k3Q2Yya05lcm8
   VULKAN: https://drive.google.com/uc?export=download&id=1A2eOMmCO714i0U7J0qI4aEMKnuWl8l_R
+  COMPATDB: https://rpcs3.net/compatibility?api=v1&export
 
 cache:
- - llvmlibs.7z -> appveyor.yml
- - vulkan.7z -> appveyor.yml
+- llvmlibs.7z -> appveyor.yml
+- vulkan.7z -> appveyor.yml
+- compat_database.dat
 
 install:
 - ps: | # set version env vars, update appveyor build version accordingly
@@ -64,6 +66,14 @@ before_build:
 after_build:
 - ps: | # remove unnecessary files
     rm .\bin\rpcs3.exp, .\bin\rpcs3.lib, .\bin\rpcs3.pdb
+
+- ps: | # prepare compatibility database for packaging
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $db = irm $env:COMPATDB -ea SilentlyContinue
+    if ($db -and $db.return_code -eq 0) {
+      $db | convertto-json -compress | out-file -encoding utf8 compat_database.dat
+    }
+    copy-item compat_database.dat .\bin\GuiConfigs\compat_database.dat
 
 - ps: | # package artifacts
     7z a $env:BUILD .\bin\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,9 +67,12 @@ after_build:
 
 - ps: | # package artifacts
     7z a $env:BUILD .\bin\*
+    7z a openssl_win64.7z C:\OpenSSL-Win64\bin\libeay32.dll C:\OpenSSL-Win64\bin\ssleay32.dll
 
 test: off
 
 artifacts:
 - path: $(BUILD)
   name: rpcs3
+- path: openssl_win64.7z
+  name: openssl


### PR DESCRIPTION
* Various formatting and changes to the file structure (mainly `cmd -> powershell` for better readability).
* Updated versioning - rpcs3 latest release tag is now fetched using `git describe`, no need to manually update `appveyor.yaml` for each release or milestone.
* Updated Qt to version 5.10.0.
* Added a __separate__ OpenSSL artifact containing the required libs to make compat DB fetching work. These binaries are distributed by AppVeyor as part of the build env. Users can be directed to download and extract the binaries to their local rpcs3 dir (e.g. in the quickstart guide). A warning can also be included regarding legal issues pertaining to using OpenSSL, if any.
* Package artifacts using `7z` format, reduces rpcs3 artifact size from ~20MB to ~14MB.
* Compat DB is fetched and packaged after the build has finished. Failed DB downloads are (hopefully) accounted for by adding some basic fault tolerance using powershell + AppVeyor caching.

_Errata:_
* In 1d0baf3 commit message: after_package -> before_package