### PR TITLE
Add sceNpMatchingInt

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpMatchingInt.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpMatchingInt.cpp
@@ -1,0 +1,41 @@
+#include "stdafx.h"
+#include "Emu/System.h"
+#include "Emu/Cell/PPUModule.h"
+
+namespace vm { using namespace ps3; }
+
+logs::channel sceNpMatchingInt("sceNpMatchingInt");
+
+s32 sceNpMatchingGetRoomMemberList()
+{
+	UNIMPLEMENTED_FUNC(sceNpMatchingInt);
+	return CELL_OK;
+}
+
+// Parameter "unknown" added to distinguish this function
+// from the one in sceNp.cpp which has the same name
+s32 sceNpMatchingJoinRoomGUI(vm::ptr<void> unknown)
+{
+	UNIMPLEMENTED_FUNC(sceNpMatchingInt);
+	return CELL_OK;
+}
+
+s32 sceNpMatchingGetRoomListGUI()
+{
+	UNIMPLEMENTED_FUNC(sceNpMatchingInt);
+	return CELL_OK;
+}
+
+s32 sceNpMatchingSendRoomMessage()
+{
+	UNIMPLEMENTED_FUNC(sceNpMatchingInt);
+	return CELL_OK;
+}
+
+DECLARE(ppu_module_manager::sceNpMatchingInt)("sceNpMatchingInt", []()
+{
+	REG_FUNC(sceNpMatchingInt, sceNpMatchingGetRoomMemberList);
+	REG_FUNC(sceNpMatchingInt, sceNpMatchingJoinRoomGUI);
+	REG_FUNC(sceNpMatchingInt, sceNpMatchingGetRoomListGUI);
+	REG_FUNC(sceNpMatchingInt, sceNpMatchingSendRoomMessage);
+});

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -244,6 +244,7 @@ static void ppu_initialize_modules(const std::shared_ptr<ppu_linkage_info>& link
 		&ppu_module_manager::sceNp2,
 		&ppu_module_manager::sceNpClans,
 		&ppu_module_manager::sceNpCommerce2,
+		&ppu_module_manager::sceNpMatchingInt,
 		&ppu_module_manager::sceNpSns,
 		&ppu_module_manager::sceNpTrophy,
 		&ppu_module_manager::sceNpTus,

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -255,6 +255,7 @@ public:
 	static const ppu_static_module sceNp2;
 	static const ppu_static_module sceNpClans;
 	static const ppu_static_module sceNpCommerce2;
+	static const ppu_static_module sceNpMatchingInt;
 	static const ppu_static_module sceNpSns;
 	static const ppu_static_module sceNpTrophy;
 	static const ppu_static_module sceNpTus;

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -250,6 +250,7 @@
     <ClCompile Include="Emu\Cell\Modules\sceNp2.cpp" />
     <ClCompile Include="Emu\Cell\Modules\sceNpClans.cpp" />
     <ClCompile Include="Emu\Cell\Modules\sceNpCommerce2.cpp" />
+    <ClCompile Include="Emu\Cell\Modules\sceNpMatchingInt.cpp" />
     <ClCompile Include="Emu\Cell\Modules\sceNpSns.cpp" />
     <ClCompile Include="Emu\Cell\Modules\sceNpTrophy.cpp" />
     <ClCompile Include="Emu\Cell\Modules\sceNpTus.cpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -587,6 +587,9 @@
     <ClCompile Include="Emu\Cell\Modules\sceNpCommerce2.cpp">
       <Filter>Emu\Cell\Modules</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\Cell\Modules\sceNpMatchingInt.cpp">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClCompile>
     <ClCompile Include="Emu\Cell\Modules\sceNpSns.cpp">
       <Filter>Emu\Cell\Modules</Filter>
     </ClCompile>
@@ -937,7 +940,7 @@
     </ClCompile>
     <ClCompile Include="Emu\Io\PadHandler.cpp">
       <Filter>Emu\Io</Filter>
-	</ClCompile>
+    </ClCompile>
     <ClCompile Include="Emu\RSX\overlays.cpp">
       <Filter>Emu\GPU\RSX</Filter>
     </ClCompile>


### PR DESCRIPTION
Manually load _libsysutil_np.sprx_ in the cpu settings then boot a game and check logs using trace level.

**Master**
! LDR: **** sceNpMatchingInt export: [0x170829D3] at 0x84d9f8
! LDR: **** sceNpMatchingInt export: [0x474B7B13] at 0x84da80
! LDR: **** sceNpMatchingInt export: [0xB00F408A] at 0x84dab0
! LDR: **** sceNpMatchingInt export: [0xE61F7EE9] at 0x84da08

**With this PR**
! LDR: **** sceNpMatchingInt export: [sceNpMatchingGetRoomMemberList] at 0x84d9f8
! LDR: **** sceNpMatchingInt export: [sceNpMatchingJoinRoomGUI] at 0x84da80
! LDR: **** sceNpMatchingInt export: [sceNpMatchingGetRoomListGUI] at 0x84dab0
! LDR: **** sceNpMatchingInt export: [sceNpMatchingSendRoomMessage] at 0x84da08