### PR TITLE
Clamp spu address [disasm]

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -553,9 +553,12 @@ void debugger_list::ShowAddr(u32 addr)
 	}
 	else
 	{
-		const u32 cpu_offset = cpu->id_type() != 1 ? static_cast<SPUThread&>(*cpu).offset : 0;
+		const bool is_spu = cpu->id_type() != 1;
+		const u32 cpu_offset = is_spu ? static_cast<SPUThread&>(*cpu).offset : 0;
+		const u32 address_limits = is_spu ? 0x3ffff : ~0;
+		m_pc &= address_limits;
 		m_debugFrame->m_disasm->offset = (u8*)vm::base(cpu_offset);
-		for (uint i = 0, count = 4; i<m_item_count; ++i, m_pc += count)
+		for (uint i = 0, count = 4; i<m_item_count; ++i, m_pc = (m_pc + count) & address_limits)
 		{
 			if (!vm::check_addr(cpu_offset + m_pc, 4))
 			{


### PR DESCRIPTION
this allows the spu disassembler to nicely wrap around addresses instead of reporting "illegal address" on addresses outside of LS and resolves potential memory conflicts with main storage memory in the debugger.

