### PR TITLE
RPCS3 0.0.5: Versioning Changes (Hotfix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,8 @@ before_script:
       export PATH=${TRAVIS_BUILD_DIR}/build/squashfs-root/usr/bin/:${PATH} ;
       ./squashfs-root/usr/bin/appimagetool ${TRAVIS_BUILD_DIR}/build/appdir ;
       find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq ;
-      COMM_TAG="$(git describe --tags $(git rev-list --tags --max-count=1))"
-      COMM_COUNT="$(git rev-list --count HEAD)"
+      COMM_TAG="$(git describe --tags $(git rev-list --tags --max-count=1))" ;
+      COMM_COUNT="$(git rev-list --count HEAD)" ;
       curl "${UPLOAD_URL}${TRAVIS_COMMIT:0:8}&t=${COMM_TAG}&a=${COMM_COUNT}" --upload-file ./RPCS3*.AppImage;
    fi;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,19 +16,18 @@ cache:
 
 install:
 - ps: | # set env vars for versioning
-    $commTag = $(git describe --tags $(git rev-list --tags --max-count=1))
-    $commCount = $(git rev-list --count HEAD)
-    $commHash = $env:APPVEYOR_REPO_COMMIT.Substring(0,8)
+    $env:COMM_TAG = $(git describe --tags $(git rev-list --tags --max-count=1))
+    $env:COMM_COUNT = $(git rev-list --count HEAD)
+    $env:COMM_HASH = $env:APPVEYOR_REPO_COMMIT.Substring(0,8)
     
     if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-        $env:BUILD = "{0}-{1}" -f $commTag, $commHash
+        $env:BUILD = "rpcs3-{0}-{1}_win64.7z" -f $env:COMM_TAG, $env:COMM_HASH
     }
     else {
-        $env:BUILD = "{0}-{1}-{2}" -f $commTag, $commCount, $commHash
+        $env:BUILD = "rpcs3-{0}-{1}-{2}_win64.7z" -f $env:COMM_TAG, $env:COMM_COUNT, $env:COMM_HASH
     }
     
-    $env:AVVER = "{0}-{1}" -f $commTag.TrimStart("v"), $env:APPVEYOR_BUILD_NUMBER
-    $env:RPCS3 = "rpcs3-{0}_win64.7z" -f $env:BUILD
+    $env:AVVER = "{0}-{1}" -f $env:COMM_TAG.TrimStart("v"), $env:APPVEYOR_BUILD_NUMBER
 
 - ps: | # used for experimental build warnings for pr builds
     $env:BRANCH = "{0}/{1}/#{2}" -f $env:APPVEYOR_REPO_NAME, `
@@ -82,20 +81,20 @@ after_build:
     copy-item compat_database.dat .\bin\GuiConfigs\compat_database.dat
 
 - ps: | # package artifacts
-    7z a -m0=LZMA2 -mx9 $env:RPCS3 .\bin\*
+    7z a -m0=LZMA2 -mx9 $env:BUILD .\bin\*
     7z a -m0=LZMA2 -mx9 openssl_win64.7z C:\OpenSSL-Win64\bin\libeay32.dll `
       C:\OpenSSL-Win64\bin\ssleay32.dll
 
 - ps: | # generate sha256 hashes
-    (get-filehash $env:RPCS3 -algorithm SHA256).Hash > ("{0}.sha256" -f $env:RPCS3)
+    (get-filehash $env:BUILD -algorithm SHA256).Hash > ("{0}.sha256" -f $env:BUILD)
     (get-filehash openssl_win64.7z -algorithm SHA256).Hash > "openssl_win64.7z.sha256"
 
 test: off
 
 artifacts:
-- path: $(RPCS3)
+- path: $(BUILD)
   name: rpcs3
-- path: $(RPCS3).sha256
+- path: $(BUILD).sha256
   name: rpcs3 sha256 hash
 - path: openssl_win64.7z
   name: openssl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,12 @@ install:
     
     if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
         $env:BUILD = "rpcs3-{0}-{1}_win64.7z" -f $env:COMM_TAG, $env:COMM_HASH
+        $env:AVVER = "{0}-{1}" -f $env:COMM_TAG.TrimStart("v"), $env:COMM_HASH
     }
     else {
         $env:BUILD = "rpcs3-{0}-{1}-{2}_win64.7z" -f $env:COMM_TAG, $env:COMM_COUNT, $env:COMM_HASH
+        $env:AVVER = "{0}-{1}-{2}" -f $env:COMM_TAG.TrimStart("v"), $env:COMM_COUNT, $env:COMM_HASH
     }
-    
-    $env:AVVER = "{0}-{1}" -f $env:COMM_TAG.TrimStart("v"), $env:APPVEYOR_BUILD_NUMBER
 
 - ps: | # used for experimental build warnings for pr builds
     $env:BRANCH = "{0}/{1}/#{2}" -f $env:APPVEYOR_REPO_NAME, `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,8 +86,8 @@ after_build:
       C:\OpenSSL-Win64\bin\ssleay32.dll
 
 - ps: | # generate sha256 hashes
-    (get-filehash $env:BUILD -algorithm SHA256).Hash > ("{0}.sha256" -f $env:BUILD)
-    (get-filehash openssl_win64.7z -algorithm SHA256).Hash > "openssl_win64.7z.sha256"
+    (get-filehash $env:BUILD -algorithm SHA256).Hash | out-file ("{0}.sha256" -f $env:BUILD) -encoding ascii
+    (get-filehash openssl_win64.7z -algorithm SHA256).Hash | out-file "openssl_win64.7z.sha256" -encoding ascii
 
 test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
     }
     else {
         $env:BUILD = "rpcs3-{0}-{1}-{2}_win64.7z" -f $env:COMM_TAG, $env:COMM_COUNT, $env:COMM_HASH
-        $env:AVVER = "{0}-{1}-{2}" -f $env:COMM_TAG.TrimStart("v"), $env:COMM_COUNT, $env:COMM_HASH
+        $env:AVVER = "{0}-{1}" -f $env:COMM_TAG.TrimStart("v"), $env:COMM_COUNT
     }
 
 - ps: | # used for experimental build warnings for pr builds

--- a/rpcs3/rpcs3_version.cpp
+++ b/rpcs3/rpcs3_version.cpp
@@ -9,5 +9,5 @@ namespace rpcs3
 		return RPCS3_GIT_BRANCH;
 	}
 
-	const extern utils::version version{ 0, 0, 4, utils::version_type::alpha, 1, RPCS3_GIT_VERSION };
+	const extern utils::version version{ 0, 0, 5, utils::version_type::alpha, 1, RPCS3_GIT_VERSION };
 }


### PR DESCRIPTION
* Make Travis upload appimages for real this time. Hopefully.
* Expose AppVeyor versioning env vars, these can be retrieved via API or deployment.
* Update AppVeyor build version to (almost) match artifact versions.
* Version bump.