### PR TITLE
cellgame: Fix cellDiscGameGetBootDiscInfo return values

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.h
+++ b/rpcs3/Emu/Cell/Modules/cellGame.h
@@ -43,6 +43,13 @@ enum CellGameDataError : u32
 	CELL_GAMEDATA_ERROR_FAILURE      = 0x8002b607,
 };
 
+enum CellDiscGameError : u32
+{
+	CELL_DISCGAME_ERROR_INTERNAL      = 0x8002bd01,
+	CELL_DISCGAME_ERROR_NOT_DISCBOOT  = 0x8002bd02,
+	CELL_DISCGAME_ERROR_PARAM         = 0x8002bd03,
+};
+
 // Definitions
 enum
 {


### PR DESCRIPTION
fixes psn rac quest for booty to actually boot, thanks to @hcorion for finding it

The mentioned game ('NBA 08 Live Demo') in the comment of the function was tested, and still works the same