### PR TITLE
[WIP] Debugger refactoring

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -313,7 +313,7 @@ static bool ppu_break(ppu_thread& ppu, ppu_opcode_t op)
 }
 
 // Set or remove breakpoint
-extern void ppu_breakpoint(u32 addr)
+extern void ppu_breakpoint(u32 addr, bool isAdding)
 {
 	if (g_cfg.core.ppu_decoder == ppu_decoder_type::llvm)
 	{
@@ -322,15 +322,15 @@ extern void ppu_breakpoint(u32 addr)
 
 	const auto _break = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(&ppu_break));
 
-	if (ppu_ref(addr) == _break)
-	{
-		// Remove breakpoint
-		ppu_ref(addr) = ppu_cache(addr);
-	}
-	else
+	if (isAdding)
 	{
 		// Set breakpoint
 		ppu_ref(addr) = _break;
+	}
+	else
+	{
+		// Remove breakpoint
+		ppu_ref(addr) = ppu_cache(addr);
 	}
 }
 

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -932,6 +932,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="rpcs3qt\about_dialog.cpp" />
+    <ClCompile Include="rpcs3qt\breakpoint_handler.cpp" />
     <ClCompile Include="rpcs3qt\find_dialog.cpp" />
     <ClCompile Include="rpcs3qt\gamepads_settings_dialog.cpp" />
     <ClCompile Include="rpcs3qt\game_compatibility.cpp" />
@@ -1308,6 +1309,7 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DLLVM_AVAILABLE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE "-I.\..\Vulkan\Vulkan-LoaderAndValidationLayers\include" "-I.\.." "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtQuick" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)\." "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras"</Command>
     </CustomBuild>
+    <ClInclude Include="rpcs3qt\breakpoint_handler.h" />
     <ClInclude Include="rpcs3qt\find_dialog.h" />
     <ClInclude Include="rpcs3qt\custom_table_widget_item.h" />
     <ClInclude Include="rpcs3qt\gamepads_settings_dialog.h" />

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -371,6 +371,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_debugger_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_emu_settings.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -512,6 +517,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug\moc_debugger_frame.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_debugger_list.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
@@ -671,6 +681,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_debugger_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_emu_settings.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
@@ -816,6 +831,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_debugger_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_emu_settings.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -933,6 +953,7 @@
     </ClCompile>
     <ClCompile Include="rpcs3qt\about_dialog.cpp" />
     <ClCompile Include="rpcs3qt\breakpoint_handler.cpp" />
+    <ClCompile Include="rpcs3qt\debugger_list.cpp" />
     <ClCompile Include="rpcs3qt\find_dialog.cpp" />
     <ClCompile Include="rpcs3qt\gamepads_settings_dialog.cpp" />
     <ClCompile Include="rpcs3qt\game_compatibility.cpp" />
@@ -1310,6 +1331,24 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DLLVM_AVAILABLE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE "-I.\..\Vulkan\Vulkan-LoaderAndValidationLayers\include" "-I.\.." "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtQuick" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)\." "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras"</Command>
     </CustomBuild>
     <ClInclude Include="rpcs3qt\breakpoint_handler.h" />
+    <CustomBuild Include="rpcs3qt\debugger_list.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DBRANCH= -DLLVM_AVAILABLE -D_UNICODE "-I.\..\Vulkan\Vulkan-LoaderAndValidationLayers\include" "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtQuick" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)\." "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -D_SCL_SECURE_NO_WARNINGS -D_UNICODE "-I.\..\Vulkan\Vulkan-LoaderAndValidationLayers\include" "-I.\.." "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtQuick" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)\." "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -D_UNICODE "-I.\..\Vulkan\Vulkan-LoaderAndValidationLayers\include" "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtQuick" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)\." "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DLLVM_AVAILABLE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE "-I.\..\Vulkan\Vulkan-LoaderAndValidationLayers\include" "-I.\.." "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtQuick" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)\." "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras"</Command>
+    </CustomBuild>
     <ClInclude Include="rpcs3qt\find_dialog.h" />
     <ClInclude Include="rpcs3qt\custom_table_widget_item.h" />
     <ClInclude Include="rpcs3qt\gamepads_settings_dialog.h" />

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -605,6 +605,9 @@
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_register_editor_dialog.cpp">
       <Filter>Generated Files\Debug - LLVM</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\breakpoint_handler.cpp">
+      <Filter>Gui\debugger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="\rpcs3qt\*.h">
@@ -687,6 +690,9 @@
     </ClInclude>
     <ClInclude Include="rpcs3qt\qt_utils.h">
       <Filter>Gui\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="rpcs3qt\breakpoint_handler.h">
+      <Filter>Gui\debugger</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -608,6 +608,21 @@
     <ClCompile Include="rpcs3qt\breakpoint_handler.cpp">
       <Filter>Gui\debugger</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\debugger_list.cpp">
+      <Filter>Gui\debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_debugger_list.cpp">
+      <Filter>Generated Files\Release - LLVM</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_debugger_list.cpp">
+      <Filter>Generated Files\Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_debugger_list.cpp">
+      <Filter>Generated Files\Release</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_debugger_list.cpp">
+      <Filter>Generated Files\Debug - LLVM</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="\rpcs3qt\*.h">
@@ -814,6 +829,9 @@
       <Filter>Gui\game list</Filter>
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\register_editor_dialog.h">
+      <Filter>Gui\debugger</Filter>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\debugger_list.h">
       <Filter>Gui\debugger</Filter>
     </CustomBuild>
   </ItemGroup>

--- a/rpcs3/rpcs3qt/breakpoint_handler.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_handler.cpp
@@ -2,7 +2,7 @@
 
 extern void ppu_breakpoint(u32 loc, bool isAdding);
 
-breakpoint_handler::breakpoint_handler()
+breakpoint_handler::breakpoint_handler() :m_breakpoints()
 {
 
 }

--- a/rpcs3/rpcs3qt/breakpoint_handler.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_handler.cpp
@@ -1,0 +1,32 @@
+#include "breakpoint_handler.h"
+
+extern void ppu_breakpoint(u32 loc, bool isAdding);
+
+breakpoint_handler::breakpoint_handler()
+{
+
+}
+
+breakpoint_handler::~breakpoint_handler()
+{
+
+}
+
+bool breakpoint_handler::HasBreakpoint(u32 loc) const
+{
+	return m_breakpoints.find(loc) != m_breakpoints.end();
+}
+
+bool breakpoint_handler::AddBreakpoint(u32 loc)
+{
+	m_breakpoints.insert(loc);
+	ppu_breakpoint(loc, true);
+	return true;
+}
+
+bool breakpoint_handler::RemoveBreakpoint(u32 loc)
+{
+	m_breakpoints.erase(loc);
+	ppu_breakpoint(loc, false);
+	return true;
+}

--- a/rpcs3/rpcs3qt/breakpoint_handler.h
+++ b/rpcs3/rpcs3qt/breakpoint_handler.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "stdafx.h"
+#include "Emu/Cell/PPUThread.h"
+#include <set>
+
+enum breakpoint_types
+{
+	read = 0x1,
+	write = 0x2,
+	exec = 0x4,
+};
+
+/*
+* This class acts as a layer between the UI and Emu for breakpoints.
+*/
+class breakpoint_handler
+{
+
+public:
+	breakpoint_handler();
+	~breakpoint_handler();
+
+	/**
+	* Returns true iff breakpoint exists at loc.
+	* TODO: Add arg for flags, gameid.
+	*/
+	bool HasBreakpoint(u32 loc) const;
+
+	/**
+	* Returns true if added successfully. TODO: flags
+	*/
+	bool AddBreakpoint(u32 loc);
+
+
+	/**
+	* Returns true if removed breakpoint at loc successfully.
+	*/
+	bool RemoveBreakpoint(u32 loc);
+
+private:
+	// TODO : generalize to hold multiple games and handle flags.Probably do : std::map<std::string, std::set<breakpoint>>.
+	// May also do std::map<loc, breakpoint> where breakpoint has gameid depending on how map is used most.
+	std::set<u32> m_breakpoints; //! Holds all breakpoints.
+};

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -133,9 +133,9 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 	connect(m_choice_units, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &debugger_frame::OnSelectUnit);
 	connect(this, &QDockWidget::visibilityChanged, this, &debugger_frame::EnableUpdateTimer);
 
-	connect(m_breakpoints_list, &QListWidget::itemDoubleClicked, this, &debugger_frame::OnBreakpointList_doubleClicked);
-	connect(m_breakpoints_list, &QListWidget::customContextMenuRequested, this, &debugger_frame::OnBreakpointList_rightClicked);
-	connect(m_breakpoints_list_delete, &QAction::triggered, this, &debugger_frame::OnBreakpointList_delete);
+	connect(m_breakpoints_list, &QListWidget::itemDoubleClicked, this, &debugger_frame::OnBreakpointListDoubleClicked);
+	connect(m_breakpoints_list, &QListWidget::customContextMenuRequested, this, &debugger_frame::OnBreakpointListRightClicked);
+	connect(m_breakpoints_list_delete, &QAction::triggered, this, &debugger_frame::OnBreakpointListDelete);
 
 	m_list->ShowAddr(CentrePc(m_list->m_pc));
 	UpdateUnitList();
@@ -488,13 +488,13 @@ void debugger_frame::ClearBreakpoints()
 	g_breakpoints.clear();
 }
 
-void debugger_frame::OnBreakpointList_doubleClicked()
+void debugger_frame::OnBreakpointListDoubleClicked()
 {
 	m_list->ShowAddr(CentrePc(m_breakpoints_list->currentItem()->data(Qt::UserRole).value<u32>()));
 	m_list->setCurrentRow(16);
 }
 
-void debugger_frame::OnBreakpointList_rightClicked(const QPoint &pos)
+void debugger_frame::OnBreakpointListRightClicked(const QPoint &pos)
 {
 	if (m_breakpoints_list->itemAt(pos) == NULL)
 		return;
@@ -521,7 +521,7 @@ void debugger_frame::OnBreakpointList_rightClicked(const QPoint &pos)
 	}
 }
 
-void debugger_frame::OnBreakpointList_delete()
+void debugger_frame::OnBreakpointListDelete()
 {
 	int selectedCount = m_breakpoints_list->selectedItems().count();
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -209,7 +209,10 @@ void debugger_frame::UpdateUI()
 {
 	UpdateUnitList();
 
-	if (m_no_thread_selected) return;
+	if (m_no_thread_selected)
+	{
+		return;
+	}
 
 	const auto cpu = this->cpu.lock();
 
@@ -534,8 +537,10 @@ void debugger_frame::OnBreakpointListDoubleClicked()
 
 void debugger_frame::OnBreakpointListRightClicked(const QPoint &pos)
 {
-	if (m_breakpoints_list->itemAt(pos) == NULL)
+	if (!m_breakpoints_list->itemAt(pos))
+	{
 		return;
+	}
 
 	QMenu* menu = new QMenu();
 
@@ -547,15 +552,12 @@ void debugger_frame::OnBreakpointListRightClicked(const QPoint &pos)
 	menu->addAction(m_breakpoints_list_delete);
 
 	QAction* selectedItem = menu->exec(QCursor::pos());
-	if (selectedItem != NULL)
+	if (selectedItem && selectedItem->text() == "Rename")
 	{
-		if (selectedItem->text() == "Rename")
-		{
-			QListWidgetItem* currentItem = m_breakpoints_list->selectedItems().at(0);
+		QListWidgetItem* currentItem = m_breakpoints_list->selectedItems().at(0);
 
-			currentItem->setFlags(currentItem->flags() | Qt::ItemIsEditable);
-			m_breakpoints_list->editItem(currentItem);
-		}
+		currentItem->setFlags(currentItem->flags() | Qt::ItemIsEditable);
+		m_breakpoints_list->editItem(currentItem);
 	}
 }
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -558,21 +558,21 @@ void debugger_list::ShowAddr(u32 addr)
 		{
 			if (!vm::check_addr(cpu_offset + m_pc, 4))
 			{
-				item(i)->setText((IsBreakPoint(m_pc) ? ">>> " : "    ") + qstr(fmt::format("[%08x] illegal address", m_pc)));
+				item(i)->setText((m_debugFrame->m_brkpt_handler.HasBreakpoint(m_pc) ? ">>> " : "    ") + qstr(fmt::format("[%08x] illegal address", m_pc)));
 				count = 4;
 				continue;
 			}
 
 			count = m_debugFrame->m_disasm->disasm(m_debugFrame->m_disasm->dump_pc = m_pc);
 
-			item(i)->setText((IsBreakPoint(m_pc) ? ">>> " : "    ") + qstr(m_debugFrame->m_disasm->last_opcode));
+			item(i)->setText((m_debugFrame->m_brkpt_handler.HasBreakpoint(m_pc) ? ">>> " : "    ") + qstr(m_debugFrame->m_disasm->last_opcode));
 
 			if (test(cpu->state & cpu_state_pause) && m_pc == m_debugFrame->GetPc())
 			{
 				item(i)->setTextColor(m_text_color_pc);
 				item(i)->setBackgroundColor(m_color_pc);
 			}
-			else if (IsBreakPoint(m_pc))
+			else if (m_debugFrame->m_brkpt_handler.HasBreakpoint(m_pc))
 			{
 				item(i)->setTextColor(m_text_color_bp);
 				item(i)->setBackgroundColor(m_color_bp);
@@ -588,18 +588,8 @@ void debugger_list::ShowAddr(u32 addr)
 	setLineWidth(-1);
 }
 
-bool debugger_list::IsBreakPoint(u32 pc)
-{
-	return m_debugFrame->m_brkpt_handler.HasBreakpoint(pc);
-}
-
 void debugger_list::AddBreakPoint(u32 pc)
 {
-	if (m_debugFrame->m_brkpt_handler.HasBreakpoint(pc))
-	{
-		RemoveBreakPoint(pc);
-		return;
-	}
 	m_debugFrame->m_brkpt_handler.AddBreakpoint(pc);
 
 	const auto cpu = m_debugFrame->cpu.lock();
@@ -697,7 +687,7 @@ void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
 		const u32 pc = start_pc + i * 4;
 		//ConLog.Write("pc=0x%llx", pc);
 
-		if (IsBreakPoint(pc))
+		if (m_debugFrame->m_brkpt_handler.HasBreakpoint(pc))
 		{
 			RemoveBreakPoint(pc);
 		}

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -82,6 +82,8 @@ public:
 	void WriteRegs();
 	void EnableButtons(bool enable);
 	void ClearBreakpoints();
+	void RemoveBreakpoint(u32 loc);
+	void AddBreakpoint(u32 loc);
 
 	void OnUpdate();
 
@@ -123,10 +125,6 @@ public:
 public:
 	debugger_list(debugger_frame* parent);
 	void ShowAddr(u32 addr);
-	void RemoveBreakPoint(u32 pc);
-
-private:
-	void AddBreakPoint(u32 pc);
 
 protected:
 	void keyPressEvent(QKeyEvent* event);

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -13,6 +13,7 @@
 #include "Emu/Cell/SPUDisAsm.h"
 #include "Emu/Cell/PPUInterpreter.h"
 
+#include "debugger_list.h"
 #include "breakpoint_handler.h"
 #include "instruction_editor_dialog.h"
 #include "register_editor_dialog.h"
@@ -27,8 +28,6 @@
 #include <QTimer>
 #include <QTextEdit>
 #include <QSplitter>
-
-class debugger_list;
 
 class debugger_frame : public QDockWidget
 {
@@ -61,11 +60,11 @@ class debugger_frame : public QDockWidget
 
 	std::shared_ptr<gui_settings> xgui_settings;
 
+	breakpoint_handler* m_brkpt_handler; // Handles communicating with PPU to simplify logic in debugger.
 	QAction* m_breakpoints_list_delete;
 public:
-	std::unique_ptr<CPUDisAsm> m_disasm;
+	std::shared_ptr<CPUDisAsm> m_disasm;
 	QListWidget* m_breakpoints_list;
-	breakpoint_handler m_brkpt_handler;
 	std::weak_ptr<cpu_thread> cpu;
 
 public:
@@ -98,6 +97,7 @@ Q_SIGNALS:
 public Q_SLOTS:
 	void DoStep();
 private Q_SLOTS:
+	void HandleBreakpointRequest(u32 loc);
 	void OnBreakpointListDoubleClicked();
 	void OnBreakpointListRightClicked(const QPoint &pos);
 	void OnBreakpointListDelete();
@@ -105,32 +105,6 @@ private Q_SLOTS:
 	void Show_Val();
 	void Show_PC();
 	void EnableUpdateTimer(bool state);
-};
-
-class debugger_list : public QListWidget
-{
-	Q_OBJECT
-
-	debugger_frame* m_debugFrame;
-
-public:
-	u32 m_pc;
-	u32 m_item_count;
-	bool m_no_thread_selected;
-	QColor m_color_bp;
-	QColor m_color_pc;
-	QColor m_text_color_bp;
-	QColor m_text_color_pc;
-
-public:
-	debugger_list(debugger_frame* parent);
-	void ShowAddr(u32 addr);
-
-protected:
-	void keyPressEvent(QKeyEvent* event);
-	void mouseDoubleClickEvent(QMouseEvent* event);
-	void wheelEvent(QWheelEvent* event);
-	void resizeEvent(QResizeEvent* event);
 };
 
 Q_DECLARE_METATYPE(u32);

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -13,6 +13,7 @@
 #include "Emu/Cell/SPUDisAsm.h"
 #include "Emu/Cell/PPUInterpreter.h"
 
+#include "breakpoint_handler.h"
 #include "instruction_editor_dialog.h"
 #include "register_editor_dialog.h"
 #include "gui_settings.h"
@@ -61,10 +62,10 @@ class debugger_frame : public QDockWidget
 	std::shared_ptr<gui_settings> xgui_settings;
 
 	QAction* m_breakpoints_list_delete;
-
 public:
 	std::unique_ptr<CPUDisAsm> m_disasm;
 	QListWidget* m_breakpoints_list;
+	breakpoint_handler m_brkpt_handler;
 	std::weak_ptr<cpu_thread> cpu;
 
 public:
@@ -122,7 +123,7 @@ public:
 public:
 	debugger_list(debugger_frame* parent);
 	void ShowAddr(u32 addr);
-	void RemoveBreakPoint(u32 pc, bool eraseFromMap = true);
+	void RemoveBreakPoint(u32 pc);
 
 private:
 	bool IsBreakPoint(u32 pc);

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -33,40 +33,6 @@ class debugger_frame : public QDockWidget
 {
 	Q_OBJECT
 
-	debugger_list* m_list;
-	QSplitter* m_right_splitter;
-	QFont m_mono;
-	QTextEdit* m_regs;
-	QPushButton* m_go_to_addr;
-	QPushButton* m_go_to_pc;
-	QPushButton* m_btn_capture;
-	QPushButton* m_btn_step;
-	QPushButton* m_btn_run;
-	QComboBox* m_choice_units;
-	QString m_current_choice;
-	bool m_no_thread_selected = true;
-
-	u64 m_threads_created = 0;
-	u64 m_threads_deleted = 0;
-	u32 m_last_pc = -1;
-	u32 m_last_stat = 0;
-
-	QTimer* m_update;
-	QSplitter* m_splitter;
-
-	const QString NoThread = tr("No Thread");
-	const QString Run = tr("Run");
-	const QString Pause = tr("Pause");
-
-	std::shared_ptr<gui_settings> xgui_settings;
-
-	breakpoint_handler* m_brkpt_handler; // Handles communicating with PPU to simplify logic in debugger.
-	QAction* m_breakpoints_list_delete;
-public:
-	std::shared_ptr<CPUDisAsm> m_disasm;
-	QListWidget* m_breakpoints_list;
-	std::weak_ptr<cpu_thread> cpu;
-
 public:
 	explicit debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *parent = 0);
 	void SaveSettings();
@@ -105,6 +71,41 @@ private Q_SLOTS:
 	void Show_Val();
 	void Show_PC();
 	void EnableUpdateTimer(bool state);
+
+private:
+	debugger_list* m_list;
+	QSplitter* m_right_splitter;
+	QFont m_mono;
+	QTextEdit* m_regs;
+	QPushButton* m_go_to_addr;
+	QPushButton* m_go_to_pc;
+	QPushButton* m_btn_capture;
+	QPushButton* m_btn_step;
+	QPushButton* m_btn_run;
+	QComboBox* m_choice_units;
+	QString m_current_choice;
+	bool m_no_thread_selected = true;
+
+	u64 m_threads_created = 0;
+	u64 m_threads_deleted = 0;
+	u32 m_last_pc = -1;
+	u32 m_last_stat = 0;
+
+	QTimer* m_update;
+	QSplitter* m_splitter;
+
+	const QString NoThread = tr("No Thread");
+	const QString Run = tr("Run");
+	const QString Pause = tr("Pause");
+
+	QListWidget* m_breakpoints_list;
+	breakpoint_handler* m_brkpt_handler; // Handles communicating with PPU to simplify logic in debugger.
+	QAction* m_breakpoints_list_delete;
+
+	std::shared_ptr<CPUDisAsm> m_disasm;
+	std::weak_ptr<cpu_thread> cpu;
+
+	std::shared_ptr<gui_settings> xgui_settings;
 };
 
 Q_DECLARE_METATYPE(u32);

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -126,7 +126,6 @@ public:
 	void RemoveBreakPoint(u32 pc);
 
 private:
-	bool IsBreakPoint(u32 pc);
 	void AddBreakPoint(u32 pc);
 
 protected:

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -95,9 +95,9 @@ Q_SIGNALS:
 public Q_SLOTS:
 	void DoStep();
 private Q_SLOTS:
-	void OnBreakpointList_doubleClicked();
-	void OnBreakpointList_rightClicked(const QPoint &pos);
-	void OnBreakpointList_delete();
+	void OnBreakpointListDoubleClicked();
+	void OnBreakpointListRightClicked(const QPoint &pos);
+	void OnBreakpointListDelete();
 	void OnSelectUnit();
 	void Show_Val();
 	void Show_PC();

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -1,0 +1,189 @@
+#include "debugger_list.h"
+#include "register_editor_dialog.h"
+#include "instruction_editor_dialog.h"
+
+#include <QApplication>
+#include <QWheelEvent>
+#include <QMouseEvent>
+
+constexpr auto qstr = QString::fromStdString;
+
+debugger_list::debugger_list(QWidget* parent, breakpoint_handler* handler)
+	: QListWidget(parent), m_brkpoint_handler(handler)
+{
+	m_pc = 0;
+	m_item_count = 30;
+};
+
+u32 debugger_list::GetPc() const
+{
+	const auto cpu = this->cpu.lock();
+
+	if (!cpu)
+	{
+		return 0;
+	}
+
+	return cpu->id_type() == 1 ? static_cast<ppu_thread*>(cpu.get())->cia : static_cast<SPUThread*>(cpu.get())->pc;
+}
+
+void debugger_list::ShowAddr(u32 addr)
+{
+	m_pc = addr;
+
+	const auto cpu = this->cpu.lock();
+
+	if (!cpu)
+	{
+		for (uint i = 0; i<m_item_count; ++i, m_pc += 4)
+		{
+			item(i)->setText(qstr(fmt::format("[%08x] illegal address", m_pc)));
+		}
+	}
+	else
+	{
+		bool hasBreakpoint = m_brkpoint_handler->HasBreakpoint(m_pc);
+		const bool is_spu = cpu->id_type() != 1;
+		const u32 cpu_offset = is_spu ? static_cast<SPUThread&>(*cpu).offset : 0;
+		const u32 address_limits = is_spu ? 0x3ffff : ~0;
+		m_pc &= address_limits;
+		m_disasm->offset = (u8*)vm::base(cpu_offset);
+		for (uint i = 0, count = 4; i<m_item_count; ++i, m_pc = (m_pc + count) & address_limits)
+		{
+			if (!vm::check_addr(cpu_offset + m_pc, 4))
+			{
+				item(i)->setText((hasBreakpoint ? ">>> " : "    ") + qstr(fmt::format("[%08x] illegal address", m_pc)));
+				count = 4;
+				continue;
+			}
+
+			count = m_disasm->disasm(m_disasm->dump_pc = m_pc);
+
+			item(i)->setText((hasBreakpoint ? ">>> " : "    ") + qstr(m_disasm->last_opcode));
+
+			if (test(cpu->state & cpu_state_pause) && m_pc == GetPc())
+			{
+				item(i)->setTextColor(m_text_color_pc);
+				item(i)->setBackgroundColor(m_color_pc);
+			}
+			else if (hasBreakpoint)
+			{
+				item(i)->setTextColor(m_text_color_bp);
+				item(i)->setBackgroundColor(m_color_bp);
+			}
+			else
+			{
+				item(i)->setTextColor(palette().color(foregroundRole()));
+				item(i)->setBackgroundColor(palette().color(backgroundRole()));
+			}
+		}
+	}
+
+	setLineWidth(-1);
+}
+
+void debugger_list::UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_ptr<CPUDisAsm> disasm)
+{
+	this->cpu = cpu;
+	m_disasm = disasm;
+}
+
+void debugger_list::keyPressEvent(QKeyEvent* event)
+{
+	if (!isActiveWindow())
+	{
+		return;
+	}
+
+	const auto cpu = this->cpu.lock();
+	long i = currentRow();
+
+	if (i < 0 || !cpu)
+	{
+		return;
+	}
+
+	const u32 start_pc = m_pc - m_item_count * 4;
+	const u32 pc = start_pc + i * 4;
+
+	if (event->key() == Qt::Key_Space && QApplication::keyboardModifiers() & Qt::ControlModifier)
+	{
+		Q_EMIT RequestCPUStep();
+		return;
+	}
+	else
+	{
+		switch (event->key())
+		{
+		case Qt::Key_PageUp:   ShowAddr(m_pc - (m_item_count * 2) * 4); return;
+		case Qt::Key_PageDown: ShowAddr(m_pc); return;
+		case Qt::Key_Up:       ShowAddr(m_pc - (m_item_count + 1) * 4); return;
+		case Qt::Key_Down:     ShowAddr(m_pc - (m_item_count - 1) * 4); return;
+		case Qt::Key_E:
+		{
+			instruction_editor_dialog* dlg = new instruction_editor_dialog(this, pc, cpu, m_disasm.get());
+			dlg->show();
+			return;
+		}
+		case Qt::Key_R:
+		{
+			register_editor_dialog* dlg = new register_editor_dialog(this, pc, cpu, m_disasm.get());
+			dlg->show();
+			return;
+		}
+		}
+	}
+}
+
+void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
+{
+	if (event->button() == Qt::LeftButton && !Emu.IsStopped() && !m_no_thread_selected)
+	{
+		long i = currentRow();
+		if (i < 0) return;
+
+		const u32 start_pc = m_pc - m_item_count * 4;
+		const u32 pc = start_pc + i * 4;
+		//ConLog.Write("pc=0x%llx", pc);
+
+		// Let debugger_frame know about breakpoint.
+		Q_EMIT BreakpointRequested(pc);
+
+		ShowAddr(start_pc);
+	}
+}
+
+void debugger_list::wheelEvent(QWheelEvent* event)
+{
+	QPoint numSteps = event->angleDelta() / 8 / 15;	// http://doc.qt.io/qt-5/qwheelevent.html#pixelDelta
+	const int value = numSteps.y();
+
+	ShowAddr(m_pc - (event->modifiers() == Qt::ControlModifier ? m_item_count * (value + 1) : m_item_count + value) * 4);
+}
+
+void debugger_list::resizeEvent(QResizeEvent* event)
+{
+	Q_UNUSED(event);
+
+	if (count() < 1 || visualItemRect(item(0)).height() < 1)
+	{
+		return;
+	}
+
+	m_item_count = (rect().height() - frameWidth() * 2) / visualItemRect(item(0)).height();
+
+	clear();
+
+	for (u32 i = 0; i < m_item_count; ++i)
+	{
+		insertItem(i, new QListWidgetItem(""));
+	}
+
+	if (horizontalScrollBar())
+	{
+		m_item_count--;
+		delete item(m_item_count);
+	}
+
+	ShowAddr(m_pc - m_item_count * 4);
+}

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "breakpoint_handler.h"
+
+#include "Emu/CPU/CPUThread.h"
+#include "Emu/CPU/CPUDisAsm.h"
+
+#include <QListWidget>
+
+class debugger_list : public QListWidget
+{
+	Q_OBJECT
+
+public:
+	u32 m_pc;
+	u32 m_item_count;
+	bool m_no_thread_selected;
+	QColor m_color_bp;
+	QColor m_color_pc;
+	QColor m_text_color_bp;
+	QColor m_text_color_pc;
+
+Q_SIGNALS:
+	void BreakpointRequested(u32 loc);
+	void RequestCPUStep();
+public:
+	debugger_list(QWidget* parent, breakpoint_handler* handler);
+	void ShowAddr(u32 addr);
+	void UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_ptr<CPUDisAsm> disasm);
+protected:
+	void keyPressEvent(QKeyEvent* event);
+	void mouseDoubleClickEvent(QMouseEvent* event);
+	void wheelEvent(QWheelEvent* event);
+	void resizeEvent(QResizeEvent* event);
+private:
+	/**
+	* It really upsetted me I had to copy this code to make debugger_list/frame not circularly dependent.
+	*/
+	u32 GetPc() const;
+
+	breakpoint_handler* m_brkpoint_handler;
+	std::weak_ptr<cpu_thread> cpu;
+	std::shared_ptr<CPUDisAsm> m_disasm;
+};


### PR DESCRIPTION
Some refactoring to debugger.

1) Split into THREE classes.  Debugger list, debugger frame, and stuff to handle breakpoints.
2) Made debugger list/frame independent.  They no longer are strongly connected.
3) Declare variables the way I prefer lul.
4) Change the hideous break_Point method names.

The code itself is basically the same.  It just got reorganized, a lot, that's all.

~~Seriously. Already a merge conflict?  I updated to master this morning~~

MIght merge in tge's improvements. Might close this and do this later.