### PR TITLE
Fix raw spu interrupt thread overflowing

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -575,6 +575,11 @@ void ppu_thread::cpu_task()
 			cmd_pop(), lv2_obj::sleep(*this);
 			break;
 		}
+		case ppu_cmd::reset_stack:
+		{
+			cmd_pop(), gpr[1] = ::align(stack_addr + stack_size, 0x200) - 0x200;
+			break;
+		}
 		default:
 		{
 			fmt::throw_exception("Unknown ppu_cmd(0x%x)" HERE, (u32)type);

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -16,6 +16,7 @@ enum class ppu_cmd : u32
 	hle_call, // Execute function by index (arg)
 	initialize, // ppu_initialize()
 	sleep,
+	reset_stack, // resets stack address
 };
 
 // Formatting helper

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -16,6 +16,7 @@ void lv2_int_serv::exec()
 {
 	thread->cmd_list
 	({
+		{ ppu_cmd::reset_stack, 0 },
 		{ ppu_cmd::set_args, 2 }, arg1, arg2,
 		{ ppu_cmd::lle_call, 2 },
 		{ ppu_cmd::sleep, 0 }


### PR DESCRIPTION
The stack wasn't getting reset between interrupt calls with raw spu's, leading to a stack overflow in some cases. Fixes vancouver booting, now gets to at least main menu

Test is here for those curious https://github.com/jarveson/rpcs3elfs/tree/master/raw_spu_test/stack_addr 

I added the reset as a 'ppu_cmd' as it seems like a kinda one-off, I didn't see any other places the stack should also be reset