### PR TITLE
rsx: Fix alpha test on VK/GL

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -348,6 +348,26 @@ void GLFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 		}
 	}
 
+	OS << "}\n\n";
+
+	OS << "void main()\n";
+	OS << "{\n";
+
+	std::string parameters = "";
+	for (auto &reg_name : output_values)
+	{
+		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", reg_name))
+		{
+			if (parameters.length())
+				parameters += ", ";
+
+			parameters += reg_name;
+			OS << "	vec4 " << reg_name << " = vec4(0.);\n";
+		}
+	}
+
+	OS << "\n" << "	fs_main(" + parameters + ");\n\n";
+
 	if (!first_output_name.empty())
 	{
 		auto make_comparison_test = [](rsx::comparison_function compare_func, const std::string &test, const std::string &a, const std::string &b) -> std::string
@@ -381,28 +401,8 @@ void GLFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 			}
 		}
 
-		OS << "	if (alpha_test != 0 && !comparison_passes(" << first_output_name << ".a, alpha_ref, alpha_func)) discard;\n";
+		OS << "	if (alpha_test != 0 && !comparison_passes(" << first_output_name << ".a, alpha_ref, alpha_func)) discard;\n\n";
 	}
-
-	OS << "}\n\n";
-
-	OS << "void main()\n";
-	OS << "{\n";
-
-	std::string parameters = "";
-	for (auto &reg_name : output_values)
-	{
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", reg_name))
-		{
-			if (parameters.length())
-				parameters += ", ";
-
-			parameters += reg_name;
-			OS << "	vec4 " << reg_name << " = vec4(0.);\n";
-		}
-	}
-
-	OS << "\n" << "	fs_main(" + parameters + ");\n\n";
 
 	//Append the color output assignments
 	OS << color_output_block;

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -340,6 +340,26 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 		}
 	}
 
+	OS << "}\n\n";
+
+	OS << "void main()\n";
+	OS << "{\n";
+
+	std::string parameters = "";
+	for (auto &reg_name : output_values)
+	{
+		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", reg_name))
+		{
+			if (parameters.length())
+				parameters += ", ";
+
+			parameters += reg_name;
+			OS << "	vec4 " << reg_name << " = vec4(0.);\n";
+		}
+	}
+
+	OS << "\n" << "	fs_main(" + parameters + ");\n\n";
+
 	if (!first_output_name.empty())
 	{
 		auto make_comparison_test = [](rsx::comparison_function compare_func, const std::string &test, const std::string &a, const std::string &b) -> std::string
@@ -373,28 +393,8 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 			}
 		}
 
-		OS << "	if (alpha_test != 0 && !comparison_passes(" << first_output_name << ".a, alpha_ref, alpha_func)) discard;\n";
+		OS << "	if (alpha_test != 0 && !comparison_passes(" << first_output_name << ".a, alpha_ref, alpha_func)) discard;\n\n";
 	}
-
-	OS << "}\n\n";
-
-	OS << "void main()\n";
-	OS << "{\n";
-
-	std::string parameters = "";
-	for (auto &reg_name : output_values)
-	{
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", reg_name))
-		{
-			if (parameters.length())
-				parameters += ", ";
-
-			parameters += reg_name;
-			OS << "	vec4 " << reg_name << " = vec4(0.);\n";
-		}
-	}
-
-	OS << "\n" << "	fs_main(" + parameters + ");\n\n";
 
 	//Append the color output assignments
 	OS << color_output_block;


### PR DESCRIPTION
Moving alpha test outside of fp_main. 
This enforces alpha test is still done even if shader asm has early return

Fixes kh2 timeless river world transparency