### PR TITLE
rsx/Qt: add option to hide shader compilation hints + add option to hide game list entries + misc

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1061,15 +1061,18 @@ void GLGSRender::load_program(const gl::vertex_upload_info& upload_info)
 		m_shaders_cache->store(pipeline_properties, vertex_program, fragment_program);
 
 		//Notify the user with HUD notification
-		if (!m_custom_ui)
+		if (g_cfg.misc.show_shader_compilation_hint)
 		{
-			//Create notification but do not draw it at this time. No need to spam flip requests
-			m_custom_ui = std::make_unique<rsx::overlays::shader_compile_notification>();
-		}
-		else if (auto casted = dynamic_cast<rsx::overlays::shader_compile_notification*>(m_custom_ui.get()))
-		{
-			//Probe the notification
-			casted->touch();
+			if (!m_custom_ui)
+			{
+				//Create notification but do not draw it at this time. No need to spam flip requests
+				m_custom_ui = std::make_unique<rsx::overlays::shader_compile_notification>();
+			}
+			else if (auto casted = dynamic_cast<rsx::overlays::shader_compile_notification*>(m_custom_ui.get()))
+			{
+				//Probe the notification
+				casted->touch();
+			}
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2303,15 +2303,18 @@ void VKGSRender::load_program(const vk::vertex_upload_info& vertex_info)
 		m_shaders_cache->store(properties, vertex_program, fragment_program);
 
 		//Notify the user with HUD notification
-		if (!m_custom_ui)
+		if (g_cfg.misc.show_shader_compilation_hint)
 		{
-			//Create notification but do not draw it at this time. No need to spam flip requests
-			m_custom_ui = std::make_unique<rsx::overlays::shader_compile_notification>();
-		}
-		else if (auto casted = dynamic_cast<rsx::overlays::shader_compile_notification*>(m_custom_ui.get()))
-		{
-			//Probe the notification
-			casted->touch();
+			if (!m_custom_ui)
+			{
+				//Create notification but do not draw it at this time. No need to spam flip requests
+				m_custom_ui = std::make_unique<rsx::overlays::shader_compile_notification>();
+			}
+			else if (auto casted = dynamic_cast<rsx::overlays::shader_compile_notification*>(m_custom_ui.get()))
+			{
+				//Probe the notification
+				casted->touch();
+			}
 		}
 	}
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -433,6 +433,7 @@ struct cfg_root : cfg::node
 		cfg::_bool start_fullscreen{ this, "Start games in fullscreen mode" };
 		cfg::_bool show_fps_in_title{ this, "Show FPS counter in window title", true};
 		cfg::_bool show_trophy_popups{ this, "Show trophy popups", true};
+		cfg::_bool show_shader_compilation_hint{ this, "Show shader compilation hint", true };
 		cfg::_bool use_native_interface{ this, "Use native user interface", true };
 		cfg::_int<1, 65535> gdb_server_port{this, "Port", 2345};
 

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -65,6 +65,7 @@
 			"showTrophyPopups": "Show trophy popups when a trophy is unlocked.",
 			"gs_disableMouse": "Disables the activation of fullscreen mode per doubleclick while the game screen is active.\nCheck this if you want to play with mouse and keyboard (for example with UCR).",
 			"maxLLVMThreads": "Limits the maximum number of threads used for PPU Module compilation.\nLower this in order to increase performance of other open applications.\nThe default uses all available threads.",
+			"showShaderCompilationHint": "Show shader compilation hints using the native overlay.",
 			"useNativeInterface": "Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, only the English language is supported."
 		}
 	},

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -392,7 +392,14 @@
     <ClInclude Include="define_new_memleakdetect.h" />
     <ClInclude Include="Emu\Cell\lv2\sys_gpio.h" />
     <ClInclude Include="Emu\Cell\lv2\sys_net.h" />
+    <ClInclude Include="Emu\Cell\Modules\cellCelp8Enc.h" />
+    <ClInclude Include="Emu\Cell\Modules\cellCelpEnc.h" />
+    <ClInclude Include="Emu\Cell\Modules\cellDaisy.h" />
+    <ClInclude Include="Emu\Cell\Modules\cellHttp.h" />
+    <ClInclude Include="Emu\Cell\Modules\cellHttpUtil.h" />
+    <ClInclude Include="Emu\Cell\Modules\cellJpgEnc.h" />
     <ClInclude Include="Emu\Cell\Modules\cellOskDialog.h" />
+    <ClInclude Include="Emu\Cell\Modules\cellVoice.h" />
     <ClInclude Include="Emu\Cell\PPUAnalyser.h" />
     <ClInclude Include="Emu\Cell\PPUTranslator.h" />
     <ClInclude Include="Emu\CPU\CPUTranslator.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1414,5 +1414,26 @@
     <ClInclude Include="Emu\Cell\lv2\sys_gpio.h">
       <Filter>Emu\Cell\lv2</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\Cell\Modules\cellVoice.h">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Cell\Modules\cellCelp8Enc.h">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Cell\Modules\cellCelpEnc.h">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Cell\Modules\cellDaisy.h">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Cell\Modules\cellHttp.h">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Cell\Modules\cellHttpUtil.h">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\Cell\Modules\cellJpgEnc.h">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1,4 +1,5 @@
 #include "debugger_frame.h"
+#include "qt_utils.h"
 
 #include <QScrollBar>
 #include <QApplication>
@@ -155,10 +156,10 @@ void debugger_frame::ChangeColors()
 {
 	if (m_list)
 	{
-		m_list->m_color_bp = gui::get_Label_Color("debugger_frame_breakpoint", QPalette::Background);
-		m_list->m_color_pc = gui::get_Label_Color("debugger_frame_pc", QPalette::Background);
-		m_list->m_text_color_bp = gui::get_Label_Color("debugger_frame_breakpoint");;
-		m_list->m_text_color_pc = gui::get_Label_Color("debugger_frame_pc");;
+		m_list->m_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint", QPalette::Background);
+		m_list->m_color_pc = gui::utils::get_label_color("debugger_frame_pc", QPalette::Background);
+		m_list->m_text_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint");;
+		m_list->m_text_color_pc = gui::utils::get_label_color("debugger_frame_pc");;
 	}
 }
 

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -88,6 +88,7 @@ public:
 		ShowTrophyPopups,
 		ShowWelcomeScreen,
 		UseNativeInterface,
+		ShowShaderCompilationHint,
 
 		// Network
 		ConnectionStatus,
@@ -240,20 +241,21 @@ private:
 		{ Move,            { "Input/Output", "Move" }},
 
 		// Misc
-		{ExitRPCS3OnFinish,   { "Miscellaneous", "Exit RPCS3 when process finishes" }},
-		{StartOnBoot,         { "Miscellaneous", "Automatically start games after boot" }},
-		{StartGameFullscreen, { "Miscellaneous", "Start games in fullscreen mode"}},
-		{ShowFPSInTitle,      { "Miscellaneous", "Show FPS counter in window title"}},
-		{ShowTrophyPopups,    { "Miscellaneous", "Show trophy popups"}},
-		{ShowWelcomeScreen,   { "Miscellaneous", "Show Welcome Screen"}},
-		{UseNativeInterface,  { "Miscellaneous", "Use native user interface"}},
+		{ ExitRPCS3OnFinish,         { "Miscellaneous", "Exit RPCS3 when process finishes" }},
+		{ StartOnBoot,               { "Miscellaneous", "Automatically start games after boot" }},
+		{ StartGameFullscreen,       { "Miscellaneous", "Start games in fullscreen mode"}},
+		{ ShowFPSInTitle,            { "Miscellaneous", "Show FPS counter in window title"}},
+		{ ShowTrophyPopups,          { "Miscellaneous", "Show trophy popups"}},
+		{ ShowWelcomeScreen,         { "Miscellaneous", "Show Welcome Screen"}},
+		{ UseNativeInterface,        { "Miscellaneous", "Use native user interface"}},
+		{ ShowShaderCompilationHint, { "Miscellaneous", "Show shader compilation hint"}},
 
 		// Networking
-		{ConnectionStatus, { "Net", "Connection status"}},
+		{ ConnectionStatus, { "Net", "Connection status"}},
 
 		// System
-		{Language,       { "System", "Language"}},
-		{EnableHostRoot, { "VFS", "Enable /host_root/"}},
+		{ Language,       { "System", "Language"}},
+		{ EnableHostRoot, { "VFS", "Enable /host_root/"}},
 
 		// Virtual File System
 		{ emulatorLocation,   { "VFS", "$(EmulatorDir)"}},

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -70,13 +70,13 @@ void game_compatibility::RequestCompatibility(bool online)
 			QJsonObject json_result = json_results[key].toObject();
 
 			// Retrieve compatibility information from json
-			Compat_Status compat_status = Status_Data.at(json_result.value("status").toString("NoResult"));
+			compat_status status = Status_Data.at(json_result.value("status").toString("NoResult"));
 
 			// Add date if possible
-			compat_status.date = json_result.value("date").toString();
+			status.date = json_result.value("date").toString();
 
 			// Add status to map
-			m_compat_database.emplace(std::pair<std::string, Compat_Status>(sstr(key), compat_status));
+			m_compat_database.emplace(std::pair<std::string, compat_status>(sstr(key), status));
 		}
 
 		return true;
@@ -220,7 +220,7 @@ void game_compatibility::RequestCompatibility(bool online)
 	Q_EMIT DownloadStarted();
 }
 
-Compat_Status game_compatibility::GetCompatibility(const std::string& title_id)
+compat_status game_compatibility::GetCompatibility(const std::string& title_id)
 {
 	if (m_compat_database.empty())
 	{
@@ -234,7 +234,7 @@ Compat_Status game_compatibility::GetCompatibility(const std::string& title_id)
 	return Status_Data.at("NoResult");
 }
 
-Compat_Status game_compatibility::GetStatusData(const QString& status)
+compat_status game_compatibility::GetStatusData(const QString& status)
 {
 	return Status_Data.at(status);
 }

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -1,5 +1,6 @@
 #include "game_compatibility.h"
 
+#include <QLabel>
 #include <QMessageBox>
 
 constexpr auto qstr = QString::fromStdString;

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -15,11 +15,20 @@
 
 #include "gui_settings.h"
 
+struct compat_status
+{
+	int index;
+	QString date;
+	QString color;
+	QString text;
+	QString tooltip;
+};
+
 class game_compatibility : public QObject
 {
 	Q_OBJECT
 
-	const std::map<QString, Compat_Status> Status_Data =
+	const std::map<QString, compat_status> Status_Data =
 	{
 		{ "Playable", { 0, "", "#1ebc61", QObject::tr("Playable"),         QObject::tr("Games that can be properly played from start to finish") } },
 		{ "Ingame",   { 1, "", "#f9b32f", QObject::tr("Ingame"),           QObject::tr("Games that either can't be finished, have serious glitches or have insufficient performance") } },
@@ -38,7 +47,7 @@ class game_compatibility : public QObject
 	std::unique_ptr<QTimer> m_progress_timer;
 	std::unique_ptr<QProgressDialog> m_progress_dialog;
 	std::unique_ptr<QNetworkAccessManager> m_network_access_manager;
-	std::map<std::string, Compat_Status> m_compat_database;
+	std::map<std::string, compat_status> m_compat_database;
 
 public:
 	/** Handles reads, writes and downloads for the compatibility database */
@@ -48,10 +57,10 @@ public:
 	void RequestCompatibility(bool online = false);
 
 	/** Returns the compatibility status for the requested title */
-	Compat_Status GetCompatibility(const std::string& title_id);
+	compat_status GetCompatibility(const std::string& title_id);
 
 	/** Returns the data for the requested status */
-	Compat_Status GetStatusData(const QString& status);
+	compat_status GetStatusData(const QString& status);
 
 Q_SIGNALS:
 	void DownloadStarted();

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -890,12 +890,9 @@ int game_list_frame::PopulateGameList()
 
 	auto l_GetItem = [](const std::string& text)
 	{
-		// force single line text ("hack" used instead of Qt shenanigans like Qt::TextSingleLine)
-		QString formattedText = gui::get_Single_Line(qstr(text));
-
 		QTableWidgetItem* curr = new QTableWidgetItem;
 		curr->setFlags(curr->flags() & ~Qt::ItemIsEditable);
-		curr->setText(formattedText);
+		curr->setText(qstr(text).simplified()); // simplified() forces single line text
 		return curr;
 	};
 
@@ -1008,7 +1005,7 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 
 	for (const auto& app : matching_apps)
 	{
-		QString title = gui::get_Single_Line(qstr(app.first->info.name));
+		const QString title = qstr(app.first->info.name).simplified(); // simplified() forces single line text
 
 		m_xgrid->addItem(app.first->pxmap, title, app.second, r, c);
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -397,7 +397,7 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 
 		auto op = [](const GUI_GameInfo& game1, const GUI_GameInfo& game2)
 		{
-			return game1.info.name < game2.info.name;
+			return qstr(game1.info.name).toLower() < qstr(game2.info.name).toLower();
 		};
 
 		// Sort by name at the very least.

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1,5 +1,5 @@
 #include "game_list_frame.h"
-
+#include "qt_utils.h"
 #include "settings_dialog.h"
 #include "table_item_delegate.h"
 #include "custom_table_widget_item.h"
@@ -790,7 +790,7 @@ void game_list_frame::RepaintIcons(const bool& fromSettings)
 		}
 		else
 		{
-			m_Icon_Color = gui::get_Label_Color("gamelist_icon_background_color");
+			m_Icon_Color = gui::utils::get_label_color("gamelist_icon_background_color");
 		}
 	}
 

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -13,6 +13,7 @@
 #include <QToolBar>
 #include <QLineEdit>
 #include <QStackedWidget>
+#include <QSet>
 
 #include <memory>
 
@@ -165,7 +166,6 @@ struct GUI_GameInfo
 	Compat_Status compat;
 	QImage icon;
 	QPixmap pxmap;
-	bool isVisible;
 	bool bootable;
 	bool hasCustomConfig;
 };
@@ -196,6 +196,8 @@ public:
 	/** Repaint Gamelist Icons with new background color */
 	void RepaintIcons(const bool& fromSettings = false);
 
+	void SetShowHidden(bool show);
+
 public Q_SLOTS:
 	void SetListMode(const bool& isList);
 	void SetSearchText(const QString& text);
@@ -220,7 +222,7 @@ protected:
 private:
 	QPixmap PaintedPixmap(const QImage& img, bool paintConfigIcon = false);
 	void PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color);
-	void FilterData();
+	bool IsEntryVisible(const GUI_GameInfo& game);
 	void SortGameList();
 
 	int PopulateGameList();
@@ -254,6 +256,8 @@ private:
 	std::shared_ptr<gui_settings> xgui_settings;
 	std::shared_ptr<emu_settings> xemu_settings;
 	std::vector<GUI_GameInfo> m_game_data;
+	QSet<QString> m_hidden_list;
+	bool m_show_hidden{false};
 
 	// Search
 	QString m_search_text;

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -163,7 +163,7 @@ namespace sound
 struct GUI_GameInfo
 {
 	GameInfo info;
-	Compat_Status compat;
+	compat_status compat;
 	QImage icon;
 	QPixmap pxmap;
 	bool bootable;

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -1,6 +1,6 @@
 #include "game_list_grid.h"
 #include "game_list_grid_delegate.h"
-#include "gui_settings.h"
+#include "qt_utils.h"
 
 #include <QHeaderView>
 #include <QLabel>
@@ -20,8 +20,8 @@ game_list_grid::game_list_grid(const QSize& icon_size, const QColor& icon_color,
 	}
 
 	// font by stylesheet
-	QFont font = gui::get_Label_Font("gamegrid_font");
-	QColor font_color = gui::get_Label_Color("gamegrid_font");
+	QFont font = gui::utils::get_label_font("gamegrid_font");
+	QColor font_color = gui::utils::get_label_color("gamegrid_font");
 
 	grid_item_delegate = new game_list_grid_delegate(item_size, m_margin_factor, m_text_factor, font, font_color, this);
 	setItemDelegate(grid_item_delegate);

--- a/rpcs3/rpcs3qt/gamepads_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/gamepads_settings_dialog.cpp
@@ -1,5 +1,7 @@
 #include "gamepads_settings_dialog.h"
 #include "pad_settings_dialog.h"
+#include "qt_utils.h"
+
 #include "../Emu/Io/PadHandler.h"
 #include "../ds4_pad_handler.h"
 #ifdef _WIN32
@@ -11,6 +13,7 @@
 #include "../keyboard_pad_handler.h"
 #include "../Emu/Io/Null/NullPadHandler.h"
 
+#include <QDir>
 #include <QJsonObject>
 #include <QJsonDocument>
 #include <QInputDialog>
@@ -368,7 +371,7 @@ void gamepads_settings_dialog::ChangeInputType(int player)
 	if (config_enabled)
 	{
 		QString s_profile_dir = qstr(PadHandlerBase::get_config_dir(cur_pad_handler->m_type));
-		QStringList profiles = gui_settings::GetDirEntries(QDir(s_profile_dir), QStringList() << "*.yml");
+		QStringList profiles = gui::utils::get_dir_entries(QDir(s_profile_dir), QStringList() << "*.yml");
 
 		if (profiles.isEmpty())
 		{

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -128,43 +128,45 @@ namespace gui
 	const gui_save rg_freeze  = gui_save(main_window, "recentGamesFrozen", false);
 	const gui_save rg_entries = gui_save(main_window, "recentGamesNames",  QVariant::fromValue(q_pair_list()));
 
-	const gui_save ib_pkg_success  = gui_save(main_window, "infoBoxEnabledInstallPKG", true );
-	const gui_save ib_pup_success  = gui_save(main_window, "infoBoxEnabledInstallPUP", true );
-	const gui_save ib_show_welcome = gui_save(main_window, "infoBoxEnabledWelcome",    true );
+	const gui_save ib_pkg_success  = gui_save(main_window, "infoBoxEnabledInstallPKG", true);
+	const gui_save ib_pup_success  = gui_save(main_window, "infoBoxEnabledInstallPUP", true);
+	const gui_save ib_show_welcome = gui_save(main_window, "infoBoxEnabledWelcome",    true);
 
-	const gui_save fd_install_pkg  = gui_save(main_window, "lastExplorePathPKG",  "" );
-	const gui_save fd_install_pup  = gui_save(main_window, "lastExplorePathPUP",  "" );
-	const gui_save fd_boot_elf     = gui_save(main_window, "lastExplorePathELF",  "" );
-	const gui_save fd_boot_game    = gui_save(main_window, "lastExplorePathGAME", "" );
-	const gui_save fd_decrypt_sprx = gui_save(main_window, "lastExplorePathSPRX", "" );
-	const gui_save fd_cg_disasm    = gui_save(main_window, "lastExplorePathCGD",  "" );
+	const gui_save fd_install_pkg  = gui_save(main_window, "lastExplorePathPKG",  "");
+	const gui_save fd_install_pup  = gui_save(main_window, "lastExplorePathPUP",  "");
+	const gui_save fd_boot_elf     = gui_save(main_window, "lastExplorePathELF",  "");
+	const gui_save fd_boot_game    = gui_save(main_window, "lastExplorePathGAME", "");
+	const gui_save fd_decrypt_sprx = gui_save(main_window, "lastExplorePathSPRX", "");
+	const gui_save fd_cg_disasm    = gui_save(main_window, "lastExplorePathCGD",  "");
 
-	const gui_save mw_debugger       = gui_save(main_window, "debuggerVisible", false );
-	const gui_save mw_logger         = gui_save(main_window, "loggerVisible",   true );
-	const gui_save mw_gamelist       = gui_save(main_window, "gamelistVisible", true );
-	const gui_save mw_toolBarVisible = gui_save(main_window, "toolBarVisible",  true );
+	const gui_save mw_debugger       = gui_save(main_window, "debuggerVisible", false);
+	const gui_save mw_logger         = gui_save(main_window, "loggerVisible",   true);
+	const gui_save mw_gamelist       = gui_save(main_window, "gamelistVisible", true);
+	const gui_save mw_toolBarVisible = gui_save(main_window, "toolBarVisible",  true);
 	const gui_save mw_toolBarColor   = gui_save(main_window, "toolBarColor",    mw_tool_bar_color);
 	const gui_save mw_toolIconColor  = gui_save(main_window, "toolIconColor",   mw_tool_icon_color);
-	const gui_save mw_geometry       = gui_save(main_window, "geometry",        QByteArray() );
-	const gui_save mw_windowState    = gui_save(main_window, "windowState",     QByteArray() );
-	const gui_save mw_mwState        = gui_save(main_window, "wwState",         QByteArray() );
+	const gui_save mw_geometry       = gui_save(main_window, "geometry",        QByteArray());
+	const gui_save mw_windowState    = gui_save(main_window, "windowState",     QByteArray());
+	const gui_save mw_mwState        = gui_save(main_window, "wwState",         QByteArray());
 
-	const gui_save cat_hdd_game    = gui_save(game_list, "categoryVisibleHDDGame",    true );
-	const gui_save cat_disc_game   = gui_save(game_list, "categoryVisibleDiscGame",   true );
-	const gui_save cat_home        = gui_save(game_list, "categoryVisibleHome",       true );
-	const gui_save cat_audio_video = gui_save(game_list, "categoryVisibleAudioVideo", true );
-	const gui_save cat_game_data   = gui_save(game_list, "categoryVisibleGameData",   false );
-	const gui_save cat_unknown     = gui_save(game_list, "categoryVisibleUnknown",    true );
-	const gui_save cat_other       = gui_save(game_list, "categoryVisibleOther",      true );
+	const gui_save cat_hdd_game    = gui_save(game_list, "categoryVisibleHDDGame",    true);
+	const gui_save cat_disc_game   = gui_save(game_list, "categoryVisibleDiscGame",   true);
+	const gui_save cat_home        = gui_save(game_list, "categoryVisibleHome",       true);
+	const gui_save cat_audio_video = gui_save(game_list, "categoryVisibleAudioVideo", true);
+	const gui_save cat_game_data   = gui_save(game_list, "categoryVisibleGameData",   false);
+	const gui_save cat_unknown     = gui_save(game_list, "categoryVisibleUnknown",    true);
+	const gui_save cat_other       = gui_save(game_list, "categoryVisibleOther",      true);
 
-	const gui_save gl_sortAsc       = gui_save(game_list, "sortAsc",       true );
-	const gui_save gl_sortCol       = gui_save(game_list, "sortCol",       1 );
-	const gui_save gl_state         = gui_save(game_list, "state",         QByteArray() );
-	const gui_save gl_iconSize      = gui_save(game_list, "iconSize",      get_Index(gl_icon_size_small));
-	const gui_save gl_iconColor     = gui_save(game_list, "iconColor",     gl_icon_color);
-	const gui_save gl_listMode      = gui_save(game_list, "listMode",      true );
-	const gui_save gl_textFactor    = gui_save(game_list, "textFactor",    (qreal) 2.0 );
-	const gui_save gl_marginFactor  = gui_save(game_list, "marginFactor",  (qreal) 0.09 );
+	const gui_save gl_sortAsc      = gui_save(game_list, "sortAsc",      true);
+	const gui_save gl_sortCol      = gui_save(game_list, "sortCol",      1);
+	const gui_save gl_state        = gui_save(game_list, "state",        QByteArray());
+	const gui_save gl_iconSize     = gui_save(game_list, "iconSize",     get_Index(gl_icon_size_small));
+	const gui_save gl_iconColor    = gui_save(game_list, "iconColor",    gl_icon_color);
+	const gui_save gl_listMode     = gui_save(game_list, "listMode",     true);
+	const gui_save gl_textFactor   = gui_save(game_list, "textFactor",   (qreal) 2.0);
+	const gui_save gl_marginFactor = gui_save(game_list, "marginFactor", (qreal) 0.09);
+	const gui_save gl_show_hidden  = gui_save(game_list, "show_hidden",  false);
+	const gui_save gl_hidden_list  = gui_save(game_list, "hidden_list",  QStringList());
 
 	const gui_save fs_emulator_dir_list = gui_save(fs, "emulator_dir_list", QStringList());
 	const gui_save fs_dev_hdd0_list     = gui_save(fs, "dev_hdd0_list",     QStringList());
@@ -172,12 +174,12 @@ namespace gui
 	const gui_save fs_dev_flash_list    = gui_save(fs, "dev_flash_list",    QStringList());
 	const gui_save fs_dev_usb000_list   = gui_save(fs, "dev_usb000_list",   QStringList());
 
-	const gui_save l_tty   = gui_save(logger, "TTY",   true );
-	const gui_save l_level = gui_save(logger, "level", (uint)(logs::level::success) );
-	const gui_save l_stack = gui_save(logger, "stack", true );
+	const gui_save l_tty   = gui_save(logger, "TTY",   true);
+	const gui_save l_level = gui_save(logger, "level", (uint)(logs::level::success));
+	const gui_save l_stack = gui_save(logger, "stack", true);
 
 	const gui_save d_splitterState = gui_save(debugger, "splitterState", QByteArray());
-	const gui_save d_centerPC = gui_save(debugger, "centerPC", false);
+	const gui_save d_centerPC      = gui_save(debugger, "centerPC",      false);
 
 	const gui_save m_currentConfig     = gui_save(meta, "currentConfig",     QObject::tr("CurrentSettings"));
 	const gui_save m_currentStylesheet = gui_save(meta, "currentStylesheet", Default);

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -70,16 +70,9 @@ namespace gui
 		return gl_max_slider_pos * current_delta / size_delta;
 	};
 
-	inline QString get_Single_Line(const QString& multi_line_string)
-	{
-		QString single_line_string = multi_line_string;
-		single_line_string.replace("\n"," ");
-		return single_line_string;
-	}
-
 	inline q_string_pair Recent_Game(const QString& path, const QString& title)
 	{
-		return q_string_pair(path, get_Single_Line(title));
+		return q_string_pair(path, title.simplified()); // simplified() forces single line text
 	}
 
 	const QString Default     = QObject::tr("default");

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -10,15 +10,6 @@
 #include <QBitmap>
 #include <QLabel>
 
-struct Compat_Status
-{
-	int index;
-	QString date;
-	QString color;
-	QString text;
-	QString tooltip;
-};
-
 struct gui_save
 {
 	QString key;

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -7,8 +7,6 @@
 #include <QVariant>
 #include <QSize>
 #include <QColor>
-#include <QBitmap>
-#include <QLabel>
 
 struct gui_save
 {
@@ -70,22 +68,6 @@ namespace gui
 		int size_delta = gl_icon_size_max.width() - gl_icon_size_min.width();
 		int current_delta = current.width() - gl_icon_size_min.width();
 		return gl_max_slider_pos * current_delta / size_delta;
-	};
-
-	inline QColor get_Label_Color(const QString& objectName, QPalette::ColorRole colorRole = QPalette::Foreground)
-	{
-		QLabel dummy_color;
-		dummy_color.setObjectName(objectName);
-		dummy_color.ensurePolished();
-		return dummy_color.palette().color(colorRole);
-	};
-
-	inline QFont get_Label_Font(const QString& objectName)
-	{
-		QLabel dummy_font;
-		dummy_font.setObjectName(objectName);
-		dummy_font.ensurePolished();
-		return dummy_font.font();
 	};
 
 	inline QString get_Single_Line(const QString& multi_line_string)
@@ -222,21 +204,9 @@ public:
 	bool GetGamelistColVisibility(int col);
 	QColor GetCustomColor(int col);
 	QStringList GetConfigEntries();
-	static QStringList GetDirEntries(const QDir& dir, const QStringList& nameFilters);
 	QString GetCurrentStylesheetPath();
 	QStringList GetStylesheetEntries();
 	QStringList GetGameListCategoryFilters();
-
-	/**
-		Creates a custom colored QIcon based on another QIcon
-		@param icon the icon to colorize
-		@param oldColor the current color of icon
-		@param newColor the desired color for the new icon
-		@param useSpecialMasks only used for icons with white parts and disc game icon
-	*/
-	static QIcon colorizedIcon(const QIcon& icon, const QColor& oldColor, const QColor& newColor, bool useSpecialMasks = false, bool colorizeAll = false);
-	static QPixmap colorizedPixmap(const QPixmap& old_pixmap, const QColor& oldColor, const QColor& newColor, bool useSpecialMasks = false, bool colorizeAll = false);
-	static QImage GetOpaqueImageArea(const QString& path);
 
 public Q_SLOTS:
 	void Reset(bool removeMeta = false);

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -1,4 +1,5 @@
 #include "log_frame.h"
+#include "qt_utils.h"
 
 #include "stdafx.h"
 #include "rpcs3_version.h"
@@ -267,7 +268,7 @@ void log_frame::CreateAndConnectActions()
 		menu->exec(mapToGlobal(pos));
 	});
 
-	connect(m_tabWidget, &QTabWidget::currentChanged, [this](int index)
+	connect(m_tabWidget, &QTabWidget::currentChanged, [this](int/* index*/)
 	{
 		if (m_find_dialog)
 			m_find_dialog->close();
@@ -289,18 +290,18 @@ void log_frame::RepaintTextColors()
 {
 	// Get text color. Do this once to prevent possible slowdown
 	m_color.clear();
-	m_color.append(gui::get_Label_Color("log_level_always"));
-	m_color.append(gui::get_Label_Color("log_level_fatal"));
-	m_color.append(gui::get_Label_Color("log_level_error"));
-	m_color.append(gui::get_Label_Color("log_level_todo"));
-	m_color.append(gui::get_Label_Color("log_level_success"));
-	m_color.append(gui::get_Label_Color("log_level_warning"));
-	m_color.append(gui::get_Label_Color("log_level_notice"));
-	m_color.append(gui::get_Label_Color("log_level_trace"));
+	m_color.append(gui::utils::get_label_color("log_level_always"));
+	m_color.append(gui::utils::get_label_color("log_level_fatal"));
+	m_color.append(gui::utils::get_label_color("log_level_error"));
+	m_color.append(gui::utils::get_label_color("log_level_todo"));
+	m_color.append(gui::utils::get_label_color("log_level_success"));
+	m_color.append(gui::utils::get_label_color("log_level_warning"));
+	m_color.append(gui::utils::get_label_color("log_level_notice"));
+	m_color.append(gui::utils::get_label_color("log_level_trace"));
 
-	m_color_stack = gui::get_Label_Color("log_stack");
+	m_color_stack = gui::utils::get_label_color("log_stack");
 
-	m_tty->setTextColor(gui::get_Label_Color("tty_text"));
+	m_tty->setTextColor(gui::utils::get_label_color("tty_text"));
 }
 
 void log_frame::UpdateUI()

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -8,6 +8,7 @@
 #include <QDesktopWidget>
 #include <QMimeData>
 
+#include "qt_utils.h"
 #include "vfs_dialog.h"
 #include "save_manager_dialog.h"
 #include "trophy_manager_dialog.h"
@@ -604,11 +605,11 @@ void main_window::SaveWindowState()
 
 void main_window::RepaintThumbnailIcons()
 {
-	QColor newColor = gui::get_Label_Color("thumbnail_icon_color");
+	QColor newColor = gui::utils::get_label_color("thumbnail_icon_color");
 
 	auto icon = [&newColor](const QString& path)
 	{
-		return gui_settings::colorizedIcon(QPixmap::fromImage(gui_settings::GetOpaqueImageArea(path)), gui::mw_tool_icon_color, newColor);
+		return gui::utils::get_colorized_icon(QPixmap::fromImage(gui::utils::get_opaque_image_area(path)), gui::mw_tool_icon_color, newColor);
 	};
 
 #ifdef _WIN32
@@ -635,12 +636,12 @@ void main_window::RepaintToolBarIcons()
 	}
 	else
 	{
-		newColor = gui::get_Label_Color("toolbar_icon_color");
+		newColor = gui::utils::get_label_color("toolbar_icon_color");
 	}
 
 	auto icon = [&newColor](const QString& path)
 	{
-		return gui_settings::colorizedIcon(QIcon(path), gui::mw_tool_icon_color, newColor);
+		return gui::utils::get_colorized_icon(QIcon(path), gui::mw_tool_icon_color, newColor);
 	};
 
 	m_icon_play           = icon(":/Icons/play.png");

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1186,6 +1186,13 @@ void main_window::CreateConnects()
 		guiSettings->SetValue(gui::mw_toolBarVisible, checked);
 	});
 
+	connect(ui->showHiddenEntriesAct, &QAction::triggered, [=](bool checked)
+	{
+		guiSettings->SetValue(gui::gl_show_hidden, checked);
+		m_gameListFrame->SetShowHidden(checked);
+		m_gameListFrame->Refresh();
+	});
+
 	connect(ui->refreshGameListAct, &QAction::triggered, [=]
 	{
 		m_gameListFrame->Refresh(true);
@@ -1410,6 +1417,9 @@ void main_window::ConfigureGuiFromSettings(bool configure_all)
 	ui->toolBar->setVisible(ui->showToolBarAct->isChecked());
 
 	RepaintToolbar();
+
+	ui->showHiddenEntriesAct->setChecked(guiSettings->GetValue(gui::gl_show_hidden).toBool());
+	m_gameListFrame->SetShowHidden(ui->showHiddenEntriesAct->isChecked()); // prevent GetValue in m_gameListFrame->LoadSettings
 
 	ui->showCatHDDGameAct->setChecked(guiSettings->GetCategoryVisibility(Category::Non_Disc_Game));
 	ui->showCatDiscGameAct->setChecked(guiSettings->GetCategoryVisibility(Category::Disc_Game));

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -141,7 +141,7 @@
      <x>0</x>
      <y>0</y>
      <width>1058</width>
-     <height>38</height>
+     <height>26</height>
     </rect>
    </property>
    <property name="contextMenuPolicy">
@@ -260,6 +260,8 @@
     <addaction name="showToolBarAct"/>
     <addaction name="separator"/>
     <addaction name="showGameListAct"/>
+    <addaction name="separator"/>
+    <addaction name="showHiddenEntriesAct"/>
     <addaction name="separator"/>
     <addaction name="refreshGameListAct"/>
     <addaction name="menuGame_List_Mode"/>
@@ -939,6 +941,14 @@
    </property>
    <property name="text">
     <string>Show Game Tool Bar</string>
+   </property>
+  </action>
+  <action name="showHiddenEntriesAct">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Hidden Entries</string>
    </property>
   </action>
  </widget>

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -7,6 +7,7 @@
 #include <QAction>
 #include <QPainter>
 
+#include "qt_utils.h"
 #include "pad_settings_dialog.h"
 #include "ui_pad_settings_dialog.h"
 
@@ -281,10 +282,8 @@ pad_settings_dialog::pad_settings_dialog(const std::string& device, const std::s
 
 	UpdateLabel();
 
-	gui_settings settings(this);
-
 	// repaint and resize controller image
-	ui->l_controller->setPixmap(settings.colorizedPixmap(*ui->l_controller->pixmap(), QColor(), gui::get_Label_Color("l_controller"), false, true));
+	ui->l_controller->setPixmap(gui::utils::get_colorized_pixmap(*ui->l_controller->pixmap(), QColor(), gui::utils::get_label_color("l_controller"), false, true));
 	ui->l_controller->setMaximumSize(ui->gb_description->sizeHint().width(), ui->l_controller->maximumHeight() * ui->gb_description->sizeHint().width() / ui->l_controller->maximumWidth());
 
 	layout()->setSizeConstraint(QLayout::SetFixedSize);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <QButtonGroup>
 #include <QDialog>
 #include <QEvent>
 #include <QKeyEvent>
+#include <QLabel>
 #include <QTimer>
-#include <QButtonGroup>
 
 #include "keyboard_pad_handler.h"
 #include "Utilities/types.h"
@@ -12,7 +13,6 @@
 #include "Emu/Io/PadHandler.h"
 #include "stdafx.h"
 #include "Emu/System.h"
-#include "gui_settings.h"
 
 #ifdef _WIN32
 #include "xinput_pad_handler.h"

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -1,6 +1,8 @@
 
 #include "qt_utils.h"
 #include <QApplication>
+#include <QBitmap>
+#include <QPainter>
 #include <QScreen>
 
 namespace gui
@@ -32,6 +34,126 @@ namespace gui
 			s32 frame_y = std::clamp(frame_y_raw, min_screen_y, max_screen_y);
 
 			return QRect(frame_x, frame_y, width, height);
+		}
+
+		QPixmap get_colorized_pixmap(const QPixmap& old_pixmap, const QColor& old_color, const QColor& new_color, bool use_special_masks, bool colorize_all)
+		{
+			QPixmap pixmap = old_pixmap;
+
+			if (colorize_all)
+			{
+				QBitmap mask = pixmap.createMaskFromColor(Qt::transparent, Qt::MaskInColor);
+				pixmap.fill(new_color);
+				pixmap.setMask(mask);
+				return pixmap;
+			}
+
+			QBitmap mask = pixmap.createMaskFromColor(old_color, Qt::MaskOutColor);
+			pixmap.fill(new_color);
+			pixmap.setMask(mask);
+
+			// special masks for disc icon and others
+			if (use_special_masks)
+			{
+				// Example usage for an icon with multiple shades of the same color
+
+				//auto saturatedColor = [](const QColor& col, float sat /* must be < 1 */)
+				//{
+				//	int r = col.red() + sat * (255 - col.red());
+				//	int g = col.green() + sat * (255 - col.green());
+				//	int b = col.blue() + sat * (255 - col.blue());
+				//	return QColor(r, g, b, col.alpha());
+				//};
+
+				//QColor test_color(0, 173, 246, 255);
+				//QPixmap test_pixmap = old_pixmap;
+				//QBitmap test_mask = test_pixmap.createMaskFromColor(test_color, Qt::MaskOutColor);
+				//test_pixmap.fill(saturatedColor(new_color, 0.6f));
+				//test_pixmap.setMask(test_mask);
+
+				QColor white_color(Qt::white);
+				QPixmap white_pixmap = old_pixmap;
+				QBitmap white_mask = white_pixmap.createMaskFromColor(white_color, Qt::MaskOutColor);
+				white_pixmap.fill(white_color);
+				white_pixmap.setMask(white_mask);
+
+				QPainter painter(&pixmap);
+				painter.drawPixmap(QPoint(0, 0), white_pixmap);
+				//painter.drawPixmap(QPoint(0, 0), test_pixmap);
+				painter.end();
+			}
+			return pixmap;
+		}
+
+		QIcon get_colorized_icon(const QIcon& old_icon, const QColor& old_color, const QColor& new_color, bool use_special_masks, bool colorize_all)
+		{
+			return QIcon(get_colorized_pixmap(old_icon.pixmap(old_icon.availableSizes().at(0)), old_color, new_color, use_special_masks, colorize_all));
+		}
+
+		QStringList get_dir_entries(const QDir& dir, const QStringList& name_filters)
+		{
+			QFileInfoList entries = dir.entryInfoList(name_filters, QDir::Files);
+			QStringList res;
+			for (const QFileInfo &entry : entries)
+			{
+				res.append(entry.baseName());
+			}
+			return res;
+		}
+
+		QColor get_label_color(const QString& object_name, QPalette::ColorRole color_role)
+		{
+			QLabel dummy_color;
+			dummy_color.setObjectName(object_name);
+			dummy_color.ensurePolished();
+			return dummy_color.palette().color(color_role);
+		};
+
+		QFont get_label_font(const QString& object_name)
+		{
+			QLabel dummy_font;
+			dummy_font.setObjectName(object_name);
+			dummy_font.ensurePolished();
+			return dummy_font.font();
+		};
+
+		QImage get_opaque_image_area(const QString& path)
+		{
+			QImage image = QImage(path);
+
+			int w_min = 0;
+			int w_max = image.width();
+			int h_min = 0;
+			int h_max = image.height();
+
+			for (int y = 0; y < image.height(); ++y)
+			{
+				QRgb *row = (QRgb*)image.scanLine(y);
+				bool row_filled = false;
+
+				for (int x = 0; x < image.width(); ++x)
+				{
+					if (qAlpha(row[x]))
+					{
+						row_filled = true;
+						w_min = std::max(w_min, x);
+
+						if (w_max > x)
+						{
+							w_max = x;
+							x = w_min;
+						}
+					}
+				}
+
+				if (row_filled)
+				{
+					h_max = std::min(h_max, y);
+					h_min = y;
+				}
+			}
+
+			return image.copy(QRect(QPoint(w_max, h_max), QPoint(w_min, h_min)));
 		}
 	} // utils
 } // gui

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -2,6 +2,9 @@
 
 #include "stdafx.h"
 #include <QtCore>
+#include <QFont>
+#include <QIcon>
+#include <QLabel>
 
 namespace gui
 {
@@ -10,5 +13,27 @@ namespace gui
 		// Creates a frame geometry rectangle with given width height that's centered inside the origin,
 		// while still considering screen boundaries.
 		QRect create_centered_window_geometry(const QRect& origin, s32 width, s32 height);
+
+		// Returns a custom colored QPixmap based on another QPixmap.
+		// use colorize_all to repaint every opaque pixel with the chosen color
+		// use_special_masks is only used for pixmaps with multiple predefined colors
+		QPixmap get_colorized_pixmap(const QPixmap& old_pixmap, const QColor& old_color, const QColor& new_color, bool use_special_masks = false, bool colorize_all = false);
+
+		// Returns a custom colored QIcon based on another QIcon.
+		// use colorize_all to repaint every opaque pixel with the chosen color
+		// use_special_masks is only used for icons with multiple predefined colors
+		QIcon get_colorized_icon(const QIcon& old_icon, const QColor& old_color, const QColor& new_color, bool use_special_masks = false, bool colorize_all = false);
+
+		// Returns a list of all base names of files in dir whose complete file names contain one of the given name_filters
+		QStringList get_dir_entries(const QDir& dir, const QStringList& name_filters);
+
+		// Returns the color specified by its color_role for the QLabels with object_name
+		QColor get_label_color(const QString& object_name, QPalette::ColorRole color_role = QPalette::Foreground);
+
+		// Returns the font of the QLabels with object_name
+		QFont get_label_font(const QString& object_name);
+
+		// Returns the part of the image loaded from path that is inside the bounding box of its opaque areas
+		QImage get_opaque_image_area(const QString& path);
 	} // utils
 } // gui

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -730,6 +730,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xemu_settings->EnhanceCheckBox(ui->useNativeInterface, emu_settings::UseNativeInterface);
 	SubscribeTooltip(ui->useNativeInterface, json_emu_misc["useNativeInterface"].toString());
 
+	xemu_settings->EnhanceCheckBox(ui->showShaderCompilationHint, emu_settings::ShowShaderCompilationHint);
+	SubscribeTooltip(ui->showShaderCompilationHint, json_emu_misc["showShaderCompilationHint"].toString());
+
 	if (game)
 	{
 		ui->gb_stylesheets->setEnabled(false);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1,5 +1,4 @@
 #include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QPushButton>
 #include <QMessageBox>
 #include <QInputDialog>
@@ -13,8 +12,8 @@
 #include <QDesktopWidget>
 #include <QTimer>
 
+#include "qt_utils.h"
 #include "settings_dialog.h"
-
 #include "ui_settings_dialog.h"
 
 #include "stdafx.h"
@@ -756,7 +755,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 			}
 			else
 			{
-				button->setIcon(gui_settings::colorizedIcon(icon, iconColor, color));
+				button->setIcon(gui::utils::get_colorized_icon(icon, iconColor, color));
 			}
 			button->setText("");
 			button->setStyleSheet(styleSheet().append("text-align:left;"));
@@ -857,7 +856,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 					xgui_settings->SetCustomColor(i, dlg.customColor(i));
 				}
 				xgui_settings->SetValue(color, dlg.selectedColor());
-				button->setIcon(gui_settings::colorizedIcon(button->icon(), oldColor, dlg.selectedColor(), true));
+				button->setIcon(gui::utils::get_colorized_icon(button->icon(), oldColor, dlg.selectedColor(), true));
 				Q_EMIT GuiRepaintRequest();
 			}
 		};

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -6,6 +6,7 @@
 #include "Emu/GameInfo.h"
 
 #include <QDialog>
+#include <QLabel>
 #include <QTabWidget>
 
 #include <memory>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1011</width>
-    <height>775</height>
+    <width>816</width>
+    <height>570</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1226,11 +1226,18 @@
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_47">
            <item>
-            <widget class="QGroupBox" name="groupBox_55">
+            <widget class="QGroupBox" name="gb_emu_settings">
              <property name="title">
               <string>Emulator Settings</string>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_41">
+              <item>
+               <widget class="QCheckBox" name="cb_show_welcome">
+                <property name="text">
+                 <string>Show Welcome Screen</string>
+                </property>
+               </widget>
+              </item>
               <item>
                <widget class="QCheckBox" name="exitOnStop">
                 <property name="text">
@@ -1273,9 +1280,48 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QCheckBox" name="showShaderCompilationHint">
+                <property name="text">
+                 <string>Show shader compilation hint</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_13">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
              </layout>
             </widget>
            </item>
+           <item>
+            <widget class="QGroupBox" name="gb_max_llvm">
+             <property name="title">
+              <string>Max LLVM Compile Threads</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_63">
+              <item>
+               <widget class="QComboBox" name="maxLLVMThreads"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_60">
            <item>
             <widget class="QGroupBox" name="gb_viewport">
              <property name="title">
@@ -1368,108 +1414,6 @@
              </layout>
             </widget>
            </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_58">
-           <item>
-            <widget class="QGroupBox" name="groupBox_2">
-             <property name="title">
-              <string>Max LLVM Compile Threads</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_63">
-              <item>
-               <widget class="QComboBox" name="maxLLVMThreads"/>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="gb_settings">
-             <property name="title">
-              <string>UI Settings</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_42">
-              <item>
-               <widget class="QCheckBox" name="cb_show_welcome">
-                <property name="text">
-                 <string>Show Welcome Screen</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_reset_default">
-                <property name="text">
-                 <string>Restore default settings</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_backup_config">
-                <property name="text">
-                 <string>Save current settings</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_open_folder">
-                <property name="text">
-                 <string>Open configuration folder</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::MinimumExpanding</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>0</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QComboBox" name="combo_configs"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_apply_config">
-                <property name="text">
-                 <string>Apply</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_60">
-           <item>
-            <widget class="QGroupBox" name="gb_stylesheets">
-             <property name="title">
-              <string>UI Stylesheets</string>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_43">
-              <item>
-               <widget class="QComboBox" name="combo_stylesheets"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_apply_stylesheet">
-                <property name="text">
-                 <string>Apply</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
            <item>
             <widget class="QGroupBox" name="gb_colors">
              <property name="title">
@@ -1519,6 +1463,85 @@
                  </size>
                 </property>
                </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_58">
+           <item>
+            <widget class="QGroupBox" name="gb_stylesheets">
+             <property name="title">
+              <string>UI Stylesheets</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_43">
+              <item>
+               <widget class="QComboBox" name="combo_stylesheets"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pb_apply_stylesheet">
+                <property name="text">
+                 <string>Apply</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="gb_settings">
+             <property name="title">
+              <string>UI Settings</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_42">
+              <item>
+               <widget class="QPushButton" name="pb_reset_default">
+                <property name="text">
+                 <string>Restore default settings</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pb_backup_config">
+                <property name="text">
+                 <string>Save current settings</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pb_open_folder">
+                <property name="text">
+                 <string>Open configuration folder</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QComboBox" name="combo_configs"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pb_apply_config">
+                <property name="text">
+                 <string>Apply</string>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>


### PR DESCRIPTION
- add possibility to hide/unhide apps by serial (Rightclick on entry -> Hide From Game List)
- add possibility to show hidden apps (View -> Show Hidden Entries)
- clean the hidden entry list from garbage serials on full refresh
- optimize the gamelist/grid entry filter (I hope it is faster like that)
- remove some spaces in guisettings
- add missing visual studio filters for some module headers
- clean up gui_settings.h: move the compat_status struct to game_compatibility.h
- clean up gui_settings.h: move general functions to qt_utils.h
- replace get_single_line workaround with QString::simplified() - I hope this does not create unexpected titles
- initially sort gamelist case insensitive. should fix #4306 
- add option "Show shader compilation hint" to Settings->Emulator. should fix #4309 