### PR TITLE
Restore performance for some of the radeon with Mesa

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -88,6 +88,7 @@ namespace gl
 		bool vendor_INTEL = false;  //has broken GLSL compiler
 		bool vendor_AMD = false;    //has broken ARB_multidraw
 		bool vendor_NVIDIA = false; //has NaN poisoning issues
+		bool vendor_MESA = false;   //requires CLIENT_STORAGE bit set for streaming buffers
 
 		void initialize()
 		{
@@ -199,6 +200,10 @@ namespace gl
 			else if (vendor_string.find("nvidia") != std::string::npos)
 			{
 				vendor_NVIDIA = true;
+			}
+			else if (vendor_string.find("x.org") != std::string::npos)
+			{
+				vendor_MESA = true;
 			}
 #ifdef _WIN32
 			else if (vendor_string.find("amd") != std::string::npos || vendor_string.find("ati") != std::string::npos)
@@ -868,8 +873,11 @@ namespace gl
 
 			buffer::create();
 
+			GLbitfield buffer_storage_flags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
+			if (get_driver_caps().vendor_MESA) buffer_storage_flags |= GL_CLIENT_STORAGE_BIT;
+
 			glBindBuffer((GLenum)m_target, m_id);
-			glBufferStorage((GLenum)m_target, size, data, GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
+			glBufferStorage((GLenum)m_target, size, data, buffer_storage_flags);
 			m_memory_mapping = glMapBufferRange((GLenum)m_target, 0, size, GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
 
 			verify(HERE), m_memory_mapping != nullptr;


### PR DESCRIPTION
Fixes #4307 

> So, about GL_CLIENT_STORAGE_BIT:
> - On NVIDIA, DMA CACHED memory is used when this flag is set. SYSTEM HEAP
>   memory is used without it, which (in my testing) is much faster.
> - On Mesa, GTT is used when this flag is set. This is what we want- we
>   upload to VRAM occur otherwise, which is unusably slow (on radeon).

Source: https://github.com/acomminos/wine-pba/commit/87307b1b9093c769d21d0803bb122b9866bb887c

> 22:10 gregory38: hum it seems AMD use GTT when GL_CLIENT_STORAGE_BIT is set (for write)
> 22:10 gregory38: otherwise VRAM
> 22:11 gregory38: with extra flags for write-combining and cpu access 

Source: https://people.freedesktop.org/~cbrill/dri-log/index.php?channel=nouveau&date=2017-02-03