### PR TITLE
Fix git-version.h not correctly updating.

### DIFF
--- a/rpcs3/git-version.cmake
+++ b/rpcs3/git-version.cmake
@@ -40,14 +40,14 @@ if(EXISTS ${GIT_VERSION_FILE})
 	# Don't update if marked not to update.
 	file(STRINGS ${GIT_VERSION_FILE} match
 		REGEX "RPCS3_GIT_VERSION_NO_UPDATE 1")
-	if(NOT "${match}" EQUAL "")
+	if(NOT "${match}" STREQUAL "")
 		set(GIT_VERSION_UPDATE "0")
 	endif()
 
 	# Don't update if it's already the same.
 	file(STRINGS ${GIT_VERSION_FILE} match
 		REGEX "${GIT_VERSION}")
-	if(NOT "${match}" EQUAL "")
+	if(NOT "${match}" STREQUAL "")
 		set(GIT_VERSION_UPDATE "0")
 	endif()	
 endif()


### PR DESCRIPTION
Use STREQUAL to check ${match} to be empty string, instead of using EQUAL to compare by value.