### PR TITLE
Fix missing Detection for AVX OS Support

### DIFF
--- a/Utilities/sysinfo.cpp
+++ b/Utilities/sysinfo.cpp
@@ -15,13 +15,13 @@ bool utils::has_ssse3()
 
 bool utils::has_avx()
 {
-	static const bool g_value = get_cpuid(0, 0)[0] >= 0x1 && get_cpuid(1, 0)[2] & 0x10000000;
+	static const bool g_value = get_cpuid(0, 0)[0] >= 0x1 && get_cpuid(1, 0)[2] & 0x10000000 && (get_cpuid(1, 0)[2] & 0x0C000000) == 0x0C000000 && (get_xgetbv(0) & 0x6) == 0x6;
 	return g_value;
 }
 
 bool utils::has_avx2()
 {
-	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && get_cpuid(7, 0)[1] & 0x20;
+	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && get_cpuid(7, 0)[1] & 0x20 && (get_cpuid(1, 0)[2] & 0x0C000000) == 0x0C000000 && (get_xgetbv(0) & 0x6) == 0x6;
 	return g_value;
 }
 
@@ -35,7 +35,7 @@ bool utils::has_rtm()
 bool utils::has_512()
 {
 	// Check AVX512F, AVX512CD, AVX512DQ, AVX512BW, AVX512VL extensions (Skylake-X level support)
-	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && (get_cpuid(7, 0)[1] & 0xd0030000) == 0xd0030000;
+	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && (get_cpuid(7, 0)[1] & 0xd0030000) == 0xd0030000 && (get_cpuid(1,0)[2] & 0x0C000000) == 0x0C000000 && (get_xgetbv(0) & 0xe6) == 0xe6;
 	return g_value;
 }
 

--- a/Utilities/sysinfo.h
+++ b/Utilities/sysinfo.h
@@ -16,6 +16,17 @@ namespace utils
 		return {0u+regs[0], 0u+regs[1], 0u+regs[2], 0u+regs[3]};
 	}
 
+	inline u64 get_xgetbv(u32 xcr)
+	{
+#ifdef _MSC_VER
+		return _xgetbv(xcr);
+#else
+		u32 eax, edx;
+		__asm__ volatile( "xgetbv" : "=a"(eax), "=d"(edx) : "c"(xcr));
+		return eax | (u64(edx) << 32);
+#endif
+	}
+
 	bool has_ssse3();
 
 	bool has_avx();


### PR DESCRIPTION
A Fix for Issue #4323, where now in addition to the CPU Capabilities, the OS Support is also queried when checking for AVX/AVX2/AVX512 availability.
This is done by an additional check to the XCR_XFEATURE Register using the xgetbv instruction. Since this is not present on some older CPU's, we first need to check for it's availability with CPUID EAX=1 for bits 26 and 27 in ECX.
Tested on my System with an i7 7800X and Win8.1 (with support for AVX/AVX2 but not for AVX512), where avx/avx2 are still enabled, but avx-512 is now correctly disabled. Might require further testing on machines where AVX512 is confirmed to work as well as on linux.