### PR TITLE
Partial compilation fixes for osx

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -396,6 +396,12 @@ if(NOT MSVC)
 	target_link_libraries(rpcs3 GLEW::GLEW)
 endif()
 
+if(UNIX)
+	find_package(X11 REQUIRED)
+	target_include_directories(rpcs3 PUBLIC ${X11_INCLUDE_DIR})
+	target_link_libraries(rpcs3 ${X11_LIBRARIES})
+endif()
+
 if(WIN32)
 	target_link_libraries(rpcs3 ws2_32.lib Winmm.lib Psapi.lib gdi32.lib VKstatic.1 glslang OSDependent OGLCompiler SPIRV HLSL setupapi.lib hidapi-hid Shlwapi.lib)
 	if(NOT MSVC)

--- a/rpcs3/Emu/RSX/GL/OpenGL.cpp
+++ b/rpcs3/Emu/RSX/GL/OpenGL.cpp
@@ -57,6 +57,6 @@ void gl::set_swapinterval(int interval)
 	//No existing drawable or missing swap extension, EGL?
 	LOG_ERROR(RSX, "Failed to set swap interval");
 #else
-	LOG_UNIMPLEMENTED(RSX, "Swap control not implemented for this platform. Vsync options not available.");
+	LOG_ERROR(RSX, "Swap control not implemented for this platform. Vsync options not available.");
 #endif
 }


### PR DESCRIPTION
- `LOG_UNIMPLEMENTED` does not exist, replaced by `LOG_ERROR`
- Add X11 as a required package for UNIX system in cmake and include necessary files for compilation

With these changes, it is possible to build RPCS3 without LLVM support on OSX.