### PR TITLE
spu: quike fixes

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -503,7 +503,7 @@ void SPUThread::push_snr(u32 number, u32 value)
 
 void SPUThread::do_dma_transfer(const spu_mfc_cmd& args, bool from_mfc)
 {
-	const bool is_get = (args.cmd & ~(MFC_BARRIER_MASK | MFC_FENCE_MASK)) == MFC_GET_CMD;
+	const bool is_get = (args.cmd & ~(MFC_BARRIER_MASK | MFC_FENCE_MASK | MFC_START_MASK)) == MFC_GET_CMD;
 
 	u32 eal = args.eal;
 	u32 lsa = args.lsa & 0x3ffff;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -43,11 +43,11 @@ void sys_spu_image::load(const fs::file& stream)
 		}
 	}
 
-	const u32 mem_size = nsegs * sizeof(sys_spu_segment) + ::size32(stream);
-
 	type        = SYS_SPU_IMAGE_TYPE_KERNEL;
 	entry_point = obj.header.e_entry;
 	nsegs       = sys_spu_image::get_nsegs(obj.progs);
+
+	const u32 mem_size = nsegs * sizeof(sys_spu_segment) + ::size32(stream);
 	segs        = vm::cast(vm::alloc(mem_size, vm::main));
 
 	const u32 src = segs.addr() + nsegs * sizeof(sys_spu_segment);

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -298,7 +298,7 @@ error_code sys_spu_thread_group_create(vm::ptr<u32> id, u32 num, s32 prio, vm::p
 
 	// TODO: max num value should be affected by sys_spu_initialize() settings
 
-	if (attr->nsize > 0x80 || !num || num > 6 || ((prio < 16 || prio > 255) && attr->type != SYS_SPU_THREAD_GROUP_TYPE_EXCLUSIVE_NON_CONTEXT))
+	if (attr->nsize > 0x80 || !num || num > 6 || ((prio < 16 || prio > 255) && (attr->type != SYS_SPU_THREAD_GROUP_TYPE_EXCLUSIVE_NON_CONTEXT && attr->type != SYS_SPU_THREAD_GROUP_TYPE_COOPERATE_WITH_SYSTEM)))
 	{
 		return CELL_EINVAL;
 	}


### PR DESCRIPTION
- Check get start type proxy mfc commands :
crysis 1 (**nothing => Intro**)
crysis 2 (**nothing => Inagme**)

- Dont check prio if spu group type is 0x20 in sys_spu_thread_group_create
far cry 4 (**loadable => Intro**)
F1 race stars (**nothing => Intro**)

- Fix spu image loading address calculation
harry potter 7 part 1 (**nothing => Intro/Loadable** (depends on luck lol))
fixes #3834

Originated from raw fixes pr but neko wants a quike review and merge.. 😂