### PR TITLE
rsx: Clamp negative fog distance

### DIFF
--- a/Vulkan/Vulkan-build/pre-build.bat
+++ b/Vulkan/Vulkan-build/pre-build.bat
@@ -3,7 +3,7 @@
 REM Setting up dummy git helper
 MKDIR ..\Vulkan-LoaderAndValidationLayers\external\glslang\External\spirv-tools
 SET header="@ECHO off"
-SET content="ECHO unused"
+SET content="ECHO 12345678deadbeef12345678cafebabe12345678"
 ECHO %header:"=% > git.bat
 ECHO %content:"=% >> git.bat
 COPY /Y git.bat ..\Vulkan-LoaderAndValidationLayers\external\glslang\External\spirv-tools\git.bat

--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -65,6 +65,7 @@ namespace program_common
 		template_body += "		break;\n";
 		template_body += "	}\n";
 		template_body += "\n";
+		template_body += "	result.x = max(result.x, 0.);\n";
 		template_body += "	result.y = clamp(result.y, 0., 1.);\n";
 		template_body += "	return result;\n";
 		template_body += "}\n\n";


### PR DESCRIPTION
- Noticed while looking through ngs1 traces that the fog distance was negative due to `(scale * coord)` being less than the bias variable (equation is generally `scale * coord + bias` and bias can be negative with some equations). Opened as a separate PR to make testing easier.