### PR TITLE
Update settings to indicate speed differences between Interpreters and Recompilers for less confusion

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -159,19 +159,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 		for (int i = 0; i < ppu_list.count(); i++)
 		{
-			ppuBG->button(i)->setText(ppu_list[i]);
-
 			if (ppu_list[i] == selectedPPU)
 			{
 				ppuBG->button(i)->setChecked(true);
 			}
-
-#ifndef LLVM_AVAILABLE
-			if (ppu_list[i].toLower().contains("llvm"))
-			{
-				ppuBG->button(i)->setEnabled(false);
-			}
-#endif
 
 			connect(ppuBG->button(i), &QAbstractButton::pressed, [=]()
 			{
@@ -198,8 +189,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 		for (int i = 0; i < spu_list.count(); i++)
 		{
-			spuBG->button(i)->setText(spu_list[i]);
-
 			if (spu_list[i] == selectedSPU)
 			{
 				spuBG->button(i)->setChecked(true);
@@ -211,6 +200,11 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 			});
 		}
 	}
+
+#ifndef LLVM_AVAILABLE
+	ui->ppu_llvm->setEnabled(false);
+	ui->spu_llvm->setEnabled(false);
+#endif
 
 	// lib options tool tips
 	SubscribeTooltip(ui->lib_auto, json_cpu_lib["auto"].toString());

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -63,7 +63,7 @@
               <item>
                <widget class="QRadioButton" name="ppu_fast">
                 <property name="text">
-                 <string>Interpreter (fast)</string>
+                 <string>Interpreter</string>
                 </property>
                </widget>
               </item>
@@ -93,7 +93,7 @@
               <item>
                <widget class="QRadioButton" name="spu_fast">
                 <property name="text">
-                 <string>Interpreter (fast)</string>
+                 <string>Interpreter</string>
                 </property>
                </widget>
               </item>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -63,14 +63,14 @@
               <item>
                <widget class="QRadioButton" name="ppu_fast">
                 <property name="text">
-                 <string>Interpreter</string>
+                 <string>Interpreter (fast)</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QRadioButton" name="ppu_llvm">
                 <property name="text">
-                 <string>Recompiler (LLVM)</string>
+                 <string>LLVM Recompiler (fastest)</string>
                 </property>
                </widget>
               </item>
@@ -93,14 +93,14 @@
               <item>
                <widget class="QRadioButton" name="spu_fast">
                 <property name="text">
-                 <string>Interpreter</string>
+                 <string>Interpreter (fast)</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QRadioButton" name="spu_asmjit">
                 <property name="text">
-                 <string>Recompiler (ASMJIT)</string>
+                 <string>ASMJIT Recompiler (fastest)</string>
                 </property>
                </widget>
               </item>
@@ -110,7 +110,7 @@
                  <bool>false</bool>
                 </property>
                 <property name="text">
-                 <string>Recompiler (LLVM)</string>
+                 <string>LLVM Recompiler</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Some users were repeatedly using Interpreter (fast) simply because of it having (fast) in the name, Hopefully this won't bring too much discussion about the best wording. Even though it is faster than the precise interpreter I don't think further clarification on speed is needed.