### PR TITLE
rsx: Minor format fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -475,7 +475,7 @@ namespace glsl
 			OS << "#define TEX1D_BIAS(index, tex, coord1, bias) process_texel(texture(tex, coord1 * texture_parameters[index].x, bias), uint(texture_parameters[index].w))\n";
 			OS << "#define TEX1D_LOD(index, tex, coord1, lod) process_texel(textureLod(tex, coord1 * texture_parameters[index].x, lod), uint(texture_parameters[index].w))\n";
 			OS << "#define TEX1D_GRAD(index, tex, coord1, dpdx, dpdy) process_texel(textureGrad(tex, coord1 * texture_parameters[index].x, dpdx, dpdy), uint(texture_parameters[index].w))\n";
-			OS << "#define TEX1D_PROJ(index, tex, coord2) process_texel(textureGrad(tex, coord2 * vec2(texture_parameters[index].x, 1.)), uint(texture_parameters[index].w))\n";
+			OS << "#define TEX1D_PROJ(index, tex, coord2) process_texel(textureProj(tex, coord2 * vec2(texture_parameters[index].x, 1.)), uint(texture_parameters[index].w))\n";
 
 			OS << "#define TEX2D(index, tex, coord2) process_texel(texture(tex, coord2 * texture_parameters[index].xy), uint(texture_parameters[index].w))\n";
 			OS << "#define TEX2D_BIAS(index, tex, coord2, bias) process_texel(texture(tex, coord2 * texture_parameters[index].xy, bias), uint(texture_parameters[index].w))\n";
@@ -536,11 +536,11 @@ namespace glsl
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE1D:
 			return "TEX1D($_i, $t, $0.x)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE1D_BIAS:
-			return "TEX1D_BIAS($_i, $t, $0.xy)";
+			return "TEX1D_BIAS($_i, $t, $0.x, $1.x)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE1D_PROJ:
 			return "TEX1D_PROJ($_i, $t, $0.xy)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE1D_LOD:
-			return "TEX1D_LOD($_i, $t, $0.x)";
+			return "TEX1D_LOD($_i, $t, $0.x, $1.x)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE1D_GRAD:
 			return "TEX1D_GRAD($_i, $t, $0.x, $1.x, $2.x)";
 		case FUNCTION::FUNCTION_TEXTURE_SAMPLE2D:

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -24,7 +24,7 @@ namespace rsx
 			(((/*alphakill*/0) << 2) | (/*maxaniso*/0) << 4) | ((/*maxlod*/0xc00) << 7) | ((/*minlod*/0) << 19) | ((/*enable*/0) << 31);
 
 		// Control1
-		registers[NV4097_SET_TEXTURE_CONTROL1 + (m_index * 8)] = 0xE4;
+		registers[NV4097_SET_TEXTURE_CONTROL1 + (m_index * 8)] = 0xAAE4;
 
 		// Filter
 		registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)] =
@@ -204,6 +204,18 @@ namespace rsx
 			}
 
 			remap_ctl &= 0xFFFF;
+			break;
+		}
+		case CELL_GCM_TEXTURE_B8:
+		{
+			//Low bit in remap control seems to affect whether the A component is forced to 1
+			//Only seen in BLUS31604
+			//TODO: Verify with a hardware test
+			if (remap_override)
+			{
+				//Set remap lookup for A component to FORCE_ONE
+				remap_ctl = remap_ctl & ~(3 << 8) | (1 << 8);
+			}
 			break;
 		}
 		default:


### PR DESCRIPTION
- Disable gamma control on depth and the special non-rgb texture formats
- Implement B8 remap override (HW tests pending)
- Fix some copypastas in glsl emitter

Fixes https://github.com/RPCS3/rpcs3/issues/4351