### PR TITLE
Load stylesheets properly when in AppImage or make install

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -98,7 +98,7 @@ if(USE_NATIVE_INSTRUCTIONS)
 endif()
 
 if(NOT MSVC)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-pch -Wno-unused-command-line-argument -fexceptions")
 	# This hides our LLVM from mesa's LLVM, otherwise we get some unresolvable conflicts.
 	if(NOT APPLE)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--exclude-libs,ALL")

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -375,6 +375,20 @@ void rpcs3_app::OnChangeStyleSheetRequest(const QString& sheetFilePath)
 		setStyleSheet(file.readAll());
 		file.close();
 	}
+#if !defined(_WIN32) && !defined(__APPLE__)
+	else
+	{
+		// If we can't open the file, try the /share folder
+		QString shareDir = QCoreApplication::applicationDirPath() + "/../share/rpcs3/";
+		QDir::setCurrent(shareDir);
+		QFile newFile(shareDir + "GuiConfigs/" + QFileInfo(file.fileName()).fileName());
+		if (newFile.open(QIODevice::ReadOnly | QIODevice::Text))
+		{
+			setStyleSheet(newFile.readAll());
+			newFile.close();
+		}
+	}
+#endif
 	gui::stylesheet = styleSheet();
 	RPCS3MainWin->RepaintGui();
 }

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -1,6 +1,7 @@
 #include "gui_settings.h"
 
 #include "game_list_frame.h"
+#include "qt_utils.h"
 
 #include <QCoreApplication>
 #include <QMessageBox>
@@ -235,15 +236,15 @@ void gui_settings::BackupSettingsToTarget(const QString& friendlyName)
 
 QStringList gui_settings::GetStylesheetEntries()
 {
-	QStringList nameFilter;
-	nameFilter << "*.qss";
-	QFileInfoList entries = m_settingsDir.entryInfoList(nameFilter, QDir::Files);
-	QStringList res;
-	for (const QFileInfo &entry : entries)
-	{
-		res.append(entry.baseName());
-	}
-
+	QStringList nameFilter = QStringList("*.qss");
+	QStringList res = gui::utils::get_dir_entries(m_settingsDir, nameFilter);
+#if !defined(_WIN32) && !defined(__APPLE__)
+	// Makes stylesheets load if using AppImage or installed to /usr/bin
+	QDir linuxStylesheetDir = QCoreApplication::applicationDirPath() + "/../share/rpcs3/GuiConfigs/";
+	res.append(gui::utils::get_dir_entries(linuxStylesheetDir, nameFilter));
+	res.removeDuplicates();
+#endif
+	res.sort(Qt::CaseInsensitive);
 	return res;
 }
 


### PR DESCRIPTION
`-Wno-invalid-pch`
was added because it was spammed constantly by gcc on Arch Linux.
`-Wno-unused-command-line-argument`
was added because it was occasionally spammed, during the build.