### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -456,7 +456,7 @@ namespace glsl
 			OS << "	if ((control_bits & 0x10) > 0)\n";
 			OS << "	{\n";
 			OS << "		//Alphakill\n";
-			OS << "		if (!comparison_passes(rgba.a, 0., (control_bits >> 5) & 0x7))\n";
+			OS << "		if (rgba.a < 0.0000000001)\n";
 			OS << "		{\n";
 			OS << "			discard;\n";
 			OS << "			return rgba;\n";

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1548,12 +1548,7 @@ namespace rsx
 				if (tex.alpha_kill_enabled())
 				{
 					//alphakill can be ignored unless a valid comparison function is set
-					const rsx::comparison_function func = (rsx::comparison_function)tex.zfunc();
-					if (func < rsx::comparison_function::always && func >= rsx::comparison_function::never)
-					{
-						texture_control |= (1 << 4);			//alphakill enable
-						texture_control |= ((u32)func << 5);	//alphakill function
-					}
+					texture_control |= (1 << 4);
 				}
 
 				const u32 texaddr = rsx::get_address(tex.offset(), tex.location());

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -638,64 +638,81 @@ namespace vk
 			std::unique_ptr<vk::image> image;
 			std::unique_ptr<vk::image_view> view;
 
+			VkImageAspectFlags dst_aspect;
+			VkFormat dst_format = vk::get_compatible_sampler_format(gcm_format);
+
 			image.reset(new vk::image(*vk::get_current_renderer(), m_memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 				VK_IMAGE_TYPE_2D,
-				vk::get_compatible_sampler_format(gcm_format),
+				dst_format,
 				size, size, 1, 1, 6, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT));
 
-			VkImageSubresourceRange subresource_range = {};
-			VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT;
-
-			switch (sections_to_copy[0].src->info.format)
+			switch (gcm_format)
 			{
-			case VK_FORMAT_D16_UNORM:
-				aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+			case CELL_GCM_TEXTURE_DEPTH16:
+				dst_aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
 				break;
-			case VK_FORMAT_D24_UNORM_S8_UINT:
-			case VK_FORMAT_D32_SFLOAT_S8_UINT:
-				aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+			case CELL_GCM_TEXTURE_DEPTH24_D8:
+				dst_aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+				break;
+			default:
+				dst_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
 				break;
 			}
 
-			VkImageSubresourceRange view_range = { aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 1, 0, 6 };
+			VkImageSubresourceRange view_range = { dst_aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 1, 0, 6 };
 			view.reset(new vk::image_view(*vk::get_current_renderer(), image->value, VK_IMAGE_VIEW_TYPE_CUBE, image->info.format, image->native_component_map, view_range));
-			subresource_range = view_range;
-			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresource_range);
-			subresource_range.layerCount = 1;
 
-			if (!(aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
+			VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 6 };
+			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
+
+			if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
 			{
 				VkClearColorValue clear = {};
-				vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &subresource_range);
+				vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
 			}
 			else
 			{
 				VkClearDepthStencilValue clear = { 1.f, 0 };
-				vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &subresource_range);
+				vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
 			}
 
 			for (const auto &section : sections_to_copy)
 			{
 				if (section.src)
 				{
+					VkImageAspectFlags src_aspect;
+					switch (section.src->info.format)
+					{
+					case VK_FORMAT_D16_UNORM:
+						src_aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+						break;
+					case VK_FORMAT_D24_UNORM_S8_UINT:
+					case VK_FORMAT_D32_SFLOAT_S8_UINT:
+						src_aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+						break;
+					default:
+						src_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+						break;
+					}
+
+					VkImageSubresourceRange src_range = { src_aspect, 0, 1, 0, 1 };
 					VkImageLayout old_src_layout = section.src->current_layout;
-					vk::change_image_layout(cmd, section.src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, subresource_range);
+					vk::change_image_layout(cmd, section.src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, src_range);
 
 					VkImageCopy copy_rgn;
 					copy_rgn.srcOffset = { section.src_x, section.src_y, 0 };
 					copy_rgn.dstOffset = { section.dst_x, section.dst_y, 0 };
-					copy_rgn.dstSubresource = { aspect, 0, section.dst_z, 1 };
-					copy_rgn.srcSubresource = { aspect, 0, 0, 1 };
+					copy_rgn.dstSubresource = { dst_aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, section.dst_z, 1 };
+					copy_rgn.srcSubresource = { src_aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 0, 1 };
 					copy_rgn.extent = { section.w, section.h, 1 };
 
 					vkCmdCopyImage(cmd, section.src->value, section.src->current_layout, image->value, image->current_layout, 1, &copy_rgn);
-					vk::change_image_layout(cmd, section.src, old_src_layout, subresource_range);
+					vk::change_image_layout(cmd, section.src, old_src_layout, src_range);
 				}
 			}
 
-			subresource_range.layerCount = 6;
-			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, subresource_range);
+			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
 
 			const u32 resource_memory = size * size * 6 * 4; //Rough approximate
 			m_discardable_storage.push_back({ image, view });
@@ -711,62 +728,81 @@ namespace vk
 			std::unique_ptr<vk::image> image;
 			std::unique_ptr<vk::image_view> view;
 
+			VkImageAspectFlags dst_aspect;
+			VkFormat dst_format = vk::get_compatible_sampler_format(gcm_format);
+
 			image.reset(new vk::image(*vk::get_current_renderer(), m_memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 				VK_IMAGE_TYPE_3D,
 				vk::get_compatible_sampler_format(gcm_format),
 				width, height, depth, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0));
 
-			VkImageSubresourceRange subresource_range = {};
-			VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT;
-
-			switch (sections_to_copy[0].src->info.format)
+			switch (gcm_format)
 			{
-			case VK_FORMAT_D16_UNORM:
-				aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+			case CELL_GCM_TEXTURE_DEPTH16:
+				dst_aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
 				break;
-			case VK_FORMAT_D24_UNORM_S8_UINT:
-			case VK_FORMAT_D32_SFLOAT_S8_UINT:
-				aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+			case CELL_GCM_TEXTURE_DEPTH24_D8:
+				dst_aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+				break;
+			default:
+				dst_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
 				break;
 			}
 
-			VkImageSubresourceRange view_range = { aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 1, 0, 1 };
+			VkImageSubresourceRange view_range = { dst_aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 1, 0, 1 };
 			view.reset(new vk::image_view(*vk::get_current_renderer(), image->value, VK_IMAGE_VIEW_TYPE_3D, image->info.format, image->native_component_map, view_range));
-			subresource_range = view_range;
-			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresource_range);
 
-			if (!(aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
+			VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 1 };
+			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
+
+			if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
 			{
 				VkClearColorValue clear = {};
-				vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &subresource_range);
+				vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
 			}
 			else
 			{
 				VkClearDepthStencilValue clear = { 1.f, 0 };
-				vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &subresource_range);
+				vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
 			}
 
 			for (const auto &section : sections_to_copy)
 			{
 				if (section.src)
 				{
+					VkImageAspectFlags src_aspect;
+					switch (section.src->info.format)
+					{
+					case VK_FORMAT_D16_UNORM:
+						src_aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+						break;
+					case VK_FORMAT_D24_UNORM_S8_UINT:
+					case VK_FORMAT_D32_SFLOAT_S8_UINT:
+						src_aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+						break;
+					default:
+						src_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+						break;
+					}
+
+					VkImageSubresourceRange src_range = { src_aspect, 0, 1, 0, 1 };
 					VkImageLayout old_src_layout = section.src->current_layout;
-					vk::change_image_layout(cmd, section.src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, subresource_range);
+					vk::change_image_layout(cmd, section.src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, src_range);
 
 					VkImageCopy copy_rgn;
 					copy_rgn.srcOffset = { section.src_x, section.src_y, 0 };
 					copy_rgn.dstOffset = { section.dst_x, section.dst_y, section.dst_z };
-					copy_rgn.dstSubresource = { aspect, 0, 0, 1 };
-					copy_rgn.srcSubresource = { aspect, 0, 0, 1 };
+					copy_rgn.dstSubresource = { dst_aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 0, 1 };
+					copy_rgn.srcSubresource = { src_aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 0, 1 };
 					copy_rgn.extent = { section.w, section.h, 1 };
 
 					vkCmdCopyImage(cmd, section.src->value, section.src->current_layout, image->value, image->current_layout, 1, &copy_rgn);
-					vk::change_image_layout(cmd, section.src, old_src_layout, subresource_range);
+					vk::change_image_layout(cmd, section.src, old_src_layout, src_range);
 				}
 			}
 
-			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, subresource_range);
+			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
 
 			const u32 resource_memory = width * height * depth * 4; //Rough approximate
 			m_discardable_storage.push_back({ image, view });
@@ -796,7 +832,7 @@ namespace vk
 				break;
 			}
 
-			VkImageSubresourceRange subresource_range = { aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 1, 0, 1 };
+			VkImageSubresourceRange subresource_range = { aspect, 0, 1, 0, 1 };
 			vk::change_image_layout(cmd, dst, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresource_range);
 
 			for (const auto &region : sections_to_copy)
@@ -807,8 +843,8 @@ namespace vk
 				VkImageCopy copy_rgn;
 				copy_rgn.srcOffset = { region.src_x, region.src_y, 0 };
 				copy_rgn.dstOffset = { region.dst_x, region.dst_y, 0 };
-				copy_rgn.dstSubresource = { aspect, 0, 0, 1 };
-				copy_rgn.srcSubresource = { aspect, 0, 0, 1 };
+				copy_rgn.dstSubresource = { aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 0, 1 };
+				copy_rgn.srcSubresource = { aspect & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 0, 1 };
 				copy_rgn.extent = { region.w, region.h, 1 };
 
 				vkCmdCopyImage(cmd, region.src->value, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -561,11 +561,6 @@ namespace rsx
 				u16 x = method_registers.nv308a_x();
 				u16 y = method_registers.nv308a_y();
 
-				if (y)
-				{
-					LOG_ERROR(RSX, "%s: y is not null (0x%x)", __FUNCTION__, y);
-				}
-
 				const u32 pixel_offset = (method_registers.blit_engine_output_pitch_nv3062() * y) + (x << 2);
 				u32 address = get_address(method_registers.blit_engine_output_offset_nv3062() + pixel_offset + index * 4, method_registers.blit_engine_output_location_nv3062());
 				vm::write32(address, arg);


### PR DESCRIPTION
- Fix render-to-3d and render-to-cubemap and improve deferred texture subresource handling
  Should fix broken 3d LUTs in some games (dirt 3) and make more games show ingame reflections
- Properly implement Z-curve decoder compatible with 3 dimensions
  Fixes 'swizzled' 3D storage decode. Fixes more broken 3d 'palette' LUTs in some games like skate 2
- Fix detection of vertex input stream to decide whether register read is an array or a single vector
- Fix alphakill broken by epic fixes PR