### PR TITLE
spu: minor optimizations

### DIFF
--- a/rpcs3/Emu/Cell/MFC.h
+++ b/rpcs3/Emu/Cell/MFC.h
@@ -28,8 +28,9 @@ enum MFC : u8
 };
 
 // Atomic Status Update
-enum : u32
+enum : s32
 {
+	MFC_ATOMIC_EMPTY = -1, // Originally unused, value is used when the atomic channel is empty
 	MFC_PUTLLC_SUCCESS = 0,
 	MFC_PUTLLC_FAILURE = 1, // reservation was lost
 	MFC_PUTLLUC_SUCCESS = 2,
@@ -37,8 +38,9 @@ enum : u32
 };
 
 // MFC Write Tag Status Update Request Channel (ch23) operations
-enum : u32
+enum : s32
 {
+	MFC_TAG_STAT_EMPTY       = -1, // Originally unused, value is used when the tag status update channel is empty
 	MFC_TAG_UPDATE_IMMEDIATE = 0,
 	MFC_TAG_UPDATE_ANY       = 1,
 	MFC_TAG_UPDATE_ALL       = 2,

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1333,8 +1333,8 @@ void spu_recompiler::RDCH(spu_opcode_t op)
 		Label wait = c->newLabel();
 		Label next = c->newLabel();
 		c->mov(SPU_OFF_32(pc), m_pos);
-		c->cmp(x86::byte_ptr(*cpu, offset32(&SPUThread::ch_in_mbox) + 1), 0);
-		c->jz(wait);
+		c->cmp(x86::dword_ptr(*cpu, offset32(&SPUThread::ch_in_mbox) + 16), 0);
+		c->jle(wait);
 
 		after.emplace_back([=]
 		{
@@ -1630,9 +1630,8 @@ void spu_recompiler::RCHCNT(spu_opcode_t op)
 	case SPU_RdInMbox:
 	{
 		const XmmLink& vr = XmmAlloc();
-		c->movdqa(vr, SPU_OFF_128(ch_in_mbox));
-		c->pslldq(vr, 14);
-		c->psrldq(vr, 3);
+		c->movd(vr, x86::dword_ptr(*cpu, offset32(&SPUThread::ch_in_mbox) + 16));
+		c->pslldq(vr, 12);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vr);
 		return;
 	}

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -545,12 +545,12 @@ public:
 	u32 raddr = 0;
 
 	u32 srr0;
-	u32 ch_tag_upd;
+	s32 ch_tag_upd;
 	u32 ch_tag_mask;
-	spu_channel ch_tag_stat;
+	u32 ch_tag_stat;
 	u32 ch_stall_mask;
-	spu_channel ch_stall_stat;
-	spu_channel ch_atomic_stat;
+	u32 ch_stall_stat; // count is set if not zero
+	s32 ch_atomic_stat; // count is set if not negative
 
 	spu_channel_4_t ch_in_mbox;
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -269,88 +269,89 @@ struct spu_channel_4_t
 {
 	struct alignas(16) sync_var_t
 	{
-		u8 waiting;
-		u8 count;
-		u32 value0;
-		u32 value1;
-		u32 value2;
+		u32 value[4];
 	};
 
-	atomic_t<sync_var_t> values;
-	atomic_t<u32> value3;
+	union
+	{
+		atomic_t<sync_var_t> data;
+		atomic_t<u32> m_values[4];
+	};
+
+	atomic_t<s32> count;
 
 public:
-	void clear()
-	{
-		values.store({});
-		value3 = 0;
-	}
+	static const s32 is_waiting = -1;
 
 	// push unconditionally (overwriting latest value), returns true if needs signaling
-	void push(cpu_thread& spu, u32 value)
+	void push(cpu_thread& spu, const u32 value)
 	{
-		value3 = value; _mm_sfence();
+		const s32 old_count = this->count.load();
 
-		if (values.atomic_op([=](sync_var_t& data) -> bool
+		// Only overwrite last value if the mailbox is full
+		if (old_count == 4)
 		{
-			switch (data.count++)
-			{
-			case 0: data.value0 = value; break;
-			case 1: data.value1 = value; break;
-			case 2: data.value2 = value; break;
-			default: data.count = 4;
-			}
-
-			if (data.waiting)
-			{
-				data.waiting = 0;
-
-				return true;
-			}
-
-			return false;
-		}))
-		{
-			spu.notify();
+			m_values[3].store(value);
+			return;
 		}
+
+		// the SPU thread is waiting for a notification
+		if (old_count < 0)
+		{
+			this->count += 2; // set count to 1 via lock add
+			m_values[0].store(value);
+			return spu.notify();
+		}
+
+		m_values[this->count++].store(value);
 	}
 
 	// returns non-zero value on success: queue size before removal
 	uint try_pop(u32& out)
 	{
-		return values.atomic_op([&](sync_var_t& data)
+		// If the mailbox has atleast one entry, read it, else turn on the wait state
+		if (this->count > 0)
 		{
-			const uint result = data.count;
+			out = m_values[0].load();
 
-			if (result != 0)
 			{
-				data.waiting = 0;
-				data.count--;
-				out = data.value0;
+				sync_var_t new_data;
+				*reinterpret_cast<u64*>(&new_data.value[0]) = (*reinterpret_cast<atomic_t<u64>*>(&m_values[1].raw())).load();
 
-				data.value0 = data.value1;
-				data.value1 = data.value2;
-				_mm_lfence();
-				data.value2 = this->value3;
-			}
-			else
-			{
-				data.waiting = 1;
+				new_data.value[2] = m_values[3].load();
+
+				data.store(new_data);
 			}
 
-			return result;
-		});
+			_mm_mfence();
+			return static_cast<uint>(this->count--);
+		}
+
+		this->count.store(is_waiting);
+		return 0;
 	}
 
 	u32 get_count()
 	{
-		return values.raw().count;
+		return (u32)count.raw();
 	}
 
-	void set_values(u32 count, u32 value0, u32 value1 = 0, u32 value2 = 0, u32 value3 = 0)
+	template<const u32 count>
+	inline void set_values(u32 value0 = 0, u32 value1 = 0, u32 value2 = 0, u32 value3 = 0)
 	{
-		this->values.raw() = { 0, static_cast<u8>(count), value0, value1, value2 };
-		this->value3 = value3;
+		static_assert(count <= 4, "Illegal inbound mailbox count.");
+
+		// Write only on specified entries, the if's are being inlined due to the template
+		if (count > 0)
+			this->m_values[0].raw() = value0;
+		if (count > 1)
+			this->m_values[1].raw() = value1;
+		if (count > 2)
+			this->m_values[2].raw() = value2;
+		if (count > 3)
+			this->m_values[3].raw() = value3;
+
+		this->count.raw() = count;
 	}
 };
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -563,7 +563,7 @@ public:
 	spu_channel ch_snr1; // SPU Signal Notification Register 1
 	spu_channel ch_snr2; // SPU Signal Notification Register 2
 
-	atomic_t<u32> ch_event_mask;
+	u32 ch_event_mask;
 	atomic_t<u32> ch_event_stat;
 	atomic_t<bool> interrupts_enabled;
 
@@ -606,7 +606,7 @@ public:
 	u32 get_mfc_completed();
 
 	bool process_mfc_cmd(spu_mfc_cmd args);
-	u32 get_events(bool waiting = false);
+	u32 get_events();
 	void set_events(u32 mask);
 	void set_interrupt_status(bool enable);
 	u32 get_ch_count(u32 ch);

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -65,7 +65,7 @@ bool lv2_event_queue::send(lv2_event event)
 		const u32 data1 = static_cast<u32>(std::get<1>(event));
 		const u32 data2 = static_cast<u32>(std::get<2>(event));
 		const u32 data3 = static_cast<u32>(std::get<3>(event));
-		spu.ch_in_mbox.set_values(4, CELL_OK, data1, data2, data3);
+		spu.ch_in_mbox.set_values<4>(CELL_OK, data1, data2, data3);
 
 		spu.state += cpu_flag::signal;
 		spu.notify();
@@ -180,7 +180,7 @@ error_code sys_event_queue_destroy(ppu_thread& ppu, u32 equeue_id, s32 mode)
 			}
 			else
 			{
-				static_cast<SPUThread&>(*cpu).ch_in_mbox.set_values(1, CELL_ECANCELED);
+				static_cast<SPUThread&>(*cpu).ch_in_mbox.set_values<1>(CELL_ECANCELED);
 				cpu->state += cpu_flag::signal;
 				cpu->notify();
 			}

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -40,24 +40,6 @@ namespace vm
 		page_allocated          = (1 << 7),
 	};
 
-	struct waiter
-	{
-		named_thread* owner;
-		u32 addr;
-		u32 size;
-		u64 stamp;
-		const void* data;
-
-		waiter() = default;
-
-		waiter(const waiter&) = delete;
-
-		void init();
-		void test() const;
-
-		~waiter();
-	};
-
 	// Address type
 	enum addr_t : u32 {};
 
@@ -116,9 +98,6 @@ namespace vm
 
 	// Check and notify memory changes at address
 	void notify(u32 addr, u32 size);
-
-	// Check and notify memory changes
-	void notify_all();
 
 	// Change memory protection of specified memory region
 	bool page_protect(u32 addr, u32 size, u8 flags_test = 0, u8 flags_set = 0, u8 flags_clear = 0);


### PR DESCRIPTION
- Change `ch_atomic_stat` type from `spu_channel_t` to the lighter `s32` type
It can be done since this channel does not require sync between threads and has specific predefined values.
hence we can use an additional value when the channel is empty and drop sync requirements, count value etc `spu_channel_t` type has.

- Change `ch_stall_stat` type to `u32`
Similarly to `ch_atomic_stat` channel, this channel does not require specail sync mechanisms, and the only value that is guaranteed to not be returned when reading the channel data is 0 (since at least one stalled list in a command group must be reported, so one bit atleast must be set), so use this value when the cahnnel is empty.

- Replace `vm::waiter` with an array of waiting spu threads
also removed disabled code in getllar that stalls the spu if a reservation with the same address already made.
testcase for it: https://github.com/elad335/myps3tests/tree/master/spu_test/two%20reservation%20at%20the%20same%20address

- Minor mfc dma optimizations