### PR TITLE
cellVdec: Do not decode next frame during end_sequence

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -226,6 +226,11 @@ struct vdec_thread : ppu_thread
 
 				while (max_frames)
 				{
+					if (vcmd == vdec_cmd::end_seq)
+					{
+						break;
+					}
+
 					vdec_frame frame;
 					frame.avf.reset(av_frame_alloc());
 


### PR DESCRIPTION
Fixes issue #2930, only tested on the intro cutscene.