### PR TITLE
Minor bugfix

### DIFF
--- a/rpcs3/Emu/RSX/overlays.h
+++ b/rpcs3/Emu/RSX/overlays.h
@@ -377,7 +377,8 @@ namespace rsx
 
 					if (auto picon = +listSet->newData->icon)
 					{
-						title = picon->title.get_ptr();
+						if (picon->title)
+							title = picon->title.get_ptr();
 
 						if (picon->iconBuf && picon->iconBufSize && picon->iconBufSize <= 225280)
 						{


### PR DESCRIPTION
Fixes issue #4420 

It looks like some games may provide an icon resource, but they don't always provide a save title for creating a new save. Odd behavior, but it is what it is. on Uncharted, it looks like the data gets overwritten afterwards by the game, cause if I load a newly created save made with this pr it has all the names and metadata.

I'm open to suggestions as to the correctness of my implementation.