### PR TITLE
remove new line from (in file ....) log message to fix stack mode

### DIFF
--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -51,7 +51,7 @@
 #define STRINGIZE_DETAIL(x) #x ""
 #define STRINGIZE(x) STRINGIZE_DETAIL(x)
 
-#define HERE "\n(in file " __FILE__ ":" STRINGIZE(__LINE__) ")"
+#define HERE " (in file " __FILE__ ":" STRINGIZE(__LINE__) ")"
 
 // Ensure that the expression evaluates to true. Obsolete.
 //#define EXPECTS(...) do { if (!(__VA_ARGS__)) fmt::raw_error("Precondition failed: " #__VA_ARGS__ HERE); } while (0)


### PR DESCRIPTION
I think it is not necessary to have these in a new line.
Also they make the log slower

Here the broken stack mode:
![untitled](https://user-images.githubusercontent.com/23019877/38690524-9c318984-3e7e-11e8-801b-438c96c6b91f.png)