### PR TITLE
Fix AppImages for distros that are not ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,9 @@ after_script:
       mkdir -p appdir/usr/optional/ ; mkdir -p appdir/usr/optional/libstdc++/ ;
       cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/ ;
       rm ./appdir/AppRun ;
-      wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -O ./appdir/AppRun ;
+      wget -c https://github.com/RPCS3/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -O ./appdir/AppRun ;
       chmod a+x ./appdir/AppRun ;
-      wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./appdir/usr/optional/exec.so ;
+      wget -c https://github.com/RPCS3/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./appdir/usr/optional/exec.so ;
       
       echo "Package it up and send it off" ;
       ./linuxdeployqt*.AppImage --appimage-extract ;


### PR DESCRIPTION
Fixes #4414 and possible also 4427, though I think that's a different issue.

Basically, this makes libstdc++6 load only ubuntu 14.04, and uses the distros's lib otherwise.
If you want more details on the actual implementation, check out:
 https://github.com/darealshinji/AppImageKit-checkrt/compare/master...RPCS3:master