### PR TITLE
Add AppStream metadata for linux

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -484,6 +484,8 @@ if(UNIX AND NOT APPLE)
 		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/48x48/apps)
 	install(FILES rpcs3.desktop
 		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+	install(FILES rpcs3.appdata.xml
+			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo)
     # Install other files
     install(DIRECTORY ../bin/Icons
 		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rpcs3)

--- a/rpcs3/rpcs3.appdata.xml
+++ b/rpcs3/rpcs3.appdata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2018 RPCS3-->
+​<component type="desktop-application">
+    ​<id>RPCS3</id>
+    ​<metadata_license>FSFAP</metadata_license>
+    ​<project_license>GPL-2.0</project_license>
+    ​<name>Power Statistics</name>
+    ​<summary>Observe power management</summary>
+    ​
+    ​<description>
+        ​<p>
+            RPCS3 is an experimental open-source Sony PlayStation 3 emulator and debugger written in C++ for Windows and Linux. RPCS3 started development in May of 2011 by its founders DH and Hykem.
+            The emulator is currently capable of running over 1800 commercial titles powered by Vulkan and OpenGL.
+
+            The goal of this project is to experiment, research, and educate on the topic of PlayStation 3 emulation that can be performed on compatible devices and operating systems.
+            All information was obtained legally by purchasing PlayStation 3 hardware and software. Additional information was obtained from various sources on the internet that include but is not limited to system hardware and software documentation.
+            Most of this information can be found on the PlayStation 3 Developer Wiki.
+        ​</p>
+    ​</description>
+    ​
+    ​<launchable type="desktop-id">rpcs3.desktop</launchable>
+    ​
+    ​<url type="homepage">https://rpcs3.net</url>
+    ​<provides>
+        ​<binary>rpcs3</binary>
+    ​</provides>
+​</component>


### PR DESCRIPTION
Description was copied from https://rpcs3.net and https://rpcs3.net/about

See: https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html
for more information about AppStream metadata.

The main motivation for this was so that we can get a nice description on https://appimage.github.io/RPCS3/