### PR TITLE
Fix Cross Edge

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -449,6 +449,9 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 	vm::var<CellGameDataStatSet>  cbSet;
 	cbGet->isNewData = fs::is_dir(vfs::get(dir)) ? CELL_GAMEDATA_ISNEWDATA_NO : CELL_GAMEDATA_ISNEWDATA_YES;
 
+	vm::var<CellGameDataSystemFileParam> setParam;
+	cbSet->setParam = setParam;
+
 	// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
 	cbGet->hddFreeSizeKB = 40000000; //40 GB
 


### PR DESCRIPTION
The CellGameDataStatCallback in Cross Edge expects setParam to be initialized and thus died on null dereference. Initializing it fixes Cross Edge [BLUS30348] and probably the Korean version [BLKS20112] as well.