### PR TITLE
Better Support For Game Collections

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -314,7 +314,7 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 		}
 
 		Emu.SetForceBoot(true);
-		Emu.BootGame(path, true);
+		Emu.BootGame(path, "", true);
 	});
 
 	ppu.state += cpu_flag::dbg_global_stop;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -220,6 +220,7 @@ class Emulator final
 	std::string m_cat;
 	std::string m_dir;
 	std::string m_sfo_dir;
+	std::string m_game_dir{"PS3_GAME"};
 	std::string m_usr{"00000001"};
 	u32 m_usrid{1};
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -312,7 +312,7 @@ public:
 
 	std::string PPUCache() const;
 
-	bool BootGame(const std::string& path, bool direct = false, bool add_only = false, bool force_global_config = false);
+	bool BootGame(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, bool force_global_config = false);
 	bool BootRsxCapture(const std::string& path);
 	bool InstallPkg(const std::string& path);
 
@@ -323,7 +323,7 @@ private:
 	void LimitCacheSize();
 public:
 	static std::string GetHddDir();
-	static std::string GetSfoDirFromGamePath(const std::string& game_path, const std::string& user);
+	static std::string GetSfoDirFromGamePath(const std::string& game_path, const std::string& user, const std::string& title_id = "");
 
 	static std::string GetCustomConfigDir();
 	static std::string GetCustomConfigPath(const std::string& title_id, bool get_deprecated_path = false);
@@ -332,7 +332,7 @@ public:
 
 	void SetForceBoot(bool force_boot);
 
-	void Load(bool add_only = false, bool force_global_config = false);
+	void Load(const std::string& title_id = "", bool add_only = false, bool force_global_config = false);
 	void Run();
 	bool Pause();
 	void Resume();

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -1,4 +1,4 @@
-// Qt5.2+ frontend implementation for rpcs3. Known to work on Windows, Linux, Mac
+﻿// Qt5.2+ frontend implementation for rpcs3. Known to work on Windows, Linux, Mac
 // by Sacha Refshauge, Megamouse and flash-fire
 
 #include <QApplication>
@@ -160,7 +160,7 @@ int main(int argc, char** argv)
 		{
 			Emu.argv = std::move(argv);
 			Emu.SetForceBoot(true);
-			Emu.BootGame(path, true);
+			Emu.BootGame(path, "", true);
 		});
 	}
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -15,6 +15,7 @@
 #include <iterator>
 #include <memory>
 #include <set>
+#include <regex>
 
 #include <QDesktopServices>
 #include <QHeaderView>
@@ -390,9 +391,25 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 		{
 			for (const auto& entry : fs::dir(path))
 			{
-				if (entry.is_directory)
+				const std::string entry_path = path + entry.name;
+				if (fs::is_file(entry_path + "/PS3_DISC.SFB"))
 				{
-					path_list.emplace_back(path + entry.name);
+					for (const auto& sub_entry : fs::dir(entry_path))
+					{
+						if (!sub_entry.is_directory)
+						{
+							continue;
+						}
+
+						if (sub_entry.name == "PS3_GAME" || std::regex_match(sub_entry.name, std::regex("^PS3_GM[[:digit:]]{2}$")))
+						{
+							path_list.emplace_back(entry_path + "/" + sub_entry.name);
+						}
+					}
+				}
+				else if (entry.is_directory)
+				{
+					path_list.emplace_back(entry_path);
 				}
 			}
 		};

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -387,25 +387,36 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 
 		std::vector<std::string> path_list;
 
+		const auto add_disc_dir = [&](const std::string& path)
+		{
+			for (const auto& entry : fs::dir(path))
+			{
+				if (!entry.is_directory || entry.name == "." || entry.name == "..")
+				{
+					continue;
+				}
+
+				if (entry.name == "PS3_GAME" || std::regex_match(entry.name, std::regex("^PS3_GM[[:digit:]]{2}$")))
+				{
+					path_list.emplace_back(path + "/" + entry.name);
+				}
+			}
+		};
+
 		const auto add_dir = [&](const std::string& path)
 		{
 			for (const auto& entry : fs::dir(path))
 			{
+				if (entry.name == "." || entry.name == "..")
+				{
+					continue;
+				}
+
 				const std::string entry_path = path + entry.name;
+
 				if (fs::is_file(entry_path + "/PS3_DISC.SFB"))
 				{
-					for (const auto& sub_entry : fs::dir(entry_path))
-					{
-						if (!sub_entry.is_directory)
-						{
-							continue;
-						}
-
-						if (sub_entry.name == "PS3_GAME" || std::regex_match(sub_entry.name, std::regex("^PS3_GM[[:digit:]]{2}$")))
-						{
-							path_list.emplace_back(entry_path + "/" + sub_entry.name);
-						}
-					}
+					add_disc_dir(entry_path);
 				}
 				else if (entry.is_directory)
 				{
@@ -419,8 +430,17 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 
 		for (auto pair : YAML::Load(fs::file{fs::get_config_dir() + "/games.yml", fs::read + fs::create}.to_string()))
 		{
-			path_list.push_back(pair.second.Scalar());
-			path_list.back().resize(path_list.back().find_last_not_of('/') + 1);
+			const std::string game_dir = pair.second.Scalar();
+
+			if (fs::is_file(game_dir + "/PS3_DISC.SFB"))
+			{
+				add_disc_dir(game_dir);
+			}
+			else
+			{
+				path_list.push_back(game_dir);
+				path_list.back().resize(path_list.back().find_last_not_of('/') + 1);
+			}
 		}
 
 		// Used to remove duplications from the list (serial -> set of cat names)
@@ -665,7 +685,7 @@ void game_list_frame::doubleClickedSlot(QTableWidgetItem *item)
 	}
 
 	LOG_NOTICE(LOADER, "Booting from gamelist per doubleclick...");
-	Q_EMIT RequestBoot(game->info.path);
+	Q_EMIT RequestBoot(game);
 }
 
 void game_list_frame::ShowContextMenu(const QPoint &pos)
@@ -710,7 +730,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		connect(boot_custom, &QAction::triggered, [=]
 		{
 			LOG_NOTICE(LOADER, "Booting from gamelist per context menu...");
-			Q_EMIT RequestBoot(currGame.path);
+			Q_EMIT RequestBoot(gameinfo);
 		});
 	}
 	else
@@ -804,7 +824,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	connect(boot, &QAction::triggered, [=]
 	{
 		LOG_NOTICE(LOADER, "Booting from gamelist per context menu...");
-		Q_EMIT RequestBoot(currGame.path, gameinfo->hasCustomConfig);
+		Q_EMIT RequestBoot(gameinfo, gameinfo->hasCustomConfig);
 	});
 	connect(configure, &QAction::triggered, [=]
 	{
@@ -852,7 +872,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	});
 	connect(createPPUCache, &QAction::triggered, [=]
 	{
-		CreatePPUCache(currGame.path);
+		CreatePPUCache(gameinfo);
 	});
 	connect(removeGame, &QAction::triggered, [=]
 	{
@@ -978,20 +998,20 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	myMenu.exec(globalPos);
 }
 
-bool game_list_frame::CreatePPUCache(const std::string& path)
+bool game_list_frame::CreatePPUCache(const game_info& game)
 {
 	Emu.SetForceBoot(true);
 	Emu.Stop();
 	Emu.SetForceBoot(true);
-	const bool success = Emu.BootGame(path, true);
+	const bool success = Emu.BootGame(game->info.path, game->info.serial, true);
 
 	if (success)
 	{
-		LOG_WARNING(GENERAL, "Creating PPU Cache for %s", path);
+		LOG_WARNING(GENERAL, "Creating PPU Cache for %s", game->info.path);
 	}
 	else
 	{
-		LOG_ERROR(GENERAL, "Could not create PPU Cache for %s", path);
+		LOG_ERROR(GENERAL, "Could not create PPU Cache for %s", game->info.path);
 	}
 	return success;
 }
@@ -1188,12 +1208,7 @@ bool game_list_frame::RemoveSPUCache(const std::string& base_dir, bool is_intera
 
 void game_list_frame::BatchCreatePPUCaches()
 {
-	std::set<std::string> paths;
-	for (const auto& game : m_game_data)
-	{
-		paths.emplace(game->info.path);
-	}
-	const u32 total = paths.size();
+	const u32 total = m_game_data.size();
 
 	if (total == 0)
 	{
@@ -1208,7 +1223,7 @@ void game_list_frame::BatchCreatePPUCaches()
 	pdlg->show();
 
 	u32 created = 0;
-	for (const auto& path : paths)
+	for (const auto& game : m_game_data)
 	{
 		if (pdlg->wasCanceled())
 		{
@@ -1217,7 +1232,7 @@ void game_list_frame::BatchCreatePPUCaches()
 		}
 		QApplication::processEvents();
 
-		if (CreatePPUCache(path))
+		if (CreatePPUCache(game))
 		{
 			while (!Emu.IsStopped())
 			{
@@ -1652,7 +1667,7 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 					return false;
 
 				LOG_NOTICE(LOADER, "Booting from gamelist by pressing %s...", keyEvent->key() == Qt::Key_Enter ? "Enter" : "Return");
-				Q_EMIT RequestBoot(gameinfo->info.path);
+				Q_EMIT RequestBoot(gameinfo);
 
 				return true;
 			}

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -228,7 +228,7 @@ private Q_SLOTS:
 	void doubleClickedSlot(QTableWidgetItem *item);
 Q_SIGNALS:
 	void GameListFrameClosed();
-	void RequestBoot(const std::string& path, bool force_global_config = false);
+	void RequestBoot(const game_info& game, bool force_global_config = false);
 	void RequestIconSizeChange(const int& val);
 protected:
 	/** Override inherited method from Qt to allow signalling when close happened.*/
@@ -251,7 +251,7 @@ private:
 	bool RemoveShadersCache(const std::string& base_dir, bool is_interactive = false);
 	bool RemovePPUCache(const std::string& base_dir, bool is_interactive = false);
 	bool RemoveSPUCache(const std::string& base_dir, bool is_interactive = false);
-	bool CreatePPUCache(const std::string& path);
+	bool CreatePPUCache(const game_info& game);
 
 	std::string GetCacheDirBySerial(const std::string& serial);
 	std::string GetDataDirBySerial(const std::string& serial);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -188,11 +188,15 @@ QIcon main_window::GetAppIcon()
 void main_window::SetAppIconFromPath(const std::string& path)
 {
 	// get Icon for the gs_frame from path. this handles presumably all possible use cases
-	QString qpath = qstr(path);
-	std::string path_list[] = { path, sstr(qpath.section("/", 0, -2)), sstr(qpath.section("/", 0, -3)) };
-	for (std::string pth : path_list)
+	const QString qpath = qstr(path);
+	const std::string path_list[] = { path, sstr(qpath.section("/", 0, -2)), sstr(qpath.section("/", 0, -3)) };
+
+	for (const std::string& pth : path_list)
 	{
-		if (!fs::is_dir(pth)) continue;
+		if (!fs::is_dir(pth))
+		{
+			continue;
+		}
 
 		const std::string sfo_dir = Emu.GetSfoDirFromGamePath(pth, Emu.GetUsr());
 		const std::string ico     = sfo_dir + "/ICON0.PNG";

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -185,7 +185,7 @@ QIcon main_window::GetAppIcon()
 }
 
 // loads the appIcon from path and embeds it centered into an empty square icon
-void main_window::SetAppIconFromPath(const std::string& path)
+void main_window::SetAppIconFromPath(const std::string& path, const std::string& title_id)
 {
 	// get Icon for the gs_frame from path. this handles presumably all possible use cases
 	const QString qpath = qstr(path);
@@ -198,7 +198,7 @@ void main_window::SetAppIconFromPath(const std::string& path)
 			continue;
 		}
 
-		const std::string sfo_dir = Emu.GetSfoDirFromGamePath(pth, Emu.GetUsr());
+		const std::string sfo_dir = Emu.GetSfoDirFromGamePath(pth, Emu.GetUsr(), title_id);
 		const std::string ico     = sfo_dir + "/ICON0.PNG";
 		if (fs::is_file(ico))
 		{
@@ -272,7 +272,7 @@ void main_window::OnPlayOrPause()
 	}
 }
 
-void main_window::Boot(const std::string& path, bool direct, bool add_only, bool force_global_config)
+void main_window::Boot(const std::string& path, const std::string& title_id, bool direct, bool add_only, bool force_global_config)
 {
 	if (!Emu.IsStopped())
 	{
@@ -287,11 +287,11 @@ void main_window::Boot(const std::string& path, bool direct, bool add_only, bool
 		}
 	}
 
-	SetAppIconFromPath(path);
+	SetAppIconFromPath(path, title_id);
 	Emu.SetForceBoot(true);
 	Emu.Stop();
 
-	if (Emu.BootGame(path, direct, add_only, force_global_config))
+	if (Emu.BootGame(path, title_id, direct, add_only, force_global_config))
 	{
 		LOG_SUCCESS(LOADER, "Boot successful.");
 		const std::string serial = Emu.GetTitleID().empty() ? "" : "[" + Emu.GetTitleID() + "] ";
@@ -341,7 +341,7 @@ void main_window::BootElf()
 	const std::string path = sstr(QFileInfo(filePath).canonicalFilePath());
 
 	LOG_NOTICE(LOADER, "Booting from BootElf...");
-	Boot(path, true);
+	Boot(path, "", true);
 }
 
 void main_window::BootGame()
@@ -656,7 +656,7 @@ void main_window::InstallPup(const QString& dropPath)
 		guiSettings->ShowInfoBox(tr("Success!"), tr("Successfully installed PS3 firmware and LLE Modules!"), gui::ib_pup_success, this);
 
 		Emu.SetForceBoot(true);
-		Emu.BootGame(g_cfg.vfs.get_dev_flash() + "sys/external/", true);
+		Emu.BootGame(g_cfg.vfs.get_dev_flash() + "sys/external/", "", true);
 	}
 }
 
@@ -1026,7 +1026,7 @@ void main_window::BootRecentAction(const QAction* act)
 	}
 
 	LOG_NOTICE(LOADER, "Booting from recent games list...");
-	Boot(path, true);
+	Boot(path, "", true);
 };
 
 QAction* main_window::CreateRecentAction(const q_string_pair& entry, const uint& sc_idx)
@@ -1582,9 +1582,9 @@ void main_window::CreateDockWindows()
 		}
 	});
 
-	connect(m_gameListFrame, &game_list_frame::RequestBoot, [this](const std::string& path, bool force_global_config)
+	connect(m_gameListFrame, &game_list_frame::RequestBoot, [this](const game_info& game, bool force_global_config)
 	{
-		Boot(path, false, false, force_global_config);
+		Boot(game->info.path, game->info.serial, false, false, force_global_config);
 	});
 }
 
@@ -1778,7 +1778,7 @@ void main_window::AddGamesFromDir(const QString& path)
 	const std::string s_path = sstr(path);
 
 	// search dropped path first or else the direct parent to an elf is wrongly skipped
-	if (Emu.BootGame(s_path, false, true))
+	if (Emu.BootGame(s_path, "", false, true))
 	{
 		LOG_NOTICE(GENERAL, "Returned from game addition by drag and drop: %s", s_path);
 	}
@@ -1789,7 +1789,7 @@ void main_window::AddGamesFromDir(const QString& path)
 	{
 		std::string pth = sstr(dir_iter.next());
 
-		if (Emu.BootGame(pth, false, true))
+		if (Emu.BootGame(pth, "", false, true))
 		{
 			LOG_NOTICE(GENERAL, "Returned from game addition by drag and drop: %s", pth);
 		}
@@ -1920,7 +1920,7 @@ void main_window::dropEvent(QDropEvent* event)
 		m_gameListFrame->Refresh(true);
 		break;
 	case drop_type::drop_game: // import valid games to gamelist (games.yaml)
-		if (Emu.BootGame(sstr(dropPaths.first()), true))
+		if (Emu.BootGame(sstr(dropPaths.first()), "", true))
 		{
 			LOG_SUCCESS(GENERAL, "Elf Boot from drag and drop done: %s", sstr(dropPaths.first()));
 		}

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -89,7 +89,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
 	void OnPlayOrPause();
-	void Boot(const std::string& path, bool direct = false, bool add_only = false, bool force_global_config = false);
+	void Boot(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, bool force_global_config = false);
 	void BootElf();
 	void BootGame();
 	void BootRsxCapture(std::string path = "");
@@ -108,7 +108,8 @@ protected:
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dragMoveEvent(QDragMoveEvent* event) override;
 	void dragLeaveEvent(QDragLeaveEvent* event) override;
-	void SetAppIconFromPath(const std::string& path);
+	void SetAppIconFromPath(const std::string& path, const std::string& title_id = "");
+
 private:
 	void RepaintToolBarIcons();
 	void RepaintThumbnailIcons();


### PR DESCRIPTION
Hereby I attempt to enable the usage of PS3_GM01, PS3_GM02 etc in the gamelist, by adding a new emu member m_game_dir and using this instead of PS3_GAME.
The granularity of games.yml had to be increased.
Also the addition of games to the games.yml by BootGame(add_only) was extended.

aims to fix #4448