### PR TITLE
Fix build with ffmpeg 4.0

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAdec.cpp
@@ -8,6 +8,9 @@ extern "C"
 {
 #include "libavcodec/avcodec.h"
 #include "libavformat/avformat.h"
+#ifndef AV_INPUT_BUFFER_PADDING_SIZE
+#define AV_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
+#endif
 }
 
 #include "cellPamf.h"
@@ -229,8 +232,8 @@ public:
 
 						if (size)
 						{
-							data = (u8*)av_calloc(1, size + FF_INPUT_BUFFER_PADDING_SIZE);
-							this->size = size + FF_INPUT_BUFFER_PADDING_SIZE;
+							data = (u8*)av_calloc(1, size + AV_INPUT_BUFFER_PADDING_SIZE);
+							this->size = size + AV_INPUT_BUFFER_PADDING_SIZE;
 						}
 						else
 						{


### PR DESCRIPTION
Compatibility with the new ffmpeg version 4.0. See e.g. https://github.com/twitter/vireo/issues/11

Also `av_register_all`, `avcodec_register_all`, `frame->pkt_pts`, `avcodec_decode_video2` are marked as deprecated, but they still work.