### PR TITLE
Add Rich Presence option

### DIFF
--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -54,6 +54,7 @@
 			"configs": "Only useful to developers.\nIf unsure, don't use this option.",
 			"stylesheets": "Changes the overall look of RPCS3.\nChoose a stylesheet and click Apply to change between styles.",
 			"show_welcome": "Shows the initial welcome screen upon starting RPCS3.",
+			"useRichPresence": "Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to apply.",
 			"custom_colors": "Prioritize custom user interface colors over properties set in stylesheet."
 		},
 		"misc": {

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -94,8 +94,12 @@ void rpcs3_app::Init()
 		welcome->exec();
 	}
 #ifdef WITH_DISCORD_RPC
-	DiscordEventHandlers handlers = {};
-	Discord_Initialize("424004941485572097", &handlers, 1, NULL);
+	// Discord Rich Presence Integration
+	if (guiSettings->GetValue(gui::m_richPresence).toBool())
+	{
+		DiscordEventHandlers handlers = {};
+		Discord_Initialize("424004941485572097", &handlers, 1, NULL);
+	}
 #endif
 }
 

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -157,6 +157,7 @@ namespace gui
 	const gui_save m_saveNotes         = gui_save(meta, "saveNotes",         QVariantMap());
 	const gui_save m_showDebugTab      = gui_save(meta, "showDebugTab",      false);
 	const gui_save m_enableUIColors    = gui_save(meta, "enableUIColors",    false);
+	const gui_save m_richPresence      = gui_save(meta, "useRichPresence",   true);
 
 	const gui_save gs_disableMouse = gui_save(gs_frame, "disableMouse", false);
 	const gui_save gs_resize       = gui_save(gs_frame, "resize",       false);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -248,14 +248,17 @@ void main_window::Boot(const std::string& path, bool direct, bool add_only)
 		AddRecentAction(gui::Recent_Game(qstr(Emu.GetBoot()), qstr(serial + Emu.GetTitle())));
 #ifdef WITH_DISCORD_RPC
 		// Discord Rich Presence Integration
-		DiscordRichPresence discordPresence = {};
-		discordPresence.state = Emu.GetTitleID().c_str();
-		discordPresence.details = Emu.GetTitle().c_str();
-		discordPresence.largeImageKey = "rpcs3_logo";
-		discordPresence.largeImageText = "RPCS3 is the world's first PlayStation 3 emulator.";
-		discordPresence.startTimestamp = time(0);
-		discordPresence.instance = 0;
-		Discord_UpdatePresence(&discordPresence);
+		if (guiSettings->GetValue(gui::m_richPresence).toBool())
+		{
+			DiscordRichPresence discordPresence = {};
+			discordPresence.state = Emu.GetTitleID().c_str();
+			discordPresence.details = Emu.GetTitle().c_str();
+			discordPresence.largeImageKey = "rpcs3_logo";
+			discordPresence.largeImageText = "RPCS3 is the world's first PlayStation 3 emulator.";
+			discordPresence.startTimestamp = time(0);
+			discordPresence.instance = 0;
+			Discord_UpdatePresence(&discordPresence);
+		}
 #endif
 	}
 	else
@@ -775,10 +778,13 @@ void main_window::OnEmuStop()
 	}
 #ifdef WITH_DISCORD_RPC
 	// Discord Rich Presence Integration
-	DiscordRichPresence discordPresence = {};
-	discordPresence.largeImageKey = "rpcs3_logo";
-	discordPresence.largeImageText = "RPCS3 is the world's first PlayStation 3 emulator.";
-	Discord_UpdatePresence(&discordPresence);
+	if (guiSettings->GetValue(gui::m_richPresence).toBool())
+	{
+		DiscordRichPresence discordPresence = {};
+		discordPresence.largeImageKey = "rpcs3_logo";
+		discordPresence.largeImageText = "RPCS3 is the world's first PlayStation 3 emulator.";
+		Discord_UpdatePresence(&discordPresence);
+	}
 #endif
 }
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -706,6 +706,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 	SubscribeTooltip(ui->cb_custom_colors, json_emu_gui["custom_colors"].toString());
 
+	SubscribeTooltip(ui->useRichPresence, json_emu_gui["useRichPresence"].toString());
+
 	xemu_settings->EnhanceCheckBox(ui->exitOnStop, emu_settings::ExitRPCS3OnFinish);
 	SubscribeTooltip(ui->exitOnStop, json_emu_misc["exitOnStop"].toString());
 
@@ -905,6 +907,13 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		{
 			ui->gs_height->setValue(std::min(ui->gs_height->value(), QApplication::desktop()->screenGeometry().height()));
 			xgui_settings->SetValue(gui::gs_height, ui->gs_height->value());
+		});
+
+		ui->useRichPresence->setChecked(xgui_settings->GetValue(gui::m_richPresence).toBool());
+
+		connect(ui->useRichPresence, &QCheckBox::clicked, [=](bool val)
+		{
+			xgui_settings->SetValue(gui::m_richPresence, val);
 		});
 
 		AddConfigs();

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1288,6 +1288,13 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="useRichPresence">
+                <property name="text">
+                 <string>Use Discord Rich Presence</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <spacer name="verticalSpacer_13">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Added an option to disable Discord Rich Presence. I found this way of doing it to be the most compatible with the current code. You could also move the initialization to the Boot function, and then terminate it after you close the game. That way it's never even initialized if the option is off. Also does anyone know why the tooltip isn't working?