### PR TITLE
SPU: fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -574,7 +574,7 @@ void _spurs::handler_entry(ppu_thread& ppu, vm::ptr<CellSpurs> spurs)
 
 		CHECK_SUCCESS(sys_spu_thread_group_start(ppu, spurs->spuTG));
 
-		if (s32 rc = sys_spu_thread_group_join(ppu, spurs->spuTG, vm::null, vm::null))
+		if (s32 rc = sys_spu_thread_group_join(ppu, spurs->spuTG, vm::make_var<u32>(0), vm::make_var<u32>(0)))
 		{
 			if (rc == CELL_ESTAT)
 			{
@@ -845,7 +845,7 @@ s32 _spurs::finalize_spu(ppu_thread& ppu, vm::ptr<CellSpurs> spurs)
 	{
 		while (true)
 		{
-			CHECK_SUCCESS(sys_spu_thread_group_join(ppu, spurs->spuTG, vm::null, vm::null));
+			CHECK_SUCCESS(sys_spu_thread_group_join(ppu, spurs->spuTG, vm::make_var<u32>(0), vm::make_var<u32>(0)));
 
 			if (s32 rc = sys_spu_thread_group_destroy(spurs->spuTG))
 			{

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -142,6 +142,9 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 		case MFC_PUTS_CMD:
 		case MFC_PUTBS_CMD:
 		case MFC_PUTFS_CMD:
+		case MFC_PUTR_CMD:
+		case MFC_PUTRF_CMD:
+		case MFC_PUTRB_CMD:
 		case MFC_GET_CMD:
 		case MFC_GETB_CMD:
 		case MFC_GETF_CMD:

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -2936,7 +2936,23 @@ void spu_recompiler::IRET(spu_opcode_t op)
 
 void spu_recompiler::BISLED(spu_opcode_t op)
 {
-	fmt::throw_exception("Unimplemented instruction" HERE);
+	c->mov(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, 3));
+	c->and_(*addr, 0x3fffc);
+
+	const XmmLink& vr = XmmAlloc();
+	c->movdqa(vr, XmmConst(_mm_set_epi32(spu_branch_target(m_pos + 4), 0, 0, 0)));
+	c->movdqa(SPU_OFF_128(gpr, op.rt), vr);
+
+	asmjit::Label branch_label = c->newLabel();
+	get_events();
+	c->jne(branch_label);
+
+	after.emplace_back([=]
+	{
+		c->align(asmjit::kAlignCode, 16);
+		c->bind(branch_label);
+		branch_indirect(op);
+	});
 }
 
 void spu_recompiler::HBR(spu_opcode_t op)

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -485,7 +485,15 @@ bool spu_interpreter::IRET(spu_thread& spu, spu_opcode_t op)
 
 bool spu_interpreter::BISLED(spu_thread& spu, spu_opcode_t op)
 {
-	fmt::throw_exception("Unimplemented instruction" HERE);
+	const u32 target = spu_branch_target(spu.gpr[op.ra]._u32[3]);
+	spu.gpr[op.rt] = v128::from32r(spu_branch_target(spu.pc + 4));
+
+	if (spu.get_events())
+	{
+		spu.pc = target;
+		set_interrupt_status(spu, op);
+		return false;
+	}
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -910,6 +910,7 @@ bool spu_thread::do_dma_check(const spu_mfc_cmd& args)
 				if ((mfc_queue[i].cmd & ~0xc) == MFC_BARRIER_CMD)
 				{
 					mfc_barrier |= -1;
+					mfc_fence |= 1u << mfc_queue[i].tag;
 					continue;
 				}
 
@@ -1070,6 +1071,7 @@ void spu_thread::do_mfc(bool wait)
 
 			// Block all tags
 			barrier |= -1;
+			fence |= 1u << args.tag;
 			return false;
 		}
 
@@ -1434,6 +1436,7 @@ bool spu_thread::process_mfc_cmd(spu_mfc_cmd args)
 		{
 			mfc_queue[mfc_size++] = args;
 			mfc_barrier |= -1;
+			mfc_fence |= 1u << args.tag;
 		}
 
 		return true;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2119,7 +2119,7 @@ bool spu_thread::stop_and_signal(u32 code)
 	case 0x002:
 	{
 		state += cpu_flag::ret;
-		return true;
+		return false;
 	}
 
 	case 0x110:
@@ -2297,6 +2297,7 @@ bool spu_thread::stop_and_signal(u32 code)
 			if (thread && thread.get() != this)
 			{
 				thread->state += cpu_flag::stop;
+				thread->status.store(SPU_STATUS_STOPPED_BY_STOP);
 				thread_ctrl::notify(*thread);
 			}
 		}
@@ -2307,7 +2308,8 @@ bool spu_thread::stop_and_signal(u32 code)
 		group->cv.notify_one();
 
 		state += cpu_flag::stop;
-		return true;
+		status.store(SPU_STATUS_STOPPED_BY_STOP);
+		return false;
 	}
 
 	case 0x102:
@@ -2323,11 +2325,11 @@ bool spu_thread::stop_and_signal(u32 code)
 
 		std::lock_guard lock(group->mutex);
 
-		status |= SPU_STATUS_STOPPED_BY_STOP;
+		status.store(SPU_STATUS_STOPPED_BY_STOP);
 		group->cv.notify_one();
 
 		state += cpu_flag::stop;
-		return true;
+		return false;
 	}
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -359,7 +359,7 @@ struct spu_int_ctrl_t
 
 	std::shared_ptr<struct lv2_int_tag> tag;
 
-	void set(u64 ints);
+	bool set(u64 ints);
 
 	void clear(u64 ints)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -385,8 +385,6 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 
 	std::lock_guard lock(group->mutex);
 
-	group->join_state = 0;
-
 	for (auto& thread : group->threads)
 	{
 		if (thread)
@@ -600,16 +598,17 @@ error_code sys_spu_thread_group_terminate(u32 id, s32 value)
 
 	group->run_state = SPU_THREAD_GROUP_STATUS_INITIALIZED;
 	group->exit_status = value;
-	group->join_state |= SPU_TGJSF_TERMINATED;
-	group->cv.notify_one();
+
+	if (group->join_state.exchange(SYS_SPU_THREAD_GROUP_JOIN_TERMINATED) & SYS_SPU_THREAD_GROUP_IS_JOINING)
+	{
+		group->joiner.load()->notify();
+	}
 
 	return CELL_OK;
 }
 
 error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause, vm::ptr<u32> status)
 {
-	vm::temporary_unlock(ppu);
-
 	sys_spu.warning("sys_spu_thread_group_join(id=0x%x, cause=*0x%x, status=*0x%x)", id, cause, status);
 
 	const auto group = idm::get<lv2_spu_group>(id);
@@ -619,9 +618,6 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 		return CELL_ESRCH;
 	}
 
-	u32 join_state = 0;
-	s32 exit_value = 0;
-
 	{
 		std::lock_guard lock(group->mutex);
 
@@ -630,7 +626,7 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 			return CELL_ESTAT;
 		}
 
-		if (group->join_state.fetch_or(SPU_TGJSF_IS_JOINING) & SPU_TGJSF_IS_JOINING)
+		if (atomic_storage<u32>::bts(group->join_state.raw(), 3))
 		{
 			// another PPU thread is joining this thread group
 			return CELL_EBUSY;
@@ -638,40 +634,13 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 
 		lv2_obj::sleep(ppu);
 
-		while ((group->join_state & ~SPU_TGJSF_IS_JOINING) == 0)
-		{
-			if (ppu.is_stopped())
-			{
-				return 0;
-			}
+		group->joiner = &ppu;
+	}
 
-			bool stopped = true;
-
-			for (auto& t : group->threads)
-			{
-				if (t)
-				{
-					if ((t->status & SPU_STATUS_STOPPED_BY_STOP) == 0)
-					{
-						stopped = false;
-						break;
-					}
-				}
-			}
-
-			if (stopped)
-			{
-				break;
-			}
-
-			// TODO
-			group->cv.wait(group->mutex, 1000);
-		}
-
-		join_state = group->join_state;
-		exit_value = group->exit_status;
-		group->join_state &= ~SPU_TGJSF_IS_JOINING;
-		group->run_state = SPU_THREAD_GROUP_STATUS_INITIALIZED; // hack
+	// Wait for the thread group to be terminated
+	while (!ppu.is_stopped() && group->join_state & SYS_SPU_THREAD_GROUP_IS_JOINING) 
+	{
+		thread_ctrl::wait();
 	}
 
 	if (ppu.test_stopped())
@@ -679,33 +648,9 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 		return 0;
 	}
 
-	switch (join_state & ~SPU_TGJSF_IS_JOINING)
-	{
-	case 0:
-	{
-		if (cause) *cause = SYS_SPU_THREAD_GROUP_JOIN_ALL_THREADS_EXIT;
-		break;
-	}
-	case SPU_TGJSF_GROUP_EXIT:
-	{
-		if (cause) *cause = SYS_SPU_THREAD_GROUP_JOIN_GROUP_EXIT;
-		break;
-	}
-	case SPU_TGJSF_TERMINATED:
-	{
-		if (cause) *cause = SYS_SPU_THREAD_GROUP_JOIN_TERMINATED;
-		break;
-	}
-	default:
-	{
-		fmt::throw_exception("Unexpected join_state" HERE);
-	}
-	}
+	*cause = group->join_state.exchange(SYS_SPU_THREAD_GROUP_NO_JOIN); // Clear all join flags
 
-	if (status)
-	{
-		*status = group->exit_status;
-	}
+	*status = group->exit_status;
 
 	return CELL_OK;
 }


### PR DESCRIPTION
- Wait for the interrupt mailbox to empty on raw spu before resuming.
allows naughty bear to go in-game.

- rewrite `sys_spu_thread_group_join` to allow the ppu thread to being fully asleep while waiting on an spu group to exit.

- Implement `bisled` instruction
fixes GTA V's `class std::runtime_error thrown: Unimplemented instruction
(in file Emu\Cell\SPUASMJITRecompiler.cpp:1431)`

- fix exit stop codes on spu interpreters

- add result type mfc proxy commands

- fix tag status for sync type commands : [testcase](https://github.com/elad335/myps3tests/tree/master/spu_tests/sync%20command)