### PR TITLE
3rdparty: update stb_image.h and stb_truetype.h

### DIFF
--- a/3rdparty/stblib/stb_image.h
+++ b/3rdparty/stblib/stb_image.h
@@ -1,218 +1,106 @@
-/* stb_image - v2.10 - public domain image loader - http://nothings.org/stb_image.h
-no warranty implied; use at your own risk
+/* stb_image - v2.19 - public domain image loader - http://nothings.org/stb
+                                  no warranty implied; use at your own risk
 
-Do this:
-#define STB_IMAGE_IMPLEMENTATION
-before you include this file in *one* C or C++ file to create the implementation.
+   Do this:
+      #define STB_IMAGE_IMPLEMENTATION
+   before you include this file in *one* C or C++ file to create the implementation.
 
-// i.e. it should look like this:
-#include ...
-#include ...
-#include ...
-#define STB_IMAGE_IMPLEMENTATION
-#include "stb_image.h"
+   // i.e. it should look like this:
+   #include ...
+   #include ...
+   #include ...
+   #define STB_IMAGE_IMPLEMENTATION
+   #include "stb_image.h"
 
-You can #define STBI_ASSERT(x) before the #include to avoid using assert.h.
-And #define STBI_MALLOC, STBI_REALLOC, and STBI_FREE to avoid using malloc,realloc,free
-
-
-QUICK NOTES:
-Primarily of interest to game developers and other people who can
-avoid problematic images and only need the trivial interface
-
-JPEG baseline & progressive (12 bpc/arithmetic not supported, same as stock IJG lib)
-PNG 1/2/4/8-bit-per-channel (16 bpc not supported)
-
-TGA (not sure what subset, if a subset)
-BMP non-1bpp, non-RLE
-PSD (composited view only, no extra channels, 8/16 bit-per-channel)
-
-GIF (*comp always reports as 4-channel)
-HDR (radiance rgbE format)
-PIC (Softimage PIC)
-PNM (PPM and PGM binary only)
-
-Animated GIF still needs a proper API, but here's one way to do it:
-http://gist.github.com/urraka/685d9a6340b26b830d49
-
-- decode from memory or through FILE (define STBI_NO_STDIO to remove code)
-- decode from arbitrary I/O callbacks
-- SIMD acceleration on x86/x64 (SSE2) and ARM (NEON)
-
-Full documentation under "DOCUMENTATION" below.
+   You can #define STBI_ASSERT(x) before the #include to avoid using assert.h.
+   And #define STBI_MALLOC, STBI_REALLOC, and STBI_FREE to avoid using malloc,realloc,free
 
 
-Revision 2.00 release notes:
+   QUICK NOTES:
+      Primarily of interest to game developers and other people who can
+          avoid problematic images and only need the trivial interface
 
-- Progressive JPEG is now supported.
+      JPEG baseline & progressive (12 bpc/arithmetic not supported, same as stock IJG lib)
+      PNG 1/2/4/8/16-bit-per-channel
 
-- PPM and PGM binary formats are now supported, thanks to Ken Miller.
+      TGA (not sure what subset, if a subset)
+      BMP non-1bpp, non-RLE
+      PSD (composited view only, no extra channels, 8/16 bit-per-channel)
 
-- x86 platforms now make use of SSE2 SIMD instructions for
-JPEG decoding, and ARM platforms can use NEON SIMD if requested.
-This work was done by Fabian "ryg" Giesen. SSE2 is used by
-default, but NEON must be enabled explicitly; see docs.
+      GIF (*comp always reports as 4-channel)
+      HDR (radiance rgbE format)
+      PIC (Softimage PIC)
+      PNM (PPM and PGM binary only)
 
-With other JPEG optimizations included in this version, we see
-2x speedup on a JPEG on an x86 machine, and a 1.5x speedup
-on a JPEG on an ARM machine, relative to previous versions of this
-library. The same results will not obtain for all JPGs and for all
-x86/ARM machines. (Note that progressive JPEGs are significantly
-slower to decode than regular JPEGs.) This doesn't mean that this
-is the fastest JPEG decoder in the land; rather, it brings it
-closer to parity with standard libraries. If you want the fastest
-decode, look elsewhere. (See "Philosophy" section of docs below.)
+      Animated GIF still needs a proper API, but here's one way to do it:
+          http://gist.github.com/urraka/685d9a6340b26b830d49
 
-See final bullet items below for more info on SIMD.
+      - decode from memory or through FILE (define STBI_NO_STDIO to remove code)
+      - decode from arbitrary I/O callbacks
+      - SIMD acceleration on x86/x64 (SSE2) and ARM (NEON)
 
-- Added STBI_MALLOC, STBI_REALLOC, and STBI_FREE macros for replacing
-the memory allocator. Unlike other STBI libraries, these macros don't
-support a context parameter, so if you need to pass a context in to
-the allocator, you'll have to store it in a global or a thread-local
-variable.
-
-- Split existing STBI_NO_HDR flag into two flags, STBI_NO_HDR and
-STBI_NO_LINEAR.
-STBI_NO_HDR:     suppress implementation of .hdr reader format
-STBI_NO_LINEAR:  suppress high-dynamic-range light-linear float API
-
-- You can suppress implementation of any of the decoders to reduce
-your code footprint by #defining one or more of the following
-symbols before creating the implementation.
-
-STBI_NO_JPEG
-STBI_NO_PNG
-STBI_NO_BMP
-STBI_NO_PSD
-STBI_NO_TGA
-STBI_NO_GIF
-STBI_NO_HDR
-STBI_NO_PIC
-STBI_NO_PNM   (.ppm and .pgm)
-
-- You can request *only* certain decoders and suppress all other ones
-(this will be more forward-compatible, as addition of new decoders
-doesn't require you to disable them explicitly):
-
-STBI_ONLY_JPEG
-STBI_ONLY_PNG
-STBI_ONLY_BMP
-STBI_ONLY_PSD
-STBI_ONLY_TGA
-STBI_ONLY_GIF
-STBI_ONLY_HDR
-STBI_ONLY_PIC
-STBI_ONLY_PNM   (.ppm and .pgm)
-
-Note that you can define multiples of these, and you will get all
-of them ("only x" and "only y" is interpreted to mean "only x&y").
-
-- If you use STBI_NO_PNG (or _ONLY_ without PNG), and you still
-want the zlib decoder to be available, #define STBI_SUPPORT_ZLIB
-
-- Compilation of all SIMD code can be suppressed with
-#define STBI_NO_SIMD
-It should not be necessary to disable SIMD unless you have issues
-compiling (e.g. using an x86 compiler which doesn't support SSE
-intrinsics or that doesn't support the method used to detect
-SSE2 support at run-time), and even those can be reported as
-bugs so I can refine the built-in compile-time checking to be
-smarter.
-
-- The old STBI_SIMD system which allowed installing a user-defined
-IDCT etc. has been removed. If you need this, don't upgrade. My
-assumption is that almost nobody was doing this, and those who
-were will find the built-in SIMD more satisfactory anyway.
-
-- RGB values computed for JPEG images are slightly different from
-previous versions of stb_image. (This is due to using less
-integer precision in SIMD.) The C code has been adjusted so
-that the same RGB values will be computed regardless of whether
-SIMD support is available, so your app should always produce
-consistent results. But these results are slightly different from
-previous versions. (Specifically, about 3% of available YCbCr values
-will compute different RGB results from pre-1.49 versions by +-1;
-most of the deviating values are one smaller in the G channel.)
-
-- If you must produce consistent results with previous versions of
-stb_image, #define STBI_JPEG_OLD and you will get the same results
-you used to; however, you will not get the SIMD speedups for
-the YCbCr-to-RGB conversion step (although you should still see
-significant JPEG speedup from the other changes).
-
-Please note that STBI_JPEG_OLD is a temporary feature; it will be
-removed in future versions of the library. It is only intended for
-near-term back-compatibility use.
-
-
-Latest revision history:
-2.10  (2016-01-22) avoid warning introduced in 2.09
-2.09  (2016-01-16) 16-bit TGA; comments in PNM files; STBI_REALLOC_SIZED
-2.08  (2015-09-13) fix to 2.07 cleanup, reading RGB PSD as RGBA
-2.07  (2015-09-13) partial animated GIF support
-limited 16-bit PSD support
-minor bugs, code cleanup, and compiler warnings
-2.06  (2015-04-19) fix bug where PSD returns wrong '*comp' value
-2.05  (2015-04-19) fix bug in progressive JPEG handling, fix warning
-2.04  (2015-04-15) try to re-enable SIMD on MinGW 64-bit
-2.03  (2015-04-12) additional corruption checking
-stbi_set_flip_vertically_on_load
-fix NEON support; fix mingw support
-2.02  (2015-01-19) fix incorrect assert, fix warning
-2.01  (2015-01-17) fix various warnings
-2.00b (2014-12-25) fix STBI_MALLOC in progressive JPEG
-2.00  (2014-12-25) optimize JPEG, including x86 SSE2 & ARM NEON SIMD
-progressive JPEG
-PGM/PPM support
-STBI_MALLOC,STBI_REALLOC,STBI_FREE
-STBI_NO_*, STBI_ONLY_*
-GIF bugfix
-1.48  (2014-12-14) fix incorrectly-named assert()
-1.47  (2014-12-14) 1/2/4-bit PNG support (both grayscale and paletted)
-optimize PNG
-fix bug in interlaced PNG with user-specified channel count
-
-See end of file for full revision history.
-
-
-============================    Contributors    =========================
-
-Image formats                          Extensions, features
-Sean Barrett (jpeg, png, bmp)          Jetro Lauha (stbi_info)
-Nicolas Schulz (hdr, psd)              Martin "SpartanJ" Golini (stbi_info)
-Jonathan Dummer (tga)                  James "moose2000" Brown (iPhone PNG)
-Jean-Marc Lienher (gif)                Ben "Disch" Wenger (io callbacks)
-Tom Seddon (pic)                       Omar Cornut (1/2/4-bit PNG)
-Thatcher Ulrich (psd)                  Nicolas Guillemot (vertical flip)
-Ken Miller (pgm, ppm)                  Richard Mitton (16-bit PSD)
-urraka@github (animated gif)           Junggon Kim (PNM comments)
-Daniel Gibson (16-bit TGA)
-
-Optimizations & bugfixes
-Fabian "ryg" Giesen
-Arseny Kapoulkine
-
-Bug & warning fixes
-Marc LeBlanc            David Woo          Guillaume George   Martins Mozeiko
-Christpher Lloyd        Martin Golini      Jerry Jansson      Joseph Thomson
-Dave Moore              Roy Eltham         Hayaki Saito       Phil Jordan
-Won Chun                Luke Graham        Johan Duparc       Nathan Reed
-the Horde3D community   Thomas Ruf         Ronny Chevalier    Nick Verigakis
-Janez Zemva             John Bartholomew   Michal Cichon      svdijk@github
-Jonathan Blow           Ken Hamada         Tero Hanninen      Baldur Karlsson
-Laurent Gomila          Cort Stratton      Sergio Gonzalez    romigrou@github
-Aruelien Pocheville     Thibault Reuille   Cass Everitt
-Ryamond Barbiero        Paul Du Bois       Engin Manap
-Blazej Dariusz Roszkowski
-Michaelangel007@github
+   Full documentation under "DOCUMENTATION" below.
 
 
 LICENSE
 
-This software is in the public domain. Where that dedication is not
-recognized, you are granted a perpetual, irrevocable license to copy,
-distribute, and modify this file as you see fit.
+  See end of file for license information.
 
+RECENT REVISION HISTORY:
+
+      2.19  (2018-02-11) fix warning
+      2.18  (2018-01-30) fix warnings
+      2.17  (2018-01-29) bugfix, 1-bit BMP, 16-bitness query, fix warnings
+      2.16  (2017-07-23) all functions have 16-bit variants; optimizations; bugfixes
+      2.15  (2017-03-18) fix png-1,2,4; all Imagenet JPGs; no runtime SSE detection on GCC
+      2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
+      2.13  (2016-12-04) experimental 16-bit API, only for PNG so far; fixes
+      2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
+      2.11  (2016-04-02) 16-bit PNGS; enable SSE2 in non-gcc x64
+                         RGB-format JPEG; remove white matting in PSD;
+                         allocate large structures on the stack;
+                         correct channel count for PNG & BMP
+      2.10  (2016-01-22) avoid warning introduced in 2.09
+      2.09  (2016-01-16) 16-bit TGA; comments in PNM files; STBI_REALLOC_SIZED
+
+   See end of file for full revision history.
+
+
+ ============================    Contributors    =========================
+
+ Image formats                          Extensions, features
+    Sean Barrett (jpeg, png, bmp)          Jetro Lauha (stbi_info)
+    Nicolas Schulz (hdr, psd)              Martin "SpartanJ" Golini (stbi_info)
+    Jonathan Dummer (tga)                  James "moose2000" Brown (iPhone PNG)
+    Jean-Marc Lienher (gif)                Ben "Disch" Wenger (io callbacks)
+    Tom Seddon (pic)                       Omar Cornut (1/2/4-bit PNG)
+    Thatcher Ulrich (psd)                  Nicolas Guillemot (vertical flip)
+    Ken Miller (pgm, ppm)                  Richard Mitton (16-bit PSD)
+    github:urraka (animated gif)           Junggon Kim (PNM comments)
+    Christopher Forseth (animated gif)     Daniel Gibson (16-bit TGA)
+                                           socks-the-fox (16-bit PNG)
+                                           Jeremy Sawicki (handle all ImageNet JPGs)
+ Optimizations & bugfixes                  Mikhail Morozov (1-bit BMP)
+    Fabian "ryg" Giesen                    Anael Seghezzi (is-16-bit query)
+    Arseny Kapoulkine
+    John-Mark Allen
+
+ Bug & warning fixes
+    Marc LeBlanc            David Woo          Guillaume George   Martins Mozeiko
+    Christpher Lloyd        Jerry Jansson      Joseph Thomson     Phil Jordan
+    Dave Moore              Roy Eltham         Hayaki Saito       Nathan Reed
+    Won Chun                Luke Graham        Johan Duparc       Nick Verigakis
+    the Horde3D community   Thomas Ruf         Ronny Chevalier    github:rlyeh
+    Janez Zemva             John Bartholomew   Michal Cichon      github:romigrou
+    Jonathan Blow           Ken Hamada         Tero Hanninen      github:svdijk
+    Laurent Gomila          Cort Stratton      Sergio Gonzalez    github:snagar
+    Aruelien Pocheville     Thibault Reuille   Cass Everitt       github:Zelex
+    Ryamond Barbiero        Paul Du Bois       Engin Manap        github:grim210
+    Aldo Culquicondor       Philipp Wiesemann  Dale Weiler        github:sammyhw
+    Oriol Ferrer Mesia      Josh Tobin         Matthew Gregan     github:phprus
+    Julian Raschke          Gregory Mullen     Baldur Karlsson    github:poppolopoppo
+    Christian Floisand      Kevin Schmidt                         github:darealshinji
+    Blazej Dariusz Roszkowski                                     github:Michaelangel007
 */
 
 #ifndef STBI_INCLUDE_STB_IMAGE_H
@@ -221,10 +109,8 @@ distribute, and modify this file as you see fit.
 // DOCUMENTATION
 //
 // Limitations:
-//    - no 16-bit-per-channel PNG
 //    - no 12-bit-per-channel JPEG
 //    - no JPEGs with arithmetic coding
-//    - no 1-bit BMP
 //    - GIF always returns *comp=4
 //
 // Basic usage (see HDR discussion below for HDR usage):
@@ -237,10 +123,10 @@ distribute, and modify this file as you see fit.
 //    stbi_image_free(data)
 //
 // Standard parameters:
-//    int *x       -- outputs image width in pixels
-//    int *y       -- outputs image height in pixels
-//    int *comp    -- outputs # of image components in image file
-//    int req_comp -- if non-zero, # of image components requested in result
+//    int *x                 -- outputs image width in pixels
+//    int *y                 -- outputs image height in pixels
+//    int *channels_in_file  -- outputs # of image components in image file
+//    int desired_channels   -- if non-zero, # of image components requested in result
 //
 // The return value from an image loader is an 'unsigned char *' which points
 // to the pixel data, or NULL on an allocation failure or if the image is
@@ -248,11 +134,12 @@ distribute, and modify this file as you see fit.
 // with each pixel consisting of N interleaved 8-bit components; the first
 // pixel pointed to is top-left-most in the image. There is no padding between
 // image scanlines or between pixels, regardless of format. The number of
-// components N is 'req_comp' if req_comp is non-zero, or *comp otherwise.
-// If req_comp is non-zero, *comp has the number of components that _would_
-// have been output otherwise. E.g. if you set req_comp to 4, you will always
-// get RGBA output, but you can check *comp to see if it's trivially opaque
-// because e.g. there were only 3 channels in the source image.
+// components N is 'desired_channels' if desired_channels is non-zero, or
+// *channels_in_file otherwise. If desired_channels is non-zero,
+// *channels_in_file has the number of components that _would_ have been
+// output otherwise. E.g. if you set desired_channels to 4, you will always
+// get RGBA output, but you can check *channels_in_file to see if it's trivially
+// opaque because e.g. there were only 3 channels in the source image.
 //
 // An output image with N components has the following components interleaved
 // in this order in each pixel:
@@ -264,10 +151,10 @@ distribute, and modify this file as you see fit.
 //       4           red, green, blue, alpha
 //
 // If image loading fails for any reason, the return value will be NULL,
-// and *x, *y, *comp will be unchanged. The function stbi_failure_reason()
-// can be queried for an extremely brief, end-user unfriendly explanation
-// of why the load failed. Define STBI_NO_FAILURE_STRINGS to avoid
-// compiling these strings at all, and STBI_FAILURE_USERMSG to get slightly
+// and *x, *y, *channels_in_file will be unchanged. The function
+// stbi_failure_reason() can be queried for an extremely brief, end-user
+// unfriendly explanation of why the load failed. Define STBI_NO_FAILURE_STRINGS
+// to avoid compiling these strings at all, and STBI_FAILURE_USERMSG to get slightly
 // more user-friendly ones.
 //
 // Paletted PNG, BMP, GIF, and PIC images are automatically depalettized.
@@ -286,13 +173,13 @@ distribute, and modify this file as you see fit.
 // and for best performance I may provide less-easy-to-use APIs that give higher
 // performance, in addition to the easy to use ones. Nevertheless, it's important
 // to keep in mind that from the standpoint of you, a client of this library,
-// all you care about is #1 and #3, and stb libraries do not emphasize #3 above all.
+// all you care about is #1 and #3, and stb libraries DO NOT emphasize #3 above all.
 //
 // Some secondary priorities arise directly from the first two, some of which
 // make more explicit reasons why performance can't be emphasized.
 //
 //    - Portable ("ease of use")
-//    - Small footprint ("easy to maintain")
+//    - Small source code footprint ("easy to maintain")
 //    - No dependencies ("ease of use")
 //
 // ===========================================================================
@@ -323,13 +210,6 @@ distribute, and modify this file as you see fit.
 // the typical path is to have separate builds for NEON and non-NEON devices
 // (at least this is true for iOS and Android). Therefore, the NEON support is
 // toggled by a build flag: define STBI_NEON to get NEON loops.
-//
-// The output of the JPEG decoder is slightly different from versions where
-// SIMD support was introduced (that is, for versions before 1.49). The
-// difference is only +-1 in the 8-bit RGB channels, and only on a small
-// fraction of pixels. You can force the pre-1.49 behavior by defining
-// STBI_JPEG_OLD, but this will disable some of the SIMD decoding path
-// and hence cost some performance.
 //
 // If for some reason you do not want to use any of SIMD code, or if
 // you have issues compiling it, you can disable it entirely by
@@ -386,6 +266,41 @@ distribute, and modify this file as you see fit.
 // says there's premultiplied data (currently only happens in iPhone images,
 // and only if iPhone convert-to-rgb processing is on).
 //
+// ===========================================================================
+//
+// ADDITIONAL CONFIGURATION
+//
+//  - You can suppress implementation of any of the decoders to reduce
+//    your code footprint by #defining one or more of the following
+//    symbols before creating the implementation.
+//
+//        STBI_NO_JPEG
+//        STBI_NO_PNG
+//        STBI_NO_BMP
+//        STBI_NO_PSD
+//        STBI_NO_TGA
+//        STBI_NO_GIF
+//        STBI_NO_HDR
+//        STBI_NO_PIC
+//        STBI_NO_PNM   (.ppm and .pgm)
+//
+//  - You can request *only* certain decoders and suppress all other ones
+//    (this will be more forward-compatible, as addition of new decoders
+//    doesn't require you to disable them explicitly):
+//
+//        STBI_ONLY_JPEG
+//        STBI_ONLY_PNG
+//        STBI_ONLY_BMP
+//        STBI_ONLY_PSD
+//        STBI_ONLY_TGA
+//        STBI_ONLY_GIF
+//        STBI_ONLY_HDR
+//        STBI_ONLY_PIC
+//        STBI_ONLY_PNM   (.ppm and .pgm)
+//
+//   - If you use STBI_NO_PNG (or _ONLY_ without PNG), and you still
+//     want the zlib decoder to be available, #define STBI_SUPPORT_ZLIB
+//
 
 
 #ifndef STBI_NO_STDIO
@@ -396,15 +311,16 @@ distribute, and modify this file as you see fit.
 
 enum
 {
-	STBI_default = 0, // only used for req_comp
+   STBI_default = 0, // only used for desired_channels
 
-	STBI_grey = 1,
-	STBI_grey_alpha = 2,
-	STBI_rgb = 3,
-	STBI_rgb_alpha = 4
+   STBI_grey       = 1,
+   STBI_grey_alpha = 2,
+   STBI_rgb        = 3,
+   STBI_rgb_alpha  = 4
 };
 
 typedef unsigned char stbi_uc;
+typedef unsigned short stbi_us;
 
 #ifdef __cplusplus
 extern "C" {
@@ -416,100 +332,129 @@ extern "C" {
 #define STBIDEF extern
 #endif
 
-	//////////////////////////////////////////////////////////////////////////////
-	//
-	// PRIMARY API - works on images of any type
-	//
+//////////////////////////////////////////////////////////////////////////////
+//
+// PRIMARY API - works on images of any type
+//
 
-	//
-	// load image by filename, open file, or memory buffer
-	//
+//
+// load image by filename, open file, or memory buffer
+//
 
-	typedef struct
-	{
-		int(*read)  (void *user, char *data, int size);   // fill 'data' with 'size' bytes.  return number of bytes actually read
-		void(*skip)  (void *user, int n);                 // skip the next 'n' bytes, or 'unget' the last -n bytes if negative
-		int(*eof)   (void *user);                       // returns nonzero if we are at end of file/data
-	} stbi_io_callbacks;
+typedef struct
+{
+   int      (*read)  (void *user,char *data,int size);   // fill 'data' with 'size' bytes.  return number of bytes actually read
+   void     (*skip)  (void *user,int n);                 // skip the next 'n' bytes, or 'unget' the last -n bytes if negative
+   int      (*eof)   (void *user);                       // returns nonzero if we are at end of file/data
+} stbi_io_callbacks;
 
-	STBIDEF stbi_uc *stbi_load(char              const *filename, int *x, int *y, int *comp, int req_comp);
-	STBIDEF stbi_uc *stbi_load_from_memory(stbi_uc           const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-	STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp);
+////////////////////////////////////
+//
+// 8-bits-per-channel interface
+//
 
-#ifndef STBI_NO_STDIO
-	STBIDEF stbi_uc *stbi_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp);
-	// for stbi_load_from_file, file pointer is left pointing immediately after image
+STBIDEF stbi_uc *stbi_load_from_memory   (stbi_uc           const *buffer, int len   , int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk  , void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+#ifndef STBI_NO_GIF
+STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
 #endif
 
+
+#ifndef STBI_NO_STDIO
+STBIDEF stbi_uc *stbi_load            (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc *stbi_load_from_file  (FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+// for stbi_load_from_file, file pointer is left pointing immediately after image
+#endif
+
+////////////////////////////////////
+//
+// 16-bits-per-channel interface
+//
+
+STBIDEF stbi_us *stbi_load_16_from_memory   (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+
+#ifndef STBI_NO_STDIO
+STBIDEF stbi_us *stbi_load_16          (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us *stbi_load_from_file_16(FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+#endif
+
+////////////////////////////////////
+//
+// float-per-channel interface
+//
 #ifndef STBI_NO_LINEAR
-	STBIDEF float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp);
-	STBIDEF float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp);
-	STBIDEF float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp);
+   STBIDEF float *stbi_loadf_from_memory     (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
+   STBIDEF float *stbi_loadf_from_callbacks  (stbi_io_callbacks const *clbk, void *user, int *x, int *y,  int *channels_in_file, int desired_channels);
 
-#ifndef STBI_NO_STDIO
-	STBIDEF float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *comp, int req_comp);
-#endif
+   #ifndef STBI_NO_STDIO
+   STBIDEF float *stbi_loadf            (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+   STBIDEF float *stbi_loadf_from_file  (FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+   #endif
 #endif
 
 #ifndef STBI_NO_HDR
-	STBIDEF void   stbi_hdr_to_ldr_gamma(float gamma);
-	STBIDEF void   stbi_hdr_to_ldr_scale(float scale);
+   STBIDEF void   stbi_hdr_to_ldr_gamma(float gamma);
+   STBIDEF void   stbi_hdr_to_ldr_scale(float scale);
 #endif // STBI_NO_HDR
 
 #ifndef STBI_NO_LINEAR
-	STBIDEF void   stbi_ldr_to_hdr_gamma(float gamma);
-	STBIDEF void   stbi_ldr_to_hdr_scale(float scale);
+   STBIDEF void   stbi_ldr_to_hdr_gamma(float gamma);
+   STBIDEF void   stbi_ldr_to_hdr_scale(float scale);
 #endif // STBI_NO_LINEAR
 
-	// stbi_is_hdr is always defined, but always returns false if STBI_NO_HDR
-	STBIDEF int    stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user);
-	STBIDEF int    stbi_is_hdr_from_memory(stbi_uc const *buffer, int len);
+// stbi_is_hdr is always defined, but always returns false if STBI_NO_HDR
+STBIDEF int    stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user);
+STBIDEF int    stbi_is_hdr_from_memory(stbi_uc const *buffer, int len);
 #ifndef STBI_NO_STDIO
-	STBIDEF int      stbi_is_hdr(char const *filename);
-	STBIDEF int      stbi_is_hdr_from_file(FILE *f);
+STBIDEF int      stbi_is_hdr          (char const *filename);
+STBIDEF int      stbi_is_hdr_from_file(FILE *f);
 #endif // STBI_NO_STDIO
 
 
-	// get a VERY brief reason for failure
-	// NOT THREADSAFE
-	STBIDEF const char *stbi_failure_reason(void);
+// get a VERY brief reason for failure
+// NOT THREADSAFE
+STBIDEF const char *stbi_failure_reason  (void);
 
-	// free the loaded image -- this is just free()
-	STBIDEF void     stbi_image_free(void *retval_from_stbi_load);
+// free the loaded image -- this is just free()
+STBIDEF void     stbi_image_free      (void *retval_from_stbi_load);
 
-	// get image dimensions & components without fully decoding
-	STBIDEF int      stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
-	STBIDEF int      stbi_info_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp);
+// get image dimensions & components without fully decoding
+STBIDEF int      stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
+STBIDEF int      stbi_info_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp);
+STBIDEF int      stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len);
+STBIDEF int      stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *clbk, void *user);
 
 #ifndef STBI_NO_STDIO
-	STBIDEF int      stbi_info(char const *filename, int *x, int *y, int *comp);
-	STBIDEF int      stbi_info_from_file(FILE *f, int *x, int *y, int *comp);
-
+STBIDEF int      stbi_info               (char const *filename,     int *x, int *y, int *comp);
+STBIDEF int      stbi_info_from_file     (FILE *f,                  int *x, int *y, int *comp);
+STBIDEF int      stbi_is_16_bit          (char const *filename);
+STBIDEF int      stbi_is_16_bit_from_file(FILE *f);
 #endif
 
 
 
-	// for image formats that explicitly notate that they have premultiplied alpha,
-	// we just return the colors as stored in the file. set this flag to force
-	// unpremultiplication. results are undefined if the unpremultiply overflow.
-	STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply);
+// for image formats that explicitly notate that they have premultiplied alpha,
+// we just return the colors as stored in the file. set this flag to force
+// unpremultiplication. results are undefined if the unpremultiply overflow.
+STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply);
 
-	// indicate whether we should process iphone images back to canonical format,
-	// or just pass them through "as-is"
-	STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert);
+// indicate whether we should process iphone images back to canonical format,
+// or just pass them through "as-is"
+STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert);
 
-	// flip the image vertically, so the first pixel in the output array is the bottom left
-	STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip);
+// flip the image vertically, so the first pixel in the output array is the bottom left
+STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip);
 
-	// ZLIB client - used by PNG, available for other purposes
+// ZLIB client - used by PNG, available for other purposes
 
-	STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen);
-	STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header);
-	STBIDEF char *stbi_zlib_decode_malloc(const char *buffer, int len, int *outlen);
-	STBIDEF int   stbi_zlib_decode_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
+STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen);
+STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header);
+STBIDEF char *stbi_zlib_decode_malloc(const char *buffer, int len, int *outlen);
+STBIDEF int   stbi_zlib_decode_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
 
-	STBIDEF char *stbi_zlib_decode_noheader_malloc(const char *buffer, int len, int *outlen);
-	STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
+STBIDEF char *stbi_zlib_decode_noheader_malloc(const char *buffer, int len, int *outlen);
+STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
 
 
 #ifdef __cplusplus
@@ -527,33 +472,33 @@ extern "C" {
   || defined(STBI_ONLY_TGA) || defined(STBI_ONLY_GIF) || defined(STBI_ONLY_PSD) \
   || defined(STBI_ONLY_HDR) || defined(STBI_ONLY_PIC) || defined(STBI_ONLY_PNM) \
   || defined(STBI_ONLY_ZLIB)
-#ifndef STBI_ONLY_JPEG
-#define STBI_NO_JPEG
-#endif
-#ifndef STBI_ONLY_PNG
-#define STBI_NO_PNG
-#endif
-#ifndef STBI_ONLY_BMP
-#define STBI_NO_BMP
-#endif
-#ifndef STBI_ONLY_PSD
-#define STBI_NO_PSD
-#endif
-#ifndef STBI_ONLY_TGA
-#define STBI_NO_TGA
-#endif
-#ifndef STBI_ONLY_GIF
-#define STBI_NO_GIF
-#endif
-#ifndef STBI_ONLY_HDR
-#define STBI_NO_HDR
-#endif
-#ifndef STBI_ONLY_PIC
-#define STBI_NO_PIC
-#endif
-#ifndef STBI_ONLY_PNM
-#define STBI_NO_PNM
-#endif
+   #ifndef STBI_ONLY_JPEG
+   #define STBI_NO_JPEG
+   #endif
+   #ifndef STBI_ONLY_PNG
+   #define STBI_NO_PNG
+   #endif
+   #ifndef STBI_ONLY_BMP
+   #define STBI_NO_BMP
+   #endif
+   #ifndef STBI_ONLY_PSD
+   #define STBI_NO_PSD
+   #endif
+   #ifndef STBI_ONLY_TGA
+   #define STBI_NO_TGA
+   #endif
+   #ifndef STBI_ONLY_GIF
+   #define STBI_NO_GIF
+   #endif
+   #ifndef STBI_ONLY_HDR
+   #define STBI_NO_HDR
+   #endif
+   #ifndef STBI_ONLY_PIC
+   #define STBI_NO_PIC
+   #endif
+   #ifndef STBI_ONLY_PNM
+   #define STBI_NO_PNM
+   #endif
 #endif
 
 #if defined(STBI_NO_PNG) && !defined(STBI_SUPPORT_ZLIB) && !defined(STBI_NO_ZLIB)
@@ -565,9 +510,10 @@ extern "C" {
 #include <stddef.h> // ptrdiff_t on osx
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
-#include <math.h>  // ldexp
+#include <math.h>  // ldexp, pow
 #endif
 
 #ifndef STBI_NO_STDIO
@@ -581,13 +527,13 @@ extern "C" {
 
 
 #ifndef _MSC_VER
-#ifdef __cplusplus
-#define stbi_inline inline
+   #ifdef __cplusplus
+   #define stbi_inline inline
+   #else
+   #define stbi_inline
+   #endif
 #else
-#define stbi_inline
-#endif
-#else
-#define stbi_inline __forceinline
+   #define stbi_inline __forceinline
 #endif
 
 
@@ -605,7 +551,7 @@ typedef int32_t  stbi__int32;
 #endif
 
 // should produce compiler error if size is wrong
-typedef unsigned char validate_uint32[sizeof(stbi__uint32) == 4 ? 1 : -1];
+typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
 
 #ifdef _MSC_VER
 #define STBI_NOTUSED(v)  (void)(v)
@@ -618,9 +564,9 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32) == 4 ? 1 : -1];
 #endif
 
 #ifdef STBI_HAS_LROTL
-#define stbi_lrot(x,y)  _lrotl(x,y)
+   #define stbi_lrot(x,y)  _lrotl(x,y)
 #else
-#define stbi_lrot(x,y)  (((x) << (y)) | ((x) >> (32 - (y))))
+   #define stbi_lrot(x,y)  (((x) << (y)) | ((x) >> (32 - (y))))
 #endif
 
 #if defined(STBI_MALLOC) && defined(STBI_FREE) && (defined(STBI_REALLOC) || defined(STBI_REALLOC_SIZED))
@@ -648,12 +594,14 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32) == 4 ? 1 : -1];
 #define STBI__X86_TARGET
 #endif
 
-#if defined(__GNUC__) && (defined(STBI__X86_TARGET) || defined(STBI__X64_TARGET)) && !defined(__SSE2__) && !defined(STBI_NO_SIMD)
-// NOTE: not clear do we actually need this for the 64-bit path?
+#if defined(__GNUC__) && defined(STBI__X86_TARGET) && !defined(__SSE2__) && !defined(STBI_NO_SIMD)
 // gcc doesn't support sse2 intrinsics unless you compile with -msse2,
-// (but compiling with -msse2 allows the compiler to use SSE2 everywhere;
-// this is just broken and gcc are jerks for not fixing it properly
-// http://www.virtualdub.org/blog/pivot/entry.php?id=363 )
+// which in turn means it gets to use SSE2 everywhere. This is unfortunate,
+// but previous attempts to provide the SSE2 functions with runtime
+// detection caused numerous issues. The way architecture extensions are
+// exposed in GCC/Clang is, sadly, not really suited for one-file libs.
+// New behavior: if compiled with -msse2, we use SSE2 without any
+// detection; if not, we don't use it at all.
 #define STBI_NO_SIMD
 #endif
 
@@ -672,7 +620,7 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32) == 4 ? 1 : -1];
 #define STBI_NO_SIMD
 #endif
 
-#if !defined(STBI_NO_SIMD) && defined(STBI__X86_TARGET)
+#if !defined(STBI_NO_SIMD) && (defined(STBI__X86_TARGET) || defined(STBI__X64_TARGET))
 #define STBI_SSE2
 #include <emmintrin.h>
 
@@ -682,43 +630,39 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32) == 4 ? 1 : -1];
 #include <intrin.h> // __cpuid
 static int stbi__cpuid3(void)
 {
-	int info[4];
-	__cpuid(info, 1);
-	return info[3];
+   int info[4];
+   __cpuid(info,1);
+   return info[3];
 }
 #else
 static int stbi__cpuid3(void)
 {
-	int res;
-	__asm {
-		mov  eax, 1
-			cpuid
-			mov  res, edx
-	}
-	return res;
+   int res;
+   __asm {
+      mov  eax,1
+      cpuid
+      mov  res,edx
+   }
+   return res;
 }
 #endif
 
 #define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
 
-static int stbi__sse2_available()
+static int stbi__sse2_available(void)
 {
-	int info3 = stbi__cpuid3();
-	return ((info3 >> 26) & 1) != 0;
+   int info3 = stbi__cpuid3();
+   return ((info3 >> 26) & 1) != 0;
 }
 #else // assume GCC-style if not VC++
 #define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
 
-static int stbi__sse2_available()
+static int stbi__sse2_available(void)
 {
-#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 // GCC 4.8 or later
-	// GCC 4.8+ has a nice way to do this
-	return __builtin_cpu_supports("sse2");
-#else
-	// portable way to do this, preferably without using GCC inline ASM?
-	// just bail for now.
-	return 0;
-#endif
+   // If we're even attempting to compile this on GCC/Clang, that means
+   // -msse2 is on, which means the compiler is allowed to use SSE2
+   // instructions at will, and so are we.
+   return 1;
 }
 #endif
 #endif
@@ -746,18 +690,18 @@ static int stbi__sse2_available()
 // contains all the IO context, plus some basic image information
 typedef struct
 {
-	stbi__uint32 img_x, img_y;
-	int img_n, img_out_n;
+   stbi__uint32 img_x, img_y;
+   int img_n, img_out_n;
 
-	stbi_io_callbacks io;
-	void *io_user_data;
+   stbi_io_callbacks io;
+   void *io_user_data;
 
-	int read_from_callbacks;
-	int buflen;
-	stbi_uc buffer_start[128];
+   int read_from_callbacks;
+   int buflen;
+   stbi_uc buffer_start[128];
 
-	stbi_uc *img_buffer, *img_buffer_end;
-	stbi_uc *img_buffer_original, *img_buffer_original_end;
+   stbi_uc *img_buffer, *img_buffer_end;
+   stbi_uc *img_buffer_original, *img_buffer_original_end;
 } stbi__context;
 
 
@@ -766,51 +710,51 @@ static void stbi__refill_buffer(stbi__context *s);
 // initialize a memory-decode context
 static void stbi__start_mem(stbi__context *s, stbi_uc const *buffer, int len)
 {
-	s->io.read = NULL;
-	s->read_from_callbacks = 0;
-	s->img_buffer = s->img_buffer_original = (stbi_uc *)buffer;
-	s->img_buffer_end = s->img_buffer_original_end = (stbi_uc *)buffer + len;
+   s->io.read = NULL;
+   s->read_from_callbacks = 0;
+   s->img_buffer = s->img_buffer_original = (stbi_uc *) buffer;
+   s->img_buffer_end = s->img_buffer_original_end = (stbi_uc *) buffer+len;
 }
 
 // initialize a callback-based context
 static void stbi__start_callbacks(stbi__context *s, stbi_io_callbacks *c, void *user)
 {
-	s->io = *c;
-	s->io_user_data = user;
-	s->buflen = sizeof(s->buffer_start);
-	s->read_from_callbacks = 1;
-	s->img_buffer_original = s->buffer_start;
-	stbi__refill_buffer(s);
-	s->img_buffer_original_end = s->img_buffer_end;
+   s->io = *c;
+   s->io_user_data = user;
+   s->buflen = sizeof(s->buffer_start);
+   s->read_from_callbacks = 1;
+   s->img_buffer_original = s->buffer_start;
+   stbi__refill_buffer(s);
+   s->img_buffer_original_end = s->img_buffer_end;
 }
 
 #ifndef STBI_NO_STDIO
 
 static int stbi__stdio_read(void *user, char *data, int size)
 {
-	return (int)fread(data, 1, size, (FILE*)user);
+   return (int) fread(data,1,size,(FILE*) user);
 }
 
 static void stbi__stdio_skip(void *user, int n)
 {
-	fseek((FILE*)user, n, SEEK_CUR);
+   fseek((FILE*) user, n, SEEK_CUR);
 }
 
 static int stbi__stdio_eof(void *user)
 {
-	return feof((FILE*)user);
+   return feof((FILE*) user);
 }
 
 static stbi_io_callbacks stbi__stdio_callbacks =
 {
-	stbi__stdio_read,
-	stbi__stdio_skip,
-	stbi__stdio_eof,
+   stbi__stdio_read,
+   stbi__stdio_skip,
+   stbi__stdio_eof,
 };
 
 static void stbi__start_file(stbi__context *s, FILE *f)
 {
-	stbi__start_callbacks(s, &stbi__stdio_callbacks, (void *)f);
+   stbi__start_callbacks(s, &stbi__stdio_callbacks, (void *) f);
 }
 
 //static void stop_file(stbi__context *s) { }
@@ -819,64 +763,80 @@ static void stbi__start_file(stbi__context *s, FILE *f)
 
 static void stbi__rewind(stbi__context *s)
 {
-	// conceptually rewind SHOULD rewind to the beginning of the stream,
-	// but we just rewind to the beginning of the initial buffer, because
-	// we only use it after doing 'test', which only ever looks at at most 92 bytes
-	s->img_buffer = s->img_buffer_original;
-	s->img_buffer_end = s->img_buffer_original_end;
+   // conceptually rewind SHOULD rewind to the beginning of the stream,
+   // but we just rewind to the beginning of the initial buffer, because
+   // we only use it after doing 'test', which only ever looks at at most 92 bytes
+   s->img_buffer = s->img_buffer_original;
+   s->img_buffer_end = s->img_buffer_original_end;
 }
+
+enum
+{
+   STBI_ORDER_RGB,
+   STBI_ORDER_BGR
+};
+
+typedef struct
+{
+   int bits_per_channel;
+   int num_channels;
+   int channel_order;
+} stbi__result_info;
 
 #ifndef STBI_NO_JPEG
 static int      stbi__jpeg_test(stbi__context *s);
-static stbi_uc *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_PNG
 static int      stbi__png_test(stbi__context *s);
-static stbi_uc *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__png_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__png_is16(stbi__context *s);
 #endif
 
 #ifndef STBI_NO_BMP
 static int      stbi__bmp_test(stbi__context *s);
-static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_TGA
 static int      stbi__tga_test(stbi__context *s);
-static stbi_uc *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__tga_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_PSD
 static int      stbi__psd_test(stbi__context *s);
-static stbi_uc *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc);
 static int      stbi__psd_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__psd_is16(stbi__context *s);
 #endif
 
 #ifndef STBI_NO_HDR
 static int      stbi__hdr_test(stbi__context *s);
-static float   *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static float   *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_PIC
 static int      stbi__pic_test(stbi__context *s);
-static stbi_uc *stbi__pic_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__pic_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__pic_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_GIF
 static int      stbi__gif_test(stbi__context *s);
-static stbi_uc *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static void    *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
 static int      stbi__gif_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
 #ifndef STBI_NO_PNM
 static int      stbi__pnm_test(stbi__context *s);
-static stbi_uc *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp);
+static void    *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
 static int      stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp);
 #endif
 
@@ -885,30 +845,105 @@ static const char *stbi__g_failure_reason;
 
 STBIDEF const char *stbi_failure_reason(void)
 {
-	return stbi__g_failure_reason;
+   return stbi__g_failure_reason;
 }
 
 static int stbi__err(const char *str)
 {
-	stbi__g_failure_reason = str;
-	return 0;
+   stbi__g_failure_reason = str;
+   return 0;
 }
 
 static void *stbi__malloc(size_t size)
 {
-	return STBI_MALLOC(size);
+    return STBI_MALLOC(size);
 }
+
+// stb_image uses ints pervasively, including for offset calculations.
+// therefore the largest decoded image size we can support with the
+// current code, even on 64-bit targets, is INT_MAX. this is not a
+// significant limitation for the intended use case.
+//
+// we do, however, need to make sure our size calculations don't
+// overflow. hence a few helper functions for size calculations that
+// multiply integers together, making sure that they're non-negative
+// and no overflow occurs.
+
+// return 1 if the sum is valid, 0 on overflow.
+// negative terms are considered invalid.
+static int stbi__addsizes_valid(int a, int b)
+{
+   if (b < 0) return 0;
+   // now 0 <= b <= INT_MAX, hence also
+   // 0 <= INT_MAX - b <= INTMAX.
+   // And "a + b <= INT_MAX" (which might overflow) is the
+   // same as a <= INT_MAX - b (no overflow)
+   return a <= INT_MAX - b;
+}
+
+// returns 1 if the product is valid, 0 on overflow.
+// negative factors are considered invalid.
+static int stbi__mul2sizes_valid(int a, int b)
+{
+   if (a < 0 || b < 0) return 0;
+   if (b == 0) return 1; // mul-by-0 is always safe
+   // portable way to check for no overflows in a*b
+   return a <= INT_MAX/b;
+}
+
+// returns 1 if "a*b + add" has no negative terms/factors and doesn't overflow
+static int stbi__mad2sizes_valid(int a, int b, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__addsizes_valid(a*b, add);
+}
+
+// returns 1 if "a*b*c + add" has no negative terms/factors and doesn't overflow
+static int stbi__mad3sizes_valid(int a, int b, int c, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
+      stbi__addsizes_valid(a*b*c, add);
+}
+
+// returns 1 if "a*b*c*d + add" has no negative terms/factors and doesn't overflow
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
+static int stbi__mad4sizes_valid(int a, int b, int c, int d, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
+      stbi__mul2sizes_valid(a*b*c, d) && stbi__addsizes_valid(a*b*c*d, add);
+}
+#endif
+
+// mallocs with size overflow checking
+static void *stbi__malloc_mad2(int a, int b, int add)
+{
+   if (!stbi__mad2sizes_valid(a, b, add)) return NULL;
+   return stbi__malloc(a*b + add);
+}
+
+static void *stbi__malloc_mad3(int a, int b, int c, int add)
+{
+   if (!stbi__mad3sizes_valid(a, b, c, add)) return NULL;
+   return stbi__malloc(a*b*c + add);
+}
+
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
+static void *stbi__malloc_mad4(int a, int b, int c, int d, int add)
+{
+   if (!stbi__mad4sizes_valid(a, b, c, d, add)) return NULL;
+   return stbi__malloc(a*b*c*d + add);
+}
+#endif
 
 // stbi__err - error
 // stbi__errpf - error returning pointer to float
 // stbi__errpuc - error returning pointer to unsigned char
 
 #ifdef STBI_NO_FAILURE_STRINGS
-#define stbi__err(x,y)  0
+   #define stbi__err(x,y)  0
 #elif defined(STBI_FAILURE_USERMSG)
-#define stbi__err(x,y)  stbi__err(y)
+   #define stbi__err(x,y)  stbi__err(y)
 #else
-#define stbi__err(x,y)  stbi__err(x)
+   #define stbi__err(x,y)  stbi__err(x)
 #endif
 
 #define stbi__errpf(x,y)   ((float *)(size_t) (stbi__err(x,y)?NULL:NULL))
@@ -916,7 +951,7 @@ static void *stbi__malloc(size_t size)
 
 STBIDEF void stbi_image_free(void *retval_from_stbi_load)
 {
-	STBI_FREE(retval_from_stbi_load);
+   STBI_FREE(retval_from_stbi_load);
 }
 
 #ifndef STBI_NO_LINEAR
@@ -931,94 +966,178 @@ static int stbi__vertically_flip_on_load = 0;
 
 STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip)
 {
-	stbi__vertically_flip_on_load = flag_true_if_should_flip;
+    stbi__vertically_flip_on_load = flag_true_if_should_flip;
 }
 
-static unsigned char *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
 {
-#ifndef STBI_NO_JPEG
-	if (stbi__jpeg_test(s)) return stbi__jpeg_load(s, x, y, comp, req_comp);
-#endif
-#ifndef STBI_NO_PNG
-	if (stbi__png_test(s))  return stbi__png_load(s, x, y, comp, req_comp);
-#endif
-#ifndef STBI_NO_BMP
-	if (stbi__bmp_test(s))  return stbi__bmp_load(s, x, y, comp, req_comp);
-#endif
-#ifndef STBI_NO_GIF
-	if (stbi__gif_test(s))  return stbi__gif_load(s, x, y, comp, req_comp);
-#endif
-#ifndef STBI_NO_PSD
-	if (stbi__psd_test(s))  return stbi__psd_load(s, x, y, comp, req_comp);
-#endif
-#ifndef STBI_NO_PIC
-	if (stbi__pic_test(s))  return stbi__pic_load(s, x, y, comp, req_comp);
-#endif
-#ifndef STBI_NO_PNM
-	if (stbi__pnm_test(s))  return stbi__pnm_load(s, x, y, comp, req_comp);
-#endif
+   memset(ri, 0, sizeof(*ri)); // make sure it's initialized if we add new fields
+   ri->bits_per_channel = 8; // default is 8 so most paths don't have to be changed
+   ri->channel_order = STBI_ORDER_RGB; // all current input & output are this, but this is here so we can add BGR order
+   ri->num_channels = 0;
 
-#ifndef STBI_NO_HDR
-	if (stbi__hdr_test(s)) {
-		float *hdr = stbi__hdr_load(s, x, y, comp, req_comp);
-		return stbi__hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
-	}
-#endif
+   #ifndef STBI_NO_JPEG
+   if (stbi__jpeg_test(s)) return stbi__jpeg_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_PNG
+   if (stbi__png_test(s))  return stbi__png_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_BMP
+   if (stbi__bmp_test(s))  return stbi__bmp_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_GIF
+   if (stbi__gif_test(s))  return stbi__gif_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_test(s))  return stbi__psd_load(s,x,y,comp,req_comp, ri, bpc);
+   #endif
+   #ifndef STBI_NO_PIC
+   if (stbi__pic_test(s))  return stbi__pic_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_PNM
+   if (stbi__pnm_test(s))  return stbi__pnm_load(s,x,y,comp,req_comp, ri);
+   #endif
 
-#ifndef STBI_NO_TGA
-	// test tga last because it's a crappy test!
-	if (stbi__tga_test(s))
-		return stbi__tga_load(s, x, y, comp, req_comp);
-#endif
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_test(s)) {
+      float *hdr = stbi__hdr_load(s, x,y,comp,req_comp, ri);
+      return stbi__hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
+   }
+   #endif
 
-	return stbi__errpuc("unknown image type", "Image not of any known type, or corrupt");
+   #ifndef STBI_NO_TGA
+   // test tga last because it's a crappy test!
+   if (stbi__tga_test(s))
+      return stbi__tga_load(s,x,y,comp,req_comp, ri);
+   #endif
+
+   return stbi__errpuc("unknown image type", "Image not of any known type, or corrupt");
 }
 
-static unsigned char *stbi__load_flip(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static stbi_uc *stbi__convert_16_to_8(stbi__uint16 *orig, int w, int h, int channels)
 {
-	unsigned char *result = stbi__load_main(s, x, y, comp, req_comp);
+   int i;
+   int img_len = w * h * channels;
+   stbi_uc *reduced;
 
-	if (stbi__vertically_flip_on_load && result != NULL) {
-		int w = *x, h = *y;
-		int depth = req_comp ? req_comp : *comp;
-		int row, col, z;
-		stbi_uc temp;
+   reduced = (stbi_uc *) stbi__malloc(img_len);
+   if (reduced == NULL) return stbi__errpuc("outofmem", "Out of memory");
 
-		// @OPTIMIZE: use a bigger temp buffer and memcpy multiple pixels at once
-		for (row = 0; row < (h >> 1); row++) {
-			for (col = 0; col < w; col++) {
-				for (z = 0; z < depth; z++) {
-					temp = result[(row * w + col) * depth + z];
-					result[(row * w + col) * depth + z] = result[((h - row - 1) * w + col) * depth + z];
-					result[((h - row - 1) * w + col) * depth + z] = temp;
-				}
-			}
-		}
-	}
+   for (i = 0; i < img_len; ++i)
+      reduced[i] = (stbi_uc)((orig[i] >> 8) & 0xFF); // top half of each byte is sufficient approx of 16->8 bit scaling
 
-	return result;
+   STBI_FREE(orig);
+   return reduced;
 }
 
-#ifndef STBI_NO_HDR
+static stbi__uint16 *stbi__convert_8_to_16(stbi_uc *orig, int w, int h, int channels)
+{
+   int i;
+   int img_len = w * h * channels;
+   stbi__uint16 *enlarged;
+
+   enlarged = (stbi__uint16 *) stbi__malloc(img_len*2);
+   if (enlarged == NULL) return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+
+   for (i = 0; i < img_len; ++i)
+      enlarged[i] = (stbi__uint16)((orig[i] << 8) + orig[i]); // replicate to high and low byte, maps 0->0, 255->0xffff
+
+   STBI_FREE(orig);
+   return enlarged;
+}
+
+static void stbi__vertical_flip(void *image, int w, int h, int bytes_per_pixel)
+{
+   int row;
+   size_t bytes_per_row = (size_t)w * bytes_per_pixel;
+   stbi_uc temp[2048];
+   stbi_uc *bytes = (stbi_uc *)image;
+
+   for (row = 0; row < (h>>1); row++) {
+      stbi_uc *row0 = bytes + row*bytes_per_row;
+      stbi_uc *row1 = bytes + (h - row - 1)*bytes_per_row;
+      // swap row0 with row1
+      size_t bytes_left = bytes_per_row;
+      while (bytes_left) {
+         size_t bytes_copy = (bytes_left < sizeof(temp)) ? bytes_left : sizeof(temp);
+         memcpy(temp, row0, bytes_copy);
+         memcpy(row0, row1, bytes_copy);
+         memcpy(row1, temp, bytes_copy);
+         row0 += bytes_copy;
+         row1 += bytes_copy;
+         bytes_left -= bytes_copy;
+      }
+   }
+}
+
+static void stbi__vertical_flip_slices(void *image, int w, int h, int z, int bytes_per_pixel)
+{
+   int slice;
+   int slice_size = w * h * bytes_per_pixel;
+
+   stbi_uc *bytes = (stbi_uc *)image;
+   for (slice = 0; slice < z; ++slice) {
+      stbi__vertical_flip(bytes, w, h, bytes_per_pixel); 
+      bytes += slice_size; 
+   }
+}
+
+static unsigned char *stbi__load_and_postprocess_8bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__result_info ri;
+   void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 8);
+
+   if (result == NULL)
+      return NULL;
+
+   if (ri.bits_per_channel != 8) {
+      STBI_ASSERT(ri.bits_per_channel == 16);
+      result = stbi__convert_16_to_8((stbi__uint16 *) result, *x, *y, req_comp == 0 ? *comp : req_comp);
+      ri.bits_per_channel = 8;
+   }
+
+   // @TODO: move stbi__convert_format to here
+
+   if (stbi__vertically_flip_on_load) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi_uc));
+   }
+
+   return (unsigned char *) result;
+}
+
+static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__result_info ri;
+   void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 16);
+
+   if (result == NULL)
+      return NULL;
+
+   if (ri.bits_per_channel != 16) {
+      STBI_ASSERT(ri.bits_per_channel == 8);
+      result = stbi__convert_8_to_16((stbi_uc *) result, *x, *y, req_comp == 0 ? *comp : req_comp);
+      ri.bits_per_channel = 16;
+   }
+
+   // @TODO: move stbi__convert_format16 to here
+   // @TODO: special case RGB-to-Y (and RGBA-to-YA) for 8-bit-to-16-bit case to keep more precision
+
+   if (stbi__vertically_flip_on_load) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi__uint16));
+   }
+
+   return (stbi__uint16 *) result;
+}
+
+#if !defined(STBI_NO_HDR) || !defined(STBI_NO_LINEAR)
 static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, int req_comp)
 {
-	if (stbi__vertically_flip_on_load && result != NULL) {
-		int w = *x, h = *y;
-		int depth = req_comp ? req_comp : *comp;
-		int row, col, z;
-		float temp;
-
-		// @OPTIMIZE: use a bigger temp buffer and memcpy multiple pixels at once
-		for (row = 0; row < (h >> 1); row++) {
-			for (col = 0; col < w; col++) {
-				for (z = 0; z < depth; z++) {
-					temp = result[(row * w + col) * depth + z];
-					result[(row * w + col) * depth + z] = result[((h - row - 1) * w + col) * depth + z];
-					result[((h - row - 1) * w + col) * depth + z] = temp;
-				}
-			}
-		}
-	}
+   if (stbi__vertically_flip_on_load && result != NULL) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(float));
+   }
 }
 #endif
 
@@ -1026,103 +1145,159 @@ static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, in
 
 static FILE *stbi__fopen(char const *filename, char const *mode)
 {
-	FILE *f;
+   FILE *f;
 #if defined(_MSC_VER) && _MSC_VER >= 1400
-	if (0 != fopen_s(&f, filename, mode))
-		f = 0;
+   if (0 != fopen_s(&f, filename, mode))
+      f=0;
 #else
-	f = fopen(filename, mode);
+   f = fopen(filename, mode);
 #endif
-	return f;
+   return f;
 }
 
 
 STBIDEF stbi_uc *stbi_load(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
-	FILE *f = stbi__fopen(filename, "rb");
-	unsigned char *result;
-	if (!f) return stbi__errpuc("can't fopen", "Unable to open file");
-	result = stbi_load_from_file(f, x, y, comp, req_comp);
-	fclose(f);
-	return result;
+   FILE *f = stbi__fopen(filename, "rb");
+   unsigned char *result;
+   if (!f) return stbi__errpuc("can't fopen", "Unable to open file");
+   result = stbi_load_from_file(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
 }
 
 STBIDEF stbi_uc *stbi_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
 {
-	unsigned char *result;
-	stbi__context s;
-	stbi__start_file(&s, f);
-	result = stbi__load_flip(&s, x, y, comp, req_comp);
-	if (result) {
-		// need to 'unget' all the characters in the IO buffer
-		fseek(f, -(int)(s.img_buffer_end - s.img_buffer), SEEK_CUR);
-	}
-	return result;
+   unsigned char *result;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   result = stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
+   if (result) {
+      // need to 'unget' all the characters in the IO buffer
+      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+   }
+   return result;
 }
+
+STBIDEF stbi__uint16 *stbi_load_from_file_16(FILE *f, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__uint16 *result;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   result = stbi__load_and_postprocess_16bit(&s,x,y,comp,req_comp);
+   if (result) {
+      // need to 'unget' all the characters in the IO buffer
+      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+   }
+   return result;
+}
+
+STBIDEF stbi_us *stbi_load_16(char const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   FILE *f = stbi__fopen(filename, "rb");
+   stbi__uint16 *result;
+   if (!f) return (stbi_us *) stbi__errpuc("can't fopen", "Unable to open file");
+   result = stbi_load_from_file_16(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+
 #endif //!STBI_NO_STDIO
+
+STBIDEF stbi_us *stbi_load_16_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__load_and_postprocess_16bit(&s,x,y,channels_in_file,desired_channels);
+}
+
+STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
+   return stbi__load_and_postprocess_16bit(&s,x,y,channels_in_file,desired_channels);
+}
 
 STBIDEF stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
 {
-	stbi__context s;
-	stbi__start_mem(&s, buffer, len);
-	return stbi__load_flip(&s, x, y, comp, req_comp);
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
 }
 
 STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
 {
-	stbi__context s;
-	stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
-	return stbi__load_flip(&s, x, y, comp, req_comp);
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
 }
+
+#ifndef STBI_NO_GIF
+STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
+{
+   unsigned char *result;
+   stbi__context s; 
+   stbi__start_mem(&s,buffer,len); 
+   
+   result = (unsigned char*) stbi__load_gif_main(&s, delays, x, y, z, comp, req_comp);
+   if (stbi__vertically_flip_on_load) {
+      stbi__vertical_flip_slices( result, *x, *y, *z, *comp ); 
+   }
+
+   return result; 
+}
+#endif
 
 #ifndef STBI_NO_LINEAR
 static float *stbi__loadf_main(stbi__context *s, int *x, int *y, int *comp, int req_comp)
 {
-	unsigned char *data;
-#ifndef STBI_NO_HDR
-	if (stbi__hdr_test(s)) {
-		float *hdr_data = stbi__hdr_load(s, x, y, comp, req_comp);
-		if (hdr_data)
-			stbi__float_postprocess(hdr_data, x, y, comp, req_comp);
-		return hdr_data;
-	}
-#endif
-	data = stbi__load_flip(s, x, y, comp, req_comp);
-	if (data)
-		return stbi__ldr_to_hdr(data, *x, *y, req_comp ? req_comp : *comp);
-	return stbi__errpf("unknown image type", "Image not of any known type, or corrupt");
+   unsigned char *data;
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_test(s)) {
+      stbi__result_info ri;
+      float *hdr_data = stbi__hdr_load(s,x,y,comp,req_comp, &ri);
+      if (hdr_data)
+         stbi__float_postprocess(hdr_data,x,y,comp,req_comp);
+      return hdr_data;
+   }
+   #endif
+   data = stbi__load_and_postprocess_8bit(s, x, y, comp, req_comp);
+   if (data)
+      return stbi__ldr_to_hdr(data, *x, *y, req_comp ? req_comp : *comp);
+   return stbi__errpf("unknown image type", "Image not of any known type, or corrupt");
 }
 
 STBIDEF float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
 {
-	stbi__context s;
-	stbi__start_mem(&s, buffer, len);
-	return stbi__loadf_main(&s, x, y, comp, req_comp);
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
 }
 
 STBIDEF float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
 {
-	stbi__context s;
-	stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
-	return stbi__loadf_main(&s, x, y, comp, req_comp);
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
 }
 
 #ifndef STBI_NO_STDIO
 STBIDEF float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
-	float *result;
-	FILE *f = stbi__fopen(filename, "rb");
-	if (!f) return stbi__errpf("can't fopen", "Unable to open file");
-	result = stbi_loadf_from_file(f, x, y, comp, req_comp);
-	fclose(f);
-	return result;
+   float *result;
+   FILE *f = stbi__fopen(filename, "rb");
+   if (!f) return stbi__errpf("can't fopen", "Unable to open file");
+   result = stbi_loadf_from_file(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
 }
 
 STBIDEF float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
 {
-	stbi__context s;
-	stbi__start_file(&s, f);
-	return stbi__loadf_main(&s, x, y, comp, req_comp);
+   stbi__context s;
+   stbi__start_file(&s,f);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
 }
 #endif // !STBI_NO_STDIO
 
@@ -1134,66 +1309,70 @@ STBIDEF float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *comp, int req_
 
 STBIDEF int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
 {
-#ifndef STBI_NO_HDR
-	stbi__context s;
-	stbi__start_mem(&s, buffer, len);
-	return stbi__hdr_test(&s);
-#else
-	STBI_NOTUSED(buffer);
-	STBI_NOTUSED(len);
-	return 0;
-#endif
+   #ifndef STBI_NO_HDR
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__hdr_test(&s);
+   #else
+   STBI_NOTUSED(buffer);
+   STBI_NOTUSED(len);
+   return 0;
+   #endif
 }
 
 #ifndef STBI_NO_STDIO
-STBIDEF int      stbi_is_hdr(char const *filename)
+STBIDEF int      stbi_is_hdr          (char const *filename)
 {
-	FILE *f = stbi__fopen(filename, "rb");
-	int result = 0;
-	if (f) {
-		result = stbi_is_hdr_from_file(f);
-		fclose(f);
-	}
-	return result;
+   FILE *f = stbi__fopen(filename, "rb");
+   int result=0;
+   if (f) {
+      result = stbi_is_hdr_from_file(f);
+      fclose(f);
+   }
+   return result;
 }
 
-STBIDEF int      stbi_is_hdr_from_file(FILE *f)
+STBIDEF int stbi_is_hdr_from_file(FILE *f)
 {
-#ifndef STBI_NO_HDR
-	stbi__context s;
-	stbi__start_file(&s, f);
-	return stbi__hdr_test(&s);
-#else
-	STBI_NOTUSED(f);
-	return 0;
-#endif
+   #ifndef STBI_NO_HDR
+   long pos = ftell(f);
+   int res;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   res = stbi__hdr_test(&s);
+   fseek(f, pos, SEEK_SET);
+   return res;
+   #else
+   STBI_NOTUSED(f);
+   return 0;
+   #endif
 }
 #endif // !STBI_NO_STDIO
 
 STBIDEF int      stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user)
 {
-#ifndef STBI_NO_HDR
-	stbi__context s;
-	stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
-	return stbi__hdr_test(&s);
-#else
-	STBI_NOTUSED(clbk);
-	STBI_NOTUSED(user);
-	return 0;
-#endif
+   #ifndef STBI_NO_HDR
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__hdr_test(&s);
+   #else
+   STBI_NOTUSED(clbk);
+   STBI_NOTUSED(user);
+   return 0;
+   #endif
 }
 
 #ifndef STBI_NO_LINEAR
-static float stbi__l2h_gamma = 2.2f, stbi__l2h_scale = 1.0f;
+static float stbi__l2h_gamma=2.2f, stbi__l2h_scale=1.0f;
 
 STBIDEF void   stbi_ldr_to_hdr_gamma(float gamma) { stbi__l2h_gamma = gamma; }
 STBIDEF void   stbi_ldr_to_hdr_scale(float scale) { stbi__l2h_scale = scale; }
 #endif
 
-static float stbi__h2l_gamma_i = 1.0f / 2.2f, stbi__h2l_scale_i = 1.0f;
+static float stbi__h2l_gamma_i=1.0f/2.2f, stbi__h2l_scale_i=1.0f;
 
-STBIDEF void   stbi_hdr_to_ldr_gamma(float gamma) { stbi__h2l_gamma_i = 1 / gamma; }
-STBIDEF void   stbi_hdr_to_ldr_scale(float scale) { stbi__h2l_scale_i = 1 / scale; }
+STBIDEF void   stbi_hdr_to_ldr_gamma(float gamma) { stbi__h2l_gamma_i = 1/gamma; }
+STBIDEF void   stbi_hdr_to_ldr_scale(float scale) { stbi__h2l_scale_i = 1/scale; }
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1203,103 +1382,101 @@ STBIDEF void   stbi_hdr_to_ldr_scale(float scale) { stbi__h2l_scale_i = 1 / scal
 
 enum
 {
-	STBI__SCAN_load = 0,
-	STBI__SCAN_type,
-	STBI__SCAN_header
+   STBI__SCAN_load=0,
+   STBI__SCAN_type,
+   STBI__SCAN_header
 };
 
 static void stbi__refill_buffer(stbi__context *s)
 {
-	int n = (s->io.read)(s->io_user_data, (char*)s->buffer_start, s->buflen);
-	if (n == 0) {
-		// at end of file, treat same as if from memory, but need to handle case
-		// where s->img_buffer isn't pointing to safe memory, e.g. 0-byte file
-		s->read_from_callbacks = 0;
-		s->img_buffer = s->buffer_start;
-		s->img_buffer_end = s->buffer_start + 1;
-		*s->img_buffer = 0;
-	}
-	else {
-		s->img_buffer = s->buffer_start;
-		s->img_buffer_end = s->buffer_start + n;
-	}
+   int n = (s->io.read)(s->io_user_data,(char*)s->buffer_start,s->buflen);
+   if (n == 0) {
+      // at end of file, treat same as if from memory, but need to handle case
+      // where s->img_buffer isn't pointing to safe memory, e.g. 0-byte file
+      s->read_from_callbacks = 0;
+      s->img_buffer = s->buffer_start;
+      s->img_buffer_end = s->buffer_start+1;
+      *s->img_buffer = 0;
+   } else {
+      s->img_buffer = s->buffer_start;
+      s->img_buffer_end = s->buffer_start + n;
+   }
 }
 
 stbi_inline static stbi_uc stbi__get8(stbi__context *s)
 {
-	if (s->img_buffer < s->img_buffer_end)
-		return *s->img_buffer++;
-	if (s->read_from_callbacks) {
-		stbi__refill_buffer(s);
-		return *s->img_buffer++;
-	}
-	return 0;
+   if (s->img_buffer < s->img_buffer_end)
+      return *s->img_buffer++;
+   if (s->read_from_callbacks) {
+      stbi__refill_buffer(s);
+      return *s->img_buffer++;
+   }
+   return 0;
 }
 
 stbi_inline static int stbi__at_eof(stbi__context *s)
 {
-	if (s->io.read) {
-		if (!(s->io.eof)(s->io_user_data)) return 0;
-		// if feof() is true, check if buffer = end
-		// special case: we've only got the special 0 character at the end
-		if (s->read_from_callbacks == 0) return 1;
-	}
+   if (s->io.read) {
+      if (!(s->io.eof)(s->io_user_data)) return 0;
+      // if feof() is true, check if buffer = end
+      // special case: we've only got the special 0 character at the end
+      if (s->read_from_callbacks == 0) return 1;
+   }
 
-	return s->img_buffer >= s->img_buffer_end;
+   return s->img_buffer >= s->img_buffer_end;
 }
 
 static void stbi__skip(stbi__context *s, int n)
 {
-	if (n < 0) {
-		s->img_buffer = s->img_buffer_end;
-		return;
-	}
-	if (s->io.read) {
-		int blen = (int)(s->img_buffer_end - s->img_buffer);
-		if (blen < n) {
-			s->img_buffer = s->img_buffer_end;
-			(s->io.skip)(s->io_user_data, n - blen);
-			return;
-		}
-	}
-	s->img_buffer += n;
+   if (n < 0) {
+      s->img_buffer = s->img_buffer_end;
+      return;
+   }
+   if (s->io.read) {
+      int blen = (int) (s->img_buffer_end - s->img_buffer);
+      if (blen < n) {
+         s->img_buffer = s->img_buffer_end;
+         (s->io.skip)(s->io_user_data, n - blen);
+         return;
+      }
+   }
+   s->img_buffer += n;
 }
 
 static int stbi__getn(stbi__context *s, stbi_uc *buffer, int n)
 {
-	if (s->io.read) {
-		int blen = (int)(s->img_buffer_end - s->img_buffer);
-		if (blen < n) {
-			int res, count;
+   if (s->io.read) {
+      int blen = (int) (s->img_buffer_end - s->img_buffer);
+      if (blen < n) {
+         int res, count;
 
-			memcpy(buffer, s->img_buffer, blen);
+         memcpy(buffer, s->img_buffer, blen);
 
-			count = (s->io.read)(s->io_user_data, (char*)buffer + blen, n - blen);
-			res = (count == (n - blen));
-			s->img_buffer = s->img_buffer_end;
-			return res;
-		}
-	}
+         count = (s->io.read)(s->io_user_data, (char*) buffer + blen, n - blen);
+         res = (count == (n-blen));
+         s->img_buffer = s->img_buffer_end;
+         return res;
+      }
+   }
 
-	if (s->img_buffer + n <= s->img_buffer_end) {
-		memcpy(buffer, s->img_buffer, n);
-		s->img_buffer += n;
-		return 1;
-	}
-	else
-		return 0;
+   if (s->img_buffer+n <= s->img_buffer_end) {
+      memcpy(buffer, s->img_buffer, n);
+      s->img_buffer += n;
+      return 1;
+   } else
+      return 0;
 }
 
 static int stbi__get16be(stbi__context *s)
 {
-	int z = stbi__get8(s);
-	return (z << 8) + stbi__get8(s);
+   int z = stbi__get8(s);
+   return (z << 8) + stbi__get8(s);
 }
 
 static stbi__uint32 stbi__get32be(stbi__context *s)
 {
-	stbi__uint32 z = stbi__get16be(s);
-	return (z << 16) + stbi__get16be(s);
+   stbi__uint32 z = stbi__get16be(s);
+   return (z << 16) + stbi__get16be(s);
 }
 
 #if defined(STBI_NO_BMP) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF)
@@ -1307,16 +1484,16 @@ static stbi__uint32 stbi__get32be(stbi__context *s)
 #else
 static int stbi__get16le(stbi__context *s)
 {
-	int z = stbi__get8(s);
-	return z + (stbi__get8(s) << 8);
+   int z = stbi__get8(s);
+   return z + (stbi__get8(s) << 8);
 }
 #endif
 
 #ifndef STBI_NO_BMP
 static stbi__uint32 stbi__get32le(stbi__context *s)
 {
-	stbi__uint32 z = stbi__get16le(s);
-	return z + (stbi__get16le(s) << 16);
+   stbi__uint32 z = stbi__get16le(s);
+   return z + (stbi__get16le(s) << 16);
 }
 #endif
 
@@ -1336,69 +1513,120 @@ static stbi__uint32 stbi__get32le(stbi__context *s)
 
 static stbi_uc stbi__compute_y(int r, int g, int b)
 {
-	return (stbi_uc)(((r * 77) + (g * 150) + (29 * b)) >> 8);
+   return (stbi_uc) (((r*77) + (g*150) +  (29*b)) >> 8);
 }
 
 static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int req_comp, unsigned int x, unsigned int y)
 {
-	int i, j;
-	unsigned char *good;
+   int i,j;
+   unsigned char *good;
 
-	if (req_comp == img_n) return data;
-	STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+   if (req_comp == img_n) return data;
+   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
 
-	good = (unsigned char *)stbi__malloc(req_comp * x * y);
-	if (good == NULL) {
-		STBI_FREE(data);
-		return stbi__errpuc("outofmem", "Out of memory");
-	}
+   good = (unsigned char *) stbi__malloc_mad3(req_comp, x, y, 0);
+   if (good == NULL) {
+      STBI_FREE(data);
+      return stbi__errpuc("outofmem", "Out of memory");
+   }
 
-	for (j = 0; j < (int)y; ++j) {
-		unsigned char *src = data + j * x * img_n;
-		unsigned char *dest = good + j * x * req_comp;
+   for (j=0; j < (int) y; ++j) {
+      unsigned char *src  = data + j * x * img_n   ;
+      unsigned char *dest = good + j * x * req_comp;
 
-#define COMBO(a,b)  ((a)*8+(b))
-#define CASE(a,b)   case COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
-		// convert source image with img_n components to one with req_comp components;
-		// avoid switch per pixel, so use switch per scanline and massive macros
-		switch (COMBO(img_n, req_comp)) {
-			CASE(1, 2) dest[0] = src[0], dest[1] = 255; break;
-			CASE(1, 3) dest[0] = dest[1] = dest[2] = src[0]; break;
-			CASE(1, 4) dest[0] = dest[1] = dest[2] = src[0], dest[3] = 255; break;
-			CASE(2, 1) dest[0] = src[0]; break;
-			CASE(2, 3) dest[0] = dest[1] = dest[2] = src[0]; break;
-			CASE(2, 4) dest[0] = dest[1] = dest[2] = src[0], dest[3] = src[1]; break;
-			CASE(3, 4) dest[0] = src[0], dest[1] = src[1], dest[2] = src[2], dest[3] = 255; break;
-			CASE(3, 1) dest[0] = stbi__compute_y(src[0], src[1], src[2]); break;
-			CASE(3, 2) dest[0] = stbi__compute_y(src[0], src[1], src[2]), dest[1] = 255; break;
-			CASE(4, 1) dest[0] = stbi__compute_y(src[0], src[1], src[2]); break;
-			CASE(4, 2) dest[0] = stbi__compute_y(src[0], src[1], src[2]), dest[1] = src[3]; break;
-			CASE(4, 3) dest[0] = src[0], dest[1] = src[1], dest[2] = src[2]; break;
-		default: STBI_ASSERT(0);
-		}
-#undef CASE
-	}
+      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      // convert source image with img_n components to one with req_comp components;
+      // avoid switch per pixel, so use switch per scanline and massive macros
+      switch (STBI__COMBO(img_n, req_comp)) {
+         STBI__CASE(1,2) { dest[0]=src[0], dest[1]=255;                                     } break;
+         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=255;                     } break;
+         STBI__CASE(2,1) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=src[1];                  } break;
+         STBI__CASE(3,4) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2],dest[3]=255;        } break;
+         STBI__CASE(3,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]), dest[1] = 255;    } break;
+         STBI__CASE(4,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]), dest[1] = src[3]; } break;
+         STBI__CASE(4,3) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2];                    } break;
+         default: STBI_ASSERT(0);
+      }
+      #undef STBI__CASE
+   }
 
-	STBI_FREE(data);
-	return good;
+   STBI_FREE(data);
+   return good;
+}
+
+static stbi__uint16 stbi__compute_y_16(int r, int g, int b)
+{
+   return (stbi__uint16) (((r*77) + (g*150) +  (29*b)) >> 8);
+}
+
+static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int req_comp, unsigned int x, unsigned int y)
+{
+   int i,j;
+   stbi__uint16 *good;
+
+   if (req_comp == img_n) return data;
+   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+
+   good = (stbi__uint16 *) stbi__malloc(req_comp * x * y * 2);
+   if (good == NULL) {
+      STBI_FREE(data);
+      return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+   }
+
+   for (j=0; j < (int) y; ++j) {
+      stbi__uint16 *src  = data + j * x * img_n   ;
+      stbi__uint16 *dest = good + j * x * req_comp;
+
+      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      // convert source image with img_n components to one with req_comp components;
+      // avoid switch per pixel, so use switch per scanline and massive macros
+      switch (STBI__COMBO(img_n, req_comp)) {
+         STBI__CASE(1,2) { dest[0]=src[0], dest[1]=0xffff;                                     } break;
+         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
+         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=0xffff;                     } break;
+         STBI__CASE(2,1) { dest[0]=src[0];                                                     } break;
+         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
+         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0], dest[3]=src[1];                     } break;
+         STBI__CASE(3,4) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2],dest[3]=0xffff;        } break;
+         STBI__CASE(3,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]), dest[1] = 0xffff; } break;
+         STBI__CASE(4,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]), dest[1] = src[3]; } break;
+         STBI__CASE(4,3) { dest[0]=src[0],dest[1]=src[1],dest[2]=src[2];                       } break;
+         default: STBI_ASSERT(0);
+      }
+      #undef STBI__CASE
+   }
+
+   STBI_FREE(data);
+   return good;
 }
 
 #ifndef STBI_NO_LINEAR
 static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
 {
-	int i, k, n;
-	float *output = (float *)stbi__malloc(x * y * comp * sizeof(float));
-	if (output == NULL) { STBI_FREE(data); return stbi__errpf("outofmem", "Out of memory"); }
-	// compute number of non-alpha components
-	if (comp & 1) n = comp; else n = comp - 1;
-	for (i = 0; i < x*y; ++i) {
-		for (k = 0; k < n; ++k) {
-			output[i*comp + k] = (float)(pow(data[i*comp + k] / 255.0f, stbi__l2h_gamma) * stbi__l2h_scale);
-		}
-		if (k < comp) output[i*comp + k] = data[i*comp + k] / 255.0f;
-	}
-	STBI_FREE(data);
-	return output;
+   int i,k,n;
+   float *output;
+   if (!data) return NULL;
+   output = (float *) stbi__malloc_mad4(x, y, comp, sizeof(float), 0);
+   if (output == NULL) { STBI_FREE(data); return stbi__errpf("outofmem", "Out of memory"); }
+   // compute number of non-alpha components
+   if (comp & 1) n = comp; else n = comp-1;
+   for (i=0; i < x*y; ++i) {
+      for (k=0; k < n; ++k) {
+         output[i*comp + k] = (float) (pow(data[i*comp+k]/255.0f, stbi__l2h_gamma) * stbi__l2h_scale);
+      }
+      if (k < comp) output[i*comp + k] = data[i*comp+k]/255.0f;
+   }
+   STBI_FREE(data);
+   return output;
 }
 #endif
 
@@ -1406,27 +1634,29 @@ static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
 #define stbi__float2int(x)   ((int) (x))
 static stbi_uc *stbi__hdr_to_ldr(float   *data, int x, int y, int comp)
 {
-	int i, k, n;
-	stbi_uc *output = (stbi_uc *)stbi__malloc(x * y * comp);
-	if (output == NULL) { STBI_FREE(data); return stbi__errpuc("outofmem", "Out of memory"); }
-	// compute number of non-alpha components
-	if (comp & 1) n = comp; else n = comp - 1;
-	for (i = 0; i < x*y; ++i) {
-		for (k = 0; k < n; ++k) {
-			float z = (float)pow(data[i*comp + k] * stbi__h2l_scale_i, stbi__h2l_gamma_i) * 255 + 0.5f;
-			if (z < 0) z = 0;
-			if (z > 255) z = 255;
-			output[i*comp + k] = (stbi_uc)stbi__float2int(z);
-		}
-		if (k < comp) {
-			float z = data[i*comp + k] * 255 + 0.5f;
-			if (z < 0) z = 0;
-			if (z > 255) z = 255;
-			output[i*comp + k] = (stbi_uc)stbi__float2int(z);
-		}
-	}
-	STBI_FREE(data);
-	return output;
+   int i,k,n;
+   stbi_uc *output;
+   if (!data) return NULL;
+   output = (stbi_uc *) stbi__malloc_mad3(x, y, comp, 0);
+   if (output == NULL) { STBI_FREE(data); return stbi__errpuc("outofmem", "Out of memory"); }
+   // compute number of non-alpha components
+   if (comp & 1) n = comp; else n = comp-1;
+   for (i=0; i < x*y; ++i) {
+      for (k=0; k < n; ++k) {
+         float z = (float) pow(data[i*comp+k]*stbi__h2l_scale_i, stbi__h2l_gamma_i) * 255 + 0.5f;
+         if (z < 0) z = 0;
+         if (z > 255) z = 255;
+         output[i*comp + k] = (stbi_uc) stbi__float2int(z);
+      }
+      if (k < comp) {
+         float z = data[i*comp+k] * 255 + 0.5f;
+         if (z < 0) z = 0;
+         if (z > 255) z = 255;
+         output[i*comp + k] = (stbi_uc) stbi__float2int(z);
+      }
+   }
+   STBI_FREE(data);
+   return output;
 }
 #endif
 
@@ -1458,485 +1688,480 @@ static stbi_uc *stbi__hdr_to_ldr(float   *data, int x, int y, int comp)
 
 typedef struct
 {
-	stbi_uc  fast[1 << FAST_BITS];
-	// weirdly, repacking this into AoS is a 10% speed loss, instead of a win
-	stbi__uint16 code[256];
-	stbi_uc  values[256];
-	stbi_uc  size[257];
-	unsigned int maxcode[18];
-	int    delta[17];   // old 'firstsymbol' - old 'firstcode'
+   stbi_uc  fast[1 << FAST_BITS];
+   // weirdly, repacking this into AoS is a 10% speed loss, instead of a win
+   stbi__uint16 code[256];
+   stbi_uc  values[256];
+   stbi_uc  size[257];
+   unsigned int maxcode[18];
+   int    delta[17];   // old 'firstsymbol' - old 'firstcode'
 } stbi__huffman;
 
 typedef struct
 {
-	stbi__context *s;
-	stbi__huffman huff_dc[4];
-	stbi__huffman huff_ac[4];
-	stbi_uc dequant[4][64];
-	stbi__int16 fast_ac[4][1 << FAST_BITS];
+   stbi__context *s;
+   stbi__huffman huff_dc[4];
+   stbi__huffman huff_ac[4];
+   stbi__uint16 dequant[4][64];
+   stbi__int16 fast_ac[4][1 << FAST_BITS];
 
-	// sizes for components, interleaved MCUs
-	int img_h_max, img_v_max;
-	int img_mcu_x, img_mcu_y;
-	int img_mcu_w, img_mcu_h;
+// sizes for components, interleaved MCUs
+   int img_h_max, img_v_max;
+   int img_mcu_x, img_mcu_y;
+   int img_mcu_w, img_mcu_h;
 
-	// definition of jpeg image component
-	struct
-	{
-		int id;
-		int h, v;
-		int tq;
-		int hd, ha;
-		int dc_pred;
+// definition of jpeg image component
+   struct
+   {
+      int id;
+      int h,v;
+      int tq;
+      int hd,ha;
+      int dc_pred;
 
-		int x, y, w2, h2;
-		stbi_uc *data;
-		void *raw_data, *raw_coeff;
-		stbi_uc *linebuf;
-		short   *coeff;   // progressive only
-		int      coeff_w, coeff_h; // number of 8x8 coefficient blocks
-	} img_comp[4];
+      int x,y,w2,h2;
+      stbi_uc *data;
+      void *raw_data, *raw_coeff;
+      stbi_uc *linebuf;
+      short   *coeff;   // progressive only
+      int      coeff_w, coeff_h; // number of 8x8 coefficient blocks
+   } img_comp[4];
 
-	stbi__uint32   code_buffer; // jpeg entropy-coded buffer
-	int            code_bits;   // number of valid bits
-	unsigned char  marker;      // marker seen while filling entropy buffer
-	int            nomore;      // flag if we saw a marker so must stop
+   stbi__uint32   code_buffer; // jpeg entropy-coded buffer
+   int            code_bits;   // number of valid bits
+   unsigned char  marker;      // marker seen while filling entropy buffer
+   int            nomore;      // flag if we saw a marker so must stop
 
-	int            progressive;
-	int            spec_start;
-	int            spec_end;
-	int            succ_high;
-	int            succ_low;
-	int            eob_run;
+   int            progressive;
+   int            spec_start;
+   int            spec_end;
+   int            succ_high;
+   int            succ_low;
+   int            eob_run;
+   int            jfif;
+   int            app14_color_transform; // Adobe APP14 tag
+   int            rgb;
 
-	int scan_n, order[4];
-	int restart_interval, todo;
+   int scan_n, order[4];
+   int restart_interval, todo;
 
-	// kernels
-	void(*idct_block_kernel)(stbi_uc *out, int out_stride, short data[64]);
-	void(*YCbCr_to_RGB_kernel)(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step);
-	stbi_uc *(*resample_row_hv_2_kernel)(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs);
+// kernels
+   void (*idct_block_kernel)(stbi_uc *out, int out_stride, short data[64]);
+   void (*YCbCr_to_RGB_kernel)(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step);
+   stbi_uc *(*resample_row_hv_2_kernel)(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs);
 } stbi__jpeg;
 
 static int stbi__build_huffman(stbi__huffman *h, int *count)
 {
-	int i, j, k = 0, code;
-	// build size list for each symbol (from JPEG spec)
-	for (i = 0; i < 16; ++i)
-		for (j = 0; j < count[i]; ++j)
-			h->size[k++] = (stbi_uc)(i + 1);
-	h->size[k] = 0;
+   int i,j,k=0;
+   unsigned int code;
+   // build size list for each symbol (from JPEG spec)
+   for (i=0; i < 16; ++i)
+      for (j=0; j < count[i]; ++j)
+         h->size[k++] = (stbi_uc) (i+1);
+   h->size[k] = 0;
 
-	// compute actual symbols (from jpeg spec)
-	code = 0;
-	k = 0;
-	for (j = 1; j <= 16; ++j) {
-		// compute delta to add to code to compute symbol id
-		h->delta[j] = k - code;
-		if (h->size[k] == j) {
-			while (h->size[k] == j)
-				h->code[k++] = (stbi__uint16)(code++);
-			if (code - 1 >= (1 << j)) return stbi__err("bad code lengths", "Corrupt JPEG");
-		}
-		// compute largest code + 1 for this size, preshifted as needed later
-		h->maxcode[j] = code << (16 - j);
-		code <<= 1;
-	}
-	h->maxcode[j] = 0xffffffff;
+   // compute actual symbols (from jpeg spec)
+   code = 0;
+   k = 0;
+   for(j=1; j <= 16; ++j) {
+      // compute delta to add to code to compute symbol id
+      h->delta[j] = k - code;
+      if (h->size[k] == j) {
+         while (h->size[k] == j)
+            h->code[k++] = (stbi__uint16) (code++);
+         if (code-1 >= (1u << j)) return stbi__err("bad code lengths","Corrupt JPEG");
+      }
+      // compute largest code + 1 for this size, preshifted as needed later
+      h->maxcode[j] = code << (16-j);
+      code <<= 1;
+   }
+   h->maxcode[j] = 0xffffffff;
 
-	// build non-spec acceleration table; 255 is flag for not-accelerated
-	memset(h->fast, 255, 1 << FAST_BITS);
-	for (i = 0; i < k; ++i) {
-		int s = h->size[i];
-		if (s <= FAST_BITS) {
-			int c = h->code[i] << (FAST_BITS - s);
-			int m = 1 << (FAST_BITS - s);
-			for (j = 0; j < m; ++j) {
-				h->fast[c + j] = (stbi_uc)i;
-			}
-		}
-	}
-	return 1;
+   // build non-spec acceleration table; 255 is flag for not-accelerated
+   memset(h->fast, 255, 1 << FAST_BITS);
+   for (i=0; i < k; ++i) {
+      int s = h->size[i];
+      if (s <= FAST_BITS) {
+         int c = h->code[i] << (FAST_BITS-s);
+         int m = 1 << (FAST_BITS-s);
+         for (j=0; j < m; ++j) {
+            h->fast[c+j] = (stbi_uc) i;
+         }
+      }
+   }
+   return 1;
 }
 
 // build a table that decodes both magnitude and value of small ACs in
 // one go.
 static void stbi__build_fast_ac(stbi__int16 *fast_ac, stbi__huffman *h)
 {
-	int i;
-	for (i = 0; i < (1 << FAST_BITS); ++i) {
-		stbi_uc fast = h->fast[i];
-		fast_ac[i] = 0;
-		if (fast < 255) {
-			int rs = h->values[fast];
-			int run = (rs >> 4) & 15;
-			int magbits = rs & 15;
-			int len = h->size[fast];
+   int i;
+   for (i=0; i < (1 << FAST_BITS); ++i) {
+      stbi_uc fast = h->fast[i];
+      fast_ac[i] = 0;
+      if (fast < 255) {
+         int rs = h->values[fast];
+         int run = (rs >> 4) & 15;
+         int magbits = rs & 15;
+         int len = h->size[fast];
 
-			if (magbits && len + magbits <= FAST_BITS) {
-				// magnitude code followed by receive_extend code
-				int k = ((i << len) & ((1 << FAST_BITS) - 1)) >> (FAST_BITS - magbits);
-				int m = 1 << (magbits - 1);
-				if (k < m) k += (-1 << magbits) + 1;
-				// if the result is small enough, we can fit it in fast_ac table
-				if (k >= -128 && k <= 127)
-					fast_ac[i] = (stbi__int16)((k << 8) + (run << 4) + (len + magbits));
-			}
-		}
-	}
+         if (magbits && len + magbits <= FAST_BITS) {
+            // magnitude code followed by receive_extend code
+            int k = ((i << len) & ((1 << FAST_BITS) - 1)) >> (FAST_BITS - magbits);
+            int m = 1 << (magbits - 1);
+            if (k < m) k += (~0U << magbits) + 1;
+            // if the result is small enough, we can fit it in fast_ac table
+            if (k >= -128 && k <= 127)
+               fast_ac[i] = (stbi__int16) ((k * 256) + (run * 16) + (len + magbits));
+         }
+      }
+   }
 }
 
 static void stbi__grow_buffer_unsafe(stbi__jpeg *j)
 {
-	do {
-		int b = j->nomore ? 0 : stbi__get8(j->s);
-		if (b == 0xff) {
-			int c = stbi__get8(j->s);
-			if (c != 0) {
-				j->marker = (unsigned char)c;
-				j->nomore = 1;
-				return;
-			}
-		}
-		j->code_buffer |= b << (24 - j->code_bits);
-		j->code_bits += 8;
-	} while (j->code_bits <= 24);
+   do {
+      unsigned int b = j->nomore ? 0 : stbi__get8(j->s);
+      if (b == 0xff) {
+         int c = stbi__get8(j->s);
+         while (c == 0xff) c = stbi__get8(j->s); // consume fill bytes
+         if (c != 0) {
+            j->marker = (unsigned char) c;
+            j->nomore = 1;
+            return;
+         }
+      }
+      j->code_buffer |= b << (24 - j->code_bits);
+      j->code_bits += 8;
+   } while (j->code_bits <= 24);
 }
 
 // (1 << n) - 1
-static stbi__uint32 stbi__bmask[17] = { 0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535 };
+static const stbi__uint32 stbi__bmask[17]={0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535};
 
 // decode a jpeg huffman value from the bitstream
 stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
 {
-	unsigned int temp;
-	int c, k;
+   unsigned int temp;
+   int c,k;
 
-	if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
 
-	// look at the top FAST_BITS and determine what symbol ID it is,
-	// if the code is <= FAST_BITS
-	c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS) - 1);
-	k = h->fast[c];
-	if (k < 255) {
-		int s = h->size[k];
-		if (s > j->code_bits)
-			return -1;
-		j->code_buffer <<= s;
-		j->code_bits -= s;
-		return h->values[k];
-	}
+   // look at the top FAST_BITS and determine what symbol ID it is,
+   // if the code is <= FAST_BITS
+   c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+   k = h->fast[c];
+   if (k < 255) {
+      int s = h->size[k];
+      if (s > j->code_bits)
+         return -1;
+      j->code_buffer <<= s;
+      j->code_bits -= s;
+      return h->values[k];
+   }
 
-	// naive test is to shift the code_buffer down so k bits are
-	// valid, then test against maxcode. To speed this up, we've
-	// preshifted maxcode left so that it has (16-k) 0s at the
-	// end; in other words, regardless of the number of bits, it
-	// wants to be compared against something shifted to have 16;
-	// that way we don't need to shift inside the loop.
-	temp = j->code_buffer >> 16;
-	for (k = FAST_BITS + 1; ; ++k)
-		if (temp < h->maxcode[k])
-			break;
-	if (k == 17) {
-		// error! code not found
-		j->code_bits -= 16;
-		return -1;
-	}
+   // naive test is to shift the code_buffer down so k bits are
+   // valid, then test against maxcode. To speed this up, we've
+   // preshifted maxcode left so that it has (16-k) 0s at the
+   // end; in other words, regardless of the number of bits, it
+   // wants to be compared against something shifted to have 16;
+   // that way we don't need to shift inside the loop.
+   temp = j->code_buffer >> 16;
+   for (k=FAST_BITS+1 ; ; ++k)
+      if (temp < h->maxcode[k])
+         break;
+   if (k == 17) {
+      // error! code not found
+      j->code_bits -= 16;
+      return -1;
+   }
 
-	if (k > j->code_bits)
-		return -1;
+   if (k > j->code_bits)
+      return -1;
 
-	// convert the huffman code to the symbol id
-	c = ((j->code_buffer >> (32 - k)) & stbi__bmask[k]) + h->delta[k];
-	STBI_ASSERT((((j->code_buffer) >> (32 - h->size[c])) & stbi__bmask[h->size[c]]) == h->code[c]);
+   // convert the huffman code to the symbol id
+   c = ((j->code_buffer >> (32 - k)) & stbi__bmask[k]) + h->delta[k];
+   STBI_ASSERT((((j->code_buffer) >> (32 - h->size[c])) & stbi__bmask[h->size[c]]) == h->code[c]);
 
-	// convert the id to a symbol
-	j->code_bits -= k;
-	j->code_buffer <<= k;
-	return h->values[c];
+   // convert the id to a symbol
+   j->code_bits -= k;
+   j->code_buffer <<= k;
+   return h->values[c];
 }
 
 // bias[n] = (-1<<n) + 1
-static int const stbi__jbias[16] = { 0,-1,-3,-7,-15,-31,-63,-127,-255,-511,-1023,-2047,-4095,-8191,-16383,-32767 };
+static const int stbi__jbias[16] = {0,-1,-3,-7,-15,-31,-63,-127,-255,-511,-1023,-2047,-4095,-8191,-16383,-32767};
 
 // combined JPEG 'receive' and JPEG 'extend', since baseline
 // always extends everything it receives.
 stbi_inline static int stbi__extend_receive(stbi__jpeg *j, int n)
 {
-	unsigned int k;
-	int sgn;
-	if (j->code_bits < n) stbi__grow_buffer_unsafe(j);
+   unsigned int k;
+   int sgn;
+   if (j->code_bits < n) stbi__grow_buffer_unsafe(j);
 
-	sgn = (stbi__int32)j->code_buffer >> 31; // sign bit is always in MSB
-	k = stbi_lrot(j->code_buffer, n);
-	STBI_ASSERT(n >= 0 && n < (int)(sizeof(stbi__bmask) / sizeof(*stbi__bmask)));
-	j->code_buffer = k & ~stbi__bmask[n];
-	k &= stbi__bmask[n];
-	j->code_bits -= n;
-	return k + (stbi__jbias[n] & ~sgn);
+   sgn = (stbi__int32)j->code_buffer >> 31; // sign bit is always in MSB
+   k = stbi_lrot(j->code_buffer, n);
+   STBI_ASSERT(n >= 0 && n < (int) (sizeof(stbi__bmask)/sizeof(*stbi__bmask)));
+   j->code_buffer = k & ~stbi__bmask[n];
+   k &= stbi__bmask[n];
+   j->code_bits -= n;
+   return k + (stbi__jbias[n] & ~sgn);
 }
 
 // get some unsigned bits
 stbi_inline static int stbi__jpeg_get_bits(stbi__jpeg *j, int n)
 {
-	unsigned int k;
-	if (j->code_bits < n) stbi__grow_buffer_unsafe(j);
-	k = stbi_lrot(j->code_buffer, n);
-	j->code_buffer = k & ~stbi__bmask[n];
-	k &= stbi__bmask[n];
-	j->code_bits -= n;
-	return k;
+   unsigned int k;
+   if (j->code_bits < n) stbi__grow_buffer_unsafe(j);
+   k = stbi_lrot(j->code_buffer, n);
+   j->code_buffer = k & ~stbi__bmask[n];
+   k &= stbi__bmask[n];
+   j->code_bits -= n;
+   return k;
 }
 
 stbi_inline static int stbi__jpeg_get_bit(stbi__jpeg *j)
 {
-	unsigned int k;
-	if (j->code_bits < 1) stbi__grow_buffer_unsafe(j);
-	k = j->code_buffer;
-	j->code_buffer <<= 1;
-	--j->code_bits;
-	return k & 0x80000000;
+   unsigned int k;
+   if (j->code_bits < 1) stbi__grow_buffer_unsafe(j);
+   k = j->code_buffer;
+   j->code_buffer <<= 1;
+   --j->code_bits;
+   return k & 0x80000000;
 }
 
 // given a value that's at position X in the zigzag stream,
 // where does it appear in the 8x8 matrix coded as row-major?
-static stbi_uc stbi__jpeg_dezigzag[64 + 15] =
+static const stbi_uc stbi__jpeg_dezigzag[64+15] =
 {
-	0,  1,  8, 16,  9,  2,  3, 10,
-	17, 24, 32, 25, 18, 11,  4,  5,
-	12, 19, 26, 33, 40, 48, 41, 34,
-	27, 20, 13,  6,  7, 14, 21, 28,
-	35, 42, 49, 56, 57, 50, 43, 36,
-	29, 22, 15, 23, 30, 37, 44, 51,
-	58, 59, 52, 45, 38, 31, 39, 46,
-	53, 60, 61, 54, 47, 55, 62, 63,
-	// let corrupt input sample past end
-	63, 63, 63, 63, 63, 63, 63, 63,
-	63, 63, 63, 63, 63, 63, 63
+    0,  1,  8, 16,  9,  2,  3, 10,
+   17, 24, 32, 25, 18, 11,  4,  5,
+   12, 19, 26, 33, 40, 48, 41, 34,
+   27, 20, 13,  6,  7, 14, 21, 28,
+   35, 42, 49, 56, 57, 50, 43, 36,
+   29, 22, 15, 23, 30, 37, 44, 51,
+   58, 59, 52, 45, 38, 31, 39, 46,
+   53, 60, 61, 54, 47, 55, 62, 63,
+   // let corrupt input sample past end
+   63, 63, 63, 63, 63, 63, 63, 63,
+   63, 63, 63, 63, 63, 63, 63
 };
 
 // decode one 64-entry block--
-static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman *hdc, stbi__huffman *hac, stbi__int16 *fac, int b, stbi_uc *dequant)
+static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman *hdc, stbi__huffman *hac, stbi__int16 *fac, int b, stbi__uint16 *dequant)
 {
-	int diff, dc, k;
-	int t;
+   int diff,dc,k;
+   int t;
 
-	if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
-	t = stbi__jpeg_huff_decode(j, hdc);
-	if (t < 0) return stbi__err("bad huffman code", "Corrupt JPEG");
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+   t = stbi__jpeg_huff_decode(j, hdc);
+   if (t < 0) return stbi__err("bad huffman code","Corrupt JPEG");
 
-	// 0 all the ac values now so we can do it 32-bits at a time
-	memset(data, 0, 64 * sizeof(data[0]));
+   // 0 all the ac values now so we can do it 32-bits at a time
+   memset(data,0,64*sizeof(data[0]));
 
-	diff = t ? stbi__extend_receive(j, t) : 0;
-	dc = j->img_comp[b].dc_pred + diff;
-	j->img_comp[b].dc_pred = dc;
-	data[0] = (short)(dc * dequant[0]);
+   diff = t ? stbi__extend_receive(j, t) : 0;
+   dc = j->img_comp[b].dc_pred + diff;
+   j->img_comp[b].dc_pred = dc;
+   data[0] = (short) (dc * dequant[0]);
 
-	// decode AC components, see JPEG spec
-	k = 1;
-	do {
-		unsigned int zig;
-		int c, r, s;
-		if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
-		c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS) - 1);
-		r = fac[c];
-		if (r) { // fast-AC path
-			k += (r >> 4) & 15; // run
-			s = r & 15; // combined length
-			j->code_buffer <<= s;
-			j->code_bits -= s;
-			// decode into unzigzag'd location
-			zig = stbi__jpeg_dezigzag[k++];
-			data[zig] = (short)((r >> 8) * dequant[zig]);
-		}
-		else {
-			int rs = stbi__jpeg_huff_decode(j, hac);
-			if (rs < 0) return stbi__err("bad huffman code", "Corrupt JPEG");
-			s = rs & 15;
-			r = rs >> 4;
-			if (s == 0) {
-				if (rs != 0xf0) break; // end block
-				k += 16;
-			}
-			else {
-				k += r;
-				// decode into unzigzag'd location
-				zig = stbi__jpeg_dezigzag[k++];
-				data[zig] = (short)(stbi__extend_receive(j, s) * dequant[zig]);
-			}
-		}
-	} while (k < 64);
-	return 1;
+   // decode AC components, see JPEG spec
+   k = 1;
+   do {
+      unsigned int zig;
+      int c,r,s;
+      if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+      c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+      r = fac[c];
+      if (r) { // fast-AC path
+         k += (r >> 4) & 15; // run
+         s = r & 15; // combined length
+         j->code_buffer <<= s;
+         j->code_bits -= s;
+         // decode into unzigzag'd location
+         zig = stbi__jpeg_dezigzag[k++];
+         data[zig] = (short) ((r >> 8) * dequant[zig]);
+      } else {
+         int rs = stbi__jpeg_huff_decode(j, hac);
+         if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+         s = rs & 15;
+         r = rs >> 4;
+         if (s == 0) {
+            if (rs != 0xf0) break; // end block
+            k += 16;
+         } else {
+            k += r;
+            // decode into unzigzag'd location
+            zig = stbi__jpeg_dezigzag[k++];
+            data[zig] = (short) (stbi__extend_receive(j,s) * dequant[zig]);
+         }
+      }
+   } while (k < 64);
+   return 1;
 }
 
 static int stbi__jpeg_decode_block_prog_dc(stbi__jpeg *j, short data[64], stbi__huffman *hdc, int b)
 {
-	int diff, dc;
-	int t;
-	if (j->spec_end != 0) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+   int diff,dc;
+   int t;
+   if (j->spec_end != 0) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
 
-	if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
 
-	if (j->succ_high == 0) {
-		// first scan for DC coefficient, must be first
-		memset(data, 0, 64 * sizeof(data[0])); // 0 all the ac values now
-		t = stbi__jpeg_huff_decode(j, hdc);
-		diff = t ? stbi__extend_receive(j, t) : 0;
+   if (j->succ_high == 0) {
+      // first scan for DC coefficient, must be first
+      memset(data,0,64*sizeof(data[0])); // 0 all the ac values now
+      t = stbi__jpeg_huff_decode(j, hdc);
+      diff = t ? stbi__extend_receive(j, t) : 0;
 
-		dc = j->img_comp[b].dc_pred + diff;
-		j->img_comp[b].dc_pred = dc;
-		data[0] = (short)(dc << j->succ_low);
-	}
-	else {
-		// refinement scan for DC coefficient
-		if (stbi__jpeg_get_bit(j))
-			data[0] += (short)(1 << j->succ_low);
-	}
-	return 1;
+      dc = j->img_comp[b].dc_pred + diff;
+      j->img_comp[b].dc_pred = dc;
+      data[0] = (short) (dc << j->succ_low);
+   } else {
+      // refinement scan for DC coefficient
+      if (stbi__jpeg_get_bit(j))
+         data[0] += (short) (1 << j->succ_low);
+   }
+   return 1;
 }
 
 // @OPTIMIZE: store non-zigzagged during the decode passes,
 // and only de-zigzag when dequantizing
 static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__huffman *hac, stbi__int16 *fac)
 {
-	int k;
-	if (j->spec_start == 0) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+   int k;
+   if (j->spec_start == 0) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
 
-	if (j->succ_high == 0) {
-		int shift = j->succ_low;
+   if (j->succ_high == 0) {
+      int shift = j->succ_low;
 
-		if (j->eob_run) {
-			--j->eob_run;
-			return 1;
-		}
+      if (j->eob_run) {
+         --j->eob_run;
+         return 1;
+      }
 
-		k = j->spec_start;
-		do {
-			unsigned int zig;
-			int c, r, s;
-			if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
-			c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS) - 1);
-			r = fac[c];
-			if (r) { // fast-AC path
-				k += (r >> 4) & 15; // run
-				s = r & 15; // combined length
-				j->code_buffer <<= s;
-				j->code_bits -= s;
-				zig = stbi__jpeg_dezigzag[k++];
-				data[zig] = (short)((r >> 8) << shift);
-			}
-			else {
-				int rs = stbi__jpeg_huff_decode(j, hac);
-				if (rs < 0) return stbi__err("bad huffman code", "Corrupt JPEG");
-				s = rs & 15;
-				r = rs >> 4;
-				if (s == 0) {
-					if (r < 15) {
-						j->eob_run = (1 << r);
-						if (r)
-							j->eob_run += stbi__jpeg_get_bits(j, r);
-						--j->eob_run;
-						break;
-					}
-					k += 16;
-				}
-				else {
-					k += r;
-					zig = stbi__jpeg_dezigzag[k++];
-					data[zig] = (short)(stbi__extend_receive(j, s) << shift);
-				}
-			}
-		} while (k <= j->spec_end);
-	}
-	else {
-		// refinement scan for these AC coefficients
+      k = j->spec_start;
+      do {
+         unsigned int zig;
+         int c,r,s;
+         if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+         c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+         r = fac[c];
+         if (r) { // fast-AC path
+            k += (r >> 4) & 15; // run
+            s = r & 15; // combined length
+            j->code_buffer <<= s;
+            j->code_bits -= s;
+            zig = stbi__jpeg_dezigzag[k++];
+            data[zig] = (short) ((r >> 8) << shift);
+         } else {
+            int rs = stbi__jpeg_huff_decode(j, hac);
+            if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+            s = rs & 15;
+            r = rs >> 4;
+            if (s == 0) {
+               if (r < 15) {
+                  j->eob_run = (1 << r);
+                  if (r)
+                     j->eob_run += stbi__jpeg_get_bits(j, r);
+                  --j->eob_run;
+                  break;
+               }
+               k += 16;
+            } else {
+               k += r;
+               zig = stbi__jpeg_dezigzag[k++];
+               data[zig] = (short) (stbi__extend_receive(j,s) << shift);
+            }
+         }
+      } while (k <= j->spec_end);
+   } else {
+      // refinement scan for these AC coefficients
 
-		short bit = (short)(1 << j->succ_low);
+      short bit = (short) (1 << j->succ_low);
 
-		if (j->eob_run) {
-			--j->eob_run;
-			for (k = j->spec_start; k <= j->spec_end; ++k) {
-				short *p = &data[stbi__jpeg_dezigzag[k]];
-				if (*p != 0)
-					if (stbi__jpeg_get_bit(j))
-						if ((*p & bit) == 0) {
-							if (*p > 0)
-								*p += bit;
-							else
-								*p -= bit;
-						}
-			}
-		}
-		else {
-			k = j->spec_start;
-			do {
-				int r, s;
-				int rs = stbi__jpeg_huff_decode(j, hac); // @OPTIMIZE see if we can use the fast path here, advance-by-r is so slow, eh
-				if (rs < 0) return stbi__err("bad huffman code", "Corrupt JPEG");
-				s = rs & 15;
-				r = rs >> 4;
-				if (s == 0) {
-					if (r < 15) {
-						j->eob_run = (1 << r) - 1;
-						if (r)
-							j->eob_run += stbi__jpeg_get_bits(j, r);
-						r = 64; // force end of block
-					}
-					else {
-						// r=15 s=0 should write 16 0s, so we just do
-						// a run of 15 0s and then write s (which is 0),
-						// so we don't have to do anything special here
-					}
-				}
-				else {
-					if (s != 1) return stbi__err("bad huffman code", "Corrupt JPEG");
-					// sign bit
-					if (stbi__jpeg_get_bit(j))
-						s = bit;
-					else
-						s = -bit;
-				}
+      if (j->eob_run) {
+         --j->eob_run;
+         for (k = j->spec_start; k <= j->spec_end; ++k) {
+            short *p = &data[stbi__jpeg_dezigzag[k]];
+            if (*p != 0)
+               if (stbi__jpeg_get_bit(j))
+                  if ((*p & bit)==0) {
+                     if (*p > 0)
+                        *p += bit;
+                     else
+                        *p -= bit;
+                  }
+         }
+      } else {
+         k = j->spec_start;
+         do {
+            int r,s;
+            int rs = stbi__jpeg_huff_decode(j, hac); // @OPTIMIZE see if we can use the fast path here, advance-by-r is so slow, eh
+            if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+            s = rs & 15;
+            r = rs >> 4;
+            if (s == 0) {
+               if (r < 15) {
+                  j->eob_run = (1 << r) - 1;
+                  if (r)
+                     j->eob_run += stbi__jpeg_get_bits(j, r);
+                  r = 64; // force end of block
+               } else {
+                  // r=15 s=0 should write 16 0s, so we just do
+                  // a run of 15 0s and then write s (which is 0),
+                  // so we don't have to do anything special here
+               }
+            } else {
+               if (s != 1) return stbi__err("bad huffman code", "Corrupt JPEG");
+               // sign bit
+               if (stbi__jpeg_get_bit(j))
+                  s = bit;
+               else
+                  s = -bit;
+            }
 
-				// advance by r
-				while (k <= j->spec_end) {
-					short *p = &data[stbi__jpeg_dezigzag[k++]];
-					if (*p != 0) {
-						if (stbi__jpeg_get_bit(j))
-							if ((*p & bit) == 0) {
-								if (*p > 0)
-									*p += bit;
-								else
-									*p -= bit;
-							}
-					}
-					else {
-						if (r == 0) {
-							*p = (short)s;
-							break;
-						}
-						--r;
-					}
-				}
-			} while (k <= j->spec_end);
-		}
-	}
-	return 1;
+            // advance by r
+            while (k <= j->spec_end) {
+               short *p = &data[stbi__jpeg_dezigzag[k++]];
+               if (*p != 0) {
+                  if (stbi__jpeg_get_bit(j))
+                     if ((*p & bit)==0) {
+                        if (*p > 0)
+                           *p += bit;
+                        else
+                           *p -= bit;
+                     }
+               } else {
+                  if (r == 0) {
+                     *p = (short) s;
+                     break;
+                  }
+                  --r;
+               }
+            }
+         } while (k <= j->spec_end);
+      }
+   }
+   return 1;
 }
 
 // take a -128..127 value and stbi__clamp it and convert to 0..255
 stbi_inline static stbi_uc stbi__clamp(int x)
 {
-	// trick to use a single test to catch both cases
-	if ((unsigned int)x > 255) {
-		if (x < 0) return 0;
-		if (x > 255) return 255;
-	}
-	return (stbi_uc)x;
+   // trick to use a single test to catch both cases
+   if ((unsigned int) x > 255) {
+      if (x < 0) return 0;
+      if (x > 255) return 255;
+   }
+   return (stbi_uc) x;
 }
 
 #define stbi__f2f(x)  ((int) (((x) * 4096 + 0.5)))
-#define stbi__fsh(x)  ((x) << 12)
+#define stbi__fsh(x)  ((x) * 4096)
 
 // derived from jidctint -- DCT_ISLOW
 #define STBI__IDCT_1D(s0,s1,s2,s3,s4,s5,s6,s7) \
@@ -1978,62 +2203,61 @@ stbi_inline static stbi_uc stbi__clamp(int x)
 
 static void stbi__idct_block(stbi_uc *out, int out_stride, short data[64])
 {
-	int i, val[64], *v = val;
-	stbi_uc *o;
-	short *d = data;
+   int i,val[64],*v=val;
+   stbi_uc *o;
+   short *d = data;
 
-	// columns
-	for (i = 0; i < 8; ++i, ++d, ++v) {
-		// if all zeroes, shortcut -- this avoids dequantizing 0s and IDCTing
-		if (d[8] == 0 && d[16] == 0 && d[24] == 0 && d[32] == 0
-			&& d[40] == 0 && d[48] == 0 && d[56] == 0) {
-			//    no shortcut                 0     seconds
-			//    (1|2|3|4|5|6|7)==0          0     seconds
-			//    all separate               -0.047 seconds
-			//    1 && 2|3 && 4|5 && 6|7:    -0.047 seconds
-			int dcterm = d[0] << 2;
-			v[0] = v[8] = v[16] = v[24] = v[32] = v[40] = v[48] = v[56] = dcterm;
-		}
-		else {
-			STBI__IDCT_1D(d[0], d[8], d[16], d[24], d[32], d[40], d[48], d[56])
-				// constants scaled things up by 1<<12; let's bring them back
-				// down, but keep 2 extra bits of precision
-				x0 += 512; x1 += 512; x2 += 512; x3 += 512;
-			v[0] = (x0 + t3) >> 10;
-			v[56] = (x0 - t3) >> 10;
-			v[8] = (x1 + t2) >> 10;
-			v[48] = (x1 - t2) >> 10;
-			v[16] = (x2 + t1) >> 10;
-			v[40] = (x2 - t1) >> 10;
-			v[24] = (x3 + t0) >> 10;
-			v[32] = (x3 - t0) >> 10;
-		}
-	}
+   // columns
+   for (i=0; i < 8; ++i,++d, ++v) {
+      // if all zeroes, shortcut -- this avoids dequantizing 0s and IDCTing
+      if (d[ 8]==0 && d[16]==0 && d[24]==0 && d[32]==0
+           && d[40]==0 && d[48]==0 && d[56]==0) {
+         //    no shortcut                 0     seconds
+         //    (1|2|3|4|5|6|7)==0          0     seconds
+         //    all separate               -0.047 seconds
+         //    1 && 2|3 && 4|5 && 6|7:    -0.047 seconds
+         int dcterm = d[0]*4;
+         v[0] = v[8] = v[16] = v[24] = v[32] = v[40] = v[48] = v[56] = dcterm;
+      } else {
+         STBI__IDCT_1D(d[ 0],d[ 8],d[16],d[24],d[32],d[40],d[48],d[56])
+         // constants scaled things up by 1<<12; let's bring them back
+         // down, but keep 2 extra bits of precision
+         x0 += 512; x1 += 512; x2 += 512; x3 += 512;
+         v[ 0] = (x0+t3) >> 10;
+         v[56] = (x0-t3) >> 10;
+         v[ 8] = (x1+t2) >> 10;
+         v[48] = (x1-t2) >> 10;
+         v[16] = (x2+t1) >> 10;
+         v[40] = (x2-t1) >> 10;
+         v[24] = (x3+t0) >> 10;
+         v[32] = (x3-t0) >> 10;
+      }
+   }
 
-	for (i = 0, v = val, o = out; i < 8; ++i, v += 8, o += out_stride) {
-		// no fast case since the first 1D IDCT spread components out
-		STBI__IDCT_1D(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7])
-			// constants scaled things up by 1<<12, plus we had 1<<2 from first
-			// loop, plus horizontal and vertical each scale by sqrt(8) so together
-			// we've got an extra 1<<3, so 1<<17 total we need to remove.
-			// so we want to round that, which means adding 0.5 * 1<<17,
-			// aka 65536. Also, we'll end up with -128 to 127 that we want
-			// to encode as 0..255 by adding 128, so we'll add that before the shift
-			x0 += 65536 + (128 << 17);
-		x1 += 65536 + (128 << 17);
-		x2 += 65536 + (128 << 17);
-		x3 += 65536 + (128 << 17);
-		// tried computing the shifts into temps, or'ing the temps to see
-		// if any were out of range, but that was slower
-		o[0] = stbi__clamp((x0 + t3) >> 17);
-		o[7] = stbi__clamp((x0 - t3) >> 17);
-		o[1] = stbi__clamp((x1 + t2) >> 17);
-		o[6] = stbi__clamp((x1 - t2) >> 17);
-		o[2] = stbi__clamp((x2 + t1) >> 17);
-		o[5] = stbi__clamp((x2 - t1) >> 17);
-		o[3] = stbi__clamp((x3 + t0) >> 17);
-		o[4] = stbi__clamp((x3 - t0) >> 17);
-	}
+   for (i=0, v=val, o=out; i < 8; ++i,v+=8,o+=out_stride) {
+      // no fast case since the first 1D IDCT spread components out
+      STBI__IDCT_1D(v[0],v[1],v[2],v[3],v[4],v[5],v[6],v[7])
+      // constants scaled things up by 1<<12, plus we had 1<<2 from first
+      // loop, plus horizontal and vertical each scale by sqrt(8) so together
+      // we've got an extra 1<<3, so 1<<17 total we need to remove.
+      // so we want to round that, which means adding 0.5 * 1<<17,
+      // aka 65536. Also, we'll end up with -128 to 127 that we want
+      // to encode as 0..255 by adding 128, so we'll add that before the shift
+      x0 += 65536 + (128<<17);
+      x1 += 65536 + (128<<17);
+      x2 += 65536 + (128<<17);
+      x3 += 65536 + (128<<17);
+      // tried computing the shifts into temps, or'ing the temps to see
+      // if any were out of range, but that was slower
+      o[0] = stbi__clamp((x0+t3) >> 17);
+      o[7] = stbi__clamp((x0-t3) >> 17);
+      o[1] = stbi__clamp((x1+t2) >> 17);
+      o[6] = stbi__clamp((x1-t2) >> 17);
+      o[2] = stbi__clamp((x2+t1) >> 17);
+      o[5] = stbi__clamp((x2-t1) >> 17);
+      o[3] = stbi__clamp((x3+t0) >> 17);
+      o[4] = stbi__clamp((x3-t0) >> 17);
+   }
 }
 
 #ifdef STBI_SSE2
@@ -2042,16 +2266,16 @@ static void stbi__idct_block(stbi_uc *out, int out_stride, short data[64])
 // fully "transparent".
 static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
 {
-	// This is constructed to match our regular (generic) integer IDCT exactly.
-	__m128i row0, row1, row2, row3, row4, row5, row6, row7;
-	__m128i tmp;
+   // This is constructed to match our regular (generic) integer IDCT exactly.
+   __m128i row0, row1, row2, row3, row4, row5, row6, row7;
+   __m128i tmp;
 
-	// dot product constant: even elems=x, odd elems=y
-#define dct_const(x,y)  _mm_setr_epi16((x),(y),(x),(y),(x),(y),(x),(y))
+   // dot product constant: even elems=x, odd elems=y
+   #define dct_const(x,y)  _mm_setr_epi16((x),(y),(x),(y),(x),(y),(x),(y))
 
-	// out(0) = c0[even]*x + c0[odd]*y   (c0, x, y 16-bit, out 32-bit)
-	// out(1) = c1[even]*x + c1[odd]*y
-#define dct_rot(out0,out1, x,y,c0,c1) \
+   // out(0) = c0[even]*x + c0[odd]*y   (c0, x, y 16-bit, out 32-bit)
+   // out(1) = c1[even]*x + c1[odd]*y
+   #define dct_rot(out0,out1, x,y,c0,c1) \
       __m128i c0##lo = _mm_unpacklo_epi16((x),(y)); \
       __m128i c0##hi = _mm_unpackhi_epi16((x),(y)); \
       __m128i out0##_l = _mm_madd_epi16(c0##lo, c0); \
@@ -2059,23 +2283,23 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
       __m128i out1##_l = _mm_madd_epi16(c0##lo, c1); \
       __m128i out1##_h = _mm_madd_epi16(c0##hi, c1)
 
-	// out = in << 12  (in 16-bit, out 32-bit)
-#define dct_widen(out, in) \
+   // out = in << 12  (in 16-bit, out 32-bit)
+   #define dct_widen(out, in) \
       __m128i out##_l = _mm_srai_epi32(_mm_unpacklo_epi16(_mm_setzero_si128(), (in)), 4); \
       __m128i out##_h = _mm_srai_epi32(_mm_unpackhi_epi16(_mm_setzero_si128(), (in)), 4)
 
-	// wide add
-#define dct_wadd(out, a, b) \
+   // wide add
+   #define dct_wadd(out, a, b) \
       __m128i out##_l = _mm_add_epi32(a##_l, b##_l); \
       __m128i out##_h = _mm_add_epi32(a##_h, b##_h)
 
-	// wide sub
-#define dct_wsub(out, a, b) \
+   // wide sub
+   #define dct_wsub(out, a, b) \
       __m128i out##_l = _mm_sub_epi32(a##_l, b##_l); \
       __m128i out##_h = _mm_sub_epi32(a##_h, b##_h)
 
-	// butterfly a/b, add bias, then shift by "s" and pack
-#define dct_bfly32o(out0, out1, a,b,bias,s) \
+   // butterfly a/b, add bias, then shift by "s" and pack
+   #define dct_bfly32o(out0, out1, a,b,bias,s) \
       { \
          __m128i abiased_l = _mm_add_epi32(a##_l, bias); \
          __m128i abiased_h = _mm_add_epi32(a##_h, bias); \
@@ -2085,19 +2309,19 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
          out1 = _mm_packs_epi32(_mm_srai_epi32(dif_l, s), _mm_srai_epi32(dif_h, s)); \
       }
 
-	// 8-bit interleave step (for transposes)
-#define dct_interleave8(a, b) \
+   // 8-bit interleave step (for transposes)
+   #define dct_interleave8(a, b) \
       tmp = a; \
       a = _mm_unpacklo_epi8(a, b); \
       b = _mm_unpackhi_epi8(tmp, b)
 
-	// 16-bit interleave step (for transposes)
-#define dct_interleave16(a, b) \
+   // 16-bit interleave step (for transposes)
+   #define dct_interleave16(a, b) \
       tmp = a; \
       a = _mm_unpacklo_epi16(a, b); \
       b = _mm_unpackhi_epi16(tmp, b)
 
-#define dct_pass(bias,shift) \
+   #define dct_pass(bias,shift) \
       { \
          /* even part */ \
          dct_rot(t2e,t3e, row2,row6, rot0_0,rot0_1); \
@@ -2125,84 +2349,84 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
          dct_bfly32o(row3,row4, x3,x4,bias,shift); \
       }
 
-	__m128i rot0_0 = dct_const(stbi__f2f(0.5411961f), stbi__f2f(0.5411961f) + stbi__f2f(-1.847759065f));
-	__m128i rot0_1 = dct_const(stbi__f2f(0.5411961f) + stbi__f2f(0.765366865f), stbi__f2f(0.5411961f));
-	__m128i rot1_0 = dct_const(stbi__f2f(1.175875602f) + stbi__f2f(-0.899976223f), stbi__f2f(1.175875602f));
-	__m128i rot1_1 = dct_const(stbi__f2f(1.175875602f), stbi__f2f(1.175875602f) + stbi__f2f(-2.562915447f));
-	__m128i rot2_0 = dct_const(stbi__f2f(-1.961570560f) + stbi__f2f(0.298631336f), stbi__f2f(-1.961570560f));
-	__m128i rot2_1 = dct_const(stbi__f2f(-1.961570560f), stbi__f2f(-1.961570560f) + stbi__f2f(3.072711026f));
-	__m128i rot3_0 = dct_const(stbi__f2f(-0.390180644f) + stbi__f2f(2.053119869f), stbi__f2f(-0.390180644f));
-	__m128i rot3_1 = dct_const(stbi__f2f(-0.390180644f), stbi__f2f(-0.390180644f) + stbi__f2f(1.501321110f));
+   __m128i rot0_0 = dct_const(stbi__f2f(0.5411961f), stbi__f2f(0.5411961f) + stbi__f2f(-1.847759065f));
+   __m128i rot0_1 = dct_const(stbi__f2f(0.5411961f) + stbi__f2f( 0.765366865f), stbi__f2f(0.5411961f));
+   __m128i rot1_0 = dct_const(stbi__f2f(1.175875602f) + stbi__f2f(-0.899976223f), stbi__f2f(1.175875602f));
+   __m128i rot1_1 = dct_const(stbi__f2f(1.175875602f), stbi__f2f(1.175875602f) + stbi__f2f(-2.562915447f));
+   __m128i rot2_0 = dct_const(stbi__f2f(-1.961570560f) + stbi__f2f( 0.298631336f), stbi__f2f(-1.961570560f));
+   __m128i rot2_1 = dct_const(stbi__f2f(-1.961570560f), stbi__f2f(-1.961570560f) + stbi__f2f( 3.072711026f));
+   __m128i rot3_0 = dct_const(stbi__f2f(-0.390180644f) + stbi__f2f( 2.053119869f), stbi__f2f(-0.390180644f));
+   __m128i rot3_1 = dct_const(stbi__f2f(-0.390180644f), stbi__f2f(-0.390180644f) + stbi__f2f( 1.501321110f));
 
-	// rounding biases in column/row passes, see stbi__idct_block for explanation.
-	__m128i bias_0 = _mm_set1_epi32(512);
-	__m128i bias_1 = _mm_set1_epi32(65536 + (128 << 17));
+   // rounding biases in column/row passes, see stbi__idct_block for explanation.
+   __m128i bias_0 = _mm_set1_epi32(512);
+   __m128i bias_1 = _mm_set1_epi32(65536 + (128<<17));
 
-	// load
-	row0 = _mm_load_si128((const __m128i *) (data + 0 * 8));
-	row1 = _mm_load_si128((const __m128i *) (data + 1 * 8));
-	row2 = _mm_load_si128((const __m128i *) (data + 2 * 8));
-	row3 = _mm_load_si128((const __m128i *) (data + 3 * 8));
-	row4 = _mm_load_si128((const __m128i *) (data + 4 * 8));
-	row5 = _mm_load_si128((const __m128i *) (data + 5 * 8));
-	row6 = _mm_load_si128((const __m128i *) (data + 6 * 8));
-	row7 = _mm_load_si128((const __m128i *) (data + 7 * 8));
+   // load
+   row0 = _mm_load_si128((const __m128i *) (data + 0*8));
+   row1 = _mm_load_si128((const __m128i *) (data + 1*8));
+   row2 = _mm_load_si128((const __m128i *) (data + 2*8));
+   row3 = _mm_load_si128((const __m128i *) (data + 3*8));
+   row4 = _mm_load_si128((const __m128i *) (data + 4*8));
+   row5 = _mm_load_si128((const __m128i *) (data + 5*8));
+   row6 = _mm_load_si128((const __m128i *) (data + 6*8));
+   row7 = _mm_load_si128((const __m128i *) (data + 7*8));
 
-	// column pass
-	dct_pass(bias_0, 10);
+   // column pass
+   dct_pass(bias_0, 10);
 
-	{
-		// 16bit 8x8 transpose pass 1
-		dct_interleave16(row0, row4);
-		dct_interleave16(row1, row5);
-		dct_interleave16(row2, row6);
-		dct_interleave16(row3, row7);
+   {
+      // 16bit 8x8 transpose pass 1
+      dct_interleave16(row0, row4);
+      dct_interleave16(row1, row5);
+      dct_interleave16(row2, row6);
+      dct_interleave16(row3, row7);
 
-		// transpose pass 2
-		dct_interleave16(row0, row2);
-		dct_interleave16(row1, row3);
-		dct_interleave16(row4, row6);
-		dct_interleave16(row5, row7);
+      // transpose pass 2
+      dct_interleave16(row0, row2);
+      dct_interleave16(row1, row3);
+      dct_interleave16(row4, row6);
+      dct_interleave16(row5, row7);
 
-		// transpose pass 3
-		dct_interleave16(row0, row1);
-		dct_interleave16(row2, row3);
-		dct_interleave16(row4, row5);
-		dct_interleave16(row6, row7);
-	}
+      // transpose pass 3
+      dct_interleave16(row0, row1);
+      dct_interleave16(row2, row3);
+      dct_interleave16(row4, row5);
+      dct_interleave16(row6, row7);
+   }
 
-	// row pass
-	dct_pass(bias_1, 17);
+   // row pass
+   dct_pass(bias_1, 17);
 
-	{
-		// pack
-		__m128i p0 = _mm_packus_epi16(row0, row1); // a0a1a2a3...a7b0b1b2b3...b7
-		__m128i p1 = _mm_packus_epi16(row2, row3);
-		__m128i p2 = _mm_packus_epi16(row4, row5);
-		__m128i p3 = _mm_packus_epi16(row6, row7);
+   {
+      // pack
+      __m128i p0 = _mm_packus_epi16(row0, row1); // a0a1a2a3...a7b0b1b2b3...b7
+      __m128i p1 = _mm_packus_epi16(row2, row3);
+      __m128i p2 = _mm_packus_epi16(row4, row5);
+      __m128i p3 = _mm_packus_epi16(row6, row7);
 
-		// 8bit 8x8 transpose pass 1
-		dct_interleave8(p0, p2); // a0e0a1e1...
-		dct_interleave8(p1, p3); // c0g0c1g1...
+      // 8bit 8x8 transpose pass 1
+      dct_interleave8(p0, p2); // a0e0a1e1...
+      dct_interleave8(p1, p3); // c0g0c1g1...
 
-								 // transpose pass 2
-		dct_interleave8(p0, p1); // a0c0e0g0...
-		dct_interleave8(p2, p3); // b0d0f0h0...
+      // transpose pass 2
+      dct_interleave8(p0, p1); // a0c0e0g0...
+      dct_interleave8(p2, p3); // b0d0f0h0...
 
-								 // transpose pass 3
-		dct_interleave8(p0, p2); // a0b0c0d0...
-		dct_interleave8(p1, p3); // a4b4c4d4...
+      // transpose pass 3
+      dct_interleave8(p0, p2); // a0b0c0d0...
+      dct_interleave8(p1, p3); // a4b4c4d4...
 
-								 // store
-		_mm_storel_epi64((__m128i *) out, p0); out += out_stride;
-		_mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p0, 0x4e)); out += out_stride;
-		_mm_storel_epi64((__m128i *) out, p2); out += out_stride;
-		_mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p2, 0x4e)); out += out_stride;
-		_mm_storel_epi64((__m128i *) out, p1); out += out_stride;
-		_mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p1, 0x4e)); out += out_stride;
-		_mm_storel_epi64((__m128i *) out, p3); out += out_stride;
-		_mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p3, 0x4e));
-	}
+      // store
+      _mm_storel_epi64((__m128i *) out, p0); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p0, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p2); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p2, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p1); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p1, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p3); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p3, 0x4e));
+   }
 
 #undef dct_const
 #undef dct_rot
@@ -2223,20 +2447,20 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
 // results to the generic C version.
 static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
 {
-	int16x8_t row0, row1, row2, row3, row4, row5, row6, row7;
+   int16x8_t row0, row1, row2, row3, row4, row5, row6, row7;
 
-	int16x4_t rot0_0 = vdup_n_s16(stbi__f2f(0.5411961f));
-	int16x4_t rot0_1 = vdup_n_s16(stbi__f2f(-1.847759065f));
-	int16x4_t rot0_2 = vdup_n_s16(stbi__f2f(0.765366865f));
-	int16x4_t rot1_0 = vdup_n_s16(stbi__f2f(1.175875602f));
-	int16x4_t rot1_1 = vdup_n_s16(stbi__f2f(-0.899976223f));
-	int16x4_t rot1_2 = vdup_n_s16(stbi__f2f(-2.562915447f));
-	int16x4_t rot2_0 = vdup_n_s16(stbi__f2f(-1.961570560f));
-	int16x4_t rot2_1 = vdup_n_s16(stbi__f2f(-0.390180644f));
-	int16x4_t rot3_0 = vdup_n_s16(stbi__f2f(0.298631336f));
-	int16x4_t rot3_1 = vdup_n_s16(stbi__f2f(2.053119869f));
-	int16x4_t rot3_2 = vdup_n_s16(stbi__f2f(3.072711026f));
-	int16x4_t rot3_3 = vdup_n_s16(stbi__f2f(1.501321110f));
+   int16x4_t rot0_0 = vdup_n_s16(stbi__f2f(0.5411961f));
+   int16x4_t rot0_1 = vdup_n_s16(stbi__f2f(-1.847759065f));
+   int16x4_t rot0_2 = vdup_n_s16(stbi__f2f( 0.765366865f));
+   int16x4_t rot1_0 = vdup_n_s16(stbi__f2f( 1.175875602f));
+   int16x4_t rot1_1 = vdup_n_s16(stbi__f2f(-0.899976223f));
+   int16x4_t rot1_2 = vdup_n_s16(stbi__f2f(-2.562915447f));
+   int16x4_t rot2_0 = vdup_n_s16(stbi__f2f(-1.961570560f));
+   int16x4_t rot2_1 = vdup_n_s16(stbi__f2f(-0.390180644f));
+   int16x4_t rot3_0 = vdup_n_s16(stbi__f2f( 0.298631336f));
+   int16x4_t rot3_1 = vdup_n_s16(stbi__f2f( 2.053119869f));
+   int16x4_t rot3_2 = vdup_n_s16(stbi__f2f( 3.072711026f));
+   int16x4_t rot3_3 = vdup_n_s16(stbi__f2f( 1.501321110f));
 
 #define dct_long_mul(out, inq, coeff) \
    int32x4_t out##_l = vmull_s16(vget_low_s16(inq), coeff); \
@@ -2250,17 +2474,17 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
    int32x4_t out##_l = vshll_n_s16(vget_low_s16(inq), 12); \
    int32x4_t out##_h = vshll_n_s16(vget_high_s16(inq), 12)
 
-	// wide add
+// wide add
 #define dct_wadd(out, a, b) \
    int32x4_t out##_l = vaddq_s32(a##_l, b##_l); \
    int32x4_t out##_h = vaddq_s32(a##_h, b##_h)
 
-	// wide sub
+// wide sub
 #define dct_wsub(out, a, b) \
    int32x4_t out##_l = vsubq_s32(a##_l, b##_l); \
    int32x4_t out##_h = vsubq_s32(a##_h, b##_h)
 
-	// butterfly a/b, then shift using "shiftop" by "s" and pack
+// butterfly a/b, then shift using "shiftop" by "s" and pack
 #define dct_bfly32o(out0,out1, a,b,shiftop,s) \
    { \
       dct_wadd(sum, a, b); \
@@ -2309,110 +2533,110 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
       dct_bfly32o(row3,row4, x3,x4,shiftop,shift); \
    }
 
-	// load
-	row0 = vld1q_s16(data + 0 * 8);
-	row1 = vld1q_s16(data + 1 * 8);
-	row2 = vld1q_s16(data + 2 * 8);
-	row3 = vld1q_s16(data + 3 * 8);
-	row4 = vld1q_s16(data + 4 * 8);
-	row5 = vld1q_s16(data + 5 * 8);
-	row6 = vld1q_s16(data + 6 * 8);
-	row7 = vld1q_s16(data + 7 * 8);
+   // load
+   row0 = vld1q_s16(data + 0*8);
+   row1 = vld1q_s16(data + 1*8);
+   row2 = vld1q_s16(data + 2*8);
+   row3 = vld1q_s16(data + 3*8);
+   row4 = vld1q_s16(data + 4*8);
+   row5 = vld1q_s16(data + 5*8);
+   row6 = vld1q_s16(data + 6*8);
+   row7 = vld1q_s16(data + 7*8);
 
-	// add DC bias
-	row0 = vaddq_s16(row0, vsetq_lane_s16(1024, vdupq_n_s16(0), 0));
+   // add DC bias
+   row0 = vaddq_s16(row0, vsetq_lane_s16(1024, vdupq_n_s16(0), 0));
 
-	// column pass
-	dct_pass(vrshrn_n_s32, 10);
+   // column pass
+   dct_pass(vrshrn_n_s32, 10);
 
-	// 16bit 8x8 transpose
-	{
-		// these three map to a single VTRN.16, VTRN.32, and VSWP, respectively.
-		// whether compilers actually get this is another story, sadly.
+   // 16bit 8x8 transpose
+   {
+// these three map to a single VTRN.16, VTRN.32, and VSWP, respectively.
+// whether compilers actually get this is another story, sadly.
 #define dct_trn16(x, y) { int16x8x2_t t = vtrnq_s16(x, y); x = t.val[0]; y = t.val[1]; }
 #define dct_trn32(x, y) { int32x4x2_t t = vtrnq_s32(vreinterpretq_s32_s16(x), vreinterpretq_s32_s16(y)); x = vreinterpretq_s16_s32(t.val[0]); y = vreinterpretq_s16_s32(t.val[1]); }
 #define dct_trn64(x, y) { int16x8_t x0 = x; int16x8_t y0 = y; x = vcombine_s16(vget_low_s16(x0), vget_low_s16(y0)); y = vcombine_s16(vget_high_s16(x0), vget_high_s16(y0)); }
 
-		// pass 1
-		dct_trn16(row0, row1); // a0b0a2b2a4b4a6b6
-		dct_trn16(row2, row3);
-		dct_trn16(row4, row5);
-		dct_trn16(row6, row7);
+      // pass 1
+      dct_trn16(row0, row1); // a0b0a2b2a4b4a6b6
+      dct_trn16(row2, row3);
+      dct_trn16(row4, row5);
+      dct_trn16(row6, row7);
 
-		// pass 2
-		dct_trn32(row0, row2); // a0b0c0d0a4b4c4d4
-		dct_trn32(row1, row3);
-		dct_trn32(row4, row6);
-		dct_trn32(row5, row7);
+      // pass 2
+      dct_trn32(row0, row2); // a0b0c0d0a4b4c4d4
+      dct_trn32(row1, row3);
+      dct_trn32(row4, row6);
+      dct_trn32(row5, row7);
 
-		// pass 3
-		dct_trn64(row0, row4); // a0b0c0d0e0f0g0h0
-		dct_trn64(row1, row5);
-		dct_trn64(row2, row6);
-		dct_trn64(row3, row7);
+      // pass 3
+      dct_trn64(row0, row4); // a0b0c0d0e0f0g0h0
+      dct_trn64(row1, row5);
+      dct_trn64(row2, row6);
+      dct_trn64(row3, row7);
 
 #undef dct_trn16
 #undef dct_trn32
 #undef dct_trn64
-	}
+   }
 
-	// row pass
-	// vrshrn_n_s32 only supports shifts up to 16, we need
-	// 17. so do a non-rounding shift of 16 first then follow
-	// up with a rounding shift by 1.
-	dct_pass(vshrn_n_s32, 16);
+   // row pass
+   // vrshrn_n_s32 only supports shifts up to 16, we need
+   // 17. so do a non-rounding shift of 16 first then follow
+   // up with a rounding shift by 1.
+   dct_pass(vshrn_n_s32, 16);
 
-	{
-		// pack and round
-		uint8x8_t p0 = vqrshrun_n_s16(row0, 1);
-		uint8x8_t p1 = vqrshrun_n_s16(row1, 1);
-		uint8x8_t p2 = vqrshrun_n_s16(row2, 1);
-		uint8x8_t p3 = vqrshrun_n_s16(row3, 1);
-		uint8x8_t p4 = vqrshrun_n_s16(row4, 1);
-		uint8x8_t p5 = vqrshrun_n_s16(row5, 1);
-		uint8x8_t p6 = vqrshrun_n_s16(row6, 1);
-		uint8x8_t p7 = vqrshrun_n_s16(row7, 1);
+   {
+      // pack and round
+      uint8x8_t p0 = vqrshrun_n_s16(row0, 1);
+      uint8x8_t p1 = vqrshrun_n_s16(row1, 1);
+      uint8x8_t p2 = vqrshrun_n_s16(row2, 1);
+      uint8x8_t p3 = vqrshrun_n_s16(row3, 1);
+      uint8x8_t p4 = vqrshrun_n_s16(row4, 1);
+      uint8x8_t p5 = vqrshrun_n_s16(row5, 1);
+      uint8x8_t p6 = vqrshrun_n_s16(row6, 1);
+      uint8x8_t p7 = vqrshrun_n_s16(row7, 1);
 
-		// again, these can translate into one instruction, but often don't.
+      // again, these can translate into one instruction, but often don't.
 #define dct_trn8_8(x, y) { uint8x8x2_t t = vtrn_u8(x, y); x = t.val[0]; y = t.val[1]; }
 #define dct_trn8_16(x, y) { uint16x4x2_t t = vtrn_u16(vreinterpret_u16_u8(x), vreinterpret_u16_u8(y)); x = vreinterpret_u8_u16(t.val[0]); y = vreinterpret_u8_u16(t.val[1]); }
 #define dct_trn8_32(x, y) { uint32x2x2_t t = vtrn_u32(vreinterpret_u32_u8(x), vreinterpret_u32_u8(y)); x = vreinterpret_u8_u32(t.val[0]); y = vreinterpret_u8_u32(t.val[1]); }
 
-		// sadly can't use interleaved stores here since we only write
-		// 8 bytes to each scan line!
+      // sadly can't use interleaved stores here since we only write
+      // 8 bytes to each scan line!
 
-		// 8x8 8-bit transpose pass 1
-		dct_trn8_8(p0, p1);
-		dct_trn8_8(p2, p3);
-		dct_trn8_8(p4, p5);
-		dct_trn8_8(p6, p7);
+      // 8x8 8-bit transpose pass 1
+      dct_trn8_8(p0, p1);
+      dct_trn8_8(p2, p3);
+      dct_trn8_8(p4, p5);
+      dct_trn8_8(p6, p7);
 
-		// pass 2
-		dct_trn8_16(p0, p2);
-		dct_trn8_16(p1, p3);
-		dct_trn8_16(p4, p6);
-		dct_trn8_16(p5, p7);
+      // pass 2
+      dct_trn8_16(p0, p2);
+      dct_trn8_16(p1, p3);
+      dct_trn8_16(p4, p6);
+      dct_trn8_16(p5, p7);
 
-		// pass 3
-		dct_trn8_32(p0, p4);
-		dct_trn8_32(p1, p5);
-		dct_trn8_32(p2, p6);
-		dct_trn8_32(p3, p7);
+      // pass 3
+      dct_trn8_32(p0, p4);
+      dct_trn8_32(p1, p5);
+      dct_trn8_32(p2, p6);
+      dct_trn8_32(p3, p7);
 
-		// store
-		vst1_u8(out, p0); out += out_stride;
-		vst1_u8(out, p1); out += out_stride;
-		vst1_u8(out, p2); out += out_stride;
-		vst1_u8(out, p3); out += out_stride;
-		vst1_u8(out, p4); out += out_stride;
-		vst1_u8(out, p5); out += out_stride;
-		vst1_u8(out, p6); out += out_stride;
-		vst1_u8(out, p7);
+      // store
+      vst1_u8(out, p0); out += out_stride;
+      vst1_u8(out, p1); out += out_stride;
+      vst1_u8(out, p2); out += out_stride;
+      vst1_u8(out, p3); out += out_stride;
+      vst1_u8(out, p4); out += out_stride;
+      vst1_u8(out, p5); out += out_stride;
+      vst1_u8(out, p6); out += out_stride;
+      vst1_u8(out, p7);
 
 #undef dct_trn8_8
 #undef dct_trn8_16
 #undef dct_trn8_32
-	}
+   }
 
 #undef dct_long_mul
 #undef dct_long_mac
@@ -2431,13 +2655,13 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
 // marker, return 0xff, which is never a valid marker value
 static stbi_uc stbi__get_marker(stbi__jpeg *j)
 {
-	stbi_uc x;
-	if (j->marker != STBI__MARKER_none) { x = j->marker; j->marker = STBI__MARKER_none; return x; }
-	x = stbi__get8(j->s);
-	if (x != 0xff) return STBI__MARKER_none;
-	while (x == 0xff)
-		x = stbi__get8(j->s);
-	return x;
+   stbi_uc x;
+   if (j->marker != STBI__MARKER_none) { x = j->marker; j->marker = STBI__MARKER_none; return x; }
+   x = stbi__get8(j->s);
+   if (x != 0xff) return STBI__MARKER_none;
+   while (x == 0xff)
+      x = stbi__get8(j->s); // consume repeated 0xff fill bytes
+   return x;
 }
 
 // in each scan, we'll have scan_n components, and the order
@@ -2448,357 +2672,412 @@ static stbi_uc stbi__get_marker(stbi__jpeg *j)
 // the dc prediction
 static void stbi__jpeg_reset(stbi__jpeg *j)
 {
-	j->code_bits = 0;
-	j->code_buffer = 0;
-	j->nomore = 0;
-	j->img_comp[0].dc_pred = j->img_comp[1].dc_pred = j->img_comp[2].dc_pred = 0;
-	j->marker = STBI__MARKER_none;
-	j->todo = j->restart_interval ? j->restart_interval : 0x7fffffff;
-	j->eob_run = 0;
-	// no more than 1<<31 MCUs if no restart_interal? that's plenty safe,
-	// since we don't even allow 1<<30 pixels
+   j->code_bits = 0;
+   j->code_buffer = 0;
+   j->nomore = 0;
+   j->img_comp[0].dc_pred = j->img_comp[1].dc_pred = j->img_comp[2].dc_pred = j->img_comp[3].dc_pred = 0;
+   j->marker = STBI__MARKER_none;
+   j->todo = j->restart_interval ? j->restart_interval : 0x7fffffff;
+   j->eob_run = 0;
+   // no more than 1<<31 MCUs if no restart_interal? that's plenty safe,
+   // since we don't even allow 1<<30 pixels
 }
 
 static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
 {
-	stbi__jpeg_reset(z);
-	if (!z->progressive) {
-		if (z->scan_n == 1) {
-			int i, j;
-			STBI_SIMD_ALIGN(short, data[64]);
-			int n = z->order[0];
-			// non-interleaved data, we just need to process one block at a time,
-			// in trivial scanline order
-			// number of blocks to do just depends on how many actual "pixels" this
-			// component has, independent of interleaved MCU blocking and such
-			int w = (z->img_comp[n].x + 7) >> 3;
-			int h = (z->img_comp[n].y + 7) >> 3;
-			for (j = 0; j < h; ++j) {
-				for (i = 0; i < w; ++i) {
-					int ha = z->img_comp[n].ha;
-					if (!stbi__jpeg_decode_block(z, data, z->huff_dc + z->img_comp[n].hd, z->huff_ac + ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq])) return 0;
-					z->idct_block_kernel(z->img_comp[n].data + z->img_comp[n].w2*j * 8 + i * 8, z->img_comp[n].w2, data);
-					// every data block is an MCU, so countdown the restart interval
-					if (--z->todo <= 0) {
-						if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
-						// if it's NOT a restart, then just bail, so we get corrupt data
-						// rather than no data
-						if (!STBI__RESTART(z->marker)) return 1;
-						stbi__jpeg_reset(z);
-					}
-				}
-			}
-			return 1;
-		}
-		else { // interleaved
-			int i, j, k, x, y;
-			STBI_SIMD_ALIGN(short, data[64]);
-			for (j = 0; j < z->img_mcu_y; ++j) {
-				for (i = 0; i < z->img_mcu_x; ++i) {
-					// scan an interleaved mcu... process scan_n components in order
-					for (k = 0; k < z->scan_n; ++k) {
-						int n = z->order[k];
-						// scan out an mcu's worth of this component; that's just determined
-						// by the basic H and V specified for the component
-						for (y = 0; y < z->img_comp[n].v; ++y) {
-							for (x = 0; x < z->img_comp[n].h; ++x) {
-								int x2 = (i*z->img_comp[n].h + x) * 8;
-								int y2 = (j*z->img_comp[n].v + y) * 8;
-								int ha = z->img_comp[n].ha;
-								if (!stbi__jpeg_decode_block(z, data, z->huff_dc + z->img_comp[n].hd, z->huff_ac + ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq])) return 0;
-								z->idct_block_kernel(z->img_comp[n].data + z->img_comp[n].w2*y2 + x2, z->img_comp[n].w2, data);
-							}
-						}
-					}
-					// after all interleaved components, that's an interleaved MCU,
-					// so now count down the restart interval
-					if (--z->todo <= 0) {
-						if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
-						if (!STBI__RESTART(z->marker)) return 1;
-						stbi__jpeg_reset(z);
-					}
-				}
-			}
-			return 1;
-		}
-	}
-	else {
-		if (z->scan_n == 1) {
-			int i, j;
-			int n = z->order[0];
-			// non-interleaved data, we just need to process one block at a time,
-			// in trivial scanline order
-			// number of blocks to do just depends on how many actual "pixels" this
-			// component has, independent of interleaved MCU blocking and such
-			int w = (z->img_comp[n].x + 7) >> 3;
-			int h = (z->img_comp[n].y + 7) >> 3;
-			for (j = 0; j < h; ++j) {
-				for (i = 0; i < w; ++i) {
-					short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
-					if (z->spec_start == 0) {
-						if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
-							return 0;
-					}
-					else {
-						int ha = z->img_comp[n].ha;
-						if (!stbi__jpeg_decode_block_prog_ac(z, data, &z->huff_ac[ha], z->fast_ac[ha]))
-							return 0;
-					}
-					// every data block is an MCU, so countdown the restart interval
-					if (--z->todo <= 0) {
-						if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
-						if (!STBI__RESTART(z->marker)) return 1;
-						stbi__jpeg_reset(z);
-					}
-				}
-			}
-			return 1;
-		}
-		else { // interleaved
-			int i, j, k, x, y;
-			for (j = 0; j < z->img_mcu_y; ++j) {
-				for (i = 0; i < z->img_mcu_x; ++i) {
-					// scan an interleaved mcu... process scan_n components in order
-					for (k = 0; k < z->scan_n; ++k) {
-						int n = z->order[k];
-						// scan out an mcu's worth of this component; that's just determined
-						// by the basic H and V specified for the component
-						for (y = 0; y < z->img_comp[n].v; ++y) {
-							for (x = 0; x < z->img_comp[n].h; ++x) {
-								int x2 = (i*z->img_comp[n].h + x);
-								int y2 = (j*z->img_comp[n].v + y);
-								short *data = z->img_comp[n].coeff + 64 * (x2 + y2 * z->img_comp[n].coeff_w);
-								if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
-									return 0;
-							}
-						}
-					}
-					// after all interleaved components, that's an interleaved MCU,
-					// so now count down the restart interval
-					if (--z->todo <= 0) {
-						if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
-						if (!STBI__RESTART(z->marker)) return 1;
-						stbi__jpeg_reset(z);
-					}
-				}
-			}
-			return 1;
-		}
-	}
+   stbi__jpeg_reset(z);
+   if (!z->progressive) {
+      if (z->scan_n == 1) {
+         int i,j;
+         STBI_SIMD_ALIGN(short, data[64]);
+         int n = z->order[0];
+         // non-interleaved data, we just need to process one block at a time,
+         // in trivial scanline order
+         // number of blocks to do just depends on how many actual "pixels" this
+         // component has, independent of interleaved MCU blocking and such
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               int ha = z->img_comp[n].ha;
+               if (!stbi__jpeg_decode_block(z, data, z->huff_dc+z->img_comp[n].hd, z->huff_ac+ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq])) return 0;
+               z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*j*8+i*8, z->img_comp[n].w2, data);
+               // every data block is an MCU, so countdown the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  // if it's NOT a restart, then just bail, so we get corrupt data
+                  // rather than no data
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      } else { // interleaved
+         int i,j,k,x,y;
+         STBI_SIMD_ALIGN(short, data[64]);
+         for (j=0; j < z->img_mcu_y; ++j) {
+            for (i=0; i < z->img_mcu_x; ++i) {
+               // scan an interleaved mcu... process scan_n components in order
+               for (k=0; k < z->scan_n; ++k) {
+                  int n = z->order[k];
+                  // scan out an mcu's worth of this component; that's just determined
+                  // by the basic H and V specified for the component
+                  for (y=0; y < z->img_comp[n].v; ++y) {
+                     for (x=0; x < z->img_comp[n].h; ++x) {
+                        int x2 = (i*z->img_comp[n].h + x)*8;
+                        int y2 = (j*z->img_comp[n].v + y)*8;
+                        int ha = z->img_comp[n].ha;
+                        if (!stbi__jpeg_decode_block(z, data, z->huff_dc+z->img_comp[n].hd, z->huff_ac+ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq])) return 0;
+                        z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*y2+x2, z->img_comp[n].w2, data);
+                     }
+                  }
+               }
+               // after all interleaved components, that's an interleaved MCU,
+               // so now count down the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      }
+   } else {
+      if (z->scan_n == 1) {
+         int i,j;
+         int n = z->order[0];
+         // non-interleaved data, we just need to process one block at a time,
+         // in trivial scanline order
+         // number of blocks to do just depends on how many actual "pixels" this
+         // component has, independent of interleaved MCU blocking and such
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
+               if (z->spec_start == 0) {
+                  if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
+                     return 0;
+               } else {
+                  int ha = z->img_comp[n].ha;
+                  if (!stbi__jpeg_decode_block_prog_ac(z, data, &z->huff_ac[ha], z->fast_ac[ha]))
+                     return 0;
+               }
+               // every data block is an MCU, so countdown the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      } else { // interleaved
+         int i,j,k,x,y;
+         for (j=0; j < z->img_mcu_y; ++j) {
+            for (i=0; i < z->img_mcu_x; ++i) {
+               // scan an interleaved mcu... process scan_n components in order
+               for (k=0; k < z->scan_n; ++k) {
+                  int n = z->order[k];
+                  // scan out an mcu's worth of this component; that's just determined
+                  // by the basic H and V specified for the component
+                  for (y=0; y < z->img_comp[n].v; ++y) {
+                     for (x=0; x < z->img_comp[n].h; ++x) {
+                        int x2 = (i*z->img_comp[n].h + x);
+                        int y2 = (j*z->img_comp[n].v + y);
+                        short *data = z->img_comp[n].coeff + 64 * (x2 + y2 * z->img_comp[n].coeff_w);
+                        if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
+                           return 0;
+                     }
+                  }
+               }
+               // after all interleaved components, that's an interleaved MCU,
+               // so now count down the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      }
+   }
 }
 
-static void stbi__jpeg_dequantize(short *data, stbi_uc *dequant)
+static void stbi__jpeg_dequantize(short *data, stbi__uint16 *dequant)
 {
-	int i;
-	for (i = 0; i < 64; ++i)
-		data[i] *= dequant[i];
+   int i;
+   for (i=0; i < 64; ++i)
+      data[i] *= dequant[i];
 }
 
 static void stbi__jpeg_finish(stbi__jpeg *z)
 {
-	if (z->progressive) {
-		// dequantize and idct the data
-		int i, j, n;
-		for (n = 0; n < z->s->img_n; ++n) {
-			int w = (z->img_comp[n].x + 7) >> 3;
-			int h = (z->img_comp[n].y + 7) >> 3;
-			for (j = 0; j < h; ++j) {
-				for (i = 0; i < w; ++i) {
-					short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
-					stbi__jpeg_dequantize(data, z->dequant[z->img_comp[n].tq]);
-					z->idct_block_kernel(z->img_comp[n].data + z->img_comp[n].w2*j * 8 + i * 8, z->img_comp[n].w2, data);
-				}
-			}
-		}
-	}
+   if (z->progressive) {
+      // dequantize and idct the data
+      int i,j,n;
+      for (n=0; n < z->s->img_n; ++n) {
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
+               stbi__jpeg_dequantize(data, z->dequant[z->img_comp[n].tq]);
+               z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*j*8+i*8, z->img_comp[n].w2, data);
+            }
+         }
+      }
+   }
 }
 
 static int stbi__process_marker(stbi__jpeg *z, int m)
 {
-	int L;
-	switch (m) {
-	case STBI__MARKER_none: // no marker found
-		return stbi__err("expected marker", "Corrupt JPEG");
+   int L;
+   switch (m) {
+      case STBI__MARKER_none: // no marker found
+         return stbi__err("expected marker","Corrupt JPEG");
 
-	case 0xDD: // DRI - specify restart interval
-		if (stbi__get16be(z->s) != 4) return stbi__err("bad DRI len", "Corrupt JPEG");
-		z->restart_interval = stbi__get16be(z->s);
-		return 1;
+      case 0xDD: // DRI - specify restart interval
+         if (stbi__get16be(z->s) != 4) return stbi__err("bad DRI len","Corrupt JPEG");
+         z->restart_interval = stbi__get16be(z->s);
+         return 1;
 
-	case 0xDB: // DQT - define quantization table
-		L = stbi__get16be(z->s) - 2;
-		while (L > 0) {
-			int q = stbi__get8(z->s);
-			int p = q >> 4;
-			int t = q & 15, i;
-			if (p != 0) return stbi__err("bad DQT type", "Corrupt JPEG");
-			if (t > 3) return stbi__err("bad DQT table", "Corrupt JPEG");
-			for (i = 0; i < 64; ++i)
-				z->dequant[t][stbi__jpeg_dezigzag[i]] = stbi__get8(z->s);
-			L -= 65;
-		}
-		return L == 0;
+      case 0xDB: // DQT - define quantization table
+         L = stbi__get16be(z->s)-2;
+         while (L > 0) {
+            int q = stbi__get8(z->s);
+            int p = q >> 4, sixteen = (p != 0);
+            int t = q & 15,i;
+            if (p != 0 && p != 1) return stbi__err("bad DQT type","Corrupt JPEG");
+            if (t > 3) return stbi__err("bad DQT table","Corrupt JPEG");
 
-	case 0xC4: // DHT - define huffman table
-		L = stbi__get16be(z->s) - 2;
-		while (L > 0) {
-			stbi_uc *v;
-			int sizes[16], i, n = 0;
-			int q = stbi__get8(z->s);
-			int tc = q >> 4;
-			int th = q & 15;
-			if (tc > 1 || th > 3) return stbi__err("bad DHT header", "Corrupt JPEG");
-			for (i = 0; i < 16; ++i) {
-				sizes[i] = stbi__get8(z->s);
-				n += sizes[i];
-			}
-			L -= 17;
-			if (tc == 0) {
-				if (!stbi__build_huffman(z->huff_dc + th, sizes)) return 0;
-				v = z->huff_dc[th].values;
-			}
-			else {
-				if (!stbi__build_huffman(z->huff_ac + th, sizes)) return 0;
-				v = z->huff_ac[th].values;
-			}
-			for (i = 0; i < n; ++i)
-				v[i] = stbi__get8(z->s);
-			if (tc != 0)
-				stbi__build_fast_ac(z->fast_ac[th], z->huff_ac + th);
-			L -= n;
-		}
-		return L == 0;
-	}
-	// check for comment block or APP blocks
-	if ((m >= 0xE0 && m <= 0xEF) || m == 0xFE) {
-		stbi__skip(z->s, stbi__get16be(z->s) - 2);
-		return 1;
-	}
-	return 0;
+            for (i=0; i < 64; ++i)
+               z->dequant[t][stbi__jpeg_dezigzag[i]] = (stbi__uint16)(sixteen ? stbi__get16be(z->s) : stbi__get8(z->s));
+            L -= (sixteen ? 129 : 65);
+         }
+         return L==0;
+
+      case 0xC4: // DHT - define huffman table
+         L = stbi__get16be(z->s)-2;
+         while (L > 0) {
+            stbi_uc *v;
+            int sizes[16],i,n=0;
+            int q = stbi__get8(z->s);
+            int tc = q >> 4;
+            int th = q & 15;
+            if (tc > 1 || th > 3) return stbi__err("bad DHT header","Corrupt JPEG");
+            for (i=0; i < 16; ++i) {
+               sizes[i] = stbi__get8(z->s);
+               n += sizes[i];
+            }
+            L -= 17;
+            if (tc == 0) {
+               if (!stbi__build_huffman(z->huff_dc+th, sizes)) return 0;
+               v = z->huff_dc[th].values;
+            } else {
+               if (!stbi__build_huffman(z->huff_ac+th, sizes)) return 0;
+               v = z->huff_ac[th].values;
+            }
+            for (i=0; i < n; ++i)
+               v[i] = stbi__get8(z->s);
+            if (tc != 0)
+               stbi__build_fast_ac(z->fast_ac[th], z->huff_ac + th);
+            L -= n;
+         }
+         return L==0;
+   }
+
+   // check for comment block or APP blocks
+   if ((m >= 0xE0 && m <= 0xEF) || m == 0xFE) {
+      L = stbi__get16be(z->s);
+      if (L < 2) {
+         if (m == 0xFE)
+            return stbi__err("bad COM len","Corrupt JPEG");
+         else
+            return stbi__err("bad APP len","Corrupt JPEG");
+      }
+      L -= 2;
+
+      if (m == 0xE0 && L >= 5) { // JFIF APP0 segment
+         static const unsigned char tag[5] = {'J','F','I','F','\0'};
+         int ok = 1;
+         int i;
+         for (i=0; i < 5; ++i)
+            if (stbi__get8(z->s) != tag[i])
+               ok = 0;
+         L -= 5;
+         if (ok)
+            z->jfif = 1;
+      } else if (m == 0xEE && L >= 12) { // Adobe APP14 segment
+         static const unsigned char tag[6] = {'A','d','o','b','e','\0'};
+         int ok = 1;
+         int i;
+         for (i=0; i < 6; ++i)
+            if (stbi__get8(z->s) != tag[i])
+               ok = 0;
+         L -= 6;
+         if (ok) {
+            stbi__get8(z->s); // version
+            stbi__get16be(z->s); // flags0
+            stbi__get16be(z->s); // flags1
+            z->app14_color_transform = stbi__get8(z->s); // color transform
+            L -= 6;
+         }
+      }
+
+      stbi__skip(z->s, L);
+      return 1;
+   }
+
+   return stbi__err("unknown marker","Corrupt JPEG");
 }
 
 // after we see SOS
 static int stbi__process_scan_header(stbi__jpeg *z)
 {
-	int i;
-	int Ls = stbi__get16be(z->s);
-	z->scan_n = stbi__get8(z->s);
-	if (z->scan_n < 1 || z->scan_n > 4 || z->scan_n > (int)z->s->img_n) return stbi__err("bad SOS component count", "Corrupt JPEG");
-	if (Ls != 6 + 2 * z->scan_n) return stbi__err("bad SOS len", "Corrupt JPEG");
-	for (i = 0; i < z->scan_n; ++i) {
-		int id = stbi__get8(z->s), which;
-		int q = stbi__get8(z->s);
-		for (which = 0; which < z->s->img_n; ++which)
-			if (z->img_comp[which].id == id)
-				break;
-		if (which == z->s->img_n) return 0; // no match
-		z->img_comp[which].hd = q >> 4;   if (z->img_comp[which].hd > 3) return stbi__err("bad DC huff", "Corrupt JPEG");
-		z->img_comp[which].ha = q & 15;   if (z->img_comp[which].ha > 3) return stbi__err("bad AC huff", "Corrupt JPEG");
-		z->order[i] = which;
-	}
+   int i;
+   int Ls = stbi__get16be(z->s);
+   z->scan_n = stbi__get8(z->s);
+   if (z->scan_n < 1 || z->scan_n > 4 || z->scan_n > (int) z->s->img_n) return stbi__err("bad SOS component count","Corrupt JPEG");
+   if (Ls != 6+2*z->scan_n) return stbi__err("bad SOS len","Corrupt JPEG");
+   for (i=0; i < z->scan_n; ++i) {
+      int id = stbi__get8(z->s), which;
+      int q = stbi__get8(z->s);
+      for (which = 0; which < z->s->img_n; ++which)
+         if (z->img_comp[which].id == id)
+            break;
+      if (which == z->s->img_n) return 0; // no match
+      z->img_comp[which].hd = q >> 4;   if (z->img_comp[which].hd > 3) return stbi__err("bad DC huff","Corrupt JPEG");
+      z->img_comp[which].ha = q & 15;   if (z->img_comp[which].ha > 3) return stbi__err("bad AC huff","Corrupt JPEG");
+      z->order[i] = which;
+   }
 
-	{
-		int aa;
-		z->spec_start = stbi__get8(z->s);
-		z->spec_end = stbi__get8(z->s); // should be 63, but might be 0
-		aa = stbi__get8(z->s);
-		z->succ_high = (aa >> 4);
-		z->succ_low = (aa & 15);
-		if (z->progressive) {
-			if (z->spec_start > 63 || z->spec_end > 63 || z->spec_start > z->spec_end || z->succ_high > 13 || z->succ_low > 13)
-				return stbi__err("bad SOS", "Corrupt JPEG");
-		}
-		else {
-			if (z->spec_start != 0) return stbi__err("bad SOS", "Corrupt JPEG");
-			if (z->succ_high != 0 || z->succ_low != 0) return stbi__err("bad SOS", "Corrupt JPEG");
-			z->spec_end = 63;
-		}
-	}
+   {
+      int aa;
+      z->spec_start = stbi__get8(z->s);
+      z->spec_end   = stbi__get8(z->s); // should be 63, but might be 0
+      aa = stbi__get8(z->s);
+      z->succ_high = (aa >> 4);
+      z->succ_low  = (aa & 15);
+      if (z->progressive) {
+         if (z->spec_start > 63 || z->spec_end > 63  || z->spec_start > z->spec_end || z->succ_high > 13 || z->succ_low > 13)
+            return stbi__err("bad SOS", "Corrupt JPEG");
+      } else {
+         if (z->spec_start != 0) return stbi__err("bad SOS","Corrupt JPEG");
+         if (z->succ_high != 0 || z->succ_low != 0) return stbi__err("bad SOS","Corrupt JPEG");
+         z->spec_end = 63;
+      }
+   }
 
-	return 1;
+   return 1;
+}
+
+static int stbi__free_jpeg_components(stbi__jpeg *z, int ncomp, int why)
+{
+   int i;
+   for (i=0; i < ncomp; ++i) {
+      if (z->img_comp[i].raw_data) {
+         STBI_FREE(z->img_comp[i].raw_data);
+         z->img_comp[i].raw_data = NULL;
+         z->img_comp[i].data = NULL;
+      }
+      if (z->img_comp[i].raw_coeff) {
+         STBI_FREE(z->img_comp[i].raw_coeff);
+         z->img_comp[i].raw_coeff = 0;
+         z->img_comp[i].coeff = 0;
+      }
+      if (z->img_comp[i].linebuf) {
+         STBI_FREE(z->img_comp[i].linebuf);
+         z->img_comp[i].linebuf = NULL;
+      }
+   }
+   return why;
 }
 
 static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 {
-	stbi__context *s = z->s;
-	int Lf, p, i, q, h_max = 1, v_max = 1, c;
-	Lf = stbi__get16be(s);         if (Lf < 11) return stbi__err("bad SOF len", "Corrupt JPEG"); // JPEG
-	p = stbi__get8(s);            if (p != 8) return stbi__err("only 8-bit", "JPEG format not supported: 8-bit only"); // JPEG baseline
-	s->img_y = stbi__get16be(s);   if (s->img_y == 0) return stbi__err("no header height", "JPEG format not supported: delayed height"); // Legal, but we don't handle it--but neither does IJG
-	s->img_x = stbi__get16be(s);   if (s->img_x == 0) return stbi__err("0 width", "Corrupt JPEG"); // JPEG requires
-	c = stbi__get8(s);
-	if (c != 3 && c != 1) return stbi__err("bad component count", "Corrupt JPEG");    // JFIF requires
-	s->img_n = c;
-	for (i = 0; i < c; ++i) {
-		z->img_comp[i].data = NULL;
-		z->img_comp[i].linebuf = NULL;
-	}
+   stbi__context *s = z->s;
+   int Lf,p,i,q, h_max=1,v_max=1,c;
+   Lf = stbi__get16be(s);         if (Lf < 11) return stbi__err("bad SOF len","Corrupt JPEG"); // JPEG
+   p  = stbi__get8(s);            if (p != 8) return stbi__err("only 8-bit","JPEG format not supported: 8-bit only"); // JPEG baseline
+   s->img_y = stbi__get16be(s);   if (s->img_y == 0) return stbi__err("no header height", "JPEG format not supported: delayed height"); // Legal, but we don't handle it--but neither does IJG
+   s->img_x = stbi__get16be(s);   if (s->img_x == 0) return stbi__err("0 width","Corrupt JPEG"); // JPEG requires
+   c = stbi__get8(s);
+   if (c != 3 && c != 1 && c != 4) return stbi__err("bad component count","Corrupt JPEG");
+   s->img_n = c;
+   for (i=0; i < c; ++i) {
+      z->img_comp[i].data = NULL;
+      z->img_comp[i].linebuf = NULL;
+   }
 
-	if (Lf != 8 + 3 * s->img_n) return stbi__err("bad SOF len", "Corrupt JPEG");
+   if (Lf != 8+3*s->img_n) return stbi__err("bad SOF len","Corrupt JPEG");
 
-	for (i = 0; i < s->img_n; ++i) {
-		z->img_comp[i].id = stbi__get8(s);
-		if (z->img_comp[i].id != i + 1)   // JFIF requires
-			if (z->img_comp[i].id != i)  // some version of jpegtran outputs non-JFIF-compliant files!
-				return stbi__err("bad component ID", "Corrupt JPEG");
-		q = stbi__get8(s);
-		z->img_comp[i].h = (q >> 4);  if (!z->img_comp[i].h || z->img_comp[i].h > 4) return stbi__err("bad H", "Corrupt JPEG");
-		z->img_comp[i].v = q & 15;    if (!z->img_comp[i].v || z->img_comp[i].v > 4) return stbi__err("bad V", "Corrupt JPEG");
-		z->img_comp[i].tq = stbi__get8(s);  if (z->img_comp[i].tq > 3) return stbi__err("bad TQ", "Corrupt JPEG");
-	}
+   z->rgb = 0;
+   for (i=0; i < s->img_n; ++i) {
+      static const unsigned char rgb[3] = { 'R', 'G', 'B' };
+      z->img_comp[i].id = stbi__get8(s);
+      if (s->img_n == 3 && z->img_comp[i].id == rgb[i])
+         ++z->rgb;
+      q = stbi__get8(s);
+      z->img_comp[i].h = (q >> 4);  if (!z->img_comp[i].h || z->img_comp[i].h > 4) return stbi__err("bad H","Corrupt JPEG");
+      z->img_comp[i].v = q & 15;    if (!z->img_comp[i].v || z->img_comp[i].v > 4) return stbi__err("bad V","Corrupt JPEG");
+      z->img_comp[i].tq = stbi__get8(s);  if (z->img_comp[i].tq > 3) return stbi__err("bad TQ","Corrupt JPEG");
+   }
 
-	if (scan != STBI__SCAN_load) return 1;
+   if (scan != STBI__SCAN_load) return 1;
 
-	if ((1 << 30) / s->img_x / s->img_n < s->img_y) return stbi__err("too large", "Image too large to decode");
+   if (!stbi__mad3sizes_valid(s->img_x, s->img_y, s->img_n, 0)) return stbi__err("too large", "Image too large to decode");
 
-	for (i = 0; i < s->img_n; ++i) {
-		if (z->img_comp[i].h > h_max) h_max = z->img_comp[i].h;
-		if (z->img_comp[i].v > v_max) v_max = z->img_comp[i].v;
-	}
+   for (i=0; i < s->img_n; ++i) {
+      if (z->img_comp[i].h > h_max) h_max = z->img_comp[i].h;
+      if (z->img_comp[i].v > v_max) v_max = z->img_comp[i].v;
+   }
 
-	// compute interleaved mcu info
-	z->img_h_max = h_max;
-	z->img_v_max = v_max;
-	z->img_mcu_w = h_max * 8;
-	z->img_mcu_h = v_max * 8;
-	z->img_mcu_x = (s->img_x + z->img_mcu_w - 1) / z->img_mcu_w;
-	z->img_mcu_y = (s->img_y + z->img_mcu_h - 1) / z->img_mcu_h;
+   // compute interleaved mcu info
+   z->img_h_max = h_max;
+   z->img_v_max = v_max;
+   z->img_mcu_w = h_max * 8;
+   z->img_mcu_h = v_max * 8;
+   // these sizes can't be more than 17 bits
+   z->img_mcu_x = (s->img_x + z->img_mcu_w-1) / z->img_mcu_w;
+   z->img_mcu_y = (s->img_y + z->img_mcu_h-1) / z->img_mcu_h;
 
-	for (i = 0; i < s->img_n; ++i) {
-		// number of effective pixels (e.g. for non-interleaved MCU)
-		z->img_comp[i].x = (s->img_x * z->img_comp[i].h + h_max - 1) / h_max;
-		z->img_comp[i].y = (s->img_y * z->img_comp[i].v + v_max - 1) / v_max;
-		// to simplify generation, we'll allocate enough memory to decode
-		// the bogus oversized data from using interleaved MCUs and their
-		// big blocks (e.g. a 16x16 iMCU on an image of width 33); we won't
-		// discard the extra data until colorspace conversion
-		z->img_comp[i].w2 = z->img_mcu_x * z->img_comp[i].h * 8;
-		z->img_comp[i].h2 = z->img_mcu_y * z->img_comp[i].v * 8;
-		z->img_comp[i].raw_data = stbi__malloc(z->img_comp[i].w2 * z->img_comp[i].h2 + 15);
+   for (i=0; i < s->img_n; ++i) {
+      // number of effective pixels (e.g. for non-interleaved MCU)
+      z->img_comp[i].x = (s->img_x * z->img_comp[i].h + h_max-1) / h_max;
+      z->img_comp[i].y = (s->img_y * z->img_comp[i].v + v_max-1) / v_max;
+      // to simplify generation, we'll allocate enough memory to decode
+      // the bogus oversized data from using interleaved MCUs and their
+      // big blocks (e.g. a 16x16 iMCU on an image of width 33); we won't
+      // discard the extra data until colorspace conversion
+      //
+      // img_mcu_x, img_mcu_y: <=17 bits; comp[i].h and .v are <=4 (checked earlier)
+      // so these muls can't overflow with 32-bit ints (which we require)
+      z->img_comp[i].w2 = z->img_mcu_x * z->img_comp[i].h * 8;
+      z->img_comp[i].h2 = z->img_mcu_y * z->img_comp[i].v * 8;
+      z->img_comp[i].coeff = 0;
+      z->img_comp[i].raw_coeff = 0;
+      z->img_comp[i].linebuf = NULL;
+      z->img_comp[i].raw_data = stbi__malloc_mad2(z->img_comp[i].w2, z->img_comp[i].h2, 15);
+      if (z->img_comp[i].raw_data == NULL)
+         return stbi__free_jpeg_components(z, i+1, stbi__err("outofmem", "Out of memory"));
+      // align blocks for idct using mmx/sse
+      z->img_comp[i].data = (stbi_uc*) (((size_t) z->img_comp[i].raw_data + 15) & ~15);
+      if (z->progressive) {
+         // w2, h2 are multiples of 8 (see above)
+         z->img_comp[i].coeff_w = z->img_comp[i].w2 / 8;
+         z->img_comp[i].coeff_h = z->img_comp[i].h2 / 8;
+         z->img_comp[i].raw_coeff = stbi__malloc_mad3(z->img_comp[i].w2, z->img_comp[i].h2, sizeof(short), 15);
+         if (z->img_comp[i].raw_coeff == NULL)
+            return stbi__free_jpeg_components(z, i+1, stbi__err("outofmem", "Out of memory"));
+         z->img_comp[i].coeff = (short*) (((size_t) z->img_comp[i].raw_coeff + 15) & ~15);
+      }
+   }
 
-		if (z->img_comp[i].raw_data == NULL) {
-			for (--i; i >= 0; --i) {
-				STBI_FREE(z->img_comp[i].raw_data);
-				z->img_comp[i].raw_data = NULL;
-			}
-			return stbi__err("outofmem", "Out of memory");
-		}
-		// align blocks for idct using mmx/sse
-		z->img_comp[i].data = (stbi_uc*)(((size_t)z->img_comp[i].raw_data + 15) & ~15);
-		z->img_comp[i].linebuf = NULL;
-		if (z->progressive) {
-			z->img_comp[i].coeff_w = (z->img_comp[i].w2 + 7) >> 3;
-			z->img_comp[i].coeff_h = (z->img_comp[i].h2 + 7) >> 3;
-			z->img_comp[i].raw_coeff = STBI_MALLOC(z->img_comp[i].coeff_w * z->img_comp[i].coeff_h * 64 * sizeof(short) + 15);
-			z->img_comp[i].coeff = (short*)(((size_t)z->img_comp[i].raw_coeff + 15) & ~15);
-		}
-		else {
-			z->img_comp[i].coeff = 0;
-			z->img_comp[i].raw_coeff = 0;
-		}
-	}
-
-	return 1;
+   return 1;
 }
 
 // use comparisons since in some cases we handle more than one case (e.g. SOF)
@@ -2812,660 +3091,688 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 
 static int stbi__decode_jpeg_header(stbi__jpeg *z, int scan)
 {
-	int m;
-	z->marker = STBI__MARKER_none; // initialize cached marker to empty
-	m = stbi__get_marker(z);
-	if (!stbi__SOI(m)) return stbi__err("no SOI", "Corrupt JPEG");
-	if (scan == STBI__SCAN_type) return 1;
-	m = stbi__get_marker(z);
-	while (!stbi__SOF(m)) {
-		if (!stbi__process_marker(z, m)) return 0;
-		m = stbi__get_marker(z);
-		while (m == STBI__MARKER_none) {
-			// some files have extra padding after their blocks, so ok, we'll scan
-			if (stbi__at_eof(z->s)) return stbi__err("no SOF", "Corrupt JPEG");
-			m = stbi__get_marker(z);
-		}
-	}
-	z->progressive = stbi__SOF_progressive(m);
-	if (!stbi__process_frame_header(z, scan)) return 0;
-	return 1;
+   int m;
+   z->jfif = 0;
+   z->app14_color_transform = -1; // valid values are 0,1,2
+   z->marker = STBI__MARKER_none; // initialize cached marker to empty
+   m = stbi__get_marker(z);
+   if (!stbi__SOI(m)) return stbi__err("no SOI","Corrupt JPEG");
+   if (scan == STBI__SCAN_type) return 1;
+   m = stbi__get_marker(z);
+   while (!stbi__SOF(m)) {
+      if (!stbi__process_marker(z,m)) return 0;
+      m = stbi__get_marker(z);
+      while (m == STBI__MARKER_none) {
+         // some files have extra padding after their blocks, so ok, we'll scan
+         if (stbi__at_eof(z->s)) return stbi__err("no SOF", "Corrupt JPEG");
+         m = stbi__get_marker(z);
+      }
+   }
+   z->progressive = stbi__SOF_progressive(m);
+   if (!stbi__process_frame_header(z, scan)) return 0;
+   return 1;
 }
 
 // decode image to YCbCr format
 static int stbi__decode_jpeg_image(stbi__jpeg *j)
 {
-	int m;
-	for (m = 0; m < 4; m++) {
-		j->img_comp[m].raw_data = NULL;
-		j->img_comp[m].raw_coeff = NULL;
-	}
-	j->restart_interval = 0;
-	if (!stbi__decode_jpeg_header(j, STBI__SCAN_load)) return 0;
-	m = stbi__get_marker(j);
-	while (!stbi__EOI(m)) {
-		if (stbi__SOS(m)) {
-			if (!stbi__process_scan_header(j)) return 0;
-			if (!stbi__parse_entropy_coded_data(j)) return 0;
-			if (j->marker == STBI__MARKER_none) {
-				// handle 0s at the end of image data from IP Kamera 9060
-				while (!stbi__at_eof(j->s)) {
-					int x = stbi__get8(j->s);
-					if (x == 255) {
-						j->marker = stbi__get8(j->s);
-						break;
-					}
-					else if (x != 0) {
-						return stbi__err("junk before marker", "Corrupt JPEG");
-					}
-				}
-				// if we reach eof without hitting a marker, stbi__get_marker() below will fail and we'll eventually return 0
-			}
-		}
-		else {
-			if (!stbi__process_marker(j, m)) return 0;
-		}
-		m = stbi__get_marker(j);
-	}
-	if (j->progressive)
-		stbi__jpeg_finish(j);
-	return 1;
+   int m;
+   for (m = 0; m < 4; m++) {
+      j->img_comp[m].raw_data = NULL;
+      j->img_comp[m].raw_coeff = NULL;
+   }
+   j->restart_interval = 0;
+   if (!stbi__decode_jpeg_header(j, STBI__SCAN_load)) return 0;
+   m = stbi__get_marker(j);
+   while (!stbi__EOI(m)) {
+      if (stbi__SOS(m)) {
+         if (!stbi__process_scan_header(j)) return 0;
+         if (!stbi__parse_entropy_coded_data(j)) return 0;
+         if (j->marker == STBI__MARKER_none ) {
+            // handle 0s at the end of image data from IP Kamera 9060
+            while (!stbi__at_eof(j->s)) {
+               int x = stbi__get8(j->s);
+               if (x == 255) {
+                  j->marker = stbi__get8(j->s);
+                  break;
+               }
+            }
+            // if we reach eof without hitting a marker, stbi__get_marker() below will fail and we'll eventually return 0
+         }
+      } else if (stbi__DNL(m)) {
+         int Ld = stbi__get16be(j->s);
+         stbi__uint32 NL = stbi__get16be(j->s);
+         if (Ld != 4) return stbi__err("bad DNL len", "Corrupt JPEG");
+         if (NL != j->s->img_y) return stbi__err("bad DNL height", "Corrupt JPEG");
+      } else {
+         if (!stbi__process_marker(j, m)) return 0;
+      }
+      m = stbi__get_marker(j);
+   }
+   if (j->progressive)
+      stbi__jpeg_finish(j);
+   return 1;
 }
 
 // static jfif-centered resampling (across block boundaries)
 
 typedef stbi_uc *(*resample_row_func)(stbi_uc *out, stbi_uc *in0, stbi_uc *in1,
-	int w, int hs);
+                                    int w, int hs);
 
 #define stbi__div4(x) ((stbi_uc) ((x) >> 2))
 
 static stbi_uc *resample_row_1(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
 {
-	STBI_NOTUSED(out);
-	STBI_NOTUSED(in_far);
-	STBI_NOTUSED(w);
-	STBI_NOTUSED(hs);
-	return in_near;
+   STBI_NOTUSED(out);
+   STBI_NOTUSED(in_far);
+   STBI_NOTUSED(w);
+   STBI_NOTUSED(hs);
+   return in_near;
 }
 
 static stbi_uc* stbi__resample_row_v_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
 {
-	// need to generate two samples vertically for every one in input
-	int i;
-	STBI_NOTUSED(hs);
-	for (i = 0; i < w; ++i)
-		out[i] = stbi__div4(3 * in_near[i] + in_far[i] + 2);
-	return out;
+   // need to generate two samples vertically for every one in input
+   int i;
+   STBI_NOTUSED(hs);
+   for (i=0; i < w; ++i)
+      out[i] = stbi__div4(3*in_near[i] + in_far[i] + 2);
+   return out;
 }
 
 static stbi_uc*  stbi__resample_row_h_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
 {
-	// need to generate two samples horizontally for every one in input
-	int i;
-	stbi_uc *input = in_near;
+   // need to generate two samples horizontally for every one in input
+   int i;
+   stbi_uc *input = in_near;
 
-	if (w == 1) {
-		// if only one sample, can't do any interpolation
-		out[0] = out[1] = input[0];
-		return out;
-	}
+   if (w == 1) {
+      // if only one sample, can't do any interpolation
+      out[0] = out[1] = input[0];
+      return out;
+   }
 
-	out[0] = input[0];
-	out[1] = stbi__div4(input[0] * 3 + input[1] + 2);
-	for (i = 1; i < w - 1; ++i) {
-		int n = 3 * input[i] + 2;
-		out[i * 2 + 0] = stbi__div4(n + input[i - 1]);
-		out[i * 2 + 1] = stbi__div4(n + input[i + 1]);
-	}
-	out[i * 2 + 0] = stbi__div4(input[w - 2] * 3 + input[w - 1] + 2);
-	out[i * 2 + 1] = input[w - 1];
+   out[0] = input[0];
+   out[1] = stbi__div4(input[0]*3 + input[1] + 2);
+   for (i=1; i < w-1; ++i) {
+      int n = 3*input[i]+2;
+      out[i*2+0] = stbi__div4(n+input[i-1]);
+      out[i*2+1] = stbi__div4(n+input[i+1]);
+   }
+   out[i*2+0] = stbi__div4(input[w-2]*3 + input[w-1] + 2);
+   out[i*2+1] = input[w-1];
 
-	STBI_NOTUSED(in_far);
-	STBI_NOTUSED(hs);
+   STBI_NOTUSED(in_far);
+   STBI_NOTUSED(hs);
 
-	return out;
+   return out;
 }
 
 #define stbi__div16(x) ((stbi_uc) ((x) >> 4))
 
 static stbi_uc *stbi__resample_row_hv_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
 {
-	// need to generate 2x2 samples for every one in input
-	int i, t0, t1;
-	if (w == 1) {
-		out[0] = out[1] = stbi__div4(3 * in_near[0] + in_far[0] + 2);
-		return out;
-	}
+   // need to generate 2x2 samples for every one in input
+   int i,t0,t1;
+   if (w == 1) {
+      out[0] = out[1] = stbi__div4(3*in_near[0] + in_far[0] + 2);
+      return out;
+   }
 
-	t1 = 3 * in_near[0] + in_far[0];
-	out[0] = stbi__div4(t1 + 2);
-	for (i = 1; i < w; ++i) {
-		t0 = t1;
-		t1 = 3 * in_near[i] + in_far[i];
-		out[i * 2 - 1] = stbi__div16(3 * t0 + t1 + 8);
-		out[i * 2] = stbi__div16(3 * t1 + t0 + 8);
-	}
-	out[w * 2 - 1] = stbi__div4(t1 + 2);
+   t1 = 3*in_near[0] + in_far[0];
+   out[0] = stbi__div4(t1+2);
+   for (i=1; i < w; ++i) {
+      t0 = t1;
+      t1 = 3*in_near[i]+in_far[i];
+      out[i*2-1] = stbi__div16(3*t0 + t1 + 8);
+      out[i*2  ] = stbi__div16(3*t1 + t0 + 8);
+   }
+   out[w*2-1] = stbi__div4(t1+2);
 
-	STBI_NOTUSED(hs);
+   STBI_NOTUSED(hs);
 
-	return out;
+   return out;
 }
 
 #if defined(STBI_SSE2) || defined(STBI_NEON)
 static stbi_uc *stbi__resample_row_hv_2_simd(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
 {
-	// need to generate 2x2 samples for every one in input
-	int i = 0, t0, t1;
+   // need to generate 2x2 samples for every one in input
+   int i=0,t0,t1;
 
-	if (w == 1) {
-		out[0] = out[1] = stbi__div4(3 * in_near[0] + in_far[0] + 2);
-		return out;
-	}
+   if (w == 1) {
+      out[0] = out[1] = stbi__div4(3*in_near[0] + in_far[0] + 2);
+      return out;
+   }
 
-	t1 = 3 * in_near[0] + in_far[0];
-	// process groups of 8 pixels for as long as we can.
-	// note we can't handle the last pixel in a row in this loop
-	// because we need to handle the filter boundary conditions.
-	for (; i < ((w - 1) & ~7); i += 8) {
+   t1 = 3*in_near[0] + in_far[0];
+   // process groups of 8 pixels for as long as we can.
+   // note we can't handle the last pixel in a row in this loop
+   // because we need to handle the filter boundary conditions.
+   for (; i < ((w-1) & ~7); i += 8) {
 #if defined(STBI_SSE2)
-		// load and perform the vertical filtering pass
-		// this uses 3*x + y = 4*x + (y - x)
-		__m128i zero = _mm_setzero_si128();
-		__m128i farb = _mm_loadl_epi64((__m128i *) (in_far + i));
-		__m128i nearb = _mm_loadl_epi64((__m128i *) (in_near + i));
-		__m128i farw = _mm_unpacklo_epi8(farb, zero);
-		__m128i nearw = _mm_unpacklo_epi8(nearb, zero);
-		__m128i diff = _mm_sub_epi16(farw, nearw);
-		__m128i nears = _mm_slli_epi16(nearw, 2);
-		__m128i curr = _mm_add_epi16(nears, diff); // current row
+      // load and perform the vertical filtering pass
+      // this uses 3*x + y = 4*x + (y - x)
+      __m128i zero  = _mm_setzero_si128();
+      __m128i farb  = _mm_loadl_epi64((__m128i *) (in_far + i));
+      __m128i nearb = _mm_loadl_epi64((__m128i *) (in_near + i));
+      __m128i farw  = _mm_unpacklo_epi8(farb, zero);
+      __m128i nearw = _mm_unpacklo_epi8(nearb, zero);
+      __m128i diff  = _mm_sub_epi16(farw, nearw);
+      __m128i nears = _mm_slli_epi16(nearw, 2);
+      __m128i curr  = _mm_add_epi16(nears, diff); // current row
 
-												   // horizontal filter works the same based on shifted vers of current
-												   // row. "prev" is current row shifted right by 1 pixel; we need to
-												   // insert the previous pixel value (from t1).
-												   // "next" is current row shifted left by 1 pixel, with first pixel
-												   // of next block of 8 pixels added in.
-		__m128i prv0 = _mm_slli_si128(curr, 2);
-		__m128i nxt0 = _mm_srli_si128(curr, 2);
-		__m128i prev = _mm_insert_epi16(prv0, t1, 0);
-		__m128i next = _mm_insert_epi16(nxt0, 3 * in_near[i + 8] + in_far[i + 8], 7);
+      // horizontal filter works the same based on shifted vers of current
+      // row. "prev" is current row shifted right by 1 pixel; we need to
+      // insert the previous pixel value (from t1).
+      // "next" is current row shifted left by 1 pixel, with first pixel
+      // of next block of 8 pixels added in.
+      __m128i prv0 = _mm_slli_si128(curr, 2);
+      __m128i nxt0 = _mm_srli_si128(curr, 2);
+      __m128i prev = _mm_insert_epi16(prv0, t1, 0);
+      __m128i next = _mm_insert_epi16(nxt0, 3*in_near[i+8] + in_far[i+8], 7);
 
-		// horizontal filter, polyphase implementation since it's convenient:
-		// even pixels = 3*cur + prev = cur*4 + (prev - cur)
-		// odd  pixels = 3*cur + next = cur*4 + (next - cur)
-		// note the shared term.
-		__m128i bias = _mm_set1_epi16(8);
-		__m128i curs = _mm_slli_epi16(curr, 2);
-		__m128i prvd = _mm_sub_epi16(prev, curr);
-		__m128i nxtd = _mm_sub_epi16(next, curr);
-		__m128i curb = _mm_add_epi16(curs, bias);
-		__m128i even = _mm_add_epi16(prvd, curb);
-		__m128i odd = _mm_add_epi16(nxtd, curb);
+      // horizontal filter, polyphase implementation since it's convenient:
+      // even pixels = 3*cur + prev = cur*4 + (prev - cur)
+      // odd  pixels = 3*cur + next = cur*4 + (next - cur)
+      // note the shared term.
+      __m128i bias  = _mm_set1_epi16(8);
+      __m128i curs = _mm_slli_epi16(curr, 2);
+      __m128i prvd = _mm_sub_epi16(prev, curr);
+      __m128i nxtd = _mm_sub_epi16(next, curr);
+      __m128i curb = _mm_add_epi16(curs, bias);
+      __m128i even = _mm_add_epi16(prvd, curb);
+      __m128i odd  = _mm_add_epi16(nxtd, curb);
 
-		// interleave even and odd pixels, then undo scaling.
-		__m128i int0 = _mm_unpacklo_epi16(even, odd);
-		__m128i int1 = _mm_unpackhi_epi16(even, odd);
-		__m128i de0 = _mm_srli_epi16(int0, 4);
-		__m128i de1 = _mm_srli_epi16(int1, 4);
+      // interleave even and odd pixels, then undo scaling.
+      __m128i int0 = _mm_unpacklo_epi16(even, odd);
+      __m128i int1 = _mm_unpackhi_epi16(even, odd);
+      __m128i de0  = _mm_srli_epi16(int0, 4);
+      __m128i de1  = _mm_srli_epi16(int1, 4);
 
-		// pack and write output
-		__m128i outv = _mm_packus_epi16(de0, de1);
-		_mm_storeu_si128((__m128i *) (out + i * 2), outv);
+      // pack and write output
+      __m128i outv = _mm_packus_epi16(de0, de1);
+      _mm_storeu_si128((__m128i *) (out + i*2), outv);
 #elif defined(STBI_NEON)
-		// load and perform the vertical filtering pass
-		// this uses 3*x + y = 4*x + (y - x)
-		uint8x8_t farb = vld1_u8(in_far + i);
-		uint8x8_t nearb = vld1_u8(in_near + i);
-		int16x8_t diff = vreinterpretq_s16_u16(vsubl_u8(farb, nearb));
-		int16x8_t nears = vreinterpretq_s16_u16(vshll_n_u8(nearb, 2));
-		int16x8_t curr = vaddq_s16(nears, diff); // current row
+      // load and perform the vertical filtering pass
+      // this uses 3*x + y = 4*x + (y - x)
+      uint8x8_t farb  = vld1_u8(in_far + i);
+      uint8x8_t nearb = vld1_u8(in_near + i);
+      int16x8_t diff  = vreinterpretq_s16_u16(vsubl_u8(farb, nearb));
+      int16x8_t nears = vreinterpretq_s16_u16(vshll_n_u8(nearb, 2));
+      int16x8_t curr  = vaddq_s16(nears, diff); // current row
 
-												 // horizontal filter works the same based on shifted vers of current
-												 // row. "prev" is current row shifted right by 1 pixel; we need to
-												 // insert the previous pixel value (from t1).
-												 // "next" is current row shifted left by 1 pixel, with first pixel
-												 // of next block of 8 pixels added in.
-		int16x8_t prv0 = vextq_s16(curr, curr, 7);
-		int16x8_t nxt0 = vextq_s16(curr, curr, 1);
-		int16x8_t prev = vsetq_lane_s16(t1, prv0, 0);
-		int16x8_t next = vsetq_lane_s16(3 * in_near[i + 8] + in_far[i + 8], nxt0, 7);
+      // horizontal filter works the same based on shifted vers of current
+      // row. "prev" is current row shifted right by 1 pixel; we need to
+      // insert the previous pixel value (from t1).
+      // "next" is current row shifted left by 1 pixel, with first pixel
+      // of next block of 8 pixels added in.
+      int16x8_t prv0 = vextq_s16(curr, curr, 7);
+      int16x8_t nxt0 = vextq_s16(curr, curr, 1);
+      int16x8_t prev = vsetq_lane_s16(t1, prv0, 0);
+      int16x8_t next = vsetq_lane_s16(3*in_near[i+8] + in_far[i+8], nxt0, 7);
 
-		// horizontal filter, polyphase implementation since it's convenient:
-		// even pixels = 3*cur + prev = cur*4 + (prev - cur)
-		// odd  pixels = 3*cur + next = cur*4 + (next - cur)
-		// note the shared term.
-		int16x8_t curs = vshlq_n_s16(curr, 2);
-		int16x8_t prvd = vsubq_s16(prev, curr);
-		int16x8_t nxtd = vsubq_s16(next, curr);
-		int16x8_t even = vaddq_s16(curs, prvd);
-		int16x8_t odd = vaddq_s16(curs, nxtd);
+      // horizontal filter, polyphase implementation since it's convenient:
+      // even pixels = 3*cur + prev = cur*4 + (prev - cur)
+      // odd  pixels = 3*cur + next = cur*4 + (next - cur)
+      // note the shared term.
+      int16x8_t curs = vshlq_n_s16(curr, 2);
+      int16x8_t prvd = vsubq_s16(prev, curr);
+      int16x8_t nxtd = vsubq_s16(next, curr);
+      int16x8_t even = vaddq_s16(curs, prvd);
+      int16x8_t odd  = vaddq_s16(curs, nxtd);
 
-		// undo scaling and round, then store with even/odd phases interleaved
-		uint8x8x2_t o;
-		o.val[0] = vqrshrun_n_s16(even, 4);
-		o.val[1] = vqrshrun_n_s16(odd, 4);
-		vst2_u8(out + i * 2, o);
+      // undo scaling and round, then store with even/odd phases interleaved
+      uint8x8x2_t o;
+      o.val[0] = vqrshrun_n_s16(even, 4);
+      o.val[1] = vqrshrun_n_s16(odd,  4);
+      vst2_u8(out + i*2, o);
 #endif
 
-		// "previous" value for next iter
-		t1 = 3 * in_near[i + 7] + in_far[i + 7];
-	}
+      // "previous" value for next iter
+      t1 = 3*in_near[i+7] + in_far[i+7];
+   }
 
-	t0 = t1;
-	t1 = 3 * in_near[i] + in_far[i];
-	out[i * 2] = stbi__div16(3 * t1 + t0 + 8);
+   t0 = t1;
+   t1 = 3*in_near[i] + in_far[i];
+   out[i*2] = stbi__div16(3*t1 + t0 + 8);
 
-	for (++i; i < w; ++i) {
-		t0 = t1;
-		t1 = 3 * in_near[i] + in_far[i];
-		out[i * 2 - 1] = stbi__div16(3 * t0 + t1 + 8);
-		out[i * 2] = stbi__div16(3 * t1 + t0 + 8);
-	}
-	out[w * 2 - 1] = stbi__div4(t1 + 2);
+   for (++i; i < w; ++i) {
+      t0 = t1;
+      t1 = 3*in_near[i]+in_far[i];
+      out[i*2-1] = stbi__div16(3*t0 + t1 + 8);
+      out[i*2  ] = stbi__div16(3*t1 + t0 + 8);
+   }
+   out[w*2-1] = stbi__div4(t1+2);
 
-	STBI_NOTUSED(hs);
+   STBI_NOTUSED(hs);
 
-	return out;
+   return out;
 }
 #endif
 
 static stbi_uc *stbi__resample_row_generic(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
 {
-	// resample with nearest-neighbor
-	int i, j;
-	STBI_NOTUSED(in_far);
-	for (i = 0; i < w; ++i)
-		for (j = 0; j < hs; ++j)
-			out[i*hs + j] = in_near[i];
-	return out;
+   // resample with nearest-neighbor
+   int i,j;
+   STBI_NOTUSED(in_far);
+   for (i=0; i < w; ++i)
+      for (j=0; j < hs; ++j)
+         out[i*hs+j] = in_near[i];
+   return out;
 }
 
-#ifdef STBI_JPEG_OLD
-// this is the same YCbCr-to-RGB calculation that stb_image has used
-// historically before the algorithm changes in 1.49
-#define float2fixed(x)  ((int) ((x) * 65536 + 0.5))
-static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step)
-{
-	int i;
-	for (i = 0; i < count; ++i) {
-		int y_fixed = (y[i] << 16) + 32768; // rounding
-		int r, g, b;
-		int cr = pcr[i] - 128;
-		int cb = pcb[i] - 128;
-		r = y_fixed + cr*float2fixed(1.40200f);
-		g = y_fixed - cr*float2fixed(0.71414f) - cb*float2fixed(0.34414f);
-		b = y_fixed + cb*float2fixed(1.77200f);
-		r >>= 16;
-		g >>= 16;
-		b >>= 16;
-		if ((unsigned)r > 255) { if (r < 0) r = 0; else r = 255; }
-		if ((unsigned)g > 255) { if (g < 0) g = 0; else g = 255; }
-		if ((unsigned)b > 255) { if (b < 0) b = 0; else b = 255; }
-		out[0] = (stbi_uc)r;
-		out[1] = (stbi_uc)g;
-		out[2] = (stbi_uc)b;
-		out[3] = 255;
-		out += step;
-	}
-}
-#else
 // this is a reduced-precision calculation of YCbCr-to-RGB introduced
 // to make sure the code produces the same results in both SIMD and scalar
-#define float2fixed(x)  (((int) ((x) * 4096.0f + 0.5f)) << 8)
+#define stbi__float2fixed(x)  (((int) ((x) * 4096.0f + 0.5f)) << 8)
 static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step)
 {
-	int i;
-	for (i = 0; i < count; ++i) {
-		int y_fixed = (y[i] << 20) + (1 << 19); // rounding
-		int r, g, b;
-		int cr = pcr[i] - 128;
-		int cb = pcb[i] - 128;
-		r = y_fixed + cr* float2fixed(1.40200f);
-		g = y_fixed + (cr*-float2fixed(0.71414f)) + ((cb*-float2fixed(0.34414f)) & 0xffff0000);
-		b = y_fixed + cb* float2fixed(1.77200f);
-		r >>= 20;
-		g >>= 20;
-		b >>= 20;
-		if ((unsigned)r > 255) { if (r < 0) r = 0; else r = 255; }
-		if ((unsigned)g > 255) { if (g < 0) g = 0; else g = 255; }
-		if ((unsigned)b > 255) { if (b < 0) b = 0; else b = 255; }
-		out[0] = (stbi_uc)r;
-		out[1] = (stbi_uc)g;
-		out[2] = (stbi_uc)b;
-		out[3] = 255;
-		out += step;
-	}
+   int i;
+   for (i=0; i < count; ++i) {
+      int y_fixed = (y[i] << 20) + (1<<19); // rounding
+      int r,g,b;
+      int cr = pcr[i] - 128;
+      int cb = pcb[i] - 128;
+      r = y_fixed +  cr* stbi__float2fixed(1.40200f);
+      g = y_fixed + (cr*-stbi__float2fixed(0.71414f)) + ((cb*-stbi__float2fixed(0.34414f)) & 0xffff0000);
+      b = y_fixed                                     +   cb* stbi__float2fixed(1.77200f);
+      r >>= 20;
+      g >>= 20;
+      b >>= 20;
+      if ((unsigned) r > 255) { if (r < 0) r = 0; else r = 255; }
+      if ((unsigned) g > 255) { if (g < 0) g = 0; else g = 255; }
+      if ((unsigned) b > 255) { if (b < 0) b = 0; else b = 255; }
+      out[0] = (stbi_uc)r;
+      out[1] = (stbi_uc)g;
+      out[2] = (stbi_uc)b;
+      out[3] = 255;
+      out += step;
+   }
 }
-#endif
 
 #if defined(STBI_SSE2) || defined(STBI_NEON)
 static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc const *pcb, stbi_uc const *pcr, int count, int step)
 {
-	int i = 0;
+   int i = 0;
 
 #ifdef STBI_SSE2
-	// step == 3 is pretty ugly on the final interleave, and i'm not convinced
-	// it's useful in practice (you wouldn't use it for textures, for example).
-	// so just accelerate step == 4 case.
-	if (step == 4) {
-		// this is a fairly straightforward implementation and not super-optimized.
-		__m128i signflip = _mm_set1_epi8(-0x80);
-		__m128i cr_const0 = _mm_set1_epi16((short)(1.40200f*4096.0f + 0.5f));
-		__m128i cr_const1 = _mm_set1_epi16(-(short)(0.71414f*4096.0f + 0.5f));
-		__m128i cb_const0 = _mm_set1_epi16(-(short)(0.34414f*4096.0f + 0.5f));
-		__m128i cb_const1 = _mm_set1_epi16((short)(1.77200f*4096.0f + 0.5f));
-		__m128i y_bias = _mm_set1_epi8((char)(unsigned char)128);
-		__m128i xw = _mm_set1_epi16(255); // alpha channel
+   // step == 3 is pretty ugly on the final interleave, and i'm not convinced
+   // it's useful in practice (you wouldn't use it for textures, for example).
+   // so just accelerate step == 4 case.
+   if (step == 4) {
+      // this is a fairly straightforward implementation and not super-optimized.
+      __m128i signflip  = _mm_set1_epi8(-0x80);
+      __m128i cr_const0 = _mm_set1_epi16(   (short) ( 1.40200f*4096.0f+0.5f));
+      __m128i cr_const1 = _mm_set1_epi16( - (short) ( 0.71414f*4096.0f+0.5f));
+      __m128i cb_const0 = _mm_set1_epi16( - (short) ( 0.34414f*4096.0f+0.5f));
+      __m128i cb_const1 = _mm_set1_epi16(   (short) ( 1.77200f*4096.0f+0.5f));
+      __m128i y_bias = _mm_set1_epi8((char) (unsigned char) 128);
+      __m128i xw = _mm_set1_epi16(255); // alpha channel
 
-		for (; i + 7 < count; i += 8) {
-			// load
-			__m128i y_bytes = _mm_loadl_epi64((__m128i *) (y + i));
-			__m128i cr_bytes = _mm_loadl_epi64((__m128i *) (pcr + i));
-			__m128i cb_bytes = _mm_loadl_epi64((__m128i *) (pcb + i));
-			__m128i cr_biased = _mm_xor_si128(cr_bytes, signflip); // -128
-			__m128i cb_biased = _mm_xor_si128(cb_bytes, signflip); // -128
+      for (; i+7 < count; i += 8) {
+         // load
+         __m128i y_bytes = _mm_loadl_epi64((__m128i *) (y+i));
+         __m128i cr_bytes = _mm_loadl_epi64((__m128i *) (pcr+i));
+         __m128i cb_bytes = _mm_loadl_epi64((__m128i *) (pcb+i));
+         __m128i cr_biased = _mm_xor_si128(cr_bytes, signflip); // -128
+         __m128i cb_biased = _mm_xor_si128(cb_bytes, signflip); // -128
 
-																   // unpack to short (and left-shift cr, cb by 8)
-			__m128i yw = _mm_unpacklo_epi8(y_bias, y_bytes);
-			__m128i crw = _mm_unpacklo_epi8(_mm_setzero_si128(), cr_biased);
-			__m128i cbw = _mm_unpacklo_epi8(_mm_setzero_si128(), cb_biased);
+         // unpack to short (and left-shift cr, cb by 8)
+         __m128i yw  = _mm_unpacklo_epi8(y_bias, y_bytes);
+         __m128i crw = _mm_unpacklo_epi8(_mm_setzero_si128(), cr_biased);
+         __m128i cbw = _mm_unpacklo_epi8(_mm_setzero_si128(), cb_biased);
 
-			// color transform
-			__m128i yws = _mm_srli_epi16(yw, 4);
-			__m128i cr0 = _mm_mulhi_epi16(cr_const0, crw);
-			__m128i cb0 = _mm_mulhi_epi16(cb_const0, cbw);
-			__m128i cb1 = _mm_mulhi_epi16(cbw, cb_const1);
-			__m128i cr1 = _mm_mulhi_epi16(crw, cr_const1);
-			__m128i rws = _mm_add_epi16(cr0, yws);
-			__m128i gwt = _mm_add_epi16(cb0, yws);
-			__m128i bws = _mm_add_epi16(yws, cb1);
-			__m128i gws = _mm_add_epi16(gwt, cr1);
+         // color transform
+         __m128i yws = _mm_srli_epi16(yw, 4);
+         __m128i cr0 = _mm_mulhi_epi16(cr_const0, crw);
+         __m128i cb0 = _mm_mulhi_epi16(cb_const0, cbw);
+         __m128i cb1 = _mm_mulhi_epi16(cbw, cb_const1);
+         __m128i cr1 = _mm_mulhi_epi16(crw, cr_const1);
+         __m128i rws = _mm_add_epi16(cr0, yws);
+         __m128i gwt = _mm_add_epi16(cb0, yws);
+         __m128i bws = _mm_add_epi16(yws, cb1);
+         __m128i gws = _mm_add_epi16(gwt, cr1);
 
-			// descale
-			__m128i rw = _mm_srai_epi16(rws, 4);
-			__m128i bw = _mm_srai_epi16(bws, 4);
-			__m128i gw = _mm_srai_epi16(gws, 4);
+         // descale
+         __m128i rw = _mm_srai_epi16(rws, 4);
+         __m128i bw = _mm_srai_epi16(bws, 4);
+         __m128i gw = _mm_srai_epi16(gws, 4);
 
-			// back to byte, set up for transpose
-			__m128i brb = _mm_packus_epi16(rw, bw);
-			__m128i gxb = _mm_packus_epi16(gw, xw);
+         // back to byte, set up for transpose
+         __m128i brb = _mm_packus_epi16(rw, bw);
+         __m128i gxb = _mm_packus_epi16(gw, xw);
 
-			// transpose to interleave channels
-			__m128i t0 = _mm_unpacklo_epi8(brb, gxb);
-			__m128i t1 = _mm_unpackhi_epi8(brb, gxb);
-			__m128i o0 = _mm_unpacklo_epi16(t0, t1);
-			__m128i o1 = _mm_unpackhi_epi16(t0, t1);
+         // transpose to interleave channels
+         __m128i t0 = _mm_unpacklo_epi8(brb, gxb);
+         __m128i t1 = _mm_unpackhi_epi8(brb, gxb);
+         __m128i o0 = _mm_unpacklo_epi16(t0, t1);
+         __m128i o1 = _mm_unpackhi_epi16(t0, t1);
 
-			// store
-			_mm_storeu_si128((__m128i *) (out + 0), o0);
-			_mm_storeu_si128((__m128i *) (out + 16), o1);
-			out += 32;
-		}
-	}
+         // store
+         _mm_storeu_si128((__m128i *) (out + 0), o0);
+         _mm_storeu_si128((__m128i *) (out + 16), o1);
+         out += 32;
+      }
+   }
 #endif
 
 #ifdef STBI_NEON
-	// in this version, step=3 support would be easy to add. but is there demand?
-	if (step == 4) {
-		// this is a fairly straightforward implementation and not super-optimized.
-		uint8x8_t signflip = vdup_n_u8(0x80);
-		int16x8_t cr_const0 = vdupq_n_s16((short)(1.40200f*4096.0f + 0.5f));
-		int16x8_t cr_const1 = vdupq_n_s16(-(short)(0.71414f*4096.0f + 0.5f));
-		int16x8_t cb_const0 = vdupq_n_s16(-(short)(0.34414f*4096.0f + 0.5f));
-		int16x8_t cb_const1 = vdupq_n_s16((short)(1.77200f*4096.0f + 0.5f));
+   // in this version, step=3 support would be easy to add. but is there demand?
+   if (step == 4) {
+      // this is a fairly straightforward implementation and not super-optimized.
+      uint8x8_t signflip = vdup_n_u8(0x80);
+      int16x8_t cr_const0 = vdupq_n_s16(   (short) ( 1.40200f*4096.0f+0.5f));
+      int16x8_t cr_const1 = vdupq_n_s16( - (short) ( 0.71414f*4096.0f+0.5f));
+      int16x8_t cb_const0 = vdupq_n_s16( - (short) ( 0.34414f*4096.0f+0.5f));
+      int16x8_t cb_const1 = vdupq_n_s16(   (short) ( 1.77200f*4096.0f+0.5f));
 
-		for (; i + 7 < count; i += 8) {
-			// load
-			uint8x8_t y_bytes = vld1_u8(y + i);
-			uint8x8_t cr_bytes = vld1_u8(pcr + i);
-			uint8x8_t cb_bytes = vld1_u8(pcb + i);
-			int8x8_t cr_biased = vreinterpret_s8_u8(vsub_u8(cr_bytes, signflip));
-			int8x8_t cb_biased = vreinterpret_s8_u8(vsub_u8(cb_bytes, signflip));
+      for (; i+7 < count; i += 8) {
+         // load
+         uint8x8_t y_bytes  = vld1_u8(y + i);
+         uint8x8_t cr_bytes = vld1_u8(pcr + i);
+         uint8x8_t cb_bytes = vld1_u8(pcb + i);
+         int8x8_t cr_biased = vreinterpret_s8_u8(vsub_u8(cr_bytes, signflip));
+         int8x8_t cb_biased = vreinterpret_s8_u8(vsub_u8(cb_bytes, signflip));
 
-			// expand to s16
-			int16x8_t yws = vreinterpretq_s16_u16(vshll_n_u8(y_bytes, 4));
-			int16x8_t crw = vshll_n_s8(cr_biased, 7);
-			int16x8_t cbw = vshll_n_s8(cb_biased, 7);
+         // expand to s16
+         int16x8_t yws = vreinterpretq_s16_u16(vshll_n_u8(y_bytes, 4));
+         int16x8_t crw = vshll_n_s8(cr_biased, 7);
+         int16x8_t cbw = vshll_n_s8(cb_biased, 7);
 
-			// color transform
-			int16x8_t cr0 = vqdmulhq_s16(crw, cr_const0);
-			int16x8_t cb0 = vqdmulhq_s16(cbw, cb_const0);
-			int16x8_t cr1 = vqdmulhq_s16(crw, cr_const1);
-			int16x8_t cb1 = vqdmulhq_s16(cbw, cb_const1);
-			int16x8_t rws = vaddq_s16(yws, cr0);
-			int16x8_t gws = vaddq_s16(vaddq_s16(yws, cb0), cr1);
-			int16x8_t bws = vaddq_s16(yws, cb1);
+         // color transform
+         int16x8_t cr0 = vqdmulhq_s16(crw, cr_const0);
+         int16x8_t cb0 = vqdmulhq_s16(cbw, cb_const0);
+         int16x8_t cr1 = vqdmulhq_s16(crw, cr_const1);
+         int16x8_t cb1 = vqdmulhq_s16(cbw, cb_const1);
+         int16x8_t rws = vaddq_s16(yws, cr0);
+         int16x8_t gws = vaddq_s16(vaddq_s16(yws, cb0), cr1);
+         int16x8_t bws = vaddq_s16(yws, cb1);
 
-			// undo scaling, round, convert to byte
-			uint8x8x4_t o;
-			o.val[0] = vqrshrun_n_s16(rws, 4);
-			o.val[1] = vqrshrun_n_s16(gws, 4);
-			o.val[2] = vqrshrun_n_s16(bws, 4);
-			o.val[3] = vdup_n_u8(255);
+         // undo scaling, round, convert to byte
+         uint8x8x4_t o;
+         o.val[0] = vqrshrun_n_s16(rws, 4);
+         o.val[1] = vqrshrun_n_s16(gws, 4);
+         o.val[2] = vqrshrun_n_s16(bws, 4);
+         o.val[3] = vdup_n_u8(255);
 
-			// store, interleaving r/g/b/a
-			vst4_u8(out, o);
-			out += 8 * 4;
-		}
-	}
+         // store, interleaving r/g/b/a
+         vst4_u8(out, o);
+         out += 8*4;
+      }
+   }
 #endif
 
-	for (; i < count; ++i) {
-		int y_fixed = (y[i] << 20) + (1 << 19); // rounding
-		int r, g, b;
-		int cr = pcr[i] - 128;
-		int cb = pcb[i] - 128;
-		r = y_fixed + cr* float2fixed(1.40200f);
-		g = y_fixed + cr*-float2fixed(0.71414f) + ((cb*-float2fixed(0.34414f)) & 0xffff0000);
-		b = y_fixed + cb* float2fixed(1.77200f);
-		r >>= 20;
-		g >>= 20;
-		b >>= 20;
-		if ((unsigned)r > 255) { if (r < 0) r = 0; else r = 255; }
-		if ((unsigned)g > 255) { if (g < 0) g = 0; else g = 255; }
-		if ((unsigned)b > 255) { if (b < 0) b = 0; else b = 255; }
-		out[0] = (stbi_uc)r;
-		out[1] = (stbi_uc)g;
-		out[2] = (stbi_uc)b;
-		out[3] = 255;
-		out += step;
-	}
+   for (; i < count; ++i) {
+      int y_fixed = (y[i] << 20) + (1<<19); // rounding
+      int r,g,b;
+      int cr = pcr[i] - 128;
+      int cb = pcb[i] - 128;
+      r = y_fixed + cr* stbi__float2fixed(1.40200f);
+      g = y_fixed + cr*-stbi__float2fixed(0.71414f) + ((cb*-stbi__float2fixed(0.34414f)) & 0xffff0000);
+      b = y_fixed                                   +   cb* stbi__float2fixed(1.77200f);
+      r >>= 20;
+      g >>= 20;
+      b >>= 20;
+      if ((unsigned) r > 255) { if (r < 0) r = 0; else r = 255; }
+      if ((unsigned) g > 255) { if (g < 0) g = 0; else g = 255; }
+      if ((unsigned) b > 255) { if (b < 0) b = 0; else b = 255; }
+      out[0] = (stbi_uc)r;
+      out[1] = (stbi_uc)g;
+      out[2] = (stbi_uc)b;
+      out[3] = 255;
+      out += step;
+   }
 }
 #endif
 
 // set up the kernels
 static void stbi__setup_jpeg(stbi__jpeg *j)
 {
-	j->idct_block_kernel = stbi__idct_block;
-	j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_row;
-	j->resample_row_hv_2_kernel = stbi__resample_row_hv_2;
+   j->idct_block_kernel = stbi__idct_block;
+   j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_row;
+   j->resample_row_hv_2_kernel = stbi__resample_row_hv_2;
 
 #ifdef STBI_SSE2
-	if (stbi__sse2_available()) {
-		j->idct_block_kernel = stbi__idct_simd;
-#ifndef STBI_JPEG_OLD
-		j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
-#endif
-		j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
-	}
+   if (stbi__sse2_available()) {
+      j->idct_block_kernel = stbi__idct_simd;
+      j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
+      j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
+   }
 #endif
 
 #ifdef STBI_NEON
-	j->idct_block_kernel = stbi__idct_simd;
-#ifndef STBI_JPEG_OLD
-	j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
-#endif
-	j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
+   j->idct_block_kernel = stbi__idct_simd;
+   j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
+   j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
 #endif
 }
 
 // clean up the temporary component buffers
 static void stbi__cleanup_jpeg(stbi__jpeg *j)
 {
-	int i;
-	for (i = 0; i < j->s->img_n; ++i) {
-		if (j->img_comp[i].raw_data) {
-			STBI_FREE(j->img_comp[i].raw_data);
-			j->img_comp[i].raw_data = NULL;
-			j->img_comp[i].data = NULL;
-		}
-		if (j->img_comp[i].raw_coeff) {
-			STBI_FREE(j->img_comp[i].raw_coeff);
-			j->img_comp[i].raw_coeff = 0;
-			j->img_comp[i].coeff = 0;
-		}
-		if (j->img_comp[i].linebuf) {
-			STBI_FREE(j->img_comp[i].linebuf);
-			j->img_comp[i].linebuf = NULL;
-		}
-	}
+   stbi__free_jpeg_components(j, j->s->img_n, 0);
 }
 
 typedef struct
 {
-	resample_row_func resample;
-	stbi_uc *line0, *line1;
-	int hs, vs;   // expansion factor in each axis
-	int w_lores; // horizontal pixels pre-expansion
-	int ystep;   // how far through vertical expansion we are
-	int ypos;    // which pre-expansion row we're on
+   resample_row_func resample;
+   stbi_uc *line0,*line1;
+   int hs,vs;   // expansion factor in each axis
+   int w_lores; // horizontal pixels pre-expansion
+   int ystep;   // how far through vertical expansion we are
+   int ypos;    // which pre-expansion row we're on
 } stbi__resample;
+
+// fast 0..255 * 0..255 => 0..255 rounded multiplication
+static stbi_uc stbi__blinn_8x8(stbi_uc x, stbi_uc y)
+{
+   unsigned int t = x*y + 128;
+   return (stbi_uc) ((t + (t >>8)) >> 8);
+}
 
 static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp, int req_comp)
 {
-	int n, decode_n;
-	z->s->img_n = 0; // make stbi__cleanup_jpeg safe
+   int n, decode_n, is_rgb;
+   z->s->img_n = 0; // make stbi__cleanup_jpeg safe
 
-					 // validate req_comp
-	if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
+   // validate req_comp
+   if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
 
-	// load a jpeg image from whichever source, but leave in YCbCr format
-	if (!stbi__decode_jpeg_image(z)) { stbi__cleanup_jpeg(z); return NULL; }
+   // load a jpeg image from whichever source, but leave in YCbCr format
+   if (!stbi__decode_jpeg_image(z)) { stbi__cleanup_jpeg(z); return NULL; }
 
-	// determine actual number of components to generate
-	n = req_comp ? req_comp : z->s->img_n;
+   // determine actual number of components to generate
+   n = req_comp ? req_comp : z->s->img_n >= 3 ? 3 : 1;
 
-	if (z->s->img_n == 3 && n < 3)
-		decode_n = 1;
-	else
-		decode_n = z->s->img_n;
+   is_rgb = z->s->img_n == 3 && (z->rgb == 3 || (z->app14_color_transform == 0 && !z->jfif));
 
-	// resample and color-convert
-	{
-		int k;
-		unsigned int i, j;
-		stbi_uc *output;
-		stbi_uc *coutput[4];
+   if (z->s->img_n == 3 && n < 3 && !is_rgb)
+      decode_n = 1;
+   else
+      decode_n = z->s->img_n;
 
-		stbi__resample res_comp[4];
+   // resample and color-convert
+   {
+      int k;
+      unsigned int i,j;
+      stbi_uc *output;
+      stbi_uc *coutput[4];
 
-		for (k = 0; k < decode_n; ++k) {
-			stbi__resample *r = &res_comp[k];
+      stbi__resample res_comp[4];
 
-			// allocate line buffer big enough for upsampling off the edges
-			// with upsample factor of 4
-			z->img_comp[k].linebuf = (stbi_uc *)stbi__malloc(z->s->img_x + 3);
-			if (!z->img_comp[k].linebuf) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
+      for (k=0; k < decode_n; ++k) {
+         stbi__resample *r = &res_comp[k];
 
-			r->hs = z->img_h_max / z->img_comp[k].h;
-			r->vs = z->img_v_max / z->img_comp[k].v;
-			r->ystep = r->vs >> 1;
-			r->w_lores = (z->s->img_x + r->hs - 1) / r->hs;
-			r->ypos = 0;
-			r->line0 = r->line1 = z->img_comp[k].data;
+         // allocate line buffer big enough for upsampling off the edges
+         // with upsample factor of 4
+         z->img_comp[k].linebuf = (stbi_uc *) stbi__malloc(z->s->img_x + 3);
+         if (!z->img_comp[k].linebuf) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
 
-			if (r->hs == 1 && r->vs == 1) r->resample = resample_row_1;
-			else if (r->hs == 1 && r->vs == 2) r->resample = stbi__resample_row_v_2;
-			else if (r->hs == 2 && r->vs == 1) r->resample = stbi__resample_row_h_2;
-			else if (r->hs == 2 && r->vs == 2) r->resample = z->resample_row_hv_2_kernel;
-			else                               r->resample = stbi__resample_row_generic;
-		}
+         r->hs      = z->img_h_max / z->img_comp[k].h;
+         r->vs      = z->img_v_max / z->img_comp[k].v;
+         r->ystep   = r->vs >> 1;
+         r->w_lores = (z->s->img_x + r->hs-1) / r->hs;
+         r->ypos    = 0;
+         r->line0   = r->line1 = z->img_comp[k].data;
 
-		// can't error after this so, this is safe
-		output = (stbi_uc *)stbi__malloc(n * z->s->img_x * z->s->img_y + 1);
-		if (!output) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
+         if      (r->hs == 1 && r->vs == 1) r->resample = resample_row_1;
+         else if (r->hs == 1 && r->vs == 2) r->resample = stbi__resample_row_v_2;
+         else if (r->hs == 2 && r->vs == 1) r->resample = stbi__resample_row_h_2;
+         else if (r->hs == 2 && r->vs == 2) r->resample = z->resample_row_hv_2_kernel;
+         else                               r->resample = stbi__resample_row_generic;
+      }
 
-		// now go ahead and resample
-		for (j = 0; j < z->s->img_y; ++j) {
-			stbi_uc *out = output + n * z->s->img_x * j;
-			for (k = 0; k < decode_n; ++k) {
-				stbi__resample *r = &res_comp[k];
-				int y_bot = r->ystep >= (r->vs >> 1);
-				coutput[k] = r->resample(z->img_comp[k].linebuf,
-					y_bot ? r->line1 : r->line0,
-					y_bot ? r->line0 : r->line1,
-					r->w_lores, r->hs);
-				if (++r->ystep >= r->vs) {
-					r->ystep = 0;
-					r->line0 = r->line1;
-					if (++r->ypos < z->img_comp[k].y)
-						r->line1 += z->img_comp[k].w2;
-				}
-			}
-			if (n >= 3) {
-				stbi_uc *y = coutput[0];
-				if (z->s->img_n == 3) {
-					z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
-				}
-				else
-					for (i = 0; i < z->s->img_x; ++i) {
-						out[0] = out[1] = out[2] = y[i];
-						out[3] = 255; // not used if n==3
-						out += n;
-					}
-			}
-			else {
-				stbi_uc *y = coutput[0];
-				if (n == 1)
-					for (i = 0; i < z->s->img_x; ++i) out[i] = y[i];
-				else
-					for (i = 0; i < z->s->img_x; ++i) *out++ = y[i], *out++ = 255;
-			}
-		}
-		stbi__cleanup_jpeg(z);
-		*out_x = z->s->img_x;
-		*out_y = z->s->img_y;
-		if (comp) *comp = z->s->img_n; // report original components, not output
-		return output;
-	}
+      // can't error after this so, this is safe
+      output = (stbi_uc *) stbi__malloc_mad3(n, z->s->img_x, z->s->img_y, 1);
+      if (!output) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
+
+      // now go ahead and resample
+      for (j=0; j < z->s->img_y; ++j) {
+         stbi_uc *out = output + n * z->s->img_x * j;
+         for (k=0; k < decode_n; ++k) {
+            stbi__resample *r = &res_comp[k];
+            int y_bot = r->ystep >= (r->vs >> 1);
+            coutput[k] = r->resample(z->img_comp[k].linebuf,
+                                     y_bot ? r->line1 : r->line0,
+                                     y_bot ? r->line0 : r->line1,
+                                     r->w_lores, r->hs);
+            if (++r->ystep >= r->vs) {
+               r->ystep = 0;
+               r->line0 = r->line1;
+               if (++r->ypos < z->img_comp[k].y)
+                  r->line1 += z->img_comp[k].w2;
+            }
+         }
+         if (n >= 3) {
+            stbi_uc *y = coutput[0];
+            if (z->s->img_n == 3) {
+               if (is_rgb) {
+                  for (i=0; i < z->s->img_x; ++i) {
+                     out[0] = y[i];
+                     out[1] = coutput[1][i];
+                     out[2] = coutput[2][i];
+                     out[3] = 255;
+                     out += n;
+                  }
+               } else {
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+               }
+            } else if (z->s->img_n == 4) {
+               if (z->app14_color_transform == 0) { // CMYK
+                  for (i=0; i < z->s->img_x; ++i) {
+                     stbi_uc m = coutput[3][i];
+                     out[0] = stbi__blinn_8x8(coutput[0][i], m);
+                     out[1] = stbi__blinn_8x8(coutput[1][i], m);
+                     out[2] = stbi__blinn_8x8(coutput[2][i], m);
+                     out[3] = 255;
+                     out += n;
+                  }
+               } else if (z->app14_color_transform == 2) { // YCCK
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+                  for (i=0; i < z->s->img_x; ++i) {
+                     stbi_uc m = coutput[3][i];
+                     out[0] = stbi__blinn_8x8(255 - out[0], m);
+                     out[1] = stbi__blinn_8x8(255 - out[1], m);
+                     out[2] = stbi__blinn_8x8(255 - out[2], m);
+                     out += n;
+                  }
+               } else { // YCbCr + alpha?  Ignore the fourth channel for now
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+               }
+            } else
+               for (i=0; i < z->s->img_x; ++i) {
+                  out[0] = out[1] = out[2] = y[i];
+                  out[3] = 255; // not used if n==3
+                  out += n;
+               }
+         } else {
+            if (is_rgb) {
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i)
+                     *out++ = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+               else {
+                  for (i=0; i < z->s->img_x; ++i, out += 2) {
+                     out[0] = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+                     out[1] = 255;
+                  }
+               }
+            } else if (z->s->img_n == 4 && z->app14_color_transform == 0) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  stbi_uc m = coutput[3][i];
+                  stbi_uc r = stbi__blinn_8x8(coutput[0][i], m);
+                  stbi_uc g = stbi__blinn_8x8(coutput[1][i], m);
+                  stbi_uc b = stbi__blinn_8x8(coutput[2][i], m);
+                  out[0] = stbi__compute_y(r, g, b);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else if (z->s->img_n == 4 && z->app14_color_transform == 2) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  out[0] = stbi__blinn_8x8(255 - coutput[0][i], coutput[3][i]);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else {
+               stbi_uc *y = coutput[0];
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i) out[i] = y[i];
+               else
+                  for (i=0; i < z->s->img_x; ++i) *out++ = y[i], *out++ = 255;
+            }
+         }
+      }
+      stbi__cleanup_jpeg(z);
+      *out_x = z->s->img_x;
+      *out_y = z->s->img_y;
+      if (comp) *comp = z->s->img_n >= 3 ? 3 : 1; // report original components, not output
+      return output;
+   }
 }
 
-static unsigned char *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
-	stbi__jpeg j;
-	j.s = s;
-	stbi__setup_jpeg(&j);
-	return load_jpeg_image(&j, x, y, comp, req_comp);
+   unsigned char* result;
+   stbi__jpeg* j = (stbi__jpeg*) stbi__malloc(sizeof(stbi__jpeg));
+   STBI_NOTUSED(ri);
+   j->s = s;
+   stbi__setup_jpeg(j);
+   result = load_jpeg_image(j, x,y,comp,req_comp);
+   STBI_FREE(j);
+   return result;
 }
 
 static int stbi__jpeg_test(stbi__context *s)
 {
-	int r;
-	stbi__jpeg j;
-	j.s = s;
-	stbi__setup_jpeg(&j);
-	r = stbi__decode_jpeg_header(&j, STBI__SCAN_type);
-	stbi__rewind(s);
-	return r;
+   int r;
+   stbi__jpeg* j = (stbi__jpeg*)stbi__malloc(sizeof(stbi__jpeg));
+   j->s = s;
+   stbi__setup_jpeg(j);
+   r = stbi__decode_jpeg_header(j, STBI__SCAN_type);
+   stbi__rewind(s);
+   STBI_FREE(j);
+   return r;
 }
 
 static int stbi__jpeg_info_raw(stbi__jpeg *j, int *x, int *y, int *comp)
 {
-	if (!stbi__decode_jpeg_header(j, STBI__SCAN_header)) {
-		stbi__rewind(j->s);
-		return 0;
-	}
-	if (x) *x = j->s->img_x;
-	if (y) *y = j->s->img_y;
-	if (comp) *comp = j->s->img_n;
-	return 1;
+   if (!stbi__decode_jpeg_header(j, STBI__SCAN_header)) {
+      stbi__rewind( j->s );
+      return 0;
+   }
+   if (x) *x = j->s->img_x;
+   if (y) *y = j->s->img_y;
+   if (comp) *comp = j->s->img_n >= 3 ? 3 : 1;
+   return 1;
 }
 
 static int stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	stbi__jpeg j;
-	j.s = s;
-	return stbi__jpeg_info_raw(&j, x, y, comp);
+   int result;
+   stbi__jpeg* j = (stbi__jpeg*) (stbi__malloc(sizeof(stbi__jpeg)));
+   j->s = s;
+   result = stbi__jpeg_info_raw(j, x, y, comp);
+   STBI_FREE(j);
+   return result;
 }
 #endif
 
@@ -3486,76 +3793,76 @@ static int stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp)
 // (jpegs packs from left, zlib from right, so can't share code)
 typedef struct
 {
-	stbi__uint16 fast[1 << STBI__ZFAST_BITS];
-	stbi__uint16 firstcode[16];
-	int maxcode[17];
-	stbi__uint16 firstsymbol[16];
-	stbi_uc  size[288];
-	stbi__uint16 value[288];
+   stbi__uint16 fast[1 << STBI__ZFAST_BITS];
+   stbi__uint16 firstcode[16];
+   int maxcode[17];
+   stbi__uint16 firstsymbol[16];
+   stbi_uc  size[288];
+   stbi__uint16 value[288];
 } stbi__zhuffman;
 
 stbi_inline static int stbi__bitreverse16(int n)
 {
-	n = ((n & 0xAAAA) >> 1) | ((n & 0x5555) << 1);
-	n = ((n & 0xCCCC) >> 2) | ((n & 0x3333) << 2);
-	n = ((n & 0xF0F0) >> 4) | ((n & 0x0F0F) << 4);
-	n = ((n & 0xFF00) >> 8) | ((n & 0x00FF) << 8);
-	return n;
+  n = ((n & 0xAAAA) >>  1) | ((n & 0x5555) << 1);
+  n = ((n & 0xCCCC) >>  2) | ((n & 0x3333) << 2);
+  n = ((n & 0xF0F0) >>  4) | ((n & 0x0F0F) << 4);
+  n = ((n & 0xFF00) >>  8) | ((n & 0x00FF) << 8);
+  return n;
 }
 
 stbi_inline static int stbi__bit_reverse(int v, int bits)
 {
-	STBI_ASSERT(bits <= 16);
-	// to bit reverse n bits, reverse 16 and shift
-	// e.g. 11 bits, bit reverse and shift away 5
-	return stbi__bitreverse16(v) >> (16 - bits);
+   STBI_ASSERT(bits <= 16);
+   // to bit reverse n bits, reverse 16 and shift
+   // e.g. 11 bits, bit reverse and shift away 5
+   return stbi__bitreverse16(v) >> (16-bits);
 }
 
-static int stbi__zbuild_huffman(stbi__zhuffman *z, stbi_uc *sizelist, int num)
+static int stbi__zbuild_huffman(stbi__zhuffman *z, const stbi_uc *sizelist, int num)
 {
-	int i, k = 0;
-	int code, next_code[16], sizes[17];
+   int i,k=0;
+   int code, next_code[16], sizes[17];
 
-	// DEFLATE spec for generating codes
-	memset(sizes, 0, sizeof(sizes));
-	memset(z->fast, 0, sizeof(z->fast));
-	for (i = 0; i < num; ++i)
-		++sizes[sizelist[i]];
-	sizes[0] = 0;
-	for (i = 1; i < 16; ++i)
-		if (sizes[i] >(1 << i))
-			return stbi__err("bad sizes", "Corrupt PNG");
-	code = 0;
-	for (i = 1; i < 16; ++i) {
-		next_code[i] = code;
-		z->firstcode[i] = (stbi__uint16)code;
-		z->firstsymbol[i] = (stbi__uint16)k;
-		code = (code + sizes[i]);
-		if (sizes[i])
-			if (code - 1 >= (1 << i)) return stbi__err("bad codelengths", "Corrupt PNG");
-		z->maxcode[i] = code << (16 - i); // preshift for inner loop
-		code <<= 1;
-		k += sizes[i];
-	}
-	z->maxcode[16] = 0x10000; // sentinel
-	for (i = 0; i < num; ++i) {
-		int s = sizelist[i];
-		if (s) {
-			int c = next_code[s] - z->firstcode[s] + z->firstsymbol[s];
-			stbi__uint16 fastv = (stbi__uint16)((s << 9) | i);
-			z->size[c] = (stbi_uc)s;
-			z->value[c] = (stbi__uint16)i;
-			if (s <= STBI__ZFAST_BITS) {
-				int j = stbi__bit_reverse(next_code[s], s);
-				while (j < (1 << STBI__ZFAST_BITS)) {
-					z->fast[j] = fastv;
-					j += (1 << s);
-				}
-			}
-			++next_code[s];
-		}
-	}
-	return 1;
+   // DEFLATE spec for generating codes
+   memset(sizes, 0, sizeof(sizes));
+   memset(z->fast, 0, sizeof(z->fast));
+   for (i=0; i < num; ++i)
+      ++sizes[sizelist[i]];
+   sizes[0] = 0;
+   for (i=1; i < 16; ++i)
+      if (sizes[i] > (1 << i))
+         return stbi__err("bad sizes", "Corrupt PNG");
+   code = 0;
+   for (i=1; i < 16; ++i) {
+      next_code[i] = code;
+      z->firstcode[i] = (stbi__uint16) code;
+      z->firstsymbol[i] = (stbi__uint16) k;
+      code = (code + sizes[i]);
+      if (sizes[i])
+         if (code-1 >= (1 << i)) return stbi__err("bad codelengths","Corrupt PNG");
+      z->maxcode[i] = code << (16-i); // preshift for inner loop
+      code <<= 1;
+      k += sizes[i];
+   }
+   z->maxcode[16] = 0x10000; // sentinel
+   for (i=0; i < num; ++i) {
+      int s = sizelist[i];
+      if (s) {
+         int c = next_code[s] - z->firstcode[s] + z->firstsymbol[s];
+         stbi__uint16 fastv = (stbi__uint16) ((s << 9) | i);
+         z->size [c] = (stbi_uc     ) s;
+         z->value[c] = (stbi__uint16) i;
+         if (s <= STBI__ZFAST_BITS) {
+            int j = stbi__bit_reverse(next_code[s],s);
+            while (j < (1 << STBI__ZFAST_BITS)) {
+               z->fast[j] = fastv;
+               j += (1 << s);
+            }
+         }
+         ++next_code[s];
+      }
+   }
+   return 1;
 }
 
 // zlib-from-memory implementation for PNG reading
@@ -3566,373 +3873,381 @@ static int stbi__zbuild_huffman(stbi__zhuffman *z, stbi_uc *sizelist, int num)
 
 typedef struct
 {
-	stbi_uc *zbuffer, *zbuffer_end;
-	int num_bits;
-	stbi__uint32 code_buffer;
+   stbi_uc *zbuffer, *zbuffer_end;
+   int num_bits;
+   stbi__uint32 code_buffer;
 
-	char *zout;
-	char *zout_start;
-	char *zout_end;
-	int   z_expandable;
+   char *zout;
+   char *zout_start;
+   char *zout_end;
+   int   z_expandable;
 
-	stbi__zhuffman z_length, z_distance;
+   stbi__zhuffman z_length, z_distance;
 } stbi__zbuf;
 
 stbi_inline static stbi_uc stbi__zget8(stbi__zbuf *z)
 {
-	if (z->zbuffer >= z->zbuffer_end) return 0;
-	return *z->zbuffer++;
+   if (z->zbuffer >= z->zbuffer_end) return 0;
+   return *z->zbuffer++;
 }
 
 static void stbi__fill_bits(stbi__zbuf *z)
 {
-	do {
-		STBI_ASSERT(z->code_buffer < (1U << z->num_bits));
-		z->code_buffer |= (unsigned int)stbi__zget8(z) << z->num_bits;
-		z->num_bits += 8;
-	} while (z->num_bits <= 24);
+   do {
+      STBI_ASSERT(z->code_buffer < (1U << z->num_bits));
+      z->code_buffer |= (unsigned int) stbi__zget8(z) << z->num_bits;
+      z->num_bits += 8;
+   } while (z->num_bits <= 24);
 }
 
 stbi_inline static unsigned int stbi__zreceive(stbi__zbuf *z, int n)
 {
-	unsigned int k;
-	if (z->num_bits < n) stbi__fill_bits(z);
-	k = z->code_buffer & ((1 << n) - 1);
-	z->code_buffer >>= n;
-	z->num_bits -= n;
-	return k;
+   unsigned int k;
+   if (z->num_bits < n) stbi__fill_bits(z);
+   k = z->code_buffer & ((1 << n) - 1);
+   z->code_buffer >>= n;
+   z->num_bits -= n;
+   return k;
 }
 
 static int stbi__zhuffman_decode_slowpath(stbi__zbuf *a, stbi__zhuffman *z)
 {
-	int b, s, k;
-	// not resolved by fast table, so compute it the slow way
-	// use jpeg approach, which requires MSbits at top
-	k = stbi__bit_reverse(a->code_buffer, 16);
-	for (s = STBI__ZFAST_BITS + 1; ; ++s)
-		if (k < z->maxcode[s])
-			break;
-	if (s == 16) return -1; // invalid code!
-							// code size is s, so:
-	b = (k >> (16 - s)) - z->firstcode[s] + z->firstsymbol[s];
-	STBI_ASSERT(z->size[b] == s);
-	a->code_buffer >>= s;
-	a->num_bits -= s;
-	return z->value[b];
+   int b,s,k;
+   // not resolved by fast table, so compute it the slow way
+   // use jpeg approach, which requires MSbits at top
+   k = stbi__bit_reverse(a->code_buffer, 16);
+   for (s=STBI__ZFAST_BITS+1; ; ++s)
+      if (k < z->maxcode[s])
+         break;
+   if (s == 16) return -1; // invalid code!
+   // code size is s, so:
+   b = (k >> (16-s)) - z->firstcode[s] + z->firstsymbol[s];
+   STBI_ASSERT(z->size[b] == s);
+   a->code_buffer >>= s;
+   a->num_bits -= s;
+   return z->value[b];
 }
 
 stbi_inline static int stbi__zhuffman_decode(stbi__zbuf *a, stbi__zhuffman *z)
 {
-	int b, s;
-	if (a->num_bits < 16) stbi__fill_bits(a);
-	b = z->fast[a->code_buffer & STBI__ZFAST_MASK];
-	if (b) {
-		s = b >> 9;
-		a->code_buffer >>= s;
-		a->num_bits -= s;
-		return b & 511;
-	}
-	return stbi__zhuffman_decode_slowpath(a, z);
+   int b,s;
+   if (a->num_bits < 16) stbi__fill_bits(a);
+   b = z->fast[a->code_buffer & STBI__ZFAST_MASK];
+   if (b) {
+      s = b >> 9;
+      a->code_buffer >>= s;
+      a->num_bits -= s;
+      return b & 511;
+   }
+   return stbi__zhuffman_decode_slowpath(a, z);
 }
 
 static int stbi__zexpand(stbi__zbuf *z, char *zout, int n)  // need to make room for n bytes
 {
-	char *q;
-	int cur, limit, old_limit;
-	z->zout = zout;
-	if (!z->z_expandable) return stbi__err("output buffer limit", "Corrupt PNG");
-	cur = (int)(z->zout - z->zout_start);
-	limit = old_limit = (int)(z->zout_end - z->zout_start);
-	while (cur + n > limit)
-		limit *= 2;
-	q = (char *)STBI_REALLOC_SIZED(z->zout_start, old_limit, limit);
-	STBI_NOTUSED(old_limit);
-	if (q == NULL) return stbi__err("outofmem", "Out of memory");
-	z->zout_start = q;
-	z->zout = q + cur;
-	z->zout_end = q + limit;
-	return 1;
+   char *q;
+   int cur, limit, old_limit;
+   z->zout = zout;
+   if (!z->z_expandable) return stbi__err("output buffer limit","Corrupt PNG");
+   cur   = (int) (z->zout     - z->zout_start);
+   limit = old_limit = (int) (z->zout_end - z->zout_start);
+   while (cur + n > limit)
+      limit *= 2;
+   q = (char *) STBI_REALLOC_SIZED(z->zout_start, old_limit, limit);
+   STBI_NOTUSED(old_limit);
+   if (q == NULL) return stbi__err("outofmem", "Out of memory");
+   z->zout_start = q;
+   z->zout       = q + cur;
+   z->zout_end   = q + limit;
+   return 1;
 }
 
-static int stbi__zlength_base[31] = {
-	3,4,5,6,7,8,9,10,11,13,
-	15,17,19,23,27,31,35,43,51,59,
-	67,83,99,115,131,163,195,227,258,0,0 };
+static const int stbi__zlength_base[31] = {
+   3,4,5,6,7,8,9,10,11,13,
+   15,17,19,23,27,31,35,43,51,59,
+   67,83,99,115,131,163,195,227,258,0,0 };
 
-static int stbi__zlength_extra[31] =
+static const int stbi__zlength_extra[31]=
 { 0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,0,0 };
 
-static int stbi__zdist_base[32] = { 1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,
-257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577,0,0 };
+static const int stbi__zdist_base[32] = { 1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,
+257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577,0,0};
 
-static int stbi__zdist_extra[32] =
-{ 0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13 };
+static const int stbi__zdist_extra[32] =
+{ 0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13};
 
 static int stbi__parse_huffman_block(stbi__zbuf *a)
 {
-	char *zout = a->zout;
-	for (;;) {
-		int z = stbi__zhuffman_decode(a, &a->z_length);
-		if (z < 256) {
-			if (z < 0) return stbi__err("bad huffman code", "Corrupt PNG"); // error in huffman codes
-			if (zout >= a->zout_end) {
-				if (!stbi__zexpand(a, zout, 1)) return 0;
-				zout = a->zout;
-			}
-			*zout++ = (char)z;
-		}
-		else {
-			stbi_uc *p;
-			int len, dist;
-			if (z == 256) {
-				a->zout = zout;
-				return 1;
-			}
-			z -= 257;
-			len = stbi__zlength_base[z];
-			if (stbi__zlength_extra[z]) len += stbi__zreceive(a, stbi__zlength_extra[z]);
-			z = stbi__zhuffman_decode(a, &a->z_distance);
-			if (z < 0) return stbi__err("bad huffman code", "Corrupt PNG");
-			dist = stbi__zdist_base[z];
-			if (stbi__zdist_extra[z]) dist += stbi__zreceive(a, stbi__zdist_extra[z]);
-			if (zout - a->zout_start < dist) return stbi__err("bad dist", "Corrupt PNG");
-			if (zout + len > a->zout_end) {
-				if (!stbi__zexpand(a, zout, len)) return 0;
-				zout = a->zout;
-			}
-			p = (stbi_uc *)(zout - dist);
-			if (dist == 1) { // run of one byte; common in images.
-				stbi_uc v = *p;
-				if (len) { do *zout++ = v; while (--len); }
-			}
-			else {
-				if (len) { do *zout++ = *p++; while (--len); }
-			}
-		}
-	}
+   char *zout = a->zout;
+   for(;;) {
+      int z = stbi__zhuffman_decode(a, &a->z_length);
+      if (z < 256) {
+         if (z < 0) return stbi__err("bad huffman code","Corrupt PNG"); // error in huffman codes
+         if (zout >= a->zout_end) {
+            if (!stbi__zexpand(a, zout, 1)) return 0;
+            zout = a->zout;
+         }
+         *zout++ = (char) z;
+      } else {
+         stbi_uc *p;
+         int len,dist;
+         if (z == 256) {
+            a->zout = zout;
+            return 1;
+         }
+         z -= 257;
+         len = stbi__zlength_base[z];
+         if (stbi__zlength_extra[z]) len += stbi__zreceive(a, stbi__zlength_extra[z]);
+         z = stbi__zhuffman_decode(a, &a->z_distance);
+         if (z < 0) return stbi__err("bad huffman code","Corrupt PNG");
+         dist = stbi__zdist_base[z];
+         if (stbi__zdist_extra[z]) dist += stbi__zreceive(a, stbi__zdist_extra[z]);
+         if (zout - a->zout_start < dist) return stbi__err("bad dist","Corrupt PNG");
+         if (zout + len > a->zout_end) {
+            if (!stbi__zexpand(a, zout, len)) return 0;
+            zout = a->zout;
+         }
+         p = (stbi_uc *) (zout - dist);
+         if (dist == 1) { // run of one byte; common in images.
+            stbi_uc v = *p;
+            if (len) { do *zout++ = v; while (--len); }
+         } else {
+            if (len) { do *zout++ = *p++; while (--len); }
+         }
+      }
+   }
 }
 
 static int stbi__compute_huffman_codes(stbi__zbuf *a)
 {
-	static stbi_uc length_dezigzag[19] = { 16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
-	stbi__zhuffman z_codelength;
-	stbi_uc lencodes[286 + 32 + 137];//padding for maximum single op
-	stbi_uc codelength_sizes[19];
-	int i, n;
+   static const stbi_uc length_dezigzag[19] = { 16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
+   stbi__zhuffman z_codelength;
+   stbi_uc lencodes[286+32+137];//padding for maximum single op
+   stbi_uc codelength_sizes[19];
+   int i,n;
 
-	int hlit = stbi__zreceive(a, 5) + 257;
-	int hdist = stbi__zreceive(a, 5) + 1;
-	int hclen = stbi__zreceive(a, 4) + 4;
+   int hlit  = stbi__zreceive(a,5) + 257;
+   int hdist = stbi__zreceive(a,5) + 1;
+   int hclen = stbi__zreceive(a,4) + 4;
+   int ntot  = hlit + hdist;
 
-	memset(codelength_sizes, 0, sizeof(codelength_sizes));
-	for (i = 0; i < hclen; ++i) {
-		int s = stbi__zreceive(a, 3);
-		codelength_sizes[length_dezigzag[i]] = (stbi_uc)s;
-	}
-	if (!stbi__zbuild_huffman(&z_codelength, codelength_sizes, 19)) return 0;
+   memset(codelength_sizes, 0, sizeof(codelength_sizes));
+   for (i=0; i < hclen; ++i) {
+      int s = stbi__zreceive(a,3);
+      codelength_sizes[length_dezigzag[i]] = (stbi_uc) s;
+   }
+   if (!stbi__zbuild_huffman(&z_codelength, codelength_sizes, 19)) return 0;
 
-	n = 0;
-	while (n < hlit + hdist) {
-		int c = stbi__zhuffman_decode(a, &z_codelength);
-		if (c < 0 || c >= 19) return stbi__err("bad codelengths", "Corrupt PNG");
-		if (c < 16)
-			lencodes[n++] = (stbi_uc)c;
-		else if (c == 16) {
-			c = stbi__zreceive(a, 2) + 3;
-			memset(lencodes + n, lencodes[n - 1], c);
-			n += c;
-		}
-		else if (c == 17) {
-			c = stbi__zreceive(a, 3) + 3;
-			memset(lencodes + n, 0, c);
-			n += c;
-		}
-		else {
-			STBI_ASSERT(c == 18);
-			c = stbi__zreceive(a, 7) + 11;
-			memset(lencodes + n, 0, c);
-			n += c;
-		}
-	}
-	if (n != hlit + hdist) return stbi__err("bad codelengths", "Corrupt PNG");
-	if (!stbi__zbuild_huffman(&a->z_length, lencodes, hlit)) return 0;
-	if (!stbi__zbuild_huffman(&a->z_distance, lencodes + hlit, hdist)) return 0;
-	return 1;
+   n = 0;
+   while (n < ntot) {
+      int c = stbi__zhuffman_decode(a, &z_codelength);
+      if (c < 0 || c >= 19) return stbi__err("bad codelengths", "Corrupt PNG");
+      if (c < 16)
+         lencodes[n++] = (stbi_uc) c;
+      else {
+         stbi_uc fill = 0;
+         if (c == 16) {
+            c = stbi__zreceive(a,2)+3;
+            if (n == 0) return stbi__err("bad codelengths", "Corrupt PNG");
+            fill = lencodes[n-1];
+         } else if (c == 17)
+            c = stbi__zreceive(a,3)+3;
+         else {
+            STBI_ASSERT(c == 18);
+            c = stbi__zreceive(a,7)+11;
+         }
+         if (ntot - n < c) return stbi__err("bad codelengths", "Corrupt PNG");
+         memset(lencodes+n, fill, c);
+         n += c;
+      }
+   }
+   if (n != ntot) return stbi__err("bad codelengths","Corrupt PNG");
+   if (!stbi__zbuild_huffman(&a->z_length, lencodes, hlit)) return 0;
+   if (!stbi__zbuild_huffman(&a->z_distance, lencodes+hlit, hdist)) return 0;
+   return 1;
 }
 
-static int stbi__parse_uncomperssed_block(stbi__zbuf *a)
+static int stbi__parse_uncompressed_block(stbi__zbuf *a)
 {
-	stbi_uc header[4];
-	int len, nlen, k;
-	if (a->num_bits & 7)
-		stbi__zreceive(a, a->num_bits & 7); // discard
-											// drain the bit-packed data into header
-	k = 0;
-	while (a->num_bits > 0) {
-		header[k++] = (stbi_uc)(a->code_buffer & 255); // suppress MSVC run-time check
-		a->code_buffer >>= 8;
-		a->num_bits -= 8;
-	}
-	STBI_ASSERT(a->num_bits == 0);
-	// now fill header the normal way
-	while (k < 4)
-		header[k++] = stbi__zget8(a);
-	len = header[1] * 256 + header[0];
-	nlen = header[3] * 256 + header[2];
-	if (nlen != (len ^ 0xffff)) return stbi__err("zlib corrupt", "Corrupt PNG");
-	if (a->zbuffer + len > a->zbuffer_end) return stbi__err("read past buffer", "Corrupt PNG");
-	if (a->zout + len > a->zout_end)
-		if (!stbi__zexpand(a, a->zout, len)) return 0;
-	memcpy(a->zout, a->zbuffer, len);
-	a->zbuffer += len;
-	a->zout += len;
-	return 1;
+   stbi_uc header[4];
+   int len,nlen,k;
+   if (a->num_bits & 7)
+      stbi__zreceive(a, a->num_bits & 7); // discard
+   // drain the bit-packed data into header
+   k = 0;
+   while (a->num_bits > 0) {
+      header[k++] = (stbi_uc) (a->code_buffer & 255); // suppress MSVC run-time check
+      a->code_buffer >>= 8;
+      a->num_bits -= 8;
+   }
+   STBI_ASSERT(a->num_bits == 0);
+   // now fill header the normal way
+   while (k < 4)
+      header[k++] = stbi__zget8(a);
+   len  = header[1] * 256 + header[0];
+   nlen = header[3] * 256 + header[2];
+   if (nlen != (len ^ 0xffff)) return stbi__err("zlib corrupt","Corrupt PNG");
+   if (a->zbuffer + len > a->zbuffer_end) return stbi__err("read past buffer","Corrupt PNG");
+   if (a->zout + len > a->zout_end)
+      if (!stbi__zexpand(a, a->zout, len)) return 0;
+   memcpy(a->zout, a->zbuffer, len);
+   a->zbuffer += len;
+   a->zout += len;
+   return 1;
 }
 
 static int stbi__parse_zlib_header(stbi__zbuf *a)
 {
-	int cmf = stbi__zget8(a);
-	int cm = cmf & 15;
-	/* int cinfo = cmf >> 4; */
-	int flg = stbi__zget8(a);
-	if ((cmf * 256 + flg) % 31 != 0) return stbi__err("bad zlib header", "Corrupt PNG"); // zlib spec
-	if (flg & 32) return stbi__err("no preset dict", "Corrupt PNG"); // preset dictionary not allowed in png
-	if (cm != 8) return stbi__err("bad compression", "Corrupt PNG"); // DEFLATE required for png
-																	 // window = 1 << (8 + cinfo)... but who cares, we fully buffer output
-	return 1;
+   int cmf   = stbi__zget8(a);
+   int cm    = cmf & 15;
+   /* int cinfo = cmf >> 4; */
+   int flg   = stbi__zget8(a);
+   if ((cmf*256+flg) % 31 != 0) return stbi__err("bad zlib header","Corrupt PNG"); // zlib spec
+   if (flg & 32) return stbi__err("no preset dict","Corrupt PNG"); // preset dictionary not allowed in png
+   if (cm != 8) return stbi__err("bad compression","Corrupt PNG"); // DEFLATE required for png
+   // window = 1 << (8 + cinfo)... but who cares, we fully buffer output
+   return 1;
 }
 
-// @TODO: should statically initialize these for optimal thread safety
-static stbi_uc stbi__zdefault_length[288], stbi__zdefault_distance[32];
-static void stbi__init_zdefaults(void)
+static const stbi_uc stbi__zdefault_length[288] =
 {
-	int i;   // use <= to match clearly with spec
-	for (i = 0; i <= 143; ++i)     stbi__zdefault_length[i] = 8;
-	for (; i <= 255; ++i)     stbi__zdefault_length[i] = 9;
-	for (; i <= 279; ++i)     stbi__zdefault_length[i] = 7;
-	for (; i <= 287; ++i)     stbi__zdefault_length[i] = 8;
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, 7,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8
+};
+static const stbi_uc stbi__zdefault_distance[32] =
+{
+   5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5
+};
+/*
+Init algorithm:
+{
+   int i;   // use <= to match clearly with spec
+   for (i=0; i <= 143; ++i)     stbi__zdefault_length[i]   = 8;
+   for (   ; i <= 255; ++i)     stbi__zdefault_length[i]   = 9;
+   for (   ; i <= 279; ++i)     stbi__zdefault_length[i]   = 7;
+   for (   ; i <= 287; ++i)     stbi__zdefault_length[i]   = 8;
 
-	for (i = 0; i <= 31; ++i)     stbi__zdefault_distance[i] = 5;
+   for (i=0; i <=  31; ++i)     stbi__zdefault_distance[i] = 5;
 }
+*/
 
 static int stbi__parse_zlib(stbi__zbuf *a, int parse_header)
 {
-	int final, type;
-	if (parse_header)
-		if (!stbi__parse_zlib_header(a)) return 0;
-	a->num_bits = 0;
-	a->code_buffer = 0;
-	do {
-		final = stbi__zreceive(a, 1);
-		type = stbi__zreceive(a, 2);
-		if (type == 0) {
-			if (!stbi__parse_uncomperssed_block(a)) return 0;
-		}
-		else if (type == 3) {
-			return 0;
-		}
-		else {
-			if (type == 1) {
-				// use fixed code lengths
-				if (!stbi__zdefault_distance[31]) stbi__init_zdefaults();
-				if (!stbi__zbuild_huffman(&a->z_length, stbi__zdefault_length, 288)) return 0;
-				if (!stbi__zbuild_huffman(&a->z_distance, stbi__zdefault_distance, 32)) return 0;
-			}
-			else {
-				if (!stbi__compute_huffman_codes(a)) return 0;
-			}
-			if (!stbi__parse_huffman_block(a)) return 0;
-		}
-	} while (!final);
-	return 1;
+   int final, type;
+   if (parse_header)
+      if (!stbi__parse_zlib_header(a)) return 0;
+   a->num_bits = 0;
+   a->code_buffer = 0;
+   do {
+      final = stbi__zreceive(a,1);
+      type = stbi__zreceive(a,2);
+      if (type == 0) {
+         if (!stbi__parse_uncompressed_block(a)) return 0;
+      } else if (type == 3) {
+         return 0;
+      } else {
+         if (type == 1) {
+            // use fixed code lengths
+            if (!stbi__zbuild_huffman(&a->z_length  , stbi__zdefault_length  , 288)) return 0;
+            if (!stbi__zbuild_huffman(&a->z_distance, stbi__zdefault_distance,  32)) return 0;
+         } else {
+            if (!stbi__compute_huffman_codes(a)) return 0;
+         }
+         if (!stbi__parse_huffman_block(a)) return 0;
+      }
+   } while (!final);
+   return 1;
 }
 
 static int stbi__do_zlib(stbi__zbuf *a, char *obuf, int olen, int exp, int parse_header)
 {
-	a->zout_start = obuf;
-	a->zout = obuf;
-	a->zout_end = obuf + olen;
-	a->z_expandable = exp;
+   a->zout_start = obuf;
+   a->zout       = obuf;
+   a->zout_end   = obuf + olen;
+   a->z_expandable = exp;
 
-	return stbi__parse_zlib(a, parse_header);
+   return stbi__parse_zlib(a, parse_header);
 }
 
 STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen)
 {
-	stbi__zbuf a;
-	char *p = (char *)stbi__malloc(initial_size);
-	if (p == NULL) return NULL;
-	a.zbuffer = (stbi_uc *)buffer;
-	a.zbuffer_end = (stbi_uc *)buffer + len;
-	if (stbi__do_zlib(&a, p, initial_size, 1, 1)) {
-		if (outlen) *outlen = (int)(a.zout - a.zout_start);
-		return a.zout_start;
-	}
-	else {
-		STBI_FREE(a.zout_start);
-		return NULL;
-	}
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(initial_size);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer + len;
+   if (stbi__do_zlib(&a, p, initial_size, 1, 1)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
 }
 
 STBIDEF char *stbi_zlib_decode_malloc(char const *buffer, int len, int *outlen)
 {
-	return stbi_zlib_decode_malloc_guesssize(buffer, len, 16384, outlen);
+   return stbi_zlib_decode_malloc_guesssize(buffer, len, 16384, outlen);
 }
 
 STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header)
 {
-	stbi__zbuf a;
-	char *p = (char *)stbi__malloc(initial_size);
-	if (p == NULL) return NULL;
-	a.zbuffer = (stbi_uc *)buffer;
-	a.zbuffer_end = (stbi_uc *)buffer + len;
-	if (stbi__do_zlib(&a, p, initial_size, 1, parse_header)) {
-		if (outlen) *outlen = (int)(a.zout - a.zout_start);
-		return a.zout_start;
-	}
-	else {
-		STBI_FREE(a.zout_start);
-		return NULL;
-	}
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(initial_size);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer + len;
+   if (stbi__do_zlib(&a, p, initial_size, 1, parse_header)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
 }
 
 STBIDEF int stbi_zlib_decode_buffer(char *obuffer, int olen, char const *ibuffer, int ilen)
 {
-	stbi__zbuf a;
-	a.zbuffer = (stbi_uc *)ibuffer;
-	a.zbuffer_end = (stbi_uc *)ibuffer + ilen;
-	if (stbi__do_zlib(&a, obuffer, olen, 0, 1))
-		return (int)(a.zout - a.zout_start);
-	else
-		return -1;
+   stbi__zbuf a;
+   a.zbuffer = (stbi_uc *) ibuffer;
+   a.zbuffer_end = (stbi_uc *) ibuffer + ilen;
+   if (stbi__do_zlib(&a, obuffer, olen, 0, 1))
+      return (int) (a.zout - a.zout_start);
+   else
+      return -1;
 }
 
 STBIDEF char *stbi_zlib_decode_noheader_malloc(char const *buffer, int len, int *outlen)
 {
-	stbi__zbuf a;
-	char *p = (char *)stbi__malloc(16384);
-	if (p == NULL) return NULL;
-	a.zbuffer = (stbi_uc *)buffer;
-	a.zbuffer_end = (stbi_uc *)buffer + len;
-	if (stbi__do_zlib(&a, p, 16384, 1, 0)) {
-		if (outlen) *outlen = (int)(a.zout - a.zout_start);
-		return a.zout_start;
-	}
-	else {
-		STBI_FREE(a.zout_start);
-		return NULL;
-	}
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(16384);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer+len;
+   if (stbi__do_zlib(&a, p, 16384, 1, 0)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
 }
 
 STBIDEF int stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen)
 {
-	stbi__zbuf a;
-	a.zbuffer = (stbi_uc *)ibuffer;
-	a.zbuffer_end = (stbi_uc *)ibuffer + ilen;
-	if (stbi__do_zlib(&a, obuffer, olen, 0, 0))
-		return (int)(a.zout - a.zout_start);
-	else
-		return -1;
+   stbi__zbuf a;
+   a.zbuffer = (stbi_uc *) ibuffer;
+   a.zbuffer_end = (stbi_uc *) ibuffer + ilen;
+   if (stbi__do_zlib(&a, obuffer, olen, 0, 0))
+      return (int) (a.zout - a.zout_start);
+   else
+      return -1;
 }
 #endif
 
@@ -3949,356 +4264,410 @@ STBIDEF int stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char
 #ifndef STBI_NO_PNG
 typedef struct
 {
-	stbi__uint32 length;
-	stbi__uint32 type;
+   stbi__uint32 length;
+   stbi__uint32 type;
 } stbi__pngchunk;
 
 static stbi__pngchunk stbi__get_chunk_header(stbi__context *s)
 {
-	stbi__pngchunk c;
-	c.length = stbi__get32be(s);
-	c.type = stbi__get32be(s);
-	return c;
+   stbi__pngchunk c;
+   c.length = stbi__get32be(s);
+   c.type   = stbi__get32be(s);
+   return c;
 }
 
 static int stbi__check_png_header(stbi__context *s)
 {
-	static stbi_uc png_sig[8] = { 137,80,78,71,13,10,26,10 };
-	int i;
-	for (i = 0; i < 8; ++i)
-		if (stbi__get8(s) != png_sig[i]) return stbi__err("bad png sig", "Not a PNG");
-	return 1;
+   static const stbi_uc png_sig[8] = { 137,80,78,71,13,10,26,10 };
+   int i;
+   for (i=0; i < 8; ++i)
+      if (stbi__get8(s) != png_sig[i]) return stbi__err("bad png sig","Not a PNG");
+   return 1;
 }
 
 typedef struct
 {
-	stbi__context *s;
-	stbi_uc *idata, *expanded, *out;
+   stbi__context *s;
+   stbi_uc *idata, *expanded, *out;
+   int depth;
 } stbi__png;
 
 
 enum {
-	STBI__F_none = 0,
-	STBI__F_sub = 1,
-	STBI__F_up = 2,
-	STBI__F_avg = 3,
-	STBI__F_paeth = 4,
-	// synthetic filters used for first scanline to avoid needing a dummy row of 0s
-	STBI__F_avg_first,
-	STBI__F_paeth_first
+   STBI__F_none=0,
+   STBI__F_sub=1,
+   STBI__F_up=2,
+   STBI__F_avg=3,
+   STBI__F_paeth=4,
+   // synthetic filters used for first scanline to avoid needing a dummy row of 0s
+   STBI__F_avg_first,
+   STBI__F_paeth_first
 };
 
 static stbi_uc first_row_filter[5] =
 {
-	STBI__F_none,
-	STBI__F_sub,
-	STBI__F_none,
-	STBI__F_avg_first,
-	STBI__F_paeth_first
+   STBI__F_none,
+   STBI__F_sub,
+   STBI__F_none,
+   STBI__F_avg_first,
+   STBI__F_paeth_first
 };
 
 static int stbi__paeth(int a, int b, int c)
 {
-	int p = a + b - c;
-	int pa = abs(p - a);
-	int pb = abs(p - b);
-	int pc = abs(p - c);
-	if (pa <= pb && pa <= pc) return a;
-	if (pb <= pc) return b;
-	return c;
+   int p = a + b - c;
+   int pa = abs(p-a);
+   int pb = abs(p-b);
+   int pc = abs(p-c);
+   if (pa <= pb && pa <= pc) return a;
+   if (pb <= pc) return b;
+   return c;
 }
 
-static stbi_uc stbi__depth_scale_table[9] = { 0, 0xff, 0x55, 0, 0x11, 0,0,0, 0x01 };
+static const stbi_uc stbi__depth_scale_table[9] = { 0, 0xff, 0x55, 0, 0x11, 0,0,0, 0x01 };
 
 // create the png data from post-deflated data
 static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 raw_len, int out_n, stbi__uint32 x, stbi__uint32 y, int depth, int color)
 {
-	stbi__context *s = a->s;
-	stbi__uint32 i, j, stride = x*out_n;
-	stbi__uint32 img_len, img_width_bytes;
-	int k;
-	int img_n = s->img_n; // copy it into a local for later
+   int bytes = (depth == 16? 2 : 1);
+   stbi__context *s = a->s;
+   stbi__uint32 i,j,stride = x*out_n*bytes;
+   stbi__uint32 img_len, img_width_bytes;
+   int k;
+   int img_n = s->img_n; // copy it into a local for later
 
-	STBI_ASSERT(out_n == s->img_n || out_n == s->img_n + 1);
-	a->out = (stbi_uc *)stbi__malloc(x * y * out_n); // extra bytes to write off the end into
-	if (!a->out) return stbi__err("outofmem", "Out of memory");
+   int output_bytes = out_n*bytes;
+   int filter_bytes = img_n*bytes;
+   int width = x;
 
-	img_width_bytes = (((img_n * x * depth) + 7) >> 3);
-	img_len = (img_width_bytes + 1) * y;
-	if (s->img_x == x && s->img_y == y) {
-		if (raw_len != img_len) return stbi__err("not enough pixels", "Corrupt PNG");
-	}
-	else { // interlaced:
-		if (raw_len < img_len) return stbi__err("not enough pixels", "Corrupt PNG");
-	}
+   STBI_ASSERT(out_n == s->img_n || out_n == s->img_n+1);
+   a->out = (stbi_uc *) stbi__malloc_mad3(x, y, output_bytes, 0); // extra bytes to write off the end into
+   if (!a->out) return stbi__err("outofmem", "Out of memory");
 
-	for (j = 0; j < y; ++j) {
-		stbi_uc *cur = a->out + stride*j;
-		stbi_uc *prior = cur - stride;
-		int filter = *raw++;
-		int filter_bytes = img_n;
-		int width = x;
-		if (filter > 4)
-			return stbi__err("invalid filter", "Corrupt PNG");
+   if (!stbi__mad3sizes_valid(img_n, x, depth, 7)) return stbi__err("too large", "Corrupt PNG");
+   img_width_bytes = (((img_n * x * depth) + 7) >> 3);
+   img_len = (img_width_bytes + 1) * y;
 
-		if (depth < 8) {
-			STBI_ASSERT(img_width_bytes <= x);
-			cur += x*out_n - img_width_bytes; // store output to the rightmost img_len bytes, so we can decode in place
-			filter_bytes = 1;
-			width = img_width_bytes;
-		}
+   // we used to check for exact match between raw_len and img_len on non-interlaced PNGs,
+   // but issue #276 reported a PNG in the wild that had extra data at the end (all zeros),
+   // so just check for raw_len < img_len always.
+   if (raw_len < img_len) return stbi__err("not enough pixels","Corrupt PNG");
 
-		// if first row, use special filter that doesn't sample previous row
-		if (j == 0) filter = first_row_filter[filter];
+   for (j=0; j < y; ++j) {
+      stbi_uc *cur = a->out + stride*j;
+      stbi_uc *prior;
+      int filter = *raw++;
 
-		// handle first byte explicitly
-		for (k = 0; k < filter_bytes; ++k) {
-			switch (filter) {
-			case STBI__F_none: cur[k] = raw[k]; break;
-			case STBI__F_sub: cur[k] = raw[k]; break;
-			case STBI__F_up: cur[k] = STBI__BYTECAST(raw[k] + prior[k]); break;
-			case STBI__F_avg: cur[k] = STBI__BYTECAST(raw[k] + (prior[k] >> 1)); break;
-			case STBI__F_paeth: cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(0, prior[k], 0)); break;
-			case STBI__F_avg_first: cur[k] = raw[k]; break;
-			case STBI__F_paeth_first: cur[k] = raw[k]; break;
-			}
-		}
+      if (filter > 4)
+         return stbi__err("invalid filter","Corrupt PNG");
 
-		if (depth == 8) {
-			if (img_n != out_n)
-				cur[img_n] = 255; // first pixel
-			raw += img_n;
-			cur += out_n;
-			prior += out_n;
-		}
-		else {
-			raw += 1;
-			cur += 1;
-			prior += 1;
-		}
+      if (depth < 8) {
+         STBI_ASSERT(img_width_bytes <= x);
+         cur += x*out_n - img_width_bytes; // store output to the rightmost img_len bytes, so we can decode in place
+         filter_bytes = 1;
+         width = img_width_bytes;
+      }
+      prior = cur - stride; // bugfix: need to compute this after 'cur +=' computation above
 
-		// this is a little gross, so that we don't switch per-pixel or per-component
-		if (depth < 8 || img_n == out_n) {
-			int nk = (width - 1)*img_n;
-#define CASE(f) \
+      // if first row, use special filter that doesn't sample previous row
+      if (j == 0) filter = first_row_filter[filter];
+
+      // handle first byte explicitly
+      for (k=0; k < filter_bytes; ++k) {
+         switch (filter) {
+            case STBI__F_none       : cur[k] = raw[k]; break;
+            case STBI__F_sub        : cur[k] = raw[k]; break;
+            case STBI__F_up         : cur[k] = STBI__BYTECAST(raw[k] + prior[k]); break;
+            case STBI__F_avg        : cur[k] = STBI__BYTECAST(raw[k] + (prior[k]>>1)); break;
+            case STBI__F_paeth      : cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(0,prior[k],0)); break;
+            case STBI__F_avg_first  : cur[k] = raw[k]; break;
+            case STBI__F_paeth_first: cur[k] = raw[k]; break;
+         }
+      }
+
+      if (depth == 8) {
+         if (img_n != out_n)
+            cur[img_n] = 255; // first pixel
+         raw += img_n;
+         cur += out_n;
+         prior += out_n;
+      } else if (depth == 16) {
+         if (img_n != out_n) {
+            cur[filter_bytes]   = 255; // first pixel top byte
+            cur[filter_bytes+1] = 255; // first pixel bottom byte
+         }
+         raw += filter_bytes;
+         cur += output_bytes;
+         prior += output_bytes;
+      } else {
+         raw += 1;
+         cur += 1;
+         prior += 1;
+      }
+
+      // this is a little gross, so that we don't switch per-pixel or per-component
+      if (depth < 8 || img_n == out_n) {
+         int nk = (width - 1)*filter_bytes;
+         #define STBI__CASE(f) \
              case f:     \
                 for (k=0; k < nk; ++k)
-			switch (filter) {
-				// "none" filter turns into a memcpy here; make that explicit.
-			case STBI__F_none:         memcpy(cur, raw, nk); break;
-				CASE(STBI__F_sub)          cur[k] = STBI__BYTECAST(raw[k] + cur[k - filter_bytes]); break;
-				CASE(STBI__F_up)           cur[k] = STBI__BYTECAST(raw[k] + prior[k]); break;
-				CASE(STBI__F_avg)          cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k - filter_bytes]) >> 1)); break;
-				CASE(STBI__F_paeth)        cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k - filter_bytes], prior[k], prior[k - filter_bytes])); break;
-				CASE(STBI__F_avg_first)    cur[k] = STBI__BYTECAST(raw[k] + (cur[k - filter_bytes] >> 1)); break;
-				CASE(STBI__F_paeth_first)  cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k - filter_bytes], 0, 0)); break;
-			}
-#undef CASE
-			raw += nk;
-		}
-		else {
-			STBI_ASSERT(img_n + 1 == out_n);
-#define CASE(f) \
+         switch (filter) {
+            // "none" filter turns into a memcpy here; make that explicit.
+            case STBI__F_none:         memcpy(cur, raw, nk); break;
+            STBI__CASE(STBI__F_sub)          { cur[k] = STBI__BYTECAST(raw[k] + cur[k-filter_bytes]); } break;
+            STBI__CASE(STBI__F_up)           { cur[k] = STBI__BYTECAST(raw[k] + prior[k]); } break;
+            STBI__CASE(STBI__F_avg)          { cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k-filter_bytes])>>1)); } break;
+            STBI__CASE(STBI__F_paeth)        { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k-filter_bytes],prior[k],prior[k-filter_bytes])); } break;
+            STBI__CASE(STBI__F_avg_first)    { cur[k] = STBI__BYTECAST(raw[k] + (cur[k-filter_bytes] >> 1)); } break;
+            STBI__CASE(STBI__F_paeth_first)  { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k-filter_bytes],0,0)); } break;
+         }
+         #undef STBI__CASE
+         raw += nk;
+      } else {
+         STBI_ASSERT(img_n+1 == out_n);
+         #define STBI__CASE(f) \
              case f:     \
-                for (i=x-1; i >= 1; --i, cur[img_n]=255,raw+=img_n,cur+=out_n,prior+=out_n) \
-                   for (k=0; k < img_n; ++k)
-			switch (filter) {
-				CASE(STBI__F_none)         cur[k] = raw[k]; break;
-				CASE(STBI__F_sub)          cur[k] = STBI__BYTECAST(raw[k] + cur[k - out_n]); break;
-				CASE(STBI__F_up)           cur[k] = STBI__BYTECAST(raw[k] + prior[k]); break;
-				CASE(STBI__F_avg)          cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k - out_n]) >> 1)); break;
-				CASE(STBI__F_paeth)        cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k - out_n], prior[k], prior[k - out_n])); break;
-				CASE(STBI__F_avg_first)    cur[k] = STBI__BYTECAST(raw[k] + (cur[k - out_n] >> 1)); break;
-				CASE(STBI__F_paeth_first)  cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k - out_n], 0, 0)); break;
-			}
-#undef CASE
-		}
-	}
+                for (i=x-1; i >= 1; --i, cur[filter_bytes]=255,raw+=filter_bytes,cur+=output_bytes,prior+=output_bytes) \
+                   for (k=0; k < filter_bytes; ++k)
+         switch (filter) {
+            STBI__CASE(STBI__F_none)         { cur[k] = raw[k]; } break;
+            STBI__CASE(STBI__F_sub)          { cur[k] = STBI__BYTECAST(raw[k] + cur[k- output_bytes]); } break;
+            STBI__CASE(STBI__F_up)           { cur[k] = STBI__BYTECAST(raw[k] + prior[k]); } break;
+            STBI__CASE(STBI__F_avg)          { cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k- output_bytes])>>1)); } break;
+            STBI__CASE(STBI__F_paeth)        { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k- output_bytes],prior[k],prior[k- output_bytes])); } break;
+            STBI__CASE(STBI__F_avg_first)    { cur[k] = STBI__BYTECAST(raw[k] + (cur[k- output_bytes] >> 1)); } break;
+            STBI__CASE(STBI__F_paeth_first)  { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k- output_bytes],0,0)); } break;
+         }
+         #undef STBI__CASE
 
-	// we make a separate pass to expand bits to pixels; for performance,
-	// this could run two scanlines behind the above code, so it won't
-	// intefere with filtering but will still be in the cache.
-	if (depth < 8) {
-		for (j = 0; j < y; ++j) {
-			stbi_uc *cur = a->out + stride*j;
-			stbi_uc *in = a->out + stride*j + x*out_n - img_width_bytes;
-			// unpack 1/2/4-bit into a 8-bit buffer. allows us to keep the common 8-bit path optimal at minimal cost for 1/2/4-bit
-			// png guarante byte alignment, if width is not multiple of 8/4/2 we'll decode dummy trailing data that will be skipped in the later loop
-			stbi_uc scale = (color == 0) ? stbi__depth_scale_table[depth] : 1; // scale grayscale values to 0..255 range
+         // the loop above sets the high byte of the pixels' alpha, but for
+         // 16 bit png files we also need the low byte set. we'll do that here.
+         if (depth == 16) {
+            cur = a->out + stride*j; // start at the beginning of the row again
+            for (i=0; i < x; ++i,cur+=output_bytes) {
+               cur[filter_bytes+1] = 255;
+            }
+         }
+      }
+   }
 
-																			   // note that the final byte might overshoot and write more data than desired.
-																			   // we can allocate enough data that this never writes out of memory, but it
-																			   // could also overwrite the next scanline. can it overwrite non-empty data
-																			   // on the next scanline? yes, consider 1-pixel-wide scanlines with 1-bit-per-pixel.
-																			   // so we need to explicitly clamp the final ones
+   // we make a separate pass to expand bits to pixels; for performance,
+   // this could run two scanlines behind the above code, so it won't
+   // intefere with filtering but will still be in the cache.
+   if (depth < 8) {
+      for (j=0; j < y; ++j) {
+         stbi_uc *cur = a->out + stride*j;
+         stbi_uc *in  = a->out + stride*j + x*out_n - img_width_bytes;
+         // unpack 1/2/4-bit into a 8-bit buffer. allows us to keep the common 8-bit path optimal at minimal cost for 1/2/4-bit
+         // png guarante byte alignment, if width is not multiple of 8/4/2 we'll decode dummy trailing data that will be skipped in the later loop
+         stbi_uc scale = (color == 0) ? stbi__depth_scale_table[depth] : 1; // scale grayscale values to 0..255 range
 
-			if (depth == 4) {
-				for (k = x*img_n; k >= 2; k -= 2, ++in) {
-					*cur++ = scale * ((*in >> 4));
-					*cur++ = scale * ((*in) & 0x0f);
-				}
-				if (k > 0) *cur++ = scale * ((*in >> 4));
-			}
-			else if (depth == 2) {
-				for (k = x*img_n; k >= 4; k -= 4, ++in) {
-					*cur++ = scale * ((*in >> 6));
-					*cur++ = scale * ((*in >> 4) & 0x03);
-					*cur++ = scale * ((*in >> 2) & 0x03);
-					*cur++ = scale * ((*in) & 0x03);
-				}
-				if (k > 0) *cur++ = scale * ((*in >> 6));
-				if (k > 1) *cur++ = scale * ((*in >> 4) & 0x03);
-				if (k > 2) *cur++ = scale * ((*in >> 2) & 0x03);
-			}
-			else if (depth == 1) {
-				for (k = x*img_n; k >= 8; k -= 8, ++in) {
-					*cur++ = scale * ((*in >> 7));
-					*cur++ = scale * ((*in >> 6) & 0x01);
-					*cur++ = scale * ((*in >> 5) & 0x01);
-					*cur++ = scale * ((*in >> 4) & 0x01);
-					*cur++ = scale * ((*in >> 3) & 0x01);
-					*cur++ = scale * ((*in >> 2) & 0x01);
-					*cur++ = scale * ((*in >> 1) & 0x01);
-					*cur++ = scale * ((*in) & 0x01);
-				}
-				if (k > 0) *cur++ = scale * ((*in >> 7));
-				if (k > 1) *cur++ = scale * ((*in >> 6) & 0x01);
-				if (k > 2) *cur++ = scale * ((*in >> 5) & 0x01);
-				if (k > 3) *cur++ = scale * ((*in >> 4) & 0x01);
-				if (k > 4) *cur++ = scale * ((*in >> 3) & 0x01);
-				if (k > 5) *cur++ = scale * ((*in >> 2) & 0x01);
-				if (k > 6) *cur++ = scale * ((*in >> 1) & 0x01);
-			}
-			if (img_n != out_n) {
-				int q;
-				// insert alpha = 255
-				cur = a->out + stride*j;
-				if (img_n == 1) {
-					for (q = x - 1; q >= 0; --q) {
-						cur[q * 2 + 1] = 255;
-						cur[q * 2 + 0] = cur[q];
-					}
-				}
-				else {
-					STBI_ASSERT(img_n == 3);
-					for (q = x - 1; q >= 0; --q) {
-						cur[q * 4 + 3] = 255;
-						cur[q * 4 + 2] = cur[q * 3 + 2];
-						cur[q * 4 + 1] = cur[q * 3 + 1];
-						cur[q * 4 + 0] = cur[q * 3 + 0];
-					}
-				}
-			}
-		}
-	}
+         // note that the final byte might overshoot and write more data than desired.
+         // we can allocate enough data that this never writes out of memory, but it
+         // could also overwrite the next scanline. can it overwrite non-empty data
+         // on the next scanline? yes, consider 1-pixel-wide scanlines with 1-bit-per-pixel.
+         // so we need to explicitly clamp the final ones
 
-	return 1;
+         if (depth == 4) {
+            for (k=x*img_n; k >= 2; k-=2, ++in) {
+               *cur++ = scale * ((*in >> 4)       );
+               *cur++ = scale * ((*in     ) & 0x0f);
+            }
+            if (k > 0) *cur++ = scale * ((*in >> 4)       );
+         } else if (depth == 2) {
+            for (k=x*img_n; k >= 4; k-=4, ++in) {
+               *cur++ = scale * ((*in >> 6)       );
+               *cur++ = scale * ((*in >> 4) & 0x03);
+               *cur++ = scale * ((*in >> 2) & 0x03);
+               *cur++ = scale * ((*in     ) & 0x03);
+            }
+            if (k > 0) *cur++ = scale * ((*in >> 6)       );
+            if (k > 1) *cur++ = scale * ((*in >> 4) & 0x03);
+            if (k > 2) *cur++ = scale * ((*in >> 2) & 0x03);
+         } else if (depth == 1) {
+            for (k=x*img_n; k >= 8; k-=8, ++in) {
+               *cur++ = scale * ((*in >> 7)       );
+               *cur++ = scale * ((*in >> 6) & 0x01);
+               *cur++ = scale * ((*in >> 5) & 0x01);
+               *cur++ = scale * ((*in >> 4) & 0x01);
+               *cur++ = scale * ((*in >> 3) & 0x01);
+               *cur++ = scale * ((*in >> 2) & 0x01);
+               *cur++ = scale * ((*in >> 1) & 0x01);
+               *cur++ = scale * ((*in     ) & 0x01);
+            }
+            if (k > 0) *cur++ = scale * ((*in >> 7)       );
+            if (k > 1) *cur++ = scale * ((*in >> 6) & 0x01);
+            if (k > 2) *cur++ = scale * ((*in >> 5) & 0x01);
+            if (k > 3) *cur++ = scale * ((*in >> 4) & 0x01);
+            if (k > 4) *cur++ = scale * ((*in >> 3) & 0x01);
+            if (k > 5) *cur++ = scale * ((*in >> 2) & 0x01);
+            if (k > 6) *cur++ = scale * ((*in >> 1) & 0x01);
+         }
+         if (img_n != out_n) {
+            int q;
+            // insert alpha = 255
+            cur = a->out + stride*j;
+            if (img_n == 1) {
+               for (q=x-1; q >= 0; --q) {
+                  cur[q*2+1] = 255;
+                  cur[q*2+0] = cur[q];
+               }
+            } else {
+               STBI_ASSERT(img_n == 3);
+               for (q=x-1; q >= 0; --q) {
+                  cur[q*4+3] = 255;
+                  cur[q*4+2] = cur[q*3+2];
+                  cur[q*4+1] = cur[q*3+1];
+                  cur[q*4+0] = cur[q*3+0];
+               }
+            }
+         }
+      }
+   } else if (depth == 16) {
+      // force the image data from big-endian to platform-native.
+      // this is done in a separate pass due to the decoding relying
+      // on the data being untouched, but could probably be done
+      // per-line during decode if care is taken.
+      stbi_uc *cur = a->out;
+      stbi__uint16 *cur16 = (stbi__uint16*)cur;
+
+      for(i=0; i < x*y*out_n; ++i,cur16++,cur+=2) {
+         *cur16 = (cur[0] << 8) | cur[1];
+      }
+   }
+
+   return 1;
 }
 
 static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint32 image_data_len, int out_n, int depth, int color, int interlaced)
 {
-	stbi_uc *final;
-	int p;
-	if (!interlaced)
-		return stbi__create_png_image_raw(a, image_data, image_data_len, out_n, a->s->img_x, a->s->img_y, depth, color);
+   int bytes = (depth == 16 ? 2 : 1);
+   int out_bytes = out_n * bytes;
+   stbi_uc *final;
+   int p;
+   if (!interlaced)
+      return stbi__create_png_image_raw(a, image_data, image_data_len, out_n, a->s->img_x, a->s->img_y, depth, color);
 
-	// de-interlacing
-	final = (stbi_uc *)stbi__malloc(a->s->img_x * a->s->img_y * out_n);
-	for (p = 0; p < 7; ++p) {
-		int xorig[] = { 0,4,0,2,0,1,0 };
-		int yorig[] = { 0,0,4,0,2,0,1 };
-		int xspc[] = { 8,8,4,4,2,2,1 };
-		int yspc[] = { 8,8,8,4,4,2,2 };
-		int i, j, x, y;
-		// pass1_x[4] = 0, pass1_x[5] = 1, pass1_x[12] = 1
-		x = (a->s->img_x - xorig[p] + xspc[p] - 1) / xspc[p];
-		y = (a->s->img_y - yorig[p] + yspc[p] - 1) / yspc[p];
-		if (x && y) {
-			stbi__uint32 img_len = ((((a->s->img_n * x * depth) + 7) >> 3) + 1) * y;
-			if (!stbi__create_png_image_raw(a, image_data, image_data_len, out_n, x, y, depth, color)) {
-				STBI_FREE(final);
-				return 0;
-			}
-			for (j = 0; j < y; ++j) {
-				for (i = 0; i < x; ++i) {
-					int out_y = j*yspc[p] + yorig[p];
-					int out_x = i*xspc[p] + xorig[p];
-					memcpy(final + out_y*a->s->img_x*out_n + out_x*out_n,
-						a->out + (j*x + i)*out_n, out_n);
-				}
-			}
-			STBI_FREE(a->out);
-			image_data += img_len;
-			image_data_len -= img_len;
-		}
-	}
-	a->out = final;
+   // de-interlacing
+   final = (stbi_uc *) stbi__malloc_mad3(a->s->img_x, a->s->img_y, out_bytes, 0);
+   for (p=0; p < 7; ++p) {
+      int xorig[] = { 0,4,0,2,0,1,0 };
+      int yorig[] = { 0,0,4,0,2,0,1 };
+      int xspc[]  = { 8,8,4,4,2,2,1 };
+      int yspc[]  = { 8,8,8,4,4,2,2 };
+      int i,j,x,y;
+      // pass1_x[4] = 0, pass1_x[5] = 1, pass1_x[12] = 1
+      x = (a->s->img_x - xorig[p] + xspc[p]-1) / xspc[p];
+      y = (a->s->img_y - yorig[p] + yspc[p]-1) / yspc[p];
+      if (x && y) {
+         stbi__uint32 img_len = ((((a->s->img_n * x * depth) + 7) >> 3) + 1) * y;
+         if (!stbi__create_png_image_raw(a, image_data, image_data_len, out_n, x, y, depth, color)) {
+            STBI_FREE(final);
+            return 0;
+         }
+         for (j=0; j < y; ++j) {
+            for (i=0; i < x; ++i) {
+               int out_y = j*yspc[p]+yorig[p];
+               int out_x = i*xspc[p]+xorig[p];
+               memcpy(final + out_y*a->s->img_x*out_bytes + out_x*out_bytes,
+                      a->out + (j*x+i)*out_bytes, out_bytes);
+            }
+         }
+         STBI_FREE(a->out);
+         image_data += img_len;
+         image_data_len -= img_len;
+      }
+   }
+   a->out = final;
 
-	return 1;
+   return 1;
 }
 
 static int stbi__compute_transparency(stbi__png *z, stbi_uc tc[3], int out_n)
 {
-	stbi__context *s = z->s;
-	stbi__uint32 i, pixel_count = s->img_x * s->img_y;
-	stbi_uc *p = z->out;
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi_uc *p = z->out;
 
-	// compute color-based transparency, assuming we've
-	// already got 255 as the alpha value in the output
-	STBI_ASSERT(out_n == 2 || out_n == 4);
+   // compute color-based transparency, assuming we've
+   // already got 255 as the alpha value in the output
+   STBI_ASSERT(out_n == 2 || out_n == 4);
 
-	if (out_n == 2) {
-		for (i = 0; i < pixel_count; ++i) {
-			p[1] = (p[0] == tc[0] ? 0 : 255);
-			p += 2;
-		}
-	}
-	else {
-		for (i = 0; i < pixel_count; ++i) {
-			if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
-				p[3] = 0;
-			p += 4;
-		}
-	}
-	return 1;
+   if (out_n == 2) {
+      for (i=0; i < pixel_count; ++i) {
+         p[1] = (p[0] == tc[0] ? 0 : 255);
+         p += 2;
+      }
+   } else {
+      for (i=0; i < pixel_count; ++i) {
+         if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
+            p[3] = 0;
+         p += 4;
+      }
+   }
+   return 1;
+}
+
+static int stbi__compute_transparency16(stbi__png *z, stbi__uint16 tc[3], int out_n)
+{
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi__uint16 *p = (stbi__uint16*) z->out;
+
+   // compute color-based transparency, assuming we've
+   // already got 65535 as the alpha value in the output
+   STBI_ASSERT(out_n == 2 || out_n == 4);
+
+   if (out_n == 2) {
+      for (i = 0; i < pixel_count; ++i) {
+         p[1] = (p[0] == tc[0] ? 0 : 65535);
+         p += 2;
+      }
+   } else {
+      for (i = 0; i < pixel_count; ++i) {
+         if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
+            p[3] = 0;
+         p += 4;
+      }
+   }
+   return 1;
 }
 
 static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int pal_img_n)
 {
-	stbi__uint32 i, pixel_count = a->s->img_x * a->s->img_y;
-	stbi_uc *p, *temp_out, *orig = a->out;
+   stbi__uint32 i, pixel_count = a->s->img_x * a->s->img_y;
+   stbi_uc *p, *temp_out, *orig = a->out;
 
-	p = (stbi_uc *)stbi__malloc(pixel_count * pal_img_n);
-	if (p == NULL) return stbi__err("outofmem", "Out of memory");
+   p = (stbi_uc *) stbi__malloc_mad2(pixel_count, pal_img_n, 0);
+   if (p == NULL) return stbi__err("outofmem", "Out of memory");
 
-	// between here and free(out) below, exitting would leak
-	temp_out = p;
+   // between here and free(out) below, exitting would leak
+   temp_out = p;
 
-	if (pal_img_n == 3) {
-		for (i = 0; i < pixel_count; ++i) {
-			int n = orig[i] * 4;
-			p[0] = palette[n];
-			p[1] = palette[n + 1];
-			p[2] = palette[n + 2];
-			p += 3;
-		}
-	}
-	else {
-		for (i = 0; i < pixel_count; ++i) {
-			int n = orig[i] * 4;
-			p[0] = palette[n];
-			p[1] = palette[n + 1];
-			p[2] = palette[n + 2];
-			p[3] = palette[n + 3];
-			p += 4;
-		}
-	}
-	STBI_FREE(a->out);
-	a->out = temp_out;
+   if (pal_img_n == 3) {
+      for (i=0; i < pixel_count; ++i) {
+         int n = orig[i]*4;
+         p[0] = palette[n  ];
+         p[1] = palette[n+1];
+         p[2] = palette[n+2];
+         p += 3;
+      }
+   } else {
+      for (i=0; i < pixel_count; ++i) {
+         int n = orig[i]*4;
+         p[0] = palette[n  ];
+         p[1] = palette[n+1];
+         p[2] = palette[n+2];
+         p[3] = palette[n+3];
+         p += 4;
+      }
+   }
+   STBI_FREE(a->out);
+   a->out = temp_out;
 
-	STBI_NOTUSED(len);
+   STBI_NOTUSED(len);
 
-	return 1;
+   return 1;
 }
 
 static int stbi__unpremultiply_on_load = 0;
@@ -4306,277 +4675,306 @@ static int stbi__de_iphone_flag = 0;
 
 STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply)
 {
-	stbi__unpremultiply_on_load = flag_true_if_should_unpremultiply;
+   stbi__unpremultiply_on_load = flag_true_if_should_unpremultiply;
 }
 
 STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert)
 {
-	stbi__de_iphone_flag = flag_true_if_should_convert;
+   stbi__de_iphone_flag = flag_true_if_should_convert;
 }
 
 static void stbi__de_iphone(stbi__png *z)
 {
-	stbi__context *s = z->s;
-	stbi__uint32 i, pixel_count = s->img_x * s->img_y;
-	stbi_uc *p = z->out;
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi_uc *p = z->out;
 
-	if (s->img_out_n == 3) {  // convert bgr to rgb
-		for (i = 0; i < pixel_count; ++i) {
-			stbi_uc t = p[0];
-			p[0] = p[2];
-			p[2] = t;
-			p += 3;
-		}
-	}
-	else {
-		STBI_ASSERT(s->img_out_n == 4);
-		if (stbi__unpremultiply_on_load) {
-			// convert bgr to rgb and unpremultiply
-			for (i = 0; i < pixel_count; ++i) {
-				stbi_uc a = p[3];
-				stbi_uc t = p[0];
-				if (a) {
-					p[0] = p[2] * 255 / a;
-					p[1] = p[1] * 255 / a;
-					p[2] = t * 255 / a;
-				}
-				else {
-					p[0] = p[2];
-					p[2] = t;
-				}
-				p += 4;
-			}
-		}
-		else {
-			// convert bgr to rgb
-			for (i = 0; i < pixel_count; ++i) {
-				stbi_uc t = p[0];
-				p[0] = p[2];
-				p[2] = t;
-				p += 4;
-			}
-		}
-	}
+   if (s->img_out_n == 3) {  // convert bgr to rgb
+      for (i=0; i < pixel_count; ++i) {
+         stbi_uc t = p[0];
+         p[0] = p[2];
+         p[2] = t;
+         p += 3;
+      }
+   } else {
+      STBI_ASSERT(s->img_out_n == 4);
+      if (stbi__unpremultiply_on_load) {
+         // convert bgr to rgb and unpremultiply
+         for (i=0; i < pixel_count; ++i) {
+            stbi_uc a = p[3];
+            stbi_uc t = p[0];
+            if (a) {
+               stbi_uc half = a / 2;
+               p[0] = (p[2] * 255 + half) / a;
+               p[1] = (p[1] * 255 + half) / a;
+               p[2] = ( t   * 255 + half) / a;
+            } else {
+               p[0] = p[2];
+               p[2] = t;
+            }
+            p += 4;
+         }
+      } else {
+         // convert bgr to rgb
+         for (i=0; i < pixel_count; ++i) {
+            stbi_uc t = p[0];
+            p[0] = p[2];
+            p[2] = t;
+            p += 4;
+         }
+      }
+   }
 }
 
-#define STBI__PNG_TYPE(a,b,c,d)  (((a) << 24) + ((b) << 16) + ((c) << 8) + (d))
+#define STBI__PNG_TYPE(a,b,c,d)  (((unsigned) (a) << 24) + ((unsigned) (b) << 16) + ((unsigned) (c) << 8) + (unsigned) (d))
 
 static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
 {
-	stbi_uc palette[1024], pal_img_n = 0;
-	stbi_uc has_trans = 0, tc[3];
-	stbi__uint32 ioff = 0, idata_limit = 0, i, pal_len = 0;
-	int first = 1, k, interlace = 0, color = 0, depth = 0, is_iphone = 0;
-	stbi__context *s = z->s;
+   stbi_uc palette[1024], pal_img_n=0;
+   stbi_uc has_trans=0, tc[3];
+   stbi__uint16 tc16[3];
+   stbi__uint32 ioff=0, idata_limit=0, i, pal_len=0;
+   int first=1,k,interlace=0, color=0, is_iphone=0;
+   stbi__context *s = z->s;
 
-	z->expanded = NULL;
-	z->idata = NULL;
-	z->out = NULL;
+   z->expanded = NULL;
+   z->idata = NULL;
+   z->out = NULL;
 
-	if (!stbi__check_png_header(s)) return 0;
+   if (!stbi__check_png_header(s)) return 0;
 
-	if (scan == STBI__SCAN_type) return 1;
+   if (scan == STBI__SCAN_type) return 1;
 
-	for (;;) {
-		stbi__pngchunk c = stbi__get_chunk_header(s);
-		switch (c.type) {
-		case STBI__PNG_TYPE('C', 'g', 'B', 'I'):
-			is_iphone = 1;
-			stbi__skip(s, c.length);
-			break;
-		case STBI__PNG_TYPE('I', 'H', 'D', 'R'): {
-			int comp, filter;
-			if (!first) return stbi__err("multiple IHDR", "Corrupt PNG");
-			first = 0;
-			if (c.length != 13) return stbi__err("bad IHDR len", "Corrupt PNG");
-			s->img_x = stbi__get32be(s); if (s->img_x > (1 << 24)) return stbi__err("too large", "Very large image (corrupt?)");
-			s->img_y = stbi__get32be(s); if (s->img_y > (1 << 24)) return stbi__err("too large", "Very large image (corrupt?)");
-			depth = stbi__get8(s);  if (depth != 1 && depth != 2 && depth != 4 && depth != 8)  return stbi__err("1/2/4/8-bit only", "PNG not supported: 1/2/4/8-bit only");
-			color = stbi__get8(s);  if (color > 6)         return stbi__err("bad ctype", "Corrupt PNG");
-			if (color == 3) pal_img_n = 3; else if (color & 1) return stbi__err("bad ctype", "Corrupt PNG");
-			comp = stbi__get8(s);  if (comp) return stbi__err("bad comp method", "Corrupt PNG");
-			filter = stbi__get8(s);  if (filter) return stbi__err("bad filter method", "Corrupt PNG");
-			interlace = stbi__get8(s); if (interlace>1) return stbi__err("bad interlace method", "Corrupt PNG");
-			if (!s->img_x || !s->img_y) return stbi__err("0-pixel image", "Corrupt PNG");
-			if (!pal_img_n) {
-				s->img_n = (color & 2 ? 3 : 1) + (color & 4 ? 1 : 0);
-				if ((1 << 30) / s->img_x / s->img_n < s->img_y) return stbi__err("too large", "Image too large to decode");
-				if (scan == STBI__SCAN_header) return 1;
-			}
-			else {
-				// if paletted, then pal_n is our final components, and
-				// img_n is # components to decompress/filter.
-				s->img_n = 1;
-				if ((1 << 30) / s->img_x / 4 < s->img_y) return stbi__err("too large", "Corrupt PNG");
-				// if SCAN_header, have to scan to see if we have a tRNS
-			}
-			break;
-		}
+   for (;;) {
+      stbi__pngchunk c = stbi__get_chunk_header(s);
+      switch (c.type) {
+         case STBI__PNG_TYPE('C','g','B','I'):
+            is_iphone = 1;
+            stbi__skip(s, c.length);
+            break;
+         case STBI__PNG_TYPE('I','H','D','R'): {
+            int comp,filter;
+            if (!first) return stbi__err("multiple IHDR","Corrupt PNG");
+            first = 0;
+            if (c.length != 13) return stbi__err("bad IHDR len","Corrupt PNG");
+            s->img_x = stbi__get32be(s); if (s->img_x > (1 << 24)) return stbi__err("too large","Very large image (corrupt?)");
+            s->img_y = stbi__get32be(s); if (s->img_y > (1 << 24)) return stbi__err("too large","Very large image (corrupt?)");
+            z->depth = stbi__get8(s);  if (z->depth != 1 && z->depth != 2 && z->depth != 4 && z->depth != 8 && z->depth != 16)  return stbi__err("1/2/4/8/16-bit only","PNG not supported: 1/2/4/8/16-bit only");
+            color = stbi__get8(s);  if (color > 6)         return stbi__err("bad ctype","Corrupt PNG");
+            if (color == 3 && z->depth == 16)                  return stbi__err("bad ctype","Corrupt PNG");
+            if (color == 3) pal_img_n = 3; else if (color & 1) return stbi__err("bad ctype","Corrupt PNG");
+            comp  = stbi__get8(s);  if (comp) return stbi__err("bad comp method","Corrupt PNG");
+            filter= stbi__get8(s);  if (filter) return stbi__err("bad filter method","Corrupt PNG");
+            interlace = stbi__get8(s); if (interlace>1) return stbi__err("bad interlace method","Corrupt PNG");
+            if (!s->img_x || !s->img_y) return stbi__err("0-pixel image","Corrupt PNG");
+            if (!pal_img_n) {
+               s->img_n = (color & 2 ? 3 : 1) + (color & 4 ? 1 : 0);
+               if ((1 << 30) / s->img_x / s->img_n < s->img_y) return stbi__err("too large", "Image too large to decode");
+               if (scan == STBI__SCAN_header) return 1;
+            } else {
+               // if paletted, then pal_n is our final components, and
+               // img_n is # components to decompress/filter.
+               s->img_n = 1;
+               if ((1 << 30) / s->img_x / 4 < s->img_y) return stbi__err("too large","Corrupt PNG");
+               // if SCAN_header, have to scan to see if we have a tRNS
+            }
+            break;
+         }
 
-		case STBI__PNG_TYPE('P', 'L', 'T', 'E'): {
-			if (first) return stbi__err("first not IHDR", "Corrupt PNG");
-			if (c.length > 256 * 3) return stbi__err("invalid PLTE", "Corrupt PNG");
-			pal_len = c.length / 3;
-			if (pal_len * 3 != c.length) return stbi__err("invalid PLTE", "Corrupt PNG");
-			for (i = 0; i < pal_len; ++i) {
-				palette[i * 4 + 0] = stbi__get8(s);
-				palette[i * 4 + 1] = stbi__get8(s);
-				palette[i * 4 + 2] = stbi__get8(s);
-				palette[i * 4 + 3] = 255;
-			}
-			break;
-		}
+         case STBI__PNG_TYPE('P','L','T','E'):  {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (c.length > 256*3) return stbi__err("invalid PLTE","Corrupt PNG");
+            pal_len = c.length / 3;
+            if (pal_len * 3 != c.length) return stbi__err("invalid PLTE","Corrupt PNG");
+            for (i=0; i < pal_len; ++i) {
+               palette[i*4+0] = stbi__get8(s);
+               palette[i*4+1] = stbi__get8(s);
+               palette[i*4+2] = stbi__get8(s);
+               palette[i*4+3] = 255;
+            }
+            break;
+         }
 
-		case STBI__PNG_TYPE('t', 'R', 'N', 'S'): {
-			if (first) return stbi__err("first not IHDR", "Corrupt PNG");
-			if (z->idata) return stbi__err("tRNS after IDAT", "Corrupt PNG");
-			if (pal_img_n) {
-				if (scan == STBI__SCAN_header) { s->img_n = 4; return 1; }
-				if (pal_len == 0) return stbi__err("tRNS before PLTE", "Corrupt PNG");
-				if (c.length > pal_len) return stbi__err("bad tRNS len", "Corrupt PNG");
-				pal_img_n = 4;
-				for (i = 0; i < c.length; ++i)
-					palette[i * 4 + 3] = stbi__get8(s);
-			}
-			else {
-				if (!(s->img_n & 1)) return stbi__err("tRNS with alpha", "Corrupt PNG");
-				if (c.length != (stbi__uint32)s->img_n * 2) return stbi__err("bad tRNS len", "Corrupt PNG");
-				has_trans = 1;
-				for (k = 0; k < s->img_n; ++k)
-					tc[k] = (stbi_uc)(stbi__get16be(s) & 255) * stbi__depth_scale_table[depth]; // non 8-bit images will be larger
-			}
-			break;
-		}
+         case STBI__PNG_TYPE('t','R','N','S'): {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (z->idata) return stbi__err("tRNS after IDAT","Corrupt PNG");
+            if (pal_img_n) {
+               if (scan == STBI__SCAN_header) { s->img_n = 4; return 1; }
+               if (pal_len == 0) return stbi__err("tRNS before PLTE","Corrupt PNG");
+               if (c.length > pal_len) return stbi__err("bad tRNS len","Corrupt PNG");
+               pal_img_n = 4;
+               for (i=0; i < c.length; ++i)
+                  palette[i*4+3] = stbi__get8(s);
+            } else {
+               if (!(s->img_n & 1)) return stbi__err("tRNS with alpha","Corrupt PNG");
+               if (c.length != (stbi__uint32) s->img_n*2) return stbi__err("bad tRNS len","Corrupt PNG");
+               has_trans = 1;
+               if (z->depth == 16) {
+                  for (k = 0; k < s->img_n; ++k) tc16[k] = (stbi__uint16)stbi__get16be(s); // copy the values as-is
+               } else {
+                  for (k = 0; k < s->img_n; ++k) tc[k] = (stbi_uc)(stbi__get16be(s) & 255) * stbi__depth_scale_table[z->depth]; // non 8-bit images will be larger
+               }
+            }
+            break;
+         }
 
-		case STBI__PNG_TYPE('I', 'D', 'A', 'T'): {
-			if (first) return stbi__err("first not IHDR", "Corrupt PNG");
-			if (pal_img_n && !pal_len) return stbi__err("no PLTE", "Corrupt PNG");
-			if (scan == STBI__SCAN_header) { s->img_n = pal_img_n; return 1; }
-			if ((int)(ioff + c.length) < (int)ioff) return 0;
-			if (ioff + c.length > idata_limit) {
-				stbi__uint32 idata_limit_old = idata_limit;
-				stbi_uc *p;
-				if (idata_limit == 0) idata_limit = c.length > 4096 ? c.length : 4096;
-				while (ioff + c.length > idata_limit)
-					idata_limit *= 2;
-				STBI_NOTUSED(idata_limit_old);
-				p = (stbi_uc *)STBI_REALLOC_SIZED(z->idata, idata_limit_old, idata_limit); if (p == NULL) return stbi__err("outofmem", "Out of memory");
-				z->idata = p;
-			}
-			if (!stbi__getn(s, z->idata + ioff, c.length)) return stbi__err("outofdata", "Corrupt PNG");
-			ioff += c.length;
-			break;
-		}
+         case STBI__PNG_TYPE('I','D','A','T'): {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (pal_img_n && !pal_len) return stbi__err("no PLTE","Corrupt PNG");
+            if (scan == STBI__SCAN_header) { s->img_n = pal_img_n; return 1; }
+            if ((int)(ioff + c.length) < (int)ioff) return 0;
+            if (ioff + c.length > idata_limit) {
+               stbi__uint32 idata_limit_old = idata_limit;
+               stbi_uc *p;
+               if (idata_limit == 0) idata_limit = c.length > 4096 ? c.length : 4096;
+               while (ioff + c.length > idata_limit)
+                  idata_limit *= 2;
+               STBI_NOTUSED(idata_limit_old);
+               p = (stbi_uc *) STBI_REALLOC_SIZED(z->idata, idata_limit_old, idata_limit); if (p == NULL) return stbi__err("outofmem", "Out of memory");
+               z->idata = p;
+            }
+            if (!stbi__getn(s, z->idata+ioff,c.length)) return stbi__err("outofdata","Corrupt PNG");
+            ioff += c.length;
+            break;
+         }
 
-		case STBI__PNG_TYPE('I', 'E', 'N', 'D'): {
-			stbi__uint32 raw_len, bpl;
-			if (first) return stbi__err("first not IHDR", "Corrupt PNG");
-			if (scan != STBI__SCAN_load) return 1;
-			if (z->idata == NULL) return stbi__err("no IDAT", "Corrupt PNG");
-			// initial guess for decoded data size to avoid unnecessary reallocs
-			bpl = (s->img_x * depth + 7) / 8; // bytes per line, per component
-			raw_len = bpl * s->img_y * s->img_n /* pixels */ + s->img_y /* filter mode per row */;
-			z->expanded = (stbi_uc *)stbi_zlib_decode_malloc_guesssize_headerflag((char *)z->idata, ioff, raw_len, (int *)&raw_len, !is_iphone);
-			if (z->expanded == NULL) return 0; // zlib should set error
-			STBI_FREE(z->idata); z->idata = NULL;
-			if ((req_comp == s->img_n + 1 && req_comp != 3 && !pal_img_n) || has_trans)
-				s->img_out_n = s->img_n + 1;
-			else
-				s->img_out_n = s->img_n;
-			if (!stbi__create_png_image(z, z->expanded, raw_len, s->img_out_n, depth, color, interlace)) return 0;
-			if (has_trans)
-				if (!stbi__compute_transparency(z, tc, s->img_out_n)) return 0;
-			if (is_iphone && stbi__de_iphone_flag && s->img_out_n > 2)
-				stbi__de_iphone(z);
-			if (pal_img_n) {
-				// pal_img_n == 3 or 4
-				s->img_n = pal_img_n; // record the actual colors we had
-				s->img_out_n = pal_img_n;
-				if (req_comp >= 3) s->img_out_n = req_comp;
-				if (!stbi__expand_png_palette(z, palette, pal_len, s->img_out_n))
-					return 0;
-			}
-			STBI_FREE(z->expanded); z->expanded = NULL;
-			return 1;
-		}
+         case STBI__PNG_TYPE('I','E','N','D'): {
+            stbi__uint32 raw_len, bpl;
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (scan != STBI__SCAN_load) return 1;
+            if (z->idata == NULL) return stbi__err("no IDAT","Corrupt PNG");
+            // initial guess for decoded data size to avoid unnecessary reallocs
+            bpl = (s->img_x * z->depth + 7) / 8; // bytes per line, per component
+            raw_len = bpl * s->img_y * s->img_n /* pixels */ + s->img_y /* filter mode per row */;
+            z->expanded = (stbi_uc *) stbi_zlib_decode_malloc_guesssize_headerflag((char *) z->idata, ioff, raw_len, (int *) &raw_len, !is_iphone);
+            if (z->expanded == NULL) return 0; // zlib should set error
+            STBI_FREE(z->idata); z->idata = NULL;
+            if ((req_comp == s->img_n+1 && req_comp != 3 && !pal_img_n) || has_trans)
+               s->img_out_n = s->img_n+1;
+            else
+               s->img_out_n = s->img_n;
+            if (!stbi__create_png_image(z, z->expanded, raw_len, s->img_out_n, z->depth, color, interlace)) return 0;
+            if (has_trans) {
+               if (z->depth == 16) {
+                  if (!stbi__compute_transparency16(z, tc16, s->img_out_n)) return 0;
+               } else {
+                  if (!stbi__compute_transparency(z, tc, s->img_out_n)) return 0;
+               }
+            }
+            if (is_iphone && stbi__de_iphone_flag && s->img_out_n > 2)
+               stbi__de_iphone(z);
+            if (pal_img_n) {
+               // pal_img_n == 3 or 4
+               s->img_n = pal_img_n; // record the actual colors we had
+               s->img_out_n = pal_img_n;
+               if (req_comp >= 3) s->img_out_n = req_comp;
+               if (!stbi__expand_png_palette(z, palette, pal_len, s->img_out_n))
+                  return 0;
+            } else if (has_trans) {
+               // non-paletted image with tRNS -> source image has (constant) alpha
+               ++s->img_n;
+            }
+            STBI_FREE(z->expanded); z->expanded = NULL;
+            return 1;
+         }
 
-		default:
-			// if critical, fail
-			if (first) return stbi__err("first not IHDR", "Corrupt PNG");
-			if ((c.type & (1 << 29)) == 0) {
-#ifndef STBI_NO_FAILURE_STRINGS
-				// not threadsafe
-				static char invalid_chunk[] = "XXXX PNG chunk not known";
-				invalid_chunk[0] = STBI__BYTECAST(c.type >> 24);
-				invalid_chunk[1] = STBI__BYTECAST(c.type >> 16);
-				invalid_chunk[2] = STBI__BYTECAST(c.type >> 8);
-				invalid_chunk[3] = STBI__BYTECAST(c.type >> 0);
-#endif
-				return stbi__err(invalid_chunk, "PNG not supported: unknown PNG chunk type");
-			}
-			stbi__skip(s, c.length);
-			break;
-		}
-		// end of PNG chunk, read and skip CRC
-		stbi__get32be(s);
-	}
+         default:
+            // if critical, fail
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if ((c.type & (1 << 29)) == 0) {
+               #ifndef STBI_NO_FAILURE_STRINGS
+               // not threadsafe
+               static char invalid_chunk[] = "XXXX PNG chunk not known";
+               invalid_chunk[0] = STBI__BYTECAST(c.type >> 24);
+               invalid_chunk[1] = STBI__BYTECAST(c.type >> 16);
+               invalid_chunk[2] = STBI__BYTECAST(c.type >>  8);
+               invalid_chunk[3] = STBI__BYTECAST(c.type >>  0);
+               #endif
+               return stbi__err(invalid_chunk, "PNG not supported: unknown PNG chunk type");
+            }
+            stbi__skip(s, c.length);
+            break;
+      }
+      // end of PNG chunk, read and skip CRC
+      stbi__get32be(s);
+   }
 }
 
-static unsigned char *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp)
+static void *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp, stbi__result_info *ri)
 {
-	unsigned char *result = NULL;
-	if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
-	if (stbi__parse_png_file(p, STBI__SCAN_load, req_comp)) {
-		result = p->out;
-		p->out = NULL;
-		if (req_comp && req_comp != p->s->img_out_n) {
-			result = stbi__convert_format(result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
-			p->s->img_out_n = req_comp;
-			if (result == NULL) return result;
-		}
-		*x = p->s->img_x;
-		*y = p->s->img_y;
-		if (n) *n = p->s->img_out_n;
-	}
-	STBI_FREE(p->out);      p->out = NULL;
-	STBI_FREE(p->expanded); p->expanded = NULL;
-	STBI_FREE(p->idata);    p->idata = NULL;
+   void *result=NULL;
+   if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
+   if (stbi__parse_png_file(p, STBI__SCAN_load, req_comp)) {
+      if (p->depth < 8)
+         ri->bits_per_channel = 8;
+      else
+         ri->bits_per_channel = p->depth;
+      result = p->out;
+      p->out = NULL;
+      if (req_comp && req_comp != p->s->img_out_n) {
+         if (ri->bits_per_channel == 8)
+            result = stbi__convert_format((unsigned char *) result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         else
+            result = stbi__convert_format16((stbi__uint16 *) result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         p->s->img_out_n = req_comp;
+         if (result == NULL) return result;
+      }
+      *x = p->s->img_x;
+      *y = p->s->img_y;
+      if (n) *n = p->s->img_n;
+   }
+   STBI_FREE(p->out);      p->out      = NULL;
+   STBI_FREE(p->expanded); p->expanded = NULL;
+   STBI_FREE(p->idata);    p->idata    = NULL;
 
-	return result;
+   return result;
 }
 
-static unsigned char *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
-	stbi__png p;
-	p.s = s;
-	return stbi__do_png(&p, x, y, comp, req_comp);
+   stbi__png p;
+   p.s = s;
+   return stbi__do_png(&p, x,y,comp,req_comp, ri);
 }
 
 static int stbi__png_test(stbi__context *s)
 {
-	int r;
-	r = stbi__check_png_header(s);
-	stbi__rewind(s);
-	return r;
+   int r;
+   r = stbi__check_png_header(s);
+   stbi__rewind(s);
+   return r;
 }
 
 static int stbi__png_info_raw(stbi__png *p, int *x, int *y, int *comp)
 {
-	if (!stbi__parse_png_file(p, STBI__SCAN_header, 0)) {
-		stbi__rewind(p->s);
-		return 0;
-	}
-	if (x) *x = p->s->img_x;
-	if (y) *y = p->s->img_y;
-	if (comp) *comp = p->s->img_n;
-	return 1;
+   if (!stbi__parse_png_file(p, STBI__SCAN_header, 0)) {
+      stbi__rewind( p->s );
+      return 0;
+   }
+   if (x) *x = p->s->img_x;
+   if (y) *y = p->s->img_y;
+   if (comp) *comp = p->s->img_n;
+   return 1;
 }
 
 static int stbi__png_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	stbi__png p;
-	p.s = s;
-	return stbi__png_info_raw(&p, x, y, comp);
+   stbi__png p;
+   p.s = s;
+   return stbi__png_info_raw(&p, x, y, comp);
+}
+
+static int stbi__png_is16(stbi__context *s)
+{
+   stbi__png p;
+   p.s = s;
+   if (!stbi__png_info_raw(&p, NULL, NULL, NULL))
+	   return 0;
+   if (p.depth != 16) {
+      stbi__rewind(p.s);
+      return 0;
+   }
+   return 1;
 }
 #endif
 
@@ -4585,317 +4983,336 @@ static int stbi__png_info(stbi__context *s, int *x, int *y, int *comp)
 #ifndef STBI_NO_BMP
 static int stbi__bmp_test_raw(stbi__context *s)
 {
-	int r;
-	int sz;
-	if (stbi__get8(s) != 'B') return 0;
-	if (stbi__get8(s) != 'M') return 0;
-	stbi__get32le(s); // discard filesize
-	stbi__get16le(s); // discard reserved
-	stbi__get16le(s); // discard reserved
-	stbi__get32le(s); // discard data offset
-	sz = stbi__get32le(s);
-	r = (sz == 12 || sz == 40 || sz == 56 || sz == 108 || sz == 124);
-	return r;
+   int r;
+   int sz;
+   if (stbi__get8(s) != 'B') return 0;
+   if (stbi__get8(s) != 'M') return 0;
+   stbi__get32le(s); // discard filesize
+   stbi__get16le(s); // discard reserved
+   stbi__get16le(s); // discard reserved
+   stbi__get32le(s); // discard data offset
+   sz = stbi__get32le(s);
+   r = (sz == 12 || sz == 40 || sz == 56 || sz == 108 || sz == 124);
+   return r;
 }
 
 static int stbi__bmp_test(stbi__context *s)
 {
-	int r = stbi__bmp_test_raw(s);
-	stbi__rewind(s);
-	return r;
+   int r = stbi__bmp_test_raw(s);
+   stbi__rewind(s);
+   return r;
 }
 
 
 // returns 0..31 for the highest set bit
 static int stbi__high_bit(unsigned int z)
 {
-	int n = 0;
-	if (z == 0) return -1;
-	if (z >= 0x10000) n += 16, z >>= 16;
-	if (z >= 0x00100) n += 8, z >>= 8;
-	if (z >= 0x00010) n += 4, z >>= 4;
-	if (z >= 0x00004) n += 2, z >>= 2;
-	if (z >= 0x00002) n += 1, z >>= 1;
-	return n;
+   int n=0;
+   if (z == 0) return -1;
+   if (z >= 0x10000) n += 16, z >>= 16;
+   if (z >= 0x00100) n +=  8, z >>=  8;
+   if (z >= 0x00010) n +=  4, z >>=  4;
+   if (z >= 0x00004) n +=  2, z >>=  2;
+   if (z >= 0x00002) n +=  1, z >>=  1;
+   return n;
 }
 
 static int stbi__bitcount(unsigned int a)
 {
-	a = (a & 0x55555555) + ((a >> 1) & 0x55555555); // max 2
-	a = (a & 0x33333333) + ((a >> 2) & 0x33333333); // max 4
-	a = (a + (a >> 4)) & 0x0f0f0f0f; // max 8 per 4, now 8 bits
-	a = (a + (a >> 8)); // max 16 per 8 bits
-	a = (a + (a >> 16)); // max 32 per 8 bits
-	return a & 0xff;
+   a = (a & 0x55555555) + ((a >>  1) & 0x55555555); // max 2
+   a = (a & 0x33333333) + ((a >>  2) & 0x33333333); // max 4
+   a = (a + (a >> 4)) & 0x0f0f0f0f; // max 8 per 4, now 8 bits
+   a = (a + (a >> 8)); // max 16 per 8 bits
+   a = (a + (a >> 16)); // max 32 per 8 bits
+   return a & 0xff;
 }
 
+// extract an arbitrarily-aligned N-bit value (N=bits)
+// from v, and then make it 8-bits long and fractionally
+// extend it to full full range.
 static int stbi__shiftsigned(int v, int shift, int bits)
 {
-	int result;
-	int z = 0;
-
-	if (shift < 0) v <<= -shift;
-	else v >>= shift;
-	result = v;
-
-	z = bits;
-	while (z < 8) {
-		result += v >> z;
-		z += bits;
-	}
-	return result;
+   static unsigned int mul_table[9] = {
+      0,
+      0xff/*0b11111111*/, 0x55/*0b01010101*/, 0x49/*0b01001001*/, 0x11/*0b00010001*/,
+      0x21/*0b00100001*/, 0x41/*0b01000001*/, 0x81/*0b10000001*/, 0x01/*0b00000001*/,
+   };
+   static unsigned int shift_table[9] = {
+      0, 0,0,1,0,2,4,6,0,
+   };
+   if (shift < 0)
+      v <<= -shift;
+   else
+      v >>= shift;
+   STBI_ASSERT(v >= 0 && v < 256);
+   v >>= (8-bits);
+   STBI_ASSERT(bits >= 0 && bits <= 8);
+   return (int) ((unsigned) v * mul_table[bits]) >> shift_table[bits];
 }
 
 typedef struct
 {
-	int bpp, offset, hsz;
-	unsigned int mr, mg, mb, ma, all_a;
+   int bpp, offset, hsz;
+   unsigned int mr,mg,mb,ma, all_a;
 } stbi__bmp_data;
 
 static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
 {
-	int hsz;
-	if (stbi__get8(s) != 'B' || stbi__get8(s) != 'M') return stbi__errpuc("not BMP", "Corrupt BMP");
-	stbi__get32le(s); // discard filesize
-	stbi__get16le(s); // discard reserved
-	stbi__get16le(s); // discard reserved
-	info->offset = stbi__get32le(s);
-	info->hsz = hsz = stbi__get32le(s);
+   int hsz;
+   if (stbi__get8(s) != 'B' || stbi__get8(s) != 'M') return stbi__errpuc("not BMP", "Corrupt BMP");
+   stbi__get32le(s); // discard filesize
+   stbi__get16le(s); // discard reserved
+   stbi__get16le(s); // discard reserved
+   info->offset = stbi__get32le(s);
+   info->hsz = hsz = stbi__get32le(s);
+   info->mr = info->mg = info->mb = info->ma = 0;
 
-	if (hsz != 12 && hsz != 40 && hsz != 56 && hsz != 108 && hsz != 124) return stbi__errpuc("unknown BMP", "BMP type not supported: unknown");
-	if (hsz == 12) {
-		s->img_x = stbi__get16le(s);
-		s->img_y = stbi__get16le(s);
-	}
-	else {
-		s->img_x = stbi__get32le(s);
-		s->img_y = stbi__get32le(s);
-	}
-	if (stbi__get16le(s) != 1) return stbi__errpuc("bad BMP", "bad BMP");
-	info->bpp = stbi__get16le(s);
-	if (info->bpp == 1) return stbi__errpuc("monochrome", "BMP type not supported: 1-bit");
-	if (hsz != 12) {
-		int compress = stbi__get32le(s);
-		if (compress == 1 || compress == 2) return stbi__errpuc("BMP RLE", "BMP type not supported: RLE");
-		stbi__get32le(s); // discard sizeof
-		stbi__get32le(s); // discard hres
-		stbi__get32le(s); // discard vres
-		stbi__get32le(s); // discard colorsused
-		stbi__get32le(s); // discard max important
-		if (hsz == 40 || hsz == 56) {
-			if (hsz == 56) {
-				stbi__get32le(s);
-				stbi__get32le(s);
-				stbi__get32le(s);
-				stbi__get32le(s);
-			}
-			if (info->bpp == 16 || info->bpp == 32) {
-				info->mr = info->mg = info->mb = 0;
-				if (compress == 0) {
-					if (info->bpp == 32) {
-						info->mr = 0xffu << 16;
-						info->mg = 0xffu << 8;
-						info->mb = 0xffu << 0;
-						info->ma = 0xffu << 24;
-						info->all_a = 0; // if all_a is 0 at end, then we loaded alpha channel but it was all 0
-					}
-					else {
-						info->mr = 31u << 10;
-						info->mg = 31u << 5;
-						info->mb = 31u << 0;
-					}
-				}
-				else if (compress == 3) {
-					info->mr = stbi__get32le(s);
-					info->mg = stbi__get32le(s);
-					info->mb = stbi__get32le(s);
-					// not documented, but generated by photoshop and handled by mspaint
-					if (info->mr == info->mg && info->mg == info->mb) {
-						// ?!?!?
-						return stbi__errpuc("bad BMP", "bad BMP");
-					}
-				}
-				else
-					return stbi__errpuc("bad BMP", "bad BMP");
-			}
-		}
-		else {
-			int i;
-			if (hsz != 108 && hsz != 124)
-				return stbi__errpuc("bad BMP", "bad BMP");
-			info->mr = stbi__get32le(s);
-			info->mg = stbi__get32le(s);
-			info->mb = stbi__get32le(s);
-			info->ma = stbi__get32le(s);
-			stbi__get32le(s); // discard color space
-			for (i = 0; i < 12; ++i)
-				stbi__get32le(s); // discard color space parameters
-			if (hsz == 124) {
-				stbi__get32le(s); // discard rendering intent
-				stbi__get32le(s); // discard offset of profile data
-				stbi__get32le(s); // discard size of profile data
-				stbi__get32le(s); // discard reserved
-			}
-		}
-	}
-	return (void *)1;
+   if (hsz != 12 && hsz != 40 && hsz != 56 && hsz != 108 && hsz != 124) return stbi__errpuc("unknown BMP", "BMP type not supported: unknown");
+   if (hsz == 12) {
+      s->img_x = stbi__get16le(s);
+      s->img_y = stbi__get16le(s);
+   } else {
+      s->img_x = stbi__get32le(s);
+      s->img_y = stbi__get32le(s);
+   }
+   if (stbi__get16le(s) != 1) return stbi__errpuc("bad BMP", "bad BMP");
+   info->bpp = stbi__get16le(s);
+   if (hsz != 12) {
+      int compress = stbi__get32le(s);
+      if (compress == 1 || compress == 2) return stbi__errpuc("BMP RLE", "BMP type not supported: RLE");
+      stbi__get32le(s); // discard sizeof
+      stbi__get32le(s); // discard hres
+      stbi__get32le(s); // discard vres
+      stbi__get32le(s); // discard colorsused
+      stbi__get32le(s); // discard max important
+      if (hsz == 40 || hsz == 56) {
+         if (hsz == 56) {
+            stbi__get32le(s);
+            stbi__get32le(s);
+            stbi__get32le(s);
+            stbi__get32le(s);
+         }
+         if (info->bpp == 16 || info->bpp == 32) {
+            if (compress == 0) {
+               if (info->bpp == 32) {
+                  info->mr = 0xffu << 16;
+                  info->mg = 0xffu <<  8;
+                  info->mb = 0xffu <<  0;
+                  info->ma = 0xffu << 24;
+                  info->all_a = 0; // if all_a is 0 at end, then we loaded alpha channel but it was all 0
+               } else {
+                  info->mr = 31u << 10;
+                  info->mg = 31u <<  5;
+                  info->mb = 31u <<  0;
+               }
+            } else if (compress == 3) {
+               info->mr = stbi__get32le(s);
+               info->mg = stbi__get32le(s);
+               info->mb = stbi__get32le(s);
+               // not documented, but generated by photoshop and handled by mspaint
+               if (info->mr == info->mg && info->mg == info->mb) {
+                  // ?!?!?
+                  return stbi__errpuc("bad BMP", "bad BMP");
+               }
+            } else
+               return stbi__errpuc("bad BMP", "bad BMP");
+         }
+      } else {
+         int i;
+         if (hsz != 108 && hsz != 124)
+            return stbi__errpuc("bad BMP", "bad BMP");
+         info->mr = stbi__get32le(s);
+         info->mg = stbi__get32le(s);
+         info->mb = stbi__get32le(s);
+         info->ma = stbi__get32le(s);
+         stbi__get32le(s); // discard color space
+         for (i=0; i < 12; ++i)
+            stbi__get32le(s); // discard color space parameters
+         if (hsz == 124) {
+            stbi__get32le(s); // discard rendering intent
+            stbi__get32le(s); // discard offset of profile data
+            stbi__get32le(s); // discard size of profile data
+            stbi__get32le(s); // discard reserved
+         }
+      }
+   }
+   return (void *) 1;
 }
 
 
-static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
-	stbi_uc *out;
-	unsigned int mr = 0, mg = 0, mb = 0, ma = 0, all_a;
-	stbi_uc pal[256][4];
-	int psize = 0, i, j, width;
-	int flip_vertically, pad, target;
-	stbi__bmp_data info;
+   stbi_uc *out;
+   unsigned int mr=0,mg=0,mb=0,ma=0, all_a;
+   stbi_uc pal[256][4];
+   int psize=0,i,j,width;
+   int flip_vertically, pad, target;
+   stbi__bmp_data info;
+   STBI_NOTUSED(ri);
 
-	info.all_a = 255;
-	if (stbi__bmp_parse_header(s, &info) == NULL)
-		return NULL; // error code already set
+   info.all_a = 255;
+   if (stbi__bmp_parse_header(s, &info) == NULL)
+      return NULL; // error code already set
 
-	flip_vertically = ((int)s->img_y) > 0;
-	s->img_y = abs((int)s->img_y);
+   flip_vertically = ((int) s->img_y) > 0;
+   s->img_y = abs((int) s->img_y);
 
-	mr = info.mr;
-	mg = info.mg;
-	mb = info.mb;
-	ma = info.ma;
-	all_a = info.all_a;
+   mr = info.mr;
+   mg = info.mg;
+   mb = info.mb;
+   ma = info.ma;
+   all_a = info.all_a;
 
-	if (info.hsz == 12) {
-		if (info.bpp < 24)
-			psize = (info.offset - 14 - 24) / 3;
-	}
-	else {
-		if (info.bpp < 16)
-			psize = (info.offset - 14 - info.hsz) >> 2;
-	}
+   if (info.hsz == 12) {
+      if (info.bpp < 24)
+         psize = (info.offset - 14 - 24) / 3;
+   } else {
+      if (info.bpp < 16)
+         psize = (info.offset - 14 - info.hsz) >> 2;
+   }
 
-	s->img_n = ma ? 4 : 3;
-	if (req_comp && req_comp >= 3) // we can directly decode 3 or 4
-		target = req_comp;
-	else
-		target = s->img_n; // if they want monochrome, we'll post-convert
+   s->img_n = ma ? 4 : 3;
+   if (req_comp && req_comp >= 3) // we can directly decode 3 or 4
+      target = req_comp;
+   else
+      target = s->img_n; // if they want monochrome, we'll post-convert
 
-	out = (stbi_uc *)stbi__malloc(target * s->img_x * s->img_y);
-	if (!out) return stbi__errpuc("outofmem", "Out of memory");
-	if (info.bpp < 16) {
-		int z = 0;
-		if (psize == 0 || psize > 256) { STBI_FREE(out); return stbi__errpuc("invalid", "Corrupt BMP"); }
-		for (i = 0; i < psize; ++i) {
-			pal[i][2] = stbi__get8(s);
-			pal[i][1] = stbi__get8(s);
-			pal[i][0] = stbi__get8(s);
-			if (info.hsz != 12) stbi__get8(s);
-			pal[i][3] = 255;
-		}
-		stbi__skip(s, info.offset - 14 - info.hsz - psize * (info.hsz == 12 ? 3 : 4));
-		if (info.bpp == 4) width = (s->img_x + 1) >> 1;
-		else if (info.bpp == 8) width = s->img_x;
-		else { STBI_FREE(out); return stbi__errpuc("bad bpp", "Corrupt BMP"); }
-		pad = (-width) & 3;
-		for (j = 0; j < (int)s->img_y; ++j) {
-			for (i = 0; i < (int)s->img_x; i += 2) {
-				int v = stbi__get8(s), v2 = 0;
-				if (info.bpp == 4) {
-					v2 = v & 15;
-					v >>= 4;
-				}
-				out[z++] = pal[v][0];
-				out[z++] = pal[v][1];
-				out[z++] = pal[v][2];
-				if (target == 4) out[z++] = 255;
-				if (i + 1 == (int)s->img_x) break;
-				v = (info.bpp == 8) ? stbi__get8(s) : v2;
-				out[z++] = pal[v][0];
-				out[z++] = pal[v][1];
-				out[z++] = pal[v][2];
-				if (target == 4) out[z++] = 255;
-			}
-			stbi__skip(s, pad);
-		}
-	}
-	else {
-		int rshift = 0, gshift = 0, bshift = 0, ashift = 0, rcount = 0, gcount = 0, bcount = 0, acount = 0;
-		int z = 0;
-		int easy = 0;
-		stbi__skip(s, info.offset - 14 - info.hsz);
-		if (info.bpp == 24) width = 3 * s->img_x;
-		else if (info.bpp == 16) width = 2 * s->img_x;
-		else /* bpp = 32 and pad = 0 */ width = 0;
-		pad = (-width) & 3;
-		if (info.bpp == 24) {
-			easy = 1;
-		}
-		else if (info.bpp == 32) {
-			if (mb == 0xff && mg == 0xff00 && mr == 0x00ff0000 && ma == 0xff000000)
-				easy = 2;
-		}
-		if (!easy) {
-			if (!mr || !mg || !mb) { STBI_FREE(out); return stbi__errpuc("bad masks", "Corrupt BMP"); }
-			// right shift amt to put high bit in position #7
-			rshift = stbi__high_bit(mr) - 7; rcount = stbi__bitcount(mr);
-			gshift = stbi__high_bit(mg) - 7; gcount = stbi__bitcount(mg);
-			bshift = stbi__high_bit(mb) - 7; bcount = stbi__bitcount(mb);
-			ashift = stbi__high_bit(ma) - 7; acount = stbi__bitcount(ma);
-		}
-		for (j = 0; j < (int)s->img_y; ++j) {
-			if (easy) {
-				for (i = 0; i < (int)s->img_x; ++i) {
-					unsigned char a;
-					out[z + 2] = stbi__get8(s);
-					out[z + 1] = stbi__get8(s);
-					out[z + 0] = stbi__get8(s);
-					z += 3;
-					a = (easy == 2 ? stbi__get8(s) : 255);
-					all_a |= a;
-					if (target == 4) out[z++] = a;
-				}
-			}
-			else {
-				int bpp = info.bpp;
-				for (i = 0; i < (int)s->img_x; ++i) {
-					stbi__uint32 v = (bpp == 16 ? (stbi__uint32)stbi__get16le(s) : stbi__get32le(s));
-					int a;
-					out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mr, rshift, rcount));
-					out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mg, gshift, gcount));
-					out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mb, bshift, bcount));
-					a = (ma ? stbi__shiftsigned(v & ma, ashift, acount) : 255);
-					all_a |= a;
-					if (target == 4) out[z++] = STBI__BYTECAST(a);
-				}
-			}
-			stbi__skip(s, pad);
-		}
-	}
+   // sanity-check size
+   if (!stbi__mad3sizes_valid(target, s->img_x, s->img_y, 0))
+      return stbi__errpuc("too large", "Corrupt BMP");
 
-	// if alpha channel is all 0s, replace with all 255s
-	if (target == 4 && all_a == 0)
-		for (i = 4 * s->img_x*s->img_y - 1; i >= 0; i -= 4)
-			out[i] = 255;
+   out = (stbi_uc *) stbi__malloc_mad3(target, s->img_x, s->img_y, 0);
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   if (info.bpp < 16) {
+      int z=0;
+      if (psize == 0 || psize > 256) { STBI_FREE(out); return stbi__errpuc("invalid", "Corrupt BMP"); }
+      for (i=0; i < psize; ++i) {
+         pal[i][2] = stbi__get8(s);
+         pal[i][1] = stbi__get8(s);
+         pal[i][0] = stbi__get8(s);
+         if (info.hsz != 12) stbi__get8(s);
+         pal[i][3] = 255;
+      }
+      stbi__skip(s, info.offset - 14 - info.hsz - psize * (info.hsz == 12 ? 3 : 4));
+      if (info.bpp == 1) width = (s->img_x + 7) >> 3;
+      else if (info.bpp == 4) width = (s->img_x + 1) >> 1;
+      else if (info.bpp == 8) width = s->img_x;
+      else { STBI_FREE(out); return stbi__errpuc("bad bpp", "Corrupt BMP"); }
+      pad = (-width)&3;
+      if (info.bpp == 1) {
+         for (j=0; j < (int) s->img_y; ++j) {
+            int bit_offset = 7, v = stbi__get8(s);
+            for (i=0; i < (int) s->img_x; ++i) {
+               int color = (v>>bit_offset)&0x1;
+               out[z++] = pal[color][0];
+               out[z++] = pal[color][1];
+               out[z++] = pal[color][2];
+               if((--bit_offset) < 0) {
+                  bit_offset = 7;
+                  v = stbi__get8(s);
+               }
+            }
+            stbi__skip(s, pad);
+         }
+      } else {
+         for (j=0; j < (int) s->img_y; ++j) {
+            for (i=0; i < (int) s->img_x; i += 2) {
+               int v=stbi__get8(s),v2=0;
+               if (info.bpp == 4) {
+                  v2 = v & 15;
+                  v >>= 4;
+               }
+               out[z++] = pal[v][0];
+               out[z++] = pal[v][1];
+               out[z++] = pal[v][2];
+               if (target == 4) out[z++] = 255;
+               if (i+1 == (int) s->img_x) break;
+               v = (info.bpp == 8) ? stbi__get8(s) : v2;
+               out[z++] = pal[v][0];
+               out[z++] = pal[v][1];
+               out[z++] = pal[v][2];
+               if (target == 4) out[z++] = 255;
+            }
+            stbi__skip(s, pad);
+         }
+      }
+   } else {
+      int rshift=0,gshift=0,bshift=0,ashift=0,rcount=0,gcount=0,bcount=0,acount=0;
+      int z = 0;
+      int easy=0;
+      stbi__skip(s, info.offset - 14 - info.hsz);
+      if (info.bpp == 24) width = 3 * s->img_x;
+      else if (info.bpp == 16) width = 2*s->img_x;
+      else /* bpp = 32 and pad = 0 */ width=0;
+      pad = (-width) & 3;
+      if (info.bpp == 24) {
+         easy = 1;
+      } else if (info.bpp == 32) {
+         if (mb == 0xff && mg == 0xff00 && mr == 0x00ff0000 && ma == 0xff000000)
+            easy = 2;
+      }
+      if (!easy) {
+         if (!mr || !mg || !mb) { STBI_FREE(out); return stbi__errpuc("bad masks", "Corrupt BMP"); }
+         // right shift amt to put high bit in position #7
+         rshift = stbi__high_bit(mr)-7; rcount = stbi__bitcount(mr);
+         gshift = stbi__high_bit(mg)-7; gcount = stbi__bitcount(mg);
+         bshift = stbi__high_bit(mb)-7; bcount = stbi__bitcount(mb);
+         ashift = stbi__high_bit(ma)-7; acount = stbi__bitcount(ma);
+      }
+      for (j=0; j < (int) s->img_y; ++j) {
+         if (easy) {
+            for (i=0; i < (int) s->img_x; ++i) {
+               unsigned char a;
+               out[z+2] = stbi__get8(s);
+               out[z+1] = stbi__get8(s);
+               out[z+0] = stbi__get8(s);
+               z += 3;
+               a = (easy == 2 ? stbi__get8(s) : 255);
+               all_a |= a;
+               if (target == 4) out[z++] = a;
+            }
+         } else {
+            int bpp = info.bpp;
+            for (i=0; i < (int) s->img_x; ++i) {
+               stbi__uint32 v = (bpp == 16 ? (stbi__uint32) stbi__get16le(s) : stbi__get32le(s));
+               unsigned int a;
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mr, rshift, rcount));
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mg, gshift, gcount));
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mb, bshift, bcount));
+               a = (ma ? stbi__shiftsigned(v & ma, ashift, acount) : 255);
+               all_a |= a;
+               if (target == 4) out[z++] = STBI__BYTECAST(a);
+            }
+         }
+         stbi__skip(s, pad);
+      }
+   }
 
-	if (flip_vertically) {
-		stbi_uc t;
-		for (j = 0; j < (int)s->img_y >> 1; ++j) {
-			stbi_uc *p1 = out + j     *s->img_x*target;
-			stbi_uc *p2 = out + (s->img_y - 1 - j)*s->img_x*target;
-			for (i = 0; i < (int)s->img_x*target; ++i) {
-				t = p1[i], p1[i] = p2[i], p2[i] = t;
-			}
-		}
-	}
+   // if alpha channel is all 0s, replace with all 255s
+   if (target == 4 && all_a == 0)
+      for (i=4*s->img_x*s->img_y-1; i >= 0; i -= 4)
+         out[i] = 255;
 
-	if (req_comp && req_comp != target) {
-		out = stbi__convert_format(out, target, req_comp, s->img_x, s->img_y);
-		if (out == NULL) return out; // stbi__convert_format frees input on failure
-	}
+   if (flip_vertically) {
+      stbi_uc t;
+      for (j=0; j < (int) s->img_y>>1; ++j) {
+         stbi_uc *p1 = out +      j     *s->img_x*target;
+         stbi_uc *p2 = out + (s->img_y-1-j)*s->img_x*target;
+         for (i=0; i < (int) s->img_x*target; ++i) {
+            t = p1[i], p1[i] = p2[i], p2[i] = t;
+         }
+      }
+   }
 
-	*x = s->img_x;
-	*y = s->img_y;
-	if (comp) *comp = s->img_n;
-	return out;
+   if (req_comp && req_comp != target) {
+      out = stbi__convert_format(out, target, req_comp, s->img_x, s->img_y);
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+
+   *x = s->img_x;
+   *y = s->img_y;
+   if (comp) *comp = s->img_n;
+   return out;
 }
 #endif
 
@@ -4905,333 +5322,328 @@ static stbi_uc *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int 
 // returns STBI_rgb or whatever, 0 on error
 static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int* is_rgb16)
 {
-	// only RGB or RGBA (incl. 16bit) or grey allowed
-	if (is_rgb16) *is_rgb16 = 0;
-	switch (bits_per_pixel) {
-	case 8:  return STBI_grey;
-	case 16: if (is_grey) return STBI_grey_alpha;
-		// else: fall-through
-	case 15: if (is_rgb16) *is_rgb16 = 1;
-		return STBI_rgb;
-	case 24: // fall-through
-	case 32: return bits_per_pixel / 8;
-	default: return 0;
-	}
+   // only RGB or RGBA (incl. 16bit) or grey allowed
+   if (is_rgb16) *is_rgb16 = 0;
+   switch(bits_per_pixel) {
+      case 8:  return STBI_grey;
+      case 16: if(is_grey) return STBI_grey_alpha;
+               // fallthrough
+      case 15: if(is_rgb16) *is_rgb16 = 1;
+               return STBI_rgb;
+      case 24: // fallthrough
+      case 32: return bits_per_pixel/8;
+      default: return 0;
+   }
 }
 
 static int stbi__tga_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	int tga_w, tga_h, tga_comp, tga_image_type, tga_bits_per_pixel, tga_colormap_bpp;
-	int sz, tga_colormap_type;
-	stbi__get8(s);                   // discard Offset
-	tga_colormap_type = stbi__get8(s); // colormap type
-	if (tga_colormap_type > 1) {
-		stbi__rewind(s);
-		return 0;      // only RGB or indexed allowed
-	}
-	tga_image_type = stbi__get8(s); // image type
-	if (tga_colormap_type == 1) { // colormapped (paletted) image
-		if (tga_image_type != 1 && tga_image_type != 9) {
-			stbi__rewind(s);
-			return 0;
-		}
-		stbi__skip(s, 4);       // skip index of first colormap entry and number of entries
-		sz = stbi__get8(s);    //   check bits per palette color entry
-		if ((sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32)) {
-			stbi__rewind(s);
-			return 0;
-		}
-		stbi__skip(s, 4);       // skip image x and y origin
-		tga_colormap_bpp = sz;
-	}
-	else { // "normal" image w/o colormap - only RGB or grey allowed, +/- RLE
-		if ((tga_image_type != 2) && (tga_image_type != 3) && (tga_image_type != 10) && (tga_image_type != 11)) {
-			stbi__rewind(s);
-			return 0; // only RGB or grey allowed, +/- RLE
-		}
-		stbi__skip(s, 9); // skip colormap specification and image x/y origin
-		tga_colormap_bpp = 0;
-	}
-	tga_w = stbi__get16le(s);
-	if (tga_w < 1) {
-		stbi__rewind(s);
-		return 0;   // test width
-	}
-	tga_h = stbi__get16le(s);
-	if (tga_h < 1) {
-		stbi__rewind(s);
-		return 0;   // test height
-	}
-	tga_bits_per_pixel = stbi__get8(s); // bits per pixel
-	stbi__get8(s); // ignore alpha bits
-	if (tga_colormap_bpp != 0) {
-		if ((tga_bits_per_pixel != 8) && (tga_bits_per_pixel != 16)) {
-			// when using a colormap, tga_bits_per_pixel is the size of the indexes
-			// I don't think anything but 8 or 16bit indexes makes sense
-			stbi__rewind(s);
-			return 0;
-		}
-		tga_comp = stbi__tga_get_comp(tga_colormap_bpp, 0, NULL);
-	}
-	else {
-		tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3) || (tga_image_type == 11), NULL);
-	}
-	if (!tga_comp) {
-		stbi__rewind(s);
-		return 0;
-	}
-	if (x) *x = tga_w;
-	if (y) *y = tga_h;
-	if (comp) *comp = tga_comp;
-	return 1;                   // seems to have passed everything
+    int tga_w, tga_h, tga_comp, tga_image_type, tga_bits_per_pixel, tga_colormap_bpp;
+    int sz, tga_colormap_type;
+    stbi__get8(s);                   // discard Offset
+    tga_colormap_type = stbi__get8(s); // colormap type
+    if( tga_colormap_type > 1 ) {
+        stbi__rewind(s);
+        return 0;      // only RGB or indexed allowed
+    }
+    tga_image_type = stbi__get8(s); // image type
+    if ( tga_colormap_type == 1 ) { // colormapped (paletted) image
+        if (tga_image_type != 1 && tga_image_type != 9) {
+            stbi__rewind(s);
+            return 0;
+        }
+        stbi__skip(s,4);       // skip index of first colormap entry and number of entries
+        sz = stbi__get8(s);    //   check bits per palette color entry
+        if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) {
+            stbi__rewind(s);
+            return 0;
+        }
+        stbi__skip(s,4);       // skip image x and y origin
+        tga_colormap_bpp = sz;
+    } else { // "normal" image w/o colormap - only RGB or grey allowed, +/- RLE
+        if ( (tga_image_type != 2) && (tga_image_type != 3) && (tga_image_type != 10) && (tga_image_type != 11) ) {
+            stbi__rewind(s);
+            return 0; // only RGB or grey allowed, +/- RLE
+        }
+        stbi__skip(s,9); // skip colormap specification and image x/y origin
+        tga_colormap_bpp = 0;
+    }
+    tga_w = stbi__get16le(s);
+    if( tga_w < 1 ) {
+        stbi__rewind(s);
+        return 0;   // test width
+    }
+    tga_h = stbi__get16le(s);
+    if( tga_h < 1 ) {
+        stbi__rewind(s);
+        return 0;   // test height
+    }
+    tga_bits_per_pixel = stbi__get8(s); // bits per pixel
+    stbi__get8(s); // ignore alpha bits
+    if (tga_colormap_bpp != 0) {
+        if((tga_bits_per_pixel != 8) && (tga_bits_per_pixel != 16)) {
+            // when using a colormap, tga_bits_per_pixel is the size of the indexes
+            // I don't think anything but 8 or 16bit indexes makes sense
+            stbi__rewind(s);
+            return 0;
+        }
+        tga_comp = stbi__tga_get_comp(tga_colormap_bpp, 0, NULL);
+    } else {
+        tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3) || (tga_image_type == 11), NULL);
+    }
+    if(!tga_comp) {
+      stbi__rewind(s);
+      return 0;
+    }
+    if (x) *x = tga_w;
+    if (y) *y = tga_h;
+    if (comp) *comp = tga_comp;
+    return 1;                   // seems to have passed everything
 }
 
 static int stbi__tga_test(stbi__context *s)
 {
-	int res = 0;
-	int sz, tga_color_type;
-	stbi__get8(s);      //   discard Offset
-	tga_color_type = stbi__get8(s);   //   color type
-	if (tga_color_type > 1) goto errorEnd;   //   only RGB or indexed allowed
-	sz = stbi__get8(s);   //   image type
-	if (tga_color_type == 1) { // colormapped (paletted) image
-		if (sz != 1 && sz != 9) goto errorEnd; // colortype 1 demands image type 1 or 9
-		stbi__skip(s, 4);       // skip index of first colormap entry and number of entries
-		sz = stbi__get8(s);    //   check bits per palette color entry
-		if ((sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32)) goto errorEnd;
-		stbi__skip(s, 4);       // skip image x and y origin
-	}
-	else { // "normal" image w/o colormap
-		if ((sz != 2) && (sz != 3) && (sz != 10) && (sz != 11)) goto errorEnd; // only RGB or grey allowed, +/- RLE
-		stbi__skip(s, 9); // skip colormap specification and image x/y origin
-	}
-	if (stbi__get16le(s) < 1) goto errorEnd;      //   test width
-	if (stbi__get16le(s) < 1) goto errorEnd;      //   test height
-	sz = stbi__get8(s);   //   bits per pixel
-	if ((tga_color_type == 1) && (sz != 8) && (sz != 16)) goto errorEnd; // for colormapped images, bpp is size of an index
-	if ((sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32)) goto errorEnd;
+   int res = 0;
+   int sz, tga_color_type;
+   stbi__get8(s);      //   discard Offset
+   tga_color_type = stbi__get8(s);   //   color type
+   if ( tga_color_type > 1 ) goto errorEnd;   //   only RGB or indexed allowed
+   sz = stbi__get8(s);   //   image type
+   if ( tga_color_type == 1 ) { // colormapped (paletted) image
+      if (sz != 1 && sz != 9) goto errorEnd; // colortype 1 demands image type 1 or 9
+      stbi__skip(s,4);       // skip index of first colormap entry and number of entries
+      sz = stbi__get8(s);    //   check bits per palette color entry
+      if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) goto errorEnd;
+      stbi__skip(s,4);       // skip image x and y origin
+   } else { // "normal" image w/o colormap
+      if ( (sz != 2) && (sz != 3) && (sz != 10) && (sz != 11) ) goto errorEnd; // only RGB or grey allowed, +/- RLE
+      stbi__skip(s,9); // skip colormap specification and image x/y origin
+   }
+   if ( stbi__get16le(s) < 1 ) goto errorEnd;      //   test width
+   if ( stbi__get16le(s) < 1 ) goto errorEnd;      //   test height
+   sz = stbi__get8(s);   //   bits per pixel
+   if ( (tga_color_type == 1) && (sz != 8) && (sz != 16) ) goto errorEnd; // for colormapped images, bpp is size of an index
+   if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) goto errorEnd;
 
-	res = 1; // if we got this far, everything's good and we can return 1 instead of 0
+   res = 1; // if we got this far, everything's good and we can return 1 instead of 0
 
 errorEnd:
-	stbi__rewind(s);
-	return res;
+   stbi__rewind(s);
+   return res;
 }
 
 // read 16bit value and convert to 24bit RGB
-void stbi__tga_read_rgb16(stbi__context *s, stbi_uc* out)
+static void stbi__tga_read_rgb16(stbi__context *s, stbi_uc* out)
 {
-	stbi__uint16 px = stbi__get16le(s);
-	stbi__uint16 fiveBitMask = 31;
-	// we have 3 channels with 5bits each
-	int r = (px >> 10) & fiveBitMask;
-	int g = (px >> 5) & fiveBitMask;
-	int b = px & fiveBitMask;
-	// Note that this saves the data in RGB(A) order, so it doesn't need to be swapped later
-	out[0] = (r * 255) / 31;
-	out[1] = (g * 255) / 31;
-	out[2] = (b * 255) / 31;
+   stbi__uint16 px = (stbi__uint16)stbi__get16le(s);
+   stbi__uint16 fiveBitMask = 31;
+   // we have 3 channels with 5bits each
+   int r = (px >> 10) & fiveBitMask;
+   int g = (px >> 5) & fiveBitMask;
+   int b = px & fiveBitMask;
+   // Note that this saves the data in RGB(A) order, so it doesn't need to be swapped later
+   out[0] = (stbi_uc)((r * 255)/31);
+   out[1] = (stbi_uc)((g * 255)/31);
+   out[2] = (stbi_uc)((b * 255)/31);
 
-	// some people claim that the most significant bit might be used for alpha
-	// (possibly if an alpha-bit is set in the "image descriptor byte")
-	// but that only made 16bit test images completely translucent..
-	// so let's treat all 15 and 16bit TGAs as RGB with no alpha.
+   // some people claim that the most significant bit might be used for alpha
+   // (possibly if an alpha-bit is set in the "image descriptor byte")
+   // but that only made 16bit test images completely translucent..
+   // so let's treat all 15 and 16bit TGAs as RGB with no alpha.
 }
 
-static stbi_uc *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
-	//   read in the TGA header stuff
-	int tga_offset = stbi__get8(s);
-	int tga_indexed = stbi__get8(s);
-	int tga_image_type = stbi__get8(s);
-	int tga_is_RLE = 0;
-	int tga_palette_start = stbi__get16le(s);
-	int tga_palette_len = stbi__get16le(s);
-	int tga_palette_bits = stbi__get8(s);
-	int tga_x_origin = stbi__get16le(s);
-	int tga_y_origin = stbi__get16le(s);
-	int tga_width = stbi__get16le(s);
-	int tga_height = stbi__get16le(s);
-	int tga_bits_per_pixel = stbi__get8(s);
-	int tga_comp, tga_rgb16 = 0;
-	int tga_inverted = stbi__get8(s);
-	// int tga_alpha_bits = tga_inverted & 15; // the 4 lowest bits - unused (useless?)
-	//   image data
-	unsigned char *tga_data;
-	unsigned char *tga_palette = NULL;
-	int i, j;
-	unsigned char raw_data[4];
-	int RLE_count = 0;
-	int RLE_repeating = 0;
-	int read_next_pixel = 1;
+   //   read in the TGA header stuff
+   int tga_offset = stbi__get8(s);
+   int tga_indexed = stbi__get8(s);
+   int tga_image_type = stbi__get8(s);
+   int tga_is_RLE = 0;
+   int tga_palette_start = stbi__get16le(s);
+   int tga_palette_len = stbi__get16le(s);
+   int tga_palette_bits = stbi__get8(s);
+   int tga_x_origin = stbi__get16le(s);
+   int tga_y_origin = stbi__get16le(s);
+   int tga_width = stbi__get16le(s);
+   int tga_height = stbi__get16le(s);
+   int tga_bits_per_pixel = stbi__get8(s);
+   int tga_comp, tga_rgb16=0;
+   int tga_inverted = stbi__get8(s);
+   // int tga_alpha_bits = tga_inverted & 15; // the 4 lowest bits - unused (useless?)
+   //   image data
+   unsigned char *tga_data;
+   unsigned char *tga_palette = NULL;
+   int i, j;
+   unsigned char raw_data[4] = {0};
+   int RLE_count = 0;
+   int RLE_repeating = 0;
+   int read_next_pixel = 1;
+   STBI_NOTUSED(ri);
 
-	//   do a tiny bit of precessing
-	if (tga_image_type >= 8)
-	{
-		tga_image_type -= 8;
-		tga_is_RLE = 1;
-	}
-	tga_inverted = 1 - ((tga_inverted >> 5) & 1);
+   //   do a tiny bit of precessing
+   if ( tga_image_type >= 8 )
+   {
+      tga_image_type -= 8;
+      tga_is_RLE = 1;
+   }
+   tga_inverted = 1 - ((tga_inverted >> 5) & 1);
 
-	//   If I'm paletted, then I'll use the number of bits from the palette
-	if (tga_indexed) tga_comp = stbi__tga_get_comp(tga_palette_bits, 0, &tga_rgb16);
-	else tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3), &tga_rgb16);
+   //   If I'm paletted, then I'll use the number of bits from the palette
+   if ( tga_indexed ) tga_comp = stbi__tga_get_comp(tga_palette_bits, 0, &tga_rgb16);
+   else tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3), &tga_rgb16);
 
-	if (!tga_comp) // shouldn't really happen, stbi__tga_test() should have ensured basic consistency
-		return stbi__errpuc("bad format", "Can't find out TGA pixelformat");
+   if(!tga_comp) // shouldn't really happen, stbi__tga_test() should have ensured basic consistency
+      return stbi__errpuc("bad format", "Can't find out TGA pixelformat");
 
-	//   tga info
-	*x = tga_width;
-	*y = tga_height;
-	if (comp) *comp = tga_comp;
+   //   tga info
+   *x = tga_width;
+   *y = tga_height;
+   if (comp) *comp = tga_comp;
 
-	tga_data = (unsigned char*)stbi__malloc((size_t)tga_width * tga_height * tga_comp);
-	if (!tga_data) return stbi__errpuc("outofmem", "Out of memory");
+   if (!stbi__mad3sizes_valid(tga_width, tga_height, tga_comp, 0))
+      return stbi__errpuc("too large", "Corrupt TGA");
 
-	// skip to the data's starting position (offset usually = 0)
-	stbi__skip(s, tga_offset);
+   tga_data = (unsigned char*)stbi__malloc_mad3(tga_width, tga_height, tga_comp, 0);
+   if (!tga_data) return stbi__errpuc("outofmem", "Out of memory");
 
-	if (!tga_indexed && !tga_is_RLE && !tga_rgb16) {
-		for (i = 0; i < tga_height; ++i) {
-			int row = tga_inverted ? tga_height - i - 1 : i;
-			stbi_uc *tga_row = tga_data + row*tga_width*tga_comp;
-			stbi__getn(s, tga_row, tga_width * tga_comp);
-		}
-	}
-	else {
-		//   do I need to load a palette?
-		if (tga_indexed)
-		{
-			//   any data to skip? (offset usually = 0)
-			stbi__skip(s, tga_palette_start);
-			//   load the palette
-			tga_palette = (unsigned char*)stbi__malloc(tga_palette_len * tga_comp);
-			if (!tga_palette) {
-				STBI_FREE(tga_data);
-				return stbi__errpuc("outofmem", "Out of memory");
-			}
-			if (tga_rgb16) {
-				stbi_uc *pal_entry = tga_palette;
-				STBI_ASSERT(tga_comp == STBI_rgb);
-				for (i = 0; i < tga_palette_len; ++i) {
-					stbi__tga_read_rgb16(s, pal_entry);
-					pal_entry += tga_comp;
-				}
-			}
-			else if (!stbi__getn(s, tga_palette, tga_palette_len * tga_comp)) {
-				STBI_FREE(tga_data);
-				STBI_FREE(tga_palette);
-				return stbi__errpuc("bad palette", "Corrupt TGA");
-			}
-		}
-		//   load the data
-		for (i = 0; i < tga_width * tga_height; ++i)
-		{
-			//   if I'm in RLE mode, do I need to get a RLE stbi__pngchunk?
-			if (tga_is_RLE)
-			{
-				if (RLE_count == 0)
-				{
-					//   yep, get the next byte as a RLE command
-					int RLE_cmd = stbi__get8(s);
-					RLE_count = 1 + (RLE_cmd & 127);
-					RLE_repeating = RLE_cmd >> 7;
-					read_next_pixel = 1;
-				}
-				else if (!RLE_repeating)
-				{
-					read_next_pixel = 1;
-				}
-			}
-			else
-			{
-				read_next_pixel = 1;
-			}
-			//   OK, if I need to read a pixel, do it now
-			if (read_next_pixel)
-			{
-				//   load however much data we did have
-				if (tga_indexed)
-				{
-					// read in index, then perform the lookup
-					int pal_idx = (tga_bits_per_pixel == 8) ? stbi__get8(s) : stbi__get16le(s);
-					if (pal_idx >= tga_palette_len) {
-						// invalid index
-						pal_idx = 0;
-					}
-					pal_idx *= tga_comp;
-					for (j = 0; j < tga_comp; ++j) {
-						raw_data[j] = tga_palette[pal_idx + j];
-					}
-				}
-				else if (tga_rgb16) {
-					STBI_ASSERT(tga_comp == STBI_rgb);
-					stbi__tga_read_rgb16(s, raw_data);
-				}
-				else {
-					//   read in the data raw
-					for (j = 0; j < tga_comp; ++j) {
-						raw_data[j] = stbi__get8(s);
-					}
-				}
-				//   clear the reading flag for the next pixel
-				read_next_pixel = 0;
-			} // end of reading a pixel
+   // skip to the data's starting position (offset usually = 0)
+   stbi__skip(s, tga_offset );
 
-			  // copy data
-			for (j = 0; j < tga_comp; ++j)
-				tga_data[i*tga_comp + j] = raw_data[j];
+   if ( !tga_indexed && !tga_is_RLE && !tga_rgb16 ) {
+      for (i=0; i < tga_height; ++i) {
+         int row = tga_inverted ? tga_height -i - 1 : i;
+         stbi_uc *tga_row = tga_data + row*tga_width*tga_comp;
+         stbi__getn(s, tga_row, tga_width * tga_comp);
+      }
+   } else  {
+      //   do I need to load a palette?
+      if ( tga_indexed)
+      {
+         //   any data to skip? (offset usually = 0)
+         stbi__skip(s, tga_palette_start );
+         //   load the palette
+         tga_palette = (unsigned char*)stbi__malloc_mad2(tga_palette_len, tga_comp, 0);
+         if (!tga_palette) {
+            STBI_FREE(tga_data);
+            return stbi__errpuc("outofmem", "Out of memory");
+         }
+         if (tga_rgb16) {
+            stbi_uc *pal_entry = tga_palette;
+            STBI_ASSERT(tga_comp == STBI_rgb);
+            for (i=0; i < tga_palette_len; ++i) {
+               stbi__tga_read_rgb16(s, pal_entry);
+               pal_entry += tga_comp;
+            }
+         } else if (!stbi__getn(s, tga_palette, tga_palette_len * tga_comp)) {
+               STBI_FREE(tga_data);
+               STBI_FREE(tga_palette);
+               return stbi__errpuc("bad palette", "Corrupt TGA");
+         }
+      }
+      //   load the data
+      for (i=0; i < tga_width * tga_height; ++i)
+      {
+         //   if I'm in RLE mode, do I need to get a RLE stbi__pngchunk?
+         if ( tga_is_RLE )
+         {
+            if ( RLE_count == 0 )
+            {
+               //   yep, get the next byte as a RLE command
+               int RLE_cmd = stbi__get8(s);
+               RLE_count = 1 + (RLE_cmd & 127);
+               RLE_repeating = RLE_cmd >> 7;
+               read_next_pixel = 1;
+            } else if ( !RLE_repeating )
+            {
+               read_next_pixel = 1;
+            }
+         } else
+         {
+            read_next_pixel = 1;
+         }
+         //   OK, if I need to read a pixel, do it now
+         if ( read_next_pixel )
+         {
+            //   load however much data we did have
+            if ( tga_indexed )
+            {
+               // read in index, then perform the lookup
+               int pal_idx = (tga_bits_per_pixel == 8) ? stbi__get8(s) : stbi__get16le(s);
+               if ( pal_idx >= tga_palette_len ) {
+                  // invalid index
+                  pal_idx = 0;
+               }
+               pal_idx *= tga_comp;
+               for (j = 0; j < tga_comp; ++j) {
+                  raw_data[j] = tga_palette[pal_idx+j];
+               }
+            } else if(tga_rgb16) {
+               STBI_ASSERT(tga_comp == STBI_rgb);
+               stbi__tga_read_rgb16(s, raw_data);
+            } else {
+               //   read in the data raw
+               for (j = 0; j < tga_comp; ++j) {
+                  raw_data[j] = stbi__get8(s);
+               }
+            }
+            //   clear the reading flag for the next pixel
+            read_next_pixel = 0;
+         } // end of reading a pixel
 
-			//   in case we're in RLE mode, keep counting down
-			--RLE_count;
-		}
-		//   do I need to invert the image?
-		if (tga_inverted)
-		{
-			for (j = 0; j * 2 < tga_height; ++j)
-			{
-				int index1 = j * tga_width * tga_comp;
-				int index2 = (tga_height - 1 - j) * tga_width * tga_comp;
-				for (i = tga_width * tga_comp; i > 0; --i)
-				{
-					unsigned char temp = tga_data[index1];
-					tga_data[index1] = tga_data[index2];
-					tga_data[index2] = temp;
-					++index1;
-					++index2;
-				}
-			}
-		}
-		//   clear my palette, if I had one
-		if (tga_palette != NULL)
-		{
-			STBI_FREE(tga_palette);
-		}
-	}
+         // copy data
+         for (j = 0; j < tga_comp; ++j)
+           tga_data[i*tga_comp+j] = raw_data[j];
 
-	// swap RGB - if the source data was RGB16, it already is in the right order
-	if (tga_comp >= 3 && !tga_rgb16)
-	{
-		unsigned char* tga_pixel = tga_data;
-		for (i = 0; i < tga_width * tga_height; ++i)
-		{
-			unsigned char temp = tga_pixel[0];
-			tga_pixel[0] = tga_pixel[2];
-			tga_pixel[2] = temp;
-			tga_pixel += tga_comp;
-		}
-	}
+         //   in case we're in RLE mode, keep counting down
+         --RLE_count;
+      }
+      //   do I need to invert the image?
+      if ( tga_inverted )
+      {
+         for (j = 0; j*2 < tga_height; ++j)
+         {
+            int index1 = j * tga_width * tga_comp;
+            int index2 = (tga_height - 1 - j) * tga_width * tga_comp;
+            for (i = tga_width * tga_comp; i > 0; --i)
+            {
+               unsigned char temp = tga_data[index1];
+               tga_data[index1] = tga_data[index2];
+               tga_data[index2] = temp;
+               ++index1;
+               ++index2;
+            }
+         }
+      }
+      //   clear my palette, if I had one
+      if ( tga_palette != NULL )
+      {
+         STBI_FREE( tga_palette );
+      }
+   }
 
-	// convert to target component count
-	if (req_comp && req_comp != tga_comp)
-		tga_data = stbi__convert_format(tga_data, tga_comp, req_comp, tga_width, tga_height);
+   // swap RGB - if the source data was RGB16, it already is in the right order
+   if (tga_comp >= 3 && !tga_rgb16)
+   {
+      unsigned char* tga_pixel = tga_data;
+      for (i=0; i < tga_width * tga_height; ++i)
+      {
+         unsigned char temp = tga_pixel[0];
+         tga_pixel[0] = tga_pixel[2];
+         tga_pixel[2] = temp;
+         tga_pixel += tga_comp;
+      }
+   }
 
-	//   the things I do to get rid of an error message, and yet keep
-	//   Microsoft's C compilers happy... [8^(
-	tga_palette_start = tga_palette_len = tga_palette_bits =
-		tga_x_origin = tga_y_origin = 0;
-	//   OK, done
-	return tga_data;
+   // convert to target component count
+   if (req_comp && req_comp != tga_comp)
+      tga_data = stbi__convert_format(tga_data, tga_comp, req_comp, tga_width, tga_height);
+
+   //   the things I do to get rid of an error message, and yet keep
+   //   Microsoft's C compilers happy... [8^(
+   tga_palette_start = tga_palette_len = tga_palette_bits =
+         tga_x_origin = tga_y_origin = 0;
+   //   OK, done
+   return tga_data;
 }
 #endif
 
@@ -5241,183 +5653,245 @@ static stbi_uc *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int 
 #ifndef STBI_NO_PSD
 static int stbi__psd_test(stbi__context *s)
 {
-	int r = (stbi__get32be(s) == 0x38425053);
-	stbi__rewind(s);
-	return r;
+   int r = (stbi__get32be(s) == 0x38425053);
+   stbi__rewind(s);
+   return r;
 }
 
-static stbi_uc *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static int stbi__psd_decode_rle(stbi__context *s, stbi_uc *p, int pixelCount)
 {
-	int   pixelCount;
-	int channelCount, compression;
-	int channel, i, count, len;
-	int bitdepth;
-	int w, h;
-	stbi_uc *out;
+   int count, nleft, len;
 
-	// Check identifier
-	if (stbi__get32be(s) != 0x38425053)   // "8BPS"
-		return stbi__errpuc("not PSD", "Corrupt PSD image");
+   count = 0;
+   while ((nleft = pixelCount - count) > 0) {
+      len = stbi__get8(s);
+      if (len == 128) {
+         // No-op.
+      } else if (len < 128) {
+         // Copy next len+1 bytes literally.
+         len++;
+         if (len > nleft) return 0; // corrupt data
+         count += len;
+         while (len) {
+            *p = stbi__get8(s);
+            p += 4;
+            len--;
+         }
+      } else if (len > 128) {
+         stbi_uc   val;
+         // Next -len+1 bytes in the dest are replicated from next source byte.
+         // (Interpret len as a negative 8-bit int.)
+         len = 257 - len;
+         if (len > nleft) return 0; // corrupt data
+         val = stbi__get8(s);
+         count += len;
+         while (len) {
+            *p = val;
+            p += 4;
+            len--;
+         }
+      }
+   }
 
-	// Check file type version.
-	if (stbi__get16be(s) != 1)
-		return stbi__errpuc("wrong version", "Unsupported version of PSD image");
+   return 1;
+}
 
-	// Skip 6 reserved bytes.
-	stbi__skip(s, 6);
+static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
+{
+   int pixelCount;
+   int channelCount, compression;
+   int channel, i;
+   int bitdepth;
+   int w,h;
+   stbi_uc *out;
+   STBI_NOTUSED(ri);
 
-	// Read the number of channels (R, G, B, A, etc).
-	channelCount = stbi__get16be(s);
-	if (channelCount < 0 || channelCount > 16)
-		return stbi__errpuc("wrong channel count", "Unsupported number of channels in PSD image");
+   // Check identifier
+   if (stbi__get32be(s) != 0x38425053)   // "8BPS"
+      return stbi__errpuc("not PSD", "Corrupt PSD image");
 
-	// Read the rows and columns of the image.
-	h = stbi__get32be(s);
-	w = stbi__get32be(s);
+   // Check file type version.
+   if (stbi__get16be(s) != 1)
+      return stbi__errpuc("wrong version", "Unsupported version of PSD image");
 
-	// Make sure the depth is 8 bits.
-	bitdepth = stbi__get16be(s);
-	if (bitdepth != 8 && bitdepth != 16)
-		return stbi__errpuc("unsupported bit depth", "PSD bit depth is not 8 or 16 bit");
+   // Skip 6 reserved bytes.
+   stbi__skip(s, 6 );
 
-	// Make sure the color mode is RGB.
-	// Valid options are:
-	//   0: Bitmap
-	//   1: Grayscale
-	//   2: Indexed color
-	//   3: RGB color
-	//   4: CMYK color
-	//   7: Multichannel
-	//   8: Duotone
-	//   9: Lab color
-	if (stbi__get16be(s) != 3)
-		return stbi__errpuc("wrong color format", "PSD is not in RGB color format");
+   // Read the number of channels (R, G, B, A, etc).
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16)
+      return stbi__errpuc("wrong channel count", "Unsupported number of channels in PSD image");
 
-	// Skip the Mode Data.  (It's the palette for indexed color; other info for other modes.)
-	stbi__skip(s, stbi__get32be(s));
+   // Read the rows and columns of the image.
+   h = stbi__get32be(s);
+   w = stbi__get32be(s);
 
-	// Skip the image resources.  (resolution, pen tool paths, etc)
-	stbi__skip(s, stbi__get32be(s));
+   // Make sure the depth is 8 bits.
+   bitdepth = stbi__get16be(s);
+   if (bitdepth != 8 && bitdepth != 16)
+      return stbi__errpuc("unsupported bit depth", "PSD bit depth is not 8 or 16 bit");
 
-	// Skip the reserved data.
-	stbi__skip(s, stbi__get32be(s));
+   // Make sure the color mode is RGB.
+   // Valid options are:
+   //   0: Bitmap
+   //   1: Grayscale
+   //   2: Indexed color
+   //   3: RGB color
+   //   4: CMYK color
+   //   7: Multichannel
+   //   8: Duotone
+   //   9: Lab color
+   if (stbi__get16be(s) != 3)
+      return stbi__errpuc("wrong color format", "PSD is not in RGB color format");
 
-	// Find out if the data is compressed.
-	// Known values:
-	//   0: no compression
-	//   1: RLE compressed
-	compression = stbi__get16be(s);
-	if (compression > 1)
-		return stbi__errpuc("bad compression", "PSD has an unknown compression format");
+   // Skip the Mode Data.  (It's the palette for indexed color; other info for other modes.)
+   stbi__skip(s,stbi__get32be(s) );
 
-	// Create the destination image.
-	out = (stbi_uc *)stbi__malloc(4 * w*h);
-	if (!out) return stbi__errpuc("outofmem", "Out of memory");
-	pixelCount = w*h;
+   // Skip the image resources.  (resolution, pen tool paths, etc)
+   stbi__skip(s, stbi__get32be(s) );
 
-	// Initialize the data to zero.
-	//memset( out, 0, pixelCount * 4 );
+   // Skip the reserved data.
+   stbi__skip(s, stbi__get32be(s) );
 
-	// Finally, the image data.
-	if (compression) {
-		// RLE as used by .PSD and .TIFF
-		// Loop until you get the number of unpacked bytes you are expecting:
-		//     Read the next source byte into n.
-		//     If n is between 0 and 127 inclusive, copy the next n+1 bytes literally.
-		//     Else if n is between -127 and -1 inclusive, copy the next byte -n+1 times.
-		//     Else if n is 128, noop.
-		// Endloop
+   // Find out if the data is compressed.
+   // Known values:
+   //   0: no compression
+   //   1: RLE compressed
+   compression = stbi__get16be(s);
+   if (compression > 1)
+      return stbi__errpuc("bad compression", "PSD has an unknown compression format");
 
-		// The RLE-compressed data is preceeded by a 2-byte data count for each row in the data,
-		// which we're going to just skip.
-		stbi__skip(s, h * channelCount * 2);
+   // Check size
+   if (!stbi__mad3sizes_valid(4, w, h, 0))
+      return stbi__errpuc("too large", "Corrupt PSD");
 
-		// Read the RLE data by channel.
-		for (channel = 0; channel < 4; channel++) {
-			stbi_uc *p;
+   // Create the destination image.
 
-			p = out + channel;
-			if (channel >= channelCount) {
-				// Fill this channel with default data.
-				for (i = 0; i < pixelCount; i++, p += 4)
-					*p = (channel == 3 ? 255 : 0);
-			}
-			else {
-				// Read the RLE data.
-				count = 0;
-				while (count < pixelCount) {
-					len = stbi__get8(s);
-					if (len == 128) {
-						// No-op.
-					}
-					else if (len < 128) {
-						// Copy next len+1 bytes literally.
-						len++;
-						count += len;
-						while (len) {
-							*p = stbi__get8(s);
-							p += 4;
-							len--;
-						}
-					}
-					else if (len > 128) {
-						stbi_uc   val;
-						// Next -len+1 bytes in the dest are replicated from next source byte.
-						// (Interpret len as a negative 8-bit int.)
-						len ^= 0x0FF;
-						len += 2;
-						val = stbi__get8(s);
-						count += len;
-						while (len) {
-							*p = val;
-							p += 4;
-							len--;
-						}
-					}
-				}
-			}
-		}
+   if (!compression && bitdepth == 16 && bpc == 16) {
+      out = (stbi_uc *) stbi__malloc_mad3(8, w, h, 0);
+      ri->bits_per_channel = 16;
+   } else
+      out = (stbi_uc *) stbi__malloc(4 * w*h);
 
-	}
-	else {
-		// We're at the raw image data.  It's each channel in order (Red, Green, Blue, Alpha, ...)
-		// where each channel consists of an 8-bit value for each pixel in the image.
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   pixelCount = w*h;
 
-		// Read the data by channel.
-		for (channel = 0; channel < 4; channel++) {
-			stbi_uc *p;
+   // Initialize the data to zero.
+   //memset( out, 0, pixelCount * 4 );
 
-			p = out + channel;
-			if (channel >= channelCount) {
-				// Fill this channel with default data.
-				stbi_uc val = channel == 3 ? 255 : 0;
-				for (i = 0; i < pixelCount; i++, p += 4)
-					*p = val;
-			}
-			else {
-				// Read the data.
-				if (bitdepth == 16) {
-					for (i = 0; i < pixelCount; i++, p += 4)
-						*p = (stbi_uc)(stbi__get16be(s) >> 8);
-				}
-				else {
-					for (i = 0; i < pixelCount; i++, p += 4)
-						*p = stbi__get8(s);
-				}
-			}
-		}
-	}
+   // Finally, the image data.
+   if (compression) {
+      // RLE as used by .PSD and .TIFF
+      // Loop until you get the number of unpacked bytes you are expecting:
+      //     Read the next source byte into n.
+      //     If n is between 0 and 127 inclusive, copy the next n+1 bytes literally.
+      //     Else if n is between -127 and -1 inclusive, copy the next byte -n+1 times.
+      //     Else if n is 128, noop.
+      // Endloop
 
-	if (req_comp && req_comp != 4) {
-		out = stbi__convert_format(out, 4, req_comp, w, h);
-		if (out == NULL) return out; // stbi__convert_format frees input on failure
-	}
+      // The RLE-compressed data is preceeded by a 2-byte data count for each row in the data,
+      // which we're going to just skip.
+      stbi__skip(s, h * channelCount * 2 );
 
-	if (comp) *comp = 4;
-	*y = h;
-	*x = w;
+      // Read the RLE data by channel.
+      for (channel = 0; channel < 4; channel++) {
+         stbi_uc *p;
 
-	return out;
+         p = out+channel;
+         if (channel >= channelCount) {
+            // Fill this channel with default data.
+            for (i = 0; i < pixelCount; i++, p += 4)
+               *p = (channel == 3 ? 255 : 0);
+         } else {
+            // Read the RLE data.
+            if (!stbi__psd_decode_rle(s, p, pixelCount)) {
+               STBI_FREE(out);
+               return stbi__errpuc("corrupt", "bad RLE data");
+            }
+         }
+      }
+
+   } else {
+      // We're at the raw image data.  It's each channel in order (Red, Green, Blue, Alpha, ...)
+      // where each channel consists of an 8-bit (or 16-bit) value for each pixel in the image.
+
+      // Read the data by channel.
+      for (channel = 0; channel < 4; channel++) {
+         if (channel >= channelCount) {
+            // Fill this channel with default data.
+            if (bitdepth == 16 && bpc == 16) {
+               stbi__uint16 *q = ((stbi__uint16 *) out) + channel;
+               stbi__uint16 val = channel == 3 ? 65535 : 0;
+               for (i = 0; i < pixelCount; i++, q += 4)
+                  *q = val;
+            } else {
+               stbi_uc *p = out+channel;
+               stbi_uc val = channel == 3 ? 255 : 0;
+               for (i = 0; i < pixelCount; i++, p += 4)
+                  *p = val;
+            }
+         } else {
+            if (ri->bits_per_channel == 16) {    // output bpc
+               stbi__uint16 *q = ((stbi__uint16 *) out) + channel;
+               for (i = 0; i < pixelCount; i++, q += 4)
+                  *q = (stbi__uint16) stbi__get16be(s);
+            } else {
+               stbi_uc *p = out+channel;
+               if (bitdepth == 16) {  // input bpc
+                  for (i = 0; i < pixelCount; i++, p += 4)
+                     *p = (stbi_uc) (stbi__get16be(s) >> 8);
+               } else {
+                  for (i = 0; i < pixelCount; i++, p += 4)
+                     *p = stbi__get8(s);
+               }
+            }
+         }
+      }
+   }
+
+   // remove weird white matte from PSD
+   if (channelCount >= 4) {
+      if (ri->bits_per_channel == 16) {
+         for (i=0; i < w*h; ++i) {
+            stbi__uint16 *pixel = (stbi__uint16 *) out + 4*i;
+            if (pixel[3] != 0 && pixel[3] != 65535) {
+               float a = pixel[3] / 65535.0f;
+               float ra = 1.0f / a;
+               float inv_a = 65535.0f * (1 - ra);
+               pixel[0] = (stbi__uint16) (pixel[0]*ra + inv_a);
+               pixel[1] = (stbi__uint16) (pixel[1]*ra + inv_a);
+               pixel[2] = (stbi__uint16) (pixel[2]*ra + inv_a);
+            }
+         }
+      } else {
+         for (i=0; i < w*h; ++i) {
+            unsigned char *pixel = out + 4*i;
+            if (pixel[3] != 0 && pixel[3] != 255) {
+               float a = pixel[3] / 255.0f;
+               float ra = 1.0f / a;
+               float inv_a = 255.0f * (1 - ra);
+               pixel[0] = (unsigned char) (pixel[0]*ra + inv_a);
+               pixel[1] = (unsigned char) (pixel[1]*ra + inv_a);
+               pixel[2] = (unsigned char) (pixel[2]*ra + inv_a);
+            }
+         }
+      }
+   }
+
+   // convert to desired output format
+   if (req_comp && req_comp != 4) {
+      if (ri->bits_per_channel == 16)
+         out = (stbi_uc *) stbi__convert_format16((stbi__uint16 *) out, 4, req_comp, w, h);
+      else
+         out = stbi__convert_format(out, 4, req_comp, w, h);
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+
+   if (comp) *comp = 4;
+   *y = h;
+   *x = w;
+
+   return out;
 }
 #endif
 
@@ -5429,209 +5903,211 @@ static stbi_uc *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int 
 // See http://ozviz.wasp.uwa.edu.au/~pbourke/dataformats/softimagepic/
 
 #ifndef STBI_NO_PIC
-static int stbi__pic_is4(stbi__context *s, const char *str)
+static int stbi__pic_is4(stbi__context *s,const char *str)
 {
-	int i;
-	for (i = 0; i<4; ++i)
-		if (stbi__get8(s) != (stbi_uc)str[i])
-			return 0;
+   int i;
+   for (i=0; i<4; ++i)
+      if (stbi__get8(s) != (stbi_uc)str[i])
+         return 0;
 
-	return 1;
+   return 1;
 }
 
 static int stbi__pic_test_core(stbi__context *s)
 {
-	int i;
+   int i;
 
-	if (!stbi__pic_is4(s, "\x53\x80\xF6\x34"))
-		return 0;
+   if (!stbi__pic_is4(s,"\x53\x80\xF6\x34"))
+      return 0;
 
-	for (i = 0; i<84; ++i)
-		stbi__get8(s);
+   for(i=0;i<84;++i)
+      stbi__get8(s);
 
-	if (!stbi__pic_is4(s, "PICT"))
-		return 0;
+   if (!stbi__pic_is4(s,"PICT"))
+      return 0;
 
-	return 1;
+   return 1;
 }
 
 typedef struct
 {
-	stbi_uc size, type, channel;
+   stbi_uc size,type,channel;
 } stbi__pic_packet;
 
 static stbi_uc *stbi__readval(stbi__context *s, int channel, stbi_uc *dest)
 {
-	int mask = 0x80, i;
+   int mask=0x80, i;
 
-	for (i = 0; i<4; ++i, mask >>= 1) {
-		if (channel & mask) {
-			if (stbi__at_eof(s)) return stbi__errpuc("bad file", "PIC file too short");
-			dest[i] = stbi__get8(s);
-		}
-	}
+   for (i=0; i<4; ++i, mask>>=1) {
+      if (channel & mask) {
+         if (stbi__at_eof(s)) return stbi__errpuc("bad file","PIC file too short");
+         dest[i]=stbi__get8(s);
+      }
+   }
 
-	return dest;
+   return dest;
 }
 
-static void stbi__copyval(int channel, stbi_uc *dest, const stbi_uc *src)
+static void stbi__copyval(int channel,stbi_uc *dest,const stbi_uc *src)
 {
-	int mask = 0x80, i;
+   int mask=0x80,i;
 
-	for (i = 0; i<4; ++i, mask >>= 1)
-		if (channel&mask)
-			dest[i] = src[i];
+   for (i=0;i<4; ++i, mask>>=1)
+      if (channel&mask)
+         dest[i]=src[i];
 }
 
-static stbi_uc *stbi__pic_load_core(stbi__context *s, int width, int height, int *comp, stbi_uc *result)
+static stbi_uc *stbi__pic_load_core(stbi__context *s,int width,int height,int *comp, stbi_uc *result)
 {
-	int act_comp = 0, num_packets = 0, y, chained;
-	stbi__pic_packet packets[10];
+   int act_comp=0,num_packets=0,y,chained;
+   stbi__pic_packet packets[10];
 
-	// this will (should...) cater for even some bizarre stuff like having data
-	// for the same channel in multiple packets.
-	do {
-		stbi__pic_packet *packet;
+   // this will (should...) cater for even some bizarre stuff like having data
+    // for the same channel in multiple packets.
+   do {
+      stbi__pic_packet *packet;
 
-		if (num_packets == sizeof(packets) / sizeof(packets[0]))
-			return stbi__errpuc("bad format", "too many packets");
+      if (num_packets==sizeof(packets)/sizeof(packets[0]))
+         return stbi__errpuc("bad format","too many packets");
 
-		packet = &packets[num_packets++];
+      packet = &packets[num_packets++];
 
-		chained = stbi__get8(s);
-		packet->size = stbi__get8(s);
-		packet->type = stbi__get8(s);
-		packet->channel = stbi__get8(s);
+      chained = stbi__get8(s);
+      packet->size    = stbi__get8(s);
+      packet->type    = stbi__get8(s);
+      packet->channel = stbi__get8(s);
 
-		act_comp |= packet->channel;
+      act_comp |= packet->channel;
 
-		if (stbi__at_eof(s))          return stbi__errpuc("bad file", "file too short (reading packets)");
-		if (packet->size != 8)  return stbi__errpuc("bad format", "packet isn't 8bpp");
-	} while (chained);
+      if (stbi__at_eof(s))          return stbi__errpuc("bad file","file too short (reading packets)");
+      if (packet->size != 8)  return stbi__errpuc("bad format","packet isn't 8bpp");
+   } while (chained);
 
-	*comp = (act_comp & 0x10 ? 4 : 3); // has alpha channel?
+   *comp = (act_comp & 0x10 ? 4 : 3); // has alpha channel?
 
-	for (y = 0; y<height; ++y) {
-		int packet_idx;
+   for(y=0; y<height; ++y) {
+      int packet_idx;
 
-		for (packet_idx = 0; packet_idx < num_packets; ++packet_idx) {
-			stbi__pic_packet *packet = &packets[packet_idx];
-			stbi_uc *dest = result + y*width * 4;
+      for(packet_idx=0; packet_idx < num_packets; ++packet_idx) {
+         stbi__pic_packet *packet = &packets[packet_idx];
+         stbi_uc *dest = result+y*width*4;
 
-			switch (packet->type) {
-			default:
-				return stbi__errpuc("bad format", "packet has bad compression type");
+         switch (packet->type) {
+            default:
+               return stbi__errpuc("bad format","packet has bad compression type");
 
-			case 0: {//uncompressed
-				int x;
+            case 0: {//uncompressed
+               int x;
 
-				for (x = 0; x<width; ++x, dest += 4)
-					if (!stbi__readval(s, packet->channel, dest))
-						return 0;
-				break;
-			}
+               for(x=0;x<width;++x, dest+=4)
+                  if (!stbi__readval(s,packet->channel,dest))
+                     return 0;
+               break;
+            }
 
-			case 1://Pure RLE
-			{
-				int left = width, i;
+            case 1://Pure RLE
+               {
+                  int left=width, i;
 
-				while (left>0) {
-					stbi_uc count, value[4];
+                  while (left>0) {
+                     stbi_uc count,value[4];
 
-					count = stbi__get8(s);
-					if (stbi__at_eof(s))   return stbi__errpuc("bad file", "file too short (pure read count)");
+                     count=stbi__get8(s);
+                     if (stbi__at_eof(s))   return stbi__errpuc("bad file","file too short (pure read count)");
 
-					if (count > left)
-						count = (stbi_uc)left;
+                     if (count > left)
+                        count = (stbi_uc) left;
 
-					if (!stbi__readval(s, packet->channel, value))  return 0;
+                     if (!stbi__readval(s,packet->channel,value))  return 0;
 
-					for (i = 0; i<count; ++i, dest += 4)
-						stbi__copyval(packet->channel, dest, value);
-					left -= count;
-				}
-			}
-			break;
+                     for(i=0; i<count; ++i,dest+=4)
+                        stbi__copyval(packet->channel,dest,value);
+                     left -= count;
+                  }
+               }
+               break;
 
-			case 2: {//Mixed RLE
-				int left = width;
-				while (left>0) {
-					int count = stbi__get8(s), i;
-					if (stbi__at_eof(s))  return stbi__errpuc("bad file", "file too short (mixed read count)");
+            case 2: {//Mixed RLE
+               int left=width;
+               while (left>0) {
+                  int count = stbi__get8(s), i;
+                  if (stbi__at_eof(s))  return stbi__errpuc("bad file","file too short (mixed read count)");
 
-					if (count >= 128) { // Repeated
-						stbi_uc value[4];
+                  if (count >= 128) { // Repeated
+                     stbi_uc value[4];
 
-						if (count == 128)
-							count = stbi__get16be(s);
-						else
-							count -= 127;
-						if (count > left)
-							return stbi__errpuc("bad file", "scanline overrun");
+                     if (count==128)
+                        count = stbi__get16be(s);
+                     else
+                        count -= 127;
+                     if (count > left)
+                        return stbi__errpuc("bad file","scanline overrun");
 
-						if (!stbi__readval(s, packet->channel, value))
-							return 0;
+                     if (!stbi__readval(s,packet->channel,value))
+                        return 0;
 
-						for (i = 0; i<count; ++i, dest += 4)
-							stbi__copyval(packet->channel, dest, value);
-					}
-					else { // Raw
-						++count;
-						if (count>left) return stbi__errpuc("bad file", "scanline overrun");
+                     for(i=0;i<count;++i, dest += 4)
+                        stbi__copyval(packet->channel,dest,value);
+                  } else { // Raw
+                     ++count;
+                     if (count>left) return stbi__errpuc("bad file","scanline overrun");
 
-						for (i = 0; i<count; ++i, dest += 4)
-							if (!stbi__readval(s, packet->channel, dest))
-								return 0;
-					}
-					left -= count;
-				}
-				break;
-			}
-			}
-		}
-	}
+                     for(i=0;i<count;++i, dest+=4)
+                        if (!stbi__readval(s,packet->channel,dest))
+                           return 0;
+                  }
+                  left-=count;
+               }
+               break;
+            }
+         }
+      }
+   }
 
-	return result;
+   return result;
 }
 
-static stbi_uc *stbi__pic_load(stbi__context *s, int *px, int *py, int *comp, int req_comp)
+static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_comp, stbi__result_info *ri)
 {
-	stbi_uc *result;
-	int i, x, y;
+   stbi_uc *result;
+   int i, x,y, internal_comp;
+   STBI_NOTUSED(ri);
 
-	for (i = 0; i<92; ++i)
-		stbi__get8(s);
+   if (!comp) comp = &internal_comp;
 
-	x = stbi__get16be(s);
-	y = stbi__get16be(s);
-	if (stbi__at_eof(s))  return stbi__errpuc("bad file", "file too short (pic header)");
-	if ((1 << 28) / x < y) return stbi__errpuc("too large", "Image too large to decode");
+   for (i=0; i<92; ++i)
+      stbi__get8(s);
 
-	stbi__get32be(s); //skip `ratio'
-	stbi__get16be(s); //skip `fields'
-	stbi__get16be(s); //skip `pad'
+   x = stbi__get16be(s);
+   y = stbi__get16be(s);
+   if (stbi__at_eof(s))  return stbi__errpuc("bad file","file too short (pic header)");
+   if (!stbi__mad3sizes_valid(x, y, 4, 0)) return stbi__errpuc("too large", "PIC image too large to decode");
 
-					  // intermediate buffer is RGBA
-	result = (stbi_uc *)stbi__malloc(x*y * 4);
-	memset(result, 0xff, x*y * 4);
+   stbi__get32be(s); //skip `ratio'
+   stbi__get16be(s); //skip `fields'
+   stbi__get16be(s); //skip `pad'
 
-	if (!stbi__pic_load_core(s, x, y, comp, result)) {
-		STBI_FREE(result);
-		result = 0;
-	}
-	*px = x;
-	*py = y;
-	if (req_comp == 0) req_comp = *comp;
-	result = stbi__convert_format(result, 4, req_comp, x, y);
+   // intermediate buffer is RGBA
+   result = (stbi_uc *) stbi__malloc_mad3(x, y, 4, 0);
+   memset(result, 0xff, x*y*4);
 
-	return result;
+   if (!stbi__pic_load_core(s,x,y,comp, result)) {
+      STBI_FREE(result);
+      result=0;
+   }
+   *px = x;
+   *py = y;
+   if (req_comp == 0) req_comp = *comp;
+   result=stbi__convert_format(result,4,req_comp,x,y);
+
+   return result;
 }
 
 static int stbi__pic_test(stbi__context *s)
 {
-	int r = stbi__pic_test_core(s);
-	stbi__rewind(s);
-	return r;
+   int r = stbi__pic_test_core(s);
+   stbi__rewind(s);
+   return r;
 }
 #endif
 
@@ -5641,374 +6117,477 @@ static int stbi__pic_test(stbi__context *s)
 #ifndef STBI_NO_GIF
 typedef struct
 {
-	stbi__int16 prefix;
-	stbi_uc first;
-	stbi_uc suffix;
+   stbi__int16 prefix;
+   stbi_uc first;
+   stbi_uc suffix;
 } stbi__gif_lzw;
 
 typedef struct
 {
-	int w, h;
-	stbi_uc *out, *old_out;             // output buffer (always 4 components)
-	int flags, bgindex, ratio, transparent, eflags, delay;
-	stbi_uc  pal[256][4];
-	stbi_uc lpal[256][4];
-	stbi__gif_lzw codes[4096];
-	stbi_uc *color_table;
-	int parse, step;
-	int lflags;
-	int start_x, start_y;
-	int max_x, max_y;
-	int cur_x, cur_y;
-	int line_size;
+   int w,h;
+   stbi_uc *out;                 // output buffer (always 4 components)
+   stbi_uc *background;          // The current "background" as far as a gif is concerned
+   stbi_uc *history; 
+   int flags, bgindex, ratio, transparent, eflags;
+   stbi_uc  pal[256][4];
+   stbi_uc lpal[256][4];
+   stbi__gif_lzw codes[8192];
+   stbi_uc *color_table;
+   int parse, step;
+   int lflags;
+   int start_x, start_y;
+   int max_x, max_y;
+   int cur_x, cur_y;
+   int line_size;
+   int delay;
 } stbi__gif;
 
 static int stbi__gif_test_raw(stbi__context *s)
 {
-	int sz;
-	if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8') return 0;
-	sz = stbi__get8(s);
-	if (sz != '9' && sz != '7') return 0;
-	if (stbi__get8(s) != 'a') return 0;
-	return 1;
+   int sz;
+   if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8') return 0;
+   sz = stbi__get8(s);
+   if (sz != '9' && sz != '7') return 0;
+   if (stbi__get8(s) != 'a') return 0;
+   return 1;
 }
 
 static int stbi__gif_test(stbi__context *s)
 {
-	int r = stbi__gif_test_raw(s);
-	stbi__rewind(s);
-	return r;
+   int r = stbi__gif_test_raw(s);
+   stbi__rewind(s);
+   return r;
 }
 
 static void stbi__gif_parse_colortable(stbi__context *s, stbi_uc pal[256][4], int num_entries, int transp)
 {
-	int i;
-	for (i = 0; i < num_entries; ++i) {
-		pal[i][2] = stbi__get8(s);
-		pal[i][1] = stbi__get8(s);
-		pal[i][0] = stbi__get8(s);
-		pal[i][3] = transp == i ? 0 : 255;
-	}
+   int i;
+   for (i=0; i < num_entries; ++i) {
+      pal[i][2] = stbi__get8(s);
+      pal[i][1] = stbi__get8(s);
+      pal[i][0] = stbi__get8(s);
+      pal[i][3] = transp == i ? 0 : 255;
+   }
 }
 
 static int stbi__gif_header(stbi__context *s, stbi__gif *g, int *comp, int is_info)
 {
-	stbi_uc version;
-	if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8')
-		return stbi__err("not GIF", "Corrupt GIF");
+   stbi_uc version;
+   if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8')
+      return stbi__err("not GIF", "Corrupt GIF");
 
-	version = stbi__get8(s);
-	if (version != '7' && version != '9')    return stbi__err("not GIF", "Corrupt GIF");
-	if (stbi__get8(s) != 'a')                return stbi__err("not GIF", "Corrupt GIF");
+   version = stbi__get8(s);
+   if (version != '7' && version != '9')    return stbi__err("not GIF", "Corrupt GIF");
+   if (stbi__get8(s) != 'a')                return stbi__err("not GIF", "Corrupt GIF");
 
-	stbi__g_failure_reason = "";
-	g->w = stbi__get16le(s);
-	g->h = stbi__get16le(s);
-	g->flags = stbi__get8(s);
-	g->bgindex = stbi__get8(s);
-	g->ratio = stbi__get8(s);
-	g->transparent = -1;
+   stbi__g_failure_reason = "";
+   g->w = stbi__get16le(s);
+   g->h = stbi__get16le(s);
+   g->flags = stbi__get8(s);
+   g->bgindex = stbi__get8(s);
+   g->ratio = stbi__get8(s);
+   g->transparent = -1;
 
-	if (comp != 0) *comp = 4;  // can't actually tell whether it's 3 or 4 until we parse the comments
+   if (comp != 0) *comp = 4;  // can't actually tell whether it's 3 or 4 until we parse the comments
 
-	if (is_info) return 1;
+   if (is_info) return 1;
 
-	if (g->flags & 0x80)
-		stbi__gif_parse_colortable(s, g->pal, 2 << (g->flags & 7), -1);
+   if (g->flags & 0x80)
+      stbi__gif_parse_colortable(s,g->pal, 2 << (g->flags & 7), -1);
 
-	return 1;
+   return 1;
 }
 
 static int stbi__gif_info_raw(stbi__context *s, int *x, int *y, int *comp)
 {
-	stbi__gif g;
-	if (!stbi__gif_header(s, &g, comp, 1)) {
-		stbi__rewind(s);
-		return 0;
-	}
-	if (x) *x = g.w;
-	if (y) *y = g.h;
-	return 1;
+   stbi__gif* g = (stbi__gif*) stbi__malloc(sizeof(stbi__gif));
+   if (!stbi__gif_header(s, g, comp, 1)) {
+      STBI_FREE(g);
+      stbi__rewind( s );
+      return 0;
+   }
+   if (x) *x = g->w;
+   if (y) *y = g->h;
+   STBI_FREE(g);
+   return 1;
 }
 
 static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
 {
-	stbi_uc *p, *c;
+   stbi_uc *p, *c;
+   int idx; 
 
-	// recurse to decode the prefixes, since the linked-list is backwards,
-	// and working backwards through an interleaved image would be nasty
-	if (g->codes[code].prefix >= 0)
-		stbi__out_gif_code(g, g->codes[code].prefix);
+   // recurse to decode the prefixes, since the linked-list is backwards,
+   // and working backwards through an interleaved image would be nasty
+   if (g->codes[code].prefix >= 0)
+      stbi__out_gif_code(g, g->codes[code].prefix);
 
-	if (g->cur_y >= g->max_y) return;
+   if (g->cur_y >= g->max_y) return;
 
-	p = &g->out[g->cur_x + g->cur_y];
-	c = &g->color_table[g->codes[code].suffix * 4];
+   idx = g->cur_x + g->cur_y; 
+   p = &g->out[idx];
+   g->history[idx / 4] = 1;  
 
-	if (c[3] >= 128) {
-		p[0] = c[2];
-		p[1] = c[1];
-		p[2] = c[0];
-		p[3] = c[3];
-	}
-	g->cur_x += 4;
+   c = &g->color_table[g->codes[code].suffix * 4];
+   if (c[3] > 128) { // don't render transparent pixels; 
+      p[0] = c[2];
+      p[1] = c[1];
+      p[2] = c[0];
+      p[3] = c[3];
+   }
+   g->cur_x += 4;
 
-	if (g->cur_x >= g->max_x) {
-		g->cur_x = g->start_x;
-		g->cur_y += g->step;
+   if (g->cur_x >= g->max_x) {
+      g->cur_x = g->start_x;
+      g->cur_y += g->step;
 
-		while (g->cur_y >= g->max_y && g->parse > 0) {
-			g->step = (1 << g->parse) * g->line_size;
-			g->cur_y = g->start_y + (g->step >> 1);
-			--g->parse;
-		}
-	}
+      while (g->cur_y >= g->max_y && g->parse > 0) {
+         g->step = (1 << g->parse) * g->line_size;
+         g->cur_y = g->start_y + (g->step >> 1);
+         --g->parse;
+      }
+   }
 }
 
 static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
 {
-	stbi_uc lzw_cs;
-	stbi__int32 len, init_code;
-	stbi__uint32 first;
-	stbi__int32 codesize, codemask, avail, oldcode, bits, valid_bits, clear;
-	stbi__gif_lzw *p;
+   stbi_uc lzw_cs;
+   stbi__int32 len, init_code;
+   stbi__uint32 first;
+   stbi__int32 codesize, codemask, avail, oldcode, bits, valid_bits, clear;
+   stbi__gif_lzw *p;
 
-	lzw_cs = stbi__get8(s);
-	if (lzw_cs > 12) return NULL;
-	clear = 1 << lzw_cs;
-	first = 1;
-	codesize = lzw_cs + 1;
-	codemask = (1 << codesize) - 1;
-	bits = 0;
-	valid_bits = 0;
-	for (init_code = 0; init_code < clear; init_code++) {
-		g->codes[init_code].prefix = -1;
-		g->codes[init_code].first = (stbi_uc)init_code;
-		g->codes[init_code].suffix = (stbi_uc)init_code;
-	}
+   lzw_cs = stbi__get8(s);
+   if (lzw_cs > 12) return NULL;
+   clear = 1 << lzw_cs;
+   first = 1;
+   codesize = lzw_cs + 1;
+   codemask = (1 << codesize) - 1;
+   bits = 0;
+   valid_bits = 0;
+   for (init_code = 0; init_code < clear; init_code++) {
+      g->codes[init_code].prefix = -1;
+      g->codes[init_code].first = (stbi_uc) init_code;
+      g->codes[init_code].suffix = (stbi_uc) init_code;
+   }
 
-	// support no starting clear code
-	avail = clear + 2;
-	oldcode = -1;
+   // support no starting clear code
+   avail = clear+2;
+   oldcode = -1;
 
-	len = 0;
-	for (;;) {
-		if (valid_bits < codesize) {
-			if (len == 0) {
-				len = stbi__get8(s); // start new block
-				if (len == 0)
-					return g->out;
-			}
-			--len;
-			bits |= (stbi__int32)stbi__get8(s) << valid_bits;
-			valid_bits += 8;
-		}
-		else {
-			stbi__int32 code = bits & codemask;
-			bits >>= codesize;
-			valid_bits -= codesize;
-			// @OPTIMIZE: is there some way we can accelerate the non-clear path?
-			if (code == clear) {  // clear code
-				codesize = lzw_cs + 1;
-				codemask = (1 << codesize) - 1;
-				avail = clear + 2;
-				oldcode = -1;
-				first = 0;
-			}
-			else if (code == clear + 1) { // end of stream code
-				stbi__skip(s, len);
-				while ((len = stbi__get8(s)) > 0)
-					stbi__skip(s, len);
-				return g->out;
-			}
-			else if (code <= avail) {
-				if (first) return stbi__errpuc("no clear code", "Corrupt GIF");
+   len = 0;
+   for(;;) {
+      if (valid_bits < codesize) {
+         if (len == 0) {
+            len = stbi__get8(s); // start new block
+            if (len == 0)
+               return g->out;
+         }
+         --len;
+         bits |= (stbi__int32) stbi__get8(s) << valid_bits;
+         valid_bits += 8;
+      } else {
+         stbi__int32 code = bits & codemask;
+         bits >>= codesize;
+         valid_bits -= codesize;
+         // @OPTIMIZE: is there some way we can accelerate the non-clear path?
+         if (code == clear) {  // clear code
+            codesize = lzw_cs + 1;
+            codemask = (1 << codesize) - 1;
+            avail = clear + 2;
+            oldcode = -1;
+            first = 0;
+         } else if (code == clear + 1) { // end of stream code
+            stbi__skip(s, len);
+            while ((len = stbi__get8(s)) > 0)
+               stbi__skip(s,len);
+            return g->out;
+         } else if (code <= avail) {
+            if (first) {
+               return stbi__errpuc("no clear code", "Corrupt GIF");
+            }
 
-				if (oldcode >= 0) {
-					p = &g->codes[avail++];
-					if (avail > 4096)        return stbi__errpuc("too many codes", "Corrupt GIF");
-					p->prefix = (stbi__int16)oldcode;
-					p->first = g->codes[oldcode].first;
-					p->suffix = (code == avail) ? p->first : g->codes[code].first;
-				}
-				else if (code == avail)
-					return stbi__errpuc("illegal code in raster", "Corrupt GIF");
+            if (oldcode >= 0) {
+               p = &g->codes[avail++];
+               if (avail > 8192) {
+                  return stbi__errpuc("too many codes", "Corrupt GIF");
+               }
 
-				stbi__out_gif_code(g, (stbi__uint16)code);
+               p->prefix = (stbi__int16) oldcode;
+               p->first = g->codes[oldcode].first;
+               p->suffix = (code == avail) ? p->first : g->codes[code].first;
+            } else if (code == avail)
+               return stbi__errpuc("illegal code in raster", "Corrupt GIF");
 
-				if ((avail & codemask) == 0 && avail <= 0x0FFF) {
-					codesize++;
-					codemask = (1 << codesize) - 1;
-				}
+            stbi__out_gif_code(g, (stbi__uint16) code);
 
-				oldcode = code;
-			}
-			else {
-				return stbi__errpuc("illegal code in raster", "Corrupt GIF");
-			}
-		}
-	}
-}
+            if ((avail & codemask) == 0 && avail <= 0x0FFF) {
+               codesize++;
+               codemask = (1 << codesize) - 1;
+            }
 
-static void stbi__fill_gif_background(stbi__gif *g, int x0, int y0, int x1, int y1)
-{
-	int x, y;
-	stbi_uc *c = g->pal[g->bgindex];
-	for (y = y0; y < y1; y += 4 * g->w) {
-		for (x = x0; x < x1; x += 4) {
-			stbi_uc *p = &g->out[y + x];
-			p[0] = c[2];
-			p[1] = c[1];
-			p[2] = c[0];
-			p[3] = 0;
-		}
-	}
+            oldcode = code;
+         } else {
+            return stbi__errpuc("illegal code in raster", "Corrupt GIF");
+         }
+      }
+   }
 }
 
 // this function is designed to support animated gifs, although stb_image doesn't support it
-static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp)
+// two back is the image from two frames ago, used for a very specific disposal format
+static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
 {
-	int i;
-	stbi_uc *prev_out = 0;
+   int dispose; 
+   int first_frame; 
+   int pi; 
+   int pcount; 
 
-	if (g->out == 0 && !stbi__gif_header(s, g, comp, 0))
-		return 0; // stbi__g_failure_reason set by stbi__gif_header
+   // on first frame, any non-written pixels get the background colour (non-transparent)
+   first_frame = 0; 
+   if (g->out == 0) {
+      if (!stbi__gif_header(s, g, comp,0))     return 0; // stbi__g_failure_reason set by stbi__gif_header
+      g->out = (stbi_uc *) stbi__malloc(4 * g->w * g->h);
+      g->background = (stbi_uc *) stbi__malloc(4 * g->w * g->h); 
+      g->history = (stbi_uc *) stbi__malloc(g->w * g->h); 
+      if (g->out == 0)                      return stbi__errpuc("outofmem", "Out of memory");
 
-	prev_out = g->out;
-	g->out = (stbi_uc *)stbi__malloc(4 * g->w * g->h);
-	if (g->out == 0) return stbi__errpuc("outofmem", "Out of memory");
+      // image is treated as "tranparent" at the start - ie, nothing overwrites the current background; 
+      // background colour is only used for pixels that are not rendered first frame, after that "background"
+      // color refers to teh color that was there the previous frame. 
+      memset( g->out, 0x00, 4 * g->w * g->h ); 
+      memset( g->background, 0x00, 4 * g->w * g->h ); // state of the background (starts transparent)
+      memset( g->history, 0x00, g->w * g->h );        // pixels that were affected previous frame
+      first_frame = 1; 
+   } else {
+      // second frame - how do we dispoase of the previous one?
+      dispose = (g->eflags & 0x1C) >> 2; 
+      pcount = g->w * g->h; 
 
-	switch ((g->eflags & 0x1C) >> 2) {
-	case 0: // unspecified (also always used on 1st frame)
-		stbi__fill_gif_background(g, 0, 0, 4 * g->w, 4 * g->w * g->h);
-		break;
-	case 1: // do not dispose
-		if (prev_out) memcpy(g->out, prev_out, 4 * g->w * g->h);
-		g->old_out = prev_out;
-		break;
-	case 2: // dispose to background
-		if (prev_out) memcpy(g->out, prev_out, 4 * g->w * g->h);
-		stbi__fill_gif_background(g, g->start_x, g->start_y, g->max_x, g->max_y);
-		break;
-	case 3: // dispose to previous
-		if (g->old_out) {
-			for (i = g->start_y; i < g->max_y; i += 4 * g->w)
-				memcpy(&g->out[i + g->start_x], &g->old_out[i + g->start_x], g->max_x - g->start_x);
-		}
-		break;
-	}
+      if ((dispose == 3) && (two_back == 0)) {
+         dispose = 2; // if I don't have an image to revert back to, default to the old background
+      }
 
-	for (;;) {
-		switch (stbi__get8(s)) {
-		case 0x2C: /* Image Descriptor */
-		{
-			int prev_trans = -1;
-			stbi__int32 x, y, w, h;
-			stbi_uc *o;
+      if (dispose == 3) { // use previous graphic
+         for (pi = 0; pi < pcount; ++pi) {
+            if (g->history[pi]) {
+               memcpy( &g->out[pi * 4], &two_back[pi * 4], 4 ); 
+            }
+         }
+      } else if (dispose == 2) { 
+         // restore what was changed last frame to background before that frame; 
+         for (pi = 0; pi < pcount; ++pi) {
+            if (g->history[pi]) {
+               memcpy( &g->out[pi * 4], &g->background[pi * 4], 4 ); 
+            }
+         }
+      } else {
+         // This is a non-disposal case eithe way, so just 
+         // leave the pixels as is, and they will become the new background
+         // 1: do not dispose
+         // 0:  not specified.
+      }
 
-			x = stbi__get16le(s);
-			y = stbi__get16le(s);
-			w = stbi__get16le(s);
-			h = stbi__get16le(s);
-			if (((x + w) > (g->w)) || ((y + h) > (g->h)))
-				return stbi__errpuc("bad Image Descriptor", "Corrupt GIF");
+      // background is what out is after the undoing of the previou frame; 
+      memcpy( g->background, g->out, 4 * g->w * g->h ); 
+   }
 
-			g->line_size = g->w * 4;
-			g->start_x = x * 4;
-			g->start_y = y * g->line_size;
-			g->max_x = g->start_x + w * 4;
-			g->max_y = g->start_y + h * g->line_size;
-			g->cur_x = g->start_x;
-			g->cur_y = g->start_y;
+   // clear my history; 
+   memset( g->history, 0x00, g->w * g->h );        // pixels that were affected previous frame
 
-			g->lflags = stbi__get8(s);
+   for (;;) {
+      int tag = stbi__get8(s); 
+      switch (tag) {
+         case 0x2C: /* Image Descriptor */
+         {
+            stbi__int32 x, y, w, h;
+            stbi_uc *o;
 
-			if (g->lflags & 0x40) {
-				g->step = 8 * g->line_size; // first interlaced spacing
-				g->parse = 3;
-			}
-			else {
-				g->step = g->line_size;
-				g->parse = 0;
-			}
+            x = stbi__get16le(s);
+            y = stbi__get16le(s);
+            w = stbi__get16le(s);
+            h = stbi__get16le(s);
+            if (((x + w) > (g->w)) || ((y + h) > (g->h)))
+               return stbi__errpuc("bad Image Descriptor", "Corrupt GIF");
 
-			if (g->lflags & 0x80) {
-				stbi__gif_parse_colortable(s, g->lpal, 2 << (g->lflags & 7), g->eflags & 0x01 ? g->transparent : -1);
-				g->color_table = (stbi_uc *)g->lpal;
-			}
-			else if (g->flags & 0x80) {
-				if (g->transparent >= 0 && (g->eflags & 0x01)) {
-					prev_trans = g->pal[g->transparent][3];
-					g->pal[g->transparent][3] = 0;
-				}
-				g->color_table = (stbi_uc *)g->pal;
-			}
-			else
-				return stbi__errpuc("missing color table", "Corrupt GIF");
+            g->line_size = g->w * 4;
+            g->start_x = x * 4;
+            g->start_y = y * g->line_size;
+            g->max_x   = g->start_x + w * 4;
+            g->max_y   = g->start_y + h * g->line_size;
+            g->cur_x   = g->start_x;
+            g->cur_y   = g->start_y;
 
-			o = stbi__process_gif_raster(s, g);
-			if (o == NULL) return NULL;
+            g->lflags = stbi__get8(s);
 
-			if (prev_trans != -1)
-				g->pal[g->transparent][3] = (stbi_uc)prev_trans;
+            if (g->lflags & 0x40) {
+               g->step = 8 * g->line_size; // first interlaced spacing
+               g->parse = 3;
+            } else {
+               g->step = g->line_size;
+               g->parse = 0;
+            }
 
-			return o;
-		}
+            if (g->lflags & 0x80) {
+               stbi__gif_parse_colortable(s,g->lpal, 2 << (g->lflags & 7), g->eflags & 0x01 ? g->transparent : -1);
+               g->color_table = (stbi_uc *) g->lpal;
+            } else if (g->flags & 0x80) {
+               g->color_table = (stbi_uc *) g->pal;
+            } else
+               return stbi__errpuc("missing color table", "Corrupt GIF");            
+            
+            o = stbi__process_gif_raster(s, g);
+            if (o == NULL) return NULL;
 
-		case 0x21: // Comment Extension.
-		{
-			int len;
-			if (stbi__get8(s) == 0xF9) { // Graphic Control Extension.
-				len = stbi__get8(s);
-				if (len == 4) {
-					g->eflags = stbi__get8(s);
-					g->delay = stbi__get16le(s);
-					g->transparent = stbi__get8(s);
-				}
-				else {
-					stbi__skip(s, len);
-					break;
-				}
-			}
-			while ((len = stbi__get8(s)) != 0)
-				stbi__skip(s, len);
-			break;
-		}
+            // if this was the first frame, 
+            pcount = g->w * g->h; 
+            if (first_frame && (g->bgindex > 0)) {
+               // if first frame, any pixel not drawn to gets the background color
+               for (pi = 0; pi < pcount; ++pi) {
+                  if (g->history[pi] == 0) {
+                     g->pal[g->bgindex][3] = 255; // just in case it was made transparent, undo that; It will be reset next frame if need be; 
+                     memcpy( &g->out[pi * 4], &g->pal[g->bgindex], 4 ); 
+                  }
+               }
+            }
 
-		case 0x3B: // gif stream termination code
-			return (stbi_uc *)s; // using '1' causes warning on some compilers
+            return o;
+         }
 
-		default:
-			return stbi__errpuc("unknown code", "Corrupt GIF");
-		}
-	}
+         case 0x21: // Comment Extension.
+         {
+            int len;
+            int ext = stbi__get8(s); 
+            if (ext == 0xF9) { // Graphic Control Extension.
+               len = stbi__get8(s);
+               if (len == 4) {
+                  g->eflags = stbi__get8(s);
+                  g->delay = 10 * stbi__get16le(s); // delay - 1/100th of a second, saving as 1/1000ths.
 
-	STBI_NOTUSED(req_comp);
+                  // unset old transparent
+                  if (g->transparent >= 0) {
+                     g->pal[g->transparent][3] = 255; 
+                  } 
+                  if (g->eflags & 0x01) {
+                     g->transparent = stbi__get8(s);
+                     if (g->transparent >= 0) {
+                        g->pal[g->transparent][3] = 0; 
+                     }
+                  } else {
+                     // don't need transparent
+                     stbi__skip(s, 1); 
+                     g->transparent = -1; 
+                  }
+               } else {
+                  stbi__skip(s, len);
+                  break;
+               }
+            } 
+            while ((len = stbi__get8(s)) != 0) {
+               stbi__skip(s, len);
+            }
+            break;
+         }
+
+         case 0x3B: // gif stream termination code
+            return (stbi_uc *) s; // using '1' causes warning on some compilers
+
+         default:
+            return stbi__errpuc("unknown code", "Corrupt GIF");
+      }
+   }
 }
 
-static stbi_uc *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
 {
-	stbi_uc *u = 0;
-	stbi__gif g;
-	memset(&g, 0, sizeof(g));
+   if (stbi__gif_test(s)) {
+      int layers = 0; 
+      stbi_uc *u = 0;
+      stbi_uc *out = 0;
+      stbi_uc *two_back = 0; 
+      stbi__gif g;
+      int stride; 
+      memset(&g, 0, sizeof(g));
+      if (delays) {
+         *delays = 0; 
+      }
 
-	u = stbi__gif_load_next(s, &g, comp, req_comp);
-	if (u == (stbi_uc *)s) u = 0;  // end of animated gif marker
-	if (u) {
-		*x = g.w;
-		*y = g.h;
-		if (req_comp && req_comp != 4)
-			u = stbi__convert_format(u, 4, req_comp, g.w, g.h);
-	}
-	else if (g.out)
-		STBI_FREE(g.out);
+      do {
+         u = stbi__gif_load_next(s, &g, comp, req_comp, two_back);
+         if (u == (stbi_uc *) s) u = 0;  // end of animated gif marker
 
-	return u;
+         if (u) {
+            *x = g.w;
+            *y = g.h;
+            ++layers; 
+            stride = g.w * g.h * 4; 
+         
+            if (out) {
+               out = (stbi_uc*) STBI_REALLOC( out, layers * stride ); 
+               if (delays) {
+                  *delays = (int*) STBI_REALLOC( *delays, sizeof(int) * layers ); 
+               }
+            } else {
+               out = (stbi_uc*)stbi__malloc( layers * stride ); 
+               if (delays) {
+                  *delays = (int*) stbi__malloc( layers * sizeof(int) ); 
+               }
+            }
+            memcpy( out + ((layers - 1) * stride), u, stride ); 
+            if (layers >= 2) {
+               two_back = out - 2 * stride; 
+            }
+
+            if (delays) {
+               (*delays)[layers - 1U] = g.delay; 
+            }
+         }
+      } while (u != 0); 
+
+      // free temp buffer; 
+      STBI_FREE(g.out); 
+      STBI_FREE(g.history); 
+      STBI_FREE(g.background); 
+
+      // do the final conversion after loading everything; 
+      if (req_comp && req_comp != 4)
+         out = stbi__convert_format(out, 4, req_comp, layers * g.w, g.h);
+
+      *z = layers; 
+      return out;
+   } else {
+      return stbi__errpuc("not GIF", "Image was not as a gif type."); 
+   }
+}
+
+static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *u = 0;
+   stbi__gif g;
+   memset(&g, 0, sizeof(g));
+
+   u = stbi__gif_load_next(s, &g, comp, req_comp, 0);
+   if (u == (stbi_uc *) s) u = 0;  // end of animated gif marker
+   if (u) {
+      *x = g.w;
+      *y = g.h;
+
+      // moved conversion to after successful load so that the same
+      // can be done for multiple frames. 
+      if (req_comp && req_comp != 4)
+         u = stbi__convert_format(u, 4, req_comp, g.w, g.h);
+   }
+
+   // free buffers needed for multiple frame loading; 
+   STBI_FREE(g.history);
+   STBI_FREE(g.background); 
+
+   return u;
 }
 
 static int stbi__gif_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	return stbi__gif_info_raw(s, x, y, comp);
+   return stbi__gif_info_raw(s,x,y,comp);
 }
 #endif
 
@@ -6016,330 +6595,388 @@ static int stbi__gif_info(stbi__context *s, int *x, int *y, int *comp)
 // Radiance RGBE HDR loader
 // originally by Nicolas Schulz
 #ifndef STBI_NO_HDR
-static int stbi__hdr_test_core(stbi__context *s)
+static int stbi__hdr_test_core(stbi__context *s, const char *signature)
 {
-	const char *signature = "#?RADIANCE\n";
-	int i;
-	for (i = 0; signature[i]; ++i)
-		if (stbi__get8(s) != signature[i])
-			return 0;
-	return 1;
+   int i;
+   for (i=0; signature[i]; ++i)
+      if (stbi__get8(s) != signature[i])
+          return 0;
+   stbi__rewind(s);
+   return 1;
 }
 
 static int stbi__hdr_test(stbi__context* s)
 {
-	int r = stbi__hdr_test_core(s);
-	stbi__rewind(s);
-	return r;
+   int r = stbi__hdr_test_core(s, "#?RADIANCE\n");
+   stbi__rewind(s);
+   if(!r) {
+       r = stbi__hdr_test_core(s, "#?RGBE\n");
+       stbi__rewind(s);
+   }
+   return r;
 }
 
 #define STBI__HDR_BUFLEN  1024
 static char *stbi__hdr_gettoken(stbi__context *z, char *buffer)
 {
-	int len = 0;
-	char c = '\0';
+   int len=0;
+   char c = '\0';
 
-	c = (char)stbi__get8(z);
+   c = (char) stbi__get8(z);
 
-	while (!stbi__at_eof(z) && c != '\n') {
-		buffer[len++] = c;
-		if (len == STBI__HDR_BUFLEN - 1) {
-			// flush to end of line
-			while (!stbi__at_eof(z) && stbi__get8(z) != '\n')
-				;
-			break;
-		}
-		c = (char)stbi__get8(z);
-	}
+   while (!stbi__at_eof(z) && c != '\n') {
+      buffer[len++] = c;
+      if (len == STBI__HDR_BUFLEN-1) {
+         // flush to end of line
+         while (!stbi__at_eof(z) && stbi__get8(z) != '\n')
+            ;
+         break;
+      }
+      c = (char) stbi__get8(z);
+   }
 
-	buffer[len] = 0;
-	return buffer;
+   buffer[len] = 0;
+   return buffer;
 }
 
 static void stbi__hdr_convert(float *output, stbi_uc *input, int req_comp)
 {
-	if (input[3] != 0) {
-		float f1;
-		// Exponent
-		f1 = (float)ldexp(1.0f, input[3] - (int)(128 + 8));
-		if (req_comp <= 2)
-			output[0] = (input[0] + input[1] + input[2]) * f1 / 3;
-		else {
-			output[0] = input[0] * f1;
-			output[1] = input[1] * f1;
-			output[2] = input[2] * f1;
-		}
-		if (req_comp == 2) output[1] = 1;
-		if (req_comp == 4) output[3] = 1;
-	}
-	else {
-		switch (req_comp) {
-		case 4: output[3] = 1; /* fallthrough */
-		case 3: output[0] = output[1] = output[2] = 0;
-			break;
-		case 2: output[1] = 1; /* fallthrough */
-		case 1: output[0] = 0;
-			break;
-		}
-	}
+   if ( input[3] != 0 ) {
+      float f1;
+      // Exponent
+      f1 = (float) ldexp(1.0f, input[3] - (int)(128 + 8));
+      if (req_comp <= 2)
+         output[0] = (input[0] + input[1] + input[2]) * f1 / 3;
+      else {
+         output[0] = input[0] * f1;
+         output[1] = input[1] * f1;
+         output[2] = input[2] * f1;
+      }
+      if (req_comp == 2) output[1] = 1;
+      if (req_comp == 4) output[3] = 1;
+   } else {
+      switch (req_comp) {
+         case 4: output[3] = 1; /* fallthrough */
+         case 3: output[0] = output[1] = output[2] = 0;
+                 break;
+         case 2: output[1] = 1; /* fallthrough */
+         case 1: output[0] = 0;
+                 break;
+      }
+   }
 }
 
-static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
-	char buffer[STBI__HDR_BUFLEN];
-	char *token;
-	int valid = 0;
-	int width, height;
-	stbi_uc *scanline;
-	float *hdr_data;
-	int len;
-	unsigned char count, value;
-	int i, j, k, c1, c2, z;
+   char buffer[STBI__HDR_BUFLEN];
+   char *token;
+   int valid = 0;
+   int width, height;
+   stbi_uc *scanline;
+   float *hdr_data;
+   int len;
+   unsigned char count, value;
+   int i, j, k, c1,c2, z;
+   const char *headerToken;
+   STBI_NOTUSED(ri);
 
+   // Check identifier
+   headerToken = stbi__hdr_gettoken(s,buffer);
+   if (strcmp(headerToken, "#?RADIANCE") != 0 && strcmp(headerToken, "#?RGBE") != 0)
+      return stbi__errpf("not HDR", "Corrupt HDR image");
 
-	// Check identifier
-	if (strcmp(stbi__hdr_gettoken(s, buffer), "#?RADIANCE") != 0)
-		return stbi__errpf("not HDR", "Corrupt HDR image");
+   // Parse header
+   for(;;) {
+      token = stbi__hdr_gettoken(s,buffer);
+      if (token[0] == 0) break;
+      if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
+   }
 
-	// Parse header
-	for (;;) {
-		token = stbi__hdr_gettoken(s, buffer);
-		if (token[0] == 0) break;
-		if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
-	}
+   if (!valid)    return stbi__errpf("unsupported format", "Unsupported HDR format");
 
-	if (!valid)    return stbi__errpf("unsupported format", "Unsupported HDR format");
+   // Parse width and height
+   // can't use sscanf() if we're not using stdio!
+   token = stbi__hdr_gettoken(s,buffer);
+   if (strncmp(token, "-Y ", 3))  return stbi__errpf("unsupported data layout", "Unsupported HDR format");
+   token += 3;
+   height = (int) strtol(token, &token, 10);
+   while (*token == ' ') ++token;
+   if (strncmp(token, "+X ", 3))  return stbi__errpf("unsupported data layout", "Unsupported HDR format");
+   token += 3;
+   width = (int) strtol(token, NULL, 10);
 
-	// Parse width and height
-	// can't use sscanf() if we're not using stdio!
-	token = stbi__hdr_gettoken(s, buffer);
-	if (strncmp(token, "-Y ", 3))  return stbi__errpf("unsupported data layout", "Unsupported HDR format");
-	token += 3;
-	height = (int)strtol(token, &token, 10);
-	while (*token == ' ') ++token;
-	if (strncmp(token, "+X ", 3))  return stbi__errpf("unsupported data layout", "Unsupported HDR format");
-	token += 3;
-	width = (int)strtol(token, NULL, 10);
+   *x = width;
+   *y = height;
 
-	*x = width;
-	*y = height;
+   if (comp) *comp = 3;
+   if (req_comp == 0) req_comp = 3;
 
-	if (comp) *comp = 3;
-	if (req_comp == 0) req_comp = 3;
+   if (!stbi__mad4sizes_valid(width, height, req_comp, sizeof(float), 0))
+      return stbi__errpf("too large", "HDR image is too large");
 
-	// Read data
-	hdr_data = (float *)stbi__malloc(height * width * req_comp * sizeof(float));
+   // Read data
+   hdr_data = (float *) stbi__malloc_mad4(width, height, req_comp, sizeof(float), 0);
+   if (!hdr_data)
+      return stbi__errpf("outofmem", "Out of memory");
 
-	// Load image data
-	// image data is stored as some number of sca
-	if (width < 8 || width >= 32768) {
-		// Read flat data
-		for (j = 0; j < height; ++j) {
-			for (i = 0; i < width; ++i) {
-				stbi_uc rgbe[4];
-			main_decode_loop:
-				stbi__getn(s, rgbe, 4);
-				stbi__hdr_convert(hdr_data + j * width * req_comp + i * req_comp, rgbe, req_comp);
-			}
-		}
-	}
-	else {
-		// Read RLE-encoded data
-		scanline = NULL;
+   // Load image data
+   // image data is stored as some number of sca
+   if ( width < 8 || width >= 32768) {
+      // Read flat data
+      for (j=0; j < height; ++j) {
+         for (i=0; i < width; ++i) {
+            stbi_uc rgbe[4];
+           main_decode_loop:
+            stbi__getn(s, rgbe, 4);
+            stbi__hdr_convert(hdr_data + j * width * req_comp + i * req_comp, rgbe, req_comp);
+         }
+      }
+   } else {
+      // Read RLE-encoded data
+      scanline = NULL;
 
-		for (j = 0; j < height; ++j) {
-			c1 = stbi__get8(s);
-			c2 = stbi__get8(s);
-			len = stbi__get8(s);
-			if (c1 != 2 || c2 != 2 || (len & 0x80)) {
-				// not run-length encoded, so we have to actually use THIS data as a decoded
-				// pixel (note this can't be a valid pixel--one of RGB must be >= 128)
-				stbi_uc rgbe[4];
-				rgbe[0] = (stbi_uc)c1;
-				rgbe[1] = (stbi_uc)c2;
-				rgbe[2] = (stbi_uc)len;
-				rgbe[3] = (stbi_uc)stbi__get8(s);
-				stbi__hdr_convert(hdr_data, rgbe, req_comp);
-				i = 1;
-				j = 0;
-				STBI_FREE(scanline);
-				goto main_decode_loop; // yes, this makes no sense
-			}
-			len <<= 8;
-			len |= stbi__get8(s);
-			if (len != width) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("invalid decoded scanline length", "corrupt HDR"); }
-			if (scanline == NULL) scanline = (stbi_uc *)stbi__malloc(width * 4);
+      for (j = 0; j < height; ++j) {
+         c1 = stbi__get8(s);
+         c2 = stbi__get8(s);
+         len = stbi__get8(s);
+         if (c1 != 2 || c2 != 2 || (len & 0x80)) {
+            // not run-length encoded, so we have to actually use THIS data as a decoded
+            // pixel (note this can't be a valid pixel--one of RGB must be >= 128)
+            stbi_uc rgbe[4];
+            rgbe[0] = (stbi_uc) c1;
+            rgbe[1] = (stbi_uc) c2;
+            rgbe[2] = (stbi_uc) len;
+            rgbe[3] = (stbi_uc) stbi__get8(s);
+            stbi__hdr_convert(hdr_data, rgbe, req_comp);
+            i = 1;
+            j = 0;
+            STBI_FREE(scanline);
+            goto main_decode_loop; // yes, this makes no sense
+         }
+         len <<= 8;
+         len |= stbi__get8(s);
+         if (len != width) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("invalid decoded scanline length", "corrupt HDR"); }
+         if (scanline == NULL) {
+            scanline = (stbi_uc *) stbi__malloc_mad2(width, 4, 0);
+            if (!scanline) {
+               STBI_FREE(hdr_data);
+               return stbi__errpf("outofmem", "Out of memory");
+            }
+         }
 
-			for (k = 0; k < 4; ++k) {
-				i = 0;
-				while (i < width) {
-					count = stbi__get8(s);
-					if (count > 128) {
-						// Run
-						value = stbi__get8(s);
-						count -= 128;
-						for (z = 0; z < count; ++z)
-							scanline[i++ * 4 + k] = value;
-					}
-					else {
-						// Dump
-						for (z = 0; z < count; ++z)
-							scanline[i++ * 4 + k] = stbi__get8(s);
-					}
-				}
-			}
-			for (i = 0; i < width; ++i)
-				stbi__hdr_convert(hdr_data + (j*width + i)*req_comp, scanline + i * 4, req_comp);
-		}
-		STBI_FREE(scanline);
-	}
+         for (k = 0; k < 4; ++k) {
+            int nleft;
+            i = 0;
+            while ((nleft = width - i) > 0) {
+               count = stbi__get8(s);
+               if (count > 128) {
+                  // Run
+                  value = stbi__get8(s);
+                  count -= 128;
+                  if (count > nleft) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("corrupt", "bad RLE data in HDR"); }
+                  for (z = 0; z < count; ++z)
+                     scanline[i++ * 4 + k] = value;
+               } else {
+                  // Dump
+                  if (count > nleft) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("corrupt", "bad RLE data in HDR"); }
+                  for (z = 0; z < count; ++z)
+                     scanline[i++ * 4 + k] = stbi__get8(s);
+               }
+            }
+         }
+         for (i=0; i < width; ++i)
+            stbi__hdr_convert(hdr_data+(j*width + i)*req_comp, scanline + i*4, req_comp);
+      }
+      if (scanline)
+         STBI_FREE(scanline);
+   }
 
-	return hdr_data;
+   return hdr_data;
 }
 
 static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	char buffer[STBI__HDR_BUFLEN];
-	char *token;
-	int valid = 0;
+   char buffer[STBI__HDR_BUFLEN];
+   char *token;
+   int valid = 0;
+   int dummy;
 
-	if (stbi__hdr_test(s) == 0) {
-		stbi__rewind(s);
-		return 0;
-	}
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
 
-	for (;;) {
-		token = stbi__hdr_gettoken(s, buffer);
-		if (token[0] == 0) break;
-		if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
-	}
+   if (stbi__hdr_test(s) == 0) {
+       stbi__rewind( s );
+       return 0;
+   }
 
-	if (!valid) {
-		stbi__rewind(s);
-		return 0;
-	}
-	token = stbi__hdr_gettoken(s, buffer);
-	if (strncmp(token, "-Y ", 3)) {
-		stbi__rewind(s);
-		return 0;
-	}
-	token += 3;
-	*y = (int)strtol(token, &token, 10);
-	while (*token == ' ') ++token;
-	if (strncmp(token, "+X ", 3)) {
-		stbi__rewind(s);
-		return 0;
-	}
-	token += 3;
-	*x = (int)strtol(token, NULL, 10);
-	*comp = 3;
-	return 1;
+   for(;;) {
+      token = stbi__hdr_gettoken(s,buffer);
+      if (token[0] == 0) break;
+      if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
+   }
+
+   if (!valid) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token = stbi__hdr_gettoken(s,buffer);
+   if (strncmp(token, "-Y ", 3)) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token += 3;
+   *y = (int) strtol(token, &token, 10);
+   while (*token == ' ') ++token;
+   if (strncmp(token, "+X ", 3)) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token += 3;
+   *x = (int) strtol(token, NULL, 10);
+   *comp = 3;
+   return 1;
 }
 #endif // STBI_NO_HDR
 
 #ifndef STBI_NO_BMP
 static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	void *p;
-	stbi__bmp_data info;
+   void *p;
+   stbi__bmp_data info;
 
-	info.all_a = 255;
-	p = stbi__bmp_parse_header(s, &info);
-	stbi__rewind(s);
-	if (p == NULL)
-		return 0;
-	*x = s->img_x;
-	*y = s->img_y;
-	*comp = info.ma ? 4 : 3;
-	return 1;
+   info.all_a = 255;
+   p = stbi__bmp_parse_header(s, &info);
+   stbi__rewind( s );
+   if (p == NULL)
+      return 0;
+   if (x) *x = s->img_x;
+   if (y) *y = s->img_y;
+   if (comp) *comp = info.ma ? 4 : 3;
+   return 1;
 }
 #endif
 
 #ifndef STBI_NO_PSD
 static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	int channelCount;
-	if (stbi__get32be(s) != 0x38425053) {
-		stbi__rewind(s);
-		return 0;
-	}
-	if (stbi__get16be(s) != 1) {
-		stbi__rewind(s);
-		return 0;
-	}
-	stbi__skip(s, 6);
-	channelCount = stbi__get16be(s);
-	if (channelCount < 0 || channelCount > 16) {
-		stbi__rewind(s);
-		return 0;
-	}
-	*y = stbi__get32be(s);
-	*x = stbi__get32be(s);
-	if (stbi__get16be(s) != 8) {
-		stbi__rewind(s);
-		return 0;
-	}
-	if (stbi__get16be(s) != 3) {
-		stbi__rewind(s);
-		return 0;
-	}
-	*comp = 4;
-	return 1;
+   int channelCount, dummy, depth;
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+   if (stbi__get32be(s) != 0x38425053) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 1) {
+       stbi__rewind( s );
+       return 0;
+   }
+   stbi__skip(s, 6);
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   *y = stbi__get32be(s);
+   *x = stbi__get32be(s);
+   depth = stbi__get16be(s);
+   if (depth != 8 && depth != 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 3) {
+       stbi__rewind( s );
+       return 0;
+   }
+   *comp = 4;
+   return 1;
+}
+
+static int stbi__psd_is16(stbi__context *s)
+{
+   int channelCount, depth;
+   if (stbi__get32be(s) != 0x38425053) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 1) {
+       stbi__rewind( s );
+       return 0;
+   }
+   stbi__skip(s, 6);
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   (void) stbi__get32be(s);
+   (void) stbi__get32be(s);
+   depth = stbi__get16be(s);
+   if (depth != 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   return 1;
 }
 #endif
 
 #ifndef STBI_NO_PIC
 static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	int act_comp = 0, num_packets = 0, chained;
-	stbi__pic_packet packets[10];
+   int act_comp=0,num_packets=0,chained,dummy;
+   stbi__pic_packet packets[10];
 
-	if (!stbi__pic_is4(s, "\x53\x80\xF6\x34")) {
-		stbi__rewind(s);
-		return 0;
-	}
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
 
-	stbi__skip(s, 88);
+   if (!stbi__pic_is4(s,"\x53\x80\xF6\x34")) {
+      stbi__rewind(s);
+      return 0;
+   }
 
-	*x = stbi__get16be(s);
-	*y = stbi__get16be(s);
-	if (stbi__at_eof(s)) {
-		stbi__rewind(s);
-		return 0;
-	}
-	if ((*x) != 0 && (1 << 28) / (*x) < (*y)) {
-		stbi__rewind(s);
-		return 0;
-	}
+   stbi__skip(s, 88);
 
-	stbi__skip(s, 8);
+   *x = stbi__get16be(s);
+   *y = stbi__get16be(s);
+   if (stbi__at_eof(s)) {
+      stbi__rewind( s);
+      return 0;
+   }
+   if ( (*x) != 0 && (1 << 28) / (*x) < (*y)) {
+      stbi__rewind( s );
+      return 0;
+   }
 
-	do {
-		stbi__pic_packet *packet;
+   stbi__skip(s, 8);
 
-		if (num_packets == sizeof(packets) / sizeof(packets[0]))
-			return 0;
+   do {
+      stbi__pic_packet *packet;
 
-		packet = &packets[num_packets++];
-		chained = stbi__get8(s);
-		packet->size = stbi__get8(s);
-		packet->type = stbi__get8(s);
-		packet->channel = stbi__get8(s);
-		act_comp |= packet->channel;
+      if (num_packets==sizeof(packets)/sizeof(packets[0]))
+         return 0;
 
-		if (stbi__at_eof(s)) {
-			stbi__rewind(s);
-			return 0;
-		}
-		if (packet->size != 8) {
-			stbi__rewind(s);
-			return 0;
-		}
-	} while (chained);
+      packet = &packets[num_packets++];
+      chained = stbi__get8(s);
+      packet->size    = stbi__get8(s);
+      packet->type    = stbi__get8(s);
+      packet->channel = stbi__get8(s);
+      act_comp |= packet->channel;
 
-	*comp = (act_comp & 0x10 ? 4 : 3);
+      if (stbi__at_eof(s)) {
+          stbi__rewind( s );
+          return 0;
+      }
+      if (packet->size != 8) {
+          stbi__rewind( s );
+          return 0;
+      }
+   } while (chained);
 
-	return 1;
+   *comp = (act_comp & 0x10 ? 4 : 3);
+
+   return 1;
 }
 #endif
 
@@ -6359,340 +6996,467 @@ static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
 
 static int      stbi__pnm_test(stbi__context *s)
 {
-	char p, t;
-	p = (char)stbi__get8(s);
-	t = (char)stbi__get8(s);
-	if (p != 'P' || (t != '5' && t != '6')) {
-		stbi__rewind(s);
-		return 0;
-	}
-	return 1;
+   char p, t;
+   p = (char) stbi__get8(s);
+   t = (char) stbi__get8(s);
+   if (p != 'P' || (t != '5' && t != '6')) {
+       stbi__rewind( s );
+       return 0;
+   }
+   return 1;
 }
 
-static stbi_uc *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
-	stbi_uc *out;
-	if (!stbi__pnm_info(s, (int *)&s->img_x, (int *)&s->img_y, (int *)&s->img_n))
-		return 0;
-	*x = s->img_x;
-	*y = s->img_y;
-	*comp = s->img_n;
+   stbi_uc *out;
+   STBI_NOTUSED(ri);
 
-	out = (stbi_uc *)stbi__malloc(s->img_n * s->img_x * s->img_y);
-	if (!out) return stbi__errpuc("outofmem", "Out of memory");
-	stbi__getn(s, out, s->img_n * s->img_x * s->img_y);
+   if (!stbi__pnm_info(s, (int *)&s->img_x, (int *)&s->img_y, (int *)&s->img_n))
+      return 0;
 
-	if (req_comp && req_comp != s->img_n) {
-		out = stbi__convert_format(out, s->img_n, req_comp, s->img_x, s->img_y);
-		if (out == NULL) return out; // stbi__convert_format frees input on failure
-	}
-	return out;
+   *x = s->img_x;
+   *y = s->img_y;
+   if (comp) *comp = s->img_n;
+
+   if (!stbi__mad3sizes_valid(s->img_n, s->img_x, s->img_y, 0))
+      return stbi__errpuc("too large", "PNM too large");
+
+   out = (stbi_uc *) stbi__malloc_mad3(s->img_n, s->img_x, s->img_y, 0);
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   stbi__getn(s, out, s->img_n * s->img_x * s->img_y);
+
+   if (req_comp && req_comp != s->img_n) {
+      out = stbi__convert_format(out, s->img_n, req_comp, s->img_x, s->img_y);
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+   return out;
 }
 
 static int      stbi__pnm_isspace(char c)
 {
-	return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
+   return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
 }
 
 static void     stbi__pnm_skip_whitespace(stbi__context *s, char *c)
 {
-	for (;;) {
-		while (!stbi__at_eof(s) && stbi__pnm_isspace(*c))
-			*c = (char)stbi__get8(s);
+   for (;;) {
+      while (!stbi__at_eof(s) && stbi__pnm_isspace(*c))
+         *c = (char) stbi__get8(s);
 
-		if (stbi__at_eof(s) || *c != '#')
-			break;
+      if (stbi__at_eof(s) || *c != '#')
+         break;
 
-		while (!stbi__at_eof(s) && *c != '\n' && *c != '\r')
-			*c = (char)stbi__get8(s);
-	}
+      while (!stbi__at_eof(s) && *c != '\n' && *c != '\r' )
+         *c = (char) stbi__get8(s);
+   }
 }
 
 static int      stbi__pnm_isdigit(char c)
 {
-	return c >= '0' && c <= '9';
+   return c >= '0' && c <= '9';
 }
 
 static int      stbi__pnm_getinteger(stbi__context *s, char *c)
 {
-	int value = 0;
+   int value = 0;
 
-	while (!stbi__at_eof(s) && stbi__pnm_isdigit(*c)) {
-		value = value * 10 + (*c - '0');
-		*c = (char)stbi__get8(s);
-	}
+   while (!stbi__at_eof(s) && stbi__pnm_isdigit(*c)) {
+      value = value*10 + (*c - '0');
+      *c = (char) stbi__get8(s);
+   }
 
-	return value;
+   return value;
 }
 
 static int      stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp)
 {
-	int maxv;
-	char c, p, t;
+   int maxv, dummy;
+   char c, p, t;
 
-	stbi__rewind(s);
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
 
-	// Get identifier
-	p = (char)stbi__get8(s);
-	t = (char)stbi__get8(s);
-	if (p != 'P' || (t != '5' && t != '6')) {
-		stbi__rewind(s);
-		return 0;
-	}
+   stbi__rewind(s);
 
-	*comp = (t == '6') ? 3 : 1;  // '5' is 1-component .pgm; '6' is 3-component .ppm
+   // Get identifier
+   p = (char) stbi__get8(s);
+   t = (char) stbi__get8(s);
+   if (p != 'P' || (t != '5' && t != '6')) {
+       stbi__rewind(s);
+       return 0;
+   }
 
-	c = (char)stbi__get8(s);
-	stbi__pnm_skip_whitespace(s, &c);
+   *comp = (t == '6') ? 3 : 1;  // '5' is 1-component .pgm; '6' is 3-component .ppm
 
-	*x = stbi__pnm_getinteger(s, &c); // read width
-	stbi__pnm_skip_whitespace(s, &c);
+   c = (char) stbi__get8(s);
+   stbi__pnm_skip_whitespace(s, &c);
 
-	*y = stbi__pnm_getinteger(s, &c); // read height
-	stbi__pnm_skip_whitespace(s, &c);
+   *x = stbi__pnm_getinteger(s, &c); // read width
+   stbi__pnm_skip_whitespace(s, &c);
 
-	maxv = stbi__pnm_getinteger(s, &c);  // read max value
+   *y = stbi__pnm_getinteger(s, &c); // read height
+   stbi__pnm_skip_whitespace(s, &c);
 
-	if (maxv > 255)
-		return stbi__err("max value > 255", "PPM image not 8-bit");
-	else
-		return 1;
+   maxv = stbi__pnm_getinteger(s, &c);  // read max value
+
+   if (maxv > 255)
+      return stbi__err("max value > 255", "PPM image not 8-bit");
+   else
+      return 1;
 }
 #endif
 
 static int stbi__info_main(stbi__context *s, int *x, int *y, int *comp)
 {
-#ifndef STBI_NO_JPEG
-	if (stbi__jpeg_info(s, x, y, comp)) return 1;
-#endif
+   #ifndef STBI_NO_JPEG
+   if (stbi__jpeg_info(s, x, y, comp)) return 1;
+   #endif
 
-#ifndef STBI_NO_PNG
-	if (stbi__png_info(s, x, y, comp))  return 1;
-#endif
+   #ifndef STBI_NO_PNG
+   if (stbi__png_info(s, x, y, comp))  return 1;
+   #endif
 
-#ifndef STBI_NO_GIF
-	if (stbi__gif_info(s, x, y, comp))  return 1;
-#endif
+   #ifndef STBI_NO_GIF
+   if (stbi__gif_info(s, x, y, comp))  return 1;
+   #endif
 
-#ifndef STBI_NO_BMP
-	if (stbi__bmp_info(s, x, y, comp))  return 1;
-#endif
+   #ifndef STBI_NO_BMP
+   if (stbi__bmp_info(s, x, y, comp))  return 1;
+   #endif
 
-#ifndef STBI_NO_PSD
-	if (stbi__psd_info(s, x, y, comp))  return 1;
-#endif
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_info(s, x, y, comp))  return 1;
+   #endif
 
-#ifndef STBI_NO_PIC
-	if (stbi__pic_info(s, x, y, comp))  return 1;
-#endif
+   #ifndef STBI_NO_PIC
+   if (stbi__pic_info(s, x, y, comp))  return 1;
+   #endif
 
-#ifndef STBI_NO_PNM
-	if (stbi__pnm_info(s, x, y, comp))  return 1;
-#endif
+   #ifndef STBI_NO_PNM
+   if (stbi__pnm_info(s, x, y, comp))  return 1;
+   #endif
 
-#ifndef STBI_NO_HDR
-	if (stbi__hdr_info(s, x, y, comp))  return 1;
-#endif
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_info(s, x, y, comp))  return 1;
+   #endif
 
-	// test tga last because it's a crappy test!
-#ifndef STBI_NO_TGA
-	if (stbi__tga_info(s, x, y, comp))
-		return 1;
-#endif
-	return stbi__err("unknown image type", "Image not of any known type, or corrupt");
+   // test tga last because it's a crappy test!
+   #ifndef STBI_NO_TGA
+   if (stbi__tga_info(s, x, y, comp))
+       return 1;
+   #endif
+   return stbi__err("unknown image type", "Image not of any known type, or corrupt");
+}
+
+static int stbi__is_16_main(stbi__context *s)
+{
+   #ifndef STBI_NO_PNG
+   if (stbi__png_is16(s))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_is16(s))  return 1;
+   #endif
+
+   return 0;
 }
 
 #ifndef STBI_NO_STDIO
 STBIDEF int stbi_info(char const *filename, int *x, int *y, int *comp)
 {
-	FILE *f = stbi__fopen(filename, "rb");
-	int result;
-	if (!f) return stbi__err("can't fopen", "Unable to open file");
-	result = stbi_info_from_file(f, x, y, comp);
-	fclose(f);
-	return result;
+    FILE *f = stbi__fopen(filename, "rb");
+    int result;
+    if (!f) return stbi__err("can't fopen", "Unable to open file");
+    result = stbi_info_from_file(f, x, y, comp);
+    fclose(f);
+    return result;
 }
 
 STBIDEF int stbi_info_from_file(FILE *f, int *x, int *y, int *comp)
 {
-	int r;
-	stbi__context s;
-	long pos = ftell(f);
-	stbi__start_file(&s, f);
-	r = stbi__info_main(&s, x, y, comp);
-	fseek(f, pos, SEEK_SET);
-	return r;
+   int r;
+   stbi__context s;
+   long pos = ftell(f);
+   stbi__start_file(&s, f);
+   r = stbi__info_main(&s,x,y,comp);
+   fseek(f,pos,SEEK_SET);
+   return r;
+}
+
+STBIDEF int stbi_is_16_bit(char const *filename)
+{
+    FILE *f = stbi__fopen(filename, "rb");
+    int result;
+    if (!f) return stbi__err("can't fopen", "Unable to open file");
+    result = stbi_is_16_bit_from_file(f);
+    fclose(f);
+    return result;
+}
+
+STBIDEF int stbi_is_16_bit_from_file(FILE *f)
+{
+   int r;
+   stbi__context s;
+   long pos = ftell(f);
+   stbi__start_file(&s, f);
+   r = stbi__is_16_main(&s);
+   fseek(f,pos,SEEK_SET);
+   return r;
 }
 #endif // !STBI_NO_STDIO
 
 STBIDEF int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
 {
-	stbi__context s;
-	stbi__start_mem(&s, buffer, len);
-	return stbi__info_main(&s, x, y, comp);
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__info_main(&s,x,y,comp);
 }
 
 STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const *c, void *user, int *x, int *y, int *comp)
 {
-	stbi__context s;
-	stbi__start_callbacks(&s, (stbi_io_callbacks *)c, user);
-	return stbi__info_main(&s, x, y, comp);
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) c, user);
+   return stbi__info_main(&s,x,y,comp);
+}
+
+STBIDEF int stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__is_16_main(&s);
+}
+
+STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) c, user);
+   return stbi__is_16_main(&s);
 }
 
 #endif // STB_IMAGE_IMPLEMENTATION
 
 /*
-revision history:
-2.10  (2016-01-22) avoid warning introduced in 2.09 by STBI_REALLOC_SIZED
-2.09  (2016-01-16) allow comments in PNM files
-16-bit-per-pixel TGA (not bit-per-component)
-info() for TGA could break due to .hdr handling
-info() for BMP to shares code instead of sloppy parse
-can use STBI_REALLOC_SIZED if allocator doesn't support realloc
-code cleanup
-2.08  (2015-09-13) fix to 2.07 cleanup, reading RGB PSD as RGBA
-2.07  (2015-09-13) fix compiler warnings
-partial animated GIF support
-limited 16-bpc PSD support
-#ifdef unused functions
-bug with < 92 byte PIC,PNM,HDR,TGA
-2.06  (2015-04-19) fix bug where PSD returns wrong '*comp' value
-2.05  (2015-04-19) fix bug in progressive JPEG handling, fix warning
-2.04  (2015-04-15) try to re-enable SIMD on MinGW 64-bit
-2.03  (2015-04-12) extra corruption checking (mmozeiko)
-stbi_set_flip_vertically_on_load (nguillemot)
-fix NEON support; fix mingw support
-2.02  (2015-01-19) fix incorrect assert, fix warning
-2.01  (2015-01-17) fix various warnings; suppress SIMD on gcc 32-bit without -msse2
-2.00b (2014-12-25) fix STBI_MALLOC in progressive JPEG
-2.00  (2014-12-25) optimize JPG, including x86 SSE2 & NEON SIMD (ryg)
-progressive JPEG (stb)
-PGM/PPM support (Ken Miller)
-STBI_MALLOC,STBI_REALLOC,STBI_FREE
-GIF bugfix -- seemingly never worked
-STBI_NO_*, STBI_ONLY_*
-1.48  (2014-12-14) fix incorrectly-named assert()
-1.47  (2014-12-14) 1/2/4-bit PNG support, both direct and paletted (Omar Cornut & stb)
-optimize PNG (ryg)
-fix bug in interlaced PNG with user-specified channel count (stb)
-1.46  (2014-08-26)
-fix broken tRNS chunk (colorkey-style transparency) in non-paletted PNG
-1.45  (2014-08-16)
-fix MSVC-ARM internal compiler error by wrapping malloc
-1.44  (2014-08-07)
-various warning fixes from Ronny Chevalier
-1.43  (2014-07-15)
-fix MSVC-only compiler problem in code changed in 1.42
-1.42  (2014-07-09)
-don't define _CRT_SECURE_NO_WARNINGS (affects user code)
-fixes to stbi__cleanup_jpeg path
-added STBI_ASSERT to avoid requiring assert.h
-1.41  (2014-06-25)
-fix search&replace from 1.36 that messed up comments/error messages
-1.40  (2014-06-22)
-fix gcc struct-initialization warning
-1.39  (2014-06-15)
-fix to TGA optimization when req_comp != number of components in TGA;
-fix to GIF loading because BMP wasn't rewinding (whoops, no GIFs in my test suite)
-add support for BMP version 5 (more ignored fields)
-1.38  (2014-06-06)
-suppress MSVC warnings on integer casts truncating values
-fix accidental rename of 'skip' field of I/O
-1.37  (2014-06-04)
-remove duplicate typedef
-1.36  (2014-06-03)
-convert to header file single-file library
-if de-iphone isn't set, load iphone images color-swapped instead of returning NULL
-1.35  (2014-05-27)
-various warnings
-fix broken STBI_SIMD path
-fix bug where stbi_load_from_file no longer left file pointer in correct place
-fix broken non-easy path for 32-bit BMP (possibly never used)
-TGA optimization by Arseny Kapoulkine
-1.34  (unknown)
-use STBI_NOTUSED in stbi__resample_row_generic(), fix one more leak in tga failure case
-1.33  (2011-07-14)
-make stbi_is_hdr work in STBI_NO_HDR (as specified), minor compiler-friendly improvements
-1.32  (2011-07-13)
-support for "info" function for all supported filetypes (SpartanJ)
-1.31  (2011-06-20)
-a few more leak fixes, bug in PNG handling (SpartanJ)
-1.30  (2011-06-11)
-added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
-removed deprecated format-specific test/load functions
-removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
-error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)
-fix inefficiency in decoding 32-bit BMP (David Woo)
-1.29  (2010-08-16)
-various warning fixes from Aurelien Pocheville
-1.28  (2010-08-01)
-fix bug in GIF palette transparency (SpartanJ)
-1.27  (2010-08-01)
-cast-to-stbi_uc to fix warnings
-1.26  (2010-07-24)
-fix bug in file buffering for PNG reported by SpartanJ
-1.25  (2010-07-17)
-refix trans_data warning (Won Chun)
-1.24  (2010-07-12)
-perf improvements reading from files on platforms with lock-heavy fgetc()
-minor perf improvements for jpeg
-deprecated type-specific functions so we'll get feedback if they're needed
-attempt to fix trans_data warning (Won Chun)
-1.23    fixed bug in iPhone support
-1.22  (2010-07-10)
-removed image *writing* support
-stbi_info support from Jetro Lauha
-GIF support from Jean-Marc Lienher
-iPhone PNG-extensions from James Brown
-warning-fixes from Nicolas Schulz and Janez Zemva (i.stbi__err. Janez (U+017D)emva)
-1.21    fix use of 'stbi_uc' in header (reported by jon blow)
-1.20    added support for Softimage PIC, by Tom Seddon
-1.19    bug in interlaced PNG corruption check (found by ryg)
-1.18  (2008-08-02)
-fix a threading bug (local mutable static)
-1.17    support interlaced PNG
-1.16    major bugfix - stbi__convert_format converted one too many pixels
-1.15    initialize some fields for thread safety
-1.14    fix threadsafe conversion bug
-header-file-only version (#define STBI_HEADER_FILE_ONLY before including)
-1.13    threadsafe
-1.12    const qualifiers in the API
-1.11    Support installable IDCT, colorspace conversion routines
-1.10    Fixes for 64-bit (don't use "unsigned long")
-optimized upsampling by Fabian "ryg" Giesen
-1.09    Fix format-conversion for PSD code (bad global variables!)
-1.08    Thatcher Ulrich's PSD code integrated by Nicolas Schulz
-1.07    attempt to fix C++ warning/errors again
-1.06    attempt to fix C++ warning/errors again
-1.05    fix TGA loading to return correct *comp and use good luminance calc
-1.04    default float alpha is 1, not 255; use 'void *' for stbi_image_free
-1.03    bugfixes to STBI_NO_STDIO, STBI_NO_HDR
-1.02    support for (subset of) HDR files, float interface for preferred access to them
-1.01    fix bug: possible bug in handling right-side up bmps... not sure
-fix bug: the stbi__bmp_load() and stbi__tga_load() functions didn't work at all
-1.00    interface to zlib that skips zlib header
-0.99    correct handling of alpha in palette
-0.98    TGA loader by lonesock; dynamically add loaders (untested)
-0.97    jpeg errors on too large a file; also catch another malloc failure
-0.96    fix detection of invalid v value - particleman@mollyrocket forum
-0.95    during header scan, seek to markers in case of padding
-0.94    STBI_NO_STDIO to disable stdio usage; rename all #defines the same
-0.93    handle jpegtran output; verbose errors
-0.92    read 4,8,16,24,32-bit BMP files of several formats
-0.91    output 24-bit Windows 3.0 BMP files
-0.90    fix a few more warnings; bump version number to approach 1.0
-0.61    bugfixes due to Marc LeBlanc, Christopher Lloyd
-0.60    fix compiling as c++
-0.59    fix warnings: merge Dave Moore's -Wall fixes
-0.58    fix bug: zlib uncompressed mode len/nlen was wrong endian
-0.57    fix bug: jpg last huffman symbol before marker was >9 bits but less than 16 available
-0.56    fix bug: zlib uncompressed mode len vs. nlen
-0.55    fix bug: restart_interval not initialized to 0
-0.54    allow NULL for 'int *comp'
-0.53    fix bug in png 3->4; speedup png decoding
-0.52    png handles req_comp=3,4 directly; minor cleanup; jpeg comments
-0.51    obey req_comp requests, 1-component jpegs return as 1-component,
-on 'test' only check type, not whether we support this variant
-0.50  (2006-11-19)
-first released version
+   revision history:
+      2.19  (2018-02-11) fix warning
+      2.18  (2018-01-30) fix warnings
+      2.17  (2018-01-29) change sbti__shiftsigned to avoid clang -O2 bug
+                         1-bit BMP
+                         *_is_16_bit api
+                         avoid warnings
+      2.16  (2017-07-23) all functions have 16-bit variants;
+                         STBI_NO_STDIO works again;
+                         compilation fixes;
+                         fix rounding in unpremultiply;
+                         optimize vertical flip;
+                         disable raw_len validation;
+                         documentation fixes
+      2.15  (2017-03-18) fix png-1,2,4 bug; now all Imagenet JPGs decode;
+                         warning fixes; disable run-time SSE detection on gcc;
+                         uniform handling of optional "return" values;
+                         thread-safe initialization of zlib tables
+      2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
+      2.13  (2016-11-29) add 16-bit API, only supported for PNG right now
+      2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
+      2.11  (2016-04-02) allocate large structures on the stack
+                         remove white matting for transparent PSD
+                         fix reported channel count for PNG & BMP
+                         re-enable SSE2 in non-gcc 64-bit
+                         support RGB-formatted JPEG
+                         read 16-bit PNGs (only as 8-bit)
+      2.10  (2016-01-22) avoid warning introduced in 2.09 by STBI_REALLOC_SIZED
+      2.09  (2016-01-16) allow comments in PNM files
+                         16-bit-per-pixel TGA (not bit-per-component)
+                         info() for TGA could break due to .hdr handling
+                         info() for BMP to shares code instead of sloppy parse
+                         can use STBI_REALLOC_SIZED if allocator doesn't support realloc
+                         code cleanup
+      2.08  (2015-09-13) fix to 2.07 cleanup, reading RGB PSD as RGBA
+      2.07  (2015-09-13) fix compiler warnings
+                         partial animated GIF support
+                         limited 16-bpc PSD support
+                         #ifdef unused functions
+                         bug with < 92 byte PIC,PNM,HDR,TGA
+      2.06  (2015-04-19) fix bug where PSD returns wrong '*comp' value
+      2.05  (2015-04-19) fix bug in progressive JPEG handling, fix warning
+      2.04  (2015-04-15) try to re-enable SIMD on MinGW 64-bit
+      2.03  (2015-04-12) extra corruption checking (mmozeiko)
+                         stbi_set_flip_vertically_on_load (nguillemot)
+                         fix NEON support; fix mingw support
+      2.02  (2015-01-19) fix incorrect assert, fix warning
+      2.01  (2015-01-17) fix various warnings; suppress SIMD on gcc 32-bit without -msse2
+      2.00b (2014-12-25) fix STBI_MALLOC in progressive JPEG
+      2.00  (2014-12-25) optimize JPG, including x86 SSE2 & NEON SIMD (ryg)
+                         progressive JPEG (stb)
+                         PGM/PPM support (Ken Miller)
+                         STBI_MALLOC,STBI_REALLOC,STBI_FREE
+                         GIF bugfix -- seemingly never worked
+                         STBI_NO_*, STBI_ONLY_*
+      1.48  (2014-12-14) fix incorrectly-named assert()
+      1.47  (2014-12-14) 1/2/4-bit PNG support, both direct and paletted (Omar Cornut & stb)
+                         optimize PNG (ryg)
+                         fix bug in interlaced PNG with user-specified channel count (stb)
+      1.46  (2014-08-26)
+              fix broken tRNS chunk (colorkey-style transparency) in non-paletted PNG
+      1.45  (2014-08-16)
+              fix MSVC-ARM internal compiler error by wrapping malloc
+      1.44  (2014-08-07)
+              various warning fixes from Ronny Chevalier
+      1.43  (2014-07-15)
+              fix MSVC-only compiler problem in code changed in 1.42
+      1.42  (2014-07-09)
+              don't define _CRT_SECURE_NO_WARNINGS (affects user code)
+              fixes to stbi__cleanup_jpeg path
+              added STBI_ASSERT to avoid requiring assert.h
+      1.41  (2014-06-25)
+              fix search&replace from 1.36 that messed up comments/error messages
+      1.40  (2014-06-22)
+              fix gcc struct-initialization warning
+      1.39  (2014-06-15)
+              fix to TGA optimization when req_comp != number of components in TGA;
+              fix to GIF loading because BMP wasn't rewinding (whoops, no GIFs in my test suite)
+              add support for BMP version 5 (more ignored fields)
+      1.38  (2014-06-06)
+              suppress MSVC warnings on integer casts truncating values
+              fix accidental rename of 'skip' field of I/O
+      1.37  (2014-06-04)
+              remove duplicate typedef
+      1.36  (2014-06-03)
+              convert to header file single-file library
+              if de-iphone isn't set, load iphone images color-swapped instead of returning NULL
+      1.35  (2014-05-27)
+              various warnings
+              fix broken STBI_SIMD path
+              fix bug where stbi_load_from_file no longer left file pointer in correct place
+              fix broken non-easy path for 32-bit BMP (possibly never used)
+              TGA optimization by Arseny Kapoulkine
+      1.34  (unknown)
+              use STBI_NOTUSED in stbi__resample_row_generic(), fix one more leak in tga failure case
+      1.33  (2011-07-14)
+              make stbi_is_hdr work in STBI_NO_HDR (as specified), minor compiler-friendly improvements
+      1.32  (2011-07-13)
+              support for "info" function for all supported filetypes (SpartanJ)
+      1.31  (2011-06-20)
+              a few more leak fixes, bug in PNG handling (SpartanJ)
+      1.30  (2011-06-11)
+              added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
+              removed deprecated format-specific test/load functions
+              removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
+              error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)
+              fix inefficiency in decoding 32-bit BMP (David Woo)
+      1.29  (2010-08-16)
+              various warning fixes from Aurelien Pocheville
+      1.28  (2010-08-01)
+              fix bug in GIF palette transparency (SpartanJ)
+      1.27  (2010-08-01)
+              cast-to-stbi_uc to fix warnings
+      1.26  (2010-07-24)
+              fix bug in file buffering for PNG reported by SpartanJ
+      1.25  (2010-07-17)
+              refix trans_data warning (Won Chun)
+      1.24  (2010-07-12)
+              perf improvements reading from files on platforms with lock-heavy fgetc()
+              minor perf improvements for jpeg
+              deprecated type-specific functions so we'll get feedback if they're needed
+              attempt to fix trans_data warning (Won Chun)
+      1.23    fixed bug in iPhone support
+      1.22  (2010-07-10)
+              removed image *writing* support
+              stbi_info support from Jetro Lauha
+              GIF support from Jean-Marc Lienher
+              iPhone PNG-extensions from James Brown
+              warning-fixes from Nicolas Schulz and Janez Zemva (i.stbi__err. Janez (U+017D)emva)
+      1.21    fix use of 'stbi_uc' in header (reported by jon blow)
+      1.20    added support for Softimage PIC, by Tom Seddon
+      1.19    bug in interlaced PNG corruption check (found by ryg)
+      1.18  (2008-08-02)
+              fix a threading bug (local mutable static)
+      1.17    support interlaced PNG
+      1.16    major bugfix - stbi__convert_format converted one too many pixels
+      1.15    initialize some fields for thread safety
+      1.14    fix threadsafe conversion bug
+              header-file-only version (#define STBI_HEADER_FILE_ONLY before including)
+      1.13    threadsafe
+      1.12    const qualifiers in the API
+      1.11    Support installable IDCT, colorspace conversion routines
+      1.10    Fixes for 64-bit (don't use "unsigned long")
+              optimized upsampling by Fabian "ryg" Giesen
+      1.09    Fix format-conversion for PSD code (bad global variables!)
+      1.08    Thatcher Ulrich's PSD code integrated by Nicolas Schulz
+      1.07    attempt to fix C++ warning/errors again
+      1.06    attempt to fix C++ warning/errors again
+      1.05    fix TGA loading to return correct *comp and use good luminance calc
+      1.04    default float alpha is 1, not 255; use 'void *' for stbi_image_free
+      1.03    bugfixes to STBI_NO_STDIO, STBI_NO_HDR
+      1.02    support for (subset of) HDR files, float interface for preferred access to them
+      1.01    fix bug: possible bug in handling right-side up bmps... not sure
+              fix bug: the stbi__bmp_load() and stbi__tga_load() functions didn't work at all
+      1.00    interface to zlib that skips zlib header
+      0.99    correct handling of alpha in palette
+      0.98    TGA loader by lonesock; dynamically add loaders (untested)
+      0.97    jpeg errors on too large a file; also catch another malloc failure
+      0.96    fix detection of invalid v value - particleman@mollyrocket forum
+      0.95    during header scan, seek to markers in case of padding
+      0.94    STBI_NO_STDIO to disable stdio usage; rename all #defines the same
+      0.93    handle jpegtran output; verbose errors
+      0.92    read 4,8,16,24,32-bit BMP files of several formats
+      0.91    output 24-bit Windows 3.0 BMP files
+      0.90    fix a few more warnings; bump version number to approach 1.0
+      0.61    bugfixes due to Marc LeBlanc, Christopher Lloyd
+      0.60    fix compiling as c++
+      0.59    fix warnings: merge Dave Moore's -Wall fixes
+      0.58    fix bug: zlib uncompressed mode len/nlen was wrong endian
+      0.57    fix bug: jpg last huffman symbol before marker was >9 bits but less than 16 available
+      0.56    fix bug: zlib uncompressed mode len vs. nlen
+      0.55    fix bug: restart_interval not initialized to 0
+      0.54    allow NULL for 'int *comp'
+      0.53    fix bug in png 3->4; speedup png decoding
+      0.52    png handles req_comp=3,4 directly; minor cleanup; jpeg comments
+      0.51    obey req_comp requests, 1-component jpegs return as 1-component,
+              on 'test' only check type, not whether we support this variant
+      0.50  (2006-11-19)
+              first released version
+*/
+
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
 */

--- a/3rdparty/stblib/stb_truetype.h
+++ b/3rdparty/stblib/stb_truetype.h
@@ -1,11 +1,12 @@
-// stb_truetype.h - v1.09 - public domain
-// authored from 2009-2015 by Sean Barrett / RAD Game Tools
+// stb_truetype.h - v1.19 - public domain
+// authored from 2009-2016 by Sean Barrett / RAD Game Tools
 //
 //   This library processes TrueType files:
 //        parse files
 //        extract glyph metrics
 //        extract glyph shapes
 //        render glyphs to one-channel bitmaps with antialiasing (box filter)
+//        render glyphs to one-channel SDF bitmaps (signed-distance field/function)
 //
 //   Todo:
 //        non-MS cmaps
@@ -20,36 +21,44 @@
 //
 //   Mikko Mononen: compound shape support, more cmap formats
 //   Tor Andersson: kerning, subpixel rendering
-//
-//   Bug/warning reports/fixes:
-//       "Zer" on mollyrocket (with fix)
-//       Cass Everitt
-//       stoiko (Haemimont Games)
-//       Brian Hook 
-//       Walter van Niftrik
-//       David Gow
-//       David Given
-//       Ivan-Assen Ivanov
-//       Anthony Pesch
-//       Johan Duparc
-//       Hou Qiming
-//       Fabian "ryg" Giesen
-//       Martins Mozeiko
-//       Cap Petschulat
-//       Omar Cornut
-//       github:aloucks
-//       Peter LaValle
-//       Sergey Popov
-//       Giumo X. Clanjor
-//       Higor Euripedes
-//       Thomas Fields
-//       Derek Vinyard
+//   Dougall Johnson: OpenType / Type 2 font handling
+//   Daniel Ribeiro Maciel: basic GPOS-based kerning
 //
 //   Misc other:
 //       Ryan Gordon
+//       Simon Glass
+//       github:IntellectualKitty
+//       Imanol Celaya
+//       Daniel Ribeiro Maciel
 //
+//   Bug/warning reports/fixes:
+//       "Zer" on mollyrocket       Fabian "ryg" Giesen
+//       Cass Everitt               Martins Mozeiko
+//       stoiko (Haemimont Games)   Cap Petschulat
+//       Brian Hook                 Omar Cornut
+//       Walter van Niftrik         github:aloucks
+//       David Gow                  Peter LaValle
+//       David Given                Sergey Popov
+//       Ivan-Assen Ivanov          Giumo X. Clanjor
+//       Anthony Pesch              Higor Euripedes
+//       Johan Duparc               Thomas Fields
+//       Hou Qiming                 Derek Vinyard
+//       Rob Loach                  Cort Stratton
+//       Kenney Phillis Jr.         github:oyvindjam
+//       Brian Costabile            github:vassvik
+//       
 // VERSION HISTORY
 //
+//   1.19 (2018-02-11) GPOS kerning, STBTT_fmod
+//   1.18 (2018-01-29) add missing function
+//   1.17 (2017-07-23) make more arguments const; doc fix
+//   1.16 (2017-07-12) SDF support
+//   1.15 (2017-03-03) make more arguments const
+//   1.14 (2017-01-16) num-fonts-in-TTC function
+//   1.13 (2017-01-02) support OpenType fonts, certain Apple fonts
+//   1.12 (2016-10-25) suppress warnings about casting away const with -Wcast-qual
+//   1.11 (2016-04-02) fix unused-variable warning
+//   1.10 (2016-04-02) user-defined fabs(); rare memory leak; remove duplicate typedef
 //   1.09 (2016-01-16) warning fix; avoid crash on outofmem; use allocation userdata properly
 //   1.08 (2015-09-13) document stbtt_Rasterize(); fixes for vertical & horizontal edges
 //   1.07 (2015-08-01) allow PackFontRanges to accept arrays of sparse codepoints;
@@ -57,20 +66,12 @@
 //                     fix stbtt_GetFontOFfsetForIndex (never worked for non-0 input?);
 //                     fixed an assert() bug in the new rasterizer
 //                     replace assert() with STBTT_assert() in new rasterizer
-//   1.06 (2015-07-14) performance improvements (~35% faster on x86 and x64 on test machine)
-//                     also more precise AA rasterizer, except if shapes overlap
-//                     remove need for STBTT_sort
-//   1.05 (2015-04-15) fix misplaced definitions for STBTT_STATIC
-//   1.04 (2015-04-15) typo in example
-//   1.03 (2015-04-12) STBTT_STATIC, fix memory leak in new packing, various fixes
 //
 //   Full history can be found at the end of this file.
 //
 // LICENSE
 //
-//   This software is in the public domain. Where that dedication is not
-//   recognized, you are granted a perpetual, irrevocable license to copy,
-//   distribute, and modify this file as you see fit.
+//   See end of file for license information.
 //
 // USAGE
 //
@@ -90,14 +91,15 @@
 //   Improved 3D API (more shippable):
 //           #include "stb_rect_pack.h"           -- optional, but you really want it
 //           stbtt_PackBegin()
-//           stbtt_PackSetOversample()            -- for improved quality on small fonts
+//           stbtt_PackSetOversampling()          -- for improved quality on small fonts
 //           stbtt_PackFontRanges()               -- pack and renders
 //           stbtt_PackEnd()
 //           stbtt_GetPackedQuad()
 //
 //   "Load" a font file from a memory buffer (you have to keep the buffer loaded)
 //           stbtt_InitFont()
-//           stbtt_GetFontOffsetForIndex()        -- use for TTC font collections
+//           stbtt_GetFontOffsetForIndex()        -- indexing for TTC font collections
+//           stbtt_GetNumberOfFonts()             -- number of fonts for TTC font collections
 //
 //   Render a unicode codepoint to a bitmap
 //           stbtt_GetCodepointBitmap()           -- allocates and returns a bitmap
@@ -107,6 +109,7 @@
 //   Character advance/positioning
 //           stbtt_GetCodepointHMetrics()
 //           stbtt_GetFontVMetrics()
+//           stbtt_GetFontVMetricsOS2()
 //           stbtt_GetCodepointKernAdvance()
 //
 //   Starting with version 1.06, the rasterizer was replaced with a new,
@@ -162,7 +165,7 @@
 //         measurement for describing font size, defined as 72 points per inch.
 //         stb_truetype provides a point API for compatibility. However, true
 //         "per inch" conventions don't make much sense on computer displays
-//         since they different monitors have different number of pixels per
+//         since different monitors have different number of pixels per
 //         inch. For example, Windows traditionally uses a convention that
 //         there are 96 pixels per inch, thus making 'inch' measurements have
 //         nothing to do with inches, and thus effectively defining a point to
@@ -171,6 +174,39 @@
 //         but the author has observed that this scale factor is often wrong
 //         for non-commercial fonts, thus making fonts scaled in points
 //         according to the TrueType spec incoherently sized in practice.
+//
+// DETAILED USAGE:
+//
+//  Scale:
+//    Select how high you want the font to be, in points or pixels.
+//    Call ScaleForPixelHeight or ScaleForMappingEmToPixels to compute
+//    a scale factor SF that will be used by all other functions.
+//
+//  Baseline:
+//    You need to select a y-coordinate that is the baseline of where
+//    your text will appear. Call GetFontBoundingBox to get the baseline-relative
+//    bounding box for all characters. SF*-y0 will be the distance in pixels
+//    that the worst-case character could extend above the baseline, so if
+//    you want the top edge of characters to appear at the top of the
+//    screen where y=0, then you would set the baseline to SF*-y0.
+//
+//  Current point:
+//    Set the current point where the first character will appear. The
+//    first character could extend left of the current point; this is font
+//    dependent. You can either choose a current point that is the leftmost
+//    point and hope, or add some padding, or check the bounding box or
+//    left-side-bearing of the first character to be displayed and set
+//    the current point based on that.
+//
+//  Displaying a character:
+//    Compute the bounding box of the character. It will contain signed values
+//    relative to <current_point, baseline>. I.e. if it returns x0,y0,x1,y1,
+//    then the character should be displayed in the rectangle from
+//    <current_point+SF*x0, baseline+SF*y0> to <current_point+SF*x1,baseline+SF*y1).
+//
+//  Advancing for the next character:
+//    Call GlyphHMetrics, and compute 'current_point += SF * advance'.
+// 
 //
 // ADVANCED USAGE
 //
@@ -239,42 +275,42 @@
 #define STB_TRUETYPE_IMPLEMENTATION  // force following include to generate implementation
 #include "stb_truetype.h"
 
-unsigned char ttf_buffer[1 << 20];
-unsigned char temp_bitmap[512 * 512];
+unsigned char ttf_buffer[1<<20];
+unsigned char temp_bitmap[512*512];
 
 stbtt_bakedchar cdata[96]; // ASCII 32..126 is 95 glyphs
 GLuint ftex;
 
 void my_stbtt_initfont(void)
 {
-	fread(ttf_buffer, 1, 1 << 20, fopen("c:/windows/fonts/times.ttf", "rb"));
-	stbtt_BakeFontBitmap(ttf_buffer, 0, 32.0, temp_bitmap, 512, 512, 32, 96, cdata); // no guarantee this fits!
-																					 // can free ttf_buffer at this point
-	glGenTextures(1, &ftex);
-	glBindTexture(GL_TEXTURE_2D, ftex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, 512, 512, 0, GL_ALPHA, GL_UNSIGNED_BYTE, temp_bitmap);
-	// can free temp_bitmap at this point
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+   fread(ttf_buffer, 1, 1<<20, fopen("c:/windows/fonts/times.ttf", "rb"));
+   stbtt_BakeFontBitmap(ttf_buffer,0, 32.0, temp_bitmap,512,512, 32,96, cdata); // no guarantee this fits!
+   // can free ttf_buffer at this point
+   glGenTextures(1, &ftex);
+   glBindTexture(GL_TEXTURE_2D, ftex);
+   glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, 512,512, 0, GL_ALPHA, GL_UNSIGNED_BYTE, temp_bitmap);
+   // can free temp_bitmap at this point
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 }
 
 void my_stbtt_print(float x, float y, char *text)
 {
-	// assume orthographic projection with units = screen pixels, origin at top left
-	glEnable(GL_TEXTURE_2D);
-	glBindTexture(GL_TEXTURE_2D, ftex);
-	glBegin(GL_QUADS);
-	while (*text) {
-		if (*text >= 32 && *text < 128) {
-			stbtt_aligned_quad q;
-			stbtt_GetBakedQuad(cdata, 512, 512, *text - 32, &x, &y, &q, 1);//1=opengl & d3d10+,0=d3d9
-			glTexCoord2f(q.s0, q.t1); glVertex2f(q.x0, q.y0);
-			glTexCoord2f(q.s1, q.t1); glVertex2f(q.x1, q.y0);
-			glTexCoord2f(q.s1, q.t0); glVertex2f(q.x1, q.y1);
-			glTexCoord2f(q.s0, q.t0); glVertex2f(q.x0, q.y1);
-		}
-		++text;
-	}
-	glEnd();
+   // assume orthographic projection with units = screen pixels, origin at top left
+   glEnable(GL_TEXTURE_2D);
+   glBindTexture(GL_TEXTURE_2D, ftex);
+   glBegin(GL_QUADS);
+   while (*text) {
+      if (*text >= 32 && *text < 128) {
+         stbtt_aligned_quad q;
+         stbtt_GetBakedQuad(cdata, 512,512, *text-32, &x,&y,&q,1);//1=opengl & d3d10+,0=d3d9
+         glTexCoord2f(q.s0,q.t1); glVertex2f(q.x0,q.y0);
+         glTexCoord2f(q.s1,q.t1); glVertex2f(q.x1,q.y0);
+         glTexCoord2f(q.s1,q.t0); glVertex2f(q.x1,q.y1);
+         glTexCoord2f(q.s0,q.t0); glVertex2f(q.x0,q.y1);
+      }
+      ++text;
+   }
+   glEnd();
 }
 #endif
 //
@@ -288,25 +324,25 @@ void my_stbtt_print(float x, float y, char *text)
 #define STB_TRUETYPE_IMPLEMENTATION  // force following include to generate implementation
 #include "stb_truetype.h"
 
-char ttf_buffer[1 << 25];
+char ttf_buffer[1<<25];
 
 int main(int argc, char **argv)
 {
-	stbtt_fontinfo font;
-	unsigned char *bitmap;
-	int w, h, i, j, c = (argc > 1 ? atoi(argv[1]) : 'a'), s = (argc > 2 ? atoi(argv[2]) : 20);
+   stbtt_fontinfo font;
+   unsigned char *bitmap;
+   int w,h,i,j,c = (argc > 1 ? atoi(argv[1]) : 'a'), s = (argc > 2 ? atoi(argv[2]) : 20);
 
-	fread(ttf_buffer, 1, 1 << 25, fopen(argc > 3 ? argv[3] : "c:/windows/fonts/arialbd.ttf", "rb"));
+   fread(ttf_buffer, 1, 1<<25, fopen(argc > 3 ? argv[3] : "c:/windows/fonts/arialbd.ttf", "rb"));
 
-	stbtt_InitFont(&font, ttf_buffer, stbtt_GetFontOffsetForIndex(ttf_buffer, 0));
-	bitmap = stbtt_GetCodepointBitmap(&font, 0, stbtt_ScaleForPixelHeight(&font, s), c, &w, &h, 0, 0);
+   stbtt_InitFont(&font, ttf_buffer, stbtt_GetFontOffsetForIndex(ttf_buffer,0));
+   bitmap = stbtt_GetCodepointBitmap(&font, 0,stbtt_ScaleForPixelHeight(&font, s), c, &w, &h, 0,0);
 
-	for (j = 0; j < h; ++j) {
-		for (i = 0; i < w; ++i)
-			putchar(" .:ioVM@"[bitmap[j*w + i] >> 5]);
-		putchar('\n');
-	}
-	return 0;
+   for (j=0; j < h; ++j) {
+      for (i=0; i < w; ++i)
+         putchar(" .:ioVM@"[bitmap[j*w+i]>>5]);
+      putchar('\n');
+   }
+   return 0;
 }
 #endif 
 //
@@ -328,46 +364,46 @@ int main(int argc, char **argv)
 // Complete program: print "Hello World!" banner, with bugs
 //
 #if 0
-char buffer[24 << 20];
+char buffer[24<<20];
 unsigned char screen[20][79];
 
 int main(int arg, char **argv)
 {
-	stbtt_fontinfo font;
-	int i, j, ascent, baseline, ch = 0;
-	float scale, xpos = 2; // leave a little padding in case the character extends left
-	char *text = "Heljo World!"; // intentionally misspelled to show 'lj' brokenness
+   stbtt_fontinfo font;
+   int i,j,ascent,baseline,ch=0;
+   float scale, xpos=2; // leave a little padding in case the character extends left
+   char *text = "Heljo World!"; // intentionally misspelled to show 'lj' brokenness
 
-	fread(buffer, 1, 1000000, fopen("c:/windows/fonts/arialbd.ttf", "rb"));
-	stbtt_InitFont(&font, buffer, 0);
+   fread(buffer, 1, 1000000, fopen("c:/windows/fonts/arialbd.ttf", "rb"));
+   stbtt_InitFont(&font, buffer, 0);
 
-	scale = stbtt_ScaleForPixelHeight(&font, 15);
-	stbtt_GetFontVMetrics(&font, &ascent, 0, 0);
-	baseline = (int)(ascent*scale);
+   scale = stbtt_ScaleForPixelHeight(&font, 15);
+   stbtt_GetFontVMetrics(&font, &ascent,0,0);
+   baseline = (int) (ascent*scale);
 
-	while (text[ch]) {
-		int advance, lsb, x0, y0, x1, y1;
-		float x_shift = xpos - (float)floor(xpos);
-		stbtt_GetCodepointHMetrics(&font, text[ch], &advance, &lsb);
-		stbtt_GetCodepointBitmapBoxSubpixel(&font, text[ch], scale, scale, x_shift, 0, &x0, &y0, &x1, &y1);
-		stbtt_MakeCodepointBitmapSubpixel(&font, &screen[baseline + y0][(int)xpos + x0], x1 - x0, y1 - y0, 79, scale, scale, x_shift, 0, text[ch]);
-		// note that this stomps the old data, so where character boxes overlap (e.g. 'lj') it's wrong
-		// because this API is really for baking character bitmaps into textures. if you want to render
-		// a sequence of characters, you really need to render each bitmap to a temp buffer, then
-		// "alpha blend" that into the working buffer
-		xpos += (advance * scale);
-		if (text[ch + 1])
-			xpos += scale*stbtt_GetCodepointKernAdvance(&font, text[ch], text[ch + 1]);
-		++ch;
-	}
+   while (text[ch]) {
+      int advance,lsb,x0,y0,x1,y1;
+      float x_shift = xpos - (float) floor(xpos);
+      stbtt_GetCodepointHMetrics(&font, text[ch], &advance, &lsb);
+      stbtt_GetCodepointBitmapBoxSubpixel(&font, text[ch], scale,scale,x_shift,0, &x0,&y0,&x1,&y1);
+      stbtt_MakeCodepointBitmapSubpixel(&font, &screen[baseline + y0][(int) xpos + x0], x1-x0,y1-y0, 79, scale,scale,x_shift,0, text[ch]);
+      // note that this stomps the old data, so where character boxes overlap (e.g. 'lj') it's wrong
+      // because this API is really for baking character bitmaps into textures. if you want to render
+      // a sequence of characters, you really need to render each bitmap to a temp buffer, then
+      // "alpha blend" that into the working buffer
+      xpos += (advance * scale);
+      if (text[ch+1])
+         xpos += scale*stbtt_GetCodepointKernAdvance(&font, text[ch],text[ch+1]);
+      ++ch;
+   }
 
-	for (j = 0; j < 20; ++j) {
-		for (i = 0; i < 78; ++i)
-			putchar(" .:ioVM@"[screen[j][i] >> 5]);
-		putchar('\n');
-	}
+   for (j=0; j < 20; ++j) {
+      for (i=0; i < 78; ++i)
+         putchar(" .:ioVM@"[screen[j][i]>>5]);
+      putchar('\n');
+   }
 
-	return 0;
+   return 0;
 }
 #endif
 
@@ -378,58 +414,74 @@ int main(int arg, char **argv)
 ////   INTEGRATION WITH YOUR CODEBASE
 ////
 ////   The following sections allow you to supply alternate definitions
-////   of C library functions used by stb_truetype.
+////   of C library functions used by stb_truetype, e.g. if you don't
+////   link with the C runtime library.
 
 #ifdef STB_TRUETYPE_IMPLEMENTATION
-// #define your own (u)stbtt_int8/16/32 before including to override this
-#ifndef stbtt_uint8
-typedef unsigned char   stbtt_uint8;
-typedef signed   char   stbtt_int8;
-typedef unsigned short  stbtt_uint16;
-typedef signed   short  stbtt_int16;
-typedef unsigned int    stbtt_uint32;
-typedef signed   int    stbtt_int32;
-#endif
+   // #define your own (u)stbtt_int8/16/32 before including to override this
+   #ifndef stbtt_uint8
+   typedef unsigned char   stbtt_uint8;
+   typedef signed   char   stbtt_int8;
+   typedef unsigned short  stbtt_uint16;
+   typedef signed   short  stbtt_int16;
+   typedef unsigned int    stbtt_uint32;
+   typedef signed   int    stbtt_int32;
+   #endif
 
-typedef char stbtt__check_size32[sizeof(stbtt_int32) == 4 ? 1 : -1];
-typedef char stbtt__check_size16[sizeof(stbtt_int16) == 2 ? 1 : -1];
+   typedef char stbtt__check_size32[sizeof(stbtt_int32)==4 ? 1 : -1];
+   typedef char stbtt__check_size16[sizeof(stbtt_int16)==2 ? 1 : -1];
 
-// #define your own STBTT_ifloor/STBTT_iceil() to avoid math.h
-#ifndef STBTT_ifloor
-#include <math.h>
-#define STBTT_ifloor(x)   ((int) floor(x))
-#define STBTT_iceil(x)    ((int) ceil(x))
-#endif
+   // e.g. #define your own STBTT_ifloor/STBTT_iceil() to avoid math.h
+   #ifndef STBTT_ifloor
+   #include <math.h>
+   #define STBTT_ifloor(x)   ((int) floor(x))
+   #define STBTT_iceil(x)    ((int) ceil(x))
+   #endif
 
-#ifndef STBTT_sqrt
-#include <math.h>
-#define STBTT_sqrt(x)      sqrt(x)
-#endif
+   #ifndef STBTT_sqrt
+   #include <math.h>
+   #define STBTT_sqrt(x)      sqrt(x)
+   #define STBTT_pow(x,y)     pow(x,y)
+   #endif
 
-// #define your own functions "STBTT_malloc" / "STBTT_free" to avoid malloc.h
-#ifndef STBTT_malloc
-#ifndef __APPLE__
-#include <stdlib.h>
-#endif
-#define STBTT_malloc(x,u)  ((void)(u),malloc(x))
-#define STBTT_free(x,u)    ((void)(u),free(x))
-#endif
+   #ifndef STBTT_fmod
+   #include <math.h>
+   #define STBTT_fmod(x,y)    fmod(x,y)
+   #endif
 
-#ifndef STBTT_assert
-#include <assert.h>
-#define STBTT_assert(x)    assert(x)
-#endif
+   #ifndef STBTT_cos
+   #include <math.h>
+   #define STBTT_cos(x)       cos(x)
+   #define STBTT_acos(x)      acos(x)
+   #endif
 
-#ifndef STBTT_strlen
-#include <string.h>
-#define STBTT_strlen(x)    strlen(x)
-#endif
+   #ifndef STBTT_fabs
+   #include <math.h>
+   #define STBTT_fabs(x)      fabs(x)
+   #endif
 
-#ifndef STBTT_memcpy
-#include <memory.h>
-#define STBTT_memcpy       memcpy
-#define STBTT_memset       memset
-#endif
+   // #define your own functions "STBTT_malloc" / "STBTT_free" to avoid malloc.h
+   #ifndef STBTT_malloc
+   #include <stdlib.h>
+   #define STBTT_malloc(x,u)  ((void)(u),malloc(x))
+   #define STBTT_free(x,u)    ((void)(u),free(x))
+   #endif
+
+   #ifndef STBTT_assert
+   #include <assert.h>
+   #define STBTT_assert(x)    assert(x)
+   #endif
+
+   #ifndef STBTT_strlen
+   #include <string.h>
+   #define STBTT_strlen(x)    strlen(x)
+   #endif
+
+   #ifndef STBTT_memcpy
+   #include <string.h>
+   #define STBTT_memcpy       memcpy
+   #define STBTT_memset       memset
+   #endif
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -452,468 +504,558 @@ typedef char stbtt__check_size16[sizeof(stbtt_int16) == 2 ? 1 : -1];
 extern "C" {
 #endif
 
-	//////////////////////////////////////////////////////////////////////////////
-	//
-	// TEXTURE BAKING API
-	//
-	// If you use this API, you only have to call two functions ever.
-	//
+// private structure
+typedef struct
+{
+   unsigned char *data;
+   int cursor;
+   int size;
+} stbtt__buf;
 
-	typedef struct
-	{
-		unsigned short x0, y0, x1, y1; // coordinates of bbox in bitmap
-		float xoff, yoff, xadvance;
-	} stbtt_bakedchar;
+//////////////////////////////////////////////////////////////////////////////
+//
+// TEXTURE BAKING API
+//
+// If you use this API, you only have to call two functions ever.
+//
 
-	STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,  // font location (use offset=0 for plain .ttf)
-		float pixel_height,                     // height of font in pixels
-		unsigned char *pixels, int pw, int ph,  // bitmap to be filled in
-		int first_char, int num_chars,          // characters to bake
-		stbtt_bakedchar *chardata);             // you allocate this, it's num_chars long
-												// if return is positive, the first unused row of the bitmap
-												// if return is negative, returns the negative of the number of characters that fit
-												// if return is 0, no characters fit and no rows were used
-												// This uses a very crappy packing.
+typedef struct
+{
+   unsigned short x0,y0,x1,y1; // coordinates of bbox in bitmap
+   float xoff,yoff,xadvance;
+} stbtt_bakedchar;
 
-	typedef struct
-	{
-		float x0, y0, s0, t0; // top-left
-		float x1, y1, s1, t1; // bottom-right
-	} stbtt_aligned_quad;
+STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,  // font location (use offset=0 for plain .ttf)
+                                float pixel_height,                     // height of font in pixels
+                                unsigned char *pixels, int pw, int ph,  // bitmap to be filled in
+                                int first_char, int num_chars,          // characters to bake
+                                stbtt_bakedchar *chardata);             // you allocate this, it's num_chars long
+// if return is positive, the first unused row of the bitmap
+// if return is negative, returns the negative of the number of characters that fit
+// if return is 0, no characters fit and no rows were used
+// This uses a very crappy packing.
 
-	STBTT_DEF void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph,  // same data as above
-		int char_index,             // character to display
-		float *xpos, float *ypos,   // pointers to current position in screen pixel space
-		stbtt_aligned_quad *q,      // output: quad to draw
-		int opengl_fillrule);       // true if opengl fill rule; false if DX9 or earlier
-									// Call GetBakedQuad with char_index = 'character - first_char', and it
-									// creates the quad you need to draw and advances the current position.
-									//
-									// The coordinate system used assumes y increases downwards.
-									//
-									// Characters will extend both above and below the current position;
-									// see discussion of "BASELINE" above.
-									//
-									// It's inefficient; you might want to c&p it and optimize it.
+typedef struct
+{
+   float x0,y0,s0,t0; // top-left
+   float x1,y1,s1,t1; // bottom-right
+} stbtt_aligned_quad;
+
+STBTT_DEF void stbtt_GetBakedQuad(const stbtt_bakedchar *chardata, int pw, int ph,  // same data as above
+                               int char_index,             // character to display
+                               float *xpos, float *ypos,   // pointers to current position in screen pixel space
+                               stbtt_aligned_quad *q,      // output: quad to draw
+                               int opengl_fillrule);       // true if opengl fill rule; false if DX9 or earlier
+// Call GetBakedQuad with char_index = 'character - first_char', and it
+// creates the quad you need to draw and advances the current position.
+//
+// The coordinate system used assumes y increases downwards.
+//
+// Characters will extend both above and below the current position;
+// see discussion of "BASELINE" above.
+//
+// It's inefficient; you might want to c&p it and optimize it.
 
 
 
-									//////////////////////////////////////////////////////////////////////////////
-									//
-									// NEW TEXTURE BAKING API
-									//
-									// This provides options for packing multiple fonts into one atlas, not
-									// perfectly but better than nothing.
+//////////////////////////////////////////////////////////////////////////////
+//
+// NEW TEXTURE BAKING API
+//
+// This provides options for packing multiple fonts into one atlas, not
+// perfectly but better than nothing.
 
-	typedef struct
-	{
-		unsigned short x0, y0, x1, y1; // coordinates of bbox in bitmap
-		float xoff, yoff, xadvance;
-		float xoff2, yoff2;
-	} stbtt_packedchar;
+typedef struct
+{
+   unsigned short x0,y0,x1,y1; // coordinates of bbox in bitmap
+   float xoff,yoff,xadvance;
+   float xoff2,yoff2;
+} stbtt_packedchar;
 
-	typedef struct stbtt_pack_context stbtt_pack_context;
-	typedef struct stbtt_fontinfo stbtt_fontinfo;
+typedef struct stbtt_pack_context stbtt_pack_context;
+typedef struct stbtt_fontinfo stbtt_fontinfo;
 #ifndef STB_RECT_PACK_VERSION
-	typedef struct stbrp_rect stbrp_rect;
+typedef struct stbrp_rect stbrp_rect;
 #endif
 
-	STBTT_DEF int  stbtt_PackBegin(stbtt_pack_context *spc, unsigned char *pixels, int width, int height, int stride_in_bytes, int padding, void *alloc_context);
-	// Initializes a packing context stored in the passed-in stbtt_pack_context.
-	// Future calls using this context will pack characters into the bitmap passed
-	// in here: a 1-channel bitmap that is weight x height. stride_in_bytes is
-	// the distance from one row to the next (or 0 to mean they are packed tightly
-	// together). "padding" is the amount of padding to leave between each
-	// character (normally you want '1' for bitmaps you'll use as textures with
-	// bilinear filtering).
-	//
-	// Returns 0 on failure, 1 on success.
+STBTT_DEF int  stbtt_PackBegin(stbtt_pack_context *spc, unsigned char *pixels, int width, int height, int stride_in_bytes, int padding, void *alloc_context);
+// Initializes a packing context stored in the passed-in stbtt_pack_context.
+// Future calls using this context will pack characters into the bitmap passed
+// in here: a 1-channel bitmap that is width * height. stride_in_bytes is
+// the distance from one row to the next (or 0 to mean they are packed tightly
+// together). "padding" is the amount of padding to leave between each
+// character (normally you want '1' for bitmaps you'll use as textures with
+// bilinear filtering).
+//
+// Returns 0 on failure, 1 on success.
 
-	STBTT_DEF void stbtt_PackEnd(stbtt_pack_context *spc);
-	// Cleans up the packing context and frees all memory.
+STBTT_DEF void stbtt_PackEnd  (stbtt_pack_context *spc);
+// Cleans up the packing context and frees all memory.
 
 #define STBTT_POINT_SIZE(x)   (-(x))
 
-	STBTT_DEF int  stbtt_PackFontRange(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, float font_size,
-		int first_unicode_char_in_range, int num_chars_in_range, stbtt_packedchar *chardata_for_range);
-	// Creates character bitmaps from the font_index'th font found in fontdata (use
-	// font_index=0 if you don't know what that is). It creates num_chars_in_range
-	// bitmaps for characters with unicode values starting at first_unicode_char_in_range
-	// and increasing. Data for how to render them is stored in chardata_for_range;
-	// pass these to stbtt_GetPackedQuad to get back renderable quads.
-	//
-	// font_size is the full height of the character from ascender to descender,
-	// as computed by stbtt_ScaleForPixelHeight. To use a point size as computed
-	// by stbtt_ScaleForMappingEmToPixels, wrap the point size in STBTT_POINT_SIZE()
-	// and pass that result as 'font_size':
-	//       ...,                  20 , ... // font max minus min y is 20 pixels tall
-	//       ..., STBTT_POINT_SIZE(20), ... // 'M' is 20 pixels tall
+STBTT_DEF int  stbtt_PackFontRange(stbtt_pack_context *spc, const unsigned char *fontdata, int font_index, float font_size,
+                                int first_unicode_char_in_range, int num_chars_in_range, stbtt_packedchar *chardata_for_range);
+// Creates character bitmaps from the font_index'th font found in fontdata (use
+// font_index=0 if you don't know what that is). It creates num_chars_in_range
+// bitmaps for characters with unicode values starting at first_unicode_char_in_range
+// and increasing. Data for how to render them is stored in chardata_for_range;
+// pass these to stbtt_GetPackedQuad to get back renderable quads.
+//
+// font_size is the full height of the character from ascender to descender,
+// as computed by stbtt_ScaleForPixelHeight. To use a point size as computed
+// by stbtt_ScaleForMappingEmToPixels, wrap the point size in STBTT_POINT_SIZE()
+// and pass that result as 'font_size':
+//       ...,                  20 , ... // font max minus min y is 20 pixels tall
+//       ..., STBTT_POINT_SIZE(20), ... // 'M' is 20 pixels tall
 
-	typedef struct
-	{
-		float font_size;
-		int first_unicode_codepoint_in_range;  // if non-zero, then the chars are continuous, and this is the first codepoint
-		int *array_of_unicode_codepoints;       // if non-zero, then this is an array of unicode codepoints
-		int num_chars;
-		stbtt_packedchar *chardata_for_range; // output
-		unsigned char h_oversample, v_oversample; // don't set these, they're used internally
-	} stbtt_pack_range;
+typedef struct
+{
+   float font_size;
+   int first_unicode_codepoint_in_range;  // if non-zero, then the chars are continuous, and this is the first codepoint
+   int *array_of_unicode_codepoints;       // if non-zero, then this is an array of unicode codepoints
+   int num_chars;
+   stbtt_packedchar *chardata_for_range; // output
+   unsigned char h_oversample, v_oversample; // don't set these, they're used internally
+} stbtt_pack_range;
 
-	STBTT_DEF int  stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges);
-	// Creates character bitmaps from multiple ranges of characters stored in
-	// ranges. This will usually create a better-packed bitmap than multiple
-	// calls to stbtt_PackFontRange. Note that you can call this multiple
-	// times within a single PackBegin/PackEnd.
+STBTT_DEF int  stbtt_PackFontRanges(stbtt_pack_context *spc, const unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges);
+// Creates character bitmaps from multiple ranges of characters stored in
+// ranges. This will usually create a better-packed bitmap than multiple
+// calls to stbtt_PackFontRange. Note that you can call this multiple
+// times within a single PackBegin/PackEnd.
 
-	STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h_oversample, unsigned int v_oversample);
-	// Oversampling a font increases the quality by allowing higher-quality subpixel
-	// positioning, and is especially valuable at smaller text sizes.
-	//
-	// This function sets the amount of oversampling for all following calls to
-	// stbtt_PackFontRange(s) or stbtt_PackFontRangesGatherRects for a given
-	// pack context. The default (no oversampling) is achieved by h_oversample=1
-	// and v_oversample=1. The total number of pixels required is
-	// h_oversample*v_oversample larger than the default; for example, 2x2
-	// oversampling requires 4x the storage of 1x1. For best results, render
-	// oversampled textures with bilinear filtering. Look at the readme in
-	// stb/tests/oversample for information about oversampled fonts
-	//
-	// To use with PackFontRangesGather etc., you must set it before calls
-	// call to PackFontRangesGatherRects.
+STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h_oversample, unsigned int v_oversample);
+// Oversampling a font increases the quality by allowing higher-quality subpixel
+// positioning, and is especially valuable at smaller text sizes.
+//
+// This function sets the amount of oversampling for all following calls to
+// stbtt_PackFontRange(s) or stbtt_PackFontRangesGatherRects for a given
+// pack context. The default (no oversampling) is achieved by h_oversample=1
+// and v_oversample=1. The total number of pixels required is
+// h_oversample*v_oversample larger than the default; for example, 2x2
+// oversampling requires 4x the storage of 1x1. For best results, render
+// oversampled textures with bilinear filtering. Look at the readme in
+// stb/tests/oversample for information about oversampled fonts
+//
+// To use with PackFontRangesGather etc., you must set it before calls
+// call to PackFontRangesGatherRects.
 
-	STBTT_DEF void stbtt_GetPackedQuad(stbtt_packedchar *chardata, int pw, int ph,  // same data as above
-		int char_index,             // character to display
-		float *xpos, float *ypos,   // pointers to current position in screen pixel space
-		stbtt_aligned_quad *q,      // output: quad to draw
-		int align_to_integer);
+STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar *chardata, int pw, int ph,  // same data as above
+                               int char_index,             // character to display
+                               float *xpos, float *ypos,   // pointers to current position in screen pixel space
+                               stbtt_aligned_quad *q,      // output: quad to draw
+                               int align_to_integer);
 
-	STBTT_DEF int  stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
-	STBTT_DEF void stbtt_PackFontRangesPackRects(stbtt_pack_context *spc, stbrp_rect *rects, int num_rects);
-	STBTT_DEF int  stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
-	// Calling these functions in sequence is roughly equivalent to calling
-	// stbtt_PackFontRanges(). If you more control over the packing of multiple
-	// fonts, or if you want to pack custom data into a font texture, take a look
-	// at the source to of stbtt_PackFontRanges() and create a custom version 
-	// using these functions, e.g. call GatherRects multiple times,
-	// building up a single array of rects, then call PackRects once,
-	// then call RenderIntoRects repeatedly. This may result in a
-	// better packing than calling PackFontRanges multiple times
-	// (or it may not).
+STBTT_DEF int  stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, const stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
+STBTT_DEF void stbtt_PackFontRangesPackRects(stbtt_pack_context *spc, stbrp_rect *rects, int num_rects);
+STBTT_DEF int  stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, const stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
+// Calling these functions in sequence is roughly equivalent to calling
+// stbtt_PackFontRanges(). If you more control over the packing of multiple
+// fonts, or if you want to pack custom data into a font texture, take a look
+// at the source to of stbtt_PackFontRanges() and create a custom version 
+// using these functions, e.g. call GatherRects multiple times,
+// building up a single array of rects, then call PackRects once,
+// then call RenderIntoRects repeatedly. This may result in a
+// better packing than calling PackFontRanges multiple times
+// (or it may not).
 
-	// this is an opaque structure that you shouldn't mess with which holds
-	// all the context needed from PackBegin to PackEnd.
-	struct stbtt_pack_context {
-		void *user_allocator_context;
-		void *pack_info;
-		int   width;
-		int   height;
-		int   stride_in_bytes;
-		int   padding;
-		unsigned int   h_oversample, v_oversample;
-		unsigned char *pixels;
-		void  *nodes;
-	};
+// this is an opaque structure that you shouldn't mess with which holds
+// all the context needed from PackBegin to PackEnd.
+struct stbtt_pack_context {
+   void *user_allocator_context;
+   void *pack_info;
+   int   width;
+   int   height;
+   int   stride_in_bytes;
+   int   padding;
+   unsigned int   h_oversample, v_oversample;
+   unsigned char *pixels;
+   void  *nodes;
+};
 
-	//////////////////////////////////////////////////////////////////////////////
-	//
-	// FONT LOADING
-	//
-	//
+//////////////////////////////////////////////////////////////////////////////
+//
+// FONT LOADING
+//
+//
 
-	STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index);
-	// Each .ttf/.ttc file may have more than one font. Each font has a sequential
-	// index number starting from 0. Call this function to get the font offset for
-	// a given index; it returns -1 if the index is out of range. A regular .ttf
-	// file will only define one font and it always be at offset 0, so it will
-	// return '0' for index 0, and -1 for all other indices. You can just skip
-	// this step if you know it's that kind of font.
+STBTT_DEF int stbtt_GetNumberOfFonts(const unsigned char *data);
+// This function will determine the number of fonts in a font file.  TrueType
+// collection (.ttc) files may contain multiple fonts, while TrueType font
+// (.ttf) files only contain one font. The number of fonts can be used for
+// indexing with the previous function where the index is between zero and one
+// less than the total fonts. If an error occurs, -1 is returned.
 
+STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index);
+// Each .ttf/.ttc file may have more than one font. Each font has a sequential
+// index number starting from 0. Call this function to get the font offset for
+// a given index; it returns -1 if the index is out of range. A regular .ttf
+// file will only define one font and it always be at offset 0, so it will
+// return '0' for index 0, and -1 for all other indices.
 
-	// The following structure is defined publically so you can declare one on
-	// the stack or as a global or etc, but you should treat it as opaque.
-	typedef struct stbtt_fontinfo
-	{
-		void           * userdata;
-		unsigned char  * data;              // pointer to .ttf file
-		int              fontstart;         // offset of start of font
+// The following structure is defined publically so you can declare one on
+// the stack or as a global or etc, but you should treat it as opaque.
+struct stbtt_fontinfo
+{
+   void           * userdata;
+   unsigned char  * data;              // pointer to .ttf file
+   int              fontstart;         // offset of start of font
 
-		int numGlyphs;                     // number of glyphs, needed for range checking
+   int numGlyphs;                     // number of glyphs, needed for range checking
 
-		int loca, head, glyf, hhea, hmtx, kern; // table locations as offset from start of .ttf
-		int index_map;                     // a cmap mapping for our chosen character encoding
-		int indexToLocFormat;              // format needed to map from glyph index to glyph
-	} stbtt_fontinfo;
+   int loca,head,glyf,hhea,hmtx,kern,gpos; // table locations as offset from start of .ttf
+   int index_map;                     // a cmap mapping for our chosen character encoding
+   int indexToLocFormat;              // format needed to map from glyph index to glyph
 
-	STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data, int offset);
-	// Given an offset into the file that defines a font, this function builds
-	// the necessary cached info for the rest of the system. You must allocate
-	// the stbtt_fontinfo yourself, and stbtt_InitFont will fill it out. You don't
-	// need to do anything special to free it, because the contents are pure
-	// value data with no additional data structures. Returns 0 on failure.
+   stbtt__buf cff;                    // cff font data
+   stbtt__buf charstrings;            // the charstring index
+   stbtt__buf gsubrs;                 // global charstring subroutines index
+   stbtt__buf subrs;                  // private charstring subroutines index
+   stbtt__buf fontdicts;              // array of font dicts
+   stbtt__buf fdselect;               // map from glyph to fontdict
+};
 
-
-	//////////////////////////////////////////////////////////////////////////////
-	//
-	// CHARACTER TO GLYPH-INDEX CONVERSIOn
-
-	STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codepoint);
-	// If you're going to perform multiple operations on the same character
-	// and you want a speed-up, call this function with the character you're
-	// going to process, then use glyph-based functions instead of the
-	// codepoint-based functions.
-
-
-	//////////////////////////////////////////////////////////////////////////////
-	//
-	// CHARACTER PROPERTIES
-	//
-
-	STBTT_DEF float stbtt_ScaleForPixelHeight(const stbtt_fontinfo *info, float pixels);
-	// computes a scale factor to produce a font whose "height" is 'pixels' tall.
-	// Height is measured as the distance from the highest ascender to the lowest
-	// descender; in other words, it's equivalent to calling stbtt_GetFontVMetrics
-	// and computing:
-	//       scale = pixels / (ascent - descent)
-	// so if you prefer to measure height by the ascent only, use a similar calculation.
-
-	STBTT_DEF float stbtt_ScaleForMappingEmToPixels(const stbtt_fontinfo *info, float pixels);
-	// computes a scale factor to produce a font whose EM size is mapped to
-	// 'pixels' tall. This is probably what traditional APIs compute, but
-	// I'm not positive.
-
-	STBTT_DEF void stbtt_GetFontVMetrics(const stbtt_fontinfo *info, int *ascent, int *descent, int *lineGap);
-	// ascent is the coordinate above the baseline the font extends; descent
-	// is the coordinate below the baseline the font extends (i.e. it is typically negative)
-	// lineGap is the spacing between one row's descent and the next row's ascent...
-	// so you should advance the vertical position by "*ascent - *descent + *lineGap"
-	//   these are expressed in unscaled coordinates, so you must multiply by
-	//   the scale factor for a given size
-
-	STBTT_DEF void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info, int *x0, int *y0, int *x1, int *y1);
-	// the bounding box around all possible characters
-
-	STBTT_DEF void stbtt_GetCodepointHMetrics(const stbtt_fontinfo *info, int codepoint, int *advanceWidth, int *leftSideBearing);
-	// leftSideBearing is the offset from the current horizontal position to the left edge of the character
-	// advanceWidth is the offset from the current horizontal position to the next horizontal position
-	//   these are expressed in unscaled coordinates
-
-	STBTT_DEF int  stbtt_GetCodepointKernAdvance(const stbtt_fontinfo *info, int ch1, int ch2);
-	// an additional amount to add to the 'advance' value between ch1 and ch2
-
-	STBTT_DEF int stbtt_GetCodepointBox(const stbtt_fontinfo *info, int codepoint, int *x0, int *y0, int *x1, int *y1);
-	// Gets the bounding box of the visible part of the glyph, in unscaled coordinates
-
-	STBTT_DEF void stbtt_GetGlyphHMetrics(const stbtt_fontinfo *info, int glyph_index, int *advanceWidth, int *leftSideBearing);
-	STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2);
-	STBTT_DEF int  stbtt_GetGlyphBox(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1);
-	// as above, but takes one or more glyph indices for greater efficiency
+STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data, int offset);
+// Given an offset into the file that defines a font, this function builds
+// the necessary cached info for the rest of the system. You must allocate
+// the stbtt_fontinfo yourself, and stbtt_InitFont will fill it out. You don't
+// need to do anything special to free it, because the contents are pure
+// value data with no additional data structures. Returns 0 on failure.
 
 
-	//////////////////////////////////////////////////////////////////////////////
-	//
-	// GLYPH SHAPES (you probably don't need these, but they have to go before
-	// the bitmaps for C declaration-order reasons)
-	//
+//////////////////////////////////////////////////////////////////////////////
+//
+// CHARACTER TO GLYPH-INDEX CONVERSIOn
+
+STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codepoint);
+// If you're going to perform multiple operations on the same character
+// and you want a speed-up, call this function with the character you're
+// going to process, then use glyph-based functions instead of the
+// codepoint-based functions.
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// CHARACTER PROPERTIES
+//
+
+STBTT_DEF float stbtt_ScaleForPixelHeight(const stbtt_fontinfo *info, float pixels);
+// computes a scale factor to produce a font whose "height" is 'pixels' tall.
+// Height is measured as the distance from the highest ascender to the lowest
+// descender; in other words, it's equivalent to calling stbtt_GetFontVMetrics
+// and computing:
+//       scale = pixels / (ascent - descent)
+// so if you prefer to measure height by the ascent only, use a similar calculation.
+
+STBTT_DEF float stbtt_ScaleForMappingEmToPixels(const stbtt_fontinfo *info, float pixels);
+// computes a scale factor to produce a font whose EM size is mapped to
+// 'pixels' tall. This is probably what traditional APIs compute, but
+// I'm not positive.
+
+STBTT_DEF void stbtt_GetFontVMetrics(const stbtt_fontinfo *info, int *ascent, int *descent, int *lineGap);
+// ascent is the coordinate above the baseline the font extends; descent
+// is the coordinate below the baseline the font extends (i.e. it is typically negative)
+// lineGap is the spacing between one row's descent and the next row's ascent...
+// so you should advance the vertical position by "*ascent - *descent + *lineGap"
+//   these are expressed in unscaled coordinates, so you must multiply by
+//   the scale factor for a given size
+
+STBTT_DEF int  stbtt_GetFontVMetricsOS2(const stbtt_fontinfo *info, int *typoAscent, int *typoDescent, int *typoLineGap);
+// analogous to GetFontVMetrics, but returns the "typographic" values from the OS/2
+// table (specific to MS/Windows TTF files).
+//
+// Returns 1 on success (table present), 0 on failure.
+
+STBTT_DEF void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info, int *x0, int *y0, int *x1, int *y1);
+// the bounding box around all possible characters
+
+STBTT_DEF void stbtt_GetCodepointHMetrics(const stbtt_fontinfo *info, int codepoint, int *advanceWidth, int *leftSideBearing);
+// leftSideBearing is the offset from the current horizontal position to the left edge of the character
+// advanceWidth is the offset from the current horizontal position to the next horizontal position
+//   these are expressed in unscaled coordinates
+
+STBTT_DEF int  stbtt_GetCodepointKernAdvance(const stbtt_fontinfo *info, int ch1, int ch2);
+// an additional amount to add to the 'advance' value between ch1 and ch2
+
+STBTT_DEF int stbtt_GetCodepointBox(const stbtt_fontinfo *info, int codepoint, int *x0, int *y0, int *x1, int *y1);
+// Gets the bounding box of the visible part of the glyph, in unscaled coordinates
+
+STBTT_DEF void stbtt_GetGlyphHMetrics(const stbtt_fontinfo *info, int glyph_index, int *advanceWidth, int *leftSideBearing);
+STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2);
+STBTT_DEF int  stbtt_GetGlyphBox(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1);
+// as above, but takes one or more glyph indices for greater efficiency
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// GLYPH SHAPES (you probably don't need these, but they have to go before
+// the bitmaps for C declaration-order reasons)
+//
 
 #ifndef STBTT_vmove // you can predefine these to use different values (but why?)
-	enum {
-		STBTT_vmove = 1,
-		STBTT_vline,
-		STBTT_vcurve
-	};
+   enum {
+      STBTT_vmove=1,
+      STBTT_vline,
+      STBTT_vcurve,
+      STBTT_vcubic
+   };
 #endif
 
 #ifndef stbtt_vertex // you can predefine this to use different values
-	// (we share this with other code at RAD)
-#define stbtt_vertex_type short // can't use stbtt_int16 because that's not visible in the header file
-	typedef struct
-	{
-		stbtt_vertex_type x, y, cx, cy;
-		unsigned char type, padding;
-	} stbtt_vertex;
+                   // (we share this with other code at RAD)
+   #define stbtt_vertex_type short // can't use stbtt_int16 because that's not visible in the header file
+   typedef struct
+   {
+      stbtt_vertex_type x,y,cx,cy,cx1,cy1;
+      unsigned char type,padding;
+   } stbtt_vertex;
 #endif
 
-	STBTT_DEF int stbtt_IsGlyphEmpty(const stbtt_fontinfo *info, int glyph_index);
-	// returns non-zero if nothing is drawn for this glyph
+STBTT_DEF int stbtt_IsGlyphEmpty(const stbtt_fontinfo *info, int glyph_index);
+// returns non-zero if nothing is drawn for this glyph
 
-	STBTT_DEF int stbtt_GetCodepointShape(const stbtt_fontinfo *info, int unicode_codepoint, stbtt_vertex **vertices);
-	STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **vertices);
-	// returns # of vertices and fills *vertices with the pointer to them
-	//   these are expressed in "unscaled" coordinates
-	//
-	// The shape is a series of countours. Each one starts with
-	// a STBTT_moveto, then consists of a series of mixed
-	// STBTT_lineto and STBTT_curveto segments. A lineto
-	// draws a line from previous endpoint to its x,y; a curveto
-	// draws a quadratic bezier from previous endpoint to
-	// its x,y, using cx,cy as the bezier control point.
+STBTT_DEF int stbtt_GetCodepointShape(const stbtt_fontinfo *info, int unicode_codepoint, stbtt_vertex **vertices);
+STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **vertices);
+// returns # of vertices and fills *vertices with the pointer to them
+//   these are expressed in "unscaled" coordinates
+//
+// The shape is a series of countours. Each one starts with
+// a STBTT_moveto, then consists of a series of mixed
+// STBTT_lineto and STBTT_curveto segments. A lineto
+// draws a line from previous endpoint to its x,y; a curveto
+// draws a quadratic bezier from previous endpoint to
+// its x,y, using cx,cy as the bezier control point.
 
-	STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *vertices);
-	// frees the data allocated above
+STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *vertices);
+// frees the data allocated above
 
-	//////////////////////////////////////////////////////////////////////////////
-	//
-	// BITMAP RENDERING
-	//
+//////////////////////////////////////////////////////////////////////////////
+//
+// BITMAP RENDERING
+//
 
-	STBTT_DEF void stbtt_FreeBitmap(unsigned char *bitmap, void *userdata);
-	// frees the bitmap allocated below
+STBTT_DEF void stbtt_FreeBitmap(unsigned char *bitmap, void *userdata);
+// frees the bitmap allocated below
 
-	STBTT_DEF unsigned char *stbtt_GetCodepointBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int codepoint, int *width, int *height, int *xoff, int *yoff);
-	// allocates a large-enough single-channel 8bpp bitmap and renders the
-	// specified character/glyph at the specified scale into it, with
-	// antialiasing. 0 is no coverage (transparent), 255 is fully covered (opaque).
-	// *width & *height are filled out with the width & height of the bitmap,
-	// which is stored left-to-right, top-to-bottom.
-	//
-	// xoff/yoff are the offset it pixel space from the glyph origin to the top-left of the bitmap
+STBTT_DEF unsigned char *stbtt_GetCodepointBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int codepoint, int *width, int *height, int *xoff, int *yoff);
+// allocates a large-enough single-channel 8bpp bitmap and renders the
+// specified character/glyph at the specified scale into it, with
+// antialiasing. 0 is no coverage (transparent), 255 is fully covered (opaque).
+// *width & *height are filled out with the width & height of the bitmap,
+// which is stored left-to-right, top-to-bottom.
+//
+// xoff/yoff are the offset it pixel space from the glyph origin to the top-left of the bitmap
 
-	STBTT_DEF unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint, int *width, int *height, int *xoff, int *yoff);
-	// the same as stbtt_GetCodepoitnBitmap, but you can specify a subpixel
-	// shift for the character
+STBTT_DEF unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint, int *width, int *height, int *xoff, int *yoff);
+// the same as stbtt_GetCodepoitnBitmap, but you can specify a subpixel
+// shift for the character
 
-	STBTT_DEF void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int codepoint);
-	// the same as stbtt_GetCodepointBitmap, but you pass in storage for the bitmap
-	// in the form of 'output', with row spacing of 'out_stride' bytes. the bitmap
-	// is clipped to out_w/out_h bytes. Call stbtt_GetCodepointBitmapBox to get the
-	// width and height and positioning info for it first.
+STBTT_DEF void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int codepoint);
+// the same as stbtt_GetCodepointBitmap, but you pass in storage for the bitmap
+// in the form of 'output', with row spacing of 'out_stride' bytes. the bitmap
+// is clipped to out_w/out_h bytes. Call stbtt_GetCodepointBitmapBox to get the
+// width and height and positioning info for it first.
 
-	STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint);
-	// same as stbtt_MakeCodepointBitmap, but you can specify a subpixel
-	// shift for the character
+STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint);
+// same as stbtt_MakeCodepointBitmap, but you can specify a subpixel
+// shift for the character
 
-	STBTT_DEF void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
-	// get the bbox of the bitmap centered around the glyph origin; so the
-	// bitmap width is ix1-ix0, height is iy1-iy0, and location to place
-	// the bitmap top left is (leftSideBearing*scale,iy0).
-	// (Note that the bitmap uses y-increases-down, but the shape uses
-	// y-increases-up, so CodepointBitmapBox and CodepointBox are inverted.)
+STBTT_DEF void stbtt_MakeCodepointBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int oversample_x, int oversample_y, float *sub_x, float *sub_y, int codepoint);
+// same as stbtt_MakeCodepointBitmapSubpixel, but prefiltering
+// is performed (see stbtt_PackSetOversampling)
 
-	STBTT_DEF void stbtt_GetCodepointBitmapBoxSubpixel(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1);
-	// same as stbtt_GetCodepointBitmapBox, but you can specify a subpixel
-	// shift for the character
+STBTT_DEF void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
+// get the bbox of the bitmap centered around the glyph origin; so the
+// bitmap width is ix1-ix0, height is iy1-iy0, and location to place
+// the bitmap top left is (leftSideBearing*scale,iy0).
+// (Note that the bitmap uses y-increases-down, but the shape uses
+// y-increases-up, so CodepointBitmapBox and CodepointBox are inverted.)
 
-	// the following functions are equivalent to the above functions, but operate
-	// on glyph indices instead of Unicode codepoints (for efficiency)
-	STBTT_DEF unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int *width, int *height, int *xoff, int *yoff);
-	STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int glyph, int *width, int *height, int *xoff, int *yoff);
-	STBTT_DEF void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int glyph);
-	STBTT_DEF void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int glyph);
-	STBTT_DEF void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
-	STBTT_DEF void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1);
+STBTT_DEF void stbtt_GetCodepointBitmapBoxSubpixel(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1);
+// same as stbtt_GetCodepointBitmapBox, but you can specify a subpixel
+// shift for the character
 
-
-	// @TODO: don't expose this structure
-	typedef struct
-	{
-		int w, h, stride;
-		unsigned char *pixels;
-	} stbtt__bitmap;
-
-	// rasterize a shape with quadratic beziers into a bitmap
-	STBTT_DEF void stbtt_Rasterize(stbtt__bitmap *result,        // 1-channel bitmap to draw into
-		float flatness_in_pixels,     // allowable error of curve in pixels
-		stbtt_vertex *vertices,       // array of vertices defining shape
-		int num_verts,                // number of vertices in above array
-		float scale_x, float scale_y, // scale applied to input vertices
-		float shift_x, float shift_y, // translation applied to input vertices
-		int x_off, int y_off,         // another translation applied to input
-		int invert,                   // if non-zero, vertically flip shape
-		void *userdata);              // context for to STBTT_MALLOC
-
-									  //////////////////////////////////////////////////////////////////////////////
-									  //
-									  // Finding the right font...
-									  //
-									  // You should really just solve this offline, keep your own tables
-									  // of what font is what, and don't try to get it out of the .ttf file.
-									  // That's because getting it out of the .ttf file is really hard, because
-									  // the names in the file can appear in many possible encodings, in many
-									  // possible languages, and e.g. if you need a case-insensitive comparison,
-									  // the details of that depend on the encoding & language in a complex way
-									  // (actually underspecified in truetype, but also gigantic).
-									  //
-									  // But you can use the provided functions in two possible ways:
-									  //     stbtt_FindMatchingFont() will use *case-sensitive* comparisons on
-									  //             unicode-encoded names to try to find the font you want;
-									  //             you can run this before calling stbtt_InitFont()
-									  //
-									  //     stbtt_GetFontNameString() lets you get any of the various strings
-									  //             from the file yourself and do your own comparisons on them.
-									  //             You have to have called stbtt_InitFont() first.
+// the following functions are equivalent to the above functions, but operate
+// on glyph indices instead of Unicode codepoints (for efficiency)
+STBTT_DEF unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int *width, int *height, int *xoff, int *yoff);
+STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int glyph, int *width, int *height, int *xoff, int *yoff);
+STBTT_DEF void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int glyph);
+STBTT_DEF void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int glyph);
+STBTT_DEF void stbtt_MakeGlyphBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int oversample_x, int oversample_y, float *sub_x, float *sub_y, int glyph);
+STBTT_DEF void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
+STBTT_DEF void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y,float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1);
 
 
-	STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *fontdata, const char *name, int flags);
-	// returns the offset (not index) of the font that matches, or -1 if none
-	//   if you use STBTT_MACSTYLE_DONTCARE, use a font name like "Arial Bold".
-	//   if you use any other flag, use a font name like "Arial"; this checks
-	//     the 'macStyle' header field; i don't know if fonts set this consistently
+// @TODO: don't expose this structure
+typedef struct
+{
+   int w,h,stride;
+   unsigned char *pixels;
+} stbtt__bitmap;
+
+// rasterize a shape with quadratic beziers into a bitmap
+STBTT_DEF void stbtt_Rasterize(stbtt__bitmap *result,        // 1-channel bitmap to draw into
+                               float flatness_in_pixels,     // allowable error of curve in pixels
+                               stbtt_vertex *vertices,       // array of vertices defining shape
+                               int num_verts,                // number of vertices in above array
+                               float scale_x, float scale_y, // scale applied to input vertices
+                               float shift_x, float shift_y, // translation applied to input vertices
+                               int x_off, int y_off,         // another translation applied to input
+                               int invert,                   // if non-zero, vertically flip shape
+                               void *userdata);              // context for to STBTT_MALLOC
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// Signed Distance Function (or Field) rendering
+
+STBTT_DEF void stbtt_FreeSDF(unsigned char *bitmap, void *userdata);
+// frees the SDF bitmap allocated below
+
+STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float scale, int glyph, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff);
+STBTT_DEF unsigned char * stbtt_GetCodepointSDF(const stbtt_fontinfo *info, float scale, int codepoint, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff);
+// These functions compute a discretized SDF field for a single character, suitable for storing
+// in a single-channel texture, sampling with bilinear filtering, and testing against
+// larger than some threshhold to produce scalable fonts.
+//        info              --  the font
+//        scale             --  controls the size of the resulting SDF bitmap, same as it would be creating a regular bitmap
+//        glyph/codepoint   --  the character to generate the SDF for
+//        padding           --  extra "pixels" around the character which are filled with the distance to the character (not 0),
+//                                 which allows effects like bit outlines
+//        onedge_value      --  value 0-255 to test the SDF against to reconstruct the character (i.e. the isocontour of the character)
+//        pixel_dist_scale  --  what value the SDF should increase by when moving one SDF "pixel" away from the edge (on the 0..255 scale)
+//                                 if positive, > onedge_value is inside; if negative, < onedge_value is inside
+//        width,height      --  output height & width of the SDF bitmap (including padding)
+//        xoff,yoff         --  output origin of the character
+//        return value      --  a 2D array of bytes 0..255, width*height in size
+//
+// pixel_dist_scale & onedge_value are a scale & bias that allows you to make
+// optimal use of the limited 0..255 for your application, trading off precision
+// and special effects. SDF values outside the range 0..255 are clamped to 0..255.
+//
+// Example:
+//      scale = stbtt_ScaleForPixelHeight(22)
+//      padding = 5
+//      onedge_value = 180
+//      pixel_dist_scale = 180/5.0 = 36.0
+//
+//      This will create an SDF bitmap in which the character is about 22 pixels
+//      high but the whole bitmap is about 22+5+5=32 pixels high. To produce a filled
+//      shape, sample the SDF at each pixel and fill the pixel if the SDF value
+//      is greater than or equal to 180/255. (You'll actually want to antialias,
+//      which is beyond the scope of this example.) Additionally, you can compute
+//      offset outlines (e.g. to stroke the character border inside & outside,
+//      or only outside). For example, to fill outside the character up to 3 SDF
+//      pixels, you would compare against (180-36.0*3)/255 = 72/255. The above
+//      choice of variables maps a range from 5 pixels outside the shape to
+//      2 pixels inside the shape to 0..255; this is intended primarily for apply
+//      outside effects only (the interior range is needed to allow proper
+//      antialiasing of the font at *smaller* sizes)
+//
+// The function computes the SDF analytically at each SDF pixel, not by e.g.
+// building a higher-res bitmap and approximating it. In theory the quality
+// should be as high as possible for an SDF of this size & representation, but
+// unclear if this is true in practice (perhaps building a higher-res bitmap
+// and computing from that can allow drop-out prevention).
+//
+// The algorithm has not been optimized at all, so expect it to be slow
+// if computing lots of characters or very large sizes. 
+
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// Finding the right font...
+//
+// You should really just solve this offline, keep your own tables
+// of what font is what, and don't try to get it out of the .ttf file.
+// That's because getting it out of the .ttf file is really hard, because
+// the names in the file can appear in many possible encodings, in many
+// possible languages, and e.g. if you need a case-insensitive comparison,
+// the details of that depend on the encoding & language in a complex way
+// (actually underspecified in truetype, but also gigantic).
+//
+// But you can use the provided functions in two possible ways:
+//     stbtt_FindMatchingFont() will use *case-sensitive* comparisons on
+//             unicode-encoded names to try to find the font you want;
+//             you can run this before calling stbtt_InitFont()
+//
+//     stbtt_GetFontNameString() lets you get any of the various strings
+//             from the file yourself and do your own comparisons on them.
+//             You have to have called stbtt_InitFont() first.
+
+
+STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *fontdata, const char *name, int flags);
+// returns the offset (not index) of the font that matches, or -1 if none
+//   if you use STBTT_MACSTYLE_DONTCARE, use a font name like "Arial Bold".
+//   if you use any other flag, use a font name like "Arial"; this checks
+//     the 'macStyle' header field; i don't know if fonts set this consistently
 #define STBTT_MACSTYLE_DONTCARE     0
 #define STBTT_MACSTYLE_BOLD         1
 #define STBTT_MACSTYLE_ITALIC       2
 #define STBTT_MACSTYLE_UNDERSCORE   4
 #define STBTT_MACSTYLE_NONE         8   // <= not same as 0, this makes us check the bitfield is 0
 
-	STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const char *s2, int len2);
-	// returns 1/0 whether the first string interpreted as utf8 is identical to
-	// the second string interpreted as big-endian utf16... useful for strings from next func
+STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const char *s2, int len2);
+// returns 1/0 whether the first string interpreted as utf8 is identical to
+// the second string interpreted as big-endian utf16... useful for strings from next func
 
-	STBTT_DEF const char *stbtt_GetFontNameString(const stbtt_fontinfo *font, int *length, int platformID, int encodingID, int languageID, int nameID);
-	// returns the string (which may be big-endian double byte, e.g. for unicode)
-	// and puts the length in bytes in *length.
-	//
-	// some of the values for the IDs are below; for more see the truetype spec:
-	//     http://developer.apple.com/textfonts/TTRefMan/RM06/Chap6name.html
-	//     http://www.microsoft.com/typography/otspec/name.htm
+STBTT_DEF const char *stbtt_GetFontNameString(const stbtt_fontinfo *font, int *length, int platformID, int encodingID, int languageID, int nameID);
+// returns the string (which may be big-endian double byte, e.g. for unicode)
+// and puts the length in bytes in *length.
+//
+// some of the values for the IDs are below; for more see the truetype spec:
+//     http://developer.apple.com/textfonts/TTRefMan/RM06/Chap6name.html
+//     http://www.microsoft.com/typography/otspec/name.htm
 
-	enum { // platformID
-		STBTT_PLATFORM_ID_UNICODE = 0,
-		STBTT_PLATFORM_ID_MAC = 1,
-		STBTT_PLATFORM_ID_ISO = 2,
-		STBTT_PLATFORM_ID_MICROSOFT = 3
-	};
+enum { // platformID
+   STBTT_PLATFORM_ID_UNICODE   =0,
+   STBTT_PLATFORM_ID_MAC       =1,
+   STBTT_PLATFORM_ID_ISO       =2,
+   STBTT_PLATFORM_ID_MICROSOFT =3
+};
 
-	enum { // encodingID for STBTT_PLATFORM_ID_UNICODE
-		STBTT_UNICODE_EID_UNICODE_1_0 = 0,
-		STBTT_UNICODE_EID_UNICODE_1_1 = 1,
-		STBTT_UNICODE_EID_ISO_10646 = 2,
-		STBTT_UNICODE_EID_UNICODE_2_0_BMP = 3,
-		STBTT_UNICODE_EID_UNICODE_2_0_FULL = 4
-	};
+enum { // encodingID for STBTT_PLATFORM_ID_UNICODE
+   STBTT_UNICODE_EID_UNICODE_1_0    =0,
+   STBTT_UNICODE_EID_UNICODE_1_1    =1,
+   STBTT_UNICODE_EID_ISO_10646      =2,
+   STBTT_UNICODE_EID_UNICODE_2_0_BMP=3,
+   STBTT_UNICODE_EID_UNICODE_2_0_FULL=4
+};
 
-	enum { // encodingID for STBTT_PLATFORM_ID_MICROSOFT
-		STBTT_MS_EID_SYMBOL = 0,
-		STBTT_MS_EID_UNICODE_BMP = 1,
-		STBTT_MS_EID_SHIFTJIS = 2,
-		STBTT_MS_EID_UNICODE_FULL = 10
-	};
+enum { // encodingID for STBTT_PLATFORM_ID_MICROSOFT
+   STBTT_MS_EID_SYMBOL        =0,
+   STBTT_MS_EID_UNICODE_BMP   =1,
+   STBTT_MS_EID_SHIFTJIS      =2,
+   STBTT_MS_EID_UNICODE_FULL  =10
+};
 
-	enum { // encodingID for STBTT_PLATFORM_ID_MAC; same as Script Manager codes
-		STBTT_MAC_EID_ROMAN = 0, STBTT_MAC_EID_ARABIC = 4,
-		STBTT_MAC_EID_JAPANESE = 1, STBTT_MAC_EID_HEBREW = 5,
-		STBTT_MAC_EID_CHINESE_TRAD = 2, STBTT_MAC_EID_GREEK = 6,
-		STBTT_MAC_EID_KOREAN = 3, STBTT_MAC_EID_RUSSIAN = 7
-	};
+enum { // encodingID for STBTT_PLATFORM_ID_MAC; same as Script Manager codes
+   STBTT_MAC_EID_ROMAN        =0,   STBTT_MAC_EID_ARABIC       =4,
+   STBTT_MAC_EID_JAPANESE     =1,   STBTT_MAC_EID_HEBREW       =5,
+   STBTT_MAC_EID_CHINESE_TRAD =2,   STBTT_MAC_EID_GREEK        =6,
+   STBTT_MAC_EID_KOREAN       =3,   STBTT_MAC_EID_RUSSIAN      =7
+};
 
-	enum { // languageID for STBTT_PLATFORM_ID_MICROSOFT; same as LCID...
-		   // problematic because there are e.g. 16 english LCIDs and 16 arabic LCIDs
-		STBTT_MS_LANG_ENGLISH = 0x0409, STBTT_MS_LANG_ITALIAN = 0x0410,
-		STBTT_MS_LANG_CHINESE = 0x0804, STBTT_MS_LANG_JAPANESE = 0x0411,
-		STBTT_MS_LANG_DUTCH = 0x0413, STBTT_MS_LANG_KOREAN = 0x0412,
-		STBTT_MS_LANG_FRENCH = 0x040c, STBTT_MS_LANG_RUSSIAN = 0x0419,
-		STBTT_MS_LANG_GERMAN = 0x0407, STBTT_MS_LANG_SPANISH = 0x0409,
-		STBTT_MS_LANG_HEBREW = 0x040d, STBTT_MS_LANG_SWEDISH = 0x041D
-	};
+enum { // languageID for STBTT_PLATFORM_ID_MICROSOFT; same as LCID...
+       // problematic because there are e.g. 16 english LCIDs and 16 arabic LCIDs
+   STBTT_MS_LANG_ENGLISH     =0x0409,   STBTT_MS_LANG_ITALIAN     =0x0410,
+   STBTT_MS_LANG_CHINESE     =0x0804,   STBTT_MS_LANG_JAPANESE    =0x0411,
+   STBTT_MS_LANG_DUTCH       =0x0413,   STBTT_MS_LANG_KOREAN      =0x0412,
+   STBTT_MS_LANG_FRENCH      =0x040c,   STBTT_MS_LANG_RUSSIAN     =0x0419,
+   STBTT_MS_LANG_GERMAN      =0x0407,   STBTT_MS_LANG_SPANISH     =0x0409,
+   STBTT_MS_LANG_HEBREW      =0x040d,   STBTT_MS_LANG_SWEDISH     =0x041D
+};
 
-	enum { // languageID for STBTT_PLATFORM_ID_MAC
-		STBTT_MAC_LANG_ENGLISH = 0, STBTT_MAC_LANG_JAPANESE = 11,
-		STBTT_MAC_LANG_ARABIC = 12, STBTT_MAC_LANG_KOREAN = 23,
-		STBTT_MAC_LANG_DUTCH = 4, STBTT_MAC_LANG_RUSSIAN = 32,
-		STBTT_MAC_LANG_FRENCH = 1, STBTT_MAC_LANG_SPANISH = 6,
-		STBTT_MAC_LANG_GERMAN = 2, STBTT_MAC_LANG_SWEDISH = 5,
-		STBTT_MAC_LANG_HEBREW = 10, STBTT_MAC_LANG_CHINESE_SIMPLIFIED = 33,
-		STBTT_MAC_LANG_ITALIAN = 3, STBTT_MAC_LANG_CHINESE_TRAD = 19
-	};
+enum { // languageID for STBTT_PLATFORM_ID_MAC
+   STBTT_MAC_LANG_ENGLISH      =0 ,   STBTT_MAC_LANG_JAPANESE     =11,
+   STBTT_MAC_LANG_ARABIC       =12,   STBTT_MAC_LANG_KOREAN       =23,
+   STBTT_MAC_LANG_DUTCH        =4 ,   STBTT_MAC_LANG_RUSSIAN      =32,
+   STBTT_MAC_LANG_FRENCH       =1 ,   STBTT_MAC_LANG_SPANISH      =6 ,
+   STBTT_MAC_LANG_GERMAN       =2 ,   STBTT_MAC_LANG_SWEDISH      =5 ,
+   STBTT_MAC_LANG_HEBREW       =10,   STBTT_MAC_LANG_CHINESE_SIMPLIFIED =33,
+   STBTT_MAC_LANG_ITALIAN      =3 ,   STBTT_MAC_LANG_CHINESE_TRAD =19
+};
 
 #ifdef __cplusplus
 }
@@ -938,11 +1080,163 @@ extern "C" {
 #error "STBTT_MAX_OVERSAMPLE cannot be > 255"
 #endif
 
-typedef int stbtt__test_oversample_pow2[(STBTT_MAX_OVERSAMPLE & (STBTT_MAX_OVERSAMPLE - 1)) == 0 ? 1 : -1];
+typedef int stbtt__test_oversample_pow2[(STBTT_MAX_OVERSAMPLE & (STBTT_MAX_OVERSAMPLE-1)) == 0 ? 1 : -1];
 
 #ifndef STBTT_RASTERIZER_VERSION
 #define STBTT_RASTERIZER_VERSION 2
 #endif
+
+#ifdef _MSC_VER
+#define STBTT__NOTUSED(v)  (void)(v)
+#else
+#define STBTT__NOTUSED(v)  (void)sizeof(v)
+#endif
+
+//////////////////////////////////////////////////////////////////////////
+//
+// stbtt__buf helpers to parse data from file
+//
+
+static stbtt_uint8 stbtt__buf_get8(stbtt__buf *b)
+{
+   if (b->cursor >= b->size)
+      return 0;
+   return b->data[b->cursor++];
+}
+
+static stbtt_uint8 stbtt__buf_peek8(stbtt__buf *b)
+{
+   if (b->cursor >= b->size)
+      return 0;
+   return b->data[b->cursor];
+}
+
+static void stbtt__buf_seek(stbtt__buf *b, int o)
+{
+   STBTT_assert(!(o > b->size || o < 0));
+   b->cursor = (o > b->size || o < 0) ? b->size : o;
+}
+
+static void stbtt__buf_skip(stbtt__buf *b, int o)
+{
+   stbtt__buf_seek(b, b->cursor + o);
+}
+
+static stbtt_uint32 stbtt__buf_get(stbtt__buf *b, int n)
+{
+   stbtt_uint32 v = 0;
+   int i;
+   STBTT_assert(n >= 1 && n <= 4);
+   for (i = 0; i < n; i++)
+      v = (v << 8) | stbtt__buf_get8(b);
+   return v;
+}
+
+static stbtt__buf stbtt__new_buf(const void *p, size_t size)
+{
+   stbtt__buf r;
+   STBTT_assert(size < 0x40000000);
+   r.data = (stbtt_uint8*) p;
+   r.size = (int) size;
+   r.cursor = 0;
+   return r;
+}
+
+#define stbtt__buf_get16(b)  stbtt__buf_get((b), 2)
+#define stbtt__buf_get32(b)  stbtt__buf_get((b), 4)
+
+static stbtt__buf stbtt__buf_range(const stbtt__buf *b, int o, int s)
+{
+   stbtt__buf r = stbtt__new_buf(NULL, 0);
+   if (o < 0 || s < 0 || o > b->size || s > b->size - o) return r;
+   r.data = b->data + o;
+   r.size = s;
+   return r;
+}
+
+static stbtt__buf stbtt__cff_get_index(stbtt__buf *b)
+{
+   int count, start, offsize;
+   start = b->cursor;
+   count = stbtt__buf_get16(b);
+   if (count) {
+      offsize = stbtt__buf_get8(b);
+      STBTT_assert(offsize >= 1 && offsize <= 4);
+      stbtt__buf_skip(b, offsize * count);
+      stbtt__buf_skip(b, stbtt__buf_get(b, offsize) - 1);
+   }
+   return stbtt__buf_range(b, start, b->cursor - start);
+}
+
+static stbtt_uint32 stbtt__cff_int(stbtt__buf *b)
+{
+   int b0 = stbtt__buf_get8(b);
+   if (b0 >= 32 && b0 <= 246)       return b0 - 139;
+   else if (b0 >= 247 && b0 <= 250) return (b0 - 247)*256 + stbtt__buf_get8(b) + 108;
+   else if (b0 >= 251 && b0 <= 254) return -(b0 - 251)*256 - stbtt__buf_get8(b) - 108;
+   else if (b0 == 28)               return stbtt__buf_get16(b);
+   else if (b0 == 29)               return stbtt__buf_get32(b);
+   STBTT_assert(0);
+   return 0;
+}
+
+static void stbtt__cff_skip_operand(stbtt__buf *b) {
+   int v, b0 = stbtt__buf_peek8(b);
+   STBTT_assert(b0 >= 28);
+   if (b0 == 30) {
+      stbtt__buf_skip(b, 1);
+      while (b->cursor < b->size) {
+         v = stbtt__buf_get8(b);
+         if ((v & 0xF) == 0xF || (v >> 4) == 0xF)
+            break;
+      }
+   } else {
+      stbtt__cff_int(b);
+   }
+}
+
+static stbtt__buf stbtt__dict_get(stbtt__buf *b, int key)
+{
+   stbtt__buf_seek(b, 0);
+   while (b->cursor < b->size) {
+      int start = b->cursor, end, op;
+      while (stbtt__buf_peek8(b) >= 28)
+         stbtt__cff_skip_operand(b);
+      end = b->cursor;
+      op = stbtt__buf_get8(b);
+      if (op == 12)  op = stbtt__buf_get8(b) | 0x100;
+      if (op == key) return stbtt__buf_range(b, start, end-start);
+   }
+   return stbtt__buf_range(b, 0, 0);
+}
+
+static void stbtt__dict_get_ints(stbtt__buf *b, int key, int outcount, stbtt_uint32 *out)
+{
+   int i;
+   stbtt__buf operands = stbtt__dict_get(b, key);
+   for (i = 0; i < outcount && operands.cursor < operands.size; i++)
+      out[i] = stbtt__cff_int(&operands);
+}
+
+static int stbtt__cff_index_count(stbtt__buf *b)
+{
+   stbtt__buf_seek(b, 0);
+   return stbtt__buf_get16(b);
+}
+
+static stbtt__buf stbtt__cff_index_get(stbtt__buf b, int i)
+{
+   int count, offsize, start, end;
+   stbtt__buf_seek(&b, 0);
+   count = stbtt__buf_get16(&b);
+   offsize = stbtt__buf_get8(&b);
+   STBTT_assert(i >= 0 && i < count);
+   STBTT_assert(offsize >= 1 && offsize <= 4);
+   stbtt__buf_skip(&b, i*offsize);
+   start = stbtt__buf_get(&b, offsize);
+   end = stbtt__buf_get(&b, offsize);
+   return stbtt__buf_range(&b, 2+(count+1)*offsize+start, end - start);
+}
 
 //////////////////////////////////////////////////////////////////////////
 //
@@ -956,622 +1250,1356 @@ typedef int stbtt__test_oversample_pow2[(STBTT_MAX_OVERSAMPLE & (STBTT_MAX_OVERS
 #define ttCHAR(p)     (* (stbtt_int8 *) (p))
 #define ttFixed(p)    ttLONG(p)
 
-#if defined(STB_TRUETYPE_BIGENDIAN) && !defined(ALLOW_UNALIGNED_TRUETYPE)
-
-#define ttUSHORT(p)   (* (stbtt_uint16 *) (p))
-#define ttSHORT(p)    (* (stbtt_int16 *) (p))
-#define ttULONG(p)    (* (stbtt_uint32 *) (p))
-#define ttLONG(p)     (* (stbtt_int32 *) (p))
-
-#else
-
-static stbtt_uint16 ttUSHORT(const stbtt_uint8 *p) { return p[0] * 256 + p[1]; }
-static stbtt_int16 ttSHORT(const stbtt_uint8 *p) { return p[0] * 256 + p[1]; }
-static stbtt_uint32 ttULONG(const stbtt_uint8 *p) { return (p[0] << 24) + (p[1] << 16) + (p[2] << 8) + p[3]; }
-static stbtt_int32 ttLONG(const stbtt_uint8 *p) { return (p[0] << 24) + (p[1] << 16) + (p[2] << 8) + p[3]; }
-
-#endif
+static stbtt_uint16 ttUSHORT(stbtt_uint8 *p) { return p[0]*256 + p[1]; }
+static stbtt_int16 ttSHORT(stbtt_uint8 *p)   { return p[0]*256 + p[1]; }
+static stbtt_uint32 ttULONG(stbtt_uint8 *p)  { return (p[0]<<24) + (p[1]<<16) + (p[2]<<8) + p[3]; }
+static stbtt_int32 ttLONG(stbtt_uint8 *p)    { return (p[0]<<24) + (p[1]<<16) + (p[2]<<8) + p[3]; }
 
 #define stbtt_tag4(p,c0,c1,c2,c3) ((p)[0] == (c0) && (p)[1] == (c1) && (p)[2] == (c2) && (p)[3] == (c3))
 #define stbtt_tag(p,str)           stbtt_tag4(p,str[0],str[1],str[2],str[3])
 
-static int stbtt__isfont(const stbtt_uint8 *font)
+static int stbtt__isfont(stbtt_uint8 *font)
 {
-	// check the version number
-	if (stbtt_tag4(font, '1', 0, 0, 0))  return 1; // TrueType 1
-	if (stbtt_tag(font, "typ1"))   return 1; // TrueType with type 1 font -- we don't support this!
-	if (stbtt_tag(font, "OTTO"))   return 1; // OpenType with CFF
-	if (stbtt_tag4(font, 0, 1, 0, 0)) return 1; // OpenType 1.0
-	return 0;
+   // check the version number
+   if (stbtt_tag4(font, '1',0,0,0))  return 1; // TrueType 1
+   if (stbtt_tag(font, "typ1"))   return 1; // TrueType with type 1 font -- we don't support this!
+   if (stbtt_tag(font, "OTTO"))   return 1; // OpenType with CFF
+   if (stbtt_tag4(font, 0,1,0,0)) return 1; // OpenType 1.0
+   if (stbtt_tag(font, "true"))   return 1; // Apple specification for TrueType fonts
+   return 0;
 }
 
 // @OPTIMIZE: binary search
 static stbtt_uint32 stbtt__find_table(stbtt_uint8 *data, stbtt_uint32 fontstart, const char *tag)
 {
-	stbtt_int32 num_tables = ttUSHORT(data + fontstart + 4);
-	stbtt_uint32 tabledir = fontstart + 12;
-	stbtt_int32 i;
-	for (i = 0; i < num_tables; ++i) {
-		stbtt_uint32 loc = tabledir + 16 * i;
-		if (stbtt_tag(data + loc + 0, tag))
-			return ttULONG(data + loc + 8);
-	}
-	return 0;
+   stbtt_int32 num_tables = ttUSHORT(data+fontstart+4);
+   stbtt_uint32 tabledir = fontstart + 12;
+   stbtt_int32 i;
+   for (i=0; i < num_tables; ++i) {
+      stbtt_uint32 loc = tabledir + 16*i;
+      if (stbtt_tag(data+loc+0, tag))
+         return ttULONG(data+loc+8);
+   }
+   return 0;
 }
 
-STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *font_collection, int index)
+static int stbtt_GetFontOffsetForIndex_internal(unsigned char *font_collection, int index)
 {
-	// if it's just a font, there's only one valid index
-	if (stbtt__isfont(font_collection))
-		return index == 0 ? 0 : -1;
+   // if it's just a font, there's only one valid index
+   if (stbtt__isfont(font_collection))
+      return index == 0 ? 0 : -1;
 
-	// check if it's a TTC
-	if (stbtt_tag(font_collection, "ttcf")) {
-		// version 1?
-		if (ttULONG(font_collection + 4) == 0x00010000 || ttULONG(font_collection + 4) == 0x00020000) {
-			stbtt_int32 n = ttLONG(font_collection + 8);
-			if (index >= n)
-				return -1;
-			return ttULONG(font_collection + 12 + index * 4);
-		}
-	}
-	return -1;
+   // check if it's a TTC
+   if (stbtt_tag(font_collection, "ttcf")) {
+      // version 1?
+      if (ttULONG(font_collection+4) == 0x00010000 || ttULONG(font_collection+4) == 0x00020000) {
+         stbtt_int32 n = ttLONG(font_collection+8);
+         if (index >= n)
+            return -1;
+         return ttULONG(font_collection+12+index*4);
+      }
+   }
+   return -1;
 }
 
-STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data2, int fontstart)
+static int stbtt_GetNumberOfFonts_internal(unsigned char *font_collection)
 {
-	stbtt_uint8 *data = (stbtt_uint8 *)data2;
-	stbtt_uint32 cmap, t;
-	stbtt_int32 i, numTables;
+   // if it's just a font, there's only one valid font
+   if (stbtt__isfont(font_collection))
+      return 1;
 
-	info->data = data;
-	info->fontstart = fontstart;
+   // check if it's a TTC
+   if (stbtt_tag(font_collection, "ttcf")) {
+      // version 1?
+      if (ttULONG(font_collection+4) == 0x00010000 || ttULONG(font_collection+4) == 0x00020000) {
+         return ttLONG(font_collection+8);
+      }
+   }
+   return 0;
+}
 
-	cmap = stbtt__find_table(data, fontstart, "cmap");       // required
-	info->loca = stbtt__find_table(data, fontstart, "loca"); // required
-	info->head = stbtt__find_table(data, fontstart, "head"); // required
-	info->glyf = stbtt__find_table(data, fontstart, "glyf"); // required
-	info->hhea = stbtt__find_table(data, fontstart, "hhea"); // required
-	info->hmtx = stbtt__find_table(data, fontstart, "hmtx"); // required
-	info->kern = stbtt__find_table(data, fontstart, "kern"); // not required
-	if (!cmap || !info->loca || !info->head || !info->glyf || !info->hhea || !info->hmtx)
-		return 0;
+static stbtt__buf stbtt__get_subrs(stbtt__buf cff, stbtt__buf fontdict)
+{
+   stbtt_uint32 subrsoff = 0, private_loc[2] = { 0, 0 };
+   stbtt__buf pdict;
+   stbtt__dict_get_ints(&fontdict, 18, 2, private_loc);
+   if (!private_loc[1] || !private_loc[0]) return stbtt__new_buf(NULL, 0);
+   pdict = stbtt__buf_range(&cff, private_loc[1], private_loc[0]);
+   stbtt__dict_get_ints(&pdict, 19, 1, &subrsoff);
+   if (!subrsoff) return stbtt__new_buf(NULL, 0);
+   stbtt__buf_seek(&cff, private_loc[1]+subrsoff);
+   return stbtt__cff_get_index(&cff);
+}
 
-	t = stbtt__find_table(data, fontstart, "maxp");
-	if (t)
-		info->numGlyphs = ttUSHORT(data + t + 4);
-	else
-		info->numGlyphs = 0xffff;
+static int stbtt_InitFont_internal(stbtt_fontinfo *info, unsigned char *data, int fontstart)
+{
+   stbtt_uint32 cmap, t;
+   stbtt_int32 i,numTables;
 
-	// find a cmap encoding table we understand *now* to avoid searching
-	// later. (todo: could make this installable)
-	// the same regardless of glyph.
-	numTables = ttUSHORT(data + cmap + 2);
-	info->index_map = 0;
-	for (i = 0; i < numTables; ++i) {
-		stbtt_uint32 encoding_record = cmap + 4 + 8 * i;
-		// find an encoding we understand:
-		switch (ttUSHORT(data + encoding_record)) {
-		case STBTT_PLATFORM_ID_MICROSOFT:
-			switch (ttUSHORT(data + encoding_record + 2)) {
-			case STBTT_MS_EID_UNICODE_BMP:
-			case STBTT_MS_EID_UNICODE_FULL:
-				// MS/Unicode
-				info->index_map = cmap + ttULONG(data + encoding_record + 4);
-				break;
-			}
-			break;
-		case STBTT_PLATFORM_ID_UNICODE:
-			// Mac/iOS has these
-			// all the encodingIDs are unicode, so we don't bother to check it
-			info->index_map = cmap + ttULONG(data + encoding_record + 4);
-			break;
-		}
-	}
-	if (info->index_map == 0)
-		return 0;
+   info->data = data;
+   info->fontstart = fontstart;
+   info->cff = stbtt__new_buf(NULL, 0);
 
-	info->indexToLocFormat = ttUSHORT(data + info->head + 50);
-	return 1;
+   cmap = stbtt__find_table(data, fontstart, "cmap");       // required
+   info->loca = stbtt__find_table(data, fontstart, "loca"); // required
+   info->head = stbtt__find_table(data, fontstart, "head"); // required
+   info->glyf = stbtt__find_table(data, fontstart, "glyf"); // required
+   info->hhea = stbtt__find_table(data, fontstart, "hhea"); // required
+   info->hmtx = stbtt__find_table(data, fontstart, "hmtx"); // required
+   info->kern = stbtt__find_table(data, fontstart, "kern"); // not required
+   info->gpos = stbtt__find_table(data, fontstart, "GPOS"); // not required
+
+   if (!cmap || !info->head || !info->hhea || !info->hmtx)
+      return 0;
+   if (info->glyf) {
+      // required for truetype
+      if (!info->loca) return 0;
+   } else {
+      // initialization for CFF / Type2 fonts (OTF)
+      stbtt__buf b, topdict, topdictidx;
+      stbtt_uint32 cstype = 2, charstrings = 0, fdarrayoff = 0, fdselectoff = 0;
+      stbtt_uint32 cff;
+
+      cff = stbtt__find_table(data, fontstart, "CFF ");
+      if (!cff) return 0;
+
+      info->fontdicts = stbtt__new_buf(NULL, 0);
+      info->fdselect = stbtt__new_buf(NULL, 0);
+
+      // @TODO this should use size from table (not 512MB)
+      info->cff = stbtt__new_buf(data+cff, 512*1024*1024);
+      b = info->cff;
+
+      // read the header
+      stbtt__buf_skip(&b, 2);
+      stbtt__buf_seek(&b, stbtt__buf_get8(&b)); // hdrsize
+
+      // @TODO the name INDEX could list multiple fonts,
+      // but we just use the first one.
+      stbtt__cff_get_index(&b);  // name INDEX
+      topdictidx = stbtt__cff_get_index(&b);
+      topdict = stbtt__cff_index_get(topdictidx, 0);
+      stbtt__cff_get_index(&b);  // string INDEX
+      info->gsubrs = stbtt__cff_get_index(&b);
+
+      stbtt__dict_get_ints(&topdict, 17, 1, &charstrings);
+      stbtt__dict_get_ints(&topdict, 0x100 | 6, 1, &cstype);
+      stbtt__dict_get_ints(&topdict, 0x100 | 36, 1, &fdarrayoff);
+      stbtt__dict_get_ints(&topdict, 0x100 | 37, 1, &fdselectoff);
+      info->subrs = stbtt__get_subrs(b, topdict);
+
+      // we only support Type 2 charstrings
+      if (cstype != 2) return 0;
+      if (charstrings == 0) return 0;
+
+      if (fdarrayoff) {
+         // looks like a CID font
+         if (!fdselectoff) return 0;
+         stbtt__buf_seek(&b, fdarrayoff);
+         info->fontdicts = stbtt__cff_get_index(&b);
+         info->fdselect = stbtt__buf_range(&b, fdselectoff, b.size-fdselectoff);
+      }
+
+      stbtt__buf_seek(&b, charstrings);
+      info->charstrings = stbtt__cff_get_index(&b);
+   }
+
+   t = stbtt__find_table(data, fontstart, "maxp");
+   if (t)
+      info->numGlyphs = ttUSHORT(data+t+4);
+   else
+      info->numGlyphs = 0xffff;
+
+   // find a cmap encoding table we understand *now* to avoid searching
+   // later. (todo: could make this installable)
+   // the same regardless of glyph.
+   numTables = ttUSHORT(data + cmap + 2);
+   info->index_map = 0;
+   for (i=0; i < numTables; ++i) {
+      stbtt_uint32 encoding_record = cmap + 4 + 8 * i;
+      // find an encoding we understand:
+      switch(ttUSHORT(data+encoding_record)) {
+         case STBTT_PLATFORM_ID_MICROSOFT:
+            switch (ttUSHORT(data+encoding_record+2)) {
+               case STBTT_MS_EID_UNICODE_BMP:
+               case STBTT_MS_EID_UNICODE_FULL:
+                  // MS/Unicode
+                  info->index_map = cmap + ttULONG(data+encoding_record+4);
+                  break;
+            }
+            break;
+        case STBTT_PLATFORM_ID_UNICODE:
+            // Mac/iOS has these
+            // all the encodingIDs are unicode, so we don't bother to check it
+            info->index_map = cmap + ttULONG(data+encoding_record+4);
+            break;
+      }
+   }
+   if (info->index_map == 0)
+      return 0;
+
+   info->indexToLocFormat = ttUSHORT(data+info->head + 50);
+   return 1;
 }
 
 STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codepoint)
 {
-	stbtt_uint8 *data = info->data;
-	stbtt_uint32 index_map = info->index_map;
+   stbtt_uint8 *data = info->data;
+   stbtt_uint32 index_map = info->index_map;
 
-	stbtt_uint16 format = ttUSHORT(data + index_map + 0);
-	if (format == 0) { // apple byte encoding
-		stbtt_int32 bytes = ttUSHORT(data + index_map + 2);
-		if (unicode_codepoint < bytes - 6)
-			return ttBYTE(data + index_map + 6 + unicode_codepoint);
-		return 0;
-	}
-	else if (format == 6) {
-		stbtt_uint32 first = ttUSHORT(data + index_map + 6);
-		stbtt_uint32 count = ttUSHORT(data + index_map + 8);
-		if ((stbtt_uint32)unicode_codepoint >= first && (stbtt_uint32)unicode_codepoint < first + count)
-			return ttUSHORT(data + index_map + 10 + (unicode_codepoint - first) * 2);
-		return 0;
-	}
-	else if (format == 2) {
-		STBTT_assert(0); // @TODO: high-byte mapping for japanese/chinese/korean
-		return 0;
-	}
-	else if (format == 4) { // standard mapping for windows fonts: binary search collection of ranges
-		stbtt_uint16 segcount = ttUSHORT(data + index_map + 6) >> 1;
-		stbtt_uint16 searchRange = ttUSHORT(data + index_map + 8) >> 1;
-		stbtt_uint16 entrySelector = ttUSHORT(data + index_map + 10);
-		stbtt_uint16 rangeShift = ttUSHORT(data + index_map + 12) >> 1;
+   stbtt_uint16 format = ttUSHORT(data + index_map + 0);
+   if (format == 0) { // apple byte encoding
+      stbtt_int32 bytes = ttUSHORT(data + index_map + 2);
+      if (unicode_codepoint < bytes-6)
+         return ttBYTE(data + index_map + 6 + unicode_codepoint);
+      return 0;
+   } else if (format == 6) {
+      stbtt_uint32 first = ttUSHORT(data + index_map + 6);
+      stbtt_uint32 count = ttUSHORT(data + index_map + 8);
+      if ((stbtt_uint32) unicode_codepoint >= first && (stbtt_uint32) unicode_codepoint < first+count)
+         return ttUSHORT(data + index_map + 10 + (unicode_codepoint - first)*2);
+      return 0;
+   } else if (format == 2) {
+      STBTT_assert(0); // @TODO: high-byte mapping for japanese/chinese/korean
+      return 0;
+   } else if (format == 4) { // standard mapping for windows fonts: binary search collection of ranges
+      stbtt_uint16 segcount = ttUSHORT(data+index_map+6) >> 1;
+      stbtt_uint16 searchRange = ttUSHORT(data+index_map+8) >> 1;
+      stbtt_uint16 entrySelector = ttUSHORT(data+index_map+10);
+      stbtt_uint16 rangeShift = ttUSHORT(data+index_map+12) >> 1;
 
-		// do a binary search of the segments
-		stbtt_uint32 endCount = index_map + 14;
-		stbtt_uint32 search = endCount;
+      // do a binary search of the segments
+      stbtt_uint32 endCount = index_map + 14;
+      stbtt_uint32 search = endCount;
 
-		if (unicode_codepoint > 0xffff)
-			return 0;
+      if (unicode_codepoint > 0xffff)
+         return 0;
 
-		// they lie from endCount .. endCount + segCount
-		// but searchRange is the nearest power of two, so...
-		if (unicode_codepoint >= ttUSHORT(data + search + rangeShift * 2))
-			search += rangeShift * 2;
+      // they lie from endCount .. endCount + segCount
+      // but searchRange is the nearest power of two, so...
+      if (unicode_codepoint >= ttUSHORT(data + search + rangeShift*2))
+         search += rangeShift*2;
 
-		// now decrement to bias correctly to find smallest
-		search -= 2;
-		while (entrySelector) {
-			stbtt_uint16 end;
-			searchRange >>= 1;
-			end = ttUSHORT(data + search + searchRange * 2);
-			if (unicode_codepoint > end)
-				search += searchRange * 2;
-			--entrySelector;
-		}
-		search += 2;
+      // now decrement to bias correctly to find smallest
+      search -= 2;
+      while (entrySelector) {
+         stbtt_uint16 end;
+         searchRange >>= 1;
+         end = ttUSHORT(data + search + searchRange*2);
+         if (unicode_codepoint > end)
+            search += searchRange*2;
+         --entrySelector;
+      }
+      search += 2;
 
-		{
-			stbtt_uint16 offset, start;
-			stbtt_uint16 item = (stbtt_uint16)((search - endCount) >> 1);
+      {
+         stbtt_uint16 offset, start;
+         stbtt_uint16 item = (stbtt_uint16) ((search - endCount) >> 1);
 
-			STBTT_assert(unicode_codepoint <= ttUSHORT(data + endCount + 2 * item));
-			start = ttUSHORT(data + index_map + 14 + segcount * 2 + 2 + 2 * item);
-			if (unicode_codepoint < start)
-				return 0;
+         STBTT_assert(unicode_codepoint <= ttUSHORT(data + endCount + 2*item));
+         start = ttUSHORT(data + index_map + 14 + segcount*2 + 2 + 2*item);
+         if (unicode_codepoint < start)
+            return 0;
 
-			offset = ttUSHORT(data + index_map + 14 + segcount * 6 + 2 + 2 * item);
-			if (offset == 0)
-				return (stbtt_uint16)(unicode_codepoint + ttSHORT(data + index_map + 14 + segcount * 4 + 2 + 2 * item));
+         offset = ttUSHORT(data + index_map + 14 + segcount*6 + 2 + 2*item);
+         if (offset == 0)
+            return (stbtt_uint16) (unicode_codepoint + ttSHORT(data + index_map + 14 + segcount*4 + 2 + 2*item));
 
-			return ttUSHORT(data + offset + (unicode_codepoint - start) * 2 + index_map + 14 + segcount * 6 + 2 + 2 * item);
-		}
-	}
-	else if (format == 12 || format == 13) {
-		stbtt_uint32 ngroups = ttULONG(data + index_map + 12);
-		stbtt_int32 low, high;
-		low = 0; high = (stbtt_int32)ngroups;
-		// Binary search the right group.
-		while (low < high) {
-			stbtt_int32 mid = low + ((high - low) >> 1); // rounds down, so low <= mid < high
-			stbtt_uint32 start_char = ttULONG(data + index_map + 16 + mid * 12);
-			stbtt_uint32 end_char = ttULONG(data + index_map + 16 + mid * 12 + 4);
-			if ((stbtt_uint32)unicode_codepoint < start_char)
-				high = mid;
-			else if ((stbtt_uint32)unicode_codepoint > end_char)
-				low = mid + 1;
-			else {
-				stbtt_uint32 start_glyph = ttULONG(data + index_map + 16 + mid * 12 + 8);
-				if (format == 12)
-					return start_glyph + unicode_codepoint - start_char;
-				else // format == 13
-					return start_glyph;
-			}
-		}
-		return 0; // not found
-	}
-	// @TODO
-	STBTT_assert(0);
-	return 0;
+         return ttUSHORT(data + offset + (unicode_codepoint-start)*2 + index_map + 14 + segcount*6 + 2 + 2*item);
+      }
+   } else if (format == 12 || format == 13) {
+      stbtt_uint32 ngroups = ttULONG(data+index_map+12);
+      stbtt_int32 low,high;
+      low = 0; high = (stbtt_int32)ngroups;
+      // Binary search the right group.
+      while (low < high) {
+         stbtt_int32 mid = low + ((high-low) >> 1); // rounds down, so low <= mid < high
+         stbtt_uint32 start_char = ttULONG(data+index_map+16+mid*12);
+         stbtt_uint32 end_char = ttULONG(data+index_map+16+mid*12+4);
+         if ((stbtt_uint32) unicode_codepoint < start_char)
+            high = mid;
+         else if ((stbtt_uint32) unicode_codepoint > end_char)
+            low = mid+1;
+         else {
+            stbtt_uint32 start_glyph = ttULONG(data+index_map+16+mid*12+8);
+            if (format == 12)
+               return start_glyph + unicode_codepoint-start_char;
+            else // format == 13
+               return start_glyph;
+         }
+      }
+      return 0; // not found
+   }
+   // @TODO
+   STBTT_assert(0);
+   return 0;
 }
 
 STBTT_DEF int stbtt_GetCodepointShape(const stbtt_fontinfo *info, int unicode_codepoint, stbtt_vertex **vertices)
 {
-	return stbtt_GetGlyphShape(info, stbtt_FindGlyphIndex(info, unicode_codepoint), vertices);
+   return stbtt_GetGlyphShape(info, stbtt_FindGlyphIndex(info, unicode_codepoint), vertices);
 }
 
 static void stbtt_setvertex(stbtt_vertex *v, stbtt_uint8 type, stbtt_int32 x, stbtt_int32 y, stbtt_int32 cx, stbtt_int32 cy)
 {
-	v->type = type;
-	v->x = (stbtt_int16)x;
-	v->y = (stbtt_int16)y;
-	v->cx = (stbtt_int16)cx;
-	v->cy = (stbtt_int16)cy;
+   v->type = type;
+   v->x = (stbtt_int16) x;
+   v->y = (stbtt_int16) y;
+   v->cx = (stbtt_int16) cx;
+   v->cy = (stbtt_int16) cy;
 }
 
 static int stbtt__GetGlyfOffset(const stbtt_fontinfo *info, int glyph_index)
 {
-	int g1, g2;
+   int g1,g2;
 
-	if (glyph_index >= info->numGlyphs) return -1; // glyph index out of range
-	if (info->indexToLocFormat >= 2)    return -1; // unknown index->glyph map format
+   STBTT_assert(!info->cff.size);
 
-	if (info->indexToLocFormat == 0) {
-		g1 = info->glyf + ttUSHORT(info->data + info->loca + glyph_index * 2) * 2;
-		g2 = info->glyf + ttUSHORT(info->data + info->loca + glyph_index * 2 + 2) * 2;
-	}
-	else {
-		g1 = info->glyf + ttULONG(info->data + info->loca + glyph_index * 4);
-		g2 = info->glyf + ttULONG(info->data + info->loca + glyph_index * 4 + 4);
-	}
+   if (glyph_index >= info->numGlyphs) return -1; // glyph index out of range
+   if (info->indexToLocFormat >= 2)    return -1; // unknown index->glyph map format
 
-	return g1 == g2 ? -1 : g1; // if length is 0, return -1
+   if (info->indexToLocFormat == 0) {
+      g1 = info->glyf + ttUSHORT(info->data + info->loca + glyph_index * 2) * 2;
+      g2 = info->glyf + ttUSHORT(info->data + info->loca + glyph_index * 2 + 2) * 2;
+   } else {
+      g1 = info->glyf + ttULONG (info->data + info->loca + glyph_index * 4);
+      g2 = info->glyf + ttULONG (info->data + info->loca + glyph_index * 4 + 4);
+   }
+
+   return g1==g2 ? -1 : g1; // if length is 0, return -1
 }
+
+static int stbtt__GetGlyphInfoT2(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1);
 
 STBTT_DEF int stbtt_GetGlyphBox(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1)
 {
-	int g = stbtt__GetGlyfOffset(info, glyph_index);
-	if (g < 0) return 0;
+   if (info->cff.size) {
+      stbtt__GetGlyphInfoT2(info, glyph_index, x0, y0, x1, y1);
+   } else {
+      int g = stbtt__GetGlyfOffset(info, glyph_index);
+      if (g < 0) return 0;
 
-	if (x0) *x0 = ttSHORT(info->data + g + 2);
-	if (y0) *y0 = ttSHORT(info->data + g + 4);
-	if (x1) *x1 = ttSHORT(info->data + g + 6);
-	if (y1) *y1 = ttSHORT(info->data + g + 8);
-	return 1;
+      if (x0) *x0 = ttSHORT(info->data + g + 2);
+      if (y0) *y0 = ttSHORT(info->data + g + 4);
+      if (x1) *x1 = ttSHORT(info->data + g + 6);
+      if (y1) *y1 = ttSHORT(info->data + g + 8);
+   }
+   return 1;
 }
 
 STBTT_DEF int stbtt_GetCodepointBox(const stbtt_fontinfo *info, int codepoint, int *x0, int *y0, int *x1, int *y1)
 {
-	return stbtt_GetGlyphBox(info, stbtt_FindGlyphIndex(info, codepoint), x0, y0, x1, y1);
+   return stbtt_GetGlyphBox(info, stbtt_FindGlyphIndex(info,codepoint), x0,y0,x1,y1);
 }
 
 STBTT_DEF int stbtt_IsGlyphEmpty(const stbtt_fontinfo *info, int glyph_index)
 {
-	stbtt_int16 numberOfContours;
-	int g = stbtt__GetGlyfOffset(info, glyph_index);
-	if (g < 0) return 1;
-	numberOfContours = ttSHORT(info->data + g);
-	return numberOfContours == 0;
+   stbtt_int16 numberOfContours;
+   int g;
+   if (info->cff.size)
+      return stbtt__GetGlyphInfoT2(info, glyph_index, NULL, NULL, NULL, NULL) == 0;
+   g = stbtt__GetGlyfOffset(info, glyph_index);
+   if (g < 0) return 1;
+   numberOfContours = ttSHORT(info->data + g);
+   return numberOfContours == 0;
 }
 
 static int stbtt__close_shape(stbtt_vertex *vertices, int num_vertices, int was_off, int start_off,
-	stbtt_int32 sx, stbtt_int32 sy, stbtt_int32 scx, stbtt_int32 scy, stbtt_int32 cx, stbtt_int32 cy)
+    stbtt_int32 sx, stbtt_int32 sy, stbtt_int32 scx, stbtt_int32 scy, stbtt_int32 cx, stbtt_int32 cy)
 {
-	if (start_off) {
-		if (was_off)
-			stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, (cx + scx) >> 1, (cy + scy) >> 1, cx, cy);
-		stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, sx, sy, scx, scy);
-	}
-	else {
-		if (was_off)
-			stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, sx, sy, cx, cy);
-		else
-			stbtt_setvertex(&vertices[num_vertices++], STBTT_vline, sx, sy, 0, 0);
-	}
-	return num_vertices;
+   if (start_off) {
+      if (was_off)
+         stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, (cx+scx)>>1, (cy+scy)>>1, cx,cy);
+      stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, sx,sy,scx,scy);
+   } else {
+      if (was_off)
+         stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve,sx,sy,cx,cy);
+      else
+         stbtt_setvertex(&vertices[num_vertices++], STBTT_vline,sx,sy,0,0);
+   }
+   return num_vertices;
+}
+
+static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **pvertices)
+{
+   stbtt_int16 numberOfContours;
+   stbtt_uint8 *endPtsOfContours;
+   stbtt_uint8 *data = info->data;
+   stbtt_vertex *vertices=0;
+   int num_vertices=0;
+   int g = stbtt__GetGlyfOffset(info, glyph_index);
+
+   *pvertices = NULL;
+
+   if (g < 0) return 0;
+
+   numberOfContours = ttSHORT(data + g);
+
+   if (numberOfContours > 0) {
+      stbtt_uint8 flags=0,flagcount;
+      stbtt_int32 ins, i,j=0,m,n, next_move, was_off=0, off, start_off=0;
+      stbtt_int32 x,y,cx,cy,sx,sy, scx,scy;
+      stbtt_uint8 *points;
+      endPtsOfContours = (data + g + 10);
+      ins = ttUSHORT(data + g + 10 + numberOfContours * 2);
+      points = data + g + 10 + numberOfContours * 2 + 2 + ins;
+
+      n = 1+ttUSHORT(endPtsOfContours + numberOfContours*2-2);
+
+      m = n + 2*numberOfContours;  // a loose bound on how many vertices we might need
+      vertices = (stbtt_vertex *) STBTT_malloc(m * sizeof(vertices[0]), info->userdata);
+      if (vertices == 0)
+         return 0;
+
+      next_move = 0;
+      flagcount=0;
+
+      // in first pass, we load uninterpreted data into the allocated array
+      // above, shifted to the end of the array so we won't overwrite it when
+      // we create our final data starting from the front
+
+      off = m - n; // starting offset for uninterpreted data, regardless of how m ends up being calculated
+
+      // first load flags
+
+      for (i=0; i < n; ++i) {
+         if (flagcount == 0) {
+            flags = *points++;
+            if (flags & 8)
+               flagcount = *points++;
+         } else
+            --flagcount;
+         vertices[off+i].type = flags;
+      }
+
+      // now load x coordinates
+      x=0;
+      for (i=0; i < n; ++i) {
+         flags = vertices[off+i].type;
+         if (flags & 2) {
+            stbtt_int16 dx = *points++;
+            x += (flags & 16) ? dx : -dx; // ???
+         } else {
+            if (!(flags & 16)) {
+               x = x + (stbtt_int16) (points[0]*256 + points[1]);
+               points += 2;
+            }
+         }
+         vertices[off+i].x = (stbtt_int16) x;
+      }
+
+      // now load y coordinates
+      y=0;
+      for (i=0; i < n; ++i) {
+         flags = vertices[off+i].type;
+         if (flags & 4) {
+            stbtt_int16 dy = *points++;
+            y += (flags & 32) ? dy : -dy; // ???
+         } else {
+            if (!(flags & 32)) {
+               y = y + (stbtt_int16) (points[0]*256 + points[1]);
+               points += 2;
+            }
+         }
+         vertices[off+i].y = (stbtt_int16) y;
+      }
+
+      // now convert them to our format
+      num_vertices=0;
+      sx = sy = cx = cy = scx = scy = 0;
+      for (i=0; i < n; ++i) {
+         flags = vertices[off+i].type;
+         x     = (stbtt_int16) vertices[off+i].x;
+         y     = (stbtt_int16) vertices[off+i].y;
+
+         if (next_move == i) {
+            if (i != 0)
+               num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx,sy,scx,scy,cx,cy);
+
+            // now start the new one               
+            start_off = !(flags & 1);
+            if (start_off) {
+               // if we start off with an off-curve point, then when we need to find a point on the curve
+               // where we can start, and we need to save some state for when we wraparound.
+               scx = x;
+               scy = y;
+               if (!(vertices[off+i+1].type & 1)) {
+                  // next point is also a curve point, so interpolate an on-point curve
+                  sx = (x + (stbtt_int32) vertices[off+i+1].x) >> 1;
+                  sy = (y + (stbtt_int32) vertices[off+i+1].y) >> 1;
+               } else {
+                  // otherwise just use the next point as our start point
+                  sx = (stbtt_int32) vertices[off+i+1].x;
+                  sy = (stbtt_int32) vertices[off+i+1].y;
+                  ++i; // we're using point i+1 as the starting point, so skip it
+               }
+            } else {
+               sx = x;
+               sy = y;
+            }
+            stbtt_setvertex(&vertices[num_vertices++], STBTT_vmove,sx,sy,0,0);
+            was_off = 0;
+            next_move = 1 + ttUSHORT(endPtsOfContours+j*2);
+            ++j;
+         } else {
+            if (!(flags & 1)) { // if it's a curve
+               if (was_off) // two off-curve control points in a row means interpolate an on-curve midpoint
+                  stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, (cx+x)>>1, (cy+y)>>1, cx, cy);
+               cx = x;
+               cy = y;
+               was_off = 1;
+            } else {
+               if (was_off)
+                  stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, x,y, cx, cy);
+               else
+                  stbtt_setvertex(&vertices[num_vertices++], STBTT_vline, x,y,0,0);
+               was_off = 0;
+            }
+         }
+      }
+      num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx,sy,scx,scy,cx,cy);
+   } else if (numberOfContours == -1) {
+      // Compound shapes.
+      int more = 1;
+      stbtt_uint8 *comp = data + g + 10;
+      num_vertices = 0;
+      vertices = 0;
+      while (more) {
+         stbtt_uint16 flags, gidx;
+         int comp_num_verts = 0, i;
+         stbtt_vertex *comp_verts = 0, *tmp = 0;
+         float mtx[6] = {1,0,0,1,0,0}, m, n;
+         
+         flags = ttSHORT(comp); comp+=2;
+         gidx = ttSHORT(comp); comp+=2;
+
+         if (flags & 2) { // XY values
+            if (flags & 1) { // shorts
+               mtx[4] = ttSHORT(comp); comp+=2;
+               mtx[5] = ttSHORT(comp); comp+=2;
+            } else {
+               mtx[4] = ttCHAR(comp); comp+=1;
+               mtx[5] = ttCHAR(comp); comp+=1;
+            }
+         }
+         else {
+            // @TODO handle matching point
+            STBTT_assert(0);
+         }
+         if (flags & (1<<3)) { // WE_HAVE_A_SCALE
+            mtx[0] = mtx[3] = ttSHORT(comp)/16384.0f; comp+=2;
+            mtx[1] = mtx[2] = 0;
+         } else if (flags & (1<<6)) { // WE_HAVE_AN_X_AND_YSCALE
+            mtx[0] = ttSHORT(comp)/16384.0f; comp+=2;
+            mtx[1] = mtx[2] = 0;
+            mtx[3] = ttSHORT(comp)/16384.0f; comp+=2;
+         } else if (flags & (1<<7)) { // WE_HAVE_A_TWO_BY_TWO
+            mtx[0] = ttSHORT(comp)/16384.0f; comp+=2;
+            mtx[1] = ttSHORT(comp)/16384.0f; comp+=2;
+            mtx[2] = ttSHORT(comp)/16384.0f; comp+=2;
+            mtx[3] = ttSHORT(comp)/16384.0f; comp+=2;
+         }
+         
+         // Find transformation scales.
+         m = (float) STBTT_sqrt(mtx[0]*mtx[0] + mtx[1]*mtx[1]);
+         n = (float) STBTT_sqrt(mtx[2]*mtx[2] + mtx[3]*mtx[3]);
+
+         // Get indexed glyph.
+         comp_num_verts = stbtt_GetGlyphShape(info, gidx, &comp_verts);
+         if (comp_num_verts > 0) {
+            // Transform vertices.
+            for (i = 0; i < comp_num_verts; ++i) {
+               stbtt_vertex* v = &comp_verts[i];
+               stbtt_vertex_type x,y;
+               x=v->x; y=v->y;
+               v->x = (stbtt_vertex_type)(m * (mtx[0]*x + mtx[2]*y + mtx[4]));
+               v->y = (stbtt_vertex_type)(n * (mtx[1]*x + mtx[3]*y + mtx[5]));
+               x=v->cx; y=v->cy;
+               v->cx = (stbtt_vertex_type)(m * (mtx[0]*x + mtx[2]*y + mtx[4]));
+               v->cy = (stbtt_vertex_type)(n * (mtx[1]*x + mtx[3]*y + mtx[5]));
+            }
+            // Append vertices.
+            tmp = (stbtt_vertex*)STBTT_malloc((num_vertices+comp_num_verts)*sizeof(stbtt_vertex), info->userdata);
+            if (!tmp) {
+               if (vertices) STBTT_free(vertices, info->userdata);
+               if (comp_verts) STBTT_free(comp_verts, info->userdata);
+               return 0;
+            }
+            if (num_vertices > 0) STBTT_memcpy(tmp, vertices, num_vertices*sizeof(stbtt_vertex));
+            STBTT_memcpy(tmp+num_vertices, comp_verts, comp_num_verts*sizeof(stbtt_vertex));
+            if (vertices) STBTT_free(vertices, info->userdata);
+            vertices = tmp;
+            STBTT_free(comp_verts, info->userdata);
+            num_vertices += comp_num_verts;
+         }
+         // More components ?
+         more = flags & (1<<5);
+      }
+   } else if (numberOfContours < 0) {
+      // @TODO other compound variations?
+      STBTT_assert(0);
+   } else {
+      // numberOfCounters == 0, do nothing
+   }
+
+   *pvertices = vertices;
+   return num_vertices;
+}
+
+typedef struct
+{
+   int bounds;
+   int started;
+   float first_x, first_y;
+   float x, y;
+   stbtt_int32 min_x, max_x, min_y, max_y;
+
+   stbtt_vertex *pvertices;
+   int num_vertices;
+} stbtt__csctx;
+
+#define STBTT__CSCTX_INIT(bounds) {bounds,0, 0,0, 0,0, 0,0,0,0, NULL, 0}
+
+static void stbtt__track_vertex(stbtt__csctx *c, stbtt_int32 x, stbtt_int32 y)
+{
+   if (x > c->max_x || !c->started) c->max_x = x;
+   if (y > c->max_y || !c->started) c->max_y = y;
+   if (x < c->min_x || !c->started) c->min_x = x;
+   if (y < c->min_y || !c->started) c->min_y = y;
+   c->started = 1;
+}
+
+static void stbtt__csctx_v(stbtt__csctx *c, stbtt_uint8 type, stbtt_int32 x, stbtt_int32 y, stbtt_int32 cx, stbtt_int32 cy, stbtt_int32 cx1, stbtt_int32 cy1)
+{
+   if (c->bounds) {
+      stbtt__track_vertex(c, x, y);
+      if (type == STBTT_vcubic) {
+         stbtt__track_vertex(c, cx, cy);
+         stbtt__track_vertex(c, cx1, cy1);
+      }
+   } else {
+      stbtt_setvertex(&c->pvertices[c->num_vertices], type, x, y, cx, cy);
+      c->pvertices[c->num_vertices].cx1 = (stbtt_int16) cx1;
+      c->pvertices[c->num_vertices].cy1 = (stbtt_int16) cy1;
+   }
+   c->num_vertices++;
+}
+
+static void stbtt__csctx_close_shape(stbtt__csctx *ctx)
+{
+   if (ctx->first_x != ctx->x || ctx->first_y != ctx->y)
+      stbtt__csctx_v(ctx, STBTT_vline, (int)ctx->first_x, (int)ctx->first_y, 0, 0, 0, 0);
+}
+
+static void stbtt__csctx_rmove_to(stbtt__csctx *ctx, float dx, float dy)
+{
+   stbtt__csctx_close_shape(ctx);
+   ctx->first_x = ctx->x = ctx->x + dx;
+   ctx->first_y = ctx->y = ctx->y + dy;
+   stbtt__csctx_v(ctx, STBTT_vmove, (int)ctx->x, (int)ctx->y, 0, 0, 0, 0);
+}
+
+static void stbtt__csctx_rline_to(stbtt__csctx *ctx, float dx, float dy)
+{
+   ctx->x += dx;
+   ctx->y += dy;
+   stbtt__csctx_v(ctx, STBTT_vline, (int)ctx->x, (int)ctx->y, 0, 0, 0, 0);
+}
+
+static void stbtt__csctx_rccurve_to(stbtt__csctx *ctx, float dx1, float dy1, float dx2, float dy2, float dx3, float dy3)
+{
+   float cx1 = ctx->x + dx1;
+   float cy1 = ctx->y + dy1;
+   float cx2 = cx1 + dx2;
+   float cy2 = cy1 + dy2;
+   ctx->x = cx2 + dx3;
+   ctx->y = cy2 + dy3;
+   stbtt__csctx_v(ctx, STBTT_vcubic, (int)ctx->x, (int)ctx->y, (int)cx1, (int)cy1, (int)cx2, (int)cy2);
+}
+
+static stbtt__buf stbtt__get_subr(stbtt__buf idx, int n)
+{
+   int count = stbtt__cff_index_count(&idx);
+   int bias = 107;
+   if (count >= 33900)
+      bias = 32768;
+   else if (count >= 1240)
+      bias = 1131;
+   n += bias;
+   if (n < 0 || n >= count)
+      return stbtt__new_buf(NULL, 0);
+   return stbtt__cff_index_get(idx, n);
+}
+
+static stbtt__buf stbtt__cid_get_glyph_subrs(const stbtt_fontinfo *info, int glyph_index)
+{
+   stbtt__buf fdselect = info->fdselect;
+   int nranges, start, end, v, fmt, fdselector = -1, i;
+
+   stbtt__buf_seek(&fdselect, 0);
+   fmt = stbtt__buf_get8(&fdselect);
+   if (fmt == 0) {
+      // untested
+      stbtt__buf_skip(&fdselect, glyph_index);
+      fdselector = stbtt__buf_get8(&fdselect);
+   } else if (fmt == 3) {
+      nranges = stbtt__buf_get16(&fdselect);
+      start = stbtt__buf_get16(&fdselect);
+      for (i = 0; i < nranges; i++) {
+         v = stbtt__buf_get8(&fdselect);
+         end = stbtt__buf_get16(&fdselect);
+         if (glyph_index >= start && glyph_index < end) {
+            fdselector = v;
+            break;
+         }
+         start = end;
+      }
+   }
+   if (fdselector == -1) stbtt__new_buf(NULL, 0);
+   return stbtt__get_subrs(info->cff, stbtt__cff_index_get(info->fontdicts, fdselector));
+}
+
+static int stbtt__run_charstring(const stbtt_fontinfo *info, int glyph_index, stbtt__csctx *c)
+{
+   int in_header = 1, maskbits = 0, subr_stack_height = 0, sp = 0, v, i, b0;
+   int has_subrs = 0, clear_stack;
+   float s[48];
+   stbtt__buf subr_stack[10], subrs = info->subrs, b;
+   float f;
+
+#define STBTT__CSERR(s) (0)
+
+   // this currently ignores the initial width value, which isn't needed if we have hmtx
+   b = stbtt__cff_index_get(info->charstrings, glyph_index);
+   while (b.cursor < b.size) {
+      i = 0;
+      clear_stack = 1;
+      b0 = stbtt__buf_get8(&b);
+      switch (b0) {
+      // @TODO implement hinting
+      case 0x13: // hintmask
+      case 0x14: // cntrmask
+         if (in_header)
+            maskbits += (sp / 2); // implicit "vstem"
+         in_header = 0;
+         stbtt__buf_skip(&b, (maskbits + 7) / 8);
+         break;
+
+      case 0x01: // hstem
+      case 0x03: // vstem
+      case 0x12: // hstemhm
+      case 0x17: // vstemhm
+         maskbits += (sp / 2);
+         break;
+
+      case 0x15: // rmoveto
+         in_header = 0;
+         if (sp < 2) return STBTT__CSERR("rmoveto stack");
+         stbtt__csctx_rmove_to(c, s[sp-2], s[sp-1]);
+         break;
+      case 0x04: // vmoveto
+         in_header = 0;
+         if (sp < 1) return STBTT__CSERR("vmoveto stack");
+         stbtt__csctx_rmove_to(c, 0, s[sp-1]);
+         break;
+      case 0x16: // hmoveto
+         in_header = 0;
+         if (sp < 1) return STBTT__CSERR("hmoveto stack");
+         stbtt__csctx_rmove_to(c, s[sp-1], 0);
+         break;
+
+      case 0x05: // rlineto
+         if (sp < 2) return STBTT__CSERR("rlineto stack");
+         for (; i + 1 < sp; i += 2)
+            stbtt__csctx_rline_to(c, s[i], s[i+1]);
+         break;
+
+      // hlineto/vlineto and vhcurveto/hvcurveto alternate horizontal and vertical
+      // starting from a different place.
+
+      case 0x07: // vlineto
+         if (sp < 1) return STBTT__CSERR("vlineto stack");
+         goto vlineto;
+      case 0x06: // hlineto
+         if (sp < 1) return STBTT__CSERR("hlineto stack");
+         for (;;) {
+            if (i >= sp) break;
+            stbtt__csctx_rline_to(c, s[i], 0);
+            i++;
+      vlineto:
+            if (i >= sp) break;
+            stbtt__csctx_rline_to(c, 0, s[i]);
+            i++;
+         }
+         break;
+
+      case 0x1F: // hvcurveto
+         if (sp < 4) return STBTT__CSERR("hvcurveto stack");
+         goto hvcurveto;
+      case 0x1E: // vhcurveto
+         if (sp < 4) return STBTT__CSERR("vhcurveto stack");
+         for (;;) {
+            if (i + 3 >= sp) break;
+            stbtt__csctx_rccurve_to(c, 0, s[i], s[i+1], s[i+2], s[i+3], (sp - i == 5) ? s[i + 4] : 0.0f);
+            i += 4;
+      hvcurveto:
+            if (i + 3 >= sp) break;
+            stbtt__csctx_rccurve_to(c, s[i], 0, s[i+1], s[i+2], (sp - i == 5) ? s[i+4] : 0.0f, s[i+3]);
+            i += 4;
+         }
+         break;
+
+      case 0x08: // rrcurveto
+         if (sp < 6) return STBTT__CSERR("rcurveline stack");
+         for (; i + 5 < sp; i += 6)
+            stbtt__csctx_rccurve_to(c, s[i], s[i+1], s[i+2], s[i+3], s[i+4], s[i+5]);
+         break;
+
+      case 0x18: // rcurveline
+         if (sp < 8) return STBTT__CSERR("rcurveline stack");
+         for (; i + 5 < sp - 2; i += 6)
+            stbtt__csctx_rccurve_to(c, s[i], s[i+1], s[i+2], s[i+3], s[i+4], s[i+5]);
+         if (i + 1 >= sp) return STBTT__CSERR("rcurveline stack");
+         stbtt__csctx_rline_to(c, s[i], s[i+1]);
+         break;
+
+      case 0x19: // rlinecurve
+         if (sp < 8) return STBTT__CSERR("rlinecurve stack");
+         for (; i + 1 < sp - 6; i += 2)
+            stbtt__csctx_rline_to(c, s[i], s[i+1]);
+         if (i + 5 >= sp) return STBTT__CSERR("rlinecurve stack");
+         stbtt__csctx_rccurve_to(c, s[i], s[i+1], s[i+2], s[i+3], s[i+4], s[i+5]);
+         break;
+
+      case 0x1A: // vvcurveto
+      case 0x1B: // hhcurveto
+         if (sp < 4) return STBTT__CSERR("(vv|hh)curveto stack");
+         f = 0.0;
+         if (sp & 1) { f = s[i]; i++; }
+         for (; i + 3 < sp; i += 4) {
+            if (b0 == 0x1B)
+               stbtt__csctx_rccurve_to(c, s[i], f, s[i+1], s[i+2], s[i+3], 0.0);
+            else
+               stbtt__csctx_rccurve_to(c, f, s[i], s[i+1], s[i+2], 0.0, s[i+3]);
+            f = 0.0;
+         }
+         break;
+
+      case 0x0A: // callsubr
+         if (!has_subrs) {
+            if (info->fdselect.size)
+               subrs = stbtt__cid_get_glyph_subrs(info, glyph_index);
+            has_subrs = 1;
+         }
+         // fallthrough
+      case 0x1D: // callgsubr
+         if (sp < 1) return STBTT__CSERR("call(g|)subr stack");
+         v = (int) s[--sp];
+         if (subr_stack_height >= 10) return STBTT__CSERR("recursion limit");
+         subr_stack[subr_stack_height++] = b;
+         b = stbtt__get_subr(b0 == 0x0A ? subrs : info->gsubrs, v);
+         if (b.size == 0) return STBTT__CSERR("subr not found");
+         b.cursor = 0;
+         clear_stack = 0;
+         break;
+
+      case 0x0B: // return
+         if (subr_stack_height <= 0) return STBTT__CSERR("return outside subr");
+         b = subr_stack[--subr_stack_height];
+         clear_stack = 0;
+         break;
+
+      case 0x0E: // endchar
+         stbtt__csctx_close_shape(c);
+         return 1;
+
+      case 0x0C: { // two-byte escape
+         float dx1, dx2, dx3, dx4, dx5, dx6, dy1, dy2, dy3, dy4, dy5, dy6;
+         float dx, dy;
+         int b1 = stbtt__buf_get8(&b);
+         switch (b1) {
+         // @TODO These "flex" implementations ignore the flex-depth and resolution,
+         // and always draw beziers.
+         case 0x22: // hflex
+            if (sp < 7) return STBTT__CSERR("hflex stack");
+            dx1 = s[0];
+            dx2 = s[1];
+            dy2 = s[2];
+            dx3 = s[3];
+            dx4 = s[4];
+            dx5 = s[5];
+            dx6 = s[6];
+            stbtt__csctx_rccurve_to(c, dx1, 0, dx2, dy2, dx3, 0);
+            stbtt__csctx_rccurve_to(c, dx4, 0, dx5, -dy2, dx6, 0);
+            break;
+
+         case 0x23: // flex
+            if (sp < 13) return STBTT__CSERR("flex stack");
+            dx1 = s[0];
+            dy1 = s[1];
+            dx2 = s[2];
+            dy2 = s[3];
+            dx3 = s[4];
+            dy3 = s[5];
+            dx4 = s[6];
+            dy4 = s[7];
+            dx5 = s[8];
+            dy5 = s[9];
+            dx6 = s[10];
+            dy6 = s[11];
+            //fd is s[12]
+            stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, dy3);
+            stbtt__csctx_rccurve_to(c, dx4, dy4, dx5, dy5, dx6, dy6);
+            break;
+
+         case 0x24: // hflex1
+            if (sp < 9) return STBTT__CSERR("hflex1 stack");
+            dx1 = s[0];
+            dy1 = s[1];
+            dx2 = s[2];
+            dy2 = s[3];
+            dx3 = s[4];
+            dx4 = s[5];
+            dx5 = s[6];
+            dy5 = s[7];
+            dx6 = s[8];
+            stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, 0);
+            stbtt__csctx_rccurve_to(c, dx4, 0, dx5, dy5, dx6, -(dy1+dy2+dy5));
+            break;
+
+         case 0x25: // flex1
+            if (sp < 11) return STBTT__CSERR("flex1 stack");
+            dx1 = s[0];
+            dy1 = s[1];
+            dx2 = s[2];
+            dy2 = s[3];
+            dx3 = s[4];
+            dy3 = s[5];
+            dx4 = s[6];
+            dy4 = s[7];
+            dx5 = s[8];
+            dy5 = s[9];
+            dx6 = dy6 = s[10];
+            dx = dx1+dx2+dx3+dx4+dx5;
+            dy = dy1+dy2+dy3+dy4+dy5;
+            if (STBTT_fabs(dx) > STBTT_fabs(dy))
+               dy6 = -dy;
+            else
+               dx6 = -dx;
+            stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, dy3);
+            stbtt__csctx_rccurve_to(c, dx4, dy4, dx5, dy5, dx6, dy6);
+            break;
+
+         default:
+            return STBTT__CSERR("unimplemented");
+         }
+      } break;
+
+      default:
+         if (b0 != 255 && b0 != 28 && (b0 < 32 || b0 > 254))
+            return STBTT__CSERR("reserved operator");
+
+         // push immediate
+         if (b0 == 255) {
+            f = (float)(stbtt_int32)stbtt__buf_get32(&b) / 0x10000;
+         } else {
+            stbtt__buf_skip(&b, -1);
+            f = (float)(stbtt_int16)stbtt__cff_int(&b);
+         }
+         if (sp >= 48) return STBTT__CSERR("push stack overflow");
+         s[sp++] = f;
+         clear_stack = 0;
+         break;
+      }
+      if (clear_stack) sp = 0;
+   }
+   return STBTT__CSERR("no endchar");
+
+#undef STBTT__CSERR
+}
+
+static int stbtt__GetGlyphShapeT2(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **pvertices)
+{
+   // runs the charstring twice, once to count and once to output (to avoid realloc)
+   stbtt__csctx count_ctx = STBTT__CSCTX_INIT(1);
+   stbtt__csctx output_ctx = STBTT__CSCTX_INIT(0);
+   if (stbtt__run_charstring(info, glyph_index, &count_ctx)) {
+      *pvertices = (stbtt_vertex*)STBTT_malloc(count_ctx.num_vertices*sizeof(stbtt_vertex), info->userdata);
+      output_ctx.pvertices = *pvertices;
+      if (stbtt__run_charstring(info, glyph_index, &output_ctx)) {
+         STBTT_assert(output_ctx.num_vertices == count_ctx.num_vertices);
+         return output_ctx.num_vertices;
+      }
+   }
+   *pvertices = NULL;
+   return 0;
+}
+
+static int stbtt__GetGlyphInfoT2(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1)
+{
+   stbtt__csctx c = STBTT__CSCTX_INIT(1);
+   int r = stbtt__run_charstring(info, glyph_index, &c);
+   if (x0)  *x0 = r ? c.min_x : 0;
+   if (y0)  *y0 = r ? c.min_y : 0;
+   if (x1)  *x1 = r ? c.max_x : 0;
+   if (y1)  *y1 = r ? c.max_y : 0;
+   return r ? c.num_vertices : 0;
 }
 
 STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **pvertices)
 {
-	stbtt_int16 numberOfContours;
-	stbtt_uint8 *endPtsOfContours;
-	stbtt_uint8 *data = info->data;
-	stbtt_vertex *vertices = 0;
-	int num_vertices = 0;
-	int g = stbtt__GetGlyfOffset(info, glyph_index);
-
-	*pvertices = NULL;
-
-	if (g < 0) return 0;
-
-	numberOfContours = ttSHORT(data + g);
-
-	if (numberOfContours > 0) {
-		stbtt_uint8 flags = 0, flagcount;
-		stbtt_int32 ins, i, j = 0, m, n, next_move, was_off = 0, off, start_off = 0;
-		stbtt_int32 x, y, cx, cy, sx, sy, scx, scy;
-		stbtt_uint8 *points;
-		endPtsOfContours = (data + g + 10);
-		ins = ttUSHORT(data + g + 10 + numberOfContours * 2);
-		points = data + g + 10 + numberOfContours * 2 + 2 + ins;
-
-		n = 1 + ttUSHORT(endPtsOfContours + numberOfContours * 2 - 2);
-
-		m = n + 2 * numberOfContours;  // a loose bound on how many vertices we might need
-		vertices = (stbtt_vertex *)STBTT_malloc(m * sizeof(vertices[0]), info->userdata);
-		if (vertices == 0)
-			return 0;
-
-		next_move = 0;
-		flagcount = 0;
-
-		// in first pass, we load uninterpreted data into the allocated array
-		// above, shifted to the end of the array so we won't overwrite it when
-		// we create our final data starting from the front
-
-		off = m - n; // starting offset for uninterpreted data, regardless of how m ends up being calculated
-
-					 // first load flags
-
-		for (i = 0; i < n; ++i) {
-			if (flagcount == 0) {
-				flags = *points++;
-				if (flags & 8)
-					flagcount = *points++;
-			}
-			else
-				--flagcount;
-			vertices[off + i].type = flags;
-		}
-
-		// now load x coordinates
-		x = 0;
-		for (i = 0; i < n; ++i) {
-			flags = vertices[off + i].type;
-			if (flags & 2) {
-				stbtt_int16 dx = *points++;
-				x += (flags & 16) ? dx : -dx; // ???
-			}
-			else {
-				if (!(flags & 16)) {
-					x = x + (stbtt_int16)(points[0] * 256 + points[1]);
-					points += 2;
-				}
-			}
-			vertices[off + i].x = (stbtt_int16)x;
-		}
-
-		// now load y coordinates
-		y = 0;
-		for (i = 0; i < n; ++i) {
-			flags = vertices[off + i].type;
-			if (flags & 4) {
-				stbtt_int16 dy = *points++;
-				y += (flags & 32) ? dy : -dy; // ???
-			}
-			else {
-				if (!(flags & 32)) {
-					y = y + (stbtt_int16)(points[0] * 256 + points[1]);
-					points += 2;
-				}
-			}
-			vertices[off + i].y = (stbtt_int16)y;
-		}
-
-		// now convert them to our format
-		num_vertices = 0;
-		sx = sy = cx = cy = scx = scy = 0;
-		for (i = 0; i < n; ++i) {
-			flags = vertices[off + i].type;
-			x = (stbtt_int16)vertices[off + i].x;
-			y = (stbtt_int16)vertices[off + i].y;
-
-			if (next_move == i) {
-				if (i != 0)
-					num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx, sy, scx, scy, cx, cy);
-
-				// now start the new one               
-				start_off = !(flags & 1);
-				if (start_off) {
-					// if we start off with an off-curve point, then when we need to find a point on the curve
-					// where we can start, and we need to save some state for when we wraparound.
-					scx = x;
-					scy = y;
-					if (!(vertices[off + i + 1].type & 1)) {
-						// next point is also a curve point, so interpolate an on-point curve
-						sx = (x + (stbtt_int32)vertices[off + i + 1].x) >> 1;
-						sy = (y + (stbtt_int32)vertices[off + i + 1].y) >> 1;
-					}
-					else {
-						// otherwise just use the next point as our start point
-						sx = (stbtt_int32)vertices[off + i + 1].x;
-						sy = (stbtt_int32)vertices[off + i + 1].y;
-						++i; // we're using point i+1 as the starting point, so skip it
-					}
-				}
-				else {
-					sx = x;
-					sy = y;
-				}
-				stbtt_setvertex(&vertices[num_vertices++], STBTT_vmove, sx, sy, 0, 0);
-				was_off = 0;
-				next_move = 1 + ttUSHORT(endPtsOfContours + j * 2);
-				++j;
-			}
-			else {
-				if (!(flags & 1)) { // if it's a curve
-					if (was_off) // two off-curve control points in a row means interpolate an on-curve midpoint
-						stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, (cx + x) >> 1, (cy + y) >> 1, cx, cy);
-					cx = x;
-					cy = y;
-					was_off = 1;
-				}
-				else {
-					if (was_off)
-						stbtt_setvertex(&vertices[num_vertices++], STBTT_vcurve, x, y, cx, cy);
-					else
-						stbtt_setvertex(&vertices[num_vertices++], STBTT_vline, x, y, 0, 0);
-					was_off = 0;
-				}
-			}
-		}
-		num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx, sy, scx, scy, cx, cy);
-	}
-	else if (numberOfContours == -1) {
-		// Compound shapes.
-		int more = 1;
-		stbtt_uint8 *comp = data + g + 10;
-		num_vertices = 0;
-		vertices = 0;
-		while (more) {
-			stbtt_uint16 flags, gidx;
-			int comp_num_verts = 0, i;
-			stbtt_vertex *comp_verts = 0, *tmp = 0;
-			float mtx[6] = { 1,0,0,1,0,0 }, m, n;
-
-			flags = ttSHORT(comp); comp += 2;
-			gidx = ttSHORT(comp); comp += 2;
-
-			if (flags & 2) { // XY values
-				if (flags & 1) { // shorts
-					mtx[4] = ttSHORT(comp); comp += 2;
-					mtx[5] = ttSHORT(comp); comp += 2;
-				}
-				else {
-					mtx[4] = ttCHAR(comp); comp += 1;
-					mtx[5] = ttCHAR(comp); comp += 1;
-				}
-			}
-			else {
-				// @TODO handle matching point
-				STBTT_assert(0);
-			}
-			if (flags & (1 << 3)) { // WE_HAVE_A_SCALE
-				mtx[0] = mtx[3] = ttSHORT(comp) / 16384.0f; comp += 2;
-				mtx[1] = mtx[2] = 0;
-			}
-			else if (flags & (1 << 6)) { // WE_HAVE_AN_X_AND_YSCALE
-				mtx[0] = ttSHORT(comp) / 16384.0f; comp += 2;
-				mtx[1] = mtx[2] = 0;
-				mtx[3] = ttSHORT(comp) / 16384.0f; comp += 2;
-			}
-			else if (flags & (1 << 7)) { // WE_HAVE_A_TWO_BY_TWO
-				mtx[0] = ttSHORT(comp) / 16384.0f; comp += 2;
-				mtx[1] = ttSHORT(comp) / 16384.0f; comp += 2;
-				mtx[2] = ttSHORT(comp) / 16384.0f; comp += 2;
-				mtx[3] = ttSHORT(comp) / 16384.0f; comp += 2;
-			}
-
-			// Find transformation scales.
-			m = (float)STBTT_sqrt(mtx[0] * mtx[0] + mtx[1] * mtx[1]);
-			n = (float)STBTT_sqrt(mtx[2] * mtx[2] + mtx[3] * mtx[3]);
-
-			// Get indexed glyph.
-			comp_num_verts = stbtt_GetGlyphShape(info, gidx, &comp_verts);
-			if (comp_num_verts > 0) {
-				// Transform vertices.
-				for (i = 0; i < comp_num_verts; ++i) {
-					stbtt_vertex* v = &comp_verts[i];
-					stbtt_vertex_type x, y;
-					x = v->x; y = v->y;
-					v->x = (stbtt_vertex_type)(m * (mtx[0] * x + mtx[2] * y + mtx[4]));
-					v->y = (stbtt_vertex_type)(n * (mtx[1] * x + mtx[3] * y + mtx[5]));
-					x = v->cx; y = v->cy;
-					v->cx = (stbtt_vertex_type)(m * (mtx[0] * x + mtx[2] * y + mtx[4]));
-					v->cy = (stbtt_vertex_type)(n * (mtx[1] * x + mtx[3] * y + mtx[5]));
-				}
-				// Append vertices.
-				tmp = (stbtt_vertex*)STBTT_malloc((num_vertices + comp_num_verts)*sizeof(stbtt_vertex), info->userdata);
-				if (!tmp) {
-					if (vertices) STBTT_free(vertices, info->userdata);
-					if (comp_verts) STBTT_free(comp_verts, info->userdata);
-					return 0;
-				}
-				if (num_vertices > 0) STBTT_memcpy(tmp, vertices, num_vertices*sizeof(stbtt_vertex));
-				STBTT_memcpy(tmp + num_vertices, comp_verts, comp_num_verts*sizeof(stbtt_vertex));
-				if (vertices) STBTT_free(vertices, info->userdata);
-				vertices = tmp;
-				STBTT_free(comp_verts, info->userdata);
-				num_vertices += comp_num_verts;
-			}
-			// More components ?
-			more = flags & (1 << 5);
-		}
-	}
-	else if (numberOfContours < 0) {
-		// @TODO other compound variations?
-		STBTT_assert(0);
-	}
-	else {
-		// numberOfCounters == 0, do nothing
-	}
-
-	*pvertices = vertices;
-	return num_vertices;
+   if (!info->cff.size)
+      return stbtt__GetGlyphShapeTT(info, glyph_index, pvertices);
+   else
+      return stbtt__GetGlyphShapeT2(info, glyph_index, pvertices);
 }
 
 STBTT_DEF void stbtt_GetGlyphHMetrics(const stbtt_fontinfo *info, int glyph_index, int *advanceWidth, int *leftSideBearing)
 {
-	stbtt_uint16 numOfLongHorMetrics = ttUSHORT(info->data + info->hhea + 34);
-	if (glyph_index < numOfLongHorMetrics) {
-		if (advanceWidth)     *advanceWidth = ttSHORT(info->data + info->hmtx + 4 * glyph_index);
-		if (leftSideBearing)  *leftSideBearing = ttSHORT(info->data + info->hmtx + 4 * glyph_index + 2);
-	}
-	else {
-		if (advanceWidth)     *advanceWidth = ttSHORT(info->data + info->hmtx + 4 * (numOfLongHorMetrics - 1));
-		if (leftSideBearing)  *leftSideBearing = ttSHORT(info->data + info->hmtx + 4 * numOfLongHorMetrics + 2 * (glyph_index - numOfLongHorMetrics));
-	}
+   stbtt_uint16 numOfLongHorMetrics = ttUSHORT(info->data+info->hhea + 34);
+   if (glyph_index < numOfLongHorMetrics) {
+      if (advanceWidth)     *advanceWidth    = ttSHORT(info->data + info->hmtx + 4*glyph_index);
+      if (leftSideBearing)  *leftSideBearing = ttSHORT(info->data + info->hmtx + 4*glyph_index + 2);
+   } else {
+      if (advanceWidth)     *advanceWidth    = ttSHORT(info->data + info->hmtx + 4*(numOfLongHorMetrics-1));
+      if (leftSideBearing)  *leftSideBearing = ttSHORT(info->data + info->hmtx + 4*numOfLongHorMetrics + 2*(glyph_index - numOfLongHorMetrics));
+   }
 }
 
-STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2)
+static int  stbtt__GetGlyphKernInfoAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2)
 {
-	stbtt_uint8 *data = info->data + info->kern;
-	stbtt_uint32 needle, straw;
-	int l, r, m;
+   stbtt_uint8 *data = info->data + info->kern;
+   stbtt_uint32 needle, straw;
+   int l, r, m;
 
-	// we only look at the first table. it must be 'horizontal' and format 0.
-	if (!info->kern)
-		return 0;
-	if (ttUSHORT(data + 2) < 1) // number of tables, need at least 1
-		return 0;
-	if (ttUSHORT(data + 8) != 1) // horizontal flag must be set in format
-		return 0;
+   // we only look at the first table. it must be 'horizontal' and format 0.
+   if (!info->kern)
+      return 0;
+   if (ttUSHORT(data+2) < 1) // number of tables, need at least 1
+      return 0;
+   if (ttUSHORT(data+8) != 1) // horizontal flag must be set in format
+      return 0;
 
-	l = 0;
-	r = ttUSHORT(data + 10) - 1;
-	needle = glyph1 << 16 | glyph2;
-	while (l <= r) {
-		m = (l + r) >> 1;
-		straw = ttULONG(data + 18 + (m * 6)); // note: unaligned read
-		if (needle < straw)
-			r = m - 1;
-		else if (needle > straw)
-			l = m + 1;
-		else
-			return ttSHORT(data + 22 + (m * 6));
-	}
-	return 0;
+   l = 0;
+   r = ttUSHORT(data+10) - 1;
+   needle = glyph1 << 16 | glyph2;
+   while (l <= r) {
+      m = (l + r) >> 1;
+      straw = ttULONG(data+18+(m*6)); // note: unaligned read
+      if (needle < straw)
+         r = m - 1;
+      else if (needle > straw)
+         l = m + 1;
+      else
+         return ttSHORT(data+22+(m*6));
+   }
+   return 0;
+}
+
+static stbtt_int32  stbtt__GetCoverageIndex(stbtt_uint8 *coverageTable, int glyph)
+{
+    stbtt_uint16 coverageFormat = ttUSHORT(coverageTable);
+    switch(coverageFormat) {
+        case 1: {
+            stbtt_uint16 glyphCount = ttUSHORT(coverageTable + 2);
+
+            // Binary search.
+            stbtt_int32 l=0, r=glyphCount-1, m;
+            int straw, needle=glyph;
+            while (l <= r) {
+                stbtt_uint8 *glyphArray = coverageTable + 4;
+                stbtt_uint16 glyphID;
+                m = (l + r) >> 1;
+                glyphID = ttUSHORT(glyphArray + 2 * m);
+                straw = glyphID;
+                if (needle < straw)
+                    r = m - 1;
+                else if (needle > straw)
+                    l = m + 1;
+                else {
+                     return m;
+                }
+            }
+        } break;
+
+        case 2: {
+            stbtt_uint16 rangeCount = ttUSHORT(coverageTable + 2);
+            stbtt_uint8 *rangeArray = coverageTable + 4;
+
+            // Binary search.
+            stbtt_int32 l=0, r=rangeCount-1, m;
+            int strawStart, strawEnd, needle=glyph;
+            while (l <= r) {
+                stbtt_uint8 *rangeRecord;
+                m = (l + r) >> 1;
+                rangeRecord = rangeArray + 6 * m;
+                strawStart = ttUSHORT(rangeRecord);
+                strawEnd = ttUSHORT(rangeRecord + 2);
+                if (needle < strawStart)
+                    r = m - 1;
+                else if (needle > strawEnd)
+                    l = m + 1;
+                else {
+                    stbtt_uint16 startCoverageIndex = ttUSHORT(rangeRecord + 4);
+                    return startCoverageIndex + glyph - strawStart;
+                }
+            }
+        } break;
+
+        default: {
+            // There are no other cases.
+            STBTT_assert(0);
+        } break;
+    }
+
+    return -1;
+}
+
+static stbtt_int32  stbtt__GetGlyphClass(stbtt_uint8 *classDefTable, int glyph)
+{
+    stbtt_uint16 classDefFormat = ttUSHORT(classDefTable);
+    switch(classDefFormat)
+    {
+        case 1: {
+            stbtt_uint16 startGlyphID = ttUSHORT(classDefTable + 2);
+            stbtt_uint16 glyphCount = ttUSHORT(classDefTable + 4);
+            stbtt_uint8 *classDef1ValueArray = classDefTable + 6;
+
+            if (glyph >= startGlyphID && glyph < startGlyphID + glyphCount)
+                return (stbtt_int32)ttUSHORT(classDef1ValueArray + 2 * (glyph - startGlyphID));
+
+            classDefTable = classDef1ValueArray + 2 * glyphCount;
+        } break;
+
+        case 2: {
+            stbtt_uint16 classRangeCount = ttUSHORT(classDefTable + 2);
+            stbtt_uint8 *classRangeRecords = classDefTable + 4;
+
+            // Binary search.
+            stbtt_int32 l=0, r=classRangeCount-1, m;
+            int strawStart, strawEnd, needle=glyph;
+            while (l <= r) {
+                stbtt_uint8 *classRangeRecord;
+                m = (l + r) >> 1;
+                classRangeRecord = classRangeRecords + 6 * m;
+                strawStart = ttUSHORT(classRangeRecord);
+                strawEnd = ttUSHORT(classRangeRecord + 2);
+                if (needle < strawStart)
+                    r = m - 1;
+                else if (needle > strawEnd)
+                    l = m + 1;
+                else
+                    return (stbtt_int32)ttUSHORT(classRangeRecord + 4);
+            }
+
+            classDefTable = classRangeRecords + 6 * classRangeCount;
+        } break;
+
+        default: {
+            // There are no other cases.
+            STBTT_assert(0);
+        } break;
+    }
+
+    return -1;
+}
+
+// Define to STBTT_assert(x) if you want to break on unimplemented formats.
+#define STBTT_GPOS_TODO_assert(x)
+
+static stbtt_int32  stbtt__GetGlyphGPOSInfoAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2)
+{
+    stbtt_uint16 lookupListOffset;
+    stbtt_uint8 *lookupList;
+    stbtt_uint16 lookupCount;
+    stbtt_uint8 *data;
+    stbtt_int32 i;
+
+    if (!info->gpos) return 0;
+
+    data = info->data + info->gpos;
+
+    if (ttUSHORT(data+0) != 1) return 0; // Major version 1
+    if (ttUSHORT(data+2) != 0) return 0; // Minor version 0
+
+    lookupListOffset = ttUSHORT(data+8);
+    lookupList = data + lookupListOffset;
+    lookupCount = ttUSHORT(lookupList);
+
+    for (i=0; i<lookupCount; ++i) {
+        stbtt_uint16 lookupOffset = ttUSHORT(lookupList + 2 + 2 * i);
+        stbtt_uint8 *lookupTable = lookupList + lookupOffset;
+
+        stbtt_uint16 lookupType = ttUSHORT(lookupTable);
+        stbtt_uint16 subTableCount = ttUSHORT(lookupTable + 4);
+        stbtt_uint8 *subTableOffsets = lookupTable + 6;
+        switch(lookupType) {
+            case 2: { // Pair Adjustment Positioning Subtable
+                stbtt_int32 sti;
+                for (sti=0; sti<subTableCount; sti++) {
+                    stbtt_uint16 subtableOffset = ttUSHORT(subTableOffsets + 2 * sti);
+                    stbtt_uint8 *table = lookupTable + subtableOffset;
+                    stbtt_uint16 posFormat = ttUSHORT(table);
+                    stbtt_uint16 coverageOffset = ttUSHORT(table + 2);
+                    stbtt_int32 coverageIndex = stbtt__GetCoverageIndex(table + coverageOffset, glyph1);
+                    if (coverageIndex == -1) continue;
+
+                    switch (posFormat) {
+                        case 1: {
+                            stbtt_int32 l, r, m;
+                            int straw, needle;
+                            stbtt_uint16 valueFormat1 = ttUSHORT(table + 4);
+                            stbtt_uint16 valueFormat2 = ttUSHORT(table + 6);
+                            stbtt_int32 valueRecordPairSizeInBytes = 2;
+                            stbtt_uint16 pairSetCount = ttUSHORT(table + 8);
+                            stbtt_uint16 pairPosOffset = ttUSHORT(table + 10 + 2 * coverageIndex);
+                            stbtt_uint8 *pairValueTable = table + pairPosOffset;
+                            stbtt_uint16 pairValueCount = ttUSHORT(pairValueTable);
+                            stbtt_uint8 *pairValueArray = pairValueTable + 2;
+                            // TODO: Support more formats.
+                            STBTT_GPOS_TODO_assert(valueFormat1 == 4);
+                            if (valueFormat1 != 4) return 0;
+                            STBTT_GPOS_TODO_assert(valueFormat2 == 0);
+                            if (valueFormat2 != 0) return 0;
+
+                            STBTT_assert(coverageIndex < pairSetCount);
+
+                            needle=glyph2;
+                            r=pairValueCount-1;
+                            l=0;
+
+                            // Binary search.
+                            while (l <= r) {
+                                stbtt_uint16 secondGlyph;
+                                stbtt_uint8 *pairValue;
+                                m = (l + r) >> 1;
+                                pairValue = pairValueArray + (2 + valueRecordPairSizeInBytes) * m;
+                                secondGlyph = ttUSHORT(pairValue);
+                                straw = secondGlyph;
+                                if (needle < straw)
+                                    r = m - 1;
+                                else if (needle > straw)
+                                    l = m + 1;
+                                else {
+                                    stbtt_int16 xAdvance = ttSHORT(pairValue + 2);
+                                    return xAdvance;
+                                }
+                            }
+                        } break;
+
+                        case 2: {
+                            stbtt_uint16 valueFormat1 = ttUSHORT(table + 4);
+                            stbtt_uint16 valueFormat2 = ttUSHORT(table + 6);
+
+                            stbtt_uint16 classDef1Offset = ttUSHORT(table + 8);
+                            stbtt_uint16 classDef2Offset = ttUSHORT(table + 10);
+                            int glyph1class = stbtt__GetGlyphClass(table + classDef1Offset, glyph1);
+                            int glyph2class = stbtt__GetGlyphClass(table + classDef2Offset, glyph2);
+
+                            stbtt_uint16 class1Count = ttUSHORT(table + 12);
+                            stbtt_uint16 class2Count = ttUSHORT(table + 14);
+                            STBTT_assert(glyph1class < class1Count);
+                            STBTT_assert(glyph2class < class2Count);
+
+                            // TODO: Support more formats.
+                            STBTT_GPOS_TODO_assert(valueFormat1 == 4);
+                            if (valueFormat1 != 4) return 0;
+                            STBTT_GPOS_TODO_assert(valueFormat2 == 0);
+                            if (valueFormat2 != 0) return 0;
+
+                            if (glyph1class >= 0 && glyph1class < class1Count && glyph2class >= 0 && glyph2class < class2Count) {
+                                stbtt_uint8 *class1Records = table + 16;
+                                stbtt_uint8 *class2Records = class1Records + 2 * (glyph1class * class2Count);
+                                stbtt_int16 xAdvance = ttSHORT(class2Records + 2 * glyph2class);
+                                return xAdvance;
+                            }
+                        } break;
+
+                        default: {
+                            // There are no other cases.
+                            STBTT_assert(0);
+                            break;
+                        };
+                    }
+                }
+                break;
+            };
+
+            default:
+                // TODO: Implement other stuff.
+                break;
+        }
+    }
+
+    return 0;
+}
+
+STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int g1, int g2)
+{
+   int xAdvance = 0;
+
+   if (info->gpos)
+      xAdvance += stbtt__GetGlyphGPOSInfoAdvance(info, g1, g2);
+
+   if (info->kern)
+      xAdvance += stbtt__GetGlyphKernInfoAdvance(info, g1, g2);
+
+   return xAdvance;
 }
 
 STBTT_DEF int  stbtt_GetCodepointKernAdvance(const stbtt_fontinfo *info, int ch1, int ch2)
 {
-	if (!info->kern) // if no kerning table, don't waste time looking up both codepoint->glyphs
-		return 0;
-	return stbtt_GetGlyphKernAdvance(info, stbtt_FindGlyphIndex(info, ch1), stbtt_FindGlyphIndex(info, ch2));
+   if (!info->kern && !info->gpos) // if no kerning table, don't waste time looking up both codepoint->glyphs
+      return 0;
+   return stbtt_GetGlyphKernAdvance(info, stbtt_FindGlyphIndex(info,ch1), stbtt_FindGlyphIndex(info,ch2));
 }
 
 STBTT_DEF void stbtt_GetCodepointHMetrics(const stbtt_fontinfo *info, int codepoint, int *advanceWidth, int *leftSideBearing)
 {
-	stbtt_GetGlyphHMetrics(info, stbtt_FindGlyphIndex(info, codepoint), advanceWidth, leftSideBearing);
+   stbtt_GetGlyphHMetrics(info, stbtt_FindGlyphIndex(info,codepoint), advanceWidth, leftSideBearing);
 }
 
 STBTT_DEF void stbtt_GetFontVMetrics(const stbtt_fontinfo *info, int *ascent, int *descent, int *lineGap)
 {
-	if (ascent) *ascent = ttSHORT(info->data + info->hhea + 4);
-	if (descent) *descent = ttSHORT(info->data + info->hhea + 6);
-	if (lineGap) *lineGap = ttSHORT(info->data + info->hhea + 8);
+   if (ascent ) *ascent  = ttSHORT(info->data+info->hhea + 4);
+   if (descent) *descent = ttSHORT(info->data+info->hhea + 6);
+   if (lineGap) *lineGap = ttSHORT(info->data+info->hhea + 8);
+}
+
+STBTT_DEF int  stbtt_GetFontVMetricsOS2(const stbtt_fontinfo *info, int *typoAscent, int *typoDescent, int *typoLineGap)
+{
+   int tab = stbtt__find_table(info->data, info->fontstart, "OS/2");
+   if (!tab)
+      return 0;
+   if (typoAscent ) *typoAscent  = ttSHORT(info->data+tab + 68);
+   if (typoDescent) *typoDescent = ttSHORT(info->data+tab + 70);
+   if (typoLineGap) *typoLineGap = ttSHORT(info->data+tab + 72);
+   return 1;
 }
 
 STBTT_DEF void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info, int *x0, int *y0, int *x1, int *y1)
 {
-	*x0 = ttSHORT(info->data + info->head + 36);
-	*y0 = ttSHORT(info->data + info->head + 38);
-	*x1 = ttSHORT(info->data + info->head + 40);
-	*y1 = ttSHORT(info->data + info->head + 42);
+   *x0 = ttSHORT(info->data + info->head + 36);
+   *y0 = ttSHORT(info->data + info->head + 38);
+   *x1 = ttSHORT(info->data + info->head + 40);
+   *y1 = ttSHORT(info->data + info->head + 42);
 }
 
 STBTT_DEF float stbtt_ScaleForPixelHeight(const stbtt_fontinfo *info, float height)
 {
-	int fheight = ttSHORT(info->data + info->hhea + 4) - ttSHORT(info->data + info->hhea + 6);
-	return (float)height / fheight;
+   int fheight = ttSHORT(info->data + info->hhea + 4) - ttSHORT(info->data + info->hhea + 6);
+   return (float) height / fheight;
 }
 
 STBTT_DEF float stbtt_ScaleForMappingEmToPixels(const stbtt_fontinfo *info, float pixels)
 {
-	int unitsPerEm = ttUSHORT(info->data + info->head + 18);
-	return pixels / unitsPerEm;
+   int unitsPerEm = ttUSHORT(info->data + info->head + 18);
+   return pixels / unitsPerEm;
 }
 
 STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *v)
 {
-	STBTT_free(v, info->userdata);
+   STBTT_free(v, info->userdata);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1579,38 +2607,37 @@ STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *v)
 // antialiasing software rasterizer
 //
 
-STBTT_DEF void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1)
+STBTT_DEF void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y,float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1)
 {
-	int x0 = 0, y0 = 0, x1, y1; // =0 suppresses compiler warning
-	if (!stbtt_GetGlyphBox(font, glyph, &x0, &y0, &x1, &y1)) {
-		// e.g. space character
-		if (ix0) *ix0 = 0;
-		if (iy0) *iy0 = 0;
-		if (ix1) *ix1 = 0;
-		if (iy1) *iy1 = 0;
-	}
-	else {
-		// move to integral bboxes (treating pixels as little squares, what pixels get touched)?
-		if (ix0) *ix0 = STBTT_ifloor(x0 * scale_x + shift_x);
-		if (iy0) *iy0 = STBTT_ifloor(-y1 * scale_y + shift_y);
-		if (ix1) *ix1 = STBTT_iceil(x1 * scale_x + shift_x);
-		if (iy1) *iy1 = STBTT_iceil(-y0 * scale_y + shift_y);
-	}
+   int x0=0,y0=0,x1,y1; // =0 suppresses compiler warning
+   if (!stbtt_GetGlyphBox(font, glyph, &x0,&y0,&x1,&y1)) {
+      // e.g. space character
+      if (ix0) *ix0 = 0;
+      if (iy0) *iy0 = 0;
+      if (ix1) *ix1 = 0;
+      if (iy1) *iy1 = 0;
+   } else {
+      // move to integral bboxes (treating pixels as little squares, what pixels get touched)?
+      if (ix0) *ix0 = STBTT_ifloor( x0 * scale_x + shift_x);
+      if (iy0) *iy0 = STBTT_ifloor(-y1 * scale_y + shift_y);
+      if (ix1) *ix1 = STBTT_iceil ( x1 * scale_x + shift_x);
+      if (iy1) *iy1 = STBTT_iceil (-y0 * scale_y + shift_y);
+   }
 }
 
 STBTT_DEF void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1)
 {
-	stbtt_GetGlyphBitmapBoxSubpixel(font, glyph, scale_x, scale_y, 0.0f, 0.0f, ix0, iy0, ix1, iy1);
+   stbtt_GetGlyphBitmapBoxSubpixel(font, glyph, scale_x, scale_y,0.0f,0.0f, ix0, iy0, ix1, iy1);
 }
 
 STBTT_DEF void stbtt_GetCodepointBitmapBoxSubpixel(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1)
 {
-	stbtt_GetGlyphBitmapBoxSubpixel(font, stbtt_FindGlyphIndex(font, codepoint), scale_x, scale_y, shift_x, shift_y, ix0, iy0, ix1, iy1);
+   stbtt_GetGlyphBitmapBoxSubpixel(font, stbtt_FindGlyphIndex(font,codepoint), scale_x, scale_y,shift_x,shift_y, ix0,iy0,ix1,iy1);
 }
 
 STBTT_DEF void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1)
 {
-	stbtt_GetCodepointBitmapBoxSubpixel(font, codepoint, scale_x, scale_y, 0.0f, 0.0f, ix0, iy0, ix1, iy1);
+   stbtt_GetCodepointBitmapBoxSubpixel(font, codepoint, scale_x, scale_y,0.0f,0.0f, ix0,iy0,ix1,iy1);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1619,75 +2646,74 @@ STBTT_DEF void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font, int codep
 
 typedef struct stbtt__hheap_chunk
 {
-	struct stbtt__hheap_chunk *next;
+   struct stbtt__hheap_chunk *next;
 } stbtt__hheap_chunk;
 
 typedef struct stbtt__hheap
 {
-	struct stbtt__hheap_chunk *head;
-	void   *first_free;
-	int    num_remaining_in_head_chunk;
+   struct stbtt__hheap_chunk *head;
+   void   *first_free;
+   int    num_remaining_in_head_chunk;
 } stbtt__hheap;
 
 static void *stbtt__hheap_alloc(stbtt__hheap *hh, size_t size, void *userdata)
 {
-	if (hh->first_free) {
-		void *p = hh->first_free;
-		hh->first_free = *(void **)p;
-		return p;
-	}
-	else {
-		if (hh->num_remaining_in_head_chunk == 0) {
-			int count = (size < 32 ? 2000 : size < 128 ? 800 : 100);
-			stbtt__hheap_chunk *c = (stbtt__hheap_chunk *)STBTT_malloc(sizeof(stbtt__hheap_chunk) + size * count, userdata);
-			if (c == NULL)
-				return NULL;
-			c->next = hh->head;
-			hh->head = c;
-			hh->num_remaining_in_head_chunk = count;
-		}
-		--hh->num_remaining_in_head_chunk;
-		return (char *)(hh->head) + size * hh->num_remaining_in_head_chunk;
-	}
+   if (hh->first_free) {
+      void *p = hh->first_free;
+      hh->first_free = * (void **) p;
+      return p;
+   } else {
+      if (hh->num_remaining_in_head_chunk == 0) {
+         int count = (size < 32 ? 2000 : size < 128 ? 800 : 100);
+         stbtt__hheap_chunk *c = (stbtt__hheap_chunk *) STBTT_malloc(sizeof(stbtt__hheap_chunk) + size * count, userdata);
+         if (c == NULL)
+            return NULL;
+         c->next = hh->head;
+         hh->head = c;
+         hh->num_remaining_in_head_chunk = count;
+      }
+      --hh->num_remaining_in_head_chunk;
+      return (char *) (hh->head) + sizeof(stbtt__hheap_chunk) + size * hh->num_remaining_in_head_chunk;
+   }
 }
 
 static void stbtt__hheap_free(stbtt__hheap *hh, void *p)
 {
-	*(void **)p = hh->first_free;
-	hh->first_free = p;
+   *(void **) p = hh->first_free;
+   hh->first_free = p;
 }
 
 static void stbtt__hheap_cleanup(stbtt__hheap *hh, void *userdata)
 {
-	stbtt__hheap_chunk *c = hh->head;
-	while (c) {
-		stbtt__hheap_chunk *n = c->next;
-		STBTT_free(c, userdata);
-		c = n;
-	}
+   stbtt__hheap_chunk *c = hh->head;
+   while (c) {
+      stbtt__hheap_chunk *n = c->next;
+      STBTT_free(c, userdata);
+      c = n;
+   }
 }
 
 typedef struct stbtt__edge {
-	float x0, y0, x1, y1;
-	int invert;
+   float x0,y0, x1,y1;
+   int invert;
 } stbtt__edge;
 
 
 typedef struct stbtt__active_edge
 {
-	struct stbtt__active_edge *next;
-#if STBTT_RASTERIZER_VERSION==1
-	int x, dx;
-	float ey;
-	int direction;
-#elif STBTT_RASTERIZER_VERSION==2
-	float fx, fdx, fdy;
-	float direction;
-	float sy;
-	float ey;
-#else
-#error "Unrecognized value of STBTT_RASTERIZER_VERSION"
-#endif
+   struct stbtt__active_edge *next;
+   #if STBTT_RASTERIZER_VERSION==1
+   int x,dx;
+   float ey;
+   int direction;
+   #elif STBTT_RASTERIZER_VERSION==2
+   float fx,fdx,fdy;
+   float direction;
+   float sy;
+   float ey;
+   #else
+   #error "Unrecognized value of STBTT_RASTERIZER_VERSION"
+   #endif
 } stbtt__active_edge;
 
 #if STBTT_RASTERIZER_VERSION == 1
@@ -1697,42 +2723,42 @@ typedef struct stbtt__active_edge
 
 static stbtt__active_edge *stbtt__new_active(stbtt__hheap *hh, stbtt__edge *e, int off_x, float start_point, void *userdata)
 {
-	stbtt__active_edge *z = (stbtt__active_edge *)stbtt__hheap_alloc(hh, sizeof(*z), userdata);
-	float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
-	STBTT_assert(z != NULL);
-	if (!z) return z;
+   stbtt__active_edge *z = (stbtt__active_edge *) stbtt__hheap_alloc(hh, sizeof(*z), userdata);
+   float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
+   STBTT_assert(z != NULL);
+   if (!z) return z;
+   
+   // round dx down to avoid overshooting
+   if (dxdy < 0)
+      z->dx = -STBTT_ifloor(STBTT_FIX * -dxdy);
+   else
+      z->dx = STBTT_ifloor(STBTT_FIX * dxdy);
 
-	// round dx down to avoid overshooting
-	if (dxdy < 0)
-		z->dx = -STBTT_ifloor(STBTT_FIX * -dxdy);
-	else
-		z->dx = STBTT_ifloor(STBTT_FIX * dxdy);
+   z->x = STBTT_ifloor(STBTT_FIX * e->x0 + z->dx * (start_point - e->y0)); // use z->dx so when we offset later it's by the same amount
+   z->x -= off_x * STBTT_FIX;
 
-	z->x = STBTT_ifloor(STBTT_FIX * e->x0 + z->dx * (start_point - e->y0)); // use z->dx so when we offset later it's by the same amount
-	z->x -= off_x * STBTT_FIX;
-
-	z->ey = e->y1;
-	z->next = 0;
-	z->direction = e->invert ? 1 : -1;
-	return z;
+   z->ey = e->y1;
+   z->next = 0;
+   z->direction = e->invert ? 1 : -1;
+   return z;
 }
 #elif STBTT_RASTERIZER_VERSION == 2
 static stbtt__active_edge *stbtt__new_active(stbtt__hheap *hh, stbtt__edge *e, int off_x, float start_point, void *userdata)
 {
-	stbtt__active_edge *z = (stbtt__active_edge *)stbtt__hheap_alloc(hh, sizeof(*z), userdata);
-	float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
-	STBTT_assert(z != NULL);
-	//STBTT_assert(e->y0 <= start_point);
-	if (!z) return z;
-	z->fdx = dxdy;
-	z->fdy = dxdy != 0.0f ? (1.0f / dxdy) : 0.0f;
-	z->fx = e->x0 + dxdy * (start_point - e->y0);
-	z->fx -= off_x;
-	z->direction = e->invert ? 1.0f : -1.0f;
-	z->sy = e->y0;
-	z->ey = e->y1;
-	z->next = 0;
-	return z;
+   stbtt__active_edge *z = (stbtt__active_edge *) stbtt__hheap_alloc(hh, sizeof(*z), userdata);
+   float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
+   STBTT_assert(z != NULL);
+   //STBTT_assert(e->y0 <= start_point);
+   if (!z) return z;
+   z->fdx = dxdy;
+   z->fdy = dxdy != 0.0f ? (1.0f/dxdy) : 0.0f;
+   z->fx = e->x0 + dxdy * (start_point - e->y0);
+   z->fx -= off_x;
+   z->direction = e->invert ? 1.0f : -1.0f;
+   z->sy = e->y0;
+   z->ey = e->y1;
+   z->next = 0;
+   return z;
 }
 #else
 #error "Unrecognized value of STBTT_RASTERIZER_VERSION"
@@ -1744,148 +2770,144 @@ static stbtt__active_edge *stbtt__new_active(stbtt__hheap *hh, stbtt__edge *e, i
 // are wrong, or if the user supplies a too-small bitmap
 static void stbtt__fill_active_edges(unsigned char *scanline, int len, stbtt__active_edge *e, int max_weight)
 {
-	// non-zero winding fill
-	int x0 = 0, w = 0;
+   // non-zero winding fill
+   int x0=0, w=0;
 
-	while (e) {
-		if (w == 0) {
-			// if we're currently at zero, we need to record the edge start point
-			x0 = e->x; w += e->direction;
-		}
-		else {
-			int x1 = e->x; w += e->direction;
-			// if we went to zero, we need to draw
-			if (w == 0) {
-				int i = x0 >> STBTT_FIXSHIFT;
-				int j = x1 >> STBTT_FIXSHIFT;
+   while (e) {
+      if (w == 0) {
+         // if we're currently at zero, we need to record the edge start point
+         x0 = e->x; w += e->direction;
+      } else {
+         int x1 = e->x; w += e->direction;
+         // if we went to zero, we need to draw
+         if (w == 0) {
+            int i = x0 >> STBTT_FIXSHIFT;
+            int j = x1 >> STBTT_FIXSHIFT;
 
-				if (i < len && j >= 0) {
-					if (i == j) {
-						// x0,x1 are the same pixel, so compute combined coverage
-						scanline[i] = scanline[i] + (stbtt_uint8)((x1 - x0) * max_weight >> STBTT_FIXSHIFT);
-					}
-					else {
-						if (i >= 0) // add antialiasing for x0
-							scanline[i] = scanline[i] + (stbtt_uint8)(((STBTT_FIX - (x0 & STBTT_FIXMASK)) * max_weight) >> STBTT_FIXSHIFT);
-						else
-							i = -1; // clip
+            if (i < len && j >= 0) {
+               if (i == j) {
+                  // x0,x1 are the same pixel, so compute combined coverage
+                  scanline[i] = scanline[i] + (stbtt_uint8) ((x1 - x0) * max_weight >> STBTT_FIXSHIFT);
+               } else {
+                  if (i >= 0) // add antialiasing for x0
+                     scanline[i] = scanline[i] + (stbtt_uint8) (((STBTT_FIX - (x0 & STBTT_FIXMASK)) * max_weight) >> STBTT_FIXSHIFT);
+                  else
+                     i = -1; // clip
 
-						if (j < len) // add antialiasing for x1
-							scanline[j] = scanline[j] + (stbtt_uint8)(((x1 & STBTT_FIXMASK) * max_weight) >> STBTT_FIXSHIFT);
-						else
-							j = len; // clip
+                  if (j < len) // add antialiasing for x1
+                     scanline[j] = scanline[j] + (stbtt_uint8) (((x1 & STBTT_FIXMASK) * max_weight) >> STBTT_FIXSHIFT);
+                  else
+                     j = len; // clip
 
-						for (++i; i < j; ++i) // fill pixels between x0 and x1
-							scanline[i] = scanline[i] + (stbtt_uint8)max_weight;
-					}
-				}
-			}
-		}
-
-		e = e->next;
-	}
+                  for (++i; i < j; ++i) // fill pixels between x0 and x1
+                     scanline[i] = scanline[i] + (stbtt_uint8) max_weight;
+               }
+            }
+         }
+      }
+      
+      e = e->next;
+   }
 }
 
 static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e, int n, int vsubsample, int off_x, int off_y, void *userdata)
 {
-	stbtt__hheap hh = { 0, 0, 0 };
-	stbtt__active_edge *active = NULL;
-	int y, j = 0;
-	int max_weight = (255 / vsubsample);  // weight per vertical scanline
-	int s; // vertical subsample index
-	unsigned char scanline_data[512], *scanline;
+   stbtt__hheap hh = { 0, 0, 0 };
+   stbtt__active_edge *active = NULL;
+   int y,j=0;
+   int max_weight = (255 / vsubsample);  // weight per vertical scanline
+   int s; // vertical subsample index
+   unsigned char scanline_data[512], *scanline;
 
-	if (result->w > 512)
-		scanline = (unsigned char *)STBTT_malloc(result->w, userdata);
-	else
-		scanline = scanline_data;
+   if (result->w > 512)
+      scanline = (unsigned char *) STBTT_malloc(result->w, userdata);
+   else
+      scanline = scanline_data;
 
-	y = off_y * vsubsample;
-	e[n].y0 = (off_y + result->h) * (float)vsubsample + 1;
+   y = off_y * vsubsample;
+   e[n].y0 = (off_y + result->h) * (float) vsubsample + 1;
 
-	while (j < result->h) {
-		STBTT_memset(scanline, 0, result->w);
-		for (s = 0; s < vsubsample; ++s) {
-			// find center of pixel for this scanline
-			float scan_y = y + 0.5f;
-			stbtt__active_edge **step = &active;
+   while (j < result->h) {
+      STBTT_memset(scanline, 0, result->w);
+      for (s=0; s < vsubsample; ++s) {
+         // find center of pixel for this scanline
+         float scan_y = y + 0.5f;
+         stbtt__active_edge **step = &active;
 
-			// update all active edges;
-			// remove all active edges that terminate before the center of this scanline
-			while (*step) {
-				stbtt__active_edge * z = *step;
-				if (z->ey <= scan_y) {
-					*step = z->next; // delete from list
-					STBTT_assert(z->direction);
-					z->direction = 0;
-					stbtt__hheap_free(&hh, z);
-				}
-				else {
-					z->x += z->dx; // advance to position for current scanline
-					step = &((*step)->next); // advance through list
-				}
-			}
+         // update all active edges;
+         // remove all active edges that terminate before the center of this scanline
+         while (*step) {
+            stbtt__active_edge * z = *step;
+            if (z->ey <= scan_y) {
+               *step = z->next; // delete from list
+               STBTT_assert(z->direction);
+               z->direction = 0;
+               stbtt__hheap_free(&hh, z);
+            } else {
+               z->x += z->dx; // advance to position for current scanline
+               step = &((*step)->next); // advance through list
+            }
+         }
 
-			// resort the list if needed
-			for (;;) {
-				int changed = 0;
-				step = &active;
-				while (*step && (*step)->next) {
-					if ((*step)->x > (*step)->next->x) {
-						stbtt__active_edge *t = *step;
-						stbtt__active_edge *q = t->next;
+         // resort the list if needed
+         for(;;) {
+            int changed=0;
+            step = &active;
+            while (*step && (*step)->next) {
+               if ((*step)->x > (*step)->next->x) {
+                  stbtt__active_edge *t = *step;
+                  stbtt__active_edge *q = t->next;
 
-						t->next = q->next;
-						q->next = t;
-						*step = q;
-						changed = 1;
-					}
-					step = &(*step)->next;
-				}
-				if (!changed) break;
-			}
+                  t->next = q->next;
+                  q->next = t;
+                  *step = q;
+                  changed = 1;
+               }
+               step = &(*step)->next;
+            }
+            if (!changed) break;
+         }
 
-			// insert all edges that start before the center of this scanline -- omit ones that also end on this scanline
-			while (e->y0 <= scan_y) {
-				if (e->y1 > scan_y) {
-					stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y, userdata);
-					if (z != NULL) {
-						// find insertion point
-						if (active == NULL)
-							active = z;
-						else if (z->x < active->x) {
-							// insert at front
-							z->next = active;
-							active = z;
-						}
-						else {
-							// find thing to insert AFTER
-							stbtt__active_edge *p = active;
-							while (p->next && p->next->x < z->x)
-								p = p->next;
-							// at this point, p->next->x is NOT < z->x
-							z->next = p->next;
-							p->next = z;
-						}
-					}
-				}
-				++e;
-			}
+         // insert all edges that start before the center of this scanline -- omit ones that also end on this scanline
+         while (e->y0 <= scan_y) {
+            if (e->y1 > scan_y) {
+               stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y, userdata);
+               if (z != NULL) {
+                  // find insertion point
+                  if (active == NULL)
+                     active = z;
+                  else if (z->x < active->x) {
+                     // insert at front
+                     z->next = active;
+                     active = z;
+                  } else {
+                     // find thing to insert AFTER
+                     stbtt__active_edge *p = active;
+                     while (p->next && p->next->x < z->x)
+                        p = p->next;
+                     // at this point, p->next->x is NOT < z->x
+                     z->next = p->next;
+                     p->next = z;
+                  }
+               }
+            }
+            ++e;
+         }
 
-			// now process all active edges in XOR fashion
-			if (active)
-				stbtt__fill_active_edges(scanline, result->w, active, max_weight);
+         // now process all active edges in XOR fashion
+         if (active)
+            stbtt__fill_active_edges(scanline, result->w, active, max_weight);
 
-			++y;
-		}
-		STBTT_memcpy(result->pixels + j * result->stride, scanline, result->w);
-		++j;
-	}
+         ++y;
+      }
+      STBTT_memcpy(result->pixels + j * result->stride, scanline, result->w);
+      ++j;
+   }
 
-	stbtt__hheap_cleanup(&hh, userdata);
+   stbtt__hheap_cleanup(&hh, userdata);
 
-	if (scanline != scanline_data)
-		STBTT_free(scanline, userdata);
+   if (scanline != scanline_data)
+      STBTT_free(scanline, userdata);
 }
 
 #elif STBTT_RASTERIZER_VERSION == 2
@@ -1894,304 +2916,292 @@ static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e,
 // (i.e. it has already been clipped to those)
 static void stbtt__handle_clipped_edge(float *scanline, int x, stbtt__active_edge *e, float x0, float y0, float x1, float y1)
 {
-	if (y0 == y1) return;
-	STBTT_assert(y0 < y1);
-	STBTT_assert(e->sy <= e->ey);
-	if (y0 > e->ey) return;
-	if (y1 < e->sy) return;
-	if (y0 < e->sy) {
-		x0 += (x1 - x0) * (e->sy - y0) / (y1 - y0);
-		y0 = e->sy;
-	}
-	if (y1 > e->ey) {
-		x1 += (x1 - x0) * (e->ey - y1) / (y1 - y0);
-		y1 = e->ey;
-	}
+   if (y0 == y1) return;
+   STBTT_assert(y0 < y1);
+   STBTT_assert(e->sy <= e->ey);
+   if (y0 > e->ey) return;
+   if (y1 < e->sy) return;
+   if (y0 < e->sy) {
+      x0 += (x1-x0) * (e->sy - y0) / (y1-y0);
+      y0 = e->sy;
+   }
+   if (y1 > e->ey) {
+      x1 += (x1-x0) * (e->ey - y1) / (y1-y0);
+      y1 = e->ey;
+   }
 
-	if (x0 == x)
-		STBTT_assert(x1 <= x + 1);
-	else if (x0 == x + 1)
-		STBTT_assert(x1 >= x);
-	else if (x0 <= x)
-		STBTT_assert(x1 <= x);
-	else if (x0 >= x + 1)
-		STBTT_assert(x1 >= x + 1);
-	else
-		STBTT_assert(x1 >= x && x1 <= x + 1);
+   if (x0 == x)
+      STBTT_assert(x1 <= x+1);
+   else if (x0 == x+1)
+      STBTT_assert(x1 >= x);
+   else if (x0 <= x)
+      STBTT_assert(x1 <= x);
+   else if (x0 >= x+1)
+      STBTT_assert(x1 >= x+1);
+   else
+      STBTT_assert(x1 >= x && x1 <= x+1);
 
-	if (x0 <= x && x1 <= x)
-		scanline[x] += e->direction * (y1 - y0);
-	else if (x0 >= x + 1 && x1 >= x + 1)
-		;
-	else {
-		STBTT_assert(x0 >= x && x0 <= x + 1 && x1 >= x && x1 <= x + 1);
-		scanline[x] += e->direction * (y1 - y0) * (1 - ((x0 - x) + (x1 - x)) / 2); // coverage = 1 - average x position
-	}
+   if (x0 <= x && x1 <= x)
+      scanline[x] += e->direction * (y1-y0);
+   else if (x0 >= x+1 && x1 >= x+1)
+      ;
+   else {
+      STBTT_assert(x0 >= x && x0 <= x+1 && x1 >= x && x1 <= x+1);
+      scanline[x] += e->direction * (y1-y0) * (1-((x0-x)+(x1-x))/2); // coverage = 1 - average x position
+   }
 }
 
 static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill, int len, stbtt__active_edge *e, float y_top)
 {
-	float y_bottom = y_top + 1;
+   float y_bottom = y_top+1;
 
-	while (e) {
-		// brute force every pixel
+   while (e) {
+      // brute force every pixel
 
-		// compute intersection points with top & bottom
-		STBTT_assert(e->ey >= y_top);
+      // compute intersection points with top & bottom
+      STBTT_assert(e->ey >= y_top);
 
-		if (e->fdx == 0) {
-			float x0 = e->fx;
-			if (x0 < len) {
-				if (x0 >= 0) {
-					stbtt__handle_clipped_edge(scanline, (int)x0, e, x0, y_top, x0, y_bottom);
-					stbtt__handle_clipped_edge(scanline_fill - 1, (int)x0 + 1, e, x0, y_top, x0, y_bottom);
-				}
-				else {
-					stbtt__handle_clipped_edge(scanline_fill - 1, 0, e, x0, y_top, x0, y_bottom);
-				}
-			}
-		}
-		else {
-			float x0 = e->fx;
-			float dx = e->fdx;
-			float xb = x0 + dx;
-			float x_top, x_bottom;
-			float sy0, sy1;
-			float dy = e->fdy;
-			STBTT_assert(e->sy <= y_bottom && e->ey >= y_top);
+      if (e->fdx == 0) {
+         float x0 = e->fx;
+         if (x0 < len) {
+            if (x0 >= 0) {
+               stbtt__handle_clipped_edge(scanline,(int) x0,e, x0,y_top, x0,y_bottom);
+               stbtt__handle_clipped_edge(scanline_fill-1,(int) x0+1,e, x0,y_top, x0,y_bottom);
+            } else {
+               stbtt__handle_clipped_edge(scanline_fill-1,0,e, x0,y_top, x0,y_bottom);
+            }
+         }
+      } else {
+         float x0 = e->fx;
+         float dx = e->fdx;
+         float xb = x0 + dx;
+         float x_top, x_bottom;
+         float sy0,sy1;
+         float dy = e->fdy;
+         STBTT_assert(e->sy <= y_bottom && e->ey >= y_top);
 
-			// compute endpoints of line segment clipped to this scanline (if the
-			// line segment starts on this scanline. x0 is the intersection of the
-			// line with y_top, but that may be off the line segment.
-			if (e->sy > y_top) {
-				x_top = x0 + dx * (e->sy - y_top);
-				sy0 = e->sy;
-			}
-			else {
-				x_top = x0;
-				sy0 = y_top;
-			}
-			if (e->ey < y_bottom) {
-				x_bottom = x0 + dx * (e->ey - y_top);
-				sy1 = e->ey;
-			}
-			else {
-				x_bottom = xb;
-				sy1 = y_bottom;
-			}
+         // compute endpoints of line segment clipped to this scanline (if the
+         // line segment starts on this scanline. x0 is the intersection of the
+         // line with y_top, but that may be off the line segment.
+         if (e->sy > y_top) {
+            x_top = x0 + dx * (e->sy - y_top);
+            sy0 = e->sy;
+         } else {
+            x_top = x0;
+            sy0 = y_top;
+         }
+         if (e->ey < y_bottom) {
+            x_bottom = x0 + dx * (e->ey - y_top);
+            sy1 = e->ey;
+         } else {
+            x_bottom = xb;
+            sy1 = y_bottom;
+         }
 
-			if (x_top >= 0 && x_bottom >= 0 && x_top < len && x_bottom < len) {
-				// from here on, we don't have to range check x values
+         if (x_top >= 0 && x_bottom >= 0 && x_top < len && x_bottom < len) {
+            // from here on, we don't have to range check x values
 
-				if ((int)x_top == (int)x_bottom) {
-					float height;
-					// simple case, only spans one pixel
-					int x = (int)x_top;
-					height = sy1 - sy0;
-					STBTT_assert(x >= 0 && x < len);
-					scanline[x] += e->direction * (1 - ((x_top - x) + (x_bottom - x)) / 2)  * height;
-					scanline_fill[x] += e->direction * height; // everything right of this pixel is filled
-				}
-				else {
-					int x, x1, x2;
-					float y_crossing, step, sign, area;
-					// covers 2+ pixels
-					if (x_top > x_bottom) {
-						// flip scanline vertically; signed area is the same
-						float t;
-						sy0 = y_bottom - (sy0 - y_top);
-						sy1 = y_bottom - (sy1 - y_top);
-						t = sy0, sy0 = sy1, sy1 = t;
-						t = x_bottom, x_bottom = x_top, x_top = t;
-						dx = -dx;
-						dy = -dy;
-						t = x0, x0 = xb, xb = t;
-					}
+            if ((int) x_top == (int) x_bottom) {
+               float height;
+               // simple case, only spans one pixel
+               int x = (int) x_top;
+               height = sy1 - sy0;
+               STBTT_assert(x >= 0 && x < len);
+               scanline[x] += e->direction * (1-((x_top - x) + (x_bottom-x))/2)  * height;
+               scanline_fill[x] += e->direction * height; // everything right of this pixel is filled
+            } else {
+               int x,x1,x2;
+               float y_crossing, step, sign, area;
+               // covers 2+ pixels
+               if (x_top > x_bottom) {
+                  // flip scanline vertically; signed area is the same
+                  float t;
+                  sy0 = y_bottom - (sy0 - y_top);
+                  sy1 = y_bottom - (sy1 - y_top);
+                  t = sy0, sy0 = sy1, sy1 = t;
+                  t = x_bottom, x_bottom = x_top, x_top = t;
+                  dx = -dx;
+                  dy = -dy;
+                  t = x0, x0 = xb, xb = t;
+               }
 
-					x1 = (int)x_top;
-					x2 = (int)x_bottom;
-					// compute intersection with y axis at x1+1
-					y_crossing = (x1 + 1 - x0) * dy + y_top;
+               x1 = (int) x_top;
+               x2 = (int) x_bottom;
+               // compute intersection with y axis at x1+1
+               y_crossing = (x1+1 - x0) * dy + y_top;
 
-					sign = e->direction;
-					// area of the rectangle covered from y0..y_crossing
-					area = sign * (y_crossing - sy0);
-					// area of the triangle (x_top,y0), (x+1,y0), (x+1,y_crossing)
-					scanline[x1] += area * (1 - ((x_top - x1) + (x1 + 1 - x1)) / 2);
+               sign = e->direction;
+               // area of the rectangle covered from y0..y_crossing
+               area = sign * (y_crossing-sy0);
+               // area of the triangle (x_top,y0), (x+1,y0), (x+1,y_crossing)
+               scanline[x1] += area * (1-((x_top - x1)+(x1+1-x1))/2);
 
-					step = sign * dy;
-					for (x = x1 + 1; x < x2; ++x) {
-						scanline[x] += area + step / 2;
-						area += step;
-					}
-					y_crossing += dy * (x2 - (x1 + 1));
+               step = sign * dy;
+               for (x = x1+1; x < x2; ++x) {
+                  scanline[x] += area + step/2;
+                  area += step;
+               }
+               y_crossing += dy * (x2 - (x1+1));
 
-					STBTT_assert(fabs(area) <= 1.01f);
+               STBTT_assert(STBTT_fabs(area) <= 1.01f);
 
-					scanline[x2] += area + sign * (1 - ((x2 - x2) + (x_bottom - x2)) / 2) * (sy1 - y_crossing);
+               scanline[x2] += area + sign * (1-((x2-x2)+(x_bottom-x2))/2) * (sy1-y_crossing);
 
-					scanline_fill[x2] += sign * (sy1 - sy0);
-				}
-			}
-			else {
-				// if edge goes outside of box we're drawing, we require
-				// clipping logic. since this does not match the intended use
-				// of this library, we use a different, very slow brute
-				// force implementation
-				int x;
-				for (x = 0; x < len; ++x) {
-					// cases:
-					//
-					// there can be up to two intersections with the pixel. any intersection
-					// with left or right edges can be handled by splitting into two (or three)
-					// regions. intersections with top & bottom do not necessitate case-wise logic.
-					//
-					// the old way of doing this found the intersections with the left & right edges,
-					// then used some simple logic to produce up to three segments in sorted order
-					// from top-to-bottom. however, this had a problem: if an x edge was epsilon
-					// across the x border, then the corresponding y position might not be distinct
-					// from the other y segment, and it might ignored as an empty segment. to avoid
-					// that, we need to explicitly produce segments based on x positions.
+               scanline_fill[x2] += sign * (sy1-sy0);
+            }
+         } else {
+            // if edge goes outside of box we're drawing, we require
+            // clipping logic. since this does not match the intended use
+            // of this library, we use a different, very slow brute
+            // force implementation
+            int x;
+            for (x=0; x < len; ++x) {
+               // cases:
+               //
+               // there can be up to two intersections with the pixel. any intersection
+               // with left or right edges can be handled by splitting into two (or three)
+               // regions. intersections with top & bottom do not necessitate case-wise logic.
+               //
+               // the old way of doing this found the intersections with the left & right edges,
+               // then used some simple logic to produce up to three segments in sorted order
+               // from top-to-bottom. however, this had a problem: if an x edge was epsilon
+               // across the x border, then the corresponding y position might not be distinct
+               // from the other y segment, and it might ignored as an empty segment. to avoid
+               // that, we need to explicitly produce segments based on x positions.
 
-					// rename variables to clear pairs
-					float y0 = y_top;
-					float x1 = (float)(x);
-					float x2 = (float)(x + 1);
-					float x3 = xb;
-					float y3 = y_bottom;
-					float y1, y2;
+               // rename variables to clearly-defined pairs
+               float y0 = y_top;
+               float x1 = (float) (x);
+               float x2 = (float) (x+1);
+               float x3 = xb;
+               float y3 = y_bottom;
 
-					// x = e->x + e->dx * (y-y_top)
-					// (y-y_top) = (x - e->x) / e->dx
-					// y = (x - e->x) / e->dx + y_top
-					y1 = (x - x0) / dx + y_top;
-					y2 = (x + 1 - x0) / dx + y_top;
+               // x = e->x + e->dx * (y-y_top)
+               // (y-y_top) = (x - e->x) / e->dx
+               // y = (x - e->x) / e->dx + y_top
+               float y1 = (x - x0) / dx + y_top;
+               float y2 = (x+1 - x0) / dx + y_top;
 
-					if (x0 < x1 && x3 > x2) {         // three segments descending down-right
-						stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x1, y1);
-						stbtt__handle_clipped_edge(scanline, x, e, x1, y1, x2, y2);
-						stbtt__handle_clipped_edge(scanline, x, e, x2, y2, x3, y3);
-					}
-					else if (x3 < x1 && x0 > x2) {  // three segments descending down-left
-						stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x2, y2);
-						stbtt__handle_clipped_edge(scanline, x, e, x2, y2, x1, y1);
-						stbtt__handle_clipped_edge(scanline, x, e, x1, y1, x3, y3);
-					}
-					else if (x0 < x1 && x3 > x1) {  // two segments across x, down-right
-						stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x1, y1);
-						stbtt__handle_clipped_edge(scanline, x, e, x1, y1, x3, y3);
-					}
-					else if (x3 < x1 && x0 > x1) {  // two segments across x, down-left
-						stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x1, y1);
-						stbtt__handle_clipped_edge(scanline, x, e, x1, y1, x3, y3);
-					}
-					else if (x0 < x2 && x3 > x2) {  // two segments across x+1, down-right
-						stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x2, y2);
-						stbtt__handle_clipped_edge(scanline, x, e, x2, y2, x3, y3);
-					}
-					else if (x3 < x2 && x0 > x2) {  // two segments across x+1, down-left
-						stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x2, y2);
-						stbtt__handle_clipped_edge(scanline, x, e, x2, y2, x3, y3);
-					}
-					else {  // one segment
-						stbtt__handle_clipped_edge(scanline, x, e, x0, y0, x3, y3);
-					}
-				}
-			}
-		}
-		e = e->next;
-	}
+               if (x0 < x1 && x3 > x2) {         // three segments descending down-right
+                  stbtt__handle_clipped_edge(scanline,x,e, x0,y0, x1,y1);
+                  stbtt__handle_clipped_edge(scanline,x,e, x1,y1, x2,y2);
+                  stbtt__handle_clipped_edge(scanline,x,e, x2,y2, x3,y3);
+               } else if (x3 < x1 && x0 > x2) {  // three segments descending down-left
+                  stbtt__handle_clipped_edge(scanline,x,e, x0,y0, x2,y2);
+                  stbtt__handle_clipped_edge(scanline,x,e, x2,y2, x1,y1);
+                  stbtt__handle_clipped_edge(scanline,x,e, x1,y1, x3,y3);
+               } else if (x0 < x1 && x3 > x1) {  // two segments across x, down-right
+                  stbtt__handle_clipped_edge(scanline,x,e, x0,y0, x1,y1);
+                  stbtt__handle_clipped_edge(scanline,x,e, x1,y1, x3,y3);
+               } else if (x3 < x1 && x0 > x1) {  // two segments across x, down-left
+                  stbtt__handle_clipped_edge(scanline,x,e, x0,y0, x1,y1);
+                  stbtt__handle_clipped_edge(scanline,x,e, x1,y1, x3,y3);
+               } else if (x0 < x2 && x3 > x2) {  // two segments across x+1, down-right
+                  stbtt__handle_clipped_edge(scanline,x,e, x0,y0, x2,y2);
+                  stbtt__handle_clipped_edge(scanline,x,e, x2,y2, x3,y3);
+               } else if (x3 < x2 && x0 > x2) {  // two segments across x+1, down-left
+                  stbtt__handle_clipped_edge(scanline,x,e, x0,y0, x2,y2);
+                  stbtt__handle_clipped_edge(scanline,x,e, x2,y2, x3,y3);
+               } else {  // one segment
+                  stbtt__handle_clipped_edge(scanline,x,e, x0,y0, x3,y3);
+               }
+            }
+         }
+      }
+      e = e->next;
+   }
 }
 
 // directly AA rasterize edges w/o supersampling
 static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e, int n, int vsubsample, int off_x, int off_y, void *userdata)
 {
-	stbtt__hheap hh = { 0, 0, 0 };
-	stbtt__active_edge *active = NULL;
-	int y, j = 0, i;
-	float scanline_data[129], *scanline, *scanline2;
+   stbtt__hheap hh = { 0, 0, 0 };
+   stbtt__active_edge *active = NULL;
+   int y,j=0, i;
+   float scanline_data[129], *scanline, *scanline2;
 
-	if (result->w > 64)
-		scanline = (float *)STBTT_malloc((result->w * 2 + 1) * sizeof(float), userdata);
-	else
-		scanline = scanline_data;
+   STBTT__NOTUSED(vsubsample);
 
-	scanline2 = scanline + result->w;
+   if (result->w > 64)
+      scanline = (float *) STBTT_malloc((result->w*2+1) * sizeof(float), userdata);
+   else
+      scanline = scanline_data;
 
-	y = off_y;
-	e[n].y0 = (float)(off_y + result->h) + 1;
+   scanline2 = scanline + result->w;
 
-	while (j < result->h) {
-		// find center of pixel for this scanline
-		float scan_y_top = y + 0.0f;
-		float scan_y_bottom = y + 1.0f;
-		stbtt__active_edge **step = &active;
+   y = off_y;
+   e[n].y0 = (float) (off_y + result->h) + 1;
 
-		STBTT_memset(scanline, 0, result->w*sizeof(scanline[0]));
-		STBTT_memset(scanline2, 0, (result->w + 1)*sizeof(scanline[0]));
+   while (j < result->h) {
+      // find center of pixel for this scanline
+      float scan_y_top    = y + 0.0f;
+      float scan_y_bottom = y + 1.0f;
+      stbtt__active_edge **step = &active;
 
-		// update all active edges;
-		// remove all active edges that terminate before the top of this scanline
-		while (*step) {
-			stbtt__active_edge * z = *step;
-			if (z->ey <= scan_y_top) {
-				*step = z->next; // delete from list
-				STBTT_assert(z->direction);
-				z->direction = 0;
-				stbtt__hheap_free(&hh, z);
-			}
-			else {
-				step = &((*step)->next); // advance through list
-			}
-		}
+      STBTT_memset(scanline , 0, result->w*sizeof(scanline[0]));
+      STBTT_memset(scanline2, 0, (result->w+1)*sizeof(scanline[0]));
 
-		// insert all edges that start before the bottom of this scanline
-		while (e->y0 <= scan_y_bottom) {
-			if (e->y0 != e->y1) {
-				stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y_top, userdata);
-				if (z != NULL) {
-					STBTT_assert(z->ey >= scan_y_top);
-					// insert at front
-					z->next = active;
-					active = z;
-				}
-			}
-			++e;
-		}
+      // update all active edges;
+      // remove all active edges that terminate before the top of this scanline
+      while (*step) {
+         stbtt__active_edge * z = *step;
+         if (z->ey <= scan_y_top) {
+            *step = z->next; // delete from list
+            STBTT_assert(z->direction);
+            z->direction = 0;
+            stbtt__hheap_free(&hh, z);
+         } else {
+            step = &((*step)->next); // advance through list
+         }
+      }
 
-		// now process all active edges
-		if (active)
-			stbtt__fill_active_edges_new(scanline, scanline2 + 1, result->w, active, scan_y_top);
+      // insert all edges that start before the bottom of this scanline
+      while (e->y0 <= scan_y_bottom) {
+         if (e->y0 != e->y1) {
+            stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y_top, userdata);
+            if (z != NULL) {
+               STBTT_assert(z->ey >= scan_y_top);
+               // insert at front
+               z->next = active;
+               active = z;
+            }
+         }
+         ++e;
+      }
 
-		{
-			float sum = 0;
-			for (i = 0; i < result->w; ++i) {
-				float k;
-				int m;
-				sum += scanline2[i];
-				k = scanline[i] + sum;
-				k = (float)fabs(k) * 255 + 0.5f;
-				m = (int)k;
-				if (m > 255) m = 255;
-				result->pixels[j*result->stride + i] = (unsigned char)m;
-			}
-		}
-		// advance all the edges
-		step = &active;
-		while (*step) {
-			stbtt__active_edge *z = *step;
-			z->fx += z->fdx; // advance to position for current scanline
-			step = &((*step)->next); // advance through list
-		}
+      // now process all active edges
+      if (active)
+         stbtt__fill_active_edges_new(scanline, scanline2+1, result->w, active, scan_y_top);
 
-		++y;
-		++j;
-	}
+      {
+         float sum = 0;
+         for (i=0; i < result->w; ++i) {
+            float k;
+            int m;
+            sum += scanline2[i];
+            k = scanline[i] + sum;
+            k = (float) STBTT_fabs(k)*255 + 0.5f;
+            m = (int) k;
+            if (m > 255) m = 255;
+            result->pixels[j*result->stride + i] = (unsigned char) m;
+         }
+      }
+      // advance all the edges
+      step = &active;
+      while (*step) {
+         stbtt__active_edge *z = *step;
+         z->fx += z->fdx; // advance to position for current scanline
+         step = &((*step)->next); // advance through list
+      }
 
-	stbtt__hheap_cleanup(&hh, userdata);
+      ++y;
+      ++j;
+   }
 
-	if (scanline != scanline_data)
-		STBTT_free(scanline, userdata);
+   stbtt__hheap_cleanup(&hh, userdata);
+
+   if (scanline != scanline_data)
+      STBTT_free(scanline, userdata);
 }
 #else
 #error "Unrecognized value of STBTT_RASTERIZER_VERSION"
@@ -2201,353 +3211,410 @@ static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e,
 
 static void stbtt__sort_edges_ins_sort(stbtt__edge *p, int n)
 {
-	int i, j;
-	for (i = 1; i < n; ++i) {
-		stbtt__edge t = p[i], *a = &t;
-		j = i;
-		while (j > 0) {
-			stbtt__edge *b = &p[j - 1];
-			int c = STBTT__COMPARE(a, b);
-			if (!c) break;
-			p[j] = p[j - 1];
-			--j;
-		}
-		if (i != j)
-			p[j] = t;
-	}
+   int i,j;
+   for (i=1; i < n; ++i) {
+      stbtt__edge t = p[i], *a = &t;
+      j = i;
+      while (j > 0) {
+         stbtt__edge *b = &p[j-1];
+         int c = STBTT__COMPARE(a,b);
+         if (!c) break;
+         p[j] = p[j-1];
+         --j;
+      }
+      if (i != j)
+         p[j] = t;
+   }
 }
 
 static void stbtt__sort_edges_quicksort(stbtt__edge *p, int n)
 {
-	/* threshhold for transitioning to insertion sort */
-	while (n > 12) {
-		stbtt__edge t;
-		int c01, c12, c, m, i, j;
+   /* threshhold for transitioning to insertion sort */
+   while (n > 12) {
+      stbtt__edge t;
+      int c01,c12,c,m,i,j;
 
-		/* compute median of three */
-		m = n >> 1;
-		c01 = STBTT__COMPARE(&p[0], &p[m]);
-		c12 = STBTT__COMPARE(&p[m], &p[n - 1]);
-		/* if 0 >= mid >= end, or 0 < mid < end, then use mid */
-		if (c01 != c12) {
-			/* otherwise, we'll need to swap something else to middle */
-			int z;
-			c = STBTT__COMPARE(&p[0], &p[n - 1]);
-			/* 0>mid && mid<n:  0>n => n; 0<n => 0 */
-			/* 0<mid && mid>n:  0>n => 0; 0<n => n */
-			z = (c == c12) ? 0 : n - 1;
-			t = p[z];
-			p[z] = p[m];
-			p[m] = t;
-		}
-		/* now p[m] is the median-of-three */
-		/* swap it to the beginning so it won't move around */
-		t = p[0];
-		p[0] = p[m];
-		p[m] = t;
+      /* compute median of three */
+      m = n >> 1;
+      c01 = STBTT__COMPARE(&p[0],&p[m]);
+      c12 = STBTT__COMPARE(&p[m],&p[n-1]);
+      /* if 0 >= mid >= end, or 0 < mid < end, then use mid */
+      if (c01 != c12) {
+         /* otherwise, we'll need to swap something else to middle */
+         int z;
+         c = STBTT__COMPARE(&p[0],&p[n-1]);
+         /* 0>mid && mid<n:  0>n => n; 0<n => 0 */
+         /* 0<mid && mid>n:  0>n => 0; 0<n => n */
+         z = (c == c12) ? 0 : n-1;
+         t = p[z];
+         p[z] = p[m];
+         p[m] = t;
+      }
+      /* now p[m] is the median-of-three */
+      /* swap it to the beginning so it won't move around */
+      t = p[0];
+      p[0] = p[m];
+      p[m] = t;
 
-		/* partition loop */
-		i = 1;
-		j = n - 1;
-		for (;;) {
-			/* handling of equality is crucial here */
-			/* for sentinels & efficiency with duplicates */
-			for (;; ++i) {
-				if (!STBTT__COMPARE(&p[i], &p[0])) break;
-			}
-			for (;; --j) {
-				if (!STBTT__COMPARE(&p[0], &p[j])) break;
-			}
-			/* make sure we haven't crossed */
-			if (i >= j) break;
-			t = p[i];
-			p[i] = p[j];
-			p[j] = t;
+      /* partition loop */
+      i=1;
+      j=n-1;
+      for(;;) {
+         /* handling of equality is crucial here */
+         /* for sentinels & efficiency with duplicates */
+         for (;;++i) {
+            if (!STBTT__COMPARE(&p[i], &p[0])) break;
+         }
+         for (;;--j) {
+            if (!STBTT__COMPARE(&p[0], &p[j])) break;
+         }
+         /* make sure we haven't crossed */
+         if (i >= j) break;
+         t = p[i];
+         p[i] = p[j];
+         p[j] = t;
 
-			++i;
-			--j;
-		}
-		/* recurse on smaller side, iterate on larger */
-		if (j < (n - i)) {
-			stbtt__sort_edges_quicksort(p, j);
-			p = p + i;
-			n = n - i;
-		}
-		else {
-			stbtt__sort_edges_quicksort(p + i, n - i);
-			n = j;
-		}
-	}
+         ++i;
+         --j;
+      }
+      /* recurse on smaller side, iterate on larger */
+      if (j < (n-i)) {
+         stbtt__sort_edges_quicksort(p,j);
+         p = p+i;
+         n = n-i;
+      } else {
+         stbtt__sort_edges_quicksort(p+i, n-i);
+         n = j;
+      }
+   }
 }
 
 static void stbtt__sort_edges(stbtt__edge *p, int n)
 {
-	stbtt__sort_edges_quicksort(p, n);
-	stbtt__sort_edges_ins_sort(p, n);
+   stbtt__sort_edges_quicksort(p, n);
+   stbtt__sort_edges_ins_sort(p, n);
 }
 
 typedef struct
 {
-	float x, y;
+   float x,y;
 } stbtt__point;
 
 static void stbtt__rasterize(stbtt__bitmap *result, stbtt__point *pts, int *wcount, int windings, float scale_x, float scale_y, float shift_x, float shift_y, int off_x, int off_y, int invert, void *userdata)
 {
-	float y_scale_inv = invert ? -scale_y : scale_y;
-	stbtt__edge *e;
-	int n, i, j, k, m;
+   float y_scale_inv = invert ? -scale_y : scale_y;
+   stbtt__edge *e;
+   int n,i,j,k,m;
 #if STBTT_RASTERIZER_VERSION == 1
-	int vsubsample = result->h < 8 ? 15 : 5;
+   int vsubsample = result->h < 8 ? 15 : 5;
 #elif STBTT_RASTERIZER_VERSION == 2
-	int vsubsample = 1;
+   int vsubsample = 1;
 #else
-#error "Unrecognized value of STBTT_RASTERIZER_VERSION"
+   #error "Unrecognized value of STBTT_RASTERIZER_VERSION"
 #endif
-	// vsubsample should divide 255 evenly; otherwise we won't reach full opacity
+   // vsubsample should divide 255 evenly; otherwise we won't reach full opacity
 
-	// now we have to blow out the windings into explicit edge lists
-	n = 0;
-	for (i = 0; i < windings; ++i)
-		n += wcount[i];
+   // now we have to blow out the windings into explicit edge lists
+   n = 0;
+   for (i=0; i < windings; ++i)
+      n += wcount[i];
 
-	e = (stbtt__edge *)STBTT_malloc(sizeof(*e) * (n + 1), userdata); // add an extra one as a sentinel
-	if (e == 0) return;
-	n = 0;
+   e = (stbtt__edge *) STBTT_malloc(sizeof(*e) * (n+1), userdata); // add an extra one as a sentinel
+   if (e == 0) return;
+   n = 0;
 
-	m = 0;
-	for (i = 0; i < windings; ++i) {
-		stbtt__point *p = pts + m;
-		m += wcount[i];
-		j = wcount[i] - 1;
-		for (k = 0; k < wcount[i]; j = k++) {
-			int a = k, b = j;
-			// skip the edge if horizontal
-			if (p[j].y == p[k].y)
-				continue;
-			// add edge from j to k to the list
-			e[n].invert = 0;
-			if (invert ? p[j].y > p[k].y : p[j].y < p[k].y) {
-				e[n].invert = 1;
-				a = j, b = k;
-			}
-			e[n].x0 = p[a].x * scale_x + shift_x;
-			e[n].y0 = (p[a].y * y_scale_inv + shift_y) * vsubsample;
-			e[n].x1 = p[b].x * scale_x + shift_x;
-			e[n].y1 = (p[b].y * y_scale_inv + shift_y) * vsubsample;
-			++n;
-		}
-	}
+   m=0;
+   for (i=0; i < windings; ++i) {
+      stbtt__point *p = pts + m;
+      m += wcount[i];
+      j = wcount[i]-1;
+      for (k=0; k < wcount[i]; j=k++) {
+         int a=k,b=j;
+         // skip the edge if horizontal
+         if (p[j].y == p[k].y)
+            continue;
+         // add edge from j to k to the list
+         e[n].invert = 0;
+         if (invert ? p[j].y > p[k].y : p[j].y < p[k].y) {
+            e[n].invert = 1;
+            a=j,b=k;
+         }
+         e[n].x0 = p[a].x * scale_x + shift_x;
+         e[n].y0 = (p[a].y * y_scale_inv + shift_y) * vsubsample;
+         e[n].x1 = p[b].x * scale_x + shift_x;
+         e[n].y1 = (p[b].y * y_scale_inv + shift_y) * vsubsample;
+         ++n;
+      }
+   }
 
-	// now sort the edges by their highest point (should snap to integer, and then by x)
-	//STBTT_sort(e, n, sizeof(e[0]), stbtt__edge_compare);
-	stbtt__sort_edges(e, n);
+   // now sort the edges by their highest point (should snap to integer, and then by x)
+   //STBTT_sort(e, n, sizeof(e[0]), stbtt__edge_compare);
+   stbtt__sort_edges(e, n);
 
-	// now, traverse the scanlines and find the intersections on each scanline, use xor winding rule
-	stbtt__rasterize_sorted_edges(result, e, n, vsubsample, off_x, off_y, userdata);
+   // now, traverse the scanlines and find the intersections on each scanline, use xor winding rule
+   stbtt__rasterize_sorted_edges(result, e, n, vsubsample, off_x, off_y, userdata);
 
-	STBTT_free(e, userdata);
+   STBTT_free(e, userdata);
 }
 
 static void stbtt__add_point(stbtt__point *points, int n, float x, float y)
 {
-	if (!points) return; // during first pass, it's unallocated
-	points[n].x = x;
-	points[n].y = y;
+   if (!points) return; // during first pass, it's unallocated
+   points[n].x = x;
+   points[n].y = y;
 }
 
 // tesselate until threshhold p is happy... @TODO warped to compensate for non-linear stretching
 static int stbtt__tesselate_curve(stbtt__point *points, int *num_points, float x0, float y0, float x1, float y1, float x2, float y2, float objspace_flatness_squared, int n)
 {
-	// midpoint
-	float mx = (x0 + 2 * x1 + x2) / 4;
-	float my = (y0 + 2 * y1 + y2) / 4;
-	// versus directly drawn line
-	float dx = (x0 + x2) / 2 - mx;
-	float dy = (y0 + y2) / 2 - my;
-	if (n > 16) // 65536 segments on one curve better be enough!
-		return 1;
-	if (dx*dx + dy*dy > objspace_flatness_squared) { // half-pixel error allowed... need to be smaller if AA
-		stbtt__tesselate_curve(points, num_points, x0, y0, (x0 + x1) / 2.0f, (y0 + y1) / 2.0f, mx, my, objspace_flatness_squared, n + 1);
-		stbtt__tesselate_curve(points, num_points, mx, my, (x1 + x2) / 2.0f, (y1 + y2) / 2.0f, x2, y2, objspace_flatness_squared, n + 1);
-	}
-	else {
-		stbtt__add_point(points, *num_points, x2, y2);
-		*num_points = *num_points + 1;
-	}
-	return 1;
+   // midpoint
+   float mx = (x0 + 2*x1 + x2)/4;
+   float my = (y0 + 2*y1 + y2)/4;
+   // versus directly drawn line
+   float dx = (x0+x2)/2 - mx;
+   float dy = (y0+y2)/2 - my;
+   if (n > 16) // 65536 segments on one curve better be enough!
+      return 1;
+   if (dx*dx+dy*dy > objspace_flatness_squared) { // half-pixel error allowed... need to be smaller if AA
+      stbtt__tesselate_curve(points, num_points, x0,y0, (x0+x1)/2.0f,(y0+y1)/2.0f, mx,my, objspace_flatness_squared,n+1);
+      stbtt__tesselate_curve(points, num_points, mx,my, (x1+x2)/2.0f,(y1+y2)/2.0f, x2,y2, objspace_flatness_squared,n+1);
+   } else {
+      stbtt__add_point(points, *num_points,x2,y2);
+      *num_points = *num_points+1;
+   }
+   return 1;
+}
+
+static void stbtt__tesselate_cubic(stbtt__point *points, int *num_points, float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3, float objspace_flatness_squared, int n)
+{
+   // @TODO this "flatness" calculation is just made-up nonsense that seems to work well enough
+   float dx0 = x1-x0;
+   float dy0 = y1-y0;
+   float dx1 = x2-x1;
+   float dy1 = y2-y1;
+   float dx2 = x3-x2;
+   float dy2 = y3-y2;
+   float dx = x3-x0;
+   float dy = y3-y0;
+   float longlen = (float) (STBTT_sqrt(dx0*dx0+dy0*dy0)+STBTT_sqrt(dx1*dx1+dy1*dy1)+STBTT_sqrt(dx2*dx2+dy2*dy2));
+   float shortlen = (float) STBTT_sqrt(dx*dx+dy*dy);
+   float flatness_squared = longlen*longlen-shortlen*shortlen;
+
+   if (n > 16) // 65536 segments on one curve better be enough!
+      return;
+
+   if (flatness_squared > objspace_flatness_squared) {
+      float x01 = (x0+x1)/2;
+      float y01 = (y0+y1)/2;
+      float x12 = (x1+x2)/2;
+      float y12 = (y1+y2)/2;
+      float x23 = (x2+x3)/2;
+      float y23 = (y2+y3)/2;
+
+      float xa = (x01+x12)/2;
+      float ya = (y01+y12)/2;
+      float xb = (x12+x23)/2;
+      float yb = (y12+y23)/2;
+
+      float mx = (xa+xb)/2;
+      float my = (ya+yb)/2;
+
+      stbtt__tesselate_cubic(points, num_points, x0,y0, x01,y01, xa,ya, mx,my, objspace_flatness_squared,n+1);
+      stbtt__tesselate_cubic(points, num_points, mx,my, xb,yb, x23,y23, x3,y3, objspace_flatness_squared,n+1);
+   } else {
+      stbtt__add_point(points, *num_points,x3,y3);
+      *num_points = *num_points+1;
+   }
 }
 
 // returns number of contours
 static stbtt__point *stbtt_FlattenCurves(stbtt_vertex *vertices, int num_verts, float objspace_flatness, int **contour_lengths, int *num_contours, void *userdata)
 {
-	stbtt__point *points = 0;
-	int num_points = 0;
+   stbtt__point *points=0;
+   int num_points=0;
 
-	float objspace_flatness_squared = objspace_flatness * objspace_flatness;
-	int i, n = 0, start = 0, pass;
+   float objspace_flatness_squared = objspace_flatness * objspace_flatness;
+   int i,n=0,start=0, pass;
 
-	// count how many "moves" there are to get the contour count
-	for (i = 0; i < num_verts; ++i)
-		if (vertices[i].type == STBTT_vmove)
-			++n;
+   // count how many "moves" there are to get the contour count
+   for (i=0; i < num_verts; ++i)
+      if (vertices[i].type == STBTT_vmove)
+         ++n;
 
-	*num_contours = n;
-	if (n == 0) return 0;
+   *num_contours = n;
+   if (n == 0) return 0;
 
-	*contour_lengths = (int *)STBTT_malloc(sizeof(**contour_lengths) * n, userdata);
+   *contour_lengths = (int *) STBTT_malloc(sizeof(**contour_lengths) * n, userdata);
 
-	if (*contour_lengths == 0) {
-		*num_contours = 0;
-		return 0;
-	}
+   if (*contour_lengths == 0) {
+      *num_contours = 0;
+      return 0;
+   }
 
-	// make two passes through the points so we don't need to realloc
-	for (pass = 0; pass < 2; ++pass) {
-		float x = 0, y = 0;
-		if (pass == 1) {
-			points = (stbtt__point *)STBTT_malloc(num_points * sizeof(points[0]), userdata);
-			if (points == NULL) goto error;
-		}
-		num_points = 0;
-		n = -1;
-		for (i = 0; i < num_verts; ++i) {
-			switch (vertices[i].type) {
-			case STBTT_vmove:
-				// start the next contour
-				if (n >= 0)
-					(*contour_lengths)[n] = num_points - start;
-				++n;
-				start = num_points;
+   // make two passes through the points so we don't need to realloc
+   for (pass=0; pass < 2; ++pass) {
+      float x=0,y=0;
+      if (pass == 1) {
+         points = (stbtt__point *) STBTT_malloc(num_points * sizeof(points[0]), userdata);
+         if (points == NULL) goto error;
+      }
+      num_points = 0;
+      n= -1;
+      for (i=0; i < num_verts; ++i) {
+         switch (vertices[i].type) {
+            case STBTT_vmove:
+               // start the next contour
+               if (n >= 0)
+                  (*contour_lengths)[n] = num_points - start;
+               ++n;
+               start = num_points;
 
-				x = vertices[i].x, y = vertices[i].y;
-				stbtt__add_point(points, num_points++, x, y);
-				break;
-			case STBTT_vline:
-				x = vertices[i].x, y = vertices[i].y;
-				stbtt__add_point(points, num_points++, x, y);
-				break;
-			case STBTT_vcurve:
-				stbtt__tesselate_curve(points, &num_points, x, y,
-					vertices[i].cx, vertices[i].cy,
-					vertices[i].x, vertices[i].y,
-					objspace_flatness_squared, 0);
-				x = vertices[i].x, y = vertices[i].y;
-				break;
-			}
-		}
-		(*contour_lengths)[n] = num_points - start;
-	}
+               x = vertices[i].x, y = vertices[i].y;
+               stbtt__add_point(points, num_points++, x,y);
+               break;
+            case STBTT_vline:
+               x = vertices[i].x, y = vertices[i].y;
+               stbtt__add_point(points, num_points++, x, y);
+               break;
+            case STBTT_vcurve:
+               stbtt__tesselate_curve(points, &num_points, x,y,
+                                        vertices[i].cx, vertices[i].cy,
+                                        vertices[i].x,  vertices[i].y,
+                                        objspace_flatness_squared, 0);
+               x = vertices[i].x, y = vertices[i].y;
+               break;
+            case STBTT_vcubic:
+               stbtt__tesselate_cubic(points, &num_points, x,y,
+                                        vertices[i].cx, vertices[i].cy,
+                                        vertices[i].cx1, vertices[i].cy1,
+                                        vertices[i].x,  vertices[i].y,
+                                        objspace_flatness_squared, 0);
+               x = vertices[i].x, y = vertices[i].y;
+               break;
+         }
+      }
+      (*contour_lengths)[n] = num_points - start;
+   }
 
-	return points;
+   return points;
 error:
-	STBTT_free(points, userdata);
-	STBTT_free(*contour_lengths, userdata);
-	*contour_lengths = 0;
-	*num_contours = 0;
-	return NULL;
+   STBTT_free(points, userdata);
+   STBTT_free(*contour_lengths, userdata);
+   *contour_lengths = 0;
+   *num_contours = 0;
+   return NULL;
 }
 
 STBTT_DEF void stbtt_Rasterize(stbtt__bitmap *result, float flatness_in_pixels, stbtt_vertex *vertices, int num_verts, float scale_x, float scale_y, float shift_x, float shift_y, int x_off, int y_off, int invert, void *userdata)
 {
-	float scale = scale_x > scale_y ? scale_y : scale_x;
-	int winding_count, *winding_lengths;
-	stbtt__point *windings = stbtt_FlattenCurves(vertices, num_verts, flatness_in_pixels / scale, &winding_lengths, &winding_count, userdata);
-	if (windings) {
-		stbtt__rasterize(result, windings, winding_lengths, winding_count, scale_x, scale_y, shift_x, shift_y, x_off, y_off, invert, userdata);
-		STBTT_free(winding_lengths, userdata);
-		STBTT_free(windings, userdata);
-	}
+   float scale            = scale_x > scale_y ? scale_y : scale_x;
+   int winding_count      = 0;
+   int *winding_lengths   = NULL;
+   stbtt__point *windings = stbtt_FlattenCurves(vertices, num_verts, flatness_in_pixels / scale, &winding_lengths, &winding_count, userdata);
+   if (windings) {
+      stbtt__rasterize(result, windings, winding_lengths, winding_count, scale_x, scale_y, shift_x, shift_y, x_off, y_off, invert, userdata);
+      STBTT_free(winding_lengths, userdata);
+      STBTT_free(windings, userdata);
+   }
 }
 
 STBTT_DEF void stbtt_FreeBitmap(unsigned char *bitmap, void *userdata)
 {
-	STBTT_free(bitmap, userdata);
+   STBTT_free(bitmap, userdata);
 }
 
 STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int glyph, int *width, int *height, int *xoff, int *yoff)
 {
-	int ix0, iy0, ix1, iy1;
-	stbtt__bitmap gbm;
-	stbtt_vertex *vertices;
-	int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
+   int ix0,iy0,ix1,iy1;
+   stbtt__bitmap gbm;
+   stbtt_vertex *vertices;   
+   int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
 
-	if (scale_x == 0) scale_x = scale_y;
-	if (scale_y == 0) {
-		if (scale_x == 0) return NULL;
-		scale_y = scale_x;
-	}
+   if (scale_x == 0) scale_x = scale_y;
+   if (scale_y == 0) {
+      if (scale_x == 0) {
+         STBTT_free(vertices, info->userdata);
+         return NULL;
+      }
+      scale_y = scale_x;
+   }
 
-	stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale_x, scale_y, shift_x, shift_y, &ix0, &iy0, &ix1, &iy1);
+   stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale_x, scale_y, shift_x, shift_y, &ix0,&iy0,&ix1,&iy1);
 
-	// now we get the size
-	gbm.w = (ix1 - ix0);
-	gbm.h = (iy1 - iy0);
-	gbm.pixels = NULL; // in case we error
+   // now we get the size
+   gbm.w = (ix1 - ix0);
+   gbm.h = (iy1 - iy0);
+   gbm.pixels = NULL; // in case we error
 
-	if (width) *width = gbm.w;
-	if (height) *height = gbm.h;
-	if (xoff) *xoff = ix0;
-	if (yoff) *yoff = iy0;
+   if (width ) *width  = gbm.w;
+   if (height) *height = gbm.h;
+   if (xoff  ) *xoff   = ix0;
+   if (yoff  ) *yoff   = iy0;
+   
+   if (gbm.w && gbm.h) {
+      gbm.pixels = (unsigned char *) STBTT_malloc(gbm.w * gbm.h, info->userdata);
+      if (gbm.pixels) {
+         gbm.stride = gbm.w;
 
-	if (gbm.w && gbm.h) {
-		gbm.pixels = (unsigned char *)STBTT_malloc(gbm.w * gbm.h, info->userdata);
-		if (gbm.pixels) {
-			gbm.stride = gbm.w;
-
-			stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, shift_x, shift_y, ix0, iy0, 1, info->userdata);
-		}
-	}
-	STBTT_free(vertices, info->userdata);
-	return gbm.pixels;
-}
+         stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, shift_x, shift_y, ix0, iy0, 1, info->userdata);
+      }
+   }
+   STBTT_free(vertices, info->userdata);
+   return gbm.pixels;
+}   
 
 STBTT_DEF unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int *width, int *height, int *xoff, int *yoff)
 {
-	return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y, 0.0f, 0.0f, glyph, width, height, xoff, yoff);
+   return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y, 0.0f, 0.0f, glyph, width, height, xoff, yoff);
 }
 
 STBTT_DEF void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int glyph)
 {
-	int ix0, iy0;
-	stbtt_vertex *vertices;
-	int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
-	stbtt__bitmap gbm;
+   int ix0,iy0;
+   stbtt_vertex *vertices;
+   int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
+   stbtt__bitmap gbm;   
 
-	stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale_x, scale_y, shift_x, shift_y, &ix0, &iy0, 0, 0);
-	gbm.pixels = output;
-	gbm.w = out_w;
-	gbm.h = out_h;
-	gbm.stride = out_stride;
+   stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale_x, scale_y, shift_x, shift_y, &ix0,&iy0,0,0);
+   gbm.pixels = output;
+   gbm.w = out_w;
+   gbm.h = out_h;
+   gbm.stride = out_stride;
 
-	if (gbm.w && gbm.h)
-		stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, shift_x, shift_y, ix0, iy0, 1, info->userdata);
+   if (gbm.w && gbm.h)
+      stbtt_Rasterize(&gbm, 0.35f, vertices, num_verts, scale_x, scale_y, shift_x, shift_y, ix0,iy0, 1, info->userdata);
 
-	STBTT_free(vertices, info->userdata);
+   STBTT_free(vertices, info->userdata);
 }
 
 STBTT_DEF void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int glyph)
 {
-	stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, 0.0f, 0.0f, glyph);
+   stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, 0.0f,0.0f, glyph);
 }
 
 STBTT_DEF unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint, int *width, int *height, int *xoff, int *yoff)
 {
-	return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y, shift_x, shift_y, stbtt_FindGlyphIndex(info, codepoint), width, height, xoff, yoff);
+   return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y,shift_x,shift_y, stbtt_FindGlyphIndex(info,codepoint), width,height,xoff,yoff);
+}   
+
+STBTT_DEF void stbtt_MakeCodepointBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int oversample_x, int oversample_y, float *sub_x, float *sub_y, int codepoint)
+{
+   stbtt_MakeGlyphBitmapSubpixelPrefilter(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, oversample_x, oversample_y, sub_x, sub_y, stbtt_FindGlyphIndex(info,codepoint));
 }
 
 STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint)
 {
-	stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, stbtt_FindGlyphIndex(info, codepoint));
+   stbtt_MakeGlyphBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, stbtt_FindGlyphIndex(info,codepoint));
 }
 
 STBTT_DEF unsigned char *stbtt_GetCodepointBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int codepoint, int *width, int *height, int *xoff, int *yoff)
 {
-	return stbtt_GetCodepointBitmapSubpixel(info, scale_x, scale_y, 0.0f, 0.0f, codepoint, width, height, xoff, yoff);
-}
+   return stbtt_GetCodepointBitmapSubpixel(info, scale_x, scale_y, 0.0f,0.0f, codepoint, width,height,xoff,yoff);
+}   
 
 STBTT_DEF void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int codepoint)
 {
-	stbtt_MakeCodepointBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, 0.0f, 0.0f, codepoint);
+   stbtt_MakeCodepointBitmapSubpixel(info, output, out_w, out_h, out_stride, scale_x, scale_y, 0.0f,0.0f, codepoint);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -2556,71 +3623,71 @@ STBTT_DEF void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info, unsigned ch
 //
 // This is SUPER-CRAPPY packing to keep source code small
 
-STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,  // font location (use offset=0 for plain .ttf)
-	float pixel_height,                     // height of font in pixels
-	unsigned char *pixels, int pw, int ph,  // bitmap to be filled in
-	int first_char, int num_chars,          // characters to bake
-	stbtt_bakedchar *chardata)
+static int stbtt_BakeFontBitmap_internal(unsigned char *data, int offset,  // font location (use offset=0 for plain .ttf)
+                                float pixel_height,                     // height of font in pixels
+                                unsigned char *pixels, int pw, int ph,  // bitmap to be filled in
+                                int first_char, int num_chars,          // characters to bake
+                                stbtt_bakedchar *chardata)
 {
-	float scale;
-	int x, y, bottom_y, i;
-	stbtt_fontinfo f;
-	f.userdata = NULL;
-	if (!stbtt_InitFont(&f, data, offset))
-		return -1;
-	STBTT_memset(pixels, 0, pw*ph); // background of 0 around pixels
-	x = y = 1;
-	bottom_y = 1;
+   float scale;
+   int x,y,bottom_y, i;
+   stbtt_fontinfo f;
+   f.userdata = NULL;
+   if (!stbtt_InitFont(&f, data, offset))
+      return -1;
+   STBTT_memset(pixels, 0, pw*ph); // background of 0 around pixels
+   x=y=1;
+   bottom_y = 1;
 
-	scale = stbtt_ScaleForPixelHeight(&f, pixel_height);
+   scale = stbtt_ScaleForPixelHeight(&f, pixel_height);
 
-	for (i = 0; i < num_chars; ++i) {
-		int advance, lsb, x0, y0, x1, y1, gw, gh;
-		int g = stbtt_FindGlyphIndex(&f, first_char + i);
-		stbtt_GetGlyphHMetrics(&f, g, &advance, &lsb);
-		stbtt_GetGlyphBitmapBox(&f, g, scale, scale, &x0, &y0, &x1, &y1);
-		gw = x1 - x0;
-		gh = y1 - y0;
-		if (x + gw + 1 >= pw)
-			y = bottom_y, x = 1; // advance to next row
-		if (y + gh + 1 >= ph) // check if it fits vertically AFTER potentially moving to next row
-			return -i;
-		STBTT_assert(x + gw < pw);
-		STBTT_assert(y + gh < ph);
-		stbtt_MakeGlyphBitmap(&f, pixels + x + y*pw, gw, gh, pw, scale, scale, g);
-		chardata[i].x0 = (stbtt_int16)x;
-		chardata[i].y0 = (stbtt_int16)y;
-		chardata[i].x1 = (stbtt_int16)(x + gw);
-		chardata[i].y1 = (stbtt_int16)(y + gh);
-		chardata[i].xadvance = scale * advance;
-		chardata[i].xoff = (float)x0;
-		chardata[i].yoff = (float)y0;
-		x = x + gw + 1;
-		if (y + gh + 1 > bottom_y)
-			bottom_y = y + gh + 1;
-	}
-	return bottom_y;
+   for (i=0; i < num_chars; ++i) {
+      int advance, lsb, x0,y0,x1,y1,gw,gh;
+      int g = stbtt_FindGlyphIndex(&f, first_char + i);
+      stbtt_GetGlyphHMetrics(&f, g, &advance, &lsb);
+      stbtt_GetGlyphBitmapBox(&f, g, scale,scale, &x0,&y0,&x1,&y1);
+      gw = x1-x0;
+      gh = y1-y0;
+      if (x + gw + 1 >= pw)
+         y = bottom_y, x = 1; // advance to next row
+      if (y + gh + 1 >= ph) // check if it fits vertically AFTER potentially moving to next row
+         return -i;
+      STBTT_assert(x+gw < pw);
+      STBTT_assert(y+gh < ph);
+      stbtt_MakeGlyphBitmap(&f, pixels+x+y*pw, gw,gh,pw, scale,scale, g);
+      chardata[i].x0 = (stbtt_int16) x;
+      chardata[i].y0 = (stbtt_int16) y;
+      chardata[i].x1 = (stbtt_int16) (x + gw);
+      chardata[i].y1 = (stbtt_int16) (y + gh);
+      chardata[i].xadvance = scale * advance;
+      chardata[i].xoff     = (float) x0;
+      chardata[i].yoff     = (float) y0;
+      x = x + gw + 1;
+      if (y+gh+1 > bottom_y)
+         bottom_y = y+gh+1;
+   }
+   return bottom_y;
 }
 
-STBTT_DEF void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int opengl_fillrule)
+STBTT_DEF void stbtt_GetBakedQuad(const stbtt_bakedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int opengl_fillrule)
 {
-	float d3d_bias = opengl_fillrule ? 0 : -0.5f;
-	float ipw = 1.0f / pw, iph = 1.0f / ph;
-	stbtt_bakedchar *b = chardata + char_index;
-	int round_x = STBTT_ifloor((*xpos + b->xoff) + 0.5f);
-	int round_y = STBTT_ifloor((*ypos + b->yoff) + 0.5f);
+   float d3d_bias = opengl_fillrule ? 0 : -0.5f;
+   float ipw = 1.0f / pw, iph = 1.0f / ph;
+   const stbtt_bakedchar *b = chardata + char_index;
+   int round_x = STBTT_ifloor((*xpos + b->xoff) + 0.5f);
+   int round_y = STBTT_ifloor((*ypos + b->yoff) + 0.5f);
 
-	q->x0 = round_x + d3d_bias;
-	q->y0 = round_y + d3d_bias;
-	q->x1 = round_x + b->x1 - b->x0 + d3d_bias;
-	q->y1 = round_y + b->y1 - b->y0 + d3d_bias;
+   q->x0 = round_x + d3d_bias;
+   q->y0 = round_y + d3d_bias;
+   q->x1 = round_x + b->x1 - b->x0 + d3d_bias;
+   q->y1 = round_y + b->y1 - b->y0 + d3d_bias;
 
-	q->s0 = b->x0 * ipw;
-	q->t0 = b->y0 * iph;
-	q->s1 = b->x1 * ipw;
-	q->t1 = b->y1 * iph;
+   q->s0 = b->x0 * ipw;
+   q->t0 = b->y0 * iph;
+   q->s1 = b->x1 * ipw;
+   q->t1 = b->y1 * iph;
 
-	*xpos += b->xadvance;
+   *xpos += b->xadvance;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -2629,11 +3696,6 @@ STBTT_DEF void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph, int
 //
 
 #ifndef STB_RECT_PACK_VERSION
-#ifdef _MSC_VER
-#define STBTT__NOTUSED(v)  (void)(v)
-#else
-#define STBTT__NOTUSED(v)  (void)sizeof(v)
-#endif
 
 typedef int stbrp_coord;
 
@@ -2650,51 +3712,51 @@ typedef int stbrp_coord;
 
 typedef struct
 {
-	int width, height;
-	int x, y, bottom_y;
+   int width,height;
+   int x,y,bottom_y;
 } stbrp_context;
 
 typedef struct
 {
-	unsigned char x;
+   unsigned char x;
 } stbrp_node;
 
 struct stbrp_rect
 {
-	stbrp_coord x, y;
-	int id, w, h, was_packed;
+   stbrp_coord x,y;
+   int id,w,h,was_packed;
 };
 
 static void stbrp_init_target(stbrp_context *con, int pw, int ph, stbrp_node *nodes, int num_nodes)
 {
-	con->width = pw;
-	con->height = ph;
-	con->x = 0;
-	con->y = 0;
-	con->bottom_y = 0;
-	STBTT__NOTUSED(nodes);
-	STBTT__NOTUSED(num_nodes);
+   con->width  = pw;
+   con->height = ph;
+   con->x = 0;
+   con->y = 0;
+   con->bottom_y = 0;
+   STBTT__NOTUSED(nodes);
+   STBTT__NOTUSED(num_nodes);   
 }
 
 static void stbrp_pack_rects(stbrp_context *con, stbrp_rect *rects, int num_rects)
 {
-	int i;
-	for (i = 0; i < num_rects; ++i) {
-		if (con->x + rects[i].w > con->width) {
-			con->x = 0;
-			con->y = con->bottom_y;
-		}
-		if (con->y + rects[i].h > con->height)
-			break;
-		rects[i].x = con->x;
-		rects[i].y = con->y;
-		rects[i].was_packed = 1;
-		con->x += rects[i].w;
-		if (con->y + rects[i].h > con->bottom_y)
-			con->bottom_y = con->y + rects[i].h;
-	}
-	for (; i < num_rects; ++i)
-		rects[i].was_packed = 0;
+   int i;
+   for (i=0; i < num_rects; ++i) {
+      if (con->x + rects[i].w > con->width) {
+         con->x = 0;
+         con->y = con->bottom_y;
+      }
+      if (con->y + rects[i].h > con->height)
+         break;
+      rects[i].x = con->x;
+      rects[i].y = con->y;
+      rects[i].was_packed = 1;
+      con->x += rects[i].w;
+      if (con->y + rects[i].h > con->bottom_y)
+         con->bottom_y = con->y + rects[i].h;
+   }
+   for (   ; i < num_rects; ++i)
+      rects[i].was_packed = 0;
 }
 #endif
 
@@ -2707,383 +3769,785 @@ static void stbrp_pack_rects(stbrp_context *con, stbrp_rect *rects, int num_rect
 
 STBTT_DEF int stbtt_PackBegin(stbtt_pack_context *spc, unsigned char *pixels, int pw, int ph, int stride_in_bytes, int padding, void *alloc_context)
 {
-	stbrp_context *context = (stbrp_context *)STBTT_malloc(sizeof(*context), alloc_context);
-	int            num_nodes = pw - padding;
-	stbrp_node    *nodes = (stbrp_node    *)STBTT_malloc(sizeof(*nodes) * num_nodes, alloc_context);
+   stbrp_context *context = (stbrp_context *) STBTT_malloc(sizeof(*context)            ,alloc_context);
+   int            num_nodes = pw - padding;
+   stbrp_node    *nodes   = (stbrp_node    *) STBTT_malloc(sizeof(*nodes  ) * num_nodes,alloc_context);
 
-	if (context == NULL || nodes == NULL) {
-		if (context != NULL) STBTT_free(context, alloc_context);
-		if (nodes != NULL) STBTT_free(nodes, alloc_context);
-		return 0;
-	}
+   if (context == NULL || nodes == NULL) {
+      if (context != NULL) STBTT_free(context, alloc_context);
+      if (nodes   != NULL) STBTT_free(nodes  , alloc_context);
+      return 0;
+   }
 
-	spc->user_allocator_context = alloc_context;
-	spc->width = pw;
-	spc->height = ph;
-	spc->pixels = pixels;
-	spc->pack_info = context;
-	spc->nodes = nodes;
-	spc->padding = padding;
-	spc->stride_in_bytes = stride_in_bytes != 0 ? stride_in_bytes : pw;
-	spc->h_oversample = 1;
-	spc->v_oversample = 1;
+   spc->user_allocator_context = alloc_context;
+   spc->width = pw;
+   spc->height = ph;
+   spc->pixels = pixels;
+   spc->pack_info = context;
+   spc->nodes = nodes;
+   spc->padding = padding;
+   spc->stride_in_bytes = stride_in_bytes != 0 ? stride_in_bytes : pw;
+   spc->h_oversample = 1;
+   spc->v_oversample = 1;
 
-	stbrp_init_target(context, pw - padding, ph - padding, nodes, num_nodes);
+   stbrp_init_target(context, pw-padding, ph-padding, nodes, num_nodes);
 
-	if (pixels)
-		STBTT_memset(pixels, 0, pw*ph); // background of 0 around pixels
+   if (pixels)
+      STBTT_memset(pixels, 0, pw*ph); // background of 0 around pixels
 
-	return 1;
+   return 1;
 }
 
-STBTT_DEF void stbtt_PackEnd(stbtt_pack_context *spc)
+STBTT_DEF void stbtt_PackEnd  (stbtt_pack_context *spc)
 {
-	STBTT_free(spc->nodes, spc->user_allocator_context);
-	STBTT_free(spc->pack_info, spc->user_allocator_context);
+   STBTT_free(spc->nodes    , spc->user_allocator_context);
+   STBTT_free(spc->pack_info, spc->user_allocator_context);
 }
 
 STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h_oversample, unsigned int v_oversample)
 {
-	STBTT_assert(h_oversample <= STBTT_MAX_OVERSAMPLE);
-	STBTT_assert(v_oversample <= STBTT_MAX_OVERSAMPLE);
-	if (h_oversample <= STBTT_MAX_OVERSAMPLE)
-		spc->h_oversample = h_oversample;
-	if (v_oversample <= STBTT_MAX_OVERSAMPLE)
-		spc->v_oversample = v_oversample;
+   STBTT_assert(h_oversample <= STBTT_MAX_OVERSAMPLE);
+   STBTT_assert(v_oversample <= STBTT_MAX_OVERSAMPLE);
+   if (h_oversample <= STBTT_MAX_OVERSAMPLE)
+      spc->h_oversample = h_oversample;
+   if (v_oversample <= STBTT_MAX_OVERSAMPLE)
+      spc->v_oversample = v_oversample;
 }
 
 #define STBTT__OVER_MASK  (STBTT_MAX_OVERSAMPLE-1)
 
 static void stbtt__h_prefilter(unsigned char *pixels, int w, int h, int stride_in_bytes, unsigned int kernel_width)
 {
-	unsigned char buffer[STBTT_MAX_OVERSAMPLE];
-	int safe_w = w - kernel_width;
-	int j;
-	STBTT_memset(buffer, 0, STBTT_MAX_OVERSAMPLE); // suppress bogus warning from VS2013 -analyze
-	for (j = 0; j < h; ++j) {
-		int i;
-		unsigned int total;
-		STBTT_memset(buffer, 0, kernel_width);
+   unsigned char buffer[STBTT_MAX_OVERSAMPLE];
+   int safe_w = w - kernel_width;
+   int j;
+   STBTT_memset(buffer, 0, STBTT_MAX_OVERSAMPLE); // suppress bogus warning from VS2013 -analyze
+   for (j=0; j < h; ++j) {
+      int i;
+      unsigned int total;
+      STBTT_memset(buffer, 0, kernel_width);
 
-		total = 0;
+      total = 0;
 
-		// make kernel_width a constant in common cases so compiler can optimize out the divide
-		switch (kernel_width) {
-		case 2:
-			for (i = 0; i <= safe_w; ++i) {
-				total += pixels[i] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
-				pixels[i] = (unsigned char)(total / 2);
-			}
-			break;
-		case 3:
-			for (i = 0; i <= safe_w; ++i) {
-				total += pixels[i] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
-				pixels[i] = (unsigned char)(total / 3);
-			}
-			break;
-		case 4:
-			for (i = 0; i <= safe_w; ++i) {
-				total += pixels[i] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
-				pixels[i] = (unsigned char)(total / 4);
-			}
-			break;
-		case 5:
-			for (i = 0; i <= safe_w; ++i) {
-				total += pixels[i] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
-				pixels[i] = (unsigned char)(total / 5);
-			}
-			break;
-		default:
-			for (i = 0; i <= safe_w; ++i) {
-				total += pixels[i] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i];
-				pixels[i] = (unsigned char)(total / kernel_width);
-			}
-			break;
-		}
+      // make kernel_width a constant in common cases so compiler can optimize out the divide
+      switch (kernel_width) {
+         case 2:
+            for (i=0; i <= safe_w; ++i) {
+               total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i];
+               pixels[i] = (unsigned char) (total / 2);
+            }
+            break;
+         case 3:
+            for (i=0; i <= safe_w; ++i) {
+               total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i];
+               pixels[i] = (unsigned char) (total / 3);
+            }
+            break;
+         case 4:
+            for (i=0; i <= safe_w; ++i) {
+               total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i];
+               pixels[i] = (unsigned char) (total / 4);
+            }
+            break;
+         case 5:
+            for (i=0; i <= safe_w; ++i) {
+               total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i];
+               pixels[i] = (unsigned char) (total / 5);
+            }
+            break;
+         default:
+            for (i=0; i <= safe_w; ++i) {
+               total += pixels[i] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i];
+               pixels[i] = (unsigned char) (total / kernel_width);
+            }
+            break;
+      }
 
-		for (; i < w; ++i) {
-			STBTT_assert(pixels[i] == 0);
-			total -= buffer[i & STBTT__OVER_MASK];
-			pixels[i] = (unsigned char)(total / kernel_width);
-		}
+      for (; i < w; ++i) {
+         STBTT_assert(pixels[i] == 0);
+         total -= buffer[i & STBTT__OVER_MASK];
+         pixels[i] = (unsigned char) (total / kernel_width);
+      }
 
-		pixels += stride_in_bytes;
-	}
+      pixels += stride_in_bytes;
+   }
 }
 
 static void stbtt__v_prefilter(unsigned char *pixels, int w, int h, int stride_in_bytes, unsigned int kernel_width)
 {
-	unsigned char buffer[STBTT_MAX_OVERSAMPLE];
-	int safe_h = h - kernel_width;
-	int j;
-	STBTT_memset(buffer, 0, STBTT_MAX_OVERSAMPLE); // suppress bogus warning from VS2013 -analyze
-	for (j = 0; j < w; ++j) {
-		int i;
-		unsigned int total;
-		STBTT_memset(buffer, 0, kernel_width);
+   unsigned char buffer[STBTT_MAX_OVERSAMPLE];
+   int safe_h = h - kernel_width;
+   int j;
+   STBTT_memset(buffer, 0, STBTT_MAX_OVERSAMPLE); // suppress bogus warning from VS2013 -analyze
+   for (j=0; j < w; ++j) {
+      int i;
+      unsigned int total;
+      STBTT_memset(buffer, 0, kernel_width);
 
-		total = 0;
+      total = 0;
 
-		// make kernel_width a constant in common cases so compiler can optimize out the divide
-		switch (kernel_width) {
-		case 2:
-			for (i = 0; i <= safe_h; ++i) {
-				total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
-				pixels[i*stride_in_bytes] = (unsigned char)(total / 2);
-			}
-			break;
-		case 3:
-			for (i = 0; i <= safe_h; ++i) {
-				total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
-				pixels[i*stride_in_bytes] = (unsigned char)(total / 3);
-			}
-			break;
-		case 4:
-			for (i = 0; i <= safe_h; ++i) {
-				total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
-				pixels[i*stride_in_bytes] = (unsigned char)(total / 4);
-			}
-			break;
-		case 5:
-			for (i = 0; i <= safe_h; ++i) {
-				total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
-				pixels[i*stride_in_bytes] = (unsigned char)(total / 5);
-			}
-			break;
-		default:
-			for (i = 0; i <= safe_h; ++i) {
-				total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
-				buffer[(i + kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
-				pixels[i*stride_in_bytes] = (unsigned char)(total / kernel_width);
-			}
-			break;
-		}
+      // make kernel_width a constant in common cases so compiler can optimize out the divide
+      switch (kernel_width) {
+         case 2:
+            for (i=0; i <= safe_h; ++i) {
+               total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
+               pixels[i*stride_in_bytes] = (unsigned char) (total / 2);
+            }
+            break;
+         case 3:
+            for (i=0; i <= safe_h; ++i) {
+               total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
+               pixels[i*stride_in_bytes] = (unsigned char) (total / 3);
+            }
+            break;
+         case 4:
+            for (i=0; i <= safe_h; ++i) {
+               total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
+               pixels[i*stride_in_bytes] = (unsigned char) (total / 4);
+            }
+            break;
+         case 5:
+            for (i=0; i <= safe_h; ++i) {
+               total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
+               pixels[i*stride_in_bytes] = (unsigned char) (total / 5);
+            }
+            break;
+         default:
+            for (i=0; i <= safe_h; ++i) {
+               total += pixels[i*stride_in_bytes] - buffer[i & STBTT__OVER_MASK];
+               buffer[(i+kernel_width) & STBTT__OVER_MASK] = pixels[i*stride_in_bytes];
+               pixels[i*stride_in_bytes] = (unsigned char) (total / kernel_width);
+            }
+            break;
+      }
 
-		for (; i < h; ++i) {
-			STBTT_assert(pixels[i*stride_in_bytes] == 0);
-			total -= buffer[i & STBTT__OVER_MASK];
-			pixels[i*stride_in_bytes] = (unsigned char)(total / kernel_width);
-		}
+      for (; i < h; ++i) {
+         STBTT_assert(pixels[i*stride_in_bytes] == 0);
+         total -= buffer[i & STBTT__OVER_MASK];
+         pixels[i*stride_in_bytes] = (unsigned char) (total / kernel_width);
+      }
 
-		pixels += 1;
-	}
+      pixels += 1;
+   }
 }
 
 static float stbtt__oversample_shift(int oversample)
 {
-	if (!oversample)
-		return 0.0f;
+   if (!oversample)
+      return 0.0f;
 
-	// The prefilter is a box filter of width "oversample",
-	// which shifts phase by (oversample - 1)/2 pixels in
-	// oversampled space. We want to shift in the opposite
-	// direction to counter this.
-	return (float)-(oversample - 1) / (2.0f * (float)oversample);
+   // The prefilter is a box filter of width "oversample",
+   // which shifts phase by (oversample - 1)/2 pixels in
+   // oversampled space. We want to shift in the opposite
+   // direction to counter this.
+   return (float)-(oversample - 1) / (2.0f * (float)oversample);
 }
 
 // rects array must be big enough to accommodate all characters in the given ranges
-STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
+STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, const stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
 {
-	int i, j, k;
+   int i,j,k;
 
-	k = 0;
-	for (i = 0; i < num_ranges; ++i) {
-		float fh = ranges[i].font_size;
-		float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh) : stbtt_ScaleForMappingEmToPixels(info, -fh);
-		ranges[i].h_oversample = (unsigned char)spc->h_oversample;
-		ranges[i].v_oversample = (unsigned char)spc->v_oversample;
-		for (j = 0; j < ranges[i].num_chars; ++j) {
-			int x0, y0, x1, y1;
-			int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
-			int glyph = stbtt_FindGlyphIndex(info, codepoint);
-			stbtt_GetGlyphBitmapBoxSubpixel(info, glyph,
-				scale * spc->h_oversample,
-				scale * spc->v_oversample,
-				0, 0,
-				&x0, &y0, &x1, &y1);
-			rects[k].w = (stbrp_coord)(x1 - x0 + spc->padding + spc->h_oversample - 1);
-			rects[k].h = (stbrp_coord)(y1 - y0 + spc->padding + spc->v_oversample - 1);
-			++k;
-		}
-	}
+   k=0;
+   for (i=0; i < num_ranges; ++i) {
+      float fh = ranges[i].font_size;
+      float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh) : stbtt_ScaleForMappingEmToPixels(info, -fh);
+      ranges[i].h_oversample = (unsigned char) spc->h_oversample;
+      ranges[i].v_oversample = (unsigned char) spc->v_oversample;
+      for (j=0; j < ranges[i].num_chars; ++j) {
+         int x0,y0,x1,y1;
+         int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
+         int glyph = stbtt_FindGlyphIndex(info, codepoint);
+         stbtt_GetGlyphBitmapBoxSubpixel(info,glyph,
+                                         scale * spc->h_oversample,
+                                         scale * spc->v_oversample,
+                                         0,0,
+                                         &x0,&y0,&x1,&y1);
+         rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
+         rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
+         ++k;
+      }
+   }
 
-	return k;
+   return k;
+}
+
+STBTT_DEF void stbtt_MakeGlyphBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int prefilter_x, int prefilter_y, float *sub_x, float *sub_y, int glyph)
+{
+   stbtt_MakeGlyphBitmapSubpixel(info,
+                                 output,
+                                 out_w - (prefilter_x - 1),
+                                 out_h - (prefilter_y - 1),
+                                 out_stride,
+                                 scale_x,
+                                 scale_y,
+                                 shift_x,
+                                 shift_y,
+                                 glyph);
+
+   if (prefilter_x > 1)
+      stbtt__h_prefilter(output, out_w, out_h, out_stride, prefilter_x);
+
+   if (prefilter_y > 1)
+      stbtt__v_prefilter(output, out_w, out_h, out_stride, prefilter_y);
+
+   *sub_x = stbtt__oversample_shift(prefilter_x);
+   *sub_y = stbtt__oversample_shift(prefilter_y);
 }
 
 // rects array must be big enough to accommodate all characters in the given ranges
-STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
+STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, const stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
 {
-	int i, j, k, return_value = 1;
+   int i,j,k, return_value = 1;
 
-	// save current values
-	int old_h_over = spc->h_oversample;
-	int old_v_over = spc->v_oversample;
+   // save current values
+   int old_h_over = spc->h_oversample;
+   int old_v_over = spc->v_oversample;
 
-	k = 0;
-	for (i = 0; i < num_ranges; ++i) {
-		float fh = ranges[i].font_size;
-		float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh) : stbtt_ScaleForMappingEmToPixels(info, -fh);
-		float recip_h, recip_v, sub_x, sub_y;
-		spc->h_oversample = ranges[i].h_oversample;
-		spc->v_oversample = ranges[i].v_oversample;
-		recip_h = 1.0f / spc->h_oversample;
-		recip_v = 1.0f / spc->v_oversample;
-		sub_x = stbtt__oversample_shift(spc->h_oversample);
-		sub_y = stbtt__oversample_shift(spc->v_oversample);
-		for (j = 0; j < ranges[i].num_chars; ++j) {
-			stbrp_rect *r = &rects[k];
-			if (r->was_packed) {
-				stbtt_packedchar *bc = &ranges[i].chardata_for_range[j];
-				int advance, lsb, x0, y0, x1, y1;
-				int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
-				int glyph = stbtt_FindGlyphIndex(info, codepoint);
-				stbrp_coord pad = (stbrp_coord)spc->padding;
+   k = 0;
+   for (i=0; i < num_ranges; ++i) {
+      float fh = ranges[i].font_size;
+      float scale = fh > 0 ? stbtt_ScaleForPixelHeight(info, fh) : stbtt_ScaleForMappingEmToPixels(info, -fh);
+      float recip_h,recip_v,sub_x,sub_y;
+      spc->h_oversample = ranges[i].h_oversample;
+      spc->v_oversample = ranges[i].v_oversample;
+      recip_h = 1.0f / spc->h_oversample;
+      recip_v = 1.0f / spc->v_oversample;
+      sub_x = stbtt__oversample_shift(spc->h_oversample);
+      sub_y = stbtt__oversample_shift(spc->v_oversample);
+      for (j=0; j < ranges[i].num_chars; ++j) {
+         stbrp_rect *r = &rects[k];
+         if (r->was_packed) {
+            stbtt_packedchar *bc = &ranges[i].chardata_for_range[j];
+            int advance, lsb, x0,y0,x1,y1;
+            int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
+            int glyph = stbtt_FindGlyphIndex(info, codepoint);
+            stbrp_coord pad = (stbrp_coord) spc->padding;
 
-				// pad on left and top
-				r->x += pad;
-				r->y += pad;
-				r->w -= pad;
-				r->h -= pad;
-				stbtt_GetGlyphHMetrics(info, glyph, &advance, &lsb);
-				stbtt_GetGlyphBitmapBox(info, glyph,
-					scale * spc->h_oversample,
-					scale * spc->v_oversample,
-					&x0, &y0, &x1, &y1);
-				stbtt_MakeGlyphBitmapSubpixel(info,
-					spc->pixels + r->x + r->y*spc->stride_in_bytes,
-					r->w - spc->h_oversample + 1,
-					r->h - spc->v_oversample + 1,
-					spc->stride_in_bytes,
-					scale * spc->h_oversample,
-					scale * spc->v_oversample,
-					0, 0,
-					glyph);
+            // pad on left and top
+            r->x += pad;
+            r->y += pad;
+            r->w -= pad;
+            r->h -= pad;
+            stbtt_GetGlyphHMetrics(info, glyph, &advance, &lsb);
+            stbtt_GetGlyphBitmapBox(info, glyph,
+                                    scale * spc->h_oversample,
+                                    scale * spc->v_oversample,
+                                    &x0,&y0,&x1,&y1);
+            stbtt_MakeGlyphBitmapSubpixel(info,
+                                          spc->pixels + r->x + r->y*spc->stride_in_bytes,
+                                          r->w - spc->h_oversample+1,
+                                          r->h - spc->v_oversample+1,
+                                          spc->stride_in_bytes,
+                                          scale * spc->h_oversample,
+                                          scale * spc->v_oversample,
+                                          0,0,
+                                          glyph);
 
-				if (spc->h_oversample > 1)
-					stbtt__h_prefilter(spc->pixels + r->x + r->y*spc->stride_in_bytes,
-						r->w, r->h, spc->stride_in_bytes,
-						spc->h_oversample);
+            if (spc->h_oversample > 1)
+               stbtt__h_prefilter(spc->pixels + r->x + r->y*spc->stride_in_bytes,
+                                  r->w, r->h, spc->stride_in_bytes,
+                                  spc->h_oversample);
 
-				if (spc->v_oversample > 1)
-					stbtt__v_prefilter(spc->pixels + r->x + r->y*spc->stride_in_bytes,
-						r->w, r->h, spc->stride_in_bytes,
-						spc->v_oversample);
+            if (spc->v_oversample > 1)
+               stbtt__v_prefilter(spc->pixels + r->x + r->y*spc->stride_in_bytes,
+                                  r->w, r->h, spc->stride_in_bytes,
+                                  spc->v_oversample);
 
-				bc->x0 = (stbtt_int16)r->x;
-				bc->y0 = (stbtt_int16)r->y;
-				bc->x1 = (stbtt_int16)(r->x + r->w);
-				bc->y1 = (stbtt_int16)(r->y + r->h);
-				bc->xadvance = scale * advance;
-				bc->xoff = (float)x0 * recip_h + sub_x;
-				bc->yoff = (float)y0 * recip_v + sub_y;
-				bc->xoff2 = (x0 + r->w) * recip_h + sub_x;
-				bc->yoff2 = (y0 + r->h) * recip_v + sub_y;
-			}
-			else {
-				return_value = 0; // if any fail, report failure
-			}
+            bc->x0       = (stbtt_int16)  r->x;
+            bc->y0       = (stbtt_int16)  r->y;
+            bc->x1       = (stbtt_int16) (r->x + r->w);
+            bc->y1       = (stbtt_int16) (r->y + r->h);
+            bc->xadvance =                scale * advance;
+            bc->xoff     =       (float)  x0 * recip_h + sub_x;
+            bc->yoff     =       (float)  y0 * recip_v + sub_y;
+            bc->xoff2    =                (x0 + r->w) * recip_h + sub_x;
+            bc->yoff2    =                (y0 + r->h) * recip_v + sub_y;
+         } else {
+            return_value = 0; // if any fail, report failure
+         }
 
-			++k;
-		}
-	}
+         ++k;
+      }
+   }
 
-	// restore original values
-	spc->h_oversample = old_h_over;
-	spc->v_oversample = old_v_over;
+   // restore original values
+   spc->h_oversample = old_h_over;
+   spc->v_oversample = old_v_over;
 
-	return return_value;
+   return return_value;
 }
 
 STBTT_DEF void stbtt_PackFontRangesPackRects(stbtt_pack_context *spc, stbrp_rect *rects, int num_rects)
 {
-	stbrp_pack_rects((stbrp_context *)spc->pack_info, rects, num_rects);
+   stbrp_pack_rects((stbrp_context *) spc->pack_info, rects, num_rects);
 }
 
-STBTT_DEF int stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges)
+STBTT_DEF int stbtt_PackFontRanges(stbtt_pack_context *spc, const unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges)
 {
-	stbtt_fontinfo info;
-	int i, j, n, return_value = 1;
-	//stbrp_context *context = (stbrp_context *) spc->pack_info;
-	stbrp_rect    *rects;
+   stbtt_fontinfo info;
+   int i,j,n, return_value = 1;
+   //stbrp_context *context = (stbrp_context *) spc->pack_info;
+   stbrp_rect    *rects;
 
-	// flag all characters as NOT packed
-	for (i = 0; i < num_ranges; ++i)
-		for (j = 0; j < ranges[i].num_chars; ++j)
-			ranges[i].chardata_for_range[j].x0 =
-			ranges[i].chardata_for_range[j].y0 =
-			ranges[i].chardata_for_range[j].x1 =
-			ranges[i].chardata_for_range[j].y1 = 0;
+   // flag all characters as NOT packed
+   for (i=0; i < num_ranges; ++i)
+      for (j=0; j < ranges[i].num_chars; ++j)
+         ranges[i].chardata_for_range[j].x0 =
+         ranges[i].chardata_for_range[j].y0 =
+         ranges[i].chardata_for_range[j].x1 =
+         ranges[i].chardata_for_range[j].y1 = 0;
 
-	n = 0;
-	for (i = 0; i < num_ranges; ++i)
-		n += ranges[i].num_chars;
+   n = 0;
+   for (i=0; i < num_ranges; ++i)
+      n += ranges[i].num_chars;
+         
+   rects = (stbrp_rect *) STBTT_malloc(sizeof(*rects) * n, spc->user_allocator_context);
+   if (rects == NULL)
+      return 0;
 
-	rects = (stbrp_rect *)STBTT_malloc(sizeof(*rects) * n, spc->user_allocator_context);
-	if (rects == NULL)
-		return 0;
+   info.userdata = spc->user_allocator_context;
+   stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata,font_index));
 
-	info.userdata = spc->user_allocator_context;
-	stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata, font_index));
+   n = stbtt_PackFontRangesGatherRects(spc, &info, ranges, num_ranges, rects);
 
-	n = stbtt_PackFontRangesGatherRects(spc, &info, ranges, num_ranges, rects);
+   stbtt_PackFontRangesPackRects(spc, rects, n);
+  
+   return_value = stbtt_PackFontRangesRenderIntoRects(spc, &info, ranges, num_ranges, rects);
 
-	stbtt_PackFontRangesPackRects(spc, rects, n);
-
-	return_value = stbtt_PackFontRangesRenderIntoRects(spc, &info, ranges, num_ranges, rects);
-
-	STBTT_free(rects, spc->user_allocator_context);
-	return return_value;
+   STBTT_free(rects, spc->user_allocator_context);
+   return return_value;
 }
 
-STBTT_DEF int stbtt_PackFontRange(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, float font_size,
-	int first_unicode_codepoint_in_range, int num_chars_in_range, stbtt_packedchar *chardata_for_range)
+STBTT_DEF int stbtt_PackFontRange(stbtt_pack_context *spc, const unsigned char *fontdata, int font_index, float font_size,
+            int first_unicode_codepoint_in_range, int num_chars_in_range, stbtt_packedchar *chardata_for_range)
 {
-	stbtt_pack_range range;
-	range.first_unicode_codepoint_in_range = first_unicode_codepoint_in_range;
-	range.array_of_unicode_codepoints = NULL;
-	range.num_chars = num_chars_in_range;
-	range.chardata_for_range = chardata_for_range;
-	range.font_size = font_size;
-	return stbtt_PackFontRanges(spc, fontdata, font_index, &range, 1);
+   stbtt_pack_range range;
+   range.first_unicode_codepoint_in_range = first_unicode_codepoint_in_range;
+   range.array_of_unicode_codepoints = NULL;
+   range.num_chars                   = num_chars_in_range;
+   range.chardata_for_range          = chardata_for_range;
+   range.font_size                   = font_size;
+   return stbtt_PackFontRanges(spc, fontdata, font_index, &range, 1);
 }
 
-STBTT_DEF void stbtt_GetPackedQuad(stbtt_packedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int align_to_integer)
+STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int align_to_integer)
 {
-	float ipw = 1.0f / pw, iph = 1.0f / ph;
-	stbtt_packedchar *b = chardata + char_index;
+   float ipw = 1.0f / pw, iph = 1.0f / ph;
+   const stbtt_packedchar *b = chardata + char_index;
 
-	if (align_to_integer) {
-		float x = (float)STBTT_ifloor((*xpos + b->xoff) + 0.5f);
-		float y = (float)STBTT_ifloor((*ypos + b->yoff) + 0.5f);
-		q->x0 = x;
-		q->y0 = y;
-		q->x1 = x + b->xoff2 - b->xoff;
-		q->y1 = y + b->yoff2 - b->yoff;
-	}
-	else {
-		q->x0 = *xpos + b->xoff;
-		q->y0 = *ypos + b->yoff;
-		q->x1 = *xpos + b->xoff2;
-		q->y1 = *ypos + b->yoff2;
-	}
+   if (align_to_integer) {
+      float x = (float) STBTT_ifloor((*xpos + b->xoff) + 0.5f);
+      float y = (float) STBTT_ifloor((*ypos + b->yoff) + 0.5f);
+      q->x0 = x;
+      q->y0 = y;
+      q->x1 = x + b->xoff2 - b->xoff;
+      q->y1 = y + b->yoff2 - b->yoff;
+   } else {
+      q->x0 = *xpos + b->xoff;
+      q->y0 = *ypos + b->yoff;
+      q->x1 = *xpos + b->xoff2;
+      q->y1 = *ypos + b->yoff2;
+   }
 
-	q->s0 = b->x0 * ipw;
-	q->t0 = b->y0 * iph;
-	q->s1 = b->x1 * ipw;
-	q->t1 = b->y1 * iph;
+   q->s0 = b->x0 * ipw;
+   q->t0 = b->y0 * iph;
+   q->s1 = b->x1 * ipw;
+   q->t1 = b->y1 * iph;
 
-	*xpos += b->xadvance;
+   *xpos += b->xadvance;
 }
 
+//////////////////////////////////////////////////////////////////////////////
+//
+// sdf computation
+//
+
+#define STBTT_min(a,b)  ((a) < (b) ? (a) : (b))
+#define STBTT_max(a,b)  ((a) < (b) ? (b) : (a))
+
+static int stbtt__ray_intersect_bezier(float orig[2], float ray[2], float q0[2], float q1[2], float q2[2], float hits[2][2])
+{
+   float q0perp = q0[1]*ray[0] - q0[0]*ray[1];
+   float q1perp = q1[1]*ray[0] - q1[0]*ray[1];
+   float q2perp = q2[1]*ray[0] - q2[0]*ray[1];
+   float roperp = orig[1]*ray[0] - orig[0]*ray[1];
+
+   float a = q0perp - 2*q1perp + q2perp;
+   float b = q1perp - q0perp;
+   float c = q0perp - roperp;
+
+   float s0 = 0., s1 = 0.;
+   int num_s = 0;
+
+   if (a != 0.0) {
+      float discr = b*b - a*c;
+      if (discr > 0.0) {
+         float rcpna = -1 / a;
+         float d = (float) STBTT_sqrt(discr);
+         s0 = (b+d) * rcpna;
+         s1 = (b-d) * rcpna;
+         if (s0 >= 0.0 && s0 <= 1.0)
+            num_s = 1;
+         if (d > 0.0 && s1 >= 0.0 && s1 <= 1.0) {
+            if (num_s == 0) s0 = s1;
+            ++num_s;
+         }
+      }
+   } else {
+      // 2*b*s + c = 0
+      // s = -c / (2*b)
+      s0 = c / (-2 * b);
+      if (s0 >= 0.0 && s0 <= 1.0)
+         num_s = 1;
+   }
+
+   if (num_s == 0)
+      return 0;
+   else {
+      float rcp_len2 = 1 / (ray[0]*ray[0] + ray[1]*ray[1]);
+      float rayn_x = ray[0] * rcp_len2, rayn_y = ray[1] * rcp_len2;
+
+      float q0d =   q0[0]*rayn_x +   q0[1]*rayn_y;
+      float q1d =   q1[0]*rayn_x +   q1[1]*rayn_y;
+      float q2d =   q2[0]*rayn_x +   q2[1]*rayn_y;
+      float rod = orig[0]*rayn_x + orig[1]*rayn_y;
+
+      float q10d = q1d - q0d;
+      float q20d = q2d - q0d;
+      float q0rd = q0d - rod;
+
+      hits[0][0] = q0rd + s0*(2.0f - 2.0f*s0)*q10d + s0*s0*q20d;
+      hits[0][1] = a*s0+b;
+
+      if (num_s > 1) {
+         hits[1][0] = q0rd + s1*(2.0f - 2.0f*s1)*q10d + s1*s1*q20d;
+         hits[1][1] = a*s1+b;
+         return 2;
+      } else {
+         return 1;
+      }
+   }
+}
+
+static int equal(float *a, float *b)
+{
+   return (a[0] == b[0] && a[1] == b[1]);
+}
+
+static int stbtt__compute_crossings_x(float x, float y, int nverts, stbtt_vertex *verts)
+{
+   int i;
+   float orig[2], ray[2] = { 1, 0 };
+   float y_frac;
+   int winding = 0;
+
+   orig[0] = x;
+   orig[1] = y;
+
+   // make sure y never passes through a vertex of the shape
+   y_frac = (float) STBTT_fmod(y, 1.0f);
+   if (y_frac < 0.01f)
+      y += 0.01f;
+   else if (y_frac > 0.99f)
+      y -= 0.01f;
+   orig[1] = y;
+
+   // test a ray from (-infinity,y) to (x,y)
+   for (i=0; i < nverts; ++i) {
+      if (verts[i].type == STBTT_vline) {
+         int x0 = (int) verts[i-1].x, y0 = (int) verts[i-1].y;
+         int x1 = (int) verts[i  ].x, y1 = (int) verts[i  ].y;
+         if (y > STBTT_min(y0,y1) && y < STBTT_max(y0,y1) && x > STBTT_min(x0,x1)) {
+            float x_inter = (y - y0) / (y1 - y0) * (x1-x0) + x0;
+            if (x_inter < x)  
+               winding += (y0 < y1) ? 1 : -1;
+         }
+      }
+      if (verts[i].type == STBTT_vcurve) {
+         int x0 = (int) verts[i-1].x , y0 = (int) verts[i-1].y ;
+         int x1 = (int) verts[i  ].cx, y1 = (int) verts[i  ].cy;
+         int x2 = (int) verts[i  ].x , y2 = (int) verts[i  ].y ;
+         int ax = STBTT_min(x0,STBTT_min(x1,x2)), ay = STBTT_min(y0,STBTT_min(y1,y2));
+         int by = STBTT_max(y0,STBTT_max(y1,y2));
+         if (y > ay && y < by && x > ax) {
+            float q0[2],q1[2],q2[2];
+            float hits[2][2];
+            q0[0] = (float)x0;
+            q0[1] = (float)y0;
+            q1[0] = (float)x1;
+            q1[1] = (float)y1;
+            q2[0] = (float)x2;
+            q2[1] = (float)y2;
+            if (equal(q0,q1) || equal(q1,q2)) {
+               x0 = (int)verts[i-1].x;
+               y0 = (int)verts[i-1].y;
+               x1 = (int)verts[i  ].x;
+               y1 = (int)verts[i  ].y;
+               if (y > STBTT_min(y0,y1) && y < STBTT_max(y0,y1) && x > STBTT_min(x0,x1)) {
+                  float x_inter = (y - y0) / (y1 - y0) * (x1-x0) + x0;
+                  if (x_inter < x)  
+                     winding += (y0 < y1) ? 1 : -1;
+               }
+            } else {
+               int num_hits = stbtt__ray_intersect_bezier(orig, ray, q0, q1, q2, hits);
+               if (num_hits >= 1)
+                  if (hits[0][0] < 0)
+                     winding += (hits[0][1] < 0 ? -1 : 1);
+               if (num_hits >= 2)
+                  if (hits[1][0] < 0)
+                     winding += (hits[1][1] < 0 ? -1 : 1);
+            }
+         } 
+      }
+   }
+   return winding;
+}
+
+static float stbtt__cuberoot( float x )
+{
+   if (x<0)
+      return -(float) STBTT_pow(-x,1.0f/3.0f);
+   else
+      return  (float) STBTT_pow( x,1.0f/3.0f);
+}
+
+// x^3 + c*x^2 + b*x + a = 0
+static int stbtt__solve_cubic(float a, float b, float c, float* r)
+{
+	float s = -a / 3;
+	float p = b - a*a / 3;
+	float q = a * (2*a*a - 9*b) / 27 + c;
+   float p3 = p*p*p;
+	float d = q*q + 4*p3 / 27;
+	if (d >= 0) {
+		float z = (float) STBTT_sqrt(d);
+		float u = (-q + z) / 2;
+		float v = (-q - z) / 2;
+		u = stbtt__cuberoot(u);
+		v = stbtt__cuberoot(v);
+		r[0] = s + u + v;
+		return 1;
+	} else {
+	   float u = (float) STBTT_sqrt(-p/3);
+	   float v = (float) STBTT_acos(-STBTT_sqrt(-27/p3) * q / 2) / 3; // p3 must be negative, since d is negative
+	   float m = (float) STBTT_cos(v);
+      float n = (float) STBTT_cos(v-3.141592/2)*1.732050808f;
+	   r[0] = s + u * 2 * m;
+	   r[1] = s - u * (m + n);
+	   r[2] = s - u * (m - n);
+
+      //STBTT_assert( STBTT_fabs(((r[0]+a)*r[0]+b)*r[0]+c) < 0.05f);  // these asserts may not be safe at all scales, though they're in bezier t parameter units so maybe?
+      //STBTT_assert( STBTT_fabs(((r[1]+a)*r[1]+b)*r[1]+c) < 0.05f);
+      //STBTT_assert( STBTT_fabs(((r[2]+a)*r[2]+b)*r[2]+c) < 0.05f);
+   	return 3;
+   }
+}
+
+STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float scale, int glyph, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff)
+{
+   float scale_x = scale, scale_y = scale;
+   int ix0,iy0,ix1,iy1;
+   int w,h;
+   unsigned char *data;
+
+   // if one scale is 0, use same scale for both
+   if (scale_x == 0) scale_x = scale_y;
+   if (scale_y == 0) {
+      if (scale_x == 0) return NULL;  // if both scales are 0, return NULL
+      scale_y = scale_x;
+   }
+
+   stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale, scale, 0.0f,0.0f, &ix0,&iy0,&ix1,&iy1);
+
+   // if empty, return NULL
+   if (ix0 == ix1 || iy0 == iy1)
+      return NULL;
+
+   ix0 -= padding;
+   iy0 -= padding;
+   ix1 += padding;
+   iy1 += padding;
+
+   w = (ix1 - ix0);
+   h = (iy1 - iy0);
+
+   if (width ) *width  = w;
+   if (height) *height = h;
+   if (xoff  ) *xoff   = ix0;
+   if (yoff  ) *yoff   = iy0;
+
+   // invert for y-downwards bitmaps
+   scale_y = -scale_y;
+      
+   {
+      int x,y,i,j;
+      float *precompute;
+      stbtt_vertex *verts;
+      int num_verts = stbtt_GetGlyphShape(info, glyph, &verts);
+      data = (unsigned char *) STBTT_malloc(w * h, info->userdata);
+      precompute = (float *) STBTT_malloc(num_verts * sizeof(float), info->userdata);
+
+      for (i=0,j=num_verts-1; i < num_verts; j=i++) {
+         if (verts[i].type == STBTT_vline) {
+            float x0 = verts[i].x*scale_x, y0 = verts[i].y*scale_y;
+            float x1 = verts[j].x*scale_x, y1 = verts[j].y*scale_y;
+            float dist = (float) STBTT_sqrt((x1-x0)*(x1-x0) + (y1-y0)*(y1-y0));
+            precompute[i] = (dist == 0) ? 0.0f : 1.0f / dist;
+         } else if (verts[i].type == STBTT_vcurve) {
+            float x2 = verts[j].x *scale_x, y2 = verts[j].y *scale_y;
+            float x1 = verts[i].cx*scale_x, y1 = verts[i].cy*scale_y;
+            float x0 = verts[i].x *scale_x, y0 = verts[i].y *scale_y;
+            float bx = x0 - 2*x1 + x2, by = y0 - 2*y1 + y2;
+            float len2 = bx*bx + by*by;
+            if (len2 != 0.0f)
+               precompute[i] = 1.0f / (bx*bx + by*by);
+            else
+               precompute[i] = 0.0f;
+         } else
+            precompute[i] = 0.0f;
+      }
+
+      for (y=iy0; y < iy1; ++y) {
+         for (x=ix0; x < ix1; ++x) {
+            float val;
+            float min_dist = 999999.0f;
+            float sx = (float) x + 0.5f;
+            float sy = (float) y + 0.5f;
+            float x_gspace = (sx / scale_x);
+            float y_gspace = (sy / scale_y);
+
+            int winding = stbtt__compute_crossings_x(x_gspace, y_gspace, num_verts, verts); // @OPTIMIZE: this could just be a rasterization, but needs to be line vs. non-tesselated curves so a new path
+
+            for (i=0; i < num_verts; ++i) {
+               float x0 = verts[i].x*scale_x, y0 = verts[i].y*scale_y;
+
+               // check against every point here rather than inside line/curve primitives -- @TODO: wrong if multiple 'moves' in a row produce a garbage point, and given culling, probably more efficient to do within line/curve
+               float dist2 = (x0-sx)*(x0-sx) + (y0-sy)*(y0-sy);
+               if (dist2 < min_dist*min_dist)
+                  min_dist = (float) STBTT_sqrt(dist2);
+
+               if (verts[i].type == STBTT_vline) {
+                  float x1 = verts[i-1].x*scale_x, y1 = verts[i-1].y*scale_y;
+
+                  // coarse culling against bbox
+                  //if (sx > STBTT_min(x0,x1)-min_dist && sx < STBTT_max(x0,x1)+min_dist &&
+                  //    sy > STBTT_min(y0,y1)-min_dist && sy < STBTT_max(y0,y1)+min_dist)
+                  float dist = (float) STBTT_fabs((x1-x0)*(y0-sy) - (y1-y0)*(x0-sx)) * precompute[i];
+                  STBTT_assert(i != 0);
+                  if (dist < min_dist) {
+                     // check position along line
+                     // x' = x0 + t*(x1-x0), y' = y0 + t*(y1-y0)
+                     // minimize (x'-sx)*(x'-sx)+(y'-sy)*(y'-sy)
+                     float dx = x1-x0, dy = y1-y0;
+                     float px = x0-sx, py = y0-sy;
+                     // minimize (px+t*dx)^2 + (py+t*dy)^2 = px*px + 2*px*dx*t + t^2*dx*dx + py*py + 2*py*dy*t + t^2*dy*dy
+                     // derivative: 2*px*dx + 2*py*dy + (2*dx*dx+2*dy*dy)*t, set to 0 and solve
+                     float t = -(px*dx + py*dy) / (dx*dx + dy*dy);
+                     if (t >= 0.0f && t <= 1.0f)
+                        min_dist = dist;
+                  }
+               } else if (verts[i].type == STBTT_vcurve) {
+                  float x2 = verts[i-1].x *scale_x, y2 = verts[i-1].y *scale_y;
+                  float x1 = verts[i  ].cx*scale_x, y1 = verts[i  ].cy*scale_y;
+                  float box_x0 = STBTT_min(STBTT_min(x0,x1),x2);
+                  float box_y0 = STBTT_min(STBTT_min(y0,y1),y2);
+                  float box_x1 = STBTT_max(STBTT_max(x0,x1),x2);
+                  float box_y1 = STBTT_max(STBTT_max(y0,y1),y2);
+                  // coarse culling against bbox to avoid computing cubic unnecessarily
+                  if (sx > box_x0-min_dist && sx < box_x1+min_dist && sy > box_y0-min_dist && sy < box_y1+min_dist) {
+                     int num=0;
+                     float ax = x1-x0, ay = y1-y0;
+                     float bx = x0 - 2*x1 + x2, by = y0 - 2*y1 + y2;
+                     float mx = x0 - sx, my = y0 - sy;
+                     float res[3],px,py,t,it;
+                     float a_inv = precompute[i];
+                     if (a_inv == 0.0) { // if a_inv is 0, it's 2nd degree so use quadratic formula
+                        float a = 3*(ax*bx + ay*by);
+                        float b = 2*(ax*ax + ay*ay) + (mx*bx+my*by);
+                        float c = mx*ax+my*ay;
+                        if (a == 0.0) { // if a is 0, it's linear
+                           if (b != 0.0) {
+                              res[num++] = -c/b;
+                           }
+                        } else {
+                           float discriminant = b*b - 4*a*c;
+                           if (discriminant < 0)
+                              num = 0;
+                           else {
+                              float root = (float) STBTT_sqrt(discriminant);
+                              res[0] = (-b - root)/(2*a);
+                              res[1] = (-b + root)/(2*a);
+                              num = 2; // don't bother distinguishing 1-solution case, as code below will still work
+                           }
+                        }
+                     } else {
+                        float b = 3*(ax*bx + ay*by) * a_inv; // could precompute this as it doesn't depend on sample point
+                        float c = (2*(ax*ax + ay*ay) + (mx*bx+my*by)) * a_inv;
+                        float d = (mx*ax+my*ay) * a_inv;
+                        num = stbtt__solve_cubic(b, c, d, res);
+                     }
+                     if (num >= 1 && res[0] >= 0.0f && res[0] <= 1.0f) {
+                        t = res[0], it = 1.0f - t;
+                        px = it*it*x0 + 2*t*it*x1 + t*t*x2;
+                        py = it*it*y0 + 2*t*it*y1 + t*t*y2;
+                        dist2 = (px-sx)*(px-sx) + (py-sy)*(py-sy);
+                        if (dist2 < min_dist * min_dist)
+                           min_dist = (float) STBTT_sqrt(dist2);
+                     }
+                     if (num >= 2 && res[1] >= 0.0f && res[1] <= 1.0f) {
+                        t = res[1], it = 1.0f - t;
+                        px = it*it*x0 + 2*t*it*x1 + t*t*x2;
+                        py = it*it*y0 + 2*t*it*y1 + t*t*y2;
+                        dist2 = (px-sx)*(px-sx) + (py-sy)*(py-sy);
+                        if (dist2 < min_dist * min_dist)
+                           min_dist = (float) STBTT_sqrt(dist2);
+                     }
+                     if (num >= 3 && res[2] >= 0.0f && res[2] <= 1.0f) {
+                        t = res[2], it = 1.0f - t;
+                        px = it*it*x0 + 2*t*it*x1 + t*t*x2;
+                        py = it*it*y0 + 2*t*it*y1 + t*t*y2;
+                        dist2 = (px-sx)*(px-sx) + (py-sy)*(py-sy);
+                        if (dist2 < min_dist * min_dist)
+                           min_dist = (float) STBTT_sqrt(dist2);
+                     }
+                  }
+               }
+            }
+            if (winding == 0)
+               min_dist = -min_dist;  // if outside the shape, value is negative
+            val = onedge_value + pixel_dist_scale * min_dist;
+            if (val < 0)
+               val = 0;
+            else if (val > 255)
+               val = 255;
+            data[(y-iy0)*w+(x-ix0)] = (unsigned char) val;
+         }
+      }
+      STBTT_free(precompute, info->userdata);
+      STBTT_free(verts, info->userdata);
+   }
+   return data;
+}   
+
+STBTT_DEF unsigned char * stbtt_GetCodepointSDF(const stbtt_fontinfo *info, float scale, int codepoint, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff)
+{
+   return stbtt_GetGlyphSDF(info, scale, stbtt_FindGlyphIndex(info, codepoint), padding, onedge_value, pixel_dist_scale, width, height, xoff, yoff);
+}
+
+STBTT_DEF void stbtt_FreeSDF(unsigned char *bitmap, void *userdata)
+{
+   STBTT_free(bitmap, userdata);
+}
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -3091,172 +4555,218 @@ STBTT_DEF void stbtt_GetPackedQuad(stbtt_packedchar *chardata, int pw, int ph, i
 //
 
 // check if a utf8 string contains a prefix which is the utf16 string; if so return length of matching utf8 string
-static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(const stbtt_uint8 *s1, stbtt_int32 len1, const stbtt_uint8 *s2, stbtt_int32 len2)
+static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(stbtt_uint8 *s1, stbtt_int32 len1, stbtt_uint8 *s2, stbtt_int32 len2) 
 {
-	stbtt_int32 i = 0;
+   stbtt_int32 i=0;
 
-	// convert utf16 to utf8 and compare the results while converting
-	while (len2) {
-		stbtt_uint16 ch = s2[0] * 256 + s2[1];
-		if (ch < 0x80) {
-			if (i >= len1) return -1;
-			if (s1[i++] != ch) return -1;
-		}
-		else if (ch < 0x800) {
-			if (i + 1 >= len1) return -1;
-			if (s1[i++] != 0xc0 + (ch >> 6)) return -1;
-			if (s1[i++] != 0x80 + (ch & 0x3f)) return -1;
-		}
-		else if (ch >= 0xd800 && ch < 0xdc00) {
-			stbtt_uint32 c;
-			stbtt_uint16 ch2 = s2[2] * 256 + s2[3];
-			if (i + 3 >= len1) return -1;
-			c = ((ch - 0xd800) << 10) + (ch2 - 0xdc00) + 0x10000;
-			if (s1[i++] != 0xf0 + (c >> 18)) return -1;
-			if (s1[i++] != 0x80 + ((c >> 12) & 0x3f)) return -1;
-			if (s1[i++] != 0x80 + ((c >> 6) & 0x3f)) return -1;
-			if (s1[i++] != 0x80 + ((c)& 0x3f)) return -1;
-			s2 += 2; // plus another 2 below
-			len2 -= 2;
-		}
-		else if (ch >= 0xdc00 && ch < 0xe000) {
-			return -1;
-		}
-		else {
-			if (i + 2 >= len1) return -1;
-			if (s1[i++] != 0xe0 + (ch >> 12)) return -1;
-			if (s1[i++] != 0x80 + ((ch >> 6) & 0x3f)) return -1;
-			if (s1[i++] != 0x80 + ((ch)& 0x3f)) return -1;
-		}
-		s2 += 2;
-		len2 -= 2;
-	}
-	return i;
+   // convert utf16 to utf8 and compare the results while converting
+   while (len2) {
+      stbtt_uint16 ch = s2[0]*256 + s2[1];
+      if (ch < 0x80) {
+         if (i >= len1) return -1;
+         if (s1[i++] != ch) return -1;
+      } else if (ch < 0x800) {
+         if (i+1 >= len1) return -1;
+         if (s1[i++] != 0xc0 + (ch >> 6)) return -1;
+         if (s1[i++] != 0x80 + (ch & 0x3f)) return -1;
+      } else if (ch >= 0xd800 && ch < 0xdc00) {
+         stbtt_uint32 c;
+         stbtt_uint16 ch2 = s2[2]*256 + s2[3];
+         if (i+3 >= len1) return -1;
+         c = ((ch - 0xd800) << 10) + (ch2 - 0xdc00) + 0x10000;
+         if (s1[i++] != 0xf0 + (c >> 18)) return -1;
+         if (s1[i++] != 0x80 + ((c >> 12) & 0x3f)) return -1;
+         if (s1[i++] != 0x80 + ((c >>  6) & 0x3f)) return -1;
+         if (s1[i++] != 0x80 + ((c      ) & 0x3f)) return -1;
+         s2 += 2; // plus another 2 below
+         len2 -= 2;
+      } else if (ch >= 0xdc00 && ch < 0xe000) {
+         return -1;
+      } else {
+         if (i+2 >= len1) return -1;
+         if (s1[i++] != 0xe0 + (ch >> 12)) return -1;
+         if (s1[i++] != 0x80 + ((ch >> 6) & 0x3f)) return -1;
+         if (s1[i++] != 0x80 + ((ch     ) & 0x3f)) return -1;
+      }
+      s2 += 2;
+      len2 -= 2;
+   }
+   return i;
 }
 
-STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const char *s2, int len2)
+static int stbtt_CompareUTF8toUTF16_bigendian_internal(char *s1, int len1, char *s2, int len2) 
 {
-	return len1 == stbtt__CompareUTF8toUTF16_bigendian_prefix((const stbtt_uint8*)s1, len1, (const stbtt_uint8*)s2, len2);
+   return len1 == stbtt__CompareUTF8toUTF16_bigendian_prefix((stbtt_uint8*) s1, len1, (stbtt_uint8*) s2, len2);
 }
 
 // returns results in whatever encoding you request... but note that 2-byte encodings
 // will be BIG-ENDIAN... use stbtt_CompareUTF8toUTF16_bigendian() to compare
 STBTT_DEF const char *stbtt_GetFontNameString(const stbtt_fontinfo *font, int *length, int platformID, int encodingID, int languageID, int nameID)
 {
-	stbtt_int32 i, count, stringOffset;
-	stbtt_uint8 *fc = font->data;
-	stbtt_uint32 offset = font->fontstart;
-	stbtt_uint32 nm = stbtt__find_table(fc, offset, "name");
-	if (!nm) return NULL;
+   stbtt_int32 i,count,stringOffset;
+   stbtt_uint8 *fc = font->data;
+   stbtt_uint32 offset = font->fontstart;
+   stbtt_uint32 nm = stbtt__find_table(fc, offset, "name");
+   if (!nm) return NULL;
 
-	count = ttUSHORT(fc + nm + 2);
-	stringOffset = nm + ttUSHORT(fc + nm + 4);
-	for (i = 0; i < count; ++i) {
-		stbtt_uint32 loc = nm + 6 + 12 * i;
-		if (platformID == ttUSHORT(fc + loc + 0) && encodingID == ttUSHORT(fc + loc + 2)
-			&& languageID == ttUSHORT(fc + loc + 4) && nameID == ttUSHORT(fc + loc + 6)) {
-			*length = ttUSHORT(fc + loc + 8);
-			return (const char *)(fc + stringOffset + ttUSHORT(fc + loc + 10));
-		}
-	}
-	return NULL;
+   count = ttUSHORT(fc+nm+2);
+   stringOffset = nm + ttUSHORT(fc+nm+4);
+   for (i=0; i < count; ++i) {
+      stbtt_uint32 loc = nm + 6 + 12 * i;
+      if (platformID == ttUSHORT(fc+loc+0) && encodingID == ttUSHORT(fc+loc+2)
+          && languageID == ttUSHORT(fc+loc+4) && nameID == ttUSHORT(fc+loc+6)) {
+         *length = ttUSHORT(fc+loc+8);
+         return (const char *) (fc+stringOffset+ttUSHORT(fc+loc+10));
+      }
+   }
+   return NULL;
 }
 
 static int stbtt__matchpair(stbtt_uint8 *fc, stbtt_uint32 nm, stbtt_uint8 *name, stbtt_int32 nlen, stbtt_int32 target_id, stbtt_int32 next_id)
 {
-	stbtt_int32 i;
-	stbtt_int32 count = ttUSHORT(fc + nm + 2);
-	stbtt_int32 stringOffset = nm + ttUSHORT(fc + nm + 4);
+   stbtt_int32 i;
+   stbtt_int32 count = ttUSHORT(fc+nm+2);
+   stbtt_int32 stringOffset = nm + ttUSHORT(fc+nm+4);
 
-	for (i = 0; i < count; ++i) {
-		stbtt_uint32 loc = nm + 6 + 12 * i;
-		stbtt_int32 id = ttUSHORT(fc + loc + 6);
-		if (id == target_id) {
-			// find the encoding
-			stbtt_int32 platform = ttUSHORT(fc + loc + 0), encoding = ttUSHORT(fc + loc + 2), language = ttUSHORT(fc + loc + 4);
+   for (i=0; i < count; ++i) {
+      stbtt_uint32 loc = nm + 6 + 12 * i;
+      stbtt_int32 id = ttUSHORT(fc+loc+6);
+      if (id == target_id) {
+         // find the encoding
+         stbtt_int32 platform = ttUSHORT(fc+loc+0), encoding = ttUSHORT(fc+loc+2), language = ttUSHORT(fc+loc+4);
 
-			// is this a Unicode encoding?
-			if (platform == 0 || (platform == 3 && encoding == 1) || (platform == 3 && encoding == 10)) {
-				stbtt_int32 slen = ttUSHORT(fc + loc + 8);
-				stbtt_int32 off = ttUSHORT(fc + loc + 10);
+         // is this a Unicode encoding?
+         if (platform == 0 || (platform == 3 && encoding == 1) || (platform == 3 && encoding == 10)) {
+            stbtt_int32 slen = ttUSHORT(fc+loc+8);
+            stbtt_int32 off = ttUSHORT(fc+loc+10);
 
-				// check if there's a prefix match
-				stbtt_int32 matchlen = stbtt__CompareUTF8toUTF16_bigendian_prefix(name, nlen, fc + stringOffset + off, slen);
-				if (matchlen >= 0) {
-					// check for target_id+1 immediately following, with same encoding & language
-					if (i + 1 < count && ttUSHORT(fc + loc + 12 + 6) == next_id && ttUSHORT(fc + loc + 12) == platform && ttUSHORT(fc + loc + 12 + 2) == encoding && ttUSHORT(fc + loc + 12 + 4) == language) {
-						slen = ttUSHORT(fc + loc + 12 + 8);
-						off = ttUSHORT(fc + loc + 12 + 10);
-						if (slen == 0) {
-							if (matchlen == nlen)
-								return 1;
-						}
-						else if (matchlen < nlen && name[matchlen] == ' ') {
-							++matchlen;
-							if (stbtt_CompareUTF8toUTF16_bigendian((char*)(name + matchlen), nlen - matchlen, (char*)(fc + stringOffset + off), slen))
-								return 1;
-						}
-					}
-					else {
-						// if nothing immediately following
-						if (matchlen == nlen)
-							return 1;
-					}
-				}
-			}
+            // check if there's a prefix match
+            stbtt_int32 matchlen = stbtt__CompareUTF8toUTF16_bigendian_prefix(name, nlen, fc+stringOffset+off,slen);
+            if (matchlen >= 0) {
+               // check for target_id+1 immediately following, with same encoding & language
+               if (i+1 < count && ttUSHORT(fc+loc+12+6) == next_id && ttUSHORT(fc+loc+12) == platform && ttUSHORT(fc+loc+12+2) == encoding && ttUSHORT(fc+loc+12+4) == language) {
+                  slen = ttUSHORT(fc+loc+12+8);
+                  off = ttUSHORT(fc+loc+12+10);
+                  if (slen == 0) {
+                     if (matchlen == nlen)
+                        return 1;
+                  } else if (matchlen < nlen && name[matchlen] == ' ') {
+                     ++matchlen;
+                     if (stbtt_CompareUTF8toUTF16_bigendian_internal((char*) (name+matchlen), nlen-matchlen, (char*)(fc+stringOffset+off),slen))
+                        return 1;
+                  }
+               } else {
+                  // if nothing immediately following
+                  if (matchlen == nlen)
+                     return 1;
+               }
+            }
+         }
 
-			// @TODO handle other encodings
-		}
-	}
-	return 0;
+         // @TODO handle other encodings
+      }
+   }
+   return 0;
 }
 
 static int stbtt__matches(stbtt_uint8 *fc, stbtt_uint32 offset, stbtt_uint8 *name, stbtt_int32 flags)
 {
-	stbtt_int32 nlen = (stbtt_int32)STBTT_strlen((char *)name);
-	stbtt_uint32 nm, hd;
-	if (!stbtt__isfont(fc + offset)) return 0;
+   stbtt_int32 nlen = (stbtt_int32) STBTT_strlen((char *) name);
+   stbtt_uint32 nm,hd;
+   if (!stbtt__isfont(fc+offset)) return 0;
 
-	// check italics/bold/underline flags in macStyle...
-	if (flags) {
-		hd = stbtt__find_table(fc, offset, "head");
-		if ((ttUSHORT(fc + hd + 44) & 7) != (flags & 7)) return 0;
-	}
+   // check italics/bold/underline flags in macStyle...
+   if (flags) {
+      hd = stbtt__find_table(fc, offset, "head");
+      if ((ttUSHORT(fc+hd+44) & 7) != (flags & 7)) return 0;
+   }
 
-	nm = stbtt__find_table(fc, offset, "name");
-	if (!nm) return 0;
+   nm = stbtt__find_table(fc, offset, "name");
+   if (!nm) return 0;
 
-	if (flags) {
-		// if we checked the macStyle flags, then just check the family and ignore the subfamily
-		if (stbtt__matchpair(fc, nm, name, nlen, 16, -1))  return 1;
-		if (stbtt__matchpair(fc, nm, name, nlen, 1, -1))  return 1;
-		if (stbtt__matchpair(fc, nm, name, nlen, 3, -1))  return 1;
-	}
-	else {
-		if (stbtt__matchpair(fc, nm, name, nlen, 16, 17))  return 1;
-		if (stbtt__matchpair(fc, nm, name, nlen, 1, 2))  return 1;
-		if (stbtt__matchpair(fc, nm, name, nlen, 3, -1))  return 1;
-	}
+   if (flags) {
+      // if we checked the macStyle flags, then just check the family and ignore the subfamily
+      if (stbtt__matchpair(fc, nm, name, nlen, 16, -1))  return 1;
+      if (stbtt__matchpair(fc, nm, name, nlen,  1, -1))  return 1;
+      if (stbtt__matchpair(fc, nm, name, nlen,  3, -1))  return 1;
+   } else {
+      if (stbtt__matchpair(fc, nm, name, nlen, 16, 17))  return 1;
+      if (stbtt__matchpair(fc, nm, name, nlen,  1,  2))  return 1;
+      if (stbtt__matchpair(fc, nm, name, nlen,  3, -1))  return 1;
+   }
 
-	return 0;
+   return 0;
 }
 
-STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *font_collection, const char *name_utf8, stbtt_int32 flags)
+static int stbtt_FindMatchingFont_internal(unsigned char *font_collection, char *name_utf8, stbtt_int32 flags)
 {
-	stbtt_int32 i;
-	for (i = 0;; ++i) {
-		stbtt_int32 off = stbtt_GetFontOffsetForIndex(font_collection, i);
-		if (off < 0) return off;
-		if (stbtt__matches((stbtt_uint8 *)font_collection, off, (stbtt_uint8*)name_utf8, flags))
-			return off;
-	}
+   stbtt_int32 i;
+   for (i=0;;++i) {
+      stbtt_int32 off = stbtt_GetFontOffsetForIndex(font_collection, i);
+      if (off < 0) return off;
+      if (stbtt__matches((stbtt_uint8 *) font_collection, off, (stbtt_uint8*) name_utf8, flags))
+         return off;
+   }
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+
+STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,
+                                float pixel_height, unsigned char *pixels, int pw, int ph,
+                                int first_char, int num_chars, stbtt_bakedchar *chardata)
+{
+   return stbtt_BakeFontBitmap_internal((unsigned char *) data, offset, pixel_height, pixels, pw, ph, first_char, num_chars, chardata);
+}
+
+STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index)
+{
+   return stbtt_GetFontOffsetForIndex_internal((unsigned char *) data, index);   
+}
+
+STBTT_DEF int stbtt_GetNumberOfFonts(const unsigned char *data)
+{
+   return stbtt_GetNumberOfFonts_internal((unsigned char *) data);
+}
+
+STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data, int offset)
+{
+   return stbtt_InitFont_internal(info, (unsigned char *) data, offset);
+}
+
+STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *fontdata, const char *name, int flags)
+{
+   return stbtt_FindMatchingFont_internal((unsigned char *) fontdata, (char *) name, flags);
+}
+
+STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const char *s2, int len2)
+{
+   return stbtt_CompareUTF8toUTF16_bigendian_internal((char *) s1, len1, (char *) s2, len2);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif // STB_TRUETYPE_IMPLEMENTATION
 
 
 // FULL VERSION HISTORY
 //
+//   1.19 (2018-02-11) OpenType GPOS kerning (horizontal only), STBTT_fmod
+//   1.18 (2018-01-29) add missing function
+//   1.17 (2017-07-23) make more arguments const; doc fix
+//   1.16 (2017-07-12) SDF support
+//   1.15 (2017-03-03) make more arguments const
+//   1.14 (2017-01-16) num-fonts-in-TTC function
+//   1.13 (2017-01-02) support OpenType fonts, certain Apple fonts
+//   1.12 (2016-10-25) suppress warnings about casting away const with -Wcast-qual
+//   1.11 (2016-04-02) fix unused-variable warning
+//   1.10 (2016-04-02) allow user-defined fabs() replacement
+//                     fix memory leak if fontsize=0.0
+//                     fix warning from duplicate typedef
 //   1.09 (2016-01-16) warning fix; avoid crash on outofmem; use alloc userdata for PackFontRanges
 //   1.08 (2015-09-13) document stbtt_Rasterize(); fixes for vertical & horizontal edges
 //   1.07 (2015-08-01) allow PackFontRanges to accept arrays of sparse codepoints;
@@ -3299,3 +4809,45 @@ STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *font_collection, const
 //   0.2  (2009-03-11) Fix unsigned/signed char warnings
 //   0.1  (2009-03-09) First public release
 //
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this 
+software, either in source code form or as a compiled binary, for any purpose, 
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this 
+software dedicate any and all copyright interest in the software to the public 
+domain. We make this dedication for the benefit of the public at large and to 
+the detriment of our heirs and successors. We intend this dedication to be an 
+overt act of relinquishment in perpetuity of all present and future rights to 
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN 
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/


### PR DESCRIPTION
**3rdparty**
- Update stb_image.h
> 2.19  (2018-02-11) fix warning
> 2.18  (2018-01-30) fix warnings
> 2.17  (2018-01-29) bugfix, 1-bit BMP, 16-bitness query, fix warnings
> 2.16  (2017-07-23) all functions have 16-bit variants; optimizations; bugfixes
> 2.15  (2017-03-18) fix png-1,2,4; all Imagenet JPGs; no runtime SSE detection on GCC
> 2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
> 2.13  (2016-12-04) experimental 16-bit API, only for PNG so far; fixes
> 2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
> 2.11  (2016-04-02) 16-bit PNGS; enable SSE2 in non-gcc x64
                         RGB-format JPEG; remove white matting in PSD;
                         allocate large structures on the stack;
                         correct channel count for PNG & BMP
- Update stb_truetype.h
> 1.19 (2018-02-11) GPOS kerning, STBTT_fmod
> 1.18 (2018-01-29) add missing function
> 1.17 (2017-07-23) make more arguments const; doc fix
> 1.16 (2017-07-12) SDF support
> 1.15 (2017-03-03) make more arguments const
> 1.14 (2017-01-16) num-fonts-in-TTC function
> 1.13 (2017-01-02) support OpenType fonts, certain Apple fonts
> 1.12 (2016-10-25) suppress warnings about casting away const with -Wcast-qual
> 1.11 (2016-04-02) fix unused-variable warning
> 1.10 (2016-04-02) user-defined fabs(); rare memory leak; remove duplicate typedef