### PR TITLE
hle: make cellSubDisplayInit returns CELL_SUBDISPLAY_ERROR_ZERO_REGISTERED

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSubDisplay.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSubDisplay.cpp
@@ -29,7 +29,7 @@ void fmt_class_string<CellSubDisplayError>::format(std::string& out, u64 arg)
 error_code cellSubDisplayInit(vm::ptr<CellSubDisplayParam> pParam, vm::ptr<CellSubDisplayHandler> func, vm::ptr<void> userdata, u32 container)
 {
 	cellSubDisplay.todo("cellSubDisplayInit(pParam=*0x%x, func=*0x%x, userdata=*0x%x, container=0x%x)", pParam, func, userdata, container);
-	return CELL_OK;
+	return CELL_SUBDISPLAY_ERROR_ZERO_REGISTERED;
 }
 
 error_code cellSubDisplayEnd()


### PR DESCRIPTION
It simulates the fact we don't have a remote play device registered.

Affected Games:
- [X] Class of Heroes 2G can now go **Ingame**, previously [Loadable](https://forums.rpcs3.net/thread-195309.html).
- [X] Guacamelee! (Playable Demo) can now go **Ingame** with Interpreter (fast), previously [Intro](https://forums.rpcs3.net/thread-196580.html).
- [X] SingStar® Guitar, no changes.

Screenshots:
![screenshot from 2018-05-03 21-55-29](https://user-images.githubusercontent.com/25406440/39600510-3e1977ba-4f1f-11e8-8af9-14092a062b80.png)
![screenshot from 2018-05-03 21-55-53](https://user-images.githubusercontent.com/25406440/39600513-3fea3c28-4f1f-11e8-990d-a00af9f5ab34.png)
![screenshot from 2018-05-03 21-57-07](https://user-images.githubusercontent.com/25406440/39600516-41202a94-4f1f-11e8-8ba1-c0319e2d7a00.png)
![screenshot from 2018-05-03 21-57-27](https://user-images.githubusercontent.com/25406440/39600518-42811268-4f1f-11e8-810d-a64bcc296a93.png)

