### PR TITLE
Fix max stacksize

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1472,6 +1472,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	case 0x50: primary_stacksize = 256 * 1024; break; // SYS_PROCESS_PRIMARY_STACK_SIZE_256K
 	case 0x60: primary_stacksize = 512 * 1024; break; // SYS_PROCESS_PRIMARY_STACK_SIZE_512K
 	case 0x70: primary_stacksize = 1024 * 1024; break; // SYS_PROCESS_PRIMARY_STACK_SIZE_1M
+	default:   primary_stacksize = std::clamp<u32>(primary_stacksize, 0x8000, 0x100000); break;
 	}
 
 	// Initialize main thread

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -358,11 +358,11 @@ void ppu_thread::on_init(const std::shared_ptr<void>& _this)
 
 		// Make the gap inaccessible
 		vm::page_protect(new_stack_base, 4096, 0, 0, vm::page_readable + vm::page_writable);
-
-		gpr[1] = ::align(stack_addr + stack_size, 0x200) - 0x200;
-
-		cpu_thread::on_init(_this);
 	}
+
+	gpr[1] = ::align(stack_addr + stack_size, 0x200) - 0x200;
+
+	cpu_thread::on_init(_this);
 }
 
 //sets breakpoint, does nothing if there is a breakpoint there already
@@ -703,11 +703,11 @@ ppu_thread::~ppu_thread()
 	}
 }
 
-ppu_thread::ppu_thread(const std::string& name, u32 prio, u32 stack)
+ppu_thread::ppu_thread(const std::string& name, u32 prio, u32 stack, u32 stack_addr)
 	: cpu_thread(idm::last_id())
 	, prio(prio)
-	, stack_size(stack >= 0x1000 ? ::align(std::min<u32>(stack, 0x100000), 0x1000) : 0x4000)
-	, stack_addr(0)
+	, stack_size(stack >= 0x1000 ? ::align(stack, 0x1000) : 0x4000)
+	, stack_addr(stack_addr)
 	, start_time(get_system_time())
 	, m_name(name)
 {

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -41,7 +41,7 @@ public:
 	virtual void cpu_unmem() override;
 	virtual ~ppu_thread() override;
 
-	ppu_thread(const std::string& name, u32 prio = 0, u32 stack = 0x10000);
+	ppu_thread(const std::string& name, u32 prio = 0, u32 stack = 0x10000, u32 stack_addr = 0);
 
 	u64 gpr[32] = {}; // General-Purpose Registers
 	f64 fpr[32] = {}; // Floating Point Registers


### PR DESCRIPTION
Akiba's Trip 2 creates a thread with stacksize 0x110000, and with the current stacksize clamp to 0x100000 it runs out of stack space and crashes. If I up the max stacksize to 0x110000 the game works and goes ingame. 

This raised the question of what the actual max stacksize is. Thanks to @TGEnigma for helping and doing HW tests which showed that `_sys_ppu_thread_create` will create threads fine with a much larger stacksize than 0x110000. It's just limited by system memory.

Edit: I would also like to change VM::stack size to 0x0D001000 in vm.cpp:775 as that seems to be the maximum size you can do on a real ps3 but I'd to hear Nekos thoughts first.

So I added a check in `_sys_ppu_thread_create` and removed the limit in `ppu_thread()`

![image](https://user-images.githubusercontent.com/26828095/39656702-1677bff8-5002-11e8-9e5c-4ba07cd2ba40.png)

stack size test: https://cdn.discordapp.com/attachments/272082353759715328/442128808691367937/PS3_PPU_ThreadStackSizeTest.self