### PR TITLE
""""Fix"""" Bourne Demo

### DIFF
--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -601,11 +601,11 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 	// Get next reliable function address
 	auto get_limit = [&](u32 addr) -> u32
 	{
-		for (auto it = fmap.lower_bound(addr), end = fmap.end(); it != end; it++)
+		for (auto& entry: fmap)
 		{
-			if (test(it->second.attr, ppu_attr::known_addr))
+			if (test(entry.second.attr, ppu_attr::known_addr))
 			{
-				return it->first;
+				return entry.first;
 			}
 		}
 


### PR DESCRIPTION
~~I think this is a compiler optimization bug as this code looks functionally identical to the previous code.~~

But, I swear BOURNE DEMO INTRO NOW!!

(It still freezes the emulator, but only after showing a couple screens now.  Unfortunately, the new freeze point is less suspicious when I pause the game. As, the main_thread is running assembly, and the main thread is running Qt stuff.