### PR TITLE
Fix compile with Qt 5.11

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -10,6 +10,7 @@
 #include <QSpinBox>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QButtonGroup>
 #include <QTimer>
 
 #include "qt_utils.h"


### PR DESCRIPTION
QButtonGroup is no longer an implicit include.