### PR TITLE
Make Travis happy again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	ignore = dirty
 [submodule "llvm"]
 	path = llvm
-	url = https://github.com/RPCS3/llvm
+	url = https://github.com/llvm-mirror/llvm
 	branch = release_60
 [submodule "GSL"]
 	path = 3rdparty/GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
     fi;
 
 before_script:
-  - git submodule update --init llvm asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng Utilities/yaml-cpp 3rdparty/cereal 3rdparty/hidapi 3rdparty/Optional Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
+  - git submodule update --init asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng Utilities/yaml-cpp 3rdparty/cereal 3rdparty/hidapi 3rdparty/Optional Vulkan/glslang Vulkan/Vulkan-LoaderAndValidationLayers
   - mkdir build ; cd build
   - export CMAKE_PREFIX_PATH=~/Qt/${QTVER}/gcc_64/lib/cmake
   - if [ "$TRAVIS_PULL_REQUEST" = false ]; then
@@ -100,6 +100,7 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-6.0
       - sourceline: 'ppa:jonathonf/binutils' # We need to update binutils to a newer version to link against the ffmpeg libs on.
       - sourceline: 'ppa:beineri/opt-qt-5.10.1-trusty' # <<WARNING>>: This needs to be updated manually whenever the QT Version changes. Add QT PPA since the installer is quite bad.
     packages:
@@ -113,6 +114,8 @@ addons:
       #- libvulkan1
       #- libvulkan-dev
       - libc6-dev
+      - llvm-6.0
+      - llvm-6.0-dev
       # Clang 5.0 is now bundled in travis, so we no longer need the ppa version.
       #- clang-4.0
       - libedit-dev

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -181,7 +181,7 @@ set(CMAKE_MODULE_PATH "${RPCS3_SRC_DIR}/cmake_modules")
 find_package(OpenGL REQUIRED)
 find_package(OpenAL REQUIRED)
 if(NOT WITHOUT_LLVM)
-	find_package(LLVM 999.666 CONFIG)
+	find_package(LLVM 6.0 CONFIG)
 	if(NOT LLVM_FOUND)
 		message("LLVM will be built from the submodule.")
 


### PR DESCRIPTION
Temporarily use upstream llvm instead of the one from RPCS3. Like this, Travis will not fail to build and then we can merge a couple of PRs :smile:
AppVeyor needs to be updated as well to stay in sync with these changes (not done here)