### PR TITLE
Added "(experimental)" next to the SPU LLVM Recompiler

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -107,7 +107,7 @@
               <item>
                <widget class="QRadioButton" name="spu_llvm">
                 <property name="text">
-                 <string>LLVM Recompiler</string>
+                 <string>LLVM Recompiler (experimental)</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
All of the other PPU and SPU Decoders have something in parentheses next to them, so I added 
"(experimental)" next to the SPU LLVM Recompiler so it doesn't look weird.