### PR TITLE
Debian dependencies updated in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you want to contribute please take a look at the [Coding Style](https://githu
 ### Linux
 * [Qt 5.10+](https://www.qt.io/download-open-source/)
 * GCC 5.1+ or Clang 3.5.0+ ([not GCC 6.1](https://github.com/RPCS3/rpcs3/issues/1691))
-* Debian & Ubuntu: `sudo apt-get install cmake build-essential libasound2-dev libpulse-dev libopenal-dev libglew-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git qt5-default`
+* Debian & Ubuntu: `sudo apt-get install cmake build-essential libasound2-dev libpulse-dev libopenal-dev libglew-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git qt5-default qtbase5-private-dev qtdeclarative5-dev`
 * Arch: `sudo pacman -S glew openal cmake llvm qt5-base`
 * Fedora: `sudo dnf install cmake glew glew-devel libatomic libudev-devel openal-devel qt5-devel vulkan-devel`
 * OpenSUSE: `sudo zypper install git cmake libasound2 libpulse-devel openal-soft-devel glew-devel zlib-devel libedit-devel vulkan-devel libudev-devel libqt5-qtbase-devel libevdev-devel`


### PR DESCRIPTION
RPCS3 wont build on Debian with current dependency list as some packages are missing.
This PR fixes that.