### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -4,6 +4,7 @@
 #define ASMJIT_DEBUG
 
 #include "asmjit.h"
+#include <array>
 #include <functional>
 
 namespace asmjit


### PR DESCRIPTION
Regressed by #4580. See [error log](https://ptpb.pw/yCeF). GCC/libstdc++ probably bootlegs `<array>` via another header unlike clang/libc++.
