### PR TITLE
Performance Overlay

### DIFF
--- a/Utilities/CPUStats.h
+++ b/Utilities/CPUStats.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <Utilities/types.h>
+
+#ifdef _WIN32
+#include "windows.h"
+#include "tlhelp32.h"
+#else
+#include "dirent.h"
+#include "stdlib.h"
+#include "stdio.h"
+#include "string.h"
+#include "sys/times.h"
+#include "sys/types.h"
+#endif
+
+class CPUStats
+{
+#ifdef _WIN32
+	HANDLE m_self;
+	using time_type = ULARGE_INTEGER;
+#else
+	using time_type = clock_t;
+#endif
+
+private:
+	s32 m_num_processors;
+	time_type m_last_cpu, m_sys_cpu, m_usr_cpu;
+
+public:
+	CPUStats()
+	{
+#ifdef _WIN32
+		SYSTEM_INFO sysInfo;
+		FILETIME ftime, fsys, fuser;
+
+		GetSystemInfo(&sysInfo);
+		m_num_processors = sysInfo.dwNumberOfProcessors;
+
+		GetSystemTimeAsFileTime(&ftime);
+		memcpy(&m_last_cpu, &ftime, sizeof(FILETIME));
+
+		m_self = GetCurrentProcess();
+		GetProcessTimes(m_self, &ftime, &ftime, &fsys, &fuser);
+		memcpy(&m_sys_cpu, &fsys, sizeof(FILETIME));
+		memcpy(&m_usr_cpu, &fuser, sizeof(FILETIME));
+#else
+		FILE* file;
+		struct tms timeSample;
+		char line[128];
+
+		m_last_cpu = times(&timeSample);
+		m_sys_cpu  = timeSample.tms_stime;
+		m_usr_cpu  = timeSample.tms_utime;
+
+		file             = fopen("/proc/cpuinfo", "r");
+		m_num_processors = 0;
+		while (fgets(line, 128, file) != NULL)
+		{
+			if (strncmp(line, "processor", 9) == 0)
+				m_num_processors++;
+		}
+		fclose(file);
+#endif
+	}
+
+	double get_usage()
+	{
+#ifdef _WIN32
+		FILETIME ftime, fsys, fusr;
+		ULARGE_INTEGER now, sys, usr;
+
+		GetSystemTimeAsFileTime(&ftime);
+		memcpy(&now, &ftime, sizeof(FILETIME));
+
+		GetProcessTimes(m_self, &ftime, &ftime, &fsys, &fusr);
+		memcpy(&sys, &fsys, sizeof(FILETIME));
+		memcpy(&usr, &fusr, sizeof(FILETIME));
+		double percent = (sys.QuadPart - m_sys_cpu.QuadPart) + (usr.QuadPart - m_usr_cpu.QuadPart);
+		percent /= (now.QuadPart - m_last_cpu.QuadPart);
+		percent /= m_num_processors;
+
+		m_last_cpu = now;
+		m_usr_cpu  = usr;
+		m_sys_cpu  = sys;
+
+		return std::clamp(percent * 100, 0.0, 100.0);
+#else
+		struct tms timeSample;
+		clock_t now;
+		double percent;
+
+		now = times(&timeSample);
+		if (now <= m_last_cpu || timeSample.tms_stime < m_sys_cpu || timeSample.tms_utime < m_usr_cpu)
+		{
+			// Overflow detection. Just skip this value.
+			percent = -1.0;
+		}
+		else
+		{
+			percent = (timeSample.tms_stime - m_sys_cpu) + (timeSample.tms_utime - m_usr_cpu);
+			percent /= (now - m_last_cpu);
+			percent /= m_num_processors;
+			percent *= 100;
+		}
+		m_last_cpu = now;
+		m_sys_cpu  = timeSample.tms_stime;
+		m_usr_cpu  = timeSample.tms_utime;
+
+		return percent;
+#endif
+	}
+
+	static u32 get_thread_count()
+	{
+#ifdef _WIN32
+		// first determine the id of the current process
+		DWORD const id = GetCurrentProcessId();
+
+		// then get a process list snapshot.
+		HANDLE const snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0);
+
+		// initialize the process entry structure.
+		PROCESSENTRY32 entry = {0};
+		entry.dwSize         = sizeof(entry);
+
+		// get the first process info.
+		BOOL ret = true;
+		ret      = Process32First(snapshot, &entry);
+		while (ret && entry.th32ProcessID != id)
+		{
+			ret = Process32Next(snapshot, &entry);
+		}
+		CloseHandle(snapshot);
+		return ret ? entry.cntThreads : 0;
+#else
+		u32 thread_count{0};
+
+		DIR* proc_dir = opendir("/proc/self/task");
+		if (proc_dir)
+		{
+			// proc available, iterate through tasks and count them
+			struct dirent* entry;
+			while ((entry = readdir(proc_dir)) != NULL)
+			{
+				if (entry->d_name[0] == '.')
+					continue;
+
+				++thread_count;
+			}
+
+			closedir(proc_dir);
+		}
+		return thread_count;
+#endif
+	}
+};

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -138,6 +138,9 @@ class thread_ctrl final
 	// Fixed name
 	std::string m_name;
 
+	// CPU cycles thread has run for
+	u64 m_cycles{0};
+
 	// Start thread
 	static void start(const std::shared_ptr<thread_ctrl>&, task_stack);
 
@@ -170,6 +173,15 @@ public:
 	const std::string& get_name() const
 	{
 		return m_name;
+	}
+
+	// Get CPU cycles since last time this function was called. First call returns 0.
+	u64 get_cycles();
+
+	// Get platform-specific thread handle
+	std::uintptr_t get_native_handle() const
+	{
+		return m_thread.load();
 	}
 
 	// Get exception

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -523,7 +523,7 @@ namespace gl
 			}
 		}
 
-		void run(u16 w, u16 h, GLuint target, rsx::overlays::user_interface& ui)
+		void run(u16 w, u16 h, GLuint target, rsx::overlays::overlay& ui)
 		{
 			program_handle.uniforms["ui_scale"] = color4f((f32)ui.virtual_width, (f32)ui.virtual_height, 1.f, 1.f);
 			program_handle.uniforms["time"] = (f32)(get_system_time() / 1000) * 0.005f;

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -627,6 +627,7 @@ namespace rsx
 
 			overlay_element() {}
 			overlay_element(u16 _w, u16 _h) : w(_w), h(_h) {}
+			virtual ~overlay_element() = default;
 
 			virtual void refresh()
 			{
@@ -949,7 +950,7 @@ namespace rsx
 
 		struct vertical_layout : public layout_container
 		{
-			overlay_element* add_element(std::unique_ptr<overlay_element>& item, int offset = -1)
+			overlay_element* add_element(std::unique_ptr<overlay_element>& item, int offset = -1) override
 			{
 				if (auto_resize)
 				{
@@ -1023,7 +1024,7 @@ namespace rsx
 
 		struct horizontal_layout : public layout_container
 		{
-			overlay_element* add_element(std::unique_ptr<overlay_element>& item, int offset = -1)
+			overlay_element* add_element(std::unique_ptr<overlay_element>& item, int offset = -1) override
 			{
 				if (auto_resize)
 				{
@@ -1490,7 +1491,7 @@ namespace rsx
 				m_cancel_btn->translate(_x, _y);
 			}
 
-			compiled_resource& get_compiled()
+			compiled_resource& get_compiled() override
 			{
 				if (!is_compiled)
 				{

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -1,0 +1,233 @@
+#include "stdafx.h"
+#include "overlays.h"
+#include "../GSRender.h"
+
+#include "Emu/Cell/SPUThread.h"
+#include "Emu/Cell/RawSPUThread.h"
+#include "Emu/Cell/PPUThread.h"
+#include "Utilities/sysinfo.h"
+
+namespace rsx
+{
+	namespace overlays
+	{
+		void perf_metrics_overlay::reset_body()
+		{
+			m_body.set_font("n023055ms.ttf", m_font_size);
+			m_body.set_pos(50, 50);
+			m_body.fore_color     = {0xFF / 255.f, 0xe1 / 255.f, 0x38 / 255.f, 1.0f};
+			m_body.back_color     = {0x00 / 255.f, 0x23 / 255.f, 0x39 / 255.f, 0.7f};
+			m_body.padding_top    = 0;
+			m_body.padding_bottom = -14;
+			m_body.set_margin(5, 5, 0, 0);
+		}
+
+		void perf_metrics_overlay::reset_titles()
+		{
+			m_titles.set_font("n023055ms.ttf", m_font_size);
+			m_titles.set_pos(50, 50);
+			m_titles.fore_color     = {0xf2 / 256.0, 0x6C / 256.0, 0x24 / 256.0, 1.0f};
+			m_titles.back_color     = {0.0f, 0.0f, 0.0f, 0.0f};
+			m_titles.padding_top    = 0;
+			m_titles.padding_bottom = -14;
+			m_titles.set_margin(5, 5, 0, 0);
+
+			switch (m_detail)
+			{
+			case detail_level::minimal:
+			case detail_level::low: m_titles.text = ""; break;
+			case detail_level::medium: m_titles.text = fmt::format("\n\n%s", title1_medium); break;
+			case detail_level::high: m_titles.text = fmt::format("\n\n%s\n\n\n\n\n\n%s", title1_high, title2); break;
+			}
+			m_titles.auto_resize();
+			m_titles.refresh();
+		}
+
+		void perf_metrics_overlay::init()
+		{
+			reset_titles();
+			reset_body();
+
+			force_next_update();
+			update();
+			m_update_timer.Start();
+		}
+
+		perf_metrics_overlay::perf_metrics_overlay(bool initialize)
+		{
+			// Default values, will change based on config options
+			m_update_interval = 350;
+			m_detail          = detail_level::high;
+			m_font_size       = 10;
+
+			if (initialize)
+				init();
+		}
+
+		// In ms
+		void perf_metrics_overlay::set_update_interval(u32 update_interval)
+		{
+			m_update_interval = update_interval;
+		}
+
+		void perf_metrics_overlay::set_detail_level(detail_level level)
+		{
+			m_detail = level;
+			reset_titles();
+		}
+
+		void perf_metrics_overlay::set_font_size(u32 font_size)
+		{
+			m_font_size = font_size;
+			reset_titles();
+			reset_body();
+		}
+
+		void perf_metrics_overlay::force_next_update()
+		{
+			m_force_update = true;
+		}
+
+		void perf_metrics_overlay::update()
+		{
+			const auto elapsed = m_update_timer.GetElapsedTimeInMilliSec();
+			
+			if (!m_force_update)
+			{
+				++m_frames;
+			}
+
+			if (elapsed >= m_update_interval || m_force_update)
+			{
+				f32 fps{0};
+				f32 frametime{0};
+
+				u64 ppu_cycles{0};
+				u64 spu_cycles{0};
+				u64 rsx_cycles{0};
+				u64 total_cycles{0};
+
+				u32 ppus{0};
+				u32 spus{0};
+				u32 rawspus{0};
+
+				f32 cpu_usage{-1.f};
+				u32 total_threads{0};
+
+				f32 ppu_usage{0};
+				f32 spu_usage{0};
+				f32 rsx_usage{0};
+				u32 rsx_load{0};
+
+				std::shared_ptr<GSRender> rsx_thread;
+
+				std::string perf_text;
+
+				// 1. Fetch/calculate metrics we'll need
+				switch (m_detail)
+				{
+				case detail_level::high:
+				{
+					frametime = m_force_update ? 0 : std::max(0.0, elapsed / m_frames);
+
+					rsx_thread = fxm::get<GSRender>();
+					rsx_load = rsx_thread->get_load();
+
+					total_threads = CPUStats::get_thread_count();
+
+					// fallthrough
+				}
+				case detail_level::medium:
+				{
+					ppus = idm::select<ppu_thread>([&ppu_cycles](u32, ppu_thread& ppu) { ppu_cycles += ppu.get()->get_cycles(); });
+
+					spus = idm::select<SPUThread>([&spu_cycles](u32, SPUThread& spu) { spu_cycles += spu.get()->get_cycles(); });
+
+					rawspus = idm::select<RawSPUThread>([&spu_cycles](u32, RawSPUThread& rawspu) { spu_cycles += rawspu.get()->get_cycles(); });
+
+					if (!rsx_thread)
+						rsx_thread = fxm::get<GSRender>();
+
+					rsx_cycles += rsx_thread->get()->get_cycles();
+
+					total_cycles = ppu_cycles + spu_cycles + rsx_cycles;
+					cpu_usage = m_cpu_stats.get_usage();
+
+					ppu_usage = std::clamp(cpu_usage * ppu_cycles / total_cycles, 0.f, 100.f);
+					spu_usage = std::clamp(cpu_usage * spu_cycles / total_cycles, 0.f, 100.f);
+					rsx_usage = std::clamp(cpu_usage * rsx_cycles / total_cycles, 0.f, 100.f);
+
+					// fallthrough
+				}
+				case detail_level::low:
+				{
+					if (cpu_usage == -1.f)
+						cpu_usage = m_cpu_stats.get_usage();
+
+					// fallthrough
+				}
+				case detail_level::minimal:
+				{
+					fps = m_force_update ? 0 : std::max(0.0, static_cast<f32>(m_frames) / (elapsed / 1000));
+				}
+				}
+
+				// 2. Format output string
+				switch (m_detail)
+				{
+				case detail_level::minimal:
+				{
+					perf_text += fmt::format("FPS : %05.2f", fps);
+					break;
+				}
+				case detail_level::low:
+				{
+					perf_text += fmt::format("FPS : %05.2f\n"
+					                         "CPU : %04.1f %%",
+					    fps, cpu_usage);
+					break;
+				}
+				case detail_level::medium:
+				{
+					perf_text += fmt::format("FPS : %05.2f\n\n"
+					                         "%s\n"
+					                         " PPU   : %04.1f %%\n"
+					                         " SPU   : %04.1f %%\n"
+					                         " RSX   : %04.1f %%\n"
+					                         " Total : %04.1f %%",
+					    fps, std::string(title1_medium.size(), ' '), ppu_usage, spu_usage, rsx_usage, cpu_usage, std::string(title2.size(), ' '));
+					break;
+				}
+				case detail_level::high:
+				{
+					perf_text += fmt::format("FPS : %05.2f (%03.1fms)\n\n"
+					                         "%s\n"
+					                         " PPU   : %04.1f %% (%2u)\n"
+					                         " SPU   : %04.1f %% (%2u)\n"
+					                         " RSX   : %04.1f %% ( 1)\n"
+					                         " Total : %04.1f %% (%2u)\n\n"
+					                         "%s\n"
+					                         " RSX   : %02u %%",
+					    fps, frametime, std::string(title1_high.size(), ' '), ppu_usage, ppus, spu_usage, spus + rawspus, rsx_usage, cpu_usage, total_threads, std::string(title2.size(), ' '), rsx_load);
+					break;
+				}
+				}
+
+				m_body.text = perf_text;
+				m_body.auto_resize();
+				m_body.refresh();
+
+				if (!m_force_update)
+				{
+					m_frames = 0;
+					m_update_timer.Start();
+				}
+				else
+				{
+					// Only force once
+					m_force_update = false;
+				}
+			}
+		}
+	} // namespace overlays
+} // namespace rsx

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -20,12 +20,12 @@ namespace rsx
 				on_close(return_code);
 		}
 
-		void user_interface::refresh()
+		void overlay::refresh()
 		{
 			if (auto rsxthr = rsx::get_current_renderer())
 			{
 				rsxthr->native_ui_flip_request.store(true);
 			}
 		}
-	}
-}
+	} // namespace overlays
+} // namespace rsx

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -355,6 +355,16 @@ namespace rsx
 		if (supports_native_ui)
 		{
 			m_overlay_manager = fxm::make_always<rsx::overlays::display_manager>();
+
+			if (g_cfg.video.perf_overlay.perf_overlay_enabled)
+			{
+				auto perf_overlay = m_overlay_manager->create<rsx::overlays::perf_metrics_overlay>(false);
+
+				perf_overlay->set_detail_level(g_cfg.video.perf_overlay.level);
+				perf_overlay->set_update_interval(g_cfg.video.perf_overlay.update_interval);
+				perf_overlay->set_font_size(g_cfg.video.perf_overlay.font_size);
+				perf_overlay->init();
+			}
 		}
 
 		on_init_thread();

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -654,7 +654,7 @@ namespace vk
 		}
 
 		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::framebuffer* target, VkRenderPass render_pass,
-				vk::vk_data_heap &upload_heap, rsx::overlays::user_interface &ui)
+				vk::vk_data_heap &upload_heap, rsx::overlays::overlay &ui)
 		{
 			m_scale_offset = color4f((f32)ui.virtual_width, (f32)ui.virtual_height, 1.f, 1.f);
 			m_time = (f32)(get_system_time() / 1000) * 0.005f;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -198,6 +198,23 @@ void fmt_class_string<audio_renderer>::format(std::string& out, u64 arg)
 	});
 }
 
+template <>
+inline void fmt_class_string<detail_level>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](detail_level value)
+	{
+		switch (value)
+		{
+		case detail_level::minimal: return "Minimal";
+		case detail_level::low: return "Low";
+		case detail_level::medium: return "Medium";
+		case detail_level::high: return "High";
+		}
+
+		return unknown;
+	});
+}
+
 void Emulator::Init()
 {
 	if (!g_tty)

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -147,6 +147,14 @@ enum class frame_limit_type
 	_auto,
 };
 
+enum class detail_level
+{
+	minimal,
+	low,
+	medium,
+	high,
+};
+
 enum CellNetCtlState : s32;
 enum CellSysutilLang : s32;
 
@@ -392,6 +400,17 @@ struct cfg_root : cfg::node
 			cfg::_bool force_primitive_restart{this, "Force primitive restart flag"};
 
 		} vk{this};
+
+		struct node_perf_overlay : cfg::node
+		{
+			node_perf_overlay(cfg::node* _this) : cfg::node(_this, "Perfomance Overlay") {}
+
+			cfg::_bool perf_overlay_enabled{this, "Enabled", false};
+			cfg::_enum<detail_level> level{this, "Detail level", detail_level::high};
+			cfg::_int<30, 5000> update_interval{this, "Metrics update interval (ms)", 350};
+			cfg::_int<4, 36> font_size{this, "Font size (px)", 10};
+
+		} perf_overlay{this};
 
 	} video{this};
 

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -295,6 +295,7 @@
     </ClCompile>
     <ClCompile Include="Emu\RSX\Null\NullGSRender.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlays.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\overlay_perf_metrics.cpp" />
     <ClCompile Include="Emu\RSX\rsx_methods.cpp" />
     <ClCompile Include="Emu\RSX\rsx_utils.cpp" />
     <ClCompile Include="Crypto\aes.cpp">

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -749,6 +749,9 @@
     <ClCompile Include="Emu\RSX\Overlays\overlays.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\overlay_perf_metrics.cpp">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">


### PR DESCRIPTION
# Summary
This is meant to be a **user-oriented overlay** for getting **real-time performance metrics.**

See discussion in #4500 if you want to see how the design progressed.

# Features
* Other than **FPS**, **frametime** and **RSX Load**, it includes new stats:
  * **How much the PPU, SPU or RSX emulation takes a toll on your CPU.**
  * **How many thread there are, for each of the above.**
  * **Total (process) CPU usage.**
* It makes use of kd's native overlay system so can look much better than the debug overlay.
* I've made 5 "presets", each one with with different levels of detail.
* The following are configurable via the config file as of now:
  * Detail level (preset)
  * Update interval of the metrics
  * Size (dictated by font size)

These will soon(tm) be configurable via GUI (in another PR), for now they're config options.

Currently it uses a font from the firmware so it'll be present everywhere.
Initially I used [this downloaded one](https://user-images.githubusercontent.com/6632271/40274543-996fa2dc-5be1-11e8-8bd9-3496b2f50e1b.png), but I'm not sure if it's worth to include it with RPCS3.

# Screenshots

*Note: They're since opening the PR, so a bit outdated*
In the most detail possible (number in parentheses in Host Utilization is thread count):

![image](https://user-images.githubusercontent.com/6632271/40274462-14d2fa44-5bdf-11e8-99f4-bf37bb3c060e.png)
<details/>
  <summary>Fullscreen</summary>

![image](https://user-images.githubusercontent.com/6632271/40274463-2ff27264-5bdf-11e8-93d5-e294a1bcfc45.png)

</details>

![image](https://user-images.githubusercontent.com/6632271/40274468-6c6a87b8-5bdf-11e8-9485-8ba2941baeca.png)

<details/>
  <summary>Fullscreen</summary>

![image](https://user-images.githubusercontent.com/6632271/40274469-74c98422-5bdf-11e8-8057-bde6617b59c7.png)

</details>

---
Here's all the detail levels:

#### 1. Minimal 
![image](https://user-images.githubusercontent.com/6632271/40274486-e2c3ccb2-5bdf-11e8-92ce-308fffe40739.png)

#### 2. Low 
![image](https://user-images.githubusercontent.com/6632271/40274490-f9fc52f0-5bdf-11e8-8084-5d463c19cd39.png)

#### 3. Medium 
![image](https://user-images.githubusercontent.com/6632271/40274491-127f3e82-5be0-11e8-9e91-92198ec0ced0.png)

#### 4. High 
![image](https://user-images.githubusercontent.com/6632271/40274495-335c1684-5be0-11e8-9d89-db454c9f2660.png)

#### 5. Ultra
![image](https://user-images.githubusercontent.com/6632271/40274462-14d2fa44-5bdf-11e8-99f4-bf37bb3c060e.png)

# Future work

* More stats:
  * PPU/SPU _guest_ load (CPU usage currently shown is probably more useful for users)
  * CPU/GPU model
  * Graphs(?)
* Other possible configurable settings:
  * Text/title/background colors and opacity 
  * Overlay position on the screen
  * Font

# Closing words

~~As the title suggest, this is a WIP, getting some stats in Linux doesn't work yet and I haven't made proper commits (also it's enabled by default, for easier testing).~~

#### That's all, please post feedback!