### PR TITLE
rsx: Fixup

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -976,7 +976,6 @@ namespace rsx
 				no_access_range = region.get_min_max(no_access_range);
 			}
 
-			region.protect(utils::protection::no);
 			region.create(width, height, 1, 1, nullptr, image, pitch, false, std::forward<Args>(extras)...);
 			region.set_context(texture_upload_context::framebuffer_storage);
 			region.set_sampler_status(rsx::texture_sampler_status::status_uninitialized);
@@ -1018,6 +1017,8 @@ namespace rsx
 				}
 			}
 
+			// Delay protection until here in case the invalidation block above has unprotected pages in this range
+			region.reprotect(utils::protection::no, { 0, memory_size });
 			update_cache_tag();
 		}
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -493,13 +493,26 @@ namespace gl
 					require_manual_shuffle = true;
 			}
 
-			if (real_pitch >= rsx_pitch || scaled_texture != 0)
+			if (real_pitch >= rsx_pitch || scaled_texture != 0 || valid_range.second <= rsx_pitch)
 			{
 				memcpy(dst, src, valid_range.second);
 			}
 			else
 			{
-				fmt::throw_exception("Unreachable");
+				if (valid_range.second % rsx_pitch)
+				{
+					fmt::throw_exception("Unreachable" HERE);
+				}
+
+				u8 *_src = (u8*)src;
+				u8 *_dst = (u8*)dst;
+				const auto num_rows = valid_range.second / rsx_pitch;
+				for (u32 row = 0; row < num_rows; ++row)
+				{
+					memcpy(_dst, _src, real_pitch);
+					_src += real_pitch;
+					_dst += rsx_pitch;
+				}
 			}
 
 			if (require_manual_shuffle)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1280,14 +1280,17 @@ namespace rsx
 	{
 		if (!in_begin_end)
 		{
-			reader_lock lock(m_mtx_task);
-			for (const auto& range : m_invalidated_memory_ranges)
+			if (!m_invalidated_memory_ranges.empty())
 			{
-				on_invalidate_memory_range(range.first, range.second);
-			}
+				writer_lock lock(m_mtx_task);
 
-			lock.upgrade();
-			m_invalidated_memory_ranges.clear();
+				for (const auto& range : m_invalidated_memory_ranges)
+				{
+					on_invalidate_memory_range(range.first, range.second);
+				}
+
+				m_invalidated_memory_ranges.clear();
+			}
 		}
 	}
 


### PR DESCRIPTION
- Memory protection fixup. Fixes flickering and missing stuff in some games especially if wcb is enabled.
- Optimize a check in main rsx loop to restore performance lost in https://github.com/RPCS3/rpcs3/pull/4611
- Fix openGL wcb regression ('unreachable' assert)