### PR TITLE
[WIP] Fix for Tales of Vesperia slow animation on Windows.

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -290,26 +290,30 @@ error_code sys_timer_sleep(ppu_thread& ppu, u32 sleep_time)
 
 error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 {
-	if (sleep_time < 10) {
-		u64 start = get_system_time();
-		while ((get_system_time() - start) < sleep_time) {
-			_mm_pause();
-		}
-		return CELL_OK;
-	}
-
-	vm::temporary_unlock(ppu);
+	// Windows OS mininum sleep time is 500 usec (i.e. the timer resolution which is set to 0.5 msec by rpcs3)
+	// TODO - determine Linux value
+	const int os_sleep_resolution_usec = 500;
 
 	sys_timer.trace("sys_timer_usleep(sleep_time=0x%llx)", sleep_time);
 
-	u64 passed = 0;
+	vm::temporary_unlock(ppu);
 
-	lv2_obj::sleep(ppu, std::max<u64>(1, sleep_time));
+	s64 remaining = sleep_time;
+	lv2_obj::sleep(ppu, sleep_time);
 
-	while (sleep_time >= passed)
+	while (remaining > 0)
 	{
-		thread_ctrl::wait_for(std::max<u64>(1, sleep_time - passed));
-		passed = get_system_time() - ppu.start_time;
+		if (remaining > os_sleep_resolution_usec)
+		{
+			thread_ctrl::wait_for(remaining - (remaining % os_sleep_resolution_usec));
+		}
+		else
+		{
+			// ~1 usec on a 4 GHz CPU
+			busy_wait(4000);
+		}
+
+		remaining = sleep_time - (get_system_time() - ppu.start_time);
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -290,6 +290,10 @@ error_code sys_timer_sleep(ppu_thread& ppu, u32 sleep_time)
 
 error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 {
+	if (sleep_time <= 300) {
+		return CELL_OK;
+	}
+
 	vm::temporary_unlock(ppu);
 
 	sys_timer.trace("sys_timer_usleep(sleep_time=0x%llx)", sleep_time);

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -290,7 +290,11 @@ error_code sys_timer_sleep(ppu_thread& ppu, u32 sleep_time)
 
 error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 {
-	if (sleep_time <= 300) {
+	if (sleep_time < 10) {
+		u64 start = get_system_time();
+		while ((get_system_time() - start) < sleep_time) {
+			_mm_pause();
+		}
 		return CELL_OK;
 	}
 


### PR DESCRIPTION
This is a temporary fix for the Tales of Vesperia slow animation issue on Windows https://github.com/RPCS3/rpcs3/issues/4607.

Note this may break (or fix) other games.  For example, I tested Nier and it won't load with this temp fix.  We need a better fix or if failing that we will need a way to enable/disable this fix per game.

Edit - Nier is working now too with the latest change.

As a side effect, Tales of Vesperia performance is greatly improved in most areas.

```
Sleeping dog  
   50 => 60 fps  (20% gain)
Town (top of stairs)
   23 => 29 fps  (26% gain)
Battle
   40 => 100 fps (150% gain, need to use frame limiter now as the animation is too fast :-) )


```


