### PR TITLE
Rsx: Naughty fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -769,7 +769,8 @@ void cellGcmSetInvalidateTile(u8 index)
 
 s32 cellGcmTerminate()
 {
-	fmt::throw_exception("Unimplemented" HERE);
+	// The firmware just return CELL_OK as well
+	return CELL_OK;
 }
 
 s32 cellGcmDumpGraphicsError()

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -992,8 +992,7 @@ s32 cellGcmMapMainMemory(u32 ea, u32 size, vm::ptr<u32> offset)
 {
 	cellGcmSys.warning("cellGcmMapMainMemory(ea=0x%x, size=0x%x, offset=*0x%x)", ea, size, offset);
 
-	if (size == 0) return CELL_OK;
-	if ((ea & 0xFFFFF) || (size & 0xFFFFF)) return CELL_GCM_ERROR_FAILURE;
+	if (!size || (ea & 0xFFFFF) || (size & 0xFFFFF)) return CELL_GCM_ERROR_FAILURE;
 
 	u32 io = RSXIOMem.Map(ea, size);
 

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -919,12 +919,15 @@ s32 cellGcmIoOffsetToAddress(u32 ioOffset, vm::ptr<u32> address)
 {
 	cellGcmSys.trace("cellGcmIoOffsetToAddress(ioOffset=0x%x, address=*0x%x)", ioOffset, address);
 
-	u32 realAddr;
+	const u32 upper12Bits = offsetTable.eaAddress[ioOffset >> 20];
 
-	if (!RSXIOMem.getRealAddr(ioOffset, realAddr))
+	if (static_cast<s16>(upper12Bits) < 0)
+	{
+		cellGcmSys.error("cellGcmIoOffsetToAddress: CELL_GCM_ERROR_FAILURE");
 		return CELL_GCM_ERROR_FAILURE;
+	}
 
-	*address = realAddr;
+	*address = (upper12Bits << 20) | (ioOffset & 0xFFFFF);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.h
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.h
@@ -1,7 +1,5 @@
 #pragma once
 
-
-
 #include "Emu/RSX/GCM.h"
 
 enum
@@ -19,6 +17,8 @@ struct CellGcmOffsetTable
 	vm::bptr<u16> ioAddress;
 	vm::bptr<u16> eaAddress;
 };
+
+void InitOffsetTable();
 
 // Auxiliary functions
 s32 gcmMapEaIoAddress(u32 ea, u32 io, u32 size, bool is_strict);

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -419,8 +419,8 @@ s32 sys_rsx_device_map(vm::ptr<u64> addr, vm::ptr<u64> a2, u32 dev_id)
 		fmt::throw_exception("sys_rsx_device_map: Invalid dev_id %d", dev_id);
 	}
 
-	// a2 seems to not be referenced in cellGcmSys
-	*a2 = 0;
+	// a2 seems to not be referenced in cellGcmSys, tests show this arg is ignored
+	//*a2 = 0;
 
 	*addr = 0x40000000;
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -182,10 +182,13 @@ s32 sys_rsx_context_free(u32 context_id)
 s32 sys_rsx_context_iomap(u32 context_id, u32 io, u32 ea, u32 size, u64 flags)
 {
 	sys_rsx.warning("sys_rsx_context_iomap(context_id=0x%x, io=0x%x, ea=0x%x, size=0x%x, flags=0x%llx)", context_id, io, ea, size, flags);
-	if (size == 0) return CELL_OK;
-	if (RSXIOMem.Map(ea, size, io))
-		return CELL_OK;
-	return CELL_EINVAL;
+
+	if (!RSXIOMem.Map(ea, size, io))
+	{
+		return CELL_EINVAL;
+	}
+
+	return CELL_OK;
 }
 
 /*

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -51,7 +51,7 @@ s32 sys_rsx_memory_allocate(vm::ptr<u32> mem_handle, vm::ptr<u64> mem_addr, u32 
 {
 	sys_rsx.warning("sys_rsx_memory_allocate(mem_handle=*0x%x, mem_addr=*0x%x, size=0x%x, flags=0x%llx, a5=0x%llx, a6=0x%llx, a7=0x%llx)", mem_handle, mem_addr, size, flags, a5, a6, a7);
 
-	*mem_handle = 1;
+	*mem_handle = 0x5a5a5a5b;
 	*mem_addr = vm::falloc(0xC0000000, size, vm::video);
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -9,15 +9,9 @@
 #include "sys_event.h"
 
 
-
 logs::channel sys_rsx("sys_rsx");
 
 extern u64 get_timebased_time();
-
-struct SysRsxConfig {
-	be_t<u32> rsx_event_port{ 0 };
-	u32 driverInfo{ 0 };
-};
 
 u64 rsxTimeStamp() {
 	return get_timebased_time();

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -99,6 +99,12 @@ struct RsxDisplayInfo
 	be_t<u32> height;
 };
 
+struct SysRsxConfig
+{
+	be_t<u32> rsx_event_port{ 0 };
+	u32 driverInfo{ 0 };
+};
+
 // SysCalls
 s32 sys_rsx_device_open();
 s32 sys_rsx_device_close();

--- a/rpcs3/Emu/Memory/Memory.cpp
+++ b/rpcs3/Emu/Memory/Memory.cpp
@@ -51,17 +51,6 @@ bool VirtualMemoryBlock::Map(u32 realaddr, u32 size, u32 addr)
 		return false;
 	}
 
-	for (u32 i = 0; i<m_mapped_memory.size(); ++i)
-	{
-		if (addr >= m_mapped_memory[i].addr && addr + size - 1 <= m_mapped_memory[i].addr + m_mapped_memory[i].size - 1)
-		{
-			// it seems mapping another range inside a previous one is legit on ps3
-			// as long as it's coherent aliasing : offset from EA must match IO offset
-			// example game using this pattern : BCES01584 - the last of us
-			return (addr - m_mapped_memory[i].addr) == (realaddr - m_mapped_memory[i].realAddress);
-		}
-	}
-
 	m_mapped_memory.emplace_back(addr, realaddr, size);
 	return true;
 }

--- a/rpcs3/Emu/Memory/Memory.cpp
+++ b/rpcs3/Emu/Memory/Memory.cpp
@@ -18,8 +18,6 @@ bool VirtualMemoryBlock::IsInMyRange(const u32 addr, const u32 size)
 
 u32 VirtualMemoryBlock::Map(u32 realaddr, u32 size)
 {
-	verify(HERE), (size);
-
 	for (u32 addr = m_range_start; addr <= m_range_start + m_range_size - 1 - GetReservedAmount() - size;)
 	{
 		bool is_good_addr = true;
@@ -48,9 +46,7 @@ u32 VirtualMemoryBlock::Map(u32 realaddr, u32 size)
 
 bool VirtualMemoryBlock::Map(u32 realaddr, u32 size, u32 addr)
 {
-	verify(HERE), (size);
-
-	if (!IsInMyRange(addr, size))
+	if (!size || !IsInMyRange(addr, size))
 	{
 		return false;
 	}

--- a/rpcs3/Emu/Memory/Memory.cpp
+++ b/rpcs3/Emu/Memory/Memory.cpp
@@ -13,35 +13,7 @@ VirtualMemoryBlock* VirtualMemoryBlock::SetRange(const u32 start, const u32 size
 
 bool VirtualMemoryBlock::IsInMyRange(const u32 addr, const u32 size)
 {
-	return addr >= m_range_start && addr + size - 1 <= m_range_start + m_range_size - 1 - GetReservedAmount();
-}
-
-u32 VirtualMemoryBlock::Map(u32 realaddr, u32 size)
-{
-	for (u32 addr = m_range_start; addr <= m_range_start + m_range_size - 1 - GetReservedAmount() - size;)
-	{
-		bool is_good_addr = true;
-
-		// check if address is already mapped
-		for (u32 i = 0; i<m_mapped_memory.size(); ++i)
-		{
-			if ((addr >= m_mapped_memory[i].addr && addr < m_mapped_memory[i].addr + m_mapped_memory[i].size) ||
-				(m_mapped_memory[i].addr >= addr && m_mapped_memory[i].addr < addr + size))
-			{
-				is_good_addr = false;
-				addr = m_mapped_memory[i].addr + m_mapped_memory[i].size;
-				break;
-			}
-		}
-
-		if (!is_good_addr) continue;
-
-		m_mapped_memory.emplace_back(addr, realaddr, size);
-
-		return addr;
-	}
-
-	return 0;
+	return addr >= m_range_start && addr + size <= m_range_start + m_range_size - GetReservedAmount();
 }
 
 bool VirtualMemoryBlock::Map(u32 realaddr, u32 size, u32 addr)
@@ -117,7 +89,7 @@ bool VirtualMemoryBlock::getRealAddr(u32 addr, u32& result)
 	return false;
 }
 
-u32 VirtualMemoryBlock::getMappedAddress(u32 realAddress)
+s32 VirtualMemoryBlock::getMappedAddress(u32 realAddress)
 {
 	for (u32 i = 0; i<m_mapped_memory.size(); ++i)
 	{
@@ -127,7 +99,7 @@ u32 VirtualMemoryBlock::getMappedAddress(u32 realAddress)
 		}
 	}
 
-	return 0;
+	return -1;
 }
 
 bool VirtualMemoryBlock::Reserve(u32 size)
@@ -151,4 +123,14 @@ bool VirtualMemoryBlock::Unreserve(u32 size)
 u32 VirtualMemoryBlock::GetReservedAmount()
 {
 	return m_reserve_size;
+}
+
+u32 VirtualMemoryBlock::GetRangeStart()
+{
+	return m_range_start;
+}
+
+u32 VirtualMemoryBlock::GetRangeEnd()
+{
+	return m_range_start + m_range_size - GetReservedAmount();
 }

--- a/rpcs3/Emu/Memory/MemoryBlock.h
+++ b/rpcs3/Emu/Memory/MemoryBlock.h
@@ -51,10 +51,8 @@ public:
 	u32 GetSize() const { return m_range_size; }
 	bool IsInMyRange(const u32 addr, const u32 size);
 
-	// maps real address to virtual address space, returns the mapped address or 0 on failure (if no address is specified the
-	// first mappable space is used)
+	// maps real address to virtual address space
 	bool Map(u32 realaddr, u32 size, u32 addr);
-	u32 Map(u32 realaddr, u32 size);
 
 	// Unmap real address (please specify only starting point, no midway memory will be unmapped), returns the size of the unmapped area
 	bool UnmapRealAddress(u32 realaddr, u32& size);
@@ -70,6 +68,12 @@ public:
 
 	// Return the total amount of reserved memory
 	u32 GetReservedAmount();
+
+	// Return the start of the mapped space
+	u32 GetRangeStart();
+
+	// Return the end of the mapped space
+	u32 GetRangeEnd();
 
 	bool Read32(const u32 addr, u32* value);
 
@@ -92,6 +96,6 @@ public:
 		return realAddr;
 	}
 
-	// return the mapped address given a real address, if not mapped return 0
-	u32 getMappedAddress(u32 realAddress);
+	// return the mapped address given a real address, if not mapped return minus one
+	s32 getMappedAddress(u32 realAddress);
 };

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -11,6 +11,8 @@
 #include "Capture/rsx_capture.h"
 #include "rsx_methods.h"
 #include "rsx_utils.h"
+#include "Emu/Cell/lv2/sys_event.h"
+#include "Emu/Cell/Modules/cellGcmSys.h"
 
 #include "Utilities/GSL.h"
 #include "Utilities/StrUtil.h"
@@ -26,6 +28,8 @@ class GSRender;
 bool user_asked_for_frame_capture = false;
 rsx::frame_trace_data frame_debug;
 rsx::frame_capture_data frame_capture;
+
+extern CellGcmOffsetTable offsetTable;
 
 namespace rsx
 {
@@ -2332,6 +2336,28 @@ namespace rsx
 
 	void thread::on_notify_memory_unmapped(u32 base_address, u32 size)
 	{
+		{
+			s32 io_addr = RSXIOMem.getMappedAddress(base_address);
+			if (io_addr >= 0)
+			{
+				if (!isHLE)
+				{
+					const u64 unmap_key = u64((1ull << (size >> 20)) - 1) << ((io_addr >> 20) & 0x3f);
+					const u64 gcm_flag = 0x100000000ull << (io_addr >> 26);
+					sys_event_port_send(fxm::get<SysRsxConfig>()->rsx_event_port, 0, gcm_flag, unmap_key);
+				}
+				else
+				{
+					const u32 end = (base_address + size) >> 20;
+					for (base_address >>= 20, io_addr >>= 20; base_address < end;) 
+					{
+						offsetTable.ioAddress[base_address++] = 0xFFFF;
+						offsetTable.eaAddress[io_addr++] = 0xFFFF;
+					}
+				}
+			}
+		}
+
 		writer_lock lock(m_mtx_task);
 		m_invalidated_memory_ranges.push_back({ base_address, size });
 	}


### PR DESCRIPTION
Allow sys_mmapper to unmap rsx mapped memory - a little background
from hw testing, when `sys_mmapper` unmaps memory that was mapped to rsx memory, it notifies the kernel that this memory can be remapped for rsx later on, doing that fixes `cellGcmMapMainMemory` offset return values.
the fix for this was different in hle and lle `cellgcm`
`cellgcm` hle fix- set memory "unmapped" status values in the rsx offset table in `sys_mmapper` and check them later in `cellGcmMapMainMemory`.
`cellgcm` lle fix- notify the gcm interrupt thread about freeing rsx mappped memory in sys_mmapper
(credit to @jarveson for figuring out how sys_mmapper communicates with cellgcm, I figured the data's encryption in the notification event and how the gcm knows the address and the size of the memory that was unmapped.)
a few naughty dog games not only use this feature but check the offset values returned from this call.



# games improved
**Uncharted 2 can now go ingame!** (with lle libvdec)
**Uncharted 3 goes to menu for the first time!**
**The Last Of Us no longer traps on cutscenes** (but still requires a save because of a segfault in video closing sequance.)

![image](https://user-images.githubusercontent.com/18193363/40575766-9e93d5fa-60f3-11e8-8a73-ad868bce8902.png)

cheers!
