### PR TITLE
More stuff

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -301,10 +301,15 @@ void D3D12GSRender::on_exit()
 	return GSRender::on_exit();
 }
 
-void D3D12GSRender::do_local_task(bool)
+void D3D12GSRender::do_local_task(rsx::FIFO_state state)
 {
-	//TODO
-	m_frame->clear_wm_events();
+	if (state != rsx::FIFO_state::lock_wait)
+	{
+		//TODO
+		m_frame->clear_wm_events();
+	}
+
+	rsx::thread::do_local_task(state);
 }
 
 bool D3D12GSRender::do_method(u32 cmd, u32 arg)

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -173,7 +173,7 @@ private:
 protected:
 	virtual void on_init_thread() override;
 	virtual void on_exit() override;
-	virtual void do_local_task(bool idle) override;
+	virtual void do_local_task(rsx::FIFO_state state) override;
 	virtual bool do_method(u32 cmd, u32 arg) override;
 	virtual void end() override;
 	virtual void flip(int buffer) override;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -35,15 +35,23 @@ namespace gl
 
 struct work_item
 {
-	std::condition_variable cv;
-	std::mutex guard_mutex;
-
 	u32  address_to_flush = 0;
 	gl::texture_cache::thrashed_set section_data;
 
 	volatile bool processed = false;
 	volatile bool result = false;
 	volatile bool received = false;
+
+	void producer_wait()
+	{
+		while (!processed)
+		{
+			_mm_lfence();
+			std::this_thread::yield();
+		}
+
+		received = true;
+	}
 };
 
 struct driver_state

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -381,7 +381,7 @@ protected:
 	bool do_method(u32 id, u32 arg) override;
 	void flip(int buffer) override;
 
-	void do_local_task(bool idle) override;
+	void do_local_task(rsx::FIFO_state state) override;
 
 	bool on_access_violation(u32 address, bool is_writing) override;
 	void on_invalidate_memory_range(u32 address_base, u32 size) override;

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -339,7 +339,8 @@ namespace rsx
 					std::remove_if(m_dirty_list.begin(), m_dirty_list.end(), [&uids](std::unique_ptr<user_interface>& e)
 					{
 						return std::find(uids.begin(), uids.end(), e->uid) != uids.end();
-					})
+					}),
+					m_dirty_list.end()
 				);
 			}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -499,7 +499,7 @@ namespace rsx
 			}
 
 			//Execute backend-local tasks first
-			do_local_task(performance_counters.state != FIFO_state::running);
+			do_local_task(performance_counters.state);
 
 			//Update sub-units
 			zcull_ctrl->update(this);
@@ -1276,9 +1276,9 @@ namespace rsx
 		}
 	}
 
-	void thread::do_local_task(bool /*idle*/)
+	void thread::do_local_task(FIFO_state state)
 	{
-		if (!in_begin_end)
+		if (!in_begin_end && state != FIFO_state::lock_wait)
 		{
 			if (!m_invalidated_memory_ranges.empty())
 			{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -87,6 +87,7 @@ namespace rsx
 		empty = 1,    // PUT == GET
 		spinning = 2, // Puller continuously jumps to self addr (synchronization technique)
 		nop = 3,      // Puller is processing a NOP command
+		lock_wait = 4 // Puller is processing a lock acquire
 	};
 
 	u32 get_vertex_type_size_on_host(vertex_base_type type, u32 size);
@@ -417,9 +418,8 @@ namespace rsx
 
 		/**
 		 * Execute a backend local task queue
-		 * Idle argument checks that the FIFO queue is in an idle state
 		 */
-		virtual void do_local_task(bool idle);
+		virtual void do_local_task(FIFO_state state);
 
 	public:
 		virtual std::string get_name() const override;
@@ -544,6 +544,11 @@ namespace rsx
 		 * Any data held in the defined range is discarded
 		 */
 		void on_notify_memory_unmapped(u32 address_base, u32 size);
+
+		/**
+		 * Notify to check internal state during semaphore wait
+		 */
+		void on_semaphore_acquire_wait() { do_local_task(FIFO_state::lock_wait); }
 
 		/**
 		 * Copy rtt values to buffer.

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -351,7 +351,6 @@ private:
 
 	u8 m_draw_buffers_count = 0;
 	bool m_flush_draw_buffers = false;
-	std::atomic<int> m_last_flushable_cb = {-1 };
 	
 	shared_mutex m_flush_queue_mutex;
 	flush_request_task m_flush_requests;
@@ -420,7 +419,7 @@ protected:
 	bool do_method(u32 id, u32 arg) override;
 	void flip(int buffer) override;
 
-	void do_local_task(bool idle) override;
+	void do_local_task(rsx::FIFO_state state) override;
 	bool scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate) override;
 	void notify_tile_unbound(u32 tile) override;
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -241,7 +241,7 @@ struct flush_request_task
 		while (pending_state.load())
 		{
 			_mm_lfence();
-			_mm_pause();
+			std::this_thread::yield();
 		}
 	}
 };


### PR DESCRIPTION
- Evade semaphore acquire deadlock by constantly pinging rsx thread during spinwait to check for cyclic dependencies. Sometimes, the very thread that is supposed to wake rsx is stuck waiting for rsx to consume an event.
- Simplify task queue management and use yield instead of busy_wait to hopefully reduce audio stutter on i5s.
- Fix silly bug causing native UI crashes when trophy popup closes.