### PR TITLE
fix memory mapping alignment

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -279,7 +279,14 @@ error_code sys_mmapper_map_shared_memory(u32 addr, u32 mem_id, u64 flags)
 
 	const auto mem = idm::get<lv2_obj, lv2_memory>(mem_id, [&](lv2_memory& mem) -> CellError
 	{
-		if (addr % mem.align)
+		const u32 page_alignment = area->flags & SYS_MEMORY_PAGE_SIZE_1M ? 0x100000 : 0x10000;
+
+		if (mem.align < page_alignment)
+		{
+			return CELL_EINVAL;
+		}
+
+		if (addr % page_alignment)
 		{
 			return CELL_EALIGN;
 		}


### PR DESCRIPTION
it seems like `sys_mmapper_map_shared_memory` checks address alignment not based on the alignment specified by mem_id, but from it's address region's. (that is specified with `sys_mmapper_allocate_address`).
quite a few games are in the nothing catagory because of it ha.
testcase : https://github.com/elad335/myps3tests/tree/master/ppu_tests/sys_mmapper
example games : PES 2016, 2017, 2018

![image](https://user-images.githubusercontent.com/18193363/40680406-b1132224-638e-11e8-8abb-609c301e936c.png)
