### PR TITLE
Qt: Add a gui tab and performance overlay options to the settings dialog

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -403,7 +403,7 @@ struct cfg_root : cfg::node
 
 		struct node_perf_overlay : cfg::node
 		{
-			node_perf_overlay(cfg::node* _this) : cfg::node(_this, "Perfomance Overlay") {}
+			node_perf_overlay(cfg::node* _this) : cfg::node(_this, "Performance Overlay") {}
 
 			cfg::_bool perf_overlay_enabled{this, "Enabled", false};
 			cfg::_enum<detail_level> level{this, "Detail level", detail_level::high};

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -52,13 +52,6 @@
 		"disableFIFOReordering": "Disables RSX FIFO optimizations completely. Draws are processed as they are received by the DMA puller."
 	},
 	"emulator": {
-		"gui": {
-			"configs": "Only useful to developers.\nIf unsure, don't use this option.",
-			"stylesheets": "Changes the overall look of RPCS3.\nChoose a stylesheet and click Apply to change between styles.",
-			"show_welcome": "Shows the initial welcome screen upon starting RPCS3.",
-			"useRichPresence": "Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to apply.",
-			"custom_colors": "Prioritize custom user interface colors over properties set in stylesheet."
-		},
 		"misc": {
 			"exitOnStop": "Automatically close RPCS3 when closing a game, or when a game closes itself.",
 			"alwaysStart": "Leave this enabled unless you are a developer.",
@@ -95,6 +88,13 @@
 			"disableVertexCache": "Disables the vertex cache.\nMight resolve missing or flickering graphics output.\nMay degrade performance.",
 			"stretchToDisplayArea": "Overrides the aspect ratio and stretches the image to the full display area."
 		}
+	},
+	"gui": {
+		"configs": "Only useful to developers.\nIf unsure, don't use this option.",
+		"stylesheets": "Changes the overall look of RPCS3.\nChoose a stylesheet and click Apply to change between styles.",
+		"show_welcome": "Shows the initial welcome screen upon starting RPCS3.",
+		"useRichPresence": "Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to apply.",
+		"custom_colors": "Prioritize custom user interface colors over properties set in stylesheet."
 	},
 	"input": {
 		"padHandlerBox": "If you want to use the keyboard to control, select the Keyboard option.\nIf you have a DualShock 4, select DualShock 4.\nIf you have an Xbox controller, or another compatible device, use XInput.\nOlder controllers such as PS2 controllers with an adapter usually work fine with MMJoystick.\nCheck button mappings in the Windows control panel.",

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -63,6 +63,12 @@
 			"maxLLVMThreads": "Limits the maximum number of threads used for PPU Module compilation.\nLower this in order to increase performance of other open applications.\nThe default uses all available threads.",
 			"showShaderCompilationHint": "Show shader compilation hints using the native overlay.",
 			"useNativeInterface": "Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, only the English language is supported."
+		},
+		"overlay": {
+			"perfOverlayEnabled": "Enables or disables the performance overlay.",
+			"perfOverlayDetailLevel": "Controls the amount of information displayed on the performance overlay.",
+			"perfOverlayUpdateInterval": "Sets the time interval in which the performance overlay is being updated (measured in milliseconds).",
+			"perfOverlayFontSize": "Sets the font size of the performance overlay (measured in pixels)."
 		}
 	},
 	"gpu": {

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -68,6 +68,12 @@ public:
 		DisableOnDiskShaderCache,
 		DisableVulkanMemAllocator,
 
+		// Performance Overlay
+		PerfOverlayEnabled,
+		PerfOverlayDetailLevel,
+		PerfOverlayUpdateInterval,
+		PerfOverlayFontSize,
+
 		// Audio
 		AudioRenderer,
 		DumpToFile,
@@ -223,12 +229,18 @@ private:
 		{ DisableFIFOReordering,    { "Video", "Disable FIFO Reordering" }},
 		{ ForceCPUBlitEmulation,    { "Video", "Force CPU Blit" }},
 		{ DisableOnDiskShaderCache, { "Video", "Disable On-Disk Shader Cache"}},
-		{ DisableVulkanMemAllocator, { "Video", "Disable Vulkan Memory Allocator" }},
+		{ DisableVulkanMemAllocator,{ "Video", "Disable Vulkan Memory Allocator" }},
 		{ AnisotropicFilterOverride,{ "Video", "Anisotropic Filter Override" }},
 		{ ResolutionScale,          { "Video", "Resolution Scale" }},
 		{ MinimumScalableDimension, { "Video", "Minimum Scalable Dimension" }},
 		{ D3D12Adapter,             { "Video", "D3D12", "Adapter"}},
 		{ VulkanAdapter,            { "Video", "Vulkan", "Adapter"}},
+
+		// Performance Overlay
+		{ PerfOverlayEnabled,       { "Video", "Performance Overlay", "Enabled" } },
+		{ PerfOverlayDetailLevel,   { "Video", "Performance Overlay", "Detail level" } },
+		{ PerfOverlayUpdateInterval,{ "Video", "Performance Overlay", "Metrics update interval (ms)" } },
+		{ PerfOverlayFontSize,      { "Video", "Performance Overlay", "Font size (px)" } },
 
 		// Audio
 		{ AudioRenderer,  { "Audio", "Renderer"}},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -39,6 +39,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xgui_settings->SetValue(gui::m_showDebugTab, showDebugTab);
 	if (!showDebugTab)
 	{
+		ui->tab_widget_settings->removeTab(8);
+	}
+	if (game)
+	{
 		ui->tab_widget_settings->removeTab(7);
 	}
 
@@ -50,6 +54,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	SubscribeDescription(ui->description_system);
 	SubscribeDescription(ui->description_network);
 	SubscribeDescription(ui->description_emulator);
+	SubscribeDescription(ui->description_gui);
 	SubscribeDescription(ui->description_debug);
 
 	// read tooltips from json
@@ -76,8 +81,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	QJsonObject json_net   = json_obj.value("network").toObject();
 
 	QJsonObject json_emu      = json_obj.value("emulator").toObject();
-	QJsonObject json_emu_gui  = json_emu.value("gui").toObject();
 	QJsonObject json_emu_misc = json_emu.value("misc").toObject();
+
+	QJsonObject json_gui = json_obj.value("gui").toObject();
 
 	QJsonObject json_debug = json_obj.value("debug").toObject();
 
@@ -693,21 +699,11 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	SubscribeTooltip(ui->maxLLVMThreads, json_emu_misc["maxLLVMThreads"].toString());
 	ui->maxLLVMThreads->setItemText(ui->maxLLVMThreads->findData("0"), tr("All (%1)").arg(std::thread::hardware_concurrency()));
 
-	SubscribeTooltip(ui->combo_configs, json_emu_gui["configs"].toString());
-
-	SubscribeTooltip(ui->combo_stylesheets, json_emu_gui["stylesheets"].toString());
-
 	// Checkboxes
 
 	SubscribeTooltip(ui->gs_resizeOnBoot, json_emu_misc["gs_resizeOnBoot"].toString());
 
 	SubscribeTooltip(ui->gs_disableMouse, json_emu_misc["gs_disableMouse"].toString());
-
-	SubscribeTooltip(ui->cb_show_welcome, json_emu_gui["show_welcome"].toString());
-
-	SubscribeTooltip(ui->cb_custom_colors, json_emu_gui["custom_colors"].toString());
-
-	SubscribeTooltip(ui->useRichPresence, json_emu_gui["useRichPresence"].toString());
 
 	xemu_settings->EnhanceCheckBox(ui->exitOnStop, emu_settings::ExitRPCS3OnFinish);
 	SubscribeTooltip(ui->exitOnStop, json_emu_misc["exitOnStop"].toString());
@@ -730,14 +726,71 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xemu_settings->EnhanceCheckBox(ui->showShaderCompilationHint, emu_settings::ShowShaderCompilationHint);
 	SubscribeTooltip(ui->showShaderCompilationHint, json_emu_misc["showShaderCompilationHint"].toString());
 
-	if (game)
+	if (!game)
 	{
-		ui->gb_stylesheets->setEnabled(false);
-		ui->gb_settings->setEnabled(false);
-		ui->gb_colors->setEnabled(false);
-		ui->gb_viewport->setEnabled(false);
+		ui->gs_disableMouse->setChecked(xgui_settings->GetValue(gui::gs_disableMouse).toBool());
+		connect(ui->gs_disableMouse, &QCheckBox::clicked, [=](bool val)
+		{
+			xgui_settings->SetValue(gui::gs_disableMouse, val);
+		});
+
+		bool enableButtons = xgui_settings->GetValue(gui::gs_resize).toBool();
+		ui->gs_resizeOnBoot->setChecked(enableButtons);
+		ui->gs_width->setEnabled(enableButtons);
+		ui->gs_height->setEnabled(enableButtons);
+
+		QRect screen = QApplication::desktop()->screenGeometry();
+		int width = xgui_settings->GetValue(gui::gs_width).toInt();
+		int height = xgui_settings->GetValue(gui::gs_height).toInt();
+		ui->gs_width->setValue(std::min(width, screen.width()));
+		ui->gs_height->setValue(std::min(height, screen.height()));
+
+		connect(ui->gs_resizeOnBoot, &QCheckBox::clicked, [=](bool val)
+		{
+			xgui_settings->SetValue(gui::gs_resize, val);
+			ui->gs_width->setEnabled(val);
+			ui->gs_height->setEnabled(val);
+		});
+		connect(ui->gs_width, &QSpinBox::editingFinished, [=]()
+		{
+			ui->gs_width->setValue(std::min(ui->gs_width->value(), QApplication::desktop()->screenGeometry().width()));
+			xgui_settings->SetValue(gui::gs_width, ui->gs_width->value());
+		});
+		connect(ui->gs_height, &QSpinBox::editingFinished, [=]()
+		{
+			ui->gs_height->setValue(std::min(ui->gs_height->value(), QApplication::desktop()->screenGeometry().height()));
+			xgui_settings->SetValue(gui::gs_height, ui->gs_height->value());
+		});
+
+		ui->useRichPresence->setChecked(xgui_settings->GetValue(gui::m_richPresence).toBool());
+
+		connect(ui->useRichPresence, &QCheckBox::clicked, [=](bool val)
+		{
+			xgui_settings->SetValue(gui::m_richPresence, val);
+		});
 	}
-	else
+
+	//     _____  _    _  _   _______    _     
+	//    / ____|| |  | || | |__   __|  | |    
+	//   | |  __|| |  | || |    | | __ _| |__  
+	//   | | |_ || |  | || |    | |/ _` | '_ \
+	//   | |__| || |__| || |    | | (_| | |_) |
+	//    \_____| \____/ |_|    |_|\__,_|_.__/ 
+
+	// Comboboxes
+	SubscribeTooltip(ui->combo_configs, json_gui["configs"].toString());
+
+	SubscribeTooltip(ui->combo_stylesheets, json_gui["stylesheets"].toString());
+
+	// Checkboxes:
+	SubscribeTooltip(ui->cb_custom_colors, json_gui["custom_colors"].toString());
+
+	// Checkboxes: gui options
+	SubscribeTooltip(ui->cb_show_welcome, json_gui["show_welcome"].toString());
+
+	SubscribeTooltip(ui->useRichPresence, json_gui["useRichPresence"].toString());
+
+	if (!game)
 	{
 		// colorize preview icons
 		auto addColoredIcon = [&](QPushButton *button, const QColor& color, const QIcon& icon = QIcon(), const QColor& iconColor = QColor())
@@ -874,47 +927,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		connect(ui->pb_tool_icon_color, &QAbstractButton::clicked, [=]()
 		{
 			colorDialog(gui::mw_toolIconColor, tr("Choose tool icon color"), ui->pb_tool_icon_color);
-		});
-
-		ui->gs_disableMouse->setChecked(xgui_settings->GetValue(gui::gs_disableMouse).toBool());
-		connect(ui->gs_disableMouse, &QCheckBox::clicked, [=](bool val)
-		{
-			xgui_settings->SetValue(gui::gs_disableMouse, val);
-		});
-
-		bool enableButtons = xgui_settings->GetValue(gui::gs_resize).toBool();
-		ui->gs_resizeOnBoot->setChecked(enableButtons);
-		ui->gs_width->setEnabled(enableButtons);
-		ui->gs_height->setEnabled(enableButtons);
-
-		QRect screen = QApplication::desktop()->screenGeometry();
-		int width = xgui_settings->GetValue(gui::gs_width).toInt();
-		int height = xgui_settings->GetValue(gui::gs_height).toInt();
-		ui->gs_width->setValue(std::min(width, screen.width()));
-		ui->gs_height->setValue(std::min(height, screen.height()));
-
-		connect(ui->gs_resizeOnBoot, &QCheckBox::clicked, [=](bool val)
-		{
-			xgui_settings->SetValue(gui::gs_resize, val);
-			ui->gs_width->setEnabled(val);
-			ui->gs_height->setEnabled(val);
-		});
-		connect(ui->gs_width, &QSpinBox::editingFinished, [=]()
-		{
-			ui->gs_width->setValue(std::min(ui->gs_width->value(), QApplication::desktop()->screenGeometry().width()));
-			xgui_settings->SetValue(gui::gs_width, ui->gs_width->value());
-		});
-		connect(ui->gs_height, &QSpinBox::editingFinished, [=]()
-		{
-			ui->gs_height->setValue(std::min(ui->gs_height->value(), QApplication::desktop()->screenGeometry().height()));
-			xgui_settings->SetValue(gui::gs_height, ui->gs_height->value());
-		});
-
-		ui->useRichPresence->setChecked(xgui_settings->GetValue(gui::m_richPresence).toBool());
-
-		connect(ui->useRichPresence, &QCheckBox::clicked, [=](bool val)
-		{
-			xgui_settings->SetValue(gui::m_richPresence, val);
 		});
 
 		AddConfigs();

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>816</width>
-    <height>570</height>
+    <width>752</width>
+    <height>519</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1229,13 +1229,6 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_41">
               <item>
-               <widget class="QCheckBox" name="cb_show_welcome">
-                <property name="text">
-                 <string>Show Welcome Screen</string>
-                </property>
-               </widget>
-              </item>
-              <item>
                <widget class="QCheckBox" name="exitOnStop">
                 <property name="text">
                  <string>Exit RPCS3 when process finishes</string>
@@ -1281,13 +1274,6 @@
                <widget class="QCheckBox" name="showShaderCompilationHint">
                 <property name="text">
                  <string>Show shader compilation hint</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="useRichPresence">
-                <property name="text">
-                 <string>Use Discord Rich Presence</string>
                 </property>
                </widget>
               </item>
@@ -1419,68 +1405,89 @@
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="gb_colors">
-             <property name="title">
-              <string>UI Colors</string>
+            <spacer name="verticalSpacer_14">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_13">
-              <item>
-               <widget class="QCheckBox" name="cb_custom_colors">
-                <property name="text">
-                 <string>Use custom UI Colors</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_tool_bar_color">
-                <property name="text">
-                 <string>Main window tool bar</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_tool_icon_color">
-                <property name="text">
-                 <string>Main window tool icons</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_gl_icon_color">
-                <property name="text">
-                 <string>Gamelist icons</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_5">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::MinimumExpanding</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
+             <property name="sizeType">
+              <enum>QSizePolicy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_58">
+          <layout class="QVBoxLayout" name="verticalLayout_58"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_11">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::MinimumExpanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_62">
+         <property name="title">
+          <string>Description</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_45">
+          <item>
+           <widget class="QLabel" name="description_emulator">
+            <property name="text">
+             <string>Point your mouse at an option to display a description in here.
+
+
+</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="guiTab">
+      <attribute name="title">
+       <string>GUI</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_43">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_9">
            <item>
             <widget class="QGroupBox" name="gb_stylesheets">
              <property name="title">
               <string>UI Stylesheets</string>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_43">
+             <layout class="QVBoxLayout" name="verticalLayout_55">
               <item>
                <widget class="QComboBox" name="combo_stylesheets"/>
               </item>
@@ -1494,6 +1501,83 @@
              </layout>
             </widget>
            </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_10">
+             <item>
+              <widget class="QGroupBox" name="gb_colors">
+               <property name="title">
+                <string>UI Colors</string>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_13">
+                <item>
+                 <widget class="QCheckBox" name="cb_custom_colors">
+                  <property name="text">
+                   <string>Use custom UI Colors</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="pb_tool_bar_color">
+                  <property name="text">
+                   <string>Main window tool bar</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="pb_tool_icon_color">
+                  <property name="text">
+                   <string>Main window tool icons</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="pb_gl_icon_color">
+                  <property name="text">
+                   <string>Gamelist icons</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer_5">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::MinimumExpanding</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_4">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_8">
            <item>
             <widget class="QGroupBox" name="gb_settings">
              <property name="title">
@@ -1522,7 +1606,17 @@
                </widget>
               </item>
               <item>
-               <spacer name="verticalSpacer_4">
+               <widget class="QComboBox" name="combo_configs"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="pb_apply_config">
+                <property name="text">
+                 <string>Apply</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_15">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
                 </property>
@@ -1537,15 +1631,48 @@
                 </property>
                </spacer>
               </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_66">
+           <item>
+            <widget class="QGroupBox" name="gb_gui_options">
+             <property name="title">
+              <string>UI Options</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_65">
               <item>
-               <widget class="QComboBox" name="combo_configs"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pb_apply_config">
+               <widget class="QCheckBox" name="cb_show_welcome">
                 <property name="text">
-                 <string>Apply</string>
+                 <string>Show Welcome Screen</string>
                 </property>
                </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="useRichPresence">
+                <property name="text">
+                 <string>Use Discord Rich Presence</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_17">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>13</width>
+                  <height>13</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
              </layout>
             </widget>
@@ -1555,7 +1682,7 @@
         </layout>
        </item>
        <item>
-        <spacer name="verticalSpacer_11">
+        <spacer name="verticalSpacer_16">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -1571,13 +1698,13 @@
         </spacer>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_62">
+        <widget class="QGroupBox" name="groupBox_64">
          <property name="title">
           <string>Description</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_45">
+         <layout class="QVBoxLayout" name="verticalLayout_64">
           <item>
-           <widget class="QLabel" name="description_emulator">
+           <widget class="QLabel" name="description_gui">
             <property name="text">
              <string>Point your mouse at an option to display a description in here.
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -36,7 +36,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>7</number>
+      <number>6</number>
      </property>
      <widget class="QWidget" name="coreTab">
       <attribute name="title">
@@ -1401,29 +1401,106 @@
                 </item>
                </layout>
               </item>
+              <item>
+               <spacer name="verticalSpacer_14">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
              </layout>
             </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_14">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::MinimumExpanding</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-            </spacer>
            </item>
           </layout>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_58"/>
+          <layout class="QVBoxLayout" name="verticalLayout_58">
+           <item>
+            <widget class="QGroupBox" name="gb_performance_overlay">
+             <property name="title">
+              <string>Performance Overlay</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_67">
+              <item>
+               <widget class="QCheckBox" name="perfOverlayEnabled">
+                <property name="text">
+                 <string>Enable performance overlay</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_detail_level">
+                <property name="text">
+                 <string>Detail Level:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="perfOverlayDetailLevel"/>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_update_interval">
+                <property name="text">
+                 <string>Update Interval:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSlider" name="perfOverlayUpdateInterval">
+                <property name="singleStep">
+                 <number>10</number>
+                </property>
+                <property name="pageStep">
+                 <number>100</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_font_size">
+                <property name="text">
+                 <string>Font Size: </string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSlider" name="perfOverlayFontSize">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_18">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>55</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>


### PR DESCRIPTION
This is mainly to make space in the emulator tab for overlay stuff