### PR TITLE
Parallel shader cache loading

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -88,4 +88,5 @@ public:
 	virtual void ProgressBarSetMsg(u32 progressBarIndex, const std::string& msg) = 0;
 	virtual void ProgressBarReset(u32 progressBarIndex) = 0;
 	virtual void ProgressBarInc(u32 progressBarIndex, u32 delta) = 0;
+	virtual void ProgressBarSetLimit(u32 index, u32 limit) = 0;
 };

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -151,8 +151,7 @@ protected:
 			return std::forward_as_tuple(I->second, true);
 		}
 		LOG_NOTICE(RSX, "VP not found in buffer!");
-
-		vertex_program_type &new_shader = m_vertex_shader_cache[rsx_vp];
+		vertex_program_type& new_shader = m_vertex_shader_cache[rsx_vp];
 		backend_traits::recompile_vertex_program(rsx_vp, new_shader, m_next_id++);
 
 		return std::forward_as_tuple(new_shader, false);
@@ -172,7 +171,6 @@ protected:
 		std::memcpy(fragment_program_ucode_copy, rsx_fp.addr, fragment_program_size);
 		RSXFragmentProgram new_fp_key = rsx_fp;
 		new_fp_key.addr = fragment_program_ucode_copy;
-
 		fragment_program_type &new_shader = m_fragment_shader_cache[new_fp_key];
 		backend_traits::recompile_fragment_program(rsx_fp, new_shader, m_next_id++);
 
@@ -310,9 +308,8 @@ public:
 		LOG_NOTICE(RSX, "*** fp id = %d", fragment_program.id);
 
 		pipeline_storage_type pipeline = backend_traits::build_pipeline(vertex_program, fragment_program, pipelineProperties, std::forward<Args>(args)...);
-		s_mtx.lock();
+		std::lock_guard<std::mutex> lock(s_mtx);
 		auto &rtn = m_storage[key] = std::move(pipeline);
-		s_mtx.unlock();
 		m_cache_miss_flag = true;
 
 		LOG_SUCCESS(RSX, "New program compiled successfully");

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -857,7 +857,7 @@ void GLGSRender::on_init_thread()
 
 			void update_msg(u32 index, u32 processed, u32 entry_count) override
 			{
-				char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
+				const char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
 				dlg->progress_bar_set_message(index, fmt::format(text, processed, entry_count));
 				owner->flip(0);
 			}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -845,7 +845,7 @@ void GLGSRender::on_init_thread()
 			{
 				MsgDialogType type = {};
 				type.disable_cancel = true;
-				type.progress_bar_count = 1;
+				type.progress_bar_count = 2;
 
 				dlg = fxm::get<rsx::overlays::display_manager>()->create<rsx::overlays::message_dialog>();
 				dlg->show("Loading precompiled shaders from disk...", type, [](s32 status)
@@ -855,15 +855,22 @@ void GLGSRender::on_init_thread()
 				});
 			}
 
-			void update_msg(u32 processed, u32 entry_count) override
+			void update_msg(u32 index, u32 processed, u32 entry_count) override
 			{
-				dlg->progress_bar_set_message(0, fmt::format("Loading pipeline object %u of %u", processed, entry_count));
+				char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
+				dlg->progress_bar_set_message(index, fmt::format(text, processed, entry_count));
 				owner->flip(0);
 			}
 
-			void inc_value(u32 value) override
+			void inc_value(u32 index, u32 value) override
 			{
-				dlg->progress_bar_increment(0, (f32)value);
+				dlg->progress_bar_increment(index, (f32)value);
+				owner->flip(0);
+			}
+
+			void set_limit(u32 index, u32 limit) override
+			{
+				dlg->progress_bar_set_limit(index, limit);
 				owner->flip(0);
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
+++ b/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
@@ -102,6 +102,12 @@ public:
 		getGraphicPipelineState(vp, fp, props, std::forward<Args>(args)...);
 	}
 
+    void preload_programs(RSXVertexProgram &vp, RSXFragmentProgram &fp)
+    {
+		search_vertex_program(vp);
+		search_fragment_program(fp);
+    }
+
 	bool check_cache_missed() const
 	{
 		return m_cache_miss_flag;

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -938,7 +938,8 @@ namespace rsx
 				return CELL_OK;
 			}
 
-			s32 progress_bar_set_limit(u32 index, u32 limit) {
+			s32 progress_bar_set_limit(u32 index, u32 limit)
+			{
 				if (index >= num_progress_bars)
 					return CELL_MSGDIALOG_ERROR_PARAM;
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -937,6 +937,18 @@ namespace rsx
 
 				return CELL_OK;
 			}
+
+			s32 progress_bar_set_limit(u32 index, u32 limit) {
+				if (index >= num_progress_bars)
+					return CELL_MSGDIALOG_ERROR_PARAM;
+
+				if (index == 0)
+					progress_1.set_limit((float)limit);
+				else
+					progress_2.set_limit((float)limit);
+
+				return CELL_OK;
+			}
 		};
 
 		struct trophy_notification : public user_interface

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1610,7 +1610,7 @@ void VKGSRender::on_init_thread()
 
 			void update_msg(u32 index, u32 processed, u32 entry_count) override
 			{
-				char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
+				const char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
 				dlg->progress_bar_set_message(index, fmt::format(text, processed, entry_count));
 				owner->flip(0);
 			}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1598,7 +1598,7 @@ void VKGSRender::on_init_thread()
 			{
 				MsgDialogType type = {};
 				type.disable_cancel = true;
-				type.progress_bar_count = 1;
+				type.progress_bar_count = 2;
 
 				dlg = fxm::get<rsx::overlays::display_manager>()->create<rsx::overlays::message_dialog>();
 				dlg->show("Loading precompiled shaders from disk...", type, [](s32 status)
@@ -1608,15 +1608,22 @@ void VKGSRender::on_init_thread()
 				});
 			}
 
-			void update_msg(u32 processed, u32 entry_count) override
+			void update_msg(u32 index, u32 processed, u32 entry_count) override
 			{
-				dlg->progress_bar_set_message(0, fmt::format("Loading pipeline object %u of %u", processed, entry_count));
+				char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
+				dlg->progress_bar_set_message(index, fmt::format(text, processed, entry_count));
 				owner->flip(0);
 			}
 
-			void inc_value(u32 value) override
+			void inc_value(u32 index, u32 value) override
 			{
-				dlg->progress_bar_increment(0, (f32)value);
+				dlg->progress_bar_increment(index, (f32)value);
+				owner->flip(0);
+			}
+
+			void set_limit(u32 index, u32 limit) override
+			{
+				dlg->progress_bar_set_limit(index, limit);
 				owner->flip(0);
 			}
 

--- a/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
@@ -208,6 +208,13 @@ public:
 		getGraphicPipelineState(vp, fp, props, std::forward<Args>(args)...);
 	}
 
+    void preload_programs(RSXVertexProgram &vp, RSXFragmentProgram &fp)
+    {
+        vp.skip_vertex_input_check = true;
+        search_vertex_program(vp);
+        search_fragment_program(fp);
+    }
+
 	bool check_cache_missed() const
 	{
 		return m_cache_miss_flag;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -8,6 +8,7 @@
 #include "Emu/System.h"
 
 #include "rsx_utils.h"
+#include <thread>
 
 namespace rsx
 {

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -412,7 +412,7 @@ namespace rsx
 				dlg = Emu.GetCallbacks().get_msg_dialog();
 				dlg->type.se_normal = true;
 				dlg->type.bg_invisible = true;
-				dlg->type.progress_bar_count = 1;
+				dlg->type.progress_bar_count = 2;
 				dlg->on_close = [](s32 status)
 				{
 					Emu.CallAfter([]()
@@ -437,7 +437,8 @@ namespace rsx
 			{
 				Emu.CallAfter([=]()
 				{
-					dlg->ProgressBarSetMsg(0, fmt::format("Loading pipeline object %u of %u", processed, entry_count));
+					const char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
+					dlg->ProgressBarSetMsg(index, fmt::format(text, processed, entry_count));
 				});
 			}
 
@@ -445,12 +446,17 @@ namespace rsx
 			{
 				Emu.CallAfter([=]()
 				{
-					dlg->ProgressBarInc(0, value);
+					dlg->ProgressBarInc(index, value);
 				});
 			}
 			
 			virtual void set_limit(u32 index, u32 limit)
-			{}
+			{
+				Emu.CallAfter([=]()
+				{
+					dlg->ProgressBarSetLimit(index, limit);
+				});
+			}
 
 			virtual void close()
 			{}

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -394,6 +394,22 @@ void msg_dialog_frame::ProgressBarInc(u32 index, u32 delta)
 	}
 }
 
+void msg_dialog_frame::ProgressBarSetLimit(u32 index, u32 limit)
+{
+	if (m_dialog)
+	{
+		if (index == 0 && m_gauge1)
+		{
+			m_gauge1->setMaximum(limit);
+		}
+
+		if (index == 1 && m_gauge2)
+		{
+			m_gauge2->setMaximum(limit);
+		}
+	}
+}
+
 #ifdef HAVE_QTDBUS
 void msg_dialog_frame::UpdateProgress(int progress, bool disable)
 {

--- a/rpcs3/rpcs3qt/msg_dialog_frame.h
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.h
@@ -67,6 +67,7 @@ public:
 	virtual void ProgressBarSetMsg(u32 progressBarIndex, const std::string& msg) override;
 	virtual void ProgressBarReset(u32 progressBarIndex) override;
 	virtual void ProgressBarInc(u32 progressBarIndex, u32 delta) override;
+	virtual void ProgressBarSetLimit(u32 index, u32 limit) override;
 #ifdef HAVE_QTDBUS
 private:
 	void UpdateProgress(int progress, bool disable = false);


### PR DESCRIPTION
Use all available threads during the initial shader compilation process in hopes of speeding it up.

The code is mostly unchanged and has multi-threading essentially hammered into it. The result isn't exactly pretty but hey, it works.

Multi-threaded path in Vulkan only, at least for now.