### PR TITLE
Fix for Tales of Vesperia half screen issue [WIP]

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -131,6 +131,7 @@ namespace rsx
 	public:
 		std::array<std::tuple<u32, surface_type>, 4> m_bound_render_targets = {};
 		std::tuple<u32, surface_type> m_bound_depth_stencil = {};
+		std::tuple<u32, surface_type> m_surface_change_bound_render_target;
 
 		std::list<surface_storage_type> invalidated_resources;
 		u64 cache_tag = 0ull;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -358,6 +358,15 @@ namespace rsx
 		bool m_vertex_textures_dirty[4];
 		bool m_framebuffer_state_contested = false;
 		u32  m_graphics_state = 0;
+		bool m_surface_change_valid = false;
+		u32 m_surface_change_address;
+		u32 m_surface_change_width;
+		u32 m_surface_change_height;
+		u32 m_surface_change_pitch;
+		surface_color_format m_surface_change_color_format;
+		u32 m_surface_zeta_surface_address;
+		surface_depth_format m_surface_zeta_surface_format;
+		u32 m_surface_zeta_surface_pitch;
 
 	protected:
 		std::array<u32, 4> get_color_surface_addresses() const;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -377,6 +377,24 @@ namespace rsx
 			rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty | rsx::pipeline_state::fragment_program_dirty;
 		}
 
+		
+		void set_shader_window(thread* rsxthr, u32 _reg, u32 arg)	
+		{
+			if (!rsxthr->m_surface_change_valid)
+			{
+				rsxthr->m_surface_change_valid = true;
+				rsxthr->m_surface_change_address = rsx::get_address(rsx::method_registers.surface_a_offset(), rsx::method_registers.surface_a_dma());
+				rsxthr->m_surface_change_width = rsx::method_registers.surface_clip_width();
+				rsxthr->m_surface_change_height = rsx::method_registers.surface_clip_height();
+				rsxthr->m_surface_change_color_format = rsx::method_registers.surface_color();
+				rsxthr->m_surface_change_pitch = rsx::method_registers.surface_a_pitch();
+				rsxthr->m_surface_zeta_surface_address = rsx::get_address(rsx::method_registers.surface_z_offset(), rsx::method_registers.surface_z_dma());
+				rsxthr->m_surface_zeta_surface_format = rsx::method_registers.surface_depth_fmt();
+				rsxthr->m_surface_zeta_surface_pitch = rsx::method_registers.surface_z_pitch();
+			}
+
+		}
+
 		void set_begin_end(thread* rsxthr, u32 _reg, u32 arg)
 		{
 			if (arg)
@@ -1739,7 +1757,9 @@ namespace rsx
 		bind<NV4097_INVALIDATE_L2, nv4097::invalidate_L2>();
 		bind<NV4097_SET_TRANSFORM_PROGRAM_START, nv4097::set_transform_program_start>();
 		bind<NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK, nv4097::set_vertex_attribute_output_mask>();
+		bind<NV4097_SET_SHADER_WINDOW, nv4097::set_shader_window>();
 
+		
 		//NV308A
 		bind_range<NV308A_COLOR, 1, 256, nv308a::color>();
 		bind_range<NV308A_COLOR + 256, 1, 512, nv308a::color, 256>();


### PR DESCRIPTION
**WIP** 
This is a **_very_** hacky fix for the Tales of Vesperia half screen issue (see https://github.com/RPCS3/rpcs3/issues/4357).  

The screen renders with normal width now, but there are visible artifacts (half the screen is blurry/out of focus).

This solution is obviously not sufficient and I'd like to discuss alternate approaches in this PR.

**Problem**

RPCS3 is missing cellGcmSetSurface / cellGcmSetSurfaceWindow  calls from the game.  The reason is that we look at the surface state at the beginning of rendering, rather than hooking the appropriate register write.

SetSurface => SetSurfaceWindow => CELL_GCM_METHOD_SET_SHADER_WINDOW =>CELL_GCM_NV4097_SET_SHADER_WINDOW

Without hooking the register write, I see the game setting the 0xC0000000 surface as follows:
```

prepare_rtts: render target CHANGED - clip_width = 2560, clip_height = 576
prepare_render_target: surface address = c0000000

prepare_rtts: render target CHANGED - clip_width = 1280, clip_height = 576
prepare_render_target: surface address = c0730000


```

In other words, the 0xC0000000 surface does not get reset to 1280 x 576.

If I instead hook the register write (NV4097_SET_SHADER_WINDOW), I see

```

set_shader_window - width = 2560, height = 576, surface0 = c0000000, surface1 = c0000000, surface2 = c0000000, surface3 = c0000000
prepare_rtts: render target CHANGED - clip_width = 2560, clip_height = 576
prepare_render_target: surface address = c0000000

						
set_shader_window - width = 1280, height = 576, surface0 = c0000000, surface1 = c0000000, surface2 = c0000000, surface3 = c0000000	=> this is being dropped
set_shader_window - width = 1280, height = 576, surface0 = c0730000, surface1 = c0000000, surface2 = c0000000, surface3 = c0000000							

prepare_rtts: render target CHANGED - clip_width = 1280, clip_height = 576
prepare_render_target: surface address = c0730000

```


**Initial (hacky) solution**
- Hook register write  and save surface state changes (address, width, height)
- On begin rendering, if the saved surface address doesn't match the current surface address => update the saved surface.

Currently, I only save one surface state change.

**Alternate approaches?**
- Call init_buffers on NV4097_SET_SHADER_WINDOW.  I tried this, but it quickly became complicated.

