### PR TITLE
"Simple" fix

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -740,7 +740,7 @@ namespace rsx
 		template <typename T, typename U>
 		inline void get_native_dimensions(T &width, T &height, U surface)
 		{
-			switch (surface->aa_mode)
+			switch (surface->read_aa_mode)
 			{
 			case rsx::surface_antialiasing::center_1_sample:
 				return;
@@ -758,7 +758,7 @@ namespace rsx
 		template <typename T, typename U>
 		inline void get_rsx_dimensions(T &width, T &height, U surface)
 		{
-			switch (surface->aa_mode)
+			switch (surface->read_aa_mode)
 			{
 			case rsx::surface_antialiasing::center_1_sample:
 				return;
@@ -776,7 +776,7 @@ namespace rsx
 		template <typename T>
 		inline f32 get_internal_scaling_x(T surface)
 		{
-			switch (surface->aa_mode)
+			switch (surface->read_aa_mode)
 			{
 			default:
 			case rsx::surface_antialiasing::center_1_sample:
@@ -791,7 +791,7 @@ namespace rsx
 		template <typename T>
 		inline f32 get_internal_scaling_y(T surface)
 		{
-			switch (surface->aa_mode)
+			switch (surface->read_aa_mode)
 			{
 			default:
 			case rsx::surface_antialiasing::center_1_sample:

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1593,8 +1593,8 @@ namespace rsx
 
 			if (requires_processing)
 			{
-				const auto w = rsx::apply_resolution_scale(internal_width, true);
-				const auto h = rsx::apply_resolution_scale(internal_height, true);
+				const auto w = rsx::apply_resolution_scale(std::min<u16>(internal_width, surface_width), true);
+				const auto h = rsx::apply_resolution_scale(std::min<u16>(internal_height, surface_height), true);
 
 				auto command = update_subresource_cache ? deferred_request_command::copy_image_dynamic : deferred_request_command::copy_image_static;
 				return { texptr->get_surface(), command, texaddr, format, 0, 0, w, h, 1,

--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.h
@@ -129,21 +129,17 @@ struct render_target_traits
 	}
 
 	static
-	void invalidate_rtt_surface_contents(
+	void invalidate_surface_contents(
 		gsl::not_null<ID3D12GraphicsCommandList*>,
-		ID3D12Resource*, ID3D12Resource*, bool)
+		ID3D12Resource*, ID3D12Resource*)
 	{}
 
 	static
-	void invalidate_depth_surface_contents(
-		gsl::not_null<ID3D12GraphicsCommandList*>,
-		ID3D12Resource*, ID3D12Resource*, bool)
-	{
-		//TODO
-	}
+	void notify_surface_invalidated(const ComPtr<ID3D12Resource>&)
+	{}
 
 	static
-	void notify_surface_invalidated(const ComPtr<ID3D12Resource>&)
+	void notify_surface_persist(const ComPtr<ID3D12Resource>&)
 	{}
 
 	static

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -465,7 +465,10 @@ void GLGSRender::end()
 	}
 
 	const GLenum draw_mode = gl::draw_mode(rsx::method_registers.current_draw_clause.primitive);
-	bool single_draw = !supports_multidraw || (rsx::method_registers.current_draw_clause.first_count_commands.size() <= 1 || rsx::method_registers.current_draw_clause.is_disjoint_primitive);
+	const bool allow_multidraw = supports_multidraw && !g_cfg.video.disable_FIFO_reordering;
+	const bool single_draw = (!allow_multidraw ||
+		rsx::method_registers.current_draw_clause.first_count_commands.size() <= 1 ||
+		rsx::method_registers.current_draw_clause.is_disjoint_primitive);
 
 	if (upload_info.index_info)
 	{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1632,8 +1632,13 @@ void GLGSRender::synchronize_buffers()
 
 bool GLGSRender::scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate)
 {
-	m_samplers_dirty.store(true);
-	return m_gl_texture_cache.blit(src, dst, interpolate, m_rtts);
+	if (m_gl_texture_cache.blit(src, dst, interpolate, m_rtts))
+	{
+		m_samplers_dirty.store(true);
+		return true;
+	}
+
+	return false;
 }
 
 void GLGSRender::notify_tile_unbound(u32 tile)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -214,6 +214,10 @@ void GLGSRender::end()
 			//Copy data from old contents onto this one
 			const auto region = rsx::get_transferable_region(surface);
 			gl::g_hw_blitter->scale_image(surface->old_contents, surface, { 0, 0, std::get<0>(region), std::get<1>(region) }, { 0, 0, std::get<2>(region) , std::get<3>(region) }, !is_depth, is_depth, {});
+
+			// Memory has been transferred, discard old contents and update memory flags
+			// TODO: Preserve memory outside surface clip region
+			surface->on_write();
 		}
 		//TODO: download image contents and reupload them or do a memory cast to copy memory contents if not compatible
 	};
@@ -275,7 +279,9 @@ void GLGSRender::end()
 	if (ds && ds->old_contents != nullptr && ds->get_rsx_pitch() == static_cast<gl::render_target*>(ds->old_contents)->get_rsx_pitch() &&
 		ds->old_contents->get_internal_format() == gl::texture::internal_format::rgba8)
 	{
+		// TODO: Partial memory transfer
 		m_depth_converter.run(ds->width(), ds->height(), ds->id(), ds->old_contents->id());
+		ds->on_write();
 	}
 
 	if (g_cfg.video.strict_rendering_mode)

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -375,13 +375,13 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 					{
 						if (auto surface = std::get<1>(m_rtts.m_bound_render_targets[index]))
 						{
-							surface->aa_mode = aa_mode;
+							surface->write_aa_mode = aa_mode;
 						}
 					}
 
 					if (auto ds = std::get<1>(m_rtts.m_bound_depth_stencil))
 					{
-						ds->aa_mode = aa_mode;
+						ds->write_aa_mode = aa_mode;
 					}
 
 					return;
@@ -426,7 +426,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 			m_surface_info[i] = { surface_addresses[i], pitchs[i], false, surface_format, depth_format, clip_horizontal, clip_vertical };
 
 			rtt->tile = find_tile(color_offsets[i], color_locations[i]);
-			rtt->aa_mode = aa_mode;
+			rtt->write_aa_mode = aa_mode;
 			m_gl_texture_cache.notify_surface_changed(surface_addresses[i]);
 			m_gl_texture_cache.tag_framebuffer(surface_addresses[i]);
 		}
@@ -455,7 +455,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		std::get<1>(m_rtts.m_bound_depth_stencil)->set_rsx_pitch(rsx::method_registers.surface_z_pitch());
 		m_depth_surface_info = { depth_address, depth_surface_pitch, true, surface_format, depth_format, clip_horizontal, clip_vertical };
 
-		ds->aa_mode = aa_mode;
+		ds->write_aa_mode = aa_mode;
 		m_gl_texture_cache.notify_surface_changed(depth_address);
 
 		m_gl_texture_cache.tag_framebuffer(depth_address);

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -366,7 +366,24 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 			{
 				if (depth_address == m_depth_surface_info.address)
 				{
-					//Nothing has changed, we're still using the same framebuffer
+					// Nothing has changed, we're still using the same framebuffer
+					// Update flags to match current
+
+					const auto aa_mode = rsx::method_registers.surface_antialias();
+
+					for (u32 index = 0; index < 4; index++)
+					{
+						if (auto surface = std::get<1>(m_rtts.m_bound_render_targets[index]))
+						{
+							surface->aa_mode = aa_mode;
+						}
+					}
+
+					if (auto ds = std::get<1>(m_rtts.m_bound_depth_stencil))
+					{
+						ds->aa_mode = aa_mode;
+					}
+
 					return;
 				}
 			}

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -265,7 +265,7 @@ namespace gl
 				if (pbo_id == 0)
 					init_buffer();
 
-				aa_mode = static_cast<gl::render_target*>(image)->aa_mode;
+				aa_mode = static_cast<gl::render_target*>(image)->read_aa_mode;
 			}
 
 			flushed = false;

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -84,8 +84,29 @@ namespace gl
 			s32 old_fbo = 0;
 			glGetIntegerv(GL_FRAMEBUFFER_BINDING, &old_fbo);
 
-			filter interp = linear_interpolation ? filter::linear : filter::nearest;
-			GLenum attachment = is_depth_copy ? GL_DEPTH_ATTACHMENT : GL_COLOR_ATTACHMENT0;
+			filter interp = (linear_interpolation && !is_depth_copy) ? filter::linear : filter::nearest;
+			GLenum attachment;
+			gl::buffers target;
+
+			if (is_depth_copy)
+			{
+				if (src->get_internal_format() == gl::texture::internal_format::depth16 ||
+					dst->get_internal_format() == gl::texture::internal_format::depth16)
+				{
+					attachment = GL_DEPTH_ATTACHMENT;
+					target = gl::buffers::depth;
+				}
+				else
+				{
+					attachment = GL_DEPTH_STENCIL_ATTACHMENT;
+					target = gl::buffers::depth_stencil;
+				}
+			}
+			else
+			{
+				attachment = GL_COLOR_ATTACHMENT0;
+				target = gl::buffers::color;
+			}
 
 			blit_src.bind();
 			glFramebufferTexture2D(GL_FRAMEBUFFER, attachment, GL_TEXTURE_2D, src_id, 0);
@@ -99,7 +120,7 @@ namespace gl
 			if (scissor_test_enabled)
 				glDisable(GL_SCISSOR_TEST);
 
-			blit_src.blit(blit_dst, src_rect, dst_rect, is_depth_copy ? buffers::depth : buffers::color, interp);
+			blit_src.blit(blit_dst, src_rect, dst_rect, target, interp);
 
 			if (xfer_info.dst_is_typeless)
 			{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1137,11 +1137,14 @@ void VKGSRender::end()
 	{
 		if (ds->old_contents->info.format == VK_FORMAT_B8G8R8A8_UNORM)
 		{
+			// TODO: Partial memory transfer
 			auto rp = vk::get_render_pass_location(VK_FORMAT_UNDEFINED, ds->info.format, 0);
 			auto render_pass = m_render_passes[rp];
 			m_depth_converter->run(*m_current_command_buffer, ds->width(), ds->height(), ds,
 				static_cast<vk::render_target*>(ds->old_contents)->get_view(0xAAE4, rsx::default_remap_vector),
 				render_pass, m_framebuffers_to_clean);
+
+			ds->on_write();
 		}
 	}
 
@@ -1162,6 +1165,10 @@ void VKGSRender::end()
 				vk::copy_scaled_image(*m_current_command_buffer, surface->old_contents->value, surface->value,
 					surface->old_contents->current_layout, surface->current_layout, 0, 0, src_w, src_h,
 					0, 0, dst_w, dst_h, 1, aspect, true, VK_FILTER_LINEAR, surface->info.format, surface->old_contents->info.format);
+
+				// Memory has been transferred, discard old contents and update memory flags
+				// TODO: Preserve memory outside surface clip region
+				surface->on_write();
 			}
 		};
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1430,7 +1430,8 @@ void VKGSRender::end()
 	bool primitive_emulated = false;
 	vk::get_appropriate_topology(rsx::method_registers.current_draw_clause.primitive, primitive_emulated);
 
-	const bool single_draw = (!supports_multidraw ||
+	const bool allow_multidraw = supports_multidraw && !g_cfg.video.disable_FIFO_reordering;
+	const bool single_draw = (!allow_multidraw ||
 		rsx::method_registers.current_draw_clause.first_count_commands.size() <= 1 ||
 		rsx::method_registers.current_draw_clause.is_disjoint_primitive);
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -557,7 +557,6 @@ VKGSRender::VKGSRender() : GSRender()
 		m_mem_allocator = std::make_shared<vk::mem_allocator_vma>(*m_device, m_device->gpu());
 	}
 
-	
 	vk::set_current_mem_allocator(m_mem_allocator);
 
 	m_client_width = m_frame->client_width();
@@ -781,11 +780,9 @@ VKGSRender::~VKGSRender()
 	m_secondary_command_buffer.destroy();
 	m_secondary_command_buffer_pool.destroy();
 
-	// Memory allocator (device memory)
-	m_mem_allocator->destroy();
-
 	//Device handles/contexts
 	m_swapchain->destroy();
+	m_mem_allocator->destroy();
 	m_thread_context.close();
 	
 #if !defined(_WIN32) && defined(HAVE_VULKAN)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -547,18 +547,6 @@ VKGSRender::VKGSRender() : GSRender()
 	vk::set_current_thread_ctx(m_thread_context);
 	vk::set_current_renderer(m_swapchain->get_device());
 
-	// Choose memory allocator (device memory)
-	if (g_cfg.video.disable_vulkan_mem_allocator) 
-	{
-		m_mem_allocator = std::make_shared<vk::mem_allocator_vk>(*m_device, m_device->gpu());
-	}
-	else 
-	{
-		m_mem_allocator = std::make_shared<vk::mem_allocator_vma>(*m_device, m_device->gpu());
-	}
-
-	vk::set_current_mem_allocator(m_mem_allocator);
-
 	m_client_width = m_frame->client_width();
 	m_client_height = m_frame->client_height();
 	if (!m_swapchain->init(m_client_width, m_client_height))
@@ -782,7 +770,6 @@ VKGSRender::~VKGSRender()
 
 	//Device handles/contexts
 	m_swapchain->destroy();
-	m_mem_allocator->destroy();
 	m_thread_context.close();
 	
 #if !defined(_WIN32) && defined(HAVE_VULKAN)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -287,8 +287,6 @@ public:
 	std::unique_ptr<vk::vertex_cache> m_vertex_cache;
 	std::unique_ptr<vk::shader_cache> m_shaders_cache;
 
-	std::shared_ptr<vk::mem_allocator_base> m_mem_allocator;
-
 private:
 	std::unique_ptr<VKProgramBuffer> m_prog_buffer;
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -261,7 +261,6 @@ private:
 
 	std::unique_ptr<vk::text_writer> m_text_writer;
 	std::unique_ptr<vk::depth_convert_pass> m_depth_converter;
-	std::unique_ptr<vk::depth_scaling_pass> m_depth_scaler;
 	std::unique_ptr<vk::ui_overlay_renderer> m_ui_renderer;
 	std::unique_ptr<vk::attachment_clear_pass> m_attachment_clear_pass;
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -58,6 +58,14 @@ namespace vk
 
 	//VkAllocationCallbacks default_callbacks();
 
+	enum driver_vendor
+	{
+		unknown,
+		AMD,
+		NVIDIA,
+		RADV
+	};
+
 	class context;
 	class render_device;
 	class swap_chain_image;
@@ -66,7 +74,8 @@ namespace vk
 	struct image;
 	struct vk_data_heap;
 	class mem_allocator_base;
-	enum driver_vendor;
+	struct memory_type_mapping;
+	struct gpu_formats_support;
 
 	vk::context *get_current_thread_ctx();
 	void set_current_thread_ctx(const vk::context &ctx);
@@ -92,6 +101,9 @@ namespace vk
 	VkSampler null_sampler();
 	VkImageView null_image_view(vk::command_buffer&);
 	image* get_typeless_helper(VkFormat format);
+
+	memory_type_mapping get_memory_mapping(const physical_device& dev);
+	gpu_formats_support get_optimal_tiling_supported_formats(const physical_device& dev);
 
 	//Sync helpers around vkQueueSubmit
 	void acquire_global_submit_lock();
@@ -143,14 +155,6 @@ namespace vk
 
 	void die_with_error(const char* faulting_addr, VkResult error_code);
 
-	enum driver_vendor
-	{
-		unknown,
-		AMD,
-		NVIDIA,
-		RADV
-	};
-
 	struct memory_type_mapping
 	{
 		uint32_t host_visible_coherent;
@@ -162,9 +166,6 @@ namespace vk
 		bool d24_unorm_s8;
 		bool d32_sfloat_s8;
 	};
-
-	memory_type_mapping get_memory_mapping(const physical_device& dev);
-	gpu_formats_support get_optimal_tiling_supported_formats(const physical_device& dev);
 
 	class physical_device
 	{
@@ -1310,7 +1311,6 @@ public:
 		{
 			window_handle = handle;
 			hDstDC = GetDC(handle);
-			init();
 		}
 
 		void destroy(bool full=true) override
@@ -1403,7 +1403,6 @@ public:
 			}
 
 			gc = DefaultGC(display, DefaultScreen(display));
-			init();
 		}
 
 		void destroy(bool full=true) override

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -110,7 +110,7 @@ namespace vk
 	void change_image_layout(VkCommandBuffer cmd, vk::image *image, VkImageLayout new_layout, VkImageSubresourceRange range);
 	void change_image_layout(VkCommandBuffer cmd, vk::image *image, VkImageLayout new_layout);
 	void copy_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout, u32 width, u32 height, u32 mipmaps, VkImageAspectFlagBits aspect);
-	void copy_scaled_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout, u32 src_x_offset, u32 src_y_offset, u32 src_width, u32 src_height, u32 dst_x_offset, u32 dst_y_offset, u32 dst_width, u32 dst_height, u32 mipmaps, VkImageAspectFlagBits aspect, bool compatible_formats);
+	void copy_scaled_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout, u32 src_x_offset, u32 src_y_offset, u32 src_width, u32 src_height, u32 dst_x_offset, u32 dst_y_offset, u32 dst_width, u32 dst_height, u32 mipmaps, VkImageAspectFlags aspect, bool compatible_formats);
 
 	std::pair<VkFormat, VkComponentMapping> get_compatible_surface_format(rsx::surface_color_format color_format);
 	size_t get_render_pass_location(VkFormat color_surface_format, VkFormat depth_stencil_format, u8 color_surface_count);

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -100,7 +100,7 @@ namespace vk
 			VkImageLayout srcLayout, VkImageLayout dstLayout,
 			u32 src_x_offset, u32 src_y_offset, u32 src_width, u32 src_height,
 			u32 dst_x_offset, u32 dst_y_offset, u32 dst_width, u32 dst_height,
-			u32 mipmaps, VkImageAspectFlagBits aspect, bool compatible_formats)
+			u32 mipmaps, VkImageAspectFlags aspect, bool compatible_formats)
 	{
 		VkImageSubresourceLayers a_src = {}, a_dst = {};
 		a_src.aspectMask = aspect;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -296,7 +296,7 @@ namespace vk
 				//Scale image to fit
 				//usually we can just get away with nearest filtering
 				u8 samples_u = 1, samples_v = 1;
-				switch (static_cast<vk::render_target*>(vram_texture)->aa_mode)
+				switch (static_cast<vk::render_target*>(vram_texture)->read_aa_mode)
 				{
 				case rsx::surface_antialiasing::diagonal_centered_2_samples:
 					samples_u = 2;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1041,18 +1041,6 @@ namespace vk
 
 	public:
 
-		struct vk_blit_op_result : public blit_op_result
-		{
-			bool deferred = false;
-			vk::image *src_image = nullptr;
-			vk::image *dst_image = nullptr;
-			vk::image_view *src_view = nullptr;
-
-			using blit_op_result::blit_op_result;
-		};
-
-	public:
-
 		void initialize(vk::render_device& device, VkQueue submit_queue, vk::vk_data_heap& upload_heap)
 		{
 			m_device = &device;
@@ -1133,14 +1121,14 @@ namespace vk
 			return upload_texture(cmd, tex, m_rtts, cmd, const_cast<const VkQueue>(m_submit_queue));
 		}
 
-		vk::image *upload_image_simple(vk::command_buffer& /*cmd*/, u32 address, u32 width, u32 height)
+		vk::image *upload_image_simple(vk::command_buffer& cmd, u32 address, u32 width, u32 height)
 		{
 			//Uploads a linear memory range as a BGRA8 texture
 			auto image = std::make_unique<vk::image>(*m_device, m_memory_types.host_visible_coherent,
 				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
 				VK_IMAGE_TYPE_2D,
 				VK_FORMAT_B8G8R8A8_UNORM,
-				width, height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
+				width, height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_PREINITIALIZED,
 				VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0);
 
 			VkImageSubresource subresource{};
@@ -1170,6 +1158,8 @@ namespace vk
 
 			image->memory->unmap();
 
+			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+
 			auto result = image.get();
 			const u32 resource_memory = width * height * 4; //Rough approximate
 			m_discardable_storage.push_back(image);
@@ -1179,22 +1169,16 @@ namespace vk
 			return result;
 		}
 
-		vk_blit_op_result blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, rsx::vk_render_targets& m_rtts, vk::command_buffer& cmd)
+		bool blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, rsx::vk_render_targets& m_rtts, vk::command_buffer& cmd)
 		{
 			struct blit_helper
 			{
 				vk::command_buffer* commands;
+				VkFormat format;
 				blit_helper(vk::command_buffer *c) : commands(c) {}
 
-				bool deferred = false;
-				vk::image* deferred_op_src = nullptr;
-				vk::image* deferred_op_dst = nullptr;
-
-				void scale_image(vk::image* src, vk::image* dst, areai src_area, areai dst_area, bool /*interpolate*/, bool is_depth, const rsx::typeless_xfer& /*typeless*/)
+				void scale_image(vk::image* src, vk::image* dst, areai src_area, areai dst_area, bool interpolate, bool /*is_depth*/, const rsx::typeless_xfer& /*typeless*/)
 				{
-					VkImageAspectFlagBits aspect = VK_IMAGE_ASPECT_COLOR_BIT;
-					if (is_depth) aspect = (VkImageAspectFlagBits)(src->info.format == VK_FORMAT_D16_UNORM ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
-
 					//Checks
 					if (src_area.x2 <= src_area.x1 || src_area.y2 <= src_area.y1 || dst_area.x2 <= dst_area.x1 || dst_area.y2 <= dst_area.y1)
 					{
@@ -1214,54 +1198,35 @@ namespace vk
 						return;
 					}
 
+					const auto aspect = vk::get_aspect_flags(src->info.format);
 					const auto src_width = src_area.x2 - src_area.x1;
 					const auto src_height = src_area.y2 - src_area.y1;
 					const auto dst_width = dst_area.x2 - dst_area.x1;
 					const auto dst_height = dst_area.y2 - dst_area.y1;
 
-					deferred_op_src = src;
-					deferred_op_dst = dst;
-
-					if (aspect & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
-					{
-						if (src_width != dst_width || src_height != dst_height || src->info.format != dst->info.format)
-						{
-							//Scaled depth scaling
-							deferred = true;
-						}
-					}
-
-					if (!deferred)
-					{
-						copy_scaled_image(*commands, src->value, dst->value, src->current_layout, dst->current_layout, src_area.x1, src_area.y1, src_width, src_height,
-							dst_area.x1, dst_area.y1, dst_width, dst_height, 1, aspect, src->info.format == dst->info.format);
-					}
+					copy_scaled_image(*commands, src->value, dst->value, src->current_layout, dst->current_layout, src_area.x1, src_area.y1, src_width, src_height,
+						dst_area.x1, dst_area.y1, dst_width, dst_height, 1, aspect, src->info.format == dst->info.format,
+						interpolate? VK_FILTER_LINEAR : VK_FILTER_NEAREST, src->info.format, dst->info.format);
 
 					change_image_layout(*commands, dst, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, {(VkImageAspectFlags)aspect, 0, dst->info.mipLevels, 0, dst->info.arrayLayers});
+					format = dst->info.format;
 				}
 			}
 			helper(&cmd);
 
 			auto reply = upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper, cmd, const_cast<const VkQueue>(m_submit_queue));
 
-			vk_blit_op_result result = reply.succeeded;
-			result.real_dst_address = reply.real_dst_address;
-			result.real_dst_size = reply.real_dst_size;
-			result.is_depth = reply.is_depth;
-			result.deferred = helper.deferred;
-			result.dst_image = helper.deferred_op_dst;
-			result.src_image = helper.deferred_op_src;
+			if (reply.succeeded)
+			{
+				if (reply.real_dst_size)
+				{
+					flush_if_cache_miss_likely(helper.format, reply.real_dst_address, reply.real_dst_size, cmd, m_submit_queue);
+				}
 
-			if (!helper.deferred)
-				return result;
+				return true;
+			}
 
-			VkImageSubresourceRange view_range = { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 };
-			auto tmp_view = std::make_unique<vk::image_view>(*vk::get_current_renderer(), helper.deferred_op_src->value, VK_IMAGE_VIEW_TYPE_2D,
-					helper.deferred_op_src->info.format, helper.deferred_op_src->native_component_map, view_range);
-
-			result.src_view = tmp_view.get();
-			m_discardable_storage.push_back(tmp_view);
-			return result;
+			return false;
 		}
 
 		const u32 get_unreleased_textures_count() const override

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -502,7 +502,7 @@ namespace rsx
 				entries.push_back(tmp);
 			}
 
-			if ((entry_count = entries.size()) <= 2)
+			if ((entry_count = (u32)entries.size()) <= 2)
 				return;
 
 			root.rewind();

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -587,6 +587,52 @@ namespace rsx
 	}
 
 	/**
+	 * Calculates the regions used for memory transfer between rendertargets on succession events
+	 */
+	template <typename SurfaceType>
+	std::tuple<u16, u16, u16, u16> get_transferable_region(SurfaceType* surface)
+	{
+		const u16 src_w = surface->old_contents->width();
+		const u16 src_h = surface->old_contents->height();
+		u16 dst_w = src_w;
+		u16 dst_h = src_h;
+
+		switch (surface->old_contents->aa_mode)
+		{
+		case rsx::surface_antialiasing::center_1_sample:
+			break;
+		case rsx::surface_antialiasing::diagonal_centered_2_samples:
+			dst_w *= 2;
+			break;
+		case rsx::surface_antialiasing::square_centered_4_samples:
+		case rsx::surface_antialiasing::square_rotated_4_samples:
+			dst_w *= 2;
+			dst_h *= 2;
+			break;
+		}
+
+		switch (surface->aa_mode)
+		{
+		case rsx::surface_antialiasing::center_1_sample:
+			break;
+		case rsx::surface_antialiasing::diagonal_centered_2_samples:
+			dst_w /= 2;
+			break;
+		case rsx::surface_antialiasing::square_centered_4_samples:
+		case rsx::surface_antialiasing::square_rotated_4_samples:
+			dst_w /= 2;
+			dst_h /= 2;
+			break;
+		}
+
+		const f32 scale_x = (f32)dst_w / src_w;
+		const f32 scale_y = (f32)dst_h / src_h;
+
+		std::tie(std::ignore, std::ignore, dst_w, dst_h) = clip_region<u16>(dst_w, dst_h, 0, 0, surface->width(), surface->height(), true);
+		return std::make_tuple(u16(dst_w / scale_x), u16(dst_h / scale_y), dst_w, dst_h);
+	}
+
+	/**
 	 * Remove restart index and emulate using degenerate triangles
 	 * Can be used as a workaround when restart_index doesnt work too well
 	 * dst should be able to hold at least 2xcount entries

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -597,7 +597,7 @@ namespace rsx
 		u16 dst_w = src_w;
 		u16 dst_h = src_h;
 
-		switch (surface->old_contents->aa_mode)
+		switch (static_cast<SurfaceType*>(surface->old_contents)->read_aa_mode)
 		{
 		case rsx::surface_antialiasing::center_1_sample:
 			break;
@@ -611,7 +611,7 @@ namespace rsx
 			break;
 		}
 
-		switch (surface->aa_mode)
+		switch (surface->write_aa_mode)
 		{
 		case rsx::surface_antialiasing::center_1_sample:
 			break;


### PR DESCRIPTION
_**Ugh. MSAA needs another rewrite**_

- Performs MSAA resolve during framebuffer persistence transfer (strict mode) allowing the samples to live on correctly in their descendants.
- Perserve MSAA fetch state separate from write state to preserve the AA flag across memory respecifications. Some applications use evil hacks to play around with AA memory.

Other fixes
- amdvlk: Avoid use after free (vkFence)
- Reimplement depth texture scaling using vulkan. Allows proper MSAA resolve by preserving stencil contents.
- Fix a rendering bug when FIFO reordering is disabled
- Allow overlays to accept multiple image inputs

See https://github.com/RPCS3/rpcs3/pull/4692