### PR TITLE
minor dialog fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -82,7 +82,7 @@ public:
 	std::function<void()> on_osk_input_entered;
 
 	virtual ~MsgDialogBase();
-	virtual void Create(const std::string& msg) = 0;
+	virtual void Create(const std::string& msg, const std::string& title = "") = 0;
 	virtual void CreateOsk(const std::string& msg, char16_t* osk_text, u32 charlimit) = 0;
 	virtual void SetMsg(const std::string& msg) = 0;
 	virtual void ProgressBarSetMsg(u32 progressBarIndex, const std::string& msg) = 0;

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -73,13 +73,14 @@ enum class MsgDialogState
 
 class MsgDialogBase
 {
+protected:
+	// the progressbar that will be represented in the taskbar. Use -1 to combine the progress.
+	s32 taskbar_index = 0;
+
 public:
 	atomic_t<MsgDialogState> state{ MsgDialogState::Open };
 
 	MsgDialogType type{};
-
-	// the progressbar that will be represented in the taskbar. Use -1 to combine the progress.
-	s32 taskbar_index = 0;
 
 	std::function<void(s32 status)> on_close;
 	std::function<void()> on_osk_input_entered;
@@ -92,4 +93,9 @@ public:
 	virtual void ProgressBarReset(u32 progressBarIndex) = 0;
 	virtual void ProgressBarInc(u32 progressBarIndex, u32 delta) = 0;
 	virtual void ProgressBarSetLimit(u32 index, u32 limit) = 0;
+
+	void ProgressBarSetTaskbarIndex(s32 index)
+	{
+		taskbar_index = index;
+	}
 };

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -78,6 +78,9 @@ public:
 
 	MsgDialogType type{};
 
+	// the progressbar that will be represented in the taskbar. Use -1 to combine the progress.
+	s32 taskbar_index = 0;
+
 	std::function<void(s32 status)> on_close;
 	std::function<void()> on_osk_input_entered;
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -783,6 +783,11 @@ static NEVER_INLINE s32 savedata_op(ppu_thread& ppu, u32 operation, u32 version,
 		case CELL_SAVEDATA_FILEOP_WRITE:
 		{
 			fs::file file(dir_path + file_path, fs::write + fs::create);
+			if (!file)
+			{
+				fmt::throw_exception("Failed to open file. The file might be read-only: %s%s" HERE, dir_path, file_path);
+			}
+
 			file.seek(fileSet->fileOffset);
 			const auto start = static_cast<uchar*>(fileSet->fileBuf.get_ptr());
 			std::vector<uchar> buf(start, start + std::min<u32>(fileSet->fileSize, fileSet->fileBufSize));
@@ -801,6 +806,11 @@ static NEVER_INLINE s32 savedata_op(ppu_thread& ppu, u32 operation, u32 version,
 		case CELL_SAVEDATA_FILEOP_WRITE_NOTRUNC:
 		{
 			fs::file file(dir_path + file_path, fs::write + fs::create);
+			if (!file)
+			{
+				fmt::throw_exception("Failed to open file. The file might be read-only: %s%s" HERE, dir_path, file_path);
+			}
+
 			file.seek(fileSet->fileOffset);
 			const auto start = static_cast<uchar*>(fileSet->fileBuf.get_ptr());
 			std::vector<uchar> buf(start, start + std::min<u32>(fileSet->fileSize, fileSet->fileBufSize));

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -848,6 +848,7 @@ void GLGSRender::on_init_thread()
 				type.progress_bar_count = 2;
 
 				dlg = fxm::get<rsx::overlays::display_manager>()->create<rsx::overlays::message_dialog>();
+				dlg->progress_bar_set_taskbar_index(-1);
 				dlg->show("Loading precompiled shaders from disk...", type, [](s32 status)
 				{
 					if (status != CELL_OK)

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -14,7 +14,15 @@ namespace rsx
 			//Force unload
 			exit = true;
 			if (auto manager = fxm::get<display_manager>())
+			{
+				if (auto dlg = manager->get<rsx::overlays::message_dialog>())
+				{
+					if (dlg->progress_bar_count())
+						Emu.GetCallbacks().handle_taskbar_progress(0, 0);
+				}
+
 				manager->remove(uid);
+			}
 
 			if (on_close)
 				on_close(return_code);

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -722,6 +722,8 @@ namespace rsx
 			overlay_element bottom_bar, background;
 			progress_bar progress_1, progress_2;
 			u8 num_progress_bars = 0;
+			s32 taskbar_index = 0;
+			s32 taskbar_limit = 0;
 
 			bool interactive = false;
 			bool ok_only = false;
@@ -900,6 +902,16 @@ namespace rsx
 				return CELL_OK;
 			}
 
+			u32 progress_bar_count()
+			{
+				return num_progress_bars;
+			}
+
+			void progress_bar_set_taskbar_index(s32 index)
+			{
+				taskbar_index = index;
+			}
+
 			s32 progress_bar_set_message(u32 index, const std::string& msg)
 			{
 				if (index >= num_progress_bars)
@@ -923,6 +935,9 @@ namespace rsx
 				else
 					progress_2.inc(value);
 
+				if (index == taskbar_index || taskbar_index == -1)
+					Emu.GetCallbacks().handle_taskbar_progress(1, value);
+
 				return CELL_OK;
 			}
 
@@ -936,6 +951,8 @@ namespace rsx
 				else
 					progress_2.set_value(0.f);
 
+				Emu.GetCallbacks().handle_taskbar_progress(0, 0);
+
 				return CELL_OK;
 			}
 
@@ -948,6 +965,17 @@ namespace rsx
 					progress_1.set_limit((float)limit);
 				else
 					progress_2.set_limit((float)limit);
+
+				if (index == taskbar_index)
+				{
+					taskbar_limit = limit;
+					Emu.GetCallbacks().handle_taskbar_progress(2, taskbar_limit);
+				}
+				else if (taskbar_index == -1)
+				{
+					taskbar_limit += limit;
+					Emu.GetCallbacks().handle_taskbar_progress(2, taskbar_limit);
+				}
 
 				return CELL_OK;
 			}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1601,6 +1601,7 @@ void VKGSRender::on_init_thread()
 				type.progress_bar_count = 2;
 
 				dlg = fxm::get<rsx::overlays::display_manager>()->create<rsx::overlays::message_dialog>();
+				dlg->progress_bar_set_taskbar_index(-1);
 				dlg->show("Loading precompiled shaders from disk...", type, [](s32 status)
 				{
 					if (status != CELL_OK)

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -404,6 +404,8 @@ namespace rsx
 
 		struct progress_dialog_helper
 		{
+			s32 taskbar_index = -1; // -1 to combine all progressbars in the taskbar progress
+
 			std::shared_ptr<MsgDialogBase> dlg;
 			atomic_t<bool> initialized{ false };
 
@@ -413,6 +415,7 @@ namespace rsx
 				dlg->type.se_normal = true;
 				dlg->type.bg_invisible = true;
 				dlg->type.progress_bar_count = 2;
+				dlg->taskbar_index = taskbar_index;
 				dlg->on_close = [](s32 status)
 				{
 					Emu.CallAfter([]()

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -423,7 +423,7 @@ namespace rsx
 
 				Emu.CallAfter([&]()
 				{
-					dlg->Create("Preloading cached shaders from disk.\nPlease wait...");
+					dlg->Create("Preloading cached shaders from disk.\nPlease wait...", "Shader Compilation");
 					initialized.store(true);
 				});
 

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -404,8 +404,6 @@ namespace rsx
 
 		struct progress_dialog_helper
 		{
-			s32 taskbar_index = -1; // -1 to combine all progressbars in the taskbar progress
-
 			std::shared_ptr<MsgDialogBase> dlg;
 			atomic_t<bool> initialized{ false };
 
@@ -415,7 +413,7 @@ namespace rsx
 				dlg->type.se_normal = true;
 				dlg->type.bg_invisible = true;
 				dlg->type.progress_bar_count = 2;
-				dlg->taskbar_index = taskbar_index;
+				dlg->ProgressBarSetTaskbarIndex(-1); // -1 to combine all progressbars in the taskbar progress
 				dlg->on_close = [](s32 status)
 				{
 					Emu.CallAfter([]()

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -167,6 +167,7 @@ struct EmuCallbacks
 	std::function<void()> on_stop;
 	std::function<void()> on_ready;
 	std::function<void()> exit;
+	std::function<void(s32, s32)> handle_taskbar_progress;
 	std::function<std::shared_ptr<class KeyboardHandlerBase>()> get_kb_handler;
 	std::function<std::shared_ptr<class MouseHandlerBase>()> get_mouse_handler;
 	std::function<std::shared_ptr<class pad_thread>()> get_pad_handler;

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -275,6 +275,28 @@ void rpcs3_app::InitializeCallbacks()
 	callbacks.on_stop = [=]() { OnEmulatorStop(); };
 	callbacks.on_ready = [=]() { OnEmulatorReady(); };
 
+	callbacks.handle_taskbar_progress = [=](s32 type, s32 value)
+	{
+		if (gameWindow)
+		{
+			switch (type)
+			{
+			case 0:
+				((gs_frame*)gameWindow)->progress_reset();
+				break;
+			case 1:
+				((gs_frame*)gameWindow)->progress_increment(value);
+				break;
+			case 2:
+				((gs_frame*)gameWindow)->progress_set_limit(value);
+				break;
+			default:
+				LOG_FATAL(GENERAL, "Unknown type in handle_taskbar_progress(type=%d, value=%d)", type, value);
+				break;
+			}
+		}
+	};
+
 	Emu.SetCallbacks(std::move(callbacks));
 }
 

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -6,9 +6,30 @@
 #include <QWidget>
 #include <QWindow>
 
+#ifdef _WIN32
+#include <QWinTaskbarProgress>
+#include <QWinTaskbarButton>
+#include <QWinTHumbnailToolbar>
+#include <QWinTHumbnailToolbutton>
+#elif HAVE_QTDBUS
+#include <QtDBus/QDBusMessage>
+#include <QtDBus/QDBusConnection>
+#endif
+
 class gs_frame : public QWindow, public GSFrameBase
 {
 	Q_OBJECT
+
+private:
+	// taskbar progress
+	int m_gauge_max = 100;
+#ifdef _WIN32
+	QWinTaskbarButton* m_tb_button = nullptr;
+	QWinTaskbarProgress* m_tb_progress = nullptr;
+#elif HAVE_QTDBUS
+	int m_progress_value = 0;
+	void UpdateProgress(int progress, bool disable = false);
+#endif
 
 	u64 m_frames = 0;
 	QString m_windowTitle;
@@ -22,12 +43,19 @@ class gs_frame : public QWindow, public GSFrameBase
 
 public:
 	gs_frame(const QString& title, const QRect& geometry, QIcon appIcon, bool disableMouse);
+	~gs_frame();
 
 	draw_context_t make_context() override;
 	void set_current(draw_context_t context) override;
 	void delete_context(draw_context_t context) override;
 
 	wm_event get_default_wm_event() const override;
+
+	// taskbar progress
+	void progress_reset();
+	void progress_increment(int delta);
+	void progress_set_limit(int limit);
+
 protected:
 	virtual void paintEvent(QPaintEvent *event);
 	virtual void showEvent(QShowEvent *event) override;
@@ -51,6 +79,7 @@ protected:
 	bool nativeEvent(const QByteArray &eventType, void *message, long *result) override;
 
 	bool event(QEvent* ev) override;
+
 private Q_SLOTS:
 	void HandleCursor(QWindow::Visibility visibility);
 };

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -7,7 +7,7 @@
 
 constexpr auto qstr = QString::fromStdString;
 
-void msg_dialog_frame::Create(const std::string& msg)
+void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 {
 	static const auto& barWidth = [](){return QLabel("This is the very length of the progressbar due to hidpi reasons.").sizeHint().width();};
 
@@ -18,7 +18,7 @@ void msg_dialog_frame::Create(const std::string& msg)
 	}
 
 	m_dialog = new custom_dialog(type.disable_cancel);
-	m_dialog->setWindowTitle(type.se_normal ? "Normal dialog" : "Error dialog");
+	m_dialog->setWindowTitle(title.empty() ? (type.se_normal ? "Normal dialog" : "Error dialog") : qstr(title));
 	m_dialog->setWindowOpacity(type.bg_invisible ? 1. : 0.75);
 
 	m_text = new QLabel(qstr(msg));

--- a/rpcs3/rpcs3qt/msg_dialog_frame.h
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.h
@@ -34,12 +34,12 @@ class msg_dialog_frame : public QObject, public MsgDialogBase
 {
 	Q_OBJECT
 
+private:
 #ifdef _WIN32
 	QWinTaskbarButton* m_tb_button = nullptr;
 	QWinTaskbarProgress* m_tb_progress = nullptr;
-
 #elif HAVE_QTDBUS
-	int progressValue = 0;
+	int m_progress_value = 0;
 #endif
 	custom_dialog* m_dialog =nullptr;
 	QLabel* m_text = nullptr;
@@ -56,7 +56,7 @@ class msg_dialog_frame : public QObject, public MsgDialogBase
 	custom_dialog* m_osk_dialog = nullptr;
 	char16_t* m_osk_text_return;
 
-	const int m_gauge_max = 100;
+	int m_gauge_max = 0;
 
 public:
 	msg_dialog_frame(QWindow* taskbarTarget);

--- a/rpcs3/rpcs3qt/msg_dialog_frame.h
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.h
@@ -39,7 +39,7 @@ class msg_dialog_frame : public QObject, public MsgDialogBase
 	QWinTaskbarProgress* m_tb_progress = nullptr;
 
 #elif HAVE_QTDBUS
-	int* progressValue = nullptr;
+	int progressValue = 0;
 #endif
 	custom_dialog* m_dialog =nullptr;
 	QLabel* m_text = nullptr;

--- a/rpcs3/rpcs3qt/msg_dialog_frame.h
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.h
@@ -61,7 +61,7 @@ class msg_dialog_frame : public QObject, public MsgDialogBase
 public:
 	msg_dialog_frame(QWindow* taskbarTarget);
 	~msg_dialog_frame();
-	virtual void Create(const std::string& msg) override;
+	virtual void Create(const std::string& msg, const std::string& title = "") override;
 	virtual void CreateOsk(const std::string& msg, char16_t* osk_text, u32 charlimit) override;
 	virtual void SetMsg(const std::string& msg) override;
 	virtual void ProgressBarSetMsg(u32 progressBarIndex, const std::string& msg) override;


### PR DESCRIPTION
Fixes Qt Dialog progress bars never reaching 100%.

Switches weird progressvalue int pointer to int.

Handle file access error in cellSaveData by returning an error.

Remove old code for the ppu compile wall of dialogs.

Add taskbar progress to all progressbar dialogs (Qt dialog AND native UI).