### PR TITLE
sys_timer_usleep fix

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -318,6 +318,11 @@ error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 				// Wait until the end of the last quantum before the target time
 				thread_ctrl::wait_for(remaining - host_min_quantum);
 			}
+			else if (sleep_time == 300)
+			{
+				// Special case, on ps3 sleeps for random duration, on windows causes high idle CPU usage if unmanaged
+				thread_ctrl::wait_for(1);
+			}
 			else
 			{
 				// Try yielding. May cause long wake latency but helps weaker CPUs a lot by alleviating resource pressure

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -315,8 +315,8 @@ error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 
 			if (remaining > host_min_quantum)
 			{
-				// Wait on multiple of min quantum for large durations
-				thread_ctrl::wait_for(remaining - (remaining % host_min_quantum));
+				// Wait until the end of the last quantum before the target time
+				thread_ctrl::wait_for(remaining - host_min_quantum);
 			}
 			else
 			{


### PR DESCRIPTION
While testing sleep timings with the test provided by kd-11 [here](https://github.com/RPCS3/rpcs3/issues/4702) I noticed that for the case 600us the delay was much higher than expected (around 800-900us), so I tested some more values higher than 500us (the scheduling quantum on Windows) and this was the result:

```
Application started
Calculating baseline delay...(0us)
Testing usleep(600)...
    Latency = 972us
Testing usleep(610)...
    Latency = 885us
Testing usleep(650)...
    Latency = 968us
Testing usleep(700)...
    Latency = 934us
Testing usleep(800)...
    Latency = 921us
Testing usleep(1000)...
    Latency = 1261us
Testing usleep(1355)...
    Latency = 1463us
Application finished
```

This because it waits for a multiple of the time quantum (e.g. with 600us it waits for 500us), but it does not start waiting at the start of the quantum, as a consequence the thread wakes up at the beginning of the quantum after the expected one, missing the sleep target time.

Here is a diagram illustrating the issue:
![bug_complete2](https://user-images.githubusercontent.com/29335145/41067176-ecda079e-69e4-11e8-9af7-92fb12361755.png)

So I changed it to make it wait until exactly a quantum before the target time. In this way the thread wakes up at the end of the quantum immediately before the sleep target time, so the sleep ends at the right time.

Here is another diagram illustrating what happens now:
![bug_complete2a](https://user-images.githubusercontent.com/29335145/41067171-e7728c0e-69e4-11e8-93a6-77c5f68dc559.png)

With this change sleep times above 500us are accurate:
```
Application started
Calculating baseline delay...(0us)
Testing usleep(600)...
    Latency = 602us
Testing usleep(610)...
    Latency = 611us
Testing usleep(650)...
    Latency = 652us
Testing usleep(700)...
    Latency = 702us
Testing usleep(800)...
    Latency = 802us
Testing usleep(1000)...
    Latency = 1003us
Testing usleep(1355)...
    Latency = 1357us
Application finished
```

Here is the extended sleep test I used: 
[timer_extended.zip](https://github.com/RPCS3/rpcs3/files/2078278/timer_extended.zip)

(All tests were done on Windows 10 Pro 17134.48)