### PR TITLE
Fix dumb games

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -398,6 +398,12 @@ error_code cellGameContentPermit(vm::ptr<char[CELL_GAME_PATH_MAX]> contentInfoPa
 		return CELL_GAME_ERROR_FAILURE;
 	}
 
+	if (prm->can_create && prm->temp.empty())
+	{
+		verify(HERE), fxm::remove<content_permission>();
+		return CELL_OK;
+	}
+
 	const std::string dir = prm->dir.empty() ? "/dev_bdvd/PS3_GAME"s : "/dev_hdd0/game/" + prm->dir;
 
 	if (!prm->temp.empty())


### PR DESCRIPTION
The disc version of Game of Thrones: A Telltale Games Series [BLES02215] is dumb and calls `cellGameContentPermit` on gamedata without calling `cellGameCreateGameData` first. We used to return the path to a non-existing gamedata folder which made the game think everything was fine and it dies. I made a [test](https://github.com/isJuhn/ps3tests/blob/master/cellGameContentPermit/expected.txt) and as expected we shouldn't set the path in such cases, just remove the `content_permission`.

Loadable -> Ingame (maybe playable?)
![image](https://user-images.githubusercontent.com/26828095/41173427-24611a36-6b57-11e8-88c3-9462e8b6c4c4.png)
Thanks to Deminating for testing and the screenshot.