### PR TITLE
rsx: stuff

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -83,7 +83,8 @@ namespace glsl
 	enum program_domain
 	{
 		glsl_vertex_program = 0,
-		glsl_fragment_program = 1
+		glsl_fragment_program = 1,
+		glsl_compute_program = 2
 	};
 
 	enum glsl_rules

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -679,13 +679,17 @@ namespace rsx
 						m_unreleased_texture_objects++;
 					}
 
-					//Only unsynchronized (no-flush) sections should reach here, and only if the rendering thread is the caller
+					// Only unsynchronized (no-flush) sections should reach here, and only if the rendering thread is the caller
 					if (discard_only)
+					{
 						obj.first->discard();
+						obj.second->remove_one();
+					}
 					else
-						obj.first->unprotect();
-
-					obj.second->remove_one();
+					{
+						// Delay unprotect in case there are sections to flush
+						result.sections_to_unprotect.push_back(obj.first);
+					}
 				}
 
 				if (deferred_flush && result.sections_to_flush.size())

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -72,8 +72,9 @@ namespace rsx
 
 		bool synchronized = false;
 		bool flushed = false;
-		u32  num_writes = 0;
-		u32  required_writes = 1;
+
+		u32 num_writes = 0;
+		std::deque<u32> read_history;
 
 		u64 cache_tag = 0;
 
@@ -120,7 +121,12 @@ namespace rsx
 
 		void reset_write_statistics()
 		{
-			required_writes = num_writes;
+			if (read_history.size() == 16)
+			{
+				read_history.pop_back();
+			}
+
+			read_history.push_front(num_writes);
 			num_writes = 0;
 		}
 
@@ -196,8 +202,51 @@ namespace rsx
 
 		bool writes_likely_completed() const
 		{
+			// TODO: Move this to the miss statistics block
 			if (context == rsx::texture_upload_context::blit_engine_dst)
-				return num_writes >= required_writes;
+			{
+				const auto num_records = read_history.size();
+
+				if (num_records == 0)
+				{
+					return false;
+				}
+				else if (num_records == 1)
+				{
+					return num_writes >= read_history.front();
+				}
+				else
+				{
+					const u32 last = read_history.front();
+					const u32 prev_last = read_history[1];
+
+					if (last == prev_last && num_records <= 3)
+					{
+						return num_writes >= last;
+					}
+
+					u32 compare = UINT32_MAX;
+					for (u32 n = 1; n < num_records; n++)
+					{
+						if (read_history[n] == last)
+						{
+							// Uncertain, but possible
+							compare = read_history[n - 1];
+
+							if (num_records > (n + 1))
+							{
+								if (read_history[n + 1] == prev_last)
+								{
+									// Confirmed with 2 values
+									break;
+								}
+							}
+						}
+					}
+
+					return num_writes >= compare;
+				}
+			}
 
 			return true;
 		}
@@ -1045,7 +1094,7 @@ namespace rsx
 		}
 
 		template <typename ...Args>
-		bool flush_memory_to_cache(u32 memory_address, u32 memory_size, bool skip_synchronized, Args&&... extra)
+		bool flush_memory_to_cache(u32 memory_address, u32 memory_size, bool skip_synchronized, u32 allowed_types_mask, Args&&... extra)
 		{
 			writer_lock lock(m_cache_mutex);
 			section_storage_type* region = find_flushable_section(memory_address, memory_size);
@@ -1056,6 +1105,9 @@ namespace rsx
 
 			if (skip_synchronized && region->is_synchronized())
 				return false;
+
+			if ((allowed_types_mask & region->get_context()) == 0)
+				return true;
 
 			if (!region->writes_likely_completed())
 				return true;
@@ -1243,23 +1295,26 @@ namespace rsx
 				//Reset since the data has changed
 				//TODO: Keep track of all this information together
 				m_cache_miss_statistics_table[memory_address] = { 0, memory_size, fmt };
-				return false;
 			}
 
-			//Properly synchronized - no miss
-			if (!value.misses) return false;
+			// By default, blit targets are always to be tested for readback
+			u32 flush_mask = rsx::texture_upload_context::blit_engine_dst;
 
-			//Auto flush if this address keeps missing (not properly synchronized)
-			if (value.misses > 16)
+			// Auto flush if this address keeps missing (not properly synchronized)
+			if (value.misses >= 4)
 			{
-				//TODO: Determine better way of setting threshold
-				if (!flush_memory_to_cache(memory_address, memory_size, true, std::forward<Args>(extras)...))
-					value.misses--;
-
-				return true;
+				// TODO: Determine better way of setting threshold
+				// Allow all types
+				flush_mask = 0xFF;
 			}
 
-			return false;
+			if (!flush_memory_to_cache(memory_address, memory_size, true, flush_mask, std::forward<Args>(extras)...) &&
+				value.misses > 0)
+			{
+				value.misses--;
+			}
+
+			return true;
 		}
 
 		void purge_dirty()

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -706,7 +706,7 @@ void GLGSRender::write_buffers()
 				*/
 
 				const u32 range = m_surface_info[i].pitch * m_surface_info[i].height;
-				__glcheck m_gl_texture_cache.flush_memory_to_cache(m_surface_info[i].address, range, true);
+				__glcheck m_gl_texture_cache.flush_memory_to_cache(m_surface_info[i].address, range, true, 0xFF);
 			}
 		};
 
@@ -721,6 +721,6 @@ void GLGSRender::write_buffers()
 		u32 range = m_depth_surface_info.width * m_depth_surface_info.height * 2;
 		if (m_depth_surface_info.depth_format != rsx::surface_depth_format::z16) range *= 2;
 
-		m_gl_texture_cache.flush_memory_to_cache(m_depth_surface_info.address, range, true);
+		m_gl_texture_cache.flush_memory_to_cache(m_depth_surface_info.address, range, true, 0xFF);
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
@@ -140,7 +140,8 @@ namespace vk
 
 	bool compile_glsl_to_spv(std::string& shader, program_domain domain, std::vector<u32>& spv)
 	{
-		EShLanguage lang = (domain == glsl_fragment_program) ? EShLangFragment : EShLangVertex;
+		EShLanguage lang = (domain == glsl_fragment_program) ? EShLangFragment :
+			(domain == glsl_vertex_program)? EShLangVertex : EShLangCompute;
 
 		glslang::TProgram program;
 		glslang::TShader shader_object(lang);

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -1,0 +1,256 @@
+#pragma once
+#include "VKHelpers.h"
+
+namespace vk
+{
+	struct compute_task
+	{
+		std::string m_src;
+		vk::glsl::shader m_shader;
+		std::unique_ptr<vk::glsl::program> m_program;
+
+		vk::descriptor_pool m_descriptor_pool;
+		VkDescriptorSet m_descriptor_set = nullptr;
+		VkDescriptorSetLayout m_descriptor_layout = nullptr;
+		VkPipelineLayout m_pipeline_layout = nullptr;
+		u32 m_used_descriptors = 0;
+
+		bool initialized = false;
+		u32 optimal_group_size = 64;
+
+		void init_descriptors()
+		{
+			VkDescriptorPoolSize descriptor_pool_sizes[1] =
+			{
+				{ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 120 },
+			};
+
+			//Reserve descriptor pools
+			m_descriptor_pool.create(*get_current_renderer(), descriptor_pool_sizes, 1);
+
+			std::vector<VkDescriptorSetLayoutBinding> bindings(1);
+
+			bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+			bindings[0].descriptorCount = 1;
+			bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+			bindings[0].binding = 0;
+			bindings[0].pImmutableSamplers = nullptr;
+
+			VkDescriptorSetLayoutCreateInfo infos = {};
+			infos.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+			infos.pBindings = bindings.data();
+			infos.bindingCount = bindings.size();
+
+			CHECK_RESULT(vkCreateDescriptorSetLayout(*get_current_renderer(), &infos, nullptr, &m_descriptor_layout));
+
+			VkPipelineLayoutCreateInfo layout_info = {};
+			layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+			layout_info.setLayoutCount = 1;
+			layout_info.pSetLayouts = &m_descriptor_layout;
+
+			CHECK_RESULT(vkCreatePipelineLayout(*get_current_renderer(), &layout_info, nullptr, &m_pipeline_layout));
+		}
+
+		void create()
+		{
+			if (!initialized)
+			{
+				init_descriptors();
+
+				switch (vk::get_driver_vendor())
+				{
+				case vk::driver_vendor::unknown:
+					// Probably intel
+				case vk::driver_vendor::NVIDIA:
+					optimal_group_size = 32;
+					break;
+				}
+
+				initialized = true;
+			}
+		}
+
+		void destroy()
+		{
+			if (initialized)
+			{
+				m_shader.destroy();
+				m_program.reset();
+
+				vkDestroyDescriptorSetLayout(*get_current_renderer(), m_descriptor_layout, nullptr);
+				vkDestroyPipelineLayout(*get_current_renderer(), m_pipeline_layout, nullptr);
+				m_descriptor_pool.destroy();
+
+				initialized = false;
+			}
+		}
+
+		void free_resources()
+		{
+			if (m_used_descriptors == 0)
+				return;
+
+			vkResetDescriptorPool(*get_current_renderer(), m_descriptor_pool, 0);
+			m_used_descriptors = 0;
+		}
+
+		virtual void bind_resources()
+		{}
+
+		void load_program(const vk::command_buffer& cmd)
+		{
+			if (!m_program)
+			{
+				m_shader.create(::glsl::program_domain::glsl_compute_program, m_src);
+				auto handle = m_shader.compile();
+
+				VkPipelineShaderStageCreateInfo shader_stage{};
+				shader_stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+				shader_stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+				shader_stage.module = handle;
+				shader_stage.pName = "main";
+
+				VkComputePipelineCreateInfo info{};
+				info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+				info.stage = shader_stage;
+				info.layout = m_pipeline_layout;
+				info.basePipelineIndex = -1;
+				info.basePipelineHandle = VK_NULL_HANDLE;
+
+				VkPipeline pipeline;
+				vkCreateComputePipelines(*get_current_renderer(), nullptr, 1, &info, nullptr, &pipeline);
+
+				std::vector<vk::glsl::program_input> inputs;
+				m_program = std::make_unique<vk::glsl::program>(*get_current_renderer(), pipeline, inputs, inputs);
+			}
+
+			verify(HERE), m_used_descriptors < 120;
+
+			VkDescriptorSetAllocateInfo alloc_info = {};
+			alloc_info.descriptorPool = m_descriptor_pool;
+			alloc_info.descriptorSetCount = 1;
+			alloc_info.pSetLayouts = &m_descriptor_layout;
+			alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+
+			CHECK_RESULT(vkAllocateDescriptorSets(*get_current_renderer(), &alloc_info, &m_descriptor_set));
+			m_used_descriptors++;
+
+			bind_resources();
+
+			vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_program->pipeline);
+			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline_layout, 0, 1, &m_descriptor_set, 0, nullptr);
+		}
+
+		virtual void run(const vk::command_buffer& cmd, u32 num_invocations)
+		{
+			load_program(cmd);
+			vkCmdDispatch(cmd, num_invocations, 1, 1);
+		}
+	};
+
+	struct cs_shuffle_base : compute_task
+	{
+		vk::buffer* m_data;
+		u32 kernel_size = 1;
+
+		void build(const char* function_name, u32 _kernel_size)
+		{
+			kernel_size = _kernel_size;
+
+			m_src =
+			{
+				"#version 430\n"
+				"layout(local_size_x=%ws, local_size_y=1, local_size_z=1) in;\n"
+				"layout(std430, set=0, binding=0) buffer ssbo{ uint data[]; };\n\n"
+				"\n"
+				"#define KERNEL_SIZE %ks\n"
+				"#define bswap_u16(bits)     (bits & 0xFF) << 8 | (bits & 0xFF00) >> 8 | (bits & 0xFF0000) << 8 | (bits & 0xFF000000) >> 8\n"
+				"#define bswap_u32(bits)     (bits & 0xFF) << 24 | (bits & 0xFF00) << 8 | (bits & 0xFF0000) >> 8 | (bits & 0xFF000000) >> 24\n"
+				"#define bswap_u16_u32(bits) (bits & 0xFFFF) << 16 | (bits & 0xFFFF0000) >> 16\n"
+				"\n"
+				"void main()\n"
+				"{\n"
+				"	uint index = gl_GlobalInvocationID.x * KERNEL_SIZE;\n"
+				"	for (uint loop = 0; loop < KERNEL_SIZE; ++loop)\n"
+				"	{\n"
+				"		uint value = data[index];\n"
+				"		data[index] = %f(value);\n"
+				"		index++;\n"
+				"	}\n"
+				"}\n"
+			};
+
+			const std::pair<std::string, std::string> syntax_replace[] =
+			{
+				{ "%ws", std::to_string(optimal_group_size) },
+				{ "%ks", std::to_string(kernel_size) },
+				{ "%f", function_name }
+			};
+
+			m_src = fmt::replace_all(m_src, syntax_replace);
+		}
+
+		void bind_resources() override
+		{
+			m_program->bind_buffer({ m_data->value, 0, VK_WHOLE_SIZE }, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_descriptor_set);
+		}
+
+		void run(const vk::command_buffer& cmd, vk::buffer* data, u32 mem_size)
+		{
+			m_data = data;
+
+			const auto num_bytes_per_invocation = optimal_group_size * kernel_size * 4;
+			const auto num_invocations = align(mem_size, 256) / num_bytes_per_invocation;
+			compute_task::run(cmd, num_invocations);
+		}
+	};
+
+	struct cs_shuffle_16 : cs_shuffle_base
+	{
+		vk::buffer* m_data;
+
+		// byteswap ushort
+		cs_shuffle_16()
+		{
+			cs_shuffle_base::build("bswap_u16", 32);
+		}
+	};
+
+	struct cs_shuffle_32 : cs_shuffle_base
+	{
+		// byteswap_ulong
+		cs_shuffle_32()
+		{
+			cs_shuffle_base::build("bswap_u32", 32);
+		}
+	};
+
+	struct cs_shuffle_32_16 : cs_shuffle_base
+	{
+		// byteswap_ulong + byteswap_ushort
+		cs_shuffle_32_16()
+		{
+			cs_shuffle_base::build("bswap_u16_u32", 32);
+		}
+	};
+
+	// TODO: Replace with a proper manager
+	extern std::unordered_map<u32, std::unique_ptr<vk::compute_task>> g_compute_tasks;
+
+	template<class T>
+	T* get_compute_task()
+	{
+		u32 index = id_manager::typeinfo::get_index<T>();
+		auto &e = g_compute_tasks[index];
+
+		if (!e)
+		{
+			e = std::make_unique<T>();
+			e->create();
+		}
+
+		return static_cast<T*>(e.get());
+	}
+
+	void reset_compute_tasks();
+}

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -39,7 +39,7 @@ namespace vk
 			VkDescriptorSetLayoutCreateInfo infos = {};
 			infos.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
 			infos.pBindings = bindings.data();
-			infos.bindingCount = bindings.size();
+			infos.bindingCount = (u32)bindings.size();
 
 			CHECK_RESULT(vkCreateDescriptorSetLayout(*get_current_renderer(), &infos, nullptr, &m_descriptor_layout));
 

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -362,8 +362,11 @@ VKFragmentProgram::~VKFragmentProgram()
 void VKFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 {
 	u32 size;
-	VKFragmentDecompilerThread decompiler(shader, parr, prog, size, *this);
+	std::string source;
+	VKFragmentDecompilerThread decompiler(source, parr, prog, size, *this);
 	decompiler.Task();
+
+	shader.create(::glsl::program_domain::glsl_fragment_program, source);
 	
 	for (const ParamType& PT : decompiler.m_parr.params[PF_PARAM_UNIFORM])
 	{
@@ -384,34 +387,13 @@ void VKFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 void VKFragmentProgram::Compile()
 {
 	fs::create_path(fs::get_config_dir() + "/shaderlog");
-	fs::file(fs::get_config_dir() + "shaderlog/FragmentProgram" + std::to_string(id) + ".spirv", fs::rewrite).write(shader);
-
-	std::vector<u32> spir_v;
-	if (!vk::compile_glsl_to_spv(shader, glsl::glsl_fragment_program, spir_v))
-		fmt::throw_exception("Failed to compile fragment shader" HERE);
-
-	//Create the object and compile
-	VkShaderModuleCreateInfo fs_info;
-	fs_info.codeSize = spir_v.size() * sizeof(u32);
-	fs_info.pNext = nullptr;
-	fs_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-	fs_info.pCode = (uint32_t*)spir_v.data();
-	fs_info.flags = 0;
-
-	VkDevice dev = (VkDevice)*vk::get_current_renderer();
-	vkCreateShaderModule(dev, &fs_info, nullptr, &handle);
+	fs::file(fs::get_config_dir() + "shaderlog/FragmentProgram" + std::to_string(id) + ".spirv", fs::rewrite).write(shader.get_source());
+	handle = shader.compile();
 }
 
 void VKFragmentProgram::Delete()
 {
-	shader.clear();
-
-	if (handle)
-	{
-		VkDevice dev = (VkDevice)*vk::get_current_renderer();
-		vkDestroyShaderModule(dev, handle, NULL);
-		handle = nullptr;
-	}
+	shader.destroy();
 }
 
 void VKFragmentProgram::SetInputs(std::vector<vk::glsl::program_input>& inputs)

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
@@ -49,7 +49,7 @@ public:
 	ParamArray parr;
 	VkShaderModule handle = nullptr;
 	u32 id;
-	std::string shader;
+	vk::glsl::shader shader;
 	std::vector<size_t> FragmentConstantOffsetCache;
 
 	std::array<u32, 4> output_color_masks{ {} };

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -588,17 +588,11 @@ VKGSRender::VKGSRender() : GSRender()
 	semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
 
 	//VRAM allocation
-	const auto& memory_map = m_device->get_memory_mapping();
-	m_attrib_ring_info.init(VK_ATTRIB_RING_BUFFER_SIZE_M * 0x100000, "attrib buffer", 0x400000);
-	m_attrib_ring_info.heap.reset(new vk::buffer(*m_device, VK_ATTRIB_RING_BUFFER_SIZE_M * 0x100000, memory_map.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, 0));
-	m_uniform_buffer_ring_info.init(VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "uniform buffer");
-	m_uniform_buffer_ring_info.heap.reset(new vk::buffer(*m_device, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, memory_map.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0));
-	m_transform_constants_ring_info.init(VK_TRANSFORM_CONSTANTS_BUFFER_SIZE_M * 0x100000, "transform constants buffer");
-	m_transform_constants_ring_info.heap.reset(new vk::buffer(*m_device, VK_TRANSFORM_CONSTANTS_BUFFER_SIZE_M * 0x100000, memory_map.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0));
-	m_index_buffer_ring_info.init(VK_INDEX_RING_BUFFER_SIZE_M * 0x100000, "index buffer");
-	m_index_buffer_ring_info.heap.reset(new vk::buffer(*m_device, VK_INDEX_RING_BUFFER_SIZE_M * 0x100000, memory_map.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, 0));
-	m_texture_upload_buffer_ring_info.init(VK_TEXTURE_UPLOAD_RING_BUFFER_SIZE_M * 0x100000, "texture upload buffer", 32 * 0x100000);
-	m_texture_upload_buffer_ring_info.heap.reset(new vk::buffer(*m_device, VK_TEXTURE_UPLOAD_RING_BUFFER_SIZE_M * 0x100000, memory_map.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0));
+	m_attrib_ring_info.create(VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, VK_ATTRIB_RING_BUFFER_SIZE_M * 0x100000, "attrib buffer", 0x400000);
+	m_uniform_buffer_ring_info.create(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "uniform buffer");
+	m_transform_constants_ring_info.create(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_TRANSFORM_CONSTANTS_BUFFER_SIZE_M * 0x100000, "transform constants buffer");
+	m_index_buffer_ring_info.create(VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_INDEX_RING_BUFFER_SIZE_M * 0x100000, "index buffer");
+	m_texture_upload_buffer_ring_info.create(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_TEXTURE_UPLOAD_RING_BUFFER_SIZE_M * 0x100000, "texture upload buffer", 32 * 0x100000);
 
 	for (auto &ctx : frame_context_storage)
 	{
@@ -606,6 +600,7 @@ VKGSRender::VKGSRender() : GSRender()
 		ctx.descriptor_pool.create(*m_device, sizes.data(), static_cast<uint32_t>(sizes.size()));
 	}
 
+	const auto& memory_map = m_device->get_memory_mapping();
 	null_buffer = std::make_unique<vk::buffer>(*m_device, 32, memory_map.host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, 0);
 	null_buffer_view = std::make_unique<vk::buffer_view>(*m_device, null_buffer->value, VK_FORMAT_R8_UINT, 0, 32);
 
@@ -685,11 +680,11 @@ VKGSRender::~VKGSRender()
 	vk::destroy_global_resources();
 
 	//Heaps
-	m_index_buffer_ring_info.heap.reset();
-	m_uniform_buffer_ring_info.heap.reset();
-	m_transform_constants_ring_info.heap.reset();
-	m_attrib_ring_info.heap.reset();
-	m_texture_upload_buffer_ring_info.heap.reset();
+	m_index_buffer_ring_info.destroy();
+	m_uniform_buffer_ring_info.destroy();
+	m_transform_constants_ring_info.destroy();
+	m_attrib_ring_info.destroy();
+	m_texture_upload_buffer_ring_info.destroy();
 
 	//Fallback bindables
 	null_buffer.reset();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2024,6 +2024,8 @@ void VKGSRender::process_swap_request(frame_context_t *ctx, bool free_resources)
 			m_overlay_manager->dispose(uids_to_dispose);
 		}
 
+		vk::reset_compute_tasks();
+
 		m_attachment_clear_pass->free_resources();
 		m_depth_converter->free_resources();
 		m_ui_renderer->free_resources();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1812,7 +1812,7 @@ void VKGSRender::copy_render_targets_to_dma_location()
 			if (!m_surface_info[index].pitch)
 				continue;
 
-			m_texture_cache.flush_memory_to_cache(m_surface_info[index].address, m_surface_info[index].pitch * m_surface_info[index].height, true,
+			m_texture_cache.flush_memory_to_cache(m_surface_info[index].address, m_surface_info[index].pitch * m_surface_info[index].height, true, 0xFF,
 					*m_current_command_buffer, m_swapchain->get_graphics_queue());
 		}
 	}
@@ -1821,7 +1821,7 @@ void VKGSRender::copy_render_targets_to_dma_location()
 	{
 		if (m_depth_surface_info.pitch)
 		{
-			m_texture_cache.flush_memory_to_cache(m_depth_surface_info.address, m_depth_surface_info.pitch * m_depth_surface_info.height, true,
+			m_texture_cache.flush_memory_to_cache(m_depth_surface_info.address, m_depth_surface_info.pitch * m_depth_surface_info.height, true, 0xFF,
 				*m_current_command_buffer, m_swapchain->get_graphics_queue());
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -9,6 +9,7 @@ namespace vk
 
 	std::unique_ptr<image> g_null_texture;
 	std::unique_ptr<image_view> g_null_image_view;
+	std::unique_ptr<buffer> g_scratch_buffer;
 	std::unordered_map<u32, std::unique_ptr<image>> g_typeless_textures;
 
 	VkSampler g_null_sampler = nullptr;
@@ -187,6 +188,19 @@ namespace vk
 		return ptr.get();
 	}
 
+	vk::buffer* get_scratch_buffer()
+	{
+		if (!g_scratch_buffer)
+		{
+			// 32M disposable scratch memory
+			g_scratch_buffer = std::make_unique<vk::buffer>(*g_current_renderer, 32 * 0x100000,
+				g_current_renderer->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+				VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
+		}
+
+		return g_scratch_buffer.get();
+	}
+
 	void acquire_global_submit_lock()
 	{
 		g_submit_mutex.lock();
@@ -201,6 +215,7 @@ namespace vk
 	{
 		g_null_texture.reset();
 		g_null_image_view.reset();
+		g_scratch_buffer.reset();
 
 		g_typeless_textures.clear();
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -72,6 +72,7 @@ namespace vk
 	class physical_device;
 	class command_buffer;
 	struct image;
+	struct buffer;
 	struct vk_data_heap;
 	class mem_allocator_base;
 	struct memory_type_mapping;
@@ -100,6 +101,7 @@ namespace vk
 	VkSampler null_sampler();
 	VkImageView null_image_view(vk::command_buffer&);
 	image* get_typeless_helper(VkFormat format);
+	buffer* get_scratch_buffer();
 
 	memory_type_mapping get_memory_mapping(const physical_device& dev);
 	gpu_formats_support get_optimal_tiling_supported_formats(const physical_device& dev);
@@ -123,6 +125,10 @@ namespace vk
 	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range);
 	void change_image_layout(VkCommandBuffer cmd, vk::image *image, VkImageLayout new_layout, VkImageSubresourceRange range);
 	void change_image_layout(VkCommandBuffer cmd, vk::image *image, VkImageLayout new_layout);
+
+	void copy_image_typeless(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout,
+		const areai& src_rect, const areai& dst_rect, u32 mipmaps, VkImageAspectFlags src_aspect, VkImageAspectFlags dst_aspect,
+		VkImageAspectFlags src_transfer_mask = 0xFF, VkImageAspectFlags dst_transfer_mask = 0xFF);
 
 	void copy_image(VkCommandBuffer cmd, VkImage &src, VkImage &dst, VkImageLayout srcLayout, VkImageLayout dstLayout,
 			const areai& src_rect, const areai& dst_rect, u32 mipmaps, VkImageAspectFlags src_aspect, VkImageAspectFlags dst_aspect,
@@ -701,7 +707,7 @@ namespace vk
 		VkBufferCreateInfo info = {};
 		std::unique_ptr<vk::memory_block> memory;
 
-		buffer(vk::render_device& dev, u64 size, uint32_t memory_type_index, uint32_t access_flags, VkBufferUsageFlagBits usage, VkBufferCreateFlags flags)
+		buffer(const vk::render_device& dev, u64 size, uint32_t memory_type_index, uint32_t access_flags, VkBufferUsageFlags usage, VkBufferCreateFlags flags)
 			: m_device(dev)
 		{
 			info.size = size;

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -11,8 +11,8 @@ namespace vk
 	//TODO: Refactor text print class to inherit from this base class
 	struct overlay_pass
 	{
-		VKVertexProgram m_vertex_shader;
-		VKFragmentProgram m_fragment_shader;
+		vk::glsl::shader m_vertex_shader;
+		vk::glsl::shader m_fragment_shader;
 
 		vk::descriptor_pool m_descriptor_pool;
 		VkDescriptorSet m_descriptor_set = nullptr;
@@ -149,11 +149,11 @@ namespace vk
 		{
 			if (!compiled)
 			{
-				m_vertex_shader.shader = vs_src;
-				m_vertex_shader.Compile();
+				m_vertex_shader.create(::glsl::program_domain::glsl_vertex_program, vs_src);
+				m_vertex_shader.compile();
 
-				m_fragment_shader.shader = fs_src;
-				m_fragment_shader.Compile();
+				m_fragment_shader.create(::glsl::program_domain::glsl_fragment_program, fs_src);
+				m_fragment_shader.compile();
 
 				compiled = true;
 			}
@@ -161,12 +161,12 @@ namespace vk
 			VkPipelineShaderStageCreateInfo shader_stages[2] = {};
 			shader_stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
 			shader_stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-			shader_stages[0].module = m_vertex_shader.handle;
+			shader_stages[0].module = m_vertex_shader.get_handle();
 			shader_stages[0].pName = "main";
 
 			shader_stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
 			shader_stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-			shader_stages[1].module = m_fragment_shader.handle;
+			shader_stages[1].module = m_fragment_shader.get_handle();
 			shader_stages[1].pName = "main";
 
 			VkDynamicState dynamic_state_descriptors[VK_DYNAMIC_STATE_RANGE_SIZE] = {};
@@ -282,6 +282,8 @@ namespace vk
 		{
 			if (initialized)
 			{
+				m_vertex_shader.destroy();
+				m_fragment_shader.destroy();
 				m_program_cache.clear();
 				m_sampler.reset();
 
@@ -434,9 +436,6 @@ namespace vk
 			renderpass_config.set_depth_mask(true);
 			renderpass_config.enable_depth_test(VK_COMPARE_OP_ALWAYS);
 			renderpass_config.enable_stencil_test(VK_STENCIL_OP_REPLACE, VK_STENCIL_OP_REPLACE, VK_STENCIL_OP_REPLACE, VK_COMPARE_OP_ALWAYS, 0xFF, 0xFF);
-
-			m_vertex_shader.id = 100002;
-			m_fragment_shader.id = 100003;
 		}
 	};
 
@@ -521,9 +520,6 @@ namespace vk
 				VK_BLEND_FACTOR_SRC_ALPHA, VK_BLEND_FACTOR_SRC_ALPHA,
 				VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
 				VK_BLEND_OP_ADD, VK_BLEND_OP_ADD);
-
-			m_vertex_shader.id = 100004;
-			m_fragment_shader.id = 100005;
 		}
 
 		vk::image_view* upload_simple_texture(vk::render_device &dev, vk::command_buffer &cmd,
@@ -784,9 +780,6 @@ namespace vk
 			renderpass_config.set_depth_mask(false);
 			renderpass_config.set_color_mask(true, true, true, true);
 			renderpass_config.set_attachment_count(1);
-
-			m_vertex_shader.id = 100006;
-			m_fragment_shader.id = 100007;
 		}
 
 		void update_uniforms(vk::glsl::program* /*program*/) override

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -48,7 +48,7 @@ namespace vk
 			return false;
 		}
 
-		void program::bind_uniform(VkDescriptorImageInfo image_descriptor, std::string uniform_name, VkDescriptorSet &descriptor_set)
+		void program::bind_uniform(const VkDescriptorImageInfo &image_descriptor, std::string uniform_name, VkDescriptorSet &descriptor_set)
 		{
 			for (auto &uniform : uniforms)
 			{
@@ -72,19 +72,9 @@ namespace vk
 			LOG_NOTICE(RSX, "texture not found in program: %s", uniform_name.c_str());
 		}
 
-		void program::bind_uniform(VkDescriptorBufferInfo buffer_descriptor, uint32_t binding_point, VkDescriptorSet &descriptor_set)
+		void program::bind_uniform(const VkDescriptorBufferInfo &buffer_descriptor, uint32_t binding_point, VkDescriptorSet &descriptor_set)
 		{
-			VkWriteDescriptorSet descriptor_writer = {};
-			descriptor_writer.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-			descriptor_writer.dstSet = descriptor_set;
-			descriptor_writer.descriptorCount = 1;
-			descriptor_writer.pBufferInfo = &buffer_descriptor;
-			descriptor_writer.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-			descriptor_writer.dstArrayElement = 0;
-			descriptor_writer.dstBinding = binding_point;
-
-			vkUpdateDescriptorSets(m_device, 1, &descriptor_writer, 0, nullptr);
-			attribute_location_mask |= (1ull << binding_point);
+			bind_buffer(buffer_descriptor, binding_point, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, descriptor_set);
 		}
 
 		void program::bind_uniform(const VkBufferView &buffer_view, const std::string &binding_name, VkDescriptorSet &descriptor_set)
@@ -109,6 +99,21 @@ namespace vk
 			}
 			
 			LOG_NOTICE(RSX, "vertex buffer not found in program: %s", binding_name.c_str());
+		}
+
+		void program::bind_buffer(const VkDescriptorBufferInfo &buffer_descriptor, uint32_t binding_point, VkDescriptorType type, VkDescriptorSet &descriptor_set)
+		{
+			VkWriteDescriptorSet descriptor_writer = {};
+			descriptor_writer.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			descriptor_writer.dstSet = descriptor_set;
+			descriptor_writer.descriptorCount = 1;
+			descriptor_writer.pBufferInfo = &buffer_descriptor;
+			descriptor_writer.descriptorType = type;
+			descriptor_writer.dstArrayElement = 0;
+			descriptor_writer.dstBinding = binding_point;
+
+			vkUpdateDescriptorSets(m_device, 1, &descriptor_writer, 0, nullptr);
+			attribute_location_mask |= (1ull << binding_point);
 		}
 
 		u64 program::get_vertex_input_attributes_mask()

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -13,8 +13,8 @@ namespace vk
 		std::unique_ptr<vk::buffer> m_uniforms_buffer;
 		
 		std::unique_ptr<vk::glsl::program> m_program;
-		VKVertexProgram m_vertex_shader;
-		VKFragmentProgram m_fragment_shader;
+		vk::glsl::shader m_vertex_shader;
+		vk::glsl::shader m_fragment_shader;
 
 		vk::descriptor_pool m_descriptor_pool;
 		VkDescriptorSet m_descriptor_set = nullptr;
@@ -102,23 +102,21 @@ namespace vk
 				"}\n"
 			};
 
-			m_vertex_shader.shader = vs;
-			m_vertex_shader.id = 100000;
-			m_vertex_shader.Compile();
+			m_vertex_shader.create(::glsl::program_domain::glsl_vertex_program, vs);
+			m_vertex_shader.compile();
 
-			m_fragment_shader.shader = fs;
-			m_fragment_shader.id = 100001;
-			m_fragment_shader.Compile();
+			m_fragment_shader.create(::glsl::program_domain::glsl_fragment_program, fs);
+			m_fragment_shader.compile();
 
 			VkPipelineShaderStageCreateInfo shader_stages[2] = {};
 			shader_stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
 			shader_stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-			shader_stages[0].module = m_vertex_shader.handle;
+			shader_stages[0].module = m_vertex_shader.get_handle();
 			shader_stages[0].pName = "main";
 
 			shader_stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
 			shader_stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-			shader_stages[1].module = m_fragment_shader.handle;
+			shader_stages[1].module = m_fragment_shader.get_handle();
 			shader_stages[1].pName = "main";
 
 			VkDynamicState dynamic_state_descriptors[VK_DYNAMIC_STATE_RANGE_SIZE] = {};
@@ -246,6 +244,9 @@ namespace vk
 		{
 			if (initialized)
 			{
+				m_vertex_shader.destroy();
+				m_fragment_shader.destroy();
+
 				vkDestroyDescriptorSetLayout(device, m_descriptor_layout, nullptr);
 				vkDestroyPipelineLayout(device, m_pipeline_layout, nullptr);
 				m_descriptor_pool.destroy();

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1177,8 +1177,44 @@ namespace vk
 				VkFormat format;
 				blit_helper(vk::command_buffer *c) : commands(c) {}
 
-				void scale_image(vk::image* src, vk::image* dst, areai src_area, areai dst_area, bool interpolate, bool /*is_depth*/, const rsx::typeless_xfer& /*typeless*/)
+				void scale_image(vk::image* src, vk::image* dst, areai src_area, areai dst_area, bool interpolate, bool /*is_depth*/, const rsx::typeless_xfer& xfer_info)
 				{
+					const auto src_aspect = vk::get_aspect_flags(src->info.format);
+					const auto dst_aspect = vk::get_aspect_flags(dst->info.format);
+
+					vk::image* real_src = src;
+					vk::image* real_dst = dst;
+
+					if (xfer_info.src_is_typeless)
+					{
+						auto internal_width = src->width() * xfer_info.src_scaling_hint;
+						auto format = vk::get_compatible_sampler_format(vk::get_current_renderer()->get_formats_support(), xfer_info.src_gcm_format);
+
+						// Transfer bits from src to typeless src
+						real_src = vk::get_typeless_helper(format);
+						src_area.x1 = (u16)(src_area.x1 * xfer_info.src_scaling_hint);
+						src_area.x2 = (u16)(src_area.x2 * xfer_info.src_scaling_hint);
+
+						vk::copy_image_typeless(*commands, src->value, real_src->value, src->current_layout, real_src->current_layout,
+							{ 0, 0, (s32)src->width(), (s32)src->height() }, { 0, 0, (s32)internal_width, (s32)src->height() }, 1,
+							vk::get_aspect_flags(src->info.format), vk::get_aspect_flags(format));
+					}
+
+					if (xfer_info.dst_is_typeless)
+					{
+						auto internal_width = dst->width() * xfer_info.dst_scaling_hint;
+						auto format = vk::get_compatible_sampler_format(vk::get_current_renderer()->get_formats_support(), xfer_info.dst_gcm_format);
+
+						// Transfer bits from dst to typeless dst
+						real_dst = vk::get_typeless_helper(format);
+						dst_area.x1 = (u16)(dst_area.x1 * xfer_info.dst_scaling_hint);
+						dst_area.x2 = (u16)(dst_area.x2 * xfer_info.dst_scaling_hint);
+
+						vk::copy_image_typeless(*commands, dst->value, real_dst->value, dst->current_layout, real_dst->current_layout,
+							{ 0, 0, (s32)dst->width(), (s32)dst->height() }, { 0, 0, (s32)internal_width, (s32)dst->height() }, 1,
+							vk::get_aspect_flags(dst->info.format), vk::get_aspect_flags(format));
+					}
+
 					//Checks
 					if (src_area.x2 <= src_area.x1 || src_area.y2 <= src_area.y1 || dst_area.x2 <= dst_area.x1 || dst_area.y2 <= dst_area.y1)
 					{
@@ -1186,29 +1222,36 @@ namespace vk
 						return;
 					}
 
-					if (src_area.x1 < 0 || src_area.x2 > (s32)src->width() || src_area.y1 < 0 || src_area.y2 > (s32)src->height())
+					if (src_area.x1 < 0 || src_area.x2 >(s32)real_src->width() || src_area.y1 < 0 || src_area.y2 >(s32)real_src->height())
 					{
 						LOG_ERROR(RSX, "Blit request denied because the source region does not fit!");
 						return;
 					}
 
-					if (dst_area.x1 < 0 || dst_area.x2 > (s32)dst->width() || dst_area.y1 < 0 || dst_area.y2 > (s32)dst->height())
+					if (dst_area.x1 < 0 || dst_area.x2 >(s32)real_dst->width() || dst_area.y1 < 0 || dst_area.y2 >(s32)real_dst->height())
 					{
 						LOG_ERROR(RSX, "Blit request denied because the destination region does not fit!");
 						return;
 					}
 
-					const auto aspect = vk::get_aspect_flags(src->info.format);
 					const auto src_width = src_area.x2 - src_area.x1;
 					const auto src_height = src_area.y2 - src_area.y1;
 					const auto dst_width = dst_area.x2 - dst_area.x1;
 					const auto dst_height = dst_area.y2 - dst_area.y1;
 
-					copy_scaled_image(*commands, src->value, dst->value, src->current_layout, dst->current_layout, src_area.x1, src_area.y1, src_width, src_height,
-						dst_area.x1, dst_area.y1, dst_width, dst_height, 1, aspect, src->info.format == dst->info.format,
-						interpolate? VK_FILTER_LINEAR : VK_FILTER_NEAREST, src->info.format, dst->info.format);
+					copy_scaled_image(*commands, real_src->value, real_dst->value, real_src->current_layout, real_dst->current_layout, src_area.x1, src_area.y1, src_width, src_height,
+						dst_area.x1, dst_area.y1, dst_width, dst_height, 1, dst_aspect, real_src->info.format == real_dst->info.format,
+						interpolate ? VK_FILTER_LINEAR : VK_FILTER_NEAREST, real_src->info.format, real_dst->info.format);
 
-					change_image_layout(*commands, dst, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, {(VkImageAspectFlags)aspect, 0, dst->info.mipLevels, 0, dst->info.arrayLayers});
+					if (real_dst != dst)
+					{
+						auto internal_width = dst->width() * xfer_info.dst_scaling_hint;
+						vk::copy_image_typeless(*commands, real_dst->value, dst->value, real_dst->current_layout, dst->current_layout,
+							{ 0, 0, (s32)internal_width, (s32)dst->height() }, { 0, 0, (s32)dst->width(), (s32)dst->height() }, 1,
+							vk::get_aspect_flags(real_dst->info.format), vk::get_aspect_flags(dst->info.format));
+					}
+
+					change_image_layout(*commands, dst, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, {(VkImageAspectFlags)dst_aspect, 0, dst->info.mipLevels, 0, dst->info.arrayLayers});
 					format = dst->info.format;
 				}
 			}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1195,8 +1195,7 @@ namespace vk
 						src_area.x1 = (u16)(src_area.x1 * xfer_info.src_scaling_hint);
 						src_area.x2 = (u16)(src_area.x2 * xfer_info.src_scaling_hint);
 
-						vk::copy_image_typeless(*commands, src->value, real_src->value, src->current_layout, real_src->current_layout,
-							{ 0, 0, (s32)src->width(), (s32)src->height() }, { 0, 0, (s32)internal_width, (s32)src->height() }, 1,
+						vk::copy_image_typeless(*commands, src, real_src, { 0, 0, (s32)src->width(), (s32)src->height() }, { 0, 0, (s32)internal_width, (s32)src->height() }, 1,
 							vk::get_aspect_flags(src->info.format), vk::get_aspect_flags(format));
 					}
 
@@ -1210,8 +1209,7 @@ namespace vk
 						dst_area.x1 = (u16)(dst_area.x1 * xfer_info.dst_scaling_hint);
 						dst_area.x2 = (u16)(dst_area.x2 * xfer_info.dst_scaling_hint);
 
-						vk::copy_image_typeless(*commands, dst->value, real_dst->value, dst->current_layout, real_dst->current_layout,
-							{ 0, 0, (s32)dst->width(), (s32)dst->height() }, { 0, 0, (s32)internal_width, (s32)dst->height() }, 1,
+						vk::copy_image_typeless(*commands, dst, real_dst, { 0, 0, (s32)dst->width(), (s32)dst->height() }, { 0, 0, (s32)internal_width, (s32)dst->height() }, 1,
 							vk::get_aspect_flags(dst->info.format), vk::get_aspect_flags(format));
 					}
 
@@ -1246,8 +1244,7 @@ namespace vk
 					if (real_dst != dst)
 					{
 						auto internal_width = dst->width() * xfer_info.dst_scaling_hint;
-						vk::copy_image_typeless(*commands, real_dst->value, dst->value, real_dst->current_layout, dst->current_layout,
-							{ 0, 0, (s32)internal_width, (s32)dst->height() }, { 0, 0, (s32)dst->width(), (s32)dst->height() }, 1,
+						vk::copy_image_typeless(*commands, real_dst, dst, { 0, 0, (s32)internal_width, (s32)dst->height() }, { 0, 0, (s32)dst->width(), (s32)dst->height() }, 1,
 							vk::get_aspect_flags(real_dst->info.format), vk::get_aspect_flags(dst->info.format));
 					}
 

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.h
@@ -46,7 +46,7 @@ public:
 	ParamArray parr;
 	VkShaderModule handle = nullptr;
 	u32 id;
-	std::string shader;
+	vk::glsl::shader shader;
 	std::vector<vk::glsl::program_input> uniforms;
 
 	void Decompile(const RSXVertexProgram& prog);

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Emu\RSX\VK\VKCommonDecompiler.h" />
+    <ClInclude Include="Emu\RSX\VK\VKCompute.h" />
     <ClInclude Include="Emu\RSX\VK\VKFormats.h" />
     <ClInclude Include="Emu\RSX\VK\VKFragmentProgram.h" />
     <ClInclude Include="Emu\RSX\VK\VKGSRender.h" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -43,6 +43,9 @@
     <ClInclude Include="Emu\RSX\VK\VKOverlays.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\VKCompute.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Emu\RSX\VK\VKGSRender.cpp">


### PR DESCRIPTION
- vk: Implement type-agnostic transfer (e.g rgba16f to rgba8 memory). Fixes lighting in some situations
- vk: Introduce compute transactions to offload some calculations from the cpu. This is still very barebones and integration is not finalized.
- Minor theoretical fixup for texture cache
- rsx: Improve read prediction for synchronized resources (wcb or blit engine). Significantly reduces the number of hard faults and lowers latency by eliminating unexpected readback
- vk: Fixup for RADV driver