### PR TITLE
minor fix

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -245,7 +245,9 @@ struct vdec_thread : ppu_thread
 
 					if (decode < 0)
 					{
-						fmt::throw_exception("AU decoding error(0x%x)" HERE, decode);
+						char av_error[AV_ERROR_MAX_STRING_SIZE];
+						av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, decode);
+						fmt::throw_exception("AU decoding error(0x%x): %s" HERE, decode, av_error);
 					}
 
 					if (got_picture == 0)

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -195,31 +195,39 @@ void emu_settings::LoadSettings(const std::string& path)
 	m_currentSettings = YAML::Load(g_cfg_defaults);
 
 	// Add global config
-	m_config = fs::file(fs::get_config_dir() + "/config.yml", fs::read + fs::write + fs::create);
-	m_currentSettings += YAML::Load(m_config.to_string());
+	fs::file config(fs::get_config_dir() + "/config.yml", fs::read + fs::write + fs::create);
+	m_currentSettings += YAML::Load(config.to_string());
+	config.close();
 
 	// Add game config
 	if (!path.empty() && fs::is_file(fs::get_config_dir() + path + "/config.yml"))
 	{
-		m_config = fs::file(fs::get_config_dir() + path + "/config.yml", fs::read + fs::write);
-		m_currentSettings += YAML::Load(m_config.to_string());
+		config = fs::file(fs::get_config_dir() + path + "/config.yml", fs::read + fs::write);
+		m_currentSettings += YAML::Load(config.to_string());
+		config.close();
 	}
 }
 
 void emu_settings::SaveSettings()
 {
+	fs::file config;
 	YAML::Emitter out;
 	emitData(out, m_currentSettings);
 
 	if (!m_path.empty())
 	{
-		m_config = fs::file(fs::get_config_dir() + m_path + "/config.yml", fs::read + fs::write + fs::create);
+		config = fs::file(fs::get_config_dir() + m_path + "/config.yml", fs::read + fs::write + fs::create);
+	}
+	else
+	{
+		config = fs::file(fs::get_config_dir() + "/config.yml", fs::read + fs::write + fs::create);
 	}
 
 	// Save config
-	m_config.seek(0);
-	m_config.trunc(0);
-	m_config.write(out.c_str(), out.size());
+	config.seek(0);
+	config.trunc(0);
+	config.write(out.c_str(), out.size());
+	config.close();
 }
 
 void emu_settings::EnhanceComboBox(QComboBox* combobox, SettingsType type, bool is_ranged, bool use_max, int max)

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -287,6 +287,5 @@ private:
 
 	YAML::Node m_defaultSettings; // The default settings as a YAML node.
 	YAML::Node m_currentSettings; // The current settings as a YAML node.
-	fs::file m_config; //! File to read/write the config settings.
 	std::string m_path;
 };

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -15,74 +15,73 @@ game_compatibility::game_compatibility(std::shared_ptr<gui_settings> settings) :
 	RequestCompatibility();
 }
 
+bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_download)
+{
+	int return_code = json_data["return_code"].toInt();
+
+	if (return_code < 0)
+	{
+		if (after_download)
+		{
+			std::string error_message;
+			switch (return_code)
+			{
+			case -1:
+				error_message = "Server Error - Internal Error";
+				break;
+			case -2:
+				error_message = "Server Error - Maintenance Mode";
+				break;
+			default:
+				error_message = "Server Error - Unknown Error";
+				break;
+			}
+			LOG_ERROR(GENERAL, "Compatibility error: { %s: return code %d }", error_message, return_code);
+			Q_EMIT DownloadError(qstr(error_message) + " " + QString::number(return_code));
+		}
+		else
+		{
+			LOG_ERROR(GENERAL, "Compatibility error: { Database Error - Invalid: return code %d }", return_code);
+		}
+		return false;
+	}
+
+	if (!json_data["results"].isObject())
+	{
+		LOG_ERROR(GENERAL, "Compatibility error: { Database Error - No Results found }");
+		return false;
+	}
+
+	m_compat_database.clear();
+
+	QJsonObject json_results = json_data["results"].toObject();
+
+	// Retrieve status data for every valid entry
+	for (const auto& key : json_results.keys())
+	{
+		if (!json_results[key].isObject())
+		{
+			LOG_ERROR(GENERAL, "Compatibility error: { Database Error - Unusable object %s }", sstr(key));
+			continue;
+		}
+
+		QJsonObject json_result = json_results[key].toObject();
+
+		// Retrieve compatibility information from json
+		compat_status status = Status_Data.at(json_result.value("status").toString("NoResult"));
+
+		// Add date if possible
+		status.date = json_result.value("date").toString();
+
+		// Add status to map
+		m_compat_database.emplace(std::pair<std::string, compat_status>(sstr(key), status));
+	}
+
+	return true;
+}
+
 void game_compatibility::RequestCompatibility(bool online)
 {
-	// Creates new map from database
-	auto ReadJSON = [=](const QJsonObject& json_data, bool after_download)
-	{
-		int return_code = json_data["return_code"].toInt();
-
-		if (return_code < 0)
-		{
-			if (after_download)
-			{
-				std::string error_message;
-				switch (return_code)
-				{
-				case -1:
-					error_message = "Server Error - Internal Error";
-					break;
-				case -2:
-					error_message = "Server Error - Maintenance Mode";
-					break;
-				default:
-					error_message = "Server Error - Unknown Error";
-					break;
-				}
-				LOG_ERROR(GENERAL, "Compatibility error: { %s: return code %d }", error_message, return_code);
-				Q_EMIT DownloadError(qstr(error_message) + " " + QString::number(return_code));
-			}
-			else
-			{
-				LOG_ERROR(GENERAL, "Compatibility error: { Database Error - Invalid: return code %d }", return_code);
-			}
-			return false;
-		}
-
-		if (!json_data["results"].isObject())
-		{
-			LOG_ERROR(GENERAL, "Compatibility error: { Database Error - No Results found }");
-			return false;
-		}
-
-		m_compat_database.clear();
-
-		QJsonObject json_results = json_data["results"].toObject();
-
-		// Retrieve status data for every valid entry
-		for (const auto& key : json_results.keys())
-		{
-			if (!json_results[key].isObject())
-			{
-				LOG_ERROR(GENERAL, "Compatibility error: { Database Error - Unusable object %s }", sstr(key));
-				continue;
-			}
-
-			QJsonObject json_result = json_results[key].toObject();
-
-			// Retrieve compatibility information from json
-			compat_status status = Status_Data.at(json_result.value("status").toString("NoResult"));
-
-			// Add date if possible
-			status.date = json_result.value("date").toString();
-
-			// Add status to map
-			m_compat_database.emplace(std::pair<std::string, compat_status>(sstr(key), status));
-		}
-
-		return true;
-	};
-
 	if (!online)
 	{
 		// Retrieve database from file

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -28,6 +28,7 @@ class game_compatibility : public QObject
 {
 	Q_OBJECT
 
+private:
 	const std::map<QString, compat_status> Status_Data =
 	{
 		{ "Playable", { 0, "", "#1ebc61", QObject::tr("Playable"),         QObject::tr("Games that can be properly played from start to finish") } },
@@ -48,6 +49,9 @@ class game_compatibility : public QObject
 	std::unique_ptr<progress_dialog> m_progress_dialog;
 	std::unique_ptr<QNetworkAccessManager> m_network_access_manager;
 	std::map<std::string, compat_status> m_compat_database;
+
+	/** Creates new map from the database */
+	bool ReadJSON(const QJsonObject& json_data, bool after_download);
 
 public:
 	/** Handles reads, writes and downloads for the compatibility database */

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -832,17 +832,18 @@ bool game_list_frame::DeleteShadersCache(const std::string& base_dir, bool is_in
 	if (is_interactive && QMessageBox::question(this, tr("Confirm Delete"), tr("Delete shaders cache?")) != QMessageBox::Yes)
 		return false;
 
-	fs::dir root = fs::dir(base_dir);
-	fs::dir_entry tmp;
-
-	while (root.read(tmp))
+	QDirIterator dir_iter(qstr(base_dir), QDir::Dirs | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+	while (dir_iter.hasNext())
 	{
-		if (!fs::is_dir(base_dir + "/" + tmp.name))
-			continue;
+		const QString filepath = dir_iter.next();
 
-		const std::string shader_cache_name = base_dir + "/" + tmp.name + "/shaders_cache";
-		if (fs::is_dir(shader_cache_name))
-			fs::remove_all(shader_cache_name, true);
+		if (dir_iter.fileName() == "shaders_cache")
+		{
+			if (QDir(filepath).removeRecursively())
+				LOG_NOTICE(GENERAL, "Removed shaders cache dir: %s", sstr(filepath));
+			else
+				LOG_WARNING(GENERAL, "Could not remove shaders cache file: %s", sstr(filepath));
+		}
 	}
 
 	LOG_SUCCESS(GENERAL, "Removed shaders cache in %s", base_dir);
@@ -857,21 +858,21 @@ bool game_list_frame::DeleteLLVMCache(const std::string& base_dir, bool is_inter
 	if (is_interactive && QMessageBox::question(this, tr("Confirm Delete"), tr("Delete LLVM cache?")) != QMessageBox::Yes)
 		return false;
 
-	for (auto&& subdir : fs::dir{ base_dir })
+	QDirIterator dir_iter(qstr(base_dir), QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+	while (dir_iter.hasNext())
 	{
-		if (!subdir.is_directory || subdir.name == "." || subdir.name == "..")
-			continue;
+		const QString filepath = dir_iter.next();
 
-		const std::string dir = base_dir + "/" + subdir.name;
-
-		for (auto&& entry : fs::dir{ dir })
+		if (dir_iter.fileInfo().absoluteFilePath().endsWith(".obj", Qt::CaseInsensitive))
 		{
-			if (entry.name.size() >= 4 && entry.name.compare(entry.name.size() - 4, 4, ".obj", 4) == 0)
-				fs::remove_file(dir + "/" + entry.name);
+			if (QFile::remove(filepath))
+				LOG_NOTICE(GENERAL, "Removed LLVM cache file: %s", sstr(filepath));
+			else
+				LOG_WARNING(GENERAL, "Could not remove LLVM cache file: %s", sstr(filepath));
 		}
 	}
 
-	LOG_SUCCESS(GENERAL, "Removed llvm cache in %s", base_dir);
+	LOG_SUCCESS(GENERAL, "Removed LLVM cache in %s", base_dir);
 	return true;
 }
 

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -214,6 +214,7 @@ private Q_SLOTS:
 	bool RemoveCustomConfiguration(const std::string& base_dir, bool is_interactive = false);
 	bool DeleteShadersCache(const std::string& base_dir, bool is_interactive = false);
 	bool DeleteLLVMCache(const std::string& base_dir, bool is_interactive = false);
+	bool DeleteSPUCache(const std::string& base_dir, bool is_interactive = false);
 	void OnColClicked(int col);
 	void ShowContextMenu(const QPoint &pos);
 	void doubleClickedSlot(QTableWidgetItem *item);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1620,7 +1620,8 @@ Add valid disc games to gamelist (games.yml)
 */
 void main_window::AddGamesFromDir(const QString& path)
 {
-	if (!QFileInfo(path).isDir()) return;
+	if (!QFileInfo(path).isDir())
+		return;
 
 	const std::string s_path = sstr(path);
 
@@ -1631,13 +1632,10 @@ void main_window::AddGamesFromDir(const QString& path)
 	}
 
 	// search direct subdirectories, that way we can drop one folder containing all games
-	for (const auto& entry : fs::dir(s_path))
+	QDirIterator dir_iter(path, QDir::Dirs | QDir::NoDotAndDotDot);
+	while (dir_iter.hasNext())
 	{
-		if (entry.name == "." || entry.name == "..") continue;
-
-		const std::string pth = s_path + "/" + entry.name;
-
-		if (!QFileInfo(qstr(pth)).isDir()) continue;
+		std::string pth = sstr(dir_iter.next());
 
 		if (Emu.BootGame(pth, false, true))
 		{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -241,6 +241,26 @@ void main_window::SetAppIconFromPath(const std::string& path)
 	m_appIcon = QApplication::windowIcon();
 }
 
+void main_window::ResizeIcons(int index)
+{
+	if (ui->sizeSlider->value() != index)
+	{
+		ui->sizeSlider->setSliderPosition(index);
+		return; // ResizeIcons will be triggered again by setSliderPosition, so return here
+	}
+
+	if (m_save_slider_pos)
+	{
+		m_save_slider_pos = false;
+		guiSettings->SetValue(m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid, index);
+
+		// this will also fire when we used the actions, but i didn't want to add another boolean member
+		SetIconSizeActions(index);
+	}
+
+	m_gameListFrame->ResizeIcons(index);
+}
+
 void main_window::OnPlayOrPause()
 {
 	if (Emu.IsReady())
@@ -1304,43 +1324,31 @@ void main_window::CreateConnects()
 
 	connect(ui->aboutQtAct, &QAction::triggered, qApp, &QApplication::aboutQt);
 
-	auto resizeIcons = [=](const int& index)
-	{
-		if (ui->sizeSlider->value() != index)
-		{
-			ui->sizeSlider->setSliderPosition(index);
-		}
-		if (m_save_slider_pos)
-		{
-			m_save_slider_pos = false;
-			guiSettings->SetValue(m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid, index);
-		}
-		m_gameListFrame->ResizeIcons(index);
-	};
-
 	connect(m_iconSizeActGroup, &QActionGroup::triggered, [=](QAction* act)
 	{
+		static const int index_small  = gui::get_Index(gui::gl_icon_size_small);
+		static const int index_medium = gui::get_Index(gui::gl_icon_size_medium);
+
 		int index;
 
 		if (act == ui->setIconSizeTinyAct)
 			index = 0;
 		else if (act == ui->setIconSizeSmallAct)
-			index = gui::get_Index(gui::gl_icon_size_small);
+			index = index_small;
 		else if (act == ui->setIconSizeMediumAct)
-			index = gui::get_Index(gui::gl_icon_size_medium);
+			index = index_medium;
 		else
 			index = gui::gl_max_slider_pos;
 
 		m_save_slider_pos = true;
-		resizeIcons(index);
+		ResizeIcons(index);
 	});
 
 	connect (m_gameListFrame, &game_list_frame::RequestIconSizeChange, [=](const int& val)
 	{
 		const int idx = ui->sizeSlider->value() + val;
 		m_save_slider_pos = true;
-		SetIconSizeActions(idx);
-		resizeIcons(idx);
+		ResizeIcons(idx);
 	});
 
 	connect(m_listModeActGroup, &QActionGroup::triggered, [=](QAction* act)
@@ -1382,10 +1390,12 @@ void main_window::CreateConnects()
 	connect(ui->toolbar_list, &QAction::triggered, [=]() { ui->setlistModeListAct->trigger(); });
 	connect(ui->toolbar_grid, &QAction::triggered, [=]() { ui->setlistModeGridAct->trigger(); });
 
-	connect(ui->sizeSlider, &QSlider::valueChanged, resizeIcons);
+	connect(ui->sizeSlider, &QSlider::valueChanged, this, &main_window::ResizeIcons);
 	connect(ui->sizeSlider, &QSlider::sliderReleased, this, [&]
 	{
-		guiSettings->SetValue(m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid, ui->sizeSlider->value());
+		const int index = ui->sizeSlider->value();
+		guiSettings->SetValue(m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid, index);
+		SetIconSizeActions(index);
 	});
 	connect(ui->sizeSlider, &QSlider::actionTriggered, [&](int action)
 	{
@@ -1540,11 +1550,15 @@ void main_window::ConfigureGuiFromSettings(bool configure_all)
 
 void main_window::SetIconSizeActions(int idx)
 {
-	if (idx < gui::get_Index((gui::gl_icon_size_small + gui::gl_icon_size_min) / 2))
+	static const int threshold_tiny = gui::get_Index((gui::gl_icon_size_small + gui::gl_icon_size_min) / 2);
+	static const int threshold_small = gui::get_Index((gui::gl_icon_size_medium + gui::gl_icon_size_small) / 2);
+	static const int threshold_medium = gui::get_Index((gui::gl_icon_size_max + gui::gl_icon_size_medium) / 2);
+
+	if (idx < threshold_tiny)
 		ui->setIconSizeTinyAct->setChecked(true);
-	else if (idx < gui::get_Index((gui::gl_icon_size_medium + gui::gl_icon_size_small) / 2))
+	else if (idx < threshold_small)
 		ui->setIconSizeSmallAct->setChecked(true);
-	else if (idx < gui::get_Index((gui::gl_icon_size_max + gui::gl_icon_size_medium) / 2))
+	else if (idx < threshold_medium)
 		ui->setIconSizeMediumAct->setChecked(true);
 	else
 		ui->setIconSizeLargeAct->setChecked(true);

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -96,6 +96,7 @@ private Q_SLOTS:
 	void SaveWindowState();
 	void ConfigureGuiFromSettings(bool configure_all = false);
 	void SetIconSizeActions(int idx);
+	void ResizeIcons(int index);
 
 protected:
 	void closeEvent(QCloseEvent *event) override;

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -5,7 +5,7 @@ progress_dialog::progress_dialog(const QString &labelText, const QString &cancel
 {
 #ifdef _WIN32
 	m_tb_button = std::make_unique<QWinTaskbarButton>();
-	m_tb_button->setWindow(parent->windowHandle());
+	m_tb_button->setWindow(parent ? parent->windowHandle() : windowHandle());
 	m_tb_progress = m_tb_button->progress();
 	m_tb_progress->setRange(minimum, maximum);
 	m_tb_progress->setVisible(true);

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -157,9 +157,9 @@ void save_data_list_dialog::OnSort(int logicalIndex)
 		{
 			m_sort_ascending = true;
 		}
+		m_sort_column = logicalIndex;
 		Qt::SortOrder sort_order = m_sort_ascending ? Qt::AscendingOrder : Qt::DescendingOrder;
 		m_list->sortByColumn(m_sort_column, sort_order);
-		m_sort_column = logicalIndex;
 	}
 }
 

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -217,9 +217,9 @@ void save_manager_dialog::OnSort(int logicalIndex)
 		{
 			m_sort_ascending = true;
 		}
+		m_sort_column = logicalIndex;
 		Qt::SortOrder sort_order = m_sort_ascending ? Qt::AscendingOrder : Qt::DescendingOrder;
 		m_list->sortByColumn(m_sort_column, sort_order);
-		m_sort_column = logicalIndex;
 	}
 }
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1235,6 +1235,7 @@ int settings_dialog::exec()
 	// If we use setCurrentIndex now we will miraculously see a resize of the dialog as soon as we
 	// switch to the cpu tab after conjuring the settings_dialog with another tab opened first.
 	// Weirdly enough this won't happen if we change the tab order so that anything else is at index 0.
+	ui->tab_widget_settings->setCurrentIndex(0);
 	QTimer::singleShot(0, [=]{ ui->tab_widget_settings->setCurrentIndex(m_tab_Index); });
 	return QDialog::exec();
 }

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -111,14 +111,10 @@ trophy_manager_dialog::trophy_manager_dialog(std::shared_ptr<gui_settings> gui_s
 	m_splitter->addWidget(m_trophy_table);
 
 	// Populate the trophy database
-	QDirIterator dir_iter(qstr(vfs::get(m_TROPHY_DIR)));
+	QDirIterator dir_iter(qstr(vfs::get(m_TROPHY_DIR)), QDir::Dirs | QDir::NoDotAndDotDot);
 	while (dir_iter.hasNext()) 
 	{
 		dir_iter.next();
-		if (dir_iter.fileName() == "." || dir_iter.fileName() == ".." || dir_iter.fileName() == ".gitignore")
-		{
-			continue;
-		}
 		std::string dirName = sstr(dir_iter.fileName());
 		LOG_TRACE(GENERAL, "Loading trophy dir: %s", dirName);
 		LoadTrophyFolderToDB(dirName);

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.h
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.h
@@ -1,5 +1,4 @@
-#ifndef TROPHY_MANAGER_DIALOG
-#define TROPHY_MANAGER_DIALOG
+#pragma once
 
 #include "stdafx.h"
 #include "rpcs3/Loader/TROPUSR.h"
@@ -76,6 +75,7 @@ private:
 	void ReadjustTrophyTable();
 
 	void closeEvent(QCloseEvent *event) override;
+	bool eventFilter(QObject *object, QEvent *event) override;
 
 	std::shared_ptr<gui_settings> m_gui_settings;
 
@@ -103,5 +103,3 @@ private:
 	bool m_save_game_icon_size = false;
 	QSlider* m_game_icon_slider = nullptr;
 };
-
-#endif


### PR DESCRIPTION
- Fixes the compatibility database download 🤦‍♂️ 
- Fix icon size actions not always being updated in the menu
- Add more options to change trophy manager icon sizes (mousewheel, ctrl +, ctrl -)
- Disabling discord rpc now uses Discord_Shutdown after upstream got patched
- Adds a "Delete SPU Cache" functionality
- Use Qt to find and delete files
- should also address https://github.com/RPCS3/rpcs3/issues/4725 (settings dialog tabsize)
- should also address https://github.com/RPCS3/rpcs3/pull/4717 (close config files)