### PR TITLE
mfc: clamp list transfer size

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -967,7 +967,7 @@ bool SPUThread::do_list_transfer(spu_mfc_cmd& args)
 		args.lsa &= 0x3fff0;
 		item = _ref<list_element>(args.eal & 0x3fff8);
 
-		const u32 size = item.ts;
+		const u32 size = item.ts & 0x7fff;
 		const u32 addr = item.ea;
 
 		LOG_TRACE(SPU, "LIST: addr=0x%x, size=0x%x, lsa=0x%05x, sb=0x%x", addr, size, args.lsa | (addr & 0xf), item.sb);


### PR DESCRIPTION
fixes #4614 

only the first 15 bits of the list transfer size are being used.
I also tested if the mfc stalls when turning on one of the reserved bits on the list element, it doesn't.
this allows to pass the cutscene on hitman sniper challenge.

[testcase](https://github.com/elad335/myps3tests/blob/master/spu_tests/list%20transfer%20size%20(LTS)%20bits/expected.txt)

![image](https://user-images.githubusercontent.com/18193363/41509528-fd1697d6-725d-11e8-8d49-e83a0c8dd0b9.png)

