### PR TITLE
Qt/RSX: reset gs_frame taskbar progr. when closing native progr. dialogs

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -18,7 +18,7 @@ namespace rsx
 				if (auto dlg = manager->get<rsx::overlays::message_dialog>())
 				{
 					if (dlg->progress_bar_count())
-						Emu.GetCallbacks().handle_taskbar_progress(0, 0);
+						Emu.GetCallbacks().handle_taskbar_progress(0, 1);
 				}
 
 				manager->remove(uid);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -182,7 +182,7 @@ struct EmuCallbacks
 	std::function<void()> on_stop;
 	std::function<void()> on_ready;
 	std::function<void()> exit;
-	std::function<void(s32, s32)> handle_taskbar_progress;
+	std::function<void(s32, s32)> handle_taskbar_progress; // (type, value) type: 0 for reset, 1 for increment, 2 for set_limit
 	std::function<std::shared_ptr<class KeyboardHandlerBase>()> get_kb_handler;
 	std::function<std::shared_ptr<class MouseHandlerBase>()> get_mouse_handler;
 	std::function<std::shared_ptr<class pad_thread>()> get_pad_handler;

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -282,7 +282,7 @@ void rpcs3_app::InitializeCallbacks()
 			switch (type)
 			{
 			case 0:
-				((gs_frame*)gameWindow)->progress_reset();
+				((gs_frame*)gameWindow)->progress_reset(value);
 				break;
 			case 1:
 				((gs_frame*)gameWindow)->progress_increment(value);

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -417,7 +417,7 @@ wm_event gs_frame::get_default_wm_event() const
 	return (m_user_interaction_active) ? wm_event::geometry_change_in_progress : wm_event::none;
 }
 
-void gs_frame::progress_reset()
+void gs_frame::progress_reset(bool reset_limit)
 {
 #ifdef _WIN32
 	if (m_tb_progress)
@@ -427,6 +427,11 @@ void gs_frame::progress_reset()
 #elif HAVE_QTDBUS
 	UpdateProgress(0);
 #endif
+
+	if (reset_limit)
+	{
+		progress_set_limit(100);
+	}
 }
 
 void gs_frame::progress_increment(int delta)

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -52,7 +52,7 @@ public:
 	wm_event get_default_wm_event() const override;
 
 	// taskbar progress
-	void progress_reset();
+	void progress_reset(bool reset_limit = false);
 	void progress_increment(int delta);
 	void progress_set_limit(int limit);
 


### PR DESCRIPTION
I forgot that the gs_frame's taskbar progress will stay unchanged due to its persistence, unlike the msgdialog.

requesting review from @KD-11