### PR TITLE
Fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ image: Visual Studio 2015
 environment:
   QTDIR: C:\Qt\5.10\msvc2015_64
   LLVMLIBS: https://github.com/RPCS3/llvm/releases/download/continuous-release_60/llvmlibs.7z
-  GLSLANG: https://drive.google.com/uc?export=download&id=1A2eOMmCO714i0U7J0qI4aEMKnuWl8l_R
+  GLSLANG: https://drive.google.com/uc?export=download&id=1nJK_NEeRzJ_r_u4zWLySwLmMrV8ZO_wL
   COMPATDB: https://rpcs3.net/compatibility?api=v1&export
   VULKAN_SDK: "C:\\VulkanSDK\\1.1.73.0"
   VULKAN_SDK_URL: https://sdk.lunarg.com/sdk/download/1.1.73.0/windows/VulkanSDK-1.1.73.0-Installer.exe

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -9,10 +9,10 @@ namespace rsx
 {
 	enum texture_upload_context
 	{
-		shader_read = 0,
-		blit_engine_src = 1,
-		blit_engine_dst = 2,
-		framebuffer_storage = 3
+		shader_read = 1,
+		blit_engine_src = 2,
+		blit_engine_dst = 4,
+		framebuffer_storage = 8
 	};
 
 	enum texture_colorspace

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -204,52 +204,47 @@ namespace rsx
 		bool writes_likely_completed() const
 		{
 			// TODO: Move this to the miss statistics block
-			if (context == rsx::texture_upload_context::blit_engine_dst)
+			const auto num_records = read_history.size();
+
+			if (num_records == 0)
 			{
-				const auto num_records = read_history.size();
+				return false;
+			}
+			else if (num_records == 1)
+			{
+				return num_writes >= read_history.front();
+			}
+			else
+			{
+				const u32 last = read_history.front();
+				const u32 prev_last = read_history[1];
 
-				if (num_records == 0)
+				if (last == prev_last && num_records <= 3)
 				{
-					return false;
+					return num_writes >= last;
 				}
-				else if (num_records == 1)
-				{
-					return num_writes >= read_history.front();
-				}
-				else
-				{
-					const u32 last = read_history.front();
-					const u32 prev_last = read_history[1];
 
-					if (last == prev_last && num_records <= 3)
+				u32 compare = UINT32_MAX;
+				for (u32 n = 1; n < num_records; n++)
+				{
+					if (read_history[n] == last)
 					{
-						return num_writes >= last;
-					}
+						// Uncertain, but possible
+						compare = read_history[n - 1];
 
-					u32 compare = UINT32_MAX;
-					for (u32 n = 1; n < num_records; n++)
-					{
-						if (read_history[n] == last)
+						if (num_records > (n + 1))
 						{
-							// Uncertain, but possible
-							compare = read_history[n - 1];
-
-							if (num_records > (n + 1))
+							if (read_history[n + 1] == prev_last)
 							{
-								if (read_history[n + 1] == prev_last)
-								{
-									// Confirmed with 2 values
-									break;
-								}
+								// Confirmed with 2 values
+								break;
 							}
 						}
 					}
-
-					return num_writes >= compare;
 				}
-			}
 
-			return true;
+				return num_writes >= compare;
+			}
 		}
 
 		void reprotect(utils::protection prot, const std::pair<u32, u32>& range)
@@ -473,8 +468,10 @@ namespace rsx
 		std::atomic<u32> m_texture_memory_in_use = { 0 };
 
 		//Other statistics
+		const u32 m_cache_miss_threshold = 8; // How many times an address can miss speculative writing before it is considered high priority
 		std::atomic<u32> m_num_flush_requests = { 0 };
 		std::atomic<u32> m_num_cache_misses = { 0 };
+		std::atomic<u32> m_num_cache_speculative_writes = { 0 };
 		std::atomic<u32> m_num_cache_mispredictions = { 0 };
 
 		/* Helpers */
@@ -729,7 +726,7 @@ namespace rsx
 							{
 								if (obj.first->get_memory_read_flags() == rsx::memory_read_flags::flush_always)
 								{
-									// This region is set to always read from itself (unavoi
+									// This region is set to always read from itself (unavoidable hard sync)
 									const auto ROP_timestamp = rsx::get_current_renderer()->ROP_sync_timestamp;
 									if (obj.first->is_synchronized() && ROP_timestamp > obj.first->get_sync_timestamp())
 									{
@@ -1072,6 +1069,7 @@ namespace rsx
 			region.set_sampler_status(rsx::texture_sampler_status::status_uninitialized);
 			region.set_image_type(rsx::texture_dimension_extended::texture_dimension_2d);
 			region.set_memory_read_flags(memory_read_flags::flush_always);
+			region.touch();
 
 			m_flush_always_cache[memory_address] = memory_size;
 
@@ -1151,6 +1149,7 @@ namespace rsx
 				return true;
 
 			region->copy_texture(false, std::forward<Args>(extra)...);
+			m_num_cache_speculative_writes++;
 			return true;
 		}
 
@@ -1256,7 +1255,7 @@ namespace rsx
 					{
 						if (tex->get_memory_read_flags() == rsx::memory_read_flags::flush_always)
 						{
-							// This region is set to always read from itself (unavoi
+							// This region is set to always read from itself (unavoidable hard sync)
 							const auto ROP_timestamp = rsx::get_current_renderer()->ROP_sync_timestamp;
 							if (tex->is_synchronized() && ROP_timestamp > tex->get_sync_timestamp())
 							{
@@ -1351,7 +1350,7 @@ namespace rsx
 			u32 flush_mask = rsx::texture_upload_context::blit_engine_dst;
 
 			// Auto flush if this address keeps missing (not properly synchronized)
-			if (value.misses >= 4)
+			if (value.misses >= m_cache_miss_threshold)
 			{
 				// Disable prediction if memory is flagged as flush_always
 				if (m_flush_always_cache.find(memory_address) == m_flush_always_cache.end())
@@ -2485,6 +2484,7 @@ namespace rsx
 			m_num_flush_requests.store(0u);
 			m_num_cache_misses.store(0u);
 			m_num_cache_mispredictions.store(0u);
+			m_num_cache_speculative_writes.store(0u);
 		}
 
 		virtual const u32 get_unreleased_textures_count() const
@@ -2505,6 +2505,11 @@ namespace rsx
 		virtual u32 get_num_cache_mispredictions() const
 		{
 			return m_num_cache_mispredictions;
+		}
+
+		virtual u32 get_num_cache_speculative_writes() const
+		{
+			return m_num_cache_speculative_writes;
 		}
 
 		virtual f32 get_cache_miss_ratio() const

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -404,7 +404,7 @@ void D3D12GSRender::end()
 			);
 	}
 
-	m_graphics_state = 0;
+	m_graphics_state &= ~rsx::pipeline_state::memory_barrier_bits;
 
 	std::chrono::time_point<steady_clock> constants_duration_end = steady_clock::now();
 	m_timers.constants_duration += std::chrono::duration_cast<std::chrono::microseconds>(constants_duration_end - constants_duration_start).count();

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1518,10 +1518,11 @@ void GLGSRender::flip(int buffer)
 		const auto texture_memory_size = m_gl_texture_cache.get_texture_memory_in_use() / (1024 * 1024);
 		const auto num_flushes = m_gl_texture_cache.get_num_flush_requests();
 		const auto num_mispredict = m_gl_texture_cache.get_num_cache_mispredictions();
+		const auto num_speculate = m_gl_texture_cache.get_num_cache_speculative_writes();
 		const auto cache_miss_ratio = (u32)ceil(m_gl_texture_cache.get_cache_miss_ratio() * 100);
 		m_text_printer.print_text(0, 126, m_frame->client_width(), m_frame->client_height(), "Unreleased textures: " + std::to_string(num_dirty_textures));
 		m_text_printer.print_text(0, 144, m_frame->client_width(), m_frame->client_height(), "Texture memory: " + std::to_string(texture_memory_size) + "M");
-		m_text_printer.print_text(0, 162, m_frame->client_width(), m_frame->client_height(), fmt::format("Flush requests: %d (%d%% hard faults, %d mispredictions)", num_flushes, cache_miss_ratio, num_mispredict));
+		m_text_printer.print_text(0, 162, m_frame->client_width(), m_frame->client_height(), fmt::format("Flush requests: %d (%d%% hard faults, %d misprediction(s), %d speculation(s))", num_flushes, cache_miss_ratio, num_mispredict, num_speculate));
 	}
 
 	m_frame->flip(m_context);

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -1567,13 +1567,36 @@ namespace gl
 				}
 				else
 				{
-					GLint r, g, b, a;
-					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_RED_SIZE, &r);
-					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_GREEN_SIZE, &g);
-					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_BLUE_SIZE, &b);
-					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_ALPHA_SIZE, &a);
+					switch (sized_format)
+					{
+					case GL_DEPTH_COMPONENT16:
+					{
+						m_pitch = width * 2;
+						break;
+					}
+					case GL_DEPTH24_STENCIL8:
+					case GL_DEPTH32F_STENCIL8:
+					{
+						m_pitch = width * 4;
+						break;
+					}
+					default:
+					{
+						GLint r, g, b, a;
+						glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_RED_SIZE, &r);
+						glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_GREEN_SIZE, &g);
+						glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_BLUE_SIZE, &b);
+						glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_ALPHA_SIZE, &a);
 
-					m_pitch = width * (r + g + b + a) / 8;
+						m_pitch = width * (r + g + b + a) / 8;
+						break;
+					}
+					}
+
+					if (!m_pitch)
+					{
+						fmt::throw_exception("Unhandled GL format 0x%X" HERE, sized_format);
+					}
 				}
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -1469,6 +1469,8 @@ namespace gl
 		GLuint m_height = 0;
 		GLuint m_depth = 0;
 		GLuint m_mipmaps = 0;
+		GLuint m_pitch = 0;
+		GLuint m_compressed = GL_FALSE;
 
 		target m_target = target::texture2D;
 		internal_format m_internal_format = internal_format::rgba8;
@@ -1553,6 +1555,26 @@ namespace gl
 				m_height = height;
 				m_depth = depth;
 				m_mipmaps = mipmaps;
+
+				GLenum query_target = (target == GL_TEXTURE_CUBE_MAP) ? GL_TEXTURE_CUBE_MAP_POSITIVE_X : target;
+				glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_COMPRESSED, (GLint*)&m_compressed);
+
+				if (m_compressed)
+				{
+					GLint compressed_size;
+					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_COMPRESSED_IMAGE_SIZE, &compressed_size);
+					m_pitch = compressed_size / height;
+				}
+				else
+				{
+					GLint r, g, b, a;
+					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_RED_SIZE, &r);
+					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_GREEN_SIZE, &g);
+					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_BLUE_SIZE, &b);
+					glGetTexLevelParameteriv(query_target, 0, GL_TEXTURE_ALPHA_SIZE, &a);
+
+					m_pitch = width * (r + g + b + a) / 8;
+				}
 			}
 
 			m_target = static_cast<texture::target>(target);
@@ -1620,6 +1642,16 @@ namespace gl
 		GLuint levels() const
 		{
 			return m_mipmaps;
+		}
+
+		GLuint pitch() const
+		{
+			return m_pitch;
+		}
+
+		GLboolean compressed() const
+		{
+			return m_compressed;
 		}
 
 		sizei size2D() const

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -260,6 +260,7 @@ namespace gl
 
 			flushed = false;
 			synchronized = false;
+			sync_timestamp = 0ull;
 			is_depth = false;
 
 			vram_texture = nullptr;
@@ -291,6 +292,7 @@ namespace gl
 
 			flushed = false;
 			synchronized = false;
+			sync_timestamp = 0ull;
 			is_depth = false;
 
 			this->width = w;
@@ -454,6 +456,7 @@ namespace gl
 
 			m_fence.reset();
 			synchronized = true;
+			sync_timestamp = get_system_time();
 		}
 
 		void fill_texture(gl::texture* tex)
@@ -601,20 +604,6 @@ namespace gl
 			reset_write_statistics();
 
 			return result;
-		}
-
-		void reprotect(utils::protection prot, const std::pair<u32, u32>& range)
-		{
-			flushed = false;
-			synchronized = false;
-			protect(prot, range);
-		}
-
-		void reprotect(utils::protection prot)
-		{
-			flushed = false;
-			synchronized = false;
-			protect(prot);
 		}
 
 		void destroy()

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -330,6 +330,9 @@ namespace rsx
 
 		in_begin_end = false;
 
+		m_graphics_state |= rsx::pipeline_state::framebuffer_reads_dirty;
+		ROP_sync_timestamp = get_system_time();
+
 		for (u8 index = 0; index < rsx::limits::vertex_count; ++index)
 		{
 			//Disabled, see https://github.com/RPCS3/rpcs3/issues/1932

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -76,8 +76,10 @@ namespace rsx
 		fragment_state_dirty = 4,
 		vertex_state_dirty = 8,
 		transform_constants_dirty = 16,
+		framebuffer_reads_dirty = 32,
 
 		invalidate_pipeline_bits = fragment_program_dirty | vertex_program_dirty,
+		memory_barrier_bits = framebuffer_reads_dirty,
 		all_dirty = 255
 	};
 
@@ -358,6 +360,7 @@ namespace rsx
 		bool m_vertex_textures_dirty[4];
 		bool m_framebuffer_state_contested = false;
 		u32  m_graphics_state = 0;
+		u64  ROP_sync_timestamp = 0;
 
 	protected:
 		std::array<u32, 4> get_color_surface_addresses() const;

--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
@@ -147,8 +147,8 @@ namespace vk
 		glslang::TShader shader_object(lang);
 
 		shader_object.setEnvInput(glslang::EShSourceGlsl, lang, glslang::EShClientVulkan, 100);
-		shader_object.setEnvClient(glslang::EShClientVulkan, 100);
-		shader_object.setEnvTarget(glslang::EshTargetSpv, 0x00001000);
+		shader_object.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetClientVersion::EShTargetVulkan_1_0);
+		shader_object.setEnvTarget(glslang::EshTargetSpv, glslang::EShTargetLanguageVersion::EShTargetSpv_1_0);
 		
 		bool success = false;
 		const char *shader_text = shader.data();

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -187,7 +187,7 @@ namespace vk
 				"\n"
 				"// Depth format conversions\n"
 				"#define d24x8_to_f32(bits)           floatBitsToUint(float(bits >> 8) / 16777214.f)\n"
-				"#define d24x8_to_d24x8_swapped(bits) (bits & 0xFF00FF00) | (bits & 0xFF0000) >> 16 | (bits & 0xFF) << 16\n"
+				"#define d24x8_to_d24x8_swapped(bits) (bits & 0xFF00) | (bits & 0xFF0000) >> 16 | (bits & 0xFF) << 16\n"
 				"#define f32_to_d24x8_swapped(bits)   d24x8_to_d24x8_swapped(uint(uintBitsToFloat(bits) * 16777214.f))\n"
 				"\n"
 				"void main()\n"

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -269,7 +269,16 @@ namespace vk
 			m_data_length = data_length;
 
 			const auto num_bytes_per_invocation = optimal_group_size * kernel_size * 4;
-			const auto num_invocations = align(data_length, 256) / num_bytes_per_invocation;
+			const auto num_bytes_to_process = align(data_length, num_bytes_per_invocation);
+			const auto num_invocations = num_bytes_to_process / num_bytes_per_invocation;
+
+			if (num_bytes_to_process > data->size())
+			{
+				// Technically robust buffer access should keep the driver from crashing in OOB situations
+				LOG_ERROR(RSX, "Inadequate buffer length submitted for a compute operation."
+					"Required=%d bytes, Available=%d bytes", num_bytes_to_process, data->size());
+			}
+
 			compute_task::run(cmd, num_invocations);
 		}
 	};

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3241,11 +3241,12 @@ void VKGSRender::flip(int buffer)
 			const auto tmp_texture_memory_size = m_texture_cache.get_temporary_memory_in_use() / (1024 * 1024);
 			const auto num_flushes = m_texture_cache.get_num_flush_requests();
 			const auto num_mispredict = m_texture_cache.get_num_cache_mispredictions();
+			const auto num_speculate = m_texture_cache.get_num_cache_speculative_writes();
 			const auto cache_miss_ratio = (u32)ceil(m_texture_cache.get_cache_miss_ratio() * 100);
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 144, direct_fbo->width(), direct_fbo->height(), "Unreleased textures: " + std::to_string(num_dirty_textures));
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 162, direct_fbo->width(), direct_fbo->height(), "Texture cache memory: " + std::to_string(texture_memory_size) + "M");
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 180, direct_fbo->width(), direct_fbo->height(), "Temporary texture memory: " + std::to_string(tmp_texture_memory_size) + "M");
-			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 198, direct_fbo->width(), direct_fbo->height(), fmt::format("Flush requests: %d (%d%% hard faults, %d mispredictions)", num_flushes, cache_miss_ratio, num_mispredict));
+			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 198, direct_fbo->width(), direct_fbo->height(), fmt::format("Flush requests: %d (%d%% hard faults, %d misprediction(s), %d speculation(s))", num_flushes, cache_miss_ratio, num_mispredict, num_speculate));
 		}
 
 		vk::change_image_layout(*m_current_command_buffer, target_image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, present_layout, subres);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -347,13 +347,13 @@ namespace vk
 		return g_drv_disable_fence_reset;
 	}
 
-	void insert_buffer_memory_barrier(VkCommandBuffer cmd, VkBuffer buffer, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask)
+	void insert_buffer_memory_barrier(VkCommandBuffer cmd, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize length, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask)
 	{
 		VkBufferMemoryBarrier barrier = {};
 		barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
 		barrier.buffer = buffer;
-		barrier.offset = 0;
-		barrier.size = VK_WHOLE_SIZE;
+		barrier.offset = offset;
+		barrier.size = length;
 		barrier.srcAccessMask = src_mask;
 		barrier.dstAccessMask = dst_mask;
 		barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -472,11 +472,13 @@ namespace vk
 			//Currently we require:
 			//1. Anisotropic sampling
 			//2. DXT support
+			//3. Indexable storage buffers
 			VkPhysicalDeviceFeatures available_features;
 			vkGetPhysicalDeviceFeatures(*pgpu, &available_features);
 
 			available_features.samplerAnisotropy = VK_TRUE;
 			available_features.textureCompressionBC = VK_TRUE;
+			available_features.shaderStorageBufferArrayDynamicIndexing = VK_TRUE;
 
 			VkDeviceCreateInfo device = {};
 			device.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -149,7 +149,8 @@ namespace vk
 	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout layout, VkImageSubresourceRange range);
 	void insert_texture_barrier(VkCommandBuffer cmd, vk::image *image);
 
-	void insert_buffer_memory_barrier(VkCommandBuffer cmd, VkBuffer buffer, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask);
+	void insert_buffer_memory_barrier(VkCommandBuffer cmd, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize length,
+			VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask);
 
 	//Manage 'uininterruptible' state where secondary operations (e.g violation handlers) will have to wait
 	void enter_uninterruptible();

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -152,7 +152,10 @@ namespace vk
 				}
 				else
 				{
-					insert_buffer_memory_barrier(cmd, scratch_buf->value, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+					const auto elem_size = vk::get_format_texel_width(src->info.format);
+					const auto length = elem_size * src_copy.imageExtent.width * src_copy.imageExtent.height;
+
+					insert_buffer_memory_barrier(cmd, scratch_buf->value, 0, length, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
 						VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT);
 
 					vk::cs_shuffle_base *shuffle_kernel = nullptr;
@@ -177,12 +180,9 @@ namespace vk
 						}
 					}
 
-					const auto elem_size = vk::get_format_texel_width(src->info.format);
-					const auto length = elem_size * src_copy.imageExtent.width * src_copy.imageExtent.height;
-
 					shuffle_kernel->run(cmd, scratch_buf, length);
 
-					insert_buffer_memory_barrier(cmd, scratch_buf->value, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+					insert_buffer_memory_barrier(cmd, scratch_buf->value, 0, length, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
 						VK_ACCESS_SHADER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
 				}
 			}
@@ -338,7 +338,7 @@ namespace vk
 					info.imageSubresource = { aspect & transfer_flags, 0, 0, 1 };
 
 					vkCmdCopyImageToBuffer(cmd, src, preferred_src_format, scratch_buf->value, 1, &info);
-					insert_buffer_memory_barrier(cmd, scratch_buf->value, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
+					insert_buffer_memory_barrier(cmd, scratch_buf->value, 0, VK_WHOLE_SIZE, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
 
 					info.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
 					vkCmdCopyBufferToImage(cmd, scratch_buf->value, typeless, VK_IMAGE_LAYOUT_GENERAL, 1, &info);
@@ -352,7 +352,7 @@ namespace vk
 					info.imageOffset = { 0, (s32)src_h, 0 };
 
 					vkCmdCopyImageToBuffer(cmd, typeless, VK_IMAGE_LAYOUT_GENERAL, scratch_buf->value, 1, &info);
-					insert_buffer_memory_barrier(cmd, scratch_buf->value, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
+					insert_buffer_memory_barrier(cmd, scratch_buf->value, 0, VK_WHOLE_SIZE, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
 
 					info.imageOffset = { dst_rect.x1, dst_rect.y1, 0 };
 					info.imageSubresource = { aspect & transfer_flags, 0, 0, 1 };
@@ -432,7 +432,6 @@ namespace vk
 		u32 mipmap_level = 0;
 		u32 block_in_pixel = get_format_block_size_in_texel(format);
 		u8 block_size_in_bytes = get_format_block_size_in_bytes(format);
-		std::vector<u8> staging_buffer;
 
 		//TODO: Depth and stencil transfer together
 		flags &= ~(VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -447,48 +446,31 @@ namespace vk
 			void *mapped_buffer = upload_heap.map(offset_in_buffer, image_linear_size + 8);
 			void *dst = mapped_buffer;
 
-			bool use_staging = false;
-			if (dst_image->info.format == VK_FORMAT_D24_UNORM_S8_UINT ||
-				dst_image->info.format == VK_FORMAT_D32_SFLOAT_S8_UINT)
+			if (dst_image->info.format == VK_FORMAT_D24_UNORM_S8_UINT)
 			{
 				//Misalign intentionally to skip the first stencil byte in D24S8 data
 				//Ensures the real depth data is dword aligned
 
-				if (dst_image->info.format == VK_FORMAT_D32_SFLOAT_S8_UINT)
-				{
-					//Emulate D24x8 passthrough to D32 format
-					//Reads from GPU managed memory are slow at best and at worst unreliable
-					use_staging = true;
-					staging_buffer.resize(image_linear_size + 8);
-					dst = staging_buffer.data() + 4 - 1;
-				}
-				else
-				{
-					//Skip leading dword when writing to texture
-					offset_in_buffer += 4;
-					dst = (char*)(mapped_buffer) + 4 - 1;
-				}
+				//Skip leading dword when writing to texture
+				offset_in_buffer += 4;
+				dst = (char*)(mapped_buffer) + 4 - 1;
 			}
 
 			gsl::span<gsl::byte> mapped{ (gsl::byte*)dst, ::narrow<int>(image_linear_size) };
 			upload_texture_subresource(mapped, layout, format, is_swizzled, false, 256);
-
-			if (use_staging)
-			{
-				if (dst_image->info.format == VK_FORMAT_D32_SFLOAT_S8_UINT)
-				{
-					//Map depth component from D24x8 to a f32 depth value
-					//NOTE: One byte (contains first S8 value) is skipped
-					rsx::convert_le_d24x8_to_le_f32(mapped_buffer, (char*)dst + 1, image_linear_size >> 2, 1);
-				}
-				else //unused
-				{
-					//Copy emulated data back to the target buffer
-					memcpy(mapped_buffer, dst, image_linear_size);
-				}
-			}
-
 			upload_heap.unmap();
+
+			if (dst_image->info.format == VK_FORMAT_D32_SFLOAT_S8_UINT)
+			{
+				// Run GPU compute task to convert the D24x8 to FP32
+				// NOTE: On commandbuffer submission, the HOST_WRITE to ALL_COMMANDS barrier is implicitly inserted according to spec
+				// No need to add another explicit barrier unless a driver bug is found
+
+				vk::get_compute_task<vk::cs_shuffle_d24x8_f32>()->run(cmd, upload_heap.heap.get(), image_linear_size, offset_in_buffer);
+
+				insert_buffer_memory_barrier(cmd, upload_heap.heap->value, offset_in_buffer, image_linear_size, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+					VK_ACCESS_SHADER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
+			}
 
 			VkBufferImageCopy copy_info = {};
 			copy_info.bufferOffset = offset_in_buffer;

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -275,7 +275,7 @@ namespace vk
 		if (dstLayout != preferred_dst_format)
 			change_image_layout(cmd, dst, dstLayout, preferred_dst_format, vk::get_image_subresource_range(0, 0, 1, 1, aspect));
 
-		if (compatible_formats && src_width == dst_width && src_height != dst_height)
+		if (compatible_formats && src_width == dst_width && src_height == dst_height)
 		{
 			VkImageCopy copy_rgn;
 			copy_rgn.srcOffset = { (int32_t)src_x_offset, (int32_t)src_y_offset, 0 };

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -20,8 +20,6 @@ namespace vk
 
 		//DMA relevant data
 		VkFence dma_fence = VK_NULL_HANDLE;
-		u64 sync_timestamp = 0;
-		u64 last_use_timestamp = 0;
 		vk::render_device* m_device = nullptr;
 		vk::image *vram_texture = nullptr;
 		std::unique_ptr<vk::buffer> dma_buffer;
@@ -72,7 +70,6 @@ namespace vk
 			synchronized = false;
 			flushed = false;
 			sync_timestamp = 0ull;
-			last_use_timestamp = get_system_time();
 		}
 
 		void release_dma_resources()
@@ -351,39 +348,9 @@ namespace vk
 			pack_unpack_swap_bytes = swap_bytes;
 		}
 
-		void reprotect(utils::protection prot, const std::pair<u32, u32>& range)
-		{
-			//Reset properties and protect again
-			flushed = false;
-			synchronized = false;
-			sync_timestamp = 0ull;
-
-			protect(prot, range);
-		}
-
-		void reprotect(utils::protection prot)
-		{
-			//Reset properties and protect again
-			flushed = false;
-			synchronized = false;
-			sync_timestamp = 0ull;
-
-			protect(prot);
-		}
-
-		void invalidate_cached()
-		{
-			synchronized = false;
-		}
-
 		bool is_synchronized() const
 		{
 			return synchronized;
-		}
-
-		bool sync_valid() const
-		{
-			return (sync_timestamp > last_use_timestamp);
 		}
 
 		bool has_compatible_format(vk::image* tex) const
@@ -402,11 +369,6 @@ namespace vk
 			default:
 				return false;
 			}
-		}
-
-		u64 get_sync_timestamp() const
-		{
-			return sync_timestamp;
 		}
 	};
 	

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -66,8 +66,6 @@ namespace vk
 			else
 				this->rsx_pitch = cpu_address_range / height;
 
-			real_pitch = vk::get_format_texel_width(image->info.format) * width;
-
 			//Even if we are managing the same vram section, we cannot guarantee contents are static
 			//The create method is only invoked when a new mangaged session is required
 			synchronized = false;
@@ -166,25 +164,61 @@ namespace vk
 				cmd.begin();
 			}
 
-			const u16 internal_width = (context != rsx::texture_upload_context::framebuffer_storage? width : std::min(width, rsx::apply_resolution_scale(width, true)));
-			const u16 internal_height = (context != rsx::texture_upload_context::framebuffer_storage? height : std::min(height, rsx::apply_resolution_scale(height, true)));
+			vk::image *target = vram_texture;
+			real_pitch = vk::get_format_texel_width(vram_texture->info.format) * vram_texture->width();
+
 			VkImageAspectFlags aspect_flag = vk::get_aspect_flags(vram_texture->info.format);
-
-			//TODO: Read back stencil values (is this really necessary?)
-			VkBufferImageCopy copyRegion = {};
-			copyRegion.bufferOffset = 0;
-			copyRegion.bufferRowLength = internal_width;
-			copyRegion.bufferImageHeight = internal_height;
-			copyRegion.imageSubresource = {aspect_flag & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 0, 1};
-			copyRegion.imageOffset = {};
-			copyRegion.imageExtent = {internal_width, internal_height, 1};
-
 			VkImageSubresourceRange subresource_range = { aspect_flag, 0, 1, 0, 1 };
-			
-			VkImageLayout layout = vram_texture->current_layout;
+			u32 transfer_width = width;
+			u32 transfer_height = height;
+
+			VkImageLayout old_layout = vram_texture->current_layout;
 			change_image_layout(cmd, vram_texture, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, subresource_range);
-			vkCmdCopyImageToBuffer(cmd, vram_texture->value, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dma_buffer->value, 1, &copyRegion);
-			change_image_layout(cmd, vram_texture, layout, subresource_range);
+
+			if ((rsx::get_resolution_scale_percent() != 100 && context == rsx::texture_upload_context::framebuffer_storage) ||
+				(real_pitch != rsx_pitch))
+			{
+				if (context == rsx::texture_upload_context::framebuffer_storage)
+				{
+					switch (static_cast<vk::render_target*>(vram_texture)->read_aa_mode)
+					{
+					case rsx::surface_antialiasing::center_1_sample:
+						break;
+					case rsx::surface_antialiasing::diagonal_centered_2_samples:
+						transfer_width *= 2;
+						break;
+					default:
+						transfer_width *= 2;
+						transfer_height *= 2;
+						break;
+					}
+				}
+
+				if (transfer_width != vram_texture->width() || transfer_height != vram_texture->height())
+				{
+					// TODO: Synchronize access to typeles textures
+					target = vk::get_typeless_helper(vram_texture->info.format);
+					vk::copy_scaled_image(cmd, vram_texture->value, target->value, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, target->current_layout,
+						0, 0, vram_texture->width(), vram_texture->height(), 0, 0, transfer_width, transfer_height, 1, aspect_flag, true, VK_FILTER_NEAREST,
+						vram_texture->info.format, target->info.format);
+				}
+			}
+
+			if (target->current_layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+			{
+				// Using a scaled intermediary
+				verify(HERE), target != vram_texture;
+				change_image_layout(cmd, target, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, subresource_range);
+			}
+
+			// TODO: Read back stencil values (is this really necessary?)
+			VkBufferImageCopy region = {};
+			region.imageSubresource = {aspect_flag & ~(VK_IMAGE_ASPECT_STENCIL_BIT), 0, 0, 1};
+			region.imageExtent = {transfer_width, transfer_height, 1};
+			vkCmdCopyImageToBuffer(cmd, target->value, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dma_buffer->value, 1, &region);
+
+			change_image_layout(cmd, vram_texture, old_layout, subresource_range);
+			real_pitch = vk::get_format_texel_width(vram_texture->info.format) * transfer_width;
 
 			if (manage_cb_lifetime)
 			{
@@ -205,7 +239,7 @@ namespace vk
 		}
 
 		template<typename T, bool swapped>
-		void do_memory_transfer(void *pixels_dst, const void *pixels_src, u32 max_length)
+		void do_memory_transfer_packed(void *pixels_dst, const void *pixels_src, u32 max_length)
 		{
 			if (sizeof(T) == 1 || !swapped)
 			{
@@ -219,6 +253,38 @@ namespace vk
 
 				for (u32 px = 0; px < block_size; ++px)
 					typed_dst[px] = typed_src[px];
+			}
+		}
+
+		template<typename T, bool swapped>
+		void do_memory_transfer_padded(void *pixels_dst, const void *pixels_src, u32 src_pitch, u32 dst_pitch, u32 num_rows)
+		{
+			auto src = (char*)pixels_src;
+			auto dst = (char*)pixels_dst;
+
+			if (sizeof(T) == 1 || !swapped)
+			{
+				for (u32 y = 0; y < num_rows; ++y)
+				{
+					memcpy(dst, src, src_pitch);
+					src += src_pitch;
+					dst += dst_pitch;
+				}
+			}
+			else
+			{
+				const u32 block_size = src_pitch / sizeof(T);
+				for (u32 y = 0; y < num_rows; ++y)
+				{
+					auto typed_dst = (be_t<T> *)dst;
+					auto typed_src = (T *)src;
+
+					for (u32 px = 0; px < block_size; ++px)
+						typed_dst[px] = typed_src[px];
+
+					src += src_pitch;
+					dst += dst_pitch;
+				}
 			}
 		}
 
@@ -241,6 +307,7 @@ namespace vk
 				result = false;
 			}
 
+			verify(HERE), real_pitch > 0;
 			flushed = true;
 
 			const auto valid_range = get_confirmed_range();
@@ -250,67 +317,81 @@ namespace vk
 			const auto texel_layout = vk::get_format_element_size(vram_texture->info.format);
 			const auto elem_size = texel_layout.first;
 
-			//We have to do our own byte swapping since the driver doesnt do it for us
-			if (real_pitch == rsx_pitch)
+			auto memory_transfer_packed = [=]()
 			{
-				bool is_depth_format = true;
+				switch (elem_size)
+				{
+				default:
+					LOG_ERROR(RSX, "Invalid element width %d", elem_size);
+				case 1:
+					do_memory_transfer_packed<u8, false>(pixels_dst, pixels_src, valid_range.second);
+					break;
+				case 2:
+					if (pack_unpack_swap_bytes)
+						do_memory_transfer_packed<u16, true>(pixels_dst, pixels_src, valid_range.second);
+					else
+						do_memory_transfer_packed<u16, false>(pixels_dst, pixels_src, valid_range.second);
+					break;
+				case 4:
+					if (pack_unpack_swap_bytes)
+						do_memory_transfer_packed<u32, true>(pixels_dst, pixels_src, valid_range.second);
+					else
+						do_memory_transfer_packed<u32, false>(pixels_dst, pixels_src, valid_range.second);
+					break;
+				}
+			};
+
+			auto memory_transfer_padded = [=]()
+			{
+				const u32 num_rows = valid_range.second / rsx_pitch;
+				switch (elem_size)
+				{
+				default:
+					LOG_ERROR(RSX, "Invalid element width %d", elem_size);
+				case 1:
+					do_memory_transfer_padded<u8, false>(pixels_dst, pixels_src, real_pitch, rsx_pitch, num_rows);
+					break;
+				case 2:
+					if (pack_unpack_swap_bytes)
+						do_memory_transfer_padded<u16, true>(pixels_dst, pixels_src, real_pitch, rsx_pitch, num_rows);
+					else
+						do_memory_transfer_padded<u16, false>(pixels_dst, pixels_src, real_pitch, rsx_pitch, num_rows);
+					break;
+				case 4:
+					if (pack_unpack_swap_bytes)
+						do_memory_transfer_padded<u32, true>(pixels_dst, pixels_src, real_pitch, rsx_pitch, num_rows);
+					else
+						do_memory_transfer_padded<u32, false>(pixels_dst, pixels_src, real_pitch, rsx_pitch, num_rows);
+					break;
+				}
+			};
+
+			// NOTE: We have to do our own byte swapping since the driver doesnt do it for us
+			// TODO: Replace the cpu-side transformations with trivial compute pipelines
+			if (real_pitch >= rsx_pitch || valid_range.second <= rsx_pitch)
+			{
 				switch (vram_texture->info.format)
 				{
 				case VK_FORMAT_D32_SFLOAT_S8_UINT:
+				{
 					rsx::convert_le_f32_to_be_d24(pixels_dst, pixels_src, valid_range.second >> 2, 1);
 					break;
+				}
 				case VK_FORMAT_D24_UNORM_S8_UINT:
+				{
 					rsx::convert_le_d24x8_to_be_d24x8(pixels_dst, pixels_src, valid_range.second >> 2, 1);
 					break;
+				}
 				default:
-					is_depth_format = false;
+				{
+					memory_transfer_packed();
 					break;
 				}
-
-				if (!is_depth_format)
-				{
-					switch (elem_size)
-					{
-					default:
-						LOG_ERROR(RSX, "Invalid element width %d", elem_size);
-					case 1:
-						do_memory_transfer<u8, false>(pixels_dst, pixels_src, valid_range.second);
-						break;
-					case 2:
-						if (pack_unpack_swap_bytes)
-							do_memory_transfer<u16, true>(pixels_dst, pixels_src, valid_range.second);
-						else
-							do_memory_transfer<u16, false>(pixels_dst, pixels_src, valid_range.second);
-						break;
-					case 4:
-						if (pack_unpack_swap_bytes)
-							do_memory_transfer<u32, true>(pixels_dst, pixels_src, valid_range.second);
-						else
-							do_memory_transfer<u32, false>(pixels_dst, pixels_src, valid_range.second);
-						break;
-					}
 				}
 			}
 			else
 			{
-				//Scale image to fit
-				//usually we can just get away with nearest filtering
-				u8 samples_u = 1, samples_v = 1;
-				switch (static_cast<vk::render_target*>(vram_texture)->read_aa_mode)
-				{
-				case rsx::surface_antialiasing::diagonal_centered_2_samples:
-					samples_u = 2;
-					break;
-				case rsx::surface_antialiasing::square_centered_4_samples:
-				case rsx::surface_antialiasing::square_rotated_4_samples:
-					samples_u = 2;
-					samples_v = 2;
-					break;
-				}
-
-				const u16 row_length = u16(width * texel_layout.second);
-				const u16 usable_height = (valid_range.second / rsx_pitch) / samples_v;
-				rsx::scale_image_nearest(pixels_dst, pixels_src, row_length, usable_height, rsx_pitch, real_pitch, elem_size, samples_u, samples_v, pack_unpack_swap_bytes);
+				memory_transfer_padded();
 
 				switch (vram_texture->info.format)
 				{


### PR DESCRIPTION
- Improve buffer synchronization logic
  Fixes 'zoom' when using WCB/cpu blit and upscaling resolution
- Replace all memory block operations including endianness swapping and format conversions using compute for vulkan (The driver automatically does this step for OpenGL)
- Reimplement framebuffer access, loosen up memory relocking logic and implement forced reads if self-referencing active render targets.
- Update glslang to a much newer version (Fixes broken SPIR-V)

TODO before merge
- [x] Performance tuning