### PR TITLE
better logging for spu halt instructions

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1297,7 +1297,16 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 		}
 
 		vm::temporary_unlock(*cpu);
-		LOG_FATAL(MEMORY, "Access violation %s location 0x%x", is_writing ? "writing" : "reading", addr);
+
+		if (addr == 0xffdead00)
+		{
+			LOG_FATAL(SPU, "Halt!");
+		}
+		else
+		{
+			LOG_FATAL(MEMORY, "Access violation %s location 0x%x", is_writing ? "writing" : "reading", addr);
+		}
+
 		cpu->state += cpu_flag::dbg_pause;
 		cpu->check_state();
 	}


### PR DESCRIPTION
commit 2fecddcde made spu halt instructions on recompilers access violate on address 0xffdead00, so give a better logging when that happens inside the access violation handler.