### PR TITLE
Kot fixes

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -4405,7 +4405,15 @@ bool ppu_interpreter::LBZU(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + op.simm16 : op.simm16;
-	vm::write32(vm::cast(addr, HERE), (u32)ppu.gpr[op.rs]);
+	const u32 value = (u32)ppu.gpr[op.rs];
+	vm::write32(vm::cast(addr, HERE), value);
+
+	//Insomniac engine v3 & v4 (newer R&C, Fuse, Resitance 3)
+	if (UNLIKELY(value == 0xAAAAAAAA))
+	{
+		vm::reservation_update(addr, 128);
+	}
+
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1309,6 +1309,7 @@ extern void ppu_initialize(const ppu_module& info)
 			{ "__lvrx", s_use_ssse3 ? (u64)&sse_cellbe_lvrx : (u64)&sse_cellbe_lvrx_v0 },
 			{ "__stvlx", s_use_ssse3 ? (u64)&sse_cellbe_stvlx : (u64)&sse_cellbe_stvlx_v0 },
 			{ "__stvrx", s_use_ssse3 ? (u64)&sse_cellbe_stvrx : (u64)&sse_cellbe_stvrx_v0 },
+			{ "__resupdate", (u64)&vm::reservation_update },
 		};
 
 		for (u64 index = 0; index < 1024; index++)


### PR DESCRIPTION
Newer games by Insomniac games use reservations in a very specific way which we don't support. Fully emulating the correct behavior would slow down the emulator a lot as we'd need to do a reservation update on every single write done by the game. Luckily insomniac games were nice enough to always write with the same value (`0xAAAAAAAA`) when they want to fire an `lr` event. Thanks to this we can support these games without having to slow down writes as much. 
Affected games should be: R&C ACiT, R&C Nexus, R&C A4O, R&C FFA, Resistance 3 and Fuse.
closes #4516
![rpcs3_2018-06-23_19-04-03](https://user-images.githubusercontent.com/26828095/41811957-b31588c0-7719-11e8-9796-6cf3b098b443.png)
