### PR TITLE
handle empty update param.sfo data

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -293,7 +293,7 @@ public:
 
 	void SetForceBoot(bool force_boot);
 
-	void Load(bool add_only = false);
+	void Load(bool add_only = false, bool is_update = false);
 	void Run();
 	bool Pause();
 	void Resume();


### PR DESCRIPTION
Sometimes the game data folders don't contain every info in their param.sfo. This leads to m_cache_dir pointing to a wrong path, since the m_title_id is empty, and thus the boot fails.

Keeping the original data in case of empty strings can fix this problem.