### PR TITLE
vfs (dev_flash) fix

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -359,7 +359,7 @@ struct cfg_root : cfg::node
 		cfg::string emulator_dir{this, "$(EmulatorDir)"}; // Default (empty): taken from fs::get_config_dir()
 		cfg::string dev_hdd0{this, "/dev_hdd0/", "$(EmulatorDir)dev_hdd0/"};
 		cfg::string dev_hdd1{this, "/dev_hdd1/", "$(EmulatorDir)dev_hdd1/"};
-		cfg::string dev_flash{this, "/dev_flash/"};
+		cfg::string dev_flash{this, "/dev_flash/", "$(EmulatorDir)dev_flash/"};
 		cfg::string dev_usb000{this, "/dev_usb000/", "$(EmulatorDir)dev_usb000/"};
 		cfg::string dev_bdvd{this, "/dev_bdvd/"}; // Not mounted
 		cfg::string app_home{this, "/app_home/"}; // Not mounted


### PR DESCRIPTION
The vfs was given odd behavior for dev_flash after d62b0c88b0169f9f43b2d11695817986a410430a causing the config file to be empty. Not sure if this is a bug or intentional. Feel free to close if this is correct behavior.

Attempting to address #4812 
