### PR TITLE
rsx: Program Fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -110,23 +110,45 @@ namespace glsl
 		}
 	}
 
-	static std::string compareFunctionImpl(COMPARE f, const std::string &Op0, const std::string &Op1)
+	static std::string compareFunctionImpl(COMPARE f, const std::string &Op0, const std::string &Op1, bool scalar = false)
 	{
-		switch (f)
+		if (scalar)
 		{
-		case COMPARE::FUNCTION_SEQ:
-			return "equal(" + Op0 + ", " + Op1 + ")";
-		case COMPARE::FUNCTION_SGE:
-			return "greaterThanEqual(" + Op0 + ", " + Op1 + ")";
-		case COMPARE::FUNCTION_SGT:
-			return "greaterThan(" + Op0 + ", " + Op1 + ")";
-		case COMPARE::FUNCTION_SLE:
-			return "lessThanEqual(" + Op0 + ", " + Op1 + ")";
-		case COMPARE::FUNCTION_SLT:
-			return "lessThan(" + Op0 + ", " + Op1 + ")";
-		case COMPARE::FUNCTION_SNE:
-			return "notEqual(" + Op0 + ", " + Op1 + ")";
+			switch (f)
+			{
+			case COMPARE::FUNCTION_SEQ:
+				return Op0 + " == " + Op1;
+			case COMPARE::FUNCTION_SGE:
+				return Op0 + " >= " + Op1;
+			case COMPARE::FUNCTION_SGT:
+				return Op0 + " > " + Op1;
+			case COMPARE::FUNCTION_SLE:
+				return Op0 + " <= " + Op1;
+			case COMPARE::FUNCTION_SLT:
+				return Op0 + " < " + Op1;
+			case COMPARE::FUNCTION_SNE:
+				return Op0 + " != " + Op1;
+			}
 		}
+		else
+		{
+			switch (f)
+			{
+			case COMPARE::FUNCTION_SEQ:
+				return "equal(" + Op0 + ", " + Op1 + ")";
+			case COMPARE::FUNCTION_SGE:
+				return "greaterThanEqual(" + Op0 + ", " + Op1 + ")";
+			case COMPARE::FUNCTION_SGT:
+				return "greaterThan(" + Op0 + ", " + Op1 + ")";
+			case COMPARE::FUNCTION_SLE:
+				return "lessThanEqual(" + Op0 + ", " + Op1 + ")";
+			case COMPARE::FUNCTION_SLT:
+				return "lessThan(" + Op0 + ", " + Op1 + ")";
+			case COMPARE::FUNCTION_SNE:
+				return "notEqual(" + Op0 + ", " + Op1 + ")";
+			}
+		}
+
 		fmt::throw_exception("Unknown compare function" HERE);
 	}
 

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -1,5 +1,8 @@
 #include "stdafx.h"
 #include "ProgramStateCache.h"
+#include "Emu/System.h"
+
+#include <stack>
 
 using namespace program_hash_util;
 
@@ -12,54 +15,222 @@ size_t vertex_program_utils::get_vertex_program_ucode_hash(const RSXVertexProgra
 	bool end = false;
 	for (unsigned i = 0; i < program.data.size() / 4; i++)
 	{
-		const qword inst = instbuffer[instIndex];
-		hash ^= inst.dword[0];
-		hash += (hash << 1) + (hash << 4) + (hash << 5) + (hash << 7) + (hash << 8) + (hash << 40);
-		hash ^= inst.dword[1];
-		hash += (hash << 1) + (hash << 4) + (hash << 5) + (hash << 7) + (hash << 8) + (hash << 40);
+		if (program.instruction_mask[i])
+		{
+			const qword inst = instbuffer[instIndex];
+			hash ^= inst.dword[0];
+			hash += (hash << 1) + (hash << 4) + (hash << 5) + (hash << 7) + (hash << 8) + (hash << 40);
+			hash ^= inst.dword[1];
+			hash += (hash << 1) + (hash << 4) + (hash << 5) + (hash << 7) + (hash << 8) + (hash << 40);
+		}
+
 		instIndex++;
 	}
 	return hash;
 }
 
-vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vertex_program(const std::vector<u32>& data)
+vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vertex_program(const u32* data, u32 entry, RSXVertexProgram& dst_prog)
 {
-	u32 ucode_size = 0;
-	u32 current_instrution = 0;
+	vertex_program_utils::vertex_program_metadata result;
 	u32 last_instruction_address = 0;
+	u32 first_instruction_address = entry;
+
+	std::stack<u32> call_stack;
+	std::pair<u32, u32> instruction_range = { UINT32_MAX, 0 };
+	std::bitset<512> instructions_to_patch;
+	bool has_branch_instruction = false;
+
 	D3  d3;
 	D2  d2;
 	D1  d1;
+	D0  d0;
 
-	for (; ucode_size < data.size(); ucode_size += 4)
+	std::function<void(u32, bool)> walk_function = [&](u32 start, bool fast_exit)
 	{
-		d1.HEX = data[ucode_size + 1];
-		d3.HEX = data[ucode_size + 3];
+		u32 current_instrution = start;
+		std::set<u32> conditional_targets;
 
-		switch (d1.sca_opcode)
+		while (true)
 		{
-		case RSX_SCA_OPCODE_BRI:
-		case RSX_SCA_OPCODE_BRB:
-		case RSX_SCA_OPCODE_CAL:
-		case RSX_SCA_OPCODE_CLI:
-		case RSX_SCA_OPCODE_CLB:
-		{
-			d2.HEX = data[ucode_size + 2];
+			verify(HERE), current_instrution < 512;
 
-			u32 jump_address = ((d2.iaddrh << 3) | d3.iaddrl) * 4;
-			last_instruction_address = std::max(last_instruction_address, jump_address);
-			break;
+			if (result.instruction_mask[current_instrution])
+			{
+				if (!fast_exit)
+				{
+					// This can be harmless if a dangling RET was encountered before
+					LOG_ERROR(RSX, "vp_analyser: Possible infinite loop detected");
+					current_instrution++;
+					continue;
+				}
+				else
+				{
+					// Block walk, looking for earliest exit
+					break;
+				}
+			}
+
+			const qword* instruction = (const qword*)&data[current_instrution * 4];
+			d1.HEX = instruction->word[1];
+			d3.HEX = instruction->word[3];
+
+			// Touch current instruction
+			result.instruction_mask[current_instrution] = 1;
+			instruction_range.first = std::min(current_instrution, instruction_range.first);
+			instruction_range.second = std::max(current_instrution, instruction_range.second);
+
+			bool static_jump = false;
+			bool function_call = true;
+
+			switch (d1.sca_opcode)
+			{
+			case RSX_SCA_OPCODE_BRI:
+			{
+				d0.HEX = instruction->word[0];
+				static_jump = (d0.cond == 0x7);
+				// Fall through
+			}
+			case RSX_SCA_OPCODE_BRB:
+			{
+				function_call = false;
+				// Fall through
+			}
+			case RSX_SCA_OPCODE_CAL:
+			case RSX_SCA_OPCODE_CLI:
+			case RSX_SCA_OPCODE_CLB:
+			{
+				// Need to patch the jump address to be consistent wherever the program is located
+				instructions_to_patch[current_instrution] = true;
+				has_branch_instruction = true;
+
+				d2.HEX = instruction->word[2];
+				const u32 jump_address = ((d2.iaddrh << 3) | d3.iaddrl);
+
+				if (function_call)
+				{
+					call_stack.push(current_instrution + 1);
+					current_instrution = jump_address;
+					continue;
+				}
+				else if (static_jump)
+				{
+					// NOTE: This will skip potential jump target blocks between current->target
+					current_instrution = jump_address;
+					continue;
+				}
+				else
+				{
+					// Set possible end address and proceed as usual
+					conditional_targets.emplace(jump_address);
+					instruction_range.second = std::max(jump_address, instruction_range.second);
+				}
+
+				break;
+			}
+			case RSX_SCA_OPCODE_RET:
+			{
+				if (call_stack.empty())
+				{
+					LOG_ERROR(RSX, "vp_analyser: RET found outside subroutine call");
+				}
+				else
+				{
+					current_instrution = call_stack.top();
+					call_stack.pop();
+					continue;
+				}
+
+				break;
+			}
+			}
+
+			if (d3.end && (fast_exit || current_instrution >= instruction_range.second) ||
+				(current_instrution + 1) == 512)
+			{
+				break;
+			}
+
+			current_instrution++;
 		}
+
+		for (const u32 target : conditional_targets)
+		{
+			if (!result.instruction_mask[target])
+			{
+				walk_function(target, true);
+			}
+		}
+	};
+
+	if (g_cfg.video.log_programs)
+	{
+		fs::file dump(fs::get_config_dir() + "shaderlog/vp_analyser.bin", fs::rewrite);
+		dump.write(&entry, 4);
+		dump.write(data, 512 * 16);
+		dump.close();
+	}
+
+	walk_function(entry, false);
+
+	const u32 instruction_count = (instruction_range.second - instruction_range.first + 1);
+	result.ucode_length = instruction_count * 16;
+
+	dst_prog.base_address = instruction_range.first;
+	dst_prog.entry = entry;
+	dst_prog.data.resize(instruction_count * 4);
+	dst_prog.instruction_mask = (result.instruction_mask >> instruction_range.first);
+
+	if (!has_branch_instruction)
+	{
+		verify(HERE), instruction_range.first == entry;
+		std::memcpy(dst_prog.data.data(), data + (instruction_range.first * 4), result.ucode_length);
+	}
+	else
+	{
+		for (u32 i = instruction_range.first, count = 0; i <= instruction_range.second; ++i, ++count)
+		{
+			const qword* instruction = (const qword*)&data[i * 4];
+			qword* dst = (qword*)&dst_prog.data[count * 4];
+
+			if (result.instruction_mask[i])
+			{
+				dst->dword[0] = instruction->dword[0];
+				dst->dword[1] = instruction->dword[1];
+
+				if (instructions_to_patch[i])
+				{
+					d2.HEX = dst->word[2];
+					d3.HEX = dst->word[3];
+
+					u32 address = ((d2.iaddrh << 3) | d3.iaddrl);
+					address -= instruction_range.first;
+
+					d2.iaddrh = (address >> 3);
+					d3.iaddrl = (address & 0x7);
+					dst->word[2] = d2.HEX;
+					dst->word[3] = d3.HEX;
+
+					dst_prog.jump_table.emplace(address);
+				}
+			}
+			else
+			{
+				dst->dword[0] = 0ull;
+				dst->dword[1] = 0ull;
+			}
 		}
 
-		if (d3.end && (ucode_size >= last_instruction_address))
+		// Verification
+		for (const u32 target : dst_prog.jump_table)
 		{
-			//Jumping over an end label is legal (verified)
-			break;
+			if (!result.instruction_mask[target])
+			{
+				LOG_ERROR(RSX, "vp_analyser: Failed, branch target 0x%x was not resolved", target);
+			}
 		}
 	}
 
-	return{ ucode_size + 4 };
+	return result;
 }
 
 size_t vertex_program_storage_hash::operator()(const RSXVertexProgram &program) const
@@ -75,6 +246,8 @@ bool vertex_program_compare::operator()(const RSXVertexProgram &binary1, const R
 		return false;
 	if (binary1.data.size() != binary2.data.size())
 		return false;
+	if (binary1.jump_table != binary2.jump_table)
+		return false;
 	if (!binary1.skip_vertex_input_check && !binary2.skip_vertex_input_check && binary1.rsx_vertex_inputs != binary2.rsx_vertex_inputs)
 		return false;
 
@@ -83,10 +256,22 @@ bool vertex_program_compare::operator()(const RSXVertexProgram &binary1, const R
 	size_t instIndex = 0;
 	for (unsigned i = 0; i < binary1.data.size() / 4; i++)
 	{
-		const qword& inst1 = instBuffer1[instIndex];
-		const qword& inst2 = instBuffer2[instIndex];
-		if (inst1.dword[0] != inst2.dword[0] || inst1.dword[1] != inst2.dword[1])
+		const auto active = binary1.instruction_mask[instIndex];
+		if (active != binary2.instruction_mask[instIndex])
+		{
 			return false;
+		}
+
+		if (active)
+		{
+			const qword& inst1 = instBuffer1[instIndex];
+			const qword& inst2 = instBuffer2[instIndex];
+			if (inst1.dword[0] != inst2.dword[0] || inst1.dword[1] != inst2.dword[1])
+			{
+				return false;
+			}
+		}
+
 		instIndex++;
 	}
 

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -29,12 +29,13 @@ namespace program_hash_util
 	{
 		struct vertex_program_metadata
 		{
-			u32 ucode_size;
+			std::bitset<512> instruction_mask;
+			u32 ucode_length;
 		};
 
 		static size_t get_vertex_program_ucode_hash(const RSXVertexProgram &program);
 
-		static vertex_program_metadata analyse_vertex_program(const std::vector<u32>& data);
+		static vertex_program_metadata analyse_vertex_program(const u32* data, u32 entry, RSXVertexProgram& dst_prog);
 	};
 
 	struct vertex_program_storage_hash

--- a/rpcs3/Emu/RSX/Common/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Common/ShaderParam.h
@@ -177,7 +177,20 @@ public:
 	ShaderVariable() = default;
 	ShaderVariable(const std::string& var)
 	{
-		auto var_blocks = fmt::split(var, { "." });
+		// Separate 'double destination' variables 'X=Y=SRC'
+		std::string simple_var;
+		const auto pos = var.find("=");
+
+		if (pos != std::string::npos)
+		{
+			simple_var = var.substr(0, pos - 1);
+		}
+		else
+		{
+			simple_var = var;
+		}
+
+		auto var_blocks = fmt::split(simple_var, { "." });
 
 		verify(HERE), (var_blocks.size() != 0);
 

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -52,7 +52,7 @@ std::string VertexProgramDecompiler::GetDST(bool isSca)
 	default:
 		if (d3.dst > 15)
 			LOG_ERROR(RSX, "dst index out of range: %u", d3.dst);
-		ret += m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), std::string("dst_reg") + std::to_string(d3.dst), d3.dst == 0 ? getFloatTypeName(4) + "(0.0f, 0.0f, 0.0f, 1.0f)" : getFloatTypeName(4) + "(0.0, 0.0, 0.0, 0.0)") + mask;
+		ret += m_parr.AddParam(PF_PARAM_OUT, getFloatTypeName(4), std::string("dst_reg") + std::to_string(d3.dst), d3.dst == 0 ? getFloatTypeName(4) + "(0.0f, 0.0f, 0.0f, 1.0f)" : getFloatTypeName(4) + "(0.0, 0.0, 0.0, 0.0)") + mask;
 		// Handle double destination register as 'dst_reg = tmp'
 		if (d0.dst_tmp != 0x3f)
 			ret += " = " + m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), std::string("tmp") + std::to_string(d0.dst_tmp)) + mask;
@@ -389,6 +389,13 @@ std::string VertexProgramDecompiler::BuildCode()
 		}
 
 		lvl += m_instructions[i].open_scopes;
+	}
+
+	bool is_valid = m_parr.HasParam(PF_PARAM_OUT, getFloatTypeName(4), "dst_reg0");
+	if (!is_valid)
+	{
+		LOG_WARNING(RSX, "Vertex program has no POS output, shader will be NOPed");
+		main_body = "/*" + main_body + "*/";
 	}
 
 	std::stringstream OS;

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.h
@@ -53,11 +53,10 @@ struct VertexProgramDecompiler
 	Instruction* m_cur_instr;
 	size_t m_instr_count;
 
-	std::set<int> m_jump_lvls;
 	std::vector<std::string> m_body;
 	std::stack<u32> m_call_stack;
 
-	const std::vector<u32>& m_data;
+	const RSXVertexProgram& m_prog;
 	ParamArray m_parr;
 
 	std::string NotZeroPositive(const std::string& code);

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.h
@@ -98,7 +98,7 @@ protected:
 
 	/** returns string calling comparison function on 2 args passed as strings.
 	*/
-	virtual std::string compareFunction(COMPARE, const std::string &, const std::string &) = 0;
+	virtual std::string compareFunction(COMPARE, const std::string &, const std::string &, bool scalar = false) = 0;
 
 	/** Insert header of shader file (eg #version, "system constants"...)
 	*/

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -53,7 +53,7 @@ void D3D12GSRender::load_program()
 		return std::make_tuple(true, native_pitch);
 	};
 
-	get_current_vertex_program();
+	get_current_vertex_program(false);
 	get_current_fragment_program_legacy(rtt_lookup_func);
 
 	if (!current_fragment_program.valid)

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
@@ -175,8 +175,22 @@ void D3D12VertexProgramDecompiler::insertMainStart(std::stringstream & OS)
 	OS << "PixelInput main(uint vertex_id : SV_VertexID)\n";
 	OS << "{\n";
 
-	// Declare inside main function
+	// Declare temp registers
 	for (const ParamType PT : m_parr.params[PF_PARAM_NONE])
+	{
+		for (const ParamItem &PI : PT.items)
+		{
+			OS << "	" << PT.type << " " << PI.name;
+			if (!PI.value.empty())
+				OS << " = " << PI.value;
+			else
+				OS << " = " << "float4(0., 0., 0., 0.);";
+			OS << ";\n";
+		}
+	}
+
+	// Declare outputs
+	for (const ParamType PT : m_parr.params[PF_PARAM_OUT])
 	{
 		for (const ParamItem &PI : PT.items)
 		{
@@ -212,7 +226,7 @@ void D3D12VertexProgramDecompiler::insertMainEnd(std::stringstream & OS)
 	// Declare inside main function
 	for (auto &i : reg_table)
 	{
-		if (m_parr.HasParam(PF_PARAM_NONE, "float4", i.src_reg))
+		if (m_parr.HasParam(PF_PARAM_OUT, "float4", i.src_reg))
 		{
 			if (i.name == "front_diff_color")
 				insert_front_diffuse = false;
@@ -238,11 +252,11 @@ void D3D12VertexProgramDecompiler::insertMainEnd(std::stringstream & OS)
 
 	//If 2 sided lighting is active and only back is written, copy the value to the front side (Outrun online arcade)
 	if (insert_front_diffuse && insert_back_diffuse)
-		if (m_parr.HasParam(PF_PARAM_NONE, "float4", "dst_reg1"))
+		if (m_parr.HasParam(PF_PARAM_OUT, "float4", "dst_reg1"))
 			OS << "	Out.dst_reg3 = dst_reg1;\n";
 
 	if (insert_front_specular && insert_back_specular)
-		if (m_parr.HasParam(PF_PARAM_NONE, "float4", "dst_reg2"))
+		if (m_parr.HasParam(PF_PARAM_OUT, "float4", "dst_reg2"))
 			OS << "	Out.dst_reg4 = dst_reg2;\n";
 
 	OS << "	Out.dst_reg0 = mul(Out.dst_reg0, scaleOffsetMat);\n";

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.cpp
@@ -21,7 +21,7 @@ std::string D3D12VertexProgramDecompiler::getFunction(enum class FUNCTION f)
 	return getFunctionImp(f);
 }
 
-std::string D3D12VertexProgramDecompiler::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1)
+std::string D3D12VertexProgramDecompiler::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1, bool /*scalar*/)
 {
 	return compareFunctionImp(f, Op0, Op1);
 }

--- a/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12VertexProgramDecompiler.h
@@ -10,7 +10,7 @@ protected:
 	virtual std::string getFloatTypeName(size_t elementCount) override;
 	std::string getIntTypeName(size_t elementCount) override;
 	virtual std::string getFunction(enum class FUNCTION) override;
-	virtual std::string compareFunction(enum class COMPARE, const std::string &, const std::string &) override;
+	virtual std::string compareFunction(enum class COMPARE, const std::string &, const std::string &, bool scalar) override;
 
 	virtual void insertHeader(std::stringstream &OS);
 	virtual void insertInputs(std::stringstream &OS, const std::vector<ParamType> &inputs);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -24,7 +24,7 @@ namespace
 
 GLGSRender::GLGSRender() : GSRender()
 {
-	m_shaders_cache.reset(new gl::shader_cache(m_prog_buffer, "opengl", "v1.3"));
+	m_shaders_cache.reset(new gl::shader_cache(m_prog_buffer, "opengl", "v1.5"));
 
 	if (g_cfg.video.disable_vertex_cache)
 		m_vertex_cache.reset(new gl::null_vertex_cache());

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -156,7 +156,7 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	for (int i = 0; i < 16; ++i)
 	{
 		std::string reg_name = "dst_reg" + std::to_string(i);
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", reg_name))
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", reg_name))
 		{
 			if (parameters.length())
 				parameters += ", ";
@@ -213,7 +213,7 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	std::string parameters = "";
 
-	if (ParamType *vec4Types = m_parr.SearchParam(PF_PARAM_NONE, "vec4"))
+	if (ParamType *vec4Types = m_parr.SearchParam(PF_PARAM_OUT, "vec4"))
 	{
 		for (int i = 0; i < 16; ++i)
 		{
@@ -258,7 +258,7 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 		if (front_back_specular && name == "spec_color")
 			name = "back_spec_color";
 
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", i.src_reg))
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", i.src_reg))
 		{
 			if (i.check_mask && (rsx_vertex_program.output_mask & i.check_mask_value) == 0)
 				continue;
@@ -290,11 +290,11 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 	}
 
 	if (insert_back_diffuse && insert_front_diffuse)
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "dst_reg1"))
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", "dst_reg1"))
 			OS << "	front_diff_color = dst_reg1;\n";
 
 	if (insert_back_specular && insert_front_specular)
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "dst_reg2"))
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", "dst_reg2"))
 			OS << "	front_spec_color = dst_reg2;\n";
 
 	OS << "	gl_PointSize = point_size;\n";

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -23,9 +23,9 @@ std::string GLVertexDecompilerThread::getFunction(FUNCTION f)
 	return glsl::getFunctionImpl(f);
 }
 
-std::string GLVertexDecompilerThread::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1)
+std::string GLVertexDecompilerThread::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1, bool scalar)
 {
-	return glsl::compareFunctionImpl(f, Op0, Op1);
+	return glsl::compareFunctionImpl(f, Op0, Op1, scalar);
 }
 
 void GLVertexDecompilerThread::insertHeader(std::stringstream &OS)

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.h
@@ -20,7 +20,7 @@ protected:
 	virtual std::string getFloatTypeName(size_t elementCount) override;
 	std::string getIntTypeName(size_t elementCount) override;
 	virtual std::string getFunction(FUNCTION) override;
-	virtual std::string compareFunction(COMPARE, const std::string&, const std::string&) override;
+	virtual std::string compareFunction(COMPARE, const std::string&, const std::string&, bool scalar) override;
 
 	virtual void insertHeader(std::stringstream &OS) override;
 	virtual void insertInputs(std::stringstream &OS, const std::vector<ParamType> &inputs) override;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1676,6 +1676,11 @@ namespace rsx
 				{
 					switch (format)
 					{
+					case CELL_GCM_TEXTURE_X16:
+					{
+						// NOP, a simple way to quickly read DEPTH16 data without shadow comparison
+						break;
+					}
 					case CELL_GCM_TEXTURE_A8R8G8B8:
 					case CELL_GCM_TEXTURE_D8R8G8B8:
 					case CELL_GCM_TEXTURE_A4R4G4B4: //TODO

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -377,7 +377,7 @@ namespace rsx
 		program_hash_util::fragment_program_utils::fragment_program_metadata current_fp_metadata = {};
 		program_hash_util::vertex_program_utils::vertex_program_metadata current_vp_metadata = {};
 
-		void get_current_vertex_program();
+		void get_current_vertex_program(bool skip_vertex_inputs = true);
 
 		/**
 		 * Gets current fragment program and associated fragment state

--- a/rpcs3/Emu/RSX/RSXVertexProgram.h
+++ b/rpcs3/Emu/RSX/RSXVertexProgram.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <bitset>
+#include <set>
+
 enum vp_reg_type
 {
 	RSX_VP_REGISTER_TYPE_TEMP = 1,
@@ -229,4 +232,9 @@ struct RSXVertexProgram
 	std::vector<rsx_vertex_input> rsx_vertex_inputs;
 	u32 output_mask;
 	bool skip_vertex_input_check;
+
+	u32 base_address;
+	u32 entry;
+	std::bitset<512> instruction_mask;
+	std::set<u32> jump_table;
 };

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -626,7 +626,7 @@ VKGSRender::VKGSRender() : GSRender()
 	else
 		m_vertex_cache.reset(new vk::weak_vertex_cache());
 
-	m_shaders_cache.reset(new vk::shader_cache(*m_prog_buffer.get(), "vulkan", "v1.3"));
+	m_shaders_cache.reset(new vk::shader_cache(*m_prog_buffer.get(), "vulkan", "v1.5"));
 
 	open_command_buffer();
 

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -150,7 +150,7 @@ void VKVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::
 
 	for (auto &i : reg_table)
 	{
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", i.src_reg) && i.need_declare)
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", i.src_reg) && i.need_declare)
 		{
 			if (i.check_mask && (rsx_vertex_program.output_mask & i.check_mask_value) == 0)
 				continue;
@@ -192,7 +192,7 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	for (int i = 0; i < 16; ++i)
 	{
 		std::string reg_name = "dst_reg" + std::to_string(i);
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", reg_name))
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", reg_name))
 		{
 			if (parameters.length())
 				parameters += ", ";
@@ -238,7 +238,7 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	std::string parameters = "";
 
-	if (ParamType *vec4Types = m_parr.SearchParam(PF_PARAM_NONE, "vec4"))
+	if (ParamType *vec4Types = m_parr.SearchParam(PF_PARAM_OUT, "vec4"))
 	{
 		for (int i = 0; i < 16; ++i)
 		{
@@ -272,7 +272,7 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	for (auto &i : reg_table)
 	{
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", i.src_reg))
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", i.src_reg))
 		{
 			if (i.check_mask && (rsx_vertex_program.output_mask & i.check_mask_value) == 0)
 				continue;
@@ -305,11 +305,11 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 	}
 
 	if (insert_back_diffuse && insert_front_diffuse)
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "dst_reg1"))
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", "dst_reg1"))
 			OS << "	front_diff_color = dst_reg1;\n";
 
 	if (insert_back_specular && insert_front_specular)
-		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "dst_reg2"))
+		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", "dst_reg2"))
 			OS << "	front_spec_color = dst_reg2;\n";
 
 	OS << "	gl_PointSize = point_size;\n";

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -20,9 +20,9 @@ std::string VKVertexDecompilerThread::getFunction(FUNCTION f)
 	return glsl::getFunctionImpl(f);
 }
 
-std::string VKVertexDecompilerThread::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1)
+std::string VKVertexDecompilerThread::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1, bool scalar)
 {
-	return glsl::compareFunctionImpl(f, Op0, Op1);
+	return glsl::compareFunctionImpl(f, Op0, Op1, scalar);
 }
 
 void VKVertexDecompilerThread::insertHeader(std::stringstream &OS)

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.h
@@ -14,7 +14,7 @@ protected:
 	virtual std::string getFloatTypeName(size_t elementCount) override;
 	std::string getIntTypeName(size_t elementCount) override;
 	virtual std::string getFunction(FUNCTION) override;
-	virtual std::string compareFunction(COMPARE, const std::string&, const std::string&) override;
+	virtual std::string compareFunction(COMPARE, const std::string&, const std::string&, bool scalar) override;
 
 	virtual void insertHeader(std::stringstream &OS) override;
 	virtual void insertInputs(std::stringstream &OS, const std::vector<ParamType> &inputs) override;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -340,9 +340,11 @@ namespace rsx
 				static constexpr u32 reg = index / 4;
 				static constexpr u8 subreg = index % 4;
 
-				u32 load = rsx::method_registers.transform_constant_load();
-				if ((load + index) >= 512)
+				const u32 load = rsx::method_registers.transform_constant_load();
+				const u32 address = load + reg;
+				if (address >= 468)
 				{
+					// Ignore addresses outside the usable [0, 467] range
 					LOG_ERROR(RSX, "Invalid transform register index (load=%d, index=%d)", load, index);
 					return;
 				}
@@ -538,7 +540,7 @@ namespace rsx
 			rsx->sync();
 		}
 
-		void invalidate_L2(thread* rsx, u32, u32)
+		void set_shader_program_dirty(thread* rsx, u32, u32)
 		{
 			rsx->m_graphics_state |= rsx::pipeline_state::fragment_program_dirty;
 		}
@@ -1757,7 +1759,7 @@ namespace rsx
 		bind_range<NV4097_SET_TEXTURE_ADDRESS, 8, 16, nv4097::set_texture_dirty_bit>();
 		bind_range<NV4097_SET_TEXTURE_CONTROL0, 8, 16, nv4097::set_texture_dirty_bit>();
 		bind_range<NV4097_SET_TEXTURE_CONTROL1, 8, 16, nv4097::set_texture_dirty_bit>();
-		bind_range<NV4097_SET_TEXTURE_CONTROL2, 8, 16, nv4097::set_texture_dirty_bit>();
+		bind_range<NV4097_SET_TEXTURE_CONTROL2, 1, 16, nv4097::set_texture_dirty_bit>();
 		bind_range<NV4097_SET_TEXTURE_CONTROL3, 1, 16, nv4097::set_texture_dirty_bit>();
 		bind_range<NV4097_SET_TEXTURE_FILTER, 8, 16, nv4097::set_texture_dirty_bit>();
 		bind_range<NV4097_SET_TEXTURE_IMAGE_RECT, 8, 16, nv4097::set_texture_dirty_bit>();
@@ -1782,7 +1784,8 @@ namespace rsx
 		bind<NV4097_WAIT_FOR_IDLE, nv4097::sync>();
 		bind<NV4097_ZCULL_SYNC, nv4097::sync>();
 		bind<NV4097_SET_CONTEXT_DMA_REPORT, nv4097::sync>();
-		bind<NV4097_INVALIDATE_L2, nv4097::invalidate_L2>();
+		bind<NV4097_INVALIDATE_L2, nv4097::set_shader_program_dirty>();
+		bind<NV4097_SET_SHADER_PROGRAM, nv4097::set_shader_program_dirty>();
 		bind<NV4097_SET_TRANSFORM_PROGRAM_START, nv4097::set_transform_program_start>();
 		bind<NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK, nv4097::set_vertex_attribute_output_mask>();
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1169,6 +1169,16 @@ namespace rsx
 			return decode<NV308A_POINT>().y();
 		}
 
+		u16 nv308a_size_in_x() const
+		{
+			return u16(registers[NV308A_SIZE_IN] & 0xFFFF);
+		}
+
+		u16 nv308a_size_out_x() const
+		{
+			return u16(registers[NV308A_SIZE_OUT] & 0xFFFF);
+		}
+
 		void commit_4_transform_program_instructions(u32 index)
 		{
 			u32& load = registers[NV4097_SET_TRANSFORM_PROGRAM_LOAD];

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -5,6 +5,7 @@
 #include "gcm_enums.h"
 #include <atomic>
 #include <memory>
+#include <bitset>
 
 // TODO: replace the code below by #include <optional> when C++17 or newer will be used
 #include <optional.hpp>
@@ -725,5 +726,42 @@ namespace rsx
 	static inline thread* get_current_renderer()
 	{
 		return g_current_renderer;
+	}
+
+	template <int N>
+	void unpack_bitset(std::bitset<N>& block, u64* values)
+	{
+		constexpr int count = N / 64;
+		for (int n = 0; n < count; ++n)
+		{
+			int i = (n << 6);
+			values[n] = 0;
+
+			for (int bit = 0; bit < 64; ++bit, ++i)
+			{
+				if (block[i])
+				{
+					values[n] |= (1 << bit);
+				}
+			}
+		}
+	}
+
+	template <int N>
+	void pack_bitset(std::bitset<N>& block, u64* values)
+	{
+		constexpr int count = N / 64;
+		for (int n = (count - 1); n >= 0; --n)
+		{
+			if ((n + 1) < count)
+			{
+				block <<= 64;
+			}
+
+			if (values[n])
+			{
+				block |= values[n];
+			}
+		}
 	}
 }


### PR DESCRIPTION
**Details**
- Fix nv308a::color implementation
- Vertex program decompiler : Fix branch target extraction
- Vertex program decompiler : Fix double destination writes
- Vertex program decompiler : More human-readable code generated from masked writes
- Vertex program analyser rewritten [WIP]
- Silence unnecessary log spam (https://github.com/RPCS3/rpcs3/issues/4398)

**Results**
- Fixes https://github.com/RPCS3/rpcs3/issues/3323
- Largely reduces number of generated shaders in some titles with infinite compilation. Corner cases exist so some titles still try to generate new shaders but they are actually false positives (they are not actually saved to the cache at all). This will be fixed before merge.

~~NOTE: Contains the patch from https://github.com/RPCS3/rpcs3/pull/4830. This is not a replacement - the patch will be removed before merging. It makes testing some titles easier if they are unstable on master.~~