### PR TITLE
 Fix cellSysCacheClear

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -300,7 +300,7 @@ s32 cellSysCacheClear()
 
 	const std::string& cache_id = param->cacheId;
 
-	const std::string& cache_path = "/dev_hdd1/cache/" + cache_id + '/';
+	const std::string& cache_path = "/dev_hdd1/cache/" + cache_id;
 	const std::string& dir_path = vfs::get(cache_path);
 
 	if (!fs::exists(dir_path) || !fs::is_dir(dir_path))
@@ -320,7 +320,7 @@ s32 cellSysCacheMount(vm::ptr<CellSysCacheParam> param)
 	const std::string& cache_id = param->cacheId;
 	verify(HERE), cache_id.size() < sizeof(param->cacheId);
 
-	const std::string& cache_path = "/dev_hdd1/cache/" + cache_id + '/';
+	const std::string& cache_path = "/dev_hdd1/cache/" + cache_id;
 	strcpy_trunc(param->getCachePath, cache_path);
 
 	// TODO: implement (what?)

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -308,7 +308,7 @@ s32 cellSysCacheClear()
 		return CELL_SYSCACHE_ERROR_ACCESS_ERROR;
 	}
 
-	fs::remove_all(dir_path, true);
+	fs::remove_all(dir_path, false);
 
 	return CELL_SYSCACHE_RET_OK_CLEARED;
 }

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -324,10 +324,13 @@ s32 cellSysCacheMount(vm::ptr<CellSysCacheParam> param)
 	strcpy_trunc(param->getCachePath, cache_path);
 
 	// TODO: implement (what?)
-	fs::create_dir(vfs::get(cache_path));
 	fxm::make_always<CellSysCacheParam>(*param);
+	if (!fs::create_dir(vfs::get(cache_path)))
+	{
+		return CELL_SYSCACHE_RET_OK_RELAYED;
+	}
 
-	return CELL_SYSCACHE_RET_OK_RELAYED;
+	return CELL_SYSCACHE_RET_OK_CLEARED;
 }
 
 bool g_bgm_playback_enabled = true;


### PR DESCRIPTION
- dont remove cache directory after clear, only clear cache dir's content.

- Fix cache dir path returned 

- Fix 'error' code returned in cellSysCacheMount

the [testcase](https://github.com/elad335/myps3tests/tree/master/ppu_tests/Cellsyscache) I created tries to create cache dir twice, first error code is `CELL_SYSCACHE_RET_OK_CLEARED` (0), second is `CELL_SYSCACHE_RET_OK_RELAYED` (1)
then tries to create file.txt inside the folder cache, clear cache, and trying to get that file again, this fails with `CELL_ENOENT`, indicating the deletion of the file.
but recreating the file works and returned `CELL_OK`, indicating that the cache dir is NOT removed and is still usable.

fixes #4470

pinging @Kravickas to retest