### PR TITLE
Added option to decrypt .iso

### DIFF
--- a/rpcs3/iso_decryptor.cpp
+++ b/rpcs3/iso_decryptor.cpp
@@ -8,7 +8,6 @@
 #include <QString>
 #include <QByteArray>
 #include <QFileDevice>
-#include <QMessageBox>
 #include <QDesktopServices>
 
 #include "Crypto/aes.h"

--- a/rpcs3/iso_decryptor.cpp
+++ b/rpcs3/iso_decryptor.cpp
@@ -1,0 +1,142 @@
+
+
+#include "iso_decryptor.h"
+
+#include <iostream>
+
+#include <QDir>
+#include <QUrl>
+#include <QFile>
+#include <QObject>
+#include <QString>
+#include <QtGlobal>
+#include <QByteArray>
+#include <QFileDevice>
+#include <QMessageBox>
+#include <QDesktopServices>
+
+#include "Crypto/aes.h"
+#include "Utilities/Log.h"
+#include "Utilities/File.h"
+#include "rpcs3qt/progress_dialog.h"
+
+iso_decryptor::iso_decryptor(QString filePath)
+    : m_iso_file(filePath)
+{
+}
+
+int iso_decryptor::decrypt()
+{
+
+	if (!(m_iso_file.permissions() & QFileDevice::ReadUser))
+	{
+		return -1;
+	}
+
+	if (!m_iso_file.open(QIODevice::ReadOnly))
+	{
+		return 0;
+	}
+
+	m_filesize = m_iso_file.size();
+
+	auto readInt  = [this](int length) { return m_iso_file.read(length).toHex().toInt(nullptr, 16); };
+	auto readUint = [this](int length) { return m_iso_file.read(length).toHex().toUInt(nullptr, 16); };
+
+	m_iso_file.seek(0);
+	m_region_count = readInt(4);
+	m_iso_file.skip(4); // Skip unused bytes
+
+	for (int i = 0; i < m_region_count * 2; i++)
+	{
+		m_regions.push_back((qint64(readUint(4))) * 2048);
+	}
+
+	if (m_regions.back() > m_filesize)
+	{
+		return -2;
+	}
+
+	m_regions.push_back(m_filesize);
+
+	m_iso_file.seek(SECTOR + 16); // game_id is located 16 bytes after the start of sector 2
+	m_game_id = QString::fromUtf8(m_iso_file.read(16)).trimmed();
+
+	m_iso_file.seek(3968); // data1 is located at a specific location in sector 2
+	m_data1 = m_iso_file.read(16);
+
+	aes_context enc;
+	aes_setkey_enc(&enc, keyCast(ISO_SECRET), ISO_SECRET.length() * 8); // 128
+
+	unsigned char disc_key[16];
+	aes_crypt_cbc(&enc, AES_ENCRYPT, m_data1.length(), keyCast(ISO_IV), keyCast(m_data1), disc_key);
+	m_disc_key = QByteArray::fromRawData((const char*)disc_key, 16);
+
+	QString dir = QString::fromStdString(fs::get_config_dir()) + QString("dev_hdd0/disc/") + m_game_id;
+	if (!QDir().mkpath(dir))
+	{
+		return -4;
+	}
+
+	QString filepath = dir + "/" + m_game_id + ".iso";
+	QFile out_iso(filepath);
+
+	if (!out_iso.open(QIODevice::WriteOnly))
+	{
+		return -3;
+	}
+
+	// Set AES context for decrypting data:
+	aes_context dec;
+	aes_setkey_dec(&dec, keyCast(m_disc_key), m_disc_key.length() * 8); // 128
+
+	m_iso_file.seek(0);
+	QByteArray buffer;
+	buffer.resize(SECTOR);
+	QByteArray iv;
+	iv.resize(m_data1.length());
+	unsigned char decrypted[SECTOR];
+
+	int current_region = 1;
+	bool encrypted     = false;
+	while (!m_iso_file.atEnd())
+	{
+		if (encrypted)
+		{
+			int sector_num = m_iso_file.pos() / 2048;
+			for (int i = 15; i >= 0; i--)
+			{
+				iv[i] = (unsigned char)(sector_num & 0xFF);
+				sector_num >>= 8;
+			}
+
+			m_iso_file.read(buffer.data(), SECTOR);
+
+			aes_crypt_cbc(&dec, AES_DECRYPT, SECTOR, keyCast(iv), keyCast(buffer), decrypted);
+
+			if (out_iso.write((const char*)decrypted, SECTOR) < SECTOR)
+			{
+				return -3;
+			}
+		}
+		else
+		{
+			m_iso_file.read(buffer.data(), SECTOR);
+			if (out_iso.write(buffer) < SECTOR)
+			{
+				return -3;
+			}
+		}
+
+		if (m_iso_file.pos() == m_regions[current_region])
+		{
+			encrypted = !encrypted;
+			current_region++;
+		}
+	}
+
+	QUrl url("file:" + dir);
+	QDesktopServices::openUrl(url);
+
+	return 1;
+}

--- a/rpcs3/iso_decryptor.cpp
+++ b/rpcs3/iso_decryptor.cpp
@@ -2,14 +2,10 @@
 
 #include "iso_decryptor.h"
 
-#include <iostream>
-
 #include <QDir>
 #include <QUrl>
 #include <QFile>
-#include <QObject>
 #include <QString>
-#include <QtGlobal>
 #include <QByteArray>
 #include <QFileDevice>
 #include <QMessageBox>
@@ -18,7 +14,6 @@
 #include "Crypto/aes.h"
 #include "Utilities/Log.h"
 #include "Utilities/File.h"
-#include "rpcs3qt/progress_dialog.h"
 
 iso_decryptor::iso_decryptor(QString filePath)
     : m_iso_file(filePath)

--- a/rpcs3/iso_decryptor.h
+++ b/rpcs3/iso_decryptor.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include <QFile>
+#include <QString>
+#include <QByteArray>
+
+const int SECTOR            = 2048;
+const QByteArray ISO_SECRET = QByteArray::fromHex("380bcf0b53455b3c7817ab4fa3ba90ed");
+const QByteArray ISO_IV     = QByteArray::fromHex("69474772af6fdab342743aefaa186287");
+
+auto keyCast = [](QByteArray array) { return reinterpret_cast<unsigned char*>(array.data()); };
+
+class iso_decryptor
+{
+private:
+	QByteArray m_data1;
+	QByteArray m_disc_key;
+	qint64 m_filesize;
+	int m_region_count;
+	std::vector<qint64> m_regions;
+	QString m_game_id;
+	QFile m_iso_file;
+
+public:
+	explicit iso_decryptor(QString filePath);
+
+	int decrypt();
+};

--- a/rpcs3/iso_decryptor.h
+++ b/rpcs3/iso_decryptor.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <map>
 #include <vector>
 
 #include <QFile>

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1,4 +1,5 @@
 
+#include <QDir>
 #include <QApplication>
 #include <QMenuBar>
 #include <QMessageBox>
@@ -31,6 +32,7 @@
 #include "about_dialog.h"
 #include "gamepads_settings_dialog.h"
 #include "progress_dialog.h"
+#include "iso_decryptor.h"
 
 #include <thread>
 
@@ -1150,6 +1152,7 @@ void main_window::CreateConnects()
 
 	connect(ui->bootInstallPkgAct, &QAction::triggered, [this] {InstallPkg(); });
 	connect(ui->bootInstallPupAct, &QAction::triggered, [this] {InstallPup(); });
+	connect(ui->isoDecryptAct, &QAction::triggered, [this] { DecryptIso(); });
 	connect(ui->exitAct, &QAction::triggered, this, &QWidget::close);
 	connect(ui->sysPauseAct, &QAction::triggered, this, &main_window::OnPlayOrPause);
 	connect(ui->sysStopAct, &QAction::triggered, [=]() { Emu.Stop(); });
@@ -1772,4 +1775,63 @@ void main_window::dragMoveEvent(QDragMoveEvent* event)
 void main_window::dragLeaveEvent(QDragLeaveEvent* event)
 {
 	event->accept();
+}
+
+void main_window::DecryptIso()
+{
+
+	QString filePath = QFileDialog::getOpenFileName(this, tr("Select PS3 .iso To Decrypt"), QDir::homePath(), tr("PS3 .iso file (*.iso)"));
+
+	LOG_NOTICE(GENERAL, "Decrypting %s, please wait..", filePath.toStdString());
+
+	if (filePath.isEmpty())
+	{
+		return;
+	}
+
+	iso_decryptor decryptor(filePath);
+
+	switch (decryptor.decrypt())
+	{
+	case -4:
+	{
+		LOG_ERROR(GENERAL, "Error while decrypting .iso: Unable to make directory.");
+		QMessageBox::critical(this, tr("Failure!"), tr("Error while decrypting .iso: Unable to make directory."));
+		return;
+	}
+	case -3:
+	{
+		LOG_ERROR(GENERAL, "Error while decrypting .iso: Unable to write to output file.");
+		QMessageBox::critical(this, tr("Failure!"), tr("Error while decrypting .iso: Unable to write to output file."));
+		return;
+	}
+	case -2:
+	{
+		LOG_ERROR(GENERAL, "Error while reading .iso: Last region size is larger than filesize. Most likely corrupt ISO.");
+		QMessageBox::critical(this, tr("Failure!"), tr("Error while reading .iso: Last region size is larger than filesize. Most likely corrupt ISO."));
+		return;
+	}
+	case -1:
+	{
+		LOG_ERROR(GENERAL, "Error while opening .iso: No read access permission.");
+		QMessageBox::critical(this, tr("Failure!"), tr("Error while opening .iso: No read access permission."));
+		return;
+	}
+	case 0:
+		LOG_ERROR(GENERAL, "Error while decrypting .iso: Could not open file.");
+		QMessageBox::critical(this, tr("Failure!"), tr("Error while decrypting .iso: Could not open file."));
+		return;
+	case 1: break;
+	default:
+		LOG_ERROR(GENERAL, "Error while decrypting .iso: Unknown error.");
+		QMessageBox::critical(this, tr("Failure!"), tr("Error while decrypting .iso: Unknown error."));
+		return;
+	}
+
+	LOG_SUCCESS(GENERAL, "Successfully decrypted %s!", filePath.toStdString());
+
+	QMessageBox::information(this, tr("Successfully decrypted .iso!"),
+	    tr("We've opened a folder for you,\n"
+	       "please extract the decrypted .iso with 7-zip.\n"
+	       "You can delete the .iso after extraction, if you wish."));
 }

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -117,6 +117,8 @@ private:
 	void InstallPkg(const QString& dropPath = "");
 	void InstallPup(const QString& dropPath = "");
 
+	void DecryptIso();
+
 	int IsValidFile(const QMimeData& md, QStringList* dropPaths = nullptr);
 	void AddGamesFromDir(const QString& path);
 

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -169,6 +169,8 @@
     <addaction name="bootGameAct"/>
     <addaction name="bootRecentMenu"/>
     <addaction name="separator"/>
+    <addaction name="isoDecryptAct"/>
+    <addaction name="separator"/>
     <addaction name="bootInstallPkgAct"/>
     <addaction name="bootInstallPupAct"/>
     <addaction name="separator"/>
@@ -343,6 +345,11 @@
    <property name="text">
     <string>Boot Game</string>
    </property>
+  </action>
+  <action name="isoDecryptAct">
+    <property name="text">
+      <string>Decrypt .iso</string>
+    </property>
   </action>
   <action name="bootInstallPkgAct">
    <property name="text">


### PR DESCRIPTION
For the past three-four weeks I've been looking into how ps3 .isos are decrypted.

This patch adds a new "Decrypt .iso" option under "File" that allows one to decrypt a properly dumped .iso file. This will only work on .isos patched with the data1 decryption key from .ird files.
Here's a demonstration: https://gfycat.com/ReasonableGracefulAzurevasesponge ([backup](https://media.giphy.com/media/1SB5xqtPsw4LawlCqU/giphy.mp4))

Unfortunately this does not show progress while it is decrypting, and it does also not extract the decrypted iso as I would've had to add a dependency to do so. 
I believe it is possible to add 7zip as a dependency and then extract the .iso using that, but I'll leave that for someone else.

If you don't want this capability in RPCS3 then simply reject this PR, I've made a Python tool to do the same: https://notabug.org/necklace/libray

