### PR TITLE
Clang compilation fixes

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -1,5 +1,9 @@
 #include "JIT.h"
 
+#ifndef _XABORT_RETRY
+#define _XABORT_RETRY (1 << 1)
+#endif
+
 asmjit::JitRuntime& asmjit::get_global_runtime()
 {
 	// Magic static

--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -469,7 +469,7 @@ public:
 		{
 			auto buf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(cached.size());
 			cached.read(buf->getBufferStart(), buf->getBufferSize());
-			return buf;
+			return std::move(buf);
 		}
 
 		return nullptr;

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -184,8 +184,6 @@ else()
 	message("-- Using Custom RPCS3_SRC_DIR=${RPCS3_SRC_DIR}")
 endif()
 
-set(CMAKE_MODULE_PATH "${RPCS3_SRC_DIR}/cmake_modules")
-
 # Prefer GLVND for OpenGL rather than legacy
 set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL REQUIRED)

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -28,7 +28,7 @@ const u32 tiled_pitches[] = {
 
 struct CellGcmSysConfig {
 	u32 zculls_addr;
-	vm::ptr<CellGcmDisplayInfo> gcm_buffers{ vm::null };
+	vm::ptr<CellGcmDisplayInfo> gcm_buffers = vm::null;
 	u32 tiles_addr;
 	u32 ctxt_addr;
 	CellGcmConfig current_config;

--- a/rpcs3/Emu/RSX/Common/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Common/ShaderParam.h
@@ -179,7 +179,7 @@ public:
 	{
 		// Separate 'double destination' variables 'X=Y=SRC'
 		std::string simple_var;
-		const auto pos = var.find("=");
+		const auto pos = var.find('=');
 
 		if (pos != std::string::npos)
 		{

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -309,7 +309,7 @@ void VertexProgramDecompiler::AddCodeCond(const std::string& dst, const std::str
 	auto get_masked_dst = [](const std::string& dest, const char mask)
 	{
 		const auto selector = std::string(".") + mask;
-		const auto pos = dest.find("=");
+		const auto pos = dest.find('=');
 
 		std::string result = dest + selector;
 


### PR DESCRIPTION
Compilation fixes for old versions of Clang, still supported by RPCS3.
- Error on 3.8: 
```
../Utilities/JIT.cpp:472:11: error: no viable conversion from returned value of type 'unique_ptr<llvm::WritableMemoryBuffer, default_delete<llvm::WritableMemoryBuffer>>' to function return type 'unique_ptr<llvm::MemoryBuffer, default_delete<llvm::MemoryBuffer>>'
   return buf;
```
- Error on 3.7:
```
../Utilities/JIT.cpp:16:19: error: use of undeclared identifier '_XABORT_RETRY'
 c.test(x86::eax, _XABORT_RETRY);
```
- Error on 3.6:
```
../rpcs3/Emu/Cell/Modules/cellGcmSys.cpp:31:41: error: no matching constructor for initialization of 'vm::ptr<CellGcmDisplayInfo>' (aka 'vm::_ptr_base<CellGcmDisplayInfo, unsigned int>')
 vm::ptr<CellGcmDisplayInfo> gcm_buffers{ vm::null };
```

About the cmake change, these two lines does the same job:
- https://github.com/RPCS3/rpcs3/blob/master/rpcs3/CMakeLists.txt#L3
- https://github.com/RPCS3/rpcs3/blob/master/rpcs3/CMakeLists.txt#L187

I kept the first one.