### PR TITLE
rsx: Fix multi-remapped textures, Restore OGL performance, OGL cleanup and FIFO optimizations

### DIFF
--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -334,8 +334,11 @@ public:
 		fmt::throw_exception("Trying to get unknown shader program" HERE);
 	}
 
+	// Returns 2 booleans.
+	// First flag hints that there is more work to do (busy hint)
+	// Second flag is true if at least one program has been linked successfully (sync hint)
 	template<typename... Args>
-	bool async_update(u32 max_decompile_count, Args&& ...args)
+	std::pair<bool, bool> async_update(u32 max_decompile_count, Args&& ...args)
 	{
 		// Decompile shaders and link one pipeline object per 'run'
 		// NOTE: Linking is much slower than decompilation step, so always decompile at least 1 unit
@@ -381,7 +384,7 @@ public:
 			}
 			else
 			{
-				return busy;
+				return { busy, false };
 			}
 		}
 
@@ -392,7 +395,7 @@ public:
 		m_storage[key] = std::move(pipeline);
 		m_link_queue.erase(key);
 
-		return (busy || !m_link_queue.empty());
+		return { (busy || !m_link_queue.empty()), true };
 	}
 
 	template<typename... Args>

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -19,7 +19,7 @@ namespace gl
 	float max_aniso(rsx::texture_max_anisotropy aniso);
 	std::array<GLenum, 4> get_swizzle_remap(u32 texture_format);
 
-	texture* create_texture(u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, rsx::texture_dimension_extended type, rsx::texture_colorspace colorspace);
+	viewable_image* create_texture(u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, rsx::texture_dimension_extended type);
 
 	void copy_typeless(texture* dst, const texture* src);
 	/**
@@ -31,8 +31,7 @@ namespace gl
 	 * static_state - set up the texture without consideration for sampler state (useful for vertex textures which have no real sampler state on RSX)
 	 */
 	void upload_texture(GLuint id, u32 texaddr, u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, bool is_swizzled, rsx::texture_dimension_extended type,
-		const std::vector<rsx_subresource_layout>& subresources_layout, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap, bool static_state,
-		rsx::texture_colorspace colorspace);
+		const std::vector<rsx_subresource_layout>& subresources_layout);
 
 	std::array<GLenum, 4> apply_swizzle_remap(const std::array<GLenum, 4>& swizzle_remap, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& decoded_remap);
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -437,10 +437,6 @@ namespace rsx
 				thread_ctrl::set_thread_affinity_mask(thread_ctrl::get_affinity_mask(thread_class::rsx));
 			}
 
-			// Weak cpus need all the help they can get, sleep instead of yield loop
-			// Lowers decompiler responsiveness but improves emulator performance
-			const bool prefer_sleep = (std::thread::hardware_concurrency() < 6);
-
 			while (!Emu.IsStopped() && !m_rsx_thread_exiting)
 			{
 				if (!on_decompiler_task())
@@ -449,13 +445,9 @@ namespace rsx
 					{
 						std::this_thread::sleep_for(1ms);
 					}
-					else if (prefer_sleep)
-					{
-						std::this_thread::sleep_for(500us);
-					}
 					else
 					{
-						std::this_thread::yield();
+						std::this_thread::sleep_for(500us);
 					}
 				}
 			}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3442,5 +3442,5 @@ void VKGSRender::discard_occlusion_query(rsx::reports::occlusion_query_info* que
 
 bool VKGSRender::on_decompiler_task()
 {
-	return m_prog_buffer->async_update(8, *m_device, pipeline_layout);
+	return m_prog_buffer->async_update(8, *m_device, pipeline_layout).first;
 }

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -671,7 +671,9 @@ namespace vk
 			CHECK_RESULT(vkCreateImageView(m_device, &info, nullptr, &value));
 		}
 
-		image_view(VkDevice dev, vk::image* resource, VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}, VkComponentMapping mapping = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A })
+		image_view(VkDevice dev, vk::image* resource,
+			const VkComponentMapping mapping = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A },
+			const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1})
 			: m_device(dev)
 		{
 			info.format = resource->info.format;
@@ -708,6 +710,54 @@ namespace vk
 		image_view(image_view&&) = delete;
 	private:
 		VkDevice m_device;
+	};
+
+	struct viewable_image : public image
+	{
+		std::unordered_multimap<u32, std::unique_ptr<vk::image_view>> views;
+
+		viewable_image(vk::render_device &dev,
+			uint32_t memory_type_index,
+			uint32_t access_flags,
+			VkImageType image_type,
+			VkFormat format,
+			uint32_t width, uint32_t height, uint32_t depth,
+			uint32_t mipmaps, uint32_t layers,
+			VkSampleCountFlagBits samples,
+			VkImageLayout initial_layout,
+			VkImageTiling tiling,
+			VkImageUsageFlags usage,
+			VkImageCreateFlags image_flags)
+
+			:image(dev, memory_type_index, access_flags, image_type, format, width, height, depth,
+					mipmaps, layers, samples, initial_layout, tiling, usage, image_flags)
+		{}
+
+		image_view* get_view(u32 remap_encoding, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap,
+			VkImageAspectFlags mask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT)
+		{
+			auto found = views.equal_range(remap_encoding);
+			for (auto It = found.first; It != found.second; ++It)
+			{
+				if (It->second->info.subresourceRange.aspectMask & mask)
+				{
+					return It->second.get();
+				}
+			}
+
+			VkComponentMapping real_mapping = vk::apply_swizzle_remap
+			(
+				{native_component_map.a, native_component_map.r, native_component_map.g, native_component_map.b },
+				remap
+			);
+
+			const auto range = vk::get_image_subresource_range(0, 0, 1, info.mipLevels, get_aspect_flags(info.format) & mask);
+			auto view = std::make_unique<vk::image_view>(*get_current_renderer(), this, real_mapping, range);
+
+			auto result = view.get();
+			views.emplace(remap_encoding, std::move(view));
+			return result;
+		}
 	};
 
 	struct buffer

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -561,7 +561,7 @@ namespace vk
 			vkCmdCopyBufferToImage(cmd, upload_heap.heap->value, tex->value, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 			change_image_layout(cmd, tex.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, range);
 
-			auto view = std::make_unique<vk::image_view>(dev, tex.get(), range, mapping);
+			auto view = std::make_unique<vk::image_view>(dev, tex.get(), mapping, range);
 
 			auto result = view.get();
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -780,7 +780,6 @@ namespace vk
 			const u16 section_depth = depth;
 			const bool is_cubemap = type == rsx::texture_dimension_extended::texture_dimension_cubemap;
 			VkFormat vk_format;
-			VkComponentMapping mapping;
 			VkImageAspectFlags aspect_flags;
 			VkImageType image_type;
 			VkImageViewType image_view_type;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -371,12 +371,18 @@ namespace rsx
 
 		void set_transform_program_start(thread* rsx, u32, u32)
 		{
-			rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty;
+			if (method_registers.register_change_flag)
+			{
+				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty;
+			}
 		}
 
 		void set_vertex_attribute_output_mask(thread* rsx, u32, u32)
 		{
-			rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty | rsx::pipeline_state::fragment_program_dirty;
+			if (method_registers.register_change_flag)
+			{
+				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty | rsx::pipeline_state::fragment_program_dirty;
+			}
 		}
 
 		void set_begin_end(thread* rsxthr, u32 _reg, u32 arg)
@@ -1310,7 +1316,16 @@ namespace rsx
 
 	void rsx_state::decode(u32 reg, u32 value)
 	{
-		registers[reg] = value;
+		auto& old_value = registers[reg];
+		if (old_value != value)
+		{
+			register_change_flag = true;
+			old_value = value;
+		}
+		else
+		{
+			register_change_flag = false;
+		}
 	}
 
 	bool rsx_state::test(u32 reg, u32 value) const

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -159,6 +159,8 @@ namespace rsx
 
 		draw_clause current_draw_clause;
 
+		bool register_change_flag;
+
 		/**
 		* RSX can sources vertex attributes from 2 places:
 		* 1. Immediate values passed by NV4097_SET_VERTEX_DATA*_M + ARRAY_ID write.


### PR DESCRIPTION
- Remove static image-view pairings for regular texture uploads. Transition to a multiview format like already existing for rendertargets.
- Minor cleanup and optimization in preparation for some upcoming changes.

This PR restores OpenGL performance largely lost in the Async PR that adds async recompiler. Also fixes the black ground textures in some Atelier games.