### PR TITLE
Qt/windows: use Qt's high dpi scaling

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -94,12 +94,8 @@ int main(int argc, char** argv)
 {
 	logs::set_init();
 
-#ifdef _WIN32
-	// use this instead of SetProcessDPIAware if Qt ever fully supports this on windows
-	// at the moment it can't display QCombobox frames for example
-	// I think there was an issue with gsframe if I recall correctly, so look out for that
-	//QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-	SetProcessDPIAware();
+#if defined(_WIN32) || defined(__APPLE__)
+	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #else
 	qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
 #endif

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -67,6 +67,8 @@ gs_frame::gs_frame(const QString& title, const QRect& geometry, QIcon appIcon, b
 		setSurfaceType(QSurface::VulkanSurface);
 #endif
 
+	setMinimumWidth(160);
+	setMinimumHeight(90);
 	setGeometry(geometry);
 	setTitle(m_windowTitle);
 	setVisibility(Hidden);

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -252,20 +252,26 @@ void gs_frame::delete_context(draw_context_t ctx)
 
 int gs_frame::client_width()
 {
-#if defined(_WIN32) || defined(__APPLE__)
-	return size().width();
-#else
-	return size().width() * devicePixelRatio();
-#endif
+#ifdef _WIN32
+	RECT rect;
+	if (GetClientRect(HWND(winId()), &rect))
+	{
+		return rect.right - rect.left;
+	}
+#endif // _WIN32
+	return width() * devicePixelRatio();
 }
 
 int gs_frame::client_height()
 {
-#if defined(_WIN32) || defined(__APPLE__)
-	return size().height();
-#else
-	return size().height() * devicePixelRatio();
-#endif
+#ifdef _WIN32
+	RECT rect;
+	if (GetClientRect(HWND(winId()), &rect))
+	{
+		return rect.bottom - rect.top;
+	}
+#endif // _WIN32
+	return height() * devicePixelRatio();
 }
 
 void gs_frame::flip(draw_context_t, bool /*skip_frame*/)


### PR DESCRIPTION
This should work as before now, even on window's high dpi settings.
The main reason for this PR was to use Qt's frontend highdpi stuff instead of using SetProcessDPIAware.
Also fixes a crash on Vulkan when resizing the window to a small height (by setting a min height on Qt side XD).

~~There is a bug still present in the gs-frame that causes a swapchain error. The max is 1 less than the calculated size on eg. pixelratios of 2~~

~~E {rsx::thread} RSX: Swapchain: Swapchain creation failed because dimensions cannot fit. Max = 993, 604, Requested = 994, 604~~