### PR TITLE
Add a channel map to the PA backend to fix surround sound

### DIFF
--- a/rpcs3/Emu/Audio/Pulse/PulseThread.cpp
+++ b/rpcs3/Emu/Audio/Pulse/PulseThread.cpp
@@ -50,10 +50,10 @@ void PulseThread::Open(const void* src, int size)
 		channel_map.channels =  8;
 		channel_map.map[0] = PA_CHANNEL_POSITION_FRONT_LEFT;
 		channel_map.map[1] = PA_CHANNEL_POSITION_FRONT_RIGHT;
-		channel_map.map[2] = PA_CHANNEL_POSITION_REAR_LEFT;
-		channel_map.map[3] = PA_CHANNEL_POSITION_REAR_RIGHT;
-		channel_map.map[4] = PA_CHANNEL_POSITION_FRONT_CENTER;
-		channel_map.map[5] = PA_CHANNEL_POSITION_LFE;
+		channel_map.map[2] = PA_CHANNEL_POSITION_FRONT_CENTER;
+		channel_map.map[3] = PA_CHANNEL_POSITION_LFE;
+		channel_map.map[4] = PA_CHANNEL_POSITION_REAR_LEFT;
+		channel_map.map[5] = PA_CHANNEL_POSITION_REAR_RIGHT;
 		channel_map.map[6] = PA_CHANNEL_POSITION_SIDE_LEFT;
 		channel_map.map[7] = PA_CHANNEL_POSITION_SIDE_RIGHT;
 	}

--- a/rpcs3/Emu/Audio/Pulse/PulseThread.cpp
+++ b/rpcs3/Emu/Audio/Pulse/PulseThread.cpp
@@ -35,11 +35,32 @@ void PulseThread::Open(const void* src, int size)
 {
 	pa_sample_spec ss;
 	ss.format = g_cfg.audio.convert_to_u16 ? PA_SAMPLE_S16LE : PA_SAMPLE_FLOAT32LE;
-	ss.channels = g_cfg.audio.downmix_to_2ch ? 2 : 8;
 	ss.rate = 48000;
 
+	pa_channel_map channel_map;
+
+	if (g_cfg.audio.downmix_to_2ch)
+	{
+		channel_map.channels =  2;
+		channel_map.map[0] = PA_CHANNEL_POSITION_FRONT_LEFT;
+		channel_map.map[1] = PA_CHANNEL_POSITION_FRONT_RIGHT;
+	}
+	else
+	{
+		channel_map.channels =  8;
+		channel_map.map[0] = PA_CHANNEL_POSITION_FRONT_LEFT;
+		channel_map.map[1] = PA_CHANNEL_POSITION_FRONT_RIGHT;
+		channel_map.map[2] = PA_CHANNEL_POSITION_REAR_LEFT;
+		channel_map.map[3] = PA_CHANNEL_POSITION_REAR_RIGHT;
+		channel_map.map[4] = PA_CHANNEL_POSITION_FRONT_CENTER;
+		channel_map.map[5] = PA_CHANNEL_POSITION_LFE;
+		channel_map.map[6] = PA_CHANNEL_POSITION_SIDE_LEFT;
+		channel_map.map[7] = PA_CHANNEL_POSITION_SIDE_RIGHT;
+	}
+	ss.channels = channel_map.channels;
+
 	int err;
-	this->connection = pa_simple_new(NULL, "RPCS3", PA_STREAM_PLAYBACK, NULL, "Game", &ss, NULL, NULL, &err);
+	this->connection = pa_simple_new(NULL, "RPCS3", PA_STREAM_PLAYBACK, NULL, "Game", &ss, &channel_map, NULL, &err);
 	if(!this->connection) {
 		fprintf(stderr, "PulseAudio: Failed to initialize audio: %s\n", pa_strerror(err));
 	}


### PR DESCRIPTION
Hello,

per https://github.com/RPCS3/rpcs3/issues/4909 I've been having issues with PA when not using downsampling, PA would simply not connect.

This patch makes it work for both downsampling and standard surround. The map is currently taken from channelmap.c from PA, in the PA_CHANNEL_MAP_ALSA case but that may be wrong. If someone knows the correct PS3 surround mapping or where to find it, please tell me. If not, a homebrew that tells the channels would be great too.

This is what I found without the patch/without a map:
- PulseThread::Open calls pa_simple_new
- pa_simple_new calls pa_stream_new
- pa_stream_new calls pa_stream_new_with_proplist
- pa_stream_new_with_proplist calls pa_channel_map_init_auto
- in pa_channel_map_init_auto def is PA_CHANNEL_MAP_AIFF, the default for PA_CHANNEL_MAP_DEFAULT, and channels is 8, but there is no case for 8 so it goes to default which returns null instead of a map, and that's the issue.

With downsampling it's all the same till the end, where there is a case for channels == 2 and so it returns a map and it all works.


Please comment.

Thanks!