### PR TITLE
ppu-precise: improve vaddsws and vadduws instructions

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -444,7 +444,7 @@ bool ppu_interpreter_precise::VADDSWS(ppu_thread& ppu, ppu_opcode_t op)
 
 	for (u8 i = 0; i < 4; i++)
 	{
-		const s64 sum = a._s32[i] + b._s32[i];
+		const s64 sum = (s64)a._s32[i] + (s64)b._s32[i];
 
 		if (sum < INT32_MIN)
 		{
@@ -560,7 +560,7 @@ bool ppu_interpreter_precise::VADDUWS(ppu_thread& ppu, ppu_opcode_t op)
 
 	for (u8 i = 0; i < 4; i++)
 	{
-		const u64 sum = a._u32[i] + b._u32[i];
+		const u64 sum =  (u64)a._u32[i] + (u64)b._u32[i];
 
 		if (sum > UINT32_MAX)
 		{


### PR DESCRIPTION
Results based on this test: https://github.com/RPCS3/ps3autotests/blob/master/tests/cpu/ppu_vpu/ppu_vpu.cpp
```
vec_vaddsws (441 tests):
	[master-precise] Matches: 372 (84.35%)
	[pr-precise] Matches: 441 (100.00%)
vec_vadduws (441 tests):
	[master-precise] Matches: 294 (66.67%)
	[pr-precise] Matches: 441 (100.00%)
```