### PR TITLE
ppu-interpreter: improve vminfp instruction

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -1027,7 +1027,9 @@ bool ppu_interpreter_precise::VMHRADDSHS(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::VMINFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	ppu.vr[op.vd].vf = _mm_min_ps(ppu.vr[op.va].vf, ppu.vr[op.vb].vf);
+	const auto a = ppu.vr[op.va].vf;
+	const auto b = ppu.vr[op.vb].vf;
+	ppu.vr[op.vd].vf = _mm_or_ps(_mm_min_ps(a, b),  _mm_min_ps(b, a));
 	return true;
 }
 


### PR DESCRIPTION
Results based on this test: https://github.com/RPCS3/ps3autotests/blob/master/tests/cpu/ppu_vpu/ppu_vpu.cpp
```
vec_vmaxfp (484 tests):
	[master-fast] Matches: 440 (90.91%)
	[master-llvm] Matches: 440 (90.91%)
	[pr-fast] Matches: 441 (91.12%)
	[pr-llvm] Matches: 420 (86.78%) (with the commented code)
vec_vminfp (484 tests):
	[master-fast] Matches: 420 (86.78%)
	[master-llvm] Matches: 420 (86.78%)
	[pr-fast] Matches: 441 (91.12%)
	[pr-llvm] Matches: 440 (90.91%)
```

Notes:
- The maximum of +0 and -0 is +0
- The minimum of + 0.0 and - 0.0 is - 0.0