### PR TITLE
PSMove: initial support mouse with basic handler.

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -290,16 +290,18 @@ static bool ds3_input_to_ext(const u32 port_no, CellGemExtPortData& ext)
 * \param analog_t Analog value of Move's Trigger.
 * \return true on success, false if mouse mouse_no is invalid
 */
-static bool map_to_mouse_input(const u32 mouse_no, be_t<u16>& digital_buttons, be_t<u16>& analog_t)
+static bool mouse_input_to_pad(const u32 mouse_no, be_t<u16>& digital_buttons, be_t<u16>& analog_t)
 {
 	const auto handler = fxm::get<MouseHandlerBase>();
 
-	if (handler->GetInfo().status[mouse_no] != CELL_MOUSE_STATUS_CONNECTED)
+	if (!handler || handler->GetInfo().status[mouse_no] != CELL_MOUSE_STATUS_CONNECTED)
 	{
 		return false;
 	}
 
-	const MouseData& mouse_data = handler->GetData(mouse_no);
+	const MouseData& mouse_data = handler->GetDataList(mouse_no).front();
+
+	memset(&digital_buttons, 0, sizeof(digital_buttons));
 
 	if (mouse_data.buttons & CELL_MOUSE_BUTTON_1)
 		digital_buttons |= CELL_GEM_CTRL_T;
@@ -307,7 +309,39 @@ static bool map_to_mouse_input(const u32 mouse_no, be_t<u16>& digital_buttons, b
 	if (mouse_data.buttons & CELL_MOUSE_BUTTON_2)
 		digital_buttons |= CELL_GEM_CTRL_MOVE;
 
+	if (mouse_data.buttons & CELL_MOUSE_BUTTON_3)
+		digital_buttons |= CELL_GEM_CTRL_CROSS;
+
 	analog_t = mouse_data.buttons & CELL_MOUSE_BUTTON_1 ? 0xFFFF : 0;
+
+	return true;
+}
+
+static bool mouse_input_to_gem(const u32 mouse_no, vm::ptr<CellGemState>& gem_state)
+{
+	const auto handler = fxm::get<MouseHandlerBase>();
+	
+	if (!gem_state || !handler)
+	{
+		return false;
+	}
+
+	auto& mouse = handler->GetMice().at(0);
+
+	f32 x_pos = mouse.x_pos;
+	f32 y_pos = mouse.y_pos;
+
+	static constexpr auto aspect_ratio = 1.2;
+
+	static constexpr auto screen_offset_x = 400.0;
+	static constexpr auto screen_offset_y = screen_offset_x * aspect_ratio;
+
+	static constexpr auto screen_scale = 6.0;
+
+	gem_state->pos[0] = screen_offset_x / screen_scale + x_pos / screen_scale;
+	gem_state->pos[1] = screen_offset_y / screen_scale + -y_pos / screen_scale * aspect_ratio;
+	gem_state->pos[2] = 2000;
+	gem_state->pos[3] = 0;
 
 	return true;
 }
@@ -430,7 +464,11 @@ s32 cellGemEnd()
 		return CELL_GEM_ERROR_UNINITIALIZED;
 	}
 
-	fxm::remove<MouseHandlerBase>();
+	if (g_cfg.io.move == move_handler::fake &&
+		g_cfg.io.mouse == mouse_handler::basic)
+	{
+		fxm::remove<MouseHandlerBase>();
+	}
 
 	return CELL_OK;
 }
@@ -561,9 +599,9 @@ s32 cellGemGetHuePixels(vm::cptr<void> camera_frame, u32 hue, vm::ptr<u8> pixels
 	return CELL_OK;
 }
 
-s32 cellGemGetImageState(u32 gem_num, vm::ptr<CellGemImageState> image_state)
+s32 cellGemGetImageState(u32 gem_num, vm::ptr<CellGemImageState> gem_image_state)
 {
-	cellGem.todo("cellGemGetImageState(gem_num=%d, image_state=&0x%x)", gem_num, image_state);
+	cellGem.todo("cellGemGetImageState(gem_num=%d, image_state=&0x%x)", gem_num, gem_image_state);
 	const auto gem = fxm::get<gem_t>();
 
 	if (!gem)
@@ -571,7 +609,7 @@ s32 cellGemGetImageState(u32 gem_num, vm::ptr<CellGemImageState> image_state)
 		return CELL_GEM_ERROR_UNINITIALIZED;
 	}
 
-	if (!check_gem_num(gem_num) || !image_state)
+	if (!check_gem_num(gem_num) || !gem_image_state)
 	{
 		return CELL_GEM_ERROR_INVALID_PARAMETER;
 	}
@@ -580,35 +618,40 @@ s32 cellGemGetImageState(u32 gem_num, vm::ptr<CellGemImageState> image_state)
 	{
 		auto shared_data = fxm::get_always<gem_camera_shared>();
 
-	if (g_cfg.io.move == move_handler::fake &&
-		g_cfg.io.mouse == mouse_handler::basic)
-	{
-		auto shared_data = fxm::get_always<gem_camera_shared>();
+		if (g_cfg.io.mouse == mouse_handler::basic)
+		{
+			const auto handler = fxm::get<MouseHandlerBase>();
+			auto& mouse = handler->GetMice().at(0);
 
-		const auto handler = fxm::get<MouseHandlerBase>();
-		auto& mouse = handler->GetMice().at(0);
+			f32 x_pos = mouse.x_pos;
+			f32 y_pos = mouse.y_pos;
 
-		f32 x_pos = mouse.x_pos;
-		f32 y_pos = mouse.y_pos;
+			static constexpr auto aspect_ratio = 1.2;
 
-		static constexpr auto aspect_ratio = 1.2;
+			static constexpr auto screen_offset_x = 400.0;
+			static constexpr auto screen_offset_y = screen_offset_x * aspect_ratio;
 
-		static constexpr auto screen_offset_x = 400.0;
-		static constexpr auto screen_offset_y = screen_offset_x * aspect_ratio;
+			static constexpr auto screen_scale = 3.0;
 
-		static constexpr auto screen_scale = 3.0;
+			gem_image_state->u = screen_offset_x / screen_scale + x_pos / screen_scale;
+			gem_image_state->v = screen_offset_y / screen_scale + y_pos / screen_scale * aspect_ratio;
+			gem_image_state->r = 10;
+		}
+		else
+		{
+			gem_image_state->u = 0;
+			gem_image_state->v = 0;
+			gem_image_state->r = 20;
+		}
 
-		image_state->frame_timestamp = shared_data->frame_timestamp.load();
-		image_state->timestamp = image_state->frame_timestamp + 10;   // arbitrarily define 10 usecs of frame processing
-		image_state->visible = true;
-		image_state->u = screen_offset_x / screen_scale + x_pos / screen_scale;
-		image_state->v = screen_offset_y / screen_scale + y_pos / screen_scale * aspect_ratio;
-		image_state->r = 10;
-		image_state->r_valid = true;
-		image_state->distance = 2 * 1000;   // 2 meters away from camera
+		gem_image_state->frame_timestamp = shared_data->frame_timestamp.load();
+		gem_image_state->timestamp = gem_image_state->frame_timestamp + 10;   // arbitrarily define 10 usecs of frame processing
+		gem_image_state->visible = true;
+		gem_image_state->r_valid = true;
+		gem_image_state->distance = 2 * 1000;   // 2 meters away from camera
 		// TODO
-		image_state->projectionx = 1;
-		image_state->projectiony = 1;
+		gem_image_state->projectionx = 1;
+		gem_image_state->projectiony = 1;
 	}
 
 	return CELL_OK;
@@ -631,12 +674,15 @@ s32 cellGemGetInertialState(u32 gem_num, u32 state_flag, u64 timestamp, vm::ptr<
 
 	if (g_cfg.io.move == move_handler::fake)
 	{
-		ds3_input_to_pad(gem_num, inertial_state->pad.digitalbuttons, inertial_state->pad.analog_T);
 		ds3_input_to_ext(gem_num, inertial_state->ext);
 
 		if (g_cfg.io.mouse == mouse_handler::basic)
 		{
-			map_to_mouse_input(gem_num, inertial_state->pad.digitalbuttons, inertial_state->pad.analog_T);
+			mouse_input_to_pad(gem_num, inertial_state->pad.digitalbuttons, inertial_state->pad.analog_T);
+		}
+		else
+		{
+			ds3_input_to_pad(gem_num, inertial_state->pad.digitalbuttons, inertial_state->pad.analog_T);
 		}
 
 		inertial_state->timestamp = gem->timer.GetElapsedTimeInMicroSec();
@@ -750,12 +796,16 @@ s32 cellGemGetState(u32 gem_num, u32 flag, u64 time_parameter, vm::ptr<CellGemSt
 
 	if (g_cfg.io.move == move_handler::fake)
 	{
-		ds3_input_to_pad(gem_num, gem_state->pad.digitalbuttons, gem_state->pad.analog_T);
 		ds3_input_to_ext(gem_num, gem_state->ext);
 
 		if (g_cfg.io.mouse == mouse_handler::basic)
 		{
-			map_to_mouse_input(gem_num, gem_state->pad.digitalbuttons, gem_state->pad.analog_T);
+			mouse_input_to_pad(gem_num, gem_state->pad.digitalbuttons, gem_state->pad.analog_T);
+			mouse_input_to_gem(gem_num, gem_state);
+		}
+		else
+		{
+			ds3_input_to_pad(gem_num, gem_state->pad.digitalbuttons, gem_state->pad.analog_T);
 		}
 
 		gem_state->tracking_flags = CELL_GEM_TRACKING_FLAG_POSITION_TRACKED | CELL_GEM_TRACKING_FLAG_VISIBLE;
@@ -956,7 +1006,7 @@ s32 cellGemPrepareVideoConvert(vm::cptr<CellGemVideoConvertAttribute> vc_attribu
 
 s32 cellGemReadExternalPortDeviceInfo(u32 gem_num, vm::ptr<u32> ext_id, vm::ptr<u8[CELL_GEM_EXTERNAL_PORT_DEVICE_INFO_SIZE]> ext_info)
 {
-	cellGem.todo("cellGemReset(gem_num=%d, ext_id=*0x%x, ext_info=%s)", gem_num, ext_id, ext_info);
+	cellGem.todo("cellGemReadExternalPortDeviceInfo(gem_num=%d, ext_id=*0x%x, ext_info=%s)", gem_num, ext_id, ext_info);
 	auto gem = fxm::get<gem_t>();
 
 	if (!gem)

--- a/rpcs3/Emu/Cell/Modules/cellGem.h
+++ b/rpcs3/Emu/Cell/Modules/cellGem.h
@@ -139,16 +139,16 @@ struct CellGemExtPortData
 
 struct CellGemImageState
 {
-	be_t<u64> frame_timestamp;
-	be_t<u64> timestamp;
-	be_t<f32> u;         // horizontal screen position in pixels
-	be_t<f32> v;         // vertical screen position in pixels
-	be_t<f32> r;         // size of sphere on screen in pixels
+	be_t<u64> frame_timestamp; // time the frame was captured by libCamera (usecs)
+	be_t<u64> timestamp;       // time processing of the frame was finished (usecs)
+	be_t<f32> u;               // horizontal screen position in pixels
+	be_t<f32> v;               // vertical screen position in pixels
+	be_t<f32> r;               // size of sphere on screen in pixels
 	be_t<f32> projectionx;
 	be_t<f32> projectiony;
-	be_t<f32> distance;
-	u8 visible;
-	u8 r_valid;
+	be_t<f32> distance;        // Move sphere distance from camera (probably)
+	u8 visible;	               // whether the sphere is visible in the current frame
+	u8 r_valid;                // whether `r` contains valid size
 };
 
 struct CellGemPadData


### PR DESCRIPTION
Initial implement support mouse with use basic mouse handler for emulate cursor psmove, good works particulary for rail shooter game like house of the dead serie and time crsisis.

Credit to @VelocityRa for Original commit with initial mouse emulate psmove support here https://github.com/VelocityRa/rpcs3/commit/55c5b2a0a1cfb0cbd859ac058913fbd98b4ad54b

After used my long test with implemented real psmove tracker for undertstund how use this for implemented function pos.

For tester, button on mouse is left click= trigger, right click=move, midle click = X (needed obligatory for time crisis)