### PR TITLE
Readme dependency cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ RPCS3
 
 The world's first open-source PlayStation 3 emulator/debugger written in C++ for Windows and Linux.
 
-You can find some basic information in our [**website**](https://rpcs3.net/).
-For discussion about this emulator and PS3 emulation please visit our [**forums**](https://forums.rpcs3.net) and our [**Discord server**](https://discord.me/RPCS3).
+You can find some basic information in our [**website**](https://rpcs3.net/). Game info is being populated on the [**wiki**](https://wiki.rpcs3.net/).
+For discussion about this emulator and PS3 emulation, or game compatibility reports, please visit our [**forums**](https://forums.rpcs3.net) and our [**Discord server**](https://discord.me/RPCS3).
 
 [**Support Lead Developers Nekotekina and kd-11 on Patreon**](https://www.patreon.com/Nekotekina)
 
@@ -22,11 +22,13 @@ If you want to contribute please take a look at the [Coding Style](https://githu
 ### Windows
 * [Visual Studio 2015](https://www.visualstudio.com/vs/older-downloads/)
 * [Visual C++ Redistributable Packages for Visual Studio 2015](http://www.microsoft.com/en-us/download/details.aspx?id=48145)
-* [Cmake 3.1.0+](https://www.cmake.org/download/) (required; add to PATH)
-* [Python 3.3+](https://www.python.org/downloads/) (required; add to PATH)
-* [Qt 5.10+](https://www.qt.io/download-open-source/) (required; add QTDIR environment variable if you do not want to use the Visual Studio Qt Plugin: e.g. `<QtInstallFolder>\5.11.1\msvc2015_64\`)
-* [Visual Studio Qt Plugin](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools2015) (optional; see above)
-* [Vulkan SDK](https://sdk.lunarg.com/sdk/download/1.1.73.0/windows/VulkanSDK-1.1.73.0-Installer.exe) (required)
+* [Cmake 3.1.0+](https://www.cmake.org/download/) (add to PATH)
+* [Python 3.3+](https://www.python.org/downloads/) (add to PATH)
+* [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) (See "Install the SDK" [here](https://vulkan.lunarg.com/doc/sdk/latest/windows/getting_started.html))
+* [Qt 5.10+](https://www.qt.io/download-open-source/)
+
+
+**Either add the** `QTDIR` **environment variable, e.g.** `<QtInstallFolder>\5.11.1\msvc2015_64\` **, or use the [Visual Studio Qt Plugin](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools2015)**
 
 ### Linux
 * [Qt 5.10+](https://www.qt.io/download-open-source/)
@@ -47,24 +49,18 @@ MacOS is not supported at this moment because it doesn't meet system requirement
 ## Building on Windows:
 To initialize the repository don't forget to execute `git submodule update --init` to pull the submodules.
 
-*If you're using Visual Studio 2017, when you first open the project, do not upgrade the targets or the packages. Leave both at "No upgrade". Note that you will need the v140 toolset, which may not be in 2017 by default.*
+*If you're using Visual Studio 2017, when you first open the project, do not upgrade the targets or the packages. Leave both at "No upgrade". Note that you will need the v140 toolset, which may not be in VS 2017 by default. It can be acquired by running the VS installer.*
 
-### Configuring Qt
+### Configuring the Qt plugin (if used)
 
-*If you're using Visual Studio 2017 without Qt plugin support (or simply dont want to use it):*
-1) Add `QTDIR` environment variable and set it to e.g `<QtInstallFolder>\5.11.1\msvc2015_64\`
-
-Open `rpcs3.sln`
-
-
-*If you wish to use the Visual Studio plugin for Qt:* </br>
-1) Go to the Qt5 menu and edit Qt5 options. Add the path to your Qt installation with compiler e.g. `C:\Qt\5.11.1\msvc2015_64`.
+1) Go to the Qt5 menu and edit Qt5 options. Add the path to your Qt installation with compiler e.g. `<QtInstallFolder>\5.11.1\msvc2015_64`.
 2) While selecting the rpcs3qt project, go to Qt5->Project Setting and select the version you added.
 
 ### Building the projects
-The recommended build configuration is Release - LLVM, for all purposes.
 
-You may want to download precompiled [LLVM lib](https://github.com/RPCS3/llvm/releases/download/continuous-master/llvmlibs.7z) and extract to root rpcs3 folder (which contains `rpcs3.sln`), as well as download and extract [additional libs](https://drive.google.com/uc?export=download&id=1A2eOMmCO714i0U7J0qI4aEMKnuWl8l_R) to `lib\%CONFIGURATION%-x64\` to speed up compilation time (unoptimised/debug libs are currently not available precompiled).
+Open `rpcs3.sln`. The recommended build configuration is `Release - LLVM`, for all purposes.
+
+You may want to download precompiled [LLVM libs](https://github.com/RPCS3/llvm/releases/download/continuous-master/llvmlibs.7z) and extract to root rpcs3 folder (which contains `rpcs3.sln`), as well as download and extract [additional libs](https://drive.google.com/uc?export=download&id=1A2eOMmCO714i0U7J0qI4aEMKnuWl8l_R) to `lib\%CONFIGURATION%-x64\` to speed up compilation time (unoptimised/debug libs are currently not available precompiled).
 
 If you're not using precompiled libs, build the projects in *__BUILD_BEFORE* folder: right-click on every project > *Build*.
 


### PR DESCRIPTION
- Added wiki link
- Remove "required" from dependency list. The word "dependency" implies requirement, therefore only optionality is notable.
- Update Vulkan links to point to latest always
- Added link to Vulkan config instructions, which describes how to ensure environment vars are set correctly (some people have had trouble with this)
- Remove redundant Qt config info, as it's already in the dependency list
- Various minor typo fixes