### PR TITLE
Qt: User Manager Improvements

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -52,7 +52,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 
 	m_gameList = new game_list();
 	m_gameList->setShowGrid(false);
-	m_gameList->setItemDelegate(new table_item_delegate(this));
+	m_gameList->setItemDelegate(new table_item_delegate(this, true));
 	m_gameList->setEditTriggers(QAbstractItemView::NoEditTriggers);
 	m_gameList->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_gameList->setSelectionMode(QAbstractItemView::SingleSelection);

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -91,7 +91,7 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 
 	m_tw_rsx = new QTabWidget();
 
-	//adds a tab containing a list to the tabwidget
+	// adds a tab containing a list to the tabwidget
 	auto l_addRSXTab = [=](QTableWidget* table, const QString& tabname, int columns)
 	{
 		table = new QTableWidget();
@@ -119,7 +119,7 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 	m_list_texture = l_addRSXTab(m_list_texture, tr("Texture"), 9);
 	m_list_settings = l_addRSXTab(m_list_settings, tr("Settings"), 2);
 
-	//Tabs: List Columns
+	// Tabs: List Columns
 	m_list_commands->viewport()->installEventFilter(this);
 	m_list_commands->setHorizontalHeaderLabels(QStringList() << tr("Column") << tr("Value") << tr("Command") << tr("Count"));
 	m_list_commands->setColumnWidth(0, 70);
@@ -149,7 +149,7 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 	m_list_settings->setColumnWidth(0, 170);
 	m_list_settings->setColumnWidth(1, 270);
 
-	//Tools: Tools = Controls + Notebook Tabs
+	// Tools: Tools = Controls + Notebook Tabs
 	QVBoxLayout* vbox_tools = new QVBoxLayout();
 	vbox_tools->addLayout(hbox_controls);
 	vbox_tools->addWidget(m_tw_rsx);

--- a/rpcs3/rpcs3qt/table_item_delegate.h
+++ b/rpcs3/rpcs3qt/table_item_delegate.h
@@ -6,15 +6,18 @@
 /** This class is used to get rid of somewhat ugly item focus rectangles. You could change the rectangle instead of omiting it if you wanted */
 class table_item_delegate : public QStyledItemDelegate
 {
+private:
+	bool m_has_icons;
+
 public:
-	explicit table_item_delegate(QObject *parent = 0) : QStyledItemDelegate(parent) {}
+	explicit table_item_delegate(QObject *parent = 0, bool has_icons = false) : QStyledItemDelegate(parent), m_has_icons(has_icons) {}
 
 	virtual void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override
 	{
 		// Remove the focus frame around selected items
 		option->state &= ~QStyle::State_HasFocus;
 
-		if (index.column() == 0)
+		if (m_has_icons && index.column() == 0)
 		{
 			// Don't highlight icons
 			option->state &= ~QStyle::State_Selected;

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -76,7 +76,7 @@ trophy_manager_dialog::trophy_manager_dialog(std::shared_ptr<gui_settings> gui_s
 	m_game_table->verticalScrollBar()->installEventFilter(this);
 	m_game_table->verticalScrollBar()->setSingleStep(20);
 	m_game_table->horizontalScrollBar()->setSingleStep(20);
-	m_game_table->setItemDelegate(new table_item_delegate(this));
+	m_game_table->setItemDelegate(new table_item_delegate(this, true));
 	m_game_table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_game_table->setSelectionMode(QAbstractItemView::SingleSelection);
 	m_game_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -98,7 +98,7 @@ trophy_manager_dialog::trophy_manager_dialog(std::shared_ptr<gui_settings> gui_s
 	m_trophy_table->verticalScrollBar()->installEventFilter(this);
 	m_trophy_table->verticalScrollBar()->setSingleStep(20);
 	m_trophy_table->horizontalScrollBar()->setSingleStep(20);
-	m_trophy_table->setItemDelegate(new table_item_delegate(this));
+	m_trophy_table->setItemDelegate(new table_item_delegate(this, true));
 	m_trophy_table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_trophy_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
 	m_trophy_table->setColumnCount(TrophyColumns::Count);

--- a/rpcs3/rpcs3qt/user_account.cpp
+++ b/rpcs3/rpcs3qt/user_account.cpp
@@ -12,12 +12,18 @@ UserAccount::UserAccount(const std::string& user_id)
 	fs::file file;
 	if (file.open(m_user_dir + "localusername", fs::read))
 	{
-		file.read(m_username, 16*sizeof(char)); // max of 16 chars on real PS3
+		m_username = file.to_string();
 		file.close();
+
+		if (m_username.length() > 16) // max of 16 chars on real PS3
+		{
+			m_username = m_username.substr(0, 16);
+			LOG_WARNING(GENERAL, "UserAccount: localusername of userId=%s was too long, cropped to: %s", m_user_id, m_username);
+		}
 	}
 	else
 	{
-		LOG_WARNING(GENERAL, "UserAccount: localusername file read error (userId=%s, userDir=%s).", m_user_id, m_user_dir);
+		LOG_ERROR(GENERAL, "UserAccount: localusername file read error (userId=%s, userDir=%s).", m_user_id, m_user_dir);
 	}
 }
 

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -23,11 +23,11 @@ namespace
 			}
 
 			// Is the folder name exactly 8 all-numerical characters long?
-			// We use strtol to find any non-numeric characters in folder name.
+			// We use strtoul to find any non-numeric characters in folder name.
 			char* non_numeric_char;
-			u32 key = static_cast<u32>(std::strtol(user_folder.name.c_str(), &non_numeric_char, 10));
+			const u32 key = static_cast<u32>(std::strtoul(user_folder.name.c_str(), &non_numeric_char, 10));
 
-			if (user_folder.name.length() != 8 || *non_numeric_char != '\0')
+			if (key == 0 || user_folder.name.length() != 8 || *non_numeric_char != '\0')
 			{
 				continue;
 			}

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -63,13 +63,21 @@ void user_manager_dialog::Init()
 	m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_table->setContextMenuPolicy(Qt::CustomContextMenu);
 	m_table->setColumnCount(2);
+	m_table->setCornerButtonEnabled(false);
 	m_table->setHorizontalHeaderLabels(QStringList() << tr("User ID") << tr("User Name"));
 	m_table->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
 
 	QPushButton* push_remove_user = new QPushButton(tr("Delete User"), this);
+	push_remove_user->setAutoDefault(false);
+
 	QPushButton* push_create_user = new QPushButton(tr("Create User"), this);
+	push_create_user->setAutoDefault(false);
+
 	QPushButton* push_login_user = new QPushButton(tr("Log In User"), this);
+	push_login_user->setAutoDefault(false);
+
 	QPushButton* push_rename_user = new QPushButton(tr("Rename User"), this);
+	push_rename_user->setAutoDefault(false);
 
 	QPushButton* push_close = new QPushButton(tr("&Close"), this);
 	push_close->setAutoDefault(true);
@@ -101,14 +109,15 @@ void user_manager_dialog::Init()
 		u32 key = GetUserKey();
 		if (key == 0)
 		{
+			push_login_user->setEnabled(false);
 			push_rename_user->setEnabled(false);
 			push_remove_user->setEnabled(false);
 			return;
 		}
 
-		std::string idx_user = m_user_list[key].GetUserId();
-		bool enable = idx_user != m_active_user;
+		const bool enable = m_user_list[key].GetUserId() != m_active_user;
 
+		push_login_user->setEnabled(enable);
 		push_rename_user->setEnabled(enable);
 		push_remove_user->setEnabled(enable);
 	};

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -64,8 +64,11 @@ void user_manager_dialog::Init()
 	m_table->setContextMenuPolicy(Qt::CustomContextMenu);
 	m_table->setColumnCount(2);
 	m_table->setCornerButtonEnabled(false);
+	m_table->setAlternatingRowColors(true);
 	m_table->setHorizontalHeaderLabels(QStringList() << tr("User ID") << tr("User Name"));
 	m_table->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
+	m_table->horizontalHeader()->setStretchLastSection(true);
+	m_table->horizontalHeader()->setDefaultSectionSize(150);
 
 	QPushButton* push_remove_user = new QPushButton(tr("Delete User"), this);
 	push_remove_user->setAutoDefault(false);

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -270,10 +270,12 @@ void user_manager_dialog::OnUserRename()
 
 	const std::string user_id = m_user_list[key].GetUserId();
 	const std::string username = m_user_list[key].GetUsername();
+	const QString q_username = qstr(username);
 
 	QInputDialog* dialog = new QInputDialog(this);
 	dialog->setWindowTitle(tr("Rename User"));
-	dialog->setLabelText(tr("User Id: %0\nOld Username: %1\n\nNew Username: ").arg(qstr(user_id)).arg(qstr(username)));
+	dialog->setLabelText(tr("User Id: %0\nOld Username: %1\n\nNew Username: ").arg(qstr(user_id)).arg(q_username));
+	dialog->setTextValue(q_username);
 	dialog->resize(200, 100);
 
 	while (dialog->exec() != QDialog::Rejected)

--- a/rpcs3/rpcs3qt/user_manager_dialog.h
+++ b/rpcs3/rpcs3qt/user_manager_dialog.h
@@ -42,6 +42,7 @@ private:
 	void ShowContextMenu(const QPoint &pos);
 
 	void closeEvent(QCloseEvent* event) override;
+	bool eventFilter(QObject* object, QEvent* event) override;
 
 	u32 GetUserKey();
 


### PR DESCRIPTION
- improves user manager style.
- improves user manager button behavior.
- fixes scanning the home directory. It was able to show users with ids <= 0
- fixes usernames always having 16 characters
- add initial marked old usernames to the rename dialog
- add some hotkeys (F2, Delete, Enter, Return)


![image](https://user-images.githubusercontent.com/23019877/43287444-61fbf408-9125-11e8-8d9d-ebb48ab81da0.png)
