### PR TITLE
Texture cache fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -739,6 +739,9 @@ namespace rsx
 						else if (deferred_flush)
 						{
 							//allow_flush = false and not synchronized
+							obj.first->set_dirty(true);
+							m_unreleased_texture_objects++;
+
 							result.sections_to_unprotect.push_back(obj.first);
 							continue;
 						}
@@ -776,6 +779,7 @@ namespace rsx
 					//Flushes happen in one go, now its time to remove protection
 					for (auto& section : result.sections_to_unprotect)
 					{
+						verify(HERE), section->is_flushed() || section->is_dirty();
 						section->unprotect();
 						m_cache[get_block_address(section->get_section_base())].remove_one();
 					}
@@ -1265,7 +1269,7 @@ namespace rsx
 				{
 					if (tex->is_locked())
 					{
-						tex->set_dirty(true);
+						verify(HERE), tex->is_dirty();
 						tex->unprotect();
 						m_cache[get_block_address(tex->get_section_base())].remove_one();
 					}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -572,7 +572,8 @@ namespace rsx
 			std::pair<u32, u32> trampled_range = std::make_pair(address, address + range);
 			const bool strict_range_check = g_cfg.video.write_color_buffers || g_cfg.video.write_depth_buffer;
 
-			for (auto It = m_cache.begin(); It != m_cache.end(); It++)
+			auto It = m_cache.begin();
+			while(It != m_cache.end())
 			{
 				auto &range_data = It->second;
 				const u32 base = It->first;
@@ -585,7 +586,10 @@ namespace rsx
 				{
 					//Only if a valid range, ignore empty sets
 					if (trampled_range.first >= (range_data.max_addr + range_data.max_range) || range_data.min_addr >= trampled_range.second)
+					{
+						It++;
 						continue;
+					}
 				}
 
 				for (int i = 0; i < range_data.data.size(); i++)
@@ -621,6 +625,8 @@ namespace rsx
 					last_dirty_block = base;
 					It = m_cache.begin();
 				}
+				else
+					It++;
 			}
 
 			return result;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -240,7 +240,7 @@ namespace rsx
 		std::tuple<bool, std::pair<u32, u32>> overlaps_page(const std::pair<u32, u32>& old_range, u32 address, overlap_test_bounds bounds) const
 		{
 			const u32 page_base = address & ~4095;
-			const u32 page_limit = address + 4096;
+			const u32 page_limit = page_base + 4096;
 
 			const u32 compare_min = std::min(old_range.first, page_base);
 			const u32 compare_max = std::max(old_range.second, page_limit);


### PR DESCRIPTION
While investigating the P5 texture swap issues, I stumbled into two different bugs in the texture cache, specifically in the `overlaps_page` and `get_intersecting_set` methods.

This pull request fixes these two bugs:

- In `overlaps_page`, if `address` is not page-aligned, the calculated end address for the corresponding page is incorrect which can lead to false positives, causing some textures to be re-uploaded unnecessarily.
- When the trampled range changes, `get_intersecting_set` restarts the outer loop. However, due to an off-by-one error, it skips the first cache entry when doing so. This can cause a texture to not be correctly unlocked, which could lead to issues such as texture corruption or even deadlocks.

I have ran these through @kd-11 and he has confirmed these are actual bugs.

In addition, after some discussion with @kd-11, I have refactored `get_intersecting_set` to avoid unnecessary looping. It will now only execute the minimum number of iterations necessary to ensure all textures have been processed using the correct `trampled_range`. I have tested this last change by comparing it directly with the old implementation (see https://github.com/ruipin/rpcs3/commit/25b6f2f172ef8d187ae9d0886367690a4c8bfc19) and saw no difference in behaviour.

Note that I have only tested these changes with P5, since that is the only game I have available right now.

(This is my first PR here, comments/suggestions/criticism/etc are welcome!)