### PR TITLE
AAA fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -698,6 +698,7 @@ void cellGcmSetZcull(u8 index, u32 offset, u32 width, u32 height, u32 cullStart,
 	zcull.sFunc = sFunc;
 	zcull.sRef = sRef;
 	zcull.sMask = sMask;
+	zcull.binded = (zCullFormat > 0);
 
 	vm::_ptr<CellGcmZcullInfo>(m_config->zculls_addr)[index] = zcull.pack();
 }
@@ -1261,6 +1262,7 @@ s32 cellGcmSetTile(u8 index, u8 location, u32 offset, u32 size, u32 pitch, u8 co
 	tile.comp = comp;
 	tile.base = base;
 	tile.bank = bank;
+	tile.binded = (pitch > 0);
 
 	vm::_ptr<CellGcmTileInfo>(m_config->tiles_addr)[index] = tile.pack();
 	return CELL_OK;

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -329,6 +329,7 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 	s32 index = 0;
 	s32 program_offset = -1;
 	u32 ucode_size = 0;
+	u32 constants_size = 0;
 	u16 textures_mask = 0;
 
 	while (true)
@@ -364,6 +365,7 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 				//Instruction references constant, skip one slot occupied by data
 				index++;
 				ucode_size += 16;
+				constants_size += 16;
 			}
 		}
 
@@ -386,7 +388,7 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 		index++;
 	}
 
-	return{ (u32)program_offset, ucode_size, textures_mask };
+	return{ (u32)program_offset, ucode_size, constants_size, textures_mask };
 }
 
 size_t fragment_program_utils::get_fragment_program_ucode_hash(const RSXFragmentProgram& program)

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -57,6 +57,7 @@ namespace program_hash_util
 		{
 			u32 program_start_offset;
 			u32 program_ucode_length;
+			u32 program_constants_buffer_length;
 			u16 referenced_textures_mask;
 		};
 

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -218,7 +218,7 @@ namespace rsx
 
 				if (fits_w && fits_h)
 				{
-					surface_hierachy_info<surface_type>::memory_overlap_t overlap;
+					typename surface_hierachy_info<surface_type>::memory_overlap_t overlap;
 					overlap._ref = surface;
 					overlap.memory_address = address;
 					overlap.x = offset_x;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -33,6 +33,8 @@ namespace rsx
 		u32 dst_gcm_format = 0;
 		f32 src_scaling_hint = 1.f;
 		f32 dst_scaling_hint = 1.f;
+		texture_upload_context src_context = texture_upload_context::blit_engine_src;
+		texture_upload_context dst_context = texture_upload_context::blit_engine_dst;
 
 		void analyse()
 		{
@@ -2125,6 +2127,7 @@ namespace rsx
 				if (cached_dest)
 				{
 					dest_texture = cached_dest->get_raw_texture();
+					typeless_info.dst_context = cached_dest->get_context();
 
 					max_dst_width = cached_dest->get_width();
 					max_dst_height = cached_dest->get_height();
@@ -2144,6 +2147,7 @@ namespace rsx
 				dst_area.y2 += dst_subres.y;
 
 				dest_texture = dst_subres.surface->get_surface();
+				typeless_info.dst_context = texture_upload_context::framebuffer_storage;
 
 				max_dst_width = (u16)(dst_subres.surface->get_surface_width() * typeless_info.dst_scaling_hint);
 				max_dst_height = dst_subres.surface->get_surface_height();
@@ -2179,6 +2183,7 @@ namespace rsx
 						src_area.y2 <= surface->get_height())
 					{
 						vram_texture = surface->get_raw_texture();
+						typeless_info.src_context = surface->get_context();
 						break;
 					}
 
@@ -2206,6 +2211,7 @@ namespace rsx
 						subresource_layout, rsx::texture_dimension_extended::texture_dimension_2d, dst.swizzled)->get_raw_texture();
 
 					m_texture_memory_in_use += src.pitch * src.slice_h;
+					typeless_info.src_context = texture_upload_context::blit_engine_src;
 				}
 			}
 			else
@@ -2232,6 +2238,7 @@ namespace rsx
 				src_area.y2 += src_subres.y;
 
 				vram_texture = src_subres.surface->get_surface();
+				typeless_info.src_context = texture_upload_context::framebuffer_storage;
 			}
 
 			const bool src_is_depth = src_subres.is_depth_surface;
@@ -2342,6 +2349,7 @@ namespace rsx
 					channel_order);
 
 				dest_texture = cached_dest->get_raw_texture();
+				typeless_info.dst_context = texture_upload_context::blit_engine_dst;
 				m_texture_memory_in_use += dst.pitch * dst_dimensions.height;
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1029,9 +1029,9 @@ void GLGSRender::clear_surface(u32 arg)
 		gl_state.clear_depth(f32(clear_depth) / max_depth_value);
 		mask |= GLenum(gl::buffers::depth);
 
-		if (auto ds = std::get<1>(m_rtts.m_bound_depth_stencil))
+		if (const auto address = std::get<0>(m_rtts.m_bound_depth_stencil))
 		{
-			ds->on_write();
+			m_rtts.on_write(address);
 		}
 	}
 
@@ -1075,9 +1075,9 @@ void GLGSRender::clear_surface(u32 arg)
 
 			for (auto &rtt : m_rtts.m_bound_render_targets)
 			{
-				if (auto surface = std::get<1>(rtt))
+				if (const auto address = std::get<0>(rtt))
 				{
-					surface->on_write();
+					m_rtts.on_write(address);
 				}
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -632,7 +632,11 @@ void GLGSRender::on_init_thread()
 	// NOTES: All contexts have to be created before any is bound to a thread
 	// This allows context sharing to work (both GLRCs passed to wglShareLists have to be idle or you get ERROR_BUSY)
 	m_context = m_frame->make_context();
-	m_decompiler_context = m_frame->make_context();
+
+	if (!g_cfg.video.disable_asynchronous_shader_compiler)
+	{
+		m_decompiler_context = m_frame->make_context();
+	}
 
 	// Bind primary context to main RSX thread
 	m_frame->set_current(m_context);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -269,7 +269,7 @@ void GLGSRender::end()
 			GLfloat colors[] = { 0.f, 0.f, 0.f, 0.f };
 			//It is impossible for the render target to be type A or B here (clear all would have been flagged)
 			for (auto &i : buffers_to_clear)
-				glClearBufferfv(draw_fbo.id(), i, colors);
+				glClearBufferfv(m_draw_fbo->id(), i, colors);
 		}
 
 		if (clear_depth)
@@ -924,10 +924,12 @@ void GLGSRender::on_exit()
 
 	m_prog_buffer.clear();
 
-	if (draw_fbo)
+	for (auto &fbo : m_framebuffer_cache)
 	{
-		draw_fbo.remove();
+		fbo.remove();
 	}
+
+	m_framebuffer_cache.clear();
 
 	if (m_flip_fbo)
 	{
@@ -1595,6 +1597,16 @@ void GLGSRender::flip(int buffer)
 
 	m_rtts.free_invalidated();
 	m_vertex_cache->purge();
+
+	if (m_framebuffer_cache.size() > 32)
+	{
+		for (auto &fbo : m_framebuffer_cache)
+		{
+			fbo.remove();
+		}
+
+		m_framebuffer_cache.clear();
+	}
 
 	//If we are skipping the next frame, do not reset perf counters
 	if (skip_frame) return;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1189,7 +1189,7 @@ void GLGSRender::load_program_env(const gl::vertex_upload_info& upload_info)
 	u32 vertex_constants_offset;
 	u32 fragment_constants_offset;
 
-	const u32 fragment_constants_size = (const u32)m_prog_buffer.get_fragment_constants_buffer_size(current_fragment_program);
+	const u32 fragment_constants_size = current_fp_metadata.program_constants_buffer_length;
 	const u32 fragment_buffer_size = fragment_constants_size + (18 * 4 * sizeof(float));
 	const bool update_transform_constants = !!(m_graphics_state & rsx::pipeline_state::transform_constants_dirty);
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -325,7 +325,6 @@ private:
 	shared_mutex queue_guard;
 	std::list<work_item> work_queue;
 
-	bool flush_draw_buffers = false;
 	std::thread::id m_thread_id;
 
 	GLProgramBuffer m_prog_buffer;
@@ -369,10 +368,8 @@ private:
 
 public:
 	void read_buffers();
-	void write_buffers();
 	void set_viewport();
 
-	void synchronize_buffers();
 	work_item& post_flush_request(u32 address, gl::texture_cache::thrashed_set& flush_data);
 
 	bool scaled_image_from_memory(rsx::blit_src_info& src_info, rsx::blit_dst_info& dst_info, bool interpolate) override;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -331,7 +331,8 @@ private:
 	draw_context_t m_decompiler_context;
 
 	//buffer
-	gl::fbo draw_fbo;
+	gl::fbo* m_draw_fbo = nullptr;
+	std::list<gl::fbo> m_framebuffer_cache;
 	gl::fbo m_flip_fbo;
 	std::unique_ptr<gl::texture> m_flip_tex_color;
 

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -306,6 +306,20 @@ namespace gl
 		return m_size;
 	}
 
+	bool fbo::matches(std::array<GLuint, 4> color_targets, GLuint depth_stencil_target)
+	{
+		for (u32 index = 0; index < 4; ++index)
+		{
+			if (color[index].resource_id() != color_targets[index])
+			{
+				return false;
+			}
+		}
+
+		const auto depth_resource = depth.resource_id() | depth_stencil.resource_id();
+		return depth_resource == depth_stencil_target;
+	}
+
 	bool is_primitive_native(rsx::primitive_type in)
 	{
 		switch (in)

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -2026,6 +2026,9 @@ public:
 		GLuint m_id = GL_NONE;
 		size2i m_size;
 
+	protected:
+		std::unordered_map<GLenum, GLuint> m_resource_bindings;
+
 	public:
 		fbo() = default;
 
@@ -2095,9 +2098,21 @@ public:
 				return m_id;
 			}
 
+			GLuint resource_id() const
+			{
+				const auto found = m_parent.m_resource_bindings.find(m_id);
+				if (found != m_parent.m_resource_bindings.end())
+				{
+					return found->second;
+				}
+
+				return GL_NONE;
+			}
+
 			void operator = (const rbo& rhs)
 			{
 				save_binding_state save(m_parent);
+				m_parent.m_resource_bindings[m_id] = rhs.id();
 				glFramebufferRenderbuffer(GL_FRAMEBUFFER, m_id, GL_RENDERBUFFER, rhs.id());
 			}
 
@@ -2106,12 +2121,14 @@ public:
 				save_binding_state save(m_parent);
 
 				verify(HERE), rhs.get_target() == texture::target::texture2D;
+				m_parent.m_resource_bindings[m_id] = rhs.id();
 				glFramebufferTexture2D(GL_FRAMEBUFFER, m_id, GL_TEXTURE_2D, rhs.id(), 0);
 			}
 
 			void operator = (const GLuint rhs)
 			{
 				save_binding_state save(m_parent);
+				m_parent.m_resource_bindings[m_id] = rhs;
 				glFramebufferTexture2D(GL_FRAMEBUFFER, m_id, GL_TEXTURE_2D, rhs, 0);
 			}
 		};
@@ -2199,6 +2216,8 @@ public:
 
 		void set_extents(size2i extents);
 		size2i get_extents() const;
+
+		bool matches(std::array<GLuint, 4> color_targets, GLuint depth_stencil_target);
 
 		explicit operator bool() const
 		{

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -153,8 +153,6 @@ namespace gl
 		std::unique_ptr<gl::viewable_image> managed_texture;
 		std::unique_ptr<gl::texture> scaled_texture;
 
-		bool is_depth = false;
-
 		texture::format format = texture::format::rgba;
 		texture::type type = texture::type::ubyte;
 		rsx::surface_antialiasing aa_mode = rsx::surface_antialiasing::center_1_sample;
@@ -260,7 +258,6 @@ namespace gl
 			flushed = false;
 			synchronized = false;
 			sync_timestamp = 0ull;
-			is_depth = false;
 
 			vram_texture = nullptr;
 			managed_texture.reset();
@@ -287,7 +284,6 @@ namespace gl
 			flushed = false;
 			synchronized = false;
 			sync_timestamp = 0ull;
-			is_depth = false;
 
 			this->width = w;
 			this->height = h;
@@ -347,11 +343,6 @@ namespace gl
 			}
 		}
 
-		void set_depth_flag(bool is_depth_fmt)
-		{
-			is_depth = is_depth_fmt;
-		}
-
 		void copy_texture(bool=false)
 		{
 			if (!pbo_id)
@@ -405,7 +396,8 @@ namespace gl
 						scaled_texture = std::make_unique<gl::texture>(GL_TEXTURE_2D, real_width, real_height, 1, 1, (GLenum)ifmt);
 					}
 
-					bool linear_interp = false; //TODO: Make optional or detect full sized sources
+					const bool is_depth = is_depth_texture();
+					const bool linear_interp = is_depth? false : true;
 					g_hw_blitter->scale_image(vram_texture, scaled_texture.get(), src_area, dst_area, linear_interp, is_depth, {});
 					target_texture = scaled_texture.get();
 				}
@@ -674,7 +666,15 @@ namespace gl
 
 		bool is_depth_texture() const
 		{
-			return is_depth;
+			switch (vram_texture->get_internal_format())
+			{
+			case gl::texture::internal_format::depth16:
+			case gl::texture::internal_format::depth24_stencil8:
+			case gl::texture::internal_format::depth32f_stencil8:
+				return true;
+			default:
+				return false;
+			}
 		}
 
 		bool has_compatible_format(gl::texture* tex) const
@@ -950,15 +950,6 @@ namespace gl
 		cached_texture_section* create_new_texture(void*&, u32 rsx_address, u32 rsx_size, u16 width, u16 height, u16 depth, u16 mipmaps, u32 gcm_format,
 				rsx::texture_upload_context context, rsx::texture_dimension_extended type, rsx::texture_create_flags flags) override
 		{
-			bool depth_flag = false;
-			switch (gcm_format)
-			{
-			case CELL_GCM_TEXTURE_DEPTH24_D8:
-			case CELL_GCM_TEXTURE_DEPTH16:
-				depth_flag = true;
-				break;
-			}
-
 			auto image = gl::create_texture(gcm_format, width, height, depth, mipmaps, type);
 
 			const auto swizzle = get_component_mapping(gcm_format, flags);
@@ -966,7 +957,6 @@ namespace gl
 
 			auto& cached = create_texture(image, rsx_address, rsx_size, width, height, depth, mipmaps);
 			cached.set_dirty(false);
-			cached.set_depth_flag(depth_flag);
 			cached.set_view_flags(flags);
 			cached.set_context(context);
 			cached.set_gcm_format(gcm_format);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2333,7 +2333,7 @@ namespace rsx
 
 		if (zcull_ctrl->has_pending())
 		{
-			LOG_ERROR(RSX, "Dangling reports found, discarding...");
+			LOG_TRACE(RSX, "Dangling reports found, discarding...");
 			zcull_ctrl->sync(this);
 		}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1373,6 +1373,24 @@ namespace rsx
 				for (const auto& range : m_invalidated_memory_ranges)
 				{
 					on_invalidate_memory_range(range.first, range.second);
+
+					// Clean the main memory super_ptr cache if invalidated
+					const auto range_end = range.first + range.second;
+					for (auto It = main_super_memory_block.begin(); It != main_super_memory_block.end();)
+					{
+						const auto mem_start = It->first;
+						const auto mem_end = mem_start + It->second.size();
+						const bool overlaps = (mem_start < range_end && range.first < mem_end);
+
+						if (overlaps)
+						{
+							It = main_super_memory_block.erase(It);
+						}
+						else
+						{
+							It++;
+						}
+					}
 				}
 
 				m_invalidated_memory_ranges.clear();

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -791,7 +791,7 @@ namespace rsx
 				bool execute_method_call = true;
 
 				//TODO: Flatten draw calls when multidraw is not supported to simplify checking in the end() methods
-				if (supports_multidraw && !g_cfg.video.disable_FIFO_reordering)
+				if (supports_multidraw && !g_cfg.video.disable_FIFO_reordering && !capture_current_frame)
 				{
 					//TODO: Make this cleaner
 					bool flush_commands_flag = has_deferred_call;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1207,10 +1207,19 @@ namespace rsx
 		}
 	}
 
-	u64 thread::timestamp() const
+	u64 thread::timestamp()
 	{
 		// Get timestamp, and convert it from microseconds to nanoseconds
-		return get_system_time() * 1000;
+		const u64 t = get_system_time() * 1000;
+		if (t != timestamp_ctrl)
+		{
+			timestamp_ctrl = t;
+			timestamp_subvalue = 0;
+			return t;
+		}
+
+		timestamp_subvalue += 10;
+		return t + timestamp_subvalue;
 	}
 
 	gsl::span<const gsl::byte> thread::get_raw_index_array(const std::vector<std::pair<u32, u32> >& draw_indexed_clause) const

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1884,7 +1884,7 @@ namespace rsx
 					block.base_offset = base_address;
 					block.attribute_stride = info.stride();
 					block.memory_location = info.offset() >> 31;
-					block.locations.reserve(4);
+					block.locations.reserve(8);
 					block.locations.push_back(index);
 					block.min_divisor = info.frequency();
 					block.all_modulus = !!(frequency_divider_mask & (1 << index));

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -587,7 +587,7 @@ namespace rsx
 					}
 					else if (zcull_ctrl->has_pending())
 					{
-						zcull_ctrl->sync(this);
+						//zcull_ctrl->sync(this);
 					}
 					else
 					{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -213,6 +213,24 @@ namespace rsx
 		std::array<attribute_buffer_placement, 16> attribute_placement;
 	};
 
+	struct framebuffer_layout
+	{
+		u16 width;
+		u16 height;
+		std::array<u32, 4> color_addresses;
+		std::array<u32, 4> color_pitch;
+		std::array<u32, 4> actual_color_pitch;
+		u32 zeta_address;
+		u32 zeta_pitch;
+		u32 actual_zeta_pitch;
+		rsx::surface_target target;
+		rsx::surface_color_format color_format;
+		rsx::surface_depth_format depth_format;
+		rsx::surface_antialiasing aa_mode;
+		u32 aa_factors[2];
+		bool ignore_change;
+	};
+
 	namespace reports
 	{
 		struct occlusion_query_info
@@ -391,6 +409,8 @@ namespace rsx
 		bool m_textures_dirty[16];
 		bool m_vertex_textures_dirty[4];
 		bool m_framebuffer_state_contested = false;
+		rsx::framebuffer_creation_context m_framebuffer_contest_type = rsx::framebuffer_creation_context::context_draw;
+
 		u32  m_graphics_state = 0;
 		u64  ROP_sync_timestamp = 0;
 
@@ -400,6 +420,8 @@ namespace rsx
 	protected:
 		std::array<u32, 4> get_color_surface_addresses() const;
 		u32 get_zeta_surface_address() const;
+
+		framebuffer_layout get_framebuffer_layout(rsx::framebuffer_creation_context context);
 
 		/**
 		 * Analyze vertex inputs and group all interleaved blocks

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -382,7 +382,8 @@ namespace rsx
 		GcmZcullInfo zculls[limits::zculls_count];
 
 		// Super memory map (mapped block with r/w permissions)
-		std::pair<u32, std::shared_ptr<u8>> super_memory_map;
+		std::pair<u32, std::shared_ptr<u8>> local_super_memory_block;
+		std::unordered_map<u32, rsx::weak_ptr> main_super_memory_block;
 
 		bool capture_current_frame = false;
 		void capture_frame(const std::string &name);

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -326,6 +326,9 @@ namespace rsx
 		std::shared_ptr<thread_ctrl> m_vblank_thread;
 		std::shared_ptr<thread_ctrl> m_decompiler_thread;
 
+		u64 timestamp_ctrl = 0;
+		u64 timestamp_subvalue = 0;
+
 	protected:
 		atomic_t<bool> m_rsx_thread_exiting{true};
 		s32 m_return_addr{-1}, restore_ret_addr{-1};
@@ -496,7 +499,7 @@ namespace rsx
 		virtual void on_init_thread() = 0;
 		virtual bool do_method(u32 /*cmd*/, u32 /*value*/) { return false; }
 		virtual void flip(int buffer) = 0;
-		virtual u64 timestamp() const;
+		virtual u64 timestamp();
 		virtual bool on_access_violation(u32 /*address*/, bool /*is_writing*/) { return false; }
 		virtual void on_invalidate_memory_range(u32 /*address*/, u32 /*range*/) {}
 		virtual void notify_tile_unbound(u32 /*tile*/) {}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -258,9 +258,9 @@ namespace rsx
 
 		struct ZCULL_control
 		{
-			// Delay in 'cycles' before a report update operation is forced to retire
-			const u32 max_zcull_cycles_delay = 128;
-			const u32 min_zcull_cycles_delay = 16;
+			// Delay before a report update operation is forced to retire
+			const u32 max_zcull_delay_us = 500;
+			const u32 min_zcull_delay_us = 50;
 
 			// Number of occlusion query slots available. Real hardware actually has far fewer units before choking
 			const u32 occlusion_query_count = 128;
@@ -273,7 +273,7 @@ namespace rsx
 			occlusion_query_info* m_current_task = nullptr;
 			u32 m_statistics_tag_id = 0;
 			u64 m_tsc = 0;
-			u32 m_cycles_delay = max_zcull_cycles_delay;
+			u32 m_cycles_delay = max_zcull_delay_us;
 
 			std::vector<queued_report_write> m_pending_writes;
 			std::unordered_map<u32, u32> m_statistics_map;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1326,7 +1326,7 @@ void VKGSRender::end()
 	m_vertex_upload_time += std::chrono::duration_cast<std::chrono::microseconds>(vertex_end - vertex_start).count();
 
 	// Load program execution environment
-	program_start = textures_end;
+	program_start = vertex_end;
 	load_program_env(upload_info);
 
 	VkBufferView persistent_buffer = m_persistent_attribute_storage ? m_persistent_attribute_storage->value : null_buffer_view->value;
@@ -2374,7 +2374,7 @@ void VKGSRender::load_program_env(const vk::vertex_upload_info& vertex_info)
 
 	if (1)//m_graphics_state & (rsx::pipeline_state::fragment_state_dirty | rsx::pipeline_state::vertex_state_dirty))
 	{
-		const size_t fragment_constants_sz = m_prog_buffer->get_fragment_constants_buffer_size(current_fragment_program);
+		const size_t fragment_constants_sz = current_fp_metadata.program_constants_buffer_length;
 		const size_t fragment_buffer_sz = fragment_constants_sz + (18 * 4 * sizeof(float));
 		const size_t required_mem = 512 + fragment_buffer_sz;
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3140,15 +3140,7 @@ void VKGSRender::end_occlusion_query(rsx::reports::occlusion_query_info* query)
 	m_occlusion_query_active = false;
 	m_active_query_info = nullptr;
 
-	//Avoid stalling later if this query is already tied to a report
-	if (query->num_draws && query->owned && !m_flush_requests.pending())
-	{
-		if (0)//m_current_command_buffer->flags & cb_has_occlusion_task)
-		{
-			m_flush_requests.post(false);
-			m_flush_requests.remove_one();
-		}
-	}
+	// NOTE: flushing the queue is very expensive, do not flush just because query stopped
 }
 
 bool VKGSRender::check_occlusion_query_status(rsx::reports::occlusion_query_info* query)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3113,9 +3113,6 @@ bool VKGSRender::scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst
 	//Verify enough memory exists before attempting to handle data transfer
 	check_heap_status();
 
-	//Stop all parallel operations until this is finished
-	std::lock_guard<shared_mutex> lock(m_secondary_cb_guard);
-
 	if (m_texture_cache.blit(src, dst, interpolate, m_rtts, *m_current_command_buffer))
 	{
 		m_samplers_dirty.store(true);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1775,9 +1775,9 @@ void VKGSRender::clear_surface(u32 mask)
 
 				for (auto &rtt : m_rtts.m_bound_render_targets)
 				{
-					if (auto surface = std::get<1>(rtt))
+					if (const auto address = std::get<0>(rtt))
 					{
-						surface->on_write();
+						m_rtts.on_write(address);
 					}
 				}
 			}
@@ -1786,9 +1786,9 @@ void VKGSRender::clear_surface(u32 mask)
 
 	if (mask & 0x3)
 	{
-		if (auto ds = std::get<1>(m_rtts.m_bound_depth_stencil))
+		if (const auto address = std::get<0>(m_rtts.m_bound_depth_stencil))
 		{
-			ds->on_write();
+			m_rtts.on_write(address);
 			clear_descriptors.push_back({ (VkImageAspectFlags)depth_stencil_mask, 0, depth_stencil_clear_values });
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -354,7 +354,6 @@ private:
 	s64 m_flip_time = 0;
 
 	u8 m_draw_buffers_count = 0;
-	bool m_flush_draw_buffers = false;
 	
 	shared_mutex m_flush_queue_mutex;
 	flush_request_task m_flush_requests;
@@ -380,9 +379,7 @@ private:
 	void clear_surface(u32 mask);
 	void close_and_submit_command_buffer(const std::vector<VkSemaphore> &semaphores, VkFence fence, VkPipelineStageFlags pipeline_stage_flags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 	void open_command_buffer();
-	void sync_at_semaphore_release();
 	void prepare_rtts(rsx::framebuffer_creation_context context);
-	void copy_render_targets_to_dma_location();
 
 	void flush_command_queue(bool hard_sync = false);
 	void queue_swap_request();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -360,7 +360,7 @@ private:
 	s64 m_draw_time = 0;
 	s64 m_flip_time = 0;
 
-	u8 m_draw_buffers_count = 0;
+	std::vector<u8> m_draw_buffers;
 	
 	shared_mutex m_flush_queue_mutex;
 	flush_request_task m_flush_requests;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -47,10 +47,18 @@ namespace vk
 
 extern u64 get_system_time();
 
+enum command_buffer_data_flag
+{
+	cb_has_occlusion_task = 1
+};
+
 struct command_buffer_chunk: public vk::command_buffer
 {
 	VkFence submit_fence = VK_NULL_HANDLE;
 	VkDevice m_device = VK_NULL_HANDLE;
+
+	u32 num_draws = 0;
+	u32 flags = 0;
 
 	std::atomic_bool pending = { false };
 	std::atomic<u64> last_sync = { 0 };
@@ -90,11 +98,16 @@ struct command_buffer_chunk: public vk::command_buffer
 			wait();
 
 		CHECK_RESULT(vkResetCommandBuffer(commands, 0));
+		num_draws = 0;
+		flags = 0;
 	}
 
 	bool poke()
 	{
 		reader_lock lock(guard_mutex);
+
+		if (!pending)
+			return true;
 
 		if (vkGetFenceStatus(m_device, submit_fence) == VK_SUCCESS)
 		{
@@ -117,14 +130,8 @@ struct command_buffer_chunk: public vk::command_buffer
 		if (!pending)
 			return;
 
-		switch(vkGetFenceStatus(m_device, submit_fence))
-		{
-		case VK_SUCCESS:
-			break;
-		case VK_NOT_READY:
-			CHECK_RESULT(vkWaitForFences(m_device, 1, &submit_fence, VK_TRUE, UINT64_MAX));
-			break;
-		}
+		// NOTE: vkWaitForFences is slower than polling fence status at least on NV
+		while (vkGetFenceStatus(m_device, submit_fence) == VK_NOT_READY);
 
 		lock.upgrade();
 
@@ -405,6 +412,8 @@ public:
 	void read_buffers();
 	void write_buffers();
 	void set_viewport();
+
+	void sync_hint(rsx::FIFO_hint hint) override;
 
 	void begin_occlusion_query(rsx::reports::occlusion_query_info* query) override;
 	void end_occlusion_query(rsx::reports::occlusion_query_info* query) override;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -195,7 +195,7 @@ namespace vk
 		if (!g_scratch_buffer)
 		{
 			// 32M disposable scratch memory
-			g_scratch_buffer = std::make_unique<vk::buffer>(*g_current_renderer, 32 * 0x100000,
+			g_scratch_buffer = std::make_unique<vk::buffer>(*g_current_renderer, 64 * 0x100000,
 				g_current_renderer->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 				VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, 0);
 		}

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -2688,8 +2688,12 @@ public:
 
 		void unmap()
 		{
-			//mapped = false;
-			//heap->unmap();
+			if (g_cfg.video.disable_vulkan_mem_allocator)
+			{
+				heap->unmap();
+				mapped = false;
+				_ptr = nullptr;
+			}
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -189,8 +189,11 @@ namespace vk
 					target = vk::get_typeless_helper(vram_texture->info.format);
 					change_image_layout(cmd, target, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, subresource_range);
 
+					// Allow bilinear filtering on color textures where compatibility is likely
+					const auto filter = (aspect_flag == VK_IMAGE_ASPECT_COLOR_BIT) ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
+
 					vk::copy_scaled_image(cmd, vram_texture->value, target->value, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, target->current_layout,
-						0, 0, vram_texture->width(), vram_texture->height(), 0, 0, transfer_width, transfer_height, 1, aspect_flag, true, VK_FILTER_NEAREST,
+						0, 0, vram_texture->width(), vram_texture->height(), 0, 0, transfer_width, transfer_height, 1, aspect_flag, true, filter,
 						vram_texture->info.format, target->info.format);
 				}
 			}

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -354,7 +354,8 @@ namespace rsx
 
 		void flush_io(u32 offset = 0, u32 len = 0) const
 		{
-			locked_memory_ptr.flush(offset, len);
+			const auto write_length = len ? len : (cpu_address_range - offset);
+			locked_memory_ptr.flush(offset, write_length);
 		}
 
 		std::pair<u32, u32> get_confirmed_range() const

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -160,6 +160,8 @@ namespace rsx
 
 		void texture_read_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
+			// Pipeline barrier seems to be equivalent to a SHADER_READ stage barrier
+
 			const u32 index = method_registers.semaphore_offset_4097() >> 4;
 			// lle-gcm likes to inject system reserved semaphores, presumably for system/vsh usage
 			// Avoid calling render to avoid any havoc(flickering) they may cause from invalid flush/write
@@ -169,7 +171,6 @@ namespace rsx
 				//
 			}
 
-			rsx->sync();
 			auto& sema = vm::_ref<RsxReports>(rsx->label_addr);
 			sema.semaphore[index].val = arg;
 			sema.semaphore[index].pad = 0;
@@ -178,6 +179,8 @@ namespace rsx
 
 		void back_end_write_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
+			// Full pipeline barrier
+
 			const u32 index = method_registers.semaphore_offset_4097() >> 4;
 			if (index > 63 && !rsx->do_method(NV4097_BACK_END_WRITE_SEMAPHORE_RELEASE, arg))
 			{

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1083,13 +1083,7 @@ namespace rsx
 
 	void flip_command(thread* rsx, u32, u32 arg)
 	{
-		if (user_asked_for_frame_capture && !g_cfg.video.strict_rendering_mode)
-		{
-			// not dealing with non-strict rendering capture for now
-			user_asked_for_frame_capture = false;
-			LOG_FATAL(RSX, "RSX Capture: Capture only supported when ran with strict rendering mode.");
-		}
-		else if (user_asked_for_frame_capture && !rsx->capture_current_frame)
+		if (user_asked_for_frame_capture && !rsx->capture_current_frame)
 		{
 			rsx->capture_current_frame = true;
 			user_asked_for_frame_capture = false;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -521,9 +521,10 @@ namespace rsx
 				return;
 			}
 
-			rsx->sync();
-			vm::ptr<CellGcmReportData> result = address_ptr;
-			rsx->conditional_render_test_failed = (result->value == 0);
+			// Defer conditional render evaluation
+			rsx->sync_hint(FIFO_hint::hint_conditional_render_eval);
+			rsx->conditional_render_test_address = address_ptr;
+			rsx->conditional_render_test_failed = false;
 		}
 
 		void set_zcull_render_enable(thread* rsx, u32, u32 arg)
@@ -1809,8 +1810,6 @@ namespace rsx
 		bind<NV4097_SET_DEPTH_MASK, nv4097::set_surface_options_dirty_bit>();
 		bind<NV4097_SET_COLOR_MASK, nv4097::set_surface_options_dirty_bit>();
 		bind<NV4097_WAIT_FOR_IDLE, nv4097::sync>();
-		bind<NV4097_ZCULL_SYNC, nv4097::sync>();
-		bind<NV4097_SET_CONTEXT_DMA_REPORT, nv4097::sync>();
 		bind<NV4097_INVALIDATE_L2, nv4097::set_shader_program_dirty>();
 		bind<NV4097_SET_SHADER_PROGRAM, nv4097::set_shader_program_dirty>();
 		bind<NV4097_SET_TRANSFORM_PROGRAM_START, nv4097::set_transform_program_start>();

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -43,7 +43,7 @@ namespace rsx
 	{
 		//Don't throw, gather information and ignore broken/garbage commands
 		//TODO: Investigate why these commands are executed at all. (Heap corruption? Alignment padding?)
-		LOG_ERROR(RSX, "Invalid RSX method 0x%x (arg=0x%x)" HERE, _reg << 2, arg);
+		LOG_ERROR(RSX, "Invalid RSX method 0x%x (arg=0x%x)", _reg << 2, arg);
 		rsx->invalid_command_interrupt_raised = true;
 	}
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -348,7 +348,7 @@ namespace rsx
 				if (address >= 468)
 				{
 					// Ignore addresses outside the usable [0, 467] range
-					LOG_ERROR(RSX, "Invalid transform register index (load=%d, index=%d)", load, index);
+					LOG_WARNING(RSX, "Invalid transform register index (load=%d, index=%d)", load, index);
 					return;
 				}
 
@@ -367,6 +367,15 @@ namespace rsx
 		{
 			static void impl(thread* rsx, u32 _reg, u32 arg)
 			{
+				if (rsx::method_registers.transform_program_load() >= 512)
+				{
+					// PS3 seems to allow exceeding the program buffer by upto 32 instructions before crashing
+					// Discard the "excess" instructions to not overflow our transform program buffer
+					// TODO: Check if the instructions in the overflow area are executed by PS3
+					LOG_WARNING(RSX, "Program buffer overflow!");
+					return;
+				}
+
 				method_registers.commit_4_transform_program_instructions(index);
 				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty;
 			}

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1181,6 +1181,11 @@ namespace rsx
 			return u16(registers[NV308A_SIZE_OUT] & 0xFFFF);
 		}
 
+		u32 transform_program_load()
+		{
+			return registers[NV4097_SET_TRANSFORM_PROGRAM_LOAD];
+		}
+
 		void commit_4_transform_program_instructions(u32 index)
 		{
 			u32& load = registers[NV4097_SET_TRANSFORM_PROGRAM_LOAD];
@@ -1194,7 +1199,7 @@ namespace rsx
 
 		u32 transform_constant_load()
 		{
-			return decode<NV4097_SET_TRANSFORM_CONSTANT_LOAD>().transform_constant_load();
+			return registers[NV4097_SET_TRANSFORM_CONSTANT_LOAD];
 		}
 
 		u32 transform_branch_bits()

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -60,9 +60,9 @@ namespace rsx
 			}
 		}
 
-		weak_ptr(std::shared_ptr<u8>& block)
+		weak_ptr(std::shared_ptr<u8>& block, u32 size)
 		{
-			_blocks.push_back({ block, 0 });
+			_blocks.push_back({ block, size });
 			_ptr = block.get();
 		}
 
@@ -193,6 +193,11 @@ namespace rsx
 					base_offset += block.second;
 				}
 			}
+		}
+
+		u32 size() const
+		{
+			return contiguous ? _blocks[0].second : (u32)io_cache.size();
 		}
 
 		operator bool() const


### PR DESCRIPTION
- Separate texture read barrier from full pipeline barriers and avoids a lot of unnecessary sync/work caused by doing a full sync for texture read barriers. Applications tend to spam a lot of the texture read barriers so its better to let the cache deal with a raw miss than to try and optimize with a barrier hint.
- ZCULL: Implement targeted synchronization to avoid stalling for too long gathering results that may be unused.
- ZCULL: Defer conditional render evaluation to avoid a hard stall whenever a conditional render register is touched.
- ZCULL: Change from arbitrary counters to microsecond counters to determine evaluation deadlines. The result is much more consistent throughput and latency.
- Improve aliased memory contention evaluation. It is common for the same memory address to be used as both a color target and depth target in a draw, but configuration registers ultimately determine whether the hardware will write depth or color, or both and one overwrites the other.
- Fix a vulkan regression (https://github.com/RPCS3/rpcs3/issues/4923)
- Improve rsx timestamp accuracy to simulate nanosecond timing.
- Fix blit engine writes to active rendertargets for vulkan.
- Improve vm deadlock evasion; should avoid some situations that would cause the emulator to lock up and die (e.g prince of persia, warrior within)
- Improve memory tracking so that writing to a large block of memory should reach any framebuffers that live in the disturbed range. Only basic invalidation has been done right now.
- Enable swizzle formats for all textures unless proven otherwise. Tests have shown that Z scanning is valid for almost all formats except some special compressed ones like DXT.
- vk/gl: Several minor optimizations to hash functions and resource management to squeeze out a few more frames in some applications.