### PR TITLE
Split fixes

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -625,4 +625,6 @@ namespace fs
 
 		return false;
 	}
+
+	file make_gather(std::vector<file>);
 }

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -46,7 +46,7 @@ u32 local_addr = 0;
 /*
  * Get usable local memory size for a specific game SDK version
  * Example: For 0x00446000 (FW 4.46) we get a localSize of 0x0F900000 (249MB)
- */ 
+ */
 u32 gcmGetLocalMemorySize(u32 sdk_version)
 {
 	if (sdk_version >= 0x00220000)
@@ -397,16 +397,8 @@ s32 _cellGcmInitBody(vm::pptr<CellGcmContextData> context, u32 cmdSize, u32 ioSi
 	m_config->current_config.coreFrequency = 500000000;
 
 	// Create contexts
-
-	u32 rsx_ctxaddr = 0;
-	for (u32 addr = 0x30000000; addr < 0xC0000000; addr += 0x10000000)
-	{
-		if (vm::map(addr, 0x10000000, 0x400))
-		{
-			rsx_ctxaddr = addr;
-			break;
-		}
-	}
+	auto ctx_area = vm::find_map(0x10000000, 0x10000000, 0x403);
+	u32 rsx_ctxaddr = ctx_area ? ctx_area->addr : 0;
 
 	if (!rsx_ctxaddr || vm::falloc(rsx_ctxaddr, 0x400000) != rsx_ctxaddr)
 		fmt::throw_exception("Failed to alloc rsx context.");
@@ -898,7 +890,7 @@ s32 cellGcmAddressToOffset(u32 address, vm::ptr<u32> offset)
 	{
 		result = address - 0xC0000000;
 	}
-	// Address in main memory else check 
+	// Address in main memory else check
 	else
 	{
 		const u32 upper12Bits = offsetTable.ioAddress[address >> 20];

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -884,7 +884,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1 && values[1] & ~0x3fff0u)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: IL -> 0x%x", pos, values[1]);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: IL -> 0x%x", pos, values[1]);
 			}
 
 			break;
@@ -897,7 +897,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1 && values[1] & ~0x3fff0u)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: ILA -> 0x%x", pos, values[1]);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: ILA -> 0x%x", pos, values[1]);
 			}
 
 			break;
@@ -910,7 +910,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1 && values[1] & ~0x3fff0u)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: ILH -> 0x%x", pos, values[1]);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: ILH -> 0x%x", pos, values[1]);
 			}
 
 			break;
@@ -923,7 +923,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1 && values[1] & ~0x3fff0u)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: ILHU -> 0x%x", pos, values[1]);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: ILHU -> 0x%x", pos, values[1]);
 			}
 
 			break;
@@ -935,7 +935,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1 && op.i16 % 16)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: IOHL, 0x%x", pos, op.i16);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: IOHL, 0x%x", pos, op.i16);
 			}
 
 			break;
@@ -961,7 +961,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: OR", pos);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: OR", pos);
 			}
 
 			break;
@@ -974,7 +974,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: ANDI", pos);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: ANDI", pos);
 			}
 
 			break;
@@ -987,7 +987,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: AND", pos);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: AND", pos);
 			}
 
 			break;
@@ -1000,7 +1000,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1 && op.si10 % 16)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: AI, 0x%x", pos, op.si10 + 0u);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: AI, 0x%x", pos, op.si10 + 0u);
 			}
 
 			break;
@@ -1036,7 +1036,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: SFI", pos);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: SFI", pos);
 			}
 
 			break;
@@ -1049,7 +1049,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: SF", pos);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: SF", pos);
 			}
 
 			break;
@@ -1060,7 +1060,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: ROTMI", pos);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: ROTMI", pos);
 			}
 
 			if (-op.i7 & 0x20)
@@ -1080,7 +1080,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op.rt == 1)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: SHLI", pos);
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: SHLI", pos);
 			}
 
 			if (op.i7 & 0x20)
@@ -1104,7 +1104,7 @@ std::vector<u32> spu_recompiler_base::block(const be_t<u32>* ls, u32 entry_point
 
 			if (op_rt == 1)
 			{
-				LOG_TODO(SPU, "[0x%x] Unexpected instruction on $SP: %s", pos, s_spu_iname.decode(data));
+				LOG_WARNING(SPU, "[0x%x] Unexpected instruction on $SP: %s", pos, s_spu_iname.decode(data));
 			}
 
 			break;
@@ -1982,7 +1982,7 @@ class spu_llvm_recompiler : public spu_recompiler_base, public cpu_translator
 			{
 				if (phi->getNumUses())
 				{
-					LOG_TODO(SPU, "[0x%x] $%u: Phi has uses :(", m_pos, index);
+					LOG_WARNING(SPU, "[0x%x] $%u: Phi has uses :(", m_pos, index);
 				}
 				else
 				{
@@ -3405,7 +3405,7 @@ public:
 				}
 			}
 
-			LOG_TODO(SPU, "[0x%x] MFC_WrTagUpdate: $%u is not a good constant", m_pos, +op.rt);
+			LOG_WARNING(SPU, "[0x%x] MFC_WrTagUpdate: $%u is not a good constant", m_pos, +op.rt);
 			break;
 		}
 		case MFC_LSA:
@@ -3702,7 +3702,7 @@ public:
 			}
 
 			// Fallback to unoptimized WRCH implementation (TODO)
-			LOG_TODO(SPU, "[0x%x] MFC_Cmd: $%u is not a constant", m_pos, +op.rt);
+			LOG_WARNING(SPU, "[0x%x] MFC_Cmd: $%u is not a constant", m_pos, +op.rt);
 			break;
 		}
 		case MFC_WrListStallAck:

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -211,7 +211,7 @@ s32 sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size)
 	}
 
 	const u32 end = (io >>= 20) + (size >>= 20);
-	for (u32 ea = RSXIOMem.ea[io]; io < end;) 
+	for (u32 ea = RSXIOMem.ea[io]; io < end;)
 	{
 		RSXIOMem.io[ea++] = 0xFFFF;
 		RSXIOMem.ea[io++] = 0xFFFF;
@@ -446,16 +446,11 @@ s32 sys_rsx_device_map(vm::ptr<u64> dev_addr, vm::ptr<u64> a2, u32 dev_id)
 		return CELL_EINVAL; // sys_rsx_device_map called twice
 	}
 
-	for (u32 addr = 0x30000000; addr < 0xC0000000; addr += 0x10000000)
+	if (const auto area = vm::find_map(0x10000000, 0x10000000, 0x403))
 	{
-		if (vm::map(addr, 0x10000000, 0x400))
-		{
-			vm::falloc(addr, 0x400000);
-
-			m_sysrsx->rsx_context_addr = *dev_addr = addr;
-
-			return CELL_OK;
-		}
+		vm::falloc(area->addr, 0x400000);
+		m_sysrsx->rsx_context_addr = *dev_addr = area->addr;
+		return CELL_OK;
 	}
 
 	return CELL_ENOMEM;

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -21,9 +21,10 @@ namespace vm
 	enum memory_location_t : uint
 	{
 		main,
-		user_space,
 		video,
 		stack,
+		user64k,
+		user1m,
 
 		memory_location_max,
 		any = 0xffffffff,
@@ -176,6 +177,9 @@ namespace vm
 
 	// Create new memory block with specified parameters and return it
 	std::shared_ptr<block_t> map(u32 addr, u32 size, u64 flags = 0);
+
+	// Create new memory block with at arbitrary position with specified alignment
+	std::shared_ptr<block_t> find_map(u32 size, u32 align, u64 flags = 0);
 
 	// Delete existing memory block with specified start address, return it
 	std::shared_ptr<block_t> unmap(u32 addr, bool must_be_empty = false);

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -28,7 +28,8 @@ namespace rsx
 
 		// 'fake' initialize usermemory
 		// todo: seriously, need to probly watch the replay memory map and just make sure its mapped before we copy rather than do this
-		vm::falloc(0x20000000, 0x10000000, vm::user_space);
+		const auto user_mem = vm::get(vm::user64k);
+		vm::falloc(user_mem->addr, 0x10000000);
 
 		return contextInfo.context_id;
 	}
@@ -37,7 +38,7 @@ namespace rsx
 	{
 		u32 fifo_size = 4;
 
-		// run through replay commands to figure out how big command buffer needs to be 
+		// run through replay commands to figure out how big command buffer needs to be
 		// technically we could do this in batches if it gets too big, but we should be fine
 		// as we aren't allocating anything on main memory, although it may make issues with iooffset later
 		for (const auto& rc : frame->replay_commands)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1304,7 +1304,7 @@ void Emulator::Resume()
 
 		std::string dump;
 
-		for (u32 i = 0x10000; i < 0x30000000;)
+		for (u32 i = 0x10000; i < 0x20000000;)
 		{
 			if (vm::check_addr(i))
 			{

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -63,14 +63,14 @@ void kernel_explorer::Update()
 {
 	m_tree->clear();
 
-	const auto vm_block = vm::get(vm::user_space);
+	const auto dct = fxm::get_always<lv2_memory_container>();
 
-	if (!vm_block)
+	if (!dct)
 	{
 		return;
 	}
 
-	const u32 total_memory_usage = vm_block->used();
+	const u32 total_memory_usage = dct->used;
 
 	QTreeWidgetItem* root = new QTreeWidgetItem();
 	root->setText(0, qstr(fmt::format("Process, ID = 0x00000001, Total Memory Usage = 0x%x (%0.2f MB)", total_memory_usage, (float)total_memory_usage / (1024 * 1024))));


### PR DESCRIPTION
Should automatically try to read split files with extensions 66600, 66601 in the case the original file is not found.