### PR TITLE
Unbreak build with Clang 7

### DIFF
--- a/rpcs3/cmake_modules/ConfigureCompiler.cmake
+++ b/rpcs3/cmake_modules/ConfigureCompiler.cmake
@@ -53,8 +53,6 @@ if(NOT MSVC)
 		# This fixes 'some' of the st11range issues. See issue #2516
 		if(APPLE)
 			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-image_base,0x10000 -Wl,-pagezero_size,0x10000")
-		else()
-			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -image-base=0x10000")
 		endif()
 	endif()
 


### PR DESCRIPTION
`--image-base=value` is only supported by LLD but Clang doesn't forward many options to linker by default. See [error log](http://package18.nyi.freebsd.org/data/headamd64PR230355-default/2018-08-11_19h01m06s/logs/errors/rpcs3-0.0.5.703.log)

```
$ clang60 -image-base=0x10000 -fuse-ld=lld /path/to/test.c
clang-6.0: warning: argument unused during compilation: '-image-base=0x10000' [-Wunused-command-line-argument]
$ clang70 -image-base=0x10000 -fuse-ld=lld  /path/to/test.c
clang-7.0: error: unknown argument: '-image-base=0x10000'
```
