### PR TITLE
rsx-capture: unbreak

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -22,7 +22,7 @@ error_code sys_memory_allocate(u32 size, u64 flags, vm::ptr<u32> alloc_addr)
 	const u32 align =
 		flags == SYS_MEMORY_PAGE_SIZE_1M ? 0x100000 :
 		flags == SYS_MEMORY_PAGE_SIZE_64K ? 0x10000 :
-		flags == 0 ? 0x10000 : 0;
+		flags == 0 ? 0x100000 : 0;
 
 	if (!align)
 	{
@@ -57,7 +57,7 @@ error_code sys_memory_allocate_from_container(u32 size, u32 cid, u64 flags, vm::
 	const u32 align =
 		flags == SYS_MEMORY_PAGE_SIZE_1M ? 0x100000 :
 		flags == SYS_MEMORY_PAGE_SIZE_64K ? 0x10000 :
-		flags == 0 ? 0x10000 : 0;
+		flags == 0 ? 0x100000 : 0;
 
 	if (!align)
 	{

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -881,10 +881,10 @@ namespace vm
 			g_locations =
 			{
 				std::make_shared<block_t>(0x00010000, 0x1FFF0000), // main
-				std::make_shared<block_t>(0xC0000000, 0x10000000), // video
-				std::make_shared<block_t>(0xD0000000, 0x10000000), // stack
 				nullptr, // user 64k pages
 				nullptr, // user 1m pages
+				std::make_shared<block_t>(0xC0000000, 0x10000000), // video
+				std::make_shared<block_t>(0xD0000000, 0x10000000), // stack
 				std::make_shared<block_t>(0xE0000000, 0x20000000), // SPU reserved
 			};
 		}

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -21,10 +21,10 @@ namespace vm
 	enum memory_location_t : uint
 	{
 		main,
-		video,
-		stack,
 		user64k,
 		user1m,
+		video,
+		stack,
 
 		memory_location_max,
 		any = 0xffffffff,

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -12,6 +12,11 @@ namespace rsx
 {
 	be_t<u32> rsx_replay_thread::allocate_context()
 	{
+		// 'fake' initialize usermemory
+		// todo: seriously, need to probly watch the replay memory map and just make sure its mapped before we copy rather than do this
+		const auto user_mem = vm::get(vm::user64k);
+		vm::falloc(user_mem->addr, 0x10000000);
+
 		const u32 contextAddr = vm::alloc(sizeof(rsx_context), vm::main);
 		if (contextAddr == 0)
 			fmt::throw_exception("Capture Replay: context alloc failed");
@@ -25,11 +30,6 @@ namespace rsx
 
 		if (sys_rsx_context_allocate(vm::get_addr(&contextInfo.context_id), vm::get_addr(&contextInfo.dma_addr), vm::get_addr(&contextInfo.driver_info), vm::get_addr(&contextInfo.reports_addr), contextInfo.mem_handle, 0) != CELL_OK)
 			fmt::throw_exception("Capture Replay: sys_rsx_context_allocate failed!");
-
-		// 'fake' initialize usermemory
-		// todo: seriously, need to probly watch the replay memory map and just make sure its mapped before we copy rather than do this
-		const auto user_mem = vm::get(vm::user64k);
-		vm::falloc(user_mem->addr, 0x10000000);
 
 		return contextInfo.context_id;
 	}


### PR DESCRIPTION
- Fix rsx capture's user mem base allocation by moving it before `sys_rsx_device_map`. fixes the regression caused by #4975 

- sys_memory: Fix default alignment if no page flags are specified. [testcase](https://github.com/elad335/myps3tests/blob/master/ppu_tests/default%20memory%20alignment/expected.txt)
