### PR TITLE
Fixup for nvidia vulkan performance problems

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1682,11 +1682,19 @@ public:
 			VkPresentModeKHR swapchain_present_mode = VK_PRESENT_MODE_FIFO_KHR;
 			std::vector<VkPresentModeKHR> preferred_modes;
 
-			//List of preferred modes in decreasing desirability
-			if (g_cfg.video.vsync)
-				preferred_modes = { VK_PRESENT_MODE_MAILBOX_KHR };
-			else if (!g_cfg.video.vk.force_fifo)
-				preferred_modes = { VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR, VK_PRESENT_MODE_MAILBOX_KHR };
+			if (!g_cfg.video.vk.force_fifo)
+			{
+				// List of preferred modes in decreasing desirability
+				// NOTE: Always picks "triple-buffered vsync" types if possible
+				if (g_cfg.video.vsync)
+				{
+					preferred_modes = { VK_PRESENT_MODE_MAILBOX_KHR };
+				}
+				else
+				{
+					preferred_modes = { VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR };
+				}
+			}
 
 			bool mode_found = false;
 			for (VkPresentModeKHR preferred_mode : preferred_modes)


### PR DESCRIPTION
Newer nvidia drivers are not exposing IMMEDIATE present mode unless you change options in nvidia control panel. This can cause severe performance degradation unless the vsync option is set to "off" in control panel.

This commit prefers MAILBOX mode over FIFO_RELAXED which seems to be just as slow as FIFO and allows performance closer to the true IMMEDIATE mode. Note that vsync on nvidia cards is broken under vulkan, but this is not an rpcs3 bug.