### PR TITLE
Rsx: fix unknown cull faces

### DIFF
--- a/rpcs3/Emu/RSX/gcm_enums.cpp
+++ b/rpcs3/Emu/RSX/gcm_enums.cpp
@@ -232,7 +232,7 @@ namespace rsx
 		case cull_face::front: return "front";
 		case cull_face::front_and_back: return "front and back";
 		}
-		fmt::throw_exception("Unexpected enum found" HERE);
+		return "Unknown cull face value";
 	}
 
 	std::string to_string(surface_target target)
@@ -825,17 +825,6 @@ rsx::front_face rsx::to_front_face(u16 in)
 	case CELL_GCM_CCW: return rsx::front_face::ccw;
 	}
 	fmt::throw_exception("Unknown front face 0x%x" HERE, in);
-}
-
-rsx::cull_face rsx::to_cull_face(u16 in)
-{
-	switch (in)
-	{
-	case CELL_GCM_FRONT_AND_BACK: return rsx::cull_face::front_and_back;
-	case CELL_GCM_FRONT: return rsx::cull_face::front;
-	case CELL_GCM_BACK: return rsx::cull_face::back;
-	}
-	fmt::throw_exception("Unknown cull face 0x%x" HERE, in);
 }
 
 enum

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -271,14 +271,12 @@ namespace rsx
 
 	front_face to_front_face(u16 in);
 
-	enum class cull_face : u8
+	enum class cull_face : u32
 	{
-		front,
-		back,
-		front_and_back,
+		front = 0x0404, // CELL_GCM_FRONT
+		back = 0x0405, // CELL_GCM_BACK
+		front_and_back = 0x0408, // CELL_GCM_FRONT_AND_BACK
 	};
-
-	cull_face to_cull_face(u16 in);
 
 	enum class user_clip_plane_op : u8
 	{

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -2927,14 +2927,13 @@ struct registers_decoder<NV4097_SET_CULL_FACE>
 		union
 		{
 			u32 raw_value;
-			bitfield_decoder_t<0, 32> cull_face_mode;
 		} m_data;
 	public:
 		decoded_type(u32 raw_value) { m_data.raw_value = raw_value; }
 
 		cull_face cull_face_mode() const
 		{
-			return to_cull_face(m_data.cull_face_mode);
+			return static_cast<cull_face>(m_data.raw_value);
 		}
 	};
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1170,8 +1170,7 @@ namespace rsx
 		rsx->flip(arg);
 		// After each flip PS3 system is executing a routine that changes registers value to some default.
 		// Some game use this default state (SH3).
-		if (rsx->isHLE)
-			rsx->reset();
+		rsx->reset();
 
 		rsx->last_flip_time = get_system_time() - 1000000;
 		rsx->flip_status = CELL_GCM_DISPLAY_FLIP_STATUS_DONE;
@@ -1214,7 +1213,6 @@ namespace rsx
 		{
 			static void impl(thread* rsx, u32 _reg, u32 arg)
 			{
-				rsx->reset();
 				sys_rsx_context_attribute(0x55555555, 0x102, index, arg, 0, 0);
 			}
 		};

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1314,6 +1314,10 @@ namespace rsx
 		registers[NV4097_SET_CONTEXT_DMA_COLOR_D] = CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER;
 		registers[NV4097_SET_CONTEXT_DMA_ZETA] = CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER;
 
+		// Vertex shader attributes masks
+		registers[NV4097_SET_VERTEX_ATTRIB_INPUT_MASK] = 0xFFFF;
+		registers[NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK] = 0x3FFFFF;
+
 		registers[NV3089_SET_CONTEXT_SURFACE] = 0x313371C3; // CELL_GCM_CONTEXT_SURFACE2D
 
 		for (auto& tex : fragment_textures) tex.init();

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -127,8 +127,9 @@ namespace rsx
 
 	struct rsx_state
 	{
-	protected:
-		std::array<u32, 0x10000 / 4> registers;
+	public:
+		std::array<u32, 0x10000 / 4> registers{};
+		u32 register_previous_value;
 
 		template<u32 opcode>
 		using decoded_type = typename registers_decoder<opcode>::decoded_type;
@@ -140,7 +141,6 @@ namespace rsx
 			return decoded_type<opcode>(register_value);
 		}
 
-	public:
 		rsx_state &operator=(const rsx_state& in)
 		{
 			registers = in.registers;
@@ -158,8 +158,6 @@ namespace rsx
 		std::array<u32[4], 512> transform_constants;
 
 		draw_clause current_draw_clause;
-
-		bool register_change_flag;
 
 		/**
 		* RSX can sources vertex attributes from 2 places:


### PR DESCRIPTION
- Add default vertex shader attributes values in `rsx_state::reset()`
- Fix method registers reset, move it to flip command instead of a driver flip. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/driver%20flip)
testcase is writing a non-initial value into `NV4097_SET_CULL_FACE`, does a driver flip on head 0 and head 1, and emits a crash dump. the value written remained.
- Ignore unknown culll face modes. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/unknown%20cull%20face)
testcase is writing a non-initial mode `CELL_GCM_FRONT` into `NV4097_SET_CULL_FACE`, then writes -1, and emits a crash dump, regiser's value is `CELL_GCM_FRONT`.

fixes #2444 , enables [Monster Jam: Path of Destruction](https://forums.rpcs3.net/thread-188969.html) to go in-game.
![image](https://user-images.githubusercontent.com/18193363/44625197-3e04be00-a90c-11e8-85bb-033253ee682c.png)
