### PR TITLE
Git Revision Fix

### DIFF
--- a/Utilities/git-version-gen.cmd
+++ b/Utilities/git-version-gen.cmd
@@ -69,14 +69,14 @@ if defined APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH (
 		rem // Otherwise, GIT_BRANCH=branch
 		set GIT_BRANCH=%APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%
 	)
-	
+
 	rem // Make GIT_VERSION the last commit (shortened); Don't include commit count on non-master builds
-	for /F %%I IN ('call %GIT% rev-parse --short HEAD') do set GIT_VERSION=%%I
-	
+	for /F %%I IN ('call %GIT% rev-parse --short=8 HEAD') do set GIT_VERSION=%%I
+
 ) else (
 	rem // Get last commit (shortened) and concat after commit count in GIT_VERSION
-	for /F %%I IN ('call %GIT% rev-parse --short HEAD') do set GIT_VERSION=%COMMIT_COUNT%-%%I
-	
+	for /F %%I IN ('call %GIT% rev-parse --short=8 HEAD') do set GIT_VERSION=%COMMIT_COUNT%-%%I
+
 	for /F %%I IN ('call %GIT% rev-parse --abbrev-ref HEAD') do set GIT_BRANCH=%%I
 )
 

--- a/Utilities/git-version-gen.cmd
+++ b/Utilities/git-version-gen.cmd
@@ -71,11 +71,11 @@ if defined APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH (
 	)
 
 	rem // Make GIT_VERSION the last commit (shortened); Don't include commit count on non-master builds
-	for /F %%I IN ('call %GIT% rev-parse --short=8 HEAD') do set GIT_VERSION=%%I
+	for /F %%I IN ('call %GIT% rev-parse --short^=8 HEAD') do set GIT_VERSION=%%I
 
 ) else (
 	rem // Get last commit (shortened) and concat after commit count in GIT_VERSION
-	for /F %%I IN ('call %GIT% rev-parse --short=8 HEAD') do set GIT_VERSION=%COMMIT_COUNT%-%%I
+	for /F %%I IN ('call %GIT% rev-parse --short^=8 HEAD') do set GIT_VERSION=%COMMIT_COUNT%-%%I
 
 	for /F %%I IN ('call %GIT% rev-parse --abbrev-ref HEAD') do set GIT_BRANCH=%%I
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
 - ps: | # set env vars for versioning
     $env:COMM_TAG = $(git describe --tags $(git rev-list --tags --max-count=1))
     $env:COMM_COUNT = $(git rev-list --count HEAD)
-    $env:COMM_HASH = $env:APPVEYOR_REPO_COMMIT.Substring(0,8)
+    $env:COMM_HASH = $(git rev-parse --short=8 HEAD)
 
     if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
         $env:BUILD = "rpcs3-{0}-{1}_win64.7z" -f $env:COMM_TAG, $env:COMM_HASH

--- a/rpcs3/git-version.cmake
+++ b/rpcs3/git-version.cmake
@@ -12,7 +12,7 @@ if(GIT_FOUND AND EXISTS "${SOURCE_DIR}/../.git/")
 	if(NOT ${exit_code} EQUAL 0)
 		message(WARNING "git rev-list failed, unable to include version.")
 	endif()
-	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short=8 HEAD
 		WORKING_DIRECTORY ${SOURCE_DIR}
 		RESULT_VARIABLE exit_code
 		OUTPUT_VARIABLE GIT_VERSION_)
@@ -49,7 +49,7 @@ if(EXISTS ${GIT_VERSION_FILE})
 		REGEX "${GIT_VERSION}")
 	if(NOT "${match}" STREQUAL "")
 		set(GIT_VERSION_UPDATE "0")
-	endif()	
+	endif()
 endif()
 
 set(code_string "// This is a generated file.\n\n"


### PR DESCRIPTION
The git revision in the rpcs3 version string doesn't match the AppVeyor revision (sometimes), this PR should hopefully fix that.

![ver](https://user-images.githubusercontent.com/36057965/44667584-d9d51d80-aa23-11e8-808b-368321328d84.png)

The new revision will always be trimmed (or extended) to exactly 8 chars.

This however doesn't match the GitHub trimmed hash (7 chars).