### PR TITLE
3rdparty: remove optional submodule + misc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,9 +26,6 @@
 	url = https://github.com/RPCS3/hidapi
 	branch = master
 	ignore = dirty
-[submodule "3rdparty/Optional"]
-	path = 3rdparty/Optional
-	url = https://github.com/akrzemi1/Optional.git
 [submodule "3rdparty/pugixml"]
 	path = 3rdparty/pugixml
 	url = https://github.com/zeux/pugixml

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
      fi;
 
 before_script:
-  - git submodule update --init asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng 3rdparty/cereal 3rdparty/hidapi 3rdparty/Optional 3rdparty/xxHash 3rdparty/yaml-cpp Vulkan/glslang
+  - git submodule update --init asmjit 3rdparty/ffmpeg 3rdparty/pugixml 3rdparty/GSL 3rdparty/libpng 3rdparty/cereal 3rdparty/hidapi 3rdparty/xxHash 3rdparty/yaml-cpp Vulkan/glslang
   - mkdir build ; cd build
   - if [ "$TRAVIS_PULL_REQUEST" = false ]; then
       export CXXFLAGS="$CXXFLAGS -DBRANCH=$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,6 @@ install:
       3rdparty/GSL `
       3rdparty/hidapi `
       3rdparty/libpng `
-      3rdparty/Optional `
       3rdparty/pugixml `
       3rdparty/xxHash `
       3rdparty/yaml-cpp `

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -328,7 +328,6 @@ ${LLVM_INCLUDE_DIRS}
 "${RPCS3_SRC_DIR}/../3rdparty/GL"
 "${RPCS3_SRC_DIR}/../3rdparty/stblib"
 "${RPCS3_SRC_DIR}/../3rdparty/cereal/include"
-"${RPCS3_SRC_DIR}/../3rdparty/Optional"
 "${RPCS3_SRC_DIR}/../3rdparty/discord-rpc/include"
 "${RPCS3_SRC_DIR}/../3rdparty/xxHash"
 "${RPCS3_SRC_DIR}/../3rdparty/GPUOpen/include"

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -487,8 +487,8 @@ void GLGSRender::end()
 
 	if (upload_info.index_info)
 	{
-		const GLenum index_type = std::get<0>(upload_info.index_info.value());
-		const u32 index_offset = std::get<1>(upload_info.index_info.value());
+		const GLenum index_type = std::get<0>(*upload_info.index_info);
+		const u32 index_offset = std::get<1>(*upload_info.index_info);
 		const bool restarts_valid = gl::is_primitive_native(rsx::method_registers.current_draw_clause.primitive) && !rsx::method_registers.current_draw_clause.is_disjoint_primitive;
 
 		if (gl_state.enable(restarts_valid && rsx::method_registers.restart_index_enabled(), GL_PRIMITIVE_RESTART))

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -4,8 +4,6 @@
 #include "GLTexture.h"
 #include "GLTextureCache.h"
 #include "GLRenderTargets.h"
-#include "restore_new.h"
-#include "define_new_memleakdetect.h"
 #include "GLProgramBuffer.h"
 #include "GLTextOut.h"
 #include "GLOverlays.h"

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -20,8 +20,6 @@
 #include "Utilities/geometry.h"
 #include "Capture/rsx_trace.h"
 #include "Capture/rsx_replay.h"
-#include "restore_new.h"
-#include "define_new_memleakdetect.h"
 
 #include "Emu/Cell/lv2/sys_rsx.h"
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1484,7 +1484,7 @@ void VKGSRender::end()
 		const u32 index_count = upload_info.vertex_draw_count;
 		VkDeviceSize offset;
 
-		std::tie(offset, index_type) = upload_info.index_info.value();
+		std::tie(offset, index_type) = *upload_info.index_info;
 		vkCmdBindIndexBuffer(*m_current_command_buffer, m_index_buffer_ring_info.heap->value, offset, index_type);
 
 		if (single_draw)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -6,8 +6,6 @@
 #include "VKFormats.h"
 #include "VKTextOut.h"
 #include "VKOverlays.h"
-#include "restore_new.h"
-#include "define_new_memleakdetect.h"
 #include "VKProgramBuffer.h"
 #include "../GCM.h"
 #include "../rsx_utils.h"

--- a/rpcs3/cmake_modules/ConfigureCompiler.cmake
+++ b/rpcs3/cmake_modules/ConfigureCompiler.cmake
@@ -2,13 +2,9 @@ cmake_minimum_required(VERSION 3.8.2)
 # Check and configure compiler options for RPCS3
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-	# GCC 4.9 and lower are too old
-	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
-		message(FATAL_ERROR "RPCS3 requires at least gcc-5.1.")
-	endif()
-	# GCC 6.1 is blacklisted
-	if(CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 6.1)
-		message(FATAL_ERROR "RPCS3 can't be compiled with gcc-6.1, see #1691.")
+	# GCC 7.3 or latter is required
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.3)
+		message(FATAL_ERROR "RPCS3 requires at least gcc-7.3.")
 	endif()
 
 	# Set compiler options here
@@ -17,9 +13,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 	add_compile_options(-Wno-attributes -Wno-enum-compare -Wno-invalid-offsetof)
 
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-	# Clang 3.4 and lower are too old
-	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)
-		message(FATAL_ERROR "RPCS3 requires at least clang-3.5.")
+	# Clang 5.0 or latter is required
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+		message(FATAL_ERROR "RPCS3 requires at least clang-5.0.")
 	endif()
 
 	# Set compiler options here


### PR DESCRIPTION
With C++17, the optional submodule is not necessary anymore.