### PR TITLE
Unbreak build on FreeBSD with GCC

### DIFF
--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -6,6 +6,7 @@
 #include "Utilities/sysinfo.h"
 #include "Utilities/Thread.h"
 #include "rpcs3_version.h"
+#include <cstring>
 #include <string>
 #include <unordered_map>
 #include <thread>

--- a/Utilities/sync.h
+++ b/Utilities/sync.h
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #else
 #endif
+#include <algorithm>
 #include <ctime>
 #include <chrono>
 #include <mutex>


### PR DESCRIPTION
Tested on GCC 7.3.0/8.2.0. Older versions have incomplete C++17 support. Note, FreeBSD on x86_64 defaults to Clang but switching to GCC maybe useful to compare performance or for debugging.
