### PR TITLE
Fix cellMic regression from #4467

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -58,8 +58,8 @@ s32 cellMicInit()
 s32 cellMicEnd()
 {
 	cellMic.trace("cellMicEnd()");
-	const auto micThread = fxm::withdraw<mic_thread>();
 	micInited = false;
+	const auto micThread = fxm::withdraw<mic_thread>();
 	if (!micThread)
 		return CELL_MIC_ERROR_NOT_INIT;
 


### PR DESCRIPTION
`cellMicEnd` would get stuck waiting for the cellMic thread to finish, but it never does because `micInited` is still true.

Fixes Resistance: Fall of Mankind getting stuck after the menu.