### PR TITLE
rsx: Fix FP temp register count

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -111,6 +111,8 @@ void FragmentProgramDecompiler::SetDst(std::string code, bool append_mask)
 	}
 
 	u32 reg_index = dst.fp16 ? dst.dest_reg >> 1 : dst.dest_reg;
+
+	verify(HERE), reg_index < temp_registers.size();
 	temp_registers[reg_index].tag(dst.dest_reg, !!dst.fp16, dst.mask_x, dst.mask_y, dst.mask_z, dst.mask_w);
 }
 

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
@@ -134,7 +134,7 @@ class FragmentProgramDecompiler
 	std::vector<u32> m_end_offsets;
 	std::vector<u32> m_else_offsets;
 
-	std::array<temp_register, 24> temp_registers;
+	std::array<temp_register, 64> temp_registers;
 
 	std::string GetMask();
 


### PR DESCRIPTION
Credit to @elad335 for help isolating the issue.

- Fixes a buffer overflow in FP decompiler and adds an assert to keep this from happening again. Fixes some rare segfaults when a shader consumes more than 24 temp registers (using R25+ would corrupt the heap).