### PR TITLE
[vk] Check for BGRA8 linear image to support blitting

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -20,9 +20,13 @@ namespace vk
 			&& !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
 			&& !!(props.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT);
 
-		//Hide d24_s8 if force high precision z buffer is enabled
+		// Hide d24_s8 if force high precision z buffer is enabled
 		if (g_cfg.video.force_high_precision_z_buffer && result.d32_sfloat_s8)
 			result.d24_unorm_s8 = false;
+
+		// Checks if BGRA8 images can be used for blitting
+		vkGetPhysicalDeviceFormatProperties(dev, VK_FORMAT_B8G8R8A8_UNORM, &props);
+		result.bgra8_linear = !!(props.linearTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT);
 
 		return result;
 	}

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -185,6 +185,7 @@ namespace vk
 	{
 		bool d24_unorm_s8;
 		bool d32_sfloat_s8;
+		bool bgra8_linear;
 	};
 
 	// Memory Allocator - base class

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1043,7 +1043,12 @@ namespace vk
 
 		vk::image *upload_image_simple(vk::command_buffer& cmd, u32 address, u32 width, u32 height)
 		{
-			//Uploads a linear memory range as a BGRA8 texture
+			if (!m_formats_support.bgra8_linear)
+			{
+				return nullptr;
+			}
+
+			// Uploads a linear memory range as a BGRA8 texture
 			auto image = std::make_unique<vk::image>(*m_device, m_memory_types.host_visible_coherent,
 				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
 				VK_IMAGE_TYPE_2D,


### PR DESCRIPTION
The result of `upload_image_simple` is used as a blit source, so we need to make sure it's possible.