### PR TITLE
[vk] check for attachment format properties before pre-creating render passes

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
@@ -206,6 +206,7 @@ public:
 	void add_pipeline_entry(RSXVertexProgram &vp, RSXFragmentProgram &fp, vk::pipeline_props &props, Args&& ...args)
 	{
 		props.render_pass = m_render_pass_data[props.render_pass_location];
+		verify("Usupported renderpass configuration" HERE), props.render_pass != VK_NULL_HANDLE;
 		vp.skip_vertex_input_check = true;
 		get_graphics_pipeline(vp, fp, props, false, std::forward<Args>(args)...);
 	}

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -255,6 +255,8 @@ namespace vk
 
 		void init(vk::render_device &dev, VkRenderPass &render_pass)
 		{
+			verify(HERE), render_pass != VK_NULL_HANDLE;
+
 			//At worst case, 1 char = 16*16*8 bytes (average about 24*8), so ~256K for 128 chars. Allocating 512k for verts
 			//uniform params are 8k in size, allocating for 120 lines (max lines at 4k, one column per row. Can be expanded
 			m_vertex_buffer.reset( new vk::buffer(dev, 524288, dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0));


### PR DESCRIPTION
Fixes #5108
Ideally, the `gpu_formats_support` struct would know which of the formats we can use as render targets. However, it was tempting enough to performs the checks in-place (at `get_precomputed_render_passes`) as opposed to having a field per format in the support struct. So I went the easier route. Let me know if you'd like the support struct to do the queries instead.