### PR TITLE
rsx: remove shader address check hack

### DIFF
--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -81,24 +81,23 @@ namespace rsx
 
 			// capture fragment shader mem
 			const u32 shader_program = method_registers.shader_program_address();
-			if (shader_program != 0)
-			{
-				const u32 program_location = (shader_program & 0x3) - 1;
-				const u32 program_offset   = (shader_program & ~0x3);
+			verify("Null shader address!" HERE), shader_program != 0;
 
-				const u32 addr          = get_address(program_offset, program_location);
-				const auto program_info = program_hash_util::fragment_program_utils::analyse_fragment_program(vm::base(addr));
-				const u32 program_start = program_info.program_start_offset;
-				const u32 ucode_size    = program_info.program_ucode_length;
+			const u32 program_location = (shader_program & 0x3) - 1;
+			const u32 program_offset   = (shader_program & ~0x3);
 
-				frame_capture_data::memory_block block;
-				block.addr     = addr;
-				block.ioOffset = get_io_offset(program_offset, program_location);
-				frame_capture_data::memory_block_data block_data;
-				block_data.data.resize(ucode_size + program_start);
-				std::memcpy(block_data.data.data(), vm::base(addr), ucode_size + program_start);
-				insert_mem_block_in_map(mem_changes, std::move(block), std::move(block_data));
-			}
+			const u32 addr          = get_address(program_offset, program_location);
+			const auto program_info = program_hash_util::fragment_program_utils::analyse_fragment_program(vm::base(addr));
+			const u32 program_start = program_info.program_start_offset;
+			const u32 ucode_size    = program_info.program_ucode_length;
+
+			frame_capture_data::memory_block block;
+			block.addr     = addr;
+			block.ioOffset = get_io_offset(program_offset, program_location);
+			frame_capture_data::memory_block_data block_data;
+			block_data.data.resize(ucode_size + program_start);
+			std::memcpy(block_data.data.data(), vm::base(addr), ucode_size + program_start);
+			insert_mem_block_in_map(mem_changes, std::move(block), std::move(block_data));
 
 			// vertex shader is passed in registers, so it can be ignored
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -181,8 +181,7 @@ void GLGSRender::end()
 	std::chrono::time_point<steady_clock> state_check_start = steady_clock::now();
 
 	if (skip_frame || !framebuffer_status_valid ||
-		(conditional_render_enabled && conditional_render_test_failed) ||
-		!check_program_state())
+		(conditional_render_enabled && conditional_render_test_failed))
 	{
 		rsx::thread::end();
 		return;
@@ -1138,11 +1137,6 @@ bool GLGSRender::do_method(u32 cmd, u32 arg)
 	}
 
 	return false;
-}
-
-bool GLGSRender::check_program_state()
-{
-	return (rsx::method_registers.shader_program_address() != 0);
 }
 
 bool GLGSRender::load_program()

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -359,7 +359,6 @@ private:
 	void clear_surface(u32 arg);
 	void init_buffers(rsx::framebuffer_creation_context context, bool skip_reading = false);
 
-	bool check_program_state();
 	bool load_program();
 	void load_program_env(const gl::vertex_upload_info& upload_info);
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1946,11 +1946,6 @@ namespace rsx
 		auto &result = current_fragment_program = {};
 
 		const u32 shader_program = rsx::method_registers.shader_program_address();
-		if (shader_program == 0)
-		{
-			current_fp_metadata = {};
-			return;
-		}
 
 		const u32 program_location = (shader_program & 0x3) - 1;
 		const u32 program_offset = (shader_program & ~0x3);
@@ -2083,9 +2078,6 @@ namespace rsx
 		auto &result = current_fragment_program = {};
 
 		const u32 shader_program = rsx::method_registers.shader_program_address();
-		if (shader_program == 0)
-			return;
-
 		const u32 program_location = (shader_program & 0x3) - 1;
 		const u32 program_offset = (shader_program & ~0x3);
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1084,8 +1084,7 @@ void VKGSRender::close_render_pass()
 void VKGSRender::end()
 {
 	if (skip_frame || !framebuffer_status_valid || renderer_unavailable ||
-		(conditional_render_enabled && conditional_render_test_failed) ||
-		!check_program_status())
+		(conditional_render_enabled && conditional_render_test_failed))
 	{
 		rsx::thread::end();
 		return;
@@ -2192,11 +2191,6 @@ bool VKGSRender::do_method(u32 cmd, u32 arg)
 	default:
 		return false;
 	}
-}
-
-bool VKGSRender::check_program_status()
-{
-	return (rsx::method_registers.shader_program_address() != 0);
 }
 
 bool VKGSRender::load_program()

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -404,7 +404,6 @@ private:
 	vk::vertex_upload_info upload_vertex_data();
 
 public:
-	bool check_program_status();
 	bool load_program();
 	void load_program_env(const vk::vertex_upload_info& vertex_info);
 	void init_buffers(rsx::framebuffer_creation_context context, bool skip_reading = false);

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -461,6 +461,8 @@ namespace rsx
 			if (!(rsx::method_registers.current_draw_clause.first_count_commands.empty() &&
 			        rsx::method_registers.current_draw_clause.inline_vertex_array.empty()))
 			{
+				verify("Null shader address!" HERE), (method_registers.shader_program_address());
+
 				rsxthr->end();
 			}
 		}


### PR DESCRIPTION
Real hardware doesnt ignore draw calls when the program address is 0. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/Fragment%20program%20address%200)

This hack was probably there as a workaround for `rsx_state::reset()` resets the program address when it shouldn't. now that the reset is fixed, this hack can be happily removed.