### PR TITLE
ppu: Fix extreme reservation corner case

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1005,11 +1005,13 @@ static T ppu_load_acquire_reservation(ppu_thread& ppu, u32 addr)
 
 extern u32 ppu_lwarx(ppu_thread& ppu, u32 addr)
 {
+	ppu.lr_64 = false;
 	return ppu_load_acquire_reservation<u32>(ppu, addr);
 }
 
 extern u64 ppu_ldarx(ppu_thread& ppu, u32 addr)
 {
+	ppu.lr_64 = true;
 	return ppu_load_acquire_reservation<u64>(ppu, addr);
 }
 
@@ -1063,6 +1065,8 @@ const auto ppu_stwcx_tx = build_function_asm<bool(*)(u32 raddr, u64 rtime, u64 r
 extern bool ppu_stwcx(ppu_thread& ppu, u32 addr, u32 reg_value)
 {
 	atomic_be_t<u32>& data = vm::_ref<atomic_be_t<u32>>(addr);
+
+	if (UNLIKELY(ppu.lr_64)) ppu.rdata >>= 32;
 
 	if (ppu.raddr != addr || ppu.rdata != data.load() || ppu.rtime != vm::reservation_acquire(addr, sizeof(u32)))
 	{

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -135,6 +135,7 @@ public:
 	u32 raddr{0}; // Reservation addr
 	u64 rtime{0};
 	u64 rdata{0}; // Reservation data
+	bool lr_64{false}; // Reservation size (true for 64 bit, false for 32 bit)
 
 	atomic_t<u32> prio{0}; // Thread priority (0..3071)
 	const u32 stack_size; // Stack size


### PR DESCRIPTION
This corner case happens when the ppu executes an atomic loop with `ldarx` and `stwcx` instructions.

Brings [Blade kitten](https://forums.rpcs3.net/thread-178199.html) from loadable straight into ingame.
![image](https://user-images.githubusercontent.com/18193363/45449636-62b7ae80-b6de-11e8-914f-5e3f53cf7afb.png)
