### PR TITLE
rsx: Add a default shader address state

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -388,6 +388,8 @@ namespace rsx
 
 		on_init_thread();
 
+		// Special value in initialization, this is not set by a context reset
+		method_registers.registers[NV4097_SET_SHADER_PROGRAM] = (0 << 2) | CELL_GCM_LOCATION_LOCAL;
 		reset();
 
 		if (!zcull_ctrl)


### PR DESCRIPTION
description is in the [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/Fragment%20program%20address%200%20(2))'s code.
attempt to fix the regression from #5110 , hopefully the shader data in offset 0 in local memory is "valid".