### PR TITLE
rsx/vp: Fix ARL opcode

### DIFF
--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.h
@@ -70,7 +70,6 @@ struct VertexProgramDecompiler
 	std::string GetOptionalBranchCond();	//Conditional branch expression modified externally at runtime
 	std::string AddAddrMask();
 	std::string AddAddrReg();
-	std::string AddAddrRegWithoutMask();
 	std::string AddCondReg();
 	u32 GetAddr();
 	std::string Format(const std::string& code);


### PR DESCRIPTION
Fixes use of address registers in VP. Should fix broken animations in applications that use the vertex pipeline for effects like skinning e.g https://github.com/RPCS3/rpcs3/issues/5044