### PR TITLE
rsx: Clamp texture offsets

### DIFF
--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -8,7 +8,7 @@ namespace rsx
 {
 	u32 fragment_texture::offset() const
 	{
-		return registers[NV4097_SET_TEXTURE_OFFSET + (m_index * 8)];
+		return registers[NV4097_SET_TEXTURE_OFFSET + (m_index * 8)] & 0x7FFFFFFF;
 	}
 
 	u8 fragment_texture::location() const
@@ -279,7 +279,7 @@ namespace rsx
 
 	u32 vertex_texture::offset() const
 	{
-		return registers[NV4097_SET_VERTEX_TEXTURE_OFFSET + (m_index * 8)];
+		return registers[NV4097_SET_VERTEX_TEXTURE_OFFSET + (m_index * 8)] & 0x7FFFFFFF;
 	}
 
 	u8 vertex_texture::location() const

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -121,7 +121,7 @@ namespace rsx
 
 	bool fragment_texture::enabled() const
 	{
-		return location() <= 1 && ((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 31) & 0x1);
+		return ((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 31) & 0x1);
 	}
 
 	u16 fragment_texture::min_lod() const
@@ -349,7 +349,7 @@ namespace rsx
 
 	bool vertex_texture::enabled() const
 	{
-		return location() <= 1 && ((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 31) & 0x1);
+		return ((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 31) & 0x1);
 	}
 
 	u16 vertex_texture::min_lod() const


### PR DESCRIPTION
It seems like the highest bit of fragment texture offset is ignored by real hardware, and only that bit alone. This feature is used in a few insomniac games and caused a translation exception anytime it was used. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/TEXTURE_OFFSET)

Also remove texture location check as it seems to be incorrect as the usage of invalid locations throw an exception on realhw. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/TEXTURE_LOCATION)