### PR TITLE
spu: Fix MMIO thread index checking

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -716,7 +716,7 @@ void SPUThread::do_dma_transfer(const spu_mfc_cmd& args)
 		{
 			fmt::throw_exception("SPU MMIO used for RawSPU (cmd=0x%x, lsa=0x%x, ea=0x%llx, tag=0x%x, size=0x%x)" HERE, args.cmd, args.lsa, args.eal, args.tag, args.size);
 		}
-		else if (group && index < group->num && group->threads[index])
+		else if (group && group->threads[index])
 		{
 			auto& spu = static_cast<SPUThread&>(*group->threads[index]);
 


### PR DESCRIPTION
Threaded SPU identification number in group can be anywere from 0 to 255 and is not limited by the group's size. [testcase](https://github.com/elad335/myps3tests/tree/master/spu_tests/spu%20thread%20number)
Testcase is creating two spu threads in the same group, one with thread number 0, and the other with thread number 255. the two SPUs send data to each other in mmio to the partner's LS storage. 