### PR TITLE
CMake refactor fixup (LLVM disabled in UI and Qt resources missing)

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.8.2)
 
-set(RES_FILES "")
-
 include(cotire)
 
 # Generate git-version.h at build time.
@@ -14,10 +12,6 @@ include(ConfigureCompiler)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 	add_definitions(-DNDEBUG)
-endif()
-
-if(WIN32)
-	set(RES_FILES "rpcs3.rc")
 endif()
 
 set(ADDITIONAL_LIBS "")
@@ -50,9 +44,9 @@ add_subdirectory(rpcs3qt)
 file(GLOB RPCS3_SRC "*.cpp")
 
 if(WIN32)
-	add_executable(rpcs3 WIN32 ${RPCS3_SRC} ${RES_FILES} resources.qrc windows.qrc)
+	add_executable(rpcs3 WIN32 ${RPCS3_SRC})
 else()
-	add_executable(rpcs3 ${RPCS3_SRC} ${RES_FILES} resources.qrc)
+	add_executable(rpcs3 ${RPCS3_SRC})
 endif()
 
 add_dependencies(rpcs3 GitVersion)
@@ -64,6 +58,11 @@ set_target_properties(rpcs3
 target_link_libraries(rpcs3 ${ADDITIONAL_LIBS})
 target_link_libraries(rpcs3 rpcs3_emu rpcs3_ui)
 target_link_libraries(rpcs3 3rdparty::discord-rpc 3rdparty::qt5 3rdparty::hidapi)
+
+# Win resource file
+if (WIN32)
+	target_sources(rpcs3 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rpcs3.rc")
+endif()
 
 if(UNIX)
 	find_package(X11 REQUIRED)

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -4,7 +4,9 @@ add_library(rpcs3_emu ${SRC_FILES})
 
 target_link_libraries(rpcs3_emu
 	PRIVATE
-		3rdparty::zlib 3rdparty::yaml-cpp)
+		3rdparty::zlib 3rdparty::yaml-cpp
+	PUBLIC
+		3rdparty::libevdev)
 
 # For stdafx.h
 target_include_directories(rpcs3_emu
@@ -45,7 +47,7 @@ if(WIN32)
 endif()
 
 target_link_libraries(rpcs3_emu
-	PRIVATE
+	PUBLIC
 		3rdparty::alsa 3rdparty::pulse 3rdparty::openal)
 
 
@@ -71,7 +73,7 @@ file(GLOB_RECURSE CPU_SRC_FILES "CPU/*.cpp")
 target_sources(rpcs3_emu PRIVATE ${CPU_SRC_FILES})
 
 target_link_libraries(rpcs3_emu
-	PRIVATE 3rdparty::llvm 3rdparty::asmjit)
+	PUBLIC 3rdparty::llvm 3rdparty::asmjit)
 
 
 # Io

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -1,13 +1,19 @@
 file(GLOB SRC_FILES "*.cpp")
-
 file(GLOB UI_FILES "*.ui")
 
-add_library(rpcs3_ui ${SRC_FILES} ${UI_FILES})
+set(RES_FILES "../resources.qrc")
+
+if(WIN32)
+	list(APPEND RES_FILES "../windows.qrc")
+endif()
+
+add_library(rpcs3_ui ${SRC_FILES} ${UI_FILES} ${RES_FILES})
 
 set_target_properties(rpcs3_ui
 	PROPERTIES
 		AUTOMOC ON
-		AUTOUIC ON)
+		AUTOUIC ON
+		AUTORCC ON)
 
 target_link_libraries(rpcs3_ui
 	PUBLIC

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -74,6 +74,8 @@ main_window::~main_window()
  */
 void main_window::Init()
 {
+	Q_INIT_RESOURCE(resources);
+
 	ui->setupUi(this);
 
 	setAcceptDrops(true);


### PR DESCRIPTION
- Fixes LLVM recompiler options being disabled in the UI and Qt resource files not being properly included in the build