### PR TITLE
rsx: Fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -290,7 +290,7 @@ namespace rsx
 
 			void notify(u32 addr, u32 data_size)
 			{
-				verify(HERE), valid_count >= 0;
+				//verify(HERE), valid_count >= 0;
 
 				const u32 addr_base = addr & ~0xfff;
 				const u32 block_sz = align(addr + data_size, 4096u) - addr_base;
@@ -303,7 +303,7 @@ namespace rsx
 
 			void notify()
 			{
-				verify(HERE), valid_count >= 0;
+				//verify(HERE), valid_count >= 0;
 				valid_count++;
 			}
 
@@ -315,7 +315,7 @@ namespace rsx
 
 			void remove_one()
 			{
-				verify(HERE), valid_count > 0;
+				//verify(HERE), valid_count > 0;
 				valid_count--;
 			}
 
@@ -1510,8 +1510,8 @@ namespace rsx
 			{
 				auto &range_data = address_range.second;
 
-				if (range_data.valid_count == 0)
-					empty_addresses.push_back(address_range.first);
+				//if (range_data.valid_count == 0)
+					//empty_addresses.push_back(address_range.first);
 
 				for (auto &tex : range_data.data)
 				{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1436,7 +1436,9 @@ void GLGSRender::flip(int buffer)
 	u32 buffer_height = display_buffers[buffer].height;
 	u32 buffer_pitch = display_buffers[buffer].pitch;
 
-	if ((u32)buffer < display_buffers_count && buffer_width && buffer_height && buffer_pitch)
+	if (!buffer_pitch) buffer_pitch = buffer_width * 4;
+
+	if ((u32)buffer < display_buffers_count && buffer_width && buffer_height)
 	{
 		// Calculate blit coordinates
 		coordi aspect_ratio;
@@ -1476,7 +1478,7 @@ void GLGSRender::flip(int buffer)
 
 			image = render_target_texture->raw_handle();
 		}
-		else if (auto surface = m_gl_texture_cache.find_texture_from_dimensions(absolute_address))
+		else if (auto surface = m_gl_texture_cache.find_texture_from_dimensions(absolute_address, buffer_width, buffer_height))
 		{
 			//Hack - this should be the first location to check for output
 			//The render might have been done offscreen or in software and a blit used to display
@@ -1486,7 +1488,6 @@ void GLGSRender::flip(int buffer)
 		{
 			LOG_WARNING(RSX, "Flip texture was not found in cache. Uploading surface from CPU");
 
-			if (!buffer_pitch) buffer_pitch = buffer_width * 4;
 			gl::pixel_unpack_settings unpack_settings;
 			unpack_settings.alignment(1).row_length(buffer_pitch / 4);
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "Emu/RSX/GSRender.h"
 #include "GLHelpers.h"
 #include "GLTexture.h"
@@ -330,7 +330,7 @@ private:
 
 	//buffer
 	gl::fbo* m_draw_fbo = nullptr;
-	std::list<gl::fbo> m_framebuffer_cache;
+	std::list<gl::framebuffer_holder> m_framebuffer_cache;
 	gl::fbo m_flip_fbo;
 	std::unique_ptr<gl::texture> m_flip_tex_color;
 

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "GLHelpers.h"
 #include "Utilities/Log.h"
 
@@ -35,11 +35,15 @@ namespace gl
 		switch (type)
 		{
 		case GL_DEBUG_TYPE_ERROR:
+		{
 			LOG_ERROR(RSX, "%s", message);
 			return;
+		}
 		default:
+		{
 			LOG_WARNING(RSX, "%s", message);
 			return;
+		}
 		}
 	}
 #endif
@@ -306,7 +310,7 @@ namespace gl
 		return m_size;
 	}
 
-	bool fbo::matches(std::array<GLuint, 4> color_targets, GLuint depth_stencil_target)
+	bool fbo::matches(const std::array<GLuint, 4>& color_targets, GLuint depth_stencil_target) const
 	{
 		for (u32 index = 0; index < 4; ++index)
 		{
@@ -317,7 +321,18 @@ namespace gl
 		}
 
 		const auto depth_resource = depth.resource_id() | depth_stencil.resource_id();
-		return depth_resource == depth_stencil_target;
+		return (depth_resource == depth_stencil_target);
+	}
+
+	bool fbo::references_any(const std::vector<GLuint>& resources) const
+	{
+		for (const auto &e : m_resource_bindings)
+		{
+			if (std::find(resources.begin(), resources.end(), e.second) != resources.end())
+				return true;
+		}
+
+		return false;
 	}
 
 	bool is_primitive_native(rsx::primitive_type in)

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <exception>
 #include <string>
@@ -2234,7 +2234,8 @@ public:
 		void set_extents(size2i extents);
 		size2i get_extents() const;
 
-		bool matches(std::array<GLuint, 4> color_targets, GLuint depth_stencil_target);
+		bool matches(const std::array<GLuint, 4>& color_targets, GLuint depth_stencil_target) const;
+		bool references_any(const std::vector<GLuint>& resources) const;
 
 		explicit operator bool() const
 		{

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -1464,7 +1464,7 @@ namespace gl
 			depth = GL_TEXTURE_DEPTH_TYPE
 		};
 
-	private:
+	protected:
 		GLuint m_id = 0;
 		GLuint m_width = 0;
 		GLuint m_height = 0;
@@ -1902,6 +1902,7 @@ namespace gl
 
 public:
 		using texture::texture;
+
 		texture_view* get_view(u32 remap_encoding, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap)
 		{
 			auto found = views.find(remap_encoding);
@@ -1915,6 +1916,18 @@ public:
 			auto result = view.get();
 			views[remap_encoding] = std::move(view);
 			return result;
+		}
+
+		void set_native_component_layout(const std::array<GLenum, 4>& layout)
+		{
+			if (m_component_layout[0] != layout[0] ||
+				m_component_layout[1] != layout[1] ||
+				m_component_layout[2] != layout[2] ||
+				m_component_layout[3] != layout[3])
+			{
+				texture::set_native_component_layout(layout);
+				views.clear();
+			}
 		}
 	};
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "../rsx_methods.h"
 #include "GLGSRender.h"
 #include "Emu/System.h"
@@ -294,7 +294,12 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 	{
 		if (fbo.matches(color_targets, depth_stencil_target))
 		{
+			fbo.reset_refs();
+
 			m_draw_fbo = &fbo;
+			m_draw_fbo->bind();
+			m_draw_fbo->set_extents({ (int)layout.width, (int)layout.height });
+
 			framebuffer_status_valid = true;
 			break;
 		}
@@ -327,43 +332,40 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 				m_draw_fbo->depth = depth_stencil_target;
 			}
 		}
-
-		switch (rsx::method_registers.surface_color_target())
-		{
-		case rsx::surface_target::none: break;
-
-		case rsx::surface_target::surface_a:
-			m_draw_fbo->draw_buffer(m_draw_fbo->color[0]);
-			m_draw_fbo->read_buffer(m_draw_fbo->color[0]);
-			break;
-
-		case rsx::surface_target::surface_b:
-			m_draw_fbo->draw_buffer(m_draw_fbo->color[1]);
-			m_draw_fbo->read_buffer(m_draw_fbo->color[1]);
-			break;
-
-		case rsx::surface_target::surfaces_a_b:
-			m_draw_fbo->draw_buffers({ m_draw_fbo->color[0], m_draw_fbo->color[1] });
-			m_draw_fbo->read_buffer(m_draw_fbo->color[0]);
-			break;
-
-		case rsx::surface_target::surfaces_a_b_c:
-			m_draw_fbo->draw_buffers({ m_draw_fbo->color[0], m_draw_fbo->color[1], m_draw_fbo->color[2] });
-			m_draw_fbo->read_buffer(m_draw_fbo->color[0]);
-			break;
-
-		case rsx::surface_target::surfaces_a_b_c_d:
-			m_draw_fbo->draw_buffers({ m_draw_fbo->color[0], m_draw_fbo->color[1], m_draw_fbo->color[2], m_draw_fbo->color[3] });
-			m_draw_fbo->read_buffer(m_draw_fbo->color[0]);
-			break;
-		}
-
-		framebuffer_status_valid = m_draw_fbo->check();
 	}
-	
-	if (!framebuffer_status_valid) return;
 
-	m_draw_fbo->bind();
+	switch (rsx::method_registers.surface_color_target())
+	{
+	case rsx::surface_target::none: break;
+
+	case rsx::surface_target::surface_a:
+		m_draw_fbo->draw_buffer(m_draw_fbo->color[0]);
+		m_draw_fbo->read_buffer(m_draw_fbo->color[0]);
+		break;
+
+	case rsx::surface_target::surface_b:
+		m_draw_fbo->draw_buffer(m_draw_fbo->color[1]);
+		m_draw_fbo->read_buffer(m_draw_fbo->color[1]);
+		break;
+
+	case rsx::surface_target::surfaces_a_b:
+		m_draw_fbo->draw_buffers({ m_draw_fbo->color[0], m_draw_fbo->color[1] });
+		m_draw_fbo->read_buffer(m_draw_fbo->color[0]);
+		break;
+
+	case rsx::surface_target::surfaces_a_b_c:
+		m_draw_fbo->draw_buffers({ m_draw_fbo->color[0], m_draw_fbo->color[1], m_draw_fbo->color[2] });
+		m_draw_fbo->read_buffer(m_draw_fbo->color[0]);
+		break;
+
+	case rsx::surface_target::surfaces_a_b_c_d:
+		m_draw_fbo->draw_buffers({ m_draw_fbo->color[0], m_draw_fbo->color[1], m_draw_fbo->color[2], m_draw_fbo->color[3] });
+		m_draw_fbo->read_buffer(m_draw_fbo->color[0]);
+		break;
+	}
+
+	framebuffer_status_valid = m_draw_fbo->check();
+	if (!framebuffer_status_valid) return;
 
 	check_zcull_status(true);
 	set_viewport();

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -1030,7 +1030,10 @@ namespace gl
 				return;
 
 			const auto swizzle = get_component_mapping(gcm_format, flags);
-			section.get_raw_texture()->set_native_component_layout(swizzle);
+			auto image = static_cast<gl::viewable_image*>(section.get_raw_texture());
+
+			verify(HERE), image != nullptr;
+			image->set_native_component_layout(swizzle);
 
 			section.set_view_flags(flags);
 		}

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -1107,8 +1107,8 @@ namespace gl
 			if (found == m_cache.end())
 				return false;
 
-			if (found->second.valid_count == 0)
-				return false;
+			//if (found->second.valid_count == 0)
+				//return false;
 
 			for (auto& tex : found->second.data)
 			{

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "stdafx.h"
 
@@ -252,12 +252,7 @@ namespace gl
 
 		void reset(u32 base, u32 size, bool /*flushable*/=false)
 		{
-			rsx::protection_policy policy = g_cfg.video.strict_rendering_mode ? rsx::protection_policy::protect_policy_full_range : rsx::protection_policy::protect_policy_conservative;
-			rsx::buffered_section::reset(base, size, policy);
-
-			flushed = false;
-			synchronized = false;
-			sync_timestamp = 0ull;
+			rsx::cached_texture_section::reset(base, size);
 
 			vram_texture = nullptr;
 			managed_texture.reset();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "VKGSRender.h"
@@ -2922,7 +2922,6 @@ void VKGSRender::flip(int buffer)
 
 	u32 buffer_width = display_buffers[buffer].width;
 	u32 buffer_height = display_buffers[buffer].height;
-	u32 buffer_pitch = display_buffers[buffer].pitch;
 
 	coordi aspect_ratio;
 
@@ -2999,7 +2998,7 @@ void VKGSRender::flip(int buffer)
 	//Blit contents to screen..
 	vk::image* image_to_flip = nullptr;
 
-	if ((u32)buffer < display_buffers_count && buffer_width && buffer_height && buffer_pitch)
+	if ((u32)buffer < display_buffers_count && buffer_width && buffer_height)
 	{
 		rsx::tiled_region buffer_region = get_tiled_address(display_buffers[buffer].offset, CELL_GCM_LOCATION_LOCAL);
 		u32 absolute_address = buffer_region.address + buffer_region.base;
@@ -3008,7 +3007,7 @@ void VKGSRender::flip(int buffer)
 		{
 			image_to_flip = render_target_texture;
 		}
-		else if (auto surface = m_texture_cache.find_texture_from_dimensions(absolute_address))
+		else if (auto surface = m_texture_cache.find_texture_from_dimensions(absolute_address, buffer_width, buffer_height))
 		{
 			//Hack - this should be the first location to check for output
 			//The render might have been done offscreen or in software and a blit used to display

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "stdafx.h"
 #include <exception>
@@ -809,26 +809,13 @@ namespace vk
 		}
 	};
 
-	struct viewable_image : public image
+	class viewable_image : public image
 	{
+	private:
 		std::unordered_multimap<u32, std::unique_ptr<vk::image_view>> views;
 
-		viewable_image(vk::render_device &dev,
-			uint32_t memory_type_index,
-			uint32_t access_flags,
-			VkImageType image_type,
-			VkFormat format,
-			uint32_t width, uint32_t height, uint32_t depth,
-			uint32_t mipmaps, uint32_t layers,
-			VkSampleCountFlagBits samples,
-			VkImageLayout initial_layout,
-			VkImageTiling tiling,
-			VkImageUsageFlags usage,
-			VkImageCreateFlags image_flags)
-
-			:image(dev, memory_type_index, access_flags, image_type, format, width, height, depth,
-					mipmaps, layers, samples, initial_layout, tiling, usage, image_flags)
-		{}
+	public:
+		using image::image;
 
 		image_view* get_view(u32 remap_encoding, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap,
 			VkImageAspectFlags mask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT)
@@ -854,6 +841,18 @@ namespace vk
 			auto result = view.get();
 			views.emplace(remap_encoding, std::move(view));
 			return result;
+		}
+
+		void set_native_component_layout(VkComponentMapping new_layout)
+		{
+			if (new_layout.r != native_component_map.r ||
+				new_layout.g != native_component_map.g ||
+				new_layout.b != native_component_map.b ||
+				new_layout.a != native_component_map.a)
+			{
+				native_component_map = new_layout;
+				views.clear();
+			}
 		}
 	};
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -917,7 +917,10 @@ namespace vk
 				return;
 
 			const VkComponentMapping mapping = apply_component_mapping_flags(gcm_format, expected_flags, rsx::default_remap_vector);
-			section.get_raw_texture()->native_component_map = mapping;
+			auto image = static_cast<vk::viewable_image*>(section.get_raw_texture());
+
+			verify(HERE), image != nullptr;
+			image->set_native_component_layout(mapping);
 
 			section.set_view_flags(expected_flags);
 		}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "stdafx.h"
 #include "VKRenderTargets.h"
 #include "VKGSRender.h"
@@ -32,8 +32,7 @@ namespace vk
 			if (length > cpu_address_range)
 				release_dma_resources();
 
-			rsx::protection_policy policy = g_cfg.video.strict_rendering_mode ? rsx::protection_policy::protect_policy_full_range : rsx::protection_policy::protect_policy_conservative;
-			rsx::buffered_section::reset(base, length, policy);
+			rsx::cached_texture_section::reset(base, length);
 		}
 
 		void create(u16 w, u16 h, u16 depth, u16 mipmaps, vk::image *image, u32 rsx_pitch, bool managed, u32 gcm_format, bool pack_swap_bytes = false)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -985,8 +985,8 @@ namespace vk
 			if (found == m_cache.end())
 				return false;
 
-			if (found->second.valid_count == 0)
-				return false;
+			//if (found->second.valid_count == 0)
+				//return false;
 
 			for (auto& tex : found->second.data)
 			{

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -171,6 +171,9 @@ namespace rsx
 			protection = utils::protection::rw;
 			dirty = true;
 			locked = false;
+
+			confirmed_range = { 0, 0 };
+			locked_memory_ptr = {};
 		}
 
 		/**


### PR DESCRIPTION
**Blit Engine**
- Forcefully downloads and reuploads data from the CPU in case of unexpected overlaps
- Properly detect correct size of newly created blit targets

**Other**
- Fix flip source buffer selection
- Fix resource readback for overlapping sections (WCB)
- Fix flickering in OpenGL

Fixes https://github.com/RPCS3/rpcs3/issues/5135
Also fixes part of https://github.com/RPCS3/rpcs3/issues/4258