### PR TITLE
Fix Linux WITHOUT_LLVM build

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -1,4 +1,5 @@
 #include "JIT.h"
+#include <immintrin.h>
 
 asmjit::JitRuntime& asmjit::get_global_runtime()
 {


### PR DESCRIPTION
- _XABORT_RETRY is defined in immintrin.h which wasn't included explicitly and asmjit doesn't happen to include it on Linux