### PR TITLE
rsx: Fixups

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1732,8 +1732,7 @@ void GLGSRender::do_local_task(rsx::FIFO_state state)
 	{
 		if (!in_begin_end && async_flip_requested & flip_request::native_ui)
 		{
-			s32 buffer_id = (async_flip_requested & flip_request::emu_requested) ? async_flip_buffer : (s32)current_display_buffer;
-			flip(buffer_id);
+			flip((s32)current_display_buffer);
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1356,7 +1356,7 @@ namespace rsx
 
 	void thread::do_local_task(FIFO_state state)
 	{
-		if (async_flip_requested & flip_request::any)
+		if (async_flip_requested & flip_request::emu_requested)
 		{
 			handle_emu_flip(async_flip_buffer);
 		}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2201,10 +2201,8 @@ void VKGSRender::do_local_task(rsx::FIFO_state state)
 	{
 		if (!in_begin_end && async_flip_requested & flip_request::native_ui)
 		{
-			s32 buffer_id = (async_flip_requested & flip_request::emu_requested) ? async_flip_buffer : (s32)current_display_buffer;
-
 			flush_command_queue(true);
-			flip((s32)buffer_id);
+			flip((s32)current_display_buffer);
 		}
 	}
 }


### PR DESCRIPTION
- Separate UI flip from Emu flip again.
- Fix regressons introduced by https://github.com/RPCS3/rpcs3/pull/5175