### PR TITLE
rsx: Minor pfifo opcode fixes

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -708,7 +708,7 @@ namespace rsx
 				continue;
 			}
 
-			if (cmd == RSX_METHOD_RETURN_CMD)
+			if ((cmd & ~0xfffc) == RSX_METHOD_RETURN_CMD)
 			{
 				if (m_return_addr == -1)
 				{


### PR DESCRIPTION
- Any command with zero count that aint a branch instruction is a nop. [testcase](https://github.com/elad335/myps3tests/blob/master/rsx_tests/cmds%20with%20count%200/mainrsxcrap.cpp)

- Return command opcode ignores the method offset part of the opcode. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/RET%20command%20opcode)