### PR TITLE
rsx: Remove a few texture params hacks

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -232,8 +232,8 @@ s32 sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size)
  */
 s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u64 a5, u64 a6)
 {
-	// Flip/queue/user command/vblank as trace to help with log spam
-	if (package_id == 0x102 || package_id == 0x103 || package_id == 0xFED || package_id == 0xFEF)
+	// Flip/queue/reset flip/flip event/user command/vblank as trace to help with log spam
+	if (package_id == 0x102 || package_id == 0x103 || package_id == 0x10a || package_id == 0xFEC || package_id == 0xFED || package_id == 0xFEF)
 		sys_rsx.trace("sys_rsx_context_attribute(context_id=0x%x, package_id=0x%x, a3=0x%llx, a4=0x%llx, a5=0x%llx, a6=0x%llx)", context_id, package_id, a3, a4, a5, a6);
 	else
 		sys_rsx.warning("sys_rsx_context_attribute(context_id=0x%x, package_id=0x%x, a3=0x%llx, a4=0x%llx, a5=0x%llx, a6=0x%llx)", context_id, package_id, a3, a4, a5, a6);

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -114,7 +114,7 @@ namespace rsx
 				for (const auto& l : layout)
 					texSize += l.data.size();
 
-				if (!texaddr || !texSize)
+				if (!texSize)
 					continue;
 
 				frame_capture_data::memory_block block;
@@ -141,7 +141,7 @@ namespace rsx
 				for (const auto& l : layout)
 					texSize += l.data.size();
 
-				if (!texaddr || !texSize)
+				if (!texSize)
 					continue;
 
 				frame_capture_data::memory_block block;

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -528,7 +528,7 @@ u8 get_format_block_size_in_bytes(rsx::surface_color_format format)
 size_t get_placed_texture_storage_size(u16 width, u16 height, u32 depth, u8 format, u16 mipmap, bool cubemap, size_t row_pitch_alignment, size_t mipmap_alignment)
 {
 	size_t w = width;
-	size_t h = std::max<u16>(height, 1);
+	size_t h = height;
 	size_t d = std::max<u16>(depth, 1);
 
 	format &= ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
@@ -547,7 +547,8 @@ size_t get_placed_texture_storage_size(u16 width, u16 height, u32 depth, u8 form
 		width_in_blocks = std::max<size_t>(width_in_blocks / 2, 1);
 	}
 
-	return result * (cubemap ? 6 : 1);
+	// Mipmap, height and width aren't allowed to be zero
+	return verify("Texture params" HERE, result) * (cubemap ? 6 : 1); 
 }
 
 size_t get_placed_texture_storage_size(const rsx::fragment_texture &texture, size_t row_pitch_alignment, size_t mipmap_alignment)

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -527,22 +527,18 @@ u8 get_format_block_size_in_bytes(rsx::surface_color_format format)
 
 size_t get_placed_texture_storage_size(u16 width, u16 height, u32 depth, u8 format, u16 mipmap, bool cubemap, size_t row_pitch_alignment, size_t mipmap_alignment)
 {
-	size_t w = width;
-	size_t h = height;
-	size_t d = std::max<u16>(depth, 1);
-
 	format &= ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 	size_t block_edge = get_format_block_size_in_texel(format);
 	size_t block_size_in_byte = get_format_block_size_in_bytes(format);
 
-	size_t height_in_blocks = (h + block_edge - 1) / block_edge;
-	size_t width_in_blocks = (w + block_edge - 1) / block_edge;
+	size_t height_in_blocks = (height + block_edge - 1) / block_edge;
+	size_t width_in_blocks  = (width + block_edge - 1) / block_edge;
 
 	size_t result = 0;
 	for (u16 i = 0; i < mipmap; ++i)
 	{
 		size_t rowPitch = align(block_size_in_byte * width_in_blocks, row_pitch_alignment);
-		result += align(rowPitch * height_in_blocks * d, mipmap_alignment);
+		result += align(rowPitch * height_in_blocks * depth, mipmap_alignment);
 		height_in_blocks = std::max<size_t>(height_in_blocks / 2, 1);
 		width_in_blocks = std::max<size_t>(width_in_blocks / 2, 1);
 	}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1771,7 +1771,6 @@ namespace rsx
 			switch (extended_dimension)
 			{
 			case rsx::texture_dimension_extended::texture_dimension_1d:
-				tex_height = 1;
 				depth = 1;
 				break;
 			case rsx::texture_dimension_extended::texture_dimension_2d:

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1762,7 +1762,7 @@ namespace rsx
 			const bool is_compressed_format = (format == CELL_GCM_TEXTURE_COMPRESSED_DXT1 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT23 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT45);
 
 			const auto extended_dimension = tex.get_extended_texture_dimension();
-			u16 depth = 0;
+			u16 depth;
 			u16 tex_height = (u16)tex.height();
 			const u16 tex_width = tex.width();
 			u16 tex_pitch = is_compressed_format? (u16)(get_texture_size(tex) / tex_height) : tex.pitch(); //NOTE: Compressed textures dont have a real pitch (tex_size = (w*h)/6)

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1761,7 +1761,7 @@ namespace rsx
 			const u32 format = tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 			const bool is_compressed_format = (format == CELL_GCM_TEXTURE_COMPRESSED_DXT1 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT23 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT45);
 
-			if (!texaddr || !tex_size || !tex_range.valid())
+			if (!tex_size || !tex_range.valid())
 			{
 				LOG_ERROR(RSX, "Texture upload requested but texture not found, (address=0x%X, size=0x%X, w=%d, h=%d, p=%d, format=0x%X)", texaddr, tex_size, tex.width(), tex.height(), tex.pitch(), tex.format());
 				return {};

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1761,12 +1761,6 @@ namespace rsx
 			const u32 format = tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 			const bool is_compressed_format = (format == CELL_GCM_TEXTURE_COMPRESSED_DXT1 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT23 || format == CELL_GCM_TEXTURE_COMPRESSED_DXT45);
 
-			if (!tex_size || !tex_range.valid())
-			{
-				LOG_ERROR(RSX, "Texture upload requested but texture not found, (address=0x%X, size=0x%X, w=%d, h=%d, p=%d, format=0x%X)", texaddr, tex_size, tex.width(), tex.height(), tex.pitch(), tex.format());
-				return {};
-			}
-
 			const auto extended_dimension = tex.get_extended_texture_dimension();
 			u16 depth = 0;
 			u16 tex_height = (u16)tex.height();

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -563,9 +563,7 @@ namespace gl
 	void upload_texture(GLuint id, u32 texaddr, u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, bool is_swizzled, rsx::texture_dimension_extended type,
 			const std::vector<rsx_subresource_layout>& subresources_layout)
 	{
-		const bool is_cubemap = type == rsx::texture_dimension_extended::texture_dimension_cubemap;
-		
-		size_t texture_data_sz = get_placed_texture_storage_size(width, height, depth, gcm_format, mipmaps, is_cubemap, 256, 512);
+		size_t texture_data_sz = get_placed_texture_storage_size(width, height, depth, gcm_format, mipmaps, type == rsx::texture_dimension_extended::texture_dimension_cubemap, 256, 512);
 		std::vector<gsl::byte> data_upload_buf(texture_data_sz);
 
 		GLenum target;

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -214,7 +214,7 @@ namespace gl
 		glSamplerParameterfv(samplerHandle, GL_TEXTURE_BORDER_COLOR, border_color.rgba);
 
 		if (sampled_image->upload_context != rsx::texture_upload_context::shader_read ||
-			tex.get_exact_mipmap_count() <= 1)
+			tex.get_exact_mipmap_count() == 1)
 		{
 			GLint min_filter = tex_min_filter(tex.min_filter());
 

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -258,7 +258,7 @@ namespace rsx
 
 	u16 fragment_texture::height() const
 	{
-		return ((registers[NV4097_SET_TEXTURE_IMAGE_RECT + (m_index * 8)]) & 0xffff);
+		return dimension() != rsx::texture_dimension::dimension1d ? ((registers[NV4097_SET_TEXTURE_IMAGE_RECT + (m_index * 8)]) & 0xffff) : 1;
 	}
 
 	u32 fragment_texture::border_color() const
@@ -396,7 +396,7 @@ namespace rsx
 
 	u16 vertex_texture::height() const
 	{
-		return ((registers[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT + (m_index * 8)]) & 0xffff);
+		return dimension() != rsx::texture_dimension::dimension1d ? ((registers[NV4097_SET_VERTEX_TEXTURE_IMAGE_RECT + (m_index * 8)]) & 0xffff) : 1;
 	}
 
 	u32 vertex_texture::border_color() const

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -268,7 +268,7 @@ namespace rsx
 
 	u16 fragment_texture::depth() const
 	{
-		return registers[NV4097_SET_TEXTURE_CONTROL3 + m_index] >> 20;
+		return dimension() == rsx::texture_dimension::dimension3d ? (registers[NV4097_SET_TEXTURE_CONTROL3 + m_index] >> 20) : 1;
 	}
 
 	u32 fragment_texture::pitch() const
@@ -406,7 +406,7 @@ namespace rsx
 
 	u16 vertex_texture::depth() const
 	{
-		return registers[NV4097_SET_VERTEX_TEXTURE_CONTROL3 + (m_index * 8)] >> 20;
+		return dimension() == rsx::texture_dimension::dimension3d ? (registers[NV4097_SET_VERTEX_TEXTURE_CONTROL3 + (m_index * 8)] >> 20) : 1;
 	}
 
 	u32 vertex_texture::pitch() const

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -65,18 +65,17 @@ namespace rsx
 
 	u16 fragment_texture::get_exact_mipmap_count() const
 	{
-		u16 max_mipmap_count = 1;
+		u16 max_mipmap_count;
 		if (is_compressed_format())
 		{
 			// OpenGL considers that highest mipmap level for DXTC format is when either width or height is 1
 			// not both. Assume it's the same for others backend.
-			max_mipmap_count = static_cast<u16>(floor(log2(std::min(width() / 4, height() / 4))) + 1);
+			max_mipmap_count = floor_log2(static_cast<u32>(std::min(width() / 4, height() / 4))) + 1;
 		}
 		else
-			max_mipmap_count = static_cast<u16>(floor(log2(std::max(width(), height()))) + 1);
+			max_mipmap_count = floor_log2(static_cast<u32>(std::max(width(), height()))) + 1;
 		
-		max_mipmap_count = std::min(mipmap(), max_mipmap_count);
-		return (max_mipmap_count > 0) ? max_mipmap_count : 1;
+		return std::min(verify(HERE, mipmap()), max_mipmap_count);
 	}
 
 	rsx::texture_wrap_mode fragment_texture::wrap_s() const
@@ -326,10 +325,8 @@ namespace rsx
 
 	u16 vertex_texture::get_exact_mipmap_count() const
 	{
-		u16 max_mipmap_count = static_cast<u16>(floor(log2(std::max(width(), height()))) + 1);
-		max_mipmap_count = std::min(mipmap(), max_mipmap_count);
-
-		return (max_mipmap_count > 0) ? max_mipmap_count : 1;
+		const u16 max_mipmap_count = floor_log2(static_cast<u32>(std::max(width(), height()))) + 1;
+		return std::min(verify(HERE, mipmap()), max_mipmap_count);
 	}
 
 	std::pair<std::array<u8, 4>, std::array<u8, 4>> vertex_texture::decoded_remap() const

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1165,12 +1165,12 @@ namespace rsx
 
 		for (u32 i = 0; i < 16; i++)
 		{
-			registers[NV4097_SET_TEXTURE_FORMAT + (i * 8)] = (1 << 16 /* mipmap */) | ((CELL_GCM_TEXTURE_R5G6B5 | CELL_GCM_TEXTURE_SZ | CELL_GCM_TEXTURE_NR) << 8) | ((u32)texture_dimension::dimension2d << 4) | CELL_GCM_LOCATION_LOCAL + 1;
+			registers[NV4097_SET_TEXTURE_FORMAT + (i * 8)] = (1 << 16 /* mipmap */) | ((CELL_GCM_TEXTURE_R5G6B5 | CELL_GCM_TEXTURE_SZ | CELL_GCM_TEXTURE_NR) << 8) | (2 << 4 /* 2D */) | CELL_GCM_LOCATION_LOCAL + 1;
 		}
 
 		for (u32 i = 0; i < 4; i++)
 		{
-			registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (i * 8)] = (1 << 16 /* mipmap */) | ((CELL_GCM_TEXTURE_X32_FLOAT | CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_NR) << 8) | ((u32)texture_dimension::dimension2d << 4) | CELL_GCM_LOCATION_LOCAL + 1;
+			registers[NV4097_SET_VERTEX_TEXTURE_FORMAT + (i * 8)] = (1 << 16 /* mipmap */) | ((CELL_GCM_TEXTURE_X32_FLOAT | CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_NR) << 8) | (2 << 4 /* 2D */) | CELL_GCM_LOCATION_LOCAL + 1;
 		}
 
 		if (get_current_renderer()->isHLE)

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -144,6 +144,11 @@ namespace rsx
 	}
 
 	//
+	static inline u32 floor_log2(u32 value)
+	{
+		return value <= 1 ? 0 : utils::cntlz32(value, true) ^ 31;
+	}
+
 	static inline u32 ceil_log2(u32 value)
 	{
 		return value <= 1 ? 0 : utils::cntlz32((value - 1) << 1, true) ^ 31;


### PR DESCRIPTION
- Mipmap, height and width arent allowed to be zero, those throw at register write time. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/TEXTURE_SIZE)

- Depth param is ignored and doesnt throw if the texture type is non-3d even when set to silly values such as 0 or 513, only throws when its 3d. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/TEXTURE_DEPTH)

- Since realhw doesnt throw when using height above 1 with 1d textures, read it as 1. [testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/TEXTURE_HEIGHT)