### PR TITLE
rsx: Fix u16 index arrays overflow 

### DIFF
--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -236,12 +236,12 @@ namespace rsx
 						auto fifo = vm::ptr<u16>::make(idxAddr);
 						for (u32 i = 0; i < idxCount; ++i)
 						{
-							u16 index = fifo[i];
-							if (is_primitive_restart_enabled && (u32)index == primitive_restart_index)
+							u32 index = fifo[i];
+							if (is_primitive_restart_enabled && index == primitive_restart_index)
 								continue;
-							index     = (u16)get_index_from_base(index, method_registers.vertex_data_base_index());
-							min_index = (u16)std::min(index, (u16)min_index);
-							max_index = (u16)std::max(index, (u16)max_index);
+							index     = get_index_from_base(index, method_registers.vertex_data_base_index());
+							min_index = std::min(index, min_index);
+							max_index = std::max(index, max_index);
 						}
 						break;
 					}

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -237,7 +237,7 @@ namespace rsx
 						for (u32 i = 0; i < idxCount; ++i)
 						{
 							u16 index = fifo[i];
-							if (is_primitive_restart_enabled && index == (u16)primitive_restart_index)
+							if (is_primitive_restart_enabled && (u32)index == primitive_restart_index)
 								continue;
 							index     = (u16)get_index_from_base(index, method_registers.vertex_data_base_index());
 							min_index = (u16)std::min(index, (u16)min_index);

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -539,7 +539,7 @@ void write_vertex_array_data_to_buffer(gsl::span<gsl::byte> raw_dst_span, gsl::s
 namespace
 {
 template<typename T>
-std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, bool is_primitive_restart_enabled, T primitive_restart_index, u32 base_index)
+std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, bool is_primitive_restart_enabled, u32 primitive_restart_index, u32 base_index)
 {
 	T min_index = -1;
 	T max_index = 0;
@@ -549,7 +549,7 @@ std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::spa
 	u32 dst_idx = 0;
 	for (T index : src)
 	{
-		if (is_primitive_restart_enabled && index == primitive_restart_index)
+		if (is_primitive_restart_enabled && (u32)index == primitive_restart_index)
 		{
 			// List types do not need primitive restart. Just skip over this instead
 			if (rsx::method_registers.current_draw_clause.is_disjoint_primitive)
@@ -570,7 +570,7 @@ std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::spa
 }
 
 template<typename T>
-std::tuple<T, T, u32> expand_indexed_triangle_fan(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, bool is_primitive_restart_enabled, T primitive_restart_index, u32 base_index)
+std::tuple<T, T, u32> expand_indexed_triangle_fan(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, bool is_primitive_restart_enabled, u32 primitive_restart_index, u32 base_index)
 {
 	const T invalid_index = (T)-1;
 
@@ -593,7 +593,7 @@ std::tuple<T, T, u32> expand_indexed_triangle_fan(gsl::span<to_be_t<const T>> sr
 
 		if (needs_anchor)
 		{
-			if (is_primitive_restart_enabled && src[src_idx] == primitive_restart_index)
+			if (is_primitive_restart_enabled && (u32)src[src_idx] == primitive_restart_index)
 				continue;
 
 			anchor = index;
@@ -601,7 +601,7 @@ std::tuple<T, T, u32> expand_indexed_triangle_fan(gsl::span<to_be_t<const T>> sr
 			continue;
 		}
 
-		if (is_primitive_restart_enabled && src[src_idx] == primitive_restart_index)
+		if (is_primitive_restart_enabled && (u32)src[src_idx] == primitive_restart_index)
 		{
 			needs_anchor = true;
 			last_index = invalid_index;
@@ -629,7 +629,7 @@ std::tuple<T, T, u32> expand_indexed_triangle_fan(gsl::span<to_be_t<const T>> sr
 }
 
 template<typename T>
-std::tuple<T, T, u32> expand_indexed_quads(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, bool is_primitive_restart_enabled, T primitive_restart_index, u32 base_index)
+std::tuple<T, T, u32> expand_indexed_quads(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, bool is_primitive_restart_enabled, u32 primitive_restart_index, u32 base_index)
 {
 	T min_index = -1;
 	T max_index = 0;
@@ -644,7 +644,7 @@ std::tuple<T, T, u32> expand_indexed_quads(gsl::span<to_be_t<const T>> src, gsl:
 	{
 		T index = src[src_idx];
 		index = rsx::get_index_from_base(index, base_index);
-		if (is_primitive_restart_enabled && src[src_idx] == primitive_restart_index)
+		if (is_primitive_restart_enabled && (u32)src[src_idx] == primitive_restart_index)
 		{
 			//empty temp buffer
 			set_size = 0;

--- a/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Buffer.cpp
@@ -395,7 +395,7 @@ namespace
 				rsx::index_array_type::u32:
 				rsx::method_registers.index_type();
 
-			size_t index_size = get_index_type_size(indexed_type);
+			constexpr size_t index_size = sizeof(u32); // Force u32 destination to avoid overflows when adding base
 
 			// Alloc
 			size_t buffer_size = align(index_count * index_size, 64);
@@ -418,7 +418,7 @@ namespace
 			m_buffer_data.unmap(CD3DX12_RANGE(heap_offset, heap_offset + buffer_size));
 			D3D12_INDEX_BUFFER_VIEW index_buffer_view = {
 				m_buffer_data.get_heap()->GetGPUVirtualAddress() + heap_offset, (UINT)buffer_size,
-				get_index_type(indexed_type)};
+				DXGI_FORMAT_R32_UINT};
 			// m_timers.buffer_upload_size += buffer_size;
 			command_list->IASetIndexBuffer(&index_buffer_view);
 

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -132,7 +132,7 @@ namespace
 				rsx::index_array_type::u32 :
 				rsx::method_registers.index_type();
 
-			u32 type_size = gsl::narrow<u32>(get_index_type_size(index_type));
+			constexpr u32 type_size = sizeof(u32); // Force u32 index size dest to avoid overflows when adding vertex base index
 
 			u32 index_count = rsx::method_registers.current_draw_clause.get_elements_count();
 			if (primitives_emulated)
@@ -177,20 +177,13 @@ namespace
 
 			if (emulate_restart)
 			{
-				if (index_type == rsx::index_array_type::u16)
-				{
-					index_count = rsx::remove_restart_index((u16*)buf, (u16*)tmp.data(), index_count, (u16)UINT16_MAX);
-				}
-				else
-				{
-					index_count = rsx::remove_restart_index((u32*)buf, (u32*)tmp.data(), index_count, (u32)UINT32_MAX);
-				}
+				index_count = rsx::remove_restart_index((u32*)buf, (u32*)tmp.data(), index_count, (u32)UINT32_MAX);
 			}
 
 			m_index_buffer_ring_info.unmap();
 
 			std::optional<std::tuple<VkDeviceSize, VkIndexType>> index_info =
-				std::make_tuple(offset_in_index_buffer, vk::get_index_type(index_type));
+				std::make_tuple(offset_in_index_buffer, VK_INDEX_TYPE_UINT32);
 
 			//check for vertex arrays with frequency modifiers
 			for (auto &block : m_vertex_layout.interleaved_blocks)


### PR DESCRIPTION
- Force u32 destination index arrays when an overflow occurs while adding the vertex base index.

- Dont ignore the upper 16-bits of the restart index if u16 array is specified.

Fixes yakuza series' exploding vertices.

**before**
![before](https://user-images.githubusercontent.com/18193363/46572880-f2771280-c995-11e8-936d-47c0f492146e.png)
![before2](https://user-images.githubusercontent.com/18193363/46572893-205c5700-c996-11e8-8d0e-6c44296f648f.png)
**after**
![after](https://user-images.githubusercontent.com/18193363/46572899-2eaa7300-c996-11e8-9ca2-354ac3322b91.png)
![after2](https://user-images.githubusercontent.com/18193363/46572901-3538ea80-c996-11e8-962d-4fbb43d02258.png)


