### PR TITLE
Change default renderer to Vulkan

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -401,7 +401,7 @@ struct cfg_root : cfg::node
 	{
 		node_video(cfg::node* _this) : cfg::node(_this, "Video") {}
 
-		cfg::_enum<video_renderer> renderer{this, "Renderer", video_renderer::opengl};
+		cfg::_enum<video_renderer> renderer{this, "Renderer", video_renderer::vulkan};
 
 		cfg::_enum<video_resolution> resolution{this, "Resolution", video_resolution::_720};
 		cfg::_enum<video_aspect> aspect_ratio{this, "Aspect ratio", video_aspect::_16_9};


### PR DESCRIPTION
The default renderer should be changed to Vulkan to fit more in line with the PPU and SPU decoders, whose default settings favor speed over accuracy. The description of the renderer box also states that "Should you have any compatibility issues, fall back to OpenGL" indicating that OpenGL should be more of a last resort than a first choice like it is now.