### PR TITLE
rsx_capture/gcm: Fix tile binding

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -386,7 +386,7 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 			render->notify_tile_unbound(a3);
 
 		tile.location = ((a4 >> 32) & 0xF) - 1;
-		tile.offset = ((((a4 >> 32) & 0xFFFFFFFF) >> 16) * 0x10000);
+		tile.offset = ((((a4 >> 32) & 0x7FFFFFFF) >> 16) * 0x10000);
 		tile.size = ((((a4 & 0x7FFFFFFF) >> 16) + 1) * 0x10000) - tile.offset;
 		tile.pitch = (((a5 >> 32) & 0xFFFFFFFF) >> 8) * 0x100;
 		tile.comp = ((a5 & 0xFFFFFFFF) >> 26) & 0xF;

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -196,7 +196,7 @@ namespace rsx
 				zc.zFormat = zctile.zFormat;
 
 				const auto& zci = zc.pack();
-				sys_rsx_context_attribute(context_id, 0x301, i, (u64)zci.region << 32 | zci.size, (u64)zci.start << 32 | zci.offset, (u64)zci.status0 << 32 | zci.status1);
+				sys_rsx_context_attribute(context_id, 0x301, i, (u64)zci.region << 32 | zci.size, (u64)zci.start << 32 | zci.offset, zc.binded ? (u64)zci.status0 << 32 | zci.status1 : 0);
 			}
 
 			cs.tile_hash = replay_cmd.tile_state;

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -170,7 +170,7 @@ namespace rsx
 				t.size = tstile.size;
 
 				const auto& ti = t.pack();
-				sys_rsx_context_attribute(context_id, 0x300, i, (u64)ti.tile << 32 | ti.limit, (u64)ti.pitch << 32 | ti.format, 0);
+				sys_rsx_context_attribute(context_id, 0x300, i, (u64)ti.tile << 32 | ti.limit, t.binded ? (u64)ti.pitch << 32 | ti.format : 0, 0);
 			}
 
 			for (u32 i = 0; i < limits::zculls_count; ++i)


### PR DESCRIPTION
- bit-63 of arg4 signifyies location, so ignore that while reading the offset.

- Fix the binding of unbound tiles and zculls in rsx replay.