### PR TITLE
Add option for showing compatibility status in grid view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ rpcs3/rpcs3_autogen/*
 
 # QtCreator
 CMakeLists.txt.user
+
+# CLion
+/.idea/*
+/cmake-build-*/

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -180,6 +180,7 @@ void game_list_frame::LoadSettings()
 	m_colSortOrder = m_gui_settings->GetValue(gui::gl_sortAsc).toBool() ? Qt::AscendingOrder : Qt::DescendingOrder;
 	m_sortColumn = m_gui_settings->GetValue(gui::gl_sortCol).toInt();
 	m_categoryFilters = m_gui_settings->GetGameListCategoryFilters();
+	m_drawCompatStatusToGrid = m_gui_settings->GetValue(gui::gl_draw_compat).toBool();
 
 	Refresh(true);
 
@@ -463,11 +464,13 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 				LOG_WARNING(GENERAL, "Could not load image from path %s", sstr(QDir(qstr(game.icon_path)).absolutePath()));
 			}
 
-			bool hasCustomConfig = fs::is_file(fs::get_config_dir() + "data/" + game.serial + "/config.yml");
+			const auto compat = m_game_compat->GetCompatibility(game.serial);
+			const bool hasCustomConfig = fs::is_file(fs::get_config_dir() + "data/" + game.serial + "/config.yml");
+			const QColor color = getGridCompatibilityColor(compat.color);
 
-			QPixmap pxmap = PaintedPixmap(img, hasCustomConfig);
+			const QPixmap pxmap = PaintedPixmap(img, hasCustomConfig, color);
 
-			m_game_data.push_back(game_info(new gui_game_info{ game, m_game_compat->GetCompatibility(game.serial), img, pxmap, hasCustomConfig }));
+			m_game_data.push_back(game_info(new gui_game_info{ game, compat, img, pxmap, hasCustomConfig }));
 		}
 		catch (const std::exception& e)
 		{
@@ -909,7 +912,7 @@ bool game_list_frame::DeleteSPUCache(const std::string& base_dir, bool is_intera
 	return true;
 }
 
-QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon)
+QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon, const QColor& compatibility_color)
 {
 	const QSize original_size = img.size();
 
@@ -930,6 +933,16 @@ QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon
 		painter.drawImage(origin, QImage(":/Icons/custom_config_2.png").scaled(QSize(width, width), Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
 	}
 
+	if (compatibility_color.isValid())
+	{
+		const int size = original_size.height() * 0.2;
+		const int spacing = original_size.height() * 0.05;
+		QColor copyColor = QColor(compatibility_color);
+		copyColor.setAlpha(215); // ~85% opacity
+		painter.setBrush(QBrush(copyColor));
+		painter.drawEllipse(spacing, spacing, size, size);
+	}
+
 	painter.end();
 
 	return QPixmap::fromImage(image.scaled(m_Icon_Size, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
@@ -944,7 +957,8 @@ void game_list_frame::ShowCustomConfigIcon(QTableWidgetItem* item, bool enabled)
 	}
 
 	game->hasCustomConfig = enabled;
-	game->pxmap = PaintedPixmap(game->icon, enabled);
+	const QColor color = getGridCompatibilityColor(game->compat.color);
+	game->pxmap = PaintedPixmap(game->icon, enabled, color);
 
 	if (!m_isListLayout)
 	{
@@ -986,7 +1000,8 @@ void game_list_frame::RepaintIcons(const bool& fromSettings)
 
 	for (auto& game : m_game_data)
 	{
-		game->pxmap = PaintedPixmap(game->icon, game->hasCustomConfig);
+		QColor color = getGridCompatibilityColor(game->compat.color);
+		game->pxmap = PaintedPixmap(game->icon, game->hasCustomConfig, color);
 	}
 
 	Refresh();
@@ -1379,4 +1394,19 @@ game_info game_list_frame::GetGameInfoFromItem(QTableWidgetItem* item)
 	}
 
 	return var.value<game_info>();
+}
+
+QColor game_list_frame::getGridCompatibilityColor(const QString& string)
+{
+	if (m_drawCompatStatusToGrid && !m_isListLayout)
+	{
+		return QColor(string);
+	}
+	return QColor();
+}
+
+void game_list_frame::SetShowCompatibilityInGrid(bool show)
+{
+	m_drawCompatStatusToGrid = show;
+	RepaintIcons();
 }

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -209,6 +209,7 @@ public:
 public Q_SLOTS:
 	void SetListMode(const bool& isList);
 	void SetSearchText(const QString& text);
+	void SetShowCompatibilityInGrid(bool show);
 
 private Q_SLOTS:
 	bool RemoveCustomConfiguration(const std::string& base_dir, bool is_interactive = false);
@@ -228,7 +229,8 @@ protected:
 	void resizeEvent(QResizeEvent *event) override;
 	bool eventFilter(QObject *object, QEvent *event) override;
 private:
-	QPixmap PaintedPixmap(const QImage& img, bool paint_config_icon = false);
+	QPixmap PaintedPixmap(const QImage& img, bool paint_config_icon = false, const QColor& color = QColor());
+	QColor getGridCompatibilityColor(const QString& string);
 	void ShowCustomConfigIcon(QTableWidgetItem* item, bool enabled);
 	void PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color);
 	bool IsEntryVisible(const game_info& game);
@@ -282,4 +284,5 @@ private:
 	QSize m_Icon_Size = gui::gl_icon_size_min; // ensure a valid size
 	qreal m_Margin_Factor;
 	qreal m_Text_Factor;
+	bool m_drawCompatStatusToGrid;
 };

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -173,6 +173,7 @@ namespace gui
 	const gui_save gl_marginFactor = gui_save(game_list, "marginFactor", (qreal) 0.09);
 	const gui_save gl_show_hidden  = gui_save(game_list, "show_hidden",  false);
 	const gui_save gl_hidden_list  = gui_save(game_list, "hidden_list",  QStringList());
+	const gui_save gl_draw_compat  = gui_save(game_list, "draw_compat",  false);
 
 	const gui_save fs_emulator_dir_list = gui_save(fs, "emulator_dir_list", QStringList());
 	const gui_save fs_dev_hdd0_list     = gui_save(fs, "dev_hdd0_list",     QStringList());

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1331,6 +1331,8 @@ void main_window::CreateConnects()
 		m_gameListFrame->Refresh();
 	});
 
+	connect(ui->showCompatibilityInGridAct, &QAction::triggered, m_gameListFrame, &game_list_frame::SetShowCompatibilityInGrid);
+
 	connect(ui->refreshGameListAct, &QAction::triggered, [=]
 	{
 		m_gameListFrame->Refresh(true);
@@ -1556,6 +1558,8 @@ void main_window::ConfigureGuiFromSettings(bool configure_all)
 
 	ui->showHiddenEntriesAct->setChecked(guiSettings->GetValue(gui::gl_show_hidden).toBool());
 	m_gameListFrame->SetShowHidden(ui->showHiddenEntriesAct->isChecked()); // prevent GetValue in m_gameListFrame->LoadSettings
+
+	ui->showCompatibilityInGridAct->setChecked(guiSettings->GetValue(gui::gl_draw_compat).toBool());
 
 	ui->showCatHDDGameAct->setChecked(guiSettings->GetCategoryVisibility(Category::Non_Disc_Game));
 	ui->showCatDiscGameAct->setChecked(guiSettings->GetCategoryVisibility(Category::Disc_Game));

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -264,6 +264,8 @@
     <addaction name="separator"/>
     <addaction name="showHiddenEntriesAct"/>
     <addaction name="separator"/>
+    <addaction name="showCompatibilityInGridAct"/>
+    <addaction name="separator"/>
     <addaction name="refreshGameListAct"/>
     <addaction name="menuGame_List_Mode"/>
     <addaction name="menuGame_List_Icons"/>
@@ -590,6 +592,14 @@
    </property>
    <property name="text">
     <string>Show Tool Bar</string>
+   </property>
+  </action>
+  <action name="showCompatibilityInGridAct">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Game Compatibility in Grid Mode</string>
    </property>
   </action>
   <action name="refreshGameListAct">


### PR DESCRIPTION
Adds an option in view menu for showing compatibility status in grid view. Does not affect list view.

Example:
![image](https://user-images.githubusercontent.com/19759300/46855992-f11e6d80-ce0d-11e8-9813-e3b15d83f232.png)

The reasoning behind this PR is to add more information to the grid view so that users woudn't need to switch back and forth between the two modes. It's set to off by default and thus needs to be manually enabled for those who wish for it to be shown.

Notes:
- Also adds support for CLion IDE; ignores `.idea/` for settings and `cmake-build-*/` for the default build directories.
- I haven't written a line of C++ before this, so I apoligize if I've made a mistake somewhere.
- Colors for Intro and Ingame are very close to each other and can thus be hard to distinquish. I haven't touched this myself as it's out of scope for this PR, but it could be worth it to consider adjusting them.
- Similarly, games that aren't in compatibility list do not have any color assigned so no circle can be shown for them.