### PR TITLE
Qt: set Vulkan surface in gs_frame

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -57,6 +57,12 @@ gs_frame::gs_frame(const QString& title, const QRect& geometry, QIcon appIcon, b
 
 	m_show_fps = static_cast<bool>(g_cfg.misc.show_fps_in_title);
 
+#ifdef __APPLE__
+	// Needed for MoltenVK to work properly on MacOS
+	if (g_cfg.video.renderer == video_renderer::vulkan)
+		setSurfaceType(QSurface::VulkanSurface);
+#endif
+
 	setGeometry(geometry);
 	setTitle(m_windowTitle);
 	setVisibility(Hidden);


### PR DESCRIPTION
This is needed for MoltenVK on MacOS, however the Vulkan->MoltenVK correlation was only established in Qt 5.12, so if you want to test MoltenVK (hint: it doesn't work nearly as well as gfx-rs/portability) you'll need to use the Qt 5.12 Beta as of right now.

Requesting review from @Megamouse 