### PR TITLE
Support for Master volume level setting

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -478,11 +478,11 @@ error_code cellAudioPortOpen(vm::ptr<CellAudioPortParam> audioParam, vm::ptr<u32
 
 	if (attr & CELL_AUDIO_PORTATTR_INITLEVEL)
 	{
-		port->level = audioParam->level;
+		port->level = audioParam->level * g_cfg.audio.volume / 100.0f;
 	}
 	else
 	{
-		port->level = 1.0f;
+		port->level = g_cfg.audio.volume / 100.0f;
 	}
 
 	port->level_set.store({ port->level, 0.0f });
@@ -696,6 +696,8 @@ error_code cellAudioSetPortLevel(u32 portNum, float level)
 	{
 		return CELL_AUDIO_ERROR_PORT_NOT_OPEN;
 	}
+
+	level *= g_cfg.audio.volume / 100.0f;
 
 	if (level >= 0.0f)
 	{

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -508,6 +508,7 @@ struct cfg_root : cfg::node
 		cfg::_bool downmix_to_2ch{this, "Downmix to Stereo", true};
 		cfg::_int<2, 128> frames{this, "Buffer Count", 32};
 		cfg::_int<1, 128> startt{this, "Start Threshold", 1};
+		cfg::_int<0, 200> volume{this, "Master Volume", 100};
 
 	} audio{this};
 


### PR DESCRIPTION
The idea with this PR is to allow users to modify the loudness of game sounds without having to tinker with OS settings, and add the possibility of having game-specific volume settings.

Notes:
* Does not include any changes for the settings menu, and thus the setting has to be modified by altering `config.yml` manually.

If someone wants to do GUI support ~~(@Megamouse perhaps?)~~ for this setting then I could cherrypick your commits into this PR, or those can be submitted as separate PR's after this one has been merged.