### PR TITLE
sys_fs_fcntl with parameter 0xC0000002 fix

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "sys_fs.h"
 
 #include <mutex>
@@ -982,12 +982,24 @@ error_code sys_fs_fcntl(u32 fd, u32 op, vm::ptr<void> _arg, u32 _size)
 		const auto arg = vm::static_ptr_cast<lv2_file_c0000002>(_arg);
 
 		const std::string_view vpath = arg->path.get_ptr();
-		const std::string local_path = vfs::get(vpath);
 
-		if (vpath.find_first_not_of('/') == -1)
+		if (vpath[0] != '/')
 		{
 			return {CELL_EPERM, vpath};
 		}
+
+		// Extract device from path
+		std::size_t lastslash = vpath.find_first_not_of('/', 1);
+		if (lastslash != std::string_view::npos)
+		{
+			lastslash = vpath.find_first_of('/', lastslash + 1);
+		}
+
+		if (lastslash == std::string_view::npos) lastslash = vpath.length();
+		else lastslash++;
+
+		const std::string_view device_path = vpath.substr(0, lastslash);
+		const std::string local_path = vfs::get(device_path);
 
 		if (local_path.empty())
 		{


### PR DESCRIPTION
sys_fs_fcntl with parameter 0xC0000002 should extract device path from the given path and use that to gather free space information.

I'm open to better implementations :p.