### PR TITLE
spu: remove npc variable

### DIFF
--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -53,8 +53,7 @@ bool spu_thread::read_reg(const u32 addr, u32& value)
 
 	case SPU_NPC_offs:
 	{
-		//npc = pc | ((ch_event_stat & SPU_EVENT_INTR_ENABLED) != 0);
-		value = npc;
+		value = pc | (interrupts_enabled);
 		return true;
 	}
 
@@ -237,7 +236,8 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 			break;
 		}
 
-		npc = value;
+		pc = value & 0x3fffc;
+		interrupts_enabled = (value & 1) != 0;
 		return true;
 	}
 
@@ -274,5 +274,7 @@ void spu_load_exec(const spu_exec_object& elf)
 		}
 	}
 
-	spu->npc = elf.header.e_entry;
+	const u32 npc = elf.header.e_entry;
+	spu->pc = npc & 0x3fffc;
+	spu->interrupts_enabled = (npc & 1) != 0;
 }

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2095,7 +2095,7 @@ bool spu_thread::stop_and_signal(u32 code)
 	case 0x002:
 	{
 		state += cpu_flag::ret;
-		return true;
+		return false;
 	}
 
 	case 0x110:
@@ -2283,7 +2283,7 @@ bool spu_thread::stop_and_signal(u32 code)
 		group->cv.notify_one();
 
 		state += cpu_flag::stop;
-		return true;
+		return false;
 	}
 
 	case 0x102:
@@ -2303,7 +2303,7 @@ bool spu_thread::stop_and_signal(u32 code)
 		group->cv.notify_one();
 
 		state += cpu_flag::stop;
-		return true;
+		return false;
 	}
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -563,7 +563,6 @@ public:
 
 	atomic_t<u32> run_ctrl; // SPU Run Control register (only provided to get latest data written)
 	atomic_t<u32> status; // SPU Status register
-	atomic_t<u32> npc; // SPU Next Program Counter register
 
 	std::array<spu_int_ctrl_t, 3> int_ctrl; // SPU Class 0, 1, 2 Interrupt Management
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -404,6 +404,7 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 
 			thread->status.exchange(SPU_STATUS_RUNNING);
 			atomic_storage<u32>::store(thread->pc, img.first.entry_point);
+			_mm_mfence();
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -397,13 +397,13 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 			sys_spu_image::deploy(thread->offset, img.second.data(), img.first.nsegs);
 
 			thread->cpu_init();
-			thread->npc = img.first.entry_point;
 			thread->gpr[3] = v128::from64(0, args[0]);
 			thread->gpr[4] = v128::from64(0, args[1]);
 			thread->gpr[5] = v128::from64(0, args[2]);
 			thread->gpr[6] = v128::from64(0, args[3]);
 
 			thread->status.exchange(SPU_STATUS_RUNNING);
+			atomic_storage<u32>::store(thread->pc, img.first.entry_point);
 		}
 	}
 


### PR DESCRIPTION
* avoids race conditions between sys_spu_thread_group_start and spu thread temporary exit in cpu_task() by removing npc setting. seen in catherine.
* emit check_state check immediatly after an exit stop code.