### PR TITLE
Extra check when opening pup file

### DIFF
--- a/rpcs3/Loader/PUP.cpp
+++ b/rpcs3/Loader/PUP.cpp
@@ -1,9 +1,15 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 
 #include "PUP.h"
 
 pup_object::pup_object(const fs::file& file): m_file(file)
 {
+	if (!file)
+	{
+		isValid = false;
+		return;
+	}
+
 	PUPHeader m_header;
 	m_file.read(m_header);
 	if (m_header.magic != "SCEUF\0\0\0"_u64)

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #include <QApplication>
 #include <QMenuBar>
 #include <QMessageBox>
@@ -532,6 +532,13 @@ void main_window::InstallPup(const QString& dropPath)
 	const std::string path = sstr(filePath);
 
 	fs::file pup_f(path);
+	if (!pup_f)
+	{
+		LOG_ERROR(GENERAL, "Error opening PUP file %s", path);
+		QMessageBox::critical(this, tr("Failure!"), tr("The selected firmware file couldn't be opened."));
+		return;
+	}
+
 	pup_object pup(pup_f);
 	if (!pup)
 	{


### PR DESCRIPTION
Adds an extra check to avoid "fs::file is null" exception in the event that the pup file couldn't be opened.