### PR TITLE
Increases default stack allocation for callbacks

### DIFF
--- a/rpcs3/Emu/Cell/PPUCallback.h
+++ b/rpcs3/Emu/Cell/PPUCallback.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Emu/Cell/PPUThread.h"
 
@@ -167,9 +167,9 @@ namespace ppu_cb_detail
 		FORCE_INLINE static void call(ppu_thread& CPU, u32 pc, u32 rtoc, T... args)
 		{
 			const bool stack = _bind_func_args<0, 0, 0, T...>(CPU, args...);
-			CPU.gpr[1] -= stack ? FIXED_STACK_FRAME_SIZE : 0x30; // create reserved area
+			CPU.gpr[1] -= stack ? FIXED_STACK_FRAME_SIZE : 0x70; // create reserved area
 			CPU.fast_call(pc, rtoc);
-			CPU.gpr[1] += stack ? FIXED_STACK_FRAME_SIZE : 0x30;
+			CPU.gpr[1] += stack ? FIXED_STACK_FRAME_SIZE : 0x70;
 		}
 	};
 }


### PR DESCRIPTION
This change moves "Afrika" a bit further ingame.

Before it died because a callback stores a value at r1[0x30]

seg001:002604A8                 stdu      r1, -0x40(r1)
seg001:002604AC                 std       r31, 0x38(r1)
seg001:002604B0                 mr        r31, r1
seg001:002604B4                 std       r3, 0x70(r31)  <- stores a value at +0x30 over the previous stack value

With previous stack allocation r1[0x30] was the r1[0] for the previous caller which is where is stored the saved stack.