### PR TITLE
cellVdecGetPicture accurate error checking

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUModule.h"
@@ -551,7 +551,7 @@ s32 cellVdecGetPicture(u32 handle, vm::cptr<CellVdecPicFormat> format, vm::ptr<u
 
 	const auto vdec = idm::get<vdec_context>(handle);
 
-	if (!format || !vdec)
+	if (!format || !vdec || format->formatType > 4 || (format->formatType <= CELL_VDEC_PICFMT_RGBA32_ILV && format->colorMatrixType > CELL_VDEC_COLOR_MATRIX_TYPE_BT709))
 	{
 		return CELL_VDEC_ERROR_ARG;
 	}
@@ -599,10 +599,6 @@ s32 cellVdecGetPicture(u32 handle, vm::cptr<CellVdecPicFormat> format, vm::ptr<u
 		}
 
 		// TODO: color matrix
-		if (format->colorMatrixType & ~1)
-		{
-			fmt::throw_exception("Unknown colorMatrixType (%d)" HERE, format->colorMatrixType);
-		}
 
 		if (alpha_plane)
 		{

--- a/rpcs3/Emu/Cell/Modules/cellVdec.h
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 
 
@@ -39,7 +39,7 @@ enum CellVdecDecodeMode : s32
 };
 
 // Output Picture Format Type
-enum CellVdecPicFormatType : s32
+enum CellVdecPicFormatType : u32
 {
 	CELL_VDEC_PICFMT_ARGB32_ILV,
 	CELL_VDEC_PICFMT_RGBA32_ILV,
@@ -48,7 +48,7 @@ enum CellVdecPicFormatType : s32
 };
 
 // Output Color Matrix Coef
-enum CellVdecColorMatrixType : s32
+enum CellVdecColorMatrixType : u32
 {
 	CELL_VDEC_COLOR_MATRIX_TYPE_BT601,
 	CELL_VDEC_COLOR_MATRIX_TYPE_BT709,
@@ -157,15 +157,15 @@ struct CellVdecPicItem
 // Output Picture Format
 struct CellVdecPicFormat
 {
-	be_t<s32> formatType; // CellVdecPicFormatType
-	be_t<s32> colorMatrixType; // CellVdecColorMatrixType
+	be_t<u32> formatType; // CellVdecPicFormatType
+	be_t<u32> colorMatrixType; // CellVdecColorMatrixType
 	u8 alpha;
 };
 
 struct CellVdecPicFormat2
 {
-	be_t<s32> formatType; // CellVdecPicFormatType
-	be_t<s32> colorMatrixType; // CellVdecColorMatrixType
+	be_t<u32> formatType; // CellVdecPicFormatType
+	be_t<u32> colorMatrixType; // CellVdecColorMatrixType
 	be_t<u32> unk0;
 	u8 alpha;
 	be_t<u32> unk1;


### PR DESCRIPTION
Value of format->colorMatrixType is only checked for certain formats.
Fixes an issue with Ridge Racer 7 3D.