### PR TITLE
RawSPU Interrupts Race Condition Fixes

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -4,6 +4,7 @@
 #include "../CPU/CPUThread.h"
 #include "../Memory/vm.h"
 #include "Utilities/lockless.h"
+#include "SPUThread.h"
 
 enum class ppu_cmd : u32
 {
@@ -170,6 +171,8 @@ public:
 	const u32 stack_addr; // Stack address
 
 	atomic_t<u32> joiner{~0u}; // Joining thread (-1 if detached)
+	atomic_t<spu_int_ctrl_t*> intr_ctrl{}; // Bound SPU thread interrupt entry
+	atomic_t<bool> intr_cleared{false}; // Set if the interrupt has been ack
 
 	lf_fifo<atomic_t<cmd64>, 127> cmd_queue; // Command queue for asynchronous operations.
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -728,8 +728,6 @@ void spu_thread::cpu_init()
 	ch_out_mbox.data.release({});
 	ch_out_intr_mbox.data.release({});
 
-	snr_config = 0;
-
 	ch_snr1.data.release({});
 	ch_snr2.data.release({});
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -546,7 +546,7 @@ public:
 	spu_channel ch_out_mbox;
 	spu_channel ch_out_intr_mbox;
 
-	u64 snr_config; // SPU SNR Config Register
+	u64 snr_config = 0; // SPU SNR Config Register
 
 	spu_channel ch_snr1; // SPU Signal Notification Register 1
 	spu_channel ch_snr2; // SPU Signal Notification Register 2

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -230,12 +230,12 @@ public:
 	}
 
 	// Pop unconditionally (loading last value), may require notification
-	u32 pop(cpu_thread& spu)
+	u32 pop(cpu_thread& spu, bool use_count = false)
 	{
 		// Value is not cleared and may be read again
 		const u64 old = data.fetch_and(~(bit_count | bit_wait));
 
-		if (old & bit_wait)
+		if (old & (use_count ? bit_count : bit_wait))
 		{
 			spu.notify();
 		}
@@ -355,11 +355,11 @@ struct spu_int_ctrl_t
 
 	std::shared_ptr<struct lv2_int_tag> tag;
 
-	void set(u64 ints);
+	bool set(u64 ints);
 
-	void clear(u64 ints)
+	bool clear(u64 ints)
 	{
-		stat &= ~ints;
+		return stat.fetch_and(~ints) & ints;
 	}
 
 	void clear()

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -851,16 +851,16 @@ error_code sys_spu_thread_set_spu_cfg(u32 id, u64 value)
 {
 	sys_spu.warning("sys_spu_thread_set_spu_cfg(id=0x%x, value=0x%x)", id, value);
 
+	if (value > 3)
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto thread = idm::get<named_thread<spu_thread>>(id);
 
 	if (UNLIKELY(!thread || !thread->group))
 	{
 		return CELL_ESRCH;
-	}
-
-	if (value > 3)
-	{
-		return CELL_EINVAL;
 	}
 
 	thread->snr_config = value;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -324,7 +324,7 @@ error_code sys_raw_spu_destroy(ppu_thread& ppu, u32 id);
 error_code sys_raw_spu_create_interrupt_tag(u32 id, u32 class_id, u32 hwthread, vm::ptr<u32> intrtag);
 error_code sys_raw_spu_set_int_mask(u32 id, u32 class_id, u64 mask);
 error_code sys_raw_spu_get_int_mask(u32 id, u32 class_id, vm::ptr<u64> mask);
-error_code sys_raw_spu_set_int_stat(u32 id, u32 class_id, u64 stat);
+error_code sys_raw_spu_set_int_stat(ppu_thread& ppu, u32 id, u32 class_id, u64 stat);
 error_code sys_raw_spu_get_int_stat(u32 id, u32 class_id, vm::ptr<u64> stat);
 error_code sys_raw_spu_read_puint_mb(u32 id, vm::ptr<u32> value);
 error_code sys_raw_spu_set_spu_cfg(u32 id, u32 value);


### PR DESCRIPTION
* Wait for the interrupt thread to read the mailbox before continueing.
* Wait for the previous interrupt to be completed before invoking the next.
* Fix sys_spu_thread_set_cfg: fix error checking order and value if set before thread_group_start(). [testcase](https://github.com/elad335/myps3tests/tree/master/spu_tests/spu%20cfg)
testcase is testing returned error code when setting invalid cfg value with non-existing spu thread id, and spu cfg value after group_start().
* Loop interrupt handler until the interrupt status is cleared.

[testcase](https://github.com/elad335/myps3tests/tree/master/spu_tests/raw%20spu/mailbox%20interrupts%20(2)), spu thread pushes one value into the interrupt mailbox, The handler avoids clearing the interrupt status and loops infinitely until eventually it clears the status after the 10th interrupt to avoid tty spam. (defaults are shown on tty)   