### PR TITLE
Debug console emulation

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.h
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.h
@@ -395,8 +395,6 @@ public:
 		u32 v1, v2;
 	};
 	attr_t attr[500]{};
-
-	lv2_memory_container container;
 	atomic_t<u32> frame_num;
 };
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1526,6 +1526,12 @@ void ppu_load_exec(const ppu_exec_object& elf)
 		mem_size = 0xC800000;
 	}
 
+	if (g_cfg.core.debug_console_mode)
+	{
+		// TODO: Check for all sdk versions
+		mem_size += 0xC000000;
+	}
+
 	fxm::make_always<lv2_memory_container>(mem_size);
 
 	ppu->cmd_push({ppu_cmd::initialize, 0});

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -12,6 +12,7 @@
 #include "Emu/Cell/PPUAnalyser.h"
 
 #include "Emu/Cell/lv2/sys_prx.h"
+#include "Emu/Cell/lv2/sys_memory.h"
 
 #include <map>
 #include <set>
@@ -1496,6 +1497,36 @@ void ppu_load_exec(const ppu_exec_object& elf)
 		std::memcpy(vm::base(ppu->stack_addr + ppu->stack_size - ::size32(Emu.data)), Emu.data.data(), Emu.data.size());
 		ppu->gpr[1] -= Emu.data.size();
 	}
+
+	// Initialize memory stats (according to sdk version)
+	// TODO: This is probably wrong with vsh.self
+	u32 mem_size;
+	if (sdk_version > 0x0021FFFF)
+	{
+		mem_size = 0xD500000; 
+	}
+	else if (sdk_version > 0x00192FFF)
+	{
+		mem_size = 0xD300000;
+	}
+	else if (sdk_version > 0x0018FFFF)
+	{
+		mem_size = 0xD100000;
+	}
+	else if (sdk_version > 0x0017FFFF)
+	{
+		mem_size = 0xD000000;
+	}
+	else if (sdk_version > 0x00154FFF)
+	{
+		mem_size = 0xCC00000;
+	}
+	else
+	{
+		mem_size = 0xC800000;
+	}
+
+	fxm::make_always<lv2_memory_container>(mem_size);
 
 	ppu->cmd_push({ppu_cmd::initialize, 0});
 

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -37,7 +37,7 @@ error_code sys_memory_allocate(u32 size, u64 flags, vm::ptr<u32> alloc_addr)
 	}
 
 	// Get "default" memory container
-	const auto dct = fxm::get_always<lv2_memory_container>();
+	const auto dct = fxm::get<lv2_memory_container>();
 
 	// Try to get "physical memory"
 	if (!dct->take(size))
@@ -151,7 +151,7 @@ error_code sys_memory_free(u32 addr)
 		}
 
 		// Return "physical memory" to the default container
-		fxm::get_always<lv2_memory_container>()->used -= shm.second->size();
+		fxm::get<lv2_memory_container>()->used -= shm.second->size();
 
 		return CELL_OK;
 	}
@@ -209,7 +209,7 @@ error_code sys_memory_get_user_memory_size(vm::ptr<sys_memory_info_t> mem_info)
 	sys_memory.warning("sys_memory_get_user_memory_size(mem_info=*0x%x)", mem_info);
 
 	// Get "default" memory container
-	const auto dct = fxm::get_always<lv2_memory_container>();
+	const auto dct = fxm::get<lv2_memory_container>();
 
 	mem_info->total_user_memory = dct->size;
 	mem_info->available_user_memory = dct->size - dct->used;
@@ -235,7 +235,7 @@ error_code sys_memory_container_create(vm::ptr<u32> cid, u32 size)
 		return CELL_ENOMEM;
 	}
 
-	const auto dct = fxm::get_always<lv2_memory_container>();
+	const auto dct = fxm::get<lv2_memory_container>();
 
 	// Try to obtain "physical memory" from the default container
 	if (!dct->take(size))

--- a/rpcs3/Emu/Cell/lv2/sys_memory.h
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.h
@@ -50,13 +50,8 @@ struct lv2_memory_container
 	static const u32 id_step = 0x1;
 	static const u32 id_count = 16;
 
-	// This is purposely set lower to fake the size of the OS
-	// Todo: This could change with requested sdk
-	const u32 size = 0xEC00000; // Amount of "physical" memory in this container
-
+	const u32 size; // Amount of "physical" memory in this container
 	atomic_t<u32> used{}; // Amount of "physical" memory currently used
-
-	lv2_memory_container() = default;
 
 	lv2_memory_container(u32 size)
 		: size(size)

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -77,6 +77,7 @@ error_code sys_mmapper_allocate_shared_memory(u64 unk, u32 size, u64 flags, vm::
 	// Check page granularity
 	switch (flags & SYS_MEMORY_PAGE_SIZE_MASK)
 	{
+	case 0:
 	case SYS_MEMORY_PAGE_SIZE_1M:
 	{
 		if (size % 0x100000)
@@ -112,7 +113,7 @@ error_code sys_mmapper_allocate_shared_memory(u64 unk, u32 size, u64 flags, vm::
 	}
 
 	// Generate a new mem ID
-	*mem_id = idm::make<lv2_obj, lv2_memory>(size, flags & SYS_MEMORY_PAGE_SIZE_1M ? 0x100000 : 0x10000, flags, dct);
+	*mem_id = idm::make<lv2_obj, lv2_memory>(size, flags & SYS_MEMORY_PAGE_SIZE_64K ? 0x10000 : 0x100000, flags, dct);
 
 	return CELL_OK;
 }
@@ -124,6 +125,7 @@ error_code sys_mmapper_allocate_shared_memory_from_container(u64 unk, u32 size, 
 	// Check page granularity.
 	switch (flags & SYS_MEMORY_PAGE_SIZE_MASK)
 	{
+	case 0:
 	case SYS_MEMORY_PAGE_SIZE_1M:
 	{
 		if (size % 0x100000)
@@ -172,7 +174,7 @@ error_code sys_mmapper_allocate_shared_memory_from_container(u64 unk, u32 size, 
 	}
 
 	// Generate a new mem ID
-	*mem_id = idm::make<lv2_obj, lv2_memory>(size, flags & SYS_MEMORY_PAGE_SIZE_1M ? 0x100000 : 0x10000, flags, ct.ptr);
+	*mem_id = idm::make<lv2_obj, lv2_memory>(size, flags & SYS_MEMORY_PAGE_SIZE_64K ? 0x10000 : 0x100000, flags, ct.ptr);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -105,7 +105,7 @@ error_code sys_mmapper_allocate_shared_memory(u64 unk, u32 size, u64 flags, vm::
 	}
 
 	// Get "default" memory container
-	const auto dct = fxm::get_always<lv2_memory_container>();
+	const auto dct = fxm::get<lv2_memory_container>();
 
 	if (!dct->take(size))
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_tty.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_tty.cpp
@@ -1,4 +1,6 @@
 #include "stdafx.h"
+#include "Emu/System.h"
+
 #include "sys_tty.h"
 
 #include <deque>
@@ -15,7 +17,7 @@ error_code sys_tty_read(s32 ch, vm::ptr<char> buf, u32 len, vm::ptr<u32> preadle
 {
 	sys_tty.trace("sys_tty_read(ch=%d, buf=*0x%x, len=%d, preadlen=*0x%x)", ch, buf, len, preadlen);
 
-	if (false) // TODO: debug mode check
+	if (!g_cfg.core.debug_console_mode)
 	{
 		return CELL_EIO;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -21,7 +21,7 @@ error_code sys_vm_memory_map(u32 vsize, u32 psize, u32 cid, u64 flag, u64 policy
 	}
 
 	// Look for unmapped space
-	if (const auto area = vm::find_map(vsize, vsize == 0x10000000 ? 0x10000000 : 0x1000000, 2 | (flag & SYS_MEMORY_PAGE_SIZE_MASK)))
+	if (const auto area = vm::find_map(0x10000000, 0x10000000, 2 | (flag & SYS_MEMORY_PAGE_SIZE_MASK)))
 	{
 		// Alloc all memory (shall not fail)
 		verify(HERE), area->alloc(vsize);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -380,6 +380,7 @@ struct cfg_root : cfg::node
 		cfg::_bool spu_accurate_xfloat{this, "Accurate xfloat", false};
 		cfg::_bool spu_approx_xfloat{this, "Approximate xfloat", true};
 
+		cfg::_bool debug_console_mode{this, "Debug Console Mode", false}; // Debug console emulation, not recommended
 		cfg::_enum<lib_loading_type> lib_loading{this, "Lib Loader", lib_loading_type::liblv2only};
 		cfg::_bool hook_functions{this, "Hook static functions"};
 		cfg::set_entry load_libraries{this, "Load libraries"};

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -63,7 +63,7 @@ void kernel_explorer::Update()
 {
 	m_tree->clear();
 
-	const auto dct = fxm::get_always<lv2_memory_container>();
+	const auto dct = fxm::get<lv2_memory_container>();
 
 	if (!dct)
 	{


### PR DESCRIPTION
* Add missing 0 cases allocation granularity size flag for `sys_mmapper_allocate_shared_memory_x`, treat them as 1m (like sys_memory_allocate) . [testcase](https://github.com/elad335/myps3tests/tree/master/ppu_tests/sys_mmapper%20case%200%20alloc%20flag), the testcase tries 0 flag on shared memory allocation, tries to map it with an area with 1m page flags, returns CELL_OK.

* Fix sys_vm_memory_map address base when vsize is less than 256mb, allocate the block as 256mb in size. [testcase](https://github.com/elad335/myps3tests/tree/master/ppu_tests/sys_vm%2032%20mb), the testcase tries to call sys_vm_memory_map twice with 32 mb vsize, the address returned of the second map is 0x40000000. (0x32000000 on master)

* Change total amount of memory returned with sdk version:
I've tested this using a self file that I've changed its sdk version with an hex editor, to get the location of the sdk I've searched for the magic number of `process_param_t` and added 8 bytes from it.
The results are changes spotted and tracked down between different sdk versions, I've tested this with alot more versions but when memory size didnt change, I didnt include that. I've tested sdk ranges from 0.00.000 (fake minimum) to 4.75.001 (latest). .vesrion samples were taken from http://www.psdevwiki.com/ps3/SCEI_PS3_SDK. I've set the DECR to "console mode" to fake available memory on a retail console.

This was the first attempt to fix [Pirates of the Caribbean: At World's End](https://forums.rpcs3.net/thread-178150.html) as it tests availablle memory size and compares it with 192mb : above that it assumes its on a DECR console and can use much more memory than he can, which leads to an access violation.
Unfortunatly, this wasnt not enough, even though it was really close, work needs to be done for the memory stats to get lower enough for the test to pass successfuly. (e.g decreasing available memory size with sys_prx module loading, stack allocations etc).
So: I've started to think going with this the other way around: what if we give the same amounts of memory as the DECR gives? I've grabbed again the testcase and set the DECR to "debug tool mode", which makes the available 512mb ram of the console available to the user. In this case the memory size added to original memory size was anywhere from 192mb (0.00) to 194mb (4.75.001) so I've simply added 192mb to the total memory size and guess what, it booted like magic. Which led me to add a setting for it as mentioned below. with this setting enabled, its possible for the game to boot.

* Add debug console emulation mode

**Nothing** -> **Intro**
![image](https://user-images.githubusercontent.com/18193363/48841972-ae9c6900-ed9b-11e8-99ea-eb07d5b8b203.png)
