### PR TITLE
Readme cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,18 @@ For discussion about this emulator, PS3 emulation, and game compatibility report
 [**Support Lead Developers Nekotekina and kd-11 on Patreon**](https://www.patreon.com/Nekotekina)
 
 
-## Development
+## Contributing
 
-If you want to contribute, please take a look at the [Coding Style](https://github.com/RPCS3/rpcs3/wiki/Coding-Style), [Roadmap](https://github.com/RPCS3/rpcs3/wiki/Roadmap) and [Developer Information](https://github.com/RPCS3/rpcs3/wiki/Developer-Information) pages. You should also contact any of the developers in the forums or in the Discord server to learn more about the current state of the emulator.
+If you want to help the project but do not code, the best way to help out is to test games and make bug reports. See:
+* [Quickstart](https://rpcs3.net/quickstart)
+
+If you want to contribute as a developer, please take a look at the following pages:
+
+* [Coding Style](https://github.com/RPCS3/rpcs3/wiki/Coding-Style)
+* [Developer Information](https://github.com/RPCS3/rpcs3/wiki/Developer-Information)
+* [Roadmap](https://rpcs3.net/roadmap)
+
+You should also contact any of the developers in the forums or in the Discord server to learn more about the current state of the emulator.
 
 
 ## Dependencies
@@ -25,13 +34,13 @@ If you want to contribute, please take a look at the [Coding Style](https://gith
 * [CMake 3.8.2+](https://www.cmake.org/download/) (add to PATH)
 * [Python 3.3+](https://www.python.org/downloads/) (add to PATH)
 * [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) (See "Install the SDK" [here](https://vulkan.lunarg.com/doc/sdk/latest/windows/getting_started.html))
-* [Qt 5.10+](https://www.qt.io/download-open-source/)
+* [Qt 5.10+](https://www.qt.io/download-open-source/) (Avoid 5.11.1, due to a bug)
 
 
-**Either add the** `QTDIR` **environment variable, e.g.** `<QtInstallFolder>\5.11.1\msvc2017_64\` **, or use the [Visual Studio Qt Plugin](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools2017)**
+**Either add the** `QTDIR` **environment variable, e.g.** `<QtInstallFolder>\5.11.2\msvc2017_64\` **, or use the [Visual Studio Qt Plugin](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools-19123)**
 
 ### Linux
-* [Qt 5.10+](https://www.qt.io/download-open-source/)
+* [Qt 5.10+](https://www.qt.io/download-open-source/) (Avoid 5.11.1, due to a bug)
 * GCC 7.3+ or Clang 5.0+
 * CMake 3.8.2+
 * Debian & Ubuntu: `sudo apt-get install cmake build-essential libasound2-dev libpulse-dev libopenal-dev libglew-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git qt5-default libevdev-dev`
@@ -41,21 +50,25 @@ If you want to contribute, please take a look at the [Coding Style](https://gith
 
 **If you have an NVIDIA GPU, you may need to install the libglvnd package.**
 
-### MacOS
-MacOS is not supported at this moment because it doesn't meet system requirements (OpenGL 4.3)
-* Xcode 10
-* Install with Homebrew: `brew install glew llvm qt cmake`
 
+## Building
 
-## Building on Windows:
-To initialize the repository, don't forget to execute `git submodule update --init` to pull the submodules.
+Only Windows and Linux are officially supported for building. However, various other platforms are capable of building RPCS3. Other instructions may be found [here](https://wiki.rpcs3.net/index.php?title=Building).
 
-### Configuring the Qt plugin (if used)
+Clone and initialize the repository:
 
-1) Go to the Qt5 menu and edit Qt5 options. Add the path to your Qt installation with compiler e.g. `<QtInstallFolder>\5.11.1\msvc2017_64`.
-2) While selecting the rpcs3qt project, go to Qt5->Project Setting and select the version you added.
+1) `git clone https://github.com/RPCS3/rpcs3.git`
+2) `cd rpcs3/`
+3) `git submodule update --init`
 
-### Building the projects
+### Windows
+#### Configuring the Qt plugin (if used)
+
+1) Go to the Qt5 menu and edit Qt5 options.
+2) Add the path to your Qt installation with compiler e.g. `<QtInstallFolder>\5.11.2\msvc2017_64`.
+3) While selecting the rpcs3qt project, go to Qt5->Project Setting and select the version you added.
+
+#### Building the projects
 
 Open `rpcs3.sln`. The recommended build configuration is `Release - LLVM` for all purposes.
 
@@ -67,71 +80,16 @@ If you're not using precompiled libs, build the projects in *__BUILD_BEFORE* fol
 `Build > Build Solution`
 
 
-## Building on Windows (MinGW):
+### Linux
 
-1) Install packages
-- `pacman -S base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-yasm mingw-w64-x86_64-python2 mingw-w64-x86_64-ntldd-git mingw-w64-x86_64-qt5 mingw-w64-x86_64-openal mingw-w64-x86_64-glew git`
-2) Clone repository
-- `git clone https://github.com/RPCS3/rpcs3.git`
-3) Update submodules
-- `cd rpcs3`
-- `git submodule update --init`
-- `cd ..`
-4) Configure and compile RPCS3
-- `mkdir rpcs3_build && cd rpcs3_build`
-- `cmake -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM=mingw32-make ../rpcs3/`
-- `mingw32-make.exe GitVersion && mingw32-make.exe discord-rpc`
-- If you use ```-DUSE_SYSTEM_FFMPEG=OFF```, run `mingw32-make ffmpeg-mingw`
-5) Build RPCS3
-- Run `mingw32-make` or `mingw32-make -jX` where X is your CPU cores.
-6) Copy dependencies
-- `cd ./bin`
-- `for l in $(ntldd.exe -R rpcs3.exe|grep mingw64|sed -e 's/^[ \t]*//'|cut -d' ' -f3);do cp $l .;done`
-7) Copy qt plugins
-- `mkdir -p ./qt/plugins/{bearer,imageformats,platforms,styles}`
-- `cp /mingw64/share/qt5/plugins/bearer/qgenericbearer.dll ./qt/plugins/bearer/`
-- `cp /mingw64/share/qt5/plugins/imageformats/{qgif.dll,qicns.dll,qico.dll,qjpeg.dll,qtga.dll,qtiff.dll,qwbmp.dll,qwebp.dll} ./qt/plugins/imageformats/`
-- `cp /mingw64/share/qt5/plugins/platforms/qwindows.dll ./qt/plugins/platforms/`
-- `cp /mingw64/share/qt5/plugins/styles/qwindowsvistastyle.dll ./qt/plugins/styles/`
-8) Run RPCS3 with `./rpcs3`
+While still in the project root:
 
-
-## Building on Linux & Mac OS:
-
-1) `git clone https://github.com/RPCS3/rpcs3.git`
-2) `cd rpcs3/`
-3) `git submodule update --init`
-4) `cd ../ && mkdir rpcs3_build && cd rpcs3_build`
-4) `cmake ../rpcs3/ && make GitVersion && make`
-5) Run RPCS3 with `./bin/rpcs3`
-
-If you are on MacOS and want to build with brew llvm and qt, don't forget to add the following environment variables:
-
- * `LLVM_DIR=/usr/local/opt/llvm/` (or wherever llvm was installed).
- * `Qt5_DIR=/usr/local/opt/qt/lib/cmake/Qt5` (or wherever qt was installed).
+1) `cd .. && mkdir rpcs3_build && cd rpcs3_build`
+2) `cmake ../rpcs3/ && make GitVersion && make`
+3) Run RPCS3 with `./bin/rpcs3`
 
 When using GDB, configure it to ignore SIGSEGV signal (`handle SIGSEGV nostop noprint`).
-
-
-## CMake Build Options (Linux & Mac OS)
-
-- ```-DUSE_SYSTEM_LIBPNG=ON/OFF``` (default = *OFF*)
-Build against the shared libpng instead of using the built-in one. libpng 1.6+ highly recommended. Try this option if you get version conflict errors or only see black game icons.
-
-- ```-DUSE_SYSTEM_FFMPEG=ON/OFF``` (default = *OFF*)
-Build against the shared ffmpeg libraries instead of using the built-in patched version. Try this if the built-in version breaks the OpenGL renderer for you.
-
-- ```-DWITHOUT_LLVM=ON/OFF``` (default = *OFF*)
-This forces RPCS3 to build without LLVM (not recommended).
-
-- ```-DWITH_GDB=ON/OFF``` (default = *OFF*)
-This builds RPCS3 with support for debugging PS3 games using gdb.
-
-- ```-DUSE_VULKAN=ON/OFF``` (default = *ON*)
-This builds RPCS3 with Vulkan support.
-
-- ```-DUSE_NATIVE_INSTRUCTIONS=ON/OFF``` (default = *ON*)
-This builds RPCS3 with -march=native, which is useful for local builds, but not good for packages.
+If desired, use the various build options in [CMakeLists](https://github.com/RPCS3/rpcs3/blob/master/CMakeLists.txt).
 
 ## License
 


### PR DESCRIPTION
>why

The readme was getting really noisy. It may not seem super important, but a well written readme is always inviting to devs and users alike.

With that said, there are a couple of things that should probably be discussed. This project is used, built, and developed on a wide range of platforms, with a far wider set of tools and build chains. I do not think it makes sense, however, to have build and configuration info clogging the readme.

Therefore, I think there should simply be either:
1) Soft support for other platforms, hard support for Windows and Linux. By that I mean that build-fix prs and patches, or anything else relating to "oddball" platforms should be accepted by the project, as they already are, but not significantly maintained, or even acknowledged. This is essentially what we do now anyway: there's no CI or testing for these platforms, there's no artifact hosting for them either.

2) Hard support for all platforms and toolchains, with `kot` -level support for Windows and Linux. By this I mean potentially adding a page to the github wiki about various build tools and other configuration intructions. We should probably have a build page as it is, with at least some troubleshooting to keep basic build questions from leaking into #development on discord.

It seems apparent that it may be worthwhile to "merge" these two solutions into one.

Also @hcorion any chance you can have the other prepackaged libs get pushed to github? The google drive link is rather sad at this point.

p.s. If this gets merged, I was planning on squashing all the commits into one. We don't need 7 commits in the history for a readme :smile_cat: 


EDIT: Getting sense for how it looks is hard through diffs, so look here
https://github.com/JohnHolmesII/rpcs3/tree/readme