### PR TITLE
cellFsOpen flag fix

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -230,6 +230,11 @@ error_code sys_fs_open(vm::cptr<char> path, s32 flags, vm::ptr<u32> fd, s32 mode
 	if (flags & CELL_FS_O_CREAT)
 	{
 		open_mode += fs::create;
+
+		if (flags & CELL_FS_O_EXCL)
+		{
+			open_mode += fs::excl;
+		}
 	}
 
 	if (flags & CELL_FS_O_TRUNC)
@@ -240,18 +245,6 @@ error_code sys_fs_open(vm::cptr<char> path, s32 flags, vm::ptr<u32> fd, s32 mode
 	if (flags & CELL_FS_O_APPEND)
 	{
 		open_mode += fs::append;
-	}
-
-	if (flags & CELL_FS_O_EXCL)
-	{
-		if (flags & CELL_FS_O_CREAT)
-		{
-			open_mode += fs::excl;
-		}
-		else
-		{
-			open_mode = {}; // error
-		}
 	}
 
 	if (flags & CELL_FS_O_MSELF)


### PR DESCRIPTION
`CELL_FS_O_EXCL` has no effect without `CELL_FS_O_CREAT`. [testcase](https://github.com/elad335/myps3tests/tree/master/ppu_tests/cellFsOpen%20flags)
The testcase tries to open a non-existent file with EXCL with a few combinations of flags, error code is ENOENT.
Then creates the file and tries to open it again with the same flags, CELL_OK is returned.
Fixes an issue when trying to install game data with the updated version of Gran Turismo 6.