### PR TITLE
rsx: Reduce capture size + image_in fixes

### DIFF
--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -311,11 +311,12 @@ namespace rsx
 				in_pitch = in_bpp * in_w;
 			}
 
-			rsx->read_barrier(src_region.address, in_pitch * in_h);
+			const u32 src_size = in_pitch * (in_h - 1) + (in_w * in_bpp);
+			rsx->read_barrier(src_region.address, src_size);
 
 			frame_capture_data::memory_block_data block_data;
-			block_data.data.resize(in_pitch * in_h);
-			std::memcpy(block_data.data.data(), pixels_src, in_pitch * in_h);
+			block_data.data.resize(src_size);
+			std::memcpy(block_data.data.data(), pixels_src, src_size);
 			insert_mem_block_in_map(replay_command.memory_state, std::move(block), std::move(block_data));
 
 			capture_display_tile_state(rsx, replay_command);
@@ -337,7 +338,7 @@ namespace rsx
 			u32 src_dma    = method_registers.nv0039_input_location();
 			u32 src_addr   = get_address(src_offset, src_dma);
 
-			rsx->read_barrier(src_addr, in_pitch * line_count);
+			rsx->read_barrier(src_addr, in_pitch * (line_count - 1) + line_length);
 
 			const u8* src = (u8*)vm::base(src_addr);
 
@@ -345,7 +346,7 @@ namespace rsx
 			block.offset = src_offset;
 			block.location = src_dma;
 			frame_capture_data::memory_block_data block_data;
-			block_data.data.resize(in_pitch * line_count);
+			block_data.data.resize(in_pitch * (line_count - 1) + line_length);
 
 			for (u32 i = 0; i < line_count; ++i)
 			{

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -273,8 +273,8 @@ namespace rsx
 		{
 			const rsx::blit_engine::transfer_operation operation = method_registers.blit_engine_operation();
 
-			const u16 out_w = method_registers.blit_engine_output_width();
-			const u16 out_h = method_registers.blit_engine_output_height();
+			const u16 clip_w = std::min(method_registers.blit_engine_output_width(), method_registers.blit_engine_clip_width());
+			const u16 clip_h = std::min(method_registers.blit_engine_output_height(), method_registers.blit_engine_clip_height());
 
 			const u16 in_w = method_registers.blit_engine_input_width();
 			const u16 in_h = method_registers.blit_engine_input_height();
@@ -288,7 +288,7 @@ namespace rsx
 
 			u16 in_pitch = method_registers.blit_engine_input_pitch();
 
-			if (in_w == 0 || in_h == 0 || out_w == 0 || out_h == 0)
+			if (in_w == 0 || in_h == 0 || clip_w == 0 || clip_h == 0)
 			{
 				return;
 			}

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -150,7 +150,7 @@ namespace rsx
 					{
 						const auto& range = method_registers.current_draw_clause.get_range();
 						const u32 vertCount = range.count;
-						const size_t bufferSize = vertCount * vertStride + vertSize;
+						const size_t bufferSize = (vertCount - 1) * vertStride + vertSize;
 
 						frame_capture_data::memory_block block;
 						block.offset = base_address + (range.first * vertStride);
@@ -306,11 +306,6 @@ namespace rsx
 
 			u8* pixels_src = src_region.tile ? src_region.ptr + src_region.base : src_region.ptr;
 
-			if (in_pitch == 0)
-			{
-				in_pitch = in_bpp * in_w;
-			}
-
 			const u32 src_size = in_pitch * (in_h - 1) + (in_w * in_bpp);
 			rsx->read_barrier(src_region.address, src_size);
 
@@ -328,11 +323,6 @@ namespace rsx
 			const u32 line_length = method_registers.nv0039_line_length();
 			const u32 line_count  = method_registers.nv0039_line_count();
 			const u8 in_format    = method_registers.nv0039_input_format();
-
-			if (!in_pitch)
-			{
-				in_pitch = line_length;
-			}
 
 			u32 src_offset = method_registers.nv0039_input_offset();
 			u32 src_dma    = method_registers.nv0039_input_location();
@@ -355,7 +345,6 @@ namespace rsx
 			}
 
 			insert_mem_block_in_map(replay_command.memory_state, std::move(block), std::move(block_data));
-
 			capture_display_tile_state(rsx, replay_command);
 		}
 

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -13,40 +13,11 @@ namespace rsx
 {
 	namespace capture
 	{
-		u32 get_io_offset(u32 offset, u32 location)
-		{
-			switch (location)
-			{
-			case CELL_GCM_CONTEXT_DMA_MEMORY_HOST_BUFFER:
-			case CELL_GCM_LOCATION_MAIN:
-			{
-				if (u32 result = RSXIOMem.RealAddr(offset))
-				{
-					return offset;
-				}
-			}
-			case CELL_GCM_CONTEXT_DMA_REPORT_LOCATION_MAIN:
-			{
-				if (u32 result = RSXIOMem.RealAddr(0x0e000000 + offset))
-				{
-					return 0x0e000000 + offset;
-				}
-			}
-			default: return 0xFFFFFFFFu;
-			}
-		}
-
 		void insert_mem_block_in_map(std::unordered_set<u64>& mem_changes, frame_capture_data::memory_block&& block, frame_capture_data::memory_block_data&& data)
 		{
-			u64 data_hash = 0;
 			if (data.data.size() > 0)
 			{
-				data_hash = XXH64(data.data.data(), data.data.size(), 0);
-				// using 0 to signify no block in use, so this one is 'reserved'
-				if (data_hash == 0)
-					fmt::throw_exception("Memory block data hash equal to 0");
-
-				block.size       = data.data.size();
+				u64 data_hash = XXH64(data.data.data(), data.data.size(), 0);
 				block.data_state = data_hash;
 
 				auto it = frame_capture.memory_data_map.find(data_hash);
@@ -58,12 +29,12 @@ namespace rsx
 				}
 				else
 					frame_capture.memory_data_map.insert(std::make_pair(data_hash, std::move(data)));
-			}
 
-			u64 block_hash = XXH64(&block, sizeof(frame_capture_data::memory_block), 0);
-			mem_changes.insert(block_hash);
-			if (frame_capture.memory_map.find(block_hash) == frame_capture.memory_map.end())
-				frame_capture.memory_map.insert(std::make_pair(block_hash, std::move(block)));
+				u64 block_hash = XXH64(&block, sizeof(frame_capture_data::memory_block), 0);
+				mem_changes.insert(block_hash);
+				if (frame_capture.memory_map.find(block_hash) == frame_capture.memory_map.end())
+					frame_capture.memory_map.insert(std::make_pair(block_hash, std::move(block)));
+			}
 		}
 
 		void capture_draw_memory(thread* rsx)
@@ -91,7 +62,7 @@ namespace rsx
 			const u32 ucode_size    = program_info.program_ucode_length;
 
 			frame_capture_data::memory_block block;
-			block.ioOffset = program_offset, 
+			block.offset = program_offset;
 			block.location = program_location;
 			frame_capture_data::memory_block_data block_data;
 			block_data.data.resize(ucode_size + program_start);
@@ -118,9 +89,8 @@ namespace rsx
 					continue;
 
 				frame_capture_data::memory_block block;
-				block.ioOffset = tex.offset();
+				block.offset = tex.offset();
 				block.location = tex.location();
-
 				frame_capture_data::memory_block_data block_data;
 				block_data.data.resize(texSize);
 				std::memcpy(block_data.data.data(), vm::base(texaddr), texSize);
@@ -145,7 +115,7 @@ namespace rsx
 					continue;
 
 				frame_capture_data::memory_block block;
-				block.ioOffset = tex.offset();
+				block.offset = tex.offset();
 				block.location = tex.location();
 				frame_capture_data::memory_block_data block_data;
 				block_data.data.resize(texSize);
@@ -183,12 +153,11 @@ namespace rsx
 						const size_t bufferSize = vertCount * vertStride + vertSize;
 
 						frame_capture_data::memory_block block;
-						block.ioOffset = base_address;
+						block.offset = base_address + (range.first * vertStride);
 						block.location = memory_location;
-						block.offset = (range.first * vertStride);
 						frame_capture_data::memory_block_data block_data;
 						block_data.data.resize(bufferSize);
-						std::memcpy(block_data.data.data(), vm::base(addr + block.offset), bufferSize);
+						std::memcpy(block_data.data.data(), vm::base(addr + (range.first * vertStride)), bufferSize);
 						insert_mem_block_in_map(mem_changes, std::move(block), std::move(block_data));
 					}
 					while (method_registers.current_draw_clause.next());
@@ -207,9 +176,7 @@ namespace rsx
 				const auto index_type = method_registers.index_type();
 
 				// manually parse index buffer and copy vertex buffer
-				u32 min_index = 0xFFFF, max_index = 0;
-				if (index_type == index_array_type::u32)
-					min_index = 0xFFFFFFFF;
+				u32 min_index = 0xFFFFFFFF, max_index = 0;
 
 				const bool is_primitive_restart_enabled = method_registers.restart_index_enabled();
 				const u32 primitive_restart_index       = method_registers.restart_index();
@@ -225,10 +192,8 @@ namespace rsx
 					const size_t bufferSize = idxCount * type_size;
 
 					frame_capture_data::memory_block block;
-					block.ioOffset = base_address;
+					block.offset = base_address + (idxFirst * type_size);
 					block.location = memory_location;
-					block.offset   = (idxFirst * type_size);
-
 					frame_capture_data::memory_block_data block_data;
 					block_data.data.resize(bufferSize);
 					std::memcpy(block_data.data.data(), vm::base(idxAddr), bufferSize);
@@ -268,45 +233,39 @@ namespace rsx
 				}
 				while (method_registers.current_draw_clause.next());
 
-				if (min_index > max_index)
+				if (min_index <= max_index)
 				{
-					// ignore?
-				}
+					for (u8 index = 0; index < limits::vertex_count; ++index)
+					{
+						const bool enabled = !!(input_mask & (1 << index));
+						if (!enabled)
+							continue;
 
-				for (u8 index = 0; index < limits::vertex_count; ++index)
-				{
-					const bool enabled = !!(input_mask & (1 << index));
-					if (!enabled)
-						continue;
+						const auto& info = method_registers.vertex_arrays_info[index];
+						if (!info.size())
+							continue;
 
-					const auto& info = method_registers.vertex_arrays_info[index];
-					if (!info.size())
-						continue;
+						// vert buffer
+						const u32 vertStride      = info.stride();
+						const u32 base_address    = get_vertex_offset_from_base(method_registers.vertex_data_base_offset(), (info.offset() & 0x7fffffff));
+						const u32 memory_location = info.offset() >> 31;
 
-					// vert buffer
-					const u32 vertStride      = info.stride();
-					const u32 base_address    = get_vertex_offset_from_base(method_registers.vertex_data_base_offset(), info.offset() & 0x7fffffff);
-					const u32 memory_location = info.offset() >> 31;
+						const u32 addr     = get_address(base_address, memory_location);
+						const u32 vertSize = get_vertex_type_size_on_host(info.type(), info.size());
+						const u32 bufferSize = vertStride * (max_index - min_index + 1) + vertSize;
 
-					const u32 addr     = get_address(base_address, memory_location);
-					const u32 vertSize = get_vertex_type_size_on_host(info.type(), info.size());
-
-					const u32 bufferSize = vertStride * (max_index - min_index + 1) + vertSize;
-
-					frame_capture_data::memory_block block;
-					block.ioOffset = base_address;
-					block.location = memory_location;
-					block.offset   = (min_index * vertStride);
-
-					frame_capture_data::memory_block_data block_data;
-					block_data.data.resize(bufferSize);
-					std::memcpy(block_data.data.data(), vm::base(addr + block.offset), bufferSize);
-					insert_mem_block_in_map(mem_changes, std::move(block), std::move(block_data));
+						frame_capture_data::memory_block block;
+						block.offset = base_address + (min_index * vertStride);
+						block.location = memory_location;
+						frame_capture_data::memory_block_data block_data;
+						block_data.data.resize(bufferSize);
+						std::memcpy(block_data.data.data(), vm::base(addr + (min_index * vertStride)), bufferSize);
+						insert_mem_block_in_map(mem_changes, std::move(block), std::move(block_data));
+					}
 				}
 			}
 
 			capture_display_tile_state(rsx, frame_capture.replay_commands.back());
-			capture_surface_state(rsx, frame_capture.replay_commands.back());
 		}
 
 		// i realize these are a slight copy pasta of the rsx_method implementations but its kinda unavoidable currently
@@ -314,8 +273,6 @@ namespace rsx
 		{
 			const rsx::blit_engine::transfer_operation operation = method_registers.blit_engine_operation();
 
-			const u16 out_x = method_registers.blit_engine_output_x();
-			const u16 out_y = method_registers.blit_engine_output_y();
 			const u16 out_w = method_registers.blit_engine_output_width();
 			const u16 out_h = method_registers.blit_engine_output_height();
 
@@ -344,7 +301,7 @@ namespace rsx
 			const tiled_region src_region = rsx->get_tiled_address(src_offset + in_offset, src_dma & 0xf);
 
 			frame_capture_data::memory_block block;
-			block.ioOffset   = src_region.tile ? src_region.base : src_offset + in_offset;
+			block.offset = src_region.tile ? src_region.base : src_offset + in_offset;
 			block.location = src_dma & 0xf;
 
 			u8* pixels_src = src_region.tile ? src_region.ptr + src_region.base : src_region.ptr;
@@ -360,48 +317,6 @@ namespace rsx
 			block_data.data.resize(in_pitch * in_h);
 			std::memcpy(block_data.data.data(), pixels_src, in_pitch * in_h);
 			insert_mem_block_in_map(replay_command.memory_state, std::move(block), std::move(block_data));
-
-			// 'capture' destination to ensure memory is alloc'd and usable in replay
-			u32 dst_offset = 0;
-			u32 dst_dma    = 0;
-			rsx::blit_engine::transfer_destination_format dst_color_format;
-			u32 out_pitch    = 0;
-			u32 out_alignment = 64;
-
-			switch (method_registers.blit_engine_context_surface())
-			{
-			case blit_engine::context_surface::surface2d:
-				dst_dma          = method_registers.blit_engine_output_location_nv3062();
-				dst_offset       = method_registers.blit_engine_output_offset_nv3062();
-				dst_color_format = method_registers.blit_engine_nv3062_color_format();
-				out_pitch        = method_registers.blit_engine_output_pitch_nv3062();
-				out_alignment     = method_registers.blit_engine_output_alignment_nv3062();
-				break;
-
-			case blit_engine::context_surface::swizzle2d:
-				dst_dma          = method_registers.blit_engine_nv309E_location();
-				dst_offset       = method_registers.blit_engine_nv309E_offset();
-				dst_color_format = method_registers.blit_engine_output_format_nv309E();
-				break;
-
-			default: break;
-			}
-
-			const u32 out_bpp             = (dst_color_format == rsx::blit_engine::transfer_destination_format::r5g6b5) ? 2 : 4;
-			const s32 out_offset          = out_x * out_bpp + out_pitch * out_y;
-			const tiled_region dst_region = rsx->get_tiled_address(dst_offset + out_offset, dst_dma & 0xf);
-
-			frame_capture_data::memory_block blockDst;
-			blockDst.ioOffset = dst_region.tile ? dst_region.base : dst_offset + out_offset;
-			blockDst.location = dst_dma & 0xf;
-			if (get_io_offset(blockDst.ioOffset, blockDst.location) != -1)
-			{
-				u32 blockSize = method_registers.blit_engine_context_surface() != blit_engine::context_surface::swizzle2d ? out_pitch * out_h : out_bpp * next_pow2(out_w) * next_pow2(out_h);
-
-				blockDst.size = blockSize;
-				frame_capture_data::memory_block_data block_data;
-				insert_mem_block_in_map(replay_command.memory_state, std::move(blockDst), std::move(block_data));
-			}
 
 			capture_display_tile_state(rsx, replay_command);
 		}
@@ -427,9 +342,8 @@ namespace rsx
 			const u8* src = (u8*)vm::base(src_addr);
 
 			frame_capture_data::memory_block block;
-			block.ioOffset = src_offset;
+			block.offset = src_offset;
 			block.location = src_dma;
-
 			frame_capture_data::memory_block_data block_data;
 			block_data.data.resize(in_pitch * line_count);
 
@@ -440,29 +354,6 @@ namespace rsx
 			}
 
 			insert_mem_block_in_map(replay_command.memory_state, std::move(block), std::move(block_data));
-
-			// we 'capture' destination mostly to ensure that the location is allocated when replaying
-			u32 dst_offset = method_registers.nv0039_output_offset();
-			u32 dst_dma    = method_registers.nv0039_output_location();
-			u32 dst_addr   = get_address(dst_offset, dst_dma);
-
-			s32 out_pitch = method_registers.nv0039_output_pitch();
-			if (!out_pitch)
-			{
-				out_pitch = line_length;
-			}
-
-			frame_capture_data::memory_block blockDst;
-			blockDst.ioOffset = dst_offset;
-			blockDst.location = dst_dma;
-
-			// check if allocated
-			if (get_io_offset(blockDst.ioOffset, blockDst.location) != -1)
-			{
-				frame_capture_data::memory_block_data block_data;
-				blockDst.size = out_pitch * line_count;
-				insert_mem_block_in_map(replay_command.memory_state, std::move(blockDst), std::move(block_data));
-			}
 
 			capture_display_tile_state(rsx, replay_command);
 		}
@@ -489,34 +380,26 @@ namespace rsx
 			frame_capture_data::tile_state tilestate;
 			for (u32 i = 0; i < limits::tiles_count; ++i)
 			{
-				const auto& tile = rsx->tiles[i];
-				auto& tstate     = tilestate.tiles[i];
-				tstate.bank      = tile.bank;
-				tstate.base      = tile.base;
-				tstate.binded    = tile.binded;
-				tstate.comp      = tile.comp;
-				tstate.location  = tile.location;
-				tstate.offset    = tile.offset;
-				tstate.pitch     = tile.pitch;
-				tstate.size      = tile.size;
+				// Avoid byteswapping
+				auto tile = rsx->tiles[i].pack();
+				auto& tstate = tilestate.tiles[i];
+				tstate.tile = *reinterpret_cast<u32*>(&tile.tile);
+				tstate.limit = *reinterpret_cast<u32*>(&tile.limit);
+				tstate.pitch = rsx->tiles[i].binded ? *reinterpret_cast<u32*>(&tile.pitch) : 0;
+				tstate.format = rsx->tiles[i].binded ? *reinterpret_cast<u32*>(&tile.format) : 0;
 			}
 
 			for (u32 i = 0; i < limits::zculls_count; ++i)
 			{
-				const auto& zc      = rsx->zculls[i];
-				auto& zcstate       = tilestate.zculls[i];
-				zcstate.aaFormat    = zc.aaFormat;
-				zcstate.binded      = zc.binded;
-				zcstate.cullStart   = zc.cullStart;
-				zcstate.height      = zc.height;
-				zcstate.offset      = zc.offset;
-				zcstate.sFunc       = zc.sFunc;
-				zcstate.sMask       = zc.sMask;
-				zcstate.sRef        = zc.sRef;
-				zcstate.width       = zc.width;
-				zcstate.zcullDir    = zc.zcullDir;
-				zcstate.zcullFormat = zc.zcullFormat;
-				zcstate.zFormat     = zc.zFormat;
+				// Avoid byteswapping
+				auto zc = rsx->zculls[i].pack();
+				auto& zcstate = tilestate.zculls[i];
+				zcstate.region = *reinterpret_cast<u32*>(&zc.region);
+				zcstate.size = *reinterpret_cast<u32*>(&zc.size);
+				zcstate.start = *reinterpret_cast<u32*>(&zc.start);
+				zcstate.offset = *reinterpret_cast<u32*>(&zc.offset);
+				zcstate.status0 = rsx->zculls[i].binded ? *reinterpret_cast<u32*>(&zc.status0) : 0;
+				zcstate.status1 = rsx->zculls[i].binded ? *reinterpret_cast<u32*>(&zc.status1) : 0;
 			}
 
 			const u64 tsnum = XXH64(&tilestate, sizeof(frame_capture_data::tile_state), 0);
@@ -526,105 +409,6 @@ namespace rsx
 
 			replay_command.display_buffer_state = dbnum;
 			replay_command.tile_state           = tsnum;
-		}
-
-		// for the most part capturing this is just to make sure the iomemory is recorded/allocated and accounted for in replay
-		void capture_get_report(thread* rsx, frame_capture_data::replay_command& replay_command, u32 arg)
-		{
-			u32 location = 0;
-			u32 offset   = arg & 0xffffff;
-
-			blit_engine::context_dma report_dma = method_registers.context_dma_report();
-
-			switch (report_dma)
-			{
-			// ignore regular report location
-			case blit_engine::context_dma::to_memory_get_report: location = CELL_GCM_CONTEXT_DMA_REPORT_LOCATION_LOCAL; return;
-			case blit_engine::context_dma::report_location_main: location = CELL_GCM_CONTEXT_DMA_REPORT_LOCATION_MAIN; break;
-			case blit_engine::context_dma::memory_host_buffer: location = CELL_GCM_CONTEXT_DMA_MEMORY_HOST_BUFFER; break;
-			default: return;
-			}
-
-			u32 addr = get_address(offset, location);
-
-			frame_capture_data::memory_block block;
-			block.ioOffset = offset;
-			block.location = location;
-			block.size     = 16;
-
-			frame_capture_data::memory_block_data block_data;
-			
-			insert_mem_block_in_map(replay_command.memory_state, std::move(block), std::move(block_data));
-		}
-
-		// This just checks the color/depth addresses and makes sure they are accounted for in io allocations
-		// Hopefully this works without fully having to calculate actual size
-		void capture_surface_state(thread* rsx, frame_capture_data::replay_command& replay_command)
-		{
-			const auto target = rsx::method_registers.surface_color_target();
-
-			u32 offset_color[] =
-			{
-			    rsx::method_registers.surface_a_offset(),
-			    rsx::method_registers.surface_b_offset(),
-			    rsx::method_registers.surface_c_offset(),
-			    rsx::method_registers.surface_d_offset(),
-			};
-
-			u32 context_dma_color[] =
-			{
-			    rsx::method_registers.surface_a_dma(),
-			    rsx::method_registers.surface_b_dma(),
-			    rsx::method_registers.surface_c_dma(),
-			    rsx::method_registers.surface_d_dma(),
-			};
-
-			auto check_add = [&replay_command](u32 offset, u32 dma) -> void
-			{
-				u32 ioOffset = get_io_offset(offset, dma);
-				if (ioOffset == -1)
-					return;
-
-				frame_capture_data::memory_block block;
-				block.ioOffset = offset;
-				block.location = dma;
-				block.size     = 64;
-
-				frame_capture_data::memory_block_data block_data;
-				insert_mem_block_in_map(replay_command.memory_state, std::move(block), std::move(block_data));
-			};
-
-			for (const auto& index : utility::get_rtt_indexes(target))
-			{
-				check_add(offset_color[index], context_dma_color[index]);
-			}
-
-			check_add(rsx::method_registers.surface_z_offset(), rsx::method_registers.surface_z_dma());
-		}
-
-		void capture_inline_transfer(thread* rsx, frame_capture_data::replay_command& replay_command, u32 idx, u32 arg)
-		{
-			const u16 x = method_registers.nv308a_x();
-			const u16 y = method_registers.nv308a_y();
-
-			const u32 pixel_offset = (method_registers.blit_engine_output_pitch_nv3062() * y) + (x << 2);
-			const u32 addr_offset  = method_registers.blit_engine_output_offset_nv3062() + pixel_offset + idx * 4;
-
-			// just need to capture dst for allocation later if in iomem
-
-			const u32 memory_location = method_registers.blit_engine_output_location_nv3062();
-
-			const u32 ioOffset = get_io_offset(addr_offset, memory_location);
-			if (ioOffset == -1)
-				return;
-
-			frame_capture_data::memory_block block;
-			block.ioOffset   = addr_offset;
-			block.location = memory_location;
-			block.size     = 4;
-
-			frame_capture_data::memory_block_data block_data;
-			insert_mem_block_in_map(replay_command.memory_state, std::move(block), std::move(block_data));
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.h
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.h
@@ -10,8 +10,5 @@ namespace rsx
 		void capture_image_in(thread* rsx, frame_capture_data::replay_command& replay_command);
 		void capture_buffer_notify(thread* rsx, frame_capture_data::replay_command& replay_command);
 		void capture_display_tile_state(thread* rsx, frame_capture_data::replay_command& replay_command);
-		void capture_surface_state(thread* rsx, frame_capture_data::replay_command& replay_command);
-		void capture_get_report(thread* rsx, frame_capture_data::replay_command& replay_command, u32 arg);
-		void capture_inline_transfer(thread* rsx, frame_capture_data::replay_command& replay_command, u32 idx, u32 arg);
 	}
 }

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.h
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.h
@@ -4,9 +4,7 @@
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/Cell/lv2/sys_sync.h"
-#include "Emu/Cell/lv2/sys_ppu_thread.h"
 #include "Emu/RSX/rsx_methods.h"
-#include "Emu/RSX/gcm_enums.h"
 
 #include <cereal/types/vector.hpp>
 #include <cereal/types/array.hpp>
@@ -17,10 +15,9 @@
 namespace rsx
 {
 	constexpr u32 FRAME_CAPTURE_MAGIC = 0x52524300; // ascii 'RRC/0'
-	constexpr u32 FRAME_CAPTURE_VERSION = 0x3;
+	constexpr u32 FRAME_CAPTURE_VERSION = 0x4;
 	struct frame_capture_data
 	{
-
 		struct memory_block_data
 		{
 			std::vector<u8> data;
@@ -34,17 +31,14 @@ namespace rsx
 		// simple block to hold ps3 address and data
 		struct memory_block
 		{
-			u32 ioOffset{0xFFFFFFFF}; // rsx ioOffset, -1 signifies unused
-			u32 offset{0};		// offset into addr/ioOffset to copy state into
-			u32 size{0}; // size of block needed
-			u32 location{0xFFFFFFFF}; // Location of the block in RSX memory space
-			u64 data_state{0};		  // this can be 0, in which case its just needed as an alloc
+			u32 offset; // Offset in rsx address space
+			u32 location; // rsx memory location of the block
+			u64 data_state;
+
 			template<typename Archive>
 			void serialize(Archive & ar)
 			{
-				ar(ioOffset);
 				ar(offset);
-				ar(size);
 				ar(location);
 				ar(data_state);
 			}
@@ -67,62 +61,41 @@ namespace rsx
 			}
 		};
 
-		// same thing as gcmtileinfo
 		struct tile_info
 		{
-			u32 location{0};
-			u32 offset{0};
-			u32 size{0};
-			u32 pitch{0};
-			u32 comp{0};
-			u32 base{0};
-			u32 bank{0};
-			bool binded{false};
+			u32 tile;
+			u32 limit;
+			u32 pitch;
+			u32 format;
 
 			template<typename Archive>
 			void serialize(Archive & ar)
 			{
-				ar(location);
-				ar(offset);
-				ar(size);
+				ar(tile);
+				ar(limit);
 				ar(pitch);
-				ar(comp);
-				ar(base);
-				ar(bank);
-				ar(binded);
+				ar(format);
 			}
 		};
 
-		// same thing as gcmzcullinfo
 		struct zcull_info
 		{
-			u32 offset{0};
-			u32 width{0};
-			u32 height{0};
-			u32 cullStart{0};
-			u32 zFormat{0};
-			u32 aaFormat{0};
-			u32 zcullDir{0};
-			u32 zcullFormat{0};
-			u32 sFunc{0};
-			u32 sRef{0};
-			u32 sMask{0};
-			bool binded{false};
+			u32 region;
+			u32 size;
+			u32 start;
+			u32 offset;
+			u32 status0;
+			u32 status1;
 
 			template<typename Archive>
 			void serialize(Archive & ar)
 			{
+				ar(region);
+				ar(size);
+				ar(start);
 				ar(offset);
-				ar(width);
-				ar(cullStart);
-				ar(zFormat);
-				ar(aaFormat);
-				ar(zcullDir);
-				ar(zcullFormat);
-				ar(sFunc);
-				ar(sRef);
-				ar(sMask);
-				ar(binded);
+				ar(status0);
+				ar(status1);
 			}
 		};
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1990,12 +1990,6 @@ namespace rsx
 			u16 dst_w = dst.clip_width;
 			u16 dst_h = dst.clip_height;
 
-			if (!src_w || !src_h || !dst_w || !dst_h)
-			{
-				LOG_ERROR(RSX, "Blit engine request failed because of empty region");
-				return true;
-			}
-
 			//Check if src/dst are parts of render targets
 			auto dst_subres = m_rtts.get_surface_subresource_if_applicable(dst_address, dst.width, dst.clip_height, dst.pitch, true, false, false);
 			dst_is_render_target = dst_subres.surface != nullptr;

--- a/rpcs3/Emu/RSX/GCM.h
+++ b/rpcs3/Emu/RSX/GCM.h
@@ -73,12 +73,12 @@ struct CellGcmReportData
 
 struct CellGcmZcullInfo
 {
-	u32 region;
-	u32 size;
-	u32 start;
-	u32 offset;
-	u32 status0;
-	u32 status1;
+	be_t<u32> region;
+	be_t<u32> size;
+	be_t<u32> start;
+	be_t<u32> offset;
+	be_t<u32> status0;
+	be_t<u32> status1;
 };
 
 struct CellGcmDisplayInfo

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -523,21 +523,13 @@ namespace rsx
 
 					switch (reg)
 					{
-					case NV4097_GET_REPORT:
-						capture::capture_get_report(this, *it, value);
-						break;
 					case NV3089_IMAGE_IN:
 						capture::capture_image_in(this, *it);
 						break;
 					case NV0039_BUFFER_NOTIFY:
 						capture::capture_buffer_notify(this, *it);
 						break;
-					case NV4097_CLEAR_SURFACE:
-						capture::capture_surface_state(this, *it);
-						break;
 					default:
-						if (reg >= NV308A_COLOR && reg < NV3089_SET_OBJECT)
-							capture::capture_inline_transfer(this, *it, reg - NV308A_COLOR, value);
 						break;
 					}
 				}

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -2106,6 +2106,31 @@ struct registers_decoder<NV406E_SEMAPHORE_OFFSET>
 };
 
 template<>
+struct registers_decoder<NV4097_SET_CONTEXT_DMA_SEMAPHORE>
+{
+	struct decoded_type
+	{
+	private:
+		union
+		{
+			u32 raw_value;
+		} m_data;
+	public:
+		decoded_type(u32 raw_value) { m_data.raw_value = raw_value; }
+
+		u32 context_dma() const
+		{
+			return m_data.raw_value;
+		}
+	};
+
+	static std::string dump(decoded_type &&decoded_values)
+	{
+		return "NV4097 semaphore: context = " + std::to_string(decoded_values.context_dma());
+	}
+};
+
+template<>
 struct registers_decoder<NV4097_SET_SEMAPHORE_OFFSET>
 {
 	struct decoded_type

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "Utilities/types.h"
 #include "Utilities/BitField.h"
 #include "Utilities/StrFmt.h"
@@ -2243,9 +2243,22 @@ struct registers_decoder<NV3089_DS_DX>
 	public:
 		decoded_type(u32 raw_value) { m_data.raw_value = raw_value; }
 
-		u32 ds_dx() const
+		// Convert signed fixed point 32-bit format
+		f32 ds_dx() const
 		{
-			return m_data.raw_value;
+			const u32 val = m_data.raw_value;
+
+			if ((val & ~(1<<31)) == 0)
+			{
+				return 0;
+			}
+
+		    if ((s32)val < 0)
+			{
+		        return 1. / (((val & ~(1<<31)) / 1048576.f) - 2048.f);
+		    }
+
+			return 1048576.f / val;
 		}
 	};
 
@@ -2268,9 +2281,22 @@ struct registers_decoder<NV3089_DT_DY>
 	public:
 		decoded_type(u32 raw_value) { m_data.raw_value = raw_value; }
 
-		u32 dt_dy() const
+		// Convert signed fixed point 32-bit format
+		f32 dt_dy() const
 		{
-			return m_data.raw_value;
+		    const u32 val = m_data.raw_value;
+
+			if ((val & ~(1<<31)) == 0)
+			{
+				return 0;
+			}
+
+		    if ((s32)val < 0)
+			{
+		        return 1. / (((val & ~(1<<31)) / 1048576.f) - 2048.f);
+		    }
+
+		    return 1048576.f / val;
 		}
 	};
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -885,11 +885,6 @@ namespace rsx
 				out_pitch = out_bpp * out_w;
 			}
 
-			if (in_pitch == 0)
-			{
-				in_pitch = in_bpp * in_w;
-			}
-
 			const u32 in_offset = u32(in_x * in_bpp + in_pitch * in_y);
 			const s32 out_offset = out_x * out_bpp + out_pitch * out_y;
 
@@ -1164,16 +1159,6 @@ namespace rsx
 
 			LOG_TRACE(RSX, "NV0039_OFFSET_IN: pitch(in=0x%x, out=0x%x), line(len=0x%x, cnt=0x%x), fmt(in=0x%x, out=0x%x), notify=0x%x",
 				in_pitch, out_pitch, line_length, line_count, in_format, out_format, notify);
-
-			if (!in_pitch)
-			{
-				in_pitch = line_length;
-			}
-
-			if (!out_pitch)
-			{
-				out_pitch = line_length;
-			}
 
 			u32 src_offset = method_registers.nv0039_input_offset();
 			u32 src_dma = method_registers.nv0039_input_location();

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -900,7 +900,7 @@ namespace rsx
 			u8* pixels_dst = vm::_ptr<u8>(get_address(dst_offset + out_offset, dst_dma));
 
 			const auto read_address = get_address(src_offset, src_dma);
-			rsx->read_barrier(read_address, in_pitch * in_h);
+			rsx->read_barrier(read_address, in_pitch * (in_h - 1) + (in_w * in_bpp));
 
 			if (dst_color_format != rsx::blit_engine::transfer_destination_format::r5g6b5 &&
 				dst_color_format != rsx::blit_engine::transfer_destination_format::a8r8g8b8)
@@ -1182,7 +1182,7 @@ namespace rsx
 			u32 dst_dma = method_registers.nv0039_output_location();
 
 			const auto read_address = get_address(src_offset, src_dma);
-			rsx->read_barrier(read_address, in_pitch * line_count);
+			rsx->read_barrier(read_address, in_pitch * (line_count - 1) + line_length);
 
 			u8 *dst = (u8*)vm::base(get_address(dst_offset, dst_dma));
 			const u8 *src = (u8*)vm::base(read_address);

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -811,35 +811,30 @@ namespace rsx
 
 			//Clipping
 			//Validate that clipping rect will fit onto both src and dst regions
-			u16 clip_w = std::min(method_registers.blit_engine_clip_width(), out_w);
-			u16 clip_h = std::min(method_registers.blit_engine_clip_height(), out_h);
+			const u16 clip_w = std::min(method_registers.blit_engine_clip_width(), out_w);
+			const u16 clip_h = std::min(method_registers.blit_engine_clip_height(), out_h);
+
+			// Check both clip dimensions and dst dimensions
+			if (clip_w == 0 || clip_h == 0)
+			{
+				LOG_WARNING(RSX, "NV3089_IMAGE_IN: Operation NOPed out due to empty regions");
+				return;
+			}
+
+			if (in_w == 0 || in_h == 0)
+			{
+				LOG_ERROR(RSX, "NV3089_IMAGE_IN_SIZE: Invalid blit dimensions passed");
+				return;
+			}
 
 			u16 clip_x = method_registers.blit_engine_clip_x();
 			u16 clip_y = method_registers.blit_engine_clip_y();
-
-			if (clip_w == 0)
-			{
-				clip_x = 0;
-				clip_w = out_w;
-			}
-
-			if (clip_h == 0)
-			{
-				clip_y = 0;
-				clip_h = out_h;
-			}
 
 			//Fit onto dst
 			if (clip_x && (out_x + clip_x + clip_w) > out_w) clip_x = 0;
 			if (clip_y && (out_y + clip_y + clip_h) > out_h) clip_y = 0;
 
 			u16 in_pitch = method_registers.blit_engine_input_pitch();
-
-			if (in_w == 0 || in_h == 0 || out_w == 0 || out_h == 0)
-			{
-				LOG_ERROR(RSX, "NV3089_IMAGE_IN_SIZE: Invalid blit dimensions passed");
-				return;
-			}
 
 			if (in_origin != blit_engine::transfer_origin::corner)
 			{

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -820,8 +820,8 @@ namespace rsx
 
 			if (in_w == 0 || in_h == 0)
 			{
-				LOG_ERROR(RSX, "NV3089_IMAGE_IN_SIZE: Invalid blit dimensions passed");
-				return;
+				// Input cant be an empty region
+				fmt::throw_exception("NV3089_IMAGE_IN_SIZE: Invalid blit dimensions passed (in_w=%d, in_h=%d)" HERE, in_w, in_h);
 			}
 
 			u16 clip_x = method_registers.blit_engine_clip_x();
@@ -841,7 +841,7 @@ namespace rsx
 
 			if (operation != rsx::blit_engine::transfer_operation::srccopy)
 			{
-				LOG_ERROR(RSX, "NV3089_IMAGE_IN_SIZE: unknown operation (%d)", (u8)operation);
+				fmt::throw_exception("NV3089_IMAGE_IN_SIZE: unknown operation (%d)" HERE, (u8)operation);
 			}
 
 			const u32 src_offset = method_registers.blit_engine_input_offset();
@@ -856,19 +856,21 @@ namespace rsx
 			switch (method_registers.blit_engine_context_surface())
 			{
 			case blit_engine::context_surface::surface2d:
+			{
 				dst_dma = method_registers.blit_engine_output_location_nv3062();
 				dst_offset = method_registers.blit_engine_output_offset_nv3062();
 				dst_color_format = method_registers.blit_engine_nv3062_color_format();
 				out_pitch = method_registers.blit_engine_output_pitch_nv3062();
 				out_alignment = method_registers.blit_engine_output_alignment_nv3062();
 				break;
-
+			}
 			case blit_engine::context_surface::swizzle2d:
+			{
 				dst_dma = method_registers.blit_engine_nv309E_location();
 				dst_offset = method_registers.blit_engine_nv309E_offset();
 				dst_color_format = method_registers.blit_engine_output_format_nv309E();
 				break;
-
+			}
 			default:
 				LOG_ERROR(RSX, "NV3089_IMAGE_IN_SIZE: unknown m_context_surface (0x%x)", (u8)method_registers.blit_engine_context_surface());
 				return;
@@ -897,13 +899,13 @@ namespace rsx
 			if (dst_color_format != rsx::blit_engine::transfer_destination_format::r5g6b5 &&
 				dst_color_format != rsx::blit_engine::transfer_destination_format::a8r8g8b8)
 			{
-				LOG_ERROR(RSX, "NV3089_IMAGE_IN_SIZE: unknown dst_color_format (%d)", (u8)dst_color_format);
+				fmt::throw_exception("NV3089_IMAGE_IN_SIZE: unknown dst_color_format (%d)" HERE, (u8)dst_color_format);
 			}
 
 			if (src_color_format != rsx::blit_engine::transfer_source_format::r5g6b5 &&
 				src_color_format != rsx::blit_engine::transfer_source_format::a8r8g8b8)
 			{
-				LOG_ERROR(RSX, "NV3089_IMAGE_IN_SIZE: unknown src_color_format (%d)", (u8)src_color_format);
+				fmt::throw_exception("NV3089_IMAGE_IN_SIZE: unknown src_color_format (%d)" HERE, (u8)src_color_format);
 			}
 
 			f32 scale_x = 1048576.f / method_registers.blit_engine_ds_dx();

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1048,7 +1048,9 @@ namespace rsx
 					{
 						if (need_convert)
 						{
-							convert_scale_image(temp2, out_format, convert_w, convert_h, out_pitch,
+							temp2.reset(new u8[out_pitch * (std::max(convert_h, (u32)clip_h) - 1) + (out_bpp * std::max(convert_w, (u32)clip_w))]);
+
+							convert_scale_image(temp2.get(), out_format, convert_w, convert_h, out_pitch,
 								pixels_src, in_format, in_w, in_h, in_pitch, slice_h, in_inter == blit_engine::transfer_interpolator::foh);
 
 							clip_image(pixels_dst, temp2.get(), clip_x, clip_y, clip_w, clip_h, out_bpp, out_pitch, out_pitch);
@@ -1090,7 +1092,9 @@ namespace rsx
 					{
 						if (need_convert)
 						{
-							convert_scale_image(temp2, out_format, convert_w, convert_h, out_pitch,
+							temp2.reset(new u8[out_pitch * (std::max(convert_h, (u32)clip_h) - 1) + (out_bpp * std::max(convert_w, (u32)clip_w))]);
+
+							convert_scale_image(temp2.get(), out_format, convert_w, convert_h, out_pitch,
 								pixels_src, in_format, in_w, in_h, in_pitch, slice_h, in_inter == blit_engine::transfer_interpolator::foh);
 
 							clip_image(temp3, temp2.get(), clip_x, clip_y, clip_w, clip_h, out_bpp, out_pitch, out_pitch);
@@ -1102,7 +1106,9 @@ namespace rsx
 					}
 					else
 					{
-						convert_scale_image(temp3, out_format, out_w, out_h, out_pitch,
+						temp3.reset(new u8[out_pitch * (out_h - 1) + (out_bpp * out_w)]);
+
+						convert_scale_image(temp3.get(), out_format, out_w, out_h, out_pitch,
 							pixels_src, in_format, in_w, in_h, in_pitch, clip_h, in_inter == blit_engine::transfer_interpolator::foh);
 					}
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1310,6 +1310,11 @@ namespace rsx
 			return decode<NV406E_SEMAPHORE_OFFSET>().semaphore_offset();
 		}
 
+		u32 semaphore_context_dma_4097() const
+		{
+			return decode<NV4097_SET_CONTEXT_DMA_SEMAPHORE>().context_dma();
+		}
+
 		u32 semaphore_offset_4097() const
 		{
 			return decode<NV4097_SET_SEMAPHORE_OFFSET>().semaphore_offset();

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1469,12 +1469,12 @@ namespace rsx
 			return decode<NV309E_SET_FORMAT>().format();
 		}
 
-		u32 blit_engine_ds_dx() const
+		f32 blit_engine_ds_dx() const
 		{
 			return decode<NV3089_DS_DX>().ds_dx();
 		}
 
-		u32 blit_engine_dt_dy() const
+		f32 blit_engine_dt_dy() const
 		{
 			return decode<NV3089_DT_DY>().dt_dy();
 		}

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -23,14 +23,6 @@ namespace rsx
 		sws_scale(sws.get(), &src, &src_pitch, 0, src_slice_h, &dst, &dst_pitch);
 	}
 
-	void convert_scale_image(std::unique_ptr<u8[]>& dst, AVPixelFormat dst_format, int dst_width, int dst_height, int dst_pitch,
-		const u8 *src, AVPixelFormat src_format, int src_width, int src_height, int src_pitch, int src_slice_h, bool bilinear)
-	{
-		dst.reset(new u8[dst_pitch * dst_height]);
-		convert_scale_image(dst.get(), dst_format, dst_width, dst_height, dst_pitch,
-			src, src_format, src_width, src_height, src_pitch, src_slice_h, bilinear);
-	}
-
 	void clip_image(u8 *dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch)
 	{
 		u8 *pixels_src = (u8*)src + clip_y * src_pitch + clip_x * bpp;

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -161,6 +161,17 @@ namespace rsx
 		return static_cast<u32>((1ULL << 32) >> utils::cntlz32(x - 1, true));
 	}
 
+	// Copy memory in inverse direction from source
+	// Used to scale negatively x axis while transfering image data
+	template <typename Ts = u8, typename Td = Ts>
+	static void memcpy_r(void* dst, void* src, std::size_t size)
+	{
+		for (u32 i = 0; i < size; i++)
+		{
+			*((Td*)dst + i) = *((Ts*)src - i);
+		}
+	}
+
 	// Returns interleaved bits of X|Y|Z used as Z-order curve indices
 	static inline u32 calculate_z_index(u32 x, u32 y, u32 z)
 	{

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -307,9 +307,6 @@ namespace rsx
 	void convert_scale_image(u8 *dst, AVPixelFormat dst_format, int dst_width, int dst_height, int dst_pitch,
 		const u8 *src, AVPixelFormat src_format, int src_width, int src_height, int src_pitch, int src_slice_h, bool bilinear);
 
-	void convert_scale_image(std::unique_ptr<u8[]>& dst, AVPixelFormat dst_format, int dst_width, int dst_height, int dst_pitch,
-		const u8 *src, AVPixelFormat src_format, int src_width, int src_height, int src_pitch, int src_slice_h, bool bilinear);
-
 	void clip_image(u8 *dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch);
 	void clip_image(std::unique_ptr<u8[]>& dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch);
 


### PR DESCRIPTION
* Reduce capture size.
* ignore image_in transfers with empty clip region. its not executed at all according to hw tests.
* Dont "fix" in_pitch and out_pitch when 0 (image_in and buffer notify)
e.g when src pitch is 0, the same line is copied to the destination.
[testcase](https://github.com/elad335/myps3tests/tree/master/rsx_tests/image%20in) used
original [texture](https://imgur.com/k43HvCX).
[result](https://imgur.com/dkNa1ym) using image_in with zero src pitch.
[result](https://imgur.com/T2CQj9o) using buffer_notify with zero dst pitch;
[result](https://imgur.com/dkNa1ym) using buffer_notify with zero src pitch.
* Minor size of rect fixes.
* Add rsx lv2 defaults for sempahore context, cus vsh.
* Implement backwards source image reading in image_in. Fixes #4747.