### PR TITLE
Added ignore = dirty to all submodules to make git operations faster

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "rpcs3-ffmpeg"]
 	path = 3rdparty/ffmpeg
 	url = https://github.com/hrydgard/ppsspp-ffmpeg
+	ignore = dirty
 [submodule "asmjit"]
 	path = asmjit
 	url = https://github.com/kobalicek/asmjit
@@ -9,18 +10,23 @@
 	path = llvm
 	url = https://github.com/RPCS3/llvm
 	branch = release_60
+	ignore = dirty
 [submodule "GSL"]
 	path = 3rdparty/GSL
 	url = https://github.com/Microsoft/GSL.git
+	ignore = dirty
 [submodule "Vulkan/glslang"]
 	path = Vulkan/glslang
 	url = https://github.com/KhronosGroup/glslang.git
+	ignore = dirty
 [submodule "3rdparty/cereal"]
 	path = 3rdparty/cereal
 	url = https://github.com/USCiLab/cereal.git
+	ignore = dirty
 [submodule "3rdparty/zlib"]
 	path = 3rdparty/zlib
 	url = https://github.com/madler/zlib
+	ignore = dirty
 [submodule "3rdparty/hidapi"]
 	path = 3rdparty/hidapi
 	url = https://github.com/RPCS3/hidapi
@@ -29,12 +35,15 @@
 [submodule "3rdparty/pugixml"]
 	path = 3rdparty/pugixml
 	url = https://github.com/zeux/pugixml
+	ignore = dirty
 [submodule "3rdparty/xxHash"]
 	path = 3rdparty/xxHash
 	url = https://github.com/Cyan4973/xxHash
+	ignore = dirty
 [submodule "3rdparty/yaml-cpp"]
 	path = 3rdparty/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git
+	ignore = dirty
 [submodule "3rdparty/libpng"]
 	path = 3rdparty/libpng
 	url = https://github.com/glennrp/libpng.git


### PR DESCRIPTION
What: ignore submodules to make git operations faster.

Why: git operations were very slow

How: added `ignore = dirty` to all submodules in `.gitmodules`

Testing: I can confirm that `git status` is now substantially faster, down from 3.5 seconds to 0.15 seconds 

Assumptions: 
- I'm assuming that changes to submodules will be so rare that it's not worth having git check them for changes.
- I tested this on windows 10, it is possilble that other OSs will not see the same speedup

Source of info: https://stackoverflow.com/questions/4994772/ways-to-improve-git-status-performance