### PR TITLE
Fifo fixups

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -271,7 +271,7 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 
 	case 0x102: // Display flip
 	{
-		u32 flip_idx = -1u;
+		u32 flip_idx = ~0u;
 
 		// high bit signifys grabbing a queued buffer
 		// otherwise it contains a display buffer offset
@@ -301,7 +301,7 @@ s32 sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u6
 					break;
 				}
 			}
-			if (flip_idx == -1u)
+			if (flip_idx == ~0u)
 			{
 				LOG_ERROR(RSX, "Display Flip: Couldn't find display buffer offset, flipping 0. Offset: 0x%x", a4);
 				flip_idx = 0;

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -555,7 +555,7 @@ std::tuple<u32, u32, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl:
 			if (rsx::method_registers.current_draw_clause.is_disjoint_primitive)
 				continue;
 
-			dst[dst_idx++] = -1u;
+			dst[dst_idx++] = ~0u;
 		}
 		else
 		{
@@ -571,7 +571,7 @@ std::tuple<u32, u32, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl:
 template<typename T>
 std::tuple<u32, u32, u32> expand_indexed_triangle_fan(gsl::span<to_be_t<const T>> src, gsl::span<u32> dst, bool is_primitive_restart_enabled, u32 primitive_restart_index, u32 base_index)
 {
-	const u32 invalid_index = -1u;
+	const u32 invalid_index = ~0u;
 
 	u32 min_index = invalid_index;
 	u32 max_index = 0;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -557,7 +557,7 @@ void GLGSRender::end()
 				{
 					firsts[dst_index] = first;
 					counts[dst_index] = range.count;
-					offsets[dst_index++] = (const GLvoid*)(first << 2);
+					offsets[dst_index++] = (const GLvoid*)(u64(first << 2));
 
 					if (driver_caps.vendor_AMD && (first + range.count) > (0x100000 >> 2))
 					{
@@ -572,7 +572,7 @@ void GLGSRender::end()
 				if (use_draw_arrays_fallback)
 				{
 					//MultiDrawArrays is broken on some primitive types using AMD. One known type is GL_TRIANGLE_STRIP but there could be more
-					for (int n = 0; n < draw_count; ++n)
+					for (u32 n = 0; n < draw_count; ++n)
 					{
 						glDrawArrays(draw_mode, firsts[n], counts[n]);
 					}

--- a/rpcs3/Emu/RSX/Null/NullGSRender.cpp
+++ b/rpcs3/Emu/RSX/Null/NullGSRender.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "NullGSRender.h"
 #include "Emu/System.h"
 
@@ -14,4 +14,9 @@ NullGSRender::NullGSRender() : GSRender()
 bool NullGSRender::do_method(u32 cmd, u32 value)
 {
 	return false;
+}
+
+void NullGSRender::end()
+{
+	rsx::method_registers.current_draw_clause.end();
 }

--- a/rpcs3/Emu/RSX/Null/NullGSRender.h
+++ b/rpcs3/Emu/RSX/Null/NullGSRender.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "Emu/RSX/GSRender.h"
 
 class NullGSRender : public GSRender
@@ -9,4 +9,5 @@ public:
 
 private:
 	bool do_method(u32 cmd, u32 value) override final;
+	void end() override;
 };

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -201,17 +201,34 @@ namespace rsx
 			}
 		}
 
+		void flattening_helper::reset(bool _enabled)
+		{
+			enabled = _enabled;
+			num_collapsed = 0;
+			begin_end_ctr = 0;
+		}
+
 		void flattening_helper::force_disable()
 		{
-			enabled = false;
-			num_collapsed = 0;
-			fifo_hint = optimization_hint::load_unoptimizable;
+			if (enabled)
+			{
+				LOG_WARNING(RSX, "FIFO optimizations have been disabled as the application is not compatible with per-frame analysis");
+
+				reset(false);
+				fifo_hint = optimization_hint::application_not_compatible;
+			}
 		}
 
 		void flattening_helper::evaluate_performance(u32 total_draw_count)
 		{
 			if (!enabled)
 			{
+				if (fifo_hint == optimization_hint::application_not_compatible)
+				{
+					// Not compatible, do nothing
+					return;
+				}
+
 				if (total_draw_count <= 2000)
 				{
 					// Low draw call pressure
@@ -244,7 +261,7 @@ namespace rsx
 					fifo_hint = load_low;
 				}
 
-				num_collapsed = 0;
+				reset(enabled);
 			}
 			else
 			{
@@ -254,6 +271,7 @@ namespace rsx
 				{
 					// If its set to unoptimizable, we already tried and it did not work
 					// If it resets to load low (usually after some kind of loading screen) we can try again
+					verify("Incorrect initial state" HERE), begin_end_ctr == 0, num_collapsed == 0;
 					enabled = true;
 				}
 			}
@@ -295,7 +313,9 @@ namespace rsx
 				}
 				else
 				{
-					fmt::throw_exception("Unreachable" HERE);
+					LOG_ERROR(RSX, "Fifo flattener misalignment, disable FIFO reordering and report to developers");
+					begin_end_ctr = 0;
+					flush_cmd = 0u;
 				}
 
 				break;

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -194,7 +194,7 @@ namespace rsx
 
 			for (const auto &method : ignorable_ranges)
 			{
-				for (int i = 0; i < method.second; ++i)
+				for (u32 i = 0; i < method.second; ++i)
 				{
 					m_register_properties[method.first + i] |= register_props::always_ignore;
 				}
@@ -279,7 +279,7 @@ namespace rsx
 
 		flatten_op flattening_helper::test(register_pair& command)
 		{
-			u32 flush_cmd = -1u;
+			u32 flush_cmd = ~0u;
 			switch (const u32 reg = (command.reg >> 2))
 			{
 			case NV4097_SET_BEGIN_END:
@@ -352,7 +352,7 @@ namespace rsx
 			}
 			}
 
-			if (flush_cmd != -1u)
+			if (flush_cmd != ~0u)
 			{
 				num_collapsed += draw_count? (draw_count - 1) : 0;
 				draw_count = 0;

--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -63,7 +63,8 @@ namespace rsx
 			{
 				unknown,
 				load_low,
-				load_unoptimizable
+				load_unoptimizable,
+				application_not_compatible
 			};
 
 			std::array<u8, 0x10000 / 4> m_register_properties;
@@ -74,6 +75,8 @@ namespace rsx
 			bool enabled = false;
 			u32  num_collapsed = 0;
 			optimization_hint fifo_hint = unknown;
+
+			void reset(bool _enabled);
 
 		public:
 			flattening_helper();

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -105,7 +105,7 @@ namespace rsx
 
 		invalidate_pipeline_bits = fragment_program_dirty | vertex_program_dirty,
 		memory_barrier_bits = framebuffer_reads_dirty,
-		all_dirty = -1u
+		all_dirty = ~0u
 	};
 
 	enum FIFO_state : u8

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -890,7 +890,7 @@ bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 		}
 		else
 		{
-			LOG_ERROR(RSX, "Fault in uninterruptible code!");
+			//LOG_ERROR(RSX, "Fault in uninterruptible code!");
 		}
 
 		if (sync_timestamp > 0)

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -2530,7 +2530,7 @@ public:
 		{
 			if (available_slots.empty())
 			{
-				return -1u;
+				return ~0u;
 			}
 
 			u32 result = available_slots.front();

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -53,7 +53,7 @@ namespace rsx
 
 		bool operator < (const barrier_t& other) const
 		{
-			if (address != -1u)
+			if (address != ~0u)
 			{
 				return address < other.address;
 			}
@@ -91,7 +91,7 @@ namespace rsx
 		}
 
 		// Insert a new draw command within the others
-		void insert_draw_command(int index, const draw_range_t& range)
+		void insert_draw_command(u32 index, const draw_range_t& range)
 		{
 			auto range_It = draw_command_ranges.begin();
 			while (index--)
@@ -160,7 +160,7 @@ namespace rsx
 				append_draw_command({});
 				const auto command_index = draw_command_ranges.size() - 1;
 
-				_do_barrier_insert({ command_index, get_system_time(), -1u, arg, 0, type });
+				_do_barrier_insert({ command_index, get_system_time(), ~0u, arg, 0, type });
 				last_execution_barrier_index = command_index;
 			}
 		}
@@ -206,7 +206,7 @@ namespace rsx
 					return;
 				}
 
-				for (int index = last_execution_barrier_index; index < draw_command_ranges.size(); ++index)
+				for (auto index = last_execution_barrier_index; index < draw_command_ranges.size(); ++index)
 				{
 					if (draw_command_ranges[index].first == first &&
 						draw_command_ranges[index].count == count)
@@ -262,7 +262,7 @@ namespace rsx
 				return true;
 			}
 
-			verify(HERE), current_range_index != -1u;
+			verify(HERE), current_range_index != ~0u;
 			for (const auto &barrier : draw_command_barriers)
 			{
 				if (barrier.draw_id != current_range_index)
@@ -301,7 +301,7 @@ namespace rsx
 
 		void reset(rsx::primitive_type type)
 		{
-			current_range_index = -1u;
+			current_range_index = ~0u;
 			last_execution_barrier_index = 0;
 
 			command = draw_command::none;

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -676,9 +676,9 @@ namespace rsx
 		u32 _size = 0;
 		Ty* _data = nullptr;
 
-		inline u32 offset(const_iterator pos)
+		inline u64 offset(const_iterator pos)
 		{
-			return (_data) ? (pos - _data) : 0;
+			return (_data) ? u64(pos - _data) : 0ull;
 		}
 
 	public:
@@ -727,17 +727,16 @@ namespace rsx
 			if (_capacity > size)
 				return;
 
-			auto old_data = _data;
-			auto old_size = _size;
-
-			_data = (Ty*)malloc(sizeof(Ty) * size);
-			_capacity = size;
-
-			if (old_data)
+			if (_data)
 			{
-				memcpy(_data, old_data, sizeof(Ty) * old_size);
-				free(old_data);
+				_data = (Ty*)realloc(_data, sizeof(Ty) * size);
 			}
+			else
+			{
+				_data = (Ty*)malloc(sizeof(Ty) * size);
+			}
+
+			_capacity = size;
 		}
 
 		void push_back(const Ty& val)
@@ -779,7 +778,7 @@ namespace rsx
 
 			verify(HERE), _loc < _size;
 
-			const u32 remaining = (_size - _loc);
+			const auto remaining = (_size - _loc);
 			memmove(pos + 1, pos, remaining * sizeof(Ty));
 
 			*pos = val;


### PR DESCRIPTION
Fixes some regressions from the FIFO PR. See https://github.com/RPCS3/rpcs3/issues/5380
- Restore Null renderer to working condition (debugging only)
- Fix the flattener to avoid getting "Unreachable" assert in R&C 1
- Silence unnecessary log spam in vulkan
- Minor code cleanup