### PR TITLE
Clear disk cache if it grows too large (dev_hdd1/cache)

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -317,6 +317,9 @@ public:
 
 private:
 	static std::string GetEmuDir();
+	static std::string GetHdd1Dir();
+
+	void LimitCacheSize();
 public:
 	static std::string GetHddDir();
 	static std::string GetSfoDirFromGamePath(const std::string& game_path, const std::string& user);
@@ -403,6 +406,9 @@ struct cfg_root : cfg::node
 
 		cfg::_bool host_root{this, "Enable /host_root/"};
 		cfg::_bool init_dirs{this, "Initialize Directories", true};
+
+		cfg::_bool limit_cache_size{this, "Limit disk cache size", false};
+		cfg::_int<0, 10240> cache_max_size{this, "Disk cache maximum size (MB)", 5120};
 
 	} vfs{this};
 

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -140,6 +140,7 @@
 	"system": {
 		"sysLangBox": "Some games may fail to boot if the system language is not available in the game itself.\nOther games will switch language automatically to what is selected here.\nIt is recommended leaving this on a language supported by the game.",
 		"enterButtonAssignment": "The button used for enter/accept/confirm in system dialogs.\nChange this to use the circle button instead, which is the default configuration on japanese systems and in many japanese games.\nIn these cases having the cross button assigned can often lead to confusion.",
-		"enableHostRoot": "Required for some Homebrew.\nIf unsure, don't use this option."
+		"enableHostRoot": "Required for some Homebrew.\nIf unsure, don't use this option.",
+		"limitCacheSize": "Automatically removes older files from disk cache on boot if it grows larger than the specified value.\nGames can use the cache folder to temporarily store data outside of system memory. It is not used for long term storage."
 	}
 }

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -128,6 +128,8 @@ public:
 		Language,
 		EnterButtonAssignment,
 		EnableHostRoot,
+		LimitCacheSize,
+		MaximumCacheSize,
 
 		// Virtual File System
 		emulatorLocation,
@@ -330,6 +332,8 @@ private:
 		{ Language,              { "System", "Language"}},
 		{ EnterButtonAssignment, { "System", "Enter button assignment"}},
 		{ EnableHostRoot,        { "VFS", "Enable /host_root/"}},
+		{ LimitCacheSize,        { "VFS", "Limit disk cache size"}},
+		{ MaximumCacheSize,      { "VFS", "Disk cache maximum size (MB)"}},
 
 		// Virtual File System
 		{ emulatorLocation,   { "VFS", "$(EmulatorDir)"}},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -784,6 +784,16 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xemu_settings->EnhanceCheckBox(ui->enableHostRoot, emu_settings::EnableHostRoot);
 	SubscribeTooltip(ui->enableHostRoot, json_sys["enableHostRoot"].toString());
 
+	xemu_settings->EnhanceCheckBox(ui->enableCacheClearing, emu_settings::LimitCacheSize);
+	SubscribeTooltip(ui->enableCacheClearing, json_sys["limitCacheSize"].toString());
+	connect(ui->enableCacheClearing, &QCheckBox::stateChanged, ui->maximumCacheSize, &QSlider::setEnabled);
+
+	// Sliders
+
+	EnhanceSlider(emu_settings::MaximumCacheSize, ui->maximumCacheSize, ui->maximumCacheSizeLabel, tr("Maximum size: %0 MB"));
+	SubscribeTooltip(ui->maximumCacheSize, json_sys["limitCacheSize"].toString());
+	ui->maximumCacheSize->setEnabled(ui->enableCacheClearing->isChecked());
+
 	// Radio Buttons
 
 	SubscribeTooltip(ui->gb_enterButtonAssignment, json_sys["enterButtonAssignment"].toString());

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1150,6 +1150,55 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_18" stretch="1,1,1">
+         <item>
+          <widget class="QGroupBox" name="gb_DiskCacheClearing">
+           <property name="title">
+            <string>Disk cache</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_73">
+            <item>
+             <widget class="QCheckBox" name="enableCacheClearing">
+              <property name="text">
+               <string>Clear cache automatically</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="maximumCacheSizeLabel">
+              <property name="text">
+               <string>Cache size: 3072 MB</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSlider" name="maximumCacheSize">
+              <property name="pageStep">
+               <number>512</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="tickPosition">
+               <enum>QSlider::TicksBelow</enum>
+              </property>
+              <property name="tickInterval">
+               <number>1024</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="widget_14" native="true"/>
+         </item>
+         <item>
+          <widget class="QWidget" name="widget_15" native="true"/>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_8">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
The folder dev_hdd1/cache is a temporary folder and is used by games to temporarily store data outside of main memory. On PS3, this folder limited to 1 GB (afaik) and the console will automatically delete ~~files out of it to keep it under that treshold~~ everything inside it when switching games.

However, on this emulator the folder is never cleared and thus can grow to tens of gigabytes over time. While it is not a huge issue, I still believe that the emulator should keep the size of this folder in check so that it woudn't rob too much disc space. After all, these are just temporary files and thus aren't interesting enough to store permanently.

This PR checks the cache size and deletes olderst folders from it untill it's less than the treshold. Users can disable the feature and customize the delete threshold if they wish so.