### PR TITLE
added libevdev-dev as requirement for Debian & Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to contribute, please take a look at the [Coding Style](https://gith
 * [Qt 5.10+](https://www.qt.io/download-open-source/)
 * GCC 7.3+ or Clang 5.0+
 * CMake 3.8.2+
-* Debian & Ubuntu: `sudo apt-get install cmake build-essential libasound2-dev libpulse-dev libopenal-dev libglew-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git qt5-default`
+* Debian & Ubuntu: `sudo apt-get install cmake build-essential libasound2-dev libpulse-dev libopenal-dev libglew-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git qt5-default libevdev-dev`
 * Arch: `sudo pacman -S glew openal cmake vulkan-validation-layers qt5-base`
 * Fedora: `sudo dnf install alsa-lib-devel cmake glew glew-devel libatomic libevdev-devel libudev-devel openal-devel qt5-devel vulkan-devel`
 * OpenSUSE: `sudo zypper install git cmake libasound2 libpulse-devel openal-soft-devel glew-devel zlib-devel libedit-devel vulkan-devel libudev-devel libqt5-qtbase-devel libevdev-devel`


### PR DESCRIPTION
Since libevdev-dev is not installed by default this will prevent future usererrors when a Controller is not recognised