### PR TITLE
[Testers needed] DS4 fixes and pad settings improvements

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -448,7 +448,7 @@ public:
 	PadHandlerBase(pad_handler type = pad_handler::null);
 	virtual ~PadHandlerBase() = default;
 	//Sets window to config the controller(optional)
-	virtual void GetNextButtonPress(const std::string& /*padId*/, const std::function<void(u16, std::string, int[])>& /*callback*/, const std::function<void()>& /*fail_callback*/, bool /*get_blacklist*/ = false, std::vector<std::string> /*buttons*/ = {}) {};
+	virtual void GetNextButtonPress(const std::string& /*padId*/, const std::function<void(u16, std::string, std::string, int[])>& /*callback*/, const std::function<void(std::string)>& /*fail_callback*/, bool /*get_blacklist*/ = false, std::vector<std::string> /*buttons*/ = {}) {};
 	virtual void TestVibration(const std::string& /*padId*/, u32 /*largeMotor*/, u32 /*smallMotor*/) {};
 	//Return list of devices for that handler
 	virtual std::vector<std::string> ListDevices() = 0;

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -448,7 +448,7 @@ public:
 	PadHandlerBase(pad_handler type = pad_handler::null);
 	virtual ~PadHandlerBase() = default;
 	//Sets window to config the controller(optional)
-	virtual void GetNextButtonPress(const std::string& /*padId*/, const std::function<void(u16, std::string, int[])>& /*callback*/, bool /*get_blacklist*/ = false, std::vector<std::string> /*buttons*/ = {}) {};
+	virtual void GetNextButtonPress(const std::string& /*padId*/, const std::function<void(u16, std::string, int[])>& /*callback*/, const std::function<void()>& /*fail_callback*/, bool /*get_blacklist*/ = false, std::vector<std::string> /*buttons*/ = {}) {};
 	virtual void TestVibration(const std::string& /*padId*/, u32 /*largeMotor*/, u32 /*smallMotor*/) {};
 	//Return list of devices for that handler
 	virtual std::vector<std::string> ListDevices() = 0;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -189,6 +189,7 @@ struct EmuCallbacks
 	std::function<void()> on_ready;
 	std::function<void()> exit;
 	std::function<void()> reset_pads;
+	std::function<void(bool)> enable_pads;
 	std::function<void(s32, s32)> handle_taskbar_progress; // (type, value) type: 0 for reset, 1 for increment, 2 for set_limit
 	std::function<std::shared_ptr<class KeyboardHandlerBase>()> get_kb_handler;
 	std::function<std::shared_ptr<class MouseHandlerBase>()> get_mouse_handler;

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -262,7 +262,7 @@ std::shared_ptr<ds4_pad_handler::DS4Device> ds4_pad_handler::GetDevice(const std
 	std::string pad_serial = padId.substr(pos + 9);
 	std::shared_ptr<DS4Device> device = nullptr;
 
-	int i = 0;
+	int i = 1; // Controllers 1-n in GUI
 	for (auto& cur_control : controllers)
 	{
 		if (pad_serial == std::to_string(i++) || pad_serial == cur_control.first)
@@ -770,7 +770,7 @@ std::vector<std::string> ds4_pad_handler::ListDevices()
 	if (!Init())
 		return ds4_pads_list;
 
-	for (size_t i = 0; i < controllers.size(); ++i)
+	for (size_t i = 1; i <= controllers.size(); ++i) // Controllers 1-n in GUI
 	{
 		ds4_pads_list.emplace_back(m_name_string + std::to_string(i));
 	}

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -150,14 +150,14 @@ void ds4_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, bool get_blacklist, std::vector<std::string> buttons)
+void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
 
 	std::shared_ptr<DS4Device> device = GetDevice(padId);
 	if (device == nullptr || device->hidDevice == nullptr)
-		return;
+		return fail_callback();
 
 	// Now that we have found a device, get its status
 	DS4DataStatus status = GetRawData(device);
@@ -167,7 +167,7 @@ void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::fu
 		// this also can mean disconnected, either way deal with it on next loop and reconnect
 		hid_close(device->hidDevice);
 		device->hidDevice = nullptr;
-		return;
+		return fail_callback();
 	}
 
 	// return if nothing new has happened. ignore this to get the current state for blacklist

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -151,14 +151,14 @@ void ds4_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
+void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
 
 	std::shared_ptr<DS4Device> device = GetDevice(padId, true);
 	if (device == nullptr || device->hidDevice == nullptr)
-		return fail_callback();
+		return fail_callback(padId);
 
 	// Now that we have found a device, get its status
 	DS4DataStatus status = GetRawData(device);
@@ -168,7 +168,7 @@ void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::fu
 		// this also can mean disconnected, either way deal with it on next loop and reconnect
 		hid_close(device->hidDevice);
 		device->hidDevice = nullptr;
-		return fail_callback();
+		return fail_callback(padId);
 	}
 
 	// return if nothing new has happened. ignore this to get the current state for blacklist
@@ -216,9 +216,9 @@ void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::fu
 	int preview_values[6] = { data[L2], data[R2], data[LSXPos] - data[LSXNeg], data[LSYPos] - data[LSYNeg], data[RSXPos] - data[RSXNeg], data[RSYPos] - data[RSYNeg] };
 
 	if (pressed_button.first > 0)
-		return callback(pressed_button.first, pressed_button.second, preview_values);
+		return callback(pressed_button.first, pressed_button.second, padId, preview_values);
 	else
-		return callback(0, "", preview_values);
+		return callback(0, "", padId, preview_values);
 }
 
 void ds4_pad_handler::TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor)

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -96,7 +96,8 @@ ds4_pad_handler::ds4_pad_handler() : PadHandlerBase(pad_handler::ds4)
 	b_has_rumble = true;
 	b_has_deadzones = true;
 
-	m_name_string = "Ds4 Pad #";
+	m_name_string = "DS4 Pad #";
+	m_max_devices = CELL_PAD_MAX_PORT_NUM;
 
 	m_trigger_threshold = trigger_max / 2;
 	m_thumb_threshold = thumb_max / 2;
@@ -261,9 +262,10 @@ std::shared_ptr<ds4_pad_handler::DS4Device> ds4_pad_handler::GetDevice(const std
 	std::string pad_serial = padId.substr(pos + 9);
 	std::shared_ptr<DS4Device> device = nullptr;
 
+	int i = 0;
 	for (auto& cur_control : controllers)
 	{
-		if (pad_serial == cur_control.first)
+		if (pad_serial == std::to_string(i++) || pad_serial == cur_control.first)
 		{
 			device = cur_control.second;
 			break;
@@ -768,9 +770,9 @@ std::vector<std::string> ds4_pad_handler::ListDevices()
 	if (!Init())
 		return ds4_pads_list;
 
-	for (auto& pad : controllers)
+	for (size_t i = 0; i < controllers.size(); ++i)
 	{
-		ds4_pads_list.emplace_back(m_name_string + pad.first);
+		ds4_pads_list.emplace_back(m_name_string + std::to_string(i));
 	}
 
 	return ds4_pads_list;

--- a/rpcs3/ds4_pad_handler.h
+++ b/rpcs3/ds4_pad_handler.h
@@ -154,7 +154,7 @@ private:
 	std::shared_ptr<DS4Device> m_dev;
 
 private:
-	std::shared_ptr<DS4Device> GetDevice(const std::string& padId);
+	std::shared_ptr<DS4Device> GetDevice(const std::string& padId, bool try_reconnect = false);
 	void TranslateButtonPress(u64 keyCode, bool& pressed, u16& val, bool ignore_threshold = false) override;
 	void ProcessDataToPad(const std::shared_ptr<DS4Device>& ds4Device, const std::shared_ptr<Pad>& pad);
 	// Copies data into padData if status is NewData, otherwise buffer is untouched

--- a/rpcs3/ds4_pad_handler.h
+++ b/rpcs3/ds4_pad_handler.h
@@ -142,7 +142,7 @@ public:
 	std::vector<std::string> ListDevices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
-	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& buttonCallback, const std::function<void()>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
+	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& buttonCallback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
 	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 

--- a/rpcs3/ds4_pad_handler.h
+++ b/rpcs3/ds4_pad_handler.h
@@ -142,7 +142,7 @@ public:
 	std::vector<std::string> ListDevices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
-	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& buttonCallback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
+	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& buttonCallback, const std::function<void()>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
 	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -257,7 +257,7 @@ evdev_joystick_handler::EvdevDevice* evdev_joystick_handler::get_device(const st
 	return &dev;
 }
 
-void evdev_joystick_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, bool get_blacklist, std::vector<std::string> buttons)
+void evdev_joystick_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
@@ -265,7 +265,7 @@ void evdev_joystick_handler::GetNextButtonPress(const std::string& padId, const 
 	// Get our evdev device
 	EvdevDevice* device = get_device(padId);
 	if (device == nullptr || device->device == nullptr)
-		return;
+		return fail_callback();
 	libevdev* dev = device->device;
 
 	// Try to query the latest event from the joystick.

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -257,7 +257,7 @@ evdev_joystick_handler::EvdevDevice* evdev_joystick_handler::get_device(const st
 	return &dev;
 }
 
-void evdev_joystick_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
+void evdev_joystick_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
@@ -265,7 +265,7 @@ void evdev_joystick_handler::GetNextButtonPress(const std::string& padId, const 
 	// Get our evdev device
 	EvdevDevice* device = get_device(padId);
 	if (device == nullptr || device->device == nullptr)
-		return fail_callback();
+		return fail_callback(padId);
 	libevdev* dev = device->device;
 
 	// Try to query the latest event from the joystick.
@@ -381,20 +381,21 @@ void evdev_joystick_handler::GetNextButtonPress(const std::string& padId, const 
 		return it != data.end() && dir == it->second.second ? it->second.first : 0;
 	};
 
-	int preview_values[6] =
+	int preview_values[6] = { 0, 0, 0, 0, 0, 0 };
+	if (buttons.size() == 10)
 	{
-		find_value(buttons[0]),                          // Left Trigger
-		find_value(buttons[1]),                          // Right Trigger
-		find_value(buttons[3]) - find_value(buttons[2]), // Left Stick X
-		find_value(buttons[5]) - find_value(buttons[4]), // Left Stick Y
-		find_value(buttons[7]) - find_value(buttons[6]), // Right Stick X
-		find_value(buttons[9]) - find_value(buttons[8]), // Right Stick Y
-	};
+		preview_values[0] = find_value(buttons[0]);                          // Left Trigger
+		preview_values[1] = find_value(buttons[1]);                          // Right Trigger
+		preview_values[2] = find_value(buttons[3]) - find_value(buttons[2]); // Left Stick X
+		preview_values[3] = find_value(buttons[5]) - find_value(buttons[4]); // Left Stick Y
+		preview_values[4] = find_value(buttons[7]) - find_value(buttons[6]); // Right Stick X
+		preview_values[5] = find_value(buttons[9]) - find_value(buttons[8]); // Right Stick Y
+	}
 
 	if (pressed_button.first > 0)
-		return callback(pressed_button.first, pressed_button.second, preview_values);
+		return callback(pressed_button.first, pressed_button.second, padId, preview_values);
 	else
-		return callback(0, "", preview_values);
+		return callback(0, "", padId, preview_values);
 }
 
 // https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp

--- a/rpcs3/evdev_joystick_handler.h
+++ b/rpcs3/evdev_joystick_handler.h
@@ -338,7 +338,7 @@ public:
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
 	void Close();
-	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
+	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
 	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
 
 private:

--- a/rpcs3/evdev_joystick_handler.h
+++ b/rpcs3/evdev_joystick_handler.h
@@ -338,7 +338,7 @@ public:
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
 	void Close();
-	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
+	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
 	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
 
 private:

--- a/rpcs3/mm_joystick_handler.cpp
+++ b/rpcs3/mm_joystick_handler.cpp
@@ -579,7 +579,7 @@ bool mm_joystick_handler::GetMMJOYDevice(int index, MMJOYDevice* dev)
 	LOG_NOTICE(GENERAL, "Joystick nr.%d found. Driver: %s", index, drv);
 
 	dev->device_id = index;
-	dev->device_name = m_name_string + std::to_string(index);
+	dev->device_name = m_name_string + std::to_string(index + 1); // Controllers 1-n in GUI
 	dev->device_info = js_info;
 	dev->device_caps = js_caps;
 

--- a/rpcs3/mm_joystick_handler.cpp
+++ b/rpcs3/mm_joystick_handler.cpp
@@ -283,13 +283,13 @@ void mm_joystick_handler::ThreadProc()
 	}
 }
 
-void mm_joystick_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, bool get_blacklist, std::vector<std::string> buttons)
+void mm_joystick_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
 
 	if (!Init())
-		return;
+		return fail_callback();
 
 	static std::string cur_pad = "";
 	static int id = -1;
@@ -301,7 +301,7 @@ void mm_joystick_handler::GetNextButtonPress(const std::string& padId, const std
 		if (id < 0)
 		{
 			LOG_ERROR(GENERAL, "MMJOY GetNextButtonPress for device [%s] failed with id = %d", padId, id);
-			return;
+			return fail_callback();
 		}
 	}
 
@@ -316,7 +316,7 @@ void mm_joystick_handler::GetNextButtonPress(const std::string& padId, const std
 	switch (status)
 	{
 	case JOYERR_UNPLUGGED:
-		break;
+		return fail_callback();
 
 	case JOYERR_NOERROR:
 		auto data = GetButtonValues(js_info, js_caps);

--- a/rpcs3/mm_joystick_handler.h
+++ b/rpcs3/mm_joystick_handler.h
@@ -108,7 +108,7 @@ public:
 	std::vector<std::string> ListDevices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
-	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
+	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:

--- a/rpcs3/mm_joystick_handler.h
+++ b/rpcs3/mm_joystick_handler.h
@@ -108,7 +108,7 @@ public:
 	std::vector<std::string> ListDevices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
-	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
+	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:

--- a/rpcs3/pad_thread.cpp
+++ b/rpcs3/pad_thread.cpp
@@ -142,11 +142,21 @@ void pad_thread::Reset()
 	reset = active.load();
 }
 
+void pad_thread::SetEnabled(bool enabled)
+{
+	is_enabled = enabled;
+}
+
 void pad_thread::ThreadFunc()
 {
 	active = true;
 	while (active)
 	{
+		if (!is_enabled)
+		{
+			std::this_thread::sleep_for(1ms);
+			continue;
+		}
 		if (reset && reset.exchange(false))
 		{
 			Init();

--- a/rpcs3/pad_thread.h
+++ b/rpcs3/pad_thread.h
@@ -24,6 +24,7 @@ public:
 	void SetRumble(const u32 pad, u8 largeMotor, bool smallMotor);
 	void Init();
 	void Reset();
+	void SetEnabled(bool enabled);
 
 protected:
 	void ThreadFunc();
@@ -40,6 +41,7 @@ protected:
 
 	atomic_t<bool> active{ false };
 	atomic_t<bool> reset{ false };
+	atomic_t<bool> is_enabled{ true };
 	std::shared_ptr<std::thread> thread;
 };
 

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -146,6 +146,10 @@ void rpcs3_app::InitializeCallbacks()
 	{
 		pad::get_current_handler()->Reset();
 	};
+	callbacks.enable_pads = [this](bool enable)
+	{
+		pad::get_current_handler()->SetEnabled(enable);
+	};
 
 	callbacks.get_kb_handler = [=]() -> std::shared_ptr<KeyboardHandlerBase>
 	{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1260,9 +1260,17 @@ void main_window::CreateConnects()
 			}
 			Emu.GetCallbacks().reset_pads();
 		};
+		if (!Emu.IsStopped())
+		{
+			Emu.GetCallbacks().enable_pads(false);
+		}
 		pad_settings_dialog dlg(this);
 		connect(&dlg, &QDialog::accepted, resetPadHandlers);
 		dlg.exec();
+		if (!Emu.IsStopped())
+		{
+			Emu.GetCallbacks().enable_pads(true);
+		}
 	};
 
 	connect(ui->confPadsAct, &QAction::triggered, openPadSettings);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1252,7 +1252,16 @@ void main_window::CreateConnects()
 
 	auto openPadSettings = [this]
 	{
+		auto resetPadHandlers = [this]
+		{
+			if (Emu.IsStopped())
+			{
+				return;
+			}
+			Emu.GetCallbacks().reset_pads();
+		};
 		pad_settings_dialog dlg(this);
+		connect(&dlg, &QDialog::accepted, resetPadHandlers);
 		dlg.exec();
 	};
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -90,13 +90,14 @@ pad_settings_dialog::pad_settings_dialog(QWidget *parent)
 	connect(ui->chooseHandler, &QComboBox::currentTextChanged, this, &pad_settings_dialog::ChangeInputType);
 
 	// Combobox: Devices
-	connect(ui->chooseDevice, &QComboBox::currentTextChanged, [this](const QString& dev)
+	connect(ui->chooseDevice, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index)
 	{
-		if (dev.isEmpty())
+		if (index < 0)
 		{
 			return;
 		}
-		m_device_name = sstr(dev);
+		const pad_info info = ui->chooseDevice->itemData(index).value<pad_info>();
+		m_device_name = info.name;
 		if (!g_cfg_input.player[m_tabs->currentIndex()]->device.from_string(m_device_name))
 		{
 			// Something went wrong
@@ -316,8 +317,10 @@ void pad_settings_dialog::InitButtons()
 	});
 
 	// Enable Button Remapping
-	const auto& callback = [=](u16 val, std::string name, int preview_values[6])
+	const auto& callback = [=](u16 val, std::string name, std::string pad_name, int preview_values[6])
 	{
+		SwitchPadInfo(pad_name, true);
+
 		if (!m_enable_buttons && !m_timer.isActive())
 		{
 			SwitchButtons(true);
@@ -354,8 +357,9 @@ void pad_settings_dialog::InitButtons()
 	};
 
 	// Disable Button Remapping
-	const auto& fail_callback = [this]()
+	const auto& fail_callback = [this](const std::string& pad_name)
 	{
+		SwitchPadInfo(pad_name, false);
 		if (m_enable_buttons)
 		{
 			SwitchButtons(false);
@@ -374,6 +378,35 @@ void pad_settings_dialog::InitButtons()
 		};
 		m_handler->GetNextButtonPress(m_device_name, callback, fail_callback, false, buttons);
 	});
+
+	// Use timer to refresh pad connection status
+	connect(&m_timer_pad_refresh, &QTimer::timeout, [this]()
+	{
+		for (int i = 0; i < ui->chooseDevice->count(); i++)
+		{
+			if (!ui->chooseDevice->itemData(i).canConvert<pad_info>())
+			{
+				LOG_FATAL(GENERAL, "Cannot convert itemData for index %d and itemText %s", i, sstr(ui->chooseDevice->itemText(i)));
+				continue;
+			}
+			const pad_info info = ui->chooseDevice->itemData(i).value<pad_info>();
+			m_handler->GetNextButtonPress(info.name, [=](u16 val, std::string name, std::string pad_name, int preview_values[6]) { SwitchPadInfo(pad_name, true); }, [=](std::string pad_name) { SwitchPadInfo(pad_name, false); }, false);
+		}
+	});
+}
+
+void pad_settings_dialog::SwitchPadInfo(const std::string& pad_name, bool is_connected)
+{
+	for (int i = 0; i < ui->chooseDevice->count(); i++)
+	{
+		const pad_info info = ui->chooseDevice->itemData(i).value<pad_info>();
+		if (info.name == pad_name && info.is_connected != is_connected)
+		{
+			ui->chooseDevice->setItemData(i, QVariant::fromValue(pad_info{ pad_name, is_connected }));
+			ui->chooseDevice->setItemText(i, is_connected ? qstr(pad_name) : (qstr(pad_name) + Disconnected_suffix));
+			break;
+		}
+	}
 }
 
 void pad_settings_dialog::ReloadButtons()
@@ -785,7 +818,7 @@ void pad_settings_dialog::ChangeInputType()
 
 	// Get this player's current handler and it's currently available devices
 	m_handler = GetHandler(g_cfg_input.player[player]->handler);
-	const std::vector<std::string> list_devices = m_handler->ListDevices();
+	const auto device_list = m_handler->ListDevices();
 
 	// Refill the device combobox with currently available devices
 	switch (m_handler->m_type)
@@ -797,7 +830,8 @@ void pad_settings_dialog::ChangeInputType()
 		const QString name_string = qstr(m_handler->name_string());
 		for (int i = 1; i <= m_handler->max_devices(); i++) // Controllers 1-n in GUI
 		{
-			ui->chooseDevice->addItem(name_string + QString::number(i), i);
+			const QString device_name = name_string + QString::number(i);
+			ui->chooseDevice->addItem(device_name, QVariant::fromValue(pad_info{ sstr(device_name), false }));
 		}
 		force_enable = true;
 		break;
@@ -805,21 +839,34 @@ void pad_settings_dialog::ChangeInputType()
 #endif
 	default:
 	{
-		for (int i = 0; i < list_devices.size(); i++)
+		for (int i = 0; i < device_list.size(); i++)
 		{
-			ui->chooseDevice->addItem(qstr(list_devices[i]), i);
+			ui->chooseDevice->addItem(qstr(device_list[i]), QVariant::fromValue(pad_info{ device_list[i], true }));
 		}
 		break;
 	}
 	}
 
 	// Handle empty device list
-	bool config_enabled = force_enable || (m_handler->m_type != pad_handler::null && list_devices.size() > 0);
+	bool config_enabled = force_enable || (m_handler->m_type != pad_handler::null && ui->chooseDevice->count() > 0);
 	ui->chooseDevice->setEnabled(config_enabled);
 
 	if (config_enabled)
 	{
-		ui->chooseDevice->setCurrentText(qstr(device));
+		for (int i = 0; i < ui->chooseDevice->count(); i++)
+		{
+			if (!ui->chooseDevice->itemData(i).canConvert<pad_info>())
+			{
+				LOG_FATAL(GENERAL, "Cannot convert itemData for index %d and itemText %s", i, sstr(ui->chooseDevice->itemText(i)));
+				continue;
+			}
+			const pad_info info = ui->chooseDevice->itemData(i).value<pad_info>();
+			m_handler->GetNextButtonPress(info.name, [=](u16 val, std::string name, std::string pad_name, int preview_values[6]) { SwitchPadInfo(pad_name, true); }, [=](std::string pad_name) { SwitchPadInfo(pad_name, false); }, false);
+			if (info.name == device)
+			{
+				ui->chooseDevice->setCurrentIndex(i);
+			}
+		}
 
 		QString profile_dir = qstr(PadHandlerBase::get_config_dir(m_handler->m_type));
 		QStringList profiles = gui::utils::get_dir_entries(QDir(profile_dir), QStringList() << "*.yml");
@@ -852,7 +899,7 @@ void pad_settings_dialog::ChangeInputType()
 	}
 
 	// enable configuration and profile list if possible
-	SwitchButtons(false || config_enabled && m_handler->m_type == pad_handler::keyboard);
+	SwitchButtons(config_enabled && m_handler->m_type == pad_handler::keyboard);
 	ui->b_addProfile->setEnabled(config_enabled);
 	ui->chooseProfile->setEnabled(config_enabled);
 }
@@ -872,6 +919,10 @@ void pad_settings_dialog::ChangeProfile()
 	if (m_timer_input.isActive())
 	{
 		m_timer_input.stop();
+	}
+	if (m_timer_pad_refresh.isActive())
+	{
+		m_timer_pad_refresh.stop();
 	}
 
 	// Change handler
@@ -917,6 +968,7 @@ void pad_settings_dialog::ChangeProfile()
 	if (ui->chooseDevice->isEnabled() && ui->chooseDevice->currentIndex() >= 0)
 	{
 		m_timer_input.start(1);
+		m_timer_pad_refresh.start(1000);
 	}
 }
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -400,10 +400,18 @@ void pad_settings_dialog::SwitchPadInfo(const std::string& pad_name, bool is_con
 	for (int i = 0; i < ui->chooseDevice->count(); i++)
 	{
 		const pad_info info = ui->chooseDevice->itemData(i).value<pad_info>();
-		if (info.name == pad_name && info.is_connected != is_connected)
+		if (info.name == pad_name)
 		{
-			ui->chooseDevice->setItemData(i, QVariant::fromValue(pad_info{ pad_name, is_connected }));
-			ui->chooseDevice->setItemText(i, is_connected ? qstr(pad_name) : (qstr(pad_name) + Disconnected_suffix));
+			if (info.is_connected != is_connected)
+			{
+				ui->chooseDevice->setItemData(i, QVariant::fromValue(pad_info{ pad_name, is_connected }));
+				ui->chooseDevice->setItemText(i, is_connected ? qstr(pad_name) : (qstr(pad_name) + Disconnected_suffix));
+			}
+
+			if (!is_connected && m_timer.isActive() && ui->chooseDevice->currentIndex() == i)
+			{
+				ReactivateButtons();
+			}
 			break;
 		}
 	}
@@ -831,7 +839,7 @@ void pad_settings_dialog::ChangeInputType()
 		for (int i = 1; i <= m_handler->max_devices(); i++) // Controllers 1-n in GUI
 		{
 			const QString device_name = name_string + QString::number(i);
-			ui->chooseDevice->addItem(device_name, QVariant::fromValue(pad_info{ sstr(device_name), false }));
+			ui->chooseDevice->addItem(device_name, QVariant::fromValue(pad_info{ sstr(device_name), true }));
 		}
 		force_enable = true;
 		break;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -795,7 +795,7 @@ void pad_settings_dialog::ChangeInputType()
 	case pad_handler::xinput:
 	{
 		const QString name_string = qstr(m_handler->name_string());
-		for (int i = 0; i < m_handler->max_devices(); i++)
+		for (int i = 1; i <= m_handler->max_devices(); i++) // Controllers 1-n in GUI
 		{
 			ui->chooseDevice->addItem(name_string + QString::number(i), i);
 		}

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -791,6 +791,7 @@ void pad_settings_dialog::ChangeInputType()
 	switch (m_handler->m_type)
 	{
 #ifdef _WIN32
+	case pad_handler::ds4:
 	case pad_handler::xinput:
 	{
 		const QString name_string = qstr(m_handler->name_string());
@@ -960,16 +961,6 @@ void pad_settings_dialog::SaveProfile()
 	m_handler_cfg.save();
 }
 
-void pad_settings_dialog::ResetPadHandler()
-{
-	if (Emu.IsStopped())
-	{
-		return;
-	}
-
-	Emu.GetCallbacks().reset_pads();
-}
-
 void pad_settings_dialog::SaveExit()
 {
 	SaveProfile();
@@ -985,8 +976,6 @@ void pad_settings_dialog::SaveExit()
 	}
 
 	g_cfg_input.save();
-
-	ResetPadHandler();
 
 	QDialog::accept();
 }

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -93,6 +93,11 @@ private:
 	// TabWidget
 	QTabWidget* m_tabs;
 
+	// Capabilities
+	bool m_enable_buttons{ false };
+	bool m_enable_rumble{ false };
+	bool m_enable_deadzones{ false };
+
 	// Button Mapping
 	QButtonGroup* m_padButtons;
 	u32 m_button_id = id_pad_begin;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -14,6 +14,14 @@ namespace Ui
 	class pad_settings_dialog;
 }
 
+struct pad_info
+{
+	std::string name;
+	bool is_connected;
+};
+
+Q_DECLARE_METATYPE(pad_info);
+
 class pad_settings_dialog : public QDialog
 {
 	Q_OBJECT
@@ -73,6 +81,8 @@ class pad_settings_dialog : public QDialog
 		QString text;
 	};
 
+	const QString Disconnected_suffix = tr(" (disconnected)");
+
 public:
 	explicit pad_settings_dialog(QWidget *parent = nullptr);
 	~pad_settings_dialog();
@@ -121,6 +131,7 @@ private:
 	pad_config m_handler_cfg;
 	std::string m_device_name;
 	std::string m_profile;
+	QTimer m_timer_pad_refresh;
 
 	// Remap Timer
 	const int MAX_SECONDS = 5;
@@ -135,6 +146,7 @@ private:
 
 	/** Update all the Button Labels with current button mapping */
 	void UpdateLabel(bool is_reset = false);
+	void SwitchPadInfo(const std::string& name, bool is_connected);
 
 	/** Enable/Disable Buttons while trying to remap an other */
 	void SwitchButtons(bool is_enabled);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -146,7 +146,6 @@ private:
 	void ReloadButtons();
 
 	void ChangeProfile();
-	void ResetPadHandler();
 
 	/** Repaints a stick deadzone preview label */
 	void RepaintPreviewLabel(QLabel* l, int dz, int w, int x, int y);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>pad_settings_dialog</class>
  <widget class="QDialog" name="pad_settings_dialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -197,7 +197,7 @@ int xinput_pad_handler::GetDeviceNumber(const std::string& padId)
 	if (pos == std::string::npos)
 		return -1;
 
-	int device_number = std::stoul(padId.substr(pos + 12));
+	int device_number = std::stoul(padId.substr(pos + 12)) - 1; // Controllers 1-n in GUI
 	if (device_number >= XUSER_MAX_COUNT)
 		return -1;
 
@@ -455,7 +455,7 @@ std::vector<std::string> xinput_pad_handler::ListDevices()
 		XINPUT_STATE state;
 		DWORD result = (*xinputGetState)(i, &state);
 		if (result == ERROR_SUCCESS)
-			xinput_pads_list.push_back(m_name_string + std::to_string(i));
+			xinput_pads_list.push_back(m_name_string + std::to_string(i + 1)); // Controllers 1-n in GUI
 	}
 	return xinput_pads_list;
 }

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -74,14 +74,14 @@ void xinput_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, bool get_blacklist, std::vector<std::string> buttons)
+void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
 
 	int device_number = GetDeviceNumber(padId);
 	if (device_number < 0)
-		return;
+		return fail_callback();
 
 	DWORD dwResult;
 	XINPUT_STATE state;
@@ -90,7 +90,7 @@ void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std:
 	// Simply get the state of the controller from XInput.
 	dwResult = (*xinputGetState)(static_cast<u32>(device_number), &state);
 	if (dwResult != ERROR_SUCCESS)
-		return;
+		return fail_callback();
 
 	// Check for each button in our list if its corresponding (maybe remapped) button or axis was pressed.
 	// Return the new value if the button was pressed (aka. its value was bigger than 0 or the defined threshold)

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -74,14 +74,14 @@ void xinput_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
+void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, std::vector<std::string> buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
 
 	int device_number = GetDeviceNumber(padId);
 	if (device_number < 0)
-		return fail_callback();
+		return fail_callback(padId);
 
 	DWORD dwResult;
 	XINPUT_STATE state;
@@ -90,7 +90,7 @@ void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std:
 	// Simply get the state of the controller from XInput.
 	dwResult = (*xinputGetState)(static_cast<u32>(device_number), &state);
 	if (dwResult != ERROR_SUCCESS)
-		return fail_callback();
+		return fail_callback(padId);
 
 	// Check for each button in our list if its corresponding (maybe remapped) button or axis was pressed.
 	// Return the new value if the button was pressed (aka. its value was bigger than 0 or the defined threshold)
@@ -131,9 +131,9 @@ void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std:
 	int preview_values[6] = { data[LT], data[RT], data[LSXPos] - data[LSXNeg], data[LSYPos] - data[LSYNeg], data[RSXPos] - data[RSXNeg], data[RSYPos] - data[RSYNeg] };
 
 	if (pressed_button.first > 0)
-		return callback(pressed_button.first, pressed_button.second, preview_values);
+		return callback(pressed_button.first, pressed_button.second, padId, preview_values);
 	else
-		return callback(0, "", preview_values);
+		return callback(0, "", padId, preview_values);
 }
 
 void xinput_pad_handler::TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor)

--- a/rpcs3/xinput_pad_handler.h
+++ b/rpcs3/xinput_pad_handler.h
@@ -107,7 +107,7 @@ public:
 	std::vector<std::string> ListDevices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
-	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
+	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
 	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 

--- a/rpcs3/xinput_pad_handler.h
+++ b/rpcs3/xinput_pad_handler.h
@@ -107,7 +107,7 @@ public:
 	std::vector<std::string> ListDevices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
-	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, int[])>& callback, const std::function<void()>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
+	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, std::vector<std::string> buttons = {}) override;
 	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 


### PR DESCRIPTION
1.
Please test with one or multiple ds4 controllers.
I changed the way ds4 controllers are handled. We now treat them as one of 7 controllers. the internal logic remembers the order.
Please investigate what happens if you connect or disconnect one or multiple new ds4 controllers ingame.
Possible crash: during saving of ds4 settings ingame.

2.
All pad settings (handlers) need testing.
The pad settings dialog remapping should now be mostly disabled when a controller is not detected.
Please test if the buttons enable/disable correctly when you plug/unplug controllers

**UPDATE:** 
Okay with the latest changes I
1. changed the index to 1-n instead of 0-n,
2. also made it possible to reconnect DS4 controllers without pressing the Refresh button,
3. added connection status to the device name in the dropdown,
4. immediately cancel remapping in case a controller was disconnected.

Please test these changes like before on all handlers and with multiple controllers.
I can't test evdev myself so that would be nice to see tested also.