### PR TITLE
Remove distro whitelist and use the new automated stdc++ checker

### DIFF
--- a/.travis/deploy-linux.bash
+++ b/.travis/deploy-linux.bash
@@ -17,10 +17,17 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
 	mkdir -p appdir/usr/optional/ ; mkdir -p appdir/usr/optional/libstdc++/
 	cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/
 	rm ./appdir/AppRun
-	curl -sL https://github.com/RPCS3/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -o ./appdir/AppRun
+	curl -sL https://github.com/RPCS3/AppImageKit-checkrt/releases/download/continuous2/AppRun-patched-x86_64 -o ./appdir/AppRun
 	chmod a+x ./appdir/AppRun
-	curl -sL https://github.com/RPCS3/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -o ./appdir/usr/optional/exec.so
-
+	curl -sL https://github.com/RPCS3/AppImageKit-checkrt/releases/download/continuous2/exec-x86_64.so -o ./appdir/usr/optional/exec.so
+	
+	# Compile checker binary for AppImageKit-checkrt
+	
+	# This may need updating if you update the compiler or rpcs3 uses newer c++ features
+	# See https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/config/abi/pre/gnu.ver
+	# for which definitions correlate to which CXXABI version.
+	printf "#include <memory>\nint main(){std::make_exception_ptr(0);}" | $CXX -x c++ -o ./appdir/usr/optional/checker -
+	
 	# Package it up and send it off
 	./squashfs-root/usr/bin/appimagetool /rpcs3/build/appdir
 	ls


### PR DESCRIPTION
This fixes #5362 and all similar issues in a distro-agnostic way.

For those interested in the AppImageKit-checkrt side of things see this commit: https://github.com/RPCS3/AppImageKit-checkrt/commit/e4343b957f54c0089afe4f214478da068b318791