### PR TITLE
sceNpTrophyCreateContext yielding

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -15,6 +15,10 @@
 
 #include "Utilities/StrUtil.h"
 
+#include "Emu/Cell/lv2/sys_event.h"
+#include "Emu/Cell/lv2/sys_process.h"
+#include "Emu/Cell/lv2/sys_timer.h"
+
 LOG_CHANNEL(sceNpTrophy);
 
 TrophyNotificationBase::~TrophyNotificationBase()
@@ -324,21 +328,39 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 	}
 
 	// This emulates vsh sending the events and ensures that not 2 events are processed at once
-	auto statuses =
+	const std::pair<u32, u32> statuses[] =
 	{
-		SCE_NP_TROPHY_STATUS_PROCESSING_SETUP,
-		SCE_NP_TROPHY_STATUS_PROCESSING_PROGRESS,
-		SCE_NP_TROPHY_STATUS_PROCESSING_FINALIZE,
-		SCE_NP_TROPHY_STATUS_PROCESSING_COMPLETE
+		{ SCE_NP_TROPHY_STATUS_PROCESSING_SETUP, 3 },
+		{ SCE_NP_TROPHY_STATUS_PROCESSING_PROGRESS, tropusr->GetTrophiesCount() },
+		{ SCE_NP_TROPHY_STATUS_PROCESSING_FINALIZE, 4 },
+		{ SCE_NP_TROPHY_STATUS_PROCESSING_COMPLETE, 0 }
 	};
 
+	static atomic_t<u32> queued;
+
+	queued = 0;
 	for (auto status : statuses)
 	{
-		sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+		// One status max per cellSysutilCheckCallback call
+		queued += status.second;
+		for (u32 completed = 0; completed <= status.second; completed++)
 		{
-			statusCb(cb_ppu, context, status, 100, 100, arg);
-			return 0;
-		});
+			sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+			{
+				statusCb(cb_ppu, context, status.first, completed, status.second, arg);
+				queued--;
+				return 0;
+			});
+		}
+
+		u32 passed_time=0;
+		while (queued)
+		{
+			sys_timer_usleep(ppu, 5000);
+			passed_time += 5;
+			// If too much time passes just send the rest of the events anyway
+			if (passed_time > 300) break;
+		}
 	}
 
 	return CELL_OK;


### PR DESCRIPTION
sceNpTrophyCreateContext calls cellSysutilPacketRead which would yield the thread while waiting for a cond.
Also ensures status messages granularity through changes made by neko to Sysutil cb handling.

This should fix the last issues with trophies hopefully.