### PR TITLE
Micro Contribution: Fix cut off Icons after emu crash

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -199,6 +199,7 @@ void game_list_frame::LoadSettings()
 		m_gameList->setColumnHidden(col, !vis);
 	}
 
+	SortGameList();
 	FixNarrowColumns();
 
 	m_gameList->horizontalHeader()->restoreState(m_gameList->horizontalHeader()->saveState());


### PR DESCRIPTION
This was sorely needed when the app crashed after resizing icons