### PR TITLE
Fixes issues where the mutex is destroyed while an unlock is happening

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -80,6 +80,8 @@ error_code sys_mutex_destroy(u32 mutex_id)
 
 	const auto mutex = idm::withdraw<lv2_obj, lv2_mutex>(mutex_id, [](lv2_mutex& mutex) -> CellError
 	{
+		std::lock_guard lock(mutex.mutex);
+
 		if (mutex.owner || mutex.lock_count)
 		{
 			return CELL_EBUSY;


### PR DESCRIPTION
Should fix 4C4T issues(including DeS).

Problem I think is specifically when a mutex unlock awake a thread that then destroy the mutex, when unlock thread runs again the lock_guard destructor fails because mutex->mutex doesn't exist(either crashes or unlock gets stuck).

I think the lock guard might actually be ok because that destroy should succeed on a ps3 so it'll wait until the unlock ends and destroy it.