### PR TITLE
Deploy Linux binaries to GitHub Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
           services: docker
           cache: ccache
           install: "docker pull rpcs3/rpcs3-travis-trusty:1.0"
-          script: 'travis_wait docker run -v $(pwd):/rpcs3 -v "$HOME/.ccache":/root/.ccache -e TRAVIS_PULL_REQUEST -e TRAVIS_BRANCH -e UPLOAD_URL -e COMPILER rpcs3/rpcs3-travis-trusty:1.0 /bin/bash -ex /rpcs3/.travis/build-linux.bash'
+          script: 'travis_wait docker run -v $(pwd):/rpcs3 -v "$HOME/.ccache":/root/.ccache --env-file .travis/travis.env rpcs3/rpcs3-travis-trusty:1.0 /bin/bash -ex /rpcs3/.travis/build-linux.bash'
         - os: linux
           env:
             - NAME="Linux build"
@@ -19,7 +19,7 @@ matrix:
           services: docker
           cache: ccache
           install: "docker pull rpcs3/rpcs3-travis-trusty:1.0"
-          script: 'travis_wait docker run -v $(pwd):/rpcs3 -v "$HOME/.ccache":/root/.ccache -e TRAVIS_PULL_REQUEST -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e COMPILER -e UPLOAD_URL -e DEPLOY_APPIMAGE rpcs3/rpcs3-travis-trusty:1.0 /bin/bash -ex /rpcs3/.travis/build-linux.bash'
+          script: 'travis_wait docker run -v $(pwd):/rpcs3 -v "$HOME/.ccache":/root/.ccache --env-file .travis/travis.env rpcs3/rpcs3-travis-trusty:1.0 /bin/bash -ex /rpcs3/.travis/build-linux.bash'
         - os: osx
           osx_image: xcode10
           script: "/bin/bash -ex .travis/build-mac.bash"

--- a/.travis/build-linux.bash
+++ b/.travis/build-linux.bash
@@ -32,4 +32,4 @@ ninja
 
 cd ..
 # If it compiled succesfully let's deploy
-if [ $? -eq 0 ] && [ -n "$UPLOAD_URL" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then /bin/bash -ex .travis/deploy-linux.bash ; fi
+if [ $? -eq 0 ] && [ -n "$GITHUB_TOKEN" ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then /bin/bash -ex .travis/deploy-linux.bash ; fi

--- a/.travis/deploy-linux.bash
+++ b/.travis/deploy-linux.bash
@@ -33,7 +33,20 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
 	ls
 	COMM_TAG="$(git describe --tags $(git rev-list --tags --max-count=1))"
 	COMM_COUNT="$(git rev-list --count HEAD)"
-	echo $(curl "${UPLOAD_URL}${TRAVIS_COMMIT:0:8}&t=${COMM_TAG}&a=${COMM_COUNT}" --upload-file ./RPCS3*.AppImage)
+	curl -sLO https://github.com/hcorion/uploadtool/raw/master/upload.sh
+	
+	mv ./RPCS3*.AppImage rpcs3-${COMM_TAG}-${COMM_COUNT}-${TRAVIS_COMMIT:0:8}_linux64.AppImage
+	
+	FILESIZEMB=$(bc <<< "scale=6; $(stat -c %s ./rpcs3*.AppImage)/1000000")
+	SHA256SUM=($(sha256sum ./rpcs3*.AppImage))
+	
+	unset TRAVIS_REPO_SLUG
+	REPO_SLUG=RPCS3/rpcs3-binaries-linux \
+		UPLOADTOOL_BODY="$SHA256SUM;${FILESIZEMB}MB"\
+		RELEASE_NAME=build-${TRAVIS_COMMIT}\
+		RELEASE_TITLE=${COMM_TAG}-${COMM_COUNT}\
+		REPO_COMMIT=d812f1254a1157c80fd402f94446310560f54e5f\
+		bash upload.sh rpcs3*.AppImage
 fi
 if [ "$DEPLOY_PPA" = "true" ]; then
 	export DEBFULLNAME="RPCS3 Build Bot"

--- a/.travis/travis.env
+++ b/.travis/travis.env
@@ -1,0 +1,9 @@
+# Variables set by Travis CI
+TRAVIS_PULL_REQUEST
+TRAVIS_BRANCH
+TRAVIS_COMMIT
+# Variables for Travis build matrix
+COMPILER
+DEPLOY_APPIMAGE
+# Private Travis CI variables
+GITHUB_TOKEN


### PR DESCRIPTION
This PR makes the Linux AppImages get pushed to RPCS3/rpcs3-binaries-linux instead of hosting it ourselves. It is setup the exact same as RPCS3/rpcs3-binaries-windows. MacOS deployment will be submitted later, but this PR makes for an easy reference for setting up Mac deployment, if anybody else wants to tackle it.

This allows for the project to provide an easy way to test various RPCS3 builds on Linux.

Requesting review from @AniLeo 