### PR TITLE
Spawn Exit Game Confirmation when closing the game window

### DIFF
--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -122,6 +122,7 @@
 		"stylesheets": "Changes the overall look of RPCS3.\nChoose a stylesheet and click Apply to change between styles.",
 		"show_welcome": "Shows the initial welcome screen upon starting RPCS3.",
 		"show_exit_game": "Shows a confirmation dialog when the game window is being closed.",
+		"show_boot_game": "Shows a confirmation dialog when a game was booted while another game is running.",
 		"show_pkg_install": "Shows a dialog when packages were installed successfully.",
 		"show_pup_install": "Shows a dialog when firmware was installed successfully.",
 		"useRichPresence": "Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to completely close the connection.",

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -121,6 +121,9 @@
 		"configs": "Only useful to developers.\nIf unsure, don't use this option.",
 		"stylesheets": "Changes the overall look of RPCS3.\nChoose a stylesheet and click Apply to change between styles.",
 		"show_welcome": "Shows the initial welcome screen upon starting RPCS3.",
+		"show_exit_game": "Shows a confirmation dialog when the game window is being closed.",
+		"show_pkg_install": "Shows a dialog when packages were installed successfully.",
+		"show_pup_install": "Shows a dialog when firmware was installed successfully.",
 		"useRichPresence": "Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to completely close the connection.",
 		"discordState": "Tell your friends what you are doing.",
 		"custom_colors": "Prioritize custom user interface colors over properties set in stylesheet."

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -202,7 +202,6 @@ void rpcs3_app::InitializeCallbacks()
 			h = guiSettings->GetValue(gui::gs_height).toInt();
 		}
 
-		bool disableMouse = guiSettings->GetValue(gui::gs_disableMouse).toBool();
 		auto frame_geometry = gui::utils::create_centered_window_geometry(RPCS3MainWin->geometry(), w, h);
 
 		gs_frame* frame;
@@ -211,23 +210,23 @@ void rpcs3_app::InitializeCallbacks()
 		{
 		case video_renderer::null:
 		{
-			frame = new gs_frame("Null", frame_geometry, RPCS3MainWin->GetAppIcon(), disableMouse);
+			frame = new gs_frame("Null", frame_geometry, RPCS3MainWin->GetAppIcon(), guiSettings);
 			break;
 		}
 		case video_renderer::opengl:
 		{
-			frame = new gl_gs_frame(frame_geometry, RPCS3MainWin->GetAppIcon(), disableMouse);
+			frame = new gl_gs_frame(frame_geometry, RPCS3MainWin->GetAppIcon(), guiSettings);
 			break;
 		}
 		case video_renderer::vulkan:
 		{
-			frame = new gs_frame("Vulkan", frame_geometry, RPCS3MainWin->GetAppIcon(), disableMouse);
+			frame = new gs_frame("Vulkan", frame_geometry, RPCS3MainWin->GetAppIcon(), guiSettings);
 			break;
 		}
 #ifdef _MSC_VER
 		case video_renderer::dx12:
 		{
-			frame = new gs_frame("DirectX 12", frame_geometry, RPCS3MainWin->GetAppIcon(), disableMouse);
+			frame = new gs_frame("DirectX 12", frame_geometry, RPCS3MainWin->GetAppIcon(), guiSettings);
 			break;
 		}
 #endif

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -6,8 +6,8 @@
 #include <qoffscreensurface.h>
 #include <QWindow>
 
-gl_gs_frame::gl_gs_frame(const QRect& geometry, QIcon appIcon, bool disableMouse)
-	: gs_frame("OpenGL", geometry, appIcon, disableMouse)
+gl_gs_frame::gl_gs_frame(const QRect& geometry, const QIcon& appIcon, const std::shared_ptr<gui_settings>& gui_settings)
+	: gs_frame("OpenGL", geometry, appIcon, gui_settings)
 {
 	setSurfaceType(QSurface::OpenGLSurface);
 

--- a/rpcs3/rpcs3qt/gl_gs_frame.h
+++ b/rpcs3/rpcs3qt/gl_gs_frame.h
@@ -17,7 +17,7 @@ private:
 	GLContext *m_primary_context = nullptr;
 
 public:
-	gl_gs_frame(const QRect& geometry, QIcon appIcon, bool disableMouse);
+	gl_gs_frame(const QRect& geometry, const QIcon& appIcon, const std::shared_ptr<gui_settings>& gui_settings);
 
 	draw_context_t make_context() override;
 	void set_current(draw_context_t context) override;

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -3,6 +3,8 @@
 #include "stdafx.h"
 #include "Emu/RSX/GSRender.h"
 
+#include "gui_settings.h"
+
 #include <QWidget>
 #include <QWindow>
 
@@ -31,6 +33,8 @@ private:
 	void UpdateProgress(int progress, bool disable = false);
 #endif
 
+	std::shared_ptr<gui_settings> m_gui_settings;
+
 	u64 m_frames = 0;
 	QString m_windowTitle;
 	bool m_show_fps;
@@ -44,7 +48,7 @@ private:
 	bool m_use_5_11_1_workaround = false;   // QT ABI bug workaround
 
 public:
-	gs_frame(const QString& title, const QRect& geometry, QIcon appIcon, bool disableMouse);
+	gs_frame(const QString& title, const QRect& geometry, const QIcon& appIcon, const std::shared_ptr<gui_settings>& gui_settings);
 	~gs_frame();
 
 	draw_context_t make_context() override;

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -140,6 +140,7 @@ namespace gui
 	const gui_save ib_pup_success  = gui_save(main_window, "infoBoxEnabledInstallPUP", true);
 	const gui_save ib_show_welcome = gui_save(main_window, "infoBoxEnabledWelcome",    true);
 	const gui_save ib_confirm_exit = gui_save(main_window, "confirmationBoxExitGame",  true);
+	const gui_save ib_confirm_boot = gui_save(main_window, "confirmationBoxBootGame",  true);
 
 	const gui_save fd_install_pkg  = gui_save(main_window, "lastExplorePathPKG",  "");
 	const gui_save fd_install_pup  = gui_save(main_window, "lastExplorePathPUP",  "");

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -139,6 +139,7 @@ namespace gui
 	const gui_save ib_pkg_success  = gui_save(main_window, "infoBoxEnabledInstallPKG", true);
 	const gui_save ib_pup_success  = gui_save(main_window, "infoBoxEnabledInstallPUP", true);
 	const gui_save ib_show_welcome = gui_save(main_window, "infoBoxEnabledWelcome",    true);
+	const gui_save ib_confirm_exit = gui_save(main_window, "confirmationBoxExitGame",  true);
 
 	const gui_save fd_install_pkg  = gui_save(main_window, "lastExplorePathPKG",  "");
 	const gui_save fd_install_pup  = gui_save(main_window, "lastExplorePathPUP",  "");
@@ -250,7 +251,8 @@ public:
 	QVariant List2Var(const q_pair_list& list);
 	q_pair_list Var2List(const QVariant &var);
 
-	void ShowInfoBox(const gui_save& entry, const QString& title, const QString& text, QWidget* parent = 0);
+	void ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent);
+	void ShowInfoBox(const QString& title, const QString& text, const gui_save& entry, QWidget* parent);
 
 	logs::level GetLogLevel();
 	bool GetGamelistColVisibility(int col);
@@ -285,6 +287,7 @@ public Q_SLOTS:
 private:
 	QString ComputeSettingsDir();
 	void BackupSettingsToTarget(const QString& friendly_name);
+	void ShowBox(bool confirm, const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent);
 
 	QSettings m_settings;
 	QDir m_settingsDir;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -493,7 +493,7 @@ void main_window::InstallPkg(const QString& dropPath, bool is_bulk)
 	{
 		m_gameListFrame->Refresh(true);
 		LOG_SUCCESS(GENERAL, "Successfully installed %s.", fileName);
-		guiSettings->ShowInfoBox(gui::ib_pkg_success, tr("Success!"), tr("Successfully installed software from package!"), this);
+		guiSettings->ShowInfoBox(tr("Success!"), tr("Successfully installed software from package!"), gui::ib_pkg_success, this);
 	}
 }
 
@@ -633,7 +633,7 @@ void main_window::InstallPup(const QString& dropPath)
 	if (progress > 0)
 	{
 		LOG_SUCCESS(GENERAL, "Successfully installed PS3 firmware version %s.", version_string);
-		guiSettings->ShowInfoBox(gui::ib_pup_success, tr("Success!"), tr("Successfully installed PS3 firmware and LLE Modules!"), this);
+		guiSettings->ShowInfoBox(tr("Success!"), tr("Successfully installed PS3 firmware and LLE Modules!"), gui::ib_pup_success, this);
 
 		Emu.SetForceBoot(true);
 		Emu.BootGame(g_cfg.vfs.get_dev_flash() + "sys/external/", true);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -270,6 +270,19 @@ void main_window::OnPlayOrPause()
 
 void main_window::Boot(const std::string& path, bool direct, bool add_only)
 {
+	if (!Emu.IsStopped())
+	{
+		int result;
+		guiSettings->ShowConfirmationBox(tr("Close Running Game?"),
+			tr("Booting another game will close the current game.\nDo you really want to boot another game?\n\nAny unsaved progress will be lost!\n"),
+			gui::ib_confirm_boot, &result, this);
+
+		if (result != QMessageBox::Yes)
+		{
+			return;
+		}
+	}
+
 	SetAppIconFromPath(path);
 	Emu.SetForceBoot(true);
 	Emu.Stop();

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1011,6 +1011,12 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	// Checkboxes: gui options
 	SubscribeTooltip(ui->cb_show_welcome, json_gui["show_welcome"].toString());
 
+	SubscribeTooltip(ui->cb_show_exit_game, json_gui["show_exit_game"].toString());
+
+	SubscribeTooltip(ui->cb_show_pkg_install, json_gui["show_pkg_install"].toString());
+
+	SubscribeTooltip(ui->cb_show_pup_install, json_gui["show_pup_install"].toString());
+
 	SubscribeTooltip(ui->useRichPresence, json_gui["useRichPresence"].toString());
 
 	SubscribeTooltip(ui->discordState, json_gui["discordState"].toString());
@@ -1067,6 +1073,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		AddColoredIcons();
 
 		ui->cb_show_welcome->setChecked(xgui_settings->GetValue(gui::ib_show_welcome).toBool());
+		ui->cb_show_exit_game->setChecked(xgui_settings->GetValue(gui::ib_confirm_exit).toBool());
+		ui->cb_show_pkg_install->setChecked(xgui_settings->GetValue(gui::ib_pkg_success).toBool());
+		ui->cb_show_pup_install->setChecked(xgui_settings->GetValue(gui::ib_pup_success).toBool());
 
 		bool enableUIColors = xgui_settings->GetValue(gui::m_enableUIColors).toBool();
 		ui->cb_custom_colors->setChecked(enableUIColors);
@@ -1124,6 +1133,18 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		connect(ui->cb_show_welcome, &QCheckBox::clicked, [=](bool val)
 		{
 			xgui_settings->SetValue(gui::ib_show_welcome, val);
+		});
+		connect(ui->cb_show_exit_game, &QCheckBox::clicked, [=](bool val)
+		{
+			xgui_settings->SetValue(gui::ib_confirm_exit, val);
+		});
+		connect(ui->cb_show_pkg_install, &QCheckBox::clicked, [=](bool val)
+		{
+			xgui_settings->SetValue(gui::ib_pkg_success, val);
+		});
+		connect(ui->cb_show_pup_install, &QCheckBox::clicked, [=](bool val)
+		{
+			xgui_settings->SetValue(gui::ib_pup_success, val);
 		});
 
 		connect(ui->cb_custom_colors, &QCheckBox::clicked, [=](bool val)

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1013,6 +1013,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 	SubscribeTooltip(ui->cb_show_exit_game, json_gui["show_exit_game"].toString());
 
+	SubscribeTooltip(ui->cb_show_boot_game, json_gui["show_boot_game"].toString());
+
 	SubscribeTooltip(ui->cb_show_pkg_install, json_gui["show_pkg_install"].toString());
 
 	SubscribeTooltip(ui->cb_show_pup_install, json_gui["show_pup_install"].toString());
@@ -1074,6 +1076,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 		ui->cb_show_welcome->setChecked(xgui_settings->GetValue(gui::ib_show_welcome).toBool());
 		ui->cb_show_exit_game->setChecked(xgui_settings->GetValue(gui::ib_confirm_exit).toBool());
+		ui->cb_show_boot_game->setChecked(xgui_settings->GetValue(gui::ib_confirm_boot).toBool());
 		ui->cb_show_pkg_install->setChecked(xgui_settings->GetValue(gui::ib_pkg_success).toBool());
 		ui->cb_show_pup_install->setChecked(xgui_settings->GetValue(gui::ib_pup_success).toBool());
 
@@ -1137,6 +1140,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		connect(ui->cb_show_exit_game, &QCheckBox::clicked, [=](bool val)
 		{
 			xgui_settings->SetValue(gui::ib_confirm_exit, val);
+		});
+		connect(ui->cb_show_boot_game, &QCheckBox::clicked, [=](bool val)
+		{
+			xgui_settings->SetValue(gui::ib_confirm_boot, val);
 		});
 		connect(ui->cb_show_pkg_install, &QCheckBox::clicked, [=](bool val)
 		{

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1926,6 +1926,13 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="cb_show_boot_game">
+                <property name="text">
+                 <string>Show Boot Game Dialog</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="cb_show_pkg_install">
                 <property name="text">
                  <string>Show PGK Installation Dialog</string>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>752</width>
-    <height>576</height>
+    <height>584</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1915,6 +1915,27 @@
                <widget class="QCheckBox" name="cb_show_welcome">
                 <property name="text">
                  <string>Show Welcome Screen</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="cb_show_exit_game">
+                <property name="text">
+                 <string>Show Exit Game Dialog</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="cb_show_pkg_install">
+                <property name="text">
+                 <string>Show PGK Installation Dialog</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="cb_show_pup_install">
+                <property name="text">
+                 <string>Show PUP Installation Dialog</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Since some users requested this I implemented a "Exit game?" dialog that lets you abort the exit process and also warns about loss of progress. A similar Dialog will be spawned when you boot a game while another is running.

The dialog can be disabled via "Don't show again" checkbox and reenabled in the gui settings. I also added the other forgotten remaining info dialog settings to the same location.

This dialog is pure Qt btw, because once you close the window you will have most likely used mouse and keyboard anyway.

fixes #5107