### PR TITLE
cellGame: fix some installation issues

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -833,11 +833,24 @@ error_code cellGameGetSizeKB(vm::ptr<s32> size)
 		return CELL_GAME_ERROR_FAILURE;
 	}
 
+	if (Emu.GetCat() == "DG")
+	{
+		return CELL_GAME_ERROR_NOTSUPPORTED;
+	}
+
 	const std::string local_dir = !prm->temp.empty() ? prm->temp : vfs::get("/dev_hdd0/game/" + prm->dir);
 
 	if (!fs::is_dir(local_dir))
 	{
-		return CELL_GAME_ERROR_ACCESS_ERROR;
+		if (fs::g_tls_error == fs::error::noent)
+		{
+			*size = 0;
+			return CELL_OK;
+		}
+		else
+		{
+			return CELL_GAME_ERROR_ACCESS_ERROR;
+		}
 	}
 
 	*size = ::narrow<u32>(fs::get_dir_size(local_dir) / 1024);


### PR DESCRIPTION
HAWX2 wouldn't get past cellGameGetSizeKb because the dir was not existant.
I don't really know if this approach is correct but it led to a proper installation into said dir.
Sadly the game immediately crashes on the first logo.