### PR TITLE
[Experimental] Forcefully yield in run_FIFO on low-core-count CPUs

### DIFF
--- a/Utilities/sysinfo.cpp
+++ b/Utilities/sysinfo.cpp
@@ -1,4 +1,4 @@
-#include "sysinfo.h"
+﻿#include "sysinfo.h"
 #include "StrFmt.h"
 
 #ifdef _WIN32
@@ -54,6 +54,12 @@ bool utils::has_xop()
 {
 	static const bool g_value = has_avx() && get_cpuid(0x80000001, 0)[2] & 0x800;
 	return g_value;
+}
+
+u32 utils::hardware_concurrency()
+{
+	static const u32 nthreads = std::thread::hardware_concurrency();
+	return nthreads;
 }
 
 std::string utils::get_system_info()

--- a/Utilities/sysinfo.h
+++ b/Utilities/sysinfo.h
@@ -1,7 +1,8 @@
-#pragma once
+﻿#pragma once
 
 #include "types.h"
 #include <string>
+#include <thread>
 
 namespace utils
 {
@@ -42,6 +43,8 @@ namespace utils
 	bool has_512();
 
 	bool has_xop();
+
+	u32 hardware_concurrency();
 
 	std::string get_system_info();
 }


### PR DESCRIPTION
std::this_thread::yield may behave as a NOP if there is no other thread of same or higher priority ready to run. Since the FIFO thread has a high priority, it is likely that this will always be the case. Profiling runs of RPCS3 showed that in low core count CPUs, the FIFO thread was spending almost 50% of it's active time spinning, and was very rarely pre-empted, effectively locking down a whole CPU thread a significant portion of the time without achieving anything productive.

Low core count CPUs suffer significantly by having a CPU thread busy looping when the RSX FIFO is empty. Now, we sleep for 1ms. This has been shown to increase performance slightly. In P5 Shibuya on a i5-4670k with SPU LLVM, this was shown to improve performance by 3-4FPS over master.

High core count CPUs however can afford to busy-loop. Surrendering the core does not increase performance, and may actually reduce it. As such, high core-count CPUs still behave exactly as before. Do not expect a performance increase if you have a 4C8T or better CPU.

This is experimental, and may cause issues, further testing is needed. It is also possible it might reduce performance in some systems. Additionally, the cut-off for what is a "high core count CPU" (currently set at >=8 threads) may also need to be tweaked, as well as the sleep duration (currently 1ms).