### PR TITLE
File memery

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1,4 +1,4 @@
-#include "File.h"
+﻿#include "File.h"
 #include "mutex.h"
 #include "StrFmt.h"
 #include "BEType.h"
@@ -1489,7 +1489,7 @@ void fs::remove_all(const std::string& path, bool remove_root)
 	}
 }
 
-u64 fs::get_dir_size(const std::string& path)
+u64 fs::get_dir_size(const std::string& path, u64 rounding_alignment)
 {
 	u64 result = 0;
 
@@ -1502,12 +1502,12 @@ u64 fs::get_dir_size(const std::string& path)
 
 		if (entry.is_directory == false)
 		{
-			result += entry.size;
+			result += ::align(entry.size, rounding_alignment);
 		}
 
 		if (entry.is_directory == true)
 		{
-			result += get_dir_size(path + '/' + entry.name);
+			result += get_dir_size(path + '/' + entry.name, rounding_alignment);
 		}
 	}
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "types.h"
 #include "bit_set.h"
@@ -491,7 +491,7 @@ namespace fs
 	void remove_all(const std::string& path, bool remove_root = true);
 
 	// Get size of all files recursively
-	u64 get_dir_size(const std::string& path);
+	u64 get_dir_size(const std::string& path, u64 rounding_alignment = 1);
 
 	enum class error : uint
 	{

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -2,6 +2,7 @@
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUModule.h"
+#include "Emu/Cell/lv2/sys_fs.h"
 
 #include "cellSysutil.h"
 #include "cellMsgDialog.h"
@@ -213,6 +214,14 @@ s32 cellHddGameGetSizeKB(vm::ptr<u32> size)
 		return (s32)CELL_HDDGAME_ERROR_FAILURE;
 	}
 
+	idm::select<lv2_fs_object, lv2_file>([](u32, lv2_file& file)
+	{
+		if (file.flags & CELL_FS_O_WRONLY)
+		{
+			file.file.sync();
+		}
+	});
+
 	*size = ::narrow<u32>(fs::get_dir_size(local_dir) / 1024);
 
 	return CELL_OK;
@@ -261,6 +270,14 @@ s32 cellGameDataGetSizeKB(vm::ptr<u32> size)
 	{
 		return CELL_GAMEDATA_ERROR_FAILURE;
 	}
+
+	idm::select<lv2_fs_object, lv2_file>([](u32, lv2_file& file)
+	{
+		if (file.flags & CELL_FS_O_WRONLY)
+		{
+			file.file.sync();
+		}
+	});
 
 	*size = ::narrow<u32>(fs::get_dir_size(local_dir) / 1024);
 
@@ -847,6 +864,14 @@ error_code cellGameGetSizeKB(vm::ptr<s32> size)
 			return CELL_GAME_ERROR_ACCESS_ERROR;
 		}
 	}
+
+	idm::select<lv2_fs_object, lv2_file>([](u32, lv2_file& file)
+	{
+		if (file.flags & CELL_FS_O_WRONLY)
+		{
+			file.file.sync();
+		}
+	});
 
 	*size = ::narrow<u32>(fs::get_dir_size(local_dir) / 1024);
 

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -222,7 +222,7 @@ s32 cellHddGameGetSizeKB(vm::ptr<u32> size)
 		}
 	});
 
-	*size = ::narrow<u32>(fs::get_dir_size(local_dir) / 1024);
+	*size = ::narrow<u32>(fs::get_dir_size(local_dir, 1024) / 1024);
 
 	return CELL_OK;
 }
@@ -279,7 +279,7 @@ s32 cellGameDataGetSizeKB(vm::ptr<u32> size)
 		}
 	});
 
-	*size = ::narrow<u32>(fs::get_dir_size(local_dir) / 1024);
+	*size = ::narrow<u32>(fs::get_dir_size(local_dir, 1024) / 1024);
 
 	return CELL_OK;
 }
@@ -873,7 +873,7 @@ error_code cellGameGetSizeKB(vm::ptr<s32> size)
 		}
 	});
 
-	*size = ::narrow<u32>(fs::get_dir_size(local_dir) / 1024);
+	*size = ::narrow<u32>(fs::get_dir_size(local_dir, 1024) / 1024);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Emu/Memory/vm.h"
 #include "Emu/Cell/ErrorCodes.h"
@@ -132,7 +132,7 @@ struct lv2_fs_object
 	const std::add_pointer_t<lv2_fs_mount_point> mp;
 
 	// File Name (max 1055)
-	const std::array<char, 0x420> name;
+	std::array<char, 0x420> name;
 
 	lv2_fs_object(lv2_fs_mount_point* mp, const char* filename)
 		: mp(mp)
@@ -163,7 +163,8 @@ struct lv2_fs_object
 
 struct lv2_file final : lv2_fs_object
 {
-	const fs::file file;
+	fs::file file;
+	fs::stat_t info;
 	const s32 mode;
 	const s32 flags;
 
@@ -175,6 +176,7 @@ struct lv2_file final : lv2_fs_object
 		, file(std::move(file))
 		, mode(mode)
 		, flags(flags)
+		, info(lv2_file::file.stat())
 	{
 	}
 
@@ -183,6 +185,7 @@ struct lv2_file final : lv2_fs_object
 		, file(std::move(file))
 		, mode(mode)
 		, flags(flags)
+		, info(lv2_file::file.stat())
 	{
 	}
 
@@ -191,6 +194,8 @@ struct lv2_file final : lv2_fs_object
 
 	// File writing with intermediate buffer
 	u64 op_write(vm::cptr<void> buf, u64 size);
+
+	const fs::stat_t& stat();
 
 	// For MSELF support
 	struct file_view;


### PR DESCRIPTION
Fixes possibly the worst game in history, Jissen Pachi-Slot Hisshouhou! Hokuto no Ken F - Seikimatsu Kyuuseishu [BLJM60468]
The game refuses to boot unless the reported game data size is exact down to the kilobyte
[BLJM60468] loadable -> ingame (playable?)
![image](https://user-images.githubusercontent.com/26828095/51133522-7d896380-1835-11e9-9f45-3835d194379b.png)

Could be worth testing more games that crash/freeze when/after installing data