### PR TITLE
cellOskDialog/osk_dialog_frame: fix regexp for CELL_OSKDIALOG_NO_SPACE

### DIFF
--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -74,7 +74,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 
 		if (options & CELL_OSKDIALOG_NO_SPACE)
 		{
-			input->setValidator(new QRegExpValidator(QRegExp("^\S*$"), this));
+			input->setValidator(new QRegExpValidator(QRegExp("^\\S*$"), this));
 		}
 
 		connect(input, &QLineEdit::textChanged, [=](const QString& text)


### PR DESCRIPTION
Fixes my facepalm mistake that leads to osk dialogs only taking S as input when they should just prevent whitespace.

This should fix the issue with H.A.W.X.2 for example.