### PR TITLE
Patch ppu main thread prio

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1044,7 +1044,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 
 	// Process information
 	u32 sdk_version = 0x360001;
-	s32 primary_prio = 0x50;
+	s32 primary_prio = 1001;
 	u32 primary_stacksize = 0x100000;
 	u32 malloc_pagesize = 0x100000;
 
@@ -1182,7 +1182,12 @@ void ppu_load_exec(const ppu_exec_object& elf)
 				else
 				{
 					sdk_version = info.sdk_version;
-					primary_prio = info.primary_prio;
+
+					if (s32 prio = info.primary_prio; prio < 3072 && prio >= 0)
+					{
+						primary_prio = prio;
+					}
+
 					primary_stacksize = info.primary_stacksize;
 					malloc_pagesize = info.malloc_pagesize;
 


### PR DESCRIPTION
Use a default of 1001 prio when the main thread priority specified by the executable image is invalid.
Fixes the weeb and loadable game White Album 2, which reuses main thread prio for creating other threads.
The main is invalid, making ppu thread creations fail as well.
testcase : https://github.com/elad335/myps3tests/tree/master/ppu_tests/default%20main%20prio
![image](https://user-images.githubusercontent.com/18193363/51333837-38f50680-1a87-11e9-9ee3-65ec1b390ccf.png)
