### PR TITLE
Wait until condition confirmation in atomic operations (try once methods)

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -171,17 +171,7 @@ error_code sys_semaphore_trywait(u32 sem_id)
 
 	const auto sem = idm::check<lv2_obj, lv2_sema>(sem_id, [&](lv2_sema& sema)
 	{
-		const s32 val = sema.val;
-
-		if (val > 0)
-		{
-			if (sema.val.compare_and_swap_test(val, val - 1))
-			{
-				return true;
-			}
-		}
-
-		return false;
+		return sema.val.try_dec(0);
 	});
 
 	if (!sem)


### PR DESCRIPTION
Do not abort prematurely on failed cmpxchg, restart the atomic loop and wait for condition confirmation instead.

Example: two threads are executing semaphore trywait at the same time on semaphore with an initial value of 2.
Ideally, both should succeed and return CELL_OK.
On the current method, when the first thread decreements the sema's value while the second thread is in the middle of trywait operation, the second thread will fail to store due to failed cmpxchg. (EBUSY is returned)
With an atomic loop restart the second thread will restart the atomic loop and reload the semaphore value, check it and decrement its value, both operations return CELL_OK.

Condition confirmation is important in try once methods.
