### PR TITLE
rsx: Fix unknown vertex base types

### DIFF
--- a/rpcs3/Emu/RSX/gcm_enums.cpp
+++ b/rpcs3/Emu/RSX/gcm_enums.cpp
@@ -5,6 +5,7 @@ rsx::vertex_base_type rsx::to_vertex_base_type(u8 in)
 {
 	switch (in)
 	{
+	case 0: return rsx::vertex_base_type::ub256;
 	case 1: return rsx::vertex_base_type::s1;
 	case 2: return rsx::vertex_base_type::f;
 	case 3: return rsx::vertex_base_type::sf;

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -4598,7 +4598,7 @@ struct vertex_array_helper
 		union
 		{
 			u32 raw_value;
-			bitfield_decoder_t<0, 4> type;
+			bitfield_decoder_t<0, 3> type;
 			bitfield_decoder_t<4, 4> size;
 			bitfield_decoder_t<8, 8> stride;
 			bitfield_decoder_t<16, 16> frequency;


### PR DESCRIPTION

- Clamp vertex type field into 3-bit instead of 4-bit value, vertex type 0 is the same as ub256.

Testcase : https://github.com/elad335/myps3tests/tree/master/rsx_tests/vertex%20base%20type%200

Testing conditions:
- all vertex base types are being ORed with 0x8, this doesnt affect the results on realhw but crashes on rpcs3.

1) Vertex base type 0 is used for POSITION array, values of ub256 are being passed and normalized manually into [-1, +1] by doing `new_value = ((value) - 128) / 128` in the vertex shader.
Rendering works and produces normal image.

Fixes #5582
Fixes #2408