### PR TITLE
Fix some minor shenanigans

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -283,7 +283,7 @@ u64 audio_ringbuffer::update()
 	{
 		if (!new_playing)
 		{
-			cellAudio.error("Audio backend stopped unexpectedly, likely due to a buffer underrun");
+			cellAudio.warning("Audio backend stopped unexpectedly, likely due to a buffer underrun");
 
 			flush();
 			playing = false;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -458,7 +458,7 @@ namespace rsx
 			{
 				ref_cnt++;
 
-				Emu.CallAfter([&]()
+				Emu.CallAfter([&, index, processed, entry_count]()
 				{
 					const char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
 					dlg->ProgressBarSetMsg(index, fmt::format(text, processed, entry_count));
@@ -470,7 +470,7 @@ namespace rsx
 			{
 				ref_cnt++;
 
-				Emu.CallAfter([&]()
+				Emu.CallAfter([&, index, value]()
 				{
 					dlg->ProgressBarInc(index, value);
 					ref_cnt--;
@@ -481,7 +481,7 @@ namespace rsx
 			{
 				ref_cnt++;
 
-				Emu.CallAfter([&]()
+				Emu.CallAfter([&, index, limit]()
 				{
 					dlg->ProgressBarSetLimit(index, limit);
 					ref_cnt--;


### PR DESCRIPTION
I suddenly noticed some strange behavior with my shader compilation dialog.
At first I thought it was my build but then it also happened on master.
After some investigation I found out that the values passed to the CallAfters weren't the same as those that were actually used inside the lamda.
So I hope this is the correct fix.

Also use log level warning instead of error for the notorious underrun message.