### PR TITLE
Make main_thread unjoinable

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1494,7 +1494,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	p.stack_addr = vm::cast(vm::alloc(primary_stacksize, vm::stack, 4096));
 	p.stack_size = primary_stacksize;
 
-	auto ppu = idm::make_ptr<named_thread<ppu_thread>>("PPU[0x1000000] Thread (main_thread)", p, "main_thread", primary_prio);
+	auto ppu = idm::make_ptr<named_thread<ppu_thread>>("PPU[0x1000000] Thread (main_thread)", p, "main_thread", primary_prio, 1);
 
 	// Write initial data (exitspawn)
 	if (Emu.data.size())

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -188,11 +188,17 @@ error_code sys_ppu_thread_detach(u32 thread_id)
 	return CELL_OK;
 }
 
-void sys_ppu_thread_get_join_state(ppu_thread& ppu, vm::ptr<s32> isjoinable)
+error_code sys_ppu_thread_get_join_state(ppu_thread& ppu, vm::ptr<s32> isjoinable)
 {
 	sys_ppu_thread.trace("sys_ppu_thread_get_join_state(isjoinable=*0x%x)", isjoinable);
 
+	if (!isjoinable)
+	{
+		return CELL_EFAULT;
+	}
+
 	*isjoinable = ppu.joiner != -1;
+	return CELL_OK;
 }
 
 error_code sys_ppu_thread_set_priority(ppu_thread& ppu, u32 thread_id, s32 prio)

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.h
@@ -58,7 +58,7 @@ void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode);
 void sys_ppu_thread_yield(ppu_thread& ppu);
 error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr);
 error_code sys_ppu_thread_detach(u32 thread_id);
-void sys_ppu_thread_get_join_state(ppu_thread& ppu, vm::ptr<s32> isjoinable);
+error_code sys_ppu_thread_get_join_state(ppu_thread& ppu, vm::ptr<s32> isjoinable); // Error code is ignored by the library
 error_code sys_ppu_thread_set_priority(ppu_thread& ppu, u32 thread_id, s32 prio);
 error_code sys_ppu_thread_get_priority(u32 thread_id, vm::ptr<s32> priop);
 error_code sys_ppu_thread_get_stack_information(ppu_thread& ppu, vm::ptr<sys_ppu_thread_stack_t> sp);


### PR DESCRIPTION
* Make main thread unjoinable.
* Return error code in sys_ppu_thread_get_join_state. (the library ignores it by default)

Testcase : https://github.com/elad335/myps3tests/tree/master/ppu_tests/Main%20thread%20joinability
The testcase tests the main thread's joinability using sys_ppu_thread_get_join_state and a join from a different thread.
This also tests the error code returned when passing invalid ptr to sys_ppu_thread_get_join_state. (EFAULT is returned in this case, otherwise CELL_OK is returned)
get_join_state call was designed using a direct lv2 call to get the error code.