### PR TITLE
Fix potential crash in begin_occlusion_query() while closing the Emu

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1123,7 +1123,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 			g_tls_fault_rsx++;
 			if (cpu && cpu->test_stopped())
 			{
-				std::terminate();
+				//
 			}
 
 			return true;
@@ -1265,7 +1265,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 	{
 		if (cpu && cpu->test_stopped())
 		{
-			std::terminate();
+			//
 		}
 
 		return true;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2612,7 +2612,7 @@ namespace rsx
 		void ZCULL_control::allocate_new_query(::rsx::thread* ptimer)
 		{
 			int retries = 0;
-			while (!Emu.IsStopped())
+			while (true)
 			{
 				for (u32 n = 0; n < occlusion_query_count; ++n)
 				{


### PR DESCRIPTION
If the emu is stopped while in allocate_new_query(), m_current_task will not be set and remain as nullptr in ZCULL_control::set_active().
The pointer is later on dereferenced in begin_occlusion_query().