### PR TITLE
Make sys_spu_thread_group_join return once per termination

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -574,7 +574,7 @@ void _spurs::handler_entry(ppu_thread& ppu, vm::ptr<CellSpurs> spurs)
 
 		CHECK_SUCCESS(sys_spu_thread_group_start(ppu, spurs->spuTG));
 
-		if (s32 rc = sys_spu_thread_group_join(ppu, spurs->spuTG, vm::null, vm::null))
+		if (s32 rc = sys_spu_thread_group_join(ppu, spurs->spuTG, vm::var<u32>{}, vm::var<u32>{}))
 		{
 			if (rc == CELL_ESTAT)
 			{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -521,6 +521,11 @@ void spu_thread::cpu_stop()
 				group->stop_count++;
 				group->run_state = SPU_THREAD_GROUP_STATUS_INITIALIZED;
 
+				if (!group->join_state)
+				{
+					group->join_state = SYS_SPU_THREAD_GROUP_JOIN_ALL_THREADS_EXIT;
+				}
+
 				if (const auto ppu = std::exchange(group->waiter, nullptr))
 				{
 					// Send exit status directly to the joining thread
@@ -2436,7 +2441,7 @@ bool spu_thread::stop_and_signal(u32 code)
 		}
 
 		group->exit_status = value;
-		group->join_state |= SPU_TGJSF_GROUP_EXIT;
+		group->join_state = SYS_SPU_THREAD_GROUP_JOIN_GROUP_EXIT;
 
 		state += cpu_flag::stop;
 		return true;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -276,8 +276,8 @@ struct spu_channel_4_t
 public:
 	void clear()
 	{
-		values.store({});
-		value3 = 0;
+		values.release({});
+		value3.release(0);
 	}
 
 	// push unconditionally (overwriting latest value), returns true if needs signaling
@@ -364,8 +364,8 @@ struct spu_int_ctrl_t
 
 	void clear()
 	{
-		mask = 0;
-		stat = 0;
+		mask.release(0);
+		stat.release(0);
 		tag = nullptr;
 	}
 };

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -266,7 +266,7 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 			return cpu;
 		}
 
-		mutex->signaled = 1;
+		mutex->signaled.release(1);
 		return nullptr;
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -175,7 +175,7 @@ error_code _sys_lwmutex_unlock(ppu_thread& ppu, u32 lwmutex_id)
 			return cpu;
 		}
 
-		mutex.signaled = 1;
+		mutex.signaled.release(1);
 		return nullptr;
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -120,19 +120,21 @@ error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr
 	// Wait for cleanup
 	(*thread.ptr)();
 
-	// Get the exit status from the register
-	if (vptr)
+	if (ppu.test_stopped())
 	{
-		if (ppu.test_stopped())
-		{
-			return 0;
-		}
-
-		*vptr = thread->gpr[3];
+		return 0;
 	}
 
 	// Cleanup
 	idm::remove<named_thread<ppu_thread>>(thread->id);
+
+	if (!vptr)
+	{
+		return CELL_EFAULT;
+	}
+
+	// Get the exit status from the register
+	*vptr = thread->gpr[3];
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -683,16 +683,19 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 		return 0;
 	}
 
-	if (cause)
+	if (!cause)
 	{
-		*cause = static_cast<u32>(ppu.gpr[4]);
+		return CELL_EFAULT;
 	}
 
-	if (status)
+	*cause = static_cast<u32>(ppu.gpr[4]);
+
+	if (!status)
 	{
-		*status = static_cast<s32>(ppu.gpr[5]);
+		return CELL_EFAULT;
 	}
 
+	*status = static_cast<s32>(ppu.gpr[5]);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -607,7 +607,7 @@ error_code sys_spu_thread_group_terminate(u32 id, s32 value)
 	}
 
 	group->exit_status = value;
-	group->join_state |= SPU_TGJSF_TERMINATED;
+	group->join_state = SYS_SPU_THREAD_GROUP_JOIN_TERMINATED;
 
 	// Wait until the threads are actually stopped
 	const u64 last_stop = group->stop_count - !group->running;
@@ -648,11 +648,12 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 			return CELL_EBUSY;
 		}
 
-		if (group->run_state == SPU_THREAD_GROUP_STATUS_INITIALIZED)
+		if (group->join_state)
 		{
-			// Already terminated
+			// Already signaled
 			ppu.gpr[4] = group->join_state;
 			ppu.gpr[5] = group->exit_status;
+			group->join_state.release(0);
 			break;
 		}
 		else
@@ -661,11 +662,9 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 			group->waiter = &ppu;
 		}
 
-		const u64 last_stop = group->stop_count - !group->running;
-
 		lv2_obj::sleep(ppu);
 
-		while (group->stop_count == last_stop)
+		while (!group->join_state)
 		{
 			if (ppu.is_stopped())
 			{
@@ -674,6 +673,8 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 
 			group->cond.wait(lock);
 		}
+
+		group->join_state.release(0);
 	}
 	while (0);
 
@@ -682,27 +683,9 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 		return 0;
 	}
 
-	switch (ppu.gpr[4] & (SPU_TGJSF_GROUP_EXIT | SPU_TGJSF_TERMINATED))
+	if (cause)
 	{
-	case 0:
-	{
-		if (cause) *cause = SYS_SPU_THREAD_GROUP_JOIN_ALL_THREADS_EXIT;
-		break;
-	}
-	case SPU_TGJSF_GROUP_EXIT:
-	{
-		if (cause) *cause = SYS_SPU_THREAD_GROUP_JOIN_GROUP_EXIT;
-		break;
-	}
-	case SPU_TGJSF_TERMINATED:
-	{
-		if (cause) *cause = SYS_SPU_THREAD_GROUP_JOIN_TERMINATED;
-		break;
-	}
-	default:
-	{
-		fmt::throw_exception("Unexpected join_state" HERE);
-	}
+		*cause = static_cast<u32>(ppu.gpr[4]);
 	}
 
 	if (status)

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -207,13 +207,6 @@ enum : u32
 	SYS_SPU_IMAGE_DIRECT  = 1,
 };
 
-// SPU Thread Group Join State Flag
-enum : u32
-{
-	SPU_TGJSF_TERMINATED = (1 << 1), // set if SPU Thread Group is terminated by sys_spu_thread_group_terminate
-	SPU_TGJSF_GROUP_EXIT = (1 << 2), // set if SPU Thread Group is terminated by sys_spu_thread_group_exit
-};
-
 struct lv2_spu_group
 {
 	static const u32 id_base = 1; // Wrong?
@@ -232,7 +225,7 @@ struct lv2_spu_group
 	atomic_t<s32> prio; // SPU Thread Group Priority
 	atomic_t<u32> run_state; // SPU Thread Group State
 	atomic_t<s32> exit_status; // SPU Thread Group Exit Status
-	atomic_t<u32> join_state; // flags used to detect exit cause
+	atomic_t<u32> join_state; // flags used to detect exit cause and signal
 	atomic_t<u32> running; // Number of running threads
 	cond_variable cond; // used to signal waiting PPU thread
 	atomic_t<u64> stop_count;


### PR DESCRIPTION
This makes the amount of times sys_spu_thread_group_join returned always be equal to the amount of times sys_spu_thread_group_start was called, and the amount of times a termination signal was signaled.

This also means that when executing a second sys_spu_thread_group_join, it waits until another signal will be received.
In theory, to exit from this situation another thread has to call sys_spu_thread_group_start, and waiting until the SPUs will signal termination again.

Source for this:
https://user-images.githubusercontent.com/18193363/52517440-0bdde300-2c44-11e9-8c52-773a9de5a233.png

Past tests hinted this behavior, although it was unclear if an absolute deadlock will occur on the second sys_spu_thread_group_join execution, or how to exit from this situation.
