### PR TITLE
rsx: Texturing improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -7,7 +7,7 @@
 
 namespace rsx
 {
-	enum texture_upload_context
+	enum texture_upload_context : u32
 	{
 		shader_read = 1,
 		blit_engine_src = 2,
@@ -15,7 +15,7 @@ namespace rsx
 		framebuffer_storage = 8
 	};
 
-	enum texture_colorspace
+	enum texture_colorspace : u32
 	{
 		rgb_linear = 0,
 		srgb_nonlinear = 1

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -3,6 +3,7 @@
 #include "Utilities/GSL.h"
 #include "Emu/Memory/vm.h"
 #include "../GCM.h"
+#include "../rsx_utils.h"
 #include <list>
 
 namespace
@@ -507,7 +508,7 @@ namespace rsx
 //			u32 clip_x = clip_horizontal_reg;
 //			u32 clip_y = clip_vertical_reg;
 
-			cache_tag++;
+			cache_tag = rsx::get_shared_tag();
 			m_memory_tree.clear();
 
 			// Make previous RTTs sampleable
@@ -542,15 +543,11 @@ namespace rsx
 		}
 
 		/**
-		 * Search for given address in stored color surface and returns it if size/format match.
+		 * Search for given address in stored color surface
 		 * Return an empty surface_type otherwise.
 		 */
 		surface_type get_texture_from_render_target_if_applicable(u32 address)
 		{
-			// TODO: Handle texture that overlaps one (or several) surface.
-			// Handle texture conversion
-			// FIXME: Disgaea 3 loading screen seems to use a subset of a surface. It's not properly handled here.
-			// Note: not const because conversions/resolve/... can happen
 			auto It = m_render_targets_storage.find(address);
 			if (It != m_render_targets_storage.end())
 				return Traits::get(It->second);
@@ -558,12 +555,11 @@ namespace rsx
 		}
 
 		/**
-		* Search for given address in stored depth stencil surface and returns it if size/format match.
+		* Search for given address in stored depth stencil surface
 		* Return an empty surface_type otherwise.
 		*/
 		surface_type get_texture_from_depth_stencil_if_applicable(u32 address)
 		{
-			// TODO: Same as above although there wasn't any game using corner case for DS yet.
 			auto It = m_depth_stencil_storage.find(address);
 			if (It != m_depth_stencil_storage.end())
 				return Traits::get(It->second);
@@ -723,7 +719,7 @@ namespace rsx
 						invalidated_resources.push_back(std::move(It->second));
 						m_render_targets_storage.erase(It);
 
-						cache_tag++;
+						cache_tag = rsx::get_shared_tag();
 						return;
 					}
 				}
@@ -741,7 +737,7 @@ namespace rsx
 						invalidated_resources.push_back(std::move(It->second));
 						m_depth_stencil_storage.erase(It);
 
-						cache_tag++;
+						cache_tag = rsx::get_shared_tag();
 						return;
 					}
 				}
@@ -768,7 +764,7 @@ namespace rsx
 					invalidated_resources.push_back(std::move(It->second));
 					m_render_targets_storage.erase(It);
 
-					cache_tag++;
+					cache_tag = rsx::get_shared_tag();
 					return;
 				}
 			}
@@ -781,7 +777,7 @@ namespace rsx
 					invalidated_resources.push_back(std::move(It->second));
 					m_depth_stencil_storage.erase(It);
 
-					cache_tag++;
+					cache_tag = rsx::get_shared_tag();
 					return;
 				}
 			}
@@ -1138,7 +1134,7 @@ namespace rsx
 
 		void notify_memory_structure_changed()
 		{
-			cache_tag++;
+			cache_tag = rsx::get_shared_tag();
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -997,7 +997,7 @@ namespace rsx
 						continue;
 
 					surface = std::get<1>(tex_info).get();
-					if (surface->get_rsx_pitch() != requested_pitch)
+					if (!rsx::pitch_compatible(surface, requested_pitch, requested_height))
 						continue;
 
 					if (requested_width == 0 || requested_height == 0)
@@ -1023,7 +1023,7 @@ namespace rsx
 						continue;
 
 					surface = std::get<1>(tex_info).get();
-					if (surface->get_rsx_pitch() != requested_pitch)
+					if (!rsx::pitch_compatible(surface, requested_pitch, requested_height))
 						continue;
 
 					if (requested_width == 0 || requested_height == 0)
@@ -1059,7 +1059,7 @@ namespace rsx
 
 					auto surface = std::get<1>(tex_info).get();
 					const auto pitch = surface->get_rsx_pitch();
-					if (pitch != required_pitch)
+					if (!rsx::pitch_compatible(surface, required_pitch, required_height))
 						continue;
 
 					const auto texture_size = pitch * surface->get_surface_height();

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1628,8 +1628,8 @@ namespace rsx
 				const auto h = std::min(section_end, slice_end) - section.dst_y;
 				auto src_width = rsx::apply_resolution_scale(section.width, true);
 				auto src_height = rsx::apply_resolution_scale(h, true);
-				auto dst_width = src_width;
-				auto dst_height = src_height;
+				auto dst_width = u16(src_width * scale_x);
+				auto dst_height = u16(src_height * scale_y);
 
 				if (scale_x > 1.f)
 				{
@@ -1639,13 +1639,13 @@ namespace rsx
 
 					if (limit_x > slice_w)
 					{
-						dst_width = (limit_x - dst_x);
+						dst_width = (slice_w - dst_x);
 						src_width = dst_width / scale_x;
 					}
 
 					if (limit_y > slice_h)
 					{
-						dst_height = (limit_y - dst_y);
+						dst_height = (slice_h - dst_y);
 						src_height = dst_height / scale_y;
 					}
 				}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -720,6 +720,8 @@ namespace rsx
 			// Fast code-path for keeping the fault range protection when not flushing anything
 			if (cause.keep_fault_range_protection() && cause.skip_flush() && !trampled_set.sections.empty())
 			{
+				verify(HERE), cause != invalidation_cause::committed_as_fbo;
+
 				// We discard all sections fully inside fault_range
 				for (auto &obj : trampled_set.sections)
 				{
@@ -792,7 +794,8 @@ namespace rsx
 						// Unsynchronized sections (or any flushable when skipping flushes) that do not overlap the fault range directly can also be ignored
 						(invalidation_ignore_unsynchronized && tex.is_flushable() && (cause.skip_flush() || !tex.is_synchronized()) && !overlaps_fault_range) ||
 						// HACK: When being superseded by an fbo, we preserve other overlapped fbos unless the start addresses match
-						(overlaps_fault_range && cause.skip_fbos() && tex.get_context() == texture_upload_context::framebuffer_storage && tex.get_section_base() != fault_range_in.start)
+						// If region is committed as fbo, all non-fbo data is removed but all fbos in the region must be preserved if possible
+						(overlaps_fault_range && tex.get_context() == texture_upload_context::framebuffer_storage && cause.skip_fbos() && (tex.get_section_base() != fault_range_in.start || cause == invalidation_cause::committed_as_fbo))
 					   )
 					{
 						// False positive

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -99,6 +99,17 @@ namespace rsx
 				fmt::throw_exception("Unreachable " HERE);
 		}
 
+		constexpr invalidation_cause defer() const
+		{
+			AUDIT(!deferred_flush());
+			if (cause == read)
+				return deferred_read;
+			else if (cause == write)
+				return deferred_write;
+			else
+				fmt::throw_exception("Unreachable " HERE);
+		}
+
 		constexpr invalidation_cause() : cause(invalid) {}
 		constexpr invalidation_cause(enum_type _cause) : cause(_cause) {}
 		operator enum_type&() { return cause; }

--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.cpp
@@ -1,4 +1,4 @@
-#ifdef _MSC_VER
+﻿#ifdef _MSC_VER
 #include "stdafx.h"
 #include "stdafx_d3d12.h"
 #include "D3D12RenderTargetSets.h"
@@ -177,20 +177,17 @@ void D3D12GSRender::prepare_render_targets(ID3D12GraphicsCommandList *copycmdlis
 		rsx::method_registers.clear_color_a() / 255.f,
 	};
 
-	u32 clip_width = rsx::method_registers.surface_clip_width();
-	u32 clip_height = rsx::method_registers.surface_clip_height();
-
-	if (clip_height == 0 || clip_width == 0)
+	const auto layout = get_framebuffer_layout(rsx::framebuffer_creation_context::context_draw);
+	if (!framebuffer_status_valid)
 		return;
 
 	m_rtts.prepare_render_target(copycmdlist,
-		rsx::method_registers.surface_color(), rsx::method_registers.surface_depth_fmt(),
-		clip_width, clip_height,
-		rsx::method_registers.surface_color_target(),
-		get_color_surface_addresses(), get_zeta_surface_address(),
+		layout.color_format, layout.depth_format,
+		layout.width, layout.height,
+		layout.target, layout.aa_mode,
+		layout.color_addresses, layout.zeta_address,
+		layout.actual_color_pitch, layout.actual_zeta_pitch,
 		m_device.Get(), clear_color, 1.f, 0);
-
-	framebuffer_status_valid = true;
 
 	// write descriptors
 	DXGI_FORMAT dxgi_format = get_color_surface_format(rsx::method_registers.surface_color());

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -216,7 +216,7 @@ void GLGSRender::end()
 	// Handle special memory barrier for ARGB8->D24S8 in an active DSV
 	if (ds && ds->old_contents != nullptr &&
 		ds->old_contents->get_internal_format() == gl::texture::internal_format::rgba8 &&
-		ds->get_rsx_pitch() == static_cast<gl::render_target*>(ds->old_contents)->get_rsx_pitch())
+		rsx::pitch_compatible(ds, static_cast<gl::render_target*>(ds->old_contents)))
 	{
 		gl_state.enable(GL_FALSE, GL_SCISSOR_TEST);
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -458,7 +458,7 @@ void GLGSRender::end()
 			GLfloat colors[] = { 0.f, 0.f, 0.f, 0.f };
 			//It is impossible for the render target to be type A or B here (clear all would have been flagged)
 			for (auto &i : buffers_to_clear)
-				glClearBufferfv(m_draw_fbo->id(), i, colors);
+				glClearBufferfv(GL_COLOR, i, colors);
 		}
 
 		if (clear_depth)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1645,7 +1645,7 @@ void GLGSRender::flip(int buffer)
 			else
 			{
 				gl::command_context cmd = { gl_state };
-				const auto overlap_info = m_rtts.get_merged_texture_memory_region(cmd, absolute_address, buffer_width, buffer_height, buffer_pitch, 4);
+				const auto overlap_info = m_rtts.get_merged_texture_memory_region(cmd, absolute_address, buffer_width, buffer_height, buffer_pitch);
 				verify(HERE), !overlap_info.empty();
 
 				if (overlap_info.back().surface == render_target_texture)

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -603,7 +603,7 @@ void gl::render_target::memory_barrier(gl::command_context& cmd, bool force_init
 	}
 
 	auto src_texture = static_cast<gl::render_target*>(old_contents);
-	if (src_texture->get_rsx_pitch() != get_rsx_pitch())
+	if (!rsx::pitch_compatible(this, src_texture))
 	{
 		LOG_TRACE(RSX, "Pitch mismatch, could not transfer inherited memory");
 		return;

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -215,8 +215,12 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		return;
 	}
 
-	m_rtts.prepare_render_target(nullptr, layout.color_format, layout.depth_format, layout.width, layout.height,
-		layout.target, layout.color_addresses, layout.zeta_address);
+	m_rtts.prepare_render_target(nullptr,
+		layout.color_format, layout.depth_format,
+		layout.width, layout.height,
+		layout.target, layout.aa_mode,
+		layout.color_addresses, layout.zeta_address,
+		layout.actual_color_pitch, layout.actual_zeta_pitch);
 
 	bool old_format_found = false;
 	gl::texture::format old_format;

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -107,6 +107,19 @@ namespace gl
 			return surface_height;
 		}
 
+		bool is_depth_surface() const override
+		{
+			switch (get_internal_format())
+			{
+			case gl::texture::internal_format::depth16:
+			case gl::texture::internal_format::depth24_stencil8:
+			case gl::texture::internal_format::depth32f_stencil8:
+				return true;
+			default:
+				return false;
+			}
+		}
+
 		texture* get_surface() override
 		{
 			return (gl::texture*)this;

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -182,9 +182,9 @@ struct gl_render_target_traits
 		result->set_native_component_layout(native_layout);
 		result->old_contents = old_surface;
 
-		result->queue_tag(address);
 		result->set_cleared(false);
 		result->update_surface();
+		result->queue_tag(address);
 		return result;
 	}
 
@@ -210,9 +210,9 @@ struct gl_render_target_traits
 		result->set_native_component_layout(native_layout);
 		result->old_contents = old_surface;
 
-		result->queue_tag(address);
 		result->set_cleared(false);
 		result->update_surface();
+		result->queue_tag(address);
 		return result;
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -762,6 +762,11 @@ namespace gl
 
 		gl::texture* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const
 		{
+			if (LIKELY(sections_to_transfer.size() == 1))
+			{
+				return sections_to_transfer.front().src;
+			}
+
 			gl::texture* result = nullptr;
 			for (const auto &section : sections_to_transfer)
 			{
@@ -854,7 +859,9 @@ namespace gl
 		gl::texture_view* generate_atlas_from_images(gl::command_context& cmd, u32 gcm_format, u16 width, u16 height, const std::vector<copy_region_descriptor>& sections_to_copy,
 				const texture_channel_remap_t& remap_vector) override
 		{
-			auto result = create_temporary_subresource_impl(nullptr, GL_NONE, GL_TEXTURE_2D, gcm_format, 0, 0, width, height, remap_vector, false);
+			auto _template = get_template_from_collection_impl(sections_to_copy);
+			const GLenum ifmt = _template ? (GLenum)_template->get_internal_format() : GL_NONE;
+			auto result = create_temporary_subresource_impl(_template, ifmt, GL_TEXTURE_2D, gcm_format, 0, 0, width, height, remap_vector, false);
 
 			copy_transfer_regions_impl(cmd, result->image(), sections_to_copy);
 			return result;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2893,8 +2893,9 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	m_rtts.prepare_render_target(&*m_current_command_buffer,
 		layout.color_format, layout.depth_format,
 		layout.width, layout.height,
-		layout.target,
+		layout.target, layout.aa_mode,
 		layout.color_addresses, layout.zeta_address,
+		layout.actual_color_pitch, layout.actual_zeta_pitch,
 		(*m_device), &*m_current_command_buffer);
 
 	// Reset framebuffer information

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1436,7 +1436,7 @@ void VKGSRender::end()
 	auto ds = std::get<1>(m_rtts.m_bound_depth_stencil);
 	if (ds && ds->old_contents &&
 		ds->old_contents->info.format == VK_FORMAT_B8G8R8A8_UNORM &&
-		ds->get_rsx_pitch() == static_cast<vk::render_target*>(ds->old_contents)->get_rsx_pitch())
+		rsx::pitch_compatible(ds, static_cast<vk::render_target*>(ds->old_contents)))
 	{
 		auto rp = vk::get_render_pass_location(VK_FORMAT_UNDEFINED, ds->info.format, 0);
 		auto render_pass = m_render_passes[rp];

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3313,7 +3313,7 @@ void VKGSRender::flip(int buffer)
 			}
 			else
 			{
-				const auto overlap_info = m_rtts.get_merged_texture_memory_region(*m_current_command_buffer, absolute_address, buffer_width, buffer_height, buffer_pitch, 4);
+				const auto overlap_info = m_rtts.get_merged_texture_memory_region(*m_current_command_buffer, absolute_address, buffer_width, buffer_height, buffer_pitch);
 				verify(HERE), !overlap_info.empty();
 
 				if (overlap_info.back().surface == render_target_texture)

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -51,6 +51,11 @@ namespace vk
 			return native_pitch;
 		}
 
+		bool is_depth_surface() const override
+		{
+			return !!(attachment_aspect_flag & VK_IMAGE_ASPECT_DEPTH_BIT);
+		}
+
 		bool matches_dimensions(u16 _width, u16 _height) const
 		{
 			//Use forward scaling to account for rounding and clamping errors

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -100,7 +100,7 @@ namespace vk
 			}
 
 			auto src_texture = static_cast<vk::render_target*>(old_contents);
-			if (src_texture->get_rsx_pitch() != get_rsx_pitch())
+			if (!rsx::pitch_compatible(this, src_texture))
 			{
 				LOG_TRACE(RSX, "Pitch mismatch, could not transfer inherited memory");
 				return;

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -123,7 +123,7 @@ namespace vk
 		if (src->current_layout != preferred_src_format)
 			change_image_layout(cmd, src->value, src_layout, preferred_src_format, vk::get_image_subresource_range(0, 0, 1, 1, src_aspect));
 
-		if (dst->current_layout != preferred_dst_format)
+		if (dst->current_layout != preferred_dst_format && src != dst)
 			change_image_layout(cmd, dst->value, dst_layout, preferred_dst_format, vk::get_image_subresource_range(0, 0, 1, 1, dst_aspect));
 
 		auto scratch_buf = vk::get_scratch_buffer();
@@ -196,7 +196,7 @@ namespace vk
 		if (src_layout != preferred_src_format)
 			change_image_layout(cmd, src->value, preferred_src_format, src_layout, vk::get_image_subresource_range(0, 0, 1, 1, src_aspect));
 
-		if (dst_layout != preferred_dst_format)
+		if (dst_layout != preferred_dst_format && src != dst)
 			change_image_layout(cmd, dst->value, preferred_dst_format, dst_layout, vk::get_image_subresource_range(0, 0, 1, 1, dst_aspect));
 	}
 
@@ -231,7 +231,7 @@ namespace vk
 		if (srcLayout != preferred_src_format)
 			change_image_layout(cmd, src, srcLayout, preferred_src_format, vk::get_image_subresource_range(0, 0, 1, 1, src_aspect));
 
-		if (dstLayout != preferred_dst_format)
+		if (dstLayout != preferred_dst_format && src != dst)
 			change_image_layout(cmd, dst, dstLayout, preferred_dst_format, vk::get_image_subresource_range(0, 0, 1, 1, dst_aspect));
 
 		for (u32 mip_level = 0; mip_level < mipmaps; ++mip_level)
@@ -245,7 +245,7 @@ namespace vk
 		if (srcLayout != preferred_src_format)
 			change_image_layout(cmd, src, preferred_src_format, srcLayout, vk::get_image_subresource_range(0, 0, 1, 1, src_aspect));
 
-		if (dstLayout != preferred_dst_format)
+		if (dstLayout != preferred_dst_format && src != dst)
 			change_image_layout(cmd, dst, preferred_dst_format, dstLayout, vk::get_image_subresource_range(0, 0, 1, 1, dst_aspect));
 	}
 
@@ -272,7 +272,7 @@ namespace vk
 		if (srcLayout != preferred_src_format)
 			change_image_layout(cmd, src, srcLayout, preferred_src_format, vk::get_image_subresource_range(0, 0, 1, 1, aspect));
 
-		if (dstLayout != preferred_dst_format)
+		if (dstLayout != preferred_dst_format && src != dst)
 			change_image_layout(cmd, dst, dstLayout, preferred_dst_format, vk::get_image_subresource_range(0, 0, 1, 1, aspect));
 
 		if (compatible_formats && src_width == dst_width && src_height == dst_height)
@@ -296,7 +296,7 @@ namespace vk
 			}
 			else
 			{
-				auto stretch_image_typeless_unsafe = [&cmd, preferred_src_format, preferred_dst_format](VkImage src, VkImage dst, VkImage typeless,
+				auto stretch_image_typeless_unsafe = [&cmd, preferred_src_format, preferred_dst_format, filter](VkImage src, VkImage dst, VkImage typeless,
 						const areai& src_rect, const areai& dst_rect, VkImageAspectFlags aspect, VkImageAspectFlags transfer_flags = 0xFF)
 				{
 					const u32 src_w = u32(src_rect.x2 - src_rect.x1);
@@ -314,14 +314,14 @@ namespace vk
 
 					//2. Blit typeless surface to self
 					copy_scaled_image(cmd, typeless, typeless, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL,
-						0, 0, src_w, src_h, 0, src_h, dst_w, dst_h, 1, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_ASPECT_COLOR_BIT, VK_FILTER_NEAREST);
+						0, 0, src_w, src_h, 0, src_h, dst_w, dst_h, 1, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_ASPECT_COLOR_BIT, filter);
 
 					//3. Copy back the aspect bits
 					copy_image(cmd, typeless, dst, VK_IMAGE_LAYOUT_GENERAL, preferred_dst_format,
 						{0, (s32)src_h, (s32)dst_w, s32(src_h + dst_h) }, dst_rect, 1, VK_IMAGE_ASPECT_COLOR_BIT, aspect, 0xFF, transfer_flags);
 				};
 
-				auto stretch_image_typeless_safe = [&cmd, preferred_src_format, preferred_dst_format](VkImage src, VkImage dst, VkImage typeless,
+				auto stretch_image_typeless_safe = [&cmd, preferred_src_format, preferred_dst_format, filter](VkImage src, VkImage dst, VkImage typeless,
 					const areai& src_rect, const areai& dst_rect, VkImageAspectFlags aspect, VkImageAspectFlags transfer_flags = 0xFF)
 				{
 					const u32 src_w = u32(src_rect.x2 - src_rect.x1);
@@ -345,7 +345,7 @@ namespace vk
 
 					//2. Blit typeless surface to self
 					copy_scaled_image(cmd, typeless, typeless, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL,
-						0, 0, src_w, src_h, 0, src_h, dst_w, dst_h, 1, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_ASPECT_COLOR_BIT, VK_FILTER_NEAREST);
+						0, 0, src_w, src_h, 0, src_h, dst_w, dst_h, 1, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_ASPECT_COLOR_BIT, filter);
 
 					//3. Copy back the aspect bits
 					info.imageExtent = { dst_w, dst_h, 1 };
@@ -423,7 +423,7 @@ namespace vk
 		if (srcLayout != preferred_src_format)
 			change_image_layout(cmd, src, preferred_src_format, srcLayout, vk::get_image_subresource_range(0, 0, 1, 1, aspect));
 
-		if (dstLayout != preferred_dst_format)
+		if (dstLayout != preferred_dst_format && src != dst)
 			change_image_layout(cmd, dst, preferred_dst_format, dstLayout, vk::get_image_subresource_range(0, 0, 1, 1, aspect));
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -236,7 +236,7 @@ namespace vk
 
 		for (u32 mip_level = 0; mip_level < mipmaps; ++mip_level)
 		{
-			vkCmdCopyImage(cmd, src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &rgn);
+			vkCmdCopyImage(cmd, src, preferred_src_format, dst, preferred_dst_format, 1, &rgn);
 
 			rgn.srcSubresource.mipLevel++;
 			rgn.dstSubresource.mipLevel++;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -590,6 +590,11 @@ namespace vk
 
 		vk::image* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const
 		{
+			if (LIKELY(sections_to_transfer.size() == 1))
+			{
+				return sections_to_transfer.front().src;
+			}
+
 			vk::image* result = nullptr;
 			for (const auto &section : sections_to_transfer)
 			{
@@ -804,7 +809,8 @@ namespace vk
 		vk::image_view* generate_atlas_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
 				const std::vector<copy_region_descriptor>& sections_to_copy, const texture_channel_remap_t& remap_vector) override
 		{
-			auto result = create_temporary_subresource_view_impl(cmd, nullptr, VK_IMAGE_TYPE_2D,
+			auto _template = get_template_from_collection_impl(sections_to_copy);
+			auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
 					VK_IMAGE_VIEW_TYPE_2D, gcm_format, 0, 0, width, height, remap_vector, false);
 
 			const auto image = result->image();

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -61,6 +61,12 @@ namespace rsx
 
 	surface_depth_format to_surface_depth_format(u8 in);
 
+	enum class surface_raster_type : u8
+	{
+		linear = 1,
+		swizzle = 2,
+	};
+
 	enum class surface_antialiasing : u8
 	{
 		center_1_sample,

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3530,6 +3530,7 @@ struct registers_decoder<NV4097_SET_SURFACE_FORMAT>
 			u32 raw_value;
 			bitfield_decoder_t<0, 5> color_fmt;
 			bitfield_decoder_t<5, 3> depth_fmt;
+			bitfield_decoder_t<8, 4> type;
 			bitfield_decoder_t<12, 4> antialias;
 			bitfield_decoder_t<16, 8> log2width;
 			bitfield_decoder_t<24, 8> log2height;
@@ -3545,6 +3546,11 @@ struct registers_decoder<NV4097_SET_SURFACE_FORMAT>
 		surface_depth_format depth_fmt() const
 		{
 			return to_surface_depth_format(m_data.depth_fmt);
+		}
+
+		surface_raster_type type() const
+		{
+			return static_cast<surface_raster_type>(u8(m_data.type));
 		}
 
 		surface_antialiasing antialias() const

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1243,6 +1243,11 @@ namespace rsx
 			return decode<NV4097_SET_SURFACE_FORMAT>().depth_fmt();
 		}
 
+		surface_raster_type surface_type() const
+		{
+			return decode<NV4097_SET_SURFACE_FORMAT>().type();
+		}
+
 		surface_antialiasing surface_antialias() const
 		{
 			return decode<NV4097_SET_SURFACE_FORMAT>().antialias();

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "rsx_utils.h"
 #include "rsx_methods.h"
 #include "RSXThread.h"
@@ -14,6 +14,8 @@ extern "C"
 
 namespace rsx
 {
+	atomic_t<u64> g_rsx_shared_tag{ 0 };
+
 	void convert_scale_image(u8 *dst, AVPixelFormat dst_format, int dst_width, int dst_height, int dst_pitch,
 		const u8 *src, AVPixelFormat src_format, int src_width, int src_height, int src_pitch, int src_slice_h, bool bilinear)
 	{

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -544,6 +544,32 @@ namespace rsx
 		return std::make_tuple(u16(dst_w / scale_x), u16(dst_h / scale_y), dst_w, dst_h);
 	}
 
+	template <typename SurfaceType>
+	inline bool pitch_compatible(SurfaceType* a, SurfaceType* b)
+	{
+		if (a->get_surface_height() == 1 || b->get_surface_height() == 1)
+			return true;
+
+		return (a->get_rsx_pitch() == b->get_rsx_pitch());
+	}
+
+	template <bool __is_surface = true, typename SurfaceType>
+	inline bool pitch_compatible(SurfaceType* surface, u16 pitch_required, u16 height_required)
+	{
+		if constexpr (__is_surface)
+		{
+			if (height_required == 1 || surface->get_surface_height() == 1)
+				return true;
+		}
+		else
+		{
+			if (height_required == 1 || surface->get_height() == 1)
+				return true;
+		}
+
+		return (surface->get_rsx_pitch() == pitch_required);
+	}
+
 	/**
 	 * Remove restart index and emulate using degenerate triangles
 	 * Can be used as a workaround when restart_index doesnt work too well

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -450,7 +450,7 @@ namespace rsx
 		}
 		else
 		{
-			const auto offset = dst_address - src_address;
+			const auto offset = src_address - dst_address;
 			const auto src_x = 0u;
 			const auto src_y = 0u;
 			const auto dst_y = (offset / pitch);


### PR DESCRIPTION
Improves texture search logic by attempting to 'merge' the surface store data and the texture cache data whenever overlaps are encountered. A full data collapse would be infeasible due to performance concerns, but since the two sources are optionally data locked, this should almost always resolve correctly especially when WCB is enabled.

This PR is still very WIP and has been made available for testing. Please look out for significant graphical or performance regressions. Optimizations are still ongoing.

Glitched:
- [x] Motorstorm
- [x] Rio
- [x] Resistance 3 (OGL)
- [x] GOW3 (GPU blit)
- [x] GOW3 (WCB)
- [x] SC4 Bloom