### PR TITLE
Implement _sys_lwmutex_unlock SYS_SYNC_RETRY mode

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
@@ -42,7 +42,7 @@ error_code sys_lwmutex_create(vm::ptr<sys_lwmutex_t> lwmutex, vm::ptr<sys_lwmute
 	attrs->flags     = 0;
 	attrs->name_u64  = attr->name_u64;
 
-	if (error_code res = g_cfg.core.hle_lwmutex ? sys_mutex_create(out_id, attrs) : _sys_lwmutex_create(out_id, protocol, lwmutex, 0x80000001, attr->name_u64, 0))
+	if (error_code res = g_cfg.core.hle_lwmutex ? sys_mutex_create(out_id, attrs) : _sys_lwmutex_create(out_id, protocol, lwmutex, 0x80000001, attr->name_u64))
 	{
 		return res;
 	}

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -176,7 +176,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	BIND_FUNC(sys_semaphore_get_value),                     //114 (0x072)
 	BIND_FUNC(_sys_lwcond_signal),                          //115 (0x073)
 	BIND_FUNC(_sys_lwcond_signal_all),                      //116 (0x074)
-	null_func,//BIND_FUNC(sys_semaphore_...)                //117 (0x075) // internal, used by sys_lwmutex_unlock
+	BIND_FUNC(_sys_lwmutex_unlock2),                        //117 (0x075)
 	BIND_FUNC(sys_event_flag_clear),                        //118 (0x076)
 	null_func,//BIND_FUNC(sys_time_get_rtc)                 //119 (0x077)  ROOT
 	BIND_FUNC(sys_rwlock_create),                           //120 (0x078)

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -73,17 +73,35 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 {
 	sys_lwmutex.trace("_sys_lwmutex_lock(lwmutex_id=0x%x, timeout=0x%llx)", lwmutex_id, timeout);
 
+	ppu.gpr[3] = CELL_OK;
+
 	const auto mutex = idm::get<lv2_obj, lv2_lwmutex>(lwmutex_id, [&](lv2_lwmutex& mutex)
 	{
-		if (mutex.signaled.try_dec())
+		if (mutex.signaled.try_dec(0))
 		{
 			return true;
 		}
 
 		std::lock_guard lock(mutex.mutex);
 
-		if (mutex.signaled.try_dec())
+		auto [old, _] = mutex.signaled.fetch_op([](s32& value)
+		{ 
+			if (value)
+			{
+				value = 0;
+				return true;
+			}
+
+			return false;
+		});
+
+		if (old)
 		{
+			if (old == (1 << 31))
+			{
+				ppu.gpr[3] = CELL_EBUSY;
+			}
+
 			return true;
 		}
 
@@ -99,10 +117,8 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 
 	if (mutex.ret)
 	{
-		return CELL_OK;
+		return not_an_error(ppu.gpr[3]);
 	}
-
-	ppu.gpr[3] = CELL_OK;
 
 	while (!ppu.state.test_and_reset(cpu_flag::signal))
 	{
@@ -146,7 +162,18 @@ error_code _sys_lwmutex_trylock(u32 lwmutex_id)
 
 	const auto mutex = idm::check<lv2_obj, lv2_lwmutex>(lwmutex_id, [&](lv2_lwmutex& mutex)
 	{
-		return mutex.signaled.try_dec();
+		auto [_, ok] = mutex.signaled.fetch_op([](s32& value)
+		{ 
+			if (value & 1)
+			{
+				value = 0;
+				return true;
+			}
+
+			return false;
+		});
+
+		return ok;
 	});
 
 	if (!mutex)
@@ -175,7 +202,38 @@ error_code _sys_lwmutex_unlock(ppu_thread& ppu, u32 lwmutex_id)
 			return cpu;
 		}
 
-		mutex.signaled.release(1);
+		mutex.signaled |= 1;
+		return nullptr;
+	});
+
+	if (!mutex)
+	{
+		return CELL_ESRCH;
+	}
+
+	if (mutex.ret)
+	{
+		mutex->awake(*mutex.ret);
+	}
+
+	return CELL_OK;
+}
+
+error_code _sys_lwmutex_unlock2(u32 lwmutex_id)
+{
+	sys_lwmutex.warning("_sys_lwmutex_unlock2(lwmutex_id=0x%x)", lwmutex_id);
+
+	const auto mutex = idm::check<lv2_obj, lv2_lwmutex>(lwmutex_id, [&](lv2_lwmutex& mutex) -> cpu_thread*
+	{
+		std::lock_guard lock(mutex.mutex);
+
+		if (const auto cpu = mutex.schedule<ppu_thread>(mutex.sq, mutex.protocol))
+		{
+			static_cast<ppu_thread*>(cpu)->gpr[3] = CELL_EBUSY;
+			return cpu;
+		}
+
+		mutex.signaled |= 1 << 31;
 		return nullptr;
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -13,9 +13,9 @@ LOG_CHANNEL(sys_lwmutex);
 
 extern u64 get_system_time();
 
-error_code _sys_lwmutex_create(vm::ptr<u32> lwmutex_id, u32 protocol, vm::ptr<sys_lwmutex_t> control, u32 arg4, u64 name, u32 arg6)
+error_code _sys_lwmutex_create(vm::ptr<u32> lwmutex_id, u32 protocol, vm::ptr<sys_lwmutex_t> control, s32 has_name, u64 name)
 {
-	sys_lwmutex.warning("_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, arg4=0x%x, name=0x%llx, arg6=0x%x)", lwmutex_id, protocol, control, arg4, name, arg6);
+	sys_lwmutex.warning("_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, arg4=0x%x, name=0x%llx, arg6=0x%x)", lwmutex_id, protocol, control, has_name, name);
 
 	if (protocol == SYS_SYNC_RETRY)
 		sys_lwmutex.todo("_sys_lwmutex_create(): SYS_SYNC_RETRY");
@@ -26,9 +26,9 @@ error_code _sys_lwmutex_create(vm::ptr<u32> lwmutex_id, u32 protocol, vm::ptr<sy
 		return CELL_EINVAL;
 	}
 
-	if (arg4 != 0x80000001 || arg6)
+	if (!(has_name < 0))
 	{
-		fmt::throw_exception("Unknown arguments (arg4=0x%x, arg6=0x%x)" HERE, arg4, arg6);
+		name = 0;
 	}
 
 	if (const u32 id = idm::make<lv2_obj, lv2_lwmutex>(protocol, control, name))

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -58,7 +58,7 @@ struct lv2_lwmutex final : lv2_obj
 	const u64 name;
 
 	shared_mutex mutex;
-	atomic_t<u32> signaled{0};
+	atomic_t<s32> signaled{0};
 	std::deque<cpu_thread*> sq;
 
 	lv2_lwmutex(u32 protocol, vm::ptr<sys_lwmutex_t> control, u64 name)
@@ -79,3 +79,4 @@ error_code _sys_lwmutex_destroy(u32 lwmutex_id);
 error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout);
 error_code _sys_lwmutex_trylock(u32 lwmutex_id);
 error_code _sys_lwmutex_unlock(ppu_thread& ppu, u32 lwmutex_id);
+error_code _sys_lwmutex_unlock2(u32 lwmutex_id);

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -74,7 +74,7 @@ class ppu_thread;
 
 // Syscalls
 
-error_code _sys_lwmutex_create(vm::ptr<u32> lwmutex_id, u32 protocol, vm::ptr<sys_lwmutex_t> control, u32 arg4, u64 name, u32 arg6);
+error_code _sys_lwmutex_create(vm::ptr<u32> lwmutex_id, u32 protocol, vm::ptr<sys_lwmutex_t> control, s32 has_name, u64 name);
 error_code _sys_lwmutex_destroy(u32 lwmutex_id);
 error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout);
 error_code _sys_lwmutex_trylock(u32 lwmutex_id);


### PR DESCRIPTION
Implement syscall 117, used by liblv2 lwmutex when using protocol SYS_SYNC_RETRY
~on unlock, this mode unlocks the lwmutex, and awakes a waiter with EBUSY error code.~
~in this case the waiter in liblv2 lwmutex_lock retries to lock and call the syscall again.~
Fixes OG Infinite Battle when using load liblv2 only option, allows it to go ingame.  (ingame in auto lib loading)