### PR TITLE
InstallPup: Fix exception on newline trim

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -565,7 +565,11 @@ void main_window::InstallPup(const QString& dropPath)
 		updatefilenames.end());
 
 	std::string version_string = pup.get_file(0x100).to_string();
-	version_string.erase(version_string.find('\n'));
+	size_t version_pos = version_string.find('\n');
+	if (version_pos != std::string::npos)
+	{
+		version_string.erase(version_pos);
+	}
 
 	const std::string cur_version = "4.84";
 


### PR DESCRIPTION
Avoid throwing fatal error when installing firmware without a \n character on the version string
Fixes #5646