### PR TITLE
cellPad, cellVdec and sys_process fixes

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1280,13 +1280,13 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 
 		if (auto pf_entries = fxm::get<page_fault_notification_entries>())
 		{
-			std::shared_lock lock(pf_entries->mutex);
-
-			for (const auto& entry : pf_entries->entries)
+			if (auto mem = vm::get(vm::any, addr))
 			{
-				if (auto mem = vm::get(vm::any, entry.start_addr))
+				std::shared_lock lock(pf_entries->mutex);
+
+				for (const auto& entry : pf_entries->entries)
 				{
-					if (entry.start_addr <= addr && addr <= addr + mem->size - 1)
+					if (entry.start_addr == mem->addr)
 					{
 						pf_port_id = entry.port_id;
 						break;

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/System.h"
 #include "Emu/Memory/vm.h"
 #include "CPUThread.h"

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -66,7 +66,7 @@ error_code cellPadClearBuf(u32 port_no)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -110,7 +110,7 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -363,7 +363,7 @@ error_code cellPadPeriphGetInfo(vm::ptr<CellPadPeriphInfo> info)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -407,7 +407,7 @@ error_code cellPadPeriphGetData(u32 port_no, vm::ptr<CellPadPeriphData> data)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -441,7 +441,7 @@ error_code cellPadGetRawData(u32 port_no, vm::ptr<CellPadData> data)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -472,7 +472,7 @@ error_code cellPadGetDataExtra(u32 port_no, vm::ptr<u32> device_type, vm::ptr<Ce
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -513,7 +513,7 @@ error_code cellPadSetActDirect(u32 port_no, vm::ptr<CellPadActParam> param)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -553,7 +553,7 @@ error_code cellPadGetInfo(vm::ptr<CellPadInfo> info)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -608,7 +608,7 @@ error_code cellPadGetInfo2(vm::ptr<CellPadInfo2> info)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -648,7 +648,7 @@ error_code cellPadGetCapabilityInfo(u32 port_no, vm::ptr<CellPadCapabilityInfo> 
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -681,7 +681,7 @@ error_code cellPadSetPortSetting(u32 port_no, u32 port_setting)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -708,7 +708,7 @@ s32 cellPadInfoPressMode(u32 port_no)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -737,7 +737,7 @@ s32 cellPadInfoSensorMode(u32 port_no)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -766,7 +766,7 @@ error_code cellPadSetPressMode(u32 port_no, u32 mode)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;
@@ -802,7 +802,7 @@ error_code cellPadSetSensorMode(u32 port_no, u32 mode)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	const auto config = fxm::get<pad_t>();
+	const auto config = fxm::check<pad_t>();
 
 	if (!config)
 		return CELL_PAD_ERROR_UNINITIALIZED;

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -577,8 +577,8 @@ error_code cellPadGetInfo(vm::ptr<CellPadInfo> info)
 		if (i >= config->max_connect)
 			break;
 
+		pads[i]->m_port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES; // TODO: should ASSIGN flags be cleared here?
 		info->status[i] = pads[i]->m_port_status;
-		pads[i]->m_port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES;
 
 		switch (pads[i]->m_class_type)
 		{

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -505,6 +505,7 @@ s32 cellVdecClose(ppu_thread& ppu, u32 handle)
 	}
 
 	ppu_execute<&sys_interrupt_thread_disestablish>(ppu, vdec->ppu_tid);
+	idm::remove<vdec_context>(handle);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -435,6 +435,17 @@ s32 cellVdecQueryAttrEx(vm::cptr<CellVdecTypeEx> type, vm::ptr<CellVdecAttr> att
 template <typename T, typename U>
 static s32 vdecOpen(ppu_thread& ppu, T type, U res, vm::cptr<CellVdecCb> cb, vm::ptr<u32> handle)
 {
+	if (!type || !res || !cb || !handle)
+	{
+		return CELL_VDEC_ERROR_ARG;
+	}
+
+	if (u32(res->ppuThreadPriority) > 3071 || u32(res->spuThreadPriority) > 255 || res->ppuThreadStackSize < 4096
+		|| u32(type->codecType) > 0xd)
+	{
+		return CELL_VDEC_ERROR_ARG;
+	}
+
 	// Create decoder context
 	const u32 vid = idm::make<vdec_context>(type->codecType, type->profileLevel, res->memAddr, res->memSize, cb->cbFunc, cb->cbArg);
 

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -33,17 +33,17 @@ void lv2_timer_context::operator()()
 				if (const auto queue = port.lock())
 				{
 					queue->send(source, data1, data2, next);
-
-					if (period)
-					{
-						// Set next expiration time and check again (HACK)
-						expire += period;
-						continue;
-					}
 				}
 
-				// Stop: oneshot or the event port was disconnected (TODO: is it correct?)
-				state = SYS_TIMER_STATE_STOP;
+				if (period)
+				{
+					// Set next expiration time and check again (HACK)
+					expire += period;
+					continue;
+				}
+
+				// Stop after oneshot
+				state.compare_and_swap_test(SYS_TIMER_STATE_RUN, SYS_TIMER_STATE_STOP);
 				continue;
 			}
 

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -331,7 +331,7 @@ error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 	}
 	else
 	{
-		lv2_obj::yield(ppu);
+		std::this_thread::yield();
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -1,8 +1,27 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "sys_vm.h"
-#include "sys_memory.h"
 
+sys_vm_t::sys_vm_t(const std::shared_ptr<vm::block_t>& area, const std::shared_ptr<lv2_memory_container>& ct, u32 psize)
+	: ct(ct)
+	, psize(psize)
+	, addr(area->addr)
+	, size(area->size)
+{
+	// Write ID
+	g_ids[addr >> 28].release(idm::last_id());
+}
 
+sys_vm_t::~sys_vm_t()
+{
+	// Free ID
+	g_ids[addr >> 28].release(0);
+
+	// Free block
+	verify(HERE), vm::unmap(addr);
+
+	// Return memory
+	ct->used -= psize;
+}
 
 LOG_CHANNEL(sys_vm);
 
@@ -15,9 +34,16 @@ error_code sys_vm_memory_map(u32 vsize, u32 psize, u32 cid, u64 flag, u64 policy
 		return CELL_EINVAL;
 	}
 
-	if (cid != SYS_MEMORY_CONTAINER_ID_INVALID && !idm::check<lv2_memory_container>(cid))
+	auto ct = cid == SYS_MEMORY_CONTAINER_ID_INVALID ? fxm::get<lv2_memory_container>() : idm::get<lv2_memory_container>(cid);
+
+	if (!ct)
 	{
 		return CELL_ESRCH;
+	}
+
+	if (!ct->take(psize))
+	{
+		return CELL_ENOMEM;
 	}
 
 	// Look for unmapped space
@@ -26,11 +52,14 @@ error_code sys_vm_memory_map(u32 vsize, u32 psize, u32 cid, u64 flag, u64 policy
 		// Alloc all memory (shall not fail)
 		verify(HERE), area->alloc(vsize);
 
+		idm::make<sys_vm_t>(area, ct, psize);
+
 		// Write a pointer for the allocated memory
 		*addr = area->addr;
 		return CELL_OK;
 	}
 
+	ct->used -= psize;
 	return CELL_ENOMEM;
 }
 
@@ -46,9 +75,16 @@ error_code sys_vm_unmap(u32 addr)
 {
 	sys_vm.warning("sys_vm_unmap(addr=0x%x)", addr);
 
-	if (!vm::unmap(addr))
+	// Special case, check if its a start address by alignment
+	if (addr % 0x10000000)
 	{
-		return {CELL_EINVAL, addr};
+		return CELL_EINVAL;
+	}
+
+	// Free block and info
+	if (!idm::remove<sys_vm_t>(sys_vm_t::find_id(addr)))
+	{
+		return CELL_EINVAL;
 	}
 
 	return CELL_OK;
@@ -58,6 +94,26 @@ error_code sys_vm_append_memory(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_append_memory(addr=0x%x, size=0x%x)", addr, size);
 
+	if (!size || size % 0x100000)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || block->addr != addr)
+	{
+		return CELL_EINVAL;
+	}
+
+	std::lock_guard lock(block->mutex);
+
+	if (!block->ct->take(size))
+	{
+		return CELL_ENOMEM;
+	}
+
+	block->psize += size;
 	return CELL_OK;
 }
 
@@ -65,12 +121,45 @@ error_code sys_vm_return_memory(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_return_memory(addr=0x%x, size=0x%x)", addr, size);
 
+	if (!size || size % 0x100000)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || block->addr != addr)
+	{
+		return CELL_EINVAL;
+	}
+
+	std::lock_guard lock(block->mutex);
+
+	if (block->psize < 0x100000 + size)
+	{
+		return CELL_EBUSY;
+	}
+
+	block->psize -= size;
+	block->ct->used -= size;
 	return CELL_OK;
 }
 
 error_code sys_vm_lock(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_lock(addr=0x%x, size=0x%x)", addr, size);
+
+	if (!size)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || addr + size > block->addr + block->size)
+	{
+		return CELL_EINVAL;
+	}
 
 	return CELL_OK;
 }
@@ -79,12 +168,36 @@ error_code sys_vm_unlock(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_unlock(addr=0x%x, size=0x%x)", addr, size);
 
+	if (!size)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || addr + size > block->addr + block->size)
+	{
+		return CELL_EINVAL;
+	}
+
 	return CELL_OK;
 }
 
 error_code sys_vm_touch(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_touch(addr=0x%x, size=0x%x)", addr, size);
+
+	if (!size)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || addr + size > block->addr + block->size)
+	{
+		return CELL_EINVAL;
+	}
 
 	return CELL_OK;
 }
@@ -93,12 +206,36 @@ error_code sys_vm_flush(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_flush(addr=0x%x, size=0x%x)", addr, size);
 
+	if (!size)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || addr + size > block->addr + block->size)
+	{
+		return CELL_EINVAL;
+	}
+
 	return CELL_OK;
 }
 
 error_code sys_vm_invalidate(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_invalidate(addr=0x%x, size=0x%x)", addr, size);
+
+	if (!size)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || addr + size > block->addr + block->size)
+	{
+		return CELL_EINVAL;
+	}
 
 	std::memset(vm::base(addr), 0, size);
 	return CELL_OK;
@@ -108,6 +245,18 @@ error_code sys_vm_store(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_store(addr=0x%x, size=0x%x)", addr, size);
 
+	if (!size)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || addr + size > block->addr + block->size)
+	{
+		return CELL_EINVAL;
+	}
+
 	return CELL_OK;
 }
 
@@ -115,12 +264,31 @@ error_code sys_vm_sync(u32 addr, u32 size)
 {
 	sys_vm.warning("sys_vm_sync(addr=0x%x, size=0x%x)", addr, size);
 
+	if (!size)
+	{
+		return CELL_EINVAL;
+	}
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || addr + size > block->addr + block->size)
+	{
+		return CELL_EINVAL;
+	}
+
 	return CELL_OK;
 }
 
 error_code sys_vm_test(u32 addr, u32 size, vm::ptr<u64> result)
 {
 	sys_vm.warning("sys_vm_test(addr=0x%x, size=0x%x, result=*0x%x)", addr, size, result);
+
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || addr + size > block->addr + block->size)
+	{
+		return CELL_EINVAL;
+	}
 
 	*result = SYS_VM_STATE_ON_MEMORY;
 
@@ -131,13 +299,22 @@ error_code sys_vm_get_statistics(u32 addr, vm::ptr<sys_vm_statistics_t> stat)
 {
 	sys_vm.warning("sys_vm_get_statistics(addr=0x%x, stat=*0x%x)", addr, stat);
 
+	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+
+	if (!block || block->addr != addr)
+	{
+		return CELL_EINVAL;
+	}
+
 	stat->page_fault_ppu = 0;
 	stat->page_fault_spu = 0;
 	stat->page_in = 0;
 	stat->page_out = 0;
-	stat->pmem_total = 0;
+	stat->pmem_total = block->psize;
 	stat->pmem_used = 0;
 	stat->timestamp = 0;
 
 	return CELL_OK;
 }
+
+DECLARE(sys_vm_t::g_ids){};

--- a/rpcs3/Emu/Cell/lv2/sys_vm.h
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.h
@@ -1,8 +1,11 @@
-#pragma once
+﻿#pragma once
 
 #include "Emu/Memory/vm.h"
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/IdManager.h"
+#include "sys_memory.h"
+
+#include <array>
 
 enum : u64
 {
@@ -23,6 +26,30 @@ struct sys_vm_statistics_t
 	be_t<u32> pmem_total;     // Total physical memory allocated for the virtual memory area.
 	be_t<u32> pmem_used;      // Physical memory in use by the virtual memory area.
 	be_t<u64> timestamp;
+};
+
+// Block info
+struct sys_vm_t
+{
+	static const u32 id_base = 0x1;
+	static const u32 id_step = 0x1;
+	static const u32 id_count = 16;
+
+	const std::shared_ptr<lv2_memory_container> ct;
+	const u32 addr;
+	const u32 size;
+	u32 psize;
+	shared_mutex mutex;
+
+	sys_vm_t(const std::shared_ptr<vm::block_t>& area, const std::shared_ptr<lv2_memory_container>& ct, u32 psize);
+	~sys_vm_t();
+
+	static std::array<atomic_t<u32>, id_count> g_ids;
+
+	static u32 find_id(u32 addr)
+	{
+		return g_ids[addr >> 28].load();
+	}
 };
 
 // SysCalls

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -638,7 +638,7 @@ namespace vm
 			// Special path for 4k-aligned pages
 			m_common = std::make_shared<utils::shm>(size);
 			verify(HERE), m_common->map_critical(vm::base(addr), utils::protection::no) == vm::base(addr);
-			verify(HERE), m_common->map_critical(vm::get_super_ptr(addr), utils::protection::no) == vm::get_super_ptr(addr);
+			verify(HERE), m_common->map_critical(vm::get_super_ptr(addr), utils::protection::rw) == vm::get_super_ptr(addr);
 		}
 	}
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -903,10 +903,8 @@ namespace vm
 		return nullptr;
 	}
 
-	std::shared_ptr<block_t> map(u32 addr, u32 size, u64 flags)
+	static std::shared_ptr<block_t> _map(u32 addr, u32 size, u64 flags)
 	{
-		vm::writer_lock lock(0);
-
 		if (!size || (size | addr) % 4096)
 		{
 			fmt::throw_exception("Invalid arguments (addr=0x%x, size=0x%x)" HERE, addr, size);
@@ -930,6 +928,13 @@ namespace vm
 		g_locations.emplace_back(block);
 
 		return block;
+	}
+
+	std::shared_ptr<block_t> map(u32 addr, u32 size, u64 flags)
+	{
+		vm::writer_lock lock(0);
+
+		return _map(addr, size, flags);
 	}
 
 	std::shared_ptr<block_t> find_map(u32 orig_size, u32 align, u64 flags)
@@ -1028,6 +1033,12 @@ namespace vm
 			{
 				return block;
 			}
+		}
+
+		if (area_size)
+		{
+			lock.upgrade();
+			return _map(addr, area_size, 0x200);
 		}
 
 		return nullptr;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -958,7 +958,7 @@ namespace vm
 
 		auto block = _find_map(size, align, flags);
 
-		g_locations.emplace_back(block);
+		if (block) g_locations.emplace_back(block);
 
 		return block;
 	}

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -60,8 +60,7 @@ namespace rsx
 			}
 
 			// Update ctrl registers
-			m_ctrl->get = get;
-			m_internal_get = get;
+			m_ctrl->get.release(m_internal_get = get);
 			m_remaining_commands = 0;
 
 			// Clear memwatch spinner
@@ -167,7 +166,7 @@ namespace rsx
 
 			if (!count)
 			{
-				m_ctrl->get.store(m_internal_get + 4);
+				m_ctrl->get.release(m_internal_get + 4);
 				data.reg = FIFO_NOP;
 				return;
 			}

--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -114,7 +114,7 @@ namespace rsx
 			~FIFO_control() {}
 
 			u32 get_pos() { return m_internal_get; }
-			void sync_get() { m_ctrl->get.store(m_internal_get); }
+			void sync_get() { m_ctrl->get.release(m_internal_get); }
 			void inc_get(bool wait);
 			void set_get(u32 get);
 			void set_put(u32 put);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -471,13 +471,14 @@ namespace rsx
 						thread_ctrl::notify(*intr_thread);
 					}
 
+					std::this_thread::sleep_for(16ms);
 					continue;
 				}
 
 				while (Emu.IsPaused() && !m_rsx_thread_exiting)
-					std::this_thread::sleep_for(10ms);
+					std::this_thread::sleep_for(16ms);
 
-				std::this_thread::sleep_for(1ms); // hack
+				thread_ctrl::wait_for(100); // Hack
 			}
 		});
 

--- a/rpcs3/pad_thread.cpp
+++ b/rpcs3/pad_thread.cpp
@@ -48,7 +48,7 @@ void pad_thread::Init()
 	std::vector<pad_setting> pad_settings;
 	for (u32 i = 0; i < CELL_PAD_MAX_PORT_NUM; i++) // max 7 pads
 	{
-		if (i >= m_pads.size())
+		if (!m_pads[i])
 		{
 			pad_settings.push_back({ CELL_PAD_STATUS_DISCONNECTED, CELL_PAD_CAPABILITY_PS3_CONFORMITY | CELL_PAD_CAPABILITY_PRESS_MODE | CELL_PAD_CAPABILITY_ACTUATOR, CELL_PAD_DEV_TYPE_STANDARD });
 		}
@@ -63,7 +63,6 @@ void pad_thread::Init()
 	m_info.now_connect = 0;
 	m_info.system_info |= system_info;
 
-	m_pads.clear();
 	handlers.clear();
 
 	g_cfg_input.load();
@@ -120,13 +119,13 @@ void pad_thread::Init()
 		}
 		cur_pad_handler->Init();
 
-		m_pads.push_back(std::make_shared<Pad>(CELL_PAD_STATUS_DISCONNECTED, pad_settings[i].device_capability, pad_settings[i].device_type));
+		m_pads[i] = std::make_shared<Pad>(CELL_PAD_STATUS_DISCONNECTED, pad_settings[i].device_capability, pad_settings[i].device_type);
 
-		if (cur_pad_handler->bindPadToDevice(m_pads.back(), g_cfg_input.player[i]->device.to_string()) == false)
+		if (cur_pad_handler->bindPadToDevice(m_pads[i], g_cfg_input.player[i]->device.to_string()) == false)
 		{
 			// Failed to bind the device to cur_pad_handler so binds to NullPadHandler
 			LOG_ERROR(GENERAL, "Failed to bind device %s to handler %s", g_cfg_input.player[i]->device.to_string(), handler_type.to_string());
-			nullpad->bindPadToDevice(m_pads.back(), g_cfg_input.player[i]->device.to_string());
+			nullpad->bindPadToDevice(m_pads[i], g_cfg_input.player[i]->device.to_string());
 		}
 	}
 }

--- a/rpcs3/pad_thread.h
+++ b/rpcs3/pad_thread.h
@@ -20,7 +20,7 @@ public:
 	~pad_thread();
 
 	PadInfo& GetInfo() { return m_info; }
-	std::vector<std::shared_ptr<Pad>>& GetPads() { return m_pads; }
+	auto& GetPads() { return m_pads; }
 	void SetRumble(const u32 pad, u8 largeMotor, bool smallMotor);
 	void Init();
 	void Reset();
@@ -38,7 +38,7 @@ protected:
 	void *curwindow;
 
 	PadInfo m_info{ 0, 0 };
-	std::vector<std::shared_ptr<Pad>> m_pads;
+	std::array<std::shared_ptr<Pad>, CELL_PAD_MAX_PORT_NUM> m_pads;
 
 	atomic_t<bool> active{ false };
 	atomic_t<bool> reset{ false };


### PR DESCRIPTION
* Fix passing ASSIGN_CHANGES flag in cellPadGetInfor since its not supported by this function.
* Minor optimizations in pad_thread, use raw ptr when possible and replace std::vector with std::array in m_pads container.
* Fix segfault when reading stack memory in the debugger.
* Remove handle in cellVdecClose.
* Fix page fault range check. (old bug)
* Allow recieving frame information only once in cellVdecGetPicItem, fixes Toy Home. (used to iterate this func infinitely)
* Fix Emulator crash after SPU access violation.
* Fix sys_process_exit2 when waiting for SPUs at av handler to terminate. Fixes #5713 
* Improve vblank timing, fixing potential stutter and micro frame rate spikes.
* Fix timer (sys_timer) state after event queue destruction. [testcase](https://github.com/elad335/myps3tests/tree/master/ppu_tests/timer%20state%20afte%20event%20queue%20destruction)
* Implemented sys_vm_append/return_memory, improved sys_vm error checking.