### PR TITLE
rsx: Texturing improvements followup

### DIFF
--- a/Utilities/geometry.h
+++ b/Utilities/geometry.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cmath>
 
@@ -673,6 +673,16 @@ struct area_base
 		return{ x1, y1, x2 - x1, y2 - y1 };
 	}
 
+	constexpr T width() const
+	{
+		return (x1 < x2) ? (x2 - x1) : (x1 - x2);
+	}
+
+	constexpr T height() const
+	{
+		return (y1 < y2) ? (y2 - y1) : (y1 - y2);
+	}
+
 	void flip_vertical()
 	{
 		T _y = y1; y1 = y2; y2 = _y;
@@ -691,6 +701,11 @@ struct area_base
 	constexpr area_base flipped_horizontal() const
 	{
 		return{ x2, y1, x1, y2 };
+	}
+
+	constexpr bool is_flipped() const
+	{
+		return (x1 > x2 || y1 > y2);
 	}
 
 	constexpr bool operator == (const area_base& rhs) const

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -101,6 +101,11 @@ u8 get_format_block_size_in_texel(int format);
 u8 get_format_block_size_in_bytes(rsx::surface_color_format format);
 
 /**
+ * Returns number of texel rows encoded in one pitch-length line of bytes
+ */
+u8 get_format_texel_rows_per_line(u32 format);
+
+/**
 * Get number of bytes occupied by texture in RSX mem
 */
 size_t get_texture_size(const rsx::fragment_texture &texture);

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -40,6 +40,9 @@ namespace rsx
 		bool dst_is_typeless = false;
 		bool src_is_depth = false;
 		bool dst_is_depth = false;
+		bool flip_vertical = false;
+		bool flip_horizontal = false;
+
 		u32 src_gcm_format = 0;
 		u32 dst_gcm_format = 0;
 		u32 src_native_format_override = 0;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2670,6 +2670,7 @@ namespace rsx
 			else
 			{
 				verify(HERE), dst_is_render_target;
+				dst_subres.surface->on_write();
 			}
 
 			if (rsx::get_resolution_scale_percent() != 100)

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -278,7 +278,7 @@ namespace rsx
 					if (_v > max_y) max_y = _v;
 
 					if (const auto _w = max_x - min_x, _h = max_y - min_y;
-						(_w * _h) >= target_area)
+						u32(_w * _h) >= target_area)
 					{
 						// Target area mostly covered, return success
 						return true;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2630,7 +2630,7 @@ namespace rsx
 					subres.height_in_block = dst_dimensions.height;
 					subres.pitch_in_block = pitch_in_block;
 					subres.depth = 1;
-					subres.data = { (const gsl::byte*)dst.pixels, dst.pitch * dst_dimensions.height };
+					subres.data = { reinterpret_cast<const gsl::byte*>(vm::base(dst.rsx_address)), dst.pitch * dst_dimensions.height };
 					subresource_layout.push_back(subres);
 
 					cached_dest = upload_image_from_cpu(cmd, rsx_range, dst_dimensions.width, dst_dimensions.height, 1, 1, dst.pitch,

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2098,7 +2098,6 @@ namespace rsx
 
 							if (last.width >= internal_width && last.height >= internal_height)
 							{
-								verify(HERE), last.surface->test();
 								return process_framebuffer_resource_fast(cmd, last.surface, texaddr, tex.format(), tex_width, tex_height, depth,
 									extended_dimension, tex.remap(), tex.decoded_remap(), false);
 							}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1100,12 +1100,19 @@ namespace rsx
 			return results;
 		}
 
+		template <bool check_unlocked = false>
 		section_storage_type *find_texture_from_dimensions(u32 rsx_address, u16 width = 0, u16 height = 0, u16 depth = 0, u16 mipmaps = 0)
 		{
 			auto &block = m_storage.block_for(rsx_address);
 			for (auto &tex : block)
 			{
-				if (tex.matches(rsx_address, width, height, depth, mipmaps) && !tex.is_dirty())
+				if constexpr (check_unlocked)
+				{
+					if (!tex.is_locked())
+						continue;
+				}
+
+				if (!tex.is_dirty() && tex.matches(rsx_address, width, height, depth, mipmaps))
 				{
 					return &tex;
 				}

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1303,14 +1303,10 @@ namespace rsx
 			return get_context() != texture_upload_context::shader_read && get_memory_read_flags() != memory_read_flags::flush_always;
 		}
 
-		void on_flush(bool miss)
+		void on_flush()
 		{
 			speculatively_flushed = false;
 
-			if (miss)
-			{
-				m_tex_cache->on_miss(*derived());
-			}
 			m_tex_cache->on_flush();
 
 			if (tracked_by_predictor())
@@ -1326,6 +1322,12 @@ namespace rsx
 			speculatively_flushed = true;
 
 			m_tex_cache->on_speculative_flush();
+		}
+
+		void on_miss()
+		{
+			LOG_WARNING(RSX, "Cache miss at address 0x%X. This is gonna hurt...", get_section_base());
+			m_tex_cache->on_miss(*derived());
 		}
 
 		void touch(u64 tag)
@@ -1454,11 +1456,9 @@ namespace rsx
 
 	public:
 		// Returns false if there was a cache miss
-		template <typename ...Args>
-		bool flush(Args&&... extras)
+		void flush()
 		{
-			if (flushed) return true;
-			bool miss = false;
+			if (flushed) return;
 
 			// Sanity checks
 			ASSERT(exists());
@@ -1469,19 +1469,12 @@ namespace rsx
 			{
 				flushed = true;
 				flush_exclusions.clear();
-				on_flush(miss);
-				return !miss;
+				on_flush();
+				return;
 			}
 
-			// If we are not synchronized, we must synchronize before proceeding (hard fault)
-			if (!synchronized)
-			{
-				LOG_WARNING(RSX, "Cache miss at address 0x%X. This is gonna hurt...", get_section_base());
-				derived()->synchronize(true, std::forward<Args>(extras)...);
-				miss = true;
-
-				ASSERT(synchronized); // TODO ruipin: This might be possible in OGL. Revisit
-			}
+			// NOTE: Hard faults should have been pre-processed beforehand
+			ASSERT(synchronized);
 
 			// Copy flush result to guest memory
 			imp_flush();
@@ -1491,9 +1484,7 @@ namespace rsx
 			flushed = true;
 			derived()->finish_flush();
 			flush_exclusions.clear();
-			on_flush(miss);
-
-			return !miss;
+			on_flush();
 		}
 
 		void add_flush_exclusion(const address_range& rng)

--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.h
@@ -24,7 +24,7 @@ struct render_target_traits
 	static
 	ComPtr<ID3D12Resource> create_new_surface(
 		u32 address,
-		surface_color_format color_format, size_t width, size_t height,
+		surface_color_format color_format, size_t width, size_t height, size_t /*pitch*/,
 		ID3D12Resource* /*old*/,
 		ID3D12Device* device, const std::array<float, 4> &clear_color, float, u8)
 	{
@@ -85,7 +85,7 @@ struct render_target_traits
 	static
 	ComPtr<ID3D12Resource> create_new_surface(
 		u32 address,
-		surface_depth_format surfaceDepthFormat, size_t width, size_t height,
+		surface_depth_format surfaceDepthFormat, size_t width, size_t height, size_t /*pitch*/,
 		ID3D12Resource* /*old*/,
 		ID3D12Device* device, const std::array<float, 4>& , float clear_depth, u8 clear_stencil)
 	{
@@ -130,9 +130,9 @@ struct render_target_traits
 
 	static
 	void invalidate_surface_contents(
-		u32,
 		ID3D12GraphicsCommandList*,
-		ID3D12Resource*, ID3D12Resource*)
+		ID3D12Resource*, ID3D12Resource*,
+		u32, size_t)
 	{}
 
 	static
@@ -142,6 +142,12 @@ struct render_target_traits
 	static
 	void notify_surface_persist(const ComPtr<ID3D12Resource>&)
 	{}
+
+	static
+	bool surface_is_pitch_compatible(const ComPtr<ID3D12Resource>&, size_t)
+	{
+		return true;
+	}
 
 	static
 	bool rtt_has_format_width_height(const ComPtr<ID3D12Resource> &rtt, surface_color_format surface_color_format, size_t width, size_t height, bool=false)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1673,11 +1673,11 @@ void GLGSRender::flip(int buffer)
 				}
 			}
 		}
-		else if (auto surface = m_gl_texture_cache.find_texture_from_dimensions(absolute_address, buffer_width, buffer_height))
+		else if (auto surface = m_gl_texture_cache.find_texture_from_dimensions<true>(absolute_address, buffer_width, buffer_height))
 		{
 			//Hack - this should be the first location to check for output
 			//The render might have been done offscreen or in software and a blit used to display
-			image = surface->get_raw_texture()->id();
+			if (const auto tex = surface->get_raw_texture(); tex) image = tex->id();
 		}
 
 		if (!image)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1646,9 +1646,8 @@ void GLGSRender::flip(int buffer)
 			{
 				gl::command_context cmd = { gl_state };
 				const auto overlap_info = m_rtts.get_merged_texture_memory_region(cmd, absolute_address, buffer_width, buffer_height, buffer_pitch);
-				verify(HERE), !overlap_info.empty();
 
-				if (overlap_info.back().surface == render_target_texture)
+				if (!overlap_info.empty() && overlap_info.back().surface == render_target_texture)
 				{
 					// Confirmed to be the newest data source in that range
 					image = render_target_texture->raw_handle();

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -434,6 +434,16 @@ namespace gl
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, blit_dst.id());
 		glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, attachment, GL_TEXTURE_2D, dst_id, 0);
 
+		if (xfer_info.flip_horizontal)
+		{
+			src_rect.flip_horizontal();
+		}
+
+		if (xfer_info.flip_vertical)
+		{
+			src_rect.flip_vertical();
+		}
+
 		glBlitFramebuffer(src_rect.x1, src_rect.y1, src_rect.x2, src_rect.y2,
 			dst_rect.x1, dst_rect.y1, dst_rect.x2, dst_rect.y2,
 			(GLbitfield)target, (GLenum)interp);

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -256,7 +256,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 			auto rtt = std::get<1>(m_rtts.m_bound_render_targets[i]);
 			color_targets[i] = rtt->id();
 
-			rtt->set_rsx_pitch(layout.actual_color_pitch[i]);
+			verify("Pitch mismatch!" HERE), rtt->get_rsx_pitch() == layout.actual_color_pitch[i];
 			m_surface_info[i] = { layout.color_addresses[i], layout.actual_color_pitch[i], false, layout.color_format, layout.depth_format, layout.width, layout.height, color_bpp };
 
 			rtt->tile = find_tile(color_offsets[i], color_locations[i]);
@@ -285,7 +285,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		auto ds = std::get<1>(m_rtts.m_bound_depth_stencil);
 		depth_stencil_target = ds->id();
 
-		std::get<1>(m_rtts.m_bound_depth_stencil)->set_rsx_pitch(layout.actual_zeta_pitch);
+		verify("Pitch mismatch!" HERE), std::get<1>(m_rtts.m_bound_depth_stencil)->get_rsx_pitch() == layout.actual_zeta_pitch;
 		m_depth_surface_info = { layout.zeta_address, layout.actual_zeta_pitch, true, layout.color_format, layout.depth_format, layout.width, layout.height, depth_bpp };
 
 		ds->write_aa_mode = layout.aa_mode;

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -392,7 +392,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		{
 			// Mark buffer regions as NO_ACCESS on Cell-visible side
 			m_gl_texture_cache.lock_memory_region(cmd, std::get<1>(m_rtts.m_bound_render_targets[i]), surface_range, m_surface_info[i].width, m_surface_info[i].height, m_surface_info[i].pitch,
-				std::tuple<>{}, color_format.format, color_format.type, color_format.swap_bytes);
+				color_format.format, color_format.type, color_format.swap_bytes);
 		}
 		else
 		{
@@ -407,7 +407,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		{
 			const auto depth_format_gl = rsx::internals::surface_depth_format_to_gl(layout.depth_format);
 			m_gl_texture_cache.lock_memory_region(cmd, std::get<1>(m_rtts.m_bound_depth_stencil), surface_range, m_depth_surface_info.width, m_depth_surface_info.height, m_depth_surface_info.pitch,
-				std::tuple<>{}, depth_format_gl.format, depth_format_gl.type, true);
+				depth_format_gl.format, depth_format_gl.type, true);
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -387,6 +387,7 @@ namespace gl
 		{
 			AUDIT(synchronized);
 
+			verify(HERE), (offset + size) <= pbo_size;
 			glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo_id);
 			return glMapBufferRange(GL_PIXEL_PACK_BUFFER, offset, size, GL_MAP_READ_BIT);
 		}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3366,7 +3366,7 @@ void VKGSRender::flip(int buffer)
 		}
 
 		vk::copy_scaled_image(*m_current_command_buffer, image_to_flip->value, target_image, image_to_flip->current_layout, target_layout,
-			0, 0, buffer_width, buffer_height, aspect_ratio.x, aspect_ratio.y, aspect_ratio.width, aspect_ratio.height, 1, VK_IMAGE_ASPECT_COLOR_BIT, false);
+			{ 0, 0, (s32)buffer_width, (s32)buffer_height }, aspect_ratio, 1, VK_IMAGE_ASPECT_COLOR_BIT, false);
 
 		if (target_layout != present_layout)
 		{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -855,7 +855,7 @@ bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 		std::lock_guard lock(m_secondary_cb_guard);
 
 		const rsx::invalidation_cause cause = is_writing ? rsx::invalidation_cause::deferred_write : rsx::invalidation_cause::deferred_read;
-		result = std::move(m_texture_cache.invalidate_address(m_secondary_command_buffer, address, cause, m_swapchain->get_graphics_queue()));
+		result = std::move(m_texture_cache.invalidate_address(m_secondary_command_buffer, address, cause));
 	}
 
 	if (!result.violation_handled)
@@ -897,7 +897,7 @@ bool VKGSRender::on_access_violation(u32 address, bool is_writing)
 			m_flush_requests.producer_wait();
 		}
 
-		m_texture_cache.flush_all(m_secondary_command_buffer, result, m_swapchain->get_graphics_queue());
+		m_texture_cache.flush_all(m_secondary_command_buffer, result);
 
 		if (has_queue_ref)
 		{
@@ -913,7 +913,7 @@ void VKGSRender::on_invalidate_memory_range(const utils::address_range &range)
 {
 	std::lock_guard lock(m_secondary_cb_guard);
 
-	auto data = std::move(m_texture_cache.invalidate_range(m_secondary_command_buffer, range, rsx::invalidation_cause::unmap, m_swapchain->get_graphics_queue()));
+	auto data = std::move(m_texture_cache.invalidate_range(m_secondary_command_buffer, range, rsx::invalidation_cause::unmap));
 	AUDIT(data.empty());
 
 	if (data.violation_handled)
@@ -1454,7 +1454,7 @@ void VKGSRender::end()
 
 				if (rsx::method_registers.fragment_textures[i].enabled())
 				{
-					*sampler_state = m_texture_cache._upload_texture(*m_current_command_buffer, rsx::method_registers.fragment_textures[i], m_rtts);
+					*sampler_state = m_texture_cache.upload_texture(*m_current_command_buffer, rsx::method_registers.fragment_textures[i], m_rtts);
 
 					const u32 texture_format = rsx::method_registers.fragment_textures[i].format() & ~(CELL_GCM_TEXTURE_UN | CELL_GCM_TEXTURE_LN);
 					const VkBool32 compare_enabled = (texture_format == CELL_GCM_TEXTURE_DEPTH16 || texture_format == CELL_GCM_TEXTURE_DEPTH24_D8 ||
@@ -1526,7 +1526,7 @@ void VKGSRender::end()
 
 				if (rsx::method_registers.vertex_textures[i].enabled())
 				{
-					*sampler_state = m_texture_cache._upload_texture(*m_current_command_buffer, rsx::method_registers.vertex_textures[i], m_rtts);
+					*sampler_state = m_texture_cache.upload_texture(*m_current_command_buffer, rsx::method_registers.vertex_textures[i], m_rtts);
 
 					bool replace = !vs_sampler_handles[i];
 					const VkBool32 unnormalized_coords = !!(rsx::method_registers.vertex_textures[i].format() & CELL_GCM_TEXTURE_UN);
@@ -1725,7 +1725,7 @@ void VKGSRender::end()
 		m_occlusion_map[m_active_query_info->driver_handle].indices.push_back(occlusion_id);
 		m_occlusion_map[m_active_query_info->driver_handle].command_buffer_to_wait = m_current_command_buffer;
 
-		m_current_command_buffer->flags |= cb_has_occlusion_task;
+		m_current_command_buffer->flags |= vk::command_buffer::cb_has_occlusion_task;
 	}
 
 	// Apply write memory barriers
@@ -1796,7 +1796,6 @@ void VKGSRender::end()
 		m_occlusion_query_pool.end_query(*m_current_command_buffer, occlusion_id);
 	}
 
-	m_current_command_buffer->num_draws++;
 	m_rtts.on_write();
 
 	rsx::thread::end();
@@ -2187,7 +2186,7 @@ void VKGSRender::sync_hint(rsx::FIFO_hint hint)
 {
 	if (hint == rsx::FIFO_hint::hint_conditional_render_eval)
 	{
-		if (m_current_command_buffer->flags & cb_has_occlusion_task)
+		if (m_current_command_buffer->flags & vk::command_buffer::cb_has_occlusion_task)
 		{
 			// Occlusion test result evaluation is coming up, avoid a hard sync
 			if (!m_flush_requests.pending())
@@ -2881,7 +2880,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 
 			const utils::address_range rsx_range = m_surface_info[i].get_memory_range();
 			m_texture_cache.set_memory_read_flags(rsx_range, rsx::memory_read_flags::flush_once);
-			m_texture_cache.flush_if_cache_miss_likely(*m_current_command_buffer, rsx_range, m_swapchain->get_graphics_queue());
+			m_texture_cache.flush_if_cache_miss_likely(*m_current_command_buffer, rsx_range);
 		}
 
 		m_surface_info[i].address = m_surface_info[i].pitch = 0;
@@ -2898,7 +2897,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 			auto old_format = vk::get_compatible_depth_surface_format(m_device->get_formats_support(), m_depth_surface_info.depth_format);
 			const utils::address_range surface_range = m_depth_surface_info.get_memory_range();
 			m_texture_cache.set_memory_read_flags(surface_range, rsx::memory_read_flags::flush_once);
-			m_texture_cache.flush_if_cache_miss_likely(*m_current_command_buffer, surface_range, m_swapchain->get_graphics_queue());
+			m_texture_cache.flush_if_cache_miss_likely(*m_current_command_buffer, surface_range);
 		}
 
 		m_depth_surface_info.address = m_depth_surface_info.pitch = 0;
@@ -2944,6 +2943,12 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		m_texture_cache.notify_surface_changed(layout.zeta_address);
 	}
 
+	// Before messing with memory properties, flush command queue if there are dma transfers queued up
+	if (m_current_command_buffer->flags & vk::command_buffer::cb_has_dma_transfer)
+	{
+		flush_command_queue();
+	}
+
 	const auto color_fmt_info = vk::get_compatible_gcm_format(layout.color_format);
 	for (u8 index : m_draw_buffers)
 	{
@@ -2953,11 +2958,11 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		if (g_cfg.video.write_color_buffers)
 		{
 			m_texture_cache.lock_memory_region(*m_current_command_buffer, std::get<1>(m_rtts.m_bound_render_targets[index]), surface_range,
-				m_surface_info[index].width, m_surface_info[index].height, layout.actual_color_pitch[index], std::tuple<VkQueue>{ m_swapchain->get_graphics_queue() }, color_fmt_info.first, color_fmt_info.second);
+				m_surface_info[index].width, m_surface_info[index].height, layout.actual_color_pitch[index], color_fmt_info.first, color_fmt_info.second);
 		}
 		else
 		{
-			m_texture_cache.commit_framebuffer_memory_region(*m_current_command_buffer, surface_range, m_swapchain->get_graphics_queue());
+			m_texture_cache.commit_framebuffer_memory_region(*m_current_command_buffer, surface_range);
 		}
 	}
 
@@ -2968,11 +2973,11 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		{
 			const u32 gcm_format = (m_depth_surface_info.depth_format != rsx::surface_depth_format::z16) ? CELL_GCM_TEXTURE_DEPTH16 : CELL_GCM_TEXTURE_DEPTH24_D8;
 			m_texture_cache.lock_memory_region(*m_current_command_buffer, std::get<1>(m_rtts.m_bound_depth_stencil), surface_range,
-				m_depth_surface_info.width, m_depth_surface_info.height, layout.actual_zeta_pitch, std::tuple<VkQueue>{ m_swapchain->get_graphics_queue() }, gcm_format, false);
+				m_depth_surface_info.width, m_depth_surface_info.height, layout.actual_zeta_pitch, gcm_format, false);
 		}
 		else
 		{
-			m_texture_cache.commit_framebuffer_memory_region(*m_current_command_buffer, surface_range, m_swapchain->get_graphics_queue());
+			m_texture_cache.commit_framebuffer_memory_region(*m_current_command_buffer, surface_range);
 		}
 	}
 
@@ -3323,21 +3328,22 @@ void VKGSRender::flip(int buffer)
 			const auto range = utils::address_range::start_length(absolute_address, buffer_pitch * buffer_height);
 			const u32  lookup_mask = rsx::texture_upload_context::blit_engine_dst | rsx::texture_upload_context::framebuffer_storage;
 			const auto overlap = m_texture_cache.find_texture_from_range<true>(range, 0, lookup_mask);
-			bool flush_queue = false;
 
 			for (const auto & section : overlap)
 			{
-				section->copy_texture(*m_current_command_buffer, false, m_swapchain->get_graphics_queue());
-				flush_queue = true;
+				if (!section->is_synchronized())
+				{
+					section->copy_texture(*m_current_command_buffer, true);
+				}
 			}
 
-			if (flush_queue)
+			if (m_current_command_buffer->flags & vk::command_buffer::cb_has_dma_transfer)
 			{
 				// Submit for processing to lower hard fault penalty
 				flush_command_queue();
 			}
 
-			m_texture_cache.invalidate_range(*m_current_command_buffer, range, rsx::invalidation_cause::read, m_swapchain->get_graphics_queue());
+			m_texture_cache.invalidate_range(*m_current_command_buffer, range, rsx::invalidation_cause::read);
 			image_to_flip = m_texture_cache.upload_image_simple(*m_current_command_buffer, absolute_address, buffer_width, buffer_height);
 		}
 	}
@@ -3487,16 +3493,15 @@ bool VKGSRender::scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst
 	//Verify enough memory exists before attempting to handle data transfer
 	check_heap_status();
 
-	const auto old_speculations_count = m_texture_cache.get_num_cache_speculative_writes();
 	if (m_texture_cache.blit(src, dst, interpolate, m_rtts, *m_current_command_buffer))
 	{
 		m_samplers_dirty.store(true);
-		m_current_command_buffer->flags |= cb_has_blit_transfer;
+		m_current_command_buffer->set_flag(vk::command_buffer::cb_has_blit_transfer);
 
-		if (m_texture_cache.get_num_cache_speculative_writes() > old_speculations_count)
+		if (m_current_command_buffer->flags & vk::command_buffer::cb_has_dma_transfer)
 		{
-			// A speculative write happened, flush while the dma resource is valid
-			// TODO: Deeper investigation as to why this can trigger problems
+			// A dma transfer has been queued onto this cb
+			// This likely means that we're done with the tranfers to the target (writes_likely_completed=1)
 			flush_command_queue();
 		}
 		return true;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3310,7 +3310,7 @@ void VKGSRender::flip(int buffer)
 				}
 			}
 		}
-		else if (auto surface = m_texture_cache.find_texture_from_dimensions(absolute_address, buffer_width, buffer_height))
+		else if (auto surface = m_texture_cache.find_texture_from_dimensions<true>(absolute_address, buffer_width, buffer_height))
 		{
 			//Hack - this should be the first location to check for output
 			//The render might have been done offscreen or in software and a blit used to display

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -48,19 +48,10 @@ namespace vk
 
 extern u64 get_system_time();
 
-enum command_buffer_data_flag
-{
-	cb_has_occlusion_task = 1,
-	cb_has_blit_transfer = 2
-};
-
 struct command_buffer_chunk: public vk::command_buffer
 {
 	VkFence submit_fence = VK_NULL_HANDLE;
 	VkDevice m_device = VK_NULL_HANDLE;
-
-	u32 num_draws = 0;
-	u32 flags = 0;
 
 	std::atomic_bool pending = { false };
 	std::atomic<u64> last_sync = { 0 };
@@ -100,8 +91,6 @@ struct command_buffer_chunk: public vk::command_buffer
 			wait(FRAME_PRESENT_TIMEOUT);
 
 		CHECK_RESULT(vkResetCommandBuffer(commands, 0));
-		num_draws = 0;
-		flags = 0;
 	}
 
 	bool poke()

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -50,7 +50,8 @@ extern u64 get_system_time();
 
 enum command_buffer_data_flag
 {
-	cb_has_occlusion_task = 1
+	cb_has_occlusion_task = 1,
+	cb_has_blit_transfer = 2
 };
 
 struct command_buffer_chunk: public vk::command_buffer

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -654,6 +654,42 @@ namespace vk
 		}
 	}
 
+	VkResult wait_for_event(VkEvent event, u64 timeout)
+	{
+		u64 t = 0;
+		while (true)
+		{
+			switch (const auto status = vkGetEventStatus(*g_current_renderer, event))
+			{
+			case VK_EVENT_SET:
+				return VK_SUCCESS;
+			case VK_EVENT_RESET:
+				break;
+			default:
+				die_with_error(HERE, status);
+				return status;
+			}
+
+			if (timeout)
+			{
+				if (!t)
+				{
+					t = get_system_time();
+					continue;
+				}
+
+				if ((get_system_time() - t) > timeout)
+				{
+					LOG_ERROR(RSX, "[vulkan] vk::wait_for_event has timed out!");
+					return VK_TIMEOUT;
+				}
+			}
+
+			//std::this_thread::yield();
+			_mm_pause();
+		}
+	}
+
 	void die_with_error(const char* faulting_addr, VkResult error_code)
 	{
 		std::string error_message;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1168,6 +1168,14 @@ namespace vk
 		}
 		access_hint = flush_only;
 
+		enum command_buffer_data_flag : u32
+		{
+			cb_has_occlusion_task = 1,
+			cb_has_blit_transfer = 2,
+			cb_has_dma_transfer = 4
+		};
+		u32 flags = 0;
+
 	public:
 		command_buffer() {}
 		~command_buffer() {}
@@ -1204,6 +1212,16 @@ namespace vk
 		vk::command_pool& get_command_pool() const
 		{
 			return *pool;
+		}
+
+		void clear_flags()
+		{
+			flags = 0;
+		}
+
+		void set_flag(command_buffer_data_flag flag)
+		{
+			flags |= flag;
 		}
 
 		operator VkCommandBuffer() const
@@ -1278,6 +1296,8 @@ namespace vk
 			acquire_global_submit_lock();
 			CHECK_RESULT(vkQueueSubmit(queue, 1, &infos, fence));
 			release_global_submit_lock();
+
+			clear_flags();
 		}
 	};
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -155,8 +155,8 @@ namespace vk
 			VkImageAspectFlags src_transfer_mask = 0xFF, VkImageAspectFlags dst_transfer_mask = 0xFF);
 
 	void copy_scaled_image(VkCommandBuffer cmd, VkImage src, VkImage dst, VkImageLayout srcLayout, VkImageLayout dstLayout,
-			u32 src_x_offset, u32 src_y_offset, u32 src_width, u32 src_height, u32 dst_x_offset, u32 dst_y_offset, u32 dst_width, u32 dst_height, u32 mipmaps,
-			VkImageAspectFlags aspect, bool compatible_formats, VkFilter filter = VK_FILTER_LINEAR, VkFormat src_format = VK_FORMAT_UNDEFINED, VkFormat dst_format = VK_FORMAT_UNDEFINED);
+			const areai& src_rect, const areai& dst_rect, u32 mipmaps, VkImageAspectFlags aspect, bool compatible_formats,
+			VkFilter filter = VK_FILTER_LINEAR, VkFormat src_format = VK_FORMAT_UNDEFINED, VkFormat dst_format = VK_FORMAT_UNDEFINED);
 
 	std::pair<VkFormat, VkComponentMapping> get_compatible_surface_format(rsx::surface_color_format color_format);
 	size_t get_render_pass_location(VkFormat color_surface_format, VkFormat depth_stencil_format, u8 color_surface_count);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -181,6 +181,7 @@ namespace vk
 	// Fence reset with driver workarounds in place
 	void reset_fence(VkFence *pFence);
 	VkResult wait_for_fence(VkFence pFence, u64 timeout = 0ull);
+	VkResult wait_for_event(VkEvent pEvent, u64 timeout = 0ull);
 
 	void die_with_error(const char* faulting_addr, VkResult error_code);
 

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -252,8 +252,7 @@ namespace vk
 	void copy_scaled_image(VkCommandBuffer cmd,
 			VkImage src, VkImage dst,
 			VkImageLayout srcLayout, VkImageLayout dstLayout,
-			u32 src_x_offset, u32 src_y_offset, u32 src_width, u32 src_height,
-			u32 dst_x_offset, u32 dst_y_offset, u32 dst_width, u32 dst_height,
+			const areai& src_rect, const areai& dst_rect,
 			u32 mipmaps, VkImageAspectFlags aspect, bool compatible_formats,
 			VkFilter filter, VkFormat src_format, VkFormat dst_format)
 	{
@@ -275,14 +274,15 @@ namespace vk
 		if (dstLayout != preferred_dst_format && src != dst)
 			change_image_layout(cmd, dst, dstLayout, preferred_dst_format, vk::get_image_subresource_range(0, 0, 1, 1, aspect));
 
-		if (compatible_formats && src_width == dst_width && src_height == dst_height)
+		if (compatible_formats && !src_rect.is_flipped() && !dst_rect.is_flipped() &&
+			src_rect.width() == dst_rect.width() && src_rect.height() == dst_rect.height())
 		{
 			VkImageCopy copy_rgn;
-			copy_rgn.srcOffset = { (int32_t)src_x_offset, (int32_t)src_y_offset, 0 };
-			copy_rgn.dstOffset = { (int32_t)dst_x_offset, (int32_t)dst_y_offset, 0 };
+			copy_rgn.srcOffset = { src_rect.x1, src_rect.y1, 0 };
+			copy_rgn.dstOffset = { dst_rect.x1, dst_rect.y1, 0 };
 			copy_rgn.dstSubresource = { (VkImageAspectFlags)aspect, 0, 0, 1 };
 			copy_rgn.srcSubresource = { (VkImageAspectFlags)aspect, 0, 0, 1 };
-			copy_rgn.extent = { src_width, src_height, 1 };
+			copy_rgn.extent = { (u32)src_rect.width(), (u32)src_rect.height(), 1 };
 
 			vkCmdCopyImage(cmd, src, preferred_src_format, dst, preferred_dst_format, 1, &copy_rgn);
 		}
@@ -291,18 +291,19 @@ namespace vk
 			//Most depth/stencil formats cannot be scaled using hw blit
 			if (src_format == VK_FORMAT_UNDEFINED)
 			{
-				LOG_ERROR(RSX, "Could not blit depth/stencil image. src_fmt=0x%x, src=%dx%d, dst=%dx%d",
-					(u32)src_format, src_width, src_height, dst_width, dst_height);
+				LOG_ERROR(RSX, "Could not blit depth/stencil image. src_fmt=0x%x", (u32)src_format);
 			}
 			else
 			{
+				verify(HERE), !dst_rect.is_flipped();
+
 				auto stretch_image_typeless_unsafe = [&cmd, preferred_src_format, preferred_dst_format, filter](VkImage src, VkImage dst, VkImage typeless,
 						const areai& src_rect, const areai& dst_rect, VkImageAspectFlags aspect, VkImageAspectFlags transfer_flags = 0xFF)
 				{
-					const u32 src_w = u32(src_rect.x2 - src_rect.x1);
-					const u32 src_h = u32(src_rect.y2 - src_rect.y1);
-					const u32 dst_w = u32(dst_rect.x2 - dst_rect.x1);
-					const u32 dst_h = u32(dst_rect.y2 - dst_rect.y1);
+					const auto src_w = src_rect.width();
+					const auto src_h = src_rect.height();
+					const auto dst_w = dst_rect.width();
+					const auto dst_h = dst_rect.height();
 
 					// Drivers are not very accepting of aspect COLOR -> aspect DEPTH or aspect STENCIL separately
 					// However, this works okay for D24S8 (nvidia-only format)
@@ -310,31 +311,31 @@ namespace vk
 
 					//1. Copy unscaled to typeless surface
 					copy_image(cmd, src, typeless, preferred_src_format, VK_IMAGE_LAYOUT_GENERAL,
-						src_rect, { 0, 0, (s32)src_w, (s32)src_h }, 1, aspect, VK_IMAGE_ASPECT_COLOR_BIT, transfer_flags, 0xFF);
+						src_rect, { 0, 0, src_w, src_h }, 1, aspect, VK_IMAGE_ASPECT_COLOR_BIT, transfer_flags, 0xFF);
 
 					//2. Blit typeless surface to self
 					copy_scaled_image(cmd, typeless, typeless, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL,
-						0, 0, src_w, src_h, 0, src_h, dst_w, dst_h, 1, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_ASPECT_COLOR_BIT, filter);
+						{ 0, 0, src_w, src_h }, { 0, src_h, dst_w, (src_h + dst_h) }, 1, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_ASPECT_COLOR_BIT, filter);
 
 					//3. Copy back the aspect bits
 					copy_image(cmd, typeless, dst, VK_IMAGE_LAYOUT_GENERAL, preferred_dst_format,
-						{0, (s32)src_h, (s32)dst_w, s32(src_h + dst_h) }, dst_rect, 1, VK_IMAGE_ASPECT_COLOR_BIT, aspect, 0xFF, transfer_flags);
+						{0, src_h, dst_w, (src_h + dst_h) }, dst_rect, 1, VK_IMAGE_ASPECT_COLOR_BIT, aspect, 0xFF, transfer_flags);
 				};
 
 				auto stretch_image_typeless_safe = [&cmd, preferred_src_format, preferred_dst_format, filter](VkImage src, VkImage dst, VkImage typeless,
 					const areai& src_rect, const areai& dst_rect, VkImageAspectFlags aspect, VkImageAspectFlags transfer_flags = 0xFF)
 				{
-					const u32 src_w = u32(src_rect.x2 - src_rect.x1);
-					const u32 src_h = u32(src_rect.y2 - src_rect.y1);
-					const u32 dst_w = u32(dst_rect.x2 - dst_rect.x1);
-					const u32 dst_h = u32(dst_rect.y2 - dst_rect.y1);
+					const auto src_w = src_rect.width();
+					const auto src_h = src_rect.height();
+					const auto dst_w = dst_rect.width();
+					const auto dst_h = dst_rect.height();
 
 					auto scratch_buf = vk::get_scratch_buffer();
 
 					//1. Copy unscaled to typeless surface
 					VkBufferImageCopy info{};
-					info.imageOffset = { src_rect.x1, src_rect.y1, 0 };
-					info.imageExtent = { src_w, src_h, 1 };
+					info.imageOffset = { std::min(src_rect.x1, src_rect.x2), std::min(src_rect.y1, src_rect.y2), 0 };
+					info.imageExtent = { (u32)src_w, (u32)src_h, 1 };
 					info.imageSubresource = { aspect & transfer_flags, 0, 0, 1 };
 
 					vkCmdCopyImageToBuffer(cmd, src, preferred_src_format, scratch_buf->value, 1, &info);
@@ -343,13 +344,17 @@ namespace vk
 					info.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
 					vkCmdCopyBufferToImage(cmd, scratch_buf->value, typeless, VK_IMAGE_LAYOUT_GENERAL, 1, &info);
 
-					//2. Blit typeless surface to self
+					//2. Blit typeless surface to self and apply transform if necessary
+					areai src_rect2 = { 0, 0, src_w, src_h };
+					if (src_rect.x1 > src_rect.x2) src_rect2.flip_horizontal();
+					if (src_rect.y1 > src_rect.y2) src_rect2.flip_vertical();
+
 					copy_scaled_image(cmd, typeless, typeless, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL,
-						0, 0, src_w, src_h, 0, src_h, dst_w, dst_h, 1, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_ASPECT_COLOR_BIT, filter);
+						src_rect2, { 0, src_h, dst_w, (src_h + dst_h) }, 1, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_ASPECT_COLOR_BIT, filter);
 
 					//3. Copy back the aspect bits
-					info.imageExtent = { dst_w, dst_h, 1 };
-					info.imageOffset = { 0, (s32)src_h, 0 };
+					info.imageExtent = { (u32)dst_w, (u32)dst_h, 1 };
+					info.imageOffset = { 0, src_h, 0 };
 
 					vkCmdCopyImageToBuffer(cmd, typeless, VK_IMAGE_LAYOUT_GENERAL, scratch_buf->value, 1, &info);
 					insert_buffer_memory_barrier(cmd, scratch_buf->value, 0, VK_WHOLE_SIZE, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
@@ -359,10 +364,8 @@ namespace vk
 					vkCmdCopyBufferToImage(cmd, scratch_buf->value, dst, preferred_dst_format, 1, &info);
 				};
 
-				const areai src_rect = { (s32)src_x_offset, (s32)src_y_offset, s32(src_x_offset + src_width), s32(src_y_offset + src_height) };
-				const areai dst_rect = { (s32)dst_x_offset, (s32)dst_y_offset, s32(dst_x_offset + dst_width), s32(dst_y_offset + dst_height) };
-				const u32 typeless_w = dst_width;
-				const u32 typeless_h = src_height + dst_height;
+				const u32 typeless_w = dst_rect.width();
+				const u32 typeless_h = src_rect.height() + dst_rect.height();
 
 				switch (src_format)
 				{
@@ -404,10 +407,10 @@ namespace vk
 		else
 		{
 			VkImageBlit rgn = {};
-			rgn.srcOffsets[0] = { (int32_t)src_x_offset, (int32_t)src_y_offset, 0 };
-			rgn.srcOffsets[1] = { (int32_t)(src_width + src_x_offset), (int32_t)(src_height + src_y_offset), 1 };
-			rgn.dstOffsets[0] = { (int32_t)dst_x_offset, (int32_t)dst_y_offset, 0 };
-			rgn.dstOffsets[1] = { (int32_t)(dst_width + dst_x_offset), (int32_t)(dst_height + dst_y_offset), 1 };
+			rgn.srcOffsets[0] = { src_rect.x1, src_rect.y1, 0 };
+			rgn.srcOffsets[1] = { src_rect.x2, src_rect.y2, 1 };
+			rgn.dstOffsets[0] = { dst_rect.x1, dst_rect.y1, 0 };
+			rgn.dstOffsets[1] = { dst_rect.x2, dst_rect.y2, 1 };
 			rgn.dstSubresource = a_dst;
 			rgn.srcSubresource = a_src;
 
@@ -638,13 +641,18 @@ namespace vk
 			return;
 		}
 
-		const auto src_width = src_area.x2 - src_area.x1;
-		const auto src_height = src_area.y2 - src_area.y1;
-		const auto dst_width = dst_area.x2 - dst_area.x1;
-		const auto dst_height = dst_area.y2 - dst_area.y1;
+		if (xfer_info.flip_horizontal)
+		{
+			src_area.flip_horizontal();
+		}
 
-		copy_scaled_image(cmd, real_src->value, real_dst->value, real_src->current_layout, real_dst->current_layout, src_area.x1, src_area.y1, src_width, src_height,
-			dst_area.x1, dst_area.y1, dst_width, dst_height, 1, dst_aspect, real_src->info.format == real_dst->info.format,
+		if (xfer_info.flip_vertical)
+		{
+			src_area.flip_vertical();
+		}
+
+		copy_scaled_image(cmd, real_src->value, real_dst->value, real_src->current_layout, real_dst->current_layout,
+			src_area, dst_area, 1, dst_aspect, real_src->info.format == real_dst->info.format,
 			interpolate ? VK_FILTER_LINEAR : VK_FILTER_NEAREST, real_src->info.format, real_dst->info.format);
 
 		if (real_dst != dst)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -235,8 +235,8 @@ namespace vk
 					const auto filter = (aspect_flag == VK_IMAGE_ASPECT_COLOR_BIT) ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
 
 					vk::copy_scaled_image(cmd, vram_texture->value, target->value, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, target->current_layout,
-						0, 0, vram_texture->width(), vram_texture->height(), 0, 0, transfer_width, transfer_height, 1, aspect_flag, true, filter,
-						vram_texture->info.format, target->info.format);
+						{ 0, 0, (s32)vram_texture->width(), (s32)vram_texture->height() }, { 0, 0, (s32)transfer_width, (s32)transfer_height },
+						1, aspect_flag, true, filter, vram_texture->info.format, target->info.format);
 				}
 			}
 
@@ -536,7 +536,7 @@ namespace vk
 				{
 					verify(HERE), section.dst_z == 0;
 
-					u32 dst_x = section.dst_x, dst_y = section.dst_y;
+					u16 dst_x = section.dst_x, dst_y = section.dst_y;
 					vk::image* _dst;
 
 					if (LIKELY(section.src->info.format == dst->info.format))
@@ -552,8 +552,8 @@ namespace vk
 					if (section.xform == surface_transform::identity)
 					{
 						vk::copy_scaled_image(cmd, section.src->value, _dst->value, section.src->current_layout, _dst->current_layout,
-							section.src_x, section.src_y, section.src_w, section.src_h,
-							section.dst_x, section.dst_y, section.dst_w, section.dst_h,
+							coordi{ { section.src_x, section.src_y }, { section.src_w, section.src_h } },
+							coordi{ { section.dst_x, section.dst_y }, { section.dst_w, section.dst_h } },
 							1, src_aspect, section.src->info.format == _dst->info.format,
 							VK_FILTER_NEAREST, section.src->info.format, _dst->info.format);
 					}
@@ -593,8 +593,8 @@ namespace vk
 						}
 
 						vk::copy_scaled_image(cmd, tmp->value, _dst->value, tmp->current_layout, _dst->current_layout,
-							0, 0, section.src_w, section.src_h,
-							dst_x, dst_y, section.dst_w, section.dst_h,
+							areai{ 0, 0, (s32)section.src_w, (s32)section.src_h },
+							coordi{ {dst_x, dst_y}, {section.dst_w, section.dst_h} },
 							1, src_aspect, section.src->info.format == _dst->info.format,
 							VK_FILTER_NEAREST, tmp->info.format, _dst->info.format);
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -988,7 +988,7 @@ namespace rsx
 				dst_info.max_tile_h = static_cast<u16>((dst_region.tile->size - dst_region.base) / out_pitch);
 			}
 
-			if (!g_cfg.video.force_cpu_blit_processing && (dst_dma == CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER || src_dma == CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER) && scale_x > 0 && scale_y > 0)
+			if (!g_cfg.video.force_cpu_blit_processing && (dst_dma == CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER || src_dma == CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER))
 			{
 				//For now, only use this for actual scaled images, there are use cases that should not go through 3d engine, e.g program ucode transfer
 				//TODO: Figure out more instances where we can use this without problems


### PR DESCRIPTION
A follow-up to the last PR addressing a few issues
- Tons of accuracy and stability/crash fixes in texture cache and blit engine
- Vastly improved synchronization mechanism (DMA flush)
- Implemented blit engine rotations on the GPU
- Lays groundwork for the next task (variable sized framebuffers to preserve memory contents)

Tracker: https://github.com/RPCS3/rpcs3/issues/5708