### PR TITLE
Update DualShock 3 warning

### DIFF
--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -1502,7 +1502,7 @@
            <item>
             <widget class="QLabel" name="l_description">
              <property name="text">
-              <string>Unfortunately, we currently do not natively support DualShock 3 controllers. You can however use third party tools like SCP Driver Package to allow your DualShock 3 controller to function like an XInput controller. We plan to add additional input methods in the future.</string>
+              <string>To use a DualShock 3 controller on Windows you need a generic driver, like WinUSB. Press the PS button to activate the controller.</string>
              </property>
              <property name="textFormat">
               <enum>Qt::PlainText</enum>


### PR DESCRIPTION
Now that DS3 support is implemented, that text is no longer accurate.
I updated it to mention the need for a driver like WinUSB (mentioned on the PR) that I assume is only needed on Windows, and the need for pressing the PS button to wake the controller up. Tell me if I missed anything or if I should change something (or if I should just close this and stop trying to get my 5 seconds of fame :D)