### PR TITLE
rsx: Fixups

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -613,8 +613,8 @@ void gl::render_target::memory_barrier(gl::command_context& cmd, bool force_init
 		return;
 	}
 
-	auto src_bpp = src_texture->get_native_pitch() / src_texture->width();
-	auto dst_bpp = get_native_pitch() / width();
+	auto src_bpp = src_texture->get_native_pitch() / src_texture->get_surface_width();
+	auto dst_bpp = get_native_pitch() / get_surface_width();
 	rsx::typeless_xfer typeless_info{};
 
 	const bool dst_is_depth = is_depth(get_internal_format());

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -54,8 +54,6 @@ namespace gl
 		u32 rsx_pitch = 0;
 		u16 native_pitch = 0;
 
-		u16 internal_width = 0;
-		u16 internal_height = 0;
 		u16 surface_height = 0;
 		u16 surface_width = 0;
 		u16 surface_pixel_size = 0;
@@ -86,7 +84,13 @@ namespace gl
 			return native_pitch;
 		}
 
-		// Rsx pitch
+		void set_surface_dimensions(u16 w, u16 h, u16 pitch)
+		{
+			surface_width = w;
+			surface_height = h;
+			rsx_pitch = pitch;
+		}
+
 		void set_rsx_pitch(u16 pitch)
 		{
 			rsx_pitch = pitch;
@@ -130,18 +134,10 @@ namespace gl
 			return id();
 		}
 
-		void update_surface()
-		{
-			internal_width = width();
-			internal_height = height();
-			surface_width = rsx::apply_inverse_resolution_scale(internal_width, true);
-			surface_height = rsx::apply_inverse_resolution_scale(internal_height, true);
-		}
-
 		bool matches_dimensions(u16 _width, u16 _height) const
 		{
 			//Use forward scaling to account for rounding and clamping errors
-			return (rsx::apply_resolution_scale(_width, true) == internal_width) && (rsx::apply_resolution_scale(_height, true) == internal_height);
+			return (rsx::apply_resolution_scale(_width, true) == width()) && (rsx::apply_resolution_scale(_height, true) == height());
 		}
 
 		void memory_barrier(gl::command_context& cmd, bool force_init = false);
@@ -176,14 +172,13 @@ struct gl_render_target_traits
 		std::unique_ptr<gl::render_target> result(new gl::render_target(rsx::apply_resolution_scale((u16)width, true),
 			rsx::apply_resolution_scale((u16)height, true), (GLenum)internal_fmt));
 		result->set_native_pitch((u16)width * format.channel_count * format.channel_size);
-		result->set_rsx_pitch((u16)pitch);
+		result->set_surface_dimensions(width, height, (u16)pitch);
 
 		std::array<GLenum, 4> native_layout = { (GLenum)format.swizzle.a, (GLenum)format.swizzle.r, (GLenum)format.swizzle.g, (GLenum)format.swizzle.b };
 		result->set_native_component_layout(native_layout);
 		result->set_old_contents(old_surface);
 
 		result->set_cleared(false);
-		result->update_surface();
 		result->queue_tag(address);
 		return result;
 	}
@@ -206,12 +201,11 @@ struct gl_render_target_traits
 
 		std::array<GLenum, 4> native_layout = { GL_RED, GL_RED, GL_RED, GL_RED };
 		result->set_native_pitch(native_pitch);
-		result->set_rsx_pitch((u16)pitch);
+		result->set_surface_dimensions(width, height, (u16)pitch);
 		result->set_native_component_layout(native_layout);
 		result->set_old_contents(old_surface);
 
 		result->set_cleared(false);
-		result->update_surface();
 		result->queue_tag(address);
 		return result;
 	}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -106,8 +106,8 @@ namespace vk
 				return;
 			}
 
-			auto src_bpp = src_texture->get_native_pitch() / src_texture->width();
-			auto dst_bpp = get_native_pitch() / width();
+			auto src_bpp = src_texture->get_native_pitch() / src_texture->get_surface_width();
+			auto dst_bpp = get_native_pitch() / get_surface_width();
 			rsx::typeless_xfer typeless_info{};
 
 			const auto region = rsx::get_transferable_region(this);


### PR DESCRIPTION
- Fix surface cache hit intersection tests when the pitch*height tile is larger than the real size of the texture
- Fix bpp calculation for typeless memory inheritance (RTT read barriers)

Fixes https://github.com/RPCS3/rpcs3/issues/5739