### PR TITLE
[WIP] Implement rescheduling timer interrupts

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Utilities/mutex.h"
 #include "Utilities/sema.h"
@@ -212,6 +212,12 @@ struct lv2_obj
 		}
 		}
 	}
+
+	// Last time a thread was released
+	static atomic_t<u64> g_last_sleep;
+
+	// Forcefully put running threads to sleep, reschedule
+	static void release_all();
 
 private:
 	// Scheduler mutex


### PR DESCRIPTION
Fixes #5740, the game used to work because yield() was bugged and freed ppu threads completely from the scheduler before #5314.
This game spawns two threads with the same high prio, their only sleep is happenning between yields, so without full thread release they will end up both busy waiting and deadlocking the scheduler.

TODO: Implement timed based ppu scheduler to avoid such cases..