### PR TITLE
PPU/SPU Interpreter + Recompiler instruction fixes and improvements

### DIFF
--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -2524,12 +2524,14 @@ std::vector<ppu_function_t>& ppu_function_manager::access()
 		{
 			LOG_ERROR(PPU, "Unregistered function called (LR=0x%x)", ppu.lr);
 			ppu.gpr[3] = 0;
-			return true;
+			ppu.cia += 4;
+			return false;
 		},
 		[](ppu_thread& ppu) -> bool
 		{
 			ppu.state += cpu_flag::ret;
-			return true;
+			ppu.cia += 4;
+			return false;
 		},
 	};
 

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/System.h"
 #include "PPUThread.h"
 #include "PPUInterpreter.h"
@@ -22,7 +22,7 @@ inline void ppu_cr_set(ppu_thread& ppu, u32 field, bool le, bool gt, bool eq, bo
 
 	if (UNLIKELY(g_cfg.core.ppu_debug))
 	{
-		*(u32*)(vm::g_stat_addr + ppu.cia) |= *(u32*)(u8*)(ppu.cr + field * 4);
+		*(u32*)(vm::g_stat_addr + ppu.cia) |= *(u32*)(ppu.cr.bits + field * 4);
 	}
 }
 
@@ -2941,7 +2941,7 @@ bool ppu_interpreter::B(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::MCRF(ppu_thread& ppu, ppu_opcode_t op)
 {
 	CHECK_SIZE(ppu_thread::cr, 32);
-	reinterpret_cast<u32*>(ppu.cr)[op.crfd] = reinterpret_cast<u32*>(ppu.cr)[op.crfs];
+	reinterpret_cast<u32*>(+ppu.cr.bits)[op.crfd] = reinterpret_cast<u32*>(+ppu.cr.bits)[op.crfs];
 	return true;
 }
 
@@ -3237,7 +3237,7 @@ bool ppu_interpreter::MFOCRF(ppu_thread& ppu, ppu_opcode_t op)
 	else
 	{
 		// MFCR
-		auto* lanes = reinterpret_cast<be_t<v128>*>(ppu.cr);
+		auto* lanes = reinterpret_cast<be_t<v128>*>(+ppu.cr.bits);
 		const u32 mh = _mm_movemask_epi8(_mm_slli_epi64(lanes[0].value().vi, 7));
 		const u32 ml = _mm_movemask_epi8(_mm_slli_epi64(lanes[1].value().vi, 7));
 
@@ -3518,7 +3518,7 @@ bool ppu_interpreter::MTOCRF(ppu_thread& ppu, ppu_opcode_t op)
 		const u32 n = utils::cntlz32(op.crm) & 7;
 		const u32 p = n * 4;
 		const u64 v = (s >> (p ^ 0x1c)) & 0xf;
-		*(u32*)(u8*)(ppu.cr + p) = *(u32*)(s_table + v);
+		*(u32*)(ppu.cr.bits + p) = *(u32*)(s_table + v);
 	}
 	else
 	{
@@ -3530,7 +3530,7 @@ bool ppu_interpreter::MTOCRF(ppu_thread& ppu, ppu_opcode_t op)
 			{
 				const u32 p = i * 4;
 				const u64 v = (s >> (p ^ 0x1c)) & 0xf;
-				*(u32*)(u8*)(ppu.cr + p) = *(u32*)(s_table + v);
+				*(u32*)(ppu.cr.bits + p) = *(u32*)(s_table + v);
 			}
 		}
 	}
@@ -4673,28 +4673,46 @@ bool ppu_interpreter::FNMADDS(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::MTFSB1(ppu_thread& ppu, ppu_opcode_t op)
 {
-	LOG_WARNING(PPU, "MTFSB1");
+	const u32 bit = op.crbd;
+	if (bit < 16 || bit > 19) LOG_WARNING(PPU, "MTFSB1(%d)", bit);
+	ppu.fpscr.bits[bit] = 1;
 	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
 bool ppu_interpreter::MCRFS(ppu_thread& ppu, ppu_opcode_t op)
 {
-	LOG_WARNING(PPU, "MCRFS");
-	ppu_cr_set(ppu, op.crfd, false, false, false, false);
+	if (op.crfs != 4) LOG_WARNING(PPU, "MCRFS(%d)", op.crfs);
+	reinterpret_cast<u32*>(+ppu.cr.bits)[op.crfd] = reinterpret_cast<u32*>(&ppu.fpscr.bits[0])[op.crfs];
 	return true;
 }
 
 bool ppu_interpreter::MTFSB0(ppu_thread& ppu, ppu_opcode_t op)
 {
-	LOG_WARNING(PPU, "MTFSB0");
+	const u32 bit = op.crbd;
+	if (bit < 16 || bit > 19) LOG_WARNING(PPU, "MTFSB0(%d)", bit);
+	ppu.fpscr.bits[bit] = 0;
 	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
 bool ppu_interpreter::MTFSFI(ppu_thread& ppu, ppu_opcode_t op)
 {
-	LOG_WARNING(PPU, "MTFSFI");
+	const u32 bf = op.crfd * 4;
+	if (bf != 4 * 4) 
+	{
+		// Do nothing on non-FPCC field (TODO)
+		LOG_WARNING(PPU, "MTFSFI(%d)", op.crfd);
+	}
+	else
+	{
+		u32 i = op.i;
+		ppu.fpscr.bits[bf + 3] = i & 1; i >>= 1;
+		ppu.fpscr.bits[bf + 2] = i & 1; i >>= 1;
+		ppu.fpscr.bits[bf + 1] = i & 1; i >>= 1;
+		ppu.fpscr.bits[bf + 0] = i & 1;
+	}
+
 	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
@@ -4702,7 +4720,7 @@ bool ppu_interpreter::MTFSFI(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::MFFS(ppu_thread& ppu, ppu_opcode_t op)
 {
 	LOG_WARNING(PPU, "MFFS");
-	ppu.fpr[op.frd] = 0.0;
+	(u64&)ppu.fpr[op.frd] = u64{ppu.fpscr.fl} << 15 | u64{ppu.fpscr.fg} << 14 | u64{ppu.fpscr.fe} << 13 | u64{ppu.fpscr.fu} << 12;
 	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
@@ -4718,10 +4736,10 @@ bool ppu_interpreter::FCMPU(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const f64 a = ppu.fpr[op.fra];
 	const f64 b = ppu.fpr[op.frb];
-	ppu.fpscr.fg = a > b;
-	ppu.fpscr.fl = a < b;
-	ppu.fpscr.fe = a == b;
-	//ppu.fpscr.fu = a != a || b != b;
+	u8 test_fu = ppu.fpscr.fg = a > b;
+	test_fu |= ppu.fpscr.fl = a < b;
+	test_fu |= ppu.fpscr.fe = a == b;
+	(u8&)ppu.fpscr.fu = test_fu ^ 1;
 	ppu_cr_set(ppu, op.crfd, ppu.fpscr.fl, ppu.fpscr.fg, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -1426,7 +1426,7 @@ bool ppu_interpreter_precise::VPKSHSS(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto& a = ppu.vr[op.va];
 	const auto& b = ppu.vr[op.vb];
-	auto& d = ppu.vr[op.vd];
+	v128 d;
 
 	for (u8 i = 0; i < 8; i++)
 	{
@@ -1465,6 +1465,7 @@ bool ppu_interpreter_precise::VPKSHSS(ppu_thread& ppu, ppu_opcode_t op)
 		}
 	}
 
+	ppu.vr[op.vd] = d;
 	return true;
 }
 
@@ -1476,47 +1477,20 @@ bool ppu_interpreter_fast::VPKSHUS(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter_precise::VPKSHUS(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const auto& a = ppu.vr[op.va];
-	const auto& b = ppu.vr[op.vb];
-	auto& d = ppu.vr[op.vd];
+	const auto a = ppu.vr[op.va];
+	const auto b = ppu.vr[op.vb];
 
-	for (u8 i = 0; i < 8; i++)
+	// Detect saturation
 	{
-		s16 result = a._s16[i];
-
-		if (result < 0)
+		const u64 mask = 0xFF00FF00FF00FF00ULL;
+		const auto all_bits = v128::fromV(_mm_or_si128(a.vi, b.vi));
+		if ((all_bits._u64[0] | all_bits._u64[1]) & mask)
 		{
-			d._u8[i + 8] = 0;
 			ppu.sat = true;
-		}
-		else if (result > UINT8_MAX)
-		{
-			d._u8[i + 8] = UINT8_MAX;
-			ppu.sat = true;
-		}
-		else
-		{
-			d._u8[i + 8] = (u8)result;
-		}
-
-		result = b._s16[i];
-
-		if (result < 0)
-		{
-			d._u8[i] = 0;
-			ppu.sat = true;
-		}
-		else if (result > UINT8_MAX)
-		{
-			d._u8[i] = UINT8_MAX;
-			ppu.sat = true;
-		}
-		else
-		{
-			d._u8[i] = (u8)result;
 		}
 	}
 
+	ppu.vr[op.vd].vi = _mm_packus_epi16(b.vi, a.vi);
 	return true;
 }
 
@@ -1530,7 +1504,7 @@ bool ppu_interpreter_precise::VPKSWSS(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto& a = ppu.vr[op.va];
 	const auto& b = ppu.vr[op.vb];
-	auto& d = ppu.vr[op.vd];
+	v128 d;
 
 	for (u8 i = 0; i < 4; i++)
 	{
@@ -1569,6 +1543,7 @@ bool ppu_interpreter_precise::VPKSWSS(ppu_thread& ppu, ppu_opcode_t op)
 		}
 	}
 
+	ppu.vr[op.vd] = d;
 	return true;
 }
 
@@ -2495,7 +2470,7 @@ bool ppu_interpreter_precise::VSUMSWS(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter_fast::VSUM2SWS(ppu_thread& ppu, ppu_opcode_t op)
 {
-	auto& d = ppu.vr[op.vd];
+	v128 d;
 	const auto& a = ppu.vr[op.va];
 	const auto& b = ppu.vr[op.vb];
 
@@ -2516,12 +2491,13 @@ bool ppu_interpreter_fast::VSUM2SWS(ppu_thread& ppu, ppu_opcode_t op)
 	}
 	d._s32[1] = 0;
 	d._s32[3] = 0;
+	ppu.vr[op.vd] = d;
 	return true;
 }
 
 bool ppu_interpreter_precise::VSUM2SWS(ppu_thread& ppu, ppu_opcode_t op)
 {
-	auto& d = ppu.vr[op.vd];
+	v128 d;
 	const auto& a = ppu.vr[op.va];
 	const auto& b = ppu.vr[op.vb];
 
@@ -2542,8 +2518,10 @@ bool ppu_interpreter_precise::VSUM2SWS(ppu_thread& ppu, ppu_opcode_t op)
 		else
 			d._s32[n * 2] = (s32)sum;
 	}
+
 	d._s32[1] = 0;
 	d._s32[3] = 0;
+	ppu.vr[op.vd] = d;
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -443,7 +443,7 @@ std::string ppu_thread::dump() const
 	for (uint i = 0; i < 32; ++i) fmt::append(ret, "FPR[%d] = %.6G\n", i, fpr[i]);
 	for (uint i = 0; i < 32; ++i) fmt::append(ret, "VR[%d] = %s [x: %g y: %g z: %g w: %g]\n", i, vr[i], vr[i]._f[3], vr[i]._f[2], vr[i]._f[1], vr[i]._f[0]);
 
-	fmt::append(ret, "CR = 0x%08x\n", cr_pack());
+	fmt::append(ret, "CR = 0x%08x\n", cr.pack());
 	fmt::append(ret, "LR = 0x%llx\n", lr);
 	fmt::append(ret, "CTR = 0x%llx\n", ctr);
 	fmt::append(ret, "VRSAVE = 0x%08x\n", vrsave);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -169,13 +169,13 @@ static void ppu_initialize2(class jit_compiler& jit, const ppu_module& module_pa
 extern void ppu_execute_syscall(ppu_thread& ppu, u64 code);
 
 // Get pointer to executable cache
-static u32& ppu_ref(u32 addr)
+static u64& ppu_ref(u32 addr)
 {
-	return *reinterpret_cast<u32*>(vm::g_exec_addr + addr);
+	return *reinterpret_cast<u64*>(vm::g_exec_addr + (u64)addr * 2);
 }
 
 // Get interpreter cache value
-static u32 ppu_cache(u32 addr)
+static u64 ppu_cache(u32 addr)
 {
 	// Select opcode table
 	const auto& table = *(
@@ -183,7 +183,8 @@ static u32 ppu_cache(u32 addr)
 		g_cfg.core.ppu_decoder == ppu_decoder_type::fast ? &g_ppu_interpreter_fast.get_table() :
 		(fmt::throw_exception<std::logic_error>("Invalid PPU decoder"), nullptr));
 
-	return ::narrow<u32>(reinterpret_cast<std::uintptr_t>(table[ppu_decode(vm::read32(addr))]));
+	const u32 value = vm::read32(addr);
+	return (u64)value << 32 | ::narrow<u32>(reinterpret_cast<std::uintptr_t>(table[ppu_decode(value)]));
 }
 
 static bool ppu_fallback(ppu_thread& ppu, ppu_opcode_t op)
@@ -207,20 +208,19 @@ void ppu_recompiler_fallback(ppu_thread& ppu)
 	}
 
 	const auto& table = g_ppu_interpreter_fast.get_table();
-	const auto base = vm::g_base_addr;
 	const auto cache = vm::g_exec_addr;
 
 	while (true)
 	{
 		// Run instructions in interpreter
-		if (const u32 op = *reinterpret_cast<be_t<u32>*>(base + ppu.cia);
+		if (const u32 op = *reinterpret_cast<u32*>(cache + (u64)ppu.cia * 2 + 4);
 			LIKELY(table[ppu_decode(op)](ppu, { op })))
 		{
 			ppu.cia += 4;
 			continue;
 		}
 
-		if (uptr func = *reinterpret_cast<u32*>(cache + ppu.cia);
+		if (uptr func = *reinterpret_cast<u32*>(cache + (u64)ppu.cia * 2);
 			func != reinterpret_cast<uptr>(ppu_recompiler_fallback))
 		{
 			// We found a recompiler function at cia, return
@@ -269,7 +269,7 @@ extern void ppu_register_range(u32 addr, u32 size)
 	}
 
 	// Register executable range at
-	utils::memory_commit(&ppu_ref(addr), size, utils::protection::rw);
+	utils::memory_commit(&ppu_ref(addr), size * 2, utils::protection::rw);
 
 	const u32 fallback = ::narrow<u32>(g_cfg.core.ppu_decoder == ppu_decoder_type::llvm ? 
 	reinterpret_cast<uptr>(ppu_recompiler_fallback) : reinterpret_cast<uptr>(ppu_fallback));
@@ -277,7 +277,7 @@ extern void ppu_register_range(u32 addr, u32 size)
 	size &= ~3; // Loop assumes `size = n * 4`, enforce that by rounding down
 	while (size)
 	{
-		ppu_ref(addr) = fallback;
+		ppu_ref(addr) = (u64)vm::read32(addr) << 32 | fallback;
 		addr += 4;
 		size -= 4;
 	}
@@ -288,7 +288,7 @@ extern void ppu_register_function_at(u32 addr, u32 size, ppu_function_t ptr)
 	// Initialize specific function
 	if (ptr)
 	{
-		ppu_ref(addr) = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(ptr));
+		*reinterpret_cast<u32*>(&ppu_ref(addr)) = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(ptr));
 		return;
 	}
 
@@ -312,7 +312,7 @@ extern void ppu_register_function_at(u32 addr, u32 size, ppu_function_t ptr)
 
 	while (size)
 	{
-		if (ppu_ref(addr) == fallback)
+		if ((u32)ppu_ref(addr) == fallback)
 		{
 			ppu_ref(addr) = ppu_cache(addr);
 		}
@@ -357,7 +357,7 @@ extern void ppu_breakpoint(u32 addr, bool isAdding)
 	if (isAdding)
 	{
 		// Set breakpoint
-		ppu_ref(addr) = _break;
+		*reinterpret_cast<u32*>(&ppu_ref(addr)) = _break;
 	}
 	else
 	{
@@ -376,9 +376,9 @@ extern void ppu_set_breakpoint(u32 addr)
 
 	const auto _break = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(&ppu_break));
 
-	if (ppu_ref(addr) != _break)
+	if ((u32)ppu_ref(addr) != _break)
 	{
-		ppu_ref(addr) = _break;
+		*reinterpret_cast<u32*>(&ppu_ref(addr)) = _break;
 	}
 }
 
@@ -392,7 +392,7 @@ extern void ppu_remove_breakpoint(u32 addr)
 
 	const auto _break = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(&ppu_break));
 
-	if (ppu_ref(addr) == _break)
+	if ((u32)ppu_ref(addr) == _break)
 	{
 		ppu_ref(addr) = ppu_cache(addr);
 	}
@@ -420,7 +420,7 @@ extern bool ppu_patch(u32 addr, u32 value)
 	const u32 _break = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(&ppu_break));
 	const u32 fallback = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(&ppu_fallback));
 
-	if (ppu_ref(addr) != _break && ppu_ref(addr) != fallback)
+	if ((u32)ppu_ref(addr) != _break && (u32)ppu_ref(addr) != fallback)
 	{
 		ppu_ref(addr) = ppu_cache(addr);
 	}
@@ -622,81 +622,72 @@ void ppu_thread::exec_task()
 	{
 		while (!(state & (cpu_flag::ret + cpu_flag::exit + cpu_flag::stop + cpu_flag::dbg_global_stop)))
 		{
-			reinterpret_cast<ppu_function_t>(static_cast<std::uintptr_t>(ppu_ref(cia)))(*this);
+			reinterpret_cast<ppu_function_t>(static_cast<std::uintptr_t>((u32)ppu_ref(cia)))(*this);
 		}
 
 		return;
 	}
 
-	const auto base = vm::_ptr<const u8>(0);
 	const auto cache = vm::g_exec_addr;
-	const auto bswap4 = _mm_set_epi8(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
-
-	v128 _op;
 	using func_t = decltype(&ppu_interpreter::UNK);
-	func_t func0, func1, func2, func3, func4, func5;
 
 	while (true)
 	{
-		if (UNLIKELY(state))
+		const auto exec_op = [this](u64 op)
 		{
-			if (check_state()) return;
+			return reinterpret_cast<func_t>((uptr)(u32)op)(*this, {u32(op >> 32)});
+		};
+
+		if (cia % 8 || !s_use_ssse3 || UNLIKELY(state))
+		{
+			if (test_stopped()) return;
 
 			// Decode single instruction (may be step)
-			const u32 op = *reinterpret_cast<const be_t<u32>*>(base + cia);
-			if (reinterpret_cast<func_t>((std::uintptr_t)ppu_ref(cia))(*this, {op})) { cia += 4; }
+			if (exec_op(*reinterpret_cast<u64*>(cache + (u64)cia * 2))) { cia += 4; }
 			continue;
 		}
 
-		if (cia % 16 || !s_use_ssse3)
-		{
-			// Unaligned
-			const u32 op = *reinterpret_cast<const be_t<u32>*>(base + cia);
-			if (reinterpret_cast<func_t>((std::uintptr_t)ppu_ref(cia))(*this, {op})) { cia += 4; }
-			continue;
-		}
+		u64 op0, op1, op2, op3;
+		u64 _pos = (u64)cia * 2;
 
 		// Reinitialize
 		{
-			const v128 x = v128::fromV(_mm_load_si128(reinterpret_cast<const __m128i*>(cache + cia)));
-			func0 = reinterpret_cast<func_t>((std::uintptr_t)x._u32[0]);
-			func1 = reinterpret_cast<func_t>((std::uintptr_t)x._u32[1]);
-			func2 = reinterpret_cast<func_t>((std::uintptr_t)x._u32[2]);
-			func3 = reinterpret_cast<func_t>((std::uintptr_t)x._u32[3]);
-			_op.vi =  _mm_shuffle_epi8(_mm_load_si128(reinterpret_cast<const __m128i*>(base + cia)), bswap4);
+			const v128 _op0 = *reinterpret_cast<const v128*>(cache + _pos);
+			const v128 _op1 = *reinterpret_cast<const v128*>(cache + _pos + 16);
+			op0 = _op0._u64[0];
+			op1 = _op0._u64[1];
+			op2 = _op1._u64[0];
+			op3 = _op1._u64[1];
 		}
 
-		while (LIKELY(func0(*this, {_op._u32[0]})))
+		while (LIKELY(exec_op(op0)))
 		{
 			cia += 4;
 
-			if (LIKELY(func1(*this, {_op._u32[1]})))
+			if (LIKELY(exec_op(op1)))
 			{
 				cia += 4;
 
-				const v128 x = v128::fromV(_mm_load_si128(reinterpret_cast<const __m128i*>(cache + cia + 8)));
-				func0 = reinterpret_cast<func_t>((std::uintptr_t)x._u32[0]);
-				func1 = reinterpret_cast<func_t>((std::uintptr_t)x._u32[1]);
-				func4 = reinterpret_cast<func_t>((std::uintptr_t)x._u32[2]);
-				func5 = reinterpret_cast<func_t>((std::uintptr_t)x._u32[3]);
-
-				if (LIKELY(func2(*this, {_op._u32[2]})))
+				if (LIKELY(exec_op(op2)))
 				{
 					cia += 4;
 
-					if (LIKELY(func3(*this, {_op._u32[3]})))
+					if (LIKELY(exec_op(op3)))
 					{
 						cia += 4;
-
-						func2 = func4;
-						func3 = func5;
 
 						if (UNLIKELY(state))
 						{
 							break;
 						}
 
-						_op.vi = _mm_shuffle_epi8(_mm_load_si128(reinterpret_cast<const __m128i*>(base + cia)), bswap4);
+						_pos += 32;
+						const v128 _op0 = *reinterpret_cast<const v128*>(cache + _pos);
+						const v128 _op1 = *reinterpret_cast<const v128*>(cache + _pos + 16);
+						op0 = _op0._u64[0];
+						op1 = _op0._u64[1];
+						op2 = _op1._u64[0];
+						op3 = _op1._u64[1];
 						continue;
 					}
 					break;
@@ -1296,7 +1287,7 @@ extern void ppu_initialize(const ppu_module& info)
 			if (g_cfg.core.ppu_debug && func.size && func.toc != -1)
 			{
 				s_ppu_toc->emplace(func.addr, func.toc);
-				ppu_ref(func.addr) = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(&ppu_check_toc));
+				*reinterpret_cast<u32*>(&ppu_ref(func.addr)) = ::narrow<u32>(reinterpret_cast<std::uintptr_t>(&ppu_check_toc));
 			}
 		}
 
@@ -1553,7 +1544,7 @@ extern void ppu_initialize(const ppu_module& info)
 #endif
 
 			// Write version, hash, CPU, settings
-			fmt::append(obj_name, "v2-tane-%s-%s-%s.obj", fmt::base57(output, 16), fmt::base57(settings), jit_compiler::cpu(g_cfg.core.llvm_cpu));
+			fmt::append(obj_name, "v3-tane-%s-%s-%s.obj", fmt::base57(output, 16), fmt::base57(settings), jit_compiler::cpu(g_cfg.core.llvm_cpu));
 		}
 
 		if (Emu.IsStopped())
@@ -1652,7 +1643,7 @@ extern void ppu_initialize(const ppu_module& info)
 				{
 					const u64 addr = jit->get(fmt::format("__0x%x", block.first - reloc));
 					jit_mod.funcs.emplace_back(reinterpret_cast<ppu_function_t>(addr));
-					ppu_ref(block.first) = ::narrow<u32>(addr);
+					*reinterpret_cast<u32*>(&ppu_ref(block.first)) = ::narrow<u32>(addr);
 				}
 			}
 		}
@@ -1683,7 +1674,7 @@ extern void ppu_initialize(const ppu_module& info)
 			{
 				if (block.second)
 				{
-					ppu_ref(block.first) = ::narrow<u32>(reinterpret_cast<uptr>(jit_mod.funcs[index++]));
+					*reinterpret_cast<u32*>(&ppu_ref(block.first)) = ::narrow<u32>(reinterpret_cast<uptr>(jit_mod.funcs[index++]));
 				}
 			}
 		}

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Common.h"
 #include "../CPU/CPUThread.h"
@@ -59,47 +59,64 @@ public:
 	f64 fpr[32] = {}; // Floating Point Registers
 	v128 vr[32] = {}; // Vector Registers
 
-	alignas(16) bool cr[32] = {}; // Condition Registers (unpacked)
-
-	alignas(16) struct // Floating-Point Status and Control Register (unpacked)
+	struct cr_bits
 	{
-		// TODO
-		bool _start[16]{};
-		bool fl{}; // FPCC.FL
-		bool fg{}; // FPCC.FG
-		bool fe{}; // FPCC.FE
-		bool fu{}; // FPCC.FU
-		bool _end[12]{};
+		alignas(16) u8 bits[32];
+
+		u8& operator [](std::size_t i)
+		{
+			return bits[i];
+		}
+
+		// Pack CR bits
+		u32 pack() const
+		{
+			u32 result{};
+
+			for (u32 bit : bits)
+			{
+				result <<= 1;
+				result |= bit;
+			}
+
+			return result;	
+		}
+
+		// Unpack CR bits
+		void unpack(u32 value)
+		{
+			for (u8& b : bits)
+			{
+				b = value & 0x1;
+				value >>= 1;
+			}
+		}
+	};
+
+	cr_bits cr{}; // Condition Registers (unpacked)
+
+	// Floating-Point Status and Control Register (unpacked)
+	union
+	{
+		struct
+		{
+			// TODO
+			bool _start[16];
+			bool fl; // FPCC.FL
+			bool fg; // FPCC.FG
+			bool fe; // FPCC.FE
+			bool fu; // FPCC.FU
+			bool _end[12];
+		};
+
+		cr_bits bits;
 	}
-	fpscr;
+	fpscr{};
 
 	u64 lr{}; // Link Register
 	u64 ctr{}; // Counter Register
 	u32 vrsave{0xffffffff}; // VR Save Register
 	u32 cia{}; // Current Instruction Address
-
-	// Pack CR bits
-	u32 cr_pack() const
-	{
-		u32 result{};
-
-		for (u32 bit : cr)
-		{
-			result = (result << 1) | bit;
-		}
-
-		return result;
-	}
-
-	// Unpack CR bits
-	void cr_unpack(u32 value)
-	{
-		for (bool& b : cr)
-		{
-			b = (value & 0x1) != 0;
-			value >>= 1;
-		}
-	}
 
 	// Fixed-Point Exception Register (abstract representation)
 	struct

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -142,7 +142,7 @@ public:
 			exception, the corresponding element in the target vr is cleared to '0'. In both cases, the '0'
 			has the same sign as the denormalized or underflowing value.
 	*/
-	bool nj = true;
+	bool nj = false;
 
 	u32 raddr{0}; // Reservation addr
 	u64 rtime{0};

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -49,7 +49,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* module, const ppu_mod
 	m_thread_type = StructType::create(m_context, thread_struct, "context_t");
 
 	// Callable
-	m_call = new GlobalVariable(*module, ArrayType::get(GetType<u32>(), 0x40000000)->getPointerTo(), true, GlobalValue::ExternalLinkage, 0, fmt::format("__cptr%x", gsuffix));
+	m_call = new GlobalVariable(*module, ArrayType::get(GetType<u32>(), 0x80000000)->getPointerTo(), true, GlobalValue::ExternalLinkage, 0, fmt::format("__cptr%x", gsuffix));
 	m_call->setInitializer(ConstantPointerNull::get(cast<PointerType>(m_call->getType()->getPointerElementType())));
 	m_call->setExternallyInitialized(true);
 
@@ -282,7 +282,7 @@ void PPUTranslator::CallFunction(u64 target, Value* indirect)
 			}
 		}
 
-		const auto pos = m_ir->CreateLShr(indirect, 2, "", true);
+		const auto pos = m_ir->CreateShl(m_ir->CreateLShr(indirect, 2, "", true), 1, "", true);
 		const auto ptr = m_ir->CreateGEP(m_ir->CreateLoad(m_call), {m_ir->getInt64(0), pos});
 		indirect = m_ir->CreateIntToPtr(m_ir->CreateLoad(ptr), type->getPointerTo());
 	}

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -3086,6 +3086,7 @@ void PPUTranslator::LSWI(ppu_opcode_t op)
 				if (--index)
 				{
 					addr = m_ir->CreateAdd(addr, m_ir->getInt64(1));
+					i--;
 				}
 			}
 
@@ -3181,7 +3182,7 @@ void PPUTranslator::STSWI(ppu_opcode_t op)
 
 			while (index)
 			{
-				WriteMemory(addr, m_ir->CreateLShr(buf, 24));
+				WriteMemory(addr, Trunc(m_ir->CreateLShr(buf, 24), GetType<u8>()));
 
 				if (--index)
 				{

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1,4 +1,4 @@
-#ifdef LLVM_AVAILABLE
+﻿#ifdef LLVM_AVAILABLE
 
 #include "PPUTranslator.h"
 #include "PPUThread.h"
@@ -271,6 +271,8 @@ void PPUTranslator::CallFunction(u64 target, Value* indirect)
 	}
 	else
 	{
+		m_ir->CreateStore(Trunc(indirect, GetType<u32>()), m_ir->CreateStructGEP(nullptr, m_thread, &m_cia - m_locals), true);
+
 		// Try to optimize
 		if (auto inst = dyn_cast_or_null<Instruction>(indirect))
 		{

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -496,7 +496,16 @@ bool spu_interpreter::IRET(spu_thread& spu, spu_opcode_t op)
 
 bool spu_interpreter::BISLED(spu_thread& spu, spu_opcode_t op)
 {
-	fmt::throw_exception("Unimplemented instruction" HERE);
+	const u32 target = spu_branch_target(spu.gpr[op.ra]._u32[3]);
+	spu.gpr[op.rt] = v128::from32r(spu_branch_target(spu.pc + 4));
+
+	if (spu.get_events())
+	{
+		spu.pc = target;
+		set_interrupt_status(spu, op);
+		return false;
+	}
+
 	return true;
 }
 
@@ -1043,10 +1052,7 @@ bool spu_interpreter_fast::FCMGT(spu_thread& spu, spu_opcode_t op)
 
 bool spu_interpreter::DFCMGT(spu_thread& spu, spu_opcode_t op)
 {
-	const auto mask = _mm_castsi128_pd(_mm_set1_epi64x(0x7fffffffffffffff));
-	const auto ra = _mm_and_pd(spu.gpr[op.ra].vd, mask);
-	const auto rb = _mm_and_pd(spu.gpr[op.rb].vd, mask);
-	spu.gpr[op.rt].vd = _mm_cmpgt_pd(ra, rb);
+	fmt::throw_exception("Unexpected Instruction" HERE);
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -3342,7 +3342,7 @@ public:
 					// Emit state check if necessary (TODO: more conditions)
 					for (u32 pred : pfound->second)
 					{
-						if (pred >= baddr && bi > 0)
+						if (pred >= baddr)
 						{
 							// If this block is a target of a backward branch (possibly loop), emit a check
 							check_state(baddr);

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6257,8 +6257,10 @@ public:
 				return;
 			}
 
+			const auto _max = fsplat<f64[4]>(std::exp2(32.f));
 			r.value = m_ir->CreateFPToUI(a.value, get_type<s32[4]>());
-			set_vr(op.rt, r & sext<s32[4]>(fcmp<llvm::FCmpInst::FCMP_OGE>(a, fsplat<f64[4]>(0.))));
+			r.value = m_ir->CreateSelect(m_ir->CreateFCmpUGE(a.value, _max.value), splat<s32[4]>(-1).eval(m_ir), (r & sext<s32[4]>(fcmp<llvm::FCmpInst::FCMP_OGE>(a, fsplat<f64[4]>(0.)))).eval(m_ir));
+			set_vr(op.rt, r);
 		}
 		else
 		{
@@ -6272,8 +6274,10 @@ public:
 				a = eval(a * s);
 
 			value_t<s32[4]> r;
+			const auto _max = fsplat<f32[4]>(std::exp2(32.f));
 			r.value = m_ir->CreateFPToUI(a.value, get_type<s32[4]>());
-			set_vr(op.rt, r & ~(bitcast<s32[4]>(a) >> 31));
+			r.value = m_ir->CreateSelect(m_ir->CreateFCmpUGE(a.value, _max.value), splat<s32[4]>(-1).eval(m_ir), (r & ~(bitcast<s32[4]>(a) >> 31)).eval(m_ir));
+			set_vr(op.rt, r);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -236,10 +236,9 @@ error_code _sys_prx_start_module(u32 id, u64 flags, vm::ptr<sys_prx_start_stop_m
 		return CELL_ESRCH;
 	}
 
-	//if (prx->is_started)
-	//	return CELL_PRX_ERROR_ALREADY_STARTED;
+	if (prx->is_started.exchange(true))
+		return not_an_error(CELL_PRX_ERROR_ALREADY_STARTED);
 
-	//prx->is_started = true;
 	pOpt->entry.set(prx->start ? prx->start.addr() : ~0ull);
 	pOpt->entry2.set(prx->prologue ? prx->prologue.addr() : ~0ull);
 	return CELL_OK;
@@ -256,10 +255,9 @@ error_code _sys_prx_stop_module(u32 id, u64 flags, vm::ptr<sys_prx_start_stop_mo
 		return CELL_ESRCH;
 	}
 
-	//if (!prx->is_started)
-	//	return CELL_PRX_ERROR_ALREADY_STOPPED;
+	if (!prx->is_started.exchange(false))
+		return not_an_error(CELL_PRX_ERROR_ALREADY_STOPPED);
 
-	//prx->is_started = false;
 	pOpt->entry.set(prx->stop ? prx->stop.addr() : ~0ull);
 	pOpt->entry2.set(prx->epilogue ? prx->epilogue.addr() : ~0ull);
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -119,7 +119,7 @@ struct lv2_prx final : lv2_obj, ppu_module
 {
 	static const u32 id_base = 0x23000000;
 
-	bool is_started = false;
+	atomic_t<bool> is_started = false;
 
 	std::unordered_map<u32, u32> specials;
 	std::unordered_map<u32, void*> imports;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -364,7 +364,7 @@ namespace vm
 
 		if (flags & page_executable)
 		{
-			utils::memory_commit(g_exec_addr + addr, size);
+			utils::memory_commit(g_exec_addr + addr * 2, size * 2);
 		}
 
 		if (g_cfg.core.ppu_debug)
@@ -494,7 +494,7 @@ namespace vm
 
 		if (is_exec)
 		{
-			utils::memory_decommit(g_exec_addr + addr, size);
+			utils::memory_decommit(g_exec_addr + addr * 2, size * 2);
 		}
 
 		if (g_cfg.core.ppu_debug)

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #include "register_editor_dialog.h"
 
 constexpr auto qstr = QString::fromStdString;
@@ -105,7 +105,7 @@ void register_editor_dialog::updateRegister(const QString& text)
 			if (reg.compare(0, 3, "FPR") == 0) str = fmt::format("%016llx", ppu.fpr[reg_index]);
 			if (reg.compare(0, 2, "VR") == 0)  str = fmt::format("%016llx%016llx", ppu.vr[reg_index]._u64[1], ppu.vr[reg_index]._u64[0]);
 		}
-		if (reg == "CR")  str = fmt::format("%08x", ppu.cr_pack());
+		if (reg == "CR")  str = fmt::format("%08x", ppu.cr.pack());
 		if (reg == "LR")  str = fmt::format("%016llx", ppu.lr);
 		if (reg == "CTR") str = fmt::format("%016llx", ppu.ctr);
 	}
@@ -169,7 +169,7 @@ void register_editor_dialog::OnOkay(const std::shared_ptr<cpu_thread>& _cpu)
 			if (reg == "CR")
 			{
 				const ullong reg_value = std::stoull(value.substr(24, 31), 0, 16);
-				if (reg == "CR") ppu.cr_unpack((u32)reg_value);
+				if (reg == "CR") ppu.cr.unpack((u32)reg_value);
 				return;
 			}
 		}


### PR DESCRIPTION
* Fix a few SIMD with saturation instructions on ppu Fast and Precise decoders: Properly handle cases where destination reg is also one of the source registers. Fixes loading icon in Beyond Two Souls with ppu precise. Fixes #2827

* Improve FPCC handling in ppu interpreter to be closer to LLVM implementation, fixing part of #3516

* Rewrite VPKSHUS in ppu precise decoder to be almost as fast as its "fast" counterpart.

* Fix default non-java mode reported.

* Status check added to sys_prx_start/stop_module.

* like ppu interpreters, if the instruction/function is not found fallback to decoding single instructions in PPU LLVM recompiler, fixes part of #2909 . 

* Fix STSWI and LWSI instructions in ppu llvm when number of bytes isnt 32bit aligned.
* Increment cia manually in unregistered hle func access, this is not done automatically in llvm. Fixes #4087

* Prefetch byteswapped opcodes in PPU Interpreter, register usage optimizations.

* Implement BISLED instruction for all SPU decoders.

* Fix CFLTU instruction for SPU LLVM decoders.