### PR TITLE
rsx: Fixups

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2290,6 +2290,7 @@ namespace rsx
 			if (!g_cfg.video.use_gpu_texture_scaling && !(src_is_render_target || dst_is_render_target))
 				return false;
 
+
 			// Check if trivial memcpy can perform the same task
 			// Used to copy programs and arbitrary data to the GPU in some cases
 			if (!src_is_render_target && !dst_is_render_target && dst_is_argb8 == src_is_argb8 && !dst.swizzled)
@@ -2312,6 +2313,17 @@ namespace rsx
 						// Rotation transform applied, use fallback
 						return false;
 					}
+				}
+			}
+
+			// Sanity and format compatibility checks
+			if (dst_is_render_target)
+			{
+				if (src_subres.is_depth != dst_subres.is_depth)
+				{
+					// Create a cache-local resource to resolve later
+					// TODO: Support depth->RGBA typeless transfer for vulkan
+					dst_is_render_target = false;
 				}
 			}
 
@@ -2377,12 +2389,11 @@ namespace rsx
 
 			reader_lock lock(m_cache_mutex);
 
+			const auto old_dst_area = dst_area;
 			if (!dst_is_render_target)
 			{
 				// Check for any available region that will fit this one
 				auto overlapping_surfaces = find_texture_from_range(address_range::start_length(dst_address, dst.pitch * dst.clip_height), dst.pitch, rsx::texture_upload_context::blit_engine_dst);
-				const auto old_dst_area = dst_area;
-
 				for (const auto &surface : overlapping_surfaces)
 				{
 					if (!surface->is_locked())
@@ -2444,48 +2455,42 @@ namespace rsx
 				max_dst_height = dst_subres.surface->get_surface_height();
 			}
 
-			const bool src_is_depth = src_subres.is_depth;
-			const bool dst_is_depth = dst_is_render_target? dst_subres.is_depth :
-										dest_texture ? cached_dest->is_depth_texture() : src_is_depth;
-
-			// Type of blit decided by the source, destination use should adapt on the fly
-			const bool is_depth_blit = src_is_depth;
-
-			bool format_mismatch = (src_is_depth != dst_is_depth);
-			if (format_mismatch)
+			// Check if available target is acceptable
+			// TODO: Check for other types of format mismatch
+			bool format_mismatch = false;
+			if (cached_dest)
 			{
-				if (dst_is_render_target)
+				if (cached_dest->is_depth_texture() != src_subres.is_depth)
 				{
-					LOG_ERROR(RSX, "Depth<->RGBA blit on a framebuffer requested but not supported");
-					return false;
-				}
-			}
-			else if (src_is_render_target && cached_dest)
-			{
-				switch (cached_dest->get_gcm_format())
-				{
-				case CELL_GCM_TEXTURE_A8R8G8B8:
-				case CELL_GCM_TEXTURE_DEPTH24_D8:
-					format_mismatch = !dst_is_argb8;
-					break;
-				case CELL_GCM_TEXTURE_R5G6B5:
-				case CELL_GCM_TEXTURE_DEPTH16:
-					format_mismatch = dst_is_argb8;
-					break;
-				default:
+					// Dest surface has the wrong 'aspect'
 					format_mismatch = true;
-					break;
+				}
+				else
+				{
+					// Check if it matches the transfer declaration
+					switch (cached_dest->get_gcm_format())
+					{
+					case CELL_GCM_TEXTURE_A8R8G8B8:
+					case CELL_GCM_TEXTURE_DEPTH24_D8:
+						format_mismatch = !dst_is_argb8;
+						break;
+					case CELL_GCM_TEXTURE_R5G6B5:
+					case CELL_GCM_TEXTURE_DEPTH16:
+						format_mismatch = dst_is_argb8;
+						break;
+					default:
+						format_mismatch = true;
+						break;
+					}
 				}
 			}
 
-			//TODO: Check for other types of format mismatch
-			const address_range dst_range = address_range::start_length(dst_address, dst.pitch * dst.height);
-			AUDIT(cached_dest == nullptr || cached_dest->overlaps(dst_range, section_bounds::full_range));
 			if (format_mismatch)
 			{
 				// The invalidate call before creating a new target will remove this section
 				cached_dest = nullptr;
 				dest_texture = 0;
+				dst_area = old_dst_area;
 			}
 
 			// Create source texture if does not exist
@@ -2564,7 +2569,10 @@ namespace rsx
 				typeless_info.src_context = texture_upload_context::framebuffer_storage;
 			}
 
+			// Type of blit decided by the source, destination use should adapt on the fly
+			const bool is_depth_blit = src_subres.is_depth;
 			u32 gcm_format;
+
 			if (is_depth_blit)
 				gcm_format = (dst_is_argb8) ? CELL_GCM_TEXTURE_DEPTH24_D8 : CELL_GCM_TEXTURE_DEPTH16;
 			else

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2620,6 +2620,12 @@ namespace rsx
 					dst_is_argb8 ? rsx::texture_create_flags::default_component_order :
 					rsx::texture_create_flags::swapped_native_component_order;
 
+				// Translate dst_area into the 'full' dst block based on dst.rsx_address as (0, 0)
+				dst_area.x1 += dst.offset_x;
+				dst_area.x2 += dst.offset_x;
+				dst_area.y1 += dst.offset_y;
+				dst_area.y2 += dst.offset_y;
+
 				if (!dst_area.x1 && !dst_area.y1 && dst_area.x2 == dst_dimensions.width && dst_area.y2 == dst_dimensions.height)
 				{
 					cached_dest = create_new_texture(cmd, rsx_range, dst_dimensions.width, dst_dimensions.height, 1, 1, dst.pitch,

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1734,8 +1734,8 @@ namespace rsx
 				const auto clipped = rsx::intersect_region(address, slice_w, slice_h, bpp,
 					section->get_section_base(), section->get_width(), section->get_height(), section_bpp, pitch);
 
-				const auto slice_begin = (slice * src_slice_h);
-				const auto slice_end = (slice_begin + slice_h);
+				const auto slice_begin = u32(slice * src_slice_h);
+				const auto slice_end = u32(slice_begin + slice_h);
 
 				const auto dst_y = std::get<1>(clipped).y;
 				const auto dst_h = std::get<2>(clipped).height;
@@ -2087,7 +2087,7 @@ namespace rsx
 				// Optimize the range a bit by only searching for mip0, layer0 to avoid false positives
 				const auto texel_rows_per_line = get_format_texel_rows_per_line(format);
 				const auto num_rows = (tex_height + texel_rows_per_line - 1) / texel_rows_per_line;
-				if (const auto length = num_rows * tex_pitch; length < tex_range.length())
+				if (const auto length = u32(num_rows * tex_pitch); length < tex_range.length())
 				{
 					lookup_range = utils::address_range::start_length(texaddr, length);
 				}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1645,7 +1645,7 @@ void GLGSRender::flip(int buffer)
 			else
 			{
 				gl::command_context cmd = { gl_state };
-				const auto overlap_info = m_rtts.get_merged_texture_memory_region(cmd, absolute_address, buffer_width, buffer_height, buffer_pitch);
+				const auto overlap_info = m_rtts.get_merged_texture_memory_region(cmd, absolute_address, buffer_width, buffer_height, buffer_pitch, render_target_texture->get_bpp());
 
 				if (!overlap_info.empty() && overlap_info.back().surface == render_target_texture)
 				{

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -613,8 +613,8 @@ void gl::render_target::memory_barrier(gl::command_context& cmd, bool force_init
 		return;
 	}
 
-	auto src_bpp = src_texture->get_native_pitch() / src_texture->get_surface_width();
-	auto dst_bpp = get_native_pitch() / get_surface_width();
+	const auto src_bpp = src_texture->get_bpp();
+	const auto dst_bpp = get_bpp();
 	rsx::typeless_xfer typeless_info{};
 
 	const bool dst_is_depth = is_depth(get_internal_format());

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -172,7 +172,7 @@ struct gl_render_target_traits
 		std::unique_ptr<gl::render_target> result(new gl::render_target(rsx::apply_resolution_scale((u16)width, true),
 			rsx::apply_resolution_scale((u16)height, true), (GLenum)internal_fmt));
 		result->set_native_pitch((u16)width * format.channel_count * format.channel_size);
-		result->set_surface_dimensions(width, height, (u16)pitch);
+		result->set_surface_dimensions((u16)width, (u16)height, (u16)pitch);
 
 		std::array<GLenum, 4> native_layout = { (GLenum)format.swizzle.a, (GLenum)format.swizzle.r, (GLenum)format.swizzle.g, (GLenum)format.swizzle.b };
 		result->set_native_component_layout(native_layout);
@@ -201,7 +201,7 @@ struct gl_render_target_traits
 
 		std::array<GLenum, 4> native_layout = { GL_RED, GL_RED, GL_RED, GL_RED };
 		result->set_native_pitch(native_pitch);
-		result->set_surface_dimensions(width, height, (u16)pitch);
+		result->set_surface_dimensions((u16)width, (u16)height, (u16)pitch);
 		result->set_native_component_layout(native_layout);
 		result->set_old_contents(old_surface);
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -217,7 +217,7 @@ struct gl_render_target_traits
 		info->native_pitch = surface->get_native_pitch();
 		info->surface_width = surface->get_surface_width();
 		info->surface_height = surface->get_surface_height();
-		info->bpp = static_cast<u8>(info->native_pitch / info->surface_width);
+		info->bpp = surface->get_bpp();
 	}
 
 	static void prepare_rtt_for_drawing(void *, gl::render_target *rtt) { rtt->reset_refs(); }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3288,7 +3288,7 @@ void VKGSRender::flip(int buffer)
 			}
 			else
 			{
-				const auto overlap_info = m_rtts.get_merged_texture_memory_region(*m_current_command_buffer, absolute_address, buffer_width, buffer_height, buffer_pitch);
+				const auto overlap_info = m_rtts.get_merged_texture_memory_region(*m_current_command_buffer, absolute_address, buffer_width, buffer_height, buffer_pitch, render_target_texture->get_bpp());
 				if (!overlap_info.empty() && overlap_info.back().surface == render_target_texture)
 				{
 					// Confirmed to be the newest data source in that range

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -183,7 +183,7 @@ namespace vk
 			u32 new_height = align(requested_height, 1024u);
 
 			return new vk::image(*g_current_renderer, g_current_renderer->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				VK_IMAGE_TYPE_2D, format, 4096, 4096, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
+				VK_IMAGE_TYPE_2D, format, new_width, new_height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, 0);
 		};
 

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -106,8 +106,8 @@ namespace vk
 				return;
 			}
 
-			auto src_bpp = src_texture->get_native_pitch() / src_texture->get_surface_width();
-			auto dst_bpp = get_native_pitch() / get_surface_width();
+			const auto src_bpp = src_texture->get_bpp();
+			const auto dst_bpp = get_bpp();
 			rsx::typeless_xfer typeless_info{};
 
 			const auto region = rsx::get_transferable_region(this);
@@ -259,7 +259,7 @@ namespace rsx
 			info->native_pitch = surface->native_pitch;
 			info->surface_width = surface->get_surface_width();
 			info->surface_height = surface->get_surface_height();
-			info->bpp = static_cast<u8>(info->native_pitch / info->surface_width);
+			info->bpp = surface->get_bpp();
 		}
 
 		static void prepare_rtt_for_drawing(vk::command_buffer* pcmd, vk::render_target *surface)

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -95,10 +95,7 @@ namespace rsx
 		void insert_draw_command(u32 index, const draw_range_t& range)
 		{
 			auto range_It = draw_command_ranges.begin();
-			while (index--)
-			{
-				++range_It;
-			}
+			std::advance(range_It, index);
 
 			draw_command_ranges.insert(range_It, range);
 


### PR DESCRIPTION
- Fix typeless format conversions when doing blit transfers (regression)
- Fix slice gather methods (regression)
- Fix typeless resource management when resolution scaling is in use
- Fix out-of-order draw command insertion (old bug)
- Silence some msvc warnings