### PR TITLE
Fix macOS compilation

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -111,10 +111,10 @@ target_link_libraries(rpcs3_emu
 	PUBLIC
 		3rdparty::ffmpeg 3rdparty::cereal
 		3rdparty::opengl 3rdparty::stblib
-		3rdparty::vulkan
+		3rdparty::vulkan 3rdparty::glew
 	PRIVATE
 		3rdparty::gsl 3rdparty::xxhash
-		3rdparty::dx12 3rdparty::glew)
+		3rdparty::dx12)
 
 
 # Setup cotire


### PR DESCRIPTION
This is needed for GL/glew.h to be found.