### PR TITLE
Ease cache line interference on TSX path

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1229,6 +1229,15 @@ fs::native_handle fs::file::get_handle() const
 #endif
 }
 
+#ifdef _WIN32
+bool fs::file::set_delete(bool autodelete) const
+{
+	FILE_DISPOSITION_INFO disp;
+	disp.DeleteFileW = autodelete;
+	return SetFileInformationByHandle(get_handle(), FileDispositionInfo, &disp, sizeof(disp)) != 0;
+}
+#endif
+
 void fs::dir::xnull() const
 {
 	fmt::throw_exception<std::logic_error>("fs::dir is null");

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -192,6 +192,15 @@ namespace fs
 		// Do notning
 	}
 
+	native_handle file_base::get_native_handle()
+	{
+#ifdef _WIN32
+		return INVALID_HANDLE_VALUE;
+#else
+		return -1;
+#endif
+	}
+
 	dir_base::~dir_base()
 	{
 	}
@@ -884,7 +893,7 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 		return;
 	}
 
-	class windows_file final : public file_base, public get_native_handle
+	class windows_file final : public file_base
 	{
 		const HANDLE m_handle;
 
@@ -987,7 +996,7 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 			return size.QuadPart;
 		}
 
-		native_handle get() override
+		native_handle get_native_handle() override
 		{
 			return m_handle;
 		}
@@ -1034,7 +1043,7 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 		::ftruncate(fd, 0);
 	}
 
-	class unix_file final : public file_base, public get_native_handle
+	class unix_file final : public file_base
 	{
 		const int m_fd;
 
@@ -1127,7 +1136,7 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 			return file_info.st_size;
 		}
 
-		native_handle get() override
+		native_handle get_native_handle() override
 		{
 			return m_fd;
 		}
@@ -1208,9 +1217,9 @@ fs::file::file(const void* ptr, std::size_t size)
 
 fs::native_handle fs::file::get_handle() const
 {
-	if (auto getter = dynamic_cast<get_native_handle*>(m_file.get()))
+	if (m_file)
 	{
-		return getter->get();
+		return m_file->get_native_handle();
 	}
 
 #ifdef _WIN32

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -65,12 +65,6 @@ namespace fs
 		s64 ctime;
 	};
 
-	// Native handle getter
-	struct get_native_handle
-	{
-		virtual native_handle get() = 0;
-	};
-
 	// File handle base
 	struct file_base
 	{
@@ -83,6 +77,7 @@ namespace fs
 		virtual u64 write(const void* buffer, u64 size) = 0;
 		virtual u64 seek(s64 offset, seek_mode whence) = 0;
 		virtual u64 size() = 0;
+		virtual native_handle get_native_handle();
 	};
 
 	// Directory entry (TODO)

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -361,6 +361,11 @@ namespace fs
 
 		// Get native handle if available
 		native_handle get_handle() const;
+
+#ifdef _WIN32
+		// Windows-specific function
+		bool set_delete(bool autodelete = true) const;
+#endif
 	};
 
 	class dir final

--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -387,9 +387,7 @@ logs::file_writer::file_writer(const std::string& name)
 
 #ifdef _WIN32
 		// Autodelete compressed log file
-		FILE_DISPOSITION_INFO disp;
-		disp.DeleteFileW = TRUE;
-		SetFileInformationByHandle(m_fout2.get_handle(), FileDispositionInfo, &disp, sizeof(disp));
+		m_fout2.set_delete();
 #endif
 	}
 	catch (const std::exception& e)
@@ -469,9 +467,7 @@ logs::file_writer::~file_writer()
 
 #ifdef _WIN32
 	// Cancel compressed log file autodeletion
-	FILE_DISPOSITION_INFO disp;
-	disp.DeleteFileW = FALSE;
-	SetFileInformationByHandle(m_fout2.get_handle(), FileDispositionInfo, &disp, sizeof(disp));
+	m_fout2.set_delete(false);
 
 	UnmapViewOfFile(m_fptr);
 	CloseHandle(m_fmap);

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -453,7 +453,7 @@ error_code cellGameContentPermit(vm::ptr<char[CELL_GAME_PATH_MAX]> contentInfoPa
 		// Make temporary directory persistent
 		const auto vdir = vfs::get(dir);
 
-		if (fs::rename(prm->temp, vdir, false))
+		if (vfs::host::rename(prm->temp, vdir, false))
 		{
 			cellGame.success("cellGameContentPermit(): directory '%s' has been created", dir);
 		}

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -934,19 +934,16 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		fs::remove_all(old_path, false);
 
 		// Backup old savedata
-		while (!fs::rename(dir_path, old_path, true))
+		if (!vfs::host::rename(dir_path, old_path, true))
 		{
-			// Try to ignore access error in order to prevent spurious failure
-			if (Emu.IsStopped() || fs::g_tls_error != fs::error::acces)
-				fmt::throw_exception("Failed to move directory %s (%s)", dir_path, fs::g_tls_error);
+			fmt::throw_exception("Failed to move directory %s (%s)", dir_path, fs::g_tls_error);
 		}
 
 		// Commit new savedata
-		while (!fs::rename(new_path, dir_path, false))
+		if (!vfs::host::rename(new_path, dir_path, false))
 		{
 			// TODO: handle the case when only commit failed at the next save load
-			if (Emu.IsStopped() || fs::g_tls_error != fs::error::acces)
-				fmt::throw_exception("Failed to move directory %s (%s)", new_path, fs::g_tls_error);
+			fmt::throw_exception("Failed to move directory %s (%s)", new_path, fs::g_tls_error);
 		}
 
 		// Remove backup again (TODO: may be changed to persistent backup implementation)

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1054,8 +1054,12 @@ const auto ppu_stwcx_tx = build_function_asm<bool(*)(u32 raddr, u64 rtime, u64 r
 	c.jz(fail);
 	c.sar(x86::eax, 24);
 	c.js(fail);
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.lock().add(x86::dword_ptr(x86::r11), 0);
 	c.lock().add(x86::qword_ptr(x86::r10), 0);
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.jmp(begin);
 
 	c.bind(fail);
@@ -1148,8 +1152,12 @@ const auto ppu_stdcx_tx = build_function_asm<bool(*)(u32 raddr, u64 rtime, u64 r
 	c.jz(fail);
 	c.sar(x86::eax, 24);
 	c.js(fail);
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.lock().add(x86::qword_ptr(x86::r11), 0);
 	c.lock().add(x86::qword_ptr(x86::r10), 0);
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.jmp(begin);
 
 	c.bind(fail);

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -247,8 +247,12 @@ const auto spu_putllc_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, const
 	c.js(fail);
 	c.sub(args[0].r32(), 1);
 	c.jz(retry);
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.lock().add(x86::qword_ptr(x86::r11), 0);
 	c.lock().add(x86::qword_ptr(x86::r10), 0);
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 #ifdef _WIN32
 	c.vmovups(x86::ymm4, x86::yword_ptr(args[3], 0));
 	c.vmovups(x86::ymm5, x86::yword_ptr(args[3], 96));
@@ -298,8 +302,12 @@ const auto spu_getll_tx = build_function_asm<u64(*)(u32 raddr, void* rdata)>([](
 	// Touch memory after transaction failure
 	c.bind(fall);
 	c.pause();
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.mov(x86::rax, x86::qword_ptr(x86::r11));
 	c.mov(x86::rax, x86::qword_ptr(x86::r10));
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.sub(args[0], 1);
 	c.jnz(begin);
 	c.mov(x86::eax, 1);
@@ -343,8 +351,12 @@ const auto spu_putlluc_tx = build_function_asm<bool(*)(u32 raddr, const void* rd
 	// Touch memory after transaction failure
 	c.bind(fall);
 	c.pause();
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.lock().add(x86::qword_ptr(x86::r11), 0);
 	c.lock().add(x86::qword_ptr(x86::r10), 0);
+	c.xor_(x86::r11, 0xf80);
+	c.xor_(x86::r10, 0xf80);
 	c.sub(args[0], 1);
 	c.jnz(begin);
 	c.xor_(x86::eax, x86::eax);

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -852,7 +852,7 @@ error_code sys_fs_unlink(vm::cptr<char> path)
 		return {CELL_ENOTMOUNTED, path};
 	}
 
-	if (!fs::remove_file(local_path))
+	if (!vfs::host::unlink(local_path))
 	{
 		switch (auto error = fs::g_tls_error)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -774,7 +774,7 @@ error_code sys_fs_rename(vm::cptr<char> from, vm::cptr<char> to)
 		return CELL_ENOTMOUNTED;
 	}
 
-	if (!fs::rename(local_from, local_to, false))
+	if (!vfs::host::rename(local_from, local_to, false))
 	{
 		switch (auto error = fs::g_tls_error)
 		{

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -385,6 +385,17 @@ std::string vfs::unescape(std::string_view path)
 						result += '*';
 						break;
 					}
+					case char{u8"＄"[2]}:
+					{
+						if (i == 0)
+						{
+							// Special case: filename starts with full-width $ likely created by vfs::host::unlink
+							result.resize(1, '.');
+							return result;
+						}
+
+						[[fallthrough]];
+					}
 					default:
 					{
 						// Unrecognized character (ignored)
@@ -461,4 +472,32 @@ bool vfs::host::rename(const std::string& from, const std::string& to, bool over
 	}
 
 	return true;
+}
+
+bool vfs::host::unlink(const std::string& path)
+{
+#ifdef _WIN32
+	if (path.size() < 2 || reinterpret_cast<const u16&>(path.front()) != "//"_u16)
+	{
+		// Rename to special dummy name which will be ignored by VFS (but opened file handles can still read or write it)
+		const std::string dummy = fmt::format(u8"%s/＄%s%s", fs::get_parent_dir(path), fmt::base57(std::hash<std::string>()(path)), fmt::base57(__rdtsc()));
+
+		if (!fs::rename(path, dummy, true))
+		{
+			return false;
+		}
+
+		if (fs::file f{dummy, fs::read + fs::write})
+		{
+			// Set to delete on close on last handle
+			f.set_delete();
+			return true;
+		}
+
+		// TODO: what could cause this and how to handle it
+		return true;
+	}
+#endif
+
+	return fs::remove_file(path);
 }

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -1,5 +1,6 @@
 ﻿#include "stdafx.h"
 #include "IdManager.h"
+#include "System.h"
 #include "VFS.h"
 
 #include "Utilities/mutex.h"
@@ -446,4 +447,18 @@ std::string vfs::unescape(std::string_view path)
 	}
 
 	return result;
+}
+
+bool vfs::host::rename(const std::string& from, const std::string& to, bool overwrite)
+{
+	while (!fs::rename(from, to, overwrite))
+	{
+		// Try to ignore access error in order to prevent spurious failure
+		if (Emu.IsStopped() || fs::g_tls_error != fs::error::acces)
+		{
+			return false;
+		}
+	}
+
+	return true;
 }

--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -17,4 +17,11 @@ namespace vfs
 
 	// Invert escape operation
 	std::string unescape(std::string_view path);
+
+	// Functions in this namespace operate on host filepaths, similar to fs::
+	namespace host
+	{
+		// Call fs::rename with retry on access error
+		bool rename(const std::string& from, const std::string& to, bool overwrite);
+	}
 }

--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -23,5 +23,8 @@ namespace vfs
 	{
 		// Call fs::rename with retry on access error
 		bool rename(const std::string& from, const std::string& to, bool overwrite);
+
+		// Delete file without deleting its contents, emulated with MoveFileEx on Windows
+		bool unlink(const std::string&);
 	}
 }


### PR DESCRIPTION
@ruipin reported that removing this code (touching memory) improves performance in some cases. It can't be simply removed, but there is a workaround to try.