### PR TITLE
Fix ".rsx_image" section block, fix page flags

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -159,7 +159,6 @@ struct vdec_context final
 
 	void exec(ppu_thread& ppu, u32 vid)
 	{
-		ppu.state -= cpu_flag::signal;
 		lv2_obj::sleep(ppu);
 
 		ppu_tid = ppu.id;

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1083,7 +1083,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 			if (prog.bin.size() > size || prog.bin.size() != prog.p_filesz)
 				fmt::throw_exception("Invalid binary size (0x%llx, memsz=0x%x)", prog.bin.size(), size);
 
-			if (!vm::falloc(addr, size))
+			if (!vm::get(vm::any, addr, 0x10000000, 0x400)->falloc(addr, size))
 				fmt::throw_exception("vm::falloc() failed (addr=0x%x, memsz=0x%x)", addr, size);
 
 			// Copy segment data, hash it
@@ -1102,6 +1102,9 @@ void ppu_load_exec(const ppu_exec_object& elf)
 			_main->segs.emplace_back(_seg);
 		}
 	}
+
+	// Allocate user 64k allocation block
+	vm::get(vm::user64k, 0, 0x20000000);
 
 	// Load section list, used by the analyser
 	for (const auto& s : elf.shdrs)

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -981,12 +981,12 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 	}
 
 	// Apply the patch
-	auto applied = fxm::check_unlocked<patch_engine>()->apply(hash, vm::g_base_addr);
+	auto applied = fxm::check<patch_engine>()->apply(hash, vm::g_base_addr);
 
 	if (!Emu.GetTitleID().empty())
 	{
 		// Alternative patch
-		applied += fxm::check_unlocked<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
+		applied += fxm::check<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
 	}
 
 	LOG_NOTICE(LOADER, "PRX library hash: %s (<- %u)", hash, applied);
@@ -1136,12 +1136,12 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	}
 
 	// Apply the patch
-	auto applied = fxm::check_unlocked<patch_engine>()->apply(hash, vm::g_base_addr);
+	auto applied = fxm::check<patch_engine>()->apply(hash, vm::g_base_addr);
 
 	if (!Emu.GetTitleID().empty())
 	{
 		// Alternative patch
-		applied += fxm::check_unlocked<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
+		applied += fxm::check<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
 	}
 
 	LOG_NOTICE(LOADER, "PPU executable hash: %s (<- %u)", hash, applied);
@@ -1707,12 +1707,12 @@ std::shared_ptr<lv2_overlay> ppu_load_overlay(const ppu_exec_object& elf, const 
 	}
 
 	// Apply the patch
-	auto applied = fxm::check_unlocked<patch_engine>()->apply(hash, vm::g_base_addr);
+	auto applied = fxm::check<patch_engine>()->apply(hash, vm::g_base_addr);
 
 	if (!Emu.GetTitleID().empty())
 	{
 		// Alternative patch
-		applied += fxm::check_unlocked<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
+		applied += fxm::check<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
 	}
 
 	LOG_NOTICE(LOADER, "OVL executable hash: %s (<- %u)", hash, applied);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -638,7 +638,7 @@ void ppu_thread::exec_task()
 			return reinterpret_cast<func_t>((uptr)(u32)op)(*this, {u32(op >> 32)});
 		};
 
-		if (cia % 8 || !s_use_ssse3 || UNLIKELY(state))
+		if (cia % 8 || UNLIKELY(state))
 		{
 			if (test_stopped()) return;
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -620,6 +620,12 @@ void ppu_thread::exec_task()
 {
 	if (g_cfg.core.ppu_decoder == ppu_decoder_type::llvm)
 	{
+		// Reset cpu flags
+		if (state && check_state())
+		{
+			return;
+		}
+
 		while (!(state & (cpu_flag::ret + cpu_flag::exit + cpu_flag::stop + cpu_flag::dbg_global_stop)))
 		{
 			reinterpret_cast<ppu_function_t>(static_cast<std::uintptr_t>((u32)ppu_ref(cia)))(*this);

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -606,13 +606,13 @@ void spu_int_ctrl_t::set(u64 ints)
 	ints &= mask;
 
 	// notify if at least 1 bit was set
-	if (ints && ~stat.fetch_or(ints) & ints && tag)
+	if (ints && ~stat.fetch_or(ints) & ints && !tag.expired())
 	{
 		reader_lock rlock(id_manager::g_mutex);
 
-		if (tag)
+		if (auto _tag = tag.lock())
 		{
-			if (auto handler = tag->handler.lock())
+			if (auto handler = _tag->handler.lock())
 			{
 				handler->exec();
 			}

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -353,7 +353,7 @@ struct spu_int_ctrl_t
 	atomic_t<u64> mask;
 	atomic_t<u64> stat;
 
-	std::shared_ptr<struct lv2_int_tag> tag;
+	std::weak_ptr<struct lv2_int_tag> tag;
 
 	void set(u64 ints);
 
@@ -366,7 +366,7 @@ struct spu_int_ctrl_t
 	{
 		mask.release(0);
 		stat.release(0);
-		tag = nullptr;
+		tag.reset();
 	}
 };
 

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -427,7 +427,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	BIND_FUNC(sys_overlay_unload_module),                   //451 (0x1C3)
 	null_func,//BIND_FUNC(sys_overlay_get_module_list)      //452 (0x1C4)
 	null_func,//BIND_FUNC(sys_overlay_get_module_info)      //453 (0x1C5)
-	null_func,//BIND_FUNC(sys_overlay_load_module_by_fd)    //454 (0x1C6)
+	BIND_FUNC(sys_overlay_load_module_by_fd),               //454 (0x1C6)
 	null_func,//BIND_FUNC(sys_overlay_get_module_info2)     //455 (0x1C7)
 	null_func,//BIND_FUNC(sys_overlay_get_sdk_version)      //456 (0x1C8)
 	null_func,//BIND_FUNC(sys_overlay_get_module_dbg_info)  //457 (0x1C9)

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -300,7 +300,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 
 	uns_func, uns_func, uns_func, uns_func, uns_func,       //255-259  UNS
 
-	null_func,//BIND_FUNC(sys_spu_image_open_by_fd)         //260 (0x104)
+	BIND_FUNC(sys_spu_image_open_by_fd),                    //260 (0x104)
 
 	uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, //261-269  UNS
 	uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, //270-279  UNS

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -590,14 +590,10 @@ error_code sys_fs_closedir(u32 fd)
 {
 	sys_fs.warning("sys_fs_closedir(fd=%d)", fd);
 
-	const auto directory = idm::get<lv2_fs_object, lv2_dir>(fd);
-
-	if (!directory)
+	if (!idm::remove<lv2_fs_object, lv2_dir>(fd))
 	{
 		return CELL_EBADF;
 	}
-
-	idm::remove<lv2_fs_object, lv2_dir>(fd);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -130,12 +130,6 @@ error_code _sys_interrupt_thread_disestablish(ppu_thread& ppu, u32 ih, vm::ptr<u
 
 	if (!handler)
 	{
-		if (const auto thread = idm::withdraw<named_thread<ppu_thread>>(ih))
-		{
-			*r13 = thread->gpr[13];
-			return CELL_OK;
-		}
-
 		return CELL_ESRCH;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.h
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.h
@@ -12,10 +12,10 @@ struct lv2_overlay final : lv2_obj, ppu_module
 };
 
 error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry);
+error_code sys_overlay_load_module_by_fd(vm::ptr<u32> ovlmid, u32 fd, u64 flags, vm::ptr<u32> entry);
 error_code sys_overlay_unload_module(u32 ovlmid);
 //error_code sys_overlay_get_module_list(sys_pid_t pid, size_t ovlmids_num, sys_overlay_t * ovlmids, size_t * num_of_modules);
 //error_code sys_overlay_get_module_info(sys_pid_t pid, sys_overlay_t ovlmid, sys_overlay_module_info_t * info);
-//error_code sys_overlay_load_module_by_fd(sys_overlay_t * ovlmid, int fd, u64 offset, uint64_t flags, sys_addr_t * entry);
 //error_code sys_overlay_get_module_info2(sys_pid_t pid, sys_overlay_t ovlmid, sys_overlay_module_info2_t * info);//
 //error_code sys_overlay_get_sdk_version(); //2 params
 //error_code sys_overlay_get_module_dbg_info(); //3 params?

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -214,10 +214,7 @@ error_code sys_ppu_thread_set_priority(ppu_thread& ppu, u32 thread_id, s32 prio)
 
 	const auto thread = idm::check<named_thread<ppu_thread>>(thread_id, [&](ppu_thread& thread)
 	{
-		if (thread.prio != prio)
-		{
-			lv2_obj::awake(thread, prio);
-		}
+		lv2_obj::awake(thread, prio);
 	});
 
 	if (!thread)

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -127,12 +127,12 @@ void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
 	}
 
 	// Apply the patch
-	auto applied = fxm::check_unlocked<patch_engine>()->apply(hash, vm::g_base_addr + loc);
+	auto applied = fxm::check<patch_engine>()->apply(hash, vm::g_base_addr + loc);
 
 	if (!Emu.GetTitleID().empty())
 	{
 		// Alternative patch
-		applied += fxm::check_unlocked<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr + loc);
+		applied += fxm::check<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr + loc);
 	}
 
 	LOG_NOTICE(LOADER, "Loaded SPU image: %s (<- %u)%s", hash, applied, dump);

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -287,6 +287,7 @@ class ppu_thread;
 error_code sys_spu_initialize(u32 max_usable_spu, u32 max_raw_spu);
 error_code _sys_spu_image_get_information(vm::ptr<sys_spu_image> img, vm::ptr<u32> entry_point, vm::ptr<s32> nsegs);
 error_code sys_spu_image_open(vm::ptr<sys_spu_image> img, vm::cptr<char> path);
+error_code sys_spu_image_open_by_fd(vm::ptr<sys_spu_image> img, u32 fd);
 error_code _sys_spu_image_import(vm::ptr<sys_spu_image> img, u32 src, u32 size, u32 arg4);
 error_code _sys_spu_image_close(vm::ptr<sys_spu_image> img);
 error_code _sys_spu_image_get_segments(vm::ptr<sys_spu_image> img, vm::ptr<sys_spu_segment> segments, s32 nseg);

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -7,7 +7,7 @@
 #include "Utilities/asm.h"
 #include "Emu/CPU/CPUThread.h"
 #include "Emu/Cell/lv2/sys_memory.h"
-#include "Emu/RSX/GSRender.h"
+#include "Emu/RSX/RSXThread.h"
 #include <atomic>
 #include <thread>
 #include <deque>
@@ -347,7 +347,7 @@ namespace vm
 		// Notify rsx that range has become valid
 		// Note: This must be done *before* memory gets mapped while holding the vm lock, otherwise
 		//       the RSX might try to invalidate memory that got unmapped and remapped
-		if (const auto rsxthr = fxm::check_unlocked<GSRender>())
+		if (const auto rsxthr = rsx::get_current_renderer())
 		{
 			rsxthr->on_notify_memory_mapped(addr, size);
 		}
@@ -476,7 +476,7 @@ namespace vm
 		// Notify rsx to invalidate range
 		// Note: This must be done *before* memory gets unmapped while holding the vm lock, otherwise
 		//       the RSX might try to call VirtualProtect on memory that is already unmapped
-		if (const auto rsxthr = fxm::check_unlocked<GSRender>())
+		if (const auto rsxthr = rsx::get_current_renderer())
 		{
 			rsxthr->on_notify_memory_unmapped(addr, size);
 		}

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -892,7 +892,7 @@ namespace vm
 
 	static std::shared_ptr<block_t> _find_map(u32 size, u32 align, u64 flags)
 	{
-		for (u32 addr = ::align<u32>(0x20000000, align); addr < 0xC0000000; addr += align)
+		for (u32 addr = ::align<u32>(0x10000000, align); addr < 0xC0000000; addr += align)
 		{
 			if (_test_map(addr, size))
 			{
@@ -995,7 +995,7 @@ namespace vm
 		return nullptr;
 	}
 
-	std::shared_ptr<block_t> get(memory_location_t location, u32 addr, u32 area_size)
+	std::shared_ptr<block_t> get(memory_location_t location, u32 addr, u32 area_size, u64 flags)
 	{
 		vm::reader_lock lock;
 
@@ -1038,7 +1038,7 @@ namespace vm
 		if (area_size)
 		{
 			lock.upgrade();
-			return _map(addr, area_size, 0x200);
+			return _map(addr, area_size, flags);
 		}
 
 		return nullptr;
@@ -1050,8 +1050,8 @@ namespace vm
 		{
 			g_locations =
 			{
-				std::make_shared<block_t>(0x00010000, 0x1FFF0000, 0x200), // main
-				std::make_shared<block_t>(0x20000000, 0x10000000, 0x201), // user 64k pages
+				std::make_shared<block_t>(0x00010000, 0x0FFF0000, 0x200), // main
+				nullptr, // user 64k pages
 				nullptr, // user 1m pages
 				std::make_shared<block_t>(0xC0000000, 0x10000000), // video
 				std::make_shared<block_t>(0xD0000000, 0x10000000, 0x111), // stack

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -715,7 +715,7 @@ namespace vm
 			shm = std::make_shared<utils::shm>(size);
 
 		// Search for an appropriate place (unoptimized)
-		for (u32 addr = ::align(this->addr, align); addr < this->addr + this->size - 1; addr += align)
+		for (u32 addr = ::align(this->addr, align), max = this->addr + this->size - size; addr <= max; addr += align)
 		{
 			if (try_alloc(addr, pflags, size, std::move(shm)))
 			{

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -189,7 +189,7 @@ namespace vm
 	std::shared_ptr<block_t> unmap(u32 addr, bool must_be_empty = false);
 
 	// Get memory block associated with optionally specified memory location or optionally specified address
-	std::shared_ptr<block_t> get(memory_location_t location, u32 addr = 0, u32 area_size = 0);
+	std::shared_ptr<block_t> get(memory_location_t location, u32 addr = 0, u32 area_size = 0, u64 flags = 0x200);
 
 	// Get PS3/PSV virtual memory address from the provided pointer (nullptr always converted to 0)
 	inline vm::addr_t get_addr(const void* real_ptr)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1466,7 +1466,7 @@ void Emulator::Resume()
 
 		std::string dump;
 
-		for (u32 i = 0x10000; i < 0x20000000;)
+		for (u32 i = 0x10000; i < 0x10000000;)
 		{
 			if (vm::check_addr(i))
 			{


### PR DESCRIPTION
This fixes the following:
* Fixes vm::user64 base address. see https://github.com/RPCS3/rpcs3/pull/4975#issuecomment-412866301
* Fixes ".rsx_image" section page flags.

Fixes #5812, hopefully this would be the last time vm addresses are touched.
First commit ensures lv2_dir fd would be closed once at max.