### PR TITLE
Fix compiling for MSVC + CMake

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -91,6 +91,10 @@ if(CMAKE_SYSTEM MATCHES "DragonFly|FreeBSD")
 	# Always use system libusb as reference implementation isn't supported
 	add_library(usb-1.0-static INTERFACE)
 	target_link_libraries(usb-1.0-static INTERFACE usb)
+elseif(MSVC)
+	# Windows time.h defines timespec but doesn't add any flag for it, which makes libusb attempt to define it again
+	add_definitions(-DHAVE_STRUCT_TIMESPEC=1)
+	add_subdirectory(libusb EXCLUDE_FROM_ALL)
 else()
 	add_subdirectory(libusb EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
Libusb wants to be a special snowflake and use timespec without including time.h, so it defines it as follows:
```c++
// We *were* getting timespec from pthread.h:
#if (!defined(HAVE_STRUCT_TIMESPEC) && !defined(_TIMESPEC_DEFINED))
#define HAVE_STRUCT_TIMESPEC 1
#define _TIMESPEC_DEFINED 1
struct timespec {
	long tv_sec;
	long tv_nsec;
};
#endif /* HAVE_STRUCT_TIMESPEC | _TIMESPEC_DEFINED */
```

However, the windows version of time.h doesn't define HAVE_STRUCT_TIMESPEC or _TIMESPEC_DEFINED even though it defines the timespec struct. Because neither of these flags is set libusb tries to define the struct again which then causes compiling to fail.

My proposal is to define HAVE_STRUCT_TIMESPEC for MSVC, which causes the `#if` to be false and thus make libusb skip the definition. This should only affect people who use CMake with MSVC, so a very tiny minority.