### PR TITLE
 TSX: expand timestamp cache lines space (Not Ready)

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1053,8 +1053,8 @@ const auto ppu_stwcx_tx = build_function_asm<bool(*)(u32 raddr, u64 rtime, u64 r
 	c.mov(x86::rax, imm_ptr(&vm::g_base_addr));
 	c.mov(x86::r11, x86::qword_ptr(x86::rax));
 	c.lea(x86::r11, x86::qword_ptr(x86::r11, args[0]));
-	c.shr(args[0], 7);
-	c.lea(x86::r10, x86::qword_ptr(x86::r10, args[0], 3));
+	c.and_(args[0], (u32)-128u);
+	c.lea(x86::r10, x86::qword_ptr(x86::r10, args[0]));
 	c.bswap(args[2].r32());
 	c.bswap(args[3].r32());
 	c.mov(args[0].r32(), 5);
@@ -1078,11 +1078,9 @@ const auto ppu_stwcx_tx = build_function_asm<bool(*)(u32 raddr, u64 rtime, u64 r
 	c.sar(x86::eax, 24);
 	c.js(fail);
 	c.xor_(x86::r11, 0xf80);
-	c.xor_(x86::r10, 0xf80);
+	c.add(x86::dword_ptr(x86::r10, 124), 0);
 	c.lock().add(x86::dword_ptr(x86::r11), 0);
-	c.lock().add(x86::qword_ptr(x86::r10), 0);
 	c.xor_(x86::r11, 0xf80);
-	c.xor_(x86::r10, 0xf80);
 	c.jmp(begin);
 
 	c.bind(fail);
@@ -1151,8 +1149,8 @@ const auto ppu_stdcx_tx = build_function_asm<bool(*)(u32 raddr, u64 rtime, u64 r
 	c.mov(x86::rax, imm_ptr(&vm::g_base_addr));
 	c.mov(x86::r11, x86::qword_ptr(x86::rax));
 	c.lea(x86::r11, x86::qword_ptr(x86::r11, args[0]));
-	c.shr(args[0], 7);
-	c.lea(x86::r10, x86::qword_ptr(x86::r10, args[0], 3));
+	c.and_(args[0], (u32)-128u);
+	c.lea(x86::r10, x86::qword_ptr(x86::r10, args[0]));
 	c.bswap(args[2]);
 	c.bswap(args[3]);
 	c.mov(args[0].r32(), 5);
@@ -1176,11 +1174,9 @@ const auto ppu_stdcx_tx = build_function_asm<bool(*)(u32 raddr, u64 rtime, u64 r
 	c.sar(x86::eax, 24);
 	c.js(fail);
 	c.xor_(x86::r11, 0xf80);
-	c.xor_(x86::r10, 0xf80);
+	c.add(x86::dword_ptr(x86::r10, 124), 0);
 	c.lock().add(x86::qword_ptr(x86::r11), 0);
-	c.lock().add(x86::qword_ptr(x86::r10), 0);
 	c.xor_(x86::r11, 0xf80);
-	c.xor_(x86::r10, 0xf80);
 	c.jmp(begin);
 
 	c.bind(fail);

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1164,7 +1164,6 @@ void spu_recompiler::get_events()
 		c->bind(rcheck);
 		c->mov(qw1->r32(), *addr);
 		c->mov(*qw0, imm_ptr(vm::g_reservations));
-		c->shr(qw1->r32(), 4);
 		c->mov(*qw0, x86::qword_ptr(*qw0, *qw1));
 		c->and_(qw0->r64(), (u64)(~1ull));
 		c->cmp(*qw0, SPU_OFF_64(rtime));

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -510,7 +510,7 @@ public:
 	static const u32 id_step = 1;
 	static const u32 id_count = 2048;
 
-	spu_thread(vm::addr_t ls, lv2_spu_group* group, u32 index, std::string_view name);
+	spu_thread(vm::addr_t _ls, lv2_spu_group* group, u32 index, std::string_view name);
 
 	u32 pc = 0;
 
@@ -569,6 +569,7 @@ public:
 
 	const u32 index; // SPU index
 	const u32 offset; // SPU LS offset
+	u8* const ls; // SPU LS direct pointer
 	lv2_spu_group* const group; // SPU Thread Group
 
 	lf_value<std::string> spu_name; // Thread name
@@ -605,7 +606,7 @@ public:
 	template<typename T>
 	inline to_be_t<T>* _ptr(u32 lsa)
 	{
-		return static_cast<to_be_t<T>*>(vm::base(offset + lsa));
+		return reinterpret_cast<to_be_t<T>*>(ls + lsa);
 	}
 
 	// Convert specified SPU LS address to a reference of specified (possibly converted to BE) type


### PR DESCRIPTION
Before this change one cache line in reservations table contained 8 timestamps of different virtual memory chache line, this means that nearby data (1024 bytes!) which is very common to have can collide into each others transactions and lead to high abortions rate and slower atomic commands execution on TSX path.
This change make it that one entry on timestamp table will handle one virtual memory cache line.

What this means?

- Faster TSX transcations with reduced chance to collide.
- Reduced RAM usage, allocate only necessary entries on reservation data. 