### PR TITLE
Fix unregistered HLE function access on PPU LLVM, Fix PPU breakpoints

### DIFF
--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -2524,7 +2524,7 @@ std::vector<ppu_function_t>& ppu_function_manager::access()
 		{
 			LOG_ERROR(PPU, "Unregistered function called (LR=0x%x)", ppu.lr);
 			ppu.gpr[3] = 0;
-			ppu.cia += 4;
+			ppu.cia = (u32)ppu.lr & ~3;
 			return false;
 		},
 		[](ppu_thread& ppu) -> bool

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -252,7 +252,7 @@ static bool ppu_check_toc(ppu_thread& ppu, ppu_opcode_t op)
 	}
 
 	// Fallback to the interpreter function
-	if (reinterpret_cast<decltype(&ppu_interpreter::UNK)>(std::uintptr_t{ppu_cache(ppu.cia)})(ppu, op))
+	if (reinterpret_cast<decltype(&ppu_interpreter::UNK)>(std::uintptr_t{(u32)ppu_cache(ppu.cia)})(ppu, op))
 	{
 		ppu.cia += 4;
 	}
@@ -336,7 +336,7 @@ static bool ppu_break(ppu_thread& ppu, ppu_opcode_t op)
 	}
 
 	// Fallback to the interpreter function
-	if (reinterpret_cast<decltype(&ppu_interpreter::UNK)>(std::uintptr_t{ppu_cache(ppu.cia)})(ppu, op))
+	if (reinterpret_cast<decltype(&ppu_interpreter::UNK)>(std::uintptr_t{(u32)ppu_cache(ppu.cia)})(ppu, op))
 	{
 		ppu.cia += 4;
 	}


### PR DESCRIPTION
Do not continue to BLR in unknown HLE function access in PPU LLVM, opcode was unregistered, Fixes MGS Peace Walker with PPU LLVM.
Fixes segfaults with PPU interpreter breakpoints after #5749.