### PR TITLE
misc: Lower default perf overlay detail

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -478,7 +478,7 @@ struct cfg_root : cfg::node
 			node_perf_overlay(cfg::node* _this) : cfg::node(_this, "Performance Overlay") {}
 
 			cfg::_bool perf_overlay_enabled{this, "Enabled", false};
-			cfg::_enum<detail_level> level{this, "Detail level", detail_level::high};
+			cfg::_enum<detail_level> level{this, "Detail level", detail_level::medium};
 			cfg::_int<30, 5000> update_interval{ this, "Metrics update interval (ms)", 350 };
 			cfg::_int<4, 36> font_size{ this, "Font size (px)", 10 };
 			cfg::_enum<screen_quadrant> position{this, "Position", screen_quadrant::top_left};


### PR DESCRIPTION
Because RSX Guest utilization confuses people and is mostly only meaningful for debugging.