### PR TITLE
RADV fix

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -81,9 +81,9 @@ namespace vk
 					break;
 				case vk::driver_vendor::AMD:
 				case vk::driver_vendor::RADV:
-					unroll_loops = false;
-					optimal_kernel_size = 1;
-					optimal_group_size = 64;
+					unroll_loops = true;
+					optimal_group_size = 32;
+					optimal_kernel_size = 16;
 					break;
 				}
 


### PR DESCRIPTION
I'm using a RX580 on Linux with the RADV driver. When using Vulkan, in some games walking into new areas causes missing textures until they're cached. So I see things like invisible walls, characters that are just black textures, etc.

This seems to last an unreasonably long time, seeing as this either doesn't happen on OpenGL, or the cache happens extremely faster.  (Yes I've deleted the cache inbetween tests.)

I edited VKCompute.h here https://github.com/RPCS3/rpcs3/blob/master/rpcs3/Emu/RSX/VK/VKCompute.h

I just matched the config you have for Nvidia cards like this

```
				switch (vk::get_driver_vendor())
				{
				case vk::driver_vendor::unknown:
					// Probably intel
				case vk::driver_vendor::NVIDIA:
					unroll_loops = true;
					optimal_group_size = 32;
					optimal_kernel_size = 16;
					break;
				case vk::driver_vendor::AMD:
				case vk::driver_vendor::RADV:
					unroll_loops = true;
					optimal_kernel_size = 16;
					optimal_group_size = 32;
					break;
				}
```

Recompiled and the problem is gone. Missing textures in areas of games that I would use to test that were always reproducible are now not a problem, they load in without any invisible walls, black textures, etc. 

I'm not sure how long ago this code was added, but it's likely RADV is much more mature than when it was, please consider.