### PR TITLE
PPU Precise: FPCC handling on float ops implemented

### DIFF
--- a/Utilities/GDBDebugServer.cpp
+++ b/Utilities/GDBDebugServer.cpp
@@ -354,7 +354,7 @@ std::string GDBDebugServer::get_reg(std::shared_ptr<ppu_thread> thread, u32 rid)
 	case 65:
 		return std::string(16, 'x');
 	case 66:
-		return u32_to_padded_hex(thread->cr_pack());
+		return u32_to_padded_hex(thread->cr.pack());
 	case 67:
 		return u64_to_padded_hex(thread->lr);
 	case 68:
@@ -368,7 +368,7 @@ std::string GDBDebugServer::get_reg(std::shared_ptr<ppu_thread> thread, u32 rid)
 	default:
 		if (rid > 70) return "";
 		return (rid > 31)
-			? u64_to_padded_hex(reinterpret_cast<u64&>(thread->fpr[rid - 32])) //fpr
+			? u64_to_padded_hex(std::bit_cast<u64>(thread->fpr[rid - 32])) //fpr
 			: u64_to_padded_hex(thread->gpr[rid]); //gpr
 	}
 }
@@ -383,7 +383,7 @@ bool GDBDebugServer::set_reg(std::shared_ptr<ppu_thread> thread, u32 rid, std::s
 	case 65:
 		return true;
 	case 66:
-		thread->cr_unpack(hex_to_u32(value));
+		thread->cr.unpack(hex_to_u32(value));
 		return true;
 	case 67:
 		thread->lr = hex_to_u64(value);
@@ -401,7 +401,7 @@ bool GDBDebugServer::set_reg(std::shared_ptr<ppu_thread> thread, u32 rid, std::s
 		if (rid > 70) return false;
 		if (rid > 31) {
 			u64 val = hex_to_u64(value);
-			thread->fpr[rid - 32] = reinterpret_cast<f64&>(val);
+			thread->fpr[rid - 32] = std::bit_cast<f64>(val);
 		} else {
 			thread->gpr[rid] = hex_to_u64(value);
 		}

--- a/rpcs3/Emu/Cell/PPUInterpreter.h
+++ b/rpcs3/Emu/Cell/PPUInterpreter.h
@@ -310,16 +310,6 @@ struct ppu_interpreter
 	static bool LWA(ppu_thread&, ppu_opcode_t);
 	static bool STD(ppu_thread&, ppu_opcode_t);
 	static bool STDU(ppu_thread&, ppu_opcode_t);
-	static bool FDIVS(ppu_thread&, ppu_opcode_t);
-	static bool FSUBS(ppu_thread&, ppu_opcode_t);
-	static bool FADDS(ppu_thread&, ppu_opcode_t);
-	static bool FSQRTS(ppu_thread&, ppu_opcode_t);
-	static bool FRES(ppu_thread&, ppu_opcode_t);
-	static bool FMULS(ppu_thread&, ppu_opcode_t);
-	static bool FMADDS(ppu_thread&, ppu_opcode_t);
-	static bool FMSUBS(ppu_thread&, ppu_opcode_t);
-	static bool FNMSUBS(ppu_thread&, ppu_opcode_t);
-	static bool FNMADDS(ppu_thread&, ppu_opcode_t);
 	static bool MTFSB1(ppu_thread&, ppu_opcode_t);
 	static bool MCRFS(ppu_thread&, ppu_opcode_t);
 	static bool MTFSB0(ppu_thread&, ppu_opcode_t);
@@ -327,20 +317,9 @@ struct ppu_interpreter
 	static bool MFFS(ppu_thread&, ppu_opcode_t);
 	static bool MTFSF(ppu_thread&, ppu_opcode_t);
 	static bool FCMPU(ppu_thread&, ppu_opcode_t);
-	static bool FRSP(ppu_thread&, ppu_opcode_t);
 	static bool FCTIW(ppu_thread&, ppu_opcode_t);
 	static bool FCTIWZ(ppu_thread&, ppu_opcode_t);
-	static bool FDIV(ppu_thread&, ppu_opcode_t);
-	static bool FSUB(ppu_thread&, ppu_opcode_t);
-	static bool FADD(ppu_thread&, ppu_opcode_t);
-	static bool FSQRT(ppu_thread&, ppu_opcode_t);
 	static bool FSEL(ppu_thread&, ppu_opcode_t);
-	static bool FMUL(ppu_thread&, ppu_opcode_t);
-	static bool FRSQRTE(ppu_thread&, ppu_opcode_t);
-	static bool FMSUB(ppu_thread&, ppu_opcode_t);
-	static bool FMADD(ppu_thread&, ppu_opcode_t);
-	static bool FNMSUB(ppu_thread&, ppu_opcode_t);
-	static bool FNMADD(ppu_thread&, ppu_opcode_t);
 	static bool FCMPO(ppu_thread&, ppu_opcode_t);
 	static bool FNEG(ppu_thread&, ppu_opcode_t);
 	static bool FMR(ppu_thread&, ppu_opcode_t);
@@ -394,6 +373,29 @@ struct ppu_interpreter_precise final : ppu_interpreter
 	static bool VSUM4UBS(ppu_thread&, ppu_opcode_t);
 	static bool VCTSXS(ppu_thread&, ppu_opcode_t);
 	static bool VCTUXS(ppu_thread&, ppu_opcode_t);
+
+	static bool FDIVS(ppu_thread&, ppu_opcode_t);
+	static bool FSUBS(ppu_thread&, ppu_opcode_t);
+	static bool FADDS(ppu_thread&, ppu_opcode_t);
+	static bool FSQRTS(ppu_thread&, ppu_opcode_t);
+	static bool FRES(ppu_thread&, ppu_opcode_t);
+	static bool FMULS(ppu_thread&, ppu_opcode_t);
+	static bool FMADDS(ppu_thread&, ppu_opcode_t);
+	static bool FMSUBS(ppu_thread&, ppu_opcode_t);
+	static bool FNMSUBS(ppu_thread&, ppu_opcode_t);
+	static bool FNMADDS(ppu_thread&, ppu_opcode_t);
+
+	static bool FRSP(ppu_thread&, ppu_opcode_t);
+	static bool FDIV(ppu_thread&, ppu_opcode_t);
+	static bool FSUB(ppu_thread&, ppu_opcode_t);
+	static bool FADD(ppu_thread&, ppu_opcode_t);
+	static bool FSQRT(ppu_thread&, ppu_opcode_t);
+	static bool FMUL(ppu_thread&, ppu_opcode_t);
+	static bool FRSQRTE(ppu_thread&, ppu_opcode_t);
+	static bool FMSUB(ppu_thread&, ppu_opcode_t);
+	static bool FMADD(ppu_thread&, ppu_opcode_t);
+	static bool FNMSUB(ppu_thread&, ppu_opcode_t);
+	static bool FNMADD(ppu_thread&, ppu_opcode_t);
 };
 
 struct ppu_interpreter_fast final : ppu_interpreter
@@ -437,4 +439,27 @@ struct ppu_interpreter_fast final : ppu_interpreter
 	static bool VSUM4UBS(ppu_thread&, ppu_opcode_t);
 	static bool VCTSXS(ppu_thread&, ppu_opcode_t);
 	static bool VCTUXS(ppu_thread&, ppu_opcode_t);
+
+	static bool FDIVS(ppu_thread&, ppu_opcode_t);
+	static bool FSUBS(ppu_thread&, ppu_opcode_t);
+	static bool FADDS(ppu_thread&, ppu_opcode_t);
+	static bool FSQRTS(ppu_thread&, ppu_opcode_t);
+	static bool FRES(ppu_thread&, ppu_opcode_t);
+	static bool FMULS(ppu_thread&, ppu_opcode_t);
+	static bool FMADDS(ppu_thread&, ppu_opcode_t);
+	static bool FMSUBS(ppu_thread&, ppu_opcode_t);
+	static bool FNMSUBS(ppu_thread&, ppu_opcode_t);
+	static bool FNMADDS(ppu_thread&, ppu_opcode_t);
+
+	static bool FRSP(ppu_thread&, ppu_opcode_t);
+	static bool FDIV(ppu_thread&, ppu_opcode_t);
+	static bool FSUB(ppu_thread&, ppu_opcode_t);
+	static bool FADD(ppu_thread&, ppu_opcode_t);
+	static bool FSQRT(ppu_thread&, ppu_opcode_t);
+	static bool FMUL(ppu_thread&, ppu_opcode_t);
+	static bool FRSQRTE(ppu_thread&, ppu_opcode_t);
+	static bool FMSUB(ppu_thread&, ppu_opcode_t);
+	static bool FMADD(ppu_thread&, ppu_opcode_t);
+	static bool FNMSUB(ppu_thread&, ppu_opcode_t);
+	static bool FNMADD(ppu_thread&, ppu_opcode_t);
 };

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -58,9 +58,10 @@ public:
 	f64 fpr[32] = {}; // Floating Point Registers
 	v128 vr[32] = {}; // Vector Registers
 
-	struct cr_bits
+	union alignas(16) cr_bits
 	{
-		alignas(16) u8 bits[32];
+		u8 bits[32];
+		u32 fields[8];
 
 		u8& operator [](std::size_t i)
 		{
@@ -108,6 +109,7 @@ public:
 			bool _end[12];
 		};
 
+		u32 fields[8];
 		cr_bits bits;
 	}
 	fpscr{};

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -31,10 +31,7 @@ error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sy
 
 	const u32 protocol = attr->protocol;
 
-	if (protocol == SYS_SYNC_PRIORITY_INHERIT)
-		sys_semaphore.warning("sys_semaphore_create(): SYS_SYNC_PRIORITY_INHERIT");
-
-	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_PRIORITY && protocol != SYS_SYNC_PRIORITY_INHERIT)
+	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_PRIORITY)
 	{
 		sys_semaphore.error("sys_semaphore_create(): unknown protocol (0x%x)", protocol);
 		return CELL_EINVAL;


### PR DESCRIPTION
This adds missing FPCC tests on floting-point ops for ppu precise, and optimizes existing tests for ppu interpreters.

Also improve error checking of sys_semaphore_create: Return EINVAL on SYS_SYNC_PRIORITY_INHERIT protocol.