### PR TITLE
Print Operating System version to log

### DIFF
--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -602,6 +602,17 @@ logs::file_listener::file_listener(const std::string& name)
 	file_writer::log(logs::level::always, ver.text.data(), ver.text.size());
 	file_writer::log(logs::level::always, "\n", 1);
 	messages.emplace_back(std::move(ver));
+
+	// Write OS version
+	stored_message os;
+	os.m.ch  = nullptr;
+	os.m.sev = level::notice;
+	os.stamp = 0;
+	os.text = utils::get_OS_version();
+
+	file_writer::log(logs::level::notice, os.text.data(), os.text.size());
+	file_writer::log(logs::level::notice, "\n", 1);
+	messages.emplace_back(std::move(os));
 }
 
 void logs::file_listener::log(u64 stamp, const logs::message& msg, const std::string& prefix, const std::string& _text)

--- a/Utilities/sysinfo.h
+++ b/Utilities/sysinfo.h
@@ -46,4 +46,6 @@ namespace utils
 	std::string get_system_info();
 
 	std::string get_firmware_version();
+
+	std::string get_OS_version();
 }


### PR DESCRIPTION
The idea behind this is to get some more data about the operating system RPCS3 is ran on, so that issues like #5621 and #5799 we could potentially determine which system updates are causing issues. I also added an implementation for Linux/BSD/Mac, maybe that will prove useful some day. Also includes a check for compatibility modes, in case someone decides to use one for any reason.