### PR TITLE
cellPad: Update vendor and product IDs

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -580,20 +580,41 @@ error_code cellPadGetInfo(vm::ptr<CellPadInfo> info)
 		pads[i]->m_port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES; // TODO: should ASSIGN flags be cleared here?
 		info->status[i] = pads[i]->m_port_status;
 
+		// TODO: Allow selecting different product IDs
 		switch (pads[i]->m_class_type)
 		{
 		case CELL_PAD_PCLASS_TYPE_GUITAR:
-			// Guitar Hero Guitar
+			// Sony Computer Entertainment America
 			info->vendor_id[i] = 0x12BA;
-			info->product_id[i] = 0x0200;
+			// RedOctane Guitar (Guitar Hero)
+			info->product_id[i] = 0x0100;
+			// Harmonix Guitar (Rock Band)
+			// info->product_id[i] = 0x0200;
 			break;
 		case CELL_PAD_PCLASS_TYPE_DRUM:
-			// Guitar Hero Drum
+			// Sony Computer Entertainment America
 			info->vendor_id[i] = 0x12BA;
-			info->product_id[i] = 0x0210;
+			// RedOctane Drum Kit (Guitar Hero)
+			info->product_id[i] = 0x0120;
+			// Harmonix Drum Kit (Rock Band)
+			// info->product_id[i] = 0x0210;
+			break;
+		case CELL_PAD_PCLASS_TYPE_DJ:
+			// Sony Computer Entertainment America
+			info->vendor_id[i] = 0x12BA;
+			// DJ Hero Turntable
+			info->product_id[i] = 0x0140;
+			break;
+		case CELL_PAD_PCLASS_TYPE_DANCEMAT:
+			// Konami Digital Entertainment
+			info->vendor_id[i] = 0x1CCF;
+			// Dance Dance Revolution Mat
+			info->product_id[i] = 0x0140;
 			break;
 		default:
+			// Sony Corp.
 			info->vendor_id[i] = 0x054C;
+			// PlayStation 3 Controller
 			info->product_id[i] = 0x0268;
 			break;
 		}


### PR DESCRIPTION
- Used IDs were not from the Guitar Hero instruments but in fact from the Rock Band ones. Sets the correct Guitar Hero IDs and adds the Rock Band ones on comments. TODO: Allow selecting the specific devices on the PAD Settings.
- Adds DJ Hero Turntable VID/PID.
- Adds Dance Dance Revolution Mat VID/PID.

--- 

Documentation:

- [USB vendor list](https://usb-ids.gowdy.us/read/UD/12ba) shows 0x12BA is Sony Computer Entertainment America and contains the list of known devices
- HIDRAW contains the Vendor and Product IDs for the Dance Dance Revolution Mat on
https://github.com/Orochimarufan/HIDRAW/blob/master/usb_ddrpad/Devices/konami_ps3.h#L26
- Turntable IDs were checked on the turntable itself