### PR TITLE
PPU/LV2: Make thread-lists scheduling atomic

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -228,7 +228,7 @@ error_code cellMsgDialogOpen2(u32 type, vm::cptr<char> msgString, vm::ptr<CellMs
 	Emu.CallAfter([&]()
 	{
 		dlg->Create(msgString.get_ptr());
-		lv2_obj::awake(ppu);
+		lv2_obj::awake(&ppu);
 	});
 
 	while (!ppu.state.test_and_reset(cpu_flag::signal))

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -615,7 +615,7 @@ void ppu_thread::cpu_task()
 void ppu_thread::cpu_sleep()
 {
 	vm::temporary_unlock(*this);
-	lv2_obj::awake(*this);
+	lv2_obj::awake(this);
 }
 
 void ppu_thread::cpu_mem()

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "sys_event_flag.h"
 
 #include "Emu/System.h"
@@ -310,7 +310,7 @@ error_code sys_event_flag_set(u32 id, u64 bitptn)
 			if (ppu.gpr[3] == CELL_OK)
 			{
 				flag->waiters--;
-				flag->awake(ppu);
+				flag->append(cpu);
 				return true;
 			}
 
@@ -318,6 +318,7 @@ error_code sys_event_flag_set(u32 id, u64 bitptn)
 		});
 
 		flag->sq.erase(tail, flag->sq.end());
+		lv2_obj::awake_all();
 	}
 
 	return CELL_OK;
@@ -376,8 +377,10 @@ error_code sys_event_flag_cancel(ppu_thread& ppu, u32 id, vm::ptr<u32> num)
 			ppu.gpr[6] = pattern;
 
 			flag->waiters--;
-			flag->awake(ppu);
+			flag->append(thread);
 		}
+
+		lv2_obj::awake_all();
 	}
 
 	if (ppu.test_stopped())

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -212,7 +212,7 @@ error_code _sys_lwmutex_unlock(ppu_thread& ppu, u32 lwmutex_id)
 
 	if (mutex.ret)
 	{
-		mutex->awake(*mutex.ret);
+		mutex->awake(mutex.ret);
 	}
 
 	return CELL_OK;
@@ -245,7 +245,7 @@ error_code _sys_lwmutex_unlock2(ppu_thread& ppu, u32 lwmutex_id)
 
 	if (mutex.ret)
 	{
-		mutex->awake(*mutex.ret);
+		mutex->awake(mutex.ret);
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -237,7 +237,7 @@ error_code sys_mutex_unlock(ppu_thread& ppu, u32 mutex_id)
 
 		if (auto cpu = mutex->reown<ppu_thread>())
 		{
-			mutex->awake(*cpu);
+			mutex->awake(cpu);
 		}
 	}
 	else if (mutex.ret)

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -203,8 +203,10 @@ extern void network_thread_init()
 			for (ppu_thread* ppu : s_to_awake)
 			{
 				network_clear_queue(*ppu);
-				lv2_obj::awake(*ppu);
+				lv2_obj::append(ppu);
 			}
+
+			lv2_obj::awake_all();
 
 			s_to_awake.clear();
 			socklist.clear();
@@ -309,7 +311,7 @@ s32 sys_net_bnet_accept(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr> addr, 
 
 				if (native_socket != -1 || (result = get_last_error(!sock.so_nbio)))
 				{
-					lv2_obj::awake(ppu);
+					lv2_obj::awake(&ppu);
 					return true;
 				}
 			}
@@ -532,7 +534,7 @@ s32 sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr> addr,
 					result = native_error ? get_last_error(false, native_error) : 0;
 				}
 
-				lv2_obj::awake(ppu);
+				lv2_obj::awake(&ppu);
 				return true;
 			}
 
@@ -946,7 +948,7 @@ s32 sys_net_bnet_recvfrom(ppu_thread& ppu, s32 s, vm::ptr<void> buf, u32 len, s3
 
 				if (native_result >= 0 || (result = get_last_error(!sock.so_nbio && (flags & SYS_NET_MSG_DONTWAIT) == 0)))
 				{
-					lv2_obj::awake(ppu);
+					lv2_obj::awake(&ppu);
 					return true;
 				}
 			}
@@ -1115,7 +1117,7 @@ s32 sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 len, s32
 
 				if (native_result >= 0 || (result = get_last_error(!sock.so_nbio && (flags & SYS_NET_MSG_DONTWAIT) == 0)))
 				{
-					lv2_obj::awake(ppu);
+					lv2_obj::awake(&ppu);
 					return true;
 				}
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -49,7 +49,7 @@ void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode)
 		std::lock_guard lock(id_manager::g_mutex);
 
 		// Schedule joiner and unqueue
-		lv2_obj::awake(*idm::check_unlocked<named_thread<ppu_thread>>(jid), -2);
+		lv2_obj::awake(idm::check_unlocked<named_thread<ppu_thread>>(jid), -2);
 	}
 
 	// Unqueue
@@ -63,7 +63,7 @@ void sys_ppu_thread_yield(ppu_thread& ppu)
 {
 	sys_ppu_thread.trace("sys_ppu_thread_yield()");
 
-	lv2_obj::awake(ppu, -4);
+	lv2_obj::yield(ppu);
 }
 
 error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr)
@@ -219,7 +219,7 @@ error_code sys_ppu_thread_set_priority(ppu_thread& ppu, u32 thread_id, s32 prio)
 	{
 		if (thread.prio != prio)
 		{
-			lv2_obj::awake(thread, prio);
+			lv2_obj::awake(&thread, prio);
 		}
 	});
 
@@ -359,7 +359,7 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 
 	const auto thread = idm::get<named_thread<ppu_thread>>(thread_id, [&](ppu_thread& thread)
 	{
-		lv2_obj::awake(thread, -2);
+		lv2_obj::awake(&thread, -2);
 	});
 
 	if (!thread)

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "sys_semaphore.h"
 
 #include "Emu/System.h"
@@ -242,8 +242,10 @@ error_code sys_semaphore_post(ppu_thread& ppu, u32 sem_id, s32 count)
 		// Wake threads
 		for (s32 i = std::min<s32>(-std::min<s32>(val, 0), count); i > 0; i--)
 		{
-			sem->awake(*verify(HERE, sem->schedule<ppu_thread>(sem->sq, sem->protocol)));
+			sem->append(verify(HERE, sem->schedule<ppu_thread>(sem->sq, sem->protocol)));
 		}
+
+		lv2_obj::awake_all();
 	}
 
 	return CELL_OK;


### PR DESCRIPTION
Fixes temporary awakening wrong threads with awake threads-list with FIFO protocol (because it doesn't match with the native priority protocol of the scheduler).
Fixes state fragmentation of running threads queue state at the time of beginning to end of thread list wakeup.
Matches with the kernel.