### PR TITLE
Touch-ups to Skyline and Envy

### DIFF
--- a/bin/GuiConfigs/Envy.qss
+++ b/bin/GuiConfigs/Envy.qss
@@ -39,18 +39,22 @@ QToolTip {
 }
 
 /* Table Headers */
+QHeaderView {
+	border: none;
+	border-bottom: 1px solid #8cf944;
+}
+
 QHeaderView::section {
 	background-color: #23262d;
 	color: #f8f8f8;
 	padding-top: 3px;
-	padding-left: 5px;	
+	padding-left: 3px;
 	height: 20px;
 	border: none;
 }
 
-QHeaderView {
-	border: none;
-	border-bottom: 1px solid #8cf944;
+QHeaderView::section:first {
+	padding-left: 5px;
 }
 
 /* Tabs */

--- a/bin/GuiConfigs/Envy.qss
+++ b/bin/GuiConfigs/Envy.qss
@@ -256,7 +256,7 @@ QComboBox:disabled {
 
 /* Sliders */
 QSlider::groove:horizontal {
-	border: -5px solid #8cf944;
+	border: -3px solid transparent;
 	border-radius: 0.45em;
 	height: 8px;
 	background: #8cf944;

--- a/bin/GuiConfigs/Envy.qss
+++ b/bin/GuiConfigs/Envy.qss
@@ -42,16 +42,18 @@ QToolTip {
 QHeaderView::section {
 	background-color: #23262d;
 	color: #f8f8f8;
-	padding-left: 0.25em;
-	padding-top: 0.25em;
-	padding-bottom: 0.25em;
-	border: 1px solid #8cf944;
-	border-top: none;
-	border-left: none;
-	border-right: none;
+	padding-top: 3px;
+	padding-left: 5px;	
+	height: 20px;
+	border: none;
 }
 
-/* Settings Dialog: Tabs */
+QHeaderView {
+	border: none;
+	border-bottom: 1px solid #8cf944;
+}
+
+/* Tabs */
 QTabBar::tab {
 	color: #8cf944;
 	padding-left: 1.25em;
@@ -61,6 +63,14 @@ QTabBar::tab {
 	border: none;
 	min-width: 65px;
 	border-bottom: 1px solid #8cf944;
+}
+
+QTabWidget::pane {
+	border: none;
+}
+
+QTabWidget::tab-bar {
+	alignment: center;
 }
 
 QTabBar::tab:!selected {
@@ -94,6 +104,11 @@ QTabBar#tab_bar_settings::tab:selected {
 QTabBar#tab_bar_settings::tab:hover {
 	color: #b1f184;
 	border-bottom: 1px solid #8cf944;
+}
+
+/* Log Tabs */
+QTabWidget#tab_widget_log::tab-bar {
+	alignment: left;
 }
 
 QTabBar#tab_bar_log::tab:!selected {
@@ -134,7 +149,7 @@ QCheckBox::indicator:unchecked {
 	background-color: #000;
 }
 
-QCheckBox::indicator::disabled {
+QCheckBox::indicator:disabled {
 	background-color: #4d5058;
 }
 
@@ -189,7 +204,7 @@ QRadioButton::indicator:unchecked {
 	background-color: #000;
 }
 
-QRadioButton::indicator::disabled {
+QRadioButton::indicator:disabled {
 	background-color: #4d5058; 
 }
 
@@ -204,7 +219,7 @@ QComboBox {
 	min-height: 14px;
 }
 
-QComboBox::hover {
+QComboBox:hover {
 	color: #8cf944;
 	background-color: #2d3038;
 	border: 0.0625em solid #8cf944;
@@ -230,7 +245,7 @@ QComboBox::!selected {
 	padding-left: 0.25em;
 }
 
-QComboBox::disabled {
+QComboBox:disabled {
 	background-color: #4d5058;
 	color: #fff;
 }
@@ -242,6 +257,10 @@ QSlider::groove:horizontal {
 	height: 8px;
 	background: #8cf944;
 	margin: 1px;
+}
+
+QSlider::groove:horizontal:disabled {
+	background: #4d5058;
 }
 
 QSlider::handle:horizontal {
@@ -311,7 +330,7 @@ QPushButton:hover {
 	color: #8cf944;
 }
 
-QPushButton::disabled {
+QPushButton:disabled {
 	color: #999999;
 }
 
@@ -323,7 +342,7 @@ QPushButton::pressed {
 QSpinBox, QDoubleSpinBox {
 	border: 1px solid #999999;
 	padding: 2px;
-	color: #999999;
+	color: #FFFFFF;
 	border-radius: 2px;
 	background-color: transparent;
 }
@@ -370,11 +389,6 @@ QDockWidget::close-button, QDockWidget::float-button {
 	width: auto;
 }
 
-/* Disable Borders */
-QTabWidget::pane {
-	border: none;
-}
-
 /* Top Menu Bar */
 QMenuBar::item:selected {
 	margin-bottom: 0.125em;
@@ -417,6 +431,15 @@ QMenu::item:disabled {
 }
 
 /* Libraries List */
+QListWidget {
+	border: 1px solid #bdc3c7;
+	border-radius: 0.1em;
+}
+
+QListWidget:disabled {
+	border: 1px solid #4d5058;
+}
+
 QListWidget::item:selected {
 	background-color: #30333a;
 	color: #b1f184;
@@ -500,6 +523,10 @@ QToolBar {
 }
 
 /* Toolbar Buttons */
+QLabel#toolbar_icon_color {
+	color: #FFFFFF;
+}
+
 QToolButton {
 	background: transparent;
 	border-radius: 0em;
@@ -512,12 +539,12 @@ QToolButton {
 	border-bottom: 1px solid transparent;
 }
 
-QToolButton::disabled {
+QToolButton:disabled {
 	background-color: #30333a;
 	color: #f8f8f8;
 }
 
-QToolButton::hover {
+QToolButton:hover {
 	background-color: #2d3038;
 	color: #8cf944;
 	border-bottom: 1px solid #8cf944;
@@ -574,7 +601,7 @@ QLabel#log_level_warning {
 }
 
 QLabel#log_level_notice {
-	color: #ffffff;
+	color: #FFFFFF;
 }
 
 QLabel#log_level_trace {
@@ -585,43 +612,12 @@ QLabel#log_stack {
 	color: #3498d8;
 }
 
-/* Set TTY colors */
+/* TTY colors */
 QTextEdit#tty_frame {
 	background-color: #23262d;
 }
 
 QLabel#tty_text {
-	color: #FFFFFF;
-}
-
-/* RSX Debugger */
-QLabel#rsx_debugger_display_buffer {
-	background-color: #131313;
-}
-
-/* Kernel Explorer */
-QDialog#kernel_explorer {
-	background-color: #131313;
-}
-
-/* Memory Viewer */
-QDialog#memory_viewer {
-	background-color: #131313;
-	color: #FFF;
-}
-
-QLabel#memory_viewer_address_panel {
-	color: #8cf944;
-	background-color: #131313;
-}
-
-QLabel#memory_viewer_hex_panel {
-	color: #FFF;
-	background-color: #131313;
-}
-
-QLabel#memory_viewer_ascii_panel {
-	color: #FFF;
-	background-color: #131313;
+	color: #f8f8f8;
 }
 

--- a/bin/GuiConfigs/Envy.qss
+++ b/bin/GuiConfigs/Envy.qss
@@ -272,21 +272,17 @@ QSlider::handle:horizontal {
 	border: 1px solid #5c5c5c;
 	border-radius: 0.1em;
 	width: 18px;
-	margin: -2px 4; 
+	margin: -2px 2; 
 }
 
 QSlider::handle:horizontal:hover {
 	background: #23262d;
 	border: 1px solid #8cf944;
-	width: 18px;
-	margin: -2px 4; 
 }
 
 QSlider::handle:horizontal:pressed {
 	background: #30333a;
 	border: 1px solid #8cf944;
-	width: 18px;
-	margin: -2px 4; 
 }
 
 /* Progress Bar */

--- a/bin/GuiConfigs/Skyline (Nightfall).qss
+++ b/bin/GuiConfigs/Skyline (Nightfall).qss
@@ -541,20 +541,24 @@ QLabel#gamelist_icon_background_color {
 }
 
 /* Table Headers */
-QHeaderView::section {
-	background-color: #111525;
-	color: #FFFFFF;
-	padding-top: 3px;
-	padding-left: 5px;	
-	height: 20px;
-	border: none;
-}
-
 QHeaderView {
 	border: 1px solid qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #370048, stop: 0.5 #161249, stop: 1 #00364a);
 	border-left: none;
 	border-right: none;
 	border-top: none;
+}
+
+QHeaderView::section {
+	background-color: #111525;
+	color: #FFFFFF;
+	padding-top: 3px;
+	padding-left: 3px;	
+	height: 20px;
+	border: none;
+}
+
+QHeaderView::section:first {
+	padding-left: 5px;
 }
 
 /* Tooltips */

--- a/bin/GuiConfigs/Skyline (Nightfall).qss
+++ b/bin/GuiConfigs/Skyline (Nightfall).qss
@@ -404,9 +404,9 @@ QComboBox::item:!selected {
 }
 
 QComboBox::indicator{
-	background-color:transparent;
-	selection-background-color:transparent;
-	color:transparent;
+	background-color: transparent;
+	selection-background-color: transparent;
+	color: transparent;
 	selection-color: transparent;
 }
 
@@ -567,7 +567,7 @@ QToolTip {
 	color: #FFFFFF;
 	padding: 0.1em;
 	border: none;
-	opacity: 200;
+	opacity: 225;
 }
 
 /* Log and Debugger Borders */

--- a/bin/GuiConfigs/Skyline (Nightfall).qss
+++ b/bin/GuiConfigs/Skyline (Nightfall).qss
@@ -132,7 +132,7 @@ QSlider {
 }
 
 QSlider::groove:horizontal {
-	border: -5px solid #8cf944;
+	border: -3px solid transparent;
 	border-radius: 0.45em;
 	height: 8px;
 	background: #0074e7;
@@ -567,6 +567,7 @@ QToolTip {
 	color: #FFFFFF;
 	padding: 0.1em;
 	border: none;
+	opacity: 200;
 }
 
 /* Log and Debugger Borders */

--- a/bin/GuiConfigs/Skyline (Nightfall).qss
+++ b/bin/GuiConfigs/Skyline (Nightfall).qss
@@ -148,21 +148,17 @@ QSlider::handle:horizontal {
 	border: 1px solid #5c5c5c;
 	border-radius: 0.1em;
 	width: 18px;
-	margin: -2px 4; 
+	margin: -2px 2; 
 }
 
 QSlider::handle:horizontal:hover {
 	background: #111525;
 	border: 1px solid #0074e7;
-	width: 18px;
-	margin: -2px 4; 
 }
 
 QSlider::handle:horizontal:pressed {
 	border: 1px solid #0074e7;
 	background: #1c273d;
-	width: 18px;
-	margin: -2px 4; 
 }
 
 /* Slider on Toolbar */
@@ -517,6 +513,10 @@ QTableView {
 	selection-color: #FFFFFF;
 	border: none;
 	color: #FFFFFF;
+}
+
+QTableView::item:hover {
+	color: #0074e7;
 }
 
 /* Progress Bar */

--- a/bin/GuiConfigs/Skyline (Nightfall).qss
+++ b/bin/GuiConfigs/Skyline (Nightfall).qss
@@ -96,11 +96,11 @@ QToolButton {
 	border-bottom: 2px solid transparent;
 }
 
-QToolButton::disabled {
+QToolButton:disabled {
 	color: #999999;
 }
 
-QToolButton::hover {
+QToolButton:hover {
 	border-bottom: 2px solid #FFFFFF;
 }
 
@@ -137,6 +137,10 @@ QSlider::groove:horizontal {
 	height: 8px;
 	background: #0074e7;
 	margin: 1px;
+}
+
+QSlider::groove:horizontal:disabled {
+	background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #51657e, stop:1 #455971);
 }
 
 QSlider::handle:horizontal {
@@ -242,32 +246,37 @@ QRadioButton::indicator:unchecked {
 	background-color: #FFFFFF;
 }
 
-QRadioButton::indicator::disabled {
+QRadioButton::indicator:disabled {
 	background-color: #455971; 
 }
 
 /* Checkboxes */
 QCheckBox::indicator {
 	border: 1px solid #455971;
+	border-radius: 2px;
 	width: 0.75em;
 	height: 0.75em;
 	margin-top: 1px;
 }
 
 QCheckBox::indicator:checked {
-	background-color: #0074e7;
+	background-color: qradialgradient(cx:0, cy:0, radius: 1, fx:0.3, fy:0.3, stop:0.8 #008be7, stop:1 #0074e7);
 }
 
 QCheckBox::indicator:unchecked:hover {
 	border: 1px solid #0074e7;
 }
 
+QCheckBox::indicator:checked:hover {
+	background-color: qradialgradient(cx:0, cy:0, radius: 1, fx:0.3, fy:0.3, stop:0.8 #3ca3e7, stop:1 #2a89e7);
+}
+
 QCheckBox::indicator:unchecked {
 	background-color: #FFFFFF;
 }
 
-QCheckBox::indicator::disabled {
-	background-color: #455971;
+QCheckBox::indicator:disabled {
+	background-color: qradialgradient(cx:0, cy:0, radius: 1, fx:0.3, fy:0.3, stop:0.8 #51657e, stop:1 #455971);
 }
 
 /* Group Boxes (Settings Dialog) */
@@ -286,7 +295,7 @@ QGroupBox::title {
 }
 
 
-/* Settings Dialog: Tabs */
+/* Tabs */
 QTabBar::tab {
 	color: #455971;
 	padding-left: 1.25em;
@@ -296,6 +305,14 @@ QTabBar::tab {
 	border: none;
 	min-width: 65px;
 	border-bottom: 1px solid transparent;
+}
+
+QTabWidget::pane {
+	border: none;
+}
+
+QTabWidget::tab-bar {
+	alignment: center;
 }
 
 QTabBar::tab:!selected {
@@ -332,17 +349,17 @@ QTabBar#tab_bar_settings::tab:hover {
 	border-bottom: 1px solid transparent;
 }
 
+/* Log Tabs */
+QTabWidget#tab_widget_log::tab-bar {
+	alignment: left;
+}
+
 QTabBar#tab_bar_log::tab:!selected {
 	color: #FFFFFF;
 	border: none;
 }
 
-QTabBar#tab_bar_log::tab:selected {
-	color: #0074e7;
-	border: none;
-}
-
-QTabBar#tab_bar_log::tab:hover {
+QTabBar#tab_bar_log::tab:selected, QTabBar#tab_bar_log::tab:hover {
 	color: #0074e7;
 	border: none;
 }
@@ -358,7 +375,7 @@ QComboBox {
 	min-height: 14px;
 }
 
-QComboBox::hover {
+QComboBox:hover {
 	color: #FFFFFF;
 	background-color: #1c273d;
 	border: 0.0625em solid #0074e7;
@@ -401,7 +418,7 @@ QComboBox::selected {
 	padding-bottom: 0.125em;
 }
 
-QComboBox::disabled {
+QComboBox:disabled {
 	background-color: #26293b;
 	color: #455971;
 }
@@ -424,10 +441,10 @@ QPushButton:hover {
 }
 
 QPushButton::pressed {
-	background-color: #111525;
+	background-color: #121d34;
 }
 
-QPushButton::disabled {
+QPushButton:disabled {
 	border: 1px solid #999999;
 	color: #999999;
 }
@@ -459,14 +476,27 @@ QSpinBox:disabled, QDoubleSpinBox:disabled {
 }
 
 /* Libraries List */
+QListWidget {
+	border: 1px solid #FFFFFF;
+	border-radius: 0.1em;
+}
+
+QListWidget:disabled {
+	border: 1px solid #455971;
+}
+
 QListWidget::item:selected {
-	background-color: #111525;
+	background-color: #1c273d;
 	color: #0074e7;
 	border-radius: 0.125em;
 }
 
 QListWidget::item:hover {
 	background-color: #1c273d;
+}
+
+QListWidget:disabled, QListWidget:disabled:hover, QListWidget::item:disabled:hover {
+	background-color: #111525;
 	color: #FFFFFF;
 	border-radius: 0.25em;
 }
@@ -514,10 +544,14 @@ QLabel#gamelist_icon_background_color {
 QHeaderView::section {
 	background-color: #111525;
 	color: #FFFFFF;
-	padding-left: 0.25em;
-	padding-top: 0.25em;
-	padding-bottom: 0.25em;
-	border: 2px solid #370048;
+	padding-top: 3px;
+	padding-left: 5px;	
+	height: 20px;
+	border: none;
+}
+
+QHeaderView {
+	border: 1px solid qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #370048, stop: 0.5 #161249, stop: 1 #00364a);
 	border-left: none;
 	border-right: none;
 	border-top: none;
@@ -580,7 +614,7 @@ QLabel#log_level_warning {
 }
 
 QLabel#log_level_notice {
-	color: #ffffff;
+	color: #FFFFFF;
 }
 
 QLabel#log_level_trace {
@@ -589,11 +623,6 @@ QLabel#log_level_trace {
 
 QLabel#log_stack {
 	color: #0071ec;
-}
-
-/* Disable Borders */
-QTabWidget::pane {
-	border: none;
 }
 
 /* Debug UI Settings buttons */

--- a/bin/GuiConfigs/Skyline.qss
+++ b/bin/GuiConfigs/Skyline.qss
@@ -140,7 +140,7 @@ QSlider::groove:horizontal {
 }
 
 QSlider::groove:horizontal:disabled {
-	background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #51657e, stop:1 #455971);
+	background: #b3b3b3;
 }
 
 QSlider::handle:horizontal {
@@ -149,6 +149,10 @@ QSlider::handle:horizontal {
 	border-radius: 0.1em;
 	width: 18px;
 	margin: -2px 4; 
+}
+
+QSlider::handle:horizontal:disabled {
+	border: 1px solid #b3b3b3;
 }
 
 QSlider::handle:horizontal:hover {
@@ -283,8 +287,12 @@ QCheckBox::indicator:unchecked {
 	background-color: #FFFFFF;
 }
 
-QCheckBox::indicator:disabled {
-	background-color: qradialgradient(cx:0, cy:0, radius: 1, fx:0.3, fy:0.3, stop:0.8 #51657e, stop:1 #455971);
+QCheckBox::indicator:checked:disabled {
+	background-color: qradialgradient(cx:0, cy:0, radius: 1, fx:0.3, fy:0.3, stop:0.8 #b3b3b3, stop:1 #9d9d9d);
+}
+
+QCheckBox::indicator:unchecked:disabled {
+	border: 1px solid #b3b3b3;
 }
 
 /* Group Boxes (Settings Dialog) */

--- a/bin/GuiConfigs/Skyline.qss
+++ b/bin/GuiConfigs/Skyline.qss
@@ -148,7 +148,7 @@ QSlider::handle:horizontal {
 	border: 1px solid #5c5c5c;
 	border-radius: 0.1em;
 	width: 18px;
-	margin: -2px 4; 
+	margin: -2px 2; 
 }
 
 QSlider::handle:horizontal:disabled {
@@ -158,15 +158,11 @@ QSlider::handle:horizontal:disabled {
 QSlider::handle:horizontal:hover {
 	background: qlineargradient(x1: 0, y1: 1, x2: 0, y2: 0, stop: 0.2 #FFF3FF, stop: 1 #FFFFFF);
 	border: 1px solid #8500ae;
-	width: 18px;
-	margin: -2px 4; 
 }
 
 QSlider::handle:horizontal:pressed {
 	background: #f8edfb;
 	border: 1px solid #8500ae;
-	width: 18px;
-	margin: -2px 4; 
 }
 
 /* Slider on Toolbar */

--- a/bin/GuiConfigs/Skyline.qss
+++ b/bin/GuiConfigs/Skyline.qss
@@ -568,20 +568,24 @@ QLabel#gamelist_icon_background_color {
 }
 
 /* Table Headers */
-QHeaderView::section {
-	background-color: #FFFFFF;
-	color: #455971;
-	padding-top: 3px;
-	padding-left: 5px;	
-	height: 20px;
-	border: none;
-}
-
 QHeaderView {
 	border: 1px solid qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #8500ae, stop: 0.5 #4343c1, stop: 1 #009ed0);
 	border-left: none;
 	border-right: none;
 	border-top: none;
+}
+
+QHeaderView::section {
+	background-color: #FFFFFF;
+	color: #455971;
+	padding-top: 3px;
+	padding-left: 3px;	
+	height: 20px;
+	border: none;
+}
+
+QHeaderView::section:first {
+	padding-left: 5px;
 }
 
 /* Tooltips */

--- a/bin/GuiConfigs/Skyline.qss
+++ b/bin/GuiConfigs/Skyline.qss
@@ -202,7 +202,7 @@ QScrollBar {
 }
 
 QScrollArea {
-    background: transparent;
+	background: transparent;
 }
 
 QTableView QScrollBar {
@@ -424,9 +424,9 @@ QComboBox::item:!selected {
 }
 
 QComboBox::indicator {
-	background-color:transparent;
-	selection-background-color:transparent;
-	color:transparent;
+	background-color: transparent;
+	selection-background-color: transparent;
+	color: transparent;
 	selection-color: transparent;
 }
 
@@ -594,7 +594,7 @@ QToolTip {
 	color: #8500ae;
 	padding: 0.1em;
 	border: none;
-	opacity: 200;
+	opacity: 225;
 }
 
 /* Log and Debugger Borders */

--- a/bin/GuiConfigs/Skyline.qss
+++ b/bin/GuiConfigs/Skyline.qss
@@ -132,7 +132,7 @@ QSlider {
 }
 
 QSlider::groove:horizontal {
-	border: -5px solid #8cf944;
+	border: -3px solid transparent;
 	border-radius: 0.45em;
 	height: 8px;
 	background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #8500ae, stop: 0.5 #4343c1, stop: 1 #009ed0);
@@ -594,6 +594,7 @@ QToolTip {
 	color: #8500ae;
 	padding: 0.1em;
 	border: none;
+	opacity: 200;
 }
 
 /* Log and Debugger Borders */

--- a/bin/GuiConfigs/Skyline.qss
+++ b/bin/GuiConfigs/Skyline.qss
@@ -96,11 +96,11 @@ QToolButton {
 	border-bottom: 2px solid transparent;
 }
 
-QToolButton::disabled {
+QToolButton:disabled {
 	color: #999999;
 }
 
-QToolButton::hover {
+QToolButton:hover {
 	border-bottom: 2px solid #FFFFFF;
 }
 
@@ -139,6 +139,10 @@ QSlider::groove:horizontal {
 	margin: 1px;
 }
 
+QSlider::groove:horizontal:disabled {
+	background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #51657e, stop:1 #455971);
+}
+
 QSlider::handle:horizontal {
 	background: #FFFFFF;
 	border: 1px solid #5c5c5c;
@@ -148,7 +152,7 @@ QSlider::handle:horizontal {
 }
 
 QSlider::handle:horizontal:hover {
-	background: #FFFFFF;
+	background: qlineargradient(x1: 0, y1: 1, x2: 0, y2: 0, stop: 0.2 #FFF3FF, stop: 1 #FFFFFF);
 	border: 1px solid #8500ae;
 	width: 18px;
 	margin: -2px 4; 
@@ -250,32 +254,37 @@ QRadioButton::indicator:unchecked {
 	background-color: #FFFFFF;
 }
 
-QRadioButton::indicator::disabled {
+QRadioButton::indicator:disabled {
 	background-color: #455971; 
 }
 
 /* Checkboxes */
 QCheckBox::indicator {
 	border: 1px solid #455971;
+	border-radius: 2px;
 	width: 0.75em;
 	height: 0.75em;
 	margin-top: 1px;
 }
 
 QCheckBox::indicator:checked {
-	background-color: #8500ae;
+	background-color: qradialgradient(cx:0, cy:0, radius: 1, fx:0.3, fy:0.3, stop:0.8 #c500ff, stop:1 #8500ae);
 }
 
 QCheckBox::indicator:unchecked:hover {
 	border: 1px solid #8500ae;
 }
 
+QCheckBox::indicator:checked:hover {
+	background-color: qradialgradient(cx:0, cy:0, radius: 1, fx:0.3, fy:0.3, stop:0.8 #da5eff, stop:1 #974cae);
+}
+
 QCheckBox::indicator:unchecked {
 	background-color: #FFFFFF;
 }
 
-QCheckBox::indicator::disabled {
-	background-color: #455971;
+QCheckBox::indicator:disabled {
+	background-color: qradialgradient(cx:0, cy:0, radius: 1, fx:0.3, fy:0.3, stop:0.8 #51657e, stop:1 #455971);
 }
 
 /* Group Boxes (Settings Dialog) */
@@ -294,7 +303,7 @@ QGroupBox::title {
 }
 
 
-/* Settings Dialog: Tabs */
+/* Tabs */
 QTabBar::tab {
 	color: #455971;
 	padding-left: 1.25em;
@@ -304,6 +313,14 @@ QTabBar::tab {
 	border: none;
 	min-width: 65px;
 	border-bottom: 1px solid #455971;
+}
+
+QTabWidget::pane {
+	border: none;
+}
+
+QTabWidget::tab-bar {
+	alignment: center;
 }
 
 QTabBar::tab:!selected {
@@ -337,6 +354,11 @@ QTabBar#tab_bar_settings::tab:selected, QTabBar#tab_bar_settings::tab:hover {
 	border-bottom: 1px solid #8500ae;
 }
 
+/* Log Tabs */
+QTabWidget#tab_widget_log::tab-bar {
+	alignment: left;
+}
+
 QTabBar#tab_bar_log::tab:!selected {
 	color: #956fa1;
 	border: none;
@@ -365,7 +387,7 @@ QComboBox {
 	min-height: 14px;
 }
 
-QComboBox::hover {
+QComboBox:hover {
 	color: #455971;
 	background-color: #FFFFFF;
 	border: 0.0625em solid qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #8500ae, stop: 0.5 #4343c1, stop: 1 #009ed0);
@@ -408,7 +430,7 @@ QComboBox::selected {
 	padding-bottom: 0.125em;
 }
 
-QComboBox::disabled {
+QComboBox:disabled {
 	background-color: #b3b3b3;
 	color: #455971;
 }
@@ -436,7 +458,7 @@ QPushButton::pressed {
 	background-color: #f8edfb;
 }
 
-QPushButton::disabled {
+QPushButton:disabled {
 	border: 1px solid #b3b3b3;
 	color: #b3b3b3;
 }
@@ -468,6 +490,16 @@ QSpinBox:disabled, QDoubleSpinBox:disabled {
 }
 
 /* Libraries List */
+QListWidget {
+	border: 1px solid #455971;
+	border-radius: 0.1em;
+}
+
+QListWidget:disabled, QListWidget:disabled:hover, QListWidget::item:disabled:hover {
+	border: 1px solid #999999;
+	background: #FFFFFF;
+}
+
 QListWidget::item:selected {
 	background-color: #FFFFFF;
 	color: #4343c1;
@@ -503,7 +535,7 @@ QTableView {
 
 QTableView::item:hover {
 	color: #4343c1;
-}      
+}
 
 /* Progress Bar */
 QProgressBar {
@@ -531,10 +563,14 @@ QLabel#gamelist_icon_background_color {
 QHeaderView::section {
 	background-color: #FFFFFF;
 	color: #455971;
-	padding-left: 0.25em;
-	padding-top: 0.25em;
-	padding-bottom: 0.25em;
-	border: 1px solid #8500ae;
+	padding-top: 3px;
+	padding-left: 5px;	
+	height: 20px;
+	border: none;
+}
+
+QHeaderView {
+	border: 1px solid qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #8500ae, stop: 0.5 #4343c1, stop: 1 #009ed0);
 	border-left: none;
 	border-right: none;
 	border-top: none;
@@ -597,7 +633,7 @@ QLabel#log_level_warning {
 }
 
 QLabel#log_level_notice {
-	color: #ffffff;
+	color: #FFFFFF;
 }
 
 QLabel#log_level_trace {
@@ -606,11 +642,6 @@ QLabel#log_level_trace {
 
 QLabel#log_stack {
 	color: #0071ec;
-}
-
-/* Disable Borders */
-QTabWidget::pane {
-	border: none;
 }
 
 /* Debug UI Settings buttons */


### PR DESCRIPTION
Please consider merging these changes: 

* Rework checkboxes on Skyline & Nightfall
* Add gradient to header border on Skyline and Nightfall
* Specify tab alignment
* Add styling to disabled sliders
* Correct spinbox text color on Envy
* Improve styling of firmware libraries list
* Inherit debugger and memory viewer styling from main on Envy
* Fix disabled Firmware Library hover effects on Windows

...and some other small fixes here and there.

The most noticeable changes are the checkbox re-work...

![comparsion](https://user-images.githubusercontent.com/49168108/56753871-3d227580-6794-11e9-9d8f-4f7c42cabe16.png)

... and the styling for disabled sliders:

![audiosliders](https://user-images.githubusercontent.com/49168108/56753903-50cddc00-6794-11e9-9b5f-14d6aa0f6c9c.png)


