### PR TITLE
 sys_overlay/process: Implement ppc segmentation flag

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -16,8 +16,6 @@
 
 LOG_CHANNEL(cellSaveData);
 
-extern u32 g_ps3_sdk_version;
-
 template<>
 void fmt_class_string<CellSaveDataError>::format(std::string& out, u64 arg)
 {
@@ -140,7 +138,7 @@ static bool savedata_check_args(u32 operation, u32 version, vm::cptr<char> dirNa
 		}
 
 		if (!memchr(setList->dirNamePrefix.get_ptr(), '\0', CELL_SAVEDATA_PREFIX_SIZE)
-			|| (g_ps3_sdk_version > 0x3FFFFF && !setList->dirNamePrefix[0]))
+			|| (g_ps3_process_info.sdk_ver > 0x3FFFFF && !setList->dirNamePrefix[0]))
 		{
 			// ****** sysutil savedata parameter error : 17 ******
 			return false;
@@ -803,7 +801,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				return CELL_SAVEDATA_ERROR_PARAM;
 			}
 
-			if (g_ps3_sdk_version > 0x36FFFF)
+			if (g_ps3_process_info.sdk_ver > 0x36FFFF)
 			{
 				for (u8 resv : statSet->setParam->reserved2)
 				{

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -158,6 +158,9 @@ struct vdec_context final
 
 	void exec(ppu_thread& ppu, u32 vid)
 	{
+		ppu.state -= cpu_flag::signal;
+		lv2_obj::sleep(ppu);
+
 		ppu_tid = ppu.id;
 
 		for (auto cmds = in_cmd.pop_all(); !Emu.IsStopped(); cmds ? cmds.pop_front() : cmds = in_cmd.pop_all())
@@ -450,20 +453,9 @@ static s32 vdecOpen(ppu_thread& ppu, T type, U res, vm::cptr<CellVdecCb> cb, vm:
 	// Run thread
 	vm::var<u64> _tid;
 	vm::var<char[]> _name = vm::make_str("HLE Video Decoder");
-	ppu_execute<&sys_ppu_thread_create>(ppu, +_tid, 0x10000, vid, +res->ppuThreadPriority, +res->ppuThreadStackSize, SYS_PPU_THREAD_CREATE_INTERRUPT, +_name);
+	ppu_execute<&sys_ppu_thread_create>(ppu, +_tid, ppu_function_manager::addr + 8 * FIND_FUNC(vdecEntry), vid, +res->ppuThreadPriority, +res->ppuThreadStackSize, SYS_PPU_THREAD_CREATE_JOINABLE, +_name);
+
 	*handle = vid;
-
-	const auto thrd = idm::get<named_thread<ppu_thread>>(*_tid);
-
-	thrd->cmd_list
-	({
-		{ ppu_cmd::set_args, 1 }, u64{vid},
-		{ ppu_cmd::hle_call, FIND_FUNC(vdecEntry) },
-	});
-
-	thrd->state -= cpu_flag::stop;
-	thread_ctrl::notify(*thrd);
-
 	return CELL_OK;
 }
 
@@ -492,7 +484,6 @@ s32 cellVdecClose(ppu_thread& ppu, u32 handle)
 		return CELL_VDEC_ERROR_ARG;
 	}
 
-	lv2_obj::sleep(ppu);
 	vdec->out_max = 0;
 	vdec->in_cmd.push(vdec_close);
 
@@ -501,8 +492,14 @@ s32 cellVdecClose(ppu_thread& ppu, u32 handle)
 		thread_ctrl::wait_for(1000);
 	}
 
-	ppu_execute<&sys_interrupt_thread_disestablish>(ppu, vdec->ppu_tid);
-	idm::remove<vdec_context>(handle);
+	vm::var<u64> ret;
+	sys_ppu_thread_join(ppu, vdec->ppu_tid, +ret);
+
+	if (!idm::remove<vdec_context>(handle))
+	{
+		return CELL_VDEC_ERROR_ARG;
+	}
+
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -158,7 +158,6 @@ struct vdec_context final
 
 	void exec(ppu_thread& ppu, u32 vid)
 	{
-		ppu.state -= cpu_flag::signal;
 		lv2_obj::sleep(ppu);
 
 		ppu_tid = ppu.id;

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1083,7 +1083,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 			if (prog.bin.size() > size || prog.bin.size() != prog.p_filesz)
 				fmt::throw_exception("Invalid binary size (0x%llx, memsz=0x%x)", prog.bin.size(), size);
 
-			if (!vm::falloc(addr, size))
+			if (addr >= 0x20000000 || !vm::get(vm::any, addr, 0x10000000, (flag >> 24) & 0xf ? 0x400 : 0x200)->falloc(addr, size))
 				fmt::throw_exception("vm::falloc() failed (addr=0x%x, memsz=0x%x)", addr, size);
 
 			// Copy segment data, hash it
@@ -1102,6 +1102,9 @@ void ppu_load_exec(const ppu_exec_object& elf)
 			_main->segs.emplace_back(_seg);
 		}
 	}
+
+	// Allocate user 64k allocation block
+	vm::get(vm::user64k, 0, 0x20000000);
 
 	// Load section list, used by the analyser
 	for (const auto& s : elf.shdrs)

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -638,7 +638,7 @@ void ppu_thread::exec_task()
 			return reinterpret_cast<func_t>((uptr)(u32)op)(*this, {u32(op >> 32)});
 		};
 
-		if (cia % 8 || !s_use_ssse3 || UNLIKELY(state))
+		if (cia % 8 || UNLIKELY(state))
 		{
 			if (test_stopped()) return;
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -620,6 +620,12 @@ void ppu_thread::exec_task()
 {
 	if (g_cfg.core.ppu_decoder == ppu_decoder_type::llvm)
 	{
+		// Reset cpu flags
+		if (state && check_state())
+		{
+			return;
+		}
+
 		while (!(state & (cpu_flag::ret + cpu_flag::exit + cpu_flag::stop + cpu_flag::dbg_global_stop)))
 		{
 			reinterpret_cast<ppu_function_t>(static_cast<std::uintptr_t>((u32)ppu_ref(cia)))(*this);

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -427,7 +427,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	BIND_FUNC(sys_overlay_unload_module),                   //451 (0x1C3)
 	null_func,//BIND_FUNC(sys_overlay_get_module_list)      //452 (0x1C4)
 	null_func,//BIND_FUNC(sys_overlay_get_module_info)      //453 (0x1C5)
-	null_func,//BIND_FUNC(sys_overlay_load_module_by_fd)    //454 (0x1C6)
+	BIND_FUNC(sys_overlay_load_module_by_fd),               //454 (0x1C6)
 	null_func,//BIND_FUNC(sys_overlay_get_module_info2)     //455 (0x1C7)
 	null_func,//BIND_FUNC(sys_overlay_get_sdk_version)      //456 (0x1C8)
 	null_func,//BIND_FUNC(sys_overlay_get_module_dbg_info)  //457 (0x1C9)

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -300,7 +300,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 
 	uns_func, uns_func, uns_func, uns_func, uns_func,       //255-259  UNS
 
-	null_func,//BIND_FUNC(sys_spu_image_open_by_fd)         //260 (0x104)
+	BIND_FUNC(sys_spu_image_open_by_fd),                    //260 (0x104)
 
 	uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, //261-269  UNS
 	uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, //270-279  UNS

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1066,11 +1066,15 @@ void lv2_obj::awake(cpu_thread& cpu, u32 prio)
 
 	if (prio < INT32_MAX)
 	{
-        // Priority set
-        if (static_cast<ppu_thread&>(cpu).prio.exchange(prio) == prio || !unqueue(g_ppu, &cpu))
-        {
-            return;
-        }
+		// Priority set
+		const u32 old = static_cast<ppu_thread&>(cpu).prio.exchange(prio);
+
+		// On current thread: yield if priority has been lowered
+		// On other thread: yield unconditionally
+		if ((&cpu == get_current_cpu_thread() && old == prio) || !unqueue(g_ppu, &cpu))
+		{
+			return;
+		}
 	}
 	else if (prio == -4)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -602,14 +602,10 @@ error_code sys_fs_closedir(ppu_thread& ppu, u32 fd)
 
 	sys_fs.warning("sys_fs_closedir(fd=%d)", fd);
 
-	const auto directory = idm::get<lv2_fs_object, lv2_dir>(fd);
-
-	if (!directory)
+	if (!idm::remove<lv2_fs_object, lv2_dir>(fd))
 	{
 		return CELL_EBADF;
 	}
-
-	idm::remove<lv2_fs_object, lv2_dir>(fd);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -130,12 +130,6 @@ error_code _sys_interrupt_thread_disestablish(ppu_thread& ppu, u32 ih, vm::ptr<u
 
 	if (!handler)
 	{
-		if (const auto thread = idm::withdraw<named_thread<ppu_thread>>(ih))
-		{
-			*r13 = thread->gpr[13];
-			return CELL_OK;
-		}
-
 		return CELL_ESRCH;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -18,13 +18,24 @@ error_code _sys_lwcond_create(vm::ptr<u32> lwcond_id, u32 lwmutex_id, vm::ptr<sy
 {
 	sys_lwcond.warning("_sys_lwcond_create(lwcond_id=*0x%x, lwmutex_id=0x%x, control=*0x%x, name=0x%llx, arg5=0x%x)", lwcond_id, lwmutex_id, control, name, arg5);
 
-	// Temporarily
-	if (!idm::check<lv2_obj, lv2_lwmutex>(lwmutex_id))
+	u32 protocol;
+
+	// Extract protocol from lwmutex
+	if (!idm::check<lv2_obj, lv2_lwmutex>(lwmutex_id, [&protocol](lv2_lwmutex& mutex)
+	{
+		protocol = mutex.protocol;
+	}))
 	{
 		return CELL_ESRCH;
 	}
 
-	if (const u32 id = idm::make<lv2_obj, lv2_lwcond>(name, lwmutex_id, control))
+	if (protocol == SYS_SYNC_RETRY)
+	{
+		// Lwcond can't have SYS_SYNC_RETRY protocol 
+		protocol = SYS_SYNC_PRIORITY;
+	}
+
+	if (const u32 id = idm::make<lv2_obj, lv2_lwcond>(name, lwmutex_id, protocol, control))
 	{
 		*lwcond_id = id;
 		return CELL_OK;
@@ -112,7 +123,7 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u3
 			}
 			else
 			{
-				result = cond.schedule<ppu_thread>(cond.sq, cond.control->lwmutex->attribute & SYS_SYNC_ATTR_PROTOCOL_MASK);
+				result = cond.schedule<ppu_thread>(cond.sq, cond.protocol);
 			}
 
 			if (result)
@@ -202,7 +213,7 @@ error_code _sys_lwcond_signal_all(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 
 			u32 result = 0;
 
-			while (const auto cpu = cond.schedule<ppu_thread>(cond.sq, cond.control->lwmutex->attribute & SYS_SYNC_ATTR_PROTOCOL_MASK))
+			while (const auto cpu = cond.schedule<ppu_thread>(cond.sq, cond.protocol))
 			{
 				cond.waiters--;
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.h
@@ -25,15 +25,17 @@ struct lv2_lwcond final : lv2_obj
 
 	const u64 name;
 	const u32 lwid;
+	const u32 protocol;
 	vm::ptr<sys_lwcond_t> control;
 
 	shared_mutex mutex;
 	atomic_t<u32> waiters{0};
 	std::deque<cpu_thread*> sq;
 
-	lv2_lwcond(u64 name, u32 lwid, vm::ptr<sys_lwcond_t> control)
+	lv2_lwcond(u64 name, u32 lwid, u32 protocol, vm::ptr<sys_lwcond_t> control)
 		: name(name)
 		, lwid(lwid)
+		, protocol(protocol)
 		, control(control)
 	{
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -45,7 +45,7 @@ error_code sys_memory_allocate(u32 size, u64 flags, vm::ptr<u32> alloc_addr)
 		return CELL_ENOMEM;
 	}
 
-	if (const auto area = vm::get(align == 0x10000 ? vm::user64k : vm::user1m, 0, ::align(size, 0x10000000)))
+	if (const auto area = vm::get(align == 0x10000 ? vm::user64k : vm::user1m, 0, ::align(size, 0x10000000), 0x401))
 	{
 		if (u32 addr = area->alloc(size, align))
 		{
@@ -109,7 +109,7 @@ error_code sys_memory_allocate_from_container(u32 size, u32 cid, u64 flags, vm::
 	// Create phantom memory object
 	const auto mem = idm::make_ptr<lv2_memory_alloca>(size, align, flags, ct.ptr);
 
-	if (const auto area = vm::get(align == 0x10000 ? vm::user64k : vm::user1m, 0, ::align(size, 0x10000000)))
+	if (const auto area = vm::get(align == 0x10000 ? vm::user64k : vm::user1m, 0, ::align(size, 0x10000000), 0x401))
 	{
 		if (u32 addr = area->alloc(size, mem->align, &mem->shm))
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -261,9 +261,14 @@ error_code sys_memory_container_create(vm::ptr<u32> cid, u32 size)
 	}
 
 	// Create the memory container
-	*cid = idm::make<lv2_memory_container>(size);
+	if (const u32 id = idm::make<lv2_memory_container>(size))
+	{
+		*cid = id;
+		return CELL_OK;
+	}
 
-	return CELL_OK;
+	dct->used -= size;
+	return CELL_EAGAIN;
 }
 
 error_code sys_memory_container_destroy(u32 cid)

--- a/rpcs3/Emu/Cell/lv2/sys_memory.h
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.h
@@ -46,7 +46,7 @@ struct sys_page_attr_t
 
 struct lv2_memory_container
 {
-	static const u32 id_base = 0x1; // Wrong?
+	static const u32 id_base = 0x3F000000;
 	static const u32 id_step = 0x1;
 	static const u32 id_count = 16;
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -33,7 +33,7 @@ struct lv2_mutex final : lv2_obj
 
 	shared_mutex mutex;
 	atomic_t<u32> owner{0}; // Owner Thread ID
-	atomic_t<u32> lock_count{0}; // Recursive Locks
+	u32 lock_count{0}; // Recursive Locks
 	atomic_t<u32> cond_count{0}; // Condition Variables
 	std::deque<cpu_thread*> sq;
 
@@ -132,12 +132,12 @@ struct lv2_mutex final : lv2_obj
 	{
 		if (auto cpu = schedule<T>(sq, protocol))
 		{
-			owner = cpu->id << 1 | !sq.empty();
+			owner.release(cpu->id << 1 | !sq.empty());
 			return static_cast<T*>(cpu);
 		}
 		else
 		{
-			owner = 0;
+			owner.release(0);
 			return nullptr;
 		}
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -6,6 +6,7 @@
 #include "Crypto/unedat.h"
 #include "Loader/ELF.h"
 
+#include "sys_process.h"
 #include "sys_overlay.h"
 #include "sys_fs.h"
 
@@ -17,6 +18,12 @@ LOG_CHANNEL(sys_overlay);
 
 static error_code overlay_load_module(vm::ptr<u32> ovlmid, std::string path, u64 flags, vm::ptr<u32> entry)
 {
+	if (!g_ps3_process_info.ppc_seg)
+	{
+		// Process not permitted
+		return CELL_ENOSYS;
+	}
+
 	const auto name = path.substr(path.find_last_of('/') + 1);
 
 	const ppu_exec_object obj = decrypt_self(fs::file(vfs::get(path)), fxm::get_always<LoadedNpdrmKeys_t>()->devKlic.data());

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -7,6 +7,7 @@
 #include "Loader/ELF.h"
 
 #include "sys_overlay.h"
+#include "sys_fs.h"
 
 extern std::shared_ptr<lv2_overlay> ppu_load_overlay(const ppu_exec_object&, const std::string& path);
 
@@ -14,11 +15,8 @@ extern void ppu_initialize(const ppu_module&);
 
 LOG_CHANNEL(sys_overlay);
 
-error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path2, u64 flags, vm::ptr<u32> entry)
+static error_code overlay_load_module(vm::ptr<u32> ovlmid, std::string path, u64 flags, vm::ptr<u32> entry)
 {
-	sys_overlay.warning("sys_overlay_load_module(ovlmid=*0x%x, path=%s, flags=0x%x, entry=*0x%x)", ovlmid, path2, flags, entry);
-
-	const std::string path = path2.get_ptr();
 	const auto name = path.substr(path.find_last_of('/') + 1);
 
 	const ppu_exec_object obj = decrypt_self(fs::file(vfs::get(path)), fxm::get_always<LoadedNpdrmKeys_t>()->devKlic.data());
@@ -32,12 +30,50 @@ error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path2, u6
 
 	ppu_initialize(*ovlm);
 
-	sys_overlay.success("Loaded overlay: %s", path);
+	const u32 id = idm::last_id();
 
-	*ovlmid = idm::last_id();
+	if (!ovlmid || !entry)
+	{
+		if (ovlmid)
+		{
+			*ovlmid = id;
+		}
+
+		sys_overlay_unload_module(id);
+		return CELL_EFAULT;
+	}
+
+	*ovlmid = id;
 	*entry  = ovlm->entry;
 
+	sys_overlay.success("Loaded overlay: %s", path);
 	return CELL_OK;
+}
+
+error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry)
+{
+	sys_overlay.warning("sys_overlay_load_module(ovlmid=*0x%x, path=%s, flags=0x%x, entry=*0x%x)", ovlmid, path, flags, entry);
+
+	if (!path)
+	{
+		return CELL_EFAULT;
+	}
+
+	return overlay_load_module(ovlmid, path.get_ptr(), flags, entry);
+}
+
+error_code sys_overlay_load_module_by_fd(vm::ptr<u32> ovlmid, u32 fd, u64 offset, u64 flags, vm::ptr<u32> entry)
+{
+	sys_overlay.warning("sys_overlay_load_module_by_fd(ovlmid=*0x%x, fd=%d, flags=0x%x, entry=*0x%x)", ovlmid, fd, flags, entry);
+
+	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+
+	if (!file)
+	{
+		return CELL_EBADF;
+	}
+
+	return overlay_load_module(ovlmid, fmt::format("%s_x%x", file->name.data(), offset), flags, entry);
 }
 
 error_code sys_overlay_unload_module(u32 ovlmid)

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.h
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.h
@@ -12,10 +12,10 @@ struct lv2_overlay final : lv2_obj, ppu_module
 };
 
 error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry);
+error_code sys_overlay_load_module_by_fd(vm::ptr<u32> ovlmid, u32 fd, u64 offset, u64 flags, vm::ptr<u32> entry);
 error_code sys_overlay_unload_module(u32 ovlmid);
 //error_code sys_overlay_get_module_list(sys_pid_t pid, size_t ovlmids_num, sys_overlay_t * ovlmids, size_t * num_of_modules);
 //error_code sys_overlay_get_module_info(sys_pid_t pid, sys_overlay_t ovlmid, sys_overlay_module_info_t * info);
-//error_code sys_overlay_load_module_by_fd(sys_overlay_t * ovlmid, int fd, u64 offset, uint64_t flags, sys_addr_t * entry);
 //error_code sys_overlay_get_module_info2(sys_pid_t pid, sys_overlay_t ovlmid, sys_overlay_module_info2_t * info);//
 //error_code sys_overlay_get_sdk_version(); //2 params
 //error_code sys_overlay_get_module_dbg_info(); //3 params?

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -214,10 +214,7 @@ error_code sys_ppu_thread_set_priority(ppu_thread& ppu, u32 thread_id, s32 prio)
 
 	const auto thread = idm::check<named_thread<ppu_thread>>(thread_id, [&](ppu_thread& thread)
 	{
-		if (thread.prio != prio)
-		{
-			lv2_obj::awake(thread, prio);
-		}
+		lv2_obj::awake(thread, prio);
 	});
 
 	if (!thread)

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -339,6 +339,7 @@ error_code _sys_ppu_thread_create(vm::ptr<u64> thread_id, vm::ptr<ppu_thread_par
 
 	if (!tid)
 	{
+		vm::dealloc(stack_base);
 		return CELL_EAGAIN;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -28,7 +28,7 @@
 
 LOG_CHANNEL(sys_process);
 
-u32 g_ps3_sdk_version;
+ps3_process_info_t g_ps3_process_info;
 
 s32 process_getpid()
 {
@@ -182,7 +182,7 @@ s32 _sys_process_get_paramsfo(vm::ptr<char> buffer)
 s32 process_get_sdk_version(u32 pid, s32& ver)
 {
 	// get correct SDK version for selected pid
-	ver = g_ps3_sdk_version;
+	ver = g_ps3_process_info.sdk_ver;
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -34,6 +34,14 @@ struct sys_exit2_param
 	vm::bpptr<char, u64, u64> args;
 };
 
+struct ps3_process_info_t 
+{
+	u32 sdk_ver;
+	u32 ppc_seg;
+};
+
+extern ps3_process_info_t  g_ps3_process_info;
+
 // Auxiliary functions
 s32 process_getpid();
 s32 process_get_sdk_version(u32 pid, s32& ver);

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -8,6 +8,7 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Crypto/unedat.h"
 #include "sys_fs.h"
+#include "sys_process.h"
 #include "sys_prx.h"
 
 
@@ -83,6 +84,21 @@ static const std::unordered_map<std::string, int> s_prx_ignore
 
 static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<sys_prx_load_module_option_t> pOpt, fs::file src = {})
 {
+	if ((u32)flags)
+	{
+		if (flags & SYS_PRX_LOAD_MODULE_FLAGS_INVALIDMASK)
+		{
+			return CELL_EINVAL;
+		}
+
+		if (flags & SYS_PRX_LOAD_MODULE_FLAGS_FIXEDADDR && !g_ps3_process_info.ppc_seg)
+		{
+			return CELL_ENOSYS;
+		}
+
+		fmt::throw_exception("sys_prx: Unimplemented fixed address allocations" HERE);
+	}
+
 	std::string name = vpath.substr(vpath.find_last_of('/') + 1);
 	std::string path = vfs::get(vpath);
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -135,6 +135,12 @@ struct lv2_prx final : lv2_obj, ppu_module
 	be_t<u16> module_info_attributes;
 };
 
+enum : u64
+{
+	SYS_PRX_LOAD_MODULE_FLAGS_FIXEDADDR = 1,
+	SYS_PRX_LOAD_MODULE_FLAGS_INVALIDMASK = 0xFFFFFFFE
+};
+
 // SysCalls
 
 error_code sys_prx_get_ppu_guid();

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -287,6 +287,7 @@ class ppu_thread;
 error_code sys_spu_initialize(u32 max_usable_spu, u32 max_raw_spu);
 error_code _sys_spu_image_get_information(vm::ptr<sys_spu_image> img, vm::ptr<u32> entry_point, vm::ptr<s32> nsegs);
 error_code sys_spu_image_open(vm::ptr<sys_spu_image> img, vm::cptr<char> path);
+error_code sys_spu_image_open_by_fd(vm::ptr<sys_spu_image> img, u32 fd, u64 offset);
 error_code _sys_spu_image_import(vm::ptr<sys_spu_image> img, u32 src, u32 size, u32 arg4);
 error_code _sys_spu_image_close(vm::ptr<sys_spu_image> img);
 error_code _sys_spu_image_get_segments(vm::ptr<sys_spu_image> img, vm::ptr<sys_spu_segment> segments, s32 nseg);

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -892,7 +892,7 @@ namespace vm
 
 	static std::shared_ptr<block_t> _find_map(u32 size, u32 align, u64 flags)
 	{
-		for (u32 addr = ::align<u32>(0x20000000, align); addr < 0xC0000000; addr += align)
+		for (u32 addr = ::align<u32>(0x10000000, align); addr < 0xC0000000; addr += align)
 		{
 			if (_test_map(addr, size))
 			{
@@ -995,7 +995,7 @@ namespace vm
 		return nullptr;
 	}
 
-	std::shared_ptr<block_t> get(memory_location_t location, u32 addr, u32 area_size)
+	std::shared_ptr<block_t> get(memory_location_t location, u32 addr, u32 area_size, u64 flags)
 	{
 		vm::reader_lock lock;
 
@@ -1038,7 +1038,7 @@ namespace vm
 		if (area_size)
 		{
 			lock.upgrade();
-			return _map(addr, area_size, 0x200);
+			return _map(addr, area_size, flags);
 		}
 
 		return nullptr;
@@ -1050,8 +1050,8 @@ namespace vm
 		{
 			g_locations =
 			{
-				std::make_shared<block_t>(0x00010000, 0x1FFF0000, 0x200), // main
-				std::make_shared<block_t>(0x20000000, 0x10000000, 0x201), // user 64k pages
+				std::make_shared<block_t>(0x00010000, 0x0FFF0000, 0x200), // main
+				nullptr, // user 64k pages
 				nullptr, // user 1m pages
 				std::make_shared<block_t>(0xC0000000, 0x10000000), // video
 				std::make_shared<block_t>(0xD0000000, 0x10000000, 0x111), // stack

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -715,7 +715,7 @@ namespace vm
 			shm = std::make_shared<utils::shm>(size);
 
 		// Search for an appropriate place (unoptimized)
-		for (u32 addr = ::align(this->addr, align); addr < this->addr + this->size - 1; addr += align)
+		for (u32 addr = ::align(this->addr, align), max = this->addr + this->size - size; addr <= max; addr += align)
 		{
 			if (try_alloc(addr, pflags, size, std::move(shm)))
 			{

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1008,15 +1008,12 @@ namespace vm
 
 				if (!loc && area_size)
 				{
-					if (location == vm::user64k || location == vm::user1m)
-					{
-						lock.upgrade();
+					lock.upgrade();
 
-						if (!loc)
-						{
-							// Deferred allocation
-							loc = _find_map(area_size, 0x10000000, location == vm::user64k ? 0x201 : 0x401);
-						}
+					if (!loc)
+					{
+						// Deferred allocation
+						loc = _find_map(area_size, 0x10000000, flags);
 					}
 				}
 
@@ -1051,6 +1048,7 @@ namespace vm
 			g_locations =
 			{
 				std::make_shared<block_t>(0x00010000, 0x0FFF0000, 0x200), // main
+				nullptr, // main extended
 				nullptr, // user 64k pages
 				nullptr, // user 1m pages
 				std::make_shared<block_t>(0xC0000000, 0x10000000), // video

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -189,7 +189,7 @@ namespace vm
 	std::shared_ptr<block_t> unmap(u32 addr, bool must_be_empty = false);
 
 	// Get memory block associated with optionally specified memory location or optionally specified address
-	std::shared_ptr<block_t> get(memory_location_t location, u32 addr = 0, u32 area_size = 0);
+	std::shared_ptr<block_t> get(memory_location_t location, u32 addr = 0, u32 area_size = 0, u64 flags = 0x200);
 
 	// Get PS3/PSV virtual memory address from the provided pointer (nullptr always converted to 0)
 	inline vm::addr_t get_addr(const void* real_ptr)

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <map>
 #include <functional>
@@ -21,6 +21,7 @@ namespace vm
 	enum memory_location_t : uint
 	{
 		main,
+		main_ex,
 		user64k,
 		user1m,
 		video,

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1553,7 +1553,7 @@ void Emulator::Resume()
 
 		std::string dump;
 
-		for (u32 i = 0x10000; i < 0x20000000;)
+		for (u32 i = 0x10000; i < 0x10000000;)
 		{
 			if (vm::check_addr(i))
 			{

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -241,7 +241,7 @@ void kernel_explorer::Update()
 		}
 		case SYS_LWCOND_OBJECT:
 		{
-			auto& lwc = static_cast<lv2_cond&>(obj);
+			auto& lwc = static_cast<lv2_lwcond&>(obj);
 			l_addTreeChild(node, qstr(fmt::format("LWCond: ID = 0x%08x \"%s\", Waiters = %zu", id, +name64(lwc.name), +lwc.waiters)));
 			break;
 		}


### PR DESCRIPTION
What ppc segmentation flag does: reserves one segment for fixed allocations by sys_overlay, if it is not set ENOSYS is returned.
Allows Metal Gear Solid 4 to boot.
I was needed to modify my testcases' self files with a hex editor to discover this.

![image](https://user-images.githubusercontent.com/18193363/56863266-0e3b1800-69bd-11e9-927c-04c72caa7b86.png)
