### PR TITLE
Use wiki for DS3/DS4 troubleshoot instructions

### DIFF
--- a/rpcs3/ds3_pad_handler.cpp
+++ b/rpcs3/ds3_pad_handler.cpp
@@ -135,20 +135,19 @@ bool ds3_pad_handler::Init()
 
 	if (warn_about_drivers)
 	{
-#ifdef _WIN32
-		LOG_ERROR(HLE, "[DS3] One or more DS3 pads were detected but couldn't be handled because of drivers");
-		LOG_ERROR(HLE, "[DS3] We recommend you use Zadig( https://zadig.akeo.ie/ ) to change your ds3 drivers to WinUSB ones");
-#else
 		LOG_ERROR(HLE, "[DS3] One or more DS3 pads were detected but couldn't be interacted with directly");
-#ifdef __linux__
-		LOG_ERROR(HLE, "[DS3] On linux you can try to add those udev rules:\n# DS3 Bluetooth\nKERNEL==\"hidraw*\", KERNELS==\"*054C:0268*\", MODE=\"0666\"\n\n# DS3 USB\nKERNEL==\"hidraw*\", ATTRS{idVendor}==\"054c\", ATTRS{idProduct}==\"0268\", MODE=\"0666\"");
-#endif
+#if defined(_WIN32) || defined(__linux__)
+		LOG_ERROR(HLE, "[DS3] Check https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration for intructions on how to solve this issue");
 #endif
 	}
 	else if (controllers.size() == 0)
+	{
 		LOG_WARNING(HLE, "[DS3] No controllers found!");
+	}
 	else
+	{
 		LOG_SUCCESS(HLE, "[DS3] Controllers found: %d", controllers.size());
+	}
 
 	is_init = true;
 	return true;

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -745,6 +745,7 @@ bool ds4_pad_handler::Init()
 		fmt::throw_exception("hidapi-init error.threadproc");
 
 	// get all the possible controllers at start
+	bool warn_about_drivers = false;
 	for (auto pid : ds4Pids)
 	{
 		hid_device_info* devInfo = hid_enumerate(DS4_VID, pid);
@@ -756,18 +757,34 @@ bool ds4_pad_handler::Init()
 
 			hid_device* dev = hid_open_path(devInfo->path);
 			if (dev)
+			{
 				CheckAddDevice(dev, devInfo);
+			}
 			else
+			{
 				LOG_ERROR(HLE, "[DS4] hid_open_path failed! Reason: %s", hid_error(dev));
+				warn_about_drivers = true;
+			}
 			devInfo = devInfo->next;
 		}
 		hid_free_enumeration(head);
 	}
 
-	if (controllers.size() == 0)
+	if (warn_about_drivers)
+	{
+		LOG_ERROR(HLE, "[DS4] One or more DS4 pads were detected but couldn't be interacted with directly");
+#if defined(_WIN32) || defined(__linux__)
+		LOG_ERROR(HLE, "[DS4] Check https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration for intructions on how to solve this issue");
+#endif
+	}
+	else if (controllers.size() == 0)
+	{
 		LOG_WARNING(HLE, "[DS4] No controllers found!");
+	}
 	else
+	{
 		LOG_SUCCESS(HLE, "[DS4] Controllers found: %d", controllers.size());
+	}
 
 	is_init = true;
 	return true;


### PR DESCRIPTION
The instructions for letting emulator access DS3 and DS4 have been added to the [RPCS3 wiki](https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration). I think we should link to that page instead of printing instructions to log since wiki pages are easier to both read and maintain.