### PR TITLE
Two fixes for sys_rwlock

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -246,7 +246,7 @@ error_code sys_rwlock_runlock(ppu_thread& ppu, u32 rw_lock_id)
 		{
 			if (const auto cpu = rwlock->schedule<ppu_thread>(rwlock->wq, rwlock->protocol))
 			{
-				rwlock->owner = cpu->id << 1 | !rwlock->wq.empty();
+				rwlock->owner = cpu->id << 1 | !rwlock->wq.empty() | !rwlock->rq.empty();
 
 				rwlock->awake(*cpu);
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -343,10 +343,12 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 					continue;
 				}
 
-				// If the last waiter quit the writer sleep queue, readers must acquire the lock
-				if (!rwlock->rq.empty() && rwlock->wq.empty())
+				// If the last waiter quit the writer sleep queue, wake blocked readers
+				if (!rwlock->rq.empty() && rwlock->wq.empty() && rwlock->owner < 0)
 				{
-					rwlock->owner = (s64{-2} * rwlock->rq.size()) | 1;
+					verify(HERE), rwlock->owner & 1;
+
+					rwlock->owner -= s64{2} * rwlock->rq.size();
 
 					while (auto cpu = rwlock->schedule<ppu_thread>(rwlock->rq, SYS_SYNC_PRIORITY))
 					{


### PR DESCRIPTION
Both regarding readers blocked because theres a writer on the sleep queue.

First fix: fix signaling bit when ownership passed to a writer, yet there are still readers waiting on the sleep queue.

Second fix: Do not signal readers while the lock is *still* acquired by a writer when the last writer on the sleep queue quits.