### PR TITLE
High DPI Icons

### DIFF
--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -82,8 +82,8 @@ public:
 
 		QPainter painter(this);
 		setDevicePixelRatio(pixel_ratio);
-		painter.setPen(color);
+		painter.setPen(Qt::NoPen);
 		painter.setBrush(color);
-		painter.drawEllipse(0, 0, 15 * pixel_ratio, 15 * pixel_ratio);
+		painter.drawEllipse(0, 0, width(), height());
 	}
 };

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -76,13 +76,14 @@ Q_SIGNALS:
 class compat_pixmap : public QPixmap
 {
 public:
-	compat_pixmap(const QColor& color) : QPixmap(16, 16)
+	compat_pixmap(const QColor& color, int pixel_ratio) : QPixmap(16 * pixel_ratio, 16 * pixel_ratio)
 	{
 		fill(Qt::transparent);
 
 		QPainter painter(this);
+		setDevicePixelRatio(pixel_ratio);
 		painter.setPen(color);
 		painter.setBrush(color);
-		painter.drawEllipse(0, 0, 15, 15);
+		painter.drawEllipse(0, 0, 15 * pixel_ratio, 15 * pixel_ratio);
 	}
 };

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1,4 +1,4 @@
-﻿#include "game_list_frame.h"
+#include "game_list_frame.h"
 #include "qt_utils.h"
 #include "settings_dialog.h"
 #include "table_item_delegate.h"
@@ -1297,7 +1297,7 @@ int game_list_frame::PopulateGameList()
 		compat_item->setToolTip(game->compat.tooltip);
 		if (!game->compat.color.isEmpty())
 		{
-			compat_item->setData(Qt::DecorationRole, compat_pixmap(game->compat.color));
+			compat_item->setData(Qt::DecorationRole, compat_pixmap(game->compat.color, devicePixelRatio() * 2));
 		}
 
 		// Version

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1,4 +1,4 @@
-#include "game_list_frame.h"
+﻿#include "game_list_frame.h"
 #include "qt_utils.h"
 #include "settings_dialog.h"
 #include "table_item_delegate.h"
@@ -1020,9 +1020,11 @@ bool game_list_frame::RemoveSPUCache(const std::string& base_dir, bool is_intera
 
 QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon, const QColor& compatibility_color)
 {
+	const int device_pixel_ratio = devicePixelRatio();
 	const QSize original_size = img.size();
 
-	QImage image = QImage(original_size, QImage::Format_ARGB32);
+	QImage image = QImage(original_size * device_pixel_ratio, QImage::Format_ARGB32);
+	image.setDevicePixelRatio(device_pixel_ratio);
 	image.fill(m_Icon_Color);
 
 	QPainter painter(&image);
@@ -1051,7 +1053,7 @@ QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon
 
 	painter.end();
 
-	return QPixmap::fromImage(image.scaled(m_Icon_Size, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
+	return QPixmap::fromImage(image.scaled(m_Icon_Size * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
 }
 
 void game_list_frame::ShowCustomConfigIcon(QTableWidgetItem* item, bool enabled)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1038,7 +1038,9 @@ QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon
 	{
 		const int width = original_size.width() * 0.2;
 		const QPoint origin = QPoint(original_size.width() - width, 0);
-		painter.drawImage(origin, QImage(":/Icons/custom_config_2.png").scaled(QSize(width, width), Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
+		QImage custom_config_icon(":/Icons/custom_config_2.png");
+		custom_config_icon.setDevicePixelRatio(device_pixel_ratio);
+		painter.drawImage(origin, custom_config_icon.scaled(QSize(width, width) * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
 	}
 
 	if (compatibility_color.isValid())

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -59,6 +59,8 @@ void game_list_grid::setIconSize(const QSize& size)
 
 void game_list_grid::addItem(const QPixmap& img, const QString& name, const int& row, const int& col)
 {
+	const int device_pixel_ratio = devicePixelRatio();
+
 	// define size of expanded image, which is raw image size + margins
 	QSize exp_size;
 	if (m_text_enabled)
@@ -74,11 +76,13 @@ void game_list_grid::addItem(const QPixmap& img, const QString& name, const int&
 	QPoint offset = QPoint(m_icon_size.width() * m_margin_factor, m_icon_size.height() * m_margin_factor);
 
 	// create empty canvas for expanded image
-	QImage exp_img = QImage(exp_size, QImage::Format_ARGB32);
+	QImage exp_img = QImage(exp_size * device_pixel_ratio, QImage::Format_ARGB32);
+	exp_img.setDevicePixelRatio(device_pixel_ratio);
 	exp_img.fill(Qt::transparent);
 
 	// create background for image
 	QImage bg_img = QImage(img.size(), QImage::Format_ARGB32);
+	bg_img.setDevicePixelRatio(device_pixel_ratio);
 	bg_img.fill(m_icon_color);
 
 	// place raw image inside expanded image


### PR DESCRIPTION
Improves Game Icon quality when using a higher device pixel ratio.
Improves the game compatibility circle icon quality.
fixes #5885

Please test on different monitors (especially on 4K devices) with different window and/or icon scaling.

Thank you @drysalter for the circle idea and Daginatsuko for showing me how bad the game icons actually look on her monitor.


**My results on a 4K Screen with 200% window scaling:**

List Circles:
![image](https://user-images.githubusercontent.com/23019877/57183533-cb8ea980-6eae-11e9-9347-50fe0d21bd07.png)

Grid Circles:
![image](https://user-images.githubusercontent.com/23019877/57183582-73a47280-6eaf-11e9-95f1-06d8ed91a8ce.png)

List Icons (Smallest icon scale):
![image](https://user-images.githubusercontent.com/23019877/57183564-2d4f1380-6eaf-11e9-8cce-58fe732cdf1f.png)

Grid Icons (Smallest icon scale):
![image](https://user-images.githubusercontent.com/23019877/57183617-d85fcd00-6eaf-11e9-997e-dc6d0e45edbe.png)

Grid Custom config icons:
![image](https://user-images.githubusercontent.com/23019877/57183834-e6fbb380-6eb2-11e9-9d9a-ddbd911d7027.png)
