### PR TITLE
rsx: Minor tweaks

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -299,6 +299,7 @@ namespace gl
 
 			pixel_pack_settings pack_settings;
 			pack_settings.alignment(1);
+			pack_settings.swap_bytes(pack_unpack_swap_bytes);
 
 			target_texture->copy_to(nullptr, format, type, pack_settings);
 			real_pitch = target_texture->pitch();

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -73,7 +73,7 @@ namespace vk
 				switch (vk::get_driver_vendor())
 				{
 				case vk::driver_vendor::unknown:
-					// Probably intel
+				case vk::driver_vendor::INTEL:
 				case vk::driver_vendor::NVIDIA:
 					unroll_loops = true;
 					optimal_group_size = 32;

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -235,7 +235,7 @@ void VKFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	properties2.require_wpos = properties.has_wpos_input;
 	properties2.require_texture_ops = properties.has_tex_op;
 	properties2.emulate_shadow_compare = device_props.emulate_depth_compare;
-	properties2.low_precision_tests = vk::get_current_renderer()->gpu().get_driver_vendor() == vk::driver_vendor::NVIDIA;
+	properties2.low_precision_tests = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
 
 	glsl::insert_glsl_legacy_function(OS, properties2);
 }

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -313,6 +313,7 @@ namespace vk
 			// Nvidia cards are easily susceptible to NaN poisoning
 			g_drv_sanitize_fp_values = true;
 			break;
+		case driver_vendor::INTEL:
 		default:
 			LOG_WARNING(RSX, "Unsupported device: %s", gpu_name);
 		}


### PR DESCRIPTION
- Allow some drivers to bypass the window state polling if they properly handle OUT_OF_DATE and/or SUBOPTIMAL return codes to signal that the window surface has changed. This should offset the surprisingly large penalty of polling the window size from Qt on some linux window managers.
- Fix a typo in OpenGL code.

Fixes https://github.com/RPCS3/rpcs3/issues/5921 and also fixes https://github.com/RPCS3/rpcs3/issues/5913