### PR TITLE
Further improvements to Skyline and Envy

### DIFF
--- a/bin/GuiConfigs/Envy.qss
+++ b/bin/GuiConfigs/Envy.qss
@@ -382,11 +382,18 @@ QLineEdit:focus {
 	border-right: none;
 }
 
-
-/* Title Bar Docking Buttons */
+/* Title Bar Docks */
 QDockWidget::close-button, QDockWidget::float-button {
 	background-color: #23262d;
 	width: auto;
+}
+
+QDockWidget#logger {
+	color: transparent;
+}
+
+QDockWidget#gamelist {
+	color: #f8f8f8;
 }
 
 /* Top Menu Bar */

--- a/bin/GuiConfigs/Skyline (Nightfall).qss
+++ b/bin/GuiConfigs/Skyline (Nightfall).qss
@@ -162,7 +162,6 @@ QSlider::handle:horizontal:pressed {
 }
 
 /* Slider on Toolbar */
-
 QToolBar#mw_toolbar QSlider {
 	background-color: transparent;
 }
@@ -234,7 +233,7 @@ QRadioButton::indicator:checked {
 	background: qradialgradient(cx:0, cy:0, radius: 1, fx:1, fy:1, stop:0.25 #0074e7, stop:0.3 #FFFFFF);
 }
 
-QRadioButton::indicator:unchecked:hover {
+QRadioButton::indicator:unchecked:hover, QRadioButton::indicator:checked:hover {
 	border: 0.0625em solid #0074e7;
 }
 
@@ -503,20 +502,27 @@ QListWidget::item:disabled {
 
 /* Title Bar Docking Buttons */
 QDockWidget::close-button, QDockWidget::float-button {
-	background-color: transparent;
-	width: auto;
+	background: transparent;
+}
+
+QDockWidget::title#gamelist {
+	background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #370048, stop: 0.5 #161249, stop: 1 #00364a);
+}
+
+QDockWidget#gamelist {
+	color: #FFFFFF;
 }
 
 /* Game Table */
 QTableView {
 	selection-background-color: #0f1d36;
-	selection-color: #FFFFFF;
+	selection-color: #2397ff;
 	border: none;
 	color: #FFFFFF;
 }
 
 QTableView::item:hover {
-	color: #0074e7;
+	color: #2397ff;
 }
 
 /* Progress Bar */
@@ -571,6 +577,14 @@ QToolTip {
 }
 
 /* Log and Debugger Borders */
+QDockWidget::title#logger {
+	background: #111525;
+}
+
+QDockWidget#logger {
+	color: transparent;
+}
+
 QTextEdit {
 	border-top: 1px solid #0074e7;
 }

--- a/bin/GuiConfigs/Skyline.qss
+++ b/bin/GuiConfigs/Skyline.qss
@@ -166,7 +166,6 @@ QSlider::handle:horizontal:pressed {
 }
 
 /* Slider on Toolbar */
-
 QToolBar#mw_toolbar QSlider {
 	background-color: transparent;
 }
@@ -243,10 +242,10 @@ QRadioButton::indicator {
 }
 
 QRadioButton::indicator:checked {
-	background: qradialgradient(cx:0, cy:0, radius: 1, fx:1, fy:1, stop:0.25 #8500ae, stop:0.3 #FFFFFF);
+	background: qradialgradient(cx:0, cy:0, radius: 1, fx:1, fy:1, stop:0.25 #b345d9, stop:0.3 #FFFFFF);
 }
 
-QRadioButton::indicator:unchecked:hover {
+QRadioButton::indicator:unchecked:hover, QRadioButton::indicator:checked:hover {
 	border: 0.0625em solid #8500ae;
 }
 
@@ -520,14 +519,17 @@ QListWidget::item:disabled {
 	color: #999999;
 }
 
-/* Title Bar Docking Buttons */
+/* Title Bar & Docking Buttons */
 QDockWidget::close-button, QDockWidget::float-button {
-	background-color: transparent;
-	width: auto;
+	background: transparent;
 }
 
-QDockWidget::title {
-	background: #FFFFFF;
+QDockWidget::title#gamelist {
+	background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #8500ae, stop: 0.5 #4343c1, stop: 1 #009ed0);
+}
+
+QDockWidget#gamelist {
+	color: #FFFFFF;
 }
 
 /* Game Table */
@@ -594,6 +596,14 @@ QToolTip {
 }
 
 /* Log and Debugger Borders */
+QDockWidget::title#logger {
+	background: #FFFFFF;
+}
+
+QDockWidget#logger {
+	color: transparent;
+}
+
 QTextEdit {
 	border-top: 1px solid qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0.25 #8500ae, stop: 0.5 #4343c1, stop: 1 #009ed0);
 }


### PR DESCRIPTION
* Add gradient to gamelist title bar
* Change radio button color on Skyline
* Add hover effect to checked radio buttons
* Hide log text from dock on all themes (it is redundant due to the "Log" tab)
* Change text color for game table selections on Nightfall


Most noticeable change below:
![toolbars](https://user-images.githubusercontent.com/49168108/57311787-fd914d00-70f4-11e9-9e9c-f8b7c10dc57d.png)
