### PR TITLE
rsx: Surface cache improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -21,6 +21,13 @@ namespace rsx
 		srgb_nonlinear = 1
 	};
 
+	enum surface_usage_flags : u32
+	{
+		unknown = 0,
+		attachment = 1,
+		storage = 2
+	};
+
 	//Sampled image descriptor
 	struct sampled_image_descriptor_base
 	{

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -25,7 +25,7 @@ namespace rsx
 	{
 		unknown = 0,
 		attachment = 1,
-		storage = 2
+		storage = 2,
 	};
 
 	//Sampled image descriptor

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -134,6 +134,8 @@ namespace rsx
 		GcmTileInfo *tile = nullptr;
 		rsx::surface_antialiasing write_aa_mode = rsx::surface_antialiasing::center_1_sample;
 
+		flags32_t usage = surface_usage_flags::unknown;
+
 		union
 		{
 			rsx::surface_color_format gcm_color_format;

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -812,7 +812,7 @@ namespace rsx
 
 #ifndef INCOMPLETE_SURFACE_CACHE_IMPL
 			// Check if old_surface is 'new' and avoid intersection
-			if (old_surface && old_surface->last_use_tag == write_tag)
+			if (old_surface && old_surface->last_use_tag >= write_tag)
 			{
 				new_surface->set_old_contents(old_surface);
 			}
@@ -943,7 +943,7 @@ namespace rsx
 
 #ifndef INCOMPLETE_SURFACE_CACHE_IMPL
 			// Check if old_surface is 'new' and avoid intersection
-			if (old_surface && old_surface->last_use_tag == write_tag)
+			if (old_surface && old_surface->last_use_tag >= write_tag)
 			{
 				new_surface->set_old_contents(old_surface);
 			}

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -214,8 +214,8 @@ namespace rsx
 				old_contents.dst_x /= bytes_to_texels_x2;
 				old_contents.dst_y /= rows_to_texels_y2;
 
-				old_contents.transfer_scale_x = f32(bytes_to_texels_x2) / bytes_to_texels_x;
-				old_contents.transfer_scale_y = f32(rows_to_texels_y2) / rows_to_texels_y;
+				old_contents.transfer_scale_x = f32(bytes_to_texels_x) / bytes_to_texels_x2;
+				old_contents.transfer_scale_y = f32(rows_to_texels_y) / rows_to_texels_y2;
 			}
 
 			// Apply resolution scale if needed

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -872,6 +872,9 @@ namespace rsx
 			}
 
 #ifndef INCOMPLETE_SURFACE_CACHE_IMPL
+			// TODO: This can be done better after refactoring
+			new_surface->write_aa_mode = antialias;
+
 			// Check if old_surface is 'new' and avoid intersection
 			if (old_surface && old_surface->last_use_tag >= write_tag)
 			{
@@ -1001,6 +1004,9 @@ namespace rsx
 			}
 
 #ifndef INCOMPLETE_SURFACE_CACHE_IMPL
+			// TODO: Forward this to the management functions
+			new_surface->write_aa_mode = antialias;
+
 			// Check if old_surface is 'new' and avoid intersection
 			if (old_surface && old_surface->last_use_tag >= write_tag)
 			{

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -1280,10 +1280,17 @@ namespace rsx
 					if (LIKELY(this_address >= texaddr))
 					{
 						const auto offset = this_address - texaddr;
-						info.src_x = 0;
-						info.src_y = 0;
 						info.dst_y = (offset / required_pitch);
 						info.dst_x = (offset % required_pitch) / required_bpp;
+
+						if (UNLIKELY(info.dst_x >= required_width || info.dst_y >= required_height))
+						{
+							// Out of bounds
+							continue;
+						}
+
+						info.src_x = 0;
+						info.src_y = 0;
 						info.width = std::min<u32>(normalized_surface_width, required_width - info.dst_x);
 						info.height = std::min<u32>(normalized_surface_height, required_height - info.dst_y);
 					}

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -2,6 +2,7 @@
 
 #include "Utilities/GSL.h"
 #include "Emu/Memory/vm.h"
+#include "TextureUtils.h"
 #include "../GCM.h"
 #include "../rsx_utils.h"
 #include <list>
@@ -59,24 +60,65 @@ namespace rsx
 		u8 bpp;
 	};
 
-	template <typename image_storage_type>
-	struct surface_hierachy_info
+	template <typename surface_type>
+	struct deferred_clipped_region
 	{
-		struct memory_overlap_t
+		u16 src_x, src_y, dst_x, dst_y, width, height;
+		f32 transfer_scale_x, transfer_scale_y;
+		surface_type target;
+		surface_type source;
+
+		template <typename T>
+		deferred_clipped_region<T> cast() const
 		{
-			image_storage_type _ref;
-			u32 memory_address;
-			u32 x;
-			u32 y;
-			u32 w;
-			u32 h;
-		};
+			deferred_clipped_region<T> ret;
+			ret.src_x = src_x;
+			ret.src_y = src_y;
+			ret.dst_x = dst_x;
+			ret.dst_y = dst_y;
+			ret.width = width;
+			ret.height = height;
+			ret.transfer_scale_x = transfer_scale_x;
+			ret.transfer_scale_y = transfer_scale_y;
+			ret.target = (T)(target);
+			ret.source = (T)(source);
 
-		u32 memory_address;
-		u32 memory_range;
-		image_storage_type memory_contents;
+			return ret;
+		}
 
-		std::vector<memory_overlap_t> overlapping_set;
+		operator bool() const
+		{
+			return (source != nullptr);
+		}
+
+		template <typename T>
+		void init_transfer(T target_surface)
+		{
+			if (!width)
+			{
+				// Perform intersection here
+				const auto region = rsx::get_transferable_region(target_surface);
+				width = std::get<0>(region);
+				height = std::get<1>(region);
+
+				transfer_scale_x = f32(std::get<2>(region)) / width;
+				transfer_scale_y = f32(std::get<3>(region)) / height;
+
+				target = target_surface;
+			}
+		}
+
+		areai src_rect() const
+		{
+			verify(HERE), width;
+			return { src_x, src_y, src_x + width, src_y + height };
+		}
+
+		areai dst_rect() const
+		{
+			verify(HERE), width;
+			return { dst_x, dst_y, dst_x + u16(width * transfer_scale_x + 0.5f), dst_y + u16(height * transfer_scale_y + 0.5f) };
+		}
 	};
 
 	template <typename image_storage_type>
@@ -86,7 +128,7 @@ namespace rsx
 		std::array<std::pair<u32, u64>, 5> memory_tag_samples;
 
 		bool dirty = false;
-		image_storage_type old_contents = nullptr;
+		deferred_clipped_region<image_storage_type> old_contents{};
 		rsx::surface_antialiasing read_aa_mode = rsx::surface_antialiasing::center_1_sample;
 
 		GcmTileInfo *tile = nullptr;
@@ -142,11 +184,60 @@ namespace rsx
 		{
 			if (!other || other->get_rsx_pitch() != this->get_rsx_pitch())
 			{
-				old_contents = nullptr;
+				old_contents = {};
 				return;
 			}
 
-			old_contents = other;
+			old_contents = {};
+			old_contents.source = other;
+		}
+
+		template<typename T>
+		void set_old_contents_region(const T& region, bool normalized)
+		{
+			// NOTE: This method will not perform pitch verification!
+			verify(HERE), region.source;
+			old_contents = region.template cast<image_storage_type>();
+
+			// Reverse normalization process if needed
+			if (normalized)
+			{
+				const u16 bytes_to_texels_x = region.source->get_bpp() * (region.source->write_aa_mode == rsx::surface_antialiasing::center_1_sample? 1 : 2);
+				const u16 rows_to_texels_y = (region.source->write_aa_mode > rsx::surface_antialiasing::diagonal_centered_2_samples? 2 : 1);
+				old_contents.src_x /= bytes_to_texels_x;
+				old_contents.src_y /= rows_to_texels_y;
+				old_contents.width /= bytes_to_texels_x;
+				old_contents.height /= rows_to_texels_y;
+
+				const u16 bytes_to_texels_x2 = (get_bpp() * (write_aa_mode == rsx::surface_antialiasing::center_1_sample? 1 : 2));
+				const u16 rows_to_texels_y2 = (write_aa_mode > rsx::surface_antialiasing::diagonal_centered_2_samples)? 2 : 1;
+				old_contents.dst_x /= bytes_to_texels_x2;
+				old_contents.dst_y /= rows_to_texels_y2;
+
+				old_contents.transfer_scale_x = f32(bytes_to_texels_x2) / bytes_to_texels_x;
+				old_contents.transfer_scale_y = f32(rows_to_texels_y2) / rows_to_texels_y;
+			}
+
+			// Apply resolution scale if needed
+			if (g_cfg.video.resolution_scale_percent != 100)
+			{
+				auto src_width = rsx::apply_resolution_scale(old_contents.width, true, old_contents.source->width());
+				auto src_height = rsx::apply_resolution_scale(old_contents.height, true, old_contents.source->height());
+
+				auto dst_width = rsx::apply_resolution_scale(old_contents.width, true, old_contents.target->width());
+				auto dst_height = rsx::apply_resolution_scale(old_contents.height, true, old_contents.target->height());
+
+				old_contents.transfer_scale_x *= f32(dst_width) / src_width;
+				old_contents.transfer_scale_y *= f32(dst_height) / src_height;
+
+				old_contents.width = src_width;
+				old_contents.height = src_height;
+
+				old_contents.src_x = rsx::apply_resolution_scale(old_contents.src_x, false, old_contents.source->width());
+				old_contents.src_y = rsx::apply_resolution_scale(old_contents.src_y, false, old_contents.source->height());
+				old_contents.dst_x = rsx::apply_resolution_scale(old_contents.dst_x, false, old_contents.target->width());
+				old_contents.dst_y = rsx::apply_resolution_scale(old_contents.dst_y, false, old_contents.target->height());
+			}
 		}
 
 		void queue_tag(u32 address)
@@ -207,7 +298,22 @@ namespace rsx
 
 			read_aa_mode = write_aa_mode;
 			dirty = false;
-			old_contents = nullptr;
+			old_contents = {};
+		}
+
+		// Returns the rect area occupied by this surface expressed as an 8bpp image with no AA
+		areau get_normalized_memory_area() const
+		{
+			const u16 internal_width = get_native_pitch() * (write_aa_mode > rsx::surface_antialiasing::center_1_sample? 2: 1);
+			const u16 internal_height = get_surface_height() * (write_aa_mode > rsx::surface_antialiasing::diagonal_centered_2_samples? 2: 1);
+
+			return { 0, 0, internal_width, internal_height };
+		}
+
+		rsx::address_range get_memory_range() const
+		{
+			const u32 internal_height = get_surface_height() * (write_aa_mode > rsx::surface_antialiasing::diagonal_centered_2_samples? 2: 1);
+			return rsx::address_range::start_length(memory_tag_samples[0].first, internal_height * get_rsx_pitch());
 		}
 	};
 
@@ -257,6 +363,11 @@ namespace rsx
 			}
 		}
 
+		constexpr u32 get_aa_factor_u(surface_antialiasing aa_mode)
+		{
+			return (aa_mode == surface_antialiasing::center_1_sample)? 1 : 2;
+		}
+
 		constexpr u32 get_aa_factor_v(surface_antialiasing aa_mode)
 		{
 			switch (aa_mode)
@@ -284,100 +395,251 @@ namespace rsx
 		rsx::address_range m_depth_stencil_memory_range;
 
 	public:
-		std::array<std::tuple<u32, surface_type>, 4> m_bound_render_targets = {};
-		std::tuple<u32, surface_type> m_bound_depth_stencil = {};
+		std::array<std::pair<u32, surface_type>, 4> m_bound_render_targets = {};
+		std::pair<u32, surface_type> m_bound_depth_stencil = {};
 
 		std::list<surface_storage_type> invalidated_resources;
-		std::vector<surface_hierachy_info<surface_type>> m_memory_tree;
 		u64 cache_tag = 0ull;
 		u64 write_tag = 0ull;
-		u64 memory_tag = 0ull;
 
 		surface_store() = default;
 		~surface_store() = default;
 		surface_store(const surface_store&) = delete;
 
 	private:
-		void generate_render_target_memory_tree()
+		template <bool is_depth_surface>
+		void split_surface_region(command_list_type cmd, u32 address, surface_type prev_surface, u16 width, u16 height, u8 bpp, rsx::surface_antialiasing aa)
 		{
-			auto process_entry = [](surface_hierachy_info<surface_type>& block_info,
-				const surface_format_info& info,
-				u32 memory_address, u32 memory_end,
-				u32 address, surface_type surface)
+#ifndef INCOMPLETE_SURFACE_CACHE_IMPL
+			auto insert_new_surface = [&](
+				u32 new_address,
+				deferred_clipped_region<surface_type>& region,
+				std::unordered_map<u32, surface_storage_type>& data)
 			{
-				if (address <= memory_address) // also intentionally fails on self-test
-					return;
-
-				if (address >= memory_end)
-					return;
-
-				surface_format_info info2{};
-				Traits::get_surface_info(surface, &info2);
-				const auto offset = (address - memory_address);
-				const auto offset_y = (offset / info.rsx_pitch);
-				const auto offset_x = (offset % info.rsx_pitch) / info.bpp;
-				const auto pitch2 = info2.bpp * info2.surface_width;
-
-				const bool fits_w = ((offset % info.rsx_pitch) + pitch2) <= info.rsx_pitch;
-				const bool fits_h = ((offset_y + info2.surface_height) * info.rsx_pitch) <= (memory_end - memory_address);
-
-				if (fits_w && fits_h)
+				verify(HERE), prev_surface;
+				if (prev_surface->read_barrier(cmd); !prev_surface->test())
 				{
-					typename surface_hierachy_info<surface_type>::memory_overlap_t overlap{};
-					overlap._ref = surface;
-					overlap.memory_address = address;
-					overlap.x = offset_x;
-					overlap.y = offset_y;
-					overlap.w = info2.surface_width;
-					overlap.h = info2.surface_height;
+					return;
+				}
 
-					block_info.overlapping_set.push_back(overlap);
+				surface_storage_type sink;
+				if (const auto found = data.find(new_address);
+					found != data.end())
+				{
+					if (Traits::is_compatible_surface(Traits::get(found->second), region.source, region.width, region.height, 1))
+					{
+						// There is no need to erase due to the reinsertion below
+						sink = std::move(found->second);
+					}
+					else
+					{
+						// TODO: Merge the 2 regions
+						invalidated_resources.push_back(std::move(found->second));
+						data.erase(new_address);
+
+						auto &old = invalidated_resources.back();
+						Traits::notify_surface_invalidated(old);
+					}
+				}
+
+				Traits::clone_surface(cmd, sink, region.source, new_address, region);
+				verify(HERE), region.target == Traits::get(sink);
+				data[new_address] = std::move(sink);
+			};
+
+			// Define incoming region
+			size2u old, _new;
+
+			const auto prev_area = prev_surface->get_normalized_memory_area();
+			old.width = prev_area.x2;
+			old.height = prev_area.y2;
+
+			_new.width = width * bpp * get_aa_factor_u(aa);
+			_new.height = height * get_aa_factor_v(aa);
+
+			if (old.width > _new.width)
+			{
+				// Split in X
+				const u32 baseaddr = address + _new.width;
+				const u32 bytes_to_texels_x = (bpp * get_aa_factor_u(prev_surface->write_aa_mode));
+
+				deferred_clipped_region<surface_type> copy;
+				copy.src_x = _new.width / bytes_to_texels_x;
+				copy.src_y = 0;
+				copy.dst_x = 0;
+				copy.dst_y = 0;
+				copy.width = (old.width - _new.width) / bytes_to_texels_x;
+				copy.height = prev_surface->get_surface_height();
+				copy.transfer_scale_x = 1.f;
+				copy.transfer_scale_y = 1.f;
+				copy.target = nullptr;
+				copy.source = prev_surface;
+
+				if constexpr (is_depth_surface)
+				{
+					insert_new_surface(baseaddr, copy, m_depth_stencil_storage);
 				}
 				else
 				{
-					// TODO
-				}
-			};
-
-			auto process_block = [this, process_entry](u32 memory_address, surface_type surface)
-			{
-				surface_hierachy_info<surface_type> block_info;
-				surface_format_info info{};
-				Traits::get_surface_info(surface, &info);
-				const auto memory_end = memory_address + (info.rsx_pitch * info.surface_height);
-
-				for (const auto &rtt : m_render_targets_storage)
-				{
-					process_entry(block_info, info, memory_address, memory_end, rtt.first, Traits::get(rtt.second));
-				}
-
-				for (const auto &ds : m_depth_stencil_storage)
-				{
-					process_entry(block_info, info, memory_address, memory_end, ds.first, Traits::get(ds.second));
-				}
-
-				if (!block_info.overlapping_set.empty())
-				{
-					block_info.memory_address = memory_address;
-					block_info.memory_range = (memory_end - memory_address);
-					block_info.memory_contents = surface;
-
-					m_memory_tree.push_back(block_info);
-				}
-			};
-
-			for (auto &rtt : m_bound_render_targets)
-			{
-				if (const auto address = std::get<0>(rtt))
-				{
-					process_block(address, std::get<1>(rtt));
+					insert_new_surface(baseaddr, copy, m_render_targets_storage);
 				}
 			}
 
-			if (const auto address = std::get<0>(m_bound_depth_stencil))
+			if (old.height > _new.height)
 			{
-				process_block(address, std::get<1>(m_bound_depth_stencil));
+				// Split in Y
+				const u32 baseaddr = address + (_new.height * prev_surface->get_rsx_pitch());
+				const u32 bytes_to_texels_x = (bpp * get_aa_factor_u(prev_surface->write_aa_mode));
+
+				deferred_clipped_region<surface_type> copy;
+				copy.src_x = 0;
+				copy.src_y = _new.height / get_aa_factor_v(prev_surface->write_aa_mode);
+				copy.dst_x = 0;
+				copy.dst_y = 0;
+				copy.width = std::min(_new.width, old.width) / bytes_to_texels_x;
+				copy.height = (old.height - _new.height) / get_aa_factor_v(prev_surface->write_aa_mode);
+				copy.transfer_scale_x = 1.f;
+				copy.transfer_scale_y = 1.f;
+				copy.target = nullptr;
+				copy.source = prev_surface;
+
+				if constexpr (is_depth_surface)
+				{
+					insert_new_surface(baseaddr, copy, m_depth_stencil_storage);
+				}
+				else
+				{
+					insert_new_surface(baseaddr, copy, m_render_targets_storage);
+				}
 			}
+#endif
+		}
+
+		template <bool is_depth_surface>
+		void intersect_surface_region(command_list_type cmd, u32 address, surface_type new_surface)
+		{
+#ifndef INCOMPLETE_SURFACE_CACHE_IMPL
+			auto scan_list = [&new_surface](const rsx::address_range& mem_range,
+				std::unordered_map<u32, surface_storage_type>& data) -> std::vector<std::pair<u32, surface_type>>
+			{
+				std::vector<std::pair<u32, surface_type>> result;
+				for (const auto &e : data)
+				{
+					auto surface = Traits::get(e.second);
+
+					if (new_surface == surface || e.second->dirty || e.second->last_use_tag <= new_surface->last_use_tag)
+					{
+						// Do not bother synchronizing with uninitialized data
+						continue;
+					}
+
+					// Memory partition check
+					if (mem_range.start >= 0xc0000000)
+					{
+						if (e.first < 0xc0000000) continue;
+					}
+					else
+					{
+						if (e.first >= 0xc0000000) continue;
+					}
+
+					// Pitch check
+					if (!rsx::pitch_compatible(surface, new_surface))
+					{
+						continue;
+					}
+
+					// Range check
+					const rsx::address_range this_range = surface->get_memory_range();
+					if (!this_range.overlaps(mem_range))
+					{
+						continue;
+					}
+
+					result.push_back({ e.first, surface });
+				}
+
+				return result;
+			};
+
+			const rsx::address_range mem_range = new_surface->get_memory_range();
+			const auto list1 = scan_list(mem_range, m_render_targets_storage);
+			const auto list2 = scan_list(mem_range, m_depth_stencil_storage);
+
+			if (list1.empty() && list2.empty())
+			{
+				return;
+			}
+
+			std::vector<std::pair<u32, surface_type>> surface_info;
+			if (list1.empty())
+			{
+				surface_info = std::move(list2);
+			}
+			else if (list2.empty())
+			{
+				surface_info = std::move(list1);
+			}
+			else
+			{
+				surface_info = std::move(list1);
+				surface_info.reserve(list1.size() + list2.size());
+
+				for (const auto& e : list2) surface_info.push_back(e);
+			}
+
+			if (UNLIKELY(surface_info.size() > 1))
+			{
+				// Sort with newest first for early exit
+				std::sort(surface_info.begin(), surface_info.end(), [](const auto& a, const auto& b)
+				{
+					return (a.second->last_use_tag > b.second->last_use_tag);
+				});
+			}
+
+			// TODO: Modify deferred_clip_region::direct_copy() to take a few more things into account!
+			const areau child_region = new_surface->get_normalized_memory_area();
+			const auto child_w = child_region.width();
+			const auto child_h = child_region.height();
+
+			const auto pitch = new_surface->get_rsx_pitch();
+			for (const auto &e: surface_info)
+			{
+				const auto parent_region = e.second->get_normalized_memory_area();
+				const auto parent_w = parent_region.width();
+				const auto parent_h = parent_region.height();
+				const auto rect = rsx::intersect_region(e.first, parent_w, parent_h, 1, address, child_w, child_h, 1, pitch);
+
+				const auto src_offset = std::get<0>(rect);
+				const auto dst_offset = std::get<1>(rect);
+				const auto size = std::get<2>(rect);
+
+				if (src_offset.x >= parent_w || src_offset.y >= parent_h)
+				{
+					continue;
+				}
+
+				if (dst_offset.x >= child_w || dst_offset.y >= child_h)
+				{
+					continue;
+				}
+
+				// TODO: Eventually need to stack all the overlapping regions, but for now just do the latest rect in the space
+				deferred_clipped_region<surface_type> region;
+				region.src_x = src_offset.x;
+				region.src_y = src_offset.y;
+				region.dst_x = dst_offset.x;
+				region.dst_y = dst_offset.y;
+				region.width = size.width;
+				region.height = size.height;
+				region.source = e.second;
+				region.target = new_surface;
+
+				new_surface->set_old_contents_region(region, true);
+				new_surface->dirty = true;
+				break;
+			}
+#endif
 		}
 
 	protected:
@@ -401,87 +663,124 @@ namespace rsx
 			surface_storage_type new_surface_storage;
 			surface_type old_surface = nullptr;
 			surface_type new_surface = nullptr;
-			surface_type convert_surface = nullptr;
+			bool store = true;
 
-			// Remove any depth surfaces occupying this memory address (TODO: Discard all overlapping range)
-			auto aliased_depth_surface = m_depth_stencil_storage.find(address);
-			if (aliased_depth_surface != m_depth_stencil_storage.end())
-			{
-				Traits::notify_surface_invalidated(aliased_depth_surface->second);
-				convert_surface = Traits::get(aliased_depth_surface->second);
-				invalidated_resources.push_back(std::move(aliased_depth_surface->second));
-				m_depth_stencil_storage.erase(aliased_depth_surface);
-			}
-
+			// Check if render target already exists
 			auto It = m_render_targets_storage.find(address);
 			if (It != m_render_targets_storage.end())
 			{
 				surface_storage_type &rtt = It->second;
+				const bool pitch_compatible = Traits::surface_is_pitch_compatible(rtt, pitch);
+
+				if (pitch_compatible)
+				{
+					// Preserve memory outside the area to be inherited if needed
+					const u8 bpp = get_format_block_size_in_bytes(color_format);
+					split_surface_region<false>(command_list, address, Traits::get(rtt), (u16)width, (u16)height, bpp, antialias);
+				}
+
 				if (Traits::rtt_has_format_width_height(rtt, color_format, width, height))
 				{
-					if (Traits::surface_is_pitch_compatible(rtt, pitch))
+					if (pitch_compatible)
 						Traits::notify_surface_persist(rtt);
 					else
-						Traits::invalidate_surface_contents(command_list, Traits::get(rtt), nullptr, address, pitch);
+						Traits::invalidate_surface_contents(command_list, Traits::get(rtt), address, pitch);
 
 					Traits::prepare_rtt_for_drawing(command_list, Traits::get(rtt));
-					return Traits::get(rtt);
+					new_surface = Traits::get(rtt);
+					store = false;
 				}
-
-				old_surface = Traits::get(rtt);
-				old_surface_storage = std::move(rtt);
-				m_render_targets_storage.erase(address);
-			}
-
-			// Range test
-			const auto aa_factor_v = get_aa_factor_v(antialias);
-			rsx::address_range range = rsx::address_range::start_length(address, u32(pitch * height * aa_factor_v));
-			m_render_targets_memory_range = range.get_min_max(m_render_targets_memory_range);
-
-			// Select source of original data if any
-			auto contents_to_copy = old_surface == nullptr ? convert_surface : old_surface;
-
-			// Search invalidated resources for a suitable surface
-			for (auto It = invalidated_resources.begin(); It != invalidated_resources.end(); It++)
-			{
-				auto &rtt = *It;
-				if (Traits::rtt_has_format_width_height(rtt, color_format, width, height, true))
+				else
 				{
-					new_surface_storage = std::move(rtt);
-
-					if (old_surface)
-					{
-						//Exchange this surface with the invalidated one
-						Traits::notify_surface_invalidated(old_surface_storage);
-						rtt = std::move(old_surface_storage);
-					}
-					else
-						//rtt is now empty - erase it
-						invalidated_resources.erase(It);
-
-					new_surface = Traits::get(new_surface_storage);
-					Traits::invalidate_surface_contents(command_list, new_surface, contents_to_copy, address, pitch);
-					Traits::prepare_rtt_for_drawing(command_list, new_surface);
-					break;
+					old_surface = Traits::get(rtt);
+					old_surface_storage = std::move(rtt);
+					m_render_targets_storage.erase(address);
 				}
 			}
 
+			if (!new_surface)
+			{
+				// Range test
+				const auto aa_factor_v = get_aa_factor_v(antialias);
+				rsx::address_range range = rsx::address_range::start_length(address, u32(pitch * height * aa_factor_v));
+				m_render_targets_memory_range = range.get_min_max(m_render_targets_memory_range);
+
+				// Search invalidated resources for a suitable surface
+				for (auto It = invalidated_resources.begin(); It != invalidated_resources.end(); It++)
+				{
+					auto &rtt = *It;
+					if (Traits::rtt_has_format_width_height(rtt, color_format, width, height, true))
+					{
+						new_surface_storage = std::move(rtt);
+
+						if (old_surface)
+						{
+							// Exchange this surface with the invalidated one
+							Traits::notify_surface_invalidated(old_surface_storage);
+							rtt = std::move(old_surface_storage);
+						}
+						else
+						{
+							// rtt is now empty - erase it
+							invalidated_resources.erase(It);
+						}
+
+						new_surface = Traits::get(new_surface_storage);
+						Traits::invalidate_surface_contents(command_list, new_surface, address, pitch);
+						Traits::prepare_rtt_for_drawing(command_list, new_surface);
+						break;
+					}
+				}
+			}
+
+			// Check for stale storage
 			if (old_surface != nullptr && new_surface == nullptr)
 			{
-				//This was already determined to be invalid and is excluded from testing above
+				// This was already determined to be invalid and is excluded from testing above
 				Traits::notify_surface_invalidated(old_surface_storage);
 				invalidated_resources.push_back(std::move(old_surface_storage));
 			}
 
-			if (new_surface != nullptr)
+			if (!new_surface)
 			{
-				//New surface was found among existing surfaces
+				m_render_targets_storage[address] = Traits::create_new_surface(address, color_format, width, height, pitch, std::forward<Args>(extra_params)...);
+				new_surface = Traits::get(m_render_targets_storage[address]);
+			}
+			else if (store)
+			{
+				// New surface was found among invalidated surfaces
 				m_render_targets_storage[address] = std::move(new_surface_storage);
-				return new_surface;
 			}
 
-			m_render_targets_storage[address] = Traits::create_new_surface(address, color_format, width, height, pitch, contents_to_copy, std::forward<Args>(extra_params)...);
-			return Traits::get(m_render_targets_storage[address]);
+#ifndef INCOMPLETE_SURFACE_CACHE_IMPL
+			// Check if old_surface is 'new' and avoid intersection
+			if (old_surface && old_surface->last_use_tag == write_tag)
+			{
+				new_surface->set_old_contents(old_surface);
+			}
+			else
+#endif
+			{
+				intersect_surface_region<false>(command_list, address, new_surface);
+			}
+
+			// Remove and preserve if possible any overlapping/replaced depth surface
+			auto aliased_depth_surface = m_depth_stencil_storage.find(address);
+			if (aliased_depth_surface != m_depth_stencil_storage.end())
+			{
+				if (Traits::surface_is_pitch_compatible(aliased_depth_surface->second, pitch))
+				{
+					// Preserve memory outside the area to be inherited if needed
+					const u8 bpp = get_format_block_size_in_bytes(color_format);
+					split_surface_region<true>(command_list, address, Traits::get(aliased_depth_surface->second), (u16)width, (u16)height, bpp, antialias);
+				}
+
+				Traits::notify_surface_invalidated(aliased_depth_surface->second);
+				invalidated_resources.push_back(std::move(aliased_depth_surface->second));
+				m_depth_stencil_storage.erase(aliased_depth_surface);
+			}
+
+			return new_surface;
 		}
 
 		template <typename ...Args>
@@ -497,67 +796,68 @@ namespace rsx
 			surface_storage_type new_surface_storage;
 			surface_type old_surface = nullptr;
 			surface_type new_surface = nullptr;
-			surface_type convert_surface = nullptr;
-
-			// Remove any color surfaces occupying this memory range (TODO: Discard all overlapping surfaces)
-			auto aliased_rtt_surface = m_render_targets_storage.find(address);
-			if (aliased_rtt_surface != m_render_targets_storage.end())
-			{
-				Traits::notify_surface_invalidated(aliased_rtt_surface->second);
-				convert_surface = Traits::get(aliased_rtt_surface->second);
-				invalidated_resources.push_back(std::move(aliased_rtt_surface->second));
-				m_render_targets_storage.erase(aliased_rtt_surface);
-			}
+			bool store = true;
 
 			auto It = m_depth_stencil_storage.find(address);
 			if (It != m_depth_stencil_storage.end())
 			{
 				surface_storage_type &ds = It->second;
-				if (Traits::ds_has_format_width_height(ds, depth_format, width, height))
-				{
-					if (Traits::surface_is_pitch_compatible(ds, pitch))
-						Traits::notify_surface_persist(ds);
-					else
-						Traits::invalidate_surface_contents(command_list, Traits::get(ds), nullptr, address, pitch);
+				const bool pitch_compatible = Traits::surface_is_pitch_compatible(ds, pitch);
 
-					Traits::prepare_ds_for_drawing(command_list, Traits::get(ds));
-					return Traits::get(ds);
+				if (pitch_compatible)
+				{
+					const u8 bpp = (depth_format == rsx::surface_depth_format::z16)? 2 : 4;
+					split_surface_region<true>(command_list, address, Traits::get(ds), (u16)width, (u16)height, bpp, antialias);
 				}
 
-				old_surface = Traits::get(ds);
-				old_surface_storage = std::move(ds);
-				m_depth_stencil_storage.erase(address);
+				if (Traits::ds_has_format_width_height(ds, depth_format, width, height))
+				{
+					if (pitch_compatible)
+						Traits::notify_surface_persist(ds);
+					else
+						Traits::invalidate_surface_contents(command_list, Traits::get(ds), address, pitch);
+
+					Traits::prepare_ds_for_drawing(command_list, Traits::get(ds));
+					new_surface = Traits::get(ds);
+					store = false;
+				}
+				else
+				{
+					old_surface = Traits::get(ds);
+					old_surface_storage = std::move(ds);
+					m_depth_stencil_storage.erase(address);
+				}
 			}
 
-			// Range test
-			const auto aa_factor_v = get_aa_factor_v(antialias);
-			rsx::address_range range = rsx::address_range::start_length(address, u32(pitch * height * aa_factor_v));
-			m_depth_stencil_memory_range = range.get_min_max(m_depth_stencil_memory_range);
-
-			// Select source of original data if any
-			auto contents_to_copy = old_surface == nullptr ? convert_surface : old_surface;
-
-			//Search invalidated resources for a suitable surface
-			for (auto It = invalidated_resources.begin(); It != invalidated_resources.end(); It++)
+			if (!new_surface)
 			{
-				auto &ds = *It;
-				if (Traits::ds_has_format_width_height(ds, depth_format, width, height, true))
+				// Range test
+				const auto aa_factor_v = get_aa_factor_v(antialias);
+				rsx::address_range range = rsx::address_range::start_length(address, u32(pitch * height * aa_factor_v));
+				m_depth_stencil_memory_range = range.get_min_max(m_depth_stencil_memory_range);
+
+				//Search invalidated resources for a suitable surface
+				for (auto It = invalidated_resources.begin(); It != invalidated_resources.end(); It++)
 				{
-					new_surface_storage = std::move(ds);
-
-					if (old_surface)
+					auto &ds = *It;
+					if (Traits::ds_has_format_width_height(ds, depth_format, width, height, true))
 					{
-						//Exchange this surface with the invalidated one
-						Traits::notify_surface_invalidated(old_surface_storage);
-						ds = std::move(old_surface_storage);
-					}
-					else
-						invalidated_resources.erase(It);
+						new_surface_storage = std::move(ds);
 
-					new_surface = Traits::get(new_surface_storage);
-					Traits::prepare_ds_for_drawing(command_list, new_surface);
-					Traits::invalidate_surface_contents(command_list, new_surface, contents_to_copy, address, pitch);
-					break;
+						if (old_surface)
+						{
+							//Exchange this surface with the invalidated one
+							Traits::notify_surface_invalidated(old_surface_storage);
+							ds = std::move(old_surface_storage);
+						}
+						else
+							invalidated_resources.erase(It);
+
+						new_surface = Traits::get(new_surface_storage);
+						Traits::prepare_ds_for_drawing(command_list, new_surface);
+						Traits::invalidate_surface_contents(command_list, new_surface, address, pitch);
+						break;
+					}
 				}
 			}
 
@@ -568,15 +868,45 @@ namespace rsx
 				invalidated_resources.push_back(std::move(old_surface_storage));
 			}
 
-			if (new_surface != nullptr)
+			if (!new_surface)
 			{
-				//New surface was found among existing surfaces
+				m_depth_stencil_storage[address] = Traits::create_new_surface(address, depth_format, width, height, pitch, std::forward<Args>(extra_params)...);
+				new_surface = Traits::get(m_depth_stencil_storage[address]);
+			}
+			else if (store)
+			{
+				// New surface was found among invalidated surfaces
 				m_depth_stencil_storage[address] = std::move(new_surface_storage);
-				return new_surface;
 			}
 
-			m_depth_stencil_storage[address] = Traits::create_new_surface(address, depth_format, width, height, pitch, contents_to_copy, std::forward<Args>(extra_params)...);
-			return Traits::get(m_depth_stencil_storage[address]);
+#ifndef INCOMPLETE_SURFACE_CACHE_IMPL
+			// Check if old_surface is 'new' and avoid intersection
+			if (old_surface && old_surface->last_use_tag == write_tag)
+			{
+				new_surface->set_old_contents(old_surface);
+			}
+			else
+#endif
+			{
+				intersect_surface_region<true>(command_list, address, new_surface);
+			}
+
+			// Remove and preserve if possible any overlapping/replaced color surface
+			auto aliased_rtt_surface = m_render_targets_storage.find(address);
+			if (aliased_rtt_surface != m_render_targets_storage.end())
+			{
+				if (Traits::surface_is_pitch_compatible(aliased_rtt_surface->second, pitch))
+				{
+					const u8 bpp = (depth_format == rsx::surface_depth_format::z16) ? 2 : 4;
+					split_surface_region<false>(command_list, address, Traits::get(aliased_rtt_surface->second), (u16)width, (u16)height, bpp, antialias);
+				}
+
+				Traits::notify_surface_invalidated(aliased_rtt_surface->second);
+				invalidated_resources.push_back(std::move(aliased_rtt_surface->second));
+				m_render_targets_storage.erase(aliased_rtt_surface);
+			}
+
+			return new_surface;
 		}
 	public:
 		/**
@@ -600,14 +930,13 @@ namespace rsx
 //			u32 clip_y = clip_vertical_reg;
 
 			cache_tag = rsx::get_shared_tag();
-			m_memory_tree.clear();
 
 			// Make previous RTTs sampleable
-			for (std::tuple<u32, surface_type> &rtt : m_bound_render_targets)
+			for (auto &rtt : m_bound_render_targets)
 			{
 				if (std::get<1>(rtt) != nullptr)
 					Traits::prepare_rtt_for_sampling(command_list, std::get<1>(rtt));
-				rtt = std::make_tuple(0, nullptr);
+				rtt = std::make_pair(0, nullptr);
 			}
 
 			// Create/Reuse requested rtts
@@ -616,7 +945,7 @@ namespace rsx
 				if (surface_addresses[surface_index] == 0)
 					continue;
 
-				m_bound_render_targets[surface_index] = std::make_tuple(surface_addresses[surface_index],
+				m_bound_render_targets[surface_index] = std::make_pair(surface_addresses[surface_index],
 					bind_address_as_render_targets(command_list, surface_addresses[surface_index], color_format, antialias,
 						clip_width, clip_height, surface_pitch[surface_index], std::forward<Args>(extra_params)...));
 			}
@@ -625,12 +954,12 @@ namespace rsx
 			if (std::get<1>(m_bound_depth_stencil) != nullptr)
 				Traits::prepare_ds_for_sampling(command_list, std::get<1>(m_bound_depth_stencil));
 
-			m_bound_depth_stencil = std::make_tuple(0, nullptr);
+			m_bound_depth_stencil = std::make_pair(0, nullptr);
 
 			if (!address_z)
 				return;
 
-			m_bound_depth_stencil = std::make_tuple(address_z,
+			m_bound_depth_stencil = std::make_pair(address_z,
 				bind_address_as_depth_stencil(command_list, address_z, depth_format, antialias,
 					clip_width, clip_height, zeta_pitch, std::forward<Args>(extra_params)...));
 		}
@@ -1054,49 +1383,48 @@ namespace rsx
 				{
 					write_tag = cache_tag;
 				}
-			}
 
-			if (memory_tag != cache_tag)
-			{
-				generate_render_target_memory_tree();
-				memory_tag = cache_tag;
-			}
-
-			if (!m_memory_tree.empty())
-			{
-				for (auto &e : m_memory_tree)
+				// Tag all available surfaces
+				for (int i = 0; i < m_bound_render_targets.size(); ++i)
 				{
-					if (address && e.memory_address != address)
+					// Usually only 1 or 2 buffers are bound anyway
+					if (LIKELY(!m_bound_render_targets[i].first))
+					{
+						if (i) break;
+
+						// B-surface binding
+						continue;
+					}
+
+					m_bound_render_targets[i].second->on_write(write_tag);
+				}
+
+				if (m_bound_depth_stencil.first)
+				{
+					m_bound_depth_stencil.second->on_write(write_tag);
+				}
+			}
+			else
+			{
+				for (int i = 0; i < m_bound_render_targets.size(); ++i)
+				{
+					if (LIKELY(!m_bound_render_targets[i].first))
+					{
+						if (i) break;
+						continue;
+					}
+
+					if (m_bound_render_targets[i].first != address)
 					{
 						continue;
 					}
 
-					for (auto &entry : e.overlapping_set)
-					{
-						// GPU-side contents changed
-						entry._ref->dirty = true;
-					}
-				}
-			}
-
-			for (auto &rtt : m_bound_render_targets)
-			{
-				if (address && std::get<0>(rtt) != address)
-				{
-					continue;
+					m_bound_render_targets[i].second->on_write(write_tag);
 				}
 
-				if (auto surface = std::get<1>(rtt))
+				if (m_bound_depth_stencil.first == address)
 				{
-					surface->on_write(write_tag);
-				}
-			}
-
-			if (auto ds = std::get<1>(m_bound_depth_stencil))
-			{
-				if (!address || std::get<0>(m_bound_depth_stencil) == address)
-				{
-					ds->on_write(write_tag);
+					m_bound_depth_stencil.second->on_write(write_tag);
 				}
 			}
 		}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2939,7 +2939,8 @@ namespace rsx
 			}
 			else
 			{
-				dst_subres.surface->on_write();
+				dst_subres.surface->on_write(rsx::get_shared_tag());
+				m_rtts.notify_memory_structure_changed();
 			}
 
 			if (rsx::get_resolution_scale_percent() != 100)

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1750,8 +1750,11 @@ namespace rsx
 				// Intersect this resource with the original one
 				const auto section_bpp = get_format_block_size_in_bytes(section->get_gcm_format());
 				const auto normalized_width = (section->get_width() * section_bpp) / bpp;
-				const auto clipped = rsx::intersect_region(address, slice_w, slice_h, bpp,
-					section->get_section_base(), normalized_width, section->get_height(), section_bpp, pitch);
+
+				const auto clipped = rsx::intersect_region(
+					section->get_section_base(), normalized_width, section->get_height(), section_bpp, /* parent region (extractee) */
+					address, slice_w, slice_h, bpp, /* child region (extracted) */
+					pitch);
 
 				// Rect intersection test
 				// TODO: Make the intersection code cleaner with proper 2D regions

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1252,7 +1252,7 @@ namespace rsx
 		}
 
 		template <typename ...FlushArgs, typename ...Args>
-		void lock_memory_region(commandbuffer_type& cmd, image_storage_type* image, const address_range &rsx_range, u32 width, u32 height, u32 pitch, Args&&... extras)
+		void lock_memory_region(commandbuffer_type& cmd, image_storage_type* image, const address_range &rsx_range, bool is_active_surface, u32 width, u32 height, u32 pitch, Args&&... extras)
 		{
 			AUDIT(g_cfg.video.write_color_buffers || g_cfg.video.write_depth_buffer); // this method is only called when either WCB or WDB are enabled
 
@@ -1297,15 +1297,18 @@ namespace rsx
 			region.set_dirty(false);
 			region.touch(m_cache_update_tag);
 
-			// Add to flush always cache
-			if (region.get_memory_read_flags() != memory_read_flags::flush_always)
+			if (is_active_surface)
 			{
-				region.set_memory_read_flags(memory_read_flags::flush_always, false);
-				update_flush_always_cache(region, true);
-			}
-			else
-			{
-				AUDIT(m_flush_always_cache.find(region.get_section_range()) != m_flush_always_cache.end());
+				// Add to flush always cache
+				if (region.get_memory_read_flags() != memory_read_flags::flush_always)
+				{
+					region.set_memory_read_flags(memory_read_flags::flush_always, false);
+					update_flush_always_cache(region, true);
+				}
+				else
+				{
+					AUDIT(m_flush_always_cache.find(region.get_section_range()) != m_flush_always_cache.end());
+				}
 			}
 
 			update_cache_tag();

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2461,7 +2461,7 @@ namespace rsx
 
 				for (auto It = list.rbegin(); It != list.rend(); ++It)
 				{
-					if (!(It->surface->usage & rsx::surface_usage_flags::attachment))
+					if (!(It->surface->memory_usage_flags & rsx::surface_usage_flags::attachment))
 					{
 						// HACK
 						// TODO: Properly analyse the input here to determine if it can properly fit what we need

--- a/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12RenderTargetSets.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#define INCOMPLETE_SURFACE_CACHE_IMPL
+
 #include <utility>
 #include <d3d12.h>
 #include "d3dx12.h"
@@ -25,7 +27,6 @@ struct render_target_traits
 	ComPtr<ID3D12Resource> create_new_surface(
 		u32 address,
 		surface_color_format color_format, size_t width, size_t height, size_t /*pitch*/,
-		ID3D12Resource* /*old*/,
 		ID3D12Device* device, const std::array<float, 4> &clear_color, float, u8)
 	{
 		DXGI_FORMAT dxgi_format = get_color_surface_format(color_format);
@@ -86,7 +87,6 @@ struct render_target_traits
 	ComPtr<ID3D12Resource> create_new_surface(
 		u32 address,
 		surface_depth_format surfaceDepthFormat, size_t width, size_t height, size_t /*pitch*/,
-		ID3D12Resource* /*old*/,
 		ID3D12Device* device, const std::array<float, 4>& , float clear_depth, u8 clear_stencil)
 	{
 		D3D12_CLEAR_VALUE clear_depth_value = {};
@@ -131,7 +131,7 @@ struct render_target_traits
 	static
 	void invalidate_surface_contents(
 		ID3D12GraphicsCommandList*,
-		ID3D12Resource*, ID3D12Resource*,
+		ID3D12Resource*,
 		u32, size_t)
 	{}
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1013,6 +1013,7 @@ void GLGSRender::on_exit()
 	zcull_ctrl.release();
 
 	m_prog_buffer.clear();
+	m_rtts.destroy();
 
 	for (auto &fbo : m_framebuffer_cache)
 	{
@@ -1800,10 +1801,9 @@ void GLGSRender::flip(int buffer, bool emu_flip)
 	auto removed_textures = m_rtts.free_invalidated();
 	m_framebuffer_cache.remove_if([&](auto& fbo)
 	{
-		if (fbo.deref_count >= 2) return true; // Remove if stale
+		if (fbo.unused_check_count() >= 2) return true; // Remove if stale
 		if (fbo.references_any(removed_textures)) return true; // Remove if any of the attachments is invalid
 
-		fbo.deref_count++;
 		return false;
 	});
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -398,7 +398,9 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		if (g_cfg.video.write_color_buffers)
 		{
 			// Mark buffer regions as NO_ACCESS on Cell-visible side
-			m_gl_texture_cache.lock_memory_region(cmd, std::get<1>(m_rtts.m_bound_render_targets[i]), surface_range, m_surface_info[i].width, m_surface_info[i].height, m_surface_info[i].pitch,
+			m_gl_texture_cache.lock_memory_region(
+				cmd, m_rtts.m_bound_render_targets[i].second, surface_range, true,
+				m_surface_info[i].width, m_surface_info[i].height, m_surface_info[i].pitch,
 				color_format.format, color_format.type, color_format.swap_bytes);
 		}
 		else
@@ -413,7 +415,9 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		if (g_cfg.video.write_depth_buffer)
 		{
 			const auto depth_format_gl = rsx::internals::surface_depth_format_to_gl(layout.depth_format);
-			m_gl_texture_cache.lock_memory_region(cmd, std::get<1>(m_rtts.m_bound_depth_stencil), surface_range, m_depth_surface_info.width, m_depth_surface_info.height, m_depth_surface_info.pitch,
+			m_gl_texture_cache.lock_memory_region(
+				cmd, m_rtts.m_bound_depth_stencil.second, surface_range, true,
+				m_depth_surface_info.width, m_depth_surface_info.height, m_depth_surface_info.pitch,
 				depth_format_gl.format, depth_format_gl.type, true);
 		}
 		else
@@ -451,7 +455,8 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 					swap_bytes = color_format_gl.swap_bytes;
 				}
 
-				m_gl_texture_cache.lock_memory_region(cmd, surface, surface->get_memory_range(),
+				m_gl_texture_cache.lock_memory_region(
+					cmd, surface, surface->get_memory_range(), false,
 					surface->get_surface_width(), surface->get_surface_height(), surface->get_rsx_pitch(),
 					format, type, swap_bytes);
 			}
@@ -681,7 +686,7 @@ void gl::render_target::memory_barrier(gl::command_context& cmd, bool force_init
 	if (state_flags & rsx::surface_state_flags::erase_bkgnd)
 	{
 		const auto area = old_contents.dst_rect();
-		if (area.x1 > 0 || area.y1 > 0 || area.x2 < width() || area.y2 < height())
+		if (area.x1 > 0 || area.y1 > 0 || unsigned(area.x2) < width() || unsigned(area.y2) < height())
 		{
 			clear_surface_impl();
 		}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -422,6 +422,44 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		}
 	}
 
+	if (!m_rtts.orphaned_surfaces.empty())
+	{
+		if (g_cfg.video.write_color_buffers || g_cfg.video.write_depth_buffer)
+		{
+			gl::texture::format format;
+			gl::texture::type type;
+			bool swap_bytes;
+
+			for (auto& surface : m_rtts.orphaned_surfaces)
+			{
+				if (surface->is_depth_surface())
+				{
+					if (!g_cfg.video.write_depth_buffer) continue;
+
+					const auto depth_format_gl = rsx::internals::surface_depth_format_to_gl(surface->get_surface_depth_format());
+					format = depth_format_gl.format;
+					type = depth_format_gl.type;
+					swap_bytes = true;
+				}
+				else
+				{
+					if (!g_cfg.video.write_color_buffers) continue;
+
+					const auto color_format_gl = rsx::internals::surface_color_format_to_gl(surface->get_surface_color_format());
+					format = color_format_gl.format;
+					type = color_format_gl.type;
+					swap_bytes = color_format_gl.swap_bytes;
+				}
+
+				m_gl_texture_cache.lock_memory_region(cmd, surface, surface->get_memory_range(),
+					surface->get_surface_width(), surface->get_surface_height(), surface->get_rsx_pitch(),
+					format, type, swap_bytes);
+			}
+		}
+
+		m_rtts.orphaned_surfaces.clear();
+	}
+
 	if (m_gl_texture_cache.get_ro_tex_invalidate_intr())
 	{
 		//Invalidate cached sampler state

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -188,6 +188,7 @@ struct gl_render_target_traits
 		std::array<GLenum, 4> native_layout = { (GLenum)format.swizzle.a, (GLenum)format.swizzle.r, (GLenum)format.swizzle.g, (GLenum)format.swizzle.b };
 		result->set_native_component_layout(native_layout);
 
+		result->usage = rsx::surface_usage_flags::attachment;
 		result->set_cleared(false);
 		result->queue_tag(address);
 		result->add_ref();
@@ -215,6 +216,7 @@ struct gl_render_target_traits
 		result->set_native_component_layout(native_layout);
 		result->set_format(surface_depth_format);
 
+		result->usage = rsx::surface_usage_flags::attachment;
 		result->set_cleared(false);
 		result->queue_tag(address);
 		result->add_ref();
@@ -234,6 +236,7 @@ struct gl_render_target_traits
 			const auto new_h = rsx::apply_resolution_scale(prev.height, true, ref->get_surface_height());
 
 			sink.reset(new gl::render_target(new_w, new_h, internal_format));
+			sink->usage = rsx::surface_usage_flags::storage;
 			sink->add_ref();
 			sink->format_info = ref->format_info;
 			sink->set_native_pitch(prev.width * ref->get_bpp());
@@ -272,10 +275,17 @@ struct gl_render_target_traits
 		info->bpp = surface->get_bpp();
 	}
 
-	static void prepare_rtt_for_drawing(gl::command_context&, gl::render_target*) {}
+	static void prepare_rtt_for_drawing(gl::command_context&, gl::render_target* rtt)
+	{
+		rtt->usage |= rsx::surface_usage_flags::attachment;
+	}
+
+	static void prepare_ds_for_drawing(gl::command_context&, gl::render_target* ds)
+	{
+		ds->usage |= rsx::surface_usage_flags::attachment;
+	}
+
 	static void prepare_rtt_for_sampling(gl::command_context&, gl::render_target*) {}
-	
-	static void prepare_ds_for_drawing(gl::command_context&, gl::render_target*) {}
 	static void prepare_ds_for_sampling(gl::command_context&, gl::render_target*) {}
 
 	static
@@ -292,6 +302,7 @@ struct gl_render_target_traits
 		surface->queue_tag(address);
 		surface->set_cleared(false);
 		surface->last_use_tag = 0;
+		surface->usage = rsx::surface_usage_flags::unknown;
 	}
 
 	static

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -284,12 +284,18 @@ struct gl_render_target_traits
 		surface->reset_aa_mode();
 		surface->queue_tag(address);
 		surface->set_cleared(false);
+		surface->last_use_tag = 0;
 	}
 
 	static
 	void notify_surface_invalidated(const std::unique_ptr<gl::render_target>& surface)
 	{
-		if (surface->old_contents) surface->clear_rw_barrier();
+		if (surface->old_contents)
+		{
+			// TODO: Retire the deferred writes
+			surface->clear_rw_barrier();
+		}
+
 		surface->release();
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -233,7 +233,7 @@ namespace gl
 			if (context == rsx::texture_upload_context::framebuffer_storage)
 			{
 				auto as_rtt = static_cast<gl::render_target*>(vram_texture);
-				if (as_rtt->dirty) as_rtt->read_barrier(cmd);
+				if (as_rtt->dirty()) as_rtt->read_barrier(cmd);
 			}
 
 			gl::texture* target_texture = vram_texture;

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -32,8 +32,8 @@ namespace vk
 				{ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_MAX_COMPUTE_TASKS }
 			};
 
-			//Reserve descriptor pools
-			m_descriptor_pool.create(*get_current_renderer(), descriptor_pool_sizes, 1);
+			// Reserve descriptor pools
+			m_descriptor_pool.create(*get_current_renderer(), descriptor_pool_sizes, 2);
 
 			std::vector<VkDescriptorSetLayoutBinding> bindings(2);
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3083,8 +3083,10 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		const utils::address_range surface_range = m_surface_info[index].get_memory_range();
 		if (g_cfg.video.write_color_buffers)
 		{
-			m_texture_cache.lock_memory_region(*m_current_command_buffer, std::get<1>(m_rtts.m_bound_render_targets[index]), surface_range,
-				m_surface_info[index].width, m_surface_info[index].height, layout.actual_color_pitch[index], color_fmt_info.first, color_fmt_info.second);
+			m_texture_cache.lock_memory_region(
+				*m_current_command_buffer, m_rtts.m_bound_render_targets[index].second, surface_range, true,
+				m_surface_info[index].width, m_surface_info[index].height, layout.actual_color_pitch[index],
+				color_fmt_info.first, color_fmt_info.second);
 		}
 		else
 		{
@@ -3098,7 +3100,8 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		if (g_cfg.video.write_depth_buffer)
 		{
 			const u32 gcm_format = (m_depth_surface_info.depth_format != rsx::surface_depth_format::z16) ? CELL_GCM_TEXTURE_DEPTH16 : CELL_GCM_TEXTURE_DEPTH24_D8;
-			m_texture_cache.lock_memory_region(*m_current_command_buffer, std::get<1>(m_rtts.m_bound_depth_stencil), surface_range,
+			m_texture_cache.lock_memory_region(
+				*m_current_command_buffer, m_rtts.m_bound_depth_stencil.second, surface_range, true,
 				m_depth_surface_info.width, m_depth_surface_info.height, layout.actual_zeta_pitch, gcm_format, false);
 		}
 		else
@@ -3132,7 +3135,8 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 					swap_bytes = info.second;
 				}
 
-				m_texture_cache.lock_memory_region(*m_current_command_buffer, surface, surface->get_memory_range(),
+				m_texture_cache.lock_memory_region(
+					*m_current_command_buffer, surface, surface->get_memory_range(), false,
 					surface->get_surface_width(), surface->get_surface_height(), surface->get_rsx_pitch(),
 					gcm_format, swap_bytes);
 			}

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -150,7 +150,7 @@ namespace vk
 	void copy_image_to_buffer(VkCommandBuffer cmd, const vk::image* src, const vk::buffer* dst, const VkBufferImageCopy& region);
 	void copy_buffer_to_image(VkCommandBuffer cmd, const vk::buffer* src, const vk::image* dst, const VkBufferImageCopy& region);
 
-	void copy_image_typeless(const command_buffer &cmd, const image *src, const image *dst, const areai& src_rect, const areai& dst_rect,
+	void copy_image_typeless(const command_buffer &cmd, image *src, image *dst, const areai& src_rect, const areai& dst_rect,
 		u32 mipmaps, VkImageAspectFlags src_aspect, VkImageAspectFlags dst_aspect,
 		VkImageAspectFlags src_transfer_mask = 0xFF, VkImageAspectFlags dst_transfer_mask = 0xFF);
 
@@ -1067,13 +1067,13 @@ namespace vk
 			return m_storage_aspect;
 		}
 
-		void push_layout(command_buffer& cmd, VkImageLayout layout)
+		void push_layout(VkCommandBuffer cmd, VkImageLayout layout)
 		{
 			m_layout_stack.push(current_layout);
 			change_image_layout(cmd, this, layout);
 		}
 
-		void pop_layout(command_buffer& cmd)
+		void pop_layout(VkCommandBuffer cmd)
 		{
 			verify(HERE), !m_layout_stack.empty();
 

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -312,7 +312,7 @@ namespace vk
 				auto fbo = It->get();
 				if (fbo->matches(test, target->width(), target->height()))
 				{
-					fbo->deref_count = 0;
+					fbo->add_ref();
 					return fbo;
 				}
 			}
@@ -338,6 +338,7 @@ namespace vk
 			auto result = fbo.get();
 			framebuffer_resources.push_back(std::move(fbo));
 
+			result->add_ref();
 			return result;
 		}
 
@@ -381,7 +382,10 @@ namespace vk
 		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::image* target, const std::vector<VkImageView>& src, VkRenderPass render_pass, std::list<std::unique_ptr<vk::framebuffer_holder>>& framebuffer_resources)
 		{
 			vk::framebuffer *fbo = get_framebuffer(target, render_pass, framebuffer_resources);
+
 			run(cmd, w, h, fbo, src, render_pass);
+
+			static_cast<vk::framebuffer_holder*>(fbo)->release();
 		}
 
 		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::image* target, VkImageView src, VkRenderPass render_pass, std::list<std::unique_ptr<vk::framebuffer_holder>>& framebuffer_resources)

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -197,6 +197,7 @@ namespace rsx
 			change_image_layout(cmd, rtt.get(), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, vk::get_image_subresource_range(0, 0, 1, 1, VK_IMAGE_ASPECT_COLOR_BIT));
 
 			rtt->set_format(format);
+			rtt->usage = rsx::surface_usage_flags::attachment;
 			rtt->native_component_map = fmt.second;
 			rtt->rsx_pitch = (u16)pitch;
 			rtt->native_pitch = (u16)width * get_format_block_size_in_bytes(format);
@@ -235,7 +236,9 @@ namespace rsx
 				VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT| VK_IMAGE_USAGE_TRANSFER_SRC_BIT| VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_SAMPLED_BIT,
 				0));
 
+
 			ds->set_format(format);
+			ds->usage = rsx::surface_usage_flags::attachment;
 			ds->native_component_map = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
 			change_image_layout(cmd, ds.get(), VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, range);
 
@@ -277,6 +280,7 @@ namespace rsx
 
 				sink->add_ref();
 				sink->format_info = ref->format_info;
+				sink->usage = rsx::surface_usage_flags::storage;
 				sink->native_component_map = ref->native_component_map;
 				sink->native_pitch = u16(prev.width * ref->get_bpp());
 				sink->surface_width = prev.width;
@@ -315,6 +319,7 @@ namespace rsx
 		{
 			surface->change_layout(cmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 			surface->frame_tag = 0;
+			surface->usage |= rsx::surface_usage_flags::attachment;
 		}
 
 		static void prepare_rtt_for_sampling(vk::command_buffer& cmd, vk::render_target *surface)
@@ -326,6 +331,7 @@ namespace rsx
 		{
 			surface->change_layout(cmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 			surface->frame_tag = 0;
+			surface->usage |= rsx::surface_usage_flags::attachment;
 		}
 
 		static void prepare_ds_for_sampling(vk::command_buffer& cmd, vk::render_target *surface)
@@ -345,6 +351,7 @@ namespace rsx
 			surface->queue_tag(address);
 			surface->dirty = true;
 			surface->last_use_tag = 0;
+			surface->usage = rsx::surface_usage_flags::unknown;
 		}
 
 		static void notify_surface_invalidated(const std::unique_ptr<vk::render_target> &surface)

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -146,7 +146,7 @@ namespace vk
 			if (state_flags & rsx::surface_state_flags::erase_bkgnd)
 			{
 				const auto area = old_contents.dst_rect();
-				if (area.x1 > 0 || area.y1 > 0 || area.x2 < width() || area.y2 < height())
+				if (area.x1 > 0 || area.y1 > 0 || unsigned(area.x2) < width() || unsigned(area.y2) < height())
 				{
 					clear_surface_impl();
 				}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -341,6 +341,7 @@ namespace rsx
 			surface->reset_aa_mode();
 			surface->queue_tag(address);
 			surface->dirty = true;
+			surface->last_use_tag = 0;
 		}
 
 		static void notify_surface_invalidated(const std::unique_ptr<vk::render_target> &surface)
@@ -348,7 +349,12 @@ namespace rsx
 			surface->frame_tag = vk::get_current_frame_id();
 			if (!surface->frame_tag) surface->frame_tag = 1;
 
-			if (surface->old_contents) surface->clear_rw_barrier();
+			if (surface->old_contents)
+			{
+				// TODO: Retire the deferred writes
+				surface->clear_rw_barrier();
+			}
+
 			surface->release();
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -439,7 +439,7 @@ namespace vk
 					vkCmdCopyBufferToImage(cmd, scratch_buf->value, dst, preferred_dst_format, 1, &info);
 				};
 
-				const u32 typeless_w = dst_rect.width();
+				const u32 typeless_w = std::max(dst_rect.width(), src_rect.width());
 				const u32 typeless_h = src_rect.height() + dst_rect.height();
 
 				switch (src_format)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -192,7 +192,7 @@ namespace vk
 			if (context == rsx::texture_upload_context::framebuffer_storage)
 			{
 				auto as_rtt = static_cast<vk::render_target*>(vram_texture);
-				if (as_rtt->dirty) as_rtt->read_barrier(cmd);
+				if (as_rtt->dirty()) as_rtt->read_barrier(cmd);
 			}
 
 			vk::image *target = vram_texture;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -555,7 +555,6 @@ namespace vk
 					verify(HERE), section.dst_z == 0;
 
 					u16 dst_x = section.dst_x, dst_y = section.dst_y;
-					auto xform = section.xform;
 					vk::image* _dst;
 
 					if (LIKELY(src_image->info.format == dst->info.format))

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -810,7 +810,6 @@ namespace rsx
 
 	namespace nv3089
 	{
-#pragma optimize("", off)
 		void image_in(thread *rsx, u32 _reg, u32 arg)
 		{
 			const rsx::blit_engine::transfer_operation operation = method_registers.blit_engine_operation();
@@ -1191,7 +1190,6 @@ namespace rsx
 				std::memcpy(pixels_dst, swizzled_pixels, out_bpp * sw_width * sw_height);
 			}
 		}
-#pragma optimize("", on)
 	}
 
 	namespace nv0039

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -470,32 +470,35 @@ namespace rsx
 		return std::make_tuple(x, y, width, height);
 	}
 
+	/**
+	 * Extracts from 'parent' a region that fits in 'child'
+	 */
 	static inline std::tuple<position2u, position2u, size2u> intersect_region(
-		u32 dst_address, u16 dst_w, u16 dst_h, u16 dst_bpp,
-		u32 src_address, u16 src_w, u16 src_h, u32 src_bpp,
+		u32 parent_address, u16 parent_w, u16 parent_h, u16 parent_bpp,
+		u32 child_address, u16 child_w, u16 child_h, u32 child_bpp,
 		u32 pitch)
 	{
-		if (src_address < dst_address)
+		if (child_address < parent_address)
 		{
-			const auto offset = dst_address - src_address;
-			const auto src_y = (offset / pitch);
-			const auto src_x = (offset % pitch) / src_bpp;
-			const auto dst_x = 0u;
-			const auto dst_y = 0u;
-			const auto w = std::min<u32>(dst_w, src_w - src_x);
-			const auto h = std::min<u32>(dst_h, src_h - src_y);
+			const auto offset = parent_address - child_address;
+			const auto src_x = 0u;
+			const auto src_y = 0u;
+			const auto dst_y = (offset / pitch);
+			const auto dst_x = (offset % pitch) / child_bpp;
+			const auto w = std::min<u32>(parent_w, child_w - dst_x);
+			const auto h = std::min<u32>(parent_h, child_h - dst_y);
 
 			return std::make_tuple<position2u, position2u, size2u>({ src_x, src_y }, { dst_x, dst_y }, { w, h });
 		}
 		else
 		{
-			const auto offset = src_address - dst_address;
-			const auto src_x = 0u;
-			const auto src_y = 0u;
-			const auto dst_y = (offset / pitch);
-			const auto dst_x = (offset % pitch) / dst_bpp;
-			const auto w = std::min<u32>(src_w, dst_w - dst_x);
-			const auto h = std::min<u32>(src_h, dst_h - dst_y);
+			const auto offset = child_address - parent_address;
+			const auto src_y = (offset / pitch);
+			const auto src_x = (offset % pitch) / parent_bpp;
+			const auto dst_x = 0u;
+			const auto dst_y = 0u;
+			const auto w = std::min<u32>(child_w, parent_w - src_x);
+			const auto h = std::min<u32>(child_h, parent_h - src_y);
 
 			return std::make_tuple<position2u, position2u, size2u>({ src_x, src_y }, { dst_x, dst_y }, { w, h });
 		}
@@ -511,10 +514,14 @@ namespace rsx
 		return g_cfg.video.strict_rendering_mode ? 100 : g_cfg.video.resolution_scale_percent;
 	}
 
-	static inline const u16 apply_resolution_scale(u16 value, bool clamp)
+	static inline const u16 apply_resolution_scale(u16 value, bool clamp, u16 ref = 0)
 	{
-		if (value <= g_cfg.video.min_scalable_dimension)
+		if (ref == 0)
+			ref = value;
+
+		if (ref <= g_cfg.video.min_scalable_dimension)
 			return value;
+
 		else if (clamp)
 			return (u16)std::max((get_resolution_scale_percent() * value) / 100, 1);
 		else
@@ -541,14 +548,14 @@ namespace rsx
 	 * Returns <src_w, src_h, dst_w, dst_h>
 	 */
 	template <typename SurfaceType>
-	std::tuple<u16, u16, u16, u16> get_transferable_region(SurfaceType* surface)
+	std::tuple<u16, u16, u16, u16> get_transferable_region(const SurfaceType* surface)
 	{
-		const u16 src_w = surface->old_contents->width();
-		const u16 src_h = surface->old_contents->height();
+		const u16 src_w = surface->old_contents.source->width();
+		const u16 src_h = surface->old_contents.source->height();
 		u16 dst_w = src_w;
 		u16 dst_h = src_h;
 
-		switch (static_cast<SurfaceType*>(surface->old_contents)->read_aa_mode)
+		switch (static_cast<const SurfaceType*>(surface->old_contents.source)->read_aa_mode)
 		{
 		case rsx::surface_antialiasing::center_1_sample:
 			break;
@@ -584,7 +591,7 @@ namespace rsx
 	}
 
 	template <typename SurfaceType>
-	inline bool pitch_compatible(SurfaceType* a, SurfaceType* b)
+	inline bool pitch_compatible(const SurfaceType* a, const SurfaceType* b)
 	{
 		if (a->get_surface_height() == 1 || b->get_surface_height() == 1)
 			return true;
@@ -593,7 +600,7 @@ namespace rsx
 	}
 
 	template <bool __is_surface = true, typename SurfaceType>
-	inline bool pitch_compatible(SurfaceType* surface, u16 pitch_required, u16 height_required)
+	inline bool pitch_compatible(const SurfaceType* surface, u16 pitch_required, u16 height_required)
 	{
 		if constexpr (__is_surface)
 		{

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -27,6 +27,11 @@ namespace rsx
 	using utils::page_end;
 	using utils::next_page;
 
+	using flags64_t = uint64_t;
+	using flags32_t = uint32_t;
+	using flags16_t = uint16_t;
+	using flags8_t = uint8_t;
+
 	// Definitions
 	class thread;
 	extern thread* g_current_renderer;


### PR DESCRIPTION
Variable-sized framebuffers idea turned out to be a disaster, so I had to go back to the drawing board. Perform surface cache intersection resolve for surfaces to allow propagation of old data through most cases. Essentially guarantees that previous ROP writes to an arbitrary memory range are present if any render-target is created from the same range. Removes need for the memory hierachy invalidation hack needed for RDR to render accurate shadows.

- Allows render targets to behave like stacked 3D views same as shader inputs are resolved
- Basically implements most of 'Read Color/Depth Buffers" option for 'free'.
- Allows splitting RTV/DSV resources if they are superceded by a partial surface
- Also allows intersecting new resources through the surface cache for proper inheritance from other scattered data