### PR TITLE
SPU LLVM: Fix "Mega" regression

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -1936,7 +1936,7 @@ const std::vector<u32>& spu_recompiler_base::analyse(const be_t<u32>* ls, u32 en
 		block.preds = pred.second;
 
 		// Fill register usage info
-		for (u32 ia = pred.first; ia < 0x40000; ia += 4)
+		for (u32 ia = pred.first; ia < limit; ia += 4)
 		{
 			block.size++;
 


### PR DESCRIPTION
Should fix #5950 and other assorted crashes when using SPU LLVM Mega since #5923

Tested RDR and TLOU with SPU LLVM Mega and they no longer crash (TLOU still has significant issues with race-conditions, but I managed to get in-game after enough tries).

Thanks to @Nekotekina for his help figuring this one out, he did basically all the work, I just tested 👍 