### PR TITLE
Use setenv instead of qputenv for QT_AUTO_SCREEN_SCALE_FACTOR

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
 #if defined(_WIN32) || defined(__APPLE__)
 	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #else
-	qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
+	setenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1", 0);
 #endif
 
 #ifdef __linux__


### PR DESCRIPTION
RPCS3 is hardcoded to set this environment variable.

A user on Discord reported they had issues with Qt's hidpi scaling with RPCS3 on Linux. They could not disable it by setting this environment variable to 0, because qputenv inside RPCS3 is hardcoded to overwrite it, setenv with 0 as third arg won't ovewrite already set environment variables.