### PR TITLE
vk: Workaround for cyclic feedback loops

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -34,6 +34,7 @@ namespace rsx
 		texture_upload_context upload_context = texture_upload_context::shader_read;
 		rsx::texture_dimension_extended image_type = texture_dimension_extended::texture_dimension_2d;
 		bool is_depth_texture = false;
+		bool is_cyclic_reference = false;
 		f32 scale_x = 1.f;
 		f32 scale_y = 1.f;
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -213,11 +213,13 @@ namespace rsx
 			sampled_image_descriptor()
 			{}
 
-			sampled_image_descriptor(image_view_type handle, texture_upload_context ctx, bool is_depth, f32 x_scale, f32 y_scale, rsx::texture_dimension_extended type)
+			sampled_image_descriptor(image_view_type handle, texture_upload_context ctx, bool is_depth,
+				f32 x_scale, f32 y_scale, rsx::texture_dimension_extended type, bool cyclic_reference = false)
 			{
 				image_handle = handle;
 				upload_context = ctx;
 				is_depth_texture = is_depth;
+				is_cyclic_reference = cyclic_reference;
 				scale_x = x_scale;
 				scale_y = y_scale;
 				image_type = type;
@@ -1981,7 +1983,7 @@ namespace rsx
 				}
 
 				return{ texptr->get_view(encoded_remap, decoded_remap), texture_upload_context::framebuffer_storage,
-					is_depth, scale_x, scale_y, rsx::texture_dimension_extended::texture_dimension_2d };
+					is_depth, scale_x, scale_y, rsx::texture_dimension_extended::texture_dimension_2d, assume_bound };
 			}
 
 			const auto scaled_w = rsx::apply_resolution_scale(internal_width, true);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -396,7 +396,8 @@ private:
 
 	std::atomic<u64> m_last_sync_event = { 0 };
 
-	bool render_pass_open = false;
+	bool m_render_pass_open = false;
+	bool m_render_pass_is_cyclic = false;
 	size_t m_current_renderpass_id = 0;
 
 	//Vertex layout

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -69,23 +69,21 @@ namespace vk
 			// Helper to optionally clear/initialize memory contents depending on barrier type
 			auto clear_surface_impl = [&]()
 			{
+				push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 				VkImageSubresourceRange range{ aspect(), 0, 1, 0, 1 };
-				const auto old_layout = current_layout;
-
-				change_image_layout(cmd, this, VK_IMAGE_LAYOUT_GENERAL, range);
 
 				if (aspect() & VK_IMAGE_ASPECT_COLOR_BIT)
 				{
 					VkClearColorValue color{};
-					vkCmdClearColorImage(cmd, value, VK_IMAGE_LAYOUT_GENERAL, &color, 1, &range);
+					vkCmdClearColorImage(cmd, value, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &color, 1, &range);
 				}
 				else
 				{
 					VkClearDepthStencilValue clear{ 1.f, 255 };
-					vkCmdClearDepthStencilImage(cmd, value, VK_IMAGE_LAYOUT_GENERAL, &clear, 1, &range);
+					vkCmdClearDepthStencilImage(cmd, value, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &range);
 				}
 
-				change_image_layout(cmd, this, old_layout, range);
+				pop_layout(cmd);
 				state_flags &= ~rsx::surface_state_flags::erase_bkgnd;
 			};
 


### PR DESCRIPTION
- Transition attachments to LAYOUT_GENERAL in case of a feedback loop. Fixes appearance of garbage along polygon edges in some post-processing passes.
  - Also reverse this transition when rendering goes back to normal
- Optimize transitions from LAYOUT_GENERAL to some common read/write layouts.

Retry of https://github.com/RPCS3/rpcs3/pull/5973