### PR TITLE
Input: add a stick multiplier for better game pad support

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -277,7 +277,7 @@ error_code getText(vm::ptr<CellOskDialogCallbackReturnParam> OutputInfo, bool is
 
 	bool do_copy = OutputInfo->pResultString && (OutputInfo->result == CELL_OSKDIALOG_INPUT_FIELD_RESULT_OK || (is_unload && OutputInfo->result == CELL_OSKDIALOG_INPUT_FIELD_RESULT_NO_INPUT_TEXT));
 
-	for (u32 i = 0; i < CELL_OSKDIALOG_STRING_SIZE - 1; i++)
+	for (s32 i = 0; i < CELL_OSKDIALOG_STRING_SIZE - 1; i++)
 	{
 		osk->osk_text_old[i] = osk->osk_text[i];
 

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -255,8 +255,8 @@ public:
 
 	atomic_t<CellOskDialogContinuousMode> osk_continuous_mode{ CellOskDialogContinuousMode::CELL_OSKDIALOG_CONTINUOUS_MODE_NONE };
 	atomic_t<CellOskDialogInputFieldResult> osk_input_result{ CellOskDialogInputFieldResult::CELL_OSKDIALOG_INPUT_FIELD_RESULT_OK };
-	char16_t osk_text[CELL_OSKDIALOG_STRING_SIZE];
-	char16_t osk_text_old[CELL_OSKDIALOG_STRING_SIZE];
+	char16_t osk_text[CELL_OSKDIALOG_STRING_SIZE]{};
+	char16_t osk_text_old[CELL_OSKDIALOG_STRING_SIZE]{};
 
 	vm::ptr<cellOskDialogConfirmWordFilterCallback> osk_confirm_callback{ vm::null };
 };

--- a/rpcs3/Emu/GameInfo.h
+++ b/rpcs3/Emu/GameInfo.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 struct GameInfo
 {
@@ -11,11 +11,11 @@ struct GameInfo
 	std::string category;
 	std::string fw;
 
-	u32 attr;
-	u32 bootable;
-	u32 parental_lvl;
-	u32 sound_format;
-	u32 resolution;
+	u32 attr = 0;
+	u32 bootable = 0;
+	u32 parental_lvl = 0;
+	u32 sound_format = 0;
+	u32 resolution = 0;
 
 	GameInfo()
 	{

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -130,14 +130,14 @@ u16 PadHandlerBase::NormalizeTriggerInput(u16 value, int threshold)
 
 // normalizes a directed input, meaning it will correspond to a single "button" and not an axis with two directions
 // the input values must lie in 0+
-u16 PadHandlerBase::NormalizeDirectedInput(u16 raw_value, s32 threshold, s32 maximum)
+u16 PadHandlerBase::NormalizeDirectedInput(s32 raw_value, s32 threshold, s32 maximum)
 {
 	if (threshold >= maximum || maximum <= 0)
 	{
 		return static_cast<u16>(0);
 	}
 
-	float val = float(std::clamp(static_cast<s32>(raw_value), 0, maximum)) / float(maximum); // value based on max range converted to [0, 1]
+	float val = float(std::clamp(raw_value, 0, maximum)) / float(maximum); // value based on max range converted to [0, 1]
 
 	if (threshold <= 0)
 	{
@@ -150,15 +150,17 @@ u16 PadHandlerBase::NormalizeDirectedInput(u16 raw_value, s32 threshold, s32 max
 	}
 }
 
-u16 PadHandlerBase::NormalizeStickInput(u16 raw_value, int threshold, bool ignore_threshold)
+u16 PadHandlerBase::NormalizeStickInput(u16 raw_value, int threshold, int multiplier, bool ignore_threshold)
 {
+	const s32 scaled_value = (multiplier * raw_value) / 100;
+
 	if (ignore_threshold)
 	{
-		return static_cast<u16>(ScaleStickInput(raw_value, 0, thumb_max));
+		return static_cast<u16>(ScaleStickInput(scaled_value, 0, thumb_max));
 	}
 	else
 	{
-		return NormalizeDirectedInput(raw_value, threshold, thumb_max);
+		return NormalizeDirectedInput(scaled_value, threshold, thumb_max);
 	}
 }
 

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -488,8 +488,7 @@ public:
 	virtual ~PadHandlerBase() = default;
 	//Sets window to config the controller(optional)
 	virtual void GetNextButtonPress(const std::string& /*padId*/, const std::function<void(u16, std::string, std::string, int[])>& /*callback*/, const std::function<void(std::string)>& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) {}
-	virtual void TestVibration(const std::string& /*padId*/, u32 /*largeMotor*/, u32 /*smallMotor*/) {}
-	virtual void SetLED(const std::string& /*padId*/, s32 /*r*/, s32 /*g*/, s32 /*b*/) {}
+	virtual void SetPadData(const std::string& /*padId*/, u32 /*largeMotor*/, u32 /*smallMotor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/) {}
 	//Return list of devices for that handler
 	virtual std::vector<std::string> ListDevices() = 0;
 	//Callback called during pad_thread::ThreadFunc

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <cmath>
 #include <vector>
@@ -175,7 +175,7 @@ struct Pad
 	// Cable State:   0 - 1  plugged in ?
 	u8 m_cable_state;
 
-	// DS4: 0 - 9  while unplugged, 0 - 10 while plugged in, 11 charge complete
+	// DS4: 0 - 9 while unplugged, 0 - 10 while plugged in, 11 charge complete
 	// XInput: 0 = Empty, 1 = Low, 2 = Medium, 3 = Full
 	u8 m_battery_level;
 
@@ -227,6 +227,9 @@ struct Pad
 		, m_port_status(port_status)
 		, m_device_capability(device_capability)
 		, m_device_type(device_type)
+		, m_class_type(0)
+		, m_cable_state(0)
+		, m_battery_level(0)
 
 		, m_digital_1(0)
 		, m_digital_2(0)

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cmath>
 #include <vector>
@@ -346,6 +346,8 @@ struct pad_config final : cfg::node
 	cfg::string l2      { this, "L2", "" };
 	cfg::string l3      { this, "L3", "" };
 
+	cfg::_int<0, 200> lstickmultiplier{this, "Left Stick Multiplier", 100};
+	cfg::_int<0, 200> rstickmultiplier{this, "Right Stick Multiplier", 100};
 	cfg::_int<0, 1000000> lstickdeadzone{ this, "Left Stick Deadzone", 0 };
 	cfg::_int<0, 1000000> rstickdeadzone{ this, "Right Stick Deadzone", 0 };
 	cfg::_int<0, 1000000> ltriggerthreshold{ this, "Left Trigger Threshold", 0 };
@@ -437,9 +439,9 @@ protected:
 
 	// normalizes a directed input, meaning it will correspond to a single "button" and not an axis with two directions
 	// the input values must lie in 0+
-	u16 NormalizeDirectedInput(u16 raw_value, s32 threshold, s32 maximum);
+	u16 NormalizeDirectedInput(s32 raw_value, s32 threshold, s32 maximum);
 
-	u16 NormalizeStickInput(u16 raw_value, int threshold, bool ignore_threshold = false);
+	u16 NormalizeStickInput(u16 raw_value, int threshold, int multiplier, bool ignore_threshold = false);
 
 	// This function normalizes stick deadzone based on the DS3's deadzone, which is ~13%
 	// X and Y is expected to be in (-255) to 255 range, deadzone should be in terms of thumb stick range

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "overlays.h"
 #include "../GSRender.h"
 
@@ -19,7 +19,7 @@ namespace rsx
 			}
 
 			unsigned long hexval;
-			const int len = hex_color.length();
+			const size_t len = hex_color.length();
 
 			try
 			{

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "PSF.h"
 
 template<>
@@ -103,7 +103,7 @@ namespace psf
 		registry result;
 
 		// Hack for empty input (TODO)
-		if (!stream)
+		if (!stream || !stream.size())
 		{
 			return result;
 		}

--- a/rpcs3/ds3_pad_handler.cpp
+++ b/rpcs3/ds3_pad_handler.cpp
@@ -238,7 +238,7 @@ void ds3_pad_handler::ThreadProc()
 	}
 }
 
-void ds3_pad_handler::TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor)
+void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 b/* b*/)
 {
 	std::shared_ptr<ds3_device> device = get_device(padId);
 	if (device == nullptr || device->handle == nullptr)

--- a/rpcs3/ds3_pad_handler.h
+++ b/rpcs3/ds3_pad_handler.h
@@ -134,7 +134,7 @@ public:
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
 	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& buttonCallback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
-	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
+	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -222,7 +222,7 @@ void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::fu
 		return callback(0, "", padId, preview_values);
 }
 
-void ds4_pad_handler::TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor)
+void ds4_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b)
 {
 	std::shared_ptr<DS4Device> device = GetDevice(padId);
 	if (device == nullptr || device->hidDevice == nullptr)
@@ -247,41 +247,15 @@ void ds4_pad_handler::TestVibration(const std::string& padId, u32 largeMotor, u3
 		}
 	}
 
-	// Start/Stop the engines :)
-	SendVibrateData(device);
-}
-
-void ds4_pad_handler::SetLED(const std::string& padId, s32 r, s32 g, s32 b)
-{
-	std::shared_ptr<DS4Device> device = GetDevice(padId);
-	if (device == nullptr || device->hidDevice == nullptr)
-		return;
-
-	int index = 0;
-	for (int i = 0; i < MAX_GAMEPADS; i++)
+	// Set new LED color
+	if (r >= 0 && g >= 0 && b >= 0 && r <= 255 && g <= 255 && b <= 255)
 	{
-		if (g_cfg_input.player[i]->handler == pad_handler::ds4)
-		{
-			if (g_cfg_input.player[i]->device.to_string() == padId)
-			{
-				m_pad_configs[index].load();
-				device->config = &m_pad_configs[index];
-				break;
-			}
-			index++;
-		}
+		device->config->colorR.set(r);
+		device->config->colorG.set(g);
+		device->config->colorB.set(b);
 	}
 
-	// disable pulse
-	device->led_delay_on  = 0;
-	device->led_delay_off = 0;
-
-	// set new color
-	device->config->colorR.set(r);
-	device->config->colorG.set(g);
-	device->config->colorB.set(b);
-
-	// Show new color :)
+	// Start/Stop the engines :)
 	SendVibrateData(device);
 }
 

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -1,4 +1,4 @@
-#include "ds4_pad_handler.h"
+﻿#include "ds4_pad_handler.h"
 
 #include <thread>
 
@@ -340,14 +340,14 @@ void ds4_pad_handler::TranslateButtonPress(u64 keyCode, bool& pressed, u16& val,
 	case DS4KeyCodes::LSYNeg:
 	case DS4KeyCodes::LSYPos:
 		pressed = val > (ignore_threshold ? 0 : p_profile->lstickdeadzone);
-		val = pressed ? NormalizeStickInput(val, p_profile->lstickdeadzone, ignore_threshold) : 0;
+		val = pressed ? NormalizeStickInput(val, p_profile->lstickdeadzone, p_profile->lstickmultiplier, ignore_threshold) : 0;
 		break;
 	case DS4KeyCodes::RSXNeg:
 	case DS4KeyCodes::RSXPos:
 	case DS4KeyCodes::RSYNeg:
 	case DS4KeyCodes::RSYPos:
 		pressed = val > (ignore_threshold ? 0 : p_profile->rstickdeadzone);
-		val = pressed ? NormalizeStickInput(val, p_profile->rstickdeadzone, ignore_threshold) : 0;
+		val = pressed ? NormalizeStickInput(val, p_profile->rstickdeadzone, p_profile->rstickmultiplier, ignore_threshold) : 0;
 		break;
 	default: // normal button (should in theory also support sensitive buttons)
 		pressed = val > 0;

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -1,4 +1,4 @@
-﻿#include "ds4_pad_handler.h"
+#include "ds4_pad_handler.h"
 
 #include <thread>
 
@@ -494,7 +494,7 @@ void ds4_pad_handler::ProcessDataToPad(const std::shared_ptr<DS4Device>& device,
 #endif
 
 	// used to get the absolute value of an axis
-	s32 stick_val[4];
+	s32 stick_val[4]{0};
 
 	// Translate any corresponding keycodes to our two sticks. (ignoring thresholds for now)
 	for (int i = 0; i < static_cast<int>(pad->m_sticks.size()); i++)

--- a/rpcs3/ds4_pad_handler.h
+++ b/rpcs3/ds4_pad_handler.h
@@ -143,8 +143,7 @@ public:
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
 	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& buttonCallback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
-	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
-	void SetLED(const std::string& padId, s32 r, s32 g, s32 b) override;
+	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -525,12 +525,12 @@ void evdev_joystick_handler::TranslateButtonPress(u64 keyCode, bool& pressed, u1
 	else if (checkButtons(m_dev.axis_left))
 	{
 		pressed = value > (ignore_threshold ? 0 : profile->lstickdeadzone);
-		value = pressed ? NormalizeStickInput(value, profile->lstickdeadzone, ignore_threshold) : 0;
+		value = pressed ? NormalizeStickInput(value, profile->lstickdeadzone, profile->lstickmultiplier, ignore_threshold) : 0;
 	}
 	else if (checkButtons(m_dev.axis_right))
 	{
 		pressed = value > (ignore_threshold ? 0 : profile->rstickdeadzone);
-		value = pressed ? NormalizeStickInput(value, profile->rstickdeadzone, ignore_threshold) : 0;
+		value = pressed ? NormalizeStickInput(value, profile->rstickdeadzone, profile->rstickmultiplier, ignore_threshold) : 0;
 	}
 	else // normal button (should in theory also support sensitive buttons)
 	{

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -478,7 +478,7 @@ void evdev_joystick_handler::SetRumble(EvdevDevice* device, u16 large, u16 small
 	device->force_small = small;
 }
 
-void evdev_joystick_handler::TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor)
+void evdev_joystick_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32/* b*/)
 {
 	// Get our evdev device
 	EvdevDevice* dev = get_device(padId);

--- a/rpcs3/evdev_joystick_handler.h
+++ b/rpcs3/evdev_joystick_handler.h
@@ -339,7 +339,7 @@ public:
 	void ThreadProc() override;
 	void Close();
 	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
-	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
+	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b) override;
 
 private:
 	void TranslateButtonPress(u64 keyCode, bool& pressed, u16& value, bool ignore_threshold = false) override;

--- a/rpcs3/mm_joystick_handler.cpp
+++ b/rpcs3/mm_joystick_handler.cpp
@@ -1,4 +1,4 @@
-#ifdef _WIN32
+﻿#ifdef _WIN32
 #include "mm_joystick_handler.h"
 
 mm_joystick_handler::mm_joystick_handler() : PadHandlerBase(pad_handler::mm)
@@ -448,12 +448,12 @@ void mm_joystick_handler::TranslateButtonPress(u64 keyCode, bool& pressed, u16& 
 	else if (std::find(m_dev->axis_left.begin(), m_dev->axis_left.end(), keyCode) != m_dev->axis_left.end())
 	{
 		pressed = val > (ignore_threshold ? 0 : p_profile->lstickdeadzone);
-		val = pressed ? NormalizeStickInput(val, p_profile->lstickdeadzone, ignore_threshold) : 0;
+		val = pressed ? NormalizeStickInput(val, p_profile->lstickdeadzone, p_profile->lstickmultiplier, ignore_threshold) : 0;
 	}
 	else if (std::find(m_dev->axis_right.begin(), m_dev->axis_right.end(), keyCode) != m_dev->axis_right.end())
 	{
 		pressed = val > (ignore_threshold ? 0 : p_profile->rstickdeadzone);
-		val = pressed ? NormalizeStickInput(val, p_profile->rstickdeadzone, ignore_threshold) : 0;
+		val = pressed ? NormalizeStickInput(val, p_profile->rstickdeadzone, p_profile->rstickmultiplier, ignore_threshold) : 0;
 	}
 	else // normal button (should in theory also support sensitive buttons)
 	{

--- a/rpcs3/mm_joystick_handler.cpp
+++ b/rpcs3/mm_joystick_handler.cpp
@@ -1,4 +1,4 @@
-﻿#ifdef _WIN32
+#ifdef _WIN32
 #include "mm_joystick_handler.h"
 
 mm_joystick_handler::mm_joystick_handler() : PadHandlerBase(pad_handler::mm)
@@ -244,7 +244,7 @@ void mm_joystick_handler::ThreadProc()
 			TranslateButtonPress(btn.m_keyCode, btn.m_pressed, btn.m_value);
 		}
 
-		s32 stick_val[4];
+		s32 stick_val[4]{0};
 
 		// Translate any corresponding keycodes to our two sticks. (ignoring thresholds for now)
 		for (int i = 0; i < static_cast<int>(pad->m_sticks.size()); i++)

--- a/rpcs3/mm_joystick_handler.cpp
+++ b/rpcs3/mm_joystick_handler.cpp
@@ -297,7 +297,7 @@ void mm_joystick_handler::GetNextButtonPress(const std::string& padId, const std
 
 	if (cur_pad != padId)
 	{
-		cur_pad == padId;
+		cur_pad = padId;
 		id = GetIDByName(padId);
 		if (id < 0)
 		{

--- a/rpcs3/rpcs3_app.h
+++ b/rpcs3/rpcs3_app.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "stdafx.h"
 
@@ -52,7 +52,7 @@ private:
 	void InitializeCallbacks();
 	void InitializeConnects();
 
-	main_window* RPCS3MainWin;
+	main_window* RPCS3MainWin = nullptr;
 
 	std::shared_ptr<gui_settings> guiSettings;
 	std::shared_ptr<emu_settings> emuSettings;

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -150,7 +150,7 @@ public:
 		QString name;
 		QString old_adapter;
 		QStringList adapters;
-		SettingsType type;
+		SettingsType type = VulkanAdapter;
 		bool supported = true;
 		bool has_adapters = true;
 

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -127,7 +127,7 @@ void game_compatibility::RequestCompatibility(bool online)
 	QNetworkReply* network_reply = m_network_access_manager->get(m_network_request);
 
 	// Show Progress
-	m_progress_dialog.reset(new progress_dialog(tr(".Please wait."), tr("Abort"), 0, 100));
+	m_progress_dialog = new progress_dialog(tr(".Please wait."), tr("Abort"), 0, 100);
 	m_progress_dialog->setWindowTitle(tr("Downloading Database"));
 	m_progress_dialog->setFixedWidth(QLabel("This is the very length of the progressbar due to hidpi reasons.").sizeHint().width());
 	m_progress_dialog->setValue(0);
@@ -154,7 +154,8 @@ void game_compatibility::RequestCompatibility(bool online)
 	m_progress_timer->start(500);
 
 	// Handle abort
-	connect(m_progress_dialog.get(), &QProgressDialog::canceled, network_reply, &QNetworkReply::abort);
+	connect(m_progress_dialog, &QProgressDialog::canceled, network_reply, &QNetworkReply::abort);
+	connect(m_progress_dialog, &QProgressDialog::finished, m_progress_dialog, &QProgressDialog::deleteLater);
 
 	// Handle progress
 	connect(network_reply, &QNetworkReply::downloadProgress, [&](qint64 bytesReceived, qint64 bytesTotal)

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -45,9 +45,9 @@ private:
 	QString m_filepath;
 	QString m_url;
 	QNetworkRequest m_network_request;
+	progress_dialog* m_progress_dialog = nullptr;
 	std::shared_ptr<gui_settings> m_xgui_settings;
 	std::unique_ptr<QTimer> m_progress_timer;
-	std::unique_ptr<progress_dialog> m_progress_dialog;
 	std::unique_ptr<QNetworkAccessManager> m_network_access_manager;
 	std::map<std::string, compat_status> m_compat_database;
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -719,7 +719,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		{
 			if (RemoveCustomConfiguration(currGame.serial, gameinfo, true))
 			{
-				ShowCustomConfigIcon(item, config::type::emu);
+				ShowCustomConfigIcon(item);
 			}
 		});
 	}
@@ -730,7 +730,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		{
 			if (RemoveCustomPadConfiguration(currGame.serial, gameinfo, true))
 			{
-				ShowCustomConfigIcon(item, config::type::pad);
+				ShowCustomConfigIcon(item);
 			}
 		});
 	}
@@ -795,7 +795,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		if (dlg.exec() == QDialog::Accepted && !gameinfo->hasCustomConfig)
 		{
 			gameinfo->hasCustomConfig = true;
-			ShowCustomConfigIcon(item, config::type::emu);
+			ShowCustomConfigIcon(item);
 		}
 	});
 	connect(pad_configure, &QAction::triggered, [=]
@@ -816,7 +816,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		if (dlg.exec() == QDialog::Accepted && !gameinfo->hasCustomPadConfig)
 		{
 			gameinfo->hasCustomPadConfig = true;
-			ShowCustomConfigIcon(item, config::type::pad);
+			ShowCustomConfigIcon(item);
 		}
 		if (!Emu.IsStopped())
 		{
@@ -1488,7 +1488,7 @@ QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon
 	return QPixmap::fromImage(image.scaled(m_Icon_Size * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
 }
 
-void game_list_frame::ShowCustomConfigIcon(QTableWidgetItem* item, config::type type)
+void game_list_frame::ShowCustomConfigIcon(QTableWidgetItem* item)
 {
 	auto game = GetGameInfoFromItem(item);
 	if (game == nullptr)

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -31,15 +31,6 @@ enum Category
 	Others,
 };
 
-namespace config
-{
-	enum class type
-	{
-		emu,
-		pad
-	};
-}
-
 namespace category // (see PARAM.SFO in psdevwiki.com) TODO: Disc Categories 
 {
 	// PS3 bootable
@@ -247,7 +238,7 @@ protected:
 private:
 	QPixmap PaintedPixmap(const QImage& img, bool paint_config_icon = false, bool paint_pad_config_icon = false, const QColor& color = QColor());
 	QColor getGridCompatibilityColor(const QString& string);
-	void ShowCustomConfigIcon(QTableWidgetItem* item, config::type type);
+	void ShowCustomConfigIcon(QTableWidgetItem* item);
 	void PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color);
 	bool IsEntryVisible(const game_info& game);
 	void SortGameList();

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -310,5 +310,5 @@ private:
 	QSize m_Icon_Size = gui::gl_icon_size_min; // ensure a valid size
 	qreal m_Margin_Factor;
 	qreal m_Text_Factor;
-	bool m_drawCompatStatusToGrid;
+	bool m_drawCompatStatusToGrid = false;
 };

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1417,7 +1417,7 @@ void main_window::CreateConnects()
 	connect(m_categoryVisibleActGroup, &QActionGroup::triggered, [=](QAction* act)
 	{
 		QStringList categories;
-		int id;
+		int id = 0;
 		const bool& checked = act->isChecked();
 
 		if      (act == ui->showCatHDDGameAct)    categories += category::hdd_game, id = Category::HDD_Game;
@@ -1432,8 +1432,11 @@ void main_window::CreateConnects()
 		else if (act == ui->showCatOtherAct)      categories += category::others, id = Category::Others;
 		else LOG_WARNING(GENERAL, "categoryVisibleActGroup: category action not found");
 
-		m_gameListFrame->ToggleCategoryFilter(categories, checked);
-		guiSettings->SetCategoryVisibility(id, checked);
+		if (!categories.isEmpty())
+		{
+			m_gameListFrame->ToggleCategoryFilter(categories, checked);
+			guiSettings->SetCategoryVisibility(id, checked);
+		}
 	});
 
 	connect(ui->aboutAct, &QAction::triggered, [this]

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -29,7 +29,7 @@ class main_window : public QMainWindow
 
 	Ui::main_window *ui;
 
-	bool m_sys_menu_opened;
+	bool m_sys_menu_opened = false;
 	bool m_is_list_mode = true;
 	bool m_save_slider_pos = false;
 	int m_other_slider_pos = 0;
@@ -130,17 +130,17 @@ private:
 	q_pair_list m_rg_entries;
 	QList<QAction*> m_recentGameActs;
 
-	QActionGroup* m_iconSizeActGroup;
-	QActionGroup* m_listModeActGroup;
-	QActionGroup* m_categoryVisibleActGroup;
+	QActionGroup* m_iconSizeActGroup = nullptr;
+	QActionGroup* m_listModeActGroup = nullptr;
+	QActionGroup* m_categoryVisibleActGroup = nullptr;
 
 	QMessageBox::StandardButton m_install_bulk = QMessageBox::NoButton;
 
 	// Dockable widget frames
-	QMainWindow *m_mw;
-	log_frame *m_logFrame;
-	debugger_frame *m_debuggerFrame;
-	game_list_frame *m_gameListFrame;
+	QMainWindow *m_mw = nullptr;
+	log_frame* m_logFrame = nullptr;
+	debugger_frame* m_debuggerFrame = nullptr;
+	game_list_frame* m_gameListFrame = nullptr;
 	std::shared_ptr<gui_settings> guiSettings;
 	std::shared_ptr<emu_settings> emuSettings;
 };

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -180,7 +180,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 
 void osk_dialog_frame::SetOskText(const QString& text)
 {
-	std::memcpy(osk_text, reinterpret_cast<const char16_t*>(text.constData()), size_t(text.size() + 1) * sizeof(char16_t));
+	std::memcpy(osk_text, reinterpret_cast<const char16_t*>(text.constData()), ((size_t)text.size() + 1) * sizeof(char16_t));
 }
 
 void osk_dialog_frame::Close(bool accepted)

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -331,7 +331,12 @@ void pad_settings_dialog::InitButtons()
 
 	connect(ui->b_led, &QPushButton::clicked, [=]()
 	{
-		QColorDialog dlg(QColor(m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB), this);
+		QColor led_color(m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
+		if (ui->b_led->property("led").canConvert<QColor>())
+		{
+			led_color = ui->b_led->property("led").value<QColor>();
+		}
+		QColorDialog dlg(led_color, this);
 		dlg.setWindowTitle(tr("LED Color"));
 		if (dlg.exec() == QColorDialog::Accepted)
 		{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -787,6 +787,7 @@ void pad_settings_dialog::SwitchButtons(bool is_enabled)
 	ui->gb_mouse_accel->setEnabled(is_enabled && m_handler->m_type == pad_handler::keyboard);
 	ui->gb_mouse_dz->setEnabled(is_enabled && m_handler->m_type == pad_handler::keyboard);
 	ui->gb_stick_lerp->setEnabled(is_enabled && m_handler->m_type == pad_handler::keyboard);
+	ui->b_blacklist->setEnabled(is_enabled && m_handler->m_type != pad_handler::keyboard);
 
 	for (int i = button_ids::id_pad_begin + 1; i < button_ids::id_pad_end; i++)
 	{
@@ -1034,7 +1035,6 @@ void pad_settings_dialog::ChangeProfile()
 		((NullPadHandler*)m_handler.get())->init_config(&m_handler_cfg, cfg_name);
 		break;
 	case pad_handler::keyboard:
-		ui->b_blacklist->setEnabled(false);
 		((keyboard_pad_handler*)m_handler.get())->init_config(&m_handler_cfg, cfg_name);
 		break;
 	case pad_handler::ds3:

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -277,12 +277,12 @@ void pad_settings_dialog::InitButtons()
 			return;
 		}
 
-		ui->chb_vibration_switch->isChecked() ? m_handler->TestVibration(m_device_name, m_min_force, m_max_force)
-		                                      : m_handler->TestVibration(m_device_name, m_max_force, m_min_force);
+		ui->chb_vibration_switch->isChecked() ? SetPadData(m_min_force, m_max_force)
+		                                      : SetPadData(m_max_force, m_min_force);
 
 		QTimer::singleShot(300, [this]()
 		{
-			m_handler->TestVibration(m_device_name, m_min_force, m_min_force);
+			SetPadData(m_min_force, m_min_force);
 		});
 	});
 
@@ -293,28 +293,28 @@ void pad_settings_dialog::InitButtons()
 			return;
 		}
 
-		ui->chb_vibration_switch->isChecked() ? m_handler->TestVibration(m_device_name, m_max_force, m_min_force)
-		                                      : m_handler->TestVibration(m_device_name, m_min_force, m_max_force);
+		ui->chb_vibration_switch->isChecked() ? SetPadData(m_max_force, m_min_force)
+		                                      : SetPadData(m_min_force, m_max_force);
 
 		QTimer::singleShot(300, [this]()
 		{
-			m_handler->TestVibration(m_device_name, m_min_force, m_min_force);
+			SetPadData(m_min_force, m_min_force);
 		});
 	});
 
 	connect(ui->chb_vibration_switch, &QCheckBox::clicked, [this](bool checked)
 	{
-		checked ? m_handler->TestVibration(m_device_name, m_min_force, m_max_force)
-		        : m_handler->TestVibration(m_device_name, m_max_force, m_min_force);
+		checked ? SetPadData(m_min_force, m_max_force)
+		        : SetPadData(m_max_force, m_min_force);
 
 		QTimer::singleShot(200, [this, checked]()
 		{
-			checked ? m_handler->TestVibration(m_device_name, m_max_force, m_min_force)
-			        : m_handler->TestVibration(m_device_name, m_min_force, m_max_force);
+			checked ? SetPadData(m_max_force, m_min_force)
+			        : SetPadData(m_min_force, m_max_force);
 
 			QTimer::singleShot(200, [this]()
 			{
-				m_handler->TestVibration(m_device_name, m_min_force, m_min_force);
+				SetPadData(m_min_force, m_min_force);
 			});
 		});
 	});
@@ -341,7 +341,7 @@ void pad_settings_dialog::InitButtons()
 		if (dlg.exec() == QColorDialog::Accepted)
 		{
 			const QColor newColor = dlg.selectedColor();
-			m_handler->SetLED(m_device_name, newColor.red(), newColor.green(), newColor.blue());
+			m_handler->SetPadData(m_device_name, 0, 0, newColor.red(), newColor.green(), newColor.blue());
 			ui->b_led->setIcon(gui::utils::get_colorized_icon(QIcon(":/Icons/controllers.png"), Qt::black, newColor));
 			ui->b_led->setProperty("led", newColor);
 		}
@@ -424,6 +424,16 @@ void pad_settings_dialog::InitButtons()
 			m_handler->GetNextButtonPress(info.name, [=](u16, std::string, std::string pad_name, int[6]) { SwitchPadInfo(pad_name, true); }, [=](std::string pad_name) { SwitchPadInfo(pad_name, false); }, false);
 		}
 	});
+}
+
+void pad_settings_dialog::SetPadData(u32 large_motor, u32 small_motor)
+{
+	QColor led_color(m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
+	if (ui->b_led->property("led").canConvert<QColor>())
+	{
+		led_color = ui->b_led->property("led").value<QColor>();
+	}
+	m_handler->SetPadData(m_device_name, large_motor, small_motor, led_color.red(), led_color.green(), led_color.blue());
 }
 
 void pad_settings_dialog::SwitchPadInfo(const std::string& pad_name, bool is_connected)
@@ -555,7 +565,7 @@ void pad_settings_dialog::ReloadButtons()
 
 	// Enable and repaint the LED Button
 	m_enable_led = m_handler->has_led();
-	m_handler->SetLED(m_device_name, m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
+	m_handler->SetPadData(m_device_name, 0, 0, m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
 
 	const QColor led_color(m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
 	ui->b_led->setIcon(gui::utils::get_colorized_icon(QIcon(":/Icons/controllers.png"), Qt::black, led_color));
@@ -763,7 +773,7 @@ void pad_settings_dialog::UpdateLabel(bool is_reset)
 			const QColor led_color(m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
 			ui->b_led->setProperty("led", led_color);
 			ui->b_led->setIcon(gui::utils::get_colorized_icon(QIcon(":/Icons/controllers.png"), Qt::black, led_color));
-			m_handler->SetLED(m_device_name, m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
+			m_handler->SetPadData(m_device_name, 0, 0, m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
 		}
 	}
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -416,7 +416,7 @@ void pad_settings_dialog::InitButtons()
 				continue;
 			}
 			const pad_info info = ui->chooseDevice->itemData(i).value<pad_info>();
-			m_handler->GetNextButtonPress(info.name, [=](u16 val, std::string name, std::string pad_name, int preview_values[6]) { SwitchPadInfo(pad_name, true); }, [=](std::string pad_name) { SwitchPadInfo(pad_name, false); }, false);
+			m_handler->GetNextButtonPress(info.name, [=](u16, std::string, std::string pad_name, int[6]) { SwitchPadInfo(pad_name, true); }, [=](std::string pad_name) { SwitchPadInfo(pad_name, false); }, false);
 		}
 	});
 }
@@ -670,7 +670,7 @@ void pad_settings_dialog::mouseReleaseEvent(QMouseEvent* event)
 	ReactivateButtons();
 }
 
-void pad_settings_dialog::mouseMoveEvent(QMouseEvent* event)
+void pad_settings_dialog::mouseMoveEvent(QMouseEvent*/* event*/)
 {
 	if (m_handler->m_type != pad_handler::keyboard)
 	{
@@ -960,7 +960,7 @@ void pad_settings_dialog::ChangeInputType()
 				continue;
 			}
 			const pad_info info = ui->chooseDevice->itemData(i).value<pad_info>();
-			m_handler->GetNextButtonPress(info.name, [=](u16 val, std::string name, std::string pad_name, int preview_values[6]) { SwitchPadInfo(pad_name, true); }, [=](std::string pad_name) { SwitchPadInfo(pad_name, false); }, false);
+			m_handler->GetNextButtonPress(info.name, [=](u16, std::string, std::string pad_name, int[6]) { SwitchPadInfo(pad_name, true); }, [=](std::string pad_name) { SwitchPadInfo(pad_name, false); }, false);
 			if (info.name == device)
 			{
 				ui->chooseDevice->setCurrentIndex(i);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -18,7 +18,7 @@ namespace Ui
 struct pad_info
 {
 	std::string name;
-	bool is_connected;
+	bool is_connected{false};
 };
 
 Q_DECLARE_METATYPE(pad_info);
@@ -104,7 +104,7 @@ private:
 	std::string m_title_id;
 
 	// TabWidget
-	QTabWidget* m_tabs;
+	QTabWidget* m_tabs = nullptr;
 
 	// Capabilities
 	bool m_enable_buttons{ false };
@@ -113,7 +113,7 @@ private:
 	bool m_enable_led{ false };
 
 	// Button Mapping
-	QButtonGroup* m_padButtons;
+	QButtonGroup* m_padButtons = nullptr;
 	u32 m_button_id = id_pad_begin;
 	std::map<int /*id*/, pad_button /*info*/> m_cfg_entries;
 
@@ -124,8 +124,8 @@ private:
 	int ry = 0;
 
 	// Rumble
-	s32 m_min_force;
-	s32 m_max_force;
+	s32 m_min_force = 0;
+	s32 m_max_force = 0;
 
 	// Backup for standard button palette
 	QPalette m_palette;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -148,6 +148,9 @@ private:
 	// Input timer. Its Callback handles the input
 	QTimer m_timer_input;
 
+	// Set vibrate data while keeping the current color
+	void SetPadData(u32 large_motor, u32 small_motor);
+
 	/** Update all the Button Labels with current button mapping */
 	void UpdateLabel(bool is_reset = false);
 	void SwitchPadInfo(const std::string& name, bool is_connected);

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #include "rsx_debugger.h"
 #include "qt_utils.h"
 
@@ -633,7 +633,7 @@ void rsx_debugger::GetMemory()
 	int item_count = m_list_commands->rowCount();
 
 	// Write information
-	for(u32 i=0, addr = m_addr; i < item_count; i++, addr += 4)
+	for (int i = 0, addr = m_addr; i < item_count; i++, addr += 4)
 	{
 		QTableWidgetItem* address_item = new QTableWidgetItem(qstr(fmt::format("%07x", addr)));
 		address_item->setData(Qt::UserRole, addr);

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -224,7 +224,7 @@ void save_manager_dialog::OnSort(int logicalIndex)
 }
 
 /**
- *Display info dialog directly. Copied from save_data_list_dialog
+ * Display info dialog directly. Copied from save_data_list_dialog
  */
 void save_manager_dialog::OnEntryInfo()
 {
@@ -238,7 +238,7 @@ void save_manager_dialog::OnEntryInfo()
 	}
 }
 
-//Remove a save file, need to be confirmed.
+// Remove a save file, need to be confirmed.
 void save_manager_dialog::OnEntryRemove()
 {
 	int idx = m_list->currentRow();
@@ -279,7 +279,7 @@ void save_manager_dialog::OnEntriesRemove()
 	}
 }
 
-//Pop-up a small context-menu, being a replacement for save_data_manage_dialog
+// Pop-up a small context-menu, being a replacement for save_data_manage_dialog
 void save_manager_dialog::ShowContextMenu(const QPoint &pos)
 {
 	bool selectedItems = m_list->selectionModel()->selectedRows().size() > 1;
@@ -300,14 +300,14 @@ void save_manager_dialog::ShowContextMenu(const QPoint &pos)
 	QAction* infoAct = new QAction(tr("&Info"), this);
 	QAction* showDirAct = new QAction(tr("&Open Save Directory"), this);
 
-	//This is also a stub for the sort setting. Ids are set accordingly to their sort-type integer.
+	// This is also a stub for the sort setting. Ids are set accordingly to their sort-type integer.
 	// TODO: add more sorting types.
-	m_sort_options = new QMenu(tr("&Sort By"));
-	m_sort_options->addAction(titleAct);
-	m_sort_options->addAction(subtitleAct);
-	m_sort_options->addAction(saveIDAct);
+	QMenu* sort_options = new QMenu(tr("&Sort By"), this);
+	sort_options->addAction(titleAct);
+	sort_options->addAction(subtitleAct);
+	sort_options->addAction(saveIDAct);
 
-	menu->addMenu(m_sort_options);
+	menu->addMenu(sort_options);
 	menu->addSeparator();
 	menu->addAction(removeAct);
 	menu->addAction(infoAct);

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -33,7 +33,7 @@ namespace
 		// get the saves matching the supplied prefix
 		for (const auto& entry : fs::dir(base_dir))
 		{
-			if (!entry.is_directory)
+			if (!entry.is_directory || entry.name == "." || entry.name == "..")
 			{
 				continue;
 			}
@@ -43,6 +43,7 @@ namespace
 
 			if (psf.empty())
 			{
+				LOG_ERROR(LOADER, "Failed to load savedata: %s", base_dir + "/" + entry.name);
 				continue;
 			}
 

--- a/rpcs3/rpcs3qt/save_manager_dialog.h
+++ b/rpcs3/rpcs3qt/save_manager_dialog.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "stdafx.h"
 #include "Emu/Memory/vm.h"
@@ -32,13 +32,11 @@ private:
 
 	void closeEvent(QCloseEvent* event) override;
 
-	QTableWidget* m_list;
+	QTableWidget* m_list = nullptr;
 	std::string m_dir;
 	std::vector<SaveDataEntry> m_save_entries;
 
 	std::shared_ptr<gui_settings> m_gui_settings;
-
-	QMenu* m_sort_options;
 
 	int m_sort_column;
 	bool m_sort_ascending;

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -136,7 +136,7 @@ void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std:
 		return callback(0, "", padId, preview_values);
 }
 
-void xinput_pad_handler::TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor)
+void xinput_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32/* b*/)
 {
 	int device_number = GetDeviceNumber(padId);
 	if (device_number < 0)

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #ifdef _WIN32
 #include "xinput_pad_handler.h"
 
@@ -172,14 +172,14 @@ void xinput_pad_handler::TranslateButtonPress(u64 keyCode, bool& pressed, u16& v
 	case XInputKeyCodes::LSYPos:
 	case XInputKeyCodes::LSYNeg:
 		pressed = val > (ignore_threshold ? 0 : p_profile->lstickdeadzone);
-		val = pressed ? NormalizeStickInput(val, p_profile->lstickdeadzone, ignore_threshold) : 0;
+		val = pressed ? NormalizeStickInput(val, p_profile->lstickdeadzone, p_profile->lstickmultiplier, ignore_threshold) : 0;
 		break;
 	case XInputKeyCodes::RSXNeg:
 	case XInputKeyCodes::RSXPos:
 	case XInputKeyCodes::RSYPos:
 	case XInputKeyCodes::RSYNeg:
 		pressed = val > (ignore_threshold ? 0 : p_profile->rstickdeadzone);
-		val = pressed ? NormalizeStickInput(val, p_profile->rstickdeadzone, ignore_threshold) : 0;
+		val = pressed ? NormalizeStickInput(val, p_profile->rstickdeadzone, p_profile->rstickmultiplier, ignore_threshold) : 0;
 		break;
 	default: // normal button (should in theory also support sensitive buttons)
 		pressed = val > 0;

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -1,4 +1,4 @@
-﻿
+
 #ifdef _WIN32
 #include "xinput_pad_handler.h"
 
@@ -369,7 +369,7 @@ void xinput_pad_handler::ThreadProc()
 			}
 
 			// used to get the absolute value of an axis
-			s32 stick_val[4];
+			s32 stick_val[4]{0};
 
 			// Translate any corresponding keycodes to our two sticks. (ignoring thresholds for now)
 			for (int i = 0; i < static_cast<int>(pad->m_sticks.size()); i++)

--- a/rpcs3/xinput_pad_handler.h
+++ b/rpcs3/xinput_pad_handler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Utilities/Config.h"
 #include "Emu/Io/PadHandler.h"
@@ -108,7 +108,7 @@ public:
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
 	void GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
-	void TestVibration(const std::string& padId, u32 largeMotor, u32 smallMotor) override;
+	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:


### PR DESCRIPTION
This adds simple multipliers for left and right sticks to the input config files.
They range from 0-200 (0.0 - 2.0) and the default is 100 (1.0).

I will try to add an input field to the pad settings dialog as well.

This also fixes a crash in the pad settings dialog that was caused when clicking "Filter Noise" while the current pad was disabled. The button will now only be activated when there is a pad connected.

Fixes a bug that shows the wrong color when selecting led colors.
Fixes a bug that resets the led colors when clicking the vibration checkboxes.

Fixes a crash when downloading the compatibility database twice in a row.

Also fixes a crash when trying to load empty param.sfo s.

Also gets rid of some warnings.

fixes #6001