### PR TITLE
rsx: Minor fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -606,7 +606,8 @@ namespace gl
 		// The rest of sampler state is now handled by sampler state objects
 
 		// Calculate staging buffer size
-		size_t texture_data_sz = depth * height * width * get_format_block_size_in_bytes(gcm_format);
+		const u32 aligned_pitch = align<u32>(width * get_format_block_size_in_bytes(gcm_format), 4);
+		size_t texture_data_sz = depth * height * aligned_pitch;
 		std::vector<gsl::byte> data_upload_buf(texture_data_sz);
 
 		const auto format_type = get_format_type(gcm_format);

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -33,7 +33,7 @@ namespace vk
 			};
 
 			// Reserve descriptor pools
-			m_descriptor_pool.create(*get_current_renderer(), descriptor_pool_sizes, 2);
+			m_descriptor_pool.create(*get_current_renderer(), descriptor_pool_sizes, 2, VK_MAX_COMPUTE_TASKS, 2);
 
 			std::vector<VkDescriptorSetLayoutBinding> bindings(2);
 
@@ -112,7 +112,7 @@ namespace vk
 			if (m_used_descriptors == 0)
 				return;
 
-			vkResetDescriptorPool(*get_current_renderer(), m_descriptor_pool, 0);
+			m_descriptor_pool.reset(0);
 			m_used_descriptors = 0;
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -152,18 +152,16 @@ namespace vk
 		return g_null_sampler;
 	}
 
-	VkImageView null_image_view(vk::command_buffer &cmd)
+	vk::image_view* null_image_view(vk::command_buffer &cmd)
 	{
 		if (g_null_image_view)
-			return g_null_image_view->value;
+			return g_null_image_view.get();
 
 		g_null_texture.reset(new image(*g_current_renderer, g_current_renderer->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 			VK_IMAGE_TYPE_2D, VK_FORMAT_B8G8R8A8_UNORM, 4, 4, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0));
 
-		g_null_image_view.reset(new image_view(*g_current_renderer, g_null_texture->value, VK_IMAGE_VIEW_TYPE_2D,
-			VK_FORMAT_B8G8R8A8_UNORM, {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A},
-			{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}));
+		g_null_image_view.reset(new image_view(*g_current_renderer, g_null_texture.get()));
 
 		// Initialize memory to transparent black
 		VkClearColorValue clear_color = {};
@@ -173,7 +171,7 @@ namespace vk
 
 		// Prep for shader access
 		change_image_layout(cmd, g_null_texture.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, range);
-		return g_null_image_view->value;
+		return g_null_image_view.get();
 	}
 
 	vk::image* get_typeless_helper(VkFormat format, u32 requested_width, u32 requested_height)
@@ -562,7 +560,7 @@ namespace vk
 		image->current_layout = new_layout;
 	}
 
-	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout layout, VkImageSubresourceRange range)
+	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range)
 	{
 		// NOTE: Sampling from an attachment in ATTACHMENT_OPTIMAL layout on some hw ends up with garbage output
 		// Transition to GENERAL if this resource is both input and output
@@ -573,7 +571,7 @@ namespace vk
 		VkPipelineStageFlags src_stage;
 		if (range.aspectMask == VK_IMAGE_ASPECT_COLOR_BIT)
 		{
-			if (!rsx::method_registers.color_write_enabled() && layout == VK_IMAGE_LAYOUT_GENERAL)
+			if (!rsx::method_registers.color_write_enabled() && current_layout == new_layout)
 			{
 				// Nothing to do
 				return;
@@ -584,7 +582,7 @@ namespace vk
 		}
 		else
 		{
-			if (!rsx::method_registers.depth_write_enabled() && layout == VK_IMAGE_LAYOUT_GENERAL)
+			if (!rsx::method_registers.depth_write_enabled() && current_layout == new_layout)
 			{
 				// Nothing to do
 				return;
@@ -596,8 +594,8 @@ namespace vk
 
 		VkImageMemoryBarrier barrier = {};
 		barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-		barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-		barrier.oldLayout = layout;
+		barrier.newLayout = new_layout;
+		barrier.oldLayout = current_layout;
 		barrier.image = image;
 		barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 		barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -608,10 +606,10 @@ namespace vk
 		vkCmdPipelineBarrier(cmd, src_stage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
 	}
 
-	void insert_texture_barrier(VkCommandBuffer cmd, vk::image *image)
+	void insert_texture_barrier(VkCommandBuffer cmd, vk::image *image, VkImageLayout new_layout)
 	{
-		insert_texture_barrier(cmd, image->value, image->current_layout, { image->aspect(), 0, 1, 0, 1 });
-		image->current_layout = VK_IMAGE_LAYOUT_GENERAL;
+		insert_texture_barrier(cmd, image->value, image->current_layout, new_layout, { image->aspect(), 0, 1, 0, 1 });
+		image->current_layout = new_layout;
 	}
 
 	void enter_uninterruptible()

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -88,6 +88,7 @@ namespace vk
 	class physical_device;
 	class command_buffer;
 	class image;
+	struct image_view;
 	struct buffer;
 	struct data_heap;
 	class mem_allocator_base;
@@ -116,7 +117,7 @@ namespace vk
 	VkImageAspectFlags get_aspect_flags(VkFormat format);
 
 	VkSampler null_sampler();
-	VkImageView null_image_view(vk::command_buffer&);
+	image_view* null_image_view(vk::command_buffer&);
 	image* get_typeless_helper(VkFormat format, u32 requested_width, u32 requested_height);
 	buffer* get_scratch_buffer();
 
@@ -166,8 +167,8 @@ namespace vk
 	size_t get_render_pass_location(VkFormat color_surface_format, VkFormat depth_stencil_format, u8 color_surface_count);
 
 	//Texture barrier applies to a texture to ensure writes to it are finished before any reads are attempted to avoid RAW hazards
-	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout layout, VkImageSubresourceRange range);
-	void insert_texture_barrier(VkCommandBuffer cmd, vk::image *image);
+	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range);
+	void insert_texture_barrier(VkCommandBuffer cmd, vk::image *image, VkImageLayout new_layout);
 
 	void insert_buffer_memory_barrier(VkCommandBuffer cmd, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize length,
 			VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask);

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -219,7 +219,7 @@ namespace vk
 			return result;
 		}
 
-		void load_program(vk::command_buffer cmd, VkRenderPass pass, const std::vector<VkImageView>& src)
+		void load_program(vk::command_buffer cmd, VkRenderPass pass, const std::vector<vk::image_view*>& src)
 		{
 			vk::glsl::program *program = nullptr;
 			auto found = m_program_cache.find(pass);
@@ -252,7 +252,7 @@ namespace vk
 
 			for (int n = 0; n < src.size(); ++n)
 			{
-				VkDescriptorImageInfo info = { m_sampler->value, src[n], VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+				VkDescriptorImageInfo info = { m_sampler->value, src[n]->value, src[n]->image()->current_layout };
 				program->bind_uniform(info, "fs" + std::to_string(n), m_descriptor_set);
 			}
 
@@ -360,7 +360,7 @@ namespace vk
 			vkCmdSetScissor(cmd, 0, 1, &vs);
 		}
 
-		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::framebuffer* fbo, const std::vector<VkImageView>& src, VkRenderPass render_pass)
+		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::framebuffer* fbo, const std::vector<vk::image_view*>& src, VkRenderPass render_pass)
 		{
 			load_program(cmd, render_pass, src);
 			set_up_viewport(cmd, w, h);
@@ -379,7 +379,7 @@ namespace vk
 			vkCmdEndRenderPass(cmd);
 		}
 
-		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::image* target, const std::vector<VkImageView>& src, VkRenderPass render_pass, std::list<std::unique_ptr<vk::framebuffer_holder>>& framebuffer_resources)
+		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::image* target, const std::vector<vk::image_view*>& src, VkRenderPass render_pass, std::list<std::unique_ptr<vk::framebuffer_holder>>& framebuffer_resources)
 		{
 			vk::framebuffer *fbo = get_framebuffer(target, render_pass, framebuffer_resources);
 
@@ -388,15 +388,10 @@ namespace vk
 			static_cast<vk::framebuffer_holder*>(fbo)->release();
 		}
 
-		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::image* target, VkImageView src, VkRenderPass render_pass, std::list<std::unique_ptr<vk::framebuffer_holder>>& framebuffer_resources)
-		{
-			std::vector<VkImageView> views = { src };
-			run(cmd, w, h, target, views, render_pass, framebuffer_resources);
-		}
-
 		void run(vk::command_buffer &cmd, u16 w, u16 h, vk::image* target, vk::image_view* src, VkRenderPass render_pass, std::list<std::unique_ptr<vk::framebuffer_holder>>& framebuffer_resources)
 		{
-			run(cmd, w, h, target, src->value, render_pass, framebuffer_resources);
+			std::vector<vk::image_view*> views = { src };
+			run(cmd, w, h, target, views, render_pass, framebuffer_resources);
 		}
 	};
 
@@ -821,13 +816,13 @@ namespace vk
 					break;
 				case rsx::overlays::image_resource_id::font_file:
 					m_texture_type = 2;
-					src = find_font(command.config.font_ref, cmd, upload_heap)->value;
+					src = find_font(command.config.font_ref, cmd, upload_heap);
 					break;
 				case rsx::overlays::image_resource_id::raw_image:
-					src = find_temp_image((rsx::overlays::image_info*)command.config.external_data_ref, cmd, upload_heap, ui.uid)->value;
+					src = find_temp_image((rsx::overlays::image_info*)command.config.external_data_ref, cmd, upload_heap, ui.uid);
 					break;
 				default:
-					src = view_cache[command.config.texture_ref]->value;
+					src = view_cache[command.config.texture_ref].get();
 					break;
 				}
 
@@ -938,7 +933,7 @@ namespace vk
 			region = rect;
 
 			overlay_pass::run(cmd, target->width(), target->height(), target,
-				target->get_view(0xAAE4, rsx::default_remap_vector)->value,
+				target->get_view(0xAAE4, rsx::default_remap_vector),
 				render_pass, framebuffer_resources);
 		}
 	};

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -74,7 +74,7 @@ namespace vk
 			};
 
 			//Reserve descriptor pools
-			m_descriptor_pool.create(*m_device, descriptor_pool_sizes, 2);
+			m_descriptor_pool.create(*m_device, descriptor_pool_sizes, 2, VK_OVERLAY_MAX_DRAW_CALLS, 2);
 
 			std::vector<VkDescriptorSetLayoutBinding> bindings(1 + m_num_usable_samplers);
 
@@ -297,7 +297,7 @@ namespace vk
 			if (m_used_descriptors == 0)
 				return;
 
-			vkResetDescriptorPool(*m_device, m_descriptor_pool, 0);
+			m_descriptor_pool.reset(0);
 			m_used_descriptors = 0;
 
 			m_vao.reset_allocation_stats();

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "VKHelpers.h"
 #include "VKVertexProgram.h"
 #include "VKFragmentProgram.h"
@@ -39,7 +39,7 @@ namespace vk
 			};
 
 			//Reserve descriptor pools
-			m_descriptor_pool.create(dev, descriptor_pools, 1);
+			m_descriptor_pool.create(dev, descriptor_pools, 1, 120, 2);
 
 			VkDescriptorSetLayoutBinding bindings[1] = {};
 			
@@ -370,7 +370,7 @@ namespace vk
 			if (m_used_descriptors == 0)
 				return;
 
-			vkResetDescriptorPool(device, m_descriptor_pool, 0);
+			m_descriptor_pool.reset(0);
 			m_used_descriptors = 0;
 		}
 	};

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1043,7 +1043,7 @@ namespace vk
 
 		void insert_texture_barrier(vk::command_buffer& cmd, vk::image* tex) override
 		{
-			vk::insert_texture_barrier(cmd, tex);
+			vk::insert_texture_barrier(cmd, tex, VK_IMAGE_LAYOUT_GENERAL);
 		}
 
 		bool render_target_format_is_compatible(vk::image* tex, u32 gcm_format) override


### PR DESCRIPTION
gl: Fix staging buffer size calculation
- Pitch is row-aligned to 4 bytes, not 1 byte. Fixes gsl::span assert when using OpenGL in some games.

vk: Always pass the stored layout to the descriptors
- Renderpass management is still WIP and in reality does unwanted layout transitions making the declared layouts wrong.