### PR TITLE
vk: check_window_status fixes for linux

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -2025,11 +2025,8 @@ public:
 #endif
 				break;
 			case driver_vendor::AMD:
-#ifdef _WIN32
 				break;
-#endif
 			case driver_vendor::INTEL:
-				// Untested
 			case driver_vendor::RADV:
 				m_wm_reports_flag = true;
 				break;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -437,6 +437,9 @@ namespace vk
 			const auto gpu_name = get_name();
 			if (gpu_name.find("Radeon") != std::string::npos)
 			{
+#ifndef _WIN32
+				LOG_ERROR(RSX, "Using non RADV drivers on linux currently incurs a ~40% performance loss due to a window resizing workaround. Using RADV is recommended.");
+#endif
 				return driver_vendor::AMD;
 			}
 


### PR DESCRIPTION
I've installed all 3 amd drivers on linux along with anv and found some things that need changing.

I've verified that ANV works well and doesn't require any workaround for window resizing.

AMDVLK and the proprietary amd driver both require workarounds to enable window resizing on linux unfortunately. However, most users are already using RADV, and we can recommend those who aren't to switch. (The userbase of these drivers is so small that no one reported window resizing being broken until I bothered to install them myself) 

I've also added a second commit that prints a recommendation to install RADV if you use amdvlk or the prop driver on linux. It's using LOG_SUCCESS because WARNING isn't visible by default. I'm not sure if that's the best way to notify users. 
The log commit is separate so we can drop it if necessary.
