### PR TITLE
vk: Refactor renderpass management

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1925,7 +1925,7 @@ namespace rsx
 			f32 scale_x, f32 scale_y,
 			rsx::texture_dimension_extended extended_dimension,
 			u32 encoded_remap, const texture_channel_remap_t& decoded_remap,
-			bool assume_bound = true)
+			bool surface_is_rop_target)
 		{
 			texptr->read_barrier(cmd);
 
@@ -1963,7 +1963,7 @@ namespace rsx
 					internal_height = 1;
 				}
 
-				if ((assume_bound && g_cfg.video.strict_rendering_mode) ||
+				if ((surface_is_rop_target && g_cfg.video.strict_rendering_mode) ||
 					internal_width < surface_width ||
 					internal_height < surface_height ||
 					force_convert)
@@ -1971,19 +1971,19 @@ namespace rsx
 					const auto scaled_w = rsx::apply_resolution_scale(internal_width, true);
 					const auto scaled_h = rsx::apply_resolution_scale(internal_height, true);
 
-					const auto command = assume_bound ? deferred_request_command::copy_image_dynamic : deferred_request_command::copy_image_static;
+					const auto command = surface_is_rop_target ? deferred_request_command::copy_image_dynamic : deferred_request_command::copy_image_static;
 					return { texptr->get_surface(), command, texaddr, format, 0, 0, scaled_w, scaled_h, 1,
 							texture_upload_context::framebuffer_storage, is_depth, scale_x, scale_y,
 							extended_dimension, decoded_remap };
 				}
 
-				if (assume_bound)
+				if (surface_is_rop_target)
 				{
 					insert_texture_barrier(cmd, texptr);
 				}
 
 				return{ texptr->get_view(encoded_remap, decoded_remap), texture_upload_context::framebuffer_storage,
-					is_depth, scale_x, scale_y, rsx::texture_dimension_extended::texture_dimension_2d, assume_bound };
+					is_depth, scale_x, scale_y, rsx::texture_dimension_extended::texture_dimension_2d, surface_is_rop_target };
 			}
 
 			const auto scaled_w = rsx::apply_resolution_scale(internal_width, true);
@@ -2136,7 +2136,7 @@ namespace rsx
 					check_framebuffer_resource(cmd, texptr, tex_width, tex_height, depth, tex_pitch, extended_dimension))
 				{
 					return process_framebuffer_resource_fast(cmd, texptr, texaddr, format, tex_width, tex_height, depth,
-						scale_x, scale_y, extended_dimension, tex.remap(), tex.decoded_remap());
+						scale_x, scale_y, extended_dimension, tex.remap(), tex.decoded_remap(), true);
 				}
 			}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -406,8 +406,6 @@ private:
 	std::array<command_buffer_chunk, VK_MAX_ASYNC_CB_COUNT> m_primary_cb_list;
 	command_buffer_chunk* m_current_command_buffer = nullptr;
 
-	std::array<VkRenderPass, 120> m_render_passes;
-
 	VkDescriptorSetLayout descriptor_layouts;
 	VkPipelineLayout pipeline_layout;
 
@@ -468,8 +466,9 @@ private:
 	std::atomic<u64> m_last_sync_event = { 0 };
 
 	bool m_render_pass_open = false;
-	bool m_render_pass_is_cyclic = false;
-	size_t m_current_renderpass_id = 0;
+	u64  m_current_renderpass_key = 0;
+	VkRenderPass m_cached_renderpass = VK_NULL_HANDLE;
+	std::vector<vk::image*> m_fbo_images;
 
 	//Vertex layout
 	rsx::vertex_input_layout m_vertex_layout;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -1,6 +1,7 @@
 ﻿#include "stdafx.h"
 #include "VKHelpers.h"
 #include "VKCompute.h"
+#include "VKRenderPass.h"
 #include "Utilities/mutex.h"
 
 namespace vk
@@ -234,6 +235,9 @@ namespace vk
 
 	void destroy_global_resources()
 	{
+		VkDevice dev = *g_current_renderer;
+		vk::clear_renderpass_cache(dev);
+
 		g_null_texture.reset();
 		g_null_image_view.reset();
 		g_scratch_buffer.reset();
@@ -242,9 +246,10 @@ namespace vk
 		g_deleted_typeless_textures.clear();
 
 		if (g_null_sampler)
-			vkDestroySampler(*g_current_renderer, g_null_sampler, nullptr);
-
-		g_null_sampler = nullptr;
+		{
+			vkDestroySampler(dev, g_null_sampler, nullptr);
+			g_null_sampler = nullptr;
+		}
 
 		for (const auto& p : g_compute_tasks)
 		{

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -164,7 +164,6 @@ namespace vk
 			VkFilter filter = VK_FILTER_LINEAR, VkFormat src_format = VK_FORMAT_UNDEFINED, VkFormat dst_format = VK_FORMAT_UNDEFINED);
 
 	std::pair<VkFormat, VkComponentMapping> get_compatible_surface_format(rsx::surface_color_format color_format);
-	size_t get_render_pass_location(VkFormat color_surface_format, VkFormat depth_stencil_format, u8 color_surface_count);
 
 	//Texture barrier applies to a texture to ensure writes to it are finished before any reads are attempted to avoid RAW hazards
 	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range);
@@ -1056,6 +1055,11 @@ namespace vk
 		u32 depth() const
 		{
 			return info.extent.depth;
+		}
+
+		u8 samples() const
+		{
+			return u8(info.samples);
 		}
 
 		VkFormat format() const

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -1,0 +1,218 @@
+﻿#include "stdafx.h"
+
+#include "Utilities/mutex.h"
+#include "VKRenderPass.h"
+
+namespace vk
+{
+	shared_mutex g_renderpass_cache_mutex;
+	std::unordered_map<u64, VkRenderPass> g_renderpass_cache;
+
+	u64 get_renderpass_key(const std::vector<vk::image*>& images)
+	{
+		// Key structure
+		// 0-8 color_format
+		// 8-16 depth_format
+		// 16-21 sample_counts
+		// 21-37 current layouts
+		u64 key = 0;
+		u64 layout_offset = 22;
+		for (const auto &surface : images)
+		{
+			const auto format_code = u64(surface->format()) & 0xFF;
+			switch (format_code)
+			{
+			case VK_FORMAT_D16_UNORM:
+			case VK_FORMAT_D24_UNORM_S8_UINT:
+			case VK_FORMAT_D32_SFLOAT_S8_UINT:
+				key |= (format_code << 8);
+				break;
+			default:
+				key |= format_code;
+				break;
+			}
+
+			switch (const auto layout = surface->current_layout)
+			{
+			case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+			case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+			case VK_IMAGE_LAYOUT_GENERAL:
+				key |= (u64(layout) << layout_offset);
+				layout_offset += 3;
+				break;
+			default:
+				fmt::throw_exception("Unsupported image layout 0x%x", (u32)layout);
+			}
+		}
+
+		key |= u64(images[0]->samples()) << 16;
+		return key;
+	}
+
+	u64 get_renderpass_key(const std::vector<vk::image*>& images, u64 previous_key)
+	{
+		// Partial update; assumes compatible renderpass keys
+		const u64 layout_mask = (0x7FFF << 22);
+
+		u64 key = previous_key & ~layout_mask;
+		u64 layout_offset = 22;
+
+		for (const auto &surface : images)
+		{
+			switch (const auto layout = surface->current_layout)
+			{
+			case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+			case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+			case VK_IMAGE_LAYOUT_GENERAL:
+				key |= (u64(layout) << layout_offset);
+				layout_offset += 3;
+				break;
+			default:
+				fmt::throw_exception("Unsupported image layout 0x%x", (u32)layout);
+			}
+		}
+
+		return key;
+	}
+
+	u64 get_renderpass_key(VkFormat surface_format)
+	{
+		u64 key = (1ull << 16);
+
+		switch (surface_format)
+		{
+		case VK_FORMAT_D16_UNORM:
+		case VK_FORMAT_D24_UNORM_S8_UINT:
+		case VK_FORMAT_D32_SFLOAT_S8_UINT:
+			key |= (u64(surface_format) << 8);
+			key |= (u64(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL) << 22);
+			break;
+		default:
+			key |= u64(surface_format);
+			key |= (u64(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) << 22);
+			break;
+		}
+
+		return key;
+	}
+
+	VkRenderPass get_renderpass(VkDevice dev, u64 renderpass_key)
+	{
+		// 99.999% of checks will go through this block once on-disk shader cache has loaded
+		{
+			reader_lock lock(g_renderpass_cache_mutex);
+
+			auto found = g_renderpass_cache.find(renderpass_key);
+			if (found != g_renderpass_cache.end())
+			{
+				return found->second;
+			}
+		}
+
+		std::lock_guard lock(g_renderpass_cache_mutex);
+
+		// Check again
+		auto found = g_renderpass_cache.find(renderpass_key);
+		if (found != g_renderpass_cache.end())
+		{
+			return found->second;
+		}
+
+		// Decode
+		VkSampleCountFlagBits samples = VkSampleCountFlagBits((renderpass_key >> 16) & 0x1F);
+		std::vector<VkImageLayout> rtv_layouts;
+		VkImageLayout dsv_layout;
+
+		u64 layout_offset = 22;
+		for (int n = 0; n < 5; ++n)
+		{
+			const VkImageLayout layout = VkImageLayout((renderpass_key >> layout_offset) & 0x7);
+			layout_offset += 3;
+
+			if (layout)
+			{
+				rtv_layouts.push_back(layout);
+			}
+			else
+			{
+				break;
+			}
+		}
+
+		VkFormat color_format = VkFormat(renderpass_key & 0xFF);
+		VkFormat depth_format = VkFormat((renderpass_key >> 8) & 0xFF);
+
+		if (depth_format)
+		{
+			dsv_layout = rtv_layouts.back();
+			rtv_layouts.pop_back();
+		}
+
+		std::vector<VkAttachmentDescription> attachments = {};
+		std::vector<VkAttachmentReference> attachment_references;
+
+		u32 attachment_count = 0;
+		for (const auto &layout : rtv_layouts)
+		{
+			VkAttachmentDescription color_attachment_description = {};
+			color_attachment_description.format = color_format;
+			color_attachment_description.samples = samples;
+			color_attachment_description.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+			color_attachment_description.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+			color_attachment_description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+			color_attachment_description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			color_attachment_description.initialLayout = layout;
+			color_attachment_description.finalLayout = layout;
+
+			attachments.push_back(color_attachment_description);
+			attachment_references.push_back({ attachment_count++, layout });
+		}
+
+		if (depth_format)
+		{
+			VkAttachmentDescription depth_attachment_description = {};
+			depth_attachment_description.format = depth_format;
+			depth_attachment_description.samples = samples;
+			depth_attachment_description.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+			depth_attachment_description.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+			depth_attachment_description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+			depth_attachment_description.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
+			depth_attachment_description.initialLayout = dsv_layout;
+			depth_attachment_description.finalLayout = dsv_layout;
+			attachments.push_back(depth_attachment_description);
+
+			attachment_references.push_back({ attachment_count, dsv_layout });
+		}
+
+		VkSubpassDescription subpass = {};
+		subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+		subpass.colorAttachmentCount = attachment_count;
+		subpass.pColorAttachments = attachment_count? attachment_references.data() : nullptr;
+		subpass.pDepthStencilAttachment = depth_format? &attachment_references.back() : nullptr;
+
+		VkRenderPassCreateInfo rp_info = {};
+		rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+		rp_info.attachmentCount = static_cast<uint32_t>(attachments.size());
+		rp_info.pAttachments = attachments.data();
+		rp_info.subpassCount = 1;
+		rp_info.pSubpasses = &subpass;
+		rp_info.pDependencies = nullptr;
+		rp_info.dependencyCount = 0;
+
+		VkRenderPass result;
+		CHECK_RESULT(vkCreateRenderPass(dev, &rp_info, NULL, &result));
+
+		g_renderpass_cache[renderpass_key] = result;
+		return result;
+	}
+
+	void clear_renderpass_cache(VkDevice dev)
+	{
+		for (const auto &renderpass : g_renderpass_cache)
+		{
+			vkDestroyRenderPass(dev, renderpass.second, nullptr);
+		}
+
+		g_renderpass_cache.clear();
+	}
+}

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.h
@@ -1,0 +1,13 @@
+﻿#pragma once
+
+#include "VKHelpers.h"
+
+namespace vk
+{
+	u64 get_renderpass_key(const std::vector<vk::image*>& images);
+	u64 get_renderpass_key(const std::vector<vk::image*>& images, u64 previous_key);
+	u64 get_renderpass_key(VkFormat surface_format);
+	VkRenderPass get_renderpass(VkDevice dev, u64 renderpass_key);
+
+	void clear_renderpass_cache(VkDevice dev);
+}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -308,6 +308,8 @@ namespace rsx
 				sink->surface_width = prev.width;
 				sink->surface_height = prev.height;
 				sink->queue_tag(address);
+
+				change_image_layout(cmd, sink.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 			}
 
 			prev.target = sink.get();
@@ -316,8 +318,6 @@ namespace rsx
 			sink->sync_tag();
 			sink->set_old_contents_region(prev, false);
 			sink->last_use_tag = ref->last_use_tag;
-
-			change_image_layout(cmd, sink.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 		}
 
 		static bool is_compatible_surface(const vk::render_target* surface, const vk::render_target* ref, u16 width, u16 height, u8 /*sample_count*/)

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -253,7 +253,7 @@ namespace vk
 			}
 		}
 
-		void init(vk::render_device &dev, VkRenderPass &render_pass)
+		void init(vk::render_device &dev, VkRenderPass render_pass)
 		{
 			verify(HERE), render_pass != VK_NULL_HANDLE;
 

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="Emu\RSX\VK\VKHelpers.h" />
     <ClInclude Include="Emu\RSX\VK\VKOverlays.h" />
     <ClInclude Include="Emu\RSX\VK\VKProgramBuffer.h" />
+    <ClInclude Include="Emu\RSX\VK\VKRenderPass.h" />
     <ClInclude Include="Emu\RSX\VK\VKRenderTargets.h" />
     <ClInclude Include="Emu\RSX\VK\VKTextOut.h" />
     <ClInclude Include="Emu\RSX\VK\VKTextureCache.h" />
@@ -44,6 +45,7 @@
     <ClCompile Include="Emu\RSX\VK\VKGSRender.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKHelpers.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKProgramPipeline.cpp" />
+    <ClCompile Include="Emu\RSX\VK\VKRenderPass.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKTexture.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKVertexBuffers.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKVertexProgram.cpp" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClInclude Include="Emu\RSX\VK\VKCompute.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\VKRenderPass.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Emu\RSX\VK\VKGSRender.cpp">
@@ -79,6 +82,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Emu\RSX\VK\VKMemAlloc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\RSX\VK\VKRenderPass.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Do not rely on a precomputed renderpass array and instead generate a proper cache to manage these resources.
- Ensures the current renderpass matches the image properties even when a cyclic reference is detected
- Solves problems due to mismatching layouts and renderpasses