### PR TITLE
vk: Refactor framebuffers

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKFramebuffer.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFramebuffer.cpp
@@ -1,0 +1,90 @@
+﻿#include "stdafx.h"
+
+#include "VKFramebuffer.h"
+
+namespace vk
+{
+	std::unordered_map<u64, std::vector<std::unique_ptr<vk::framebuffer_holder>>> g_framebuffers_cache;
+
+	vk::framebuffer_holder *get_framebuffer(VkDevice dev, u16 width, u16 height, VkRenderPass renderpass, const std::vector<vk::image*>& image_list)
+	{
+		u64 key = u64(width) | (u64(height) << 16);
+		auto &queue = g_framebuffers_cache[key];
+
+		for (auto &fbo : queue)
+		{
+			if (fbo->matches(image_list, width, height))
+			{
+				return fbo.get();
+			}
+		}
+
+		std::vector<std::unique_ptr<vk::image_view>> image_views;
+		image_views.reserve(image_list.size());
+
+		for (auto &e : image_list)
+		{
+			const VkImageSubresourceRange subres = { e->aspect(), 0, 1, 0, 1 };
+			image_views.push_back(std::make_unique<vk::image_view>(dev, e, vk::default_component_map(), subres));
+		}
+
+		auto value = std::make_unique<vk::framebuffer_holder>(dev, renderpass, width, height, std::move(image_views));
+		auto ret = value.get();
+
+		queue.push_back(std::move(value));
+		return ret;
+	}
+
+	vk::framebuffer_holder* get_framebuffer(VkDevice dev, u16 width, u16 height, VkRenderPass renderpass, VkFormat format, VkImage attachment)
+	{
+		u64 key = u64(width) | (u64(height) << 16);
+		auto &queue = g_framebuffers_cache[key];
+
+		for (const auto &e : queue)
+		{
+			if (e->attachments[0]->info.image == attachment)
+			{
+				return e.get();
+			}
+		}
+
+		VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+		std::vector<std::unique_ptr<vk::image_view>> views;
+
+		views.push_back(std::make_unique<vk::image_view>(dev, attachment, VK_IMAGE_VIEW_TYPE_2D, format, vk::default_component_map(), range));
+		auto value = std::make_unique<vk::framebuffer_holder>(dev, renderpass, width, height, std::move(views));
+		auto ret = value.get();
+
+		queue.push_back(std::move(value));
+		return ret;
+	}
+
+	void remove_unused_framebuffers()
+	{
+		// Remove stale framebuffers. Ref counted to prevent use-after-free
+		for (auto It = g_framebuffers_cache.begin(); It != g_framebuffers_cache.end();)
+		{
+			It->second.erase(
+				std::remove_if(It->second.begin(), It->second.end(), [](const auto& fbo)
+				{
+					return (fbo->unused_check_count() >= 2);
+				}),
+				It->second.end()
+			);
+
+			if (It->second.empty())
+			{
+				It = g_framebuffers_cache.erase(It);
+			}
+			else
+			{
+				++It;
+			}
+		}
+	}
+
+	void clear_framebuffer_cache()
+	{
+		g_framebuffers_cache.clear();
+	}
+}

--- a/rpcs3/Emu/RSX/VK/VKFramebuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKFramebuffer.h
@@ -1,0 +1,17 @@
+﻿#pragma once
+
+#include "VKHelpers.h"
+
+namespace vk
+{
+	struct framebuffer_holder : public vk::framebuffer, public rsx::ref_counted
+	{
+		using framebuffer::framebuffer;
+	};
+
+	vk::framebuffer_holder* get_framebuffer(VkDevice dev, u16 width, u16 height, VkRenderPass renderpass, const std::vector<vk::image*>& image_list);
+	vk::framebuffer_holder* get_framebuffer(VkDevice dev, u16 width, u16 height, VkRenderPass renderpass, VkFormat format, VkImage attachment);
+
+	void remove_unused_framebuffers();
+	void clear_framebuffer_cache();
+}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -535,7 +535,7 @@ VKGSRender::VKGSRender() : GSRender()
 	else
 		m_vertex_cache.reset(new vk::weak_vertex_cache());
 
-	m_shaders_cache.reset(new vk::shader_cache(*m_prog_buffer.get(), "vulkan", "v1.6"));
+	m_shaders_cache.reset(new vk::shader_cache(*m_prog_buffer.get(), "vulkan", "v1.7"));
 
 	open_command_buffer();
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -7,6 +7,7 @@
 #include "VKTextOut.h"
 #include "VKOverlays.h"
 #include "VKProgramBuffer.h"
+#include "VKFramebuffer.h"
 #include "../GCM.h"
 #include "../rsx_utils.h"
 #include <thread>
@@ -409,7 +410,7 @@ private:
 	VkDescriptorSetLayout descriptor_layouts;
 	VkPipelineLayout pipeline_layout;
 
-	std::unique_ptr<vk::framebuffer_holder> m_draw_fbo;
+	vk::framebuffer_holder* m_draw_fbo = nullptr;
 
 	bool present_surface_dirty_flag = false;
 	bool renderer_unavailable = false;
@@ -437,9 +438,6 @@ private:
 	std::array<frame_context_t, VK_MAX_ASYNC_FRAMES> frame_context_storage;
 	//Temp frame context to use if the real frame queue is overburdened. Only used for storage
 	frame_context_t m_aux_frame_context;
-
-	//framebuffers are shared between frame contexts
-	std::list<std::unique_ptr<vk::framebuffer_holder>> m_framebuffers_to_clean;
 
 	u32 m_current_queue_index = 0;
 	frame_context_t* m_current_frame = nullptr;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -2,6 +2,7 @@
 #include "VKHelpers.h"
 #include "VKCompute.h"
 #include "VKRenderPass.h"
+#include "VKFramebuffer.h"
 #include "Utilities/mutex.h"
 
 namespace vk
@@ -237,6 +238,7 @@ namespace vk
 	{
 		VkDevice dev = *g_current_renderer;
 		vk::clear_renderpass_cache(dev);
+		vk::clear_framebuffer_cache();
 
 		g_null_texture.reset();
 		g_null_image_view.reset();

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -2,16 +2,16 @@
 
 #include "stdafx.h"
 #include "VKHelpers.h"
+#include "VKFormats.h"
 #include "../GCM.h"
 #include "../Common/surface_store.h"
 #include "../Common/TextureUtils.h"
 #include "../Common/texture_cache_utils.h"
-#include "VKFormats.h"
 #include "../rsx_utils.h"
 
 namespace vk
 {
-	struct render_target : public viewable_image, public rsx::ref_counted, public rsx::render_target_descriptor<vk::image*>
+	struct render_target : public viewable_image, public rsx::ref_counted, public rsx::render_target_descriptor<vk::viewable_image*>
 	{
 		u16 native_pitch = 0;
 		u16 rsx_pitch = 0;
@@ -23,9 +23,9 @@ namespace vk
 
 		using viewable_image::viewable_image;
 
-		vk::image* get_surface() override
+		vk::viewable_image* get_surface() override
 		{
-			return (vk::image*)this;
+			return (vk::viewable_image*)this;
 		}
 
 		u16 get_surface_width() const override
@@ -53,7 +53,7 @@ namespace vk
 			return !!(aspect() & VK_IMAGE_ASPECT_DEPTH_BIT);
 		}
 
-		void release_ref(vk::image* t) const override
+		void release_ref(vk::viewable_image* t) const override
 		{
 			static_cast<vk::render_target*>(t)->release();
 		}
@@ -164,17 +164,6 @@ namespace vk
 
 		void read_barrier(vk::command_buffer& cmd) { memory_barrier(cmd, true); }
 		void write_barrier(vk::command_buffer& cmd) { memory_barrier(cmd, false); }
-	};
-
-	struct framebuffer_holder: public vk::framebuffer, public rsx::ref_counted
-	{
-		framebuffer_holder(VkDevice dev,
-			VkRenderPass pass,
-			u32 width, u32 height,
-			std::vector<std::unique_ptr<vk::image_view>> &&atts)
-
-			: framebuffer(dev, pass, width, height, std::move(atts))
-		{}
 	};
 
 	static inline vk::render_target* as_rtt(vk::image* t)

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -27,6 +27,7 @@
     <ClInclude Include="Emu\RSX\VK\VKCompute.h" />
     <ClInclude Include="Emu\RSX\VK\VKFormats.h" />
     <ClInclude Include="Emu\RSX\VK\VKFragmentProgram.h" />
+    <ClInclude Include="Emu\RSX\VK\VKFramebuffer.h" />
     <ClInclude Include="Emu\RSX\VK\VKGSRender.h" />
     <ClInclude Include="Emu\RSX\VK\VKHelpers.h" />
     <ClInclude Include="Emu\RSX\VK\VKOverlays.h" />
@@ -42,6 +43,7 @@
     <ClCompile Include="Emu\RSX\VK\VKCommonDecompiler.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKFormats.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKFragmentProgram.cpp" />
+    <ClCompile Include="Emu\RSX\VK\VKFramebuffer.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKGSRender.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKHelpers.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKProgramPipeline.cpp" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -49,6 +49,9 @@
     <ClInclude Include="Emu\RSX\VK\VKRenderPass.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\VKFramebuffer.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Emu\RSX\VK\VKGSRender.cpp">
@@ -85,6 +88,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Emu\RSX\VK\VKRenderPass.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\RSX\VK\VKFramebuffer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
- Refactor out framebuffers from the renderer core.
- Use a proper cache with sorted queues for faster searching.
- Bump shader cache version which I forgot to do with the last refactor.