### PR TITLE
update glslang

### DIFF
--- a/Vulkan/CMakeLists.txt
+++ b/Vulkan/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(SKIP_GLSLANG_INSTALL ON CACHE BOOL "Skip installation" FORCE)
 set(ENABLE_GLSLANG_BINARIES OFF CACHE BOOL "Builds glslangValidator and spirv-remap" FORCE)
+set(ENABLE_OPT OFF CACHE BOOL "Enables spirv-opt capability if present" FORCE)
 set(ENABLE_HLSL OFF CACHE BOOL "Enables HLSL input support" FORCE)
+set(ENABLE_AMD_EXTENSIONS ON CACHE BOOL "Enables support of AMD-specific extensions" FORCE)
+set(ENABLE_NV_EXTENSIONS ON CACHE BOOL "Enables support of Nvidia-specific extensions" FORCE)
 add_subdirectory(glslang)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ image: Visual Studio 2017
 environment:
   QTDIR: C:\Qt\5.11\msvc2017_64
   LLVMLIBS: https://github.com/RPCS3/llvm/releases/download/continuous-master/llvmlibs.7z
-  GLSLANG: https://drive.google.com/uc?export=download&id=1nJK_NEeRzJ_r_u4zWLySwLmMrV8ZO_wL
+  GLSLANG: https://dl.dropboxusercontent.com/s/ku2qgwmtfptzbvx/glslang.7z
   COMPATDB: https://rpcs3.net/compatibility?api=v1&export
   VULKAN_SDK: "C:\\VulkanSDK\\1.1.73.0"
   VULKAN_SDK_URL: https://sdk.lunarg.com/sdk/download/1.1.73.0/windows/VulkanSDK-1.1.73.0-Installer.exe

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -32,7 +32,7 @@ void VKFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 	if (device_props.has_native_half_support)
 	{
 		OS << "#version 450\n";
-		OS << "#extension GL_KHX_shader_explicit_arithmetic_types_float16: enable\n";
+		OS << "#extension GL_EXT_shader_explicit_arithmetic_types_float16: enable\n";
 	}
 	else
 	{


### PR DESCRIPTION
Updates glslang to the last release before work on SPIRV_1_4 started. This is also the last build which does not mandate python3; all other newer versions require that PYTHON_EXECUTABLE is defined on cmake command if you have both python2 and 3 installed.
Newer glslang has improved support some extensions required for some upcoming features. No regressions are expected from this change.