### PR TITLE
vk: Fixups

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include <sstream>
 
+#include "GLSLTypes.h"
 #include "ShaderParam.h"
 
 namespace program_common
@@ -132,19 +133,6 @@ namespace program_common
 
 namespace glsl
 {
-	enum program_domain
-	{
-		glsl_vertex_program = 0,
-		glsl_fragment_program = 1,
-		glsl_compute_program = 2
-	};
-
-	enum glsl_rules
-	{
-		glsl_rules_opengl4,
-		glsl_rules_rpirv
-	};
-
 	static std::string getFloatTypeNameImpl(size_t elementCount)
 	{
 		switch (elementCount)
@@ -499,20 +487,6 @@ namespace glsl
 		"	ocol2 = " << reg2 << ";\n"
 		"	ocol3 = " << reg3 << ";\n\n";
 	}
-
-	struct shader_properties
-	{
-		glsl::program_domain domain;
-		// Applicable in vertex stage
-		bool require_lit_emulation;
-
-		// Only relevant for fragment programs
-		bool require_wpos;
-		bool require_depth_conversion;
-		bool require_texture_ops;
-		bool emulate_shadow_compare;
-		bool low_precision_tests;
-	};
 
 	static void insert_glsl_legacy_function(std::ostream& OS, const shader_properties& props)
 	{

--- a/rpcs3/Emu/RSX/Common/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Common/GLSLTypes.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace glsl
+{
+	enum program_domain
+	{
+		glsl_vertex_program = 0,
+		glsl_fragment_program = 1,
+		glsl_compute_program = 2
+	};
+
+	enum glsl_rules
+	{
+		glsl_rules_opengl4,
+		glsl_rules_spirv
+	};
+
+	struct shader_properties
+	{
+		glsl::program_domain domain;
+		// Applicable in vertex stage
+		bool require_lit_emulation;
+
+		// Only relevant for fragment programs
+		bool require_wpos;
+		bool require_depth_conversion;
+		bool require_texture_ops;
+		bool emulate_shadow_compare;
+		bool low_precision_tests;
+	};
+};

--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.h
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "../Common/ShaderParam.h"
-#include "../Common/GLSLCommon.h"
+#include "../Common/GLSLTypes.h"
 
 namespace vk
 {

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -2,9 +2,9 @@
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "VKFragmentProgram.h"
-
 #include "VKCommonDecompiler.h"
 #include "VKHelpers.h"
+#include "../Common/GLSLCommon.h"
 #include "../GCM.h"
 
 std::string VKFragmentDecompilerThread::getFloatTypeName(size_t elementCount)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1051,13 +1051,13 @@ void VKGSRender::begin()
 			m_aux_frame_context.grab_resources(*m_current_frame);
 			m_current_frame = &m_aux_frame_context;
 		}
-
-		verify(HERE), !m_current_frame->swap_command_buffer;
-		if (m_current_frame->used_descriptors)
+		else if (m_current_frame->used_descriptors)
 		{
 			m_current_frame->descriptor_pool.reset(0);
 			m_current_frame->used_descriptors = 0;
 		}
+
+		verify(HERE), !m_current_frame->swap_command_buffer;
 
 		m_current_frame->flags &= ~frame_context_state::dirty;
 	}

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -4,6 +4,7 @@
 #include "VKVertexProgram.h"
 #include "VKCommonDecompiler.h"
 #include "VKHelpers.h"
+#include "../Common/GLSLCommon.h"
 
 std::string VKVertexDecompilerThread::getFloatTypeName(size_t elementCount)
 {
@@ -205,7 +206,7 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	properties2.low_precision_tests = false;
 
 	glsl::insert_glsl_legacy_function(OS, properties2);
-	glsl::insert_vertex_input_fetch(OS, glsl::glsl_rules_rpirv);
+	glsl::insert_vertex_input_fetch(OS, glsl::glsl_rules_spirv);
 
 	std::string parameters = "";
 	for (int i = 0; i < 16; ++i)


### PR DESCRIPTION
- Fix aux context usage when handling swap queues. The aux context does not have its own descriptor pool and borrows from the laggy frame context which has a pool that is still in use.
- Refactor out GLSLCommon from VKHelpers since VKHelpers is included in GUI code to assist with context intialization. This should remove a lot of compiler warning spam about unused static functions declared in the header.

Fixes https://github.com/RPCS3/rpcs3/issues/5999