### PR TITLE
 vk: remove duplicate condition in pipeline_props struct equal operator 

### DIFF
--- a/Vulkan/CMakeLists.txt
+++ b/Vulkan/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SKIP_GLSLANG_INSTALL ON CACHE BOOL "Skip installation" FORCE)
+set(ENABLE_SPVREMAPPER OFF CACHE BOOL "Enables building of SPVRemapper" FORCE)
 set(ENABLE_GLSLANG_BINARIES OFF CACHE BOOL "Builds glslangValidator and spirv-remap" FORCE)
 set(ENABLE_OPT OFF CACHE BOOL "Enables spirv-opt capability if present" FORCE)
 set(ENABLE_HLSL OFF CACHE BOOL "Enables HLSL input support" FORCE)

--- a/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
@@ -40,9 +40,6 @@ namespace vk
 			if (memcmp(&state.ds, &other.state.ds, sizeof(VkPipelineDepthStencilStateCreateInfo)))
 				return false;
 
-			if (num_targets != other.num_targets)
-				return false;
-
 			return num_targets == other.num_targets;
 		}
 	};


### PR DESCRIPTION
I can also replace
```
if (num_targets != other.num_targets)
	return false;

return num_targets == other.num_targets;
```
by
```
if (num_targets != other.num_targets)
	return false;

return true;
```
if preferred