### PR TITLE
Add new accuracy control for PUTLLUC accuracy setting (non-TSX)

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -15,6 +15,9 @@ void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode)
 {
 	vm::temporary_unlock(ppu);
 
+	// Need to wait until the current writer finish
+	if (ppu.state & cpu_flag::memory) vm::g_mutex.lock_unlock();
+
 	sys_ppu_thread.trace("_sys_ppu_thread_exit(errorcode=0x%llx)", errorcode);
 
 	ppu.state += cpu_flag::exit;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -388,7 +388,7 @@ struct cfg_root : cfg::node
 		node_core(cfg::node* _this) : cfg::node(_this, "Core") {}
 
 		cfg::_enum<ppu_decoder_type> ppu_decoder{this, "PPU Decoder", ppu_decoder_type::llvm};
-		cfg::_int<1, 4> ppu_threads{this, "PPU Threads", 2}; // Amount of PPU threads running simultaneously (must be 2)
+		cfg::_int<1, 8> ppu_threads{this, "PPU Threads", 2}; // Amount of PPU threads running simultaneously (must be 2)
 		cfg::_bool ppu_debug{this, "PPU Debug"};
 		cfg::_bool llvm_logs{this, "Save LLVM logs"};
 		cfg::string llvm_cpu{this, "Use LLVM CPU"};


### PR DESCRIPTION
What the new accuracy control offers: ensures no fragmentation when using GET commands and a simultaneous lock line atomic store is happening on another thread.
Fixed a very rare race condition resulting in a segfault after ppu thread deletion on non-tsx path at vm::writer_lock.
The segfault fix is very obvious if you add a sleep to https://github.com/RPCS3/rpcs3/blob/master/rpcs3/Emu/Memory/vm.cpp#L247
such as 
```
for (auto& lock : g_locks)
{
	if (cpu_thread* ptr = lock)
	{
		thread_ctrl::wait_for(1000);
		ptr->state.test_and_set(cpu_flag::memory);
	}
}
```

knowing a ppu thread could have been destroyed by the time its been dereferenced.