### PR TITLE
rsx: Minor cleanup after #6055

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -213,11 +213,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 	std::array<GLuint, 4> color_targets;
 	GLuint depth_stencil_target;
 
-	const auto color_offsets = get_offsets();
-	const auto color_locations = get_locations();
-
 	const u8 color_bpp = get_format_block_size_in_bytes(layout.color_format);
-	const u8 depth_bpp = (layout.depth_format == rsx::surface_depth_format::z16 ? 2 : 4);
 	const auto samples = get_format_sample_count(layout.aa_mode);
 
 	for (int i = 0; i < rsx::limits::color_buffers_count; ++i)
@@ -253,9 +249,6 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 
 	if (m_depth_surface_info.pitch && g_cfg.video.write_depth_buffer)
 	{
-		auto bpp = m_depth_surface_info.pitch / m_depth_surface_info.width;
-		auto old_format = (bpp == 2) ? gl::texture::format::depth : gl::texture::format::depth_stencil;
-
 		const utils::address_range surface_range = m_depth_surface_info.get_memory_range();
 		m_gl_texture_cache.set_memory_read_flags(surface_range, rsx::memory_read_flags::flush_once);
 		m_gl_texture_cache.flush_if_cache_miss_likely(cmd, surface_range);

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -28,11 +28,11 @@ namespace vk
 		virtual std::vector<std::pair<VkDescriptorType, u8>> get_descriptor_layout()
 		{
 			std::vector<std::pair<VkDescriptorType, u8>> result;
-			result.push_back({ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1 });
+			result.emplace_back(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
 
 			if (uniform_inputs)
 			{
-				result.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1 });
+				result.emplace_back(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1);
 			}
 
 			return result;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2770,7 +2770,6 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		(*m_device), *m_current_command_buffer);
 
 	// Reset framebuffer information
-	VkFormat old_format = VK_FORMAT_UNDEFINED;
 	const auto color_bpp = get_format_block_size_in_bytes(layout.color_format);
 	const auto samples = get_format_sample_count(layout.aa_mode);
 
@@ -2779,9 +2778,6 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		// Flush old address if we keep missing it
 		if (m_surface_info[i].pitch && g_cfg.video.write_color_buffers)
 		{
-			if (old_format == VK_FORMAT_UNDEFINED)
-				old_format = vk::get_compatible_surface_format(m_surface_info[i].color_format).first;
-
 			const utils::address_range rsx_range = m_surface_info[i].get_memory_range();
 			m_texture_cache.set_memory_read_flags(rsx_range, rsx::memory_read_flags::flush_once);
 			m_texture_cache.flush_if_cache_miss_likely(*m_current_command_buffer, rsx_range);
@@ -2799,7 +2795,6 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	{
 		if (m_depth_surface_info.pitch && g_cfg.video.write_depth_buffer)
 		{
-			auto old_format = vk::get_compatible_depth_surface_format(m_device->get_formats_support(), m_depth_surface_info.depth_format);
 			const utils::address_range surface_range = m_depth_surface_info.get_memory_range();
 			m_texture_cache.set_memory_read_flags(surface_range, rsx::memory_read_flags::flush_once);
 			m_texture_cache.flush_if_cache_miss_likely(*m_current_command_buffer, surface_range);


### PR DESCRIPTION
- Remove unused variables
- Prefer emplace_back instead of push_back when possible (https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-emplace.html)