### PR TITLE
Fix dynamic_library::loaded

### DIFF
--- a/Utilities/dynamic_library.cpp
+++ b/Utilities/dynamic_library.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "dynamic_library.h"
 
 #ifdef _WIN32
@@ -50,7 +50,7 @@ namespace utils
 
 	bool dynamic_library::loaded() const
 	{
-		return !m_handle;
+		return m_handle != nullptr;
 	}
 
 	dynamic_library::operator bool() const


### PR DESCRIPTION
The class dynamic_library doesn't seem to be used anywhere, but the implementation of `loaded()` is incorrect, and returning the wrong value. This commit fixes that, in case anyone decides to use this class in the future.