### PR TITLE
Improve file decryption

### DIFF
--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -569,7 +569,7 @@
   </action>
   <action name="toolsDecryptSprxLibsAct">
    <property name="text">
-    <string>SPRX Decryption</string>
+    <string>Decrypt PS3 Binaries</string>
    </property>
   </action>
   <action name="showDebuggerAct">


### PR DESCRIPTION
Currently you can only decrypt .sprx files with the GUI.
This adds the following filters to the decryption file dialog:
- .bin
- .self
- All binaries (.bin, .self, .sprx)
- All files

This PR also changes the file endings of the decrypted files to .elf in case of .bin or .self.