### PR TITLE
ppu/lv2: Always reschedule when sleeping (with timeout)

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1042,16 +1042,20 @@ void lv2_obj::sleep_timeout(cpu_thread& thread, u64 timeout)
 		const u64 wait_until = start_time + timeout;
 
 		// Register timeout if necessary
-		for (auto it = g_waiting.begin(), end = g_waiting.end(); it != end; it++)
+		for (auto it = g_waiting.begin(), end = g_waiting.end();; it++)
 		{
+			if (it == end)
+			{
+				g_waiting.emplace_back(wait_until, &thread);
+				break;
+			}
+
 			if (it->first > wait_until)
 			{
 				g_waiting.emplace(it, wait_until, &thread);
-				return;
+				break;
 			}
 		}
-
-		g_waiting.emplace_back(wait_until, &thread);
 	}
 
 	schedule_all();


### PR DESCRIPTION
Imagine the following situation:
A program has 4 threads in total, all of them are sorted by priority from highest to lowest.

thread 1 (highest priority) - was running, goes to usleep with an x wait_until sleep time.
thread 2 - was running, after thread 1 went to sleep goes to a usleep with a nearer wait_until. 
thread 3 - never yields manually.
thread 4 (lowest priority) - never yields manually.

With the added reschedule, there will be a timespam where both thread 3 and 4 are allowed to execute.
Otherwise thread 4 never executes. 