### PR TITLE
Tiny Refactoring

### DIFF
--- a/Utilities/Atomic.h
+++ b/Utilities/Atomic.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "types.h"
 #include <functional>
@@ -1162,5 +1162,15 @@ public:
 				return true;
 			}
 		}
+	}
+
+	bool bts(uint bit)
+	{
+		return atomic_storage<type>::bts(m_data, bit);
+	}
+
+	bool btr(uint bit)
+	{
+		return atomic_storage<type>::btr(m_data, bit);
 	}
 };

--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef _MSC_VER
 #include <intrin.h>

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -440,7 +440,7 @@ error_code cellPadPeriphGetData(u32 port_no, vm::ptr<CellPadPeriphData> data)
 	data->pclass_type = pad->m_class_type;
 	data->pclass_profile = 0x0;
 
-	return cellPadGetData(port_no, vm::get_addr(&data->cellpad_data));
+	return cellPadGetData(port_no, data.ptr(&CellPadPeriphData::cellpad_data));
 }
 
 error_code cellPadGetRawData(u32 port_no, vm::ptr<CellPadData> data)

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -1486,7 +1486,7 @@ bool ppu_interpreter_precise::VPKSHUS(ppu_thread& ppu, ppu_opcode_t op)
 	// Detect saturation
 	{
 		const u64 mask = 0xFF00FF00FF00FF00ULL;
-		const auto all_bits = v128::fromV(_mm_or_si128(a.vi, b.vi));
+		const auto all_bits = a | b;
 		if ((all_bits._u64[0] | all_bits._u64[1]) & mask)
 		{
 			ppu.sat = true;

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -142,6 +142,9 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 		case MFC_PUTS_CMD:
 		case MFC_PUTBS_CMD:
 		case MFC_PUTFS_CMD:
+		case MFC_PUTR_CMD:
+		case MFC_PUTRB_CMD:
+		case MFC_PUTRF_CMD:
 		case MFC_GET_CMD:
 		case MFC_GETB_CMD:
 		case MFC_GETF_CMD:

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1335,8 +1335,8 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 		}
 	}
 
-	u8* dst = (u8*)vm::base(eal);
-	u8* src = (u8*)vm::base(offset + lsa);
+	u8* dst = vm::_ptr<u8>(eal);
+	u8* src = vm::_ptr<u8>(offset + lsa);
 
 	if (UNLIKELY(!is_get && !g_use_rtm))
 	{
@@ -1603,7 +1603,7 @@ void spu_thread::do_putlluc(const spu_mfc_cmd& args)
 			cpu_thread::suspend_all cpu_lock(this);
 
 			// Try to obtain bit 7 (+64)
-			if (!atomic_storage<u64>::bts(vm::reservation_acquire(addr, 128).raw(), 6))
+			if (!vm::reservation_acquire(addr, 128).bts(6))
 			{
 				auto& data = vm::_ref<decltype(rdata)>(addr);
 				mov_rdata(data, to_write);

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -94,7 +94,7 @@ void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
 			std::memcpy(vm::base(loc + seg.ls), vm::base(seg.addr), seg.size);
 			sha1_update(&sha, (uchar*)&seg.size, sizeof(seg.size));
 			sha1_update(&sha, (uchar*)&seg.ls, sizeof(seg.ls));
-			sha1_update(&sha, vm::g_base_addr + seg.addr, seg.size);
+			sha1_update(&sha, vm::_ptr<uchar>(seg.addr), seg.size);
 		}
 		else if (seg.type == SYS_SPU_SEGMENT_TYPE_FILL)
 		{
@@ -127,12 +127,12 @@ void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
 	}
 
 	// Apply the patch
-	auto applied = fxm::check_unlocked<patch_engine>()->apply(hash, vm::g_base_addr + loc);
+	auto applied = fxm::check_unlocked<patch_engine>()->apply(hash, vm::_ptr<u8>(loc));
 
 	if (!Emu.GetTitleID().empty())
 	{
 		// Alternative patch
-		applied += fxm::check_unlocked<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr + loc);
+		applied += fxm::check_unlocked<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::_ptr<u8>(loc));
 	}
 
 	LOG_NOTICE(LOADER, "Loaded SPU image: %s (<- %u)%s", hash, applied, dump);

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -310,7 +310,7 @@ namespace vm
 	{
 		for (u64 i = 0;; i++)
 		{
-			if (LIKELY(!atomic_storage<u64>::bts(res.raw(), 0)))
+			if (LIKELY(!res.bts(0)))
 			{
 				break;
 			}
@@ -750,7 +750,7 @@ namespace vm
 		const u32 size = ::align(orig_size, min_page_size);
 
 		// return if addr or size is invalid
-		if (!size || size > this->size || addr < this->addr || addr + size - 1 > this->addr + this->size - 1 || flags & 0x10)
+		if (!size || addr < this->addr || addr + u64{size} > this->addr + this->size || flags & 0x10)
 		{
 			return 0;
 		}
@@ -823,7 +823,7 @@ namespace vm
 
 	std::pair<u32, std::shared_ptr<utils::shm>> block_t::get(u32 addr, u32 size)
 	{
-		if (addr < this->addr || std::max<u32>(size, addr - this->addr + size) >= this->size)
+		if (addr < this->addr || addr + u64{size} > this->addr + this->size)
 		{
 			return {addr, nullptr};
 		}

--- a/rpcs3/Emu/Memory/vm_reservation.h
+++ b/rpcs3/Emu/Memory/vm_reservation.h
@@ -36,7 +36,7 @@ namespace vm
 	{
 		auto& res = vm::reservation_acquire(addr, size);
 
-		if (UNLIKELY(atomic_storage<u64>::bts(res.raw(), 0)))
+		if (UNLIKELY(res.bts(0)))
 		{
 			reservation_lock_internal(res);
 		}

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -330,7 +330,7 @@ namespace rsx
 
 			rsx->read_barrier(src_addr, in_pitch * (line_count - 1) + line_length);
 
-			const u8* src = (u8*)vm::base(src_addr);
+			const u8* src = vm::_ptr<u8>(src_addr);
 
 			frame_capture_data::memory_block block;
 			block.offset = src_offset;

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -32,27 +32,27 @@ namespace rsx
 		const u32 contextAddr = vm::alloc(sizeof(rsx_context), vm::main);
 		if (contextAddr == 0)
 			fmt::throw_exception("Capture Replay: context alloc failed");
-		const auto& contextInfo = vm::_ref<rsx_context>(contextAddr);
+		const auto contextInfo = vm::ptr<rsx_context>::make(contextAddr);
 
 		// 'fake' initialize usermemory
-		sys_memory_allocate(buffer_size, SYS_MEMORY_PAGE_SIZE_1M, vm::get_addr(&contextInfo.user_addr));
-		verify(HERE), (user_mem_addr = contextInfo.user_addr) != 0;
+		sys_memory_allocate(buffer_size, SYS_MEMORY_PAGE_SIZE_1M, contextInfo.ptr(&rsx_context::user_addr));
+		verify(HERE), (user_mem_addr = contextInfo->user_addr) != 0;
 
-		if (sys_rsx_device_map(vm::get_addr(&contextInfo.dev_addr), vm::null, 0x8) != CELL_OK)
+		if (sys_rsx_device_map(contextInfo.ptr(&rsx_context::dev_addr), vm::null, 0x8) != CELL_OK)
 			fmt::throw_exception("Capture Replay: sys_rsx_device_map failed!");
 
-		if (sys_rsx_memory_allocate(vm::get_addr(&contextInfo.mem_handle), vm::get_addr(&contextInfo.mem_addr), 0x0F900000, 0, 0, 0, 0) != CELL_OK)
+		if (sys_rsx_memory_allocate(contextInfo.ptr(&rsx_context::mem_handle), contextInfo.ptr(&rsx_context::mem_addr), 0x0F900000, 0, 0, 0, 0) != CELL_OK)
 			fmt::throw_exception("Capture Replay: sys_rsx_memory_allocate failed!");
 
-		if (sys_rsx_context_allocate(vm::get_addr(&contextInfo.context_id), vm::get_addr(&contextInfo.dma_addr), vm::get_addr(&contextInfo.driver_info), vm::get_addr(&contextInfo.reports_addr), contextInfo.mem_handle, 0) != CELL_OK)
+		if (sys_rsx_context_allocate(contextInfo.ptr(&rsx_context::context_id), contextInfo.ptr(&rsx_context::dma_addr), contextInfo.ptr(&rsx_context::driver_info), contextInfo.ptr(&rsx_context::reports_addr), contextInfo->mem_handle, 0) != CELL_OK)
 			fmt::throw_exception("Capture Replay: sys_rsx_context_allocate failed!");
 
 		get_current_renderer()->main_mem_size = buffer_size;
 
-		if (sys_rsx_context_iomap(contextInfo.context_id, 0, user_mem_addr, buffer_size, 0) != CELL_OK)
+		if (sys_rsx_context_iomap(contextInfo->context_id, 0, user_mem_addr, buffer_size, 0) != CELL_OK)
 			fmt::throw_exception("Capture Replay: rsx io mapping failed!");
 
-		return contextInfo.context_id;
+		return contextInfo->context_id;
 	}
 
 	std::vector<u32> rsx_replay_thread::alloc_write_fifo(be_t<u32> context_id)

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -206,13 +206,13 @@ namespace rsx
 					}
 
 					// Memory partition check
-					if (mem_range.start >= 0xc0000000)
+					if (mem_range.start >= constants::local_mem_base)
 					{
-						if (e.first < 0xc0000000) continue;
+						if (e.first < constants::local_mem_base) continue;
 					}
 					else
 					{
-						if (e.first >= 0xc0000000) continue;
+						if (e.first >= constants::local_mem_base) continue;
 					}
 
 					// Pitch check

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -489,7 +489,6 @@ namespace rsx
 		// I hate this flag, but until hle is closer to lle, its needed
 		bool isHLE{ false };
 
-		u32 ioAddress, ioSize;
 		u32 flip_status;
 		int debug_level;
 
@@ -502,7 +501,7 @@ namespace rsx
 		u32 ctxt_addr;
 		u32 label_addr;
 
-		u32 local_mem_addr, main_mem_addr, main_mem_size{0};
+		u32 main_mem_size{0};
 
 		bool m_rtts_dirty;
 		bool m_textures_dirty[16];
@@ -750,16 +749,13 @@ namespace rsx
 
 	public:
 		void reset();
-		void init(u32 ioAddress, u32 ioSize, u32 ctrlAddress, u32 localAddress);
+		void init(u32 ctrlAddress);
 
 		tiled_region get_tiled_address(u32 offset, u32 location);
 		GcmTileInfo *find_tile(u32 offset, u32 location);
 
 		// Emu App/Game flip, only immediately flips when called from rsxthread
 		void request_emu_flip(u32 buffer);
-
-		u32 ReadIO32(u32 addr);
-		void WriteIO32(u32 addr, u32 value);
 
 		void pause();
 		void unpause();

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -124,10 +124,7 @@ namespace rsx
 				res &= -128;
 			}
 
-			if (addr >> 28 != 0x4)
-			{
-				vm::reservation_notifier(addr, 4).notify_all();
-			}
+			vm::reservation_notifier(addr, 4).notify_all();
 		}
 	}
 
@@ -1222,8 +1219,8 @@ namespace rsx
 			const auto read_address = get_address(src_offset, src_dma);
 			rsx->read_barrier(read_address, in_pitch * (line_count - 1) + line_length);
 
-			u8 *dst = (u8*)vm::base(get_address(dst_offset, dst_dma));
-			const u8 *src = (u8*)vm::base(read_address);
+			u8 *dst = vm::_ptr<u8>(get_address(dst_offset, dst_dma));
+			const u8 *src = vm::_ptr<u8>(read_address);
 
 			if (in_pitch == out_pitch && out_pitch == line_length)
 			{

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -96,6 +96,9 @@ namespace rsx
 		{
 			"vtex0", "vtex1", "vtex2", "vtex3",
 		};
+
+		// Local RSX memory base (known as constant)
+		static constexpr u32 local_mem_base = 0xC0000000;
 	}
 
 	/**

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -61,7 +61,7 @@ void breakpoint_list::AddBreakpoint(u32 pc)
 
 	const auto cpu = this->cpu.lock();
 	const u32 cpu_offset = cpu->id_type() != 1 ? static_cast<spu_thread&>(*cpu).offset : 0;
-	m_disasm->offset = (u8*)vm::base(cpu_offset);
+	m_disasm->offset = vm::_ptr<u8>(cpu_offset);
 
 	m_disasm->disasm(m_disasm->dump_pc = pc);
 

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -401,7 +401,7 @@ void Buffer::ShowWindowed()
 	// TODO: Is there any better way to choose the color buffers
 #define SHOW_BUFFER(id) \
 	{ \
-		u32 addr = render->local_mem_addr + buffers[id].offset; \
+		u32 addr = rsx::constants::local_mem_base + buffers[id].offset; \
 		if (vm::check_addr(addr) && buffers[id].width && buffers[id].height) \
 			memory_viewer_panel::ShowImage(this, addr, 3, buffers[id].width, buffers[id].height, true); \
 		return; \
@@ -690,7 +690,7 @@ void rsx_debugger::GetBuffers()
 	for (u32 bufferId=0; bufferId < render->display_buffers_count; bufferId++)
 	{
 		auto buffers = render->display_buffers;
-		u32 RSXbuffer_addr = render->local_mem_addr + buffers[bufferId].offset;
+		u32 RSXbuffer_addr = rsx::constants::local_mem_base + buffers[bufferId].offset;
 
 		if(!vm::check_addr(RSXbuffer_addr))
 			continue;


### PR DESCRIPTION
- Prefer `vm::ptr<>::ptr` over `vm::get_addr`.
- Prefer `vm::_ptr`/`base` over `vm::g_base_addr` with offset. 
- Added methods `atomic_t<>::bts` and `atomic_t<>::btr` .
- Removed obsolute `rsx::thread::Read`/`WriteIO32` methods.
- Removed wrong check in `semaphore_release`.
- Added handling for PUTRx commands for RawSPU MFC proxy.
- Prefer overloaded methods of v128 instead of `_mm_...` in VPKSHUS ppu interpreter precise.
- Fixed more potential overflows that may result in wrong behaviour.
- Added `io`/`size` alignment check for `sys_rsx_context_iounmap`.
- Added `rsx::constants::local_mem_base` which represents RSX local memory base address.
- Removed obsolute `rsx::thread::main_mem_addr`/`ioSize`/`ioAddress` members.

