### PR TITLE
Fixup after #6143

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -15,6 +15,8 @@
 #include "sysPrxForUser.h"
 #include "cellSpurs.h"
 
+#include <atomic>
+
 LOG_CHANNEL(cellSpurs);
 
 error_code sys_spu_image_close(vm::ptr<sys_spu_image> img);
@@ -2575,7 +2577,7 @@ s32 _cellSpursWorkloadFlagReceiver(vm::ptr<CellSpurs> spurs, u32 wid, u32 is_set
 		return CELL_SPURS_POLICY_MODULE_ERROR_STAT;
 	}
 
-	_mm_mfence();
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 
 	if (s32 res = spurs->wklFlag.flag.atomic_op([spurs, wid, is_set](be_t<u32>& flag) -> s32
 	{

--- a/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
@@ -8,6 +8,8 @@
 #include "Emu/Cell/lv2/sys_mutex.h"
 #include "sysPrxForUser.h"
 
+#include <atomic>
+
 extern logs::channel sysPrxForUser;
 
 error_code sys_lwmutex_create(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex, vm::ptr<sys_lwmutex_attribute_t> attr)
@@ -128,7 +130,7 @@ error_code sys_lwmutex_lock(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex, u64
 
 		// recursive locking succeeded
 		lwmutex->recursive_count++;
-		_mm_mfence();
+		std::atomic_thread_fence(std::memory_order_release);
 
 		return CELL_OK;
 	}
@@ -288,7 +290,7 @@ error_code sys_lwmutex_trylock(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex)
 
 		// recursive locking succeeded
 		lwmutex->recursive_count++;
-		_mm_mfence();
+		std::atomic_thread_fence(std::memory_order_release);
 
 		return CELL_OK;
 	}

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -8,6 +8,7 @@
 #include "Emu/Cell/Common.h"
 
 #include <cmath>
+#include <atomic>
 
 #if !defined(_MSC_VER) && !defined(__SSSE3__)
 #define _mm_shuffle_epi8(opa, opb) opb
@@ -2966,7 +2967,7 @@ bool ppu_interpreter::CRANDC(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::ISYNC(ppu_thread& ppu, ppu_opcode_t op)
 {
-	_mm_mfence();
+	std::atomic_thread_fence(std::memory_order_acquire);
 	return true;
 }
 
@@ -4046,7 +4047,7 @@ bool ppu_interpreter::LFSUX(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::SYNC(ppu_thread& ppu, ppu_opcode_t op)
 {
-	_mm_mfence();
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 	return true;
 }
 
@@ -4280,7 +4281,7 @@ bool ppu_interpreter::SRADI(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::EIEIO(ppu_thread& ppu, ppu_opcode_t op)
 {
-	_mm_mfence();
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1848,7 +1848,7 @@ void PPUTranslator::CRANDC(ppu_opcode_t op)
 
 void PPUTranslator::ISYNC(ppu_opcode_t op)
 {
-	m_ir->CreateFence(AtomicOrdering::SequentiallyConsistent);
+	m_ir->CreateFence(AtomicOrdering::Acquire);
 }
 
 void PPUTranslator::CRXOR(ppu_opcode_t op)
@@ -3105,7 +3105,9 @@ void PPUTranslator::LFSUX(ppu_opcode_t op)
 
 void PPUTranslator::SYNC(ppu_opcode_t op)
 {
-	m_ir->CreateFence(AtomicOrdering::SequentiallyConsistent);
+	// sync: Full seq cst barrier
+	// lwsync: Release barrier
+	m_ir->CreateFence(op.l10 ? AtomicOrdering::Release : AtomicOrdering::SequentiallyConsistent);
 }
 
 void PPUTranslator::LFDX(ppu_opcode_t op)

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -6,6 +6,8 @@
 
 #include "Emu/Cell/RawSPUThread.h"
 
+#include <atomic>
+
 // Originally, SPU MFC registers are accessed externally in a concurrent manner (don't mix with channels, SPU MFC channels are isolated)
 thread_local spu_mfc_cmd g_tls_mfc[8] = {};
 
@@ -173,7 +175,7 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 		case MFC_SYNC_CMD:
 		{
 			g_tls_mfc[index] = {};
-			_mm_mfence();
+			std::atomic_thread_fence(std::memory_order_seq_cst);
 			return true;
 		}
 		}

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -140,14 +140,14 @@ bool spu_interpreter::LNOP(spu_thread& spu, spu_opcode_t op)
 // This instruction must be used following a store instruction that modifies the instruction stream.
 bool spu_interpreter::SYNC(spu_thread& spu, spu_opcode_t op)
 {
-	_mm_mfence();
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 	return true;
 }
 
 // This instruction forces all earlier load, store, and channel instructions to complete before proceeding.
 bool spu_interpreter::DSYNC(spu_thread& spu, spu_opcode_t op)
 {
-	_mm_mfence();
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1662,7 +1662,7 @@ void spu_thread::do_mfc(bool wait)
 			if (&args - mfc_queue <= removed)
 			{
 				// Remove barrier-class command if it's the first in the queue
-				_mm_mfence();
+				std::atomic_thread_fence(std::memory_order_seq_cst);
 				removed++;
 				return true;
 			}
@@ -2086,7 +2086,7 @@ bool spu_thread::process_mfc_cmd()
 	{
 		if (mfc_size == 0)
 		{
-			_mm_mfence();
+			std::atomic_thread_fence(std::memory_order_seq_cst);
 		}
 		else
 		{
@@ -3025,12 +3025,13 @@ bool spu_thread::stop_and_signal(u32 code)
 
 	case 0x100:
 	{
+		// SPU thread group yield (TODO)
 		if (ch_out_mbox.get_count())
 		{
 			fmt::throw_exception("STOP code 0x100: Out_MBox is not empty" HERE);
 		}
 
-		_mm_mfence();
+		std::atomic_thread_fence(std::memory_order_seq_cst);
 		return true;
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -284,7 +284,7 @@ public:
 	// push unconditionally (overwriting latest value), returns true if needs signaling
 	void push(cpu_thread& spu, u32 value)
 	{
-		value3 = value; _mm_sfence();
+		value3.store(value);
 
 		if (values.atomic_op([=](sync_var_t& data) -> bool
 		{
@@ -325,7 +325,6 @@ public:
 
 				data.value0 = data.value1;
 				data.value1 = data.value2;
-				_mm_lfence();
 				data.value2 = this->value3;
 			}
 			else

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -750,7 +750,7 @@ namespace vm
 		const u32 size = ::align(orig_size, min_page_size);
 
 		// return if addr or size is invalid
-		if (!size || addr < this->addr || addr + u64{size} > this->addr + this->size || flags & 0x10)
+		if (!size || addr < this->addr || addr + u64{size} > this->addr + u64{this->size} || flags & 0x10)
 		{
 			return 0;
 		}
@@ -823,7 +823,7 @@ namespace vm
 
 	std::pair<u32, std::shared_ptr<utils::shm>> block_t::get(u32 addr, u32 size)
 	{
-		if (addr < this->addr || addr + u64{size} > this->addr + this->size)
+		if (addr < this->addr || addr + u64{size} > this->addr + u64{this->size})
 		{
 			return {addr, nullptr};
 		}
@@ -852,7 +852,7 @@ namespace vm
 		}
 
 		// Range check
-		if (std::max<u32>(size, addr - found->first + size) > found->second.second->size())
+		if (addr + u64{size} > found->first + u64{found->second.second->size()})
 		{
 			return {addr, nullptr};
 		}

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -8,6 +8,7 @@
 #include "Emu/RSX/GSRender.h"
 
 #include <map>
+#include <atomic>
 #include <exception>
 
 namespace rsx
@@ -179,7 +180,7 @@ namespace rsx
 		{
 			// Load registers while the RSX is still idle
 			method_registers = frame->reg_state;
-			_mm_mfence();
+			std::atomic_thread_fence(std::memory_order_seq_cst);
 
 			// start up fifo buffer by dumping the put ptr to first stop
 			sys_rsx_context_attribute(context_id, 0x001, 0x10000000, fifo_stops[0], 0, 0);

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2279,8 +2279,8 @@ namespace rsx
 			image_resource_type vram_texture = 0;
 			image_resource_type dest_texture = 0;
 
-			const u32 dst_address = (u32)((u64)dst.pixels - (u64)vm::base(0));
-			u32 src_address = (u32)((u64)src.pixels - (u64)vm::base(0));
+			const u32 dst_address = vm::get_addr(dst.pixels);
+			u32 src_address = vm::get_addr(src.pixels);
 
 			const f32 scale_x = fabsf(dst.scale_x);
 			const f32 scale_y = fabsf(dst.scale_y);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -46,7 +46,6 @@ struct work_item
 	{
 		while (!processed)
 		{
-			_mm_lfence();
 			std::this_thread::yield();
 		}
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -491,7 +491,7 @@ void GLGSRender::read_buffers()
 					continue;
 
 				rsx::tiled_region color_buffer = get_tiled_address(offset, location & 0xf);
-				u32 texaddr = (u32)((u64)color_buffer.ptr - (u64)vm::base(0));
+				u32 texaddr = vm::get_addr(color_buffer.ptr);
 
 				const utils::address_range range = utils::address_range::start_length(texaddr, pitch * height);
 				bool success = m_gl_texture_cache.load_memory_from_cache(range, std::get<1>(m_rtts.m_bound_render_targets[i]));

--- a/rpcs3/Emu/RSX/RSXOffload.cpp
+++ b/rpcs3/Emu/RSX/RSXOffload.cpp
@@ -123,7 +123,7 @@ namespace rsx
 		}
 
 		while (m_enqueued_count.load() != m_processed_count)
-			_mm_lfence();
+			_mm_pause();
 	}
 
 	void dma_manager::join()

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -275,7 +275,6 @@ struct flush_request_task
 	{
 		while (num_waiters.load() != 0)
 		{
-			_mm_lfence();
 			_mm_pause();
 		}
 	}
@@ -284,7 +283,6 @@ struct flush_request_task
 	{
 		while (pending_state.load())
 		{
-			_mm_lfence();
 			std::this_thread::yield();
 		}
 	}


### PR DESCRIPTION
* vm::spu max address was overflowing resulting in issues, so cast to u64 where needed. Fixes #6145.
* Use `vm::get_addr` instead of manually substructing `vm::base(0)` from pointer in texture cache code.
* Prefer `std::atomic_thread_fence` over `_mm_?fence()`, adjust usage to be more correct.
* Used sequantially consistent ordering in `semaphore_release` for TSX path as well.
* Improved memory ordering for `sys_rsx_context_iounmap`/`map`.
* Fixed sync bugs in HLE gcm because of not using atomic instructions.
* Use release memory barrier in `lwsync` for PPU LLVM, according to [this](https://docs.microsoft.com/he-il/windows/desktop/DxTechArts/lockless-programming) xbox360 programming guide `lwsync` is a hw release memory barrier.
Also use release barrier where lwsync was originally used in liblv2 sys_lwmutex and cellSync.
* Use acquire barrier for `isync` instruction, see https://devblogs.microsoft.com/oldnewthing/20180814-00/?p=99485 