### PR TITLE
gl: Workaround slow PBO usage with Mesa

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -723,11 +723,16 @@ namespace gl
 		GLsizeiptr src_mem = src->width() * src->height();
 		GLsizeiptr dst_mem = dst->width() * dst->height();
 
+		GLenum buffer_copy_flag = GL_STATIC_COPY;
+		if (gl::get_driver_caps().vendor_MESA) buffer_copy_flag = GL_STREAM_COPY;
+		// NOTE: Mesa lacks acceleration for PBO unpacking and is currently fastest with GL_STREAM_COPY
+		// See https://bugs.freedesktop.org/show_bug.cgi?id=111043
+
 		auto max_mem = std::max(src_mem, dst_mem) * 16;
 		if (!g_typeless_transfer_buffer || max_mem > g_typeless_transfer_buffer.size())
 		{
 			if (g_typeless_transfer_buffer) g_typeless_transfer_buffer.remove();
-			g_typeless_transfer_buffer.create(buffer::target::pixel_pack, max_mem, nullptr, GL_STATIC_COPY);
+			g_typeless_transfer_buffer.create(buffer::target::pixel_pack, max_mem, nullptr, buffer_copy_flag);
 		}
 
 		auto format_type = get_format_type(src->get_internal_format());


### PR DESCRIPTION
This is a partial workaround for slow PBO performance with mesa. In Mesa PBO unpacking is currently done on the CPU which makes GL_STATIC_COPY painfully slow, even though our usage is best suited for GL_STATIC_COPY. Instead we will use GL_STREAM_COPY for Mesa which performs somewhat better, but it's still not ideal. To get full performance we will need a fix to come from Mesa. 

See:
https://gitlab.freedesktop.org/mesa/mesa/commit/a338dc01866ce50bf7555ee8dc08491c7f63b585
https://gitlab.freedesktop.org/mesa/mesa/blob/master/src/mesa/state_tracker/st_cb_bufferobjects.c#L250

<details>
<summary> NGS2 Comparison </summary>

### MASTER
![NGS2slow](https://user-images.githubusercontent.com/26352541/60389387-4aa6f500-9a8e-11e9-8f31-3c2320a9e6c9.png)

### PR
![NGS2fast2](https://user-images.githubusercontent.com/26352541/60389388-4bd82200-9a8e-11e9-82e4-23425cd18198.png)
</details>

While this game has gone from 20 up to 60 fps, other games require a driver fix to get anything close to playable. Ninja gaiden 3 has a scene which has improved from 1 fps up to 11 fps, but we can't get any better without a driver fix. 