### PR TITLE
rsx: Improve object reuse and lifetime management

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -796,3 +796,17 @@ size_t get_texture_size(const rsx::vertex_texture &texture)
 	return get_texture_size(texture.format(), texture.width(), texture.height(), texture.depth(),
 		texture.pitch(), texture.get_exact_mipmap_count(), texture.cubemap() ? 6 : 1);
 }
+
+u32 get_remap_encoding(const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap)
+{
+	u32 encode = 0;
+	encode |= (remap.first[0] << 0);
+	encode |= (remap.first[1] << 2);
+	encode |= (remap.first[2] << 4);
+	encode |= (remap.first[3] << 6);
+	encode |= (remap.second[0] << 8);
+	encode |= (remap.second[1] << 10);
+	encode |= (remap.second[2] << 12);
+	encode |= (remap.second[3] << 14);
+	return encode;
+}

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -139,3 +139,8 @@ size_t get_texture_size(const rsx::vertex_texture &texture);
 * Get packed pitch
 */
 u32 get_format_packed_pitch(u32 format, u16 width);
+
+/**
+* Reverse encoding
+*/
+u32 get_remap_encoding(const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap);

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "../rsx_cache.h"
 #include "texture_cache_predictor.h"
@@ -1114,6 +1114,9 @@ namespace rsx
 			invalidate_range();
 		}
 
+		virtual void dma_abort()
+		{}
+
 	public:
 		/**
 		 * Dirty/Unreleased Flag
@@ -1276,6 +1279,12 @@ namespace rsx
 
 		void reprotect(const utils::protection prot)
 		{
+			if (synchronized && !flushed)
+			{
+				// Abort enqueued transfer
+				dma_abort();
+			}
+
 			//Reset properties and protect again
 			flushed = false;
 			synchronized = false;
@@ -1286,6 +1295,12 @@ namespace rsx
 
 		void reprotect(const utils::protection prot, const std::pair<u32, u32>& range)
 		{
+			if (synchronized && !flushed)
+			{
+				// Abort enqueued transfer
+				dma_abort();
+			}
+
 			//Reset properties and protect again
 			flushed = false;
 			synchronized = false;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -72,7 +72,7 @@ struct command_buffer_chunk: public vk::command_buffer
 	VkDevice m_device = VK_NULL_HANDLE;
 
 	std::atomic_bool pending = { false };
-	std::atomic<u64> last_sync = { 0 };
+	u64 eid_tag = 0;
 	shared_mutex guard_mutex;
 
 	command_buffer_chunk() = default;
@@ -96,7 +96,7 @@ struct command_buffer_chunk: public vk::command_buffer
 
 	void tag()
 	{
-		last_sync = get_system_time();
+		eid_tag = vk::get_event_id();
 	}
 
 	void reset()
@@ -123,8 +123,11 @@ struct command_buffer_chunk: public vk::command_buffer
 
 			if (pending)
 			{
-				pending = false;
 				vk::reset_fence(&submit_fence);
+				vk::on_event_completed(eid_tag);
+
+				pending = false;
+				eid_tag = 0;
 			}
 		}
 
@@ -145,7 +148,10 @@ struct command_buffer_chunk: public vk::command_buffer
 		if (pending)
 		{
 			vk::reset_fence(&submit_fence);
+			vk::on_event_completed(eid_tag);
+
 			pending = false;
+			eid_tag = 0;
 		}
 
 		return ret;
@@ -288,66 +294,6 @@ struct flush_request_task
 	}
 };
 
-// TODO: This class will be expanded into a global allocator/collector eventually
-class resource_manager
-{
-private:
-	std::unordered_multimap<u64, std::unique_ptr<vk::sampler>> m_sampler_pool;
-
-	bool value_compare(const f32& a, const f32& b)
-	{
-		return fabsf(a - b) < 0.0000001f;
-	}
-
-public:
-
-	resource_manager() = default;
-	~resource_manager() = default;
-
-	void destroy()
-	{
-		m_sampler_pool.clear();
-	}
-
-	vk::sampler* find_sampler(VkDevice dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
-		VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
-		VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
-		VkBool32 depth_compare = VK_FALSE, VkCompareOp depth_compare_mode = VK_COMPARE_OP_NEVER)
-	{
-		u64 key = u16(clamp_u) | u64(clamp_v) << 3 | u64(clamp_w) << 6;
-		key |= u64(unnormalized_coordinates) << 9; // 1 bit
-		key |= u64(min_filter) << 10 | u64(mag_filter) << 11; // 1 bit each
-		key |= u64(mipmap_mode) << 12; // 1 bit
-		key |= u64(border_color) << 13; // 3 bits
-		key |= u64(depth_compare) << 16; // 1 bit
-		key |= u64(depth_compare_mode) << 17; // 3 bits
-
-		const auto found = m_sampler_pool.equal_range(key);
-		for (auto It = found.first; It != found.second; ++It)
-		{
-			const auto& info = It->second->info;
-			if (!value_compare(info.mipLodBias, mipLodBias) ||
-				!value_compare(info.maxAnisotropy, max_anisotropy) ||
-				!value_compare(info.minLod, min_lod) ||
-				!value_compare(info.maxLod, max_lod))
-			{
-				continue;
-			}
-
-			return It->second.get();
-		}
-
-		auto result = std::make_unique<vk::sampler>(
-			dev, clamp_u, clamp_v, clamp_w, unnormalized_coordinates,
-			mipLodBias, max_anisotropy, min_lod, max_lod,
-			min_filter, mag_filter, mipmap_mode, border_color,
-			depth_compare, depth_compare_mode);
-
-		auto It = m_sampler_pool.emplace(key, std::move(result));
-		return It->second.get();
-	}
-};
-
 class VKGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 {
 private:
@@ -378,8 +324,6 @@ private:
 	std::unique_ptr<vk::buffer_view> m_persistent_attribute_storage;
 	std::unique_ptr<vk::buffer_view> m_volatile_attribute_storage;
 	std::unique_ptr<vk::buffer_view> m_vertex_layout_storage;
-
-	resource_manager m_resource_manager;
 
 public:
 	//vk::fbo draw_fbo;
@@ -458,8 +402,6 @@ private:
 
 	shared_mutex m_flush_queue_mutex;
 	flush_request_task m_flush_requests;
-
-	std::atomic<u64> m_last_sync_event = { 0 };
 
 	bool m_render_pass_open = false;
 	u64  m_current_renderpass_key = 0;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -471,6 +471,9 @@ public:
 	void get_occlusion_query_result(rsx::reports::occlusion_query_info* query) override;
 	void discard_occlusion_query(rsx::reports::occlusion_query_info* query) override;
 
+	// External callback in case we need to suddenly submit a commandlist unexpectedly, e.g in a violation handler
+	void emergency_query_cleanup(vk::command_buffer* commands);
+
 protected:
 	void begin() override;
 	void end() override;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -1,5 +1,6 @@
 ﻿#include "stdafx.h"
 #include "VKHelpers.h"
+#include "VKGSRender.h"
 #include "VKCompute.h"
 #include "VKRenderPass.h"
 #include "VKFramebuffer.h"
@@ -769,6 +770,14 @@ namespace vk
 			//std::this_thread::yield();
 			_mm_pause();
 		}
+	}
+
+	void do_query_cleanup(vk::command_buffer& cmd)
+	{
+		auto renderer = dynamic_cast<VKGSRender*>(rsx::get_current_renderer());
+		verify(HERE), renderer;
+
+		renderer->emergency_query_cleanup(&cmd);
 	}
 
 	void die_with_error(const char* faulting_addr, VkResult error_code)

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -4,6 +4,7 @@
 #include "VKRenderPass.h"
 #include "VKFramebuffer.h"
 #include "VKResolveHelper.h"
+#include "VKResourceManager.h"
 #include "Utilities/mutex.h"
 
 namespace vk
@@ -247,6 +248,7 @@ namespace vk
 		vk::clear_renderpass_cache(dev);
 		vk::clear_framebuffer_cache();
 		vk::clear_resolve_helpers();
+		vk::get_resource_manager()->destroy();
 
 		g_null_texture.reset();
 		g_null_image_view.reset();

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1298,11 +1298,19 @@ private:
 				}
 			}
 
-			VkComponentMapping real_mapping = vk::apply_swizzle_remap
-			(
-				{native_component_map.a, native_component_map.r, native_component_map.g, native_component_map.b },
-				remap
-			);
+			VkComponentMapping real_mapping;
+			if (remap_encoding == 0xAAE4)
+			{
+				real_mapping = native_component_map;
+			}
+			else
+			{
+				real_mapping = vk::apply_swizzle_remap
+				(
+					{ native_component_map.a, native_component_map.r, native_component_map.g, native_component_map.b },
+					remap
+				);
+			}
 
 			const auto range = vk::get_image_subresource_range(0, 0, info.arrayLayers, info.mipLevels, aspect() & mask);
 

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -138,7 +138,7 @@ namespace vk
 			return fs_inputs;
 		}
 
-		virtual void get_dynamic_state_entries(VkDynamicState* state_descriptors, VkPipelineDynamicStateCreateInfo& info)
+		virtual void get_dynamic_state_entries(VkDynamicState* /*state_descriptors*/, VkPipelineDynamicStateCreateInfo& /*info*/)
 		{}
 
 		virtual std::vector<VkPushConstantRange> get_push_constants()

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -1,0 +1,29 @@
+#include "stdafx.h"
+#include "VKResourceManager.h"
+
+namespace vk
+{
+	resource_manager g_resource_manager;
+	atomic_t<u64> g_event_ctr;
+
+	resource_manager* get_resource_manager()
+	{
+		return &g_resource_manager;
+	}
+
+	u64 get_event_id()
+	{
+		return g_event_ctr++;
+	}
+
+	u64 current_event_id()
+	{
+		return g_event_ctr.load();
+	}
+
+	void on_event_completed(u64 event_id)
+	{
+		// TODO: Offload this to a secondary thread
+		g_resource_manager.eid_completed(event_id);
+	}
+}

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -1,0 +1,129 @@
+#pragma once
+#include "VKHelpers.h"
+
+namespace vk
+{
+	u64 get_event_id();
+	u64 current_event_id();
+	void on_event_completed(u64 event_id);
+
+	class resource_manager
+	{
+	private:
+		std::unordered_multimap<u64, std::unique_ptr<vk::sampler>> m_sampler_pool;
+		std::unordered_map<u64, std::vector<std::unique_ptr<vk::buffer>>> m_buffers_pool;
+		std::unordered_map<u64, rsx::simple_array<VkEvent>> m_events_pool;
+
+		bool value_compare(const f32& a, const f32& b)
+		{
+			return fabsf(a - b) < 0.0000001f;
+		}
+
+	public:
+
+		resource_manager() = default;
+		~resource_manager() = default;
+
+		void destroy()
+		{
+			auto& dev = *vk::get_current_renderer();
+
+			for (auto &e : m_events_pool)
+			{
+				for (auto &ev : e.second)
+				{
+					vkDestroyEvent(dev, ev, nullptr);
+				}
+			}
+
+			m_sampler_pool.clear();
+			m_buffers_pool.clear();
+			m_events_pool.clear();
+		}
+
+		vk::sampler* find_sampler(VkDevice dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
+			VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
+			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
+			VkBool32 depth_compare = VK_FALSE, VkCompareOp depth_compare_mode = VK_COMPARE_OP_NEVER)
+		{
+			u64 key = u16(clamp_u) | u64(clamp_v) << 3 | u64(clamp_w) << 6;
+			key |= u64(unnormalized_coordinates) << 9; // 1 bit
+			key |= u64(min_filter) << 10 | u64(mag_filter) << 11; // 1 bit each
+			key |= u64(mipmap_mode) << 12; // 1 bit
+			key |= u64(border_color) << 13; // 3 bits
+			key |= u64(depth_compare) << 16; // 1 bit
+			key |= u64(depth_compare_mode) << 17; // 3 bits
+
+			const auto found = m_sampler_pool.equal_range(key);
+			for (auto It = found.first; It != found.second; ++It)
+			{
+				const auto& info = It->second->info;
+				if (!value_compare(info.mipLodBias, mipLodBias) ||
+					!value_compare(info.maxAnisotropy, max_anisotropy) ||
+					!value_compare(info.minLod, min_lod) ||
+					!value_compare(info.maxLod, max_lod))
+				{
+					continue;
+				}
+
+				return It->second.get();
+			}
+
+			auto result = std::make_unique<vk::sampler>(
+				dev, clamp_u, clamp_v, clamp_w, unnormalized_coordinates,
+				mipLodBias, max_anisotropy, min_lod, max_lod,
+				min_filter, mag_filter, mipmap_mode, border_color,
+				depth_compare, depth_compare_mode);
+
+			auto It = m_sampler_pool.emplace(key, std::move(result));
+			return It->second.get();
+		}
+
+		void dispose(std::unique_ptr<vk::buffer>& buf)
+		{
+			m_buffers_pool[current_event_id()].emplace_back(std::move(buf));
+		}
+
+		void dispose(VkEvent& event)
+		{
+			m_events_pool[current_event_id()].push_back(event);
+			event = VK_NULL_HANDLE;
+		}
+
+		void eid_completed(u64 eid)
+		{
+			auto& dev = *vk::get_current_renderer();
+
+			for (auto It = m_buffers_pool.begin(); It != m_buffers_pool.end();)
+			{
+				if (It->first <= eid)
+				{
+					It = m_buffers_pool.erase(It);
+				}
+				else
+				{
+					++It;
+				}
+			}
+
+			for (auto It = m_events_pool.begin(); It != m_events_pool.end();)
+			{
+				if (It->first <= eid)
+				{
+					for (auto &ev : It->second)
+					{
+						vkDestroyEvent(dev, ev, nullptr);
+					}
+
+					It = m_events_pool.erase(It);
+				}
+				else
+				{
+					++It;
+				}
+			}
+		}
+	};
+
+	resource_manager* get_resource_manager();
+}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -96,6 +96,14 @@ namespace vk
 			}
 		}
 
+		void dma_abort() override
+		{
+			// Called if a reset occurs, usually via reprotect path after a bad prediction.
+			// Discard the sync event, the next sync, if any, will properly recreate this.
+			verify(HERE), synchronized, !flushed, dma_fence;
+			vk::get_resource_manager()->dispose(dma_fence);
+		}
+
 		void destroy()
 		{
 			if (!exists())

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -35,6 +35,7 @@
     <ClInclude Include="Emu\RSX\VK\VKRenderPass.h" />
     <ClInclude Include="Emu\RSX\VK\VKRenderTargets.h" />
     <ClInclude Include="Emu\RSX\VK\VKResolveHelper.h" />
+    <ClInclude Include="Emu\RSX\VK\VKResourceManager.h" />
     <ClInclude Include="Emu\RSX\VK\VKTextOut.h" />
     <ClInclude Include="Emu\RSX\VK\VKTextureCache.h" />
     <ClInclude Include="Emu\RSX\VK\VKVertexProgram.h" />
@@ -50,6 +51,7 @@
     <ClCompile Include="Emu\RSX\VK\VKProgramPipeline.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKRenderPass.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKResolveHelper.cpp" />
+    <ClCompile Include="Emu\RSX\VK\VKResourceManager.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKTexture.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKVertexBuffers.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKVertexProgram.cpp" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClInclude Include="Emu\RSX\VK\VKResolveHelper.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\VKResourceManager.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
     <ClInclude Include="Emu\RSX\VK\VKFramebuffer.h">
       <Filter>Source Files</Filter>
     </ClInclude>
@@ -94,6 +97,9 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClCompile Include="Emu\RSX\VK\VKResolveHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\RSX\VK\VKResourceManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Emu\RSX\VK\VKFramebuffer.cpp">


### PR DESCRIPTION
- Fixes some old issues with resource management in violation handlers and the texture cache. Freeing buffers and event handles still queued for processing would cause drivers to re-issue them and cause strange results such as premature signaling and deadlocks due to use-after-free situations in the driver.
- Handle dangling queries when doing an emergency commandlist close/submit. See https://github.com/RPCS3/rpcs3/issues/6135.
- Minor optimization by reusing temporary objects in the discard pile instead of allocating new ones. Should help lower memory utilization and may improve performance since allocations are quite expensive. The nature of identical frame-to-frame operation in games means that it is almost never required to invoke allocations unless the scene suddenly changes.

Fixes https://github.com/RPCS3/rpcs3/issues/6135