### PR TITLE
rsx: Fixups

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <exception>
 #include <string>
@@ -1443,6 +1443,7 @@ namespace gl
 			rgba8 = GL_RGBA8,
 			r5g6b5 = GL_RGB565,
 			r8 = GL_R8,
+			r16 = GL_R16,
 			r32f = GL_R32F,
 			rg8 = GL_RG8,
 			rg16 = GL_RG16,

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -100,6 +100,8 @@ namespace gl
 			return std::make_tuple(GL_RGBA, GL_UNSIGNED_BYTE, false);
 		case texture::internal_format::r8:
 			return std::make_tuple(GL_RED, GL_UNSIGNED_BYTE, false);
+		case texture::internal_format::r16:
+			return std::make_tuple(GL_RED, GL_UNSIGNED_SHORT, true);
 		case texture::internal_format::r32f:
 			return std::make_tuple(GL_RED, GL_FLOAT, true);
 		case texture::internal_format::r5g6b5:

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1363,7 +1363,12 @@ namespace rsx
 				}
 			}
 
-			result.interleaved_blocks.emplace_back(std::move(info));
+			if (info.attribute_stride)
+			{
+				// At least one array feed must be enabled for vertex input
+				result.interleaved_blocks.emplace_back(std::move(info));
+			}
+
 			return;
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -3167,9 +3167,6 @@ void VKGSRender::flip(int buffer, bool emu_flip)
 
 	if (skip_frame || swapchain_unavailable)
 	{
-		m_frame->flip(m_context);
-		rsx::thread::flip(buffer, emu_flip);
-
 		if (!skip_frame)
 		{
 			verify(HERE), swapchain_unavailable;
@@ -3186,6 +3183,8 @@ void VKGSRender::flip(int buffer, bool emu_flip)
 			m_textures_upload_time = 0;
 		}
 
+		m_frame->flip(m_context);
+		rsx::thread::flip(buffer, emu_flip);
 		return;
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -309,21 +309,8 @@ namespace vk
 		switch (g_driver_vendor = g_current_renderer->gpu().get_driver_vendor())
 		{
 		case driver_vendor::AMD:
-			// Radeon proprietary driver does not properly handle fence reset and can segfault during vkResetFences
-			// Disable fence reset for proprietary driver and delete+initialize a new fence instead
-			g_drv_disable_fence_reset = true;
-			// Fall through
 		case driver_vendor::RADV:
-			// Radeon fails to properly handle degenerate primitives if primitive restart is enabled
-			// One has to choose between using degenerate primitives or primitive restart to break up lists but not both
-			// Polaris and newer will crash with ERROR_DEVICE_LOST
-			// Older GCN will work okay most of the time but also occasionally draws garbage without reason (proprietary driver only)
-			if (g_driver_vendor == driver_vendor::AMD ||
-				gpu_name.find("VEGA") != std::string::npos ||
-				gpu_name.find("POLARIS") != std::string::npos)
-			{
-				g_drv_no_primitive_restart_flag = !g_cfg.video.vk.force_primitive_restart;
-			}
+			// Previous bugs with fence reset and primitive restart seem to have been fixed with newer drivers
 			break;
 		case driver_vendor::NVIDIA:
 			// Nvidia cards are easily susceptible to NaN poisoning

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -541,6 +541,14 @@ private:
 				// See https://bugs.freedesktop.org/show_bug.cgi?id=110970
 				LOG_FATAL(RSX, "RADV drivers have a major driver bug with LLVM 8 resulting in no visual output. Upgrade to LLVM 9 version of mesa to avoid this issue.");
 			}
+
+#ifndef _WIN32
+			if (get_name().find("VEGA"))
+			{
+				LOG_WARNING(RSX, "float16_t does not work correctly on VEGA hardware for both RADV and AMDVLK. Using float32_t fallback instead.");
+				shader_types_support.allow_float16 = false;
+			}
+#endif
 		}
 
 		std::string get_name() const

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -226,7 +226,7 @@ namespace vk
 				VkImageSubresourceRange range{ surface->aspect(), 0, 1, 0, 1 };
 				if (surface->aspect() & VK_IMAGE_ASPECT_COLOR_BIT)
 				{
-					VkClearColorValue color{};
+					VkClearColorValue color = { 0.f, 0.f, 0.f, 1.f };
 					vkCmdClearColorImage(cmd, surface->value, surface->current_layout, &color, 1, &range);
 				}
 				else

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -809,6 +809,14 @@ namespace vk
 					size, size, 1, 1, 6, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 					VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT);
 			}
+			else if (auto src = sections_to_copy[0].src; src && src->format() == dst_format)
+			{
+				image->set_native_component_layout(src->native_component_map);
+			}
+			else
+			{
+				image->set_native_component_layout({ VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A });
+			}
 
 			auto view = image->get_view(0xAAE4, rsx::default_remap_vector);
 
@@ -852,6 +860,14 @@ namespace vk
 					dst_format,
 					width, height, depth, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 					VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0);
+			}
+			else if (auto src = sections_to_copy[0].src; src && src->format() == dst_format)
+			{
+				image->set_native_component_layout(src->native_component_map);
+			}
+			else
+			{
+				image->set_native_component_layout({ VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A });
 			}
 
 			auto view = image->get_view(0xAAE4, rsx::default_remap_vector);

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1128,6 +1128,7 @@ namespace rsx
 					}
 
 					pixels_src = temp3.get();
+					in_pitch = out_pitch;
 				}
 
 				// It looks like rsx may ignore the requested swizzle size and just always
@@ -1146,10 +1147,8 @@ namespace rsx
 				u32 sw_width = next_pow2(out_w);
 				u32 sw_height = next_pow2(out_h);
 
-				temp3.reset(new u8[out_bpp * sw_width * sw_height]);
-
 				u8* linear_pixels = pixels_src;
-				u8* swizzled_pixels = temp3.get();
+				u8* swizzled_pixels = pixels_dst;
 
 				// Check and pad texture out if we are given non power of 2 output
 				if (sw_width != out_w || sw_height != out_h)
@@ -1184,8 +1183,6 @@ namespace rsx
 					convert_linear_swizzle<u32>(linear_pixels, swizzled_pixels, sw_width, sw_height, in_pitch, false);
 					break;
 				}
-
-				std::memcpy(pixels_dst, swizzled_pixels, out_bpp * sw_width * sw_height);
 			}
 		}
 	}


### PR DESCRIPTION
Collection of fixups for miscellaneous bugs
- Fix vulkan frameskip
- Fix image_in functionality to avoid use-after-free
- Mark empty inline draws as such to avoid a divide-by-zero later
- Fix unsupported GL format error in GLTexture.cpp
- Fix GT6 regression
- AMD hw tweaks for driver compatibility

Fixes https://github.com/RPCS3/rpcs3/issues/5743
Fixes https://github.com/RPCS3/rpcs3/issues/6114
Fixes https://github.com/RPCS3/rpcs3/issues/5926
Fixes https://github.com/RPCS3/rpcs3/issues/5984
Fixes https://github.com/RPCS3/rpcs3/issues/6150