### PR TITLE
Log last PPU HLE function executed after access violation

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1408,7 +1408,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 			return true;
 		}
 
-		if (cpu->id_type() == 2)
+		if (cpu->id_type() != 1)
 		{
 			LOG_FATAL(MEMORY, "Access violation %s location 0x%x", is_writing ? "writing" : "reading", addr);
 
@@ -1436,12 +1436,17 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 		}
 		else
 		{
+			if (auto last_func = static_cast<ppu_thread*>(cpu)->current_function)
+			{
+				LOG_FATAL(PPU, "Function aborted: %s", last_func);
+			}
+
 			lv2_obj::sleep(*cpu);
 		}
 	}
 
-	LOG_FATAL(MEMORY, "Access violation %s location 0x%x", is_writing ? "writing" : "reading", addr);
 	Emu.Pause();
+	LOG_FATAL(MEMORY, "Access violation %s location 0x%x", is_writing ? "writing" : "reading", addr);
 
 	while (Emu.IsPaused())
 	{

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1410,6 +1410,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 
 		if (cpu->id_type() != 1)
 		{
+			LOG_NOTICE(GENERAL, "\n%s", cpu->dump());
 			LOG_FATAL(MEMORY, "Access violation %s location 0x%x", is_writing ? "writing" : "reading", addr);
 
 			// TODO:
@@ -1446,6 +1447,12 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 	}
 
 	Emu.Pause();
+
+	if (cpu)
+	{
+		LOG_NOTICE(GENERAL, "\n%s", cpu->dump());
+	}
+
 	LOG_FATAL(MEMORY, "Access violation %s location 0x%x", is_writing ? "writing" : "reading", addr);
 
 	while (Emu.IsPaused())

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -153,9 +153,9 @@ void cpu_thread::operator()()
 			}
 			catch (const std::exception& e)
 			{
+				Emu.Pause();
 				LOG_FATAL(GENERAL, "%s thrown: %s", typeid(e).name(), e.what());
 				LOG_NOTICE(GENERAL, "\n%s", dump());
-				Emu.Pause();
 				break;
 			}
 

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -62,13 +62,13 @@ public:
 	}
 
 	// Test stopped state
-	bool is_stopped()
+	bool is_stopped() const
 	{
 		return !!(state & (cpu_flag::stop + cpu_flag::exit + cpu_flag::jit_return + cpu_flag::dbg_global_stop));
 	}
 
 	// Test paused state
-	bool is_paused()
+	bool is_paused() const
 	{
 		return !!(state & (cpu_flag::suspend + cpu_flag::dbg_global_pause + cpu_flag::dbg_pause));
 	}

--- a/rpcs3/Emu/Cell/PPUFunction.h
+++ b/rpcs3/Emu/Cell/PPUFunction.h
@@ -6,10 +6,11 @@ using ppu_function_t = bool(*)(ppu_thread&);
 
 // BIND_FUNC macro "converts" any appropriate HLE function to ppu_function_t, binding it to PPU thread context.
 #define BIND_FUNC(func, ...) (static_cast<ppu_function_t>([](ppu_thread& ppu) -> bool {\
-	const auto old_f = ppu.last_function;\
-	ppu.last_function = #func;\
+	const auto old_f = ppu.current_function;\
+	if (!old_f) ppu.last_function = #func;\
+	ppu.current_function = #func;\
 	ppu_func_detail::do_call(ppu, func);\
-	ppu.last_function = old_f;\
+	ppu.current_function = old_f;\
 	ppu.cia += 4;\
 	__VA_ARGS__;\
 	return false;\

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -180,7 +180,8 @@ public:
 	cmd64 cmd_get(u32 index) { return cmd_queue[cmd_queue.peek() + index].load(); }
 
 	u64 start_time{0}; // Sleep start timepoint
-	const char* last_function{}; // Last function name for diagnosis, optimized for speed.
+	const char* current_function{}; // Current function name for diagnosis, optimized for speed.
+	const char* last_function{}; // Sticky copy of current_function, is not cleared on function return
 
 	lf_value<std::string> ppu_name; // Thread name
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1744,9 +1744,9 @@ s32 error_code::error_report(const fmt_type_info* sup, u64 arg, const fmt_type_i
 		{
 			auto& ppu = static_cast<ppu_thread&>(*thread);
 
-			if (ppu.last_function)
+			if (ppu.current_function)
 			{
-				func = ppu.last_function;
+				func = ppu.current_function;
 			}
 		}
 	}


### PR DESCRIPTION
* Also fix MFC tag status report for explicit mfc barriers commands, affects only status report because it is already blocking all tags.
* Improve memory ordering of `cpu_init()` a little.