### PR TITLE
Fixed behaviour of some UI buttons

### DIFF
--- a/rpcs3/rpcs3qt/find_dialog.cpp
+++ b/rpcs3/rpcs3qt/find_dialog.cpp
@@ -33,10 +33,10 @@ find_dialog::find_dialog(QTextEdit* edit, QWidget *parent, Qt::WindowFlags f) : 
 	layout->addLayout(button_layout);
 	setLayout(layout);
 
-	connect(m_find_first, &QPushButton::pressed, this, &find_dialog::find_first);
-	connect(m_find_last, &QPushButton::pressed, this, &find_dialog::find_last);
-	connect(m_find_next, &QPushButton::pressed, this, &find_dialog::find_next);
-	connect(m_find_previous, &QPushButton::pressed, this, &find_dialog::find_previous);
+	connect(m_find_first, &QPushButton::clicked, this, &find_dialog::find_first);
+	connect(m_find_last, &QPushButton::clicked, this, &find_dialog::find_last);
+	connect(m_find_next, &QPushButton::clicked, this, &find_dialog::find_next);
+	connect(m_find_previous, &QPushButton::clicked, this, &find_dialog::find_previous);
 
 	show();
 }

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
@@ -65,7 +65,7 @@ instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, c
 	setModal(true);
 
 	// Events
-	connect(button_ok, &QAbstractButton::pressed, [=]()
+	connect(button_ok, &QAbstractButton::clicked, [=]()
 	{
 		bool ok;
 		ulong opcode = m_instr->text().toULong(&ok, 16);
@@ -89,7 +89,7 @@ instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, c
 
 		accept();
 	});
-	connect(button_cancel, &QAbstractButton::pressed, this, &instruction_editor_dialog::reject);
+	connect(button_cancel, &QAbstractButton::clicked, this, &instruction_editor_dialog::reject);
 	connect(m_instr, &QLineEdit::textChanged, this, &instruction_editor_dialog::updatePreview);
 
 	updatePreview();

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -73,8 +73,8 @@ register_editor_dialog::register_editor_dialog(QWidget *parent, u32 _pc, const s
 	setModal(true);
 
 	// Events
-	connect(button_ok, &QAbstractButton::pressed, this, [=](){OnOkay(_cpu); accept();});
-	connect(button_cancel, &QAbstractButton::pressed, this, &register_editor_dialog::reject);
+	connect(button_ok, &QAbstractButton::clicked, this, [=](){OnOkay(_cpu); accept();});
+	connect(button_cancel, &QAbstractButton::clicked, this, &register_editor_dialog::reject);
 	connect(m_register_combo, &QComboBox::currentTextChanged, this, &register_editor_dialog::updateRegister);
 
 	updateRegister(m_register_combo->currentText());

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -249,7 +249,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 				ppuBG->button(i)->setChecked(true);
 			}
 
-			connect(ppuBG->button(i), &QAbstractButton::pressed, [=]()
+			connect(ppuBG->button(i), &QAbstractButton::clicked, [=]()
 			{
 				xemu_settings->SetSetting(emu_settings::PPUDecoder, sstr(ppu_list[i]));
 			});
@@ -279,7 +279,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 				spuBG->button(i)->setChecked(true);
 			}
 
-			connect(spuBG->button(i), &QAbstractButton::pressed, [=]()
+			connect(spuBG->button(i), &QAbstractButton::clicked, [=]()
 			{
 				xemu_settings->SetSetting(emu_settings::SPUDecoder, sstr(spu_list[i]));
 			});
@@ -329,7 +329,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 				libModeBG->button(i)->setChecked(true);
 			}
 
-			connect(libModeBG->button(i), &QAbstractButton::pressed, [=]()
+			connect(libModeBG->button(i), &QAbstractButton::clicked, [=]()
 			{
 				xemu_settings->SetSetting(emu_settings::LibLoadOptions, sstr(libmode_list[i]));
 			});
@@ -907,7 +907,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 				enterButtonAssignmentBG->button(i)->setChecked(true);
 			}
 
-			connect(enterButtonAssignmentBG->button(i), &QAbstractButton::pressed, [=]()
+			connect(enterButtonAssignmentBG->button(i), &QAbstractButton::clicked, [=]()
 			{
 				xemu_settings->SetSetting(emu_settings::EnterButtonAssignment, sstr(assignable_buttons[i]));
 			});

--- a/rpcs3/rpcs3qt/vfs_dialog.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog.cpp
@@ -36,19 +36,19 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_pt
 
 	// Create buttons
 	QPushButton* addDir = new QPushButton(tr("Add New Directory"));
-	connect(addDir, &QAbstractButton::pressed, [=]
+	connect(addDir, &QAbstractButton::clicked, [=]
 	{
 		static_cast<vfs_dialog_tab*>(tabs->currentWidget())->AddNewDirectory();
 	});
 
 	QPushButton* reset = new QPushButton(tr("Reset"));
-	connect(reset, &QAbstractButton::pressed, [=]
+	connect(reset, &QAbstractButton::clicked, [=]
 	{
 		static_cast<vfs_dialog_tab*>(tabs->currentWidget())->Reset();
 	});
 
 	QPushButton* resetAll = new QPushButton(tr("Reset All"));
-	connect(resetAll, &QAbstractButton::pressed, [=]
+	connect(resetAll, &QAbstractButton::clicked, [=]
 	{
 		for (int i = 0; i < tabs->count(); ++i)
 		{
@@ -60,7 +60,7 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_pt
 	okay->setAutoDefault(true);
 	okay->setDefault(true);
 
-	connect(okay, &QAbstractButton::pressed, [=]
+	connect(okay, &QAbstractButton::clicked, [=]
 	{
 		for (int i = 0; i < tabs->count(); ++i)
 		{

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -31,7 +31,7 @@ welcome_dialog::welcome_dialog(QWidget* parent) : QDialog(parent), ui(new Ui::we
 		settings->SetValue(gui::ib_show_welcome, QVariant(!checked));
 	});
 
-	connect(ui->okay, &QPushButton::pressed, this, &QDialog::accept);
+	connect(ui->okay, &QPushButton::clicked, this, &QDialog::accept);
 
 	layout()->setSizeConstraint(QLayout::SetFixedSize);
 }


### PR DESCRIPTION
This PR fixes a few UI buttons reacting to incorrect signals. Previously, a few buttons did not follow the standard UI behaviour and instead of reacting to button **click** (press & release), they executed their actions on **press**. This led to a bit inconsistent experience and, in some cases, difficulties navigating (I found it the most annoying in _Virtual File System_ dialogs).

Affected dialogs:
- Welcome
- Find
- Instruction Editor
- Register Editor
- Settings (radio buttons)
- Virtual File System

While this may look like a mass Find & Replace, each case has been analyzed separately and tested for regressions.

## Reproduction Steps
To observe the changes easiest, do the following:
0. Ensure Welcome screen will show on startup (`Settings -> GUI -> Show Welcome Screen` should be set).
1. Launch RPCS3.
2. "Welcome to RPCS3" dialog should show up - click on `I have read the Quickstart guide`, then **press** `Continue`.

## Observed behaviour
Dialog closes as soon as user presses `Continue`. This is incosistent with standard UI design in RPCS3 and in systems overall.

## Expected behaviour
Dialog should close after pressing and releasing the mouse button over `Continue`, similarly to other UI parts in RPCS3 and in systems overall.