### PR TITLE
rsx: Treat blend colour as BGRA

### DIFF
--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3768,7 +3768,7 @@ struct registers_decoder<NV4097_SET_BLEND_COLOR>
 			return bf_decoder<16, 16>(value);
 		}
 
-		u8 red8() const
+		u8 blue8() const
 		{
 			return bf_decoder<0, 8>(value);
 		}
@@ -3778,7 +3778,7 @@ struct registers_decoder<NV4097_SET_BLEND_COLOR>
 			return bf_decoder<8, 8>(value);
 		}
 
-		u8 blue8() const
+		u8 red8() const
 		{
 			return bf_decoder<16, 8>(value);
 		}


### PR DESCRIPTION
**HARDWARE TESTS PENDING: @kd-11 mentioned he'll test it relatively soon.**

This PR corrects decoding of `SET_BLEND_COLOR` RSX commands. Previously colour would be interpreted as RGBA, whereas it appears like it should have been treated as BGRA.

It's assumed this feature is not used by many games, and even the ones using it do not use it consistently.

Afftected games:
* **Gran Turismo HD Concept** - fixes blue tail lights in *some* vehicles. Oddly enough, most cars looked just fine (and they still do), which hints blend color is not used to achieve red material color often.
* **Gran Turismo 5** - possibly affected. Untested, but screenshots from current RPCS3 builds show the same bug as in GTHD.

The most prominent example in GTHD is Infiniti G35, clearly showing what was wrong. Notice that the center brake light is correctly coloured in both cases!
![Base Profile Screenshot 2019 07 10 - 21 59 49 20](https://user-images.githubusercontent.com/7947461/61001783-95631f80-a360-11e9-954f-211543dc0cd9.jpg)

Best reference from real PS3 I could find:
https://youtu.be/FAMPvAZ3VPc?t=1418

When testing for regressions, look for obvious miscolorations - red things becoming blue and blue things becoming red.