### PR TITLE
rsx: Allow to configure vblank rate

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -250,10 +250,6 @@ error_code sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64
 
 	const auto render = rsx::get_current_renderer();
 
-	//hle protection
-	if (render->isHLE)
-		return CELL_OK;
-
 	auto m_sysrsx = fxm::get<SysRsxConfig>();
 
 	if (!m_sysrsx)

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <deque>
 #include <variant>
@@ -549,7 +549,7 @@ namespace rsx
 		vm::ptr<void(u32)> flip_handler = vm::null;
 		vm::ptr<void(u32)> user_handler = vm::null;
 		vm::ptr<void(u32)> vblank_handler = vm::null;
-		u64 vblank_count;
+		atomic_t<u64> vblank_count;
 
 	public:
 		bool invalid_command_interrupt_raised = false;

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3791,8 +3791,8 @@ struct registers_decoder<NV4097_SET_BLEND_COLOR>
 
 	static std::string dump(decoded_type &&decoded_values)
 	{
-		return "Blend color: 8b RGBA = " +
-			std::to_string(decoded_values.red8()) + ", " + std::to_string(decoded_values.green8()) + ", " + std::to_string(decoded_values.blue8()) + ", " + std::to_string(decoded_values.alpha8()) +
+		return "Blend color: 8b BGRA = " +
+			std::to_string(decoded_values.blue8()) + ", " + std::to_string(decoded_values.green8()) + ", " + std::to_string(decoded_values.red8()) + ", " + std::to_string(decoded_values.alpha8()) +
 			" 16b RG = " + std::to_string(decoded_values.red16()) + ", " + std::to_string(decoded_values.green16());
 	}
 };

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -477,6 +477,7 @@ struct cfg_root : cfg::node
 		cfg::_int<0, 16> anisotropic_level_override{this, "Anisotropic Filter Override", 0};
 		cfg::_int<1, 1024> min_scalable_dimension{this, "Minimum Scalable Dimension", 16};
 		cfg::_int<0, 30000000> driver_recovery_timeout{this, "Driver Recovery Timeout", 1000000};
+		cfg::_int<1, 500> vblank_rate{this, "Vblank Rate", 60}; // Changing this from 60 may affect game speed unexpected ways
 
 		struct node_d3d12 : cfg::node
 		{


### PR DESCRIPTION
Laying the groundwork for emulation speed modifiers.

Other improvements:
* Fixed an accuracy regression from #5719 (b8fb83c4483d). (recheck period before sleeping)