### PR TITLE
gui/window render: Disable read QT DPI value.

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
 	logs::set_init();
 
 #if defined(_WIN32) || defined(__APPLE__)
-	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
 #else
 	setenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1", 0);
 #endif


### PR DESCRIPTION
- Fix issue https://github.com/RPCS3/rpcs3/issues/5455
- Fix proportion and resolution for show real and no faked/zoomed x2 if you using 200 %  windows scaloing, so can re use 2K for 2k monitor and 4K in 4K monitor.
- Fix all out of box caused by zoomed any dialog depending Windows scaling set.

Now like User have tested with other, this things is usseles and continue broken all time proportion/resolution for all inside rpcs3.