### PR TITLE
Set the default SPU Decoder to LLVM and rename SPU LLVM from "experimental" to "fastest"

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -375,7 +375,7 @@ struct cfg_root : cfg::node
 		cfg::_int<0, INT32_MAX> llvm_threads{this, "Max LLVM Compile Threads", 0};
 		cfg::_bool thread_scheduler_enabled{this, "Enable thread scheduler", thread_scheduler_enabled_def};
 		cfg::_bool set_daz_and_ftz{this, "Set DAZ and FTZ", false};
-		cfg::_enum<spu_decoder_type> spu_decoder{this, "SPU Decoder", spu_decoder_type::asmjit};
+		cfg::_enum<spu_decoder_type> spu_decoder{this, "SPU Decoder", spu_decoder_type::llvm};
 		cfg::_bool lower_spu_priority{this, "Lower SPU thread priority"};
 		cfg::_bool spu_debug{this, "SPU Debug"};
 		cfg::_int<0, 6> preferred_spu_threads{this, "Preferred SPU Threads", 0}; //Numnber of hardware threads dedicated to heavy simultaneous spu tasks

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -36,7 +36,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="coreTab">
       <attribute name="title">
@@ -107,7 +107,7 @@
               <item>
                <widget class="QRadioButton" name="spu_llvm">
                 <property name="text">
-                 <string>LLVM Recompiler (experimental)</string>
+                 <string>LLVM Recompiler (fastest)</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
I've noticed that there's a lot of people using ASMJIT nowadays even after the approximate float being a thing thinking that it's the best and fastest option to all the games, which leads to people complaining that the performance they've been getting isn't nowhere near what it should be since asmjit says (faster) and 
because its the default option. This PR changes the default SPU decoder to LLVM and renames SPU LLVM (experimental) to SPU LLVM (fastest).