### PR TITLE
vk: Fix Linux Vega float16_t workaround

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -543,7 +543,7 @@ private:
 			}
 
 #ifndef _WIN32
-			if (get_name().find("VEGA"))
+			if (get_name().find("VEGA") != std::string::npos)
 			{
 				LOG_WARNING(RSX, "float16_t does not work correctly on VEGA hardware for both RADV and AMDVLK. Using float32_t fallback instead.");
 				shader_types_support.allow_float16 = false;


### PR DESCRIPTION
It was accidentally disabling float16_t for non Vega cards.