### PR TITLE
Qt: fix app versions after a patch was removed from the game list 

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -908,15 +908,8 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 			}
 			fs::remove_all(currGame.path);
 			m_game_data.erase(std::remove(m_game_data.begin(), m_game_data.end(), gameinfo), m_game_data.end());
-			if (m_isListLayout)
-			{
-				m_gameList->removeRow(m_gameList->currentItem()->row());
-			}
-			else
-			{
-				Refresh();
-			}
 			LOG_SUCCESS(GENERAL, "Removed %s %s in %s", currGame.category, currGame.name, currGame.path);
+			Refresh(true);
 		}
 	});
 	connect(openGameFolder, &QAction::triggered, [=]()


### PR DESCRIPTION
I just removed a game update from the game list and the game itself still showed the old version.
I fixed this by properly updating the game list instead of using the old way of simply removing the list entry after the files were removed.