### PR TITLE
Qt: Fix small controller icon in pad settings for high dpi modes

### DIFF
--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -187,9 +187,8 @@ pad_settings_dialog::pad_settings_dialog(QWidget *parent, const GameInfo *game)
 	// Set up first tab
 	OnTabChanged(0);
 
-	// repaint and resize controller image
+	// repaint controller image
 	ui->l_controller->setPixmap(gui::utils::get_colorized_pixmap(*ui->l_controller->pixmap(), QColor(), gui::utils::get_label_color("l_controller"), false, true));
-	ui->l_controller->setMaximumSize(ui->gb_description->sizeHint().width(), ui->l_controller->maximumHeight() * ui->gb_description->sizeHint().width() / ui->l_controller->maximumWidth());
 
 	// set tab layout constraint to the first tab
 	m_tabs->widget(0)->layout()->setSizeConstraint(QLayout::SetFixedSize);


### PR DESCRIPTION
This should (hopefully) fix the small controller icon in the pad settings dialog.

Please test this on both normal screens and window scaling.

Before:
![image](https://user-images.githubusercontent.com/23019877/61170604-e8f58900-a56b-11e9-9653-34db9516321a.png)

After: 
![image](https://user-images.githubusercontent.com/23019877/61170597-d713e600-a56b-11e9-8db8-f122167787e5.png)
