### PR TITLE
Implement cellSaveData List Deletion

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -83,6 +83,8 @@ enum class MsgDialogState
 	Close,
 };
 
+extern atomic_t<s32> g_last_user_response;
+
 error_code open_msg_dialog(bool is_blocking, u32 type, vm::cptr<char> msgString, vm::ptr<CellMsgDialogCallback> callback = vm::null, vm::ptr<void> userData = vm::null, vm::ptr<void> extParam = vm::null);
 error_code open_exit_dialog(const std::string& message, bool is_exit_requested);
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -160,7 +160,7 @@ static bool savedata_check_args(u32 operation, u32 version, vm::cptr<char> dirNa
 	}
 
 	if ((operation >= SAVEDATA_OP_LIST_AUTO_SAVE && operation <= SAVEDATA_OP_FIXED_LOAD) || operation == SAVEDATA_OP_FIXED_DELETE)
-	{	
+	{
 		if (setBuf->dirListMax > CELL_SAVEDATA_DIRLIST_MAX)
 		{
 			// ****** sysutil savedata parameter error : 8 ******
@@ -329,8 +329,6 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 						save_entry2.title = psf.at("TITLE").as_string();
 						save_entry2.subtitle = psf.at("SUB_TITLE").as_string();
 						save_entry2.details = psf.at("DETAIL").as_string();
-
-						save_entry2.size = 0;
 
 						for (const auto entry2 : fs::dir(base_dir + entry.name))
 						{

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -298,7 +298,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		// get the saves matching the supplied prefix
 		for (auto&& entry : fs::dir(base_dir))
 		{
-			if (!entry.is_directory)
+			if (!entry.is_directory || entry.name == "." || entry.name == "..")
 			{
 				continue;
 			}

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.h
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <Emu/Memory/vm_ptr.h>
 
@@ -297,12 +297,12 @@ struct SaveDataEntry
 	std::string title;
 	std::string subtitle;
 	std::string details;
-	u64 size;
-	s64 atime;
-	s64 mtime;
-	s64 ctime;
+	u64 size{0};
+	s64 atime{0};
+	s64 mtime{0};
+	s64 ctime{0};
 	std::vector<uchar> iconBuf;
-	bool isNew;
+	bool isNew{false};
 };
 
 class SaveDialogBase

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.h
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.h
@@ -186,7 +186,7 @@ struct CellSaveDataSystemFileParam
 	char subTitle[CELL_SAVEDATA_SYSP_SUBTITLE_SIZE];
 	char detail[CELL_SAVEDATA_SYSP_DETAIL_SIZE];
 	be_t<u32> attribute;
-	char reserved2[4];
+	be_t<u32> parental_level; // char reserved2[4] in firmware 3.70 or higher
 	char listParam[CELL_SAVEDATA_SYSP_LPARAM_SIZE];
 	char reserved[256];
 };

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -1168,7 +1168,7 @@ namespace rsx
 			std::unique_ptr<overlay_element> m_highlight_box;
 
 			u16 m_elements_height = 0;
-			s16 m_selected_entry = -1;
+			s32 m_selected_entry = -1;
 			u16 m_elements_count = 0;
 
 			bool m_cancel_only = false;
@@ -1178,6 +1178,7 @@ namespace rsx
 
 			void update_selection();
 
+			void select_entry(s32 entry);
 			void select_next(u16 count = 1);
 			void select_previous(u16 count = 1);
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
@@ -91,24 +91,25 @@ namespace rsx
 			refresh();
 		}
 
-		void list_view::select_next(u16 count)
+		void list_view::select_entry(s32 entry)
 		{
-			const int max_entry = m_elements_count - 1;
+			const s32 max_entry = m_elements_count - 1;
 
-			if (m_selected_entry < max_entry)
+			if (m_selected_entry != entry)
 			{
-				m_selected_entry = std::min(m_selected_entry + count, max_entry);
+				m_selected_entry = std::max(0, std::min(entry, max_entry));
 				update_selection();
 			}
 		}
 
+		void list_view::select_next(u16 count)
+		{
+			select_entry(m_selected_entry + count);
+		}
+
 		void list_view::select_previous(u16 count)
 		{
-			if (m_selected_entry > 0)
-			{
-				m_selected_entry = std::max(0, m_selected_entry - count);
-				update_selection();
-			}
+			select_entry(m_selected_entry - count);
 		}
 
 		void list_view::add_entry(std::unique_ptr<overlay_element>& entry)

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "overlays.h"
 
 namespace rsx
@@ -179,7 +179,7 @@ namespace rsx
 				m_description->set_text("Save");
 			}
 
-			const bool newpos_head = listSet->newData && listSet->newData->iconPosition == CELL_SAVEDATA_ICONPOS_HEAD;
+			const bool newpos_head = listSet && listSet->newData && listSet->newData->iconPosition == CELL_SAVEDATA_ICONPOS_HEAD;
 
 			if (!newpos_head)
 			{
@@ -189,7 +189,7 @@ namespace rsx
 				}
 			}
 
-			if (listSet->newData)
+			if (listSet && listSet->newData)
 			{
 				std::unique_ptr<overlay_element> new_stub;
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "overlays.h"
 
 namespace rsx
@@ -154,7 +154,7 @@ namespace rsx
 			return result;
 		}
 
-		s32 save_dialog::show(std::vector<SaveDataEntry>& save_entries, u32 op, vm::ptr<CellSaveDataListSet> listSet)
+		s32 save_dialog::show(std::vector<SaveDataEntry>& save_entries, u32 focused, u32 op, vm::ptr<CellSaveDataListSet> listSet)
 		{
 			std::vector<u8> icon;
 			std::vector<std::unique_ptr<overlay_element>> entries;
@@ -240,6 +240,8 @@ namespace rsx
 				m_no_saves = true;
 				m_list->set_cancel_only(true);
 			}
+
+			m_list->select_entry(focused);
 
 			static_cast<label*>(m_description.get())->auto_resize();
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -323,7 +323,10 @@ namespace rsx
 			pad::SetIntercepted(false);
 
 			if (on_close && use_callback)
+			{
+				g_last_user_response = return_code;
 				on_close(return_code);
+			}
 		}
 
 		void overlay::refresh()

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -515,7 +515,7 @@ namespace rsx
 
 			compiled_resource get_compiled() override;
 
-			s32 show(std::vector<SaveDataEntry>& save_entries, u32 op, vm::ptr<CellSaveDataListSet> listSet);
+			s32 show(std::vector<SaveDataEntry>& save_entries, u32 focused, u32 op, vm::ptr<CellSaveDataListSet> listSet);
 		};
 
 		struct message_dialog : public user_interface

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -93,12 +93,14 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 
 		connect(m_button_yes, &QAbstractButton::clicked, [=]
 		{
+			g_last_user_response = CELL_MSGDIALOG_BUTTON_YES;
 			on_close(CELL_MSGDIALOG_BUTTON_YES);
 			m_dialog->accept();
 		});
 
 		connect(m_button_no, &QAbstractButton::clicked, [=]
 		{
+			g_last_user_response = CELL_MSGDIALOG_BUTTON_NO;
 			on_close(CELL_MSGDIALOG_BUTTON_NO);
 			m_dialog->accept();
 		});
@@ -123,6 +125,7 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 
 		connect(m_button_ok, &QAbstractButton::clicked, [=]
 		{
+			g_last_user_response = CELL_MSGDIALOG_BUTTON_OK;
 			on_close(CELL_MSGDIALOG_BUTTON_OK);
 			m_dialog->accept();
 		});
@@ -134,6 +137,7 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 	{
 		if (!type.disable_cancel)
 		{
+			g_last_user_response = CELL_MSGDIALOG_BUTTON_ESCAPE;
 			on_close(CELL_MSGDIALOG_BUTTON_ESCAPE);
 		}
 	});

--- a/rpcs3/rpcs3qt/save_data_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_dialog.cpp
@@ -9,7 +9,7 @@ s32 save_data_dialog::ShowSaveDataList(std::vector<SaveDataEntry>& save_entries,
 	// TODO: Install native shell as an Emu callback
 	if (auto manager = fxm::get<rsx::overlays::display_manager>())
 	{
-		auto result = manager->create<rsx::overlays::save_dialog>()->show(save_entries, op, listSet);
+		auto result = manager->create<rsx::overlays::save_dialog>()->show(save_entries, focused, op, listSet);
 		if (result != rsx::overlays::user_interface::selection_code::error)
 			return result;
 	}

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -59,7 +59,7 @@ save_data_list_dialog::save_data_list_dialog(const std::vector<SaveDataEntry>& e
 		UpdateSelectionLabel();
 	}
 
-	if (listSet->newData)
+	if (listSet && listSet->newData)
 	{
 		QPushButton *saveNewEntry = new QPushButton(tr("Save New Entry"), this);
 		connect(saveNewEntry, &QAbstractButton::clicked, this, [&]()


### PR DESCRIPTION
I noticed a change for one of my games today:
Elad - knowingly or not - fixed input for Blazing Angels 2 a whopping 104 days ago. 🙇🙇🙇

So the first thing I did today was to play it for a few minutes.
At first I simply created a new profile and started a game, but when I came back half an hour later I noticed that the game wouldn't let me load my profile. This made me a bit sad, but I knew I had no chance at fixing it at all, so I just ignored it.
I then tried to delete the profile and was immediately greeted with an error message.
Deletion of files? That's something even I could do.

So I implemented both cellSaveDataDelete functions!

1. They open a save data list where all the entries for the current title are listed.
2. Upon selecting an entry a dialog will spawn, asking for user confirmation.
3. If the user accepts the dialog, the directory of that entry will be removed and another dialog will confirm the removal.
4. If something went wrong a dialog will alert the user in the same manner.
5. The list will be shown again in all cases.
6. This process will repeat until the list dialog was cancelled, so the user can remove as many entries as needed.

While I was at it I also added a missing feature to the native save dialog: the initial focused entry.
The list will now keep its focus on the same index while performing actions in the list, instead of resetting the focus to the first element with every user interaction.

![image](https://user-images.githubusercontent.com/23019877/61176035-ee79c000-a5b9-11e9-9a9e-55e394324cd7.png)
![image](https://user-images.githubusercontent.com/23019877/61176038-ff2a3600-a5b9-11e9-8e23-dede4effb90c.png)
![image](https://user-images.githubusercontent.com/23019877/61176040-12d59c80-a5ba-11e9-8b4f-bb42b3a5e0a6.png)

But since I kinda failed at the last step (for now), I remembered the first error that wouldn't allow me to load my profile. So I started to investigate - by adding a billion log messages to the huuuuge savedate_op function - and found where the error came from.

At first I thought it would be a corrupt PARAM.SFO file so I started to scrape the ps3devwiki for any information I could find and improved the PARAM.SFO generation a tiny bit.... but still no success.

Then I realized that it wasn't the PARAM.SFO that was broken... but the file it wanted to load (duh). So I stared at the code for a while until I finally remembered my billion log messages.
The damn thing read the ICON0.PNG file.... but why would it be broken??? And why did it only read one file if it wants a file list???

Then I facepalmed and added 1 and 1 together: Why would it only read the ICON0.PNG in the first place?
It turned out that the game really only requested one file, but it never specified which one. And up until now we simply went through the save data directory file by file until we either found all the files that weren't the param.sfo or until the requested file limit was reached.
Boohoo ... too bad that we only handed over the ICON0.PNG 😜😜😜.

This is were my fix comes in... it's still very naive, but we now read media files only after we read all the other files. This will hopefully fix most games that just wanted some sweet save files but got media garbage instead.

Let me know if this works for any of your games.

Edit:
We found out that the files seem to be actually loaded in creation or update order.
I will remove my experimental fix and we'll try this in another follow up Pull Request.