### PR TITLE
It's About Time

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -1259,7 +1259,7 @@ void camera_context::operator()()
 			continue;
 		}
 
-		const u64 frame_start = get_system_time();
+		const u64 frame_start = get_guest_system_time();
 
 		std::unique_lock lock(mutex_notify_data_map);
 
@@ -1304,7 +1304,7 @@ void camera_context::operator()()
 
 		for (const u64 frame_target_time = 1000000u / fps;;)
 		{
-			const u64 time_passed = get_system_time() - frame_start;
+			const u64 time_passed = get_guest_system_time() - frame_start;
 			if (time_passed >= frame_target_time)
 				break;
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -38,7 +38,7 @@ void mic_context::operator()()
 			continue;
 		}
 
-		const u64 stamp0   = get_system_time();
+		const u64 stamp0   = get_guest_system_time();
 		const u64 time_pos = stamp0 - start_time - Emu.GetPauseTime();
 
 		const u64 expected_time = m_counter * 256 * 1000000 / 48000;

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -254,7 +254,7 @@ public:
 	std::unordered_map<u8, microphone_device> mic_list;
 
 protected:
-	const u64 start_time = get_system_time();
+	const u64 start_time = get_guest_system_time();
 	u64 m_counter        = 0;
 
 	//	u32 signalStateLocalTalk = 9; // value is in range 0-10. 10 indicates talking, 0 indicating none.

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -332,8 +332,8 @@ error_code cellMsgDialogClose(f32 delay)
 {
 	cellSysutil.warning("cellMsgDialogClose(delay=%f)", delay);
 
-	extern u64 get_system_time();
-	const u64 wait_until = get_system_time() + static_cast<s64>(std::max<float>(delay, 0.0f) * 1000);
+	extern u64 get_guest_system_time();
+	const u64 wait_until = get_guest_system_time() + static_cast<s64>(std::max<float>(delay, 0.0f) * 1000);
 
 	if (auto manager = fxm::get<rsx::overlays::display_manager>())
 	{
@@ -341,7 +341,7 @@ error_code cellMsgDialogClose(f32 delay)
 		{
 			thread_ctrl::spawn("cellMsgDialogClose() Thread", [=]
 			{
-				while (get_system_time() < wait_until)
+				while (get_guest_system_time() < wait_until)
 				{
 					if (Emu.IsStopped())
 						return;
@@ -368,7 +368,7 @@ error_code cellMsgDialogClose(f32 delay)
 
 	thread_ctrl::spawn("cellMsgDialogClose() Thread", [=]()
 	{
-		while (dlg->state == MsgDialogState::Open && get_system_time() < wait_until)
+		while (dlg->state == MsgDialogState::Open && get_guest_system_time() < wait_until)
 		{
 			if (Emu.IsStopped()) return;
 

--- a/rpcs3/Emu/Cell/Modules/cellVpost.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVpost.cpp
@@ -113,16 +113,16 @@ s32 cellVpostExec(u32 handle, vm::cptr<u8> inPicBuff, vm::cptr<CellVpostCtrlPara
 	picInfo->reserved1 = 0;
 	picInfo->reserved2 = 0;
 
-	//u64 stamp0 = get_system_time();
+	//u64 stamp0 = get_guest_system_time();
 	std::unique_ptr<u8[]> pA(new u8[w*h]);
 
 	memset(pA.get(), ctrlParam->outAlpha, w*h);
 
-	//u64 stamp1 = get_system_time();
+	//u64 stamp1 = get_guest_system_time();
 
 	vpost->sws = sws_getCachedContext(vpost->sws, w, h, AV_PIX_FMT_YUVA420P, ow, oh, AV_PIX_FMT_RGBA, SWS_BILINEAR, NULL, NULL, NULL);
 
-	//u64 stamp2 = get_system_time();
+	//u64 stamp2 = get_guest_system_time();
 
 	const u8* in_data[4] = { &inPicBuff[0], &inPicBuff[w * h], &inPicBuff[w * h * 5 / 4], pA.get() };
 	int in_line[4] = { w, w/2, w/2, w };
@@ -132,7 +132,7 @@ s32 cellVpostExec(u32 handle, vm::cptr<u8> inPicBuff, vm::cptr<CellVpostCtrlPara
 	sws_scale(vpost->sws, in_data, in_line, 0, h, out_data, out_line);
 
 	//ConLog.Write("cellVpostExec() perf (access=%d, getContext=%d, scale=%d, finalize=%d)",
-		//stamp1 - stamp0, stamp2 - stamp1, stamp3 - stamp2, get_system_time() - stamp3);
+		//stamp1 - stamp0, stamp2 - stamp1, stamp3 - stamp2, get_guest_system_time() - stamp3);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/libmixer.cpp
+++ b/rpcs3/Emu/Cell/Modules/libmixer.cpp
@@ -346,7 +346,7 @@ struct surmixer_thread : ppu_thread
 
 			if (port.state == audio_port_state::started)
 			{
-				//u64 stamp0 = get_system_time();
+				//u64 stamp0 = get_guest_system_time();
 
 				memset(g_surmx.mixdata, 0, sizeof(g_surmx.mixdata));
 				if (g_surmx.cb)
@@ -355,7 +355,7 @@ struct surmixer_thread : ppu_thread
 					lv2_obj::sleep(*this);
 				}
 
-				//u64 stamp1 = get_system_time();
+				//u64 stamp1 = get_guest_system_time();
 
 				{
 					std::lock_guard lock(g_surmx.mutex);
@@ -434,7 +434,7 @@ struct surmixer_thread : ppu_thread
 					}
 				}
 
-				//u64 stamp2 = get_system_time();
+				//u64 stamp2 = get_guest_system_time();
 
 				auto buf = vm::_ptr<f32>(port.addr.addr() + (g_surmx.mixcount % port.num_blocks) * port.num_channels * AUDIO_BUFFER_SAMPLES * sizeof(float));
 
@@ -444,7 +444,7 @@ struct surmixer_thread : ppu_thread
 					*buf++ = mixdata;
 				}
 
-				//u64 stamp3 = get_system_time();
+				//u64 stamp3 = get_guest_system_time();
 
 				//ConLog.Write("Libmixer perf: start=%lld (cb=%lld, ssp=%lld, finalize=%lld)", stamp0 - m_config.start_time, stamp1 - stamp0, stamp2 - stamp1, stamp3 - stamp2);
 			}

--- a/rpcs3/Emu/Cell/Modules/sysPrxForUser.cpp
+++ b/rpcs3/Emu/Cell/Modules/sysPrxForUser.cpp
@@ -11,7 +11,7 @@
 
 LOG_CHANNEL(sysPrxForUser);
 
-extern u64 get_system_time();
+extern u64 get_guest_system_time();
 
 vm::gvar<s32> sys_prx_version; // ???
 vm::gvar<vm::ptr<void()>> g_ppu_atexitspawn;
@@ -22,7 +22,7 @@ s64 sys_time_get_system_time()
 {
 	sysPrxForUser.trace("sys_time_get_system_time()");
 
-	return get_system_time();
+	return get_guest_system_time();
 }
 
 void sys_process_exit(ppu_thread& ppu, s32 status)

--- a/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
@@ -214,7 +214,7 @@ error_code sys_lwmutex_lock(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex, u64
 				return CELL_OK;
 			}
 
-			const u64 time0 = timeout ? get_system_time() : 0;
+			const u64 time0 = timeout ? get_guest_system_time() : 0;
 
 			const error_code res_ = _sys_lwmutex_lock(ppu, lwmutex->sleep_queue, timeout);
 
@@ -229,7 +229,7 @@ error_code sys_lwmutex_lock(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex, u64
 			}
 			else if (timeout && res_ != CELL_ETIMEDOUT)
 			{
-				const u64 time_diff = get_system_time() - time0;
+				const u64 time_diff = get_guest_system_time() - time0;
 
 				if (timeout <= time_diff)
 				{

--- a/rpcs3/Emu/Cell/Modules/sys_spu_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_spu_.cpp
@@ -10,8 +10,6 @@
 
 extern logs::channel sysPrxForUser;
 
-extern u64 get_system_time();
-
 spu_printf_cb_t g_spu_printf_agcb;
 spu_printf_cb_t g_spu_printf_dgcb;
 spu_printf_cb_t g_spu_printf_atcb;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -64,7 +64,7 @@ const bool s_use_ssse3 =
 #define _mm_shuffle_epi8
 #endif
 
-extern u64 get_system_time();
+extern u64 get_guest_system_time();
 
 extern atomic_t<const char*> g_progr;
 extern atomic_t<u64> g_progr_ptotal;
@@ -469,7 +469,7 @@ std::string ppu_thread::dump() const
 
 	if (const auto _time = start_time)
 	{
-		fmt::append(ret, "Waiting: %fs\n", (get_system_time() - _time) / 1000000.);
+		fmt::append(ret, "Waiting: %fs\n", (get_guest_system_time() - _time) / 1000000.);
 	}
 	else
 	{
@@ -721,7 +721,7 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 	, prio(prio)
 	, stack_size(param.stack_size)
 	, stack_addr(param.stack_addr)
-	, start_time(get_system_time())
+	, start_time(get_guest_system_time())
 	, joiner(-!!detached)
 	, ppu_name(name)
 {
@@ -846,7 +846,7 @@ void ppu_thread::fast_call(u32 addr, u32 rtoc)
 			{
 				if (start_time)
 				{
-					LOG_WARNING(PPU, "'%s' aborted (%fs)", current_function, (get_system_time() - start_time) / 1000000.);
+					LOG_WARNING(PPU, "'%s' aborted (%fs)", current_function, (get_guest_system_time() - start_time) / 1000000.);
 				}
 				else
 				{

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -998,7 +998,7 @@ extern ppu_function_t ppu_get_syscall(u64 code)
 	return nullptr;
 }
 
-extern u64 get_system_time();
+extern u64 get_guest_system_time();
 
 DECLARE(lv2_obj::g_mutex);
 DECLARE(lv2_obj::g_ppu);
@@ -1009,7 +1009,7 @@ void lv2_obj::sleep_timeout(cpu_thread& thread, u64 timeout)
 {
 	std::lock_guard lock(g_mutex);
 
-	const u64 start_time = get_system_time();
+	const u64 start_time = get_guest_system_time();
 
 	if (auto ppu = static_cast<ppu_thread*>(thread.id_type() == 1 ? &thread : nullptr))
 	{
@@ -1039,7 +1039,7 @@ void lv2_obj::sleep_timeout(cpu_thread& thread, u64 timeout)
 		ppu->start_time = start_time;
 	}
 
-	if (timeout)
+	if (timeout && g_cfg.core.sleep_timers_accuracy != sleep_timers_accuracy_level::_all_timers)
 	{
 		const u64 wait_until = start_time + timeout;
 
@@ -1077,7 +1077,7 @@ void lv2_obj::awake(cpu_thread& cpu, u32 prio)
 	else if (prio == -4)
 	{
 		// Yield command
-		const u64 start_time = get_system_time();
+		const u64 start_time = get_guest_system_time();
 
 		for (std::size_t i = 0, pos = -1; i < g_ppu.size(); i++)
 		{
@@ -1183,7 +1183,7 @@ void lv2_obj::schedule_all()
 	{
 		auto& pair = g_waiting.front();
 
-		if (pair.first <= get_system_time())
+		if (pair.first <= get_guest_system_time())
 		{
 			pair.second->notify();
 			g_waiting.pop_front();

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -12,8 +12,6 @@ LOG_CHANNEL(sys_cond);
 
 template<> DECLARE(ipc_manager<lv2_cond, u64>::g_ipc) {};
 
-extern u64 get_system_time();
-
 error_code sys_cond_create(ppu_thread& ppu, vm::ptr<u32> cond_id, u32 mutex_id, vm::ptr<sys_cond_attribute_t> attr)
 {
 	vm::temporary_unlock(ppu);
@@ -262,9 +260,7 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 
 		if (timeout)
 		{
-			const u64 passed = get_system_time() - ppu.start_time;
-
-			if (passed >= timeout)
+			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
 				std::lock_guard lock(cond->mutex->mutex);
 
@@ -285,8 +281,6 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 				timeout = 0;
 				continue;
 			}
-
-			thread_ctrl::wait_for(timeout - passed);
 		}
 		else
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -14,8 +14,6 @@ LOG_CHANNEL(sys_event);
 
 template<> DECLARE(ipc_manager<lv2_event_queue, u64>::g_ipc) {};
 
-extern u64 get_system_time();
-
 std::shared_ptr<lv2_event_queue> lv2_event_queue::find(u64 ipc_key)
 {
 	if (ipc_key == SYS_EVENT_QUEUE_LOCAL)
@@ -284,9 +282,7 @@ error_code sys_event_queue_receive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sys_e
 
 		if (timeout)
 		{
-			const u64 passed = get_system_time() - ppu.start_time;
-
-			if (passed >= timeout)
+			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
 				std::lock_guard lock(queue->mutex);
 
@@ -299,8 +295,6 @@ error_code sys_event_queue_receive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sys_e
 				ppu.gpr[3] = CELL_ETIMEDOUT;
 				break;
 			}
-
-			thread_ctrl::wait_for(timeout - passed);
 		}
 		else
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -14,8 +14,6 @@ LOG_CHANNEL(sys_event_flag);
 
 template<> DECLARE(ipc_manager<lv2_event_flag, u64>::g_ipc) {};
 
-extern u64 get_system_time();
-
 error_code sys_event_flag_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<sys_event_flag_attribute_t> attr, u64 init)
 {
 	vm::temporary_unlock(ppu);
@@ -171,9 +169,7 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 
 		if (timeout)
 		{
-			const u64 passed = get_system_time() - ppu.start_time;
-
-			if (passed >= timeout)
+			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
 				std::lock_guard lock(flag->mutex);
 
@@ -188,8 +184,6 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 				ppu.gpr[6] = flag->pattern;
 				break;
 			}
-
-			thread_ctrl::wait_for(timeout - passed);
 		}
 		else
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -10,8 +10,6 @@
 
 LOG_CHANNEL(sys_lwcond);
 
-extern u64 get_system_time();
-
 error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmutex_id, vm::ptr<sys_lwcond_t> control, u64 name, u32 arg5)
 {
 	vm::temporary_unlock(ppu);
@@ -313,9 +311,7 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 
 		if (timeout)
 		{
-			const u64 passed = get_system_time() - ppu.start_time;
-
-			if (passed >= timeout)
+			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
 				std::lock_guard lock(cond->mutex);
 
@@ -330,8 +326,6 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 				ppu.gpr[3] = CELL_ETIMEDOUT;
 				break;
 			}
-
-			thread_ctrl::wait_for(timeout - passed);
 		}
 		else
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -9,8 +9,6 @@
 
 LOG_CHANNEL(sys_lwmutex);
 
-extern u64 get_system_time();
-
 error_code _sys_lwmutex_create(ppu_thread& ppu, vm::ptr<u32> lwmutex_id, u32 protocol, vm::ptr<sys_lwmutex_t> control, s32 has_name, u64 name)
 {
 	vm::temporary_unlock(ppu);
@@ -130,9 +128,7 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 
 		if (timeout)
 		{
-			const u64 passed = get_system_time() - ppu.start_time;
-
-			if (passed >= timeout)
+			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
 				std::lock_guard lock(mutex->mutex);
 
@@ -145,8 +141,6 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 				ppu.gpr[3] = CELL_ETIMEDOUT;
 				break;
 			}
-
-			thread_ctrl::wait_for(timeout - passed);
 		}
 		else
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -30,8 +30,6 @@ static std::vector<ppu_thread*> s_to_awake;
 
 static shared_mutex s_nw_mutex;
 
-extern u64 get_system_time();
-
 // Error helper functions
 static s32 get_last_error(bool is_blocking, int native_error = 0)
 {
@@ -1613,9 +1611,7 @@ s32 sys_net_bnet_poll(ppu_thread& ppu, vm::ptr<sys_net_pollfd> fds, s32 nfds, s3
 
 		if (timeout)
 		{
-			const u64 passed = get_system_time() - ppu.start_time;
-
-			if (passed >= timeout)
+			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
 				std::lock_guard nw_lock(s_nw_mutex);
 
@@ -1628,8 +1624,6 @@ s32 sys_net_bnet_poll(ppu_thread& ppu, vm::ptr<sys_net_pollfd> fds, s32 nfds, s3
 				network_clear_queue(ppu);
 				break;
 			}
-
-			thread_ctrl::wait_for(timeout - passed);
 		}
 		else
 		{
@@ -1814,9 +1808,7 @@ s32 sys_net_bnet_select(ppu_thread& ppu, s32 nfds, vm::ptr<sys_net_fd_set> readf
 
 		if (timeout)
 		{
-			const u64 passed = get_system_time() - ppu.start_time;
-
-			if (passed >= timeout)
+			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
 				std::lock_guard nw_lock(s_nw_mutex);
 
@@ -1829,8 +1821,6 @@ s32 sys_net_bnet_select(ppu_thread& ppu, s32 nfds, vm::ptr<sys_net_fd_set> readf
 				network_clear_queue(ppu);
 				break;
 			}
-
-			thread_ctrl::wait_for(timeout - passed);
 		}
 		else
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Utilities/mutex.h"
 #include "Utilities/sema.h"
@@ -9,8 +9,10 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/IdManager.h"
 #include "Emu/IPC.h"
+#include "Emu/System.h"
 
 #include <deque>
+#include <thread>
 
 // attr_protocol (waiting scheduling policy)
 enum
@@ -211,6 +213,68 @@ struct lv2_obj
 			return CELL_EINVAL;
 		}
 		}
+	}
+
+	template<bool is_usleep = false>
+	static bool wait_timeout(u64 usec, cpu_thread* const cpu = nullptr)
+	{
+		usec = (usec * g_cfg.core.clocks_scale) / 100;
+
+#ifdef __linux__
+		// TODO: Confirm whether Apple or any BSD can benefit from this as well
+		constexpr u32 host_min_quantum = 50;
+#else
+		// Host scheduler quantum for windows (worst case)
+		// NOTE: On ps3 this function has very high accuracy
+		constexpr u32 host_min_quantum = 500;
+#endif
+		extern u64 get_system_time();
+
+		u64 passed = 0;
+		u64 remaining;
+
+		const u64 start_time = get_system_time();
+		while (usec >= passed)
+		{
+			remaining = usec - passed;
+
+			if (g_cfg.core.sleep_timers_accuracy < (is_usleep ? sleep_timers_accuracy_level::_usleep : sleep_timers_accuracy_level::_all_timers))
+			{
+				thread_ctrl::wait_for(remaining);
+			}
+			else
+			{
+				if (remaining > host_min_quantum)
+				{
+#ifdef __linux__
+					// Do not wait for the last quantum to avoid loss of accuracy
+					thread_ctrl::wait_for(remaining - ((remaining % host_min_quantum) + host_min_quantum));
+#else
+					// Wait on multiple of min quantum for large durations to avoid overloading low thread cpus 
+					thread_ctrl::wait_for(remaining - (remaining % host_min_quantum));
+#endif
+				}
+				else
+				{
+					// Try yielding. May cause long wake latency but helps weaker CPUs a lot by alleviating resource pressure
+					std::this_thread::yield();
+				}
+			}
+
+			if (Emu.IsStopped())
+			{
+				return false;
+			}
+
+			if (cpu && cpu->state & cpu_flag::signal)
+			{
+				return false;
+			}
+
+			passed = get_system_time() - start_time;
+		}
+
+		return true;
 	}
 
 private:

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -790,7 +790,7 @@ namespace rsx
 	u64 thread::timestamp()
 	{
 		// Get timestamp, and convert it from microseconds to nanoseconds
-		const u64 t = get_system_time() * 1000;
+		const u64 t = get_guest_system_time() * 1000;
 		if (t != timestamp_ctrl)
 		{
 			timestamp_ctrl = t;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -20,6 +20,7 @@
 
 #include "Emu/Cell/lv2/sys_rsx.h"
 
+extern u64 get_guest_system_time();
 extern u64 get_system_time();
 
 struct RSXIOTable

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -276,6 +276,22 @@ void fmt_class_string<tsx_usage>::format(std::string& out, u64 arg)
 }
 
 template <>
+void fmt_class_string<sleep_timers_accuracy_level>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](sleep_timers_accuracy_level value)
+	{
+		switch (value)
+		{
+		case sleep_timers_accuracy_level::_as_host: return "Host";
+		case sleep_timers_accuracy_level::_usleep: return "Usleep";
+		case sleep_timers_accuracy_level::_all_timers: return "All";
+		}
+
+		return unknown;
+	});
+}
+
+template <>
 void fmt_class_string<enter_button_assign>::format(std::string& out, u64 arg)
 {
 	format_enum(out, arg, [](enter_button_assign value)

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -8,6 +8,7 @@
 #include <string>
 
 u64 get_system_time();
+u64 get_guest_system_time();
 
 enum class system_state
 {
@@ -45,6 +46,13 @@ enum class lib_loading_type
 	manual,
 	both,
 	liblv2only
+};
+
+enum sleep_timers_accuracy_level : u32
+{
+	_as_host = 0,
+	_usleep,
+	_all_timers,
 };
 
 enum class keyboard_handler
@@ -406,6 +414,8 @@ struct cfg_root : cfg::node
 		cfg::set_entry load_libraries{this, "Load libraries"};
 		cfg::_bool hle_lwmutex{this, "HLE lwmutex"}; // Force alternative lwmutex/lwcond implementation
 
+		cfg::_int<10, 1000> clocks_scale{this, "Clocks scale", 100}; // Changing this from 100 (percentage) may affect game speed in unexpected ways
+		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{this, "Sleep timers accuracy", sleep_timers_accuracy_level::_as_host}; // Affects sleep timers accuracy (to fix host's sleep accuracy)
 	} core{this};
 
 	struct node_vfs : cfg::node
@@ -477,7 +487,7 @@ struct cfg_root : cfg::node
 		cfg::_int<0, 16> anisotropic_level_override{this, "Anisotropic Filter Override", 0};
 		cfg::_int<1, 1024> min_scalable_dimension{this, "Minimum Scalable Dimension", 16};
 		cfg::_int<0, 30000000> driver_recovery_timeout{this, "Driver Recovery Timeout", 1000000};
-		cfg::_int<1, 500> vblank_rate{this, "Vblank Rate", 60}; // Changing this from 60 may affect game speed unexpected ways
+		cfg::_int<1, 500> vblank_rate{this, "Vblank Rate", 60}; // Changing this from 60 may affect game speed in unexpected ways
 
 		struct node_d3d12 : cfg::node
 		{


### PR DESCRIPTION
This pull requests allows for the first time to modify time scaling of all LV2/PPU/SPU/RSX timers including syscalls' sleep time, units are in percentage.

This also adds three new accuracy modes for LV2 sleep:

- `Host` accuracy: does not attempt to fix host operating system's sleep accuracy.
This is theoretically the fastest setting, some users reported performance increase from reverting `sys_timer_usleep` accuracy such as in Red Dead Redemption. (the new default)

- `Usleep`: Attempts to corrects the sleep time for `sys_timer_usleep` syscall, this was the default behaviour on current master, fixes stutter and inaccurate frame rate capping in some games such as Nier.

- `All`: Attempts to correct the sleep time for all syscalls with timeout, this is the most accurate setting of them all but possibly the slowest.

Three ways to get double fps cap (game dependant):
* Double `Clocks Scale` value.
* Double `Vblank Rate`.
* Double `Vblank Rate` and halve `Clocks Scale`.

NOTE: it's possible that a game may rely only on timers and not vblank for frame capping, changing time scale in this case will affect the speed of playability as well.
Or even use another method for fps capping unsupported  at the moment.