### PR TITLE
Refactor XInput handler to support ScpToolkit extensions

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -104,6 +104,7 @@ void fmt_class_string<pad_handler>::format(std::string& out, u64 arg)
 		case pad_handler::ds4: return "DualShock 4";
 #ifdef _WIN32
 		case pad_handler::xinput: return "XInput";
+		case pad_handler::xinput_scp: return "XInput (ScpToolkit)";
 		case pad_handler::mm: return "MMJoystick";
 #endif
 #ifdef HAVE_LIBEVDEV

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -76,6 +76,7 @@ enum class pad_handler
 	ds4,
 #ifdef _WIN32
 	xinput,
+	xinput_scp,
 	mm,
 #endif
 #ifdef HAVE_LIBEVDEV

--- a/rpcs3/pad_thread.cpp
+++ b/rpcs3/pad_thread.cpp
@@ -103,7 +103,7 @@ void pad_thread::Init()
 				break;
 #ifdef _WIN32
 			case pad_handler::xinput:
-				cur_pad_handler = std::make_shared<xinput_pad_handler>();
+				cur_pad_handler = std::make_shared<xinput_pad_handler>(handler_type);
 				break;
 			case pad_handler::mm:
 				cur_pad_handler = std::make_shared<mm_joystick_handler>();

--- a/rpcs3/pad_thread.cpp
+++ b/rpcs3/pad_thread.cpp
@@ -103,6 +103,7 @@ void pad_thread::Init()
 				break;
 #ifdef _WIN32
 			case pad_handler::xinput:
+			case pad_handler::xinput_scp:
 				cur_pad_handler = std::make_shared<xinput_pad_handler>(handler_type);
 				break;
 			case pad_handler::mm:

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -888,7 +888,7 @@ std::shared_ptr<PadHandlerBase> pad_settings_dialog::GetHandler(pad_handler type
 		break;
 #ifdef _WIN32
 	case pad_handler::xinput:
-		ret_handler = std::make_unique<xinput_pad_handler>();
+		ret_handler = std::make_unique<xinput_pad_handler>(type);
 		break;
 	case pad_handler::mm:
 		ret_handler = std::make_unique<mm_joystick_handler>();

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -888,6 +888,7 @@ std::shared_ptr<PadHandlerBase> pad_settings_dialog::GetHandler(pad_handler type
 		break;
 #ifdef _WIN32
 	case pad_handler::xinput:
+	case pad_handler::xinput_scp:
 		ret_handler = std::make_unique<xinput_pad_handler>(type);
 		break;
 	case pad_handler::mm:
@@ -937,6 +938,7 @@ void pad_settings_dialog::ChangeInputType()
 	{
 #ifdef _WIN32
 	case pad_handler::xinput:
+	case pad_handler::xinput_scp:
 #endif
 	case pad_handler::ds3:
 	case pad_handler::ds4:
@@ -1059,6 +1061,7 @@ void pad_settings_dialog::ChangeProfile()
 		break;
 #ifdef _WIN32
 	case pad_handler::xinput:
+	case pad_handler::xinput_scp:
 		((xinput_pad_handler*)m_handler.get())->init_config(&m_handler_cfg, cfg_name);
 		break;
 	case pad_handler::mm:

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -6,6 +6,8 @@
 #include <Windows.h>
 #include <Xinput.h>
 
+#include <optional>
+
 // ScpToolkit defined structure for pressure sensitive button query
 typedef struct
 {
@@ -47,7 +49,7 @@ protected:
 	typedef DWORD(WINAPI* PFN_XINPUTGETBATTERYINFORMATION)(DWORD, BYTE, XINPUT_BATTERY_INFORMATION*);
 
 protected:
-	bool is_init{false};
+	std::optional<bool> is_init;
 	HMODULE library{nullptr};
 	PFN_XINPUTSETSTATE xinputSetState{nullptr};
 	PFN_XINPUTGETBATTERYINFORMATION xinputGetBatteryInformation{nullptr};
@@ -145,7 +147,7 @@ public:
 	bool Init() override
 	{
 		if (is_init)
-			return true;
+			return *is_init;
 
 		for (auto it : LIBRARY_FILENAMES)
 		{
@@ -162,7 +164,7 @@ public:
 				if (xinputGetState && xinputSetState && xinputGetBatteryInformation)
 				{
 					is_init = true;
-					break;
+					return true;
 				}
 
 				FreeLibrary(library);
@@ -172,7 +174,8 @@ public:
 			}
 		}
 
-		return is_init;
+		is_init = false;
+		return false;
 	}
 
 	DWORD GetState(DWORD userIndex, XInputStateUnion* state) override
@@ -295,7 +298,7 @@ public:
 	bool Init() override
 	{
 		if (is_init)
-			return true;
+			return *is_init;
 
 		library = LoadLibrary(L"XInput1_3.dll");
 		if (library)
@@ -316,6 +319,7 @@ public:
 			xinputGetBatteryInformation = nullptr;
 		}
 
+		is_init = false;
 		return false;
 	}
 

--- a/rpcs3/xinput_pad_handler.h
+++ b/rpcs3/xinput_pad_handler.h
@@ -55,6 +55,7 @@ class xinput_pad_handler final : public PadHandlerBase
 
 	friend class xinput_pad_processor_base; // Processors need access to XInputKeyCodes
 	friend class xinput_pad_processor_xi;
+	friend class xinput_pad_processor_scp;
 
 public:
 	xinput_pad_handler(pad_handler handler);


### PR DESCRIPTION
This PR consists of three separate commits:

- The first commit improves XInput vibration handler:
  - Old code would truncate an `int` to `u8`, which then broke `newVibrateData` checks, resulting in vibration data being treated as dirty even when it wasn't. This will decrease the amount of `XInputSetState` calls performed.
  - Corrected time interval measurements. `clock()` doesn't measure real time but rather CPU time - so those "20 milliseconds" in most cases were in fact much less than that. Now `std::chrono` is used to reliably measure time between calls. This should further decrease the amount of `XInputSetState` calls performed.
- The second commit refactors `xinput_pad_handler` to split API calls and other XInput-specific boilerplate. A big chunk of includes and definitions has been moved away from the header to the .cpp file, reducing noise in the global namespace. These changes serve as a preparation for ScpToolkit API extension support. Additionally, `xinput1_2.dll` will not be probed now, as it's an old DirectX runtime DLL which should never be used nowadays.
- The third commit implemented ScpToolkit API extension as a separate part of a XInput handler. In **Pads**, this shows as a separate handler (in order to avoid possible conflicts between non-ScpToolkit pads with ScpToolkit pads), but a big chunk of the code is shared.
![image](https://user-images.githubusercontent.com/7947461/61188064-06b11400-a67a-11e9-9b43-88545310f094.png)

This + native DS3 with Sony drivers should finally fully comply with things mentioned in #1034 