### PR TITLE
input:  keep pads intercepted while regular buttons are still pressed

### DIFF
--- a/rpcs3/pad_thread.h
+++ b/rpcs3/pad_thread.h
@@ -43,6 +43,7 @@ protected:
 	atomic_t<bool> active{ false };
 	atomic_t<bool> reset{ false };
 	atomic_t<bool> is_enabled{ true };
+	atomic_t<bool> m_is_intercepted{ false };
 	std::shared_ptr<std::thread> thread;
 };
 


### PR DESCRIPTION
The PS3 hides button presses from the game during dialogs.
This is done because the game would perceive unwanted input while the user is occupied with the dialog itself.

In order to achieve that a so called "pad interception flag" is activated and passed to the game whenever it polls pad information. On top of that the pad data that is passed to the game is basically empty.

I implemented all of this in rpcs3 already and it ***just works***.

But there is one little thing we missed.

The game Hotline Miami 2 (and maybe others) immediately activates a menu option after the prior overlay dialog was accepted. This is obviously not how it works on the console.

As it turns out - thanks to @CookiePLMonster, who noticed and tested this on the PS3 - the game didn't receive any new input after a dialog was closed until Cross, Square, Circle, Triangle, Start and Select were released (L1, L2, L3, R1, R2, R3, the dpad and the sticks didn't matter).

This pull request implements exactly this behavior.

But why wasn't this an issue in other games I tested?
My best guess is that most games handle this on their own in one way or another. I guess I'll never know.