### PR TITLE
Fix .BIN decryption filtering for case sensitive platforms

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -666,7 +666,7 @@ extern void sysutil_send_system_cmd(u64 status, u64 param);
 void main_window::DecryptSPRXLibraries()
 {
 	QString path_last_SPRX = guiSettings->GetValue(gui::fd_decrypt_sprx).toString();
-	QStringList modules = QFileDialog::getOpenFileNames(this, tr("Select binary files"), path_last_SPRX, tr("BIN files (*.bin);;SELF files (*.self);;SPRX files (*.sprx);;All Binaries (*.bin *.self *.sprx);;All files (*.*)"));
+	QStringList modules = QFileDialog::getOpenFileNames(this, tr("Select binary files"), path_last_SPRX, tr("BIN files (*.BIN);;SELF files (*.self);;SPRX files (*.sprx);;All Binaries (*.BIN *.self *.sprx);;All files (*.*)"));
 
 	if (modules.isEmpty())
 	{


### PR DESCRIPTION
Über minor fix, .BIN files weren't being filtered correctly on Linux.