### PR TITLE
Fix background icons in shader loading screen / Fix disc game titles

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -49,16 +49,12 @@ namespace rsx
 
 			if (use_custom_background)
 			{
-				auto icon_path = Emu.GetSfoDir() + "/PIC1.PNG";
-				if (!fs::exists(icon_path))
-				{
-					// Fallback path
-					icon_path = Emu.GetSfoDir() + "/ICON0.PNG";
-				}
+				const auto picture_path = Emu.GetBackgroundPicturePath();
 
-				if (fs::exists(icon_path))
+				if (fs::exists(picture_path))
 				{
-					background_image = std::make_unique<image_info>(icon_path.c_str());
+					background_image = std::make_unique<image_info>(picture_path.c_str());
+
 					if (background_image->data)
 					{
 						f32 color                    = (100 - g_cfg.video.shader_preloading_dialog.darkening_strength) / 100.f;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -492,6 +492,41 @@ const bool Emulator::SetUsr(const std::string& user)
 	return true;
 }
 
+const std::string Emulator::GetBackgroundPicturePath() const
+{
+	std::string path = m_sfo_dir + "/PIC1.PNG";
+
+	if (!fs::exists(path))
+	{
+		const std::string disc_dir = vfs::get("/dev_bdvd/PS3_GAME");
+
+		if (disc_dir.empty())
+		{
+			// Fallback to ICON0.PNG
+			path = m_sfo_dir + "/ICON0.PNG";
+		}
+		else
+		{
+			// Fallback to PIC1.PNG in disc dir
+			path = disc_dir + "/PIC1.PNG";
+
+			if (!fs::exists(path))
+			{
+				// Fallback to ICON0.PNG in update dir
+				path = m_sfo_dir + "/ICON0.PNG";
+
+				if (!fs::exists(path))
+				{
+					// Fallback to ICON0.PNG in disc dir
+					path = disc_dir + "/ICON0.PNG";
+				}
+			}
+		}
+	}
+
+	return path;
+}
+
 std::string Emulator::PPUCache() const
 {
 	const auto _main = fxm::check_unlocked<ppu_module>();

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -932,13 +932,6 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 		m_title_id = psf::get_string(_psf, "TITLE_ID");
 		m_cat = psf::get_string(_psf, "CATEGORY");
 
-		for (auto& c : m_title)
-		{
-			// Replace newlines with spaces
-			if (c == '\n')
-				c = ' ';
-		}
-
 		if (!_psf.empty() && m_cat.empty())
 		{
 			LOG_FATAL(LOADER, "Corrupted PARAM.SFO found! Assuming category GD. Try reinstalling the game.");
@@ -1353,6 +1346,27 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 			// Booting game update
 			LOG_SUCCESS(LOADER, "Updates found at /dev_hdd0/game/%s/!", m_title_id);
 			return m_path = hdd0_boot, Load();
+		}
+
+		// Set title to actual disc title if necessary
+		const std::string disc_sfo_dir = vfs::get("/dev_bdvd/PS3_GAME/PARAM.SFO");
+
+		if (!disc_sfo_dir.empty() && fs::is_file(disc_sfo_dir))
+		{
+			const std::string bdvd_title = psf::get_string(psf::load_object(fs::file{ disc_sfo_dir }), "TITLE");
+
+			if (!bdvd_title.empty() && bdvd_title != m_title)
+			{
+				LOG_NOTICE(LOADER, "Title was set from %s to %s", m_title, bdvd_title);
+				m_title = bdvd_title;
+			}
+		}
+
+		for (auto& c : m_title)
+		{
+			// Replace newlines with spaces
+			if (c == '\n')
+				c = ' ';
 		}
 
 		// Mount /host_root/ if necessary (special value)

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -328,6 +328,8 @@ public:
 
 	const bool SetUsr(const std::string& user);
 
+	const std::string GetBackgroundPicturePath() const;
+
 	u64 GetPauseTime()
 	{
 		return m_pause_amend_time;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -32,14 +32,11 @@ gs_frame::gs_frame(const QString& title, const QRect& geometry, const QIcon& app
 {
 	m_disable_mouse = gui_settings->GetValue(gui::gs_disableMouse).toBool();
 
-	// Workaround for a Qt bug affecting 5.11.1 binaries
-	//m_use_5_11_1_workaround = QLibraryInfo::version() == QVersionNumber(5, 11, 1);
-
-	//Get version by substringing VersionNumber-buildnumber-commithash to get just the part before the dash
+	// Get version by substringing VersionNumber-buildnumber-commithash to get just the part before the dash
 	std::string version = rpcs3::version.to_string();
 	version = version.substr(0 , version.find_last_of('-'));
 
-	//Add branch and commit hash to version on frame , unless it's master.
+	// Add branch and commit hash to version on frame unless it's master.
 	if ((rpcs3::get_branch().compare("master") != 0) && (rpcs3::get_branch().compare("HEAD") != 0))
 	{
 		version = version + "-" + rpcs3::version.to_string().substr((rpcs3::version.to_string().find_last_of('-') + 1), 8) + "-" + rpcs3::get_branch();


### PR DESCRIPTION
fixes #6217

**Background Icons**

This fixes the background icons during shader compilations.

The path defaulted to the directory of the PARAM.SFO that was used to boot the game. In case of updated disc games this will point to the update directory in "dev_hdd0/game" instead of the actual disc directory. This is not wrong in itself, but since we preferably load the PIC1.PNG which isn't always present in that directory, we ended up loading the ICON0.PNG with (mostly) lower resolution that was supposed to be used as a fallback.

For hdd games and others nothing changed. But for disc games we now do the following:

We still default to the PIC1.PNG in the update directory as before, but instead of choosing the ICON0.PNG in the same location as a fallback we now look for the PIC1.PNG in the actual disc location. We only look for the ICON0.PNG in the same fashion if the PIC1.PNG wasn't found.

**Disc Game Titles**

This also fixes the game titles/names throughout the emulator whenever a disc game was loaded with updates. Currently the game window would show the update data name (e.g. something like "Cool Game: Update Data" instead of "Cool Game").
If a game was detected as a disc game (it has a virtual bluray drive) then we will read the original disc's PARAM.SFO again and reset the title/name to match the actual disc.