### PR TITLE
Improvements to Virtual File System dialog

### DIFF
--- a/rpcs3/rpcs3qt/vfs_dialog.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog.cpp
@@ -5,7 +5,7 @@
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent)
-	: QDialog(parent), m_gui_settings(guiSettings), m_emu_settings(emuSettings)
+	: QDialog(parent), m_gui_settings(std::move(guiSettings)), m_emu_settings(std::move(emuSettings))
 {
 	QTabWidget* tabs = new QTabWidget();
 	tabs->setUsesScrollButtons(false);

--- a/rpcs3/rpcs3qt/vfs_dialog.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog.cpp
@@ -1,6 +1,7 @@
 #include "vfs_dialog.h"
 
 #include <QPushButton>
+#include <QMessageBox>
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
@@ -35,32 +36,23 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_pt
 	tabs->addTab(dev_usb000_tab, "dev_usb000");
 
 	// Create buttons
-	QPushButton* addDir = new QPushButton(tr("Add New Directory"));
-	connect(addDir, &QAbstractButton::clicked, [=]
-	{
-		static_cast<vfs_dialog_tab*>(tabs->currentWidget())->AddNewDirectory();
-	});
-
-	QPushButton* reset = new QPushButton(tr("Reset"));
-	connect(reset, &QAbstractButton::clicked, [=]
-	{
-		static_cast<vfs_dialog_tab*>(tabs->currentWidget())->Reset();
-	});
-
-	QPushButton* resetAll = new QPushButton(tr("Reset All"));
+	QPushButton* resetAll = new QPushButton(tr("Reset Directories"));
 	connect(resetAll, &QAbstractButton::clicked, [=]
 	{
+		if (QMessageBox::question(this, tr("Confirm Reset"), tr("Reset all file system directories?")) != QMessageBox::Yes)
+			return;
+
 		for (int i = 0; i < tabs->count(); ++i)
 		{
 			static_cast<vfs_dialog_tab*>(tabs->widget(i))->Reset();
 		}
 	});
 
-	QPushButton* okay = new QPushButton(tr("Okay"));
-	okay->setAutoDefault(true);
-	okay->setDefault(true);
+	QPushButton* save = new QPushButton(tr("Save"));
+	save->setAutoDefault(true);
+	save->setDefault(true);
 
-	connect(okay, &QAbstractButton::clicked, [=]
+	connect(save, &QAbstractButton::clicked, [=]
 	{
 		for (int i = 0; i < tabs->count(); ++i)
 		{
@@ -70,12 +62,14 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_pt
 		accept();
 	});
 
+	QPushButton* close = new QPushButton(tr("Close"));
+	connect(close, &QAbstractButton::clicked, this, &QDialog::reject);
+
 	QHBoxLayout* buttons = new QHBoxLayout;
-	buttons->addWidget(addDir);
-	buttons->addWidget(reset);
 	buttons->addWidget(resetAll);
 	buttons->addStretch();
-	buttons->addWidget(okay);
+	buttons->addWidget(save);
+	buttons->addWidget(close);
 
 	QVBoxLayout* vbox = new QVBoxLayout;
 	vbox->addWidget(tabs);

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
@@ -2,6 +2,7 @@
 
 #include <QFileDialog>
 #include <QCoreApplication>
+#include <QPushButton>
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
@@ -30,11 +31,22 @@ vfs_dialog_tab::vfs_dialog_tab(vfs_settings_info settingsInfo, std::shared_ptr<g
 
 	m_dirList->setMinimumWidth(m_dirList->sizeHintForColumn(0));
 
+	QPushButton* addDir = new QPushButton(tr("+"));
+	addDir->setFixedWidth(addDir->sizeHint().height()); // Make button square
+	connect(addDir, &QAbstractButton::clicked, this, &vfs_dialog_tab::AddNewDirectory);
+
+	QPushButton* removeDir = new QPushButton(tr("-"));
+	removeDir->setFixedWidth(removeDir->sizeHint().height()); // Make button square
+	removeDir->setEnabled(false);
+	connect(removeDir, &QAbstractButton::clicked, this, &vfs_dialog_tab::RemoveDirectory);
+
 	QHBoxLayout* selectedConfigLayout = new QHBoxLayout;
 	m_selectedConfigLabel = new QLabel(current_dir.isEmpty() ? EmptyPath : current_dir);
 	selectedConfigLayout->addWidget(new QLabel(m_info.name + tr(" directory:")));
 	selectedConfigLayout->addWidget(m_selectedConfigLabel);
 	selectedConfigLayout->addStretch();
+	selectedConfigLayout->addWidget(addDir);
+	selectedConfigLayout->addWidget(removeDir);
 
 	QVBoxLayout* vbox = new QVBoxLayout;
 	vbox->addWidget(m_dirList);
@@ -48,6 +60,12 @@ vfs_dialog_tab::vfs_dialog_tab(vfs_settings_info settingsInfo, std::shared_ptr<g
 			return;
 
 		m_selectedConfigLabel->setText(current->text().isEmpty() ? EmptyPath : current->text());
+	});
+
+	connect(m_dirList, &QListWidget::currentRowChanged, [this, removeDir](int row)
+	{
+		SetCurrentRow(row);
+		removeDir->setEnabled(row > 0);
 	});
 }
 
@@ -82,4 +100,10 @@ void vfs_dialog_tab::AddNewDirectory()
 		dir += '/';
 
 	m_dirList->setCurrentItem(new QListWidgetItem(dir, m_dirList));
+}
+
+void vfs_dialog_tab::RemoveDirectory()
+{
+	QListWidgetItem* item = m_dirList->takeItem(m_currentRow);
+	delete item;
 }

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
@@ -5,8 +5,8 @@
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
-vfs_dialog_tab::vfs_dialog_tab(const vfs_settings_info& settingsInfo, std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent)
-	: QWidget(parent), m_info(settingsInfo), m_gui_settings(guiSettings), m_emu_settings(emuSettings)
+vfs_dialog_tab::vfs_dialog_tab(vfs_settings_info settingsInfo, std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent)
+	: QWidget(parent), m_info(std::move(settingsInfo)), m_gui_settings(std::move(guiSettings)), m_emu_settings(std::move(emuSettings))
 {
 	m_dirList = new QListWidget(this);
 

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.h
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.h
@@ -26,17 +26,21 @@ public:
 	explicit vfs_dialog_tab(vfs_settings_info info, std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent = nullptr);
 
 	void SetSettings();
-	void AddNewDirectory();
 
 	// Reset this tab without saving the settings yet
 	void Reset();
 
 private:
+	void AddNewDirectory();
+	void RemoveDirectory();
+	void SetCurrentRow(int row) { m_currentRow = row; }
+
 	const QString EmptyPath = tr("Empty Path");
 
 	vfs_settings_info m_info;
 	std::shared_ptr<gui_settings> m_gui_settings;
 	std::shared_ptr<emu_settings> m_emu_settings;
+	int m_currentRow = -1;
 
 	// UI variables needed in higher scope
 	QListWidget* m_dirList;

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.h
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.h
@@ -23,7 +23,7 @@ class vfs_dialog_tab : public QWidget
 	Q_OBJECT
 
 public:
-	explicit vfs_dialog_tab(const vfs_settings_info& info, std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent = nullptr);
+	explicit vfs_dialog_tab(vfs_settings_info info, std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent = nullptr);
 
 	void SetSettings();
 	void AddNewDirectory();


### PR DESCRIPTION
This PR brings several improvements to Virtual File System dialog, both visual and technical:

- Move semantics are now used in dialog constructors, cutting down on needless copying of shared pointers passed to those.
- "Add New Directory" and "Reset" buttons have been replaced with "+" and "-" buttons. Previously, it was not possible to delete a single item from the list without resetting it.
- "Reset All" has been renamed to "Reset Directories" and a confirmation message has been added to it, so now you can't missclick and lose your settings by accident.
- "Okay" button has been renamed to "Save" to be in line with the rest of RPCS3's UI. "Close" button was also added, allowing to quit without saving settings.

Dialog before my changes:
![image](https://user-images.githubusercontent.com/7947461/61576900-4051a700-aae0-11e9-9fe2-6c3ada11c815.png)

Dialog after my changes:
![image](https://user-images.githubusercontent.com/7947461/61576882-f5d02a80-aadf-11e9-9524-211bcf9a2d18.png)
