### PR TITLE
rsx: Do not clip scissor to viewport when doing buffer clear

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -650,10 +650,10 @@ void GLGSRender::set_viewport()
 	glViewport(0, 0, clip_width, clip_height);
 }
 
-void GLGSRender::set_scissor()
+void GLGSRender::set_scissor(bool clip_viewport)
 {
 	areau scissor;
-	if (get_scissor(scissor))
+	if (get_scissor(scissor, clip_viewport))
 	{
 		// NOTE: window origin does not affect scissor region (probably only affects viewport matrix; already applied)
 		// See LIMBO [NPUB-30373] which uses shader window origin = top
@@ -1784,7 +1784,7 @@ void GLGSRender::flip(int buffer, bool emu_flip)
 		// Always restore the active framebuffer
 		m_draw_fbo->bind();
 		set_viewport();
-		set_scissor();
+		set_scissor(!!(m_graphics_state & rsx::pipeline_state::scissor_setup_clipped));
 	}
 
 	// If we are skipping the next frame, do not reset perf counters

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "Emu/RSX/GSRender.h"
 #include "GLHelpers.h"
 #include "GLTexture.h"
@@ -373,7 +373,7 @@ private:
 public:
 	void read_buffers();
 	void set_viewport();
-	void set_scissor();
+	void set_scissor(bool clip_viewport);
 
 	work_item& post_flush_request(u32 address, gl::texture_cache::thrashed_set& flush_data);
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -172,11 +172,12 @@ namespace
 
 void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool skip_reading)
 {
+	const bool clipped_scissor = (context == rsx::framebuffer_creation_context::context_draw);
 	if (m_current_framebuffer_context == context && !m_rtts_dirty && m_draw_fbo)
 	{
 		// Fast path
 		// Framebuffer usage has not changed, framebuffer exists and config regs have not changed
-		set_scissor();
+		set_scissor(clipped_scissor);
 		return;
 	}
 
@@ -196,7 +197,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		// Update flags to match current
 		m_draw_fbo->bind();
 		set_viewport();
-		set_scissor();
+		set_scissor(clipped_scissor);
 
 		return;
 	}
@@ -364,7 +365,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 
 	check_zcull_status(true);
 	set_viewport();
-	set_scissor();
+	set_scissor(clipped_scissor);
 
 	m_gl_texture_cache.clear_ro_tex_invalidate_intr();
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -76,6 +76,7 @@ namespace rsx
 		scissor_config_state_dirty = 0x200,  // Scissor region changed
 
 		scissor_setup_invalid = 0x400,       // Scissor configuration is broken
+		scissor_setup_clipped = 0x800,       // Scissor region is cropped by viewport constraint
 
 		invalidate_pipeline_bits = fragment_program_dirty | vertex_program_dirty,
 		memory_barrier_bits = framebuffer_reads_dirty,
@@ -521,7 +522,7 @@ namespace rsx
 		u32 get_zeta_surface_address() const;
 
 		framebuffer_layout get_framebuffer_layout(rsx::framebuffer_creation_context context);
-		bool get_scissor(areau& region);
+		bool get_scissor(areau& region, bool clip_viewport);
 
 		/**
 		 * Analyze vertex inputs and group all interleaved blocks

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1797,10 +1797,10 @@ void VKGSRender::set_viewport()
 	m_viewport.maxDepth = 1.f;
 }
 
-void VKGSRender::set_scissor()
+void VKGSRender::set_scissor(bool clip_viewport)
 {
 	areau scissor;
-	if (get_scissor(scissor))
+	if (get_scissor(scissor, clip_viewport))
 	{
 		m_scissor.extent.height = scissor.height();
 		m_scissor.extent.width = scissor.width();
@@ -2824,11 +2824,12 @@ void VKGSRender::open_command_buffer()
 
 void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 {
+	const bool clipped_scissor = (context == rsx::framebuffer_creation_context::context_draw);
 	if (m_current_framebuffer_context == context && !m_rtts_dirty && m_draw_fbo)
 	{
 		// Fast path
 		// Framebuffer usage has not changed, framebuffer exists and config regs have not changed
-		set_scissor();
+		set_scissor(clipped_scissor);
 		return;
 	}
 
@@ -2846,7 +2847,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	{
 		// Nothing has changed, we're still using the same framebuffer
 		// Update flags to match current
-		set_scissor();
+		set_scissor(clipped_scissor);
 		return;
 	}
 
@@ -3022,7 +3023,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	m_draw_fbo->add_ref();
 
 	set_viewport();
-	set_scissor();
+	set_scissor(clipped_scissor);
 
 	check_zcull_status(true);
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -460,7 +460,7 @@ public:
 	void read_buffers();
 	void write_buffers();
 	void set_viewport();
-	void set_scissor();
+	void set_scissor(bool clip_viewport);
 	void bind_viewport();
 
 	void sync_hint(rsx::FIFO_hint hint) override;


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/RPCS3/rpcs3/pull/6224 where buffer clears were clipped to viewport. This is not correct since the viewport only clips during rendering, not during clear operations.

Fixes https://github.com/RPCS3/rpcs3/issues/6232