### PR TITLE
Fix sys_rsx_context_iounmap partial unmapping

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include "sys_rsx.h"
 
-#include <atomic>
 #include "Emu/System.h"
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/RSX/GSRender.h"
@@ -229,7 +228,7 @@ error_code sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size)
 	while (io < end)
 	{
 		const u32 ea_entry = std::exchange(RSXIOMem.ea[io++].raw(), 0xFFFF);
-		if (ea_entry < 512) RSXIOMem.io[ea_entry].raw() = 0xFFFF;
+		if (ea_entry < 0xC00) RSXIOMem.io[ea_entry].raw() = 0xFFFF;
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -219,10 +219,11 @@ error_code sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size)
 	}
 
 	const u32 end = (io >>= 20) + (size >>= 20);
-	for (u32 ea = RSXIOMem.ea[io]; io < end;)
+
+	while (io < end)
 	{
-		RSXIOMem.io[ea++].raw() = 0xFFFF;
-		RSXIOMem.ea[io++].raw() = 0xFFFF;
+		const u32 ea_entry = std::exchange(RSXIOMem.ea[io++].raw(), 0xFFFF);
+		if (ea_entry < 512) RSXIOMem.io[ea_entry].raw() = 0xFFFF;
 	}
 
 	std::atomic_thread_fence(std::memory_order_seq_cst);

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -199,8 +199,9 @@ error_code sys_rsx_context_iomap(u32 context_id, u32 io, u32 ea, u32 size, u64 f
 
 	for (u32 i = 0; i < size; i++)
 	{
+		const u32 prev_ea = std::exchange(RSXIOMem.ea[io + i].raw(), ea + i);
+		if (prev_ea < 0xC00) RSXIOMem.io[prev_ea].raw() = 0xFFFF; // Clear previous mapping if exists
 		RSXIOMem.io[ea + i].raw() = io + i;
-		RSXIOMem.ea[io + i].raw() = ea + i;
 	}
 
 	return CELL_OK;


### PR DESCRIPTION
This fixes entry indexing when part of the targeted unmap area has already been unmapped or mapped into non-continues ea addresses (overlapping fixed address io mappings and unmappings).
I'll investigate HLE gcm fix as well in a later pr.