### PR TITLE
rsx: Surface cache fixups (part 1)

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -469,7 +469,11 @@ namespace rsx
 				auto aliased_surface = secondary_storage->find(address);
 				if (aliased_surface != secondary_storage->end())
 				{
-					old_surface = Traits::get(aliased_surface->second);
+					if (Traits::surface_is_pitch_compatible(aliased_surface->second, pitch))
+					{
+						old_surface = Traits::get(aliased_surface->second);
+						split_surface_region<!depth>(command_list, address, old_surface, (u16)width, (u16)height, bpp, antialias);
+					}
 
 					Traits::notify_surface_invalidated(aliased_surface->second);
 					invalidated_resources.push_back(std::move(aliased_surface->second));


### PR DESCRIPTION
- Fixes aliased memory surface loss when doing intersection tests. When doing memory inheritance across the DEPTH<->COLOR barrier, it was possible for data to be lost due to incomplete succession.

This was intended to be part of a larger changeset but some other investigations are holding things back a bit so I decided to go ahead and submit this as a astandalone. Continuation of work on https://github.com/RPCS3/rpcs3/issues/5983