### PR TITLE
rsx: Fix gcm unmap events

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -1308,7 +1308,7 @@ void camera_context::operator()()
 			if (time_passed >= frame_target_time)
 				break;
 
-			thread_ctrl::wait_for(frame_target_time - time_passed);
+			lv2_obj::wait_timeout(frame_target_time - time_passed);
 		}
 	}
 }

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -222,6 +222,8 @@ error_code sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size)
 		return CELL_EINVAL;
 	}
 
+	vm::reader_lock rlock;
+
 	std::scoped_lock lock(s_rsxmem_mtx);
 
 	const u32 end = (io >>= 20) + (size >>= 20);

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -68,20 +68,20 @@ struct RsxDmaControl
 	be_t<u32> unk1;
 };
 
-struct RsxSemaphore
+struct alignas(16) RsxSemaphore
 {
 	be_t<u32> val;
 	be_t<u32> pad;
 	be_t<u64> timestamp;
 };
 
-struct RsxNotify
+struct alignas(16) RsxNotify
 {
 	be_t<u64> timestamp;
 	be_t<u64> zero;
 };
 
-struct RsxReport
+struct alignas(16) RsxReport
 {
 	be_t<u64> timestamp;
 	be_t<u32> val;

--- a/rpcs3/Emu/RSX/GCM.h
+++ b/rpcs3/Emu/RSX/GCM.h
@@ -65,7 +65,7 @@ struct CellGcmSurface
 	be_t<u16> y;
 };
 
-struct CellGcmReportData
+struct alignas(16) CellGcmReportData
 {
 	be_t<u64> timer;
 	be_t<u32> value;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2340,10 +2340,7 @@ namespace rsx
 			}
 		}
 
-		vm::ptr<CellGcmReportData> result = sink;
-		result->value = value;
-		result->padding = 0;
-		result->timer = timestamp();
+		vm::_ref<atomic_t<CellGcmReportData>>(sink).store({ timestamp(), value, 0});
 	}
 
 	void thread::sync()
@@ -2819,7 +2816,7 @@ namespace rsx
 			m_cycles_delay = max_zcull_delay_us;
 		}
 
-		void ZCULL_control::write(vm::addr_t sink, u32 timestamp, u32 type, u32 value)
+		void ZCULL_control::write(vm::addr_t sink, u64 timestamp, u32 type, u32 value)
 		{
 			verify(HERE), sink;
 
@@ -2840,10 +2837,7 @@ namespace rsx
 				break;
 			}
 
-			vm::ptr<CellGcmReportData> out = sink;
-			out->value = value;
-			out->timer = timestamp;
-			out->padding = 0;
+			vm::_ref<atomic_t<CellGcmReportData>>(sink).store({ timestamp, value, 0});
 		}
 
 		void ZCULL_control::sync(::rsx::thread* ptimer)
@@ -2888,7 +2882,7 @@ namespace rsx
 
 					if (!writer.forwarder)
 						//No other queries in the chain, write result
-						write(writer.sink, (u32)ptimer->timestamp(), writer.type, result);
+						write(writer.sink, ptimer->timestamp(), writer.type, result);
 
 					processed++;
 				}
@@ -3049,7 +3043,7 @@ namespace rsx
 				//only zpass supported right now
 				if (!writer.forwarder)
 					//No other queries in the chain, write result
-					write(writer.sink, (u32)ptimer->timestamp(), writer.type, result);
+					write(writer.sink, ptimer->timestamp(), writer.type, result);
 
 				processed++;
 			}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -371,7 +371,7 @@ namespace rsx
 			void set_enabled(class ::rsx::thread* ptimer, bool state);
 			void set_active(class ::rsx::thread* ptimer, bool state);
 
-			void write(vm::addr_t sink, u32 timestamp, u32 type, u32 value);
+			void write(vm::addr_t sink, u64 timestamp, u32 type, u32 value);
 
 			// Read current zcull statistics into the address provided
 			void read_report(class ::rsx::thread* ptimer, vm::addr_t sink, u32 type);


### PR DESCRIPTION
Reversed from cellGcm gcm interrupts thread code:
* Fixed unmap key value: Unmap key has been thought to be made by `(1ull << (dealloc_size >> 20)) - 1) << (io & 63)`, but this fails to handle non-contiguous unmappings as each bit actually representing an io entry.
Now non-continues unmappings are handled correctly.

Fixed missing events in those case:
* First IO entry to be unpped is not found on the first megabyte of memory deallocated.
* Not all IO entries to be unmapped are found on the same 64 bits area, such as simply by unmapping contiguous memory mapping when `(io & 63) + (size >> 20) > 64`. 

Fixed redundent events in this case:
* After allocation and deallocation on memory which has already been unmapped, the event is sent again. (fixed by clearing `RSXIOMem.io`'s entries)

Other improvements:
* Fixed zcull timestamp, previously kept in 32 bits value resulting in constant overflows every ~4 seconds, now fixed and used the full 64 bits of timestamp.
* Semaphore updates are written atomically to ensure no fragmentation is visible and memory ordering is now sequantially consistent.
* Fixed cellCamera events per frame support with clocks scaling.