### PR TITLE
ppu: Stack size allocation improvements

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -1126,11 +1126,6 @@ s32 cellCameraSetNotifyEventQueue(u64 key)
 {
 	cellCamera.todo("cellCameraSetNotifyEventQueue(key=0x%x)", key);
 
-	if (g_cfg.io.camera == camera_handler::null)
-	{
-		return CELL_OK;
-	}
-
 	const auto g_camera = fxm::get<camera_thread>();
 	if (!g_camera)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -63,9 +63,9 @@ struct vdec_frame
 
 struct vdec_context final
 {
-	static constexpr u32 id_base = 0xf0000000;
-	static constexpr u32 id_step = 0x00000100;
-	static constexpr u32 id_count = 1024;
+	static const u32 id_base = 0xf0000000;
+	static const u32 id_step = 0x00000100;
+	static const u32 id_count = 1024;
 
 	AVCodec* codec{};
 	AVCodecContext* ctx{};

--- a/rpcs3/Emu/Cell/Modules/sys_mempool.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_mempool.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 
 #include "Utilities/StrUtil.h"
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1544,7 +1544,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	case 0x70: primary_stacksize = 1024 * 1024; break; // SYS_PROCESS_PRIMARY_STACK_SIZE_1M
 	default:
 	{
-		primary_stacksize = sz >= 4096 ? ::align(std::min<u32>(sz, 0x100000), 4096) : 0x4000;
+		primary_stacksize = ::align<u32>(std::clamp<u32>(sz, 0x10000, 0x100000), 4096);
 		break;
 	}
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_memory.h
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.h
@@ -80,7 +80,7 @@ struct lv2_memory_alloca
 {
 	static const u32 id_base = 0x1;
 	static const u32 id_step = 0x1;
-	static const u32 id_count = 0x1000;
+	static const u32 id_count = 0x2000;
 
 	const u32 size; // Memory size
 	const u32 align; // Alignment required

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -307,7 +307,7 @@ error_code _sys_ppu_thread_create(vm::ptr<u64> thread_id, vm::ptr<ppu_thread_par
 	}
 
 	// Compute actual stack size and allocate
-	const u32 stack_size = _stacksz >= 4096 ? ::align(std::min<u32>(_stacksz, 0x100000), 4096) : 0x4000;
+	const u32 stack_size = ::align<u32>(std::max<u32>(_stacksz, 4096), 4096);
 
 	const vm::addr_t stack_base{vm::alloc(stack_size, vm::stack, 4096)};
 

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -3,11 +3,11 @@
 #include "Emu/Cell/PPUThread.h"
 #include "Emu/Memory/vm_locking.h"
 
-sys_vm_t::sys_vm_t(const std::shared_ptr<vm::block_t>& area, const std::shared_ptr<lv2_memory_container>& ct, u32 psize)
+sys_vm_t::sys_vm_t(u32 _addr, u32 vsize, const std::shared_ptr<lv2_memory_container>& ct, u32 psize)
 	: ct(ct)
 	, psize(psize)
-	, addr(area->addr)
-	, size(area->size)
+	, addr(_addr)
+	, size(vsize)
 {
 	// Write ID
 	g_ids[addr >> 28].release(idm::last_id());
@@ -56,7 +56,7 @@ error_code sys_vm_memory_map(ppu_thread& ppu, u32 vsize, u32 psize, u32 cid, u64
 		// Alloc all memory (shall not fail)
 		verify(HERE), area->alloc(vsize);
 
-		idm::make<sys_vm_t>(area, ct, psize);
+		idm::make<sys_vm_t>(area->addr, vsize, ct, psize);
 
 		// Write a pointer for the allocated memory
 		*addr = area->addr;

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -16,7 +16,7 @@ sys_vm_t::sys_vm_t(const std::shared_ptr<vm::block_t>& area, const std::shared_p
 sys_vm_t::~sys_vm_t()
 {
 	// Free ID
-	g_ids[addr >> 28].release(0);
+	g_ids[addr >> 28].release(id_manager::id_traits<sys_vm_t>::invalid);
 
 	// Free block
 	verify(HERE), vm::unmap(addr);

--- a/rpcs3/Emu/Cell/lv2/sys_vm.h
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.h
@@ -41,7 +41,7 @@ struct sys_vm_t
 	u32 psize;
 	shared_mutex mutex;
 
-	sys_vm_t(const std::shared_ptr<vm::block_t>& area, const std::shared_ptr<lv2_memory_container>& ct, u32 psize);
+	sys_vm_t(u32 addr, u32 vsize, const std::shared_ptr<lv2_memory_container>& ct, u32 psize);
 	~sys_vm_t();
 
 	static std::array<atomic_t<u32>, id_count> g_ids;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -709,7 +709,7 @@ namespace vm
 		}
 
 		// Return if size is invalid
-		if (!orig_size || !size || size > this->size)
+		if (!orig_size || !size || orig_size > size || size > this->size)
 		{
 			return 0;
 		}
@@ -764,7 +764,7 @@ namespace vm
 		const u32 size = ::align(orig_size, min_page_size);
 
 		// return if addr or size is invalid
-		if (!size || addr < this->addr || addr + u64{size} > this->addr + u64{this->size} || flags & 0x10)
+		if (!size || addr < this->addr || orig_size > size || addr + u64{size} > this->addr + u64{this->size} || flags & 0x10)
 		{
 			return 0;
 		}


### PR DESCRIPTION
For `sys_ppu_thread_create`:
* Remove 1m limit for stack size, see #4517.
* Treat 0 stack size arg as 4k instead of 16k, [source](https://user-images.githubusercontent.com/18193363/61990279-13544580-b046-11e9-87d9-a97c26b6f879.png) from kernel.
* Return  `CELL_ENOMEM` for `0xffff'ffff >= stack_size > 0xffff'd000`, it could have overflowed in vm due to the addition of 2 guard pages and the alignment up, matches with the kernel as it uses u64 all the way even when adding the pages. (for the 1m limit removal)

For main thread's stack:
* Min stack size bumped to 64k.

Additional fixes:
* Fix max allocations count for debug console mode, now allowing up to 512mb / 64k allocations.
* Improved idm's ID validation checking to check `id % step`.
* idm now allows to use `UINT32_MAX` as an id (as long as id_base is non-zero).
* Fix `CELL_CAMERA_ERROR_NOT_INIT` check in `cellCameraSetNotifyEventQueue` when camera is set to null.
* Fix size of block for address boundary checking in sys_vm.
* Add CELL_EALIGN check for sys_mmaper_search_and_map when shared memory's granularity is smaller than page size. [testcase](https://github.com/elad335/myps3tests/tree/master/ppu_tests/sys_mmapper_search_and_map)