### PR TITLE
Qt: improve trophy manager icons for high dpi setups

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -504,10 +504,10 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 				game.category = sstr(category::other);
 			}
 
-			// Load Image
-			QImage img;
+			// Load ICON0.PNG
+			QPixmap icon;
 
-			if (game.icon_path.empty() || !img.load(qstr(game.icon_path)))
+			if (game.icon_path.empty() || !icon.load(qstr(game.icon_path)))
 			{
 				LOG_WARNING(GENERAL, "Could not load image from path %s", sstr(QDir(qstr(game.icon_path)).absolutePath()));
 			}
@@ -518,9 +518,9 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 			const bool hasCustomPadConfig = fs::is_file(Emulator::GetCustomInputConfigPath(game.serial));
 
 			const QColor color = getGridCompatibilityColor(compat.color);
-			const QPixmap pxmap = PaintedPixmap(img, hasCustomConfig, hasCustomPadConfig, color);
+			const QPixmap pxmap = PaintedPixmap(icon, hasCustomConfig, hasCustomPadConfig, color);
 
-			m_game_data.push_back(game_info(new gui_game_info{game, compat, img, pxmap, hasCustomConfig, hasCustomPadConfig}));
+			m_game_data.push_back(game_info(new gui_game_info{game, compat, icon, pxmap, hasCustomConfig, hasCustomPadConfig}));
 		}
 		catch (const std::exception& e)
 		{
@@ -1469,20 +1469,20 @@ void game_list_frame::BatchRemoveShaderCaches()
 	QApplication::beep();
 }
 
-QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon, bool paint_pad_config_icon, const QColor& compatibility_color)
+QPixmap game_list_frame::PaintedPixmap(const QPixmap& icon, bool paint_config_icon, bool paint_pad_config_icon, const QColor& compatibility_color)
 {
 	const int device_pixel_ratio = devicePixelRatio();
-	const QSize original_size = img.size();
+	const QSize original_size = icon.size();
 
-	QImage image = QImage(original_size * device_pixel_ratio, QImage::Format_ARGB32);
-	image.setDevicePixelRatio(device_pixel_ratio);
-	image.fill(m_Icon_Color);
+	QPixmap canvas = QPixmap(original_size * device_pixel_ratio);
+	canvas.setDevicePixelRatio(device_pixel_ratio);
+	canvas.fill(m_Icon_Color);
 
-	QPainter painter(&image);
+	QPainter painter(&canvas);
 
-	if (!img.isNull())
+	if (!icon.isNull())
 	{
-		painter.drawImage(QPoint(0, 0), img);
+		painter.drawPixmap(QPoint(0, 0), icon);
 	}
 
 	if (!m_isListLayout && (paint_config_icon || paint_pad_config_icon))
@@ -1504,9 +1504,9 @@ QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon
 			icon_path = ":/Icons/controllers_2.png";
 		}
 
-		QImage custom_config_icon(icon_path);
+		QPixmap custom_config_icon(icon_path);
 		custom_config_icon.setDevicePixelRatio(device_pixel_ratio);
-		painter.drawImage(origin, custom_config_icon.scaled(QSize(width, width) * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
+		painter.drawPixmap(origin, custom_config_icon.scaled(QSize(width, width) * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
 	}
 
 	if (compatibility_color.isValid())
@@ -1521,7 +1521,7 @@ QPixmap game_list_frame::PaintedPixmap(const QImage& img, bool paint_config_icon
 
 	painter.end();
 
-	return QPixmap::fromImage(image.scaled(m_Icon_Size * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation));
+	return canvas.scaled(m_Icon_Size * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation);
 }
 
 void game_list_frame::ShowCustomConfigIcon(QTableWidgetItem* item)

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -168,7 +168,7 @@ struct gui_game_info
 {
 	GameInfo info;
 	compat_status compat;
-	QImage icon;
+	QPixmap icon;
 	QPixmap pxmap;
 	bool hasCustomConfig;
 	bool hasCustomPadConfig;
@@ -236,7 +236,7 @@ protected:
 	void resizeEvent(QResizeEvent *event) override;
 	bool eventFilter(QObject *object, QEvent *event) override;
 private:
-	QPixmap PaintedPixmap(const QImage& img, bool paint_config_icon = false, bool paint_pad_config_icon = false, const QColor& color = QColor());
+	QPixmap PaintedPixmap(const QPixmap& icon, bool paint_config_icon = false, bool paint_pad_config_icon = false, const QColor& color = QColor());
 	QColor getGridCompatibilityColor(const QString& string);
 	void ShowCustomConfigIcon(QTableWidgetItem* item);
 	void PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color);

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -1,4 +1,4 @@
-#include "trophy_manager_dialog.h"
+﻿#include "trophy_manager_dialog.h"
 #include "custom_table_widget_item.h"
 #include "table_item_delegate.h"
 #include "qt_utils.h"
@@ -470,23 +470,22 @@ void trophy_manager_dialog::HandleRepaintUiRequest()
 void trophy_manager_dialog::ResizeGameIcon(int index)
 {
 	QTableWidgetItem* item = m_game_table->item(index, GameColumns::GameIcon);
-	const QPixmap pixmap = item->data(Qt::UserRole).value<QPixmap>();
-	const QSize original_size = pixmap.size();
+	const QPixmap icon = item->data(Qt::UserRole).value<QPixmap>();
+	const int dpr = devicePixelRatio();
 
-	QPixmap new_pixmap = QPixmap(original_size);
-	new_pixmap.fill(m_game_icon_color);
+	QPixmap new_icon = QPixmap(icon.size() * dpr);
+	new_icon.setDevicePixelRatio(dpr);
+	new_icon.fill(m_game_icon_color);
 
-	QPainter painter(&new_pixmap);
-
-	if (!pixmap.isNull())
+	if (!icon.isNull())
 	{
-		painter.drawPixmap(QPoint(0, 0), pixmap);
+		QPainter painter(&new_icon);
+		painter.drawPixmap(QPoint(0, 0), icon);
+		painter.end();
 	}
 
-	painter.end();
-
-	const QPixmap scaled = new_pixmap.scaled(m_game_icon_size, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation);
-	item->setData(Qt::DecorationRole, scaled);
+	const QPixmap scaled_icon = new_icon.scaled(m_game_icon_size * dpr, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation);
+	item->setData(Qt::DecorationRole, scaled_icon);
 }
 
 void trophy_manager_dialog::ResizeGameIcons()
@@ -507,12 +506,27 @@ void trophy_manager_dialog::ResizeTrophyIcons()
 	if (m_game_combo->count() <= 0)
 		return;
 
-	int db_pos = m_game_combo->currentData().toInt();
+	const int db_pos = m_game_combo->currentData().toInt();
+	const int dpr = devicePixelRatio();
+	const int new_height = m_icon_height * dpr;
 
 	for (int i = 0; i < m_trophy_table->rowCount(); ++i)
 	{
-		int trophy_id = m_trophy_table->item(i, TrophyColumns::Id)->text().toInt();
-		QPixmap scaled = m_trophies_db[db_pos]->trophy_images[trophy_id].scaledToHeight(m_icon_height, Qt::SmoothTransformation);
+		const int trophy_id = m_trophy_table->item(i, TrophyColumns::Id)->text().toInt();
+		const QPixmap icon = m_trophies_db[db_pos]->trophy_images[trophy_id];
+
+		QPixmap new_icon = QPixmap(icon.size() * dpr);
+		new_icon.setDevicePixelRatio(dpr);
+		new_icon.fill(m_game_icon_color);
+
+		if (!icon.isNull())
+		{
+			QPainter painter(&new_icon);
+			painter.drawPixmap(QPoint(0, 0), icon);
+			painter.end();
+		}
+
+		const QPixmap scaled = new_icon.scaledToHeight(new_height, Qt::SmoothTransformation);
 		m_trophy_table->item(i, TrophyColumns::Icon)->setData(Qt::DecorationRole, scaled);
 	}
 


### PR DESCRIPTION
Added a small simplification to the game list icon logic. I hope this will be slightly faster. If it is slower for some reason then I will revert this commit.
So please test the icon resize in the game list if you have a huge amount of games (normal screen OR high dpi screen).

Added the high dpi improvements that can already be seen in the game list and in the save data manager to the trophy manager.

Added the background icon color that is already used for the game icons to the trophy icons.

Comparison: (Note my custom black background color on the trophy icons)

![comparison](https://user-images.githubusercontent.com/23019877/61992974-9638c880-b065-11e9-9208-0c6ae0662448.png)
