### PR TITLE
sys_vm: Fix sys_vm_invalidate

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -259,7 +259,6 @@ error_code sys_vm_invalidate(ppu_thread& ppu, u32 addr, u32 size)
 		return CELL_EINVAL;
 	}
 
-	std::memset(vm::base(addr), 0, size);
 	return CELL_OK;
 }
 


### PR DESCRIPTION
Do not zero-out contents of targeted memory.
Heres the testcase https://github.com/elad335/myps3tests/blob/master/ppu_tests/sys_vm_invalidate/ppumain.cpp.

Testing contents of sys_vm memory after first run, after a second sys_vm_touch and after sys_vm_invalidate by reading 4 bytes from different places.
Results: sys_vm_invalidate does not clear memory contents.
