### PR TITLE
vk: Clarify RADV llvm 8.0.0 warning 

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -535,11 +535,11 @@ private:
 			LOG_NOTICE(RSX, "Found vulkan-compatible GPU: '%s' running on driver %s", get_name(), get_driver_version());
 
 			if (get_driver_vendor() == driver_vendor::RADV &&
-				get_name().find("LLVM 8") != std::string::npos)
+				get_name().find("LLVM 8.0.0") != std::string::npos)
 			{
 				// Serious driver bug causing black screens
 				// See https://bugs.freedesktop.org/show_bug.cgi?id=110970
-				LOG_FATAL(RSX, "RADV drivers have a major driver bug with LLVM 8 resulting in no visual output. Upgrade to LLVM 9 version of mesa to avoid this issue.");
+				LOG_FATAL(RSX, "RADV drivers have a major driver bug with LLVM 8.0.0 resulting in no visual output. Upgrade to LLVM version 8.0.1 or greater to avoid this issue.");
 			}
 
 #ifndef _WIN32


### PR DESCRIPTION
The "black screen" issue that RADV users experienced with LLVM 8.0.0 was resolved in LLVM 8.0.1
So let's not warn users that have 8.0.1 installed.