### PR TITLE
rsx: Conditional render sync optimization

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3095,5 +3095,16 @@ namespace rsx
 				update(ptimer, sync_address);
 			}
 		}
+
+		occlusion_query_info* ZCULL_control::find_query(vm::addr_t sink_address)
+		{
+			for (auto &writer : m_pending_writes)
+			{
+				if (writer.sink == sink_address)
+					return writer.query;
+			}
+
+			return nullptr;
+		}
 	}
 }

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -397,6 +397,9 @@ namespace rsx
 			// Check for pending writes
 			bool has_pending() const { return !m_pending_writes.empty(); }
 
+			// Search for query synchronized at address
+			occlusion_query_info* find_query(vm::addr_t sink_address);
+
 			// Backend methods (optional, will return everything as always visible by default)
 			virtual void begin_occlusion_query(occlusion_query_info* /*query*/) {}
 			virtual void end_occlusion_query(occlusion_query_info* /*query*/) {}
@@ -614,7 +617,7 @@ namespace rsx
 		// sync
 		void sync();
 		void read_barrier(u32 memory_address, u32 memory_range);
-		virtual void sync_hint(FIFO_hint /*hint*/) {}
+		virtual void sync_hint(FIFO_hint /*hint*/, u32 /*arg*/) {}
 
 		gsl::span<const gsl::byte> get_raw_index_array(const draw_clause& draw_indexed_clause) const;
 		gsl::span<const gsl::byte> get_raw_vertex_buffer(const rsx::data_array_format_info&, u32 base_offset, const draw_clause& draw_array_clause) const;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -463,7 +463,7 @@ public:
 	void set_scissor(bool clip_viewport);
 	void bind_viewport();
 
-	void sync_hint(rsx::FIFO_hint hint) override;
+	void sync_hint(rsx::FIFO_hint hint, u32 arg) override;
 
 	void begin_occlusion_query(rsx::reports::occlusion_query_info* query) override;
 	void end_occlusion_query(rsx::reports::occlusion_query_info* query) override;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -581,7 +581,7 @@ namespace rsx
 			}
 
 			// Defer conditional render evaluation
-			rsx->sync_hint(FIFO_hint::hint_conditional_render_eval);
+			rsx->sync_hint(FIFO_hint::hint_conditional_render_eval, address_ptr);
 			rsx->conditional_render_test_address = address_ptr;
 			rsx->conditional_render_test_failed = false;
 		}


### PR DESCRIPTION
ZCULL queue was updated to one-per-cb but the conditional render sync hint was not updated.
Changes:
- Do not unconditionally flush the queue unless the upcoming ref is contained in the active CB. This avoids spamming queue flush, which frees up resources and improves performance by evading a GPU hard sync.