### PR TITLE
Accuracy improvements and some bugfixes

### DIFF
--- a/Utilities/Config.h
+++ b/Utilities/Config.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Utilities/types.h"
 #include "Utilities/StrFmt.h"
@@ -234,6 +234,10 @@ namespace cfg
 
 	public:
 		int_type def;
+
+		// Expose range
+		static const s64 max = Max;
+		static const s64 min = Min;
 
 		_int(node* owner, const std::string& name, int_type def = std::min<int_type>(Max, std::max<int_type>(Min, 0)))
 			: _base(type::_int, owner, name)

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1541,30 +1541,37 @@ const std::string& fs::get_cache_dir()
 
 bool fs::remove_all(const std::string& path, bool remove_root)
 {
-	for (const auto& entry : dir(path))
+	if (const auto root_dir = dir(path))
 	{
-		if (entry.name == "." || entry.name == "..")
+		for (const auto& entry : root_dir)
 		{
-			continue;
-		}
-
-		if (entry.is_directory == false)
-		{
-			if (!remove_file(path + '/' + entry.name))
+			if (entry.name == "." || entry.name == "..")
 			{
-				return false;
+				continue;
 			}
-		}
 
-		if (entry.is_directory == true)
-		{
-			if (!remove_all(path + '/' + entry.name))
+			if (entry.is_directory == false)
 			{
-				return false;
+				if (!remove_file(path + '/' + entry.name))
+				{
+					return false;
+				}
+			}
+
+			if (entry.is_directory == true)
+			{
+				if (!remove_all(path + '/' + entry.name))
+				{
+					return false;
+				}
 			}
 		}
 	}
-
+	else
+	{
+		return false;
+	}
+	
 	if (remove_root)
 	{
 		return remove_dir(path);

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -2577,7 +2577,7 @@ s32 _cellSpursWorkloadFlagReceiver(vm::ptr<CellSpurs> spurs, u32 wid, u32 is_set
 		return CELL_SPURS_POLICY_MODULE_ERROR_STAT;
 	}
 
-	std::atomic_thread_fence(std::memory_order_seq_cst);
+	std::atomic_thread_fence(std::memory_order_acq_rel);
 
 	if (s32 res = spurs->wklFlag.flag.atomic_op([spurs, wid, is_set](be_t<u32>& flag) -> s32
 	{

--- a/rpcs3/Emu/Cell/Modules/cellSync.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSync.cpp
@@ -87,7 +87,7 @@ error_code cellSyncMutexLock(ppu_thread& ppu, vm::ptr<CellSyncMutex> mutex)
 		}
 	}
 
-	std::atomic_thread_fence(std::memory_order_release);
+	std::atomic_thread_fence(std::memory_order_acq_rel);
 	return CELL_OK;
 }
 
@@ -196,7 +196,7 @@ error_code cellSyncBarrierTryNotify(vm::ptr<CellSyncBarrier> barrier)
 		return CELL_SYNC_ERROR_ALIGN;
 	}
 
-	std::atomic_thread_fence(std::memory_order_release);
+	std::atomic_thread_fence(std::memory_order_acq_rel);
 
 	if (!barrier->ctrl.atomic_op<&CellSyncBarrier::try_notify>())
 	{
@@ -220,7 +220,7 @@ error_code cellSyncBarrierWait(ppu_thread& ppu, vm::ptr<CellSyncBarrier> barrier
 		return CELL_SYNC_ERROR_ALIGN;
 	}
 
-	std::atomic_thread_fence(std::memory_order_release);
+	std::atomic_thread_fence(std::memory_order_acq_rel);
 
 	while (!barrier->ctrl.atomic_op<&CellSyncBarrier::try_wait>())
 	{
@@ -247,7 +247,7 @@ error_code cellSyncBarrierTryWait(vm::ptr<CellSyncBarrier> barrier)
 		return CELL_SYNC_ERROR_ALIGN;
 	}
 
-	std::atomic_thread_fence(std::memory_order_release);
+	std::atomic_thread_fence(std::memory_order_acq_rel);
 
 	if (!barrier->ctrl.atomic_op<&CellSyncBarrier::try_wait>())
 	{
@@ -281,7 +281,7 @@ error_code cellSyncRwmInitialize(vm::ptr<CellSyncRwm> rwm, vm::ptr<void> buffer,
 	rwm->size = buffer_size;
 	rwm->buffer = buffer;
 
-	std::atomic_thread_fence(std::memory_order_release);
+	std::atomic_thread_fence(std::memory_order_acq_rel);
 
 	return CELL_OK;
 }
@@ -453,7 +453,7 @@ error_code cellSyncQueueInitialize(vm::ptr<CellSyncQueue> queue, vm::ptr<u8> buf
 	queue->depth = depth;
 	queue->buffer = buffer;
 
-	std::atomic_thread_fence(std::memory_order_release);
+	std::atomic_thread_fence(std::memory_order_acq_rel);
 
 	return CELL_OK;
 }
@@ -866,7 +866,7 @@ error_code cellSyncLFQueueInitialize(vm::ptr<CellSyncLFQueue> queue, vm::cptr<vo
 			}
 		}
 
-		std::atomic_thread_fence(std::memory_order_release);
+		std::atomic_thread_fence(std::memory_order_acq_rel);
 	}
 	else
 	{

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -594,7 +594,7 @@ s32 cellVdecGetPicture(u32 handle, vm::cptr<CellVdecPicFormat> format, vm::ptr<u
 	if (notify)
 	{
 		auto vdec_ppu = idm::get<named_thread<ppu_thread>>(vdec->ppu_tid);
-		thread_ctrl::notify(*vdec_ppu);
+		if (vdec_ppu) thread_ctrl::notify(*vdec_ppu);
 	}
 
 	if (outBuff)

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -395,7 +395,7 @@ static void vdecEntry(ppu_thread& ppu, u32 vid)
 {
 	idm::get<vdec_context>(vid)->exec(ppu, vid);
 
-	_sys_ppu_thread_exit(ppu, 0);
+	ppu.state += cpu_flag::exit;
 }
 
 static u32 vdecQueryAttr(s32 type, u32 profile, u32 spec_addr /* may be 0 */, vm::ptr<CellVdecAttr> attr)

--- a/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
@@ -130,7 +130,7 @@ error_code sys_lwmutex_lock(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex, u64
 
 		// recursive locking succeeded
 		lwmutex->recursive_count++;
-		std::atomic_thread_fence(std::memory_order_release);
+		std::atomic_thread_fence(std::memory_order_acq_rel);
 
 		return CELL_OK;
 	}
@@ -290,7 +290,7 @@ error_code sys_lwmutex_trylock(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex)
 
 		// recursive locking succeeded
 		lwmutex->recursive_count++;
-		std::atomic_thread_fence(std::memory_order_release);
+		std::atomic_thread_fence(std::memory_order_acq_rel);
 
 		return CELL_OK;
 	}

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -3266,7 +3266,7 @@ bool ppu_interpreter::CNTLZW(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::SLD(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const u32 n = ppu.gpr[op.rb];
+	const u32 n = ppu.gpr[op.rb] & 0x7f;
 	ppu.gpr[op.ra] = UNLIKELY(n & 0x40) ? 0 : ppu.gpr[op.rs] << n;
 	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
@@ -3985,7 +3985,7 @@ bool ppu_interpreter::SRW(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::SRD(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const u32 n = ppu.gpr[op.rb];
+	const u32 n = ppu.gpr[op.rb] & 0x7f;
 	ppu.gpr[op.ra] = UNLIKELY(n & 0x40) ? 0 : ppu.gpr[op.rs] >> n;
 	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -650,7 +650,7 @@ void ppu_thread::exec_task()
 			return reinterpret_cast<func_t>((uptr)(u32)op)(*this, {u32(op >> 32)});
 		};
 
-		if (cia % 8 || !s_use_ssse3 || UNLIKELY(state))
+		if (cia % 8 || UNLIKELY(state))
 		{
 			if (test_stopped()) return;
 

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -3106,8 +3106,8 @@ void PPUTranslator::LFSUX(ppu_opcode_t op)
 void PPUTranslator::SYNC(ppu_opcode_t op)
 {
 	// sync: Full seq cst barrier
-	// lwsync: Release barrier
-	m_ir->CreateFence(op.l10 ? AtomicOrdering::Release : AtomicOrdering::SequentiallyConsistent);
+	// lwsync: Acq/Release barrier
+	m_ir->CreateFence(op.l10 ? AtomicOrdering::AcquireRelease : AtomicOrdering::SequentiallyConsistent);
 }
 
 void PPUTranslator::LFDX(ppu_opcode_t op)

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -4004,11 +4004,8 @@ void PPUTranslator::FRSP(ppu_opcode_t op)
 void PPUTranslator::FCTIW(ppu_opcode_t op)
 {
 	const auto b = GetFpr(op.frb);
-	//const auto sat_l = m_ir->CreateFCmpULT(b, ConstantFP::get(GetType<f64>(), -std::pow(2, 31))); // TODO ???
-	//const auto sat_h = m_ir->CreateFCmpOGE(b, ConstantFP::get(GetType<f64>(), std::pow(2, 31)));
-	//const auto converted = m_ir->CreateFPToSI(FP_SAT_OP(sat_l, b), GetType<s64>());
-	//SetFpr(op.frd, m_ir->CreateSelect(sat_h, m_ir->getInt64(0x7fffffff), converted));
-	SetFpr(op.frd, Call(GetType<s32>(), "llvm.x86.sse2.cvtsd2si", m_ir->CreateInsertElement(GetUndef<f64[2]>(), b, uint64_t{0})));
+	SetFpr(op.frd, m_ir->CreateSelect(m_ir->CreateFCmpOGE(b, ConstantFP::get(GetType<f64>(), f64(INT32_MAX))), m_ir->getInt32(INT32_MAX), 
+	Call(GetType<s32>(), "llvm.x86.sse2.cvtsd2si", m_ir->CreateInsertElement(GetUndef<f64[2]>(), b, u64{0}))));
 
 	//SetFPSCR_FR(Call(GetType<bool>(), m_pure_attr, "__fctiw_get_fr", b));
 	//SetFPSCR_FI(Call(GetType<bool>(), m_pure_attr, "__fctiw_get_fi", b));
@@ -4021,7 +4018,10 @@ void PPUTranslator::FCTIW(ppu_opcode_t op)
 void PPUTranslator::FCTIWZ(ppu_opcode_t op)
 {
 	const auto b = GetFpr(op.frb);
-	SetFpr(op.frd, Call(GetType<s32>(), "llvm.x86.sse2.cvttsd2si", m_ir->CreateInsertElement(GetUndef<f64[2]>(), b, uint64_t{0})));
+	const auto xormask = m_ir->CreateSExt(m_ir->CreateFCmpOGE(b, ConstantFP::get(GetType<f64>(), std::exp2l(31.))), GetType<s32>());
+
+	// fix result saturation (0x80000000 -> 0x7fffffff)
+	SetFpr(op.frd, m_ir->CreateXor(xormask, Call(GetType<s32>(), "llvm.x86.sse2.cvttsd2si", m_ir->CreateInsertElement(GetUndef<f64[2]>(), b, u64{0}))));
 }
 
 void PPUTranslator::FDIV(ppu_opcode_t op)
@@ -4248,11 +4248,10 @@ void PPUTranslator::FABS(ppu_opcode_t op)
 void PPUTranslator::FCTID(ppu_opcode_t op)
 {
 	const auto b = GetFpr(op.frb);
-	//const auto sat_l = m_ir->CreateFCmpULT(b, ConstantFP::get(GetType<f64>(), -std::pow(2, 63)));
-	//const auto sat_h = m_ir->CreateFCmpOGE(b, ConstantFP::get(GetType<f64>(), std::pow(2, 63)));
-	//const auto converted = m_ir->CreateFPToSI(FP_SAT_OP(sat_l, b), GetType<s64>());
-	//SetFpr(op.frd, m_ir->CreateSelect(sat_h, m_ir->getInt64(0x7fffffffffffffff), converted));
-	SetFpr(op.frd, Call(GetType<s64>(), "llvm.x86.sse2.cvtsd2si64", m_ir->CreateInsertElement(GetUndef<f64[2]>(), b, uint64_t{0})));
+	const auto xormask = m_ir->CreateSExt(m_ir->CreateFCmpOGE(b, ConstantFP::get(GetType<f64>(), std::exp2l(31.))), GetType<s64>());
+
+	// fix result saturation (0x8000000000000000 -> 0x7fffffffffffffff)
+	SetFpr(op.frd, m_ir->CreateXor(xormask, Call(GetType<s64>(), "llvm.x86.sse2.cvtsd2si64", m_ir->CreateInsertElement(GetUndef<f64[2]>(), b, u64{0}))));
 
 	//SetFPSCR_FR(Call(GetType<bool>(), m_pure_attr, "__fctid_get_fr", b));
 	//SetFPSCR_FI(Call(GetType<bool>(), m_pure_attr, "__fctid_get_fi", b));
@@ -4265,7 +4264,10 @@ void PPUTranslator::FCTID(ppu_opcode_t op)
 void PPUTranslator::FCTIDZ(ppu_opcode_t op)
 {
 	const auto b = GetFpr(op.frb);
-	SetFpr(op.frd, Call(GetType<s64>(), "llvm.x86.sse2.cvttsd2si64", m_ir->CreateInsertElement(GetUndef<f64[2]>(), b, uint64_t{0})));
+	const auto xormask = m_ir->CreateSExt(m_ir->CreateFCmpOGE(b, ConstantFP::get(GetType<f64>(), std::exp2l(31.))), GetType<s64>());
+
+	// fix result saturation (0x8000000000000000 -> 0x7fffffffffffffff)
+	SetFpr(op.frd, m_ir->CreateXor(xormask, Call(GetType<s64>(), "llvm.x86.sse2.cvttsd2si64", m_ir->CreateInsertElement(GetUndef<f64[2]>(), b, u64{0}))));
 }
 
 void PPUTranslator::FCFID(ppu_opcode_t op)

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -486,7 +486,7 @@ error_code sys_mmapper_enable_page_fault_notification(ppu_thread& ppu, u32 start
 	return CELL_OK;
 }
 
-CellError mmapper_thread_recover_page_fault(u32 id)
+error_code mmapper_thread_recover_page_fault(u32 id)
 {
 	// We can only wake a thread if it is being suspended for a page fault.
 	auto pf_events = fxm::get_always<page_fault_event_entries>();
@@ -504,5 +504,5 @@ CellError mmapper_thread_recover_page_fault(u32 id)
 	}
 
 	pf_events->cond.notify_all();
-	return CellError(CELL_OK);
+	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.h
@@ -62,7 +62,7 @@ struct page_fault_event_entries
 // Aux
 class ppu_thread;
 
-CellError mmapper_thread_recover_page_fault(u32 id);
+error_code mmapper_thread_recover_page_fault(u32 id);
 
 // SysCalls
 error_code sys_mmapper_allocate_address(ppu_thread&, u64 size, u64 flags, u64 alignment, vm::ptr<u32> alloc_addr);

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -434,12 +434,7 @@ error_code sys_ppu_thread_recover_page_fault(u32 thread_id)
 		return CELL_ESRCH;
 	}
 
-	if (auto res = mmapper_thread_recover_page_fault(thread_id))
-	{
-		return res;
-	}
-
-	return CELL_OK;
+	return mmapper_thread_recover_page_fault(thread_id);
 }
 
 error_code sys_ppu_thread_get_page_fault_context(u32 thread_id, vm::ptr<sys_ppu_thread_icontext_t> ctxt)

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1355,12 +1355,7 @@ error_code sys_spu_thread_recover_page_fault(ppu_thread& ppu, u32 id)
 		return CELL_ESRCH;
 	}
 
-	if (auto res = mmapper_thread_recover_page_fault(id))
-	{
-		return res;
-	}
-
-	return CELL_OK;
+	return mmapper_thread_recover_page_fault(id);
 }
 
 error_code sys_raw_spu_recover_page_fault(ppu_thread& ppu, u32 id)
@@ -1376,12 +1371,7 @@ error_code sys_raw_spu_recover_page_fault(ppu_thread& ppu, u32 id)
 		return CELL_ESRCH;
 	}
 
-	if (auto res = mmapper_thread_recover_page_fault(id))
-	{
-		return res;
-	}
-
-	return CELL_OK;
+	return mmapper_thread_recover_page_fault(id);
 }
 
 error_code sys_raw_spu_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<void> attr)

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -218,7 +218,9 @@ struct lv2_obj
 	template<bool is_usleep = false>
 	static bool wait_timeout(u64 usec, cpu_thread* const cpu = nullptr)
 	{
-		// Clamp to max timeout accepted (also solves potential oveflows when scaling)
+		static_assert(UINT64_MAX / cond_variable::max_timeout >= g_cfg.core.clocks_scale.max, "timeout may overflow during scaling");
+
+		// Clamp to max timeout accepted
 		if (usec > cond_variable::max_timeout) usec = cond_variable::max_timeout;
 
 		// Now scale the result

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -66,7 +66,7 @@ namespace vm
 	atomic_t<u32> g_addr_lock = 0;
 
 	// Memory mutex: passive locks
-	std::array<atomic_t<cpu_thread*>, 4> g_locks{};
+	std::array<atomic_t<cpu_thread*>, g_cfg.core.ppu_threads.max> g_locks{};
 	std::array<atomic_t<u64>, 6> g_range_locks{};
 
 	static void _register_lock(cpu_thread* _cpu)

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -913,7 +913,7 @@ namespace vm
 
 	static std::shared_ptr<block_t> _find_map(u32 size, u32 align, u64 flags)
 	{
-		for (u32 addr = ::align<u32>(0x20000000, align); addr < 0xC0000000; addr += align)
+		for (u32 addr = ::align<u32>(0x20000000, align); addr - 1 < 0xC0000000 - 1; addr += align)
 		{
 			if (_test_map(addr, size))
 			{


### PR DESCRIPTION
* Fix FCTIW, FCTIWZ, FCTID and FCTIDZ instructions handling when float rounds to an integer bigger than INT(dest type)_MAX.
* Fix shift count in SRD and SLD instruction's ppu interpreter implementation by masking the shift count with 127 (UB fix).
* Make sys_get_current_time() scale time relatively to emulator startup instead of Epoch.
* Cleanup error_code conversations in mmapper_thread_recover_page_fault's usage.
* Fix an infinite loop when vm::find_map fails to find a location after the first try with alignment 0x8000'0000.
* Expose range of min/max integral settings for constexpr context usage, such as for size of array or static_assert.
* Remove an obsolete SSSE3 check from ppu interpreter main loop.
* Block reoredering of load after load in LWSYNC and places in hle code where its used.
* Fix potential nullptr deref in cellVdecGetPicture (vdec thread was removed externally).
* Fix race condition on TLS deallocation of cellVdec's interrupt thread. (sys_interrupt...disestablish returns ESRCH)
* Avoid using sys_ppu_thread_exit on interrupt threads on join before exit.