### PR TITLE
Qt: select custom configs when opening the custom config folder

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -657,7 +657,24 @@ void game_list_frame::SaveSettings()
 static void open_dir(const std::string& spath)
 {
 	fs::create_dir(spath);
-	QString path = qstr(spath);
+	const QString path = qstr(spath);
+
+	if (fs::is_file(spath))
+	{
+		// open directory and select file
+		// https://stackoverflow.com/questions/3490336/how-to-reveal-in-finder-or-show-in-explorer-with-qt
+#ifdef _WIN32
+		QProcess::startDetached("explorer.exe", { "/select,", QDir::toNativeSeparators(path) });
+#elif defined(__APPLE__)
+		QProcess::execute("/usr/bin/osascript", { "-e", "tell application \"Finder\" to reveal POSIX file \"" + path + "\"" });
+		QProcess::execute("/usr/bin/osascript", { "-e", "tell application \"Finder\" to activate" });
+#else
+		// open parent directory
+		QDesktopServices::openUrl(QUrl("file:///" + qstr(fs::get_parent_dir(spath))));
+#endif
+		return;
+	}
+
 	QDesktopServices::openUrl(QUrl("file:///" + path));
 }
 
@@ -807,11 +824,15 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		QAction* open_config_dir = myMenu.addAction(tr("&Open Custom Config Folder"));
 		connect(open_config_dir, &QAction::triggered, [=]()
 		{
-			if (fs::is_file(Emulator::GetCustomConfigPath(currGame.serial)))
-				open_dir(Emulator::GetCustomConfigDir());
+			const std::string new_config_path = Emulator::GetCustomConfigPath(currGame.serial);
 
-			if (fs::is_file(Emulator::GetCustomConfigPath(currGame.serial, true)))
-				open_dir(data_base_dir);
+			if (fs::is_file(new_config_path))
+				open_dir(new_config_path);
+
+			const std::string old_config_path = Emulator::GetCustomConfigPath(currGame.serial, true);
+
+			if (fs::is_file(old_config_path))
+				open_dir(old_config_path);
 		});
 	}
 	if (fs::is_dir(data_base_dir))


### PR DESCRIPTION
Instead of simply opening the directory when using "Open Custom Config Folder" in the game list this should now also select the proper file in the explorer on windows and in the finder on macos respectively.

On other operating systems this will fallback to opening the parent directory as before.