### PR TITLE
Add setting for locking mouse cursor to game window

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -613,6 +613,7 @@ struct cfg_root : cfg::node
 		cfg::_bool show_trophy_popups{ this, "Show trophy popups", true};
 		cfg::_bool show_shader_compilation_hint{ this, "Show shader compilation hint", true };
 		cfg::_bool use_native_interface{ this, "Use native user interface", true };
+		cfg::_bool lock_mouse_in_fullscreen{ this, "Lock mouse cursor to window in fullscreen", false };
 		cfg::_int<1, 65535> gdb_server_port{this, "Port", 2345};
 
 	} misc{this};

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -79,7 +79,8 @@
 			"gs_disableMouse": "Disables the activation of fullscreen mode per double-click while the game screen is active.\nCheck this if you want to play with mouse and keyboard (for example with UCR).",
 			"maxLLVMThreads": "Limits the maximum number of threads used for PPU Module compilation.\nLower this in order to increase performance of other open applications.\nThe default uses all available threads.",
 			"showShaderCompilationHint": "Show shader compilation hints using the native overlay.",
-			"useNativeInterface": "Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, only the English language is supported."
+			"useNativeInterface": "Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, only the English language is supported.",
+			"lockMouseInFullscreen": "Prevents mouse cursor from escaping the game window when using fullscreen."
 		},
 		"overlay": {
 			"perfOverlayEnabled": "Enables or disables the performance overlay.",

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -129,6 +129,7 @@ public:
 		ShowWelcomeScreen,
 		UseNativeInterface,
 		ShowShaderCompilationHint,
+		LockMouseToWindow,
 
 		// Network
 		ConnectionStatus,
@@ -356,6 +357,7 @@ private:
 		{ ShowWelcomeScreen,         { "Miscellaneous", "Show Welcome Screen"}},
 		{ UseNativeInterface,        { "Miscellaneous", "Use native user interface"}},
 		{ ShowShaderCompilationHint, { "Miscellaneous", "Show shader compilation hint"}},
+		{ LockMouseToWindow,         { "Miscellaneous", "Lock mouse cursor to window in fullscreen"}},
 
 		// Networking
 		{ ConnectionStatus, { "Net", "Connection status"}},

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -23,6 +23,8 @@ class gs_frame : public QWindow, public GSFrameBase
 	Q_OBJECT
 
 private:
+	void set_cursor_lock(bool locked);
+
 	// taskbar progress
 	int m_gauge_max = 100;
 #ifdef _WIN32

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1078,6 +1078,14 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xemu_settings->EnhanceCheckBox(ui->showShaderCompilationHint, emu_settings::ShowShaderCompilationHint);
 	SubscribeTooltip(ui->showShaderCompilationHint, json_emu_misc["showShaderCompilationHint"].toString());
 
+#ifdef _WIN32
+	xemu_settings->EnhanceCheckBox(ui->lockMouseToWindow, emu_settings::LockMouseToWindow);
+	SubscribeTooltip(ui->lockMouseToWindow, json_emu_misc["lockMouseInFullscreen"].toString());
+#else
+	ui->lockMouseToWindow->setDisabled(true);
+	SubscribeTooltip(ui->lockMouseToWindow, tr("This setting has not been implemented for your OS."));
+#endif
+
 	xemu_settings->EnhanceCheckBox(ui->perfOverlayCenterX, emu_settings::PerfOverlayCenterX);
 	SubscribeTooltip(ui->perfOverlayCenterX, json_emu_overlay["perfOverlayCenterX"].toString());
 	connect(ui->perfOverlayCenterX, &QCheckBox::clicked, [this](bool checked)

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1616,6 +1616,13 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="lockMouseToWindow">
+                <property name="text">
+                 <string>Lock mouse cursor to window in fullscreen</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <spacer name="verticalSpacer_13">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -971,7 +971,7 @@
          <property name="title">
           <string>Microphone Settings</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_76">
+         <layout class="QVBoxLayout" name="verticalLayout_82">
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_7">
             <item>
@@ -1005,7 +1005,7 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_6">
             <item>
-             <layout class="QVBoxLayout" name="verticalLayout_77">
+             <layout class="QVBoxLayout" name="verticalLayout_81">
               <item>
                <widget class="QLabel" name="label_3">
                 <property name="sizePolicy">


### PR DESCRIPTION
Adds a setting that prevents cursor from leaving the game window when in fullscreen. Windows only, someone else can add x11/wayland/mac implementations.

Also cleans up two warnings from settings_dialog.ui that were added with the microphone PR.