### PR TITLE
Add new library loading modes

### DIFF
--- a/Utilities/GDBDebugServer.cpp
+++ b/Utilities/GDBDebugServer.cpp
@@ -567,7 +567,7 @@ bool GDBDebugServer::cmd_write_memory(gdb_cmd & cmd)
 	u32 len = hex_to_u32(cmd.data.substr(s + 1, s2 - s - 1));
 	const char* data_ptr = (cmd.data.c_str()) + s2 + 1;
 	for (u32 i = 0; i < len; ++i) {
-		if (vm::check_addr(addr + i, 1, vm::page_allocated | vm::page_writable)) {
+		if (vm::check_addr(addr + i, 1, vm::page_writable)) {
 			u8 val;
 			int res = sscanf_s(data_ptr, "%02hhX", &val);
 			if (!res) {

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1273,7 +1273,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 		return true;
 	}
 
-	if (vm::check_addr(addr, std::max<std::size_t>(1, d_size), vm::page_allocated | (is_writing ? vm::page_writable : vm::page_readable)))
+	if (vm::check_addr(addr, std::max<std::size_t>(1, d_size), is_writing ? vm::page_writable : vm::page_readable))
 	{
 		if (cpu && cpu->test_stopped())
 		{
@@ -1328,12 +1328,12 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 			u64 data3;
 			{
 				vm::reader_lock rlock;
-				if (vm::check_addr(addr, std::max<std::size_t>(1, d_size), vm::page_allocated | (is_writing ? vm::page_writable : vm::page_readable)))
+				if (vm::check_addr(addr, std::max<std::size_t>(1, d_size), is_writing ? vm::page_writable : vm::page_readable))
 				{
 					// Memory was allocated inbetween, retry
 					return true;
 				}
-				else if (vm::check_addr(addr, std::max<std::size_t>(1, d_size), vm::page_allocated | vm::page_readable))
+				else if (vm::check_addr(addr, std::max<std::size_t>(1, d_size)))
 				{
 					data3 = SYS_MEMORY_PAGE_FAULT_CAUSE_READ_ONLY; // TODO
 				}
@@ -2086,7 +2086,7 @@ u64 thread_ctrl::get_affinity_mask(thread_class group)
 				else
 				{
 					// zen(+)
-					// Ryzen 7, Threadripper 
+					// Ryzen 7, Threadripper
 					// Assign threads 3-16
 					ppu_mask = 0b1111111100000000;
 					spu_mask = ppu_mask;

--- a/Utilities/lockless.h
+++ b/Utilities/lockless.h
@@ -388,27 +388,13 @@ public:
 
 	// Apply func(data) to each element, return the total length
 	template <typename F>
-	std::size_t apply(F&& func)
+	std::size_t apply(F func)
 	{
 		std::size_t count = 0;
 
 		for (auto slice = pop_all(); slice; slice.pop_front())
 		{
-			std::invoke(std::forward<F>(func), *slice);
-		}
-
-		return count;
-	}
-
-	// apply() overload for callable template argument
-	template <auto F>
-	std::size_t apply()
-	{
-		std::size_t count = 0;
-
-		for (auto slice = pop_all(); slice; slice.pop_front())
-		{
-			std::invoke(F, *slice);
+			std::invoke(func, *slice);
 		}
 
 		return count;

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -50,6 +50,7 @@ void fmt_class_string<lib_loading_type>::format(std::string& out, u64 arg)
 		case lib_loading_type::both: return "Load automatic and manual selection";
 		case lib_loading_type::liblv2only: return "Load liblv2.sprx only";
 		case lib_loading_type::liblv2both: return "Load liblv2.sprx and manual selection";
+		case lib_loading_type::liblv2list: return "Load liblv2.sprx and strict selection";
 		}
 
 		return unknown;
@@ -1282,7 +1283,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 		// Load required set of modules (lib_loading_type::both processed in sys_prx.cpp)
 		load_libs = g_cfg.core.load_libraries.get_set();
 	}
-	else if (g_cfg.core.lib_loading == lib_loading_type::liblv2only || g_cfg.core.lib_loading == lib_loading_type::liblv2both)
+	else if (g_cfg.core.lib_loading >= lib_loading_type::liblv2only && g_cfg.core.lib_loading <= lib_loading_type::liblv2list)
 	{
 		// Load only liblv2.sprx
 		load_libs.emplace("liblv2.sprx");

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -49,6 +49,7 @@ void fmt_class_string<lib_loading_type>::format(std::string& out, u64 arg)
 		case lib_loading_type::manual: return "Manually load selected libraries";
 		case lib_loading_type::both: return "Load automatic and manual selection";
 		case lib_loading_type::liblv2only: return "Load liblv2.sprx only";
+		case lib_loading_type::liblv2both: return "Load liblv2.sprx and manual selection";
 		}
 
 		return unknown;
@@ -1281,7 +1282,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 		// Load required set of modules (lib_loading_type::both processed in sys_prx.cpp)
 		load_libs = g_cfg.core.load_libraries.get_set();
 	}
-	else if (g_cfg.core.lib_loading == lib_loading_type::liblv2only)
+	else if (g_cfg.core.lib_loading == lib_loading_type::liblv2only || g_cfg.core.lib_loading == lib_loading_type::liblv2both)
 	{
 		// Load only liblv2.sprx
 		load_libs.emplace("liblv2.sprx");

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -45,9 +45,8 @@ void fmt_class_string<lib_loading_type>::format(std::string& out, u64 arg)
 	{
 		switch (value)
 		{
-		case lib_loading_type::automatic: return "Automatically load required libraries";
 		case lib_loading_type::manual: return "Manually load selected libraries";
-		case lib_loading_type::both: return "Load automatic and manual selection";
+		case lib_loading_type::hybrid: return "Load automatic and manual selection";
 		case lib_loading_type::liblv2only: return "Load liblv2.sprx only";
 		case lib_loading_type::liblv2both: return "Load liblv2.sprx and manual selection";
 		case lib_loading_type::liblv2list: return "Load liblv2.sprx and strict selection";
@@ -1283,15 +1282,9 @@ void ppu_load_exec(const ppu_exec_object& elf)
 		// Load required set of modules (lib_loading_type::both processed in sys_prx.cpp)
 		load_libs = g_cfg.core.load_libraries.get_set();
 	}
-	else if (g_cfg.core.lib_loading >= lib_loading_type::liblv2only && g_cfg.core.lib_loading <= lib_loading_type::liblv2list)
+	else
 	{
-		// Load only liblv2.sprx
-		load_libs.emplace("liblv2.sprx");
-	}
-
-	if (g_cfg.core.lib_loading == lib_loading_type::automatic || g_cfg.core.lib_loading == lib_loading_type::both)
-	{
-		if (g_cfg.core.lib_loading == lib_loading_type::both && g_cfg.core.load_libraries.get_set().count("liblv2.sprx"))
+		if (g_cfg.core.lib_loading != lib_loading_type::hybrid || g_cfg.core.load_libraries.get_set().count("liblv2.sprx"))
 		{
 			// Will load libsysmodule.sprx internally
 			load_libs.emplace("liblv2.sprx");
@@ -1300,129 +1293,6 @@ void ppu_load_exec(const ppu_exec_object& elf)
 		{
 			// Load only libsysmodule.sprx
 			load_libs.emplace("libsysmodule.sprx");
-		}
-	}
-	else if (0)
-	{
-		// Load recommended set of modules: Module name -> SPRX
-		std::unordered_multimap<std::string, std::string> sprx_map
-		{
-			{ "cellAdec", "libadec.sprx" }, // cellSpurs|cell_libac3dec|cellAtrac3dec|cellAtracXdec|cellCelpDec|cellDTSdec|cellM2AACdec|cellM2BCdec|cellM4AacDec|cellMP3dec|cellTRHDdec|cellWMAdec|cellDTSLBRdec|cellDDPdec|cellM4AacDec2ch|cellDTSHDdec|cellMPL1dec|cellMP3Sdec|cellM4AacDec2chmod|cellCelp8Dec|cellWMAPROdec|cellWMALSLdec|cellDTSHDCOREdec|cellAtrac3multidec
-			{ "cellAdec", "libsre.sprx" },
-			{ "cellAdec", "libac3dec.sprx" },
-			{ "cellAdec", "libat3dec.sprx" },
-			{ "cellAdec", "libat3multidec.sprx" },
-			{ "cellAdec", "libatxdec.sprx" },
-			{ "cellAdec", "libcelp8dec.sprx" },
-			{ "cellAdec", "libcelpdec.sprx" },
-			{ "cellAdec", "libddpdec.sprx" },
-			{ "cellAdec", "libm2bcdec.sprx" },
-			{ "cellAdec", "libm4aacdec.sprx" },
-			{ "cellAdec", "libm4aacdec2ch.sprx" },
-			{ "cellAdec", "libmp3dec.sprx" },
-			{ "cellAdec", "libmpl1dec.sprx" },
-			{ "cellAdec", "libwmadec.sprx" },
-			{ "cellAtrac", "libatrac3plus.sprx" },
-			{ "cellAtrac", "cellAdec" },
-			{ "cellAtracMulti", "libatrac3multi.sprx" },
-			{ "cellAtracMulti", "cellAdec" },
-			{ "cellCelp8Enc", "libcelp8enc.sprx" },
-			{ "cellCelp8Enc", "libsre.sprx" },
-			{ "cellCelpEnc", "libcelpenc.sprx" },
-			{ "cellCelpEnc", "libsre.sprx" },
-			{ "cellDmux", "libdmux.sprx" },
-			{ "cellDmux", "libdmuxpamf.sprx" },
-			{ "cellDmux", "libsre.sprx" },
-			{ "cellFiber", "libfiber.sprx" },
-			{ "cellFont", "libfont.sprx" },
-			{ "cellFontFT", "libfontFT.sprx" },
-			{ "cellFontFT", "libfreetype.sprx" },
-			{ "cellGcmSys", "libgcm_sys.sprx" },
-			{ "cellGifDec", "libgifdec.sprx" },
-			{ "cellGifDec", "libsre.sprx" },
-			{ "cellJpgDec", "libjpgdec.sprx" },
-			{ "cellJpgDec", "libsre.sprx" },
-			{ "cellJpgEnc", "libjpgenc.sprx" },
-			{ "cellJpgEnc", "libsre.sprx" },
-			{ "cellKey2char", "libkey2char.sprx" },
-			{ "cellL10n", "libl10n.sprx" },
-			{ "cellM4hdEnc", "libm4hdenc.sprx" },
-			{ "cellM4hdEnc", "libsre.sprx" },
-			{ "cellPamf", "libpamf.sprx" },
-			{ "cellPngDec", "libpngdec.sprx" },
-			{ "cellPngDec", "libsre.sprx" },
-			{ "cellPngEnc", "libpngenc.sprx" },
-			{ "cellPngEnc", "libsre.sprx" },
-			{ "cellResc", "libresc.sprx" },
-			{ "cellRtc", "librtc.sprx" },
-			{ "cellSsl", "libssl.sprx" },
-			{ "cellSsl", "librtc.sprx" },
-			{ "cellHttp", "libhttp.sprx" },
-			{ "cellHttp", "cellSsl" },
-			{ "cellHttpUtil", "libhttp.sprx" },
-			{ "cellHttpUtil", "cellSsl" },
-			{ "cellSail", "libsail.sprx" },
-			{ "cellSail", "libsre.sprx" },
-			{ "cellSail", "libmp4.sprx" },
-			{ "cellSail", "libpamf.sprx" },
-			{ "cellSail", "libdmux.sprx" },
-			{ "cellSail", "libdmuxpamf.sprx" },
-			{ "cellSail", "libapostsrc_mini.sprx" },
-			{ "cellSail", "libsail_avi.sprx" },
-			{ "cellSail", "libvpost.sprx" },
-			{ "cellSail", "cellAdec" },
-			{ "cellSpursJq", "libspurs_jq.sprx" },
-			{ "cellSpursJq", "libsre.sprx" },
-			{ "cellSync", "libsre.sprx" },
-			{ "cellSheap", "libsre.sprx" },
-			{ "cellOvis", "libsre.sprx" },
-			{ "cellSpurs", "libsre.sprx" },
-			{ "cellDaisy", "libsre.sprx" },
-			{ "cellSpudll", "libsre.sprx" },
-			{ "cellSync2", "libsync2.sprx" },
-			{ "cellSync2", "libsre.sprx" },
-			{ "cellVpost", "libvpost.sprx" },
-			{ "cellVpost", "libsre.sprx" },
-			{ "sys_fs", "libfs.sprx" },
-		};
-
-		// Expand dependencies
-		for (bool repeat = true; repeat;)
-		{
-			repeat = false;
-
-			for (auto it = sprx_map.begin(), end = sprx_map.end(); it != end; ++it)
-			{
-				auto range = sprx_map.equal_range(it->second);
-
-				if (range.first != range.second)
-				{
-					decltype(sprx_map) add;
-
-					for (; range.first != range.second; ++range.first)
-					{
-						add.emplace(it->first, range.first->second);
-					}
-
-					sprx_map.erase(it);
-					sprx_map.insert(add.begin(), add.end());
-					repeat = true;
-					break;
-				}
-			}
-		}
-
-		for (const auto& pair : link->modules)
-		{
-			if (!pair.second.imported)
-			{
-				continue;
-			}
-
-			for (auto range = sprx_map.equal_range(pair.first); range.first != range.second; ++range.first)
-			{
-				load_libs.emplace(range.first->second);
-			}
 		}
 	}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -501,12 +501,12 @@ std::string ppu_thread::dump() const
 	u32 stack_min = stack_ptr & ~0xfff;
 	u32 stack_max = stack_min + 4096;
 
-	while (stack_min && vm::check_addr(stack_min - 4096, 4096, vm::page_allocated | vm::page_writable))
+	while (stack_min && vm::check_addr(stack_min - 4096, 4096, vm::page_writable))
 	{
 		stack_min -= 4096;
 	}
 
-	while (stack_max + 4096 && vm::check_addr(stack_max, 4096, vm::page_allocated | vm::page_writable))
+	while (stack_max + 4096 && vm::check_addr(stack_max, 4096, vm::page_writable))
 	{
 		stack_max += 4096;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_gpio.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_gpio.cpp
@@ -14,7 +14,7 @@ error_code sys_gpio_get(u64 device_id, vm::ptr<u64> value)
 		return CELL_ESRCH;
 	}
 
-	if (!vm::check_addr(value.addr(), sizeof(u64), vm::page_allocated | vm::page_writable))
+	if (!vm::check_addr(value.addr(), sizeof(u64), vm::page_writable))
 	{
 		return CELL_EFAULT;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -117,7 +117,19 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 		return CELL_PRX_ERROR_LIBRARY_FOUND;
 	}
 
-	bool ignore = s_prx_ignore.count(vpath) != 0;
+	bool ignore = false;
+
+	if (g_cfg.core.lib_loading == lib_loading_type::liblv2list)
+	{
+		if (vpath.compare(0, 24, "/dev_flash/sys/external/") == 0 && vpath != "/dev_flash/sys/external/libsysmodule.sprx"sv)
+		{
+			ignore = g_cfg.core.load_libraries.get_set().count(name) == 0;
+		}
+	}
+	else
+	{
+		ignore = s_prx_ignore.count(vpath) != 0;
+	}
 
 	if (ignore && (g_cfg.core.lib_loading == lib_loading_type::both || g_cfg.core.lib_loading == lib_loading_type::liblv2both))
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -131,7 +131,7 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 		ignore = s_prx_ignore.count(vpath) != 0;
 	}
 
-	if (ignore && (g_cfg.core.lib_loading == lib_loading_type::both || g_cfg.core.lib_loading == lib_loading_type::liblv2both))
+	if (ignore && (g_cfg.core.lib_loading == lib_loading_type::hybrid || g_cfg.core.lib_loading == lib_loading_type::liblv2both))
 	{
 		// Ignore ignore list if the library is selected in 'both' mode
 		if (g_cfg.core.load_libraries.get_set().count(name) != 0)

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -119,7 +119,7 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	bool ignore = s_prx_ignore.count(vpath) != 0;
 
-	if (ignore && g_cfg.core.lib_loading == lib_loading_type::both)
+	if (ignore && (g_cfg.core.lib_loading == lib_loading_type::both || g_cfg.core.lib_loading == lib_loading_type::liblv2both))
 	{
 		// Ignore ignore list if the library is selected in 'both' mode
 		if (g_cfg.core.load_libraries.get_set().count(name) != 0)

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -187,7 +187,7 @@ error_code sys_rsx_context_iomap(u32 context_id, u32 io, u32 ea, u32 size, u64 f
 
 	for (u32 addr = ea, end = ea + size; addr < end; addr += 0x100000)
 	{
-		if (!vm::check_addr(addr, 1, vm::page_allocated | vm::page_readable | (addr < 0x20000000 ? 0 : vm::page_1m_size)))
+		if (!vm::check_addr(addr, 1, vm::page_readable | (addr < 0x20000000 ? 0 : vm::page_1m_size)))
 		{
 			return CELL_EINVAL;
 		}

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -528,6 +528,9 @@ namespace vm
 			return false;
 		}
 
+		// Always check this flag
+		flags |= page_allocated;
+
 		for (u32 i = addr / 4096, max = (addr + size - 1) / 4096; i <= max; i++)
 		{
 			if (UNLIKELY((g_pages[i].flags & flags) != flags))

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -52,7 +52,7 @@ namespace vm
 	bool page_protect(u32 addr, u32 size, u8 flags_test = 0, u8 flags_set = 0, u8 flags_clear = 0);
 
 	// Check flags for specified memory range (unsafe)
-	bool check_addr(u32 addr, u32 size = 1, u8 flags = page_allocated | page_readable);
+	bool check_addr(u32 addr, u32 size = 1, u8 flags = page_readable);
 
 	// Search and map memory in specified memory location (min alignment is 0x10000)
 	u32 alloc(u32 size, memory_location_t location, u32 align = 0x10000);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -47,6 +47,7 @@ enum class lib_loading_type
 	both,
 	liblv2only,
 	liblv2both,
+	liblv2list,
 };
 
 enum sleep_timers_accuracy_level : u32

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -42,9 +42,8 @@ enum class spu_block_size_type
 
 enum class lib_loading_type
 {
-	automatic,
 	manual,
-	both,
+	hybrid,
 	liblv2only,
 	liblv2both,
 	liblv2list,

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -45,7 +45,8 @@ enum class lib_loading_type
 	automatic,
 	manual,
 	both,
-	liblv2only
+	liblv2only,
+	liblv2both,
 };
 
 enum sleep_timers_accuracy_level : u32

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -28,6 +28,7 @@
 			"auto": "Automatically selects the LLE libraries to load.\nWhile this option works fine in most cases, liblv2 is the preferred option.",
 			"manual": "Allows the user to manually choose the LLE libraries to load.\nIf unsure, don't use this option. Nothing will work if you use this.",
 			"both": "Automatically selects the LLE libraries to load and allows the user to choose additional libraries manually.\nIf unsure, don't use this option.",
+			"liblv2both": "Loads liblv2.sprx and chosen list of libraries.\nIf unsure, don't use this option.",
 			"liblv2": "This closely emulates how games can load and unload system module files on a real PlayStation 3.\nSome games require this.\nThis is the preferred option."
 		},
 		"checkboxes": {

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -25,9 +25,8 @@
 			"LLVM": "This is the fastest option with very good compatibility.\nRecompiles the game's SPU LLVM cache before running which adds extra start-up time.\nIf you experience issues, use the ASMJIT Recompiler."
 		},
 		"libraries": {
-			"auto": "Automatically selects the LLE libraries to load.\nWhile this option works fine in most cases, liblv2 is the preferred option.",
 			"manual": "Allows the user to manually choose the LLE libraries to load.\nIf unsure, don't use this option. Nothing will work if you use this.",
-			"both": "Automatically selects the LLE libraries to load and allows the user to choose additional libraries manually.\nIf unsure, don't use this option.",
+			"both": "Load libsysmodule.sprx and chosen list of libraries. Option for backward compatibility.\nIf unsure, don't use this option.",
 			"liblv2both": "Loads liblv2.sprx and chosen list of libraries.\nIf unsure, don't use this option.",
 			"liblv2list": "Loads liblv2.sprx and nothing but selected libraries.\nDon't use this option.",
 			"liblv2": "This closely emulates how games can load and unload system module files on a real PlayStation 3.\nSome games require this.\nThis is the preferred option."

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -29,6 +29,7 @@
 			"manual": "Allows the user to manually choose the LLE libraries to load.\nIf unsure, don't use this option. Nothing will work if you use this.",
 			"both": "Automatically selects the LLE libraries to load and allows the user to choose additional libraries manually.\nIf unsure, don't use this option.",
 			"liblv2both": "Loads liblv2.sprx and chosen list of libraries.\nIf unsure, don't use this option.",
+			"liblv2list": "Loads liblv2.sprx and nothing but selected libraries.\nDon't use this option.",
 			"liblv2": "This closely emulates how games can load and unload system module files on a real PlayStation 3.\nSome games require this.\nThis is the preferred option."
 		},
 		"checkboxes": {

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -309,6 +309,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	SubscribeTooltip(ui->lib_manu, json_cpu_lib["manual"].toString());
 	SubscribeTooltip(ui->lib_both, json_cpu_lib["both"].toString());
 	SubscribeTooltip(ui->lib_lv2,  json_cpu_lib["liblv2"].toString());
+	SubscribeTooltip(ui->lib_lv2b, json_cpu_lib["liblv2both"].toString());
 
 	// creating this in ui file keeps scrambling the order...
 	QButtonGroup *libModeBG = new QButtonGroup(this);
@@ -316,6 +317,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	libModeBG->addButton(ui->lib_manu, (int)lib_loading_type::manual);
 	libModeBG->addButton(ui->lib_both, (int)lib_loading_type::both);
 	libModeBG->addButton(ui->lib_lv2,  (int)lib_loading_type::liblv2only);
+	libModeBG->addButton(ui->lib_lv2b, (int)lib_loading_type::liblv2both);
 
 	{// Handle lib loading options
 		QString selectedLib = qstr(xemu_settings->GetSetting(emu_settings::LibLoadOptions));
@@ -387,7 +389,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 	auto l_OnLibButtonClicked = [=](int ind)
 	{
-		if (ind == (int)lib_loading_type::manual || ind == (int)lib_loading_type::both)
+		if (ind == (int)lib_loading_type::manual || ind == (int)lib_loading_type::both || ind == (int)lib_loading_type::liblv2both)
 		{
 			ui->searchBox->setEnabled(true);
 			ui->lleList->setEnabled(true);
@@ -860,7 +862,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		}
 		ChangeMicrophoneType(ui->microphoneBox->currentText());
 	};
-	
+
 	auto ChangeMicrophoneDevice = [=](u32 next_index, QString text)
 	{
 		xemu_settings->SetSetting(emu_settings::MicrophoneDevices, xemu_settings->m_microphone_creator.SetDevice(next_index, text));

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -310,6 +310,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	SubscribeTooltip(ui->lib_both, json_cpu_lib["both"].toString());
 	SubscribeTooltip(ui->lib_lv2,  json_cpu_lib["liblv2"].toString());
 	SubscribeTooltip(ui->lib_lv2b, json_cpu_lib["liblv2both"].toString());
+	SubscribeTooltip(ui->lib_lv2l, json_cpu_lib["liblv2list"].toString());
 
 	// creating this in ui file keeps scrambling the order...
 	QButtonGroup *libModeBG = new QButtonGroup(this);
@@ -318,6 +319,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	libModeBG->addButton(ui->lib_both, (int)lib_loading_type::both);
 	libModeBG->addButton(ui->lib_lv2,  (int)lib_loading_type::liblv2only);
 	libModeBG->addButton(ui->lib_lv2b, (int)lib_loading_type::liblv2both);
+	libModeBG->addButton(ui->lib_lv2l, (int)lib_loading_type::liblv2list);
 
 	{// Handle lib loading options
 		QString selectedLib = qstr(xemu_settings->GetSetting(emu_settings::LibLoadOptions));
@@ -389,7 +391,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 	auto l_OnLibButtonClicked = [=](int ind)
 	{
-		if (ind == (int)lib_loading_type::manual || ind == (int)lib_loading_type::both || ind == (int)lib_loading_type::liblv2both)
+		if (ind == (int)lib_loading_type::manual || ind == (int)lib_loading_type::both || ind == (int)lib_loading_type::liblv2both || ind == (int)lib_loading_type::liblv2list)
 		{
 			ui->searchBox->setEnabled(true);
 			ui->lleList->setEnabled(true);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -305,7 +305,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 #endif
 
 	// lib options tool tips
-	SubscribeTooltip(ui->lib_auto, json_cpu_lib["auto"].toString());
 	SubscribeTooltip(ui->lib_manu, json_cpu_lib["manual"].toString());
 	SubscribeTooltip(ui->lib_both, json_cpu_lib["both"].toString());
 	SubscribeTooltip(ui->lib_lv2,  json_cpu_lib["liblv2"].toString());
@@ -314,9 +313,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 	// creating this in ui file keeps scrambling the order...
 	QButtonGroup *libModeBG = new QButtonGroup(this);
-	libModeBG->addButton(ui->lib_auto, (int)lib_loading_type::automatic);
 	libModeBG->addButton(ui->lib_manu, (int)lib_loading_type::manual);
-	libModeBG->addButton(ui->lib_both, (int)lib_loading_type::both);
+	libModeBG->addButton(ui->lib_both, (int)lib_loading_type::hybrid);
 	libModeBG->addButton(ui->lib_lv2,  (int)lib_loading_type::liblv2only);
 	libModeBG->addButton(ui->lib_lv2b, (int)lib_loading_type::liblv2both);
 	libModeBG->addButton(ui->lib_lv2l, (int)lib_loading_type::liblv2list);
@@ -391,7 +389,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 	auto l_OnLibButtonClicked = [=](int ind)
 	{
-		if (ind == (int)lib_loading_type::manual || ind == (int)lib_loading_type::both || ind == (int)lib_loading_type::liblv2both || ind == (int)lib_loading_type::liblv2list)
+		if (ind != (int)lib_loading_type::liblv2only)
 		{
 			ui->searchBox->setEnabled(true);
 			ui->lleList->setEnabled(true);

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -213,6 +213,19 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QRadioButton" name="lib_lv2l">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Load liblv2.sprx and strict selection</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -200,6 +200,19 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QRadioButton" name="lib_lv2b">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Load liblv2.sprx and manual selection</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -149,19 +149,6 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout">
               <item>
-               <widget class="QRadioButton" name="lib_auto">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Automatically load required libraries</string>
-                </property>
-               </widget>
-              </item>
-              <item>
                <widget class="QRadioButton" name="lib_manu">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">

--- a/rpcs3/util/typeindices.hpp
+++ b/rpcs3/util/typeindices.hpp
@@ -1,0 +1,123 @@
+﻿#pragma once
+
+namespace stx
+{
+	template <typename Info>
+	class type_counter;
+
+	// Type information for given Info type, also serving as tag
+	template <typename Info>
+	class type_info final : public Info
+	{
+		// Current type id (non-zero)
+		unsigned type = 0;
+
+		// Next typeinfo in linked list
+		type_info* next = nullptr;
+
+		type_info(Info info, decltype(sizeof(int))) noexcept;
+
+		friend type_counter<Info>;
+
+	public:
+		constexpr type_info() noexcept = default;
+
+		unsigned index() const
+		{
+			return type;
+		}
+	};
+
+	// Class for automatic type registration for given Info type
+	template <typename Info>
+	class type_counter final
+	{
+		// Dummy first element to simplify list filling logic
+		type_info<Info> first{};
+
+		// Linked list built at global initialization time
+		type_info<Info>* next = &first;
+
+		friend type_info<Info>;
+
+	public:
+		constexpr type_counter() noexcept = default;
+
+		unsigned count() const
+		{
+			return next->index();
+		}
+
+		class const_iterator
+		{
+			const type_info<Info>* ptr;
+
+		public:
+			const_iterator(const type_info<Info>* ptr)
+				: ptr(ptr)
+			{
+			}
+
+			const type_info<Info>& operator*() const
+			{
+				return *ptr;
+			}
+
+			const type_info<Info>* operator->() const
+			{
+				return ptr;
+			}
+
+			const_iterator& operator++()
+			{
+				ptr = ptr->next;
+				return *this;
+			}
+
+			const_iterator operator++(int)
+			{
+				const_iterator r = ptr;
+				ptr = ptr->next;
+				return r;
+			}
+
+			bool operator==(const const_iterator& r) const
+			{
+				return ptr == r.ptr;
+			}
+
+			bool operator!=(const const_iterator& r) const
+			{
+				return ptr != r.ptr;
+			}
+		};
+
+		const_iterator begin() const
+		{
+			return first.next;
+		}
+
+		const_iterator end() const
+		{
+			return nullptr;
+		}
+
+		// Global type info instance
+		template <typename T>
+		static inline const type_info<Info> type{Info::template make_typeinfo<T>(), sizeof(T)};
+	};
+
+	// Global typecounter instance
+	template <typename Info>
+	inline type_counter<Info> typeinfo_v{};
+
+	template <typename Info>
+	type_info<Info>::type_info(Info info, decltype(sizeof(int))) noexcept
+		: Info(info)
+		, type(typeinfo_v<Info>.count() + 1)
+	{
+		// Update linked list
+		typeinfo_v<Info>.next->next = this;
+		typeinfo_v<Info>.next       = this;
+	}
+}


### PR DESCRIPTION
Load liblv2.sprx and manual selection. Similar to loading liblv2.sprx, but allows to specify libraries to LLE, like libvdec.sprx.
Load liblv2.sprx and strict selection. Only loads liblv2.sprx and libmodule.sprx, and nothing else unless specified on list.