### PR TITLE
Tiny fix of vm::check_addr

### DIFF
--- a/Utilities/GDBDebugServer.cpp
+++ b/Utilities/GDBDebugServer.cpp
@@ -541,7 +541,7 @@ bool GDBDebugServer::cmd_read_memory(gdb_cmd & cmd)
 	std::string result;
 	result.reserve(len * 2);
 	for (u32 i = 0; i < len; ++i) {
-		if (vm::check_addr(addr, 1, vm::page_allocated | vm::page_readable)) {
+		if (vm::check_addr(addr)) {
 			result += to_hexbyte(vm::read8(addr + i));
 		} else {
 			break;

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -233,6 +233,7 @@ error_code sys_memory_get_page_attribute(u32 addr, vm::ptr<sys_page_attr_t> attr
 		attr->page_size = 4096;
 	}
 
+	attr->pad = 0; // Always write 0
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -187,7 +187,7 @@ error_code sys_rsx_context_iomap(u32 context_id, u32 io, u32 ea, u32 size, u64 f
 
 	for (u32 addr = ea, end = ea + size; addr < end; addr += 0x100000)
 	{
-		if (!vm::check_addr(addr, 1, vm::page_allocated | (addr < 0x20000000 ? 0 : vm::page_1m_size)))
+		if (!vm::check_addr(addr, 1, vm::page_allocated | vm::page_readable | (addr < 0x20000000 ? 0 : vm::page_1m_size)))
 		{
 			return CELL_EINVAL;
 		}

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -52,7 +52,7 @@ namespace vm
 	bool page_protect(u32 addr, u32 size, u8 flags_test = 0, u8 flags_set = 0, u8 flags_clear = 0);
 
 	// Check flags for specified memory range (unsafe)
-	bool check_addr(u32 addr, u32 size = 1, u8 flags = page_allocated);
+	bool check_addr(u32 addr, u32 size = 1, u8 flags = page_allocated | page_readable);
 
 	// Search and map memory in specified memory location (min alignment is 0x10000)
 	u32 alloc(u32 size, memory_location_t location, u32 align = 0x10000);


### PR DESCRIPTION
Fix stack memory state checking, boundaries may be "allocated" but not mapped (guard pages).