### PR TITLE
rsx: Fix overlapping transfers of nv3089::image_in/nv0039::buffer_notify and when out_pitch != in_pitch || out_pitch != out_bpp * out_w

### DIFF
--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -941,7 +941,7 @@ namespace rsx
 			}
 
 			const u32 in_offset = in_x * in_bpp + in_pitch * in_y;
-			const s32 out_offset = out_x * out_bpp + out_pitch * out_y;
+			const u32 out_offset = out_x * out_bpp + out_pitch * out_y;
 
 			const u32 src_address = get_address(src_offset, src_dma);
 			const u32 dst_address = get_address(dst_offset, dst_dma);
@@ -1022,15 +1022,15 @@ namespace rsx
 
 			if (scale_y < 0 || scale_x < 0)
 			{
-				const auto packed_pitch = in_w * in_bpp;
+				const u32 packed_pitch = in_w * in_bpp;
 				temp1.resize(packed_pitch * in_h);
 
-				const s32 stride_y = (scale_y < 0 ? -1 : 1) * in_pitch;
+				const s32 stride_y = (scale_y < 0 ? -1 : 1) * (s32)in_pitch;
 
 				for (u32 y = 0; y < in_h; ++y)
 				{
 					u8 *dst = temp1.data() + (packed_pitch * y);
-					u8 *src = pixels_src + (y * stride_y);
+					u8 *src = pixels_src + ((s32)y * stride_y);
 
 					if (scale_x < 0)
 					{

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -32,9 +32,35 @@ namespace rsx
 
 		for (int y = 0; y < clip_h; ++y)
 		{
-			std::memmove(pixels_dst, pixels_src, row_length);
+			std::memcpy(pixels_dst, pixels_src, row_length);
 			pixels_src += src_pitch;
 			pixels_dst += dst_pitch;
+		}
+	}
+
+	void clip_image_may_overlap(u8 *dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch, u8 *buffer)
+	{
+		src += clip_y * src_pitch + clip_x * bpp;
+
+		const u32 buffer_pitch = bpp * clip_w;
+		u8* buf = buffer;
+
+		// Read the whole buffer from source
+		for (u32 y = 0; y < clip_h; ++y)
+		{
+			std::memcpy(buf, src, buffer_pitch);
+			src += src_pitch;
+			buf += buffer_pitch;
+		}
+
+		buf = buffer;
+
+		// Write to destination
+		for (u32 y = 0; y < clip_h; ++y)
+		{
+			std::memcpy(dst, buf, buffer_pitch);
+			dst += dst_pitch;
+			buf += buffer_pitch;
 		}
 	}
 

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -425,6 +425,7 @@ namespace rsx
 		const u8 *src, AVPixelFormat src_format, int src_width, int src_height, int src_pitch, int src_slice_h, bool bilinear);
 
 	void clip_image(u8 *dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch);
+	void clip_image_may_overlap(u8 *dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch, u8* buffer);
 
 	void convert_le_f32_to_be_d24(void *dst, void *src, u32 row_length_in_texels, u32 num_rows);
 	void convert_le_d24x8_to_be_d24x8(void *dst, void *src, u32 row_length_in_texels, u32 num_rows);


### PR DESCRIPTION
* Fix for nv0039::buffer_notify when encountering overlapping memory at all cases.
* Fix overlapping transfers of nv3089::image_in and nv0039::buffer_notify when `out_pitch != in_pitch || out_pitch != out_bpp * out_w` and memory dest and source is overlapping.
* Fix a UB in image_in when using negative scaling.