### PR TITLE
Update Appveyor to Qt 5.13

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ version: '{build}'
 image: Visual Studio 2017
 
 environment:
-  QTDIR: C:\Qt\5.11\msvc2017_64
+  QTDIR: C:\Qt\5.13\msvc2017_64
   LLVMLIBS: https://github.com/RPCS3/llvm/releases/download/continuous-master/llvmlibs.7z
   GLSLANG: https://dl.dropboxusercontent.com/s/ku2qgwmtfptzbvx/glslang.7z
   COMPATDB: https://rpcs3.net/compatibility?api=v1&export

--- a/rpcs3/ds3_pad_handler.cpp
+++ b/rpcs3/ds3_pad_handler.cpp
@@ -238,7 +238,7 @@ void ds3_pad_handler::ThreadProc()
 	}
 }
 
-void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 b/* b*/)
+void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 /* b*/)
 {
 	std::shared_ptr<ds3_device> device = get_device(padId);
 	if (device == nullptr || device->handle == nullptr)
@@ -267,7 +267,7 @@ void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 s
 	send_output_report(device);
 }
 
-void ds3_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+void ds3_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& /*callback*/, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& /*buttons*/)
 {
 	if (get_blacklist)
 		blacklist.clear();

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -152,7 +152,7 @@ void ds4_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+void ds4_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& /*buttons*/)
 {
 	if (get_blacklist)
 		blacklist.clear();

--- a/rpcs3/rpcs3qt/game_list_grid_delegate.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid_delegate.cpp
@@ -1,4 +1,4 @@
-#include "game_list_grid_delegate.h"
+﻿#include "game_list_grid_delegate.h"
 
 game_list_grid_delegate::game_list_grid_delegate(const QSize& size, const qreal& margin_factor, const qreal& text_factor, QObject *parent)
 	 : QStyledItemDelegate(parent), m_size(size), m_margin_factor(margin_factor), m_text_factor(text_factor)
@@ -11,6 +11,8 @@ game_list_grid_delegate::~game_list_grid_delegate()
 
 void game_list_grid_delegate::initStyleOption(QStyleOptionViewItem * option, const QModelIndex & index) const
 {
+	Q_UNUSED(index);
+
 	// Remove the focus frame around selected items
 	option->state &= ~QStyle::State_HasFocus;
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1390,7 +1390,7 @@
            <property name="title">
             <string>Disk cache</string>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_77">
+           <layout class="QVBoxLayout" name="verticalLayout_81">
             <item>
              <widget class="QCheckBox" name="enableCacheClearing">
               <property name="text">
@@ -2495,7 +2495,7 @@
               <property name="title">
                <string>Maximum Number of SPURS Threads</string>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_76">
+              <layout class="QVBoxLayout" name="verticalLayout_82">
                <item>
                 <widget class="QComboBox" name="maxSPURSThreads"/>
                </item>

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -74,7 +74,7 @@ void xinput_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+void xinput_pad_handler::GetNextButtonPress(const std::string& padId, const std::function<void(u16, std::string, std::string, int[])>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& /*buttons*/)
 {
 	if (get_blacklist)
 		blacklist.clear();


### PR DESCRIPTION
This bumps the Qt version of Appveyor builds to 5.13.

This might include some relevant internal bugfixes and improvements in High Dpi scaling.

Keeping the Qt version up to date will prevent inconsistencies between up-to-date local development and the expected outcome in official builds.