### PR TITLE
Qt: Clean up depracation warnings

### DIFF
--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -70,8 +70,8 @@ void breakpoint_list::AddBreakpoint(u32 pc)
 	breakpointItemText.remove(10, 13);
 
 	QListWidgetItem* breakpointItem = new QListWidgetItem(breakpointItemText);
-	breakpointItem->setTextColor(m_text_color_bp);
-	breakpointItem->setBackgroundColor(m_color_bp);
+	breakpointItem->setForeground(m_text_color_bp);
+	breakpointItem->setBackground(m_color_bp);
 	QVariant pcVariant;
 	pcVariant.setValue(pc);
 	breakpointItem->setData(Qt::UserRole, pcVariant);

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -92,18 +92,18 @@ void debugger_list::ShowAddress(u32 addr)
 
 			if (cpu->is_paused() && m_pc == GetPc())
 			{
-				item(i)->setTextColor(m_text_color_pc);
-				item(i)->setBackgroundColor(m_color_pc);
+				item(i)->setForeground(m_text_color_pc);
+				item(i)->setBackground(m_color_pc);
 			}
 			else if (IsBreakpoint(m_pc))
 			{
-				item(i)->setTextColor(m_text_color_bp);
-				item(i)->setBackgroundColor(m_color_bp);
+				item(i)->setForeground(m_text_color_bp);
+				item(i)->setBackground(m_color_bp);
 			}
 			else
 			{
-				item(i)->setTextColor(palette().color(foregroundRole()));
-				item(i)->setBackgroundColor(palette().color(backgroundRole()));
+				item(i)->setForeground(palette().color(foregroundRole()));
+				item(i)->setBackground(palette().color(backgroundRole()));
 			}
 		}
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -35,6 +35,8 @@
 
 #include <thread>
 
+#include <QScreen>
+
 #include "stdafx.h"
 #include "Emu/System.h"
 #include "Emu/Memory/vm.h"
@@ -1592,7 +1594,7 @@ void main_window::ConfigureGuiFromSettings(bool configure_all)
 	{
 		// By default, set the window to 70% of the screen and the debugger frame is hidden.
 		m_debuggerFrame->hide();
-		resize(QDesktopWidget().availableGeometry().size() * 0.7);
+		resize(QGuiApplication::primaryScreen()->availableSize() * 0.7);
 	}
 
 	restoreState(guiSettings->GetValue(gui::mw_windowState).toByteArray());

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -8,6 +8,7 @@
 #include <QMenu>
 #include <QDesktopWidget>
 #include <QApplication>
+#include <QScreen>
 
 constexpr auto qstr = QString::fromStdString;
 
@@ -225,7 +226,7 @@ void save_data_list_dialog::UpdateList()
 
 	QSize preferredSize = minimumSize().expandedTo(sizeHint() - m_list->sizeHint() + tableSize);
 
-	QSize maxSize = QSize(preferredSize.width(), static_cast<int>(QApplication::desktop()->screenGeometry().height()*.6));
+	QSize maxSize = QSize(preferredSize.width(), static_cast<int>(QGuiApplication::primaryScreen()->geometry().height() * 0.6));
 
 	resize(preferredSize.boundedTo(maxSize));
 }

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -18,6 +18,7 @@
 #include <QUrl>
 #include <QDesktopServices>
 #include <QPainter>
+#include <QScreen>
 
 namespace
 {
@@ -179,7 +180,7 @@ void save_manager_dialog::Init(std::string dir)
 	m_list->sortByColumn(1, Qt::AscendingOrder);
 
 	if (restoreGeometry(m_gui_settings->GetValue(gui::sd_geometry).toByteArray()))
-		resize(size().expandedTo(QDesktopWidget().availableGeometry().size() * 0.5));
+		resize(size().expandedTo(QGuiApplication::primaryScreen()->availableSize() * 0.5));
 
 	// Connects and events
 	connect(push_close, &QAbstractButton::clicked, this, &save_manager_dialog::close);
@@ -273,7 +274,7 @@ void save_manager_dialog::UpdateList()
 
 	QSize preferredSize = minimumSize().expandedTo(sizeHint() - m_list->sizeHint() + tableSize);
 
-	QSize maxSize = QSize(preferredSize.width(), static_cast<int>(QApplication::desktop()->screenGeometry().height()*.6));
+	QSize maxSize = QSize(preferredSize.width(), static_cast<int>(QGuiApplication::primaryScreen()->geometry().height() * 0.6));
 
 	resize(preferredSize.boundedTo(maxSize));
 }
@@ -352,7 +353,7 @@ void save_manager_dialog::OnEntriesRemove()
 
 	if (QMessageBox::question(this, tr("Delete Confirmation"), tr("Are you sure you want to delete these %1 items?").arg(selection.size()), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
 	{
-		qSort(selection.begin(), selection.end(), qGreater<QModelIndex>());
+		std::sort(selection.rbegin(), selection.rend());
 		for (QModelIndex index : selection)
 		{
 			int idx_real = m_list->item(index.row(), 1)->data(Qt::UserRole).toInt();

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -12,6 +12,7 @@
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QTimer>
+#include <QScreen>
 
 #include "qt_utils.h"
 #include "settings_dialog.h"
@@ -1173,7 +1174,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		ui->gs_width->setEnabled(enableButtons);
 		ui->gs_height->setEnabled(enableButtons);
 
-		QRect screen = QApplication::desktop()->screenGeometry();
+		QRect screen = QGuiApplication::primaryScreen()->geometry();
 		int width = xgui_settings->GetValue(gui::gs_width).toInt();
 		int height = xgui_settings->GetValue(gui::gs_height).toInt();
 		ui->gs_width->setValue(std::min(width, screen.width()));
@@ -1187,12 +1188,12 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		});
 		connect(ui->gs_width, &QSpinBox::editingFinished, [=]()
 		{
-			ui->gs_width->setValue(std::min(ui->gs_width->value(), QApplication::desktop()->screenGeometry().width()));
+			ui->gs_width->setValue(std::min(ui->gs_width->value(), QGuiApplication::primaryScreen()->size().width()));
 			xgui_settings->SetValue(gui::gs_width, ui->gs_width->value());
 		});
 		connect(ui->gs_height, &QSpinBox::editingFinished, [=]()
 		{
-			ui->gs_height->setValue(std::min(ui->gs_height->value(), QApplication::desktop()->screenGeometry().height()));
+			ui->gs_height->setValue(std::min(ui->gs_height->value(), QGuiApplication::primaryScreen()->size().height()));
 			xgui_settings->SetValue(gui::gs_height, ui->gs_height->value());
 		});
 	}

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -30,6 +30,8 @@
 #include <QScrollBar>
 #include <QWheelEvent>
 #include <QProgressDialog>
+#include <QGuiApplication>
+#include <QScreen>
 
 namespace
 {
@@ -426,7 +428,7 @@ void trophy_manager_dialog::RepaintUI()
 
 	if (!restoreGeometry(m_gui_settings->GetValue(gui::tr_geometry).toByteArray()))
 	{
-		resize(QDesktopWidget().availableGeometry().size() * 0.7);
+		resize(QGuiApplication::primaryScreen()->availableSize() * 0.7);
 	}
 
 	if (!m_splitter->restoreState(m_gui_settings->GetValue(gui::tr_splitterState).toByteArray()))

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -6,6 +6,7 @@
 
 #include <QRegExpValidator>
 #include <QInputDialog>
+#include <QScreen>
 
 namespace
 {
@@ -209,7 +210,7 @@ void user_manager_dialog::UpdateTable(bool mark_only)
 		m_table->horizontalHeader()->height() + m_table->verticalHeader()->length() + m_table->frameWidth() * 2);
 
 	QSize preferred_size = minimumSize().expandedTo(sizeHint() - m_table->sizeHint() + table_size).expandedTo(size());
-	QSize max_size = QSize(preferred_size.width(), static_cast<int>(QApplication::desktop()->screenGeometry().height()*.6));
+	QSize max_size = QSize(preferred_size.width(), static_cast<int>(QGuiApplication::primaryScreen()->size().height() * 0.6));
 
 	resize(preferred_size.boundedTo(max_size));
 }


### PR DESCRIPTION
Silences the following warnings:

```
warning C4996: 'QDesktopWidget::availableGeometry': Use QGuiApplication::screens()
warning C4996: 'QDesktopWidget::screenGeometry': Use QGuiApplication::screens()
warning C4996: 'QListWidgetItem::setTextColor': Use QListWidgetItem::setForeground() instead
warning C4996: 'QListWidgetItem::setBackgroundColor': Use QListWidgetItem::setBackground() instead
warning C4996: 'qSort': Use std::sort
warning C4996: 'qGreater<QModelIndex>::operator ()': Use std::greater
```