### PR TITLE
Add settings for trophy and save manager icon background colors

### DIFF
--- a/rpcs3/ds3_pad_handler.cpp
+++ b/rpcs3/ds3_pad_handler.cpp
@@ -318,7 +318,7 @@ std::shared_ptr<ds3_pad_handler::ds3_device> ds3_pad_handler::get_device(const s
 
 	int pad_number = std::stoi(padId.substr(pos + 9));
 	if (pad_number > 0 && pad_number <= controllers.size())
-		return controllers[pad_number - 1];
+		return controllers[static_cast<size_t>(pad_number) - 1];
 
 	return nullptr;
 }

--- a/rpcs3/ds3_pad_handler.h
+++ b/rpcs3/ds3_pad_handler.h
@@ -106,7 +106,7 @@ class ds3_pad_handler final : public PadHandlerBase
 		std::string device = {};
 		hid_device *handle = nullptr;
 		pad_config* config{ nullptr };
-		u8 buf[64];
+		u8 buf[64]{ 0 };
 		u8 large_motor = 0;
 		u8 small_motor = 0;
 		u8 status = DS3Status::Disconnected;

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -374,6 +374,9 @@ void rpcs3_app::OnChangeStyleSheetRequest(const QString& path)
 		// save manager icon color
 		"QLabel#save_manager_icon_background_color { color: rgba(240, 240, 240, 255); }"
 
+		// trophy manager icon color
+		"QLabel#trophy_manager_icon_background_color { color: rgba(240, 240, 240, 255); }"
+
 		// tables
 		"QTableWidget { alternate-background-color: #f2f2f2; background-color: #fff; border: none; }"
 		"QTableWidget#game_grid { alternate-background-color: #f2f2f2; background-color: #fff; font-weight: 600; font-size: 8pt; font-family: Lucida Grande; color: rgba(51, 51, 51, 255); border: 0em solid white; }"

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -1,4 +1,4 @@
-﻿#include "rpcs3_app.h"
+#include "rpcs3_app.h"
 
 #include "rpcs3qt/qt_utils.h"
 
@@ -369,7 +369,7 @@ void rpcs3_app::OnChangeStyleSheetRequest(const QString& path)
 		"QLabel#thumbnail_icon_color { color: rgba(0, 100, 231, 255); }"
 
 		// game list icon color
-		"QLabel#gamelist_icon_background_color { color: rgba(36, 36, 36, 255); }"
+		"QLabel#gamelist_icon_background_color { color: rgba(240, 240, 240, 255); }"
 
 		// tables
 		"QTableWidget { alternate-background-color: #f2f2f2; background-color: #fff; border: none; }"

--- a/rpcs3/rpcs3_app.cpp
+++ b/rpcs3/rpcs3_app.cpp
@@ -1,4 +1,4 @@
-#include "rpcs3_app.h"
+﻿#include "rpcs3_app.h"
 
 #include "rpcs3qt/qt_utils.h"
 
@@ -370,6 +370,9 @@ void rpcs3_app::OnChangeStyleSheetRequest(const QString& path)
 
 		// game list icon color
 		"QLabel#gamelist_icon_background_color { color: rgba(240, 240, 240, 255); }"
+
+		// save manager icon color
+		"QLabel#save_manager_icon_background_color { color: rgba(240, 240, 240, 255); }"
 
 		// tables
 		"QTableWidget { alternate-background-color: #f2f2f2; background-color: #fff; border: none; }"

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Utilities/Log.h"
 
@@ -225,8 +225,9 @@ namespace gui
 	const gui_save tr_games_state   = gui_save(trophy, "games_state",   QByteArray());
 	const gui_save tr_trophy_state  = gui_save(trophy, "trophy_state",  QByteArray());
 
-	const gui_save sd_geometry  = gui_save(savedata, "geometry", QByteArray());
-	const gui_save sd_icon_size = gui_save(savedata, "icon_size", 60);
+	const gui_save sd_geometry   = gui_save(savedata, "geometry",   QByteArray());
+	const gui_save sd_icon_size  = gui_save(savedata, "icon_size",  60);
+	const gui_save sd_icon_color = gui_save(savedata, "icon_color", gl_icon_color);
 
 	const gui_save um_geometry    = gui_save(users, "geometry",    QByteArray());
 	const gui_save um_active_user = gui_save(users, "active_user", "00000001");

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -211,6 +211,7 @@ namespace gui
 	const gui_save gs_width        = gui_save(gs_frame, "width",        1280);
 	const gui_save gs_height       = gui_save(gs_frame, "height",       720);
 
+	const gui_save tr_icon_color    = gui_save(trophy, "icon_color",    gl_icon_color);
 	const gui_save tr_icon_height   = gui_save(trophy, "icon_height",   75);
 	const gui_save tr_game_iconSize = gui_save(trophy, "game_iconSize", 25);
 	const gui_save tr_show_locked   = gui_save(trophy, "show_locked",   true);

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -131,7 +131,7 @@ namespace gui
 	const QString notes       = "Notes";
 	const QString titles      = "Titles";
 
-	const QColor gl_icon_color = QColor(36, 36, 36, 255);
+	const QColor gl_icon_color = QColor(240, 240, 240, 255);
 
 	const gui_save rg_freeze  = gui_save(main_window, "recentGamesFrozen", false);
 	const gui_save rg_entries = gui_save(main_window, "recentGamesNames",  QVariant::fromValue(q_pair_list()));

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1321,8 +1321,9 @@ void main_window::CreateConnects()
 
 	connect(ui->confSavedataManagerAct, &QAction::triggered, [=]
 	{
-		save_manager_dialog* sdid = new save_manager_dialog(guiSettings);
-		sdid->show();
+		save_manager_dialog* save_manager = new save_manager_dialog(guiSettings);
+		connect(this, &main_window::RequestTrophyManagerRepaint, save_manager, &save_manager_dialog::HandleRepaintUiRequest);
+		save_manager->show();
 	});
 
 	connect(ui->actionManage_Trophy_Data, &QAction::triggered, [=]

--- a/rpcs3/rpcs3qt/save_data_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_dialog.cpp
@@ -1,4 +1,4 @@
-#include "save_data_dialog.h"
+﻿#include "save_data_dialog.h"
 #include "save_data_list_dialog.h"
 
 #include <Emu/IdManager.h>

--- a/rpcs3/rpcs3qt/save_data_dialog.h
+++ b/rpcs3/rpcs3qt/save_data_dialog.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "stdafx.h"
 #include "Emu/Memory/vm.h"

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -14,7 +14,7 @@ constexpr auto qstr = QString::fromStdString;
 //Show up the savedata list, either to choose one to save/load or to manage saves.
 //I suggest to use function callbacks to give save data list or get save data entry. (Not implemented or stubbed)
 save_data_list_dialog::save_data_list_dialog(const std::vector<SaveDataEntry>& entries, s32 focusedEntry, u32 op, vm::ptr<CellSaveDataListSet> listSet, QWidget* parent)
-	: QDialog(parent), m_save_entries(entries), m_entry(selection_code::new_save), m_entry_label(nullptr)
+	: QDialog(parent), m_save_entries(entries), m_entry(selection_code::new_save), m_entry_label(nullptr), m_sort_column(0), m_sort_ascending(true)
 {
 	if (op >= 8)
 	{

--- a/rpcs3/rpcs3qt/save_data_list_dialog.h
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // I just want the struct for the save data.
 #include "stdafx.h"
@@ -35,9 +35,9 @@ private:
 	void UpdateList(void);
 
 	s32 m_entry;
-	QLabel* m_entry_label;
+	QLabel* m_entry_label = nullptr;
 
-	QTableWidget* m_list;
+	QTableWidget* m_list = nullptr;
 	std::vector<SaveDataEntry> m_save_entries;
 
 	std::shared_ptr<gui_settings> m_gui_settings;

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -25,7 +25,8 @@ namespace
 	constexpr auto qstr = QString::fromStdString;
 	inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
-	QString FormatTimestamp(u64 time) {
+	QString FormatTimestamp(u64 time)
+	{
 		QDateTime dateTime;
 		dateTime.setTime_t(time);
 		return dateTime.toString("yyyy-MM-dd HH:mm:ss");

--- a/rpcs3/rpcs3qt/save_manager_dialog.h
+++ b/rpcs3/rpcs3qt/save_manager_dialog.h
@@ -21,6 +21,8 @@ public:
 	* There'll be some duplicated code.  But, in the future, there'll be no duplicated code. So, I don't care.
 	*/
 	explicit save_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::string dir = "", QWidget* parent = nullptr);
+public Q_SLOTS:
+	void HandleRepaintUiRequest();
 private Q_SLOTS:
 	void OnEntryRemove();
 	void OnEntriesRemove();
@@ -44,6 +46,7 @@ private:
 	int m_sort_column;
 	bool m_sort_ascending;
 	QSize m_icon_size;
+	QColor m_icon_color;
 
 	QLabel* m_details_icon = nullptr;
 	QLabel* m_details_title = nullptr;

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1280,6 +1280,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		auto AddColoredIcons = [=]()
 		{
 			addColoredIcon(ui->pb_gl_icon_color, xgui_settings->GetValue(gui::gl_iconColor).value<QColor>());
+			addColoredIcon(ui->pb_sd_icon_color, xgui_settings->GetValue(gui::sd_icon_color).value<QColor>());
 		};
 		AddColoredIcons();
 
@@ -1292,6 +1293,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		bool enableUIColors = xgui_settings->GetValue(gui::m_enableUIColors).toBool();
 		ui->cb_custom_colors->setChecked(enableUIColors);
 		ui->pb_gl_icon_color->setEnabled(enableUIColors);
+		ui->pb_sd_icon_color->setEnabled(enableUIColors);
 
 		auto ApplyGuiOptions = [&](bool reset = false)
 		{
@@ -1367,6 +1369,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		{
 			xgui_settings->SetValue(gui::m_enableUIColors, val);
 			ui->pb_gl_icon_color->setEnabled(val);
+			ui->pb_sd_icon_color->setEnabled(val);
 			Q_EMIT GuiRepaintRequest();
 		});
 		auto colorDialog = [&](const gui_save& color, const QString& title, QPushButton *button)
@@ -1394,6 +1397,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		connect(ui->pb_gl_icon_color, &QAbstractButton::clicked, [=]()
 		{
 			colorDialog(gui::gl_iconColor, tr("Choose gamelist icon color"), ui->pb_gl_icon_color);
+		});
+		connect(ui->pb_sd_icon_color, &QAbstractButton::clicked, [=]()
+		{
+			colorDialog(gui::sd_icon_color, tr("Choose save manager icon color"), ui->pb_sd_icon_color);
 		});
 
 		AddConfigs();

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1281,6 +1281,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		{
 			addColoredIcon(ui->pb_gl_icon_color, xgui_settings->GetValue(gui::gl_iconColor).value<QColor>());
 			addColoredIcon(ui->pb_sd_icon_color, xgui_settings->GetValue(gui::sd_icon_color).value<QColor>());
+			addColoredIcon(ui->pb_tr_icon_color, xgui_settings->GetValue(gui::tr_icon_color).value<QColor>());
 		};
 		AddColoredIcons();
 
@@ -1294,6 +1295,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		ui->cb_custom_colors->setChecked(enableUIColors);
 		ui->pb_gl_icon_color->setEnabled(enableUIColors);
 		ui->pb_sd_icon_color->setEnabled(enableUIColors);
+		ui->pb_tr_icon_color->setEnabled(enableUIColors);
 
 		auto ApplyGuiOptions = [&](bool reset = false)
 		{
@@ -1370,6 +1372,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 			xgui_settings->SetValue(gui::m_enableUIColors, val);
 			ui->pb_gl_icon_color->setEnabled(val);
 			ui->pb_sd_icon_color->setEnabled(val);
+			ui->pb_tr_icon_color->setEnabled(val);
 			Q_EMIT GuiRepaintRequest();
 		});
 		auto colorDialog = [&](const gui_save& color, const QString& title, QPushButton *button)
@@ -1401,6 +1404,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		connect(ui->pb_sd_icon_color, &QAbstractButton::clicked, [=]()
 		{
 			colorDialog(gui::sd_icon_color, tr("Choose save manager icon color"), ui->pb_sd_icon_color);
+		});
+		connect(ui->pb_tr_icon_color, &QAbstractButton::clicked, [=]()
+		{
+			colorDialog(gui::tr_icon_color, tr("Choose trophy manager icon color"), ui->pb_tr_icon_color);
 		});
 
 		AddConfigs();

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2056,6 +2056,13 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QPushButton" name="pb_tr_icon_color">
+                  <property name="text">
+                   <string>Trophy manager icons</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <spacer name="verticalSpacer_5">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2049,6 +2049,13 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QPushButton" name="pb_sd_icon_color">
+                  <property name="text">
+                   <string>Save manager icons</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <spacer name="verticalSpacer_5">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -785,7 +785,6 @@ void trophy_manager_dialog::PopulateTrophyTable()
 		QString unlockstate = data->trop_usr->GetTrophyUnlockState(trophy_id) ? tr("Unlocked") : tr("Locked");
 
 		custom_table_widget_item* icon_item = new custom_table_widget_item();
-		icon_item->setData(Qt::DecorationRole, data->trophy_images[trophy_id].scaledToHeight(m_icon_height, Qt::SmoothTransformation));
 		icon_item->setData(Qt::UserRole, hidden, true);
 
 		custom_table_widget_item* type_item = new custom_table_widget_item(trophy_type);
@@ -803,7 +802,7 @@ void trophy_manager_dialog::PopulateTrophyTable()
 
 	m_trophy_table->setSortingEnabled(true); // Re-enable sorting after using setItem calls
 
-	ReadjustTrophyTable();
+	ResizeTrophyIcons();
 }
 
 void trophy_manager_dialog::ReadjustGameTable()

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -319,7 +319,12 @@ trophy_manager_dialog::trophy_manager_dialog(std::shared_ptr<gui_settings> gui_s
 		{
 			return;
 		}
-		m_game_combo->setCurrentText(m_game_table->item(m_game_table->selectedItems().first()->row(), GameColumns::GameName)->text());
+		QTableWidgetItem* item = m_game_table->item(m_game_table->selectedItems().first()->row(), GameColumns::GameName);
+		if (!item)
+		{
+			return;
+		}
+		m_game_combo->setCurrentText(item->text());
 	});
 
 	RepaintUI();
@@ -470,6 +475,10 @@ void trophy_manager_dialog::HandleRepaintUiRequest()
 void trophy_manager_dialog::ResizeGameIcon(int index)
 {
 	QTableWidgetItem* item = m_game_table->item(index, GameColumns::GameIcon);
+	if (!item)
+	{
+		return;
+	}
 	const QPixmap icon = item->data(Qt::UserRole).value<QPixmap>();
 	const int dpr = devicePixelRatio();
 
@@ -512,7 +521,13 @@ void trophy_manager_dialog::ResizeTrophyIcons()
 
 	for (int i = 0; i < m_trophy_table->rowCount(); ++i)
 	{
-		const int trophy_id = m_trophy_table->item(i, TrophyColumns::Id)->text().toInt();
+		QTableWidgetItem* item = m_trophy_table->item(i, TrophyColumns::Id);
+		QTableWidgetItem* icon_item = m_trophy_table->item(i, TrophyColumns::Icon);
+		if (!item || !icon_item)
+		{
+			continue;
+		}
+		const int trophy_id = item->text().toInt();
 		const QPixmap icon = m_trophies_db[db_pos]->trophy_images[trophy_id];
 
 		QPixmap new_icon = QPixmap(icon.size() * dpr);
@@ -527,7 +542,7 @@ void trophy_manager_dialog::ResizeTrophyIcons()
 		}
 
 		const QPixmap scaled = new_icon.scaledToHeight(new_height, Qt::SmoothTransformation);
-		m_trophy_table->item(i, TrophyColumns::Icon)->setData(Qt::DecorationRole, scaled);
+		icon_item->setData(Qt::DecorationRole, scaled);
 	}
 
 	ReadjustTrophyTable();
@@ -542,11 +557,20 @@ void trophy_manager_dialog::ApplyFilter()
 
 	for (int i = 0; i < m_trophy_table->rowCount(); ++i)
 	{
-		int trophy_id = m_trophy_table->item(i, TrophyColumns::Id)->text().toInt();
-		QString trophy_type = m_trophy_table->item(i, TrophyColumns::Type)->text();
+		QTableWidgetItem* item = m_trophy_table->item(i, TrophyColumns::Id);
+		QTableWidgetItem* type_item = m_trophy_table->item(i, TrophyColumns::Type);
+		QTableWidgetItem* icon_item = m_trophy_table->item(i, TrophyColumns::Icon);
+
+		if (!item || !type_item || !icon_item)
+		{
+			continue;
+		}
+
+		const int trophy_id = item->text().toInt();
+		const QString trophy_type = type_item->text();
 
 		// I could use boolean logic and reduce this to something much shorter and also much more confusing...
-		bool hidden = m_trophy_table->item(i, TrophyColumns::Icon)->data(Qt::UserRole).toBool();
+		bool hidden = icon_item->data(Qt::UserRole).toBool();
 		bool trophy_unlocked = m_trophies_db[db_pos]->trop_usr->GetTrophyUnlockState(trophy_id);
 
 		bool hide = false;

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.h
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "stdafx.h"
 #include "rpcs3/Loader/TROPUSR.h"
@@ -64,7 +64,7 @@ class trophy_manager_dialog : public QWidget
 public:
 	explicit trophy_manager_dialog(std::shared_ptr<gui_settings> gui_settings);
 	~trophy_manager_dialog() override;
-	void RepaintUI();
+	void RepaintUI(bool restore_layout = true);
 
 public Q_SLOTS:
 	void HandleRepaintUiRequest();

--- a/rpcs3/xinput_pad_handler.h
+++ b/rpcs3/xinput_pad_handler.h
@@ -135,5 +135,5 @@ private:
 
 	// holds internal controller state change
 	XINPUT_STATE state;
-	DWORD result;
+	DWORD result{ 0 };
 };


### PR DESCRIPTION
Changes the default icon background color to something brighter.

This also adds 2 more gui settings for icon colors: trophy manager icon color and save manager icon color.
You can set these in the gui settings just like the gamelist icon color.

Fixes wrong icon height in the save manager if no icon was found.
Fixes some possible nullpointer exceptions in the save manager and the trophy manager.

Handles some warnings.