### PR TITLE
Reflect proper error code in fs::remove_all on entries removal failures

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1539,7 +1539,7 @@ const std::string& fs::get_cache_dir()
 	return s_dir;
 }
 
-void fs::remove_all(const std::string& path, bool remove_root)
+bool fs::remove_all(const std::string& path, bool remove_root)
 {
 	for (const auto& entry : dir(path))
 	{
@@ -1550,19 +1550,27 @@ void fs::remove_all(const std::string& path, bool remove_root)
 
 		if (entry.is_directory == false)
 		{
-			remove_file(path + '/' + entry.name);
+			if (!remove_file(path + '/' + entry.name))
+			{
+				return false;
+			}
 		}
 
 		if (entry.is_directory == true)
 		{
-			remove_all(path + '/' + entry.name);
+			if (!remove_all(path + '/' + entry.name))
+			{
+				return false;
+			}
 		}
 	}
 
 	if (remove_root)
 	{
-		remove_dir(path);
+		return remove_dir(path);
 	}
+
+	return true;
 }
 
 u64 fs::get_dir_size(const std::string& path)

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -503,7 +503,7 @@ namespace fs
 	const std::string& get_cache_dir();
 
 	// Delete directory and all its contents recursively
-	void remove_all(const std::string& path, bool remove_root = true);
+	bool remove_all(const std::string& path, bool remove_root = true);
 
 	// Get size of all files recursively
 	u64 get_dir_size(const std::string& path);


### PR DESCRIPTION
If one remove_file/all fails inside directory entries iterations, we can't recover from it. So add verifications for it.