### PR TITLE
Fix shifted keys on the basic keyboard handler (windows only)

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(rpcs3_emu
+﻿add_library(rpcs3_emu
 	IdManager.cpp
 	System.cpp
 	VFS.cpp
@@ -298,6 +298,7 @@ target_link_libraries(rpcs3_emu
 
 # Io
 target_sources(rpcs3_emu PRIVATE
+	Io/KeyboardHandler.cpp
 	Io/PadHandler.cpp
 )
 

--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUModule.h"

--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -156,7 +156,7 @@ u16 cellKbCnvRawCode(u32 arrange, u32 mkey, u32 led, u16 rawcode)
 		if (rawcode == CELL_KEYC_PERIOD)                return get_ascii('.', '>');
 		if (rawcode == CELL_KEYC_SLASH)                 return get_ascii('/', '?');
 		if (rawcode == CELL_KEYC_BACKSLASH_106)         return get_ascii('\\', '_');
-		if (rawcode == CELL_KEYC_YEN_106)               return get_ascii('¥', '|');
+		if (rawcode == CELL_KEYC_YEN_106)               return get_ascii(190, '|'); // ¥
 	}
 	else if (arrange == CELL_KB_MAPPING_101) // (US)
 	{
@@ -187,7 +187,7 @@ u16 cellKbCnvRawCode(u32 arrange, u32 mkey, u32 led, u16 rawcode)
 	{
 		if (rawcode == CELL_KEYC_1) return get_ascii('1', '!');
 		if (rawcode == CELL_KEYC_2) return get_ascii('2', '"');
-		if (rawcode == CELL_KEYC_3) return get_ascii('3', '§');
+		if (rawcode == CELL_KEYC_3) return get_ascii('3', 245); // §
 		if (rawcode == CELL_KEYC_4) return get_ascii('4', '$');
 		if (rawcode == CELL_KEYC_5) return get_ascii('5', '%');
 		if (rawcode == CELL_KEYC_6) return get_ascii('6', '&');
@@ -197,14 +197,14 @@ u16 cellKbCnvRawCode(u32 arrange, u32 mkey, u32 led, u16 rawcode)
 		if (rawcode == CELL_KEYC_0) return get_ascii('0', '=', '}');
 
 		if (rawcode == CELL_KEYC_MINUS)                 return get_ascii('-', '_');
-		if (rawcode == CELL_KEYC_ACCENT_CIRCONFLEX_106) return get_ascii('^', '°');
+		if (rawcode == CELL_KEYC_ACCENT_CIRCONFLEX_106) return get_ascii('^', 248); // °
 		if (rawcode == CELL_KEYC_COMMA)                 return get_ascii(',', ';');
 		if (rawcode == CELL_KEYC_PERIOD)                return get_ascii('.', ':');
 		if (rawcode == CELL_KEYC_KPAD_PLUS)             return get_ascii('+', '*', '~');
 		if (rawcode == CELL_KEYC_LESS)                  return get_ascii('<', '>', '|');
 		if (rawcode == CELL_KEYC_HASHTAG)               return get_ascii('#', '\'');
-		if (rawcode == CELL_KEYC_SSHARP)                return get_ascii('ß', '?', '\\');
-		if (rawcode == CELL_KEYC_BACK_QUOTE)            return get_ascii('´', '`');
+		if (rawcode == CELL_KEYC_SSHARP)                return get_ascii(225, '?', '\\'); // ß
+		if (rawcode == CELL_KEYC_BACK_QUOTE)            return get_ascii(239, '`'); // ´
 		if (rawcode == CELL_KEYC_Q)                     return get_ascii('q', 'Q', '@');
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellKb.h
+++ b/rpcs3/Emu/Cell/Modules/cellKb.h
@@ -1,6 +1,7 @@
-#pragma once
+﻿#pragma once
 
 #include "Utilities/BEType.h"
+#include "Emu/Io/Keyboard.h"
 
 enum CellKbError : u32
 {
@@ -12,12 +13,6 @@ enum CellKbError : u32
 	CELL_KB_ERROR_READ_FAILED                = 0x80121006,
 	CELL_KB_ERROR_NO_DEVICE                  = 0x80121007,
 	CELL_KB_ERROR_SYS_SETTING_FAILED         = 0x80121008,
-};
-
-enum
-{
-	CELL_KB_MAX_KEYCODES  = 62,
-	CELL_KB_MAX_KEYBOARDS = 127,
 };
 
 struct CellKbInfo

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -192,7 +192,7 @@ s32 cellSysutilGetSystemParamInt(CellSysutilParamId id, vm::ptr<s32> value)
 	break;
 
 	case CELL_SYSUTIL_SYSTEMPARAM_ID_KEYBOARD_TYPE:
-		*value = 0;
+		*value = g_cfg.sys.keyboard_type;
 	break;
 
 	case CELL_SYSUTIL_SYSTEMPARAM_ID_JAPANESE_KEYBOARD_ENTRY_METHOD:

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.h
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Emu/Memory/vm_ptr.h"
 

--- a/rpcs3/Emu/Io/Keyboard.h
+++ b/rpcs3/Emu/Io/Keyboard.h
@@ -1,0 +1,203 @@
+﻿#pragma once
+
+#include "Utilities/types.h"
+
+enum
+{
+	CELL_KB_MAX_KEYCODES  = 62,
+	CELL_KB_MAX_KEYBOARDS = 127,
+};
+
+enum KbPortStatus
+{
+	CELL_KB_STATUS_DISCONNECTED = 0x00000000,
+	CELL_KB_STATUS_CONNECTED    = 0x00000001,
+};
+
+enum CellKbReadMode
+{
+	CELL_KB_RMODE_INPUTCHAR = 0,
+	CELL_KB_RMODE_PACKET    = 1,
+};
+
+enum CellKbCodeType
+{
+	CELL_KB_CODETYPE_RAW    = 0,
+	CELL_KB_CODETYPE_ASCII  = 1,
+};
+
+enum KbLedCodes
+{
+	CELL_KB_LED_NUM_LOCK    = 0x00000001,
+	CELL_KB_LED_CAPS_LOCK   = 0x00000002,
+	CELL_KB_LED_SCROLL_LOCK = 0x00000004,
+	CELL_KB_LED_COMPOSE     = 0x00000008,
+	CELL_KB_LED_KANA        = 0x00000016,
+};
+
+enum KbMetaKeys
+{
+	CELL_KB_MKEY_L_CTRL  = 0x00000001,
+	CELL_KB_MKEY_L_SHIFT = 0x00000002,
+	CELL_KB_MKEY_L_ALT   = 0x00000004,
+	CELL_KB_MKEY_L_WIN   = 0x00000008,
+	CELL_KB_MKEY_R_CTRL  = 0x00000010,
+	CELL_KB_MKEY_R_SHIFT = 0x00000020,
+	CELL_KB_MKEY_R_ALT   = 0x00000040,
+	CELL_KB_MKEY_R_WIN   = 0x00000080,
+};
+
+enum Keys
+{
+	// Non-ASCII Raw data
+	CELL_KEYC_NO_EVENT    = 0x00,
+	CELL_KEYC_E_ROLLOVER  = 0x01,
+	CELL_KEYC_E_POSTFAIL  = 0x02,
+	CELL_KEYC_E_UNDEF     = 0x03,
+	CELL_KEYC_ESCAPE      = 0x29,
+	CELL_KEYC_106_KANJI   = 0x35,
+	CELL_KEYC_CAPS_LOCK   = 0x39,
+	CELL_KEYC_F1          = 0x3a,
+	CELL_KEYC_F2          = 0x3b,
+	CELL_KEYC_F3          = 0x3c,
+	CELL_KEYC_F4          = 0x3d,
+	CELL_KEYC_F5          = 0x3e,
+	CELL_KEYC_F6          = 0x3f,
+	CELL_KEYC_F7          = 0x40,
+	CELL_KEYC_F8          = 0x41,
+	CELL_KEYC_F9          = 0x42,
+	CELL_KEYC_F10         = 0x43,
+	CELL_KEYC_F11         = 0x44,
+	CELL_KEYC_F12         = 0x45,
+	CELL_KEYC_PRINTSCREEN = 0x46,
+	CELL_KEYC_SCROLL_LOCK = 0x47,
+	CELL_KEYC_PAUSE       = 0x48,
+	CELL_KEYC_INSERT      = 0x49,
+	CELL_KEYC_HOME        = 0x4a,
+	CELL_KEYC_PAGE_UP     = 0x4b,
+	CELL_KEYC_DELETE      = 0x4c,
+	CELL_KEYC_END         = 0x4d,
+	CELL_KEYC_PAGE_DOWN   = 0x4e,
+	CELL_KEYC_RIGHT_ARROW = 0x4f,
+	CELL_KEYC_LEFT_ARROW  = 0x50,
+	CELL_KEYC_DOWN_ARROW  = 0x51,
+	CELL_KEYC_UP_ARROW    = 0x52,
+	CELL_KEYC_NUM_LOCK    = 0x53,
+	CELL_KEYC_APPLICATION = 0x65,
+	CELL_KEYC_KANA        = 0x88,
+	CELL_KEYC_HENKAN      = 0x8a,
+	CELL_KEYC_MUHENKAN    = 0x8b,
+	
+	// Raw keycodes for ASCII keys
+	CELL_KEYC_A                     = 0x04,
+	CELL_KEYC_B                     = 0x05,
+	CELL_KEYC_C                     = 0x06,
+	CELL_KEYC_D                     = 0x07,
+	CELL_KEYC_E                     = 0x08,
+	CELL_KEYC_F                     = 0x09,
+	CELL_KEYC_G                     = 0x0A,
+	CELL_KEYC_H                     = 0x0B,
+	CELL_KEYC_I                     = 0x0C,
+	CELL_KEYC_J                     = 0x0D,
+	CELL_KEYC_K                     = 0x0E,
+	CELL_KEYC_L                     = 0x0F,
+	CELL_KEYC_M                     = 0x10,
+	CELL_KEYC_N                     = 0x11,
+	CELL_KEYC_O                     = 0x12,
+	CELL_KEYC_P                     = 0x13,
+	CELL_KEYC_Q                     = 0x14,
+	CELL_KEYC_R                     = 0x15,
+	CELL_KEYC_S                     = 0x16,
+	CELL_KEYC_T                     = 0x17,
+	CELL_KEYC_U                     = 0x18,
+	CELL_KEYC_V                     = 0x19,
+	CELL_KEYC_W                     = 0x1A,
+	CELL_KEYC_X                     = 0x1B,
+	CELL_KEYC_Y                     = 0x1C,
+	CELL_KEYC_Z                     = 0x1D,
+	CELL_KEYC_1                     = 0x1E,
+	CELL_KEYC_2                     = 0x1F,
+	CELL_KEYC_3                     = 0x20,
+	CELL_KEYC_4                     = 0x21,
+	CELL_KEYC_5                     = 0x22,
+	CELL_KEYC_6                     = 0x23,
+	CELL_KEYC_7                     = 0x24,
+	CELL_KEYC_8                     = 0x25,
+	CELL_KEYC_9                     = 0x26,
+	CELL_KEYC_0                     = 0x27,
+	CELL_KEYC_ENTER                 = 0x28,
+	CELL_KEYC_ESC                   = 0x29,
+	CELL_KEYC_BS                    = 0x2A,
+	CELL_KEYC_TAB                   = 0x2B,
+	CELL_KEYC_SPACE                 = 0x2C,
+	CELL_KEYC_MINUS                 = 0x2D,
+	CELL_KEYC_EQUAL_101             = 0x2E,
+	CELL_KEYC_ACCENT_CIRCONFLEX_106 = 0x2E,
+	CELL_KEYC_LEFT_BRACKET_101      = 0x2F,
+	CELL_KEYC_ATMARK_106            = 0x2F,
+	CELL_KEYC_RIGHT_BRACKET_101     = 0x30,
+	CELL_KEYC_LEFT_BRACKET_106      = 0x30,
+	CELL_KEYC_BACKSLASH_101         = 0x31,
+	CELL_KEYC_RIGHT_BRACKET_106     = 0x32,
+	CELL_KEYC_SEMICOLON             = 0x33,
+	CELL_KEYC_QUOTATION_101         = 0x34,
+	CELL_KEYC_COLON_106             = 0x34,
+	CELL_KEYC_COMMA                 = 0x36,
+	CELL_KEYC_PERIOD                = 0x37,
+	CELL_KEYC_SLASH                 = 0x38,
+	//CELL_KEYC_CAPS_LOCK             = 0x39,
+	CELL_KEYC_KPAD_NUMLOCK          = 0x53,
+	CELL_KEYC_KPAD_SLASH            = 0x54,
+	CELL_KEYC_KPAD_ASTERISK         = 0x55,
+	CELL_KEYC_KPAD_MINUS            = 0x56,
+	CELL_KEYC_KPAD_PLUS             = 0x57,
+	CELL_KEYC_KPAD_ENTER            = 0x58,
+	CELL_KEYC_KPAD_1                = 0x59,
+	CELL_KEYC_KPAD_2                = 0x5A,
+	CELL_KEYC_KPAD_3                = 0x5B,
+	CELL_KEYC_KPAD_4                = 0x5C,
+	CELL_KEYC_KPAD_5                = 0x5D,
+	CELL_KEYC_KPAD_6                = 0x5E,
+	CELL_KEYC_KPAD_7                = 0x5F,
+	CELL_KEYC_KPAD_8                = 0x60,
+	CELL_KEYC_KPAD_9                = 0x61,
+	CELL_KEYC_KPAD_0                = 0x62,
+	CELL_KEYC_KPAD_PERIOD           = 0x63,
+	CELL_KEYC_BACKSLASH_106         = 0x87,
+	CELL_KEYC_YEN_106               = 0x89,
+
+	// Made up helper codes (Maybe there's a real code somewhere hidden in the SDK)
+	CELL_KEYC_LESS        = 0x90,
+	CELL_KEYC_HASHTAG     = 0x91,
+	CELL_KEYC_SSHARP      = 0x92,
+	CELL_KEYC_BACK_QUOTE  = 0x93
+};
+
+enum CellKbMappingType : s32
+{
+	CELL_KB_MAPPING_101                      = 0,
+	CELL_KB_MAPPING_106                      = 1,
+	CELL_KB_MAPPING_106_KANA                 = 2,
+	CELL_KB_MAPPING_GERMAN_GERMANY           = 3,
+	CELL_KB_MAPPING_SPANISH_SPAIN            = 4,
+	CELL_KB_MAPPING_FRENCH_FRANCE            = 5,
+	CELL_KB_MAPPING_ITALIAN_ITALY            = 6,
+	CELL_KB_MAPPING_DUTCH_NETHERLANDS        = 7,
+	CELL_KB_MAPPING_PORTUGUESE_PORTUGAL      = 8,
+	CELL_KB_MAPPING_RUSSIAN_RUSSIA           = 9,
+	CELL_KB_MAPPING_ENGLISH_UK               = 10,
+	CELL_KB_MAPPING_KOREAN_KOREA             = 11,
+	CELL_KB_MAPPING_NORWEGIAN_NORWAY         = 12,
+	CELL_KB_MAPPING_FINNISH_FINLAND          = 13,
+	CELL_KB_MAPPING_DANISH_DENMARK           = 14,
+	CELL_KB_MAPPING_SWEDISH_SWEDEN           = 15,
+	CELL_KB_MAPPING_CHINESE_TRADITIONAL      = 16,
+	CELL_KB_MAPPING_CHINESE_SIMPLIFIED       = 17,
+	CELL_KB_MAPPING_SWISS_FRENCH_SWITZERLAND = 18,
+	CELL_KB_MAPPING_SWISS_GERMAN_SWITZERLAND = 19,
+	CELL_KB_MAPPING_CANADIAN_FRENCH_CANADA   = 20,
+	CELL_KB_MAPPING_BELGIAN_BELGIUM          = 21,
+	CELL_KB_MAPPING_POLISH_POLAND            = 22,
+	CELL_KB_MAPPING_PORTUGUESE_BRAZIL        = 23,
+	CELL_KB_MAPPING_TURKISH_TURKEY           = 24
+};

--- a/rpcs3/Emu/Io/KeyboardHandler.cpp
+++ b/rpcs3/Emu/Io/KeyboardHandler.cpp
@@ -89,7 +89,7 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed)
 					}
 					else
 					{
-						data.keycode[data.len % KB_MAX_KEYCODES] = { CELL_KEYC_NO_EVENT, button.m_outKeyCode };
+						data.keycode[data.len % CELL_KB_MAX_KEYCODES] = { CELL_KEYC_NO_EVENT, button.m_outKeyCode };
 					}
 				}
 				else
@@ -107,11 +107,11 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed)
 					}
 					else
 					{
-						data.keycode[data.len % KB_MAX_KEYCODES] = { kcode, 0 };
+						data.keycode[data.len % CELL_KB_MAX_KEYCODES] = { kcode, 0 };
 					}
 				}
 
-				data.len = std::min(data.len + 1, (int)KB_MAX_KEYCODES);
+				data.len = std::min(data.len + 1, (int)CELL_KB_MAX_KEYCODES);
 			}
 			else
 			{

--- a/rpcs3/Emu/Io/KeyboardHandler.cpp
+++ b/rpcs3/Emu/Io/KeyboardHandler.cpp
@@ -1,0 +1,167 @@
+﻿#include "stdafx.h"
+#include "KeyboardHandler.h"
+#include "Utilities/StrUtil.h"
+
+template <>
+void fmt_class_string<CellKbMappingType>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](CellKbMappingType value)
+	{
+		switch (value)
+		{
+		case CELL_KB_MAPPING_101: return "English keyboard (US standard)";
+		case CELL_KB_MAPPING_106: return "Japanese keyboard";
+		case CELL_KB_MAPPING_106_KANA: return "Japanese keyboard(Kana state)";
+		case CELL_KB_MAPPING_GERMAN_GERMANY: return "German keyboard";
+		case CELL_KB_MAPPING_SPANISH_SPAIN: return "Spanish keyboard";
+		case CELL_KB_MAPPING_FRENCH_FRANCE: return "French keyboard";
+		case CELL_KB_MAPPING_ITALIAN_ITALY: return "Italian keyboard";
+		case CELL_KB_MAPPING_DUTCH_NETHERLANDS: return "Dutch keyboard";
+		case CELL_KB_MAPPING_PORTUGUESE_PORTUGAL: return "Portuguese keyboard(Portugal)";
+		case CELL_KB_MAPPING_RUSSIAN_RUSSIA: return "Russian keyboard";
+		case CELL_KB_MAPPING_ENGLISH_UK: return "English keyboard(UK standard)";
+		case CELL_KB_MAPPING_KOREAN_KOREA: return "Korean keyboard";
+		case CELL_KB_MAPPING_NORWEGIAN_NORWAY: return "Norwegian keyboard";
+		case CELL_KB_MAPPING_FINNISH_FINLAND: return "Finnish keyboard";
+		case CELL_KB_MAPPING_DANISH_DENMARK: return "Danish keyboard";
+		case CELL_KB_MAPPING_SWEDISH_SWEDEN: return "Swedish keyboard";
+		case CELL_KB_MAPPING_CHINESE_TRADITIONAL: return "Chinese keyboard(Traditional)";
+		case CELL_KB_MAPPING_CHINESE_SIMPLIFIED: return "Chinese keyboard(Simplified)";
+		case CELL_KB_MAPPING_SWISS_FRENCH_SWITZERLAND: return "French keyboard(Switzerland)";
+		case CELL_KB_MAPPING_SWISS_GERMAN_SWITZERLAND: return "German keyboard(Switzerland)";
+		case CELL_KB_MAPPING_CANADIAN_FRENCH_CANADA: return "French keyboard(Canada)";
+		case CELL_KB_MAPPING_BELGIAN_BELGIUM: return "French keyboard(Belgium)";
+		case CELL_KB_MAPPING_POLISH_POLAND: return "Polish keyboard";
+		case CELL_KB_MAPPING_PORTUGUESE_BRAZIL: return "Portuguese keyboard(Brazil)";
+		case CELL_KB_MAPPING_TURKISH_TURKEY: return "Turkish keyboard";
+		}
+
+		return unknown;
+	});
+}
+
+void KeyboardHandlerBase::Key(u32 code, bool pressed)
+{
+	// TODO: Key Repeat
+
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	for (Keyboard& keyboard : m_keyboards)
+	{
+		KbData& data = keyboard.m_data;
+		KbConfig& config = keyboard.m_config;
+
+		for (const KbButton& button : keyboard.m_buttons)
+		{
+			if (button.m_keyCode != code)
+				continue;
+
+			u16 kcode = CELL_KEYC_NO_EVENT;
+			bool is_meta_key = IsMetaKey(code);
+
+			if (!is_meta_key)
+			{
+				if (config.code_type == CELL_KB_CODETYPE_RAW)
+				{
+					kcode = button.m_outKeyCode;
+				}
+				else // config.code_type == CELL_KB_CODETYPE_ASCII
+				{
+					kcode = cellKbCnvRawCode(config.arrange, data.mkey, data.led, button.m_outKeyCode);
+				}
+			}
+
+			if (pressed)
+			{
+				if (data.len == 1 && data.keycode[0].first == CELL_KEYC_NO_EVENT)
+				{
+					data.len = 0;
+				}
+
+				// Meta Keys
+				if (is_meta_key)
+				{
+					data.mkey |= button.m_outKeyCode;
+
+					if (config.read_mode == CELL_KB_RMODE_INPUTCHAR)
+					{
+						data.keycode[0] = { CELL_KEYC_NO_EVENT, button.m_outKeyCode };
+					}
+					else
+					{
+						data.keycode[data.len % KB_MAX_KEYCODES] = { CELL_KEYC_NO_EVENT, button.m_outKeyCode };
+					}
+				}
+				else
+				{
+					// Led Keys
+					if (code == Key_CapsLock)   data.led ^= CELL_KB_LED_CAPS_LOCK;
+					if (code == Key_NumLock)    data.led ^= CELL_KB_LED_NUM_LOCK;
+					if (code == Key_ScrollLock) data.led ^= CELL_KB_LED_SCROLL_LOCK;
+					// if (code == Key_Kana_Lock) data.led ^= CELL_KB_LED_KANA;
+					// if (code == ???) data.led ^= CELL_KB_LED_COMPOSE;
+
+					if (config.read_mode == CELL_KB_RMODE_INPUTCHAR)
+					{
+						data.keycode[0] = { kcode, 0 };
+					}
+					else
+					{
+						data.keycode[data.len % KB_MAX_KEYCODES] = { kcode, 0 };
+					}
+				}
+
+				data.len = std::min(data.len + 1, (int)KB_MAX_KEYCODES);
+			}
+			else
+			{
+				// Meta Keys
+				if (is_meta_key)
+				{
+					data.mkey &= ~button.m_outKeyCode;
+				}
+
+				// Needed to indicate key releases. Without this you have to tap another key before using the same key again
+				if (config.read_mode == CELL_KB_RMODE_INPUTCHAR)
+				{
+					data.keycode[0] = { CELL_KEYC_NO_EVENT, 0 };
+					data.len = 1;
+				}
+				else
+				{
+					s32 index = data.len;
+
+					for (s32 i = 0; i < data.len; i++)
+					{
+						if (data.keycode[i].first == kcode && (!is_meta_key || data.keycode[i].second == button.m_outKeyCode))
+						{
+							index = i;
+							break;
+						}
+					}
+
+					for (s32 i = index; i < data.len - 1; i++)
+					{
+						data.keycode[i] = data.keycode[i + 1];
+					}
+
+					if (data.len <= 1)
+					{
+						data.keycode[0] = { CELL_KEYC_NO_EVENT, 0 };
+					}
+
+					data.len = std::max(1, data.len - 1);
+				}
+			}
+		}
+	}
+}
+
+bool KeyboardHandlerBase::IsMetaKey(u32 code)
+{
+	return code == Key_Control
+		|| code == Key_Shift
+		|| code == Key_Alt
+		|| code == Key_Super_L
+		|| code == Key_Super_R;
+}

--- a/rpcs3/Emu/Io/KeyboardHandler.h
+++ b/rpcs3/Emu/Io/KeyboardHandler.h
@@ -1,200 +1,10 @@
 ﻿#pragma once
 
-#include "Utilities/types.h"
+#include "Keyboard.h"
 
 #include <mutex>
 
-// TODO: HLE info (constants, structs, etc.) should not be available here
-
 extern u16 cellKbCnvRawCode(u32 arrange, u32 mkey, u32 led, u16 rawcode); // (TODO: Can it be problematic to place SysCalls in middle of nowhere?)
-
-enum KbPortStatus
-{
-	CELL_KB_STATUS_DISCONNECTED = 0x00000000,
-	CELL_KB_STATUS_CONNECTED    = 0x00000001,
-};
-
-enum CellKbReadMode
-{
-  CELL_KB_RMODE_INPUTCHAR = 0,
-  CELL_KB_RMODE_PACKET    = 1,
-};
-
-enum CellKbCodeType
-{
-  CELL_KB_CODETYPE_RAW    = 0,
-  CELL_KB_CODETYPE_ASCII  = 1,
-};
-
-enum KbLedCodes
-{
-	CELL_KB_LED_NUM_LOCK    = 0x00000001,
-	CELL_KB_LED_CAPS_LOCK   = 0x00000002,
-	CELL_KB_LED_SCROLL_LOCK = 0x00000004,
-	CELL_KB_LED_COMPOSE     = 0x00000008,
-	CELL_KB_LED_KANA        = 0x00000016,
-};
-
-enum KbMetaKeys
-{
-	CELL_KB_MKEY_L_CTRL  = 0x00000001,
-	CELL_KB_MKEY_L_SHIFT = 0x00000002,
-	CELL_KB_MKEY_L_ALT   = 0x00000004,
-	CELL_KB_MKEY_L_WIN   = 0x00000008,
-	CELL_KB_MKEY_R_CTRL  = 0x00000010,
-	CELL_KB_MKEY_R_SHIFT = 0x00000020,
-	CELL_KB_MKEY_R_ALT   = 0x00000040,
-	CELL_KB_MKEY_R_WIN   = 0x00000080,
-};
-
-enum Keys
-{
-	// Non-ASCII Raw data
-	CELL_KEYC_NO_EVENT    = 0x00,
-	CELL_KEYC_E_ROLLOVER  = 0x01,
-	CELL_KEYC_E_POSTFAIL  = 0x02,
-	CELL_KEYC_E_UNDEF     = 0x03,
-	CELL_KEYC_ESCAPE      = 0x29,
-	CELL_KEYC_106_KANJI   = 0x35,
-	CELL_KEYC_CAPS_LOCK   = 0x39,
-	CELL_KEYC_F1          = 0x3a,
-	CELL_KEYC_F2          = 0x3b,
-	CELL_KEYC_F3          = 0x3c,
-	CELL_KEYC_F4          = 0x3d,
-	CELL_KEYC_F5          = 0x3e,
-	CELL_KEYC_F6          = 0x3f,
-	CELL_KEYC_F7          = 0x40,
-	CELL_KEYC_F8          = 0x41,
-	CELL_KEYC_F9          = 0x42,
-	CELL_KEYC_F10         = 0x43,
-	CELL_KEYC_F11         = 0x44,
-	CELL_KEYC_F12         = 0x45,
-	CELL_KEYC_PRINTSCREEN = 0x46,
-	CELL_KEYC_SCROLL_LOCK = 0x47,
-	CELL_KEYC_PAUSE       = 0x48,
-	CELL_KEYC_INSERT      = 0x49,
-	CELL_KEYC_HOME        = 0x4a,
-	CELL_KEYC_PAGE_UP     = 0x4b,
-	CELL_KEYC_DELETE      = 0x4c,
-	CELL_KEYC_END         = 0x4d,
-	CELL_KEYC_PAGE_DOWN   = 0x4e,
-	CELL_KEYC_RIGHT_ARROW = 0x4f,
-	CELL_KEYC_LEFT_ARROW  = 0x50,
-	CELL_KEYC_DOWN_ARROW  = 0x51,
-	CELL_KEYC_UP_ARROW    = 0x52,
-	CELL_KEYC_NUM_LOCK    = 0x53,
-	CELL_KEYC_APPLICATION = 0x65,
-	CELL_KEYC_KANA        = 0x88,
-	CELL_KEYC_HENKAN      = 0x8a,
-	CELL_KEYC_MUHENKAN    = 0x8b,
-	
-	// Raw keycodes for ASCII keys
-	CELL_KEYC_A                     = 0x04,
-	CELL_KEYC_B                     = 0x05,
-	CELL_KEYC_C                     = 0x06,
-	CELL_KEYC_D                     = 0x07,
-	CELL_KEYC_E                     = 0x08,
-	CELL_KEYC_F                     = 0x09,
-	CELL_KEYC_G                     = 0x0A,
-	CELL_KEYC_H                     = 0x0B,
-	CELL_KEYC_I                     = 0x0C,
-	CELL_KEYC_J                     = 0x0D,
-	CELL_KEYC_K                     = 0x0E,
-	CELL_KEYC_L                     = 0x0F,
-	CELL_KEYC_M                     = 0x10,
-	CELL_KEYC_N                     = 0x11,
-	CELL_KEYC_O                     = 0x12,
-	CELL_KEYC_P                     = 0x13,
-	CELL_KEYC_Q                     = 0x14,
-	CELL_KEYC_R                     = 0x15,
-	CELL_KEYC_S                     = 0x16,
-	CELL_KEYC_T                     = 0x17,
-	CELL_KEYC_U                     = 0x18,
-	CELL_KEYC_V                     = 0x19,
-	CELL_KEYC_W                     = 0x1A,
-	CELL_KEYC_X                     = 0x1B,
-	CELL_KEYC_Y                     = 0x1C,
-	CELL_KEYC_Z                     = 0x1D,
-	CELL_KEYC_1                     = 0x1E,
-	CELL_KEYC_2                     = 0x1F,
-	CELL_KEYC_3                     = 0x20,
-	CELL_KEYC_4                     = 0x21,
-	CELL_KEYC_5                     = 0x22,
-	CELL_KEYC_6                     = 0x23,
-	CELL_KEYC_7                     = 0x24,
-	CELL_KEYC_8                     = 0x25,
-	CELL_KEYC_9                     = 0x26,
-	CELL_KEYC_0                     = 0x27,
-	CELL_KEYC_ENTER                 = 0x28,
-	CELL_KEYC_ESC                   = 0x29,
-	CELL_KEYC_BS                    = 0x2A,
-	CELL_KEYC_TAB                   = 0x2B,
-	CELL_KEYC_SPACE                 = 0x2C,
-	CELL_KEYC_MINUS                 = 0x2D,
-	CELL_KEYC_EQUAL_101             = 0x2E,
-	CELL_KEYC_ACCENT_CIRCONFLEX_106 = 0x2E,
-	CELL_KEYC_LEFT_BRACKET_101      = 0x2F,
-	CELL_KEYC_ATMARK_106            = 0x2F,
-	CELL_KEYC_RIGHT_BRACKET_101     = 0x30,
-	CELL_KEYC_LEFT_BRACKET_106      = 0x30,
-	CELL_KEYC_BACKSLASH_101         = 0x31,
-	CELL_KEYC_RIGHT_BRACKET_106     = 0x32,
-	CELL_KEYC_SEMICOLON             = 0x33,
-	CELL_KEYC_QUOTATION_101         = 0x34,
-	CELL_KEYC_COLON_106             = 0x34,
-	CELL_KEYC_COMMA                 = 0x36,
-	CELL_KEYC_PERIOD                = 0x37,
-	CELL_KEYC_SLASH                 = 0x38,
-	//CELL_KEYC_CAPS_LOCK             = 0x39,
-	CELL_KEYC_KPAD_NUMLOCK          = 0x53,
-	CELL_KEYC_KPAD_SLASH            = 0x54,
-	CELL_KEYC_KPAD_ASTERISK         = 0x55,
-	CELL_KEYC_KPAD_MINUS            = 0x56,
-	CELL_KEYC_KPAD_PLUS             = 0x57,
-	CELL_KEYC_KPAD_ENTER            = 0x58,
-	CELL_KEYC_KPAD_1                = 0x59,
-	CELL_KEYC_KPAD_2                = 0x5A,
-	CELL_KEYC_KPAD_3                = 0x5B,
-	CELL_KEYC_KPAD_4                = 0x5C,
-	CELL_KEYC_KPAD_5                = 0x5D,
-	CELL_KEYC_KPAD_6                = 0x5E,
-	CELL_KEYC_KPAD_7                = 0x5F,
-	CELL_KEYC_KPAD_8                = 0x60,
-	CELL_KEYC_KPAD_9                = 0x61,
-	CELL_KEYC_KPAD_0                = 0x62,
-	CELL_KEYC_KPAD_PERIOD           = 0x63,
-	CELL_KEYC_BACKSLASH_106         = 0x87,
-	CELL_KEYC_YEN_106               = 0x89,
-};
-
-enum CellKbMappingType : s32
-{
-	CELL_KB_MAPPING_101,
-	CELL_KB_MAPPING_106,
-	CELL_KB_MAPPING_106_KANA,
-	CELL_KB_MAPPING_GERMAN_GERMANY,
-	CELL_KB_MAPPING_SPANISH_SPAIN,
-	CELL_KB_MAPPING_FRENCH_FRANCE,
-	CELL_KB_MAPPING_ITALIAN_ITALY,
-	CELL_KB_MAPPING_DUTCH_NETHERLANDS,
-	CELL_KB_MAPPING_PORTUGUESE_PORTUGAL,
-	CELL_KB_MAPPING_RUSSIAN_RUSSIA,
-	CELL_KB_MAPPING_ENGLISH_UK,
-	CELL_KB_MAPPING_KOREAN_KOREA,
-	CELL_KB_MAPPING_NORWEGIAN_NORWAY,
-	CELL_KB_MAPPING_FINNISH_FINLAND,
-	CELL_KB_MAPPING_DANISH_DENMARK,
-	CELL_KB_MAPPING_SWEDISH_SWEDEN,
-	CELL_KB_MAPPING_CHINESE_TRADITIONAL,
-	CELL_KB_MAPPING_CHINESE_SIMPLIFIED,
-	CELL_KB_MAPPING_SWISS_FRENCH_SWITZERLAND,
-	CELL_KB_MAPPING_SWISS_GERMAN_SWITZERLAND,
-	CELL_KB_MAPPING_CANADIAN_FRENCH_CANADA,
-	CELL_KB_MAPPING_BELGIAN_BELGIUM,
-	CELL_KB_MAPPING_POLISH_POLAND,
-	CELL_KB_MAPPING_PORTUGUESE_BRAZIL,
-	CELL_KB_MAPPING_TURKISH_TURKEY
-};
 
 enum QtKeys
 {
@@ -209,15 +19,12 @@ enum QtKeys
 	Key_Super_R    = 0x01000054
 };
 
-static const u32 KB_MAX_KEYBOARDS = 127;
-static const u32 KB_MAX_KEYCODES = 62;
-
 struct KbInfo
 {
 	u32 max_connect;
 	u32 now_connect;
 	u32 info;
-	u8 status[KB_MAX_KEYBOARDS];
+	u8 status[CELL_KB_MAX_KEYBOARDS];
 };
 
 struct KbData
@@ -225,7 +32,7 @@ struct KbData
 	u32 led;
 	u32 mkey;
 	s32 len;
-	std::pair<u16, u32> keycode[KB_MAX_KEYCODES];
+	std::pair<u16, u32> keycode[CELL_KB_MAX_KEYCODES];
 
 	KbData()
 		: led(0)

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -203,6 +203,7 @@ enum enter_button_assign
 
 enum CellNetCtlState : s32;
 enum CellSysutilLang : s32;
+enum CellKbMappingType : s32;
 
 struct EmuCallbacks
 {
@@ -590,6 +591,7 @@ struct cfg_root : cfg::node
 		node_sys(cfg::node* _this) : cfg::node(_this, "System") {}
 
 		cfg::_enum<CellSysutilLang> language{this, "Language", (CellSysutilLang)1}; // CELL_SYSUTIL_LANG_ENGLISH_US
+		cfg::_enum<CellKbMappingType> keyboard_type{this, "Keyboard Type", (CellKbMappingType)0}; // CELL_KB_MAPPING_101 = US
 		cfg::_enum<enter_button_assign> enter_button_assignment{this, "Enter button assignment", enter_button_assign::cross};
 
 	} sys{this};

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -158,6 +158,7 @@
 	},
 	"system": {
 		"sysLangBox": "Some games may fail to boot if the system language is not available in the game itself.\nOther games will switch language automatically to what is selected here.\nIt is recommended leaving this on a language supported by the game.",
+		"keyboardType": "Sets the used keyboard layout.\nCurrently only US, Japanese and German layouts are fully supported at this moment.",
 		"enterButtonAssignment": "The button used for enter/accept/confirm in system dialogs.\nChange this to use the circle button instead, which is the default configuration on Japanese systems and in many Japanese games.\nIn these cases having the cross button assigned can often lead to confusion.",
 		"enableHostRoot": "Required for some Homebrew.\nIf unsure, don't use this option.",
 		"limitCacheSize": "Automatically removes older files from disk cache on boot if it grows larger than the specified value.\nGames can use the cache folder to temporarily store data outside of system memory. It is not used for long-term storage."

--- a/rpcs3/basic_keyboard_handler.cpp
+++ b/rpcs3/basic_keyboard_handler.cpp
@@ -130,12 +130,12 @@ s32 basic_keyboard_handler::getUnmodifiedKey(QKeyEvent* keyEvent)
 		return key;
 	}
 
-	UINT raw_key = static_cast<UINT>(key);
+	u32 raw_key = static_cast<u32>(key);
 
 #ifdef _WIN32
 	if (keyEvent->modifiers() != Qt::NoModifier && !keyEvent->text().isEmpty())
 	{
-		UINT mapped_key = MapVirtualKeyA((UINT)keyEvent->nativeVirtualKey(), MAPVK_VK_TO_CHAR);
+		u32 mapped_key = (u32)MapVirtualKeyA((UINT)keyEvent->nativeVirtualKey(), MAPVK_VK_TO_CHAR);
 
 		if (raw_key != mapped_key)
 		{

--- a/rpcs3/basic_keyboard_handler.cpp
+++ b/rpcs3/basic_keyboard_handler.cpp
@@ -1,4 +1,4 @@
-﻿#include "basic_keyboard_handler.h"
+#include "basic_keyboard_handler.h"
 
 #include <QApplication>
 #include <QKeyEvent>
@@ -15,10 +15,7 @@ void basic_keyboard_handler::Init(const u32 max_connect)
 	{
 		Keyboard kb = Keyboard();
 
-		// Only differentiate between japanese and us layouts right now
-		kb.m_config.arrange = g_cfg.sys.language == 0 // CELL_SYSUTIL_LANG_JAPANESE
-			? CELL_KB_MAPPING_106
-			: CELL_KB_MAPPING_101;
+		kb.m_config.arrange = g_cfg.sys.keyboard_type;
 
 		m_keyboards.emplace_back();
 	}

--- a/rpcs3/basic_keyboard_handler.cpp
+++ b/rpcs3/basic_keyboard_handler.cpp
@@ -250,7 +250,6 @@ void basic_keyboard_handler::LoadSettings()
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_9, CELL_KEYC_9);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_0, CELL_KEYC_0);
 
-
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Return, CELL_KEYC_ENTER);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Backspace, CELL_KEYC_BS);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Tab, CELL_KEYC_TAB);
@@ -265,11 +264,18 @@ void basic_keyboard_handler::LoadSettings()
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Backslash, CELL_KEYC_BACKSLASH_101);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_BracketRight, CELL_KEYC_RIGHT_BRACKET_106);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Semicolon, CELL_KEYC_SEMICOLON);
-	m_keyboards[0].m_buttons.emplace_back(Qt::Key_QuoteDbl, CELL_KEYC_QUOTATION_101);
+	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Apostrophe, CELL_KEYC_QUOTATION_101);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Colon, CELL_KEYC_COLON_106);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Comma, CELL_KEYC_COMMA);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Period, CELL_KEYC_PERIOD);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Slash, CELL_KEYC_SLASH);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Backslash, CELL_KEYC_BACKSLASH_106);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_yen, CELL_KEYC_YEN_106);
+
+	// Made up helper buttons
+	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Less, CELL_KEYC_LESS);
+	m_keyboards[0].m_buttons.emplace_back(Qt::Key_NumberSign, CELL_KEYC_HASHTAG);
+	m_keyboards[0].m_buttons.emplace_back(Qt::Key_ssharp, CELL_KEYC_SSHARP);
+	m_keyboards[0].m_buttons.emplace_back(Qt::Key_QuoteLeft, CELL_KEYC_BACK_QUOTE);
+	m_keyboards[0].m_buttons.emplace_back(Qt::Key_acute, CELL_KEYC_BACK_QUOTE);
 }

--- a/rpcs3/basic_keyboard_handler.h
+++ b/rpcs3/basic_keyboard_handler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "stdafx.h"
 #include "Emu/Io/KeyboardHandler.h"
@@ -18,6 +18,7 @@ public:
 	bool eventFilter(QObject* obj, QEvent* ev) override;
 	void keyPressEvent(QKeyEvent* event);
 	void keyReleaseEvent(QKeyEvent* event);
+	int getUnmodifiedKey(QKeyEvent* event);
 	void LoadSettings();
 private:
 	QWindow* m_target = nullptr;

--- a/rpcs3/basic_keyboard_handler.h
+++ b/rpcs3/basic_keyboard_handler.h
@@ -18,7 +18,7 @@ public:
 	bool eventFilter(QObject* obj, QEvent* ev) override;
 	void keyPressEvent(QKeyEvent* event);
 	void keyReleaseEvent(QKeyEvent* event);
-	int getUnmodifiedKey(QKeyEvent* event);
+	s32 getUnmodifiedKey(QKeyEvent* event);
 	void LoadSettings();
 private:
 	QWindow* m_target = nullptr;

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -372,6 +372,7 @@
   <ItemGroup>
     <ClInclude Include="..\3rdparty\stblib\stb_image.h" />
     <ClInclude Include="..\Utilities\address_range.h" />
+    <ClInclude Include="Emu\Io\Keyboard.h" />
     <ClInclude Include="util\atomic.hpp" />
     <ClInclude Include="..\Utilities\AtomicPtr.h" />
     <ClInclude Include="..\Utilities\BEType.h" />

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -69,6 +69,7 @@
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Emu\Io\KeyboardHandler.cpp" />
     <ClCompile Include="util\atomic.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -812,6 +812,9 @@
     <ClCompile Include="Emu\RSX\RSXOffload.cpp">
       <Filter>Emu\GPU\RSX</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\Io\KeyboardHandler.cpp">
+      <Filter>Emu\Io</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1540,5 +1540,8 @@
     <ClInclude Include="Emu\RSX\RSXOffload.h">
       <Filter>Emu\GPU\RSX</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\Io\Keyboard.h">
+      <Filter>Emu\Io</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -185,7 +185,7 @@ int main(int argc, char** argv)
 		{
 			argv.emplace_back();
 
-			for (u32 i = 1; i < args.length(); i++)
+			for (int i = 1; i < args.length(); i++)
 			{
 				argv.emplace_back(args[i].toStdString());
 			}

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -138,6 +138,7 @@ public:
 
 		// System
 		Language,
+		KeyboardType,
 		EnterButtonAssignment,
 		EnableHostRoot,
 		LimitCacheSize,
@@ -368,6 +369,7 @@ private:
 
 		// System
 		{ Language,              { "System", "Language"}},
+		{ KeyboardType,          { "System", "Keyboard Type"} },
 		{ EnterButtonAssignment, { "System", "Enter button assignment"}},
 		{ EnableHostRoot,        { "VFS", "Enable /host_root/"}},
 		{ LimitCacheSize,        { "VFS", "Limit disk cache size"}},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -986,6 +986,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	xemu_settings->EnhanceComboBox(ui->sysLangBox, emu_settings::Language, false, false, 0, true);
 	SubscribeTooltip(ui->sysLangBox, json_sys["sysLangBox"].toString());
 
+	xemu_settings->EnhanceComboBox(ui->keyboardType, emu_settings::KeyboardType, false, false, 0, true);
+	SubscribeTooltip(ui->keyboardType, json_sys["keyboardType"].toString());
+
 	// Checkboxes
 
 	xemu_settings->EnhanceCheckBox(ui->enableHostRoot, emu_settings::EnableHostRoot);

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1306,7 +1306,7 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="1,1,1">
          <item>
-          <widget class="QGroupBox" name="groupBox_34">
+          <widget class="QGroupBox" name="gb_sysLang">
            <property name="title">
             <string>Console Language</string>
            </property>
@@ -1318,7 +1318,19 @@
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="groupBox">
+          <widget class="QGroupBox" name="gb_keyboardType">
+           <property name="title">
+            <string>Keyboard Type</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_keyboardType">
+            <item>
+             <widget class="QComboBox" name="keyboardType"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="gb_homebrew">
            <property name="title">
             <string>Homebrew</string>
            </property>
@@ -1332,9 +1344,6 @@
             </item>
            </layout>
           </widget>
-         </item>
-         <item>
-          <widget class="QWidget" name="widget_3" native="true"/>
          </item>
         </layout>
        </item>


### PR DESCRIPTION
General:

Improved the number of supported keys for US and German keyboards and added an option to the system tab that controls the keyboard type.
Support for most of these specific layouts can be added quite easily in the future.


Windows only:

This should fix most issues with shifted keys (or any modified keys) when using the basic keyboard handler.
A game does not actually want us to tell it "_ was pressed". It wants us to pass "shift+-".
Before there was no easy way of knowing that '-' was pressed in 'SHIFT+-' in order to get '\_' in the game, because Qt would skip that step and tell the emulator "_ was pressed after shift". 
The same logic was added for alt.