### PR TITLE
Change default Sleep Timers Accuracy setting's value to "Usleep Only"

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -282,9 +282,9 @@ void fmt_class_string<sleep_timers_accuracy_level>::format(std::string& out, u64
 	{
 		switch (value)
 		{
-		case sleep_timers_accuracy_level::_as_host: return "Host";
-		case sleep_timers_accuracy_level::_usleep: return "Usleep";
-		case sleep_timers_accuracy_level::_all_timers: return "All";
+		case sleep_timers_accuracy_level::_as_host: return "As Host";
+		case sleep_timers_accuracy_level::_usleep: return "Usleep Only";
+		case sleep_timers_accuracy_level::_all_timers: return "All Timers";
 		}
 
 		return unknown;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -418,7 +418,7 @@ struct cfg_root : cfg::node
 		cfg::_bool hle_lwmutex{this, "HLE lwmutex"}; // Force alternative lwmutex/lwcond implementation
 
 		cfg::_int<10, 1000> clocks_scale{this, "Clocks scale", 100}; // Changing this from 100 (percentage) may affect game speed in unexpected ways
-		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{this, "Sleep timers accuracy", sleep_timers_accuracy_level::_as_host}; // Affects sleep timers accuracy (to fix host's sleep accuracy)
+		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{this, "Sleep Timers Accuracy", sleep_timers_accuracy_level::_usleep};
 	} core{this};
 
 	struct node_vfs : cfg::node

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -615,7 +615,7 @@ void emu_settings::OpenCorrectionDialog(QWidget* parent)
 {
 	if (m_broken_types.size() && QMessageBox::question(parent, tr("Fix invalid settings?"),
 		tr(
-			"Your config file contained one or more unrecognized settings.\n"
+			"Your config file contained one or more unrecognized values for settings.\n"
 			"Their default value will be used until they are corrected.\n"
 			"Consider that a correction might render them invalid for other versions of RPCS3.\n"
 			"\n"


### PR DESCRIPTION
Bonus: old configs will be updated to use Usleep setting.

Fixes #6337.