### PR TITLE
Update "Enable native user interface" description

### DIFF
--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -79,7 +79,7 @@
 			"gs_disableMouse": "Disables the activation of fullscreen mode per double-click while the game screen is active.\nCheck this if you want to play with mouse and keyboard (for example with UCR).",
 			"maxLLVMThreads": "Limits the maximum number of threads used for PPU Module compilation.\nLower this in order to increase performance of other open applications.\nThe default uses all available threads.",
 			"showShaderCompilationHint": "Show shader compilation hints using the native overlay.",
-			"useNativeInterface": "Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, only the English language is supported."
+			"useNativeInterface": "Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, only Latin characters are supported."
 		},
 		"overlay": {
 			"perfOverlayEnabled": "Enables or disables the performance overlay.",


### PR DESCRIPTION
Since the merge of native OSK, back in February 2019, RPCS3 is able to support more languages with native UI. However, the description hasn't been updated since then. 

As far as I know, the languages that are now supported are: English, French, German, Italian and Spanish (referred as _Latin characters_). 

Both Greek and Russian use different alphabets from Latin, therefore they aren't supported. Polish or Norwegian, for example, use special Latin characters that aren't covered in extended ASCII character set. 

Chinese, Japanese and Korean aren't also supported, since they use a different character set.