### PR TITLE
gui: Remove fallback font from YoRHa theme

### DIFF
--- a/bin/GuiConfigs/YoRHa by Ani.qss
+++ b/bin/GuiConfigs/YoRHa by Ani.qss
@@ -25,7 +25,7 @@ aea993
 
 /* Every widget */
 QWidget {
-	font-family: SCE-PS3 Rodin LATIN, Arial;
+	font-family: SCE-PS3 Rodin LATIN;
 	font-size: 9.00pt;
 
 	color: #292929;


### PR DESCRIPTION
Starting with QT 5.13, having both fonts causes stylesheets to use the fallback font even if the first font is present, but uses the first font when there's no fallback font.
The fallback font (Arial) can safely be removed as the default one is 'good enough' for the intended purpose of having a fallback.

Thanks to @Megamouse for investigating and figuring out this quirk