### PR TITLE
rsx: Fix possible out of range methods execution

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -548,7 +548,7 @@ namespace rsx
 				}
 			}
 
-			const u32 reg = command.reg >> 2;
+			const u32 reg = (command.reg & 0xffff) >> 2;
 			const u32 value = command.value;
 
 			method_registers.decode(reg, value);


### PR DESCRIPTION
Fixed out of range methods execution as command register progresses above limit.