### PR TITLE
lv2: Allow sys_sync_priority_inherit

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -28,7 +28,7 @@ error_code sys_mutex_create(ppu_thread& ppu, vm::ptr<u32> mutex_id, vm::ptr<sys_
 	case SYS_SYNC_FIFO: break;
 	case SYS_SYNC_PRIORITY: break;
 	case SYS_SYNC_PRIORITY_INHERIT:
-		sys_mutex.fatal("sys_mutex_create(): SYS_SYNC_PRIORITY_INHERIT");
+		sys_mutex.warning("sys_mutex_create(): SYS_SYNC_PRIORITY_INHERIT");
 		break;
 	default:
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "sys_semaphore.h"
 
 #include "Emu/System.h"
@@ -32,7 +32,7 @@ error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sy
 	const u32 protocol = attr->protocol;
 
 	if (protocol == SYS_SYNC_PRIORITY_INHERIT)
-		sys_semaphore.todo("sys_semaphore_create(): SYS_SYNC_PRIORITY_INHERIT");
+		sys_semaphore.warning("sys_semaphore_create(): SYS_SYNC_PRIORITY_INHERIT");
 
 	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_PRIORITY && protocol != SYS_SYNC_PRIORITY_INHERIT)
 	{


### PR DESCRIPTION
This protocol isn't implemented on real ps3 and is the same as SYS_SYNC_PRIORITY which is implemented and working.