### PR TITLE
Fix mismatched enum string formats in sys_config

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_config.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_config.cpp
@@ -43,8 +43,8 @@ void fmt_class_string<sys_config_service_listener_type>::format(std::string& out
 	{
 		switch (value)
 		{
-			STR_CASE(SYS_CONFIG_EVENT_SOURCE_SERVICE);
-			STR_CASE(SYS_CONFIG_EVENT_SOURCE_IO);
+			STR_CASE(SYS_CONFIG_SERVICE_LISTENER_ONCE);
+			STR_CASE(SYS_CONFIG_SERVICE_LISTENER_REPEATING);
 		}
 
 		return unknown;


### PR DESCRIPTION
The enum fed into the template did not match the enum values used in the switch. It was discovered through warnings. Do we need to implement a string formatter for the third enum type?