### PR TITLE
Fix vm::reserve_map logic

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1060,16 +1060,7 @@ namespace vm
 		}
 
 		lock.upgrade();
-
-		// Fixed allocation
-		if (addr)
-		{
-			// Recheck
-			area = _get_map(location, addr);
-
-			return !area ? _map(addr, area_size, flags) : area;
-		}
-
+		
 		// Allocation on arbitrary address
 		if (location != any && location < g_locations.size())
 		{
@@ -1085,7 +1076,10 @@ namespace vm
 			return loc;
 		}
 
-		return nullptr;
+		// Fixed address allocation
+		area = _get_map(location, addr);
+
+		return !area ? _map(addr, area_size, flags) : area;
 	}
 
 	inline namespace ps3_


### PR DESCRIPTION
Fixes mapping on vm::null (0x0) address (used in  recovering from SPU access violations after emulation stop by allocating the unmapped memory, now working on any address from 0x0 to 0xffff).