### PR TITLE
rsx: MGS4 fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -460,7 +460,9 @@ void FragmentProgramDecompiler::AddCodeCond(const std::string& dst, const std::s
 	}
 
 	// NOTE: dst = _select(dst, src, cond) is equivalent to dst = cond? src : dst;
-	const auto cond = ShaderVariable(dst).match_size(GetRawCond());
+	const auto dst_var = ShaderVariable(dst);
+	const auto raw_cond = dst_var.add_mask(GetRawCond());
+	const auto cond = dst_var.match_size(raw_cond);
 	AddCode(dst + " = _select(" + dst + ", " + src_prefix + src + ", " + cond + ");");
 }
 

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
@@ -281,6 +281,7 @@ public:
 		bool has_tex_op = false;
 		bool has_divsq = false;
 		bool has_clamp = false;
+		bool has_w_access = false;
 	}
 	properties;
 

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
@@ -252,11 +252,30 @@ protected:
 	virtual void insertMainEnd(std::stringstream &OS) = 0;
 
 public:
+	enum : u16
+	{
+		in_wpos = (1 << 0),
+		in_diff_color = (1 << 1),
+		in_spec_color = (1 << 2),
+		in_fogc = (1 << 3),
+		in_tc0 = (1 << 4),
+		in_tc1 = (1 << 5),
+		in_tc2 = (1 << 6),
+		in_tc3 = (1 << 7),
+		in_tc4 = (1 << 8),
+		in_tc5 = (1 << 9),
+		in_tc6 = (1 << 10),
+		in_tc7 = (1 << 11),
+		in_tc8 = (1 << 12),
+		in_tc9 = (1 << 13),
+		in_ssa = (1 << 14)
+	};
+
 	struct
 	{
+		u16  in_register_mask = 0;
 		bool has_lit_op = false;
 		bool has_gather_op = false;
-		bool has_wpos_input = false;
 		bool has_no_output = false;
 		bool has_discard_op = false;
 		bool has_tex_op = false;

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "ProgramStateCache.h"
 #include "Emu/System.h"
 
@@ -424,9 +424,7 @@ size_t fragment_program_storage_hash::operator()(const RSXFragmentProgram& progr
 	hash ^= program.ctrl;
 	hash ^= program.texture_dimensions;
 	hash ^= program.unnormalized_coords;
-	hash ^= program.back_color_diffuse_output;
-	hash ^= program.back_color_specular_output;
-	hash ^= program.front_back_color_enabled;
+	hash ^= program.two_sided_lighting;
 	hash ^= program.shadow_textures;
 	hash ^= program.redirected_textures;
 
@@ -436,8 +434,7 @@ size_t fragment_program_storage_hash::operator()(const RSXFragmentProgram& progr
 bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, const RSXFragmentProgram& binary2) const
 {
 	if (binary1.ctrl != binary2.ctrl || binary1.texture_dimensions != binary2.texture_dimensions || binary1.unnormalized_coords != binary2.unnormalized_coords ||
-		binary1.back_color_diffuse_output != binary2.back_color_diffuse_output || binary1.back_color_specular_output != binary2.back_color_specular_output ||
-		binary1.front_back_color_enabled != binary2.front_back_color_enabled ||
+		binary1.two_sided_lighting != binary2.two_sided_lighting ||
 		binary1.shadow_textures != binary2.shadow_textures || binary1.redirected_textures != binary2.redirected_textures)
 		return false;
 

--- a/rpcs3/Emu/RSX/Common/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Common/ShaderParam.h
@@ -311,6 +311,16 @@ public:
 			return result;
 		}
 	}
+
+	std::string add_mask(const std::string& other_var) const
+	{
+		if (swizzles.back() != "xyzw")
+		{
+			return other_var + "." + swizzles.back();
+		}
+
+		return other_var;
+	}
 };
 
 struct vertex_reg_info

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -42,12 +42,19 @@ namespace rsx
 		transfer = 2
 	};
 
+	enum format_type : u8
+	{
+		color = 0,
+		depth_uint = 1,
+		depth_float = 2
+	};
+
 	//Sampled image descriptor
 	struct sampled_image_descriptor_base
 	{
 		texture_upload_context upload_context = texture_upload_context::shader_read;
 		rsx::texture_dimension_extended image_type = texture_dimension_extended::texture_dimension_2d;
-		bool is_depth_texture = false;
+		rsx::format_type format_class = rsx::format_type::color;
 		bool is_cyclic_reference = false;
 		f32 scale_x = 1.f;
 		f32 scale_y = 1.f;

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -310,7 +310,9 @@ void VertexProgramDecompiler::AddCodeCond(const std::string& dst, const std::str
 	}
 
 	// NOTE: dst = _select(dst, src, cond) is equivalent to dst = cond? src : dst;
-	const auto cond = ShaderVariable(dst).match_size(GetRawCond());
+	const auto dst_var = ShaderVariable(dst);
+	const auto raw_cond = dst_var.add_mask(GetRawCond());
+	const auto cond = dst_var.match_size(raw_cond);
 	AddCode(dst + " = _select(" + dst + ", " + src + ", " + cond + ");");
 }
 

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -149,6 +149,8 @@ namespace rsx
 		u8  samples_x = 1;
 		u8  samples_y = 1;
 
+		format_type format_class = format_type::color;
+
 		std::unique_ptr<typename std::remove_pointer<image_storage_type>::type> resolve_surface;
 		surface_sample_layout sample_layout = surface_sample_layout::null;
 
@@ -279,14 +281,27 @@ namespace rsx
 			format_info.gcm_depth_format = format;
 		}
 
-		rsx::surface_color_format get_surface_color_format()
+		void set_depth_render_mode(bool integer)
+		{
+			if (is_depth_surface())
+			{
+				format_class = (integer) ? format_type::depth_uint : format_type::depth_float;
+			}
+		}
+
+		rsx::surface_color_format get_surface_color_format() const
 		{
 			return format_info.gcm_color_format;
 		}
 
-		rsx::surface_depth_format get_surface_depth_format()
+		rsx::surface_depth_format get_surface_depth_format() const
 		{
 			return format_info.gcm_depth_format;
+		}
+
+		rsx::format_type get_format_type() const
+		{
+			return format_class;
 		}
 
 		bool dirty() const

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1621,6 +1621,23 @@ namespace rsx
 			return sync_timestamp;
 		}
 
+		format_type get_format_type() const
+		{
+			switch (gcm_format)
+			{
+			default:
+				return format_type::color;
+			case CELL_GCM_TEXTURE_DEPTH16:
+			case CELL_GCM_TEXTURE_DEPTH24_D8:
+				return format_type::depth_uint;
+			case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
+			case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
+				return format_type::depth_float;
+			case 0:
+				fmt::throw_exception("Unreachable" HERE);
+			}
+		}
+
 		/**
 		 * Comparison
 		 */

--- a/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12FragmentProgramDecompiler.cpp
@@ -1,4 +1,4 @@
-#ifdef _MSC_VER
+﻿#ifdef _MSC_VER
 #include "stdafx.h"
 #include "stdafx_d3d12.h"
 #include "D3D12FragmentProgramDecompiler.h"
@@ -206,19 +206,6 @@ void D3D12FragmentDecompiler::insertMainStart(std::stringstream & OS)
 	{
 		for (const ParamItem &PI : PT.items)
 		{
-			if (m_prog.front_back_color_enabled)
-			{
-				if (PI.name == "spec_color" && m_prog.back_color_specular_output)
-				{
-					OS << "	float4 spec_color = is_front_face ? In.dst_reg4 : In.spec_color;\n";
-					continue;
-				}
-				if (PI.name == "diff_color" && m_prog.back_color_diffuse_output)
-				{
-					OS << "	float4 diff_color = is_front_face ? In.dst_reg3 : In.diff_color;\n";
-					continue;
-				}
-			}
 			if (PI.name == "fogc")
 			{
 				OS << "	float4 fogc = fetch_fog_value(fog_mode, In.fogc);\n";

--- a/rpcs3/Emu/RSX/GL/GLCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/GL/GLCommonDecompiler.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "GLCommonDecompiler.h"
 
 namespace gl
@@ -7,10 +7,9 @@ namespace gl
 	{{
 		{"diff_color", 1},
 		{"spec_color", 2},
-		{"back_diff_color", 1},
-		{"back_spec_color", 2},
-		{"front_diff_color", 3},
-		{"front_spec_color", 4},
+		{"diff_color1", 3},
+		{"spec_color1", 4},
+		{"fogc", 5},
 		{"fog_c", 5},
 		{"tc0", 6},
 		{"tc1", 7},

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -29,7 +29,7 @@ u64 GLGSRender::get_cycles()
 
 GLGSRender::GLGSRender() : GSRender()
 {
-	m_shaders_cache = std::make_unique<gl::shader_cache>(m_prog_buffer, "opengl", "v1.6");
+	m_shaders_cache = std::make_unique<gl::shader_cache>(m_prog_buffer, "opengl", "v1.91");
 
 	if (g_cfg.video.disable_vertex_cache || g_cfg.video.multithreaded_rsx)
 		m_vertex_cache = std::make_unique<gl::null_vertex_cache>();

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -215,6 +215,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 	{
 		auto ds = std::get<1>(m_rtts.m_bound_depth_stencil);
 		depth_stencil_target = ds->id();
+		ds->set_depth_render_mode(!layout.depth_float);
 
 		verify("Pitch mismatch!" HERE), std::get<1>(m_rtts.m_bound_depth_stencil)->get_rsx_pitch() == layout.actual_zeta_pitch;
 
@@ -223,8 +224,10 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		m_depth_surface_info.width = layout.width;
 		m_depth_surface_info.height = layout.height;
 		m_depth_surface_info.depth_format = layout.depth_format;
+		m_depth_surface_info.depth_buffer_float = layout.depth_float;
 		m_depth_surface_info.bpp = (layout.depth_format == rsx::surface_depth_format::z16? 2 : 4);
 		m_depth_surface_info.samples = samples;
+
 		m_gl_texture_cache.notify_surface_changed(m_depth_surface_info.get_memory_range(layout.aa_factors));
 	}
 	else

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -129,20 +129,37 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	insert_glsl_legacy_function(OS, properties2);
 	glsl::insert_vertex_input_fetch(OS, glsl::glsl_rules_opengl4, dev_caps.vendor_INTEL == false);
 
-	std::string parameters;
-	for (int i = 0; i < 16; ++i)
+	// Declare global registers with optional initialization
+	std::string registers;
+	if (ParamType *vec4Types = m_parr.SearchParam(PF_PARAM_OUT, "vec4"))
 	{
-		std::string reg_name = "dst_reg" + std::to_string(i);
-		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", reg_name))
+		for (auto &PI : vec4Types->items)
 		{
-			if (parameters.length())
-				parameters += ", ";
+			if (registers.length())
+				registers += ", ";
+			else
+				registers = "vec4 ";
 
-			parameters += "inout vec4 " + reg_name;
+			registers += PI.name;
+
+			if (!PI.value.empty())
+			{
+				printf("Value=%s\n", PI.value.c_str());
+				// Simplify default initialization
+				if (PI.value == "vec4(0.0, 0.0, 0.0, 0.0)")
+					registers += " = vec4(0.)";
+				else
+					registers += " = " + PI.value;
+			}
 		}
 	}
 
-	OS << "void vs_main(" << parameters << ")\n";
+	if (!registers.empty())
+	{
+		OS << registers << ";\n";
+	}
+
+	OS << "void vs_main()\n";
 	OS << "{\n";
 
 	//Declare temporary registers, ignoring those mapped to outputs
@@ -177,33 +194,7 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 	OS << "void main ()\n";
 	OS << "{\n";
 
-	std::string parameters;
-
-	if (ParamType *vec4Types = m_parr.SearchParam(PF_PARAM_OUT, "vec4"))
-	{
-		for (int i = 0; i < 16; ++i)
-		{
-			std::string reg_name = "dst_reg" + std::to_string(i);
-			for (auto &PI : vec4Types->items)
-			{
-				if (reg_name == PI.name)
-				{
-					if (parameters.length())
-						parameters += ", ";
-
-					parameters += reg_name;
-					OS << "	vec4 " << reg_name;
-
-					if (!PI.value.empty())
-						OS << "= " << PI.value;
-
-					OS << ";\n";
-				}
-			}
-		}
-	}
-
-	OS << "\n" << "	vs_main(" << parameters << ");\n\n";
+	OS << "\n" << "	vs_main();\n\n";
 
 	for (auto &i : reg_table)
 	{

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -79,77 +79,42 @@ void GLVertexDecompilerThread::insertConstants(std::stringstream & OS, const std
 static const vertex_reg_info reg_table[] =
 {
 	{ "gl_Position", false, "dst_reg0", "", false },
-	{ "diff_color", true, "dst_reg1", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE },
-	{ "spec_color", true, "dst_reg2", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR },
+	{ "diff_color", true, "dst_reg1", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE },
+	{ "spec_color", true, "dst_reg2", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR },
 	//These are only present when back variants are specified, otherwise the default diff/spec color vars are for both front and back
-	{ "front_diff_color", true, "dst_reg3", "", false },
-	{ "front_spec_color", true, "dst_reg4", "", false },
+	{ "diff_color1", true, "dst_reg3", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE },
+	{ "spec_color1", true, "dst_reg4", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR },
 	//Fog output shares a data source register with clip planes 0-2 so only declare when specified
 	{ "fog_c", true, "dst_reg5", ".xxxx", true, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FOG },
 	//Warning: Always define all 3 clip plane groups together to avoid flickering with openGL
 	{ "gl_ClipDistance[0]", false, "dst_reg5", ".y * user_clip_factor[0].x", false, "user_clip_enabled[0].x > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC0 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC1 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC2 },
 	{ "gl_ClipDistance[1]", false, "dst_reg5", ".z * user_clip_factor[0].y", false, "user_clip_enabled[0].y > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC0 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC1 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC2 },
 	{ "gl_ClipDistance[2]", false, "dst_reg5", ".w * user_clip_factor[0].z", false, "user_clip_enabled[0].z > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC0 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC1 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC2 },
-	{ "gl_PointSize", false, "dst_reg6", ".x", false },
+	{ "gl_PointSize", false, "dst_reg6", ".x", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_POINTSIZE },
 	{ "gl_ClipDistance[3]", false, "dst_reg6", ".y * user_clip_factor[0].w", false, "user_clip_enabled[0].w > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
 	{ "gl_ClipDistance[4]", false, "dst_reg6", ".z * user_clip_factor[1].x", false, "user_clip_enabled[1].x > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
 	{ "gl_ClipDistance[5]", false, "dst_reg6", ".w * user_clip_factor[1].y", false, "user_clip_enabled[1].y > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 | CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
-	{ "tc0", true, "dst_reg7", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX0 },
-	{ "tc1", true, "dst_reg8", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX1 },
-	{ "tc2", true, "dst_reg9", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX2 },
-	{ "tc3", true, "dst_reg10", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX3 },
-	{ "tc4", true, "dst_reg11", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX4 },
-	{ "tc5", true, "dst_reg12", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX5 },
-	{ "tc6", true, "dst_reg13", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX6 },
-	{ "tc7", true, "dst_reg14", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX7 },
-	{ "tc8", true, "dst_reg15", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX8 },
+	{ "tc0", true, "dst_reg7", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX0 },
+	{ "tc1", true, "dst_reg8", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX1 },
+	{ "tc2", true, "dst_reg9", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX2 },
+	{ "tc3", true, "dst_reg10", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX3 },
+	{ "tc4", true, "dst_reg11", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX4 },
+	{ "tc5", true, "dst_reg12", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX5 },
+	{ "tc6", true, "dst_reg13", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX6 },
+	{ "tc7", true, "dst_reg14", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX7 },
+	{ "tc8", true, "dst_reg15", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX8 },
 	{ "tc9", true, "dst_reg6", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX9 }  // In this line, dst_reg6 is correct since dst_reg goes from 0 to 15.
 };
 
 void GLVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::vector<ParamType> & outputs)
 {
-	bool insert_front_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE) != 0;
-	bool insert_back_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE) != 0;
-
-	bool insert_front_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR) != 0;
-	bool insert_back_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR) != 0;
-
-	bool front_back_diffuse = (insert_back_diffuse && insert_front_diffuse);
-	bool front_back_specular = (insert_back_specular && insert_front_specular);
-
-	std::vector<std::string> outputs_to_declare;
-
 	for (auto &i : reg_table)
 	{
 		if (i.need_declare)
 		{
-			if (i.name == "front_diff_color")
-				insert_front_diffuse = false;
-
-			if (i.name == "front_spec_color")
-				insert_front_specular = false;
-
-			std::string name = i.name;
-
-			if (front_back_diffuse && name == "diff_color")
-				name = "back_diff_color";
-
-			if (front_back_specular && name == "spec_color")
-				name = "back_spec_color";
-
-			outputs_to_declare.push_back(name);
+			// All outputs must be declared always to allow setting default values
+			OS << "layout(location=" << gl::get_varying_register_location(i.name) << ") out vec4 " << i.name << ";\n";
 		}
-	}
-
-	if (insert_back_diffuse && insert_front_diffuse)
-		outputs_to_declare.emplace_back("front_diff_color");
-
-	if (insert_back_specular && insert_front_specular)
-		outputs_to_declare.emplace_back("front_spec_color");
-
-	for (auto &name: outputs_to_declare)
-	{
-		OS << "layout(location=" << gl::get_varying_register_location(name) << ") out vec4 " << name << ";\n";
 	}
 }
 
@@ -240,65 +205,43 @@ void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	OS << "\n" << "	vs_main(" << parameters << ");\n\n";
 
-	bool insert_front_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE) != 0;
-	bool insert_front_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR) != 0;
-
-	bool insert_back_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE) != 0;
-	bool insert_back_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR) != 0;
-
-	bool front_back_diffuse = (insert_back_diffuse && insert_front_diffuse);
-	bool front_back_specular = (insert_back_specular && insert_front_specular);
-
 	for (auto &i : reg_table)
 	{
-		std::string name = i.name;
-
-		if (front_back_diffuse && name == "diff_color")
-			name = "back_diff_color";
-
-		if (front_back_specular && name == "spec_color")
-			name = "back_spec_color";
-
-		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", i.src_reg))
+		if (!i.check_mask || i.test(rsx_vertex_program.output_mask))
 		{
-			if (i.check_mask && (rsx_vertex_program.output_mask & i.check_mask_value) == 0)
+			if (m_parr.HasParam(PF_PARAM_OUT, "vec4", i.src_reg))
+			{
+				std::string condition = (!i.cond.empty()) ? "(" + i.cond + ") " : "";
+
+				if (condition.empty() || i.default_val.empty())
+				{
+					if (!condition.empty()) condition = "if " + condition;
+					OS << "	" << condition << i.name << " = " << i.src_reg << i.src_reg_mask << ";\n";
+				}
+				else
+				{
+					//Insert if-else condition
+					OS << "	" << i.name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";\n";
+				}
+
+				// Register was marked for output and a properly initialized source register exists
+				// Nothing more to do
 				continue;
-
-			if (i.name == "front_diff_color")
-				insert_front_diffuse = false;
-
-			if (i.name == "front_spec_color")
-				insert_front_specular = false;
-
-			std::string condition = (!i.cond.empty()) ? "(" + i.cond + ") " : "";
-			if (condition.empty() || i.default_val.empty())
-			{
-				if (!condition.empty()) condition = "if " + condition;
-				OS << "	" << condition << name << " = " << i.src_reg << i.src_reg_mask << ";\n";
-			}
-			else
-			{
-				//Insert if-else condition
-				OS << "	" << name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";\n";
 			}
 		}
-		else if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
+
+		if (i.need_declare)
 		{
-			//An output was declared but nothing was written to it
-			//Set it to all ones (Atelier Escha)
-			OS << "	" << name << " = vec4(1.);\n";
+			OS << "	" << i.name << " = vec4(0., 0., 0., 1.);\n";
 		}
 	}
 
-	if (insert_back_diffuse && insert_front_diffuse)
-		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", "dst_reg1"))
-			OS << "	front_diff_color = dst_reg1;\n";
+	// Default point size if none was generated by the program
+	if ((rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_POINTSIZE) == 0)
+	{
+		OS << "	gl_PointSize = point_size;\n";
+	}
 
-	if (insert_back_specular && insert_front_specular)
-		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", "dst_reg2"))
-			OS << "	front_spec_color = dst_reg2;\n";
-
-	OS << "	gl_PointSize = point_size;\n";
 	OS << "	gl_Position = gl_Position * scale_offset_mat;\n";
 	OS << "	gl_Position = apply_zclip_xform(gl_Position, z_near, z_far);\n";
 

--- a/rpcs3/Emu/RSX/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/RSXFragmentProgram.h
@@ -234,12 +234,9 @@ struct RSXFragmentProgram
 	u16 unnormalized_coords;
 	u16 redirected_textures;
 	u16 shadow_textures;
-	bool front_back_color_enabled : 1;
-	bool back_color_diffuse_output : 1;
-	bool back_color_specular_output : 1;
-	bool front_color_diffuse_output : 1;
-	bool front_color_specular_output : 1;
+	bool two_sided_lighting;
 	u32 texture_dimensions;
+	u32 texcoord_control_mask;
 
 	float texture_scale[16][4];
 	u8 textures_alpha_kill[16];
@@ -250,6 +247,11 @@ struct RSXFragmentProgram
 	rsx::texture_dimension_extended get_texture_dimension(u8 id) const
 	{
 		return (rsx::texture_dimension_extended)((texture_dimensions >> (id * 2)) & 0x3);
+	}
+
+	bool texcoord_is_2d(u8 index) const
+	{
+		return !!(texcoord_control_mask & (1u << index));
 	}
 
 	RSXFragmentProgram()

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1639,12 +1639,9 @@ namespace rsx
 		result.ucode_length = current_fp_metadata.program_ucode_length;
 		result.valid = true;
 		result.ctrl = rsx::method_registers.shader_control() & (CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS | CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT);
+		result.texcoord_control_mask = rsx::method_registers.texcoord_control_mask();
 		result.unnormalized_coords = 0;
-		result.front_back_color_enabled = !rsx::method_registers.two_side_light_en();
-		result.back_color_diffuse_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE);
-		result.back_color_specular_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR);
-		result.front_color_diffuse_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE);
-		result.front_color_specular_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR);
+		result.two_sided_lighting = rsx::method_registers.two_side_light_en();
 		result.redirected_textures = 0;
 		result.shadow_textures = 0;
 
@@ -1775,11 +1772,7 @@ namespace rsx
 		result.valid = true;
 		result.ctrl = rsx::method_registers.shader_control() & (CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS | CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT);
 		result.unnormalized_coords = 0;
-		result.front_back_color_enabled = !rsx::method_registers.two_side_light_en();
-		result.back_color_diffuse_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE);
-		result.back_color_specular_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR);
-		result.front_color_diffuse_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE);
-		result.front_color_specular_output = !!(rsx::method_registers.vertex_attrib_output_mask() & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR);
+		result.two_sided_lighting = rsx::method_registers.two_side_light_en();
 		result.redirected_textures = 0;
 		result.shadow_textures = 0;
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1070,6 +1070,7 @@ namespace rsx
 
 		layout.color_format = rsx::method_registers.surface_color();
 		layout.depth_format = rsx::method_registers.surface_depth_fmt();
+		layout.depth_float = rsx::method_registers.depth_buffer_float_enabled();
 		layout.target = rsx::method_registers.surface_color_target();
 
 		const auto aa_mode = rsx::method_registers.surface_antialias();
@@ -1280,6 +1281,7 @@ namespace rsx
 			{
 				if (m_surface_info[i].width != layout.width ||
 					m_surface_info[i].height != layout.height ||
+					m_surface_info[i].color_format != layout.color_format ||
 					m_surface_info[i].samples != sample_count)
 				{
 					really_changed = true;
@@ -1291,6 +1293,8 @@ namespace rsx
 		if (!really_changed)
 		{
 			if (layout.zeta_address == m_depth_surface_info.address &&
+				layout.depth_format == m_depth_surface_info.depth_format &&
+				layout.depth_float == m_depth_surface_info.depth_buffer_float &&
 				sample_count == m_depth_surface_info.samples)
 			{
 				// Same target is reused
@@ -1671,7 +1675,7 @@ namespace rsx
 				if (raw_format & CELL_GCM_TEXTURE_UN)
 					result.unnormalized_coords |= (1 << i);
 
-				if (sampler_descriptors[i]->is_depth_texture)
+				if (sampler_descriptors[i]->format_class != format_type::color)
 				{
 					switch (format)
 					{
@@ -1685,9 +1689,10 @@ namespace rsx
 					{
 						// Reading depth data as XRGB8 is supported with in-shader conversion
 						// TODO: Optionally add support for 16-bit formats (not necessary since type casts are easy with that)
-						u32 remap = tex.remap();
+						u32 control_bits = sampler_descriptors[i]->format_class == format_type::depth_float? (1u << 16) : 0u;
+						control_bits |= tex.remap() & 0xFFFF;
 						result.redirected_textures |= (1 << i);
-						result.texture_scale[i][2] = std::bit_cast<f32>(remap);
+						result.texture_scale[i][2] = std::bit_cast<f32>(control_bits);
 						break;
 					}
 					case CELL_GCM_TEXTURE_DEPTH16:

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -315,6 +315,7 @@ namespace rsx
 		rsx::surface_depth_format depth_format;
 		rsx::surface_antialiasing aa_mode;
 		u32 aa_factors[2];
+		bool depth_float;
 		bool ignore_change;
 	};
 

--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "VKCommonDecompiler.h"
 #include "restore_new.h"
 #include "SPIRV/GlslangToSpv.h"
@@ -118,11 +118,9 @@ namespace vk
 		{ "tc8", 8 },
 		{ "tc9", 9 },
 		{ "diff_color", 10 },
-		{ "back_diff_color", 10 },
-		{ "front_diff_color", 11 },
+		{ "diff_color1", 11 },
 		{ "spec_color", 12 },
-		{ "back_spec_color", 12 },
-		{ "front_spec_color", 13 },
+		{ "spec_color1", 13 },
 		{ "fog_c", 14 },
 		{ "fogc", 14 }
 	}};

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -246,34 +246,55 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 	if (properties.in_register_mask & in_fogc)
 		glsl::insert_fog_declaration(OS);
 
-	const std::set<std::string> output_values =
+	std::set<std::string> output_registers;
+	if (m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS)
 	{
-		"r0", "r1", "r2", "r3", "r4",
-		"h0", "h2", "h4", "h6", "h8"
-	};
-
-	std::string parameters;
-	const auto half4 = getHalfTypeName(4);
-	for (auto &reg_name : output_values)
+		output_registers = { "r0", "r2", "r3", "r4" };
+	}
+	else
 	{
-		const auto type = (reg_name[0] == 'r' || !device_props.has_native_half_support)? "vec4" : half4;
-		if (m_parr.HasParam(PF_PARAM_NONE, type, reg_name))
-		{
-			if (parameters.length())
-				parameters += ", ";
-
-			parameters += "inout " + type + " " + reg_name;
-		}
+		output_registers = { "h0", "h4", "h6", "h8" };
 	}
 
-	OS << "void fs_main(" << parameters << ")\n";
+	if (m_ctrl & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT)
+	{
+		output_registers.insert("r1");
+	}
+
+	std::string registers;
+	std::string reg_type;
+	const auto half4 = getHalfTypeName(4);
+	for (auto &reg_name : output_registers)
+	{
+		const auto type = (reg_name[0] == 'r' || !device_props.has_native_half_support)? "vec4" : half4;
+		if (LIKELY(reg_type == type))
+		{
+			registers += ", " + reg_name + " = " + type + "(0.)";
+		}
+		else
+		{
+			if (!registers.empty())
+				registers += ";\n";
+
+			registers += type + " " + reg_name + " = " + type + "(0.)";
+		}
+
+		reg_type = type;
+	}
+
+	if (!registers.empty())
+	{
+		OS << registers << ";\n";
+	}
+
+	OS << "void fs_main()\n";
 	OS << "{\n";
 
 	for (const ParamType& PT : m_parr.params[PF_PARAM_NONE])
 	{
 		for (const ParamItem& PI : PT.items)
 		{
-			if (output_values.find(PI.name) != output_values.end())
+			if (output_registers.find(PI.name) != output_registers.end())
 				continue;
 
 			OS << "	" << PT.type << " " << PI.name;
@@ -283,6 +304,9 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 			OS << ";\n";
 		}
 	}
+
+	if (properties.has_w_access)
+		OS << "	float in_w = (1. / gl_FragCoord.w);\n";
 
 	if (properties.in_register_mask & in_ssa)
 		OS << "	vec4 ssa = gl_FrontFacing ? vec4(1.) : vec4(-1.);\n";
@@ -305,34 +329,12 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 
 void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 {
-	const std::set<std::string> output_values =
-	{
-		"r0", "r1", "r2", "r3", "r4",
-		"h0", "h2", "h4", "h6", "h8"
-	};
-
 	OS << "}\n\n";
 
 	OS << "void main()\n";
 	OS << "{\n";
 
-	std::string parameters;
-	const auto half4 = getHalfTypeName(4);
-
-	for (auto &reg_name : output_values)
-	{
-		const std::string type = (reg_name[0] == 'r' || !device_props.has_native_half_support)? "vec4" : half4;
-		if (m_parr.HasParam(PF_PARAM_NONE, type, reg_name))
-		{
-			if (parameters.length())
-				parameters += ", ";
-
-			parameters += reg_name;
-			OS << "	" << type << " " << reg_name << " = " << type << "(0.);\n";
-		}
-	}
-
-	OS << "\n" << "	fs_main(" + parameters + ");\n\n";
+	OS << "\n" << "	fs_main();\n\n";
 
 	glsl::insert_rop(
 		OS,

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -503,7 +503,7 @@ VKGSRender::VKGSRender() : GSRender()
 	else
 		m_vertex_cache = std::make_unique<vk::weak_vertex_cache>();
 
-	m_shaders_cache = std::make_unique<vk::shader_cache>(*m_prog_buffer, "vulkan", "v1.8");
+	m_shaders_cache = std::make_unique<vk::shader_cache>(*m_prog_buffer, "vulkan", "v1.91");
 
 	open_command_buffer();
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1282,7 +1282,7 @@ void VKGSRender::end()
 
 					// Check if non-point filtering can even be used on this format
 					bool can_sample_linear;
-					if (LIKELY(!sampler_state->is_depth_texture))
+					if (LIKELY(sampler_state->format_class == rsx::format_type::color))
 					{
 						// Most PS3-like formats can be linearly filtered without problem
 						can_sample_linear = true;
@@ -2848,6 +2848,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		m_depth_surface_info.width = layout.width;
 		m_depth_surface_info.height = layout.height;
 		m_depth_surface_info.depth_format = layout.depth_format;
+		m_depth_surface_info.depth_buffer_float = layout.depth_float;
 		m_depth_surface_info.bpp = (layout.depth_format == rsx::surface_depth_format::z16? 2 : 4);
 		m_depth_surface_info.samples = samples;
 	}
@@ -2875,6 +2876,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 	if (std::get<0>(m_rtts.m_bound_depth_stencil) != 0)
 	{
 		auto ds = std::get<1>(m_rtts.m_bound_depth_stencil);
+		ds->set_depth_render_mode(!layout.depth_float);
 		m_fbo_images.push_back(ds);
 
 		m_depth_surface_info.address = layout.zeta_address;

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -6,6 +6,8 @@
 #include "VKHelpers.h"
 #include "../Common/GLSLCommon.h"
 
+#pragma optimize("", off)
+
 std::string VKVertexDecompilerThread::getFloatTypeName(size_t elementCount)
 {
 	return glsl::getFloatTypeNameImpl(elementCount);
@@ -129,70 +131,41 @@ static const vertex_reg_info reg_table[] =
 {
 	{ "gl_Position", false, "dst_reg0", "", false },
 	//Technically these two are for both back and front
-	{ "back_diff_color", true, "dst_reg1", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE },
-	{ "back_spec_color", true, "dst_reg2", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR },
-	{ "front_diff_color", true, "dst_reg3", "", false },
-	{ "front_spec_color", true, "dst_reg4", "", false },
+	{ "diff_color", true, "dst_reg1", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE },
+	{ "spec_color", true, "dst_reg2", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR },
+	{ "diff_color1", true, "dst_reg3", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE },
+	{ "spec_color1", true, "dst_reg4", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR },
 	{ "fog_c", true, "dst_reg5", ".xxxx", true, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_FOG },
 	//Warning: With spir-v if you declare clip distance var, you must assign a value even when its disabled! Runtime does not assign a default value
 	{ "gl_ClipDistance[0]", false, "dst_reg5", ".y * user_clip_factor[0].x", false, "user_clip_enabled[0].x > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC0 },
 	{ "gl_ClipDistance[1]", false, "dst_reg5", ".z * user_clip_factor[0].y", false, "user_clip_enabled[0].y > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC1 },
 	{ "gl_ClipDistance[2]", false, "dst_reg5", ".w * user_clip_factor[0].z", false, "user_clip_enabled[0].z > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC2 },
-	{ "gl_PointSize", false, "dst_reg6", ".x", false },
+	{ "gl_PointSize", false, "dst_reg6", ".x", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_POINTSIZE },
 	{ "gl_ClipDistance[3]", false, "dst_reg6", ".y * user_clip_factor[0].w", false, "user_clip_enabled[0].w > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC3 },
 	{ "gl_ClipDistance[4]", false, "dst_reg6", ".z * user_clip_factor[1].x", false, "user_clip_enabled[1].x > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC4 },
 	{ "gl_ClipDistance[5]", false, "dst_reg6", ".w * user_clip_factor[1].y", false, "user_clip_enabled[1].y > 0", "0.5", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_UC5 },
-	{ "tc0", true, "dst_reg7", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX0 },
-	{ "tc1", true, "dst_reg8", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX1 },
-	{ "tc2", true, "dst_reg9", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX2 },
-	{ "tc3", true, "dst_reg10", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX3 },
-	{ "tc4", true, "dst_reg11", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX4 },
-	{ "tc5", true, "dst_reg12", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX5 },
-	{ "tc6", true, "dst_reg13", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX6 },
-	{ "tc7", true, "dst_reg14", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX7 },
-	{ "tc8", true, "dst_reg15", "", false, "", "", "", false, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX8 },
+	{ "tc0", true, "dst_reg7", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX0 },
+	{ "tc1", true, "dst_reg8", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX1 },
+	{ "tc2", true, "dst_reg9", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX2 },
+	{ "tc3", true, "dst_reg10", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX3 },
+	{ "tc4", true, "dst_reg11", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX4 },
+	{ "tc5", true, "dst_reg12", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX5 },
+	{ "tc6", true, "dst_reg13", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX6 },
+	{ "tc7", true, "dst_reg14", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX7 },
+	{ "tc8", true, "dst_reg15", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX8 },
 	{ "tc9", true, "dst_reg6", "", false, "", "", "", true, CELL_GCM_ATTRIB_OUTPUT_MASK_TEX9 }  // In this line, dst_reg6 is correct since dst_reg goes from 0 to 15.
 };
 
 void VKVertexDecompilerThread::insertOutputs(std::stringstream & OS, const std::vector<ParamType> & outputs)
 {
-	bool insert_front_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE) != 0;
-	bool insert_back_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE) != 0;
-
-	bool insert_front_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR) != 0;
-	bool insert_back_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR) != 0;
-
 	for (auto &i : reg_table)
 	{
-		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", i.src_reg) && i.need_declare)
+		if (i.need_declare)
 		{
-			if (i.check_mask && (rsx_vertex_program.output_mask & i.check_mask_value) == 0)
-				continue;
-
-			if (i.name == "front_diff_color")
-				insert_front_diffuse = false;
-
-			if (i.name == "front_spec_color")
-				insert_front_specular = false;
-
+			// All outputs must be declared always to allow setting default values
 			OS << "layout(location=" << vk::get_varying_register_location(i.name) << ") out vec4 " << i.name << ";\n";
 		}
-		else
-		{
-			//Force some outputs to be declared even if unused so we can set default values
-			//NOTE: Registers that can be skept will not have their check_mask_value set
-			if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
-			{
-				OS << "layout(location=" << vk::get_varying_register_location(i.name) << ") out vec4 " << i.name << ";\n";
-			}
-		}
 	}
-
-	if (insert_back_diffuse && insert_front_diffuse)
-		OS << "layout(location=" << vk::get_varying_register_location("front_diff_color") << ") out vec4 front_diff_color;\n";
-
-	if (insert_back_specular && insert_front_specular)
-		OS << "layout(location=" << vk::get_varying_register_location("front_spec_color") << ") out vec4 front_spec_color;\n";
 }
 
 void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
@@ -280,55 +253,43 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	OS << "\n" << "	vs_main(" << parameters << ");\n\n";
 
-	bool insert_front_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTDIFFUSE) != 0;
-	bool insert_front_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_FRONTSPECULAR) != 0;
-
-	bool insert_back_diffuse = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE) != 0;
-	bool insert_back_specular = (rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR) != 0;
-
 	for (auto &i : reg_table)
 	{
-		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", i.src_reg))
+		if (!i.check_mask || i.test(rsx_vertex_program.output_mask))
 		{
-			if (i.check_mask && (rsx_vertex_program.output_mask & i.check_mask_value) == 0)
+			if (m_parr.HasParam(PF_PARAM_OUT, "vec4", i.src_reg))
+			{
+				std::string condition = (!i.cond.empty()) ? "(" + i.cond + ") " : "";
+
+				if (condition.empty() || i.default_val.empty())
+				{
+					if (!condition.empty()) condition = "if " + condition;
+					OS << "	" << condition << i.name << " = " << i.src_reg << i.src_reg_mask << ";\n";
+				}
+				else
+				{
+					//Insert if-else condition
+					OS << "	" << i.name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";\n";
+				}
+
+				// Register was marked for output and a properly initialized source register exists
+				// Nothing more to do
 				continue;
-
-			if (i.name == "front_diff_color")
-				insert_front_diffuse = false;
-
-			if (i.name == "front_spec_color")
-				insert_front_specular = false;
-
-			std::string condition = (!i.cond.empty()) ? "(" + i.cond + ") " : "";
-
-			if (condition.empty() || i.default_val.empty())
-			{
-				if (!condition.empty()) condition = "if " + condition;
-				OS << "	" << condition << i.name << " = " << i.src_reg << i.src_reg_mask << ";\n";
-			}
-			else
-			{
-				//Insert if-else condition
-				OS << "	" << i.name << " = " << condition << "? " << i.src_reg << i.src_reg_mask << ": " << i.default_val << ";\n";
 			}
 		}
-		else if (i.need_declare && (rsx_vertex_program.output_mask & i.check_mask_value) > 0)
+
+		if (i.need_declare)
 		{
-			//An output was declared but nothing was written to it
-			//Set it to all ones (Atelier Escha)
-			OS << "	" << i.name << " = vec4(1.);\n";
+			OS << "	" << i.name << " = vec4(0., 0., 0., 1.);\n";
 		}
 	}
 
-	if (insert_back_diffuse && insert_front_diffuse)
-		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", "dst_reg1"))
-			OS << "	front_diff_color = dst_reg1;\n";
+	// Default point size if none was generated by the program
+	if ((rsx_vertex_program.output_mask & CELL_GCM_ATTRIB_OUTPUT_MASK_POINTSIZE) == 0)
+	{
+		OS << "	gl_PointSize = point_size;\n";
+	}
 
-	if (insert_back_specular && insert_front_specular)
-		if (m_parr.HasParam(PF_PARAM_OUT, "vec4", "dst_reg2"))
-			OS << "	front_spec_color = dst_reg2;\n";
-
-	OS << "	gl_PointSize = point_size;\n";
 	OS << "	gl_Position = gl_Position * scale_offset_mat;\n";
 	OS << "	gl_Position = apply_zclip_xform(gl_Position, z_near, z_far);\n";
 	OS << "}\n";

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -401,6 +401,7 @@ namespace rsx
 
 			u32 fp_ctrl;
 			u32 fp_texture_dimensions;
+			u32 fp_texcoord_control;
 			u16 fp_unnormalized_coords;
 			u16 fp_height;
 			u16 fp_pixel_layout;
@@ -738,6 +739,7 @@ namespace rsx
 			state_hash ^= rpcs3::hash_base<u32>(data.fp_ctrl);
 			state_hash ^= rpcs3::hash_base<u32>(data.vp_texture_dimensions);
 			state_hash ^= rpcs3::hash_base<u32>(data.fp_texture_dimensions);
+			state_hash ^= rpcs3::hash_base<u32>(data.fp_texcoord_control);
 			state_hash ^= rpcs3::hash_base<u16>(data.fp_unnormalized_coords);
 			state_hash ^= rpcs3::hash_base<u16>(data.fp_height);
 			state_hash ^= rpcs3::hash_base<u16>(data.fp_pixel_layout);
@@ -810,12 +812,9 @@ namespace rsx
 
 			fp.ctrl = data.fp_ctrl;
 			fp.texture_dimensions = data.fp_texture_dimensions;
+			fp.texcoord_control_mask = data.fp_texcoord_control;
 			fp.unnormalized_coords = data.fp_unnormalized_coords;
-			fp.front_back_color_enabled = (data.fp_lighting_flags & 0x1) != 0;
-			fp.back_color_diffuse_output = ((data.fp_lighting_flags >> 1) & 0x1) != 0;
-			fp.back_color_specular_output = ((data.fp_lighting_flags >> 2) & 0x1) != 0;
-			fp.front_color_diffuse_output = ((data.fp_lighting_flags >> 3) & 0x1) != 0;
-			fp.front_color_specular_output = ((data.fp_lighting_flags >> 4) & 0x1) != 0;
+			fp.two_sided_lighting = !!(data.fp_lighting_flags & 0x1);
 			fp.shadow_textures = data.fp_shadow_textures;
 			fp.redirected_textures = data.fp_redirected_textures;
 
@@ -863,9 +862,9 @@ namespace rsx
 
 			data_block.fp_ctrl = fp.ctrl;
 			data_block.fp_texture_dimensions = fp.texture_dimensions;
+			data_block.fp_texcoord_control = fp.texcoord_control_mask;
 			data_block.fp_unnormalized_coords = fp.unnormalized_coords;
-			data_block.fp_lighting_flags = (u16)fp.front_back_color_enabled | (u16)fp.back_color_diffuse_output << 1 |
-				(u16)fp.back_color_specular_output << 2 | (u16)fp.front_color_diffuse_output << 3 | (u16)fp.front_color_specular_output << 4;
+			data_block.fp_lighting_flags = u16(fp.two_sided_lighting);
 			data_block.fp_shadow_textures = fp.shadow_textures;
 			data_block.fp_redirected_textures = fp.redirected_textures;
 

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -4185,6 +4185,29 @@ struct registers_decoder<NV4097_DRAW_INDEX_ARRAY>
 	}
 };
 
+template <>
+struct registers_decoder<NV4097_SET_CONTROL0>
+{
+	struct decoded_type
+	{
+	private:
+		u32 value;
+
+	public:
+		decoded_type(u32 value) : value(value) {}
+
+		bool depth_float() const
+		{
+			return bf_decoder<12, 1>(value) != 0;
+		}
+	};
+
+	static std::string dump(decoded_type&& decoded_values)
+	{
+		return "Depth float enabled: " + decoded_values.depth_float() ? "true" : "false";
+	}
+};
+
 #define TRANSFORM_PROGRAM(index) template<> struct registers_decoder<NV4097_SET_TRANSFORM_PROGRAM + index> : public transform_program_helper<index> {};
 #define DECLARE_TRANSFORM_PROGRAM(index) NV4097_SET_TRANSFORM_PROGRAM + index,
 EXPAND_RANGE_512(0, TRANSFORM_PROGRAM)

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1624,6 +1624,18 @@ namespace rsx
 		{
 			return decode<NV4097_SET_CONTROL0>().depth_float();
 		}
+
+		u32 texcoord_control_mask()
+		{
+			// Only 10 texture coords exist [0-9]
+			u32 control_mask = 0;
+			for (u8 index = 0; index < 10; ++index)
+			{
+				control_mask |= ((registers[NV4097_SET_TEX_COORD_CONTROL + index] & 1) << index);
+			}
+
+			return control_mask;
+		}
 	};
 
 	extern rsx_state method_registers;

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1619,6 +1619,11 @@ namespace rsx
 		{
 			return decode<NV4097_SET_SHADER_PACKER>().srgb_output_enabled();
 		}
+
+		bool depth_buffer_float_enabled()
+		{
+			return decode<NV4097_SET_CONTROL0>().depth_float();
+		}
 	};
 
 	extern rsx_state method_registers;

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -111,6 +111,7 @@ namespace rsx
 
 		rsx::surface_color_format color_format;
 		rsx::surface_depth_format depth_format;
+		bool depth_buffer_float;
 
 		u16 width = 0;
 		u16 height = 0;


### PR DESCRIPTION
- Implement 24-bit floats in depth texture decode step [D24S8->ARGB8]
- Fix some shader decompiler bugs
- Fix behavior of varying registers. Not all registers are created equal. Some have in-built saturate modifiers and texN registers can have their behavior altered through other registers. All tests confirmed on real hardware.