### PR TITLE
Fix crash when no entry is left during save data deletion

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -208,6 +208,12 @@ static error_code select_and_delete(ppu_thread& ppu)
 			save_entries.erase(save_entries.cbegin() + selected);
 			selected = -1;
 
+			// Reset the focused index if the new list is empty
+			if (save_entries.empty())
+			{
+				focused = -1;
+			}
+
 			// Display success message (return value should be irrelevant here)
 			msg = "Successfully removed entry!\n\n" + info;
 			cellSaveData.success("%s", msg);

--- a/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
@@ -56,7 +56,19 @@ namespace rsx
 
 		void list_view::update_selection()
 		{
-			auto current_element = m_items[m_selected_entry * 2].get();
+			if (m_selected_entry < 0)
+			{
+				return; // Ideally unreachable but it should still be possible to recover by user interaction.
+			}
+
+			const size_t current_index = static_cast<size_t>(m_selected_entry) * 2;
+
+			if (m_items.size() <= current_index)
+			{
+				return; // Ideally unreachable but it should still be possible to recover by user interaction.
+			}
+
+			auto current_element = m_items[current_index].get();
 
 			// Calculate bounds
 			auto min_y = current_element->y - y;

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -240,8 +240,11 @@ namespace rsx
 				m_no_saves = true;
 				m_list->set_cancel_only(true);
 			}
-
-			m_list->select_entry(focused);
+			else
+			{
+				// Only select an entry if there are entries available
+				m_list->select_entry(focused);
+			}
 
 			static_cast<label*>(m_description.get())->auto_resize();
 


### PR DESCRIPTION
Fixes a crash when the save data list overlay was loaded with focus on an element that didn't exist.