### PR TITLE
rsx: Hotfix for semaphore timeout bug

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1865,7 +1865,8 @@ void GLGSRender::on_invalidate_memory_range(const utils::address_range &range, r
 
 void GLGSRender::on_semaphore_acquire_wait()
 {
-	if (!work_queue.empty())
+	if (!work_queue.empty() ||
+		(async_flip_requested & flip_request::emu_requested))
 	{
 		do_local_task(rsx::FIFO_state::lock_wait);
 	}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -741,7 +741,9 @@ void VKGSRender::on_invalidate_memory_range(const utils::address_range &range, r
 
 void VKGSRender::on_semaphore_acquire_wait()
 {
-	if (m_flush_requests.pending() || m_queue_status & flush_queue_state::deadlock)
+	if (m_flush_requests.pending() ||
+		(async_flip_requested & flip_request::emu_requested) ||
+		(m_queue_status & flush_queue_state::deadlock))
 	{
 		do_local_task(rsx::FIFO_state::lock_wait);
 	}


### PR DESCRIPTION
- Add pending flip requests as a reason to invoke the RSX local task handler and release the vblank semaphore.

Fixes https://github.com/RPCS3/rpcs3/issues/6413