### PR TITLE
rsx: Fix surface cache hit tests

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -756,7 +756,14 @@ namespace rsx
 
 			const auto surface_internal_pitch = (required_width * required_bpp);
 
-			verify(HERE), surface_internal_pitch <= required_pitch;
+			// Sanity check
+			if (UNLIKELY(surface_internal_pitch > required_pitch))
+			{
+				LOG_WARNING(RSX, "Invalid 2D region descriptor. w=%d, h=%d, bpp=%d, pitch=%d",
+							required_width, required_height, required_bpp, required_pitch);
+				return {};
+			}
+
 			const auto test_range = utils::address_range::start_length(texaddr, (required_pitch * required_height) - (required_pitch - surface_internal_pitch));
 
 			auto process_list_function = [&](std::unordered_map<u32, surface_storage_type>& data, bool is_depth)

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -357,6 +357,8 @@ namespace rsx
 #else
 		void queue_tag(u32 address)
 		{
+			verify(HERE), native_pitch, rsx_pitch;
+
 			base_addr = address;
 
 			const u32 size_x = (native_pitch > 8)? (native_pitch - 8) : 0u;
@@ -569,7 +571,8 @@ namespace rsx
 		rsx::address_range get_memory_range() const
 		{
 			const u32 internal_height = get_surface_height(rsx::surface_metrics::samples);
-			return rsx::address_range::start_length(base_addr, internal_height * get_rsx_pitch());
+			const u32 excess = (rsx_pitch - native_pitch);
+			return rsx::address_range::start_length(base_addr, internal_height * rsx_pitch - excess);
 		}
 
 		template <typename T>

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2023,8 +2023,10 @@ namespace rsx
 				scale_x = 0.f;
 				scale_y = 0.f;
 			}
-			else if (extended_dimension == rsx::texture_dimension_extended::texture_dimension_1d)
+			else if (required_surface_height == 1)
 			{
+				// Pitch doesn't matter when height=1 and some games abuse this fact
+				tex_pitch = std::max<u16>(tex_pitch, get_format_packed_pitch(format, tex_width, !tex.border_type(), !linear));
 				scale_y = 0.f;
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -212,13 +212,10 @@ struct gl_render_target_traits
 
 			sink->set_spp(ref->get_spp());
 			sink->set_native_pitch(prev.width * ref->get_bpp() * ref->samples_x);
+			sink->set_rsx_pitch(ref->get_rsx_pitch());
 			sink->set_surface_dimensions(prev.width, prev.height, ref->get_rsx_pitch());
 			sink->set_native_component_layout(ref->get_native_component_layout());
 			sink->queue_tag(address);
-		}
-		else
-		{
-			sink->set_rsx_pitch(ref->get_rsx_pitch());
 		}
 
 		prev.target = sink.get();
@@ -236,6 +233,7 @@ struct gl_render_target_traits
 			}
 		}
 
+		sink->set_rsx_pitch(ref->get_rsx_pitch());
 		sink->set_old_contents_region(prev, false);
 		sink->last_use_tag = ref->last_use_tag;
 	}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -711,6 +711,7 @@ namespace rsx
 				sink->sample_layout = ref->sample_layout;
 				sink->stencil_init_flags = ref->stencil_init_flags;
 				sink->native_pitch = u16(prev.width * ref->get_bpp() * ref->samples_x);
+				sink->rsx_pitch = ref->get_rsx_pitch();
 				sink->surface_width = prev.width;
 				sink->surface_height = prev.height;
 				sink->queue_tag(address);
@@ -724,7 +725,6 @@ namespace rsx
 
 			prev.target = sink.get();
 
-			sink->rsx_pitch = ref->get_rsx_pitch();
 			if (!sink->old_contents.empty())
 			{
 				// Deal with this, likely only needs to clear
@@ -738,6 +738,7 @@ namespace rsx
 				}
 			}
 
+			sink->rsx_pitch = ref->get_rsx_pitch();
 			sink->set_old_contents_region(prev, false);
 			sink->last_use_tag = ref->last_use_tag;
 		}


### PR DESCRIPTION
Fixes several facepalm-worthy bugs found when investigating castlevania.
- Avoid silly broken tests due to queue_tag being called before pitch is initialized.
- Return actual memory range covered and exclude trailing padding in surface->get_memory_range().
- Coordinates in src are to be calculated with src_pitch, not required_pitch.

Fixes https://github.com/RPCS3/rpcs3/issues/6259