### PR TITLE
Fix improper string concatenation in rsx_decode.

### DIFF
--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -4258,7 +4258,7 @@ struct registers_decoder<NV4097_SET_CONTROL0>
 
 	static std::string dump(decoded_type&& decoded_values)
 	{
-		return "Depth float enabled: " + decoded_values.depth_float() ? "true" : "false";
+		return "Depth float enabled: " + (decoded_values.depth_float() ? std::string("true") : std::string("false"));
 	}
 };
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8901018/63810905-7f5fed00-c915-11e9-9a24-0763ec6e1884.png)
