### PR TITLE
rsx: GPU-accelerated texture decoding

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -110,6 +110,19 @@ struct rsx_subresource_layout
 	u32 pitch_in_block;
 };
 
+struct texture_memory_info
+{
+	int element_size;
+	bool require_swap;
+};
+
+struct texture_uploader_capabilities
+{
+	bool supports_byteswap;
+	bool supports_vtc_decoding;
+	size_t alignment;
+};
+
 /**
 * Get size to store texture in a linear fashion.
 * Storage is assumed to use a rowPitchAlignment boundary for every row of texture.
@@ -125,7 +138,7 @@ size_t get_placed_texture_storage_size(const rsx::vertex_texture &texture, size_
 std::vector<rsx_subresource_layout> get_subresources_layout(const rsx::fragment_texture &texture);
 std::vector<rsx_subresource_layout> get_subresources_layout(const rsx::vertex_texture &texture);
 
-void upload_texture_subresource(gsl::span<gsl::byte> dst_buffer, const rsx_subresource_layout &src_layout, int format, bool is_swizzled, bool vtc_support, size_t dst_row_pitch_multiple_of);
+texture_memory_info upload_texture_subresource(gsl::span<gsl::byte> dst_buffer, const rsx_subresource_layout &src_layout, int format, bool is_swizzled, const texture_uploader_capabilities& caps);
 
 u8 get_format_block_size_in_bytes(int format);
 u8 get_format_block_size_in_texel(int format);

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -887,6 +887,7 @@ namespace rsx
 			if (write_tag == cache_tag && m_skip_write_updates)
 			{
 				// Nothing to do
+				verify(HERE), !m_invalidate_on_write;
 				return;
 			}
 

--- a/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Texture.cpp
@@ -115,7 +115,8 @@ namespace {
 		size_t offset_in_buffer = 0;
 		for (const rsx_subresource_layout &layout : input_layouts)
 		{
-			upload_texture_subresource(mapped_buffer.subspan(offset_in_buffer), layout, format, is_swizzled, false, 256);
+			texture_uploader_capabilities caps{ false, false, 256 };
+			upload_texture_subresource(mapped_buffer.subspan(offset_in_buffer), layout, format, is_swizzled, caps);
 			UINT row_pitch = align(layout.width_in_block * block_size_in_bytes, 256);
 			command_list->CopyTextureRegion(&CD3DX12_TEXTURE_COPY_LOCATION(existing_texture, (UINT)mip_level), 0, 0, 0,
 				&CD3DX12_TEXTURE_COPY_LOCATION(texture_buffer_heap.get_heap(),

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1074,7 +1074,8 @@ namespace rsx
 		{
 			if (rsx::method_registers.color_write_enabled(i))
 			{
-				layout.color_write_enabled[i] = true;
+				const auto real_index = mrt_buffers[i];
+				layout.color_write_enabled[real_index] = true;
 				color_write_enabled = true;
 			}
 		}

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -89,13 +89,21 @@ namespace vk
 				{
 				case vk::driver_vendor::unknown:
 				case vk::driver_vendor::INTEL:
+					// Intel hw has 8 threads, but LDS allocation behavior makes optimal group size between 64 and 256
+					// Based on intel's own OpenCL recommended settings
+					unroll_loops = true;
+					optimal_kernel_size = 1;
+					optimal_group_size = 128;
+					break;
 				case vk::driver_vendor::NVIDIA:
+					// Warps are multiples of 32. Increasing kernel depth seems to hurt performance (Nier, Big Duck sample)
 					unroll_loops = true;
 					optimal_group_size = 32;
-					optimal_kernel_size = 16;
+					optimal_kernel_size = 1;
 					break;
 				case vk::driver_vendor::AMD:
 				case vk::driver_vendor::RADV:
+					// Wavefronts are multiples of 64
 					unroll_loops = false;
 					optimal_kernel_size = 1;
 					optimal_group_size = 64;


### PR DESCRIPTION
bswap operations are rather slow (especially on ryzen) and this causes a huge performance drop in some games that have a small texture memory pool and reuse textures a lot. Nier is a good example of this where performance recently dropped by more than half when I forced texture decode to behave consistently and avoiding swizzle hacks. Instead, its faster to upload the raw pool to GPU and use pre-existing compute kernels to generate proper data for the textures needed.
~~While this recovers all the lost performance on AMD systems, I'm still tuning for NVIDIA cards where there still exists a slight performance loss vs the old hacky method.~~