### PR TITLE
Add disk cache removal to UI

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -345,11 +345,11 @@ public:
 
 private:
 	static std::string GetEmuDir();
-	static std::string GetHdd1Dir();
 
 	void LimitCacheSize();
 public:
 	static std::string GetHddDir();
+	static std::string GetHdd1Dir();
 	static std::string GetSfoDirFromGamePath(const std::string& game_path, const std::string& user, const std::string& title_id = "");
 
 	static std::string GetCustomConfigDir();

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -150,8 +150,8 @@ void debugger_frame::ChangeColors()
 {
 	if (m_debugger_list)
 	{
-		m_debugger_list->m_color_bp = m_breakpoint_list->m_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint", QPalette::Background);
-		m_debugger_list->m_color_pc = gui::utils::get_label_color("debugger_frame_pc", QPalette::Background);
+		m_debugger_list->m_color_bp = m_breakpoint_list->m_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint", QPalette::Window);
+		m_debugger_list->m_color_pc = gui::utils::get_label_color("debugger_frame_pc", QPalette::Window);
 		m_debugger_list->m_text_color_bp = m_breakpoint_list->m_text_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint");;
 		m_debugger_list->m_text_color_pc = gui::utils::get_label_color("debugger_frame_pc");;
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1186,6 +1186,8 @@ void main_window::CreateConnects()
 	connect(ui->batchRemoveCustomConfigurationsAct, &QAction::triggered, m_gameListFrame, &game_list_frame::BatchRemoveCustomConfigurations);
 	connect(ui->batchRemoveCustomPadConfigurationsAct, &QAction::triggered, m_gameListFrame, &game_list_frame::BatchRemoveCustomPadConfigurations);
 
+	connect(ui->removeDiskCacheAct, &QAction::triggered, this, &main_window::RemoveDiskCache);
+
 	connect(ui->sysPauseAct, &QAction::triggered, this, &main_window::OnPlayOrPause);
 	connect(ui->sysStopAct, &QAction::triggered, [=]() { Emu.Stop(); });
 	connect(ui->sysRebootAct, &QAction::triggered, [=]() { Emu.Restart(); });
@@ -1635,6 +1637,20 @@ void main_window::SetIconSizeActions(int idx)
 		ui->setIconSizeMediumAct->setChecked(true);
 	else
 		ui->setIconSizeLargeAct->setChecked(true);
+}
+
+void main_window::RemoveDiskCache()
+{
+	std::string cacheDir = Emulator::GetHdd1Dir() + "/cache";
+
+	if (fs::is_dir(cacheDir) && fs::remove_all(cacheDir, false))
+	{
+		QMessageBox::information(this, tr("Cache Cleared"), tr("Disk cache was cleared successfully"));
+	}
+	else
+	{
+		QMessageBox::warning(this, tr("Error"), tr("Could not remove disk cache"));
+	}
 }
 
 void main_window::keyPressEvent(QKeyEvent *keyEvent)

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -126,6 +126,7 @@ private:
 	QAction* CreateRecentAction(const q_string_pair& entry, const uint& sc_idx);
 	void BootRecentAction(const QAction* act);
 	void AddRecentAction(const q_string_pair& entry);
+	void RemoveDiskCache();
 
 	q_pair_list m_rg_entries;
 	QList<QAction*> m_recentGameActs;

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -176,6 +176,8 @@
      <addaction name="batchRemovePPUCachesAct"/>
      <addaction name="batchRemoveSPUCachesAct"/>
      <addaction name="batchRemoveShaderCachesAct"/>
+     <addaction name="separator"/>
+     <addaction name="removeDiskCacheAct"/>
     </widget>
     <addaction name="bootElfAct"/>
     <addaction name="bootGameAct"/>
@@ -999,6 +1001,11 @@
   <action name="batchRemoveCustomPadConfigurationsAct">
    <property name="text">
     <string>Remove Custom Pad Configurations</string>
+   </property>
+  </action>
+  <action name="removeDiskCacheAct">
+   <property name="text">
+    <string>Remove Disk Cache</string>
    </property>
   </action>
  </widget>

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -31,7 +31,7 @@ namespace gui
 		QStringList get_dir_entries(const QDir& dir, const QStringList& name_filters);
 
 		// Returns the color specified by its color_role for the QLabels with object_name
-		QColor get_label_color(const QString& object_name, QPalette::ColorRole color_role = QPalette::Foreground);
+		QColor get_label_color(const QString& object_name, QPalette::ColorRole color_role = QPalette::WindowText);
 
 		// Returns the font of the QLabels with object_name
 		QFont get_label_font(const QString& object_name);


### PR DESCRIPTION
Adds a more convinient and user-friendly way of removing disk cache; by just clicking on `File > All Games > Remove Disc Cache`.