### PR TITLE
Convert EROFS error

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -153,6 +153,7 @@ static fs::error to_error(int e)
 	case EINVAL: return fs::error::inval;
 	case EACCES: return fs::error::acces;
 	case ENOTEMPTY: return fs::error::notempty;
+	case EROFS: return fs::error::readonly;
 	default: fmt::throw_exception("Unknown system error: %d.", e);
 	}
 }
@@ -1751,6 +1752,7 @@ void fmt_class_string<fs::error>::format(std::string& out, u64 arg)
 		case fs::error::exist: return "Already exists";
 		case fs::error::acces: return "Access violation";
 		case fs::error::notempty: return "Not empty";
+		case fs::error::readonly: return "Read only";
 		}
 
 		return unknown;

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -517,6 +517,7 @@ namespace fs
 		exist,
 		acces,
 		notempty,
+		readonly,
 	};
 
 	// Error code returned


### PR DESCRIPTION
Convert EROFS error to avoid crashing on a read-only filesystem