### PR TITLE
Revert File.h encoding

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "types.h"
 #include "bit_set.h"
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+
 
 namespace fs
 {


### PR DESCRIPTION
Fixes building on linux with gcc ( https://github.com/RPCS3/rpcs3/issues/6474 ).
I don't know why but it leads to double inclusion of File.h otherwise:

> In file included from /home/tomripley/Repos/rpcs3/rpcs3/stdafx.h:31,
>                  from /home/tomripley/Repos/rpcs3/Utilities/dynamic_library.cpp:1:
> /home/tomripley/Repos/rpcs3/Utilities/File.h:20:13: error: multiple definition of ‘enum class fs::open_mode’
>   enum class open_mode : u32
>              ^~~~~~~~~
> In file included from /home/tomripley/Repos/rpcs3/rpcs3/stdafx.h:31,
>                  from /home/tomripley/Repos/rpcs3_build/rpcs3/Emu/cotire/rpcs3_emu_CXX_prefix.cxx:4,
>                  from /home/tomripley/Repos/rpcs3_build/rpcs3/Emu/cotire/rpcs3_emu_CXX_prefix.hxx:4:
> /home/tomripley/Repos/rpcs3/Utilities/File.h:20:13: note: previous definition here
>   enum class open_mode : u32
>              ^~~~~~~~~
> 