### PR TITLE
Remove SSE4.1 requirement

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -4830,7 +4830,7 @@ bool ppu_interpreter::FCTIWZ(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto b = _mm_load_sd(&ppu.fpr[op.frb]);
 	const auto res = _mm_xor_si128(_mm_cvttpd_epi32(b), _mm_castpd_si128(_mm_cmpge_pd(b, _mm_set1_pd(0x80000000))));
-	ppu.fpr[op.frd] = std::bit_cast<f64, s64>(_mm_extract_epi32(res, 0));
+	ppu.fpr[op.frd] = std::bit_cast<f64, s64>(_mm_cvtsi128_si32(res));
 	if (UNLIKELY(op.rc)) fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
@@ -5022,7 +5022,7 @@ bool ppu_interpreter::FCTID(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto b = _mm_load_sd(&ppu.fpr[op.frb]);
 	const auto res = _mm_xor_si128(_mm_set1_epi64x(_mm_cvtsd_si64(b)), _mm_castpd_si128(_mm_cmpge_pd(b, _mm_set1_pd(f64(1ull << 63)))));
-	ppu.fpr[op.frd] = std::bit_cast<f64>(_mm_extract_epi64(res, 0));
+	ppu.fpr[op.frd] = std::bit_cast<f64>(_mm_cvtsi128_si64(res));
 	if (UNLIKELY(op.rc)) fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
@@ -5031,7 +5031,7 @@ bool ppu_interpreter::FCTIDZ(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto b = _mm_load_sd(&ppu.fpr[op.frb]);
 	const auto res = _mm_xor_si128(_mm_set1_epi64x(_mm_cvttsd_si64(b)), _mm_castpd_si128(_mm_cmpge_pd(b, _mm_set1_pd(f64(1ull << 63)))));
-	ppu.fpr[op.frd] = std::bit_cast<f64>(_mm_extract_epi64(res, 0));
+	ppu.fpr[op.frd] = std::bit_cast<f64>(_mm_cvtsi128_si64(res));
 	if (UNLIKELY(op.rc)) fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }


### PR DESCRIPTION
Some SSE4.1 code was introduced with https://github.com/RPCS3/rpcs3/commit/a560498cd4d18b4dff820c35f9cb3a5f00fbf630 without updating the build flags thus resulting in #6479.
The `_mm_extract_epi` calls which is the SSE4.1 code in question can easily be replace with a single `_mm_cvtsi128_si` call each since we only access the lower integer. This generates identical code and removes the SSE4.1 requirement. Fixes #6479