### PR TITLE
Fix passive reservation locks checking at Emu.Stop() (non-TSX)

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -221,7 +221,12 @@ bool cpu_thread::check_state() noexcept
 		if (state & (cpu_flag::exit + cpu_flag::jit_return + cpu_flag::dbg_global_stop))
 		{
 			state += cpu_flag::wait;
-			cpu_unmem();
+
+			if (auto ptr = vm::g_tls_locked)
+			{
+				ptr->compare_and_swap(this, nullptr);
+			}
+
 			return true;
 		}
 

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -221,6 +221,7 @@ bool cpu_thread::check_state() noexcept
 		if (state & (cpu_flag::exit + cpu_flag::jit_return + cpu_flag::dbg_global_stop))
 		{
 			state += cpu_flag::wait;
+			cpu_unmem();
 			return true;
 		}
 

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -162,6 +162,11 @@ void cpu_thread::operator()()
 		thread_ctrl::wait();
 	}
 
+	if (auto ptr = vm::g_tls_locked)
+	{
+		ptr->compare_and_swap(this, nullptr);
+	}
+
 	// Unregister and wait if necessary
 	state += cpu_flag::wait;
 	verify("g_cpu_array[...] -> null" HERE), g_cpu_array[array_slot].exchange(nullptr) == this;
@@ -221,12 +226,6 @@ bool cpu_thread::check_state() noexcept
 		if (state & (cpu_flag::exit + cpu_flag::jit_return + cpu_flag::dbg_global_stop))
 		{
 			state += cpu_flag::wait;
-
-			if (auto ptr = vm::g_tls_locked)
-			{
-				ptr->compare_and_swap(this, nullptr);
-			}
-
 			return true;
 		}
 
@@ -268,12 +267,12 @@ bool cpu_thread::check_state() noexcept
 			continue;
 		}
 
-		if (state & cpu_flag::wait)
+		if (state0 & cpu_flag::wait)
 		{
 			// Spin wait once for a bit before resorting to thread_ctrl::wait
 			for (u32 i = 0; i < 10; i++)
 			{
-				if (state0 & (cpu_flag::pause + cpu_flag::suspend))
+				if (state & (cpu_flag::pause + cpu_flag::suspend))
 				{
 					busy_wait(500);
 				}
@@ -283,7 +282,7 @@ bool cpu_thread::check_state() noexcept
 				}
 			}
 
-			if (!(state0 & (cpu_flag::pause + cpu_flag::suspend)))
+			if (!(state & (cpu_flag::pause + cpu_flag::suspend)))
 			{
 				continue;
 			}


### PR DESCRIPTION
Fixes threads not leaving their passive vm lock after exiting by dbg_global_stop.