### PR TITLE
vk: Restructure commandbuffer scoping to allow faults in vertex upload

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -442,7 +442,7 @@ VKGSRender::VKGSRender() : GSRender()
 
 	//Generate frame contexts
 	VkDescriptorPoolSize uniform_buffer_pool = { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER , 6 * DESCRIPTOR_MAX_DRAW_CALLS };
-	VkDescriptorPoolSize uniform_texel_pool = { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER , 2 * DESCRIPTOR_MAX_DRAW_CALLS };
+	VkDescriptorPoolSize uniform_texel_pool = { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER , 3 * DESCRIPTOR_MAX_DRAW_CALLS };
 	VkDescriptorPoolSize texture_pool = { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER , 20 * DESCRIPTOR_MAX_DRAW_CALLS };
 
 	std::vector<VkDescriptorPoolSize> sizes{ uniform_buffer_pool, uniform_texel_pool, texture_pool };


### PR DESCRIPTION
Defers renderpass open to allow recovery after fault in the middle of vertex upload. This fixes problem where flushing during draw calls would lead to inconsistent object state and upon "recovery" draw calls would be guaranteed to fail or crash the driver. Seemingly not a big problem for NV but should reduce chances of flickering when WCB is enabled.
Also adds a missing texel buffer entry in the descriptor pool allocation.