### PR TITLE
rsx: Minor texture optimizations

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -391,16 +391,32 @@ namespace
 }
 
 template<typename T>
-u32 get_row_pitch_in_block(u16 width_in_block, size_t multiple_constraints_in_byte)
+u32 get_row_pitch_in_block(u16 width_in_block, size_t alignment)
 {
-	size_t divided = (width_in_block * sizeof(T) + multiple_constraints_in_byte - 1) / multiple_constraints_in_byte;
-	return static_cast<u32>(divided * multiple_constraints_in_byte / sizeof(T));
+	if (const size_t pitch = width_in_block * sizeof(T);
+		pitch == alignment)
+	{
+		return width_in_block;
+	}
+	else
+	{
+		size_t divided = (pitch + alignment - 1) / alignment;
+		return static_cast<u32>(divided * alignment / sizeof(T));
+	}
 }
 
-u32 get_row_pitch_in_block(u16 block_size_in_bytes, u16 width_in_block, size_t multiple_constraints_in_byte)
+u32 get_row_pitch_in_block(u16 block_size_in_bytes, u16 width_in_block, size_t alignment)
 {
-	size_t divided = (width_in_block * block_size_in_bytes + multiple_constraints_in_byte - 1) / multiple_constraints_in_byte;
-	return static_cast<u32>(divided * multiple_constraints_in_byte / block_size_in_bytes);
+	if (const size_t pitch = width_in_block * block_size_in_bytes;
+		pitch == alignment)
+	{
+		return width_in_block;
+	}
+	else
+	{
+		size_t divided = (pitch + alignment - 1) / alignment;
+		return static_cast<u32>(divided * alignment / block_size_in_bytes);
+	}
 }
 
 /**

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -141,7 +141,7 @@ namespace vk
 	*/
 	void copy_mipmaped_image_using_buffer(VkCommandBuffer cmd, vk::image* dst_image,
 		const std::vector<rsx_subresource_layout>& subresource_layout, int format, bool is_swizzled, u16 mipmap_count,
-		VkImageAspectFlags flags, vk::data_heap &upload_heap, u32 heap_align = 256);
+		VkImageAspectFlags flags, vk::data_heap &upload_heap, u32 heap_align = 0);
 
 	//Other texture management helpers
 	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range);


### PR DESCRIPTION
- Allow fast upload of data by looking for opportunities to upload the full data block in one go.
  Minor performance improvement noted when profiling a particularly problematic game (Split Second)
- Allow for auto-matching of pitch dimensions. Dumping statistics from games shows most use pitch alignment of 1 and there is no reason to force 256-byte alignment when uploading. Allows fast-copy to work which should make it easier on the GPU and CPU to handle. Also drastically lowers memory footprint of smaller textures.
- Batch compute and transfer operations when decoding texture data. Lowers overall number of compute invocations by an order of magnitude.