### PR TITLE
rsx: Misc fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1691,7 +1691,7 @@ namespace rsx
 					surfaces.push_back
 					({
 						section->get_raw_texture(),
-						is_depth ? surface_transform::identity : surface_transform::argb_to_bgra,
+						surface_transform::identity,
 						(u16)std::get<0>(clipped).x,
 						(u16)std::get<0>(clipped).y,
 						rsx::apply_resolution_scale((u16)std::get<1>(clipped).x, true),
@@ -1710,7 +1710,7 @@ namespace rsx
 					surfaces.push_back
 					({
 						section->get_raw_texture(),
-						is_depth ? surface_transform::identity : surface_transform::argb_to_bgra,
+						surface_transform::identity,
 						(u16)std::get<0>(clipped).x,
 						(u16)std::get<0>(clipped).y,
 						(u16)std::get<1>(clipped).x,

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -868,7 +868,7 @@ namespace gl
 				}
 				case CELL_GCM_TEXTURE_DEPTH24_D8:
 				{
-					cached.set_format(gl::texture::format::depth_stencil, gl::texture::type::uint_24_8, true);
+					cached.set_format(gl::texture::format::depth_stencil, gl::texture::type::uint_24_8, false);
 					break;
 				}
 				case CELL_GCM_TEXTURE_DEPTH16:

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -416,6 +416,7 @@ namespace vk
 					vkCmdCopyImageToBuffer(cmd, src, preferred_src_format, scratch_buf->value, 1, &info);
 					insert_buffer_memory_barrier(cmd, scratch_buf->value, 0, VK_WHOLE_SIZE, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
 
+					info.imageOffset = {};
 					info.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
 					vkCmdCopyBufferToImage(cmd, scratch_buf->value, typeless, VK_IMAGE_LAYOUT_GENERAL, 1, &info);
 
@@ -465,7 +466,7 @@ namespace vk
 					// Copy from src->intermediate then intermediate->dst for each aspect separately
 
 					auto typeless_depth = vk::get_typeless_helper(VK_FORMAT_R32_SFLOAT, typeless_w, typeless_h);
-					auto typeless_stencil = vk::get_typeless_helper(VK_FORMAT_R8_UINT, typeless_w, typeless_h);
+					auto typeless_stencil = vk::get_typeless_helper(VK_FORMAT_R8_UNORM, typeless_w, typeless_h);
 					change_image_layout(cmd, typeless_depth, VK_IMAGE_LAYOUT_GENERAL);
 					change_image_layout(cmd, typeless_stencil, VK_IMAGE_LAYOUT_GENERAL);
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -621,6 +621,10 @@ namespace vk
 								1, new_src_aspect, tmp->info.format == _dst->info.format,
 								VK_FILTER_NEAREST, tmp->info.format, _dst->info.format);
 						}
+						else
+						{
+							_dst = tmp;
+						}
 					}
 					else
 					{


### PR DESCRIPTION
- Fix OGL decode description for uint_24_8. (https://github.com/RPCS3/rpcs3/issues/6433)
- Fix broken source reference when doing Z scaling (https://github.com/RPCS3/rpcs3/issues/6434)
- Fix missing target when using vulkan surface transforms without scaling. (https://github.com/RPCS3/rpcs3/issues/6434)
- Remove unused surface transform argb_to_bgra. Vulkan now has proper texture decoding so this just jumbles the data even more. (https://github.com/RPCS3/rpcs3/issues/6434)

Fixes https://github.com/RPCS3/rpcs3/issues/6433
Fixes https://github.com/RPCS3/rpcs3/issues/6434