### PR TITLE
rsx: Fixup

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -65,7 +65,7 @@ struct copy_unmodified_block
 		if (src_pitch_in_block == dst_pitch_in_block && !border)
 		{
 			// Fast copy
-			const auto data_length = width_in_block * words_per_block * row_count * depth;
+			const auto data_length = src_pitch_in_block * words_per_block * row_count * depth;
 			copy(dst, src.subspan(0, data_length));
 			return;
 		}

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -563,7 +563,7 @@ namespace vk
 			auto& copy_info = copy_regions.back();
 			copy_info.bufferOffset = offset_in_buffer;
 			copy_info.imageExtent.height = layout.height_in_block * block_in_pixel;
-			copy_info.imageExtent.width = layout.width_in_block * block_in_pixel;
+			copy_info.imageExtent.width = std::min<u32>(layout.width_in_block, layout.pitch_in_block) * block_in_pixel;
 			copy_info.imageExtent.depth = layout.depth;
 			copy_info.imageSubresource.aspectMask = flags;
 			copy_info.imageSubresource.layerCount = 1;


### PR DESCRIPTION
Fixup for fast texture copies when linear mipmapped images are uploaded.
Followup to https://github.com/RPCS3/rpcs3/pull/6488