### PR TITLE
Add handler descriptions to pad settings

### DIFF
--- a/rpcs3/Json/pad_settings.json
+++ b/rpcs3/Json/pad_settings.json
@@ -1,0 +1,15 @@
+{
+  "handlers": {
+    "null": "This controller is disabled and will appear as disconnected to software. Choose another handler to enable it.",
+    "keyboard": "While it is possible to use a keyboard as a pad in RPCS3, the use of an actual controller is strongly recommended. To bind mouse movement to a button or joystick, click on the desired button to activate it, then click and hold while dragging the mouse to a direction",
+    "ds3_windows": "In order to use the DualShock 3 handler, you need to install the official DualShock 3 driver first.\nSee the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.",
+    "ds3_linux": "In order to use the DualShock 3 handler, you might need to add udev rules to let RPCS3 access the controller.\nSee the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.",
+    "ds3_other": "The DualShock 3 handler is recommended for official DualShock 3 controllers.",
+    "ds4_windows": "If you have any issues with the DualShock 4 handler, it might be caused by third-party tools such as DS4Windows. It's recommended that you disable them while using this handler.",
+    "ds4_linux": "In order to use the DualShock 4 handler, you might need to add udev rules to let RPCS3 access the controller.\nSee the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.",
+    "ds4_other": "The DualShock 4 handler is recommended for official DualShock 4 controllers.",
+    "xinput": "The XInput handler will work with Xbox controllers and many third-party PC-compatible controllers.",
+    "evdev": "The evdev handler should work with any controller that has linux support.\nIf your joystick is not being centered properly, read the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.",
+    "mmjoy": "The MMJoystick handler should work with almost any controller recognized by Windows. However, it is recommended that you use the more specific handlers if you have a controller that supports them."
+  }
+}

--- a/rpcs3/resources.qrc
+++ b/rpcs3/resources.qrc
@@ -14,6 +14,7 @@
         <file>Icons/list.png</file>
         <file>Icons/refresh.png</file>
         <file>Json/tooltips.json</file>
+        <file>Json/pad_settings.json</file>
         <file>Icons/exit_fullscreen.png</file>
         <file>Icons/open.png</file>
         <file>Icons/custom_config.png</file>

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -3,6 +3,7 @@
 #include <QButtonGroup>
 #include <QDialog>
 #include <QEvent>
+#include <QJsonObject>
 #include <QLabel>
 #include <QTabWidget>
 #include <QTimer>
@@ -102,6 +103,9 @@ private Q_SLOTS:
 private:
 	Ui::pad_settings_dialog *ui;
 	std::string m_title_id;
+
+	// Tooltip things
+	QJsonObject m_json_handlers;
 
 	// TabWidget
 	QTabWidget* m_tabs = nullptr;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -997,7 +997,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_middle">
+       <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0,0,1">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -1540,15 +1540,18 @@
            <item>
             <widget class="QLabel" name="l_description">
              <property name="text">
-              <string>To use a DualShock 3 controller on Windows you can now use Sony's official drivers. To get them you'll have to install PlayStation Now, since the drivers are bundled with it.</string>
+              <string>This text should be replaced by an actual description.&lt;br/&gt;&lt;br/&gt;</string>
              </property>
              <property name="textFormat">
-              <enum>Qt::PlainText</enum>
+              <enum>Qt::RichText</enum>
              </property>
              <property name="alignment">
               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
              </property>
              <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+             <property name="openExternalLinks">
               <bool>true</bool>
              </property>
             </widget>


### PR DESCRIPTION
This PR adds a feature that changes the description text in pad configuration screen to provide useful information about the currently selected handler. Some of the descriptions contain links to wiki for most common issues. Hopefully this will reduce confusion and let users know about some obscure features.

I'm not a native speaker, so feel free to suggest improvements to the texts if you have any.