### PR TITLE
rsx: Texture cache fixups

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -6,7 +6,7 @@
 #include "TextureUtils.h"
 #include "../rsx_utils.h"
 
-#define  ENABLE_SURFACE_CACHE_DEBUG 0
+#define ENABLE_SURFACE_CACHE_DEBUG 0
 
 namespace rsx
 {

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -10,6 +10,8 @@
 
 extern u64 get_system_time();
 
+#define RSX_GCM_FORMAT_IGNORED 0
+
 namespace rsx
 {
 	template <typename derived_type, typename _traits>
@@ -1092,7 +1094,7 @@ namespace rsx
 			return nullptr;
 		}
 
-		section_storage_type* find_cached_texture(const address_range &range, bool create_if_not_found, bool confirm_dimensions, u16 width = 0, u16 height = 0, u16 depth = 0, u16 mipmaps = 0)
+		section_storage_type* find_cached_texture(const address_range &range, u32 gcm_format, bool create_if_not_found, bool confirm_dimensions, u16 width = 0, u16 height = 0, u16 depth = 0, u16 mipmaps = 0)
 		{
 			auto &block = m_storage.block_for(range);
 
@@ -1110,7 +1112,7 @@ namespace rsx
 				{
 					if (!tex.is_dirty())
 					{
-						if (!confirm_dimensions || tex.matches_dimensions(width, height, depth, mipmaps))
+						if (!confirm_dimensions || tex.matches(gcm_format, width, height, depth, mipmaps))
 						{
 #ifndef TEXTURE_CACHE_DEBUG
 							return &tex;
@@ -1202,7 +1204,7 @@ namespace rsx
 			std::lock_guard lock(m_cache_mutex);
 
 			// Find a cached section to use
-			section_storage_type& region = *find_cached_texture(rsx_range, true, true, width, height);
+			section_storage_type& region = *find_cached_texture(rsx_range, RSX_GCM_FORMAT_IGNORED, true, true, width, height);
 
 			// Prepare and initialize fbo region
 			if (region.exists() && region.get_context() != texture_upload_context::framebuffer_storage)
@@ -1278,7 +1280,7 @@ namespace rsx
 		{
 			std::lock_guard lock(m_cache_mutex);
 
-			auto* region_ptr = find_cached_texture(memory_range, false, false);
+			auto* region_ptr = find_cached_texture(memory_range, RSX_GCM_FORMAT_IGNORED, false, false);
 			if (region_ptr == nullptr)
 			{
 				AUDIT(m_flush_always_cache.find(memory_range) == m_flush_always_cache.end());

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1646,9 +1646,12 @@ namespace rsx
 			return valid_range() && rsx::buffered_section::matches(memory_range);
 		}
 
-		bool matches_dimensions(u32 width, u32 height, u32 depth, u32 mipmaps)
+		bool matches(u32 format, u32 width, u32 height, u32 depth, u32 mipmaps)
 		{
 			if (!valid_range())
+				return false;
+
+			if ((gcm_format & format) != format)
 				return false;
 
 			if (!width && !height && !depth && !mipmaps)
@@ -1677,10 +1680,7 @@ namespace rsx
 			if (rsx_address != get_section_base())
 				return false;
 
-			if ((gcm_format & format) != format)
-				return false;
-
-			return matches_dimensions(width, height, depth, mipmaps);
+			return matches(format, width, height, depth, mipmaps);
 		}
 
 		bool matches(const address_range& memory_range, u32 format, u32 width, u32 height, u32 depth, u32 mipmaps)
@@ -1691,10 +1691,7 @@ namespace rsx
 			if (!rsx::buffered_section::matches(memory_range))
 				return false;
 
-			if ((gcm_format & format) != format)
-				return false;
-
-			return matches_dimensions(width, height, depth, mipmaps);
+			return matches(format, width, height, depth, mipmaps);
 		}
 
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -831,7 +831,7 @@ namespace gl
 			const auto swizzle = get_component_mapping(gcm_format, flags);
 			image->set_native_component_layout(swizzle);
 
-			auto& cached = *find_cached_texture(rsx_range, true, true, width, height, depth, mipmaps);
+			auto& cached = *find_cached_texture(rsx_range, gcm_format, true, true, width, height, depth, mipmaps);
 			ASSERT(!cached.is_locked());
 
 			// Prepare section

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1020,7 +1020,7 @@ namespace vk
 
 			change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, { aspect_flags, 0, mipmaps, 0, layer });
 
-			cached_texture_section& region = *find_cached_texture(rsx_range, true, true, width, height, section_depth);
+			cached_texture_section& region = *find_cached_texture(rsx_range, gcm_format, true, true, width, height, section_depth);
 			ASSERT(!region.is_locked());
 
 			// New section, we must prepare it


### PR DESCRIPTION
- gl/vk: Check if a region matches the requested format before assuming it is a match. Fixes some instances of assert(!region.is_locked())
- rsx: Unify upload contexts. Hacks used to process types like ARGB8 were previously removed making data from blit_src, blit_src and shader_read map to the same memory layout in VRAM for a given memory input. This greatly simplifies the lookup methods when doing blit operations and should clear up the remaining crashes due to blit_src creation overlapping pre-existing shader_read data.

Fixes https://github.com/RPCS3/rpcs3/issues/6456
Fixes https://github.com/RPCS3/rpcs3/issues/6098
Fixes https://github.com/RPCS3/rpcs3/issues/6509