### PR TITLE
Drop unused is_leaf_function

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1468,62 +1468,6 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 	return true;
 }
 
-#ifdef __linux__
-extern "C" struct dwarf_eh_bases
-{
-	void* tbase;
-	void* dbase;
-	void* func;
-};
-
-extern "C" struct fde* _Unwind_Find_FDE(void* pc, struct dwarf_eh_bases* bases);
-#endif
-
-// Detect leaf function
-static bool is_leaf_function(u64 rip)
-{
-#ifdef _WIN32
-	DWORD64 base = 0;
-	if (const auto rtf = RtlLookupFunctionEntry(rip, &base, nullptr))
-	{
-		// Access UNWIND_INFO structure
-		const auto uw = (u8*)(base + rtf->UnwindData);
-
-		// Leaf function has zero epilog size and no unwind codes
-		return uw[0] == 1 && uw[1] == 0 && uw[2] == 0 && uw[3] == 0;
-	}
-
-	// No unwind info implies leaf function
-	return true;
-#elif __linux__
-	struct dwarf_eh_bases bases;
-
-	if (struct fde* f = _Unwind_Find_FDE(reinterpret_cast<void*>(rip), &bases))
-	{
-		const auto words = (const u32*)f;
-
-		if (words[0] < 0x14)
-		{
-			return true;
-		}
-
-		if (words[0] == 0x14 && !words[3] && !words[4])
-		{
-			return true;
-		}
-
-		// TODO
-		return false;
-	}
-
-	// No unwind info implies leaf function
-	return true;
-#else
-	// Unsupported
-	return false;
-#endif
-}
-
 #ifdef _WIN32
 
 static LONG exception_handler(PEXCEPTION_POINTERS pExp)


### PR DESCRIPTION
Less platform-specific code to worry about when porting.