### PR TITLE
Add a "stack mode" to the TTY.

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -190,7 +190,7 @@ namespace gui
 
 	const gui_save l_tty   = gui_save(logger, "TTY",   true);
 	const gui_save l_level = gui_save(logger, "level", (uint)(logs::level::success));
-	const gui_save l_stack_log = gui_save(logger, "log stack", true);
+	const gui_save l_stack = gui_save(logger, "log stack", true);
 	const gui_save l_stack_tty = gui_save(logger, "TTY stack", false);
 
 	const gui_save d_splitterState = gui_save(debugger, "splitterState", QByteArray());

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -190,7 +190,7 @@ namespace gui
 
 	const gui_save l_tty   = gui_save(logger, "TTY",   true);
 	const gui_save l_level = gui_save(logger, "level", (uint)(logs::level::success));
-	const gui_save l_stack = gui_save(logger, "log stack", true);
+	const gui_save l_stack = gui_save(logger, "stack", true);
 	const gui_save l_stack_tty = gui_save(logger, "TTY stack", false);
 
 	const gui_save d_splitterState = gui_save(debugger, "splitterState", QByteArray());

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -190,7 +190,8 @@ namespace gui
 
 	const gui_save l_tty   = gui_save(logger, "TTY",   true);
 	const gui_save l_level = gui_save(logger, "level", (uint)(logs::level::success));
-	const gui_save l_stack = gui_save(logger, "stack", true);
+	const gui_save l_stack_log = gui_save(logger, "log stack", true);
+	const gui_save l_stack_tty = gui_save(logger, "TTY stack", false);
 
 	const gui_save d_splitterState = gui_save(debugger, "splitterState", QByteArray());
 	const gui_save d_centerPC      = gui_save(debugger, "centerPC",      false);

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -310,6 +310,7 @@ void log_frame::CreateAndConnectActions()
 	{
 		QMenu* menu = m_tty->createStandardContextMenu();
 		menu->addAction(m_clearTTYAct);
+		menu->addSeparator();
 		menu->addAction(m_stackAct_tty);
 		menu->addSeparator();
 		menu->addActions(m_tty_channel_acts->actions());
@@ -525,7 +526,7 @@ void log_frame::UpdateUI()
 
 				// set scrollbar to max means auto-scroll
 				sb->setValue(is_max ? sb->maximum() : sb_pos);
-			}			
+			}
 		}
 
 		// Limit processing time

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -1,6 +1,5 @@
 #include "log_frame.h"
 #include "qt_utils.h"
-
 #include "stdafx.h"
 #include "rpcs3_version.h"
 #include "Utilities/sysinfo.h"
@@ -235,9 +234,7 @@ void log_frame::CreateAndConnectActions()
 		m_stack_tty = checked;
 	});
 
-
 	m_tty_channel_acts = new QActionGroup(this);
-
 	// Special Channel: All
 	QAction* all_channels_act = new QAction(tr("All user channels"), m_tty_channel_acts);
 	all_channels_act->setCheckable(true);
@@ -276,7 +273,7 @@ void log_frame::CreateAndConnectActions()
 	m_stackAct_log->setCheckable(true);
 	connect(m_stackAct_log, &QAction::toggled, xgui_settings.get(), [=](bool checked)
 	{
-		xgui_settings->SetValue(gui::l_stack_log, checked);
+		xgui_settings->SetValue(gui::l_stack, checked);
 		m_stack_log = checked;
 	});
 
@@ -368,7 +365,7 @@ void log_frame::LoadSettings()
 {
 	SetLogLevel(xgui_settings->GetLogLevel());
 	SetTTYLogging(xgui_settings->GetValue(gui::l_tty).toBool());
-	m_stack_log = xgui_settings->GetValue(gui::l_stack_log).toBool();
+	m_stack_log = xgui_settings->GetValue(gui::l_stack).toBool();
 	m_stack_tty = xgui_settings->GetValue(gui::l_stack_tty).toBool();
 	m_stackAct_log->setChecked(m_stack_log);
 	m_stackAct_tty->setChecked(m_stack_tty);
@@ -482,12 +479,10 @@ void log_frame::UpdateUI()
 			std::stringstream buf_stream;
 			buf_stream.str(buf);
 			std::string buf_line;
-			while(std::getline(buf_stream, buf_line)) 
+			while (std::getline(buf_stream, buf_line)) 
 			{
 				QString suffix;
 				QString tty_text = QString::fromStdString(buf_line);
-				std::string debugstring = "no selection";
-				
 				bool isSame = tty_text == m_old_tty_text;
 				// create counter suffix and remove recurring line if needed
 				if (m_stack_tty)
@@ -530,8 +525,7 @@ void log_frame::UpdateUI()
 
 				// set scrollbar to max means auto-scroll
 				sb->setValue(is_max ? sb->maximum() : sb_pos);
-			}
-			
+			}			
 		}
 
 		// Limit processing time

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -75,8 +75,8 @@ private:
 	QAction* m_noticeAct;
 	QAction* m_traceAct;
 
-	QAction* m_stackAct_Log;
-	QAction* m_stackAct_TTY;
+	QAction* m_stackAct_log;
+	QAction* m_stackAct_tty;
 	
 
 

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -77,7 +77,7 @@ private:
 
 	QAction* m_stackAct_log;
 	QAction* m_stackAct_tty;
-	
+
 	QAction* m_TTYAct;
 
 	QActionGroup* m_tty_channel_acts;

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -78,8 +78,6 @@ private:
 	QAction* m_stackAct_log;
 	QAction* m_stackAct_tty;
 	
-
-
 	QAction* m_TTYAct;
 
 	QActionGroup* m_tty_channel_acts;

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -49,9 +49,12 @@ private:
 	QList<QColor> m_color;
 	QColor m_color_stack;
 	QTextEdit* m_log;
-	QString m_old_text;
+	QString m_old_log_text;
+	QString m_old_tty_text;
 	ullong m_log_counter;
+	ullong m_tty_counter;
 	bool m_stack_log;
+	bool m_stack_tty;
 
 	fs::file m_tty_file;
 	QWidget* m_tty_container;
@@ -72,7 +75,10 @@ private:
 	QAction* m_noticeAct;
 	QAction* m_traceAct;
 
-	QAction* m_stackAct;
+	QAction* m_stackAct_Log;
+	QAction* m_stackAct_TTY;
+	
+
 
 	QAction* m_TTYAct;
 


### PR DESCRIPTION
Adds the ability to activate "stack mode" in the TTY viewer. Much like its counterpart in the Log, it can help increase readability by reducing repeated messages to a counter. it is off by default and can be toggled separately from the stack mode in the log by a checkbox in the TTY context menu.