### PR TITLE
Fix the build with shallow clones.

### DIFF
--- a/rpcs3/git-version.cmake
+++ b/rpcs3/git-version.cmake
@@ -25,7 +25,7 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git/")
 	if(NOT ${exit_code} EQUAL 0)
 		message(WARNING "git rev-parse failed, unable to include git branch.")
 	endif()
-	execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+	execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --always
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		RESULT_VARIABLE exit_code
 		OUTPUT_VARIABLE RPCS3_GIT_TAG)


### PR DESCRIPTION
This fixes a cmake configure error when building rpcs3 in a shallow repo made with `--depth=1`.
```
git clone --recursive --depth=1 -b master https://github.com/RPCS3/rpcs3
```
```
-- cotire 1.8.0 loaded.
fatal: No names found, cannot describe anything.
CMake Warning at rpcs3/git-version.cmake:33 (message):
  git describe failed, unable to include git tag.
Call Stack (most recent call first):
  rpcs3/CMakeLists.txt:6 (include)


CMake Error at rpcs3/git-version.cmake:40 (string):
  string sub-command STRIP requires two arguments.
Call Stack (most recent call first):
  rpcs3/CMakeLists.txt:6 (include)


CMake Error at rpcs3/git-version.cmake:41 (string):
  string sub-command REPLACE requires at least four arguments.
Call Stack (most recent call first):
  rpcs3/CMakeLists.txt:6 (include)


-- Performing Test HAS_NO_PIE
-- Performing Test HAS_NO_PIE - Success
-- Performing Test COMPILER_SUPPORTS_MARCH_NATIVE
-- Performing Test COMPILER_SUPPORTS_MARCH_NATIVE - Success
-- Initializing RPCS3_SRC_DIR=/tmp/SBo/rpcs3/rpcs3
-- CXX target rpcs3_emu cotired without unity build and precompiled header. ccache configuration cannot be determined.
-- RPCS3_GIT_VERSION: 1-b70c08a2
-- RPCS3_GIT_BRANCH: master
-- RPCS3_GIT_TAG: 
-- Found X11: /usr/include   
-- Looking for XOpenDisplay in /usr/lib64/libX11.so;/usr/lib64/libXext.so
-- Looking for XOpenDisplay in /usr/lib64/libX11.so;/usr/lib64/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- CXX target rpcs3 cotired without unity build and precompiled header. ccache configuration cannot be determined.
-- Configuring incomplete, errors occurred!
See also "/tmp/SBo/rpcs3/build/CMakeFiles/CMakeOutput.log".
See also "/tmp/SBo/rpcs3/build/CMakeFiles/CMakeError.log".
```