### PR TITLE
rsx: Restructure flip code and frame scoping

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.cpp
@@ -518,7 +518,7 @@ bool is_flip_surface_in_global_memory(rsx::surface_target color_target)
 }
 }
 
-void D3D12GSRender::flip(int buffer, bool emu_flip)
+void D3D12GSRender::flip(const rsx::display_flip_info_t&)
 {
 	ID3D12Resource *resource_to_flip;
 	float viewport_w, viewport_h;

--- a/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12GSRender.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "D3D12Utils.h"
 #include "Emu/Memory/vm.h"
@@ -177,7 +177,7 @@ protected:
 	virtual void do_local_task(rsx::FIFO_state state) override;
 	virtual bool do_method(u32 cmd, u32 arg) override;
 	virtual void end() override;
-	virtual void flip(int buffer, bool emu_flip = false) override;
+	virtual void flip(const rsx::display_flip_info_t&) override;
 
 	virtual bool on_access_violation(u32 address, bool is_writing) override;
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -86,11 +86,6 @@ private:
 	// Identity buffer used to fix broken gl_VertexID on ATI stack
 	std::unique_ptr<gl::buffer> m_identity_index_buffer;
 
-	s64 m_begin_time = 0;
-	s64 m_draw_time = 0;
-	s64 m_vertex_upload_time = 0;
-	s64 m_textures_upload_time = 0;
-
 	std::unique_ptr<gl::vertex_cache> m_vertex_cache;
 	std::unique_ptr<gl::shader_cache> m_shaders_cache;
 
@@ -171,7 +166,7 @@ protected:
 	void on_init_thread() override;
 	void on_exit() override;
 	bool do_method(u32 cmd, u32 arg) override;
-	void flip(int buffer, bool emu_flip = false) override;
+	void flip(const rsx::display_flip_info_t& info) override;
 
 	void do_local_task(rsx::FIFO_state state) override;
 

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "GLGSRender.h"
 #include "../Common/BufferUtils.h"
 #include "GLHelpers.h"
@@ -254,6 +254,6 @@ gl::vertex_upload_info GLGSRender::set_vertex_buffer()
 	//Write all the data
 	write_vertex_data_to_memory(m_vertex_layout, vertex_base, vertex_count, persistent_mapping.first, volatile_mapping.first);
 
-	m_vertex_upload_time += m_profiler.duration();
+	m_frame_stats.vertex_upload_time += m_profiler.duration();
 	return upload_info;
 }

--- a/rpcs3/Emu/RSX/GSRender.cpp
+++ b/rpcs3/Emu/RSX/GSRender.cpp
@@ -55,7 +55,7 @@ void GSRender::on_exit()
 	rsx::thread::on_exit();
 }
 
-void GSRender::flip(int buffer, bool emu_flip)
+void GSRender::flip(const rsx::display_flip_info_t& info)
 {
 	if (m_frame)
 	{

--- a/rpcs3/Emu/RSX/GSRender.h
+++ b/rpcs3/Emu/RSX/GSRender.h
@@ -104,7 +104,7 @@ public:
 	void on_init_thread() override;
 	void on_exit() override;
 
-	void flip(int buffer, bool emu_flip = false) override;
+	void flip(const rsx::display_flip_info_t& info) override;
 
 	GSFrameBase* get_frame() { return m_frame; }
 };

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2235,45 +2235,9 @@ namespace rsx
 
 	void thread::flip(int buffer, bool emu_flip)
 	{
-		if (!(async_flip_requested & flip_request::any))
+		if (async_flip_requested & flip_request::any)
 		{
-			// Flip is processed through inline FLIP command in the commandstream
-			// This is critical as it is a reliable end-of-frame marker
-
-			if (!g_cfg.video.disable_FIFO_reordering)
-			{
-				// Try to enable FIFO optimizations
-				// Only rarely useful for some games like RE4
-				m_flattener.evaluate_performance(m_draw_calls);
-			}
-
-			// Reset zcull ctrl
-			zcull_ctrl->set_active(this, false);
-			zcull_ctrl->clear(this);
-
-			if (zcull_ctrl->has_pending())
-			{
-				LOG_TRACE(RSX, "Dangling reports found, discarding...");
-				zcull_ctrl->sync(this);
-			}
-
-			if (g_cfg.video.frame_skip_enabled)
-			{
-				m_skip_frame_ctr++;
-
-				if (m_skip_frame_ctr == g_cfg.video.consequtive_frames_to_draw)
-					m_skip_frame_ctr = -g_cfg.video.consequtive_frames_to_skip;
-
-				skip_frame = (m_skip_frame_ctr < 0);
-			}
-		}
-		else
-		{
-			if (async_flip_requested & flip_request::emu_requested)
-			{
-				m_flattener.force_disable();
-			}
-
+			// Deferred flip
 			if (emu_flip)
 			{
 				async_flip_requested.clear(flip_request::emu_requested);
@@ -2284,13 +2248,16 @@ namespace rsx
 			}
 		}
 
-		if (!skip_frame)
+		if (emu_flip)
 		{
-			// Reset counter
-			m_draw_calls = 0;
-		}
+			if (g_cfg.video.frame_skip_enabled)
+			{
+				skip_frame = (m_skip_frame_ctr < 0);
+			}
 
-		performance_counters.sampled_frames++;
+			m_draw_calls = 0;
+			performance_counters.sampled_frames++;
+		}
 	}
 
 	void thread::check_zcull_status(bool framebuffer_swap)
@@ -2528,31 +2495,9 @@ namespace rsx
 		return performance_counters.approximate_load;
 	}
 
-	void thread::request_emu_flip(u32 buffer)
+	void thread::on_frame_end(u32 buffer, bool forced)
 	{
-		const bool is_rsxthr = std::this_thread::get_id() == m_rsx_thread;
-
-		// requested through command buffer
-		if (is_rsxthr)
-		{
-			// NOTE: The flip will clear any queued flip requests
-			handle_emu_flip(buffer);
-		}
-		else // requested 'manually' through ppu syscall
-		{
-			if (async_flip_requested & flip_request::emu_requested)
-			{
-				// ignore multiple requests until previous happens
-				return;
-			}
-
-			async_flip_buffer = buffer;
-			async_flip_requested |= flip_request::emu_requested;
-		}
-	}
-
-	void thread::handle_emu_flip(u32 buffer)
-	{
+		// Marks the end of a frame scope GPU-side
 		if (user_asked_for_frame_capture && !capture_current_frame)
 		{
 			capture_current_frame = true;
@@ -2586,6 +2531,81 @@ namespace rsx
 
 			frame_capture.reset();
 			Emu.Pause();
+		}
+
+		// Reset zcull ctrl
+		zcull_ctrl->set_active(this, false);
+		zcull_ctrl->clear(this);
+
+		if (zcull_ctrl->has_pending())
+		{
+			LOG_TRACE(RSX, "Dangling reports found, discarding...");
+			zcull_ctrl->sync(this);
+		}
+
+		if (LIKELY(!forced))
+		{
+			if (!g_cfg.video.disable_FIFO_reordering)
+			{
+				// Try to enable FIFO optimizations
+				// Only rarely useful for some games like RE4
+				m_flattener.evaluate_performance(m_draw_calls);
+			}
+
+			if (g_cfg.video.frame_skip_enabled)
+			{
+				m_skip_frame_ctr++;
+
+				if (m_skip_frame_ctr == g_cfg.video.consequtive_frames_to_draw)
+					m_skip_frame_ctr = -g_cfg.video.consequtive_frames_to_skip;
+			}
+		}
+		else
+		{
+			if (!g_cfg.video.disable_FIFO_reordering)
+			{
+				// Flattener is unusable due to forced random flips
+				m_flattener.force_disable();
+			}
+
+			if (g_cfg.video.frame_skip_enabled)
+			{
+				LOG_ERROR(RSX, "Frame skip is not compatible with this application");
+			}
+		}
+
+		queued_flip_index = int(buffer);
+	}
+
+	void thread::request_emu_flip(u32 buffer)
+	{
+		const bool is_rsxthr = std::this_thread::get_id() == m_rsx_thread;
+
+		// requested through command buffer
+		if (is_rsxthr)
+		{
+			// NOTE: The flip will clear any queued flip requests
+			handle_emu_flip(buffer);
+		}
+		else // requested 'manually' through ppu syscall
+		{
+			if (async_flip_requested & flip_request::emu_requested)
+			{
+				// ignore multiple requests until previous happens
+				return;
+			}
+
+			async_flip_buffer = buffer;
+			async_flip_requested |= flip_request::emu_requested;
+		}
+	}
+
+	void thread::handle_emu_flip(u32 buffer)
+	{
+		if (queued_flip_index < 0)
+		{
+			// Frame was not queued before flipping
+			on_frame_end(buffer, true);
 		}
 
 		double limit = 0.;
@@ -2634,6 +2654,7 @@ namespace rsx
 
 		last_flip_time = get_system_time() - 1000000;
 		flip_status = CELL_GCM_DISPLAY_FLIP_STATUS_DONE;
+		queued_flip_index = -1;
 
 		if (flip_handler)
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -558,6 +558,7 @@ namespace rsx
 		u64 start_rsx_time = 0;
 		u64 int_flip_index = 0;
 		u64 last_flip_time;
+		int queued_flip_index = -1;
 		vm::ptr<void(u32)> flip_handler = vm::null;
 		vm::ptr<void(u32)> user_handler = vm::null;
 		vm::ptr<void(u32)> vblank_handler = vm::null;
@@ -607,6 +608,7 @@ namespace rsx
 		virtual void on_init_rsx() = 0;
 		virtual void on_init_thread() = 0;
 		virtual bool do_method(u32 /*cmd*/, u32 /*value*/) { return false; }
+		virtual void on_frame_end(u32 buffer, bool forced = false);
 		virtual void flip(int buffer, bool emu_flip = false) = 0;
 		virtual u64 timestamp();
 		virtual bool on_access_violation(u32 /*address*/, bool /*is_writing*/) { return false; }

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -413,12 +413,32 @@ namespace rsx
 		};
 	}
 
+	struct frame_statistics_t
+	{
+		u32 draw_calls;
+		s64 setup_time;
+		s64 vertex_upload_time;
+		s64 textures_upload_time;
+		s64 draw_exec_time;
+		s64 flip_time;
+	};
+
+	struct display_flip_info_t
+	{
+		u32 buffer;
+		bool skip_frame;
+		bool emu_flip;
+		frame_statistics_t stats;
+	};
+
 	struct sampled_image_descriptor_base;
 
 	class thread
 	{
 		u64 timestamp_ctrl = 0;
 		u64 timestamp_subvalue = 0;
+
+		display_flip_info_t m_queued_flip;
 
 	protected:
 		std::thread::id m_rsx_thread;
@@ -428,7 +448,8 @@ namespace rsx
 		std::vector<u32> element_push_buffer;
 
 		s32 m_skip_frame_ctr = 0;
-		bool skip_frame = false;
+		bool skip_current_frame = false;
+		frame_statistics_t stats{};
 
 		bool supports_multidraw = false;  // Draw call batching
 		bool supports_hw_a2c = false;     // Alpha to coverage
@@ -454,11 +475,9 @@ namespace rsx
 		// Invalidated memory range
 		address_range m_invalidated_memory_range;
 
-		// Draw call stats
-		u32 m_draw_calls = 0;
-
 		// Profiler
 		rsx::profiling_timer m_profiler;
+		frame_statistics_t m_frame_stats;
 
 	public:
 		RsxDmaControl* ctrl = nullptr;
@@ -558,7 +577,6 @@ namespace rsx
 		u64 start_rsx_time = 0;
 		u64 int_flip_index = 0;
 		u64 last_flip_time;
-		int queued_flip_index = -1;
 		vm::ptr<void(u32)> flip_handler = vm::null;
 		vm::ptr<void(u32)> user_handler = vm::null;
 		vm::ptr<void(u32)> vblank_handler = vm::null;
@@ -609,7 +627,7 @@ namespace rsx
 		virtual void on_init_thread() = 0;
 		virtual bool do_method(u32 /*cmd*/, u32 /*value*/) { return false; }
 		virtual void on_frame_end(u32 buffer, bool forced = false);
-		virtual void flip(int buffer, bool emu_flip = false) = 0;
+		virtual void flip(const display_flip_info_t& info) = 0;
 		virtual u64 timestamp();
 		virtual bool on_access_violation(u32 /*address*/, bool /*is_writing*/) { return false; }
 		virtual void on_invalidate_memory_range(const address_range & /*range*/, rsx::invalidation_cause) {}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -398,13 +398,6 @@ private:
 	VkViewport m_viewport{};
 	VkRect2D m_scissor{};
 
-	// Timers
-	s64 m_setup_time = 0;
-	s64 m_vertex_upload_time = 0;
-	s64 m_textures_upload_time = 0;
-	s64 m_draw_time = 0;
-	s64 m_flip_time = 0;
-
 	std::vector<u8> m_draw_buffers;
 
 	shared_mutex m_flush_queue_mutex;
@@ -492,7 +485,7 @@ protected:
 	void on_init_thread() override;
 	void on_exit() override;
 	bool do_method(u32 cmd, u32 arg) override;
-	void flip(int buffer, bool emu_flip = false) override;
+	void flip(const rsx::display_flip_info_t& info) override;
 
 	void do_local_task(rsx::FIFO_state state) override;
 	bool scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate) override;


### PR DESCRIPTION
Add an explicit frame scope marker tied in with the queue_prepare command. Since queue_prepare is emitted at the end of a frame, it can be used as end-of-frame in games that emit this. If this command is not emitted, fifo flatenner and frameskip will not work.

- Improves compatibility of games with frameskipping and FIFO flattener optimizations.
- Fixes malformed RSX captures due to asynchronous flip handling in many games. Captures should now be frame-complete and render properly instead of the common black screen.