### PR TITLE
vk: Fix pipeline search when using MSAA

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
@@ -40,6 +40,9 @@ namespace vk
 			{
 				if (memcmp(&state.ms, &other.state.ms, sizeof(VkPipelineMultisampleStateCreateInfo)))
 					return false;
+
+				if (state.temp_storage.msaa_sample_mask != other.state.temp_storage.msaa_sample_mask)
+					return false;
 			}
 
 			return true;
@@ -57,6 +60,7 @@ namespace rpcs3
 		seed ^= hash_struct(pipelineProperties.state.ds);
 		seed ^= hash_struct(pipelineProperties.state.rs);
 		seed ^= hash_struct(pipelineProperties.state.ms);
+		seed ^= hash_base(pipelineProperties.state.temp_storage.msaa_sample_mask);
 
 		// Do not compare pointers to memory!
 		VkPipelineColorBlendStateCreateInfo tmp;


### PR DESCRIPTION
- It is possible (albeit rare) for an application to change the sample mask when rendering. This means not only the rendertarget configuration is important (with its RP key) but also the active sample mask.
Discovered when running hw tests for https://github.com/RPCS3/rpcs3/issues/6403.