### PR TITLE
Update git-version generation

### DIFF
--- a/.travis/deploy-linux.bash
+++ b/.travis/deploy-linux.bash
@@ -31,11 +31,11 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
 	# Package it up and send it off
 	./squashfs-root/usr/bin/appimagetool /rpcs3/build/appdir
 	ls
-	COMM_TAG="$(git describe --tags $(git rev-list --tags --max-count=1))"
+	COMM_TAG="$(grep 'version{.*}' rpcs3/rpcs3_version.cpp | awk -F[{,] '{printf \"%d.%d.%d\", $2, $3, $4}')"
 	COMM_COUNT="$(git rev-list --count HEAD)"
 	curl -sLO https://github.com/hcorion/uploadtool/raw/master/upload.sh
 	
-	mv ./RPCS3*.AppImage rpcs3-${COMM_TAG}-${COMM_COUNT}-${TRAVIS_COMMIT:0:8}_linux64.AppImage
+	mv ./RPCS3*.AppImage rpcs3-v${COMM_TAG}-${COMM_COUNT}-${TRAVIS_COMMIT:0:8}_linux64.AppImage
 	
 	FILESIZE=($(stat -c %s ./rpcs3*.AppImage))
 	SHA256SUM=($(sha256sum ./rpcs3*.AppImage))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,16 +21,16 @@ cache:
 
 install:
 - ps: | # set env vars for versioning
-    $env:COMM_TAG = $(git describe --tags $(git rev-list --tags --max-count=1))
+    $env:COMM_TAG = $(Get-Content ./rpcs3/rpcs3_version.cpp | findstr 'version{.*}' | %{ $ver = $_ -split "[{,]"; "{0}.{1}.{2}" -f [int]$ver[1],[int]$ver[2],[int]$ver[3]; })
     $env:COMM_COUNT = $(git rev-list --count HEAD)
     $env:COMM_HASH = $(git rev-parse --short=8 HEAD)
 
     if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-        $env:BUILD = "rpcs3-{0}-{1}_win64.7z" -f $env:COMM_TAG, $env:COMM_HASH
+        $env:BUILD = "rpcs3-v{0}-{1}_win64.7z" -f $env:COMM_TAG, $env:COMM_HASH
         $env:AVVER = "{0}-{1}" -f $env:COMM_TAG.TrimStart("v"), $env:COMM_HASH
     }
     else {
-        $env:BUILD = "rpcs3-{0}-{1}-{2}_win64.7z" -f $env:COMM_TAG, $env:COMM_COUNT, $env:COMM_HASH
+        $env:BUILD = "rpcs3-v{0}-{1}-{2}_win64.7z" -f $env:COMM_TAG, $env:COMM_COUNT, $env:COMM_HASH
         $env:AVVER = "{0}-{1}" -f $env:COMM_TAG.TrimStart("v"), $env:COMM_COUNT
     }
 

--- a/rpcs3/git-version.cmake
+++ b/rpcs3/git-version.cmake
@@ -1,6 +1,5 @@
 set(RPCS3_GIT_VERSION "unknown")
 set(RPCS3_GIT_BRANCH "unknown")
-set(RPCS3_GIT_TAG "unknown")
 
 find_package(Git)
 if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git/")
@@ -33,17 +32,7 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git/")
 	else()
 		string(STRIP ${RPCS3_GIT_BRANCH} RPCS3_GIT_BRANCH)
 	endif()
-	execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		RESULT_VARIABLE exit_code
-		OUTPUT_VARIABLE RPCS3_GIT_TAG)
-	if(NOT ${exit_code} EQUAL 0)
-		message(WARNING "git describe failed, unable to include git tag.")
-	else()
-		string(STRIP ${RPCS3_GIT_TAG} RPCS3_GIT_TAG)
-		string(REPLACE "v" "" RPCS3_GIT_TAG ${RPCS3_GIT_TAG})
-	endif()	
-	
+
 else()
 	message(WARNING "git not found, unable to include version.")
 endif()
@@ -54,7 +43,6 @@ function(gen_git_version rpcs3_src_dir)
 
 	message(STATUS "RPCS3_GIT_VERSION: " ${RPCS3_GIT_VERSION})
 	message(STATUS "RPCS3_GIT_BRANCH: " ${RPCS3_GIT_BRANCH})
-	message(STATUS "RPCS3_GIT_TAG: " ${RPCS3_GIT_TAG})
 
 	if(EXISTS ${GIT_VERSION_FILE})
 		# Don't update if marked not to update.
@@ -74,8 +62,7 @@ function(gen_git_version rpcs3_src_dir)
 
 	set(code_string "// This is a generated file.\n\n"
 		"#define RPCS3_GIT_VERSION \"${RPCS3_GIT_VERSION}\"\n"
-		"#define RPCS3_GIT_BRANCH \"${RPCS3_GIT_BRANCH}\"\n"
-		"#define RPCS3_GIT_TAG \"${RPCS3_GIT_TAG}\"\n\n"
+		"#define RPCS3_GIT_BRANCH \"${RPCS3_GIT_BRANCH}\"\n\n"
 		"// If you don't want this file to update/recompile, change to 1.\n"
 		"#define RPCS3_GIT_VERSION_NO_UPDATE 0\n")
 

--- a/rpcs3/git-version.cmake
+++ b/rpcs3/git-version.cmake
@@ -10,13 +10,19 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git/")
 		OUTPUT_VARIABLE RPCS3_GIT_VERSION)
 	if(NOT ${exit_code} EQUAL 0)
 		message(WARNING "git rev-list failed, unable to include version.")
+	else()
+		string(STRIP ${RPCS3_GIT_VERSION} RPCS3_GIT_VERSION)
 	endif()
 	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short=8 HEAD
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		RESULT_VARIABLE exit_code
+		RESULT_VARIABLE exit_code2
 		OUTPUT_VARIABLE GIT_VERSION_)
-	if(NOT ${exit_code} EQUAL 0)
+	if(NOT ${exit_code2} EQUAL 0)
 		message(WARNING "git rev-parse failed, unable to include version.")
+		string(STRIP ${GIT_VERSION_} GIT_VERSION_)
+		if(${exit_code} EQUAL 0)
+			string(STRIP ${RPCS3_GIT_VERSION}-${GIT_VERSION_} RPCS3_GIT_VERSION)
+		endif()
 	endif()
 	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -24,6 +30,8 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git/")
 		OUTPUT_VARIABLE RPCS3_GIT_BRANCH)
 	if(NOT ${exit_code} EQUAL 0)
 		message(WARNING "git rev-parse failed, unable to include git branch.")
+	else()
+		string(STRIP ${RPCS3_GIT_BRANCH} RPCS3_GIT_BRANCH)
 	endif()
 	execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -31,14 +39,11 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git/")
 		OUTPUT_VARIABLE RPCS3_GIT_TAG)
 	if(NOT ${exit_code} EQUAL 0)
 		message(WARNING "git describe failed, unable to include git tag.")
-	endif()
-
-	string(STRIP ${RPCS3_GIT_VERSION} RPCS3_GIT_VERSION)
-	string(STRIP ${GIT_VERSION_} GIT_VERSION_)
-	string(STRIP ${RPCS3_GIT_VERSION}-${GIT_VERSION_} RPCS3_GIT_VERSION)
-	string(STRIP ${RPCS3_GIT_BRANCH} RPCS3_GIT_BRANCH)
-	string(STRIP ${RPCS3_GIT_TAG} RPCS3_GIT_TAG)
-	string(REPLACE "v" "" RPCS3_GIT_TAG ${RPCS3_GIT_TAG})
+	else()
+		string(STRIP ${RPCS3_GIT_TAG} RPCS3_GIT_TAG)
+		string(REPLACE "v" "" RPCS3_GIT_TAG ${RPCS3_GIT_TAG})
+	endif()	
+	
 else()
 	message(WARNING "git not found, unable to include version.")
 endif()
@@ -69,7 +74,8 @@ function(gen_git_version rpcs3_src_dir)
 
 	set(code_string "// This is a generated file.\n\n"
 		"#define RPCS3_GIT_VERSION \"${RPCS3_GIT_VERSION}\"\n"
-		"#define RPCS3_GIT_BRANCH \"${RPCS3_GIT_BRANCH}\"\n\n"
+		"#define RPCS3_GIT_BRANCH \"${RPCS3_GIT_BRANCH}\"\n"
+		"#define RPCS3_GIT_TAG \"${RPCS3_GIT_TAG}\"\n\n"
 		"// If you don't want this file to update/recompile, change to 1.\n"
 		"#define RPCS3_GIT_VERSION_NO_UPDATE 0\n")
 

--- a/rpcs3/rpcs3_version.cpp
+++ b/rpcs3/rpcs3_version.cpp
@@ -9,6 +9,7 @@ namespace rpcs3
 		return RPCS3_GIT_BRANCH;
 	}
 
-	//TODO: Make this accessible from cmake and keep in sync with MACOSX_BUNDLE_BUNDLE_VERSION.
+	// TODO: Make this accessible from cmake and keep in sync with MACOSX_BUNDLE_BUNDLE_VERSION.
+	// Currently accessible by Windows and Linux build scripts, see implementations when doing MACOSX
 	const extern utils::version version{ 0, 0, 7, utils::version_type::alpha, 1, RPCS3_GIT_VERSION };
 }


### PR DESCRIPTION
Follow up to #6555 , still missing most things but opened for discussion

- [x] Only do the string ops if the git commands succeed. **Only does string ops if exit_code equals zero**

- [x] `git describe` is also used on CI. If it fails there, it will either fail the build or generate some weird final package name. **Dropped git describe usage on CI**

- [ ] On execute_process failure, the variable will be reset from it's "unknown" value to an empty string according to the previous log, so it still needs to be set back

- [ ] The current error code checks on git-version.cmake may not be enough to catch errors thrown by the git commands as hinted by the previous log

---

Issues with tag usage were already discussed too, but tag usage is working differently on packaging and on the emulator itself (see, for example, [this build](https://ci.appveyor.com/project/kd-11/rpcs3/builds/27467065/artifacts) which has v0.0.0.6 on package name but v0.0.7 as internal name), and it was left as it is currently pending future updates. It's probably a good idea to either:

- [x] Use only the hardcoded rpcs3_version tag and drop all other tag usages (describe);
- Use only the git describe tags and drop all other tag usages (rpcs3_version). We can use the values in git-version.h and avoid having to go through the git commands and checks again on the CI scripts.

I suggest going for the first option, this way we can end the issue of forks having different tags on package names than the ones on the emulator internal version name, while keeping the intended tag on both sides.