### PR TITLE
cellSysCache Fixes

### DIFF
--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -26,5 +26,8 @@ namespace vfs
 
 		// Delete file without deleting its contents, emulated with MoveFileEx on Windows
 		bool unlink(const std::string& path, const std::string& dev_root);
+
+		// Delete folder contents using rename, done atomically if remove_root is true
+		bool remove_all(const std::string& path, const std::string& dev_root, bool remove_root = true);
 	}
 }


### PR DESCRIPTION
* Clear() error checking simplified a bit
* Mount() now clears cache if ID was changed from last or NULL specified. (hw tested)
* Clear() now uses vfs::host::remove_all() to fix behaviour on Windows.
* Added mutex for Mount().