### PR TITLE
Fix enter button assignment in the native On-Screen Keyboard

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -375,26 +375,12 @@ namespace rsx
 			}
 			case pad_button::cross:
 			{
-				if (g_cfg.sys.enter_button_assignment != enter_button_assign::circle)
-				{
-					on_accept();
-				}
-				else
-				{
-					Close(false);
-				}
+				on_accept();
 				break;
 			}
 			case pad_button::circle:
 			{
-				if (g_cfg.sys.enter_button_assignment == enter_button_assign::circle)
-				{
-					on_accept();
-				}
-				else
-				{
-					Close(false);
-				}
+				Close(false);
 				break;
 			}
 			default:


### PR DESCRIPTION
The overlay controls as well as the native on-screen keyboard both checked for enter button assignment.
This effectively rendered the option for the osk useless by switching the buttons twice.

should fix #6518