### PR TITLE
Forces numeric locale to default

### DIFF
--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -4,6 +4,8 @@
 
 #include "Emu/RSX/GSRender.h"
 
+#include <clocale>
+
 // For now, a trivial constructor/destructor. May add command line usage later.
 headless_application::headless_application(int& argc, char** argv) : QCoreApplication(argc, argv)
 {
@@ -19,6 +21,9 @@ void headless_application::Init()
 
 	// Create connects to propagate events throughout Gui.
 	InitializeConnects();
+
+	// As per QT recommendations to avoid conflicts for POSIX functions
+	std::setlocale(LC_NUMERIC, "C");
 }
 
 void headless_application::InitializeConnects()

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -15,6 +15,8 @@
 
 #include <QScreen>
 
+#include <clocale>
+
 gui_application::gui_application(int& argc, char** argv) : QApplication(argc, argv)
 {
 }
@@ -47,6 +49,9 @@ void gui_application::Init()
 
 	// Create connects to propagate events throughout Gui.
 	InitializeConnects();
+
+	// As per QT recommendations to avoid conflicts for POSIX functions
+	std::setlocale(LC_NUMERIC, "C");
 
 	if (m_main_window)
 	{


### PR DESCRIPTION
Forces numeric locale to "C" for standard behaviour for posix function.
See https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings

This fixes https://github.com/RPCS3/rpcs3/issues/6506 .