### PR TITLE
Fix pad interception (again)

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -236,13 +236,6 @@ static bool map_to_ds3_input(const u32 port_no, be_t<u16>& digital_buttons, be_t
 			default: break;
 			}
 		}
-
-		if (button.m_flush)
-		{
-			button.m_pressed = false;
-			button.m_flush = false;
-			button.m_value = 0;
-		}
 	}
 
 	memset(&digital_buttons, 0, sizeof(digital_buttons));

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -142,7 +142,7 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 		data->len = CELL_PAD_LEN_NO_CHANGE;
 		return CELL_OK;
 	}
-	
+
 	if (pad->ldd)
 	{
 		memcpy(data.get_ptr(), pad->ldd_data, sizeof(CellPadData));
@@ -153,9 +153,8 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 		return CELL_OK;
 	}
 
-	u16 d1Initial, d2Initial;
-	d1Initial = pad->m_digital_1;
-	d2Initial = pad->m_digital_2;
+	u16 d1Initial   = pad->m_digital_1;
+	u16 d2Initial   = pad->m_digital_2;
 	bool btnChanged = false;
 
 	for (Button& button : pad->m_buttons)
@@ -165,8 +164,10 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 
 		if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL1)
 		{
-			if (button.m_pressed) pad->m_digital_1 |= button.m_outKeyCode;
-			else pad->m_digital_1 &= ~button.m_outKeyCode;
+			if (button.m_pressed)
+				pad->m_digital_1 |= button.m_outKeyCode;
+			else
+				pad->m_digital_1 &= ~button.m_outKeyCode;
 
 			switch (button.m_outKeyCode)
 			{
@@ -196,8 +197,10 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 		}
 		else if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL2)
 		{
-			if (button.m_pressed) pad->m_digital_2 |= button.m_outKeyCode;
-			else pad->m_digital_2 &= ~button.m_outKeyCode;
+			if (button.m_pressed)
+				pad->m_digital_2 |= button.m_outKeyCode;
+			else
+				pad->m_digital_2 &= ~button.m_outKeyCode;
 
 			switch (button.m_outKeyCode)
 			{
@@ -235,13 +238,6 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 				break;
 			default: break;
 			}
-		}
-
-		if (button.m_flush)
-		{
-			button.m_pressed = false;
-			button.m_flush = false;
-			button.m_value = 0;
 		}
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -137,7 +137,7 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 
 	const PadInfo& rinfo = handler->GetInfo();
 
-	if (rinfo.system_info & CELL_PAD_INFO_INTERCEPTED)
+	if (rinfo.ignore_input || (rinfo.system_info & CELL_PAD_INFO_INTERCEPTED))
 	{
 		data->len = CELL_PAD_LEN_NO_CHANGE;
 		return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -301,7 +301,7 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 	{
 		// report back new data every ~10 ms even if the input doesn't change
 		// this is observed behaviour when using a Dualshock 3 controller
-		static std::chrono::time_point<steady_clock> last_update[CELL_PAD_MAX_PORT_NUM] = { };
+		static std::array<std::chrono::time_point<steady_clock>, CELL_PAD_MAX_PORT_NUM> last_update = { };
 		const std::chrono::time_point<steady_clock> now = steady_clock::now();
 
 		if (btnChanged || pad->m_buffer_cleared || (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_update[port_no]).count() >= 10))

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -115,11 +115,9 @@ struct Button
 	u32 m_outKeyCode;
 	u16 m_value;
 	bool m_pressed;
-	bool m_flush;
 
 	Button(u32 offset, u32 keyCode, u32 outKeyCode)
 		: m_pressed(false)
-		, m_flush(false)
 		, m_offset(offset)
 		, m_keyCode(keyCode)
 		, m_outKeyCode(outKeyCode)

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -286,13 +286,6 @@ namespace rsx
 							button_state[pad_index][button_id] = button.m_pressed;
 						}
 
-						if (button.m_flush)
-						{
-							button.m_pressed = false;
-							button.m_flush = false;
-							button.m_value = 0;
-						}
-
 						if (exit)
 							return 0;
 					}

--- a/rpcs3/ds3_pad_handler.cpp
+++ b/rpcs3/ds3_pad_handler.cpp
@@ -161,7 +161,7 @@ bool ds3_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::strin
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, FindKeyCode(button_list, p_profile->l3),       CELL_PAD_CTRL_L3);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, FindKeyCode(button_list, p_profile->r3),       CELL_PAD_CTRL_R3);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, FindKeyCode(button_list, p_profile->ps),       0x100/*CELL_PAD_CTRL_PS*/);// TODO: PS button support
-	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0,                                             0x0); // Reserved
+	//pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0,                                             0x0); // Reserved (and currently not in use by rpcs3 at all)
 
 	pad->m_sensors.emplace_back(CELL_PAD_BTN_OFFSET_SENSOR_X, 512);
 	pad->m_sensors.emplace_back(CELL_PAD_BTN_OFFSET_SENSOR_Y, 399);

--- a/rpcs3/ds4_pad_handler.cpp
+++ b/rpcs3/ds4_pad_handler.cpp
@@ -853,7 +853,7 @@ bool ds4_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::strin
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, FindKeyCode(button_list, p_profile->l3),       CELL_PAD_CTRL_L3);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, FindKeyCode(button_list, p_profile->r3),       CELL_PAD_CTRL_R3);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, FindKeyCode(button_list, p_profile->ps),       0x100/*CELL_PAD_CTRL_PS*/);// TODO: PS button support
-	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0,                                             0x0); // Reserved
+	//pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0,                                             0x0); // Reserved (and currently not in use by rpcs3 at all)
 
 	pad->m_sensors.emplace_back(CELL_PAD_BTN_OFFSET_SENSOR_X, 512);
 	pad->m_sensors.emplace_back(CELL_PAD_BTN_OFFSET_SENSOR_Y, 399);

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -971,7 +971,7 @@ bool evdev_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(p_profile->down),     CELL_PAD_CTRL_DOWN);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(p_profile->left),     CELL_PAD_CTRL_LEFT);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(p_profile->right),    CELL_PAD_CTRL_RIGHT);
-	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0,                             0x0); // Reserved
+	//pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0,                             0x0); // Reserved (and currently not in use by rpcs3 at all)
 
 	m_dev.axis_left[0]  = evdevbutton(p_profile->ls_right);
 	m_dev.axis_left[1]  = evdevbutton(p_profile->ls_left);

--- a/rpcs3/keyboard_pad_handler.cpp
+++ b/rpcs3/keyboard_pad_handler.cpp
@@ -558,7 +558,7 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(p_profile->l3),       CELL_PAD_CTRL_L3);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(p_profile->select),   CELL_PAD_CTRL_SELECT);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, find_key(p_profile->ps),       0x100/*CELL_PAD_CTRL_PS*/);// TODO: PS button support
-	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0,                             0x0); // Reserved
+	//pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0,                             0x0); // Reserved (and currently not in use by rpcs3 at all)
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, find_key(p_profile->square),   CELL_PAD_CTRL_SQUARE);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, find_key(p_profile->cross),    CELL_PAD_CTRL_CROSS);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, find_key(p_profile->circle),   CELL_PAD_CTRL_CIRCLE);

--- a/rpcs3/mm_joystick_handler.cpp
+++ b/rpcs3/mm_joystick_handler.cpp
@@ -180,7 +180,7 @@ bool mm_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::s
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(p_profile->down),       CELL_PAD_CTRL_DOWN);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(p_profile->left),       CELL_PAD_CTRL_LEFT);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(p_profile->right),      CELL_PAD_CTRL_RIGHT);
-	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0, 0x0); // Reserved
+	//pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0, 0x0); // Reserved (and currently not in use by rpcs3 at all)
 
 	pad->m_sticks.emplace_back(CELL_PAD_BTN_OFFSET_ANALOG_LEFT_X,  joy_device->axis_left[0],  joy_device->axis_left[1]);
 	pad->m_sticks.emplace_back(CELL_PAD_BTN_OFFSET_ANALOG_LEFT_Y,  joy_device->axis_left[2],  joy_device->axis_left[3]);

--- a/rpcs3/pad_thread.h
+++ b/rpcs3/pad_thread.h
@@ -11,6 +11,7 @@ struct PadInfo
 {
 	u32 now_connect;
 	u32 system_info;
+	bool ignore_input;
 };
 
 class pad_thread
@@ -40,13 +41,12 @@ protected:
 	void *curthread;
 	void *curwindow;
 
-	PadInfo m_info{ 0, 0 };
+	PadInfo m_info{ 0, 0, false };
 	std::array<std::shared_ptr<Pad>, CELL_PAD_MAX_PORT_NUM> m_pads;
 
 	atomic_t<bool> active{ false };
 	atomic_t<bool> reset{ false };
 	atomic_t<bool> is_enabled{ true };
-	atomic_t<bool> m_is_intercepted{ false };
 	std::shared_ptr<std::thread> thread;
 
 	u32 num_ldd_pad = 0;

--- a/rpcs3/xinput_pad_handler.cpp
+++ b/rpcs3/xinput_pad_handler.cpp
@@ -506,7 +506,7 @@ bool xinput_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::st
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, FindKeyCode(button_list, p_profile->triangle), CELL_PAD_CTRL_TRIANGLE);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, FindKeyCode(button_list, p_profile->l2),       CELL_PAD_CTRL_L2);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, FindKeyCode(button_list, p_profile->r2),       CELL_PAD_CTRL_R2);
-	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0, 0x0); // Reserved
+	//pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, 0, 0x0); // Reserved (and currently not in use by rpcs3 at all)
 
 	pad->m_sticks.emplace_back(CELL_PAD_BTN_OFFSET_ANALOG_LEFT_X,  FindKeyCode(button_list, p_profile->ls_left), FindKeyCode(button_list, p_profile->ls_right));
 	pad->m_sticks.emplace_back(CELL_PAD_BTN_OFFSET_ANALOG_LEFT_Y,  FindKeyCode(button_list, p_profile->ls_down), FindKeyCode(button_list, p_profile->ls_up));


### PR DESCRIPTION
The prior fix for Hotline Miami was a bit overkill apparently, as Ninja Gaiden Sigma now freaks out if you hold any button too long after dialogs and opens the menu in defense.

We now don't keep the pads intercepted anymore but simply don't give the game any input while buttons are kept pressed when closing dialogs.
This should work with Hotline Miami and Ninja Gaiden Sigma.

Also removes some unused code.

This should fix #6387