### PR TITLE
rsx: Avoid recursion in flip handler

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2604,6 +2604,12 @@ namespace rsx
 
 	void thread::handle_emu_flip(u32 buffer)
 	{
+		if (m_queued_flip.in_progress)
+		{
+			// Rescursion not allowed!
+			return;
+		}
+
 		if (m_queued_flip.buffer == ~0u)
 		{
 			// Frame was not queued before flipping
@@ -2653,13 +2659,16 @@ namespace rsx
 		int_flip_index++;
 
 		verify(HERE), m_queued_flip.buffer == buffer;
+
 		current_display_buffer = buffer;
 		m_queued_flip.emu_flip = true;
+		m_queued_flip.in_progress = true;
 		flip(m_queued_flip);
 
 		last_flip_time = get_system_time() - 1000000;
 		flip_status = CELL_GCM_DISPLAY_FLIP_STATUS_DONE;
 		m_queued_flip.buffer = ~0u;
+		m_queued_flip.in_progress = false;
 
 		if (flip_handler)
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -428,6 +428,7 @@ namespace rsx
 		u32 buffer;
 		bool skip_frame;
 		bool emu_flip;
+		bool in_progress;
 		frame_statistics_t stats;
 	};
 


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/6540

Chain of events:
- Offloader thread is working slower than main renderer. Main renderer starts preparing a display flip.
- Renderer waits for offloader, but offloader faults and signals the renderer to wake it,
- Renderer enters the recovery handler. The recovery handler calls the cleanup code which noitces a pending flip request in the queue and issues another flip request while the original one is still being processed.
- We have 2 flip requests being processed recursively, and the assertion fires.