### PR TITLE
SPU: Rewrite CGX/BGX

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -3802,16 +3802,32 @@ void spu_recompiler::CGX(spu_opcode_t op) //nf
 
 void spu_recompiler::BGX(spu_opcode_t op) //nf
 {
-	for (u32 i = 0; i < 4; i++) // unrolled loop
+	const XmmLink& vt = XmmGet(op.rt, XmmType::Int);
+	const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+	const XmmLink& vb = XmmGet(op.rb, XmmType::Int);
+	const XmmLink& temp = XmmAlloc();
+	const XmmLink& sign = XmmAlloc();
+
+	c->pslld(vt, 31);
+
+	if (utils::has_avx())
 	{
-		c->bt(SPU_OFF_32(gpr, op.rt, &v128::_u32, i), 0);
-		c->cmc();
-		c->mov(*addr, SPU_OFF_32(gpr, op.rb, &v128::_u32, i));
-		c->sbb(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, i));
-		c->setnc(addr->r8());
-		c->movzx(*addr, addr->r8());
-		c->mov(SPU_OFF_32(gpr, op.rt, &v128::_u32, i), *addr);
+		c->vpcmpeqd(temp, vb, va);
 	}
+	else
+	{
+		c->movdqa(temp, vb);
+		c->pcmpeqd(temp, va);
+	}
+
+	c->pand(vt, temp);
+	c->movdqa(sign, XmmConst(_mm_set1_epi32(-0x80000000)));
+	c->pxor(va, sign);
+	c->pxor(vb, sign);
+	c->pcmpgtd(vb, va);
+	c->por(vt, vb);
+	c->psrld(vt, 31);
+	c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
 }
 
 void spu_recompiler::MPYHHA(spu_opcode_t op)

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6607,9 +6607,9 @@ public:
 	void CGX(spu_opcode_t op)
 	{
 		const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);
-		const auto x = ~get_vr(op.rt) & 1;
+		const auto x = (get_vr<s32[4]>(op.rt) << 31) >> 31;
 		const auto s = eval(a + b);
-		set_vr(op.rt, zext<u32[4]>((noncast<u32[4]>(sext<s32[4]>(s < a)) | (s & ~x)) == -1));
+		set_vr(op.rt, noncast<u32[4]>(sext<s32[4]>(s < a) | (sext<s32[4]>(s == noncast<u32[4]>(x)) & x)) >> 31);
 	}
 
 	void BGX(spu_opcode_t op)

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6616,7 +6616,7 @@ public:
 	{
 		const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);
 		const auto c = get_vr<s32[4]>(op.rt) << 31;
-		set_vr(op.rt, zext<u32[4]>((a <= b) & ~((a == b) & (c >= 0))));
+		set_vr(op.rt, noncast<u32[4]>(sext<s32[4]>(b > a) | (sext<s32[4]>(a == b) & c)) >> 31);
 	}
 
 	void MPYHHA(spu_opcode_t op)


### PR DESCRIPTION
LLVM:
* Now loads (or computes) less immediate values. (shift count is hardcoded to the instruction, it comes as free to use it)
* BGX's comparisons optimized (removed one comparison, replaced non-native "Lower/Equal" comparison with native "Greater" comparison, unfortunatly still suffers from unsigned problem).

ASMJIT:
* The instructions are now vectorized.