### PR TITLE
Qt signals/slots/emit keywords

### DIFF
--- a/rpcs3/headless_application.h
+++ b/rpcs3/headless_application.h
@@ -28,9 +28,9 @@ private:
 		return thread();
 	};
 
-Q_SIGNALS:
+signals:
 	void RequestCallAfter(const std::function<void()>& func);
 
-private Q_SLOTS:
+private slots:
 	void HandleCallAfter(const std::function<void()>& func);
 };

--- a/rpcs3/rpcs3qt/auto_pause_settings_dialog.h
+++ b/rpcs3/rpcs3qt/auto_pause_settings_dialog.h
@@ -39,9 +39,9 @@ public:
 	void LoadEntries(void);
 	void SaveEntries(void);
 
-public Q_SLOTS:
+public slots:
 	void OnRemove();
-private Q_SLOTS:
+private slots:
 	void ShowContextMenu(const QPoint &pos);
 	void keyPressEvent(QKeyEvent *event) override;
 };
@@ -60,7 +60,7 @@ class AutoPauseConfigDialog : public QDialog
 public:
 	explicit AutoPauseConfigDialog(QWidget* parent, auto_pause_settings_dialog* apsd, bool newEntry, u32* entry);
 
-private Q_SLOTS:
+private slots:
 	void OnOk();
 	void OnCancel();
 	void OnUpdateValue();

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -52,7 +52,7 @@ void breakpoint_list::RemoveBreakpoint(u32 addr)
 		}
 	}
 
-	Q_EMIT RequestShowAddress(addr);
+	emit RequestShowAddress(addr);
 }
 
 void breakpoint_list::AddBreakpoint(u32 pc)
@@ -101,7 +101,7 @@ void breakpoint_list::HandleBreakpointRequest(u32 loc)
 void breakpoint_list::OnBreakpointListDoubleClicked()
 {
 	u32 address = currentItem()->data(Qt::UserRole).value<u32>();
-	Q_EMIT RequestShowAddress(address);
+	emit RequestShowAddress(address);
 }
 
 void breakpoint_list::OnBreakpointListRightClicked(const QPoint &pos)

--- a/rpcs3/rpcs3qt/breakpoint_list.h
+++ b/rpcs3/rpcs3qt/breakpoint_list.h
@@ -20,11 +20,11 @@ public:
 
 	QColor m_text_color_bp;
 	QColor m_color_bp;
-Q_SIGNALS:
+signals:
 	void RequestShowAddress(u32 addr);
-public Q_SLOTS:
+public slots:
 	void HandleBreakpointRequest(u32 addr);
-private Q_SLOTS:
+private slots:
 	void OnBreakpointListDoubleClicked();
 	void OnBreakpointListRightClicked(const QPoint &pos);
 	void OnBreakpointListDelete();

--- a/rpcs3/rpcs3qt/cg_disasm_window.h
+++ b/rpcs3/rpcs3qt/cg_disasm_window.h
@@ -11,7 +11,7 @@ class cg_disasm_window : public QWidget
 {
 	Q_OBJECT
 
-private Q_SLOTS:
+private slots:
 	void ShowContextMenu(const QPoint &pos);
 	void ShowDisasm();
 	bool IsValidFile(const QMimeData& md, bool save = false);

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -170,7 +170,7 @@ bool debugger_frame::eventFilter(QObject* object, QEvent* ev)
 void debugger_frame::closeEvent(QCloseEvent *event)
 {
 	QDockWidget::closeEvent(event);
-	Q_EMIT DebugFrameClosed();
+	emit DebugFrameClosed();
 }
 
 void debugger_frame::showEvent(QShowEvent * event)

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -80,7 +80,7 @@ public:
 	void ClearBreakpoints(); // Fallthrough method into breakpoint_list.
 
 	/** Needed so key press events work when other objects are selected in debugger_frame. */
-	bool eventFilter(QObject* object, QEvent* event) override; 
+	bool eventFilter(QObject* object, QEvent* event) override;
 protected:
 	/** Override inherited method from Qt to allow signalling when close happened.*/
 	void closeEvent(QCloseEvent* event) override;
@@ -88,13 +88,13 @@ protected:
 	void hideEvent(QHideEvent* event) override;
 	void keyPressEvent(QKeyEvent* event) override;
 
-Q_SIGNALS:
+signals:
 	void DebugFrameClosed();
 
-public Q_SLOTS:
+public slots:
 	void DoStep(bool stepOver = false);
 
-private Q_SLOTS:
+private slots:
 	void OnSelectUnit();
 	void ShowPC();
 	void EnableUpdateTimer(bool state);

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -141,7 +141,7 @@ void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
 		// Let debugger_frame know about breakpoint.
 		// Other option is to add to breakpoint manager directly and have a signal there instead.
 		// Either the flow goes from debugger_list->breakpoint_manager->debugger_frame, or it goes debugger_list->debugger_frame, and I felt this was easier to read for now.
-		Q_EMIT BreakpointRequested(pc);
+		emit BreakpointRequested(pc);
 
 		ShowAddress(start_pc);
 	}

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -21,12 +21,12 @@ public:
 	QColor m_text_color_bp;
 	QColor m_text_color_pc;
 
-Q_SIGNALS:
+signals:
 	void BreakpointRequested(u32 loc);
 public:
 	debugger_list(QWidget* parent, std::shared_ptr<gui_settings> settings, breakpoint_handler* handler);
 	void UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_ptr<CPUDisAsm> disasm);
-public Q_SLOTS:
+public slots:
 	void ShowAddress(u32 addr);
 protected:
 	void keyPressEvent(QKeyEvent* event) override;

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -250,7 +250,7 @@ public:
 	/** Fixes all registered invalid settings after asking the user for permission.*/
 	void OpenCorrectionDialog(QWidget* parent = Q_NULLPTR);
 
-public Q_SLOTS:
+public slots:
 	/** Writes the unsaved settings to file.  Used in settings dialog on accept.*/
 	void SaveSettings();
 private:

--- a/rpcs3/rpcs3qt/find_dialog.h
+++ b/rpcs3/rpcs3qt/find_dialog.h
@@ -24,7 +24,7 @@ private:
 	QPushButton* m_find_next;
 	QPushButton* m_find_previous;
 
-private Q_SLOTS:
+private slots:
 	int count_all();
 	void find_first();
 	void find_last();

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -37,7 +37,7 @@ bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_downl
 				break;
 			}
 			LOG_ERROR(GENERAL, "Compatibility error: { %s: return code %d }", error_message, return_code);
-			Q_EMIT DownloadError(qstr(error_message) + " " + QString::number(return_code));
+			emit DownloadError(qstr(error_message) + " " + QString::number(return_code));
 		}
 		else
 		{
@@ -188,7 +188,7 @@ void game_compatibility::RequestCompatibility(bool online)
 			// We failed to retrieve a new database, therefore refresh gamelist to old state
 			QString error = network_reply->errorString();
 			network_reply->deleteLater();
-			Q_EMIT DownloadError(error);
+			emit DownloadError(error);
 			LOG_ERROR(GENERAL, "Compatibility error: { Network Error - %s }", sstr(error));
 			return;
 		}
@@ -203,7 +203,7 @@ void game_compatibility::RequestCompatibility(bool online)
 		if (ReadJSON(QJsonDocument::fromJson(data).object(), online))
 		{
 			// We have a new database in map, therefore refresh gamelist to new state
-			Q_EMIT DownloadFinished();
+			emit DownloadFinished();
 
 			// Write database to file
 			QFile file(m_filepath);
@@ -227,7 +227,7 @@ void game_compatibility::RequestCompatibility(bool online)
 	});
 
 	// We want to retrieve a new database, therefore refresh gamelist and indicate that
-	Q_EMIT DownloadStarted();
+	emit DownloadStarted();
 }
 
 compat_status game_compatibility::GetCompatibility(const std::string& title_id)

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -67,7 +67,7 @@ public:
 	/** Returns the data for the requested status */
 	compat_status GetStatusData(const QString& status);
 
-Q_SIGNALS:
+signals:
 	void DownloadStarted();
 	void DownloadFinished();
 	void DownloadError(const QString& error);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -703,7 +703,7 @@ void game_list_frame::doubleClickedSlot(QTableWidgetItem *item)
 	}
 
 	LOG_NOTICE(LOADER, "Booting from gamelist per doubleclick...");
-	Q_EMIT RequestBoot(game);
+	emit RequestBoot(game);
 }
 
 void game_list_frame::ShowContextMenu(const QPoint &pos)
@@ -748,7 +748,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		connect(boot_custom, &QAction::triggered, [=]
 		{
 			LOG_NOTICE(LOADER, "Booting from gamelist per context menu...");
-			Q_EMIT RequestBoot(gameinfo);
+			emit RequestBoot(gameinfo);
 		});
 	}
 	else
@@ -857,7 +857,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	connect(boot, &QAction::triggered, [=]
 	{
 		LOG_NOTICE(LOADER, "Booting from gamelist per context menu...");
-		Q_EMIT RequestBoot(gameinfo, gameinfo->hasCustomConfig);
+		emit RequestBoot(gameinfo, gameinfo->hasCustomConfig);
 	});
 	connect(configure, &QAction::triggered, [=]
 	{
@@ -1642,7 +1642,7 @@ void game_list_frame::SetSearchText(const QString& text)
 void game_list_frame::closeEvent(QCloseEvent *event)
 {
 	QDockWidget::closeEvent(event);
-	Q_EMIT GameListFrameClosed();
+	emit GameListFrameClosed();
 }
 
 void game_list_frame::resizeEvent(QResizeEvent *event)
@@ -1665,7 +1665,7 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 		{
 			QPoint numSteps = wheelEvent->angleDelta() / 8 / 15;	// http://doc.qt.io/qt-5/qwheelevent.html#pixelDelta
 			const int value = numSteps.y();
-			Q_EMIT RequestIconSizeChange(value);
+			emit RequestIconSizeChange(value);
 			return true;
 		}
 	}
@@ -1677,12 +1677,12 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 		{
 			if (keyEvent->key() == Qt::Key_Plus)
 			{
-				Q_EMIT RequestIconSizeChange(1);
+				emit RequestIconSizeChange(1);
 				return true;
 			}
 			else if (keyEvent->key() == Qt::Key_Minus)
 			{
-				Q_EMIT RequestIconSizeChange(-1);
+				emit RequestIconSizeChange(-1);
 				return true;
 			}
 		}
@@ -1706,7 +1706,7 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 					return false;
 
 				LOG_NOTICE(LOADER, "Booting from gamelist by pressing %s...", keyEvent->key() == Qt::Key_Enter ? "Enter" : "Return");
-				Q_EMIT RequestBoot(gameinfo);
+				emit RequestBoot(gameinfo);
 
 				return true;
 			}

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -31,7 +31,7 @@ enum Category
 	Others,
 };
 
-namespace category // (see PARAM.SFO in psdevwiki.com) TODO: Disc Categories 
+namespace category // (see PARAM.SFO in psdevwiki.com) TODO: Disc Categories
 {
 	// PS3 bootable
 	const QString app_music = QObject::tr("App Music");
@@ -211,7 +211,7 @@ public:
 
 	void SetShowHidden(bool show);
 
-public Q_SLOTS:
+public slots:
 	void BatchCreatePPUCaches();
 	void BatchRemovePPUCaches();
 	void BatchRemoveSPUCaches();
@@ -222,11 +222,11 @@ public Q_SLOTS:
 	void SetSearchText(const QString& text);
 	void SetShowCompatibilityInGrid(bool show);
 
-private Q_SLOTS:
+private slots:
 	void OnColClicked(int col);
 	void ShowContextMenu(const QPoint &pos);
 	void doubleClickedSlot(QTableWidgetItem *item);
-Q_SIGNALS:
+signals:
 	void GameListFrameClosed();
 	void RequestBoot(const game_info& game, bool force_global_config = false);
 	void RequestIconSizeChange(const int& val);

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -77,6 +77,6 @@ protected:
 
 	bool event(QEvent* ev) override;
 
-private Q_SLOTS:
+private slots:
 	void HandleCursor(QWindow::Visibility visibility);
 };

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -55,10 +55,10 @@ private:
 	bool m_show_gui = true;
 	bool m_use_cli_style = false;
 
-private Q_SLOTS:
+private slots:
 	void OnChangeStyleSheetRequest(const QString& path);
 
-Q_SIGNALS:
+signals:
 	void OnEmulatorRun();
 	void OnEmulatorPause();
 	void OnEmulatorResume();
@@ -67,6 +67,6 @@ Q_SIGNALS:
 
 	void RequestCallAfter(const std::function<void()>& func);
 
-private Q_SLOTS:
+private slots:
 	void HandleCallAfter(const std::function<void()>& func);
 };

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -269,7 +269,7 @@ public:
 	QStringList GetStylesheetEntries();
 	QStringList GetGameListCategoryFilters();
 
-public Q_SLOTS:
+public slots:
 	void Reset(bool removeMeta = false);
 
 	/** Remove entry */

--- a/rpcs3/rpcs3qt/input_dialog.h
+++ b/rpcs3/rpcs3qt/input_dialog.h
@@ -16,6 +16,6 @@ public:
 private:
 	QString m_text;
 
-Q_SIGNALS:
+signals:
 	void text_changed(const QString& text);
 };

--- a/rpcs3/rpcs3qt/kernel_explorer.h
+++ b/rpcs3/rpcs3qt/kernel_explorer.h
@@ -14,6 +14,6 @@ class kernel_explorer : public QDialog
 
 public:
 	kernel_explorer(QWidget* parent);
-private Q_SLOTS:
+private slots:
 	void Update();
 };

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -225,7 +225,7 @@ void log_frame::CreateAndConnectActions()
 
 	m_clearTTYAct = new QAction(tr("Clear"), this);
 	connect(m_clearTTYAct, &QAction::triggered, m_tty, &QTextEdit::clear);
-	
+
 	m_stackAct_tty = new QAction(tr("Stack Mode (TTY)"), this);
 	m_stackAct_tty->setCheckable(true);
 	connect(m_stackAct_tty, &QAction::toggled, xgui_settings.get(), [=](bool checked)
@@ -480,7 +480,7 @@ void log_frame::UpdateUI()
 			std::stringstream buf_stream;
 			buf_stream.str(buf);
 			std::string buf_line;
-			while (std::getline(buf_stream, buf_line)) 
+			while (std::getline(buf_stream, buf_line))
 			{
 				QString suffix;
 				QString tty_text = QString::fromStdString(buf_line);
@@ -632,7 +632,7 @@ void log_frame::UpdateUI()
 void log_frame::closeEvent(QCloseEvent *event)
 {
 	QDockWidget::closeEvent(event);
-	Q_EMIT LogFrameClosed();
+	emit LogFrameClosed();
 }
 
 bool log_frame::eventFilter(QObject* object, QEvent* event)

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -28,13 +28,13 @@ public:
 	/** Repaint log colors after new stylesheet was applied */
 	void RepaintTextColors();
 
-Q_SIGNALS:
+signals:
 	void LogFrameClosed();
 protected:
 	/** Override inherited method from Qt to allow signalling when close happened.*/
 	void closeEvent(QCloseEvent* event) override;
 	bool eventFilter(QObject* object, QEvent* event) override;
-private Q_SLOTS:
+private slots:
 	void UpdateUI();
 private:
 	void SetLogLevel(logs::level lev);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -89,7 +89,7 @@ void main_window::Init()
 	setMinimumSize(350, minimumSizeHint().height());    // seems fine on win 10
 	setWindowTitle(QString::fromStdString("RPCS3 " + rpcs3::version.to_string()));
 
-	Q_EMIT RequestGlobalStylesheetChange(guiSettings->GetCurrentStylesheetPath());
+	emit RequestGlobalStylesheetChange(guiSettings->GetCurrentStylesheetPath());
 	ConfigureGuiFromSettings(true);
 
 #ifdef BRANCH
@@ -1083,7 +1083,7 @@ void main_window::RepaintGui()
 	RepaintToolBarIcons();
 	RepaintThumbnailIcons();
 
-	Q_EMIT RequestTrophyManagerRepaint();
+	emit RequestTrophyManagerRepaint();
 }
 
 void main_window::ShowTitleBars(bool show)

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -74,11 +74,11 @@ public:
 	~main_window();
 	QIcon GetAppIcon();
 
-Q_SIGNALS:
+signals:
 	void RequestGlobalStylesheetChange(const QString& sheetFilePath);
 	void RequestTrophyManagerRepaint();
 
-public Q_SLOTS:
+public slots:
 	void OnEmuStop();
 	void OnEmuRun();
 	void OnEmuResume();
@@ -87,7 +87,7 @@ public Q_SLOTS:
 
 	void RepaintGui();
 
-private Q_SLOTS:
+private slots:
 	void OnPlayOrPause();
 	void Boot(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, bool force_global_config = false);
 	void BootElf();

--- a/rpcs3/rpcs3qt/memory_string_searcher.h
+++ b/rpcs3/rpcs3qt/memory_string_searcher.h
@@ -18,6 +18,6 @@ class memory_string_searcher : public QDialog
 public:
 	memory_string_searcher(QWidget* parent);
 
-private Q_SLOTS:
+private slots:
 	void OnSearch();
 };

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -90,7 +90,7 @@ public:
 	explicit pad_settings_dialog(QWidget *parent = nullptr, const GameInfo *game = nullptr);
 	~pad_settings_dialog();
 
-private Q_SLOTS:
+private slots:
 	void OnPadButtonClicked(int id);
 	void OnTabChanged(int index);
 	void RefreshInputTypes();

--- a/rpcs3/rpcs3qt/register_editor_dialog.h
+++ b/rpcs3/rpcs3qt/register_editor_dialog.h
@@ -33,6 +33,6 @@ public:
 private:
 	void OnOkay(const std::shared_ptr<cpu_thread>& _cpu);
 
-private Q_SLOTS:
+private slots:
 	void updateRegister(const QString& text);
 };

--- a/rpcs3/rpcs3qt/rsx_debugger.h
+++ b/rpcs3/rpcs3qt/rsx_debugger.h
@@ -96,7 +96,7 @@ public:
 
 	void SetPC(const uint pc);
 
-public Q_SLOTS:
+public slots:
 	virtual void OnClickDrawCalls();
 	virtual void SetFlags();
 	virtual void SetPrograms();

--- a/rpcs3/rpcs3qt/save_data_list_dialog.h
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.h
@@ -27,7 +27,7 @@ public:
 	explicit save_data_list_dialog(const std::vector<SaveDataEntry>& entries, s32 focusedEntry, u32 op, vm::ptr<CellSaveDataListSet>, QWidget* parent = nullptr);
 
 	s32 GetSelection();
-private Q_SLOTS:
+private slots:
 	void OnEntryInfo();
 	void OnSort(int logicalIndex);
 private:

--- a/rpcs3/rpcs3qt/save_manager_dialog.h
+++ b/rpcs3/rpcs3qt/save_manager_dialog.h
@@ -21,9 +21,9 @@ public:
 	* There'll be some duplicated code.  But, in the future, there'll be no duplicated code. So, I don't care.
 	*/
 	explicit save_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::string dir = "", QWidget* parent = nullptr);
-public Q_SLOTS:
+public slots:
 	void HandleRepaintUiRequest();
-private Q_SLOTS:
+private slots:
 	void OnEntryRemove();
 	void OnEntriesRemove();
 	void OnSort(int logicalIndex);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1405,7 +1405,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 				ApplyGuiOptions(true);
 				xgui_settings->Reset(true);
 				xgui_settings->ChangeToConfig(gui::Default);
-				Q_EMIT GuiSettingsSyncRequest(true);
+				emit GuiSettingsSyncRequest(true);
 				AddConfigs();
 				AddStylesheets();
 				AddColoredIcons();
@@ -1448,7 +1448,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 			ui->pb_gl_icon_color->setEnabled(val);
 			ui->pb_sd_icon_color->setEnabled(val);
 			ui->pb_tr_icon_color->setEnabled(val);
-			Q_EMIT GuiRepaintRequest();
+			emit GuiRepaintRequest();
 		});
 		auto colorDialog = [&](const gui_save& color, const QString& title, QPushButton *button)
 		{
@@ -1468,7 +1468,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 				}
 				xgui_settings->SetValue(color, dlg.selectedColor());
 				button->setIcon(gui::utils::get_colorized_icon(button->icon(), oldColor, dlg.selectedColor(), true));
-				Q_EMIT GuiRepaintRequest();
+				emit GuiRepaintRequest();
 			}
 		};
 
@@ -1655,7 +1655,7 @@ void settings_dialog::OnBackupCurrentConfig()
 			QMessageBox::warning(this, tr("Error"), tr("Please choose a non-existing name"));
 			continue;
 		}
-		Q_EMIT GuiSettingsSaveRequest();
+		emit GuiSettingsSaveRequest();
 		xgui_settings->SaveCurrentConfig(friendly_name);
 		ui->combo_configs->addItem(friendly_name);
 		ui->combo_configs->setCurrentText(friendly_name);
@@ -1682,14 +1682,14 @@ void settings_dialog::OnApplyConfig()
 	}
 
 	m_currentConfig = new_config;
-	Q_EMIT GuiSettingsSyncRequest(true);
+	emit GuiSettingsSyncRequest(true);
 }
 
 void settings_dialog::OnApplyStylesheet()
 {
 	m_currentStylesheet = ui->combo_stylesheets->currentData().toString();
 	xgui_settings->SetValue(gui::m_currentStylesheet, m_currentStylesheet);
-	Q_EMIT GuiStylesheetRequest(xgui_settings->GetCurrentStylesheetPath());
+	emit GuiStylesheetRequest(xgui_settings->GetCurrentStylesheetPath());
 }
 
 int settings_dialog::exec()

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -24,12 +24,12 @@ public:
 	explicit settings_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, const int& tabIndex = 0, QWidget *parent = 0, const GameInfo *game = nullptr);
 	~settings_dialog();
 	int exec() override;
-Q_SIGNALS:
+signals:
 	void GuiSettingsSyncRequest(bool configure_all);
 	void GuiStylesheetRequest(const QString& path);
 	void GuiSettingsSaveRequest();
 	void GuiRepaintRequest();
-private Q_SLOTS:
+private slots:
 	void OnBackupCurrentConfig();
 	void OnApplyConfig();
 	void OnApplyStylesheet();

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -674,7 +674,7 @@ void trophy_manager_dialog::trophy_load_thread::run()
 	QDir trophy_dir(qstr(vfs::get(m_manager->m_trophy_dir)));
 	const auto folder_list = trophy_dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 	const int count = folder_list.count();
-	Q_EMIT TotalCountChanged(count);
+	emit TotalCountChanged(count);
 
 	for (int i = 0; m_manager->m_thread_state == TrophyThreadState::RUNNING && i < count; i++)
 	{
@@ -690,12 +690,12 @@ void trophy_manager_dialog::trophy_load_thread::run()
 			// Also add a way of showing the number of corrupted/invalid folders in UI somewhere.
 			LOG_ERROR(GENERAL, "Exception occurred while parsing folder %s for trophies: %s", dir_name, e.what());
 		}
-		Q_EMIT ProcessedCountChanged(i + 1);
+		emit ProcessedCountChanged(i + 1);
 	}
 
 	if (m_manager->m_thread_state == TrophyThreadState::RUNNING)
 	{
-		Q_EMIT FinishedSuccessfully();
+		emit FinishedSuccessfully();
 	}
 
 	m_manager->m_thread_state = TrophyThreadState::CLOSED;

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.h
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.h
@@ -66,10 +66,10 @@ public:
 	~trophy_manager_dialog() override;
 	void RepaintUI(bool restore_layout = true);
 
-public Q_SLOTS:
+public slots:
 	void HandleRepaintUiRequest();
 
-private Q_SLOTS:
+private slots:
 	void ResizeGameIcon(int index);
 	void ResizeGameIcons();
 	void ResizeTrophyIcons();
@@ -77,7 +77,7 @@ private Q_SLOTS:
 	void ShowContextMenu(const QPoint& pos);
 
 private:
-	/** Loads a trophy folder. 
+	/** Loads a trophy folder.
 	Returns true if successful.  Does not attempt to install if failure occurs, like sceNpTrophy.
 	*/
 	bool LoadTrophyFolderToDB(const std::string& trop_name);
@@ -141,7 +141,7 @@ class trophy_manager_dialog::trophy_load_thread : public QThread
 		explicit trophy_load_thread(trophy_manager_dialog *manager) : m_manager(manager) {}
 		void run() override;
 
-	Q_SIGNALS:
+	signals:
 		void TotalCountChanged(int count);
 		void ProcessedCountChanged(int processed);
 		void FinishedSuccessfully();

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -377,7 +377,7 @@ void user_manager_dialog::OnUserLogin()
 	m_active_user = new_user;
 	m_gui_settings->SetValue(gui::um_active_user, qstr(m_active_user));
 	UpdateTable(true);
-	Q_EMIT OnUserLoginSuccess();
+	emit OnUserLoginSuccess();
 }
 
 void user_manager_dialog::OnSort(int logicalIndex)
@@ -389,7 +389,7 @@ void user_manager_dialog::OnSort(int logicalIndex)
 	else if (logicalIndex == m_sort_column)
 	{
 		m_sort_ascending ^= true;
-	} 
+	}
 	else
 	{
 		m_sort_ascending = true;

--- a/rpcs3/rpcs3qt/user_manager_dialog.h
+++ b/rpcs3/rpcs3qt/user_manager_dialog.h
@@ -25,9 +25,9 @@ class user_manager_dialog : public QDialog
 	Q_OBJECT
 public:
 	explicit user_manager_dialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
-Q_SIGNALS:
+signals:
 	void OnUserLoginSuccess();
-private Q_SLOTS:
+private slots:
 	void OnUserLogin();
 	void OnUserCreate();
 	void OnUserRemove();


### PR DESCRIPTION
Q_SIGNALS/Q_SLOTS/Q_EMIT is only used with third party signal/slot
mechanism. This causes build problem in Linux with Qt 5.13.