### PR TITLE
dont escape from check_state() before ensuring signal is resetted.

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -229,11 +229,6 @@ bool cpu_thread::check_state() noexcept
 			return true;
 		}
 
-		if (state & cpu_flag::signal && state.test_and_reset(cpu_flag::signal))
-		{
-			cpu_sleep_called = false;
-		}
-
 		const auto [state0, escape] = state.fetch_op([&](bs_t<cpu_flag>& flags)
 		{
 			// Atomically clean wait flag and escape
@@ -250,6 +245,11 @@ bool cpu_thread::check_state() noexcept
 
 			return true;
 		});
+
+		if (state & cpu_flag::signal && state.test_and_reset(cpu_flag::signal))
+		{
+			cpu_sleep_called = false;
+		}
 
 		if (escape)
 		{


### PR DESCRIPTION
Fixed a situation where: Theres an ETIMEDOUT in sys_cond_wait.
check_state() tries to awake ppu, didnt succeed.
fallbacks to thread_ctrl::wait(), later wakes up spuriously.
then checks cpu_flag::signal but it is not there.
a little after the thread is awaken externally.
the thead checks cpu_flag::suspend, but it is not there so it returns, but cpu_flag::signal is still set.
what causes the mess in lv2_obj::sleep when trying to wait on mutex owner.
Seen in Demon Souls as a regression because of recent sys_cond changes.
