### PR TITLE
Unbreak with Clang/LLD 9

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -10,7 +10,9 @@
 
 #include <optional>
 
+#ifdef _WIN32
 #pragma comment(lib, "opengl32.lib")
+#endif
 
 namespace gl
 {


### PR DESCRIPTION
Regressed by https://github.com/llvm/llvm-project/commit/1d16515fb407. Found via [freebsd#240629](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=240629).
```
$ c++ --version
FreeBSD clang version 9.0.0 (tags/RELEASE_900/final 372316) (based on LLVM 9.0.0)
Target: x86_64-unknown-freebsd13.0
Thread model: posix
InstalledDir: /usr/bin
$ c++ -Wl,--version
LLD 9.0.0 (FreeBSD 372316-1300004) (compatible with GNU linkers)

$ git describe --tags --always
v0.0.7-144-g40fcd457b
$ git rev-list --count HEAD
8759

$ cmake -DUSE_SYSTEM_FFMPEG=ON -DUSE_SYSTEM_LIBPNG=ON -GNinja /path/to/rpcs3
$ ninja
[...]
c++: warning: argument unused during compilation: '-no-pie' [-Wunused-command-line-argument]
ld: error: rpcs3/CMakeFiles/rpcs3.dir/main_application.cpp.o: unable to find library from dependent library specifier: opengl32.lib
ld: error: rpcs3/Emu/librpcs3_emu.a(GLGSRender.cpp.o): unable to find library from dependent library specifier: opengl32.lib
ld: error: rpcs3/Emu/librpcs3_emu.a(GLRenderTargets.cpp.o): unable to find library from dependent library specifier: opengl32.lib
ld: error: rpcs3/Emu/librpcs3_emu.a(GLVertexBuffers.cpp.o): unable to find library from dependent library specifier: opengl32.lib
c++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
http://package18.nyi.freebsd.org/data/headamd64PR240629-default/2019-09-21_22h04m49s/logs/errors/rpcs3-0.0.7.8748.log
