### PR TITLE
cellSaveData improvements

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -862,7 +862,9 @@ error_code sys_fs_unlink(ppu_thread& ppu, vm::cptr<char> path)
 	const std::string_view vpath = path.get_ptr();
 	const std::string local_path = vfs::get(vpath);
 
-	if (vpath.find_first_not_of('/') == -1)
+	const std::size_t dev_start = vpath.find_first_not_of('/');
+
+	if (dev_start == -1)
 	{
 		return {CELL_EISDIR, path};
 	}
@@ -877,7 +879,10 @@ error_code sys_fs_unlink(ppu_thread& ppu, vm::cptr<char> path)
 		return {CELL_EISDIR, path};
 	}
 
-	if (!vfs::host::unlink(local_path))
+	// Size of "/dev_hdd0"-alike substring
+	const std::size_t dev_size  = vpath.find_first_of('/', dev_start);
+
+	if (!vfs::host::unlink(local_path, vfs::get(vpath.substr(0, dev_size))))
 	{
 		switch (auto error = fs::g_tls_error)
 		{

--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -25,6 +25,6 @@ namespace vfs
 		bool rename(const std::string& from, const std::string& to, bool overwrite);
 
 		// Delete file without deleting its contents, emulated with MoveFileEx on Windows
-		bool unlink(const std::string&);
+		bool unlink(const std::string& path, const std::string& dev_root);
 	}
 }


### PR DESCRIPTION
Add savedata maintenance routine:
1) Removes junk backup directories
2) Fixes interrupted save data process in edge case
This case can happen if emu terminates between two atomic renames.

Also use directory renaming technique for delete op.

Improve sys_fs_unlink and sys_fs_rmdir behaviour on Windows.