### PR TITLE
vk: Fix DEVICE_LOST for turing cards

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -11,6 +11,46 @@
 
 namespace vk
 {
+	static chip_family_table s_AMD_family_tree = []()
+	{
+		chip_family_table table;
+		table.default_ = chip_class::AMD_gcn_generic;
+
+		// AMD cards. See https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
+		table.add(0x67C0, 0x67FF, chip_class::AMD_polaris);
+		table.add(0x6FDF, chip_class::AMD_polaris); // RX580 2048SP
+		table.add(0x6980, 0x699F, chip_class::AMD_polaris); // Polaris12
+		table.add(0x694C, 0x694F, chip_class::AMD_vega); // VegaM
+		table.add(0x6860, 0x686F, chip_class::AMD_vega); // VegaPro
+		table.add(0x687F, chip_class::AMD_vega); // Vega56/64
+		table.add(0x69A0, 0x69AF, chip_class::AMD_vega); // Vega12
+		table.add(0x66A0, 0x66AF, chip_class::AMD_vega); // Vega20
+		table.add(0x15DD, chip_class::AMD_vega); // Raven Ridge
+		table.add(0x15D8, chip_class::AMD_vega); // Raven Ridge
+		table.add(0x7310, 0x731F, chip_class::AMD_navi); // Navi10
+		table.add(0x7340, 0x7340, chip_class::AMD_navi); // Navi14
+
+		return table;
+	}();
+
+	static chip_family_table s_NV_family_tree = []()
+	{
+		chip_family_table table;
+		table.default_ = chip_class::NV_generic;
+
+		// NV cards. See https://envytools.readthedocs.io/en/latest/hw/pciid.html
+		// NOTE: Since NV device IDs are linearly incremented per generation, there is no need to carefully check all the ranges
+		table.add(0x1B00, 0x1D80, chip_class::NV_pascal);
+		table.add(0x1D81, 0x1DBA, chip_class::NV_volta);
+		table.add(0x1E02, 0x1F51, chip_class::NV_turing); // RTX 20
+		table.add(0x2182, chip_class::NV_turing); // TU116
+		table.add(0x2184, chip_class::NV_turing); // TU116
+		table.add(0x1F82, chip_class::NV_turing); // TU117
+		table.add(0x1F91, chip_class::NV_turing); // TU117
+
+		return table;
+	}();
+
 	const context* g_current_vulkan_ctx = nullptr;
 	const render_device* g_current_renderer;
 
@@ -34,6 +74,7 @@ namespace vk
 	// Driver compatibility workarounds
 	VkFlags g_heap_compatible_buffer_types = 0;
 	driver_vendor g_driver_vendor = driver_vendor::unknown;
+	chip_class g_chip_class = chip_class::unknown;
 	bool g_drv_no_primitive_restart_flag = false;
 	bool g_drv_sanitize_fp_values = false;
 	bool g_drv_disable_fence_reset = false;
@@ -124,6 +165,21 @@ namespace vk
 		if (result.device_local == VK_MAX_MEMORY_TYPES) fmt::throw_exception("GPU doesn't support device local memory" HERE);
 		if (result.host_visible_coherent == VK_MAX_MEMORY_TYPES) fmt::throw_exception("GPU doesn't support host coherent device local memory" HERE);
 		return result;
+	}
+
+	chip_class get_chip_family(uint32_t vendor_id, uint32_t device_id)
+	{
+		if (vendor_id == 0x10DE)
+		{
+			return s_NV_family_tree.find(device_id);
+		}
+
+		if (vendor_id == 0x1002)
+		{
+			return s_AMD_family_tree.find(device_id);
+		}
+
+		return chip_class::unknown;
 	}
 
 	VkAllocationCallbacks default_callbacks()
@@ -321,11 +377,15 @@ namespace vk
 		g_drv_disable_fence_reset = false;
 		g_num_processed_frames = 0;
 		g_num_total_frames = 0;
-		g_driver_vendor = driver_vendor::unknown;
 		g_heap_compatible_buffer_types = 0;
 
-		const auto gpu_name = g_current_renderer->gpu().get_name();
-		switch (g_driver_vendor = g_current_renderer->gpu().get_driver_vendor())
+		const auto& gpu = g_current_renderer->gpu();
+		const auto gpu_name = gpu.get_name();
+
+		g_driver_vendor = gpu.get_driver_vendor();
+		g_chip_class = gpu.get_chip_class();
+
+		switch (g_driver_vendor)
 		{
 		case driver_vendor::AMD:
 		case driver_vendor::RADV:
@@ -389,6 +449,11 @@ namespace vk
 	driver_vendor get_driver_vendor()
 	{
 		return g_driver_vendor;
+	}
+
+	chip_class get_chip_family()
+	{
+		return g_chip_class;
 	}
 
 	bool emulate_primitive_restart(rsx::primitive_type type)


### PR DESCRIPTION
- Adds chip family detection. Not all cards from one vendor will behave the exact same; it is useful to detect the proper class.
- Adds a fix for turing crash when doing depth_stencil scaling.

Turing cards will throw VK_ERROR_DEVICE_LOST if you try to use the depth blitting hack like rpcs3. NV cards do not export BLIT_DST feature for any of the depth-stencil formats which means to scale these, we need to transfer into a color image first, then scale and copy back. This is already supported but was only enabled for the D32S8 format which is used by all non-nvidia GPUs. The primary reason for the hacky workaround is performance; hopefully turing handles this without much performance lost.