### PR TITLE
Log game version

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1010,6 +1010,9 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 		m_title_id = psf::get_string(_psf, "TITLE_ID");
 		m_cat = psf::get_string(_psf, "CATEGORY");
 
+		std::string version_app  = psf::get_string(_psf, "APP_VER", "Unknown");
+		std::string version_disc = psf::get_string(_psf, "VERSION", "Unknown");
+
 		if (!_psf.empty() && m_cat.empty())
 		{
 			LOG_FATAL(LOADER, "Corrupted PARAM.SFO found! Assuming category GD. Try reinstalling the game.");
@@ -1019,6 +1022,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 		LOG_NOTICE(LOADER, "Title: %s", GetTitle());
 		LOG_NOTICE(LOADER, "Serial: %s", GetTitleID());
 		LOG_NOTICE(LOADER, "Category: %s", GetCat());
+		LOG_NOTICE(LOADER, "Version: %s / %s", version_app, version_disc);
 
 		if (!force_global_config)
 		{


### PR DESCRIPTION
Prints the game version to log when booting. Might be useful for debugging.