### PR TITLE
rsx: Fix overlay scaling

### DIFF
--- a/Utilities/geometry.h
+++ b/Utilities/geometry.h
@@ -664,7 +664,8 @@ struct area_base
 	{
 	}
 
-	constexpr area_base(const coord_base<T>& coord) : x1{ coord.x }, x2{ coord.x + coord.width }, y1{ coord.y }, y2{ coord.y + coord.height }
+	template<typename N>
+	constexpr area_base(const coord_base<N>& coord) : x1{ T(coord.x) }, x2{ T(coord.x + coord.width) }, y1{ T(coord.y) }, y2{ T(coord.y + coord.height) }
 	{
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -132,7 +132,7 @@ namespace gl
 			glBindVertexArray(old_vao);
 		}
 
-		virtual void run(u16 w, u16 h, GLuint target_texture, bool depth_target, bool use_blending = false)
+		virtual void run(const areau& region, GLuint target_texture, bool depth_target, bool use_blending = false)
 		{
 			if (!compiled)
 			{
@@ -198,7 +198,7 @@ namespace gl
 				}
 
 				// Set initial state
-				glViewport(0, 0, w, h);
+				glViewport(region.x1, region.y1, region.width(), region.height());
 				glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 				glDepthMask(depth_target ? GL_TRUE : GL_FALSE);
 
@@ -311,7 +311,7 @@ namespace gl
 			saved_sampler_state saved(31, m_sampler);
 			glBindTexture(GL_TEXTURE_2D, source->id());
 
-			overlay_pass::run(dst_area.x2, dst_area.y2, target->id(), true);
+			overlay_pass::run(dst_area, target->id(), true);
 		}
 	};
 
@@ -341,12 +341,12 @@ namespace gl
 				"}\n";
 		}
 
-		void run(u16 w, u16 h, GLuint target, GLuint source)
+		void run(const areau& viewport, GLuint target, GLuint source)
 		{
 			saved_sampler_state saved(31, m_sampler);
 			glBindTexture(GL_TEXTURE_2D, source);
 
-			overlay_pass::run(w, h, target, false);
+			overlay_pass::run(viewport, target, false);
 		}
 	};
 
@@ -608,9 +608,9 @@ namespace gl
 			}
 		}
 
-		void run(u16 w, u16 h, GLuint target, rsx::overlays::overlay& ui)
+		void run(const areau& viewport, GLuint target, rsx::overlays::overlay& ui)
 		{
-			program_handle.uniforms["viewport"] = color2f(f32(w), f32(h));
+			program_handle.uniforms["viewport"] = color2f((f32)viewport.width(), (f32)viewport.height());
 			program_handle.uniforms["ui_scale"] = color4f((f32)ui.virtual_width, (f32)ui.virtual_height, 1.f, 1.f);
 			program_handle.uniforms["time"] = (f32)(get_system_time() / 1000) * 0.005f;
 
@@ -658,7 +658,7 @@ namespace gl
 				program_handle.uniforms["blur_strength"] = (s32)cmd.config.blur_strength;
 				program_handle.uniforms["clip_region"] = (s32)cmd.config.clip_region;
 				program_handle.uniforms["clip_bounds"] = cmd.config.clip_rect;
-				overlay_pass::run(w, h, target, false, true);
+				overlay_pass::run(viewport, target, false, true);
 			}
 
 			ui.update();
@@ -672,17 +672,13 @@ namespace gl
 			vs_src =
 				"#version 420\n\n"
 				"layout(location=0) out vec2 tc0;\n"
-				"uniform float x_scale;\n"
-				"uniform float y_scale;\n"
-				"uniform float x_offset;\n"
-				"uniform float y_offset;\n"
 				"\n"
 				"void main()\n"
 				"{\n"
 				"	vec2 positions[] = {vec2(-1., -1.), vec2(1., -1.), vec2(-1., 1.), vec2(1., 1.)};\n"
 				"	vec2 coords[] = {vec2(0., 1.), vec2(1., 1.), vec2(0., 0.), vec2(1., 0.)};\n"
 				"	tc0 = coords[gl_VertexID % 4];\n"
-				"	vec2 pos = positions[gl_VertexID % 4] * vec2(x_scale, y_scale) + (2. * vec2(x_offset, y_offset));\n"
+				"	vec2 pos = positions[gl_VertexID % 4];\n"
 				"	gl_Position = vec4(pos, 0., 1.);\n"
 				"}\n";
 
@@ -708,23 +704,14 @@ namespace gl
 			input_filter = GL_LINEAR;
 		}
 
-		void run(u16 w, u16 h, GLuint source, const areai& region, f32 gamma, bool limited_rgb)
+		void run(const areau& viewport, GLuint source, f32 gamma, bool limited_rgb)
 		{
-			const f32 x_scale = (f32)(region.x2 - region.x1) / w;
-			const f32 y_scale = (f32)(region.y2 - region.y1) / h;
-			const f32 x_offset = (f32)(region.x1) / w;
-			const f32 y_offset = (f32)(region.y1) / h;
-
-			program_handle.uniforms["x_scale"] = x_scale;
-			program_handle.uniforms["y_scale"] = y_scale;
-			program_handle.uniforms["x_offset"] = x_offset;
-			program_handle.uniforms["y_offset"] = y_offset;
 			program_handle.uniforms["gamma"] = gamma;
 			program_handle.uniforms["limit_range"] = (int)limited_rgb;
 
 			saved_sampler_state saved(31, m_sampler);
 			glBindTexture(GL_TEXTURE_2D, source);
-			overlay_pass::run(w, h, GL_NONE, false, false);
+			overlay_pass::run(viewport, GL_NONE, false, false);
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -144,7 +144,6 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 
 			if (!PI.value.empty())
 			{
-				printf("Value=%s\n", PI.value.c_str());
 				// Simplify default initialization
 				if (PI.value == "vec4(0.0, 0.0, 0.0, 0.0)")
 					registers += " = vec4(0.)";

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2023,8 +2023,7 @@ void VKGSRender::clear_surface(u32 mask)
 								renderpass = vk::get_renderpass(*m_device, key);
 							}
 
-							m_attachment_clear_pass->run(*m_current_command_buffer, rtt,
-								region.rect, renderpass);
+							m_attachment_clear_pass->run(*m_current_command_buffer, rtt, region.rect, renderpass);
 
 							rtt->change_layout(*m_current_command_buffer, old_layout);
 						}
@@ -3425,7 +3424,7 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 
 			for (const auto& view : m_overlay_manager->get_views())
 			{
-				m_ui_renderer->run(*m_current_command_buffer, direct_fbo->width(), direct_fbo->height(), direct_fbo, single_target_pass, m_texture_upload_buffer_ring_info, *view.get());
+				m_ui_renderer->run(*m_current_command_buffer, areau(aspect_ratio), direct_fbo, single_target_pass, m_texture_upload_buffer_ring_info, *view.get());
 			}
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -268,7 +268,7 @@ namespace vk
 
 			overlay_pass::run(
 				cmd,
-				(u16)resolve_image->width(), (u16)resolve_image->height(),
+				{ 0, 0, resolve_image->width(), resolve_image->height() },
 				resolve_image, src_view,
 				render_pass);
 		}
@@ -299,7 +299,7 @@ namespace vk
 
 			overlay_pass::run(
 				cmd,
-				(u16)msaa_image->width(), (u16)msaa_image->height(),
+				{ 0, 0, msaa_image->width(), msaa_image->height() },
 				msaa_image, src_view,
 				render_pass);
 		}
@@ -364,7 +364,7 @@ namespace vk
 
 			overlay_pass::run(
 				cmd,
-				(u16)resolve_image->width(), (u16)resolve_image->height(),
+				{ 0, 0, resolve_image->width(), resolve_image->height() },
 				resolve_image, stencil_view,
 				render_pass);
 		}
@@ -432,7 +432,7 @@ namespace vk
 
 			overlay_pass::run(
 				cmd,
-				(u16)msaa_image->width(), (u16)msaa_image->height(),
+				{ 0, 0, msaa_image->width(), msaa_image->height() },
 				msaa_image, stencil_view,
 				render_pass);
 		}
@@ -474,7 +474,7 @@ namespace vk
 
 			overlay_pass::run(
 				cmd,
-				(u16)resolve_image->width(), (u16)resolve_image->height(),
+				{ 0, 0, resolve_image->width(), resolve_image->height() },
 				resolve_image, { depth_view, stencil_view },
 				render_pass);
 		}
@@ -519,7 +519,7 @@ namespace vk
 
 			overlay_pass::run(
 				cmd,
-				(u16)msaa_image->width(), (u16)msaa_image->height(),
+				{ 0, 0, msaa_image->width(), msaa_image->height() },
 				msaa_image, { depth_view, stencil_view },
 				render_pass);
 		}


### PR DESCRIPTION
- Properly fit overlays to drawable area to match game visuals.
- Remove a debug print forgotten in the code.

Fixes https://github.com/RPCS3/rpcs3/issues/6648