### PR TITLE
 rsx: Mask FIFO PUT on rsx execution

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -131,6 +131,7 @@ namespace rsx
 			void inc_get(bool wait);
 			void set_get(u32 get);
 			void set_put(u32 put);
+			u32 read_put();
 
 			void read(register_pair& data);
 			inline bool read_unsafe(register_pair& data);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -573,7 +573,7 @@ namespace rsx
 			if (sync_point_request)
 			{
 				restore_point = ctrl->get;
-				restore_ret = m_return_addr;
+				saved_fifo_ret = fifo_ret_addr;
 				sync_point_request = false;
 			}
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -459,7 +459,8 @@ namespace rsx
 		// FIFO
 		std::unique_ptr<FIFO::FIFO_control> fifo_ctrl;
 		FIFO::flattening_helper m_flattener;
-		s32 m_return_addr{ -1 }, restore_ret{ -1 };
+		u32 fifo_ret_addr = RSX_CALL_STACK_EMPTY;
+		u32 saved_fifo_ret = RSX_CALL_STACK_EMPTY;
 
 		// Occlusion query
 		bool zcull_surface_active = false;

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -1040,7 +1040,7 @@ enum
 };
 
 
-enum Method
+enum Method : u32
 {
 	/*
 	CELL_GCM_METHOD_FLAG_NON_INCREMENT = 0x40000000,
@@ -1078,6 +1078,9 @@ enum Method
 
 	RSX_METHOD_NOP_CMD = 0x00000000,
 	RSX_METHOD_NOP_MASK = 0xbfff0003,
+
+	// Stack is empty (invalid value)
+	RSX_CALL_STACK_EMPTY = 0x00000003,
 };
 
 //Fog


### PR DESCRIPTION
Testcase: https://github.com/elad335/myps3tests/tree/master/rsx_tests/FIFO%20PUT%20masking
Results: When the rsx reads from PUT: it masks down the value to 4 bytes alignment and writes back the value.
This process doesnt occur immediatly after write, only when the rsx sees the update.

How the testcase works:
- Sets an unaligned value for PUT with invalid command at the end of FIFO range, waits for possible crash.
- Crash doesnt occur.
- Reads from current value of PUT for logging.
- Spins on a loop which checks if PUT writes are modified by rsx at some point, also saved the "modified value".
- Spins on a loop which checks if the process of modifying PUT occurs immediatly.
- Prints both PUT values which we saved.

realhw:
`sample finished. PUT=0x10003c, PUT1=0x10003d`

rpcs3 master:
`E {RSX [0x10000000]} RSX: FIFO error: possible desync event x2688`

Also changes the sign of fifo return address because at some point archimatics with GET occur and its unsigned.