### PR TITLE
rsx: Restructure deferred flip queue handling

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -426,11 +426,42 @@ namespace rsx
 
 	struct display_flip_info_t
 	{
+		std::deque<u32> buffer_queue;
 		u32 buffer;
 		bool skip_frame;
 		bool emu_flip;
 		bool in_progress;
 		frame_statistics_t stats;
+
+		inline void push(u32 _buffer)
+		{
+			buffer_queue.push_back(_buffer);
+		}
+
+		inline bool pop(u32 _buffer)
+		{
+			if (buffer_queue.empty())
+			{
+				return false;
+			}
+
+			do
+			{
+				const auto index = buffer_queue.front();
+				buffer_queue.pop_front();
+
+				if (index == _buffer)
+				{
+					buffer = _buffer;
+					return true;
+				}
+			}
+			while (!buffer_queue.empty());
+
+			// Need to observe this happening in the wild
+			LOG_ERROR(RSX, "Display queue was discarded while not empty!");
+			return false;
+		}
 	};
 
 	struct sampled_image_descriptor_base;


### PR DESCRIPTION
- Allows frameskipping to occur naturally if RSX thread is bombarded with flip requests but just jumping to the last one if possible. (See request_emu_flip() for async frame submission and implicit skipping)
- Also allows display queue to fill faster than the flip thread can drain the queue.

Fixes https://github.com/RPCS3/rpcs3/issues/6662