### PR TITLE
Restore experimental optimized operators &= |= ^= for se_t

### DIFF
--- a/rpcs3/util/endian.hpp
+++ b/rpcs3/util/endian.hpp
@@ -252,6 +252,12 @@ namespace stx
 		template <typename T1>
 		se_t& operator&=(const T1& rhs)
 		{
+			if constexpr (std::is_integral_v<T>)
+			{
+				m_data = std::bit_cast<stype, T>(static_cast<T>(std::bit_cast<T>(m_data) & std::bit_cast<T>(static_cast<se_t>(rhs))));
+				return *this;
+			}
+
 			*this = value() & rhs;
 			return *this;
 		}
@@ -259,6 +265,12 @@ namespace stx
 		template <typename T1>
 		se_t& operator|=(const T1& rhs)
 		{
+			if constexpr (std::is_integral_v<T>)
+			{
+				m_data = std::bit_cast<stype, T>(static_cast<T>(std::bit_cast<T>(m_data) | std::bit_cast<T>(static_cast<se_t>(rhs))));
+				return *this;
+			}
+
 			*this = value() | rhs;
 			return *this;
 		}
@@ -266,6 +278,12 @@ namespace stx
 		template <typename T1>
 		se_t& operator^=(const T1& rhs)
 		{
+			if constexpr (std::is_integral_v<T>)
+			{
+				m_data = std::bit_cast<stype, T>(static_cast<T>(std::bit_cast<T>(m_data) ^ std::bit_cast<T>(static_cast<se_t>(rhs))));
+				return *this;
+			}
+
 			*this = value() ^ rhs;
 			return *this;
 		}

--- a/rpcs3/util/endian.hpp
+++ b/rpcs3/util/endian.hpp
@@ -199,9 +199,20 @@ namespace stx
 		{
 			using R = simple_t<T2>;
 
-			if constexpr ((std::is_integral_v<T> || std::is_enum_v<T>) && (std::is_integral_v<R> || std::is_enum_v<R>) && sizeof(T) >= sizeof(R))
+			if constexpr ((std::is_integral_v<T> || std::is_enum_v<T>) && (std::is_integral_v<R> || std::is_enum_v<R>))
 			{
-				return std::bit_cast<type>(m_data) == std::bit_cast<type>(static_cast<se_t>(rhs));
+				if constexpr (sizeof(T) >= sizeof(R))
+				{
+					if constexpr (std::is_enum_v<T> && std::is_convertible_v<T, int> && std::is_convertible_v<R, int>)
+					{
+						using under = std::underlying_type_t<T>;
+						return std::bit_cast<under>(m_data) == std::bit_cast<under>(static_cast<se_t<under, Swap>>(rhs));
+					}
+					else
+					{
+						return std::bit_cast<type>(m_data) == std::bit_cast<type>(static_cast<se_t>(rhs));
+					}
+				}
 			}
 
 			// Keep outside of if constexpr to make sure it fails on invalid comparison


### PR DESCRIPTION
They were removed approximately 3 years ago due to their rarity.