### PR TITLE
vk: Stability fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -839,7 +839,7 @@ namespace rsx
 					{
 						// Width is calculated in the coordinate-space of the requester; normalize
 						info.src_x = (info.src_x * required_bpp) / surface_bpp;
-						info.width = (info.width * required_bpp) / surface_bpp;
+						info.width = align(info.width * required_bpp, surface_bpp) / surface_bpp;
 					}
 
 					result.push_back(info);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -44,8 +44,8 @@
 
 #define VK_NUM_DESCRIPTOR_BINDINGS (VERTEX_TEXTURES_FIRST_BIND_SLOT + 4)
 
-#define FRAME_PRESENT_TIMEOUT 1000000ull // 1 second
-#define GENERAL_WAIT_TIMEOUT  100000ull  // 100ms
+#define FRAME_PRESENT_TIMEOUT 10000000ull // 10 seconds
+#define GENERAL_WAIT_TIMEOUT  2000000ull  // 2 seconds
 
 namespace rsx
 {


### PR DESCRIPTION
- Handle descriptor reset in thread::end to allow asynchronous flips to safely occur in a begin-end cycle without crashing the drivers.
- Align width up from surface cache before bpp normalization to avoid a result of 0 width.
- Increase fence/event timeout to multiple seconds.  It is possible for the driver thread to "starve" if the emulator is compiling LLVM modules with all threads, causing a small timeout to fail.

Fixes https://github.com/RPCS3/rpcs3/issues/6597
Also fixes a spurious crash in GT6 after the attract video