### PR TITLE
[DRAFT] input: reset pads with some delay after cellPadInit was called

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -47,6 +47,9 @@ error_code cellPadInit(u32 max_connect)
 
 	config->max_connect = std::min<u32>(max_connect, CELL_PAD_MAX_PORT_NUM);
 	config->port_setting.fill(CELL_PAD_SETTING_PRESS_OFF | CELL_PAD_SETTING_SENSOR_OFF);
+
+	Emu.GetCallbacks().reset_pads(Emu.GetTitleID());
+
 	return CELL_OK;
 }
 

--- a/rpcs3/pad_thread.cpp
+++ b/rpcs3/pad_thread.cpp
@@ -183,6 +183,7 @@ void pad_thread::ThreadFunc()
 		if (reset && reset.exchange(false))
 		{
 			Init();
+			std::this_thread::sleep_for(100ms); // Add some delay to simulate ps3 pad initialization
 		}
 
 		u32 connected_devices = 0;


### PR DESCRIPTION
This should fix the simpsons and the godfather initial input issues.
I couldn't find any other way for now.

May relate to #6093