### PR TITLE
rsx: Optimize FIFO PUT masking, Flush GET before semaphore_acquire

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -131,7 +131,7 @@ namespace rsx
 			void inc_get(bool wait);
 			void set_get(u32 get);
 			void set_put(u32 put);
-			u32 read_put();
+			template <bool = true> u32 read_put();
 
 			void read(register_pair& data);
 			inline bool read_unsafe(register_pair& data);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2334,6 +2334,12 @@ namespace rsx
 		//verify (HERE), async_tasks_pending.load() == 0;
 	}
 
+	void thread::flush_fifo()
+	{
+		// Make sure GET value is exposed before sync points
+		fifo_ctrl->sync_get();
+	}
+
 	void thread::read_barrier(u32 memory_address, u32 memory_range)
 	{
 		zcull_ctrl->read_barrier(this, memory_address, memory_range);

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -518,6 +518,7 @@ namespace rsx
 		u32 restore_point = 0;
 		atomic_t<bool> external_interrupt_lock{ false };
 		atomic_t<bool> external_interrupt_ack{ false };
+		void flush_fifo();
 
 		// Performance approximation counters
 		struct

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -65,13 +65,15 @@ namespace rsx
 			rsx->sync_point_request = true;
 			const u32 addr = get_address(method_registers.semaphore_offset_406e(), method_registers.semaphore_context_dma_406e());
 
-			const auto& sema = vm::_ref<atomic_t<be_t<u32>>>(addr);
+			const auto& sema = vm::_ref<atomic_be_t<u32>>(addr);
 
 			// TODO: Remove vblank semaphore hack
-			if (sema.load() == arg || addr == rsx->ctxt_addr + 0x30) return;
+			if (sema == arg || addr == rsx->ctxt_addr + 0x30) return;
+
+			rsx->flush_fifo();
 
 			u64 start = get_system_time();
-			while (sema.load() != arg)
+			while (sema != arg)
 			{
 				if (Emu.IsStopped())
 					return;


### PR DESCRIPTION
* Update GET value as it reaches semaphore_acquire -
Since the command progrerssed to the first or more argument of the command, it incremented GET.
This can techincally be used to locate if RSX is acquiring a semaphore by reading GET's value.
* Remove redundent PUT masking operations, reduce to a single one at command start.