### PR TITLE
rsx: Explicity describe transfer regions for both source and destination blocks

### DIFF
--- a/Utilities/geometry.h
+++ b/Utilities/geometry.h
@@ -618,7 +618,13 @@ struct coord_base
 	{
 	}
 
-	constexpr coord_base(T x, T y, T width, T height) : x{ x }, y{ y }, width{ width }, height{ height }
+	constexpr coord_base(const coord_base<T>& other)
+		: position{ other.position }, size{ other.size }
+	{
+	}
+
+	constexpr coord_base(T x, T y, T width, T height)
+		: x{ x }, y{ y }, width{ width }, height{ height }
 	{
 	}
 

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -32,22 +32,8 @@ namespace rsx
 		bool is_depth = false;
 		bool is_clipped = false;
 
-		u16 src_x = 0;
-		u16 src_y = 0;
-		u16 dst_x = 0;
-		u16 dst_y = 0;
-		u16 width = 0;
-		u16 height = 0;
-
-		areai get_src_area() const
-		{
-			return coordi{ {src_x, src_y}, {width, height} };
-		}
-
-		areai get_dst_area() const
-		{
-			return coordi{ {dst_x, dst_y}, {width, height} };
-		}
+		coordu src_area;
+		coordu dst_area;
 	};
 
 	template <typename surface_type>


### PR DESCRIPTION
Due to historical design decisions, transfer descriptors had to be based on one of the two surfaces, source or destination, even in cases where it made no sense to do so. When adding in some new functionality, this problem became very obvious as the descriptors are clearly rebased inconsistently. This commit explicitly defines two separate regions for the incoming and outgoing surfaces, making things much easier to work with. An optional transform descriptor is included to make porting old logic easier.
Some incoming new functionality relies on this working correctly, so I'd like to get it set up for extensive regression testing. Might also fix some strange texture cache bugs introduced in the new texture cache.