### PR TITLE
Fix mmjoystick log spam

### DIFF
--- a/rpcs3/evdev_joystick_handler.h
+++ b/rpcs3/evdev_joystick_handler.h
@@ -367,7 +367,7 @@ private:
 protected:
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
 	void get_mapping(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;
-	void apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad);
+	void apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;
 	bool get_is_left_trigger(u64 keyCode) override;
 	bool get_is_right_trigger(u64 keyCode) override;
 	bool get_is_left_stick(u64 keyCode) override;

--- a/rpcs3/mm_joystick_handler.cpp
+++ b/rpcs3/mm_joystick_handler.cpp
@@ -440,7 +440,8 @@ bool mm_joystick_handler::GetMMJOYDevice(int index, MMJOYDevice* dev)
 	js_info.dwFlags = JOY_RETURNALL;
 	joyGetDevCaps(index, &js_caps, sizeof(js_caps));
 
-	if (joyGetPosEx(index, &js_info) != JOYERR_NOERROR)
+	dev->device_status = joyGetPosEx(index, &js_info);
+	if (dev->device_status != JOYERR_NOERROR)
 		return false;
 
 	char drv[32];
@@ -495,8 +496,10 @@ PadHandlerBase::connection mm_joystick_handler::update_connection(const std::sha
 	if (!dev)
 		return connection::disconnected;
 
-	MMRESULT status = joyGetPosEx(dev->device_id, &dev->device_info);
-	if (status == JOYERR_NOERROR && GetMMJOYDevice(dev->device_id, dev.get()))
+	const auto old_status = dev->device_status;
+	dev->device_status    = joyGetPosEx(dev->device_id, &dev->device_info);
+
+	if (dev->device_status == JOYERR_NOERROR && (old_status == JOYERR_NOERROR || GetMMJOYDevice(dev->device_id, dev.get())))
 	{
 		return connection::connected;
 	}

--- a/rpcs3/mm_joystick_handler.h
+++ b/rpcs3/mm_joystick_handler.h
@@ -92,6 +92,7 @@ class mm_joystick_handler final : public PadHandlerBase
 		std::string device_name{ "" };
 		JOYINFOEX device_info{};
 		JOYCAPS device_caps{};
+		MMRESULT device_status = JOYERR_UNPLUGGED;
 		u64 trigger_left = 0;
 		u64 trigger_right = 0;
 		std::vector<u64> axis_left  = { 0,0,0,0 };


### PR DESCRIPTION
Fixes the constant mmjoystick log spam that was accidentally introduced with the pad handler refactoring a few weeks ago.
Due to a faulty function call the joysticks were constantly reconnecting during gameplay, which is only supposed happen if the controller was disconnected before.