### PR TITLE
Create emulator directories after changing dev_*** directories

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -197,23 +197,16 @@ bool pkg_install(const std::string& path, atomic_t<double>& sync)
 		archive_seek(packet.size, fs::seek_cur);
 	}
 
-	// If false, an existing directory is being overwritten: cannot cancel the operation
-	bool was_null = true;
-
 	// Get full path and create the directory
 	const std::string dir = Emulator::GetHddDir() + "game/" + install_id + '/';
 
+	// If false, an existing directory is being overwritten: cannot cancel the operation
+	const bool was_null = !fs::is_dir(dir);
+
 	if (!fs::create_path(dir))
 	{
-		if (fs::g_tls_error == fs::error::exist)
-		{
-			was_null = false;
-		}
-		else
-		{
-			LOG_ERROR(LOADER, "PKG: Could not create the installation directory %s", dir);
-			return false;
-		}
+		LOG_ERROR(LOADER, "PKG: Could not create the installation directory %s", dir);
+		return false;
 	}
 
 	// Allocate buffer with BUF_SIZE size or more if required

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -203,7 +203,7 @@ bool pkg_install(const std::string& path, atomic_t<double>& sync)
 	// Get full path and create the directory
 	const std::string dir = Emulator::GetHddDir() + "game/" + install_id + '/';
 
-	if (!fs::create_dir(dir))
+	if (!fs::create_path(dir))
 	{
 		if (fs::g_tls_error == fs::error::exist)
 		{

--- a/rpcs3/rpcs3qt/vfs_dialog.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog.cpp
@@ -4,6 +4,8 @@
 #include <QPushButton>
 #include <QMessageBox>
 
+#include "Emu/System.h"
+
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent)
@@ -60,6 +62,13 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_pt
 				static_cast<vfs_dialog_tab*>(tabs->widget(i))->SetSettings();
 			}
 			m_emu_settings->SaveSettings();
+
+			// Recreate folder structure for new VFS paths
+			if (Emu.IsStopped())
+			{
+				Emu.Init();
+			}
+
 			accept();
 		}
 		else if (button == buttons->button(QDialogButtonBox::Close))


### PR DESCRIPTION
Corrects the case where it was (usually) not possible to install games/firmware after changing path dev_hdd0 (and potentially others) in settings, and required a restart instead.

# Reproduction steps
1. Launch RPCS3 with `$(EmulatorDir) set to eg. `D\RPCS3`.
2. Open Virtual File System settings.
3. Change `$(EmulatorDir)` to any new empty folder, eg. `D:\RPCS3\NewDirForFiles` and click Save.
4. Attempt to install any game.

# Observed result
Installation fails, because directories are not created recursively and a parent directory does not exist.

# Expected result
Installation proceeds as normal.