### PR TITLE
Make windows_file::stat return the same mtime as fs::stat

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -966,7 +966,7 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 			info.is_writable = (basic_info.FileAttributes & FILE_ATTRIBUTE_READONLY) == 0;
 			info.size = this->size();
 			info.atime = to_time(basic_info.LastAccessTime);
-			info.mtime = to_time(basic_info.ChangeTime);
+			info.mtime = to_time(basic_info.LastWriteTime);
 			info.ctime = info.mtime;
 
 			if (info.atime < info.mtime)


### PR DESCRIPTION
There's no reason these two functions should return different mtime on windows, and also ChangeTime cannot be influenced by fs_utime, only LastWriteTime can.

This fixes MGS4 disc versions always deleting stage dat files on boot because mtime doesnt match expected (set by fs_utime) on windows, forcing a chapter reinstall every boot.