### PR TITLE
Improvements to misc failure conditions

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -177,6 +177,27 @@ static fs::error to_error(int e)
 
 #endif
 
+static std::string path_append(std::string_view path, std::string_view more)
+{
+	std::string result;
+
+	if (const size_t src_slash_pos = path.find_last_not_of('/'); src_slash_pos != path.npos)
+	{
+		path.remove_suffix(path.length() - src_slash_pos - 1);
+		result = path;
+	}
+
+	result.push_back('/');
+
+	if (const size_t dst_slash_pos = more.find_first_not_of('/'); dst_slash_pos != more.npos)
+	{
+		more.remove_prefix(dst_slash_pos);
+		result.append(more);
+	}
+
+	return result;
+}
+
 namespace fs
 {
 	thread_local error g_tls_error = error::ok;
@@ -1586,7 +1607,7 @@ bool fs::remove_all(const std::string& path, bool remove_root)
 
 			if (entry.is_directory == false)
 			{
-				if (!remove_file(path + '/' + entry.name))
+				if (!remove_file(path_append(path, entry.name)))
 				{
 					return false;
 				}
@@ -1594,7 +1615,7 @@ bool fs::remove_all(const std::string& path, bool remove_root)
 
 			if (entry.is_directory == true)
 			{
-				if (!remove_all(path + '/' + entry.name))
+				if (!remove_all(path_append(path, entry.name)))
 				{
 					return false;
 				}
@@ -1632,7 +1653,7 @@ u64 fs::get_dir_size(const std::string& path, u64 rounding_alignment)
 
 		if (entry.is_directory == true)
 		{
-			result += get_dir_size(path + '/' + entry.name, rounding_alignment);
+			result += get_dir_size(path_append(path, entry.name), rounding_alignment);
 		}
 	}
 

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -128,6 +128,7 @@ static fs::error to_error(DWORD e)
 	case ERROR_SHARING_VIOLATION: return fs::error::acces;
 	case ERROR_DIR_NOT_EMPTY: return fs::error::notempty;
 	case ERROR_NOT_READY: return fs::error::noent;
+	case ERROR_FILENAME_EXCED_RANGE: return fs::error::toolong;
 	//case ERROR_INVALID_PARAMETER: return fs::error::inval;
 	default: fmt::throw_exception("Unknown Win32 error: %u.", e);
 	}
@@ -1786,6 +1787,7 @@ void fmt_class_string<fs::error>::format(std::string& out, u64 arg)
 		case fs::error::notempty: return "Not empty";
 		case fs::error::readonly: return "Read only";
 		case fs::error::isdir: return "Is a directory";
+		case fs::error::toolong: return "Path too long";
 		}
 
 		return unknown;

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -515,6 +515,7 @@ namespace fs
 		notempty,
 		readonly,
 		isdir,
+		toolong,
 	};
 
 	// Error code returned

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -44,6 +44,14 @@ void progress_dialog::SetValue(int progress)
 	QProgressDialog::setValue(value);
 }
 
+void progress_dialog::SignalFailure()
+{
+#ifdef _WIN32
+	m_tb_progress->stop();
+#endif
+	// TODO: Implement an equivalent for Linux, if possible
+}
+
 #ifdef HAVE_QTDBUS
 void progress_dialog::UpdateProgress(int progress, bool disable)
 {

--- a/rpcs3/rpcs3qt/progress_dialog.h
+++ b/rpcs3/rpcs3qt/progress_dialog.h
@@ -20,6 +20,7 @@ public:
 	progress_dialog(const QString &windowTitle, const QString &labelText, const QString &cancelButtonText, int minimum, int maximum, QWidget *parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
 	~progress_dialog();
 	void SetValue(int progress);
+	void SignalFailure();
 
 private:
 #ifdef _WIN32


### PR DESCRIPTION
This PR corrects miscellaneous issues I spotted when trying to make RPCS3 break by feeding it very long paths on Windows. Those are:

- Several WinAPI functions throw `ERROR_FILENAME_EXCED_RANGE` when the input file name/directory name is longer than the function accepts (typically `MAX_PATH`). This error was not recognized by RPCS3, thus making it throw an "unknown error" exception, effectively crashing the emulator. Even worse, by relocating `$(EmulatorDir)` to such long path RPCS3 would consistently crash on startup, forcing the user to fix config files by hand!
After those changes, RPCS3 will gracefully report failure with a "Path too long" message.
* `pkg_install` was totally oblivious of installation failure and reported "success" to the user even if some files failed to unpack (due to eg. long path or permission issues). I made it properly report failure and showing it to the user via:
  - "Installation failure" message box
  - Stopping the taskbar progress bar (on Windows), effectively turning it red - this is commonly used eg. by Explorer to signal failure
* Several methods in `File.cpp` concatenated paths manually via `a + '/' + b`. This could result in double slashes, which normally should not be a problem but I noticed Windows was struggling with deleting files with such double slashes in path. Thankfully, fixing it by providing a dedicated `path_append` function which is aware of those cases was quick enough.

In the future I intend to opt-in RPCS3 for Win10 long paths - but for now I am facing some issues trying to get manifest generation to work. This is also not directly related to any issues fixed, so IMO it's better to leave it for now.