### PR TITLE
Lightweight putllc() for non-TSX if no data changed

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1943,8 +1943,8 @@ bool spu_thread::process_mfc_cmd()
 			{
 				if (cmp_rdata(rdata, to_write))
 				{
-					// No changes, just unlink data
-					result = 1;
+					// Pseudo write back: Check memory change without lock
+					result = cmp_rdata(rdata, data) && vm::reservation_acquire(raddr, 128).compare_and_swap_test(rtime, rtime + 128);
 				}
 				else
 				{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -40,25 +40,6 @@ static FORCE_INLINE bool cmp_rdata(const decltype(spu_thread::rdata)& lhs, const
 	return !(r._u64[0] | r._u64[1]);
 }
 
-static FORCE_INLINE bool cmp3_rdata(const decltype(spu_thread::rdata)& copy1, const decltype(spu_thread::rdata)& copy2, const decltype(spu_thread::rdata)& copy3)
-{
-	v128 a, b, c;
-
-	a = (copy1[0] ^ copy2[0]) | (copy2[0] ^ copy3[0]);
-	b = (copy1[1] ^ copy2[1]) | (copy2[1] ^ copy3[1]);
-	c = a | b;
-	a = (copy1[2] ^ copy2[2]) | (copy2[2] ^ copy3[2]);
-	b = (copy1[3] ^ copy2[3]) | (copy2[3] ^ copy3[3]);
-	c = c | a | b;
-	a = (copy1[4] ^ copy2[4]) | (copy2[4] ^ copy3[4]);
-	b = (copy1[5] ^ copy2[5]) | (copy2[5] ^ copy3[5]);
-	c = c | a | b;
-	a = (copy1[6] ^ copy2[6]) | (copy2[6] ^ copy3[6]);
-	b = (copy1[7] ^ copy2[7]) | (copy2[7] ^ copy3[7]);
-	c = c | a | b;
-	return !(c._u64[0] | c._u64[1]);
-}
-
 static FORCE_INLINE void mov_rdata(decltype(spu_thread::rdata)& dst, const decltype(spu_thread::rdata)& src)
 {
 	{
@@ -84,6 +65,87 @@ static FORCE_INLINE void mov_rdata(decltype(spu_thread::rdata)& dst, const declt
 		const v128 data1 = src[7];
 		dst[6] = data0;
 		dst[7] = data1;
+	}
+}
+
+u64 x_cnt = 0;		// DEBUG
+u64 x_success = 0;	// DEBUG
+u64 x_diff = 0;		// DEBUG
+u64 x_multi = 0;	// DEBUG
+u64 x_zero = 0;		// DEBUG
+u64 x_unknown = 0;	// DEBUG
+
+static FORCE_INLINE int cmpxchg_rdata(decltype(spu_thread::rdata)& dst, decltype(spu_thread::rdata)& cmp, const decltype(spu_thread::rdata)& with)
+{
+	int diffcnt = 0, pos, i, result;
+	bool ok, cres;
+	v128 *d,c,w;
+
+	if (x_cnt % 1000000 == 0)		// DEBUG
+	{					// DEBUG
+		LOG_ERROR(GENERAL,"cmpxchg(): cnt:%llu, success:%llu, zero:%llu, multi:%llu, diff:%llu, ???:%llu",x_cnt,x_success,x_zero,x_multi,x_diff,x_unknown);
+	}					// DEBUG
+	x_cnt++;				// DEBUG
+
+	for (i = 0; i < 8; i++)
+	{
+		if ((cmp[i]._u64[0] ^ with[i]._u64[0]) | (cmp[i]._u64[1] ^ with[i]._u64[1]))
+		{
+			diffcnt++;
+			pos = i;
+		}
+	};
+
+	if (diffcnt == 1) {
+		d = &dst[pos];
+		c = cmp[pos];
+		w = with[pos];
+
+		cres = cmp_rdata(dst,cmp);	// DEBUG
+
+		__asm__ __volatile__
+		(
+			"lock cmpxchg16b %1\n\t"
+			"setz %0"
+			: "=q" ( ok )
+			, "+m" ( *d )
+			, "+d" ( c._u64[1] )
+			, "+a" ( c._u64[0] )
+			: "c" ( w._u64[1] )
+			, "b" ( w._u64[0] )
+			: "cc", "memory"
+		);
+
+		if (ok)				// DEBUG
+		{				// DEBUG
+			if (cres)		// DEBUG
+			{			// DEBUG
+				x_success++;	// DEBUG
+			}			// DEBUG
+			else			// DEBUG
+			{			// DEBUG
+				x_unknown++;	// DEBUG
+			}			// DEBUG
+		}				// DEBUG
+		else				// DEBUG
+		{				// DEBUG
+			x_diff++;		// DEBUG
+		}				// DEBUG
+
+		return ok ? 1 : 0;
+	}
+	else
+	{
+		if (diffcnt)			// DEBUG
+		{				// DEBUG
+			x_multi++;		// DEBUG
+		}				// DEBUG
+		else				// DEBUG
+		{				// DEBUG
+			x_zero++;		// DEBUG
+		}				// DEBUG
+
+		return diffcnt ? -1 : 1;
 	}
 }
 
@@ -1963,17 +2025,14 @@ bool spu_thread::process_mfc_cmd()
 				auto& res = vm::reservation_lock(raddr, 128);
 				const u64 old_time = res.load() & -128;
 
-				if (rtime != old_time)
+				if (rtime == old_time)
 				{
-					res.release(old_time);
+					result = cmpxchg_rdata(data, rdata, to_write);
 				}
-				else if (cmp3_rdata(data, rdata, to_write))
+
+				if (result == -1)
 				{
-					result = 1;
-					res.release(old_time);
-				}
-				else
-				{
+					result = 0;
 					*reinterpret_cast<atomic_t<u32>*>(&data) += 0;
 
 					// Full lock (heavyweight)
@@ -1985,8 +2044,9 @@ bool spu_thread::process_mfc_cmd()
 						mov_rdata(data, to_write);
 						result = 1;
 					}
-					res.release(old_time + (long long)(result << 7));
 				}
+
+				res.release(old_time + (long long)(result << 7));
 			}
 		}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -68,6 +68,87 @@ static FORCE_INLINE void mov_rdata(decltype(spu_thread::rdata)& dst, const declt
 	}
 }
 
+u64 x_cnt = 0;		// DEBUG
+u64 x_success = 0;	// DEBUG
+u64 x_diff = 0;		// DEBUG
+u64 x_multi = 0;	// DEBUG
+u64 x_zero = 0;		// DEBUG
+u64 x_unknown = 0;	// DEBUG
+
+static FORCE_INLINE int cmpxchg_rdata(decltype(spu_thread::rdata)& dst, decltype(spu_thread::rdata)& cmp, const decltype(spu_thread::rdata)& with)
+{
+	int diffcnt = 0, pos, i, result;
+	bool ok, cres;
+	v128 *d,c,w;
+
+	if (x_cnt % 1000000 == 0)		// DEBUG
+	{					// DEBUG
+		LOG_ERROR(GENERAL,"cmpxchg(): cnt:%llu, success:%llu, zero:%llu, multi:%llu, diff:%llu, ???:%llu",x_cnt,x_success,x_zero,x_multi,x_diff,x_unknown);
+	}					// DEBUG
+	x_cnt++;				// DEBUG
+
+	for (i = 0; i < 8; i++)
+	{
+		if ((cmp[i]._u64[0] ^ with[i]._u64[0]) | (cmp[i]._u64[1] ^ with[i]._u64[1]))
+		{
+			diffcnt++;
+			pos = i;
+		}
+	};
+
+	if (diffcnt == 1) {
+		d = &dst[pos];
+		c = cmp[pos];
+		w = with[pos];
+
+		cres = cmp_rdata(dst,cmp);	// DEBUG
+
+		__asm__ __volatile__
+		(
+			"lock cmpxchg16b %1\n\t"
+			"setz %0"
+			: "=q" ( ok )
+			, "+m" ( *d )
+			, "+d" ( c._u64[1] )
+			, "+a" ( c._u64[0] )
+			: "c" ( w._u64[1] )
+			, "b" ( w._u64[0] )
+			: "cc", "memory"
+		);
+
+		if (ok)				// DEBUG
+		{				// DEBUG
+			if (cres)		// DEBUG
+			{			// DEBUG
+				x_success++;	// DEBUG
+			}			// DEBUG
+			else			// DEBUG
+			{			// DEBUG
+				x_unknown++;	// DEBUG
+			}			// DEBUG
+		}				// DEBUG
+		else				// DEBUG
+		{				// DEBUG
+			x_diff++;		// DEBUG
+		}				// DEBUG
+
+		return ok ? 1 : 0;
+	}
+	else
+	{
+		if (diffcnt)			// DEBUG
+		{				// DEBUG
+			x_multi++;		// DEBUG
+		}				// DEBUG
+		else				// DEBUG
+		{				// DEBUG
+			x_zero++;		// DEBUG
+		}				// DEBUG
+
+		return diffcnt ? -1 : 1;
+	}
+}
+
 extern u64 get_timebased_time();
 extern u64 get_system_time();
 
@@ -1939,13 +2020,19 @@ bool spu_thread::process_mfc_cmd()
 					}
 				}
 			}
-			else if (auto& data = vm::_ref<decltype(rdata)>(addr); rtime == (vm::reservation_acquire(raddr, 128) & -128) && cmp_rdata(rdata, data))
+			else if (auto& data = vm::_ref<decltype(rdata)>(addr); rtime == (vm::reservation_acquire(raddr, 128) & -128))
 			{
 				auto& res = vm::reservation_lock(raddr, 128);
 				const u64 old_time = res.load() & -128;
 
 				if (rtime == old_time)
 				{
+					result = cmpxchg_rdata(data, rdata, to_write);
+				}
+
+				if (result == -1)
+				{
+					result = 0;
 					*reinterpret_cast<atomic_t<u32>*>(&data) += 0;
 
 					// Full lock (heavyweight)
@@ -1955,18 +2042,11 @@ bool spu_thread::process_mfc_cmd()
 					if (cmp_rdata(rdata, data))
 					{
 						mov_rdata(data, to_write);
-						res.release(old_time + 128);
 						result = 1;
 					}
-					else
-					{
-						res.release(old_time);
-					}
 				}
-				else
-				{
-					res.release(old_time);
-				}
+
+				res.release(old_time + (long long)(result << 7));
 			}
 		}
 


### PR DESCRIPTION
Another one for discussion ... Again developed on Linux.

I noticed heavy contention in SPU threads because of excessive usage
of vm::writer_lock(). It boils down to the fact that some games make
heavy use of getllar() & putllc() and my machine has no TSX. The function
pair is reading/writing 128 bytes between main memory and SPU local
memory and a writeback is encapsulated into defensive locking logic.

This patch tries to mitigate the situation by establishing a workaround.
To recover the workflow:

1. getllar() links to a full cache line (128 bytes) of shared data
2. Data is copied into local SPU memory and can be modified
3. Some data inside block is modified
4. putllc() writes the data back if main memory has not changed

When executing step 4 we can distinguish 3 cases

a. No data has been changed: Why would we want to write it back?

b. Only one of the 8 16-bytes data blocks has been changed. In this case
we can use cmpxchg16b to realize an conditional atomic writeback without
a lock. This is the lucky punch.

c. Multiple 16-bytes data blocks have been changed. For that we can
fall back to the current heavyweight implementation

For a successful patch it is essential that path a/b is in use much more
often than path c. Some numbers:

GoW 3 menu screen:
- No changes: 94,7%
- Single 16-bytes block changes: 4,9%
- Multi block changes: 0,3%

Bomberman Ultra menu screen:
- No changes: 27,6%
- Single 16-bytes block changes: 60,8%
- Multi block changes: 11,6%

REMARK! Of course there might be several caveats but I want to outline a
tricky one about the implementation. To enter path b the patch does not
check changes to main memory but only to the linked backup data of the
cache line. That gives a special case not covered by now. What if we
discover that local block 1 has changed and write the data back while
another thread simultanously changes block 8 of the same shared data?
From a noob & performance perspective I would say that this does not
matter.

Attached you will find a debugging enabled patch that writes some numbers
into the error log. These are:

```
cnt:     number of putllc() calls
success: number of single 16-bytes block writebacks
zero:    number of suppressed writebacks
multi:   number of full 128 bytes writebacks
diff:    number of changes to main memory between getllar() and putllc()
???:     number of writebacks where another block in the cache line changed
```

With the patch I have no problems going ingame into GoW 3. Performance
on my 2 core machine is too awful to give a good before/after comparison
(1-2fps). Maybe someone has time to check the PR and report numbers back.