### PR TITLE
SPU: Optimize DSYNC instruction

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1400,7 +1400,7 @@ void spu_recompiler::SYNC(spu_opcode_t op)
 void spu_recompiler::DSYNC(spu_opcode_t op)
 {
 	// This instruction forces all earlier load, store, and channel instructions to complete before proceeding.
-	SYNC(op);
+	c->mfence();
 }
 
 void spu_recompiler::MFSPR(spu_opcode_t op)

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -1396,7 +1396,6 @@ const std::vector<u32>& spu_recompiler_base::analyse(const be_t<u32>* ls, u32 en
 		}
 
 		case spu_itype::SYNC:
-		case spu_itype::DSYNC:
 		case spu_itype::STOP:
 		case spu_itype::STOPD:
 		{
@@ -1760,6 +1759,7 @@ const std::vector<u32>& spu_recompiler_base::analyse(const be_t<u32>* ls, u32 en
 			break;
 		}
 
+		case spu_itype::DSYNC:
 		case spu_itype::HEQ:
 		case spu_itype::HEQI:
 		case spu_itype::HGT:
@@ -6036,7 +6036,7 @@ public:
 	void DSYNC(spu_opcode_t op) //
 	{
 		// This instruction forces all earlier load, store, and channel instructions to complete before proceeding.
-		SYNC(op);
+		m_ir->CreateFence(llvm::AtomicOrdering::SequentiallyConsistent);
 	}
 
 	void MFSPR(spu_opcode_t op) //


### PR DESCRIPTION
This instruction *does not* enforce ordering of instruction-fetches, this means recompilers do not need to to invalidate the instruction stream after encountering it.

What this may potentialy benefits:
* Less, larger SPU functions would be compiled.
* Because this instruction is being used nearly 100-percent of the times after GETLLAR and spu functions compilation isn't a short process, it may reduce the time spent in atomic loops which may improve success rates.