### PR TITLE
rsx: Recover from invalid writes to CELL_GCM_NV4097_SET_INDEX_ARRAY_DMA

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -131,6 +131,7 @@ namespace rsx
 			void inc_get(bool wait);
 			void set_get(u32 get);
 			void set_put(u32 put);
+			void abort();
 			template <bool = true> u32 read_put();
 
 			void read(register_pair& data);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2340,6 +2340,15 @@ namespace rsx
 		fifo_ctrl->sync_get();
 	}
 
+	void thread::recover_fifo()
+	{
+		// Error. Should reset the queue
+		fifo_ctrl->set_get(restore_point);
+		fifo_ret_addr = saved_fifo_ret;
+		std::this_thread::sleep_for(1ms);
+		invalid_command_interrupt_raised = false;
+	}
+
 	void thread::read_barrier(u32 memory_address, u32 memory_range)
 	{
 		zcull_ctrl->read_barrier(this, memory_address, memory_range);

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -519,6 +519,7 @@ namespace rsx
 		atomic_t<bool> external_interrupt_lock{ false };
 		atomic_t<bool> external_interrupt_ack{ false };
 		void flush_fifo();
+		void recover_fifo();
 
 		// Performance approximation counters
 		struct

--- a/rpcs3/Emu/RSX/gcm_enums.cpp
+++ b/rpcs3/Emu/RSX/gcm_enums.cpp
@@ -21,8 +21,8 @@ rsx::index_array_type rsx::to_index_array_type(u8 in)
 {
 	switch (in)
 	{
-	case 0: return rsx::index_array_type::u32;
-	case 1: return rsx::index_array_type::u16;
+	case CELL_GCM_DRAW_INDEX_ARRAY_TYPE_32: return rsx::index_array_type::u32;
+	case CELL_GCM_DRAW_INDEX_ARRAY_TYPE_16: return rsx::index_array_type::u16;
 	}
 	fmt::throw_exception("Unknown index array type %d" HERE, in);
 }

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -448,6 +448,13 @@ enum
 	CELL_GCM_SYSTEM_MODE_IOMAP_512MB = 1,
 };
 
+enum
+{
+	// Index Array Type
+	CELL_GCM_DRAW_INDEX_ARRAY_TYPE_32	= 0,
+	CELL_GCM_DRAW_INDEX_ARRAY_TYPE_16	= 1,
+};
+
 // GCM Texture
 enum
 {

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -713,6 +713,19 @@ namespace rsx
 			}
 		}
 
+		void check_index_array_dma(thread* rsx, u32 reg, u32 arg)
+		{
+			// Check if either location or index type are invalid
+			if (arg & ~(CELL_GCM_LOCATION_MAIN | (CELL_GCM_DRAW_INDEX_ARRAY_TYPE_16 << 4)))
+			{
+				// Ignore invalid value, recover
+				method_registers.registers[reg] = method_registers.register_previous_value;
+				rsx->invalid_command_interrupt_raised = true;
+
+				LOG_ERROR(RSX, "Invalid NV4097_SET_INDEX_ARRAY_DMA value: 0x%x", arg);
+			}
+		}
+
 		template<u32 index>
 		struct set_texture_dirty_bit
 		{
@@ -2911,6 +2924,7 @@ namespace rsx
 		bind_array<NV4097_SET_FOG_PARAMS, 1, 2, nv4097::set_ROP_state_dirty_bit>();
 		bind_range<NV4097_SET_VIEWPORT_SCALE, 1, 3, nv4097::set_viewport_dirty_bit>();
 		bind_range<NV4097_SET_VIEWPORT_OFFSET, 1, 3, nv4097::set_viewport_dirty_bit>();
+		bind<NV4097_SET_INDEX_ARRAY_DMA, nv4097::check_index_array_dma>();
 
 		//NV308A
 		bind_range<NV308A_COLOR, 1, 256, nv308a::color>();

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -45,6 +45,12 @@ namespace rsx
 		rsx->invalid_command_interrupt_raised = true;
 	}
 
+	void trace_method(thread* rsx, u32 _reg, u32 arg)
+	{
+		// For unknown yet valid methods
+		LOG_TRACE(RSX, "RSX method 0x%x (arg=0x%x)", _reg << 2, arg);
+	}
+
 	template<typename Type> struct vertex_data_type_from_element_type;
 	template<> struct vertex_data_type_from_element_type<float> { static const vertex_base_type type = vertex_base_type::f; };
 	template<> struct vertex_data_type_from_element_type<f16> { static const vertex_base_type type = vertex_base_type::sf; };
@@ -2798,7 +2804,11 @@ namespace rsx
 		bind_array<NV4097_SET_VERTEX_DATA4F_M, 1, 64, nullptr>();
 		bind_array<NV4097_SET_VERTEX_DATA1F_M, 1, 16, nullptr>();
 		bind_array<NV4097_SET_COLOR_KEY_COLOR, 1, 16, nullptr>();
-		bind_array<(0xac00 >> 2), 1, 16, nullptr>();  // Unknown texture control register
+
+		// Unknown (NV4097?)
+		bind<(0x171c >> 2), trace_method>();
+		bind_array<(0xac00 >> 2), 1, 16, trace_method>(); // Unknown texture control register
+		bind_array<(0xac40 >> 2), 1, 16, trace_method>();
 
 		// NV406E
 		bind<NV406E_SET_REFERENCE, nv406e::set_reference>();

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -117,8 +117,19 @@ namespace rsx
 		void semaphore_release(thread* rsx, u32 /*_reg*/, u32 arg)
 		{
 			rsx->sync();
-			rsx->sync_point_request = true;
-			const u32 addr = get_address(method_registers.semaphore_offset_406e(), method_registers.semaphore_context_dma_406e());
+
+			const u32 offset = method_registers.semaphore_offset_406e();
+			const u32 ctxt = method_registers.semaphore_context_dma_406e();
+
+			// By avoiding doing this on flip's semaphore release
+			// We allow last gcm's registers reset to occur in case of a crash
+			const bool is_flip_sema = (offset == 0x10 && ctxt == CELL_GCM_CONTEXT_DMA_SEMAPHORE_R);
+			if (!is_flip_sema)
+			{
+				rsx->sync_point_request = true;
+			}
+
+			const u32 addr = get_address(offset, ctxt);
 
 			if (LIKELY(g_use_rtm))
 			{


### PR DESCRIPTION
Hw tests reveal that any write with a bit set to 1 which are not bits 0 or 3 to register CELL_GCM_NV4097_SET_INDEX_ARRAY_DMA, results in an exception being raised at the write command.
Because the exception is raised at command write, that's where I decided to put the validation check.
This improves stability in Metal Gear Solid 4, allowing the renderer to continue after such crash.

Second commit improves FIFO recovery when the last semaphore came from a flip, allowing to reset registers using gcm's reset by ignoring the last semaphore_release (recovering from the first semaphore_acquire instead). Inspired by [flip commands sequence dump](https://github.com/elad335/myps3tests/blob/master/rsx_tests/cellGcmSetFlip%20internals/RPCS3.log)