### PR TITLE
mitigate use of cmpxchg() in FIFO_control::read_put()

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -31,7 +31,7 @@ namespace rsx
 		}
 
 		template <bool full>
-		u32 FIFO_control::read_put()
+		inline u32 FIFO_control::read_put()
 		{
 			if constexpr (!full)
 			{
@@ -39,7 +39,15 @@ namespace rsx
 			}
 			else
 			{
-				return m_ctrl->put.and_fetch(~3);
+				u32 put = m_ctrl->put;
+				if (put & 3)
+				{
+					return m_ctrl->put.and_fetch(~3);
+				}
+				else
+				{
+					return put;
+				}
 			}
 		}
 

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -40,13 +40,13 @@ namespace rsx
 			else
 			{
 				u32 put = m_ctrl->put;
-				if (put & 3)
+				if (LIKELY((put & 3) == 0))
 				{
-					return m_ctrl->put.and_fetch(~3);
+					return put;
 				}
 				else
 				{
-					return put;
+					return m_ctrl->put.and_fetch(~3);
 				}
 			}
 		}


### PR DESCRIPTION
FIFO_control::read() always starts with a read_put() statement that tries
to reset the two lower bits of m_ctrl->put. That is useless most of the
time. So just use it when really needed.

Bomberman Ultra gameplay before:
```

 16,40%     0,00%  rsx::thread  [unknown]  [.] 0000000000000000
 11,57%    10,47%  rsx::thread  rpcs3      [.] rsx::thread::run_FIFO
  9,89%     0,00%  rsx::thread  [unknown]  [.] 0x00401f0fffc832d4
  9,89%     0,00%  rsx::thread  rpcs3      [.] named_thread<VKGSRender>::~named_thread
  8,38%     8,23%  rsx::thread  rpcs3      [.] rsx::FIFO::FIFO_control::read
```

Bomberman Ultra gameplay after:
```

 17,03%     0,01%  rsx::thread  [unknown]  [k] 0000000000000000
 12,31%    11,20%  rsx::thread  rpcs3      [.] rsx::thread::run_FIFO
 11,04%     0,00%  rsx::thread  [unknown]  [.] 0x00401f0fffc832d4
 11,04%     0,00%  rsx::thread  rpcs3      [.] named_thread<VKGSRender>::~named_thread
  4,18%     4,07%  rsx::thread  rpcs3      [.] rsx::FIFO::FIFO_control::read
```

GoW 3 menu before
```

 26,03%    25,42%  rsx::thread  rpcs3      [.] rsx::FIFO::FIFO_control::read
 24,31%     0,00%  rsx::thread  [unknown]  [.] 0x00401f0fffc832d4
 24,31%     0,00%  rsx::thread  rpcs3      [.] named_thread<VKGSRender>::~named_thread
 21,27%    20,56%  rsx::thread  rpcs3      [.] VKGSRender::do_local_task
```

GoW 3 menu after

```
 26,40%     0,00%  rsx::thread  [unknown]  [.] 0x00401f0fffc832d4
 26,40%     0,00%  rsx::thread  rpcs3      [.] named_thread<VKGSRender>::~named_thread
 23,66%    22,78%  rsx::thread  rpcs3      [.] VKGSRender::do_local_task
 16,60%    15,81%  rsx::thread  rpcs3      [.] rsx::FIFO::FIFO_control::read
```