### PR TITLE
Linux: Change default Sleep Timers accuracy to host

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -252,12 +252,13 @@ public:
 			remaining = usec - passed;
 #ifdef __linux__
 			// NOTE: Assumption that timer initialization has succeeded
-			u64 host_min_quantum = is_usleep && remaining <= 1000 ? 16 : 50;
+			u64 host_min_quantum = is_usleep && remaining <= 1000 ? 10 : 50;
 #else
 			// Host scheduler quantum for windows (worst case)
 			// NOTE: On ps3 this function has very high accuracy
 			constexpr u64 host_min_quantum = 500;
 #endif
+			// TODO: Tune for other non windows operating sytems
 
 			if (g_cfg.core.sleep_timers_accuracy < (is_usleep ? sleep_timers_accuracy_level::_usleep : sleep_timers_accuracy_level::_all_timers))
 			{

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -419,7 +419,12 @@ struct cfg_root : cfg::node
 		cfg::_bool hle_lwmutex{this, "HLE lwmutex"}; // Force alternative lwmutex/lwcond implementation
 
 		cfg::_int<10, 1000> clocks_scale{this, "Clocks scale", 100}; // Changing this from 100 (percentage) may affect game speed in unexpected ways
-		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{this, "Sleep Timers Accuracy", sleep_timers_accuracy_level::_usleep};
+		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{this, "Sleep Timers Accuracy", 
+#ifdef __linux__
+		sleep_timers_accuracy_level::_as_host};
+#else
+		sleep_timers_accuracy_level::_usleep};
+#endif
 	} core{this};
 
 	struct node_vfs : cfg::node


### PR DESCRIPTION
The previous worst case for the host setting (Nier) now performs the same on both the host and the usleep setting, so let's just make host the default.
A few games are faster with host that previously required usleep (Journey)

This won't change existing configs.

Also sets the host_min_quantum to the true value and restores a lost `TODO:` comment