### PR TITLE
spu-disasm Improvement, sys_cond Fix, More verbose logging for TrophyRegisterContext

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -232,12 +232,12 @@ error_code sceNpTrophyCreateContext(vm::ptr<u32> context, vm::cptr<SceNpCommunic
 		return SCE_NP_TROPHY_ERROR_NOT_INITIALIZED;
 	}
 
-	if (!context || !commId)
+	if (!context || !commId || !commSign)
 	{
 		return SCE_NP_TROPHY_ERROR_INVALID_ARGUMENT;
 	}
 
-	if (options > 0)
+	if (options > SCE_NP_TROPHY_OPTIONS_CREATE_CONTEXT_READ_ONLY)
 	{
 		return SCE_NP_TROPHY_ERROR_NOT_SUPPORTED;
 	}
@@ -253,8 +253,8 @@ error_code sceNpTrophyCreateContext(vm::ptr<u32> context, vm::cptr<SceNpCommunic
 	sceNpTrophy.warning("sceNpTrophyCreateContext term=%s data=%s num=%d", commId->term, commId->data, commId->num);
 	if (commId->term)
 	{
-		char trimchar[10] = { 0 };
-		memcpy(trimchar, commId->data, sizeof(trimchar) - 1);
+		char trimchar[10];
+		strcpy_trunc(trimchar, commId->data);
 		deleteTerminateChar(trimchar, commId->term);
 		name = fmt::format("%s_%02d", trimchar, commId->num);
 	}

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -340,6 +340,7 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 	TRPLoader trp(ctxt->trp_stream);
 	if (!trp.LoadHeader())
 	{
+		sceNpTrophy.error("sceNpTrophyRegisterContext(): Failed to load trophy config header");
 		return SCE_NP_TROPHY_ERROR_ILLEGAL_UPDATE;
 	}
 
@@ -362,6 +363,7 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 	}
 	else if (!trp.ContainsEntry("TROPCONF.SFM"))
 	{
+		sceNpTrophy.error("sceNpTrophyRegisterContext(): Invalid/Incomplete trophy config"); 
 		return SCE_NP_TROPHY_ERROR_ILLEGAL_UPDATE;
 	}
 
@@ -378,6 +380,7 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 	std::string trophyPath = "/dev_hdd0/home/" + Emu.GetUsr() + "/trophy/" + ctxt->trp_name;
 	if (!trp.Install(trophyPath))
 	{
+		sceNpTrophy.error("sceNpTrophyRegisterContext(): Failed to install trophy context '%s' (%s)", trophyPath, fs::g_tls_error); 
 		return SCE_NP_TROPHY_ERROR_ILLEGAL_UPDATE;
 	}
 

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.h
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.h
@@ -76,6 +76,11 @@ enum SceNpTrophyGrade
 	SCE_NP_TROPHY_GRADE_BRONZE         = 4,
 };
 
+enum
+{
+	SCE_NP_TROPHY_OPTIONS_CREATE_CONTEXT_READ_ONLY = 1,
+};
+
 struct SceNpTrophyGameDetails
 {
 	be_t<u32> numTrophies;

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -83,6 +83,17 @@ private:
 		return spu_branch_target(dump_pc, imm);
 	}
 
+	static const char* BrIndirectSuffix(u32 de)
+	{
+		switch (de)
+		{
+		case 0b01: return "e";
+		case 0b10: return "d";
+		//case 0b11: return "(undef)";
+		default: return "";	
+		}
+	}
+
 private:
 	std::string& FixOp(std::string& op)
 	{
@@ -132,6 +143,16 @@ private:
 	void DisAsm(std::string op, const char* a1, const char* a2, const char* a3, const char* a4)
 	{
 		Write(fmt::format("%s %s,%s,%s,%s", FixOp(op).c_str(), a1, a2, a3, a4));
+	}
+
+	using field_de_t = decltype(spu_opcode_t{}.de);
+	void DisAsm(std::string op, field_de_t de, const char* a1)
+	{
+		Write(fmt::format("%s%s %s", FixOp(op).c_str(), BrIndirectSuffix(de), a1));
+	}
+	void DisAsm(std::string op, field_de_t de, const char* a1, const char* a2)
+	{
+		Write(fmt::format("%s%s %s", FixOp(op).c_str(), BrIndirectSuffix(de), a1, a2));
 	}
 
 public:
@@ -288,19 +309,19 @@ public:
 	}
 	void BIZ(spu_opcode_t op)
 	{
-		DisAsm("biz", spu_reg_name[op.rt], spu_reg_name[op.ra]);
+		DisAsm("biz", op.de, spu_reg_name[op.rt], spu_reg_name[op.ra]);
 	}
 	void BINZ(spu_opcode_t op)
 	{
-		DisAsm("binz", spu_reg_name[op.rt], spu_reg_name[op.ra]);
+		DisAsm("binz", op.de, spu_reg_name[op.rt], spu_reg_name[op.ra]);
 	}
 	void BIHZ(spu_opcode_t op)
 	{
-		DisAsm("bihz", spu_reg_name[op.rt], spu_reg_name[op.ra]);
+		DisAsm("bihz", op.de, spu_reg_name[op.rt], spu_reg_name[op.ra]);
 	}
 	void BIHNZ(spu_opcode_t op)
 	{
-		DisAsm("bihnz", spu_reg_name[op.rt], spu_reg_name[op.ra]);
+		DisAsm("bihnz", op.de, spu_reg_name[op.rt], spu_reg_name[op.ra]);
 	}
 	void STOPD(spu_opcode_t op)
 	{
@@ -312,19 +333,19 @@ public:
 	}
 	void BI(spu_opcode_t op)
 	{
-		DisAsm("bi", spu_reg_name[op.ra]);
+		DisAsm("bi", op.de, spu_reg_name[op.ra]);
 	}
 	void BISL(spu_opcode_t op)
 	{
-		DisAsm("bisl", spu_reg_name[op.rt], spu_reg_name[op.ra]);
+		DisAsm("bisl", op.de, spu_reg_name[op.rt], spu_reg_name[op.ra]);
 	}
 	void IRET(spu_opcode_t op)
 	{
-		DisAsm("iret", spu_reg_name[op.ra]);
+		DisAsm("iret", op.de, spu_reg_name[op.ra]);
 	}
 	void BISLED(spu_opcode_t op)
 	{
-		DisAsm("bisled", spu_reg_name[op.rt], spu_reg_name[op.ra]);
+		DisAsm("bisled", op.de, spu_reg_name[op.rt], spu_reg_name[op.ra]);
 	}
 	void HBR(spu_opcode_t op)
 	{

--- a/rpcs3/Emu/Cell/SPUOpcodes.h
+++ b/rpcs3/Emu/Cell/SPUOpcodes.h
@@ -13,6 +13,7 @@ union spu_opcode_t
 	bf_t<u32, 21, 7> rt4; // 4..10, for 4-op instructions
 	bf_t<u32, 18, 1> e; // 13, "enable interrupts" bit
 	bf_t<u32, 19, 1> d; // 12, "disable interrupts" bit
+	bf_t<u32, 18, 2> de; // 12..13 combined 'e' and 'd' bits
 	bf_t<u32, 20, 1> c; // 11, "C" bit for SYNC instruction
 	bf_t<s32, 23, 2> r0h; // 7..8, signed
 	bf_t<s32, 14, 2> roh; // 16..17, signed

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "sys_cond.h"
 
 #include "Emu/System.h"
@@ -273,15 +273,19 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 					ppu.gpr[3] = CELL_ETIMEDOUT;
 
 					// Own or requeue
-					if (!cond->mutex->try_own(ppu, ppu.id))
+					if (cond->mutex->try_own(ppu, ppu.id))
 					{
-						cond->mutex->sleep(ppu);
-						timeout = 0;
-						continue;
+						break;
 					}
 				}
+				else if (cond->mutex->owner >> 1 == ppu.id)
+				{
+					break;
+				}
 
-				break;
+				cond->mutex->sleep(ppu);
+				timeout = 0;
+				continue;
 			}
 		}
 		else

--- a/rpcs3/Loader/TRP.cpp
+++ b/rpcs3/Loader/TRP.cpp
@@ -18,7 +18,7 @@ bool TRPLoader::Install(const std::string& dest, bool show)
 
 	const std::string& local_path = vfs::get(dest);
 
-	if (!fs::create_dir(local_path) && fs::g_tls_error != fs::error::exist)
+	if (!fs::is_dir(local_path) && !fs::create_dir(local_path))
 	{
 		return false;
 	}


### PR DESCRIPTION
* Logging improvements for failed sceNpTrophyRegisterContext call with ILLEGAL_TROPHY error.
* interrupts disable/enable SPU bits status is now shown on instruction name.
* Wait a little longer for possible sys_mutex_unlock() after confirming signal by checking cond.sq, yet the owner ship has yet to pass.