### PR TITLE
avoid update of window title

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -280,13 +280,18 @@ void gs_frame::flip(draw_context_t, bool /*skip_frame*/)
 {
 	static Timer fps_t;
 
+	if (!m_show_fps_in_title && !g_cfg.misc.show_fps_in_title)
+	{
+		return;
+	}
+
 	++m_frames;
 
 	if (fps_t.GetElapsedTimeInSec() >= 0.5)
 	{
 		QString fps_title;
 
-		if (g_cfg.misc.show_fps_in_title)
+		if ((m_show_fps_in_title = g_cfg.misc.show_fps_in_title.get()))
 		{
 			fps_title = qstr(fmt::format("FPS: %.2f", (double)m_frames / fps_t.GetElapsedTimeInSec()));
 

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -36,6 +36,8 @@ private:
 	std::shared_ptr<gui_settings> m_gui_settings;
 
 	u64 m_frames = 0;
+	// display status of last title update
+	bool m_show_fps_in_title = false;
 	QString m_windowTitle;
 	bool m_disable_mouse;
 


### PR DESCRIPTION
only update the window title if user really wants to display the FPS during gameplay. Additionally wait some frames for better low FPS averages.