### PR TITLE
vk: More chip-specific workarounds

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -40,9 +40,18 @@ namespace vk
 
 		// NV cards. See https://envytools.readthedocs.io/en/latest/hw/pciid.html
 		// NOTE: Since NV device IDs are linearly incremented per generation, there is no need to carefully check all the ranges
+		table.add(0x1180, 0x11fa, chip_class::NV_kepler); // GK104, 106
+		table.add(0x0FC0, 0x0FFF, chip_class::NV_kepler); // GK107
+		table.add(0x1003, 0x1028, chip_class::NV_kepler); // GK110
+		table.add(0x1280, 0x12BA, chip_class::NV_kepler); // GK208
+		table.add(0x1381, 0x13B0, chip_class::NV_maxwell); // GM107
+		table.add(0x1340, 0x134D, chip_class::NV_maxwell); // GM108
+		table.add(0x13C0, 0x13D9, chip_class::NV_maxwell); // GM204
+		table.add(0x1401, 0x1427, chip_class::NV_maxwell); // GM206
+		table.add(0x15F7, 0x15F9, chip_class::NV_pascal); // GP100 (Tesla P100)
 		table.add(0x1B00, 0x1D80, chip_class::NV_pascal);
 		table.add(0x1D81, 0x1DBA, chip_class::NV_volta);
-		table.add(0x1E02, 0x1F51, chip_class::NV_turing); // RTX 20
+		table.add(0x1E02, 0x1F51, chip_class::NV_turing); // RTX 20 series
 		table.add(0x2182, chip_class::NV_turing); // TU116
 		table.add(0x2184, chip_class::NV_turing); // TU116
 		table.add(0x1F82, chip_class::NV_turing); // TU117

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -589,13 +589,11 @@ private:
 				LOG_FATAL(RSX, "RADV drivers have a major driver bug with LLVM 8.0.0 resulting in no visual output. Upgrade to LLVM version 8.0.1 or greater to avoid this issue.");
 			}
 
-#ifndef _WIN32
-			if (get_name().find("VEGA") != std::string::npos)
+			if (get_chip_class() == chip_class::AMD_vega)
 			{
-				LOG_WARNING(RSX, "float16_t does not work correctly on VEGA hardware for both RADV and AMDVLK. Using float32_t fallback instead.");
+				LOG_WARNING(RSX, "float16_t does not work correctly on VEGA hardware on all drivers. Using float32_t fallback instead.");
 				shader_types_support.allow_float16 = false;
 			}
-#endif
 		}
 
 		std::string get_name() const

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -88,6 +88,8 @@ namespace vk
 		AMD_vega,
 		AMD_navi,
 		NV_generic,
+		NV_kepler,
+		NV_maxwell,
 		NV_pascal,
 		NV_volta,
 		NV_turing

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.cpp
@@ -61,7 +61,17 @@ namespace vk
 
 			if (!job)
 			{
-				job.reset(new vk::cs_resolve_task(get_format_prefix(src->format())));
+				const char* format_prefix = get_format_prefix(src->format());
+				bool require_bgra_swap = false;
+
+				if (vk::get_chip_family() == vk::chip_class::NV_kepler &&
+					src->format() == VK_FORMAT_B8G8R8A8_UNORM)
+				{
+					// Workaround for NVIDIA kepler's broken image_load_store
+					require_bgra_swap = true;
+				}
+
+				job.reset(new vk::cs_resolve_task(format_prefix, require_bgra_swap));
 			}
 
 			job->run(cmd, src, dst);
@@ -122,7 +132,17 @@ namespace vk
 
 			if (!job)
 			{
-				job.reset(new vk::cs_unresolve_task(get_format_prefix(src->format())));
+				const char* format_prefix = get_format_prefix(src->format());
+				bool require_bgra_swap = false;
+
+				if (vk::get_chip_family() == vk::chip_class::NV_kepler &&
+					src->format() == VK_FORMAT_B8G8R8A8_UNORM)
+				{
+					// Workaround for NVIDIA kepler's broken image_load_store
+					require_bgra_swap = true;
+				}
+
+				job.reset(new vk::cs_unresolve_task(format_prefix, require_bgra_swap));
 			}
 
 			job->run(cmd, dst, src);

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -139,11 +139,14 @@ namespace vk
 
 	struct cs_resolve_task : cs_resolve_base
 	{
-		cs_resolve_task(const std::string& format_prefix)
+		cs_resolve_task(const std::string& format_prefix, bool bgra_swap = false)
 		{
+			// Allow rgba->bgra transformation for old GeForce cards
+			const std::string swizzle = bgra_swap? ".bgra" : "";
+
 			std::string kernel =
 			"	vec4 aa_sample = imageLoad(multisampled, aa_coords, sample_index);\n"
-			"	imageStore(resolve, resolve_coords, aa_sample);\n";
+			"	imageStore(resolve, resolve_coords, aa_sample" + swizzle + ");\n";
 
 			build(kernel, format_prefix, 0);
 		}
@@ -151,11 +154,14 @@ namespace vk
 
 	struct cs_unresolve_task : cs_resolve_base
 	{
-		cs_unresolve_task(const std::string& format_prefix)
+		cs_unresolve_task(const std::string& format_prefix, bool bgra_swap = false)
 		{
+			// Allow rgba->bgra transformation for old GeForce cards
+			const std::string swizzle = bgra_swap? ".bgra" : "";
+
 			std::string kernel =
 			"	vec4 resolved_sample = imageLoad(resolve, resolve_coords);\n"
-			"	imageStore(multisampled, aa_coords, sample_index, resolved_sample);\n";
+			"	imageStore(multisampled, aa_coords, sample_index, resolved_sample" + swizzle + ");\n";
 
 			build(kernel, format_prefix, 1);
 		}


### PR DESCRIPTION
- Properly detect kepler GPUs and add a workaround for them.
- Use chip class testing instead of GPU name to detect AMD Vega and apply the fp16 workaround.