### PR TITLE
Fixup for spu/ppu disasm prs

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellUserInfo.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellUserInfo.cpp
@@ -104,9 +104,12 @@ error_code cellUserInfoGetList(vm::ptr<u32> listNum, vm::ptr<CellUserInfoUserLis
 	cellUserInfo.todo("cellUserInfoGetList(listNum=*0x%x, listBuf=*0x%x, currentUserId=*0x%x)", listNum, listBuf, currentUserId);
 
 	// If only listNum is NULL, an error will be returned
-	if (listBuf && !listNum)
+	if (!listNum)
 	{
-		return CELL_USERINFO_ERROR_PARAM;
+		if (listBuf || !currentUserId)
+		{
+			return CELL_USERINFO_ERROR_PARAM;
+		}
 	}
 
 	if (listNum)
@@ -116,7 +119,10 @@ error_code cellUserInfoGetList(vm::ptr<u32> listNum, vm::ptr<CellUserInfoUserLis
 
 	if (listBuf)
 	{
-		listBuf->userId[0] = 1;
+		std::memset(listBuf.get_ptr(), 0, listBuf.size());
+
+		// We report only one user, so it must be the current user
+		listBuf->userId[0] = Emu.GetUsrId();
 	}
 
 	if (currentUserId)

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -71,6 +71,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x3: info.first = "bns"; break;
 		default: ASSUME(0); break;
 		}
+		break;
 	}
 	case 0b00110:
 	{
@@ -83,6 +84,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x3: info.first = "bns"; break;
 		default: ASSUME(0); break;
 		}
+		break;
 	}
 	case 0b00111:
 	{
@@ -95,6 +97,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x3: info.first = "bns"; break;
 		default: ASSUME(0); break;
 		}
+		break;
 	}
 	case 0b01100:
 	{
@@ -106,6 +109,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x3: info.first = "bso"; break;
 		default: ASSUME(0); break;
 		}
+		break;
 	}
 	case 0b01110:
 	{
@@ -118,6 +122,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x3: info.first = "bso"; break;
 		default: ASSUME(0); break;
 		}
+		break;
 	}
 	case 0b01111:
 	{
@@ -130,6 +135,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x3: info.first = "bso"; break;
 		default: ASSUME(0); break;
 		}
+		break;
 	}
 	//case 0b10100:
 	//{

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -148,11 +148,11 @@ private:
 	using field_de_t = decltype(spu_opcode_t{}.de);
 	void DisAsm(std::string op, field_de_t de, const char* a1)
 	{
-		Write(fmt::format("%s%s %s", FixOp(op).c_str(), BrIndirectSuffix(de), a1));
+		Write(fmt::format("%s %s", FixOp(op.append(BrIndirectSuffix(de))).c_str(), a1));
 	}
 	void DisAsm(std::string op, field_de_t de, const char* a1, const char* a2)
 	{
-		Write(fmt::format("%s%s %s", FixOp(op).c_str(), BrIndirectSuffix(de), a1, a2));
+		Write(fmt::format("%s %s", FixOp(op.append(BrIndirectSuffix(de))).c_str(), a1, a2));
 	}
 
 public:

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1055,8 +1055,6 @@ void spu_thread::cpu_init()
 	ch_out_mbox.data.raw() = {};
 	ch_out_intr_mbox.data.raw() = {};
 
-	snr_config = 0;
-
 	ch_snr1.data.raw() = {};
 	ch_snr2.data.raw() = {};
 
@@ -1067,6 +1065,11 @@ void spu_thread::cpu_init()
 
 	ch_dec_start_timestamp = get_timebased_time(); // ???
 	ch_dec_value = 0;
+
+	if (offset >= RAW_SPU_BASE_ADDR)
+	{
+		snr_config = 0;
+	}
 
 	run_ctrl.raw() = 0;
 	status.raw() = 0;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -546,7 +546,7 @@ public:
 	spu_channel ch_out_mbox;
 	spu_channel ch_out_intr_mbox;
 
-	u64 snr_config; // SPU SNR Config Register
+	u64 snr_config = 0; // SPU SNR Config Register
 
 	spu_channel ch_snr1; // SPU Signal Notification Register 1
 	spu_channel ch_snr2; // SPU Signal Notification Register 2

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -963,16 +963,16 @@ error_code sys_spu_thread_set_spu_cfg(ppu_thread& ppu, u32 id, u64 value)
 
 	sys_spu.warning("sys_spu_thread_set_spu_cfg(id=0x%x, value=0x%x)", id, value);
 
+	if (value > 3)
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto thread = idm::get<named_thread<spu_thread>>(id);
 
 	if (UNLIKELY(!thread || !thread->group))
 	{
 		return CELL_ESRCH;
-	}
-
-	if (value > 3)
-	{
-		return CELL_EINVAL;
 	}
 
 	thread->snr_config = value;


### PR DESCRIPTION
Also contains two more commits:

**cellUserInfoGetList changes**: 
- logically if we report only one user in user list, it must be the current user.
- Set unwritten entries to zero.
- Do not allow all args to be nullptr at once.

Restores lost commit from pr #5346, the point is to not reset spu signotify config in gropu_start(), error checking ordering fix. (the pr includes the testcases)