### PR TITLE
rsx util: Implement decode_fxp<>

### DIFF
--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -125,12 +125,12 @@ namespace rsx
 
 	f32 fragment_texture::min_lod() const
 	{
-		return rsx::decode_fx13((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 19) & 0xfff);
+		return rsx::decode_fxp<4, 8, false>((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 19) & 0xfff);
 	}
 
 	f32 fragment_texture::max_lod() const
 	{
-		return rsx::decode_fx13((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 7) & 0xfff);
+		return rsx::decode_fxp<4, 8, false>((registers[NV4097_SET_TEXTURE_CONTROL0 + (m_index * 8)] >> 7) & 0xfff);
 	}
 
 	rsx::texture_max_anisotropy fragment_texture::max_aniso() const
@@ -213,7 +213,7 @@ namespace rsx
 
 	f32 fragment_texture::bias() const
 	{
-		return rsx::decode_fx13((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff);
+		return rsx::decode_fxp<4, 8>((registers[NV4097_SET_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff);
 	}
 
 	rsx::texture_minify_filter fragment_texture::min_filter() const
@@ -352,17 +352,17 @@ namespace rsx
 
 	f32 vertex_texture::min_lod() const
 	{
-		return rsx::decode_fx13((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 19) & 0xfff);
+		return rsx::decode_fxp<4, 8, false>((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 19) & 0xfff);
 	}
 
 	f32 vertex_texture::max_lod() const
 	{
-		return rsx::decode_fx13((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 7) & 0xfff);
+		return rsx::decode_fxp<4, 8, false>((registers[NV4097_SET_VERTEX_TEXTURE_CONTROL0 + (m_index * 8)] >> 7) & 0xfff);
 	}
 
 	f32 vertex_texture::bias() const
 	{
-		return rsx::decode_fx13((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff);
+		return rsx::decode_fxp<4, 8>((registers[NV4097_SET_VERTEX_TEXTURE_FILTER + (m_index * 8)]) & 0x1fff);
 	}
 
 	rsx::texture_minify_filter vertex_texture::min_filter() const

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <climits>
 #include "gcm_enums.h"
+#include "rsx_utils.h"
 #pragma warning(disable:4503)
 
 namespace
@@ -2027,17 +2028,13 @@ struct registers_decoder<NV3089_DS_DX>
 		{
 			const u32 val = value;
 
-			if ((val & ~(1<<31)) == 0)
+			if (val == 0)
 			{
+				// Will get reported in image_in
 				return 0;
 			}
 
-			if ((s32)val < 0)
-			{
-				return 1.f / (((val & ~(1<<31)) / 1048576.f) - 2048.f);
-			}
-
-			return 1048576.f / val;
+			return 1.f / rsx::decode_fxp<11, 20>(val);
 		}
 	};
 
@@ -2063,17 +2060,13 @@ struct registers_decoder<NV3089_DT_DY>
 		{
 		    const u32 val = value;
 
-			if ((val & ~(1<<31)) == 0)
+			if (val == 0)
 			{
-				return 0;
+				// Will get reported in image_in
+				return 0.f;
 			}
 
-			if ((s32)val < 0)
-			{
-				return 1.f / (((val & ~(1<<31)) / 1048576.f) - 2048.f);
-			}
-
-			return 1048576.f / val;
+			return 1.f / rsx::decode_fxp<11, 20>(val);
 		}
 	};
 


### PR DESCRIPTION
* Fix -2048.0 scaling in image_in, was treated as invalid input.
* Unify fixed-point decoding.