### PR TITLE
Input: avoid exception while no keyboard is registered

### DIFF
--- a/rpcs3/Emu/Io/MouseHandler.h
+++ b/rpcs3/Emu/Io/MouseHandler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <list>
 #include "Utilities/mutex.h"

--- a/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
+++ b/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Emu/Io/KeyboardHandler.h"
 
@@ -10,7 +10,7 @@ public:
 		memset(&m_info, 0, sizeof(KbInfo));
 		m_info.max_connect = max_connect;
 		m_keyboards.clear();
-		for(u32 i=0; i<max_connect; i++)
+		for (u32 i = 0; i < max_connect; i++)
 		{
 			m_keyboards.emplace_back(Keyboard());
 		}

--- a/rpcs3/Emu/Io/Null/NullMouseHandler.h
+++ b/rpcs3/Emu/Io/Null/NullMouseHandler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Emu/Io/MouseHandler.h"
 

--- a/rpcs3/Emu/Io/Null/NullPadHandler.h
+++ b/rpcs3/Emu/Io/Null/NullPadHandler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Emu/Io/PadHandler.h"
 

--- a/rpcs3/basic_keyboard_handler.cpp
+++ b/rpcs3/basic_keyboard_handler.cpp
@@ -79,7 +79,7 @@ void basic_keyboard_handler::keyPressEvent(QKeyEvent* keyEvent)
 		return;
 	}
 
-	if (keyEvent->isAutoRepeat() && !m_keyboards[0].m_key_repeat)
+	if (m_keyboards.empty() || (keyEvent->isAutoRepeat() && !m_keyboards[0].m_key_repeat))
 	{
 		keyEvent->ignore();
 		return;
@@ -100,7 +100,7 @@ void basic_keyboard_handler::keyReleaseEvent(QKeyEvent* keyEvent)
 		return;
 	}
 
-	if (keyEvent->isAutoRepeat() && !m_keyboards[0].m_key_repeat)
+	if (m_keyboards.empty() || (keyEvent->isAutoRepeat() && !m_keyboards[0].m_key_repeat))
 	{
 		keyEvent->ignore();
 		return;
@@ -153,6 +153,11 @@ s32 basic_keyboard_handler::getUnmodifiedKey(QKeyEvent* keyEvent)
 
 void basic_keyboard_handler::LoadSettings()
 {
+	if (m_keyboards.empty())
+	{
+		return;
+	}
+
 	// Meta Keys
 	//m_keyboards[0].m_buttons.emplace_back(Qt::Key_Control, CELL_KB_MKEY_L_CTRL);
 	m_keyboards[0].m_buttons.emplace_back(Qt::Key_Shift, CELL_KB_MKEY_L_SHIFT);

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -36,7 +36,7 @@ private:
 	std::shared_ptr<gui_settings> m_gui_settings;
 
 	u64 m_frames = 0;
-	// display status of last title update
+	// display status of last title update, needed for dynamic changes of the fps setting
 	bool m_show_fps_in_title = false;
 	QString m_windowTitle;
 	bool m_disable_mouse;


### PR DESCRIPTION
Ignore keyboard events in the basic keyboard handler while no keyboards are registered.

may improve #6781