### PR TITLE
rsx: Minor texture cache improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -308,6 +308,7 @@ namespace rsx
 		 */
 		virtual image_view_type create_temporary_subresource_view(commandbuffer_type&, image_resource_type* src, u32 gcm_format, u16 x, u16 y, u16 w, u16 h, const texture_channel_remap_t& remap_vector) = 0;
 		virtual image_view_type create_temporary_subresource_view(commandbuffer_type&, image_storage_type* src, u32 gcm_format, u16 x, u16 y, u16 w, u16 h, const texture_channel_remap_t& remap_vector) = 0;
+		virtual void release_temporary_subresource(image_view_type rsc) = 0;
 		virtual section_storage_type* create_new_texture(commandbuffer_type&, const address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format,
 			rsx::texture_upload_context context, rsx::texture_dimension_extended type, texture_create_flags flags) = 0;
 		virtual section_storage_type* upload_image_from_cpu(commandbuffer_type&, const address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format, texture_upload_context context,
@@ -1432,6 +1433,7 @@ namespace rsx
 				const auto& desc = It->second.first;
 				if (range.overlaps(desc.cache_range))
 				{
+					release_temporary_subresource(It->second.second);
 					It = m_temporary_subresource_cache.erase(It);
 				}
 				else

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1722,7 +1722,7 @@ namespace rsx
 
 			const bool is_unnormalized = !!(tex.format() & CELL_GCM_TEXTURE_UN);
 			const bool is_swizzled = !(tex.format() & CELL_GCM_TEXTURE_LN);
-			const auto extended_dimension = tex.get_extended_texture_dimension();
+			auto extended_dimension = tex.get_extended_texture_dimension();
 
 			options.is_compressed_format = texture_cache_helpers::is_compressed_gcm_format(attributes.gcm_format);
 
@@ -1784,6 +1784,14 @@ namespace rsx
 				{
 					LOG_ERROR(RSX, "Unimplemented unnormalized sampling for texture type %d", (u32)extended_dimension);
 				}
+			}
+
+			if (options.is_compressed_format)
+			{
+				attributes.width = align(attributes.width, 4);
+				attributes.height = align(attributes.height, 4);
+
+				extended_dimension = std::max(extended_dimension, rsx::texture_dimension_extended::texture_dimension_2d);
 			}
 
 			const auto lookup_range = utils::address_range::start_length(attributes.address, attributes.pitch * required_surface_height);

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1494,10 +1494,13 @@ namespace rsx
 						auto result = texture_cache_helpers::process_framebuffer_resource_fast<sampled_image_descriptor>(
 							cmd, texptr, attr, scale, extended_dimension, encoded_remap, remap, true, force_convert);
 
-						if (!options.skip_texture_barriers)
+						if (!options.skip_texture_barriers && result.is_cyclic_reference)
 						{
+							// A texture barrier is only necessary when the rendertarget is going to be bound as a shader input.
+							// If a temporary copy is to be made, this should not be invoked
 							insert_texture_barrier(cmd, texptr);
 						}
+
 						return result;
 					}
 				}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -387,6 +387,8 @@ void GLGSRender::end()
 		}
 	}
 
+	m_gl_texture_cache.release_uncached_temporary_subresources();
+
 	m_frame_stats.textures_upload_time += m_profiler.duration();
 
 	// Optionally do memory synchronization if the texture stage has not yet triggered this

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -781,6 +781,19 @@ namespace gl
 			return view;
 		}
 
+		void release_temporary_subresource(gl::texture_view* view) override
+		{
+			for (auto& e : m_temporary_surfaces)
+			{
+				if (e.image.get() == view->image())
+				{
+					e.view.reset();
+					e.image.reset();
+					return;
+				}
+			}
+		}
+
 		void update_image_contents(gl::command_context& cmd, gl::texture_view* dst, gl::texture* src, u16 width, u16 height) override
 		{
 			std::vector<copy_region_descriptor> region =

--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -48,17 +48,17 @@ namespace vk
 		fmt::throw_exception("Invalid format (0x%x)" HERE, (u32)format);
 	}
 
-	std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(rsx::texture_minify_filter min_filter)
+	minification_filter get_min_filter(rsx::texture_minify_filter min_filter)
 	{
 		switch (min_filter)
 		{
-		case rsx::texture_minify_filter::nearest: return std::make_tuple(VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-		case rsx::texture_minify_filter::linear: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-		case rsx::texture_minify_filter::nearest_nearest: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-		case rsx::texture_minify_filter::linear_nearest: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST);
-		case rsx::texture_minify_filter::nearest_linear: return std::make_tuple(VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_LINEAR);
-		case rsx::texture_minify_filter::linear_linear: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR);
-		case rsx::texture_minify_filter::convolution_min: return std::make_tuple(VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR);
+		case rsx::texture_minify_filter::nearest: return { VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST, false };
+		case rsx::texture_minify_filter::linear: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, false };
+		case rsx::texture_minify_filter::nearest_nearest: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, true };
+		case rsx::texture_minify_filter::linear_nearest: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, true };
+		case rsx::texture_minify_filter::nearest_linear: return { VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_LINEAR, true };
+		case rsx::texture_minify_filter::linear_linear: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR, true };
+		case rsx::texture_minify_filter::convolution_min: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR, false };
 		default:
 			ASSUME(0);
 			break;

--- a/rpcs3/Emu/RSX/VK/VKFormats.h
+++ b/rpcs3/Emu/RSX/VK/VKFormats.h
@@ -1,9 +1,16 @@
-#pragma once
+﻿#pragma once
 #include "VKHelpers.h"
 #include <tuple>
 
 namespace vk
 {
+	struct minification_filter
+	{
+		VkFilter filter;
+		VkSamplerMipmapMode mipmap_mode;
+		bool sample_mipmaps;
+	};
+
 	VkBorderColor get_border_color(u32 color);
 
 	VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support, rsx::surface_depth_format format);
@@ -14,7 +21,7 @@ namespace vk
 	std::pair<bool, u32> get_format_convert_flags(VkFormat format);
 	bool formats_are_bitcast_compatible(VkFormat format1, VkFormat format2);
 
-	std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(rsx::texture_minify_filter min_filter);
+	minification_filter get_min_filter(rsx::texture_minify_filter min_filter);
 	VkFilter get_mag_filter(rsx::texture_magnify_filter mag_filter);
 	VkSamplerAddressMode vk_wrap_mode(rsx::texture_wrap_mode gcm_wrap);
 	float max_aniso(rsx::texture_max_anisotropy gcm_aniso);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1418,7 +1418,7 @@ void VKGSRender::end()
 					check_heap_status(VK_HEAP_CHECK_TEXTURE_UPLOAD_STORAGE);
 					*sampler_state = m_texture_cache.upload_texture(*m_current_command_buffer, rsx::method_registers.vertex_textures[i], m_rtts);
 
-					if (sampler_state->is_cyclic_reference)
+					if (sampler_state->is_cyclic_reference || sampler_state->external_subresource_desc.do_not_cache)
 					{
 						check_for_cyclic_refs |= true;
 					}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1691,6 +1691,8 @@ void VKGSRender::end()
 		}
 	}
 
+	m_texture_cache.release_uncached_temporary_subresources();
+
 	m_frame_stats.textures_upload_time += m_profiler.duration();
 
 	if (m_current_command_buffer->flags & vk::command_buffer::cb_load_occluson_task)

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -321,6 +321,7 @@ namespace vk
 	{
 		vk::reset_compute_tasks();
 		vk::reset_resolve_resources();
+		vk::vmm_reset();
 
 		g_upload_heap.reset_allocation_stats();
 	}

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -1,10 +1,15 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "VKResourceManager.h"
 
 namespace vk
 {
+	std::unordered_map<uintptr_t, vmm_allocation_t> g_vmm_allocations;
+	std::unordered_map<uintptr_t, atomic_t<u64>> g_vmm_memory_usage;
+
 	resource_manager g_resource_manager;
 	atomic_t<u64> g_event_ctr;
+
+	constexpr u64 s_vmm_warn_threshold_size = 2000 * 0x100000; // Warn if allocation on a single heap exceeds this value
 
 	resource_manager* get_resource_manager()
 	{
@@ -25,5 +30,49 @@ namespace vk
 	{
 		// TODO: Offload this to a secondary thread
 		g_resource_manager.eid_completed(event_id);
+	}
+
+	static constexpr f32 size_in_GiB(u64 size)
+	{
+		return size / (1024.f * 1024.f * 1024.f);
+	}
+
+	void vmm_notify_memory_allocated(void* handle, u32 memory_type, u64 memory_size)
+	{
+		auto key = reinterpret_cast<uintptr_t>(handle);
+		const vmm_allocation_t info = { memory_size, memory_type };
+
+		if (const auto ins = g_vmm_allocations.insert_or_assign(key, info);
+			!ins.second)
+		{
+			LOG_ERROR(RSX, "Duplicate vmm entry with memory handle 0x%llx", key);
+		}
+
+		auto& vmm_size = g_vmm_memory_usage[memory_type];
+		vmm_size += memory_size;
+
+		if (vmm_size > s_vmm_warn_threshold_size && (vmm_size - memory_size) <= s_vmm_warn_threshold_size)
+		{
+			LOG_WARNING(RSX, "Memory type 0x%x has allocated more than %.2fG. Currently allocated %.2fG",
+				memory_type, size_in_GiB(s_vmm_warn_threshold_size), size_in_GiB(vmm_size));
+		}
+	}
+
+	void vmm_notify_memory_freed(void* handle)
+	{
+		auto key = reinterpret_cast<uintptr_t>(handle);
+		if (auto found = g_vmm_allocations.find(key);
+			found != g_vmm_allocations.end())
+		{
+			const auto& info = found->second;
+			g_vmm_memory_usage[info.type_index] -= info.size;
+			g_vmm_allocations.erase(found);
+		}
+	}
+
+	void vmm_reset()
+	{
+		g_vmm_memory_usage.clear();
+		g_vmm_allocations.clear();
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "VKHelpers.h"
 
 namespace vk
@@ -141,6 +141,12 @@ namespace vk
 				}
 			}
 		}
+	};
+
+	struct vmm_allocation_t
+	{
+		u64 size;
+		u32 type_index;
 	};
 
 	resource_manager* get_resource_manager();


### PR DESCRIPTION
A collection of small fixes to the texture cache to improve memory usage and other miscellaneous bugs.
- Adds a video memory manager to vulkan. Doesn't do much by itself but is useful for debugging and logs suspiciously large allocations.
- Improve surface reuse in the texture cache when a subresource cache entry is available and when its not. The old way of waiting at least one whole frame before reusing memory could lead to quasi-leaks.
- Vulkan improvement to renderpass management by detecting uncacheable resources.
- Fix a minor regression from the mipmaps PR causing mismatched texture layouts in vulkan.
- Force compressed textures to be 2D or higher and force 4-texel alignment. While 1D textures are used on PS3, they are not allowed by all desktop implementations. Upload as 2D image instead with a vertical scale of 0 as a workaround.