### PR TITLE
rsx: Preserve visibility of scaled blit targets [ 2 of 3]

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -743,10 +743,10 @@ namespace rsx
 					if (tex.overlaps(fault_range, section_bounds::locked_range))
 					{
 						if (cause == invalidation_cause::superseded_by_fbo &&
-							tex.get_context() == texture_upload_context::framebuffer_storage &&
+							tex.is_flushable() &&
 							tex.get_section_base() != fault_range_in.start)
 						{
-							// HACK: When being superseded by an fbo, we preserve other overlapped fbos unless the start addresses match
+							// HACK: When being superseded by an fbo, we preserve overlapped flushables unless the start addresses match
 							continue;
 						}
 						else if (tex.inside(fault_range, section_bounds::locked_range))
@@ -807,9 +807,9 @@ namespace rsx
 						!tex.inside(trampled_set.invalidate_range, bounds) ||
 						// Unsynchronized sections (or any flushable when skipping flushes) that do not overlap the fault range directly can also be ignored
 						(invalidation_ignore_unsynchronized && tex.is_flushable() && (cause.skip_flush() || !tex.is_synchronized()) && !overlaps_fault_range) ||
-						// HACK: When being superseded by an fbo, we preserve other overlapped fbos unless the start addresses match
-						// If region is committed as fbo, all non-fbo data is removed but all fbos in the region must be preserved if possible
-						(overlaps_fault_range && tex.get_context() == texture_upload_context::framebuffer_storage && cause.skip_fbos() && tex.get_section_base() != fault_range_in.start)
+						// HACK: When being superseded by an fbo, we preserve other overlapped flushables unless the start addresses match
+						// If region is committed as fbo, all non-flushable data is removed but all flushables in the region must be preserved if possible
+						(overlaps_fault_range && tex.is_flushable() && cause.skip_fbos() && tex.get_section_base() != fault_range_in.start)
 					   )
 					{
 						// False positive

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1911,6 +1911,9 @@ namespace rsx
 			const f32 scale_x = fabsf(dst.scale_x);
 			const f32 scale_y = fabsf(dst.scale_y);
 
+			const bool is_copy_op = (fcmp(scale_x, 1.f) && fcmp(scale_y, 1.f));
+			const bool is_format_convert = (dst_is_argb8 != src_is_argb8);
+
 			// Offset in x and y for src is 0 (it is already accounted for when getting pixels_src)
 			// Reproject final clip onto source...
 			u16 src_w = (u16)((f32)dst.clip_width / scale_x);
@@ -2041,7 +2044,7 @@ namespace rsx
 				// 1. Invalidate surfaces in range
 				// 2. Proceed as normal, blit into a 'normal' surface and any upload routines should catch it
 				m_rtts.invalidate_range(utils::address_range::start_length(dst_address, dst.pitch * dst_h));
-				use_null_region = (fcmp(scale_x, 1.f) && fcmp(scale_y, 1.f));
+				use_null_region = (is_copy_op && !is_format_convert);
 			}
 
 			// TODO: Handle cases where src or dst can be a depth texture while the other is a color texture - requires a render pass to emulate
@@ -2049,28 +2052,34 @@ namespace rsx
 			src_is_render_target = src_subres.surface != nullptr;
 
 			// Always use GPU blit if src or dst is in the surface store
-			if (!g_cfg.video.use_gpu_texture_scaling && !(src_is_render_target || dst_is_render_target))
-				return false;
-
-			// Check if trivial memcpy can perform the same task
-			// Used to copy programs and arbitrary data to the GPU in some cases
-			if (!src_is_render_target && !dst_is_render_target && dst_is_argb8 == src_is_argb8 && !dst.swizzled)
+			if (!src_is_render_target && !dst_is_render_target)
 			{
-				if ((src_h == 1 && dst_h == 1) || (dst_w == src_w && dst_h == src_h && src.pitch == dst.pitch))
+				const bool is_trivial_copy = is_copy_op && !is_format_convert && !dst.swizzled;
+				if (is_trivial_copy)
 				{
-					if (dst.scale_x > 0.f && dst.scale_y > 0.f)
+					// Check if trivial memcpy can perform the same task
+					// Used to copy programs and arbitrary data to the GPU in some cases
+					// NOTE: This case overrides the GPU texture scaling option
+					if ((src_h == 1 && dst_h == 1) || (dst_w == src_w && dst_h == src_h && src.pitch == dst.pitch))
 					{
-						const u32 memcpy_bytes_length = dst.clip_width * dst_bpp * dst.clip_height;
-
-						std::lock_guard lock(m_cache_mutex);
-						invalidate_range_impl_base(cmd, address_range::start_length(src_address, memcpy_bytes_length), invalidation_cause::read, std::forward<Args>(extras)...);
-						invalidate_range_impl_base(cmd, address_range::start_length(dst_address, memcpy_bytes_length), invalidation_cause::write, std::forward<Args>(extras)...);
-						memcpy(dst.pixels, src.pixels, memcpy_bytes_length);
-						return true;
+						if (dst.scale_x > 0.f && dst.scale_y > 0.f)
+						{
+							return false;
+						}
 					}
-					else
+				}
+
+				if (!g_cfg.video.use_gpu_texture_scaling)
+				{
+					if (dst.swizzled)
 					{
-						// Rotation transform applied, use fallback
+						// Swizzle operation requested. Use fallback
+						return false;
+					}
+
+					if (is_trivial_copy && get_location(dst_address) != CELL_GCM_LOCATION_LOCAL)
+					{
+						// Trivial copy and the destination is in XDR memory
 						return false;
 					}
 				}

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -203,7 +203,7 @@ void GLFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	properties2.require_wpos = !!(properties.in_register_mask & in_wpos);
 	properties2.require_texture_ops = properties.has_tex_op;
 	properties2.require_shadow_ops = m_prog.shadow_textures != 0;
-	properties2.emulate_coverage_tests = g_cfg.video.antialiasing_level == msaa_level::none;
+	properties2.emulate_coverage_tests = true; // g_cfg.video.antialiasing_level == msaa_level::none;
 	properties2.emulate_shadow_compare = device_props.emulate_depth_compare;
 	properties2.low_precision_tests = ::gl::get_driver_caps().vendor_NVIDIA;
 

--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -54,16 +54,16 @@ namespace vk
 		{
 		case rsx::texture_minify_filter::nearest: return { VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST, false };
 		case rsx::texture_minify_filter::linear: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, false };
-		case rsx::texture_minify_filter::nearest_nearest: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, true };
+		case rsx::texture_minify_filter::nearest_nearest: return { VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST, true };
 		case rsx::texture_minify_filter::linear_nearest: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, true };
 		case rsx::texture_minify_filter::nearest_linear: return { VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_LINEAR, true };
 		case rsx::texture_minify_filter::linear_linear: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR, true };
-		case rsx::texture_minify_filter::convolution_min: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR, false };
+		case rsx::texture_minify_filter::convolution_min: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, false };
 		default:
 			ASSUME(0);
 			break;
 		}
-		fmt::throw_exception("Invalid max filter" HERE);
+		fmt::throw_exception("Invalid min filter" HERE);
 	}
 
 	VkFilter get_mag_filter(rsx::texture_magnify_filter mag_filter)


### PR DESCRIPTION
Companion PR to https://github.com/RPCS3/rpcs3/pull/6774
This PR aims to keep images scaled via blit engine visible to the texture cache lookup routines. This allows mipmaps generated through method 2 detailed in the last PR to be properly gathered.

- Adds a fix to avoid deleting blit engine generated data inadvertently when it shares pages with a framebuffer.

- Tries to improve heurestics with the behavior of RSX if "use GPU texture scaling" is set to off. If scaling or format conversion is being done, just use the GPU. Its much faster and there is little reason to force the CPU fallback in these situations. Moving the data to the GPU side also makes it visible to the texture cache when gathering mipmap levels.

With this fix, some games like The Evil Within show correct visuals when using NVIDIA hardware. Other vendors require some shader workarounds for NVIDIA hardware compatibility which will be made available in part 3.