### PR TITLE
rsx: sys_rsx Fixes, FIFO desync logging improved, cellGcmGetConfiguration fix, vblank signaling fix

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -389,11 +389,9 @@ s32 _cellGcmInitBody(ppu_thread& ppu, vm::pptr<CellGcmContextData> context, u32 
 	gcm_cfg->current_config.coreFrequency = 500000000;
 
 	// Create contexts
-	auto ctx_area = vm::find_map(0x10000000, 0x10000000, 0x403);
-	u32 rsx_ctxaddr = ctx_area ? ctx_area->addr : 0;
-
-	if (!rsx_ctxaddr || vm::falloc(rsx_ctxaddr, 0x400000) != rsx_ctxaddr)
-		fmt::throw_exception("Failed to alloc rsx context.");
+	const auto area = vm::reserve_map(vm::rsx_context, 0, 0x10000000, 0x403);
+	const u32 rsx_ctxaddr = area ? area->alloc(0x400000) : 0;
+	verify(HERE), rsx_ctxaddr != 0;
 
 	g_defaultCommandBufferBegin = ioAddress;
 	g_defaultCommandBufferFragmentCount = cmdSize / (32 * 1024);
@@ -429,7 +427,7 @@ s32 _cellGcmInitBody(ppu_thread& ppu, vm::pptr<CellGcmContextData> context, u32 
 	render->intr_thread->state -= cpu_flag::stop;
 	render->isHLE = true;
 	render->label_addr = gcm_cfg->gcm_info.label_addr;
-	render->ctxt_addr = gcm_cfg->gcm_info.context_addr;
+	render->device_addr = gcm_cfg->gcm_info.context_addr;
 	render->init(gcm_cfg->gcm_info.control_addr - 0x40);
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -68,10 +68,14 @@ error_code sys_rsx_memory_allocate(vm::ptr<u32> mem_handle, vm::ptr<u64> mem_add
 {
 	sys_rsx.warning("sys_rsx_memory_allocate(mem_handle=*0x%x, mem_addr=*0x%x, size=0x%x, flags=0x%llx, a5=0x%llx, a6=0x%llx, a7=0x%llx)", mem_handle, mem_addr, size, flags, a5, a6, a7);
 
-	*mem_handle = 0x5a5a5a5b;
-	*mem_addr = vm::falloc(rsx::constants::local_mem_base, size, vm::video);
+	if (u32 addr = vm::falloc(rsx::constants::local_mem_base, size, vm::video))
+	{
+		*mem_addr = addr;
+		*mem_handle = 0x5a5a5a5b;
+		return CELL_OK;
+	}
 
-	return CELL_OK;
+	return CELL_ENOMEM;
 }
 
 /*
@@ -80,7 +84,22 @@ error_code sys_rsx_memory_allocate(vm::ptr<u32> mem_handle, vm::ptr<u64> mem_add
  */
 error_code sys_rsx_memory_free(u32 mem_handle)
 {
-	sys_rsx.todo("sys_rsx_memory_free(mem_handle=0x%x)", mem_handle);
+	sys_rsx.warning("sys_rsx_memory_free(mem_handle=0x%x)", mem_handle);
+
+	if (!vm::check_addr(rsx::constants::local_mem_base))
+	{
+		return CELL_ENOMEM;
+	}
+
+	if (g_fxo->get<lv2_rsx_config>()->context_base)
+	{
+		fmt::throw_exception("Attempting to dealloc rsx memory when the context is still being used" HERE);
+	}
+
+	if (!vm::dealloc(rsx::constants::local_mem_base))
+	{
+		return CELL_ENOMEM;
+	}
 
 	return CELL_OK;
 }
@@ -99,18 +118,32 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 	sys_rsx.warning("sys_rsx_context_allocate(context_id=*0x%x, lpar_dma_control=*0x%x, lpar_driver_info=*0x%x, lpar_reports=*0x%x, mem_ctx=0x%llx, system_mode=0x%llx)",
 		context_id, lpar_dma_control, lpar_driver_info, lpar_reports, mem_ctx, system_mode);
 
-	auto rsx_cfg = g_fxo->get<lv2_rsx_config>();
-
-	if (!rsx_cfg->state)
+	if (!vm::check_addr(rsx::constants::local_mem_base))
 	{
 		return CELL_EINVAL;
 	}
 
-	*context_id = 0x55555555;
+	auto rsx_cfg = g_fxo->get<lv2_rsx_config>();
 
-	*lpar_dma_control = rsx_cfg->rsx_context_addr + 0x100000;
-	*lpar_driver_info = rsx_cfg->rsx_context_addr + 0x200000;
-	*lpar_reports = rsx_cfg->rsx_context_addr + 0x300000;
+	std::lock_guard lock(s_rsxmem_mtx);
+
+	if (rsx_cfg->context_base)
+	{
+		// We currently do not support multiple contexts
+		fmt::throw_exception("sys_rsx_context_allocate was called twice" HERE);
+	}
+
+	const auto area = vm::reserve_map(vm::rsx_context, 0, 0x10000000, 0x403);
+	const u32 context_base = area ? area->alloc(0x300000) : 0; 
+
+	if (!context_base)
+	{
+		return CELL_ENOMEM;
+	}
+
+	*lpar_dma_control = context_base;
+	*lpar_driver_info = context_base + 0x100000;
+	*lpar_reports = context_base + 0x200000;
 
 	auto &reports = vm::_ref<RsxReports>(*lpar_reports);
 	std::memset(&reports, 0, sizeof(RsxReports));
@@ -147,7 +180,7 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 	driverInfo.systemModeFlags = system_mode;
 	driverInfo.hardware_channel = 1; // * i think* this 1 for games, 0 for vsh
 
-	rsx_cfg->driverInfo = *lpar_driver_info;
+	rsx_cfg->driver_info = *lpar_driver_info;
 
 	auto &dmaControl = vm::_ref<RsxDmaControl>(*lpar_dma_control);
 	dmaControl.get = 0;
@@ -175,8 +208,11 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 	render->display_buffers_count = 0;
 	render->current_display_buffer = 0;
 	render->label_addr = *lpar_reports;
-	render->ctxt_addr = rsx_cfg->rsx_context_addr;
+	render->device_addr = rsx_cfg->device_addr;
 	render->init(*lpar_dma_control);
+
+	rsx_cfg->context_base = context_base;
+	*context_id = 0x55555555;
 
 	return CELL_OK;
 }
@@ -188,6 +224,15 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 error_code sys_rsx_context_free(u32 context_id)
 {
 	sys_rsx.todo("sys_rsx_context_free(context_id=0x%x)", context_id);
+
+	std::scoped_lock lock(s_rsxmem_mtx);
+
+	auto rsx_cfg = g_fxo->get<lv2_rsx_config>();
+
+	if (context_id != 0x55555555 || !rsx_cfg->context_base)
+	{
+		return CELL_EINVAL;
+	}
 
 	return CELL_OK;
 }
@@ -205,7 +250,7 @@ error_code sys_rsx_context_iomap(u32 context_id, u32 io, u32 ea, u32 size, u64 f
 	sys_rsx.warning("sys_rsx_context_iomap(context_id=0x%x, io=0x%x, ea=0x%x, size=0x%x, flags=0x%llx)", context_id, io, ea, size, flags);
 
 	if (!size || io & 0xFFFFF || ea + u64{size} > rsx::constants::local_mem_base || ea & 0xFFFFF || size & 0xFFFFF ||
-		rsx::get_current_renderer()->main_mem_size < io + u64{size})
+		context_id != 0x55555555 || rsx::get_current_renderer()->main_mem_size < io + u64{size})
 	{
 		return CELL_EINVAL;
 	}
@@ -244,7 +289,8 @@ error_code sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size)
 {
 	sys_rsx.warning("sys_rsx_context_iounmap(context_id=0x%x, io=0x%x, size=0x%x)", context_id, io, size);
 
-	if (!size || size & 0xFFFFF || io & 0xFFFFF || rsx::get_current_renderer()->main_mem_size < io + u64{size})
+	if (!size || size & 0xFFFFF || io & 0xFFFFF || context_id != 0x55555555 ||
+			rsx::get_current_renderer()->main_mem_size < io + u64{size})
 	{
 		return CELL_EINVAL;
 	}
@@ -273,7 +319,7 @@ error_code sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size)
  * @param a5 (IN):
  * @param a6 (IN):
  */
-error_code sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u64 a5, u64 a6)
+error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64 a4, u64 a5, u64 a6)
 {
 	// Flip/queue/reset flip/flip event/user command/vblank as trace to help with log spam
 	if (package_id == 0x102 || package_id == 0x103 || package_id == 0x10a || package_id == 0xFEC || package_id == 0xFED || package_id == 0xFEF)
@@ -287,12 +333,12 @@ error_code sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64
 
 	auto rsx_cfg = g_fxo->get<lv2_rsx_config>();
 
-	if (!rsx_cfg->state)
+	if (!rsx_cfg->context_base || context_id != 0x55555555)
 	{
 		return CELL_EINVAL;
 	}
 
-	auto &driverInfo = vm::_ref<RsxDriverInfo>(rsx_cfg->driverInfo);
+	auto &driverInfo = vm::_ref<RsxDriverInfo>(rsx_cfg->driver_info);
 	switch (package_id)
 	{
 	case 0x001: // FIFO
@@ -502,7 +548,7 @@ error_code sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64
 
 	case 0xFED: // hack: vblank command
 		// todo: this is wrong and should be 'second' vblank handler and freq, but since currently everything is reported as being 59.94, this should be fine
-		vm::_ref<u32>(render->ctxt_addr + 0x30) = 1;
+		vm::_ref<u32>(render->device_addr + 0x30) = 1;
 		driverInfo.head[a3].vBlankCount++;
 		driverInfo.head[a3].lastSecondVTime = rsxTimeStamp();
 		sys_event_port_send(rsx_cfg->rsx_event_port, 0, (1 << 1), 0);
@@ -530,7 +576,7 @@ error_code sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64
 /*
  * lv2 SysCall 675 (0x2A3): sys_rsx_device_map
  * @param a1 (OUT): rsx device map address : 0x40000000, 0x50000000.. 0xB0000000
- * @param a2 (OUT): Unused?
+ * @param a2 (OUT): Unused
  * @param dev_id (IN): An immediate value and always 8. (cellGcmInitPerfMon uses 11, 10, 9, 7, 12 successively).
  */
 error_code sys_rsx_device_map(vm::ptr<u64> dev_addr, vm::ptr<u64> a2, u32 dev_id)
@@ -542,25 +588,27 @@ error_code sys_rsx_device_map(vm::ptr<u64> dev_addr, vm::ptr<u64> a2, u32 dev_id
 		fmt::throw_exception("sys_rsx_device_map: Invalid dev_id %d", dev_id);
 	}
 
-	// a2 seems to not be referenced in cellGcmSys, tests show this arg is ignored
-	//*a2 = 0;
-
 	auto rsx_cfg = g_fxo->get<lv2_rsx_config>();
 
-	// TODO
-	if (!rsx_cfg->state.compare_and_swap_test(0, 1))
-	{
-		return CELL_EINVAL; // sys_rsx_device_map called twice
-	}
+	static shared_mutex device_map_mtx;
+	std::scoped_lock lock(device_map_mtx);
 
-	if (const auto area = vm::find_map(0x10000000, 0x10000000, 0x403))
+	if (!rsx_cfg->device_addr)
 	{
-		vm::falloc(area->addr, 0x400000);
-		rsx_cfg->rsx_context_addr = *dev_addr = area->addr;
+		const auto area = vm::reserve_map(vm::rsx_context, 0, 0x10000000, 0x403);
+		const u32 addr = area ? area->alloc(0x100000) : 0; 
+
+		if (!addr)
+		{
+			return CELL_ENOMEM;
+		}
+
+		rsx_cfg->device_addr = *dev_addr = addr;
 		return CELL_OK;
 	}
 
-	return CELL_ENOMEM;
+	*dev_addr = rsx_cfg->device_addr;
+	return CELL_OK;
 }
 
 /*

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -58,7 +58,7 @@ error_code sys_rsx_device_close()
  * lv2 SysCall 668 (0x29C): sys_rsx_memory_allocate
  * @param mem_handle (OUT): Context / ID, which is used by sys_rsx_memory_free to free allocated memory.
  * @param mem_addr (OUT): Returns the local memory base address, usually 0xC0000000.
- * @param size (IN): Local memory size. E.g. 0x0F900000 (249 MB).
+ * @param size (IN): Local memory size. E.g. 0x0F900000 (249 MB). (changes with sdk version)
  * @param flags (IN): E.g. Immediate value passed in cellGcmSys is 8.
  * @param a5 (IN): E.g. Immediate value passed in cellGcmSys is 0x00300000 (3 MB?).
  * @param a6 (IN): E.g. Immediate value passed in cellGcmSys is 16.
@@ -70,6 +70,7 @@ error_code sys_rsx_memory_allocate(vm::ptr<u32> mem_handle, vm::ptr<u64> mem_add
 
 	if (u32 addr = vm::falloc(rsx::constants::local_mem_base, size, vm::video))
 	{
+		g_fxo->get<lv2_rsx_config>()->memory_size = size;
 		*mem_addr = addr;
 		*mem_handle = 0x5a5a5a5b;
 		return CELL_OK;
@@ -171,7 +172,7 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 
 	driverInfo.version_driver = 0x211;
 	driverInfo.version_gpu = 0x5c;
-	driverInfo.memory_size = 0xFE00000;
+	driverInfo.memory_size = rsx_cfg->memory_size;
 	driverInfo.nvcore_frequency = 500000000; // 0x1DCD6500
 	driverInfo.memory_frequency = 650000000; // 0x26BE3680
 	driverInfo.reportsNotifyOffset = 0x1000;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -103,6 +103,7 @@ struct RsxDisplayInfo
 
 struct lv2_rsx_config
 {
+	u32 memory_size{};
 	u32 rsx_event_port{};
 	u32 context_base{};
 	u32 device_addr{};

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -1,6 +1,4 @@
-#pragma once
-
-#include "Emu/Memory/vm_ptr.h"
+﻿#pragma once
 
 #include "Emu/Memory/vm_ptr.h"
 
@@ -105,10 +103,10 @@ struct RsxDisplayInfo
 
 struct lv2_rsx_config
 {
-	atomic_t<u32> state = 0;
-	u32 rsx_event_port = 0;
-	u32 driverInfo = 0;
-	u32 rsx_context_addr = 0;
+	u32 rsx_event_port{};
+	u32 context_base{};
+	u32 device_addr{};
+	u32 driver_info{};
 };
 
 // SysCalls
@@ -120,7 +118,7 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 error_code sys_rsx_context_free(u32 context_id);
 error_code sys_rsx_context_iomap(u32 context_id, u32 io, u32 ea, u32 size, u64 flags);
 error_code sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size);
-error_code sys_rsx_context_attribute(s32 context_id, u32 package_id, u64 a3, u64 a4, u64 a5, u64 a6);
+error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64 a4, u64 a5, u64 a6);
 error_code sys_rsx_device_map(vm::ptr<u64> dev_addr, vm::ptr<u64> a2, u32 dev_id);
 error_code sys_rsx_device_unmap(u32 dev_id);
 error_code sys_rsx_attribute(u32 a1, u32 a2, u32 a3, u32 a4, u32 a5);

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1087,6 +1087,7 @@ namespace vm
 				std::make_shared<block_t>(0x00010000, 0x1FFF0000, 0x200), // main
 				std::make_shared<block_t>(0x20000000, 0x10000000, 0x201), // user 64k pages
 				nullptr, // user 1m pages
+				nullptr, // rsx context
 				std::make_shared<block_t>(0xC0000000, 0x10000000), // video
 				std::make_shared<block_t>(0xD0000000, 0x10000000, 0x111), // stack
 				std::make_shared<block_t>(0xE0000000, 0x20000000), // SPU reserved

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -22,6 +22,7 @@ namespace vm
 		main,
 		user64k,
 		user1m,
+		rsx_context,
 		video,
 		stack,
 		spu,

--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -121,12 +121,14 @@ namespace rsx
 			u32 m_command_inc = 0;
 			u32 m_remaining_commands = 0;
 			u32 m_args_ptr = 0;
+			u32 m_cmd = ~0u;
 
 		public:
 			FIFO_control(rsx::thread* pctrl);
 			~FIFO_control() = default;
 
 			u32 get_pos() { return m_internal_get; }
+			u32 last_cmd() { return m_cmd; }
 			void sync_get() { m_ctrl->get.release(m_internal_get); }
 			void inc_get(bool wait);
 			void set_get(u32 get);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2349,6 +2349,12 @@ namespace rsx
 		invalid_command_interrupt_raised = false;
 	}
 
+	u32 thread::get_fifo_cmd()
+	{
+		// Last fifo cmd for logging and utility
+		return fifo_ctrl->last_cmd();
+	}
+
 	void thread::read_barrier(u32 memory_address, u32 memory_range)
 	{
 		zcull_ctrl->read_barrier(this, memory_address, memory_range);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -91,10 +91,10 @@ namespace rsx
 			return get_current_renderer()->label_addr + offset;
 
 		case CELL_GCM_CONTEXT_DMA_DEVICE_RW:
-			return get_current_renderer()->ctxt_addr + offset;
+			return get_current_renderer()->device_addr + offset;
 
 		case CELL_GCM_CONTEXT_DMA_DEVICE_R:
-			return get_current_renderer()->ctxt_addr + offset;
+			return get_current_renderer()->device_addr + offset;
 
 		default:
 		{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -508,10 +508,21 @@ namespace rsx
 					continue;
 				}
 
-				while (Emu.IsPaused() && !m_rsx_thread_exiting)
-					thread_ctrl::wait_for(wait_sleep);
+				if (Emu.IsPaused())
+				{
+					// Save the difference before pause
+					start_time = get_system_time() - start_time;
+					
+					while (Emu.IsPaused() && !m_rsx_thread_exiting)
+					{
+						thread_ctrl::wait_for(wait_sleep);
+					}
 
-				thread_ctrl::wait_for(100); // Hack
+					// Restore difference
+					start_time = get_system_time() - start_time;
+				}
+
+				thread_ctrl::wait_for(100);
 			}
 		});
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -520,6 +520,7 @@ namespace rsx
 		atomic_t<bool> external_interrupt_ack{ false };
 		void flush_fifo();
 		void recover_fifo();
+		u32 get_fifo_cmd();
 
 		// Performance approximation counters
 		struct

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -564,7 +564,7 @@ namespace rsx
 		RsxDisplayInfo display_buffers[8];
 		u32 display_buffers_count{0};
 		u32 current_display_buffer{0};
-		u32 ctxt_addr;
+		u32 device_addr;
 		u32 label_addr;
 
 		u32 main_mem_size{0};

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -74,7 +74,7 @@ namespace rsx
 			const auto& sema = vm::_ref<atomic_be_t<u32>>(addr);
 
 			// TODO: Remove vblank semaphore hack
-			if (sema == arg || addr == rsx->ctxt_addr + 0x30) return;
+			if (sema == arg || addr == rsx->device_addr + 0x30) return;
 
 			rsx->flush_fifo();
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -41,7 +41,9 @@ namespace rsx
 	{
 		//Don't throw, gather information and ignore broken/garbage commands
 		//TODO: Investigate why these commands are executed at all. (Heap corruption? Alignment padding?)
-		LOG_ERROR(RSX, "Invalid RSX method 0x%x (arg=0x%x)", _reg << 2, arg);
+		const u32 cmd = rsx->get_fifo_cmd();
+		LOG_ERROR(RSX, "Invalid RSX method 0x%x (arg=0x%x, start=0x%x, count=0x%x, non-inc=%s)", _reg << 2, arg, 
+		cmd & 0xfffc, (cmd >> 18) & 0x7ff, !!(cmd & RSX_METHOD_NON_INCREMENT_CMD));
 		rsx->invalid_command_interrupt_raised = true;
 	}
 


### PR DESCRIPTION
* sys_rsx commit restores improved internal error checks and behaviour from #5297. (the pr includes the testcase)
* Fix local_size reported in LLE cellGcmGetConfiguartion, testcase is the same as the one mentioned above.
* Log more info about invalid methods execution and FIFO desync, including  description of starting command and methods range of it.
* Fix vblank signals flood after emulator has resumed from pausing.