### PR TITLE
Fix debug build gcc/clang linker.

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -1,5 +1,7 @@
 ﻿#include "stdafx.h"
 #include "sys_vm.h"
+
+#include "Emu/IdManager.h"
 #include "Emu/Cell/PPUThread.h"
 #include "Emu/Memory/vm_locking.h"
 
@@ -15,8 +17,11 @@ sys_vm_t::sys_vm_t(u32 _addr, u32 vsize, lv2_memory_container* ct, u32 psize)
 
 sys_vm_t::~sys_vm_t()
 {
+	// Debug build : gcc and clang can not find the static var if retrieved directly in "release" function
+	constexpr auto invalid = id_manager::id_traits<sys_vm_t>::invalid;
+
 	// Free ID
-	g_ids[addr >> 28].release(id_manager::id_traits<sys_vm_t>::invalid);
+	g_ids[addr >> 28].release(invalid);
 }
 
 LOG_CHANNEL(sys_vm);

--- a/rpcs3/Emu/Cell/lv2/sys_vm.h
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.h
@@ -2,7 +2,6 @@
 
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
-#include "Emu/IdManager.h"
 #include "sys_memory.h"
 
 #include <array>


### PR DESCRIPTION
Create temporary variable to resolve undefined reference.

[ 98%] Linking CXX executable ../bin/rpcs3
/usr/bin/ld : Emu/librpcs3_emu.a(sys_vm.cpp.o) : dans la fonction « sys_vm_t::~sys_vm_t() » :
/mnt/raid/Git/rpcs3/rpcs3/Emu/Cell/lv2/sys_vm.cpp:21 : référence indéfinie vers « id_manager::id_traits<sys_vm_t, void>::invalid »
collect2: erreur: ld a retourné le statut de sortie 1
make[2]: *** [rpcs3/CMakeFiles/rpcs3.dir/build.make:426: bin/rpcs3] Error 1