### PR TITLE
Debug build : Check ObjectFile before reading.

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -832,7 +832,16 @@ void jit_compiler::add(std::unique_ptr<llvm::Module> module)
 
 void jit_compiler::add(const std::string& path)
 {
-	m_engine->addObjectFile(std::move(llvm::object::ObjectFile::createObjectFile(*ObjectCache::load(path)).get()));
+	auto cache = ObjectCache::load(path);
+
+	if (auto object_file = llvm::object::ObjectFile::createObjectFile(*cache))
+	{
+		m_engine->addObjectFile( std::move(*object_file) );
+	}
+	else
+	{
+		LOG_ERROR(GENERAL, "ObjectCache: Adding failed: %s", path);
+	}
 }
 
 void jit_compiler::fin()


### PR DESCRIPTION
Check LLVM ObjectFile state before access to avoid llvm assertion failure.

Expected<T> must be checked before access or destruction.
Expected<T> value was in success state. (Note: Expected<T> values in success mode must still be checked prior to being destroyed).