### PR TITLE
rsx: Shader emitter fixups [ 3 of 3]

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -1184,7 +1184,7 @@ std::string FragmentProgramDecompiler::Decompile()
 		case RSX_FP_OPCODE_NOP: break;
 		case RSX_FP_OPCODE_KIL:
 			properties.has_discard_op = true;
-			AddFlowOp("discard");
+			AddFlowOp("_kill()");
 			break;
 
 		default:

--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -669,7 +669,7 @@ namespace glsl
 			"}\n\n"
 
 			//TODO: Move all the texture read control operations here
-			"vec4 process_texel(const in vec4 rgba, const in uint control_bits)\n"
+			"vec4 process_texel(in vec4 rgba, const in uint control_bits)\n"
 			"{\n"
 #ifdef __APPLE__
 			"	uint remap_bits = (control_bits >> 16) & 0xFFFF;\n"
@@ -688,6 +688,13 @@ namespace glsl
 			"			discard;\n"
 			"			return rgba;\n"
 			"		}\n"
+			"	}\n"
+			"\n"
+			"	if ((control_bits & 0x20) != 0)\n"
+			"	{\n"
+			"		// Renormalize to 8-bit (PS3) accuracy\n"
+			"		rgba = floor(rgba * 255.);\n"
+			"		rgba /= 255.;"
 			"	}\n"
 			"\n"
 			"	//TODO: Verify gamma control bit ordering, looks to be 0x7 for rgb, 0xF for rgba\n"

--- a/rpcs3/Emu/RSX/Common/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Common/GLSLTypes.h
@@ -30,5 +30,7 @@ namespace glsl
 		bool emulate_coverage_tests;
 		bool emulate_shadow_compare;
 		bool low_precision_tests;
+		bool disable_early_discard;
+		bool supports_native_fp16;
 	};
 };

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -44,6 +44,8 @@ void GLFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 			OS << "#extension GL_AMD_gpu_shader_half_float: require\n";
 		}
 	}
+
+	glsl::insert_subheader_block(OS);
 }
 
 void GLFragmentDecompilerThread::insertInputs(std::stringstream & OS)
@@ -189,7 +191,7 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 	OS << "layout(std140, binding = 5) uniform TextureParametersBuffer\n";
 	OS << "{\n";
-	OS << "	vec4 texture_parameters[16];\n";	//sampling: x,y scaling and (unused) offsets data
+	OS << "	sampler_info texture_parameters[16];\n";
 	OS << "};\n\n";
 }
 

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -197,19 +197,20 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 void GLFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 {
-	glsl::shader_properties properties2;
-	properties2.domain = glsl::glsl_fragment_program;
-	properties2.require_lit_emulation = properties.has_lit_op;
-	properties2.fp32_outputs = !!(m_prog.ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS);
-	properties2.require_depth_conversion = m_prog.redirected_textures != 0;
-	properties2.require_wpos = !!(properties.in_register_mask & in_wpos);
-	properties2.require_texture_ops = properties.has_tex_op;
-	properties2.require_shadow_ops = m_prog.shadow_textures != 0;
-	properties2.emulate_coverage_tests = true; // g_cfg.video.antialiasing_level == msaa_level::none;
-	properties2.emulate_shadow_compare = device_props.emulate_depth_compare;
-	properties2.low_precision_tests = ::gl::get_driver_caps().vendor_NVIDIA;
+	m_shader_props.domain = glsl::glsl_fragment_program;
+	m_shader_props.require_lit_emulation = properties.has_lit_op;
+	m_shader_props.fp32_outputs = !!(m_prog.ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS);
+	m_shader_props.require_depth_conversion = m_prog.redirected_textures != 0;
+	m_shader_props.require_wpos = !!(properties.in_register_mask & in_wpos);
+	m_shader_props.require_texture_ops = properties.has_tex_op;
+	m_shader_props.require_shadow_ops = m_prog.shadow_textures != 0;
+	m_shader_props.emulate_coverage_tests = true; // g_cfg.video.antialiasing_level == msaa_level::none;
+	m_shader_props.emulate_shadow_compare = device_props.emulate_depth_compare;
+	m_shader_props.low_precision_tests = ::gl::get_driver_caps().vendor_NVIDIA;
+	m_shader_props.disable_early_discard = !::gl::get_driver_caps().vendor_NVIDIA;
+	m_shader_props.supports_native_fp16 = device_props.has_native_half_support;
 
-	glsl::insert_glsl_legacy_function(OS, properties2);
+	glsl::insert_glsl_legacy_function(OS, m_shader_props);
 }
 
 void GLFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
@@ -307,11 +308,7 @@ void GLFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	OS << "\n" << "	fs_main();\n\n";
 
-	glsl::insert_rop(
-		OS,
-		!!(m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS),
-		device_props.has_native_half_support,
-		g_cfg.video.antialiasing_level == msaa_level::none);
+	glsl::insert_rop(OS, m_shader_props);
 
 	if (m_ctrl & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT)
 	{

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
@@ -1,11 +1,19 @@
-#pragma once
+﻿#pragma once
 #include "../Common/FragmentProgramDecompiler.h"
+#include "../Common/GLSLTypes.h"
 #include "Emu/RSX/RSXFragmentProgram.h"
+
+namespace glsl
+{
+	struct shader_properties;
+}
 
 struct GLFragmentDecompilerThread : public FragmentProgramDecompiler
 {
 	std::string& m_shader;
 	ParamArray& m_parrDummy;
+	glsl::shader_properties m_shader_props{};
+
 public:
 	GLFragmentDecompilerThread(std::string& shader, ParamArray& parr, const RSXFragmentProgram &prog, u32& size)
 		: FragmentProgramDecompiler(prog, size)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -699,7 +699,7 @@ namespace rsx
 		auto alpha_ref = rsx::method_registers.alpha_ref() / 255.f;
 		auto rop_control = rsx::method_registers.alpha_test_enabled()? 1u : 0u;
 
-		if (rsx::method_registers.msaa_alpha_to_coverage_enabled() && !supports_hw_a2c)
+		if (rsx::method_registers.msaa_alpha_to_coverage_enabled() && !backend_config.supports_hw_a2c)
 		{
 			// Alpha values generate a coverage mask for order independent blending
 			// Requires hardware AA to work properly (or just fragment sample stage in fragment shaders)
@@ -1726,6 +1726,22 @@ namespace rsx
 					}
 					default:
 						LOG_ERROR(RSX, "Depth texture bound to pipeline with unexpected format 0x%X", format);
+					}
+				}
+				else if (!backend_config.supports_hw_renormalization)
+				{
+					switch (format)
+					{
+					case CELL_GCM_TEXTURE_A1R5G5B5:
+					case CELL_GCM_TEXTURE_A4R4G4B4:
+					case CELL_GCM_TEXTURE_D1R5G5B5:
+					case CELL_GCM_TEXTURE_R5G5B5A1:
+					case CELL_GCM_TEXTURE_R5G6B5:
+					case CELL_GCM_TEXTURE_R6G5B5:
+						texture_control |= (1 << 5);
+						break;
+					default:
+						break;
 					}
 				}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1669,7 +1669,7 @@ namespace rsx
 			auto &tex = rsx::method_registers.fragment_textures[i];
 			result.texture_scale[i][0] = sampler_descriptors[i]->scale_x;
 			result.texture_scale[i][1] = sampler_descriptors[i]->scale_y;
-			result.texture_scale[i][2] = (f32)tex.remap();  //Debug value
+			result.texture_scale[i][2] = std::bit_cast<f32>(tex.remap());
 
 			if (tex.enabled() && (current_fp_metadata.referenced_textures_mask & (1 << i)))
 			{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -464,6 +464,13 @@ namespace rsx
 		}
 	};
 
+	struct backend_configuration
+	{
+		bool supports_multidraw;           // Draw call batching
+		bool supports_hw_a2c;              // Alpha to coverage
+		bool supports_hw_renormalization;  // Should be true on NV hardware which matches PS3 texture renormalization behaviour
+	};
+
 	struct sampled_image_descriptor_base;
 
 	class thread
@@ -484,8 +491,7 @@ namespace rsx
 		bool skip_current_frame = false;
 		frame_statistics_t stats{};
 
-		bool supports_multidraw = false;  // Draw call batching
-		bool supports_hw_a2c = false;     // Alpha to coverage
+		backend_configuration backend_config{};
 
 		// FIFO
 		std::unique_ptr<FIFO::FIFO_control> fifo_ctrl;

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -228,19 +228,20 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 void VKFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 {
-	glsl::shader_properties properties2;
-	properties2.domain = glsl::glsl_fragment_program;
-	properties2.require_lit_emulation = properties.has_lit_op;
-	properties2.fp32_outputs = !!(m_prog.ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS);
-	properties2.require_depth_conversion = m_prog.redirected_textures != 0;
-	properties2.require_wpos = !!(properties.in_register_mask & in_wpos);
-	properties2.require_texture_ops = properties.has_tex_op;
-	properties2.require_shadow_ops = m_prog.shadow_textures != 0;
-	properties2.emulate_coverage_tests = g_cfg.video.antialiasing_level == msaa_level::none;
-	properties2.emulate_shadow_compare = device_props.emulate_depth_compare;
-	properties2.low_precision_tests = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
+	m_shader_props.domain = glsl::glsl_fragment_program;
+	m_shader_props.require_lit_emulation = properties.has_lit_op;
+	m_shader_props.fp32_outputs = !!(m_prog.ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS);
+	m_shader_props.require_depth_conversion = m_prog.redirected_textures != 0;
+	m_shader_props.require_wpos = !!(properties.in_register_mask & in_wpos);
+	m_shader_props.require_texture_ops = properties.has_tex_op;
+	m_shader_props.require_shadow_ops = m_prog.shadow_textures != 0;
+	m_shader_props.emulate_coverage_tests = g_cfg.video.antialiasing_level == msaa_level::none;
+	m_shader_props.emulate_shadow_compare = device_props.emulate_depth_compare;
+	m_shader_props.low_precision_tests = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
+	m_shader_props.disable_early_discard = vk::get_driver_vendor() != vk::driver_vendor::NVIDIA;
+	m_shader_props.supports_native_fp16 = device_props.has_native_half_support;
 
-	glsl::insert_glsl_legacy_function(OS, properties2);
+	glsl::insert_glsl_legacy_function(OS, m_shader_props);
 }
 
 void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
@@ -338,11 +339,7 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 
 	OS << "\n" << "	fs_main();\n\n";
 
-	glsl::insert_rop(
-		OS,
-		!!(m_ctrl & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS),
-		device_props.has_native_half_support,
-		g_cfg.video.antialiasing_level == msaa_level::none);
+	glsl::insert_rop(OS, m_shader_props);
 
 	if (m_ctrl & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT)
 	{

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -40,6 +40,8 @@ void VKFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 	}
 
 	OS << "#extension GL_ARB_separate_shader_objects: enable\n\n";
+
+	glsl::insert_subheader_block(OS);
 }
 
 void VKFragmentDecompilerThread::insertInputs(std::stringstream & OS)
@@ -205,7 +207,7 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 	OS << "layout(std140, set = 0, binding = 4) uniform TextureParametersBuffer\n";
 	OS << "{\n";
-	OS << "	vec4 texture_parameters[16];\n";
+	OS << "	sampler_info texture_parameters[16];\n";
 	OS << "};\n\n";
 
 	vk::glsl::program_input in;

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
@@ -1,5 +1,6 @@
-#pragma once
+﻿#pragma once
 #include "../Common/FragmentProgramDecompiler.h"
+#include "../Common/GLSLTypes.h"
 #include "Emu/RSX/RSXFragmentProgram.h"
 #include "VulkanAPI.h"
 #include "VKHelpers.h"
@@ -10,6 +11,8 @@ struct VKFragmentDecompilerThread : public FragmentProgramDecompiler
 	ParamArray& m_parrDummy;
 	std::vector<vk::glsl::program_input> inputs;
 	class VKFragmentProgram *vk_prog;
+	glsl::shader_properties m_shader_props{};
+
 public:
 	VKFragmentDecompilerThread(std::string& shader, ParamArray& parr, const RSXFragmentProgram &prog, u32& size, class VKFragmentProgram& dst)
 		: FragmentProgramDecompiler(prog, size)

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -321,7 +321,6 @@ namespace vk
 	{
 		vk::reset_compute_tasks();
 		vk::reset_resolve_resources();
-		vk::vmm_reset();
 
 		g_upload_heap.reset_allocation_stats();
 	}
@@ -333,6 +332,7 @@ namespace vk
 		vk::clear_framebuffer_cache();
 		vk::clear_resolve_helpers();
 		vk::clear_dma_resources();
+		vk::vmm_reset();
 		vk::get_resource_manager()->destroy();
 
 		g_null_texture.reset();


### PR DESCRIPTION
- Implements integer renormalization at 8 bits to mimic NVIDIA hardware implementation. All NVIDIA cards seem to normalize small-width integers smaller than 8 bits to 8 bits internally which causes an arithmetic error of around 1 part in 255. This error is small, but when used as for texture lookups, the error can be magnified greatly due to the relatively large texture sizes, causing unexpected errors. This option is enabled for AMD (which is too precise) and Intel (which is untested but expected to not follow NVIDIA's unorthodox implementation).
- Refactors fragment shaders a bit to make debugging easier. Declares a useful struct to hold texture parameters and also the explicit types avoid senseless OpBitCast that were emitted all over the place.
- Implement optional delayed discard. On some AMD hardware, edge texels (samples?) can sometimes "contribute" to the discardedness of a fragment, even when the visible fragments should not have triggered the discard. FIxes a rare diagonal line glitch on AMD cards. This option is also enabled by default for intel hardware since I am not able to extensively test its behavior.