### PR TITLE
SPU LLVM: asynchronous compilation

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -45,9 +45,12 @@ void spu_recompiler::init()
 	}
 }
 
-spu_function_t spu_recompiler::compile(u64 last_reset_count, const std::vector<u32>& func)
+spu_function_t spu_recompiler::compile(u64 last_reset_count, const std::vector<u32>& func, void* fn_location)
 {
-	const auto fn_location = m_spurt->find(last_reset_count, func);
+	if (!fn_location)
+	{
+		fn_location = m_spurt->find(last_reset_count, func);
+	}
 
 	if (fn_location == spu_runtime::g_dispatcher)
 	{

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
@@ -13,7 +13,7 @@ public:
 
 	virtual void init() override;
 
-	virtual spu_function_t compile(u64 last_reset_count, const std::vector<u32>&) override;
+	virtual spu_function_t compile(u64 last_reset_count, const std::vector<u32>&, void*) override;
 
 private:
 	// ASMJIT runtime

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -104,6 +104,12 @@ public:
 	// Return opaque pointer for add()
 	void* find(u64 last_reset_count, const std::vector<u32>&);
 
+	// Get func from opaque ptr
+	static inline const std::vector<u32>& get_func(void* _where)
+	{
+		return static_cast<decltype(m_map)::value_type*>(_where)->first;
+	}
+
 	// Find existing function
 	spu_function_t find(const u32* ls, u32 addr) const;
 
@@ -133,6 +139,9 @@ public:
 
 	// Similar to g_escape, but doing tail call to the new function.
 	static void(*const g_tail_escape)(spu_thread*, spu_function_t, u8*);
+
+	// Interpreter table (spu_itype -> ptr)
+	static std::array<u64, 256> g_interpreter_table;
 
 	// Interpreter entry point
 	static spu_function_t g_interpreter;
@@ -364,7 +373,7 @@ public:
 	virtual void init() = 0;
 
 	// Compile function (may fail)
-	virtual spu_function_t compile(u64 last_reset_count, const std::vector<u32>&) = 0;
+	virtual spu_function_t compile(u64 last_reset_count, const std::vector<u32>&, void*) = 0;
 
 	// Compile function, handle failure
 	void make_function(const std::vector<u32>&);
@@ -400,4 +409,7 @@ public:
 
 	// Create recompiler instance (LLVM)
 	static std::unique_ptr<spu_recompiler_base> make_llvm_recompiler(u8 magn = 0);
+
+	// Create recompiler instance (interpreter-based LLVM)
+	static std::unique_ptr<spu_recompiler_base> make_fast_llvm_recompiler();
 };

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1227,7 +1227,7 @@ spu_thread::spu_thread(vm::addr_t ls, lv2_spu_group* group, u32 index, std::stri
 
 	if (g_cfg.core.spu_decoder == spu_decoder_type::llvm)
 	{
-		jit = spu_recompiler_base::make_llvm_recompiler();
+		jit = spu_recompiler_base::make_fast_llvm_recompiler();
 	}
 
 	if (g_cfg.core.spu_decoder != spu_decoder_type::fast && g_cfg.core.spu_decoder != spu_decoder_type::precise)

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -514,6 +514,12 @@ public:
 
 	u32 pc = 0;
 
+	// May be used internally by recompilers.
+	u32 base_pc = 0;
+
+	// May be used by recompilers.
+	u8* memory_base_addr = vm::g_base_addr;
+
 	// General-Purpose Registers
 	std::array<v128, 128> gpr;
 	SPU_FPSCR fpscr;
@@ -580,8 +586,6 @@ public:
 	u64 block_failure = 0;
 
 	u64 saved_native_sp = 0; // Host thread's stack pointer for emulated longjmp
-
-	u8* memory_base_addr = vm::g_base_addr;
 
 	std::array<v128, 0x4000> stack_mirror; // Return address information
 

--- a/rpcs3_default.props
+++ b/rpcs3_default.props
@@ -19,13 +19,14 @@
       <SDLCheck>false</SDLCheck>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalOptions>/Zc:throwingNew</AdditionalOptions>
+      <AdditionalOptions>/Zc:throwingNew -d2FH4- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>xxhash.lib;ws2_32.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\3rdparty\ffmpeg\Windows\x86_64\lib</AdditionalLibraryDirectories>
       <StackReserveSize>8388608</StackReserveSize>
       <StackCommitSize>1048576</StackCommitSize>
+      <AdditionalOptions>-d2:-FH4- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />


### PR DESCRIPTION
Should improve SPU LLVM in cases of stuttering or bugs caused by interrupting SPU threads with compilation. Compilation in SPU LLVM is now offloaded to separate thread.