### PR TITLE
rsx: Align down index array offset

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -969,8 +969,7 @@ s32 gcmMapEaIoAddress(u32 ea, u32 io, u32 size, bool is_strict)
 		return CELL_GCM_ERROR_FAILURE;
 	}
 
-	// TODO: Pass correct flags and context
-	if (s32 error = sys_rsx_context_iomap(0, io, ea, size, 0))
+	if (s32 error = sys_rsx_context_iomap(0x55555555, io, ea, size, 0xe000000000000800ull | (u64{is_strict} << 60)))
 	{
 		return error;
 	}
@@ -1035,7 +1034,7 @@ s32 cellGcmMapMainMemory(u32 ea, u32 size, vm::ptr<u32> offset)
 		{
 			if (unmap_count >= (size >> 20))
 			{
-				if (s32 error = sys_rsx_context_iomap(0, io << 20, ea, size, 0))
+				if (s32 error = sys_rsx_context_iomap(0x55555555, io << 20, ea, size, 0xe000000000000800ull))
 				{
 					return error;
 				}

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -56,6 +56,12 @@ struct RsxDriverInfo
 static_assert(sizeof(RsxDriverInfo) == 0x12F8, "rsxSizeTest");
 static_assert(sizeof(RsxDriverInfo::Head) == 0x40, "rsxHeadSizeTest");
 
+enum : u64
+{
+	// Unused
+	SYS_RSX_IO_MAP_IS_STRICT = 1ull << 60
+};
+
 struct RsxDmaControl
 {
 	u8 resv[0x40];

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -171,9 +171,9 @@ namespace rsx
 				const u32 base_address    = method_registers.index_array_address();
 				const u32 memory_location = method_registers.index_array_location();
 
-				const u32 base_addr   = get_address(base_address, memory_location);
-				const u32 type_size   = get_index_type_size(method_registers.index_type());
 				const auto index_type = method_registers.index_type();
+				const u32 type_size   = get_index_type_size(index_type);
+				const u32 base_addr   = get_address(base_address, memory_location) & ~(type_size - 1);
 
 				// manually parse index buffer and copy vertex buffer
 				u32 min_index = 0xFFFFFFFF, max_index = 0;

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -50,7 +50,7 @@ namespace rsx
 
 		get_current_renderer()->main_mem_size = buffer_size;
 
-		if (sys_rsx_context_iomap(contextInfo->context_id, 0, user_mem_addr, buffer_size, 0) != CELL_OK)
+		if (sys_rsx_context_iomap(contextInfo->context_id, 0, user_mem_addr, buffer_size, 0xf000000000000800ull) != CELL_OK)
 			fmt::throw_exception("Capture Replay: rsx io mapping failed!");
 
 		return contextInfo->context_id;

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -450,7 +450,7 @@ std::vector<rsx_subresource_layout> get_subresources_layout_impl(const RsxTextur
 	int format = texture.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 
 	const u32 texaddr = rsx::get_address(texture.offset(), texture.location());
-	auto pixels = reinterpret_cast<const gsl::byte*>(vm::_ptr<const u8>(texaddr));
+	auto pixels = vm::_ptr<const gsl::byte>(texaddr);
 
 	const bool is_swizzled = !(texture.format() & CELL_GCM_TEXTURE_LN);
 	const bool has_border = !texture.border_type();

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2407,7 +2407,7 @@ namespace rsx
 					subres.height_in_block = image_height;
 					subres.pitch_in_block = full_width;
 					subres.depth = 1;
-					subres.data = { reinterpret_cast<const gsl::byte*>(vm::base(image_base)), src.pitch * image_height };
+					subres.data = { vm::_ptr<const gsl::byte>(image_base), src.pitch * image_height };
 					subresource_layout.push_back(subres);
 
 					vram_texture = upload_image_from_cpu(cmd, rsx_range, image_width, image_height, 1, 1, src.pitch, gcm_format, texture_upload_context::blit_engine_src,
@@ -2539,7 +2539,7 @@ namespace rsx
 						subres.height_in_block = dst_dimensions.height;
 						subres.pitch_in_block = pitch_in_block;
 						subres.depth = 1;
-						subres.data = { reinterpret_cast<const gsl::byte*>(vm::get_super_ptr(dst.rsx_address)), dst.pitch * dst_dimensions.height };
+						subres.data = { vm::get_super_ptr<const gsl::byte>(dst.rsx_address), dst.pitch * dst_dimensions.height };
 						subresource_layout.push_back(subres);
 
 						cached_dest = upload_image_from_cpu(cmd, rsx_range, dst_dimensions.width, dst_dimensions.height, 1, 1, dst.pitch,

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -93,7 +93,7 @@ namespace
 				rsx::index_array_type::u32:
 				rsx::method_registers.index_type();
 			
-			u32 type_size              = ::narrow<u32>(get_index_type_size(type));
+			u32 type_size              = get_index_type_size(type);
 
 			const u32 vertex_count = rsx::method_registers.current_draw_clause.get_elements_count();
 			u32 index_count = vertex_count;

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -132,7 +132,7 @@ namespace
 				rsx::index_array_type::u32 :
 				rsx::method_registers.index_type();
 
-			u32 type_size = gsl::narrow<u32>(get_index_type_size(index_type));
+			u32 type_size = get_index_type_size(index_type);
 
 			u32 index_count = rsx::method_registers.current_draw_clause.get_elements_count();
 			if (primitives_emulated)


### PR DESCRIPTION
[testcase](https://github.com/elad335/myps3tests/blob/master/rsx_tests/Index%20array's%20indices%20alignment/mainrsxcrap.cpp#L282): it's testing two "unaligned" (one byte aligned) index array offests, one for u16 index type (0xc4900001) and the other for u32 index type (0xc4900003, both produce the same graphical output as aligned down versions. (more specifically offset 0xc4900000). rpcs3 master doesn't produce an image on both unaligned versions.

Also fixes HLE gcm regression after #6810 (pass context_id).
