### PR TITLE
Allow window resizing on Wayland, including fullscreen

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -2169,7 +2169,7 @@ public:
 		}
 
 	public:
-		swapchain_WSI(vk::physical_device &gpu, uint32_t _present_queue, uint32_t _graphics_queue, VkFormat format, VkSurfaceKHR surface, VkColorSpaceKHR color_space)
+		swapchain_WSI(vk::physical_device &gpu, uint32_t _present_queue, uint32_t _graphics_queue, VkFormat format, VkSurfaceKHR surface, VkColorSpaceKHR color_space, bool force_wm_reporting_off)
 			: WSI_swapchain_base(gpu, _present_queue, _graphics_queue, format)
 		{
 			createSwapchainKHR = (PFN_vkCreateSwapchainKHR)vkGetDeviceProcAddr(dev, "vkCreateSwapchainKHR");
@@ -2181,17 +2181,20 @@ public:
 			m_surface = surface;
 			m_color_space = color_space;
 
-			switch (gpu.get_driver_vendor())
+			if (!force_wm_reporting_off)
 			{
-			case driver_vendor::AMD:
-				break;
-			case driver_vendor::NVIDIA:
-			case driver_vendor::INTEL:
-			case driver_vendor::RADV:
-				m_wm_reports_flag = true;
-				break;
-			default:
-				break;
+				switch (gpu.get_driver_vendor())
+				{
+				case driver_vendor::AMD:
+					break;
+				case driver_vendor::NVIDIA:
+				case driver_vendor::INTEL:
+				case driver_vendor::RADV:
+					m_wm_reports_flag = true;
+					break;
+				default:
+					break;
+				}
 			}
 		}
 
@@ -2591,6 +2594,7 @@ public:
 		swapchain_base* createSwapChain(display_handle_t window_handle, vk::physical_device &dev)
 		{
 			VkSurfaceKHR surface;
+			bool force_wm_reporting_off = false;
 #ifdef _WIN32
 			using swapchain_NATIVE = swapchain_WIN32;
 			HINSTANCE hInstance = NULL;
@@ -2632,6 +2636,7 @@ public:
 					createInfo.display                       = p.first;
 					createInfo.surface                       = p.second;
 					CHECK_RESULT(vkCreateWaylandSurfaceKHR(this->m_instance, &createInfo, nullptr, &surface));
+					force_wm_reporting_off = true;
 				}
 				else
 				{
@@ -2753,7 +2758,7 @@ public:
 
 			color_space = surfFormats[0].colorSpace;
 
-			return new swapchain_WSI(dev, presentQueueNodeIndex, graphicsQueueNodeIndex, format, surface, color_space);
+			return new swapchain_WSI(dev, presentQueueNodeIndex, graphicsQueueNodeIndex, format, surface, color_space, force_wm_reporting_off);
 		}
 	};
 


### PR DESCRIPTION
The current behaviour when going fullscreen from windowed was to keep
the previous size of the swapchain, with black borders on all sides,
which looks quite ugly.

The root of this issue is that rpcs3 only checks for frame resize if
`vkQueuePresent()` returns `VK_SUBOPTIMAL_KHR`, which anv doesn’t do on
Wayland currently, an issue has been opened against it, see
https://gitlab.freedesktop.org/mesa/mesa/issues/1979

It would make sense to stop checking for that altogether, because it
introduces a delay of one frame during which the previous swapchain will
be used, even though the `GSFrameBase` implementation already knows the
buffer size should have changed.

Another alternative solution would be to change the relation between the
`GSFrameBase` implementation and the `GSRender`, and make the former tell
the latter when the buffer size changed, instead of the latter polling
the former’s size.

Comments welcome, if you prefer me to go for any of these other two
solutions rather than this simple first version.