### PR TITLE
Fix some indent mistake and unneeded std::move

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -402,7 +402,7 @@ std::vector<std::string> fmt::split(const std::string& source, std::initializer_
 		result.push_back(source.substr(cursor_begin));
 	}
 
-	return std::move(result);
+	return result;
 }
 
 std::string fmt::trim(const std::string& source, const std::string& values)

--- a/rpcs3/Emu/Cell/lv2/sys_config.h
+++ b/rpcs3/Emu/Cell/lv2/sys_config.h
@@ -200,7 +200,7 @@ public:
 		if (const u32 idm_id = idm::import_existing<lv2_config_handle>(cfg))
 		{
 			cfg->idm_id = idm_id;
-			return std::move(cfg);
+			return cfg;
 		}
 		return nullptr;
 	}
@@ -259,7 +259,7 @@ public:
 		{
 			service->wkptr = service;
 			service->idm_id = idm_id;
-			return std::move(service);
+			return service;
 		}
 
 		return nullptr;
@@ -326,7 +326,7 @@ public:
 		{
 			listener->wkptr = listener;
 			listener->idm_id = idm_id;
-			return std::move(listener);
+			return listener;
 		}
 
 		return nullptr;
@@ -389,7 +389,7 @@ public:
 
 		g_fxo->get<lv2_config>()->add_service_event(ev);
 
-		return std::move(ev);
+		return ev;
 	}
 
 	// Destructor

--- a/rpcs3/Emu/RSX/GSRender.h
+++ b/rpcs3/Emu/RSX/GSRender.h
@@ -52,42 +52,42 @@ using RSXDebuggerPrograms = std::vector<RSXDebuggerProgram>;
 using draw_context_t = void*;
 
 #ifdef _WIN32
-	using display_handle_t = HWND;
+using display_handle_t = HWND;
 #elif defined(__APPLE__)
-	using display_handle_t = void*; // NSView
+using display_handle_t = void*; // NSView
 #else
-	using display_handle_t = std::variant<
-		std::pair<Display*, Window>
+using display_handle_t = std::variant<
+	std::pair<Display*, Window>
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-		, std::pair<wl_display*, wl_surface*>
+	, std::pair<wl_display*, wl_surface*>
 #endif
-	>;
+>;
 #endif
 
-	class GSFrameBase
-	{
-	public:
-		GSFrameBase() = default;
-		GSFrameBase(const GSFrameBase&) = delete;
-		virtual ~GSFrameBase() = default;
+class GSFrameBase
+{
+public:
+	GSFrameBase() = default;
+	GSFrameBase(const GSFrameBase&) = delete;
+	virtual ~GSFrameBase() = default;
 
-		virtual void close() = 0;
-		virtual bool shown() = 0;
-		virtual void hide() = 0;
-		virtual void show() = 0;
-		virtual void toggle_fullscreen() = 0;
+	virtual void close() = 0;
+	virtual bool shown() = 0;
+	virtual void hide() = 0;
+	virtual void show() = 0;
+	virtual void toggle_fullscreen() = 0;
 
-		virtual void delete_context(draw_context_t ctx) = 0;
-		virtual draw_context_t make_context() = 0;
-		virtual void set_current(draw_context_t ctx) = 0;
-		virtual void flip(draw_context_t ctx, bool skip_frame = false) = 0;
-		virtual int client_width() = 0;
-		virtual int client_height() = 0;
+	virtual void delete_context(draw_context_t ctx) = 0;
+	virtual draw_context_t make_context() = 0;
+	virtual void set_current(draw_context_t ctx) = 0;
+	virtual void flip(draw_context_t ctx, bool skip_frame = false) = 0;
+	virtual int client_width() = 0;
+	virtual int client_height() = 0;
 
-		virtual display_handle_t handle() const = 0;
+	virtual display_handle_t handle() const = 0;
 
-		std::atomic<bool> screenshot_toggle = false;
-		virtual void take_screenshot(const std::vector<u8> sshot_data, const u32 sshot_width, const u32 sshot_height) = 0;
+	std::atomic<bool> screenshot_toggle = false;
+	virtual void take_screenshot(const std::vector<u8> sshot_data, const u32 sshot_width, const u32 sshot_height) = 0;
 };
 
 class GSRender : public rsx::thread

--- a/rpcs3/evdev_joystick_handler.cpp
+++ b/rpcs3/evdev_joystick_handler.cpp
@@ -682,7 +682,7 @@ PadHandlerBase::connection evdev_joystick_handler::update_connection(const std::
 	if (!update_device(device))
 		return connection::disconnected;
 
-		auto evdev_device = std::static_pointer_cast<EvdevDevice>(device);
+	auto evdev_device = std::static_pointer_cast<EvdevDevice>(device);
 	if (!evdev_device || !evdev_device->device)
 		return connection::disconnected;
 


### PR DESCRIPTION
`std::move()` should be avoided when returning a stack object as it prevents [copy elision](https://en.cppreference.com/w/cpp/language/copy_elision).

The indent fix was pointed out by gcc 9 as potentially misleading.