### PR TITLE
Add a file lock to check if we're restarting

### DIFF
--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -325,16 +325,25 @@ logs::file_writer::file_writer(const std::string& name)
 	const std::string log_name = fs::get_cache_dir() + name + ".log";
 	const std::string buf_name = fs::get_cache_dir() + name + ".buf";
 
+	const std::string s_filelock = fs::get_cache_dir() + ".restart_lock";
+
 	try
 	{
 		if (!m_file.open(buf_name, fs::read + fs::rewrite + fs::lock))
 		{
 #ifdef _WIN32
-			// Windows does not close all handles before starting a new process with execl
-			// We delay another check for rpcs3 restart after an update
-			// TODO: cleaner solution?
-			std::this_thread::sleep_for(500ms);
-			if (!m_file.open(buf_name, fs::read + fs::rewrite + fs::lock))
+			if (fs::exists(s_filelock))
+			{
+				// A restart is happening, wait for the file to be accessible
+				u32 tries = 0;
+				while (!m_file.open(buf_name, fs::read + fs::rewrite + fs::lock) && tries < 100)
+				{
+					std::this_thread::sleep_for(100ms);
+					tries++;
+				}
+			}
+
+			if (!m_file)
 #endif
 			{
 				if (fs::g_tls_error == fs::error::acces)
@@ -358,6 +367,10 @@ logs::file_writer::file_writer(const std::string& name)
 				fmt::throw_exception("Cannot create %s.log (error %s)", name, fs::g_tls_error);
 			}
 		}
+
+#ifdef _WIN32
+		fs::remove_file(s_filelock); // remove restart token if it exists
+#endif
 
 		// Check free space
 		fs::device_stat stats{};

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -73,8 +73,8 @@ void update_manager::handle_error(QNetworkReply::NetworkError error)
 {
 	if (error != QNetworkReply::NoError)
 	{
-		QNetworkReply* reply = qobject_cast<QNetworkReply *>(sender());
-		if(!reply)
+		QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
+		if (!reply)
 			return;
 
 		m_progress_dialog->close();
@@ -543,13 +543,16 @@ bool update_manager::handle_rpcs3(const QByteArray& rpcs3_data, bool automatic)
 
 	replace_path = Emulator::GetEmuDir() + "rpcs3.exe";
 
+	// Creating a file to indicate we're restarting
+	const std::string s_filelock = fs::get_cache_dir() + ".restart_lock";
+	verify("Restart lock" HERE), !!fs::file(s_filelock, fs::create);
+
 #endif
 
 	m_progress_dialog->close();
-
 	QMessageBox::information(m_parent, tr("Auto-updater"), tr("Update successful!"));
-	int ret = execl(replace_path.c_str(), replace_path.c_str(), nullptr);
 
+	int ret = execl(replace_path.c_str(), replace_path.c_str(), nullptr);
 	if (ret == -1)
 	{
 		LOG_ERROR(GENERAL, "[Auto-updater] Relaunching failed with result: %d(%s)", ret, strerror(errno));


### PR DESCRIPTION
Should hopefully stop people having "Another instance is running" when restarting after an update.