### PR TITLE
rsx: Copypasta fix

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -668,7 +668,7 @@ std::string FragmentProgramDecompiler::BuildCode()
 	if (m_ctrl & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT)
 	{
 		// Hw tests show that the depth export register is default-initialized to 0 and not wpos.z!!
-		m_parr.AddParam(PF_PARAM_NONE, float4_type, "r1", init_value);
+		m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), "r1", init_value);
 		shader_is_valid = (!!temp_registers[1].h1_writes);
 	}
 


### PR DESCRIPTION
- r1 is always float4 never half4. Its a full-width register unlike the
other outputs which are optionally half-width.

Fixes a problem where native fp16 support would break rendering in some titles because depth export was not working.