### PR TITLE
vk: Restore vega native use of FP16 in shaders

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -600,8 +600,8 @@ private:
 
 			if (get_chip_class() == chip_class::AMD_vega)
 			{
-				LOG_WARNING(RSX, "float16_t does not work correctly on VEGA hardware on all drivers. Using float32_t fallback instead.");
-				shader_types_support.allow_float16 = false;
+				// Disable fp16 if driver uses LLVM emitter. It does fine with AMD proprietary drivers though.
+				shader_types_support.allow_float16 = (driver_properties.driverID == VK_DRIVER_ID_AMD_PROPRIETARY_KHR);
 			}
 		}
 


### PR DESCRIPTION
With https://github.com/RPCS3/rpcs3/pull/6842 fixing the fp16 bug, it is worth retesting for owners of Vega GPUs that games are rendering correctly again even with fp16 enabled.