### PR TITLE
Adds quickstart link to SSL warnings

### DIFF
--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -115,8 +115,11 @@ void game_compatibility::RequestCompatibility(bool online)
 
 	if (QSslSocket::supportsSsl() == false)
 	{
-		LOG_ERROR(GENERAL, "Can not retrieve the online database! Please make sure your system supports SSL.");
-		QMessageBox::warning(nullptr, tr("Warning!"), tr("Can not retrieve the online database! Please make sure your system supports SSL."));
+		LOG_ERROR(GENERAL, "Can not retrieve the online database! Please make sure your system supports SSL. Visit our quickstart guide for more information: https://rpcs3.net/quickstart");
+		const QString message = tr("Can not retrieve the online database!<br>Please make sure your system supports SSL.<br>Visit our <a href='https://rpcs3.net/quickstart'>quickstart guide</a> for more information.");
+		QMessageBox box(QMessageBox::Icon::Warning, tr("Warning!"), message, QMessageBox::StandardButton::Ok, nullptr);
+		box.setTextFormat(Qt::RichText);
+		box.exec();
 		return;
 	}
 

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -6,7 +6,7 @@ progress_dialog::progress_dialog(const QString &windowTitle, const QString &labe
 	: QProgressDialog(labelText, cancelButtonText, minimum, maximum, parent, flags)
 {
 	setWindowTitle(windowTitle);
-	setFixedWidth(QLabel("This is the very length of the progressdialog due to hidpi reasons.").sizeHint().width());
+	setFixedSize(QLabel("This is the very length of the progressdialog due to hidpi reasons.").sizeHint().width(), sizeHint().height());
 	setValue(0);
 	setWindowModality(Qt::WindowModal);
 	connect(this, &QProgressDialog::canceled, this, &QProgressDialog::deleteLater);

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -35,9 +35,14 @@ void update_manager::check_for_updates(bool automatic, QWidget* parent)
 {
 	if (QSslSocket::supportsSsl() == false)
 	{
-		LOG_ERROR(GENERAL, "Can't update! Please make sure your system supports SSL.");
+		LOG_ERROR(GENERAL, "Unable to update RPCS3!Please make sure your system supports SSL. Visit our quickstart guide for more information: https://rpcs3.net/quickstart");
 		if (!automatic)
-			QMessageBox::warning(parent, tr("Auto-updater"), tr("Can't update! Please make sure your system supports SSL."));
+		{
+			const QString message = tr("Unable to update RPCS3!<br>Please make sure your system supports SSL.<br>Visit our <a href='https://rpcs3.net/quickstart'>quickstart guide</a> for more information.");
+			QMessageBox box(QMessageBox::Icon::Warning, tr("Auto-updater"), message, QMessageBox::StandardButton::Ok, parent);
+			box.setTextFormat(Qt::RichText);
+			box.exec();
+		}
 		return;
 	}
 

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -262,7 +262,7 @@ bool update_manager::handle_json(const QByteArray& data, bool automatic)
 	return true;
 }
 
-bool update_manager::handle_rpcs3(const QByteArray& rpcs3_data, bool automatic)
+bool update_manager::handle_rpcs3(const QByteArray& rpcs3_data, bool /*automatic*/)
 {
 	if (m_expected_size != rpcs3_data.size())
 	{


### PR DESCRIPTION
1. Adds the quickstart link to SSL warnings.
2. Updates error handling for the compatibility database updater.

Needs https://github.com/DAGINATSUKO/www-rpcs3/pull/42 to be deployed first.

fixes #6874