### PR TITLE
Normalize audio when downmixing to avoid clipping

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -756,6 +756,7 @@ void cell_audio_thread::mix(float *out_buffer, s32 offset)
 		auto buf = port.get_vm_ptr(offset);
 		static const float k = 0.3694f;	/* avoids clipping loud audio when downmixing multiple channels to 2
                                        https://hydrogenaud.io/index.php?topic=104214.msg855199#msg855199 */
+		static const float minus_3db = 0.7071f;
 		float& m = port.level;
 
 		// part of cellAudioSetPortLevel functionality
@@ -827,11 +828,11 @@ void cell_audio_thread::mix(float *out_buffer, s32 offset)
 
 					if constexpr (DownmixToStereo)
 					{
-						const float mid = center * 0.7071f; /* don't mix in the lfe as per
+						const float mid = center * minus_3db; /* don't mix in the lfe as per
                                                    https://hydrogenaud.io/index.php?topic=104214.msg855199#msg855199
                                                    recommendations) */
-						out_buffer[out + 0] = (left + rear_left + (side_left * 0.7071f) + mid) * k;
-						out_buffer[out + 1] = (right + rear_right + (side_right * 0.7071f) + mid) * k;
+						out_buffer[out + 0] = (left + rear_left + (side_left * minus_3db) + mid) * k;
+						out_buffer[out + 1] = (right + rear_right + (side_right * minus_3db) + mid) * k;
 					}
 					else
 					{
@@ -864,9 +865,9 @@ void cell_audio_thread::mix(float *out_buffer, s32 offset)
 
 					if constexpr (DownmixToStereo)
 					{
-						const float mid = center * 0.7071f;
-						out_buffer[out + 0] += (left + rear_left + (side_left * 0.7071f) + mid) * k;
-						out_buffer[out + 1] += (right + rear_right + (side_right * 0.7071f) + mid) * k;
+						const float mid = center * minus_3db;
+						out_buffer[out + 0] += (left + rear_left + (side_left * minus_3db) + mid) * k;
+						out_buffer[out + 1] += (right + rear_right + (side_right * minus_3db) + mid) * k;
 					}
 					else
 					{


### PR DESCRIPTION
Values taken from this topic:
https://hydrogenaud.io/index.php?topic=104214.msg855199#msg855199

Fixes overloud audio with default settings when downmixing
on Motorstorm (and probably other titles aswell)