### PR TITLE
cellVoice/cellAudio Fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -1332,7 +1332,7 @@ error_code cellAudioCreateNotifyEventQueue(vm::ptr<u32> id, vm::ptr<u64> key)
 		// Create an event queue "bruteforcing" an available key
 		const u64 key_value = 0x80004d494f323221ull + i;
 
-		if (const s32 res = sys_event_queue_create(id, attr, key_value, 32))
+		if (CellError res{sys_event_queue_create(id, attr, key_value, 32) + 0u})
 		{
 			if (res != CELL_EEXIST)
 			{

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -1322,13 +1322,11 @@ error_code cellAudioSetPortLevel(u32 portNum, float level)
 	return CELL_OK;
 }
 
-error_code cellAudioCreateNotifyEventQueue(vm::ptr<u32> id, vm::ptr<u64> key)
+static error_code AudioCreateNotifyEventQueue(vm::ptr<u32> id, vm::ptr<u64> key, u32 queue_type)
 {
-	cellAudio.warning("cellAudioCreateNotifyEventQueue(id=*0x%x, key=*0x%x)", id, key);
-
 	vm::var<sys_event_queue_attribute_t> attr;
 	attr->protocol = SYS_SYNC_FIFO;
-	attr->type     = SYS_PPU_QUEUE;
+	attr->type     = queue_type;
 	attr->name_u64 = 0;
 
 	for (u64 i = 0; i < MAX_AUDIO_EVENT_QUEUES; i++)
@@ -1353,18 +1351,24 @@ error_code cellAudioCreateNotifyEventQueue(vm::ptr<u32> id, vm::ptr<u64> key)
 	return CELL_AUDIO_ERROR_EVENT_QUEUE;
 }
 
+error_code cellAudioCreateNotifyEventQueue(vm::ptr<u32> id, vm::ptr<u64> key)
+{
+	cellAudio.warning("cellAudioCreateNotifyEventQueue(id=*0x%x, key=*0x%x)", id, key);
+
+	return AudioCreateNotifyEventQueue(id, key, SYS_PPU_QUEUE);
+}
+
 error_code cellAudioCreateNotifyEventQueueEx(vm::ptr<u32> id, vm::ptr<u64> key, u32 iFlags)
 {
-	cellAudio.todo("cellAudioCreateNotifyEventQueueEx(id=*0x%x, key=*0x%x, iFlags=0x%x)", id, key, iFlags);
+	cellAudio.warning("cellAudioCreateNotifyEventQueueEx(id=*0x%x, key=*0x%x, iFlags=0x%x)", id, key, iFlags);
 
 	if (iFlags & ~CELL_AUDIO_CREATEEVENTFLAG_SPU)
 	{
 		return CELL_AUDIO_ERROR_PARAM;
 	}
 
-	// TODO
-
-	return CELL_AUDIO_ERROR_EVENT_QUEUE;
+	const u32 queue_type = (iFlags & CELL_AUDIO_CREATEEVENTFLAG_SPU) ? SYS_SPU_QUEUE : SYS_PPU_QUEUE;
+	return AudioCreateNotifyEventQueue(id, key, queue_type);
 }
 
 error_code cellAudioSetNotifyEventQueue(u64 key)

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -1334,7 +1334,11 @@ static error_code AudioCreateNotifyEventQueue(vm::ptr<u32> id, vm::ptr<u64> key,
 		// Create an event queue "bruteforcing" an available key
 		const u64 key_value = 0x80004d494f323221ull + i;
 
-		if (CellError res{sys_event_queue_create(id, attr, key_value, 32) + 0u})
+		// This originally reads from a global sdk value set by cellAudioInit
+		// So check initialization as well
+		const u32 queue_depth = g_fxo->get<cell_audio>()->init && g_ps3_process_info.sdk_ver <= 0x35FFFF ? 2 : 8;
+
+		if (CellError res{sys_event_queue_create(id, attr, key_value, queue_depth) + 0u})
 		{
 			if (res != CELL_EEXIST)
 			{

--- a/rpcs3/Emu/Cell/Modules/cellAudio.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.h
@@ -341,7 +341,8 @@ public:
 	shared_mutex mutex;
 	atomic_t<u32> init = 0;
 
-	std::vector<u64> keys;
+	u32 key_count = 0;
+	std::vector<std::pair<u64, u64>> keys;
 	std::array<audio_port, AUDIO_PORT_COUNT> ports;
 
 	u64 m_last_period_end = 0;

--- a/rpcs3/Emu/Cell/Modules/cellVoice.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.cpp
@@ -52,7 +52,7 @@ error_code cellVoiceConnectIPortToOPort(u32 ips, u32 ops)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -76,7 +76,7 @@ error_code cellVoiceCreateNotifyEventQueue(vm::ptr<u32> id, vm::ptr<u64> key)
 
 	auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -90,7 +90,7 @@ error_code cellVoiceCreateNotifyEventQueue(vm::ptr<u32> id, vm::ptr<u64> key)
 	{
 		// Create an event queue "bruteforcing" an available key
 		const u64 key_value = 0x80004d494f323285ull + i;
-		if (const s32 res = sys_event_queue_create(id, attr, key_value, 0x40))
+		if (CellError res{sys_event_queue_create(id, attr, key_value, 0x40) + 0u})
 		{
 			if (res != CELL_EEXIST)
 			{
@@ -135,7 +135,7 @@ error_code cellVoiceCreatePort(vm::ptr<u32> portId, vm::cptr<CellVoicePortParam>
 	case CELLVOICE_PORTTYPE_OUT_VOICE:
 	{
 		// Must be an exact value
-		switch (auto bitrate = pArg->voice.bitrate)
+		switch (pArg->voice.bitrate)
 		{
 		case CELLVOICE_BITRATE_3850:
 		case CELLVOICE_BITRATE_4650:
@@ -206,7 +206,7 @@ error_code cellVoiceDisconnectIPortFromOPort(u32 ips, u32 ops)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -261,7 +261,7 @@ error_code cellVoiceGetBitRate(u32 portId, vm::ptr<u32> bitrate)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -286,7 +286,7 @@ error_code cellVoiceGetMuteFlag(u32 portId, vm::ptr<u16> bMuted)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -306,7 +306,7 @@ error_code cellVoiceGetPortAttr(u32 portId, u32 attr, vm::ptr<void> attrValue)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -326,7 +326,7 @@ error_code cellVoiceGetPortInfo(u32 portId, vm::ptr<CellVoiceBasePortInfo> pInfo
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -353,7 +353,7 @@ error_code cellVoiceGetSignalState(u32 portId, u32 attr, vm::ptr<void> attrValue
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -373,7 +373,7 @@ error_code cellVoiceGetVolume(u32 portId, vm::ptr<f32> volume)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -434,7 +434,7 @@ error_code cellVoicePausePort(u32 portId)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -453,7 +453,7 @@ error_code cellVoicePausePortAll()
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -484,7 +484,7 @@ error_code cellVoiceResetPort(u32 portId)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -503,7 +503,7 @@ error_code cellVoiceResumePort(u32 portId)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -522,7 +522,7 @@ error_code cellVoiceResumePortAll()
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -593,7 +593,7 @@ error_code cellVoiceSetMuteFlagAll(u16 bMuted)
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -664,6 +664,7 @@ error_code cellVoiceSetVolume(u32 portId, f32 volume)
 	if (!port)
 		return CELL_VOICE_ERROR_TOPOLOGY;
 
+	port->info.volume = volume;
 	return CELL_OK;
 }
 
@@ -785,7 +786,7 @@ error_code cellVoiceWriteToIPort(u32 ips, vm::cptr<void> data, vm::ptr<u32> size
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -804,7 +805,7 @@ error_code cellVoiceWriteToIPortEx(u32 ips, vm::cptr<void> data, vm::ptr<u32> si
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -823,7 +824,7 @@ error_code cellVoiceWriteToIPortEx2(u32 ips, vm::cptr<void> data, vm::ptr<u32> s
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
@@ -842,7 +843,7 @@ error_code cellVoiceReadFromOPort(u32 ops, vm::ptr<void> data, vm::ptr<u32> size
 
 	const auto manager = g_fxo->get<voice_manager>();
 
-	std::scoped_lock lock(manager->mtx);
+	std::shared_lock lock(manager->mtx);
 
 	if (manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;

--- a/rpcs3/Emu/Cell/Modules/cellVoice.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.cpp
@@ -178,10 +178,11 @@ error_code cellVoiceCreatePort(vm::ptr<u32> portId, vm::cptr<CellVoicePortParam>
 	{
 		verify(HERE), ctr2 < CELLVOICE_MAX_PORT + 1;
 
-		std::tie(port, success) = manager->ports.try_emplace((ctr2 << 8) | manager->id_ctr); 
+		std::tie(port, success) = manager->ports.try_emplace(::narrow<u16>((ctr2 << 8) | manager->id_ctr)); 
 	}
 
 	port->second.info = *pArg;
+	*portId = port->first;
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellVoice.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.cpp
@@ -4,6 +4,7 @@
 #include "Emu/Cell/PPUModule.h"
 
 #include "Emu/Cell/lv2/sys_event.h"
+#include "Emu/Cell/lv2/sys_process.h"
 #include "cellVoice.h"
 
 LOG_CHANNEL(cellVoice);
@@ -42,6 +43,7 @@ void fmt_class_string<CellVoiceError>::format(std::string& out, u64 arg)
 void voice_manager::reset()
 {
 	id_ctr = 0;
+	port_source = 0;
 	ports.clear();
 	queue_keys.clear();
 }
@@ -54,7 +56,7 @@ error_code cellVoiceConnectIPortToOPort(u32 ips, u32 ops)
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto iport = manager->access_port(ips);
@@ -288,7 +290,7 @@ error_code cellVoiceGetMuteFlag(u32 portId, vm::ptr<u16> bMuted)
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -308,7 +310,7 @@ error_code cellVoiceGetPortAttr(u32 portId, u32 attr, vm::ptr<void> attrValue)
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -328,7 +330,7 @@ error_code cellVoiceGetPortInfo(u32 portId, vm::ptr<CellVoiceBasePortInfo> pInfo
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -355,7 +357,7 @@ error_code cellVoiceGetSignalState(u32 portId, u32 attr, vm::ptr<void> attrValue
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -375,7 +377,7 @@ error_code cellVoiceGetVolume(u32 portId, vm::ptr<f32> volume)
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -436,7 +438,7 @@ error_code cellVoicePausePort(u32 portId)
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -455,7 +457,7 @@ error_code cellVoicePausePortAll()
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	return CELL_OK;
@@ -469,7 +471,7 @@ error_code cellVoiceRemoveNotifyEventQueue(u64 key)
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	if (manager->queue_keys.erase(key) == 0)
@@ -486,7 +488,7 @@ error_code cellVoiceResetPort(u32 portId)
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -505,7 +507,7 @@ error_code cellVoiceResumePort(u32 portId)
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -524,7 +526,7 @@ error_code cellVoiceResumePortAll()
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	return CELL_OK;
@@ -538,7 +540,7 @@ error_code cellVoiceSetBitRate(u32 portId, CellVoiceBitRate bitrate)
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -575,7 +577,7 @@ error_code cellVoiceSetMuteFlag(u32 portId, u16 bMuted)
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -595,7 +597,7 @@ error_code cellVoiceSetMuteFlagAll(u16 bMuted)
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	// Doesn't change port->bMute value 
@@ -610,7 +612,7 @@ error_code cellVoiceSetNotifyEventQueue(u64 key, u64 source)
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	// Note: it is allowed to enqueue the key twice (another source is enqueued with FIFO ordering)
@@ -621,7 +623,10 @@ error_code cellVoiceSetNotifyEventQueue(u64 key, u64 source)
 
 	if (!source)
 	{
-		// TODO: same thing as sys_event_port_send with port.name == 0
+		// same thing as sys_event_port_send with port.name == 0
+		// Try to give different port id everytime
+		source = ((process_getpid() + 1ull) << 32) | (lv2_event_port::id_base + manager->port_source * lv2_event_port::id_step);
+		manager->port_source = (manager->port_source + 1) % lv2_event_port::id_count;
 	}
 
 	manager->queue_keys[key].push_back(source);
@@ -636,7 +641,7 @@ error_code cellVoiceSetPortAttr(u32 portId, u32 attr, vm::ptr<void> attrValue)
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -656,7 +661,7 @@ error_code cellVoiceSetVolume(u32 portId, f32 volume)
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto port = manager->access_port(portId);
@@ -695,7 +700,7 @@ error_code cellVoiceStart()
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	return VoiceStart(manager);
@@ -709,7 +714,7 @@ error_code cellVoiceStartEx(vm::ptr<CellVoiceStartParam> pArg)
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	if (!pArg)
@@ -728,7 +733,7 @@ error_code cellVoiceStop()
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	if (!std::exchange(manager->voice_service_started, false))
@@ -756,7 +761,7 @@ error_code cellVoiceUpdatePort(u32 portId, vm::cptr<CellVoicePortParam> pArg)
 
 	std::scoped_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	if (!pArg)
@@ -788,7 +793,7 @@ error_code cellVoiceWriteToIPort(u32 ips, vm::cptr<void> data, vm::ptr<u32> size
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 	
 	auto iport = manager->access_port(ips);
@@ -807,7 +812,7 @@ error_code cellVoiceWriteToIPortEx(u32 ips, vm::cptr<void> data, vm::ptr<u32> si
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto iport = manager->access_port(ips);
@@ -826,7 +831,7 @@ error_code cellVoiceWriteToIPortEx2(u32 ips, vm::cptr<void> data, vm::ptr<u32> s
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto iport = manager->access_port(ips);
@@ -845,7 +850,7 @@ error_code cellVoiceReadFromOPort(u32 ops, vm::ptr<void> data, vm::ptr<u32> size
 
 	std::shared_lock lock(manager->mtx);
 
-	if (manager->is_init)
+	if (!manager->is_init)
 		return CELL_VOICE_ERROR_LIBVOICE_NOT_INIT;
 
 	auto oport = manager->access_port(ops);

--- a/rpcs3/Emu/Cell/Modules/cellVoice.h
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.h
@@ -187,6 +187,9 @@ struct voice_manager
 	// See cellVoiceCreatePort
 	u32 id_ctr = 0;
 
+	// For cellVoiceSetNotifyEventQueue
+	u32 port_source = 0;
+
 	std::unordered_map<u16, port_t> ports;
 	std::unordered_map<u64, std::deque<u64>> queue_keys;
 	bool voice_service_started = false;

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "sys_prx.h"
 
 #include "Emu/System.h"
@@ -257,6 +257,11 @@ error_code _sys_prx_start_module(u32 id, u64 flags, vm::ptr<sys_prx_start_stop_m
 {
 	sys_prx.warning("_sys_prx_start_module(id=0x%x, flags=0x%x, pOpt=*0x%x)", id, flags, pOpt);
 
+	if (id == 0 || !pOpt)
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto prx = idm::get<lv2_obj, lv2_prx>(id);
 
 	if (!prx)
@@ -301,7 +306,7 @@ error_code _sys_prx_unload_module(u32 id, u64 flags, vm::ptr<sys_prx_unload_modu
 
 	if (!prx)
 	{
-		return CELL_ESRCH;
+		return CELL_PRX_ERROR_UNKNOWN_MODULE;
 	}
 
 	ppu_unload_prx(*prx);
@@ -365,9 +370,19 @@ error_code _sys_prx_get_module_info(u32 id, u64 flags, vm::ptr<sys_prx_module_in
 
 	const auto prx = idm::get<lv2_obj, lv2_prx>(id);
 
-	if (!pOpt || !pOpt->info || !prx)
+	if (!pOpt)
+	{
+		return CELL_EFAULT;
+	}
+
+	if (pOpt->size != pOpt.size() || !pOpt->info)
 	{
 		return CELL_EINVAL;
+	}
+
+	if (!prx)
+	{
+		return CELL_PRX_ERROR_UNKNOWN_MODULE;
 	}
 
 	std::memset(pOpt->info->name, 0, 30);


### PR DESCRIPTION
* Use shared lock wherever possible. (std::unordered_map::find is safe to use under shared lock)
* Fix cellVoiceSetVolume.
* Fix NOT_INIT checks.
* Fix error logging of cellVoiceCreateNotifyEventQueue, cellAudioCreateNotifyEventQueue.
* Fix cellVoiceCreatePort.
* Implement 0 event source handling.
* Implement cellAudioCreateNotifyEventQueueEx.
* Implement event source for cellAudio events
* Fix cellAudioCreateNotifyEventQueue queue depth.

Other improvements:
* Minor error checking fixes for sys_prx from firmware.

Fixes #6884
Fixes Test Drive Unlimited.