### PR TITLE
rsx: Enable primitive restart index only when needed

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -39,15 +39,12 @@ namespace rsx
 			}
 			else
 			{
-				u32 put = m_ctrl->put;
-				if (LIKELY((put & 3) == 0))
+				if (u32 put = m_ctrl->put; LIKELY((put & 3) == 0))
 				{
 					return put;
 				}
-				else
-				{
-					return m_ctrl->put.and_fetch(~3);
-				}
+
+				return m_ctrl->put.and_fetch(~3);
 			}
 		}
 

--- a/rpcs3/Emu/RSX/gcm_enums.cpp
+++ b/rpcs3/Emu/RSX/gcm_enums.cpp
@@ -17,16 +17,6 @@ rsx::vertex_base_type rsx::to_vertex_base_type(u8 in)
 	fmt::throw_exception("Unknown vertex base type %d" HERE, in);
 }
 
-rsx::index_array_type rsx::to_index_array_type(u8 in)
-{
-	switch (in)
-	{
-	case CELL_GCM_DRAW_INDEX_ARRAY_TYPE_32: return rsx::index_array_type::u32;
-	case CELL_GCM_DRAW_INDEX_ARRAY_TYPE_16: return rsx::index_array_type::u16;
-	}
-	fmt::throw_exception("Unknown index array type %d" HERE, in);
-}
-
 rsx::primitive_type rsx::to_primitive_type(u8 in)
 {
 	switch (in)

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -18,11 +18,9 @@ namespace rsx
 
 	enum class index_array_type : u8
 	{
-		u32,
-		u16,
+		u32 = 0, // CELL_GCM_DRAW_INDEX_ARRAY_TYPE_32
+		u16 = 1, // CELL_GCM_DRAW_INDEX_ARRAY_TYPE_16
 	};
-
-	index_array_type to_index_array_type(u8 in);
 
 	enum class primitive_type : u8
 	{

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3369,8 +3369,8 @@ struct registers_decoder<NV4097_SET_INDEX_ARRAY_DMA>
 
 		index_array_type type() const
 		{
-			// Why truncate??
-			return to_index_array_type(static_cast<u8>(type_raw()));
+			// Must be a valid value
+			return static_cast<index_array_type>(static_cast<u8>(type_raw()));
 		}
 	};
 

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3357,7 +3357,7 @@ struct registers_decoder<NV4097_SET_INDEX_ARRAY_DMA>
 	private:
 		u32 value;
 
-		u32 type_raw() const { return bf_decoder<4, 28>(value); }
+		u8 type_raw() const { return bf_decoder<4, 8>(value); }
 
 	public:
 		decoded_type(u32 value) : value(value) {}

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3370,7 +3370,7 @@ struct registers_decoder<NV4097_SET_INDEX_ARRAY_DMA>
 		index_array_type type() const
 		{
 			// Must be a valid value
-			return static_cast<index_array_type>(static_cast<u8>(type_raw()));
+			return static_cast<index_array_type>(type_raw());
 		}
 	};
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -665,14 +665,35 @@ namespace rsx
 			return decode<NV4097_SET_STENCIL_TEST_ENABLE>().stencil_test_enabled();
 		}
 
-		bool restart_index_enabled() const
+		u8 index_array_location() const
 		{
-			return decode<NV4097_SET_RESTART_INDEX_ENABLE>().restart_index_enabled();
+			return decode<NV4097_SET_INDEX_ARRAY_DMA>().index_dma();
+		}
+
+		rsx::index_array_type index_type() const
+		{
+			return decode<NV4097_SET_INDEX_ARRAY_DMA>().type();
 		}
 
 		u32 restart_index() const
 		{
 			return decode<NV4097_SET_RESTART_INDEX>().restart_index();
+		}
+
+		bool restart_index_enabled_raw() const
+		{
+			return decode<NV4097_SET_RESTART_INDEX_ENABLE>().restart_index_enabled();
+		}
+
+		bool restart_index_enabled() const
+		{
+			if (const u32 idx = restart_index(); 
+				idx > (index_type() == rsx::index_array_type::u16 ? 0xffff : 0xfffff))
+			{
+				return false;
+			}
+
+			return restart_index_enabled_raw();
 		}
 
 		u32 z_clear_value(bool is_depth_stencil) const
@@ -693,16 +714,6 @@ namespace rsx
 		f32 fog_params_1() const
 		{
 			return decode<NV4097_SET_FOG_PARAMS + 1>().fog_param_1();
-		}
-
-		u8 index_array_location() const
-		{
-			return decode<NV4097_SET_INDEX_ARRAY_DMA>().index_dma();
-		}
-
-		rsx::index_array_type index_type() const
-		{
-			return decode<NV4097_SET_INDEX_ARRAY_DMA>().type();
 		}
 
 		bool color_mask_b(int index) const

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -693,7 +693,7 @@ namespace rsx
 
 			}
 			
-			return restart_index() > (index_type() == rsx::index_array_type::u16 ? 0xffff : 0xfffff);
+			return restart_index() <= (index_type() == rsx::index_array_type::u16 ? 0xffff : 0xfffff);
 		}
 
 		u32 z_clear_value(bool is_depth_stencil) const

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -687,13 +687,13 @@ namespace rsx
 
 		bool restart_index_enabled() const
 		{
-			if (const u32 idx = restart_index(); 
-				idx > (index_type() == rsx::index_array_type::u16 ? 0xffff : 0xfffff))
+			if (!restart_index_enabled_raw()) 
 			{
 				return false;
-			}
 
-			return restart_index_enabled_raw();
+			}
+			
+			return restart_index() > (index_type() == rsx::index_array_type::u16 ? 0xffff : 0xfffff);
 		}
 
 		u32 z_clear_value(bool is_depth_stencil) const


### PR DESCRIPTION
* If the restart index is above max valid index value, it won't ever be equal to one of the indices. (upper bits aren't ignored)
* because #6737 made index array type always valid, replace to_index_array_type() with a static_cast.
* Added restart_index_enabled_raw() in case we want the actual register value.

Default restart index value is UINT32_MAX so it's not unlikely that we enabled the restart index when there's no need to.

edit: disabled primitive restart array may be faster to process (byteswap etc) indices.