### PR TITLE
rsx: Minor fixups

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1756,9 +1756,7 @@ namespace rsx
 
 			if (options.is_compressed_format)
 			{
-				attributes.width = align(attributes.width, 4);
-				attributes.height = align(attributes.height, 4);
-
+				// Compressed textures cannot be 1D in some APIs
 				extended_dimension = std::max(extended_dimension, rsx::texture_dimension_extended::texture_dimension_2d);
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -466,12 +466,9 @@ namespace gl
 
 		if (LIKELY(is_compressed_format(format)))
 		{
-			//Compressed formats have a 4-byte alignment
-			//TODO: Verify that samplers are not affected by the padding
-			width = align(width, 4);
-			height = align(height, 4);
-
 			caps.supports_vtc_decoding = gl::get_driver_caps().vendor_NVIDIA;
+
+			unpack_settings.row_length(align(width, 4));
 			unpack_settings.apply();
 
 			for (const rsx_subresource_layout& layout : input_layouts)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1355,10 +1355,6 @@ void VKGSRender::end()
 
 					if (min_filter.sample_mipmaps && mipmap_count > 1)
 					{
-						min_lod = rsx::method_registers.fragment_textures[i].min_lod();
-						max_lod = rsx::method_registers.fragment_textures[i].max_lod();
-						lod_bias = rsx::method_registers.fragment_textures[i].bias();
-
 						f32 actual_mipmaps;
 						if (sampler_state->upload_context == rsx::texture_upload_context::shader_read)
 						{
@@ -1376,8 +1372,19 @@ void VKGSRender::end()
 
 						if (actual_mipmaps > 1.f)
 						{
+							min_lod = rsx::method_registers.fragment_textures[i].min_lod();
+							max_lod = rsx::method_registers.fragment_textures[i].max_lod();
+							lod_bias = rsx::method_registers.fragment_textures[i].bias();
+
 							min_lod = std::min(min_lod, actual_mipmaps - 1.f);
 							max_lod = std::min(max_lod, actual_mipmaps - 1.f);
+
+							if (min_filter.mipmap_mode == VK_SAMPLER_MIPMAP_MODE_NEAREST)
+							{
+								// Round to nearest 0.5 to work around some broken games
+								// Unlike openGL, sampler parameters cannot be dynamically changed on vulkan, leading to many permutations
+								lod_bias = std::floor(lod_bias * 2.f + 0.5f) * 0.5f;
+							}
 						}
 						else
 						{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2757,9 +2757,9 @@ void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_
 		if (m_vertex_layout_storage)
 			m_current_frame->buffer_views_to_clean.push_back(std::move(m_vertex_layout_storage));
 
-		// View 64M blocks at a time (different drivers will only allow a fixed viewable heap size, 64M should be safe)
-		const size_t view_size = (base_offset + m_texbuffer_view_size) > m_vertex_layout_ring_info.size() ? m_vertex_layout_ring_info.size() - base_offset : m_texbuffer_view_size;
-		m_vertex_layout_storage = std::make_unique<vk::buffer_view>(*m_device, m_vertex_layout_ring_info.heap->value, VK_FORMAT_R32G32_UINT, base_offset, view_size);
+		const size_t alloc_addr = m_vertex_layout_stream_info.offset;
+		const size_t view_size = (alloc_addr + m_texbuffer_view_size) > m_vertex_layout_ring_info.size() ? m_vertex_layout_ring_info.size() - alloc_addr : m_texbuffer_view_size;
+		m_vertex_layout_storage = std::make_unique<vk::buffer_view>(*m_device, m_vertex_layout_ring_info.heap->value, VK_FORMAT_R32G32_UINT, alloc_addr, view_size);
 		base_offset = 0;
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1558,8 +1558,9 @@ private:
 			if (info.magFilter != mag_filter || info.minFilter != min_filter || info.mipmapMode != mipmap_mode ||
 				info.addressModeU != clamp_u || info.addressModeV != clamp_v || info.addressModeW != clamp_w ||
 				info.compareEnable != depth_compare || info.unnormalizedCoordinates != unnormalized_coordinates ||
-				info.mipLodBias != mipLodBias || info.maxAnisotropy != max_anisotropy || info.maxLod != max_lod ||
-				info.minLod != min_lod || info.compareOp != depth_compare_mode || info.borderColor != border_color)
+				!rsx::fcmp(info.maxLod, max_lod) || !rsx::fcmp(info.mipLodBias, mipLodBias) || !rsx::fcmp(info.minLod, min_lod) ||
+				!rsx::fcmp(info.maxAnisotropy, max_anisotropy) ||
+				info.compareOp != depth_compare_mode || info.borderColor != border_color)
 				return false;
 
 			return true;

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -45,11 +45,6 @@ namespace vk
 		std::unordered_multimap<u64, std::unique_ptr<vk::sampler>> m_sampler_pool;
 		std::deque<eid_scope_t> m_eid_map;
 
-		bool value_compare(const f32& a, const f32& b)
-		{
-			return fabsf(a - b) < 0.0000001f;
-		}
-
 		eid_scope_t& get_current_eid_scope()
 		{
 			const auto eid = current_event_id();
@@ -94,10 +89,10 @@ namespace vk
 			for (auto It = found.first; It != found.second; ++It)
 			{
 				const auto& info = It->second->info;
-				if (!value_compare(info.mipLodBias, mipLodBias) ||
-					!value_compare(info.maxAnisotropy, max_anisotropy) ||
-					!value_compare(info.minLod, min_lod) ||
-					!value_compare(info.maxLod, max_lod))
+				if (!rsx::fcmp(info.maxLod, max_lod) ||
+					!rsx::fcmp(info.mipLodBias, mipLodBias) ||
+					!rsx::fcmp(info.minLod, min_lod) ||
+					!rsx::fcmp(info.maxAnisotropy, max_anisotropy))
 				{
 					continue;
 				}

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -42,7 +42,7 @@ namespace vk
 	class resource_manager
 	{
 	private:
-		std::unordered_multimap<u64, std::unique_ptr<vk::sampler>> m_sampler_pool;
+		std::unordered_map<u64, std::unique_ptr<vk::sampler>> m_sampler_pool;
 		std::deque<eid_scope_t> m_eid_map;
 
 		eid_scope_t& get_current_eid_scope()
@@ -59,6 +59,28 @@ namespace vk
 
 			m_eid_map.emplace_back(eid);
 			return m_eid_map.back();
+		}
+
+		template<bool _signed = false>
+		u16 encode_fxp(f32 value)
+		{
+			u16 raw = u16(std::abs(value) * 256.);
+
+			if constexpr (!_signed)
+			{
+				return raw;
+			}
+			else
+			{
+				if (LIKELY(value >= 0.f))
+				{
+					return raw;
+				}
+				else
+				{
+					return u16(0 - raw) & 0x1fff;
+				}
+			}
 		}
 
 	public:
@@ -78,26 +100,21 @@ namespace vk
 			VkBool32 depth_compare = VK_FALSE, VkCompareOp depth_compare_mode = VK_COMPARE_OP_NEVER)
 		{
 			u64 key = u16(clamp_u) | u64(clamp_v) << 3 | u64(clamp_w) << 6;
-			key |= u64(unnormalized_coordinates) << 9; // 1 bit
+			key |= u64(unnormalized_coordinates) << 9;            // 1 bit
 			key |= u64(min_filter) << 10 | u64(mag_filter) << 11; // 1 bit each
-			key |= u64(mipmap_mode) << 12; // 1 bit
-			key |= u64(border_color) << 13; // 3 bits
+			key |= u64(mipmap_mode) << 12;   // 1 bit
+			key |= u64(border_color) << 13;  // 3 bits
 			key |= u64(depth_compare) << 16; // 1 bit
-			key |= u64(depth_compare_mode) << 17; // 3 bits
+			key |= u64(depth_compare_mode) << 17;  // 3 bits
+			key |= u64(encode_fxp(min_lod)) << 20; // 12 bits
+			key |= u64(encode_fxp(max_lod)) << 32; // 12 bits
+			key |= u64(encode_fxp<true>(mipLodBias)) << 44; // 13 bits
+			key |= u64(max_anisotropy) << 57;               // 4 bits
 
-			const auto found = m_sampler_pool.equal_range(key);
-			for (auto It = found.first; It != found.second; ++It)
+			if (const auto found = m_sampler_pool.find(key);
+				found != m_sampler_pool.end())
 			{
-				const auto& info = It->second->info;
-				if (!rsx::fcmp(info.maxLod, max_lod) ||
-					!rsx::fcmp(info.mipLodBias, mipLodBias) ||
-					!rsx::fcmp(info.minLod, min_lod) ||
-					!rsx::fcmp(info.maxAnisotropy, max_anisotropy))
-				{
-					continue;
-				}
-
-				return It->second.get();
+				return found->second.get();
 			}
 
 			auto result = std::make_unique<vk::sampler>(
@@ -107,7 +124,7 @@ namespace vk
 				depth_compare, depth_compare_mode);
 
 			auto It = m_sampler_pool.emplace(key, std::move(result));
-			return It->second.get();
+			return It.first->second.get();
 		}
 
 		void dispose(std::unique_ptr<vk::buffer>& buf)


### PR DESCRIPTION
- Remove block alignment on compressed textures as long as the unpack alignment is well defined.
- Improve the vulkan sampler cache to not cause slowdown in games that have random parameters set. In some cases, uninitialized variables seem to make their way into unused variables but since we cannot assume they're unused, it causes a lot of permutations and can kill performance.
- Round lod bias to the nearest half integer for vulkan to work around issue 2 above when point mipmap sampling is used. Should provide near-correct results at all times while filtering out parameter noise.