### PR TITLE
Stop building ALSA/PulseAudio/FAudio when disabled, and make OpenAL optional

### DIFF
--- a/rpcs3/Emu/Audio/ALSA/ALSABackend.cpp
+++ b/rpcs3/Emu/Audio/ALSA/ALSABackend.cpp
@@ -1,9 +1,11 @@
+#ifndef HAVE_ALSA
+#error "ALSA support disabled but still being built."
+#endif
+
 #include "stdafx.h"
 #include "Emu/System.h"
 
 #include "ALSABackend.h"
-
-#ifdef HAVE_ALSA
 
 
 static void error(int err, const char* reason)
@@ -160,5 +162,3 @@ bool ALSABackend::AddData(const void* src, u32 num_samples)
 
 	return true;
 }
-
-#endif

--- a/rpcs3/Emu/Audio/ALSA/ALSABackend.h
+++ b/rpcs3/Emu/Audio/ALSA/ALSABackend.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#ifdef HAVE_ALSA
+#ifndef HAVE_ALSA
+#error "ALSA support disabled but still being built."
+#endif
 
 #include "Emu/Audio/AudioBackend.h"
 
@@ -26,5 +28,3 @@ public:
 	
 	virtual bool AddData(const void* src, u32 num_samples) override;
 };
-
-#endif

--- a/rpcs3/Emu/Audio/FAudio/FAudioBackend.cpp
+++ b/rpcs3/Emu/Audio/FAudio/FAudioBackend.cpp
@@ -1,6 +1,8 @@
-#include "FAudioBackend.h"
+#ifndef HAVE_FAUDIO
+#error "FAudio support disabled but still being built."
+#endif
 
-#ifdef HAVE_FAUDIO
+#include "FAudioBackend.h"
 
 FAudioBackend::FAudioBackend()
 {
@@ -175,5 +177,3 @@ f32 FAudioBackend::SetFrequencyRatio(f32 new_ratio)
 
 	return new_ratio;
 }
-
-#endif

--- a/rpcs3/Emu/Audio/FAudio/FAudioBackend.h
+++ b/rpcs3/Emu/Audio/FAudio/FAudioBackend.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#ifdef HAVE_FAUDIO
+#ifndef HAVE_FAUDIO
+#error "FAudio support disabled but still being built."
+#endif
 
 #include "Emu/Audio/AudioBackend.h"
 #include "3rdparty/FAudio/include/FAudio.h"
@@ -40,5 +42,3 @@ public:
 	virtual u64 GetNumEnqueuedSamples() override;
 	virtual f32 SetFrequencyRatio(f32 new_ratio) override;
 };
-
-#endif

--- a/rpcs3/Emu/Audio/Pulse/PulseBackend.cpp
+++ b/rpcs3/Emu/Audio/Pulse/PulseBackend.cpp
@@ -1,7 +1,9 @@
+#ifndef HAVE_PULSE
+#error "PulseAudio support disabled but still being built."
+#endif
+
 #include "Emu/System.h"
 #include "PulseBackend.h"
-
-#ifdef HAVE_PULSE
 
 #include <pulse/simple.h>
 #include <pulse/error.h>
@@ -70,5 +72,3 @@ bool PulseBackend::AddData(const void* src, u32 num_samples)
 	
 	return true;
 }
-
-#endif

--- a/rpcs3/Emu/Audio/Pulse/PulseBackend.h
+++ b/rpcs3/Emu/Audio/Pulse/PulseBackend.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#ifdef HAVE_PULSE
+#ifndef HAVE_PULSE
+#error "PulseAudio support disabled but still being built."
+#endif
+
 #include <pulse/simple.h>
 #include "Emu/Audio/AudioBackend.h"
 
@@ -23,5 +26,3 @@ public:
 private:
 	pa_simple *connection = nullptr;
 };
-
-#endif

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -88,10 +88,22 @@ target_sources(rpcs3_emu PRIVATE
 target_sources(rpcs3_emu PRIVATE
 	Audio/AudioDumper.cpp
 	Audio/AL/OpenALBackend.cpp
-	Audio/ALSA/ALSABackend.cpp
-	Audio/Pulse/PulseBackend.cpp
-	Audio/FAudio/FAudioBackend.cpp
 )
+
+if(HAVE_ALSA)
+	target_sources(rpcs3_emu PRIVATE Audio/ALSA/ALSABackend.cpp)
+	target_link_libraries(rpcs3_emu PUBLIC 3rdparty::alsa)
+endif()
+
+if(HAVE_PULSE)
+	target_sources(rpcs3_emu PRIVATE Audio/Pulse/PulseBackend.cpp)
+	target_link_libraries(rpcs3_emu PUBLIC 3rdparty::pulse)
+endif()
+
+if(HAVE_FAUDIO)
+	target_sources(rpcs3_emu PRIVATE Audio/FAudio/FAudioBackend.cpp)
+	target_link_libraries(rpcs3_emu PUBLIC 3rdparty::faudio)
+endif()
 
 if(WIN32)
 	target_sources(rpcs3_emu PRIVATE
@@ -105,7 +117,7 @@ endif()
 
 target_link_libraries(rpcs3_emu
 	PUBLIC
-		3rdparty::alsa 3rdparty::pulse 3rdparty::openal 3rdparty::faudio)
+		3rdparty::openal)
 
 
 # Cell


### PR DESCRIPTION
This PR mirrors 9253f7d645c891cb57a8785bdaeb93d02a80f307, in that it stops building audio backends which are disabled.

It also allows the user to disable OpenAL at build-time like other audio backends, this disables microphone input at the same time.

This PR is more easily read commit per commit.