### PR TITLE
spu_channel_4_t fix

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVoice.h
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.h
@@ -185,7 +185,7 @@ struct voice_manager
 	};
 
 	// See cellVoiceCreatePort
-	u32 id_ctr = 0;
+	u8 id_ctr = 0;
 
 	// For cellVoiceSetNotifyEventQueue
 	u32 port_source = 0;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -284,7 +284,7 @@ public:
 	// push unconditionally (overwriting latest value), returns true if needs signaling
 	void push(cpu_thread& spu, u32 value)
 	{
-		value3.store(value);
+		value3.release(value);
 
 		if (values.atomic_op([=](sync_var_t& data) -> bool
 		{

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -278,7 +278,6 @@ public:
 	void clear()
 	{
 		values.release({});
-		value3.release(0);
 	}
 
 	// push unconditionally (overwriting latest value), returns true if needs signaling


### PR DESCRIPTION
Fixes a possible unintended state (overriding last element with 0) by clearing last element before zeroing count. (race between the exiting thread and the one calls sys_spu_thread_write_spu_mb).
Regressed by #6917.