### PR TITLE
[Hotfix] vk: Add checks for alphaToOne support

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -38,6 +38,7 @@ GLGSRender::GLGSRender() : GSRender()
 		m_vertex_cache = std::make_unique<gl::weak_vertex_cache>();
 
 	backend_config.supports_hw_a2c = false;
+	backend_config.supports_hw_a2one = false;
 	backend_config.supports_multidraw = true;
 }
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -469,6 +469,7 @@ namespace rsx
 		bool supports_multidraw;           // Draw call batching
 		bool supports_hw_a2c;              // Alpha to coverage
 		bool supports_hw_renormalization;  // Should be true on NV hardware which matches PS3 texture renormalization behaviour
+		bool supports_hw_a2one;            // Alpha to one
 	};
 
 	struct sampled_image_descriptor_base;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -809,6 +809,13 @@ private:
 				enabled_features.depthBounds = VK_FALSE;
 			}
 
+			if (!pgpu->features.alphaToOne && enabled_features.alphaToOne)
+			{
+				// AMD proprietary drivers do not expose alphaToOne support
+				LOG_ERROR(RSX, "Your GPU does not support alpha-to-one for multisampling. Graphics may be inaccurate when MSAA is enabled.");
+				enabled_features.alphaToOne = VK_FALSE;
+			}
+
 			VkDeviceCreateInfo device = {};
 			device.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 			device.pNext = nullptr;
@@ -929,6 +936,11 @@ private:
 		bool get_depth_bounds_support() const
 		{
 			return pgpu->features.depthBounds != VK_FALSE;
+		}
+
+		bool get_alpha_to_one_support() const
+		{
+			return pgpu->features.alphaToOne != VK_FALSE;
 		}
 
 		mem_allocator_base* get_allocator() const


### PR DESCRIPTION
AMD windows driver does not support alpha-to-one and crashes when alpha-to-one feature is enabled.
To properly work around this would require also emulating the whole sample masking stage but this is very rarely used due to the fact that you can just disable blending when using alphaToCoverage. I have not encountered any PS3 application that actually uses this, but if one is found, a fallback implementation could theoretically be written. Leaving that task for the future as it is not a priority.

Fixes AMD windows driver crashing on boot when MSAA is enabled (regression).