### PR TITLE
rsx: Overlay improvements

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1725,7 +1725,7 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 
 		areai screen_area = coordi({}, { (int)buffer_width, (int)buffer_height });
 
-		if (g_cfg.video.full_rgb_range_output && avconfig->gamma == 1.f)
+		if (g_cfg.video.full_rgb_range_output && rsx::fcmp(avconfig->gamma, 1.f))
 		{
 			// Blit source image to the screen
 			m_flip_fbo.recreate();

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -43,6 +43,14 @@ namespace rsx
 			backbuffer = 255  // Use current backbuffer contents
 		};
 
+		enum class primitive_type : u8
+		{
+			quad_list = 0,
+			triangle_strip = 1,
+			line_list = 2,
+			line_strip = 3
+		};
+
 		struct vertex
 		{
 			float values[4];
@@ -353,6 +361,8 @@ namespace rsx
 		{
 			struct command_config
 			{
+				primitive_type primitives = primitive_type::quad_list;
+
 				color4f color = { 1.f, 1.f, 1.f, 1.f };
 				bool pulse_glow = false;
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -317,6 +317,7 @@ private:
 	std::unique_ptr<vk::depth_convert_pass> m_depth_converter;
 	std::unique_ptr<vk::ui_overlay_renderer> m_ui_renderer;
 	std::unique_ptr<vk::attachment_clear_pass> m_attachment_clear_pass;
+	std::unique_ptr<vk::video_out_calibration_pass> m_video_output_pass;
 
 	shared_mutex m_sampler_mutex;
 	u64 surface_store_tag = 0;


### PR DESCRIPTION
- Adds support for other primitive types other than triangle strips. This will come in handy very soon.
- Adds a video-out calibration pass for vulkan. This already existed on OpenGL and fixes some games that use video-out gamma correction to calibrate ingame brightness. In these games, the brightness settings usually have no effect on vulkan, but work on OpenGL.