### PR TITLE
[Hotfix] vk: Add explicit support for identity image views

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -1056,7 +1056,7 @@ namespace vk
 			config.gamma = gamma;
 			config.limit_range = limited_rgb? 1 : 0;
 
-			overlay_pass::run(cmd, viewport, target, { src->get_view(0xAAE4, rsx::default_remap_vector) }, render_pass);
+			overlay_pass::run(cmd, viewport, target, { src->get_view(VK_REMAP_IDENTITY, rsx::default_remap_vector) }, render_pass);
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -350,19 +350,19 @@ namespace vk
 		image_view* get_view(u32 remap_encoding, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap,
 			VkImageAspectFlags mask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT) override
 		{
-			if (remap_encoding != 0xDEADBEEF && resolve_surface)
+			if (remap_encoding == VK_REMAP_VIEW_MULTISAMPLED)
 			{
-				return resolve_surface->get_view(remap_encoding, remap, mask);
+				// Special remap flag, intercept here
+				return vk::viewable_image::get_view(VK_REMAP_IDENTITY, remap, mask);
+			}
+
+			if (LIKELY(!resolve_surface))
+			{
+				return vk::viewable_image::get_view(remap_encoding, remap, mask);
 			}
 			else
 			{
-				if (remap_encoding == 0xDEADBEEF)
-				{
-					// Special encoding to skip the resolve target fetch
-					remap_encoding = 0xAAE4;
-				}
-
-				return vk::viewable_image::get_view(remap_encoding, remap, mask);
+				return resolve_surface->get_view(remap_encoding, remap, mask);
 			}
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -117,8 +117,8 @@ namespace vk
 
 		void bind_resources() override
 		{
-			auto msaa_view = multisampled->get_view(0xDEADBEEF, rsx::default_remap_vector);
-			auto resolved_view = resolve->get_view(0xAAE4, rsx::default_remap_vector);
+			auto msaa_view = multisampled->get_view(VK_REMAP_VIEW_MULTISAMPLED, rsx::default_remap_vector);
+			auto resolved_view = resolve->get_view(VK_REMAP_IDENTITY, rsx::default_remap_vector);
 			m_program->bind_uniform({ VK_NULL_HANDLE, msaa_view->value, multisampled->current_layout }, "multisampled", VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, m_descriptor_set);
 			m_program->bind_uniform({ VK_NULL_HANDLE, resolved_view->value, resolve->current_layout }, "resolve", VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, m_descriptor_set);
 		}
@@ -270,7 +270,7 @@ namespace vk
 		void run(vk::command_buffer& cmd, vk::viewable_image* msaa_image, vk::viewable_image* resolve_image, VkRenderPass render_pass)
 		{
 			update_sample_configuration(msaa_image);
-			auto src_view = msaa_image->get_view(0xDEADBEEF, rsx::default_remap_vector);
+			auto src_view = msaa_image->get_view(VK_REMAP_VIEW_MULTISAMPLED, rsx::default_remap_vector);
 
 			overlay_pass::run(
 				cmd,
@@ -301,7 +301,7 @@ namespace vk
 			renderpass_config.set_multisample_shading_rate(1.f);
 			update_sample_configuration(msaa_image);
 
-			auto src_view = resolve_image->get_view(0xAAE4, rsx::default_remap_vector);
+			auto src_view = resolve_image->get_view(VK_REMAP_IDENTITY, rsx::default_remap_vector);
 
 			overlay_pass::run(
 				cmd,
@@ -363,7 +363,7 @@ namespace vk
 		void run(vk::command_buffer& cmd, vk::viewable_image* msaa_image, vk::viewable_image* resolve_image, VkRenderPass render_pass)
 		{
 			update_sample_configuration(msaa_image);
-			auto stencil_view = msaa_image->get_view(0xDEADBEEF, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
+			auto stencil_view = msaa_image->get_view(VK_REMAP_VIEW_MULTISAMPLED, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
 
 			region.rect.extent.width = resolve_image->width();
 			region.rect.extent.height = resolve_image->height();
@@ -431,7 +431,7 @@ namespace vk
 			renderpass_config.set_multisample_shading_rate(1.f);
 			update_sample_configuration(msaa_image);
 
-			auto stencil_view = resolve_image->get_view(0xAAE4, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
+			auto stencil_view = resolve_image->get_view(VK_REMAP_IDENTITY, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
 
 			region.rect.extent.width = resolve_image->width();
 			region.rect.extent.height = resolve_image->height();
@@ -475,8 +475,8 @@ namespace vk
 		void run(vk::command_buffer& cmd, vk::viewable_image* msaa_image, vk::viewable_image* resolve_image, VkRenderPass render_pass)
 		{
 			update_sample_configuration(msaa_image);
-			auto depth_view = msaa_image->get_view(0xDEADBEEF, rsx::default_remap_vector, VK_IMAGE_ASPECT_DEPTH_BIT);
-			auto stencil_view = msaa_image->get_view(0xDEADBEEF, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
+			auto depth_view = msaa_image->get_view(VK_REMAP_VIEW_MULTISAMPLED, rsx::default_remap_vector, VK_IMAGE_ASPECT_DEPTH_BIT);
+			auto stencil_view = msaa_image->get_view(VK_REMAP_VIEW_MULTISAMPLED, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
 
 			overlay_pass::run(
 				cmd,
@@ -520,8 +520,8 @@ namespace vk
 			renderpass_config.set_multisample_shading_rate(1.f);
 			update_sample_configuration(msaa_image);
 
-			auto depth_view = resolve_image->get_view(0xAAE4, rsx::default_remap_vector, VK_IMAGE_ASPECT_DEPTH_BIT);
-			auto stencil_view = resolve_image->get_view(0xAAE4, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
+			auto depth_view = resolve_image->get_view(VK_REMAP_IDENTITY, rsx::default_remap_vector, VK_IMAGE_ASPECT_DEPTH_BIT);
+			auto stencil_view = resolve_image->get_view(VK_REMAP_IDENTITY, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
 
 			overlay_pass::run(
 				cmd,


### PR DESCRIPTION
- Allows bypassing all remap shenanigans to make some operations that rely on the raw image to work correctly.

Fixes "blue" filter in some games with newer builds where AV filters are implemented. Since the image being drawn to the screen is 'raw', image transform is undesired. The "blue" is because the PS3 format ARGB is actually the PC format BGRA but with endianness inverted for the 32-bit block.