### PR TITLE
Implement ps3 application root flags detection

### DIFF
--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -885,11 +885,16 @@ SELFDecrypter::SELFDecrypter(const fs::file& s)
 {
 }
 
-bool SELFDecrypter::LoadHeaders(bool isElf32)
+bool SELFDecrypter::LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info)
 {
 	// Read SCE header.
 	self_f.seek(0);
 	sce_hdr.Load(self_f);
+
+	if (out_info)
+	{
+		out_info->valid = false;
+	}
 
 	// Check SCE magic.
 	if (!sce_hdr.CheckMagic())
@@ -904,6 +909,11 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 	// Read the APP INFO.
 	self_f.seek(self_hdr.se_appinfooff);
 	app_info.Load(self_f);
+
+	if (out_info)
+	{
+		out_info->app_info = app_info;
+	}
 
 	// Read ELF header.
 	self_f.seek(self_hdr.se_elfoff);
@@ -967,13 +977,17 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 	ctrlinfo_arr.clear();
 	self_f.seek(self_hdr.se_controloff);
 
-	u32 i = 0;
-	while(i < self_hdr.se_controlsize)
+	for (u64 i = 0; i < self_hdr.se_controlsize;)
 	{
 		ctrlinfo_arr.emplace_back();
 		ControlInfo &cinfo = ctrlinfo_arr.back();
 		cinfo.Load(self_f);
 		i += cinfo.size;
+	}
+
+	if (out_info)
+	{
+		out_info->ctrl_info = ctrlinfo_arr;
 	}
 
 	// Read ELF section headers.
@@ -1011,6 +1025,11 @@ bool SELFDecrypter::LoadHeaders(bool isElf32)
 			shdr64_arr.emplace_back();
 			shdr64_arr.back().Load(self_f);
 		}
+	}
+
+	if (out_info)
+	{
+		out_info->valid = true;
 	}
 
 	return true;
@@ -1374,8 +1393,13 @@ static bool CheckDebugSelf(fs::file& s)
 	return false;
 }
 
-extern fs::file decrypt_self(fs::file elf_or_self, u8* klic_key)
+fs::file decrypt_self(fs::file elf_or_self, u8* klic_key, SelfAdditionalInfo* out_info)
 {
+	if (out_info)
+	{
+		out_info->valid = false;
+	}
+
 	if (!elf_or_self)
 	{
 		return fs::file{};
@@ -1393,7 +1417,7 @@ extern fs::file decrypt_self(fs::file elf_or_self, u8* klic_key)
 		SELFDecrypter self_dec(elf_or_self);
 
 		// Load the SELF file headers.
-		if (!self_dec.LoadHeaders(isElf32))
+		if (!self_dec.LoadHeaders(isElf32, out_info))
 		{
 			LOG_ERROR(LOADER, "SELF: Failed to load SELF file headers!");
 			return fs::file{};
@@ -1420,7 +1444,7 @@ extern fs::file decrypt_self(fs::file elf_or_self, u8* klic_key)
 	return elf_or_self;
 }
 
-extern bool verify_npdrm_self_headers(const fs::file& self, u8* klic_key)
+bool verify_npdrm_self_headers(const fs::file& self, u8* klic_key)
 {
 	if (!self)
 		return false;

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -343,6 +343,13 @@ struct SelfHeader
 	void Show(){}
 };
 
+struct SelfAdditionalInfo
+{
+	bool valid = false;
+	std::vector<ControlInfo> ctrl_info;
+	AppInfo app_info;
+};
+
 class SCEDecrypter
 {
 protected:
@@ -413,7 +420,7 @@ class SELFDecrypter
 public:
 	SELFDecrypter(const fs::file& s);
 	fs::file MakeElf(bool isElf32);
-	bool LoadHeaders(bool isElf32);
+	bool LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info = nullptr);
 	void ShowHeaders(bool isElf32);
 	bool LoadMetadata(u8* klic_key);
 	bool DecryptData();
@@ -497,6 +504,6 @@ private:
 	}
 };
 
-extern fs::file decrypt_self(fs::file elf_or_self, u8* klic_key = nullptr);
-extern bool verify_npdrm_self_headers(const fs::file& self, u8* klic_key = nullptr);
-extern std::array<u8, 0x10> get_default_self_klic();
+fs::file decrypt_self(fs::file elf_or_self, u8* klic_key = nullptr, SelfAdditionalInfo* additional_info = nullptr);
+bool verify_npdrm_self_headers(const fs::file& self, u8* klic_key = nullptr);
+std::array<u8, 0x10> get_default_self_klic();

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -166,7 +166,7 @@ public:
 	u64 rtime{0};
 	u64 rdata{0}; // Reservation data
 
-	atomic_t<u32> prio{0}; // Thread priority (0..3071)
+	atomic_t<s32> prio{0}; // Thread priority (0..3071)
 	const u32 stack_size; // Stack size
 	const u32 stack_addr; // Stack address
 

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -7,6 +7,7 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 #include "sys_event.h"
+#include "sys_process.h"
 #include "sys_mmapper.h"
 
 LOG_CHANNEL(sys_ppu_thread);
@@ -210,7 +211,7 @@ error_code sys_ppu_thread_set_priority(ppu_thread& ppu, u32 thread_id, s32 prio)
 {
 	sys_ppu_thread.trace("sys_ppu_thread_set_priority(thread_id=0x%x, prio=%d)", thread_id, prio);
 
-	if (prio < 0 || prio > 3071)
+	if (prio < (g_ps3_process_info.debug_or_root() ? -512 : 0) || prio > 3071)
 	{
 		return CELL_EINVAL;
 	}
@@ -219,7 +220,7 @@ error_code sys_ppu_thread_set_priority(ppu_thread& ppu, u32 thread_id, s32 prio)
 	{
 		if (thread.prio != prio)
 		{
-			lv2_obj::awake(&thread, prio);
+			lv2_obj::set_priority(thread, prio);
 		}
 	});
 
@@ -299,7 +300,7 @@ error_code _sys_ppu_thread_create(vm::ptr<u64> thread_id, vm::ptr<ppu_thread_par
 		return CELL_EFAULT;
 	}
 
-	if (prio < 0 || prio > 3071)
+	if (prio < (g_ps3_process_info.debug_or_root() ? -512 : 0) || prio > 3071)
 	{
 		return CELL_EINVAL;
 	}
@@ -359,7 +360,7 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 
 	const auto thread = idm::get<named_thread<ppu_thread>>(thread_id, [&](ppu_thread& thread)
 	{
-		lv2_obj::awake(&thread, -2);
+		lv2_obj::awake(&thread);
 	});
 
 	if (!thread)

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -25,7 +25,23 @@
 #include "sys_fs.h"
 #include "sys_spu.h"
 
+// Check all flags known to be related to extended permissions (TODO)
+// I think anything which has root flags implicitly has debug perm as well
+// But I havn't confirmed it.
+bool ps3_process_info_t::debug_or_root() const
+{
+	return (ctrl_flags1 & (0xe << 28)) != 0;
+}
 
+bool ps3_process_info_t::has_root_perm() const
+{
+	return (ctrl_flags1 & (0xc << 28)) != 0;
+}
+
+bool ps3_process_info_t::has_debug_perm() const
+{
+	return (ctrl_flags1 & (0xa << 28)) != 0;
+}
 
 LOG_CHANNEL(sys_process);
 

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Crypto/unself.h"
 #include "Emu/Memory/vm_ptr.h"
 
 // Process Local Object Type
@@ -40,6 +41,12 @@ struct ps3_process_info_t
 {
 	u32 sdk_ver;
 	u32 ppc_seg;
+	SelfAdditionalInfo self_info;
+	u32 ctrl_flags1 = 0;
+
+	bool has_root_perm() const;
+	bool has_debug_perm() const;
+	bool debug_or_root() const;
 };
 
 extern ps3_process_info_t  g_ps3_process_info;

--- a/rpcs3/Emu/Cell/lv2/sys_ss.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
@@ -10,5 +10,6 @@ struct CellSsOpenPSID
 };
 
 error_code sys_ss_random_number_generator(u32 arg1, vm::ptr<void> buf, u64 size);
+error_code sys_ss_access_control_engine(u64 pkg_id, u64 a2, u64 a3);
 s32 sys_ss_get_console_id(vm::ptr<u8> buf);
 s32 sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> ptr);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -10,6 +10,7 @@
 #include "Emu/Cell/PPUAnalyser.h"
 #include "Emu/Cell/SPUThread.h"
 #include "Emu/Cell/RawSPUThread.h"
+#include "Emu/Cell/lv2/sys_process.h"
 #include "Emu/Cell/lv2/sys_memory.h"
 #include "Emu/Cell/lv2/sys_sync.h"
 #include "Emu/Cell/lv2/sys_prx.h"
@@ -1481,7 +1482,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 				elf_file.open(decrypted_path);
 			}
 			// Decrypt SELF
-			else if ((elf_file = decrypt_self(std::move(elf_file), klic.empty() ? nullptr : klic.data())))
+			else if ((elf_file = decrypt_self(std::move(elf_file), klic.empty() ? nullptr : klic.data(), &g_ps3_process_info.self_info)))
 			{
 				if (true)
 				{
@@ -1497,6 +1498,10 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 					LOG_ERROR(LOADER, "Failed to create boot.elf");
 				}
 			}
+		}
+		else
+		{
+			g_ps3_process_info.self_info.valid = false;
 		}
 
 		if (!elf_file)


### PR DESCRIPTION
Needed for VSH (has root flags), separated from games.

List of currently affected syscalls:
* `sys_ppu_thread_set_priority`.
* `sys_ppu_thread_create`.
* `sys_spu_thread_group_set_priority`.
* `sys_spu_thread_group_create`.
* `sys_ss_access_control_engine`.