### PR TITLE
Stop autoupdater renaming file across devices

### DIFF
--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -322,7 +322,8 @@ bool update_manager::handle_rpcs3(const QByteArray& rpcs3_data, bool /*automatic
 	m_progress_dialog->setWindowTitle(tr("Updating RPCS3"));
 
 	// Move the appimage/exe and replace with new appimage
-	fs::rename(replace_path, "/tmp/rpcs3_old", true);
+	std::string move_dest = replace_path + "_old";
+	fs::rename(replace_path, move_dest, true);
 	fs::file new_appimage(replace_path, fs::read + fs::write + fs::create + fs::trunc);
 	if (!new_appimage)
 	{


### PR DESCRIPTION
Fixes issues where rpcs3 appimage and /tmp/ directory were on different devices.
Old appimage is now renamed to old app image name + "_old" in the same directory.

Fixes https://github.com/RPCS3/rpcs3/issues/6858 .