### PR TITLE
Fixes cleanup

### DIFF
--- a/Utilities/BitField.h
+++ b/Utilities/BitField.h
@@ -1,7 +1,6 @@
-#pragma once
+﻿#pragma once
 
 #include "types.h"
-#include <limits>
 
 template<typename T, uint N>
 struct bf_base
@@ -17,7 +16,7 @@ struct bf_base
 	static constexpr uint bitsize = N;
 
 	// All ones mask
-	static constexpr utype mask1 = std::numeric_limits<utype>::max();
+	static constexpr utype mask1 = static_cast<utype>(UINTMAX_MAX);
 
 	// Value mask
 	static constexpr utype vmask = mask1 >> (bitmax - bitsize);

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -1376,6 +1376,11 @@ error_code cellAudioSetNotifyEventQueue(u64 key)
 		return CELL_AUDIO_ERROR_NOT_INIT;
 	}
 
+	if (!lv2_event_queue::find(key))
+	{
+		return CELL_AUDIO_ERROR_TRANS_EVENT;
+	}
+
 	for (auto k : g_audio->keys) // check for duplicates
 	{
 		if (k == key)

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -420,6 +420,11 @@ error_code sys_event_port_connect_ipc(ppu_thread& ppu, u32 eport_id, u64 ipc_key
 
 	sys_event.warning("sys_event_port_connect_ipc(eport_id=0x%x, ipc_key=0x%x)", eport_id, ipc_key);
 
+	if (ipc_key == 0)
+	{
+		return CELL_EINVAL;
+	}
+
 	auto queue = lv2_event_queue::find(ipc_key);
 
 	std::lock_guard lock(id_manager::g_mutex);

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -162,6 +162,11 @@ public:
 		{
 		case SYS_SYNC_PROCESS_SHARED:
 		{
+			if (ipc_key == 0)
+			{
+				return CELL_EINVAL;
+			}
+
 			switch (flags)
 			{
 			case SYS_SYNC_NEWLY_CREATED:


### PR DESCRIPTION
Contains 3 commits:
* Remove limits lib dependency from Utilities/BitField.h.
* Add EINVAL check for invalid ipc_key in - general lv2 shared sync object creation (instead of CELL_OK), sys_event_port_connect_ipc (instead of ESRCH).
* Add missng check for key in cellAudioSetNotifyEventQueue.