### PR TITLE
rsx: ZCULL tweaks

### DIFF
--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -307,7 +307,7 @@ namespace rsx
 			u8* pixels_src = (u8*)vm::base(src_address);
 
 			const u32 src_size = in_pitch * (in_h - 1) + (in_w * in_bpp);
-			rsx->read_barrier(src_address, src_size);
+			rsx->read_barrier(src_address, src_size, true);
 
 			frame_capture_data::memory_block_data block_data;
 			block_data.data.resize(src_size);
@@ -328,7 +328,7 @@ namespace rsx
 			u32 src_dma    = method_registers.nv0039_input_location();
 			u32 src_addr   = get_address(src_offset, src_dma);
 
-			rsx->read_barrier(src_addr, in_pitch * (line_count - 1) + line_length);
+			rsx->read_barrier(src_addr, in_pitch * (line_count - 1) + line_length, true);
 
 			const u8* src = vm::_ptr<u8>(src_addr);
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -296,7 +296,7 @@ namespace rsx
 		if (conditional_render_enabled && conditional_render_test_address)
 		{
 			// Evaluate conditional rendering test
-			zcull_ctrl->read_barrier(this, conditional_render_test_address, 4);
+			zcull_ctrl->read_barrier(this, conditional_render_test_address, 4, reports::sync_no_notify);
 			vm::ptr<CellGcmReportData> result = vm::cast(conditional_render_test_address);
 			conditional_render_test_failed = (result->value == 0);
 			conditional_render_test_address = 0;
@@ -2348,6 +2348,11 @@ namespace rsx
 		vm::_ref<atomic_t<CellGcmReportData>>(sink).store({ timestamp(), value, 0});
 	}
 
+	u32 thread::copy_zcull_stats(u32 memory_range_start, u32 memory_range, u32 destination)
+	{
+		return zcull_ctrl->copy_reports_to(memory_range_start, memory_range, destination);
+	}
+
 	void thread::sync()
 	{
 		zcull_ctrl->sync(this);
@@ -2384,9 +2389,10 @@ namespace rsx
 		return fifo_ctrl->last_cmd();
 	}
 
-	void thread::read_barrier(u32 memory_address, u32 memory_range)
+	flags32_t thread::read_barrier(u32 memory_address, u32 memory_range, bool unconditional)
 	{
-		zcull_ctrl->read_barrier(this, memory_address, memory_range);
+		flags32_t zcull_flags = (unconditional)? reports::sync_none : reports::sync_defer_copy;
+		return zcull_ctrl->read_barrier(this, memory_address, memory_range, zcull_flags);
 	}
 
 	void thread::notify_zcull_info_changed()
@@ -2938,6 +2944,16 @@ namespace rsx
 			vm::_ref<atomic_t<CellGcmReportData>>(sink).store({ timestamp, value, 0});
 		}
 
+		void ZCULL_control::write(queued_report_write* writer, u64 timestamp, u32 value)
+		{
+			write(writer->sink, timestamp, writer->type, value);
+
+			for (auto &addr : writer->sink_alias)
+			{
+				write(addr, timestamp, writer->type, value);
+			}
+		}
+
 		void ZCULL_control::sync(::rsx::thread* ptimer)
 		{
 			if (!m_pending_writes.empty())
@@ -2979,8 +2995,10 @@ namespace rsx
 					}
 
 					if (!writer.forwarder)
-						//No other queries in the chain, write result
-						write(writer.sink, ptimer->timestamp(), writer.type, result);
+					{
+						// No other queries in the chain, write result
+						write(&writer, ptimer->timestamp(), result);
+					}
 
 					processed++;
 				}
@@ -2997,7 +3015,7 @@ namespace rsx
 
 					if (remaining == 1)
 					{
-						m_pending_writes.front() = m_pending_writes.back();
+						m_pending_writes[0] = std::move(m_pending_writes.back());
 						m_pending_writes.resize(1);
 					}
 					else
@@ -3156,10 +3174,12 @@ namespace rsx
 
 				stat_tag_to_remove = writer.counter_tag;
 
-				//only zpass supported right now
+				// only zpass supported right now
 				if (!writer.forwarder)
-					//No other queries in the chain, write result
-					write(writer.sink, ptimer->timestamp(), writer.type, result);
+				{
+					// No other queries in the chain, write result
+					write(&writer, ptimer->timestamp(), result);
+				}
 
 				processed++;
 			}
@@ -3172,7 +3192,7 @@ namespace rsx
 				auto remaining = m_pending_writes.size() - processed;
 				if (remaining == 1)
 				{
-					m_pending_writes.front() = m_pending_writes.back();
+					m_pending_writes[0] = std::move(m_pending_writes.back());
 					m_pending_writes.resize(1);
 				}
 				else if (remaining)
@@ -3189,10 +3209,10 @@ namespace rsx
 			}
 		}
 
-		void ZCULL_control::read_barrier(::rsx::thread* ptimer, u32 memory_address, u32 memory_range)
+		flags32_t ZCULL_control::read_barrier(::rsx::thread* ptimer, u32 memory_address, u32 memory_range, flags32_t flags)
 		{
 			if (m_pending_writes.empty())
-				return;
+				return result_none;
 
 			const auto memory_end = memory_address + memory_range;
 			u32 sync_address = 0;
@@ -3208,11 +3228,21 @@ namespace rsx
 				}
 			}
 
-			if (sync_address)
+			if (!sync_address)
+				return result_none;
+
+			if (!(flags & sync_defer_copy))
 			{
-				ptimer->sync_hint(FIFO_hint::hint_zcull_sync, reinterpret_cast<uintptr_t>(query));
+				if (!(flags & sync_no_notify))
+				{
+					ptimer->sync_hint(FIFO_hint::hint_zcull_sync, reinterpret_cast<uintptr_t>(query));
+				}
+
 				update(ptimer, sync_address);
+				return result_none;
 			}
+
+			return result_zcull_intr;
 		}
 
 		occlusion_query_info* ZCULL_control::find_query(vm::addr_t sink_address)
@@ -3224,6 +3254,25 @@ namespace rsx
 			}
 
 			return nullptr;
+		}
+
+		u32 ZCULL_control::copy_reports_to(u32 start, u32 range, u32 dest)
+		{
+			u32 bytes_to_write = 0;
+			const auto memory_range = utils::address_range::start_length(start, range);
+			for (auto &writer : m_pending_writes)
+			{
+				if (!writer.sink)
+					break;
+
+				if (!writer.forwarder && memory_range.overlaps(writer.sink))
+				{
+					u32 address = (writer.sink - start) + dest;
+					writer.sink_alias.push_back(vm::cast(address));
+				}
+			}
+
+			return bytes_to_write;
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -97,7 +97,8 @@ namespace rsx
 
 	enum FIFO_hint : u8
 	{
-		hint_conditional_render_eval = 1
+		hint_conditional_render_eval = 1,
+		hint_zcull_sync = 2
 	};
 
 	u32 get_vertex_type_size_on_host(vertex_base_type type, u32 size);
@@ -330,6 +331,7 @@ namespace rsx
 			u32 driver_handle;
 			u32 result;
 			u32 num_draws;
+			bool hint;
 			bool pending;
 			bool active;
 			bool owned;
@@ -366,6 +368,7 @@ namespace rsx
 			u32 m_statistics_tag_id = 0;
 			u64 m_tsc = 0;
 			u32 m_cycles_delay = max_zcull_delay_us;
+			u32 m_backend_warn_threshold = max_zcull_delay_us / 2;
 
 			std::vector<queued_report_write> m_pending_writes;
 			std::unordered_map<u32, u32> m_statistics_map;
@@ -688,7 +691,7 @@ namespace rsx
 		// sync
 		void sync();
 		void read_barrier(u32 memory_address, u32 memory_range);
-		virtual void sync_hint(FIFO_hint /*hint*/, u32 /*arg*/) {}
+		virtual void sync_hint(FIFO_hint /*hint*/, u64 /*arg*/) {}
 
 		gsl::span<const gsl::byte> get_raw_index_array(const draw_clause& draw_indexed_clause) const;
 		gsl::span<const gsl::byte> get_raw_vertex_buffer(const rsx::data_array_format_info&, u32 base_offset, const draw_clause& draw_array_clause) const;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2169,7 +2169,7 @@ void VKGSRender::flush_command_queue(bool hard_sync)
 	open_command_buffer();
 }
 
-void VKGSRender::sync_hint(rsx::FIFO_hint hint, u32 arg)
+void VKGSRender::sync_hint(rsx::FIFO_hint hint, u64 arg)
 {
 	// Occlusion test result evaluation is coming up, avoid a hard sync
 	if (hint == rsx::FIFO_hint::hint_conditional_render_eval)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -467,7 +467,7 @@ public:
 	void set_scissor(bool clip_viewport);
 	void bind_viewport();
 
-	void sync_hint(rsx::FIFO_hint hint, u32 arg) override;
+	void sync_hint(rsx::FIFO_hint hint, u64 arg) override;
 
 	void begin_occlusion_query(rsx::reports::occlusion_query_info* query) override;
 	void end_occlusion_query(rsx::reports::occlusion_query_info* query) override;


### PR DESCRIPTION
Another changeset that almost got buried and forgotten; this PR makes several minor tweaks to ZCULL synchronization that can give tangible performance improvements in some cases.
- Avoid hard sync condition as much as possible. This is done by implementing more sync hints for the backends.
- Implements reading of partial results. I can only use RADV as the reference here since it is open source, but this should likely improve the API-side waiting.
- Allow delaying report transfers until they are ready even when using imaging methods to move the bits.

This doesn't solve all the ZCULL problems, but a lot was learned when implementing this that makes the bottlenecks a lot more obvious.