### PR TITLE
rsx: GPU texture deswizzle and other compute enhancements

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -668,13 +668,19 @@ texture_memory_info upload_texture_subresource(gsl::span<gsl::byte> dst_buffer, 
 		{
 			result.require_swap = true;
 			result.element_size = word_size;
+			result.block_length = words_per_block;
 
 			if (word_size == 2)
 			{
-				const bool skip_swizzle = ((word_size * words_per_block) & 3) == 0 && caps.supports_hw_deswizzle;
-				if (is_swizzled && skip_swizzle) result.require_deswizzle = true;
+				if (is_swizzled)
+				{
+					if (((word_size * words_per_block) & 3) == 0 && caps.supports_hw_deswizzle)
+					{
+						result.require_deswizzle = true;
+					}
+				}
 
-				if (is_swizzled && !skip_swizzle)
+				if (is_swizzled && !result.require_deswizzle)
 					copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const u16>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
 				else
 					copy_unmodified_block::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const u16>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -671,14 +671,19 @@ texture_memory_info upload_texture_subresource(gsl::span<gsl::byte> dst_buffer, 
 
 			if (word_size == 2)
 			{
-				if (is_swizzled)
+				const bool skip_swizzle = ((word_size * words_per_block) & 3) == 0 && caps.supports_hw_deswizzle;
+				if (is_swizzled && skip_swizzle) result.require_deswizzle = true;
+
+				if (is_swizzled && !skip_swizzle)
 					copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const u16>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
 				else
 					copy_unmodified_block::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const u16>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
 			}
 			else if (word_size == 4)
 			{
-				if (is_swizzled)
+				result.require_deswizzle = (is_swizzled && caps.supports_hw_deswizzle);
+				
+				if (is_swizzled && !caps.supports_hw_deswizzle)
 					copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const u32>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
 				else
 					copy_unmodified_block::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const u32>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -104,6 +104,7 @@ struct rsx_subresource_layout
 struct texture_memory_info
 {
 	int element_size;
+	int block_length;
 	bool require_swap;
 	bool require_deswizzle;
 };

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -105,12 +105,14 @@ struct texture_memory_info
 {
 	int element_size;
 	bool require_swap;
+	bool require_deswizzle;
 };
 
 struct texture_uploader_capabilities
 {
 	bool supports_byteswap;
 	bool supports_vtc_decoding;
+	bool supports_hw_deswizzle;
 	size_t alignment;
 };
 

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -459,7 +459,7 @@ namespace gl
 			const std::vector<rsx_subresource_layout> &input_layouts, bool is_swizzled, GLenum gl_format, GLenum gl_type, std::vector<gsl::byte>& staging_buffer)
 	{
 		int mip_level = 0;
-		texture_uploader_capabilities caps{ true, false, 4 };
+		texture_uploader_capabilities caps{ true, false, false, 4 };
 
 		pixel_unpack_settings unpack_settings;
 		unpack_settings.row_length(0).alignment(4);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -3299,6 +3299,7 @@ public:
 					std::string shader_type = type == ::glsl::program_domain::glsl_vertex_program ? "vertex" :
 						type == ::glsl::program_domain::glsl_fragment_program ? "fragment" : "compute";
 
+					LOG_NOTICE(RSX, "%s", m_source);
 					fmt::throw_exception("Failed to compile %s shader" HERE, shader_type);
 				}
 

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -133,7 +133,7 @@ namespace vk
 			const u32 invocations_x = align(resolve_image->width(), cs_wave_x) / cs_wave_x;
 			const u32 invocations_y = align(resolve_image->height(), cs_wave_y) / cs_wave_y;
 
-			compute_task::run(cmd, invocations_x, invocations_y);
+			compute_task::run(cmd, invocations_x, invocations_y, 1);
 		}
 	};
 

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -545,7 +545,7 @@ namespace vk
 		u32 block_in_pixel = get_format_block_size_in_texel(format);
 		u8  block_size_in_bytes = get_format_block_size_in_bytes(format);
 
-		texture_uploader_capabilities caps{ true, false, heap_align };
+		texture_uploader_capabilities caps{ true, false, true, heap_align };
 		texture_memory_info opt{};
 		bool check_caps = true;
 
@@ -580,6 +580,7 @@ namespace vk
 			if (check_caps)
 			{
 				caps.supports_byteswap = (image_linear_size >= 1024);
+				caps.supports_hw_deswizzle = caps.supports_byteswap;
 				check_caps = false;
 			}
 


### PR DESCRIPTION
GPU deswizzle was attempted in the past and was a failure, but my approach back then was a bit different. Ultimately it failed because it attempted to do deswizzle as a texture coordinate transformation which did not work too well. Even with a lookup table the texels were too far apart for emulated filters to work properly. This new approach just adds on top of the existing GPU decoders and implements deswizzle as an upload transformation. You can see some of my thoughts on this in https://github.com/RPCS3/rpcs3/issues/6882.
A downside of using GPU deswizzle is that each LOD has to be processed separately which is very inefficient to run on a GPU. Poor occupancy of lower LODs just robs the rest of the graphics pipeline of resources which actually hurts graphics throughput. There is also a huge spike in number of compute dispatches which is not ideal. I'll keep this WIP while I try and write a batching algorithm for multiple LODs. This requires implementing a 4D decoder which is going to be a pain as the compute APIs are limited to 3 dimensions.