### PR TITLE
Fix context menu showing twice in Game List

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -120,10 +120,6 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 		QMenu* configure = new QMenu(this);
 		configure->addActions(m_columnActs);
 		configure->exec(mapToGlobal(pos));
-
-		QMenu* pad_configure = new QMenu(this);
-		pad_configure->addActions(m_columnActs);
-		pad_configure->exec(mapToGlobal(pos));
 	});
 
 	connect(m_xgrid, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);


### PR DESCRIPTION
Context menu was created twice, so selecting something from it once brought up yet another menu. They were constructed in an identical way - although name `pad_configure` implies that maybe the second menu was there to allow navigating it via gamepad, I checked and it wasn't the case.