### PR TITLE
WIP: Optimise copy_unmodified_block::copy_mipmap_level()

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -66,7 +66,14 @@ struct copy_unmodified_block
 		{
 			// Fast copy
 			const auto data_length = src_pitch_in_block * words_per_block * row_count * depth;
-			copy(dst, src.subspan(0, data_length));
+			if constexpr (std::is_same<T, U>::value)
+			{
+				memcpy(dst.data(), src.data(), data_length * sizeof(T));
+			}
+			else
+			{
+				copy(dst, src.subspan(0, data_length));
+			}
 			return;
 		}
 


### PR DESCRIPTION
It was very surprising to see this function use more than 5% of the CPU
at the masked people’s town in NieR.

A compressed rrc file is available at: https://0x0.st/zg2y.xz

Replacing std::copy() on gsl::span by memcpy() on their raw pointer led
to this function basically vanishing from the profiles.  The std::copy()
codepath seems to compile to very bad mov/inc scalar assembly, while
memcpy() uses the full width of my vector registers.

I’m now wondering whether this is an issue of the std::copy()
implementation in both libstd++ and libc++, or Microsoft’s
implementation of C++20’s std::span and its iterator, or a mismatch
between them two.  And if so, should I do this optimisation elsewhere
too in the code?  Does this issue also happen on MSVC?

As an aside, any reason we’re still using C++17 instead of C++20?  We
could ditch this gsl::span for std::span by updating the version,
although I have no idea whether this would fix the performance issue.