### PR TITLE
Qt: adjust custom context menu positions

### DIFF
--- a/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #include "auto_pause_settings_dialog.h"
 
 constexpr auto qstr = QString::fromStdString;
@@ -141,7 +141,6 @@ void auto_pause_settings_dialog::ShowContextMenu(const QPoint &pos)
 {
 	int row = pauseList->indexAt(pos).row();
 
-	QPoint globalPos = pauseList->mapToGlobal(pos);
 	QMenu myMenu;
 
 	// Make Actions
@@ -174,7 +173,7 @@ void auto_pause_settings_dialog::ShowContextMenu(const QPoint &pos)
 	connect(remove, &QAction::triggered, this, &auto_pause_settings_dialog::OnRemove);
 	connect(config, &QAction::triggered, [=]() {OnEntryConfig(row, false); });
 
-	myMenu.exec(globalPos);
+	myMenu.exec(pauseList->viewport()->mapToGlobal(pos));
 }
 
 void auto_pause_settings_dialog::OnRemove()

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -1,4 +1,4 @@
-#include "breakpoint_list.h"
+﻿#include "breakpoint_list.h"
 
 #include "Emu/Cell/SPUThread.h"
 
@@ -127,7 +127,7 @@ void breakpoint_list::OnBreakpointListRightClicked(const QPoint &pos)
 
 	menu->addAction(m_breakpoint_list_delete);
 
-	QAction* selectedItem = menu->exec(QCursor::pos());
+	QAction* selectedItem = menu->exec(viewport()->mapToGlobal(pos));
 	if (selectedItem)
 	{
 		if (selectedItem->text() == "Rename")

--- a/rpcs3/rpcs3qt/cg_disasm_window.cpp
+++ b/rpcs3/rpcs3qt/cg_disasm_window.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 
 #include "cg_disasm_window.h"
 
@@ -87,7 +87,24 @@ void cg_disasm_window::ShowContextMenu(const QPoint &pos)
 		ShowDisasm();
 	});
 
-	myMenu.exec(mapToGlobal(pos));
+	const auto obj = qobject_cast<QTextEdit*>(sender());
+
+	QPoint origin;
+
+	if (obj == m_disasm_text)
+	{
+		origin = m_disasm_text->viewport()->mapToGlobal(pos);
+	}
+	else if (obj == m_glsl_text)
+	{
+		origin = m_glsl_text->viewport()->mapToGlobal(pos);
+	}
+	else
+	{
+		origin = mapToGlobal(pos);
+	}
+
+	myMenu.exec(origin);
 }
 
 void cg_disasm_window::ShowDisasm()

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -119,7 +119,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 	{
 		QMenu* configure = new QMenu(this);
 		configure->addActions(m_columnActs);
-		configure->exec(mapToGlobal(pos));
+		configure->exec(m_gameList->horizontalHeader()->viewport()->mapToGlobal(pos));
 	});
 
 	connect(m_xgrid, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
@@ -819,13 +819,13 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	if (m_isListLayout)
 	{
 		item = m_gameList->item(m_gameList->indexAt(pos).row(), gui::column_icon);
-		globalPos = m_gameList->mapToGlobal(pos);
+		globalPos = m_gameList->viewport()->mapToGlobal(pos);
 	}
 	else
 	{
 		QModelIndex mi = m_xgrid->indexAt(pos);
 		item = m_xgrid->item(mi.row(), mi.column());
-		globalPos = m_xgrid->mapToGlobal(pos);
+		globalPos = m_xgrid->viewport()->mapToGlobal(pos);
 	}
 
 	game_info gameinfo = GetGameInfoFromItem(item);

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -303,7 +303,7 @@ void log_frame::CreateAndConnectActions()
 		menu->addAction(m_stackAct_log);
 		menu->addSeparator();
 		menu->addAction(m_TTYAct);
-		menu->exec(mapToGlobal(pos));
+		menu->exec(m_log->viewport()->mapToGlobal(pos));
 	});
 
 	connect(m_tty, &QWidget::customContextMenuRequested, [=](const QPoint& pos)
@@ -314,7 +314,7 @@ void log_frame::CreateAndConnectActions()
 		menu->addAction(m_stackAct_tty);
 		menu->addSeparator();
 		menu->addActions(m_tty_channel_acts->actions());
-		menu->exec(mapToGlobal(pos));
+		menu->exec(m_tty->viewport()->mapToGlobal(pos));
 	});
 
 	connect(m_tabWidget, &QTabWidget::currentChanged, [this](int/* index*/)

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -445,19 +445,18 @@ void save_manager_dialog::OnEntriesRemove()
 // Pop-up a small context-menu, being a replacement for save_data_manage_dialog
 void save_manager_dialog::ShowContextMenu(const QPoint &pos)
 {
-	bool selectedItems = m_list->selectionModel()->selectedRows().size() > 1;
-
-	QPoint globalPos = m_list->mapToGlobal(pos);
-	QMenu* menu = new QMenu();
 	int idx = m_list->currentRow();
 	if (idx == -1)
 	{
 		return;
 	}
 
+	const bool selectedItems = m_list->selectionModel()->selectedRows().size() > 1;
+
 	QAction* removeAct = new QAction(tr("&Remove"), this);
 	QAction* showDirAct = new QAction(tr("&Open Save Directory"), this);
 
+	QMenu* menu = new QMenu();
 	menu->addAction(removeAct);
 	menu->addAction(showDirAct);
 
@@ -478,7 +477,7 @@ void save_manager_dialog::ShowContextMenu(const QPoint &pos)
 		QDesktopServices::openUrl(QUrl("file:///" + path));
 	});
 
-	menu->exec(globalPos);
+	menu->exec(m_list->viewport()->mapToGlobal(pos));
 }
 
 void save_manager_dialog::SetIconSize(int size)

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -636,19 +636,18 @@ void trophy_manager_dialog::ApplyFilter()
 	ReadjustTrophyTable();
 }
 
-void trophy_manager_dialog::ShowContextMenu(const QPoint& loc)
+void trophy_manager_dialog::ShowContextMenu(const QPoint& pos)
 {
-	QPoint globalPos = m_trophy_table->mapToGlobal(loc);
-	QMenu* menu = new QMenu();
 	QTableWidgetItem* item = m_trophy_table->item(m_trophy_table->currentRow(), TrophyColumns::Icon);
 	if (!item)
 	{
 		return;
 	}
 
+	QMenu* menu = new QMenu();
 	QAction* show_trophy_dir = new QAction(tr("Open Trophy Dir"), menu);
 
-	int db_ind = m_game_combo->currentData().toInt();
+	const int db_ind = m_game_combo->currentData().toInt();
 
 	connect(show_trophy_dir, &QAction::triggered, [=]()
 	{
@@ -657,7 +656,7 @@ void trophy_manager_dialog::ShowContextMenu(const QPoint& loc)
 	});
 
 	menu->addAction(show_trophy_dir);
-	menu->exec(globalPos);
+	menu->exec(m_trophy_table->viewport()->mapToGlobal(pos));
 }
 
 void trophy_manager_dialog::StartTrophyLoadThreads()

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -406,7 +406,6 @@ void user_manager_dialog::ShowContextMenu(const QPoint &pos)
 		return;
 	}
 
-	QPoint global_pos = m_table->mapToGlobal(pos);
 	QMenu* menu = new QMenu();
 
 	// Create submenu for sort options.
@@ -439,7 +438,7 @@ void user_manager_dialog::ShowContextMenu(const QPoint &pos)
 	connect(user_id_act, &QAction::triggered, this, [=] {OnSort(0); });
 	connect(username_act, &QAction::triggered, this, [=] {OnSort(1); });
 
-	menu->exec(global_pos);
+	menu->exec(m_table->viewport()->mapToGlobal(pos));
 }
 
 // Returns the current user's key > 0. if no user is selected, return 0


### PR DESCRIPTION
This should fix the custom context menu position.
It was offset by some amount which led to some linux users activating menu options by releasing their mouse buttons.