### PR TITLE
Implement sysutil_check_name_string, Fix process default sdk version

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -965,7 +965,7 @@ s32 cellGameThemeInstall(vm::cptr<char> usrdirPath, vm::cptr<char> fileName, u32
 {
 	cellGame.todo("cellGameThemeInstall(usrdirPath=%s, fileName=%s, option=0x%x)", usrdirPath, fileName, option);
 
-	if (!fileName || !usrdirPath || usrdirPath.size() > CELL_GAME_PATH_MAX)
+	if (!fileName || !usrdirPath || !memchr(usrdirPath.get_ptr(), '\0', CELL_GAME_PATH_MAX))
 	{
 		return CELL_GAME_ERROR_PARAM;
 	}

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -150,12 +150,15 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 {
 	cellGame.error("cellHddGameCheck(version=%d, dirName=%s, errDialog=%d, funcStat=*0x%x, container=%d)", version, dirName, errDialog, funcStat, container);
 
-	std::string dir = dirName.get_ptr();
-
-	if (dir.size() != 9)
+	if (!dirName || !funcStat || sysutil_check_name_string(dirName.get_ptr(), 1, CELL_GAME_DIRNAME_SIZE) != 0)
 	{
 		return CELL_HDDGAME_ERROR_PARAM;
 	}
+
+	std::string dir = dirName.get_ptr();
+
+	// TODO: Find error code
+	verify(HERE), dir.size() == 9;
 
 	vm::var<CellHddGameCBResult> result;
 	vm::var<CellHddGameStatGet> get;

--- a/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
@@ -115,13 +115,13 @@ error_code cellSysCacheMount(vm::ptr<CellSysCacheParam> param)
 
 	const auto cache = g_fxo->get<syscache_info>();
 
-	if (!param || !std::memchr(param->cacheId, '\0', CELL_SYSCACHE_ID_SIZE))
+	if (!param || (param->cacheId[0] && sysutil_check_name_string(param->cacheId, 1, CELL_SYSCACHE_ID_SIZE) != 0))
 	{
 		return CELL_SYSCACHE_ERROR_PARAM;
 	}
 
 	// Full virtualized cache id (with title id included)
-	std::string cache_id = vfs::escape(Emu.GetTitleID() + '_' + param->cacheId, true);
+	std::string cache_id = vfs::escape(Emu.GetTitleID() + '_' + param->cacheId);
 
 	// Full path to virtual cache root (/dev_hdd1)
 	std::string new_path = cache->cache_root + cache_id + '/';

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.h
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.h
@@ -204,3 +204,4 @@ struct CellSysCacheParam
 
 extern void sysutil_register_cb(std::function<s32(ppu_thread&)>&&);
 extern void sysutil_send_system_cmd(u64 status, u64 param);
+s32 sysutil_check_name_string(const char* src, s32 minlen, s32 maxlen);

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1054,7 +1054,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	u32 tls_vsize = 0;
 
 	// Process information
-	u32 sdk_version = 0x360001;
+	u32 sdk_version = 0xffffffff;
 	s32 primary_prio = 1001;
 	u32 primary_stacksize = 0x100000;
 	u32 malloc_pagesize = 0x100000;


### PR DESCRIPTION
* Default sdk version is -1. (SYS_PROCESS_PARAM was not set)
* Implement sysutil_check_name_string:
  - Only limited set of characters is allowed in parameters of a few sysutil functions (`\` or `/` for example aren't allowed, thus the need to escape from `/` no longer needed there).
  - It turns out if sdk version is below 3.70 it is allowed to insert another character at the end of buffer length, must be proceeded by a null terminator. (e.g for cellSysCacheMount this null term is found at getCachePath[0].)