### PR TITLE
Performance Overlay: Add graph settings and fix some minor issues

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -85,7 +85,7 @@ namespace rsx
 
 			if (g_cfg.video.perf_overlay.center_y)
 			{
-				pos.y = (virtual_height - m_body.h) / 2;
+				pos.y = (virtual_height - m_body.h - bottom_margin) / 2;
 			}
 
 			elm.set_pos(pos.x, pos.y);

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -1,5 +1,5 @@
 ﻿#include "stdafx.h"
-#include "overlays.h"
+#include "overlay_perf_metrics.h"
 #include "../GSRender.h"
 
 #include "Emu/Cell/SPUThread.h"

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -383,7 +383,7 @@ namespace rsx
 
 					rsx_cycles += rsx_thread->get_cycles();
 
-					total_cycles = ppu_cycles + spu_cycles + rsx_cycles;
+					total_cycles = std::max<u64>(1, ppu_cycles + spu_cycles + rsx_cycles);
 					cpu_usage = m_cpu_stats.get_usage();
 
 					ppu_usage = std::clamp(cpu_usage * ppu_cycles / total_cycles, 0.f, 100.f);

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.h
@@ -1,0 +1,69 @@
+﻿#pragma once
+
+#include "overlays.h"
+
+namespace rsx
+{
+	namespace overlays
+	{
+		struct perf_metrics_overlay : overlay
+		{
+		private:
+			// minimal - fps
+			// low - fps, total cpu usage
+			// medium - fps, detailed cpu usage
+			// high - fps, frametime, detailed cpu usage, thread number, rsx load
+			detail_level m_detail{};
+
+			screen_quadrant m_quadrant{};
+			positioni m_position{};
+
+			label m_body{};
+			label m_titles{};
+
+			bool m_graphs_enabled{};
+			graph m_fps_graph;
+			graph m_frametime_graph;
+
+			CPUStats m_cpu_stats{};
+			Timer m_update_timer{};
+			Timer m_frametime_timer{};
+			u32 m_update_interval{}; // in ms
+			u32 m_frames{};
+			std::string m_font{};
+			u32 m_font_size{};
+			u32 m_margin_x{}; // horizontal distance to the screen border relative to the screen_quadrant in px
+			u32 m_margin_y{}; // vertical distance to the screen border relative to the screen_quadrant in px
+			f32 m_opacity{};  // 0..1
+
+			bool m_force_update{};
+			bool m_is_initialised{};
+
+			const std::string title1_medium{ "CPU Utilization:" };
+			const std::string title1_high{ "Host Utilization (CPU):" };
+			const std::string title2{ "Guest Utilization (PS3):" };
+
+			void reset_transform(label& elm, u16 bottom_margin = 0) const;
+			void reset_transforms();
+			void reset_body();
+			void reset_titles();
+			void reset_text();
+
+		public:
+			void init();
+
+			void set_detail_level(detail_level level);
+			void set_position(screen_quadrant quadrant);
+			void set_update_interval(u32 update_interval);
+			void set_font(std::string font);
+			void set_font_size(u32 font_size);
+			void set_margins(u32 margin_x, u32 margin_y);
+			void set_opacity(f32 opacity);
+			void force_next_update();
+
+			void update() override;
+
+			compiled_resource get_compiled() override;
+		};
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.h
@@ -21,7 +21,8 @@ namespace rsx
 			label m_body{};
 			label m_titles{};
 
-			bool m_graphs_enabled{};
+			bool m_framerate_graph_enabled{};
+			bool m_frametime_graph_enabled{};
 			graph m_fps_graph;
 			graph m_frametime_graph;
 
@@ -52,6 +53,8 @@ namespace rsx
 		public:
 			void init();
 
+			void set_framerate_graph_enabled(bool enabled);
+			void set_frametime_graph_enabled(bool enabled);
 			void set_detail_level(detail_level level);
 			void set_position(screen_quadrant quadrant);
 			void set_update_interval(u32 update_interval);

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -325,68 +325,6 @@ namespace rsx
 			}
 		};
 
-		struct perf_metrics_overlay : overlay
-		{
-		private:
-			/*
-			   minimal - fps
-			   low - fps, total cpu usage
-			   medium - fps, detailed cpu usage
-			   high - fps, frametime, detailed cpu usage, thread number, rsx load
-			 */
-			detail_level m_detail{};
-
-			screen_quadrant m_quadrant{};
-			positioni m_position{};
-
-			label m_body{};
-			label m_titles{};
-
-			bool m_graphs_enabled{};
-			graph m_fps_graph;
-			graph m_frametime_graph;
-
-			CPUStats m_cpu_stats{};
-			Timer m_update_timer{};
-			Timer m_frametime_timer{};
-			u32 m_update_interval{}; // in ms
-			u32 m_frames{};
-			std::string m_font{};
-			u32 m_font_size{};
-			u32 m_margin_x{}; // horizontal distance to the screen border relative to the screen_quadrant in px
-			u32 m_margin_y{}; // vertical distance to the screen border relative to the screen_quadrant in px
-			f32 m_opacity{};  // 0..1
-
-			bool m_force_update{};
-			bool m_is_initialised{};
-
-			const std::string title1_medium{"CPU Utilization:"};
-			const std::string title1_high{"Host Utilization (CPU):"};
-			const std::string title2{"Guest Utilization (PS3):"};
-
-			void reset_transform(label& elm, u16 bottom_margin = 0) const;
-			void reset_transforms();
-			void reset_body();
-			void reset_titles();
-			void reset_text();
-
-		public:
-			void init();
-
-			void set_detail_level(detail_level level);
-			void set_position(screen_quadrant quadrant);
-			void set_update_interval(u32 update_interval);
-			void set_font(std::string font);
-			void set_font_size(u32 font_size);
-			void set_margins(u32 margin_x, u32 margin_y);
-			void set_opacity(f32 opacity);
-			void force_next_update();
-
-			void update() override;
-
-			compiled_resource get_compiled() override;
-		};
-
 		struct osk_dialog : public user_interface, public OskDialogBase
 		{
 			using callback_t = std::function<void(const std::string&)>;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -14,6 +14,7 @@
 #include "rsx_utils.h"
 #include "Emu/Cell/lv2/sys_event.h"
 #include "Emu/Cell/Modules/cellGcmSys.h"
+#include "Overlays/overlay_perf_metrics.h"
 
 #include "Utilities/span.h"
 #include "Utilities/StrUtil.h"

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -438,6 +438,8 @@ namespace rsx
 				perf_overlay->set_font_size(perf_settings.font_size);
 				perf_overlay->set_margins(perf_settings.margin_x, perf_settings.margin_y);
 				perf_overlay->set_opacity(perf_settings.opacity / 100.f);
+				perf_overlay->set_framerate_graph_enabled(perf_settings.framerate_graph_enabled.get());
+				perf_overlay->set_frametime_graph_enabled(perf_settings.frametime_graph_enabled.get());
 				perf_overlay->init();
 			}
 		}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -515,6 +515,8 @@ struct cfg_root : cfg::node
 			node_perf_overlay(cfg::node* _this) : cfg::node(_this, "Performance Overlay") {}
 
 			cfg::_bool perf_overlay_enabled{this, "Enabled", false};
+			cfg::_bool framerate_graph_enabled{ this, "Enable Framerate Graph", false };
+			cfg::_bool frametime_graph_enabled{ this, "Enable Frametime Graph", false };
 			cfg::_enum<detail_level> level{this, "Detail level", detail_level::medium};
 			cfg::_int<30, 5000> update_interval{ this, "Metrics update interval (ms)", 350 };
 			cfg::_int<4, 36> font_size{ this, "Font size (px)", 10 };

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -91,6 +91,8 @@
 		},
 		"overlay": {
 			"perfOverlayEnabled": "Enables or disables the performance overlay.",
+			"perfOverlayFramerateGraphEnabled": "Enables or disables the framerate graph.",
+			"perfOverlayFrametimeGraphEnabled": "Enables or disables the frametime graph.",
 			"perfOverlayPosition": "Sets the on-screen position (quadrant) of the performance overlay.",
 			"perfOverlayDetailLevel": "Controls the amount of information displayed on the performance overlay.",
 			"perfOverlayUpdateInterval": "Sets the time interval in which the performance overlay is being updated (measured in milliseconds).",

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -392,6 +392,7 @@
     <ClInclude Include="Emu\Cell\Modules\cellSsl.h" />
     <ClInclude Include="Emu\Io\Keyboard.h" />
     <ClInclude Include="Emu\RSX\Common\texture_cache_helpers.h" />
+    <ClInclude Include="Emu\RSX\Overlays\overlay_perf_metrics.h" />
     <ClInclude Include="util\atomic.hpp" />
     <ClInclude Include="..\Utilities\BEType.h" />
     <ClInclude Include="..\Utilities\bin_patch.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1576,5 +1576,8 @@
     <ClInclude Include="Emu\Cell\Modules\cellSsl.h">
       <Filter>Emu\Cell\Modules</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\overlay_perf_metrics.h">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -86,6 +86,8 @@ public:
 
 		// Performance Overlay
 		PerfOverlayEnabled,
+		PerfOverlayFramerateGraphEnabled,
+		PerfOverlayFrametimeGraphEnabled,
 		PerfOverlayDetailLevel,
 		PerfOverlayPosition,
 		PerfOverlayUpdateInterval,
@@ -312,16 +314,18 @@ private:
 		{ VBlankRate,                 { "Video", "Vblank Rate"}},
 
 		// Performance Overlay
-		{ PerfOverlayEnabled,       { "Video", "Performance Overlay", "Enabled" } },
-		{ PerfOverlayDetailLevel,   { "Video", "Performance Overlay", "Detail level" } },
-		{ PerfOverlayPosition,      { "Video", "Performance Overlay", "Position" } },
-		{ PerfOverlayUpdateInterval,{ "Video", "Performance Overlay", "Metrics update interval (ms)" } },
-		{ PerfOverlayFontSize,      { "Video", "Performance Overlay", "Font size (px)" } },
-		{ PerfOverlayOpacity,       { "Video", "Performance Overlay", "Opacity (%)" } },
-		{ PerfOverlayMarginX,       { "Video", "Performance Overlay", "Horizontal Margin (px)" } },
-		{ PerfOverlayMarginY,       { "Video", "Performance Overlay", "Vertical Margin (px)" } },
-		{ PerfOverlayCenterX,       { "Video", "Performance Overlay", "Center Horizontally" } },
-		{ PerfOverlayCenterY,       { "Video", "Performance Overlay", "Center Vertically" } },
+		{ PerfOverlayEnabled,               { "Video", "Performance Overlay", "Enabled" } },
+		{ PerfOverlayFramerateGraphEnabled, { "Video", "Performance Overlay", "Enable Framerate Graph" } },
+		{ PerfOverlayFrametimeGraphEnabled, { "Video", "Performance Overlay", "Enable Frametime Graph" } },
+		{ PerfOverlayDetailLevel,           { "Video", "Performance Overlay", "Detail level" } },
+		{ PerfOverlayPosition,              { "Video", "Performance Overlay", "Position" } },
+		{ PerfOverlayUpdateInterval,        { "Video", "Performance Overlay", "Metrics update interval (ms)" } },
+		{ PerfOverlayFontSize,              { "Video", "Performance Overlay", "Font size (px)" } },
+		{ PerfOverlayOpacity,               { "Video", "Performance Overlay", "Opacity (%)" } },
+		{ PerfOverlayMarginX,               { "Video", "Performance Overlay", "Horizontal Margin (px)" } },
+		{ PerfOverlayMarginY,               { "Video", "Performance Overlay", "Vertical Margin (px)" } },
+		{ PerfOverlayCenterX,               { "Video", "Performance Overlay", "Center Horizontally" } },
+		{ PerfOverlayCenterY,               { "Video", "Performance Overlay", "Center Vertically" } },
 
 		// Shader Loading Dialog
 		{ ShaderLoadBgEnabled,      { "Video", "Shader Loading Dialog", "Allow custom background" } },

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1170,6 +1170,12 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	});
 	ui->perfOverlayMarginY->setEnabled(!ui->perfOverlayCenterY->isChecked());
 
+	xemu_settings->EnhanceCheckBox(ui->perfOverlayFramerateGraphEnabled, emu_settings::PerfOverlayFramerateGraphEnabled);
+	SubscribeTooltip(ui->perfOverlayFramerateGraphEnabled, json_emu_overlay["perfOverlayFramerateGraphEnabled"].toString());
+
+	xemu_settings->EnhanceCheckBox(ui->perfOverlayFrametimeGraphEnabled, emu_settings::PerfOverlayFrametimeGraphEnabled);
+	SubscribeTooltip(ui->perfOverlayFrametimeGraphEnabled, json_emu_overlay["perfOverlayFrametimeGraphEnabled"].toString());
+
 	xemu_settings->EnhanceCheckBox(ui->perfOverlayEnabled, emu_settings::PerfOverlayEnabled);
 	SubscribeTooltip(ui->perfOverlayEnabled, json_emu_overlay["perfOverlayEnabled"].toString());
 	auto EnablePerfOverlayOptions = [this](bool enabled)
@@ -1190,6 +1196,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		ui->perfOverlayMarginY->setEnabled(enabled && !ui->perfOverlayCenterY->isChecked());
 		ui->perfOverlayCenterX->setEnabled(enabled);
 		ui->perfOverlayCenterY->setEnabled(enabled);
+		ui->perfOverlayFramerateGraphEnabled->setEnabled(enabled);
+		ui->perfOverlayFrametimeGraphEnabled->setEnabled(enabled);
 	};
 	EnablePerfOverlayOptions(ui->perfOverlayEnabled->isChecked());
 	connect(ui->perfOverlayEnabled, &QCheckBox::clicked, EnablePerfOverlayOptions);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1186,8 +1186,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		ui->perfOverlayUpdateInterval->setEnabled(enabled);
 		ui->perfOverlayFontSize->setEnabled(enabled);
 		ui->perfOverlayOpacity->setEnabled(enabled);
-		ui->perfOverlayMarginX->setEnabled(enabled);
-		ui->perfOverlayMarginY->setEnabled(enabled);
+		ui->perfOverlayMarginX->setEnabled(enabled && !ui->perfOverlayCenterX->isChecked());
+		ui->perfOverlayMarginY->setEnabled(enabled && !ui->perfOverlayCenterY->isChecked());
 		ui->perfOverlayCenterX->setEnabled(enabled);
 		ui->perfOverlayCenterY->setEnabled(enabled);
 	};

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2139,6 +2139,20 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="perfOverlayFramerateGraphEnabled">
+                <property name="text">
+                 <string>Show framerate graph</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="perfOverlayFrametimeGraphEnabled">
+                <property name="text">
+                 <string>Show frametime graph</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QLabel" name="label_detail_level">
                 <property name="text">
                  <string>Detail Level:</string>


### PR DESCRIPTION
Adds individual settings for the framerate graph and the frametime graph and detaches them from the "High" detail level.

Fixes a division by zero bug where the chip usage would show "-nand(ind)".

Moves code to a new header file.

Fixes the vertical center option when graphs are shown.

Disables the overlay margin options in the settings dialog while the center option is enabled.

#### Disclaimer:
I noticed that the graphs adjust to the body width while the graph description does an auto-resize instead. I probably won't fix it in this PR.