### PR TITLE
Avoid Start/StopPlaytime when installing firmware.

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -227,7 +227,11 @@ void gui_application::StopPlaytime()
 		return;
 
 	const QString serial = qstr(Emu.GetTitleID());
-	const auto isPUPFirmware = serial.isEmpty();
+    if (serial.isEmpty())
+    {
+        m_timer_playtime.invalidate();
+        return;
+    }
 
 	if (!isPUPFirmware)
 	{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -209,8 +209,13 @@ void gui_application::InitializeCallbacks()
 void gui_application::StartPlaytime()
 {
 	const QString serial = qstr(Emu.GetTitleID());
-	m_gui_settings->SetLastPlayed(serial, QDate::currentDate().toString("MMMM d yyyy"));
-	m_timer_playtime.start();
+	const auto isPUPFirmware = serial.isEmpty();
+
+	if (!isPUPFirmware)
+	{
+		m_gui_settings->SetLastPlayed(serial, QDate::currentDate().toString("MMMM d yyyy"));
+		m_timer_playtime.start();
+	}
 }
 
 void gui_application::StopPlaytime()
@@ -219,10 +224,15 @@ void gui_application::StopPlaytime()
 		return;
 
 	const QString serial = qstr(Emu.GetTitleID());
-	const qint64 playtime = m_gui_settings->GetPlaytime(serial) + m_timer_playtime.elapsed();
-	m_gui_settings->SetPlaytime(serial, playtime);
-	m_gui_settings->SetLastPlayed(serial, QDate::currentDate().toString("MMMM d yyyy"));
-	m_timer_playtime.invalidate();
+	const auto isPUPFirmware = serial.isEmpty();
+
+	if (!isPUPFirmware)
+	{
+		const qint64 playtime = m_gui_settings->GetPlaytime(serial) + m_timer_playtime.elapsed();
+		m_gui_settings->SetPlaytime(serial, playtime);
+		m_gui_settings->SetLastPlayed(serial, QDate::currentDate().toString("MMMM d yyyy"));
+		m_timer_playtime.invalidate();
+	}
 }
 
 /*

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -214,11 +214,8 @@ void gui_application::StartPlaytime()
 		return;
 	}
 
-	if (!isPUPFirmware)
-	{
-		m_gui_settings->SetLastPlayed(serial, QDate::currentDate().toString("MMMM d yyyy"));
-		m_timer_playtime.start();
-	}
+	m_gui_settings->SetLastPlayed(serial, QDate::currentDate().toString("MMMM d yyyy"));
+	m_timer_playtime.start();
 }
 
 void gui_application::StopPlaytime()
@@ -227,19 +224,16 @@ void gui_application::StopPlaytime()
 		return;
 
 	const QString serial = qstr(Emu.GetTitleID());
-    if (serial.isEmpty())
-    {
-        m_timer_playtime.invalidate();
-        return;
-    }
-
-	if (!isPUPFirmware)
+	if (serial.isEmpty())
 	{
-		const qint64 playtime = m_gui_settings->GetPlaytime(serial) + m_timer_playtime.elapsed();
-		m_gui_settings->SetPlaytime(serial, playtime);
-		m_gui_settings->SetLastPlayed(serial, QDate::currentDate().toString("MMMM d yyyy"));
 		m_timer_playtime.invalidate();
+		return;
 	}
+
+	const qint64 playtime = m_gui_settings->GetPlaytime(serial) + m_timer_playtime.elapsed();
+	m_gui_settings->SetPlaytime(serial, playtime);
+	m_gui_settings->SetLastPlayed(serial, QDate::currentDate().toString("MMMM d yyyy"));
+	m_timer_playtime.invalidate();
 }
 
 /*

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -209,7 +209,10 @@ void gui_application::InitializeCallbacks()
 void gui_application::StartPlaytime()
 {
 	const QString serial = qstr(Emu.GetTitleID());
-	const auto isPUPFirmware = serial.isEmpty();
+	if (serial.isEmpty())
+	{
+		return;
+	}
 
 	if (!isPUPFirmware)
 	{


### PR DESCRIPTION
Avoid "QSettings::setValue: Empty key passed" logging when installing
PUP firmware (Release/Debug build).
> game_list_frame.cpp was not done as FW dont go in the list.