### PR TITLE
LLVM Add once the symbol to the GlobalMappingMap.

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -3404,7 +3404,7 @@ class spu_llvm_recompiler : public spu_recompiler_base, public cpu_translator
 
 			// Register under a unique linkable name
 			const std::string ppname = fmt::format("%s-pp-0x%05x", m_hash, m_pos);
-			m_engine->addGlobalMapping(ppname, (u64)m_spurt->make_branch_patchpoint());
+			tryAddFunctionToGlobalAddressMap(ppname, reinterpret_cast<std::uintptr_t>(m_spurt->make_branch_patchpoint()));
 
 			// Create function with not exactly correct type
 			const auto ppfunc = llvm::cast<llvm::Function>(m_module->getOrInsertFunction(ppname, m_finfo->chunk->getFunctionType()).getCallee());
@@ -4381,7 +4381,7 @@ public:
 		entry_call->setCallingConv(entry_chunk->chunk->getCallingConv());
 
 		const auto dispatcher = llvm::cast<llvm::Function>(m_module->getOrInsertFunction("spu_dispatcher", main_func->getType()).getCallee());
-		m_engine->addGlobalMapping("spu_dispatcher", reinterpret_cast<u64>(spu_runtime::tr_all));
+		tryAddFunctionToGlobalAddressMap("spu_dispatcher", reinterpret_cast<u64>(spu_runtime::tr_all));
 		dispatcher->setCallingConv(main_func->getCallingConv());
 
 		// Proceed to the next code
@@ -4658,7 +4658,7 @@ public:
 					if (false && g_cfg.core.spu_verification)
 					{
 						const std::string ppname = fmt::format("%s-chunkpp-0x%05x", m_hash, i);
-						m_engine->addGlobalMapping(ppname, (u64)m_spurt->make_branch_patchpoint(i / 4));
+						tryAddFunctionToGlobalAddressMap(ppname, reinterpret_cast<std::uintptr_t>(m_spurt->make_branch_patchpoint(i / 4)));
 
 						const auto ppfunc = llvm::cast<llvm::Function>(m_module->getOrInsertFunction(ppname, m_finfo->chunk->getFunctionType()).getCallee());
 						ppfunc->setCallingConv(m_finfo->chunk->getCallingConv());


### PR DESCRIPTION
Avoid adding the GlobalMapping if its already present and has the same
address to avoid assertion failure in Debug build in addGlobalMapping :
"GlobalMapping already established!".

The first BT correspond to GOW3, and the 2 others to FF13 :
[gdb.txt](https://github.com/RPCS3/rpcs3/files/3855889/gdb.txt)