### PR TITLE
Clamp volume in cellAudioAdd/2c/6c/Data

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -1469,6 +1469,8 @@ error_code cellAudioAddData(u32 portNum, vm::ptr<float> src, u32 samples, float 
 
 	lock.unlock();
 
+	volume = std::isfinite(volume) ? std::clamp(volume, -16.f, 16.f) : 0.f;
+
 	for (u32 i = 0; i < samples * port.num_channels; i++)
 	{
 		dst[i] += src[i] * volume; // mix all channels
@@ -1507,6 +1509,8 @@ error_code cellAudioAdd2chData(u32 portNum, vm::ptr<float> src, u32 samples, flo
 	const auto dst = port.get_vm_ptr();
 
 	lock.unlock();
+
+	volume = std::isfinite(volume) ? std::clamp(volume, -16.f, 16.f) : 0.f;
 
 	if (port.num_channels == 2)
 	{
@@ -1573,6 +1577,8 @@ error_code cellAudioAdd6chData(u32 portNum, vm::ptr<float> src, float volume)
 	const auto dst = port.get_vm_ptr();
 
 	lock.unlock();
+
+	volume = std::isfinite(volume) ? std::clamp(volume, -16.f, 16.f) : 0.f;
 
 	if (port.num_channels == 6)
 	{


### PR DESCRIPTION
Same as firmware: NaN and Inf are flushed to zero, otherwise clamp to +-16.f range.
TODO: Check actual values specified at src?