### PR TITLE
Fix possible division by zero in sys_spu_thread_write/read_ls, sys_spu_thread_un/bind_queue bugfix and stubs

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -298,7 +298,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	BIND_FUNC(sys_spu_thread_group_connect_event_all_threads), //251 (0x0FB)
 	BIND_FUNC(sys_spu_thread_group_disconnect_event_all_threads), //252 (0x0FC)
 	null_func,//BIND_FUNC(sys_spu_thread_group...)          //253 (0x0FD)
-	null_func,//BIND_FUNC(sys_spu_thread_group_log)         //254 (0x0FE)
+	BIND_FUNC(sys_spu_thread_group_log),                    //254 (0x0FE)
 
 	uns_func, uns_func, uns_func, uns_func, uns_func,       //255-259  UNS
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -858,16 +858,16 @@ error_code sys_spu_thread_write_ls(ppu_thread& ppu, u32 id, u32 lsa, u64 value, 
 
 	sys_spu.trace("sys_spu_thread_write_ls(id=0x%x, lsa=0x%05x, value=0x%llx, type=%d)", id, lsa, value, type);
 
+	if (lsa >= 0x40000 || type > 8 || !type || (type | lsa) & (type - 1)) // check range and alignment
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto thread = idm::get<named_thread<spu_thread>>(id);
 
 	if (UNLIKELY(!thread || !thread->group))
 	{
 		return CELL_ESRCH;
-	}
-
-	if (lsa >= 0x40000 || lsa + type > 0x40000 || lsa % type) // check range and alignment
-	{
-		return CELL_EINVAL;
 	}
 
 	const auto group = thread->group;
@@ -885,7 +885,7 @@ error_code sys_spu_thread_write_ls(ppu_thread& ppu, u32 id, u32 lsa, u64 value, 
 	case 2: thread->_ref<u16>(lsa) = (u16)value; break;
 	case 4: thread->_ref<u32>(lsa) = (u32)value; break;
 	case 8: thread->_ref<u64>(lsa) = value; break;
-	default: return CELL_EINVAL;
+	default: ASSUME(0);
 	}
 
 	return CELL_OK;
@@ -897,16 +897,16 @@ error_code sys_spu_thread_read_ls(ppu_thread& ppu, u32 id, u32 lsa, vm::ptr<u64>
 
 	sys_spu.trace("sys_spu_thread_read_ls(id=0x%x, lsa=0x%05x, value=*0x%x, type=%d)", id, lsa, value, type);
 
+	if (lsa >= 0x40000 || type > 8 || !type || (type | lsa) & (type - 1)) // check range and alignment
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto thread = idm::get<named_thread<spu_thread>>(id);
 
 	if (UNLIKELY(!thread || !thread->group))
 	{
 		return CELL_ESRCH;
-	}
-
-	if (lsa >= 0x40000 || lsa + type > 0x40000 || lsa % type) // check range and alignment
-	{
-		return CELL_EINVAL;
 	}
 
 	const auto group = thread->group;
@@ -924,7 +924,7 @@ error_code sys_spu_thread_read_ls(ppu_thread& ppu, u32 id, u32 lsa, vm::ptr<u64>
 	case 2: *value = thread->_ref<u16>(lsa); break;
 	case 4: *value = thread->_ref<u32>(lsa); break;
 	case 8: *value = thread->_ref<u64>(lsa); break;
-	default: return CELL_EINVAL;
+	default: ASSUME(0);
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -39,6 +39,13 @@ enum : u64
 	SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE_KEY = 0xFFFFFFFF53505504ull,
 };
 
+enum
+{
+	SYS_SPU_THREAD_GROUP_LOG_ON         = 0x0,
+	SYS_SPU_THREAD_GROUP_LOG_OFF        = 0x1,
+	SYS_SPU_THREAD_GROUP_LOG_GET_STATUS = 0x2,
+};
+
 enum : u32
 {
 	SPU_THREAD_GROUP_STATUS_NOT_INITIALIZED,
@@ -322,6 +329,7 @@ error_code sys_spu_thread_group_connect_event(ppu_thread&, u32 id, u32 eq, u32 e
 error_code sys_spu_thread_group_disconnect_event(ppu_thread&, u32 id, u32 et);
 error_code sys_spu_thread_group_connect_event_all_threads(ppu_thread&, u32 id, u32 eq_id, u64 req, vm::ptr<u8> spup);
 error_code sys_spu_thread_group_disconnect_event_all_threads(ppu_thread&, u32 id, u8 spup);
+error_code sys_spu_thread_group_log(ppu_thread&, s32 command, vm::ptr<s32> stat);
 error_code sys_spu_thread_write_ls(ppu_thread&, u32 id, u32 address, u64 value, u32 type);
 error_code sys_spu_thread_read_ls(ppu_thread&, u32 id, u32 address, vm::ptr<u64> value, u32 type);
 error_code sys_spu_thread_write_spu_mb(ppu_thread&, u32 id, u32 value);


### PR DESCRIPTION
* When type = 0, `lsa % type` was raising an exception. This is fixed and also move all EINVAL conditions before ESTAT and ESRCH checks as fw.
* Stub sys_spu_thread_group_log.
* Fix sys_spu_thread_un/bind_queue queue existence check. (check if binded, regardless of pointer experation)
