### PR TITLE
rsx: Fixup for polygon rendering

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -936,7 +936,7 @@ namespace
 				if (is_primitive_restart_enabled && index == primitive_restart_index)
 					continue;
 
-				anchor = index;
+				anchor = min_max(min_index, max_index, index);
 				needs_anchor = false;
 				continue;
 			}
@@ -951,7 +951,7 @@ namespace
 			if (last_index == invalid_index)
 			{
 				//Need at least one anchor and one outer index to create a triangle
-				last_index = index;
+				last_index = min_max(min_index, max_index, index);
 				continue;
 			}
 


### PR DESCRIPTION
- Fixes min-max calculation for arbitrary N-sided polygons. This solves vertex flickering in some titles like Tlou. Other parts of the improvements changeset were already slowly added to master.