### PR TITLE
vk: Add sampleRateShading to the list of device enabled features

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -810,6 +810,7 @@ private:
 					LOG_FATAL(RSX, "Your GPU driver does not support some required MSAA features. Expect problems.");
 				}
 
+				enabled_features.sampleRateShading = VK_TRUE;
 				enabled_features.alphaToOne = VK_TRUE;
 				enabled_features.shaderStorageImageMultisample = VK_TRUE;
 				// enabled_features.shaderStorageImageReadWithoutFormat = VK_TRUE;  // Unused currently, may be needed soon
@@ -829,6 +830,12 @@ private:
 			{
 				LOG_ERROR(RSX, "Your GPU does not support depth bounds testing. Graphics may not work correctly.");
 				enabled_features.depthBounds = VK_FALSE;
+			}
+
+			if (!pgpu->features.sampleRateShading && enabled_features.sampleRateShading)
+			{
+				LOG_ERROR(RSX, "Your GPU does not support sample rate shading for multisampling. Graphics may be inaccurate when MSAA is enabled.");
+				enabled_features.sampleRateShading = VK_FALSE;
 			}
 
 			if (!pgpu->features.alphaToOne && enabled_features.alphaToOne)


### PR DESCRIPTION
Because `sampleShadingEnable`  is used, `sampleRateShading` needs to be set to `VK_TRUE` for the device:
https://github.com/RPCS3/rpcs3/blob/9dab0575fa3fd8ba0c3e089464427723f750ca6c/rpcs3/Emu/RSX/VK/VKHelpers.h#L3252-L3253

Fix the following messages when "Debug Output" is enabled:
```
E {RSX [0x0192250]} RSX: ERROR: [Validation] Code 0 :  [ VUID-VkPipelineMultisampleStateCreateInfo-sampleShadingEnable-00784 ] Object: VK_NULL_HANDLE (Type = 0) | vkCreateGraphicsPipelines(): parameter pCreateInfos[0].pMultisampleState->sampleShadingEnable. The Vulkan spec states: If the sample rate shading feature is not enabled, sampleShadingEnable must be VK_FALSE (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkPipelineMultisampleStateCreateInfo-sampleShadingEnable-00784)
E {RSX [0x0192250]} RSX: ERROR: [Validation] Code 0 :  [ UNASSIGNED-CoreValidation-Shader-FeatureNotEnabled ] Object: VK_NULL_HANDLE (Type = 0) | Shader requires VkPhysicalDeviceFeatures::sampleRateShading but is not enabled on the device
```