### PR TITLE
Improve no-gui option

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -168,7 +168,10 @@ static error_code select_and_delete(ppu_thread& ppu)
 		lv2_obj::sleep(ppu);
 
 		// Display Save Data List asynchronously in the GUI thread.
-		selected = Emu.GetCallbacks().get_save_dialog()->ShowSaveDataList(save_entries, focused, SAVEDATA_OP_LIST_DELETE, vm::null);
+		if (auto save_dialog = Emu.GetCallbacks().get_save_dialog())
+		{
+			selected = save_dialog->ShowSaveDataList(save_entries, focused, SAVEDATA_OP_LIST_DELETE, vm::null);
+		}
 
 		// Reschedule
 		if (ppu.check_state())
@@ -176,8 +179,8 @@ static error_code select_and_delete(ppu_thread& ppu)
 			return 0;
 		}
 
-		// Abort if dialog was canceled
-		if (selected == -2)
+		// Abort if dialog was canceled or selection is invalid in this context
+		if (selected < 0)
 		{
 			return CELL_CANCEL;
 		}

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -180,10 +180,10 @@ void gui_application::InitializeCallbacks()
 	};
 
 	callbacks.get_gs_frame    = [this]() -> std::unique_ptr<GSFrameBase> { return get_gs_frame(); };
-	callbacks.get_msg_dialog  = [this]() -> std::shared_ptr<MsgDialogBase> { return std::make_shared<msg_dialog_frame>(); };
-	callbacks.get_osk_dialog  = []() -> std::shared_ptr<OskDialogBase> { return std::make_shared<osk_dialog_frame>(); };
-	callbacks.get_save_dialog = []() -> std::unique_ptr<SaveDialogBase> { return std::make_unique<save_data_dialog>(); };
-	callbacks.get_trophy_notification_dialog = [this]() -> std::unique_ptr<TrophyNotificationBase> { return std::make_unique<trophy_notification_helper>(m_game_window); };
+	callbacks.get_msg_dialog  = [this]() -> std::shared_ptr<MsgDialogBase> { return m_show_gui ? std::make_shared<msg_dialog_frame>() : nullptr; };
+	callbacks.get_osk_dialog  = [this]() -> std::shared_ptr<OskDialogBase> { return m_show_gui ? std::make_shared<osk_dialog_frame>() : nullptr; };
+	callbacks.get_save_dialog = [this]() -> std::unique_ptr<SaveDialogBase> { return m_show_gui ? std::make_unique<save_data_dialog>() : nullptr; };
+	callbacks.get_trophy_notification_dialog = [this]() -> std::unique_ptr<TrophyNotificationBase> { return m_show_gui ? std::make_unique<trophy_notification_helper>(m_game_window) : nullptr; };
 
 	callbacks.on_run    = [=]() { OnEmulatorRun(); };
 	callbacks.on_pause  = [=]() { OnEmulatorPause(); };


### PR DESCRIPTION
Might fix some issues with Qt Dialogs when using the no-gui option.
With this you should be able to run games using the recompilers.

maybe improves #7015