### PR TITLE
Qt: properly skip trophy and savedata dialogs in no-gui mode

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUModule.h"

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -250,6 +250,7 @@ class Emulator final
 	u32 m_usrid{1};
 
 	bool m_force_boot = false;
+	bool m_has_gui = true;
 
 public:
 	Emulator() = default;
@@ -372,6 +373,9 @@ public:
 	bool IsStopped() const { return m_state == system_state::stopped; }
 	bool IsReady()   const { return m_state == system_state::ready; }
 	auto GetStatus() const { return m_state.load(); }
+
+	bool HasGui() const { return m_has_gui; }
+	void SetHasGui(bool has_gui) { m_has_gui = has_gui; }
 };
 
 extern Emulator Emu;

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -14,7 +14,7 @@ headless_application::headless_application(int& argc, char** argv) : QCoreApplic
 void headless_application::Init()
 {
 	// Force init the emulator
-	InitializeEmulator("1", true); // TODO: get user from cli args if possible
+	InitializeEmulator("1", true, false); // TODO: get user from cli args if possible
 
 	// Create callbacks from the emulator, which reference the handlers.
 	InitializeCallbacks();

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -44,8 +44,10 @@
 #endif
 
 /** Emu.Init() wrapper for user manager */
-bool main_application::InitializeEmulator(const std::string& user, bool force_init)
+bool main_application::InitializeEmulator(const std::string& user, bool force_init, bool show_gui)
 {
+	Emu.SetHasGui(show_gui);
+
 	// try to set a new user
 	const bool user_was_set = Emu.SetUsr(user);
 

--- a/rpcs3/main_application.h
+++ b/rpcs3/main_application.h
@@ -9,7 +9,7 @@ class main_application
 public:
 	virtual void Init() = 0;
 
-	static bool InitializeEmulator(const std::string& user, bool force_init);
+	static bool InitializeEmulator(const std::string& user, bool force_init, bool show_gui);
 
 protected:
 	virtual QThread* get_thread() = 0;

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -37,7 +37,7 @@ void gui_application::Init()
 	m_gui_settings.reset(new gui_settings());
 
 	// Force init the emulator
-	InitializeEmulator(m_gui_settings->GetCurrentUser().toStdString(), true);
+	InitializeEmulator(m_gui_settings->GetCurrentUser().toStdString(), true, m_show_gui);
 
 	// Create the main window
 	if (m_show_gui)
@@ -182,8 +182,8 @@ void gui_application::InitializeCallbacks()
 	callbacks.get_gs_frame    = [this]() -> std::unique_ptr<GSFrameBase> { return get_gs_frame(); };
 	callbacks.get_msg_dialog  = [this]() -> std::shared_ptr<MsgDialogBase> { return m_show_gui ? std::make_shared<msg_dialog_frame>() : nullptr; };
 	callbacks.get_osk_dialog  = [this]() -> std::shared_ptr<OskDialogBase> { return m_show_gui ? std::make_shared<osk_dialog_frame>() : nullptr; };
-	callbacks.get_save_dialog = [this]() -> std::unique_ptr<SaveDialogBase> { return m_show_gui ? std::make_unique<save_data_dialog>() : nullptr; };
-	callbacks.get_trophy_notification_dialog = [this]() -> std::unique_ptr<TrophyNotificationBase> { return m_show_gui ? std::make_unique<trophy_notification_helper>(m_game_window) : nullptr; };
+	callbacks.get_save_dialog = []() -> std::unique_ptr<SaveDialogBase> { return std::make_unique<save_data_dialog>(); };
+	callbacks.get_trophy_notification_dialog = [this]() -> std::unique_ptr<TrophyNotificationBase> { return std::make_unique<trophy_notification_helper>(m_game_window); };
 
 	callbacks.on_run    = [=]() { OnEmulatorRun(); };
 	callbacks.on_pause  = [=]() { OnEmulatorPause(); };

--- a/rpcs3/rpcs3qt/save_data_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_dialog.cpp
@@ -14,6 +14,11 @@ s32 save_data_dialog::ShowSaveDataList(std::vector<SaveDataEntry>& save_entries,
 			return result;
 	}
 
+	if (!Emu.HasGui())
+	{
+		return -2;
+	}
+
 	// Fall back to front-end GUI
 	atomic_t<bool> dlg_result(false);
 	atomic_t<s32> selection;

--- a/rpcs3/rpcs3qt/trophy_notification_helper.cpp
+++ b/rpcs3/rpcs3qt/trophy_notification_helper.cpp
@@ -1,4 +1,4 @@
-#include "trophy_notification_helper.h"
+﻿#include "trophy_notification_helper.h"
 
 #include "trophy_notification_frame.h"
 
@@ -10,6 +10,11 @@ s32 trophy_notification_helper::ShowTrophyNotification(const SceNpTrophyDetails&
 	if (auto manager = g_fxo->get<rsx::overlays::display_manager>())
 	{
 		return manager->create<rsx::overlays::trophy_notification>()->show(trophy, trophy_icon_buffer);
+	}
+
+	if (!Emu.HasGui())
+	{
+		return 0;
 	}
 
 	Emu.CallAfter([=]

--- a/rpcs3/rpcs3qt/trophy_notification_helper.h
+++ b/rpcs3/rpcs3qt/trophy_notification_helper.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "stdafx.h"
 #include "Emu/Memory/vm.h"

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -368,7 +368,7 @@ void user_manager_dialog::OnUserLogin()
 	const u32 key = GetUserKey();
 	const std::string new_user = m_user_list[key].GetUserId();
 
-	if (!main_application::InitializeEmulator(new_user, false))
+	if (!main_application::InitializeEmulator(new_user, false, Emu.HasGui()))
 	{
 		LOG_FATAL(GENERAL, "Failed to login user! username=%s key=%d", new_user, key);
 		return;


### PR DESCRIPTION
Fixup for a mistake in #7053 that caused trophy notifications and savedata dialogs to be hidden in no-gui mode despite using native game-window dialogs.