### PR TITLE
Avoid using vfs::get to let decrypt work on PSN binaries

### DIFF
--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -1293,10 +1293,10 @@ bool SELFDecrypter::GetKeyFromRap(u8* content_id, u8* npdrm_key)
 
 	// Try to find a matching RAP file under exdata folder.
 	const std::string ci_str = reinterpret_cast<const char*>(content_id);
-	const std::string rap_path = "/dev_hdd0/home/" + Emu.GetUsr() + "/exdata/" + ci_str + ".rap";
+	const std::string rap_path = Emulator::GetHddDir() + "/home/" + Emu.GetUsr() + "/exdata/" + ci_str + ".rap";
 
 	// Open the RAP file and read the key.
-	const fs::file rap_file(vfs::get(rap_path));
+	const fs::file rap_file(rap_path);
 
 	if (!rap_file)
 	{


### PR DESCRIPTION
Fixes a crash when using Utilities->Decrypt PS3 Binaries on PSN binaries that require a RAP file for decryption.