### PR TITLE
Minor sceNpTrophy improvements, Idm assert fix

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -644,18 +644,29 @@ error_code sceNpTrophyGetRequiredDiskSpace(u32 context, u32 handle, vm::ptr<u64>
 		return error;
 	}
 
+	u64 space = 0;
+
 	if (!fs::is_dir(vfs::get("/dev_hdd0/home/" + Emu.GetUsr() + "/trophy/" + ctxt->trp_name)))
 	{
 		TRPLoader trp(ctxt->trp_stream);
 
 		if (trp.LoadHeader())
 		{
-			*reqspace = trp.GetRequiredSpace();
-			return CELL_OK;
+			space = trp.GetRequiredSpace();
+		}
+		else
+		{
+			sceNpTrophy.error("sceNpTrophyGetRequiredDiskSpace(): Failed to load trophy header! (trp_name=%s)", ctxt->trp_name);
 		}
 	}
+	else
+	{
+		sceNpTrophy.warning("sceNpTrophyGetRequiredDiskSpace(): Trophy config is already installed (trp_name=%s)", ctxt->trp_name);
+	}
+	
+	sceNpTrophy.warning("sceNpTrophyGetRequiredDiskSpace(): reqspace is 0x%llx", space);
 
-	*reqspace = 0;
+	*reqspace = space;
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/IdManager.cpp
+++ b/rpcs3/Emu/IdManager.cpp
@@ -19,13 +19,9 @@ id_manager::id_map::pointer idm::allocate_id(const id_manager::id_key& info, u32
 	{
 		// Try to emplace back
 		const u32 _next = base + step * ::size32(vec);
-
-		if (_next >= base && _next < base + step * count)
-		{
-			g_id = _next;
-			vec.emplace_back(id_manager::id_key(_next, info.type()), nullptr);
-			return &vec.back();
-		}
+		g_id = _next;
+		vec.emplace_back(id_manager::id_key(_next, info.type()), nullptr);
+		return &vec.back();
 	}
 
 	// Check all IDs starting from "next id" (TODO)

--- a/rpcs3/Emu/IdManager.h
+++ b/rpcs3/Emu/IdManager.h
@@ -33,7 +33,7 @@ namespace id_manager
 		static const u32 invalid = -+!base;
 
 		// Note: full 32 bits range cannot be used at current implementation
-		static_assert(count > 0 && step > 0 && u64{step} * count + base < u64{UINT32_MAX} + (base != 0 ? 1 : 0), "ID traits: invalid object range");
+		static_assert(count && step && u64{step} * (count - 1) + base < u64{UINT32_MAX} + (base != 0 ? 1 : 0), "ID traits: invalid object range");
 	};
 
 	// Correct usage testing


### PR DESCRIPTION
* Fix an off by one "bug" in idm traits static asserts.
* Fix recursive locking of shared lock in scepTrophyUnlockTrophy.
* Log returned required space in sceNpTrophyGetRequiredDiskSpace, and add logging for other corner cases.