### PR TITLE
Qt: Look for custom game titles when filtering via Search

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -290,8 +290,9 @@ bool game_list_frame::IsEntryVisible(const game_info& game)
 		return category::CategoryInMap(game->info.category, category::cat_boot);
 	};
 
-	bool is_visible = m_show_hidden || !m_hidden_list.contains(qstr(game->info.serial));
-	return is_visible && matches_category() && SearchMatchesApp(game->info.name, game->info.serial);
+	const QString serial = qstr(game->info.serial);
+	bool is_visible = m_show_hidden || !m_hidden_list.contains(serial);
+	return is_visible && matches_category() && SearchMatchesApp(qstr(game->info.name), serial);
 }
 
 void game_list_frame::SortGameList()
@@ -2057,12 +2058,17 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 /**
 * Returns false if the game should be hidden because it doesn't match search term in toolbar.
 */
-bool game_list_frame::SearchMatchesApp(const std::string& name, const std::string& serial)
+bool game_list_frame::SearchMatchesApp(const QString& name, const QString& serial) const
 {
 	if (!m_search_text.isEmpty())
 	{
-		QString searchText = m_search_text.toLower();
-		return qstr(name).toLower().contains(searchText) || qstr(serial).toLower().contains(searchText);
+		const QString searchText = m_search_text.toLower();
+		QString gameName = m_titles[serial];
+		if (gameName.isEmpty())
+		{
+			gameName = name;
+		}
+		return gameName.toLower().contains(searchText) || serial.toLower().contains(searchText);
 	}
 	return true;
 }

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -245,7 +245,7 @@ private:
 	void SortGameList();
 
 	int PopulateGameList();
-	bool SearchMatchesApp(const std::string& name, const std::string& serial);
+	bool SearchMatchesApp(const QString& name, const QString& serial) const;
 
 	bool RemoveCustomConfiguration(const std::string& title_id, game_info game = nullptr, bool is_interactive = false);
 	bool RemoveCustomPadConfiguration(const std::string& title_id, game_info game = nullptr, bool is_interactive = false);


### PR DESCRIPTION
This PR enhances game list filtering by also taking custom names (_Rename in Game List..._) into account when filtering.

`m_titles.value()` is used instead of `operator[]`, since `.value()` returns a default initialized entry should the key not exist in the map - so if custom name does not exist, this `QString` will be an empty string and `.contains` will naturally never return true, thus I decided branching the code for whether the custom case exists or not is pointless.