### PR TITLE
Some cleanup and log messages silencing

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -587,7 +587,7 @@ error_code cellCameraGetType(s32 dev_num, vm::ptr<s32> type)
 
 s32 cellCameraIsAvailable(s32 dev_num)
 {
-	cellCamera.todo("cellCameraIsAvailable(dev_num=%d)", dev_num);
+	cellCamera.warning("cellCameraIsAvailable(dev_num=%d)", dev_num);
 
 	if (g_cfg.io.camera == camera_handler::null)
 	{
@@ -611,7 +611,7 @@ s32 cellCameraIsAvailable(s32 dev_num)
 
 s32 cellCameraIsAttached(s32 dev_num)
 {
-	cellCamera.todo("cellCameraIsAttached(dev_num=%d)", dev_num);
+	cellCamera.warning("cellCameraIsAttached(dev_num=%d)", dev_num);
 
 	if (g_cfg.io.camera == camera_handler::null)
 	{
@@ -650,7 +650,7 @@ s32 cellCameraIsAttached(s32 dev_num)
 
 s32 cellCameraIsOpen(s32 dev_num)
 {
-	cellCamera.todo("cellCameraIsOpen(dev_num=%d)", dev_num);
+	cellCamera.warning("cellCameraIsOpen(dev_num=%d)", dev_num);
 
 	if (g_cfg.io.camera == camera_handler::null)
 	{
@@ -674,9 +674,9 @@ s32 cellCameraIsOpen(s32 dev_num)
 	return g_camera->is_open;
 }
 
-error_code cellCameraIsStarted(s32 dev_num)
+s32 cellCameraIsStarted(s32 dev_num)
 {
-	cellCamera.todo("cellCameraIsStarted(dev_num=%d)", dev_num);
+	cellCamera.warning("cellCameraIsStarted(dev_num=%d)", dev_num);
 
 	if (g_cfg.io.camera == camera_handler::null)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellDmux.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellDmux.cpp
@@ -210,7 +210,7 @@ public:
 	{
 		DemuxerTask task;
 		DemuxerStream stream = {};
-		ElementaryStream* esALL[96]; memset(esALL, 0, sizeof(esALL));
+		ElementaryStream* esALL[96]{};
 		ElementaryStream** esAVC = &esALL[0]; // AVC (max 16 minus M2V count)
 		ElementaryStream** esM2V = &esALL[16]; // M2V (max 16 minus AVC count)
 		ElementaryStream** esDATA = &esALL[32]; // user data (max 16)

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -229,7 +229,7 @@ static bool ds3_input_to_pad(const u32 port_no, be_t<u16>& digital_buttons, be_t
 		}
 	}
 
-	memset(&digital_buttons, 0, sizeof(digital_buttons));
+	digital_buttons = 0;
 
 	// map the Move key to R1 and the Trigger to R2
 
@@ -310,9 +310,9 @@ static bool mouse_input_to_pad(const u32 mouse_no, be_t<u16>& digital_buttons, b
 		return false;
 	}
 
-	memset(&digital_buttons, 0, sizeof(digital_buttons));
-
 	const auto& mouse_data = handler->GetMice().at(0);
+
+	digital_buttons = 0;
 
 	if ((mouse_data.buttons & CELL_MOUSE_BUTTON_1) && (mouse_data.buttons & CELL_MOUSE_BUTTON_2))
 		digital_buttons |= CELL_GEM_CTRL_CIRCLE;

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -732,7 +732,7 @@ error_code cellGemGetImageState(u32 gem_num, vm::ptr<CellGemImageState> gem_imag
 
 error_code cellGemGetInertialState(u32 gem_num, u32 state_flag, u64 timestamp, vm::ptr<CellGemInertialState> inertial_state)
 {
-	cellGem.todo("cellGemGetInertialState(gem_num=%d, state_flag=%d, timestamp=0x%x, inertial_state=0x%x)", gem_num, state_flag, timestamp, inertial_state);
+	cellGem.warning("cellGemGetInertialState(gem_num=%d, state_flag=%d, timestamp=0x%x, inertial_state=0x%x)", gem_num, state_flag, timestamp, inertial_state);
 
 	const auto gem = g_fxo->get<gem_config>();
 
@@ -767,7 +767,7 @@ error_code cellGemGetInertialState(u32 gem_num, u32 state_flag, u64 timestamp, v
 
 error_code cellGemGetInfo(vm::ptr<CellGemInfo> info)
 {
-	cellGem.todo("cellGemGetInfo(info=*0x%x)", info);
+	cellGem.warning("cellGemGetInfo(info=*0x%x)", info);
 
 	const auto gem = g_fxo->get<gem_config>();
 
@@ -864,7 +864,7 @@ error_code cellGemGetRumble(u32 gem_num, vm::ptr<u8> rumble)
 
 error_code cellGemGetState(u32 gem_num, u32 flag, u64 time_parameter, vm::ptr<CellGemState> gem_state)
 {
-	cellGem.todo("cellGemGetState(gem_num=%d, flag=0x%x, time=0x%llx, gem_state=*0x%x)", gem_num, flag, time_parameter, gem_state);
+	cellGem.warning("cellGemGetState(gem_num=%d, flag=0x%x, time=0x%llx, gem_state=*0x%x)", gem_num, flag, time_parameter, gem_state);
 
 	const auto gem = g_fxo->get<gem_config>();
 
@@ -1247,7 +1247,7 @@ error_code cellGemTrackHues(vm::cptr<u32> req_hues, vm::ptr<u32> res_hues)
 
 error_code cellGemUpdateFinish()
 {
-	cellGem.todo("cellGemUpdateFinish()");
+	cellGem.warning("cellGemUpdateFinish()");
 
 	const auto gem = g_fxo->get<gem_config>();
 
@@ -1265,7 +1265,7 @@ error_code cellGemUpdateFinish()
 
 	if (!gem->camera_frame)
 	{
-		return CELL_GEM_NO_VIDEO;
+		return not_an_error(CELL_GEM_NO_VIDEO);
 	}
 
 	return CELL_OK;
@@ -1273,7 +1273,7 @@ error_code cellGemUpdateFinish()
 
 error_code cellGemUpdateStart(vm::cptr<void> camera_frame, u64 timestamp)
 {
-	cellGem.todo("cellGemUpdateStart(camera_frame=*0x%x, timestamp=%d)", camera_frame, timestamp);
+	cellGem.warning("cellGemUpdateStart(camera_frame=*0x%x, timestamp=%d)", camera_frame, timestamp);
 
 	const auto gem = g_fxo->get<gem_config>();
 
@@ -1293,7 +1293,7 @@ error_code cellGemUpdateStart(vm::cptr<void> camera_frame, u64 timestamp)
 	gem->camera_frame = camera_frame.addr();
 	if (!camera_frame)
 	{
-		return CELL_GEM_NO_VIDEO;
+		return not_an_error(CELL_GEM_NO_VIDEO);
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -251,6 +251,8 @@ error_code cellKbGetInfo(vm::ptr<CellKbInfo> info)
 	if (!info)
 		return CELL_KB_ERROR_INVALID_PARAMETER;
 
+	std::memset(info.get_ptr(), 0, info.size());
+
 	std::lock_guard<std::mutex> lock(handler->m_mutex);
 
 	const KbInfo& current_info = handler->GetInfo();

--- a/rpcs3/Emu/Cell/Modules/cellL10n.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellL10n.cpp
@@ -285,7 +285,7 @@ s32 _ConvertStr(s32 src_code, const void *src, s32 src_len, s32 dst_code, void *
 s32 _L10nConvertStr(s32 src_code, vm::cptr<void> src, vm::cptr<s32> src_len, s32 dst_code, vm::ptr<void> dst, vm::ptr<s32> dst_len)
 {
 	s32 dstLen = *dst_len;
-	s32 result = _ConvertStr(src_code, src.get_ptr(), *src_len, dst_code, dst == vm::null ? NULL : dst.get_ptr(), &dstLen, false);
+	s32 result = _ConvertStr(src_code, src.get_ptr(), *src_len, dst_code, dst ? dst.get_ptr() : nullptr, &dstLen, false);
 	*dst_len = dstLen;
 	return result;
 }
@@ -413,7 +413,7 @@ s32 jstrnchk(vm::cptr<u8> src, s32 src_len)
 
 	for (s32 len = 0; len < src_len; len++)
 	{
-		if (src != vm::null)
+		if (src)
 		{
 			if (*src >= 0xa1 && *src <= 0xfe)
 			{
@@ -1274,7 +1274,7 @@ s32 UTF16stoUTF8s(vm::cptr<u16> utf16, vm::ref<s32> utf16_len, vm::ptr<u8> utf8,
 		//	return SRCIllegal;
 		//}
 
-		if (utf8 != vm::null)
+		if (utf8)
 		{
 			if (len > max_len)
 			{

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -119,6 +119,8 @@ error_code cellMouseGetInfo(vm::ptr<CellMouseInfo> info)
 		return CELL_MOUSE_ERROR_INVALID_PARAMETER;
 	}
 
+	std::memset(info.get_ptr(), 0, info.size());
+
 	const MouseInfo& current_info = handler->GetInfo();
 	info->max_connect = current_info.max_connect;
 	info->now_connect = current_info.now_connect;
@@ -192,13 +194,14 @@ error_code cellMouseGetData(u32 port_no, vm::ptr<CellMouseData> data)
 		return CELL_MOUSE_ERROR_NO_DEVICE;
 	}
 
+	std::memset(data.get_ptr(), 0, data.size());
+
 	// TODO: check if (current_info.mode[port_no] != CELL_MOUSE_INFO_TABLET_MOUSE_MODE) has any impact
 
 	MouseDataList& data_list = handler->GetDataList(port_no);
 
 	if (data_list.empty())
 	{
-		*data = {};
 		return CELL_OK;
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellNetCtl.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellNetCtl.cpp
@@ -300,7 +300,7 @@ error_code cellNetCtlNetStartDialogUnloadAsync(vm::ptr<CellNetCtlNetStartDialogR
 
 error_code cellNetCtlGetNatInfo(vm::ptr<CellNetCtlNatInfo> natInfo)
 {
-	cellNetCtl.todo("cellNetCtlGetNatInfo(natInfo=*0x%x)", natInfo);
+	cellNetCtl.warning("cellNetCtlGetNatInfo(natInfo=*0x%x)", natInfo);
 
 	if (!g_fxo->get<cell_net_ctl_manager>()->is_initialized)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -113,7 +113,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 	std::memset(osk->osk_text, 0, sizeof(osk->osk_text));
 	std::memset(osk->osk_text_old, 0, sizeof(osk->osk_text_old));
 
-	if (inputFieldInfo->init_text.addr() != 0)
+	if (inputFieldInfo->init_text)
 	{
 		for (u32 i = 0; (i < maxLength) && (inputFieldInfo->init_text[i] != 0); i++)
 		{
@@ -124,10 +124,9 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 	// Get message to display above the input field
 	// Guarantees 0 terminated (+1). In praxis only 128 but for now lets display all of it
-	char16_t message[CELL_OSKDIALOG_STRING_SIZE + 1];
-	std::memset(message, 0, sizeof(message));
+	char16_t message[CELL_OSKDIALOG_STRING_SIZE + 1]{};
 
-	if (inputFieldInfo->message.addr() != 0)
+	if (inputFieldInfo->message)
 	{
 		for (u32 i = 0; (i < CELL_OSKDIALOG_STRING_SIZE) && (inputFieldInfo->message[i] != 0); i++)
 		{

--- a/rpcs3/Emu/Cell/Modules/cellPngDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPngDec.cpp
@@ -568,7 +568,7 @@ s32 pngDecSetParameter(PStream stream, PInParam in_param, POutParam out_param, P
 	// This shouldnt ever happen, but not sure what to do if it does, just want it logged for now
 	if (stream->info.bitDepth != 16 && in_param->outputBitDepth == 16)
 		cellPngDec.error("Output depth of 16 with non input depth of 16 specified!");
-	if (in_param->commandPtr != vm::null)
+	if (in_param->commandPtr)
 		cellPngDec.warning("Ignoring CommandPtr.");
 
 	if (stream->info.colorSpace != in_param->outputColorSpace)

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -3691,7 +3691,7 @@ s32 _cellSpursTasksetAttribute2Initialize(vm::ptr<CellSpursTasksetAttribute2> at
 {
 	cellSpurs.warning("_cellSpursTasksetAttribute2Initialize(attribute=*0x%x, revision=%d)", attribute, revision);
 
-	memset(attribute.get_ptr(), 0, sizeof(CellSpursTasksetAttribute2));
+	std::memset(attribute.get_ptr(), 0, attribute.size());
 	attribute->revision = revision;
 	attribute->name = vm::null;
 	attribute->args = 0;
@@ -3960,11 +3960,11 @@ s32 _cellSpursTasksetAttributeInitialize(vm::ptr<CellSpursTasksetAttribute> attr
 		}
 	}
 
-	memset(attribute.get_ptr(), 0, sizeof(CellSpursTasksetAttribute));
+	std::memset(attribute.get_ptr(), 0, attribute.size());
 	attribute->revision = revision;
 	attribute->sdk_version = sdk_version;
 	attribute->args = args;
-	memcpy(attribute->priority, priority.get_ptr(), 8);
+	std::memcpy(attribute->priority, priority.get_ptr(), 8);
 	attribute->taskset_size = 6400/*CellSpursTaskset::size*/;
 	attribute->max_contention = max_contention;
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp
@@ -903,16 +903,14 @@ void spursSysServiceMain(spu_thread& spu, u32 pollStatus)
 		spursSysServiceCleanupAfterSystemWorkload(spu, ctxt);
 
 		// Trace - SERVICE: INIT
-		CellSpursTracePacket pkt;
-		memset(&pkt, 0, sizeof(pkt));
+		CellSpursTracePacket pkt{};
 		pkt.header.tag = CELL_SPURS_TRACE_TAG_SERVICE;
 		pkt.data.service.incident = CELL_SPURS_TRACE_SERVICE_INIT;
 		cellSpursModulePutTrace(&pkt, ctxt->dmaTagId);
 	}
 
 	// Trace - START: Module='SYS '
-	CellSpursTracePacket pkt;
-	memset(&pkt, 0, sizeof(pkt));
+	CellSpursTracePacket pkt{};
 	pkt.header.tag = CELL_SPURS_TRACE_TAG_START;
 	memcpy(pkt.data.start.module, "SYS ", 4);
 	pkt.data.start.level = 1; // Policy module
@@ -928,14 +926,13 @@ void spursSysServiceMain(spu_thread& spu, u32 pollStatus)
 		if (cellSpursModulePollStatus(spu, nullptr))
 		{
 			// Trace - SERVICE: EXIT
-			CellSpursTracePacket pkt;
-			memset(&pkt, 0, sizeof(pkt));
+			CellSpursTracePacket pkt{};
 			pkt.header.tag = CELL_SPURS_TRACE_TAG_SERVICE;
 			pkt.data.service.incident = CELL_SPURS_TRACE_SERVICE_EXIT;
 			cellSpursModulePutTrace(&pkt, ctxt->dmaTagId);
 
 			// Trace - STOP: GUID
-			memset(&pkt, 0, sizeof(pkt));
+			pkt = {};
 			pkt.header.tag = CELL_SPURS_TRACE_TAG_STOP;
 			pkt.data.stop = SPURS_GUID_SYS_WKL;
 			cellSpursModulePutTrace(&pkt, ctxt->dmaTagId);
@@ -956,8 +953,7 @@ void spursSysServiceMain(spu_thread& spu, u32 pollStatus)
 		// If we reach here it means that the SPU is idling
 
 		// Trace - SERVICE: WAIT
-		CellSpursTracePacket pkt;
-		memset(&pkt, 0, sizeof(pkt));
+		CellSpursTracePacket pkt{};
 		pkt.header.tag = CELL_SPURS_TRACE_TAG_SERVICE;
 		pkt.data.service.incident = CELL_SPURS_TRACE_SERVICE_WAIT;
 		cellSpursModulePutTrace(&pkt, ctxt->dmaTagId);
@@ -1287,8 +1283,7 @@ void spursSysServiceCleanupAfterSystemWorkload(spu_thread& spu, SpursKernelConte
 	ctxt->wklCurrentId = wklId;
 
 	// Trace - STOP: GUID
-	CellSpursTracePacket pkt;
-	memset(&pkt, 0, sizeof(pkt));
+	CellSpursTracePacket pkt{};
 	pkt.header.tag = CELL_SPURS_TRACE_TAG_STOP;
 	pkt.data.stop = SPURS_GUID_SYS_WKL;
 	cellSpursModulePutTrace(&pkt, ctxt->dmaTagId);
@@ -1638,8 +1633,7 @@ void spursTasksetExit(spu_thread& spu)
 	auto ctxt = vm::_ptr<SpursTasksetContext>(spu.offset + 0x2700);
 
 	// Trace - STOP
-	CellSpursTracePacket pkt;
-	memset(&pkt, 0, sizeof(pkt));
+	CellSpursTracePacket pkt{};
 	pkt.header.tag = 0x54; // Its not clear what this tag means exactly but it seems similar to CELL_SPURS_TRACE_TAG_STOP
 	pkt.data.stop = SPURS_GUID_TASKSET_PM;
 	cellSpursModulePutTrace(&pkt, ctxt->dmaTagId);
@@ -1755,8 +1749,7 @@ void spursTasksetDispatch(spu_thread& spu)
 	taskInfo->elf.set(taskInfo->elf.addr() & 0xFFFFFFFFFFFFFFF8);
 
 	// Trace - Task: Incident=dispatch
-	CellSpursTracePacket pkt;
-	memset(&pkt, 0, sizeof(pkt));
+	CellSpursTracePacket pkt{};
 	pkt.header.tag = CELL_SPURS_TRACE_TAG_TASK;
 	pkt.data.task.incident = CELL_SPURS_TRACE_TASK_DISPATCH;
 	pkt.data.task.taskId = taskId;
@@ -1791,7 +1784,7 @@ void spursTasksetDispatch(spu_thread& spu)
 		}
 
 		// Trace - GUID
-		memset(&pkt, 0, sizeof(pkt));
+		pkt = {};
 		pkt.header.tag = CELL_SPURS_TRACE_TAG_GUID;
 		pkt.data.guid = 0; // TODO: Put GUID of taskId here
 		cellSpursModulePutTrace(&pkt, 0x1F);
@@ -1845,7 +1838,7 @@ void spursTasksetDispatch(spu_thread& spu)
 		spu.set_ch_value(SPU_WrEventMask, ctxt->savedSpuWriteEventMask);
 
 		// Trace - GUID
-		memset(&pkt, 0, sizeof(pkt));
+		pkt = {};
 		pkt.header.tag = CELL_SPURS_TRACE_TAG_GUID;
 		pkt.data.guid = 0; // TODO: Put GUID of taskId here
 		cellSpursModulePutTrace(&pkt, 0x1F);
@@ -1949,8 +1942,7 @@ s32 spursTasksetProcessSyscall(spu_thread& spu, u32 syscallNum, u32 args)
 	if (incident)
 	{
 		// Trace - TASK
-		CellSpursTracePacket pkt;
-		memset(&pkt, 0, sizeof(pkt));
+		CellSpursTracePacket pkt{};
 		pkt.header.tag = CELL_SPURS_TRACE_TAG_TASK;
 		pkt.data.task.incident = incident;
 		pkt.data.task.taskId = ctxt->taskId;
@@ -1982,8 +1974,7 @@ void spursTasksetInit(spu_thread& spu, u32 pollStatus)
 	kernelCtxt->moduleId[1] = 'K';
 
 	// Trace - START: Module='TKST'
-	CellSpursTracePacket pkt;
-	memset(&pkt, 0, sizeof(pkt));
+	CellSpursTracePacket pkt{};
 	pkt.header.tag = 0x52; // Its not clear what this tag means exactly but it seems similar to CELL_SPURS_TRACE_TAG_START
 	memcpy(pkt.data.start.module, "TKST", 4);
 	pkt.data.start.level = 2;

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -458,7 +458,7 @@ error_code npDrmIsAvailable(vm::cptr<u8> k_licensee_addr, vm::cptr<char> drm_pat
 
 	if (magic == "SCE\0"_u32)
 	{
-		if (k_licensee_addr == vm::null)
+		if (!k_licensee_addr)
 			k_licensee = get_default_self_klic();
 
 		if (verify_npdrm_self_headers(enc_file, k_licensee.data()))

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -750,7 +750,7 @@ error_code sceNpBasicSendMessageGui(vm::cptr<SceNpBasicMessageDetails> msg, sys_
 
 	if (g_psn_connection_status != SCE_NP_MANAGER_STATUS_ONLINE)
 	{
-		return SCE_NP_BASIC_ERROR_NOT_CONNECTED;
+		return not_an_error(SCE_NP_BASIC_ERROR_NOT_CONNECTED);
 	}
 
 	return CELL_OK;
@@ -777,7 +777,7 @@ error_code sceNpBasicSendMessageAttachment(vm::cptr<SceNpId> to, vm::cptr<char> 
 
 	if (g_psn_connection_status != SCE_NP_MANAGER_STATUS_ONLINE)
 	{
-		return SCE_NP_BASIC_ERROR_NOT_CONNECTED;
+		return not_an_error(SCE_NP_BASIC_ERROR_NOT_CONNECTED);
 	}
 
 	return CELL_OK;
@@ -884,7 +884,7 @@ error_code sceNpBasicAddFriend(vm::cptr<SceNpId> contact, vm::cptr<char> body, s
 
 	if (g_psn_connection_status != SCE_NP_MANAGER_STATUS_ONLINE)
 	{
-		return SCE_NP_BASIC_ERROR_NOT_CONNECTED;
+		return not_an_error(SCE_NP_BASIC_ERROR_NOT_CONNECTED);
 	}
 
 	return CELL_OK;
@@ -1102,7 +1102,7 @@ error_code sceNpBasicGetPlayersHistoryEntryCount(u32 options, vm::ptr<u32> count
 
 error_code sceNpBasicGetPlayersHistoryEntry(u32 options, u32 index, vm::ptr<SceNpId> npid)
 {
-	sceNp.todo("sceNpBasicGetPlayersHistoryEntry(options=%d, index=%d, npid=*0x%x)", options, index, npid);
+	sceNp.warning("sceNpBasicGetPlayersHistoryEntry(options=%d, index=%d, npid=*0x%x)", options, index, npid);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -1126,7 +1126,7 @@ error_code sceNpBasicGetPlayersHistoryEntry(u32 options, u32 index, vm::ptr<SceN
 
 error_code sceNpBasicAddBlockListEntry(vm::cptr<SceNpId> npid)
 {
-	sceNp.todo("sceNpBasicAddBlockListEntry(npid=*0x%x)", npid);
+	sceNp.warning("sceNpBasicAddBlockListEntry(npid=*0x%x)", npid);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -1140,7 +1140,7 @@ error_code sceNpBasicAddBlockListEntry(vm::cptr<SceNpId> npid)
 
 	if (g_psn_connection_status != SCE_NP_MANAGER_STATUS_ONLINE)
 	{
-		return SCE_NP_BASIC_ERROR_NOT_CONNECTED;
+		return not_an_error(SCE_NP_BASIC_ERROR_NOT_CONNECTED);
 	}
 
 	return CELL_OK;
@@ -1148,7 +1148,7 @@ error_code sceNpBasicAddBlockListEntry(vm::cptr<SceNpId> npid)
 
 error_code sceNpBasicGetBlockListEntryCount(vm::ptr<u32> count)
 {
-	sceNp.todo("sceNpBasicGetBlockListEntryCount(count=*0x%x)", count);
+	sceNp.warning("sceNpBasicGetBlockListEntryCount(count=*0x%x)", count);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -1438,7 +1438,7 @@ error_code sceNpBasicGetMessageEntry(u32 type, u32 index, vm::ptr<SceNpUserInfo>
 
 error_code sceNpBasicGetEvent(vm::ptr<s32> event, vm::ptr<SceNpUserInfo> from, vm::ptr<s32> data, vm::ptr<u32> size)
 {
-	sceNp.todo("sceNpBasicGetEvent(event=*0x%x, from=*0x%x, data=*0x%x, size=*0x%x)", event, from, data, size);
+	sceNp.warning("sceNpBasicGetEvent(event=*0x%x, from=*0x%x, data=*0x%x, size=*0x%x)", event, from, data, size);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -1453,7 +1453,7 @@ error_code sceNpBasicGetEvent(vm::ptr<s32> event, vm::ptr<SceNpUserInfo> from, v
 	// TODO: Check for other error and pass other events
 	//*event = SCE_NP_BASIC_EVENT_OFFLINE; // This event only indicates a contact is offline, not the current status of the connection
 
-	return SCE_NP_BASIC_ERROR_NO_EVENT;
+	return not_an_error(SCE_NP_BASIC_ERROR_NO_EVENT);
 }
 
 error_code sceNpCommerceCreateCtx(u32 version, vm::ptr<SceNpId> npId, vm::ptr<SceNpCommerceHandler> handler, vm::ptr<void> arg, vm::ptr<u32> ctx_id)
@@ -1729,7 +1729,7 @@ error_code sceNpCustomMenuRegisterExceptionList(vm::cptr<SceNpCustomMenuActionEx
 
 error_code sceNpFriendlist(vm::ptr<SceNpFriendlistResultHandler> resultHandler, vm::ptr<void> userArg, sys_memory_container_t containerId)
 {
-	sceNp.todo("sceNpFriendlist(resultHandler=*0x%x, userArg=*0x%x, containerId=%d)", resultHandler, userArg, containerId);
+	sceNp.warning("sceNpFriendlist(resultHandler=*0x%x, userArg=*0x%x, containerId=%d)", resultHandler, userArg, containerId);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -1746,7 +1746,7 @@ error_code sceNpFriendlist(vm::ptr<SceNpFriendlistResultHandler> resultHandler, 
 
 error_code sceNpFriendlistCustom(SceNpFriendlistCustomOptions options, vm::ptr<SceNpFriendlistResultHandler> resultHandler, vm::ptr<void> userArg, sys_memory_container_t containerId)
 {
-	sceNp.todo("sceNpFriendlistCustom(options=0x%x, resultHandler=*0x%x, userArg=*0x%x, containerId=%d)", options, resultHandler, userArg, containerId);
+	sceNp.warning("sceNpFriendlistCustom(options=0x%x, resultHandler=*0x%x, userArg=*0x%x, containerId=%d)", options, resultHandler, userArg, containerId);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -2272,7 +2272,7 @@ error_code sceNpManagerUnregisterCallback()
 
 error_code sceNpManagerGetStatus(vm::ptr<s32> status)
 {
-	sceNp.todo("sceNpManagerGetStatus(status=*0x%x)", status);
+	sceNp.warning("sceNpManagerGetStatus(status=*0x%x)", status);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -2376,7 +2376,7 @@ error_code sceNpManagerGetNpId(ppu_thread& ppu, vm::ptr<SceNpId> npId)
 
 error_code sceNpManagerGetOnlineName(vm::ptr<SceNpOnlineName> onlineName)
 {
-	sceNp.todo("sceNpManagerGetOnlineName(onlineName=*0x%x)", onlineName);
+	sceNp.warning("sceNpManagerGetOnlineName(onlineName=*0x%x)", onlineName);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -2403,7 +2403,7 @@ error_code sceNpManagerGetOnlineName(vm::ptr<SceNpOnlineName> onlineName)
 
 error_code sceNpManagerGetAvatarUrl(vm::ptr<SceNpAvatarUrl> avatarUrl)
 {
-	sceNp.todo("sceNpManagerGetAvatarUrl(avatarUrl=*0x%x)", avatarUrl);
+	sceNp.warning("sceNpManagerGetAvatarUrl(avatarUrl=*0x%x)", avatarUrl);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -2430,7 +2430,7 @@ error_code sceNpManagerGetAvatarUrl(vm::ptr<SceNpAvatarUrl> avatarUrl)
 
 error_code sceNpManagerGetMyLanguages(vm::ptr<SceNpMyLanguages> myLanguages)
 {
-	sceNp.todo("sceNpManagerGetMyLanguages(myLanguages=*0x%x)", myLanguages);
+	sceNp.warning("sceNpManagerGetMyLanguages(myLanguages=*0x%x)", myLanguages);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -2457,7 +2457,7 @@ error_code sceNpManagerGetMyLanguages(vm::ptr<SceNpMyLanguages> myLanguages)
 
 error_code sceNpManagerGetAccountRegion(vm::ptr<SceNpCountryCode> countryCode, vm::ptr<s32> language)
 {
-	sceNp.todo("sceNpManagerGetAccountRegion(countryCode=*0x%x, language=*0x%x)", countryCode, language);
+	sceNp.warning("sceNpManagerGetAccountRegion(countryCode=*0x%x, language=*0x%x)", countryCode, language);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -2484,7 +2484,7 @@ error_code sceNpManagerGetAccountRegion(vm::ptr<SceNpCountryCode> countryCode, v
 
 error_code sceNpManagerGetAccountAge(vm::ptr<s32> age)
 {
-	sceNp.todo("sceNpManagerGetAccountAge(age=*0x%x)", age);
+	sceNp.warning("sceNpManagerGetAccountAge(age=*0x%x)", age);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -2511,7 +2511,7 @@ error_code sceNpManagerGetAccountAge(vm::ptr<s32> age)
 
 error_code sceNpManagerGetContentRatingFlag(vm::ptr<s32> isRestricted, vm::ptr<s32> age)
 {
-	sceNp.todo("sceNpManagerGetContentRatingFlag(isRestricted=*0x%x, age=*0x%x)", isRestricted, age);
+	sceNp.warning("sceNpManagerGetContentRatingFlag(isRestricted=*0x%x, age=*0x%x)", isRestricted, age);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -2542,7 +2542,7 @@ error_code sceNpManagerGetContentRatingFlag(vm::ptr<s32> isRestricted, vm::ptr<s
 
 error_code sceNpManagerGetChatRestrictionFlag(vm::ptr<s32> isRestricted)
 {
-	sceNp.todo("sceNpManagerGetChatRestrictionFlag(isRestricted=*0x%x)", isRestricted);
+	sceNp.warning("sceNpManagerGetChatRestrictionFlag(isRestricted=*0x%x)", isRestricted);
 
 	if (!g_fxo->get<sce_np_manager>()->is_initialized)
 	{
@@ -4285,7 +4285,7 @@ error_code sceNpUtilCmpNpId(vm::ptr<SceNpId> id1, vm::ptr<SceNpId> id2)
 
 error_code sceNpUtilCmpNpIdInOrder(vm::cptr<SceNpId> id1, vm::cptr<SceNpId> id2, vm::ptr<s32> order)
 {
-	sceNp.todo("sceNpUtilCmpNpIdInOrder(id1=*0x%x, id2=*0x%x, order=*0x%x)", id1, id2, order);
+	sceNp.warning("sceNpUtilCmpNpIdInOrder(id1=*0x%x, id2=*0x%x, order=*0x%x)", id1, id2, order);
 
 	if (!id1 || !id2)
 	{
@@ -4332,7 +4332,7 @@ error_code sceNpUtilCmpNpIdInOrder(vm::cptr<SceNpId> id1, vm::cptr<SceNpId> id2,
 
 error_code sceNpUtilCmpOnlineId(vm::cptr<SceNpId> id1, vm::cptr<SceNpId> id2)
 {
-	sceNp.todo("sceNpUtilCmpOnlineId(id1=*0x%x, id2=*0x%x)", id1, id2);
+	sceNp.warning("sceNpUtilCmpOnlineId(id1=*0x%x, id2=*0x%x)", id1, id2);
 
 	if (!id1 || !id2)
 	{
@@ -4354,7 +4354,7 @@ error_code sceNpUtilCmpOnlineId(vm::cptr<SceNpId> id1, vm::cptr<SceNpId> id2)
 
 error_code sceNpUtilGetPlatformType(vm::cptr<SceNpId> npId)
 {
-	sceNp.todo("sceNpUtilGetPlatformType(npId=*0x%x)", npId);
+	sceNp.warning("sceNpUtilGetPlatformType(npId=*0x%x)", npId);
 
 	if (!npId)
 	{
@@ -4380,7 +4380,7 @@ error_code sceNpUtilGetPlatformType(vm::cptr<SceNpId> npId)
 
 error_code sceNpUtilSetPlatformType(vm::ptr<SceNpId> npId, SceNpPlatformType platformType)
 {
-	sceNp.todo("sceNpUtilSetPlatformType(npId=*0x%x, platformType=%d)", npId, platformType);
+	sceNp.warning("sceNpUtilSetPlatformType(npId=*0x%x, platformType=%d)", npId, platformType);
 
 	if (!npId)
 	{

--- a/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
@@ -184,7 +184,7 @@ error_code sceNpSnsFbGetAccessToken(u32 handle, vm::cptr<SceNpSnsFbAccessTokenPa
 
 	if (g_psn_connection_status == SCE_NP_MANAGER_STATUS_OFFLINE)
 	{
-		return SCE_NP_SNS_ERROR_NOT_SIGN_IN;
+		return not_an_error(SCE_NP_SNS_ERROR_NOT_SIGN_IN);
 	}
 
 	// TODO
@@ -309,7 +309,7 @@ error_code sceNpSnsFbGetLongAccessToken(u32 handle, vm::cptr<SceNpSnsFbAccessTok
 
 	if (g_psn_connection_status == SCE_NP_MANAGER_STATUS_OFFLINE)
 	{
-		return SCE_NP_SNS_ERROR_NOT_SIGN_IN;
+		return not_an_error(SCE_NP_SNS_ERROR_NOT_SIGN_IN);
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -588,9 +588,9 @@ error_code sceNpTrophyGetGameInfo(u32 context, u32 handle, vm::ptr<SceNpTrophyGa
 	}
 
 	if (details)
-		memset(details.get_ptr(), 0, sizeof(SceNpTrophyGameDetails));
+		*details = {};
 	if (data)
-		memset(data.get_ptr(), 0, sizeof(SceNpTrophyGameData));
+		*data = {};
 
 	for (std::shared_ptr<rXmlNode> n = trophy_base->GetChildren(); n; n = n->GetNext())
 	{
@@ -691,19 +691,8 @@ error_code sceNpTrophyUnlockTrophy(u32 context, u32 handle, s32 trophyId, vm::pt
 
 	if (g_cfg.misc.show_trophy_popups)
 	{
-		// Figure out how many zeros are needed for padding. (either 0, 1, or 2)
-		std::string padding = "";
-		if (trophyId < 10)
-		{
-			padding = "00";
-		}
-		else if (trophyId < 100)
-		{
-			padding = "0";
-		}
-
 		// Get icon for the notification.
-		const std::string padded_trophy_id = padding + std::to_string(trophyId);
+		const std::string padded_trophy_id = fmt::format("%03u", trophyId);
 		const std::string trophy_icon_path = "/dev_hdd0/home/" + Emu.GetUsr() + "/trophy/" + ctxt->trp_name + "/TROP" + padded_trophy_id + ".PNG";
 		fs::file trophy_icon_file = fs::file(vfs::get(trophy_icon_path));
 		std::vector<uchar> trophy_icon_data;
@@ -823,9 +812,9 @@ error_code sceNpTrophyGetTrophyInfo(u32 context, u32 handle, s32 trophyId, vm::p
 	}
 
 	if (details)
-		memset(details.get_ptr(), 0, sizeof(SceNpTrophyDetails));
+		*details = {};
 	if (data)
-		memset(data.get_ptr(), 0, sizeof(SceNpTrophyData));
+		*data = {};
 
 	rXmlDocument doc;
 	doc.Read(config.to_string());

--- a/rpcs3/Emu/Cell/Modules/sys_ppu_thread_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_ppu_thread_.cpp
@@ -204,11 +204,11 @@ error_code sys_ppu_thread_register_atexit(ppu_thread& ppu, vm::ptr<void()> func)
 		}
 	}
 
-	for (auto& pp : *g_ppu_atexit)
+	for (auto& pf : *g_ppu_atexit)
 	{
-		if (pp == vm::null)
+		if (!pf)
 		{
-			pp = func;
+			pf = func;
 			return CELL_OK;
 		}
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -130,7 +130,7 @@ error_code sys_mmapper_allocate_shared_memory_from_container(ppu_thread& ppu, u6
 {
 	vm::temporary_unlock(ppu);
 
-	sys_mmapper.error("sys_mmapper_allocate_shared_memory_from_container(0x%llx, size=0x%x, cid=0x%x, flags=0x%llx, mem_id=*0x%x)", unk, size, cid, flags, mem_id);
+	sys_mmapper.warning("sys_mmapper_allocate_shared_memory_from_container(0x%llx, size=0x%x, cid=0x%x, flags=0x%llx, mem_id=*0x%x)", unk, size, cid, flags, mem_id);
 
 	// Check page granularity.
 	switch (flags & SYS_MEMORY_PAGE_SIZE_MASK)

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -133,7 +133,7 @@ error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr
 
 	if (!vptr)
 	{
-		return CELL_EFAULT;
+		return not_an_error(CELL_EFAULT);
 	}
 
 	// Get the exit status from the register

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -310,7 +310,7 @@ error_code sys_spu_thread_initialize(ppu_thread& ppu, vm::ptr<u32> thread, u32 g
 
 	if (u32 option = attr->option)
 	{
-		sys_spu.todo("Unimplemented SPU Thread options (0x%x)", option);
+		sys_spu.warning("Unimplemented SPU Thread options (0x%x)", option);
 	}
 
 	const vm::addr_t ls_addr{verify("SPU LS" HERE, vm::alloc(0x80000, vm::main))};
@@ -416,7 +416,7 @@ error_code sys_spu_thread_group_create(ppu_thread& ppu, vm::ptr<u32> id, u32 num
 
 	if (attr->type)
 	{
-		sys_spu.todo("Unsupported SPU Thread Group type (0x%x)", attr->type);
+		sys_spu.warning("sys_spu_thread_group_create(): SPU Thread Group type (0x%x)", attr->type);
 	}
 
 	*id = idm::make<lv2_spu_group>(std::string(attr->name.get_ptr(), std::max<u32>(attr->nsize, 1) - 1), num, prio, attr->type, attr->ct);
@@ -782,14 +782,20 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 
 	if (!cause)
 	{
-		return CELL_EFAULT;
+		if (status)
+		{
+			// Report unwritten data
+			return CELL_EFAULT;
+		}
+
+		return not_an_error(CELL_EFAULT);
 	}
 
 	*cause = static_cast<u32>(ppu.gpr[4]);
 
 	if (!status)
 	{
-		return CELL_EFAULT;
+		return not_an_error(CELL_EFAULT);
 	}
 
 	*status = static_cast<s32>(ppu.gpr[5]);

--- a/rpcs3/Emu/Cell/lv2/sys_tty.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_tty.cpp
@@ -88,6 +88,8 @@ error_code sys_tty_read(s32 ch, vm::ptr<char> buf, u32 len, vm::ptr<u32> preadle
 
 error_code sys_tty_write(s32 ch, vm::cptr<char> buf, u32 len, vm::ptr<u32> pwritelen)
 {
+	sys_tty.notice("sys_tty_write(ch=%d, buf=*0x%x, len=%d, pwritelen=*0x%x)", ch, buf, len, pwritelen);
+
 	std::string msg;
 
 	if (static_cast<s32>(len) > 0 && vm::check_addr(buf.addr(), len))
@@ -99,8 +101,6 @@ error_code sys_tty_write(s32 ch, vm::cptr<char> buf, u32 len, vm::ptr<u32> pwrit
 			msg.clear();
 		}
 	}
-
-	sys_tty.notice("sys_tty_write(ch=%d, buf=*0x%x (“%s”), len=%d, pwritelen=*0x%x)", ch, buf, msg, len, pwritelen);
 
 	// Hack: write to tty even on CEX mode, but disable all error checks
 	if (ch < 0 || ch > 15)
@@ -125,6 +125,8 @@ error_code sys_tty_write(s32 ch, vm::cptr<char> buf, u32 len, vm::ptr<u32> pwrit
 	{
 		if (!msg.empty())
 		{
+			sys_tty.notice("sys_tty_write(): “%s”", msg);
+
 			if (g_tty)
 			{
 				// Lock size by making it negative

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -220,9 +220,7 @@ usb_handler_thread::~usb_handler_thread()
 
 void usb_handler_thread::operator()()
 {
-	timeval lusb_tv;
-	memset(&lusb_tv, 0, sizeof(timeval));
-	lusb_tv.tv_usec = 200;
+	timeval lusb_tv{0, 200};
 
 	while (thread_ctrl::state() != thread_state::aborting)
 	{

--- a/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
+++ b/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
@@ -7,7 +7,7 @@ class NullKeyboardHandler final : public KeyboardHandlerBase
 public:
 	void Init(const u32 max_connect) override
 	{
-		memset(&m_info, 0, sizeof(KbInfo));
+		m_info = {};
 		m_info.max_connect = max_connect;
 		m_keyboards.clear();
 		for (u32 i = 0; i < max_connect; i++)

--- a/rpcs3/Emu/Io/Null/NullMouseHandler.h
+++ b/rpcs3/Emu/Io/Null/NullMouseHandler.h
@@ -7,7 +7,7 @@ class NullMouseHandler final : public MouseHandlerBase
 public:
 	void Init(const u32 max_connect) override
 	{
-		memset(&m_info, 0, sizeof(MouseInfo));
+		m_info = {};
 		m_info.max_connect = max_connect;
 		m_mice.clear();
 	}

--- a/rpcs3/Emu/RSX/Common/texture_cache_checker.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_checker.h
@@ -68,8 +68,11 @@ namespace rsx {
 
 
 		// 4GB memory space / 4096 bytes per page = 1048576 pages
+		// Initialized to utils::protection::rw
 		static constexpr size_t num_pages = 0x1'0000'0000 / 4096;
-		per_page_info_t _info[num_pages];
+		per_page_info_t _info[num_pages]{0};
+	
+		static_assert(static_cast<u32>(utils::protection::rw) == 0, "utils::protection::rw must have value 0 for the above constructor to work");
 
 		static constexpr size_t rsx_address_to_index(u32 address)
 		{
@@ -108,13 +111,6 @@ namespace rsx {
 		}
 
 	public:
-		tex_cache_checker_t()
-		{
-			// Initialize array to all 0
-			memset(&_info, 0, sizeof(_info));
-		}
-		static_assert(static_cast<u32>(utils::protection::rw) == 0, "utils::protection::rw must have value 0 for the above constructor to work");
-
 		void set_protection(const address_range& range, utils::protection prot)
 		{
 			AUDIT(range.is_page_range());

--- a/rpcs3/Emu/RSX/GCM.h
+++ b/rpcs3/Emu/RSX/GCM.h
@@ -111,12 +111,7 @@ struct GcmZcullInfo
 	u32 sFunc;
 	u32 sRef;
 	u32 sMask;
-	bool binded;
-
-	GcmZcullInfo()
-	{
-		memset(this, 0, sizeof(*this));
-	}
+	bool binded = false;
 
 	CellGcmZcullInfo pack() const
 	{
@@ -142,12 +137,7 @@ struct GcmTileInfo
 	u32 comp;
 	u32 base;
 	u32 bank;
-	bool binded;
-
-	GcmTileInfo()
-	{
-		memset(this, 0, sizeof(*this));
-	}
+	bool binded = false;
 
 	CellGcmTileInfo pack() const
 	{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -918,7 +918,7 @@ namespace rsx
 
 	void thread::get_framebuffer_layout(rsx::framebuffer_creation_context context, framebuffer_layout &layout)
 	{
-		memset(&layout, 0, sizeof(layout));
+		layout = {};
 
 		layout.ignore_change = true;
 		layout.width = rsx::method_registers.surface_clip_width();

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -543,7 +543,7 @@ namespace rsx
 			vertex_arrays_info(fill_array<data_array_format_info>(registers, std::make_index_sequence<16>()))
 		{
 			//NOTE: Transform constants persist through a context reset (NPEB00913)
-			memset(transform_constants.data(), 0, 512 * 4 * sizeof(u32));
+			transform_constants = {};
 		}
 
 		~rsx_state() = default;

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -60,11 +60,7 @@ void pad_thread::Init()
 		}
 	}
 
-	const PadInfo pad_info(m_info);
-	std::memset(&m_info, 0, sizeof(m_info));
 	m_info.now_connect = 0;
-	m_info.system_info |= pad_info.system_info;
-	m_info.ignore_input = pad_info.ignore_input;
 
 	handlers.clear();
 


### PR DESCRIPTION
* Prefer default initializer over std::memset 0.
* Use std::format in trophy files name obtaining.
* Use vm::ptr<>::operator bool() instead of comparing vm::ptr to vm::null or using addr().
* Set common sceNpBasic, cellGem, cellCamera and a few others to warning level.
* Disable logging some "offline", cellCamera error codes and a few others.