### PR TITLE
[WIP] SPU LLVM: use FMA with approx xfloat when available

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -958,10 +958,12 @@ std::string jit_compiler::cpu(const std::string& _cpu)
 			m_cpu == "skylake" ||
 			m_cpu == "skylake-avx512" ||
 			m_cpu == "cascadelake" ||
+			m_cpu == "cooperlake" ||
 			m_cpu == "cannonlake" ||
 			m_cpu == "icelake" ||
 			m_cpu == "icelake-client" ||
-			m_cpu == "icelake-server")
+			m_cpu == "icelake-server" ||
+			m_cpu == "tigerlake")
 		{
 			// Downgrade if AVX is not supported by some chips
 			if (!utils::has_avx())
@@ -972,10 +974,12 @@ std::string jit_compiler::cpu(const std::string& _cpu)
 
 		if (m_cpu == "skylake-avx512" ||
 			m_cpu == "cascadelake" ||
+			m_cpu == "cooperlake" ||
 			m_cpu == "cannonlake" ||
 			m_cpu == "icelake" ||
 			m_cpu == "icelake-client" ||
-			m_cpu == "icelake-server")
+			m_cpu == "icelake-server" ||
+			m_cpu == "tigerlake")
 		{
 			// Downgrade if AVX-512 is disabled or not supported
 			if (!utils::has_512())

--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -18,8 +18,6 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 
 	const auto cpu = m_engine->getTargetMachine()->getTargetCPU();
 
-	m_use_ssse3 = true;
-
 	// Test SSSE3 feature (TODO)
 	if (cpu == "generic" ||
 		cpu == "k8" ||
@@ -33,6 +31,31 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 		cpu == "barcelona")
 	{
 		m_use_ssse3 = false;
+	}
+
+	// Test FMA feature (TODO)
+	if (cpu == "haswell" ||
+		cpu == "broadwell" ||
+		cpu == "skylake" ||
+		cpu == "bdver2" ||
+		cpu == "bdver3" ||
+		cpu == "bdver4" ||
+		cpu.substr(0, 5) == "znver")
+	{
+		m_use_fma = true;
+	}
+
+	// Test AVX-512 feature (TODO)
+	if (cpu == "skylake-avx512" ||
+		cpu == "cascadelake" ||
+		cpu == "cannonlake" ||
+		cpu == "cooperlake" ||
+		cpu == "icelake" ||
+		cpu == "icelake-client" ||
+		cpu == "icelake-server" ||
+		cpu == "tigerlake")
+	{
+		m_use_fma = true;
 	}
 }
 

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -2404,7 +2404,10 @@ protected:
 	bool m_is_be;
 
 	// Allow PSHUFB intrinsic
-	bool m_use_ssse3;
+	bool m_use_ssse3 = true;
+
+	// Allow FMA
+	bool m_use_fma = false;
 
 	// IR builder
 	llvm::IRBuilder<>* m_ir;


### PR DESCRIPTION
Should improve perf and accuracy for modern processors, but will be slower on older CPUs.