### PR TITLE
Avoid shifting by greater/equal than max bits values in ppu_rotate_mask

### DIFF
--- a/rpcs3/Emu/Cell/PPUOpcodes.h
+++ b/rpcs3/Emu/Cell/PPUOpcodes.h
@@ -64,7 +64,7 @@ union ppu_opcode_t
 
 inline u64 ppu_rotate_mask(u32 mb, u32 me)
 {
-	return utils::ror64(~0ull << (63 ^ (me - mb)), mb);
+	return utils::ror64(~0ull << (~(me - mb) & 63), mb);
 }
 
 inline u32 ppu_decode(u32 inst)


### PR DESCRIPTION
Because `me` is allowed to be lower than `mb`, substruction will cause shift count to be greater than max allowed shift count which is undefined behavior, mask the shift to 6 bits to avoid this.