### PR TITLE
WIP: PPU: Match PS3 for frsqrte and hopefully FMA instructions

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -3835,7 +3835,7 @@ void PPUTranslator::FMADDS(ppu_opcode_t op)
 	const auto c = GetFpr(op.frc);
 
 	llvm::Value* result;
-	if(m_use_fma)
+	if (m_use_fma)
 	{
 		result = m_ir->CreateCall(get_intrinsic<f32>(llvm::Intrinsic::fma), {
 			m_ir->CreateFPTrunc(a, GetType<f32>()),
@@ -3867,7 +3867,7 @@ void PPUTranslator::FMSUBS(ppu_opcode_t op)
 	const auto c = GetFpr(op.frc);
 
 	llvm::Value* result;
-	if(m_use_fma)
+	if (m_use_fma)
 	{
 		result = m_ir->CreateCall(get_intrinsic<f32>(llvm::Intrinsic::fma), {
 			m_ir->CreateFPTrunc(a, GetType<f32>()),
@@ -3899,7 +3899,7 @@ void PPUTranslator::FNMSUBS(ppu_opcode_t op)
 	const auto c = GetFpr(op.frc);
 
 	llvm::Value* result;
-	if(m_use_fma)
+	if (m_use_fma)
 	{
 		result = m_ir->CreateFNeg(m_ir->CreateCall(get_intrinsic<f32>(llvm::Intrinsic::fma), {
 			m_ir->CreateFPTrunc(a, GetType<f32>()),
@@ -3931,7 +3931,7 @@ void PPUTranslator::FNMADDS(ppu_opcode_t op)
 	const auto c = GetFpr(op.frc);
 
 	llvm::Value* result;
-	if(m_use_fma)
+	if (m_use_fma)
 	{
 		result = m_ir->CreateFNeg(m_ir->CreateCall(get_intrinsic<f32>(llvm::Intrinsic::fma), {
 			m_ir->CreateFPTrunc(a, GetType<f32>()),
@@ -4180,7 +4180,7 @@ void PPUTranslator::FRSQRTE(ppu_opcode_t op)
 		0x0002000000000000ull, 0x0001800000000000ull, 0x0001000000000000ull, 0x0000800000000000ull
 	};
 
-	if(!m_frsqrte_table)
+	if (!m_frsqrte_table)
 	{
 		m_frsqrte_table = new GlobalVariable(*m_module, ArrayType::get(GetType<u64>(), 16), true, GlobalValue::PrivateLinkage, ConstantDataArray::get(m_context, s_mantissas));
 	}
@@ -4222,7 +4222,7 @@ void PPUTranslator::FMSUB(ppu_opcode_t op)
 	const auto c = GetFpr(op.frc);
 
 	llvm::Value* result;
-	if(m_use_fma)
+	if (m_use_fma)
 	{
 		result = m_ir->CreateCall(get_intrinsic<f64>(llvm::Intrinsic::fma), { a, c, m_ir->CreateFNeg(b) });
 	}
@@ -4250,7 +4250,7 @@ void PPUTranslator::FMADD(ppu_opcode_t op)
 	const auto c = GetFpr(op.frc);
 
 	llvm::Value* result;
-	if(m_use_fma)
+	if (m_use_fma)
 	{
 		result = m_ir->CreateCall(get_intrinsic<f64>(llvm::Intrinsic::fma), { a, c, b });
 	}
@@ -4278,7 +4278,7 @@ void PPUTranslator::FNMSUB(ppu_opcode_t op)
 	const auto c = GetFpr(op.frc);
 
 	llvm::Value* result;
-	if(m_use_fma)
+	if (m_use_fma)
 	{
 		result = m_ir->CreateFNeg(m_ir->CreateCall(get_intrinsic<f64>(llvm::Intrinsic::fma), { a, c, m_ir->CreateFNeg(b) }));
 	}
@@ -4306,7 +4306,7 @@ void PPUTranslator::FNMADD(ppu_opcode_t op)
 	const auto c = GetFpr(op.frc);
 
 	llvm::Value* result;
-	if(m_use_fma)
+	if (m_use_fma)
 	{
 		result = m_ir->CreateFNeg(m_ir->CreateCall(get_intrinsic<f64>(llvm::Intrinsic::fma), { a, c, b }));
 	}

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef LLVM_AVAILABLE
 
@@ -51,6 +51,7 @@ class PPUTranslator final : public cpu_translator
 	llvm::StructType* m_thread_type;
 
 	llvm::Value* m_mtocr_table{};
+	llvm::Value* m_frsqrte_table{};
 
 	llvm::Value* m_globals[173];
 	llvm::Value** const m_g_cr = m_globals + 99;


### PR DESCRIPTION
This PR reimplements `frsqrte` in PPU LLVM to match results obtained from my PS3 for positive non-special (0, NaN, Inf, etc.) numbers. The steps for arriving at the results are my own that I came up with after staring at results for too long; there could be room for optimization.

Furthermore, FMA instructions have been made to use `llvm::Intrinsic::fma`, if present (using the same test as the recent SPU FMA commit). This fixes off-by-one-bit computational inaccuracies in their current implementation, as far as I can tell (not tested as thoroughly as `frsqrte`).
The instructions affected are `fmadd`, `fmadds`, `fnmadd`, `fnmadds`, `fmsub`, `fmsubs`, `fnmsub`, `fnmsubs`.

`frsqrte` and the FMA instructions now match PS3 on [this test](https://github.com/RPCS3/ps3autotests/tree/master/tests/cpu/ppu_fpu). Additionally, a TAS that previously deterministically desynced now syncs again.

Stuff that is still TODO:
- Fixing negative and special value inputs in `frsqrte`.
- Implementing the new `frsqrte` and the FMA intrinsics in interpreter(s).
- Ensuring no accuracy regressions outside negative and special input (while they're WIP).
- Assessing possible performance degradation (though there shouldn't be much of a difference - the instructions aren't that common, as far as I'm aware).
- Optimizing/enhancing readability of the new `frsqrte` implementation, it's a bit of mess.

Hope this helps, this is like my second PR for anything ever, and my C++ isn't the best (also some code formatting might be off).