### PR TITLE
[Need conflicts fixing] SPU/PPU reservations: Implement memory mirrors reservations

### DIFF
--- a/Utilities/address_range.h
+++ b/Utilities/address_range.h
@@ -37,7 +37,7 @@ namespace utils
 	/**
 	 * Address Range utility class
 	 */
-	class address_range
+	class alignas(8) address_range
 	{
 	public:
 		u32 start = UINT32_MAX; // First address in range
@@ -60,21 +60,16 @@ namespace utils
 			return (start1 >= start2 && end1 <= end2);
 		}
 
-		address_range(u32 _start, u32 _end) : start(_start), end(_end) {}
-
 	public:
 		// Constructors
-		address_range() = default;
-		address_range(const address_range &other) : start(other.start), end(other.end) {}
-
-		static inline address_range start_length(u32 _start, u32 _length)
+		static constexpr address_range start_length(u32 _start, u32 _length)
 		{
-			return address_range(_start, _start + (_length - 1));
+			return address_range{_start, _start + (_length - 1)};
 		}
 
-		static inline address_range start_end(u32 _start, u32 _end)
+		static constexpr address_range start_end(u32 _start, u32 _end)
 		{
-			return address_range(_start, _end);
+			return address_range{_start, _end};
 		}
 
 		// Length
@@ -227,6 +222,11 @@ namespace utils
 			return (start <= end);
 		}
 
+		operator bool() const
+		{
+			return valid();
+		}
+
 		void invalidate()
 		{
 			start = UINT32_MAX;
@@ -236,12 +236,12 @@ namespace utils
 		// Comparison Operators
 		bool operator ==(const address_range &other) const
 		{
-			return (start == other.start && end == other.end);
+			return std::memcmp(this, &other, sizeof(*this)) == 0;
 		}
 
 		bool operator !=(const address_range &other) const
 		{
-			return (start != other.start || end != other.end);
+			return std::memcmp(this, &other, sizeof(*this)) != 0;
 		}
 
 		/**

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -604,7 +604,7 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::opd_call:
 		{
-			const ppu_func_opd_t opd = cmd_get(1).as<ppu_func_opd_t>(); 
+			const ppu_func_opd_t opd = cmd_get(1).as<ppu_func_opd_t>();
 			cmd_pop(1), fast_call(opd.addr, opd.rtoc);
 			break;
 		}
@@ -1001,10 +1001,11 @@ static T ppu_load_acquire_reservation(ppu_thread& ppu, u32 addr)
 {
 	// Always load aligned 64-bit value (unaligned reservation will fail to store)
 	auto& data = vm::_ref<const atomic_be_t<u64>>(addr & -8);
-	const u64 size_off = (sizeof(T) * 8) & 63;
+	constexpr u64 size_off = (sizeof(T) * 8) & 63;
 	const u64 data_off = (addr & 7) * 8;
 
 	ppu.raddr = addr;
+	ppu.rtag = vm::get_memory_tag(addr);
 
 	u64 count = 0;
 
@@ -1089,13 +1090,13 @@ const auto ppu_stwcx_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, u64 rd
 	Label fail = c.newLabel();
 
 	// Prepare registers
-	c.mov(x86::rax, imm_ptr(&vm::g_reservations));
-	c.mov(x86::r10, x86::qword_ptr(x86::rax));
+	c.mov(x86::r10, imm_ptr(+vm::g_reservations));
 	c.mov(x86::rax, imm_ptr(&vm::g_base_addr));
 	c.mov(x86::r11, x86::qword_ptr(x86::rax));
 	c.lea(x86::r11, x86::qword_ptr(x86::r11, args[0]));
-	c.shr(args[0], 7);
-	c.lea(x86::r10, x86::qword_ptr(x86::r10, args[0], 3));
+	c.and_(args[0].r32(), 0xff80);
+	c.shr(args[0].r32(), 1);
+	c.lea(x86::r10, x86::qword_ptr(x86::r10, args[0]));
 	c.xor_(args[0].r32(), args[0].r32());
 	c.bswap(args[2].r32());
 	c.bswap(args[3].r32());
@@ -1135,13 +1136,13 @@ const auto ppu_stdcx_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, u64 rd
 	Label fail = c.newLabel();
 
 	// Prepare registers
-	c.mov(x86::rax, imm_ptr(&vm::g_reservations));
-	c.mov(x86::r10, x86::qword_ptr(x86::rax));
+	c.mov(x86::r10, imm_ptr(+vm::g_reservations));
 	c.mov(x86::rax, imm_ptr(&vm::g_base_addr));
 	c.mov(x86::r11, x86::qword_ptr(x86::rax));
 	c.lea(x86::r11, x86::qword_ptr(x86::r11, args[0]));
-	c.shr(args[0], 7);
-	c.lea(x86::r10, x86::qword_ptr(x86::r10, args[0], 3));
+	c.and_(args[0].r32(), 0xff80);
+	c.shr(args[0].r32(), 1);
+	c.lea(x86::r10, x86::qword_ptr(x86::r10, args[0]));
 	c.xor_(args[0].r32(), args[0].r32());
 	c.bswap(args[2]);
 	c.bswap(args[3]);
@@ -1181,9 +1182,9 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, T reg_value)
 
 	const T old_data = static_cast<T>(ppu.rdata << ((addr & 7) * 8) >> size_off);
 
-	if (ppu.raddr != addr || addr % sizeof(T) || old_data != data.load() || ppu.rtime != (vm::reservation_acquire(addr, sizeof(T)) & -128))
+	if (const u32 raddr = std::exchange(ppu.raddr, 0);
+		!raddr || (raddr ^ addr) % 128 || ppu.rtag != vm::get_memory_tag(addr) || addr % sizeof(T) || old_data != data || ppu.rtime != (vm::reservation_acquire(addr, sizeof(T)) & -128))
 	{
-		ppu.raddr = 0;
 		return false;
 	}
 
@@ -1196,20 +1197,16 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, T reg_value)
 		case 0:
 		{
 			// Reservation lost
-			ppu.raddr = 0;
 			return false;
 		}
 		case 1:
 		{
 			vm::reservation_notifier(addr, sizeof(T)).notify_all();
-			ppu.raddr = 0;
 			return true;
 		}
 		}
 
 		auto& res = vm::reservation_acquire(addr, sizeof(T));
-
-		ppu.raddr = 0;
 
 		if (res == ppu.rtime && res.compare_and_swap_test(ppu.rtime, ppu.rtime | 1))
 		{
@@ -1244,7 +1241,6 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, T reg_value)
 	}
 
 	vm::passive_lock(ppu);
-	ppu.raddr = 0;
 	return result;
 }
 

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -185,6 +185,7 @@ public:
 	u32 raddr{0}; // Reservation addr
 	u64 rtime{0};
 	u64 rdata{0}; // Reservation data
+	u32 rtag{UINT32_MAX}; // Reservation tag
 
 	atomic_t<s32> prio{0}; // Thread priority (0..3071)
 	const u32 stack_size; // Stack size

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1266,10 +1266,10 @@ void spu_recompiler::get_events()
 		Label fail = c->newLabel();
 		c->bind(rcheck);
 		c->mov(qw1->r32(), *addr);
-		c->mov(*qw0, imm_ptr(vm::g_reservations));
-		c->shr(qw1->r32(), 4);
+		c->mov(*qw0, imm_ptr(+vm::g_reservations));
+		c->and_(qw1->r32(), 0xff80);
+		c->shr(qw1->r32(), 1);
 		c->mov(*qw0, x86::qword_ptr(*qw0, *qw1));
-		c->and_(qw0->r64(), -128);
 		c->cmp(*qw0, SPU_OFF_64(rtime));
 		c->jne(fail);
 		c->mov(*qw0, imm_ptr(vm::g_base_addr));

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -557,6 +557,7 @@ public:
 	u64 rtime = 0;
 	std::array<v128, 8> rdata{};
 	u32 raddr = 0;
+	u32 rtag = UINT32_MAX;
 
 	u32 srr0;
 	u32 ch_tag_upd;

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -15,7 +15,7 @@ lv2_memory_alloca::lv2_memory_alloca(u32 size, u32 align, u64 flags, const std::
 	, align(align)
 	, flags(flags)
 	, ct(ct)
-	, shm(std::make_shared<utils::shm>(size))
+	, shm(std::make_shared<vm::shm>(size))
 {
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_memory.h
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.h
@@ -86,7 +86,7 @@ struct lv2_memory_alloca
 	const u32 align; // Alignment required
 	const u64 flags;
 	const std::shared_ptr<lv2_memory_container> ct;
-	const std::shared_ptr<utils::shm> shm;
+	const std::shared_ptr<vm::shm> shm;
 
 	lv2_memory_alloca(u32 size, u32 align, u64 flags, const std::shared_ptr<lv2_memory_container>& ct);
 };

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -17,7 +17,7 @@ lv2_memory::lv2_memory(u32 size, u32 align, u64 flags, lv2_memory_container* ct)
 	, align(align)
 	, flags(flags)
 	, ct(ct)
-	, shm(std::make_shared<utils::shm>(size))
+	, shm(std::make_shared<vm::shm>(size))
 {
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.h
@@ -16,7 +16,7 @@ struct lv2_memory : lv2_obj
 	const u32 align; // Alignment required
 	const u64 flags;
 	lv2_memory_container* const ct; // Associated memory container
-	const std::shared_ptr<utils::shm> shm;
+	const std::shared_ptr<vm::shm> shm;
 
 	atomic_t<u32> counter{0};
 

--- a/rpcs3/Emu/Memory/vm_locking.h
+++ b/rpcs3/Emu/Memory/vm_locking.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "vm.h"
+#include "Utilities/address_range.h"
 
 class cpu_thread;
 class shared_mutex;
@@ -13,7 +14,7 @@ namespace vm
 
 	// Register reader
 	void passive_lock(cpu_thread& cpu);
-	atomic_t<u64>* passive_lock(const u32 begin, const u32 end);
+	atomic_t<utils::address_range>* range_lock(utils::address_range range);
 
 	// Unregister reader
 	void passive_unlock(cpu_thread& cpu);
@@ -42,7 +43,7 @@ namespace vm
 	{
 		writer_lock(const writer_lock&) = delete;
 		writer_lock& operator=(const writer_lock&) = delete;
-		writer_lock(u32 addr = 0);
+		writer_lock(u32 tag = UINT32_MAX);
 		~writer_lock();
 	};
 } // namespace vm

--- a/rpcs3/Emu/Memory/vm_reservation.h
+++ b/rpcs3/Emu/Memory/vm_reservation.h
@@ -10,7 +10,7 @@ namespace vm
 	inline atomic_t<u64>& reservation_acquire(u32 addr, u32 size)
 	{
 		// Access reservation info: stamp and the lock bit
-		return reinterpret_cast<atomic_t<u64>*>(g_reservations)[addr / 128];
+		return *reinterpret_cast<atomic_t<u64>*>(g_reservations + (addr & 0xff80) / 2);
 	}
 
 	// Update reservation status
@@ -23,7 +23,7 @@ namespace vm
 	// Get reservation sync variable
 	inline atomic_t<u64>& reservation_notifier(u32 addr, u32 size)
 	{
-		return reinterpret_cast<atomic_t<u64>*>(g_reservations)[addr / 128];
+		return *reinterpret_cast<atomic_t<u64>*>(g_reservations + (addr & 0xff80) / 2);
 	}
 
 	void reservation_lock_internal(atomic_t<u64>&);


### PR DESCRIPTION
Rewrite memory reservations to be based on "real address" tags instead of virtual addresses, this makes it possible for memory mirrors (aka shared memory) reservations to work properly.
Fixing previous bugs such as race conditions and missing SPU LR events when using this feature.
It works by allocating a unqiue tag for each shared memory allocation and using this every reservation operation where the virtual address was used.
This is an important milestone for implementing multi-process shared memory.

Of course I tested it on real ps3 and compared the results with current master and pr [here](https://github.com/elad335/myps3tests/tree/master/spu_tests/memory%20mirrors%20reservations).
This testcase tries to execute an atomic store on both PPU and SPU cross memory mirrors, both stores fail on master and succeed on pr and real ps3.