### PR TITLE
Support mouse wheel binding

### DIFF
--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -8,10 +8,14 @@
 
 enum mouse
 {
-	move_left  = 0x05555550,
-	move_right = 0x05555551,
-	move_up    = 0x05555552,
-	move_down  = 0x05555553
+	move_left   = 0x05555550,
+	move_right  = 0x05555551,
+	move_up     = 0x05555552,
+	move_down   = 0x05555553,
+	wheel_up    = 0x05555554,
+	wheel_down  = 0x05555555,
+	wheel_left  = 0x05555556,
+	wheel_right = 0x05555557
 };
 
 class keyboard_pad_handler final : public QObject, public PadHandlerBase
@@ -52,6 +56,11 @@ class keyboard_pad_handler final : public QObject, public PadHandlerBase
 		{ mouse::move_right  , "Mouse MRight" },
 		{ mouse::move_up     , "Mouse MUp"    },
 		{ mouse::move_down   , "Mouse MDown"  },
+
+		{ mouse::wheel_up    , "Wheel Up"     },
+		{ mouse::wheel_down  , "Wheel Down"   },
+		{ mouse::wheel_left  , "Wheel Left"   },
+		{ mouse::wheel_right , "Wheel Right"  },
 	};
 
 public:
@@ -66,6 +75,7 @@ public:
 	void mousePressEvent(QMouseEvent* event);
 	void mouseReleaseEvent(QMouseEvent* event);
 	void mouseMoveEvent(QMouseEvent* event);
+	void mouseWheelEvent(QWheelEvent* event);
 
 	bool eventFilter(QObject* obj, QEvent* ev) override;
 
@@ -108,4 +118,10 @@ private:
 	int m_deadzone_y = 60;
 	double m_multi_x = 2;
 	double m_multi_y = 2.5;
+
+	// Mousewheel
+	std::chrono::steady_clock::time_point m_last_wheel_move_up;
+	std::chrono::steady_clock::time_point m_last_wheel_move_down;
+	std::chrono::steady_clock::time_point m_last_wheel_move_left;
+	std::chrono::steady_clock::time_point m_last_wheel_move_right;
 };

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -692,6 +692,61 @@ void pad_settings_dialog::mouseReleaseEvent(QMouseEvent* event)
 	ReactivateButtons();
 }
 
+void pad_settings_dialog::wheelEvent(QWheelEvent *event)
+{
+	if (m_handler->m_type != pad_handler::keyboard)
+	{
+		return;
+	}
+
+	if (m_button_id == button_ids::id_pad_begin)
+	{
+		return;
+	}
+
+	if (m_button_id <= button_ids::id_pad_begin || m_button_id >= button_ids::id_pad_end)
+	{
+		LOG_NOTICE(HLE, "Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
+		return;
+	}
+
+	QPoint direction = event->angleDelta();
+	if (direction.isNull())
+	{
+		// Scrolling started/ended event, no direction given
+		return;
+	}
+
+	u32 key;
+	if (const int x = direction.x())
+	{
+		bool to_left = event->inverted() ? x < 0 : x > 0;
+		if (to_left)
+		{
+			key = mouse::wheel_left;
+		}
+		else
+		{
+			key = mouse::wheel_right;
+		}
+	}
+	if (const int y = direction.y())
+	{
+		bool to_up = event->inverted() ? y < 0 : y > 0;
+		if (to_up)
+		{
+			key = mouse::wheel_up;
+		}
+		else
+		{
+			key = mouse::wheel_down;
+		}
+	}
+	m_cfg_entries[m_button_id].key = (static_cast<keyboard_pad_handler*>(m_handler.get()))->GetMouseName(key);
+	m_cfg_entries[m_button_id].text = qstr(m_cfg_entries[m_button_id].key);
+	ReactivateButtons();
+}
+
 void pad_settings_dialog::mouseMoveEvent(QMouseEvent* /*event*/)
 {
 	if (m_handler->m_type != pad_handler::keyboard)

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -180,5 +180,6 @@ protected:
 	void keyPressEvent(QKeyEvent *keyEvent) override;
 	void mouseReleaseEvent(QMouseEvent *event) override;
 	void mouseMoveEvent(QMouseEvent *event) override;
+	void wheelEvent(QWheelEvent *event) override;
 	bool eventFilter(QObject* object, QEvent* event) override;
 };


### PR DESCRIPTION
Adds mousewheel as a bindable button to keyboard handler. Theoretically supports 4-directional scroll wheels, but I don't have one to test with.

Since there's no event for "wheel movement has stopped", I've added a check that releases the button on the emulated controller when 0,1 seconds has passed since last wheel scroll to the same direction. This means that the button is considered to being held down as long as you keep scrolling, but it makes button mashing more difficult.

Should support scroll gestures on touchpads as well, but I doubt anyone is interested in trying that in action.

Closes #5396