### PR TITLE
cellSaveData: only show dialogs in fixed functions

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -957,7 +957,8 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				}
 			}
 
-			if (fixedSet->option != CELL_SAVEDATA_OPTION_NOCONFIRM)
+			if (fixedSet->option != CELL_SAVEDATA_OPTION_NOCONFIRM &&
+				(operation == SAVEDATA_OP_FIXED_SAVE || operation == SAVEDATA_OP_FIXED_LOAD || operation == SAVEDATA_OP_FIXED_DELETE))
 			{
 				// Yield
 				lv2_obj::sleep(ppu);


### PR DESCRIPTION
I assumed that only "fixed" cellSaveData functions had the funcFixed param and therefore allowed confirmation dialogs to be shown during some auto save/load/delete operations.
By checking for "fixed" functions on top of the funcFixed param this should now be fixed (pardon the pun).