### PR TITLE
vk: Clamp depth export in FS

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -345,9 +345,12 @@ void VKFragmentDecompilerThread::insertMainEnd(std::stringstream & OS)
 	{
 		if (m_parr.HasParam(PF_PARAM_NONE, "vec4", "r1"))
 		{
-			//Depth writes are always from a fp32 register. See issues section on nvidia's NV_fragment_program spec
-			//https://www.khronos.org/registry/OpenGL/extensions/NV/NV_fragment_program.txt
-			OS << "	gl_FragDepth = r1.z;\n";
+			// NOTE: Depth writes are always from a fp32 register. See issues section on nvidia's NV_fragment_program spec
+			// https://www.khronos.org/registry/OpenGL/extensions/NV/NV_fragment_program.txt
+
+			// NOTE: Depth writes in OpenGL (and by extension RSX) are clamped to 0,1 range.
+			// Indeed, hardware tests on realhw prove that even in depth float mode, values outside this range are clamped.
+			OS << "	gl_FragDepth = _saturate(r1.z);\n";
 		}
 		else
 		{


### PR DESCRIPTION
- PS3 matches OGL behavior where writing to the depth export register results in clamping.

Fixes missing overlays and effects in GOW1 from the HD collection.