### PR TITLE
Qt: repaint all related icons for custom configs

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -239,7 +239,7 @@ protected:
 private:
 	QPixmap PaintedPixmap(const QPixmap& icon, bool paint_config_icon = false, bool paint_pad_config_icon = false, const QColor& color = QColor());
 	QColor getGridCompatibilityColor(const QString& string);
-	void ShowCustomConfigIcon(QTableWidgetItem* item);
+	void ShowCustomConfigIcon(game_info game);
 	void PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color);
 	bool IsEntryVisible(const game_info& game);
 	void SortGameList();


### PR DESCRIPTION
Fixed a minor bug where saving or removing custom configs or custom pad configs only repainted the icons for that exact entry, but not the related other entries that share the same title id.