### PR TITLE
rsx: Sync improvements

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2876,6 +2876,8 @@ void VKGSRender::close_and_submit_command_buffer(vk::fence* pFence, VkSemaphore 
 	// NOTE: There is no need to wait for dma sync. When MTRSX is enabled, the commands are submitted in order anyway due to CSMT
 	if (vk::test_status_interrupt(vk::heap_dirty))
 	{
+		rsx::g_dma_manager.sync();
+
 		if (m_attrib_ring_info.dirty() ||
 			m_fragment_env_ring_info.dirty() ||
 			m_vertex_env_ring_info.dirty() ||

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -258,7 +258,7 @@ void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
 	{
 		OS << "	if (conditional_rendering_enabled != 0 && conditional_rendering_predicate == 0)\n";
 		OS << "	{\n";
-		OS << "		gl_Position = vec4(0.);\n";
+		OS << "		gl_Position = vec4(0., 0., 0., -1.);\n";
 		OS << "		return;\n";
 		OS << "}\n\n";
 	}

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -203,6 +203,8 @@ namespace rsx
 		void texture_read_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
 			// Pipeline barrier seems to be equivalent to a SHADER_READ stage barrier
+			rsx::g_dma_manager.sync();
+
 			// lle-gcm likes to inject system reserved semaphores, presumably for system/vsh usage
 			// Avoid calling render to avoid any havoc(flickering) they may cause from invalid flush/write
 			const u32 offset = method_registers.semaphore_offset_4097() & -16;
@@ -217,6 +219,7 @@ namespace rsx
 		void back_end_write_semaphore_release(thread* rsx, u32 _reg, u32 arg)
 		{
 			// Full pipeline barrier
+			rsx::g_dma_manager.sync();
 			rsx->sync();
 
 			const u32 offset = method_registers.semaphore_offset_4097() & -16;


### PR DESCRIPTION
- Flush DMA queue on RSX semaphore release (a form of pipeline barrier). Applications use these as signals that DMA operations are complete and will usually reuse texture and vertex memory immediately afterward. Flushing the DMA queue in this situation guarantees correct data is used for draw calls and fixes vertex flickering and rendering garbage in some games when MTRSX is enabled.
- Minor alteration to cond render emulation to avoid generating possible NaNs. This is a non-functional change intended to solve a theoretical problem that may not exist in practice.