### PR TITLE
Link BCrypt library on MSVC + CMake

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -375,6 +375,7 @@ else()
 
 		if (WIN32)
 			set(FFMPEG_LIB_DIR "ffmpeg/windows/x86_64")
+			target_link_libraries(3rdparty_ffmpeg INTERFACE "Bcrypt.lib")
 		elseif(CMAKE_SYSTEM MATCHES "Linux")
 			set(FFMPEG_LIB_DIR "ffmpeg/linux/x86_64")
 		elseif(APPLE)


### PR DESCRIPTION
On windows, BCrypt library has to be specified for linker or otherwise the linker will not find implementations for the BCrypt functions. Fixes compiling when using MSVC with CMake.