### PR TITLE
Native overlay fixes

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -370,6 +370,8 @@ target_sources(rpcs3_emu PRIVATE
 	RSX/Overlays/overlays.cpp
 	RSX/Overlays/overlay_shader_compile_notification.cpp
 	RSX/Overlays/overlay_trophy_notification.cpp
+	RSX/Overlays/Shaders/shader_loading_dialog.cpp
+	RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
 	RSX/Capture/rsx_capture.cpp
 	RSX/Capture/rsx_replay.cpp
 	RSX/GL/GLCommonDecompiler.cpp

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -279,7 +279,6 @@ error_code cellMsgDialogOpen2(u32 type, vm::cptr<char> msgString, vm::ptr<CellMs
 		cellSysutil.error("%s", msgString);
 	}
 
-
 	return open_msg_dialog(false, type, msgString, callback, userData, extParam);
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -961,9 +961,6 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			if (fixedSet->option != CELL_SAVEDATA_OPTION_NOCONFIRM &&
 				(operation == SAVEDATA_OP_FIXED_SAVE || operation == SAVEDATA_OP_FIXED_LOAD || operation == SAVEDATA_OP_FIXED_DELETE))
 			{
-				// Yield
-				lv2_obj::sleep(ppu);
-
 				std::string message;
 
 				if (selected == -1)

--- a/rpcs3/Emu/RSX/Common/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Common/ShaderParam.h
@@ -6,7 +6,8 @@
 #include "Utilities/StrUtil.h"
 #include "Utilities/types.h"
 
-enum class FUNCTION {
+enum class FUNCTION
+{
 	FUNCTION_DP2,
 	FUNCTION_DP2A,
 	FUNCTION_DP3,
@@ -47,7 +48,8 @@ enum class FUNCTION {
 	FUNCTION_TEXTURE_SAMPLE2D_DEPTH_RGBA
 };
 
-enum class COMPARE {
+enum class COMPARE
+{
 	FUNCTION_SEQ,
 	FUNCTION_SGE,
 	FUNCTION_SGT,

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.cpp
@@ -1,0 +1,91 @@
+﻿#include "stdafx.h"
+#include "shader_loading_dialog.h"
+
+namespace rsx
+{
+	void shader_loading_dialog::create(const std::string& msg, const std::string& title)
+	{
+		dlg = Emu.GetCallbacks().get_msg_dialog();
+		if (dlg)
+		{
+			dlg->type.se_normal = true;
+			dlg->type.bg_invisible = true;
+			dlg->type.progress_bar_count = 2;
+			dlg->ProgressBarSetTaskbarIndex(-1); // -1 to combine all progressbars in the taskbar progress
+			dlg->on_close = [](s32 status) { Emu.CallAfter([]() { Emu.Stop(); }); };
+
+			ref_cnt++;
+
+			Emu.CallAfter([&]()
+			{
+				dlg->Create(msg, title);
+				ref_cnt--;
+			});
+		}
+
+		while (ref_cnt.load() && !Emu.IsStopped())
+		{
+			_mm_pause();
+		}
+	}
+
+	void shader_loading_dialog::update_msg(u32 index, const std::string& msg)
+	{
+		if (!dlg)
+		{
+			return;
+		}
+
+		ref_cnt++;
+
+		Emu.CallAfter([&, index, msg]()
+		{
+			dlg->ProgressBarSetMsg(index, msg);
+			ref_cnt--;
+		});
+	}
+
+	void shader_loading_dialog::inc_value(u32 index, u32 value)
+	{
+		if (!dlg)
+		{
+			return;
+		}
+
+		ref_cnt++;
+
+		Emu.CallAfter([&, index, value]()
+		{
+			dlg->ProgressBarInc(index, value);
+			ref_cnt--;
+		});
+	}
+
+	void shader_loading_dialog::set_limit(u32 index, u32 limit)
+	{
+		if (!dlg)
+		{
+			return;
+		}
+
+		ref_cnt++;
+
+		Emu.CallAfter([&, index, limit]()
+		{
+			dlg->ProgressBarSetLimit(index, limit);
+			ref_cnt--;
+		});
+	}
+
+	void shader_loading_dialog::refresh()
+	{
+	}
+
+	void shader_loading_dialog::close()
+	{
+		while (ref_cnt.load() && !Emu.IsStopped())
+		{
+			_mm_pause();
+		}
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+#include "Emu/System.h"
+#include "Emu/Cell/Modules/cellMsgDialog.h"
+
+namespace rsx
+{
+	struct shader_loading_dialog
+	{
+		std::shared_ptr<MsgDialogBase> dlg;
+		atomic_t<int> ref_cnt;
+
+		virtual void create(const std::string& msg, const std::string& title);
+		virtual void update_msg(u32 index, const std::string& msg);
+		virtual void inc_value(u32 index, u32 value);
+		virtual void set_limit(u32 index, u32 limit);
+		virtual void refresh();
+		virtual void close();
+	};
+}

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
@@ -1,0 +1,54 @@
+﻿#include "stdafx.h"
+#include "shader_loading_dialog_native.h"
+
+namespace rsx
+{
+	shader_loading_dialog_native::shader_loading_dialog_native(GSRender* ptr)
+		: owner(ptr)
+	{
+	}
+
+	void shader_loading_dialog_native::create(const std::string& msg, const std::string&/* title*/)
+	{
+		MsgDialogType type = {};
+		type.disable_cancel = true;
+		type.progress_bar_count = 2;
+
+		dlg = g_fxo->get<rsx::overlays::display_manager>()->create<rsx::overlays::message_dialog>(!!g_cfg.video.shader_preloading_dialog.use_custom_background);
+		dlg->progress_bar_set_taskbar_index(-1);
+		dlg->show(false, msg, type, [](s32 status)
+		{
+			if (status != CELL_OK)
+				Emu.Stop();
+		});
+	}
+
+	void shader_loading_dialog_native::update_msg(u32 index, const std::string& msg)
+	{
+		dlg->progress_bar_set_message(index, msg);
+		owner->flip({});
+	}
+
+	void shader_loading_dialog_native::inc_value(u32 index, u32 value)
+	{
+		dlg->progress_bar_increment(index, static_cast<f32>(value));
+		owner->flip({});
+	}
+
+	void shader_loading_dialog_native::set_limit(u32 index, u32 limit)
+	{
+		dlg->progress_bar_set_limit(index, limit);
+		owner->flip({});
+	}
+
+	void shader_loading_dialog_native::refresh()
+	{
+		dlg->refresh();
+	}
+
+	void shader_loading_dialog_native::close()
+	{
+		dlg->return_code = CELL_OK;
+		dlg->close();
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.h
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.h
@@ -1,0 +1,22 @@
+﻿#pragma once
+
+#include "shader_loading_dialog.h"
+#include "../../GSRender.h"
+
+namespace rsx
+{
+	struct shader_loading_dialog_native : rsx::shader_loading_dialog
+	{
+		rsx::thread* owner = nullptr;
+		std::shared_ptr<rsx::overlays::message_dialog> dlg;
+
+		shader_loading_dialog_native(GSRender* ptr);
+
+		void create(const std::string& msg, const std::string&/* title*/) override;
+		void update_msg(u32 index, const std::string& msg) override;
+		void inc_value(u32 index, u32 value) override;
+		void set_limit(u32 index, u32 limit) override;
+		void refresh() override;
+		void close() override;
+	};
+}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2,6 +2,7 @@
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
 #include "VKGSRender.h"
+#include "../Overlays/Shaders/shader_loading_dialog_native.h"
 #include "../rsx_methods.h"
 #include "../rsx_utils.h"
 #include "../Common/BufferUtils.h"
@@ -1879,63 +1880,10 @@ void VKGSRender::on_init_thread()
 	}
 	else
 	{
-		struct native_helper : vk::shader_cache::progress_dialog_helper
-		{
-			rsx::thread *owner = nullptr;
-			std::shared_ptr<rsx::overlays::message_dialog> dlg;
-
-			native_helper(VKGSRender *ptr) :
-				owner(ptr) {}
-
-			void create() override
-			{
-				MsgDialogType type = {};
-				type.disable_cancel = true;
-				type.progress_bar_count = 2;
-
-				dlg = g_fxo->get<rsx::overlays::display_manager>()->create<rsx::overlays::message_dialog>(!!g_cfg.video.shader_preloading_dialog.use_custom_background);
-				dlg->progress_bar_set_taskbar_index(-1);
-				dlg->show(false, "Loading precompiled shaders from disk...", type, [](s32 status)
-				{
-					if (status != CELL_OK)
-						Emu.Stop();
-				});
-			}
-
-			void update_msg(u32 index, u32 processed, u32 entry_count) override
-			{
-				const char *text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
-				dlg->progress_bar_set_message(index, fmt::format(text, processed, entry_count));
-				owner->flip({});
-			}
-
-			void inc_value(u32 index, u32 value) override
-			{
-				dlg->progress_bar_increment(index, static_cast<f32>(value));
-				owner->flip({});
-			}
-
-			void set_limit(u32 index, u32 limit) override
-			{
-				dlg->progress_bar_set_limit(index, limit);
-				owner->flip({});
-			}
-
-			void refresh() override
-			{
-				dlg->refresh();
-			}
-
-			void close() override
-			{
-				dlg->return_code = CELL_OK;
-				dlg->close();
-			}
-		}
-		helper(this);
+		rsx::shader_loading_dialog_native dlg(this);
 
 		// TODO: Handle window resize messages during loading on GPUs without OUT_OF_DATE_KHR support
-		m_shaders_cache->load(&helper, *m_device, pipeline_layout);
+		m_shaders_cache->load(&dlg, *m_device, pipeline_layout);
 	}
 }
 

--- a/rpcs3/Emu/RSX/VK/VulkanAPI.h
+++ b/rpcs3/Emu/RSX/VK/VulkanAPI.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef _WIN32
 #define VK_USE_PLATFORM_WIN32_KHR
@@ -13,8 +13,3 @@
 #include <vulkan/vk_sdk_platform.h>
 #include "define_new_memleakdetect.h"
 #include "Utilities/types.h"
-
-namespace vk
-{
-	void init();
-}

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -70,6 +70,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Emu\Io\KeyboardHandler.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.cpp" />
     <ClCompile Include="util\atomic.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
@@ -395,6 +397,8 @@
     <ClInclude Include="Emu\Io\Keyboard.h" />
     <ClInclude Include="Emu\RSX\Common\texture_cache_helpers.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_perf_metrics.h" />
+    <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.h" />
+    <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.h" />
     <ClInclude Include="util\atomic.hpp" />
     <ClInclude Include="..\Utilities\BEType.h" />
     <ClInclude Include="..\Utilities\bin_patch.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -69,6 +69,9 @@
     <Filter Include="Emu\GPU\RSX\Overlays">
       <UniqueIdentifier>{7536c5ad-d58f-40a7-96db-74d959fa4c02}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Emu\GPU\RSX\Overlays\Shaders">
+      <UniqueIdentifier>{f368580d-07bc-4c8b-b488-a4198f2dd17d}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Crypto\aes.cpp">
@@ -836,6 +839,12 @@
     <ClCompile Include="Crypto\aesni.cpp">
       <Filter>Crypto</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.cpp">
+      <Filter>Emu\GPU\RSX\Overlays\Shaders</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.cpp">
+      <Filter>Emu\GPU\RSX\Overlays\Shaders</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -1584,6 +1593,12 @@
     </ClInclude>
     <ClInclude Include="Emu\Cell\Modules\cellStorage.h">
       <Filter>Emu\Cell\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.h">
+      <Filter>Emu\GPU\RSX\Overlays\Shaders</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.h">
+      <Filter>Emu\GPU\RSX\Overlays\Shaders</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
1. Removes an unused function declaration after its body removal in an earlier PR.

2. Fixes the update loop for non-interactive native dialogs.

3. Refactors native shader dialogs to get rid of duplicate code in both renderer backends.

4. Removes a duplicate sleep in a recently added cellSaveData confirmation dialog