### PR TITLE
rsx/overlays: Add support for animations

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -359,6 +359,7 @@ target_sources(rpcs3_emu PRIVATE
 	RSX/Common/TextureUtils.cpp
 	RSX/Common/VertexProgramDecompiler.cpp
 	RSX/Null/NullGSRender.cpp
+	RSX/Overlays/overlay_animation.cpp
 	RSX/Overlays/overlay_edit_text.cpp
 	RSX/Overlays/overlay_font.cpp
 	RSX/Overlays/overlay_list_view.cpp

--- a/rpcs3/Emu/RSX/Overlays/overlay_animation.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_animation.cpp
@@ -1,0 +1,76 @@
+#include "stdafx.h"
+#include "overlay_animation.h"
+#include "overlay_controls.h"
+
+namespace rsx
+{
+    namespace overlays
+    {
+        void animation_translate::apply(compiled_resource& resource)
+        {
+            if (progress == vector3i(0, 0, 0))
+            {
+                return;
+            }
+
+            const vertex delta = { static_cast<float>(progress.x), static_cast<float>(progress.y), static_cast<float>(progress.z), 0.f };
+            for (auto& cmd : resource.draw_commands)
+            {
+                for (auto& v : cmd.verts)
+                {
+                    v += delta;
+                }
+            }
+        }
+
+        void animation_translate::update(u64 t)
+        {
+            if (!active)
+            {
+                return;
+            }
+
+            if (time == 0)
+            {
+                time = t;
+                return;
+            }
+
+            const u64 delta = (t - time);
+            const u64 frames = delta / 16667;
+
+            if (frames)
+            {
+                const int mag = frames * speed;
+                const vector3i new_progress = progress + direction * mag;
+                const auto d = new_progress.distance(progress_limit);
+
+                if (distance >= 0)
+                {
+                    if (d > distance)
+                    {
+                        // Exit condition
+                        finish();
+                        return;
+                    }
+                }
+
+                progress = new_progress;
+                distance = d;
+                time = t;
+            }
+        }
+
+        void animation_translate::finish()
+        {
+            active = false;
+            distance = -1;
+            time = 0;
+
+            if (on_finish)
+            {
+                on_finish();
+            }
+        }
+    };
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_animation.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_animation.h
@@ -1,0 +1,94 @@
+#pragma once
+#include "Utilities/types.h"
+#include "Utilities/geometry.h"
+
+namespace rsx
+{
+    template<typename T>
+    struct vector3_base : public position3_base<T>
+    {
+        using position3_base<T>::position3_base;
+
+        vector3_base<T>(T x, T y, T z)
+        {
+            this->x = x;
+            this->y = y;
+            this->z = z;
+        }
+
+        vector3_base<T>(const position3_base<T>& other)
+        {
+            this->x = other.x;
+            this->y = other.y;
+            this->z = other.z;
+        }
+
+        vector3_base<T> operator * (const vector3_base<T>& rhs) const
+        {
+            return { this->x * rhs.x, this->y * rhs.y, this->z * rhs.z };
+        }
+
+        vector3_base<T> operator * (T rhs) const
+        {
+            return { this->x * rhs, this->y * rhs, this->z * rhs };
+        }
+
+         void operator *= (const vector3_base<T>& rhs)
+        {
+            this->x *= rhs.x;
+            this->y *= rhs.y;
+            this->z *= rhs.z;
+        }
+
+        void operator *= (T rhs)
+        {
+            this->x *= rhs;
+            this->y *= rhs;
+            this->z *= rhs;
+        }
+
+        T dot(const vector3_base<T>& rhs) const
+        {
+            return (this->x * rhs.x) + (this->y * rhs.y) + (this->z * rhs.z);
+        }
+
+        T distance(const vector3_base<T>& rhs) const
+        {
+            const vector3_base<T> d = *this - rhs;
+            return d.dot(d);
+        }
+    };
+
+    using vector3i = vector3_base<int>;
+    using vector3f = vector3_base<float>;
+
+    namespace overlays
+    {
+        struct compiled_resource;
+
+        struct animation_base
+        {
+            bool active = false;
+
+            virtual void apply(compiled_resource&) = 0;
+            virtual void update(u64 t) = 0;
+        };
+
+        struct animation_translate : animation_base
+        {
+            vector3i direction{};
+            vector3i progress{};
+            vector3i progress_limit{};
+
+            std::function<void()> on_finish;
+
+            int speed = 0;
+            int distance = -1;
+            u64 time = 0;
+
+            void apply(compiled_resource& data) override;
+            void update(u64 t) override;
+            void finish();
+        };
+    }
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -781,16 +781,6 @@ namespace rsx
 			}
 		};
 
-		struct animation_base
-		{
-			float duration = 0.f;
-			float t = 0.f;
-			overlay_element *ref = nullptr;
-
-			virtual void update(float /*elapsed*/) {}
-			void reset() { t = 0.f; }
-		};
-
 		struct layout_container : public overlay_element
 		{
 			std::vector<std::unique_ptr<overlay_element>> m_items;

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -20,12 +20,35 @@ namespace rsx
 			text_view.set_font("Arial", 8);
 			text_view.align_text(overlay_element::text_align::center);
 			text_view.back_color.a = 0.f;
+
+			sliding_animation.direction = { 1, 0, 0 };
+			sliding_animation.speed = 10;
+			sliding_animation.progress = { -int(frame.w), 0, 0 };
+			sliding_animation.progress_limit = { 0, 0, 0};
+			sliding_animation.active = true;
 		}
 		void trophy_notification::update()
 		{
 			u64 t = get_system_time();
 			if (((t - creation_time) / 1000) > 7500)
-				close();
+			{
+				if (!sliding_animation.active)
+				{
+					sliding_animation.direction.x = -1;
+					sliding_animation.progress_limit = { -int(frame.w), 0, 0 };
+					sliding_animation.on_finish = [this]
+					{
+						close();
+					};
+
+					sliding_animation.active = true;
+				}
+			}
+
+			if (sliding_animation.active)
+			{
+				sliding_animation.update(t);
+			}
 		}
 
 		compiled_resource trophy_notification::get_compiled()
@@ -34,6 +57,7 @@ namespace rsx
 			result.add(image.get_compiled());
 			result.add(text_view.get_compiled());
 
+			sliding_animation.apply(result);
 			return result;
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -1,4 +1,5 @@
 ﻿#pragma once
+#include "overlay_animation.h"
 #include "overlay_controls.h"
 
 #include "../../../Utilities/date_time.h"
@@ -504,6 +505,8 @@ namespace rsx
 
 			u64 creation_time = 0;
 			std::unique_ptr<image_info> icon_info;
+
+			animation_translate sliding_animation;
 
 		public:
 			trophy_notification();

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -320,6 +320,7 @@
     </ClCompile>
     <ClCompile Include="Emu\RSX\Null\NullGSRender.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlays.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\overlay_animation.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_edit_text.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_font.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_list_view.cpp" />
@@ -591,6 +592,7 @@
     <ClInclude Include="Emu\RSX\gcm_enums.h" />
     <ClInclude Include="Emu\RSX\gcm_printing.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlays.h" />
+    <ClInclude Include="Emu\RSX\Overlays\overlay_animation.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_controls.h" />
     <ClInclude Include="Emu\RSX\RSXFIFO.h" />
     <ClInclude Include="Emu\RSX\RSXOffload.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -773,6 +773,9 @@
     <ClCompile Include="Emu\RSX\Overlays\overlays.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\overlay_animation.cpp">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClCompile>
     <ClCompile Include="Emu\RSX\Overlays\overlay_perf_metrics.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
@@ -1518,6 +1521,9 @@
     </ClInclude>
     <ClInclude Include="Emu\RSX\Capture\rsx_capture.h">
       <Filter>Emu\GPU\RSX\Capture</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\overlay_animation.h">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClInclude>
     <ClInclude Include="Emu\RSX\Overlays\overlay_controls.h">
       <Filter>Emu\GPU\RSX\Overlays</Filter>


### PR DESCRIPTION
Adds animation support. This commit adds the base framework and implements a translate animation used to slide elements around the screen. This is then used to implement the sliding animation for the trophy notification.

The main animations that will be added to various dialogs include fade_in, fade_out and sliding for the time being. Rotation is also fairly easy to add if required. Basically any transform that can be trivially represented in an equation. The only other remaining task here is adding the fade_in/out to the OSK to make its spawning/despawning a bit softer but that is for a later date.