### PR TITLE
overlays: Misc trophy improvements

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -33,7 +33,7 @@ namespace rsx
 		trophy_notification::trophy_notification()
 		{
 			frame.set_pos(0, 0);
-			frame.set_size(260, 80);
+			frame.set_size(300, 80);
 			frame.back_color.a = 0.85f;
 
 			image.set_pos(8, 8);
@@ -42,7 +42,7 @@ namespace rsx
 
 			text_view.set_pos(85, 0);
 			text_view.set_padding(0, 0, 24, 0);
-			text_view.set_font("Arial", 8);
+			text_view.set_font("Arial", 9);
 			text_view.align_text(overlay_element::text_align::center);
 			text_view.back_color.a = 0.f;
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -5,6 +5,31 @@ namespace rsx
 {
 	namespace overlays
 	{
+		// TODO: Move somewhere in rsx_utils or general utils if needed anywhere else
+		class ticket_semaphore_t
+		{
+			atomic_t<u64> acquired{0};
+			atomic_t<u64> released{0};
+
+		public:
+			u64 enqueue()
+			{
+				return acquired.fetch_add(1);
+			}
+
+			bool try_acquire(u64 queue_id) const
+			{
+				return (queue_id == released.load());
+			}
+
+			void release()
+			{
+				released++;
+			}
+		};
+
+		static ticket_semaphore_t s_trophy_semaphore;
+
 		trophy_notification::trophy_notification()
 		{
 			frame.set_pos(0, 0);
@@ -27,9 +52,23 @@ namespace rsx
 			sliding_animation.progress_limit = { 0, 0, 0};
 			sliding_animation.active = true;
 		}
+
 		void trophy_notification::update()
 		{
-			u64 t = get_system_time();
+			if (!s_trophy_semaphore.try_acquire(display_sched_id))
+			{
+				// Not scheduled to run just yet
+				return;
+			}
+
+			const u64 t = get_system_time();
+			if (!creation_time)
+			{
+				// First tick
+				creation_time = t;
+				return;
+			}
+
 			if (((t - creation_time) / 1000) > 7500)
 			{
 				if (!sliding_animation.active)
@@ -38,6 +77,7 @@ namespace rsx
 					sliding_animation.progress_limit = { -int(frame.w), 0, 0 };
 					sliding_animation.on_finish = [this]
 					{
+						s_trophy_semaphore.release();
 						close();
 					};
 
@@ -53,6 +93,11 @@ namespace rsx
 
 		compiled_resource trophy_notification::get_compiled()
 		{
+			if (!creation_time)
+			{
+				return {};
+			}
+
 			auto result = frame.get_compiled();
 			result.add(image.get_compiled());
 			result.add(text_view.get_compiled());
@@ -63,6 +108,9 @@ namespace rsx
 
 		s32 trophy_notification::show(const SceNpTrophyDetails& trophy, const std::vector<uchar>& trophy_icon_buffer)
 		{
+			// Schedule to display this trophy
+			display_sched_id = s_trophy_semaphore.enqueue();
+
 			if (!trophy_icon_buffer.empty())
 			{
 				icon_info = std::make_unique<image_info>(trophy_icon_buffer);
@@ -87,7 +135,6 @@ namespace rsx
 			u16 margin_sz = text_view.x - image.w - image.x;
 			frame.w       = text_view.x + text_view.w + margin_sz;
 
-			creation_time = get_system_time();
 			return CELL_OK;
 		}
 	} // namespace overlays

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -503,6 +503,7 @@ namespace rsx
 			image_view image;
 			label text_view;
 
+			u64 display_sched_id = 0;
 			u64 creation_time = 0;
 			std::unique_ptr<image_info> icon_info;
 

--- a/rpcs3/rpcs3qt/trophy_notification_helper.cpp
+++ b/rpcs3/rpcs3qt/trophy_notification_helper.cpp
@@ -9,7 +9,9 @@ s32 trophy_notification_helper::ShowTrophyNotification(const SceNpTrophyDetails&
 {
 	if (auto manager = g_fxo->get<rsx::overlays::display_manager>())
 	{
-		return manager->create<rsx::overlays::trophy_notification>()->show(trophy, trophy_icon_buffer);
+		// Allow adding more than one trophy notification. The notification class manages scheduling
+		auto popup = std::make_shared<rsx::overlays::trophy_notification>();
+		return manager->add(popup, false)->show(trophy, trophy_icon_buffer);
 	}
 
 	if (!Emu.HasGui())


### PR DESCRIPTION
- Allow multiple trophies to be displayed at once. The trophies will be queued up and displayed when it is their turn to do so.
- Slightly increase trophy font and dialog size. This solves a long-standing problem where some libre fonts refused to work properly with the trophy notification dialog resulting is broken text.