### PR TITLE
cellFs: Few Improvements

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -635,7 +635,9 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 	const std::string_view vpath = path.get_ptr();
 	const std::string local_path = vfs::get(vpath);
 
-	if (vpath.find_first_not_of('/') == -1)
+	const auto first_name_ch = vpath.find_first_not_of('/');
+
+	if (first_name_ch == -1)
 	{
 		*sb = {CELL_FS_S_IFDIR | 0444};
 		return CELL_OK;
@@ -689,9 +691,10 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 		}
 	}
 
+	const bool supports_id = vpath.size() < (first_name_ch + 8) || !vpath.compare(first_name_ch, 8, "dev_hdd1"sv); // TODO
 	sb->mode = info.is_directory ? CELL_FS_S_IFDIR | 0777 : CELL_FS_S_IFREG | 0666;
-	sb->uid = 0; // Always zero
-	sb->gid = 0; // Always zero
+	sb->uid = supports_id ? 0 : -1;
+	sb->gid = supports_id ? 0 : -1;
 	sb->atime = info.atime;
 	sb->mtime = info.mtime;
 	sb->ctime = info.ctime;
@@ -723,9 +726,10 @@ error_code sys_fs_fstat(ppu_thread& ppu, u32 fd, vm::ptr<CellFsStat> sb)
 
 	const fs::stat_t& info = file->file.stat();
 
+	const bool supports_id = std::memcmp("/dev_hdd1", file->name.data(), 9) != 0; // TODO
 	sb->mode = info.is_directory ? CELL_FS_S_IFDIR | 0777 : CELL_FS_S_IFREG | 0666;
-	sb->uid = 0; // Always zero
-	sb->gid = 0; // Always zero
+	sb->uid = supports_id ? 0 : -1;
+	sb->gid = supports_id ? 0 : -1;
 	sb->atime = info.atime;
 	sb->mtime = info.mtime;
 	sb->ctime = info.ctime; // ctime may be incorrect
@@ -1214,15 +1218,21 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 			return CELL_EBADF;
 		}
 
-		for (; arg->_size < arg->max; arg->_size++)
+		arg->_size = 0; // This write is not really useful for cellFs but do it anyways
+
+		// NOTE: This function is actually capable of reading only one entry at a time
+		if (arg->max)
 		{
+			std::memset(arg->ptr.get_ptr(), 0, arg->max * arg->ptr.size());
+
 			if (auto* info = directory->dir_read())
 			{
-				auto& entry = arg->ptr[arg->_size];
+				auto& entry = arg->ptr[arg->_size++];
 
+				const bool supports_id = std::memcmp("/dev_hdd1", directory->name.data(), 9) != 0; // TODO
 				entry.attribute.mode = info->is_directory ? CELL_FS_S_IFDIR | 0777 : CELL_FS_S_IFREG | 0666;
-				entry.attribute.uid = 0;
-				entry.attribute.gid = 0;
+				entry.attribute.uid = supports_id ? 0 : -1;
+				entry.attribute.gid = supports_id ? 0 : -1;
 				entry.attribute.atime = info->atime;
 				entry.attribute.mtime = info->mtime;
 				entry.attribute.ctime = info->ctime;
@@ -1232,10 +1242,6 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 				entry.entry_name.d_type = info->is_directory ? CELL_FS_TYPE_DIRECTORY : CELL_FS_TYPE_REGULAR;
 				entry.entry_name.d_namlen = u8(std::min<size_t>(info->name.size(), CELL_FS_MAX_FS_FILE_NAME_LENGTH));
 				strcpy_trunc(entry.entry_name.d_name, info->name);
-			}
-			else
-			{
-				break;
 			}
 		}
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1323,16 +1323,16 @@ error_code sys_fs_lseek(ppu_thread& ppu, u32 fd, s64 offset, s32 whence, vm::ptr
 
 	sys_fs.trace("sys_fs_lseek(fd=%d, offset=0x%llx, whence=0x%x, pos=*0x%x)", fd, offset, whence, pos);
 
-	if (whence >= 3)
-	{
-		return {CELL_EINVAL, whence};
-	}
-
 	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
 		return CELL_EBADF;
+	}
+
+	if (whence + 0u >= 3)
+	{
+		return {CELL_EINVAL, whence};
 	}
 
 	std::lock_guard lock(file->mp->mutex);


### PR DESCRIPTION
* Ensure cellFsDirectoryEntry array is filled with zeroes on places above data_count range.
* Limit cellFsGetDirectoryEntries to be able to read only one entry at a time.
* Set uid, gid to -1 instead of 0 for dev_hdd1.
* Make negative whence not throw and return proper error code in cellFsLseek, also fix its checking order.
 
Moves Arthur and the Revenge of Maltazard [[BLES00772](https://forums.rpcs3.net/thread-178418.html)] from Intro (stuck on loading) to ingame, possibly playable.

![image](https://user-images.githubusercontent.com/18193363/71748110-3c40f800-2e7a-11ea-99dd-afd872b7ebfc.png)


[Testcase](https://github.com/elad335/myps3tests/tree/master/ppu_tests/cellFsGetDirectoryEntries)

Part image of previously faulty game code:
https://user-images.githubusercontent.com/18193363/71748601-bf168280-2e7b-11ea-9f76-85c8fb8fa4cb.png
Function tries to read from d_type which if entry is written should be non-zero, but it checks for zero specifically.
