### PR TITLE
Multithreaded shader compliation follow-up

### DIFF
--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -7,7 +7,6 @@
 #include "Utilities/mutex.h"
 #include "Utilities/Log.h"
 #include "Utilities/span.h"
-#include "Utilities/lockless.h"
 
 #include <deque>
 
@@ -160,8 +159,6 @@ public:
 
 		std::vector<u8> tmp_cache;
 
-		async_decompile_task_entry() = default;
-
 		async_decompile_task_entry(RSXVertexProgram _V)
 			: vp(std::move(_V)), is_fp(false)
 		{
@@ -180,6 +177,7 @@ protected:
 	shared_mutex m_vertex_mutex;
 	shared_mutex m_fragment_mutex;
 	shared_mutex m_pipeline_mutex;
+	shared_mutex m_decompiler_mutex;
 
 	atomic_t<size_t> m_next_id = 0;
 	bool m_cache_miss_flag; // Set if last lookup did not find any usable cached programs
@@ -190,7 +188,7 @@ protected:
 	std::unordered_map <pipeline_key, pipeline_storage_type, pipeline_key_hash, pipeline_key_compare> m_storage;
 
 	std::unordered_map <pipeline_key, std::unique_ptr<async_link_task_entry>, pipeline_key_hash, pipeline_key_compare> m_link_queue;
-	lf_fifo<async_decompile_task_entry, 32> m_decompile_queue; // TODO: Determine best size
+	std::deque<async_decompile_task_entry> m_decompile_queue;
 
 	vertex_program_type __null_vertex_program;
 	fragment_program_type __null_fragment_program;
@@ -366,24 +364,34 @@ public:
 	{
 		// Decompile shaders and link one pipeline object per 'run'
 		// NOTE: Linking is much slower than decompilation step, so always decompile at least 1 unit
+		// TODO: Use try_lock instead
 		bool busy = false;
 		u32 count = 0;
+		std::unique_ptr<async_decompile_task_entry> decompile_task;
 
-		u32 pos = m_decompile_queue.peek();
-		while (m_decompile_queue.size() > 0)
+		while (true)
 		{
-			async_decompile_task_entry decompile_task = m_decompile_queue[pos];
-
-			if (decompile_task.is_fp)
 			{
-				search_fragment_program(decompile_task.fp);
+				std::lock_guard lock(m_decompiler_mutex);
+				if (m_decompile_queue.empty())
+				{
+					break;
+				}
+				else
+				{
+					decompile_task = std::make_unique<async_decompile_task_entry>(std::move(m_decompile_queue.front()));
+					m_decompile_queue.pop_front();
+				}
+			}
+
+			if (decompile_task->is_fp)
+			{
+				search_fragment_program(decompile_task->fp);
 			}
 			else
 			{
-				search_vertex_program(decompile_task.vp);
+				search_vertex_program(decompile_task->vp);
 			}
-
-			pos = m_decompile_queue.pop_end();
 
 			if (++count >= max_decompile_count)
 			{
@@ -496,35 +504,33 @@ public:
 		}
 		else
 		{
-			bool add_vertex_program = true, add_fragment_program = true;
+			reader_lock lock(m_decompiler_mutex);
 
-			for (int i = 0; i < m_decompile_queue.size(); ++i)
+			auto vertex_program_found = std::find_if(m_decompile_queue.begin(), m_decompile_queue.end(), [&](const auto& V)
 			{
-				const auto& program = m_decompile_queue[i];
+				if (V.is_fp) return false;
+				return program_hash_util::vertex_program_compare()(V.vp, vertexShader);
+			});
 
-				if (program.is_fp && program_hash_util::fragment_program_compare()(program.fp, fragmentShader))
-				{
-					add_fragment_program = false;
-				}
-				else if (program_hash_util::vertex_program_compare()(program.vp, vertexShader))
-				{
-					add_vertex_program = false;
-				}
+			auto fragment_program_found = std::find_if(m_decompile_queue.begin(), m_decompile_queue.end(), [&](const auto& F)
+			{
+				if (!F.is_fp) return false;
+				return program_hash_util::fragment_program_compare()(F.fp, fragmentShader);
+			});
 
-				if (!add_fragment_program && !add_vertex_program)
-				{
-					break;
-				}
-			}
-			
+			const bool add_vertex_program = (vertex_program_found == m_decompile_queue.end());
+			const bool add_fragment_program = (fragment_program_found == m_decompile_queue.end());
+
 			if (add_vertex_program)
 			{
-				m_decompile_queue[m_decompile_queue.push_begin()] = vertexShader;
+				lock.upgrade();
+				m_decompile_queue.emplace_back(vertexShader);
 			}
 
 			if (add_fragment_program)
 			{
-				m_decompile_queue[m_decompile_queue.push_begin()] = fragmentShader;
+				lock.upgrade();
+				m_decompile_queue.emplace_back(fragmentShader);
 			}
 		}
 

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -223,8 +223,10 @@ protected:
 			recompile = inserted;
 		}
 
-		if(recompile)
+		if (recompile)
+		{
 			backend_traits::recompile_vertex_program(rsx_vp, *new_shader, m_next_id++);
+		}
 
 		return std::forward_as_tuple(*new_shader, false);
 	}
@@ -265,9 +267,13 @@ protected:
 		}
 
 		if (recompile)
+		{
 			backend_traits::recompile_fragment_program(rsx_fp, *new_shader, m_next_id++);
+		}
 		else
+		{
 			free(fragment_program_ucode_copy);
+		}
 
 		return std::forward_as_tuple(*new_shader, false);
 	}
@@ -494,30 +500,31 @@ public:
 
 			for (int i = 0; i < m_decompile_queue.size(); ++i)
 			{
-				auto& P = m_decompile_queue[i];
+				const auto& program = m_decompile_queue[i];
 
-				if (P.is_fp && program_hash_util::fragment_program_compare()(P.fp, fragmentShader)) add_fragment_program = false;
-				else if (program_hash_util::vertex_program_compare()(P.vp, vertexShader)) add_vertex_program = false;
+				if (program.is_fp && program_hash_util::fragment_program_compare()(program.fp, fragmentShader))
+				{
+					add_fragment_program = false;
+				}
+				else if (program_hash_util::vertex_program_compare()(program.vp, vertexShader))
+				{
+					add_vertex_program = false;
+				}
 
-				if (!add_fragment_program && !add_vertex_program) break;
+				if (!add_fragment_program && !add_vertex_program)
+				{
+					break;
+				}
 			}
 			
 			if (add_vertex_program)
 			{
-				// Reserve queue space
-				const u32 pos = m_decompile_queue.push_begin();
-
-				// Write object
-				m_decompile_queue[pos] = vertexShader;
+				m_decompile_queue[m_decompile_queue.push_begin()] = vertexShader;
 			}
 
 			if (add_fragment_program)
 			{
-				// Reserve queue space
-				const u32 pos = m_decompile_queue.push_begin();
-
-				// Write object
-				m_decompile_queue[pos] = fragmentShader;
+				m_decompile_queue[m_decompile_queue.push_begin()] = fragmentShader;
 			}
 		}
 

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -424,7 +424,8 @@ namespace rsx
 
 		backend_storage& m_storage;
 
-		std::string getMessage(u32 index, u32 processed, u32 entry_count) {
+		std::string get_message(u32 index, u32 processed, u32 entry_count)
+		{
 			const char* text = index == 0 ? "Loading pipeline object %u of %u" : "Compiling pipeline object %u of %u";
 			return fmt::format(text, processed, entry_count);
 		};
@@ -434,7 +435,8 @@ namespace rsx
 		{
 			atomic_t<u32> processed(0);
 
-			std::function<void(u32)> shader_load_worker = [&](u32 stop_at) {
+			std::function<void(u32)> shader_load_worker = [&](u32 stop_at)
+			{
 				u32 pos;
 				while (((pos = processed++) < stop_at) && !Emu.IsStopped())
 				{
@@ -466,7 +468,8 @@ namespace rsx
 		{
 			atomic_t<u32> processed(0);
 
-			std::function<void(u32)> shader_comp_worker = [&](u32 stop_at) {
+			std::function<void(u32)> shader_comp_worker = [&](u32 stop_at)
+			{
 				u32 pos;
 				while (((pos = processed++) < stop_at) && !Emu.IsStopped())
 				{
@@ -500,7 +503,7 @@ namespace rsx
 					processed_since_last_update += inc;
 					if ((std::chrono::duration_cast<std::chrono::milliseconds>(now - last_update) > 100ms) || (stop_at == entry_count))
 					{
-						dlg->update_msg(step, getMessage(step, stop_at, entry_count));
+						dlg->update_msg(step, get_message(step, stop_at, entry_count));
 						dlg->inc_value(step, processed_since_last_update);
 						last_update = now;
 						processed_since_last_update = 0;
@@ -529,13 +532,15 @@ namespace rsx
 
 					if (processed_since_last_update > 0)
 					{
-						dlg->update_msg(step, getMessage(step, current_progress, entry_count));
+						dlg->update_msg(step, get_message(step, current_progress, entry_count));
 						dlg->inc_value(step, processed_since_last_update);
 					}
 				}
 
 				for (std::thread& worker_thread : worker_threads)
+				{
 					worker_thread.join();
+				}
 			}
 		}
 
@@ -600,8 +605,8 @@ namespace rsx
 			dlg->create("Preloading cached shaders from disk.\nPlease wait...", "Shader Compilation");
 			dlg->set_limit(0, entry_count);
 			dlg->set_limit(1, entry_count);
-			dlg->update_msg(0, getMessage(0, 0, entry_count));
-			dlg->update_msg(1, getMessage(1, 0, entry_count));
+			dlg->update_msg(0, get_message(0, 0, entry_count));
+			dlg->update_msg(1, get_message(1, 0, entry_count));
 
 			// Preload everything needed to compile the shaders
 			unpacked_type unpacked;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -2,6 +2,7 @@
 #include "Utilities/VirtualMemory.h"
 #include "Utilities/hash.h"
 #include "Utilities/File.h"
+#include "Utilities/lockless.h"
 #include "Emu/Memory/vm.h"
 #include "gcm_enums.h"
 #include "Common/ProgramStateCache.h"


### PR DESCRIPTION
Back in the day I left the "Loading pipeline object" step of the initial shader compilation alone and only bothered with "Compiling" step. Turns out lately AMDs shader cache finally began to work for RPCS3 with Vulkan on my end so the first "Loading" step became more evident and I decided to take a better look at it.

From what I checked I haven't missed any synchronization points but I'm definitely not keen if I'm violating Vulkan specs.

OpenGL again doesn't get any love since it doesn't like multi-threading. I don't really like the different Vulkan and OpenGL paths being nearly copies of each other but not sure on how to improve it. 

ProgramStateCache.h changes could cause problems with OpenGL but from what I understand there is only one RSX Decompiler Thread. That said, there is synchronization as if multiple threads are able to enter async_update(), so I'm definitely feeling like I missing something. 

Either way, please also test OpenGL since I've probably broken it and I can't test it myself due to it not working on new AMD drivers.