### PR TITLE
rsx/vp: Properly initialize vertex output registers.

### DIFF
--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -66,7 +66,7 @@ std::string VertexProgramDecompiler::GetDST(bool is_sca)
 
 			const auto reg_type = getFloatTypeName(4);
 			const auto reg_name = std::string("dst_reg") + std::to_string(d3.dst);
-			const auto default_value = (d3.dst == 0 ? reg_type + "(0.0f, 0.0f, 0.0f, 1.0f)" : reg_type + "(0.0, 0.0, 0.0, 0.0)");
+			const auto default_value = reg_type + "(0.0f, 0.0f, 0.0f, 1.0f)";
 			ret += m_parr.AddParam(PF_PARAM_OUT, reg_type, reg_name, default_value) + mask;
 		}
 	}


### PR DESCRIPTION
- All registers tested on hw show contents to be 0, 0, 0, 1. Make default output registers match this pattern.

Fixes broken output in games with shaders that do not properly initialize the whole register block and makes the missing grass in flower visible.