### PR TITLE
overlays: Redesign animation system (add easing functions, fix bugs)

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_animation.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_animation.cpp
@@ -1,6 +1,9 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
+#pragma optimize("", off)
 #include "overlay_animation.h"
 #include "overlay_controls.h"
+
+#include <numeric>
 
 namespace rsx
 {
@@ -8,12 +11,12 @@ namespace rsx
     {
         void animation_translate::apply(compiled_resource& resource)
         {
-            if (progress == vector3i(0, 0, 0))
+            if (!active)
             {
                 return;
             }
 
-            const vertex delta = { static_cast<float>(progress.x), static_cast<float>(progress.y), static_cast<float>(progress.z), 0.f };
+            const vertex delta = { current.x, current.y, current.z, 0.f };
             for (auto& cmd : resource.draw_commands)
             {
                 for (auto& v : cmd.verts)
@@ -23,49 +26,54 @@ namespace rsx
             }
         }
 
-        void animation_translate::update(u64 t)
+        void animation_translate::update(u64 frame)
         {
             if (!active)
             {
                 return;
             }
 
-            if (time == 0)
+            if (frame_start == 0)
             {
-                time = t;
+                start = current;
+                frame_start = frame;
+                frame_end = u64(frame + duration * g_cfg.video.vblank_rate);
+
                 return;
             }
 
-            const u64 delta = (t - time);
-            const u64 frames = delta / 16667;
-
-            if (frames)
+            if (frame >= frame_end)
             {
-                const int mag = frames * speed;
-                const vector3i new_progress = progress + direction * mag;
-                const auto d = new_progress.distance(progress_limit);
-
-                if (distance >= 0)
-                {
-                    if (d > distance)
-                    {
-                        // Exit condition
-                        finish();
-                        return;
-                    }
-                }
-
-                progress = new_progress;
-                distance = d;
-                time = t;
+                // Exit condition
+                finish();
+                return;
             }
+
+            f32 t = f32(frame - frame_start) / (frame_end - frame_start);
+
+            switch (type) {
+            case animation_type::linear:
+                break;
+            case animation_type::ease_in_quad:
+                t = t * t;
+                break;
+            case animation_type::ease_out_quad:
+                t = t * (2.0 - t);
+                break;
+            case animation_type::ease_in_out_cubic:
+                t = t > 0.5 ? 4.0 * std::pow((t - 1.0), 3.0) + 1.0 : 4.0 * std::pow(t, 3.0);
+                break;
+            }
+
+            current = (1.f - t) * start + t * end;
         }
 
         void animation_translate::finish()
         {
             active = false;
-            distance = -1;
-            time = 0;
+            frame_start = 0;
+            frame_end = 0;
+            current = end; // Snap current to limit in case we went over
 
             if (on_finish)
             {

--- a/rpcs3/Emu/RSX/Overlays/overlay_animation.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_animation.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "Utilities/types.h"
 #include "Utilities/geometry.h"
 #include "overlay_utils.h"
@@ -9,28 +9,40 @@ namespace rsx
     {
         struct compiled_resource;
 
+        enum class animation_type
+        {
+            linear,
+            ease_in_quad,
+            ease_out_quad,
+            ease_in_out_cubic,
+        };
+
         struct animation_base
         {
             bool active = false;
+            animation_type type { animation_type::linear };
+
+            std::function<void()> on_finish;
 
             virtual void apply(compiled_resource&) = 0;
-            virtual void update(u64 t) = 0;
+            virtual void update(u64 frame) = 0;
         };
 
         struct animation_translate : animation_base
         {
-            vector3i direction{};
-            vector3i progress{};
-            vector3i progress_limit{};
-
-            std::function<void()> on_finish;
-
-            int speed = 0;
-            int distance = -1;
-            u64 time = 0;
+        private:
+            vector3f start{}; // Set `current` instead of this
+                              // NOTE: Necessary because update() is called after rendering,
+                              //       resulting in one frame of incorrect translation
+            u64 frame_start = 0;
+            u64 frame_end = 0;
+        public:
+            vector3f current{};
+            vector3f end{};
+            f32 duration{}; // in seconds
 
             void apply(compiled_resource& data) override;
-            void update(u64 t) override;
+            void update(u64 frame) override;
             void finish();
         };
     }

--- a/rpcs3/Emu/RSX/Overlays/overlay_animation.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_animation.h
@@ -1,67 +1,10 @@
 #pragma once
 #include "Utilities/types.h"
 #include "Utilities/geometry.h"
+#include "overlay_utils.h"
 
 namespace rsx
 {
-    template<typename T>
-    struct vector3_base : public position3_base<T>
-    {
-        using position3_base<T>::position3_base;
-
-        vector3_base<T>(T x, T y, T z)
-        {
-            this->x = x;
-            this->y = y;
-            this->z = z;
-        }
-
-        vector3_base<T>(const position3_base<T>& other)
-        {
-            this->x = other.x;
-            this->y = other.y;
-            this->z = other.z;
-        }
-
-        vector3_base<T> operator * (const vector3_base<T>& rhs) const
-        {
-            return { this->x * rhs.x, this->y * rhs.y, this->z * rhs.z };
-        }
-
-        vector3_base<T> operator * (T rhs) const
-        {
-            return { this->x * rhs, this->y * rhs, this->z * rhs };
-        }
-
-         void operator *= (const vector3_base<T>& rhs)
-        {
-            this->x *= rhs.x;
-            this->y *= rhs.y;
-            this->z *= rhs.z;
-        }
-
-        void operator *= (T rhs)
-        {
-            this->x *= rhs;
-            this->y *= rhs;
-            this->z *= rhs;
-        }
-
-        T dot(const vector3_base<T>& rhs) const
-        {
-            return (this->x * rhs.x) + (this->y * rhs.y) + (this->z * rhs.z);
-        }
-
-        T distance(const vector3_base<T>& rhs) const
-        {
-            const vector3_base<T> d = *this - rhs;
-            return d.dot(d);
-        }
-    };
-
-    using vector3i = vector3_base<int>;
-    using vector3f = vector3_base<float>;
-
     namespace overlays
     {
         struct compiled_resource;

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -2,6 +2,7 @@
 #include "Utilities/types.h"
 #include "Utilities/geometry.h"
 #include "Utilities/File.h"
+#include "overlay_utils.h"
 #include "Emu/System.h"
 
 #include <string>
@@ -49,78 +50,6 @@ namespace rsx
 			triangle_strip = 1,
 			line_list = 2,
 			line_strip = 3
-		};
-
-		struct vertex
-		{
-			float values[4];
-
-			vertex() = default;
-
-			vertex(float x, float y)
-			{
-				vec2(x, y);
-			}
-
-			vertex(float x, float y, float z)
-			{
-				vec3(x, y, z);
-			}
-
-			vertex(float x, float y, float z, float w)
-			{
-				vec4(x, y, z, w);
-			}
-
-			vertex(int x, int y, int z, int w)
-			{
-				vec4(static_cast<f32>(x), static_cast<f32>(y), static_cast<f32>(z), static_cast<f32>(w));
-			}
-
-			float& operator[](int index)
-			{
-				return values[index];
-			}
-
-			void vec2(float x, float y)
-			{
-				values[0] = x;
-				values[1] = y;
-				values[2] = 0.f;
-				values[3] = 1.f;
-			}
-
-			void vec3(float x, float y, float z)
-			{
-				values[0] = x;
-				values[1] = y;
-				values[2] = z;
-				values[3] = 1.f;
-			}
-
-			void vec4(float x, float y, float z, float w)
-			{
-				values[0] = x;
-				values[1] = y;
-				values[2] = z;
-				values[3] = w;
-			}
-
-			void operator += (const vertex& other)
-			{
-				values[0] += other.values[0];
-				values[1] += other.values[1];
-				values[2] += other.values[2];
-				values[3] += other.values[3];
-			}
-
-			void operator -= (const vertex& other)
-			{
-				values[0] -= other.values[0];
-				values[1] -= other.values[1];
-				values[2] -= other.values[2];
-				values[3] -= other.values[3];
-			}
 		};
 
 		struct font

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -1,5 +1,6 @@
 ﻿#include "stdafx.h"
 #include "overlays.h"
+#include "Emu/RSX/RSXThread.h"
 
 namespace rsx
 {
@@ -46,10 +47,10 @@ namespace rsx
 			text_view.align_text(overlay_element::text_align::center);
 			text_view.back_color.a = 0.f;
 
-			sliding_animation.direction = { 1, 0, 0 };
-			sliding_animation.speed = 10;
-			sliding_animation.progress = { -int(frame.w), 0, 0 };
-			sliding_animation.progress_limit = { 0, 0, 0};
+			sliding_animation.duration = 1.5;
+			sliding_animation.type = animation_type::ease_in_out_cubic;
+			sliding_animation.current = { -f32(frame.w), 0, 0 };
+			sliding_animation.end = { 0, 0, 0};
 			sliding_animation.active = true;
 		}
 
@@ -73,8 +74,7 @@ namespace rsx
 			{
 				if (!sliding_animation.active)
 				{
-					sliding_animation.direction.x = -1;
-					sliding_animation.progress_limit = { -int(frame.w), 0, 0 };
+					sliding_animation.end = { -f32(frame.w), 0, 0 };
 					sliding_animation.on_finish = [this]
 					{
 						s_trophy_semaphore.release();
@@ -87,7 +87,7 @@ namespace rsx
 
 			if (sliding_animation.active)
 			{
-				sliding_animation.update(t);
+				sliding_animation.update(rsx::get_current_renderer()->vblank_count);
 			}
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_utils.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_utils.h
@@ -1,0 +1,148 @@
+#pragma once
+
+struct vertex
+{
+	float values[4];
+
+	vertex() = default;
+
+	vertex(float x, float y)
+	{
+		vec2(x, y);
+	}
+
+	vertex(float x, float y, float z)
+	{
+		vec3(x, y, z);
+	}
+
+	vertex(float x, float y, float z, float w)
+	{
+		vec4(x, y, z, w);
+	}
+
+	vertex(int x, int y, int z, int w)
+	{
+		vec4(static_cast<f32>(x), static_cast<f32>(y), static_cast<f32>(z), static_cast<f32>(w));
+	}
+
+	float& operator[](int index)
+	{
+		return values[index];
+	}
+
+	void vec2(float x, float y)
+	{
+		values[0] = x;
+		values[1] = y;
+		values[2] = 0.f;
+		values[3] = 1.f;
+	}
+
+	void vec3(float x, float y, float z)
+	{
+		values[0] = x;
+		values[1] = y;
+		values[2] = z;
+		values[3] = 1.f;
+	}
+
+	void vec4(float x, float y, float z, float w)
+	{
+		values[0] = x;
+		values[1] = y;
+		values[2] = z;
+		values[3] = w;
+	}
+
+	void operator += (const vertex& other)
+	{
+		values[0] += other.values[0];
+		values[1] += other.values[1];
+		values[2] += other.values[2];
+		values[3] += other.values[3];
+	}
+
+	void operator -= (const vertex& other)
+	{
+		values[0] -= other.values[0];
+		values[1] -= other.values[1];
+		values[2] -= other.values[2];
+		values[3] -= other.values[3];
+	}
+};
+
+
+template<typename T>
+struct vector3_base : public position3_base<T>
+{
+	using position3_base<T>::position3_base;
+
+	vector3_base<T>(T x, T y, T z)
+	{
+		this->x = x;
+		this->y = y;
+		this->z = z;
+	}
+
+	vector3_base<T>(const position3_base<T>& other)
+	{
+		this->x = other.x;
+		this->y = other.y;
+		this->z = other.z;
+	}
+
+	T dot(const vector3_base<T>& rhs) const
+	{
+		return (this->x * rhs.x) + (this->y * rhs.y) + (this->z * rhs.z);
+	}
+
+	T distance(const vector3_base<T>& rhs) const
+	{
+		const vector3_base<T> d = *this - rhs;
+		return d.dot(d);
+	}
+};
+
+template<typename T>
+vector3_base<T> operator * (const vector3_base<T>& lhs, const vector3_base<T>& rhs)
+{
+	return { lhs.x * rhs.x, lhs.y * rhs.y, lhs.z * rhs.z };
+}
+
+template<typename T>
+vector3_base<T> operator * (const vector3_base<T>& lhs, T rhs)
+{
+	return { lhs.x * rhs, lhs.y * rhs, lhs.z * rhs };
+}
+
+template<typename T>
+vector3_base<T> operator * (T lhs, const vector3_base<T>& rhs)
+{
+	return { lhs * rhs.x, lhs * rhs.y, lhs * rhs.z };
+}
+
+template<typename T>
+void operator *= (const vector3_base<T>& lhs, const vector3_base<T>& rhs)
+{
+	lhs.x *= rhs.x;
+	lhs.y *= rhs.y;
+	lhs.z *= rhs.z;
+}
+
+template<typename T>
+void operator *= (const vector3_base<T>& lhs, T rhs)
+{
+	lhs.x *= rhs;
+	lhs.y *= rhs;
+	lhs.z *= rhs;
+}
+
+template<typename T>
+void operator < (const vector3_base<T>& lhs, T rhs)
+{
+	return lhs.x < rhs.x && lhs.y < rhs.y && lhs.z < rhs.z;
+}
+
+using vector3i = vector3_base<int>;
+using vector3f = vector3_base<float>;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -485,11 +485,10 @@ namespace rsx
 					do
 					{
 						start_time += period_time;
+						vblank_count++;
 
 						if (isHLE)
 						{
-							vblank_count++;
-
 							if (vblank_handler)
 							{
 								intr_thread->cmd_list

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -398,6 +398,7 @@
     <ClInclude Include="Emu\Io\Keyboard.h" />
     <ClInclude Include="Emu\RSX\Common\texture_cache_helpers.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_perf_metrics.h" />
+    <ClInclude Include="Emu\RSX\Overlays\overlay_utils.h" />
     <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.h" />
     <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.h" />
     <ClInclude Include="util\atomic.hpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1606,5 +1606,8 @@
     <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.h">
       <Filter>Emu\GPU\RSX\Overlays\Shaders</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\overlay_utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Instead of speed, direction and distance, the user now specifies start/end offsets and how much time the transition should take.

Fixes:
- Stuttering caused from framerate estimation.
- An edge case where animations would go over their supposed limit.

Adds:
- The ability to specify arbitrary easing functions for the animations
  - Implemented quadratic ease in and ease out and cubic ease in/out.
- Usage of cubic ease in/out in the trophy notification
