### PR TITLE
video: Remove pointless aspect ratio option 'Auto'

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
@@ -34,7 +34,6 @@ const extern std::unordered_map<video_resolution, CellVideoOutResolutionId, valu
 
 const extern std::unordered_map<video_aspect, CellVideoOutDisplayAspect, value_hash<video_aspect>> g_video_out_aspect_id
 {
-	{ video_aspect::_auto, CELL_VIDEO_OUT_ASPECT_AUTO },
 	{ video_aspect::_16_9, CELL_VIDEO_OUT_ASPECT_16_9 },
 	{ video_aspect::_4_3,  CELL_VIDEO_OUT_ASPECT_4_3 },
 };
@@ -61,11 +60,21 @@ void fmt_class_string<CellVideoOutError>::format(std::string& out, u64 arg)
 	});
 }
 
+error_code cellVideoOutGetNumberOfDevice(u32 videoOut);
+
 error_code cellVideoOutGetState(u32 videoOut, u32 deviceIndex, vm::ptr<CellVideoOutState> state)
 {
 	cellSysutil.trace("cellVideoOutGetState(videoOut=%d, deviceIndex=%d, state=*0x%x)", videoOut, deviceIndex, state);
 
-	if (deviceIndex) return CELL_VIDEO_OUT_ERROR_DEVICE_NOT_FOUND;
+	if (!state)
+	{
+		return CELL_VIDEO_OUT_ERROR_ILLEGAL_PARAMETER;
+	}
+
+	if (deviceIndex >= cellVideoOutGetNumberOfDevice(videoOut))
+	{
+		return CELL_VIDEO_OUT_ERROR_DEVICE_NOT_FOUND;
+	}
 
 	switch (videoOut)
 	{
@@ -183,6 +192,11 @@ error_code cellVideoOutGetConfiguration(u32 videoOut, vm::ptr<CellVideoOutConfig
 {
 	cellSysutil.warning("cellVideoOutGetConfiguration(videoOut=%d, config=*0x%x, option=*0x%x)", videoOut, config, option);
 
+	if (!config)
+	{
+		return CELL_VIDEO_OUT_ERROR_ILLEGAL_PARAMETER;
+	}
+
 	if (option) *option = {};
 	*config = {};
 
@@ -208,7 +222,15 @@ error_code cellVideoOutGetDeviceInfo(u32 videoOut, u32 deviceIndex, vm::ptr<Cell
 {
 	cellSysutil.warning("cellVideoOutGetDeviceInfo(videoOut=%d, deviceIndex=%d, info=*0x%x)", videoOut, deviceIndex, info);
 
-	if (deviceIndex) return CELL_VIDEO_OUT_ERROR_DEVICE_NOT_FOUND;
+	if (!info)
+	{
+		return CELL_VIDEO_OUT_ERROR_ILLEGAL_PARAMETER;
+	}
+
+	if (deviceIndex >= cellVideoOutGetNumberOfDevice(videoOut))
+	{
+		return CELL_VIDEO_OUT_ERROR_DEVICE_NOT_FOUND;
+	}
 
 	// Use standard dummy values for now.
 	info->portType = CELL_VIDEO_OUT_PORT_HDMI;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -157,7 +157,6 @@ void fmt_class_string<video_aspect>::format(std::string& out, u64 arg)
 	{
 		switch (value)
 		{
-		case video_aspect::_auto: return "Auto";
 		case video_aspect::_4_3: return "4:3";
 		case video_aspect::_16_9: return "16:9";
 		}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -152,7 +152,6 @@ enum class video_resolution
 
 enum class video_aspect
 {
-	_auto,
 	_4_3,
 	_16_9,
 };

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -115,7 +115,7 @@
 			"renderBox": "Vulkan is the fastest renderer. OpenGL is the most accurate renderer.\nIf unsure, use Vulkan. Should you have any compatibility issues, fall back to OpenGL.",
 			"resBox": "This setting will be ignored if the Resolution Scale is set to anything other than 100%!\nLeave this on 1280x720, every PS3 game is compatible with this resolution.\nOnly use 1920x1080 if the game supports it.\nRarely due to emulation bugs some games will only render at low resolutions like 480p.",
 			"graphicsAdapterBox": "On multi GPU systems select which GPU to use in RPCS3 when using Vulkan.\nThis is not needed when using OpenGL.",
-			"aspectBox": "Leave this on 16:9 unless you have a 4:3 monitor.\nAuto also works well, especially if you use a resolution that is not 720p.",
+			"aspectBox": "Leave this on 16:9 unless you have a 4:3 monitor.",
 			"frameLimitBox": "Off is the best option as it performs faster.\nUsing the frame limiter will add extra overhead and slow down the game.\nHowever, some games will crash if the frame rate is too high.\nIf that happens, set value to anything other than Off.",
 			"antiAliasing": "Emulate PS3 multisampling layout.\nCan fix some otherwise difficult to solve graphics glitches.\nLow to moderate performance hit depending on your GPU hardware.",
 			"anisotropicFilterOverride": "Higher values increase sharpness of textures on sloped surfaces at the cost of GPU resources.\nModern GPUs can handle this setting just fine even at 16x.\nKeep this on Automatic if you want to use the original setting used by a real PS3."


### PR DESCRIPTION
- The auto option is used when requesting the system is works like a "dont care" specifier to tell the system to use what settings have been passed in by HDMI EDID or the user TV type setting. Since this option simulates the "TV type setting", auto makes no sense and is also not something you can select on a PS3.