### PR TITLE
Embedded SPU elf patching

### DIFF
--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -39,4 +39,6 @@ public:
 
 	// Apply patch (returns the number of entries applied)
 	std::size_t apply(const std::string& name, u8* dst) const;
+	// Apply patch with a check that the address exists in SPU local storage
+	std::size_t apply_with_ls_check(const std::string&name, u8*dst, u32 filesz, u32 ls_addr) const;
 };

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1148,6 +1148,80 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	// Initialize HLE modules
 	ppu_initialize_modules(link);
 
+	// Embedded SPU elf patching
+	for (u32 i = _main->segs[0].addr; i < (_main->segs[0].addr + _main->segs[0].size); i += 4)
+	{
+		uchar* elf_header = vm::_ptr<u8>(i);
+		const spu_exec_object obj(fs::file(vm::base(vm::cast(i, HERE)), (_main->segs[0].addr + _main->segs[0].size) - i));
+
+		if (obj != elf_error::ok)
+		{
+			// This address does not have an SPU elf
+			continue;
+		}
+
+		// Segment info dump
+		std::string dump;
+
+		applied = 0;
+
+		// Executable hash 
+		sha1_context sha2;
+		sha1_starts(&sha2);
+		u8 sha1_hash[20];
+	
+		for (const auto& prog : obj.progs)
+		{
+			// Only hash the data, we are not loading it
+			sha1_update(&sha2, reinterpret_cast<const uchar*>(&prog.p_vaddr), sizeof(prog.p_vaddr));
+			sha1_update(&sha2, reinterpret_cast<const uchar*>(&prog.p_memsz), sizeof(prog.p_memsz));
+			sha1_update(&sha2, reinterpret_cast<const uchar*>(&prog.p_filesz), sizeof(prog.p_filesz));
+
+			fmt::append(dump, "\n\tSegment: p_type=0x%x, p_vaddr=0x%llx, p_filesz=0x%llx, p_memsz=0x%llx, p_offset=0x%llx", prog.p_type, prog.p_vaddr, prog.p_filesz, prog.p_memsz, prog.p_offset);
+
+			if (prog.p_type == 0x1 /* LOAD */ && prog.p_filesz > 0)
+			{
+				sha1_update(&sha2, (elf_header + prog.p_offset), prog.p_filesz);
+			}
+
+			else if (prog.p_type == 0x4 /* NOTE */ && prog.p_filesz > 0)
+			{
+				sha1_update(&sha2, (elf_header + prog.p_offset), prog.p_filesz);
+
+				// We assume that the string SPUNAME exists 0x14 bytes into the NOTE segment
+				const auto spu_name = reinterpret_cast<const char*>(elf_header + prog.p_offset + 0x14);
+				fmt::append(dump, "\n\tSPUNAME: '%s'", spu_name);
+			}
+		}
+		
+		sha1_finish(&sha2, sha1_hash);
+
+		// Format patch name
+		std::string hash("SPU-0000000000000000000000000000000000000000");
+		for (u32 i = 0; i < sizeof(sha1_hash); i++)
+		{
+			constexpr auto pal = "0123456789abcdef";
+			hash[4 + i * 2] = pal[sha1_hash[i] >> 4];
+			hash[5 + i * 2] = pal[sha1_hash[i] & 15];
+		}
+
+		// Try to patch each segment, will only succeed if the address exists in SPU local storage
+		for (const auto& prog : obj.progs)
+		{
+			// Apply the patch
+			applied += g_fxo->get<patch_engine>()->apply_with_ls_check(hash, (elf_header + prog.p_offset), prog.p_filesz, prog.p_vaddr);
+
+			if (!Emu.GetTitleID().empty())
+			{
+				// Alternative patch
+				applied += g_fxo->get<patch_engine>()->apply_with_ls_check(Emu.GetTitleID() + '-' + hash, (elf_header + prog.p_offset), prog.p_filesz, prog.p_vaddr);
+			}
+		}
+
+		LOG_NOTICE(LOADER, "SPU executable hash: %s (<- %u)%s", hash, applied, dump);
+		
+	}
+
 	// Static HLE patching
 	if (g_cfg.core.hook_functions)
 	{


### PR DESCRIPTION
Adds a system for finding SPU code that was embedded in PPU executables, and allows us to patch it before it is loaded by any game code. Also prints the SPUNAME if it exists in the note section.

Patches for this system still use SPU LS (Local Storage) addresses despite the fact that we aren't loading anything into SPU LS at this time. The patch addresses are checked against each segment and patched in place.

The motivation for this was brought on by the gains that can be seen when patching out SPU EDGE MLAA (A library created by Sony to do a form of post processing anti aliasing on the CPU!) out of games. Depending on the game, framerates gains of about 15-400% can be seen from removing this effect. But rather than patching every game, every version and region of that game, It seemed more reasonable to develop a system to patch each version of the library, and have it automatically apply to each game that loads the library.

Note that this doesn't solve resolution issues with MLAA, it only skips work done on the SPU side.

Currently ~~18~~ ~~20~~ ~~25~~ ~~31~~ 33 games are known to be patched, but this library saw wide usage, and there are probably at least over 50 games that used the library. Sadly some of the games that use it load it from somewhere else, and cannot be patched with this method.

edit: Note that the library first appeared in god of war 3, it's only worth testing games released after that (March 16, 2010).

Use this patch with this PR. 
https://cdn.discordapp.com/attachments/442667232489897997/671145486299824129/patch.yml
edit: updated to version 1.3