### PR TITLE
Smoother batch package installation

### DIFF
--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -130,7 +130,7 @@ void game_compatibility::RequestCompatibility(bool online)
 	QNetworkReply* network_reply = m_network_access_manager->get(m_network_request);
 
 	// Show Progress
-	m_progress_dialog = new progress_dialog(tr("Downloading Database"), tr(".Please wait."), tr("Abort"), 0, 100);
+	m_progress_dialog = new progress_dialog(tr("Downloading Database"), tr(".Please wait."), tr("Abort"), 0, 100, true);
 	m_progress_dialog->show();
 
 	// Animate progress dialog a bit more

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1373,7 +1373,7 @@ void game_list_frame::BatchCreatePPUCaches()
 		return;
 	}
 
-	progress_dialog* pdlg = new progress_dialog(tr("PPU Cache Batch Creation"), tr("Creating all PPU caches"), tr("Cancel"), 0, total, this);
+	progress_dialog* pdlg = new progress_dialog(tr("PPU Cache Batch Creation"), tr("Creating all PPU caches"), tr("Cancel"), 0, total, true, this);
 	pdlg->setAutoClose(false);
 	pdlg->setAutoReset(false);
 	pdlg->show();
@@ -1418,7 +1418,7 @@ void game_list_frame::BatchRemovePPUCaches()
 		return;
 	}
 
-	progress_dialog* pdlg = new progress_dialog(tr("PPU Cache Batch Removal"), tr("Removing all PPU caches"), tr("Cancel"), 0, total, this);
+	progress_dialog* pdlg = new progress_dialog(tr("PPU Cache Batch Removal"), tr("Removing all PPU caches"), tr("Cancel"), 0, total, true, this);
 	pdlg->setAutoClose(false);
 	pdlg->setAutoReset(false);
 	pdlg->show();
@@ -1503,7 +1503,7 @@ void game_list_frame::BatchRemoveCustomConfigurations()
 		return;
 	}
 
-	progress_dialog* pdlg = new progress_dialog(tr("Custom Configuration Batch Removal"), tr("Removing all custom configurations"), tr("Cancel"), 0, total, this);
+	progress_dialog* pdlg = new progress_dialog(tr("Custom Configuration Batch Removal"), tr("Removing all custom configurations"), tr("Cancel"), 0, total, true, this);
 	pdlg->setAutoClose(false);
 	pdlg->setAutoReset(false);
 	pdlg->show();
@@ -1548,7 +1548,7 @@ void game_list_frame::BatchRemoveCustomPadConfigurations()
 		return;
 	}
 
-	progress_dialog* pdlg = new progress_dialog(tr("Custom Pad Configuration Batch Removal"), tr("Removing all custom pad configurations"), tr("Cancel"), 0, total, this);
+	progress_dialog* pdlg = new progress_dialog(tr("Custom Pad Configuration Batch Removal"), tr("Removing all custom pad configurations"), tr("Cancel"), 0, total, true, this);
 	pdlg->setAutoClose(false);
 	pdlg->setAutoReset(false);
 	pdlg->show();
@@ -1590,7 +1590,7 @@ void game_list_frame::BatchRemoveShaderCaches()
 		return;
 	}
 
-	progress_dialog* pdlg = new progress_dialog(tr("Shader Cache Batch Removal"), tr("Removing all shader caches"), tr("Cancel"), 0, total, this);
+	progress_dialog* pdlg = new progress_dialog(tr("Shader Cache Batch Removal"), tr("Removing all shader caches"), tr("Cancel"), 0, total, true, this);
 	pdlg->setAutoClose(false);
 	pdlg->setAutoReset(false);
 	pdlg->show();

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -116,7 +116,7 @@ private:
 	void CreateDockWindows();
 	void EnableMenus(bool enabled);
 	void ShowTitleBars(bool show);
-	bool InstallPkg(QString filePath = "", bool show_confirm = true, bool show_success = true);
+	void InstallPackages(QStringList file_paths = QStringList(), bool show_confirm = true);
 	void InstallPup(QString filePath = "");
 
 	int IsValidFile(const QMimeData& md, QStringList* dropPaths = nullptr);

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -2,14 +2,18 @@
 
 #include <QLabel>
 
-progress_dialog::progress_dialog(const QString &windowTitle, const QString &labelText, const QString &cancelButtonText, int minimum, int maximum, QWidget *parent, Qt::WindowFlags flags)
+progress_dialog::progress_dialog(const QString &windowTitle, const QString &labelText, const QString &cancelButtonText, int minimum, int maximum, bool delete_on_close, QWidget *parent, Qt::WindowFlags flags)
 	: QProgressDialog(labelText, cancelButtonText, minimum, maximum, parent, flags)
 {
 	setWindowTitle(windowTitle);
 	setFixedSize(QLabel("This is the very length of the progressdialog due to hidpi reasons.").sizeHint().width(), sizeHint().height());
 	setValue(0);
 	setWindowModality(Qt::WindowModal);
-	connect(this, &QProgressDialog::canceled, this, &QProgressDialog::deleteLater);
+
+	if (delete_on_close)
+	{
+		connect(this, &QProgressDialog::canceled, this, &QProgressDialog::deleteLater);
+	}
 
 #ifdef _WIN32
 	m_tb_button = std::make_unique<QWinTaskbarButton>();

--- a/rpcs3/rpcs3qt/progress_dialog.h
+++ b/rpcs3/rpcs3qt/progress_dialog.h
@@ -17,7 +17,7 @@
 class progress_dialog : public QProgressDialog
 {
 public:
-	progress_dialog(const QString &windowTitle, const QString &labelText, const QString &cancelButtonText, int minimum, int maximum, QWidget *parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
+	progress_dialog(const QString &windowTitle, const QString &labelText, const QString &cancelButtonText, int minimum, int maximum, bool delete_on_close, QWidget *parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
 	~progress_dialog();
 	void SetValue(int progress);
 	void SignalFailure();

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -59,7 +59,7 @@ void update_manager::check_for_updates(bool automatic, QWidget* parent)
 	const std::string request_url = m_update_url + rpcs3::get_commit_and_hash().second;
 	QNetworkReply* reply_json     = m_manager.get(QNetworkRequest(QUrl(QString::fromStdString(request_url))));
 
-	m_progress_dialog = new progress_dialog(tr("Checking For Updates"), tr("Please wait..."), tr("Abort"), 0, 100, parent);
+	m_progress_dialog = new progress_dialog(tr("Checking For Updates"), tr("Please wait..."), tr("Abort"), 0, 100, true, parent);
 	m_progress_dialog->setAutoClose(false);
 	m_progress_dialog->setAutoReset(false);
 	m_progress_dialog->show();


### PR DESCRIPTION
Improve batch package installation:
Currently - when installing multiple .pkg files - a dialog will pop up and close itself for each file with a generic message and you don't have any indication on how far the installation has proceeded. This can get annoying if you install let's say 20 patches for Gran Turismo 6.

So I unified all installations into one dialog that stays opened until all files are installed or you cancel the installation. The dialog still tracks progress for each pkg seperately, but the message was improved in order to show how many packages are left.

I also added a new parameter to the progress_dialog that patches a bug which causes the whole application to terminate when you cancel the pkg installation.

But: package installation can't be canceled immediately, so once you cancel it the current package will still be installed in the background, even though the dialog was already closed.