### PR TITLE
Minor spu_thread::cpu_init() optimization

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1033,7 +1033,7 @@ std::string spu_thread::dump() const
 
 void spu_thread::cpu_init()
 {
-	gpr = {};
+	std::memset(gpr.data(), 0, gpr.size() * sizeof(gpr[0]));
 	fpscr.Reset();
 
 	ch_mfc_cmd = {};


### PR DESCRIPTION
* Use c++'s placement-new feature to assign values in a few places to allow/force optimizations.
This also allows to initialize structures which are non-copy constructible such if the type is atomic_t or one of its members is.

Examples:
* In spu_thread::cpu_init() : Initailizing spu_thread::gpr by `gpr = {};` was actually constructing a temporary std::array<v128, 128> object on the stack and then copying it into spu_thread::gpr on MSVC, now only default-initialize with memset 0 as intended.
Before:
![image](https://user-images.githubusercontent.com/18193363/72138046-9b2fd100-3394-11ea-9ad7-2a94a588d549.png)
After:
![image](https://user-images.githubusercontent.com/18193363/72137556-ae8e6c80-3393-11ea-818c-114b9ac3a56f.png)
* In spu_thread::cpu_init(): Avoid using atomic instructions in spu_thread::ch_in_mbox initialization. 
* Force copy-elision when assigning std::shared_ptr object in idm::create_id().
