### PR TITLE
Minor accuracy improvements for cellFsGetFreeSize

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1838,7 +1838,13 @@ error_code sys_fs_lsn_lock(ppu_thread& ppu, u32 fd)
 		return CELL_EBADF;
 	}
 
-	// TODO: seems to do nothing
+	// TODO: seems to do nothing on /dev_hdd0 or /host_root
+	if (file->mp == &g_mp_sys_dev_hdd0 || file->mp->flags & lv2_mp_flag::strict_get_block_size)
+	{
+		return CELL_OK;
+	}
+
+	file->lock.compare_and_swap(0, 1);
 	return CELL_OK;
 }
 
@@ -1853,7 +1859,8 @@ error_code sys_fs_lsn_unlock(ppu_thread& ppu, u32 fd)
 		return CELL_EBADF;
 	}
 
-	// TODO: seems to do nothing
+	// Unlock unconditionally
+	file->lock.compare_and_swap(1, 0);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -22,7 +22,7 @@ struct lv2_fs_mount_point
 lv2_fs_mount_point g_mp_sys_dev_hdd0;
 lv2_fs_mount_point g_mp_sys_dev_hdd1{512, 32768, lv2_mp_flag::no_uid_gid};
 lv2_fs_mount_point g_mp_sys_dev_usb{512, 4096, lv2_mp_flag::no_uid_gid};
-lv2_fs_mount_point g_mp_sys_dev_bdvd{2048, 2048, lv2_mp_flag::read_only + lv2_mp_flag::no_uid_gid};
+lv2_fs_mount_point g_mp_sys_dev_bdvd{2048, 65536, lv2_mp_flag::read_only + lv2_mp_flag::no_uid_gid};
 lv2_fs_mount_point g_mp_sys_app_home{512, 512, lv2_mp_flag::strict_get_block_size + lv2_mp_flag::no_uid_gid};
 lv2_fs_mount_point g_mp_sys_host_root{512, 512, lv2_mp_flag::strict_get_block_size + lv2_mp_flag::no_uid_gid};
 

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -237,9 +237,9 @@ std::string vfs::get(std::string_view vpath, std::vector<std::string>* out_dir, 
 
 				if (dir.second.path == "/"sv)
 				{
-					if (vpath.empty())
+					if (vpath.size() <= 1)
 					{
-						return {};
+						return fs::get_config_dir() + "delete_this_dir.../delete_this...";
 					}
 
 					// Handle /host_root (not escaped, not processed)


### PR DESCRIPTION
On Windows, GetDiskFreeSpaceExW is limited since it doesn't properly support long paths. It could be a problem but doesn't seem to be, since on PS3 similar functions are limited in a specific way to be able to obtain free space only by mountpoint name.