### PR TITLE
Update Appveyor to Qt 5.14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ version: '{build}'
 image: Visual Studio 2019
 
 environment:
-  QTDIR: C:\Qt\5.13\msvc2017_64
+  QTDIR: C:\Qt\5.14\msvc2017_64
   QT_URL: https://cdn.discordapp.com/attachments/442667232489897997/614126952953020416/msvc2017_64.7z
   LLVMLIBS: https://github.com/RPCS3/llvm/releases/download/continuous-master/llvmlibs.7z
   GLSLANG: https://www.dropbox.com/s/6e8w6t5dxh3ad4l/glslang.7z?dl=1


### PR DESCRIPTION
Update Appveyor to Qt 5.14.
This will mainly improve high dpi settings.

#### NOTES
- The environment variable QT_AUTO_SCREEN_SCALE_FACTOR was changed to QT_ENABLE_HIGHDPI_SCALING.
- The environment variable QT_SCALE_FACTOR_ROUNDING_POLICY was added and we default to Qt::PassThrough, which means that we don't round zoom factors anymore (e.g. 150% > 100%).
See https://doc.qt.io/qt-5/qt.html#HighDpiScaleFactorRoundingPolicy-enum

Should fix #5455
Partially handles #7204 