### PR TITLE
rsx: FIFO wake-up pause control

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -477,20 +477,21 @@ namespace rsx
 			fmt::throw_exception("Unexpected command 0x%x" HERE, cmd);
 		}
 
-		if (performance_counters.state != FIFO_state::running)
+		if (const auto state = performance_counters.state;
+			state != FIFO_state::running)
 		{
-			//Update performance counters with time spent in idle mode
-			performance_counters.idle_time += (get_system_time() - performance_counters.FIFO_idle_timestamp);
+			performance_counters.state = FIFO_state::running;
 
-			if (performance_counters.state == FIFO_state::spinning)
+			// Hack: Delay FIFO wake-up according to setting
+			// NOTE: The typical spin setup is a NOP followed by a jump-to-self
+			// NOTE: There is a small delay when the jump address is dynamically edited by cell
+			if (state != FIFO_state::nop)
 			{
-				//TODO: Properly simulate FIFO wake delay.
-				//NOTE: The typical spin setup is a NOP followed by a jump-to-self
-				//NOTE: There is a small delay when the jump address is dynamically edited by cell
-				busy_wait(3000);
+				fifo_wake_delay();
 			}
 
-			performance_counters.state = FIFO_state::running;
+			// Update performance counters with time spent in idle mode
+			performance_counters.idle_time += (get_system_time() - performance_counters.FIFO_idle_timestamp);
 		}
 
 		do

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2245,6 +2245,61 @@ namespace rsx
 		}
 	}
 
+	void thread::fifo_wake_delay(u64 div)
+	{
+		// TODO: Nanoseconds accuracy
+		u64 remaining = g_cfg.video.driver_wakeup_delay;
+
+		if (!remaining)
+		{
+			return;
+		}
+
+		// Some cases do not need full delay
+		remaining = ::aligned_div(remaining, div);
+		const u64 until = get_system_time() + remaining;
+
+		while (true)
+		{
+#ifdef __linux__
+			// NOTE: Assumption that timer initialization has succeeded
+			u64 host_min_quantum = remaining <= 1000 ? 10 : 50;
+#else
+			// Host scheduler quantum for windows (worst case)
+			// NOTE: On ps3 this function has very high accuracy
+			constexpr u64 host_min_quantum = 500;
+#endif
+			if (remaining >= host_min_quantum)
+			{
+#ifdef __linux__
+				// Do not wait for the last quantum to avoid loss of accuracy
+				thread_ctrl::wait_for(remaining - ((remaining % host_min_quantum) + host_min_quantum), false);
+#else
+				// Wait on multiple of min quantum for large durations to avoid overloading low thread cpus
+				thread_ctrl::wait_for(remaining - (remaining % host_min_quantum), false);
+#endif
+			}
+			// TODO: Determine best value for yield delay
+			else if (remaining >= host_min_quantum / 2)
+			{
+				std::this_thread::yield();
+			}
+			else
+			{
+				busy_wait(100);
+			}
+
+			const u64 current = get_system_time();
+
+			if (current >= until)
+			{
+				break;
+			}
+
+			remaining = until - current;
+		}
+	}
+
 	u32 thread::get_fifo_cmd()
 	{
 		// Last fifo cmd for logging and utility

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -607,6 +607,7 @@ namespace rsx
 		atomic_t<bool> external_interrupt_ack{ false };
 		void flush_fifo();
 		void recover_fifo();
+		void fifo_wake_delay(u64 div = 1);
 		u32 get_fifo_cmd();
 
 		// Performance approximation counters

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -76,9 +76,23 @@ namespace rsx
 			const auto& sema = vm::_ref<atomic_be_t<u32>>(addr);
 
 			// TODO: Remove vblank semaphore hack
-			if (sema == arg || addr == rsx->device_addr + 0x30) return;
+			if (addr == rsx->device_addr + 0x30) return;
 
-			rsx->flush_fifo();
+			if (sema == arg)
+			{
+				// Flip semaphore doesnt need wake-up delay
+				if (addr != rsx->label_addr + 0x10)
+				{
+					rsx->flush_fifo();
+					rsx->fifo_wake_delay(2);
+				}
+
+				return;
+			}
+			else
+			{
+				rsx->flush_fifo();
+			}
 
 			u64 start = get_system_time();
 			while (sema != arg)
@@ -113,6 +127,7 @@ namespace rsx
 				std::this_thread::yield();
 			}
 
+			rsx->fifo_wake_delay();
 			rsx->performance_counters.idle_time += (get_system_time() - start);
 		}
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -502,7 +502,8 @@ struct cfg_root : cfg::node
 		cfg::_int<50, 800> resolution_scale_percent{this, "Resolution Scale", 100};
 		cfg::_int<0, 16> anisotropic_level_override{this, "Anisotropic Filter Override", 0};
 		cfg::_int<1, 1024> min_scalable_dimension{this, "Minimum Scalable Dimension", 16};
-		cfg::_int<0, 30000000> driver_recovery_timeout{this, "Driver Recovery Timeout", 1000000};
+		cfg::_int<0, 30000000> driver_recovery_timeout{this, "Driver Recovery Timeout", 1000000, true};
+		cfg::_int<0, 16667> driver_wakeup_delay{this, "Driver Wake-Up Delay", 1, true};
 		cfg::_int<1, 500> vblank_rate{this, "Vblank Rate", 60}; // Changing this from 60 may affect game speed in unexpected ways
 
 		struct node_vk : cfg::node

--- a/rpcs3/Json/tooltips.json
+++ b/rpcs3/Json/tooltips.json
@@ -17,6 +17,7 @@
 		"sleepTimersAccuracy": "Changes the sleep period accuracy.\n'As Host' uses default accuracy of the underlying operating system, while 'All Timers' attempts to improve it.\n'Usleep Only' limits the adjustments to usleep syscall only.\nCan affect perfomance in unexpected ways.",
 		"vblankRate": "Adjusts the frequency of vertical blanking signals that the emulator sends.\nAffects timing of events which rely on these signals.",
 		"clocksScale": "Changes the scale of emulated system time.\nAffects software which uses system time to calculate things such as dynamic timesteps.",
+		"wakeupDelay": "Try fiddling with this setting when encountering unstable games. The higher value, the better stability it may provide.\nIncrements/Decrements for each test should be around 100μs to 200μs until finding the best value for optimal stability.\nValues above 1000μs may cause noticeable performance penalties, use with caution.",
 		"disabledFromGlobal": "Do not change this setting globally.\nRight-click the game in game list and choose \"Configure\" instead."
 	},
 	"audio": {

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -84,6 +84,7 @@ public:
 		MultithreadedRSX,
 		VBlankRate,
 		RelaxedZCULL,
+		DriverWakeUpDelay,
 
 		// Performance Overlay
 		PerfOverlayEnabled,
@@ -315,6 +316,7 @@ private:
 		{ MinimumScalableDimension,   { "Video", "Minimum Scalable Dimension"}},
 		{ VulkanAdapter,              { "Video", "Vulkan", "Adapter"}},
 		{ VBlankRate,                 { "Video", "Vblank Rate"}},
+		{ DriverWakeUpDelay,          { "Video", "Driver Wake-Up Delay"}},
 
 		// Performance Overlay
 		{ PerfOverlayEnabled,               { "Video", "Performance Overlay", "Enabled" } },

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -945,6 +945,13 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 
 	// Sliders
 
+	EnhanceSlider(emu_settings::DriverWakeUpDelay, ui->wakeupDelay, ui->wakeupText, tr(u8"%0 µs"));
+	int wakeupDef = stoi(xemu_settings->GetSettingDefault(emu_settings::DriverWakeUpDelay));
+	connect(ui->wakeupReset, &QAbstractButton::clicked, [=]()
+	{
+		ui->wakeupDelay->setValue(wakeupDef);
+	});
+
 	EnhanceSlider(emu_settings::VBlankRate, ui->vblank, ui->vblankText, tr("%0 Hz"));
 	int vblankDef = stoi(xemu_settings->GetSettingDefault(emu_settings::VBlankRate));
 	connect(ui->vblankReset, &QAbstractButton::clicked, [=]()

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -974,11 +974,15 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 		ui->clockScale->setDisabled(true);
 		ui->clockScaleReset->setDisabled(true);
 		SubscribeTooltip(ui->clockScale, json_advanced["disabledFromGlobal"].toString());
+		ui->wakeupDelay->setDisabled(true);
+		ui->wakeupReset->setDisabled(true);
+		SubscribeTooltip(ui->wakeupDelay, json_advanced["disabledFromGlobal"].toString());
 	}
 	else
 	{
 		SubscribeTooltip(ui->vblank, json_advanced["vblankRate"].toString());
 		SubscribeTooltip(ui->clockScale, json_advanced["clocksScale"].toString());
+		SubscribeTooltip(ui->wakeupDelay, json_advanced["wakeupDelay"].toString());
 	}
 
 	// lib options tool tips

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1760,6 +1760,49 @@
             </widget>
            </item>
            <item>
+            <widget class="QGroupBox" name="gb_wakeupDelay">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="title">
+              <string>Driver Wake-Up Delay</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_92">
+              <item>
+               <widget class="QSlider" name="wakeupDelay">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_31" stretch="1,0">
+                <item>
+                 <widget class="QLabel" name="wakeupText">
+                  <property name="text">
+                   <string>1 µs</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="wakeupReset">
+                  <property name="text">
+                   <string>Reset</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
             <widget class="QGroupBox" name="gb_vblank">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">


### PR DESCRIPTION
This attempts to provide a workaround for a very old problem with emulation: because usually emulators choose performance and simplicty of code over cycle accuracy, some programs may not work well because of it.
In PS3 emulation this problem is generally expressed as "RSX desyncs". Whats causing those desyncs usually is that the RSX executed more code than what Cell (PPU/SPU) already prepared for it, due to "design optimizations" in many games the RSX does not always stops and waits for the Cell to write more code for it to execute.
This worked in realps3 because the Cell always won the race and provided more code than what RSX already executed.
The workaround here attempts to delay, according to setting, the RSX wake-up just about there may be an important synchronization point, allowing Cell to potentially write more code for RSX in this time.

## For testers:
Test games stability with unstable games, preferrably ones with RSX errors in log but not only.
The longer the wake-up pause, the better stability it may provide at the cost of performance.
The setting is found at "advanced" settings tab, also the setting updates dynamically.
So if one area of game is more/less stable than others, you can change the setting mid-game.
The default setting's value is nearly no pause so you should increase that for testing.
The pause length is measured in microseconds.