### PR TITLE
pad_settings: show ds4 battery status in UI; use LED as an indicator

### DIFF
--- a/Utilities/Config.h
+++ b/Utilities/Config.h
@@ -126,7 +126,7 @@ namespace cfg
 		atomic_t<bool> m_value;
 
 	public:
-		const bool def;
+		bool def;
 
 		_bool(node* owner, const std::string& name, bool def = false, bool dynamic = false)
 			: _base(type::_bool, owner, name, dynamic)

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -317,7 +317,7 @@ void PadHandlerBase::init_configs()
 	}
 }
 
-void PadHandlerBase::get_next_button_press(const std::string& pad_id, const std::function<void(u16, std::string, std::string, std::array<int, 6>)>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& /*buttons*/)
+void PadHandlerBase::get_next_button_press(const std::string& pad_id, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& /*buttons*/)
 {
 	if (get_blacklist)
 		blacklist.clear();
@@ -369,11 +369,12 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const std:
 	}
 
 	const auto preview_values = get_preview_values(data);
+	const auto battery_level = get_battery_level(pad_id);
 
 	if (pressed_button.first > 0)
-		return callback(pressed_button.first, pressed_button.second, pad_id, preview_values);
+		return callback(pressed_button.first, pressed_button.second, pad_id, battery_level, preview_values);
 	else
-		return callback(0, "", pad_id, preview_values);
+		return callback(0, "", pad_id, battery_level, preview_values);
 
 	return;
 }

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -276,6 +276,11 @@ bool PadHandlerBase::has_led() const
 	return b_has_led;
 }
 
+bool PadHandlerBase::has_battery() const
+{
+	return b_has_battery;
+}
+
 std::string PadHandlerBase::get_config_dir(pad_handler type, const std::string& title_id)
 {
 	if (!title_id.empty())

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -63,6 +63,7 @@ protected:
 	int m_thumb_threshold = 0;
 
 	bool b_has_led = false;
+	bool b_has_battery = false;
 	bool b_has_deadzones = false;
 	bool b_has_rumble = false;
 	bool b_has_config = false;
@@ -134,6 +135,7 @@ public:
 	bool has_rumble() const;
 	bool has_deadzones() const;
 	bool has_led() const;
+	bool has_battery() const;
 
 	static std::string get_config_dir(pad_handler type, const std::string& title_id = "");
 	static std::string get_config_filename(int i, const std::string& title_id = "");
@@ -142,7 +144,9 @@ public:
 	PadHandlerBase(pad_handler type = pad_handler::null);
 	virtual ~PadHandlerBase() = default;
 	// Sets window to config the controller(optional)
-	virtual void SetPadData(const std::string& /*padId*/, u32 /*largeMotor*/, u32 /*smallMotor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/) {}
+	virtual void SetPadData(const std::string& /*padId*/, u32 /*largeMotor*/, u32 /*smallMotor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/) {}
+	virtual u32 get_battery_level(const std::string& /*padId*/) { return 0; }
+	virtual bool get_device_init(const std::string& /*padId*/) { return false; };
 	// Return list of devices for that handler
 	virtual std::vector<std::string> ListDevices() = 0;
 	// Callback called during pad_thread::ThreadFunc

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -11,6 +11,10 @@ struct PadDevice
 	pad_config* config{ nullptr };
 };
 
+using pad_preview_values = std::array<int, 6>;
+using pad_callback = std::function<void(u16 /*button_value*/, std::string /*button_name*/, std::string /*pad_name*/, u32 /*battery_level*/, pad_preview_values /*preview_values*/)>;
+using pad_fail_callback = std::function<void(std::string /*pad_name*/)>;
+
 class PadHandlerBase
 {
 protected:
@@ -146,7 +150,6 @@ public:
 	// Sets window to config the controller(optional)
 	virtual void SetPadData(const std::string& /*padId*/, u32 /*largeMotor*/, u32 /*smallMotor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/) {}
 	virtual u32 get_battery_level(const std::string& /*padId*/) { return 0; }
-	virtual bool get_device_init(const std::string& /*padId*/) { return false; };
 	// Return list of devices for that handler
 	virtual std::vector<std::string> ListDevices() = 0;
 	// Callback called during pad_thread::ThreadFunc
@@ -154,7 +157,7 @@ public:
 	// Binds a Pad to a device
 	virtual bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device);
 	virtual void init_config(pad_config* /*cfg*/, const std::string& /*name*/) = 0;
-	virtual void get_next_button_press(const std::string& padId, const std::function<void(u16, std::string, std::string, std::array<int, 6>)>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons = {});
+	virtual void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons = {});
 
 private:
 	virtual std::shared_ptr<PadDevice> get_device(const std::string& /*device*/) { return nullptr; };
@@ -166,7 +169,7 @@ private:
 	virtual void get_extended_info(const std::shared_ptr<PadDevice>& /*device*/, const std::shared_ptr<Pad>& /*pad*/) {};
 	virtual void apply_pad_data(const std::shared_ptr<PadDevice>& /*device*/, const std::shared_ptr<Pad>& /*pad*/) {};
 	virtual std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& /*device*/) { return {}; };
-	virtual std::array<int, 6> get_preview_values(std::unordered_map<u64, u16> /*data*/) { return {}; };
+	virtual pad_preview_values get_preview_values(std::unordered_map<u64, u16> /*data*/) { return {}; };
 
 protected:
 	virtual std::array<u32, PadHandlerBase::button::button_count> get_mapped_key_codes(const std::shared_ptr<PadDevice>& /*device*/, const pad_config* profile);

--- a/rpcs3/Emu/Io/pad_config.h
+++ b/rpcs3/Emu/Io/pad_config.h
@@ -75,6 +75,10 @@ struct pad_config final : cfg::node
 	cfg::_int<0, 255> colorG{ this, "Color Value G", 0 };
 	cfg::_int<0, 255> colorB{ this, "Color Value B", 0 };
 
+	cfg::_bool led_low_battery_blink{ this, "Blink LED when battery is below 20%", true };
+	cfg::_bool led_battery_indicator{ this, "Use LED as a battery indicator", false };
+	cfg::_int<0, 100> led_battery_indicator_brightness{ this, "LED battery indicator brightness", 50 };
+
 	cfg::_bool enable_vibration_motor_large{ this, "Enable Large Vibration Motor", true };
 	cfg::_bool enable_vibration_motor_small{ this, "Enable Small Vibration Motor", true };
 	cfg::_bool switch_vibration_motors{ this, "Switch Vibration Motors", false };

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -370,7 +370,7 @@ std::unordered_map<u64, u16> ds3_pad_handler::get_button_values(const std::share
 	return key_buf;
 }
 
-std::array<int, 6> ds3_pad_handler::get_preview_values(std::unordered_map<u64, u16> data)
+pad_preview_values ds3_pad_handler::get_preview_values(std::unordered_map<u64, u16> data)
 {
 	return { data[L2], data[R2], data[LSXPos] - data[LSXNeg], data[LSYPos] - data[LSYNeg], data[RSXPos] - data[RSXNeg], data[RSYPos] - data[RSYNeg] };
 }

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -153,7 +153,7 @@ std::vector<std::string> ds3_pad_handler::ListDevices()
 	return ds3_pads_list;
 }
 
-void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 /* b*/)
+void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 /* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
 	std::shared_ptr<ds3_device> device = get_ds3_device(padId);
 	if (device == nullptr || device->handle == nullptr)

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -98,7 +98,7 @@ public:
 	bool Init() override;
 
 	std::vector<std::string> ListDevices() override;
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b) override;
+	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -121,5 +121,5 @@ private:
 	void get_extended_info(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;
 	void apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;
 	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	std::array<int, 6> get_preview_values(std::unordered_map<u64, u16> data) override;
+	pad_preview_values get_preview_values(std::unordered_map<u64, u16> data) override;
 };

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -391,7 +391,7 @@ std::unordered_map<u64, u16> ds4_pad_handler::get_button_values(const std::share
 	return keyBuffer;
 }
 
-std::array<int, 6> ds4_pad_handler::get_preview_values(std::unordered_map<u64, u16> data)
+pad_preview_values ds4_pad_handler::get_preview_values(std::unordered_map<u64, u16> data)
 {
 	return { data[L2], data[R2], data[LSXPos] - data[LSXNeg], data[LSYPos] - data[LSYNeg], data[RSXPos] - data[RSXNeg], data[RSYPos] - data[RSYNeg] };
 }
@@ -780,16 +780,6 @@ std::shared_ptr<PadDevice> ds4_pad_handler::get_device(const std::string& device
 		return nullptr;
 
 	return ds4device;
-}
-
-bool ds4_pad_handler::get_device_init(const std::string& padId)
-{
-	std::shared_ptr<DS4Device> device = GetDS4Device(padId);
-	if (device == nullptr || device->hidDevice == nullptr)
-	{
-		return false;
-	}
-	return device->is_initialized;
 }
 
 bool ds4_pad_handler::get_is_left_trigger(u64 keyCode)

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -109,7 +109,6 @@ public:
 	std::vector<std::string> ListDevices() override;
 	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
-	bool get_device_init(const std::string& padId) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:
@@ -149,5 +148,5 @@ private:
 	void get_extended_info(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;
 	void apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;
 	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	std::array<int, 6> get_preview_values(std::unordered_map<u64, u16> data) override;
+	pad_preview_values get_preview_values(std::unordered_map<u64, u16> data) override;
 };

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -84,9 +84,11 @@ class ds4_pad_handler final : public PadHandlerBase
 		u8 smallVibrate{ 0 };
 		std::array<u8, 64> padData{};
 		u8 batteryLevel{ 0 };
+		u8 last_battery_level { 0 };
 		u8 cableState{ 0 };
 		u8 led_delay_on{ 0 };
 		u8 led_delay_off{ 0 };
+		bool is_initialized{ false };
 	};
 
 	const u16 DS4_VID = 0x054C;
@@ -105,12 +107,15 @@ public:
 	bool Init() override;
 
 	std::vector<std::string> ListDevices() override;
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b) override;
+	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
+	u32 get_battery_level(const std::string& padId) override;
+	bool get_device_init(const std::string& padId) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:
 	bool is_init = false;
 	DS4DataStatus status;
+	u32 get_battery_color(u8 battery_level, int brightness);
 
 private:
 	std::shared_ptr<DS4Device> GetDS4Device(const std::string& padId, bool try_reconnect = false);

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -493,7 +493,7 @@ void evdev_joystick_handler::SetRumble(std::shared_ptr<EvdevDevice>device, u16 l
 	device->force_small = small;
 }
 
-void evdev_joystick_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32/* b*/)
+void evdev_joystick_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 /* r*/, s32 /* g*/, s32 /* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
 	// Get our evdev device
 	auto dev = get_evdev_device(padId);

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -270,7 +270,7 @@ std::shared_ptr<evdev_joystick_handler::EvdevDevice> evdev_joystick_handler::get
 	return std::static_pointer_cast<EvdevDevice>(dev.first);
 }
 
-void evdev_joystick_handler::get_next_button_press(const std::string& padId, const std::function<void(u16, std::string, std::string, std::array<int, 6>)>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+void evdev_joystick_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
@@ -303,7 +303,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 		return it != data.end() && dir == it->second.second ? it->second.first : 0;
 	};
 
-	std::array<int, 6> preview_values = {0, 0, 0, 0, 0, 0};
+	pad_preview_values preview_values = { 0, 0, 0, 0, 0, 0 };
 
 	if (buttons.size() == 10)
 	{
@@ -317,7 +317,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 
 	// return if nothing new has happened. ignore this to get the current state for blacklist
 	if (!get_blacklist && ret < 0)
-		return callback(0, "", padId, preview_values);
+		return callback(0, "", padId, 0, preview_values);
 
 	std::pair<u16, std::string> pressed_button = { 0, "" };
 
@@ -408,9 +408,9 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 	}
 
 	if (pressed_button.first > 0)
-		return callback(pressed_button.first, pressed_button.second, padId, preview_values);
+		return callback(pressed_button.first, pressed_button.second, padId, 0, preview_values);
 	else
-		return callback(0, "", padId, preview_values);
+		return callback(0, "", padId, 0, preview_values);
 }
 
 // https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -335,7 +335,7 @@ public:
 	std::vector<std::string> ListDevices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void Close();
-	void get_next_button_press(const std::string& padId, const std::function<void(u16, std::string, std::string, std::array<int, 6>)>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
+	void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
 	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 
 private:

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -336,7 +336,7 @@ public:
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void Close();
 	void get_next_button_press(const std::string& padId, const std::function<void(u16, std::string, std::string, std::array<int, 6>)>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b) override;
+	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 
 private:
 	std::shared_ptr<EvdevDevice> get_evdev_device(const std::string& device);

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -81,7 +81,7 @@ public:
 
 	void init_config(pad_config* cfg, const std::string& name) override;
 	std::vector<std::string> ListDevices() override;
-	void get_next_button_press(const std::string& /*padId*/, const std::function<void(u16, std::string, std::string, std::array<int, 6>)>& /*callback*/, const std::function<void(std::string)>& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) override {};
+	void get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) override {};
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
 	void ThreadProc() override;
 

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -177,7 +177,7 @@ std::array<u32, PadHandlerBase::button::button_count> mm_joystick_handler::get_m
 	return mapping;
 }
 
-void mm_joystick_handler::get_next_button_press(const std::string& padId, const std::function<void(u16, std::string, std::string, std::array<int, 6>)>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+void mm_joystick_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
 {
 	if (get_blacklist)
 		blacklist.clear();
@@ -299,7 +299,7 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 			return static_cast<u64>(key);
 		};
 
-		std::array<int, 6> preview_values = { 0, 0, 0, 0, 0, 0 };
+		pad_preview_values preview_values = { 0, 0, 0, 0, 0, 0 };
 		if (buttons.size() == 10)
 		{
 			preview_values[0] = data[find_key(buttons[0])];
@@ -311,9 +311,9 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 		}
 
 		if (pressed_button.first > 0)
-			return callback(pressed_button.first, pressed_button.second, padId, preview_values);
+			return callback(pressed_button.first, pressed_button.second, padId, 0, preview_values);
 		else
-			return callback(0, "", padId, preview_values);
+			return callback(0, "", padId, 0, preview_values);
 
 		break;
 	}

--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -106,7 +106,7 @@ public:
 	bool Init() override;
 
 	std::vector<std::string> ListDevices() override;
-	void get_next_button_press(const std::string& padId, const std::function<void(u16, std::string, std::string, std::array<int, 6>)>& callback, const std::function<void(std::string)>& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
+	void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -287,7 +287,7 @@ xinput_pad_handler::PadButtonValues xinput_pad_handler::get_button_values_scp(co
 	return values;
 }
 
-std::array<int, 6> xinput_pad_handler::get_preview_values(std::unordered_map<u64, u16> data)
+pad_preview_values xinput_pad_handler::get_preview_values(std::unordered_map<u64, u16> data)
 {
 	return { data[LT], data[RT], data[LSXPos] - data[LSXNeg], data[LSYPos] - data[LSYNeg], data[RSXPos] - data[RSXNeg], data[RSYPos] - data[RSYNeg] };
 }

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -124,7 +124,7 @@ void xinput_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-void xinput_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32/* b*/)
+void xinput_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32/* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
 	int device_number = GetDeviceNumber(padId);
 	if (device_number < 0)

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -98,7 +98,7 @@ public:
 	bool Init() override;
 
 	std::vector<std::string> ListDevices() override;
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b) override;
+	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -128,5 +128,5 @@ private:
 	void get_extended_info(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;
 	void apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;
 	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	std::array<int, 6> get_preview_values(std::unordered_map<u64, u16> data) override;
+	pad_preview_values get_preview_values(std::unordered_map<u64, u16> data) override;
 };

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -476,6 +476,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_pad_led_settings_dialog.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_pad_settings_dialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -692,6 +697,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug\moc_osk_dialog_frame.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_pad_led_settings_dialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
@@ -936,6 +946,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_pad_led_settings_dialog.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_pad_settings_dialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
@@ -1156,6 +1171,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_pad_led_settings_dialog.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_pad_settings_dialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -1256,6 +1276,7 @@
     <ClCompile Include="rpcs3qt\input_dialog.cpp" />
     <ClCompile Include="rpcs3qt\localized.cpp" />
     <ClCompile Include="rpcs3qt\osk_dialog_frame.cpp" />
+    <ClCompile Include="rpcs3qt\pad_led_settings_dialog.cpp" />
     <ClCompile Include="rpcs3qt\pkg_install_dialog.cpp" />
     <ClCompile Include="rpcs3qt\persistent_settings.cpp" />
     <ClCompile Include="rpcs3qt\settings.cpp" />
@@ -1436,6 +1457,24 @@
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath);$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\moc.exe;%(FullPath);$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath);$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\pad_led_settings_dialog.h">
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Identity)...</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB "-DBRANCH=$(BRANCH)" -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\settings_dialog.h">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing settings_dialog.h...</Message>
@@ -1647,6 +1686,7 @@
     <ClInclude Include="Input\pad_thread.h" />
     <ClInclude Include="QTGeneratedFiles\ui_about_dialog.h" />
     <ClInclude Include="QTGeneratedFiles\ui_main_window.h" />
+    <ClInclude Include="QTGeneratedFiles\ui_pad_led_settings_dialog.h" />
     <ClInclude Include="QTGeneratedFiles\ui_pad_settings_dialog.h" />
     <ClInclude Include="QTGeneratedFiles\ui_settings_dialog.h" />
     <ClInclude Include="QTGeneratedFiles\ui_welcome_dialog.h" />
@@ -2382,6 +2422,26 @@
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">Rcc%27ing %(Identity)...</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">.\QTGeneratedFiles\qrc_%(Filename).cpp;%(Outputs)</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\rcc.exe" -name "%(Filename)" -no-compress "%(FullPath)" -o .\QTGeneratedFiles\qrc_%(Filename).cpp</Command>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="rpcs3qt\pad_led_settings_dialog.ui">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">$(QTDIR)\bin\uic.exe;%(AdditionalInputs)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">Uic%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">.\QTGeneratedFiles\ui_%(Filename).h;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">"$(QTDIR)\bin\uic.exe" -o ".\QTGeneratedFiles\ui_%(Filename).h" "%(FullPath)"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\uic.exe;%(AdditionalInputs)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Uic%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\QTGeneratedFiles\ui_%(Filename).h;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\uic.exe" -o ".\QTGeneratedFiles\ui_%(Filename).h" "%(FullPath)"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\uic.exe;%(AdditionalInputs)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Uic%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\ui_%(Filename).h;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\uic.exe" -o ".\QTGeneratedFiles\ui_%(Filename).h" "%(FullPath)"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">$(QTDIR)\bin\uic.exe;%(AdditionalInputs)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">Uic%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">.\QTGeneratedFiles\ui_%(Filename).h;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\uic.exe" -o ".\QTGeneratedFiles\ui_%(Filename).h" "%(FullPath)"</Command>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -868,6 +868,21 @@
     <ClCompile Include="rpcs3qt\tooltips.cpp">
       <Filter>Gui\settings</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\pad_led_settings_dialog.cpp">
+      <Filter>Gui\settings</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_pad_led_settings_dialog.cpp">
+      <Filter>Generated Files\Release - LLVM</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_pad_led_settings_dialog.cpp">
+      <Filter>Generated Files\Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_pad_led_settings_dialog.cpp">
+      <Filter>Generated Files\Release</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_pad_led_settings_dialog.cpp">
+      <Filter>Generated Files\Debug - LLVM</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="\rpcs3qt\*.h">
@@ -886,6 +901,9 @@
       <Filter>Generated Files</Filter>
     </ClInclude>
     <ClInclude Include="QTGeneratedFiles\ui_pad_settings_dialog.h">
+      <Filter>Generated Files</Filter>
+    </ClInclude>
+    <ClInclude Include="QTGeneratedFiles\ui_pad_led_settings_dialog.h">
       <Filter>Generated Files</Filter>
     </ClInclude>
     <ClInclude Include="QTGeneratedFiles\ui_settings_dialog.h">
@@ -995,6 +1013,9 @@
     <CustomBuild Include="rpcs3qt\pad_settings_dialog.ui">
       <Filter>Form Files</Filter>
     </CustomBuild>
+    <CustomBuild Include="rpcs3qt\pad_led_settings_dialog.ui">
+      <Filter>Form Files</Filter>
+    </CustomBuild>
     <CustomBuild Include="rpcs3qt\settings_dialog.ui">
       <Filter>Form Files</Filter>
     </CustomBuild>
@@ -1035,6 +1056,9 @@
       <Filter>Gui\game window</Filter>
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\pad_settings_dialog.h">
+      <Filter>Gui\settings</Filter>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\pad_led_settings_dialog.h">
       <Filter>Gui\settings</Filter>
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\log_frame.h">

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -29,6 +29,7 @@
 	memory_viewer_panel.cpp
 	msg_dialog_frame.cpp
 	osk_dialog_frame.cpp
+	pad_led_settings_dialog.cpp
 	pad_settings_dialog.cpp
 	persistent_settings.cpp
 	pkg_install_dialog.cpp
@@ -59,6 +60,7 @@
 set(UI_FILES
 	about_dialog.ui
 	main_window.ui
+	pad_led_settings_dialog.ui
 	pad_settings_dialog.ui
 	settings_dialog.ui
 	welcome_dialog.ui

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp
@@ -1,0 +1,99 @@
+﻿#include "pad_led_settings_dialog.h"
+
+#include <QColorDialog>
+#include <QPainter>
+#include <QPixmap>
+
+pad_led_settings_dialog::pad_led_settings_dialog(const int& colorR, const int& colorG, const int& colorB, const bool& led_low_battery_blink, const bool& led_battery_indicator, const int& led_battery_indicator_brightness, QDialog * parent)
+    : QDialog(parent)
+    , ui(new Ui::pad_led_settings_dialog)
+    , m_initial{colorR, colorG, colorB, led_low_battery_blink, led_battery_indicator, led_battery_indicator_brightness}
+{
+	ui->setupUi(this);
+	setFixedSize(size());
+	m_new = m_initial;
+	redraw_color_sample();
+	ui->hs_indicator_brightness->setValue(m_new.battery_indicator_brightness);
+	ui->cb_led_blink->setChecked(m_new.low_battery_blink);
+	ui->cb_led_indicate->setChecked(m_new.battery_indicator);
+	switch_groupboxes(m_new.battery_indicator);
+	update_slider_label(m_new.battery_indicator_brightness);
+	connect(ui->bb_dialog_buttons, &QDialogButtonBox::clicked, [this](QAbstractButton* button)
+	{
+		if (button == ui->bb_dialog_buttons->button(QDialogButtonBox::Ok))
+		{
+			read_form_values();
+			accept();
+		}
+		else if (button == ui->bb_dialog_buttons->button(QDialogButtonBox::Cancel))
+		{
+			m_new = m_initial;
+			reject();
+		}
+		else if (button == ui->bb_dialog_buttons->button(QDialogButtonBox::Apply))
+		{
+			read_form_values();
+		}
+		Q_EMIT pass_led_settings(m_new.cR, m_new.cG, m_new.cB, m_new.low_battery_blink, m_new.battery_indicator, m_new.battery_indicator_brightness);
+	}); 
+	connect(ui->b_colorpicker, &QPushButton::clicked, [this]()
+	{
+		const QColor led_color(m_new.cR, m_new.cG, m_new.cB);
+		QColorDialog dlg(led_color, this);
+		dlg.setWindowTitle(tr("LED Color"));
+		if (dlg.exec() == QColorDialog::Accepted)
+		{
+			const QColor new_color = dlg.selectedColor();
+			m_new.cR = new_color.red();
+			m_new.cG = new_color.green();
+			m_new.cB = new_color.blue();
+			redraw_color_sample();
+		}
+	});
+	connect(ui->hs_indicator_brightness, &QAbstractSlider::valueChanged, this, &pad_led_settings_dialog::update_slider_label);
+	connect(ui->cb_led_indicate, &QCheckBox::toggled, this, &pad_led_settings_dialog::switch_groupboxes);
+}
+
+pad_led_settings_dialog::~pad_led_settings_dialog()
+{
+	delete ui;
+}
+
+void pad_led_settings_dialog::redraw_color_sample()
+{
+	const qreal w = ui->w_color_sample->width();
+	const qreal h = ui->w_color_sample->height();
+	const qreal padding = 5;
+	const qreal radius = 5;
+	QColor led_color;
+	QPixmap color_sample(w, h);
+	color_sample.fill(QColor("transparent"));	
+	QPainter painter(&color_sample);
+	QPainterPath path;
+	QPen border(Qt::black, 1);
+	painter.setRenderHint(QPainter::Antialiasing);
+	painter.setPen(border);
+	led_color.setRgb(m_new.cR, m_new.cG, m_new.cB);
+	path.addRoundedRect(QRectF(padding, padding, w - padding * 2, h - padding * 2), radius, radius);
+	painter.fillPath(path, led_color);
+	painter.drawPath(path);
+	ui->w_color_sample->setPixmap(color_sample);
+}
+
+void pad_led_settings_dialog::update_slider_label(int val)
+{
+	const QString label = QString::number(val) + QStringLiteral("%");
+	ui->l_indicator_brightness->setText(label);
+}
+
+void pad_led_settings_dialog::switch_groupboxes(bool tick)
+{
+	ui->gb_indicator_brightness->setEnabled(tick);
+}
+
+void pad_led_settings_dialog::read_form_values()
+{
+	m_new.low_battery_blink = ui->cb_led_blink->isChecked();
+	m_new.battery_indicator = ui->cb_led_indicate->isChecked();
+	m_new.battery_indicator_brightness = ui->hs_indicator_brightness->value();
+}

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.h
@@ -1,0 +1,42 @@
+﻿#pragma once
+
+#include <QDialog>
+
+#include "ui_pad_led_settings_dialog.h"
+
+namespace Ui
+{
+	class pad_led_settings_dialog;
+}
+
+class pad_led_settings_dialog : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit pad_led_settings_dialog(const int& colorR, const int& colorG, const int& colorB, const bool& led_low_battery_blink, const bool& led_battery_indicator, const int& led_battery_indicator_brightness, QDialog* parent = Q_NULLPTR);
+	~pad_led_settings_dialog();
+
+signals:
+	void pass_led_settings(int m_cR, int m_cG, int m_cB, bool m_low_battery_blink, bool m_battery_indicator, int m_battery_indicator_brightness);
+
+private Q_SLOTS:
+	void update_slider_label(int val);
+	void switch_groupboxes(bool tick);
+
+private:
+	void redraw_color_sample();
+	void read_form_values();
+	Ui::pad_led_settings_dialog *ui;
+	struct led_settings
+	{
+		int cR = 255;
+		int cG = 255;
+		int cB = 255;
+		bool low_battery_blink = true;
+		bool battery_indicator = false;
+		int battery_indicator_brightness = 50;
+	};
+	led_settings m_initial;
+	led_settings m_new;
+};

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>pad_led_settings_dialog</class>
+ <widget class="QWidget" name="pad_led_settings_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>292</width>
+    <height>287</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>LED Settings</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,1,1,0">
+   <item>
+    <widget class="QGroupBox" name="gb_led_color">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>LED Color</string>
+     </property>
+     <layout class="QVBoxLayout" name="gb_led_color_layout" stretch="0,2">
+      <item>
+       <widget class="QLabel" name="w_color_sample">
+        <property name="minimumSize">
+         <size>
+          <width>249</width>
+          <height>39</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="b_colorpicker">
+        <property name="text">
+         <string>Select color...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gb_battery_status">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>75</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>In-game battery status</string>
+     </property>
+     <layout class="QVBoxLayout" name="gb_battery_status_layout">
+      <item>
+       <widget class="QCheckBox" name="cb_led_blink">
+        <property name="text">
+         <string>Blink LED when battery is low</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cb_led_indicate">
+        <property name="text">
+         <string>Use LED as a battery indicator</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gb_indicator_brightness">
+     <property name="title">
+      <string>LED battery indicator brightness</string>
+     </property>
+     <layout class="QHBoxLayout" name="gb_indicator_brightness_layout" stretch="2,1,13">
+      <item>
+       <widget class="QLabel" name="l_indicator_brightness">
+        <property name="text">
+         <string>100%</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QSlider" name="hs_indicator_brightness">
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="bb_dialog_buttons">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>292</width>
+    <width>287</width>
     <height>287</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>LED Settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,1,1,0">
+  <layout class="QVBoxLayout" name="pad_led_settings_dialog_layout">
    <item>
     <widget class="QGroupBox" name="gb_led_color">
      <property name="minimumSize">
@@ -25,15 +25,9 @@
      <property name="title">
       <string>LED Color</string>
      </property>
-     <layout class="QVBoxLayout" name="gb_led_color_layout" stretch="0,2">
+     <layout class="QVBoxLayout" name="gb_led_color_layout">
       <item>
        <widget class="QLabel" name="w_color_sample">
-        <property name="minimumSize">
-         <size>
-          <width>249</width>
-          <height>39</height>
-         </size>
-        </property>
         <property name="text">
          <string/>
         </property>
@@ -42,7 +36,7 @@
       <item>
        <widget class="QPushButton" name="b_colorpicker">
         <property name="text">
-         <string>Select color...</string>
+         <string>Select color</string>
         </property>
        </widget>
       </item>
@@ -51,12 +45,6 @@
    </item>
    <item>
     <widget class="QGroupBox" name="gb_battery_status">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>75</height>
-      </size>
-     </property>
      <property name="title">
       <string>In-game battery status</string>
      </property>

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -90,6 +90,9 @@ public:
 	explicit pad_settings_dialog(QWidget *parent = nullptr, const GameInfo *game = nullptr);
 	~pad_settings_dialog();
 
+public Q_SLOTS:
+	void apply_led_settings(int colorR, int colorG, int colorB, bool led_low_battery_blink, bool led_battery_indicator, int led_battery_indicator_brightness);
+
 private Q_SLOTS:
 	void OnPadButtonClicked(int id);
 	void OnTabChanged(int index);
@@ -112,6 +115,7 @@ private:
 	bool m_enable_rumble{ false };
 	bool m_enable_deadzones{ false };
 	bool m_enable_led{ false };
+	bool m_enable_battery{ false };
 
 	// Button Mapping
 	QButtonGroup* m_padButtons = nullptr;
@@ -148,6 +152,9 @@ private:
 
 	// Input timer. Its Callback handles the input
 	QTimer m_timer_input;
+
+	// DS4 workaround timer
+	QTimer m_timer_ds4_battery;
 
 	// Set vibrate data while keeping the current color
 	void SetPadData(u32 large_motor, u32 small_motor);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -153,9 +153,6 @@ private:
 	// Input timer. Its Callback handles the input
 	QTimer m_timer_input;
 
-	// DS4 workaround timer
-	QTimer m_timer_ds4_battery;
-
 	// Set vibrate data while keeping the current color
 	void SetPadData(u32 large_motor, u32 small_motor);
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -25,7 +25,7 @@
     <rect>
      <x>60</x>
      <y>10</y>
-     <width>886</width>
+     <width>889</width>
      <height>612</height>
     </rect>
    </property>
@@ -1342,8 +1342,8 @@
             <widget class="QLabel" name="l_controller">
              <property name="maximumSize">
               <size>
-               <width>430</width>
-               <height>265</height>
+               <width>415</width>
+               <height>256</height>
               </size>
              </property>
              <property name="text">
@@ -1416,41 +1416,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="gb_led">
-            <property name="title">
-             <string>LED</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_led_layout">
-             <property name="leftMargin">
-              <number>5</number>
-             </property>
-             <property name="topMargin">
-              <number>5</number>
-             </property>
-             <property name="rightMargin">
-              <number>5</number>
-             </property>
-             <property name="bottomMargin">
-              <number>5</number>
-             </property>
-             <item>
-              <widget class="QPushButton" name="b_led">
-               <property name="text">
-                <string/>
-               </property>
-               <property name="icon">
-                <iconset resource="../resources.qrc">
-                 <normaloff>:/Icons/controllers.png</normaloff>:/Icons/controllers.png</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
            <widget class="QGroupBox" name="gb_r3">
             <property name="title">
              <string>R3</string>
@@ -1497,7 +1462,7 @@
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="layout_choose_class">
+         <layout class="QHBoxLayout" name="layout_choose_class" stretch="1,1">
           <property name="spacing">
            <number>10</number>
           </property>
@@ -1507,8 +1472,52 @@
              <string>Device Class:</string>
             </property>
             <layout class="QVBoxLayout" name="gb_choose_class_layout">
-             <item>
+             <item alignment="Qt::AlignVCenter">
               <widget class="QComboBox" name="chooseClass"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="gb_battery">
+            <property name="minimumSize">
+             <size>
+              <width>104</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="title">
+             <string>Battery status and LED</string>
+            </property>
+            <layout class="QHBoxLayout" name="gb_battery_layout" stretch="1,1">
+             <item>
+              <widget class="QProgressBar" name="pb_battery">
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>15</height>
+                </size>
+               </property>
+               <property name="value">
+                <number>0</number>
+               </property>
+               <property name="invertedAppearance">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="b_led_settings">
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>23</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>LED Settings</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>
@@ -2256,7 +2265,7 @@
          </spacer>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="button_layout_right" stretch="1,1">
+         <layout class="QHBoxLayout" name="button_layout_right" stretch="0,1">
           <item>
            <widget class="QPushButton" name="b_blacklist">
             <property name="text">


### PR DESCRIPTION
Added a battery level indicator in the pad settings UI (only visible when DS4 handler is selected), extended `PadHandlerBase` to return a battery level and implemented a method to return battery level into `ds4_pad_handler`.

Also added a code block in `ds4_pad_handler` that allows battery level indication by changing the LED color according to a preset gradient. Currently disabled and subject to being fully implemented with a corresponding way to control the new function in the pad settings UI.

Battery indicator screenshot:
![7aRRWa 1](https://user-images.githubusercontent.com/7739280/72222032-6167f180-3571-11ea-95bf-d2f87c8faa51.png)
