### PR TITLE
vk: Restructure command queue flushing behavior to avoid deadlock

### DIFF
--- a/rpcs3/Emu/RSX/RSXOffload.cpp
+++ b/rpcs3/Emu/RSX/RSXOffload.cpp
@@ -137,12 +137,12 @@ namespace rsx
 		return (std::this_thread::get_id() == m_thread_id);
 	}
 
-	void dma_manager::sync()
+	bool dma_manager::sync()
 	{
 		if (LIKELY(m_enqueued_count.load() == m_processed_count))
 		{
 			// Nothing to do
-			return;
+			return true;
 		}
 
 		if (auto rsxthr = get_current_renderer(); rsxthr->is_current_thread())
@@ -150,7 +150,7 @@ namespace rsx
 			if (m_mem_fault_flag)
 			{
 				// Abort if offloader is in recovery mode
-				return;
+				return false;
 			}
 
 			while (m_enqueued_count.load() != m_processed_count)
@@ -164,6 +164,8 @@ namespace rsx
 			while (m_enqueued_count.load() != m_processed_count)
 				_mm_pause();
 		}
+
+		return true;
 	}
 
 	void dma_manager::join()

--- a/rpcs3/Emu/RSX/RSXOffload.h
+++ b/rpcs3/Emu/RSX/RSXOffload.h
@@ -77,7 +77,7 @@ namespace rsx
 
 		// Synchronization
 		bool is_current_thread() const;
-		void sync();
+		bool sync();
 		void join();
 		void set_mem_fault_flag();
 		void clear_mem_fault_flag();

--- a/rpcs3/Emu/RSX/VK/VKCommandStream.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommandStream.cpp
@@ -30,7 +30,7 @@ namespace vk
 			release_global_submit_lock();
 
 			// Signal fence
-			pfence->flushed = true;
+			pfence->signal_flushed();
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1337,7 +1337,7 @@ namespace vk
 			{
 				// Primary access command queue, must restart it after
 				vk::fence submit_fence(*m_device);
-				cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, &submit_fence, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+				cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, &submit_fence, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_TRUE);
 
 				vk::wait_for_fence(&submit_fence, GENERAL_WAIT_TIMEOUT);
 
@@ -1347,7 +1347,7 @@ namespace vk
 			else
 			{
 				// Auxilliary command queue with auto-restart capability
-				cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+				cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_TRUE);
 			}
 
 			verify(HERE), cmd.flags == 0;


### PR DESCRIPTION
- Queueing commands on the offloader is a good idea but unfortunately
page faults can still happen causing a cyclic dependency and eventual
deadlock. Characterized by a vk::wait_for_event timed out error
accompanied by severe hitching.

- Drain the fault-able commands before pushing a submit operation to the
queue. If a fault is in progress, bypass the queue system and submit
raw. Technically this is incorrect but there isn't much that can be
done about it right now.