### PR TITLE
rsx: Verify local memory offset

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -428,6 +428,7 @@ s32 _cellGcmInitBody(ppu_thread& ppu, vm::pptr<CellGcmContextData> context, u32 
 	render->isHLE = true;
 	render->label_addr = gcm_cfg->gcm_info.label_addr;
 	render->device_addr = gcm_cfg->gcm_info.context_addr;
+	render->local_mem_size = local_size;
 	render->init(gcm_cfg->gcm_info.control_addr - 0x40);
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -210,6 +210,7 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 	render->current_display_buffer = 0;
 	render->label_addr = *lpar_reports;
 	render->device_addr = rsx_cfg->device_addr;
+	render->local_mem_size = rsx_cfg->memory_size;
 	render->init(*lpar_dma_control);
 
 	rsx_cfg->context_base = context_base;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -656,6 +656,7 @@ namespace rsx
 		u32 label_addr;
 
 		u32 main_mem_size{0};
+		u32 local_mem_size{0};
 
 		bool m_rtts_dirty;
 		bool m_textures_dirty[16];


### PR DESCRIPTION
Add offset range verifications in rsx::get_address for the following locations:
* RSX local memory: must not go above rsx::thread::local_mem_size.
* DMA DEVICE: must not go above 1mb.
* DMA SEMAPHORE and DMA REPORT: must not go above sizeof(RsxReports::semaphore/report) respectively.

Those offsets are all game determined, on rsx fifo corruption offsets may be invalid.