### PR TITLE
sys_process: Fix sys_process_get_id, add error_code

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -949,7 +949,7 @@ s32 _spurs::initialize(ppu_thread& ppu, vm::ptr<CellSpurs> spurs, u32 revision, 
 		return CELL_SPURS_CORE_ERROR_INVAL;
 	}
 
-	if (sys_process_is_spu_lock_line_reservation_address(spurs.addr(), SYS_MEMORY_ACCESS_RIGHT_SPU_THR) != CELL_OK)
+	if (process_is_spu_lock_line_reservation_address(spurs.addr(), SYS_MEMORY_ACCESS_RIGHT_SPU_THR) != CELL_OK)
 	{
 		return CELL_SPURS_CORE_ERROR_PERM;
 	}

--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -22,7 +22,7 @@ extern std::string ppu_get_syscall_name(u64 code)
 	case 25: return "sys_process_get_sdk_version";
 	case 26: return "_sys_process_exit2";
 	case 28: return "_sys_process_get_number_of_object";
-	case 29: return "sys_process_get_id";
+	case 29: return "sys_process_get_id2";
 	case 30: return "_sys_process_get_paramsfo";
 	case 31: return "sys_process_get_ppu_guid";
 	case 41: return "_sys_ppu_thread_exit";

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1371,8 +1371,6 @@ extern void ppu_initialize(const ppu_module& info)
 			{ "__stvlx", s_use_ssse3 ? reinterpret_cast<u64>(sse_cellbe_stvlx) : reinterpret_cast<u64>(sse_cellbe_stvlx_v0) },
 			{ "__stvrx", s_use_ssse3 ? reinterpret_cast<u64>(sse_cellbe_stvrx) : reinterpret_cast<u64>(sse_cellbe_stvrx_v0) },
 			{ "__resupdate", reinterpret_cast<u64>(vm::reservation_update) },
-			// TODO: Remove in the next PPU cache version bump
-			{ "sys_process_get_id", reinterpret_cast<u64>(ppu_get_syscall(29)) },
 			{ "sys_config_io_event", reinterpret_cast<u64>(ppu_get_syscall(523)) },
 		};
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1371,6 +1371,8 @@ extern void ppu_initialize(const ppu_module& info)
 			{ "__stvlx", s_use_ssse3 ? reinterpret_cast<u64>(sse_cellbe_stvlx) : reinterpret_cast<u64>(sse_cellbe_stvlx_v0) },
 			{ "__stvrx", s_use_ssse3 ? reinterpret_cast<u64>(sse_cellbe_stvrx) : reinterpret_cast<u64>(sse_cellbe_stvrx_v0) },
 			{ "__resupdate", reinterpret_cast<u64>(vm::reservation_update) },
+			// TODO: Remove in the next PPU cache version bump
+			{ "sys_process_get_id", reinterpret_cast<u64>(ppu_get_syscall(29)) },
 			{ "sys_config_io_event", reinterpret_cast<u64>(ppu_get_syscall(523)) },
 		};
 

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -97,7 +97,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	BIND_FUNC(_sys_process_exit2),                          //26  (0x01A)
 	null_func,//BIND_FUNC(),                                //27  (0x01B)  DBG
 	null_func,//BIND_FUNC(_sys_process_get_number_of_object)//28  (0x01C)  ROOT
-	BIND_FUNC(sys_process_get_id),                          //29  (0x01D)  ROOT
+	BIND_FUNC(sys_process_get_id2),                          //29  (0x01D)  ROOT
 	BIND_FUNC(_sys_process_get_paramsfo),                   //30  (0x01E)
 	null_func,//BIND_FUNC(sys_process_get_ppu_guid),        //31  (0x01F)
 

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -54,20 +54,21 @@ extern ps3_process_info_t  g_ps3_process_info;
 // Auxiliary functions
 s32 process_getpid();
 s32 process_get_sdk_version(u32 pid, s32& ver);
-s32 process_is_spu_lock_line_reservation_address(u32 addr, u64 flags);
+error_code process_is_spu_lock_line_reservation_address(u32 addr, u64 flags);
 
 // SysCalls
 s32 sys_process_getpid();
 s32 sys_process_getppid();
-s32 sys_process_get_number_of_object(u32 object, vm::ptr<u32> nump);
-s32 sys_process_get_id(u32 object, vm::ptr<u32> buffer, u32 size, vm::ptr<u32> set_size);
-s32 _sys_process_get_paramsfo(vm::ptr<char> buffer);
-s32 sys_process_get_sdk_version(u32 pid, vm::ptr<s32> version);
-s32 sys_process_get_status(u64 unk);
-s32 sys_process_is_spu_lock_line_reservation_address(u32 addr, u64 flags);
-s32 sys_process_kill(u32 pid);
-s32 sys_process_wait_for_child(u32 pid, vm::ptr<u32> status, u64 unk);
-s32 sys_process_wait_for_child2(u64 unk1, u64 unk2, u64 unk3, u64 unk4, u64 unk5, u64 unk6);
-s32 sys_process_detach_child(u64 unk);
+error_code sys_process_get_number_of_object(u32 object, vm::ptr<u32> nump);
+error_code sys_process_get_id(u32 object, vm::ptr<u32> buffer, u32 size, vm::ptr<u32> set_size);
+error_code sys_process_get_id2(u32 object, vm::ptr<u32> buffer, u32 size, vm::ptr<u32> set_size);
+error_code _sys_process_get_paramsfo(vm::ptr<char> buffer);
+error_code sys_process_get_sdk_version(u32 pid, vm::ptr<s32> version);
+error_code sys_process_get_status(u64 unk);
+error_code sys_process_is_spu_lock_line_reservation_address(u32 addr, u64 flags);
+error_code sys_process_kill(u32 pid);
+error_code sys_process_wait_for_child(u32 pid, vm::ptr<u32> status, u64 unk);
+error_code sys_process_wait_for_child2(u64 unk1, u64 unk2, u64 unk3, u64 unk4, u64 unk5, u64 unk6);
+error_code sys_process_detach_child(u64 unk);
 void _sys_process_exit(ppu_thread& ppu, s32 status, u32 arg2, u32 arg3);
 void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> arg, u32 arg_size, u32 arg4);


### PR DESCRIPTION
* Due to signed checks and do-while behavior of sys_process_get_id ids processing (checking bufsize), negative and 0 values are treated as 1.
* sys_process_get_id and sys_process_get_id2 are not the same syscall handling code, infact they have a few different error checks and capabilities.

Testcase : https://github.com/elad335/myps3tests/tree/master/ppu_tests/sys_process_get_id