### PR TITLE
Improve game icon rendering for HighDPI users

### DIFF
--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -76,7 +76,7 @@ Q_SIGNALS:
 class compat_pixmap : public QPixmap
 {
 public:
-	compat_pixmap(const QColor& color, int pixel_ratio) : QPixmap(16 * pixel_ratio, 16 * pixel_ratio)
+	compat_pixmap(const QColor& color, qreal pixel_ratio) : QPixmap(16 * pixel_ratio, 16 * pixel_ratio)
 	{
 		fill(Qt::transparent);
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1618,7 +1618,7 @@ void game_list_frame::BatchRemoveShaderCaches()
 
 QPixmap game_list_frame::PaintedPixmap(const QPixmap& icon, bool paint_config_icon, bool paint_pad_config_icon, const QColor& compatibility_color)
 {
-	const int device_pixel_ratio = devicePixelRatio();
+	const qreal device_pixel_ratio = devicePixelRatioF();
 	const QSize original_size = icon.size();
 
 	QPixmap canvas = QPixmap(original_size * device_pixel_ratio);
@@ -1921,7 +1921,7 @@ int game_list_frame::PopulateGameList()
 		compat_item->setToolTip(game->compat.tooltip);
 		if (!game->compat.color.isEmpty())
 		{
-			compat_item->setData(Qt::DecorationRole, compat_pixmap(game->compat.color, devicePixelRatio() * 2));
+			compat_item->setData(Qt::DecorationRole, compat_pixmap(game->compat.color, devicePixelRatioF() * 2));
 		}
 
 		// Version

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -59,13 +59,13 @@ void game_list_grid::setIconSize(const QSize& size)
 
 void game_list_grid::addItem(const QPixmap& img, const QString& name, const int& row, const int& col)
 {
-	const int device_pixel_ratio = devicePixelRatio();
+	const qreal device_pixel_ratio = devicePixelRatioF();
 
 	// define size of expanded image, which is raw image size + margins
-	QSize exp_size;
+	QSizeF exp_size;
 	if (m_text_enabled)
 	{
-		exp_size = m_icon_size + QSize(m_icon_size.width() * m_margin_factor * 2, m_icon_size.height() * m_margin_factor * (m_text_factor + 1));
+		exp_size = m_icon_size + QSizeF(m_icon_size.width() * m_margin_factor * 2, m_icon_size.height() * m_margin_factor * (m_text_factor + 1));
 	}
 	else
 	{
@@ -76,7 +76,7 @@ void game_list_grid::addItem(const QPixmap& img, const QString& name, const int&
 	QPoint offset = QPoint(m_icon_size.width() * m_margin_factor, m_icon_size.height() * m_margin_factor);
 
 	// create empty canvas for expanded image
-	QImage exp_img = QImage(exp_size * device_pixel_ratio, QImage::Format_ARGB32);
+	QImage exp_img = QImage((exp_size * device_pixel_ratio).toSize(), QImage::Format_ARGB32);
 	exp_img.setDevicePixelRatio(device_pixel_ratio);
 	exp_img.fill(Qt::transparent);
 

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -326,7 +326,7 @@ void save_manager_dialog::HandleRepaintUiRequest()
 
 QPixmap save_manager_dialog::GetResizedIcon(int i)
 {
-	const int dpr = devicePixelRatio();
+	const qreal dpr = devicePixelRatioF();
 	const int width = m_icon_size.width() * dpr;
 	const int height = m_icon_size.height() * dpr * 176 / 320;
 

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -494,7 +494,7 @@ QPixmap trophy_manager_dialog::GetResizedGameIcon(int index)
 		return QPixmap();
 	}
 	const QPixmap icon = item->data(Qt::UserRole).value<QPixmap>();
-	const int dpr = devicePixelRatio();
+	const qreal dpr = devicePixelRatioF();
 
 	QPixmap new_icon = QPixmap(icon.size() * dpr);
 	new_icon.setDevicePixelRatio(dpr);
@@ -542,7 +542,7 @@ void trophy_manager_dialog::ResizeTrophyIcons()
 		return;
 
 	const int db_pos = m_game_combo->currentData().toInt();
-	const int dpr = devicePixelRatio();
+	const qreal dpr = devicePixelRatioF();
 	const int new_height = m_icon_height * dpr;
 
 	QList<int> indices;


### PR DESCRIPTION
Uses floating point values instead of integers for pixel ratio. Might help with #7248, test both grid and list modes for improvements.