### PR TITLE
rsx: Fix section length calculations when generating new blit targets.

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2492,13 +2492,15 @@ namespace rsx
 					}
 				}
 
-				const u32 section_length = std::max(write_end, block_end) - dst.rsx_address;
-				dst_dimensions.height = align2(section_length, dst.pitch) / dst.pitch;
+				const u32 usable_section_length = std::max(write_end, block_end) - dst.rsx_address;
+				dst_dimensions.height = align2(usable_section_length, dst.pitch) / dst.pitch;
+
+				const u32 full_section_length = ((dst_dimensions.height - 1) * dst.pitch) + (dst_dimensions.width * dst_bpp);
+				const auto rsx_range = address_range::start_length(dst.rsx_address, full_section_length);
 
 				lock.upgrade();
 
 				// NOTE: Write flag set to remove all other overlapping regions (e.g shader_read or blit_src)
-				const auto rsx_range = address_range::start_length(dst.rsx_address, section_length);
 				invalidate_range_impl_base(cmd, rsx_range, invalidation_cause::write, std::forward<Args>(extras)...);
 
 				if (LIKELY(use_null_region))

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -492,7 +492,7 @@ namespace rsx
 
 				// Call the worker function directly, stoping it prematurely to be able update the screen
 				u8 inc = 10;
-				u32 stop_at;
+				u32 stop_at = 0;
 				do
 				{
 					stop_at = std::min(stop_at + inc, entry_count);


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/7225