### PR TITLE
rsx: Optimize some imaging operations

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -609,6 +609,17 @@ namespace gl
 					const u16 src_w2 = u16(src_w * src_bpp) / dst_bpp;
 					const u16 src_x2 = u16(src_x * src_bpp) / dst_bpp;
 
+					if (src_w2 == slice.dst_w && src_h == slice.dst_h && slice.level == 0)
+					{
+						// Optimization, avoid typeless copy to tmp followed by data copy to dst
+						// Combine the two transfers into one
+						const coord3u src_region = { { src_x, src_y, 0 }, { src_w, src_h, 1 } };
+						const coord3u dst_region = { { slice.dst_x, slice.dst_y, slice.dst_z }, { slice.dst_w, slice.dst_h, 1 } };
+						gl::copy_typeless(dst_image, slice.src, dst_region, src_region);
+
+						continue;
+					}
+
 					const coord3u src_region = { { src_x, src_y, 0 }, { src_w, src_h, 1 } };
 					const coord3u dst_region = { { src_x2, src_y, 0 }, { src_w2, src_h, 1 } };
 					gl::copy_typeless(src_image, slice.src, dst_region, src_region);


### PR DESCRIPTION
There are a lot of redundant imaging operations that can be collapsed together and combined into one step. Discovered this bottleneck when reviewing https://github.com/RPCS3/rpcs3/issues/6341

It seems OGL is the most affected, I was able to gain about 75% performance improvement at 1440p on PDF (Internal res becomes 5120x2880 for that title as it uses 4x supersampling). Doesn't seem to do much for vulkan which is already very fast in that test, but I suppose it couldn't hurt to avoid doing useless work.

Fixes https://github.com/RPCS3/rpcs3/issues/6341