### PR TITLE
Fix sys_ppu_thread_create/rename and sys_spu_thread_initialize thread name range

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -329,7 +329,9 @@ error_code _sys_ppu_thread_create(vm::ptr<u64> thread_id, vm::ptr<ppu_thread_par
 
 		if (threadname)
 		{
-			ppu_name = threadname.get_ptr();
+			constexpr u32 max_size = 27; // max size including null terminator
+			const auto pname = threadname.get_ptr();
+			ppu_name.assign(pname, std::find(pname, pname + max_size, '\0'));
 			fmt::append(full_name, " (%s)", ppu_name);
 		}
 
@@ -422,8 +424,11 @@ error_code sys_ppu_thread_rename(u32 thread_id, vm::cptr<char> name)
 		return CELL_EFAULT;
 	}
 
+	constexpr u32 max_size = 27; // max size including null terminator
+	const auto pname = name.get_ptr();
+
 	// thread_ctrl name is not changed (TODO)
-	thread->ppu_name.assign(name.get_ptr());
+	thread->ppu_name.assign(pname, std::find(pname, pname + max_size, '\0'));
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -267,8 +267,13 @@ error_code sys_spu_thread_initialize(ppu_thread& ppu, vm::ptr<u32> thread, u32 g
 
 	sys_spu.warning("sys_spu_thread_initialize(thread=*0x%x, group=0x%x, spu_num=%d, img=*0x%x, attr=*0x%x, arg=*0x%x)", thread, group_id, spu_num, img, attr, arg);
 
+	if (attr->name_len > 0x80 || attr->option & ~(SYS_SPU_THREAD_OPTION_DEC_SYNC_TB_ENABLE | SYS_SPU_THREAD_OPTION_ASYNC_INTR_ENABLE))
+	{
+		return CELL_EINVAL;
+	}
+
 	// Read thread name
-	const std::string thread_name(attr->name.get_ptr(), attr->name ? attr->name_len - 1 : 0);
+	const std::string thread_name(attr->name.get_ptr(), std::max<u32>(attr->name_len, 1) - 1);
 
 	const auto group = idm::get<lv2_spu_group>(group_id);
 


### PR DESCRIPTION
PPU thread name max length is 27 max excluding null character.
Truncate string properly to 27 characters when no null terminator was found.
Threaded SPU thread name max length is 127 characters excluding null terminator (otherwise return error code), also fix empty name checking logic. 