### PR TITLE
[WIP] Make cellFsRead/Write(WithOffset) aware of unmapped memory

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellFs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellFs.cpp
@@ -893,7 +893,7 @@ struct fs_aio_thread : ppu_thread
 
 				const auto old_pos = file->file.pos(); file->file.seek(aio->offset);
 
-				result = type == 2
+				std::tie(result, error) = type == 2
 					? file->op_write(aio->buf, aio->size)
 					: file->op_read(aio->buf, aio->size);
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1750,8 +1750,8 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			}
 
 			// Read from memory file to vm
-			const u64 sr = file->second.seek(fileSet->fileOffset);
-			const u64 rr = lv2_file::op_read(file->second, fileSet->fileBuf, fileSet->fileSize);
+			const u64 sr = file.seek(fileSet->fileOffset);
+			const u64 rr = lv2_file::op_read(file, fileSet->fileBuf, fileSet->fileSize).first;
 			fileGet->excSize = ::narrow<u32>(rr);
 			break;
 		}
@@ -1781,7 +1781,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Write to memory file and truncate
 			const u64 sr = file.seek(fileSet->fileOffset);
-			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, fileSet->fileSize);
+			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, fileSet->fileSize).first;
 			file.trunc(sr + wr);
 			fileGet->excSize = ::narrow<u32>(wr);
 			all_times.erase(file_path);
@@ -1833,7 +1833,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Write to memory file normally
 			const u64 sr = file.seek(fileSet->fileOffset);
-			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, fileSet->fileSize);
+			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, fileSet->fileSize).first;
 			fileGet->excSize = ::narrow<u32>(wr);
 			all_times.erase(file_path);
 			add_to_blist(file_path);

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -222,17 +222,17 @@ struct lv2_file final : lv2_fs_object
 	static open_result_t open(std::string_view path, s32 flags, s32 mode, const void* arg = {}, u64 size = 0);
 
 	// File reading with intermediate buffer
-	static u64 op_read(const fs::file& file, vm::ptr<void> buf, u64 size);
+	static std::pair<u64, CellError> op_read(const fs::file& file, vm::ptr<void> buf, u64 size);
 
-	u64 op_read(vm::ptr<void> buf, u64 size)
+	std::pair<u64, CellError> op_read(vm::ptr<void> buf, u64 size)
 	{
 		return op_read(file, buf, size);
 	}
 
 	// File writing with intermediate buffer
-	static u64 op_write(const fs::file& file, vm::cptr<void> buf, u64 size);
+	static std::pair<u64, CellError> op_write(const fs::file& file, vm::cptr<void> buf, u64 size);
 
-	u64 op_write(vm::cptr<void> buf, u64 size)
+	std::pair<u64, CellError> op_write(vm::cptr<void> buf, u64 size)
 	{
 		return op_write(file, buf, size);
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -311,12 +311,9 @@ error_code sys_rsx_context_iomap(u32 context_id, u32 io, u32 ea, u32 size, u64 f
 
 	vm::reader_lock rlock;
 
-	for (u32 addr = ea, end = ea + size; addr < end; addr += 0x100000)
+	if (!vm::check_addr(ea, size, vm::page_readable | (ea < 0x20000000 ? 0 : vm::page_1m_size)))
 	{
-		if (!vm::check_addr(addr, 1, vm::page_readable | (addr < 0x20000000 ? 0 : vm::page_1m_size)))
-		{
-			return CELL_EINVAL;
-		}
+		return {CELL_EINVAL, ea};
 	}
 
 	io >>= 20, ea >>= 20, size >>= 20;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -395,13 +395,21 @@ namespace vm
 
 		const u8 flags_both = flags_set & flags_clear;
 
-		flags_test  |= page_allocated;
+		if (!((flags_set | flags_clear) & page_fault_notification))
+		{
+			flags_test |= page_allocated;
+		}
+		else
+		{
+			flags_test &= ~page_allocated;
+		}
+
 		flags_set   &= ~flags_both;
 		flags_clear &= ~flags_both;
 
 		for (u32 i = addr / 4096; i < addr / 4096 + size / 4096; i++)
 		{
-			if ((g_pages[i].flags & flags_test) != (flags_test | page_allocated))
+			if ((g_pages[i].flags & flags_test) != flags_test)
 			{
 				return false;
 			}
@@ -529,14 +537,40 @@ namespace vm
 		}
 
 		// Always check this flag
-		flags |= page_allocated;
+		auto test_flags = (flags | page_allocated) & ~page_fault_notification;
 
-		for (u32 i = addr / 4096, max = (addr + size - 1) / 4096; i <= max; i++)
+		for (u32 i = addr / 4096, max = (addr + size - 1) / 4096; i <= max;)
 		{
-			if ((g_pages[i].flags & flags) != flags) [[unlikely]]
+			const auto pflags = +g_pages[i].flags;
+
+			if ((pflags & test_flags) != test_flags) [[unlikely]]
 			{
-				return false;
+				// If this flag is set and passed by 'flags', ignore failure
+				if (!((pflags & flags) & page_fault_notification))
+				{
+					return false;
+				}
+
+				i++;
+				continue;
 			}
+
+			// Optimization
+			if (const auto page_size = pflags & (page_1m_size | page_64k_size))
+			{
+				if (page_size & page_1m_size)
+				{
+					i = ::align<u32>(i + 1, 0x100000 / 4096);
+				}
+				else // if (page_size & page_64k_size)
+				{
+					i = ::align<u32>(i + 1, 0x10000 / 4096);
+				}
+
+				continue;
+			}
+
+			i++;
 		}
 
 		return true;
@@ -1095,43 +1129,85 @@ namespace vm
 
 	bool try_access(u32 addr, void* ptr, u32 size, bool is_write)
 	{
-		vm::reader_lock lock;
-
 		if (size == 0)
 		{
 			return true;
 		}
 
-		if (vm::check_addr(addr, size, is_write ? page_writable : page_readable))
+		for (bool touch_mem = false;;)
 		{
-			void* src = vm::g_sudo_addr + addr;
-			void* dst = ptr;
-
-			if (is_write)
-				std::swap(src, dst);
-
-			if (size <= 16 && utils::popcnt32(size) == 1 && (addr & (size - 1)) == 0)
+			if (touch_mem)
 			{
-				if (is_write)
+				decltype(get(vm::any, 0)) block;
+
+				for (u32 i = addr, end = addr + size - 1;;)
 				{
-					switch (size)
+					// Ensures the block exists while touching the memory
+					if ((i % 0x10000000) == 0)
 					{
-					case 1: atomic_storage<u8>::release(*static_cast<u8*>(dst), *static_cast<u8*>(src)); break;
-					case 2: atomic_storage<u16>::release(*static_cast<u16*>(dst), *static_cast<u16*>(src)); break;
-					case 4: atomic_storage<u32>::release(*static_cast<u32*>(dst), *static_cast<u32*>(src)); break;
-					case 8: atomic_storage<u64>::release(*static_cast<u64*>(dst), *static_cast<u64*>(src)); break;
-					case 16: _mm_store_si128(static_cast<__m128i*>(dst), _mm_loadu_si128(static_cast<__m128i*>(src))); break;
+						block = get(vm::any, i);
 					}
 
-					return true;
+					// Touch memory
+					if (is_write)
+					{
+						// Write the expected value, avoid reads
+						vm::_ref<atomic_t<uchar>>(i).release(static_cast<uchar*>(ptr)[i - addr]); 
+					}
+					else
+					{
+						+vm::_ref<const volatile char>(i);
+					}
+
+					const u32 next = ::align(i + 1, 4096);
+
+					if (next < i || next > end)
+					{
+						break;
+					}
+
+					i = next;
 				}
 			}
 
-			std::memcpy(dst, src, size);
-			return true;
-		}
+			vm::reader_lock lock;
 
-		return false;
+			if (vm::check_addr(addr, size, (is_write ? page_writable : page_readable)))
+			{
+				void* src = vm::g_sudo_addr + addr;
+				void* dst = ptr;
+
+				if (is_write)
+					std::swap(src, dst);
+
+				if (size <= 16 && utils::popcnt32(size) == 1 && (addr & (size - 1)) == 0)
+				{
+					if (is_write)
+					{
+						switch (size)
+						{
+						case 1: atomic_storage<u8>::release(*static_cast<u8*>(dst), *static_cast<u8*>(src)); break;
+						case 2: atomic_storage<u16>::release(*static_cast<u16*>(dst), *static_cast<u16*>(src)); break;
+						case 4: atomic_storage<u32>::release(*static_cast<u32*>(dst), *static_cast<u32*>(src)); break;
+						case 8: atomic_storage<u64>::release(*static_cast<u64*>(dst), *static_cast<u64*>(src)); break;
+						case 16: _mm_store_si128(static_cast<__m128i*>(dst), _mm_loadu_si128(static_cast<__m128i*>(src))); break;
+						}
+
+						return true;
+					}
+				}
+
+				std::memcpy(dst, src, size);
+				return true;
+			}
+
+			touch_mem = vm::check_addr(addr, size, page_fault_notification | (is_write ? page_writable : page_readable));
+
+			if (!touch_mem)
+			{
+				return false;
+			}
+		}
 	}
 
 	inline namespace ps3_

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -517,6 +517,11 @@ namespace vm
 
 	bool check_addr(u32 addr, u32 size, u8 flags)
 	{
+		if (size == 0)
+		{
+			return true;
+		}
+
 		// Overflow checking
 		if (addr + size < addr && (addr + size) != 0)
 		{


### PR DESCRIPTION
* When passing unmapped memory to those functions something unexpected happens:
The first memory transaction (64k unless cellFsSetIoBuffer is used, todo) is checked with EFAULT, but the rest don't!
Instead they abort the operation, return CELL_OK and nread/nwrite is set to what succeeded to write/read until then.

Testcase: https://github.com/elad335/myps3tests/tree/master/ppu_tests/cellFsWrite-Read%20unallocated%20memory%20bound .

~~This also potentially fixes some page faults with some Unity games when passing page faults notifications enabled unmapped memory to those functions.~~