### PR TITLE
small improvement

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -273,7 +273,6 @@ static error_code check_camera_info(const CellCameraInfoEx& info)
 
 std::pair<u32, u32> get_video_resolution(const CellCameraInfoEx& info)
 {
-	std::pair<u32, u32> res;
 	switch (info.resolution)
 	{
 	case CELL_CAMERA_VGA: return{ 640, 480 };

--- a/rpcs3/Emu/Cell/Modules/cellSsl.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSsl.cpp
@@ -75,7 +75,7 @@ s32 cellSslGetMemoryInfo()
 	return CELL_OK;
 }
 
-std::string getCert(const std::string certPath, const int certID, const bool isNormalCert)
+std::string getCert(const std::string& certPath, const int certID, const bool isNormalCert)
 {
 	int newID = certID;
 

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -421,7 +421,6 @@ bool gdb_thread::select_thread(u64 id)
 
 std::string gdb_thread::get_reg(ppu_thread* thread, u32 rid)
 {
-	std::string result;
 	//ids from gdb/features/rs6000/powerpc-64.c
 	//pc
 	switch (rid) {

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -271,8 +271,9 @@ namespace rsx
 			}
 			else
 			{
+				const auto reserve = list1.size() + list2.size();
 				surface_info = std::move(list1);
-				surface_info.reserve(list1.size() + list2.size());
+				surface_info.reserve(reserve);
 
 				for (const auto& e : list2) surface_info.push_back(e);
 			}
@@ -475,6 +476,7 @@ namespace rsx
 				}
 			}
 
+			const bool not_old_surface_storage = !old_surface_storage;
 			// Check for stale storage
 			if (old_surface_storage)
 			{
@@ -543,7 +545,7 @@ namespace rsx
 				(*primary_storage)[address] = std::move(new_surface_storage);
 			}
 
-			verify(HERE), !old_surface_storage, new_surface->get_spp() == get_format_sample_count(antialias);
+			verify(HERE), not_old_surface_storage, new_surface->get_spp() == get_format_sample_count(antialias);
 			return new_surface;
 		}
 

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -476,7 +476,6 @@ namespace rsx
 				}
 			}
 
-			const bool not_old_surface_storage = !old_surface_storage;
 			// Check for stale storage
 			if (old_surface_storage)
 			{
@@ -545,7 +544,7 @@ namespace rsx
 				(*primary_storage)[address] = std::move(new_surface_storage);
 			}
 
-			verify(HERE), not_old_surface_storage, new_surface->get_spp() == get_format_sample_count(antialias);
+			verify(HERE), !old_surface_storage, new_surface->get_spp() == get_format_sample_count(antialias);
 			return new_surface;
 		}
 

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -50,8 +50,6 @@ void GLFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 
 void GLFragmentDecompilerThread::insertInputs(std::stringstream & OS)
 {
-	std::vector<std::string> inputs_to_declare;
-
 	for (const ParamType& PT : m_parr.params[PF_PARAM_IN])
 	{
 		for (const ParamItem& PI : PT.items)

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -49,7 +49,7 @@ namespace vk
 
 		allocated_memory = std::make_unique<vk::buffer>(dev, size,
 			dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-			VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
+			VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
 
 		page_info.resize(size / s_bytes_per_entry, ~0ull);
 	}
@@ -210,7 +210,7 @@ namespace vk
 
 		auto new_allocation = std::make_unique<vk::buffer>(dev, new_size,
 			dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-			VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
+			VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
 
 		VkBufferCopy copy{};
 		copy.size = allocated_memory->size();

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -697,7 +697,6 @@ PadHandlerBase::connection evdev_joystick_handler::update_connection(const std::
 
 void evdev_joystick_handler::get_mapping(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad)
 {
-	std::unordered_map<u64, u16> values;
 	m_dev = std::static_pointer_cast<EvdevDevice>(device);
 	if (!m_dev || !pad)
 		return;


### PR DESCRIPTION
Hello

I fixed some common issues in the code. Access to moved variable is not a good idea, for example. Also several unused local variables are removed. And lost `&` in a function argument.

But, some expressions are really need to be clarified, they looks like some kind of issues:

1. rpcs3/Emu/RSX/VK/VKDMA.cpp (lines 52, 213)
`VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);`
This is a same constants in a both sides of | operation;

2. rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp:696
`ctxt->selectWorkloadAddr = isKernel2 ? CELL_SPURS_KERNEL2_SELECT_WORKLOAD_ADDR : CELL_SPURS_KERNEL1_SELECT_WORKLOAD_ADDR;`
Looks legit, but in rpcs3/Emu/Cell/Modules/cellSpurs.h:114,115
`CELL_SPURS_KERNEL1_SELECT_WORKLOAD_ADDR = 0x290,`
`CELL_SPURS_KERNEL2_SELECT_WORKLOAD_ADDR = 0x290,`
both constants has the same value and no comments around; That's intriguing 