### PR TITLE
Regression fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -971,7 +971,7 @@ error_code cellVdecSetFrameRate(u32 handle, CellVdecFrameRate frameRateCode)
 	const auto vdec = idm::get<vdec_context>(handle);
 
 	// 0x80 seems like a common prefix
-	if (!vdec || (frameRateCode & 0xf0) != 0x80)
+	if (!vdec || (frameRateCode & 0xf8) != 0x80)
 	{
 		return CELL_VDEC_ERROR_ARG;
 	}

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -1908,20 +1908,16 @@ bool spu_interpreter_precise::FREST(spu_thread& spu, spu_opcode_t op)
 	for (int i = 0; i < 4; i++)
 	{
 		const auto a = ra._f[i];
-		switch (fexpf(a))
-		{
-		case 0:
+		const int exp = fexpf(a);
+
+		if (exp == 0)
 		{
 			spu.fpscr.setDivideByZeroFlag(i);
 			res._f[i] = extended(std::signbit(a), 0x7FFFFF);
-			break;
 		}
-		case (0x7e800000 >> 23): // Special case for value not handled properly in rcpps
+		else if (exp >= (0x7e800000 >> 23)) // Special case for values not handled properly in rcpps
 		{
 			res._f[i] = 0.0f;
-			break;
-		}
-		default: break;
 		}
 	}
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7225,7 +7225,7 @@ public:
 		{
 			const auto a = get_vr<f32[4]>(op.ra);
 			const auto mask_ov = sext<s32[4]>(bitcast<s32[4]>(fabs(a)) > splat<s32[4]>(0x7e7fffff));
-			const auto mask_de = eval(noncast<u32[4]>(sext<s32[4]>(fcmp_uno(a == fsplat<f32[4]>(0.)))) >> 1);
+			const auto mask_de = eval(noncast<u32[4]>(sext<s32[4]>(fcmp_ord(a == fsplat<f32[4]>(0.)))) >> 1);
 			set_vr(op.rt, (bitcast<s32[4]>(fre(a)) & ~mask_ov) | noncast<s32[4]>(mask_de));
 		}
 		else

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -998,13 +998,9 @@ std::string spu_thread::dump() const
 {
 	std::string ret = cpu_thread::dump();
 
-	if (group)
-	{
-		fmt::append(ret, "\nGroup ID: 0x%x", group->id);
-	}
-
 	fmt::append(ret, "\nBlock Weight: %u (Retreats: %u)", block_counter, block_failure);
 	fmt::append(ret, "\n[%s]", ch_mfc_cmd);
+	fmt::append(ret, "\nLocal Storage: 0x%08x..0x%08x", offset, offset + 0x3ffff);
 	fmt::append(ret, "\nTag Mask: 0x%08x", ch_tag_mask);
 	fmt::append(ret, "\nMFC Stall: 0x%08x", ch_stall_mask);
 	fmt::append(ret, "\nMFC Queue Size: %u", mfc_size);

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -120,7 +120,7 @@ u64 lv2_file::op_write(vm::cptr<void> buf, u64 size)
 	while (result < size)
 	{
 		const u64 block = std::min<u64>(size - result, sizeof(local_buf));
-		std::memcpy(local_buf, static_cast<const uchar*>(buf.get_ptr()), block);
+		std::memcpy(local_buf, static_cast<const uchar*>(buf.get_ptr()) + result, block);
 		const u64 nwrite = file.write(+local_buf, block);
 		result += nwrite;
 


### PR DESCRIPTION
* Fixups after pull requests #7281, #6998, #7257 
* Add LS address range to the debugger, remove obsolute spu group id entry (can be determined by `spu.lv2_id | 0x4000000`). 