### PR TITLE
[TESTERS NEEDED] rsx: Sync on texture read semaphore

### DIFF
--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -219,6 +219,10 @@ namespace rsx
 		{
 			// Pipeline barrier seems to be equivalent to a SHADER_READ stage barrier
 			rsx::g_dma_manager.sync();
+			if (g_cfg.video.strict_rendering_mode)
+			{
+				rsx->sync();
+			}
 
 			// lle-gcm likes to inject system reserved semaphores, presumably for system/vsh usage
 			// Avoid calling render to avoid any havoc(flickering) they may cause from invalid flush/write


### PR DESCRIPTION
One game uses texture semaphore for zcull sync which is rather bizzare. However, it works on realhw as the depth test happens before fragment shader completion.

Need confirmation that this PR does not degrade performance in ZCULL heavy games (RDR, skate series, unreal engine, etc) before I can merge. If a performance regression is uncovered even later on, I'd rather the fix be a revert of this one rather than attempted extension.

Fixes https://github.com/RPCS3/rpcs3/issues/5526