### PR TITLE
Exit emulation on Esc key press

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -137,7 +137,8 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 		if (keyEvent->modifiers() == Qt::AltModifier) { toggle_fullscreen(); return; }
 		break;
 	case Qt::Key_Escape:
-		QWindow::close();
+		if (!Emu.HasGui()) { QWindow::close(); }
+		else if (visibility() == FullScreen) { toggle_fullscreen(); return; }
 		break;
 	case Qt::Key_P:
 		if (keyEvent->modifiers() == Qt::ControlModifier && Emu.IsRunning()) { Emu.Pause(); return; }

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -137,7 +137,7 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 		if (keyEvent->modifiers() == Qt::AltModifier) { toggle_fullscreen(); return; }
 		break;
 	case Qt::Key_Escape:
-		if (visibility() == FullScreen) { toggle_fullscreen(); return; }
+		QWindow::close();
 		break;
 	case Qt::Key_P:
 		if (keyEvent->modifiers() == Qt::ControlModifier && Emu.IsRunning()) { Emu.Pause(); return; }

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -130,6 +130,9 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 {
 	switch (keyEvent->key())
 	{
+	case Qt::Key_Backspace:
+		QWindow::close();
+		break;
 	case Qt::Key_L:
 		if (keyEvent->modifiers() == Qt::AltModifier) { static int count = 0; LOG_SUCCESS(GENERAL, "Made forced mark %d in log", ++count); }
 		break;
@@ -137,8 +140,7 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 		if (keyEvent->modifiers() == Qt::AltModifier) { toggle_fullscreen(); return; }
 		break;
 	case Qt::Key_Escape:
-		if (!Emu.HasGui()) { QWindow::close(); }
-		else if (visibility() == FullScreen) { toggle_fullscreen(); return; }
+		if (visibility() == FullScreen) { toggle_fullscreen(); return; }
 		break;
 	case Qt::Key_P:
 		if (keyEvent->modifiers() == Qt::ControlModifier && Emu.IsRunning()) { Emu.Pause(); return; }


### PR DESCRIPTION
This will help people using a gamepad with the home button mapped to the <kbd>Esc</kbd> key.

Calling `QWindow::close()` will respect all configured events: check confirmation on exit, etc, etc.

Related to #5681.