### PR TITLE
overlays: Graph label tune-up

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -1167,6 +1167,7 @@ namespace rsx
 			void set_count(u32 datapoint_count);
 			void set_color(color4f color);
 			void set_guide_interval(f32 guide_interval);
+			u16 get_height() const;
 			void record_datapoint(f32 datapoint);
 			void update();
 			compiled_resource& get_compiled() override;


### PR DESCRIPTION
Place graph text on top, split in 2 lines, center it horzintally.
Also if it's wider than the graph, match up graph's width to it.

---

![image](https://user-images.githubusercontent.com/6632271/73071539-a8cc7700-3ebb-11ea-8099-9829cc05e55c.png)

![image](https://user-images.githubusercontent.com/6632271/73071088-956cdc00-3eba-11ea-8e21-5e9c8f7c8bb4.png)

![image](https://user-images.githubusercontent.com/6632271/73071580-ca2d6300-3ebb-11ea-934d-c60636d3cc46.png)
