### PR TITLE
rsx: Fix a few texture data leaks

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -221,8 +221,8 @@ namespace rsx
 				u16 min_x = external_subresource_desc.width, min_y = external_subresource_desc.height,
 					max_x = 0, max_y = 0;
 
-				// Require at least 50% coverage
-				const u32 target_area = (min_x * min_y) / 2;
+				// Require at least 90% coverage
+				const u32 target_area = ((min_x * min_y) * 90u) / 100u;
 
 				for (const auto &section : external_subresource_desc.sections_to_copy)
 				{
@@ -1553,6 +1553,14 @@ namespace rsx
 				{
 					if (cached_texture->matches(attr.address, attr.gcm_format, attr.width, attr.height, attr.depth, 0))
 					{
+#ifdef TEXTURE_CACHE_DEBUG
+						if (!memory_range.inside(cached_texture->get_confirmed_range()))
+						{
+							// TODO. This is easily possible for blit_dst textures if the blit is incomplete in Y
+							// The possibility that a texture will be split into parts on the CPU like this is very rare
+							continue;
+						}
+#endif
 						return{ cached_texture->get_view(encoded_remap, remap), cached_texture->get_context(), cached_texture->get_format_type(), scale, cached_texture->get_image_type() };
 					}
 				}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1592,6 +1592,10 @@ void VKGSRender::end()
 						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst;
 						raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 						break;
+					case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_src;
+						raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+						break;
 					case VK_IMAGE_LAYOUT_GENERAL:
 						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
 						if (!sampler_state->is_cyclic_reference)
@@ -1722,6 +1726,10 @@ void VKGSRender::end()
 				break;
 			case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
 				verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst;
+				raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+				break;
+			case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+				verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_src;
 				raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 				break;
 			case VK_IMAGE_LAYOUT_GENERAL:

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1269,7 +1269,34 @@ namespace vk
 
 			vk::leave_uninterruptible();
 
-			change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, subres_range);
+			// Insert appropriate barrier depending on use
+			VkImageLayout preferred_layout;
+			switch (context)
+			{
+			default:
+				preferred_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+				break;
+			case rsx::texture_upload_context::blit_engine_dst:
+				preferred_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+				break;
+			case rsx::texture_upload_context::blit_engine_src:
+				preferred_layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+				break;
+			}
+
+			if (preferred_layout != image->current_layout)
+			{
+				change_image_layout(cmd, image, preferred_layout, subres_range);
+			}
+			else
+			{
+				// Insert ordering barrier
+				verify(HERE), preferred_layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+				insert_image_memory_barrier(cmd, image->value, image->current_layout, preferred_layout,
+					VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+					VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_WRITE_BIT,
+					subres_range);
+			}
 
 			section->last_write_tag = rsx::get_shared_tag();
 			return section;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -246,6 +246,14 @@ namespace vk
 				}
 				else
 				{
+					if (context != rsx::texture_upload_context::dma)
+					{
+						// Partial load for the bits outside the existing image
+						// NOTE: A true DMA section would have been prepped beforehand
+						// TODO: Parial range load/flush
+						vk::load_dma(valid_range.start, section_length);
+					}
+
 					std::vector<VkBufferCopy> copy;
 					copy.reserve(transfer_height);
 


### PR DESCRIPTION
- Do not sample from incomplete textures! Raises minimum texel completeness to 99% if only one texture is found inside a range. This should exclude textures smaller than the required and avoid introducing black regions to partial blit engine textures.
- If a trivial blit operation is happening, but a live shader_read resource exists in the same range, this signifies a flush is very likely to occur. Use CPU fallback instead for performance reasons.
- Fix blit engine resources having needless memory barriers in vulkan.
- Fix some leaking texels when flushing incomplete textures using the revised vulkan DMA system. Some extensions need to be added to properly handle strided data operations.

Fixes https://github.com/RPCS3/rpcs3/issues/6822