### PR TITLE
Qt: Present game removal failure to the user

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1065,18 +1065,26 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		mb->deleteLater();
 		if (mb->exec() == QMessageBox::Yes)
 		{
-			if (mb->checkBox()->isChecked())
+			const bool remove_caches = mb->checkBox()->isChecked();
+			if (fs::remove_all(currGame.path))
 			{
-				RemoveShadersCache(cache_base_dir);
-				RemovePPUCache(cache_base_dir);
-				RemoveSPUCache(cache_base_dir);
-				RemoveCustomConfiguration(currGame.serial);
-				RemoveCustomPadConfiguration(currGame.serial);
+				if (remove_caches)
+				{
+					RemoveShadersCache(cache_base_dir);
+					RemovePPUCache(cache_base_dir);
+					RemoveSPUCache(cache_base_dir);
+					RemoveCustomConfiguration(currGame.serial);
+					RemoveCustomPadConfiguration(currGame.serial);
+				}
+				m_game_data.erase(std::remove(m_game_data.begin(), m_game_data.end(), gameinfo), m_game_data.end());
+				LOG_SUCCESS(GENERAL, "Removed %s %s in %s", currGame.category, currGame.name, currGame.path);
+				Refresh(true);
 			}
-			fs::remove_all(currGame.path);
-			m_game_data.erase(std::remove(m_game_data.begin(), m_game_data.end(), gameinfo), m_game_data.end());
-			LOG_SUCCESS(GENERAL, "Removed %s %s in %s", currGame.category, currGame.name, currGame.path);
-			Refresh(true);
+			else
+			{
+				LOG_ERROR(GENERAL, "Failed to remove %s %s in %s (%s)", currGame.category, currGame.name, currGame.path, fs::g_tls_error);
+				QMessageBox::critical(this, tr("Failure!"), tr(remove_caches ? "Failed to remove %0 from drive!\nPath: %1\nCaches and custom configs have been left intact." : "Failed to remove %0 from drive!\nPath: %1").arg(name).arg(qstr(currGame.path)));
+			}
 		}
 	});
 	connect(openGameFolder, &QAction::triggered, [=]()


### PR DESCRIPTION
This PR extends "Remove HDD Game" option with proper failure reporting. `fs::remove_all` already returned failure but UI code ignored it.
Now in case of failure to remove game files, caches/configs are left untouched. Error message informs the use about that appropriately.

![image](https://user-images.githubusercontent.com/7947461/73123292-c4ed1880-3f8e-11ea-8609-76eb3a58523e.png)

Fixes #7228