### PR TITLE
sys_spu: Implement proper SPU group flags

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2869,8 +2869,9 @@ bool spu_thread::stop_and_signal(u32 code)
 
 		spu_log.trace("sys_spu_thread_receive_event(spuq=0x%x)", spuq);
 
-		if (group->type & SYS_SPU_THREAD_GROUP_TYPE_EXCLUSIVE_NON_CONTEXT) // this check may be inaccurate
+		if (!group->has_scheduler_context /*|| group->type & 0xf00*/)
 		{
+			spu_log.error("sys_spu_thread_receive_event(): Incompatible group type = 0x%x", group->type);
 			return ch_in_mbox.set_values(1, CELL_EINVAL), true;
 		}
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -457,7 +457,7 @@ error_code sys_spu_thread_group_create(ppu_thread& ppu, vm::ptr<u32> id, u32 num
 		}
 
 		min_threads = 2; // That's what appears from reversing
-		[[fallthrough]];
+		break;
 	}
 
 	case 0x2:

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -7,10 +7,12 @@
 #include "Emu/Memory/vm_ptr.h"
 #include "Utilities/File.h"
 
+struct lv2_memory_container;
+
 enum : s32
 {
 	SYS_SPU_THREAD_GROUP_TYPE_NORMAL                = 0x00,
-	SYS_SPU_THREAD_GROUP_TYPE_SEQUENTIAL            = 0x01,
+	//SYS_SPU_THREAD_GROUP_TYPE_SEQUENTIAL            = 0x01, doesn't exist
 	SYS_SPU_THREAD_GROUP_TYPE_SYSTEM                = 0x02,
 	SYS_SPU_THREAD_GROUP_TYPE_MEMORY_FROM_CONTAINER = 0x04,
 	SYS_SPU_THREAD_GROUP_TYPE_NON_CONTEXT           = 0x08,
@@ -239,8 +241,10 @@ struct lv2_spu_group
 	const std::string name;
 	const u32 id;
 	const u32 max_num;
+	const u32 mem_size;
 	const s32 type; // SPU Thread Group Type
-	const u32 ct; // Memory Container Id
+	lv2_memory_container* const ct; // Memory Container
+	const bool has_scheduler_context;
 	u32 max_run;
 
 	shared_mutex mutex;
@@ -264,15 +268,17 @@ struct lv2_spu_group
 	std::weak_ptr<lv2_event_queue> ep_exception; // TODO: SYS_SPU_THREAD_GROUP_EVENT_EXCEPTION
 	std::weak_ptr<lv2_event_queue> ep_sysmodule; // TODO: SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE
 
-	lv2_spu_group(std::string name, u32 num, s32 prio, s32 type, u32 ct)
+	lv2_spu_group(std::string name, u32 num, s32 prio, s32 type, lv2_memory_container* ct, bool uses_scheduler, u32 mem_size)
 		: id(idm::last_id())
 		, name(name)
 		, max_num(num)
 		, max_run(num)
+		, mem_size(mem_size)
 		, init(0)
 		, prio(prio)
 		, type(type)
 		, ct(ct)
+		, has_scheduler_context(uses_scheduler)
 		, run_state(SPU_THREAD_GROUP_STATUS_NOT_INITIALIZED)
 		, exit_status(0)
 		, join_state(0)


### PR DESCRIPTION
* Following #4331, register all SPU group types with no scheduler context.
For those type don't check priority, return EINVAL in sys_spu_thread_receive_event, sys_spu_thread_group_suspend/resume.
Those are all the types with either SYS_SPU_THREAD_GROUP_TYPE_NON_CONTEXT (0x8) or SYS_SPU_THREAD_GROUP_TYPE_COOPERATE_WITH_SYSTEM (0x20) flags enabled.
* Implement SYS_SPU_THREAD_GROUP_TYPE_MEMORY_FROM_CONTAINER (0x4) flag.
* Add root permission checks for types which need it.
* Add checks in for sys_spu_thread_group_yield/resum/suspend if spceific system root group flags are set (0xf00). 
RE-ed from fw, includes types used by vsh as well.