### PR TITLE
Add Ctrl + BackSpace to exit emulation window

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -130,6 +130,9 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 {
 	switch (keyEvent->key())
 	{
+	case Qt::Key_Backspace:
+		if (keyEvent->modifiers() == Qt::ControlModifier) { QWindow::close(); return; }
+		break;
 	case Qt::Key_L:
 		if (keyEvent->modifiers() == Qt::AltModifier) { static int count = 0; LOG_SUCCESS(GENERAL, "Made forced mark %d in log", ++count); }
 		break;


### PR DESCRIPTION
Under `gs_frame`, actually we have keys for pause/stop/resume emulation, take screenshots and to toggle fullscreen, but not a key to exit current emulation (or open the confirmation dialog).

Using <kbd>BackSpace</kbd> (a key not used right now) to call `QWindow::close()` will respect all configured events: check confirmation on exit, etc, etc.

When the keybind manager get ready, user will be able to edit this key.