### PR TITLE
Increase Maximum Vblank Rate and Clocks Scale

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -253,13 +253,10 @@ public:
 	template<bool is_usleep = false>
 	static bool wait_timeout(u64 usec, cpu_thread* const cpu = {})
 	{
-		static_assert(UINT64_MAX / cond_variable::max_timeout >= g_cfg.core.clocks_scale.max, "timeout may overflow during scaling");
+		static_assert(UINT64_MAX / cond_variable::max_timeout >= 100, "max timeout is not valid for scaling");
 
-		// Clamp to max timeout accepted
-		const u64 max_usec = cond_variable::max_timeout * 100 / g_cfg.core.clocks_scale.max;
-
-		// Now scale the result
-		usec = (std::min<u64>(usec, max_usec) * g_cfg.core.clocks_scale) / 100;
+		// Clamp and scale the result
+		usec = std::min<u64>(std::min<u64>(usec, UINT64_MAX / 100) * 100 / g_cfg.core.clocks_scale, cond_variable::max_timeout);
 
 		extern u64 get_system_time();
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -502,8 +502,8 @@ namespace rsx
 #endif
 			u64 start_time = get_system_time();
 
-			const u64 period_time = 1000000 / g_cfg.video.vblank_rate;
-			const u64 wait_sleep = period_time - u64{period_time >= host_min_quantum} * host_min_quantum;
+			u64 period_time = 1000000 / g_cfg.video.vblank_rate;
+			u64 wait_sleep = period_time - u64{period_time >= host_min_quantum} * host_min_quantum;
 
 			// TODO: exit condition
 			while (!Emu.IsStopped() && !m_rsx_thread_exiting)
@@ -537,6 +537,8 @@ namespace rsx
 					while (get_system_time() - start_time >= period_time);
 
 					thread_ctrl::wait_for(wait_sleep);
+					period_time = 1000000 / g_cfg.video.vblank_rate; // Update its value
+					wait_sleep = period_time - u64{period_time >= host_min_quantum} * host_min_quantum;
 					continue;
 				}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -502,12 +502,12 @@ namespace rsx
 #endif
 			u64 start_time = get_system_time();
 
-			u64 period_time = 1000000 / g_cfg.video.vblank_rate;
-			u64 wait_sleep = period_time - u64{period_time >= host_min_quantum} * host_min_quantum;
-
 			// TODO: exit condition
 			while (!Emu.IsStopped() && !m_rsx_thread_exiting)
 			{
+				const u64 period_time = 1000000 / g_cfg.video.vblank_rate;
+				const u64 wait_sleep = period_time - u64{period_time >= host_min_quantum} * host_min_quantum;
+
 				if (get_system_time() - start_time >= period_time)
 				{
 					do
@@ -537,8 +537,6 @@ namespace rsx
 					while (get_system_time() - start_time >= period_time);
 
 					thread_ctrl::wait_for(wait_sleep);
-					period_time = 1000000 / g_cfg.video.vblank_rate; // Update its value
-					wait_sleep = period_time - u64{period_time >= host_min_quantum} * host_min_quantum;
 					continue;
 				}
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -424,7 +424,7 @@ struct cfg_root : cfg::node
 		cfg::set_entry load_libraries{this, "Load libraries"};
 		cfg::_bool hle_lwmutex{this, "HLE lwmutex"}; // Force alternative lwmutex/lwcond implementation
 
-		cfg::_int<10, 1000> clocks_scale{this, "Clocks scale", 100}; // Changing this from 100 (percentage) may affect game speed in unexpected ways
+		cfg::_int<10, 3000> clocks_scale{this, "Clocks scale", 100, true}; // Changing this from 100 (percentage) may affect game speed in unexpected ways
 		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{this, "Sleep Timers Accuracy",
 #ifdef __linux__
 		sleep_timers_accuracy_level::_as_host};
@@ -504,7 +504,7 @@ struct cfg_root : cfg::node
 		cfg::_int<1, 1024> min_scalable_dimension{this, "Minimum Scalable Dimension", 16};
 		cfg::_int<0, 30000000> driver_recovery_timeout{this, "Driver Recovery Timeout", 1000000, true};
 		cfg::_int<0, 16667> driver_wakeup_delay{this, "Driver Wake-Up Delay", 1, true};
-		cfg::_int<1, 500> vblank_rate{this, "Vblank Rate", 60}; // Changing this from 60 may affect game speed in unexpected ways
+		cfg::_int<1, 1800> vblank_rate{this, "Vblank Rate", 60, true}; // Changing this from 60 may affect game speed in unexpected ways
 
 		struct node_vk : cfg::node
 		{


### PR DESCRIPTION
Allow x30 times the speed of vblank rate + clocks scale of original PS3.
In theory a 60 fps limit game which scales frame limit perfectly with vblank rate can be played at up to 1800 fps with this change.

And:
* Fixed lv2 sleep with Clocks Scaling.
* Make these settings dynamicaly adjustable.