### PR TITLE
Don't block the explorer during installations

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "utils.h"
 #include "aes.h"
 #include "sha1.h"
@@ -10,6 +10,12 @@
 
 bool pkg_install(const std::string& path, atomic_t<double>& sync)
 {
+	if (!fs::is_file(path))
+	{
+		LOG_ERROR(LOADER, "PKG file not found!");
+		return false;
+	}
+
 	const std::size_t BUF_SIZE = 8192 * 1024; // 8 MB
 
 	std::vector<fs::file> filelist;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -397,6 +397,18 @@ void main_window::InstallPackages(QStringList file_paths, bool show_confirm)
 		}
 	}
 
+	if (!file_paths.isEmpty())
+	{
+		// Handle the actual installations with a timeout. Otherwise the source explorer instance is not usable during the following file processing.
+		QTimer::singleShot(0, [this, file_paths]()
+		{
+			HandlePackageInstallation(file_paths);
+		});
+	}
+}
+
+void main_window::HandlePackageInstallation(QStringList file_paths)
+{
 	if (file_paths.isEmpty())
 	{
 		return;
@@ -490,24 +502,36 @@ void main_window::InstallPackages(QStringList file_paths, bool show_confirm)
 	}
 }
 
-void main_window::InstallPup(QString filePath)
+void main_window::InstallPup(QString file_path)
 {
-	if (filePath.isEmpty())
+	if (file_path.isEmpty())
 	{
 		QString path_last_PUP = guiSettings->GetValue(gui::fd_install_pup).toString();
-		filePath = QFileDialog::getOpenFileName(this, tr("Select PS3UPDAT.PUP To Install"), path_last_PUP, tr("PS3 update file (PS3UPDAT.PUP);;All pup files (*.pup);;All files (*.*)"));
+		file_path = QFileDialog::getOpenFileName(this, tr("Select PS3UPDAT.PUP To Install"), path_last_PUP, tr("PS3 update file (PS3UPDAT.PUP);;All pup files (*.pup);;All files (*.*)"));
 	}
 	else
 	{
-		if (QMessageBox::question(this, tr("RPCS3 Firmware Installer"), tr("Install firmware: %1?").arg(filePath),
+		if (QMessageBox::question(this, tr("RPCS3 Firmware Installer"), tr("Install firmware: %1?").arg(file_path),
 			QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
 		{
-			LOG_NOTICE(LOADER, "Firmware: Cancelled installation from drop. File: %s", sstr(filePath));
+			LOG_NOTICE(LOADER, "Firmware: Cancelled installation from drop. File: %s", sstr(file_path));
 			return;
 		}
 	}
 
-	if (filePath.isEmpty())
+	if (!file_path.isEmpty())
+	{
+		// Handle the actual installation with a timeout. Otherwise the source explorer instance is not usable during the following file processing.
+		QTimer::singleShot(0, [this, file_path]()
+		{
+			HandlePupInstallation(file_path);
+		});
+	}
+}
+
+void main_window::HandlePupInstallation(QString file_path)
+{
+	if (file_path.isEmpty())
 	{
 		return;
 	}
@@ -515,8 +539,8 @@ void main_window::InstallPup(QString filePath)
 	Emu.SetForceBoot(true);
 	Emu.Stop();
 
-	guiSettings->SetValue(gui::fd_install_pup, QFileInfo(filePath).path());
-	const std::string path = sstr(filePath);
+	guiSettings->SetValue(gui::fd_install_pup, QFileInfo(file_path).path());
+	const std::string path = sstr(file_path);
 
 	fs::file pup_f(path);
 	if (!pup_f)

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -117,8 +117,12 @@ private:
 	void CreateDockWindows();
 	void EnableMenus(bool enabled);
 	void ShowTitleBars(bool show);
+
 	void InstallPackages(QStringList file_paths = QStringList(), bool show_confirm = true);
+	void HandlePackageInstallation(QStringList file_paths = QStringList());
+
 	void InstallPup(QString filePath = "");
+	void HandlePupInstallation(QString file_path = "");
 
 	int IsValidFile(const QMimeData& md, QStringList* dropPaths = nullptr);
 	void AddGamesFromDir(const QString& path);


### PR DESCRIPTION
This should fix the following issue:
When using drag&drop to install stuff the windows explorer instance was useless until the installation was complete.