### PR TITLE
Fix ellipsis

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -402,7 +402,7 @@ void main_window::InstallPackages(QStringList file_paths, bool show_confirm)
 		return;
 	}
 
-	progress_dialog pdlg(tr("RPCS3 Package Installer"), tr("Installing package, please wait…"), tr("Cancel"), 0, 1000, false, this);
+	progress_dialog pdlg(tr("RPCS3 Package Installer"), tr("Installing package, please wait..."), tr("Cancel"), 0, 1000, false, this);
 	pdlg.show();
 
 	// Synchronization variable
@@ -415,7 +415,7 @@ void main_window::InstallPackages(QStringList file_paths, bool show_confirm)
 		progress = 0.;
 
 		pdlg.SetValue(0);
-		pdlg.setLabelText(tr("Installing package (%0/%1), please wait…").arg(i + 1).arg(count));
+		pdlg.setLabelText(tr("Installing package (%0/%1), please wait...").arg(i + 1).arg(count));
 		pdlg.show();
 
 		Emu.SetForceBoot(true);


### PR DESCRIPTION
… is an UTF-8 character and those don't really belong in messages like this anyway.

Prevents a broken character from displaying:
![image](https://user-images.githubusercontent.com/7947461/73443597-4bbb4000-4357-11ea-8815-134be69fbdec.png)
