### PR TITLE
Make rsx::get_address report caller location

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -142,7 +142,7 @@ vm::ptr<CellGcmReportData> cellGcmGetReportDataAddressLocation(u32 index, u32 lo
 		cellGcmSys.error("cellGcmGetReportDataAddressLocation: Wrong local index (%d)", index);
 	}
 
-	return vm::ptr<CellGcmReportData>::make(g_fxo->get<gcm_config>()->gcm_info.label_addr + 0x1400 + index * 0x10);
+	return vm::ptr<CellGcmReportData>::make(g_fxo->get<gcm_config>()->gcm_info.label_addr + ::offset32(&RsxReports::report) + index * 0x10);
 }
 
 u64 cellGcmGetTimeStamp(u32 index)
@@ -154,7 +154,7 @@ u64 cellGcmGetTimeStamp(u32 index)
 		cellGcmSys.error("cellGcmGetTimeStamp: Wrong local index (%d)", index);
 	}
 
-	return vm::read64(g_fxo->get<gcm_config>()->gcm_info.label_addr + 0x1400 + index * 0x10);
+	return vm::read64(g_fxo->get<gcm_config>()->gcm_info.label_addr + ::offset32(&RsxReports::report) + index * 0x10);
 }
 
 u32 cellGcmGetCurrentField()
@@ -181,7 +181,7 @@ u32 cellGcmGetNotifyDataAddress(u32 index)
  */
 vm::ptr<CellGcmReportData> _cellGcmFunc12()
 {
-	return vm::ptr<CellGcmReportData>::make(g_fxo->get<gcm_config>()->gcm_info.label_addr + 0x1400); // TODO
+	return vm::ptr<CellGcmReportData>::make(g_fxo->get<gcm_config>()->gcm_info.label_addr + ::offset32(&RsxReports::report)); // TODO
 }
 
 u32 cellGcmGetReport(u32 type, u32 index)
@@ -210,7 +210,7 @@ u32 cellGcmGetReportDataAddress(u32 index)
 		cellGcmSys.error("cellGcmGetReportDataAddress: Wrong local index (%d)", index);
 	}
 
-	return g_fxo->get<gcm_config>()->gcm_info.label_addr + 0x1400 + index * 0x10;
+	return g_fxo->get<gcm_config>()->gcm_info.label_addr + ::offset32(&RsxReports::report) + index * 0x10;
 }
 
 u32 cellGcmGetReportDataLocation(u32 index, u32 location)
@@ -230,7 +230,7 @@ u64 cellGcmGetTimeStampLocation(u32 index, u32 location)
 			cellGcmSys.error("cellGcmGetTimeStampLocation: Wrong local index (%d)", index);
 			return 0;
 		}
-		return vm::read64(g_fxo->get<gcm_config>()->gcm_info.label_addr + 0x1400 + index * 0x10);
+		return vm::read64(g_fxo->get<gcm_config>()->gcm_info.label_addr + ::offset32(&RsxReports::report) + index * 0x10);
 	}
 
 	if (location == CELL_GCM_LOCATION_MAIN) {
@@ -1049,12 +1049,14 @@ error_code cellGcmMapMainMemory(u32 ea, u32 size, vm::ptr<u32> offset)
 		{
 			if (unmap_count >= (size >> 20))
 			{
-				if (auto error = gcmMapEaIoAddress(io << 20, ea, size, false))
+				io <<= 20;
+
+				if (auto error = gcmMapEaIoAddress(ea, io, size, false))
 				{
 					return error;
 				}
 
-				*offset = io << 20;
+				*offset = io;
 				return CELL_OK;
 			}
 		}

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -56,7 +56,7 @@ namespace rsx
 			const u32 program_location = (shader_program & 0x3) - 1;
 			const u32 program_offset   = (shader_program & ~0x3);
 
-			const u32 addr          = get_address(program_offset, program_location);
+			const u32 addr          = get_address(program_offset, program_location, HERE);
 			const auto program_info = program_hash_util::fragment_program_utils::analyse_fragment_program(vm::base(addr));
 			const u32 program_start = program_info.program_start_offset;
 			const u32 ucode_size    = program_info.program_ucode_length;
@@ -77,7 +77,7 @@ namespace rsx
 				if (!tex.enabled())
 					continue;
 
-				const u32 texaddr = get_address(tex.offset(), tex.location());
+				const u32 texaddr = get_address(tex.offset(), tex.location(), HERE);
 				auto layout       = get_subresources_layout(tex);
 
 				// todo: dont use this function and just get size somehow
@@ -103,7 +103,7 @@ namespace rsx
 				if (!tex.enabled())
 					continue;
 
-				const u32 texaddr = get_address(tex.offset(), tex.location());
+				const u32 texaddr = get_address(tex.offset(), tex.location(), HERE);
 				auto layout       = get_subresources_layout(tex);
 
 				// todo: dont use this function and just get size somehow
@@ -141,7 +141,7 @@ namespace rsx
 					const u32 base_address    = get_vertex_offset_from_base(method_registers.vertex_data_base_offset(), info.offset() & 0x7fffffff);
 					const u32 memory_location = info.offset() >> 31;
 
-					const u32 addr       = get_address(base_address, memory_location);
+					const u32 addr       = get_address(base_address, memory_location, HERE);
 					const u32 vertSize   = get_vertex_type_size_on_host(info.type(), info.size());
 					const u32 vertStride = info.stride();
 
@@ -173,7 +173,7 @@ namespace rsx
 
 				const auto index_type = method_registers.index_type();
 				const u32 type_size   = get_index_type_size(index_type);
-				const u32 base_addr   = get_address(base_address, memory_location) & ~(type_size - 1);
+				const u32 base_addr   = get_address(base_address, memory_location, HERE) & (0 - type_size);
 
 				// manually parse index buffer and copy vertex buffer
 				u32 min_index = 0xFFFFFFFF, max_index = 0;
@@ -250,7 +250,7 @@ namespace rsx
 						const u32 base_address    = get_vertex_offset_from_base(method_registers.vertex_data_base_offset(), (info.offset() & 0x7fffffff));
 						const u32 memory_location = info.offset() >> 31;
 
-						const u32 addr     = get_address(base_address, memory_location);
+						const u32 addr     = get_address(base_address, memory_location, HERE);
 						const u32 vertSize = get_vertex_type_size_on_host(info.type(), info.size());
 						const u32 bufferSize = vertStride * (max_index - min_index + 1) + vertSize;
 
@@ -303,7 +303,7 @@ namespace rsx
 			block.offset = src_offset + in_offset;
 			block.location = src_dma & 0xf;
 
-			const auto src_address = rsx::get_address(block.offset, block.location);
+			const auto src_address = rsx::get_address(block.offset, block.location, HERE);
 			u8* pixels_src = vm::_ptr<u8>(src_address);
 
 			const u32 src_size = in_pitch * (in_h - 1) + (in_w * in_bpp);
@@ -326,7 +326,7 @@ namespace rsx
 
 			u32 src_offset = method_registers.nv0039_input_offset();
 			u32 src_dma    = method_registers.nv0039_input_location();
-			u32 src_addr   = get_address(src_offset, src_dma);
+			u32 src_addr   = get_address(src_offset, src_dma, HERE);
 
 			rsx->read_barrier(src_addr, in_pitch * (line_count - 1) + line_length, true);
 

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -116,7 +116,7 @@ namespace rsx
 				fmt::throw_exception("requested memory data state for command not found in memory_data_map");
 
 			const auto& data_block = it_data->second;
-			std::memcpy(vm::base(get_address(memblock.offset, memblock.location)), data_block.data.data(), data_block.data.size());
+			std::memcpy(vm::base(get_address(memblock.offset, memblock.location, HERE)), data_block.data.data(), data_block.data.size());
 		}
 
 		if (replay_cmd.display_buffer_state != 0 && replay_cmd.display_buffer_state != cs.display_buffer_hash)

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -459,7 +459,7 @@ std::vector<rsx_subresource_layout> get_subresources_layout_impl(const RsxTextur
 
 	int format = texture.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 
-	const u32 texaddr = rsx::get_address(texture.offset(), texture.location());
+	const u32 texaddr = rsx::get_address(texture.offset(), texture.location(), HERE);
 	auto pixels = vm::_ptr<const std::byte>(texaddr);
 
 	const bool is_swizzled = !(texture.format() & CELL_GCM_TEXTURE_LN);

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1712,7 +1712,7 @@ namespace rsx
 		{
 			image_section_attributes_t attributes{};
 			texture_cache_search_options options{};
-			attributes.address = rsx::get_address(tex.offset(), tex.location());
+			attributes.address = rsx::get_address(tex.offset(), tex.location(), HERE);
 			attributes.gcm_format = tex.format() & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 			attributes.bpp = get_format_block_size_in_bytes(attributes.gcm_format);
 			attributes.width = tex.width();

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -498,7 +498,7 @@ void GLGSRender::end()
 				for (auto &info : m_vertex_layout.interleaved_blocks)
 				{
 					const auto vertex_base_offset = rsx::method_registers.vertex_data_base_offset();
-					info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info.base_offset), info.memory_location);
+					info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info.base_offset), info.memory_location, HERE);
 				}
 			}
 		}
@@ -1607,10 +1607,13 @@ bool GLGSRender::scaled_image_from_memory(rsx::blit_src_info& src, rsx::blit_dst
 
 void GLGSRender::notify_tile_unbound(u32 tile)
 {
-	//TODO: Handle texture writeback
-	//u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
-	//on_notify_memory_unmapped(addr, tiles[tile].size);
-	//m_rtts.invalidate_surface_address(addr, false);
+	// TODO: Handle texture writeback
+	if (false)
+	{
+		u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location, HERE);
+		on_notify_memory_unmapped(addr, tiles[tile].size);
+		m_rtts.invalidate_surface_address(addr, false);
+	}
 
 	{
 		std::lock_guard lock(m_sampler_mutex);

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -130,7 +130,7 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 		present_info.height = buffer_height;
 		present_info.pitch = buffer_pitch;
 		present_info.format = av_format;
-		present_info.address = rsx::get_address(display_buffers[info.buffer].offset, CELL_GCM_LOCATION_LOCAL);
+		present_info.address = rsx::get_address(display_buffers[info.buffer].offset, CELL_GCM_LOCATION_LOCAL, HERE);
 
 		image_to_flip = get_present_source(&present_info, avconfig);
 		buffer_width = present_info.width;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -46,9 +46,10 @@ namespace rsx
 
 	dma_manager g_dma_manager;
 
-	u32 get_address(u32 offset, u32 location)
+	u32 get_address(u32 offset, u32 location, const char* from)
 	{
 		const auto render = get_current_renderer();
+		std::string_view msg;
 
 		switch (location)
 		{
@@ -60,7 +61,8 @@ namespace rsx
 				return rsx::constants::local_mem_base + offset;
 			}
 
-			fmt::throw_exception("GetAddress(offset=0x%x, location=0x%x): Local RSX offset out of range" HERE, offset, location);
+			msg = "Local RSX offset out of range!"sv;
+			break;
 		}
 
 		case CELL_GCM_CONTEXT_DMA_MEMORY_HOST_BUFFER:
@@ -71,7 +73,8 @@ namespace rsx
 				return result;
 			}
 
-			fmt::throw_exception("GetAddress(offset=0x%x, location=0x%x): RSXIO memory not mapped" HERE, offset, location);
+			msg = "RSXIO memory not mapped!"sv;
+			break;
 		}
 
 		case CELL_GCM_CONTEXT_DMA_REPORT_LOCATION_LOCAL:
@@ -81,25 +84,27 @@ namespace rsx
 				return render->label_addr + 0x1400 + offset;
 			}
 
-			fmt::throw_exception("GetAddress(offset=0x%x, location=0x%x): Local RSX REPORT offset out of range" HERE, offset, location);
+			msg = "Local RSX REPORT offset out of range!"sv;
+			break;
 		}
 
 		case CELL_GCM_CONTEXT_DMA_REPORT_LOCATION_MAIN:
 		{
-			if (u32 result = RSXIOMem.RealAddr(0x0e000000 + offset))
+			if (u32 result = offset < 0x1000000 ? RSXIOMem.RealAddr(0x0e000000 + offset) : 0)
 			{
 				return result;
 			}
 
-			fmt::throw_exception("GetAddress(offset=0x%x, location=0x%x): RSXIO memory not mapped" HERE, offset, location);
+			msg = "RSXIO REPORT memory not mapped!"sv;
+			break;
 		}
 
 		// They are handled elsewhere for targeted methods, so it's unexpected for them to be passed here
 		case CELL_GCM_CONTEXT_DMA_TO_MEMORY_GET_NOTIFY0:
-			fmt::throw_exception("Unexpected CELL_GCM_CONTEXT_DMA_TO_MEMORY_GET_NOTIFY0 (offset=0x%x, location=0x%x)" HERE, offset, location);
+			msg = "CELL_GCM_CONTEXT_DMA_TO_MEMORY_GET_NOTIFY0"sv; break;
 
 		case CELL_GCM_CONTEXT_DMA_NOTIFY_MAIN_0:
-			fmt::throw_exception("Unexpected CELL_GCM_CONTEXT_DMA_NOTIFY_MAIN_0 (offset=0x%x, location=0x%x)" HERE, offset, location);
+			msg = "CELL_GCM_CONTEXT_DMA_NOTIFY_MAIN_0"sv; break;
 
 		case CELL_GCM_CONTEXT_DMA_SEMAPHORE_RW:
 		case CELL_GCM_CONTEXT_DMA_SEMAPHORE_R:
@@ -109,7 +114,8 @@ namespace rsx
 				return render->label_addr + offset;
 			}
 
-			fmt::throw_exception("GetAddress(offset=0x%x, location=0x%x): DMA SEMAPHORE offset out of range" HERE, offset, location);
+			msg = "DMA SEMAPHORE offset out of range!"sv;
+			break;
 		}
 
 		case CELL_GCM_CONTEXT_DMA_DEVICE_RW:
@@ -122,14 +128,19 @@ namespace rsx
 
 			// TODO: What happens here? It could wrap around or access other segments of rsx internal memory etc
 			// Or can simply throw access violation error
-			fmt::throw_exception("GetAddress(offset=0x%x, location=0x%x): DMA DEVICE offset out of range" HERE, offset, location);
+			msg = "DMA DEVICE offset out of range!"sv;
+			break;
 		}
 
 		default:
 		{
-			fmt::throw_exception("Invalid location (offset=0x%x, location=0x%x)" HERE, offset, location);
+			msg = "Invalid location!"sv;
+			break;
 		}
 		}
+
+		// Assume 'from' contains new line at start
+		fmt::throw_exception("rsx::get_address(offset=0x%x, location=0x%x): %s%s", offset, location, msg, from);
 	}
 
 	u32 get_vertex_type_size_on_host(vertex_base_type type, u32 size)
@@ -836,8 +847,8 @@ namespace rsx
 		const rsx::index_array_type type = rsx::method_registers.index_type();
 		const u32 type_size = get_index_type_size(type);
 
-		u32 address = rsx::get_address(rsx::method_registers.index_array_address(), rsx::method_registers.index_array_location());
-		address &= ~(type_size - 1); // Force aligned indices as realhw
+		// Force aligned indices as realhw
+		const u32 address = (0 - type_size) & get_address(rsx::method_registers.index_array_address(), rsx::method_registers.index_array_location(), HERE);
 
 		const bool is_primitive_restart_enabled = rsx::method_registers.restart_index_enabled();
 		const u32 primitive_restart_index = rsx::method_registers.restart_index();
@@ -929,10 +940,10 @@ namespace rsx
 		};
 		return
 		{
-			rsx::get_address(offset_color[0], context_dma_color[0]),
-			rsx::get_address(offset_color[1], context_dma_color[1]),
-			rsx::get_address(offset_color[2], context_dma_color[2]),
-			rsx::get_address(offset_color[3], context_dma_color[3]),
+			rsx::get_address(offset_color[0], context_dma_color[0], HERE),
+			rsx::get_address(offset_color[1], context_dma_color[1], HERE),
+			rsx::get_address(offset_color[2], context_dma_color[2], HERE),
+			rsx::get_address(offset_color[3], context_dma_color[3], HERE),
 		};
 	}
 
@@ -940,7 +951,7 @@ namespace rsx
 	{
 		u32 m_context_dma_z = rsx::method_registers.surface_z_dma();
 		u32 offset_zeta = rsx::method_registers.surface_z_offset();
-		return rsx::get_address(offset_zeta, m_context_dma_z);
+		return rsx::get_address(offset_zeta, m_context_dma_z, HERE);
 	}
 
 	void thread::get_framebuffer_layout(rsx::framebuffer_creation_context context, framebuffer_layout &layout)
@@ -1575,7 +1586,7 @@ namespace rsx
 		for (auto &info : result.interleaved_blocks)
 		{
 			//Calculate real data address to be used during upload
-			info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(state.vertex_data_base_offset(), info.base_offset), info.memory_location);
+			info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(state.vertex_data_base_offset(), info.base_offset), info.memory_location, HERE);
 		}
 	}
 
@@ -1592,7 +1603,7 @@ namespace rsx
 		const u32 program_location = (shader_program & 0x3) - 1;
 		const u32 program_offset = (shader_program & ~0x3);
 
-		result.addr = vm::base(rsx::get_address(program_offset, program_location));
+		result.addr = vm::base(rsx::get_address(program_offset, program_location, HERE));
 		current_fp_metadata = program_hash_util::fragment_program_utils::analyse_fragment_program(result.addr);
 
 		result.addr = (static_cast<u8*>(result.addr) + current_fp_metadata.program_start_offset);
@@ -1633,7 +1644,7 @@ namespace rsx
 					texture_control |= (1 << 4);
 				}
 
-				const u32 texaddr = rsx::get_address(tex.offset(), tex.location());
+				const u32 texaddr = rsx::get_address(tex.offset(), tex.location(), HERE);
 				const u32 raw_format = tex.format();
 				const u32 format = raw_format & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 
@@ -1775,7 +1786,7 @@ namespace rsx
 
 	tiled_region thread::get_tiled_address(u32 offset, u32 location)
 	{
-		u32 address = get_address(offset, location);
+		u32 address = get_address(offset, location, HERE);
 
 		GcmTileInfo *tile = find_tile(offset, location);
 		u32 base = 0;
@@ -1783,7 +1794,7 @@ namespace rsx
 		if (tile)
 		{
 			base = offset - tile->offset;
-			address = get_address(tile->offset, location);
+			address = get_address(tile->offset, location, HERE);
 		}
 
 		return{ address, base, tile, vm::_ptr<u8>(address) };
@@ -2128,7 +2139,7 @@ namespace rsx
 				{
 					if (zcull.binded)
 					{
-						const u32 rsx_address = rsx::get_address(zcull.offset, CELL_GCM_LOCATION_LOCAL);
+						const u32 rsx_address = rsx::get_address(zcull.offset, CELL_GCM_LOCATION_LOCAL, HERE);
 						if (rsx_address == zeta_address)
 						{
 							zcull_surface_active = true;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -81,7 +81,7 @@ namespace rsx
 		{
 			if (offset < sizeof(RsxReports::report) /*&& (offset % 0x10) == 0*/)
 			{
-				return render->label_addr + 0x1400 + offset;
+				return render->label_addr + ::offset32(&RsxReports::report) + offset;
 			}
 
 			msg = "Local RSX REPORT offset out of range!"sv;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -112,7 +112,8 @@ namespace rsx
 
 	u32 get_vertex_type_size_on_host(vertex_base_type type, u32 size);
 
-	u32 get_address(u32 offset, u32 location);
+	// TODO: Replace with std::source_location in c++20
+	u32 get_address(u32 offset, u32 location, const char* from);
 
 	struct tiled_region
 	{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -797,9 +797,12 @@ void VKGSRender::on_semaphore_acquire_wait()
 void VKGSRender::notify_tile_unbound(u32 tile)
 {
 	//TODO: Handle texture writeback
-	//u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
-	//on_notify_memory_unmapped(addr, tiles[tile].size);
-	//m_rtts.invalidate_surface_address(addr, false);
+	if (false)
+	{
+		u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location, HERE);
+		on_notify_memory_unmapped(addr, tiles[tile].size);
+		m_rtts.invalidate_surface_address(addr, false);
+	}
 
 	{
 		std::lock_guard lock(m_sampler_mutex);
@@ -1090,7 +1093,7 @@ void VKGSRender::emit_geometry(u32 sub_index)
 		for (auto &info : m_vertex_layout.interleaved_blocks)
 		{
 			const auto vertex_base_offset = rsx::method_registers.vertex_data_base_offset();
-			info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info.base_offset), info.memory_location);
+			info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info.base_offset), info.memory_location, HERE);
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -438,7 +438,7 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 		present_info.height = buffer_height;
 		present_info.pitch = buffer_pitch;
 		present_info.format = av_format;
-		present_info.address = rsx::get_address(display_buffers[info.buffer].offset, CELL_GCM_LOCATION_LOCAL);
+		present_info.address = rsx::get_address(display_buffers[info.buffer].offset, CELL_GCM_LOCATION_LOCAL, HERE);
 
 		image_to_flip = get_present_source(&present_info, avconfig);
 		buffer_width = present_info.width;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -71,7 +71,7 @@ namespace rsx
 		void semaphore_acquire(thread* rsx, u32 /*_reg*/, u32 arg)
 		{
 			rsx->sync_point_request = true;
-			const u32 addr = get_address(method_registers.semaphore_offset_406e(), method_registers.semaphore_context_dma_406e());
+			const u32 addr = get_address(method_registers.semaphore_offset_406e(), method_registers.semaphore_context_dma_406e(), HERE);
 
 			const auto& sema = vm::_ref<atomic_be_t<u32>>(addr);
 
@@ -146,7 +146,7 @@ namespace rsx
 				rsx->sync_point_request = true;
 			}
 
-			const u32 addr = get_address(offset, ctxt);
+			const u32 addr = get_address(offset, ctxt, HERE);
 
 			if (g_use_rtm) [[likely]]
 			{
@@ -227,7 +227,7 @@ namespace rsx
 			// lle-gcm likes to inject system reserved semaphores, presumably for system/vsh usage
 			// Avoid calling render to avoid any havoc(flickering) they may cause from invalid flush/write
 			const u32 offset = method_registers.semaphore_offset_4097() & -16;
-			vm::_ref<atomic_t<RsxSemaphore>>(get_address(offset, method_registers.semaphore_context_dma_4097())).store(
+			vm::_ref<atomic_t<RsxSemaphore>>(get_address(offset, method_registers.semaphore_context_dma_4097(), HERE)).store(
 			{
 				arg,
 				0,
@@ -243,7 +243,7 @@ namespace rsx
 
 			const u32 offset = method_registers.semaphore_offset_4097() & -16;
 			const u32 val = (arg & 0xff00ff00) | ((arg & 0xff) << 16) | ((arg >> 16) & 0xff);
-			vm::_ref<atomic_t<RsxSemaphore>>(get_address(offset, method_registers.semaphore_context_dma_4097())).store(
+			vm::_ref<atomic_t<RsxSemaphore>>(get_address(offset, method_registers.semaphore_context_dma_4097(), HERE)).store(
 			{
 				val,
 				0,
@@ -545,7 +545,7 @@ namespace rsx
 				return vm::addr_t(0);
 			}
 
-			return vm::cast(get_address(offset, location));
+			return vm::cast(get_address(offset, location, HERE));
 		}
 
 		void get_report(thread* rsx, u32 _reg, u32 arg)
@@ -823,7 +823,7 @@ namespace rsx
 				const u16 x = method_registers.nv308a_x();
 				const u16 y = method_registers.nv308a_y();
 				const u32 pixel_offset = (method_registers.blit_engine_output_pitch_nv3062() * y) + (x * write_len);
-				u32 address = get_address(method_registers.blit_engine_output_offset_nv3062() + pixel_offset + (index * write_len), method_registers.blit_engine_output_location_nv3062());
+				u32 address = get_address(method_registers.blit_engine_output_offset_nv3062() + pixel_offset + (index * write_len), method_registers.blit_engine_output_location_nv3062(), HERE);
 
 				switch (write_len)
 				{
@@ -974,8 +974,8 @@ namespace rsx
 			const u32 in_offset = in_x * in_bpp + in_pitch * in_y;
 			const u32 out_offset = out_x * out_bpp + out_pitch * out_y;
 
-			const u32 src_address = get_address(src_offset, src_dma);
-			const u32 dst_address = get_address(dst_offset, dst_dma);
+			const u32 src_address = get_address(src_offset, src_dma, HERE);
+			const u32 dst_address = get_address(dst_offset, dst_dma, HERE);
 
 			const u32 src_line_length = (in_w * in_bpp);
 			if (is_block_transfer && (clip_h == 1 || (in_pitch == out_pitch && src_line_length == in_pitch)))
@@ -1330,8 +1330,8 @@ namespace rsx
 			u32 dst_dma = method_registers.nv0039_output_location();
 
 			const bool is_block_transfer = (in_pitch == out_pitch && out_pitch == line_length);
-			const auto read_address = get_address(src_offset, src_dma);
-			const auto write_address = get_address(dst_offset, dst_dma);
+			const auto read_address = get_address(src_offset, src_dma, HERE);
+			const auto write_address = get_address(dst_offset, dst_dma, HERE);
 			const auto data_length = in_pitch * (line_count - 1) + line_length;
 
 			if (const auto result = rsx->read_barrier(read_address, data_length, !is_block_transfer);

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -384,10 +384,10 @@ void Buffer::ShowWindowed()
 	if (m_isTex)
 	{
 		/*	u8 location = render->textures[m_cur_texture].location();
-			if(location <= 1 && vm::check_addr(rsx::get_address(render->textures[m_cur_texture].offset(), location))
+			if(location <= 1 && vm::check_addr(rsx::get_address(render->textures[m_cur_texture].offset(), location, HERE))
 				&& render->textures[m_cur_texture].width() && render->textures[m_cur_texture].height())
 				memory_viewer_panel::ShowImage(this,
-					rsx::get_address(render->textures[m_cur_texture].offset(), location), 1,
+					rsx::get_address(render->textures[m_cur_texture].offset(), location, HERE), 1,
 					render->textures[m_cur_texture].width(),
 					render->textures[m_cur_texture].height(), false);*/
 	}
@@ -704,7 +704,7 @@ void rsx_debugger::GetBuffers()
 	if(location > 1)
 		return;
 
-	u32 TexBuffer_addr = rsx::get_address(offset, location);
+	u32 TexBuffer_addr = rsx::get_address(offset, location, HERE);
 
 	if(!vm::check_addr(TexBuffer_addr))
 		return;


### PR DESCRIPTION
Report line and filename of caller rsx::get_address upon failure of address translation.

Note: Also added verification for RSXIO REPORT memory for offsets out of range: offset must be lower than 10m.