### PR TITLE
Qt: Display "Reboot With Custom/Global config" on running game

### DIFF
--- a/rpcs3/Emu/Audio/XAudio2/XAudio2Backend.cpp
+++ b/rpcs3/Emu/Audio/XAudio2/XAudio2Backend.cpp
@@ -34,7 +34,7 @@ void XAudio2Backend::Pause()
 
 void XAudio2Backend::Open(u32 /* num_buffers */)
 {
-	if (lib.get() == nullptr)
+	if (!lib)
 	{
 		void* hmodule;
 

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -456,14 +456,20 @@ bool gs_frame::event(QEvent* ev)
 				toggle_fullscreen();
 			}
 
-			int result;
+			int result = QMessageBox::Yes;
+			atomic_t<bool> called = false;
 
-			Emu.CallAfter([this, &result]()
+			Emu.CallAfter([this, &result, &called]()
 			{
 				m_gui_settings->ShowConfirmationBox(tr("Exit Game?"),
 					tr("Do you really want to exit the game?\n\nAny unsaved progress will be lost!\n"),
 					gui::ib_confirm_exit, &result, nullptr);
+
+				called = true;
+				called.notify_one();
 			});
+
+			called.wait(false);
 
 			if (result != QMessageBox::Yes)
 			{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -242,7 +242,7 @@ void main_window::Boot(const std::string& path, const std::string& title_id, boo
 {
 	if (!Emu.IsStopped())
 	{
-		int result;
+		int result = QMessageBox::Yes;
 		guiSettings->ShowConfirmationBox(tr("Close Running Game?"),
 			tr("Booting another game will close the current game.\nDo you really want to boot another game?\n\nAny unsaved progress will be lost!\n"),
 			gui::ib_confirm_boot, &result, this);
@@ -1801,7 +1801,7 @@ void main_window::closeEvent(QCloseEvent* closeEvent)
 {
 	if (!Emu.IsStopped() && guiSettings->GetValue(gui::ib_confirm_exit).toBool())
 	{
-		int result;
+		int result = QMessageBox::Yes;
 
 		guiSettings->ShowConfirmationBox(tr("Exit RPCS3?"),
 			tr("A game is currently running. Do you really want to close RPCS3?\n\nAny unsaved progress will be lost!\n"),


### PR DESCRIPTION
Example on a running game:
![image](https://user-images.githubusercontent.com/18193363/73483669-7ed9ef80-43a8-11ea-9ecf-2efb049e0117.png)

And fix re/booting when running a game, using disabled "Show Boot Game Dialog" setting and using these options in game context menu.