### PR TITLE
Modernize logging API

### DIFF
--- a/Utilities/Config.cpp
+++ b/Utilities/Config.cpp
@@ -6,7 +6,7 @@
 #include <typeinfo>
 #include <charconv>
 
-LOG_CHANNEL(cfg_log);
+LOG_CHANNEL(cfg_log, "CFG");
 
 namespace cfg
 {

--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -14,7 +14,7 @@
 #define CAN_OVERCOMMIT
 #endif
 
-LOG_CHANNEL(jit_log);
+LOG_CHANNEL(jit_log, "JIT");
 
 static u8* get_jit_memory()
 {

--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -169,7 +169,7 @@ namespace logs
 
 		for (auto&& pair : get_logger()->channels)
 		{
-			pair.second->enabled = level::notice;
+			pair.second->enabled.store(level::notice, std::memory_order_relaxed);
 		}
 	}
 
@@ -179,7 +179,7 @@ namespace logs
 
 		for (auto&& pair : get_logger()->channels)
 		{
-			pair.second->enabled = level::always;
+			pair.second->enabled.store(level::always, std::memory_order_relaxed);
 		}
 	}
 
@@ -191,7 +191,7 @@ namespace logs
 
 		while (found.first != found.second)
 		{
-			found.first->second->enabled = value;
+			found.first->second->enabled.store(value, std::memory_order_relaxed);
 			found.first++;
 		}
 	}
@@ -204,7 +204,7 @@ namespace logs
 
 		if (found.first != found.second)
 		{
-			return found.first->second->enabled;
+			return found.first->second->enabled.load(std::memory_order_relaxed);
 		}
 		else
 		{

--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -101,9 +101,21 @@ namespace logs
 
 	// Get all registered log channels
 	std::vector<std::string> get_channels();
+
+	// Helper: no additional name specified
+	constexpr const char* make_channel_name(const char* name)
+	{
+		return name;
+	}
+
+	// Helper: special channel name specified
+	constexpr const char* make_channel_name(const char*, const char* name, ...)
+	{
+		return name;
+	}
 }
 
-#define LOG_CHANNEL(ch) inline ::logs::channel ch(#ch)
+#define LOG_CHANNEL(ch, ...) inline ::logs::channel ch(::logs::make_channel_name(#ch, ##__VA_ARGS__))
 
 // Legacy:
 

--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -122,7 +122,6 @@ namespace logs
 namespace logs
 {
 	/* Small set of predefined channels */
-	LOG_CHANNEL(HLE);
 	LOG_CHANNEL(PPU);
 	LOG_CHANNEL(SPU);
 }

--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -122,7 +122,6 @@ namespace logs
 namespace logs
 {
 	/* Small set of predefined channels */
-	LOG_CHANNEL(RSX);
 	LOG_CHANNEL(HLE);
 	LOG_CHANNEL(PPU);
 	LOG_CHANNEL(SPU);
@@ -135,3 +134,5 @@ namespace logs
 #define LOG_TODO(ch, fmt, ...)    logs::ch.todo   ("" fmt, ##__VA_ARGS__)
 #define LOG_TRACE(ch, fmt, ...)   logs::ch.trace  ("" fmt, ##__VA_ARGS__)
 #define LOG_FATAL(ch, fmt, ...)   logs::ch.fatal  ("" fmt, ##__VA_ARGS__)
+
+LOG_CHANNEL(rsx_log, "RSX");

--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -122,7 +122,6 @@ namespace logs
 namespace logs
 {
 	/* Small set of predefined channels */
-	LOG_CHANNEL(PPU);
 	LOG_CHANNEL(SPU);
 }
 

--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -117,20 +117,4 @@ namespace logs
 
 #define LOG_CHANNEL(ch, ...) inline ::logs::channel ch(::logs::make_channel_name(#ch, ##__VA_ARGS__))
 
-// Legacy:
-
-namespace logs
-{
-	/* Small set of predefined channels */
-	LOG_CHANNEL(SPU);
-}
-
-#define LOG_SUCCESS(ch, fmt, ...) logs::ch.success("" fmt, ##__VA_ARGS__)
-#define LOG_NOTICE(ch, fmt, ...)  logs::ch.notice ("" fmt, ##__VA_ARGS__)
-#define LOG_WARNING(ch, fmt, ...) logs::ch.warning("" fmt, ##__VA_ARGS__)
-#define LOG_ERROR(ch, fmt, ...)   logs::ch.error  ("" fmt, ##__VA_ARGS__)
-#define LOG_TODO(ch, fmt, ...)    logs::ch.todo   ("" fmt, ##__VA_ARGS__)
-#define LOG_TRACE(ch, fmt, ...)   logs::ch.trace  ("" fmt, ##__VA_ARGS__)
-#define LOG_FATAL(ch, fmt, ...)   logs::ch.fatal  ("" fmt, ##__VA_ARGS__)
-
 LOG_CHANNEL(rsx_log, "RSX");

--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "types.h"
-#include "util/atomic.hpp"
 #include "StrFmt.h"
-#include <climits>
+#include "util/atomic.hpp"
+#include <atomic>
 
 namespace logs
 {
@@ -59,7 +59,7 @@ namespace logs
 		const char* const name;
 
 		// The lowest logging level enabled for this channel (used for early filtering)
-		atomic_t<level> enabled;
+		std::atomic<level> enabled;
 
 		// Initialize and register channel
 		channel(const char* name);
@@ -69,7 +69,7 @@ namespace logs
 		template <std::size_t N, typename... Args>\
 		void _sev(const char(&fmt)[N], const Args&... args)\
 		{\
-			if (UNLIKELY(level::_sev <= enabled))\
+			if (UNLIKELY(level::_sev <= enabled.load(std::memory_order_relaxed)))\
 			{\
 				static constexpr fmt_type_info type_list[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};\
 				msg_##_sev.broadcast(fmt, type_list, u64{fmt_unveil<Args>::get(args)}...);\

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -46,7 +46,7 @@
 #include "Log.h"
 
 LOG_CHANNEL(sig_log);
-LOG_CHANNEL(vm_log);
+LOG_CHANNEL(vm_log, "VM");
 
 thread_local u64 g_tls_fault_all = 0;
 thread_local u64 g_tls_fault_rsx = 0;

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1447,7 +1447,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 		{
 			if (auto last_func = static_cast<ppu_thread*>(cpu)->current_function)
 			{
-				LOG_FATAL(PPU, "Function aborted: %s", last_func);
+				ppu_log.fatal("Function aborted: %s", last_func);
 			}
 
 			lv2_obj::sleep(*cpu);

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1117,7 +1117,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context)
 		}
 		catch (const std::exception& e)
 		{
-			LOG_FATAL(RSX, "g_access_violation_handler(0x%x, %d): %s", addr, is_writing, e.what());
+			rsx_log.fatal("g_access_violation_handler(0x%x, %d): %s", addr, is_writing, e.what());
 
 			if (cpu)
 			{

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -4,7 +4,7 @@
 
 #include <cmath>
 
-LOG_CHANNEL(edat_log);
+LOG_CHANNEL(edat_log, "EDAT");
 
 void generate_key(int crypto_mode, int version, unsigned char *key_final, unsigned char *iv_final, unsigned char *key, unsigned char *iv)
 {

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -8,7 +8,7 @@
 #include "Emu/VFS.h"
 #include "unpkg.h"
 
-LOG_CHANNEL(pkg_log);
+LOG_CHANNEL(pkg_log, "PKG");
 
 bool pkg_install(const std::string& path, atomic_t<double>& sync)
 {

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -7,7 +7,7 @@
 #include "Utilities/File.h"
 #include "Utilities/Log.h"
 
-LOG_CHANNEL(self_log);
+LOG_CHANNEL(self_log, "SELF");
 
 struct AppInfo
 {

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -16,7 +16,7 @@ DECLARE(cpu_thread::g_threads_created){0};
 DECLARE(cpu_thread::g_threads_deleted){0};
 
 LOG_CHANNEL(profiler);
-LOG_CHANNEL(sys_log);
+LOG_CHANNEL(sys_log, "SYS");
 
 template <>
 void fmt_class_string<cpu_flag>::format(std::string& out, u64 arg)

--- a/rpcs3/Emu/Cell/Modules/cellAdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAdec.cpp
@@ -453,7 +453,7 @@ public:
 				reader.addr = task.au.addr;
 				reader.size = task.au.size;
 				reader.has_ats = use_ats_headers;
-				//LOG_NOTICE(HLE, "Audio AU: size = 0x%x, pts = 0x%llx", task.au.size, task.au.pts);
+				//cellAdec.notice("Audio AU: size = 0x%x, pts = 0x%llx", task.au.size, task.au.pts);
 
 				if (just_started)
 				{
@@ -610,7 +610,7 @@ public:
 						frame.userdata = task.au.userdata;
 						frame.size = frame.data->nb_samples * frame.data->channels * nbps;
 
-						//LOG_NOTICE(HLE, "got audio frame (pts=0x%llx, nb_samples=%d, ch=%d, sample_rate=%d, nbps=%d)",
+						//cellAdec.notice("got audio frame (pts=0x%llx, nb_samples=%d, ch=%d, sample_rate=%d, nbps=%d)",
 							//frame.pts, frame.data->nb_samples, frame.data->channels, frame.data->sample_rate, nbps);
 
 						if (frames.push(frame, &is_closed))
@@ -714,7 +714,7 @@ next:
 			adec.reader.addr = adec.task.au.addr;
 			adec.reader.size = adec.task.au.size;
 			adec.reader.has_ats = adec.use_ats_headers;
-			//LOG_NOTICE(HLE, "Audio AU: size = 0x%x, pts = 0x%llx", adec.task.au.size, adec.task.au.pts);
+			//cellAdec.notice("Audio AU: size = 0x%x, pts = 0x%llx", adec.task.au.size, adec.task.au.pts);
 		}
 		break;
 

--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -1403,7 +1403,7 @@ void camera_context::set_attr(s32 attrib, u32 arg1, u32 arg2)
 	{
 		if (arg1 != CELL_CAMERA_READ_FUNCCALL && arg1 != CELL_CAMERA_READ_DIRECT)
 		{
-			LOG_WARNING(HLE, "Unknown read mode set: %d", arg1);
+			cellCamera.warning("Unknown read mode set: %d", arg1);
 			arg1 = CELL_CAMERA_READ_FUNCCALL;
 		}
 		read_mode.exchange(arg1);

--- a/rpcs3/Emu/Cell/Modules/cellDmux.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellDmux.cpp
@@ -524,7 +524,7 @@ public:
 				}
 
 				stream = task.stream;
-				//LOG_NOTICE(HLE, "*** stream updated(addr=0x%x, size=0x%x, discont=%d, userdata=0x%llx)",
+				//cellDmux.notice("*** stream updated(addr=0x%x, size=0x%x, discont=%d, userdata=0x%llx)",
 					//stream.addr, stream.size, stream.discontinuity, stream.userdata);
 				break;
 			}

--- a/rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp
@@ -866,7 +866,7 @@ void spursSysServiceMain(spu_thread& spu, u32 pollStatus)
 
 	if (!ctxt->spurs.aligned())
 	{
-		LOG_ERROR(SPU, "spursSysServiceMain(): invalid spurs alignment");
+		spu_log.error("spursSysServiceMain(): invalid spurs alignment");
 		spursHalt(spu);
 	}
 
@@ -884,7 +884,7 @@ void spursSysServiceMain(spu_thread& spu, u32 pollStatus)
 			// Halt if already initialised
 			if (spurs->sysSrvOnSpu & (1 << ctxt->spuNum))
 			{
-				LOG_ERROR(SPU, "spursSysServiceMain(): already initialized");
+				spu_log.error("spursSysServiceMain(): already initialized");
 				spursHalt(spu);
 			}
 
@@ -1424,7 +1424,7 @@ s32 spursTasksetProcessRequest(spu_thread& spu, s32 request, u32* taskId, u32* i
 		if ((taskset->waiting & taskset->running) != _0 || (taskset->ready & taskset->pending_ready) != _0 ||
 			((taskset->running | taskset->ready | taskset->pending_ready | taskset->signalled | taskset->waiting) & ~taskset->enabled) != _0)
 		{
-			LOG_ERROR(SPU, "Invalid taskset state");
+			spu_log.error("Invalid taskset state");
 			spursHalt(spu);
 		}
 
@@ -1562,7 +1562,7 @@ s32 spursTasksetProcessRequest(spu_thread& spu, s32 request, u32* taskId, u32* i
 			}
 			break;
 		default:
-			LOG_ERROR(SPU, "Unknown taskset request");
+			spu_log.error("Unknown taskset request");
 			spursHalt(spu);
 		}
 
@@ -1637,7 +1637,7 @@ void spursTasksetExit(spu_thread& spu)
 	// Not sure why this check exists. Perhaps to check for memory corruption.
 	if (memcmp(ctxt->moduleId, "SPURSTASK MODULE", 16) != 0)
 	{
-		LOG_ERROR(SPU, "spursTasksetExit(): memory corruption");
+		spu_log.error("spursTasksetExit(): memory corruption");
 		spursHalt(spu);
 	}
 
@@ -1761,7 +1761,7 @@ void spursTasksetDispatch(spu_thread& spu)
 		u32 lowestLoadAddr;
 		if (spursTasksetLoadElf(spu, &entryPoint, &lowestLoadAddr, taskInfo->elf.addr(), false) != CELL_OK)
 		{
-			LOG_ERROR(SPU, "spursTaskLoadElf() failed");
+			spu_log.error("spursTaskLoadElf() failed");
 			spursHalt(spu);
 		}
 
@@ -1809,7 +1809,7 @@ void spursTasksetDispatch(spu_thread& spu)
 			u32 entryPoint;
 			if (spursTasksetLoadElf(spu, &entryPoint, nullptr, taskInfo->elf.addr(), true) != CELL_OK)
 			{
-				LOG_ERROR(SPU, "spursTasksetLoadElf() failed");
+				spu_log.error("spursTasksetLoadElf() failed");
 				spursHalt(spu);
 			}
 		}
@@ -1917,7 +1917,7 @@ s32 spursTasksetProcessSyscall(spu_thread& spu, u32 syscallNum, u32 args)
 	case CELL_SPURS_TASK_SYSCALL_RECV_WKL_FLAG:
 		if (args == 0)
 		{ // TODO: Figure this out
-			LOG_ERROR(SPU, "args == 0");
+			spu_log.error("args == 0");
 			//spursHalt(spu);
 		}
 

--- a/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
@@ -48,7 +48,7 @@ struct syscache_info
 				cache_id.resize(cache_id.size() - 1);
 			cache_id = cache_id.substr(cache_id.find_last_of('/') + 1);
 
-			LOG_SUCCESS(PPU, "Retained cache from parent process: %s", Emu.hdd1);
+			cellSysutil.success("Retained cache from parent process: %s", Emu.hdd1);
 			return;
 		}
 

--- a/rpcs3/Emu/Cell/Modules/sysPrxForUser.cpp
+++ b/rpcs3/Emu/Cell/Modules/sysPrxForUser.cpp
@@ -112,31 +112,31 @@ error_code console_write(vm::ptr<char> data, u32 len)
 
 s32 cellGamePs1Emu_61CE2BCD()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 
 s32 cellSysconfPs1emu_639ABBDE()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 
 s32 cellSysconfPs1emu_6A12D11F()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 
 s32 cellSysconfPs1emu_83E79A23()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 
 s32 cellSysconfPs1emu_EFDDAF6C()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 
@@ -171,25 +171,25 @@ error_code sys_crash_dump_set_user_log_area(u8 index, vm::ptr<sys_crash_dump_log
 
 s32 sys_get_bd_media_id()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 
 s32 sys_get_console_id()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 
 s32 sysPs2Disc_A84FD3C3()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 
 s32 sysPs2Disc_BB7CD1AE()
 {
-	UNIMPLEMENTED_FUNC(logs::HLE);
+	UNIMPLEMENTED_FUNC(sysPrxForUser);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -585,7 +585,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 		func.addr = addr;
 		func.toc = toc;
 		func.name = fmt::format("__0x%x", func.addr);
-		LOG_TRACE(PPU, "Function 0x%x added (toc=0x%x)", addr, toc);
+		ppu_log.trace("Function 0x%x added (toc=0x%x)", addr, toc);
 		return func;
 	};
 
@@ -605,7 +605,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 				if (ptr[0] >= start && ptr[0] < end && ptr[0] % 4 == 0 && ptr[1] == toc)
 				{
 					// New function
-					LOG_TRACE(PPU, "OPD*: [0x%x] 0x%x (TOC=0x%x)", ptr, ptr[0], ptr[1]);
+					ppu_log.trace("OPD*: [0x%x] 0x%x (TOC=0x%x)", ptr, ptr[0], ptr[1]);
 					add_func(*ptr, addr_heap.count(ptr.addr()) ? toc : 0, 0);
 					ptr++;
 				}
@@ -684,7 +684,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 			}
 		}
 
-		if (sec_end) LOG_NOTICE(PPU, "Reading OPD section at 0x%x...", sec.addr);
+		if (sec_end) ppu_log.notice("Reading OPD section at 0x%x...", sec.addr);
 
 		// Mine
 		for (vm::cptr<u32> ptr = vm::cast(sec.addr); ptr < sec_end; ptr += 2)
@@ -695,7 +695,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 			// Add function and TOC
 			const u32 addr = ptr[0];
 			const u32 toc = ptr[1];
-			LOG_TRACE(PPU, "OPD: [0x%x] 0x%x (TOC=0x%x)", ptr, addr, toc);
+			ppu_log.trace("OPD: [0x%x] 0x%x (TOC=0x%x)", ptr, addr, toc);
 
 			TOCs.emplace(toc);
 			auto& func = add_func(addr, addr_heap.count(ptr.addr()) ? toc : 0, 0);
@@ -767,7 +767,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 			ptr = vm::cast(ptr.addr() + size);
 		}
 
-		if (sec_end && sec.size > 4) LOG_NOTICE(PPU, "Reading .eh_frame section at 0x%x...", sec.addr);
+		if (sec_end && sec.size > 4) ppu_log.notice("Reading .eh_frame section at 0x%x...", sec.addr);
 
 		// Mine
 		for (vm::cptr<u32> ptr = vm::cast(sec.addr); ptr < sec_end; ptr = vm::cast(ptr.addr() + ptr[0] + 4))
@@ -781,7 +781,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 			if (ptr[1] == 0)
 			{
 				// CIE
-				LOG_TRACE(PPU, ".eh_frame: [0x%x] CIE 0x%x", ptr, ptr[0]);
+				ppu_log.trace(".eh_frame: [0x%x] CIE 0x%x", ptr, ptr[0]);
 			}
 			else
 			{
@@ -808,7 +808,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 				}
 				else
 				{
-					LOG_ERROR(PPU, ".eh_frame: [0x%x] 0x%x, 0x%x, 0x%x, 0x%x, 0x%x", ptr, ptr[0], ptr[1], ptr[2], ptr[3], ptr[4]);
+					ppu_log.error(".eh_frame: [0x%x] 0x%x, 0x%x, 0x%x, 0x%x, 0x%x", ptr, ptr[0], ptr[1], ptr[2], ptr[3], ptr[4]);
 					continue;
 				}
 
@@ -818,12 +818,12 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 					addr += ptr.addr() + 8;
 				}
 
-				LOG_TRACE(PPU, ".eh_frame: [0x%x] FDE 0x%x (cie=*0x%x, addr=0x%x, size=0x%x)", ptr, ptr[0], cie, addr, size);
+				ppu_log.trace(".eh_frame: [0x%x] FDE 0x%x (cie=*0x%x, addr=0x%x, size=0x%x)", ptr, ptr[0], cie, addr, size);
 
 				// TODO: invalid offsets, zero offsets (removed functions?)
 				if (addr % 4 || size % 4 || size > (end - start) || addr < start || addr + size > end)
 				{
-					if (addr) LOG_ERROR(PPU, ".eh_frame: Invalid function 0x%x", addr);
+					if (addr) ppu_log.error(".eh_frame: Invalid function 0x%x", addr);
 					continue;
 				}
 
@@ -1127,7 +1127,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 			if (const u32 len = ppu_test(ptr, fend, ppu_patterns::abort))
 			{
 				// Function "abort"
-				LOG_NOTICE(PPU, "Function [0x%x]: 'abort'", func.addr);
+				ppu_log.notice("Function [0x%x]: 'abort'", func.addr);
 				func.attr += ppu_attr::no_return;
 				func.attr += ppu_attr::known_size;
 				func.size = len;
@@ -1209,7 +1209,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 
 					if (target < start || target >= end)
 					{
-						LOG_WARNING(PPU, "[0x%x] Invalid branch at 0x%x -> 0x%x", func.addr, iaddr, target);
+						ppu_log.warning("[0x%x] Invalid branch at 0x%x -> 0x%x", func.addr, iaddr, target);
 						continue;
 					}
 
@@ -1292,7 +1292,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 							// Acknowledge jumptable detection failure
 							if (!(func.attr & ppu_attr::no_size))
 							{
-								LOG_WARNING(PPU, "[0x%x] Jump table not found! 0x%x-0x%x", func.addr, jt_addr, jt_end);
+								ppu_log.warning("[0x%x] Jump table not found! 0x%x-0x%x", func.addr, jt_addr, jt_end);
 							}
 
 							func.attr += ppu_attr::no_size;
@@ -1301,7 +1301,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 						}
 						else
 						{
-							LOG_TRACE(PPU, "[0x%x] Jump table found: 0x%x-0x%x", func.addr, jt_addr, _ptr);
+							ppu_log.trace("[0x%x] Jump table found: 0x%x-0x%x", func.addr, jt_addr, _ptr);
 						}
 					}
 
@@ -1327,7 +1327,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 				else if (type == ppu_itype::STDU && func.attr & ppu_attr::no_size && (op.opcode == *_ptr || *_ptr == ppu_instructions::BLR()))
 				{
 					// Hack
-					LOG_SUCCESS(PPU, "[0x%x] Instruction repetition: 0x%08x", iaddr, op.opcode);
+					ppu_log.success("[0x%x] Instruction repetition: 0x%08x", iaddr, op.opcode);
 					add_block(_ptr.addr());
 					block.second = _ptr.addr() - block.first;
 					break;
@@ -1433,7 +1433,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 		// Just ensure that functions don't overlap
 		if (func.addr + func.size > next)
 		{
-			LOG_WARNING(PPU, "Function overlap: [0x%x] 0x%x -> 0x%x", func.addr, func.size, next - func.addr);
+			ppu_log.warning("Function overlap: [0x%x] 0x%x -> 0x%x", func.addr, func.size, next - func.addr);
 			continue; //func.size = next - func.addr;
 
 			// Also invalidate blocks
@@ -1503,7 +1503,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 
 			if (_ptr.addr() >= next)
 			{
-				LOG_WARNING(PPU, "Function gap: [0x%x] 0x%x bytes at 0x%x", func.addr, next - start, start);
+				ppu_log.warning("Function gap: [0x%x] 0x%x bytes at 0x%x", func.addr, next - start, start);
 				break;
 			}
 		}
@@ -1527,17 +1527,17 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 	for (auto&& pair : fmap)
 	{
 		auto& func = pair.second;
-		LOG_TRACE(PPU, "Function %s (size=0x%x, toc=0x%x, attr %#x)", func.name, func.size, func.toc, func.attr);
+		ppu_log.trace("Function %s (size=0x%x, toc=0x%x, attr %#x)", func.name, func.size, func.toc, func.attr);
 		funcs.emplace_back(std::move(func));
 	}
 
-	LOG_NOTICE(PPU, "Function analysis: %zu functions (%zu enqueued)", funcs.size(), func_queue.size());
+	ppu_log.notice("Function analysis: %zu functions (%zu enqueued)", funcs.size(), func_queue.size());
 }
 
 void ppu_acontext::UNK(ppu_opcode_t op)
 {
 	std::fill_n(gpr, 32, spec_gpr{});
-	LOG_ERROR(PPU, "Unknown/Illegal opcode: 0x%08x at 0x%x" HERE, op.opcode, cia);
+	ppu_log.error("Unknown/Illegal opcode: 0x%08x at 0x%x" HERE, op.opcode, cia);
 }
 
 void ppu_acontext::MFVSCR(ppu_opcode_t op)
@@ -3467,7 +3467,7 @@ const bool s_tes = []()
 				{
 					auto exp = ppu_acontext::spec_gpr::approx(r1.ones() & r2.ones(), r1.mask() & r2.mask());
 
-					LOG_ERROR(PPU, "ppu_acontext failure:"
+					ppu_log.error("ppu_acontext failure:"
 						"\n\tr1 = 0x%016x..0x%016x, 0x%016x:0x%016x"
 						"\n\tr2 = 0x%016x..0x%016x, 0x%016x:0x%016x"
 						"\n\tr3 = 0x%016x..0x%016x, 0x%016x:0x%016x"
@@ -3483,7 +3483,7 @@ const bool s_tes = []()
 	ppu_acontext::spec_gpr r1;
 	r1 = ppu_acontext::spec_gpr::range(0x13311, 0x1fe22);
 	r1 = r1 ^ ppu_acontext::spec_gpr::approx(0x000, 0xf00);
-	LOG_SUCCESS(PPU, "0x%x..0x%x", r1.imin, r1.imax);
+	ppu_log.success("0x%x..0x%x", r1.imin, r1.imax);
 
 	return true;
 }();

--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -2525,7 +2525,7 @@ std::vector<ppu_function_t>& ppu_function_manager::access()
 	{
 		[](ppu_thread& ppu) -> bool
 		{
-			LOG_ERROR(PPU, "Unregistered function called (LR=0x%x)", ppu.lr);
+			ppu_log.error("Unregistered function called (LR=0x%x)", ppu.lr);
 			ppu.gpr[3] = 0;
 			ppu.cia = static_cast<u32>(ppu.lr) & ~3;
 			return false;

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -4750,7 +4750,7 @@ bool ppu_interpreter_precise::FNMADDS(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::MTFSB1(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u32 bit = op.crbd;
-	if (bit < 16 || bit > 19) LOG_WARNING(PPU, "MTFSB1(%d)", bit);
+	if (bit < 16 || bit > 19) ppu_log.warning("MTFSB1(%d)", bit);
 	ppu.fpscr.bits[bit] = 1;
 	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
@@ -4758,7 +4758,7 @@ bool ppu_interpreter::MTFSB1(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::MCRFS(ppu_thread& ppu, ppu_opcode_t op)
 {
-	if (op.crfs != 4) LOG_WARNING(PPU, "MCRFS(%d)", op.crfs);
+	if (op.crfs != 4) ppu_log.warning("MCRFS(%d)", op.crfs);
 	ppu.cr.fields[op.crfd] = ppu.fpscr.fields[op.crfs];
 	return true;
 }
@@ -4766,7 +4766,7 @@ bool ppu_interpreter::MCRFS(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::MTFSB0(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u32 bit = op.crbd;
-	if (bit < 16 || bit > 19) LOG_WARNING(PPU, "MTFSB0(%d)", bit);
+	if (bit < 16 || bit > 19) ppu_log.warning("MTFSB0(%d)", bit);
 	ppu.fpscr.bits[bit] = 0;
 	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
@@ -4779,7 +4779,7 @@ bool ppu_interpreter::MTFSFI(ppu_thread& ppu, ppu_opcode_t op)
 	if (bf != 4)
 	{
 		// Do nothing on non-FPCC field (TODO)
-		LOG_WARNING(PPU, "MTFSFI(%d)", op.crfd);
+		ppu_log.warning("MTFSFI(%d)", op.crfd);
 	}
 	else
 	{
@@ -4809,7 +4809,7 @@ bool ppu_interpreter::MTFSFI(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::MFFS(ppu_thread& ppu, ppu_opcode_t op)
 {
-	LOG_WARNING(PPU, "MFFS");
+	ppu_log.warning("MFFS");
 	ppu.fpr[op.frd] = std::bit_cast<f64>(u64{ppu.fpscr.fl} << 15 | u64{ppu.fpscr.fg} << 14 | u64{ppu.fpscr.fe} << 13 | u64{ppu.fpscr.fu} << 12);
 	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
@@ -4817,7 +4817,7 @@ bool ppu_interpreter::MFFS(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::MTFSF(ppu_thread& ppu, ppu_opcode_t op)
 {
-	LOG_WARNING(PPU, "MTFSF");
+	ppu_log.warning("MTFSF");
 	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -4,6 +4,8 @@
 #include "../Memory/vm_ptr.h"
 #include "Utilities/lockless.h"
 
+LOG_CHANNEL(ppu_log, "PPU");
+
 enum class ppu_cmd : u32
 {
 	null,

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -90,7 +90,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* module, const ppu_mod
 			// case 26:
 			// case 28:
 			{
-				LOG_NOTICE(PPU, "Ignoring relative relocation at 0x%x (%u)", rel.addr, rel.type);
+				ppu_log.notice("Ignoring relative relocation at 0x%x (%u)", rel.addr, rel.type);
 				continue;
 			}
 
@@ -107,7 +107,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* module, const ppu_mod
 			case 73:
 			case 78:
 			{
-				LOG_ERROR(PPU, "Ignoring 64-bit relocation at 0x%x (%u)", rel.addr, rel.type);
+				ppu_log.error("Ignoring 64-bit relocation at 0x%x (%u)", rel.addr, rel.type);
 				continue;
 			}
 			}
@@ -115,7 +115,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* module, const ppu_mod
 			// Align relocation address (TODO)
 			if (!m_relocs.emplace(rel.addr & ~3, &rel).second)
 			{
-				LOG_ERROR(PPU, "Relocation repeated at 0x%x (%u)", rel.addr, rel.type);
+				ppu_log.error("Relocation repeated at 0x%x (%u)", rel.addr, rel.type);
 			}
 		}
 	}
@@ -200,7 +200,7 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 			if (m_rel)
 			{
 				// This is very bad. m_rel is normally set to nullptr after a relocation is handled (so it wasn't)
-				LOG_ERROR(PPU, "LLVM: [0x%x] Unsupported relocation(%u) in '%s'. Please report.", rel_found->first, m_rel->type, m_info.name);
+				ppu_log.error("LLVM: [0x%x] Unsupported relocation(%u) in '%s'. Please report.", rel_found->first, m_rel->type, m_info.name);
 				return nullptr;
 			}
 		}
@@ -563,7 +563,7 @@ void PPUTranslator::WriteMemory(Value* addr, Value* value, bool is_be, u32 align
 
 void PPUTranslator::CompilationError(const std::string& error)
 {
-	LOG_ERROR(PPU, "LLVM: [0x%08x] Error: %s", m_addr + (m_reloc ? m_reloc->addr : 0), error);
+	ppu_log.error("LLVM: [0x%08x] Error: %s", m_addr + (m_reloc ? m_reloc->addr : 0), error);
 }
 
 
@@ -3943,7 +3943,7 @@ void PPUTranslator::MTFSFI(ppu_opcode_t op)
 
 void PPUTranslator::MFFS(ppu_opcode_t op)
 {
-	LOG_WARNING(PPU, "LLVM: [0x%08x] Warning: MFFS", m_addr + (m_reloc ? m_reloc->addr : 0));
+	ppu_log.warning("LLVM: [0x%08x] Warning: MFFS", m_addr + (m_reloc ? m_reloc->addr : 0));
 
 	Value* result = m_ir->getInt64(0);
 
@@ -3959,7 +3959,7 @@ void PPUTranslator::MFFS(ppu_opcode_t op)
 
 void PPUTranslator::MTFSF(ppu_opcode_t op)
 {
-	LOG_WARNING(PPU, "LLVM: [0x%08x] Warning: MTFSF", m_addr + (m_reloc ? m_reloc->addr : 0));
+	ppu_log.warning("LLVM: [0x%08x] Warning: MTFSF", m_addr + (m_reloc ? m_reloc->addr : 0));
 
 	const auto value = GetFpr(op.frb, 32, true);
 

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -67,7 +67,7 @@ bool spu_thread::read_reg(const u32 addr, u32& value)
 	}
 	}
 
-	LOG_ERROR(SPU, "RawSPUThread[%d]: Read32(0x%x): unknown/illegal offset (0x%x)", index, addr, offset);
+	spu_log.error("RawSPUThread[%d]: Read32(0x%x): unknown/illegal offset (0x%x)", index, addr, offset);
 	return false;
 }
 
@@ -259,7 +259,7 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 	}
 	}
 
-	LOG_ERROR(SPU, "RawSPUThread[%d]: Write32(0x%x, value=0x%x): unknown/illegal offset (0x%x)", index, addr, value, offset);
+	spu_log.error("RawSPUThread[%d]: Write32(0x%x, value=0x%x): unknown/illegal offset (0x%x)", index, addr, value, offset);
 	return false;
 }
 

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -781,7 +781,7 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 			// Ignore hole
 			if (m_pos + 1)
 			{
-				LOG_ERROR(SPU, "Unexpected fallthrough to 0x%x", pos);
+				spu_log.error("Unexpected fallthrough to 0x%x", pos);
 				branch_fixed(spu_branch_target(pos));
 				m_pos = -1;
 			}
@@ -901,7 +901,7 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 			return nullptr;
 		}
 
-		LOG_FATAL(SPU, "Failed to build a function");
+		spu_log.fatal("Failed to build a function");
 	}
 
 	// Install compiled function pointer
@@ -1082,7 +1082,7 @@ void spu_recompiler::branch_indirect(spu_opcode_t op, bool jt, bool ret)
 		auto _throw = [](spu_thread* _spu)
 		{
 			_spu->state += cpu_flag::dbg_pause;
-			LOG_FATAL(SPU, "SPU Interrupts not implemented (mask=0x%x)", +_spu->ch_event_mask);
+			spu_log.fatal("SPU Interrupts not implemented (mask=0x%x)", +_spu->ch_event_mask);
 			spu_runtime::g_escape(_spu);
 		};
 
@@ -1231,7 +1231,7 @@ void spu_recompiler::fall(spu_opcode_t op)
 		if (!_func(*_spu, {opcode}))
 		{
 			_spu->state += cpu_flag::dbg_pause;
-			LOG_FATAL(SPU, "spu_recompiler::fall(): unexpected interpreter call (op=0x%08x)", opcode);
+			spu_log.fatal("spu_recompiler::fall(): unexpected interpreter call (op=0x%08x)", opcode);
 			spu_runtime::g_escape(_spu);
 		}
 	};
@@ -1362,7 +1362,7 @@ void spu_recompiler::get_events()
 		auto _throw = [](spu_thread* _spu)
 		{
 			_spu->state += cpu_flag::dbg_pause;
-			LOG_FATAL(SPU, "SPU Events not implemented (mask=0x%x).", +_spu->ch_event_mask);
+			spu_log.fatal("SPU Events not implemented (mask=0x%x).", +_spu->ch_event_mask);
 			spu_runtime::g_escape(_spu);
 		};
 
@@ -1386,7 +1386,7 @@ void spu_recompiler::UNK(spu_opcode_t op)
 	auto gate = [](spu_thread* _spu, u32 op)
 	{
 		_spu->state += cpu_flag::dbg_pause;
-		LOG_FATAL(SPU, "Unknown/Illegal instruction (0x%08x)" HERE, op);
+		spu_log.fatal("Unknown/Illegal instruction (0x%08x)" HERE, op);
 		spu_runtime::g_escape(_spu);
 	};
 
@@ -1584,7 +1584,7 @@ void spu_recompiler::RDCH(spu_opcode_t op)
 	}
 	case SPU_RdDec:
 	{
-		LOG_WARNING(SPU, "[0x%x] RDCH: RdDec", m_pos);
+		spu_log.warning("[0x%x] RDCH: RdDec", m_pos);
 
 		auto sub1 = [](spu_thread* _spu, v128* _res)
 		{
@@ -1631,7 +1631,7 @@ void spu_recompiler::RDCH(spu_opcode_t op)
 	}
 	case SPU_RdEventStat:
 	{
-		LOG_WARNING(SPU, "[0x%x] RDCH: RdEventStat", m_pos);
+		spu_log.warning("[0x%x] RDCH: RdEventStat", m_pos);
 		get_events();
 		Label wait = c->newLabel();
 		Label ret = c->newLabel();
@@ -1744,7 +1744,7 @@ void spu_recompiler::RCHCNT(spu_opcode_t op)
 	}
 	case SPU_RdEventStat:
 	{
-		LOG_WARNING(SPU, "[0x%x] RCHCNT: RdEventStat", m_pos);
+		spu_log.warning("[0x%x] RCHCNT: RdEventStat", m_pos);
 		get_events();
 		c->setnz(addr->r8());
 		c->movzx(*addr, addr->r8());
@@ -2745,7 +2745,7 @@ void spu_recompiler::BI(spu_opcode_t op)
 
 	if (found == m_targets.end())
 	{
-		LOG_ERROR(SPU, "[0x%x] BI: no targets", m_pos);
+		spu_log.error("[0x%x] BI: no targets", m_pos);
 	}
 
 	c->mov(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, 3));

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -9,6 +9,8 @@
 
 #include <map>
 
+LOG_CHANNEL(spu_log, "SPU");
+
 struct lv2_event_queue;
 struct lv2_spu_group;
 struct lv2_int_tag;

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -47,7 +47,7 @@ void fmt_class_string<ppu_syscall_code>::format(std::string& out, u64 arg)
 
 static bool null_func(ppu_thread& ppu)
 {
-	LOG_TODO(PPU, "Unimplemented syscall %s -> CELL_OK", ppu_syscall_code(ppu.gpr[11]));
+	ppu_log.todo("Unimplemented syscall %s -> CELL_OK", ppu_syscall_code(ppu.gpr[11]));
 	ppu.gpr[3] = 0;
 	ppu.cia += 4;
 	return false;
@@ -55,7 +55,7 @@ static bool null_func(ppu_thread& ppu)
 
 static bool uns_func(ppu_thread& ppu)
 {
-	LOG_TRACE(PPU, "Unused syscall %d -> ENOSYS", ppu.gpr[11]);
+	ppu_log.trace("Unused syscall %d -> ENOSYS", ppu.gpr[11]);
 	ppu.gpr[3] = CELL_ENOSYS;
 	ppu.cia += 4;
 	return false;
@@ -981,7 +981,7 @@ extern void ppu_execute_syscall(ppu_thread& ppu, u64 code)
 		if (auto func = g_ppu_syscall_table[code])
 		{
 			func(ppu);
-			LOG_TRACE(PPU, "Syscall '%s' (%llu) finished, r3=0x%llx", ppu_syscall_code(code), code, ppu.gpr[3]);
+			ppu_log.trace("Syscall '%s' (%llu) finished, r3=0x%llx", ppu_syscall_code(code), code, ppu.gpr[3]);
 			return;
 		}
 	}
@@ -1014,7 +1014,7 @@ void lv2_obj::sleep_unlocked(cpu_thread& thread, u64 timeout)
 
 	if (auto ppu = static_cast<ppu_thread*>(thread.id_type() == 1 ? &thread : nullptr))
 	{
-		LOG_TRACE(PPU, "sleep() - waiting (%zu)", g_pending.size());
+		ppu_log.trace("sleep() - waiting (%zu)", g_pending.size());
 
 		const auto [_, ok] = ppu->state.fetch_op([&](bs_t<cpu_flag>& val)
 		{
@@ -1029,7 +1029,7 @@ void lv2_obj::sleep_unlocked(cpu_thread& thread, u64 timeout)
 
 		if (!ok)
 		{
-			LOG_FATAL(PPU, "sleep() failed (signaled) (%s)", ppu->current_function);
+			ppu_log.fatal("sleep() failed (signaled) (%s)", ppu->current_function);
 			return;
 		}
 
@@ -1118,7 +1118,7 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 		{
 			if (it != end && *it == cpu)
 			{
-				LOG_TRACE(PPU, "sleep() - suspended (p=%zu)", g_pending.size());
+				ppu_log.trace("sleep() - suspended (p=%zu)", g_pending.size());
 				return;
 			}
 
@@ -1140,7 +1140,7 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 			}
 		}
 
-		LOG_TRACE(PPU, "awake(): %s", cpu->id);
+		ppu_log.trace("awake(): %s", cpu->id);
 	};
 
 	if (cpu)
@@ -1167,7 +1167,7 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 
 		if (!target->state.test_and_set(cpu_flag::suspend))
 		{
-			LOG_TRACE(PPU, "suspend(): %s", target->id);
+			ppu_log.trace("suspend(): %s", target->id);
 			g_pending.emplace_back(target);
 		}
 	}
@@ -1193,7 +1193,7 @@ void lv2_obj::schedule_all()
 
 			if (target->state & cpu_flag::suspend)
 			{
-				LOG_TRACE(PPU, "schedule(): %s", target->id);
+				ppu_log.trace("schedule(): %s", target->id);
 				target->state ^= (cpu_flag::signal + cpu_flag::suspend);
 				target->start_time = 0;
 

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -47,7 +47,7 @@ void fmt_class_string<ppu_syscall_code>::format(std::string& out, u64 arg)
 
 static bool null_func(ppu_thread& ppu)
 {
-	LOG_TODO(HLE, "Unimplemented syscall %s -> CELL_OK", ppu_syscall_code(ppu.gpr[11]));
+	LOG_TODO(PPU, "Unimplemented syscall %s -> CELL_OK", ppu_syscall_code(ppu.gpr[11]));
 	ppu.gpr[3] = 0;
 	ppu.cia += 4;
 	return false;
@@ -55,7 +55,7 @@ static bool null_func(ppu_thread& ppu)
 
 static bool uns_func(ppu_thread& ppu)
 {
-	LOG_TRACE(HLE, "Unused syscall %d -> ENOSYS", ppu.gpr[11]);
+	LOG_TRACE(PPU, "Unused syscall %d -> ENOSYS", ppu.gpr[11]);
 	ppu.gpr[3] = CELL_ENOSYS;
 	ppu.cia += 4;
 	return false;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -378,7 +378,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 			// sanity check, the head should have a 'queued' buffer on it, and it should have been previously 'queued'
 			const u32 sanity_check = 0x40000000 & (1 << flip_idx);
 			if ((driverInfo.head[a3].flipFlags & sanity_check) != sanity_check)
-				LOG_ERROR(RSX, "Display Flip Queued: Flipping non previously queued buffer 0x%llx", a4);
+				rsx_log.error("Display Flip Queued: Flipping non previously queued buffer 0x%llx", a4);
 		}
 		else
 		{
@@ -392,7 +392,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 			}
 			if (flip_idx == ~0u)
 			{
-				LOG_ERROR(RSX, "Display Flip: Couldn't find display buffer offset, flipping 0. Offset: 0x%x", a4);
+				rsx_log.error("Display Flip: Couldn't find display buffer offset, flipping 0. Offset: 0x%x", a4);
 				flip_idx = 0;
 			}
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -30,16 +30,16 @@ void sys_spu_image::load(const fs::file& stream)
 
 	for (const auto& shdr : obj.shdrs)
 	{
-		LOG_NOTICE(SPU, "** Section: sh_type=0x%x, addr=0x%llx, size=0x%llx, flags=0x%x", shdr.sh_type, shdr.sh_addr, shdr.sh_size, shdr.sh_flags);
+		spu_log.notice("** Section: sh_type=0x%x, addr=0x%llx, size=0x%llx, flags=0x%x", shdr.sh_type, shdr.sh_addr, shdr.sh_size, shdr.sh_flags);
 	}
 
 	for (const auto& prog : obj.progs)
 	{
-		LOG_NOTICE(SPU, "** Segment: p_type=0x%x, p_vaddr=0x%llx, p_filesz=0x%llx, p_memsz=0x%llx, flags=0x%x", prog.p_type, prog.p_vaddr, prog.p_filesz, prog.p_memsz, prog.p_flags);
+		spu_log.notice("** Segment: p_type=0x%x, p_vaddr=0x%llx, p_filesz=0x%llx, p_memsz=0x%llx, flags=0x%x", prog.p_type, prog.p_vaddr, prog.p_filesz, prog.p_memsz, prog.p_flags);
 
 		if (prog.p_type != SYS_SPU_SEGMENT_TYPE_COPY && prog.p_type != SYS_SPU_SEGMENT_TYPE_INFO)
 		{
-			LOG_ERROR(SPU, "Unknown program type (0x%x)", prog.p_type);
+			spu_log.error("Unknown program type (0x%x)", prog.p_type);
 		}
 	}
 
@@ -104,7 +104,7 @@ void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
 		{
 			if ((seg.ls | seg.size) % 4)
 			{
-				LOG_ERROR(SPU, "Unaligned SPU FILL type segment (ls=0x%x, size=0x%x)", seg.ls, seg.size);
+				spu_log.error("Unaligned SPU FILL type segment (ls=0x%x, size=0x%x)", seg.ls, seg.size);
 			}
 
 			std::fill_n(vm::_ptr<u32>(loc + seg.ls), seg.size / 4, seg.addr);
@@ -139,7 +139,7 @@ void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
 		applied += g_fxo->get<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::_ptr<u8>(loc));
 	}
 
-	LOG_NOTICE(SPU, "Loaded SPU image: %s (<- %u)%s", hash, applied, dump);
+	spu_log.notice("Loaded SPU image: %s (<- %u)%s", hash, applied, dump);
 }
 
 // Get spu thread ptr, returns group ptr as well for refcounting
@@ -355,7 +355,7 @@ error_code sys_spu_thread_initialize(ppu_thread& ppu, vm::ptr<u32> thread, u32 g
 				// Hack: don't run more SPURS threads than specified.
 				group->max_run = g_cfg.core.max_spurs_threads;
 
-				LOG_SUCCESS(SPU, "HACK: '%s' (0x%x) limited to %u threads.", group->name, group_id, +g_cfg.core.max_spurs_threads);
+				spu_log.success("HACK: '%s' (0x%x) limited to %u threads.", group->name, group_id, +g_cfg.core.max_spurs_threads);
 			}
 		}
 

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -4,6 +4,8 @@
 
 cfg_input g_cfg_input;
 
+LOG_CHANNEL(input_log, "Input");
+
 PadHandlerBase::PadHandlerBase(pad_handler type) : m_type(type)
 {
 }
@@ -26,7 +28,7 @@ int PadHandlerBase::FindKeyCode(const std::unordered_map<u32, std::string>& map,
 
 	if (fallback)
 	{
-		LOG_ERROR(HLE, "int FindKeyCode for [name = %s] returned with [def_code = %d] for [def = %s]", nam, def_code, def);
+		input_log.error("int FindKeyCode for [name = %s] returned with [def_code = %d] for [def = %s]", nam, def_code, def);
 		if (def_code < 0)
 			def_code = 0;
 	}
@@ -51,7 +53,7 @@ long PadHandlerBase::FindKeyCode(const std::unordered_map<u64, std::string>& map
 
 	if (fallback)
 	{
-		LOG_ERROR(HLE, "long FindKeyCode for [name = %s] returned with [def_code = %d] for [def = %s]", nam, def_code, def);
+		input_log.error("long FindKeyCode for [name = %s] returned with [def_code = %d] for [def = %s]", nam, def_code, def);
 		if (def_code < 0)
 			def_code = 0;
 	}
@@ -70,7 +72,7 @@ int PadHandlerBase::FindKeyCodeByString(const std::unordered_map<u32, std::strin
 
 	if (fallback)
 	{
-		LOG_ERROR(HLE, "long FindKeyCodeByString for [name = %s] returned with 0", name);
+		input_log.error("long FindKeyCodeByString for [name = %s] returned with 0", name);
 		return 0;
 	}
 
@@ -88,7 +90,7 @@ long PadHandlerBase::FindKeyCodeByString(const std::unordered_map<u64, std::stri
 
 	if (fallback)
 	{
-		LOG_ERROR(HLE, "long FindKeyCodeByString for [name = %s] returned with 0", name);
+		input_log.error("long FindKeyCodeByString for [name = %s] returned with 0", name);
 		return 0;
 	}
 
@@ -344,7 +346,7 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const std:
 			if (get_blacklist)
 			{
 				blacklist.emplace_back(keycode);
-				LOG_ERROR(HLE, "%s Calibration: Added key [ %d = %s ] to blacklist. Value = %d", m_type, keycode, button.second, value);
+				input_log.error("%s Calibration: Added key [ %d = %s ] to blacklist. Value = %d", m_type, keycode, button.second, value);
 			}
 			else if (value > pressed_button.first)
 				pressed_button = { value, button.second };
@@ -354,7 +356,7 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const std:
 	if (get_blacklist)
 	{
 		if (blacklist.empty())
-			LOG_SUCCESS(HLE, "%s Calibration: Blacklist is clear. No input spam detected", m_type);
+			input_log.success("%s Calibration: Blacklist is clear. No input spam detected", m_type);
 		return;
 	}
 
@@ -586,7 +588,7 @@ void PadHandlerBase::ThreadProc()
 		{
 			if (!last_connection_status[i])
 			{
-				LOG_SUCCESS(HLE, "%s device %d connected", m_type, i);
+				input_log.success("%s device %d connected", m_type, i);
 				pad->m_port_status |= CELL_PAD_STATUS_CONNECTED;
 				pad->m_port_status |= CELL_PAD_STATUS_ASSIGN_CHANGES;
 				last_connection_status[i] = true;
@@ -602,7 +604,7 @@ void PadHandlerBase::ThreadProc()
 		{
 			if (last_connection_status[i])
 			{
-				LOG_ERROR(HLE, "%s device %d disconnected", m_type, i);
+				input_log.error("%s device %d disconnected", m_type, i);
 				pad->m_port_status &= ~CELL_PAD_STATUS_CONNECTED;
 				pad->m_port_status |= CELL_PAD_STATUS_ASSIGN_CHANGES;
 				last_connection_status[i] = false;

--- a/rpcs3/Emu/Io/Skylander.cpp
+++ b/rpcs3/Emu/Io/Skylander.cpp
@@ -2,7 +2,7 @@
 #include "Skylander.h"
 #include "Emu/Cell/lv2/sys_usbd.h"
 
-LOG_CHANNEL(skylander_log);
+LOG_CHANNEL(skylander_log, "skylander");
 
 sky_portal g_skylander;
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -17,7 +17,7 @@
 #include <thread>
 #include <deque>
 
-LOG_CHANNEL(vm_log);
+LOG_CHANNEL(vm_log, "VM");
 
 namespace vm
 {

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -250,7 +250,7 @@ namespace rsx
 		}
 		catch (const std::exception& e)
 		{
-			LOG_FATAL(RSX, "%s thrown: %s", typeid(e).name(), e.what());
+			rsx_log.fatal("%s thrown: %s", typeid(e).name(), e.what());
 			Emu.Pause();
 		}
 	}

--- a/rpcs3/Emu/RSX/CgBinaryFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/CgBinaryFragmentProgram.cpp
@@ -184,7 +184,7 @@ template<typename T> std::string CgBinaryDisasm::GetSrcDisAsm(T src)
 			}
 			else
 			{
-				LOG_ERROR(RSX, "Bad src reg num: %d", u32{ dst.src_attr_reg_num });
+				rsx_log.error("Bad src reg num: %d", u32{ dst.src_attr_reg_num });
 			}
 			break;
 		}
@@ -196,7 +196,7 @@ template<typename T> std::string CgBinaryDisasm::GetSrcDisAsm(T src)
 		break;
 
 	default:
-		LOG_ERROR(RSX, "Bad src type %d", u32{ src.reg_type });
+		rsx_log.error("Bad src type %d", u32{ src.reg_type });
 		break;
 	}
 
@@ -461,7 +461,7 @@ void CgBinaryDisasm::TaskFP()
 				if (SCB()) break;
 			}
 
-			LOG_ERROR(RSX, "Unknown/illegal instruction: 0x%x (forced unit %d)", m_opcode, forced_unit);
+			rsx_log.error("Unknown/illegal instruction: 0x%x (forced unit %d)", m_opcode, forced_unit);
 			break;
 		}
 

--- a/rpcs3/Emu/RSX/CgBinaryProgram.h
+++ b/rpcs3/Emu/RSX/CgBinaryProgram.h
@@ -234,7 +234,7 @@ public:
 
 	std::string GetCgParamRes(u32 /*offset*/) const
 	{
-		// LOG_WARNING(RSX, "GetCgParamRes offset 0x%x", offset);
+		// rsx_log.warning("GetCgParamRes offset 0x%x", offset);
 		// TODO
 		return "";
 	}

--- a/rpcs3/Emu/RSX/CgBinaryVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/CgBinaryVertexProgram.cpp
@@ -61,7 +61,7 @@ std::string CgBinaryDisasm::GetDSTDisasm(bool is_sca)
 
 	default:
 		if (d3.dst > 15)
-			LOG_ERROR(RSX, "dst index out of range: %u", d3.dst);
+			rsx_log.error("dst index out of range: %u", d3.dst);
 
 		ret += fmt::format("o[%d]", d3.dst) + mask;
 		// Vertex Program supports double destinations, notably in MOV
@@ -89,7 +89,7 @@ std::string CgBinaryDisasm::GetSRCDisasm(const u32 n)
 		}
 		else
 		{
-			LOG_ERROR(RSX, "Bad input src num: %d", u32{ d1.input_src });
+			rsx_log.error("Bad input src num: %d", u32{ d1.input_src });
 			ret += fmt::format("v[%d] # bad src", d1.input_src);
 		}
 		break;
@@ -98,7 +98,7 @@ std::string CgBinaryDisasm::GetSRCDisasm(const u32 n)
 		break;
 
 	default:
-		LOG_ERROR(RSX, "Bad src%u reg type: %d", n, u32{ src[n].reg_type });
+		rsx_log.error("Bad src%u reg type: %d", n, u32{ src[n].reg_type });
 		Emu.Pause();
 		break;
 	}
@@ -367,7 +367,7 @@ void CgBinaryDisasm::TaskVP()
 
 			if (i < m_data.size())
 			{
-				LOG_ERROR(RSX, "Program end before buffer end.");
+				rsx_log.error("Program end before buffer end.");
 			}
 
 			break;
@@ -413,7 +413,7 @@ void CgBinaryDisasm::TaskVP()
 		case RSX_SCA_OPCODE_POP: SetDSTScaDisasm(""); break;
 
 		default:
-			LOG_ERROR(RSX, "Unknown vp sca_opcode 0x%x", u32{ d1.sca_opcode });
+			rsx_log.error("Unknown vp sca_opcode 0x%x", u32{ d1.sca_opcode });
 			break;
 		}
 
@@ -446,7 +446,7 @@ void CgBinaryDisasm::TaskVP()
 		case RSX_VEC_OPCODE_TXL: SetDSTVecDisasm("$t, $0"); break;
 
 		default:
-			LOG_ERROR(RSX, "Unknown vp opcode 0x%x", u32{ d1.vec_opcode });
+			rsx_log.error("Unknown vp opcode 0x%x", u32{ d1.vec_opcode });
 			break;
 		}
 	}

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -35,7 +35,7 @@ void FragmentProgramDecompiler::SetDst(std::string code, u32 flags)
 		case 7: code = "(" + code + " / "; modifier = "8."; break;
 
 		default:
-			LOG_ERROR(RSX, "Bad scale: %d", u32{ src1.scale });
+			rsx_log.error("Bad scale: %d", u32{ src1.scale });
 			break;
 		}
 
@@ -288,7 +288,7 @@ std::string FragmentProgramDecompiler::ClampValue(const std::string& code, u32 p
 		// Doesn't seem to do anything to the input from hw tests, same as 0
 		break;
 	default:
-		LOG_ERROR(RSX, "Unexpected precision modifier (%d)\n", precision);
+		rsx_log.error("Unexpected precision modifier (%d)\n", precision);
 		break;
 	}
 
@@ -609,7 +609,7 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 			// UNK
 			if (reg_var == "unk")
 			{
-				LOG_ERROR(RSX, "Bad src reg num: %d", u32{ dst.src_attr_reg_num });
+				rsx_log.error("Bad src reg num: %d", u32{ dst.src_attr_reg_num });
 			}
 
 			ret += reg_var;
@@ -633,7 +633,7 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 		break;
 
 	case RSX_FP_REGISTER_TYPE_UNKNOWN: // ??? Used by a few games, what is it?
-		LOG_ERROR(RSX, "Src type 3 used, opcode=0x%X, dst=0x%X s0=0x%X s1=0x%X s2=0x%X",
+		rsx_log.error("Src type 3 used, opcode=0x%X, dst=0x%X s0=0x%X s1=0x%X s2=0x%X",
 				dst.opcode, dst.HEX, src0.HEX, src1.HEX, src2.HEX);
 
 		ret += AddType3();
@@ -641,7 +641,7 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 		break;
 
 	default:
-		LOG_ERROR(RSX, "Bad src type %d", u32{ src.reg_type });
+		rsx_log.error("Bad src type %d", u32{ src.reg_type });
 		Emu.Pause();
 		break;
 	}
@@ -714,7 +714,7 @@ std::string FragmentProgramDecompiler::BuildCode()
 		if (!properties.has_discard_op)
 		{
 			// NOTE: Discard operation overrides output
-			LOG_WARNING(RSX, "Shader does not write to any output register and will be NOPed");
+			rsx_log.warning("Shader does not write to any output register and will be NOPed");
 			main = "/*" + main + "*/";
 		}
 	}
@@ -1127,10 +1127,10 @@ std::string FragmentProgramDecompiler::Decompile()
 			{
 			case RSX_FP_OPCODE_BRK:
 				if (m_loop_count) AddFlowOp("break");
-				else LOG_ERROR(RSX, "BRK opcode found outside of a loop");
+				else rsx_log.error("BRK opcode found outside of a loop");
 				break;
 			case RSX_FP_OPCODE_CAL:
-				LOG_ERROR(RSX, "Unimplemented SIP instruction: CAL");
+				rsx_log.error("Unimplemented SIP instruction: CAL");
 				break;
 			case RSX_FP_OPCODE_FENCT:
 				AddCode("//FENCT");
@@ -1212,7 +1212,7 @@ std::string FragmentProgramDecompiler::Decompile()
 			if (handle_sct_scb(opcode)) break;
 			forced_unit = FORCE_NONE;
 
-			LOG_ERROR(RSX, "Unknown/illegal instruction: 0x%x (forced unit %d)", opcode, prev_force_unit);
+			rsx_log.error("Unknown/illegal instruction: 0x%x (forced unit %d)", opcode, prev_force_unit);
 			break;
 		}
 
@@ -1226,7 +1226,7 @@ std::string FragmentProgramDecompiler::Decompile()
 
 	while (m_code_level > 1)
 	{
-		LOG_ERROR(RSX, "Hanging block found at end of shader. Malformed shader?");
+		rsx_log.error("Hanging block found at end of shader. Malformed shader?");
 
 		m_code_level--;
 		AddCode("}");

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -59,7 +59,7 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 				if (!fast_exit)
 				{
 					// This can be harmless if a dangling RET was encountered before
-					LOG_ERROR(RSX, "vp_analyser: Possible infinite loop detected");
+					rsx_log.error("vp_analyser: Possible infinite loop detected");
 					current_instrution++;
 					continue;
 				}
@@ -142,7 +142,7 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 			{
 				if (call_stack.empty())
 				{
-					LOG_ERROR(RSX, "vp_analyser: RET found outside subroutine call");
+					rsx_log.error("vp_analyser: RET found outside subroutine call");
 				}
 				else
 				{
@@ -236,7 +236,7 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 		{
 			if (!dst_prog.instruction_mask[target])
 			{
-				LOG_ERROR(RSX, "vp_analyser: Failed, branch target 0x%x was not resolved", target);
+				rsx_log.error("vp_analyser: Failed, branch target 0x%x was not resolved", target);
 			}
 		}
 	}

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -213,7 +213,7 @@ protected:
 				return std::forward_as_tuple(__null_vertex_program, false);
 			}
 
-			LOG_NOTICE(RSX, "VP not found in buffer!");
+			rsx_log.notice("VP not found in buffer!");
 
 			lock.upgrade();
 			auto [it, inserted] = m_vertex_shader_cache.try_emplace(rsx_vp);
@@ -249,7 +249,7 @@ protected:
 				return std::forward_as_tuple(__null_fragment_program, false);
 			}
 
-			LOG_NOTICE(RSX, "FP not found in buffer!");
+			rsx_log.notice("FP not found in buffer!");
 			fragment_program_ucode_copy = malloc(rsx_fp.ucode_length);
 
 			verify("malloc() failed!" HERE), fragment_program_ucode_copy;
@@ -419,7 +419,7 @@ public:
 		}
 
 		pipeline_storage_type pipeline = backend_traits::build_pipeline(link_entry->vp, link_entry->fp, link_entry->props, std::forward<Args>(args)...);
-		LOG_SUCCESS(RSX, "New program compiled successfully");
+		rsx_log.success("New program compiled successfully");
 
 		std::lock_guard lock(m_pipeline_mutex);
 		m_storage[key] = std::move(pipeline);
@@ -469,13 +469,13 @@ public:
 			}
 			else
 			{
-				LOG_NOTICE(RSX, "Add program (vp id = %d, fp id = %d)", vertex_program.id, fragment_program.id);
+				rsx_log.notice("Add program (vp id = %d, fp id = %d)", vertex_program.id, fragment_program.id);
 				m_program_compiled_flag = true;
 
 				pipeline_storage_type pipeline = backend_traits::build_pipeline(vertex_program, fragment_program, pipelineProperties, std::forward<Args>(args)...);
 				std::lock_guard lock(m_pipeline_mutex);
 				auto &rtn = m_storage[key] = std::move(pipeline);
-				LOG_SUCCESS(RSX, "New program compiled successfully");
+				rsx_log.success("New program compiled successfully");
 				return rtn;
 			}
 		}
@@ -496,7 +496,7 @@ public:
 				return __null_pipeline_handle;
 			}
 
-			LOG_NOTICE(RSX, "Add program (vp id = %d, fp id = %d)", vertex_program.id, fragment_program.id);
+			rsx_log.notice("Add program (vp id = %d, fp id = %d)", vertex_program.id, fragment_program.id);
 			m_program_compiled_flag = true;
 
 			lock.upgrade();

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -752,7 +752,7 @@ u8 get_format_block_size_in_bytes(int format)
 	case CELL_GCM_TEXTURE_COMPRESSED_DXT45:
 	case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT: return 16;
 	default:
-		LOG_ERROR(RSX, "Unimplemented block size in bytes for texture format: 0x%x", format);
+		rsx_log.error("Unimplemented block size in bytes for texture format: 0x%x", format);
 		return 1;
 	}
 }
@@ -789,7 +789,7 @@ u8 get_format_block_size_in_texel(int format)
 	case CELL_GCM_TEXTURE_COMPRESSED_DXT23:
 	case CELL_GCM_TEXTURE_COMPRESSED_DXT45: return 4;
 	default:
-		LOG_ERROR(RSX, "Unimplemented block size in texels for texture format: 0x%x", format);
+		rsx_log.error("Unimplemented block size in texels for texture format: 0x%x", format);
 		return 1;
 	}
 }
@@ -916,7 +916,7 @@ static size_t get_texture_size(u32 format, u16 width, u16 height, u16 depth, u32
 		if (width > 1 || height > 1)
 		{
 			// If width == 1, the scanning just returns texel 0, so it is a valid setup
-			LOG_ERROR(RSX, "Invalid texture pitch setup, width=%d, height=%d, format=0x%x(0x%x)",
+			rsx_log.error("Invalid texture pitch setup, width=%d, height=%d, format=0x%x(0x%x)",
 				width, height, format, gcm_format);
 		}
 

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -56,12 +56,12 @@ std::string VertexProgramDecompiler::GetDST(bool is_sca)
 		{
 			if (d3.dst > 15)
 			{
-				LOG_ERROR(RSX, "dst index out of range: %u", d3.dst);
+				rsx_log.error("dst index out of range: %u", d3.dst);
 			}
 
 			if (is_address_reg)
 			{
-				LOG_ERROR(RSX, "ARL opcode writing to output register!");
+				rsx_log.error("ARL opcode writing to output register!");
 			}
 
 			const auto reg_type = getFloatTypeName(4);
@@ -120,7 +120,7 @@ std::string VertexProgramDecompiler::GetSRC(const u32 n)
 		}
 		else
 		{
-			LOG_ERROR(RSX, "Bad input src num: %d", u32{ d1.input_src });
+			rsx_log.error("Bad input src num: %d", u32{ d1.input_src });
 			ret += m_parr.AddParam(PF_PARAM_IN, getFloatTypeName(4), "in_unk", d1.input_src);
 		}
 		break;
@@ -130,7 +130,7 @@ std::string VertexProgramDecompiler::GetSRC(const u32 n)
 		break;
 
 	default:
-		LOG_ERROR(RSX, "Bad src%u reg type: %d", n, u32{ src[n].reg_type });
+		rsx_log.error("Bad src%u reg type: %d", n, u32{ src[n].reg_type });
 		Emu.Pause();
 		break;
 	}
@@ -192,7 +192,7 @@ void VertexProgramDecompiler::SetDST(bool is_sca, std::string value)
 	else
 	{
 		// Broken instruction?
-		LOG_ERROR(RSX, "Operation has no output defined! (0x%x, 0x%x, 0x%x, 0x%x)", d0.HEX, d1.HEX, d2.HEX, d3.HEX);
+		rsx_log.error("Operation has no output defined! (0x%x, 0x%x, 0x%x, 0x%x)", d0.HEX, d1.HEX, d2.HEX, d3.HEX);
 		dest = " //";
 	}
 
@@ -284,7 +284,7 @@ std::string VertexProgramDecompiler::GetOptionalBranchCond()
 {
 	std::string cond_operator = d3.brb_cond_true ? " != " : " == ";
 	std::string cond = "(transform_branch_bits & (1 << " + std::to_string(d3.branch_index) + "))" + cond_operator + "0";
-	
+
 	return "if (" + cond + ")";
 }
 
@@ -386,7 +386,7 @@ std::string VertexProgramDecompiler::BuildCode()
 	bool is_valid = m_parr.HasParam(PF_PARAM_OUT, getFloatTypeName(4), "dst_reg0");
 	if (!is_valid)
 	{
-		LOG_WARNING(RSX, "Vertex program has no POS output, shader will be NOPed");
+		rsx_log.warning("Vertex program has no POS output, shader will be NOPed");
 		main_body = "/*" + main_body + "*/";
 	}
 
@@ -488,7 +488,7 @@ std::string VertexProgramDecompiler::Decompile()
 
 		while (!m_call_stack.empty())
 		{
-			LOG_ERROR(RSX, "vertex program end in subroutine call!");
+			rsx_log.error("vertex program end in subroutine call!");
 			do_function_return();
 		}
 
@@ -612,7 +612,7 @@ std::string VertexProgramDecompiler::Decompile()
 		}
 		default:
 			AddCode(fmt::format("//Unknown vp opcode 0x%x", u32{ d1.vec_opcode }));
-			LOG_ERROR(RSX, "Unknown vp opcode 0x%x", u32{ d1.vec_opcode });
+			rsx_log.error("Unknown vp opcode 0x%x", u32{ d1.vec_opcode });
 			program_end = true;
 			break;
 		}
@@ -646,7 +646,7 @@ std::string VertexProgramDecompiler::Decompile()
 			else
 			{
 				//TODO
-				LOG_ERROR(RSX, "BRA opcode found in subroutine!");
+				rsx_log.error("BRA opcode found in subroutine!");
 			}
 		}
 		break;
@@ -667,7 +667,7 @@ std::string VertexProgramDecompiler::Decompile()
 			else
 			{
 				//TODO
-				LOG_ERROR(RSX, "BRI opcode found in subroutine!");
+				rsx_log.error("BRI opcode found in subroutine!");
 			}
 		}
 		break;
@@ -678,7 +678,7 @@ std::string VertexProgramDecompiler::Decompile()
 			break;
 		case RSX_SCA_OPCODE_CLI:
 			// works same as BRI
-			LOG_ERROR(RSX, "Unimplemented VP opcode CLI");
+			rsx_log.error("Unimplemented VP opcode CLI");
 			AddCode("//CLI");
 			do_function_call("$ifcond");
 			break;
@@ -709,7 +709,7 @@ std::string VertexProgramDecompiler::Decompile()
 			else
 			{
 				//TODO
-				LOG_ERROR(RSX, "BRA opcode found in subroutine!");
+				rsx_log.error("BRA opcode found in subroutine!");
 			}
 
 			break;
@@ -721,16 +721,16 @@ std::string VertexProgramDecompiler::Decompile()
 			break;
 		case RSX_SCA_OPCODE_PSH:
 			// works differently (PSH o[1].x A0;)
-			LOG_ERROR(RSX, "Unimplemented sca_opcode PSH");
+			rsx_log.error("Unimplemented sca_opcode PSH");
 			break;
 		case RSX_SCA_OPCODE_POP:
 			// works differently (POP o[1].x;)
-			LOG_ERROR(RSX, "Unimplemented sca_opcode POP");
+			rsx_log.error("Unimplemented sca_opcode POP");
 			break;
 
 		default:
 			AddCode(fmt::format("//Unknown vp sca_opcode 0x%x", u32{ d1.sca_opcode }));
-			LOG_ERROR(RSX, "Unknown vp sca_opcode 0x%x", u32{ d1.sca_opcode });
+			rsx_log.error("Unknown vp sca_opcode 0x%x", u32{ d1.sca_opcode });
 			program_end = true;
 			break;
 		}
@@ -744,7 +744,7 @@ std::string VertexProgramDecompiler::Decompile()
 				if ((i + 1) < m_instr_count)
 				{
 					// In rare cases, this might be harmless (large coalesced program blocks controlled via branches aka ubershaders)
-					LOG_ERROR(RSX, "Vertex program block aborts prematurely. Expect glitches");
+					rsx_log.error("Vertex program block aborts prematurely. Expect glitches");
 				}
 
 				break;

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -746,7 +746,7 @@ namespace rsx
 		{
 			if (address_is_bound(addr))
 			{
-				LOG_ERROR(RSX, "Cannot invalidate a currently bound render target!");
+				rsx_log.error("Cannot invalidate a currently bound render target!");
 				return;
 			}
 
@@ -802,7 +802,7 @@ namespace rsx
 			// Sanity check
 			if (UNLIKELY(surface_internal_pitch > required_pitch))
 			{
-				LOG_WARNING(RSX, "Invalid 2D region descriptor. w=%d, h=%d, bpp=%d, pitch=%d",
+				rsx_log.warning("Invalid 2D region descriptor. w=%d, h=%d, bpp=%d, pitch=%d",
 							required_width, required_height, required_bpp, required_pitch);
 				return {};
 			}

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -159,7 +159,7 @@ namespace rsx
 			if (!old_contents.empty())
 			{
 				// Cascade resource derefs
-				LOG_ERROR(RSX, "Resource was destroyed whilst holding a resource reference!");
+				rsx_log.error("Resource was destroyed whilst holding a resource reference!");
 			}
 		}
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -353,9 +353,9 @@ namespace rsx
 				return;
 
 			if (error)
-				LOG_ERROR(RSX, "%s", *result.first);
+				rsx_log.error("%s", *result.first);
 			else
-				LOG_WARNING(RSX, "%s", *result.first);
+				rsx_log.warning("%s", *result.first);
 		}
 
 		template <typename... Args>
@@ -510,7 +510,7 @@ namespace rsx
 						count++;
 					}
 				}
-				//LOG_ERROR(RSX, "Set protection of %d blocks to 0x%x", count, static_cast<u32>(prot));
+				//rsx_log.error("Set protection of %d blocks to 0x%x", count, static_cast<u32>(prot));
 			};
 
 			auto discard_set = [this](std::vector<section_storage_type*>& _set)
@@ -1032,7 +1032,7 @@ namespace rsx
 			if (dimensions_mismatch != nullptr)
 			{
 				auto &tex = *dimensions_mismatch;
-				LOG_WARNING(RSX, "Cached object for address 0x%X was found, but it does not match stored parameters (width=%d vs %d; height=%d vs %d; depth=%d vs %d; mipmaps=%d vs %d)",
+				rsx_log.warning("Cached object for address 0x%X was found, but it does not match stored parameters (width=%d vs %d; height=%d vs %d; depth=%d vs %d; mipmaps=%d vs %d)",
 					range.start, width, tex.get_width(), height, tex.get_height(), depth, tex.get_depth(), mipmaps, tex.get_mipmaps());
 			}
 
@@ -1170,7 +1170,7 @@ namespace rsx
 			if (region_ptr == nullptr)
 			{
 				AUDIT(m_flush_always_cache.find(memory_range) == m_flush_always_cache.end());
-				LOG_ERROR(RSX, "set_memory_flags(0x%x, 0x%x, %d): region_ptr == nullptr", memory_range.start, memory_range.end, static_cast<u32>(flags));
+				rsx_log.error("set_memory_flags(0x%x, 0x%x, %d): region_ptr == nullptr", memory_range.start, memory_range.end, static_cast<u32>(flags));
 				return;
 			}
 
@@ -1766,7 +1766,7 @@ namespace rsx
 				}
 				else
 				{
-					LOG_ERROR(RSX, "Unimplemented unnormalized sampling for texture type %d", static_cast<u32>(extended_dimension));
+					rsx_log.error("Unimplemented unnormalized sampling for texture type %d", static_cast<u32>(extended_dimension));
 				}
 			}
 
@@ -1962,7 +1962,7 @@ namespace rsx
 				if (UNLIKELY((src_h + src.offset_y) > src.height))
 				{
 					// TODO: Special case that needs wrapping around (custom blit)
-					LOG_ERROR(RSX, "Transfer cropped in Y, src_h=%d, offset_y=%d, block_h=%d", src_h, src.offset_y, src.height);
+					rsx_log.error("Transfer cropped in Y, src_h=%d, offset_y=%d, block_h=%d", src_h, src.offset_y, src.height);
 
 					src_h = src.height - src.offset_y;
 					dst_h = u16(src_h * scale_y + 0.000001f);
@@ -1971,7 +1971,7 @@ namespace rsx
 				if (UNLIKELY((src_w + src.offset_x) > src.width))
 				{
 					// TODO: Special case that needs wrapping around (custom blit)
-					LOG_ERROR(RSX, "Transfer cropped in X, src_w=%d, offset_x=%d, block_w=%d", src_w, src.offset_x, src.width);
+					rsx_log.error("Transfer cropped in X, src_w=%d, offset_x=%d, block_w=%d", src_w, src.offset_x, src.width);
 
 					src_w = src.width - src.offset_x;
 					dst_w = u16(src_w * scale_x + 0.000001f);
@@ -2188,7 +2188,7 @@ namespace rsx
 				}
 				else
 				{
-					//LOG_TRACE(RSX, "Blit transfer to surface with dims %dx%d", dst_dimensions.width, dst.height);
+					//rsx_log.trace("Blit transfer to surface with dims %dx%d", dst_dimensions.width, dst.height);
 				}
 			}
 
@@ -2315,7 +2315,7 @@ namespace rsx
 						if (cached_dest->is_depth_texture() != src_is_depth)
 						{
 							// Opt to cancel the destination. Can also use typeless convert
-							LOG_WARNING(RSX, "Format mismatch on blit destination block. Performance warning.");
+							rsx_log.warning("Format mismatch on blit destination block. Performance warning.");
 
 							// The invalidate call before creating a new target will remove this section
 							cached_dest = nullptr;

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -118,7 +118,7 @@ namespace rsx
 				return CELL_GCM_TEXTURE_DEPTH16;
 			}
 
-			LOG_ERROR(RSX, "Unsupported depth conversion (0x%X)", gcm_format);
+			rsx_log.error("Unsupported depth conversion (0x%X)", gcm_format);
 			return gcm_format;
 		}
 
@@ -398,11 +398,11 @@ namespace rsx
 				if (found_slices > 0)
 				{
 					//TODO: Gather remaining sides from the texture cache or upload from cpu (too slow?)
-					LOG_ERROR(RSX, "Could not gather all required slices for cubemap/3d generation");
+					rsx_log.error("Could not gather all required slices for cubemap/3d generation");
 				}
 				else
 				{
-					LOG_WARNING(RSX, "Could not gather textures into an atlas; using CPU fallback...");
+					rsx_log.warning("Could not gather textures into an atlas; using CPU fallback...");
 				}
 			}
 		}

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1341,7 +1341,7 @@ namespace rsx
 
 		void on_miss()
 		{
-			LOG_WARNING(RSX, "Cache miss at address 0x%X. This is gonna hurt...", get_section_base());
+			rsx_log.warning("Cache miss at address 0x%X. This is gonna hurt...", get_section_base());
 			m_tex_cache->on_miss(*derived());
 		}
 
@@ -1456,7 +1456,7 @@ namespace rsx
 				const auto num_exclusions = flush_exclusions.size();
 				if (num_exclusions > 0)
 				{
-					LOG_WARNING(RSX, "Slow imp_flush path triggered with non-empty flush_exclusions (%d exclusions, %d bytes), performance might suffer", num_exclusions, valid_length);
+					rsx_log.warning("Slow imp_flush path triggered with non-empty flush_exclusions (%d exclusions, %d bytes), performance might suffer", num_exclusions, valid_length);
 				}
 
 				for (s32 remaining = s32(valid_length); remaining > 0; remaining -= rsx_pitch)

--- a/rpcs3/Emu/RSX/GL/GLCompute.h
+++ b/rpcs3/Emu/RSX/GL/GLCompute.h
@@ -231,7 +231,7 @@ namespace gl
 			if ((num_bytes_to_process + data_offset) > data->size())
 			{
 				// Technically robust buffer access should keep the driver from crashing in OOB situations
-				LOG_ERROR(RSX, "Inadequate buffer length submitted for a compute operation."
+				rsx_log.error("Inadequate buffer length submitted for a compute operation."
 					"Required=%d bytes, Available=%d bytes", num_bytes_to_process, data->size());
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -140,7 +140,7 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 				if (m_shadow_sampled_textures & mask)
 				{
 					if (m_2d_sampled_textures & mask)
-						LOG_ERROR(RSX, "Texture unit %d is sampled as both a shadow texture and a depth texture", index);
+						rsx_log.error("Texture unit %d is sampled as both a shadow texture and a depth texture", index);
 					else
 						samplerType = "sampler2DShadow";
 				}
@@ -397,12 +397,12 @@ void GLFragmentProgram::Compile()
 			char* buf = new char[infoLength]; // Buffer to store infoLog
 
 			glGetShaderInfoLog(id, infoLength, &len, buf); // Retrieve the shader info log into our buffer
-			LOG_ERROR(RSX, "Failed to compile shader: %s", buf); // Write log to the console
+			rsx_log.error("Failed to compile shader: %s", buf); // Write log to the console
 
 			delete[] buf;
 		}
 
-		LOG_NOTICE(RSX, "%s", shader); // Log the text of the shader that failed to compile
+		rsx_log.notice("%s", shader); // Log the text of the shader that failed to compile
 		Emu.Pause(); // Pause the emulator, we can't really continue from here
 	}
 }
@@ -415,7 +415,7 @@ void GLFragmentProgram::Delete()
 	{
 		if (Emu.IsStopped())
 		{
-			LOG_WARNING(RSX, "GLFragmentProgram::Delete(): glDeleteShader(%d) avoided", id);
+			rsx_log.warning("GLFragmentProgram::Delete(): glDeleteShader(%d) avoided", id);
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -85,17 +85,17 @@ namespace
 		{
 			// Note : maybe add is signed on gl
 		case rsx::blend_equation::add_signed:
-			LOG_TRACE(RSX, "blend equation add_signed used. Emulating using FUNC_ADD");
+			rsx_log.trace("blend equation add_signed used. Emulating using FUNC_ADD");
 		case rsx::blend_equation::add: return GL_FUNC_ADD;
 		case rsx::blend_equation::min: return GL_MIN;
 		case rsx::blend_equation::max: return GL_MAX;
 		case rsx::blend_equation::substract: return GL_FUNC_SUBTRACT;
 		case rsx::blend_equation::reverse_substract_signed:
-			LOG_TRACE(RSX, "blend equation reverse_subtract_signed used. Emulating using FUNC_REVERSE_SUBTRACT");
+			rsx_log.trace("blend equation reverse_subtract_signed used. Emulating using FUNC_REVERSE_SUBTRACT");
 		case rsx::blend_equation::reverse_substract: return GL_FUNC_REVERSE_SUBTRACT;
 		case rsx::blend_equation::reverse_add_signed:
 		default:
-			LOG_ERROR(RSX, "Blend equation 0x%X is unimplemented!", static_cast<u32>(op));
+			rsx_log.error("Blend equation 0x%X is unimplemented!", static_cast<u32>(op));
 			return GL_FUNC_ADD;
 		}
 	}
@@ -690,9 +690,9 @@ void GLGSRender::on_init_thread()
 	if (g_cfg.video.debug_output)
 		gl::enable_debugging();
 
-	LOG_NOTICE(RSX, "GL RENDERER: %s (%s)", reinterpret_cast<const char*>(glGetString(GL_RENDERER)), reinterpret_cast<const char*>(glGetString(GL_VENDOR)));
-	LOG_NOTICE(RSX, "GL VERSION: %s", reinterpret_cast<const char*>(glGetString(GL_VERSION)));
-	LOG_NOTICE(RSX, "GLSL VERSION: %s", reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION)));
+	rsx_log.notice("GL RENDERER: %s (%s)", reinterpret_cast<const char*>(glGetString(GL_RENDERER)), reinterpret_cast<const char*>(glGetString(GL_VENDOR)));
+	rsx_log.notice("GL VERSION: %s", reinterpret_cast<const char*>(glGetString(GL_VERSION)));
+	rsx_log.notice("GLSL VERSION: %s", reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION)));
 
 	auto& gl_caps = gl::get_driver_caps();
 
@@ -708,12 +708,12 @@ void GLGSRender::on_init_thread()
 
 	if (!gl_caps.ARB_depth_buffer_float_supported && g_cfg.video.force_high_precision_z_buffer)
 	{
-		LOG_WARNING(RSX, "High precision Z buffer requested but your GPU does not support GL_ARB_depth_buffer_float. Option ignored.");
+		rsx_log.warning("High precision Z buffer requested but your GPU does not support GL_ARB_depth_buffer_float. Option ignored.");
 	}
 
 	if (!gl_caps.ARB_texture_barrier_supported && !gl_caps.NV_texture_barrier_supported && !g_cfg.video.strict_rendering_mode)
 	{
-		LOG_WARNING(RSX, "Texture barriers are not supported by your GPU. Feedback loops will have undefined results.");
+		rsx_log.warning("Texture barriers are not supported by your GPU. Feedback loops will have undefined results.");
 	}
 
 	//Use industry standard resource alignment values as defaults
@@ -731,10 +731,10 @@ void GLGSRender::on_init_thread()
 	m_min_texbuffer_alignment = std::max(m_min_texbuffer_alignment, 16);
 	m_uniform_buffer_offset_align = std::max(m_uniform_buffer_offset_align, 16);
 
-	LOG_NOTICE(RSX, "Supported texel buffer size reported: %d bytes", m_max_texbuffer_size);
+	rsx_log.notice("Supported texel buffer size reported: %d bytes", m_max_texbuffer_size);
 	if (m_max_texbuffer_size < (16 * 0x100000))
 	{
-		LOG_ERROR(RSX, "Max texture buffer size supported is less than 16M which is useless. Expect undefined behaviour.");
+		rsx_log.error("Max texture buffer size supported is less than 16M which is useless. Expect undefined behaviour.");
 		m_max_texbuffer_size = (16 * 0x100000);
 	}
 
@@ -780,14 +780,14 @@ void GLGSRender::on_init_thread()
 
 	if (!gl_caps.ARB_buffer_storage_supported)
 	{
-		LOG_WARNING(RSX, "Forcing use of legacy OpenGL buffers because ARB_buffer_storage is not supported");
+		rsx_log.warning("Forcing use of legacy OpenGL buffers because ARB_buffer_storage is not supported");
 		// TODO: do not modify config options
 		g_cfg.video.gl_legacy_buffers.from_string("true");
 	}
 
 	if (g_cfg.video.gl_legacy_buffers)
 	{
-		LOG_WARNING(RSX, "Using legacy openGL buffers.");
+		rsx_log.warning("Using legacy openGL buffers.");
 		manually_flush_ring_buffers = true;
 
 		m_attrib_ring_buffer = std::make_unique<gl::legacy_ring_buffer>();

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -49,12 +49,12 @@ namespace gl
 		{
 		case GL_DEBUG_TYPE_ERROR:
 		{
-			LOG_ERROR(RSX, "%s", message);
+			rsx_log.error("%s", message);
 			return;
 		}
 		default:
 		{
-			LOG_WARNING(RSX, "%s", message);
+			rsx_log.warning("%s", message);
 			return;
 		}
 		}
@@ -120,7 +120,7 @@ namespace gl
 
 		if (status != GL_FRAMEBUFFER_COMPLETE)
 		{
-			LOG_ERROR(RSX, "FBO check failed: 0x%04x", status);
+			rsx_log.error("FBO check failed: 0x%04x", status);
 			return false;
 		}
 

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -125,7 +125,7 @@ namespace gl
 		{
 			if (ext_name == test)
 			{
-				LOG_NOTICE(RSX, "Extension %s is supported", ext_name);
+				rsx_log.notice("Extension %s is supported", ext_name);
 				return true;
 			}
 
@@ -230,7 +230,7 @@ namespace gl
 			}
 			else
 			{
-				LOG_ERROR(RSX, "Failed to get vendor string from driver. Are we missing a context?");
+				rsx_log.error("Failed to get vendor string from driver. Are we missing a context?");
 				vendor_string = "intel"; //lowest acceptable value
 			}
 
@@ -362,7 +362,7 @@ namespace gl
 						switch (err)
 						{
 						default:
-							LOG_ERROR(RSX, "gl::fence sync returned unknown error 0x%X", err);
+							rsx_log.error("gl::fence sync returned unknown error 0x%X", err);
 						case GL_ALREADY_SIGNALED:
 						case GL_CONDITION_SATISFIED:
 							done = true;
@@ -997,7 +997,7 @@ namespace gl
 				}
 				else
 				{
-					LOG_ERROR(RSX, "OOM Error: Ring buffer was likely being used without notify() being called");
+					rsx_log.error("OOM Error: Ring buffer was likely being used without notify() being called");
 					glFinish();
 				}
 
@@ -1832,7 +1832,7 @@ namespace gl
 				}
 				else
 				{
-					LOG_WARNING(RSX, "Cubemap upload via texture::copy_from is halfplemented!");
+					rsx_log.warning("Cubemap upload via texture::copy_from is halfplemented!");
 					auto ptr = static_cast<const u8*>(src);
 					const auto end = std::min(6u, region.z + region.depth);
 					for (unsigned face = region.z; face < end; ++face)
@@ -2760,7 +2760,7 @@ public:
 						error_msg = buf.get();
 					}
 
-					LOG_ERROR(RSX, "Validation failed: %s", error_msg.c_str());
+					rsx_log.error("Validation failed: %s", error_msg.c_str());
 				}
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -136,7 +136,7 @@ namespace gl
 		{
 			if (!compiled)
 			{
-				LOG_ERROR(RSX, "You must initialize overlay passes with create() before calling run()");
+				rsx_log.error("You must initialize overlay passes with create() before calling run()");
 				return;
 			}
 
@@ -267,7 +267,7 @@ namespace gl
 			}
 			else
 			{
-				LOG_ERROR(RSX, "Overlay pass failed because framebuffer was not complete. Run with debug output enabled to diagnose the problem");
+				rsx_log.error("Overlay pass failed because framebuffer was not complete. Run with debug output enabled to diagnose the problem");
 			}
 		}
 	};

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -61,7 +61,7 @@ GLuint GLGSRender::get_present_source(gl::present_surface_info* info, const rsx:
 
 	if (!image)
 	{
-		LOG_WARNING(RSX, "Flip texture was not found in cache. Uploading surface from CPU");
+		rsx_log.warning("Flip texture was not found in cache. Uploading surface from CPU");
 
 		gl::pixel_unpack_settings unpack_settings;
 		unpack_settings.alignment(1).row_length(info->pitch / 4);

--- a/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
+++ b/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
@@ -75,12 +75,12 @@ struct GLTraits
 		result->uniforms[0] = GL_STREAM_BUFFER_START + 0;
 		result->uniforms[1] = GL_STREAM_BUFFER_START + 1;
 
-		LOG_NOTICE(RSX, "*** prog id = %d", result->id());
-		LOG_NOTICE(RSX, "*** vp id = %d", vertexProgramData.id);
-		LOG_NOTICE(RSX, "*** fp id = %d", fragmentProgramData.id);
+		rsx_log.notice("*** prog id = %d", result->id());
+		rsx_log.notice("*** vp id = %d", vertexProgramData.id);
+		rsx_log.notice("*** fp id = %d", fragmentProgramData.id);
 
-		LOG_NOTICE(RSX, "*** vp shader = \n%s", vertexProgramData.shader.c_str());
-		LOG_NOTICE(RSX, "*** fp shader = \n%s", fragmentProgramData.shader.c_str());
+		rsx_log.notice("*** vp shader = \n%s", vertexProgramData.shader.c_str());
+		rsx_log.notice("*** fp shader = \n%s", fragmentProgramData.shader.c_str());
 
 		return result;
 	}

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -146,7 +146,7 @@ namespace gl
 		case GL_RGBA8:
 			return GL_SRGB8_ALPHA8;
 		default:
-			//LOG_ERROR(RSX, "No gamma conversion for format 0x%X", in_format);
+			//rsx_log.error("No gamma conversion for format 0x%X", in_format);
 			return in_format;
 		}
 	}
@@ -165,7 +165,7 @@ namespace gl
 		case rsx::texture_wrap_mode::mirror_once_clamp: return GL_MIRROR_CLAMP_EXT;
 		}
 
-		LOG_ERROR(RSX, "Texture wrap error: bad wrap (%d)", static_cast<u32>(wrap));
+		rsx_log.error("Texture wrap error: bad wrap (%d)", static_cast<u32>(wrap));
 		return GL_REPEAT;
 	}
 
@@ -183,7 +183,7 @@ namespace gl
 		case rsx::texture_max_anisotropy::x16: return 16.0f;
 		}
 
-		LOG_ERROR(RSX, "Texture anisotropy error: bad max aniso (%d)", static_cast<u32>(aniso));
+		rsx_log.error("Texture anisotropy error: bad max aniso (%d)", static_cast<u32>(aniso));
 		return 1.0f;
 	}
 
@@ -245,7 +245,7 @@ namespace gl
 				case GL_LINEAR_MIPMAP_LINEAR:
 					min_filter = GL_LINEAR; break;
 				default:
-					LOG_ERROR(RSX, "No mipmap fallback defined for rsx_min_filter = 0x%X", static_cast<u32>(tex.min_filter()));
+					rsx_log.error("No mipmap fallback defined for rsx_min_filter = 0x%X", static_cast<u32>(tex.min_filter()));
 					min_filter = GL_NEAREST;
 				}
 			}
@@ -591,7 +591,7 @@ namespace gl
 			switch (remap_lookup[channel])
 			{
 			default:
-				LOG_ERROR(RSX, "Unknown remap function 0x%X", remap_lookup[channel]);
+				rsx_log.error("Unknown remap function 0x%X", remap_lookup[channel]);
 			case CELL_GCM_TEXTURE_REMAP_REMAP:
 				remap_values[channel] = swizzle_remap[remap_inputs[channel]];
 				break;

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -184,11 +184,11 @@ namespace gl
 					// AMD driver bug
 					// Pixel transfer fails with GL_OUT_OF_MEMORY. Usually happens with float textures or operations attempting to swap endianness.
 					// Failed operations also leak a large amount of memory
-					LOG_ERROR(RSX, "Memory transfer failure (AMD bug). Please update your driver to Adrenalin 19.4.3 or newer. Format=0x%x, Type=0x%x, Swap=%d", static_cast<u32>(format), static_cast<u32>(type), pack_unpack_swap_bytes);
+					rsx_log.error("Memory transfer failure (AMD bug). Please update your driver to Adrenalin 19.4.3 or newer. Format=0x%x, Type=0x%x, Swap=%d", static_cast<u32>(format), static_cast<u32>(type), pack_unpack_swap_bytes);
 				}
 				else
 				{
-					LOG_ERROR(RSX, "Memory transfer failed with error 0x%x. Format=0x%x, Type=0x%x", error, static_cast<u32>(format), static_cast<u32>(type));
+					rsx_log.error("Memory transfer failed with error 0x%x. Format=0x%x, Type=0x%x", error, static_cast<u32>(format), static_cast<u32>(type));
 				}
 			}
 
@@ -730,7 +730,7 @@ namespace gl
 
 			if (GLenum err = glGetError())
 			{
-				LOG_WARNING(RSX, "Failed to copy image subresource with GL error 0x%X", err);
+				rsx_log.warning("Failed to copy image subresource with GL error 0x%X", err);
 				return nullptr;
 			}
 
@@ -752,7 +752,7 @@ namespace gl
 
 			if (GLenum err = glGetError())
 			{
-				LOG_WARNING(RSX, "Failed to copy image subresource with GL error 0x%X", err);
+				rsx_log.warning("Failed to copy image subresource with GL error 0x%X", err);
 				return nullptr;
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -300,11 +300,11 @@ void GLVertexProgram::Compile()
 			char* buf = new char[r + 1]();
 			GLsizei len;
 			glGetShaderInfoLog(id, r, &len, buf);
-			LOG_ERROR(RSX, "Failed to compile vertex shader: %s", buf);
+			rsx_log.error("Failed to compile vertex shader: %s", buf);
 			delete[] buf;
 		}
 
-		LOG_NOTICE(RSX, "%s", shader.c_str());
+		rsx_log.notice("%s", shader.c_str());
 		Emu.Pause();
 	}
 }
@@ -317,7 +317,7 @@ void GLVertexProgram::Delete()
 	{
 		if (Emu.IsStopped())
 		{
-			LOG_WARNING(RSX, "GLVertexProgram::Delete(): glDeleteShader(%d) avoided", id);
+			rsx_log.warning("GLVertexProgram::Delete(): glDeleteShader(%d) avoided", id);
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/GL/OpenGL.cpp
+++ b/rpcs3/Emu/RSX/GL/OpenGL.cpp
@@ -25,7 +25,7 @@ void gl::init()
 #ifdef _WIN32
 #define OPENGL_PROC(p, n) OPENGL_PROC2(p, gl##n, gl##n)
 #define WGL_PROC(p, n) OPENGL_PROC2(p, wgl##n, wgl##n)
-#define OPENGL_PROC2(p, n, tn) /*if(!gl##n)*/ if(!(n = (p)wglGetProcAddress(#tn))) LOG_ERROR(RSX, "OpenGL: initialization of " #tn " failed.")
+#define OPENGL_PROC2(p, n, tn) /*if(!gl##n)*/ if(!(n = (p)wglGetProcAddress(#tn))) rsx_log.error("OpenGL: initialization of " #tn " failed.")
 #include "GLProcTable.h"
 #undef OPENGL_PROC
 #undef WGL_PROC
@@ -55,8 +55,8 @@ void gl::set_swapinterval(int interval)
 	}
 
 	//No existing drawable or missing swap extension, EGL?
-	LOG_ERROR(RSX, "Failed to set swap interval");
+	rsx_log.error("Failed to set swap interval");
 #else
-	LOG_ERROR(RSX, "Swap control not implemented for this platform. Vsync options not available.");
+	rsx_log.error("Swap control not implemented for this platform. Vsync options not available.");
 #endif
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -131,7 +131,7 @@ namespace rsx
 			{
 				if (!fs::is_file(filename))
 				{
-					LOG_ERROR(RSX, "Image resource file `%s' not found", filename);
+					rsx_log.error("Image resource file `%s' not found", filename);
 					return;
 				}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_font.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_font.cpp
@@ -68,7 +68,7 @@ namespace rsx
 						file_path  = fallback_font;
 						font_found = true;
 
-						LOG_NOTICE(RSX, "Found font file '%s' as a replacement for '%s'", fallback_font.c_str(), ttf_name);
+						rsx_log.notice("Found font file '%s' as a replacement for '%s'", fallback_font.c_str(), ttf_name);
 						break;
 					}
 				}
@@ -82,7 +82,7 @@ namespace rsx
 			}
 			else
 			{
-				LOG_ERROR(RSX, "Failed to initialize font '%s.ttf'", ttf_name);
+				rsx_log.error("Failed to initialize font '%s.ttf'", ttf_name);
 				return;
 			}
 
@@ -92,7 +92,7 @@ namespace rsx
 			stbtt_pack_context context;
 			if (!stbtt_PackBegin(&context, glyph_data.data(), width, height, 0, 1, nullptr))
 			{
-				LOG_ERROR(RSX, "Font packing failed");
+				rsx_log.error("Font packing failed");
 				return;
 			}
 
@@ -104,7 +104,7 @@ namespace rsx
 
 			if (!stbtt_PackFontRange(&context, bytes.data(), 0, size_px, 0, 256, pack_info.data()))
 			{
-				LOG_ERROR(RSX, "Font packing failed");
+				rsx_log.error("Font packing failed");
 				stbtt_PackEnd(&context);
 				return;
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -212,7 +212,7 @@ namespace rsx
 				{
 					if (auto error = run_input_loop())
 					{
-						LOG_ERROR(RSX, "Dialog input loop exited with error code=%d", error);
+						rsx_log.error("Dialog input loop exited with error code=%d", error);
 						return error;
 					}
 				}
@@ -235,7 +235,7 @@ namespace rsx
 					{
 						if (auto error = run_input_loop())
 						{
-							LOG_ERROR(RSX, "Dialog input loop exited with error code=%d", error);
+							rsx_log.error("Dialog input loop exited with error code=%d", error);
 						}
 					}
 					else

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -191,7 +191,7 @@ namespace rsx
 			{
 				if (auto error = run_input_loop())
 				{
-					LOG_ERROR(RSX, "Osk input loop exited with error code=%d", error);
+					rsx_log.error("Osk input loop exited with error code=%d", error);
 				}
 			});
 		}

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -34,7 +34,7 @@ namespace rsx
 			}
 			catch (const std::exception& e)
 			{
-				LOG_ERROR(RSX, "Overlays: tried to convert incompatible color code: '%s' exception: '%s'", hex_color, e.what());
+				rsx_log.error("Overlays: tried to convert incompatible color code: '%s' exception: '%s'", hex_color, e.what());
 				return color4f(0.0f, 0.0f, 0.0f, 0.0f);
 			}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -136,7 +136,7 @@ namespace rsx
 				m_list->select_next(10);
 				break;
 			default:
-				LOG_TRACE(RSX, "[ui] Button %d pressed", static_cast<u8>(button_press));
+				rsx_log.trace("[ui] Button %d pressed", static_cast<u8>(button_press));
 			}
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -211,7 +211,7 @@ namespace rsx
 				{
 					if (++pad_index >= CELL_PAD_MAX_PORT_NUM)
 					{
-						LOG_FATAL(RSX, "The native overlay cannot handle more than 7 pads! Current number of pads: %d", pad_index + 1);
+						rsx_log.fatal("The native overlay cannot handle more than 7 pads! Current number of pads: %d", pad_index + 1);
 						continue;
 					}
 

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -206,7 +206,7 @@ namespace rsx
 		{
 			if (enabled)
 			{
-				LOG_WARNING(RSX, "FIFO optimizations have been disabled as the application is not compatible with per-frame analysis");
+				rsx_log.warning("FIFO optimizations have been disabled as the application is not compatible with per-frame analysis");
 
 				reset(false);
 				fifo_hint = optimization_hint::application_not_compatible;
@@ -307,7 +307,7 @@ namespace rsx
 				}
 				else
 				{
-					LOG_ERROR(RSX, "Fifo flattener misalignment, disable FIFO reordering and report to developers");
+					rsx_log.error("Fifo flattener misalignment, disable FIFO reordering and report to developers");
 					begin_end_ctr = 0;
 					flush_cmd = 0u;
 				}
@@ -400,7 +400,7 @@ namespace rsx
 			}
 			case FIFO::FIFO_ERROR:
 			{
-				LOG_ERROR(RSX, "FIFO error: possible desync event (last cmd = 0x%x)", fifo_ctrl->last_cmd());
+				rsx_log.error("FIFO error: possible desync event (last cmd = 0x%x)", fifo_ctrl->last_cmd());
 				recover_fifo();
 				return;
 			}
@@ -422,7 +422,7 @@ namespace rsx
 					performance_counters.state = FIFO_state::spinning;
 				}
 
-				//LOG_WARNING(RSX, "rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", offs, m_ioAddress + get, cmd, get, put);
+				//rsx_log.warning("rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", offs, m_ioAddress + get, cmd, get, put);
 				fifo_ctrl->set_get(offs);
 				return;
 			}
@@ -441,7 +441,7 @@ namespace rsx
 					performance_counters.state = FIFO_state::spinning;
 				}
 
-				//LOG_WARNING(RSX, "rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", offs, m_ioAddress + get, cmd, get, put);
+				//rsx_log.warning("rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", offs, m_ioAddress + get, cmd, get, put);
 				fifo_ctrl->set_get(offs);
 				return;
 			}
@@ -450,7 +450,7 @@ namespace rsx
 				if (fifo_ret_addr != RSX_CALL_STACK_EMPTY)
 				{
 					// Only one layer is allowed in the call stack.
-					LOG_ERROR(RSX, "FIFO: CALL found inside a subroutine. Discarding subroutine");
+					rsx_log.error("FIFO: CALL found inside a subroutine. Discarding subroutine");
 					fifo_ctrl->set_get(std::exchange(fifo_ret_addr, RSX_CALL_STACK_EMPTY));
 					return;
 				}
@@ -464,7 +464,7 @@ namespace rsx
 			{
 				if (fifo_ret_addr == RSX_CALL_STACK_EMPTY)
 				{
-					LOG_ERROR(RSX, "FIFO: RET found without corresponding CALL. Discarding queue");
+					rsx_log.error("FIFO: RET found without corresponding CALL. Discarding queue");
 					fifo_ctrl->set_get(ctrl->put);
 					return;
 				}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -114,7 +114,7 @@ namespace rsx
 
 		case CELL_GCM_CONTEXT_DMA_DEVICE_RW:
 		case CELL_GCM_CONTEXT_DMA_DEVICE_R:
-		{ 
+		{
 			if (offset < 0x100000 /*&& (offset % 0x10) == 0*/)
 			{
 				return render->device_addr + offset;
@@ -455,7 +455,7 @@ namespace rsx
 		}
 		catch (const std::exception& e)
 		{
-			LOG_FATAL(RSX, "%s thrown: %s", typeid(e).name(), e.what());
+			rsx_log.fatal("%s thrown: %s", typeid(e).name(), e.what());
 			Emu.Pause();
 		}
 
@@ -704,7 +704,7 @@ namespace rsx
 			switch (clip_plane_control[index])
 			{
 			default:
-				LOG_ERROR(RSX, "bad clip plane control (0x%x)", static_cast<u8>(clip_plane_control[index]));
+				rsx_log.error("bad clip plane control (0x%x)", static_cast<u8>(clip_plane_control[index]));
 
 			case rsx::user_clip_plane_op::disable:
 				clip_enabled_flags[index] = 0;
@@ -957,7 +957,7 @@ namespace rsx
 
 		if (layout.width == 0 || layout.height == 0)
 		{
-			LOG_TRACE(RSX, "Invalid framebuffer setup, w=%d, h=%d", layout.width, layout.height);
+			rsx_log.trace("Invalid framebuffer setup, w=%d, h=%d", layout.width, layout.height);
 			return;
 		}
 
@@ -1077,7 +1077,7 @@ namespace rsx
 		switch (const auto mode = rsx::method_registers.surface_type())
 		{
 		default:
-			LOG_ERROR(RSX, "Unknown raster mode 0x%x", static_cast<u32>(mode));
+			rsx_log.error("Unknown raster mode 0x%x", static_cast<u32>(mode));
 			[[fallthrough]];
 		case rsx::surface_raster_type::linear:
 			break;
@@ -1130,7 +1130,7 @@ namespace rsx
 			if (layout.color_pitch[index] < minimum_color_pitch)
 			{
 				// Unlike the depth buffer, when given a color target we know it is intended to be rendered to
-				LOG_ERROR(RSX, "Framebuffer setup error: Color target failed pitch check, Pitch=[%d, %d, %d, %d] + %d, target=%d, context=%d",
+				rsx_log.error("Framebuffer setup error: Color target failed pitch check, Pitch=[%d, %d, %d, %d] + %d, target=%d, context=%d",
 					layout.color_pitch[0], layout.color_pitch[1], layout.color_pitch[2], layout.color_pitch[3],
 					layout.zeta_pitch, static_cast<u32>(layout.target), static_cast<u32>(context));
 
@@ -1140,7 +1140,7 @@ namespace rsx
 
 			if (layout.color_addresses[index] == layout.zeta_address)
 			{
-				LOG_WARNING(RSX, "Framebuffer at 0x%X has aliasing color/depth targets, color_index=%d, zeta_pitch = %d, color_pitch=%d, context=%d",
+				rsx_log.warning("Framebuffer at 0x%X has aliasing color/depth targets, color_index=%d, zeta_pitch = %d, color_pitch=%d, context=%d",
 					layout.zeta_address, index, layout.zeta_pitch, layout.color_pitch[index], static_cast<u32>(context));
 
 				m_framebuffer_state_contested = true;
@@ -1182,7 +1182,7 @@ namespace rsx
 
 		if (!framebuffer_status_valid && !layout.zeta_address)
 		{
-			LOG_WARNING(RSX, "Framebuffer setup failed. Draw calls may have been lost");
+			rsx_log.warning("Framebuffer setup failed. Draw calls may have been lost");
 			return;
 		}
 
@@ -1201,7 +1201,7 @@ namespace rsx
 			// Tested with Turbo: Super stunt squad that only changes the window offset to declare new framebuffers
 			// Sampling behavior clearly indicates the addresses are expected to have changed
 			if (auto clip_type = rsx::method_registers.window_clip_type())
-				LOG_ERROR(RSX, "Unknown window clip type 0x%X" HERE, clip_type);
+				rsx_log.error("Unknown window clip type 0x%X" HERE, clip_type);
 
 			for (const auto &index : rsx::utility::get_rtt_indexes(layout.target))
 			{
@@ -1221,7 +1221,7 @@ namespace rsx
 		if ((window_clip_width && window_clip_width < layout.width) ||
 			(window_clip_height && window_clip_height < layout.height))
 		{
-			LOG_ERROR(RSX, "Unexpected window clip dimensions: window_clip=%dx%d, surface_clip=%dx%d",
+			rsx_log.error("Unexpected window clip dimensions: window_clip=%dx%d, surface_clip=%dx%d",
 				window_clip_width, window_clip_height, layout.width, layout.height);
 		}
 
@@ -1676,7 +1676,7 @@ namespace rsx
 						break;
 					}
 					default:
-						LOG_ERROR(RSX, "Depth texture bound to pipeline with unexpected format 0x%X", format);
+						rsx_log.error("Depth texture bound to pipeline with unexpected format 0x%X", format);
 					}
 				}
 				else if (!backend_config.supports_hw_renormalization)
@@ -1734,7 +1734,7 @@ namespace rsx
 			//Check that the depth stage is not disabled
 			if (!rsx::method_registers.depth_test_enabled())
 			{
-				LOG_ERROR(RSX, "FS exports depth component but depth test is disabled (INVALID_OPERATION)");
+				rsx_log.error("FS exports depth component but depth test is disabled (INVALID_OPERATION)");
 			}
 		}
 	}
@@ -2168,7 +2168,7 @@ namespace rsx
 				return;
 			}
 			default:
-				LOG_ERROR(RSX, "Unknown zcull stat type %d", type);
+				rsx_log.error("Unknown zcull stat type %d", type);
 				break;
 			}
 		}
@@ -2520,7 +2520,7 @@ namespace rsx
 				f.write(os.str());
 			}
 
-			LOG_SUCCESS(RSX, "capture successful: %s", filePath.c_str());
+			rsx_log.success("capture successful: %s", filePath.c_str());
 
 			frame_capture.reset();
 			Emu.Pause();
@@ -2566,7 +2566,7 @@ namespace rsx
 
 			if (g_cfg.video.frame_skip_enabled)
 			{
-				LOG_ERROR(RSX, "Frame skip is not compatible with this application");
+				rsx_log.error("Frame skip is not compatible with this application");
 			}
 		}
 
@@ -2836,7 +2836,7 @@ namespace rsx
 				if (!m_pending_writes.front().query)
 				{
 					// If this happens, the assert above will fire. There should never be a queue header with no work to be done
-					LOG_ERROR(RSX, "Close to our death.");
+					rsx_log.error("Close to our death.");
 				}
 
 				m_next_tsc = 0;
@@ -2939,7 +2939,7 @@ namespace rsx
 					{
 						if (It->query->sync_tag > m_sync_tag)
 						{
-							// LOG_TRACE(RSX, "[Performance warning] Query hint emit during sync command.");
+							// rsx_log.trace("[Performance warning] Query hint emit during sync command.");
 							ptimer->sync_hint(FIFO_hint::hint_zcull_sync, It->query);
 						}
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -538,7 +538,7 @@ namespace rsx
 			while (!buffer_queue.empty());
 
 			// Need to observe this happening in the wild
-			LOG_ERROR(RSX, "Display queue was discarded while not empty!");
+			rsx_log.error("Display queue was discarded while not empty!");
 			return false;
 		}
 	};

--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
@@ -184,8 +184,8 @@ namespace vk
 		}
 		else
 		{
-			LOG_ERROR(RSX, "%s", shader_object.getInfoLog());
-			LOG_ERROR(RSX, "%s", shader_object.getInfoDebugLog());
+			rsx_log.error("%s", shader_object.getInfoLog());
+			rsx_log.error("%s", shader_object.getInfoDebugLog());
 		}
 
 		return success;

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -357,7 +357,7 @@ namespace vk
 			if ((num_bytes_to_process + data_offset) > data->size())
 			{
 				// Technically robust buffer access should keep the driver from crashing in OOB situations
-				LOG_ERROR(RSX, "Inadequate buffer length submitted for a compute operation."
+				rsx_log.error("Inadequate buffer length submitted for a compute operation."
 					"Required=%d bytes, Available=%d bytes", num_bytes_to_process, data->size());
 			}
 

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -337,7 +337,7 @@ namespace vk
 				{
 					// Technically legal but assuming a map->flush usage, this shouldnot happen
 					// Optimizations could in theory batch together multiple transfers though
-					LOG_ERROR(RSX, "Sink request spans multiple allocated blocks!");
+					rsx_log.error("Sink request spans multiple allocated blocks!");
 					const auto write_end = (sync_end + 1u);
 					const auto written = (write_end - local_address);
 					length -= written;
@@ -349,7 +349,7 @@ namespace vk
 			}
 			else
 			{
-				LOG_ERROR(RSX, "Sync command on range not mapped!");
+				rsx_log.error("Sync command on range not mapped!");
 				return;
 			}
 		}

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -137,7 +137,7 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 				if (m_shadow_sampled_textures & mask)
 				{
 					if (m_2d_sampled_textures & mask)
-						LOG_ERROR(RSX, "Texture unit %d is sampled as both a shadow texture and a depth texture", index);
+						rsx_log.error("Texture unit %d is sampled as both a shadow texture and a depth texture", index);
 					else
 						samplerType = "sampler2DShadow";
 				}

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -468,10 +468,10 @@ namespace vk
 			break;
 		case driver_vendor::INTEL:
 		default:
-			LOG_WARNING(RSX, "Unsupported device: %s", gpu_name);
+			rsx_log.warning("Unsupported device: %s", gpu_name);
 		}
 
-		LOG_NOTICE(RSX, "Vulkan: Renderer initialized on device '%s'", gpu_name);
+		rsx_log.notice("Vulkan: Renderer initialized on device '%s'", gpu_name);
 
 		{
 			// Buffer memory tests, only useful for portability on macOS
@@ -917,7 +917,7 @@ namespace vk
 
 				if ((get_system_time() - t) > timeout)
 				{
-					LOG_ERROR(RSX, "[vulkan] vk::wait_for_event has timed out!");
+					rsx_log.error("[vulkan] vk::wait_for_event has timed out!");
 					return VK_TIMEOUT;
 				}
 			}
@@ -1029,7 +1029,7 @@ namespace vk
 		case 0:
 			fmt::throw_exception("Assertion Failed! Vulkan API call failed with unrecoverable error: %s%s", error_message.c_str(), faulting_addr);
 		case 1:
-			LOG_ERROR(RSX, "Vulkan API call has failed with an error but will continue: %s%s", error_message.c_str(), faulting_addr);
+			rsx_log.error("Vulkan API call has failed with an error but will continue: %s%s", error_message.c_str(), faulting_addr);
 			break;
 		case 2:
 			break;
@@ -1044,11 +1044,11 @@ namespace vk
 		{
 			if (strstr(pMsg, "IMAGE_VIEW_TYPE_1D")) return false;
 
-			LOG_ERROR(RSX, "ERROR: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
+			rsx_log.error("ERROR: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
 		}
 		else if (msgFlags & VK_DEBUG_REPORT_WARNING_BIT_EXT)
 		{
-			LOG_WARNING(RSX, "WARNING: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
+			rsx_log.warning("WARNING: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -620,14 +620,14 @@ private:
 			vkGetPhysicalDeviceMemoryProperties(pdev, &memory_properties);
 			get_physical_device_features(allow_extensions);
 
-			LOG_NOTICE(RSX, "Found vulkan-compatible GPU: '%s' running on driver %s", get_name(), get_driver_version());
+			rsx_log.notice("Found vulkan-compatible GPU: '%s' running on driver %s", get_name(), get_driver_version());
 
 			if (get_driver_vendor() == driver_vendor::RADV &&
 				get_name().find("LLVM 8.0.0") != std::string::npos)
 			{
 				// Serious driver bug causing black screens
 				// See https://bugs.freedesktop.org/show_bug.cgi?id=110970
-				LOG_FATAL(RSX, "RADV drivers have a major driver bug with LLVM 8.0.0 resulting in no visual output. Upgrade to LLVM version 8.0.1 or greater to avoid this issue.");
+				rsx_log.fatal("RADV drivers have a major driver bug with LLVM 8.0.0 resulting in no visual output. Upgrade to LLVM version 8.0.1 or greater to avoid this issue.");
 			}
 
 			if (get_chip_class() == chip_class::AMD_vega)
@@ -842,7 +842,7 @@ private:
 				{
 					// TODO: Slow fallback to emulate this
 					// Just warn and let the driver decide whether to crash or not
-					LOG_FATAL(RSX, "Your GPU driver does not support some required MSAA features. Expect problems.");
+					rsx_log.fatal("Your GPU driver does not support some required MSAA features. Expect problems.");
 				}
 
 				enabled_features.sampleRateShading = VK_TRUE;
@@ -863,20 +863,20 @@ private:
 			// Optionally disable unsupported stuff
 			if (!pgpu->features.depthBounds)
 			{
-				LOG_ERROR(RSX, "Your GPU does not support depth bounds testing. Graphics may not work correctly.");
+				rsx_log.error("Your GPU does not support depth bounds testing. Graphics may not work correctly.");
 				enabled_features.depthBounds = VK_FALSE;
 			}
 
 			if (!pgpu->features.sampleRateShading && enabled_features.sampleRateShading)
 			{
-				LOG_ERROR(RSX, "Your GPU does not support sample rate shading for multisampling. Graphics may be inaccurate when MSAA is enabled.");
+				rsx_log.error("Your GPU does not support sample rate shading for multisampling. Graphics may be inaccurate when MSAA is enabled.");
 				enabled_features.sampleRateShading = VK_FALSE;
 			}
 
 			if (!pgpu->features.alphaToOne && enabled_features.alphaToOne)
 			{
 				// AMD proprietary drivers do not expose alphaToOne support
-				LOG_ERROR(RSX, "Your GPU does not support alpha-to-one for multisampling. Graphics may be inaccurate when MSAA is enabled.");
+				rsx_log.error("Your GPU does not support alpha-to-one for multisampling. Graphics may be inaccurate when MSAA is enabled.");
 				enabled_features.alphaToOne = VK_FALSE;
 			}
 
@@ -899,11 +899,11 @@ private:
 				shader_support_info.shaderFloat16 = VK_TRUE;
 				device.pNext = &shader_support_info;
 
-				LOG_NOTICE(RSX, "GPU/driver supports float16 data types natively. Using native float16_t variables if possible.");
+				rsx_log.notice("GPU/driver supports float16 data types natively. Using native float16_t variables if possible.");
 			}
 			else
 			{
-				LOG_NOTICE(RSX, "GPU/driver lacks support for float16 data types. All float16_t arithmetic will be emulated with float32_t.");
+				rsx_log.notice("GPU/driver lacks support for float16 data types. All float16_t arithmetic will be emulated with float32_t.");
 			}
 
 			CHECK_RESULT(vkCreateDevice(*pgpu, &device, nullptr, &dev));
@@ -1251,7 +1251,7 @@ private:
 		{
 			if (!is_open)
 			{
-				LOG_ERROR(RSX, "commandbuffer->end was called but commandbuffer is not in a recording state");
+				rsx_log.error("commandbuffer->end was called but commandbuffer is not in a recording state");
 				return;
 			}
 
@@ -1263,7 +1263,7 @@ private:
 		{
 			if (is_open)
 			{
-				LOG_ERROR(RSX, "commandbuffer->submit was called whilst the command buffer is in a recording state");
+				rsx_log.error("commandbuffer->submit was called whilst the command buffer is in a recording state");
 				return;
 			}
 
@@ -2035,7 +2035,7 @@ public:
 
 			if (m_width == 0 || m_height == 0)
 			{
-				LOG_ERROR(RSX, "Invalid window dimensions %d x %d", m_width, m_height);
+				rsx_log.error("Invalid window dimensions %d x %d", m_width, m_height);
 				return false;
 			}
 
@@ -2114,7 +2114,7 @@ public:
 
 			if (m_width == 0 || m_height == 0)
 			{
-				LOG_ERROR(RSX, "Invalid window dimensions %d x %d", m_width, m_height);
+				rsx_log.error("Invalid window dimensions %d x %d", m_width, m_height);
 				return false;
 			}
 
@@ -2174,7 +2174,7 @@ public:
 
 			if (m_width == 0 || m_height == 0)
 			{
-				LOG_ERROR(RSX, "Invalid window dimensions %d x %d", m_width, m_height);
+				rsx_log.error("Invalid window dimensions %d x %d", m_width, m_height);
 				return false;
 			}
 
@@ -2184,7 +2184,7 @@ public:
 			if (!XMatchVisualInfo(display, DefaultScreen(display), bit_depth, TrueColor, &visual))
 #pragma GCC diagnostic pop
 			{
-				LOG_ERROR(RSX, "Could not find matching visual info!" HERE);
+				rsx_log.error("Could not find matching visual info!" HERE);
 				return false;
 			}
 
@@ -2207,7 +2207,7 @@ public:
 
 			if (display == NULL)
 			{
-				LOG_FATAL(RSX, "Could not create virtual display on this window protocol (Wayland?)");
+				rsx_log.fatal("Could not create virtual display on this window protocol (Wayland?)");
 				return;
 			}
 
@@ -2413,7 +2413,7 @@ public:
 		{
 			if (vk_present_queue == VK_NULL_HANDLE)
 			{
-				LOG_ERROR(RSX, "Cannot create WSI swapchain without a present queue");
+				rsx_log.error("Cannot create WSI swapchain without a present queue");
 				return false;
 			}
 
@@ -2426,7 +2426,7 @@ public:
 			if (surface_descriptors.maxImageExtent.width < m_width ||
 				surface_descriptors.maxImageExtent.height < m_height)
 			{
-				LOG_ERROR(RSX, "Swapchain: Swapchain creation failed because dimensions cannot fit. Max = %d, %d, Requested = %d, %d",
+				rsx_log.error("Swapchain: Swapchain creation failed because dimensions cannot fit. Max = %d, %d, Requested = %d, %d",
 					surface_descriptors.maxImageExtent.width, surface_descriptors.maxImageExtent.height, m_width, m_height);
 
 				return false;
@@ -2442,7 +2442,7 @@ public:
 			{
 				if (surface_descriptors.currentExtent.width == 0 || surface_descriptors.currentExtent.height == 0)
 				{
-					LOG_WARNING(RSX, "Swapchain: Current surface extent is a null region. Is the window minimized?");
+					rsx_log.warning("Swapchain: Current surface extent is a null region. Is the window minimized?");
 					return false;
 				}
 
@@ -2488,7 +2488,7 @@ public:
 					break;
 			}
 
-			LOG_NOTICE(RSX, "Swapchain: present mode %d in use.", static_cast<int>(swapchain_present_mode));
+			rsx_log.notice("Swapchain: present mode %d in use.", static_cast<int>(swapchain_present_mode));
 
 			uint32_t nb_swap_images = surface_descriptors.minImageCount + 1;
 			if (surface_descriptors.maxImageCount > 0)
@@ -2696,7 +2696,7 @@ public:
 #endif //(WAYLAND)
 				if (!found_surface_ext)
 				{
-					LOG_ERROR(RSX, "Could not find a supported Vulkan surface extension");
+					rsx_log.error("Could not find a supported Vulkan surface extension");
 					return 0;
 				}
 #endif //(WIN32, __APPLE__)
@@ -2716,7 +2716,7 @@ public:
 			{
 				if (result == VK_ERROR_LAYER_NOT_PRESENT)
 				{
-					LOG_FATAL(RSX,"Could not initialize layer VK_LAYER_KHRONOS_validation");
+					rsx_log.fatal("Could not initialize layer VK_LAYER_KHRONOS_validation");
 				}
 
 				return false;
@@ -2844,7 +2844,7 @@ public:
 
 			if (!present_possible)
 			{
-				LOG_ERROR(RSX, "It is not possible for the currently selected GPU to present to the window (Likely caused by NVIDIA driver running the current display)");
+				rsx_log.error("It is not possible for the currently selected GPU to present to the window (Likely caused by NVIDIA driver running the current display)");
 			}
 
 			// Search for a graphics and a present queue in the array of queue
@@ -2885,7 +2885,7 @@ public:
 
 			if (graphicsQueueNodeIndex == UINT32_MAX)
 			{
-				LOG_FATAL(RSX, "Failed to find a suitable graphics queue" HERE);
+				rsx_log.fatal("Failed to find a suitable graphics queue" HERE);
 				return nullptr;
 			}
 
@@ -2898,7 +2898,7 @@ public:
 			if (!present_possible)
 			{
 				//Native(sw) swapchain
-				LOG_WARNING(RSX, "Falling back to software present support (native windowing API)");
+				rsx_log.warning("Falling back to software present support (native windowing API)");
 				auto swapchain = new swapchain_NATIVE(dev, UINT32_MAX, graphicsQueueNodeIndex);
 				swapchain->create(window_handle);
 				return swapchain;
@@ -3473,7 +3473,7 @@ public:
 					std::string shader_type = type == ::glsl::program_domain::glsl_vertex_program ? "vertex" :
 						type == ::glsl::program_domain::glsl_fragment_program ? "fragment" : "compute";
 
-					LOG_NOTICE(RSX, "%s", m_source);
+					rsx_log.notice("%s", m_source);
 					fmt::throw_exception("Failed to compile %s shader" HERE, shader_type);
 				}
 
@@ -3590,7 +3590,7 @@ public:
 
 			if (!(get_heap_compatible_buffer_types() & usage))
 			{
-				LOG_WARNING(RSX, "Buffer usage %u is not heap-compatible using this driver, explicit staging buffer in use", usage);
+				rsx_log.warning("Buffer usage %u is not heap-compatible using this driver, explicit staging buffer in use", usage);
 
 				shadow = std::make_unique<buffer>(*device, size, memory_index, memory_flags, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0);
 				usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -36,7 +36,7 @@ void VKGSRender::reinitialize_swapchain()
 	// Rebuild swapchain. Old swapchain destruction is handled by the init_swapchain call
 	if (!m_swapchain->init(m_swapchain_dims.width, m_swapchain_dims.height))
 	{
-		LOG_WARNING(RSX, "Swapchain initialization failed. Request ignored [%dx%d]", m_swapchain_dims.width, m_swapchain_dims.height);
+		rsx_log.warning("Swapchain initialization failed. Request ignored [%dx%d]", m_swapchain_dims.width, m_swapchain_dims.height);
 		swapchain_unavailable = true;
 		open_command_buffer();
 		return;
@@ -381,7 +381,7 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 		if (info.stats.draw_calls > 0)
 		{
 			// This can be 'legal' if the window was being resized and no polling happened because of swapchain_unavailable flag
-			LOG_ERROR(RSX, "Possible data corruption on frame context storage detected");
+			rsx_log.error("Possible data corruption on frame context storage detected");
 		}
 
 		// There were no draws and back-to-back flips happened
@@ -473,7 +473,7 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 			should_reinitialize_swapchain = true;
 			break;
 		case VK_ERROR_OUT_OF_DATE_KHR:
-			LOG_WARNING(RSX, "vkAcquireNextImageKHR failed with VK_ERROR_OUT_OF_DATE_KHR. Flip request ignored until surface is recreated.");
+			rsx_log.warning("vkAcquireNextImageKHR failed with VK_ERROR_OUT_OF_DATE_KHR. Flip request ignored until surface is recreated.");
 			swapchain_unavailable = true;
 			reinitialize_swapchain();
 			continue;

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -128,7 +128,7 @@ namespace vk
 				}
 			}
 
-			LOG_NOTICE(RSX, "texture not found in program: %s", uniform_name.c_str());
+			rsx_log.notice("texture not found in program: %s", uniform_name.c_str());
 		}
 
 		void program::bind_uniform(const VkDescriptorImageInfo & image_descriptor, int texture_unit, ::glsl::program_domain domain, VkDescriptorSet &descriptor_set, bool is_stencil_mirror)
@@ -166,7 +166,7 @@ namespace vk
 				return;
 			}
 
-			LOG_NOTICE(RSX, "texture not found in program: %stex%u", (domain == ::glsl::program_domain::glsl_vertex_program)? "v" : "", texture_unit);
+			rsx_log.notice("texture not found in program: %stex%u", (domain == ::glsl::program_domain::glsl_vertex_program)? "v" : "", texture_unit);
 		}
 
 		void program::bind_uniform(const VkDescriptorBufferInfo &buffer_descriptor, uint32_t binding_point, VkDescriptorSet &descriptor_set)
@@ -204,8 +204,8 @@ namespace vk
 					return;
 				}
 			}
-			
-			LOG_NOTICE(RSX, "vertex buffer not found in program: %s", binding_name.c_str());
+
+			rsx_log.notice("vertex buffer not found in program: %s", binding_name.c_str());
 		}
 
 		void program::bind_buffer(const VkDescriptorBufferInfo &buffer_descriptor, uint32_t binding_point, VkDescriptorType type, VkDescriptorSet &descriptor_set)

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -509,7 +509,7 @@ namespace vk
 
 			if (UNLIKELY(!any_valid_writes))
 			{
-				LOG_WARNING(RSX, "Surface at 0x%x inherited stale references", base_addr);
+				rsx_log.warning("Surface at 0x%x inherited stale references", base_addr);
 
 				clear_rw_barrier();
 				shuffle_tag();

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -81,7 +81,7 @@ namespace vk
 			+ kernel +
 			"}\n";
 
-			LOG_NOTICE(RSX, "Compute shader:\n%s", m_src);
+			rsx_log.notice("Compute shader:\n%s", m_src);
 		}
 
 		std::vector<std::pair<VkDescriptorType, u8>> get_descriptor_layout() override
@@ -212,7 +212,7 @@ namespace vk
 					fs_src += kernel +
 				"}\n";
 
-			LOG_NOTICE(RSX, "Resolve shader:\n%s", fs_src);
+			rsx_log.notice("Resolve shader:\n%s", fs_src);
 		}
 
 		std::vector<VkPushConstantRange> get_push_constants() override

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -45,7 +45,7 @@ namespace vk
 		if (const auto ins = g_vmm_allocations.insert_or_assign(key, info);
 			!ins.second)
 		{
-			LOG_ERROR(RSX, "Duplicate vmm entry with memory handle 0x%llx", key);
+			rsx_log.error("Duplicate vmm entry with memory handle 0x%llx", key);
 		}
 
 		auto& vmm_size = g_vmm_memory_usage[memory_type];
@@ -53,7 +53,7 @@ namespace vk
 
 		if (vmm_size > s_vmm_warn_threshold_size && (vmm_size - memory_size) <= s_vmm_warn_threshold_size)
 		{
-			LOG_WARNING(RSX, "Memory type 0x%x has allocated more than %.2fG. Currently allocated %.2fG",
+			rsx_log.warning("Memory type 0x%x has allocated more than %.2fG. Currently allocated %.2fG",
 				memory_type, size_in_GiB(s_vmm_warn_threshold_size), size_in_GiB(vmm_size));
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -394,7 +394,7 @@ namespace vk
 			//Most depth/stencil formats cannot be scaled using hw blit
 			if (src_format == VK_FORMAT_UNDEFINED)
 			{
-				LOG_ERROR(RSX, "Could not blit depth/stencil image. src_fmt=0x%x", static_cast<u32>(src_format));
+				rsx_log.error("Could not blit depth/stencil image. src_fmt=0x%x", static_cast<u32>(src_format));
 			}
 			else
 			{
@@ -864,7 +864,7 @@ namespace vk
 				final_mapping[channel] = base_remap[remap_vector.first[channel]];
 				break;
 			default:
-				LOG_ERROR(RSX, "Unknown remap lookup value %d", remap_vector.second[channel]);
+				rsx_log.error("Unknown remap lookup value %d", remap_vector.second[channel]);
 			}
 		}
 
@@ -951,19 +951,19 @@ namespace vk
 		// Checks
 		if (src_area.x2 <= src_area.x1 || src_area.y2 <= src_area.y1 || dst_area.x2 <= dst_area.x1 || dst_area.y2 <= dst_area.y1)
 		{
-			LOG_ERROR(RSX, "Blit request consists of an empty region descriptor!");
+			rsx_log.error("Blit request consists of an empty region descriptor!");
 			return;
 		}
 
 		if (src_area.x1 < 0 || src_area.x2 > static_cast<s32>(real_src->width()) || src_area.y1 < 0 || src_area.y2 > static_cast<s32>(real_src->height()))
 		{
-			LOG_ERROR(RSX, "Blit request denied because the source region does not fit!");
+			rsx_log.error("Blit request denied because the source region does not fit!");
 			return;
 		}
 
 		if (dst_area.x1 < 0 || dst_area.x2 > static_cast<s32>(real_dst->width()) || dst_area.y1 < 0 || dst_area.y2 > static_cast<s32>(real_dst->height()))
 		{
-			LOG_ERROR(RSX, "Blit request denied because the destination region does not fit!");
+			rsx_log.error("Blit request denied because the destination region does not fit!");
 			return;
 		}
 

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -34,7 +34,7 @@ namespace rsx
 	{
 		verify(HERE), range.is_page_range();
 
-		//LOG_ERROR(RSX, "memory_protect(0x%x, 0x%x, %x)", static_cast<u32>(range.start), static_cast<u32>(range.length()), static_cast<u32>(prot));
+		//rsx_log.error("memory_protect(0x%x, 0x%x, %x)", static_cast<u32>(range.start), static_cast<u32>(range.length()), static_cast<u32>(prot));
 		utils::memory_protect(vm::base(range.start), range.length(), prot);
 
 #ifdef TEXTURE_CACHE_DEBUG
@@ -448,7 +448,7 @@ namespace rsx
 					fs::file f(filename);
 					if (f.size() != sizeof(pipeline_data))
 					{
-						LOG_ERROR(RSX, "Removing cached pipeline object %s since it's not binary compatible with the current shader cache", tmp.name.c_str());
+						rsx_log.error("Removing cached pipeline object %s since it's not binary compatible with the current shader cache", tmp.name.c_str());
 						fs::remove_file(filename);
 						continue;
 					}
@@ -594,7 +594,7 @@ namespace rsx
 				return;
 
 			root.rewind();
-			
+
 			// Progress dialog
 			std::unique_ptr<shader_loading_dialog> fallback_dlg;
 			if (!dlg)
@@ -633,7 +633,7 @@ namespace rsx
 
 			if (vp.jump_table.size() > 32)
 			{
-				LOG_ERROR(RSX, "shaders_cache: vertex program has more than 32 jump addresses. Entry not saved to cache");
+				rsx_log.error("shaders_cache: vertex program has more than 32 jump addresses. Entry not saved to cache");
 				return;
 			}
 

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -155,7 +155,7 @@ namespace rsx
 			switch (format)
 			{
 			default:
-				LOG_ERROR(RSX, "Invalid AV format 0x%x", format);
+				rsx_log.error("Invalid AV format 0x%x", format);
 			case 0: // CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8R8G8B8:
 			case 1: // CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8B8G8R8:
 				return CELL_GCM_TEXTURE_A8R8G8B8;
@@ -169,7 +169,7 @@ namespace rsx
 			switch (format)
 			{
 			default:
-				LOG_ERROR(RSX, "Invalid AV format 0x%x", format);
+				rsx_log.error("Invalid AV format 0x%x", format);
 			case 0: // CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8R8G8B8:
 			case 1: // CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8B8G8R8:
 				return 4;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -595,7 +595,7 @@ std::string Emulator::PPUCache() const
 
 	if (!_main || _main->cache.empty())
 	{
-		LOG_WARNING(PPU, "PPU Cache location not initialized.");
+		ppu_log.warning("PPU Cache location not initialized.");
 		return {};
 	}
 
@@ -1754,7 +1754,7 @@ void Emulator::Resume()
 			}
 		}
 
-		LOG_NOTICE(PPU, "[RESUME] Dumping instruction stats:%s", dump);
+		ppu_log.notice("[RESUME] Dumping instruction stats:%s", dump);
 	}
 
 	// Try to resume

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -48,7 +48,7 @@
 #include "Emu/RSX/VK/VulkanAPI.h"
 #endif
 
-LOG_CHANNEL(sys_log);
+LOG_CHANNEL(sys_log, "SYS");
 
 stx::manual_fixed_typemap<void> g_fixed_typemap;
 

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -9,7 +9,7 @@
 #include "windows.h"
 #endif
 
-LOG_CHANNEL(input_log);
+LOG_CHANNEL(input_log, "Input");
 
 void basic_keyboard_handler::Init(const u32 max_connect)
 {

--- a/rpcs3/Input/basic_mouse_handler.cpp
+++ b/rpcs3/Input/basic_mouse_handler.cpp
@@ -3,7 +3,7 @@
 #include <QApplication>
 #include <QCursor>
 
-LOG_CHANNEL(input_log);
+LOG_CHANNEL(input_log, "Input");
 
 void basic_mouse_handler::Init(const u32 max_connect)
 {

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -2,6 +2,8 @@
 
 #include <thread>
 
+LOG_CHANNEL(ds3_log, "DS3");
+
 ds3_pad_handler::ds3_pad_handler() : PadHandlerBase(pad_handler::ds3)
 {
 	button_list =
@@ -67,7 +69,7 @@ bool ds3_pad_handler::init_usb()
 {
 	if (hid_init() != 0)
 	{
-		LOG_FATAL(HLE, "[DS3] Failed to init hidapi for the DS3 pad handler");
+		ds3_log.fatal("Failed to init hidapi for the DS3 pad handler");
 		return false;
 	}
 	return true;
@@ -118,18 +120,18 @@ bool ds3_pad_handler::Init()
 
 	if (warn_about_drivers)
 	{
-		LOG_ERROR(HLE, "[DS3] One or more DS3 pads were detected but couldn't be interacted with directly");
+		ds3_log.error("One or more DS3 pads were detected but couldn't be interacted with directly");
 #if defined(_WIN32) || defined(__linux__)
-		LOG_ERROR(HLE, "[DS3] Check https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration for intructions on how to solve this issue");
+		ds3_log.error("Check https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration for intructions on how to solve this issue");
 #endif
 	}
 	else if (controllers.empty())
 	{
-		LOG_WARNING(HLE, "[DS3] No controllers found!");
+		ds3_log.warning("No controllers found!");
 	}
 	else
 	{
-		LOG_SUCCESS(HLE, "[DS3] Controllers found: %d", controllers.size());
+		ds3_log.success("Controllers found: %d", controllers.size());
 	}
 
 	is_init = true;
@@ -301,7 +303,7 @@ ds3_pad_handler::DS3Status ds3_pad_handler::get_data(const std::shared_ptr<ds3_d
 		}
 		else
 		{
-			LOG_WARNING(HLE, "[DS3] Unknown packet received:0x%02x", dbuf[0]);
+			ds3_log.warning("Unknown packet received:0x%02x", dbuf[0]);
 			return DS3Status::Connected;
 		}
 	}

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -17,7 +17,7 @@
 #include <cstdio>
 #include <cmath>
 
-LOG_CHANNEL(evdev_log);
+LOG_CHANNEL(evdev_log, "evdev");
 
 evdev_joystick_handler::evdev_joystick_handler() : PadHandlerBase(pad_handler::evdev)
 {

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -107,7 +107,7 @@ bool evdev_joystick_handler::Init()
 			std::string name = node.first;
 			int code = libevdev_event_code_from_name(EV_ABS, name.c_str());
 			if (code < 0)
-				LOG_ERROR(HLE, "Failed to read axis name from %s. [code = %d] [name = %s]", m_pos_axis_config.cfg_name, code, name);
+				evdev_log.error("Failed to read axis name from %s. [code = %d] [name = %s]", m_pos_axis_config.cfg_name, code, name);
 			else
 				m_positive_axis.emplace_back(code);
 		}
@@ -342,7 +342,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 			if (get_blacklist)
 			{
 				blacklist.emplace_back(name);
-				LOG_ERROR(HLE, "Evdev Calibration: Added button [ %d = %s = %s ] to blacklist. Value = %d", code, libevdev_event_code_get_name(EV_KEY, code), name, value);
+				evdev_log.error("Evdev Calibration: Added button [ %d = %s = %s ] to blacklist. Value = %d", code, libevdev_event_code_get_name(EV_KEY, code), name, value);
 			}
 			else if (value > pressed_button.first)
 				pressed_button = { value, name };
@@ -368,7 +368,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 				int min = libevdev_get_abs_minimum(dev, code);
 				int max = libevdev_get_abs_maximum(dev, code);
 				blacklist.emplace_back(name);
-				LOG_ERROR(HLE, "Evdev Calibration: Added axis [ %d = %s = %s ] to blacklist. [ Value = %d ] [ Min = %d ] [ Max = %d ]", code, libevdev_event_code_get_name(EV_ABS, code), name, value, min, max);
+				evdev_log.error("Evdev Calibration: Added axis [ %d = %s = %s ] to blacklist. [ Value = %d ] [ Min = %d ] [ Max = %d ]", code, libevdev_event_code_get_name(EV_ABS, code), name, value, min, max);
 			}
 			else if (value > pressed_button.first)
 				pressed_button = { value, name };
@@ -394,7 +394,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 				int min = libevdev_get_abs_minimum(dev, code);
 				int max = libevdev_get_abs_maximum(dev, code);
 				blacklist.emplace_back(name);
-				LOG_ERROR(HLE, "Evdev Calibration: Added rev axis [ %d = %s = %s ] to blacklist. [ Value = %d ] [ Min = %d ] [ Max = %d ]", code, libevdev_event_code_get_name(EV_ABS, code), name, value, min, max);
+				evdev_log.error("Evdev Calibration: Added rev axis [ %d = %s = %s ] to blacklist. [ Value = %d ] [ Min = %d ] [ Max = %d ]", code, libevdev_event_code_get_name(EV_ABS, code), name, value, min, max);
 			}
 			else if (value > pressed_button.first)
 				pressed_button = { value, name };
@@ -404,7 +404,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 	if (get_blacklist)
 	{
 		if (blacklist.empty())
-			LOG_SUCCESS(HLE, "Evdev Calibration: Blacklist is clear. No input spam detected");
+			evdev_log.success("Evdev Calibration: Blacklist is clear. No input spam detected");
 		return;
 	}
 
@@ -473,7 +473,7 @@ void evdev_joystick_handler::SetRumble(std::shared_ptr<EvdevDevice>device, u16 l
 
 	if (ioctl(fd, EVIOCSFF, &effect) == -1)
 	{
-		LOG_ERROR(HLE, "evdev SetRumble ioctl failed! [large = %d] [small = %d] [fd = %d]", large, small, fd);
+		evdev_log.error("evdev SetRumble ioctl failed! [large = %d] [small = %d] [fd = %d]", large, small, fd);
 		device->effect_id = -2;
 	}
 
@@ -486,7 +486,7 @@ void evdev_joystick_handler::SetRumble(std::shared_ptr<EvdevDevice>device, u16 l
 
 	if (write(fd, &play, sizeof(play)) == -1)
 	{
-		LOG_ERROR(HLE, "evdev SetRumble write failed! [large = %d] [small = %d] [fd = %d] [effect_id = %d]", large, small, fd, device->effect_id);
+		evdev_log.error("evdev SetRumble write failed! [large = %d] [small = %d] [fd = %d] [effect_id = %d]", large, small, fd, device->effect_id);
 		device->effect_id = -2;
 	}
 
@@ -500,13 +500,13 @@ void evdev_joystick_handler::SetPadData(const std::string& padId, u32 largeMotor
 	auto dev = get_evdev_device(padId);
 	if (!dev)
 	{
-		LOG_ERROR(HLE, "evdev TestVibration: Device [%s] not found! [largeMotor = %d] [smallMotor = %d]", padId, largeMotor, smallMotor);
+		evdev_log.error("evdev TestVibration: Device [%s] not found! [largeMotor = %d] [smallMotor = %d]", padId, largeMotor, smallMotor);
 		return;
 	}
 
 	if (!dev->has_rumble)
 	{
-		LOG_ERROR(HLE, "evdev TestVibration: Device [%s] does not support rumble features! [largeMotor = %d] [smallMotor = %d]", padId, largeMotor, smallMotor);
+		evdev_log.error("evdev TestVibration: Device [%s] does not support rumble features! [largeMotor = %d] [smallMotor = %d]", padId, largeMotor, smallMotor);
 		return;
 	}
 
@@ -751,7 +751,7 @@ void evdev_joystick_handler::get_mapping(const std::shared_ptr<PadDevice>& devic
 
 			if (direction < 0)
 			{
-				LOG_ERROR(HLE, "FindAxisDirection = %d, Button Nr.%d, value = %d", direction, i, value);
+				evdev_log.error("FindAxisDirection = %d, Button Nr.%d, value = %d", direction, i, value);
 				continue;
 			}
 			else if (direction != (m_is_negative ? 1 : 0))
@@ -784,7 +784,7 @@ void evdev_joystick_handler::get_mapping(const std::shared_ptr<PadDevice>& devic
 				m_dev->cur_dir = min_direction;
 
 				if (min_direction < 0)
-					LOG_ERROR(HLE, "keyCodeMin FindAxisDirection = %d, Axis Nr.%d, Button Nr.%d, value = %d", min_direction, idx, index, value);
+					evdev_log.error("keyCodeMin FindAxisDirection = %d, Axis Nr.%d, Button Nr.%d, value = %d", min_direction, idx, index, value);
 				else
 					is_direction_min = m_is_negative == (min_direction == 1);
 			}
@@ -810,7 +810,7 @@ void evdev_joystick_handler::get_mapping(const std::shared_ptr<PadDevice>& devic
 				m_dev->cur_dir = max_direction;
 
 				if (max_direction < 0)
-					LOG_ERROR(HLE, "keyCodeMax FindAxisDirection = %d, Axis Nr.%d, Button Nr.%d, value = %d", max_direction, idx, index, value);
+					evdev_log.error("keyCodeMax FindAxisDirection = %d, Axis Nr.%d, Button Nr.%d, value = %d", max_direction, idx, index, value);
 				else
 					is_direction_max = m_is_negative == (max_direction == 1);
 			}
@@ -989,7 +989,7 @@ bool evdev_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std
 	m_dev->axis_orientations = axis_orientations;
 
 	if (add_device(device, pad, false) < 0)
-		LOG_WARNING(HLE, "evdev add_device in bindPadToDevice failed for device %s", device);
+		evdev_log.warning("evdev add_device in bindPadToDevice failed for device %s", device);
 
 	update_devs();
 	return true;

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -3,7 +3,7 @@
 #include <QApplication>
 #include <QThread>
 
-LOG_CHANNEL(input_log);
+LOG_CHANNEL(input_log, "Input");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 constexpr auto qstr = QString::fromStdString;

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -1,7 +1,7 @@
 ﻿#ifdef _WIN32
 #include "mm_joystick_handler.h"
 
-LOG_CHANNEL(input_log);
+LOG_CHANNEL(input_log, "Input");
 
 mm_joystick_handler::mm_joystick_handler() : PadHandlerBase(pad_handler::mm)
 {

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -234,7 +234,7 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 				if (get_blacklist)
 				{
 					blacklist.emplace_back(keycode);
-					LOG_ERROR(HLE, "MMJOY Calibration: Added axis [ %d = %s ] to blacklist. Value = %d", keycode, button.second, value);
+					input_log.error("MMJOY Calibration: Added axis [ %d = %s ] to blacklist. Value = %d", keycode, button.second, value);
 				}
 				else if (value > pressed_button.first)
 					pressed_button = { value, button.second };
@@ -254,7 +254,7 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 				if (get_blacklist)
 				{
 					blacklist.emplace_back(keycode);
-					LOG_ERROR(HLE, "MMJOY Calibration: Added pov [ %d = %s ] to blacklist. Value = %d", keycode, button.second, value);
+					input_log.error("MMJOY Calibration: Added pov [ %d = %s ] to blacklist. Value = %d", keycode, button.second, value);
 				}
 				else if (value > pressed_button.first)
 					pressed_button = { value, button.second };
@@ -274,7 +274,7 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 				if (get_blacklist)
 				{
 					blacklist.emplace_back(keycode);
-					LOG_ERROR(HLE, "MMJOY Calibration: Added button [ %d = %s ] to blacklist. Value = %d", keycode, button.second, value);
+					input_log.error("MMJOY Calibration: Added button [ %d = %s ] to blacklist. Value = %d", keycode, button.second, value);
 				}
 				else if (value > pressed_button.first)
 					pressed_button = { value, button.second };
@@ -284,7 +284,7 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 		if (get_blacklist)
 		{
 			if (blacklist.empty())
-				LOG_SUCCESS(HLE, "MMJOY Calibration: Blacklist is clear. No input spam detected");
+				input_log.success("MMJOY Calibration: Blacklist is clear. No input spam detected");
 			return;
 		}
 

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -10,7 +10,7 @@
 #include "keyboard_pad_handler.h"
 #include "Emu/Io/Null/NullPadHandler.h"
 
-LOG_CHANNEL(input_log);
+LOG_CHANNEL(input_log, "Input");
 
 namespace pad
 {

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -1,7 +1,7 @@
 ﻿#include "stdafx.h"
 #include "PSF.h"
 
-LOG_CHANNEL(psf_log);
+LOG_CHANNEL(psf_log, "PSF");
 
 template<>
 void fmt_class_string<psf::format>::format(std::string& out, u64 arg)

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <cstdlib>
 
-LOG_CHANNEL(tar_log);
+LOG_CHANNEL(tar_log, "TAR");
 
 tar_object::tar_object(const fs::file& file, size_t offset)
 	: m_file(file)

--- a/rpcs3/Loader/TROPUSR.cpp
+++ b/rpcs3/Loader/TROPUSR.cpp
@@ -5,7 +5,7 @@
 #include "Emu/System.h"
 #include "TROPUSR.h"
 
-LOG_CHANNEL(trp_log);
+LOG_CHANNEL(trp_log, "Trophy");
 
 bool TROPUSRLoader::Load(const std::string& filepath, const std::string& configpath)
 {

--- a/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
@@ -1,6 +1,8 @@
 ﻿
 #include "auto_pause_settings_dialog.h"
 
+LOG_CHANNEL(autopause_log, "AutoPause");
+
 constexpr auto qstr = QString::fromStdString;
 
 auto_pause_settings_dialog::auto_pause_settings_dialog(QWidget *parent) : QDialog(parent)
@@ -46,7 +48,7 @@ auto_pause_settings_dialog::auto_pause_settings_dialog(QWidget *parent) : QDialo
 	connect(saveButton, &QAbstractButton::clicked, [=]
 	{
 		SaveEntries();
-		LOG_SUCCESS(HLE, "Auto Pause: File pause.bin was updated.");
+		autopause_log.success("File pause.bin was updated.");
 	});
 	connect(cancelButton, &QAbstractButton::clicked, this, &QWidget::close);
 
@@ -115,7 +117,7 @@ void auto_pause_settings_dialog::UpdateList(void)
 		callItem->setFlags(callItem->flags() & ~Qt::ItemIsEditable);
 		typeItem->setFlags(typeItem->flags() & ~Qt::ItemIsEditable);
 		if (m_entries[i] != 0xFFFFFFFF)
-		{	
+		{
 			callItem->setData(Qt::DisplayRole, qstr(fmt::format("%08x", m_entries[i])));
 		}
 		else
@@ -195,7 +197,7 @@ void auto_pause_settings_dialog::keyPressEvent(QKeyEvent *event)
 	}
 }
 
-AutoPauseConfigDialog::AutoPauseConfigDialog(QWidget* parent, auto_pause_settings_dialog* apsd, bool newEntry, u32 *entry) 
+AutoPauseConfigDialog::AutoPauseConfigDialog(QWidget* parent, auto_pause_settings_dialog* apsd, bool newEntry, u32 *entry)
 	: QDialog(parent), m_presult(entry), m_newEntry(newEntry), m_apsd(apsd)
 {
 	m_entry = *m_presult;
@@ -211,7 +213,7 @@ AutoPauseConfigDialog::AutoPauseConfigDialog(QWidget* parent, auto_pause_setting
 
 	m_current_converted = new QLabel(tr("Currently it gets an id of \"Unset\"."), this);
 	m_current_converted->setWordWrap(true);
-	
+
 	m_id = new QLineEdit(this);
 	m_id->setText(qstr(fmt::format("%08x", m_entry)));
 	m_id->setPlaceholderText("ffffffff");
@@ -219,7 +221,7 @@ AutoPauseConfigDialog::AutoPauseConfigDialog(QWidget* parent, auto_pause_setting
 	m_id->setMaxLength(8);
 	m_id->setFixedWidth(65);
 	setWindowTitle("Auto Pause Setting: " + m_id->text());
-	
+
 	connect(button_cancel, &QAbstractButton::clicked, this, &AutoPauseConfigDialog::OnCancel);
 	connect(button_ok, &QAbstractButton::clicked, this, &AutoPauseConfigDialog::OnOk);
 	connect(m_id, &QLineEdit::textChanged, this, &AutoPauseConfigDialog::OnUpdateValue);
@@ -229,7 +231,7 @@ AutoPauseConfigDialog::AutoPauseConfigDialog(QWidget* parent, auto_pause_setting
 	configHBox->addWidget(button_ok);
 	configHBox->addWidget(button_cancel);
 	configHBox->setAlignment(Qt::AlignCenter);
-	
+
 	QVBoxLayout* mainLayout = new QVBoxLayout(this);
 	mainLayout->addWidget(description);
 	mainLayout->addLayout(configHBox);
@@ -266,6 +268,6 @@ void AutoPauseConfigDialog::OnUpdateValue()
 	bool ok;
 	ullong value = m_id->text().toULongLong(&ok, 16);
 	const bool is_ok = ok && value <= UINT32_MAX;
-	
+
 	m_current_converted->setText(qstr(fmt::format("Current value: %08x (%s)", u32(value), is_ok ? "OK" : "conversion failed")));
 }

--- a/rpcs3/rpcs3qt/cg_disasm_window.cpp
+++ b/rpcs3/rpcs3qt/cg_disasm_window.cpp
@@ -16,7 +16,7 @@
 
 #include "Emu/RSX/CgBinaryProgram.h"
 
-LOG_CHANNEL(gui_log);
+LOG_CHANNEL(gui_log, "GUI");
 
 constexpr auto qstr = QString::fromStdString;
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -19,7 +19,7 @@
 
 #include "3rdparty/OpenAL/include/alext.h"
 
-LOG_CHANNEL(cfg_log);
+LOG_CHANNEL(cfg_log, "CFG");
 
 extern std::string g_cfg_defaults; //! Default settings grabbed from Utilities/Config.h
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -29,8 +29,8 @@
 #include <QApplication>
 #include <QClipboard>
 
-LOG_CHANNEL(game_list_log);
-LOG_CHANNEL(sys_log);
+LOG_CHANNEL(game_list_log, "GameList");
+LOG_CHANNEL(sys_log, "SYS");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -95,7 +95,7 @@ void gl_gs_frame::delete_context(draw_context_t ctx)
 	}
 	__except(GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
 	{
-		LOG_FATAL(RSX, "Your graphics driver just crashed whilst cleaning up. All consumed VRAM should have been released, but you may want to restart the emulator just in case");
+		rsx_log.fatal("Your graphics driver just crashed whilst cleaning up. All consumed VRAM should have been released, but you may want to restart the emulator just in case");
 	}
 #else
 	delete gl_ctx->handle;

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -18,7 +18,7 @@
 
 #include <clocale>
 
-LOG_CHANNEL(gui_log);
+LOG_CHANNEL(gui_log, "GUI");
 
 gui_application::gui_application(int& argc, char** argv) : QApplication(argc, argv)
 {

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -6,7 +6,7 @@
 #include <QCoreApplication>
 #include <QMessageBox>
 
-LOG_CHANNEL(cfg_log);
+LOG_CHANNEL(cfg_log, "CFG");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -55,7 +55,7 @@
 
 #include "ui_main_window.h"
 
-LOG_CHANNEL(gui_log);
+LOG_CHANNEL(gui_log, "GUI");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 

--- a/rpcs3/rpcs3qt/memory_string_searcher.cpp
+++ b/rpcs3/rpcs3qt/memory_string_searcher.cpp
@@ -2,7 +2,7 @@
 
 #include <QLabel>
 
-LOG_CHANNEL(gui_log);
+LOG_CHANNEL(gui_log, "GUI");
 
 memory_string_searcher::memory_string_searcher(QWidget* parent)
 	: QDialog(parent)

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -387,7 +387,7 @@ void pad_settings_dialog::InitButtons()
 			return;
 		}
 
-		LOG_NOTICE(HLE, "get_next_button_press: %s device %s button %s pressed with value %d", m_handler->m_type, pad_name, name, val);
+		cfg_log.notice("get_next_button_press: %s device %s button %s pressed with value %d", m_handler->m_type, pad_name, name, val);
 		if (m_button_id > button_ids::id_pad_begin && m_button_id < button_ids::id_pad_end)
 		{
 			m_cfg_entries[m_button_id].key  = name;
@@ -658,7 +658,7 @@ void pad_settings_dialog::keyPressEvent(QKeyEvent *keyEvent)
 
 	if (m_button_id <= button_ids::id_pad_begin || m_button_id >= button_ids::id_pad_end)
 	{
-		LOG_NOTICE(HLE, "Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
+		cfg_log.notice("Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
 	}
 	else
 	{
@@ -683,7 +683,7 @@ void pad_settings_dialog::mouseReleaseEvent(QMouseEvent* event)
 
 	if (m_button_id <= button_ids::id_pad_begin || m_button_id >= button_ids::id_pad_end)
 	{
-		LOG_NOTICE(HLE, "Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
+		cfg_log.notice("Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
 	}
 	else
 	{
@@ -708,7 +708,7 @@ void pad_settings_dialog::wheelEvent(QWheelEvent *event)
 
 	if (m_button_id <= button_ids::id_pad_begin || m_button_id >= button_ids::id_pad_end)
 	{
-		LOG_NOTICE(HLE, "Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
+		cfg_log.notice("Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
 		return;
 	}
 
@@ -764,7 +764,7 @@ void pad_settings_dialog::mouseMoveEvent(QMouseEvent* /*event*/)
 
 	if (m_button_id <= button_ids::id_pad_begin || m_button_id >= button_ids::id_pad_end)
 	{
-		LOG_NOTICE(HLE, "Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
+		cfg_log.notice("Pad Settings: Handler Type: %d, Unknown button ID: %d", static_cast<int>(m_handler->m_type), m_button_id);
 	}
 	else
 	{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -24,7 +24,7 @@
 #include "Input/evdev_joystick_handler.h"
 #endif
 
-LOG_CHANNEL(cfg_log);
+LOG_CHANNEL(cfg_log, "CFG");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 constexpr auto qstr = QString::fromStdString;

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -22,7 +22,7 @@
 #include <QPainter>
 #include <QScreen>
 
-LOG_CHANNEL(gui_log);
+LOG_CHANNEL(gui_log, "GUI");
 
 namespace
 {

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -32,7 +32,7 @@
 #include "_discord_utils.h"
 #endif
 
-LOG_CHANNEL(cfg_log);
+LOG_CHANNEL(cfg_log, "CFG");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 inline std::string sstr(const QVariant& _in) { return sstr(_in.toString()); }

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -569,11 +569,11 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 				idx = 0;
 				if (renderer.old_adapter.isEmpty())
 				{
-					LOG_WARNING(RSX, "%s adapter config empty: setting to default!", sstr(renderer.name));
+					rsx_log.warning("%s adapter config empty: setting to default!", sstr(renderer.name));
 				}
 				else
 				{
-					LOG_WARNING(RSX, "Last used %s adapter not found: setting to default!", sstr(renderer.name));
+					rsx_log.warning("Last used %s adapter not found: setting to default!", sstr(renderer.name));
 				}
 			}
 			ui->graphicsAdapterBox->setCurrentIndex(idx);

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -35,7 +35,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 
-LOG_CHANNEL(gui_log);
+LOG_CHANNEL(gui_log, "GUI");
 
 namespace
 {

--- a/rpcs3/rpcs3qt/user_account.cpp
+++ b/rpcs3/rpcs3qt/user_account.cpp
@@ -1,6 +1,6 @@
 #include "user_account.h"
 
-LOG_CHANNEL(gui_log);
+LOG_CHANNEL(gui_log, "GUI");
 
 UserAccount::UserAccount(const std::string& user_id)
 {

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -15,7 +15,7 @@
 #include <QScreen>
 #include <QKeyEvent>
 
-LOG_CHANNEL(gui_log);
+LOG_CHANNEL(gui_log, "GUI");
 
 namespace
 {


### PR DESCRIPTION
We redundantly had two ways of logging something:

`LOG_ERROR(channel, "", ...)`
and
`channel.error("", ...)`

Since first is a macro, I prefer it go away.