### PR TITLE
RSX: Protect m_storage.find(key) to fix a race

### DIFF
--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -455,11 +455,14 @@ public:
 			backend_traits::validate_pipeline_properties(vertex_program, fragment_program, pipelineProperties);
 			pipeline_key key = { vertex_program.id, fragment_program.id, pipelineProperties };
 
-			const auto I = m_storage.find(key);
-			if (I != m_storage.end())
 			{
-				m_cache_miss_flag = false;
-				return I->second;
+				reader_lock lock(m_pipeline_mutex);
+				const auto I = m_storage.find(key);
+				if (I != m_storage.end())
+				{
+					m_cache_miss_flag = false;
+					return I->second;
+				}
 			}
 
 			if (allow_async)


### PR DESCRIPTION
With multiple shader compiler workers, it was possible to have multiple threads execute `get_graphics_pipeline` concurrently, with one thread adding contents to `m_storage` while another thread was executing `.find()` on it.

I only crashed on it once, but it's pretty obvious looking at the code. I scoped the find and added a reader lock to resolve this.