### PR TITLE
[Testers Needed] Workaround for games marking themselves as Game Data

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -619,7 +619,15 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 				return {CELL_GAME_ERROR_INTERNAL, dir};
 			}
 
-			psf::save_object(fs::file(vdir + "/PARAM.SFO", fs::rewrite), sfo);
+			auto file = fs::file(vdir + "/PARAM.SFO", fs::rewrite);
+			if (file)
+			{
+				psf::save_object(file, sfo);
+			}
+			else
+			{
+				return CELL_GAMEDATA_ERROR_ACCESS_ERROR;
+			}
 		}
 
 		return CELL_OK;


### PR DESCRIPTION
This is a **workaround** for #7373. With this change, RPCS3 will continue to function correctly when param.sfo is marked as read only and thus can't be rewritten. **DO NOT MERGE!**

While this of course is not a correct fix, it allows "suicidal" games to be played more than once by marking their `param.sfo` as read only.