### PR TITLE
Fix game data boot

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -604,7 +604,10 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 
 		if (cbSet->setParam)
 		{
-			psf::assign(sfo, "CATEGORY", psf::string(3, "GD"));
+			if (sfo.find("CATEGORY") == sfo.end())
+			{
+				psf::assign(sfo, "CATEGORY", psf::string(3, "GD"));
+			}
 			psf::assign(sfo, "TITLE_ID", psf::string(CELL_GAME_SYSP_TITLEID_SIZE, cbSet->setParam->titleId));
 			psf::assign(sfo, "TITLE", psf::string(CELL_GAME_SYSP_TITLE_SIZE, cbSet->setParam->title));
 			psf::assign(sfo, "VERSION", psf::string(CELL_GAME_SYSP_VERSION_SIZE, cbSet->setParam->dataVersion));

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -767,6 +767,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 		m_title = psf::get_string(_psf, "TITLE", m_path.substr(m_path.find_last_of('/') + 1));
 		m_title_id = psf::get_string(_psf, "TITLE_ID");
 		m_cat = psf::get_string(_psf, "CATEGORY");
+		m_bootable = psf::get_integer(_psf, "BOOTABLE");
 
 		std::string version_app  = psf::get_string(_psf, "APP_VER", "Unknown");
 		std::string version_disc = psf::get_string(_psf, "VERSION", "Unknown");
@@ -1020,7 +1021,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 		}
 
 		// Booting patch data
-		if (m_cat == "GD" && bdvd_dir.empty() && disc.empty())
+		if (m_cat == "GD" && !m_bootable && bdvd_dir.empty() && disc.empty())
 		{
 			// Load /dev_bdvd/ from game list if available
 			if (auto node = games[m_title_id])
@@ -1094,7 +1095,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 			fs::file card_2_file(vfs::get("/dev_hdd0/savedata/vmc/" + argv[2]), fs::write + fs::create);
 			card_2_file.trunc(128 * 1024);
 		}
-		else if (m_cat != "DG" && m_cat != "GD")
+		else if (m_cat != "DG" && (m_cat != "GD" || m_bootable))
 		{
 			// Don't need /dev_bdvd
 		}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -49,6 +49,7 @@ class Emulator final
 	atomic_t<u64> m_pause_start_time; // set when paused
 	atomic_t<u64> m_pause_amend_time; // increased when resumed
 
+	bool m_bootable{ false };
 	std::string m_path;
 	std::string m_path_old;
 	std::string m_title_id;


### PR DESCRIPTION
1. Do not rewrite the PARAM.SFO CATEGORY in cellGameDataCheckCreate2,
2. Let's you boot bootable game data. Param.sfo contains a bootable property.

Maybe bootable should be checked on boot for every category.
Suggestions for the gamelist presentation are much appreciated.

fixes #7373