### PR TITLE
Use english locale for last played in gamelist

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -47,11 +47,18 @@ private:
 		return thread();
 	}
 
+	void SwitchTranslator(QTranslator& translator, const QString& filename);
+	void LoadLanguage(const QString& language);
+
 	void InitializeCallbacks();
 	void InitializeConnects();
 
 	void StartPlaytime();
 	void StopPlaytime();
+
+	QTranslator m_translator;
+	QTranslator m_translator_qt;
+	QString m_language;
 
 	QElapsedTimer m_timer_playtime;
 

--- a/rpcs3/rpcs3qt/persistent_settings.h
+++ b/rpcs3/rpcs3qt/persistent_settings.h
@@ -14,7 +14,9 @@ namespace gui
 		const QString last_played = "LastPlayed";
 
 		// Date format
-		const QString last_played_date_format = "MMMM d yyyy";
+		const QString last_played_date_format_old    = "MMMM d yyyy";
+		const QString last_played_date_format_new    = "MMMM d, yyyy";
+		const Qt::DateFormat last_played_date_format = Qt::DateFormat::ISODate;
 	}
 }
 


### PR DESCRIPTION
Use current locale for displaying last played dates in gamelist.
Also save new entries with ISO-8601 to make them readable from file when the locale shifts.

Also sets some of the groundwork for Qt translations which will eventually be implemented in the distant future.

fixes #7390