### PR TITLE
rsx: Fixup

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -304,7 +304,7 @@ namespace rsx
 
 				const u16 dst_w = static_cast<u16>(std::get<2>(clipped).width);
 				const u16 src_w = static_cast<u16>(dst_w * attr.bpp) / section_bpp;
-				const u16 height = static_cast<u16>(std::get<2>(clipped).height);
+				const u16 height = static_cast<u16>(dst_h);
 
 				if (scaling)
 				{
@@ -314,10 +314,10 @@ namespace rsx
 						section->get_raw_texture(),
 						surface_transform::identity,
 						0,
-						static_cast<u16>(std::get<0>(clipped).x),
-						static_cast<u16>(std::get<0>(clipped).y),
-						rsx::apply_resolution_scale(static_cast<u16>(std::get<1>(clipped).x), true),
-						rsx::apply_resolution_scale(static_cast<u16>(std::get<1>(clipped).y), true),
+						static_cast<u16>(std::get<0>(clipped).x),                                     // src.x
+						static_cast<u16>(std::get<0>(clipped).y),                                     // src.y
+						rsx::apply_resolution_scale(static_cast<u16>(std::get<1>(clipped).x), true),  // dst.x
+						rsx::apply_resolution_scale(static_cast<u16>(dst_y - slice_begin), true),     // dst.y
 						slice,
 						src_w,
 						height,
@@ -332,10 +332,10 @@ namespace rsx
 						section->get_raw_texture(),
 						surface_transform::identity,
 						0,
-						static_cast<u16>(std::get<0>(clipped).x),
-						static_cast<u16>(std::get<0>(clipped).y),
-						static_cast<u16>(std::get<1>(clipped).x),
-						static_cast<u16>(std::get<1>(clipped).y),
+						static_cast<u16>(std::get<0>(clipped).x),   // src.x
+						static_cast<u16>(std::get<0>(clipped).y),   // src.y
+						static_cast<u16>(std::get<1>(clipped).x),   // dst.x
+						static_cast<u16>(dst_y - slice_begin),      // dst.y
 						0,
 						src_w,
 						height,

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -396,15 +396,15 @@ namespace gl
 				// Final dimensions are a match
 				if (xfer_info.src_is_typeless || xfer_info.dst_is_typeless)
 				{
-					const coord3i src_region = { { src_rect.x1, src_rect.y1, 0 }, { src_w, src_rect.height(), 1 } };
-					const coord3i dst_region = { { dst_rect.x1, dst_rect.y1, 0 }, { src_w, src_rect.height(), 1 } };
+					const coord3i src_region = { { src_rect.x1, src_rect.y1, 0 }, { src_rect.width(), src_rect.height(), 1 } };
+					const coord3i dst_region = { { dst_rect.x1, dst_rect.y1, 0 }, { dst_rect.width(), dst_rect.height(), 1 } };
 					gl::copy_typeless(dst, src, dst_region, src_region);
 				}
 				else
 				{
-					glCopyImageSubData(src->id(), dst->id(), 0, src_rect.x1, src_rect.y1, 0,
+					glCopyImageSubData(src->id(), GL_TEXTURE_2D, 0, src_rect.x1, src_rect.y1, 0,
 						dst->id(), GL_TEXTURE_2D, 0, dst_rect.x1, dst_rect.y1, 0,
-						src_w, src_rect.height(), 1);
+						src_rect.width(), src_rect.height(), 1);
 				}
 
 				return;


### PR DESCRIPTION
- rsx: Fix cubemap/3D slice generation.
  Destination Y coordinate must be 'rebased' onto the current slice by subtracting its offset
  Only the local path was affected this time.

- gl: Fix imaging optimizations.
  Forgot to use original coordinates when actually performing the transfer. The variables used for comparison are already scaled according to typeless rules.

Fixes a pseudo-regression uncovered by recent optimizations. (https://github.com/RPCS3/rpcs3/issues/7388)
Fixes https://github.com/RPCS3/rpcs3/issues/7388
Fixes https://github.com/RPCS3/rpcs3/issues/7395