### PR TITLE
Modernize LIKELY/UNLIKELY

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -45,7 +45,7 @@ static u8* add_jit_memory(std::size_t size, uint align)
 	// Select subrange
 	u8* pointer = get_jit_memory() + Off;
 
-	if (UNLIKELY(!size && !align))
+	if (!size && !align) [[unlikely]]
 	{
 		// Return subrange info
 		return pointer;
@@ -59,7 +59,7 @@ static u8* add_jit_memory(std::size_t size, uint align)
 		const u64 _pos = ::align(ctr & 0xffff'ffff, align);
 		const u64 _new = ::align(_pos + size, align);
 
-		if (UNLIKELY(_new > 0x40000000))
+		if (_new > 0x40000000) [[unlikely]]
 		{
 			// Sorry, we failed, and further attempts should fail too.
 			ctr |= 0x40000000;
@@ -71,7 +71,7 @@ static u8* add_jit_memory(std::size_t size, uint align)
 		newa = olda;
 
 		// Check the necessity to commit more memory
-		if (UNLIKELY(_new > olda))
+		if (_new > olda) [[unlikely]]
 		{
 			newa = ::align(_new, 0x100000);
 		}
@@ -80,13 +80,13 @@ static u8* add_jit_memory(std::size_t size, uint align)
 		return _pos;
 	});
 
-	if (UNLIKELY(pos == -1))
+	if (pos == -1) [[unlikely]]
 	{
 		jit_log.warning("JIT: Out of memory (size=0x%x, align=0x%x, off=0x%x)", size, align, Off);
 		return nullptr;
 	}
 
-	if (UNLIKELY(olda != newa))
+	if (olda != newa) [[unlikely]]
 	{
 #ifdef CAN_OVERCOMMIT
 		madvise(pointer + olda, newa - olda, MADV_WILLNEED);
@@ -119,21 +119,21 @@ jit_runtime::~jit_runtime()
 asmjit::Error jit_runtime::_add(void** dst, asmjit::CodeHolder* code) noexcept
 {
 	std::size_t codeSize = code->getCodeSize();
-	if (UNLIKELY(!codeSize))
+	if (!codeSize) [[unlikely]]
 	{
 		*dst = nullptr;
 		return asmjit::kErrorNoCodeGenerated;
 	}
 
 	void* p = jit_runtime::alloc(codeSize, 16);
-	if (UNLIKELY(!p))
+	if (!p) [[unlikely]]
 	{
 		*dst = nullptr;
 		return asmjit::kErrorNoVirtualMemory;
 	}
 
 	std::size_t relocSize = code->relocate(p);
-	if (UNLIKELY(!relocSize))
+	if (!relocSize) [[unlikely]]
 	{
 		*dst = nullptr;
 		return asmjit::kErrorInvalidState;

--- a/Utilities/Log.cpp
+++ b/Utilities/Log.cpp
@@ -589,7 +589,7 @@ void logs::file_writer::log(logs::level sev, const char* text, std::size_t size)
 			const u64 v1 = v >> 24;
 			const u64 v2 = v & 0xffffff;
 
-			if (UNLIKELY(v2 + size > 0xffffff || v1 + v2 + size >= m_out + s_log_size))
+			if (v2 + size > 0xffffff || v1 + v2 + size >= m_out + s_log_size) [[unlikely]]
 			{
 				bufv = v;
 				return nullptr;
@@ -599,7 +599,7 @@ void logs::file_writer::log(logs::level sev, const char* text, std::size_t size)
 			return m_fptr + (v1 + v2) % s_log_size;
 		});
 
-		if (UNLIKELY(!pos))
+		if (!pos) [[unlikely]]
 		{
 			if ((bufv & 0xffffff) + size > 0xffffff || bufv & 0xffffff)
 			{

--- a/Utilities/Log.h
+++ b/Utilities/Log.h
@@ -80,7 +80,7 @@ namespace logs
 		template <std::size_t N, typename... Args>\
 		void _sev(const char(&fmt)[N], const Args&... args)\
 		{\
-			if (UNLIKELY(level::_sev <= enabled.load(std::memory_order_relaxed)))\
+			if (level::_sev <= enabled.load(std::memory_order_relaxed)) [[unlikely]]\
 			{\
 				static constexpr fmt_type_info type_list[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};\
 				msg_##_sev.broadcast(fmt, type_list, u64{fmt_unveil<Args>::get(args)}...);\
@@ -89,7 +89,7 @@ namespace logs
 		template <std::size_t N, typename... Args>\
 		void _sev(const char2(&fmt)[N], const Args&... args)\
 		{\
-			if (UNLIKELY(level::_sev <= enabled.load(std::memory_order_relaxed)))\
+			if (level::_sev <= enabled.load(std::memory_order_relaxed)) [[unlikely]]\
 			{\
 				static constexpr fmt_type_info type_list[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};\
 				msg_##_sev.broadcast(reinterpret_cast<const char*>(+fmt), type_list, u64{fmt_unveil<Args>::get(args)}...);\

--- a/Utilities/cfmt.h
+++ b/Utilities/cfmt.h
@@ -136,7 +136,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 	case '8':
 	case '9':
 	{
-		if (UNLIKELY(ctx.width))
+		if (ctx.width) [[unlikely]]
 		{
 			drop_sequence();
 		}
@@ -150,7 +150,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case '*':
 	{
-		if (UNLIKELY(ctx.width || !src.test(ctx.args)))
+		if (ctx.width || !src.test(ctx.args)) [[unlikely]]
 		{
 			drop_sequence();
 		}
@@ -166,7 +166,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case '.':
 	{
-		if (UNLIKELY(ctx.dot || ctx.prec))
+		if (ctx.dot || ctx.prec) [[unlikely]]
 		{
 			drop_sequence();
 		}
@@ -177,7 +177,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 		}
 		else if (*fmt == '*')
 		{
-			if (UNLIKELY(!src.test(ctx.args)))
+			if (!src.test(ctx.args)) [[unlikely]]
 			{
 				drop_sequence();
 			}
@@ -200,7 +200,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 'h':
 	{
-		if (UNLIKELY(ctx.type))
+		if (ctx.type) [[unlikely]]
 		{
 			drop_sequence();
 		}
@@ -219,7 +219,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 'l':
 	{
-		if (UNLIKELY(ctx.type))
+		if (ctx.type) [[unlikely]]
 		{
 			drop_sequence();
 		}
@@ -238,7 +238,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 'z':
 	{
-		if (UNLIKELY(ctx.type))
+		if (ctx.type) [[unlikely]]
 		{
 			drop_sequence();
 		}
@@ -252,7 +252,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 'j':
 	{
-		if (UNLIKELY(ctx.type))
+		if (ctx.type) [[unlikely]]
 		{
 			drop_sequence();
 		}
@@ -266,7 +266,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 't':
 	{
-		if (UNLIKELY(ctx.type))
+		if (ctx.type) [[unlikely]]
 		{
 			drop_sequence();
 		}
@@ -280,7 +280,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 'c':
 	{
-		if (UNLIKELY(ctx.type || !src.test(ctx.args)))
+		if (ctx.type || !src.test(ctx.args)) [[unlikely]]
 		{
 			drop_sequence();
 			break;
@@ -302,7 +302,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 's':
 	{
-		if (UNLIKELY(ctx.type || !src.test(ctx.args)))
+		if (ctx.type || !src.test(ctx.args)) [[unlikely]]
 		{
 			drop_sequence();
 			break;
@@ -333,7 +333,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 	case 'd':
 	case 'i':
 	{
-		if (UNLIKELY(!src.test(ctx.args)))
+		if (!src.test(ctx.args)) [[unlikely]]
 		{
 			drop_sequence();
 			break;
@@ -395,7 +395,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 'o':
 	{
-		if (UNLIKELY(!src.test(ctx.args)))
+		if (!src.test(ctx.args)) [[unlikely]]
 		{
 			drop_sequence();
 			break;
@@ -452,7 +452,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 	case 'x':
 	case 'X':
 	{
-		if (UNLIKELY(!src.test(ctx.args)))
+		if (!src.test(ctx.args)) [[unlikely]]
 		{
 			drop_sequence();
 			break;
@@ -516,7 +516,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 'u':
 	{
-		if (UNLIKELY(!src.test(ctx.args)))
+		if (!src.test(ctx.args)) [[unlikely]]
 		{
 			drop_sequence();
 			break;
@@ -563,7 +563,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 
 	case 'p':
 	{
-		if (UNLIKELY(!src.test(ctx.args) || ctx.type))
+		if (!src.test(ctx.args) || ctx.type) [[unlikely]]
 		{
 			drop_sequence();
 			break;
@@ -597,7 +597,7 @@ std::size_t cfmt_append(Dst& out, const Char* fmt, Src&& src)
 	case 'g':
 	case 'G':
 	{
-		if (UNLIKELY(!src.test(ctx.args) || ctx.type))
+		if (!src.test(ctx.args) || ctx.type) [[unlikely]]
 		{
 			drop_sequence();
 			break;

--- a/Utilities/mutex.h
+++ b/Utilities/mutex.h
@@ -45,7 +45,7 @@ public:
 	{
 		const u32 value = m_value.load();
 
-		if (UNLIKELY(value >= c_one - 1 || !m_value.compare_and_swap_test(value, value + 1)))
+		if (value >= c_one - 1 || !m_value.compare_and_swap_test(value, value + 1)) [[unlikely]]
 		{
 			imp_lock_shared(value);
 		}
@@ -55,10 +55,10 @@ public:
 	{
 		const u32 value = m_value.load();
 
-		if (LIKELY(value < c_one - 1))
+		if (value < c_one - 1) [[likely]]
 		{
 			u32 old = value;
-			if (LIKELY(atomic_storage<u32>::compare_exchange_hle_acq(m_value.raw(), old, value + 1)))
+			if (atomic_storage<u32>::compare_exchange_hle_acq(m_value.raw(), old, value + 1)) [[likely]]
 			{
 				return;
 			}
@@ -72,7 +72,7 @@ public:
 		// Unconditional decrement (can result in broken state)
 		const u32 value = m_value.fetch_sub(1);
 
-		if (UNLIKELY(value >= c_one))
+		if (value >= c_one) [[unlikely]]
 		{
 			imp_unlock_shared(value);
 		}
@@ -82,7 +82,7 @@ public:
 	{
 		const u32 value = atomic_storage<u32>::fetch_add_hle_rel(m_value.raw(), -1);
 
-		if (UNLIKELY(value >= c_one))
+		if (value >= c_one) [[unlikely]]
 		{
 			imp_unlock_shared(value);
 		}
@@ -100,7 +100,7 @@ public:
 	{
 		const u32 value = m_value.load();
 
-		if (UNLIKELY(value >= c_vip - 1 || !m_value.compare_and_swap_test(value, value + 1)))
+		if (value >= c_vip - 1 || !m_value.compare_and_swap_test(value, value + 1)) [[unlikely]]
 		{
 			imp_lock_low(value);
 		}
@@ -111,7 +111,7 @@ public:
 		// Unconditional decrement (can result in broken state)
 		const u32 value = m_value.fetch_sub(1);
 
-		if (UNLIKELY(value >= c_one))
+		if (value >= c_one) [[unlikely]]
 		{
 			imp_unlock_low(value);
 		}
@@ -129,7 +129,7 @@ public:
 	{
 		const u32 value = m_value.load();
 
-		if (UNLIKELY((value >= c_one - 1 && !(value & (c_one - c_vip))) || (value % c_vip) || !m_value.compare_and_swap_test(value, value + c_vip)))
+		if ((value >= c_one - 1 && !(value & (c_one - c_vip))) || (value % c_vip) || !m_value.compare_and_swap_test(value, value + c_vip)) [[unlikely]]
 		{
 			imp_lock_vip(value);
 		}
@@ -140,7 +140,7 @@ public:
 		// Unconditional decrement (can result in broken state)
 		const u32 value = m_value.fetch_sub(c_vip);
 
-		if (UNLIKELY(value >= c_one))
+		if (value >= c_one) [[unlikely]]
 		{
 			imp_unlock_vip(value);
 		}
@@ -155,7 +155,7 @@ public:
 	{
 		const u32 value = m_value.compare_and_swap(0, c_one);
 
-		if (UNLIKELY(value))
+		if (value) [[unlikely]]
 		{
 			imp_lock(value);
 		}
@@ -165,7 +165,7 @@ public:
 	{
 		u32 value = 0;
 
-		if (UNLIKELY(!atomic_storage<u32>::compare_exchange_hle_acq(m_value.raw(), value, c_one)))
+		if (!atomic_storage<u32>::compare_exchange_hle_acq(m_value.raw(), value, c_one)) [[unlikely]]
 		{
 			imp_lock(value);
 		}
@@ -176,7 +176,7 @@ public:
 		// Unconditional decrement (can result in broken state)
 		const u32 value = m_value.fetch_sub(c_one);
 
-		if (UNLIKELY(value != c_one))
+		if (value != c_one) [[unlikely]]
 		{
 			imp_unlock(value);
 		}
@@ -186,7 +186,7 @@ public:
 	{
 		const u32 value = atomic_storage<u32>::fetch_add_hle_rel(m_value.raw(), 0u - c_one);
 
-		if (UNLIKELY(value != c_one))
+		if (value != c_one) [[unlikely]]
 		{
 			imp_unlock(value);
 		}
@@ -202,7 +202,7 @@ public:
 
 	void lock_upgrade()
 	{
-		if (UNLIKELY(!try_lock_upgrade()))
+		if (!try_lock_upgrade()) [[unlikely]]
 		{
 			imp_lock_upgrade();
 		}
@@ -223,7 +223,7 @@ public:
 	// Optimized wait for lockability without locking, relaxed
 	void lock_unlock()
 	{
-		if (UNLIKELY(m_value != 0))
+		if (m_value != 0) [[unlikely]]
 		{
 			imp_lock_unlock();
 		}

--- a/Utilities/sema.h
+++ b/Utilities/sema.h
@@ -26,7 +26,7 @@ protected:
 		const s32 value = m_value.load();
 
 		// Conditional decrement
-		if (UNLIKELY(value <= 0 || !m_value.compare_and_swap_test(value, value - 1)))
+		if (value <= 0 || !m_value.compare_and_swap_test(value, value - 1)) [[unlikely]]
 		{
 			imp_wait();
 		}
@@ -42,7 +42,7 @@ protected:
 		// Unconditional increment
 		const s32 value = m_value.fetch_add(1);
 
-		if (UNLIKELY(value < 0 || value >= _max))
+		if (value < 0 || value >= _max) [[unlikely]]
 		{
 			imp_post(value);
 		}

--- a/Utilities/typemap.h
+++ b/Utilities/typemap.h
@@ -658,7 +658,7 @@ namespace utils
 					static_assert(!std::is_volatile_v<std::remove_reference_t<Type>>);
 
 					// Try to acquire the semaphore
-					if (UNLIKELY(!head->m_sema.try_inc(last + 1)))
+					if (!head->m_sema.try_inc(last + 1)) [[unlikely]]
 					{
 						block = nullptr;
 					}
@@ -671,7 +671,7 @@ namespace utils
 
 							if (block->m_type == 0 && block->m_mutex.try_lock())
 							{
-								if (LIKELY(block->m_type == 0))
+								if (block->m_type == 0) [[likely]]
 								{
 									break;
 								}
@@ -695,7 +695,7 @@ namespace utils
 						{
 							block = nullptr;
 						}
-						else if (UNLIKELY(block->m_type != 0))
+						else if (block->m_type != 0) [[unlikely]]
 						{
 							block->m_mutex.unlock();
 							block = nullptr;
@@ -737,13 +737,13 @@ namespace utils
 				block = reinterpret_cast<typemap_block*>(head->m_ptr + std::size_t{head->m_ssize} * unscaled);
 
 				// Check id range and type
-				if (UNLIKELY(unscaled >= typeinfo_count<Type>::max_count || unbiased % step))
+				if (unscaled >= typeinfo_count<Type>::max_count || unbiased % step) [[unlikely]]
 				{
 					block = nullptr;
 				}
 				else
 				{
-					if (UNLIKELY(block->m_type == 0))
+					if (block->m_type == 0) [[unlikely]]
 					{
 						block = nullptr;
 					}
@@ -785,12 +785,12 @@ namespace utils
 			}
 			else if constexpr (std::is_invocable_r_v<bool, const Arg&, const Type&>)
 			{
-				if (UNLIKELY(!block))
+				if (!block) [[unlikely]]
 				{
 					return;
 				}
 
-				if (LIKELY(block->m_type))
+				if (block->m_type) [[likely]]
 				{
 					if (std::invoke(std::forward<Arg>(id), std::as_const(*block->get_ptr<Type>())))
 					{
@@ -800,7 +800,7 @@ namespace utils
 			}
 			else if (block)
 			{
-				if (LIKELY(block->m_type))
+				if (block->m_type) [[likely]]
 				{
 					return;
 				}
@@ -848,7 +848,7 @@ namespace utils
 				}
 				else if constexpr (is_const || is_volatile)
 				{
-					if (LIKELY(block->m_mutex.is_lockable()))
+					if (block->m_mutex.is_lockable()) [[likely]]
 					{
 						return true;
 					}
@@ -858,7 +858,7 @@ namespace utils
 				}
 				else
 				{
-					if (LIKELY(block->m_mutex.is_free()))
+					if (block->m_mutex.is_free()) [[likely]]
 					{
 						return true;
 					}
@@ -878,7 +878,7 @@ namespace utils
 				if constexpr (I + 1 < N)
 				{
 					// Proceed recursively
-					if (LIKELY(try_lock<I + 1, Types...>(array, locked, std::integer_sequence<bool, Locks...>{})))
+					if (try_lock<I + 1, Types...>(array, locked, std::integer_sequence<bool, Locks...>{})) [[likely]]
 					{
 						return true;
 					}
@@ -973,7 +973,7 @@ namespace utils
 			while (true)
 			{
 				const uint locked = lock_array<decode_t<Types>...>(result, seq_t{}, locks_t{});
-				if (LIKELY(try_lock<0, decode_t<Types>...>(result, locked, locks_t{})))
+				if (try_lock<0, decode_t<Types>...>(result, locked, locks_t{})) [[likely]]
 					break;
 			}
 

--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -28,8 +28,6 @@
 #ifdef _MSC_VER
 
 #define ASSUME(...) __assume(__VA_ARGS__) // MSVC __assume ignores side-effects
-#define LIKELY
-#define UNLIKELY
 #define SAFE_BUFFERS __declspec(safebuffers)
 #define NEVER_INLINE __declspec(noinline)
 #define FORCE_INLINE __forceinline
@@ -48,8 +46,6 @@
 #define ASSUME(...) do { if (!(__VA_ARGS__)) __builtin_unreachable(); } while (0)  // note: the compiler will generate code to evaluate "cond" if the expression is opaque
 #endif
 
-#define LIKELY(...) __builtin_expect(!!(__VA_ARGS__), 1)
-#define UNLIKELY(...) __builtin_expect(!!(__VA_ARGS__), 0)
 #define SAFE_BUFFERS
 #define NEVER_INLINE __attribute__((noinline))
 #define FORCE_INLINE __attribute__((always_inline)) inline

--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -1334,8 +1334,7 @@ void camera_context::operator()()
 						data3 = 0;	// unused
 					}
 
-					const auto send_status = queue->send(evt_data.source, CELL_CAMERA_FRAME_UPDATE, data2, data3);
-					if (LIKELY(send_status))
+					if (queue->send(evt_data.source, CELL_CAMERA_FRAME_UPDATE, data2, data3)) [[likely]]
 					{
 						++frame_num;
 					}
@@ -1382,8 +1381,7 @@ void camera_context::send_attach_state(bool attached)
 
 			if (auto queue = lv2_event_queue::find(key))
 			{
-				const auto send_result = queue->send(evt_data.source, attached ? CELL_CAMERA_ATTACH : CELL_CAMERA_DETACH, 0, 0);
-				if (LIKELY(send_result))
+				if (queue->send(evt_data.source, attached ? CELL_CAMERA_ATTACH : CELL_CAMERA_DETACH, 0, 0)) [[likely]]
 				{
 					is_attached = attached;
 				}

--- a/rpcs3/Emu/Cell/Modules/cellSync.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSync.cpp
@@ -46,12 +46,12 @@ error_code cellSyncMutexInitialize(vm::ptr<CellSyncMutex> mutex)
 {
 	cellSync.trace("cellSyncMutexInitialize(mutex=*0x%x)", mutex);
 
-	if (UNLIKELY(!mutex))
+	if (!mutex) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!mutex.aligned()))
+	if (!mutex.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -65,12 +65,12 @@ error_code cellSyncMutexLock(ppu_thread& ppu, vm::ptr<CellSyncMutex> mutex)
 {
 	cellSync.trace("cellSyncMutexLock(mutex=*0x%x)", mutex);
 
-	if (UNLIKELY(!mutex))
+	if (!mutex) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!mutex.aligned()))
+	if (!mutex.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -95,12 +95,12 @@ error_code cellSyncMutexTryLock(vm::ptr<CellSyncMutex> mutex)
 {
 	cellSync.trace("cellSyncMutexTryLock(mutex=*0x%x)", mutex);
 
-	if (UNLIKELY(!mutex))
+	if (!mutex) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!mutex.aligned()))
+	if (!mutex.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -117,12 +117,12 @@ error_code cellSyncMutexUnlock(vm::ptr<CellSyncMutex> mutex)
 {
 	cellSync.trace("cellSyncMutexUnlock(mutex=*0x%x)", mutex);
 
-	if (UNLIKELY(!mutex))
+	if (!mutex) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!mutex.aligned()))
+	if (!mutex.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -136,17 +136,17 @@ error_code cellSyncBarrierInitialize(vm::ptr<CellSyncBarrier> barrier, u16 total
 {
 	cellSync.trace("cellSyncBarrierInitialize(barrier=*0x%x, total_count=%d)", barrier, total_count);
 
-	if (UNLIKELY(!barrier))
+	if (!barrier) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!barrier.aligned()))
+	if (!barrier.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
 
-	if (UNLIKELY(!total_count || total_count > 32767))
+	if (!total_count || total_count > 32767) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_INVAL;
 	}
@@ -161,12 +161,12 @@ error_code cellSyncBarrierNotify(ppu_thread& ppu, vm::ptr<CellSyncBarrier> barri
 {
 	cellSync.trace("cellSyncBarrierNotify(barrier=*0x%x)", barrier);
 
-	if (UNLIKELY(!barrier))
+	if (!barrier) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!barrier.aligned()))
+	if (!barrier.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -186,12 +186,12 @@ error_code cellSyncBarrierTryNotify(vm::ptr<CellSyncBarrier> barrier)
 {
 	cellSync.trace("cellSyncBarrierTryNotify(barrier=*0x%x)", barrier);
 
-	if (UNLIKELY(!barrier))
+	if (!barrier) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!barrier.aligned()))
+	if (!barrier.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -210,12 +210,12 @@ error_code cellSyncBarrierWait(ppu_thread& ppu, vm::ptr<CellSyncBarrier> barrier
 {
 	cellSync.trace("cellSyncBarrierWait(barrier=*0x%x)", barrier);
 
-	if (UNLIKELY(!barrier))
+	if (!barrier) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!barrier.aligned()))
+	if (!barrier.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -237,12 +237,12 @@ error_code cellSyncBarrierTryWait(vm::ptr<CellSyncBarrier> barrier)
 {
 	cellSync.trace("cellSyncBarrierTryWait(barrier=*0x%x)", barrier);
 
-	if (UNLIKELY(!barrier))
+	if (!barrier) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!barrier.aligned()))
+	if (!barrier.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -261,17 +261,17 @@ error_code cellSyncRwmInitialize(vm::ptr<CellSyncRwm> rwm, vm::ptr<void> buffer,
 {
 	cellSync.trace("cellSyncRwmInitialize(rwm=*0x%x, buffer=*0x%x, buffer_size=0x%x)", rwm, buffer, buffer_size);
 
-	if (UNLIKELY(!rwm || !buffer))
+	if (!rwm || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!rwm.aligned() || !buffer.aligned(128)))
+	if (!rwm.aligned() || !buffer.aligned(128)) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
 
-	if (UNLIKELY(buffer_size % 128 || buffer_size > 0x4000))
+	if (buffer_size % 128 || buffer_size > 0x4000) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_INVAL;
 	}
@@ -290,12 +290,12 @@ error_code cellSyncRwmRead(ppu_thread& ppu, vm::ptr<CellSyncRwm> rwm, vm::ptr<vo
 {
 	cellSync.trace("cellSyncRwmRead(rwm=*0x%x, buffer=*0x%x)", rwm, buffer);
 
-	if (UNLIKELY(!rwm || !buffer))
+	if (!rwm || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!rwm.aligned()))
+	if (!rwm.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -325,12 +325,12 @@ error_code cellSyncRwmTryRead(vm::ptr<CellSyncRwm> rwm, vm::ptr<void> buffer)
 {
 	cellSync.trace("cellSyncRwmTryRead(rwm=*0x%x, buffer=*0x%x)", rwm, buffer);
 
-	if (UNLIKELY(!rwm || !buffer))
+	if (!rwm || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!rwm.aligned()))
+	if (!rwm.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -357,12 +357,12 @@ error_code cellSyncRwmWrite(ppu_thread& ppu, vm::ptr<CellSyncRwm> rwm, vm::cptr<
 {
 	cellSync.trace("cellSyncRwmWrite(rwm=*0x%x, buffer=*0x%x)", rwm, buffer);
 
-	if (UNLIKELY(!rwm || !buffer))
+	if (!rwm || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!rwm.aligned()))
+	if (!rwm.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -398,12 +398,12 @@ error_code cellSyncRwmTryWrite(vm::ptr<CellSyncRwm> rwm, vm::cptr<void> buffer)
 {
 	cellSync.trace("cellSyncRwmTryWrite(rwm=*0x%x, buffer=*0x%x)", rwm, buffer);
 
-	if (UNLIKELY(!rwm || !buffer))
+	if (!rwm || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!rwm.aligned()))
+	if (!rwm.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -427,22 +427,22 @@ error_code cellSyncQueueInitialize(vm::ptr<CellSyncQueue> queue, vm::ptr<u8> buf
 {
 	cellSync.trace("cellSyncQueueInitialize(queue=*0x%x, buffer=*0x%x, size=0x%x, depth=0x%x)", queue, buffer, size, depth);
 
-	if (UNLIKELY(!queue))
+	if (!queue) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(size && !buffer))
+	if (size && !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned() || !buffer.aligned(16)))
+	if (!queue.aligned() || !buffer.aligned(16)) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
 
-	if (UNLIKELY(!depth || size % 16))
+	if (!depth || size % 16) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_INVAL;
 	}
@@ -462,12 +462,12 @@ error_code cellSyncQueuePush(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::
 {
 	cellSync.trace("cellSyncQueuePush(queue=*0x%x, buffer=*0x%x)", queue, buffer);
 
-	if (UNLIKELY(!queue || !buffer))
+	if (!queue || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -499,12 +499,12 @@ error_code cellSyncQueueTryPush(vm::ptr<CellSyncQueue> queue, vm::cptr<void> buf
 {
 	cellSync.trace("cellSyncQueueTryPush(queue=*0x%x, buffer=*0x%x)", queue, buffer);
 
-	if (UNLIKELY(!queue || !buffer))
+	if (!queue || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -533,12 +533,12 @@ error_code cellSyncQueuePop(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::p
 {
 	cellSync.trace("cellSyncQueuePop(queue=*0x%x, buffer=*0x%x)", queue, buffer);
 
-	if (UNLIKELY(!queue || !buffer))
+	if (!queue || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -570,12 +570,12 @@ error_code cellSyncQueueTryPop(vm::ptr<CellSyncQueue> queue, vm::ptr<void> buffe
 {
 	cellSync.trace("cellSyncQueueTryPop(queue=*0x%x, buffer=*0x%x)", queue, buffer);
 
-	if (UNLIKELY(!queue || !buffer))
+	if (!queue || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -604,12 +604,12 @@ error_code cellSyncQueuePeek(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue, vm::
 {
 	cellSync.trace("cellSyncQueuePeek(queue=*0x%x, buffer=*0x%x)", queue, buffer);
 
-	if (UNLIKELY(!queue || !buffer))
+	if (!queue || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -641,12 +641,12 @@ error_code cellSyncQueueTryPeek(vm::ptr<CellSyncQueue> queue, vm::ptr<void> buff
 {
 	cellSync.trace("cellSyncQueueTryPeek(queue=*0x%x, buffer=*0x%x)", queue, buffer);
 
-	if (UNLIKELY(!queue || !buffer))
+	if (!queue || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -675,12 +675,12 @@ error_code cellSyncQueueSize(vm::ptr<CellSyncQueue> queue)
 {
 	cellSync.trace("cellSyncQueueSize(queue=*0x%x)", queue);
 
-	if (UNLIKELY(!queue))
+	if (!queue) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -694,12 +694,12 @@ error_code cellSyncQueueClear(ppu_thread& ppu, vm::ptr<CellSyncQueue> queue)
 {
 	cellSync.trace("cellSyncQueueClear(queue=*0x%x)", queue);
 
-	if (UNLIKELY(!queue))
+	if (!queue) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -772,30 +772,30 @@ error_code cellSyncLFQueueInitialize(vm::ptr<CellSyncLFQueue> queue, vm::cptr<vo
 {
 	cellSync.warning("cellSyncLFQueueInitialize(queue=*0x%x, buffer=*0x%x, size=0x%x, depth=0x%x, direction=%d, eaSignal=*0x%x)", queue, buffer, size, depth, direction, eaSignal);
 
-	if (UNLIKELY(!queue))
+	if (!queue) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
 	if (size)
 	{
-		if (UNLIKELY(!buffer))
+		if (!buffer) [[unlikely]]
 		{
 			return CELL_SYNC_ERROR_NULL_POINTER;
 		}
 
-		if (UNLIKELY(size > 0x4000 || size % 16))
+		if (size > 0x4000 || size % 16) [[unlikely]]
 		{
 			return CELL_SYNC_ERROR_INVAL;
 		}
 	}
 
-	if (UNLIKELY(!depth || depth > 0x7fff || direction > 3))
+	if (!depth || depth > 0x7fff || direction > 3) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_INVAL;
 	}
 
-	if (UNLIKELY(!queue.aligned() || !buffer.aligned(16)))
+	if (!queue.aligned() || !buffer.aligned(16)) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -823,7 +823,7 @@ error_code cellSyncLFQueueInitialize(vm::ptr<CellSyncLFQueue> queue, vm::cptr<vo
 
 		if (old)
 		{
-			if (UNLIKELY(sdk_ver > 0x17ffff && old != 2))
+			if (sdk_ver > 0x17ffff && old != 2) [[unlikely]]
 			{
 				return CELL_SYNC_ERROR_STAT;
 			}
@@ -836,7 +836,7 @@ error_code cellSyncLFQueueInitialize(vm::ptr<CellSyncLFQueue> queue, vm::cptr<vo
 			{
 				for (const auto& data : vm::_ref<u64[16]>(queue.addr()))
 				{
-					if (UNLIKELY(data))
+					if (data) [[unlikely]]
 					{
 						return CELL_SYNC_ERROR_STAT;
 					}
@@ -852,14 +852,14 @@ error_code cellSyncLFQueueInitialize(vm::ptr<CellSyncLFQueue> queue, vm::cptr<vo
 
 	if (old_value == 2)
 	{
-		if (UNLIKELY(queue->m_size != size || queue->m_depth != depth || queue->m_buffer != buffer))
+		if (queue->m_size != size || queue->m_depth != depth || queue->m_buffer != buffer) [[unlikely]]
 		{
 			return CELL_SYNC_ERROR_INVAL;
 		}
 
 		if (sdk_ver > 0x17ffff)
 		{
-			if (UNLIKELY(queue->m_eaSignal != eaSignal || queue->m_direction != direction))
+			if (queue->m_eaSignal != eaSignal || queue->m_direction != direction) [[unlikely]]
 			{
 				return CELL_SYNC_ERROR_INVAL;
 			}
@@ -881,7 +881,7 @@ error_code _cellSyncLFQueueGetPushPointer(ppu_thread& ppu, vm::ptr<CellSyncLFQue
 {
 	cellSync.warning("_cellSyncLFQueueGetPushPointer(queue=*0x%x, pointer=*0x%x, isBlocking=%d, useEventQueue=%d)", queue, pointer, isBlocking, useEventQueue);
 
-	if (UNLIKELY(queue->m_direction != CELL_SYNC_QUEUE_PPU2SPU))
+	if (queue->m_direction != CELL_SYNC_QUEUE_PPU2SPU) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_PERM;
 	}
@@ -980,7 +980,7 @@ error_code _cellSyncLFQueueCompletePushPointer(ppu_thread& ppu, vm::ptr<CellSync
 {
 	cellSync.warning("_cellSyncLFQueueCompletePushPointer(queue=*0x%x, pointer=%d, fpSendSignal=*0x%x)", queue, pointer, fpSendSignal);
 
-	if (UNLIKELY(queue->m_direction != CELL_SYNC_QUEUE_PPU2SPU))
+	if (queue->m_direction != CELL_SYNC_QUEUE_PPU2SPU) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_PERM;
 	}
@@ -1122,12 +1122,12 @@ error_code _cellSyncLFQueuePushBody(ppu_thread& ppu, vm::ptr<CellSyncLFQueue> qu
 	// cellSyncLFQueuePush has 1 in isBlocking param, cellSyncLFQueueTryPush has 0
 	cellSync.warning("_cellSyncLFQueuePushBody(queue=*0x%x, buffer=*0x%x, isBlocking=%d)", queue, buffer, isBlocking);
 
-	if (UNLIKELY(!queue || !buffer))
+	if (!queue || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned() || !buffer.aligned(16)))
+	if (!queue.aligned() || !buffer.aligned(16)) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -1180,7 +1180,7 @@ error_code _cellSyncLFQueueGetPopPointer(ppu_thread& ppu, vm::ptr<CellSyncLFQueu
 {
 	cellSync.warning("_cellSyncLFQueueGetPopPointer(queue=*0x%x, pointer=*0x%x, isBlocking=%d, arg4=%d, useEventQueue=%d)", queue, pointer, isBlocking, arg4, useEventQueue);
 
-	if (UNLIKELY(queue->m_direction != CELL_SYNC_QUEUE_SPU2PPU))
+	if (queue->m_direction != CELL_SYNC_QUEUE_SPU2PPU) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_PERM;
 	}
@@ -1280,7 +1280,7 @@ error_code _cellSyncLFQueueCompletePopPointer(ppu_thread& ppu, vm::ptr<CellSyncL
 	// arguments copied from _cellSyncLFQueueCompletePushPointer + unknown argument (noQueueFull taken from LFQueue2CompletePopPointer)
 	cellSync.warning("_cellSyncLFQueueCompletePopPointer(queue=*0x%x, pointer=%d, fpSendSignal=*0x%x, noQueueFull=%d)", queue, pointer, fpSendSignal, noQueueFull);
 
-	if (UNLIKELY(queue->m_direction != CELL_SYNC_QUEUE_SPU2PPU))
+	if (queue->m_direction != CELL_SYNC_QUEUE_SPU2PPU) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_PERM;
 	}
@@ -1421,12 +1421,12 @@ error_code _cellSyncLFQueuePopBody(ppu_thread& ppu, vm::ptr<CellSyncLFQueue> que
 	// cellSyncLFQueuePop has 1 in isBlocking param, cellSyncLFQueueTryPop has 0
 	cellSync.warning("_cellSyncLFQueuePopBody(queue=*0x%x, buffer=*0x%x, isBlocking=%d)", queue, buffer, isBlocking);
 
-	if (UNLIKELY(!queue || !buffer))
+	if (!queue || !buffer) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned() || !buffer.aligned(16)))
+	if (!queue.aligned() || !buffer.aligned(16)) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -1479,12 +1479,12 @@ error_code cellSyncLFQueueClear(vm::ptr<CellSyncLFQueue> queue)
 {
 	cellSync.warning("cellSyncLFQueueClear(queue=*0x%x)", queue);
 
-	if (UNLIKELY(!queue))
+	if (!queue) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -1531,12 +1531,12 @@ error_code cellSyncLFQueueSize(vm::ptr<CellSyncLFQueue> queue, vm::ptr<u32> size
 {
 	cellSync.warning("cellSyncLFQueueSize(queue=*0x%x, size=*0x%x)", queue, size);
 
-	if (UNLIKELY(!queue || !size))
+	if (!queue || !size) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -1569,12 +1569,12 @@ error_code cellSyncLFQueueDepth(vm::ptr<CellSyncLFQueue> queue, vm::ptr<u32> dep
 {
 	cellSync.trace("cellSyncLFQueueDepth(queue=*0x%x, depth=*0x%x)", queue, depth);
 
-	if (UNLIKELY(!queue || !depth))
+	if (!queue || !depth) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -1588,12 +1588,12 @@ error_code _cellSyncLFQueueGetSignalAddress(vm::cptr<CellSyncLFQueue> queue, vm:
 {
 	cellSync.trace("_cellSyncLFQueueGetSignalAddress(queue=*0x%x, ppSignal=**0x%x)", queue, ppSignal);
 
-	if (UNLIKELY(!queue || !ppSignal))
+	if (!queue || !ppSignal) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -1607,12 +1607,12 @@ error_code cellSyncLFQueueGetDirection(vm::cptr<CellSyncLFQueue> queue, vm::ptr<
 {
 	cellSync.trace("cellSyncLFQueueGetDirection(queue=*0x%x, direction=*0x%x)", queue, direction);
 
-	if (UNLIKELY(!queue || !direction))
+	if (!queue || !direction) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}
@@ -1626,12 +1626,12 @@ error_code cellSyncLFQueueGetEntrySize(vm::cptr<CellSyncLFQueue> queue, vm::ptr<
 {
 	cellSync.trace("cellSyncLFQueueGetEntrySize(queue=*0x%x, entry_size=*0x%x)", queue, entry_size);
 
-	if (UNLIKELY(!queue || !entry_size))
+	if (!queue || !entry_size) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_NULL_POINTER;
 	}
 
-	if (UNLIKELY(!queue.aligned()))
+	if (!queue.aligned()) [[unlikely]]
 	{
 		return CELL_SYNC_ERROR_ALIGN;
 	}

--- a/rpcs3/Emu/Cell/Modules/cellSync.h
+++ b/rpcs3/Emu/Cell/Modules/cellSync.h
@@ -48,7 +48,7 @@ struct CellSyncMutex
 
 		bool try_lock()
 		{
-			if (UNLIKELY(rel != acq))
+			if (rel != acq) [[unlikely]]
 			{
 				return false;
 			}

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -26,7 +26,7 @@ inline void ppu_cr_set(ppu_thread& ppu, u32 field, bool le, bool gt, bool eq, bo
 	ppu.cr[field * 4 + 2] = eq;
 	ppu.cr[field * 4 + 3] = so;
 
-	if (UNLIKELY(g_cfg.core.ppu_debug))
+	if (g_cfg.core.ppu_debug) [[unlikely]]
 	{
 		*reinterpret_cast<u32*>(vm::g_stat_addr + ppu.cia) |= *reinterpret_cast<u32*>(ppu.cr.bits + field * 4);
 	}
@@ -54,16 +54,16 @@ inline void ppu_fpcc_set(ppu_thread& ppu, const T& a, const T& b, const bool rc,
 	u32 fpcc = u32{a < b} << (8 * 0) | u32{a > b} << (8 * 1) | u32{a == b} << (8 * 2);
 
 	// Test FU
-	if (UNLIKELY(fpcc == 0)) fpcc = 1 << (8 * 3);
+	if (fpcc == 0) [[unlikely]] fpcc = 1 << (8 * 3);
 
 	// Write FPCC
 	ppu.fpscr.fields[4] = fpcc;
 
-	if (UNLIKELY(rc))
+	if (rc) [[unlikely]]
 	{
 		ppu.cr.fields[cr_field] = fpcc;
 
-		if (UNLIKELY(g_cfg.core.ppu_debug))
+		if (g_cfg.core.ppu_debug) [[unlikely]]
 		{
 			*reinterpret_cast<u32*>(vm::g_stat_addr + ppu.cia) |= ppu.cr.fields[cr_field];
 		}
@@ -690,91 +690,91 @@ bool ppu_interpreter::VCMPBFP(ppu_thread& ppu, ppu_opcode_t op)
 	const auto cmp1 = _mm_cmpnle_ps(a, b);
 	const auto cmp2 = _mm_cmpnge_ps(a, _mm_xor_ps(b, sign));
 	ppu.vr[op.vd].vf = _mm_or_ps(_mm_and_ps(cmp1, sign), _mm_and_ps(cmp2, _mm_castsi128_ps(_mm_set1_epi32(0x40000000))));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, false, false, _mm_movemask_ps(_mm_or_ps(cmp1, cmp2)) == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, false, false, _mm_movemask_ps(_mm_or_ps(cmp1, cmp2)) == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPEQFP(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_ps(ppu.vr[op.vd].vf = _mm_cmpeq_ps(ppu.vr[op.va].vf, ppu.vr[op.vb].vf));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xf, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xf, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPEQUB(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8((ppu.vr[op.vd] = v128::eq8(ppu.vr[op.va], ppu.vr[op.vb])).vi);
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPEQUH(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8((ppu.vr[op.vd] = v128::eq16(ppu.vr[op.va], ppu.vr[op.vb])).vi);
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPEQUW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8((ppu.vr[op.vd] = v128::eq32(ppu.vr[op.va], ppu.vr[op.vb])).vi);
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPGEFP(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_ps(ppu.vr[op.vd].vf = _mm_cmpge_ps(ppu.vr[op.va].vf, ppu.vr[op.vb].vf));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xf, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xf, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPGTFP(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_ps(ppu.vr[op.vd].vf = _mm_cmpgt_ps(ppu.vr[op.va].vf, ppu.vr[op.vb].vf));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xf, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xf, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPGTSB(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8(ppu.vr[op.vd].vi = _mm_cmpgt_epi8(ppu.vr[op.va].vi, ppu.vr[op.vb].vi));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPGTSH(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8(ppu.vr[op.vd].vi = _mm_cmpgt_epi16(ppu.vr[op.va].vi, ppu.vr[op.vb].vi));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPGTSW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8(ppu.vr[op.vd].vi = _mm_cmpgt_epi32(ppu.vr[op.va].vi, ppu.vr[op.vb].vi));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPGTUB(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8(ppu.vr[op.vd].vi = sse_cmpgt_epu8(ppu.vr[op.va].vi, ppu.vr[op.vb].vi));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPGTUH(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8(ppu.vr[op.vd].vi = sse_cmpgt_epu16(ppu.vr[op.va].vi, ppu.vr[op.vb].vi));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
 bool ppu_interpreter::VCMPGTUW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto rmask = _mm_movemask_epi8(ppu.vr[op.vd].vi = sse_cmpgt_epu32(ppu.vr[op.va].vi, ppu.vr[op.vb].vi));
-	if (UNLIKELY(op.oe)) ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
+	if (op.oe) [[unlikely]] ppu_cr_set(ppu, 6, rmask == 0xffff, false, rmask == 0, false);
 	return true;
 }
 
@@ -2897,7 +2897,7 @@ bool ppu_interpreter::ADDIC(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(a, i);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.main & 1)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.main & 1) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
@@ -3060,21 +3060,21 @@ bool ppu_interpreter::RLWIMI(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 mask = ppu_rotate_mask(32 + op.mb32, 32 + op.me32);
 	ppu.gpr[op.ra] = (ppu.gpr[op.ra] & ~mask) | (dup32(utils::rol32(static_cast<u32>(ppu.gpr[op.rs]), op.sh32)) & mask);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::RLWINM(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = dup32(utils::rol32(static_cast<u32>(ppu.gpr[op.rs]), op.sh32)) & ppu_rotate_mask(32 + op.mb32, 32 + op.me32);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::RLWNM(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = dup32(utils::rol32(static_cast<u32>(ppu.gpr[op.rs]), ppu.gpr[op.rb] & 0x1f)) & ppu_rotate_mask(32 + op.mb32, 32 + op.me32);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3119,21 +3119,21 @@ bool ppu_interpreter::ANDIS(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::RLDICL(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = utils::rol64(ppu.gpr[op.rs], op.sh64) & (~0ull >> op.mbe64);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::RLDICR(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = utils::rol64(ppu.gpr[op.rs], op.sh64) & (~0ull << (op.mbe64 ^ 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::RLDIC(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = utils::rol64(ppu.gpr[op.rs], op.sh64) & ppu_rotate_mask(op.mbe64, op.sh64 ^ 63);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3141,21 +3141,21 @@ bool ppu_interpreter::RLDIMI(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 mask = ppu_rotate_mask(op.mbe64, op.sh64 ^ 63);
 	ppu.gpr[op.ra] = (ppu.gpr[op.ra] & ~mask) | (utils::rol64(ppu.gpr[op.rs], op.sh64) & mask);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::RLDCL(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = utils::rol64(ppu.gpr[op.rs], ppu.gpr[op.rb] & 0x3f) & (~0ull >> op.mbe64);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::RLDCR(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = utils::rol64(ppu.gpr[op.rs], ppu.gpr[op.rb] & 0x3f) & (~0ull << (op.mbe64 ^ 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3208,15 +3208,15 @@ bool ppu_interpreter::SUBFC(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(~RA, RB, 1);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (~RA >> 63 == RB >> 63) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (~RA >> 63 == RB >> 63) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
 bool ppu_interpreter::MULHDU(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.rd] = utils::umulh64(ppu.gpr[op.ra], ppu.gpr[op.rb]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	return true;
 }
 
@@ -3227,8 +3227,8 @@ bool ppu_interpreter::ADDC(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(RA, RB);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (RA >> 63 == RB >> 63) && (RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (RA >> 63 == RB >> 63) && (RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
@@ -3237,7 +3237,7 @@ bool ppu_interpreter::MULHWU(ppu_thread& ppu, ppu_opcode_t op)
 	u32 a = static_cast<u32>(ppu.gpr[op.ra]);
 	u32 b = static_cast<u32>(ppu.gpr[op.rb]);
 	ppu.gpr[op.rd] = (u64{a} * b) >> 32;
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 0, false, false, false, ppu.xer.so);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 0, false, false, false, ppu.xer.so);
 	return true;
 }
 
@@ -3289,29 +3289,29 @@ bool ppu_interpreter::LWZX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::SLW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = static_cast<u32>(ppu.gpr[op.rs] << (ppu.gpr[op.rb] & 0x3f));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::CNTLZW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = utils::cntlz32(static_cast<u32>(ppu.gpr[op.rs]));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::SLD(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u32 n = ppu.gpr[op.rb] & 0x7f;
-	ppu.gpr[op.ra] = UNLIKELY(n & 0x40) ? 0 : ppu.gpr[op.rs] << n;
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	ppu.gpr[op.ra] = n & 0x40 ? 0 : ppu.gpr[op.rs] << n;
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::AND(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = ppu.gpr[op.rs] & ppu.gpr[op.rb];
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3345,8 +3345,8 @@ bool ppu_interpreter::SUBF(ppu_thread& ppu, ppu_opcode_t op)
 	const u64 RA = ppu.gpr[op.ra];
 	const u64 RB = ppu.gpr[op.rb];
 	ppu.gpr[op.rd] = RB - RA;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (~RA >> 63 == RB >> 63) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (~RA >> 63 == RB >> 63) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	return true;
 }
 
@@ -3374,14 +3374,14 @@ bool ppu_interpreter::LWZUX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::CNTLZD(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = utils::cntlz64(ppu.gpr[op.rs]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::ANDC(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = ppu.gpr[op.rs] & ~ppu.gpr[op.rb];
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3410,7 +3410,7 @@ bool ppu_interpreter::LVEWX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::MULHD(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.rd] = utils::mulh64(ppu.gpr[op.ra], ppu.gpr[op.rb]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	return true;
 }
 
@@ -3419,7 +3419,7 @@ bool ppu_interpreter::MULHW(ppu_thread& ppu, ppu_opcode_t op)
 	s32 a = static_cast<s32>(ppu.gpr[op.ra]);
 	s32 b = static_cast<s32>(ppu.gpr[op.rb]);
 	ppu.gpr[op.rd] = (s64{a} * b) >> 32;
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 0, false, false, false, ppu.xer.so);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 0, false, false, false, ppu.xer.so);
 	return true;
 }
 
@@ -3453,8 +3453,8 @@ bool ppu_interpreter::NEG(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 RA = ppu.gpr[op.ra];
 	ppu.gpr[op.rd] = 0 - RA;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (~RA >> 63 == 0) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (~RA >> 63 == 0) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	return true;
 }
 
@@ -3469,7 +3469,7 @@ bool ppu_interpreter::LBZUX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::NOR(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = ~(ppu.gpr[op.rs] | ppu.gpr[op.rb]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3488,8 +3488,8 @@ bool ppu_interpreter::SUBFE(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(~RA, RB, ppu.xer.ca);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (~RA >> 63 == RB >> 63) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (~RA >> 63 == RB >> 63) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
@@ -3500,8 +3500,8 @@ bool ppu_interpreter::ADDE(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(RA, RB, ppu.xer.ca);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (RA >> 63 == RB >> 63) && (RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (RA >> 63 == RB >> 63) && (RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
@@ -3612,8 +3612,8 @@ bool ppu_interpreter::SUBFZE(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(~RA, 0, ppu.xer.ca);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (~RA >> 63 == 0) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (~RA >> 63 == 0) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
@@ -3623,8 +3623,8 @@ bool ppu_interpreter::ADDZE(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(RA, 0, ppu.xer.ca);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (RA >> 63 == 0) && (RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (RA >> 63 == 0) && (RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
@@ -3654,12 +3654,12 @@ bool ppu_interpreter::MULLD(ppu_thread& ppu, ppu_opcode_t op)
 	const s64 RA = ppu.gpr[op.ra];
 	const s64 RB = ppu.gpr[op.rb];
 	ppu.gpr[op.rd] = RA * RB;
-	if (UNLIKELY(op.oe))
+	if (op.oe) [[unlikely]]
 	{
 		const s64 high = utils::mulh64(RA, RB);
 		ppu_ov_set(ppu, high != s64(ppu.gpr[op.rd]) >> 63);
 	}
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	return true;
 }
 
@@ -3669,8 +3669,8 @@ bool ppu_interpreter::SUBFME(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(~RA, ~0ull, ppu.xer.ca);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (~RA >> 63 == 1) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (~RA >> 63 == 1) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
@@ -3680,16 +3680,16 @@ bool ppu_interpreter::ADDME(ppu_thread& ppu, ppu_opcode_t op)
 	const auto r = add64_flags(RA, ~0ull, ppu.xer.ca);
 	ppu.gpr[op.rd] = r.result;
 	ppu.xer.ca = r.carry;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (u64(RA) >> 63 == 1) && (u64(RA) >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, r.result, 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (u64(RA) >> 63 == 1) && (u64(RA) >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, r.result, 0);
 	return true;
 }
 
 bool ppu_interpreter::MULLW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.rd] = s64{static_cast<s32>(ppu.gpr[op.ra])} * static_cast<s32>(ppu.gpr[op.rb]);
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, s64(ppu.gpr[op.rd]) < INT32_MIN || s64(ppu.gpr[op.rd]) > INT32_MAX);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, s64(ppu.gpr[op.rd]) < INT32_MIN || s64(ppu.gpr[op.rd]) > INT32_MAX);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3711,8 +3711,8 @@ bool ppu_interpreter::ADD(ppu_thread& ppu, ppu_opcode_t op)
 	const u64 RA = ppu.gpr[op.ra];
 	const u64 RB = ppu.gpr[op.rb];
 	ppu.gpr[op.rd] = RA + RB;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, (RA >> 63 == RB >> 63) && (RA >> 63 != ppu.gpr[op.rd] >> 63));
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, (RA >> 63 == RB >> 63) && (RA >> 63 != ppu.gpr[op.rd] >> 63));
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	return true;
 }
 
@@ -3731,7 +3731,7 @@ bool ppu_interpreter::LHZX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::EQV(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = ~(ppu.gpr[op.rs] ^ ppu.gpr[op.rb]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3751,7 +3751,7 @@ bool ppu_interpreter::LHZUX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::XOR(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = ppu.gpr[op.rs] ^ ppu.gpr[op.rb];
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3845,7 +3845,7 @@ bool ppu_interpreter::STHX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::ORC(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = ppu.gpr[op.rs] | ~ppu.gpr[op.rb];
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3865,7 +3865,7 @@ bool ppu_interpreter::STHUX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::OR(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = ppu.gpr[op.rs] | ppu.gpr[op.rb];
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3874,8 +3874,8 @@ bool ppu_interpreter::DIVDU(ppu_thread& ppu, ppu_opcode_t op)
 	const u64 RA = ppu.gpr[op.ra];
 	const u64 RB = ppu.gpr[op.rb];
 	ppu.gpr[op.rd] = RB == 0 ? 0 : RA / RB;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, RB == 0);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, RB == 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	return true;
 }
 
@@ -3884,8 +3884,8 @@ bool ppu_interpreter::DIVWU(ppu_thread& ppu, ppu_opcode_t op)
 	const u32 RA = static_cast<u32>(ppu.gpr[op.ra]);
 	const u32 RB = static_cast<u32>(ppu.gpr[op.rb]);
 	ppu.gpr[op.rd] = RB == 0 ? 0 : RA / RB;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, RB == 0);
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 0, false, false, false, ppu.xer.so);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, RB == 0);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 0, false, false, false, ppu.xer.so);
 	return true;
 }
 
@@ -3921,7 +3921,7 @@ bool ppu_interpreter::DCBI(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::NAND(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = ~(ppu.gpr[op.rs] & ppu.gpr[op.rb]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -3938,8 +3938,8 @@ bool ppu_interpreter::DIVD(ppu_thread& ppu, ppu_opcode_t op)
 	const s64 RB = ppu.gpr[op.rb];
 	const bool o = RB == 0 || (RA == INT64_MIN && RB == -1);
 	ppu.gpr[op.rd] = o ? 0 : RA / RB;
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, o);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, o);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	return true;
 }
 
@@ -3949,8 +3949,8 @@ bool ppu_interpreter::DIVW(ppu_thread& ppu, ppu_opcode_t op)
 	const s32 RB = static_cast<s32>(ppu.gpr[op.rb]);
 	const bool o = RB == 0 || (RA == INT32_MIN && RB == -1);
 	ppu.gpr[op.rd] = o ? 0 : static_cast<u32>(RA / RB);
-	if (UNLIKELY(op.oe)) ppu_ov_set(ppu, o);
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 0, false, false, false, ppu.xer.so);
+	if (op.oe) [[unlikely]] ppu_ov_set(ppu, o);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 0, false, false, false, ppu.xer.so);
 	return true;
 }
 
@@ -4013,15 +4013,15 @@ bool ppu_interpreter::LFSX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::SRW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = (ppu.gpr[op.rs] & 0xffffffff) >> (ppu.gpr[op.rb] & 0x3f);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
 bool ppu_interpreter::SRD(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u32 n = ppu.gpr[op.rb] & 0x7f;
-	ppu.gpr[op.ra] = UNLIKELY(n & 0x40) ? 0 : ppu.gpr[op.rs] >> n;
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	ppu.gpr[op.ra] = n & 0x40 ? 0 : ppu.gpr[op.rs] >> n;
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -4254,7 +4254,7 @@ bool ppu_interpreter::SRAW(ppu_thread& ppu, ppu_opcode_t op)
 		ppu.xer.ca = (RS < 0) && ((ppu.gpr[op.ra] << shift) != RS);
 	}
 
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -4273,7 +4273,7 @@ bool ppu_interpreter::SRAD(ppu_thread& ppu, ppu_opcode_t op)
 		ppu.xer.ca = (RS < 0) && ((ppu.gpr[op.ra] << shift) != RS);
 	}
 
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -4298,7 +4298,7 @@ bool ppu_interpreter::SRAWI(ppu_thread& ppu, ppu_opcode_t op)
 	ppu.gpr[op.ra] = RS >> op.sh32;
 	ppu.xer.ca = (RS < 0) && (static_cast<u32>(ppu.gpr[op.ra] << op.sh32) != RS);
 
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -4309,7 +4309,7 @@ bool ppu_interpreter::SRADI(ppu_thread& ppu, ppu_opcode_t op)
 	ppu.gpr[op.ra] = RS >> sh;
 	ppu.xer.ca = (RS < 0) && ((ppu.gpr[op.ra] << sh) != RS);
 
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -4339,7 +4339,7 @@ bool ppu_interpreter::STHBRX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::EXTSH(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = static_cast<s16>(ppu.gpr[op.rs]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -4356,7 +4356,7 @@ bool ppu_interpreter_fast::STVRXL(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::EXTSB(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = static_cast<s8>(ppu.gpr[op.rs]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -4370,7 +4370,7 @@ bool ppu_interpreter::STFIWX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::EXTSW(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.gpr[op.ra] = static_cast<s32>(ppu.gpr[op.rs]);
-	if (UNLIKELY(op.rc)) ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
+	if (op.rc) [[unlikely]] ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.ra], 0);
 	return true;
 }
 
@@ -4424,7 +4424,7 @@ bool ppu_interpreter::STW(ppu_thread& ppu, ppu_opcode_t op)
 	vm::write32(vm::cast(addr, HERE), value);
 
 	//Insomniac engine v3 & v4 (newer R&C, Fuse, Resitance 3)
-	if (UNLIKELY(value == 0xAAAAAAAA))
+	if (value == 0xAAAAAAAA) [[unlikely]]
 	{
 		vm::reservation_update(addr, 128);
 	}
@@ -4752,7 +4752,7 @@ bool ppu_interpreter::MTFSB1(ppu_thread& ppu, ppu_opcode_t op)
 	const u32 bit = op.crbd;
 	if (bit < 16 || bit > 19) ppu_log.warning("MTFSB1(%d)", bit);
 	ppu.fpscr.bits[bit] = 1;
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -4768,7 +4768,7 @@ bool ppu_interpreter::MTFSB0(ppu_thread& ppu, ppu_opcode_t op)
 	const u32 bit = op.crbd;
 	if (bit < 16 || bit > 19) ppu_log.warning("MTFSB0(%d)", bit);
 	ppu.fpscr.bits[bit] = 0;
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -4803,7 +4803,7 @@ bool ppu_interpreter::MTFSFI(ppu_thread& ppu, ppu_opcode_t op)
 		ppu.fpscr.fields[bf] = all_values[op.i];
 	}
 
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -4811,14 +4811,14 @@ bool ppu_interpreter::MFFS(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu_log.warning("MFFS");
 	ppu.fpr[op.frd] = std::bit_cast<f64>(u64{ppu.fpscr.fl} << 15 | u64{ppu.fpscr.fg} << 14 | u64{ppu.fpscr.fe} << 13 | u64{ppu.fpscr.fu} << 12);
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
 bool ppu_interpreter::MTFSF(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu_log.warning("MTFSF");
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -4835,7 +4835,7 @@ bool ppu_interpreter::FCTIW(ppu_thread& ppu, ppu_opcode_t op)
 	const auto b = _mm_load_sd(&ppu.fpr[op.frb]);
 	const auto res = _mm_xor_si128(_mm_cvtpd_epi32(b), _mm_castpd_si128(_mm_cmpge_pd(b, _mm_set1_pd(0x80000000))));
 	ppu.fpr[op.frd] = std::bit_cast<f64, s64>(_mm_cvtsi128_si32(res));
-	if (UNLIKELY(op.rc)) fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -4844,7 +4844,7 @@ bool ppu_interpreter::FCTIWZ(ppu_thread& ppu, ppu_opcode_t op)
 	const auto b = _mm_load_sd(&ppu.fpr[op.frb]);
 	const auto res = _mm_xor_si128(_mm_cvttpd_epi32(b), _mm_castpd_si128(_mm_cmpge_pd(b, _mm_set1_pd(0x80000000))));
 	ppu.fpr[op.frd] = std::bit_cast<f64, s64>(_mm_cvtsi128_si32(res));
-	if (UNLIKELY(op.rc)) fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -4916,7 +4916,7 @@ bool ppu_interpreter_precise::FSQRT(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::FSEL(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.fpr[op.frd] = ppu.fpr[op.fra] >= 0.0 ? ppu.fpr[op.frc] : ppu.fpr[op.frb];
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -5006,28 +5006,28 @@ bool ppu_interpreter::FCMPO(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::FNEG(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.fpr[op.frd] = -ppu.fpr[op.frb];
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
 bool ppu_interpreter::FMR(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.fpr[op.frd] = ppu.fpr[op.frb];
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
 bool ppu_interpreter::FNABS(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.fpr[op.frd] = -std::fabs(ppu.fpr[op.frb]);
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
 bool ppu_interpreter::FABS(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.fpr[op.frd] = std::fabs(ppu.fpr[op.frb]);
-	if (UNLIKELY(op.rc)) ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -5036,7 +5036,7 @@ bool ppu_interpreter::FCTID(ppu_thread& ppu, ppu_opcode_t op)
 	const auto b = _mm_load_sd(&ppu.fpr[op.frb]);
 	const auto res = _mm_xor_si128(_mm_set1_epi64x(_mm_cvtsd_si64(b)), _mm_castpd_si128(_mm_cmpge_pd(b, _mm_set1_pd(f64(1ull << 63)))));
 	ppu.fpr[op.frd] = std::bit_cast<f64>(_mm_cvtsi128_si64(res));
-	if (UNLIKELY(op.rc)) fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
@@ -5045,14 +5045,14 @@ bool ppu_interpreter::FCTIDZ(ppu_thread& ppu, ppu_opcode_t op)
 	const auto b = _mm_load_sd(&ppu.fpr[op.frb]);
 	const auto res = _mm_xor_si128(_mm_set1_epi64x(_mm_cvttsd_si64(b)), _mm_castpd_si128(_mm_cmpge_pd(b, _mm_set1_pd(f64(1ull << 63)))));
 	ppu.fpr[op.frd] = std::bit_cast<f64>(_mm_cvtsi128_si64(res));
-	if (UNLIKELY(op.rc)) fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 
 bool ppu_interpreter::FCFID(ppu_thread& ppu, ppu_opcode_t op)
 {
 	_mm_store_sd(&ppu.fpr[op.frd], _mm_cvtsi64_sd(_mm_setzero_pd(), std::bit_cast<s64>(ppu.fpr[op.frb])));
-	if (UNLIKELY(op.rc)) fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
+	if (op.rc) [[unlikely]] fmt::throw_exception("%s: op.rc", __func__); //ppu_cr_set(ppu, 1, ppu.fpscr.fg, ppu.fpscr.fl, ppu.fpscr.fe, ppu.fpscr.fu);
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -299,7 +299,7 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 		{
 			const u32 cmask = get_code_mask(j, j + 64);
 
-			if (UNLIKELY(cmask == 0))
+			if (cmask == 0) [[unlikely]]
 			{
 				continue;
 			}
@@ -424,7 +424,7 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 			{
 				const u32 cmask = get_code_mask(j, j + 32);
 
-				if (UNLIKELY(cmask == 0))
+				if (cmask == 0) [[unlikely]]
 				{
 					continue;
 				}
@@ -549,7 +549,7 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 			{
 				const u32 cmask = get_code_mask(j, j + 32);
 
-				if (UNLIKELY(cmask == 0))
+				if (cmask == 0) [[unlikely]]
 				{
 					continue;
 				}
@@ -646,7 +646,7 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 		{
 			const u32 cmask = get_code_mask(j, j + 16);
 
-			if (UNLIKELY(cmask == 0))
+			if (cmask == 0) [[unlikely]]
 			{
 				continue;
 			}

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -1172,7 +1172,7 @@ void spu_recompiler_base::old_interpreter(spu_thread& spu, void* ls, u8* rip) tr
 
 	while (true)
 	{
-		if (UNLIKELY(spu.state))
+		if (spu.state) [[unlikely]]
 		{
 			if (spu.check_state())
 				break;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1148,7 +1148,7 @@ void spu_thread::cpu_task()
 	{
 		while (true)
 		{
-			if (UNLIKELY(state))
+			if (state) [[unlikely]]
 			{
 				if (check_state())
 					break;
@@ -1173,7 +1173,7 @@ void spu_thread::cpu_task()
 
 		while (true)
 		{
-			if (UNLIKELY(state))
+			if (state) [[unlikely]]
 			{
 				if (check_state())
 					break;
@@ -1335,7 +1335,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 		std::swap(dst, src);
 	}
 
-	if (UNLIKELY(!g_use_rtm && (!is_get || g_cfg.core.spu_accurate_putlluc)))
+	if (!g_use_rtm && (!is_get || g_cfg.core.spu_accurate_putlluc)) [[unlikely]]
 	{
 		switch (u32 size = args.size)
 		{
@@ -1466,7 +1466,7 @@ bool spu_thread::do_dma_check(const spu_mfc_cmd& args)
 {
 	const u32 mask = utils::rol32(1, args.tag);
 
-	if (UNLIKELY(mfc_barrier & mask || (args.cmd & (MFC_BARRIER_MASK | MFC_FENCE_MASK) && mfc_fence & mask)))
+	if (mfc_barrier & mask || (args.cmd & (MFC_BARRIER_MASK | MFC_FENCE_MASK) && mfc_fence & mask)) [[unlikely]]
 	{
 		// Check for special value combination (normally impossible)
 		if (false)
@@ -1585,7 +1585,7 @@ bool spu_thread::do_list_transfer(spu_mfc_cmd& args)
 
 		args.eal += 8;
 
-		if (UNLIKELY(items[index].sb & 0x8000))
+		if (items[index].sb & 0x8000) [[unlikely]]
 		{
 			ch_stall_mask |= utils::rol32(1, args.tag);
 
@@ -1624,7 +1624,7 @@ void spu_thread::do_putlluc(const spu_mfc_cmd& args)
 	const auto& to_write = _ref<decltype(rdata)>(args.lsa & 0x3ff80);
 
 	// Store unconditionally
-	if (LIKELY(g_use_rtm))
+	if (g_use_rtm) [[likely]]
 	{
 		const u32 result = spu_putlluc_tx(addr, to_write.data(), this);
 
@@ -1781,7 +1781,7 @@ u32 spu_thread::get_mfc_completed()
 bool spu_thread::process_mfc_cmd()
 {
 	// Stall infinitely if MFC queue is full
-	while (UNLIKELY(mfc_size >= 16))
+	while (mfc_size >= 16) [[unlikely]]
 	{
 		state += cpu_flag::wait;
 
@@ -1829,7 +1829,7 @@ bool spu_thread::process_mfc_cmd()
 			}
 		}
 
-		if (LIKELY(g_use_rtm && !g_cfg.core.spu_accurate_getllar && raddr != addr))
+		if (g_use_rtm && !g_cfg.core.spu_accurate_getllar && raddr != addr) [[likely]]
 		{
 			// TODO: maybe always start from a transaction
 			ntime = spu_getll_inexact(addr, dst.data());
@@ -1918,7 +1918,7 @@ bool spu_thread::process_mfc_cmd()
 		{
 			const auto& to_write = _ref<decltype(rdata)>(ch_mfc_cmd.lsa & 0x3ff80);
 
-			if (LIKELY(g_use_rtm))
+			if (g_use_rtm) [[likely]]
 			{
 				result = spu_putllc_tx(addr, rtime, rdata.data(), to_write.data());
 
@@ -2021,7 +2021,7 @@ bool spu_thread::process_mfc_cmd()
 	{
 		const u32 mask = utils::rol32(1, ch_mfc_cmd.tag);
 
-		if (UNLIKELY((mfc_barrier | mfc_fence) & mask))
+		if ((mfc_barrier | mfc_fence) & mask) [[unlikely]]
 		{
 			mfc_queue[mfc_size++] = ch_mfc_cmd;
 			mfc_fence |= mask;
@@ -2054,9 +2054,9 @@ bool spu_thread::process_mfc_cmd()
 	case MFC_GETB_CMD:
 	case MFC_GETF_CMD:
 	{
-		if (LIKELY(ch_mfc_cmd.size <= 0x4000))
+		if (ch_mfc_cmd.size <= 0x4000) [[likely]]
 		{
-			if (LIKELY(do_dma_check(ch_mfc_cmd)))
+			if (do_dma_check(ch_mfc_cmd)) [[likely]]
 			{
 				if (ch_mfc_cmd.size)
 				{
@@ -2089,14 +2089,14 @@ bool spu_thread::process_mfc_cmd()
 	case MFC_GETLB_CMD:
 	case MFC_GETLF_CMD:
 	{
-		if (LIKELY(ch_mfc_cmd.size <= 0x4000))
+		if (ch_mfc_cmd.size <= 0x4000) [[likely]]
 		{
 			auto& cmd = mfc_queue[mfc_size];
 			cmd = ch_mfc_cmd;
 
-			if (LIKELY(do_dma_check(cmd)))
+			if (do_dma_check(cmd)) [[likely]]
 			{
-				if (LIKELY(!cmd.size || do_list_transfer(cmd)))
+				if (!cmd.size || do_list_transfer(cmd)) [[likely]]
 				{
 					return true;
 				}

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -171,7 +171,7 @@ public:
 	{
 		const u64 old = data.fetch_op([=](u64& data)
 		{
-			if (UNLIKELY(data & bit_count))
+			if (data & bit_count) [[unlikely]]
 			{
 				data |= bit_wait;
 			}
@@ -218,7 +218,7 @@ public:
 	{
 		const u64 old = data.fetch_op([&](u64& data)
 		{
-			if (LIKELY(data & bit_count))
+			if (data & bit_count) [[likely]]
 			{
 				out = static_cast<u32>(data);
 				data = 0;
@@ -637,7 +637,7 @@ public:
 
 	static u32 find_raw_spu(u32 id)
 	{
-		if (LIKELY(id < std::size(g_raw_spu_id)))
+		if (id < std::size(g_raw_spu_id)) [[likely]]
 		{
 			return g_raw_spu_id[id];
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -374,7 +374,7 @@ error_code sys_spu_thread_set_argument(ppu_thread& ppu, u32 id, vm::ptr<sys_spu_
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -394,7 +394,7 @@ error_code sys_spu_thread_get_exit_status(ppu_thread& ppu, u32 id, vm::ptr<u32> 
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -883,7 +883,7 @@ error_code sys_spu_thread_write_ls(ppu_thread& ppu, u32 id, u32 lsa, u64 value, 
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -920,7 +920,7 @@ error_code sys_spu_thread_read_ls(ppu_thread& ppu, u32 id, u32 lsa, vm::ptr<u64>
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -952,7 +952,7 @@ error_code sys_spu_thread_write_spu_mb(ppu_thread& ppu, u32 id, u32 value)
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -977,7 +977,7 @@ error_code sys_spu_thread_set_spu_cfg(ppu_thread& ppu, u32 id, u64 value)
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -995,7 +995,7 @@ error_code sys_spu_thread_get_spu_cfg(ppu_thread& ppu, u32 id, vm::ptr<u64> valu
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1013,7 +1013,7 @@ error_code sys_spu_thread_write_snr(ppu_thread& ppu, u32 id, u32 number, u32 val
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1117,7 +1117,7 @@ error_code sys_spu_thread_connect_event(ppu_thread& ppu, u32 id, u32 eq, u32 et,
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 	const auto queue = idm::get<lv2_obj, lv2_event_queue>(eq);
 
-	if (UNLIKELY(!queue || !thread))
+	if (!queue || !thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1150,7 +1150,7 @@ error_code sys_spu_thread_disconnect_event(ppu_thread& ppu, u32 id, u32 et, u8 s
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1184,7 +1184,7 @@ error_code sys_spu_thread_bind_queue(ppu_thread& ppu, u32 id, u32 spuq, u32 spuq
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 	const auto queue = idm::get<lv2_obj, lv2_event_queue>(spuq);
 
-	if (UNLIKELY(!queue || !thread))
+	if (!queue || !thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1237,7 +1237,7 @@ error_code sys_spu_thread_unbind_queue(ppu_thread& ppu, u32 id, u32 spuq_num)
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1413,7 +1413,7 @@ error_code sys_spu_thread_recover_page_fault(ppu_thread& ppu, u32 id)
 
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1429,7 +1429,7 @@ error_code sys_raw_spu_recover_page_fault(ppu_thread& ppu, u32 id)
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1478,7 +1478,7 @@ error_code sys_raw_spu_destroy(ppu_thread& ppu, u32 id)
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1591,7 +1591,7 @@ error_code sys_raw_spu_set_int_mask(ppu_thread& ppu, u32 id, u32 class_id, u64 m
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1614,7 +1614,7 @@ error_code sys_raw_spu_get_int_mask(ppu_thread& ppu, u32 id, u32 class_id, vm::p
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1637,7 +1637,7 @@ error_code sys_raw_spu_set_int_stat(ppu_thread& ppu, u32 id, u32 class_id, u64 s
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1660,7 +1660,7 @@ error_code sys_raw_spu_get_int_stat(ppu_thread& ppu, u32 id, u32 class_id, vm::p
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1678,7 +1678,7 @@ error_code sys_raw_spu_read_puint_mb(ppu_thread& ppu, u32 id, vm::ptr<u32> value
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1701,7 +1701,7 @@ error_code sys_raw_spu_set_spu_cfg(ppu_thread& ppu, u32 id, u32 value)
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -1719,7 +1719,7 @@ error_code sys_raw_spu_get_spu_cfg(ppu_thread& ppu, u32 id, vm::ptr<u32> value)
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (UNLIKELY(!thread))
+	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -248,13 +248,13 @@ bool gdb_thread::try_read_cmd(gdb_cmd& out_cmd)
 {
 	char c = read_char();
 	//interrupt
-	if (UNLIKELY(c == 0x03)) {
+	if (c == 0x03) [[unlikely]] {
 		out_cmd.cmd = '\x03';
 		out_cmd.data = "";
 		out_cmd.checksum = 0;
 		return true;
 	}
-	if (UNLIKELY(c != '$')) {
+	if (c != '$') [[unlikely]] {
 		//gdb starts conversation with + for some reason
 		if (c == '+') {
 			c = read_char();
@@ -370,10 +370,9 @@ bool gdb_thread::send_cmd_ack(const std::string& cmd)
 	while (true) {
 		send_cmd(cmd);
 		char c = read_char();
-		if (LIKELY(c == '+')) {
+		if (c == '+') [[likely]]
 			return true;
-		}
-		if (UNLIKELY(c != '-')) {
+		if (c != '-') [[unlikely]] {
 			GDB.error("Wrong acknowledge character received: '%c'.", c);
 			return false;
 		}
@@ -384,7 +383,7 @@ bool gdb_thread::send_cmd_ack(const std::string& cmd)
 u8 gdb_thread::append_encoded_char(char c, std::string& str)
 {
 	u8 checksum = 0;
-	if (UNLIKELY((c == '#') || (c == '$') || (c == '}'))) {
+	if ((c == '#') || (c == '$') || (c == '}')) [[unlikely]] {
 		str += '}';
 		c ^= 0x20;
 		checksum = '}';

--- a/rpcs3/Emu/IdManager.h
+++ b/rpcs3/Emu/IdManager.h
@@ -408,7 +408,7 @@ public:
 	{
 		const auto found = find_id<T, Get>(id);
 
-		if (UNLIKELY(found == nullptr))
+		if (found == nullptr) [[unlikely]]
 		{
 			return nullptr;
 		}
@@ -424,7 +424,7 @@ public:
 
 		const auto found = find_id<T, Get>(id);
 
-		if (UNLIKELY(found == nullptr))
+		if (found == nullptr) [[unlikely]]
 		{
 			return nullptr;
 		}
@@ -440,7 +440,7 @@ public:
 
 		const auto found = find_id<T, Get>(id);
 
-		if (UNLIKELY(found == nullptr))
+		if (found == nullptr) [[unlikely]]
 		{
 			return {nullptr};
 		}

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -96,17 +96,17 @@ namespace vm
 
 	void passive_lock(cpu_thread& cpu)
 	{
-		if (UNLIKELY(g_tls_locked && *g_tls_locked == &cpu))
+		if (g_tls_locked && *g_tls_locked == &cpu) [[unlikely]]
 		{
 			return;
 		}
 
-		if (LIKELY(g_mutex.is_lockable()))
+		if (g_mutex.is_lockable()) [[likely]]
 		{
 			// Optimistic path (hope that mutex is not exclusively locked)
 			_register_lock(&cpu);
 
-			if (LIKELY(g_mutex.is_lockable()))
+			if (g_mutex.is_lockable()) [[likely]]
 			{
 				return;
 			}
@@ -127,12 +127,12 @@ namespace vm
 
 		atomic_t<u64>* _ret;
 
-		if (LIKELY(test_addr(g_addr_lock.load(), addr, end)))
+		if (test_addr(g_addr_lock.load(), addr, end)) [[likely]]
 		{
 			// Optimistic path (hope that address range is not locked)
 			_ret = _register_range_lock(u64{end} << 32 | addr);
 
-			if (LIKELY(test_addr(g_addr_lock.load(), addr, end)))
+			if (test_addr(g_addr_lock.load(), addr, end)) [[likely]]
 			{
 				return _ret;
 			}
@@ -304,7 +304,7 @@ namespace vm
 	{
 		for (u64 i = 0;; i++)
 		{
-			if (LIKELY(!res.bts(0)))
+			if (!res.bts(0)) [[likely]]
 			{
 				break;
 			}
@@ -527,7 +527,7 @@ namespace vm
 
 		for (u32 i = addr / 4096, max = (addr + size - 1) / 4096; i <= max; i++)
 		{
-			if (UNLIKELY((g_pages[i].flags & flags) != flags))
+			if ((g_pages[i].flags & flags) != flags) [[unlikely]]
 			{
 				return false;
 			}

--- a/rpcs3/Emu/Memory/vm_reservation.h
+++ b/rpcs3/Emu/Memory/vm_reservation.h
@@ -32,7 +32,7 @@ namespace vm
 	{
 		auto& res = vm::reservation_acquire(addr, size);
 
-		if (UNLIKELY(res.bts(0)))
+		if (res.bts(0)) [[unlikely]]
 		{
 			reservation_lock_internal(res);
 		}

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -88,7 +88,7 @@ namespace
 		const u32 iterations = dword_count >> 2;
 		const u32 remaining = dword_count % 4;
 
-		if (LIKELY(s_use_ssse3))
+		if (s_use_ssse3) [[likely]]
 		{
 			for (u32 i = 0; i < iterations; ++i)
 			{
@@ -139,7 +139,7 @@ namespace
 		const u32 iterations = word_count >> 3;
 		const u32 remaining = word_count % 8;
 
-		if (LIKELY(s_use_ssse3))
+		if (s_use_ssse3) [[likely]]
 		{
 			for (u32 i = 0; i < iterations; ++i)
 			{
@@ -199,7 +199,7 @@ namespace
 		else
 			remainder = vertex_count;
 
-		if (LIKELY(s_use_ssse3))
+		if (s_use_ssse3) [[likely]]
 		{
 			for (u32 i = 0; i < iterations; ++i)
 			{
@@ -266,7 +266,7 @@ namespace
 		else
 			remainder = vertex_count;
 
-		if (LIKELY(s_use_ssse3))
+		if (s_use_ssse3) [[likely]]
 		{
 			for (u32 i = 0; i < iterations; ++i)
 			{
@@ -1148,7 +1148,7 @@ namespace
 		rsx::primitive_type draw_mode, bool restart_index_enabled, u32 restart_index,
 		const std::function<bool(rsx::primitive_type)>& expands)
 	{
-		if (LIKELY(!expands(draw_mode)))
+		if (!expands(draw_mode)) [[likely]]
 		{
 			return upload_untouched<T>(src, dst, draw_mode, restart_index_enabled, restart_index);
 		}

--- a/rpcs3/Emu/RSX/Common/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Common/ShaderParam.h
@@ -282,12 +282,12 @@ public:
 		const auto this_size = get_vector_size();
 		const auto other_size = other.get_vector_size();
 
-		if (LIKELY(this_size == other_size))
+		if (this_size == other_size) [[likely]]
 		{
 			return other_var;
 		}
 
-		if (LIKELY(this_size < other_size))
+		if (this_size < other_size) [[likely]]
 		{
 			switch (this_size)
 			{

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -125,7 +125,7 @@ struct copy_unmodified_block_swizzled
 			const u32 size_in_block = padded_width * padded_height * depth * 2;
 			std::vector<U> tmp(size_in_block * words_per_block);
 
-			if (LIKELY(words_per_block == 1))
+			if (words_per_block == 1) [[likely]]
 			{
 				rsx::convert_linear_swizzle_3d<T>(src.data(), tmp.data(), padded_width, padded_height, depth);
 			}

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -113,7 +113,7 @@ namespace rsx
 
 						if (Traits::surface_is_pitch_compatible(old, prev_surface->get_rsx_pitch()))
 						{
-							if (UNLIKELY(old->last_use_tag >= prev_surface->last_use_tag))
+							if (old->last_use_tag >= prev_surface->last_use_tag) [[unlikely]]
 							{
 								invalidated = Traits::get(old);
 							}
@@ -123,10 +123,10 @@ namespace rsx
 
 				Traits::clone_surface(cmd, sink, region.source, new_address, region);
 
-				if (UNLIKELY(invalidated))
+				if (invalidated) [[unlikely]]
 				{
 					// Halfplement the merge by crude inheritance. Should recursively split the memory blocks instead.
-					if (LIKELY(sink->old_contents.empty()))
+					if (sink->old_contents.empty()) [[likely]]
 					{
 						sink->set_old_contents(invalidated);
 					}
@@ -331,7 +331,7 @@ namespace rsx
 				auto this_address = e.first;
 				auto surface = e.second;
 
-				if (UNLIKELY(surface->old_contents.size() == 1))
+				if (surface->old_contents.size() == 1) [[unlikely]]
 				{
 					// Dirty zombies are possible with unused pixel storage subslices and are valid
 					// Avoid double transfer if possible
@@ -404,7 +404,7 @@ namespace rsx
 					auto &object = storage[e.first];
 
 					verify(HERE), !src_offset.x, !src_offset.y, object;
-					if (UNLIKELY(!surface->old_contents.empty()))
+					if (!surface->old_contents.empty()) [[unlikely]]
 					{
 						surface->read_barrier(cmd);
 					}
@@ -660,7 +660,7 @@ namespace rsx
 			}
 
 			const auto rtt_indices = utility::get_rtt_indexes(set_surface_target);
-			if (LIKELY(!rtt_indices.empty()))
+			if (!rtt_indices.empty()) [[likely]]
 			{
 				m_bound_render_targets_config = { rtt_indices.front(), 0 };
 
@@ -689,7 +689,7 @@ namespace rsx
 				Traits::prepare_surface_for_sampling(command_list, std::get<1>(m_bound_depth_stencil));
 			}
 
-			if (LIKELY(address_z))
+			if (address_z) [[likely]]
 			{
 				m_bound_depth_stencil = std::make_pair(address_z,
 					bind_address_as_depth_stencil(command_list, address_z, depth_format, antialias,
@@ -800,7 +800,7 @@ namespace rsx
 			const auto surface_internal_pitch = (required_width * required_bpp);
 
 			// Sanity check
-			if (UNLIKELY(surface_internal_pitch > required_pitch))
+			if (surface_internal_pitch > required_pitch) [[unlikely]]
 			{
 				rsx_log.warning("Invalid 2D region descriptor. w=%d, h=%d, bpp=%d, pitch=%d",
 							required_width, required_height, required_bpp, required_pitch);
@@ -833,13 +833,13 @@ namespace rsx
 					const u32 normalized_surface_width = surface->get_surface_width(rsx::surface_metrics::bytes) / required_bpp;
 					const u32 normalized_surface_height = surface->get_surface_height(rsx::surface_metrics::samples);
 
-					if (LIKELY(range.start >= texaddr))
+					if (range.start >= texaddr) [[likely]]
 					{
 						const auto offset = range.start - texaddr;
 						info.dst_area.y = (offset / required_pitch);
 						info.dst_area.x = (offset % required_pitch) / required_bpp;
 
-						if (UNLIKELY(info.dst_area.x >= required_width || info.dst_area.y >= required_height))
+						if (info.dst_area.x >= required_width || info.dst_area.y >= required_height) [[unlikely]]
 						{
 							// Out of bounds
 							continue;
@@ -857,7 +857,7 @@ namespace rsx
 						info.src_area.y = (offset / pitch);
 						info.src_area.x = (offset % pitch) / required_bpp;
 
-						if (UNLIKELY(info.src_area.x >= normalized_surface_width || info.src_area.y >= normalized_surface_height))
+						if (info.src_area.x >= normalized_surface_width || info.src_area.y >= normalized_surface_height) [[unlikely]]
 						{
 							// Region lies outside the actual texture area, but inside the 'tile'
 							// In this case, a small region lies to the top-left corner, partially occupying the  target
@@ -881,7 +881,7 @@ namespace rsx
 					info.src_area.height = info.dst_area.height = height;
 					info.dst_area.width = width;
 
-					if (auto surface_bpp = surface->get_bpp(); UNLIKELY(surface_bpp != required_bpp))
+					if (auto surface_bpp = surface->get_bpp(); surface_bpp != required_bpp) [[unlikely]]
 					{
 						// Width is calculated in the coordinate-space of the requester; normalize
 						info.src_area.x = (info.src_area.x * required_bpp) / surface_bpp;

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -569,7 +569,7 @@ namespace rsx
 		template <typename T>
 		void transform_samples_to_pixels(area_base<T>& area)
 		{
-			if (LIKELY(spp == 1)) return;
+			if (spp == 1) [[likely]] return;
 
 			area.x1 /= samples_x;
 			area.x2 /= samples_x;
@@ -580,7 +580,7 @@ namespace rsx
 		template <typename T>
 		void transform_pixels_to_samples(area_base<T>& area)
 		{
-			if (LIKELY(spp == 1)) return;
+			if (spp == 1) [[likely]] return;
 
 			area.x1 *= samples_x;
 			area.x2 *= samples_x;
@@ -591,7 +591,7 @@ namespace rsx
 		template <typename T>
 		void transform_samples_to_pixels(T& x1, T& x2, T& y1, T& y2)
 		{
-			if (LIKELY(spp == 1)) return;
+			if (spp == 1) [[likely]] return;
 
 			x1 /= samples_x;
 			x2 /= samples_x;
@@ -602,7 +602,7 @@ namespace rsx
 		template <typename T>
 		void transform_pixels_to_samples(T& x1, T& x2, T& y1, T& y2)
 		{
-			if (LIKELY(spp == 1)) return;
+			if (spp == 1) [[likely]] return;
 
 			x1 *= samples_x;
 			x2 *= samples_x;

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1335,7 +1335,7 @@ namespace rsx
 
 		image_view_type create_temporary_subresource(commandbuffer_type &cmd, deferred_subresource& desc)
 		{
-			if (LIKELY(!desc.do_not_cache))
+			if (!desc.do_not_cache) [[likely]]
 			{
 				const auto found = m_temporary_subresource_cache.equal_range(desc.address);
 				for (auto It = found.first; It != found.second; ++It)
@@ -1431,9 +1431,9 @@ namespace rsx
 			}
 			}
 
-			if (LIKELY(result))
+			if (result) [[likely]]
 			{
-				if (LIKELY(!desc.do_not_cache))
+				if (!desc.do_not_cache) [[likely]]
 				{
 					m_temporary_subresource_cache.insert({ desc.address,{ desc, result } });
 				}
@@ -1485,7 +1485,7 @@ namespace rsx
 			rsx::texture_dimension_extended extended_dimension,
 			surface_store_type& m_rtts, Args&& ... extras)
 		{
-			if (LIKELY(options.is_compressed_format))
+			if (options.is_compressed_format) [[likely]]
 			{
 				// Most mesh textures are stored as compressed to make the most of the limited memory
 				if (auto cached_texture = find_texture_from_dimensions(attr.address, attr.gcm_format, attr.width, attr.height, attr.depth))
@@ -1496,7 +1496,7 @@ namespace rsx
 			else
 			{
 				// Fast lookup for cyclic reference
-				if (UNLIKELY(m_rtts.address_is_bound(attr.address)))
+				if (m_rtts.address_is_bound(attr.address)) [[unlikely]]
 				{
 					if (auto texptr = m_rtts.get_surface_at(attr.address);
 						helpers::check_framebuffer_resource(texptr, attr, extended_dimension))
@@ -1598,7 +1598,7 @@ namespace rsx
 				if (!overlapping_fbos.empty() || !overlapping_locals.empty())
 				{
 					int _pool = -1;
-					if (LIKELY(overlapping_locals.empty()))
+					if (overlapping_locals.empty()) [[likely]]
 					{
 						_pool = 0;
 					}
@@ -1728,7 +1728,7 @@ namespace rsx
 			u8 subsurface_count;
 			size2f scale{ 1.f, 1.f };
 
-			if (LIKELY(!is_swizzled))
+			if (!is_swizzled) [[likely]]
 			{
 				if (attributes.pitch = tex.pitch(); !attributes.pitch)
 				{
@@ -1799,7 +1799,7 @@ namespace rsx
 
 			if (result.validate())
 			{
-				if (UNLIKELY(!result.image_handle))
+				if (!result.image_handle) [[unlikely]]
 				{
 					// Deferred reconstruct
 					result.external_subresource_desc.cache_range = lookup_range;
@@ -1831,7 +1831,7 @@ namespace rsx
 				std::vector<copy_region_descriptor> sections;
 				const bool use_upscaling = (result.upload_context == rsx::texture_upload_context::framebuffer_storage && g_cfg.video.resolution_scale_percent != 100);
 
-				if (UNLIKELY(!helpers::append_mipmap_level(sections, result, attributes, 0, use_upscaling, attributes)))
+				if (!helpers::append_mipmap_level(sections, result, attributes, 0, use_upscaling, attributes)) [[unlikely]]
 				{
 					// Abort if mip0 is not compatible
 					return result;
@@ -1868,7 +1868,7 @@ namespace rsx
 					}
 				}
 
-				if (UNLIKELY(sections.size() == 1))
+				if (sections.size() == 1) [[unlikely]]
 				{
 					return result;
 				}
@@ -1973,7 +1973,7 @@ namespace rsx
 					}
 				}
 
-				if (UNLIKELY((src_h + src.offset_y) > src.height))
+				if ((src_h + src.offset_y) > src.height) [[unlikely]]
 				{
 					// TODO: Special case that needs wrapping around (custom blit)
 					rsx_log.error("Transfer cropped in Y, src_h=%d, offset_y=%d, block_h=%d", src_h, src.offset_y, src.height);
@@ -1982,7 +1982,7 @@ namespace rsx
 					dst_h = u16(src_h * scale_y + 0.000001f);
 				}
 
-				if (UNLIKELY((src_w + src.offset_x) > src.width))
+				if ((src_w + src.offset_x) > src.width) [[unlikely]]
 				{
 					// TODO: Special case that needs wrapping around (custom blit)
 					rsx_log.error("Transfer cropped in X, src_w=%d, offset_x=%d, block_w=%d", src_w, src.offset_x, src.width);
@@ -2086,7 +2086,7 @@ namespace rsx
 				const auto bpp = surf->get_bpp();
 				const bool typeless = (bpp != src_bpp || is_format_convert);
 
-				if (LIKELY(!typeless))
+				if (!typeless) [[likely]]
 				{
 					// Use format as-is
 					typeless_info.src_gcm_format = helpers::get_sized_blit_format(src_is_argb8, src_subres.is_depth);
@@ -2162,7 +2162,7 @@ namespace rsx
 				const auto bpp = dst_subres.surface->get_bpp();
 				const bool typeless = (bpp != dst_bpp || is_format_convert);
 
-				if (LIKELY(!typeless))
+				if (!typeless) [[likely]]
 				{
 					typeless_info.dst_gcm_format = helpers::get_sized_blit_format(dst_is_argb8, dst_subres.is_depth);
 				}
@@ -2194,7 +2194,7 @@ namespace rsx
 				{
 					dst_dimensions.height = std::max(src_subres.surface->get_surface_height(rsx::surface_metrics::samples), dst.height);
 				}
-				else if (LIKELY(dst_dimensions.width == 1280 || dst_dimensions.width == 2560))
+				else if (dst_dimensions.width == 1280 || dst_dimensions.width == 2560) [[likely]]
 				{
 					// Optimizations table based on common width/height pairings. If we guess wrong, the upload resolver will fix it anyway
 					// TODO: Add more entries based on empirical data
@@ -2258,7 +2258,7 @@ namespace rsx
 						continue;
 					}
 
-					if (UNLIKELY(skip_if_collision_exists))
+					if (skip_if_collision_exists) [[unlikely]]
 					{
 						if (surface->get_context() != texture_upload_context::blit_engine_dst)
 						{
@@ -2338,7 +2338,7 @@ namespace rsx
 						}
 					}
 
-					if (LIKELY(cached_dest))
+					if (cached_dest) [[likely]]
 					{
 						typeless_info.dst_gcm_format = cached_dest->get_gcm_format();
 						dst_is_depth_surface = cached_dest->is_depth_texture();
@@ -2445,7 +2445,7 @@ namespace rsx
 					u16 image_width = full_width;
 					u16 image_height = src.height;
 
-					if (LIKELY(dst.scale_x > 0.f && dst.scale_y > 0.f))
+					if (dst.scale_x > 0.f && dst.scale_y > 0.f) [[likely]]
 					{
 						// Loading full image from the corner address
 						// Translate src_area into the declared block
@@ -2566,7 +2566,7 @@ namespace rsx
 				// NOTE: Write flag set to remove all other overlapping regions (e.g shader_read or blit_src)
 				invalidate_range_impl_base(cmd, rsx_range, invalidation_cause::write, std::forward<Args>(extras)...);
 
-				if (LIKELY(use_null_region))
+				if (use_null_region) [[likely]]
 				{
 					bool force_dma_load = false;
 					if ((dst_w * dst_bpp) != dst.pitch)

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -124,7 +124,7 @@ namespace rsx
 
 		static inline u32 get_sized_blit_format(bool _32_bit, bool depth_format)
 		{
-			if (LIKELY(_32_bit))
+			if (_32_bit) [[likely]]
 			{
 				return (!depth_format) ? CELL_GCM_TEXTURE_A8R8G8B8 : CELL_GCM_TEXTURE_DEPTH24_D8;
 			}
@@ -357,7 +357,7 @@ namespace rsx
 			{
 				auto num_surface = out.size();
 
-				if (LIKELY(local.empty()))
+				if (local.empty()) [[likely]]
 				{
 					for (auto& section : fbos)
 					{
@@ -470,8 +470,8 @@ namespace rsx
 				verify(HERE), is_gcm_depth_format(attr2.gcm_format) == is_depth;
 			}
 
-			if (LIKELY(extended_dimension == rsx::texture_dimension_extended::texture_dimension_2d ||
-				extended_dimension == rsx::texture_dimension_extended::texture_dimension_1d))
+			if (extended_dimension == rsx::texture_dimension_extended::texture_dimension_2d ||
+				extended_dimension == rsx::texture_dimension_extended::texture_dimension_1d) [[likely]]
 			{
 				if (extended_dimension == rsx::texture_dimension_extended::texture_dimension_1d)
 				{

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1418,7 +1418,7 @@ namespace rsx
 			u32 mapped_offset, mapped_length;
 			if (real_pitch != rsx_pitch)
 			{
-				if (LIKELY(!valid_offset))
+				if (!valid_offset) [[likely]]
 				{
 					mapped_offset = 0;
 				}

--- a/rpcs3/Emu/RSX/GL/GLCompute.h
+++ b/rpcs3/Emu/RSX/GL/GLCompute.h
@@ -85,7 +85,7 @@ namespace gl
         void run(u32 num_invocations)
         {
 			u32 invocations_x, invocations_y;
-			if (LIKELY(num_invocations <= max_invocations_x))
+			if (num_invocations <= max_invocations_x) [[likely]]
 			{
 				invocations_x = num_invocations;
 				invocations_y = 1;

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -237,7 +237,7 @@ void GLFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 	for (auto &reg_name : output_registers)
 	{
 		const auto type = (reg_name[0] == 'r' || !device_props.has_native_half_support)? "vec4" : half4;
-		if (LIKELY(reg_type == type))
+		if (reg_type == type) [[likely]]
 		{
 			registers += ", " + reg_name + " = " + type + "(0.)";
 		}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -328,13 +328,13 @@ void GLGSRender::end()
 			if (rsx::method_registers.fragment_textures[i].enabled() &&
 				sampler_state->validate())
 			{
-				if (view = sampler_state->image_handle; UNLIKELY(!view))
+				if (view = sampler_state->image_handle; !view) [[unlikely]]
 				{
 					view = m_gl_texture_cache.create_temporary_subresource(cmd, sampler_state->external_subresource_desc);
 				}
 			}
 
-			if (LIKELY(view))
+			if (view) [[likely]]
 			{
 				view->bind();
 
@@ -371,7 +371,7 @@ void GLGSRender::end()
 			if (rsx::method_registers.vertex_textures[i].enabled() &&
 				sampler_state->validate())
 			{
-				if (LIKELY(sampler_state->image_handle))
+				if (sampler_state->image_handle) [[likely]]
 				{
 					sampler_state->image_handle->bind();
 				}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -377,7 +377,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 			const bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
 				!!g_cfg.video.write_color_buffers;
 
-			if (LIKELY(!lock))
+			if (!lock) [[likely]]
 			{
 				m_gl_texture_cache.commit_framebuffer_memory_region(cmd, surface->get_memory_range());
 				continue;

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -464,7 +464,7 @@ namespace gl
 		pixel_unpack_settings unpack_settings;
 		unpack_settings.row_length(0).alignment(4);
 
-		if (LIKELY(is_compressed_format(format)))
+		if (is_compressed_format(format)) [[likely]]
 		{
 			caps.supports_vtc_decoding = gl::get_driver_caps().vendor_NVIDIA;
 
@@ -709,7 +709,7 @@ namespace gl
 
 	bool formats_are_bitcast_compatible(GLenum format1, GLenum format2)
 	{
-		if (LIKELY(format1 == format2))
+		if (format1 == format2) [[likely]]
 		{
 			return true;
 		}
@@ -738,7 +738,7 @@ namespace gl
 	cs_shuffle_base* get_pixel_transform_job(const pixel_buffer_layout& pack_info)
 	{
 		const bool is_depth_stencil = (pack_info.type == GL_UNSIGNED_INT_24_8);
-		if (LIKELY(!is_depth_stencil))
+		if (!is_depth_stencil) [[likely]]
 		{
 			if (!pack_info.swap_bytes)
 			{
@@ -791,7 +791,7 @@ namespace gl
 		// Start pack operation
 		g_typeless_transfer_buffer.bind(buffer::target::pixel_pack);
 
-		if (LIKELY(caps.ARB_compute_shader_supported))
+		if (caps.ARB_compute_shader_supported) [[likely]]
 		{
 			// Raw copy
 			src->copy_to(nullptr, static_cast<texture::format>(pack_info.format), static_cast<texture::type>(pack_info.type), src_region, {});
@@ -808,7 +808,7 @@ namespace gl
 		// Start unpack operation
 		pixel_unpack_settings unpack_settings{};
 
-		if (LIKELY(caps.ARB_compute_shader_supported))
+		if (caps.ARB_compute_shader_supported) [[likely]]
 		{
 			auto src_transform = get_pixel_transform_job(pack_info);
 			auto dst_transform = get_pixel_transform_job(unpack_info);

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -203,7 +203,7 @@ namespace gl
 		{
 			ASSERT(exists());
 
-			if (LIKELY(!miss))
+			if (!miss) [[likely]]
 			{
 				baseclass::on_speculative_flush();
 			}
@@ -313,7 +313,7 @@ namespace gl
 				{
 					verify(HERE), pack_unpack_swap_bytes == false;
 					verify(HERE), real_pitch == (width * 4);
-					if (LIKELY(rsx_pitch == real_pitch))
+					if (rsx_pitch == real_pitch) [[likely]]
 					{
 						rsx::convert_le_d24x8_to_be_d24x8(dst, dst, valid_length / 4, 1);
 					}
@@ -597,7 +597,7 @@ namespace gl
 					surface->transform_samples_to_pixels(src_x, src_w, src_y, src_h);
 				}
 
-				if (UNLIKELY(typeless))
+				if (typeless) [[unlikely]]
 				{
 					const auto src_bpp = slice.src->pitch() / slice.src->width();
 					const u16 convert_w = u16(slice.src->width() * src_bpp) / dst_bpp;
@@ -667,7 +667,7 @@ namespace gl
 
 		gl::texture* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const
 		{
-			if (LIKELY(sections_to_transfer.size() == 1))
+			if (sections_to_transfer.size() == 1) [[likely]]
 			{
 				return sections_to_transfer.front().src;
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -67,7 +67,7 @@ namespace rsx
 
 					num_layers = std::max(num_layers, u32(_cell.outputs.size()));
 
-					if (LIKELY(props.num_cell_hz == 1))
+					if (props.num_cell_hz == 1) [[likely]]
 					{
 						_cell.flags = border_flags::default_cell;
 					}

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -39,7 +39,7 @@ namespace rsx
 			}
 			else
 			{
-				if (u32 put = m_ctrl->put; LIKELY((put & 3) == 0))
+				if (u32 put = m_ctrl->put; (put & 3) == 0) [[likely]]
 				{
 					return put;
 				}
@@ -145,7 +145,7 @@ namespace rsx
 				return;
 			}
 
-			if (UNLIKELY(m_cmd & RSX_METHOD_NON_METHOD_CMD_MASK))
+			if (m_cmd & RSX_METHOD_NON_METHOD_CMD_MASK) [[unlikely]]
 			{
 				if ((m_cmd & RSX_METHOD_OLD_JUMP_CMD_MASK) == RSX_METHOD_OLD_JUMP_CMD ||
 					(m_cmd & RSX_METHOD_NEW_JUMP_CMD_MASK) == RSX_METHOD_NEW_JUMP_CMD ||
@@ -164,7 +164,7 @@ namespace rsx
 
 			// Validate the args ptr if the command attempts to read from it
 			m_args_ptr = RSXIOMem.RealAddr(m_internal_get + 4);
-			if (UNLIKELY(!m_args_ptr))
+			if (!m_args_ptr) [[unlikely]]
 			{
 				// Optional recovery
 				data.reg = FIFO_ERROR;
@@ -283,7 +283,7 @@ namespace rsx
 				if (command.value)
 				{
 					// This is a BEGIN call
-					if (LIKELY(!deferred_primitive))
+					if (!deferred_primitive) [[likely]]
 					{
 						// New primitive block
 						deferred_primitive = command.value;
@@ -322,9 +322,9 @@ namespace rsx
 			}
 			default:
 			{
-				if (UNLIKELY(draw_count))
+				if (draw_count) [[unlikely]]
 				{
-					if (UNLIKELY(m_register_properties[reg] & register_props::always_ignore))
+					if (m_register_properties[reg] & register_props::always_ignore) [[unlikely]]
 					{
 						// Always ignore
 						command.reg = FIFO_DISABLED_COMMAND;
@@ -364,7 +364,7 @@ namespace rsx
 		fifo_ctrl->read(command);
 		const auto cmd = command.reg;
 
-		if (UNLIKELY(cmd & (0xffff0000 | RSX_METHOD_NON_METHOD_CMD_MASK)))
+		if (cmd & (0xffff0000 | RSX_METHOD_NON_METHOD_CMD_MASK)) [[unlikely]]
 		{
 			// Check for special FIFO commands
 			switch (cmd)
@@ -496,7 +496,7 @@ namespace rsx
 
 		do
 		{
-			if (UNLIKELY(capture_current_frame))
+			if (capture_current_frame) [[unlikely]]
 			{
 				const u32 reg = (command.reg & 0xfffc) >> 2;
 				const u32 value = command.value;
@@ -526,7 +526,7 @@ namespace rsx
 				}
 			}
 
-			if (UNLIKELY(m_flattener.is_enabled()))
+			if (m_flattener.is_enabled()) [[unlikely]]
 			{
 				switch(m_flattener.test(command))
 				{

--- a/rpcs3/Emu/RSX/RSXOffload.cpp
+++ b/rpcs3/Emu/RSX/RSXOffload.cpp
@@ -139,7 +139,7 @@ namespace rsx
 
 	bool dma_manager::sync()
 	{
-		if (LIKELY(m_enqueued_count.load() == m_processed_count))
+		if (m_enqueued_count.load() == m_processed_count) [[likely]]
 		{
 			// Nothing to do
 			return true;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2537,7 +2537,7 @@ namespace rsx
 		m_queued_flip.push(buffer);
 		m_queued_flip.skip_frame = skip_current_frame;
 
-		if (LIKELY(!forced))
+		if (!forced) [[likely]]
 		{
 			if (!g_cfg.video.disable_FIFO_reordering)
 			{
@@ -3258,7 +3258,7 @@ namespace rsx
 			{
 				if (!(flags & sync_no_notify))
 				{
-					if (UNLIKELY(query->sync_tag > m_sync_tag))
+					if (query->sync_tag > m_sync_tag) [[unlikely]]
 					{
 						ptimer->sync_hint(FIFO_hint::hint_zcull_sync, query);
 						verify(HERE), m_sync_tag >= query->sync_tag;
@@ -3279,7 +3279,7 @@ namespace rsx
 
 			for (auto It = m_pending_writes.crbegin(); It != m_pending_writes.crend(); ++It)
 			{
-				if (UNLIKELY(stat_id))
+				if (stat_id) [[unlikely]]
 				{
 					if (It->counter_tag != stat_id)
 					{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -196,7 +196,7 @@ namespace rsx
 
 			for (const auto &attrib : locations)
 			{
-				if (LIKELY(attrib.frequency <= 1))
+				if (attrib.frequency <= 1) [[likely]]
 				{
 					_max_index = max_index;
 				}

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -92,12 +92,12 @@ namespace vk
 				set_page_bit(page - base_address, page_bits::dirty);
 			}
 
-			if (UNLIKELY(start > range.start))
+			if (start > range.start) [[unlikely]]
 			{
 				set_page_bit(start - s_page_size, page_bits::nocache);
 			}
 
-			if (UNLIKELY(end < range.end))
+			if (end < range.end) [[unlikely]]
 			{
 				set_page_bit(end + s_page_size, page_bits::nocache);
 			}
@@ -244,7 +244,7 @@ namespace vk
 		const auto limit = local_address + length - 1;
 		auto last_block = (limit & s_dma_block_mask);
 
-		if (LIKELY(first_block == last_block))
+		if (first_block == last_block) [[likely]]
 		{
 			if (auto found = g_dma_pool.find(first_block); found != g_dma_pool.end())
 			{
@@ -333,7 +333,7 @@ namespace vk
 					found->second.flush(range);
 				}
 
-				if (UNLIKELY(sync_end < limit))
+				if (sync_end < limit) [[unlikely]]
 				{
 					// Technically legal but assuming a map->flush usage, this shouldnot happen
 					// Optimizations could in theory batch together multiple transfers though

--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -443,7 +443,7 @@ namespace vk
 
 	bool formats_are_bitcast_compatible(VkFormat format1, VkFormat format2)
 	{
-		if (LIKELY(format1 == format2))
+		if (format1 == format2) [[likely]]
 		{
 			return true;
 		}

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -268,7 +268,7 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 	for (auto &reg_name : output_registers)
 	{
 		const auto type = (reg_name[0] == 'r' || !device_props.has_native_half_support)? "vec4" : half4;
-		if (LIKELY(reg_type == type))
+		if (reg_type == type) [[likely]]
 		{
 			registers += ", " + reg_name + " = " + type + "(0.)";
 		}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1250,11 +1250,11 @@ void VKGSRender::end()
 	}
 
 	// Check for frame resource status here because it is possible for an async flip to happen between begin/end
-	if (UNLIKELY(m_current_frame->flags & frame_context_state::dirty))
+	if (m_current_frame->flags & frame_context_state::dirty) [[unlikely]]
 	{
 		check_present_status();
 
-		if (UNLIKELY(m_current_frame->swap_command_buffer))
+		if (m_current_frame->swap_command_buffer) [[unlikely]]
 		{
 			// Borrow time by using the auxilliary context
 			m_aux_frame_context.grab_resources(*m_current_frame);
@@ -1325,7 +1325,7 @@ void VKGSRender::end()
 		bool update_framebuffer_sourced = false;
 		bool check_for_cyclic_refs = false;
 
-		if (UNLIKELY(surface_store_tag != m_rtts.cache_tag))
+		if (surface_store_tag != m_rtts.cache_tag) [[unlikely]]
 		{
 			update_framebuffer_sourced = true;
 			surface_store_tag = m_rtts.cache_tag;
@@ -1388,7 +1388,7 @@ void VKGSRender::end()
 
 					// Check if non-point filtering can even be used on this format
 					bool can_sample_linear;
-					if (LIKELY(sampler_state->format_class == rsx::format_type::color))
+					if (sampler_state->format_class == rsx::format_type::color) [[likely]]
 					{
 						// Most PS3-like formats can be linearly filtered without problem
 						can_sample_linear = true;
@@ -1635,7 +1635,7 @@ void VKGSRender::end()
 				}
 			}
 
-			if (LIKELY(view))
+			if (view) [[likely]]
 			{
 				m_program->bind_uniform({ fs_sampler_handles[i]->value, view->value, view->image()->current_layout },
 					i,
@@ -2884,7 +2884,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 			const bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
 				!!g_cfg.video.write_color_buffers;
 
-			if (LIKELY(!lock))
+			if (!lock) [[likely]]
 			{
 				m_texture_cache.commit_framebuffer_memory_region(*m_current_command_buffer, surface->get_memory_range());
 				continue;
@@ -3170,7 +3170,7 @@ void VKGSRender::begin_conditional_rendering(const std::vector<rsx::reports::occ
 	size_t first = 0;
 	size_t last;
 
-	if (LIKELY(!partial_eval))
+	if (!partial_eval) [[likely]]
 	{
 		last = sources.size();
 	}

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -533,13 +533,13 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 
 	if (image_to_flip)
 	{
-		if (UNLIKELY(!g_cfg.video.full_rgb_range_output || !rsx::fcmp(avconfig->gamma, 1.f)))
+		if (!g_cfg.video.full_rgb_range_output || !rsx::fcmp(avconfig->gamma, 1.f)) [[unlikely]]
 		{
 			calibration_src = dynamic_cast<vk::viewable_image*>(image_to_flip);
 			verify("Image handle not viewable!" HERE), calibration_src;
 		}
 
-		if (LIKELY(!calibration_src))
+		if (!calibration_src) [[likely]]
 		{
 			vk::copy_scaled_image(*m_current_command_buffer, image_to_flip->value, target_image, image_to_flip->current_layout, target_layout,
 				{ 0, 0, static_cast<s32>(buffer_width), static_cast<s32>(buffer_height) }, aspect_ratio, 1, VK_IMAGE_ASPECT_COLOR_BIT, false);

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -56,7 +56,7 @@ namespace vk
 			// NOTE: This surface can only be in the ATTACHMENT_OPTIMAL layout
 			// The resolve surface can be in any type of access, but we have to assume it is likely in read-only mode like shader read-only
 
-			if (LIKELY(!is_depth_surface()))
+			if (!is_depth_surface()) [[likely]]
 			{
 				verify(HERE), current_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
@@ -91,7 +91,7 @@ namespace vk
 
 			vk::resolve_image(cmd, resolve_surface.get(), this);
 
-			if (LIKELY(!is_depth_surface()))
+			if (!is_depth_surface()) [[likely]]
 			{
 				vk::insert_image_memory_barrier(
 					cmd, this->value,
@@ -129,7 +129,7 @@ namespace vk
 			verify(HERE), !(msaa_flags & rsx::surface_state_flags::require_resolve);
 			VkImageSubresourceRange range = { aspect(), 0, 1, 0, 1 };
 
-			if (LIKELY(!is_depth_surface()))
+			if (!is_depth_surface()) [[likely]]
 			{
 				verify(HERE), current_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
@@ -164,7 +164,7 @@ namespace vk
 
 			vk::unresolve_image(cmd, this, resolve_surface.get());
 
-			if (LIKELY(!is_depth_surface()))
+			if (!is_depth_surface()) [[likely]]
 			{
 				vk::insert_image_memory_barrier(
 					cmd, this->value,
@@ -247,7 +247,7 @@ namespace vk
 			subres.depth = 1;
 			subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<gsl::span<const std::byte>::index_type>(rsx_pitch * surface_height * samples_y) };
 
-			if (LIKELY(g_cfg.video.resolution_scale_percent == 100 && samples() == 1))
+			if (g_cfg.video.resolution_scale_percent == 100 && samples() == 1) [[likely]]
 			{
 				push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 				vk::copy_mipmaped_image_using_buffer(cmd, this, { subres }, gcm_format, false, 1, aspect(), upload_heap, rsx_pitch);
@@ -258,7 +258,7 @@ namespace vk
 				vk::image* content = nullptr;
 				vk::image* final_dst = (samples() > 1) ? get_resolve_target_safe(cmd) : this;
 
-				if (LIKELY(g_cfg.video.resolution_scale_percent == 100))
+				if (g_cfg.video.resolution_scale_percent == 100) [[likely]]
 				{
 					verify(HERE), samples() > 1;
 					content = get_resolve_target_safe(cmd);
@@ -356,7 +356,7 @@ namespace vk
 				return vk::viewable_image::get_view(VK_REMAP_IDENTITY, remap, mask);
 			}
 
-			if (LIKELY(!resolve_surface))
+			if (!resolve_surface) [[likely]]
 			{
 				return vk::viewable_image::get_view(remap_encoding, remap, mask);
 			}
@@ -384,7 +384,7 @@ namespace vk
 				}
 			}
 
-			if (LIKELY(old_contents.empty()))
+			if (old_contents.empty()) [[likely]]
 			{
 				if (state_flags & rsx::surface_state_flags::erase_bkgnd)
 				{
@@ -433,7 +433,7 @@ namespace vk
 				auto src_texture = static_cast<vk::render_target*>(section.source);
 				src_texture->read_barrier(cmd);
 
-				if (LIKELY(src_texture->test()))
+				if (src_texture->test()) [[likely]]
 				{
 					any_valid_writes = true;
 				}
@@ -445,7 +445,7 @@ namespace vk
 				const auto src_bpp = src_texture->get_bpp();
 				rsx::typeless_xfer typeless_info{};
 
-				if (LIKELY(src_texture->info.format == info.format))
+				if (src_texture->info.format == info.format) [[likely]]
 				{
 					verify(HERE), src_bpp == dst_bpp;
 				}
@@ -507,7 +507,7 @@ namespace vk
 				newest_tag = src_texture->last_use_tag;
 			}
 
-			if (UNLIKELY(!any_valid_writes))
+			if (!any_valid_writes) [[unlikely]]
 			{
 				rsx_log.warning("Surface at 0x%x inherited stale references", base_addr);
 
@@ -578,7 +578,7 @@ namespace rsx
 			}
 
 			VkImageUsageFlags usage_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-			if (LIKELY(samples == 1))
+			if (samples == 1) [[likely]]
 			{
 				usage_flags |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 			}
@@ -640,7 +640,7 @@ namespace rsx
 				sample_layout = surface_sample_layout::null;
 			}
 
-			if (LIKELY(samples == 1))
+			if (samples == 1) [[likely]]
 			{
 				usage_flags |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 			}

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -72,7 +72,7 @@ namespace vk
 			}
 			else
 			{
-				if (LIKELY(value >= 0.f))
+				if (value >= 0.f) [[likely]]
 				{
 					return raw;
 				}

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -99,7 +99,7 @@ namespace vk
 
 			// 2. Interleave the separated data blocks with a compute job
 			vk::cs_interleave_task *job;
-			if (LIKELY(!swap_bytes))
+			if (!swap_bytes) [[likely]]
 			{
 				if (src->format() == VK_FORMAT_D24_UNORM_S8_UINT)
 				{
@@ -211,7 +211,7 @@ namespace vk
 			return;
 		}
 
-		if (LIKELY(src != dst))
+		if (src != dst) [[likely]]
 		{
 			src->push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 			dst->push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
@@ -712,9 +712,9 @@ namespace vk
 
 		for (const rsx_subresource_layout &layout : subresource_layout)
 		{
-			if (LIKELY(!heap_align))
+			if (!heap_align) [[likely]]
 			{
-				if (LIKELY(!layout.border))
+				if (!layout.border) [[likely]]
 				{
 					row_pitch = (layout.pitch_in_block * block_size_in_bytes);
 				}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -237,7 +237,7 @@ namespace vk
 						VK_ACCESS_SHADER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
 				}
 
-				if (LIKELY(rsx_pitch == real_pitch))
+				if (rsx_pitch == real_pitch) [[likely]]
 				{
 					VkBufferCopy copy = {};
 					copy.dstOffset = final_mapping.first;
@@ -285,7 +285,7 @@ namespace vk
 
 			src->pop_layout(cmd);
 
-			if (UNLIKELY(synchronized))
+			if (synchronized) [[unlikely]]
 			{
 				// Replace the wait event with a new one to avoid premature signaling!
 				vk::get_resource_manager()->dispose(dma_fence);
@@ -311,7 +311,7 @@ namespace vk
 		{
 			ASSERT(exists());
 
-			if (LIKELY(!miss))
+			if (!miss) [[likely]]
 			{
 				verify(HERE), !synchronized;
 				baseclass::on_speculative_flush();
@@ -609,7 +609,7 @@ namespace vk
 					surface->transform_samples_to_pixels(src_x, src_w, src_y, src_h);
 				}
 
-				if (UNLIKELY(typeless))
+				if (typeless) [[unlikely]]
 				{
 					const auto src_bpp = vk::get_format_texel_width(section.src->format());
 					const u16 convert_w = u16(src_w * src_bpp) / dst_bpp;
@@ -646,7 +646,7 @@ namespace vk
 				// Final aspect mask of the 'final' transfer source
 				const auto new_src_aspect = src_image->aspect();
 
-				if (LIKELY(src_w == section.dst_w && src_h == section.dst_h && transform == rsx::surface_transform::identity))
+				if (src_w == section.dst_w && src_h == section.dst_h && transform == rsx::surface_transform::identity) [[likely]]
 				{
 					VkImageCopy copy_rgn;
 					copy_rgn.srcOffset = { src_x, src_y, 0 };
@@ -674,7 +674,7 @@ namespace vk
 					u16 dst_x = section.dst_x, dst_y = section.dst_y;
 					vk::image* _dst;
 
-					if (LIKELY(src_image->info.format == dst->info.format && section.level == 0))
+					if (src_image->info.format == dst->info.format && section.level == 0) [[likely]]
 					{
 						_dst = dst;
 					}
@@ -725,7 +725,7 @@ namespace vk
 						if (src_w != section.dst_w || src_h != section.dst_h)
 						{
 							// Optionally scale if needed
-							if (UNLIKELY(tmp == _dst))
+							if (tmp == _dst) [[unlikely]]
 							{
 								dst_y = src_h;
 							}
@@ -746,7 +746,7 @@ namespace vk
 						fmt::throw_exception("Unreachable" HERE);
 					}
 
-					if (UNLIKELY(_dst != dst))
+					if (_dst != dst) [[unlikely]]
 					{
 						// Casting comes after the scaling!
 						VkImageCopy copy_rgn;
@@ -767,7 +767,7 @@ namespace vk
 
 		vk::image* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const
 		{
-			if (LIKELY(sections_to_transfer.size() == 1))
+			if (sections_to_transfer.size() == 1) [[likely]]
 			{
 				return sections_to_transfer.front().src;
 			}
@@ -840,7 +840,7 @@ namespace vk
 			VkImageCreateFlags image_flags = (view_type == VK_IMAGE_VIEW_TYPE_CUBE) ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT : 0;
 			VkFormat dst_format = vk::get_compatible_sampler_format(m_formats_support, gcm_format);
 
-			if (LIKELY(!image_flags))
+			if (!image_flags) [[likely]]
 			{
 				image = find_temporary_image(dst_format, w, h, 1, 1);
 			}

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -148,7 +148,7 @@ namespace rsx
 
 			const u32 addr = get_address(offset, ctxt);
 
-			if (LIKELY(g_use_rtm))
+			if (g_use_rtm) [[likely]]
 			{
 				vm::_ref<atomic_be_t<u32>>(addr) = arg;
 			}
@@ -974,7 +974,7 @@ namespace rsx
 				out_pitch = out_bpp * out_w;
 			}
 
-			if (UNLIKELY(in_x == 1 || in_y == 1))
+			if (in_x == 1 || in_y == 1) [[unlikely]]
 			{
 				if (is_block_transfer && in_bpp == out_bpp)
 				{

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -332,7 +332,7 @@ namespace rsx
 		const __m128 scale_vector = _mm_set1_ps(16777214.f);
 
 #if defined (_MSC_VER) || defined (__SSSE3__)
-		if (LIKELY(utils::has_ssse3()))
+		if (utils::has_ssse3()) [[likely]]
 		{
 			const __m128i swap_mask = _mm_set_epi8
 			(
@@ -387,7 +387,7 @@ namespace rsx
 		__m128i* src_ptr = static_cast<__m128i*>(src);
 
 #if defined (_MSC_VER) || defined (__SSSE3__)
-		if (LIKELY(utils::has_ssse3()))
+		if (utils::has_ssse3()) [[likely]]
 		{
 			const __m128i swap_mask = _mm_set_epi8
 			(

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -1112,7 +1112,7 @@ namespace rsx
 
 		void start()
 		{
-			if (UNLIKELY(enabled))
+			if (enabled) [[unlikely]]
 			{
 				last = steady_clock::now();
 			}
@@ -1120,7 +1120,7 @@ namespace rsx
 
 		s64 duration()
 		{
-			if (LIKELY(!enabled))
+			if (!enabled) [[likely]]
 			{
 				return 0ll;
 			}

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -743,7 +743,7 @@ public:
 			{
 				std::invoke(func, _new);
 
-				if (LIKELY(atomic_storage<type>::compare_exchange(m_data, old, _new)))
+				if (atomic_storage<type>::compare_exchange(m_data, old, _new)) [[likely]]
 				{
 					return old;
 				}
@@ -752,7 +752,7 @@ public:
 			{
 				RT ret = std::invoke(func, _new);
 
-				if (LIKELY(!ret || atomic_storage<type>::compare_exchange(m_data, old, _new)))
+				if (!ret || atomic_storage<type>::compare_exchange(m_data, old, _new)) [[likely]]
 				{
 					return {old, std::move(ret)};
 				}
@@ -774,7 +774,7 @@ public:
 			{
 				std::invoke(func, _new);
 
-				if (LIKELY(atomic_storage<type>::compare_exchange(m_data, old, _new)))
+				if (atomic_storage<type>::compare_exchange(m_data, old, _new)) [[likely]]
 				{
 					return;
 				}
@@ -783,7 +783,7 @@ public:
 			{
 				RT result = std::invoke(func, _new);
 
-				if (LIKELY(atomic_storage<type>::compare_exchange(m_data, old, _new)))
+				if (atomic_storage<type>::compare_exchange(m_data, old, _new)) [[likely]]
 				{
 					return result;
 				}
@@ -1095,7 +1095,7 @@ public:
 
 			_new -= 1;
 
-			if (LIKELY(atomic_storage<type>::compare_exchange(m_data, old, _new)))
+			if (atomic_storage<type>::compare_exchange(m_data, old, _new)) [[likely]]
 			{
 				return true;
 			}
@@ -1118,7 +1118,7 @@ public:
 
 			_new += 1;
 
-			if (LIKELY(atomic_storage<type>::compare_exchange(m_data, old, _new)))
+			if (atomic_storage<type>::compare_exchange(m_data, old, _new)) [[likely]]
 			{
 				return true;
 			}
@@ -1231,7 +1231,7 @@ public:
 
 	void lock()
 	{
-		while (UNLIKELY(m_data.bts(BitWidth)))
+		while (m_data.bts(BitWidth)) [[unlikely]]
 		{
 			type old_val = m_data.load();
 
@@ -1258,7 +1258,7 @@ public:
 	{
 		type old_val = m_data.load();
 
-		while (UNLIKELY(is_locked(old_val)))
+		while (is_locked(old_val)) [[unlikely]]
 		{
 			m_data.wait(old_val);
 			old_val = m_data.load();
@@ -1271,7 +1271,7 @@ public:
 	{
 		type old_val = m_data.load();
 
-		while (UNLIKELY(is_locked(old_val) || !m_data.compare_and_swap_test(old_val, clamp_value(reinterpret_cast<type>(value)))))
+		while (is_locked(old_val) || !m_data.compare_and_swap_test(old_val, clamp_value(reinterpret_cast<type>(value)))) [[unlikely]]
 		{
 			m_data.wait(old_val);
 			old_val = m_data.load();
@@ -1286,7 +1286,7 @@ public:
 
 		while (true)
 		{
-			if (UNLIKELY(is_locked(old.m_data)))
+			if (is_locked(old.m_data)) [[unlikely]]
 			{
 				m_data.wait(old.m_data);
 				old.m_data = m_data.load();
@@ -1299,7 +1299,7 @@ public:
 			{
 				std::invoke(func, reinterpret_cast<T&>(_new));
 
-				if (LIKELY(atomic_storage<type>::compare_exchange(m_data, old.m_data, clamp_value(_new.m_data))))
+				if (atomic_storage<type>::compare_exchange(m_data, old.m_data, clamp_value(_new.m_data))) [[likely]]
 				{
 					return;
 				}
@@ -1308,7 +1308,7 @@ public:
 			{
 				RT result = std::invoke(func, reinterpret_cast<T&>(_new));
 
-				if (LIKELY(atomic_storage<type>::compare_exchange(m_data, old.m_data, clamp_value(_new.m_data))))
+				if (atomic_storage<type>::compare_exchange(m_data, old.m_data, clamp_value(_new.m_data))) [[likely]]
 				{
 					return result;
 				}


### PR DESCRIPTION
Use C++20 attributes [[likely]] and [[unlikely]].

The thing is, MSVC seems to implement it in one of the preview releases. But existing macro cannot be able to make use of it, so it needs a rewrite.
GCC 9 also supports [[likely]] and [[unlikely]].