### PR TITLE
AppVeyor: Update to Vulkan 1.2 SDK

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,9 @@ environment:
   LLVMLIBS: https://github.com/RPCS3/llvm/releases/download/continuous-master/llvmlibs.7z
   GLSLANG: https://www.dropbox.com/s/6e8w6t5dxh3ad4l/glslang.7z?dl=1
   COMPATDB: https://rpcs3.net/compatibility?api=v1&export
-  VULKAN_SDK: "C:\\VulkanSDK\\1.1.126.0"
-  VULKAN_SDK_URL: https://sdk.lunarg.com/sdk/download/1.1.126.0/windows/VulkanSDK-1.1.126.0-Installer.exe
-  VULKAN_SDK_SHA: ee86f25580b550390ce46508415e744d62e87e9c0de6cd299998058253a2a4ba
+  VULKAN_SDK: "C:\\VulkanSDK\\1.2.131.1"
+  VULKAN_SDK_URL: https://sdk.lunarg.com/sdk/download/1.2.131.1/windows/VulkanSDK-1.2.131.1-Installer.exe
+  VULKAN_SDK_SHA: a65b968e6d0c888575120ad77037f1b65de8fadf32c593ec49ccf8684a3d88b3
 
 cache:
 - glslang.7z -> appveyor.yml


### PR DESCRIPTION
Updates Vulkan SDK from 1.1.126.0 to 1.2.131.1. Release notes:

- [Vulkan SDK 1.1.130.0](https://vulkan.lunarg.com/doc/sdk/1.1.130.0/windows/release_notes.html)
- [Vulkan SDK 1.2.131.1](https://vulkan.lunarg.com/doc/sdk/1.2.131.1/windows/release_notes.html)

AppVeyor build [passes](https://ci.appveyor.com/project/EwoutH/rpcs3/builds/30583800) on my side, here are the [artifacts](https://ci.appveyor.com/project/EwoutH/rpcs3/builds/30583800/artifacts). Testing is welcome!