### PR TITLE
Qt: Include trailing separators in section split

### DIFF
--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -238,7 +238,8 @@ namespace gui
 		{
 			// get Icon for the gs_frame from path. this handles presumably all possible use cases
 			const QString qpath = qstr(path);
-			const std::string path_list[] = { path, sstr(qpath.section("/", 0, -2)), sstr(qpath.section("/", 0, -3)) };
+			const std::string path_list[] = { path, sstr(qpath.section("/", 0, -2, QString::SectionIncludeTrailingSep)),
+											  sstr(qpath.section("/", 0, -3, QString::SectionIncludeTrailingSep)) };
 
 			for (const std::string& pth : path_list)
 			{


### PR DESCRIPTION
This fixes the case on Windows where one of the paths ends up consisting only of a drive letter and no trailing slash - in which case Windows treats it as "current directory on drive X" and not "root of drive X" and GetFileAttributes throws an invalid param error.

Effectively fixes a crash on Windows when attempting to Open a folder with no game which is either a root drive directory (`C:\`) or a directory directly above it (`C:\games\`).