### PR TITLE
rsx: Misc fixups and improvements

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -157,7 +157,6 @@ private:
 	GLuint get_present_source(gl::present_surface_info* info, const rsx::avconf* avconfig);
 
 public:
-	void read_buffers();
 	void set_viewport();
 	void set_scissor(bool clip_viewport);
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -424,11 +424,7 @@ std::array<std::vector<std::byte>, 2> GLGSRender::copy_depth_stencil_buffer_to_m
 	return {};
 }
 
-void GLGSRender::read_buffers()
-{
-	// TODO
-}
-
+// Render target helpers
 void gl::render_target::clear_memory(gl::command_context& cmd)
 {
 	if (aspect() & gl::image_aspect::depth)
@@ -445,8 +441,35 @@ void gl::render_target::clear_memory(gl::command_context& cmd)
 
 void gl::render_target::load_memory(gl::command_context& cmd)
 {
-	// TODO
-	clear_memory(cmd);
+	const u32 gcm_format = is_depth_surface() ?
+		get_compatible_gcm_format(format_info.gcm_depth_format).first :
+		get_compatible_gcm_format(format_info.gcm_color_format).first;
+
+	rsx_subresource_layout subres{};
+	subres.width_in_block = subres.width_in_texel = surface_width * samples_x;
+	subres.height_in_block = subres.height_in_texel = surface_height * samples_y;
+	subres.pitch_in_block = rsx_pitch / get_bpp();
+	subres.depth = 1;
+	subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<gsl::span<const std::byte>::index_type>(rsx_pitch * surface_height * samples_y) };
+
+	// TODO: MSAA support
+	if (g_cfg.video.resolution_scale_percent == 100 && spp == 1) [[likely]]
+	{
+		gl::upload_texture(id(), gcm_format, surface_width, surface_height, 1, 1,
+			false, rsx::texture_dimension_extended::texture_dimension_2d, { subres });
+	}
+	else
+	{
+		auto tmp = std::make_unique<gl::texture>(GL_TEXTURE_2D, subres.width_in_block, subres.height_in_block, 1, 1, static_cast<GLenum>(get_internal_format()));
+		gl::upload_texture(tmp->id(), gcm_format, surface_width, surface_height, 1, 1,
+			false, rsx::texture_dimension_extended::texture_dimension_2d, { subres });
+
+		gl::g_hw_blitter->scale_image(cmd, tmp.get(), this,
+			{ 0, 0, subres.width_in_block, subres.height_in_block },
+			{ 0, 0, static_cast<int>(width()), static_cast<int>(height()) },
+			!is_depth_surface(),
+			{});
+	}
 }
 
 void gl::render_target::initialize_memory(gl::command_context& cmd, bool /*read_access*/)

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -49,6 +49,10 @@ namespace gl
 	{
 		u16 surface_pixel_size = 0;
 
+		void clear_memory(gl::command_context& cmd);
+		void load_memory(gl::command_context& cmd);
+		void initialize_memory(gl::command_context& cmd, bool read_access);
+
 	public:
 		render_target(GLuint width, GLuint height, GLenum sized_format)
 			: viewable_image(GL_TEXTURE_2D, width, height, 1, 1, sized_format)
@@ -107,9 +111,9 @@ namespace gl
 			return (rsx::apply_resolution_scale(_width, true) == width()) && (rsx::apply_resolution_scale(_height, true) == height());
 		}
 
-		void memory_barrier(gl::command_context& cmd, bool force_init = false);
-		void read_barrier(gl::command_context& cmd) { memory_barrier(cmd, true); }
-		void write_barrier(gl::command_context& cmd) { memory_barrier(cmd, false); }
+		void memory_barrier(gl::command_context& cmd, rsx::surface_access access);
+		void read_barrier(gl::command_context& cmd) { memory_barrier(cmd, rsx::surface_access::read); }
+		void write_barrier(gl::command_context& cmd) { memory_barrier(cmd, rsx::surface_access::write); }
 	};
 
 	struct framebuffer_holder : public gl::fbo, public rsx::ref_counted


### PR DESCRIPTION
- Fixes an unreported bug with OpenGL framebuffer access barriers.
- Adds RCB/RDB to OpenGL which fixes some regressions.
- Fixes an unreported barrier glitch with vulkan when MSAA is disabled.

Fixes https://github.com/RPCS3/rpcs3/issues/7316