### PR TITLE
Enable C++20 for MSVC when using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,11 @@ option(USE_VULKAN "Vulkan render backend" ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/rpcs3/cmake_modules")
 
-set(CMAKE_CXX_STANDARD 17)
+if (MSVC)
+	set(CMAKE_CXX_STANDARD 20)
+else()
+	set(CMAKE_CXX_STANDARD 17)
+endif()
 include(CheckCXXCompilerFlag)
 
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Project files are already using latest c++, so CMake should be updated to match as well. I think other compilers are exluded for a reason, so I'm leaving them out for now.

Fixes obnoxious warning spam when compiling with said combination. No change to end users.