### PR TITLE
Only start the playtime clock if it makes sense

### DIFF
--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -748,7 +748,7 @@ bool gdb_thread::cmd_vcont(gdb_cmd& cmd)
 		ppu->state -= cpu_flag::dbg_pause;
 		//special case if app didn't start yet (only loaded)
 		if (!Emu.IsPaused() && !Emu.IsRunning()) {
-			Emu.Run();
+			Emu.Run(true);
 		}
 		if (Emu.IsPaused()) {
 			Emu.Resume();

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -638,7 +638,7 @@ bool Emulator::BootRsxCapture(const std::string& path)
 	Emu.GetCallbacks().init_gs_render();
 	Emu.GetCallbacks().init_pad_handler("");
 
-	GetCallbacks().on_run();
+	GetCallbacks().on_run(false);
 	m_state = system_state::running;
 
 	g_fxo->init<named_thread<rsx::rsx_replay_thread>>("RSX Replay"sv, std::move(frame));
@@ -1080,7 +1080,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 			GetCallbacks().on_ready();
 			vm::init();
 			g_fxo->init();
-			Run();
+			Run(false);
 			m_force_boot = false;
 
 			// Force LLVM recompiler
@@ -1619,7 +1619,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 
 		if ((m_force_boot || g_cfg.misc.autostart) && IsReady())
 		{
-			Run();
+			Run(true);
 			m_force_boot = false;
 		}
 		else if (IsPaused())
@@ -1635,15 +1635,22 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 	}
 }
 
-void Emulator::Run()
+void Emulator::Run(bool start_playtime)
 {
 	if (!IsReady())
 	{
 		Load();
-		if(!IsReady()) return;
+
+		if (!IsReady())
+		{
+			return;
+		}
 	}
 
-	if (IsRunning()) Stop();
+	if (IsRunning())
+	{
+		Stop();
+	}
 
 	if (IsPaused())
 	{
@@ -1651,7 +1658,7 @@ void Emulator::Run()
 		return;
 	}
 
-	GetCallbacks().on_run();
+	GetCallbacks().on_run(start_playtime);
 
 	m_pause_start_time = 0;
 	m_pause_amend_time = 0;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -208,7 +208,7 @@ enum CellKbMappingType : s32;
 struct EmuCallbacks
 {
 	std::function<void(std::function<void()>)> call_after;
-	std::function<void()> on_run;
+	std::function<void(bool)> on_run; // (start_playtime) continuing or going ingame, so start the clock
 	std::function<void()> on_pause;
 	std::function<void()> on_resume;
 	std::function<void()> on_stop;
@@ -362,7 +362,7 @@ public:
 	void SetForceBoot(bool force_boot);
 
 	void Load(const std::string& title_id = "", bool add_only = false, bool force_global_config = false);
-	void Run();
+	void Run(bool start_playtime);
 	bool Pause();
 	void Resume();
 	void Stop(bool restart = false);

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -55,7 +55,7 @@ void headless_application::InitializeCallbacks()
 	callbacks.get_save_dialog                = []() -> std::unique_ptr<SaveDialogBase> { return std::unique_ptr<SaveDialogBase>(); };
 	callbacks.get_trophy_notification_dialog = []() -> std::unique_ptr<TrophyNotificationBase> { return std::unique_ptr<TrophyNotificationBase>(); };
 
-	callbacks.on_run    = []() {};
+	callbacks.on_run    = [](bool /*start_playtime*/) {};
 	callbacks.on_pause  = []() {};
 	callbacks.on_resume = []() {};
 	callbacks.on_stop   = []() {};

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -153,7 +153,7 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 	case Qt::Key_E:
 		if (keyEvent->modifiers() == Qt::ControlModifier)
 		{
-			if (Emu.IsReady()) { Emu.Run(); return; }
+			if (Emu.IsReady()) { Emu.Run(true); return; }
 			else if (Emu.IsPaused()) { Emu.Resume(); return; }
 		}
 		break;

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -189,7 +189,7 @@ void gui_application::InitializeConnects()
 	}
 
 #ifdef WITH_DISCORD_RPC
-	connect(this, &gui_application::OnEmulatorRun, [this]()
+	connect(this, &gui_application::OnEmulatorRun, [this](bool /*start_playtime*/)
 	{
 		// Discord Rich Presence Integration
 		if (m_gui_settings->GetValue(gui::m_richPresence).toBool())
@@ -280,9 +280,9 @@ void gui_application::InitializeCallbacks()
 	callbacks.get_save_dialog = []() -> std::unique_ptr<SaveDialogBase> { return std::make_unique<save_data_dialog>(); };
 	callbacks.get_trophy_notification_dialog = [this]() -> std::unique_ptr<TrophyNotificationBase> { return std::make_unique<trophy_notification_helper>(m_game_window); };
 
-	callbacks.on_run    = [=]() { OnEmulatorRun(); };
+	callbacks.on_run    = [=](bool start_playtime) { OnEmulatorRun(start_playtime); };
 	callbacks.on_pause  = [=]() { OnEmulatorPause(); };
-	callbacks.on_resume = [=]() { OnEmulatorResume(); };
+	callbacks.on_resume = [=]() { OnEmulatorResume(true); };
 	callbacks.on_stop   = [=]() { OnEmulatorStop(); };
 	callbacks.on_ready  = [=]() { OnEmulatorReady(); };
 
@@ -303,8 +303,13 @@ void gui_application::InitializeCallbacks()
 	Emu.SetCallbacks(std::move(callbacks));
 }
 
-void gui_application::StartPlaytime()
+void gui_application::StartPlaytime(bool start_playtime = true)
 {
+	if (!start_playtime)
+	{
+		return;
+	}
+
 	const QString serial = qstr(Emu.GetTitleID());
 	if (serial.isEmpty())
 	{

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -54,7 +54,7 @@ private:
 	void InitializeCallbacks();
 	void InitializeConnects();
 
-	void StartPlaytime();
+	void StartPlaytime(bool start_playtime);
 	void StopPlaytime();
 
 	QTranslator m_translator;
@@ -75,9 +75,9 @@ private Q_SLOTS:
 	void OnEmuSettingsChange();
 
 Q_SIGNALS:
-	void OnEmulatorRun();
+	void OnEmulatorRun(bool start_playtime);
 	void OnEmulatorPause();
-	void OnEmulatorResume();
+	void OnEmulatorResume(bool start_playtime);
 	void OnEmulatorStop();
 	void OnEmulatorReady();
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -220,7 +220,7 @@ void main_window::OnPlayOrPause()
 {
 	if (Emu.IsReady())
 	{
-		Emu.Run();
+		Emu.Run(true);
 	}
 	else if (Emu.IsPaused())
 	{
@@ -852,7 +852,7 @@ void main_window::RepaintToolBarIcons()
 	ui->mw_searchbar->setFixedWidth(toolBarHeight * 5);
 }
 
-void main_window::OnEmuRun()
+void main_window::OnEmuRun(bool /*start_playtime*/)
 {
 	m_debuggerFrame->EnableButtons(true);
 #ifdef _WIN32
@@ -1815,7 +1815,7 @@ void main_window::keyPressEvent(QKeyEvent *keyEvent)
 	{
 		switch (keyEvent->key())
 		{
-		case Qt::Key_E: if (Emu.IsPaused()) Emu.Resume(); else if (Emu.IsReady()) Emu.Run(); return;
+		case Qt::Key_E: if (Emu.IsPaused()) Emu.Resume(); else if (Emu.IsReady()) Emu.Run(true); return;
 		case Qt::Key_P: if (Emu.IsRunning()) Emu.Pause(); return;
 		case Qt::Key_S: if (!Emu.IsStopped()) Emu.Stop(); return;
 		case Qt::Key_R: if (!Emu.GetBoot().empty()) Emu.Restart(); return;

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -81,7 +81,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
 	void OnEmuStop();
-	void OnEmuRun();
+	void OnEmuRun(bool start_playtime);
 	void OnEmuResume();
 	void OnEmuPause();
 	void OnEmuReady();


### PR DESCRIPTION
Don't update the playtime clock or the last played date on running rsx captures or ppu cache creation.

fixes #7411 