### PR TITLE
Fix Boot inconsistencies for Reloads

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1223,7 +1223,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 			if (fs::rename(elf_dir + "/../../", hdd0_disc + elf_dir.substr(hdd0_game.size()) + "/../../", false))
 			{
 				sys_log.success("Disc game %s moved to special location /dev_hdd0/disc/", m_title_id);
-				return m_path = hdd0_disc + m_path.substr(hdd0_game.size()), Load();
+				return m_path = hdd0_disc + m_path.substr(hdd0_game.size()), Load(m_title_id, add_only, force_global_config);
 			}
 			else
 			{
@@ -1422,7 +1422,7 @@ void Emulator::Load(const std::string& title_id, bool add_only, bool force_globa
 		{
 			// Booting game update
 			sys_log.success("Updates found at /dev_hdd0/game/%s/!", m_title_id);
-			return m_path = hdd0_boot, Load();
+			return m_path = hdd0_boot, Load(m_title_id, false, force_global_config);
 		}
 
 		// Set title to actual disc title if necessary
@@ -1639,6 +1639,8 @@ void Emulator::Run(bool start_playtime)
 {
 	if (!IsReady())
 	{
+		// Reload with global configuration.
+		// TODO: Discuss if this should use the prior configuration instead.
 		Load();
 
 		if (!IsReady())
@@ -1797,6 +1799,8 @@ void Emulator::Stop(bool restart)
 	{
 		if (restart)
 		{
+			// Reload with global configuration.
+			// TODO: Discuss if this should use the prior configuration instead.
 			return Load();
 		}
 
@@ -1841,6 +1845,8 @@ void Emulator::Stop(bool restart)
 
 	if (restart)
 	{
+		// Reload with global configuration.
+		// TODO: Discuss if this should use the prior configuration instead.
 		return Load();
 	}
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -925,6 +925,8 @@ void Emulator::SetForceBoot(bool force_boot)
 
 void Emulator::Load(const std::string& title_id, bool add_only, bool force_global_config)
 {
+	m_force_global_config = force_global_config;
+
 	if (!IsStopped())
 	{
 		Stop();
@@ -1639,9 +1641,8 @@ void Emulator::Run(bool start_playtime)
 {
 	if (!IsReady())
 	{
-		// Reload with global configuration.
-		// TODO: Discuss if this should use the prior configuration instead.
-		Load();
+		// Reload with prior configuration.
+		Load(m_title_id, false, m_force_global_config);
 
 		if (!IsReady())
 		{
@@ -1799,9 +1800,8 @@ void Emulator::Stop(bool restart)
 	{
 		if (restart)
 		{
-			// Reload with global configuration.
-			// TODO: Discuss if this should use the prior configuration instead.
-			return Load();
+			// Reload with prior configs.
+			return Load(m_title_id, false, m_force_global_config);
 		}
 
 		m_force_boot = false;
@@ -1845,9 +1845,8 @@ void Emulator::Stop(bool restart)
 
 	if (restart)
 	{
-		// Reload with global configuration.
-		// TODO: Discuss if this should use the prior configuration instead.
-		return Load();
+		// Reload with prior configs.
+		return Load(m_title_id, false, m_force_global_config);
 	}
 
 	// Boot arg cleanup (preserved in the case restarting)

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -249,6 +249,7 @@ class Emulator final
 	std::string m_usr{"00000001"};
 	u32 m_usrid{1};
 
+	bool m_force_global_config = false;
 	bool m_force_boot = false;
 	bool m_has_gui = true;
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -923,7 +923,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	hide_serial->setChecked(m_hidden_list.contains(serial));
 	myMenu.addSeparator();
 	QMenu* remove_menu = myMenu.addMenu(tr("&Remove"));
-	QAction* removeGame = remove_menu->addAction(tr("&Remove %1").arg(qstr(currGame.category)));
+	QAction* removeGame = remove_menu->addAction(tr("&Remove %1").arg(gameinfo->localized_category));
 	if (gameinfo->hasCustomConfig)
 	{
 		QAction* remove_custom_config = remove_menu->addAction(tr("&Remove Custom Configuration"));
@@ -1076,7 +1076,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 			return;
 		}
 
-		QMessageBox* mb = new QMessageBox(QMessageBox::Question, tr("Confirm %1 Removal").arg(qstr(currGame.category)), tr("Permanently remove %0 from drive?\nPath: %1").arg(name).arg(qstr(currGame.path)), QMessageBox::Yes | QMessageBox::No, this);
+		QMessageBox* mb = new QMessageBox(QMessageBox::Question, tr("Confirm %1 Removal").arg(gameinfo->localized_category), tr("Permanently remove %0 from drive?\nPath: %1").arg(name).arg(qstr(currGame.path)), QMessageBox::Yes | QMessageBox::No, this);
 		mb->setCheckBox(new QCheckBox(tr("Remove caches and custom configs")));
 		mb->deleteLater();
 		if (mb->exec() == QMessageBox::Yes)
@@ -1093,12 +1093,12 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 					RemoveCustomPadConfiguration(currGame.serial);
 				}
 				m_game_data.erase(std::remove(m_game_data.begin(), m_game_data.end(), gameinfo), m_game_data.end());
-				game_list_log.success("Removed %s %s in %s", currGame.category, currGame.name, currGame.path);
+				game_list_log.success("Removed %s %s in %s", sstr(gameinfo->localized_category), currGame.name, currGame.path);
 				Refresh(true);
 			}
 			else
 			{
-				game_list_log.error("Failed to remove %s %s in %s (%s)", currGame.category, currGame.name, currGame.path, fs::g_tls_error);
+				game_list_log.error("Failed to remove %s %s in %s (%s)", sstr(gameinfo->localized_category), currGame.name, currGame.path, fs::g_tls_error);
 				QMessageBox::critical(this, tr("Failure!"), tr(remove_caches ? "Failed to remove %0 from drive!\nPath: %1\nCaches and custom configs have been left intact." : "Failed to remove %0 from drive!\nPath: %1").arg(name).arg(qstr(currGame.path)));
 			}
 		}


### PR DESCRIPTION
Pass requested configuration to recursive game load.
This should fix inconsistencies in used configs when either:
- restarting a game in the GUI
- loading a disc game that has updates installed on dev_hdd0/game
- or loading a disc game that was falsely booted from dev_hdd0/game.

Also fixes game category localization.

fixes #7433 
closes #7435