### PR TITLE
Compilation fix for VSH pr

### DIFF
--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -516,7 +516,7 @@
     <ClInclude Include="Emu\Cell\lv2\sys_uart.h" />
     <ClInclude Include="Emu\Cell\lv2\sys_bdemu.h" />
     <ClInclude Include="Emu\Cell\lv2\sys_console.h" />
-    <ClCompile Include="Emu\Cell\lv2\sys_btsetting.h" />
+    <ClInclude Include="Emu\Cell\lv2\sys_btsetting.h" />
     <ClInclude Include="Emu\Cell\MFC.h" />
     <ClInclude Include="Emu\Cell\PPUModule.h" />
     <ClInclude Include="Emu\Cell\Modules\cellAdec.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -878,9 +878,6 @@
     <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.cpp">
       <Filter>Emu\GPU\RSX\Overlays\Shaders</Filter>
     </ClCompile>
-    <ClCompile Include="Emu\Cell\lv2\sys_btsetting.h">
-      <Filter>Header Files</Filter>
-    </ClCompile>
     <ClCompile Include="Emu\Cell\lv2\sys_crypto_engine.cpp">
       <Filter>Emu\Cell\lv2</Filter>
     </ClCompile>
@@ -1219,6 +1216,9 @@
     <ClInclude Include="Emu\Cell\lv2\sys_crypto_engine.h">
       <Filter>Emu\Cell\lv2</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\Cell\lv2\sys_btsetting.h">
+      <Filter>Emu\Cell\lv2</Filter>
+    </ClCompile>
     <ClInclude Include="Emu\Cell\Modules\cellAdec.h">
       <Filter>Emu\Cell\Modules</Filter>
     </ClInclude>


### PR DESCRIPTION
I'm a dummy, I'll duplicate the description of previous pr (#7419) to show in build updates in discord.
That pr added empty functions stubs used by VSH and missing files for them in order to ease future work on it.