### PR TITLE
[MSVC][props] Move stdcpplatest and FH4 to common_default.props

### DIFF
--- a/common_default.props
+++ b/common_default.props
@@ -8,8 +8,12 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <AdditionalOptions>-d2FH4- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
+    <Link>
+      <AdditionalOptions>-d2:-FH4- %(AdditionalOptions)</AdditionalOptions>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup />
 </Project>

--- a/rpcs3_default.props
+++ b/rpcs3_default.props
@@ -19,14 +19,13 @@
       <SDLCheck>false</SDLCheck>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalOptions>/std:c++latest /Zc:throwingNew -d2FH4- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>xxhash.lib;ws2_32.lib;Bcrypt.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\3rdparty\ffmpeg\windows\x86_64</AdditionalLibraryDirectories>
       <StackReserveSize>8388608</StackReserveSize>
       <StackCommitSize>1048576</StackCommitSize>
-      <AdditionalOptions>-d2:-FH4- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />


### PR DESCRIPTION
This way stdcpplatest  and FH4 disabling propagates to all projects except llvm and glslang.
 - stdcpplatest would need to be changed to stdcpp20 after MS actually adds it as a standard.

Maybe `common_default.props` should be loaded when building llvm and glslang the same way FH4 disabling is implemented for glslang? I wonder if that is a good decision but right now both use default stdcpp where with #7448 when using cmake to generate MSVC solution some projects use default (in VS 2019 it defaults to stdcpp17) and some use latest.