### PR TITLE
GUI Icon improvements

### DIFF
--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -82,6 +82,7 @@ public:
 
 		QPainter painter(this);
 		setDevicePixelRatio(pixel_ratio);
+		painter.setRenderHint(QPainter::Antialiasing);
 		painter.setPen(Qt::NoPen);
 		painter.setBrush(color);
 		painter.drawEllipse(0, 0, width(), height());

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -743,8 +743,8 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 
 	if (m_isListLayout)
 	{
-		int scroll_position = m_gameList->verticalScrollBar()->value();
-		int row = PopulateGameList();
+		const int scroll_position = m_gameList->verticalScrollBar()->value();
+		const int row = PopulateGameList();
 		m_gameList->selectRow(row);
 		SortGameList();
 
@@ -1677,6 +1677,7 @@ QPixmap game_list_frame::PaintedPixmap(const QPixmap& icon, bool paint_config_ic
 	canvas.fill(m_Icon_Color);
 
 	QPainter painter(&canvas);
+	painter.setRenderHint(QPainter::SmoothPixmapTransform);
 
 	if (!icon.isNull())
 	{
@@ -1713,6 +1714,7 @@ QPixmap game_list_frame::PaintedPixmap(const QPixmap& icon, bool paint_config_ic
 		const int spacing = original_size.height() * 0.05;
 		QColor copyColor = QColor(compatibility_color);
 		copyColor.setAlpha(215); // ~85% opacity
+		painter.setRenderHint(QPainter::Antialiasing);
 		painter.setBrush(QBrush(copyColor));
 		painter.drawEllipse(spacing, spacing, size, size);
 	}

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -1,4 +1,4 @@
-#include "game_list_grid.h"
+﻿#include "game_list_grid.h"
 #include "game_list_grid_delegate.h"
 #include "qt_utils.h"
 
@@ -87,6 +87,7 @@ void game_list_grid::addItem(const QPixmap& img, const QString& name, const int&
 
 	// place raw image inside expanded image
 	QPainter painter(&exp_img);
+	painter.setRenderHint(QPainter::SmoothPixmapTransform);
 	painter.drawImage(offset, bg_img);
 	painter.drawPixmap(offset, img);
 	painter.end();

--- a/rpcs3/rpcs3qt/game_list_grid_delegate.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid_delegate.cpp
@@ -20,15 +20,16 @@ void game_list_grid_delegate::initStyleOption(QStyleOptionViewItem * option, con
 	QStyledItemDelegate::initStyleOption(option, QModelIndex());
 }
 
-void game_list_grid_delegate::paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
+void game_list_grid_delegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
 	QRect r = option.rect;
 
+	painter->setRenderHints(QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
 	painter->eraseRect(r);
 
 	// Get title and image
 	QPixmap image = qvariant_cast<QPixmap>(index.data(Qt::DecorationRole));
-	QString title = index.data(Qt::DisplayRole).toString();
+	const QString title = index.data(Qt::DisplayRole).toString();
 
 	// Paint from our stylesheet
 	QStyledItemDelegate::paint(painter, option, index);
@@ -39,9 +40,9 @@ void game_list_grid_delegate::paint(QPainter * painter, const QStyleOptionViewIt
 		painter->drawPixmap(option.rect, image);
 	}
 
-	int h = r.height() / (1 + m_margin_factor + m_margin_factor*m_text_factor);
-	int height = r.height() - h - h * m_margin_factor;
-	int top = r.bottom() - height;
+	const int h = r.height() / (1 + m_margin_factor + m_margin_factor * m_text_factor);
+	const int height = r.height() - h - h * m_margin_factor;
+	const int top = r.bottom() - height;
 
 	// title
 	if (option.state & QStyle::State_Selected)

--- a/rpcs3/rpcs3qt/game_list_grid_delegate.h
+++ b/rpcs3/rpcs3qt/game_list_grid_delegate.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <QPainter>
 #include <QStyledItemDelegate>
@@ -9,7 +9,7 @@ public:
 	game_list_grid_delegate(const QSize& imageSize, const qreal& margin_factor, const qreal& margin_ratio, QObject *parent = 0);
 
 	virtual void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override;
-	void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const override;
 	void setItemSize(const QSize& size);
 	virtual ~game_list_grid_delegate();

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -608,33 +608,43 @@ void pad_settings_dialog::ReactivateButtons()
 	ui->chooseClass->setFocusPolicy(Qt::WheelFocus);
 }
 
-void pad_settings_dialog::RepaintPreviewLabel(QLabel* l, int dz, int w, int x, int y)
+void pad_settings_dialog::RepaintPreviewLabel(QLabel* l, int deadzone, int desired_width, int x, int y)
 {
-	int max = m_handler->thumb_max;
-	int origin = w * 0.1;
-	int width = w * 0.8;
-	int dz_width = width * dz / max;
-	int dz_origin = (w - dz_width) / 2;
+	const int deadzone_max = m_handler->thumb_max;
+	const qreal device_pixel_ratio = devicePixelRatioF();
+	const qreal scaled_width = desired_width * device_pixel_ratio;
+	const qreal origin = desired_width / 2.0;
+	const qreal relative_size = 0.8;
+	const qreal outer_circle_diameter = relative_size * desired_width;
+	const qreal inner_circle_diameter = outer_circle_diameter * deadzone / deadzone_max;
+	const qreal outer_circle_radius = outer_circle_diameter / 2.0;
+	const qreal stick_x = outer_circle_radius * x / deadzone_max;
+	const qreal stick_y = outer_circle_radius * -y / deadzone_max;
 
-	x = (w + (x * width / max)) / 2;
-	y = (w + (y * -1 * width / max)) / 2;
+	// Set up the canvas for our work of art
+	QPixmap pixmap(scaled_width, scaled_width);
+	pixmap.setDevicePixelRatio(device_pixel_ratio);
+	pixmap.fill(Qt::transparent);
 
-	QPixmap pm(w, w);
-	pm.fill(Qt::transparent);
-	QPainter p(&pm);
-	p.setRenderHint(QPainter::Antialiasing, true);
-	QPen pen(Qt::black, 2);
-	p.setPen(pen);
-	QBrush brush(Qt::white);
-	p.setBrush(brush);
-	p.drawEllipse(origin, origin, width, width);
-	pen = QPen(Qt::red, 2);
-	p.setPen(pen);
-	p.drawEllipse(dz_origin, dz_origin, dz_width, dz_width);
-	pen = QPen(Qt::blue, 2);
-	p.setPen(pen);
-	p.drawEllipse(x, y, 1, 1);
-	l->setPixmap(pm);
+	// Configure the painter and set its origin
+	QPainter painter(&pixmap);
+	painter.setRenderHint(QPainter::Antialiasing, true);
+	painter.translate(origin, origin);
+	painter.setBrush(QBrush(Qt::white));
+
+	// Draw a black outer circle that represents the maximum for the deadzone
+	painter.setPen(QPen(Qt::black, 2));
+	painter.drawEllipse(QRectF(-outer_circle_diameter / 2.0, -outer_circle_diameter / 2.0, outer_circle_diameter, outer_circle_diameter));
+
+	// Draw a red inner circle that represents the current deadzone
+	painter.setPen(QPen(Qt::red, 2));
+	painter.drawEllipse(QRectF(-inner_circle_diameter / 2.0, -inner_circle_diameter / 2.0, inner_circle_diameter, inner_circle_diameter));
+
+	// Draw a blue dot that represents the current stick orientation
+	painter.setPen(QPen(Qt::blue, 2));
+	painter.drawEllipse(QRectF(stick_x, stick_y, 1, 1));
+
+	l->setPixmap(pixmap);
 }
 
 void pad_settings_dialog::keyPressEvent(QKeyEvent *keyEvent)

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -167,7 +167,7 @@ private:
 	void ChangeProfile();
 
 	/** Repaints a stick deadzone preview label */
-	void RepaintPreviewLabel(QLabel* l, int dz, int w, int x, int y);
+	void RepaintPreviewLabel(QLabel* l, int deadzone, int desired_width, int x, int y);
 
 	std::shared_ptr<PadHandlerBase> GetHandler(pad_handler type);
 

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -84,6 +84,7 @@ namespace gui
 				white_pixmap.setMask(white_mask);
 
 				QPainter painter(&pixmap);
+				painter.setRenderHint(QPainter::SmoothPixmapTransform);
 				painter.drawPixmap(QPoint(0, 0), white_pixmap);
 				//painter.drawPixmap(QPoint(0, 0), test_pixmap);
 				painter.end();
@@ -239,7 +240,7 @@ namespace gui
 			// get Icon for the gs_frame from path. this handles presumably all possible use cases
 			const QString qpath = qstr(path);
 			const std::string path_list[] = { path, sstr(qpath.section("/", 0, -2, QString::SectionIncludeTrailingSep)),
-											  sstr(qpath.section("/", 0, -3, QString::SectionIncludeTrailingSep)) };
+			                                  sstr(qpath.section("/", 0, -3, QString::SectionIncludeTrailingSep)) };
 
 			for (const std::string& pth : path_list)
 			{
@@ -254,19 +255,20 @@ namespace gui
 				{
 					// load the image from path. It will most likely be a rectangle
 					QImage source = QImage(qstr(ico));
-					int edgeMax = std::max(source.width(), source.height());
+					const int edge_max = std::max(source.width(), source.height());
 
 					// create a new transparent image with square size and same format as source (maybe handle other formats than RGB32 as well?)
 					QImage::Format format = source.format() == QImage::Format_RGB32 ? QImage::Format_ARGB32 : source.format();
-					QImage dest = QImage(edgeMax, edgeMax, format);
-					dest.fill(QColor("transparent"));
+					QImage dest = QImage(edge_max, edge_max, format);
+					dest.fill(Qt::transparent);
 
 					// get the location to draw the source image centered within the dest image.
-					QPoint destPos = source.width() > source.height() ? QPoint(0, (source.width() - source.height()) / 2) : QPoint((source.height() - source.width()) / 2, 0);
+					const QPoint dest_pos = source.width() > source.height() ? QPoint(0, (source.width() - source.height()) / 2) : QPoint((source.height() - source.width()) / 2, 0);
 
 					// Paint the source into/over the dest
 					QPainter painter(&dest);
-					painter.drawImage(destPos, source);
+					painter.setRenderHint(QPainter::SmoothPixmapTransform);
+					painter.drawImage(dest_pos, source);
 					painter.end();
 
 					return QIcon(QPixmap::fromImage(dest));

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -344,6 +344,7 @@ QPixmap save_manager_dialog::GetResizedIcon(int i)
 	icon.fill(m_icon_color);
 
 	QPainter painter(&icon);
+	painter.setRenderHint(QPainter::SmoothPixmapTransform);
 	painter.drawPixmap(0, 0, data);
 	return icon.scaled(width, height, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 }

--- a/rpcs3/rpcs3qt/table_item_delegate.h
+++ b/rpcs3/rpcs3qt/table_item_delegate.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <QStyledItemDelegate>
 #include <QPainter>
@@ -26,7 +26,7 @@ public:
 		QStyledItemDelegate::initStyleOption(option, index);
 	}
 
-	virtual void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const override
+	virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
 	{
 		if (index.column() == 0 && option.state & QStyle::State_Selected)
 		{

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -505,6 +505,7 @@ QPixmap trophy_manager_dialog::GetResizedGameIcon(int index)
 	if (!icon.isNull())
 	{
 		QPainter painter(&new_icon);
+		painter.setRenderHint(QPainter::SmoothPixmapTransform);
 		painter.drawPixmap(QPoint(0, 0), icon);
 		painter.end();
 	}
@@ -569,6 +570,7 @@ void trophy_manager_dialog::ResizeTrophyIcons()
 		if (!icon.isNull())
 		{
 			QPainter painter(&new_icon);
+			painter.setRenderHint(QPainter::SmoothPixmapTransform);
 			painter.drawPixmap(QPoint(0, 0), icon);
 			painter.end();
 		}


### PR DESCRIPTION
I read on discord that some icons looked like crap with the "new high dpi settings" and that we should revert those changes.

So I tried it on my end and set my windows 10 scaling to 125% and it seems they looked bad after all.

#### Improvements
- game list icons (including the colored circle for game compatibility)
- game grid icons and font (including the colored circle for game compatibility and the custom config icons)
- trophy manager icons
- the save manager icons
- and last but not least the stick deadzones in the pad settings dialog

#### Old vs. New

![icon overhaul](https://user-images.githubusercontent.com/23019877/74111105-5fa24580-4b92-11ea-906b-ad1e6bf034e9.png)
