### PR TITLE
New Travis fun things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-matrix:
+jobs:
     include:
 #        - os: linux
 #          env:
@@ -17,15 +17,10 @@ matrix:
             - DEPLOY_APPIMAGE="true"
           services: docker
           cache: ccache
-          install: "docker pull rpcs3/rpcs3-travis-xenial:1.0"
-          addons:
-            apt:
-              packages:
-                - libsdl2-2.0
-                - libsdl2-dev          
-          script: 'travis_wait docker run -v $(pwd):/rpcs3 -v "$HOME/.ccache":/root/.ccache --env-file .travis/travis.env rpcs3/rpcs3-travis-xenial:1.0 /bin/bash -ex /rpcs3/.travis/build-linux.bash'
+          install: "docker pull rpcs3/rpcs3-travis-xenial:1.2"    
+          script: 'travis_wait docker run -v $(pwd):/rpcs3 -v "$HOME/.ccache":/root/.ccache --env-file .travis/travis.env rpcs3/rpcs3-travis-xenial:1.2 /bin/bash -ex /rpcs3/.travis/build-linux.bash'
         - os: osx
-          osx_image: xcode10.2
+          osx_image: xcode11.3
           addons:
             homebrew:
                 packages:

--- a/.travis/build-linux.bash
+++ b/.travis/build-linux.bash
@@ -26,7 +26,7 @@ else
 	export CXX=${CLANGXX_BINARY}
 fi
 
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_LLVM_SUBMODULE=OFF -DLLVM_DIR=llvmlibs/lib/cmake/llvm/ -DUSE_NATIVE_INSTRUCTIONS=OFF -G Ninja
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_LLVM_SUBMODULE=OFF -DLLVM_DIR=llvmlibs/lib/cmake/llvm/ -DUSE_NATIVE_INSTRUCTIONS=OFF -DUSE_FAUDIO=OFF -G Ninja
 
 ninja; build_status=$?;
 


### PR DESCRIPTION
The changes to the docker since xenial 1.0 are as follows:
- CMake bumped to 3.16.4
- Vulkan headers and libraries bumped to 1.1.126
- Vulkan headers and libraries are now built from source, rather than based on a package
- Clang bumped to 10
- LLD added
- GCC bumped to 9
- Qt bumped to 5.14.1
- SDL2 actually added to the docker, allowed compilation test for FAudio backend.
- Qt5Svg package was specifically installed. Hopefully should fix issue #6986 

Changes to the actual repo:
- glslang submodule bumped, for some reason it wouldn't compile with clang 10.
- Xcode bumped for no particular reason.
- FAudio backend was specifically disabled. Previously it just failed to build due to missing SDL2 dependency. Now it builds fine, but it doesn't package nicely, I'm going to be looking into upstreaming some fixes for this.