### PR TITLE
Set mininum Qt version to 5.14

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,11 +9,11 @@ Other instructions may be found [here](https://wiki.rpcs3.net/index.php?title=Bu
 
 * [CMake 3.14.1+](https://www.cmake.org/download/) (add to PATH)
 * [Python 3.3+](https://www.python.org/downloads/) (add to PATH)
-* [Qt 5.11+](https://www.qt.io/download-qt-installer) (Avoid 5.11.1, due to a bug)
+* [Qt 5.14+](https://www.qt.io/download-qt-installer)
 * [Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community)
 * [Vulkan SDK 1.1.97.0+](https://vulkan.lunarg.com/sdk/home) (See "Install the SDK" [here](https://vulkan.lunarg.com/doc/sdk/latest/windows/getting_started.html))
 
-**Either add the** `QTDIR` **environment variable, e.g.** `<QtInstallFolder>\5.11.0\msvc2017_64\` **, or use the [Visual Studio Qt Plugin](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools-19123)**
+**Either add the** `QTDIR` **environment variable, e.g.** `<QtInstallFolder>\5.14.1\msvc2017_64\` **, or use the [Visual Studio Qt Plugin](https://marketplace.visualstudio.com/items?itemName=TheQtCompany.QtVisualStudioTools-19123)**
 
 ### Linux
 
@@ -21,7 +21,7 @@ These are the essentials tools to build RPCS3 on Linux. Some of them can be inst
 
 * Clang 5.0+ or GCC 8.1+
 * [CMake 3.8.2+](https://www.cmake.org/download/)
-* [Qt 5.11+](https://www.qt.io/download-qt-installer) (Avoid 5.11.1, due to a bug)
+* [Qt 5.14+](https://www.qt.io/download-qt-installer)
 * [Vulkan SDK 1.1.97.0+](https://vulkan.lunarg.com/sdk/home) (See "Install the SDK" [here](https://vulkan.lunarg.com/doc/sdk/latest/linux/getting_started.html))
 * [SDL2](https://www.libsdl.org/download-2.0.php) (for the FAudio backend)
 
@@ -92,7 +92,7 @@ git submodule update --init
 #### Configuring the Qt plugin (if used)
 
 1) Go to the Qt5 menu and edit Qt5 options.
-2) Add the path to your Qt installation with compiler e.g. `<QtInstallFolder>\5.11.0\msvc2017_64`.
+2) Add the path to your Qt installation with compiler e.g. `<QtInstallFolder>\5.14.1\msvc2017_64`.
 3) While selecting the rpcs3qt project, go to Qt5->Project Setting and select the version you added.
 
 #### Building the projects

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -129,19 +129,13 @@ QCoreApplication* createApplication(int& argc, char* argv[])
 		const auto i_hdpi_2 = (argc > (i_hdpi + 1)) ? (i_hdpi + 1) : 0;
 		const auto high_dpi_setting = (i_hdpi_2 && !strcmp(cmp_str.c_str(), argv[i_hdpi_2])) ? "0" : "1";
 
-#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
-		// Set QT_AUTO_SCREEN_SCALE_FACTOR from environment. Defaults to cli argument, which defaults to 1.
-		use_high_dpi = "1" == qEnvironmentVariable("QT_AUTO_SCREEN_SCALE_FACTOR", high_dpi_setting);
-#else
 		// Set QT_ENABLE_HIGHDPI_SCALING from environment. Defaults to cli argument, which defaults to 1.
 		use_high_dpi = "1" == qEnvironmentVariable("QT_ENABLE_HIGHDPI_SCALING", high_dpi_setting);
-#endif
 	}
 
 	// AA_EnableHighDpiScaling has to be set before creating a QApplication
 	QApplication::setAttribute(use_high_dpi ? Qt::AA_EnableHighDpiScaling : Qt::AA_DisableHighDpiScaling);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 	if (use_high_dpi)
 	{
 		// Set QT_SCALE_FACTOR_ROUNDING_POLICY from environment. Defaults to cli argument, which defaults to RoundPreferFloor.
@@ -193,7 +187,6 @@ QCoreApplication* createApplication(int& argc, char* argv[])
 		}
 		QApplication::setHighDpiScaleFactorRoundingPolicy(rounding_val);
 	}
-#endif
 
 	return new gui_application(argc, argv);
 }
@@ -235,9 +228,7 @@ int main(int argc, char** argv)
 	parser.addOption(QCommandLineOption(arg_headless, "Run RPCS3 in headless mode."));
 	parser.addOption(QCommandLineOption(arg_no_gui, "Run RPCS3 without its GUI."));
 	parser.addOption(QCommandLineOption(arg_high_dpi, "Enables Qt High Dpi Scaling.", "enabled", "1"));
-#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 	parser.addOption(QCommandLineOption(arg_rounding, "Sets the Qt::HighDpiScaleFactorRoundingPolicy for values like 150% zoom.", "rounding", "4"));
-#endif
 	parser.addOption(QCommandLineOption(arg_styles, "Lists the available styles."));
 	parser.addOption(QCommandLineOption(arg_style, "Loads a custom style.", "style", ""));
 	parser.addOption(QCommandLineOption(arg_stylesheet, "Loads a custom stylesheet.", "path", ""));

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -505,11 +505,7 @@ void emu_settings::EnhanceSpinBox(QSpinBox* spinbox, SettingsType type, const QS
 	spinbox->setRange(min, max);
 	spinbox->setValue(val);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
 	connect(spinbox, &QSpinBox::textChanged, [=](const QString&/* text*/)
-#else
-	connect(spinbox, QOverload<const QString &>::of(&QSpinBox::valueChanged), [=](const QString&/* value*/)
-#endif
 	{
 		SetSetting(type, sstr(spinbox->cleanText()));
 	});
@@ -551,11 +547,7 @@ void emu_settings::EnhanceDoubleSpinBox(QDoubleSpinBox* spinbox, SettingsType ty
 	spinbox->setRange(min, max);
 	spinbox->setValue(val);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
 	connect(spinbox, &QDoubleSpinBox::textChanged, [=](const QString&/* text*/)
-#else
-	connect(spinbox, QOverload<const QString &>::of(&QDoubleSpinBox::valueChanged), [=](const QString&/* value*/)
-#endif
 	{
 		SetSetting(type, sstr(spinbox->cleanText()));
 	});

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -16,11 +16,7 @@ namespace gui
 		template<typename T>
 		static QSet<T> list_to_set(const QList<T>& list)
 		{
-#if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
 			return QSet<T>(list.begin(), list.end());
-#else
-			return QSet<T>::fromList(list);
-#endif
 		}
 
 		// Creates a frame geometry rectangle with given width height that's centered inside the origin,


### PR DESCRIPTION
Sets the mininum Qt version to 5.14, since both travis and appveyor are now on Qt 5.14.

Needs #7459 to be merged first.

fixes #6107
fixes #7204