### PR TITLE
geometry.h: make conversion operators explicit

### DIFF
--- a/Utilities/geometry.h
+++ b/Utilities/geometry.h
@@ -115,7 +115,7 @@ struct size2_base
 #endif
 
 	template<typename NT>
-	constexpr operator size2_base<NT>() const
+	explicit constexpr operator size2_base<NT>() const
 	{
 		return{ static_cast<NT>(width), static_cast<NT>(height) };
 	}
@@ -226,7 +226,7 @@ struct position1_base
 	}
 
 	template<typename NT>
-	operator position1_base<NT>() const
+	explicit operator position1_base<NT>() const
 	{
 		return{ static_cast<NT>(x) };
 	}
@@ -399,7 +399,7 @@ struct position2_base
 	}
 
 	template<typename NT>
-	constexpr operator position2_base<NT>() const
+	explicit constexpr operator position2_base<NT>() const
 	{
 		return{ static_cast<NT>(x), static_cast<NT>(y) };
 	}
@@ -491,7 +491,7 @@ struct position3_base
 	}
 
 	template<typename NT>
-	operator position3_base<NT>() const
+	explicit operator position3_base<NT>() const
 	{
 		return{ static_cast<NT>(x), static_cast<NT>(y), static_cast<NT>(z) };
 	}
@@ -581,7 +581,7 @@ struct position4_base
 	}
 
 	template<typename NT>
-	constexpr operator position4_base<NT>() const
+	explicit constexpr operator position4_base<NT>() const
 	{
 		return{ static_cast<NT>(x), static_cast<NT>(y), static_cast<NT>(z), static_cast<NT>(w) };
 	}
@@ -656,7 +656,7 @@ struct coord_base
 #endif
 
 	template<typename NT>
-	constexpr operator coord_base<NT>() const
+	explicit constexpr operator coord_base<NT>() const
 	{
 		return{ static_cast<NT>(x), static_cast<NT>(y), static_cast<NT>(width), static_cast<NT>(height) };
 	}
@@ -765,7 +765,7 @@ struct area_base
 	}
 
 	template<typename NT>
-	constexpr operator area_base<NT>() const
+	explicit constexpr operator area_base<NT>() const
 	{
 		return{ static_cast<NT>(x1), static_cast<NT>(y1), static_cast<NT>(x2), static_cast<NT>(y2) };
 	}
@@ -828,7 +828,7 @@ struct coord3_base
 	}
 
 	template<typename NT>
-	constexpr operator coord3_base<NT>() const
+	explicit constexpr operator coord3_base<NT>() const
 	{
 		return{ static_cast<NT>(x), static_cast<NT>(y), static_cast<NT>(z), static_cast<NT>(width), static_cast<NT>(height), static_cast<NT>(depth) };
 	}
@@ -922,7 +922,7 @@ struct color4_base
 	}
 
 	template<typename NT>
-	constexpr operator color4_base<NT>() const
+	explicit constexpr operator color4_base<NT>() const
 	{
 		return{ static_cast<NT>(x), static_cast<NT>(y), static_cast<NT>(z), static_cast<NT>(w) };
 	}
@@ -967,7 +967,7 @@ struct color3_base
 #endif
 
 	template<typename NT>
-	constexpr operator color3_base<NT>() const
+	explicit constexpr operator color3_base<NT>() const
 	{
 		return{ static_cast<NT>(x), static_cast<NT>(y), static_cast<NT>(z) };
 	}
@@ -1012,7 +1012,7 @@ struct color2_base
 #endif
 
 	template<typename NT>
-	constexpr operator color2_base<NT>() const
+	explicit constexpr operator color2_base<NT>() const
 	{
 		return{ static_cast<NT>(x), static_cast<NT>(y) };
 	}
@@ -1046,7 +1046,7 @@ struct color1_base
 #endif
 
 	template<typename NT>
-	constexpr operator color1_base<NT>() const
+	explicit constexpr operator color1_base<NT>() const
 	{
 		return{ static_cast<NT>(x) };
 	}

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -398,7 +398,7 @@ namespace gl
 				{
 					const coord3i src_region = { { src_rect.x1, src_rect.y1, 0 }, { src_rect.width(), src_rect.height(), 1 } };
 					const coord3i dst_region = { { dst_rect.x1, dst_rect.y1, 0 }, { dst_rect.width(), dst_rect.height(), 1 } };
-					gl::copy_typeless(dst, src, dst_region, src_region);
+					gl::copy_typeless(dst, src, static_cast<coord3u>(dst_region), static_cast<coord3u>(src_region));
 				}
 				else
 				{

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -311,7 +311,7 @@ namespace gl
 			saved_sampler_state saved(31, m_sampler);
 			glBindTexture(GL_TEXTURE_2D, source->id());
 
-			overlay_pass::run(dst_area, target->id(), true);
+			overlay_pass::run(static_cast<areau>(dst_area), target->id(), true);
 		}
 	};
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -811,7 +811,7 @@ namespace rsx
 						else if (item_y_limit > h || item_y_base < 0)
 						{
 							// Partial render
-							areaf clip_rect = areai{ x, y, (x + w), (y + h) };
+							areaf clip_rect = static_cast<areaf>(areai{x, y, (x + w), (y + h)});
 							result.add(item->get_compiled(), 0.f, global_y_offset, clip_rect);
 						}
 						else
@@ -885,7 +885,7 @@ namespace rsx
 						else if (item_x_limit > h || item_x_base < 0)
 						{
 							// Partial render
-							areaf clip_rect = areai{ x, y, (x + w), (y + h) };
+							areaf clip_rect = static_cast<areaf>(areai{x, y, (x + w), (y + h)});
 							result.add(item->get_compiled(), global_x_offset, 0.f, clip_rect);
 						}
 						else

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -461,7 +461,7 @@ namespace vk
 			src_scale_x = static_cast<f32>(src_area.x2) / real_src->width();
 			src_scale_y = static_cast<f32>(src_area.y2) / real_src->height();
 
-			overlay_pass::run(cmd, dst_area, dst, src, render_pass);
+			overlay_pass::run(cmd, static_cast<areau>(dst_area), dst, src, render_pass);
 		}
 	};
 

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -493,7 +493,7 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 
 	// Calculate output dimensions. Done after swapchain acquisition in case it was recreated.
 	coordi aspect_ratio;
-	sizei csize = m_swapchain_dims;
+	sizei csize = static_cast<sizei>(m_swapchain_dims);
 	sizei new_size = csize;
 
 	if (!g_cfg.video.stretch_to_display_area)


### PR DESCRIPTION
It requires static_cast<> to call them.