### PR TITLE
rsx: zcull fix, cellGcm regression fix after #7262, FIFO recovery improvements

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -49,11 +49,6 @@ namespace rsx
 			}
 		}
 
-		void FIFO_control::set_put(u32 put)
-		{
-			m_ctrl->put = put;
-		}
-
 		void FIFO_control::set_get(u32 get)
 		{
 			if (m_ctrl->get == get)
@@ -401,7 +396,7 @@ namespace rsx
 			}
 			case FIFO::FIFO_ERROR:
 			{
-				rsx_log.error("FIFO error: possible desync event (last cmd = 0x%x)", fifo_ctrl->last_cmd());
+				rsx_log.error("FIFO error: possible desync event (last cmd = 0x%x)", get_fifo_cmd());
 				recover_fifo();
 				return;
 			}
@@ -451,8 +446,8 @@ namespace rsx
 				if (fifo_ret_addr != RSX_CALL_STACK_EMPTY)
 				{
 					// Only one layer is allowed in the call stack.
-					rsx_log.error("FIFO: CALL found inside a subroutine. Discarding subroutine");
-					fifo_ctrl->set_get(std::exchange(fifo_ret_addr, RSX_CALL_STACK_EMPTY));
+					rsx_log.error("FIFO: CALL found inside a subroutine (last cmd = 0x%x)", get_fifo_cmd());
+					recover_fifo();
 					return;
 				}
 
@@ -465,8 +460,8 @@ namespace rsx
 			{
 				if (fifo_ret_addr == RSX_CALL_STACK_EMPTY)
 				{
-					rsx_log.error("FIFO: RET found without corresponding CALL. Discarding queue");
-					fifo_ctrl->set_get(ctrl->put);
+					rsx_log.error("FIFO: RET found without corresponding CALL (last cmd = 0x%x)", get_fifo_cmd());
+					recover_fifo();
 					return;
 				}
 

--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -113,7 +113,7 @@ namespace rsx
 		{
 		private:
 			RsxDmaControl* m_ctrl = nullptr;
-			rsx::rsx_iomap_table* m_iotable;
+			const rsx::rsx_iomap_table* m_iotable;
 			u32 m_internal_get = 0;
 
 			u32 m_memwatch_addr = 0;
@@ -129,12 +129,11 @@ namespace rsx
 			FIFO_control(rsx::thread* pctrl);
 			~FIFO_control() = default;
 
-			u32 get_pos() { return m_internal_get; }
-			u32 last_cmd() { return m_cmd; }
+			u32 get_pos() const { return m_internal_get; }
+			u32 last_cmd() const { return m_cmd; }
 			void sync_get() { m_ctrl->get.release(m_internal_get); }
 			void inc_get(bool wait);
 			void set_get(u32 get);
-			void set_put(u32 put);
 			void abort();
 			template <bool = true> u32 read_put();
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3248,6 +3248,9 @@ namespace rsx
 				return result_none;
 
 			const auto memory_end = memory_address + memory_range;
+
+			AUDIT(memory_end >= memory_address);
+
 			u32 sync_address = 0;
 			occlusion_query_info* query = nullptr;
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2342,7 +2342,7 @@ namespace rsx
 		}
 	}
 
-	u32 thread::get_fifo_cmd()
+	u32 thread::get_fifo_cmd() const
 	{
 		// Last fifo cmd for logging and utility
 		return fifo_ctrl->last_cmd();

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -603,8 +603,8 @@ namespace rsx
 		atomic_t<bool> external_interrupt_ack{ false };
 		void flush_fifo();
 		void recover_fifo();
-		void fifo_wake_delay(u64 div = 1);
-		u32 get_fifo_cmd();
+		static void fifo_wake_delay(u64 div = 1);
+		u32 get_fifo_cmd() const;
 
 		// Performance approximation counters
 		struct

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1000,7 +1000,7 @@ namespace rsx
 			else
 			{
 				const u32 data_length = in_pitch * (in_h - 1) + src_line_length;
-				rsx->read_barrier(src_address, dst_address, true);
+				rsx->read_barrier(src_address, data_length, true);
 			}
 
 			u8* pixels_src = vm::_ptr<u8>(src_address + in_offset);


### PR DESCRIPTION
* Fix size argument passed to `rsx::thread::read_barrier()` in image_in.
* Fix a typo in cellGcm HLE which led to memory size and io address to be x100000 as smaller as they should.
* Make fifo call/ret recovery from unexpected stack state be the same as invalid cmd recovery, add logging for its cmd hex representation in this case. 