### PR TITLE
Fix gamelist app version and firmware version

### DIFF
--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -75,8 +75,8 @@ bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_downl
 		// Add date if possible
 		status.date = json_result.value("date").toString();
 
-		// Add version if possible
-		status.version = json_result.value("update").toString();
+		// Add latest version if possible
+		status.latest_version = json_result.value("update").toString();
 
 		// Add status to map
 		m_compat_database.emplace(std::pair<std::string, compat_status>(sstr(key), status));

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -22,7 +22,7 @@ struct compat_status
 	QString color;
 	QString text;
 	QString tooltip;
-	QString version;
+	QString latest_version;
 };
 
 class game_compatibility : public QObject

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -565,6 +565,7 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 
 				GameInfo game;
 				game.path         = dir;
+				game.icon_path    = sfo_dir + "/ICON0.PNG";
 				game.serial       = psf::get_string(psf, "TITLE_ID", "");
 				game.name         = psf::get_string(psf, "TITLE", cat_unknown_localized);
 				game.app_ver      = psf::get_string(psf, "APP_VER", cat_unknown_localized);
@@ -628,25 +629,21 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 				}
 
 				auto qt_cat = qstr(game.category);
-				auto cat = thread_localized.category.cat_boot.find(qt_cat);
-				if (cat != thread_localized.category.cat_boot.end())
+
+				if (const auto boot_cat = thread_localized.category.cat_boot.find(qt_cat); boot_cat != thread_localized.category.cat_boot.end())
 				{
-					game.icon_path = sfo_dir + "/ICON0.PNG";
-					qt_cat = cat->second;
+					qt_cat = boot_cat->second;
 				}
-				else if ((cat = thread_localized.category.cat_data.find(qt_cat)) != thread_localized.category.cat_data.end())
+				else if (const auto data_cat = thread_localized.category.cat_data.find(qt_cat); data_cat != thread_localized.category.cat_data.end())
 				{
-					game.icon_path = sfo_dir + "/ICON0.PNG";
-					qt_cat = cat->second;
+					qt_cat = data_cat->second;
 				}
 				else if (game.category == cat_unknown)
 				{
-					game.icon_path = sfo_dir + "/ICON0.PNG";
 					qt_cat = localized.category.unknown;
 				}
 				else
 				{
-					game.icon_path = sfo_dir + "/ICON0.PNG";
 					qt_cat = localized.category.other;
 				}
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -533,9 +533,6 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 			}
 		}
 
-		// Used to remove duplications from the list (serial -> set of cat names)
-		std::map<std::string, std::set<std::string>> serial_cat_name;
-
 		QSet<QString> serials;
 
 		QMutex mutex_cat;
@@ -579,13 +576,6 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 				game.attr         = psf::get_integer(psf, "ATTRIBUTE", 0);
 
 				mutex_cat.lock();
-
-				// Detect duplication
-				if (!serial_cat_name[game.serial].emplace(game.category + game.name).second)
-				{
-					mutex_cat.unlock();
-					return;
-				}
 
 				const QString serial = qstr(game.serial);
 				const QString note = m_gui_settings->GetValue(gui::notes, serial, "").toString();
@@ -710,13 +700,6 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 						catch (const std::exception& e)
 						{
 							game_list_log.error("Failed to update the displayed version numbers for title ID %s\n%s thrown: %s", entry->info.serial, typeid(e).name(), e.what());
-						}
-
-						const std::string key = "GD" + other->info.name;
-						serial_cat_name[other->info.serial].erase(key);
-						if (!serial_cat_name[other->info.serial].count(key))
-						{
-							break;
 						}
 					}
 				}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -690,17 +690,17 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 				for (const auto& other : m_game_data)
 				{
 					// The patch is game data and must have the same serial and an app version
-					if (entry->info.serial == other->info.serial && other->info.category == "GD" && other->info.app_ver != cat_unknown)
+					if (entry->info.serial == other->info.serial && other->info.category == "GD" && other->info.app_ver != cat_unknown_localized)
 					{
 						try
 						{
 							// Update the app version if it's higher than the disc's version (old games may not have an app version)
-							if (entry->info.app_ver == cat_unknown || std::stod(other->info.app_ver) > std::stod(entry->info.app_ver))
+							if (entry->info.app_ver == cat_unknown_localized || std::stod(other->info.app_ver) > std::stod(entry->info.app_ver))
 							{
 								entry->info.app_ver = other->info.app_ver;
 							}
 							// Update the firmware version if possible and if it's higher than the disc's version
-							if (other->info.fw != cat_unknown && std::stod(other->info.fw) > std::stod(entry->info.fw))
+							if (other->info.fw != cat_unknown_localized && std::stod(other->info.fw) > std::stod(entry->info.fw))
 							{
 								entry->info.fw = other->info.fw;
 							}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1980,16 +1980,22 @@ int game_list_frame::PopulateGameList()
 
 		// Version
 		QString app_version = qstr(game->info.app_ver);
+		const QString unknown = localized.category.unknown;
 
-		if (app_version == localized.category.unknown)
+		if (app_version == unknown)
 		{
 			// Fall back to Disc/Pkg Revision
 			app_version = qstr(game->info.version);
 		}
 
-		if (!game->compat.version.isEmpty() && (app_version == localized.category.unknown || game->compat.version.toDouble() > app_version.toDouble()))
+		if (game->info.bootable && !game->compat.latest_version.isEmpty())
 		{
-			app_version = tr("%0 (Update available: %1)").arg(app_version, game->compat.version);
+			// If the app is bootable and the compat database contains info about the latest patch version:
+			// add a hint for available software updates if the app version is unknown or lower than the latest version.
+			if (app_version == unknown || game->compat.latest_version.toDouble() > app_version.toDouble())
+			{
+				app_version = tr("%0 (Update available: %1)").arg(app_version, game->compat.latest_version);
+			}
 		}
 
 		// Playtimes


### PR DESCRIPTION
Only add the version update hint to bootable games in the gamelist.

Allow "duplicates" in the game list.
In the past we removed duplicate entries in the game list. This also happened when the source had a different path, which is common if you have multiple game data directories for a game. But that also meant that we didn't set the game version properly if we found the older patch (game data) first and discarded the second, newer patch.
In consequence you'll see multiple game data entries from now on, or even multiple same disc games if you have them added from seperate directories (who knows why you'd do that in the first place).

Also fixes a regression caused by recent localization changes, which caused the gamelist to randomly not display patched versions for disc games.