### PR TITLE
[TESTERS NEEDED] vk: Explicitly declare null subpass dependencies

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -184,6 +184,28 @@ namespace vk
 			attachment_references.push_back({ attachment_count, dsv_layout });
 		}
 
+		VkSubpassDependency null_subpass_dependencies[2] =
+		{
+			{
+				.srcSubpass = VK_SUBPASS_EXTERNAL,
+				.dstSubpass = 0,
+				.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				.srcAccessMask = 0,
+				.dstAccessMask = 0,
+				.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT
+			},
+			{
+				.srcSubpass = 0,
+				.dstSubpass = VK_SUBPASS_EXTERNAL,
+				.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				.srcAccessMask = 0,
+				.dstAccessMask = 0,
+				.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT
+			}
+		};
+
 		VkSubpassDescription subpass = {};
 		subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 		subpass.colorAttachmentCount = attachment_count;
@@ -196,8 +218,8 @@ namespace vk
 		rp_info.pAttachments = attachments.data();
 		rp_info.subpassCount = 1;
 		rp_info.pSubpasses = &subpass;
-		rp_info.pDependencies = nullptr;
-		rp_info.dependencyCount = 0;
+		rp_info.dependencyCount = 2;
+		rp_info.pDependencies = null_subpass_dependencies;
 
 		VkRenderPass result;
 		CHECK_RESULT(vkCreateRenderPass(dev, &rp_info, NULL, &result));


### PR DESCRIPTION
Turns out to properly remove subpass dependencies you have to declare at least two.
Seeks to address https://gitlab.freedesktop.org/mesa/mesa/issues/2502