### PR TITLE
[WIP] SPU Recompilers: Fix fatal logging and exit

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp
@@ -1787,7 +1787,7 @@ void spursTasksetDispatch(spu_thread& spu)
 		if (elfAddr & 2)
 		{
 			// TODO: Figure this out
-			spu_runtime::g_escape(&spu);
+			spu.escape();
 		}
 
 		spursTasksetStartTask(spu, taskInfo->args);
@@ -1840,7 +1840,7 @@ void spursTasksetDispatch(spu_thread& spu)
 		if (elfAddr & 2)
 		{
 			// TODO: Figure this out
-			spu_runtime::g_escape(&spu);
+			spu.escape();
 		}
 
 		spu.gpr[3].clear();

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -76,10 +76,10 @@ bool spu_thread::read_reg(const u32 addr, u32& value)
 		case MFC_GETBS_CMD:
 		case MFC_GETFS_CMD:
 		{
-			if (cmd.size)
+			// Perform transfer immediately
+			if (cmd.size && !do_dma_transfer(cmd))
 			{
-				// Perform transfer immediately
-				do_dma_transfer(cmd);
+				break;
 			}
 
 			if (cmd.cmd & MFC_START_MASK)

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -997,7 +997,7 @@ static void check_state(spu_thread* _spu)
 {
 	if (_spu->state && _spu->check_state())
 	{
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 }
 
@@ -1083,7 +1083,7 @@ void spu_recompiler::branch_indirect(spu_opcode_t op, bool jt, bool ret)
 		{
 			_spu->state += cpu_flag::dbg_pause;
 			spu_log.fatal("SPU Interrupts not implemented (mask=0x%x)", +_spu->ch_event_mask);
-			spu_runtime::g_escape(_spu);
+			_spu->escape();
 		};
 
 		Label no_intr = c->newLabel();
@@ -1232,7 +1232,7 @@ void spu_recompiler::fall(spu_opcode_t op)
 		{
 			_spu->state += cpu_flag::dbg_pause;
 			spu_log.fatal("spu_recompiler::fall(): unexpected interpreter call (op=0x%08x)", opcode);
-			spu_runtime::g_escape(_spu);
+			_spu->escape();
 		}
 	};
 
@@ -1363,7 +1363,7 @@ void spu_recompiler::get_events()
 		{
 			_spu->state += cpu_flag::dbg_pause;
 			spu_log.fatal("SPU Events not implemented (mask=0x%x).", +_spu->ch_event_mask);
-			spu_runtime::g_escape(_spu);
+			_spu->escape();
 		};
 
 		c->bind(fail);
@@ -1387,7 +1387,7 @@ void spu_recompiler::UNK(spu_opcode_t op)
 	{
 		_spu->state += cpu_flag::dbg_pause;
 		spu_log.fatal("Unknown/Illegal instruction (0x%08x)" HERE, op);
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	};
 
 	c->lea(addr->r64(), get_pc(m_pos));
@@ -1404,13 +1404,13 @@ void spu_stop(spu_thread* _spu, u32 code)
 {
 	if (!_spu->stop_and_signal(code))
 	{
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 
 	if (_spu->test_stopped())
 	{
 		_spu->pc += 4;
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 }
 
@@ -1476,13 +1476,13 @@ static u32 spu_rdch(spu_thread* _spu, u32 ch)
 
 	if (result < 0)
 	{
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 
 	if (_spu->test_stopped())
 	{
 		_spu->pc += 4;
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 
 	return static_cast<u32>(result & 0xffffffff);
@@ -1598,7 +1598,7 @@ void spu_recompiler::RDCH(spu_opcode_t op)
 				if (_spu->test_stopped())
 				{
 					_spu->pc += 4;
-					spu_runtime::g_escape(_spu);
+					_spu->escape();
 				}
 			}
 
@@ -2395,13 +2395,13 @@ static void spu_wrch(spu_thread* _spu, u32 ch, u32 value)
 {
 	if (!_spu->set_ch_value(ch, value))
 	{
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 
 	if (_spu->test_stopped())
 	{
 		_spu->pc += 4;
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 }
 
@@ -2409,13 +2409,13 @@ static void spu_wrch_mfc(spu_thread* _spu)
 {
 	if (!_spu->process_mfc_cmd())
 	{
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 
 	if (_spu->test_stopped())
 	{
 		_spu->pc += 4;
-		spu_runtime::g_escape(_spu);
+		_spu->escape();
 	}
 }
 

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -87,7 +87,7 @@ namespace asmjit
 
 bool spu_interpreter::UNK(spu_thread& spu, spu_opcode_t op)
 {
-	fmt::throw_exception("Unknown/Illegal instruction (0x%08x)" HERE, op.opcode);
+	spu.escape_fatal("Unknown/Illegal instruction (0x%08x)" HERE, op.opcode);
 }
 
 
@@ -97,7 +97,7 @@ void spu_interpreter::set_interrupt_status(spu_thread& spu, spu_opcode_t op)
 	{
 		if (op.d)
 		{
-			fmt::throw_exception("Undefined behaviour" HERE);
+			spu.escape_fatal("Undefined behaviour" HERE);
 		}
 
 		spu.set_interrupt_status(true);
@@ -623,7 +623,7 @@ bool spu_interpreter::CBX(spu_thread& spu, spu_opcode_t op)
 {
 	if (op.ra == 1 && (spu.gpr[1]._u32[3] & 0xF))
 	{
-		fmt::throw_exception("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
+		spu.escape_fatal("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
 	}
 
 	const s32 t = ~(spu.gpr[op.rb]._u32[3] + spu.gpr[op.ra]._u32[3]) & 0xf;
@@ -636,7 +636,7 @@ bool spu_interpreter::CHX(spu_thread& spu, spu_opcode_t op)
 {
 	if (op.ra == 1 && (spu.gpr[1]._u32[3] & 0xF))
 	{
-		fmt::throw_exception("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
+		spu.escape_fatal("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
 	}
 
 	const s32 t = (~(spu.gpr[op.rb]._u32[3] + spu.gpr[op.ra]._u32[3]) & 0xe) >> 1;
@@ -649,7 +649,7 @@ bool spu_interpreter::CWX(spu_thread& spu, spu_opcode_t op)
 {
 	if (op.ra == 1 && (spu.gpr[1]._u32[3] & 0xF))
 	{
-		fmt::throw_exception("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
+		spu.escape_fatal("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
 	}
 
 	const s32 t = (~(spu.gpr[op.rb]._u32[3] + spu.gpr[op.ra]._u32[3]) & 0xc) >> 2;
@@ -662,7 +662,7 @@ bool spu_interpreter::CDX(spu_thread& spu, spu_opcode_t op)
 {
 	if (op.ra == 1 && (spu.gpr[1]._u32[3] & 0xF))
 	{
-		fmt::throw_exception("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
+		spu.escape_fatal("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
 	}
 
 	const s32 t = (~(spu.gpr[op.rb]._u32[3] + spu.gpr[op.ra]._u32[3]) & 0x8) >> 3;
@@ -729,7 +729,7 @@ bool spu_interpreter::CBD(spu_thread& spu, spu_opcode_t op)
 {
 	if (op.ra == 1 && (spu.gpr[1]._u32[3] & 0xF))
 	{
-		fmt::throw_exception("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
+		spu.escape_fatal("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
 	}
 
 	const s32 t = ~(op.i7 + spu.gpr[op.ra]._u32[3]) & 0xf;
@@ -742,7 +742,7 @@ bool spu_interpreter::CHD(spu_thread& spu, spu_opcode_t op)
 {
 	if (op.ra == 1 && (spu.gpr[1]._u32[3] & 0xF))
 	{
-		fmt::throw_exception("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
+		spu.escape_fatal("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
 	}
 
 	const s32 t = (~(op.i7 + spu.gpr[op.ra]._u32[3]) & 0xe) >> 1;
@@ -755,7 +755,7 @@ bool spu_interpreter::CWD(spu_thread& spu, spu_opcode_t op)
 {
 	if (op.ra == 1 && (spu.gpr[1]._u32[3] & 0xF))
 	{
-		fmt::throw_exception("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
+		spu.escape_fatal("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
 	}
 
 	const s32 t = (~(op.i7 + spu.gpr[op.ra]._u32[3]) & 0xc) >> 2;
@@ -768,7 +768,7 @@ bool spu_interpreter::CDD(spu_thread& spu, spu_opcode_t op)
 {
 	if (op.ra == 1 && (spu.gpr[1]._u32[3] & 0xF))
 	{
-		fmt::throw_exception("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
+		spu.escape_fatal("Unexpected SP value: LS:0x%05x" HERE, spu.gpr[1]._u32[3]);
 	}
 
 	const s32 t = (~(op.i7 + spu.gpr[op.ra]._u32[3]) & 0x8) >> 3;
@@ -983,7 +983,7 @@ bool spu_interpreter_fast::FCGT(spu_thread& spu, spu_opcode_t op)
 
 bool spu_interpreter::DFCGT(spu_thread& spu, spu_opcode_t op)
 {
-	fmt::throw_exception("Unexpected instruction" HERE);
+	spu.escape_fatal("Unexpected instruction" HERE);
 	return true;
 }
 
@@ -1070,7 +1070,7 @@ bool spu_interpreter_fast::FCMGT(spu_thread& spu, spu_opcode_t op)
 
 bool spu_interpreter::DFCMGT(spu_thread& spu, spu_opcode_t op)
 {
-	fmt::throw_exception("Unexpected Instruction" HERE);
+	spu.escape_fatal("Unexpected Instruction" HERE);
 	return true;
 }
 
@@ -1218,7 +1218,7 @@ bool spu_interpreter_fast::FSCRWR(spu_thread& spu, spu_opcode_t op)
 
 bool spu_interpreter::DFTSV(spu_thread& spu, spu_opcode_t op)
 {
-	fmt::throw_exception("Unexpected instruction" HERE);
+	spu.escape_fatal("Unexpected instruction" HERE);
 	return true;
 }
 
@@ -1230,7 +1230,7 @@ bool spu_interpreter_fast::FCEQ(spu_thread& spu, spu_opcode_t op)
 
 bool spu_interpreter::DFCEQ(spu_thread& spu, spu_opcode_t op)
 {
-	fmt::throw_exception("Unexpected instruction" HERE);
+	spu.escape_fatal("Unexpected instruction" HERE);
 	return true;
 }
 
@@ -1274,7 +1274,7 @@ bool spu_interpreter_fast::FCMEQ(spu_thread& spu, spu_opcode_t op)
 
 bool spu_interpreter::DFCMEQ(spu_thread& spu, spu_opcode_t op)
 {
-	fmt::throw_exception("Unexpected instruction" HERE);
+	spu.escape_fatal("Unexpected instruction" HERE);
 	return true;
 }
 


### PR DESCRIPTION
Ever since f33b81545e46f2b2542fd874ae30a146e3bc243d, exceptions would cause the emulator to crash and close for all SPU decoders except SPU precise interpreter.
Instead use fatal logging + spu_runtime::g_escape to be compatible with those changes.
Also don't use exceptions when spu_thread::do_dma_transfer fails inside access violation handler for MMIO, thus allow recovery.