### PR TITLE
Don't improperly resolve symlinks when booting games.

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -302,7 +302,7 @@ int main(int argc, char** argv)
 		}
 
 		// Ugly workaround
-		QTimer::singleShot(2, [path = sstr(QFileInfo(args.at(0)).canonicalFilePath()), argv = std::move(argv)]() mutable
+		QTimer::singleShot(2, [path = sstr(QFileInfo(args.at(0)).absoluteFilePath()), argv = std::move(argv)]() mutable
 		{
 			Emu.argv = std::move(argv);
 			Emu.SetForceBoot(true);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -307,7 +307,7 @@ void main_window::BootElf()
 	// game folder in case of having e.g. a Game Folder with collected links to elf files.
 	// Don't set last path earlier in case of cancelled dialog
 	guiSettings->SetValue(gui::fd_boot_elf, filePath);
-	const std::string path = sstr(QFileInfo(filePath).canonicalFilePath());
+	const std::string path = sstr(QFileInfo(filePath).absoluteFilePath());
 
 	gui_log.notice("Booting from BootElf...");
 	Boot(path, "", true);
@@ -324,7 +324,7 @@ void main_window::BootGame()
 	}
 
 	QString path_last_Game = guiSettings->GetValue(gui::fd_boot_game).toString();
-	QString dirPath = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"), path_last_Game, QFileDialog::ShowDirsOnly);
+	QString dirPath = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"), path_last_Game, QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
 
 	if (dirPath == NULL)
 	{
@@ -1254,7 +1254,7 @@ void main_window::CreateConnects()
 		QStringList paths;
 
 		// Only select one folder for now
-		paths << QFileDialog::getExistingDirectory(this, tr("Select a folder containing one or more games"), qstr(fs::get_config_dir()), QFileDialog::ShowDirsOnly);
+		paths << QFileDialog::getExistingDirectory(this, tr("Select a folder containing one or more games"), qstr(fs::get_config_dir()), QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
 
 		if (!paths.isEmpty())
 		{

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
@@ -93,7 +93,7 @@ void vfs_dialog_tab::Reset()
 
 void vfs_dialog_tab::AddNewDirectory()
 {
-	QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Choose a directory"), QCoreApplication::applicationDirPath());
+	QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Choose a directory"), QCoreApplication::applicationDirPath(), QFileDialog::DontResolveSymlinks);
 
 	if (dir.isEmpty())
 		return;


### PR DESCRIPTION
Currently, when you boot a game from the command line or from the menu with File > Boot SELF/ELF or File > Boot Game, RPCS3 will resolve any symlinks in the game path. I can't think of any reason why RPCS3 should resolve such symlinks. This can break HDD (PSN) games because RPCS3 expects them to be in dev_hdd0/game. If you boot the games from the game list, this issue is not present.  This PR corrects this issue; should fix #5507 and fix #4829.

