### PR TITLE
Qt: Update Game List Icons on changing Game List Mode

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1572,6 +1572,7 @@ void main_window::CreateConnects()
 
 		int slider_pos = ui->sizeSlider->sliderPosition();
 		ui->sizeSlider->setSliderPosition(m_other_slider_pos);
+		SetIconSizeActions(m_other_slider_pos);
 		m_other_slider_pos = slider_pos;
 
 		m_is_list_mode = is_list_act;


### PR DESCRIPTION
This fixes a case where perfoming these steps would desync Game List Icon selected value with the real value:

1. Have Game List Mode set to List View and Icon size set to Tiny.
2. Change Game List Mode to Grid View and Icon size to Large.
3. Change Game List mode back to List View.
4. Observe icons are small, but Icon size is still set to Large.