### PR TITLE
Replace gsl::span for std::span (c++20)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -60,10 +60,6 @@
 	path = 3rdparty/FAudio
 	url = https://github.com/FNA-XNA/FAudio.git
 	ignore = dirty
-[submodule "3rdparty/span"]
-	path = 3rdparty/span
-	url = https://github.com/tcbrindle/span
-	ignore = dirty
 [submodule "3rdparty/curl"]
 	path = 3rdparty/curl/curl
 	url = https://github.com/curl/curl.git

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -148,11 +148,6 @@ else()
 endif()
 
 
-# span
-add_library(3rdparty_span INTERFACE)
-target_include_directories(3rdparty_span INTERFACE span/include)
-
-
 # stblib
 add_library(3rdparty_stblib INTERFACE)
 target_include_directories(3rdparty_stblib INTERFACE stblib/include)
@@ -370,7 +365,6 @@ add_library(3rdparty::hidapi ALIAS 3rdparty_hidapi)
 add_library(3rdparty::libpng ALIAS ${LIBPNG_TARGET})
 add_library(3rdparty::cereal ALIAS 3rdparty_cereal)
 add_library(3rdparty::opengl ALIAS 3rdparty_opengl)
-add_library(3rdparty::span ALIAS 3rdparty_span)
 add_library(3rdparty::stblib ALIAS 3rdparty_stblib)
 add_library(3rdparty::discordRPC ALIAS 3rdparty_discordRPC)
 add_library(3rdparty::alsa ALIAS ${ALSA_TARGET})

--- a/Utilities/span.h
+++ b/Utilities/span.h
@@ -1,2 +1,0 @@
-#define TCB_SPAN_NAMESPACE_NAME gsl
-#include <tcb/span.hpp>

--- a/buildfiles/msvc/rpcs3_default.props
+++ b/buildfiles/msvc/rpcs3_default.props
@@ -3,7 +3,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IncludePath>.\;..\;..\3rdparty\asmjit\asmjit\src;..\3rdparty\yaml-cpp\include;..\3rdparty\ffmpeg\include;..\3rdparty\cereal\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(UniversalCRT_IncludePath);..\3rdparty\span\include;..\3rdparty\libpng\libpng;..\3rdparty\GL;..\3rdparty\stblib\include;..\3rdparty\OpenAL\include;..\3rdparty\pugixml\src;..\3rdparty\hidapi\hidapi;..\3rdparty\Optional;..\3rdparty\xxhash</IncludePath>
+    <IncludePath>.\;..\;..\3rdparty\asmjit\asmjit\src;..\3rdparty\yaml-cpp\include;..\3rdparty\ffmpeg\include;..\3rdparty\cereal\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(UniversalCRT_IncludePath);..\3rdparty\libpng\libpng;..\3rdparty\GL;..\3rdparty\stblib\include;..\3rdparty\OpenAL\include;..\3rdparty\pugixml\src;..\3rdparty\hidapi\hidapi;..\3rdparty\Optional;..\3rdparty\xxhash</IncludePath>
     <OutDir>$(SolutionDir)lib\$(Configuration)-$(Platform)\</OutDir>
     <LibraryPath>$(SolutionDir)lib\$(Configuration)-$(Platform)\;$(UniversalCRT_LibraryPath_x64);$(LibraryPath)</LibraryPath>
     <IntDir>$(SolutionDir)tmp\$(ProjectName)-$(Configuration)-$(Platform)\</IntDir>

--- a/rpcs3/Crypto/utils.cpp
+++ b/rpcs3/Crypto/utils.cpp
@@ -9,12 +9,12 @@
 #include <stdio.h>
 #include <time.h>
 #include "Utilities/StrUtil.h"
-#include "Utilities/span.h"
 #include "Utilities/File.h"
 
 #include <memory>
 #include <string>
 #include <string_view>
+#include <span>
 
 // Auxiliary functions (endian swap, xor).
 
@@ -132,7 +132,7 @@ char* extract_file_name(const char* file_path, char real_file_name[CRYPTO_MAX_PA
 		v.remove_prefix(pos + 1);
 	}
 
-	gsl::span r(real_file_name, CRYPTO_MAX_PATH);
+	std::span r(real_file_name, CRYPTO_MAX_PATH);
 	strcpy_trunc(r, v);
 	return real_file_name;
 }

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -62,8 +62,7 @@ target_include_directories(rpcs3_emu PUBLIC "${CMAKE_SOURCE_DIR}")
 
 target_link_libraries(rpcs3_emu
     PUBLIC
-        3rdparty::pugixml
-        3rdparty::span)
+        3rdparty::pugixml)
 
 if(MSVC)
     set_source_files_properties("../../Utilities/JIT.cpp" PROPERTIES COMPILE_FLAGS /GR-)
@@ -505,7 +504,7 @@ target_link_libraries(rpcs3_emu
         3rdparty::vulkan 3rdparty::glew
         3rdparty::libusb 3rdparty::wolfssl
     PRIVATE
-        3rdparty::span 3rdparty::xxhash
+        3rdparty::xxhash
 )
 
 if(APPLE)

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -15,7 +15,6 @@
 
 #include "Loader/PSF.h"
 #include "Utilities/StrUtil.h"
-#include "Utilities/span.h"
 #include "util/init_mutex.hpp"
 #include "util/asm.hpp"
 
@@ -1151,7 +1150,7 @@ error_code cellGameGetParamString(s32 id, vm::ptr<char> buf, u32 bufsize)
 		cellGame.warning("cellGameGetParamString(): id=%d was not found", id);
 	}
 
-	gsl::span dst(buf.get_ptr(), bufsize);
+	std::span dst(buf.get_ptr(), bufsize);
 	strcpy_trunc(dst, value);
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -18,6 +18,8 @@
 #include "util/init_mutex.hpp"
 #include "util/asm.hpp"
 
+#include <span>
+
 LOG_CHANNEL(cellGame);
 
 template<>

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -15,11 +15,11 @@
 
 #include "Loader/PSF.h"
 #include "Utilities/StrUtil.h"
-#include "Utilities/span.h"
 #include "Utilities/date_time.h"
 
 #include <mutex>
 #include <algorithm>
+#include <span>
 
 #include "util/asm.hpp"
 
@@ -1654,7 +1654,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			if (dotpos)
 			{
 				// Copy file name
-				gsl::span dst(name, dotpos + 1);
+				std::span dst(name, dotpos + 1);
 				strcpy_trunc(dst, file_path);
 
 				// Allow multiple '.' even though sysutil_check_name_string does not
@@ -1691,7 +1691,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			if (file_path.size() > dotpos + 1)
 			{
 				// Copy file extension
-				gsl::span dst(name, file_path.size() - dotpos);
+				std::span dst(name, file_path.size() - dotpos);
 				strcpy_trunc(dst, file_path.operator std::string_view().substr(dotpos + 1));
 
 				// Allow '_' at start even though sysutil_check_name_string does not

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -10,7 +10,8 @@
 
 #include "Utilities/StrUtil.h"
 #include "Utilities/lockless.h"
-#include "Utilities/span.h"
+
+#include <span>
 
 LOG_CHANNEL(cellSysutil);
 
@@ -385,7 +386,7 @@ error_code cellSysutilGetSystemParamString(CellSysutilParamId id, vm::ptr<char> 
 		cellSysutil.error("cellSysutilGetSystemParamString: Unknown ParamId 0x%x", id);
 	}
 
-	gsl::span dst(buf.get_ptr(), copy_size);
+	std::span dst(buf.get_ptr(), copy_size);
 	strcpy_trunc(dst, param_str);
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -10,10 +10,10 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Crypto/unedat.h"
 #include "Utilities/StrUtil.h"
-#include "Utilities/span.h"
 #include "sys_fs.h"
 #include "sys_process.h"
 #include "sys_memory.h"
+#include <span>
 
 extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, const std::string&, s64);
 extern void ppu_unload_prx(const lv2_prx& prx);
@@ -805,7 +805,7 @@ error_code _sys_prx_get_module_info(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<
 	pOpt->info->all_segments_num = ::size32(prx->segs);
 	if (pOpt->info->filename)
 	{
-		gsl::span dst(pOpt->info->filename.get_ptr(), pOpt->info->filename_size);
+		std::span dst(pOpt->info->filename.get_ptr(), pOpt->info->filename_size);
 		strcpy_trunc(dst, prx->name);
 	}
 

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -51,13 +51,13 @@ namespace
 	// FIXME: GSL as_span break build if template parameter is non const with current revision.
 	// Replace with true as_span when fixed.
 	template <typename T>
-	gsl::span<T> as_span_workaround(gsl::span<std::byte> unformated_span)
+	std::span<T> as_span(std::span<std::byte> unformated_span)
 	{
 		return{ reinterpret_cast<T*>(unformated_span.data()), unformated_span.size_bytes() / sizeof(T) };
 	}
 
 	template <typename T>
-	gsl::span<T> as_const_span(gsl::span<const std::byte> unformated_span)
+	std::span<T> as_const_span(std::span<const std::byte> unformated_span)
 	{
 		return{ reinterpret_cast<T*>(unformated_span.data()), unformated_span.size_bytes() / sizeof(T) };
 	}
@@ -583,7 +583,7 @@ namespace
 	}
 }
 
-void write_vertex_array_data_to_buffer(gsl::span<std::byte> raw_dst_span, gsl::span<const std::byte> src_ptr, u32 count, rsx::vertex_base_type type, u32 vector_element_count, u32 attribute_src_stride, u8 dst_stride, bool swap_endianness)
+void write_vertex_array_data_to_buffer(std::span<std::byte> raw_dst_span, std::span<const std::byte> src_ptr, u32 count, rsx::vertex_base_type type, u32 vector_element_count, u32 attribute_src_stride, u8 dst_stride, bool swap_endianness)
 {
 	ensure((vector_element_count > 0));
 	const u32 src_read_stride = rsx::get_vertex_type_size_on_host(type, vector_element_count);
@@ -665,7 +665,7 @@ void write_vertex_array_data_to_buffer(gsl::span<std::byte> raw_dst_span, gsl::s
 	}
 	case rsx::vertex_base_type::cmp:
 	{
-		gsl::span<u16> dst_span = as_span_workaround<u16>(raw_dst_span);
+		std::span<u16> dst_span = as_span<u16>(raw_dst_span);
 		for (u32 i = 0; i < count; ++i)
 		{
 			u32 src_value;
@@ -782,7 +782,7 @@ namespace
 
 		template<typename T>
 		static
-		std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::span<T> dst)
+		std::tuple<T, T, u32> upload_untouched(std::span<to_be_t<const T>> src, std::span<T> dst)
 		{
 			T min_index, max_index;
 			u32 written;
@@ -955,7 +955,7 @@ namespace
 
 		template<typename T>
 		static
-		std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, T restart_index, bool skip_restart)
+		std::tuple<T, T, u32> upload_untouched(std::span<to_be_t<const T>> src, std::span<T> dst, T restart_index, bool skip_restart)
 		{
 			T min_index = index_limit<T>();
 			T max_index = 0;
@@ -1015,7 +1015,7 @@ namespace
 	};
 
 	template<typename T>
-	std::tuple<T, T, u32> upload_untouched(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, rsx::primitive_type draw_mode, bool is_primitive_restart_enabled, u32 primitive_restart_index)
+	std::tuple<T, T, u32> upload_untouched(std::span<to_be_t<const T>> src, std::span<T> dst, rsx::primitive_type draw_mode, bool is_primitive_restart_enabled, u32 primitive_restart_index)
 	{
 		if (!is_primitive_restart_enabled)
 		{
@@ -1039,7 +1039,7 @@ namespace
 	}
 
 	template<typename T>
-	std::tuple<T, T, u32> expand_indexed_triangle_fan(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, bool is_primitive_restart_enabled, u32 primitive_restart_index)
+	std::tuple<T, T, u32> expand_indexed_triangle_fan(std::span<to_be_t<const T>> src, std::span<T> dst, bool is_primitive_restart_enabled, u32 primitive_restart_index)
 	{
 		const T invalid_index = index_limit<T>();
 
@@ -1091,7 +1091,7 @@ namespace
 	}
 
 	template<typename T>
-	std::tuple<T, T, u32> expand_indexed_quads(gsl::span<to_be_t<const T>> src, gsl::span<T> dst, bool is_primitive_restart_enabled, u32 primitive_restart_index)
+	std::tuple<T, T, u32> expand_indexed_quads(std::span<to_be_t<const T>> src, std::span<T> dst, bool is_primitive_restart_enabled, u32 primitive_restart_index)
 	{
 		T min_index = index_limit<T>();
 		T max_index = 0;
@@ -1252,8 +1252,8 @@ void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst,
 namespace
 {
 	template<typename T>
-	std::tuple<T, T, u32> write_index_array_data_to_buffer_impl(gsl::span<T> dst,
-		gsl::span<const be_t<T>> src,
+	std::tuple<T, T, u32> write_index_array_data_to_buffer_impl(std::span<T> dst,
+		std::span<const be_t<T>> src,
 		rsx::primitive_type draw_mode, bool restart_index_enabled, u32 restart_index,
 		const std::function<bool(rsx::primitive_type)>& expands)
 	{
@@ -1286,8 +1286,8 @@ namespace
 	}
 }
 
-std::tuple<u32, u32, u32> write_index_array_data_to_buffer(gsl::span<std::byte> dst_ptr,
-	gsl::span<const std::byte> src_ptr,
+std::tuple<u32, u32, u32> write_index_array_data_to_buffer(std::span<std::byte> dst_ptr,
+	std::span<const std::byte> src_ptr,
 	rsx::index_array_type type, rsx::primitive_type draw_mode, bool restart_index_enabled, u32 restart_index,
 	const std::function<bool(rsx::primitive_type)>& expands)
 {
@@ -1295,12 +1295,12 @@ std::tuple<u32, u32, u32> write_index_array_data_to_buffer(gsl::span<std::byte> 
 	{
 	case rsx::index_array_type::u16:
 	{
-		return write_index_array_data_to_buffer_impl<u16>(as_span_workaround<u16>(dst_ptr),
+		return write_index_array_data_to_buffer_impl<u16>(as_span<u16>(dst_ptr),
 			as_const_span<const be_t<u16>>(src_ptr), draw_mode, restart_index_enabled, restart_index, expands);
 	}
 	case rsx::index_array_type::u32:
 	{
-		return write_index_array_data_to_buffer_impl<u32>(as_span_workaround<u32>(dst_ptr),
+		return write_index_array_data_to_buffer_impl<u32>(as_span<u32>(dst_ptr),
 			as_const_span<const be_t<u32>>(src_ptr), draw_mode, restart_index_enabled, restart_index, expands);
 	}
 	default:

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -51,7 +51,7 @@ namespace
 	// FIXME: GSL as_span break build if template parameter is non const with current revision.
 	// Replace with true as_span when fixed.
 	template <typename T>
-	std::span<T> as_span(std::span<std::byte> unformated_span)
+	std::span<T> as_span_workaround(std::span<std::byte> unformated_span)
 	{
 		return{ reinterpret_cast<T*>(unformated_span.data()), unformated_span.size_bytes() / sizeof(T) };
 	}
@@ -665,7 +665,7 @@ void write_vertex_array_data_to_buffer(std::span<std::byte> raw_dst_span, std::s
 	}
 	case rsx::vertex_base_type::cmp:
 	{
-		std::span<u16> dst_span = as_span<u16>(raw_dst_span);
+		std::span<u16> dst_span = as_span_workaround<u16>(raw_dst_span);
 		for (u32 i = 0; i < count; ++i)
 		{
 			u32 src_value;
@@ -1295,12 +1295,12 @@ std::tuple<u32, u32, u32> write_index_array_data_to_buffer(std::span<std::byte> 
 	{
 	case rsx::index_array_type::u16:
 	{
-		return write_index_array_data_to_buffer_impl<u16>(as_span<u16>(dst_ptr),
+		return write_index_array_data_to_buffer_impl<u16>(as_span_workaround<u16>(dst_ptr),
 			as_const_span<const be_t<u16>>(src_ptr), draw_mode, restart_index_enabled, restart_index, expands);
 	}
 	case rsx::index_array_type::u32:
 	{
-		return write_index_array_data_to_buffer_impl<u32>(as_span<u32>(dst_ptr),
+		return write_index_array_data_to_buffer_impl<u32>(as_span_workaround<u32>(dst_ptr),
 			as_const_span<const be_t<u32>>(src_ptr), draw_mode, restart_index_enabled, restart_index, expands);
 	}
 	default:

--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "Utilities/span.h"
 #include "../gcm_enums.h"
 
 /**
  * Write count vertex attributes from src_ptr.
  * src_ptr array layout is deduced from the type, vector element count and src_stride arguments.
  */
-void write_vertex_array_data_to_buffer(gsl::span<std::byte> raw_dst_span, gsl::span<const std::byte> src_ptr, u32 count, rsx::vertex_base_type type, u32 vector_element_count, u32 attribute_src_stride, u8 dst_stride, bool swap_endianness);
+void write_vertex_array_data_to_buffer(std::span<std::byte> raw_dst_span, std::span<const std::byte> src_ptr, u32 count, rsx::vertex_base_type type, u32 vector_element_count, u32 attribute_src_stride, u8 dst_stride, bool swap_endianness);
 
 /*
  * If primitive mode is not supported and need to be emulated (using an index buffer) returns false.
@@ -34,7 +33,7 @@ u32 get_index_type_size(rsx::index_array_type type);
  * Returns min/max index found during the process and the number of valid indices written to the buffer.
  * The function expands index buffer for non native primitive type if expands(draw_mode) return true.
  */
-std::tuple<u32, u32, u32> write_index_array_data_to_buffer(gsl::span<std::byte> dst, gsl::span<const std::byte> src,
+std::tuple<u32, u32, u32> write_index_array_data_to_buffer(std::span<std::byte> dst, std::span<const std::byte> src,
 	rsx::index_array_type, rsx::primitive_type draw_mode, bool restart_index_enabled, u32 restart_index,
 	const std::function<bool(rsx::primitive_type)>& expands);
 
@@ -61,5 +60,3 @@ template <bool unaligned = false>
 void stream_data_to_memory_swapped_u32(void *dst, const void *src, u32 vertex_count, u8 stride);
 template <bool unaligned = false>
 bool stream_data_to_memory_swapped_and_compare_u32(void *dst, const void *src, u32 size);
-
-

--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -2,6 +2,8 @@
 
 #include "../gcm_enums.h"
 
+#include <span>
+
 /**
  * Write count vertex attributes from src_ptr.
  * src_ptr array layout is deduced from the type, vector element count and src_stride arguments.

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -11,7 +11,7 @@ namespace
 	// FIXME: GSL as_span break build if template parameter is non const with current revision.
 	// Replace with true as_span when fixed.
 	template <typename T>
-	std::span<T> as_span(std::span<std::byte> unformated_span)
+	std::span<T> as_span_workaround(std::span<std::byte> unformated_span)
 	{
 		return{ reinterpret_cast<T*>(unformated_span.data()), unformated_span.size_bytes() / sizeof(T) };
 	}

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -11,13 +11,13 @@ namespace
 	// FIXME: GSL as_span break build if template parameter is non const with current revision.
 	// Replace with true as_span when fixed.
 	template <typename T>
-	gsl::span<T> as_span_workaround(gsl::span<std::byte> unformated_span)
+	std::span<T> as_span(std::span<std::byte> unformated_span)
 	{
 		return{ reinterpret_cast<T*>(unformated_span.data()), unformated_span.size_bytes() / sizeof(T) };
 	}
 
 	template <typename T>
-	gsl::span<T> as_const_span(gsl::span<const std::byte> unformated_span)
+	std::span<T> as_const_span(std::span<const std::byte> unformated_span)
 	{
 		return{ reinterpret_cast<T*>(unformated_span.data()), unformated_span.size_bytes() / sizeof(T) };
 	}
@@ -25,7 +25,7 @@ namespace
 	// TODO: Make this function part of GSL
 	// Note: Doesn't handle overlapping range detection.
 	template<typename T1, typename T2>
-	constexpr void copy(gsl::span<T1> dst, gsl::span<T2> src)
+	constexpr void copy(std::span<T1> dst, std::span<T2> src)
 	{
 		static_assert(std::is_convertible<T1, T2>::value, "Cannot convert source and destination span type.");
 		std::copy(src.begin(), src.end(), dst.begin());
@@ -41,7 +41,7 @@ namespace
 struct copy_unmodified_block
 {
 	template<typename T, typename U>
-	static void copy_mipmap_level(gsl::span<T> dst, gsl::span<const U> src, u16 words_per_block, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block, u32 src_pitch_in_block)
+	static void copy_mipmap_level(std::span<T> dst, std::span<const U> src, u16 words_per_block, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block, u32 src_pitch_in_block)
 	{
 		static_assert(sizeof(T) == sizeof(U), "Type size doesn't match.");
 
@@ -86,7 +86,7 @@ struct copy_unmodified_block_swizzled
 	// NOTE: Pixel channel types are T (out) and const U (in). V is the pixel block type that consumes one whole pixel.
 	// e.g 4x16-bit format can use u16, be_t<u16>, u64 as arguments
 	template<typename T, typename U>
-	static void copy_mipmap_level(gsl::span<T> dst, gsl::span<const U> src, u16 words_per_block, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block)
+	static void copy_mipmap_level(std::span<T> dst, std::span<const U> src, u16 words_per_block, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block)
 	{
 		if (std::is_same<T, U>::value && dst_pitch_in_block == width_in_block && words_per_block == 1 && !border)
 		{
@@ -131,7 +131,7 @@ struct copy_unmodified_block_swizzled
 				}
 			}
 
-			gsl::span<const U> src_span = tmp;
+			std::span<const U> src_span = tmp;
 			copy_unmodified_block::copy_mipmap_level(dst, src_span, words_per_block, width_in_block, row_count, depth, border, dst_pitch_in_block, padded_width);
 		}
 	}
@@ -140,7 +140,7 @@ struct copy_unmodified_block_swizzled
 struct copy_unmodified_block_vtc
 {
 	template<typename T, typename U>
-	static void copy_mipmap_level(gsl::span<T> dst, gsl::span<const U> src, u16 width_in_block, u16 row_count, u16 depth, u32 /*dst_pitch_in_block*/, u32 /*src_pitch_in_block*/)
+	static void copy_mipmap_level(std::span<T> dst, std::span<const U> src, u16 width_in_block, u16 row_count, u16 depth, u32 /*dst_pitch_in_block*/, u32 /*src_pitch_in_block*/)
 	{
 		static_assert(sizeof(T) == sizeof(U), "Type size doesn't match.");
 		u32 row_element_count = width_in_block * row_count;
@@ -201,7 +201,7 @@ struct copy_unmodified_block_vtc
 struct copy_decoded_rb_rg_block
 {
 	template <bool SwapWords = false, typename T>
-	static void copy_mipmap_level(gsl::span<u32> dst, gsl::span<const T> src, u16 width_in_block, u16 row_count, u16 depth, u32 dst_pitch_in_block, u32 src_pitch_in_block)
+	static void copy_mipmap_level(std::span<u32> dst, std::span<const T> src, u16 width_in_block, u16 row_count, u16 depth, u32 dst_pitch_in_block, u32 src_pitch_in_block)
 	{
 		static_assert(sizeof(T) == 4, "Type size doesn't match.");
 
@@ -248,7 +248,7 @@ struct copy_decoded_rb_rg_block
 struct copy_rgb655_block
 {
 	template<typename T>
-	static void copy_mipmap_level(gsl::span<u16> dst, gsl::span<const T> src, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block, u32 src_pitch_in_block)
+	static void copy_mipmap_level(std::span<u16> dst, std::span<const T> src, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block, u32 src_pitch_in_block)
 	{
 		static_assert(sizeof(T) == 2, "Type size doesn't match.");
 
@@ -280,7 +280,7 @@ struct copy_rgb655_block
 struct copy_rgb655_block_swizzled
 {
 	template<typename T, typename U>
-	static void copy_mipmap_level(gsl::span<T> dst, gsl::span<const U> src, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block)
+	static void copy_mipmap_level(std::span<T> dst, std::span<const U> src, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block)
 	{
 		u32 padded_width, padded_height;
 		if (border)
@@ -299,7 +299,7 @@ struct copy_rgb655_block_swizzled
 
 		rsx::convert_linear_swizzle_3d<U>(src.data(), tmp.data(), padded_width, padded_height, depth);
 
-		gsl::span<const U> src_span = tmp;
+		std::span<const U> src_span = tmp;
 		copy_rgb655_block::copy_mipmap_level(dst, src_span, width_in_block, row_count, depth, border, dst_pitch_in_block, padded_width);
 	}
 };
@@ -434,7 +434,7 @@ namespace
 
 				const u32 slice_sz = src_pitch_in_block * block_size_in_bytes * full_height_in_block * depth;
 				current_subresource_layout.pitch_in_block = src_pitch_in_block;
-				current_subresource_layout.data = gsl::span<const std::byte>(texture_data_pointer + offset_in_src, slice_sz);
+				current_subresource_layout.data = std::span<const std::byte>(texture_data_pointer + offset_in_src, slice_sz);
 
 				offset_in_src += slice_sz;
 				miplevel_width_in_texel = std::max(miplevel_width_in_texel / 2, 1);
@@ -598,7 +598,7 @@ namespace rsx
 		return get_subresources_layout_impl(texture);
 	}
 
-	texture_memory_info upload_texture_subresource(gsl::span<std::byte> dst_buffer, const rsx::subresource_layout& src_layout, int format, bool is_swizzled, texture_uploader_capabilities& caps)
+	texture_memory_info upload_texture_subresource(std::span<std::byte> dst_buffer, const rsx::subresource_layout& src_layout, int format, bool is_swizzled, texture_uploader_capabilities& caps)
 	{
 		u16 w = src_layout.width_in_block;
 		u16 h = src_layout.height_in_block;

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "../RSXTexture.h"
-#include "Utilities/span.h"
 
+#include <span>
 #include <vector>
 
 namespace rsx
@@ -156,7 +156,7 @@ namespace rsx
 
 	struct subresource_layout
 	{
-		gsl::span<const std::byte> data;
+		std::span<const std::byte> data;
 		u16 width_in_texel;
 		u16 height_in_texel;
 		u16 width_in_block;
@@ -211,7 +211,7 @@ namespace rsx
 	std::vector<subresource_layout> get_subresources_layout(const rsx::fragment_texture &texture);
 	std::vector<subresource_layout> get_subresources_layout(const rsx::vertex_texture &texture);
 
-	texture_memory_info upload_texture_subresource(gsl::span<std::byte> dst_buffer, const subresource_layout &src_layout, int format, bool is_swizzled, texture_uploader_capabilities& caps);
+	texture_memory_info upload_texture_subresource(std::span<std::byte> dst_buffer, const subresource_layout &src_layout, int format, bool is_swizzled, texture_uploader_capabilities& caps);
 
 	u8 get_format_block_size_in_bytes(int format);
 	u8 get_format_block_size_in_texel(int format);

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2669,7 +2669,7 @@ namespace rsx
 					subres.height_in_block = subres.height_in_texel = image_height;
 					subres.pitch_in_block = full_width;
 					subres.depth = 1;
-					subres.data = { vm::_ptr<const std::byte>(image_base), static_cast<gsl::span<const std::byte>::index_type>(src.pitch * image_height) };
+					subres.data = { vm::_ptr<const std::byte>(image_base), static_cast<std::span<const std::byte>::index_type>(src.pitch * image_height) };
 					subresource_layout.push_back(subres);
 
 					const u32 gcm_format = helpers::get_sized_blit_format(src_is_argb8, dst_is_depth_surface, is_format_convert);
@@ -2801,7 +2801,7 @@ namespace rsx
 						subres.height_in_block = subres.height_in_texel = dst_dimensions.height;
 						subres.pitch_in_block = pitch_in_block;
 						subres.depth = 1;
-						subres.data = { vm::get_super_ptr<const std::byte>(dst_base_address), static_cast<gsl::span<const std::byte>::index_type>(dst.pitch * dst_dimensions.height) };
+						subres.data = { vm::get_super_ptr<const std::byte>(dst_base_address), static_cast<std::span<const std::byte>::index_type>(dst.pitch * dst_dimensions.height) };
 						subresource_layout.push_back(subres);
 
 						cached_dest = upload_image_from_cpu(cmd, rsx_range, dst_dimensions.width, dst_dimensions.height, 1, 1, dst.pitch,

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2669,7 +2669,7 @@ namespace rsx
 					subres.height_in_block = subres.height_in_texel = image_height;
 					subres.pitch_in_block = full_width;
 					subres.depth = 1;
-					subres.data = { vm::_ptr<const std::byte>(image_base), static_cast<std::span<const std::byte>::index_type>(src.pitch * image_height) };
+					subres.data = { vm::_ptr<const std::byte>(image_base), static_cast<std::span<const std::byte>::size_type>(src.pitch * image_height) };
 					subresource_layout.push_back(subres);
 
 					const u32 gcm_format = helpers::get_sized_blit_format(src_is_argb8, dst_is_depth_surface, is_format_convert);
@@ -2801,7 +2801,7 @@ namespace rsx
 						subres.height_in_block = subres.height_in_texel = dst_dimensions.height;
 						subres.pitch_in_block = pitch_in_block;
 						subres.depth = 1;
-						subres.data = { vm::get_super_ptr<const std::byte>(dst_base_address), static_cast<std::span<const std::byte>::index_type>(dst.pitch * dst_dimensions.height) };
+						subres.data = { vm::get_super_ptr<const std::byte>(dst_base_address), static_cast<std::span<const std::byte>::size_type>(dst.pitch * dst_dimensions.height) };
 						subresource_layout.push_back(subres);
 
 						cached_dest = upload_image_from_cpu(cmd, rsx_range, dst_dimensions.width, dst_dimensions.height, 1, 1, dst.pitch,

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -418,7 +418,7 @@ void gl::render_target::load_memory(gl::command_context& cmd)
 	subres.height_in_block = subres.height_in_texel = surface_height * samples_y;
 	subres.pitch_in_block = rsx_pitch / get_bpp();
 	subres.depth = 1;
-	subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<gsl::span<const std::byte>::index_type>(rsx_pitch * surface_height * samples_y) };
+	subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<std::span<const std::byte>::index_type>(rsx_pitch * surface_height * samples_y) };
 
 	// TODO: MSAA support
 	if (g_cfg.video.resolution_scale_percent == 100 && spp == 1) [[likely]]

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -2,6 +2,8 @@
 #include "GLGSRender.h"
 #include "Emu/RSX/rsx_methods.h"
 
+#include <span>
+
 color_format rsx::internals::surface_color_format_to_gl(rsx::surface_color_format color_format)
 {
 	//color format
@@ -418,7 +420,7 @@ void gl::render_target::load_memory(gl::command_context& cmd)
 	subres.height_in_block = subres.height_in_texel = surface_height * samples_y;
 	subres.pitch_in_block = rsx_pitch / get_bpp();
 	subres.depth = 1;
-	subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<std::span<const std::byte>::index_type>(rsx_pitch * surface_height * samples_y) };
+	subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<std::span<const std::byte>::size_type>(rsx_pitch * surface_height * samples_y) };
 
 	// TODO: MSAA support
 	if (g_cfg.video.resolution_scale_percent == 100 && spp == 1) [[likely]]

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -654,7 +654,7 @@ namespace gl
 			image_memory_requirements mem_info;
 			pixel_buffer_layout mem_layout;
 
-			gsl::span<gsl::byte> dst_buffer = staging_buffer;
+			std::span<gsl::byte> dst_buffer = staging_buffer;
 			void* out_pointer = staging_buffer.data();
 			u8 block_size_in_bytes = rsx::get_format_block_size_in_bytes(format);
 			u64 image_linear_size;

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -654,7 +654,7 @@ namespace gl
 			image_memory_requirements mem_info;
 			pixel_buffer_layout mem_layout;
 
-			std::span<gsl::byte> dst_buffer = staging_buffer;
+			std::span<std::byte> dst_buffer = staging_buffer;
 			void* out_pointer = staging_buffer.data();
 			u8 block_size_in_bytes = rsx::get_format_block_size_in_bytes(format);
 			u64 image_linear_size;
@@ -693,7 +693,7 @@ namespace gl
 				{
 					const u64 row_pitch = rsx::align2<u64, u64>(layout.width_in_block * block_size_in_bytes, caps.alignment);
 					image_linear_size = row_pitch * layout.height_in_block * layout.depth;
-					dst_buffer = { reinterpret_cast<gsl::byte*>(upload_scratch_mem.map(buffer::access::write)), image_linear_size };
+					dst_buffer = { reinterpret_cast<std::byte*>(upload_scratch_mem.map(buffer::access::write)), image_linear_size };
 				}
 
 				auto op = upload_texture_subresource(dst_buffer, layout, format, is_swizzled, caps);

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.h
@@ -5,9 +5,9 @@
 
 #include "Utilities/mutex.h"
 #include "util/logs.hpp"
-#include "Utilities/span.h"
 #include "util/fnv_hash.hpp"
 
+#include <span>
 #include <unordered_map>
 
 enum class SHADER_TYPE
@@ -398,7 +398,7 @@ public:
 			std::forward<Args>(args)...);   // Other arguments
 	}
 
-	void fill_fragment_constants_buffer(gsl::span<f32> dst_buffer, const RSXFragmentProgram& fragment_program, bool sanitize = false) const;
+	void fill_fragment_constants_buffer(std::span<f32> dst_buffer, const RSXFragmentProgram& fragment_program, bool sanitize = false) const;
 
 	void clear()
 	{

--- a/rpcs3/Emu/RSX/Program/program_state_cache2.hpp
+++ b/rpcs3/Emu/RSX/Program/program_state_cache2.hpp
@@ -6,7 +6,7 @@
 #include "util/asm.hpp"
 
 template <typename Traits>
-void program_state_cache<Traits>::fill_fragment_constants_buffer(gsl::span<f32> dst_buffer, const RSXFragmentProgram &fragment_program, bool sanitize) const
+void program_state_cache<Traits>::fill_fragment_constants_buffer(std::span<f32> dst_buffer, const RSXFragmentProgram &fragment_program, bool sanitize) const
 {
 	const auto I = m_fragment_shader_cache.find(fragment_program);
 	if (I == m_fragment_shader_cache.end())

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -17,12 +17,12 @@
 #include "Overlays/overlay_perf_metrics.h"
 #include "Program/GLSLCommon.h"
 #include "Utilities/date_time.h"
-#include "Utilities/span.h"
 #include "Utilities/StrUtil.h"
 
 #include "util/cereal.hpp"
 #include "util/asm.hpp"
 
+#include <span>
 #include <sstream>
 #include <thread>
 #include <unordered_set>
@@ -892,7 +892,7 @@ namespace rsx
 		return t + timestamp_subvalue;
 	}
 
-	gsl::span<const std::byte> thread::get_raw_index_array(const draw_clause& draw_indexed_clause) const
+	std::span<const std::byte> thread::get_raw_index_array(const draw_clause& draw_indexed_clause) const
 	{
 		if (!element_push_buffer.empty())
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -191,7 +191,7 @@ namespace rsx
 		rsx::vertex_base_type type;
 		u8 attribute_size;
 		u8 stride;
-		gsl::span<const std::byte> data;
+		std::span<const std::byte> data;
 		u8 index;
 		bool is_be;
 	};
@@ -216,7 +216,7 @@ namespace rsx
 
 	struct draw_indexed_array_command
 	{
-		gsl::span<const std::byte> raw_index_buffer;
+		std::span<const std::byte> raw_index_buffer;
 	};
 
 	struct draw_inlined_array
@@ -853,7 +853,7 @@ namespace rsx
 		flags32_t read_barrier(u32 memory_address, u32 memory_range, bool unconditional);
 		virtual void sync_hint(FIFO_hint hint, void* args);
 
-		gsl::span<const gsl::byte> get_raw_index_array(const draw_clause& draw_indexed_clause) const;
+		std::span<const std::byte> get_raw_index_array(const draw_clause& draw_indexed_clause) const;
 
 		std::variant<draw_array_command, draw_indexed_array_command, draw_inlined_array>
 		get_draw_command(const rsx::rsx_state& state) const;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -223,7 +223,7 @@ namespace vk
 		subres.height_in_block = subres.height_in_texel = surface_height * samples_y;
 		subres.pitch_in_block = rsx_pitch / get_bpp();
 		subres.depth = 1;
-		subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<gsl::span<const std::byte>::index_type>(rsx_pitch * surface_height * samples_y) };
+		subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<std::span<const std::byte>::size_type>(rsx_pitch * surface_height * samples_y) };
 
 		if (g_cfg.video.resolution_scale_percent == 100 && spp == 1) [[likely]]
 		{

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -11,6 +11,8 @@
 #include "vkutils/image.h"
 #include "vkutils/scratch.h"
 
+#include <span>
+
 namespace vk
 {
 	void resolve_image(vk::command_buffer& cmd, vk::viewable_image* dst, vk::viewable_image* src);

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -918,7 +918,7 @@ namespace vk
 				check_caps = false;
 			}
 
-			gsl::span<std::byte> mapped{ static_cast<std::byte*>(mapped_buffer), image_linear_size };
+			std::span<std::byte> mapped{ static_cast<std::byte*>(mapped_buffer), image_linear_size };
 			opt = upload_texture_subresource(mapped, layout, format, is_swizzled, caps);
 			upload_heap.unmap();
 

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -143,7 +143,7 @@ namespace
 			VkDeviceSize offset_in_index_buffer = m_index_buffer_ring_info.alloc<4>(upload_size);
 			void* buf = m_index_buffer_ring_info.map(offset_in_index_buffer, upload_size);
 
-			gsl::span<std::byte> dst;
+			std::span<std::byte> dst;
 			std::vector<std::byte> tmp;
 			if (emulate_restart)
 			{
@@ -152,7 +152,7 @@ namespace
 			}
 			else
 			{
-				dst = gsl::span<std::byte>(static_cast<std::byte*>(buf), upload_size);
+				dst = std::span<std::byte>(static_cast<std::byte*>(buf), upload_size);
 			}
 
 			/**

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -4,6 +4,8 @@
 #include "../rsx_methods.h"
 #include "vkutils/buffer_object.h"
 
+#include <span>
+
 namespace vk
 {
 	VkPrimitiveTopology get_appropriate_topology(rsx::primitive_type mode, bool &requires_modification)

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -62,12 +62,12 @@
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</IgnoreImportLibrary>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>..\3rdparty\7z\src;..\3rdparty\hidapi\hidapi\hidapi;.\;..\;..\3rdparty\asmjit\asmjit\src;..\3rdparty\yaml-cpp\include;..\3rdparty\ffmpeg\include;..\3rdparty\cereal\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(UniversalCRT_IncludePath);..\3rdparty\XAudio2Redist\include;..\3rdparty\span\include;..\3rdparty\libpng\libpng;..\3rdparty\GL;..\3rdparty\stblib\include;..\3rdparty\OpenAL\include;..\3rdparty\pugixml\src;..\3rdparty\Optional;..\3rdparty\discord-rpc\include;..\3rdparty\zlib</IncludePath>
+    <IncludePath>..\3rdparty\7z\src;..\3rdparty\hidapi\hidapi\hidapi;.\;..\;..\3rdparty\asmjit\asmjit\src;..\3rdparty\yaml-cpp\include;..\3rdparty\ffmpeg\include;..\3rdparty\cereal\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(UniversalCRT_IncludePath);..\3rdparty\XAudio2Redist\include;..\3rdparty\libpng\libpng;..\3rdparty\GL;..\3rdparty\stblib\include;..\3rdparty\OpenAL\include;..\3rdparty\pugixml\src;..\3rdparty\Optional;..\3rdparty\discord-rpc\include;..\3rdparty\zlib</IncludePath>
     <LibraryPath>$(SolutionDir)lib\$(Configuration)-$(Platform)\;$(UniversalCRT_LibraryPath_x64);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LibraryPath>$(SolutionDir)lib\$(Configuration)-$(Platform)\;$(UniversalCRT_LibraryPath_x64);$(LibraryPath)</LibraryPath>
-    <IncludePath>..\3rdparty\7z\src;..\3rdparty\hidapi\hidapi\hidapi;.\;..\;..\3rdparty\asmjit\asmjit\src;..\3rdparty\yaml-cpp\include;..\3rdparty\ffmpeg\include;..\3rdparty\cereal\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(UniversalCRT_IncludePath);..\3rdparty\XAudio2Redist\include;..\3rdparty\span\include;..\3rdparty\libpng\libpng;..\3rdparty\GL;..\3rdparty\stblib\include;..\3rdparty\OpenAL\include;..\3rdparty\pugixml\src;..\3rdparty\Optional;..\3rdparty\discord-rpc\include;..\3rdparty\zlib</IncludePath>
+    <IncludePath>..\3rdparty\7z\src;..\3rdparty\hidapi\hidapi\hidapi;.\;..\;..\3rdparty\asmjit\asmjit\src;..\3rdparty\yaml-cpp\include;..\3rdparty\ffmpeg\include;..\3rdparty\cereal\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(UniversalCRT_IncludePath);..\3rdparty\XAudio2Redist\include;..\3rdparty\libpng\libpng;..\3rdparty\GL;..\3rdparty\stblib\include;..\3rdparty\OpenAL\include;..\3rdparty\pugixml\src;..\3rdparty\Optional;..\3rdparty\discord-rpc\include;..\3rdparty\zlib</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -24,7 +24,7 @@ constexpr auto qstr = QString::fromStdString;
 namespace
 {
 	template <typename T>
-	gsl::span<T> as_const_span(gsl::span<const std::byte> unformated_span)
+	std::span<T> as_const_span(std::span<const std::byte> unformated_span)
 	{
 		return{ reinterpret_cast<T*>(unformated_span.data()), unformated_span.size_bytes() / sizeof(T) };
 	}
@@ -412,7 +412,7 @@ namespace
 		return std::bit_cast<f32>(raw);
 	}
 
-	std::array<u8, 3> get_value(gsl::span<const std::byte> orig_buffer, rsx::surface_color_format format, usz idx)
+	std::array<u8, 3> get_value(std::span<const std::byte> orig_buffer, rsx::surface_color_format format, usz idx)
 	{
 		switch (format)
 		{
@@ -471,7 +471,7 @@ namespace
 	/**
 	 * Return a new buffer that can be passed to QImage.
 	 */
-	u8* convert_to_QImage_buffer(rsx::surface_color_format format, gsl::span<const std::byte> orig_buffer, usz width, usz height) noexcept
+	u8* convert_to_QImage_buffer(rsx::surface_color_format format, std::span<const std::byte> orig_buffer, usz width, usz height) noexcept
 	{
 		u8* buffer = static_cast<u8*>(std::malloc(width * height * 4));
 		if (!buffer || width == 0 || height == 0)
@@ -521,7 +521,7 @@ void rsx_debugger::OnClickDrawCalls()
 	{
 		if (width && height && !draw_call.depth_stencil[0].empty())
 		{
-			const gsl::span<const std::byte> orig_buffer = draw_call.depth_stencil[0];
+			const std::span<const std::byte> orig_buffer = draw_call.depth_stencil[0];
 			u8* buffer = static_cast<u8*>(std::malloc(4ULL * width * height));
 
 			if (draw_call.state.surface_depth_fmt() == rsx::surface_depth_format::z24s8)
@@ -562,7 +562,7 @@ void rsx_debugger::OnClickDrawCalls()
 	{
 		if (width && height && !draw_call.depth_stencil[1].empty())
 		{
-			const gsl::span<const std::byte> orig_buffer = draw_call.depth_stencil[1];
+			const std::span<const std::byte> orig_buffer = draw_call.depth_stencil[1];
 			u8* buffer = static_cast<u8*>(std::malloc(4ULL * width * height));
 
 			for (u32 row = 0; row < height; row++)

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -13,6 +13,8 @@
 #include <QPushButton>
 #include <QKeyEvent>
 
+#include <span>
+
 enum GCMEnumTypes
 {
 	CELL_GCM_ENUM,


### PR DESCRIPTION
This is just to track implementation progress of std::span in the main 3 compilers we use. It is not possible to do such change now because none of the compilers are ready for std::span.

- Removes 3rdparty/span.
- Replaces gsl::span with std::span.

**Implemented on currently used compilers (0/3):**
- [x] MSVC (19)
- [x] GCC (9)
- [x] Clang (10)

According to https://en.cppreference.com/w/cpp/compiler_support Clang should support it since version 7, but importing `<span>` doesn't work