### PR TITLE
Show error dialogs to user when booting fails

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -16,6 +16,18 @@ enum class system_state
 	ready,
 };
 
+enum class game_boot_result : u32
+{
+	no_errors,
+	generic_error,
+	nothing_to_boot,
+	wrong_disc_location,
+	invalid_file_or_folder,
+	install_failed,
+	decryption_error,
+	file_creation_error,
+};
+
 struct EmuCallbacks
 {
 	std::function<void(std::function<void()>)> call_after;
@@ -153,7 +165,7 @@ public:
 
 	std::string PPUCache() const;
 
-	bool BootGame(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, bool force_global_config = false);
+	game_boot_result BootGame(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, bool force_global_config = false);
 	bool BootRsxCapture(const std::string& path);
 	bool InstallPkg(const std::string& path);
 
@@ -173,7 +185,7 @@ public:
 
 	void SetForceBoot(bool force_boot);
 
-	void Load(const std::string& title_id = "", bool add_only = false, bool force_global_config = false, bool is_disc_patch = false);
+	game_boot_result Load(const std::string& title_id = "", bool add_only = false, bool force_global_config = false, bool is_disc_patch = false);
 	void Run(bool start_playtime);
 	bool Pause();
 	void Resume();

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1244,17 +1244,14 @@ bool game_list_frame::CreatePPUCache(const game_info& game)
 	Emu.SetForceBoot(true);
 	Emu.Stop();
 	Emu.SetForceBoot(true);
-	const bool success = Emu.BootGame(game->info.path, game->info.serial, true);
 
-	if (success)
+	if (const auto error = Emu.BootGame(game->info.path, game->info.serial, true); error != game_boot_result::no_errors)
 	{
-		game_list_log.warning("Creating PPU Cache for %s", game->info.path);
+		game_list_log.error("Could not create PPU Cache for %s, error: %s", game->info.path, error);
+		return false;
 	}
-	else
-	{
-		game_list_log.error("Could not create PPU Cache for %s", game->info.path);
-	}
-	return success;
+	game_list_log.warning("Creating PPU Cache for %s", game->info.path);
+	return true;
 }
 
 bool game_list_frame::RemoveCustomConfiguration(const std::string& title_id, game_info game, bool is_interactive)

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -21,6 +21,8 @@ class gui_settings;
 class emu_settings;
 class persistent_settings;
 
+enum class game_boot_result : u32;
+
 namespace Ui
 {
 	class main_window;
@@ -97,6 +99,7 @@ private Q_SLOTS:
 	void BootGame();
 	void BootRsxCapture(std::string path = "");
 	void DecryptSPRXLibraries();
+	void show_boot_error(game_boot_result result);
 
 	void SaveWindowState();
 	void ConfigureGuiFromSettings(bool configure_all = false);


### PR DESCRIPTION
This pull request adds dialog messages which inform the user when booting a game fails. This doesn't aim to give detailed techical explanations for the errors, but instead gives an simple, general explanation on the possible cause. The messages are also translateable.

As a side effect, makes emulator not log "Boot successful" when booting fails due to an error.

Example dialog:
![image](https://user-images.githubusercontent.com/19759300/74913566-9c0f4600-53c9-11ea-8739-9872a8930e28.png)

Suggestions on how to improve wording on the messages are appriciated.