### PR TITLE
vm::ptr<>: Replace incorrect usages of std::decay_t with std::remove_cvref_t

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -143,7 +143,7 @@ public:
 	template <auto* Var>
 	static auto& register_static_variable(const char* module, const char* name, u32 vnid)
 	{
-		using gvar = std::decay_t<decltype(*Var)>;
+		using gvar = std::remove_cvref_t<decltype(*Var)>;
 
 		static_assert(std::is_same<u32, typename gvar::addr_type>::value, "Static variable registration: vm::gvar<T> expected");
 

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -157,7 +157,7 @@ namespace vm
 
 		// Pointer difference operator
 		template<typename T2, typename AT2>
-		std::enable_if_t<std::is_object<T2>::value && std::is_same<std::decay_t<T>, std::decay_t<T2>>::value, s32> operator -(const _ptr_base<T2, AT2>& right) const
+		std::enable_if_t<std::is_object<T2>::value && std::is_same<std::remove_cvref_t<T>, std::remove_cvref_t<T2>>::value, s32> operator -(const _ptr_base<T2, AT2>& right) const
 		{
 			return static_cast<s32>(vm::cast(m_addr, HERE) - vm::cast(right.m_addr, HERE)) / size();
 		}


### PR DESCRIPTION
std::decay_t is doing a few more alterations to the original type compared to std::remove_cvref_t such as array to pointer which is wrong in some cases.
I'll update this as I find more thing sit fixes:
* Fixes vm::gvar memory allocation size for HLE with array type.