### PR TITLE
hle: cellAuthDialogUtility

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -191,6 +191,7 @@ target_sources(rpcs3_emu PRIVATE
 	Cell/Modules/cellAtracMulti.cpp
 	Cell/Modules/cellAudio.cpp
 	Cell/Modules/cellAudioOut.cpp
+	Cell/Modules/cellAuthDialog.cpp
 	Cell/Modules/cellAvconfExt.cpp
 	Cell/Modules/cellBgdl.cpp
 	Cell/Modules/cellCamera.cpp

--- a/rpcs3/Emu/Cell/Modules/cellAuthDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAuthDialog.cpp
@@ -1,0 +1,66 @@
+#include "stdafx.h"
+#include "Emu/Cell/PPUModule.h"
+
+LOG_CHANNEL(cellSysutil);
+
+// All error codes are unknown at this point in implementation
+enum cellSysutilAuthDialogError : u32
+{
+	CELL_AUTHDIALOG_UNKNOWN_201  = 0x8002D201,
+	CELL_AUTHDIALOG_ARG1_IS_ZERO = 0x8002D202,
+	CELL_AUTHDIALOG_UNKNOWN_203  = 0x8002D203,
+};
+
+template<>
+void fmt_class_string<cellSysutilAuthDialogError>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](auto error)
+	{
+		switch (error)
+		{
+			STR_CASE(CELL_AUTHDIALOG_UNKNOWN_201);
+			STR_CASE(CELL_AUTHDIALOG_ARG1_IS_ZERO);
+			STR_CASE(CELL_AUTHDIALOG_UNKNOWN_203);
+		}
+
+		return unknown;
+	});
+}
+
+// Decompilation suggests arg1 is s64 but the check is for == 0 instead of >= 0
+error_code cellAuthDialogOpen(u64 arg1 /* arg2 */)
+{
+	cellSysutil.todo("cellAuthDialogOpen(arg1=%u)", arg1);
+
+	if (arg1 == 0)
+		return CELL_AUTHDIALOG_ARG1_IS_ZERO;
+
+	return CELL_OK;
+}
+
+error_code cellAuthDialogAbort()
+{
+	cellSysutil.todo("cellAuthDialogAbort()");
+
+	// If it fails the first if condition (not init cond?)
+	// return CELL_AUTHDIALOG_UNKNOWN_203;
+
+	return CELL_OK;
+}
+
+error_code cellAuthDialogClose(/* arg1 */)
+{
+	cellSysutil.todo("cellAuthDialogClose()");
+
+	// If it fails the first if condition (not init cond?)
+	// return CELL_AUTHDIALOG_UNKNOWN_203;
+
+	return CELL_OK;
+}
+
+DECLARE(ppu_module_manager::cellAuthDialogUtility)("cellAuthDialogUtility", []()
+{
+	REG_FUNC(cellAuthDialogUtility, cellAuthDialogOpen);
+	REG_FUNC(cellAuthDialogUtility, cellAuthDialogAbort);
+	REG_FUNC(cellAuthDialogUtility, cellAuthDialogClose);
+});

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -164,6 +164,7 @@ static void ppu_initialize_modules(ppu_linkage_info* link)
 		&ppu_module_manager::cellAtracMulti,
 		&ppu_module_manager::cellAudio,
 		&ppu_module_manager::cellAvconfExt,
+		&ppu_module_manager::cellAuthDialogUtility,
 		&ppu_module_manager::cellBGDL,
 		&ppu_module_manager::cellCamera,
 		&ppu_module_manager::cellCelp8Enc,

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -171,6 +171,7 @@ public:
 	static const ppu_static_module cellAtracMulti;
 	static const ppu_static_module cellAudio;
 	static const ppu_static_module cellAvconfExt;
+	static const ppu_static_module cellAuthDialogUtility;
 	static const ppu_static_module cellBGDL;
 	static const ppu_static_module cellCamera;
 	static const ppu_static_module cellCelp8Enc;

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -190,6 +190,7 @@
     <ClCompile Include="Emu\Cell\Modules\cellAtracMulti.cpp" />
     <ClCompile Include="Emu\Cell\Modules\cellAudio.cpp" />
     <ClCompile Include="Emu\Cell\Modules\cellAudioOut.cpp" />
+    <ClCompile Include="Emu\Cell\Modules\cellAuthDialog.cpp" />
     <ClCompile Include="Emu\Cell\Modules\cellAvconfExt.cpp" />
     <ClCompile Include="Emu\Cell\Modules\cellBgdl.cpp" />
     <ClCompile Include="Emu\Cell\Modules\cellCamera.cpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -341,6 +341,9 @@
     <ClCompile Include="Emu\Cell\Modules\cellAudioOut.cpp">
       <Filter>Emu\Cell\Modules</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\Cell\Modules\cellAuthDialog.cpp">
+      <Filter>Emu\Cell\Modules</Filter>
+    </ClCompile>
     <ClCompile Include="Emu\Cell\Modules\cellAvconfExt.cpp">
       <Filter>Emu\Cell\Modules</Filter>
     </ClCompile>


### PR DESCRIPTION
Did some quick RE on this module to stub functionality. This is imported by Torne TV App, though the app is stuck on other things and doesn't get to the part where it calls this yet.

Thanks to Clienthax for providing bruteforce of 2 of the function names.

Library is libsysutil_authdialog.sprx named cellAuthDialogUtility internally.