### PR TITLE
cellGame, sys_ss rng fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -533,7 +533,7 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 
 	//older sdk. it might not care about game type.
 
-	if (version != CELL_GAMEDATA_VERSION_CURRENT || errDialog > 1)
+	if (version != CELL_GAMEDATA_VERSION_CURRENT || errDialog > 1 || !funcStat || sysutil_check_name_string(dirName.get_ptr(), 1, CELL_GAME_DIRNAME_SIZE) != 0)
 	{
 		return CELL_GAMEDATA_ERROR_PARAM;
 	}

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -1045,16 +1045,18 @@ error_code cellDiscGameGetBootDiscInfo(vm::ptr<CellDiscGameSystemFileParam> getP
 	cellGame.warning("cellDiscGameGetBootDiscInfo(getParam=*0x%x)", getParam);
 
 	if (!getParam)
+	{
 		return CELL_DISCGAME_ERROR_PARAM;
+	}
+
+	// Always sets 0 at first dword
+	reinterpret_cast<nse_t<u32, 1>*>(getParam->titleId)[0] = 0;
 
 	// This is also called by non-disc games, see NPUB90029
-	const std::string dir = "/dev_bdvd/PS3_GAME"s;
+	static const std::string dir = "/dev_bdvd/PS3_GAME"s;
 
 	if (!fs::is_dir(vfs::get(dir)))
 	{
-		getParam->parentalLevel = 0;
-		strcpy_trunc(getParam->titleId, "0");
-
 		return CELL_DISCGAME_ERROR_NOT_DISCBOOT;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_ss.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.h
@@ -3,13 +3,22 @@
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
 
+// Unofficial error code names
+enum sys_ss_rng_error : u32
+{
+	SYS_SS_RNG_ERROR_INVALID_PKG = 0x80010500,
+	SYS_SS_RNG_ERROR_ENOMEM = 0x80010501,
+	SYS_SS_RNG_ERROR_EAGAIN = 0x80010503,
+	SYS_SS_RNG_ERROR_EFAULT = 0x80010509,
+};
+
 struct CellSsOpenPSID
 {
 	be_t<u64> high;
 	be_t<u64> low;
 };
 
-error_code sys_ss_random_number_generator(u32 arg1, vm::ptr<void> buf, u64 size);
+error_code sys_ss_random_number_generator(u64 pkg_id, vm::ptr<void> buf, u64 size);
 error_code sys_ss_access_control_engine(u64 pkg_id, u64 a2, u64 a3);
 s32 sys_ss_get_console_id(vm::ptr<u8> buf);
 s32 sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> ptr);


### PR DESCRIPTION
**improvements to sys_ss_random_number_generator**:
* Replace CELL_EABORT with exception.
* Improve error codes a bit.
* pkg_id == 1 should not return an error if root permission is present.
* Avoid passing vm pointers to native API, use temp buffer instead.

**cellGame/DiscGame improvements**:
* Fix cellDiscGameGetBootDiscInfo on error, always set first dword to 0, other bytes are untouched.
* Check dirName in cellGameDataCheckCreate(2), same as fw.
* Set nullptr in setParam by default.
* if setParam is null after funcStat and it's new data, return error code.
Testcase for cellGame commits : https://github.com/elad335/myps3tests/tree/master/ppu_tests/cellGameDataCheckCreate2
beware of chonky results.