### PR TITLE
overlays: Proper multi-language support

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -376,7 +376,7 @@ target_sources(rpcs3_emu PRIVATE
 	RSX/Null/NullGSRender.cpp
 	RSX/Overlays/overlay_animation.cpp
 	RSX/Overlays/overlay_edit_text.cpp
-	RSX/Overlays/overlay_font.cpp
+	RSX/Overlays/overlay_fonts.cpp
 	RSX/Overlays/overlay_list_view.cpp
 	RSX/Overlays/overlay_message_dialog.cpp
 	RSX/Overlays/overlay_osk.cpp

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -400,12 +400,13 @@ namespace gl
 			fs_src =
 				"#version 420\n\n"
 				"layout(binding=31) uniform sampler2D fs0;\n"
+				"layout(binding=30) uniform sampler2DArray fs1;\n"
 				"layout(location=0) in vec2 tc0;\n"
 				"layout(location=1) flat in vec4 clip_rect;\n"
 				"layout(location=0) out vec4 ocol;\n"
 				"uniform vec4 color;\n"
 				"uniform float time;\n"
-				"uniform int read_texture;\n"
+				"uniform int sampler_mode;\n"
 				"uniform int pulse_glow;\n"
 				"uniform int clip_region;\n"
 				"uniform int blur_strength;\n"
@@ -475,10 +476,18 @@ namespace gl
 				"	if (pulse_glow != 0)\n"
 				"		diff_color.a *= (sin(time) + 1.f) * 0.5f;\n"
 				"\n"
-				"	if (read_texture != 0)\n"
+				"	switch (sampler_mode)\n"
+				"	{\n"
+				"	case 1:\n"
 				"		ocol = sample_image(fs0, tc0) * diff_color;\n"
-				"	else\n"
+				"		break;\n"
+				"	case 2:\n"
+				"		ocol = texture(fs1, vec3(tc0.x, fract(tc0.y), trunc(tc0.y))) * diff_color;\n"
+				"		break;\n"
+				"	default:\n"
 				"		ocol = diff_color;\n"
+				"		break;\n"
+				"	}\n"
 				"}\n";
 
 			// Smooth filtering required for inputs
@@ -552,14 +561,27 @@ namespace gl
 
 		gl::texture_view* find_font(rsx::overlays::font *font)
 		{
+			const auto font_size = font->get_glyph_data_dimensions();
+
 			u64 key = reinterpret_cast<u64>(font);
 			auto found = view_cache.find(key);
 			if (found != view_cache.end())
-				return found->second.get();
+			{
+				if (const auto this_size = found->second->image()->size3D();
+					font_size.width == this_size.width &&
+					font_size.height == this_size.height &&
+					font_size.depth == this_size.depth)
+				{
+					return found->second.get();
+				}
+			}
 
-			//Create font file
-			auto tex = std::make_unique<gl::texture>(GL_TEXTURE_2D, font->width, font->height, 1, 1, GL_R8);
-			tex->copy_from(font->glyph_data.data(), gl::texture::format::r, gl::texture::type::ubyte, {});
+			// Create font file
+			std::vector<u8> glyph_data;
+			font->get_glyph_data(glyph_data);
+
+			auto tex = std::make_unique<gl::texture>(GL_TEXTURE_2D_ARRAY, font_size.width, font_size.height, font_size.depth, 1, GL_R8);
+			tex->copy_from(glyph_data.data(), gl::texture::format::r, gl::texture::type::ubyte, {});
 
 			GLenum remap[] = { GL_RED, GL_RED, GL_RED, GL_RED };
 			auto view = std::make_unique<gl::texture_view>(tex.get(), remap);
@@ -644,14 +666,15 @@ namespace gl
 			program_handle.uniforms["ui_scale"] = color4f(static_cast<f32>(ui.virtual_width), static_cast<f32>(ui.virtual_height), 1.f, 1.f);
 			program_handle.uniforms["time"] = static_cast<f32>(get_system_time() / 1000) * 0.005f;
 
-			saved_sampler_state saved(31, m_sampler);
+			saved_sampler_state save_30(30, m_sampler);
+			saved_sampler_state save_31(31, m_sampler);
 
 			for (auto &cmd : ui.get_compiled().draw_commands)
 			{
 				set_primitive_type(cmd.config.primitives);
 				upload_vertex_data(reinterpret_cast<f32*>(cmd.verts.data()), ::size32(cmd.verts) * 4u);
 				num_drawable_elements = ::size32(cmd.verts);
-				GLint texture_exists = GL_TRUE;
+				GLint texture_read = GL_TRUE;
 
 				switch (cmd.config.texture_ref)
 				{
@@ -660,7 +683,7 @@ namespace gl
 					//TODO
 				case rsx::overlays::image_resource_id::none:
 				{
-					texture_exists = GL_FALSE;
+					texture_read = GL_FALSE;
 					glBindTexture(GL_TEXTURE_2D, GL_NONE);
 					break;
 				}
@@ -671,7 +694,10 @@ namespace gl
 				}
 				case rsx::overlays::image_resource_id::font_file:
 				{
-					glBindTexture(GL_TEXTURE_2D, find_font(cmd.config.font_ref)->id());
+					texture_read = (GL_TRUE + 1);
+					glActiveTexture(GL_TEXTURE0 + 30);
+					glBindTexture(GL_TEXTURE_2D_ARRAY, find_font(cmd.config.font_ref)->id());
+					glActiveTexture(GL_TEXTURE0 + 31);
 					break;
 				}
 				default:
@@ -682,7 +708,7 @@ namespace gl
 				}
 
 				program_handle.uniforms["color"] = cmd.config.color;
-				program_handle.uniforms["read_texture"] = texture_exists;
+				program_handle.uniforms["sampler_mode"] = texture_read;
 				program_handle.uniforms["pulse_glow"] = static_cast<s32>(cmd.config.pulse_glow);
 				program_handle.uniforms["blur_strength"] = static_cast<s32>(cmd.config.blur_strength);
 				program_handle.uniforms["clip_region"] = static_cast<s32>(cmd.config.clip_region);

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -437,9 +437,9 @@ namespace rsx
 				is_compiled = false;
 			}
 
-			virtual void set_text(const char* text)
+			virtual void set_text(const std::wstring& text)
 			{
-				this->text = utf8_to_wstring(text);
+				this->text = text;
 				is_compiled = false;
 			}
 
@@ -1003,7 +1003,6 @@ namespace rsx
 			void set_pos(u16 _x, u16 _y) override;
 			void set_size(u16 _w, u16 _h) override;
 			void translate(s16 dx, s16 dy) override;
-			void set_text(const char* str) override;
 			void set_text(const std::string& str) override;
 
 			compiled_resource& get_compiled() override;
@@ -1061,7 +1060,7 @@ namespace rsx
 			using label::label;
 
 			void move_caret(direction dir);
-			void insert_text(const std::string& str);
+			void insert_text(const std::wstring& str);
 			void erase();
 
 			compiled_resource& get_compiled() override;

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -3,6 +3,8 @@
 #include "Utilities/geometry.h"
 #include "Utilities/File.h"
 #include "overlay_utils.h"
+#include "overlay_fonts.h"
+#include "Emu/System.h"
 
 #include <string>
 #include <vector>
@@ -23,10 +25,6 @@
 #if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/sysctl.h>
 #endif
-
-// STB_IMAGE_IMPLEMENTATION and STB_TRUETYPE_IMPLEMENTATION defined externally
-#include <stb_image.h>
-#include <stb_truetype.h>
 
 // Definitions for common UI controls and their routines
 namespace rsx
@@ -49,73 +47,6 @@ namespace rsx
 			triangle_strip = 1,
 			line_list = 2,
 			line_strip = 3
-		};
-
-		struct font
-		{
-			const u32 width = 1024;
-			const u32 height = 1024;
-			const u32 oversample = 2;
-			const u32 char_count = 256; // 16x16 grid at max 48pt
-
-			f32 size_pt = 12.f;
-			f32 size_px = 16.f; // Default font 12pt size
-			f32 em_size = 0.f;
-			std::string font_name;
-			std::vector<stbtt_packedchar> pack_info;
-			std::vector<u8> glyph_data;
-			bool initialized = false;
-
-			font(const char* ttf_name, f32 size);
-
-			stbtt_aligned_quad get_char(char c, f32& x_advance, f32& y_advance);
-
-			void render_text_ex(std::vector<vertex>& result, f32& x_advance, f32& y_advance, const char* text, u32 char_limit, u16 max_width, bool wrap);
-
-			std::vector<vertex> render_text(const char* text, u16 max_width = UINT16_MAX, bool wrap = false);
-
-			std::pair<f32, f32> get_char_offset(const char* text, u16 max_length, u16 max_width = UINT16_MAX, bool wrap = false);
-		};
-
-		// TODO: Singletons are cancer
-		class fontmgr
-		{
-		private:
-			std::vector<std::unique_ptr<font>> fonts;
-			static fontmgr *m_instance;
-
-			font* find(const char *name, int size)
-			{
-				for (auto &f : fonts)
-				{
-					if (f->font_name == name &&
-						f->size_pt == size)
-						return f.get();
-				}
-
-				fonts.push_back(std::make_unique<font>(name, static_cast<f32>(size)));
-				return fonts.back().get();
-			}
-
-		public:
-
-			fontmgr() = default;
-			~fontmgr()
-			{
-				if (m_instance)
-				{
-					delete m_instance;
-					m_instance = nullptr;
-				}
-			}
-
-			static font* get(const char *name, int size)
-			{
-				if (m_instance == nullptr)
-					m_instance = new fontmgr;
-
-				return m_instance->find(name, size);
-			}
 		};
 
 		struct image_info
@@ -400,7 +331,7 @@ namespace rsx
 			u16 w = 0;
 			u16 h = 0;
 
-			std::string text;
+			std::wstring text;
 			font* font_ref = nullptr;
 			text_align alignment = left;
 			bool wrap_text = false;
@@ -502,13 +433,13 @@ namespace rsx
 
 			virtual void set_text(const std::string& text)
 			{
-				this->text = text;
+				this->text = utf8_to_wstring(text);
 				is_compiled = false;
 			}
 
 			virtual void set_text(const char* text)
 			{
-				this->text = text;
+				this->text = utf8_to_wstring(text);
 				is_compiled = false;
 			}
 
@@ -535,7 +466,7 @@ namespace rsx
 				return font_ref ? font_ref : fontmgr::get("Arial", 12);
 			}
 
-			virtual std::vector<vertex> render_text(const char *string, f32 x, f32 y)
+			virtual std::vector<vertex> render_text(const wchar_t *string, f32 x, f32 y)
 			{
 				auto renderer = get_font();
 
@@ -554,7 +485,7 @@ namespace rsx
 						// Apply transform.
 						// (0, 0) has text sitting one line off the top left corner (text is outside the rect) hence the offset by text height
 						v.values[0] += x + padding_left;
-						v.values[1] += y + padding_top + static_cast<f32>(renderer->size_px);
+						v.values[1] += y + padding_top + static_cast<f32>(renderer->get_size_px());
 					}
 
 					if (alignment == center)
@@ -589,7 +520,7 @@ namespace rsx
 								continue;
 
 							const f32 line_length = result[p.second - 1].values[0] - result[p.first].values[0];
-							const bool wrapped = std::fabs(result[p.second - 1].values[1] - result[p.first + 3].values[1]) >= (renderer->size_px * 0.5f);
+							const bool wrapped = std::fabs(result[p.second - 1].values[1] - result[p.first + 3].values[1]) >= (renderer->get_size_px() * 0.5f);
 
 							if (wrapped)
 								continue;
@@ -665,13 +596,13 @@ namespace rsx
 				f32 unused = 0.f;
 				f32 max_w = 0.f;
 				f32 last_word = 0.f;
-				height = static_cast<u16>(renderer->size_px);
+				height = static_cast<u16>(renderer->get_size_px());
 
 				for (auto c : text)
 				{
 					if (c == '\n')
 					{
-						height += static_cast<u16>(renderer->size_px + 2);
+						height += static_cast<u16>(renderer->get_size_px() + 2);
 						max_w = std::max(max_w, text_width);
 						text_width = 0.f;
 						last_word = 0.f;
@@ -683,23 +614,15 @@ namespace rsx
 						last_word = text_width;
 					}
 
-					if (static_cast<u8>(c) > renderer->char_count)
-					{
-						// Non-existent glyph
-						text_width += renderer->em_size;
-					}
-					else
-					{
-						renderer->get_char(c, text_width, unused);
-					}
+					renderer->get_char(c, text_width, unused);
 
 					if (!ignore_word_wrap && wrap_text && text_width >= w)
 					{
 						if ((text_width - last_word) < w)
 						{
 							max_w = std::max(max_w, last_word);
-							text_width -= (last_word + renderer->em_size);
-							height += static_cast<u16>(renderer->size_px + 2);
+							text_width -= (last_word + renderer->get_em_size());
+							height += static_cast<u16>(renderer->get_size_px() + 2);
 						}
 					}
 				}
@@ -1033,7 +956,7 @@ namespace rsx
 
 			label(const std::string& text)
 			{
-				this->text = text;
+				set_text(text);
 			}
 
 			bool auto_resize(bool grow_only = false, u16 limit_w = UINT16_MAX, u16 limit_h = UINT16_MAX)
@@ -1114,7 +1037,7 @@ namespace rsx
 
 			int get_selected_index();
 
-			std::string get_selected_item();
+			std::wstring get_selected_item();
 
 			void set_cancel_only(bool cancel_only);
 			void translate(s16 _x, s16 _y) override;

--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
@@ -39,17 +39,17 @@ namespace rsx
 			if (caret_position == 0)
 			{
 				// Start
-				text = str + text;
+				text = utf8_to_wstring(str) + text;
 			}
 			else if (caret_position == text.length())
 			{
 				// End
-				text += str;
+				text += utf8_to_wstring(str);
 			}
 			else
 			{
 				// Middle
-				text.insert(caret_position, str);
+				text.insert(caret_position, utf8_to_wstring(str));
 			}
 
 			caret_position += ::narrow<u16>(str.length());
@@ -65,7 +65,7 @@ namespace rsx
 
 			if (caret_position == 1)
 			{
-				text = text.length() > 1 ? text.substr(1) : "";
+				text = text.length() > 1 ? text.substr(1) : L"";
 			}
 			else if (caret_position == text.length())
 			{
@@ -91,7 +91,7 @@ namespace rsx
 				const auto caret_loc = renderer->get_char_offset(text.c_str(), caret_position, clip_text ? w : UINT16_MAX, wrap_text);
 
 				caret.set_pos(u16(caret_loc.first + padding_left + x), u16(caret_loc.second + padding_top + y));
-				caret.set_size(1, u16(renderer->size_px + 2));
+				caret.set_size(1, u16(renderer->get_size_px() + 2));
 				caret.fore_color           = fore_color;
 				caret.back_color           = fore_color;
 				caret.pulse_effect_enabled = true;

--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
@@ -34,22 +34,22 @@ namespace rsx
 			}
 		}
 
-		void edit_text::insert_text(const std::string& str)
+		void edit_text::insert_text(const std::wstring& str)
 		{
 			if (caret_position == 0)
 			{
 				// Start
-				text = utf8_to_wstring(str) + text;
+				text = str + text;
 			}
 			else if (caret_position == text.length())
 			{
 				// End
-				text += utf8_to_wstring(str);
+				text += str;
 			}
 			else
 			{
 				// Middle
-				text.insert(caret_position, utf8_to_wstring(str));
+				text.insert(caret_position, str);
 			}
 
 			caret_position += ::narrow<u16>(str.length());

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
@@ -12,6 +12,19 @@ namespace rsx
 {
 	namespace overlays
 	{
+		enum language_class
+		{
+			default_ = 0, // Typically latin-1, extended latin, hebrew, arabic and cyrillic
+			cjk = 1       // The thousands of CJK glyphs occupying pages 2E-9F
+		};
+
+		struct glyph_load_setup
+		{
+			std::string font_name;
+			std::vector<std::string> lookup_font_dirs;
+			std::vector<std::string> fallback_fonts;
+		};
+
 		// Each 'page' holds an indexed block of 256 code points
 		// The BMP (Basic Multilingual Plane) has 256 allocated pages but not all are necessary
 		// While there are supplementary planes, the BMP is the most important thing to support
@@ -49,6 +62,8 @@ namespace rsx
 			}
 			codepage_cache;
 
+			language_class classify(u16 page);
+			glyph_load_setup get_glyph_files(language_class class_);
 			codepage* initialize_codepage(u16 page);
 		public:
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
@@ -12,17 +12,17 @@ namespace rsx
 {
 	namespace overlays
 	{
-		enum language_class
+		enum class language_class
 		{
-			default_ = 0, // Typically latin-1, extended latin, hebrew, arabic and cyrillic
-			cjk = 1       // The thousands of CJK glyphs occupying pages 2E-9F
+			default_ = 0,   // Typically latin-1, extended latin, hebrew, arabic and cyrillic
+			cjk_base = 1,   // The thousands of CJK glyphs occupying pages 2E-9F
+			hangul = 2      // Korean jamo
 		};
 
 		struct glyph_load_setup
 		{
-			std::string font_name;
+			std::vector<std::string> font_names;
 			std::vector<std::string> lookup_font_dirs;
-			std::vector<std::string> fallback_fonts;
 		};
 
 		// Each 'page' holds an indexed block of 256 code points

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
@@ -1,0 +1,116 @@
+﻿#include "Utilities/types.h"
+#include "overlay_utils.h"
+
+#include <vector>
+#include <unordered_map>
+
+// STB_IMAGE_IMPLEMENTATION and STB_TRUETYPE_IMPLEMENTATION defined externally
+#include <stb_image.h>
+#include <stb_truetype.h>
+
+namespace rsx
+{
+	namespace overlays
+	{
+		// Each 'page' holds an indexed block of 256 code points
+		// The BMP (Basic Multilingual Plane) has 256 allocated pages but not all are necessary
+		// While there are supplementary planes, the BMP is the most important thing to support
+		struct codepage
+		{
+			static constexpr u32 bitmap_width = 1024;
+			static constexpr u32 bitmap_height = 1024;
+			static constexpr u32 char_count = 256; // 16x16 grid at max 48pt
+			static constexpr u32 oversample = 2;
+
+			std::vector<stbtt_packedchar> pack_info;
+			std::vector<u8> glyph_data;
+			u16 glyph_base = 0;
+			f32 sampler_z = 0.f;
+
+			void initialize_glyphs(u16 codepage_id, f32 font_size, const std::vector<u8>& ttf_data);
+			stbtt_aligned_quad get_char(wchar_t c, f32& x_advance, f32& y_advance);
+		};
+
+		class font
+		{
+		private:
+			f32 size_pt = 12.f;
+			f32 size_px = 16.f; // Default font 12pt size
+			f32 em_size = 0.f;
+			std::string font_name;
+
+			std::vector<std::pair<u32, std::unique_ptr<codepage>>> m_glyph_map;
+			bool initialized = false;
+
+			struct
+			{
+				u16 codepage_id = 0;
+				codepage* page = nullptr;
+			}
+			codepage_cache;
+
+			codepage* initialize_codepage(u16 page);
+		public:
+
+			font(const char* ttf_name, f32 size);
+
+			stbtt_aligned_quad get_char(wchar_t c, f32& x_advance, f32& y_advance);
+
+			void render_text_ex(std::vector<vertex>& result, f32& x_advance, f32& y_advance, const wchar_t* text, u32 char_limit, u16 max_width, bool wrap);
+
+			std::vector<vertex> render_text(const wchar_t* text, u16 max_width = UINT16_MAX, bool wrap = false);
+
+			std::pair<f32, f32> get_char_offset(const wchar_t* text, u16 max_length, u16 max_width = UINT16_MAX, bool wrap = false);
+
+			bool matches(const char* name, int size) const { return font_name == name && static_cast<int>(size_pt) == size; }
+			std::string_view get_name() const { return font_name; };
+			f32 get_size_pt() const { return size_pt; }
+			f32 get_size_px() const { return size_px; }
+			f32 get_em_size() const { return em_size; }
+
+			// Renderer info
+			size3u get_glyph_data_dimensions() const { return { codepage::bitmap_width, codepage::bitmap_height, ::size32(m_glyph_map) }; }
+			void get_glyph_data(std::vector<u8>& bytes) const;
+		};
+
+		// TODO: Singletons are cancer
+		class fontmgr
+		{
+		private:
+			std::vector<std::unique_ptr<font>> fonts;
+			static fontmgr* m_instance;
+
+			font* find(const char* name, int size)
+			{
+				for (auto& f : fonts)
+				{
+					if (f->matches(name, size))
+						return f.get();
+				}
+
+				fonts.push_back(std::make_unique<font>(name, static_cast<f32>(size)));
+				return fonts.back().get();
+			}
+
+		public:
+
+			fontmgr() = default;
+			~fontmgr()
+			{
+				if (m_instance)
+				{
+					delete m_instance;
+					m_instance = nullptr;
+				}
+			}
+
+			static font* get(const char* name, int size)
+			{
+				if (m_instance == nullptr)
+					m_instance = new fontmgr;
+
+				return m_instance->find(name, size);
+			}
+		};
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
@@ -150,7 +150,7 @@ namespace rsx
 			return m_selected_entry;
 		}
 
-		std::string list_view::get_selected_item()
+		std::wstring list_view::get_selected_item()
 		{
 			if (m_selected_entry < 0)
 				return {};

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -176,7 +176,7 @@ namespace rsx
 				btn_cancel.translate(0, offset);
 			}
 
-			text_display.set_text(utf8_to_ascii8(text));
+			text_display.set_text(text);
 
 			u16 text_w, text_h;
 			text_display.measure_text(text_w, text_h);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -405,7 +405,7 @@ namespace rsx
 
 		void osk_dialog::on_text_changed()
 		{
-			const auto ws = ascii8_to_utf16(m_preview.text);
+			const auto ws = wstring_to_utf16(m_preview.text);
 			const auto length = (ws.length() + 1) * sizeof(char16_t);
 			memcpy(osk_text, ws.c_str(), length);
 
@@ -420,7 +420,7 @@ namespace rsx
 		void osk_dialog::on_default_callback(const std::string& str)
 		{
 			// Append to output text
-			if (m_preview.text == "[Enter Text]")
+			if (m_preview.text == L"[Enter Text]")
 			{
 				m_preview.caret_position = ::narrow<u16>(str.length());
 				m_preview.set_text(str);
@@ -433,7 +433,7 @@ namespace rsx
 					return;
 				}
 
-				auto new_str = m_preview.text + str;
+				auto new_str = m_preview.text + utf8_to_wstring(str);
 				if (new_str.length() <= char_limit)
 				{
 					m_preview.insert_text(str);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -29,7 +29,7 @@ namespace rsx
 			fade_animation.active = true;
 		}
 
-		void osk_dialog::initialize_layout(const std::vector<grid_entry_ctor>& layout, const std::string& title, const std::string& initial_text)
+		void osk_dialog::initialize_layout(const std::vector<grid_entry_ctor>& layout, const std::wstring& title, const std::wstring& initial_text)
 		{
 			const u32 cell_count = num_rows * num_columns;
 
@@ -370,7 +370,7 @@ namespace rsx
 			}
 			case pad_button::select:
 			{
-				on_shift("");
+				on_shift(L"");
 				break;
 			}
 			case pad_button::start:
@@ -380,12 +380,12 @@ namespace rsx
 			}
 			case pad_button::triangle:
 			{
-				on_space("");
+				on_space(L"");
 				break;
 			}
 			case pad_button::square:
 			{
-				on_backspace("");
+				on_backspace(L"");
 				break;
 			}
 			case pad_button::cross:
@@ -417,7 +417,7 @@ namespace rsx
 			m_update = true;
 		}
 
-		void osk_dialog::on_default_callback(const std::string& str)
+		void osk_dialog::on_default_callback(const std::wstring& str)
 		{
 			// Append to output text
 			if (m_preview.text == L"[Enter Text]")
@@ -433,7 +433,7 @@ namespace rsx
 					return;
 				}
 
-				auto new_str = m_preview.text + utf8_to_wstring(str);
+				auto new_str = m_preview.text + str;
 				if (new_str.length() <= char_limit)
 				{
 					m_preview.insert_text(str);
@@ -443,17 +443,17 @@ namespace rsx
 			on_text_changed();
 		}
 
-		void osk_dialog::on_shift(const std::string&)
+		void osk_dialog::on_shift(const std::wstring&)
 		{
 			selected_z = (selected_z + 1) % num_layers;
 			m_update = true;
 		}
 
-		void osk_dialog::on_space(const std::string&)
+		void osk_dialog::on_space(const std::wstring&)
 		{
 			if (!(flags & CELL_OSKDIALOG_NO_SPACE))
 			{
-				on_default_callback(" ");
+				on_default_callback(L" ");
 			}
 			else
 			{
@@ -461,7 +461,7 @@ namespace rsx
 			}
 		}
 
-		void osk_dialog::on_backspace(const std::string&)
+		void osk_dialog::on_backspace(const std::wstring&)
 		{
 			if (m_preview.text.empty())
 			{
@@ -472,11 +472,11 @@ namespace rsx
 			on_text_changed();
 		}
 
-		void osk_dialog::on_enter(const std::string&)
+		void osk_dialog::on_enter(const std::wstring&)
 		{
 			if (!(flags & CELL_OSKDIALOG_NO_RETURN))
 			{
-				on_default_callback("\n");
+				on_default_callback(L"\n");
 			}
 			else
 			{
@@ -617,59 +617,57 @@ namespace rsx
 			std::vector<osk_dialog::grid_entry_ctor> layout =
 			{
 				// Alphanumeric
-				{{"1", "!"}, default_bg, 1},
-				{{"2", "@"}, default_bg, 1},
-				{{"3", "#"}, default_bg, 1},
-				{{"4", "$"}, default_bg, 1},
-				{{"5", "%"}, default_bg, 1},
-				{{"6", "^"}, default_bg, 1},
-				{{"7", "&"}, default_bg, 1},
-				{{"8", "*"}, default_bg, 1},
-				{{"9", "("}, default_bg, 1},
-				{{"0", ")"}, default_bg, 1},
+				{{L"1", L"!"}, default_bg, 1},
+				{{L"2", L"@"}, default_bg, 1},
+				{{L"3", L"#"}, default_bg, 1},
+				{{L"4", L"$"}, default_bg, 1},
+				{{L"5", L"%"}, default_bg, 1},
+				{{L"6", L"^"}, default_bg, 1},
+				{{L"7", L"&"}, default_bg, 1},
+				{{L"8", L"*"}, default_bg, 1},
+				{{L"9", L"("}, default_bg, 1},
+				{{L"0", L")"}, default_bg, 1},
 
 				// Alpha
-				{{"q", "Q"}, default_bg, 1},
-				{{"w", "W"}, default_bg, 1},
-				{{"e", "E"}, default_bg, 1},
-				{{"r", "R"}, default_bg, 1},
-				{{"t", "T"}, default_bg, 1},
-				{{"y", "Y"}, default_bg, 1},
-				{{"u", "U"}, default_bg, 1},
-				{{"i", "I"}, default_bg, 1},
-				{{"o", "O"}, default_bg, 1},
-				{{"p", "P"}, default_bg, 1},
-				{{"a", "A"}, default_bg, 1},
-				{{"s", "S"}, default_bg, 1},
-				{{"d", "D"}, default_bg, 1},
-				{{"f", "F"}, default_bg, 1},
-				{{"g", "G"}, default_bg, 1},
-				{{"h", "H"}, default_bg, 1},
-				{{"j", "J"}, default_bg, 1},
-				{{"k", "K"}, default_bg, 1},
-				{{"l", "L"}, default_bg, 1},
-				{{"'", "\""}, default_bg, 1},
-				{{"z", "Z"}, default_bg, 1},
-				{{"x", "X"}, default_bg, 1},
-				{{"c", "C"}, default_bg, 1},
-				{{"v", "V"}, default_bg, 1},
-				{{"b", "B"}, default_bg, 1},
-				{{"n", "N"}, default_bg, 1},
-				{{"m", "M"}, default_bg, 1},
-				{{"-", "_"}, default_bg, 1},
-				{{"+", "="}, default_bg, 1},
-				{{",", "?"}, default_bg, 1},
+				{{L"q", L"Q"}, default_bg, 1},
+				{{L"w", L"W"}, default_bg, 1},
+				{{L"e", L"E"}, default_bg, 1},
+				{{L"r", L"R"}, default_bg, 1},
+				{{L"t", L"T"}, default_bg, 1},
+				{{L"y", L"Y"}, default_bg, 1},
+				{{L"u", L"U"}, default_bg, 1},
+				{{L"i", L"I"}, default_bg, 1},
+				{{L"o", L"O"}, default_bg, 1},
+				{{L"p", L"P"}, default_bg, 1},
+				{{L"a", L"A"}, default_bg, 1},
+				{{L"s", L"S"}, default_bg, 1},
+				{{L"d", L"D"}, default_bg, 1},
+				{{L"f", L"F"}, default_bg, 1},
+				{{L"g", L"G"}, default_bg, 1},
+				{{L"h", L"H"}, default_bg, 1},
+				{{L"j", L"J"}, default_bg, 1},
+				{{L"k", L"K"}, default_bg, 1},
+				{{L"l", L"L"}, default_bg, 1},
+				{{L"'", L"\""}, default_bg, 1},
+				{{L"z", L"Z"}, default_bg, 1},
+				{{L"x", L"X"}, default_bg, 1},
+				{{L"c", L"C"}, default_bg, 1},
+				{{L"v", L"V"}, default_bg, 1},
+				{{L"b", L"B"}, default_bg, 1},
+				{{L"n", L"N"}, default_bg, 1},
+				{{L"m", L"M"}, default_bg, 1},
+				{{L"-", L"_"}, default_bg, 1},
+				{{L"+", L"="}, default_bg, 1},
+				{{L",", L"?"}, default_bg, 1},
 
 				// Special
-				{{"Shift"}, special2_bg, 2, button_flags::_default, shift_callback },
-				{{"Space"}, special_bg, 4, button_flags::_space, space_callback },
-				{{"Backspace"}, special_bg, 2, button_flags::_default, delete_callback },
-				{{"Enter"}, special2_bg, 2, button_flags::_return, enter_callback },
+				{{L"Shift"}, special2_bg, 2, button_flags::_default, shift_callback },
+				{{L"Space"}, special_bg, 4, button_flags::_space, space_callback },
+				{{L"Backspace"}, special_bg, 2, button_flags::_default, delete_callback },
+				{{L"Enter"}, special2_bg, 2, button_flags::_return, enter_callback },
 			};
 
-			// Narrow to utf-8 as native does not have support for non-ascii glyphs
-			// TODO: Full multibyte string support in all of rsx::overlays (kd-11)
-			initialize_layout(layout, utf16_to_ascii8(message), utf16_to_ascii8(init_text));
+			initialize_layout(layout, utf16_to_wstring(message), utf16_to_wstring(init_text));
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -186,9 +186,9 @@ namespace rsx
 			switch (m_detail)
 			{
 			case detail_level::minimal:
-			case detail_level::low: m_titles.text = ""; break;
-			case detail_level::medium: m_titles.text = fmt::format("\n\n%s", title1_medium); break;
-			case detail_level::high: m_titles.text = fmt::format("\n\n%s\n\n\n\n\n\n%s", title1_high, title2); break;
+			case detail_level::low: m_titles.set_text(""); break;
+			case detail_level::medium: m_titles.set_text(fmt::format("\n\n%s", title1_medium)); break;
+			case detail_level::high: m_titles.set_text(fmt::format("\n\n%s\n\n\n\n\n\n%s", title1_high, title2)); break;
 			}
 			m_titles.auto_resize();
 			m_titles.refresh();
@@ -486,7 +486,7 @@ namespace rsx
 				}
 				}
 
-				m_body.text = perf_text;
+				m_body.set_text(perf_text);
 
 				if (m_body.auto_resize())
 				{
@@ -573,7 +573,7 @@ namespace rsx
 
 		void graph::set_font_size(u16 font_size)
 		{
-			const auto font_name = m_label.get_font()->font_name.c_str();
+			const auto font_name = m_label.get_font()->get_name().data();
 			m_label.set_font(font_name, font_size);
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_progress_bar.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_progress_bar.cpp
@@ -58,19 +58,6 @@ namespace rsx
 			set_pos(x + dx, y + dy);
 		}
 
-		void progress_bar::set_text(const char* str)
-		{
-			text_view.set_text(str);
-			text_view.align_text(text_align::center);
-
-			u16 text_w, text_h;
-			text_view.measure_text(text_w, text_h);
-			text_view.set_size(w, text_h);
-
-			set_pos(text_view.x, text_view.y);
-			is_compiled = false;
-		}
-
 		void progress_bar::set_text(const std::string& str)
 		{
 			text_view.set_text(str);

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -29,8 +29,8 @@ namespace rsx
 
 			std::unique_ptr<overlay_element> text_stack  = std::make_unique<vertical_layout>();
 			std::unique_ptr<overlay_element> padding     = std::make_unique<spacer>();
-			std::unique_ptr<overlay_element> header_text = std::make_unique<label>(utf8_to_ascii8(text1));
-			std::unique_ptr<overlay_element> subtext     = std::make_unique<label>(utf8_to_ascii8(text2));
+			std::unique_ptr<overlay_element> header_text = std::make_unique<label>(text1);
+			std::unique_ptr<overlay_element> subtext     = std::make_unique<label>(text2);
 
 			padding->set_size(1, 1);
 			header_text->set_size(800, 40);
@@ -54,7 +54,7 @@ namespace rsx
 			if (!text3.empty())
 			{
 				// Detail info actually exists
-				std::unique_ptr<overlay_element> detail = std::make_unique<label>(utf8_to_ascii8(text3));
+				std::unique_ptr<overlay_element> detail = std::make_unique<label>(text3);
 				detail->set_size(800, 0);
 				detail->set_font("Arial", 12);
 				detail->set_wrap_text(true);

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -127,7 +127,7 @@ namespace rsx
 			default: break;
 			}
 
-			trophy_message = "You have earned the " + trophy_message + " trophy\n" + utf8_to_ascii8(trophy.name);
+			trophy_message = "You have earned the " + trophy_message + " trophy\n" + trophy.name;
 			text_view.set_text(trophy_message);
 			text_view.auto_resize();
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_utils.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_utils.h
@@ -1,4 +1,8 @@
 ﻿#pragma once
+#include "Utilities/types.h"
+#include "Utilities/geometry.h"
+
+#include <string>
 
 struct vertex
 {
@@ -152,3 +156,4 @@ std::string utf16_to_ascii8(const std::u16string& utf16_string);
 std::u16string ascii8_to_utf16(const std::string& ascii_string);
 std::wstring utf8_to_wstring(const std::string& utf8_string);
 std::u16string wstring_to_utf16(const std::wstring& w_string);
+std::wstring utf16_to_wstring(const std::u16string& utf16_string);

--- a/rpcs3/Emu/RSX/Overlays/overlay_utils.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_utils.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 struct vertex
 {
@@ -146,3 +146,9 @@ void operator < (const vector3_base<T>& lhs, T rhs)
 
 using vector3i = vector3_base<int>;
 using vector3f = vector3_base<float>;
+
+std::string utf8_to_ascii8(const std::string& utf8_string);
+std::string utf16_to_ascii8(const std::u16string& utf16_string);
+std::u16string ascii8_to_utf16(const std::string& ascii_string);
+std::wstring utf8_to_wstring(const std::string& utf8_string);
+std::u16string wstring_to_utf16(const std::wstring& w_string);

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -200,6 +200,26 @@ std::u16string wstring_to_utf16(const std::wstring& w_string)
 	}
 }
 
+std::wstring utf16_to_wstring(const std::u16string& utf16_string)
+{
+	if constexpr (sizeof(wchar_t) == sizeof(char16_t))
+	{
+		return reinterpret_cast<const wchar_t*>(utf16_string.data());
+	}
+	else
+	{
+		std::wstring result;
+		result.reserve(utf16_string.size());
+
+		for (const auto& code : utf16_string)
+		{
+			result.push_back(code);
+		}
+
+		return result;
+	}
+}
+
 namespace rsx
 {
 	namespace overlays

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -58,15 +58,13 @@ static auto s_ascii_lowering_map = []()
 	return _map;
 }();
 
-std::string utf8_to_ascii8(const std::string& utf8_string)
+template<typename F>
+void process_multibyte(const std::string s, F&& func)
 {
-	std::string out;
-	out.reserve(utf8_string.length());
-
-	const auto end = utf8_string.length();
+	const auto end = s.length();
 	for (u32 index = 0; index < end; ++index)
 	{
-		const u8 code = static_cast<u8>(utf8_string[index]);
+		const u8 code = static_cast<u8>(s[index]);
 
 		if (!code)
 		{
@@ -75,7 +73,7 @@ std::string utf8_to_ascii8(const std::string& utf8_string)
 
 		if (code <= 0x7F)
 		{
-			out.push_back(code);
+			std::invoke(func, code);
 			continue;
 		}
 
@@ -83,7 +81,7 @@ std::string utf8_to_ascii8(const std::string& utf8_string)
 		if ((index + extra_bytes) > end)
 		{
 			// Malformed string, abort
-			overlays.error("Failed to decode supossedly malformed utf8 string '%s'", utf8_string);
+			overlays.error("Failed to decode supossedly malformed utf8 string '%s'", s);
 			break;
 		}
 
@@ -92,38 +90,46 @@ std::string utf8_to_ascii8(const std::string& utf8_string)
 		{
 		case 1:
 			// 11 bits, 6 + 5
-			u_code = (u32(code & 0x1F) << 6) | u32(utf8_string[index + 1] & 0x3F);
+			u_code = (u32(code & 0x1F) << 6) | u32(s[index + 1] & 0x3F);
 			break;
 		case 2:
 			// 16 bits, 6 + 6 + 4
-			u_code = (u32(code & 0xF) << 12) | (u32(utf8_string[index + 1] & 0x3F) << 6) | u32(utf8_string[index + 2] & 0x3F);
+			u_code = (u32(code & 0xF) << 12) | (u32(s[index + 1] & 0x3F) << 6) | u32(s[index + 2] & 0x3F);
 			break;
 		case 3:
 			// 21 bits, 6 + 6 + 6 + 3
-			u_code = (u32(code & 0x7) << 18) | (u32(utf8_string[index + 1] & 0x3F) << 12) | (u32(utf8_string[index + 2] & 0x3F) << 6) | u32(utf8_string[index + 3] & 0x3F);
+			u_code = (u32(code & 0x7) << 18) | (u32(s[index + 1] & 0x3F) << 12) | (u32(s[index + 2] & 0x3F) << 6) | u32(s[index + 3] & 0x3F);
 			break;
 		default:
 			fmt::throw_exception("Unreachable" HERE);
 		}
 
 		index += extra_bytes;
+		std::invoke(func, u_code);
+	}
+}
 
-		if (u_code <= 0xFF)
+std::string utf8_to_ascii8(const std::string& utf8_string)
+{
+	std::string out;
+	out.reserve(utf8_string.length());
+
+	process_multibyte(utf8_string, [&out](u32 code)
+	{
+		if (code <= 0x7F)
 		{
-			// Latin-1 supplement block
-			out.push_back(static_cast<u8>(u_code));
-			continue;
+			out.push_back(static_cast<u8>(code));
 		}
-
-		auto replace = s_ascii_lowering_map.find(u_code);
-		if (replace == s_ascii_lowering_map.end())
+		else if (auto replace = s_ascii_lowering_map.find(code);
+			replace == s_ascii_lowering_map.end())
 		{
 			out.push_back('#');
-			continue;
 		}
-
-		out.push_back(replace->second);
-	}
+		else
+		{
+			out.push_back(replace->second);
+		}
+	});
 
 	return out;
 }
@@ -159,6 +165,39 @@ std::u16string ascii8_to_utf16(const std::string& ascii_string)
 	}
 
 	return out;
+}
+
+std::wstring utf8_to_wstring(const std::string& utf8_string)
+{
+	std::wstring result;
+	result.reserve(utf8_string.size());
+
+	process_multibyte(utf8_string, [&result](u32 code)
+	{
+		result.push_back(static_cast<wchar_t>(code));
+	});
+
+	return result;
+}
+
+std::u16string wstring_to_utf16(const std::wstring& w_string)
+{
+	if constexpr (sizeof(wchar_t) == sizeof(char16_t))
+	{
+		return reinterpret_cast<const char16_t*>(w_string.data());
+	}
+	else
+	{
+		std::u16string result;
+		result.reserve(w_string.size());
+
+		for (const auto& code : w_string)
+		{
+			result.push_back(code);
+		}
+
+		return result;
+	}
 }
 
 namespace rsx

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -20,9 +20,6 @@
 #include <list>
 
 // Utils
-std::string utf8_to_ascii8(const std::string& utf8_string);
-std::string utf16_to_ascii8(const std::u16string& utf16_string);
-std::u16string ascii8_to_utf16(const std::string& ascii_string);
 extern u64 get_system_time();
 
 // Definition of user interface implementations

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -333,7 +333,7 @@ namespace rsx
 
 		struct osk_dialog : public user_interface, public OskDialogBase
 		{
-			using callback_t = std::function<void(const std::string&)>;
+			using callback_t = std::function<void(const std::wstring&)>;
 
 			enum border_flags
 			{
@@ -363,13 +363,13 @@ namespace rsx
 				bool selected = false;
 				bool enabled = false;
 
-				std::vector<std::string> outputs;
+				std::vector<std::wstring> outputs;
 				callback_t callback;
 			};
 
 			struct grid_entry_ctor
 			{
-				std::vector<std::string> outputs;
+				std::vector<std::wstring> outputs;
 				color4f color;
 				u32 num_cell_hz;
 				button_flags type_flags;
@@ -415,17 +415,17 @@ namespace rsx
 			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 options) override = 0;
 			void Close(bool ok) override;
 
-			void initialize_layout(const std::vector<grid_entry_ctor>& layout, const std::string& title, const std::string& initial_text);
+			void initialize_layout(const std::vector<grid_entry_ctor>& layout, const std::wstring& title, const std::wstring& initial_text);
 			void update() override;
 
 			void on_button_pressed(pad_button button_press) override;
 			void on_text_changed();
 
-			void on_default_callback(const std::string&);
-			void on_shift(const std::string&);
-			void on_space(const std::string&);
-			void on_backspace(const std::string&);
-			void on_enter(const std::string&);
+			void on_default_callback(const std::wstring&);
+			void on_shift(const std::wstring&);
+			void on_space(const std::wstring&);
+			void on_backspace(const std::wstring&);
+			void on_enter(const std::wstring&);
 
 			compiled_resource get_compiled() override;
 		};

--- a/rpcs3/Emu/RSX/VK/VKFramebuffer.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFramebuffer.cpp
@@ -25,7 +25,7 @@ namespace vk
 		for (auto &e : image_list)
 		{
 			const VkImageSubresourceRange subres = { e->aspect(), 0, 1, 0, 1 };
-			image_views.push_back(std::make_unique<vk::image_view>(dev, e, vk::default_component_map(), subres));
+			image_views.push_back(std::make_unique<vk::image_view>(dev, e, VK_IMAGE_VIEW_TYPE_2D, vk::default_component_map(), subres));
 		}
 
 		auto value = std::make_unique<vk::framebuffer_holder>(dev, renderpass, width, height, std::move(image_views));

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -141,7 +141,7 @@ namespace vk
 	VkImageAspectFlags get_aspect_flags(VkFormat format);
 
 	VkSampler null_sampler();
-	image_view* null_image_view(vk::command_buffer&);
+	image_view* null_image_view(vk::command_buffer&, VkImageViewType type);
 	image* get_typeless_helper(VkFormat format, u32 requested_width, u32 requested_height);
 	buffer* get_scratch_buffer(u32 min_required_size = 0);
 	data_heap* get_upload_heap();
@@ -1387,6 +1387,11 @@ private:
 			return info.mipLevels;
 		}
 
+		u32 layers() const
+		{
+			return info.arrayLayers;
+		}
+
 		u8 samples() const
 		{
 			return u8(info.samples);
@@ -1456,8 +1461,9 @@ private:
 		}
 
 		image_view(VkDevice dev, vk::image* resource,
-			const VkComponentMapping mapping = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A },
-			const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1})
+			VkImageViewType view_type = VK_IMAGE_VIEW_TYPE_MAX_ENUM,
+			const VkComponentMapping& mapping = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A },
+			const VkImageSubresourceRange& range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1})
 			: m_device(dev), m_resource(resource)
 		{
 			info.format = resource->info.format;
@@ -1466,23 +1472,34 @@ private:
 			info.components = mapping;
 			info.subresourceRange = range;
 
-			switch (resource->info.imageType)
+			if (view_type == VK_IMAGE_VIEW_TYPE_MAX_ENUM)
 			{
-			case VK_IMAGE_TYPE_1D:
-				info.viewType = VK_IMAGE_VIEW_TYPE_1D;
-				break;
-			case VK_IMAGE_TYPE_2D:
-				if (resource->info.flags == VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)
-					info.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
-				else
-					info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-				break;
-			case VK_IMAGE_TYPE_3D:
-				info.viewType = VK_IMAGE_VIEW_TYPE_3D;
-				break;
-			default:
-				ASSUME(0);
-				break;
+				switch (resource->info.imageType)
+				{
+				case VK_IMAGE_TYPE_1D:
+					info.viewType = VK_IMAGE_VIEW_TYPE_1D;
+					break;
+				case VK_IMAGE_TYPE_2D:
+					if (resource->info.flags == VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)
+						info.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
+					else if (resource->info.arrayLayers == 1)
+						info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+					else
+						info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+					break;
+				case VK_IMAGE_TYPE_3D:
+					info.viewType = VK_IMAGE_VIEW_TYPE_3D;
+					break;
+				default:
+					ASSUME(0);
+					break;
+				}
+
+				info.subresourceRange.layerCount = resource->info.arrayLayers;
+			}
+			else
+			{
+				info.viewType = view_type;
 			}
 
 			create_impl();
@@ -1588,7 +1605,7 @@ private:
 			const auto range = vk::get_image_subresource_range(0, 0, info.arrayLayers, info.mipLevels, aspect() & mask);
 
 			verify(HERE), range.aspectMask;
-			auto view = std::make_unique<vk::image_view>(*get_current_renderer(), this, real_mapping, range);
+			auto view = std::make_unique<vk::image_view>(*get_current_renderer(), this, VK_IMAGE_VIEW_TYPE_MAX_ENUM, real_mapping, range);
 
 			auto result = view.get();
 			views.emplace(remap_encoding, std::move(view));

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -12,6 +12,8 @@ namespace vk
 		u64 eid;
 		const vk::render_device* m_device;
 		std::vector<std::unique_ptr<vk::buffer>> m_disposed_buffers;
+		std::vector<std::unique_ptr<vk::image_view>> m_disposed_image_views;
+		std::vector<std::unique_ptr<vk::image>> m_disposed_images;
 		rsx::simple_array<VkEvent> m_disposed_events;
 
 		eid_scope_t(u64 _eid):
@@ -36,6 +38,8 @@ namespace vk
 			}
 
 			m_disposed_buffers.clear();
+			m_disposed_image_views.clear();
+			m_disposed_images.clear();
 		}
 	};
 
@@ -130,6 +134,16 @@ namespace vk
 		void dispose(std::unique_ptr<vk::buffer>& buf)
 		{
 			get_current_eid_scope().m_disposed_buffers.emplace_back(std::move(buf));
+		}
+
+		void dispose(std::unique_ptr<vk::image_view>& view)
+		{
+			get_current_eid_scope().m_disposed_image_views.emplace_back(std::move(view));
+		}
+
+		void dispose(std::unique_ptr<vk::image>& img)
+		{
+			get_current_eid_scope().m_disposed_images.emplace_back(std::move(img));
 		}
 
 		void dispose(VkEvent& event)

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -340,7 +340,7 @@
     <ClCompile Include="Emu\RSX\Overlays\overlays.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_animation.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_edit_text.cpp" />
-    <ClCompile Include="Emu\RSX\Overlays\overlay_font.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\overlay_fonts.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_list_view.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_message_dialog.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_osk.cpp" />
@@ -417,6 +417,7 @@
     <ClInclude Include="Emu\Io\Keyboard.h" />
     <ClInclude Include="Emu\Io\pad_config.h" />
     <ClInclude Include="Emu\RSX\Common\texture_cache_helpers.h" />
+    <ClInclude Include="Emu\RSX\Overlays\overlay_fonts.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_perf_metrics.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_utils.h" />
     <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -836,9 +836,6 @@
     <ClCompile Include="Emu\RSX\Overlays\overlay_trophy_notification.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
-    <ClCompile Include="Emu\RSX\Overlays\overlay_font.cpp">
-      <Filter>Emu\GPU\RSX\Overlays</Filter>
-    </ClCompile>
     <ClCompile Include="Emu\RSX\Overlays\overlay_list_view.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
@@ -895,6 +892,9 @@
     </ClCompile>
     <ClCompile Include="Emu\system_config_types.cpp">
       <Filter>Emu</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\overlay_fonts.cpp">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1698,6 +1698,9 @@
     </ClInclude>
     <ClInclude Include="Emu\system_config_types.h">
       <Filter>Emu</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\overlay_fonts.h">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Rewrites font handling and rendering to support wchar types. Allows extensible support for pretty much any language in the basic multi-lingual plane and even beyond to the extended unicode planes.

Newly supported character sets include but are not limited to:
- Japanese
- Chinese
- Korean
- Cyrillic
- etc

Dialogs have been adjusted to use the new system and should therefore work out of the box. Should solve the problem where some users have to disable the native dialogs to get the emulator usable.