### PR TITLE
hle: Fix cellAvconfExt wrongly registered functions

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -283,18 +283,6 @@ error_code cellAudioOutSetCopyControl(u32 audioOut, u32 control)
 	return CELL_OK;
 }
 
-error_code cellAudioOutConfigure2()
-{
-	cellSysutil.todo("cellAudioOutConfigure2()");
-	return CELL_OK;
-}
-
-error_code cellAudioOutGetConfiguration2()
-{
-	cellSysutil.todo("cellAudioOutGetConfiguration2()");
-	return CELL_OK;
-}
-
 error_code cellAudioOutRegisterCallback()
 {
 	cellSysutil.todo("cellAudioOutRegisterCallback()");
@@ -312,13 +300,11 @@ void cellSysutil_AudioOut_init()
 {
 	REG_FUNC(cellSysutil, cellAudioOutGetState);
 	REG_FUNC(cellSysutil, cellAudioOutConfigure);
-	REG_FUNC(cellSysutil, cellAudioOutConfigure2);
 	REG_FUNC(cellSysutil, cellAudioOutGetSoundAvailability);
 	REG_FUNC(cellSysutil, cellAudioOutGetSoundAvailability2);
 	REG_FUNC(cellSysutil, cellAudioOutGetDeviceInfo);
 	REG_FUNC(cellSysutil, cellAudioOutGetNumberOfDevice);
 	REG_FUNC(cellSysutil, cellAudioOutGetConfiguration);
-	REG_FUNC(cellSysutil, cellAudioOutGetConfiguration2);
 	REG_FUNC(cellSysutil, cellAudioOutSetCopyControl);
 	REG_FUNC(cellSysutil, cellAudioOutRegisterCallback);
 	REG_FUNC(cellSysutil, cellAudioOutUnregisterCallback);

--- a/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
@@ -188,7 +188,7 @@ error_code cellAudioInGetDeviceInfo(u32 deviceNumber, u32 deviceIndex, vm::ptr<C
 error_code cellVideoOutConvertCursorColor(u32 videoOut, s32 displaybuffer_format, f32 gamma, s32 source_buffer_format, vm::ptr<void> src_addr, vm::ptr<u32> dest_addr, s32 num)
 {
 	cellAvconfExt.todo("cellVideoOutConvertCursorColor(videoOut=%d, displaybuffer_format=0x%x, gamma=0x%x, source_buffer_format=0x%x, src_addr=*0x%x, dest_addr=*0x%x, num=0x%x)", videoOut,
-	    displaybuffer_format, gamma, source_buffer_format, src_addr, dest_addr, num);
+			displaybuffer_format, gamma, source_buffer_format, src_addr, dest_addr, num);
 	return CELL_OK;
 }
 
@@ -318,6 +318,30 @@ error_code cellVideoOutSetCopyControl(u32 videoOut, u32 control)
 	return CELL_OK;
 }
 
+error_code cellVideoOutConfigure2()
+{
+	cellAvconfExt.todo("cellVideoOutConfigure2()");
+	return CELL_OK;
+}
+
+error_code cellAudioOutGetConfiguration2()
+{
+	cellAvconfExt.todo("cellAudioOutGetConfiguration2()");
+	return CELL_OK;
+}
+
+error_code cellAudioOutConfigure2()
+{
+	cellAvconfExt.todo("cellAudioOutConfigure2()");
+	return CELL_OK;
+}
+
+error_code cellVideoOutGetResolutionAvailability2()
+{
+	cellAvconfExt.todo("cellVideoOutGetResolutionAvailability2()");
+	return CELL_OK;
+}
+
 DECLARE(ppu_module_manager::cellAvconfExt)
 ("cellSysutilAvconfExt", []() {
 	REG_FUNC(cellSysutilAvconfExt, cellAudioOutUnregisterDevice);
@@ -337,4 +361,8 @@ DECLARE(ppu_module_manager::cellAvconfExt)
 	REG_FUNC(cellSysutilAvconfExt, cellAudioInUnregisterDevice);
 	REG_FUNC(cellSysutilAvconfExt, cellVideoOutGetScreenSize);
 	REG_FUNC(cellSysutilAvconfExt, cellVideoOutSetCopyControl);
+	REG_FUNC(cellSysutilAvconfExt, cellVideoOutConfigure2);
+	REG_FUNC(cellSysutilAvconfExt, cellAudioOutGetConfiguration2);
+	REG_FUNC(cellSysutilAvconfExt, cellAudioOutConfigure2);
+	REG_FUNC(cellSysutilAvconfExt, cellVideoOutGetResolutionAvailability2);
 });

--- a/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
@@ -289,18 +289,6 @@ error_code cellVideoOutGetResolutionAvailability(u32 videoOut, u32 resolutionId,
 	return CELL_VIDEO_OUT_ERROR_UNSUPPORTED_VIDEO_OUT;
 }
 
-error_code cellVideoOutConfigure2()
-{
-	cellSysutil.todo("cellVideoOutConfigure2()");
-	return CELL_OK;
-}
-
-error_code cellVideoOutGetResolutionAvailability2()
-{
-	cellSysutil.todo("cellVideoOutGetResolutionAvailability2()");
-	return CELL_OK;
-}
-
 error_code cellVideoOutGetConvertCursorColorInfo(vm::ptr<u8> rgbOutputRange)
 {
 	cellSysutil.todo("cellVideoOutGetConvertCursorColorInfo()");
@@ -331,12 +319,10 @@ void cellSysutil_VideoOut_init()
 	REG_FUNC(cellSysutil, cellVideoOutGetState);
 	REG_FUNC(cellSysutil, cellVideoOutGetResolution).flag(MFF_PERFECT);
 	REG_FUNC(cellSysutil, cellVideoOutConfigure);
-	REG_FUNC(cellSysutil, cellVideoOutConfigure2);
 	REG_FUNC(cellSysutil, cellVideoOutGetConfiguration);
 	REG_FUNC(cellSysutil, cellVideoOutGetDeviceInfo);
 	REG_FUNC(cellSysutil, cellVideoOutGetNumberOfDevice);
 	REG_FUNC(cellSysutil, cellVideoOutGetResolutionAvailability);
-	REG_FUNC(cellSysutil, cellVideoOutGetResolutionAvailability2);
 	REG_FUNC(cellSysutil, cellVideoOutGetConvertCursorColorInfo);
 	REG_FUNC(cellSysutil, cellVideoOutDebugSetMonitorType);
 	REG_FUNC(cellSysutil, cellVideoOutRegisterCallback);


### PR DESCRIPTION
Co-authored-by: Clienthax

Torne TV App exposed an unregistered function
` E {PPU[0x1000000] Thread (main_thread) [0x005d0000]} PPU: Unregistered function called (LR=0x2a3b8)`

We figured out it was from libsysutil_avconf_ext
```
·! 0:01:52.448828 ppu_loader: ** Imported module 'cellSysutilAvconfExt' (ver=0x1, attr=0x9, 0x0, 0x0) [0x49940c]
·! 0:01:52.448829 ppu_loader: **** cellSysutilAvconfExt import: [cellVideoOutSetCopyControl] -> 0x490ecc
·! 0:01:52.448831 ppu_loader: **** cellSysutilAvconfExt import: [0x341D9459] -> 0x490eec
·! 0:01:52.448832 ppu_loader: **** cellSysutilAvconfExt import: [0x9FAA12BE] -> 0x490f0c
```

Upon checking, we noticed some functions were registered to the wrong modules. 0x9FAA12BE (cellVideoOutConfigure2) was already registered, but to cellSysutil instead of cellSysutilAvconfExt, for example.

Now Torne TV App correctly calls
` U {PPU[0x1000000] Thread (main_thread) [0x005d0328]} cellAvconfExt TODO: cellVideoOutConfigure2()`
