### PR TITLE
File.cpp: Make var ref instead of copy

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1639,7 +1639,7 @@ u64 fs::get_dir_size(const std::string& path, u64 rounding_alignment)
 {
 	u64 result = 0;
 
-	for (const auto entry : dir(path))
+	for (const auto& entry : dir(path))
 	{
 		if (entry.name == "." || entry.name == "..")
 		{


### PR DESCRIPTION
Fixes a lonely warning during build.