### PR TITLE
Qt 5.15 deprecation fixes

### DIFF
--- a/rpcs3/rpcs3qt/custom_table_widget_item.h
+++ b/rpcs3/rpcs3qt/custom_table_widget_item.h
@@ -28,7 +28,7 @@ public:
 
 	bool operator <(const QTableWidgetItem &other) const
 	{
-		return data(m_sort_role) < other.data(m_sort_role);
+		return data(m_sort_role).Int < other.data(m_sort_role).Int;
 	}
 
 	void setData(int role, const QVariant &value, bool assign_sort_role = false)

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -133,7 +133,7 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 	});
 
 	connect(m_choice_units, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, &debugger_frame::UpdateUI);
-	connect(m_choice_units, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &debugger_frame::OnSelectUnit);
+	connect(m_choice_units, static_cast<void (QComboBox::*)(int, const QString&)>(&QComboBox::currentIndexChanged), this, &debugger_frame::OnSelectUnit);
 	connect(this, &QDockWidget::visibilityChanged, this, &debugger_frame::EnableUpdateTimer);
 
 	connect(m_debugger_list, &debugger_list::BreakpointRequested, m_breakpoint_list, &breakpoint_list::HandleBreakpointRequest);

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -384,7 +384,7 @@ void emu_settings::EnhanceComboBox(QComboBox* combobox, SettingsType type, bool 
 		combobox->setCurrentIndex(index);
 	}
 
-	connect(combobox, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [=, this](int index)
+	connect(combobox, static_cast<void(QComboBox::*)(int, const QString&)>(&QComboBox::currentIndexChanged), [=, this](int index)
 	{
 		SetSetting(type, sstr(combobox->itemData(index)));
 	});

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -198,7 +198,7 @@ void game_compatibility::RequestCompatibility(bool online)
 	// Handle response according to its contents
 	connect(network_reply, &QNetworkReply::finished, [=, this]()
 	{
-		if (network_reply->error() != QNetworkReply::NoError)
+		if (network_reply->networkError() != QNetworkReply::NoError)
 		{
 			return;
 		}

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -12,7 +12,7 @@ class game_list : public QTableWidget
 private:
 	void mousePressEvent(QMouseEvent *event) override
 	{
-		if (!indexAt(event->pos()).isValid() || itemAt(event->pos())->data(Qt::UserRole) < 0)
+		if (!indexAt(event->pos()).isValid() || itemAt(event->pos())->data(Qt::UserRole).Int < 0)
 		{
 			clearSelection();
 		}

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -191,7 +191,7 @@ pad_settings_dialog::pad_settings_dialog(QWidget *parent, const GameInfo *game)
 	OnTabChanged(0);
 
 	// repaint controller image
-	ui->l_controller->setPixmap(gui::utils::get_colorized_pixmap(*ui->l_controller->pixmap(), QColor(), gui::utils::get_label_color("l_controller"), false, true));
+	ui->l_controller->setPixmap(gui::utils::get_colorized_pixmap(ui->l_controller->pixmap(Qt::ReturnByValue), QColor(), gui::utils::get_label_color("l_controller"), false, true));
 
 	// set tab layout constraint to the first tab
 	m_tabs->widget(0)->layout()->setSizeConstraint(QLayout::SetFixedSize);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -98,7 +98,7 @@ pad_settings_dialog::pad_settings_dialog(QWidget *parent, const GameInfo *game)
 	connect(ui->chooseHandler, &QComboBox::currentTextChanged, this, &pad_settings_dialog::ChangeInputType);
 
 	// Combobox: Devices
-	connect(ui->chooseDevice, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index)
+	connect(ui->chooseDevice, QOverload<int, const QString&>::of(&QComboBox::currentIndexChanged), [this](int index)
 	{
 		if (index < 0)
 		{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -260,7 +260,10 @@ void pad_settings_dialog::InitButtons()
 	m_padButtons->addButton(ui->b_ok, button_ids::id_ok);
 	m_padButtons->addButton(ui->b_cancel, button_ids::id_cancel);
 
-	connect(m_padButtons, static_cast<void(QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), this, &pad_settings_dialog::OnPadButtonClicked);
+	connect(m_padButtons, static_cast<void(QButtonGroup::*)(QAbstractButton *)>(&QButtonGroup::buttonClicked), this, [this](QAbstractButton *button)
+	{
+		OnPadButtonClicked(m_padButtons->id(button));
+	});
 
 	connect(&m_timer, &QTimer::timeout, [this]()
 	{

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1123,7 +1123,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> guiSettings, std:
 	};
 
 	// Events
-	connect(libModeBG, static_cast<void(QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), l_OnLibButtonClicked);
+	connect(libModeBG, static_cast<void(QButtonGroup::*)(QAbstractButton *)>(&QButtonGroup::buttonClicked), [&l_OnLibButtonClicked, &libModeBG](QAbstractButton *button)
+	{
+		l_OnLibButtonClicked(libModeBG->id(button));
+	});
 	connect(ui->searchBox, &QLineEdit::textChanged, l_OnSearchBoxTextChanged);
 
 	// enable multiselection (there must be a better way)

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -105,7 +105,7 @@ void update_manager::handle_error(QNetworkReply::NetworkError error)
 
 bool update_manager::handle_reply(QNetworkReply* reply, std::function<bool(update_manager& man, const QByteArray&, bool)> func, bool automatic, const std::string& message)
 {
-	if (auto error = reply->error(); error != QNetworkReply::NoError)
+	if (auto error = reply->networkError(); error != QNetworkReply::NoError)
 		return false;
 
 	// Read data from network reply


### PR DESCRIPTION
Qt 5.15 marks more stuff as deprecated, this pull request fixes those by using the appropriate replacements for each function.

From a quick glance everything should compile on 5.14, but I'm marking this as draft until travis & appveyor verifies that for me.