### PR TITLE
RawSPU: fix race condition on setting run request after stop request

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -580,6 +580,7 @@ public:
 	u32 ch_dec_value; // written decrementer value
 
 	atomic_t<u32> run_ctrl; // SPU Run Control register (only provided to get latest data written)
+	shared_mutex run_ctrl_mtx;
 
 	struct alignas(8) status_npc_sync_var
 	{


### PR DESCRIPTION
It's true that after issueing a RawSPU stop request the spu thread does not need to stop immediatly, but it does need to allow further start requests to issue immediatly.

Should address #7562, and hopefully all the related freezes for it that were there even before the offending pr.