### PR TITLE
Add "pressure sensitivity" to the keyboard pad handler

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -179,22 +179,24 @@ std::tuple<u16, u16> PadHandlerBase::NormalizeStickDeadzone(s32 inX, s32 inY, u3
 
 	if (dzRange > 0.f)
 	{
-		const float mag = std::min(sqrtf(X*X + Y*Y), 1.f);
+		const float mag = std::min(sqrtf(X * X + Y * Y), 1.f);
 
 		if (mag <= 0)
 		{
 			return std::tuple<u16, u16>(ConvertAxis(X), ConvertAxis(Y));
 		}
 
-		if (mag > dzRange) {
-			float pos = lerp(0.13f, 1.f, (mag - dzRange) / (1 - dzRange));
-			float scale = pos / mag;
+		if (mag > dzRange)
+		{
+			const float pos = std::lerp(0.13f, 1.f, (mag - dzRange) / (1 - dzRange));
+			const float scale = pos / mag;
 			X = X * scale;
 			Y = Y * scale;
 		}
-		else {
-			float pos = lerp(0.f, 0.13f, mag / dzRange);
-			float scale = pos / mag;
+		else
+		{
+			const float pos = std::lerp(0.f, 0.13f, mag / dzRange);
+			const float scale = pos / mag;
 			X = X * scale;
 			Y = Y * scale;
 		}
@@ -244,32 +246,32 @@ std::tuple<u16, u16> PadHandlerBase::ConvertToSquirclePoint(u16 inX, u16 inY, in
 	return std::tuple<u16, u16>(newX, newY);
 }
 
-std::string PadHandlerBase::name_string()
+std::string PadHandlerBase::name_string() const
 {
 	return m_name_string;
 }
 
-size_t PadHandlerBase::max_devices()
+size_t PadHandlerBase::max_devices() const
 {
 	return m_max_devices;
 }
 
-bool PadHandlerBase::has_config()
+bool PadHandlerBase::has_config() const
 {
 	return b_has_config;
 }
 
-bool PadHandlerBase::has_rumble()
+bool PadHandlerBase::has_rumble() const
 {
 	return b_has_rumble;
 }
 
-bool PadHandlerBase::has_deadzones()
+bool PadHandlerBase::has_deadzones() const
 {
 	return b_has_deadzones;
 }
 
-bool PadHandlerBase::has_led()
+bool PadHandlerBase::has_led() const
 {
 	return b_has_led;
 }
@@ -332,8 +334,8 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const std:
 	std::pair<u16, std::string> pressed_button = { 0, "" };
 	for (const auto& button : button_list)
 	{
-		u32 keycode = button.first;
-		u16 value = data[keycode];
+		const u32 keycode = button.first;
+		const u16 value = data[keycode];
 
 		if (!get_blacklist && std::find(blacklist.begin(), blacklist.end(), keycode) != blacklist.end())
 			continue;

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -321,11 +321,6 @@ protected:
 	std::unordered_map<u32, std::string> button_list;
 	std::vector<u32> blacklist;
 
-	template <typename T>
-	T lerp(T v0, T v1, T t) {
-		return std::fma(t, v1, std::fma(-t, v0, v0));
-	}
-
 	// Search an unordered map for a string value and return found keycode
 	static int FindKeyCode(const std::unordered_map<u32, std::string>& map, const cfg::string& name, bool fallback = true);
 

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -327,22 +327,22 @@ protected:
 	}
 
 	// Search an unordered map for a string value and return found keycode
-	int FindKeyCode(const std::unordered_map<u32, std::string>& map, const cfg::string& name, bool fallback = true);
+	static int FindKeyCode(const std::unordered_map<u32, std::string>& map, const cfg::string& name, bool fallback = true);
 
 	// Search an unordered map for a string value and return found keycode
-	long FindKeyCode(const std::unordered_map<u64, std::string>& map, const cfg::string& name, bool fallback = true);
+	static long FindKeyCode(const std::unordered_map<u64, std::string>& map, const cfg::string& name, bool fallback = true);
 
 	// Search an unordered map for a string value and return found keycode
-	int FindKeyCodeByString(const std::unordered_map<u32, std::string>& map, const std::string& name, bool fallback = true);
+	static int FindKeyCodeByString(const std::unordered_map<u32, std::string>& map, const std::string& name, bool fallback = true);
 
 	// Search an unordered map for a string value and return found keycode
-	long FindKeyCodeByString(const std::unordered_map<u64, std::string>& map, const std::string& name, bool fallback = true);
+	static long FindKeyCodeByString(const std::unordered_map<u64, std::string>& map, const std::string& name, bool fallback = true);
 
 	// Get new scaled value between 0 and 255 based on its minimum and maximum
-	float ScaleStickInput(s32 raw_value, int minimum, int maximum);
+	static float ScaleStickInput(s32 raw_value, int minimum, int maximum);
 
 	// Get new scaled value between -255 and 255 based on its minimum and maximum
-	float ScaleStickInput2(s32 raw_value, int minimum, int maximum);
+	static float ScaleStickInput2(s32 raw_value, int minimum, int maximum);
 
 	// Get normalized trigger value based on the range defined by a threshold
 	u16 NormalizeTriggerInput(u16 value, int threshold);
@@ -359,18 +359,18 @@ protected:
 	std::tuple<u16, u16> NormalizeStickDeadzone(s32 inX, s32 inY, u32 deadzone);
 
 	// get clamped value between 0 and 255
-	u16 Clamp0To255(f32 input);
+	static u16 Clamp0To255(f32 input);
 	// get clamped value between 0 and 1023
-	u16 Clamp0To1023(f32 input);
+	static u16 Clamp0To1023(f32 input);
 
 	// input has to be [-1,1]. result will be [0,255]
-	u16 ConvertAxis(float value);
+	static u16 ConvertAxis(float value);
 
 	// The DS3, (and i think xbox controllers) give a 'square-ish' type response, so that the corners will give (almost)max x/y instead of the ~30x30 from a perfect circle
 	// using a simple scale/sensitivity increase would *work* although it eats a chunk of our usable range in exchange
 	// this might be the best for now, in practice it seems to push the corners to max of 20x20, with a squircle_factor of 8000
 	// This function assumes inX and inY is already in 0-255
-	std::tuple<u16, u16> ConvertToSquirclePoint(u16 inX, u16 inY, int squircle_factor);
+	static std::tuple<u16, u16> ConvertToSquirclePoint(u16 inX, u16 inY, int squircle_factor);
 
 public:
 	s32 thumb_min = 0;
@@ -383,12 +383,12 @@ public:
 
 	pad_handler m_type;
 
-	std::string name_string();
-	size_t max_devices();
-	bool has_config();
-	bool has_rumble();
-	bool has_deadzones();
-	bool has_led();
+	std::string name_string() const;
+	size_t max_devices() const;
+	bool has_config() const;
+	bool has_rumble() const;
+	bool has_deadzones() const;
+	bool has_led() const;
 
 	static std::string get_config_dir(pad_handler type, const std::string& title_id = "");
 	static std::string get_config_filename(int i, const std::string& title_id = "");

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -112,11 +112,36 @@ struct Button
 	u16 m_value = 0;
 	bool m_pressed = false;
 
+	u16 m_actual_value = 0; // only used in keyboard_pad_handler
+	bool m_analog  = false; // only used in keyboard_pad_handler
+	bool m_trigger = false; // only used in keyboard_pad_handler
+
 	Button(u32 offset, u32 keyCode, u32 outKeyCode)
 		: m_offset(offset)
 		, m_keyCode(keyCode)
 		, m_outKeyCode(outKeyCode)
 	{
+		if (offset == CELL_PAD_BTN_OFFSET_DIGITAL1)
+		{
+			if (outKeyCode == CELL_PAD_CTRL_LEFT || outKeyCode == CELL_PAD_CTRL_RIGHT ||
+				outKeyCode == CELL_PAD_CTRL_UP   || outKeyCode == CELL_PAD_CTRL_DOWN)
+			{
+				m_analog = true;
+			}
+		}
+		else if (offset == CELL_PAD_BTN_OFFSET_DIGITAL2)
+		{
+			if (outKeyCode == CELL_PAD_CTRL_CROSS  || outKeyCode == CELL_PAD_CTRL_CIRCLE ||
+				outKeyCode == CELL_PAD_CTRL_SQUARE || outKeyCode == CELL_PAD_CTRL_TRIANGLE ||
+				outKeyCode == CELL_PAD_CTRL_L1     || outKeyCode == CELL_PAD_CTRL_R1)
+			{
+				m_analog = true;
+			}
+			else if (outKeyCode == CELL_PAD_CTRL_L2 || outKeyCode == CELL_PAD_CTRL_R2)
+			{
+				m_trigger = true;
+			}
+		}
 	}
 };
 

--- a/rpcs3/Emu/Io/pad_config.h
+++ b/rpcs3/Emu/Io/pad_config.h
@@ -99,6 +99,8 @@ struct pad_config final : cfg::node
 
 	cfg::_int<0, 100> l_stick_lerp_factor{ this, "Left Stick Lerp Factor", 100 };
 	cfg::_int<0, 100> r_stick_lerp_factor{ this, "Right Stick Lerp Factor", 100 };
+	cfg::_int<0, 100> analog_lerp_factor{ this, "Analog Button Lerp Factor", 100 };
+	cfg::_int<0, 100> trigger_lerp_factor{ this, "Trigger Lerp Factor", 100 };
 
 	cfg::_int<0, 5> device_class_type{ this, "Device Class Type", 0 };
 

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -693,7 +693,7 @@ void keyboard_pad_handler::ThreadProc()
 						const f32 v1 = static_cast<f32>(m_stick_val[j]);
 
 						// linear interpolation from the current stick value v0 to the desired stick value v1
-						f32 res = lerp(v0, v1, stick_lerp_factor);
+						f32 res = std::lerp(v0, v1, stick_lerp_factor);
 
 						// round to the correct direction to prevent sticky sticks on small factors
 						res = (v0 <= v1) ? std::ceil(res) : std::floor(res);

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -75,8 +75,25 @@ void keyboard_pad_handler::Key(const u32 code, bool pressed, u16 value)
 			if (button.m_keyCode != code)
 				continue;
 
-			button.m_pressed = pressed;
-			button.m_value = pressed ? value : 0;
+			button.m_actual_value = pressed ? value : 0;
+
+			bool update_button = true;
+
+			// to get the fastest response time possible we don't wanna use any lerp with factor 1
+			if (button.m_analog)
+			{
+				update_button = m_analog_lerp_factor >= 1.0f;
+			}
+			else if (button.m_trigger)
+			{
+				update_button = m_trigger_lerp_factor >= 1.0f;
+			}
+
+			if (update_button)
+			{
+				button.m_value = pressed ? value : 0;
+				button.m_pressed = pressed;
+			}
 		}
 
 		for (int i = 0; i < static_cast<int>(pad->m_sticks.size()); i++)
@@ -576,6 +593,8 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::
 	m_multi_y = p_profile->mouse_acceleration_y / 100.0;
 	m_l_stick_lerp_factor = p_profile->l_stick_lerp_factor / 100.0f;
 	m_r_stick_lerp_factor = p_profile->r_stick_lerp_factor / 100.0f;
+	m_analog_lerp_factor  = p_profile->analog_lerp_factor / 100.0f;
+	m_trigger_lerp_factor = p_profile->trigger_lerp_factor / 100.0f;
 
 	auto find_key = [&](const cfg::string& name)
 	{
@@ -635,6 +654,63 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::
 
 void keyboard_pad_handler::ThreadProc()
 {
+	static const double mouse_interval = 30.0;
+	static const double stick_interval = 10.0;
+	static const double button_interval = 10.0;
+
+	const auto now = std::chrono::steady_clock::now();
+
+	const double elapsed_left = std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_mouse_move_left).count() / 1000.0;
+	const double elapsed_right = std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_mouse_move_right).count() / 1000.0;
+	const double elapsed_up = std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_mouse_move_up).count() / 1000.0;
+	const double elapsed_down = std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_mouse_move_down).count() / 1000.0;
+	const double elapsed_stick = std::chrono::duration_cast<std::chrono::microseconds>(now - m_stick_time).count() / 1000.0;
+	const double elapsed_button = std::chrono::duration_cast<std::chrono::microseconds>(now - m_button_time).count() / 1000.0;
+
+	const bool update_sticks = elapsed_stick > stick_interval;
+	const bool update_buttons = elapsed_button > button_interval;
+
+	if (update_sticks)
+	{
+		m_stick_time = now;
+	}
+
+	if (update_buttons)
+	{
+		m_button_time = now;
+	}
+
+	// roughly 1-2 frames to process the next mouse move
+	if (elapsed_left > mouse_interval)
+	{
+		Key(mouse::move_left, false);
+		m_last_mouse_move_left = now;
+	}
+	if (elapsed_right > mouse_interval)
+	{
+		Key(mouse::move_right, false);
+		m_last_mouse_move_right = now;
+	}
+	if (elapsed_up > mouse_interval)
+	{
+		Key(mouse::move_up, false);
+		m_last_mouse_move_up = now;
+	}
+	if (elapsed_down > mouse_interval)
+	{
+		Key(mouse::move_down, false);
+		m_last_mouse_move_down = now;
+	}
+
+	const auto get_lerped = [](f32 v0, f32 v1, f32 lerp_factor)
+	{
+		// linear interpolation from the current value v0 to the desired value v1
+		const f32 res = std::lerp(v0, v1, lerp_factor);
+
+		// round to the correct direction to prevent sticky values on small factors
+		return (v0 <= v1) ? std::ceil(res) : std::floor(res);
+	};
+
 	for (uint i = 0; i < bindings.size(); i++)
 	{
 		if (last_connection_status[i] == false)
@@ -646,41 +722,7 @@ void keyboard_pad_handler::ThreadProc()
 		}
 		else
 		{
-			static std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-			now = std::chrono::steady_clock::now();
-
-			const double elapsed_left = std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_mouse_move_left).count() / 1000.0;
-			const double elapsed_right = std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_mouse_move_right).count() / 1000.0;
-			const double elapsed_up = std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_mouse_move_up).count() / 1000.0;
-			const double elapsed_down = std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_mouse_move_down).count() / 1000.0;
-			const double elapsed_stick = std::chrono::duration_cast<std::chrono::microseconds>(now - m_stick_time).count() / 1000.0;
-
-			const double mouse_interval = 30.0;
-			const double stick_interval = 10.0;
-
-			// roughly 1-2 frames to process the next mouse move
-			if (elapsed_left > mouse_interval)
-			{
-				Key(mouse::move_left, false);
-				m_last_mouse_move_left = now;
-			}
-			if (elapsed_right > mouse_interval)
-			{
-				Key(mouse::move_right, false);
-				m_last_mouse_move_right = now;
-			}
-			if (elapsed_up > mouse_interval)
-			{
-				Key(mouse::move_up, false);
-				m_last_mouse_move_up = now;
-			}
-			if (elapsed_down > mouse_interval)
-			{
-				Key(mouse::move_down, false);
-				m_last_mouse_move_down = now;
-			}
-
-			if (elapsed_stick > stick_interval)
+			if (update_sticks)
 			{
 				for (int j = 0; j < static_cast<int>(bindings[i]->m_sticks.size()); j++)
 				{
@@ -691,25 +733,50 @@ void keyboard_pad_handler::ThreadProc()
 					{
 						const f32 v0 = static_cast<f32>(bindings[i]->m_sticks[j].m_value);
 						const f32 v1 = static_cast<f32>(m_stick_val[j]);
-
-						// linear interpolation from the current stick value v0 to the desired stick value v1
-						f32 res = std::lerp(v0, v1, stick_lerp_factor);
-
-						// round to the correct direction to prevent sticky sticks on small factors
-						res = (v0 <= v1) ? std::ceil(res) : std::floor(res);
+						const f32 res = get_lerped(v0, v1, stick_lerp_factor);
 
 						bindings[i]->m_sticks[j].m_value = static_cast<u16>(res);
 					}
 				}
+			}
 
-				m_stick_time = now;
+			if (update_buttons)
+			{
+				for (auto& button : bindings[i]->m_buttons)
+				{
+					if (button.m_analog)
+					{
+						// we already applied the following values on keypress if we used factor 1
+						if (m_analog_lerp_factor < 1.0f)
+						{
+							const f32 v0 = static_cast<f32>(button.m_value);
+							const f32 v1 = static_cast<f32>(button.m_actual_value);
+							const f32 res = get_lerped(v0, v1, m_analog_lerp_factor);
+
+							button.m_value = static_cast<u16>(res);
+							button.m_pressed = button.m_value > 0;
+						}
+					}
+					else if (button.m_trigger)
+					{
+						// we already applied the following values on keypress if we used factor 1
+						if (m_trigger_lerp_factor < 1.0f)
+						{
+							const f32 v0 = static_cast<f32>(button.m_value);
+							const f32 v1 = static_cast<f32>(button.m_actual_value);
+							const f32 res = get_lerped(v0, v1, m_trigger_lerp_factor);
+
+							button.m_value = static_cast<u16>(res);
+							button.m_pressed = button.m_value > 0;
+						}
+					}
+				}
 			}
 		}
 	}
 
 	// Releases the wheel buttons 0,1 sec after they've been triggered
 	// Next activation is set to distant future to avoid activating this on every proc
-	const auto now = std::chrono::steady_clock::now();
 	const auto update_threshold = now - std::chrono::milliseconds(100);
 	const auto distant_future = now + std::chrono::hours(24);
 	if (update_threshold >= m_last_wheel_move_up)

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -101,6 +101,11 @@ private:
 	QWindow* m_target = nullptr;
 	std::vector<std::shared_ptr<Pad>> bindings;
 
+	// Button Movements
+	std::chrono::steady_clock::time_point m_button_time;
+	f32 m_analog_lerp_factor  = 1.0f;
+	f32 m_trigger_lerp_factor = 1.0f;
+
 	// Stick Movements
 	std::chrono::steady_clock::time_point m_stick_time;
 	f32 m_l_stick_lerp_factor = 1.0f;


### PR DESCRIPTION
Adds new lerp factors to the keyboard pad handler in order to simulate triggers and analog buttons.
See "Analog Button Lerp Factor" and "Trigger Lerp Factor" in the yml in InputConfigs/Keyboard/.
Values Range from 0-100 as before, where 100 is instant press and 0 is never.

Currently I'm not planning any GUI element for this.