### PR TITLE
rsx: Fix NULL renderer

### DIFF
--- a/rpcs3/Emu/RSX/Null/NullGSRender.cpp
+++ b/rpcs3/Emu/RSX/Null/NullGSRender.cpp
@@ -12,5 +12,6 @@ NullGSRender::NullGSRender() : GSRender()
 
 void NullGSRender::end()
 {
-	rsx::method_registers.current_draw_clause.end();
+	execute_nop_draw();
+	rsx::thread::end();
 }


### PR DESCRIPTION
It didn't clear draw ranges and failed with a verification failure in rsx_methods.h.