### PR TITLE
rsx: Restructure ZCULL query triggers

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -384,7 +384,7 @@ namespace rsx
 
 		void shuffle_tag()
 		{
-			memory_tag_samples[0].second = memory_tag_samples[0].second;
+			memory_tag_samples[0].second = ~memory_tag_samples[0].second;
 		}
 
 		bool test()


### PR DESCRIPTION
### Overview
- Both ZCULL stats and ZPASS stats require hardware queries, but ZCULL stats should not contribute to ZPASS stats and vice versa!
- Disables hardware queries for ZCULL stats by themselves, we cannot generate them correctly anyway and no game so far has been found to actually use them. Should lessen the load on the backend for games that do not actually require it.

### Notes
- Fixes sun shining indoors in Dark Souls
- Also significantly lowers the number of issued hw queries and could theoretically improve performance in some applications.