### PR TITLE
cellSaveData: Indirect fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1328,12 +1328,14 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 	}
 
 	fileGet->excSize = 0;
-	memset(fileGet->reserved, 0, sizeof(fileGet->reserved));
 
 	error_code savedata_result = CELL_OK;
 
 	while (funcFile)
 	{
+		std::memset(fileSet.get_ptr(), 0, fileSet.size());
+		std::memset(fileGet->reserved, 0, sizeof(fileGet->reserved));
+
 		funcFile(ppu, result, fileGet, fileSet);
 
 		if (result->result < 0)

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1,5 +1,6 @@
 ﻿#include "stdafx.h"
 #include "Emu/VFS.h"
+#include "Emu/Cell/lv2/sys_fs.h"
 #include "Emu/Cell/lv2/sys_sync.h"
 #include "Emu/Cell/lv2/sys_process.h"
 #include "Emu/Cell/PPUModule.h"
@@ -1458,7 +1459,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Read from memory file to vm
 			const u64 sr = file.seek(fileSet->fileOffset);
-			const u64 rr = file.read(fileSet->fileBuf.get_ptr(), access_size);
+			const u64 rr = lv2_file::op_read(file, fileSet->fileBuf, access_size);
 			fileGet->excSize = ::narrow<u32>(rr);
 			break;
 		}
@@ -1474,7 +1475,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Write to memory file and truncate
 			const u64 sr = file.seek(fileSet->fileOffset);
-			const u64 wr = file.write(fileSet->fileBuf.get_ptr(), access_size);
+			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, access_size);
 			file.trunc(sr + wr);
 			fileGet->excSize = ::narrow<u32>(wr);
 			all_times.erase(file_path);
@@ -1506,7 +1507,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Write to memory file normally
 			const u64 sr = file.seek(fileSet->fileOffset);
-			const u64 wr = file.write(fileSet->fileBuf.get_ptr(), access_size);
+			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, access_size);
 			fileGet->excSize = ::narrow<u32>(wr);
 			all_times.erase(file_path);
 			add_to_blist(file_path);

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -552,7 +552,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 	lv2_sleep(ppu, 500);
 
-	*g_savedata_context = {};
+	std::memset(g_savedata_context.get_ptr(), 0, g_savedata_context.size());
 
 	vm::ptr<CellSaveDataCBResult> result   = g_savedata_context.ptr(&savedata_context::result);
 	vm::ptr<CellSaveDataListGet>  listGet  = g_savedata_context.ptr(&savedata_context::listGet);

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1303,10 +1303,8 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		}
 	}
 
-
-
 	// Create save directory if necessary
-	if (!psf.empty() && save_entry.isNew && !fs::create_dir(dir_path))
+	if (!psf.empty() && save_entry.isNew && !fs::create_dir(dir_path) && fs::g_tls_error != fs::error::exist)
 	{
 		cellSaveData.warning("savedata_op(): failed to create %s (%s)", dir_path, fs::g_tls_error);
 		return CELL_SAVEDATA_ERROR_ACCESS_ERROR;

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -86,7 +86,7 @@ lv2_fs_mount_point* lv2_fs_object::get_mp(std::string_view filename)
 	return &g_mp_sys_dev_hdd0;
 }
 
-u64 lv2_file::op_read(vm::ptr<void> buf, u64 size)
+u64 lv2_file::op_read(const fs::file& file, vm::ptr<void> buf, u64 size)
 {
 	// Copy data from intermediate buffer (avoid passing vm pointer to a native API)
 	uchar local_buf[65536];
@@ -110,7 +110,7 @@ u64 lv2_file::op_read(vm::ptr<void> buf, u64 size)
 	return result;
 }
 
-u64 lv2_file::op_write(vm::cptr<void> buf, u64 size)
+u64 lv2_file::op_write(const fs::file& file, vm::cptr<void> buf, u64 size)
 {
 	// Copy data to intermediate buffer (avoid passing vm pointer to a native API)
 	uchar local_buf[65536];

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -193,10 +193,20 @@ struct lv2_file final : lv2_fs_object
 	}
 
 	// File reading with intermediate buffer
-	u64 op_read(vm::ptr<void> buf, u64 size);
+	static u64 op_read(const fs::file& file, vm::ptr<void> buf, u64 size);
+
+	u64 op_read(vm::ptr<void> buf, u64 size)
+	{
+		return op_read(file, buf, size);
+	}
 
 	// File writing with intermediate buffer
-	u64 op_write(vm::cptr<void> buf, u64 size);
+	static u64 op_write(const fs::file& file, vm::cptr<void> buf, u64 size);
+
+	u64 op_write(vm::cptr<void> buf, u64 size)
+	{
+		return op_write(file, buf, size);
+	}
 
 	// For MSELF support
 	struct file_view;


### PR DESCRIPTION
* Do not fail to create savedata on empty directory. Fixes #6689.
* Fix padding bytes reset of g_savedata_context.
* Avoid passing vm pointers to native API.
* memset 0 *fileSet and fileGet->reserved before each funcFile call, testcase : https://github.com/elad335/myps3tests/tree/master/ppu_tests/cellSaveData_FuncFile 