### PR TITLE
Fix RSX Offloader thread exit (MTRSX fix)

### DIFF
--- a/rpcs3/Emu/RSX/RSXOffload.cpp
+++ b/rpcs3/Emu/RSX/RSXOffload.cpp
@@ -34,7 +34,7 @@ namespace rsx
 				thread_ctrl::set_thread_affinity_mask(thread_ctrl::get_affinity_mask(thread_class::rsx));
 			}
 
-			while (thread_ctrl::state() != thread_state::finished)
+			while (thread_ctrl::state() != thread_state::aborting)
 			{
 				for (auto&& job : m_work_queue.pop_all())
 				{


### PR DESCRIPTION
Hangs on exit if MTRSX is enabled.