### PR TITLE
Demi-regressions fixes

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -40,7 +40,7 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 		cpu == "bdver2" ||
 		cpu == "bdver3" ||
 		cpu == "bdver4" ||
-		cpu.substr(0, 5) == "znver")
+		cpu.startswith("znver"))
 	{
 		m_use_fma = true;
 	}

--- a/rpcs3/Emu/Cell/Modules/cellSail.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSail.cpp
@@ -802,7 +802,7 @@ s32 cellSailPlayerCreateDescriptor(vm::ptr<CellSailPlayer> pSelf, s32 streamType
 		case CELL_SAIL_STREAM_PAMF:
 		{
 			std::string uri = pUri.get_ptr();
-			if (uri.substr(0, 12) == "x-cell-fs://")
+			if (uri.starts_with("x-cell-fs://"))
 			{
 				if (fs::file f{ vfs::get(uri.substr(12)) })
 				{

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1468,6 +1468,20 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				file = fs::make_stream<std::vector<uchar>>();
 			}
 
+			if (fileSet->fileBufSize < fileSet->fileSize)
+			{
+				// ****** sysutil savedata parameter error : 72 ******
+				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "72"};
+				break;
+			}
+
+			if (!fileSet->fileBuf)
+			{
+				// ****** sysutil savedata parameter error : 73 ******
+				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "73"};
+				break;
+			}
+
 			// Write to memory file and truncate
 			const u64 sr = file.seek(fileSet->fileOffset);
 			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, access_size);
@@ -1498,6 +1512,20 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			if (!file)
 			{
 				file = fs::make_stream<std::vector<uchar>>();
+			}
+
+			if (fileSet->fileBufSize < fileSet->fileSize)
+			{
+				// ****** sysutil savedata parameter error : 72 ******
+				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "72"};
+				break;
+			}
+
+			if (!fileSet->fileBuf)
+			{
+				// ****** sysutil savedata parameter error : 73 ******
+				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "73"};
+				break;
 			}
 
 			// Write to memory file normally

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1086,7 +1086,14 @@ void ppu_load_exec(const ppu_exec_object& elf)
 				fmt::throw_exception("Invalid binary size (0x%llx, memsz=0x%x)", prog.bin.size(), size);
 
 			if (!vm::falloc(addr, size, vm::main))
-				fmt::throw_exception("vm::falloc() failed (addr=0x%x, memsz=0x%x)", addr, size);
+			{
+				ppu_loader.error("vm::falloc(vm::main) failed (addr=0x%x, memsz=0x%x)", addr, size); // TODO
+
+				if (!vm::falloc(addr, size))
+				{
+					fmt::throw_exception("vm::falloc() failed (addr=0x%x, memsz=0x%x)" HERE, addr, size);
+				}
+			}
 
 			// Copy segment data, hash it
 			std::memcpy(vm::base(addr), prog.bin.data(), prog.bin.size());

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -16,11 +16,9 @@ extern u64 get_guest_system_time();
 
 void lv2_timer_context::operator()()
 {
-	while (!Emu.IsStopped())
+	while (thread_ctrl::state() != thread_state::aborting)
 	{
-		const u32 _state = state;
-
-		if (_state == SYS_TIMER_STATE_RUN)
+		if (state == SYS_TIMER_STATE_RUN)
 		{
 			const u64 _now = get_guest_system_time();
 			const u64 next = expire;
@@ -42,21 +40,16 @@ void lv2_timer_context::operator()()
 				}
 
 				// Stop after oneshot
-				state.compare_and_swap_test(SYS_TIMER_STATE_RUN, SYS_TIMER_STATE_STOP);
+				state.release(SYS_TIMER_STATE_STOP);
 				continue;
 			}
 
 			// TODO: use single global dedicated thread for busy waiting, no timer threads
 			lv2_obj::wait_timeout(next - _now);
+			continue;
 		}
-		else if (_state == SYS_TIMER_STATE_STOP)
-		{
-			thread_ctrl::wait_for(10000);
-		}
-		else
-		{
-			break;
-		}
+
+		thread_ctrl::wait_for(10000);
 	}
 }
 
@@ -83,13 +76,12 @@ error_code sys_timer_destroy(ppu_thread& ppu, u32 timer_id)
 
 	const auto timer = idm::withdraw<lv2_obj, lv2_timer>(timer_id, [&](lv2_timer& timer) -> CellError
 	{
-		std::lock_guard lock(timer.mutex);
-
-		if (!timer.port.expired())
+		if (std::shared_lock lock(timer.mutex); !timer.port.expired())
 		{
 			return CELL_EISCONN;
 		}
 
+		timer = thread_state::aborting;
 		return {};
 	});
 

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -166,7 +166,7 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	{
 		for (const ParamItem &PI : PT.items)
 		{
-			if (PI.name.substr(0, 7) == "dst_reg")
+			if (PI.name.starts_with("dst_reg"))
 				continue;
 
 			OS << "	" << PT.type << " " << PI.name;

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -226,7 +226,7 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	{
 		for (const ParamItem &PI : PT.items)
 		{
-			if (PI.name.substr(0, 7) == "dst_reg")
+			if (PI.name.starts_with("dst_reg"))
 				continue;
 
 			OS << "	" << PT.type << " " << PI.name;


### PR DESCRIPTION
* Restore behaviour for ppu_load_exec before #7506, just with more logging. https://discordapp.com/channels/272035812277878785/319224795785068545/682951364317413391
iirc vm::main and vm::user64k are the same on realhw, but it can be left to another pr.
* cellSaveData: Add error param 72, 73 checks for file write ops.
* Fix sys_timer_destroy regression.