### PR TITLE
rsx: ZCULL fixups

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2152,7 +2152,7 @@ namespace rsx
 		if (g_cfg.video.disable_zcull_queries)
 			return;
 
-		zcull_ctrl->clear(this);
+		zcull_ctrl->clear(this, type);
 	}
 
 	void thread::get_zcull_stats(u32 type, vm::addr_t sink)
@@ -2928,8 +2928,14 @@ namespace rsx
 			m_free_occlusion_pool.push(query);
 		}
 
-		void ZCULL_control::clear(class ::rsx::thread* ptimer)
+		void ZCULL_control::clear(class ::rsx::thread* ptimer, u32 type)
 		{
+			if (type != CELL_GCM_ZPASS_PIXEL_CNT)
+			{
+				// Other types do not generate queries at the moment
+				return;
+			}
+
 			if (!m_pending_writes.empty())
 			{
 				//Remove any dangling/unclaimed queries as the information is lost anyway

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2560,6 +2560,15 @@ namespace rsx
 			Emu.Pause();
 		}
 
+		if (zcull_ctrl->has_pending())
+		{
+			// NOTE: This is a workaround for buggy games.
+			// Some applications leave the zpass/stats gathering active but don't use the information.
+			// This can lead to the zcull unit using up all the memory queueing up operations that never get consumed.
+			// Seen in Diablo III and Yakuza 5
+			zcull_ctrl->clear(this, CELL_GCM_ZPASS_PIXEL_CNT | CELL_GCM_ZCULL_STATS);
+		}
+
 		// Save current state
 		m_queued_flip.stats = m_frame_stats;
 		m_queued_flip.push(buffer);
@@ -2930,7 +2939,7 @@ namespace rsx
 
 		void ZCULL_control::clear(class ::rsx::thread* ptimer, u32 type)
 		{
-			if (type != CELL_GCM_ZPASS_PIXEL_CNT)
+			if (!(type & CELL_GCM_ZPASS_PIXEL_CNT))
 			{
 				// Other types do not generate queries at the moment
 				return;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -434,7 +434,7 @@ namespace rsx
 			void read_report(class ::rsx::thread* ptimer, vm::addr_t sink, u32 type);
 
 			// Clears current stat block and increments stat_tag_id
-			void clear(class ::rsx::thread* ptimer);
+			void clear(class ::rsx::thread* ptimer, u32 type);
 
 			// Forcefully flushes all
 			void sync(class ::rsx::thread* ptimer);


### PR DESCRIPTION
- Fix ZSTATS clears destroying ZPASS data.
- Restores workaround for buggy games that leak zcull data across frames. Happens when the application sets the stats to enabled but never reads the data using reports, causing zcull to run out of allocation pool.

Fixes https://github.com/RPCS3/rpcs3/issues/7629