### PR TITLE
Improve sys_timer_get_information

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -49,7 +49,7 @@ void lv2_timer_context::operator()()
 			continue;
 		}
 
-		thread_ctrl::wait_for(10000);
+		thread_ctrl::wait();
 	}
 }
 
@@ -106,11 +106,20 @@ error_code sys_timer_get_information(ppu_thread& ppu, u32 timer_id, vm::ptr<sys_
 
 	const auto timer = idm::check<lv2_obj, lv2_timer>(timer_id, [&](lv2_timer& timer)
 	{
-		std::lock_guard lock(timer.mutex);
+		std::shared_lock lock(timer.mutex);
 
-		info->next_expire = timer.expire;
-		info->period      = timer.period;
-		info->timer_state = timer.state;
+		if (timer.state == SYS_TIMER_STATE_RUN)
+		{
+			info->timer_state = SYS_TIMER_STATE_RUN;
+			info->next_expire = timer.expire;
+			info->period      = timer.period;
+		}
+		else
+		{
+			info->timer_state = SYS_TIMER_STATE_STOP;
+			info->next_expire = 0;
+			info->period      = 0;
+		}
 	});
 
 	if (!timer)
@@ -252,12 +261,13 @@ error_code sys_timer_disconnect_event_queue(ppu_thread& ppu, u32 timer_id)
 	{
 		std::lock_guard lock(timer.mutex);
 
+		timer.state = SYS_TIMER_STATE_STOP;
+
 		if (timer.port.expired())
 		{
 			return CELL_ENOTCONN;
 		}
 
-		timer.state = SYS_TIMER_STATE_STOP;
 		timer.port.reset();
 		return {};
 	});

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -21,11 +21,17 @@ void lv2_timer_context::operator()()
 		if (state == SYS_TIMER_STATE_RUN)
 		{
 			const u64 _now = get_guest_system_time();
-			const u64 next = expire;
+			u64 next = expire;
 
 			if (_now >= next)
 			{
 				std::lock_guard lock(mutex);
+
+				if (next = expire; _now < next)
+				{
+					// expire was updated in the middle, don't send an event
+					continue;
+				}
 
 				if (const auto queue = port.lock())
 				{
@@ -34,7 +40,7 @@ void lv2_timer_context::operator()()
 
 				if (period)
 				{
-					// Set next expiration time and check again (HACK)
+					// Set next expiration time and check again
 					expire += period;
 					continue;
 				}


### PR DESCRIPTION
* sys_timer_disconnect_event_queue sets STATE_STOP regardless of port connection status.
* sys_timer_get_information sets 0 for period and next_expire if the timer is stopped.
* Fix two minor races in lv2_timer thread regarding timer.expire updating in the middle of sending an event. (see commit description for more details)

testcase : https://github.com/elad335/myps3tests/tree/master/ppu_tests/timer%20state%20info%20when%20stopped%20or%20event%20queue%20disconnected