### PR TITLE
vk: Restructure events and add AMD driver bug workaround

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -601,6 +601,11 @@ namespace vk
 		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
 	}
 
+	void insert_execution_barrier(VkCommandBuffer cmd, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage)
+	{
+		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 0, nullptr);
+	}
+
 	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range)
 	{
 		//Prepare an image to match the new layout..

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -902,12 +902,12 @@ namespace vk
 		}
 	}
 
-	VkResult wait_for_event(VkEvent event, u64 timeout)
+	VkResult wait_for_event(event* pEvent, u64 timeout)
 	{
 		u64 t = 0;
 		while (true)
 		{
-			switch (const auto status = vkGetEventStatus(*g_current_renderer, event))
+			switch (const auto status = pEvent->status())
 			{
 			case VK_EVENT_SET:
 				return VK_SUCCESS;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -208,6 +208,10 @@ namespace vk
 		VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask,
 		const VkImageSubresourceRange& range);
 
+	void insert_execution_barrier(VkCommandBuffer cmd,
+		VkPipelineStageFlags src_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+		VkPipelineStageFlags dst_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+
 	void raise_status_interrupt(runtime_state status);
 	void clear_status_interrupt(runtime_state status);
 	bool test_status_interrupt(runtime_state status);

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -14,7 +14,7 @@ namespace vk
 		std::vector<std::unique_ptr<vk::buffer>> m_disposed_buffers;
 		std::vector<std::unique_ptr<vk::image_view>> m_disposed_image_views;
 		std::vector<std::unique_ptr<vk::image>> m_disposed_images;
-		rsx::simple_array<VkEvent> m_disposed_events;
+		std::vector<std::unique_ptr<vk::event>> m_disposed_events;
 
 		eid_scope_t(u64 _eid):
 			eid(_eid), m_device(vk::get_current_renderer())
@@ -27,17 +27,8 @@ namespace vk
 
 		void discard()
 		{
-			if (!m_disposed_events.empty())
-			{
-				for (auto &ev : m_disposed_events)
-				{
-					vkDestroyEvent(*m_device, ev, nullptr);
-				}
-
-				m_disposed_events.clear();
-			}
-
 			m_disposed_buffers.clear();
+			m_disposed_events.clear();
 			m_disposed_image_views.clear();
 			m_disposed_images.clear();
 		}
@@ -146,9 +137,9 @@ namespace vk
 			get_current_eid_scope().m_disposed_images.emplace_back(std::move(img));
 		}
 
-		void dispose(VkEvent& event)
+		void dispose(std::unique_ptr<vk::event>& event)
 		{
-			get_current_eid_scope().m_disposed_events.push_back(event);
+			get_current_eid_scope().m_disposed_events.emplace_back(std::move(event));
 			event = VK_NULL_HANDLE;
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -69,13 +69,7 @@ namespace vk
 			{
 				// Even if we are managing the same vram section, we cannot guarantee contents are static
 				// The create method is only invoked when a new managed session is required
-				if (!flushed)
-				{
-					// Reset fence
-					verify(HERE), m_device, dma_fence;
-					vk::get_resource_manager()->dispose(dma_fence);
-				}
-
+				release_dma_resources();
 				synchronized = false;
 				flushed = false;
 				sync_timestamp = 0ull;
@@ -176,7 +170,9 @@ namespace vk
 
 			if (dma_fence)
 			{
-				verify(HERE), synchronized;
+				// NOTE: This can be reached if previously synchronized, or a special path happens.
+				// If a hard flush occurred while this surface was flush_always the cache would have reset its protection afterwards.
+				// DMA resource would still be present but already used to flush previously.
 				vk::get_resource_manager()->dispose(dma_fence);
 			}
 


### PR DESCRIPTION
- Implements execution barriers for simple scope dependencies.
- Implements event object as properly wrapped classes to allow for behavior extension.
- Implements a workaround for vkCmdSetEvent/vkGetEventStatus on AMD proprietary drivers which does not actually honor the scope dependency.

Fixes https://github.com/RPCS3/rpcs3/issues/7372