### PR TITLE
rsx/video-out: Obey resolution set by application if video mode was reported to application

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -338,7 +338,7 @@ vk::image* VKGSRender::get_present_source(vk::present_surface_info* info, const 
 		}
 
 		m_texture_cache.invalidate_range(*m_current_command_buffer, range, rsx::invalidation_cause::read);
-		image_to_flip = m_texture_cache.upload_image_simple(*m_current_command_buffer, info->address, info->width, info->height);
+		image_to_flip = m_texture_cache.upload_image_simple(*m_current_command_buffer, info->address, info->width, info->height, info->pitch);
 	}
 
 	return image_to_flip;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1484,7 +1484,7 @@ namespace vk
 			baseclass::on_frame_end();
 		}
 
-		vk::image *upload_image_simple(vk::command_buffer& cmd, u32 address, u32 width, u32 height)
+		vk::image *upload_image_simple(vk::command_buffer& cmd, u32 address, u32 width, u32 height, u32 pitch)
 		{
 			if (!m_formats_support.bgra8_linear)
 			{
@@ -1507,7 +1507,6 @@ namespace vk
 
 			void* mem = image->memory->map(0, layout.rowPitch * height);
 
-			u32 row_pitch = width * 4;
 			auto src = vm::_ptr<const char>(address);
 			auto dst = static_cast<char*>(mem);
 
@@ -1520,7 +1519,7 @@ namespace vk
 				for (u32 col = 0; col < width; ++col)
 					casted_dst[col] = casted_src[col];
 
-				src += row_pitch;
+				src += pitch;
 				dst += layout.rowPitch;
 			}
 

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -144,6 +144,7 @@ namespace rsx
 	{
 		u8 format = 0;             // XRGB
 		u8 aspect = 0;             // AUTO
+		u8 resolution_id = 2;      // 720p
 		u32 scanline_pitch = 0;    // PACKED
 		atomic_t<f32> gamma = 1.f; // NO GAMMA CORRECTION
 		u32 resolution_x = 1280;   // X RES


### PR DESCRIPTION
If the resolution is changed via cellVideoOutConfigure, subsequent requests to cellVideoOutGetState should either match the requested setting (successful mode change) or roll back the changes to avconf completely (modeset failure).

Fixes https://github.com/RPCS3/rpcs3/issues/7349