### PR TITLE
sys_usbd: Fix duplicate inputs for GHLtar strumming

### DIFF
--- a/rpcs3/Emu/Io/GHLtar.cpp
+++ b/rpcs3/Emu/Io/GHLtar.cpp
@@ -161,13 +161,11 @@ void usb_device_ghltar::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, 
 					pad->m_press_down = button.m_value;
 					if (button.m_pressed)
 						buf[4] = 0xFF; // Strum Down
-						buf[2] = 0x04;  // Down D-Pad (Unused)
 					break;
 				case CELL_PAD_CTRL_UP:
 					pad->m_press_up = button.m_value;
 					if (button.m_pressed)
 						buf[4] = 0x00; // Strum Up
-						buf[2] = 0x00;  // Up D-Pad (Unused)
 					break;
 				case CELL_PAD_CTRL_LEFT:
 					pad->m_press_down = button.m_value;


### PR DESCRIPTION
Emulating the D-pad up/down inputs would result in duplicate presses on Guitar Hero Live.