### PR TITLE
Fix _sys_prx_get_module_info p0pt->filename writing with 0 size

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -3,6 +3,7 @@
 
 #include "Utilities/VirtualMemory.h"
 #include "Utilities/bin_patch.h"
+#include "Utilities/StrUtil.h"
 #include "Crypto/sha1.h"
 #include "Crypto/unself.h"
 #include "Loader/ELF.h"
@@ -942,10 +943,10 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 		};
 
 		// Access library information (TODO)
-		const auto& lib_info = vm::cptr<ppu_prx_library_info>(vm::cast(prx->segs[0].addr + elf.progs[0].p_paddr - elf.progs[0].p_offset, HERE));
-		const auto& lib_name = std::string(lib_info->name);
+		const vm::cptr<ppu_prx_library_info> lib_info = vm::cast(prx->segs[0].addr + elf.progs[0].p_paddr - elf.progs[0].p_offset, HERE);
+		const std::string lib_name = lib_info->name;
 
-		std::memcpy(prx->module_info_name, lib_info->name, sizeof(prx->module_info_name));
+		strcpy_trunc(prx->module_info_name, lib_name);
 		prx->module_info_version[0] = lib_info->version[0];
 		prx->module_info_version[1] = lib_info->version[1];
 		prx->module_info_attributes = lib_info->attributes;

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -385,8 +385,7 @@ error_code _sys_prx_get_module_info(u32 id, u64 flags, vm::ptr<sys_prx_module_in
 		return CELL_PRX_ERROR_UNKNOWN_MODULE;
 	}
 
-	std::memset(pOpt->info->name, 0, 30);
-	std::memcpy(pOpt->info->name, prx->module_info_name, 28);
+	strcpy_trunc(pOpt->info->name, prx->module_info_name);
 	pOpt->info->version[0] = prx->module_info_version[0];
 	pOpt->info->version[1] = prx->module_info_version[1];
 	pOpt->info->modattribute = prx->module_info_attributes;
@@ -397,7 +396,6 @@ error_code _sys_prx_get_module_info(u32 id, u64 flags, vm::ptr<sys_prx_module_in
 	{
 		gsl::span dst(pOpt->info->filename.get_ptr(), pOpt->info->filename_size);
 		strcpy_trunc(dst, prx->name);
-		pOpt->info->filename[pOpt->info->filename_size - 1] = 0;
 	}
 
 	if (pOpt->info->segments)


### PR DESCRIPTION
0 - 1 results in an overflow, so writing a null character at that position is a bug. Also some cleanup.