### PR TITLE
Implement lv2_file::open()

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -4,6 +4,8 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Utilities/File.h"
 
+#include <string>
+
 // Open Flags
 enum : s32
 {
@@ -191,6 +193,16 @@ struct lv2_file final : lv2_fs_object
 		, flags(flags)
 	{
 	}
+
+	struct open_result_t
+	{
+		CellError error;
+		std::string ppath;
+		fs::file file;
+	};
+
+	// Open a file with wrapped logic of sys_fs_open
+	static open_result_t open(std::string_view path, s32 flags, s32 mode, const void* arg = {}, u64 size = 0);
 
 	// File reading with intermediate buffer
 	static u64 op_read(const fs::file& file, vm::ptr<void> buf, u64 size);

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -6,6 +6,7 @@
 #include "Crypto/unself.h"
 #include "Loader/ELF.h"
 
+#include "Emu/Cell/PPUModule.h"
 #include "Emu/Cell/ErrorCodes.h"
 #include "Crypto/unedat.h"
 #include "Utilities/StrUtil.h"
@@ -154,7 +155,14 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	if (!src)
 	{
-		src.open(path);
+		auto [fs_error, ppath, lv2_file] = lv2_file::open(vpath, 0, 0);
+
+		if (fs_error)
+		{
+			return {fs_error, vpath};
+		}
+
+		src = std::move(lv2_file);
 	}
 
 	const ppu_prx_object obj = decrypt_self(std::move(src), g_fxo->get<loaded_npdrm_keys>()->devKlic.data());


### PR DESCRIPTION
Used to return accurate error codes in prx_load_module, sys_spu_image_open and overlay_load_module with the logic of sys_fs_open instead of the host OS'.