### PR TITLE
GUI fixes and play button shenanigans

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -128,6 +128,11 @@ public:
 		return m_title;
 	}
 
+	const std::string GetTitleAndTitleID() const
+	{
+		return m_title + (m_title_id.empty() ? "" : " [" + m_title_id + "]");
+	}
+
 	const std::string& GetCat() const
 	{
 		return m_cat;

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <QTableWidget>
 #include <QMouseEvent>

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -15,6 +15,7 @@ private:
 		if (!indexAt(event->pos()).isValid() || itemAt(event->pos())->data(Qt::UserRole) < 0)
 		{
 			clearSelection();
+			setCurrentItem(nullptr); // Needed for currentItemChanged
 		}
 		QTableWidget::mousePressEvent(event);
 	}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -789,8 +789,7 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 	if (m_isListLayout)
 	{
 		const int scroll_position = m_gameList->verticalScrollBar()->value();
-		const int row = PopulateGameList();
-		m_gameList->selectRow(row);
+		PopulateGameList();
 		SortGameList();
 
 		if (scrollAfter)
@@ -1950,9 +1949,9 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 /**
  Cleans and readds entries to table widget in UI.
 */
-int game_list_frame::PopulateGameList()
+void game_list_frame::PopulateGameList()
 {
-	int result = -1;
+	int selected_row = -1;
 
 	std::string selected_item = CurrentSelectionIconPath();
 
@@ -2073,15 +2072,14 @@ int game_list_frame::PopulateGameList()
 
 		if (selected_item == game->info.icon_path)
 		{
-			result = row;
+			selected_row = row;
 		}
 
 		row++;
 	}
 
 	m_gameList->setRowCount(row);
-
-	return result;
+	m_gameList->selectRow(selected_row);
 }
 
 void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color)
@@ -2150,7 +2148,7 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 
 		if (selected_item == app->info.icon_path)
 		{
-			m_xgrid->setCurrentItem(m_xgrid->item(r, c));
+			m_xgrid->setCurrentCell(r, c);
 		}
 
 		if (++c >= maxCols)
@@ -2193,9 +2191,25 @@ std::string game_list_frame::CurrentSelectionIconPath()
 {
 	std::string selection;
 
-	if (m_gameList->selectedItems().count())
+	QTableWidgetItem* item = nullptr;
+
+	if (m_oldLayoutIsList)
 	{
-		QTableWidgetItem* item = m_oldLayoutIsList ? m_gameList->item(m_gameList->currentRow(), 0) : m_xgrid->currentItem();
+		if (!m_gameList->selectedItems().isEmpty())
+		{
+			item = m_gameList->item(m_gameList->currentRow(), 0);
+		}
+	}
+	else
+	{
+		if (!m_xgrid->selectedItems().isEmpty())
+		{
+			item = m_xgrid->currentItem();
+		}
+	}
+
+	if (item)
+	{
 		QVariant var = item->data(gui::game_role);
 
 		if (var.canConvert<game_info>())

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -103,26 +103,26 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 	m_game_dock->setCentralWidget(m_central_widget);
 
 	// Actions regarding showing/hiding columns
-	auto AddColumn = [this](gui::game_list_columns col, const QString& header_text, const QString& action_text)
+	auto add_column = [this](gui::game_list_columns col, const QString& header_text, const QString& action_text)
 	{
 		m_game_list->setHorizontalHeaderItem(col, new QTableWidgetItem(header_text));
 		m_columnActs.append(new QAction(action_text, this));
 	};
 
-	AddColumn(gui::column_icon,       tr("Icon"),                  tr("Show Icons"));
-	AddColumn(gui::column_name,       tr("Name"),                  tr("Show Names"));
-	AddColumn(gui::column_serial,     tr("Serial"),                tr("Show Serials"));
-	AddColumn(gui::column_firmware,   tr("Firmware"),              tr("Show Firmwares"));
-	AddColumn(gui::column_version,    tr("Version"),               tr("Show Versions"));
-	AddColumn(gui::column_category,   tr("Category"),              tr("Show Categories"));
-	AddColumn(gui::column_path,       tr("Path"),                  tr("Show Paths"));
-	AddColumn(gui::column_move,       tr("PlayStation Move"),      tr("Show PlayStation Move"));
-	AddColumn(gui::column_resolution, tr("Supported Resolutions"), tr("Show Supported Resolutions"));
-	AddColumn(gui::column_sound,      tr("Sound Formats"),         tr("Show Sound Formats"));
-	AddColumn(gui::column_parental,   tr("Parental Level"),        tr("Show Parental Levels"));
-	AddColumn(gui::column_last_play,  tr("Last Played"),           tr("Show Last Played"));
-	AddColumn(gui::column_playtime,   tr("Time Played"),           tr("Show Time Played"));
-	AddColumn(gui::column_compat,     tr("Compatibility"),         tr("Show Compatibility"));
+	add_column(gui::column_icon,       tr("Icon"),                  tr("Show Icons"));
+	add_column(gui::column_name,       tr("Name"),                  tr("Show Names"));
+	add_column(gui::column_serial,     tr("Serial"),                tr("Show Serials"));
+	add_column(gui::column_firmware,   tr("Firmware"),              tr("Show Firmwares"));
+	add_column(gui::column_version,    tr("Version"),               tr("Show Versions"));
+	add_column(gui::column_category,   tr("Category"),              tr("Show Categories"));
+	add_column(gui::column_path,       tr("Path"),                  tr("Show Paths"));
+	add_column(gui::column_move,       tr("PlayStation Move"),      tr("Show PlayStation Move"));
+	add_column(gui::column_resolution, tr("Supported Resolutions"), tr("Show Supported Resolutions"));
+	add_column(gui::column_sound,      tr("Sound Formats"),         tr("Show Sound Formats"));
+	add_column(gui::column_parental,   tr("Parental Level"),        tr("Show Parental Levels"));
+	add_column(gui::column_last_play,  tr("Last Played"),           tr("Show Last Played"));
+	add_column(gui::column_playtime,   tr("Time Played"),           tr("Show Time Played"));
+	add_column(gui::column_compat,     tr("Compatibility"),         tr("Show Compatibility"));
 
 	// Events
 	connect(m_game_list, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
@@ -207,7 +207,7 @@ void game_list_frame::LoadSettings()
 
 	Refresh(true);
 
-	QByteArray state = m_gui_settings->GetValue(gui::gl_state).toByteArray();
+	const QByteArray state = m_gui_settings->GetValue(gui::gl_state).toByteArray();
 	if (!m_game_list->horizontalHeader()->restoreState(state) && m_game_list->rowCount())
 	{
 		// If no settings exist, resize to contents.
@@ -216,7 +216,7 @@ void game_list_frame::LoadSettings()
 
 	for (int col = 0; col < m_columnActs.count(); ++col)
 	{
-		bool vis = m_gui_settings->GetGamelistColVisibility(col);
+		const bool vis = m_gui_settings->GetGamelistColVisibility(col);
 		m_columnActs[col]->setChecked(vis);
 		m_game_list->setColumnHidden(col, !vis);
 	}
@@ -915,19 +915,19 @@ void game_list_frame::itemSelectionChangedSlot()
 
 void game_list_frame::ShowContextMenu(const QPoint &pos)
 {
-	QPoint globalPos;
+	QPoint global_pos;
 	QTableWidgetItem* item;
 
 	if (m_is_list_layout)
 	{
 		item = m_game_list->item(m_game_list->indexAt(pos).row(), gui::column_icon);
-		globalPos = m_game_list->viewport()->mapToGlobal(pos);
+		global_pos = m_game_list->viewport()->mapToGlobal(pos);
 	}
 	else
 	{
 		const QModelIndex mi = m_game_grid->indexAt(pos);
 		item = m_game_grid->item(mi.row(), mi.column());
-		globalPos = m_game_grid->viewport()->mapToGlobal(pos);
+		global_pos = m_game_grid->viewport()->mapToGlobal(pos);
 	}
 
 	game_info gameinfo = GetGameInfoFromItem(item);
@@ -936,26 +936,26 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		return;
 	}
 
-	GameInfo currGame = gameinfo->info;
-	const QString serial = qstr(currGame.serial);
-	const QString name = qstr(currGame.name).simplified();
+	GameInfo current_game = gameinfo->info;
+	const QString serial = qstr(current_game.serial);
+	const QString name = qstr(current_game.name).simplified();
 
-	const std::string cache_base_dir = GetCacheDirBySerial(currGame.serial);
-	const std::string data_base_dir  = GetDataDirBySerial(currGame.serial);
+	const std::string cache_base_dir = GetCacheDirBySerial(current_game.serial);
+	const std::string data_base_dir  = GetDataDirBySerial(current_game.serial);
 
 	// Make Actions
-	QMenu myMenu;
+	QMenu menu;
 
-	const bool is_current_running_game = (Emu.IsRunning() || Emu.IsPaused()) && currGame.serial == Emu.GetTitleID();
+	const bool is_current_running_game = (Emu.IsRunning() || Emu.IsPaused()) && current_game.serial == Emu.GetTitleID();
 
 	QAction* boot = new QAction(gameinfo->hasCustomConfig ? tr(is_current_running_game ? "&Reboot with global configuration" : "&Boot with global configuration") : tr("&Boot"));
-	QFont f = boot->font();
-	f.setBold(true);
+	QFont font = boot->font();
+	font.setBold(true);
 
 	if (gameinfo->hasCustomConfig)
 	{
-		QAction* boot_custom = myMenu.addAction(tr(is_current_running_game ? "&Reboot with custom configuration" : "&Boot with custom configuration"));
-		boot_custom->setFont(f);
+		QAction* boot_custom = menu.addAction(tr(is_current_running_game ? "&Reboot with custom configuration" : "&Boot with custom configuration"));
+		boot_custom->setFont(font);
 		connect(boot_custom, &QAction::triggered, [=, this]
 		{
 			sys_log.notice("Booting from gamelist per context menu...");
@@ -964,29 +964,29 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	}
 	else
 	{
-		boot->setFont(f);
+		boot->setFont(font);
 	}
 
-	myMenu.addAction(boot);
-	myMenu.addSeparator();
+	menu.addAction(boot);
+	menu.addSeparator();
 
-	QAction* configure = myMenu.addAction(gameinfo->hasCustomConfig ? tr("&Change Custom Configuration") : tr("&Create Custom Configuration"));
-	QAction* pad_configure = myMenu.addAction(gameinfo->hasCustomPadConfig ? tr("&Change Custom Gamepad Configuration") : tr("&Create Custom Gamepad Configuration"));
-	QAction* createPPUCache = myMenu.addAction(tr("&Create PPU Cache"));
-	myMenu.addSeparator();
-	QAction* renameTitle = myMenu.addAction(tr("&Rename In Game List"));
-	QAction* hide_serial = myMenu.addAction(tr("&Hide From Game List"));
+	QAction* configure = menu.addAction(gameinfo->hasCustomConfig ? tr("&Change Custom Configuration") : tr("&Create Custom Configuration"));
+	QAction* pad_configure = menu.addAction(gameinfo->hasCustomPadConfig ? tr("&Change Custom Gamepad Configuration") : tr("&Create Custom Gamepad Configuration"));
+	QAction* create_ppu_cache = menu.addAction(tr("&Create PPU Cache"));
+	menu.addSeparator();
+	QAction* rename_title = menu.addAction(tr("&Rename In Game List"));
+	QAction* hide_serial = menu.addAction(tr("&Hide From Game List"));
 	hide_serial->setCheckable(true);
 	hide_serial->setChecked(m_hidden_list.contains(serial));
-	myMenu.addSeparator();
-	QMenu* remove_menu = myMenu.addMenu(tr("&Remove"));
-	QAction* removeGame = remove_menu->addAction(tr("&Remove %1").arg(gameinfo->localized_category));
+	menu.addSeparator();
+	QMenu* remove_menu = menu.addMenu(tr("&Remove"));
+	QAction* remove_game = remove_menu->addAction(tr("&Remove %1").arg(gameinfo->localized_category));
 	if (gameinfo->hasCustomConfig)
 	{
 		QAction* remove_custom_config = remove_menu->addAction(tr("&Remove Custom Configuration"));
 		connect(remove_custom_config, &QAction::triggered, [=, this]()
 		{
-			if (RemoveCustomConfiguration(currGame.serial, gameinfo, true))
+			if (RemoveCustomConfiguration(current_game.serial, gameinfo, true))
 			{
 				ShowCustomConfigIcon(gameinfo);
 			}
@@ -997,7 +997,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		QAction* remove_custom_pad_config = remove_menu->addAction(tr("&Remove Custom Gamepad Configuration"));
 		connect(remove_custom_pad_config, &QAction::triggered, [=, this]()
 		{
-			if (RemoveCustomPadConfiguration(currGame.serial, gameinfo, true))
+			if (RemoveCustomPadConfiguration(current_game.serial, gameinfo, true))
 			{
 				ShowCustomConfigIcon(gameinfo);
 			}
@@ -1006,23 +1006,23 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	if (fs::is_dir(cache_base_dir))
 	{
 		remove_menu->addSeparator();
-		QAction* removeShadersCache = remove_menu->addAction(tr("&Remove Shaders Cache"));
-		connect(removeShadersCache, &QAction::triggered, [=, this]()
+		QAction* remove_shaders_cache = remove_menu->addAction(tr("&Remove Shaders Cache"));
+		connect(remove_shaders_cache, &QAction::triggered, [=, this]()
 		{
 			RemoveShadersCache(cache_base_dir, true);
 		});
-		QAction* removePPUCache = remove_menu->addAction(tr("&Remove PPU Cache"));
-		connect(removePPUCache, &QAction::triggered, [=, this]()
+		QAction* remove_ppu_cache = remove_menu->addAction(tr("&Remove PPU Cache"));
+		connect(remove_ppu_cache, &QAction::triggered, [=, this]()
 		{
 			RemovePPUCache(cache_base_dir, true);
 		});
-		QAction* removeSPUCache = remove_menu->addAction(tr("&Remove SPU Cache"));
-		connect(removeSPUCache, &QAction::triggered, [=, this]()
+		QAction* remove_spu_cache = remove_menu->addAction(tr("&Remove SPU Cache"));
+		connect(remove_spu_cache, &QAction::triggered, [=, this]()
 		{
 			RemoveSPUCache(cache_base_dir, true);
 		});
-		QAction* removeAllCaches = remove_menu->addAction(tr("&Remove All Caches"));
-		connect(removeAllCaches, &QAction::triggered, [=, this]()
+		QAction* remove_all_caches = remove_menu->addAction(tr("&Remove All Caches"));
+		connect(remove_all_caches, &QAction::triggered, [=, this]()
 		{
 			if (QMessageBox::question(this, tr("Confirm Removal"), tr("Remove all caches?")) != QMessageBox::Yes)
 				return;
@@ -1032,19 +1032,19 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 			RemoveSPUCache(cache_base_dir);
 		});
 	}
-	myMenu.addSeparator();
-	QAction* openGameFolder = myMenu.addAction(tr("&Open Install Folder"));
+	menu.addSeparator();
+	QAction* open_game_folder = menu.addAction(tr("&Open Install Folder"));
 	if (gameinfo->hasCustomConfig)
 	{
-		QAction* open_config_dir = myMenu.addAction(tr("&Open Custom Config Folder"));
+		QAction* open_config_dir = menu.addAction(tr("&Open Custom Config Folder"));
 		connect(open_config_dir, &QAction::triggered, [=, this]()
 		{
-			const std::string new_config_path = Emulator::GetCustomConfigPath(currGame.serial);
+			const std::string new_config_path = Emulator::GetCustomConfigPath(current_game.serial);
 
 			if (fs::is_file(new_config_path))
 				open_dir(new_config_path);
 
-			const std::string old_config_path = Emulator::GetCustomConfigPath(currGame.serial, true);
+			const std::string old_config_path = Emulator::GetCustomConfigPath(current_game.serial, true);
 
 			if (fs::is_file(old_config_path))
 				open_dir(old_config_path);
@@ -1052,18 +1052,18 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	}
 	if (fs::is_dir(data_base_dir))
 	{
-		QAction* open_data_dir = myMenu.addAction(tr("&Open Data Folder"));
+		QAction* open_data_dir = menu.addAction(tr("&Open Data Folder"));
 		connect(open_data_dir, &QAction::triggered, [=, this]()
 		{
 			open_dir(data_base_dir);
 		});
 	}
-	myMenu.addSeparator();
-	QAction* checkCompat = myMenu.addAction(tr("&Check Game Compatibility"));
-	QAction* downloadCompat = myMenu.addAction(tr("&Download Compatibility Database"));
-	myMenu.addSeparator();
-	QAction* editNotes = myMenu.addAction(tr("&Edit Tooltip Notes"));
-	QMenu* info_menu = myMenu.addMenu(tr("&Copy Info"));
+	menu.addSeparator();
+	QAction* check_compat = menu.addAction(tr("&Check Game Compatibility"));
+	QAction* download_compat = menu.addAction(tr("&Download Compatibility Database"));
+	menu.addSeparator();
+	QAction* edit_notes = menu.addAction(tr("&Edit Tooltip Notes"));
+	QMenu* info_menu = menu.addMenu(tr("&Copy Info"));
 	QAction* copy_info = info_menu->addAction(tr("&Copy Name + Serial"));
 	QAction* copy_name = info_menu->addAction(tr("&Copy Name"));
 	QAction* copy_serial = info_menu->addAction(tr("&Copy Serial"));
@@ -1075,7 +1075,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	});
 	connect(configure, &QAction::triggered, [=, this]()
 	{
-		settings_dialog dlg(m_gui_settings, m_emu_settings, 0, this, &currGame);
+		settings_dialog dlg(m_gui_settings, m_emu_settings, 0, this, &current_game);
 		connect(&dlg, &settings_dialog::EmuSettingsApplied, [this, gameinfo]()
 		{
 			if (!gameinfo->hasCustomConfig)
@@ -1093,7 +1093,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		{
 			Emu.GetCallbacks().enable_pads(false);
 		}
-		pad_settings_dialog dlg(this, &currGame);
+		pad_settings_dialog dlg(this, &current_game);
 		connect(&dlg, &QDialog::finished, [this](int/* result*/)
 		{
 			if (Emu.IsStopped())
@@ -1122,66 +1122,66 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		m_gui_settings->SetValue(gui::gl_hidden_list, QStringList(m_hidden_list.values()));
 		Refresh();
 	});
-	connect(createPPUCache, &QAction::triggered, [=, this]
+	connect(create_ppu_cache, &QAction::triggered, [=, this]
 	{
 		CreatePPUCache(gameinfo);
 	});
-	connect(removeGame, &QAction::triggered, [=, this]
+	connect(remove_game, &QAction::triggered, [=, this]
 	{
-		if (currGame.path.empty())
+		if (current_game.path.empty())
 		{
 			game_list_log.fatal("Cannot remove game. Path is empty");
 			return;
 		}
 
-		QMessageBox* mb = new QMessageBox(QMessageBox::Question, tr("Confirm %1 Removal").arg(gameinfo->localized_category), tr("Permanently remove %0 from drive?\nPath: %1").arg(name).arg(qstr(currGame.path)), QMessageBox::Yes | QMessageBox::No, this);
+		QMessageBox* mb = new QMessageBox(QMessageBox::Question, tr("Confirm %1 Removal").arg(gameinfo->localized_category), tr("Permanently remove %0 from drive?\nPath: %1").arg(name).arg(qstr(current_game.path)), QMessageBox::Yes | QMessageBox::No, this);
 		mb->setCheckBox(new QCheckBox(tr("Remove caches and custom configs")));
 		mb->deleteLater();
 		if (mb->exec() == QMessageBox::Yes)
 		{
 			const bool remove_caches = mb->checkBox()->isChecked();
-			if (fs::remove_all(currGame.path))
+			if (fs::remove_all(current_game.path))
 			{
 				if (remove_caches)
 				{
 					RemoveShadersCache(cache_base_dir);
 					RemovePPUCache(cache_base_dir);
 					RemoveSPUCache(cache_base_dir);
-					RemoveCustomConfiguration(currGame.serial);
-					RemoveCustomPadConfiguration(currGame.serial);
+					RemoveCustomConfiguration(current_game.serial);
+					RemoveCustomPadConfiguration(current_game.serial);
 				}
 				m_game_data.erase(std::remove(m_game_data.begin(), m_game_data.end(), gameinfo), m_game_data.end());
-				game_list_log.success("Removed %s %s in %s", sstr(gameinfo->localized_category), currGame.name, currGame.path);
+				game_list_log.success("Removed %s %s in %s", sstr(gameinfo->localized_category), current_game.name, current_game.path);
 				Refresh(true);
 			}
 			else
 			{
-				game_list_log.error("Failed to remove %s %s in %s (%s)", sstr(gameinfo->localized_category), currGame.name, currGame.path, fs::g_tls_error);
-				QMessageBox::critical(this, tr("Failure!"), tr(remove_caches ? "Failed to remove %0 from drive!\nPath: %1\nCaches and custom configs have been left intact." : "Failed to remove %0 from drive!\nPath: %1").arg(name).arg(qstr(currGame.path)));
+				game_list_log.error("Failed to remove %s %s in %s (%s)", sstr(gameinfo->localized_category), current_game.name, current_game.path, fs::g_tls_error);
+				QMessageBox::critical(this, tr("Failure!"), tr(remove_caches ? "Failed to remove %0 from drive!\nPath: %1\nCaches and custom configs have been left intact." : "Failed to remove %0 from drive!\nPath: %1").arg(name).arg(qstr(current_game.path)));
 			}
 		}
 	});
-	connect(openGameFolder, &QAction::triggered, [=, this]()
+	connect(open_game_folder, &QAction::triggered, [=, this]()
 	{
-		open_dir(currGame.path);
+		open_dir(current_game.path);
 	});
-	connect(checkCompat, &QAction::triggered, [=, this]
+	connect(check_compat, &QAction::triggered, [=, this]
 	{
 		const QString link = "https://rpcs3.net/compatibility?g=" + serial;
 		QDesktopServices::openUrl(QUrl(link));
 	});
-	connect(downloadCompat, &QAction::triggered, [=, this]
+	connect(download_compat, &QAction::triggered, [=, this]
 	{
 		m_game_compat->RequestCompatibility(true);
 	});
-	connect(renameTitle, &QAction::triggered, [=, this]
+	connect(rename_title, &QAction::triggered, [=, this]
 	{
 		const QString custom_title = m_gui_settings->GetValue(gui::titles, serial, "").toString();
 		const QString old_title = custom_title.isEmpty() ? name : custom_title;
 		QString new_title;
 
 		input_dialog dlg(128, old_title, tr("Rename Title"), tr("%0\n%1\n\nYou can clear the line in order to use the original title.").arg(name).arg(serial), name, this);
-		dlg.move(globalPos);
+		dlg.move(global_pos);
 		connect(&dlg, &input_dialog::text_changed, [&new_title](const QString& text)
 		{
 			new_title = text.simplified();
@@ -1202,7 +1202,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 			Refresh(true); // full refresh in order to reliably sort the list
 		}
 	});
-	connect(editNotes, &QAction::triggered, [=, this]
+	connect(edit_notes, &QAction::triggered, [=, this]
 	{
 		bool accepted;
 		const QString old_notes = m_gui_settings->GetValue(gui::notes, serial, "").toString();
@@ -1237,18 +1237,18 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	});
 
 	// Disable options depending on software category
-	const QString category = qstr(currGame.category);
+	const QString category = qstr(current_game.category);
 
 	if (category == cat_disc_game)
 	{
-		removeGame->setEnabled(false);
+		remove_game->setEnabled(false);
 	}
 	else if (category != cat_hdd_game)
 	{
-		checkCompat->setEnabled(false);
+		check_compat->setEnabled(false);
 	}
 
-	myMenu.exec(globalPos);
+	menu.exec(global_pos);
 }
 
 bool game_list_frame::CreatePPUCache(const game_info& game)
@@ -1787,15 +1787,15 @@ void game_list_frame::ShowCustomConfigIcon(game_info game)
 	}
 
 	const std::string serial      = game->info.serial;
-	const bool hasCustomConfig    = game->hasCustomConfig;
-	const bool hasCustomPadConfig = game->hasCustomPadConfig;
+	const bool has_custom_config    = game->hasCustomConfig;
+	const bool has_custom_pad_config = game->hasCustomPadConfig;
 
 	for (auto other_game : m_game_data)
 	{
 		if (other_game->info.serial == serial)
 		{
-			other_game->hasCustomConfig    = hasCustomConfig;
-			other_game->hasCustomPadConfig = hasCustomPadConfig;
+			other_game->hasCustomConfig    = has_custom_config;
+			other_game->hasCustomPadConfig = has_custom_pad_config;
 		}
 	}
 
@@ -1876,28 +1876,28 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 	// Zoom gamelist/gamegrid
 	if (event->type() == QEvent::Wheel && (object == m_game_list->verticalScrollBar() || object == m_game_grid->verticalScrollBar()))
 	{
-		QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(event);
+		QWheelEvent *wheel_event = static_cast<QWheelEvent *>(event);
 
-		if (wheelEvent->modifiers() & Qt::ControlModifier)
+		if (wheel_event->modifiers() & Qt::ControlModifier)
 		{
-			QPoint numSteps = wheelEvent->angleDelta() / 8 / 15;	// http://doc.qt.io/qt-5/qwheelevent.html#pixelDelta
-			const int value = numSteps.y();
+			QPoint num_steps = wheel_event->angleDelta() / 8 / 15;	// http://doc.qt.io/qt-5/qwheelevent.html#pixelDelta
+			const int value = num_steps.y();
 			Q_EMIT RequestIconSizeChange(value);
 			return true;
 		}
 	}
 	else if (event->type() == QEvent::KeyPress && (object == m_game_list || object == m_game_grid))
 	{
-		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+		QKeyEvent *key_event = static_cast<QKeyEvent *>(event);
 
-		if (keyEvent->modifiers() & Qt::ControlModifier)
+		if (key_event->modifiers() & Qt::ControlModifier)
 		{
-			if (keyEvent->key() == Qt::Key_Plus)
+			if (key_event->key() == Qt::Key_Plus)
 			{
 				Q_EMIT RequestIconSizeChange(1);
 				return true;
 			}
-			else if (keyEvent->key() == Qt::Key_Minus)
+			else if (key_event->key() == Qt::Key_Minus)
 			{
 				Q_EMIT RequestIconSizeChange(-1);
 				return true;
@@ -1905,7 +1905,7 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 		}
 		else
 		{
-			if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return)
+			if (key_event->key() == Qt::Key_Enter || key_event->key() == Qt::Key_Return)
 			{
 				QTableWidgetItem* item;
 
@@ -1922,7 +1922,7 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 				if (!gameinfo)
 					return false;
 
-				sys_log.notice("Booting from gamelist by pressing %s...", keyEvent->key() == Qt::Key_Enter ? "Enter" : "Return");
+				sys_log.notice("Booting from gamelist by pressing %s...", key_event->key() == Qt::Key_Enter ? "Enter" : "Return");
 				Q_EMIT RequestBoot(gameinfo);
 
 				return true;
@@ -1931,21 +1931,21 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 	}
 	else if (event->type() == QEvent::ToolTip)
 	{
-		QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
+		QHelpEvent *help_event = static_cast<QHelpEvent *>(event);
 		QTableWidgetItem* item;
 
 		if (m_is_list_layout)
 		{
-			item = m_game_list->itemAt(helpEvent->globalPos());
+			item = m_game_list->itemAt(help_event->globalPos());
 		}
 		else
 		{
-			item = m_game_grid->itemAt(helpEvent->globalPos());
+			item = m_game_grid->itemAt(help_event->globalPos());
 		}
 
 		if (item && !item->toolTip().isEmpty() && (!m_is_list_layout || item->column() == gui::column_name || item->column() == gui::column_serial))
 		{
-			QToolTip::showText(helpEvent->globalPos(), item->toolTip());
+			QToolTip::showText(help_event->globalPos(), item->toolTip());
 		}
 		else
 		{
@@ -2137,9 +2137,9 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 
 	maxCols = std::clamp(maxCols, 1, entries);
 
-	const int needsExtraRow = (entries % maxCols) != 0;
-	const int maxRows = needsExtraRow + entries / maxCols;
-	m_game_grid->setRowCount(maxRows);
+	const int needs_extra_row = (entries % maxCols) != 0;
+	const int max_rows = needs_extra_row + entries / maxCols;
+	m_game_grid->setRowCount(max_rows);
 	m_game_grid->setColumnCount(maxCols);
 
 	for (const auto& app : matching_apps)
@@ -2195,8 +2195,8 @@ bool game_list_frame::SearchMatchesApp(const QString& name, const QString& seria
 {
 	if (!m_search_text.isEmpty())
 	{
-		const QString searchText = m_search_text.toLower();
-		return m_titles.value(serial, name).toLower().contains(searchText) || serial.toLower().contains(searchText);
+		const QString search_text = m_search_text.toLower();
+		return m_titles.value(serial, name).toLower().contains(search_text) || serial.toLower().contains(search_text);
 	}
 	return true;
 }
@@ -2224,7 +2224,7 @@ std::string game_list_frame::CurrentSelectionIconPath()
 
 	if (item)
 	{
-		QVariant var = item->data(gui::game_role);
+		const QVariant var = item->data(gui::game_role);
 
 		if (var.canConvert<game_info>())
 		{

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -41,71 +41,71 @@ LOG_CHANNEL(sys_log, "SYS");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
-game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, std::shared_ptr<persistent_settings> persistent_settings, QWidget* parent)
+game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget* parent)
 	: custom_dock_widget(tr("Game List"), parent)
-	, m_gui_settings(guiSettings)
-	, m_emu_settings(emuSettings)
+	, m_gui_settings(gui_settings)
+	, m_emu_settings(emu_settings)
 	, m_persistent_settings(persistent_settings)
 {
-	m_Icon_Size       = gui::gl_icon_size_min; // ensure a valid size
-	m_isListLayout    = m_gui_settings->GetValue(gui::gl_listMode).toBool();
-	m_Margin_Factor   = m_gui_settings->GetValue(gui::gl_marginFactor).toReal();
-	m_Text_Factor     = m_gui_settings->GetValue(gui::gl_textFactor).toReal();
-	m_Icon_Color      = m_gui_settings->GetValue(gui::gl_iconColor).value<QColor>();
-	m_colSortOrder    = m_gui_settings->GetValue(gui::gl_sortAsc).toBool() ? Qt::AscendingOrder : Qt::DescendingOrder;
-	m_sortColumn      = m_gui_settings->GetValue(gui::gl_sortCol).toInt();
+	m_icon_size       = gui::gl_icon_size_min; // ensure a valid size
+	m_is_list_layout  = m_gui_settings->GetValue(gui::gl_listMode).toBool();
+	m_margin_factor   = m_gui_settings->GetValue(gui::gl_marginFactor).toReal();
+	m_text_factor     = m_gui_settings->GetValue(gui::gl_textFactor).toReal();
+	m_icon_color      = m_gui_settings->GetValue(gui::gl_iconColor).value<QColor>();
+	m_col_sort_order  = m_gui_settings->GetValue(gui::gl_sortAsc).toBool() ? Qt::AscendingOrder : Qt::DescendingOrder;
+	m_sort_column     = m_gui_settings->GetValue(gui::gl_sortCol).toInt();
 	m_hidden_list     = gui::utils::list_to_set(m_gui_settings->GetValue(gui::gl_hidden_list).toStringList());
 
-	m_oldLayoutIsList = m_isListLayout;
+	m_old_layout_is_list = m_is_list_layout;
 
 	// Save factors for first setup
-	m_gui_settings->SetValue(gui::gl_iconColor, m_Icon_Color);
-	m_gui_settings->SetValue(gui::gl_marginFactor, m_Margin_Factor);
-	m_gui_settings->SetValue(gui::gl_textFactor, m_Text_Factor);
+	m_gui_settings->SetValue(gui::gl_iconColor, m_icon_color);
+	m_gui_settings->SetValue(gui::gl_marginFactor, m_margin_factor);
+	m_gui_settings->SetValue(gui::gl_textFactor, m_text_factor);
 
-	m_Game_Dock = new QMainWindow(this);
-	m_Game_Dock->setWindowFlags(Qt::Widget);
-	setWidget(m_Game_Dock);
+	m_game_dock = new QMainWindow(this);
+	m_game_dock->setWindowFlags(Qt::Widget);
+	setWidget(m_game_dock);
 
-	m_xgrid = new game_list_grid(QSize(), m_Icon_Color, m_Margin_Factor, m_Text_Factor, false);
+	m_game_grid = new game_list_grid(QSize(), m_icon_color, m_margin_factor, m_text_factor, false);
 
-	m_gameList = new game_list();
-	m_gameList->setShowGrid(false);
-	m_gameList->setItemDelegate(new table_item_delegate(this, true));
-	m_gameList->setEditTriggers(QAbstractItemView::NoEditTriggers);
-	m_gameList->setSelectionBehavior(QAbstractItemView::SelectRows);
-	m_gameList->setSelectionMode(QAbstractItemView::SingleSelection);
-	m_gameList->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-	m_gameList->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
-	m_gameList->verticalScrollBar()->installEventFilter(this);
-	m_gameList->verticalScrollBar()->setSingleStep(20);
-	m_gameList->horizontalScrollBar()->setSingleStep(20);
-	m_gameList->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
-	m_gameList->verticalHeader()->setVisible(false);
-	m_gameList->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
-	m_gameList->horizontalHeader()->setHighlightSections(false);
-	m_gameList->horizontalHeader()->setSortIndicatorShown(true);
-	m_gameList->horizontalHeader()->setStretchLastSection(true);
-	m_gameList->horizontalHeader()->setDefaultSectionSize(150);
-	m_gameList->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
-	m_gameList->setContextMenuPolicy(Qt::CustomContextMenu);
-	m_gameList->setAlternatingRowColors(true);
-	m_gameList->installEventFilter(this);
-	m_gameList->setColumnCount(gui::column_count);
+	m_game_list = new game_list();
+	m_game_list->setShowGrid(false);
+	m_game_list->setItemDelegate(new table_item_delegate(this, true));
+	m_game_list->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	m_game_list->setSelectionBehavior(QAbstractItemView::SelectRows);
+	m_game_list->setSelectionMode(QAbstractItemView::SingleSelection);
+	m_game_list->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_game_list->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_game_list->verticalScrollBar()->installEventFilter(this);
+	m_game_list->verticalScrollBar()->setSingleStep(20);
+	m_game_list->horizontalScrollBar()->setSingleStep(20);
+	m_game_list->verticalHeader()->setSectionResizeMode(QHeaderView::Fixed);
+	m_game_list->verticalHeader()->setVisible(false);
+	m_game_list->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
+	m_game_list->horizontalHeader()->setHighlightSections(false);
+	m_game_list->horizontalHeader()->setSortIndicatorShown(true);
+	m_game_list->horizontalHeader()->setStretchLastSection(true);
+	m_game_list->horizontalHeader()->setDefaultSectionSize(150);
+	m_game_list->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
+	m_game_list->setContextMenuPolicy(Qt::CustomContextMenu);
+	m_game_list->setAlternatingRowColors(true);
+	m_game_list->installEventFilter(this);
+	m_game_list->setColumnCount(gui::column_count);
 
 	m_game_compat = std::make_unique<game_compatibility>(m_gui_settings);
 
-	m_Central_Widget = new QStackedWidget(this);
-	m_Central_Widget->addWidget(m_gameList);
-	m_Central_Widget->addWidget(m_xgrid);
-	m_Central_Widget->setCurrentWidget(m_isListLayout ? m_gameList : m_xgrid);
+	m_central_widget = new QStackedWidget(this);
+	m_central_widget->addWidget(m_game_list);
+	m_central_widget->addWidget(m_game_grid);
+	m_central_widget->setCurrentWidget(m_is_list_layout ? m_game_list : m_game_grid);
 
-	m_Game_Dock->setCentralWidget(m_Central_Widget);
+	m_game_dock->setCentralWidget(m_central_widget);
 
 	// Actions regarding showing/hiding columns
 	auto AddColumn = [this](gui::game_list_columns col, const QString& header_text, const QString& action_text)
 	{
-		m_gameList->setHorizontalHeaderItem(col, new QTableWidgetItem(header_text));
+		m_game_list->setHorizontalHeaderItem(col, new QTableWidgetItem(header_text));
 		m_columnActs.append(new QAction(action_text, this));
 	};
 
@@ -125,21 +125,21 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 	AddColumn(gui::column_compat,     tr("Compatibility"),         tr("Show Compatibility"));
 
 	// Events
-	connect(m_gameList, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
-	connect(m_gameList, &QTableWidget::currentItemChanged, this, &game_list_frame::itemSelectedSlot);
-	connect(m_gameList, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
+	connect(m_game_list, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
+	connect(m_game_list, &QTableWidget::currentItemChanged, this, &game_list_frame::itemSelectedSlot);
+	connect(m_game_list, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
 
-	connect(m_gameList->horizontalHeader(), &QHeaderView::sectionClicked, this, &game_list_frame::OnColClicked);
-	connect(m_gameList->horizontalHeader(), &QHeaderView::customContextMenuRequested, [this](const QPoint& pos)
+	connect(m_game_list->horizontalHeader(), &QHeaderView::sectionClicked, this, &game_list_frame::OnColClicked);
+	connect(m_game_list->horizontalHeader(), &QHeaderView::customContextMenuRequested, [this](const QPoint& pos)
 	{
 		QMenu* configure = new QMenu(this);
 		configure->addActions(m_columnActs);
-		configure->exec(m_gameList->horizontalHeader()->viewport()->mapToGlobal(pos));
+		configure->exec(m_game_list->horizontalHeader()->viewport()->mapToGlobal(pos));
 	});
 
-	connect(m_xgrid, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
-	connect(m_xgrid, &QTableWidget::currentItemChanged, this, &game_list_frame::itemSelectedSlot);
-	connect(m_xgrid, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
+	connect(m_game_grid, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
+	connect(m_game_grid, &QTableWidget::currentItemChanged, this, &game_list_frame::itemSelectedSlot);
+	connect(m_game_grid, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
 
 	connect(m_game_compat.get(), &game_compatibility::DownloadStarted, [this]()
 	{
@@ -187,7 +187,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 					return;
 				}
 			}
-			m_gameList->setColumnHidden(col, !checked); // Negate because it's a set col hidden and we have menu say show.
+			m_game_list->setColumnHidden(col, !checked); // Negate because it's a set col hidden and we have menu say show.
 			m_gui_settings->SetGamelistColVisibility(col, checked);
 
 			if (checked) // handle hidden columns that have zero width after showing them (stuck between others)
@@ -200,15 +200,15 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> guiSettings, std:
 
 void game_list_frame::LoadSettings()
 {
-	m_colSortOrder = m_gui_settings->GetValue(gui::gl_sortAsc).toBool() ? Qt::AscendingOrder : Qt::DescendingOrder;
-	m_sortColumn = m_gui_settings->GetValue(gui::gl_sortCol).toInt();
-	m_categoryFilters = m_gui_settings->GetGameListCategoryFilters();
-	m_drawCompatStatusToGrid = m_gui_settings->GetValue(gui::gl_draw_compat).toBool();
+	m_col_sort_order = m_gui_settings->GetValue(gui::gl_sortAsc).toBool() ? Qt::AscendingOrder : Qt::DescendingOrder;
+	m_sort_column = m_gui_settings->GetValue(gui::gl_sortCol).toInt();
+	m_category_filters = m_gui_settings->GetGameListCategoryFilters();
+	m_draw_compat_status_to_grid = m_gui_settings->GetValue(gui::gl_draw_compat).toBool();
 
 	Refresh(true);
 
 	QByteArray state = m_gui_settings->GetValue(gui::gl_state).toByteArray();
-	if (!m_gameList->horizontalHeader()->restoreState(state) && m_gameList->rowCount())
+	if (!m_game_list->horizontalHeader()->restoreState(state) && m_game_list->rowCount())
 	{
 		// If no settings exist, resize to contents.
 		ResizeColumnsToContents();
@@ -218,13 +218,13 @@ void game_list_frame::LoadSettings()
 	{
 		bool vis = m_gui_settings->GetGamelistColVisibility(col);
 		m_columnActs[col]->setChecked(vis);
-		m_gameList->setColumnHidden(col, !vis);
+		m_game_list->setColumnHidden(col, !vis);
 	}
 
 	SortGameList();
 	FixNarrowColumns();
 
-	m_gameList->horizontalHeader()->restoreState(m_gameList->horizontalHeader()->saveState());
+	m_game_list->horizontalHeader()->restoreState(m_game_list->horizontalHeader()->saveState());
 }
 
 game_list_frame::~game_list_frame()
@@ -239,38 +239,38 @@ void game_list_frame::FixNarrowColumns()
 	// handle columns (other than the icon column) that have zero width after showing them (stuck between others)
 	for (int col = 1; col < m_columnActs.count(); ++col)
 	{
-		if (m_gameList->isColumnHidden(col))
+		if (m_game_list->isColumnHidden(col))
 		{
 			continue;
 		}
 
-		if (m_gameList->columnWidth(col) <= m_gameList->horizontalHeader()->minimumSectionSize())
+		if (m_game_list->columnWidth(col) <= m_game_list->horizontalHeader()->minimumSectionSize())
 		{
-			m_gameList->setColumnWidth(col, m_gameList->horizontalHeader()->minimumSectionSize());
+			m_game_list->setColumnWidth(col, m_game_list->horizontalHeader()->minimumSectionSize());
 		}
 	}
 }
 
 void game_list_frame::ResizeColumnsToContents(int spacing)
 {
-	if (!m_gameList)
+	if (!m_game_list)
 	{
 		return;
 	}
 
-	m_gameList->verticalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
-	m_gameList->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
+	m_game_list->verticalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
+	m_game_list->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
 
 	// Make non-icon columns slighty bigger for better visuals
-	for (int i = 1; i < m_gameList->columnCount(); i++)
+	for (int i = 1; i < m_game_list->columnCount(); i++)
 	{
-		if (m_gameList->isColumnHidden(i))
+		if (m_game_list->isColumnHidden(i))
 		{
 			continue;
 		}
 
-		int size = m_gameList->horizontalHeader()->sectionSize(i) + spacing;
-		m_gameList->horizontalHeader()->resizeSection(i, size);
+		const int size = m_game_list->horizontalHeader()->sectionSize(i) + spacing;
+		m_game_list->horizontalHeader()->resizeSection(i, size);
 	}
 }
 
@@ -278,17 +278,17 @@ void game_list_frame::OnColClicked(int col)
 {
 	if (col == 0) return; // Don't "sort" icons.
 
-	if (col == m_sortColumn)
+	if (col == m_sort_column)
 	{
-		m_colSortOrder = (m_colSortOrder == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder;
+		m_col_sort_order = (m_col_sort_order == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder;
 	}
 	else
 	{
-		m_colSortOrder = Qt::AscendingOrder;
+		m_col_sort_order = Qt::AscendingOrder;
 	}
-	m_sortColumn = col;
+	m_sort_column = col;
 
-	m_gui_settings->SetValue(gui::gl_sortAsc, m_colSortOrder == Qt::AscendingOrder);
+	m_gui_settings->SetValue(gui::gl_sortAsc, m_col_sort_order == Qt::AscendingOrder);
 	m_gui_settings->SetValue(gui::gl_sortCol, col);
 
 	SortGameList();
@@ -299,9 +299,9 @@ bool game_list_frame::IsEntryVisible(const game_info& game)
 {
 	auto matches_category = [&]()
 	{
-		if (m_isListLayout)
+		if (m_is_list_layout)
 		{
-			return m_categoryFilters.contains(qstr(game->info.category));
+			return m_category_filters.contains(qstr(game->info.category));
 		}
 
 		const auto cat_boot = Localized().category.cat_boot;
@@ -317,51 +317,51 @@ void game_list_frame::SortGameList()
 {
 	// Back-up old header sizes to handle unwanted column resize in case of zero search results
 	QList<int> column_widths;
-	int old_row_count = m_gameList->rowCount();
-	int old_game_count = m_game_data.count();
+	const int old_row_count = m_game_list->rowCount();
+	const int old_game_count = m_game_data.count();
 
-	for (int i = 0; i < m_gameList->columnCount(); i++)
+	for (int i = 0; i < m_game_list->columnCount(); i++)
 	{
-		column_widths.append(m_gameList->columnWidth(i));
+		column_widths.append(m_game_list->columnWidth(i));
 	}
 
 	// Sorting resizes hidden columns, so unhide them as a workaround
 	QList<int> columns_to_hide;
 
-	for (int i = 0; i < m_gameList->columnCount(); i++)
+	for (int i = 0; i < m_game_list->columnCount(); i++)
 	{
-		if (m_gameList->isColumnHidden(i))
+		if (m_game_list->isColumnHidden(i))
 		{
-			m_gameList->setColumnHidden(i, false);
+			m_game_list->setColumnHidden(i, false);
 			columns_to_hide << i;
 		}
 	}
 
 	// Sort the list by column and sort order
-	m_gameList->sortByColumn(m_sortColumn, m_colSortOrder);
+	m_game_list->sortByColumn(m_sort_column, m_col_sort_order);
 
 	// Hide columns again
 	for (auto i : columns_to_hide)
 	{
-		m_gameList->setColumnHidden(i, true);
+		m_game_list->setColumnHidden(i, true);
 	}
 
 	// Don't resize the columns if no game is shown to preserve the header settings
-	if (!m_gameList->rowCount())
+	if (!m_game_list->rowCount())
 	{
-		for (int i = 0; i < m_gameList->columnCount(); i++)
+		for (int i = 0; i < m_game_list->columnCount(); i++)
 		{
-			m_gameList->setColumnWidth(i, column_widths[i]);
+			m_game_list->setColumnWidth(i, column_widths[i]);
 		}
 
-		m_gameList->horizontalHeader()->setSectionResizeMode(gui::column_icon, QHeaderView::Fixed);
+		m_game_list->horizontalHeader()->setSectionResizeMode(gui::column_icon, QHeaderView::Fixed);
 		return;
 	}
 
 	// Fixate vertical header and row height
-	m_gameList->verticalHeader()->setMinimumSectionSize(m_Icon_Size.height());
-	m_gameList->verticalHeader()->setMaximumSectionSize(m_Icon_Size.height());
-	m_gameList->resizeRowsToContents();
+	m_game_list->verticalHeader()->setMinimumSectionSize(m_icon_size.height());
+	m_game_list->verticalHeader()->setMaximumSectionSize(m_icon_size.height());
+	m_game_list->resizeRowsToContents();
 
 	// Resize columns if the game list was empty before
 	if (!old_row_count && !old_game_count)
@@ -370,14 +370,14 @@ void game_list_frame::SortGameList()
 	}
 	else
 	{
-		m_gameList->resizeColumnToContents(gui::column_icon);
+		m_game_list->resizeColumnToContents(gui::column_icon);
 	}
 
 	// Fixate icon column
-	m_gameList->horizontalHeader()->setSectionResizeMode(gui::column_icon, QHeaderView::Fixed);
+	m_game_list->horizontalHeader()->setSectionResizeMode(gui::column_icon, QHeaderView::Fixed);
 
 	// Shorten the last section to remove horizontal scrollbar if possible
-	m_gameList->resizeColumnToContents(gui::column_count - 1);
+	m_game_list->resizeColumnToContents(gui::column_count - 1);
 }
 
 QString game_list_frame::GetLastPlayedBySerial(const QString& serial)
@@ -469,9 +469,9 @@ std::string game_list_frame::GetDataDirBySerial(const std::string& serial)
 	return fs::get_config_dir() + "data/" + serial;
 }
 
-void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
+void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 {
-	if (fromDrive)
+	if (from_drive)
 	{
 		const Localized localized;
 
@@ -788,38 +788,38 @@ void game_list_frame::Refresh(const bool fromDrive, const bool scrollAfter)
 
 	// Fill Game List / Game Grid
 
-	if (m_isListLayout)
+	if (m_is_list_layout)
 	{
-		const int scroll_position = m_gameList->verticalScrollBar()->value();
+		const int scroll_position = m_game_list->verticalScrollBar()->value();
 		PopulateGameList();
 		SortGameList();
 
-		if (scrollAfter)
+		if (scroll_after)
 		{
-			m_gameList->scrollTo(m_gameList->currentIndex(), QAbstractItemView::PositionAtCenter);
+			m_game_list->scrollTo(m_game_list->currentIndex(), QAbstractItemView::PositionAtCenter);
 		}
 		else
 		{
-			m_gameList->verticalScrollBar()->setValue(scroll_position);
+			m_game_list->verticalScrollBar()->setValue(scroll_position);
 		}
 	}
 	else
 	{
 		int games_per_row = 0;
 
-		if (m_Icon_Size.width() > 0 && m_Icon_Size.height() > 0)
+		if (m_icon_size.width() > 0 && m_icon_size.height() > 0)
 		{
-			games_per_row = width() / (m_Icon_Size.width() + m_Icon_Size.width() * m_xgrid->getMarginFactor() * 2);
+			games_per_row = width() / (m_icon_size.width() + m_icon_size.width() * m_game_grid->getMarginFactor() * 2);
 		}
 
-		const int scroll_position = m_xgrid->verticalScrollBar()->value();
-		PopulateGameGrid(games_per_row, m_Icon_Size, m_Icon_Color);
-		connect(m_xgrid, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
-		connect(m_xgrid, &QTableWidget::currentItemChanged, this, &game_list_frame::itemSelectedSlot);
-		connect(m_xgrid, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
-		m_Central_Widget->addWidget(m_xgrid);
-		m_Central_Widget->setCurrentWidget(m_xgrid);
-		m_xgrid->verticalScrollBar()->setValue(scroll_position);
+		const int scroll_position = m_game_grid->verticalScrollBar()->value();
+		PopulateGameGrid(games_per_row, m_icon_size, m_icon_color);
+		connect(m_game_grid, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
+		connect(m_game_grid, &QTableWidget::currentItemChanged, this, &game_list_frame::itemSelectedSlot);
+		connect(m_game_grid, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
+		m_central_widget->addWidget(m_game_grid);
+		m_central_widget->setCurrentWidget(m_game_grid);
+		m_game_grid->verticalScrollBar()->setValue(scroll_position);
 	}
 }
 
@@ -827,13 +827,13 @@ void game_list_frame::ToggleCategoryFilter(const QStringList& categories, bool s
 {
 	if (show)
 	{
-		m_categoryFilters.append(categories);
+		m_category_filters.append(categories);
 	}
 	else
 	{
 		for (const auto& cat : categories)
 		{
-			m_categoryFilters.removeAll(cat);
+			m_category_filters.removeAll(cat);
 		}
 	}
 
@@ -846,10 +846,10 @@ void game_list_frame::SaveSettings()
 	{
 		m_gui_settings->SetGamelistColVisibility(col, m_columnActs[col]->isChecked());
 	}
-	m_gui_settings->SetValue(gui::gl_sortCol, m_sortColumn);
-	m_gui_settings->SetValue(gui::gl_sortAsc, m_colSortOrder == Qt::AscendingOrder);
+	m_gui_settings->SetValue(gui::gl_sortCol, m_sort_column);
+	m_gui_settings->SetValue(gui::gl_sortAsc, m_col_sort_order == Qt::AscendingOrder);
 
-	m_gui_settings->SetValue(gui::gl_state, m_gameList->horizontalHeader()->saveState());
+	m_gui_settings->SetValue(gui::gl_state, m_game_list->horizontalHeader()->saveState());
 }
 
 static void open_dir(const std::string& spath)
@@ -911,16 +911,16 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	QPoint globalPos;
 	QTableWidgetItem* item;
 
-	if (m_isListLayout)
+	if (m_is_list_layout)
 	{
-		item = m_gameList->item(m_gameList->indexAt(pos).row(), gui::column_icon);
-		globalPos = m_gameList->viewport()->mapToGlobal(pos);
+		item = m_game_list->item(m_game_list->indexAt(pos).row(), gui::column_icon);
+		globalPos = m_game_list->viewport()->mapToGlobal(pos);
 	}
 	else
 	{
-		QModelIndex mi = m_xgrid->indexAt(pos);
-		item = m_xgrid->item(mi.row(), mi.column());
-		globalPos = m_xgrid->viewport()->mapToGlobal(pos);
+		const QModelIndex mi = m_game_grid->indexAt(pos);
+		item = m_game_grid->item(mi.row(), mi.column());
+		globalPos = m_game_grid->viewport()->mapToGlobal(pos);
 	}
 
 	game_info gameinfo = GetGameInfoFromItem(item);
@@ -1722,7 +1722,7 @@ QPixmap game_list_frame::PaintedPixmap(const QPixmap& icon, bool paint_config_ic
 
 	QPixmap canvas = QPixmap(original_size * device_pixel_ratio);
 	canvas.setDevicePixelRatio(device_pixel_ratio);
-	canvas.fill(m_Icon_Color);
+	canvas.fill(m_icon_color);
 
 	QPainter painter(&canvas);
 	painter.setRenderHint(QPainter::SmoothPixmapTransform);
@@ -1732,7 +1732,7 @@ QPixmap game_list_frame::PaintedPixmap(const QPixmap& icon, bool paint_config_ic
 		painter.drawPixmap(QPoint(0, 0), icon);
 	}
 
-	if (!m_isListLayout && (paint_config_icon || paint_pad_config_icon))
+	if (!m_is_list_layout && (paint_config_icon || paint_pad_config_icon))
 	{
 		const int width = original_size.width() * 0.2;
 		const QPoint origin = QPoint(original_size.width() - width, 0);
@@ -1769,7 +1769,7 @@ QPixmap game_list_frame::PaintedPixmap(const QPixmap& icon, bool paint_config_ic
 
 	painter.end();
 
-	return canvas.scaled(m_Icon_Size * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation);
+	return canvas.scaled(m_icon_size * device_pixel_ratio, Qt::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation);
 }
 
 void game_list_frame::ShowCustomConfigIcon(game_info game)
@@ -1795,25 +1795,25 @@ void game_list_frame::ShowCustomConfigIcon(game_info game)
 	RepaintIcons();
 }
 
-void game_list_frame::ResizeIcons(const int& sliderPos)
+void game_list_frame::ResizeIcons(const int& slider_pos)
 {
-	m_icon_size_index = sliderPos;
-	m_Icon_Size = gui_settings::SizeFromSlider(sliderPos);
+	m_icon_size_index = slider_pos;
+	m_icon_size = gui_settings::SizeFromSlider(slider_pos);
 
 	RepaintIcons();
 }
 
-void game_list_frame::RepaintIcons(const bool& fromSettings)
+void game_list_frame::RepaintIcons(const bool& from_settings)
 {
-	if (fromSettings)
+	if (from_settings)
 	{
 		if (m_gui_settings->GetValue(gui::m_enableUIColors).toBool())
 		{
-			m_Icon_Color = m_gui_settings->GetValue(gui::gl_iconColor).value<QColor>();
+			m_icon_color = m_gui_settings->GetValue(gui::gl_iconColor).value<QColor>();
 		}
 		else
 		{
-			m_Icon_Color = gui::utils::get_label_color("gamelist_icon_background_color");
+			m_icon_color = gui::utils::get_label_color("gamelist_icon_background_color");
 		}
 	}
 
@@ -1831,16 +1831,16 @@ void game_list_frame::SetShowHidden(bool show)
 	m_show_hidden = show;
 }
 
-void game_list_frame::SetListMode(const bool& isList)
+void game_list_frame::SetListMode(const bool& is_list)
 {
-	m_oldLayoutIsList = m_isListLayout;
-	m_isListLayout = isList;
+	m_old_layout_is_list = m_is_list_layout;
+	m_is_list_layout = is_list;
 
-	m_gui_settings->SetValue(gui::gl_listMode, isList);
+	m_gui_settings->SetValue(gui::gl_listMode, is_list);
 
 	Refresh(true);
 
-	m_Central_Widget->setCurrentWidget(m_isListLayout ? m_gameList : m_xgrid);
+	m_central_widget->setCurrentWidget(m_is_list_layout ? m_game_list : m_game_grid);
 }
 
 void game_list_frame::SetSearchText(const QString& text)
@@ -1857,9 +1857,9 @@ void game_list_frame::closeEvent(QCloseEvent *event)
 
 void game_list_frame::resizeEvent(QResizeEvent *event)
 {
-	if (!m_isListLayout)
+	if (!m_is_list_layout)
 	{
-		Refresh(false, m_xgrid->selectedItems().count());
+		Refresh(false, m_game_grid->selectedItems().count());
 	}
 	QDockWidget::resizeEvent(event);
 }
@@ -1867,7 +1867,7 @@ void game_list_frame::resizeEvent(QResizeEvent *event)
 bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 {
 	// Zoom gamelist/gamegrid
-	if (event->type() == QEvent::Wheel && (object == m_gameList->verticalScrollBar() || object == m_xgrid->verticalScrollBar()))
+	if (event->type() == QEvent::Wheel && (object == m_game_list->verticalScrollBar() || object == m_game_grid->verticalScrollBar()))
 	{
 		QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(event);
 
@@ -1879,7 +1879,7 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 			return true;
 		}
 	}
-	else if (event->type() == QEvent::KeyPress && (object == m_gameList || object == m_xgrid))
+	else if (event->type() == QEvent::KeyPress && (object == m_game_list || object == m_game_grid))
 	{
 		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
 
@@ -1902,10 +1902,10 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 			{
 				QTableWidgetItem* item;
 
-				if (object == m_gameList)
-					item = m_gameList->item(m_gameList->currentRow(), gui::column_icon);
+				if (object == m_game_list)
+					item = m_game_list->item(m_game_list->currentRow(), gui::column_icon);
 				else
-					item = m_xgrid->currentItem();
+					item = m_game_grid->currentItem();
 
 				if (!item || !item->isSelected())
 					return false;
@@ -1927,16 +1927,16 @@ bool game_list_frame::eventFilter(QObject *object, QEvent *event)
 		QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
 		QTableWidgetItem* item;
 
-		if (m_isListLayout)
+		if (m_is_list_layout)
 		{
-			item = m_gameList->itemAt(helpEvent->globalPos());
+			item = m_game_list->itemAt(helpEvent->globalPos());
 		}
 		else
 		{
-			item = m_xgrid->itemAt(helpEvent->globalPos());
+			item = m_game_grid->itemAt(helpEvent->globalPos());
 		}
 
-		if (item && !item->toolTip().isEmpty() && (!m_isListLayout || item->column() == gui::column_name || item->column() == gui::column_serial))
+		if (item && !item->toolTip().isEmpty() && (!m_is_list_layout || item->column() == gui::column_name || item->column() == gui::column_serial))
 		{
 			QToolTip::showText(helpEvent->globalPos(), item->toolTip());
 		}
@@ -1961,8 +1961,8 @@ void game_list_frame::PopulateGameList()
 
 	std::string selected_item = CurrentSelectionIconPath();
 
-	m_gameList->clearContents();
-	m_gameList->setRowCount(m_game_data.size());
+	m_game_list->clearContents();
+	m_game_list->setRowCount(m_game_data.size());
 
 	// Default locale. Uses current Qt application language.
 	const QLocale locale{};
@@ -2061,20 +2061,20 @@ void game_list_frame::PopulateGameList()
 			}
 		}
 
-		m_gameList->setItem(row, gui::column_icon,       icon_item);
-		m_gameList->setItem(row, gui::column_name,       title_item);
-		m_gameList->setItem(row, gui::column_serial,     serial_item);
-		m_gameList->setItem(row, gui::column_firmware,   new custom_table_widget_item(game->info.fw));
-		m_gameList->setItem(row, gui::column_version,    new custom_table_widget_item(app_version));
-		m_gameList->setItem(row, gui::column_category,   new custom_table_widget_item(game->localized_category));
-		m_gameList->setItem(row, gui::column_path,       new custom_table_widget_item(game->info.path));
-		m_gameList->setItem(row, gui::column_move,       new custom_table_widget_item(sstr(supports_move ? tr("Supported") : tr("Not Supported")), Qt::UserRole, !supports_move));
-		m_gameList->setItem(row, gui::column_resolution, new custom_table_widget_item(GetStringFromU32(game->info.resolution, localized.resolution.mode, true)));
-		m_gameList->setItem(row, gui::column_sound,      new custom_table_widget_item(GetStringFromU32(game->info.sound_format, localized.sound.format, true)));
-		m_gameList->setItem(row, gui::column_parental,   new custom_table_widget_item(GetStringFromU32(game->info.parental_lvl, localized.parental.level), Qt::UserRole, game->info.parental_lvl));
-		m_gameList->setItem(row, gui::column_last_play,  new custom_table_widget_item(locale.toString(last_played, gui::persistent::last_played_date_format_new), Qt::UserRole, last_played));
-		m_gameList->setItem(row, gui::column_playtime,   new custom_table_widget_item(GetPlayTimeByMs(elapsed_ms), Qt::UserRole, elapsed_ms));
-		m_gameList->setItem(row, gui::column_compat,     compat_item);
+		m_game_list->setItem(row, gui::column_icon,       icon_item);
+		m_game_list->setItem(row, gui::column_name,       title_item);
+		m_game_list->setItem(row, gui::column_serial,     serial_item);
+		m_game_list->setItem(row, gui::column_firmware,   new custom_table_widget_item(game->info.fw));
+		m_game_list->setItem(row, gui::column_version,    new custom_table_widget_item(app_version));
+		m_game_list->setItem(row, gui::column_category,   new custom_table_widget_item(game->localized_category));
+		m_game_list->setItem(row, gui::column_path,       new custom_table_widget_item(game->info.path));
+		m_game_list->setItem(row, gui::column_move,       new custom_table_widget_item(sstr(supports_move ? tr("Supported") : tr("Not Supported")), Qt::UserRole, !supports_move));
+		m_game_list->setItem(row, gui::column_resolution, new custom_table_widget_item(GetStringFromU32(game->info.resolution, localized.resolution.mode, true)));
+		m_game_list->setItem(row, gui::column_sound,      new custom_table_widget_item(GetStringFromU32(game->info.sound_format, localized.sound.format, true)));
+		m_game_list->setItem(row, gui::column_parental,   new custom_table_widget_item(GetStringFromU32(game->info.parental_lvl, localized.parental.level), Qt::UserRole, game->info.parental_lvl));
+		m_game_list->setItem(row, gui::column_last_play,  new custom_table_widget_item(locale.toString(last_played, gui::persistent::last_played_date_format_new), Qt::UserRole, last_played));
+		m_game_list->setItem(row, gui::column_playtime,   new custom_table_widget_item(GetPlayTimeByMs(elapsed_ms), Qt::UserRole, elapsed_ms));
+		m_game_list->setItem(row, gui::column_compat,     compat_item);
 
 		if (selected_item == game->info.icon_path)
 		{
@@ -2084,8 +2084,8 @@ void game_list_frame::PopulateGameList()
 		row++;
 	}
 
-	m_gameList->setRowCount(row);
-	m_gameList->selectRow(selected_row);
+	m_game_list->setRowCount(row);
+	m_game_list->selectRow(selected_row);
 }
 
 void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color)
@@ -2095,17 +2095,17 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 
 	const std::string selected_item = CurrentSelectionIconPath();
 
-	m_xgrid->deleteLater();
+	m_game_grid->deleteLater();
 
 	const bool showText = m_icon_size_index > gui::gl_max_slider_pos * 2 / 5;
 
 	if (m_icon_size_index < gui::gl_max_slider_pos * 2 / 3)
 	{
-		m_xgrid = new game_list_grid(image_size, image_color, m_Margin_Factor, m_Text_Factor * 2, showText);
+		m_game_grid = new game_list_grid(image_size, image_color, m_margin_factor, m_text_factor * 2, showText);
 	}
 	else
 	{
-		m_xgrid = new game_list_grid(image_size, image_color, m_Margin_Factor, m_Text_Factor, showText);
+		m_game_grid = new game_list_grid(image_size, image_color, m_margin_factor, m_text_factor, showText);
 	}
 
 	// Get list of matching apps
@@ -2131,8 +2131,8 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 
 	const int needsExtraRow = (entries % maxCols) != 0;
 	const int maxRows = needsExtraRow + entries / maxCols;
-	m_xgrid->setRowCount(maxRows);
-	m_xgrid->setColumnCount(maxCols);
+	m_game_grid->setRowCount(maxRows);
+	m_game_grid->setColumnCount(maxCols);
 
 	for (const auto& app : matching_apps)
 	{
@@ -2140,21 +2140,21 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 		const QString title = m_titles.value(serial, qstr(app->info.name));
 		const QString notes = m_notes.value(serial);
 
-		m_xgrid->addItem(app->pxmap, title, r, c);
-		m_xgrid->item(r, c)->setData(gui::game_role, QVariant::fromValue(app));
+		m_game_grid->addItem(app->pxmap, title, r, c);
+		m_game_grid->item(r, c)->setData(gui::game_role, QVariant::fromValue(app));
 
 		if (!notes.isEmpty())
 		{
-			m_xgrid->item(r, c)->setToolTip(tr("%0 [%1]\n\nNotes:\n%2").arg(title).arg(serial).arg(notes));
+			m_game_grid->item(r, c)->setToolTip(tr("%0 [%1]\n\nNotes:\n%2").arg(title).arg(serial).arg(notes));
 		}
 		else
 		{
-			m_xgrid->item(r, c)->setToolTip(tr("%0 [%1]").arg(title).arg(serial));
+			m_game_grid->item(r, c)->setToolTip(tr("%0 [%1]").arg(title).arg(serial));
 		}
 
 		if (selected_item == app->info.icon_path)
 		{
-			m_xgrid->setCurrentCell(r, c);
+			m_game_grid->setCurrentCell(r, c);
 		}
 
 		if (++c >= maxCols)
@@ -2170,14 +2170,14 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 		{
 			QTableWidgetItem* emptyItem = new QTableWidgetItem();
 			emptyItem->setFlags(Qt::NoItemFlags);
-			m_xgrid->setItem(r, col, emptyItem);
+			m_game_grid->setItem(r, col, emptyItem);
 		}
 	}
 
-	m_xgrid->resizeColumnsToContents();
-	m_xgrid->resizeRowsToContents();
-	m_xgrid->installEventFilter(this);
-	m_xgrid->verticalScrollBar()->installEventFilter(this);
+	m_game_grid->resizeColumnsToContents();
+	m_game_grid->resizeRowsToContents();
+	m_game_grid->installEventFilter(this);
+	m_game_grid->verticalScrollBar()->installEventFilter(this);
 }
 
 /**
@@ -2199,18 +2199,18 @@ std::string game_list_frame::CurrentSelectionIconPath()
 
 	QTableWidgetItem* item = nullptr;
 
-	if (m_oldLayoutIsList)
+	if (m_old_layout_is_list)
 	{
-		if (!m_gameList->selectedItems().isEmpty())
+		if (!m_game_list->selectedItems().isEmpty())
 		{
-			item = m_gameList->item(m_gameList->currentRow(), 0);
+			item = m_game_list->item(m_game_list->currentRow(), 0);
 		}
 	}
 	else
 	{
-		if (!m_xgrid->selectedItems().isEmpty())
+		if (!m_game_grid->selectedItems().isEmpty())
 		{
-			item = m_xgrid->currentItem();
+			item = m_game_grid->currentItem();
 		}
 	}
 
@@ -2228,7 +2228,7 @@ std::string game_list_frame::CurrentSelectionIconPath()
 		}
 	}
 
-	m_oldLayoutIsList = m_isListLayout;
+	m_old_layout_is_list = m_is_list_layout;
 
 	return selection;
 }
@@ -2270,9 +2270,9 @@ game_info game_list_frame::GetGameInfoByMode(const QTableWidgetItem* item)
 		return nullptr;
 	}
 
-	if (m_isListLayout)
+	if (m_is_list_layout)
 	{
-		return GetGameInfoFromItem(m_gameList->item(item->row(), gui::column_icon));
+		return GetGameInfoFromItem(m_game_list->item(item->row(), gui::column_icon));
 	}
 
 	return GetGameInfoFromItem(item);
@@ -2285,7 +2285,7 @@ game_info game_list_frame::GetGameInfoFromItem(const QTableWidgetItem* item)
 		return nullptr;
 	}
 
-	QVariant var = item->data(gui::game_role);
+	const QVariant var = item->data(gui::game_role);
 	if (!var.canConvert<game_info>())
 	{
 		return nullptr;
@@ -2296,7 +2296,7 @@ game_info game_list_frame::GetGameInfoFromItem(const QTableWidgetItem* item)
 
 QColor game_list_frame::getGridCompatibilityColor(const QString& string)
 {
-	if (m_drawCompatStatusToGrid && !m_isListLayout)
+	if (m_draw_compat_status_to_grid && !m_is_list_layout)
 	{
 		return QColor(string);
 	}
@@ -2305,7 +2305,7 @@ QColor game_list_frame::getGridCompatibilityColor(const QString& string)
 
 void game_list_frame::SetShowCompatibilityInGrid(bool show)
 {
-	m_drawCompatStatusToGrid = show;
+	m_draw_compat_status_to_grid = show;
 	RepaintIcons();
 	m_gui_settings->SetValue(gui::gl_draw_compat, show);
 }

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1213,7 +1213,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	});
 	connect(copy_info, &QAction::triggered, [=, this]
 	{
-		QApplication::clipboard()->setText(name + " [" + serial + "]");
+		QApplication::clipboard()->setText(name % QStringLiteral(" [") % serial % QStringLiteral("]"));
 	});
 	connect(copy_name, &QAction::triggered, [=, this]
 	{

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -83,8 +83,10 @@ private Q_SLOTS:
 	void OnColClicked(int col);
 	void ShowContextMenu(const QPoint &pos);
 	void doubleClickedSlot(QTableWidgetItem *item);
+	void itemSelectedSlot(QTableWidgetItem* current, QTableWidgetItem* previous);
 Q_SIGNALS:
 	void GameListFrameClosed();
+	void NotifyGameSelection(const game_info& game);
 	void RequestBoot(const game_info& game, bool force_global_config = false);
 	void RequestIconSizeChange(const int& val);
 	void NotifyEmuSettingsChange();
@@ -117,7 +119,8 @@ private:
 	std::string CurrentSelectionIconPath();
 	std::string GetStringFromU32(const u32& key, const std::map<u32, QString>& map, bool combined = false);
 
-	game_info GetGameInfoFromItem(QTableWidgetItem* item);
+	game_info GetGameInfoByMode(const QTableWidgetItem* item);
+	game_info GetGameInfoFromItem(const QTableWidgetItem* item);
 
 	// Which widget we are displaying depends on if we are in grid or list mode.
 	QMainWindow* m_Game_Dock;

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -97,11 +97,10 @@ private:
 	QPixmap PaintedPixmap(const QPixmap& icon, bool paint_config_icon = false, bool paint_pad_config_icon = false, const QColor& color = QColor());
 	QColor getGridCompatibilityColor(const QString& string);
 	void ShowCustomConfigIcon(game_info game);
+	void PopulateGameList();
 	void PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color);
 	bool IsEntryVisible(const game_info& game);
 	void SortGameList();
-
-	int PopulateGameList();
 	bool SearchMatchesApp(const QString& name, const QString& serial) const;
 
 	bool RemoveCustomConfiguration(const std::string& title_id, game_info game = nullptr, bool is_interactive = false);

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -83,7 +83,7 @@ private Q_SLOTS:
 	void OnColClicked(int col);
 	void ShowContextMenu(const QPoint &pos);
 	void doubleClickedSlot(QTableWidgetItem *item);
-	void itemSelectedSlot(QTableWidgetItem* current, QTableWidgetItem* previous);
+	void itemSelectionChangedSlot();
 Q_SIGNALS:
 	void GameListFrameClosed();
 	void NotifyGameSelection(const game_info& game);

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -39,7 +39,7 @@ class game_list_frame : public custom_dock_widget
 	Q_OBJECT
 
 public:
-	explicit game_list_frame(std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, std::shared_ptr<persistent_settings> persistent_settings, QWidget *parent = nullptr);
+	explicit game_list_frame(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget *parent = nullptr);
 	~game_list_frame();
 
 	/** Fix columns with width smaller than the minimal section size */
@@ -49,7 +49,7 @@ public:
 	void ResizeColumnsToContents(int spacing = 20);
 
 	/** Refresh the gamelist with/without loading game data from files. Public so that main frame can refresh after vfs or install */
-	void Refresh(const bool fromDrive = false, const bool scrollAfter = true);
+	void Refresh(const bool from_drive = false, const bool scroll_after = true);
 
 	/** Adds/removes categories that should be shown on gamelist. Public so that main frame menu actions can apply them */
 	void ToggleCategoryFilter(const QStringList& categories, bool show);
@@ -61,10 +61,10 @@ public:
 	void SaveSettings();
 
 	/** Resize Gamelist Icons to size given by slider position */
-	void ResizeIcons(const int& sliderPos);
+	void ResizeIcons(const int& slider_pos);
 
 	/** Repaint Gamelist Icons with new background color */
-	void RepaintIcons(const bool& fromSettings = false);
+	void RepaintIcons(const bool& from_settings = false);
 
 	void SetShowHidden(bool show);
 
@@ -75,7 +75,7 @@ public Q_SLOTS:
 	void BatchRemoveCustomConfigurations();
 	void BatchRemoveCustomPadConfigurations();
 	void BatchRemoveShaderCaches();
-	void SetListMode(const bool& isList);
+	void SetListMode(const bool& is_list);
 	void SetSearchText(const QString& text);
 	void SetShowCompatibilityInGrid(bool show);
 
@@ -123,27 +123,27 @@ private:
 	game_info GetGameInfoFromItem(const QTableWidgetItem* item);
 
 	// Which widget we are displaying depends on if we are in grid or list mode.
-	QMainWindow* m_Game_Dock;
-	QStackedWidget* m_Central_Widget;
+	QMainWindow* m_game_dock;
+	QStackedWidget* m_central_widget;
 
 	// Game Grid
-	game_list_grid* m_xgrid;
+	game_list_grid* m_game_grid;
 
 	// Game List
-	game_list* m_gameList;
+	game_list* m_game_list;
 	std::unique_ptr<game_compatibility> m_game_compat;
 	QList<QAction*> m_columnActs;
-	Qt::SortOrder m_colSortOrder;
-	int m_sortColumn;
+	Qt::SortOrder m_col_sort_order;
+	int m_sort_column;
 	QMap<QString, QString> m_notes;
 	QMap<QString, QString> m_titles;
 
 	// Categories
-	QStringList m_categoryFilters;
+	QStringList m_category_filters;
 
 	// List Mode
-	bool m_isListLayout = true;
-	bool m_oldLayoutIsList = true;
+	bool m_is_list_layout = true;
+	bool m_old_layout_is_list = true;
 
 	// Data
 	std::shared_ptr<gui_settings> m_gui_settings;
@@ -160,9 +160,9 @@ private:
 	int m_icon_size_index = 0;
 
 	// Icons
-	QColor m_Icon_Color;
-	QSize m_Icon_Size;
-	qreal m_Margin_Factor;
-	qreal m_Text_Factor;
-	bool m_drawCompatStatusToGrid = false;
+	QColor m_icon_color;
+	QSize m_icon_size;
+	qreal m_margin_factor;
+	qreal m_text_factor;
+	bool m_draw_compat_status_to_grid = false;
 };

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -41,24 +41,24 @@ QString gui_settings::GetCurrentUser()
 	return QString();
 }
 
-bool gui_settings::ChangeToConfig(const QString& friendly_name)
+bool gui_settings::ChangeToConfig(const QString& config_name)
 {
-	if (m_current_name == friendly_name)
+	if (m_current_name == config_name)
 	{
 		return false;
 	}
 
-	if (friendly_name != gui::Settings)
+	if (config_name != gui::Settings)
 	{
 		if (m_current_name == gui::Settings)
 		{
-			SetValue(gui::m_currentConfig, friendly_name);
+			SetValue(gui::m_currentConfig, config_name);
 		}
 		else
 		{
 			QSettings tmp(m_settings_dir.absoluteFilePath(gui::Settings + ".ini"), QSettings::Format::IniFormat, parent());
 			tmp.beginGroup(gui::m_currentConfig.key);
-			tmp.setValue(gui::m_currentConfig.name, friendly_name);
+			tmp.setValue(gui::m_currentConfig.name, config_name);
 			tmp.endGroup();
 		}
 	}
@@ -67,25 +67,25 @@ bool gui_settings::ChangeToConfig(const QString& friendly_name)
 
 	Reset(true);
 
-	QSettings other(m_settings_dir.absoluteFilePath(friendly_name + ".ini"), QSettings::IniFormat);
+	const QSettings other(m_settings_dir.absoluteFilePath(config_name + ".ini"), QSettings::IniFormat);
 
 	for (const QString& key : other.allKeys())
 	{
 		m_settings->setValue(key, other.value(key));
 	}
 
-	SetValue(gui::m_currentConfig, friendly_name);
+	SetValue(gui::m_currentConfig, config_name);
 
 	m_settings->sync();
 
-	m_current_name = friendly_name;
+	m_current_name = config_name;
 
 	return true;
 }
 
-void gui_settings::Reset(bool removeMeta)
+void gui_settings::Reset(bool remove_meta)
 {
-	if (removeMeta)
+	if (remove_meta)
 	{
 		m_settings->clear();
 	}
@@ -277,10 +277,11 @@ QColor gui_settings::GetCustomColor(int col)
 
 QStringList gui_settings::GetConfigEntries()
 {
-	QStringList nameFilter;
-	nameFilter << "*.ini";
-	QFileInfoList entries = m_settings_dir.entryInfoList(nameFilter, QDir::Files);
+	const QStringList name_filter = QStringList("*.ini");
+	const QFileInfoList entries = m_settings_dir.entryInfoList(name_filter, QDir::Files);
+
 	QStringList res;
+
 	for (const QFileInfo &entry : entries)
 	{
 		res.append(entry.baseName());
@@ -306,8 +307,8 @@ void gui_settings::BackupSettingsToTarget(const QString& friendly_name)
 
 QStringList gui_settings::GetStylesheetEntries()
 {
-	QStringList nameFilter = QStringList("*.qss");
-	QStringList res = gui::utils::get_dir_entries(m_settings_dir, nameFilter);
+	const QStringList name_filter = QStringList("*.qss");
+	QStringList res = gui::utils::get_dir_entries(m_settings_dir, name_filter);
 #if !defined(_WIN32)
 	// Makes stylesheets load if using AppImage (App Bundle) or installed to /usr/bin
 #ifdef __APPLE__
@@ -326,7 +327,7 @@ QString gui_settings::GetCurrentStylesheetPath()
 {
 	const Localized localized;
 
-	QString stylesheet = GetValue(gui::m_currentStylesheet).toString();
+	const QString stylesheet = GetValue(gui::m_currentStylesheet).toString();
 
 	if (stylesheet == gui::Default)
 	{
@@ -348,6 +349,6 @@ QSize gui_settings::SizeFromSlider(int pos)
 gui_save gui_settings::GetGuiSaveForColumn(int col)
 {
 	// hide sound format, parental level, firmware version and path by default
-	bool show = col != gui::column_sound && col != gui::column_parental && col != gui::column_firmware && col != gui::column_path;
+	const bool show = col != gui::column_sound && col != gui::column_parental && col != gui::column_firmware && col != gui::column_path;
 	return gui_save{ gui::game_list, "visibility_" + gui::get_game_list_column_name(static_cast<gui::game_list_columns>(col)), show };
 }

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -304,7 +304,7 @@ QStringList gui_settings::GetStylesheetEntries()
 #else
 	QDir platformStylesheetDir = QCoreApplication::applicationDirPath() + "/../share/rpcs3/GuiConfigs/";
 #endif
-	res.append(gui::utils::get_dir_entries(platformStylesheetDir, nameFilter));
+	res.append(gui::utils::get_dir_entries(platformStylesheetDir, name_filter));
 	res.removeDuplicates();
 #endif
 	res.sort(Qt::CaseInsensitive);

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -233,7 +233,7 @@ public:
 	QString GetCurrentUser();
 
 	/** Changes the settings file to the destination preset*/
-	bool ChangeToConfig(const QString& friendly_name);
+	bool ChangeToConfig(const QString& config_name);
 
 	bool GetCategoryVisibility(int cat);
 
@@ -249,7 +249,7 @@ public:
 	QStringList GetGameListCategoryFilters();
 
 public Q_SLOTS:
-	void Reset(bool removeMeta = false);
+	void Reset(bool remove_meta = false);
 
 	/** Sets the visibility of the chosen category. */
 	void SetCategoryVisibility(int cat, const bool& val);

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -258,13 +258,14 @@ public Q_SLOTS:
 
 	void SetCustomColor(int col, const QColor& val);
 
-	void SaveCurrentConfig(const QString& friendly_name);
+	void SaveCurrentConfig(const QString& config_name);
 
 	static QSize SizeFromSlider(int pos);
 	static gui_save GetGuiSaveForColumn(int col);
 
 private:
-	void BackupSettingsToTarget(const QString& friendly_name);
+	void SaveConfigNameToDefault(const QString& config_name);
+	void BackupSettingsToTarget(const QString& config_name);
 	void ShowBox(bool confirm, const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent, bool always_on_top);
 
 	QString m_current_name;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -346,8 +346,8 @@ void main_window::BootElf()
 		stopped = true;
 	}
 
-	QString path_last_ELF = m_gui_settings->GetValue(gui::fd_boot_elf).toString();
-	QString filePath = QFileDialog::getOpenFileName(this, tr("Select (S)ELF To Boot"), path_last_ELF, tr(
+	const QString path_last_elf = m_gui_settings->GetValue(gui::fd_boot_elf).toString();
+	const QString file_path = QFileDialog::getOpenFileName(this, tr("Select (S)ELF To Boot"), path_last_elf, tr(
 		"(S)ELF files (*BOOT.BIN *.elf *.self);;"
 		"ELF files (BOOT.BIN *.elf);;"
 		"SELF files (EBOOT.BIN *.self);;"
@@ -356,17 +356,20 @@ void main_window::BootElf()
 		"All files (*.*)"),
 		Q_NULLPTR, QFileDialog::DontResolveSymlinks);
 
-	if (filePath == NULL)
+	if (file_path.isEmpty())
 	{
-		if (stopped) Emu.Resume();
+		if (stopped)
+		{
+			Emu.Resume();
+		}
 		return;
 	}
 
 	// If we resolved the filepath earlier we would end up setting the last opened dir to the unwanted
 	// game folder in case of having e.g. a Game Folder with collected links to elf files.
 	// Don't set last path earlier in case of cancelled dialog
-	m_gui_settings->SetValue(gui::fd_boot_elf, filePath);
-	const std::string path = sstr(QFileInfo(filePath).absoluteFilePath());
+	m_gui_settings->SetValue(gui::fd_boot_elf, file_path);
+	const std::string path = sstr(QFileInfo(file_path).absoluteFilePath());
 
 	gui_log.notice("Booting from BootElf...");
 	Boot(path, "", true);
@@ -382,12 +385,15 @@ void main_window::BootGame()
 		stopped = true;
 	}
 
-	const QString path_last_Game = m_gui_settings->GetValue(gui::fd_boot_game).toString();
-	const QString dir_path = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"), path_last_Game, QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+	const QString path_last_game = m_gui_settings->GetValue(gui::fd_boot_game).toString();
+	const QString dir_path = QFileDialog::getExistingDirectory(this, tr("Select Game Folder"), path_last_game, QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
 
 	if (dir_path.isEmpty())
 	{
-		if (stopped) Emu.Resume();
+		if (stopped)
+		{
+			Emu.Resume();
+		}
 		return;
 	}
 
@@ -409,9 +415,9 @@ void main_window::BootRsxCapture(std::string path)
 			is_stopped = true;
 		}
 
-		QString filePath = QFileDialog::getOpenFileName(this, tr("Select RSX Capture"), qstr(fs::get_config_dir() + "captures/"), tr("RRC files (*.rrc);;All files (*.*)"));
+		const QString file_path = QFileDialog::getOpenFileName(this, tr("Select RSX Capture"), qstr(fs::get_config_dir() + "captures/"), tr("RRC files (*.rrc);;All files (*.*)"));
 
-		if (filePath.isEmpty())
+		if (file_path.isEmpty())
 		{
 			if (is_stopped)
 			{
@@ -419,7 +425,7 @@ void main_window::BootRsxCapture(std::string path)
 			}
 			return;
 		}
-		path = sstr(filePath);
+		path = sstr(file_path);
 	}
 
 	Emu.SetForceBoot(true);
@@ -814,11 +820,11 @@ void main_window::SaveWindowState()
 
 void main_window::RepaintThumbnailIcons()
 {
-	QColor newColor = gui::utils::get_label_color("thumbnail_icon_color");
+	const QColor new_color = gui::utils::get_label_color("thumbnail_icon_color");
 
-	auto icon = [&newColor](const QString& path)
+	auto icon = [&new_color](const QString& path)
 	{
-		return gui::utils::get_colorized_icon(QPixmap::fromImage(gui::utils::get_opaque_image_area(path)), Qt::black, newColor);
+		return gui::utils::get_colorized_icon(QPixmap::fromImage(gui::utils::get_opaque_image_area(path)), Qt::black, new_color);
 	};
 
 #ifdef _WIN32
@@ -837,11 +843,11 @@ void main_window::RepaintThumbnailIcons()
 
 void main_window::RepaintToolBarIcons()
 {
-	QColor newColor = gui::utils::get_label_color("toolbar_icon_color");
+	const QColor new_color = gui::utils::get_label_color("toolbar_icon_color");
 
-	auto icon = [&newColor](const QString& path)
+	auto icon = [&new_color](const QString& path)
 	{
-		return gui::utils::get_colorized_icon(QIcon(path), Qt::black, newColor);
+		return gui::utils::get_colorized_icon(QIcon(path), Qt::black, new_color);
 	};
 
 	m_icon_play           = icon(":/Icons/play.png");
@@ -882,7 +888,7 @@ void main_window::RepaintToolBarIcons()
 	}
 
 	ui->sizeSlider->setStyleSheet(ui->sizeSlider->styleSheet().append("QSlider::handle:horizontal{ background: rgba(%1, %2, %3, %4); }")
-		.arg(newColor.red()).arg(newColor.green()).arg(newColor.blue()).arg(newColor.alpha()));
+		.arg(new_color.red()).arg(new_color.green()).arg(new_color.blue()).arg(new_color.alpha()));
 
 	// resize toolbar elements
 
@@ -890,11 +896,11 @@ void main_window::RepaintToolBarIcons()
 	// choose factors to mimic Gui-Design in main_window.ui
 	// TODO: delete this in case Qt::AA_EnableHighDpiScaling is enabled in main.cpp
 #ifdef _WIN32
-	const int toolIconHeight = menuBar()->sizeHint().height() * 1.5;
-	ui->toolBar->setIconSize(QSize(toolIconHeight, toolIconHeight));
+	const int tool_icon_height = menuBar()->sizeHint().height() * 1.5;
+	ui->toolBar->setIconSize(QSize(tool_icon_height, tool_icon_height));
 #endif
 
-	const int toolBarHeight = ui->toolBar->sizeHint().height();
+	const int tool_bar_height = ui->toolBar->sizeHint().height();
 
 	for (const auto& act : ui->toolBar->actions())
 	{
@@ -903,11 +909,11 @@ void main_window::RepaintToolBarIcons()
 			continue;
 		}
 
-		ui->toolBar->widgetForAction(act)->setMinimumWidth(toolBarHeight);
+		ui->toolBar->widgetForAction(act)->setMinimumWidth(tool_bar_height);
 	}
 
-	ui->sizeSliderContainer->setFixedWidth(toolBarHeight * 4);
-	ui->mw_searchbar->setFixedWidth(toolBarHeight * 5);
+	ui->sizeSliderContainer->setFixedWidth(tool_bar_height * 4);
+	ui->mw_searchbar->setFixedWidth(tool_bar_height * 5);
 }
 
 void main_window::OnEmuRun(bool /*start_playtime*/)
@@ -1083,7 +1089,7 @@ void main_window::BootRecentAction(const QAction* act)
 	const QString pth = act->data().toString();
 	const std::string path = sstr(pth);
 	QString name;
-	bool containsPath = false;
+	bool contains_path = false;
 
 	int idx = -1;
 	for (int i = 0; i < m_rg_entries.count(); i++)
@@ -1091,16 +1097,16 @@ void main_window::BootRecentAction(const QAction* act)
 		if (m_rg_entries.at(i).first == pth)
 		{
 			idx = i;
-			containsPath = true;
+			contains_path = true;
 			name = m_rg_entries.at(idx).second;
 			break;
 		}
 	}
 
 	// path is invalid: remove action from list return
-	if ((containsPath && name.isEmpty()) || (!QFileInfo(pth).isDir() && !QFileInfo(pth).isFile()))
+	if ((contains_path && name.isEmpty()) || (!QFileInfo(pth).isDir() && !QFileInfo(pth).isFile()))
 	{
-		if (containsPath)
+		if (contains_path)
 		{
 			// clear menu of actions
 			for (auto act : m_recent_game_acts)
@@ -1145,7 +1151,7 @@ QAction* main_window::CreateRecentAction(const q_string_pair& entry, const uint&
 		{
 			gui_log.warning("Recent Game not valid, removing from Boot Recent list: %s", sstr(entry.first));
 
-			int idx = m_rg_entries.indexOf(entry);
+			const int idx = m_rg_entries.indexOf(entry);
 			m_rg_entries.removeAt(idx);
 
 			m_gui_settings->SetValue(gui::rg_entries, m_gui_settings->List2Var(m_rg_entries));
@@ -1343,7 +1349,8 @@ void main_window::CreateConnects()
 	connect(ui->bootGameAct, &QAction::triggered, this, &main_window::BootGame);
 	connect(ui->actionopen_rsx_capture, &QAction::triggered, [this](){ BootRsxCapture(); });
 
-	connect(ui->addGamesAct, &QAction::triggered, [this]() {
+	connect(ui->addGamesAct, &QAction::triggered, [this]()
+	{
 		QStringList paths;
 
 		// Only select one folder for now
@@ -1374,7 +1381,10 @@ void main_window::CreateConnects()
 
 	connect(ui->clearRecentAct, &QAction::triggered, [this]()
 	{
-		if (ui->freezeRecentAct->isChecked()) { return; }
+		if (ui->freezeRecentAct->isChecked())
+		{
+			return;
+		}
 		m_rg_entries.clear();
 		for (auto act : m_recent_game_acts)
 		{
@@ -1418,7 +1428,7 @@ void main_window::CreateConnects()
 		sysutil_send_system_cmd(0x0101 /* CELL_SYSUTIL_REQUEST_EXITGAME */, 0);
 	});
 
-	auto openSettings = [this](int tabIndex)
+	auto open_settings = [this](int tabIndex)
 	{
 		settings_dialog dlg(m_gui_settings, m_emu_settings, tabIndex, this);
 		connect(&dlg, &settings_dialog::GuiSettingsSaveRequest, this, &main_window::SaveWindowState);
@@ -1430,13 +1440,13 @@ void main_window::CreateConnects()
 		dlg.exec();
 	};
 
-	connect(ui->confCPUAct,    &QAction::triggered, [=, this]() { openSettings(0); });
-	connect(ui->confGPUAct,    &QAction::triggered, [=, this]() { openSettings(1); });
-	connect(ui->confAudioAct,  &QAction::triggered, [=, this]() { openSettings(2); });
-	connect(ui->confIOAct,     &QAction::triggered, [=, this]() { openSettings(3); });
-	connect(ui->confSystemAct, &QAction::triggered, [=, this]() { openSettings(4); });
+	connect(ui->confCPUAct,    &QAction::triggered, [=, this]() { open_settings(0); });
+	connect(ui->confGPUAct,    &QAction::triggered, [=, this]() { open_settings(1); });
+	connect(ui->confAudioAct,  &QAction::triggered, [=, this]() { open_settings(2); });
+	connect(ui->confIOAct,     &QAction::triggered, [=, this]() { open_settings(3); });
+	connect(ui->confSystemAct, &QAction::triggered, [=, this]() { open_settings(4); });
 
-	auto openPadSettings = [this]
+	auto open_pad_settings = [this]
 	{
 		if (!Emu.IsStopped())
 		{
@@ -1458,7 +1468,7 @@ void main_window::CreateConnects()
 		}
 	};
 
-	connect(ui->confPadsAct, &QAction::triggered, openPadSettings);
+	connect(ui->confPadsAct, &QAction::triggered, open_pad_settings);
 
 	connect(ui->confAutopauseManagerAct, &QAction::triggered, [this]()
 	{
@@ -1586,7 +1596,7 @@ void main_window::CreateConnects()
 	{
 		QStringList categories;
 		int id = 0;
-		const bool& checked = act->isChecked();
+		const bool checked = act->isChecked();
 
 		if      (act == ui->showCatHDDGameAct)    categories += category::cat_hdd_game, id = Category::HDD_Game;
 		else if (act == ui->showCatDiscGameAct)   categories += category::cat_disc_game, id = Category::Disc_Game;
@@ -1658,11 +1668,11 @@ void main_window::CreateConnects()
 
 	connect(m_list_mode_act_group, &QActionGroup::triggered, [this](QAction* act)
 	{
-		bool is_list_act = act == ui->setlistModeListAct;
+		const bool is_list_act = act == ui->setlistModeListAct;
 		if (is_list_act == m_is_list_mode)
 			return;
 
-		int slider_pos = ui->sizeSlider->sliderPosition();
+		const int slider_pos = ui->sizeSlider->sliderPosition();
 		ui->sizeSlider->setSliderPosition(m_other_slider_pos);
 		SetIconSizeActions(m_other_slider_pos);
 		m_other_slider_pos = slider_pos;
@@ -1691,8 +1701,8 @@ void main_window::CreateConnects()
 		}
 	});
 
-	connect(ui->toolbar_controls, &QAction::triggered, openPadSettings);
-	connect(ui->toolbar_config, &QAction::triggered, [=, this]() { openSettings(0); });
+	connect(ui->toolbar_controls, &QAction::triggered, open_pad_settings);
+	connect(ui->toolbar_config, &QAction::triggered, [=, this]() { open_settings(0); });
 	connect(ui->toolbar_list, &QAction::triggered, [this]() { ui->setlistModeListAct->trigger(); });
 	connect(ui->toolbar_grid, &QAction::triggered, [this]() { ui->setlistModeGridAct->trigger(); });
 
@@ -1928,7 +1938,7 @@ void main_window::ConfigureGuiFromSettings(bool configure_all)
 		ui->setlistModeGridAct->setChecked(true);
 	m_category_visible_act_group->setEnabled(m_is_list_mode);
 
-	int icon_size_index = m_gui_settings->GetValue(m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid).toInt();
+	const int icon_size_index = m_gui_settings->GetValue(m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid).toInt();
 	m_other_slider_pos = m_gui_settings->GetValue(!m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid).toInt();
 	ui->sizeSlider->setSliderPosition(icon_size_index);
 	SetIconSizeActions(icon_size_index);
@@ -1961,9 +1971,9 @@ void main_window::SetIconSizeActions(int idx)
 
 void main_window::RemoveDiskCache()
 {
-	std::string cacheDir = Emulator::GetHdd1Dir() + "/caches";
+	const std::string cache_dir = Emulator::GetHdd1Dir() + "/caches";
 
-	if (fs::is_dir(cacheDir) && fs::remove_all(cacheDir, false))
+	if (fs::is_dir(cache_dir) && fs::remove_all(cache_dir, false))
 	{
 		QMessageBox::information(this, tr("Cache Cleared"), tr("Disk cache was cleared successfully"));
 	}
@@ -2057,11 +2067,11 @@ void main_window::AddGamesFromDir(const QString& path)
 	QDirIterator dir_iter(path, QDir::Dirs | QDir::NoDotAndDotDot);
 	while (dir_iter.hasNext())
 	{
-		std::string pth = sstr(dir_iter.next());
+		const std::string path = sstr(dir_iter.next());
 
-		if (const auto error = Emu.BootGame(pth, "", false, true); error == game_boot_result::no_errors)
+		if (const auto error = Emu.BootGame(path, "", false, true); error == game_boot_result::no_errors)
 		{
-			gui_log.notice("Returned from game addition by drag and drop: %s", pth);
+			gui_log.notice("Returned from game addition by drag and drop: %s", path);
 		}
 	}
 }
@@ -2072,9 +2082,9 @@ Check data for valid file types and cache their paths if necessary
 @param savePaths = flag for path caching
 @returns validity of file type
 */
-int main_window::IsValidFile(const QMimeData& md, QStringList* dropPaths)
+int main_window::IsValidFile(const QMimeData& md, QStringList* drop_paths)
 {
-	int dropType = drop_type::drop_error;
+	int drop_type = drop_type::drop_error;
 
 	const QList<QUrl> list = md.urls(); // get list of all the dropped file urls
 
@@ -2087,12 +2097,12 @@ int main_window::IsValidFile(const QMimeData& md, QStringList* dropPaths)
 		// check for directories first, only valid if all other paths led to directories until now.
 		if (info.isDir())
 		{
-			if (dropType != drop_type::drop_dir && dropType != drop_type::drop_error)
+			if (drop_type != drop_type::drop_dir && drop_type != drop_type::drop_error)
 			{
 				return drop_type::drop_error;
 			}
 
-			dropType = drop_type::drop_dir;
+			drop_type = drop_type::drop_dir;
 		}
 		else if (info.fileName() == "PS3UPDAT.PUP")
 		{
@@ -2101,35 +2111,35 @@ int main_window::IsValidFile(const QMimeData& md, QStringList* dropPaths)
 				return drop_type::drop_error;
 			}
 
-			dropType = drop_type::drop_pup;
+			drop_type = drop_type::drop_pup;
 		}
 		else if (info.suffix().toLower() == "pkg")
 		{
-			if (dropType != drop_type::drop_pkg && dropType != drop_type::drop_error)
+			if (drop_type != drop_type::drop_pkg && drop_type != drop_type::drop_error)
 			{
 				return drop_type::drop_error;
 			}
 
-			dropType = drop_type::drop_pkg;
+			drop_type = drop_type::drop_pkg;
 		}
 		else if (info.suffix() == "rap")
 		{
-			if (dropType != drop_type::drop_rap && dropType != drop_type::drop_error)
+			if (drop_type != drop_type::drop_rap && drop_type != drop_type::drop_error)
 			{
 				return drop_type::drop_error;
 			}
 
-			dropType = drop_type::drop_rap;
+			drop_type = drop_type::drop_rap;
 		}
 		else if (list.size() == 1)
 		{
 			if (info.suffix() == "rrc")
 			{
-				dropType = drop_type::drop_rrc;
+				drop_type = drop_type::drop_rrc;
 			}
 			else
 			{
-				dropType = drop_type::drop_game;
+				drop_type = drop_type::drop_game;
 			}
 		}
 		else
@@ -2137,27 +2147,27 @@ int main_window::IsValidFile(const QMimeData& md, QStringList* dropPaths)
 			return drop_type::drop_error;
 		}
 
-		if (dropPaths) // we only need to know the paths on drop
+		if (drop_paths) // we only need to know the paths on drop
 		{
-			dropPaths->append(path);
+			drop_paths->append(path);
 		}
 	}
 
-	return dropType;
+	return drop_type;
 }
 
 void main_window::dropEvent(QDropEvent* event)
 {
-	QStringList dropPaths;
+	QStringList drop_paths;
 
-	switch (IsValidFile(*event->mimeData(), &dropPaths)) // get valid file paths and drop type
+	switch (IsValidFile(*event->mimeData(), &drop_paths)) // get valid file paths and drop type
 	{
 	case drop_type::drop_error:
 		break;
 	case drop_type::drop_pkg: // install the packages
-		if (dropPaths.count() > 1)
+		if (drop_paths.count() > 1)
 		{
-			pkg_install_dialog dlg(dropPaths, this);
+			pkg_install_dialog dlg(drop_paths, this);
 			connect(&dlg, &QDialog::accepted, [this, &dlg]()
 			{
 				const QStringList paths = dlg.GetPathsToInstall();
@@ -2170,14 +2180,14 @@ void main_window::dropEvent(QDropEvent* event)
 		}
 		else
 		{
-			InstallPackages(dropPaths, true);
+			InstallPackages(drop_paths, true);
 		}
 		break;
 	case drop_type::drop_pup: // install the firmware
-		InstallPup(dropPaths.first());
+		InstallPup(drop_paths.first());
 		break;
 	case drop_type::drop_rap: // import rap files to exdata dir
-		for (const auto& rap : dropPaths)
+		for (const auto& rap : drop_paths)
 		{
 			const std::string rapname = sstr(QFileInfo(rap).fileName());
 
@@ -2195,26 +2205,26 @@ void main_window::dropEvent(QDropEvent* event)
 		m_game_list_frame->Refresh(true);
 		break;
 	case drop_type::drop_dir: // import valid games to gamelist (games.yaml)
-		for (const auto& path : dropPaths)
+		for (const auto& path : drop_paths)
 		{
 			AddGamesFromDir(path);
 		}
 		m_game_list_frame->Refresh(true);
 		break;
 	case drop_type::drop_game: // import valid games to gamelist (games.yaml)
-		if (const auto error = Emu.BootGame(sstr(dropPaths.first()), "", true); error != game_boot_result::no_errors)
+		if (const auto error = Emu.BootGame(sstr(drop_paths.first()), "", true); error != game_boot_result::no_errors)
 		{
-			gui_log.error("Boot failed: reason: %s, path: %s", error, sstr(dropPaths.first()));
+			gui_log.error("Boot failed: reason: %s, path: %s", error, sstr(drop_paths.first()));
 			show_boot_error(error);
 		}
 		else
 		{
-			gui_log.success("Elf Boot from drag and drop done: %s", sstr(dropPaths.first()));
+			gui_log.success("Elf Boot from drag and drop done: %s", sstr(drop_paths.first()));
 			m_game_list_frame->Refresh(true);
 		}
 		break;
 	case drop_type::drop_rrc: // replay a rsx capture file
-		BootRsxCapture(sstr(dropPaths.first()));
+		BootRsxCapture(sstr(drop_paths.first()));
 		break;
 	default:
 		gui_log.warning("Invalid dropType in gamelist dropEvent");

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -219,9 +219,13 @@ void main_window::OnPlayOrPause()
 	{
 		Emu.Pause();
 	}
-	else if (!Emu.GetBoot().empty())
+	else if (const auto path = Emu.GetBoot(); !path.empty())
 	{
-		Emu.Load();
+		if (const auto error = Emu.Load(); error != game_boot_result::no_errors)
+		{
+			gui_log.error("Boot failed: reason: %s, path: %s", error, path);
+			show_boot_error(error);
+		}
 	}
 	else if (Emu.IsStopped() && !m_recentGameActs.isEmpty())
 	{
@@ -297,7 +301,7 @@ void main_window::Boot(const std::string& path, const std::string& title_id, boo
 
 	if (const auto error = Emu.BootGame(path, title_id, direct, add_only, force_global_config); error != game_boot_result::no_errors)
 	{
-		gui_log.error("Boot failed: %s", path);
+		gui_log.error("Boot failed: reason: %s, path: %s", error, path);
 		show_boot_error(error);
 	}
 	else

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -132,12 +132,13 @@ void main_window::Init()
 
 	if (enable_play_last)
 	{
-		ui->sysPauseAct->setEnabled(true);
 		ui->sysPauseAct->setText(tr("&Play last played game\tCtrl+E"));
 		ui->sysPauseAct->setIcon(m_icon_play);
 		ui->toolbar_start->setToolTip(start_toolip);
-		ui->toolbar_start->setEnabled(true);
 	}
+
+	ui->sysPauseAct->setEnabled(enable_play_last);
+	ui->toolbar_start->setEnabled(enable_play_last);
 
 	// create tool buttons for the taskbar thumbnail
 #ifdef _WIN32
@@ -1767,6 +1768,8 @@ void main_window::CreateDockWindows()
 		{
 			QString tooltip;
 
+			bool enable_play_buttons = true;
+
 			if (game) // A game was selected
 			{
 				const std::string title_and_title_id = game->info.name + " [" + game->info.serial + "]";
@@ -1807,9 +1810,19 @@ void main_window::CreateDockWindows()
 				}
 				else
 				{
-					ui->toolbar_start->setEnabled(false);
+					enable_play_buttons = false;
 				}
 			}
+			else
+			{
+				enable_play_buttons = false;
+			}
+
+			ui->toolbar_start->setEnabled(enable_play_buttons);
+			ui->sysPauseAct->setEnabled(enable_play_buttons);
+#ifdef _WIN32
+			m_thumb_playPause->setEnabled(enable_play_buttons);
+#endif
 
 			if (!tooltip.isEmpty())
 			{

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -41,7 +41,7 @@ class main_window : public QMainWindow
 	bool m_save_slider_pos = false;
 	int m_other_slider_pos = 0;
 
-	QIcon m_appIcon;
+	QIcon m_app_icon;
 	QIcon m_icon_play;
 	QIcon m_icon_pause;
 	QIcon m_icon_stop;
@@ -73,14 +73,14 @@ class main_window : public QMainWindow
 	};
 
 public:
-	explicit main_window(std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, std::shared_ptr<persistent_settings> persistent_settings, QWidget *parent = 0);
+	explicit main_window(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget *parent = 0);
 	void Init();
 	~main_window();
 	QIcon GetAppIcon();
 
 Q_SIGNALS:
 	void RequestLanguageChange(const QString& language);
-	void RequestGlobalStylesheetChange(const QString& sheetFilePath);
+	void RequestGlobalStylesheetChange(const QString& stylesheet_path);
 	void RequestTrophyManagerRepaint();
 	void NotifyEmuSettingsChange();
 
@@ -146,21 +146,21 @@ private:
 	QString GetCurrentTitle();
 
 	q_pair_list m_rg_entries;
-	QList<QAction*> m_recentGameActs;
+	QList<QAction*> m_recent_game_acts;
 
 	std::shared_ptr<gui_game_info> m_selected_game;
 
-	QActionGroup* m_iconSizeActGroup = nullptr;
-	QActionGroup* m_listModeActGroup = nullptr;
-	QActionGroup* m_categoryVisibleActGroup = nullptr;
+	QActionGroup* m_icon_size_act_group = nullptr;
+	QActionGroup* m_list_mode_act_group = nullptr;
+	QActionGroup* m_category_visible_act_group = nullptr;
 
 	// Dockable widget frames
 	QMainWindow *m_mw = nullptr;
-	log_frame* m_logFrame = nullptr;
-	debugger_frame* m_debuggerFrame = nullptr;
-	game_list_frame* m_gameListFrame = nullptr;
-	std::shared_ptr<gui_settings> guiSettings;
-	std::shared_ptr<emu_settings> emuSettings;
+	log_frame* m_log_frame = nullptr;
+	debugger_frame* m_debugger_frame = nullptr;
+	game_list_frame* m_game_list_frame = nullptr;
+	std::shared_ptr<gui_settings> m_gui_settings;
+	std::shared_ptr<emu_settings> m_emu_settings;
 	std::shared_ptr<persistent_settings> m_persistent_settings;
 
 	update_manager m_updater;

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -141,6 +141,8 @@ private:
 
 	void RemoveDiskCache();
 
+	QString GetCurrentTitle();
+
 	q_pair_list m_rg_entries;
 	QList<QAction*> m_recentGameActs;
 

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -132,7 +132,7 @@ private:
 	void InstallPup(QString filePath = "");
 	void HandlePupInstallation(QString file_path = "");
 
-	int IsValidFile(const QMimeData& md, QStringList* dropPaths = nullptr);
+	int IsValidFile(const QMimeData& md, QStringList* drop_paths = nullptr);
 	void AddGamesFromDir(const QString& path);
 
 	QAction* CreateRecentAction(const q_string_pair& entry, const uint& sc_idx);

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -21,6 +21,8 @@ class gui_settings;
 class emu_settings;
 class persistent_settings;
 
+struct gui_game_info;
+
 enum class game_boot_result : u32;
 
 namespace Ui
@@ -145,6 +147,8 @@ private:
 
 	q_pair_list m_rg_entries;
 	QList<QAction*> m_recentGameActs;
+
+	std::shared_ptr<gui_game_info> m_selected_game;
 
 	QActionGroup* m_iconSizeActGroup = nullptr;
 	QActionGroup* m_listModeActGroup = nullptr;

--- a/rpcs3/rpcs3qt/persistent_settings.cpp
+++ b/rpcs3/rpcs3qt/persistent_settings.cpp
@@ -3,7 +3,7 @@
 persistent_settings::persistent_settings(QObject* parent) : settings(parent)
 {
 	// Don't use the .ini file ending for now, as it will be confused for a regular gui_settings file.
-	m_settings = new QSettings(ComputeSettingsDir() + gui::persistent::persistent_file_name + ".dat", QSettings::Format::IniFormat, parent);
+	m_settings.reset(new QSettings(ComputeSettingsDir() + gui::persistent::persistent_file_name + ".dat", QSettings::Format::IniFormat, parent));
 }
 
 void persistent_settings::SetPlaytime(const QString& serial, const qint64& elapsed)

--- a/rpcs3/rpcs3qt/settings.cpp
+++ b/rpcs3/rpcs3qt/settings.cpp
@@ -17,12 +17,12 @@ settings::~settings()
 	}
 }
 
-QString settings::GetSettingsDir()
+QString settings::GetSettingsDir() const
 {
 	return m_settings_dir.absolutePath();
 }
 
-QString settings::ComputeSettingsDir()
+QString settings::ComputeSettingsDir() const
 {
 	return QString::fromStdString(fs::get_config_dir()) + "/GuiConfigs/";
 }

--- a/rpcs3/rpcs3qt/settings.h
+++ b/rpcs3/rpcs3qt/settings.h
@@ -40,12 +40,12 @@ public:
 	explicit settings(QObject* parent = nullptr);
 	~settings();
 
-	QString GetSettingsDir();
+	QString GetSettingsDir() const;
 
 	QVariant GetValue(const gui_save& entry);
 	QVariant GetValue(const QString& key, const QString& name, const QString& def);
-	QVariant List2Var(const q_pair_list& list);
-	q_pair_list Var2List(const QVariant& var);
+	static QVariant List2Var(const q_pair_list& list);
+	static q_pair_list Var2List(const QVariant& var);
 
 public Q_SLOTS:
 	/** Remove entry */
@@ -56,9 +56,9 @@ public Q_SLOTS:
 	void SetValue(const QString& key, const QString& name, const QVariant& value);
 
 protected:
-	QString ComputeSettingsDir();
+	QString ComputeSettingsDir() const;
 
-	QSettings* m_settings = nullptr;
+	std::unique_ptr<QSettings> m_settings;
 	QDir m_settings_dir;
 	QString m_current_name;
 };

--- a/rpcs3/rpcs3qt/settings.h
+++ b/rpcs3/rpcs3qt/settings.h
@@ -5,6 +5,8 @@
 #include <QVariant>
 #include <QSize>
 
+#include <memory>
+
 struct gui_save
 {
 	QString key;

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1608,7 +1608,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			{
 				apply_gui_options(true);
 				m_gui_settings->Reset(true);
-				m_gui_settings->ChangeToConfig(gui::Default);
 				Q_EMIT GuiSettingsSyncRequest(true);
 				AddConfigs();
 				AddStylesheets();

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -905,18 +905,18 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	// Edits
 
 	m_emu_settings->EnhanceEdit(ui->edit_dns, emu_settings::DNSAddress);
-	SubscribeTooltip(ui->edit_dns, tooltips.settings.dns);
+	SubscribeTooltip(ui->gb_edit_dns, tooltips.settings.dns);
 
 	m_emu_settings->EnhanceEdit(ui->edit_npid, emu_settings::PSNNPID);
-	SubscribeTooltip(ui->edit_npid, tooltips.settings.psn_npid);
+	SubscribeTooltip(ui->gb_edit_npid, tooltips.settings.psn_npid);
 
 	m_emu_settings->EnhanceEdit(ui->edit_swaps, emu_settings::IpSwapList);
-	SubscribeTooltip(ui->edit_swaps, tooltips.settings.dns_swap);
+	SubscribeTooltip(ui->gb_edit_swaps, tooltips.settings.dns_swap);
 
 	// Comboboxes
 
 	m_emu_settings->EnhanceComboBox(ui->netStatusBox, emu_settings::InternetStatus);
-	SubscribeTooltip(ui->netStatusBox, tooltips.settings.net_status);
+	SubscribeTooltip(ui->gb_netStatusBox, tooltips.settings.net_status);
 
 	connect(ui->netStatusBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index)
 	{
@@ -947,7 +947,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	});
 
 	m_emu_settings->EnhanceComboBox(ui->psnStatusBox, emu_settings::PSNStatus);
-	SubscribeTooltip(ui->psnStatusBox, tooltips.settings.psn_status);
+	SubscribeTooltip(ui->gb_psnStatusBox, tooltips.settings.psn_status);
 
 	//                _                               _   _______    _
 	//       /\      | |                             | | |__   __|  | |

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -43,16 +43,16 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	: QDialog(parent)
 	, m_tab_index(tab_index)
 	, ui(new Ui::settings_dialog)
-	, xgui_settings(gui_settings)
-	, xemu_settings(emu_settings)
+	, m_gui_settings(gui_settings)
+	, m_emu_settings(emu_settings)
 {
 	ui->setupUi(this);
 	ui->buttonBox->button(QDialogButtonBox::StandardButton::Close)->setFocus();
 	ui->tab_widget_settings->setUsesScrollButtons(false);
 	ui->tab_widget_settings->tabBar()->setObjectName("tab_bar_settings");
 
-	bool showDebugTab = xgui_settings->GetValue(gui::m_showDebugTab).toBool();
-	xgui_settings->SetValue(gui::m_showDebugTab, showDebugTab);
+	bool showDebugTab = m_gui_settings->GetValue(gui::m_showDebugTab).toBool();
+	m_gui_settings->SetValue(gui::m_showDebugTab, showDebugTab);
 	if (!showDebugTab)
 	{
 		ui->tab_widget_settings->removeTab(9);
@@ -64,7 +64,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	}
 
 	// Localized tooltips
-	Tooltips tooltips;
+	const Tooltips tooltips;
 
 	// Add description labels
 	SubscribeDescription(ui->description_cpu);
@@ -83,18 +83,18 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	if (game)
 	{
-		xemu_settings->LoadSettings(game->serial);
+		m_emu_settings->LoadSettings(game->serial);
 		setWindowTitle(tr("Settings: [") + qstr(game->serial) + "] " + qstr(game->name));
 	}
 	else
 	{
-		xemu_settings->LoadSettings();
+		m_emu_settings->LoadSettings();
 		setWindowTitle(tr("Settings"));
 	}
 
 	// Discord variables
-	m_use_discord = xgui_settings->GetValue(gui::m_richPresence).toBool();
-	m_discord_state = xgui_settings->GetValue(gui::m_discordState).toString();
+	m_use_discord = m_gui_settings->GetValue(gui::m_richPresence).toBool();
+	m_discord_state = m_gui_settings->GetValue(gui::m_discordState).toString();
 
 	// Various connects
 
@@ -110,8 +110,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			}
 		}
 		std::vector<std::string> selected_ls = std::vector<std::string>(selectedlle.begin(), selectedlle.end());
-		xemu_settings->SaveSelectedLibraries(selected_ls);
-		xemu_settings->SaveSettings();
+		m_emu_settings->SaveSelectedLibraries(selected_ls);
+		m_emu_settings->SaveSettings();
 
 		if (do_exit)
 		{
@@ -121,8 +121,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		Q_EMIT EmuSettingsApplied();
 
 		// Discord Settings can be saved regardless of WITH_DISCORD_RPC
-		xgui_settings->SetValue(gui::m_richPresence, m_use_discord);
-		xgui_settings->SetValue(gui::m_discordState, m_discord_state);
+		m_gui_settings->SetValue(gui::m_richPresence, m_use_discord);
+		m_gui_settings->SetValue(gui::m_discordState, m_discord_state);
 
 #ifdef WITH_DISCORD_RPC
 		if (m_use_discord != use_discord_old)
@@ -172,37 +172,37 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	// Checkboxes
 
-	xemu_settings->EnhanceCheckBox(ui->spuCache, emu_settings::SPUCache);
+	m_emu_settings->EnhanceCheckBox(ui->spuCache, emu_settings::SPUCache);
 	SubscribeTooltip(ui->spuCache, tooltips.settings.spu_cache);
 
-	xemu_settings->EnhanceCheckBox(ui->enableScheduler, emu_settings::EnableThreadScheduler);
+	m_emu_settings->EnhanceCheckBox(ui->enableScheduler, emu_settings::EnableThreadScheduler);
 	SubscribeTooltip(ui->enableScheduler, tooltips.settings.enable_thread_scheduler);
 
-	xemu_settings->EnhanceCheckBox(ui->lowerSPUThrPrio, emu_settings::LowerSPUThreadPrio);
+	m_emu_settings->EnhanceCheckBox(ui->lowerSPUThrPrio, emu_settings::LowerSPUThreadPrio);
 	SubscribeTooltip(ui->lowerSPUThrPrio, tooltips.settings.lower_spu_thread_priority);
 
-	xemu_settings->EnhanceCheckBox(ui->spuLoopDetection, emu_settings::SPULoopDetection);
+	m_emu_settings->EnhanceCheckBox(ui->spuLoopDetection, emu_settings::SPULoopDetection);
 	SubscribeTooltip(ui->spuLoopDetection, tooltips.settings.spu_loop_detection);
 
-	xemu_settings->EnhanceCheckBox(ui->accurateXFloat, emu_settings::AccurateXFloat);
+	m_emu_settings->EnhanceCheckBox(ui->accurateXFloat, emu_settings::AccurateXFloat);
 	SubscribeTooltip(ui->accurateXFloat, tooltips.settings.accurate_xfloat);
 
 	// Comboboxes
 
-	xemu_settings->EnhanceComboBox(ui->spuBlockSize, emu_settings::SPUBlockSize);
+	m_emu_settings->EnhanceComboBox(ui->spuBlockSize, emu_settings::SPUBlockSize);
 	SubscribeTooltip(ui->gb_spuBlockSize, tooltips.settings.spu_block_size);
 
-	xemu_settings->EnhanceComboBox(ui->preferredSPUThreads, emu_settings::PreferredSPUThreads, true);
+	m_emu_settings->EnhanceComboBox(ui->preferredSPUThreads, emu_settings::PreferredSPUThreads, true);
 	SubscribeTooltip(ui->gb_spu_threads, tooltips.settings.preferred_spu_threads);
 	ui->preferredSPUThreads->setItemText(ui->preferredSPUThreads->findData("0"), tr("Auto"));
 
 	if (utils::has_rtm())
 	{
-		xemu_settings->EnhanceComboBox(ui->enableTSX, emu_settings::EnableTSX);
+		m_emu_settings->EnhanceComboBox(ui->enableTSX, emu_settings::EnableTSX);
 		SubscribeTooltip(ui->gb_tsx, tooltips.settings.enable_tsx);
 
 		static const QString tsx_forced = qstr(fmt::format("%s", tsx_usage::forced));
-		static const QString tsx_default = qstr(xemu_settings->GetSettingDefault(emu_settings::EnableTSX));
+		static const QString tsx_default = qstr(m_emu_settings->GetSettingDefault(emu_settings::EnableTSX));
 
 		// connect the toogled signal so that the stateChanged signal in EnhanceCheckBox can be prevented
 		connect(ui->enableTSX, &QComboBox::currentTextChanged, [this](const QString& text)
@@ -236,25 +236,25 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	SubscribeTooltip(ui->ppu_fast,    tooltips.settings.ppu_fast);
 	SubscribeTooltip(ui->ppu_llvm,    tooltips.settings.ppu_llvm);
 
-	QButtonGroup *ppuBG = new QButtonGroup(this);
-	ppuBG->addButton(ui->ppu_precise, static_cast<int>(ppu_decoder_type::precise));
-	ppuBG->addButton(ui->ppu_fast,    static_cast<int>(ppu_decoder_type::fast));
-	ppuBG->addButton(ui->ppu_llvm,    static_cast<int>(ppu_decoder_type::llvm));
+	QButtonGroup *ppu_bg = new QButtonGroup(this);
+	ppu_bg->addButton(ui->ppu_precise, static_cast<int>(ppu_decoder_type::precise));
+	ppu_bg->addButton(ui->ppu_fast,    static_cast<int>(ppu_decoder_type::fast));
+	ppu_bg->addButton(ui->ppu_llvm,    static_cast<int>(ppu_decoder_type::llvm));
 
 	{ // PPU Stuff
-		QString selectedPPU = qstr(xemu_settings->GetSetting(emu_settings::PPUDecoder));
-		QStringList ppu_list = xemu_settings->GetSettingOptions(emu_settings::PPUDecoder);
+		const QString selected_ppu = qstr(m_emu_settings->GetSetting(emu_settings::PPUDecoder));
+		QStringList ppu_list = m_emu_settings->GetSettingOptions(emu_settings::PPUDecoder);
 
 		for (int i = 0; i < ppu_list.count(); i++)
 		{
-			if (ppu_list[i] == selectedPPU)
+			if (ppu_list[i] == selected_ppu)
 			{
-				ppuBG->button(i)->setChecked(true);
+				ppu_bg->button(i)->setChecked(true);
 			}
 
-			connect(ppuBG->button(i), &QAbstractButton::clicked, [=, this]()
+			connect(ppu_bg->button(i), &QAbstractButton::clicked, [=, this]()
 			{
-				xemu_settings->SetSetting(emu_settings::PPUDecoder, sstr(ppu_list[i]));
+				m_emu_settings->SetSetting(emu_settings::PPUDecoder, sstr(ppu_list[i]));
 			});
 		}
 	}
@@ -265,26 +265,26 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	SubscribeTooltip(ui->spu_asmjit,  tooltips.settings.spu_asmjit);
 	SubscribeTooltip(ui->spu_llvm,    tooltips.settings.spu_llvm);
 
-	QButtonGroup *spuBG = new QButtonGroup(this);
-	spuBG->addButton(ui->spu_precise, static_cast<int>(spu_decoder_type::precise));
-	spuBG->addButton(ui->spu_fast,    static_cast<int>(spu_decoder_type::fast));
-	spuBG->addButton(ui->spu_asmjit,  static_cast<int>(spu_decoder_type::asmjit));
-	spuBG->addButton(ui->spu_llvm,    static_cast<int>(spu_decoder_type::llvm));
+	QButtonGroup *spu_bg = new QButtonGroup(this);
+	spu_bg->addButton(ui->spu_precise, static_cast<int>(spu_decoder_type::precise));
+	spu_bg->addButton(ui->spu_fast,    static_cast<int>(spu_decoder_type::fast));
+	spu_bg->addButton(ui->spu_asmjit,  static_cast<int>(spu_decoder_type::asmjit));
+	spu_bg->addButton(ui->spu_llvm,    static_cast<int>(spu_decoder_type::llvm));
 
 	{ // Spu stuff
-		QString selectedSPU = qstr(xemu_settings->GetSetting(emu_settings::SPUDecoder));
-		QStringList spu_list = xemu_settings->GetSettingOptions(emu_settings::SPUDecoder);
+		const QString selected_spu = qstr(m_emu_settings->GetSetting(emu_settings::SPUDecoder));
+		QStringList spu_list = m_emu_settings->GetSettingOptions(emu_settings::SPUDecoder);
 
 		for (int i = 0; i < spu_list.count(); i++)
 		{
-			if (spu_list[i] == selectedSPU)
+			if (spu_list[i] == selected_spu)
 			{
-				spuBG->button(i)->setChecked(true);
+				spu_bg->button(i)->setChecked(true);
 			}
 
-			connect(spuBG->button(i), &QAbstractButton::clicked, [=, this]()
+			connect(spu_bg->button(i), &QAbstractButton::clicked, [=, this]()
 			{
-				xemu_settings->SetSetting(emu_settings::SPUDecoder, sstr(spu_list[i]));
+				m_emu_settings->SetSetting(emu_settings::SPUDecoder, sstr(spu_list[i]));
 			});
 		}
 	}
@@ -313,17 +313,17 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	//   | |__| | |    | |__| |    | | (_| | |_) |
 	//    \_____|_|     \____/     |_|\__,_|_.__/
 
-	emu_settings::Render_Creator render_creator = xemu_settings.get()->m_render_creator;
+	emu_settings::Render_Creator render_creator = m_emu_settings.get()->m_render_creator;
 
 	// Comboboxes
-	xemu_settings->EnhanceComboBox(ui->renderBox, emu_settings::Renderer);
+	m_emu_settings->EnhanceComboBox(ui->renderBox, emu_settings::Renderer);
 	SubscribeTooltip(ui->gb_renderer, tooltips.settings.renderer);
 	SubscribeTooltip(ui->gb_graphicsAdapter, tooltips.settings.graphics_adapter);
 
 	// Change displayed renderer names
 	ui->renderBox->setItemText(ui->renderBox->findData("Null"), render_creator.name_Null);
 
-	xemu_settings->EnhanceComboBox(ui->resBox, emu_settings::Resolution);
+	m_emu_settings->EnhanceComboBox(ui->resBox, emu_settings::Resolution);
 	SubscribeTooltip(ui->gb_default_resolution, tooltips.settings.resolution);
 	// remove unsupported resolutions from the dropdown
 	const int saved_index = ui->resBox->currentIndex();
@@ -342,16 +342,16 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 		for (int i = ui->resBox->count() - 1; i >= 0; i--)
 		{
-			bool hasResolution = false;
+			bool has_resolution = false;
 			for (const auto& res : resolutions)
 			{
 				if ((game->resolution & res.first) && res.second == sstr(ui->resBox->itemText(i)))
 				{
-					hasResolution = true;
+					has_resolution = true;
 					break;
 				}
 			}
-			if (!hasResolution)
+			if (!has_resolution)
 			{
 				ui->resBox->removeItem(i);
 				if (i == saved_index)
@@ -374,16 +374,16 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	}
 
-	xemu_settings->EnhanceComboBox(ui->aspectBox, emu_settings::AspectRatio);
+	m_emu_settings->EnhanceComboBox(ui->aspectBox, emu_settings::AspectRatio);
 	SubscribeTooltip(ui->gb_aspectRatio, tooltips.settings.aspect_ratio);
 
-	xemu_settings->EnhanceComboBox(ui->frameLimitBox, emu_settings::FrameLimit);
+	m_emu_settings->EnhanceComboBox(ui->frameLimitBox, emu_settings::FrameLimit);
 	SubscribeTooltip(ui->gb_frameLimit, tooltips.settings.frame_limit);
 
-	xemu_settings->EnhanceComboBox(ui->antiAliasing, emu_settings::MSAA);
+	m_emu_settings->EnhanceComboBox(ui->antiAliasing, emu_settings::MSAA);
 	SubscribeTooltip(ui->gb_antiAliasing, tooltips.settings.anti_aliasing);
 
-	xemu_settings->EnhanceComboBox(ui->anisotropicFilterOverride, emu_settings::AnisotropicFilterOverride, true);
+	m_emu_settings->EnhanceComboBox(ui->anisotropicFilterOverride, emu_settings::AnisotropicFilterOverride, true);
 	SubscribeTooltip(ui->gb_anisotropicFilter, tooltips.settings.anisotropic_filter);
 	// only allow values 0,2,4,8,16
 	for (int i = ui->anisotropicFilterOverride->count() - 1; i >= 0; i--)
@@ -406,19 +406,19 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	}
 
 	// Checkboxes: main options
-	xemu_settings->EnhanceCheckBox(ui->dumpColor, emu_settings::WriteColorBuffers);
+	m_emu_settings->EnhanceCheckBox(ui->dumpColor, emu_settings::WriteColorBuffers);
 	SubscribeTooltip(ui->dumpColor, tooltips.settings.dump_color);
 
-	xemu_settings->EnhanceCheckBox(ui->vsync, emu_settings::VSync);
+	m_emu_settings->EnhanceCheckBox(ui->vsync, emu_settings::VSync);
 	SubscribeTooltip(ui->vsync, tooltips.settings.vsync);
 
-	xemu_settings->EnhanceCheckBox(ui->stretchToDisplayArea, emu_settings::StretchToDisplayArea);
+	m_emu_settings->EnhanceCheckBox(ui->stretchToDisplayArea, emu_settings::StretchToDisplayArea);
 	SubscribeTooltip(ui->stretchToDisplayArea, tooltips.settings.stretch_to_display_area);
 
-	xemu_settings->EnhanceCheckBox(ui->disableVertexCache, emu_settings::DisableVertexCache);
+	m_emu_settings->EnhanceCheckBox(ui->disableVertexCache, emu_settings::DisableVertexCache);
 	SubscribeTooltip(ui->disableVertexCache, tooltips.settings.disable_vertex_cache);
 
-	xemu_settings->EnhanceCheckBox(ui->multithreadedRSX, emu_settings::MultithreadedRSX);
+	m_emu_settings->EnhanceCheckBox(ui->multithreadedRSX, emu_settings::MultithreadedRSX);
 	SubscribeTooltip(ui->multithreadedRSX, tooltips.settings.multithreaded_rsx);
 	connect(ui->multithreadedRSX, &QCheckBox::clicked, [this](bool checked)
 	{
@@ -426,10 +426,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	});
 	ui->disableVertexCache->setEnabled(!ui->multithreadedRSX->isChecked());
 
-	xemu_settings->EnhanceCheckBox(ui->disableAsyncShaders, emu_settings::DisableAsyncShaderCompiler);
+	m_emu_settings->EnhanceCheckBox(ui->disableAsyncShaders, emu_settings::DisableAsyncShaderCompiler);
 	SubscribeTooltip(ui->disableAsyncShaders, tooltips.settings.disable_async_shaders);
 
-	xemu_settings->EnhanceCheckBox(ui->scrictModeRendering, emu_settings::StrictRenderingMode);
+	m_emu_settings->EnhanceCheckBox(ui->scrictModeRendering, emu_settings::StrictRenderingMode);
 	SubscribeTooltip(ui->scrictModeRendering, tooltips.settings.strict_rendering_mode);
 	connect(ui->scrictModeRendering, &QCheckBox::clicked, [this](bool checked)
 	{
@@ -438,19 +438,19 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	});
 
 	// Sliders
-	static const auto& minmaxLabelWidth = [](const QString& sizer)
+	static const auto& minmax_label_width = [](const QString& sizer)
 	{
 		return QLabel(sizer).sizeHint().width();
 	};
 
-	xemu_settings->EnhanceSlider(ui->resolutionScale, emu_settings::ResolutionScale);
+	m_emu_settings->EnhanceSlider(ui->resolutionScale, emu_settings::ResolutionScale);
 	SubscribeTooltip(ui->gb_resolutionScale, tooltips.settings.resolution_scale);
 	ui->gb_resolutionScale->setEnabled(!ui->scrictModeRendering->isChecked());
 	// rename label texts to fit current state of Resolution Scale
-	int resolutionScaleDef = stoi(xemu_settings->GetSettingDefault(emu_settings::ResolutionScale));
-	auto ScaledResolution = [resolutionScaleDef](int percentage)
+	const int resolution_scale_def = stoi(m_emu_settings->GetSettingDefault(emu_settings::ResolutionScale));
+	auto scaled_resolution = [resolution_scale_def](int percentage)
 	{
-		if (percentage == resolutionScaleDef)
+		if (percentage == resolution_scale_def)
 		{
 			return QString(tr("100% (Default)"));
 		}
@@ -458,28 +458,28 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	};
 	ui->resolutionScale->setPageStep(50);
 	ui->resolutionScaleMin->setText(QString::number(ui->resolutionScale->minimum()));
-	ui->resolutionScaleMin->setFixedWidth(minmaxLabelWidth("00"));
+	ui->resolutionScaleMin->setFixedWidth(minmax_label_width("00"));
 	ui->resolutionScaleMax->setText(QString::number(ui->resolutionScale->maximum()));
-	ui->resolutionScaleMax->setFixedWidth(minmaxLabelWidth("0000"));
-	ui->resolutionScaleVal->setText(ScaledResolution(ui->resolutionScale->value()));
+	ui->resolutionScaleMax->setFixedWidth(minmax_label_width("0000"));
+	ui->resolutionScaleVal->setText(scaled_resolution(ui->resolutionScale->value()));
 	connect(ui->resolutionScale, &QSlider::valueChanged, [=, this](int value)
 	{
-		ui->resolutionScaleVal->setText(ScaledResolution(value));
+		ui->resolutionScaleVal->setText(scaled_resolution(value));
 	});
-	connect(ui->resolutionScaleReset, &QAbstractButton::clicked, [=, this]()
+	connect(ui->resolutionScaleReset, &QAbstractButton::clicked, [resolution_scale_def, this]()
 	{
-		ui->resolutionScale->setValue(resolutionScaleDef);
+		ui->resolutionScale->setValue(resolution_scale_def);
 	});
 	SnapSlider(ui->resolutionScale, 25);
 
-	xemu_settings->EnhanceSlider(ui->minimumScalableDimension, emu_settings::MinimumScalableDimension);
+	m_emu_settings->EnhanceSlider(ui->minimumScalableDimension, emu_settings::MinimumScalableDimension);
 	SubscribeTooltip(ui->gb_minimumScalableDimension, tooltips.settings.minimum_scalable_dimension);
 	ui->gb_minimumScalableDimension->setEnabled(!ui->scrictModeRendering->isChecked());
 	// rename label texts to fit current state of Minimum Scalable Dimension
-	int minimumScalableDimensionDef = stoi(xemu_settings->GetSettingDefault(emu_settings::MinimumScalableDimension));
-	auto MinScalableDimension = [minimumScalableDimensionDef](int dim)
+	const int minimum_scalable_dimension_def = stoi(m_emu_settings->GetSettingDefault(emu_settings::MinimumScalableDimension));
+	auto min_scalable_dimension = [minimum_scalable_dimension_def](int dim)
 	{
-		if (dim == minimumScalableDimensionDef)
+		if (dim == minimum_scalable_dimension_def)
 		{
 			return tr("%1x%1 (Default)").arg(dim);
 		}
@@ -487,17 +487,17 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	};
 	ui->minimumScalableDimension->setPageStep(64);
 	ui->minimumScalableDimensionMin->setText(QString::number(ui->minimumScalableDimension->minimum()));
-	ui->minimumScalableDimensionMin->setFixedWidth(minmaxLabelWidth("00"));
+	ui->minimumScalableDimensionMin->setFixedWidth(minmax_label_width("00"));
 	ui->minimumScalableDimensionMax->setText(QString::number(ui->minimumScalableDimension->maximum()));
-	ui->minimumScalableDimensionMax->setFixedWidth(minmaxLabelWidth("0000"));
-	ui->minimumScalableDimensionVal->setText(MinScalableDimension(ui->minimumScalableDimension->value()));
+	ui->minimumScalableDimensionMax->setFixedWidth(minmax_label_width("0000"));
+	ui->minimumScalableDimensionVal->setText(min_scalable_dimension(ui->minimumScalableDimension->value()));
 	connect(ui->minimumScalableDimension, &QSlider::valueChanged, [=, this](int value)
 	{
-		ui->minimumScalableDimensionVal->setText(MinScalableDimension(value));
+		ui->minimumScalableDimensionVal->setText(min_scalable_dimension(value));
 	});
-	connect(ui->minimumScalableDimensionReset, &QAbstractButton::clicked, [=, this]()
+	connect(ui->minimumScalableDimensionReset, &QAbstractButton::clicked, [minimum_scalable_dimension_def, this]()
 	{
-		ui->minimumScalableDimension->setValue(minimumScalableDimensionDef);
+		ui->minimumScalableDimension->setValue(minimum_scalable_dimension_def);
 	});
 
 	// Remove renderers from the renderer Combobox if not supported
@@ -507,7 +507,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		{
 			if (renderer->has_adapters)
 			{
-				renderer->old_adapter = qstr(xemu_settings->GetSetting(renderer->type));
+				renderer->old_adapter = qstr(m_emu_settings->GetSetting(renderer->type));
 			}
 			continue;
 		}
@@ -524,7 +524,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	m_old_renderer = ui->renderBox->currentText();
 
-	auto setRenderer = [=, this](QString text)
+	auto set_renderer = [=, this](QString text)
 	{
 		if (text.isEmpty())
 		{
@@ -538,14 +538,14 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			{
 				if (renderer.name != render->name && render->has_adapters && render->supported)
 				{
-					xemu_settings->SetSetting(render->type, sstr(render->old_adapter));
+					m_emu_settings->SetSetting(render->type, sstr(render->old_adapter));
 				}
 			}
 
 			// Enable/disable MSAA depending on renderer
 			ui->antiAliasing->setEnabled(renderer.has_msaa);
 			ui->antiAliasing->blockSignals(true);
-			ui->antiAliasing->setCurrentText(renderer.has_msaa ? qstr(xemu_settings->GetSetting(emu_settings::MSAA)) : tr("Disabled"));
+			ui->antiAliasing->setCurrentText(renderer.has_msaa ? qstr(m_emu_settings->GetSetting(emu_settings::MSAA)) : tr("Disabled"));
 			ui->antiAliasing->blockSignals(false);
 
 			// Fill combobox with placeholder if no adapters needed
@@ -576,7 +576,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 				}
 			}
 			ui->graphicsAdapterBox->setCurrentIndex(idx);
-			xemu_settings->SetSetting(renderer.type, sstr(ui->graphicsAdapterBox->currentText()));
+			m_emu_settings->SetSetting(renderer.type, sstr(ui->graphicsAdapterBox->currentText()));
 		};
 
 		for (const auto& renderer : render_creator.renderers)
@@ -589,7 +589,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	};
 
-	auto setAdapter = [=, this](QString text)
+	auto set_adapter = [=, this](QString text)
 	{
 		if (text.isEmpty())
 		{
@@ -607,28 +607,28 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		{
 			if (render->name == new_renderer && render->has_adapters && render->adapters.contains(text))
 			{
-				xemu_settings->SetSetting(render->type, sstr(text));
+				m_emu_settings->SetSetting(render->type, sstr(text));
 				break;
 			}
 		}
 	};
 
 	// Init
-	setRenderer(ui->renderBox->currentText());
-	setAdapter(ui->graphicsAdapterBox->currentText());
+	set_renderer(ui->renderBox->currentText());
+	set_adapter(ui->graphicsAdapterBox->currentText());
 
 	// Events
-	connect(ui->graphicsAdapterBox, &QComboBox::currentTextChanged, setAdapter);
-	connect(ui->renderBox, &QComboBox::currentTextChanged, setRenderer);
+	connect(ui->graphicsAdapterBox, &QComboBox::currentTextChanged, set_adapter);
+	connect(ui->renderBox, &QComboBox::currentTextChanged, set_renderer);
 
-	auto fixGLLegacy = [=, this](const QString& text)
+	auto fix_gl_legacy = [=, this](const QString& text)
 	{
 		ui->glLegacyBuffers->setEnabled(text == render_creator.name_OpenGL);
 	};
 
 	// Handle connects to disable specific checkboxes that depend on GUI state.
-	fixGLLegacy(ui->renderBox->currentText()); // Init
-	connect(ui->renderBox, &QComboBox::currentTextChanged, fixGLLegacy);
+	fix_gl_legacy(ui->renderBox->currentText()); // Init
+	connect(ui->renderBox, &QComboBox::currentTextChanged, fix_gl_legacy);
 
 	//                      _ _         _______    _
 	//       /\            | (_)       |__   __|  | |
@@ -637,44 +637,44 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	//    / ____ \ |_| | (_| | | (_) |    | | (_| | |_) |
 	//   /_/    \_\__,_|\__,_|_|\___/     |_|\__,_|_.__/
 
-	auto EnableTimeStretchingOptions = [this](bool enabled)
+	auto enable_time_stretching_options = [this](bool enabled)
 	{
 		ui->timeStretchingThresholdLabel->setEnabled(enabled);
 		ui->timeStretchingThreshold->setEnabled(enabled);
 	};
 
-	auto EnableBufferingOptions = [this, EnableTimeStretchingOptions](bool enabled)
+	auto enable_buffering_options = [this, enable_time_stretching_options](bool enabled)
 	{
 		ui->audioBufferDuration->setEnabled(enabled);
 		ui->audioBufferDurationLabel->setEnabled(enabled);
 		ui->enableTimeStretching->setEnabled(enabled);
-		EnableTimeStretchingOptions(enabled && ui->enableTimeStretching->isChecked());
+		enable_time_stretching_options(enabled && ui->enableTimeStretching->isChecked());
 	};
 
-	auto EnableBuffering = [this, EnableBufferingOptions](const QString& text)
+	auto enable_buffering = [this, enable_buffering_options](const QString& text)
 	{
 		const bool enabled = text == "XAudio2" || text == "OpenAL" || text == "FAudio";
 		ui->enableBuffering->setEnabled(enabled);
-		EnableBufferingOptions(enabled && ui->enableBuffering->isChecked());
+		enable_buffering_options(enabled && ui->enableBuffering->isChecked());
 	};
 
-	auto ChangeMicrophoneType = [=, this](QString text)
+	auto change_microphone_type = [=, this](QString text)
 	{
 		std::string s_standard, s_singstar, s_realsingstar, s_rocksmith;
 
-		auto enableMicsCombo = [=, this](u32 max)
+		auto enable_mics_combo = [=, this](u32 max)
 		{
 			ui->microphone1Box->setEnabled(true);
 
-			if (max == 1 || ui->microphone1Box->currentText() == xemu_settings->m_microphone_creator.mic_none)
+			if (max == 1 || ui->microphone1Box->currentText() == m_emu_settings->m_microphone_creator.mic_none)
 				return;
 
 			ui->microphone2Box->setEnabled(true);
 
-			if (max > 2 && ui->microphone2Box->currentText() != xemu_settings->m_microphone_creator.mic_none)
+			if (max > 2 && ui->microphone2Box->currentText() != m_emu_settings->m_microphone_creator.mic_none)
 			{
 				ui->microphone3Box->setEnabled(true);
-				if (ui->microphone3Box->currentText() != xemu_settings->m_microphone_creator.mic_none)
+				if (ui->microphone3Box->currentText() != m_emu_settings->m_microphone_creator.mic_none)
 				{
 					ui->microphone4Box->setEnabled(true);
 				}
@@ -693,30 +693,30 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 		if (text == s_standard.c_str())
 		{
-			enableMicsCombo(4);
+			enable_mics_combo(4);
 			return;
 		}
 		if (text == s_singstar.c_str())
 		{
-			enableMicsCombo(2);
+			enable_mics_combo(2);
 			return;
 		}
 		if (text == s_realsingstar.c_str() || text == s_rocksmith.c_str())
 		{
-			enableMicsCombo(1);
+			enable_mics_combo(1);
 			return;
 		}
 	};
 
-	auto PropagateUsedDevices = [=, this]()
+	auto propagate_used_devices = [=, this]()
 	{
 		for (u32 index = 0; index < 4; index++)
 		{
 			const QString cur_item = mics_combo[index]->currentText();
-			QStringList cur_list = xemu_settings->m_microphone_creator.microphones_list;
+			QStringList cur_list = m_emu_settings->m_microphone_creator.microphones_list;
 			for (u32 subindex = 0; subindex < 4; subindex++)
 			{
-				if (subindex != index && mics_combo[subindex]->currentText() != xemu_settings->m_microphone_creator.mic_none)
+				if (subindex != index && mics_combo[subindex]->currentText() != m_emu_settings->m_microphone_creator.mic_none)
 					cur_list.removeOne(mics_combo[subindex]->currentText());
 			}
 			mics_combo[index]->blockSignals(true);
@@ -725,20 +725,20 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			mics_combo[index]->setCurrentText(cur_item);
 			mics_combo[index]->blockSignals(false);
 		}
-		ChangeMicrophoneType(ui->microphoneBox->currentText());
+		change_microphone_type(ui->microphoneBox->currentText());
 	};
 
-	auto ChangeMicrophoneDevice = [=, this](u32 next_index, QString text)
+	auto change_microphone_device = [=, this](u32 next_index, QString text)
 	{
-		xemu_settings->SetSetting(emu_settings::MicrophoneDevices, xemu_settings->m_microphone_creator.SetDevice(next_index, text));
-		if (next_index < 4 && text == xemu_settings->m_microphone_creator.mic_none)
-			mics_combo[next_index]->setCurrentText(xemu_settings->m_microphone_creator.mic_none);
-		PropagateUsedDevices();
+		m_emu_settings->SetSetting(emu_settings::MicrophoneDevices, m_emu_settings->m_microphone_creator.SetDevice(next_index, text));
+		if (next_index < 4 && text == m_emu_settings->m_microphone_creator.mic_none)
+			mics_combo[next_index]->setCurrentText(m_emu_settings->m_microphone_creator.mic_none);
+		propagate_used_devices();
 	};
 
 	// Comboboxes
 
-	xemu_settings->EnhanceComboBox(ui->audioOutBox, emu_settings::AudioRenderer);
+	m_emu_settings->EnhanceComboBox(ui->audioOutBox, emu_settings::AudioRenderer);
 #ifdef WIN32
 	SubscribeTooltip(ui->gb_audio_out, tooltips.settings.audio_out);
 #else
@@ -746,59 +746,59 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 #endif
 	// Change displayed backend names
 	ui->audioOutBox->setItemText(ui->renderBox->findData("Null"), tr("Disable Audio Output"));
-	connect(ui->audioOutBox, &QComboBox::currentTextChanged, EnableBuffering);
+	connect(ui->audioOutBox, &QComboBox::currentTextChanged, enable_buffering);
 
 	// Microphone Comboboxes
 	mics_combo[0] = ui->microphone1Box;
 	mics_combo[1] = ui->microphone2Box;
 	mics_combo[2] = ui->microphone3Box;
 	mics_combo[3] = ui->microphone4Box;
-	connect(mics_combo[0], &QComboBox::currentTextChanged, [=, this](const QString& text) { ChangeMicrophoneDevice(1, text); });
-	connect(mics_combo[1], &QComboBox::currentTextChanged, [=, this](const QString& text) { ChangeMicrophoneDevice(2, text); });
-	connect(mics_combo[2], &QComboBox::currentTextChanged, [=, this](const QString& text) { ChangeMicrophoneDevice(3, text); });
-	connect(mics_combo[3], &QComboBox::currentTextChanged, [=, this](const QString& text) { ChangeMicrophoneDevice(4, text); });
-	xemu_settings->m_microphone_creator.RefreshList();
-	PropagateUsedDevices(); // Fills comboboxes list
+	connect(mics_combo[0], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(1, text); });
+	connect(mics_combo[1], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(2, text); });
+	connect(mics_combo[2], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(3, text); });
+	connect(mics_combo[3], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(4, text); });
+	m_emu_settings->m_microphone_creator.RefreshList();
+	propagate_used_devices(); // Fills comboboxes list
 
-	xemu_settings->m_microphone_creator.ParseDevices(xemu_settings->GetSetting(emu_settings::MicrophoneDevices));
+	m_emu_settings->m_microphone_creator.ParseDevices(m_emu_settings->GetSetting(emu_settings::MicrophoneDevices));
 
 	for (s32 index = 3; index >= 0; index--)
 	{
-		if (xemu_settings->m_microphone_creator.sel_list[index].empty() || mics_combo[index]->findText(qstr(xemu_settings->m_microphone_creator.sel_list[index])) == -1)
+		if (m_emu_settings->m_microphone_creator.sel_list[index].empty() || mics_combo[index]->findText(qstr(m_emu_settings->m_microphone_creator.sel_list[index])) == -1)
 		{
-			mics_combo[index]->setCurrentText(xemu_settings->m_microphone_creator.mic_none);
-			ChangeMicrophoneDevice(index+1, xemu_settings->m_microphone_creator.mic_none); // Ensures the value is set in config
+			mics_combo[index]->setCurrentText(m_emu_settings->m_microphone_creator.mic_none);
+			change_microphone_device(index+1, m_emu_settings->m_microphone_creator.mic_none); // Ensures the value is set in config
 		}
 		else
-			mics_combo[index]->setCurrentText(qstr(xemu_settings->m_microphone_creator.sel_list[index]));
+			mics_combo[index]->setCurrentText(qstr(m_emu_settings->m_microphone_creator.sel_list[index]));
 	}
 
-	xemu_settings->EnhanceComboBox(ui->microphoneBox, emu_settings::MicrophoneType);
+	m_emu_settings->EnhanceComboBox(ui->microphoneBox, emu_settings::MicrophoneType);
 	ui->microphoneBox->setItemText(ui->microphoneBox->findData("Null"), tr("Disabled"));
 	SubscribeTooltip(ui->microphoneBox, tooltips.settings.microphone);
-	connect(ui->microphoneBox, &QComboBox::currentTextChanged, ChangeMicrophoneType);
-	PropagateUsedDevices(); // Enables/Disables comboboxes and checks values from config for sanity
+	connect(ui->microphoneBox, &QComboBox::currentTextChanged, change_microphone_type);
+	propagate_used_devices(); // Enables/Disables comboboxes and checks values from config for sanity
 
 	// Checkboxes
 
-	xemu_settings->EnhanceCheckBox(ui->audioDump, emu_settings::DumpToFile);
+	m_emu_settings->EnhanceCheckBox(ui->audioDump, emu_settings::DumpToFile);
 	SubscribeTooltip(ui->audioDump, tooltips.settings.audio_dump);
 
-	xemu_settings->EnhanceCheckBox(ui->convert, emu_settings::ConvertTo16Bit);
+	m_emu_settings->EnhanceCheckBox(ui->convert, emu_settings::ConvertTo16Bit);
 	SubscribeTooltip(ui->convert, tooltips.settings.convert);
 
-	xemu_settings->EnhanceCheckBox(ui->downmix, emu_settings::DownmixStereo);
+	m_emu_settings->EnhanceCheckBox(ui->downmix, emu_settings::DownmixStereo);
 	SubscribeTooltip(ui->downmix, tooltips.settings.downmix);
 
-	xemu_settings->EnhanceCheckBox(ui->enableBuffering, emu_settings::EnableBuffering);
+	m_emu_settings->EnhanceCheckBox(ui->enableBuffering, emu_settings::EnableBuffering);
 	SubscribeTooltip(ui->enableBuffering, tooltips.settings.enable_buffering);
-	connect(ui->enableBuffering, &QCheckBox::clicked, EnableBufferingOptions);
+	connect(ui->enableBuffering, &QCheckBox::clicked, enable_buffering_options);
 
-	xemu_settings->EnhanceCheckBox(ui->enableTimeStretching, emu_settings::EnableTimeStretching);
+	m_emu_settings->EnhanceCheckBox(ui->enableTimeStretching, emu_settings::EnableTimeStretching);
 	SubscribeTooltip(ui->enableTimeStretching, tooltips.settings.enable_time_stretching);
-	connect(ui->enableTimeStretching, &QCheckBox::clicked, EnableTimeStretchingOptions);
+	connect(ui->enableTimeStretching, &QCheckBox::clicked, enable_time_stretching_options);
 
-	EnableBuffering(ui->audioOutBox->currentText());
+	enable_buffering(ui->audioOutBox->currentText());
 
 	// Sliders
 
@@ -820,19 +820,19 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	// Comboboxes
 
-	xemu_settings->EnhanceComboBox(ui->keyboardHandlerBox, emu_settings::KeyboardHandler);
+	m_emu_settings->EnhanceComboBox(ui->keyboardHandlerBox, emu_settings::KeyboardHandler);
 	SubscribeTooltip(ui->gb_keyboard_handler, tooltips.settings.keyboard_handler);
 
-	xemu_settings->EnhanceComboBox(ui->mouseHandlerBox, emu_settings::MouseHandler);
+	m_emu_settings->EnhanceComboBox(ui->mouseHandlerBox, emu_settings::MouseHandler);
 	SubscribeTooltip(ui->gb_mouse_handler, tooltips.settings.mouse_handler);
 
-	xemu_settings->EnhanceComboBox(ui->cameraTypeBox, emu_settings::CameraType);
+	m_emu_settings->EnhanceComboBox(ui->cameraTypeBox, emu_settings::CameraType);
 	SubscribeTooltip(ui->gb_camera_type, tooltips.settings.camera_type);
 
-	xemu_settings->EnhanceComboBox(ui->cameraBox, emu_settings::Camera);
+	m_emu_settings->EnhanceComboBox(ui->cameraBox, emu_settings::Camera);
 	SubscribeTooltip(ui->gb_camera_setting, tooltips.settings.camera);
 
-	xemu_settings->EnhanceComboBox(ui->moveBox, emu_settings::Move);
+	m_emu_settings->EnhanceComboBox(ui->moveBox, emu_settings::Move);
 	SubscribeTooltip(ui->gb_move_handler, tooltips.settings.move);
 
 	//     _____           _                   _______    _
@@ -846,18 +846,18 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	// Comboboxes
 
-	xemu_settings->EnhanceComboBox(ui->sysLangBox, emu_settings::Language, false, false, 0, true);
+	m_emu_settings->EnhanceComboBox(ui->sysLangBox, emu_settings::Language, false, false, 0, true);
 	SubscribeTooltip(ui->gb_sysLang, tooltips.settings.system_language);
 
-	xemu_settings->EnhanceComboBox(ui->keyboardType, emu_settings::KeyboardType, false, false, 0, true);
+	m_emu_settings->EnhanceComboBox(ui->keyboardType, emu_settings::KeyboardType, false, false, 0, true);
 	SubscribeTooltip(ui->gb_keyboardType, tooltips.settings.keyboard_type);
 
 	// Checkboxes
 
-	xemu_settings->EnhanceCheckBox(ui->enableHostRoot, emu_settings::EnableHostRoot);
+	m_emu_settings->EnhanceCheckBox(ui->enableHostRoot, emu_settings::EnableHostRoot);
 	SubscribeTooltip(ui->enableHostRoot, tooltips.settings.enable_host_root);
 
-	xemu_settings->EnhanceCheckBox(ui->enableCacheClearing, emu_settings::LimitCacheSize);
+	m_emu_settings->EnhanceCheckBox(ui->enableCacheClearing, emu_settings::LimitCacheSize);
 	SubscribeTooltip(ui->gb_DiskCacheClearing, tooltips.settings.limit_cache_size);
 	connect(ui->enableCacheClearing, &QCheckBox::stateChanged, ui->maximumCacheSize, &QSlider::setEnabled);
 
@@ -871,26 +871,26 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	SubscribeTooltip(ui->gb_enterButtonAssignment, tooltips.settings.enter_button_assignment);
 
 	// creating this in ui file keeps scrambling the order...
-	QButtonGroup *enterButtonAssignmentBG = new QButtonGroup(this);
-	enterButtonAssignmentBG->addButton(ui->enterButtonAssignCircle, 0);
-	enterButtonAssignmentBG->addButton(ui->enterButtonAssignCross, 1);
+	QButtonGroup *enter_button_assignment_bg = new QButtonGroup(this);
+	enter_button_assignment_bg->addButton(ui->enterButtonAssignCircle, 0);
+	enter_button_assignment_bg->addButton(ui->enterButtonAssignCross, 1);
 
 	{ // EnterButtonAssignment options
-		QString assigned_button = qstr(xemu_settings->GetSetting(emu_settings::EnterButtonAssignment));
-		QStringList assignable_buttons = xemu_settings->GetSettingOptions(emu_settings::EnterButtonAssignment);
+		const QString assigned_button = qstr(m_emu_settings->GetSetting(emu_settings::EnterButtonAssignment));
+		QStringList assignable_buttons = m_emu_settings->GetSettingOptions(emu_settings::EnterButtonAssignment);
 
 		for (int i = 0; i < assignable_buttons.count(); i++)
 		{
-			enterButtonAssignmentBG->button(i)->setText(assignable_buttons[i]);
+			enter_button_assignment_bg->button(i)->setText(assignable_buttons[i]);
 
 			if (assignable_buttons[i] == assigned_button)
 			{
-				enterButtonAssignmentBG->button(i)->setChecked(true);
+				enter_button_assignment_bg->button(i)->setChecked(true);
 			}
 
-			connect(enterButtonAssignmentBG->button(i), &QAbstractButton::clicked, [=, this]()
+			connect(enter_button_assignment_bg->button(i), &QAbstractButton::clicked, [=, this]()
 			{
-				xemu_settings->SetSetting(emu_settings::EnterButtonAssignment, sstr(assignable_buttons[i]));
+				m_emu_settings->SetSetting(emu_settings::EnterButtonAssignment, sstr(assignable_buttons[i]));
 			});
 		}
 	}
@@ -904,18 +904,18 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	// Edits
 
-	xemu_settings->EnhanceEdit(ui->edit_dns, emu_settings::DNSAddress);
+	m_emu_settings->EnhanceEdit(ui->edit_dns, emu_settings::DNSAddress);
 	SubscribeTooltip(ui->edit_dns, tooltips.settings.dns);
 
-	xemu_settings->EnhanceEdit(ui->edit_npid, emu_settings::PSNNPID);
+	m_emu_settings->EnhanceEdit(ui->edit_npid, emu_settings::PSNNPID);
 	SubscribeTooltip(ui->edit_npid, tooltips.settings.psn_npid);
 
-	xemu_settings->EnhanceEdit(ui->edit_swaps, emu_settings::IpSwapList);
+	m_emu_settings->EnhanceEdit(ui->edit_swaps, emu_settings::IpSwapList);
 	SubscribeTooltip(ui->edit_swaps, tooltips.settings.dns_swap);
 
 	// Comboboxes
 
-	xemu_settings->EnhanceComboBox(ui->netStatusBox, emu_settings::InternetStatus);
+	m_emu_settings->EnhanceComboBox(ui->netStatusBox, emu_settings::InternetStatus);
 	SubscribeTooltip(ui->netStatusBox, tooltips.settings.net_status);
 
 	connect(ui->netStatusBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index)
@@ -946,7 +946,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	});
 
-	xemu_settings->EnhanceComboBox(ui->psnStatusBox, emu_settings::PSNStatus);
+	m_emu_settings->EnhanceComboBox(ui->psnStatusBox, emu_settings::PSNStatus);
 	SubscribeTooltip(ui->psnStatusBox, tooltips.settings.psn_status);
 
 	//                _                               _   _______    _
@@ -959,34 +959,34 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	// Checkboxes
 
-	xemu_settings->EnhanceCheckBox(ui->debugConsoleMode, emu_settings::DebugConsoleMode);
+	m_emu_settings->EnhanceCheckBox(ui->debugConsoleMode, emu_settings::DebugConsoleMode);
 	SubscribeTooltip(ui->debugConsoleMode, tooltips.settings.debug_console_mode);
 
-	xemu_settings->EnhanceCheckBox(ui->silenceAllLogs, emu_settings::SilenceAllLogs);
+	m_emu_settings->EnhanceCheckBox(ui->silenceAllLogs, emu_settings::SilenceAllLogs);
 	SubscribeTooltip(ui->silenceAllLogs, tooltips.settings.silence_all_logs);
 
-	xemu_settings->EnhanceCheckBox(ui->readColor, emu_settings::ReadColorBuffers);
+	m_emu_settings->EnhanceCheckBox(ui->readColor, emu_settings::ReadColorBuffers);
 	SubscribeTooltip(ui->readColor, tooltips.settings.read_color);
 
-	xemu_settings->EnhanceCheckBox(ui->readDepth, emu_settings::ReadDepthBuffer);
+	m_emu_settings->EnhanceCheckBox(ui->readDepth, emu_settings::ReadDepthBuffer);
 	SubscribeTooltip(ui->readDepth, tooltips.settings.read_depth);
 
-	xemu_settings->EnhanceCheckBox(ui->dumpDepth, emu_settings::WriteDepthBuffer);
+	m_emu_settings->EnhanceCheckBox(ui->dumpDepth, emu_settings::WriteDepthBuffer);
 	SubscribeTooltip(ui->dumpDepth, tooltips.settings.dump_depth);
 
-	xemu_settings->EnhanceCheckBox(ui->disableOnDiskShaderCache, emu_settings::DisableOnDiskShaderCache);
+	m_emu_settings->EnhanceCheckBox(ui->disableOnDiskShaderCache, emu_settings::DisableOnDiskShaderCache);
 	SubscribeTooltip(ui->disableOnDiskShaderCache, tooltips.settings.disable_on_disk_shader_cache);
 
-	xemu_settings->EnhanceCheckBox(ui->relaxedZCULL, emu_settings::RelaxedZCULL);
+	m_emu_settings->EnhanceCheckBox(ui->relaxedZCULL, emu_settings::RelaxedZCULL);
 	SubscribeTooltip(ui->relaxedZCULL, tooltips.settings.relaxed_zcull);
 
 	// Comboboxes
 
-	xemu_settings->EnhanceComboBox(ui->maxSPURSThreads, emu_settings::MaxSPURSThreads, true);
+	m_emu_settings->EnhanceComboBox(ui->maxSPURSThreads, emu_settings::MaxSPURSThreads, true);
 	ui->maxSPURSThreads->setItemText(ui->maxSPURSThreads->findData("6"), tr("Unlimited (Default)"));
 	SubscribeTooltip(ui->gb_max_spurs_threads, tooltips.settings.max_spurs_threads);
 
-	xemu_settings->EnhanceComboBox(ui->sleepTimersAccuracy, emu_settings::SleepTimersAccuracy);
+	m_emu_settings->EnhanceComboBox(ui->sleepTimersAccuracy, emu_settings::SleepTimersAccuracy);
 	SubscribeTooltip(ui->gb_sleep_timers_accuracy, tooltips.settings.sleep_timers_accuracy);
 
 	// Sliders
@@ -995,28 +995,28 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	SnapSlider(ui->wakeupDelay, 200);
 	ui->wakeupDelay->setMaximum(7000); // Very large values must be entered with config.yml changes
 	ui->wakeupDelay->setPageStep(200);
-	int wakeupDef = stoi(xemu_settings->GetSettingDefault(emu_settings::DriverWakeUpDelay));
+	const int wakeup_def = stoi(m_emu_settings->GetSettingDefault(emu_settings::DriverWakeUpDelay));
 	connect(ui->wakeupReset, &QAbstractButton::clicked, [=, this]()
 	{
-		ui->wakeupDelay->setValue(wakeupDef);
+		ui->wakeupDelay->setValue(wakeup_def);
 	});
 
 	EnhanceSlider(emu_settings::VBlankRate, ui->vblank, ui->vblankText, tr("%0 Hz"));
 	SnapSlider(ui->vblank, 30);
 	ui->vblank->setPageStep(60);
-	int vblankDef = stoi(xemu_settings->GetSettingDefault(emu_settings::VBlankRate));
+	const int vblank_def = stoi(m_emu_settings->GetSettingDefault(emu_settings::VBlankRate));
 	connect(ui->vblankReset, &QAbstractButton::clicked, [=, this]()
 	{
-		ui->vblank->setValue(vblankDef);
+		ui->vblank->setValue(vblank_def);
 	});
 
 	EnhanceSlider(emu_settings::ClocksScale, ui->clockScale, ui->clockScaleText, tr("%0 %"));
 	SnapSlider(ui->clockScale, 10);
 	ui->clockScale->setPageStep(50);
-	int clocksScaleDef = stoi(xemu_settings->GetSettingDefault(emu_settings::ResolutionScale));
+	const int clocks_scale_def = stoi(m_emu_settings->GetSettingDefault(emu_settings::ResolutionScale));
 	connect(ui->clockScaleReset, &QAbstractButton::clicked, [=, this]()
 	{
-		ui->clockScale->setValue(clocksScaleDef);
+		ui->clockScale->setValue(clocks_scale_def);
 	});
 
 	if (!game) // Prevent users from doing dumb things
@@ -1046,29 +1046,29 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	SubscribeTooltip(ui->lib_lv2l, tooltips.settings.libraries_liblv2list);
 
 	// creating this in ui file keeps scrambling the order...
-	QButtonGroup *libModeBG = new QButtonGroup(this);
-	libModeBG->addButton(ui->lib_manu, static_cast<int>(lib_loading_type::manual));
-	libModeBG->addButton(ui->lib_both, static_cast<int>(lib_loading_type::hybrid));
-	libModeBG->addButton(ui->lib_lv2,  static_cast<int>(lib_loading_type::liblv2only));
-	libModeBG->addButton(ui->lib_lv2b, static_cast<int>(lib_loading_type::liblv2both));
-	libModeBG->addButton(ui->lib_lv2l, static_cast<int>(lib_loading_type::liblv2list));
+	QButtonGroup *lib_mode_bg = new QButtonGroup(this);
+	lib_mode_bg->addButton(ui->lib_manu, static_cast<int>(lib_loading_type::manual));
+	lib_mode_bg->addButton(ui->lib_both, static_cast<int>(lib_loading_type::hybrid));
+	lib_mode_bg->addButton(ui->lib_lv2,  static_cast<int>(lib_loading_type::liblv2only));
+	lib_mode_bg->addButton(ui->lib_lv2b, static_cast<int>(lib_loading_type::liblv2both));
+	lib_mode_bg->addButton(ui->lib_lv2l, static_cast<int>(lib_loading_type::liblv2list));
 
 	{// Handle lib loading options
-		QString selectedLib = qstr(xemu_settings->GetSetting(emu_settings::LibLoadOptions));
-		QStringList libmode_list = xemu_settings->GetSettingOptions(emu_settings::LibLoadOptions);
+		const QString selected_lib = qstr(m_emu_settings->GetSetting(emu_settings::LibLoadOptions));
+		QStringList libmode_list = m_emu_settings->GetSettingOptions(emu_settings::LibLoadOptions);
 
 		for (int i = 0; i < libmode_list.count(); i++)
 		{
-			libModeBG->button(i)->setText(libmode_list[i]);
+			lib_mode_bg->button(i)->setText(libmode_list[i]);
 
-			if (libmode_list[i] == selectedLib)
+			if (libmode_list[i] == selected_lib)
 			{
-				libModeBG->button(i)->setChecked(true);
+				lib_mode_bg->button(i)->setChecked(true);
 			}
 
-			connect(libModeBG->button(i), &QAbstractButton::clicked, [=, this]()
+			connect(lib_mode_bg->button(i), &QAbstractButton::clicked, [=, this]()
 			{
-				xemu_settings->SetSetting(emu_settings::LibLoadOptions, sstr(libmode_list[i]));
+				m_emu_settings->SetSetting(emu_settings::LibLoadOptions, sstr(libmode_list[i]));
 			});
 		}
 	}
@@ -1079,7 +1079,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		std::sort(vec.begin(), vec.end(), [](const std::string &str1, const std::string &str2) { return str1 < str2; });
 	};
 
-	std::vector<std::string> loadedLibs = xemu_settings->GetLoadedLibraries();
+	std::vector<std::string> loadedLibs = m_emu_settings->GetLoadedLibraries();
 
 	sort_string_vector(loadedLibs);
 
@@ -1121,7 +1121,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	ui->searchBox->setPlaceholderText(tr("Search libraries"));
 
-	auto l_OnLibButtonClicked = [=, this](int ind)
+	auto on_lib_button_clicked = [=, this](int ind)
 	{
 		if (ind != static_cast<int>(lib_loading_type::liblv2only))
 		{
@@ -1135,9 +1135,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	};
 
-	auto l_OnSearchBoxTextChanged = [=, this](QString text)
+	auto on_search_box_text_changed = [=, this](QString text)
 	{
-		QString searchTerm = text.toLower();
+		const QString search_term = text.toLower();
 		std::vector<QListWidgetItem*> items;
 
 		// duplicate current items, we need clones to preserve checkstates
@@ -1160,13 +1160,13 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			ui->lleList->addItem(items[i]);
 
 			// only show items filtered for search text
-			ui->lleList->setRowHidden(i, !items[i]->text().contains(searchTerm));
+			ui->lleList->setRowHidden(i, !items[i]->text().contains(search_term));
 		}
 	};
 
 	// Events
-	connect(libModeBG, static_cast<void(QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), l_OnLibButtonClicked);
-	connect(ui->searchBox, &QLineEdit::textChanged, l_OnSearchBoxTextChanged);
+	connect(lib_mode_bg, static_cast<void(QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), on_lib_button_clicked);
+	connect(ui->searchBox, &QLineEdit::textChanged, on_search_box_text_changed);
 
 	// enable multiselection (there must be a better way)
 	connect(ui->lleList, &QListWidget::itemChanged, [&](QListWidgetItem* item)
@@ -1177,10 +1177,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	});
 
-	int buttid = libModeBG->checkedId();
-	if (buttid != -1)
+	if (const int lib_mode_button_id = lib_mode_bg->checkedId(); lib_mode_button_id >= 0)
 	{
-		l_OnLibButtonClicked(buttid);
+		on_lib_button_clicked(lib_mode_button_id);
 	}
 
 	//    ______                 _       _               _______    _
@@ -1192,41 +1191,41 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	// Comboboxes
 
-	xemu_settings->EnhanceComboBox(ui->maxLLVMThreads, emu_settings::MaxLLVMThreads, true, true, std::thread::hardware_concurrency());
+	m_emu_settings->EnhanceComboBox(ui->maxLLVMThreads, emu_settings::MaxLLVMThreads, true, true, std::thread::hardware_concurrency());
 	SubscribeTooltip(ui->gb_max_llvm, tooltips.settings.max_llvm_threads);
 	ui->maxLLVMThreads->setItemText(ui->maxLLVMThreads->findData("0"), tr("All (%1)").arg(std::thread::hardware_concurrency()));
 
-	xemu_settings->EnhanceComboBox(ui->perfOverlayDetailLevel, emu_settings::PerfOverlayDetailLevel);
+	m_emu_settings->EnhanceComboBox(ui->perfOverlayDetailLevel, emu_settings::PerfOverlayDetailLevel);
 	SubscribeTooltip(ui->perf_overlay_detail_level, tooltips.settings.perf_overlay_detail_level);
 
-	xemu_settings->EnhanceComboBox(ui->perfOverlayPosition, emu_settings::PerfOverlayPosition);
+	m_emu_settings->EnhanceComboBox(ui->perfOverlayPosition, emu_settings::PerfOverlayPosition);
 	SubscribeTooltip(ui->perf_overlay_position, tooltips.settings.perf_overlay_position);
 
 	// Checkboxes
 
-	xemu_settings->EnhanceCheckBox(ui->exitOnStop, emu_settings::ExitRPCS3OnFinish);
+	m_emu_settings->EnhanceCheckBox(ui->exitOnStop, emu_settings::ExitRPCS3OnFinish);
 	SubscribeTooltip(ui->exitOnStop, tooltips.settings.exit_on_stop);
 
-	xemu_settings->EnhanceCheckBox(ui->alwaysStart, emu_settings::StartOnBoot);
+	m_emu_settings->EnhanceCheckBox(ui->alwaysStart, emu_settings::StartOnBoot);
 	SubscribeTooltip(ui->alwaysStart, tooltips.settings.start_on_boot);
 
-	xemu_settings->EnhanceCheckBox(ui->startGameFullscreen, emu_settings::StartGameFullscreen);
+	m_emu_settings->EnhanceCheckBox(ui->startGameFullscreen, emu_settings::StartGameFullscreen);
 	SubscribeTooltip(ui->startGameFullscreen, tooltips.settings.start_game_fullscreen);
 
-	xemu_settings->EnhanceCheckBox(ui->preventDisplaySleep, emu_settings::PreventDisplaySleep);
+	m_emu_settings->EnhanceCheckBox(ui->preventDisplaySleep, emu_settings::PreventDisplaySleep);
 	SubscribeTooltip(ui->preventDisplaySleep, tooltips.settings.prevent_display_sleep);
 	ui->preventDisplaySleep->setEnabled(display_sleep_control_supported());
 
-	xemu_settings->EnhanceCheckBox(ui->showTrophyPopups, emu_settings::ShowTrophyPopups);
+	m_emu_settings->EnhanceCheckBox(ui->showTrophyPopups, emu_settings::ShowTrophyPopups);
 	SubscribeTooltip(ui->showTrophyPopups, tooltips.settings.show_trophy_popups);
 
-	xemu_settings->EnhanceCheckBox(ui->useNativeInterface, emu_settings::UseNativeInterface);
+	m_emu_settings->EnhanceCheckBox(ui->useNativeInterface, emu_settings::UseNativeInterface);
 	SubscribeTooltip(ui->useNativeInterface, tooltips.settings.use_native_interface);
 
-	xemu_settings->EnhanceCheckBox(ui->showShaderCompilationHint, emu_settings::ShowShaderCompilationHint);
+	m_emu_settings->EnhanceCheckBox(ui->showShaderCompilationHint, emu_settings::ShowShaderCompilationHint);
 	SubscribeTooltip(ui->showShaderCompilationHint, tooltips.settings.show_shader_compilation_hint);
 
-	xemu_settings->EnhanceCheckBox(ui->perfOverlayCenterX, emu_settings::PerfOverlayCenterX);
+	m_emu_settings->EnhanceCheckBox(ui->perfOverlayCenterX, emu_settings::PerfOverlayCenterX);
 	SubscribeTooltip(ui->perfOverlayCenterX, tooltips.settings.perf_overlay_center_x);
 	connect(ui->perfOverlayCenterX, &QCheckBox::clicked, [this](bool checked)
 	{
@@ -1234,7 +1233,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	});
 	ui->perfOverlayMarginX->setEnabled(!ui->perfOverlayCenterX->isChecked());
 
-	xemu_settings->EnhanceCheckBox(ui->perfOverlayCenterY, emu_settings::PerfOverlayCenterY);
+	m_emu_settings->EnhanceCheckBox(ui->perfOverlayCenterY, emu_settings::PerfOverlayCenterY);
 	SubscribeTooltip(ui->perfOverlayCenterY, tooltips.settings.perf_overlay_center_y);
 	connect(ui->perfOverlayCenterY, &QCheckBox::clicked, [this](bool checked)
 	{
@@ -1242,15 +1241,15 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	});
 	ui->perfOverlayMarginY->setEnabled(!ui->perfOverlayCenterY->isChecked());
 
-	xemu_settings->EnhanceCheckBox(ui->perfOverlayFramerateGraphEnabled, emu_settings::PerfOverlayFramerateGraphEnabled);
+	m_emu_settings->EnhanceCheckBox(ui->perfOverlayFramerateGraphEnabled, emu_settings::PerfOverlayFramerateGraphEnabled);
 	SubscribeTooltip(ui->perfOverlayFramerateGraphEnabled, tooltips.settings.perf_overlay_framerate_graph_enabled);
 
-	xemu_settings->EnhanceCheckBox(ui->perfOverlayFrametimeGraphEnabled, emu_settings::PerfOverlayFrametimeGraphEnabled);
+	m_emu_settings->EnhanceCheckBox(ui->perfOverlayFrametimeGraphEnabled, emu_settings::PerfOverlayFrametimeGraphEnabled);
 	SubscribeTooltip(ui->perfOverlayFrametimeGraphEnabled, tooltips.settings.perf_overlay_frametime_graph_enabled);
 
-	xemu_settings->EnhanceCheckBox(ui->perfOverlayEnabled, emu_settings::PerfOverlayEnabled);
+	m_emu_settings->EnhanceCheckBox(ui->perfOverlayEnabled, emu_settings::PerfOverlayEnabled);
 	SubscribeTooltip(ui->perfOverlayEnabled, tooltips.settings.perf_overlay_enabled);
-	auto EnablePerfOverlayOptions = [this](bool enabled)
+	auto enable_perf_overlay_options = [this](bool enabled)
 	{
 		ui->label_detail_level->setEnabled(enabled);
 		ui->label_update_interval->setEnabled(enabled);
@@ -1271,20 +1270,20 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->perfOverlayFramerateGraphEnabled->setEnabled(enabled);
 		ui->perfOverlayFrametimeGraphEnabled->setEnabled(enabled);
 	};
-	EnablePerfOverlayOptions(ui->perfOverlayEnabled->isChecked());
-	connect(ui->perfOverlayEnabled, &QCheckBox::clicked, EnablePerfOverlayOptions);
+	enable_perf_overlay_options(ui->perfOverlayEnabled->isChecked());
+	connect(ui->perfOverlayEnabled, &QCheckBox::clicked, enable_perf_overlay_options);
 
-	xemu_settings->EnhanceCheckBox(ui->shaderLoadBgEnabled, emu_settings::ShaderLoadBgEnabled);
+	m_emu_settings->EnhanceCheckBox(ui->shaderLoadBgEnabled, emu_settings::ShaderLoadBgEnabled);
 	SubscribeTooltip(ui->shaderLoadBgEnabled, tooltips.settings.shader_load_bg_enabled);
-	auto EnableShaderLoaderOptions = [this](bool enabled)
+	auto enable_shader_loader_options = [this](bool enabled)
 	{
 		ui->label_shaderLoadBgDarkening->setEnabled(enabled);
 		ui->label_shaderLoadBgBlur->setEnabled(enabled);
 		ui->shaderLoadBgDarkening->setEnabled(enabled);
 		ui->shaderLoadBgBlur->setEnabled(enabled);
 	};
-	EnableShaderLoaderOptions(ui->shaderLoadBgEnabled->isChecked());
-	connect(ui->shaderLoadBgEnabled, &QCheckBox::clicked, EnableShaderLoaderOptions);
+	enable_shader_loader_options(ui->shaderLoadBgEnabled->isChecked());
+	connect(ui->shaderLoadBgEnabled, &QCheckBox::clicked, enable_shader_loader_options);
 
 	// Sliders
 
@@ -1305,10 +1304,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	// SpinBoxes
 
-	xemu_settings->EnhanceSpinBox(ui->perfOverlayMarginX, emu_settings::PerfOverlayMarginX, "", tr("px"));
+	m_emu_settings->EnhanceSpinBox(ui->perfOverlayMarginX, emu_settings::PerfOverlayMarginX, "", tr("px"));
 	SubscribeTooltip(ui->perfOverlayMarginX, tooltips.settings.perf_overlay_margin_x);
 
-	xemu_settings->EnhanceSpinBox(ui->perfOverlayMarginY, emu_settings::PerfOverlayMarginY, "", tr("px"));
+	m_emu_settings->EnhanceSpinBox(ui->perfOverlayMarginY, emu_settings::PerfOverlayMarginY, "", tr("px"));
 	SubscribeTooltip(ui->perfOverlayMarginY, tooltips.settings.perf_overlay_margin_y);
 
 	// Global settings (gui_settings)
@@ -1318,38 +1317,38 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 		SubscribeTooltip(ui->gs_disableMouse, tooltips.settings.disable_mouse);
 
-		ui->gs_disableMouse->setChecked(xgui_settings->GetValue(gui::gs_disableMouse).toBool());
+		ui->gs_disableMouse->setChecked(m_gui_settings->GetValue(gui::gs_disableMouse).toBool());
 		connect(ui->gs_disableMouse, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::gs_disableMouse, val);
+			m_gui_settings->SetValue(gui::gs_disableMouse, val);
 		});
 
-		bool enableButtons = xgui_settings->GetValue(gui::gs_resize).toBool();
-		ui->gs_resizeOnBoot->setChecked(enableButtons);
-		ui->gs_width->setEnabled(enableButtons);
-		ui->gs_height->setEnabled(enableButtons);
+		const bool enable_buttons = m_gui_settings->GetValue(gui::gs_resize).toBool();
+		ui->gs_resizeOnBoot->setChecked(enable_buttons);
+		ui->gs_width->setEnabled(enable_buttons);
+		ui->gs_height->setEnabled(enable_buttons);
 
-		QRect screen = QGuiApplication::primaryScreen()->geometry();
-		int width = xgui_settings->GetValue(gui::gs_width).toInt();
-		int height = xgui_settings->GetValue(gui::gs_height).toInt();
+		const QRect screen = QGuiApplication::primaryScreen()->geometry();
+		const int width = m_gui_settings->GetValue(gui::gs_width).toInt();
+		const int height = m_gui_settings->GetValue(gui::gs_height).toInt();
 		ui->gs_width->setValue(std::min(width, screen.width()));
 		ui->gs_height->setValue(std::min(height, screen.height()));
 
 		connect(ui->gs_resizeOnBoot, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::gs_resize, val);
+			m_gui_settings->SetValue(gui::gs_resize, val);
 			ui->gs_width->setEnabled(val);
 			ui->gs_height->setEnabled(val);
 		});
 		connect(ui->gs_width, &QSpinBox::editingFinished, [=, this]()
 		{
 			ui->gs_width->setValue(std::min(ui->gs_width->value(), QGuiApplication::primaryScreen()->size().width()));
-			xgui_settings->SetValue(gui::gs_width, ui->gs_width->value());
+			m_gui_settings->SetValue(gui::gs_width, ui->gs_width->value());
 		});
 		connect(ui->gs_height, &QSpinBox::editingFinished, [=, this]()
 		{
 			ui->gs_height->setValue(std::min(ui->gs_height->value(), QGuiApplication::primaryScreen()->size().height()));
-			xgui_settings->SetValue(gui::gs_height, ui->gs_height->value());
+			m_gui_settings->SetValue(gui::gs_height, ui->gs_height->value());
 		});
 	}
 	else
@@ -1364,8 +1363,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	{
 		rpcs3::title_format_data title_data;
 		title_data.format = sstr(format);
-		title_data.renderer = xemu_settings->GetSetting(emu_settings::Renderer);
-		title_data.vulkan_adapter = xemu_settings->GetSetting(emu_settings::VulkanAdapter);
+		title_data.renderer = m_emu_settings->GetSetting(emu_settings::Renderer);
+		title_data.vulkan_adapter = m_emu_settings->GetSetting(emu_settings::VulkanAdapter);
 		title_data.fps = 60.;
 
 		if (game)
@@ -1431,7 +1430,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			return tr("Glossary:\n\n%0\nPreview:\n\n%1\n").arg(glossary).arg(game_window_title);
 		};
 
-		const std::string game_title_format = xemu_settings->GetSetting(emu_settings::WindowTitleFormat);
+		const std::string game_title_format = m_emu_settings->GetSetting(emu_settings::WindowTitleFormat);
 
 		QString edited_format = qstr(game_title_format);
 
@@ -1446,20 +1445,20 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 		if (dlg.exec() == QDialog::Accepted)
 		{
-			xemu_settings->SetSetting(emu_settings::WindowTitleFormat, sstr(edited_format));
-			set_game_window_title(xemu_settings->GetSetting(emu_settings::WindowTitleFormat));
+			m_emu_settings->SetSetting(emu_settings::WindowTitleFormat, sstr(edited_format));
+			set_game_window_title(m_emu_settings->GetSetting(emu_settings::WindowTitleFormat));
 		}
 	});
 
 	connect(ui->reset_button_game_window_title_format, &QAbstractButton::clicked, [=, this]()
 	{
-		const std::string default_game_title_format = xemu_settings->GetSettingDefault(emu_settings::WindowTitleFormat);
-		xemu_settings->SetSetting(emu_settings::WindowTitleFormat, default_game_title_format);
+		const std::string default_game_title_format = m_emu_settings->GetSettingDefault(emu_settings::WindowTitleFormat);
+		m_emu_settings->SetSetting(emu_settings::WindowTitleFormat, default_game_title_format);
 		set_game_window_title(default_game_title_format);
 	});
 
 	// Load and apply the configured game window title format
-	set_game_window_title(xemu_settings->GetSetting(emu_settings::WindowTitleFormat));
+	set_game_window_title(m_emu_settings->GetSetting(emu_settings::WindowTitleFormat));
 
 	SubscribeTooltip(ui->gb_game_window_title, tooltips.settings.game_window_title_format);
 
@@ -1519,20 +1518,20 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		SubscribeTooltip(ui->log_limit, tooltips.settings.log_limit);
 		SubscribeTooltip(ui->tty_limit, tooltips.settings.tty_limit);
 
-		ui->spinbox_log_limit->setValue(xgui_settings->GetValue(gui::l_limit).toInt());
+		ui->spinbox_log_limit->setValue(m_gui_settings->GetValue(gui::l_limit).toInt());
 		connect(ui->spinbox_log_limit, &QSpinBox::editingFinished, [=, this]()
 		{
-			xgui_settings->SetValue(gui::l_limit, ui->spinbox_log_limit->value());
+			m_gui_settings->SetValue(gui::l_limit, ui->spinbox_log_limit->value());
 		});
 
-		ui->spinbox_tty_limit->setValue(xgui_settings->GetValue(gui::l_limit_tty).toInt());
+		ui->spinbox_tty_limit->setValue(m_gui_settings->GetValue(gui::l_limit_tty).toInt());
 		connect(ui->spinbox_tty_limit, &QSpinBox::editingFinished, [=, this]()
 		{
-			xgui_settings->SetValue(gui::l_limit_tty, ui->spinbox_tty_limit->value());
+			m_gui_settings->SetValue(gui::l_limit_tty, ui->spinbox_tty_limit->value());
 		});
 
 		// colorize preview icons
-		auto addColoredIcon = [&](QPushButton *button, const QColor& color, const QIcon& icon = QIcon(), const QColor& iconColor = QColor())
+		auto add_colored_icon = [&](QPushButton *button, const QColor& color, const QIcon& icon = QIcon(), const QColor& iconColor = QColor())
 		{
 			QLabel* text = new QLabel(button->text());
 			text->setObjectName("color_button");
@@ -1556,33 +1555,32 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			button->layout()->addWidget(text);
 		};
 
-		auto AddColoredIcons = [=, this]()
+		auto add_colored_icons = [=, this]()
 		{
-			addColoredIcon(ui->pb_gl_icon_color, xgui_settings->GetValue(gui::gl_iconColor).value<QColor>());
-			addColoredIcon(ui->pb_sd_icon_color, xgui_settings->GetValue(gui::sd_icon_color).value<QColor>());
-			addColoredIcon(ui->pb_tr_icon_color, xgui_settings->GetValue(gui::tr_icon_color).value<QColor>());
+			add_colored_icon(ui->pb_gl_icon_color, m_gui_settings->GetValue(gui::gl_iconColor).value<QColor>());
+			add_colored_icon(ui->pb_sd_icon_color, m_gui_settings->GetValue(gui::sd_icon_color).value<QColor>());
+			add_colored_icon(ui->pb_tr_icon_color, m_gui_settings->GetValue(gui::tr_icon_color).value<QColor>());
 		};
-		AddColoredIcons();
+		add_colored_icons();
 
-		ui->cb_show_welcome->setChecked(xgui_settings->GetValue(gui::ib_show_welcome).toBool());
-		ui->cb_show_exit_game->setChecked(xgui_settings->GetValue(gui::ib_confirm_exit).toBool());
-		ui->cb_show_boot_game->setChecked(xgui_settings->GetValue(gui::ib_confirm_boot).toBool());
-		ui->cb_show_pkg_install->setChecked(xgui_settings->GetValue(gui::ib_pkg_success).toBool());
-		ui->cb_show_pup_install->setChecked(xgui_settings->GetValue(gui::ib_pup_success).toBool());
+		ui->cb_show_welcome->setChecked(m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
+		ui->cb_show_exit_game->setChecked(m_gui_settings->GetValue(gui::ib_confirm_exit).toBool());
+		ui->cb_show_boot_game->setChecked(m_gui_settings->GetValue(gui::ib_confirm_boot).toBool());
+		ui->cb_show_pkg_install->setChecked(m_gui_settings->GetValue(gui::ib_pkg_success).toBool());
+		ui->cb_show_pup_install->setChecked(m_gui_settings->GetValue(gui::ib_pup_success).toBool());
 
-		ui->cb_check_update_start->setChecked(xgui_settings->GetValue(gui::m_check_upd_start).toBool());
+		ui->cb_check_update_start->setChecked(m_gui_settings->GetValue(gui::m_check_upd_start).toBool());
 
-		bool enableUIColors = xgui_settings->GetValue(gui::m_enableUIColors).toBool();
-		ui->cb_custom_colors->setChecked(enableUIColors);
-		ui->pb_gl_icon_color->setEnabled(enableUIColors);
-		ui->pb_sd_icon_color->setEnabled(enableUIColors);
-		ui->pb_tr_icon_color->setEnabled(enableUIColors);
+		const bool enable_ui_colors = m_gui_settings->GetValue(gui::m_enableUIColors).toBool();
+		ui->cb_custom_colors->setChecked(enable_ui_colors);
+		ui->pb_gl_icon_color->setEnabled(enable_ui_colors);
+		ui->pb_sd_icon_color->setEnabled(enable_ui_colors);
+		ui->pb_tr_icon_color->setEnabled(enable_ui_colors);
 
-		auto ApplyGuiOptions = [&](bool reset = false)
+		auto apply_gui_options = [&](bool reset = false)
 		{
 			if (reset)
 			{
-				m_current_gui_config = gui::Default;
 				m_current_stylesheet = gui::Default;
 				ui->combo_configs->setCurrentIndex(0);
 				ui->combo_stylesheets->setCurrentIndex(0);
@@ -1592,7 +1590,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			{
 				OnApplyConfig();
 			}
-			if (m_current_stylesheet != xgui_settings->GetValue(gui::m_currentStylesheet).toString())
+			if (m_current_stylesheet != m_gui_settings->GetValue(gui::m_currentStylesheet).toString())
 			{
 				OnApplyStylesheet();
 			}
@@ -1600,7 +1598,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 		connect(ui->buttonBox, &QDialogButtonBox::accepted, [=, this]()
 		{
-			ApplyGuiOptions();
+			apply_gui_options();
 		});
 
 		connect(ui->pb_reset_default, &QAbstractButton::clicked, [=, this]
@@ -1608,13 +1606,13 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			if (QMessageBox::question(this, tr("Reset GUI to default?"), tr("This will include your stylesheet as well. Do you wish to proceed?"),
 				QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)
 			{
-				ApplyGuiOptions(true);
-				xgui_settings->Reset(true);
-				xgui_settings->ChangeToConfig(gui::Default);
+				apply_gui_options(true);
+				m_gui_settings->Reset(true);
+				m_gui_settings->ChangeToConfig(gui::Default);
 				Q_EMIT GuiSettingsSyncRequest(true);
 				AddConfigs();
 				AddStylesheets();
-				AddColoredIcons();
+				apply_gui_options();
 			}
 		});
 
@@ -1624,75 +1622,75 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 		connect(ui->pb_open_folder, &QAbstractButton::clicked, [=, this]()
 		{
-			QDesktopServices::openUrl(xgui_settings->GetSettingsDir());
+			QDesktopServices::openUrl(m_gui_settings->GetSettingsDir());
 		});
 
 		connect(ui->cb_show_welcome, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::ib_show_welcome, val);
+			m_gui_settings->SetValue(gui::ib_show_welcome, val);
 		});
 		connect(ui->cb_show_exit_game, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::ib_confirm_exit, val);
+			m_gui_settings->SetValue(gui::ib_confirm_exit, val);
 		});
 		connect(ui->cb_show_boot_game, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::ib_confirm_boot, val);
+			m_gui_settings->SetValue(gui::ib_confirm_boot, val);
 		});
 		connect(ui->cb_show_pkg_install, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::ib_pkg_success, val);
+			m_gui_settings->SetValue(gui::ib_pkg_success, val);
 		});
 		connect(ui->cb_show_pup_install, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::ib_pup_success, val);
+			m_gui_settings->SetValue(gui::ib_pup_success, val);
 		});
 		connect(ui->cb_check_update_start, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::m_check_upd_start, val);
+			m_gui_settings->SetValue(gui::m_check_upd_start, val);
 		});
 
 		connect(ui->cb_custom_colors, &QCheckBox::clicked, [=, this](bool val)
 		{
-			xgui_settings->SetValue(gui::m_enableUIColors, val);
+			m_gui_settings->SetValue(gui::m_enableUIColors, val);
 			ui->pb_gl_icon_color->setEnabled(val);
 			ui->pb_sd_icon_color->setEnabled(val);
 			ui->pb_tr_icon_color->setEnabled(val);
 			Q_EMIT GuiRepaintRequest();
 		});
-		auto colorDialog = [&](const gui_save& color, const QString& title, QPushButton *button)
+		auto color_dialog = [&](const gui_save& color, const QString& title, QPushButton *button)
 		{
-			QColor oldColor = xgui_settings->GetValue(color).value<QColor>();
-			QColorDialog dlg(oldColor, this);
+			const QColor old_color = m_gui_settings->GetValue(color).value<QColor>();
+			QColorDialog dlg(old_color, this);
 			dlg.setWindowTitle(title);
 			dlg.setOptions(QColorDialog::ShowAlphaChannel);
 			for (int i = 0; i < dlg.customCount(); i++)
 			{
-				dlg.setCustomColor(i, xgui_settings->GetCustomColor(i));
+				dlg.setCustomColor(i, m_gui_settings->GetCustomColor(i));
 			}
 			if (dlg.exec() == QColorDialog::Accepted)
 			{
 				for (int i = 0; i < dlg.customCount(); i++)
 				{
-					xgui_settings->SetCustomColor(i, dlg.customColor(i));
+					m_gui_settings->SetCustomColor(i, dlg.customColor(i));
 				}
-				xgui_settings->SetValue(color, dlg.selectedColor());
-				button->setIcon(gui::utils::get_colorized_icon(button->icon(), oldColor, dlg.selectedColor(), true));
+				m_gui_settings->SetValue(color, dlg.selectedColor());
+				button->setIcon(gui::utils::get_colorized_icon(button->icon(), old_color, dlg.selectedColor(), true));
 				Q_EMIT GuiRepaintRequest();
 			}
 		};
 
 		connect(ui->pb_gl_icon_color, &QAbstractButton::clicked, [=, this]()
 		{
-			colorDialog(gui::gl_iconColor, tr("Choose gamelist icon color"), ui->pb_gl_icon_color);
+			color_dialog(gui::gl_iconColor, tr("Choose gamelist icon color"), ui->pb_gl_icon_color);
 		});
 		connect(ui->pb_sd_icon_color, &QAbstractButton::clicked, [=, this]()
 		{
-			colorDialog(gui::sd_icon_color, tr("Choose save manager icon color"), ui->pb_sd_icon_color);
+			color_dialog(gui::sd_icon_color, tr("Choose save manager icon color"), ui->pb_sd_icon_color);
 		});
 		connect(ui->pb_tr_icon_color, &QAbstractButton::clicked, [=, this]()
 		{
-			colorDialog(gui::tr_icon_color, tr("Choose trophy manager icon color"), ui->pb_tr_icon_color);
+			color_dialog(gui::tr_icon_color, tr("Choose trophy manager icon color"), ui->pb_tr_icon_color);
 		});
 
 		AddConfigs();
@@ -1709,59 +1707,59 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	//                            |___/
 
 	// Checkboxes: gpu debug options
-	xemu_settings->EnhanceCheckBox(ui->glLegacyBuffers, emu_settings::LegacyBuffers);
+	m_emu_settings->EnhanceCheckBox(ui->glLegacyBuffers, emu_settings::LegacyBuffers);
 	SubscribeTooltip(ui->glLegacyBuffers, tooltips.settings.gl_legacy_buffers);
 
-	xemu_settings->EnhanceCheckBox(ui->forceHighpZ, emu_settings::ForceHighpZ);
+	m_emu_settings->EnhanceCheckBox(ui->forceHighpZ, emu_settings::ForceHighpZ);
 	SubscribeTooltip(ui->forceHighpZ, tooltips.settings.force_high_pz);
 
-	xemu_settings->EnhanceCheckBox(ui->debugOutput, emu_settings::DebugOutput);
+	m_emu_settings->EnhanceCheckBox(ui->debugOutput, emu_settings::DebugOutput);
 	SubscribeTooltip(ui->debugOutput, tooltips.settings.debug_output);
 
-	xemu_settings->EnhanceCheckBox(ui->debugOverlay, emu_settings::DebugOverlay);
+	m_emu_settings->EnhanceCheckBox(ui->debugOverlay, emu_settings::DebugOverlay);
 	SubscribeTooltip(ui->debugOverlay, tooltips.settings.debug_overlay);
 
-	xemu_settings->EnhanceCheckBox(ui->logProg, emu_settings::LogShaderPrograms);
+	m_emu_settings->EnhanceCheckBox(ui->logProg, emu_settings::LogShaderPrograms);
 	SubscribeTooltip(ui->logProg, tooltips.settings.log_shader_programs);
 
-	xemu_settings->EnhanceCheckBox(ui->disableHwOcclusionQueries, emu_settings::DisableOcclusionQueries);
+	m_emu_settings->EnhanceCheckBox(ui->disableHwOcclusionQueries, emu_settings::DisableOcclusionQueries);
 	SubscribeTooltip(ui->disableHwOcclusionQueries, tooltips.settings.disable_occlusion_queries);
 
-	xemu_settings->EnhanceCheckBox(ui->forceCpuBlitEmulation, emu_settings::ForceCPUBlitEmulation);
+	m_emu_settings->EnhanceCheckBox(ui->forceCpuBlitEmulation, emu_settings::ForceCPUBlitEmulation);
 	SubscribeTooltip(ui->forceCpuBlitEmulation, tooltips.settings.force_cpu_blit_emulation);
 
-	xemu_settings->EnhanceCheckBox(ui->disableVulkanMemAllocator, emu_settings::DisableVulkanMemAllocator);
+	m_emu_settings->EnhanceCheckBox(ui->disableVulkanMemAllocator, emu_settings::DisableVulkanMemAllocator);
 	SubscribeTooltip(ui->disableVulkanMemAllocator, tooltips.settings.disable_vulkan_mem_allocator);
 
-	xemu_settings->EnhanceCheckBox(ui->disableFIFOReordering, emu_settings::DisableFIFOReordering);
+	m_emu_settings->EnhanceCheckBox(ui->disableFIFOReordering, emu_settings::DisableFIFOReordering);
 	SubscribeTooltip(ui->disableFIFOReordering, tooltips.settings.disable_fifo_reordering);
 
-	xemu_settings->EnhanceCheckBox(ui->strictTextureFlushing, emu_settings::StrictTextureFlushing);
+	m_emu_settings->EnhanceCheckBox(ui->strictTextureFlushing, emu_settings::StrictTextureFlushing);
 	SubscribeTooltip(ui->strictTextureFlushing, tooltips.settings.strict_texture_flushing);
 
-	xemu_settings->EnhanceCheckBox(ui->gpuTextureScaling, emu_settings::GPUTextureScaling);
+	m_emu_settings->EnhanceCheckBox(ui->gpuTextureScaling, emu_settings::GPUTextureScaling);
 	SubscribeTooltip(ui->gpuTextureScaling, tooltips.settings.gpu_texture_scaling);
 
 	// Checkboxes: core debug options
-	xemu_settings->EnhanceCheckBox(ui->ppuDebug, emu_settings::PPUDebug);
+	m_emu_settings->EnhanceCheckBox(ui->ppuDebug, emu_settings::PPUDebug);
 	SubscribeTooltip(ui->ppuDebug, tooltips.settings.ppu_debug);
 
-	xemu_settings->EnhanceCheckBox(ui->spuDebug, emu_settings::SPUDebug);
+	m_emu_settings->EnhanceCheckBox(ui->spuDebug, emu_settings::SPUDebug);
 	SubscribeTooltip(ui->spuDebug, tooltips.settings.spu_debug);
 
-	xemu_settings->EnhanceCheckBox(ui->setDAZandFTZ, emu_settings::SetDAZandFTZ);
+	m_emu_settings->EnhanceCheckBox(ui->setDAZandFTZ, emu_settings::SetDAZandFTZ);
 	SubscribeTooltip(ui->setDAZandFTZ, tooltips.settings.set_daz_and_ftz);
 
-	xemu_settings->EnhanceCheckBox(ui->accurateGETLLAR, emu_settings::AccurateGETLLAR);
+	m_emu_settings->EnhanceCheckBox(ui->accurateGETLLAR, emu_settings::AccurateGETLLAR);
 	SubscribeTooltip(ui->accurateGETLLAR, tooltips.settings.accurate_getllar);
 
-	xemu_settings->EnhanceCheckBox(ui->accuratePUTLLUC, emu_settings::AccuratePUTLLUC);
+	m_emu_settings->EnhanceCheckBox(ui->accuratePUTLLUC, emu_settings::AccuratePUTLLUC);
 	SubscribeTooltip(ui->accuratePUTLLUC, tooltips.settings.accurate_putlluc);
 
-	xemu_settings->EnhanceCheckBox(ui->accurateRSXAccess, emu_settings::AccurateRSXAccess);
+	m_emu_settings->EnhanceCheckBox(ui->accurateRSXAccess, emu_settings::AccurateRSXAccess);
 	SubscribeTooltip(ui->accurateRSXAccess, tooltips.settings.accurate_rsx_access);
 
-	xemu_settings->EnhanceCheckBox(ui->hookStFunc, emu_settings::HookStaticFuncs);
+	m_emu_settings->EnhanceCheckBox(ui->hookStFunc, emu_settings::HookStaticFuncs);
 	SubscribeTooltip(ui->hookStFunc, tooltips.settings.hook_static_functions);
 
 	// Layout fix for High Dpi
@@ -1775,7 +1773,7 @@ settings_dialog::~settings_dialog()
 
 void settings_dialog::EnhanceSlider(emu_settings::SettingsType settings_type, QSlider* slider, QLabel* label, const QString& label_text)
 {
-	xemu_settings->EnhanceSlider(slider, settings_type);
+	m_emu_settings->EnhanceSlider(slider, settings_type);
 
 	if (slider && label)
 	{
@@ -1823,7 +1821,7 @@ void settings_dialog::AddConfigs()
 		}
 	}
 
-	m_current_gui_config = xgui_settings->GetValue(gui::m_currentConfig).toString();
+	m_current_gui_config = m_gui_settings->GetValue(gui::m_currentConfig).toString();
 
 	const int index = ui->combo_configs->findText(m_current_gui_config);
 	if (index >= 0)
@@ -1843,7 +1841,7 @@ void settings_dialog::AddStylesheets()
 	ui->combo_stylesheets->addItem(tr("None"), gui::None);
 	ui->combo_stylesheets->addItem(tr("Default (Bright)"), gui::Default);
 
-	for (const QString& entry : xgui_settings->GetStylesheetEntries())
+	for (const QString& entry : m_gui_settings->GetStylesheetEntries())
 	{
 		if (entry != gui::Default)
 		{
@@ -1851,7 +1849,7 @@ void settings_dialog::AddStylesheets()
 		}
 	}
 
-	m_current_stylesheet = xgui_settings->GetValue(gui::m_currentStylesheet).toString();
+	m_current_stylesheet = m_gui_settings->GetValue(gui::m_currentStylesheet).toString();
 
 	const int index = ui->combo_stylesheets->findData(m_current_stylesheet);
 	if (index >= 0)
@@ -1893,7 +1891,7 @@ void settings_dialog::OnBackupCurrentConfig()
 			continue;
 		}
 		Q_EMIT GuiSettingsSaveRequest();
-		xgui_settings->SaveCurrentConfig(gui_config_name);
+		m_gui_settings->SaveCurrentConfig(gui_config_name);
 		ui->combo_configs->addItem(gui_config_name);
 		ui->combo_configs->setCurrentText(gui_config_name);
 		m_current_gui_config = gui_config_name;
@@ -1910,7 +1908,7 @@ void settings_dialog::OnApplyConfig()
 		return;
 	}
 
-	if (!xgui_settings->ChangeToConfig(new_config))
+	if (!m_gui_settings->ChangeToConfig(new_config))
 	{
 		const int new_config_idx = ui->combo_configs->currentIndex();
 		ui->combo_configs->setCurrentText(m_current_gui_config);
@@ -1925,8 +1923,8 @@ void settings_dialog::OnApplyConfig()
 void settings_dialog::OnApplyStylesheet()
 {
 	m_current_stylesheet = ui->combo_stylesheets->currentData().toString();
-	xgui_settings->SetValue(gui::m_currentStylesheet, m_current_stylesheet);
-	Q_EMIT GuiStylesheetRequest(xgui_settings->GetCurrentStylesheetPath());
+	m_gui_settings->SetValue(gui::m_currentStylesheet, m_current_stylesheet);
+	Q_EMIT GuiStylesheetRequest(m_gui_settings->GetCurrentStylesheetPath());
 }
 
 int settings_dialog::exec()
@@ -1939,7 +1937,7 @@ int settings_dialog::exec()
 	QTimer::singleShot(0, [=, this]{ ui->tab_widget_settings->setCurrentIndex(m_tab_index); });
 
 	// Open a dialog if your config file contained invalid entries
-	QTimer::singleShot(10, [this] { xemu_settings->OpenCorrectionDialog(this); });
+	QTimer::singleShot(10, [this] { m_emu_settings->OpenCorrectionDialog(this); });
 
 	return QDialog::exec();
 }

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -51,9 +51,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	ui->tab_widget_settings->setUsesScrollButtons(false);
 	ui->tab_widget_settings->tabBar()->setObjectName("tab_bar_settings");
 
-	bool showDebugTab = m_gui_settings->GetValue(gui::m_showDebugTab).toBool();
-	m_gui_settings->SetValue(gui::m_showDebugTab, showDebugTab);
-	if (!showDebugTab)
+	const bool show_debug_tab = m_gui_settings->GetValue(gui::m_showDebugTab).toBool();
+	m_gui_settings->SetValue(gui::m_showDebugTab, show_debug_tab);
+	if (!show_debug_tab)
 	{
 		ui->tab_widget_settings->removeTab(9);
 	}
@@ -1902,6 +1902,9 @@ void settings_dialog::OnApplyConfig()
 	{
 		return;
 	}
+
+	// Backup current window states
+	Q_EMIT GuiSettingsSaveRequest();
 
 	if (!m_gui_settings->ChangeToConfig(new_config))
 	{

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1811,14 +1811,9 @@ void settings_dialog::AddConfigs()
 {
 	ui->combo_configs->clear();
 
-	ui->combo_configs->addItem(gui::Default);
-
-	for (const QString& entry : xgui_settings->GetConfigEntries())
+	for (const QString& entry : m_gui_settings->GetConfigEntries())
 	{
-		if (entry != gui::Default)
-		{
-			ui->combo_configs->addItem(entry);
-		}
+		ui->combo_configs->addItem(entry);
 	}
 
 	m_current_gui_config = m_gui_settings->GetValue(gui::m_currentConfig).toString();

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -21,7 +21,7 @@ class settings_dialog : public QDialog
 	Q_OBJECT
 
 public:
-	explicit settings_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, const int& tabIndex = 0, QWidget *parent = 0, const GameInfo *game = nullptr);
+	explicit settings_dialog(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, const int& tab_index = 0, QWidget *parent = 0, const GameInfo *game = nullptr);
 	~settings_dialog();
 	int exec() override;
 Q_SIGNALS:
@@ -39,19 +39,19 @@ private:
 
 	// Snapping of sliders when moved with mouse
 	void SnapSlider(QSlider* slider, int interval);
-	QSlider* m_currentSlider = nullptr;
+	QSlider* m_current_slider = nullptr;
 
 	// Emulator tab
 	void AddConfigs();
 	void AddStylesheets();
-	QString m_currentStylesheet;
-	QString m_currentConfig;
+	QString m_current_stylesheet;
+	QString m_current_gui_config;
 	// Gpu tab
-	QString m_oldRender = "";
+	QString m_old_renderer = "";
 	// Audio tab
 	QComboBox *mics_combo[4];
 
-	int m_tab_Index;
+	int m_tab_index;
 	Ui::settings_dialog *ui;
 	std::shared_ptr<gui_settings> xgui_settings;
 	std::shared_ptr<emu_settings> xemu_settings;

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -53,8 +53,8 @@ private:
 
 	int m_tab_index;
 	Ui::settings_dialog *ui;
-	std::shared_ptr<gui_settings> xgui_settings;
-	std::shared_ptr<emu_settings> xemu_settings;
+	std::shared_ptr<gui_settings> m_gui_settings;
+	std::shared_ptr<emu_settings> m_emu_settings;
 
 	// Discord
 	bool m_use_discord;


### PR DESCRIPTION
#### Settings dialog
- Improve network tab tooltip areas. They were really small.

#### Boot process
-  Adds a missing boot error message dialog that appeared when you tried to restart a game that failed to boot before.

#### Game list/grid
- Fixes a code bug that led to a deselection of the game in the game grid when you booted a game. It was always supposed to keep its current selection.
- Add game title and title id to the tooltips for the play/pause/resume/restart/stop buttons
- The play button's tooltip now actually says "Play" instead of "Start"
- The play button now prefers the current game list/grid selection unless a game was started with "Automatically start games after boot" set to off before.

#### Gui settings
- Removes "default" logic from the gui settings dropdown in the gui tab. When resetting to default, the current file is now changed instead.
- Fixes changing from another gui settings file to the CurrentSettings.ini (It didn't load that file specifically)
- When changing to another gui settings file, we now backup the current gui settings to the currently selected file.

#### Misc
- Rename a lot of variables in a few gui classes
- Minor code improvements that shouldn't affect anything in said files


possibly handles #6083
probably handles #7715