### PR TITLE
Add forgotten error check in sys_spu_thread_group_connect_event

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1262,6 +1262,11 @@ error_code sys_spu_thread_group_connect_event(ppu_thread& ppu, u32 id, u32 eq, u
 		return CELL_EINVAL;
 	}
 
+	if (et == SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE && !(group->type & SYS_SPU_THREAD_GROUP_TYPE_COOPERATE_WITH_SYSTEM))
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto queue = idm::get<lv2_obj, lv2_event_queue>(eq);
 
 	std::lock_guard lock(group->mutex);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2703,6 +2703,12 @@ namespace rsx
 		flip_status = CELL_GCM_DISPLAY_FLIP_STATUS_DONE;
 		m_queued_flip.in_progress = false;
 
+		if (!isHLE)
+		{
+			sys_rsx_context_attribute(0x55555555, 0xFEC, buffer, 0, 0, 0);
+			return;
+		}
+
 		if (flip_handler)
 		{
 			intr_thread->cmd_list
@@ -2714,8 +2720,6 @@ namespace rsx
 
 			thread_ctrl::notify(*intr_thread);
 		}
-
-		sys_rsx_context_attribute(0x55555555, 0xFEC, buffer, 0, 0, 0);
 	}
 
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1433,7 +1433,12 @@ namespace rsx
 
 	void user_command(thread* rsx, u32, u32 arg)
 	{
-		sys_rsx_context_attribute(0x55555555, 0xFEF, 0, arg, 0, 0);
+		if (!rsx->isHLE)
+		{
+			sys_rsx_context_attribute(0x55555555, 0xFEF, 0, arg, 0, 0);
+			return;
+		}
+
 		if (rsx->user_handler)
 		{
 			rsx->intr_thread->cmd_list

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -948,7 +948,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 
 	const bool is_current_running_game = (Emu.IsRunning() || Emu.IsPaused()) && current_game.serial == Emu.GetTitleID();
 
-	QAction* boot = new QAction(gameinfo->hasCustomConfig ? tr(is_current_running_game ? "&Reboot with global configuration" : "&Boot with global configuration") : tr("&Boot"));
+	QAction* boot = new QAction(gameinfo->hasCustomConfig ? tr(is_current_running_game ? "&Reboot with global configuration" : "&Boot with global configuration") : tr(is_current_running_game ? "&Reboot" : "&Boot"));
 	QFont font = boot->font();
 	font.setBold(true);
 


### PR DESCRIPTION
Came from RE.

* Other improvements:
    * Don't call sys_rsx syscalls in HLE cellGcmSys from rsx code. 
    * Show "Reboot" on current running game when there's no config on game context menu.