### PR TITLE
rsx: Rewrite async decompiler

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -413,14 +413,7 @@ void GLFragmentProgram::Delete()
 
 	if (id)
 	{
-		if (Emu.IsStopped())
-		{
-			rsx_log.warning("GLFragmentProgram::Delete(): glDeleteShader(%d) avoided", id);
-		}
-		else
-		{
-			glDeleteShader(id);
-		}
+		glDeleteShader(id);
 		id = 0;
 	}
 }

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -903,6 +903,15 @@ void GLGSRender::on_init_thread()
 
 	m_gl_texture_cache.initialize();
 
+	m_prog_buffer.initialize
+	(
+		[this](void* const& props, const RSXVertexProgram& vp, const RSXFragmentProgram& fp)
+		{
+			// Program was linked or queued for linking
+			m_shaders_cache->store(props, vp, fp);
+		}
+	);
+
 	if (!m_overlay_manager)
 	{
 		m_frame->hide();
@@ -1196,16 +1205,10 @@ bool GLGSRender::load_program()
 
 	void* pipeline_properties = nullptr;
 	m_program = m_prog_buffer.get_graphics_pipeline(current_vertex_program, current_fragment_program, pipeline_properties,
-			!g_cfg.video.disable_asynchronous_shader_compiler).get();
+			!g_cfg.video.disable_asynchronous_shader_compiler, true).get();
 
 	if (m_prog_buffer.check_cache_missed())
 	{
-		if (m_prog_buffer.check_program_linked_flag())
-		{
-			// Program was linked or queued for linking
-			m_shaders_cache->store(pipeline_properties, current_vertex_program, current_fragment_program);
-		}
-
 		// Notify the user with HUD notification
 		if (g_cfg.misc.show_shader_compilation_hint)
 		{

--- a/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
+++ b/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
@@ -86,21 +86,26 @@ struct GLTraits
 	}
 };
 
-class GLProgramBuffer : public program_state_cache<GLTraits>
+struct GLProgramBuffer : public program_state_cache<GLTraits>
 {
-public:
+	GLProgramBuffer() = default;
 
-	u64 get_hash(void*&)
+	void initialize(decompiler_callback_t callback)
+	{
+		notify_pipeline_compiled = callback;
+	}
+
+	u64 get_hash(void* const&)
 	{
 		return 0;
 	}
 
-	u64 get_hash(RSXVertexProgram &prog)
+	u64 get_hash(const RSXVertexProgram &prog)
 	{
 		return program_hash_util::vertex_program_utils::get_vertex_program_ucode_hash(prog);
 	}
 
-	u64 get_hash(RSXFragmentProgram &prog)
+	u64 get_hash(const RSXFragmentProgram &prog)
 	{
 		return program_hash_util::fragment_program_utils::get_fragment_program_ucode_hash(prog);
 	}
@@ -109,7 +114,7 @@ public:
 	void add_pipeline_entry(RSXVertexProgram &vp, RSXFragmentProgram &fp, void* &props, Args&& ...args)
 	{
 		vp.skip_vertex_input_check = true;
-		get_graphics_pipeline(vp, fp, props, false, std::forward<Args>(args)...);
+		get_graphics_pipeline(vp, fp, props, false, false, std::forward<Args>(args)...);
 	}
 
     void preload_programs(RSXVertexProgram &vp, RSXFragmentProgram &fp)
@@ -121,10 +126,5 @@ public:
 	bool check_cache_missed() const
 	{
 		return m_cache_miss_flag;
-	}
-
-	bool check_program_linked_flag() const
-	{
-		return m_program_compiled_flag;
 	}
 };

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -315,14 +315,7 @@ void GLVertexProgram::Delete()
 
 	if (id)
 	{
-		if (Emu.IsStopped())
-		{
-			rsx_log.warning("GLVertexProgram::Delete(): glDeleteShader(%d) avoided", id);
-		}
-		else
-		{
-			glDeleteShader(id);
-		}
+		glDeleteShader(id);
 		id = 0;
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
@@ -186,26 +186,22 @@ struct VKTraits
 
 struct VKProgramBuffer : public program_state_cache<VKTraits>
 {
-	VKProgramBuffer() = default;
-
-	void clear()
+	VKProgramBuffer(decompiler_callback_t callback)
 	{
-		program_state_cache<VKTraits>::clear();
-		m_vertex_shader_cache.clear();
-		m_fragment_shader_cache.clear();
+		notify_pipeline_compiled = callback;
 	}
 
-	u64 get_hash(vk::pipeline_props &props)
+	u64 get_hash(const vk::pipeline_props &props)
 	{
 		return rpcs3::hash_struct<vk::pipeline_props>(props);
 	}
 
-	u64 get_hash(RSXVertexProgram &prog)
+	u64 get_hash(const RSXVertexProgram &prog)
 	{
 		return program_hash_util::vertex_program_utils::get_vertex_program_ucode_hash(prog);
 	}
 
-	u64 get_hash(RSXFragmentProgram &prog)
+	u64 get_hash(const RSXFragmentProgram &prog)
 	{
 		return program_hash_util::fragment_program_utils::get_fragment_program_ucode_hash(prog);
 	}
@@ -214,7 +210,7 @@ struct VKProgramBuffer : public program_state_cache<VKTraits>
 	void add_pipeline_entry(RSXVertexProgram &vp, RSXFragmentProgram &fp, vk::pipeline_props &props, Args&& ...args)
 	{
 		vp.skip_vertex_input_check = true;
-		get_graphics_pipeline(vp, fp, props, false, std::forward<Args>(args)...);
+		get_graphics_pipeline(vp, fp, props, false, false, std::forward<Args>(args)...);
 	}
 
     void preload_programs(RSXVertexProgram &vp, RSXFragmentProgram &fp)
@@ -227,10 +223,5 @@ struct VKProgramBuffer : public program_state_cache<VKTraits>
 	bool check_cache_missed() const
 	{
 		return m_cache_miss_flag;
-	}
-
-	bool check_program_linked_flag() const
-	{
-		return m_program_compiled_flag;
 	}
 };

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -616,7 +616,7 @@ namespace rsx
 			dlg->close();
 		}
 
-		void store(pipeline_storage_type &pipeline, RSXVertexProgram &vp, RSXFragmentProgram &fp)
+		void store(const pipeline_storage_type &pipeline, const RSXVertexProgram &vp, const RSXFragmentProgram &fp)
 		{
 			if (g_cfg.video.disable_on_disk_shader_cache)
 			{
@@ -739,7 +739,7 @@ namespace rsx
 			return std::make_tuple(pipeline, vp, fp);
 		}
 
-		pipeline_data pack(pipeline_storage_type &pipeline, RSXVertexProgram &vp, RSXFragmentProgram &fp)
+		pipeline_data pack(const pipeline_storage_type &pipeline, const RSXVertexProgram &vp, const RSXFragmentProgram &fp)
 		{
 			pipeline_data data_block = {};
 			data_block.pipeline_properties = pipeline;

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -772,7 +772,7 @@ namespace rsx
 	}
 
 	template <int N>
-	void unpack_bitset(std::bitset<N>& block, u64* values)
+	void unpack_bitset(const std::bitset<N>& block, u64* values)
 	{
 		constexpr int count = N / 64;
 		for (int n = 0; n < count; ++n)
@@ -893,7 +893,7 @@ namespace rsx
 
 		simple_array(const std::initializer_list<Ty>& args)
 		{
-			reserve(args.size());
+			reserve(::size32(args));
 
 			for (const auto& arg : args)
 			{


### PR DESCRIPTION
A critical design flaw in the async decompiler made it so that shaders that are used for exactly one draw call per application run (e.g for generating a lookup table or rendering something related to a save file entry, etc) would not get saved to disk. This is because the decompiler relied on pings from the main renderer to send back information about which shaders were ok to store instead of performing all actions by itself.

The new approach is such that the decompiler thread handles everything from the moment it receives the shader request to the saving of contents on disk, which guarantees even a shader used only once will get saved correctly for subsequent runs.

Fixes black screen in RR7 stage 'sunset heights' as well as numerous other glitches reported elsewhere wherein a game only renders correctly if it has async decompiler disabled (Tlou?).
