### PR TITLE
Remove most exception with this simple trick...

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -2,9 +2,11 @@
 #include "BEType.h"
 #include "StrUtil.h"
 #include "cfmt.h"
+#include "util/logs.hpp"
 
 #include <algorithm>
 #include <string_view>
+#include "Thread.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -203,7 +205,7 @@ namespace fmt
 {
 	void raw_error(const char* msg)
 	{
-		throw std::runtime_error{msg};
+		thread_ctrl::emergency_exit(msg);
 	}
 
 	void raw_verify_error(const char* msg, const fmt_type_info* sup, u64 arg)
@@ -236,7 +238,7 @@ namespace fmt
 			out += msg;
 		}
 
-		throw std::runtime_error{out};
+		thread_ctrl::emergency_exit(out);
 	}
 
 	void raw_narrow_error(const char* msg, const fmt_type_info* sup, u64 arg)
@@ -256,14 +258,14 @@ namespace fmt
 			out += msg;
 		}
 
-		throw std::range_error{out};
+		thread_ctrl::emergency_exit(out);
 	}
 
 	void raw_throw_exception(const char* fmt, const fmt_type_info* sup, const u64* args)
 	{
 		std::string out;
 		raw_append(out, fmt, sup, args);
-		throw std::runtime_error{out};
+		thread_ctrl::emergency_exit(out);
 	}
 
 	struct cfmt_src;

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -225,6 +225,9 @@ public:
 		_wait_for(-1, true);
 	}
 
+	// Exit.
+	[[noreturn]] static void emergency_exit(std::string_view reason);
+
 	// Get current thread (may be nullptr)
 	static thread_base* get_current()
 	{

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -305,6 +305,12 @@ bool update_manager::handle_rpcs3(const QByteArray& rpcs3_data, bool /*automatic
 
 	std::string replace_path;
 
+#ifdef _WIN32
+	// Get executable path
+	wchar_t orig_path[32767];
+	GetModuleFileNameW(nullptr, orig_path, sizeof(orig_path) / 2);
+#endif
+
 #ifdef __linux__
 
 	const char* appimage_path = ::getenv("APPIMAGE");
@@ -558,16 +564,13 @@ bool update_manager::handle_rpcs3(const QByteArray& rpcs3_data, bool /*automatic
 	error_free7z();
 	if (res)
 		return false;
-
-	replace_path = Emulator::GetEmuDir() + "rpcs3.exe";
-
 #endif
 
 	m_progress_dialog->close();
 	QMessageBox::information(m_parent, tr("Auto-updater"), tr("Update successful!"));
 
 #ifdef _WIN32
-	int ret = _execl(replace_path.c_str(), replace_path.c_str(), nullptr);
+	int ret = _wexecl(orig_path, orig_path, nullptr);
 #else
 	int ret = execl(replace_path.c_str(), replace_path.c_str(), nullptr);
 #endif


### PR DESCRIPTION
Implement thread_ctrl::emergency_exit (native ExitThread equivalent). Now most "throws" don't throw but instead call this method, including narrow checks and verify(HERE).

Of course, there are problems with it. It doesn't clear RAII objects, only thread_local objects. Need to be careful to not lock any mutexes when using this.