### PR TITLE
Fix settings layout

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -354,6 +354,18 @@
            <item>
             <widget class="QWidget" name="widget_gpu_top" native="true">
              <layout class="QHBoxLayout" name="widget_gpu_top_layout" stretch="1,1">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
               <item>
                <widget class="QGroupBox" name="gb_aspectRatio">
                 <property name="title">


### PR DESCRIPTION
Not sure what happened, but according to Qt Creator the box containing aspect ratio and framelimit suddendly got implict 9 pixel wide margings to all sides.

Before:
![image](https://user-images.githubusercontent.com/19759300/76165020-268ece00-615c-11ea-9a97-416f2c573dd3.png)

After:
![image](https://user-images.githubusercontent.com/19759300/76164971-d152bc80-615b-11ea-88e9-4a36240fa484.png)
