### PR TITLE
cellSaveData: funcFile improvements, some error checks added

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -90,7 +90,10 @@ namespace
 
 vm::gvar<savedata_context> g_savedata_context;
 
-std::mutex g_savedata_mutex;
+struct savedata_mutex
+{
+	semaphore<> mutex;
+};
 
 static std::vector<SaveDataEntry> get_save_entries(const std::string& base_dir, const std::string& prefix)
 {
@@ -150,7 +153,7 @@ static std::vector<SaveDataEntry> get_save_entries(const std::string& base_dir, 
 
 static error_code select_and_delete(ppu_thread& ppu)
 {
-	std::unique_lock lock(g_savedata_mutex, std::try_to_lock);
+	std::unique_lock lock(g_fxo->get<savedata_mutex>()->mutex, std::try_to_lock);
 
 	if (!lock)
 	{
@@ -537,7 +540,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		return {CELL_SAVEDATA_ERROR_PARAM, std::to_string(ecode)};
 	}
 
-	std::unique_lock lock(g_savedata_mutex, std::try_to_lock);
+	std::unique_lock lock(g_fxo->get<savedata_mutex>()->mutex, std::try_to_lock);
 
 	if (!lock)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -107,12 +107,12 @@ static std::vector<SaveDataEntry> get_save_entries(const std::string& base_dir, 
 	// get the saves matching the supplied prefix
 	for (auto&& entry : fs::dir(base_dir))
 	{
-		if (!entry.is_directory || entry.name == "." || entry.name == "..")
+		if (!entry.is_directory || sysutil_check_name_string(entry.name.c_str(), 1, CELL_SAVEDATA_DIRNAME_SIZE) != 0)
 		{
 			continue;
 		}
 
-		if (entry.name.substr(0, prefix.size()) != prefix)
+		if (!entry.name.starts_with(prefix))
 		{
 			continue;
 		}
@@ -591,7 +591,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		// get the saves matching the supplied prefix
 		for (auto&& entry : fs::dir(base_dir))
 		{
-			if (!entry.is_directory || entry.name == "." || entry.name == "..")
+			if (!entry.is_directory || sysutil_check_name_string(entry.name.c_str(), 1, CELL_SAVEDATA_DIRNAME_SIZE) != 0)
 			{
 				continue;
 			}

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -11,6 +11,7 @@
 
 #include "Loader/PSF.h"
 #include "Utilities/StrUtil.h"
+#include "Utilities/span.h"
 
 #include <thread>
 #include <mutex>
@@ -1400,63 +1401,74 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				break;
 			}
 
-			const auto fileName = fileSet->fileName.get_ptr();
+			const char* fileName = fileSet->fileName.get_ptr();
 
-			const auto termpos = std::find(fileName, fileName + CELL_SAVEDATA_FILENAME_SIZE, '\0');
-
-			if (termpos == fileName + CELL_SAVEDATA_FILENAME_SIZE)
+			if (const auto termpos = std::memchr(fileName, '\0', CELL_SAVEDATA_FILENAME_SIZE))
+			{
+				file_path.assign(fileName, static_cast<const char*>(termpos));
+			}
+			else
 			{
 				// ****** sysutil savedata parameter error : 71 ******
 				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "71"};
 				break;
 			}
 
-			char name[10];
-			name[0] = '.';
+			auto dotpos = file_path.find_last_of('.');
 
-			const auto dotpos = std::find_end(fileName, termpos, name, name + 1);
-
-			if (dotpos > fileName + 8 || termpos - dotpos > 4)
+			if (dotpos == umax)
 			{
+				// Point to end of string instead
+				dotpos = file_path.size();
+			}
+
+			if (file_path.empty() || dotpos > 8u || file_path.size() - dotpos > 4u)
+			{
+				cellSaveData.error("savedata_op(): fileSet->fileName is illegal ('%s')", file_path);
+
 				// ****** sysutil savedata parameter error : 70 ******
 				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "70"};
 				break;
 			}
 
-			if (dotpos != fileName)
+			char name[10];
+
+			if (dotpos)
 			{
-				// Reset for filename
-				std::memset(name, 0, 10);
-				std::copy(fileName, dotpos, name);
+				// Copy file name
+				gsl::span dst(name, dotpos + 1);
+				strcpy_trunc(dst, file_path);
 
 				// Allow multiple '.' even though sysutil_check_name_string does not
-				std::replace(name, name + 9, '.', '-');
+				std::replace(name, name + dotpos, '.', '-');
 
 				// Check filename
 				if (sysutil_check_name_string(name, 1, 9) == -1)
 				{
+					cellSaveData.error("savedata_op(): fileSet->fileName is illegal due to file name ('%s')", file_path);
+
 					// ****** sysutil savedata parameter error : 70 ******
 					savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "70"};
 					break;
 				}
 			}
 
-			if (dotpos < termpos - 1)
+			if (file_path.size() > dotpos + 1)
 			{
-				// Reset for file extension
-				std::memset(name, 0, 5);
-				std::copy(dotpos + 1, termpos, name);
+				// Copy file extension
+				gsl::span dst(name, file_path.size() - dotpos);
+				strcpy_trunc(dst, file_path.operator std::string_view().substr(dotpos + 1));
 
 				// Check file extension
 				if (sysutil_check_name_string(name, 1, 4) == -1)
 				{
+					cellSaveData.error("savedata_op(): fileSet->fileName is illegal due to file extension ('%s')", file_path);
+
 					// ****** sysutil savedata parameter error : 70 ******
 					savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "70"};
 					break;
 				}
 			}
-
-			file_path = fileName;
 
 			if (type == CELL_SAVEDATA_FILETYPE_SECUREFILE)
 			{
@@ -1500,8 +1512,6 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		}
 
 		psf.emplace("*" + file_path, fileSet->fileType == CELL_SAVEDATA_FILETYPE_SECUREFILE);
-
-		const u32 access_size = std::min<u32>(fileSet->fileSize, fileSet->fileBufSize);
 
 		// clang-format off
 		auto add_to_blist = [&](const std::string& to_add)
@@ -1558,7 +1568,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Read from memory file to vm
 			const u64 sr = file.seek(fileSet->fileOffset);
-			const u64 rr = lv2_file::op_read(file, fileSet->fileBuf, access_size);
+			const u64 rr = lv2_file::op_read(file, fileSet->fileBuf, fileSet->fileSize);
 			fileGet->excSize = ::narrow<u32>(rr);
 			break;
 		}
@@ -1593,7 +1603,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Write to memory file and truncate
 			const u64 sr = file.seek(fileSet->fileOffset);
-			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, access_size);
+			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, fileSet->fileSize);
 			file.trunc(sr + wr);
 			fileGet->excSize = ::narrow<u32>(wr);
 			all_times.erase(file_path);
@@ -1644,7 +1654,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Write to memory file normally
 			const u64 sr = file.seek(fileSet->fileOffset);
-			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, access_size);
+			const u64 wr = lv2_file::op_write(file, fileSet->fileBuf, fileSet->fileSize);
 			fileGet->excSize = ::narrow<u32>(wr);
 			all_times.erase(file_path);
 			add_to_blist(file_path);


### PR DESCRIPTION
* Add more logging, simplify code to use std::string subfunctions and strcpy_trunc and add one more error condition.
* Allow '_' at filenames start and extension.
* Check if reading offset is valid, fix error code to CELL_SAVEDATA_ERROR_FAILURE.
* Don't create empty file on error of write ops.
* Don't allow "." and ".." filenames on funcFile, return CELL_SAVEDATA_ERROR_BROKEN.
* Check listSet->fixedListNum.
* Check listSet->fixedList, listSet->focusDirName,  listSet->newData->dirName for nullptr and its directory items names.
* Check listSet->newData->iconPosition.
* Check statSet->setParam->parental_level for old sdk.
* Return an error if listSet->focusPosition is NEWDATA and listSet->newData is nullptr.
* Simplify savedata directory list selection.
* Fixed savedata lock after fmt::throw_exception.
* Filter directory lists to allowed savedata directories.

Fixes #7738.