### PR TITLE
rsx capture: Fix regression after #7730

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -304,8 +304,8 @@ namespace rsx
 		};
 
 		m_rtts_dirty = true;
-		memset(m_textures_dirty, -1, sizeof(m_textures_dirty));
-		memset(m_vertex_textures_dirty, -1, sizeof(m_vertex_textures_dirty));
+		m_textures_dirty.fill(true);
+		m_vertex_textures_dirty.fill(true);
 
 		m_graphics_state = pipeline_state::all_dirty;
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -3,6 +3,7 @@
 #include <deque>
 #include <variant>
 #include <stack>
+#include <atomic>
 
 #include "GCM.h"
 #include "rsx_cache.h"
@@ -26,8 +27,7 @@
 extern u64 get_guest_system_time();
 extern u64 get_system_time();
 
-extern bool user_asked_for_frame_capture;
-extern bool capture_current_frame;
+extern std::atomic<bool> user_asked_for_frame_capture;
 extern rsx::frame_trace_data frame_debug;
 extern rsx::frame_capture_data frame_capture;
 
@@ -717,6 +717,7 @@ namespace rsx
 		vm::ptr<void(u32)> user_handler = vm::null;
 		vm::ptr<void(u32)> vblank_handler = vm::null;
 		atomic_t<u64> vblank_count{0};
+		bool capture_current_frame = false;
 
 	public:
 		bool invalid_command_interrupt_raised = false;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -674,8 +674,8 @@ namespace rsx
 		u32 local_mem_size{0};
 
 		bool m_rtts_dirty;
-		bool m_textures_dirty[16];
-		bool m_vertex_textures_dirty[4];
+		std::array<bool, 16> m_textures_dirty;
+		std::array<bool, 4> m_vertex_textures_dirty;
 		bool m_framebuffer_state_contested = false;
 		rsx::framebuffer_creation_context m_current_framebuffer_context = rsx::framebuffer_creation_context::context_draw;
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -176,7 +176,7 @@ namespace rsx
 		{
 			rsx->clear_surface(arg);
 
-			if (capture_current_frame)
+			if (rsx->capture_current_frame)
 			{
 				rsx->capture_frame("clear");
 			}
@@ -184,7 +184,7 @@ namespace rsx
 
 		void clear_zcull(thread* rsx, u32 _reg, u32 arg)
 		{
-			if (capture_current_frame)
+			if (rsx->capture_current_frame)
 			{
 				rsx->capture_frame("clear zcull memory");
 			}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -282,6 +282,8 @@ void debugger_frame::UpdateUI()
 {
 	UpdateUnitList();
 
+	m_btn_capture->setEnabled(Emu.IsRunning() || Emu.IsPaused());
+
 	if (m_no_thread_selected) return;
 
 	const auto cpu = this->cpu.lock();

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -25,9 +25,10 @@
 #include <QJSEngine>
 #include <QVBoxLayout>
 #include <QTimer>
+#include <atomic>
 
 constexpr auto qstr = QString::fromStdString;
-extern bool user_asked_for_frame_capture;
+extern std::atomic<bool> user_asked_for_frame_capture;
 
 debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *parent)
 	: custom_dock_widget(tr("Debugger"), parent), xgui_settings(settings)


### PR DESCRIPTION
* Fix rsx capture state after fmt::throw_exception.
* Disable capture button if no game is running!
* Fix UB/race in rsx captures. (unprotected variables are read and written concurrently)