### PR TITLE
Fix background game input during overlays

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -116,7 +116,7 @@ struct msg_dlg_thread_info
 						continue;
 					}
 
-					dlg->close();
+					dlg->close(true, true);
 				}
 			}
 			else if (const auto dlg = g_fxo->get<msg_info>()->get())
@@ -463,7 +463,7 @@ error_code cellMsgDialogAbort()
 		if (auto dlg = manager->get<rsx::overlays::message_dialog>())
 		{
 			g_fxo->get<msg_dlg_thread>()->wait_until = 0;
-			dlg->close(false);
+			dlg->close(false, true);
 			return CELL_OK;
 		}
 	}

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
@@ -50,6 +50,6 @@ namespace rsx
 	void shader_loading_dialog_native::close()
 	{
 		dlg->return_code = CELL_OK;
-		dlg->close();
+		dlg->close(false, false);
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -159,7 +159,7 @@ namespace rsx
 			default: return;
 			}
 
-			close();
+			close(true, true);
 		}
 
 		error_code message_dialog::show(bool is_blocking, const std::string& text, const MsgDialogType& type, std::function<void(s32 status)> on_close)

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -23,7 +23,7 @@ namespace rsx
 				}
 
 				visible = false;
-				close();
+				close(true, true);
 			};
 
 			fade_animation.active = true;

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -122,7 +122,7 @@ namespace rsx
 				return_code = m_list->get_selected_index();
 				// Fall through
 			case pad_button::circle:
-				close();
+				close(true, true);
 				break;
 			case pad_button::dpad_up:
 				m_list->select_previous();

--- a/rpcs3/Emu/RSX/Overlays/overlay_shader_compile_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_shader_compile_notification.cpp
@@ -72,7 +72,7 @@ namespace rsx
 		{
 			auto current_time = get_system_time();
 			if (current_time > expire_time)
-				close();
+				close(false, false);
 
 			update_animation(current_time);
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -78,7 +78,7 @@ namespace rsx
 					sliding_animation.on_finish = [this]
 					{
 						s_trophy_semaphore.release();
-						close();
+						close(false, false);
 					};
 
 					sliding_animation.active = true;

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -181,7 +181,7 @@ namespace rsx
 			return 0;
 		}
 
-		void user_interface::close(bool use_callback)
+		void user_interface::close(bool use_callback, bool stop_pad_interception)
 		{
 			// Force unload
 			exit.release(true);
@@ -197,7 +197,10 @@ namespace rsx
 				thread_bits.wait(b);
 			}
 
-			pad::SetIntercepted(false);
+			if (stop_pad_interception)
+			{
+				pad::SetIntercepted(false);
+			}
 
 			if (on_close && use_callback)
 			{

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -90,7 +90,7 @@ namespace rsx
 
 			virtual void on_button_pressed(pad_button /*button_press*/) {}
 
-			void close(bool use_callback = true);
+			void close(bool use_callback, bool stop_pad_interception);
 
 			s32 run_input_loop();
 		};


### PR DESCRIPTION
Closing shader compilation hints and trophy notifications canceled the pad interception during proper dialogs (OSK, save data, message dialog etc.) and led to unexpected user input in the background while navigating said dialogs.

fixes #7711