### PR TITLE
Unnatural fixes

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1912,6 +1912,7 @@ bool thread_base::finalize(int) noexcept
 
 void thread_base::finalize() noexcept
 {
+	atomic_storage_futex::set_wait_callback([](const void*){ return true; });
 	g_tls_log_prefix = []() -> std::string { return {}; };
 	thread_ctrl::g_tls_this_thread = nullptr;
 }
@@ -2091,7 +2092,6 @@ void thread_ctrl::emergency_exit(std::string_view reason)
 			delete _this;
 		}
 
-		// Do some not very useful cleanup
 		thread_base::finalize();
 
 #ifdef _WIN32

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1645,17 +1645,17 @@ void Emulator::Stop(bool restart)
 
 	named_thread stop_watchdog("Stop Watchdog", [&]()
 	{
-		const auto start = std::chrono::steady_clock::now();
-
-		while (thread_ctrl::state() != thread_state::aborting)
+		for (uint i = 0; thread_ctrl::state() != thread_state::aborting; i++)
 		{
-			if (std::chrono::steady_clock::now() - start >= 5s)
+			// We don't need accurate timekeeping, using clocks may interfere with debugging
+			if (i >= 1000)
 			{
+				// Total amount of waiting: about 5s
 				report_fatal_error("Stopping emulator took too long."
 					"\nSome thread has probably deadlocked. Aborting.");
 			}
 
-			thread_ctrl::wait_for(100'000);
+			thread_ctrl::wait_for(5'000);
 		}
 	});
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -271,7 +271,16 @@ int main(int argc, char** argv)
 	// Only run RPCS3 to display an error
 	if (int err_pos = find_arg(arg_error, argc, argv))
 	{
-		report_fatal_error(argv[err_pos + 1]);
+		// Reconstruction of the error from multiple args
+		std::string error;
+		for (int i = err_pos + 1; i < argc; i++)
+		{
+			if (i > err_pos + 1)
+				error += ' ';
+			error += argv[i];
+		}
+
+		report_fatal_error(error);
 	}
 
 	const std::string lock_name = fs::get_cache_dir() + "RPCS3.buf";


### PR DESCRIPTION
* It should fix error dialogs on Windows since it decomposes the arg string.
* Fixes stop watchdog to decrease its interference with the debugging.
* Fixes crash at exit (at least one of) caused by null pointer dereference.