### PR TITLE
vk: Change texture cache memory management for disposed textures

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -137,6 +137,11 @@ namespace vk
 			get_current_eid_scope().m_disposed_images.emplace_back(std::move(img));
 		}
 
+		void dispose(std::unique_ptr<vk::viewable_image>& img)
+		{
+			get_current_eid_scope().m_disposed_images.emplace_back(std::move(img));
+		}
+
 		void dispose(std::unique_ptr<vk::event>& event)
 		{
 			get_current_eid_scope().m_disposed_events.emplace_back(std::move(event));

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -485,8 +485,7 @@ namespace vk
 		{
 			if (tex.is_managed())
 			{
-				m_temporary_memory_size += tex.get_section_size();
-				m_temporary_storage.emplace_back(tex);
+				vk::get_resource_manager()->dispose(tex.get_texture());
 			}
 		}
 


### PR DESCRIPTION
Use global resource manager instead of using the 2-frame hold behavior. Fixes high VRAM usage in some games.

Fixes https://github.com/RPCS3/rpcs3/issues/7424