### PR TITLE
vk: Fix potential MTRSX deadlock in case of a race condition

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -342,7 +342,8 @@ private:
 	enum flush_queue_state : u32
 	{
 		ok = 0,
-		deadlock = 1
+		flushing = 1,
+		deadlock = 2
 	};
 
 private:

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -848,6 +848,12 @@ namespace rsx
 			m_data.fetch_or(static_cast<bitmask_type>(mask));
 		}
 
+		bool test_and_set(T mask)
+		{
+			const auto old = m_data.fetch_or(static_cast<bitmask_type>(mask));
+			return (old & static_cast<bitmask_type>(mask)) != 0;
+		}
+
 		auto clear(T mask)
 		{
 			bitmask_type clear_mask = ~(static_cast<bitmask_type>(mask));


### PR DESCRIPTION
Followup to https://github.com/RPCS3/rpcs3/pull/7766. Fixes a possible race condition between RSX thread and the offloader thread that can cause a recursive submit. Also adds a proper assert if such a condition is ever encountered.