### PR TITLE
cellSaveData/PPU Disasm: Minor fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1648,8 +1648,6 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			break;
 		}
 
-		psf.emplace("*" + file_path, fileSet->fileType == CELL_SAVEDATA_FILETYPE_SECUREFILE);
-
 		// clang-format off
 		auto add_to_blist = [&](const std::string& to_add)
 		{
@@ -1806,6 +1804,11 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		if (savedata_result)
 		{
 			break;
+		}
+
+		if (fileSet->fileOperation != CELL_SAVEDATA_FILEOP_DELETE)
+		{
+			psf.emplace("*" + file_path, fileSet->fileType == CELL_SAVEDATA_FILETYPE_SECUREFILE);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1573,6 +1573,17 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 					name[0] = '-';
 				}
 
+				if ((dotpos >= 5u && std::memcmp(name, "PARAM", 5) == 0) ||
+					(dotpos >= 4u && std::memcmp(name, "ICON", 4) == 0) ||
+					(dotpos >= 3u && std::memcmp(name, "PIC", 3) == 0) ||
+					(dotpos >= 3u && std::memcmp(name, "SND", 3) == 0))
+				{
+					// ****** sysutil savedata parameter error : 70 ******
+					cellSaveData.error("savedata_op(): fileSet->fileName is set to a system file name (%s)", file_path);
+					savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "70"};
+					break;
+				}
+
 				// Check filename
 				if (sysutil_check_name_string(name, 1, 9) == -1)
 				{

--- a/rpcs3/Emu/Cell/PPCDisAsm.h
+++ b/rpcs3/Emu/Cell/PPCDisAsm.h
@@ -13,39 +13,39 @@ protected:
 
 	void DisAsm_V4(const std::string& op, u32 v0, u32 v1, u32 v2, u32 v3)
 	{
-		Write(fmt::format("%s v%d,v%d,v%d,v%d", FixOp(op).c_str(), v0, v1, v2, v3));
+		Write(fmt::format("%s v%d,v%d,v%d,v%d", FixOp(op), v0, v1, v2, v3));
 	}
 	void DisAsm_V3_UIMM(const std::string& op, u32 v0, u32 v1, u32 v2, u32 uimm)
 	{
-		Write(fmt::format("%s v%d,v%d,v%d,%u #%x", FixOp(op).c_str(), v0, v1, v2, uimm, uimm));
+		Write(fmt::format("%s v%d,v%d,v%d,%u #%x", FixOp(op), v0, v1, v2, uimm, uimm));
 	}
 	void DisAsm_V3(const std::string& op, u32 v0, u32 v1, u32 v2)
 	{
-		Write(fmt::format("%s v%d,v%d,v%d", FixOp(op).c_str(), v0, v1, v2));
+		Write(fmt::format("%s v%d,v%d,v%d", FixOp(op), v0, v1, v2));
 	}
 	void DisAsm_V2_UIMM(const std::string& op, u32 v0, u32 v1, u32 uimm)
 	{
-		Write(fmt::format("%s v%d,v%d,%u #%x", FixOp(op).c_str(), v0, v1, uimm, uimm));
+		Write(fmt::format("%s v%d,v%d,%u #%x", FixOp(op), v0, v1, uimm, uimm));
 	}
 	void DisAsm_V2(const std::string& op, u32 v0, u32 v1)
 	{
-		Write(fmt::format("%s v%d,v%d", FixOp(op).c_str(), v0, v1));
+		Write(fmt::format("%s v%d,v%d", FixOp(op), v0, v1));
 	}
 	void DisAsm_V1_SIMM(const std::string& op, u32 v0, s32 simm)
 	{
-		Write(fmt::format("%s v%d,%d #%x", FixOp(op).c_str(), v0, simm, simm));
+		Write(fmt::format("%s v%d,%d #%x", FixOp(op), v0, simm, simm));
 	}
 	void DisAsm_V1(const std::string& op, u32 v0)
 	{
-		Write(fmt::format("%s v%d", FixOp(op).c_str(), v0));
+		Write(fmt::format("%s v%d", FixOp(op), v0));
 	}
 	void DisAsm_V1_R2(const std::string& op, u32 v0, u32 r1, u32 r2)
 	{
-		Write(fmt::format("%s v%d,r%d,r%d", FixOp(op).c_str(), v0, r1, r2));
+		Write(fmt::format("%s v%d,r%d,r%d", FixOp(op), v0, r1, r2));
 	}
 	void DisAsm_CR1_F2_RC(const std::string& op, u32 cr0, u32 f0, u32 f1, u32 rc)
 	{
-		Write(fmt::format("%s%s cr%d,f%d,f%d", FixOp(op).c_str(), (rc ? "." : ""), cr0, f0, f1));
+		Write(fmt::format("%s%s cr%d,f%d,f%d", FixOp(op), (rc ? "." : ""), cr0, f0, f1));
 	}
 	void DisAsm_CR1_F2(const std::string& op, u32 cr0, u32 f0, u32 f1)
 	{
@@ -53,15 +53,15 @@ protected:
 	}
 	void DisAsm_INT1_R2(const std::string& op, u32 i0, u32 r0, u32 r1)
 	{
-		Write(fmt::format("%s %d,r%d,r%d", FixOp(op).c_str(), i0, r0, r1));
+		Write(fmt::format("%s %d,r%d,r%d", FixOp(op), i0, r0, r1));
 	}
 	void DisAsm_INT1_R1_IMM(const std::string& op, u32 i0, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s %d,r%d,%d #%x", FixOp(op).c_str(), i0, r0, imm0, imm0));
+		Write(fmt::format("%s %d,r%d,%d #%x", FixOp(op), i0, r0, imm0, imm0));
 	}
 	void DisAsm_INT1_R1_RC(const std::string& op, u32 i0, u32 r0, u32 rc)
 	{
-		Write(fmt::format("%s%s %d,r%d", FixOp(op).c_str(), (rc ? "." : ""), i0, r0));
+		Write(fmt::format("%s%s %d,r%d", FixOp(op), (rc ? "." : ""), i0, r0));
 	}
 	void DisAsm_INT1_R1(const std::string& op, u32 i0, u32 r0)
 	{
@@ -69,11 +69,11 @@ protected:
 	}
 	void DisAsm_F4_RC(const std::string& op, u32 f0, u32 f1, u32 f2, u32 f3, u32 rc)
 	{
-		Write(fmt::format("%s%s f%d,f%d,f%d,f%d", FixOp(op).c_str(), (rc ? "." : ""), f0, f1, f2, f3));
+		Write(fmt::format("%s%s f%d,f%d,f%d,f%d", FixOp(op), (rc ? "." : ""), f0, f1, f2, f3));
 	}
 	void DisAsm_F3_RC(const std::string& op, u32 f0, u32 f1, u32 f2, u32 rc)
 	{
-		Write(fmt::format("%s%s f%d,f%d,f%d", FixOp(op).c_str(), (rc ? "." : ""), f0, f1, f2));
+		Write(fmt::format("%s%s f%d,f%d,f%d", FixOp(op), (rc ? "." : ""), f0, f1, f2));
 	}
 	void DisAsm_F3(const std::string& op, u32 f0, u32 f1, u32 f2)
 	{
@@ -81,7 +81,7 @@ protected:
 	}
 	void DisAsm_F2_RC(const std::string& op, u32 f0, u32 f1, u32 rc)
 	{
-		Write(fmt::format("%s%s f%d,f%d", FixOp(op).c_str(), (rc ? "." : ""), f0, f1));
+		Write(fmt::format("%s%s f%d,f%d", FixOp(op), (rc ? "." : ""), f0, f1));
 	}
 	void DisAsm_F2(const std::string& op, u32 f0, u32 f1)
 	{
@@ -91,21 +91,21 @@ protected:
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s f%d,r%d,r%d", FixOp(op).c_str(), f0, r0, r1));
+			Write(fmt::format("%s f%d,r%d,r%d", FixOp(op), f0, r0, r1));
 			return;
 		}
 
-		Write(fmt::format("%s f%d,r%d(r%d)", FixOp(op).c_str(), f0, r0, r1));
+		Write(fmt::format("%s f%d,r%d(r%d)", FixOp(op), f0, r0, r1));
 	}
 	void DisAsm_F1_IMM_R1_RC(const std::string& op, u32 f0, s32 imm0, u32 r0, u32 rc)
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s%s f%d,r%d,%d #%x", FixOp(op).c_str(), (rc ? "." : ""), f0, r0, imm0, imm0));
+			Write(fmt::format("%s%s f%d,r%d,%d #%x", FixOp(op), (rc ? "." : ""), f0, r0, imm0, imm0));
 			return;
 		}
 
-		Write(fmt::format("%s%s f%d,%d(r%d) #%x", FixOp(op).c_str(), (rc ? "." : ""), f0, imm0, r0, imm0));
+		Write(fmt::format("%s%s f%d,%d(r%d) #%x", FixOp(op), (rc ? "." : ""), f0, imm0, r0, imm0));
 	}
 	void DisAsm_F1_IMM_R1(const std::string& op, u32 f0, s32 imm0, u32 r0)
 	{
@@ -113,11 +113,11 @@ protected:
 	}
 	void DisAsm_F1_RC(const std::string& op, u32 f0, u32 rc)
 	{
-		Write(fmt::format("%s%s f%d", FixOp(op).c_str(), (rc ? "." : ""), f0));
+		Write(fmt::format("%s%s f%d", FixOp(op), (rc ? "." : ""), f0));
 	}
 	void DisAsm_R1_RC(const std::string& op, u32 r0, u32 rc)
 	{
-		Write(fmt::format("%s%s r%d", FixOp(op).c_str(), (rc ? "." : ""), r0));
+		Write(fmt::format("%s%s r%d", FixOp(op), (rc ? "." : ""), r0));
 	}
 	void DisAsm_R1(const std::string& op, u32 r0)
 	{
@@ -125,7 +125,7 @@ protected:
 	}
 	void DisAsm_R2_OE_RC(const std::string& op, u32 r0, u32 r1, u32 oe, u32 rc)
 	{
-		Write(fmt::format("%s%s%s r%d,r%d", FixOp(op).c_str(), (oe ? "o" : ""), (rc ? "." : ""), r0, r1));
+		Write(fmt::format("%s%s%s r%d,r%d", FixOp(op), (oe ? "o" : ""), (rc ? "." : ""), r0, r1));
 	}
 	void DisAsm_R2_RC(const std::string& op, u32 r0, u32 r1, u32 rc)
 	{
@@ -137,11 +137,11 @@ protected:
 	}
 	void DisAsm_R3_OE_RC(const std::string& op, u32 r0, u32 r1, u32 r2, u32 oe, u32 rc)
 	{
-		Write(fmt::format("%s%s%s r%d,r%d,r%d", FixOp(op).c_str(), (oe ? "o" : ""), (rc ? "." : ""), r0, r1, r2));
+		Write(fmt::format("%s%s%s r%d,r%d,r%d", FixOp(op), (oe ? "o" : ""), (rc ? "." : ""), r0, r1, r2));
 	}
 	void DisAsm_R3_INT2_RC(const std::string& op, u32 r0, u32 r1, u32 r2, s32 i0, s32 i1, u32 rc)
 	{
-		Write(fmt::format("%s%s r%d,r%d,r%d,%d,%d", FixOp(op).c_str(), (rc ? "." : ""), r0, r1, r2, i0, i1));
+		Write(fmt::format("%s%s r%d,r%d,r%d,%d,%d", FixOp(op), (rc ? "." : ""), r0, r1, r2, i0, i1));
 	}
 	void DisAsm_R3_RC(const std::string& op, u32 r0, u32 r1, u32 r2, u32 rc)
 	{
@@ -153,7 +153,7 @@ protected:
 	}
 	void DisAsm_R2_INT3_RC(const std::string& op, u32 r0, u32 r1, s32 i0, s32 i1, s32 i2, u32 rc)
 	{
-		Write(fmt::format("%s%s r%d,r%d,%d,%d,%d", FixOp(op).c_str(), (rc ? "." : ""), r0, r1, i0, i1, i2));
+		Write(fmt::format("%s%s r%d,r%d,%d,%d,%d", FixOp(op), (rc ? "." : ""), r0, r1, i0, i1, i2));
 	}
 	void DisAsm_R2_INT3(const std::string& op, u32 r0, u32 r1, s32 i0, s32 i1, s32 i2)
 	{
@@ -161,7 +161,7 @@ protected:
 	}
 	void DisAsm_R2_INT2_RC(const std::string& op, u32 r0, u32 r1, s32 i0, s32 i1, u32 rc)
 	{
-		Write(fmt::format("%s%s r%d,r%d,%d,%d", FixOp(op).c_str(), (rc ? "." : ""), r0, r1, i0, i1));
+		Write(fmt::format("%s%s r%d,r%d,%d,%d", FixOp(op), (rc ? "." : ""), r0, r1, i0, i1));
 	}
 	void DisAsm_R2_INT2(const std::string& op, u32 r0, u32 r1, s32 i0, s32 i1)
 	{
@@ -169,7 +169,7 @@ protected:
 	}
 	void DisAsm_R2_INT1_RC(const std::string& op, u32 r0, u32 r1, s32 i0, u32 rc)
 	{
-		Write(fmt::format("%s%s r%d,r%d,%d", FixOp(op).c_str(), (rc ? "." : ""), r0, r1, i0));
+		Write(fmt::format("%s%s r%d,r%d,%d", FixOp(op), (rc ? "." : ""), r0, r1, i0));
 	}
 	void DisAsm_R2_INT1(const std::string& op, u32 r0, u32 r1, s32 i0)
 	{
@@ -179,27 +179,27 @@ protected:
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s r%d,r%d,%d  #%x", FixOp(op).c_str(), r0, r1, imm0, imm0));
+			Write(fmt::format("%s r%d,r%d,%d  #%x", FixOp(op), r0, r1, imm0, imm0));
 			return;
 		}
 
-		Write(fmt::format("%s r%d,%d(r%d)  #%x", FixOp(op).c_str(), r0, imm0, r1, imm0));
+		Write(fmt::format("%s r%d,%d(r%d)  #%x", FixOp(op), r0, imm0, r1, imm0));
 	}
 	void DisAsm_R1_IMM(const std::string& op, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s r%d,%d  #%x", FixOp(op).c_str(), r0, imm0, imm0));
+		Write(fmt::format("%s r%d,%d  #%x", FixOp(op), r0, imm0, imm0));
 	}
 	void DisAsm_IMM_R1(const std::string& op, s32 imm0, u32 r0)
 	{
-		Write(fmt::format("%s %d,r%d  #%x", FixOp(op).c_str(), imm0, r0, imm0));
+		Write(fmt::format("%s %d,r%d  #%x", FixOp(op), imm0, r0, imm0));
 	}
 	void DisAsm_CR1_R1_IMM(const std::string& op, u32 cr0, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s cr%d,r%d,%d  #%x", FixOp(op).c_str(), cr0, r0, imm0, imm0));
+		Write(fmt::format("%s cr%d,r%d,%d  #%x", FixOp(op), cr0, r0, imm0, imm0));
 	}
 	void DisAsm_CR1_R2_RC(const std::string& op, u32 cr0, u32 r0, u32 r1, u32 rc)
 	{
-		Write(fmt::format("%s%s cr%d,r%d,r%d", FixOp(op).c_str(), (rc ? "." : ""), cr0, r0, r1));
+		Write(fmt::format("%s%s cr%d,r%d,r%d", FixOp(op), (rc ? "." : ""), cr0, r0, r1));
 	}
 	void DisAsm_CR1_R2(const std::string& op, u32 cr0, u32 r0, u32 r1)
 	{
@@ -207,30 +207,30 @@ protected:
 	}
 	void DisAsm_CR2(const std::string& op, u32 cr0, u32 cr1)
 	{
-		Write(fmt::format("%s cr%d,cr%d", FixOp(op).c_str(), cr0, cr1));
+		Write(fmt::format("%s cr%d,cr%d", FixOp(op), cr0, cr1));
 	}
 	void DisAsm_INT3(const std::string& op, const int i0, const int i1, const int i2)
 	{
-		Write(fmt::format("%s %d,%d,%d", FixOp(op).c_str(), i0, i1, i2));
+		Write(fmt::format("%s %d,%d,%d", FixOp(op), i0, i1, i2));
 	}
 	void DisAsm_INT1(const std::string& op, const int i0)
 	{
-		Write(fmt::format("%s %d", FixOp(op).c_str(), i0));
+		Write(fmt::format("%s %d", FixOp(op), i0));
 	}
 	void DisAsm_BRANCH(const std::string& op, const int pc)
 	{
-		Write(fmt::format("%s 0x%x", FixOp(op).c_str(), DisAsmBranchTarget(pc)));
+		Write(fmt::format("%s 0x%x", FixOp(op), DisAsmBranchTarget(pc)));
 	}
 	void DisAsm_BRANCH_A(const std::string& op, const int pc)
 	{
-		Write(fmt::format("%s 0x%x", FixOp(op).c_str(), pc));
+		Write(fmt::format("%s 0x%x", FixOp(op), pc));
 	}
 	void DisAsm_B2_BRANCH(const std::string& op, u32 b0, u32 b1, const int pc)
 	{
-		Write(fmt::format("%s %d,%d,0x%x ", FixOp(op).c_str(), b0, b1, DisAsmBranchTarget(pc)));
+		Write(fmt::format("%s %d,%d,0x%x ", FixOp(op), b0, b1, DisAsmBranchTarget(pc)));
 	}
 	void DisAsm_CR_BRANCH(const std::string& op, u32 cr, const int pc)
 	{
-		Write(fmt::format("%s cr%d,0x%x ", FixOp(op).c_str(), cr, DisAsmBranchTarget(pc)));
+		Write(fmt::format("%s cr%d,0x%x ", FixOp(op), cr, DisAsmBranchTarget(pc)));
 	}
 };

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -948,7 +948,10 @@ void PPUDisAsm::BC(ppu_opcode_t op)
 		return;
 	}
 
-	const auto final = std::string(inst) + (lk ? "l" : "") + (aa ? "a" : "") + sign;
+	std::string final = inst;
+	if (lk) final += 'l';
+	if (aa) final += 'a';
+	if (sign) final += sign;
 
 	// Check if need to display full BI value
 	if (sign == 't' || sign == 'f')
@@ -1043,7 +1046,8 @@ void PPUDisAsm::BCLR(ppu_opcode_t op)
 		return;
 	}
 
-	const auto final = std::string(inst) + (lk ? "lrl" : "lr") + sign;
+	std::string final = std::string(inst) + (lk ? "lrl" : "lr");
+	if (sign) final += sign;
 
 	// Check if need to display full BI value
 	if (sign == 't' || sign == 'f')
@@ -1146,7 +1150,10 @@ void PPUDisAsm::BCCTR(ppu_opcode_t op)
 		return;
 	}
 
-	DisAsm_CR_BRANCH(std::string(inst) + (lk ? "ctrl" : "clr") + sign, bi / 4, bh);
+	std::string final = inst;
+	if (sign) final += sign;
+
+	DisAsm_CR_BRANCH(final, bi / 4, bh);
 }
 
 void PPUDisAsm::RLWIMI(ppu_opcode_t op)

--- a/rpcs3/Emu/Cell/PPUDisAsm.h
+++ b/rpcs3/Emu/Cell/PPUDisAsm.h
@@ -31,39 +31,39 @@ private:
 private:
 	void DisAsm_V4(const std::string& op, u32 v0, u32 v1, u32 v2, u32 v3)
 	{
-		Write(fmt::format("%s v%d,v%d,v%d,v%d", FixOp(op).c_str(), v0, v1, v2, v3));
+		Write(fmt::format("%s v%d,v%d,v%d,v%d", FixOp(op), v0, v1, v2, v3));
 	}
 	void DisAsm_V3_UIMM(const std::string& op, u32 v0, u32 v1, u32 v2, u32 uimm)
 	{
-		Write(fmt::format("%s v%d,v%d,v%d,%u #%x", FixOp(op).c_str(), v0, v1, v2, uimm, uimm));
+		Write(fmt::format("%s v%d,v%d,v%d,%u #%x", FixOp(op), v0, v1, v2, uimm, uimm));
 	}
 	void DisAsm_V3(const std::string& op, u32 v0, u32 v1, u32 v2)
 	{
-		Write(fmt::format("%s v%d,v%d,v%d", FixOp(op).c_str(), v0, v1, v2));
+		Write(fmt::format("%s v%d,v%d,v%d", FixOp(op), v0, v1, v2));
 	}
 	void DisAsm_V2_UIMM(const std::string& op, u32 v0, u32 v1, u32 uimm)
 	{
-		Write(fmt::format("%s v%d,v%d,%u #%x", FixOp(op).c_str(), v0, v1, uimm, uimm));
+		Write(fmt::format("%s v%d,v%d,%u #%x", FixOp(op), v0, v1, uimm, uimm));
 	}
 	void DisAsm_V2(const std::string& op, u32 v0, u32 v1)
 	{
-		Write(fmt::format("%s v%d,v%d", FixOp(op).c_str(), v0, v1));
+		Write(fmt::format("%s v%d,v%d", FixOp(op), v0, v1));
 	}
 	void DisAsm_V1_SIMM(const std::string& op, u32 v0, s32 simm)
 	{
-		Write(fmt::format("%s v%d,%d #%x", FixOp(op).c_str(), v0, simm, simm));
+		Write(fmt::format("%s v%d,%d #%x", FixOp(op), v0, simm, simm));
 	}
 	void DisAsm_V1(const std::string& op, u32 v0)
 	{
-		Write(fmt::format("%s v%d", FixOp(op).c_str(), v0));
+		Write(fmt::format("%s v%d", FixOp(op), v0));
 	}
 	void DisAsm_V1_R2(const std::string& op, u32 v0, u32 r1, u32 r2)
 	{
-		Write(fmt::format("%s v%d,r%d,r%d", FixOp(op).c_str(), v0, r1, r2));
+		Write(fmt::format("%s v%d,r%d,r%d", FixOp(op), v0, r1, r2));
 	}
 	void DisAsm_CR1_F2_RC(const std::string& op, u32 cr0, u32 f0, u32 f1, u32 rc)
 	{
-		Write(fmt::format("%s cr%d,f%d,f%d", FixOp(op + (rc ? "." : "")).c_str(), cr0, f0, f1));
+		Write(fmt::format("%s cr%d,f%d,f%d", FixOp(op + (rc ? "." : "")), cr0, f0, f1));
 	}
 	void DisAsm_CR1_F2(const std::string& op, u32 cr0, u32 f0, u32 f1)
 	{
@@ -71,15 +71,15 @@ private:
 	}
 	void DisAsm_INT1_R2(const std::string& op, u32 i0, u32 r0, u32 r1)
 	{
-		Write(fmt::format("%s %d,r%d,r%d", FixOp(op).c_str(), i0, r0, r1));
+		Write(fmt::format("%s %d,r%d,r%d", FixOp(op), i0, r0, r1));
 	}
 	void DisAsm_INT1_R1_IMM(const std::string& op, u32 i0, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s %d,r%d,%d #%x", FixOp(op).c_str(), i0, r0, imm0, imm0));
+		Write(fmt::format("%s %d,r%d,%d #%x", FixOp(op), i0, r0, imm0, imm0));
 	}
 	void DisAsm_INT1_R1_RC(const std::string& op, u32 i0, u32 r0, u32 rc)
 	{
-		Write(fmt::format("%s %d,r%d", FixOp(op + (rc ? "." : "")).c_str(), i0, r0));
+		Write(fmt::format("%s %d,r%d", FixOp(op + (rc ? "." : "")), i0, r0));
 	}
 	void DisAsm_INT1_R1(const std::string& op, u32 i0, u32 r0)
 	{
@@ -87,11 +87,11 @@ private:
 	}
 	void DisAsm_F4_RC(const std::string& op, u32 f0, u32 f1, u32 f2, u32 f3, u32 rc)
 	{
-		Write(fmt::format("%s f%d,f%d,f%d,f%d", FixOp(op + (rc ? "." : "")).c_str(), f0, f1, f2, f3));
+		Write(fmt::format("%s f%d,f%d,f%d,f%d", FixOp(op + (rc ? "." : "")), f0, f1, f2, f3));
 	}
 	void DisAsm_F3_RC(const std::string& op, u32 f0, u32 f1, u32 f2, u32 rc)
 	{
-		Write(fmt::format("%s f%d,f%d,f%d", FixOp(op + (rc ? "." : "")).c_str(), f0, f1, f2));
+		Write(fmt::format("%s f%d,f%d,f%d", FixOp(op + (rc ? "." : "")), f0, f1, f2));
 	}
 	void DisAsm_F3(const std::string& op, u32 f0, u32 f1, u32 f2)
 	{
@@ -99,7 +99,7 @@ private:
 	}
 	void DisAsm_F2_RC(const std::string& op, u32 f0, u32 f1, u32 rc)
 	{
-		Write(fmt::format("%s f%d,f%d", FixOp(op + (rc ? "." : "")).c_str(), f0, f1));
+		Write(fmt::format("%s f%d,f%d", FixOp(op + (rc ? "." : "")), f0, f1));
 	}
 	void DisAsm_F2(const std::string& op, u32 f0, u32 f1)
 	{
@@ -109,21 +109,21 @@ private:
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s f%d,r%d,r%d", FixOp(op).c_str(), f0, r0, r1));
+			Write(fmt::format("%s f%d,r%d,r%d", FixOp(op), f0, r0, r1));
 			return;
 		}
 
-		Write(fmt::format("%s f%d,r%d(r%d)", FixOp(op).c_str(), f0, r0, r1));
+		Write(fmt::format("%s f%d,r%d(r%d)", FixOp(op), f0, r0, r1));
 	}
 	void DisAsm_F1_IMM_R1_RC(const std::string& op, u32 f0, s32 imm0, u32 r0, u32 rc)
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s f%d,r%d,%d #%x", FixOp(op + (rc ? "." : "")).c_str(), f0, r0, imm0, imm0));
+			Write(fmt::format("%s f%d,r%d,%d #%x", FixOp(op + (rc ? "." : "")), f0, r0, imm0, imm0));
 			return;
 		}
 
-		Write(fmt::format("%s f%d,%d(r%d) #%x", FixOp(op + (rc ? "." : "")).c_str(), f0, imm0, r0, imm0));
+		Write(fmt::format("%s f%d,%d(r%d) #%x", FixOp(op + (rc ? "." : "")), f0, imm0, r0, imm0));
 	}
 	void DisAsm_F1_IMM_R1(const std::string& op, u32 f0, s32 imm0, u32 r0)
 	{
@@ -131,11 +131,11 @@ private:
 	}
 	void DisAsm_F1_RC(const std::string& op, u32 f0, u32 rc)
 	{
-		Write(fmt::format("%s f%d", FixOp(op + (rc ? "." : "")).c_str(), f0));
+		Write(fmt::format("%s f%d", FixOp(op + (rc ? "." : "")), f0));
 	}
 	void DisAsm_R1_RC(const std::string& op, u32 r0, u32 rc)
 	{
-		Write(fmt::format("%s r%d", FixOp(op + (rc ? "." : "")).c_str(), r0));
+		Write(fmt::format("%s r%d", FixOp(op + (rc ? "." : "")), r0));
 	}
 	void DisAsm_R1(const std::string& op, u32 r0)
 	{
@@ -143,7 +143,7 @@ private:
 	}
 	void DisAsm_R2_OE_RC(const std::string& op, u32 r0, u32 r1, u32 _oe, u32 rc)
 	{
-		Write(fmt::format("%s r%d,r%d", FixOp(op + (_oe ? "o" : "") + (rc ? "." : "")).c_str(), r0, r1));
+		Write(fmt::format("%s r%d,r%d", FixOp(op + (_oe ? "o" : "") + (rc ? "." : "")), r0, r1));
 	}
 	void DisAsm_R2_RC(const std::string& op, u32 r0, u32 r1, u32 rc)
 	{
@@ -155,11 +155,11 @@ private:
 	}
 	void DisAsm_R3_OE_RC(const std::string& op, u32 r0, u32 r1, u32 r2, u32 _oe, u32 rc)
 	{
-		Write(fmt::format("%s r%d,r%d,r%d", FixOp(op + (rc ? "." : "") + (_oe ? "o" : "")).c_str(), r0, r1, r2));
+		Write(fmt::format("%s r%d,r%d,r%d", FixOp(op + (rc ? "." : "") + (_oe ? "o" : "")), r0, r1, r2));
 	}
 	void DisAsm_R3_INT2_RC(const std::string& op, u32 r0, u32 r1, u32 r2, s32 i0, s32 i1, u32 rc)
 	{
-		Write(fmt::format("%s r%d,r%d,r%d,%d,%d", FixOp(op + (rc ? "." : "")).c_str(), r0, r1, r2, i0, i1));
+		Write(fmt::format("%s r%d,r%d,r%d,%d,%d", FixOp(op + (rc ? "." : "")), r0, r1, r2, i0, i1));
 	}
 	void DisAsm_R3_RC(const std::string& op, u32 r0, u32 r1, u32 r2, u32 rc)
 	{
@@ -171,7 +171,7 @@ private:
 	}
 	void DisAsm_R2_INT3_RC(const std::string& op, u32 r0, u32 r1, s32 i0, s32 i1, s32 i2, u32 rc)
 	{
-		Write(fmt::format("%s r%d,r%d,%d,%d,%d", FixOp(op + (rc ? "." : "")).c_str(), r0, r1, i0, i1, i2));
+		Write(fmt::format("%s r%d,r%d,%d,%d,%d", FixOp(op + (rc ? "." : "")), r0, r1, i0, i1, i2));
 	}
 	void DisAsm_R2_INT3(const std::string& op, u32 r0, u32 r1, s32 i0, s32 i1, s32 i2)
 	{
@@ -179,7 +179,7 @@ private:
 	}
 	void DisAsm_R2_INT2_RC(const std::string& op, u32 r0, u32 r1, s32 i0, s32 i1, u32 rc)
 	{
-		Write(fmt::format("%s r%d,r%d,%d,%d", FixOp(op + (rc ? "." : "")).c_str(), r0, r1, i0, i1));
+		Write(fmt::format("%s r%d,r%d,%d,%d", FixOp(op + (rc ? "." : "")), r0, r1, i0, i1));
 	}
 	void DisAsm_R2_INT2(const std::string& op, u32 r0, u32 r1, s32 i0, s32 i1)
 	{
@@ -187,7 +187,7 @@ private:
 	}
 	void DisAsm_R2_INT1_RC(const std::string& op, u32 r0, u32 r1, s32 i0, u32 rc)
 	{
-		Write(fmt::format("%s r%d,r%d,%d", FixOp(op + (rc ? "." : "")).c_str(), r0, r1, i0));
+		Write(fmt::format("%s r%d,r%d,%d", FixOp(op + (rc ? "." : "")), r0, r1, i0));
 	}
 	void DisAsm_R2_INT1(const std::string& op, u32 r0, u32 r1, s32 i0)
 	{
@@ -197,27 +197,27 @@ private:
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s r%d,r%d,%d  #%x", FixOp(op).c_str(), r0, r1, imm0, imm0));
+			Write(fmt::format("%s r%d,r%d,%d  #%x", FixOp(op), r0, r1, imm0, imm0));
 			return;
 		}
 
-		Write(fmt::format("%s r%d,%d(r%d)  #%x", FixOp(op).c_str(), r0, imm0, r1, imm0));
+		Write(fmt::format("%s r%d,%d(r%d)  #%x", FixOp(op), r0, imm0, r1, imm0));
 	}
 	void DisAsm_R1_IMM(const std::string& op, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s r%d,%d  #%x", FixOp(op).c_str(), r0, imm0, imm0));
+		Write(fmt::format("%s r%d,%d  #%x", FixOp(op), r0, imm0, imm0));
 	}
 	void DisAsm_IMM_R1(const std::string& op, s32 imm0, u32 r0)
 	{
-		Write(fmt::format("%s %d,r%d  #%x", FixOp(op).c_str(), imm0, r0, imm0));
+		Write(fmt::format("%s %d,r%d  #%x", FixOp(op), imm0, r0, imm0));
 	}
 	void DisAsm_CR1_R1_IMM(const std::string& op, u32 cr0, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s cr%d,r%d,%d  #%x", FixOp(op).c_str(), cr0, r0, imm0, imm0));
+		Write(fmt::format("%s cr%d,r%d,%d  #%x", FixOp(op), cr0, r0, imm0, imm0));
 	}
 	void DisAsm_CR1_R2_RC(const std::string& op, u32 cr0, u32 r0, u32 r1, u32 rc)
 	{
-		Write(fmt::format("%s%s cr%d,r%d,r%d", FixOp(op).c_str(), (rc ? "." : ""), cr0, r0, r1));
+		Write(fmt::format("%s%s cr%d,r%d,r%d", FixOp(op), (rc ? "." : ""), cr0, r0, r1));
 	}
 	void DisAsm_CR1_R2(const std::string& op, u32 cr0, u32 r0, u32 r1)
 	{
@@ -225,56 +225,56 @@ private:
 	}
 	void DisAsm_CR2(const std::string& op, u32 cr0, u32 cr1)
 	{
-		Write(fmt::format("%s cr%d,cr%d", FixOp(op).c_str(), cr0, cr1));
+		Write(fmt::format("%s cr%d,cr%d", FixOp(op), cr0, cr1));
 	}
 	void DisAsm_BI1(const std::string& op, const int i0)
 	{
-		Write(fmt::format("%s cr%d[%s]", FixOp(op).c_str(), i0 / 4, get_partial_BI_field(i0)));
+		Write(fmt::format("%s cr%d[%s]", FixOp(op), i0 / 4, get_partial_BI_field(i0)));
 	}
 	void DisAsm_BI2(const std::string& op, const int i0, const int i1)
 	{
-		Write(fmt::format("%s cr%d[%s],cr%d[%s]", FixOp(op).c_str(), i0 / 4, get_partial_BI_field(i0), i1 / 4, get_partial_BI_field(i1)));
+		Write(fmt::format("%s cr%d[%s],cr%d[%s]", FixOp(op), i0 / 4, get_partial_BI_field(i0), i1 / 4, get_partial_BI_field(i1)));
 	}
 	void DisAsm_BI3(const std::string& op, const int i0, const int i1, const int i2)
 	{
-		Write(fmt::format("%s cr%d[%s],cr%d[%s],cr%d[%s]", FixOp(op).c_str(),
+		Write(fmt::format("%s cr%d[%s],cr%d[%s],cr%d[%s]", FixOp(op),
 		i0 / 4, get_partial_BI_field(i0), i1 / 4, get_partial_BI_field(i1), i2 / 4, get_partial_BI_field(i2)));
 	}
 	void DisAsm_INT3(const std::string& op, const int i0, const int i1, const int i2)
 	{
-		Write(fmt::format("%s %d,%d,%d", FixOp(op).c_str(), i0, i1, i2));
+		Write(fmt::format("%s %d,%d,%d", FixOp(op), i0, i1, i2));
 	}
 	void DisAsm_INT1(const std::string& op, const int i0)
 	{
-		Write(fmt::format("%s %d", FixOp(op).c_str(), i0));
+		Write(fmt::format("%s %d", FixOp(op), i0));
 	}
 	void DisAsm_BRANCH(const std::string& op, const int pc)
 	{
-		Write(fmt::format("%s 0x%x", FixOp(op).c_str(), DisAsmBranchTarget(pc)));
+		Write(fmt::format("%s 0x%x", FixOp(op), DisAsmBranchTarget(pc)));
 	}
 	void DisAsm_BRANCH_A(const std::string& op, const int pc)
 	{
-		Write(fmt::format("%s 0x%x", FixOp(op).c_str(), pc));
+		Write(fmt::format("%s 0x%x", FixOp(op), pc));
 	}
 	void DisAsm_B2_BRANCH(const std::string& op, u32 b0, u32 b1, const int pc)
 	{
-		Write(fmt::format("%s %d,%d,0x%x ", FixOp(op).c_str(), b0, b1, DisAsmBranchTarget(pc)));
+		Write(fmt::format("%s %d,%d,0x%x ", FixOp(op), b0, b1, DisAsmBranchTarget(pc)));
 	}
 	void DisAsm_CR_BRANCH(const std::string& op, u32 cr, const int pc)
 	{
-		Write(fmt::format("%s cr%d,0x%x ", FixOp(op).c_str(), cr, DisAsmBranchTarget(pc)));
+		Write(fmt::format("%s cr%d,0x%x ", FixOp(op), cr, DisAsmBranchTarget(pc)));
 	}
 	void DisAsm_CR_BRANCH_A(const std::string& op, u32 cr, const int pc)
 	{
-		Write(fmt::format("%s cr%d,0x%x ", FixOp(op).c_str(), cr, pc));
+		Write(fmt::format("%s cr%d,0x%x ", FixOp(op), cr, pc));
 	}
 	void DisAsm_BI_BRANCH(const std::string& op, u32 bi, const int pc)
 	{
-		Write(fmt::format("%s cr%d[%s],0x%x ", FixOp(op).c_str(), bi / 4, get_partial_BI_field(bi), DisAsmBranchTarget(pc)));
+		Write(fmt::format("%s cr%d[%s],0x%x ", FixOp(op), bi / 4, get_partial_BI_field(bi), DisAsmBranchTarget(pc)));
 	}
 	void DisAsm_BI_BRANCH_A(const std::string& op, u32 bi, const int pc)
 	{
-		Write(fmt::format("%s cr%d[%s],0x%x ", FixOp(op).c_str(), bi / 4, get_partial_BI_field(bi), pc));
+		Write(fmt::format("%s cr%d[%s],0x%x ", FixOp(op), bi / 4, get_partial_BI_field(bi), pc));
 	}
 	
 public:

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -106,53 +106,53 @@ private:
 	}
 	void DisAsm(std::string op, u32 a1)
 	{
-		Write(fmt::format("%s 0x%x", FixOp(op).c_str(), a1));
+		Write(fmt::format("%s 0x%x", FixOp(op), a1));
 	}
 	void DisAsm(std::string op, const char* a1)
 	{
-		Write(fmt::format("%s %s", FixOp(op).c_str(), a1));
+		Write(fmt::format("%s %s", FixOp(op), a1));
 	}
 	void DisAsm(std::string op, const char* a1, const char* a2)
 	{
-		Write(fmt::format("%s %s,%s", FixOp(op).c_str(), a1, a2));
+		Write(fmt::format("%s %s,%s", FixOp(op), a1, a2));
 	}
 	void DisAsm(std::string op, int a1, const char* a2)
 	{
-		Write(fmt::format("%s 0x%x,%s", FixOp(op).c_str(), a1, a2));
+		Write(fmt::format("%s 0x%x,%s", FixOp(op), a1, a2));
 	}
 	void DisAsm(std::string op, const char* a1, int a2)
 	{
-		Write(fmt::format("%s %s,0x%x", FixOp(op).c_str(), a1, a2));
+		Write(fmt::format("%s %s,0x%x", FixOp(op), a1, a2));
 	}
 	void DisAsm(std::string op, int a1, int a2)
 	{
-		Write(fmt::format("%s 0x%x,0x%x", FixOp(op).c_str(), a1, a2));
+		Write(fmt::format("%s 0x%x,0x%x", FixOp(op), a1, a2));
 	}
 	void DisAsm(std::string op, const char* a1, const char* a2, const char* a3)
 	{
-		Write(fmt::format("%s %s,%s,%s", FixOp(op).c_str(), a1, a2, a3));
+		Write(fmt::format("%s %s,%s,%s", FixOp(op), a1, a2, a3));
 	}
 	void DisAsm(std::string op, const char* a1, int a2, const char* a3)
 	{
-		Write(fmt::format("%s %s,0x%x(%s)", FixOp(op).c_str(), a1, a2, a3));
+		Write(fmt::format("%s %s,0x%x(%s)", FixOp(op), a1, a2, a3));
 	}
 	void DisAsm(std::string op, const char* a1, const char* a2, int a3)
 	{
-		Write(fmt::format("%s %s,%s,0x%x", FixOp(op).c_str(), a1, a2, a3));
+		Write(fmt::format("%s %s,%s,0x%x", FixOp(op), a1, a2, a3));
 	}
 	void DisAsm(std::string op, const char* a1, const char* a2, const char* a3, const char* a4)
 	{
-		Write(fmt::format("%s %s,%s,%s,%s", FixOp(op).c_str(), a1, a2, a3, a4));
+		Write(fmt::format("%s %s,%s,%s,%s", FixOp(op), a1, a2, a3, a4));
 	}
 
-	using field_de_t = decltype(spu_opcode_t{}.de);
+	using field_de_t = decltype(spu_opcode_t::de);
 	void DisAsm(std::string op, field_de_t de, const char* a1)
 	{
-		Write(fmt::format("%s %s", FixOp(op.append(BrIndirectSuffix(de))).c_str(), a1));
+		Write(fmt::format("%s %s", FixOp(op.append(BrIndirectSuffix(de))), a1));
 	}
 	void DisAsm(std::string op, field_de_t de, const char* a1, const char* a2)
 	{
-		Write(fmt::format("%s %s", FixOp(op.append(BrIndirectSuffix(de))).c_str(), a1, a2));
+		Write(fmt::format("%s %s", FixOp(op.append(BrIndirectSuffix(de))), a1, a2));
 	}
 
 public:


### PR DESCRIPTION
* Return ERROR_FAILURE on funcFile deletion failures.
* Fix adding file entries to PARAM.SFO on error after funcFile.
* Do not allow to read/write/delete directly system files (such as PARAM.SFO) in funcFile, return param error 70 in this case.
* PPU Disasm: Fix branches spacing: Null terminator was added at the end which prevented proper spacing.
So now use std::string fmt formatting and avoid adding null terminator in the first place.

before:
![image](https://user-images.githubusercontent.com/18193363/76677855-cc6a8e80-65db-11ea-9efc-c21ff8b10ae9.png)

after:
![image](https://user-images.githubusercontent.com/18193363/76677885-02a80e00-65dc-11ea-830a-8ca9605957e9.png)
