### PR TITLE
PPU Disasm: Fix non-link extended BCCTR forms

### DIFF
--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -1151,7 +1151,7 @@ void PPUDisAsm::BCCTR(ppu_opcode_t op)
 	}
 
 	std::string final = inst;
-	final += lk ? "ctrl"sv : "clr"sv;
+	final += lk ? "ctrl"sv : "ctr"sv;
 	if (sign) final += sign;
 
 	DisAsm_CR_BRANCH(final, bi / 4, bh);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -78,7 +78,7 @@ void fmt_class_string<ppu_join_status>::format(std::string& out, u64 arg)
 		case ppu_join_status::detached: return "detached";
 		case ppu_join_status::zombie: return "zombie";
 		case ppu_join_status::exited: return "exited";
-		case ppu_join_status::max: return "invalid";
+		case ppu_join_status::max: break;
 		}
 
 		return unknown;

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -203,7 +203,7 @@ public:
 	static void stack_pop_verbose(u32 addr, u32 size) noexcept;
 };
 
-static_assert(ppu_join_status::max < ppu_join_status{ppu_thread::id_base});
+static_assert(ppu_join_status::max <= ppu_join_status{ppu_thread::id_base});
 
 template<typename T, typename = void>
 struct ppu_gpr_cast_impl

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -39,7 +39,7 @@ void lv2_int_serv::join()
 	thread_ctrl::notify(*thread);
 	(*thread)();
 
-	idm::remove_verify<named_thread<ppu_thread>>(thread->id, thread);
+	idm::remove_verify<named_thread<ppu_thread>>(thread->id, static_cast<std::weak_ptr<named_thread<ppu_thread>>>(thread));
 }
 
 error_code sys_interrupt_tag_destroy(ppu_thread& ppu, u32 intrtag)

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -60,7 +60,7 @@ void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode)
 			status = ppu_join_status::exited;
 		});
 
-		if (old_status > ppu_join_status::max)
+		if (old_status >= ppu_join_status::max)
 		{
 			lv2_obj::append(idm::check_unlocked<named_thread<ppu_thread>>(static_cast<u32>(old_status)));
 		}
@@ -114,7 +114,7 @@ error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr
 				return CELL_ESRCH;
 			}
 
-			if (value > ppu_join_status::max)
+			if (value >= ppu_join_status::max)
 			{
 				return CELL_EINVAL;
 			}
@@ -191,7 +191,7 @@ error_code sys_ppu_thread_detach(u32 thread_id)
 				return CELL_EINVAL;
 			}
 
-			if (value > ppu_join_status::max)
+			if (value >= ppu_join_status::max)
 			{
 				return CELL_EBUSY;
 			}


### PR DESCRIPTION
At first I thought its some typo I made in #7663 or something, but it actually goes way back to #6722.
Also minor optimization in sys_interrupt to avoid copying a shared ptr, instead use weak ptr. (can't move because its const)
