### PR TITLE
overlays: implement osk panels

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -396,6 +396,7 @@ target_sources(rpcs3_emu PRIVATE
 	RSX/Overlays/overlay_list_view.cpp
 	RSX/Overlays/overlay_message_dialog.cpp
 	RSX/Overlays/overlay_osk.cpp
+	RSX/Overlays/overlay_osk_panel.cpp
 	RSX/Overlays/overlay_perf_metrics.cpp
 	RSX/Overlays/overlay_progress_bar.cpp
 	RSX/Overlays/overlay_save_dialog.cpp

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -1,5 +1,6 @@
 ﻿#include "stdafx.h"
 #include "Emu/System.h"
+#include "Emu/system_config.h"
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/RSX/Overlays/overlay_osk.h"
 #include "Input/pad_thread.h"
@@ -62,8 +63,7 @@ std::shared_ptr<OskDialogBase> _get_osk_dialog(bool create = false)
 
 		if (auto manager = g_fxo->get<rsx::overlays::display_manager>())
 		{
-			auto dlg = std::make_shared<rsx::overlays::osk_latin>();
-
+			std::shared_ptr<rsx::overlays::osk_dialog> dlg = std::make_shared<rsx::overlays::osk_dialog>();
 			osk->dlg = manager->add(dlg);
 		}
 		else
@@ -105,7 +105,9 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 	// Get the OSK options
 	u32 maxLength = (inputFieldInfo->limit_length >= CELL_OSKDIALOG_STRING_SIZE) ? 511 : u32{inputFieldInfo->limit_length};
-	u32 options = dialogParam->prohibitFlgs;
+	const u32 prohibitFlgs = dialogParam->prohibitFlgs;
+	const u32 allowOskPanelFlg = dialogParam->allowOskPanelFlg;
+	const u32 firstViewPanel = dialogParam->firstViewPanel;
 
 	// Get init text and prepare return value
 	osk->osk_input_result = CELL_OSKDIALOG_INPUT_FIELD_RESULT_OK;
@@ -242,7 +244,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 	Emu.CallAfter([=, &result]()
 	{
-		osk->Create("On Screen Keyboard", message, osk->osk_text, maxLength, options);
+		osk->Create("On Screen Keyboard", message, osk->osk_text, maxLength, prohibitFlgs, allowOskPanelFlg, firstViewPanel);
 		result = true;
 	});
 

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -243,7 +243,7 @@ enum class OskDialogState
 class OskDialogBase
 {
 public:
-	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 options) = 0;
+	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) = 0;
 	virtual void Close(bool accepted) = 0;
 	virtual ~OskDialogBase();
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
@@ -66,6 +66,11 @@ namespace rsx
 			{
 				return language_class::hangul;
 			}
+			case 0xFF: // Halfwidth and Fullwidth Forms
+			{
+				// Found in SCE-PS3-SR-R-JPN.TTF, so we'll use cjk_base for now
+				return language_class::cjk_base;
+			}
 			default:
 			{
 				if (codepage_id >= 0xAC && codepage_id <= 0xD7)

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -558,6 +558,11 @@ namespace rsx
 
 		void osk_dialog::on_default_callback(const std::u32string& str)
 		{
+			if (str.empty())
+			{
+				return;
+			}
+
 			// Append to output text
 			if (m_preview.text == get_placeholder())
 			{

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "overlays.h"
+#include "overlay_osk_panel.h"
 #include "Emu/Cell/Modules/cellOskDialog.h"
 
 namespace rsx
@@ -9,8 +10,6 @@ namespace rsx
 	{
 		struct osk_dialog : public user_interface, public OskDialogBase
 		{
-			using callback_t = std::function<void(const std::u32string&)>;
-
 			enum border_flags
 			{
 				top = 1,
@@ -24,44 +23,16 @@ namespace rsx
 				default_cell = top | bottom | left | right
 			};
 
-			enum button_flags
-			{
-				_default = 0,
-				_return = 1,
-				_space = 2,
-				_shift = 3,
-				_mode = 4
-			};
-
-			enum layer_mode : u32
-			{
-				alphanumeric = 0,
-				extended = 1,
-				special = 2,
-
-				mode_count
-			};
-
 			struct cell
 			{
 				position2u pos;
 				color4f backcolor{};
 				border_flags flags = default_cell;
+				button_flags button_flag = button_flags::_default;
 				bool selected = false;
 				bool enabled = false;
 
-				// TODO: change to array with layer_mode::layer_count
 				std::vector<std::vector<std::u32string>> outputs;
-				callback_t callback;
-			};
-
-			struct grid_entry_ctor
-			{
-				// TODO: change to array with layer_mode::layer_count
-				std::vector<std::vector<std::u32string>> outputs;
-				color4f color;
-				u32 num_cell_hz;
-				button_flags type_flags;
 				callback_t callback;
 			};
 
@@ -81,13 +52,16 @@ namespace rsx
 			u32 cell_size_y = 0;
 			u32 num_columns = 0;
 			u32 num_rows = 0;
-			std::vector<u32> num_layers;
+			std::vector<u32> num_shift_layers_by_charset;
 			u32 selected_x = 0;
 			u32 selected_y = 0;
 			u32 selected_z = 0;
-			layer_mode m_selected_mode = layer_mode::alphanumeric;
+			u32 m_selected_charset = 0;
 
 			std::vector<cell> m_grid;
+
+			// Password mode (****)
+			bool m_password_mode = false;
 
 			// Fade in/out
 			animation_color_interpolate fade_animation;
@@ -98,33 +72,37 @@ namespace rsx
 			u32 flags = 0;
 			u32 char_limit = UINT32_MAX;
 
+			std::vector<osk_panel> m_panels;
+			size_t m_panel_index = 0;
+
 			osk_dialog() = default;
 			~osk_dialog() override = default;
 
-			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 options) override = 0;
+			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) override;
 			void Close(bool ok) override;
 
-			void initialize_layout(const std::vector<grid_entry_ctor>& layout, const std::u32string& title, const std::u32string& initial_text);
+			void initialize_layout(const std::u32string& title, const std::u32string& initial_text);
+			void add_panel(const osk_panel& panel);
+			void step_panel(bool next_panel);
+			void update_panel();
+			void update_layout();
 			void update() override;
+
+			void update_controls();
 
 			void on_button_pressed(pad_button button_press) override;
 			void on_text_changed();
 
-			void on_default_callback(const std::u32string&);
+			void on_default_callback(const std::u32string& str);
 			void on_shift(const std::u32string&);
-			void on_mode(const std::u32string&);
+			void on_layer(const std::u32string&);
 			void on_space(const std::u32string&);
 			void on_backspace(const std::u32string&);
 			void on_enter(const std::u32string&);
 
+			std::u32string get_placeholder();
+
 			compiled_resource get_compiled() override;
-		};
-
-		struct osk_latin : osk_dialog
-		{
-			using osk_dialog::osk_dialog;
-
-			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 options) override;
 		};
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -89,6 +89,7 @@ namespace rsx
 			void update() override;
 
 			void update_controls();
+			void update_selection_by_index(u32 index);
 
 			void on_button_pressed(pad_button button_press) override;
 			void on_text_changed();
@@ -101,6 +102,8 @@ namespace rsx
 			void on_enter(const std::u32string&);
 
 			std::u32string get_placeholder();
+
+			std::pair<u32, u32> get_cell_geometry(u32 index);
 
 			compiled_resource get_compiled() override;
 		};

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk_panel.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk_panel.cpp
@@ -1,0 +1,565 @@
+﻿#include "stdafx.h"
+#include "overlay_osk_panel.h"
+
+namespace rsx
+{
+	namespace overlays
+	{
+		osk_panel::osk_panel(u32 panel_mode)
+		{
+			osk_panel_mode = panel_mode;
+		}
+
+		// Language specific implementations
+
+		osk_panel_latin::osk_panel_latin(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb, u32 osk_panel_mode)
+			: osk_panel(osk_panel_mode)
+		{
+			const color4f default_bg = { 0.7f, 0.7f, 0.7f, 1.f };
+			const color4f special_bg = { 0.2f, 0.7f, 0.7f, 1.f };
+			const color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
+
+			num_rows = 5;
+			num_columns = 10;
+			cell_size_x = 50;
+			cell_size_y = 40;
+
+			layout =
+			{
+				// Row 1
+				{{{U"1", U"!"}, {U"à", U"À"}, {U"!", U"¡"}}, default_bg, 1},
+				{{{U"2", U"@"}, {U"á", U"Á"}, {U"?", U"¿"}}, default_bg, 1},
+				{{{U"3", U"#"}, {U"â", U"Â"}, {U"#", U"~"}}, default_bg, 1},
+				{{{U"4", U"$"}, {U"ã", U"Ã"}, {U"$", U"„"}}, default_bg, 1},
+				{{{U"5", U"%"}, {U"ä", U"Ä"}, {U"%", U"´"}}, default_bg, 1},
+				{{{U"6", U"^"}, {U"å", U"Å"}, {U"&", U"‘"}}, default_bg, 1},
+				{{{U"7", U"&"}, {U"æ", U"Æ"}, {U"'", U"’"}}, default_bg, 1},
+				{{{U"8", U"*"}, {U"ç", U"Ç"}, {U"(", U"‚"}}, default_bg, 1},
+				{{{U"9", U"("}, {U"[", U"<"}, {U")", U"“"}}, default_bg, 1},
+				{{{U"0", U")"}, {U"]", U">"}, {U"*", U"”"}}, default_bg, 1},
+
+				// Row 2
+				{{{U"q", U"Q"}, {U"è", U"È"}, {U"/", U"¤"}}, default_bg, 1},
+				{{{U"w", U"W"}, {U"é", U"É"}, {U"\\", U"¢"}}, default_bg, 1},
+				{{{U"e", U"E"}, {U"ê", U"Ê"}, {U"[", U"€"}}, default_bg, 1},
+				{{{U"r", U"R"}, {U"ë", U"Ë"}, {U"]", U"£"}}, default_bg, 1},
+				{{{U"t", U"T"}, {U"ì", U"Ì"}, {U"^", U"¥"}}, default_bg, 1},
+				{{{U"y", U"Y"}, {U"í", U"Í"}, {U"_", U"§"}}, default_bg, 1},
+				{{{U"u", U"U"}, {U"î", U"Î"}, {U"`", U"¦"}}, default_bg, 1},
+				{{{U"i", U"I"}, {U"ï", U"Ï"}, {U"{", U"µ"}}, default_bg, 1},
+				{{{U"o", U"O"}, {U";", U"="}, {U"}", U""}}, default_bg, 1},
+				{{{U"p", U"P"}, {U":", U"+"}, {U"|", U""}}, default_bg, 1},
+
+				// Row 3
+				{{{U"a", U"A"}, {U"ñ", U"Ñ"}, {U"@", U""}}, default_bg, 1},
+				{{{U"s", U"S"}, {U"ò", U"Ò"}, {U"°", U""}}, default_bg, 1},
+				{{{U"d", U"D"}, {U"ó", U"Ó"}, {U"‹", U""}}, default_bg, 1},
+				{{{U"f", U"F"}, {U"ô", U"Ô"}, {U"›", U""}}, default_bg, 1},
+				{{{U"g", U"G"}, {U"õ", U"Õ"}, {U"«", U""}}, default_bg, 1},
+				{{{U"h", U"H"}, {U"ö", U"Ö"}, {U"»", U""}}, default_bg, 1},
+				{{{U"j", U"J"}, {U"ø", U"Ø"}, {U"ª", U""}}, default_bg, 1},
+				{{{U"k", U"K"}, {U"œ", U"Œ"}, {U"º", U""}}, default_bg, 1},
+				{{{U"l", U"L"}, {U"`", U"~"}, {U"×", U""}}, default_bg, 1},
+				{{{U"'", U"\""}, {U"¡", U"\""}, {U"÷", U""}}, default_bg, 1},
+
+				// Row 4
+				{{{U"z", U"Z"}, {U"ß", U"ß"}, {U"+", U""}}, default_bg, 1},
+				{{{U"x", U"X"}, {U"ù", U"Ù"}, {U",", U""}}, default_bg, 1},
+				{{{U"c", U"C"}, {U"ú", U"Ú"}, {U"-", U""}}, default_bg, 1},
+				{{{U"v", U"V"}, {U"û", U"Û"}, {U".", U""}}, default_bg, 1},
+				{{{U"b", U"B"}, {U"ü", U"Ü"}, {U"\"", U""}}, default_bg, 1},
+				{{{U"n", U"N"}, {U"ý", U"Ý"}, {U":", U""}}, default_bg, 1},
+				{{{U"m", U"M"}, {U"ÿ", U"Ÿ"}, {U";", U""}}, default_bg, 1},
+				{{{U",", U"-"}, {U",", U"-"}, {U"<", U""}}, default_bg, 1},
+				{{{U".", U"_"}, {U".", U"_"}, {U"=", U""}}, default_bg, 1},
+				{{{U"?", U"/"}, {U"¿", U"/"}, {U">", U""}}, default_bg, 1},
+
+				// Special
+				{{{U"A/a"}, {U"À/à"}, {U"!/¡"}}, special2_bg, 2, button_flags::_shift, shift_cb },
+				{{{U"ÖÑß"}, {U"@#:"}, {U"ABC"}}, special2_bg, 2, button_flags::_layer, layer_cb },
+				{{{U"Space"}, {U"Space"}, {U"Space"}}, special_bg, 2, button_flags::_space, space_cb },
+				{{{U"Backspace"}, {U"Backspace"}, {U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },
+				{{{U"Enter"}, {U"Enter"}, {U"Enter"}}, special2_bg, 2, button_flags::_return, enter_cb },
+			};
+		}
+
+		osk_panel_english::osk_panel_english(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel_latin(shift_cb, layer_cb, space_cb, delete_cb, enter_cb, CELL_OSKDIALOG_PANELMODE_ENGLISH)
+		{
+			// English and latin should be mostly the same
+		}
+
+		osk_panel_japanese::osk_panel_japanese(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel(CELL_OSKDIALOG_PANELMODE_JAPANESE)
+		{
+			color4f default_bg = { 0.7f, 0.7f, 0.7f, 1.f };
+			color4f special_bg = { 0.2f, 0.7f, 0.7f, 1.f };
+			color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
+
+			num_rows = 6;
+			num_columns = 10;
+			cell_size_x = 50;
+			cell_size_y = 40;
+
+			layout =
+			{
+				// Row 1
+				{{{U"あ", U"ア"}, {U"1", U"!"}, {U"１", U"！"}, {U"，"}}, default_bg, 1},
+				{{{U"か", U"カ"}, {U"2", U"@"}, {U"２", U"＠"}, {U"．"}}, default_bg, 1},
+				{{{U"さ", U"サ"}, {U"3", U"#"}, {U"３", U"＃"}, {U"："}}, default_bg, 1},
+				{{{U"た", U"タ"}, {U"4", U"$"}, {U"４", U"＄"}, {U"；"}}, default_bg, 1},
+				{{{U"な", U"ナ"}, {U"5", U"%"}, {U"５", U"％"}, {U"！"}}, default_bg, 1},
+				{{{U"は", U"ハ"}, {U"6", U"^"}, {U"６", U"＾"}, {U"？"}}, default_bg, 1},
+				{{{U"ま", U"マ"}, {U"7", U"&"}, {U"７", U"＆"}, {U"＂"}}, default_bg, 1},
+				{{{U"や", U"ヤ"}, {U"8", U"*"}, {U"８", U"＊"}, {U"＇"}}, default_bg, 1},
+				{{{U"ら", U"ラ"}, {U"9", U"("}, {U"９", U"（"}, {U"｀"}}, default_bg, 1},
+				{{{U"わ", U"ワ"}, {U"0", U")"}, {U"０", U"）"}, {U"＾"}}, default_bg, 1},
+
+				// Row 2
+				{{{U"い", U"イ"}, {U"q", U"Q"}, {U"ｑ", U"Ｑ"}, {U"～"}}, default_bg, 1},
+				{{{U"き", U"キ"}, {U"w", U"W"}, {U"ｗ", U"Ｗ"}, {U"＿"}}, default_bg, 1},
+				{{{U"し", U"シ"}, {U"e", U"E"}, {U"ｅ", U"Ｅ"}, {U"＆"}}, default_bg, 1},
+				{{{U"ち", U"チ"}, {U"r", U"R"}, {U"ｒ", U"Ｒ"}, {U"＠"}}, default_bg, 1},
+				{{{U"に", U"ニ"}, {U"t", U"T"}, {U"ｔ", U"Ｔ"}, {U"＃"}}, default_bg, 1},
+				{{{U"ひ", U"ヒ"}, {U"y", U"Y"}, {U"ｙ", U"Ｙ"}, {U"％"}}, default_bg, 1},
+				{{{U"み", U"ミ"}, {U"u", U"U"}, {U"ｕ", U"Ｕ"}, {U"＋"}}, default_bg, 1},
+				{{{U"ゆ", U"ユ"}, {U"i", U"I"}, {U"ｉ", U"Ｉ"}, {U"－"}}, default_bg, 1},
+				{{{U"り", U"リ"}, {U"o", U"O"}, {U"ｏ", U"Ｏ"}, {U"＊"}}, default_bg, 1},
+				{{{U"を", U"ヲ"}, {U"p", U"P"}, {U"ｐ", U"Ｐ"}, {U"･"}}, default_bg, 1},
+
+				// Row 3
+				{{{U"う", U"ウ"}, {U"a", U"A"}, {U"ａ", U"Ａ"}, {U"＜"}}, default_bg, 1},
+				{{{U"く", U"ク"}, {U"s", U"S"}, {U"ｓ", U"Ｓ"}, {U"＞"}}, default_bg, 1},
+				{{{U"す", U"ス"}, {U"d", U"D"}, {U"ｄ", U"Ｄ"}, {U"（"}}, default_bg, 1},
+				{{{U"つ", U"ツ"}, {U"f", U"F"}, {U"ｆ", U"Ｆ"}, {U"）"}}, default_bg, 1},
+				{{{U"ぬ", U"ヌ"}, {U"g", U"G"}, {U"ｇ", U"Ｇ"}, {U"［"}}, default_bg, 1},
+				{{{U"ふ", U"フ"}, {U"h", U"H"}, {U"ｈ", U"Ｈ"}, {U"］"}}, default_bg, 1},
+				{{{U"む", U"ム"}, {U"j", U"J"}, {U"ｊ", U"Ｊ"}, {U"｛"}}, default_bg, 1},
+				{{{U"よ", U"ヨ"}, {U"k", U"K"}, {U"ｋ", U"Ｋ"}, {U"｝"}}, default_bg, 1},
+				{{{U"る", U"ル"}, {U"l", U"L"}, {U"ｌ", U"Ｌ"}, {U"｢"}}, default_bg, 1},
+				{{{U"ん", U"ン"}, {U"'", U"\""}, {U"＇", U"＂"}, {U"｣"}}, default_bg, 1},
+
+				// Row 4
+				{{{U"え", U"エ"}, {U"z", U"Z"}, {U"ｚ", U"Ｚ"}, {U"＝"}}, default_bg, 1},
+				{{{U"け", U"ケ"}, {U"x", U"X"}, {U"ｘ", U"Ｘ"}, {U"｜"}}, default_bg, 1},
+				{{{U"せ", U"セ"}, {U"c", U"C"}, {U"ｃ", U"Ｃ"}, {U"｡"}}, default_bg, 1},
+				{{{U"て", U"テ"}, {U"v", U"V"}, {U"ｖ", U"Ｖ"}, {U"／"}}, default_bg, 1},
+				{{{U"ね", U"ネ"}, {U"b", U"B"}, {U"ｂ", U"Ｂ"}, {U"＼"}}, default_bg, 1},
+				{{{U"へ", U"ヘ"}, {U"n", U"N"}, {U"ｎ", U"Ｎ"}, {U"￢"}}, default_bg, 1},
+				{{{U"め", U"メ"}, {U"m", U"M"}, {U"ｍ", U"Ｍ"}, {U"＄"}}, default_bg, 1},
+				{{{U"゛", U"゛"}, {U",", U"-"}, {U"，", U"－"}, {U"￥"}}, default_bg, 1},
+				{{{U"れ", U"レ"}, {U".", U"_"}, {U"．", U"＿"}, {U"､"}}, default_bg, 1},
+				{{{U"ー", U"ー"}, {U"?", U"/"}, {U"？", U"／"}, {U""}}, default_bg, 1},
+
+				// Row 5
+				{{{U"お", U"オ"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"こ", U"コ"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"そ", U"ソ"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"と", U"ト"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"の", U"ノ"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"ほ", U"ホ"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"も", U"モ"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"゜", U"゜"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"ろ", U"ロ"}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+				{{{U"", U""}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
+
+				// Special
+				{{{U"あ/ア"}, {U"A/a"}, {U"全/半"}, {U""}}, special2_bg, 2, button_flags::_shift, shift_cb },
+				{{{U"abc"}, {U"全半"}, {U"＠％"}, {U"あア"}}, special2_bg, 2, button_flags::_layer, layer_cb},
+				{{{U"Space"}, {U"Space"}, {U"Space"}, {U"Space"}}, special_bg, 2, button_flags::_space, space_cb},
+				{{{U"Backspace"}, {U"Backspace"}, {U"Backspace"}, {U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },
+				{{{U"Enter"}, {U"Enter"}, {U"Enter"}, {U"Enter"}}, special2_bg, 2, button_flags::_return, enter_cb },
+			};
+		}
+
+		osk_panel_japanese_hiragana::osk_panel_japanese_hiragana(callback_t /*shift_cb*/, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel(CELL_OSKDIALOG_PANELMODE_JAPANESE_HIRAGANA)
+		{
+			color4f default_bg = { 0.7f, 0.7f, 0.7f, 1.f };
+			color4f special_bg = { 0.2f, 0.7f, 0.7f, 1.f };
+			color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
+
+			num_rows = 6;
+			num_columns = 10;
+			cell_size_x = 50;
+			cell_size_y = 40;
+
+			layout =
+			{
+				// Row 1
+				{{{U"あ"}, {U"，"}}, default_bg, 1},
+				{{{U"か"}, {U"．"}}, default_bg, 1},
+				{{{U"さ"}, {U"："}}, default_bg, 1},
+				{{{U"た"}, {U"；"}}, default_bg, 1},
+				{{{U"な"}, {U"！"}}, default_bg, 1},
+				{{{U"は"}, {U"？"}}, default_bg, 1},
+				{{{U"ま"}, {U"＂"}}, default_bg, 1},
+				{{{U"や"}, {U"＇"}}, default_bg, 1},
+				{{{U"ら"}, {U"｀"}}, default_bg, 1},
+				{{{U"わ"}, {U"＾"}}, default_bg, 1},
+
+				// Row 2
+				{{{U"い"}, {U"～"}}, default_bg, 1},
+				{{{U"き"}, {U"＿"}}, default_bg, 1},
+				{{{U"し"}, {U"＆"}}, default_bg, 1},
+				{{{U"ち"}, {U"＠"}}, default_bg, 1},
+				{{{U"に"}, {U"＃"}}, default_bg, 1},
+				{{{U"ひ"}, {U"％"}}, default_bg, 1},
+				{{{U"み"}, {U"＋"}}, default_bg, 1},
+				{{{U"ゆ"}, {U"－"}}, default_bg, 1},
+				{{{U"り"}, {U"＊"}}, default_bg, 1},
+				{{{U"を"}, {U"･"}}, default_bg, 1},
+
+				// Row 3
+				{{{U"う"}, {U"＜"}}, default_bg, 1},
+				{{{U"く"}, {U"＞"}}, default_bg, 1},
+				{{{U"す"}, {U"（"}}, default_bg, 1},
+				{{{U"つ"}, {U"）"}}, default_bg, 1},
+				{{{U"ぬ"}, {U"［"}}, default_bg, 1},
+				{{{U"ふ"}, {U"］"}}, default_bg, 1},
+				{{{U"む"}, {U"｛"}}, default_bg, 1},
+				{{{U"よ"}, {U"｝"}}, default_bg, 1},
+				{{{U"る"}, {U"｢"}}, default_bg, 1},
+				{{{U"ん"}, {U"｣"}}, default_bg, 1},
+
+				// Row 4
+				{{{U"え"}, {U"＝"}}, default_bg, 1},
+				{{{U"け"}, {U"｜"}}, default_bg, 1},
+				{{{U"せ"}, {U"｡"}}, default_bg, 1},
+				{{{U"て"}, {U"／"}}, default_bg, 1},
+				{{{U"ね"}, {U"＼"}}, default_bg, 1},
+				{{{U"へ"}, {U"￢"}}, default_bg, 1},
+				{{{U"め"}, {U"＄"}}, default_bg, 1},
+				{{{U"゛"}, {U"￥"}}, default_bg, 1},
+				{{{U"れ"}, {U"､"}}, default_bg, 1},
+				{{{U"ー"}, {U""}}, default_bg, 1},
+
+				// Row 5
+				{{{U"お"}, {U""}}, default_bg, 1},
+				{{{U"こ"}, {U""}}, default_bg, 1},
+				{{{U"そ"}, {U""}}, default_bg, 1},
+				{{{U"と"}, {U""}}, default_bg, 1},
+				{{{U"の"}, {U""}}, default_bg, 1},
+				{{{U"ほ"}, {U""}}, default_bg, 1},
+				{{{U"も"}, {U""}}, default_bg, 1},
+				{{{U"゜"}, {U""}}, default_bg, 1},
+				{{{U"ろ"}, {U""}}, default_bg, 1},
+				{{{U""}, {U""}}, default_bg, 1},
+
+				// Special
+				{{{U""}, {U""}}, special2_bg, 2, button_flags::_shift, nullptr },
+				{{{U"＠％"}, {U"あ"}}, special2_bg, 2, button_flags::_layer, layer_cb},
+				{{{U"Space"}, {U"Space"}}, special_bg, 2, button_flags::_space, space_cb},
+				{{{U"Backspace"}, {U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },
+				{{{U"Enter"}, {U"Enter"}}, special2_bg, 2, button_flags::_return, enter_cb },
+			};
+		}
+
+		osk_panel_japanese_katakana::osk_panel_japanese_katakana(callback_t /*shift_cb*/, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel(CELL_OSKDIALOG_PANELMODE_JAPANESE_KATAKANA)
+		{
+			color4f default_bg = { 0.7f, 0.7f, 0.7f, 1.f };
+			color4f special_bg = { 0.2f, 0.7f, 0.7f, 1.f };
+			color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
+
+			num_rows = 6;
+			num_columns = 10;
+			cell_size_x = 50;
+			cell_size_y = 40;
+
+			layout =
+			{
+				// Row 1
+				{{{U"ア"}, {U"，"}}, default_bg, 1},
+				{{{U"カ"}, {U"．"}}, default_bg, 1},
+				{{{U"サ"}, {U"："}}, default_bg, 1},
+				{{{U"タ"}, {U"；"}}, default_bg, 1},
+				{{{U"ナ"}, {U"！"}}, default_bg, 1},
+				{{{U"ハ"}, {U"？"}}, default_bg, 1},
+				{{{U"マ"}, {U"＂"}}, default_bg, 1},
+				{{{U"ヤ"}, {U"＇"}}, default_bg, 1},
+				{{{U"ラ"}, {U"｀"}}, default_bg, 1},
+				{{{U"ワ"}, {U"＾"}}, default_bg, 1},
+
+				// Row 2
+				{{{U"イ"}, {U"～"}}, default_bg, 1},
+				{{{U"キ"}, {U"＿"}}, default_bg, 1},
+				{{{U"シ"}, {U"＆"}}, default_bg, 1},
+				{{{U"チ"}, {U"＠"}}, default_bg, 1},
+				{{{U"ニ"}, {U"＃"}}, default_bg, 1},
+				{{{U"ヒ"}, {U"％"}}, default_bg, 1},
+				{{{U"ミ"}, {U"＋"}}, default_bg, 1},
+				{{{U"ユ"}, {U"－"}}, default_bg, 1},
+				{{{U"リ"}, {U"＊"}}, default_bg, 1},
+				{{{U"ヲ"}, {U"･"}}, default_bg, 1},
+
+				// Row 3
+				{{{U"ウ"}, {U"＜"}}, default_bg, 1},
+				{{{U"ク"}, {U"＞"}}, default_bg, 1},
+				{{{U"ス"}, {U"（"}}, default_bg, 1},
+				{{{U"ツ"}, {U"）"}}, default_bg, 1},
+				{{{U"ヌ"}, {U"［"}}, default_bg, 1},
+				{{{U"フ"}, {U"］"}}, default_bg, 1},
+				{{{U"ム"}, {U"｛"}}, default_bg, 1},
+				{{{U"ヨ"}, {U"｝"}}, default_bg, 1},
+				{{{U"ル"}, {U"｢"}}, default_bg, 1},
+				{{{U"ン"}, {U"｣"}}, default_bg, 1},
+
+				// Row 4
+				{{{U"エ"}, {U"＝"}}, default_bg, 1},
+				{{{U"ケ"}, {U"｜"}}, default_bg, 1},
+				{{{U"セ"}, {U"｡"}}, default_bg, 1},
+				{{{U"テ"}, {U"／"}}, default_bg, 1},
+				{{{U"ネ"}, {U"＼"}}, default_bg, 1},
+				{{{U"ヘ"}, {U"￢"}}, default_bg, 1},
+				{{{U"メ"}, {U"＄"}}, default_bg, 1},
+				{{{U"゛"}, {U"￥"}}, default_bg, 1},
+				{{{U"レ"}, {U"､"}}, default_bg, 1},
+				{{{U"ー"}, {U""}}, default_bg, 1},
+
+				// Row 5
+				{{{U"オ"}, {U""}}, default_bg, 1},
+				{{{U"コ"}, {U""}}, default_bg, 1},
+				{{{U"ソ"}, {U""}}, default_bg, 1},
+				{{{U"ト"}, {U""}}, default_bg, 1},
+				{{{U"ノ"}, {U""}}, default_bg, 1},
+				{{{U"ホ"}, {U""}}, default_bg, 1},
+				{{{U"モ"}, {U""}}, default_bg, 1},
+				{{{U"゜"}, {U""}}, default_bg, 1},
+				{{{U"ロ"}, {U""}}, default_bg, 1},
+				{{{U""}, {U""}}, default_bg, 1},
+
+				// Special
+				{{{U""}, {U""}}, special2_bg, 2, button_flags::_shift, nullptr },
+				{{{U"＠％"}, {U"ア"}}, special2_bg, 2, button_flags::_layer, layer_cb},
+				{{{U"Space"}, {U"Space"}}, special_bg, 2, button_flags::_space, space_cb},
+				{{{U"Backspace"}, {U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },
+				{{{U"Enter"}, {U"Enter"}}, special2_bg, 2, button_flags::_return, enter_cb },
+			};
+		}
+
+		osk_panel_alphabet_half_width::osk_panel_alphabet_half_width(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb, u32 osk_panel_mode)
+			: osk_panel(osk_panel_mode)
+		{
+			const color4f default_bg = { 0.7f, 0.7f, 0.7f, 1.f };
+			const color4f special_bg = { 0.2f, 0.7f, 0.7f, 1.f };
+			const color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
+
+			num_rows = 5;
+			num_columns = 10;
+			cell_size_x = 50;
+			cell_size_y = 40;
+
+			layout =
+			{
+				// Row 1
+				{{{U"1", U"!"}, {U"!"}}, default_bg, 1},
+				{{{U"2", U"@"}, {U"?"}}, default_bg, 1},
+				{{{U"3", U"#"}, {U"#"}}, default_bg, 1},
+				{{{U"4", U"$"}, {U"$"}}, default_bg, 1},
+				{{{U"5", U"%"}, {U"%"}}, default_bg, 1},
+				{{{U"6", U"^"}, {U"&"}}, default_bg, 1},
+				{{{U"7", U"&"}, {U"'"}}, default_bg, 1},
+				{{{U"8", U"*"}, {U"("}}, default_bg, 1},
+				{{{U"9", U"("}, {U")"}}, default_bg, 1},
+				{{{U"0", U")"}, {U"*"}}, default_bg, 1},
+
+				// Row 2
+				{{{U"q", U"Q"}, {U"/"}}, default_bg, 1},
+				{{{U"w", U"W"}, {U"\\"}}, default_bg, 1},
+				{{{U"e", U"E"}, {U"["}}, default_bg, 1},
+				{{{U"r", U"R"}, {U"]"}}, default_bg, 1},
+				{{{U"t", U"T"}, {U"^"}}, default_bg, 1},
+				{{{U"y", U"Y"}, {U"_"}}, default_bg, 1},
+				{{{U"u", U"U"}, {U"`"}}, default_bg, 1},
+				{{{U"i", U"I"}, {U"{"}}, default_bg, 1},
+				{{{U"o", U"O"}, {U"}"}}, default_bg, 1},
+				{{{U"p", U"P"}, {U"|"}}, default_bg, 1},
+
+				// Row 3
+				{{{U"a", U"A"}, {U"@"}}, default_bg, 1},
+				{{{U"s", U"S"}, {U"°"}}, default_bg, 1},
+				{{{U"d", U"D"}, {U"‹"}}, default_bg, 1},
+				{{{U"f", U"F"}, {U"›"}}, default_bg, 1},
+				{{{U"g", U"G"}, {U"«"}}, default_bg, 1},
+				{{{U"h", U"H"}, {U"»"}}, default_bg, 1},
+				{{{U"j", U"J"}, {U"ª"}}, default_bg, 1},
+				{{{U"k", U"K"}, {U"º"}}, default_bg, 1},
+				{{{U"l", U"L"}, {U"×"}}, default_bg, 1},
+				{{{U"'", U"\""}, {U"÷"}}, default_bg, 1},
+
+				// Row 4
+				{{{U"z", U"Z"}, {U"+"}}, default_bg, 1},
+				{{{U"x", U"X"}, {U","}}, default_bg, 1},
+				{{{U"c", U"C"}, {U"-"}}, default_bg, 1},
+				{{{U"v", U"V"}, {U"."}}, default_bg, 1},
+				{{{U"b", U"B"}, {U"\""}}, default_bg, 1},
+				{{{U"n", U"N"}, {U":"}}, default_bg, 1},
+				{{{U"m", U"M"}, {U";"}}, default_bg, 1},
+				{{{U",", U"-"}, {U"<"}}, default_bg, 1},
+				{{{U".", U"_"}, {U"="}}, default_bg, 1},
+				{{{U"?", U"/"}, {U">"}}, default_bg, 1},
+
+				// Special
+				{{{U"A/a"}, {U""}}, special2_bg, 2, button_flags::_shift, shift_cb },
+				{{{U"@#:"}, {U"ABC"}}, special2_bg, 2, button_flags::_layer, layer_cb },
+				{{{U"Space"}, {U"Space"}}, special_bg, 2, button_flags::_space, space_cb },
+				{{{U"Backspace"}, {U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },
+				{{{U"Enter"}, {U"Enter"}}, special2_bg, 2, button_flags::_return, enter_cb },
+			};
+		}
+
+		osk_panel_alphabet_full_width::osk_panel_alphabet_full_width(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel(CELL_OSKDIALOG_PANELMODE_ALPHABET_FULL_WIDTH)
+		{
+			const color4f default_bg = { 0.7f, 0.7f, 0.7f, 1.f };
+			const color4f special_bg = { 0.2f, 0.7f, 0.7f, 1.f };
+			const color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
+
+			num_rows = 5;
+			num_columns = 10;
+			cell_size_x = 50;
+			cell_size_y = 40;
+
+			layout =
+			{
+				// Row 1
+				{{{U"１", U"！"}, {U"！"}}, default_bg, 1},
+				{{{U"２", U"＠"}, {U"＠"}}, default_bg, 1},
+				{{{U"３", U"＃"}, {U"＃"}}, default_bg, 1},
+				{{{U"４", U"＄"}, {U"＄"}}, default_bg, 1},
+				{{{U"５", U"％"}, {U"％"}}, default_bg, 1},
+				{{{U"６", U"＾"}, {U"＾"}}, default_bg, 1},
+				{{{U"７", U"＆"}, {U"＆"}}, default_bg, 1},
+				{{{U"８", U"＊"}, {U"＊"}}, default_bg, 1},
+				{{{U"９", U"（"}, {U"（"}}, default_bg, 1},
+				{{{U"０", U"）"}, {U"）"}}, default_bg, 1},
+
+				// Row 2
+				{{{U"ｑ", U"Ｑ"}, {U"～"}}, default_bg, 1},
+				{{{U"ｗ", U"Ｗ"}, {U"＿"}}, default_bg, 1},
+				{{{U"ｅ", U"Ｅ"}, {U"＆"}}, default_bg, 1},
+				{{{U"ｒ", U"Ｒ"}, {U"＠"}}, default_bg, 1},
+				{{{U"ｔ", U"Ｔ"}, {U"＃"}}, default_bg, 1},
+				{{{U"ｙ", U"Ｙ"}, {U"％"}}, default_bg, 1},
+				{{{U"ｕ", U"Ｕ"}, {U"＋"}}, default_bg, 1},
+				{{{U"ｉ", U"Ｉ"}, {U"－"}}, default_bg, 1},
+				{{{U"ｏ", U"Ｏ"}, {U"＊"}}, default_bg, 1},
+				{{{U"ｐ", U"Ｐ"}, {U"･"}}, default_bg, 1},
+
+				// Row 3
+				{{{U"ａ", U"Ａ"}, {U"＜"}}, default_bg, 1},
+				{{{U"ｓ", U"Ｓ"}, {U"＞"}}, default_bg, 1},
+				{{{U"ｄ", U"Ｄ"}, {U"（"}}, default_bg, 1},
+				{{{U"ｆ", U"Ｆ"}, {U"）"}}, default_bg, 1},
+				{{{U"ｇ", U"Ｇ"}, {U"［"}}, default_bg, 1},
+				{{{U"ｈ", U"Ｈ"}, {U"］"}}, default_bg, 1},
+				{{{U"ｊ", U"Ｊ"}, {U"｛"}}, default_bg, 1},
+				{{{U"ｋ", U"Ｋ"}, {U"｝"}}, default_bg, 1},
+				{{{U"ｌ", U"Ｌ"}, {U"｢"}}, default_bg, 1},
+				{{{U"＇", U"＂"}, {U"｣"}}, default_bg, 1},
+
+				// Row 4
+				{{{U"ｚ", U"Ｚ"}, {U"＝"}}, default_bg, 1},
+				{{{U"ｘ", U"Ｘ"}, {U"｜"}}, default_bg, 1},
+				{{{U"ｃ", U"Ｃ"}, {U"｡"}}, default_bg, 1},
+				{{{U"ｖ", U"Ｖ"}, {U"／"}}, default_bg, 1},
+				{{{U"ｂ", U"Ｂ"}, {U"＼"}}, default_bg, 1},
+				{{{U"ｎ", U"Ｎ"}, {U"￢"}}, default_bg, 1},
+				{{{U"ｍ", U"Ｍ"}, {U"＄"}}, default_bg, 1},
+				{{{U"，", U"－"}, {U"￥"}}, default_bg, 1},
+				{{{U"．", U"＿"}, {U"､"}}, default_bg, 1},
+				{{{U"？", U"／"}, {U""}}, default_bg, 1},
+
+				// Special
+				{{{U"Ａ/ａ"}, {U""}}, special2_bg, 2, button_flags::_shift, shift_cb },
+				{{{U"@#:"}, {U"ABC"}}, special2_bg, 2, button_flags::_layer, layer_cb },
+				{{{U"Space"}, {U"Space"}}, special_bg, 2, button_flags::_space, space_cb },
+				{{{U"Backspace"}, {U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },
+				{{{U"Enter"}, {U"Enter"}}, special2_bg, 2, button_flags::_return, enter_cb },
+			};
+		}
+
+		osk_panel_numeral_half_width::osk_panel_numeral_half_width(callback_t /*shift_cb*/, callback_t /*layer_cb*/, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel(CELL_OSKDIALOG_PANELMODE_NUMERAL)
+		{
+			const color4f default_bg = { 0.7f, 0.7f, 0.7f, 1.f };
+			const color4f special_bg = { 0.2f, 0.7f, 0.7f, 1.f };
+			const color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
+
+			num_rows = 2;
+			num_columns = 10;
+			cell_size_x = 50;
+			cell_size_y = 40;
+
+			layout =
+			{
+				// Row 1
+				{{{U"1"}}, default_bg, 1},
+				{{{U"2"}}, default_bg, 1},
+				{{{U"3"}}, default_bg, 1},
+				{{{U"4"}}, default_bg, 1},
+				{{{U"5"}}, default_bg, 1},
+				{{{U"6"}}, default_bg, 1},
+				{{{U"7"}}, default_bg, 1},
+				{{{U"8"}}, default_bg, 1},
+				{{{U"9"}}, default_bg, 1},
+				{{{U"0"}}, default_bg, 1},
+
+				// Special
+				{{{U""}}, special2_bg, 2, button_flags::_shift, nullptr },
+				{{{U""}}, special2_bg, 2, button_flags::_layer, nullptr },
+				{{{U"Space"}}, special_bg, 2, button_flags::_space, space_cb },
+				{{{U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },
+				{{{U"Enter"}}, special2_bg, 2, button_flags::_return, enter_cb },
+			};
+		}
+
+		osk_panel_numeral_full_width::osk_panel_numeral_full_width(callback_t /*shift_cb*/, callback_t /*layer_cb*/, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel(CELL_OSKDIALOG_PANELMODE_NUMERAL_FULL_WIDTH)
+		{
+			const color4f default_bg = { 0.7f, 0.7f, 0.7f, 1.f };
+			const color4f special_bg = { 0.2f, 0.7f, 0.7f, 1.f };
+			const color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
+
+			num_rows = 2;
+			num_columns = 10;
+			cell_size_x = 50;
+			cell_size_y = 40;
+
+			layout =
+			{
+				// Row 1
+				{{{U"１"}}, default_bg, 1},
+				{{{U"２"}}, default_bg, 1},
+				{{{U"３"}}, default_bg, 1},
+				{{{U"４"}}, default_bg, 1},
+				{{{U"５"}}, default_bg, 1},
+				{{{U"６"}}, default_bg, 1},
+				{{{U"７"}}, default_bg, 1},
+				{{{U"８"}}, default_bg, 1},
+				{{{U"９"}}, default_bg, 1},
+				{{{U"０"}}, default_bg, 1},
+
+				// Special
+				{{{U""}}, special2_bg, 2, button_flags::_shift, nullptr },
+				{{{U""}}, special2_bg, 2, button_flags::_layer, nullptr },
+				{{{U"Space"}}, special_bg, 2, button_flags::_space, space_cb },
+				{{{U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },
+				{{{U"Enter"}}, special2_bg, 2, button_flags::_return, enter_cb },
+			};
+		}
+
+		osk_panel_url::osk_panel_url(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel_alphabet_half_width(shift_cb, layer_cb, space_cb, delete_cb, enter_cb, CELL_OSKDIALOG_PANELMODE_URL)
+		{
+			// Roughly the same as the half-width alphanumeric character panel.
+		}
+
+		osk_panel_password::osk_panel_password(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb)
+			: osk_panel_alphabet_half_width(shift_cb, layer_cb, space_cb, delete_cb, enter_cb, CELL_OSKDIALOG_PANELMODE_PASSWORD)
+		{
+			// Same as the half-width alphanumeric character panel.
+		}
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk_panel.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk_panel.cpp
@@ -164,7 +164,7 @@ namespace rsx
 				{{{U"", U""}, {U"", U""}, {U"", U""}, {U""}}, default_bg, 1},
 
 				// Special
-				{{{U"あ/ア"}, {U"A/a"}, {U"全/半"}, {U""}}, special2_bg, 2, button_flags::_shift, shift_cb },
+				{{{U"あ/ア"}, {U"A/a"}, {U"Ａ/ａ"}, {U""}}, special2_bg, 2, button_flags::_shift, shift_cb },
 				{{{U"abc"}, {U"全半"}, {U"＠％"}, {U"あア"}}, special2_bg, 2, button_flags::_layer, layer_cb},
 				{{{U"Space"}, {U"Space"}, {U"Space"}, {U"Space"}}, special_bg, 2, button_flags::_space, space_cb},
 				{{{U"Backspace"}, {U"Backspace"}, {U"Backspace"}, {U"Backspace"}}, special_bg, 2, button_flags::_default, delete_cb },

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk_panel.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk_panel.h
@@ -1,0 +1,99 @@
+﻿#pragma once
+
+#include "Emu/Cell/Modules/cellOskDialog.h"
+#include "Utilities/geometry.h"
+
+namespace rsx
+{
+	namespace overlays
+	{
+		using callback_t = std::function<void(const std::u32string&)>;
+
+		enum button_flags
+		{
+			_default = 0,
+			_return = 1,
+			_space = 2,
+			_shift = 3,
+			_layer = 4
+		};
+
+		struct grid_entry_ctor
+		{
+			// TODO: change to array with layer_mode::layer_count
+			std::vector<std::vector<std::u32string>> outputs;
+			color4f color;
+			u32 num_cell_hz;
+			button_flags type_flags;
+			callback_t callback;
+		};
+
+		struct osk_panel
+		{
+			u32 osk_panel_mode = 0;
+			u32 num_rows = 0;
+			u32 num_columns = 0;
+			u32 cell_size_x = 0;
+			u32 cell_size_y = 0;
+
+			std::vector<grid_entry_ctor> layout;
+
+			osk_panel(u32 panel_mode = 0);
+		};
+
+		struct osk_panel_latin : public osk_panel
+		{
+			osk_panel_latin(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb, u32 osk_panel_mode = CELL_OSKDIALOG_PANELMODE_LATIN);
+		};
+
+		struct osk_panel_english : public osk_panel_latin
+		{
+			osk_panel_english(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+
+		struct osk_panel_japanese : public osk_panel
+		{
+			osk_panel_japanese(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+
+		struct osk_panel_japanese_hiragana : public osk_panel
+		{
+			osk_panel_japanese_hiragana(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+
+		struct osk_panel_japanese_katakana : public osk_panel
+		{
+			osk_panel_japanese_katakana(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+
+		struct osk_panel_alphabet_half_width : public osk_panel
+		{
+			osk_panel_alphabet_half_width(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb, u32 osk_panel_mode = CELL_OSKDIALOG_PANELMODE_ALPHABET);
+		};
+
+		struct osk_panel_alphabet_full_width : public osk_panel
+		{
+			osk_panel_alphabet_full_width(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+
+		struct osk_panel_numeral_half_width : public osk_panel
+		{
+			osk_panel_numeral_half_width(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+
+		struct osk_panel_numeral_full_width : public osk_panel
+		{
+			osk_panel_numeral_full_width(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+
+		struct osk_panel_url : public osk_panel_alphabet_half_width
+		{
+			osk_panel_url(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+
+		struct osk_panel_password : public osk_panel_alphabet_half_width
+		{
+			osk_panel_password(callback_t shift_cb, callback_t layer_cb, callback_t space_cb, callback_t delete_cb, callback_t enter_cb);
+		};
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -136,6 +136,12 @@ namespace rsx
 							case CELL_PAD_CTRL_R1:
 								button_id = pad_button::R1;
 								break;
+							case CELL_PAD_CTRL_L2:
+								button_id = pad_button::L2;
+								break;
+							case CELL_PAD_CTRL_R2:
+								button_id = pad_button::R2;
+								break;
 							}
 						}
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -65,6 +65,8 @@ namespace rsx
 				cross,
 				L1,
 				R1,
+				L2,
+				R2,
 
 				pad_button_max_enum
 			};

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -74,6 +74,7 @@
     <ClCompile Include="Emu\Io\KeyboardHandler.cpp" />
     <ClCompile Include="Emu\Io\pad_config.cpp" />
     <ClCompile Include="Emu\Io\pad_config_types.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\overlay_osk_panel.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_utils.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.cpp" />
@@ -439,6 +440,7 @@
     <ClInclude Include="Emu\RSX\Overlays\overlay_fonts.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_message_dialog.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_osk.h" />
+    <ClInclude Include="Emu\RSX\Overlays\overlay_osk_panel.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_perf_metrics.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_save_dialog.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_shader_compile_notification.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -926,6 +926,9 @@
     <ClCompile Include="Emu\NP\np_handler.cpp">
       <Filter>Emu\NP</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\overlay_osk_panel.cpp">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -1758,6 +1761,9 @@
     </ClInclude>
     <ClInclude Include="Emu\NP\np_handler.h">
       <Filter>Emu\NP</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\overlay_osk_panel.h">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -24,7 +24,7 @@ osk_dialog_frame::~osk_dialog_frame()
 	}
 }
 
-void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 options)
+void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 /*panel_flag*/, u32 /*first_view_panel*/)
 {
 	state = OskDialogState::Open;
 
@@ -64,7 +64,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 	inputLayout->setAlignment(Qt::AlignHCenter);
 
 	// Text Input
-	if (options & CELL_OSKDIALOG_NO_RETURN)
+	if (prohibit_flags & CELL_OSKDIALOG_NO_RETURN)
 	{
 		QLineEdit* input = new QLineEdit(m_dialog);
 		input->setFixedWidth(lineEditWidth());
@@ -72,7 +72,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 		input->setText(text);
 		input->setFocus();
 
-		if (options & CELL_OSKDIALOG_NO_SPACE)
+		if (prohibit_flags & CELL_OSKDIALOG_NO_SPACE)
 		{
 			input->setValidator(new QRegExpValidator(QRegExp("^\\S*$"), this));
 		}
@@ -123,7 +123,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 			int cursor_pos = cursor.position();
 
 			// Clear text of spaces if necessary
-			if (options & CELL_OSKDIALOG_NO_SPACE)
+			if (prohibit_flags & CELL_OSKDIALOG_NO_SPACE)
 			{
 				int trim_len = text.length();
 				text.remove(QRegExp("\\s+"));

--- a/rpcs3/rpcs3qt/osk_dialog_frame.h
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.h
@@ -14,7 +14,7 @@ class osk_dialog_frame : public QObject, public OskDialogBase
 public:
 	osk_dialog_frame();
 	~osk_dialog_frame();
-	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 options) override;
+	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) override;
 	virtual void Close(bool accepted) override;
 
 private:


### PR DESCRIPTION
- Refactors the overlay osk to use panels that can be switched out dynamically
- Fixes wrongly enabled control buttons (shift and layer/mode)
- Fix Full-Width alphabet, which could not be displayed before
- Uses L2 and R2 for switching between the panels
- Adds URL Panel
- Adds Password Panel (No *** yet)
- Adds Halfwidth Numeric Panel
- Adds Fullwidth Numeric Panel
- Adds Halfwidth Alphabet Panel
- Adds Fullwidth Alphabet Panel
- Adds Basic Japanese Panel (no dictionary)
- Adds Basic Hiragana Panel (no dictionary)
- Adds Basic Katakana Panel
- Adds English Panel
- Takes the osk panel modes passed by games into account and uses the system language by default
- Uses English Panel as Fallback for other languages

TODO:
- Add visual clues for current/available panels and L2/R2