### PR TITLE
Fix sys_raw_spu_destroy

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -116,7 +116,7 @@ struct vdec_context final
 	u32 frc_set{}; // Frame Rate Override
 	u64 next_pts{};
 	u64 next_dts{};
-	u32 ppu_tid{};
+	atomic_t<u32> ppu_tid{};
 
 	std::deque<vdec_frame> out;
 	atomic_t<u32> out_max = 60;
@@ -202,7 +202,7 @@ struct vdec_context final
 
 	void exec(ppu_thread& ppu, u32 vid)
 	{
-		ppu_tid = ppu.id;
+		ppu_tid.release(ppu.id);
 
 		// pcmd can be nullptr
 		for (auto* pcmd : in_cmd)
@@ -687,12 +687,17 @@ error_code cellVdecClose(ppu_thread& ppu, u32 handle)
 	vdec->out_max = 0;
 	vdec->in_cmd.push(vdec_close);
 
-	while (!atomic_storage<u32>::load(vdec->ppu_tid))
+	while (!vdec->ppu_tid)
 	{
 		thread_ctrl::wait_for(1000);
 	}
 
-	ppu_execute<&sys_interrupt_thread_disestablish>(ppu, vdec->ppu_tid);
+	const u32 tid = vdec->ppu_tid.exchange(-1);
+
+	if (tid != umax)
+	{
+		ppu_execute<&sys_interrupt_thread_disestablish>(ppu, tid);
+	}
 
 	if (!idm::remove_verify<vdec_context>(handle, std::move(vdec)))
 	{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -955,14 +955,15 @@ void spu_int_ctrl_t::set(u64 ints)
 	ints &= mask;
 
 	// notify if at least 1 bit was set
-	if (ints && ~stat.fetch_or(ints) & ints && !tag.expired())
+	if (ints && ~stat.fetch_or(ints) & ints)
 	{
-		reader_lock rlock(id_manager::g_mutex);
+		std::shared_lock rlock(id_manager::g_mutex);
 
 		if (const auto tag_ptr = tag.lock())
 		{
 			if (auto handler = tag_ptr->handler.lock())
 			{
+				rlock.unlock();
 				handler->exec();
 			}
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -150,6 +150,8 @@ error_code _sys_interrupt_thread_disestablish(ppu_thread& ppu, u32 ih, vm::ptr<u
 		return CELL_ESRCH;
 	}
 
+	lv2_obj::sleep(ppu);
+
 	// Wait for sys_interrupt_thread_eoi() and destroy interrupt thread
 	handler->join();
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1715,6 +1715,7 @@ error_code sys_raw_spu_destroy(ppu_thread& ppu, u32 id)
 			if (auto handler = tag->handler.lock())
 			{
 				// SLEEP
+				lv2_obj::sleep(ppu);
 				handler->join();
 				to_remove.emplace_back(std::move(handler), 0);
 			}


### PR DESCRIPTION
* Use cpu_flag::exit instead of cpu_flag::stop to avoid issues with MMIO start requests.
* Protect spu_thread::int_ctrl from changing in sys_raw_spu_destroy.
*  Test tag.expired() inside idm shared lock in spu_int_ctrl_t::set().
* Use lv2_obj::sleep when joing interrupt ppu thread.
* Followup fix to #7663 in cellVdecClose.
* Optimization: make sys_raw_spu_destroy not copying a shared ptr, move it instead. (copied because it was const wrongly)