### PR TITLE
vk: Lazy evaluate renderpass scope

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include "VKHelpers.h"
+#include "VKRenderPass.h"
 #include "Utilities/StrUtil.h"
 
 #define VK_MAX_COMPUTE_TASKS 4096   // Max number of jobs per frame
@@ -201,6 +202,12 @@ namespace vk
 
 		void run(VkCommandBuffer cmd, u32 invocations_x, u32 invocations_y, u32 invocations_z)
 		{
+			// CmdDispatch is outside renderpass scope only
+			if (vk::is_renderpass_open(cmd))
+			{
+				vk::end_renderpass(cmd);
+			}
+
 			load_program(cmd);
 			vkCmdDispatch(cmd, invocations_x, invocations_y, invocations_z);
 		}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -456,8 +456,8 @@ private:
 	utils::address_range m_offloader_fault_range;
 	rsx::invalidation_cause m_offloader_fault_cause;
 
-	bool m_render_pass_open = false;
-	u64  m_current_renderpass_key = 0;
+	u32 m_current_subdraw_id = 0;
+	u64 m_current_renderpass_key = 0;
 	VkRenderPass m_cached_renderpass = VK_NULL_HANDLE;
 	std::vector<vk::image*> m_fbo_images;
 
@@ -494,6 +494,7 @@ private:
 
 	void begin_render_pass();
 	void close_render_pass();
+	VkRenderPass get_render_pass();
 
 	void update_draw_state();
 

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -5,6 +5,7 @@
 #include "VKRenderTargets.h"
 #include "VKFramebuffer.h"
 #include "VKResourceManager.h"
+#include "VKRenderPass.h"
 
 #include "../Overlays/overlays.h"
 
@@ -374,18 +375,8 @@ namespace vk
 			load_program(cmd, render_pass, src);
 			set_up_viewport(cmd, viewport.x1, viewport.y1, viewport.width(), viewport.height());
 
-			VkRenderPassBeginInfo rp_begin = {};
-			rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-			rp_begin.renderPass = render_pass;
-			rp_begin.framebuffer = fbo->value;
-			rp_begin.renderArea.offset.x = static_cast<s32>(viewport.x1);
-			rp_begin.renderArea.offset.y = static_cast<s32>(viewport.y1);
-			rp_begin.renderArea.extent.width = viewport.width();
-			rp_begin.renderArea.extent.height = viewport.height();
-
-			vkCmdBeginRenderPass(cmd, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+			vk::begin_renderpass(cmd, render_pass, fbo->value, viewport);
 			emit_geometry(cmd);
-			vkCmdEndRenderPass(cmd);
 		}
 
 		void run(vk::command_buffer &cmd, const areau& viewport, vk::image* target, const std::vector<vk::image_view*>& src, VkRenderPass render_pass)

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -5,6 +5,16 @@
 
 namespace vk
 {
+	struct active_renderpass_info_t
+	{
+		VkRenderPass pass = VK_NULL_HANDLE;
+		VkFramebuffer fbo = VK_NULL_HANDLE;
+	};
+
+	atomic_t<u64> g_cached_renderpass_key = 0;
+	VkRenderPass  g_cached_renderpass = VK_NULL_HANDLE;
+	std::unordered_map<VkCommandBuffer, active_renderpass_info_t>  g_current_renderpass;
+
 	shared_mutex g_renderpass_cache_mutex;
 	std::unordered_map<u64, VkRenderPass> g_renderpass_cache;
 
@@ -247,5 +257,52 @@ namespace vk
 		}
 
 		g_renderpass_cache.clear();
+	}
+
+	void begin_renderpass(VkCommandBuffer cmd, VkRenderPass pass, VkFramebuffer target, const coordu& framebuffer_region)
+	{
+		auto& renderpass_info = g_current_renderpass[cmd];
+		if (renderpass_info.pass == pass && renderpass_info.fbo == target)
+		{
+			return;
+		}
+		else if (renderpass_info.pass != VK_NULL_HANDLE)
+		{
+			end_renderpass(cmd);
+		}
+
+		VkRenderPassBeginInfo rp_begin = {};
+		rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+		rp_begin.renderPass = pass;
+		rp_begin.framebuffer = target;
+		rp_begin.renderArea.offset.x = static_cast<int32_t>(framebuffer_region.x);
+		rp_begin.renderArea.offset.y = static_cast<int32_t>(framebuffer_region.y);
+		rp_begin.renderArea.extent.width = framebuffer_region.width;
+		rp_begin.renderArea.extent.height = framebuffer_region.height;
+
+		vkCmdBeginRenderPass(cmd, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+		renderpass_info = { pass, target };
+	}
+
+	void begin_renderpass(VkDevice dev, VkCommandBuffer cmd, u64 renderpass_key, VkFramebuffer target, const coordu& framebuffer_region)
+	{
+		if (renderpass_key != g_cached_renderpass_key)
+		{
+			g_cached_renderpass = get_renderpass(dev, renderpass_key);
+			g_cached_renderpass_key = renderpass_key;
+		}
+
+		begin_renderpass(cmd, g_cached_renderpass, target, framebuffer_region);
+	}
+
+	void end_renderpass(VkCommandBuffer cmd)
+	{
+		vkCmdEndRenderPass(cmd);
+		g_current_renderpass[cmd] = {};
+	}
+
+	bool is_renderpass_open(VkCommandBuffer cmd)
+	{
+		return g_current_renderpass[cmd].pass != VK_NULL_HANDLE;
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.h
@@ -10,4 +10,11 @@ namespace vk
 	VkRenderPass get_renderpass(VkDevice dev, u64 renderpass_key);
 
 	void clear_renderpass_cache(VkDevice dev);
+
+	// Renderpass scope management helpers.
+	// NOTE: These are not thread safe by design.
+	void begin_renderpass(VkDevice dev, VkCommandBuffer cmd, u64 renderpass_key, VkFramebuffer target, const coordu& framebuffer_region);
+	void begin_renderpass(VkCommandBuffer cmd, VkRenderPass pass, VkFramebuffer target, const coordu& framebuffer_region);
+	void end_renderpass(VkCommandBuffer cmd);
+	bool is_renderpass_open(VkCommandBuffer cmd);
 }

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -2,6 +2,7 @@
 #include "VKHelpers.h"
 #include "VKVertexProgram.h"
 #include "VKFragmentProgram.h"
+#include "VKRenderPass.h"
 #include "../Common/TextGlyphs.h"
 
 namespace vk
@@ -346,23 +347,13 @@ namespace vk
 			//TODO: Add drop shadow if deemed necessary for visibility
 			load_program(cmd, scale_x, scale_y, shader_offsets.data(), counts.size(), color);
 
-			VkRenderPassBeginInfo rp_begin = {};
-			rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-			rp_begin.renderPass = m_render_pass;
-			rp_begin.framebuffer = target.value;
-			rp_begin.renderArea.offset.x = 0;
-			rp_begin.renderArea.offset.y = 0;
-			rp_begin.renderArea.extent.width = target.width();
-			rp_begin.renderArea.extent.height = target.height();
-
-			vkCmdBeginRenderPass(cmd, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+			const coordu viewport = { positionu{0u, 0u}, sizeu{target.width(), target.height() } };
+			vk::begin_renderpass(cmd, m_render_pass, target.value, viewport);
 
 			for (uint i = 0; i < counts.size(); ++i)
 			{
 				vkCmdDraw(cmd, counts[i], 1, offsets[i], i);
 			}
-
-			vkCmdEndRenderPass(cmd);
 		}
 
 		void reset_descriptors()

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -6,6 +6,7 @@
 #include "../rsx_utils.h"
 #include "VKFormats.h"
 #include "VKCompute.h"
+#include "VKRenderPass.h"
 
 namespace vk
 {
@@ -61,6 +62,11 @@ namespace vk
 		// Always validate
 		verify("Invalid image layout!" HERE),
 			src->current_layout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL || src->current_layout == VK_IMAGE_LAYOUT_GENERAL;
+
+		if (vk::is_renderpass_open(cmd))
+		{
+			vk::end_renderpass(cmd);
+		}
 
 		switch (src->format())
 		{
@@ -142,6 +148,11 @@ namespace vk
 		verify("Invalid image layout!" HERE),
 			dst->current_layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL || dst->current_layout == VK_IMAGE_LAYOUT_GENERAL;
 
+		if (vk::is_renderpass_open(cmd))
+		{
+			vk::end_renderpass(cmd);
+		}
+
 		switch (dst->format())
 		{
 		default:
@@ -209,6 +220,11 @@ namespace vk
 		{
 			copy_image(cmd, src->value, dst->value, src->current_layout, dst->current_layout, src_rect, dst_rect, mipmaps, src_aspect, dst_aspect, src_transfer_mask, dst_transfer_mask);
 			return;
+		}
+
+		if (vk::is_renderpass_open(cmd))
+		{
+			vk::end_renderpass(cmd);
 		}
 
 		if (src != dst) [[likely]]
@@ -331,6 +347,11 @@ namespace vk
 		auto preferred_src_format = (src == dst) ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 		auto preferred_dst_format = (src == dst) ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 
+		if (vk::is_renderpass_open(cmd))
+		{
+			vk::end_renderpass(cmd);
+		}
+
 		if (srcLayout != preferred_src_format)
 			change_image_layout(cmd, src, srcLayout, preferred_src_format, vk::get_image_subresource_range(0, 0, 1, 1, src_aspect));
 
@@ -369,6 +390,11 @@ namespace vk
 
 		auto preferred_src_format = (src == dst) ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 		auto preferred_dst_format = (src == dst) ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+
+		if (vk::is_renderpass_open(cmd))
+		{
+			vk::end_renderpass(cmd);
+		}
 
 		//TODO: Use an array of offsets/dimensions for mipmapped blits (mipmap count > 1) since subimages will have different dimensions
 		if (srcLayout != preferred_src_format)
@@ -712,6 +738,11 @@ namespace vk
 		std::vector<VkBufferImageCopy> copy_regions;
 		std::vector<VkBufferCopy> buffer_copies;
 		copy_regions.reserve(subresource_layout.size());
+
+		if (vk::is_renderpass_open(cmd))
+		{
+			vk::end_renderpass(cmd);
+		}
 
 		for (const rsx_subresource_layout &layout : subresource_layout)
 		{

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -5,6 +5,7 @@
 #include "VKCompute.h"
 #include "VKResourceManager.h"
 #include "VKDMA.h"
+#include "VKRenderPass.h"
 #include "../Common/TextureUtils.h"
 #include "Utilities/mutex.h"
 #include "../Common/texture_cache.h"
@@ -174,6 +175,11 @@ namespace vk
 				// If a hard flush occurred while this surface was flush_always the cache would have reset its protection afterwards.
 				// DMA resource would still be present but already used to flush previously.
 				vk::get_resource_manager()->dispose(dma_fence);
+			}
+
+			if (vk::is_renderpass_open(cmd))
+			{
+				vk::end_renderpass(cmd);
 			}
 
 			src->push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);


### PR DESCRIPTION
Rewrites the Vulkan backend's handling of renderpass open/close scopes. This is made possible by previous commits refactoring renderpasses many months ago, as it would have been impossible before to dynamically open and close renderpasses on a global scale. With the new structure, renderpasses are always assumed to be in the open state and individual API driver calls that require renderpasses to be closed have to manually request to close the current renderpass. This allows the GPU to batch together related draw calls significantly improving rendering efficiency.

See https://youtu.be/iJfulnNr-eI