### PR TITLE
Fix sys_ppu_thread_yield

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
@@ -18,7 +18,7 @@ error_code sys_lwcond_create(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, vm::
 	attrs->pshared  = SYS_SYNC_NOT_PROCESS_SHARED;
 	attrs->name_u64 = attr->name_u64;
 
-	if (auto res = g_cfg.core.hle_lwmutex ? sys_cond_create(ppu, out_id, lwmutex->sleep_queue, attrs) : _sys_lwcond_create(ppu, out_id, lwmutex->sleep_queue, lwcond, attr->name_u64, 0))
+	if (auto res = g_cfg.core.hle_lwmutex ? sys_cond_create(ppu, out_id, lwmutex->sleep_queue, attrs) : _sys_lwcond_create(ppu, out_id, lwmutex->sleep_queue, lwcond, attr->name_u64))
 	{
 		return res;
 	}

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -106,7 +106,7 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	BIND_FUNC(_sys_process_exit2),                          //26  (0x01A)
 	BIND_FUNC(sys_process_spawns_a_self2),                  //27  (0x01B)  DBG
 	null_func,//BIND_FUNC(_sys_process_get_number_of_object)//28  (0x01C)  ROOT
-	BIND_FUNC(sys_process_get_id2),                          //29  (0x01D)  ROOT
+	BIND_FUNC(sys_process_get_id2),                         //29  (0x01D)  ROOT
 	BIND_FUNC(_sys_process_get_paramsfo),                   //30  (0x01E)
 	null_func,//BIND_FUNC(sys_process_get_ppu_guid),        //31  (0x01F)
 
@@ -121,8 +121,8 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	BIND_FUNC(sys_ppu_thread_set_priority),                 //47  (0x02F)  DBG
 	BIND_FUNC(sys_ppu_thread_get_priority),                 //48  (0x030)
 	BIND_FUNC(sys_ppu_thread_get_stack_information),        //49  (0x031)
-	null_func,//BIND_FUNC(sys_ppu_thread_stop),             //50  (0x032)  ROOT
-	null_func,//BIND_FUNC(sys_ppu_thread_restart),          //51  (0x033)  ROOT
+	BIND_FUNC(sys_ppu_thread_stop),                         //50  (0x032)  ROOT
+	BIND_FUNC(sys_ppu_thread_restart),                      //51  (0x033)  ROOT
 	BIND_FUNC(_sys_ppu_thread_create),                      //52  (0x034)  DBG
 	BIND_FUNC(sys_ppu_thread_start),                        //53  (0x035)
 	null_func,//BIND_FUNC(sys_ppu_...),                     //54  (0x036)  ROOT

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1133,7 +1133,7 @@ void lv2_obj::sleep_unlocked(cpu_thread& thread, u64 timeout)
 	}
 }
 
-void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
+bool lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 {
 	// Check thread type
 	AUDIT(!cpu || cpu->id_type() == 1);
@@ -1145,7 +1145,7 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 		// Priority set
 		if (static_cast<ppu_thread*>(cpu)->prio.exchange(prio) == prio || !unqueue(g_ppu, cpu))
 		{
-			return;
+			return true;
 		}
 
 		break;
@@ -1153,25 +1153,27 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 	case yield_cmd:
 	{
 		// Yield command
-		const u64 start_time = get_guest_system_time();
-
-		for (std::size_t i = 0, pos = -1; i < g_ppu.size(); i++)
+		for (std::size_t i = 0;; i++)
 		{
-			if (g_ppu[i] == cpu)
+			if (i + 1 >= g_ppu.size())
 			{
-				pos = i;
-				prio = g_ppu[i]->prio;
+				return false;
 			}
-			else if (i == pos + 1 && prio != -4 && g_ppu[i]->prio != prio)
+
+			if (const auto ppu = g_ppu[i]; ppu == cpu)
 			{
-				return;
+				if (g_ppu[i + 1]->prio != ppu->prio)
+				{
+					return false;
+				}
+				else
+				{
+					g_ppu.erase(g_ppu.cbegin() + i);
+					ppu->start_time = get_guest_system_time();
+					break;
+				}
 			}
 		}
-
-		unqueue(g_ppu, cpu);
-		unqueue(g_pending, cpu);
-
-		static_cast<ppu_thread*>(cpu)->start_time = start_time;
 	}
 	case enqueue_cmd:
 	{
@@ -1186,7 +1188,7 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 			if (it != end && *it == cpu)
 			{
 				ppu_log.trace("sleep() - suspended (p=%zu)", g_pending.size());
-				return;
+				return false;
 			}
 
 			// Use priority, also preserve FIFO order
@@ -1208,17 +1210,20 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 		}
 
 		ppu_log.trace("awake(): %s", cpu->id);
+		return true;
 	};
+
+	bool changed_queue = false;
 
 	if (cpu)
 	{
 		// Emplace current thread
-		emplace_thread(cpu);
+		changed_queue = emplace_thread(cpu);
 	}
 	else for (const auto _cpu : g_to_awake)
 	{
 		// Emplace threads from list
-		emplace_thread(_cpu);
+		changed_queue |= emplace_thread(_cpu);
 	}
 
 	// Remove pending if necessary
@@ -1228,7 +1233,7 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 	}
 
 	// Suspend threads if necessary
-	for (std::size_t i = g_cfg.core.ppu_threads; i < g_ppu.size(); i++)
+	for (std::size_t i = g_cfg.core.ppu_threads; changed_queue && i < g_ppu.size(); i++)
 	{
 		const auto target = g_ppu[i];
 
@@ -1240,6 +1245,7 @@ void lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 	}
 
 	schedule_all();
+	return changed_queue;
 }
 
 void lv2_obj::cleanup()

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -9,11 +9,11 @@
 
 LOG_CHANNEL(sys_lwcond);
 
-error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmutex_id, vm::ptr<sys_lwcond_t> control, u64 name, u32 arg5)
+error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmutex_id, vm::ptr<sys_lwcond_t> control, u64 name)
 {
 	vm::temporary_unlock(ppu);
 
-	sys_lwcond.warning("_sys_lwcond_create(lwcond_id=*0x%x, lwmutex_id=0x%x, control=*0x%x, name=0x%llx, arg5=0x%x)", lwcond_id, lwmutex_id, control, name, arg5);
+	sys_lwcond.warning(u8"_sys_lwcond_create(lwcond_id=*0x%x, lwmutex_id=0x%x, control=*0x%x, name=0x%llx (“%s”))", lwcond_id, lwmutex_id, control, name, lv2_obj::name64(name));
 
 	u32 protocol;
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.h
@@ -48,7 +48,7 @@ class ppu_thread;
 
 // Syscalls
 
-error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmutex_id, vm::ptr<sys_lwcond_t> control, u64 name, u32 arg5);
+error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmutex_id, vm::ptr<sys_lwcond_t> control, u64 name);
 error_code _sys_lwcond_destroy(ppu_thread& ppu, u32 lwcond_id);
 error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u32 ppu_thread_id, u32 mode);
 error_code _sys_lwcond_signal_all(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u32 mode);

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -12,7 +12,7 @@ error_code _sys_lwmutex_create(ppu_thread& ppu, vm::ptr<u32> lwmutex_id, u32 pro
 {
 	vm::temporary_unlock(ppu);
 
-	sys_lwmutex.warning("_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, has_name=0x%x, name=0x%llx)", lwmutex_id, protocol, control, has_name, name);
+	sys_lwmutex.warning(u8"_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, has_name=0x%x, name=0x%llx (“%s”))", lwmutex_id, protocol, control, has_name, name, lv2_obj::name64(name));
 
 	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_RETRY && protocol != SYS_SYNC_PRIORITY)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -78,11 +78,12 @@ void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode)
 	}
 }
 
-void sys_ppu_thread_yield(ppu_thread& ppu)
+s32 sys_ppu_thread_yield(ppu_thread& ppu)
 {
 	sys_ppu_thread.trace("sys_ppu_thread_yield()");
 
-	lv2_obj::yield(ppu);
+	// Return 1 on no-op, 0 on successful context switch
+	return +!lv2_obj::yield(ppu);
 }
 
 error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr)

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.h
@@ -56,7 +56,7 @@ enum : u32
 // Syscalls
 
 void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode);
-void sys_ppu_thread_yield(ppu_thread& ppu);
+s32 sys_ppu_thread_yield(ppu_thread& ppu); // Return value is ignored by the library
 error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr);
 error_code sys_ppu_thread_detach(u32 thread_id);
 error_code sys_ppu_thread_get_join_state(ppu_thread& ppu, vm::ptr<s32> isjoinable); // Error code is ignored by the library

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1690,7 +1690,9 @@ error_code sys_raw_spu_destroy(ppu_thread& ppu, u32 id)
 
 	sys_spu.warning("sys_raw_spu_destroy(id=%d)", id);
 
-	auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id), [](named_thread<spu_thread>& thread)
+	const u32 idm_id = spu_thread::find_raw_spu(id);
+
+	auto thread = idm::get<named_thread<spu_thread>>(idm_id, [](named_thread<spu_thread>& thread)
 	{
 		// Stop thread
 		thread.state += cpu_flag::exit;
@@ -1745,7 +1747,9 @@ error_code sys_raw_spu_destroy(ppu_thread& ppu, u32 id)
 			idm::remove_verify<lv2_obj, lv2_int_serv>(pair.second, std::move(pair.first));
 	}
 
-	if (!idm::remove_verify<named_thread<spu_thread>>(id, std::move(thread)))
+	(*thread)();
+
+	if (!idm::remove_verify<named_thread<spu_thread>>(idm_id, std::move(thread)))
 	{
 		// Other thread destroyed beforehead
 		return CELL_ESRCH;

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -130,7 +130,7 @@ private:
 	static void sleep_unlocked(cpu_thread&, u64 timeout);
 
 	// Schedule the thread
-	static void awake_unlocked(cpu_thread*, s32 prio = enqueue_cmd);
+	static bool awake_unlocked(cpu_thread*, s32 prio = enqueue_cmd);
 
 public:
 	static void sleep(cpu_thread& cpu, const u64 timeout = 0)
@@ -140,16 +140,17 @@ public:
 		g_to_awake.clear();
 	}
 
-	static inline void awake(cpu_thread* const thread, s32 prio = enqueue_cmd)
+	static inline bool awake(cpu_thread* const thread, s32 prio = enqueue_cmd)
 	{
 		std::lock_guard lock(g_mutex);
-		awake_unlocked(thread, prio);
+		return awake_unlocked(thread, prio);
 	}
 
-	static void yield(cpu_thread& thread)
+	// Returns true and success, false if did nothing
+	static bool yield(cpu_thread& thread)
 	{
 		vm::temporary_unlock(thread);
-		awake(&thread, yield_cmd);
+		return awake(&thread, yield_cmd);
 	}
 
 	static void set_priority(cpu_thread& thread, s32 prio)

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -14,6 +14,7 @@
 
 #include <deque>
 #include <thread>
+#include <string_view>
 
 // attr_protocol (waiting scheduling policy)
 enum
@@ -74,6 +75,18 @@ private:
 	};
 
 public:
+
+	static std::string_view name64(const u64& name_u64)
+	{
+		std::string_view str{reinterpret_cast<const char*>(&name_u64), 7};
+
+		if (const auto pos = str.find_first_of('\0'); pos != umax)
+		{
+			str.remove_suffix(str.size() - pos);
+		}
+
+		return str;
+	};
 
 	// Find and remove the object from the container (deque or vector)
 	template <typename T, typename E>

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -75,23 +75,6 @@ void kernel_explorer::Update()
 	root->setText(0, qstr(fmt::format("Process, ID = 0x00000001, Total Memory Usage = 0x%x (%0.2f MB)", total_memory_usage, 1.f * total_memory_usage / (1024 * 1024))));
 	m_tree->addTopLevelItem(root);
 
-	union name64
-	{
-		u64 u64_data;
-		char string[8];
-
-		name64(u64 data)
-			: u64_data(data)
-		{
-			string[7] = '\0';
-		}
-
-		const char* operator+() const
-		{
-			return string;
-		}
-	};
-
 	// TODO: FileSystem
 
 	struct lv2_obj_rec
@@ -149,21 +132,21 @@ void kernel_explorer::Update()
 		case SYS_MUTEX_OBJECT:
 		{
 			auto& mutex = static_cast<lv2_mutex&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("Mutex: ID = 0x%08x \"%s\",%s Owner = 0x%x, Locks = %u, Conds = %u, Wq = %zu", id, +name64(mutex.name),
+			l_addTreeChild(node, qstr(fmt::format(u8"Mutex: ID = 0x%08x “%s”,%s Owner = 0x%x, Locks = %u, Conds = %u, Wq = %zu", id, lv2_obj::name64(mutex.name),
 				mutex.recursive == SYS_SYNC_RECURSIVE ? " Recursive," : "", mutex.owner >> 1, +mutex.lock_count, +mutex.cond_count, mutex.sq.size())));
 			break;
 		}
 		case SYS_COND_OBJECT:
 		{
 			auto& cond = static_cast<lv2_cond&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("Cond: ID = 0x%08x \"%s\", Waiters = %u", id, +name64(cond.name), +cond.waiters)));
+			l_addTreeChild(node, qstr(fmt::format(u8"Cond: ID = 0x%08x “%s”, Waiters = %u", id, lv2_obj::name64(cond.name), +cond.waiters)));
 			break;
 		}
 		case SYS_RWLOCK_OBJECT:
 		{
 			auto& rw = static_cast<lv2_rwlock&>(obj);
 			const s64 val = rw.owner;
-			l_addTreeChild(node, qstr(fmt::format("RW Lock: ID = 0x%08x \"%s\", Owner = 0x%x(%d), Rq = %zu, Wq = %zu", id, +name64(rw.name),
+			l_addTreeChild(node, qstr(fmt::format(u8"RW Lock: ID = 0x%08x “%s”, Owner = 0x%x(%d), Rq = %zu, Wq = %zu", id, lv2_obj::name64(rw.name),
 				std::max<s64>(0, val >> 1), -std::min<s64>(0, val >> 1), rw.rq.size(), rw.wq.size())));
 			break;
 		}
@@ -182,7 +165,7 @@ void kernel_explorer::Update()
 		case SYS_EVENT_QUEUE_OBJECT:
 		{
 			auto& eq = static_cast<lv2_event_queue&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("Event Queue: ID = 0x%08x \"%s\", %s, Key = %#llx, Events = %zu/%d, Waiters = %zu", id, +name64(eq.name),
+			l_addTreeChild(node, qstr(fmt::format(u8"Event Queue: ID = 0x%08x “%s”, %s, Key = %#llx, Events = %zu/%d, Waiters = %zu", id, lv2_obj::name64(eq.name),
 				eq.type == SYS_SPU_QUEUE ? "SPU" : "PPU", eq.key, eq.events.size(), eq.size, eq.sq.size())));
 			break;
 		}
@@ -222,7 +205,7 @@ void kernel_explorer::Update()
 		case SYS_LWMUTEX_OBJECT:
 		{
 			auto& lwm = static_cast<lv2_lwmutex&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("LWMutex: ID = 0x%08x \"%s\", Wq = %zu", id, +name64(lwm.name), lwm.sq.size())));
+			l_addTreeChild(node, qstr(fmt::format(u8"LWMutex: ID = 0x%08x “%s”, Wq = %zu", id, lv2_obj::name64(lwm.name), lwm.sq.size())));
 			break;
 		}
 		case SYS_TIMER_OBJECT:
@@ -234,20 +217,20 @@ void kernel_explorer::Update()
 		case SYS_SEMAPHORE_OBJECT:
 		{
 			auto& sema = static_cast<lv2_sema&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("Semaphore: ID = 0x%08x \"%s\", Count = %d, Max Count = %d, Waiters = %#zu", id, +name64(sema.name),
+			l_addTreeChild(node, qstr(fmt::format(u8"Semaphore: ID = 0x%08x “%s”, Count = %d, Max Count = %d, Waiters = %#zu", id, lv2_obj::name64(sema.name),
 				sema.val.load(), sema.max, sema.sq.size())));
 			break;
 		}
 		case SYS_LWCOND_OBJECT:
 		{
 			auto& lwc = static_cast<lv2_lwcond&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("LWCond: ID = 0x%08x \"%s\", Waiters = %zu", id, +name64(lwc.name), +lwc.waiters)));
+			l_addTreeChild(node, qstr(fmt::format(u8"LWCond: ID = 0x%08x “%s”, Waiters = %zu", id, lv2_obj::name64(lwc.name), +lwc.waiters)));
 			break;
 		}
 		case SYS_EVENT_FLAG_OBJECT:
 		{
 			auto& ef = static_cast<lv2_event_flag&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("Event Flag: ID = 0x%08x \"%s\", Type = 0x%x, Pattern = 0x%llx, Wq = %zu", id, +name64(ef.name),
+			l_addTreeChild(node, qstr(fmt::format(u8"Event Flag: ID = 0x%08x “%s”, Type = 0x%x, Pattern = 0x%llx, Wq = %zu", id, lv2_obj::name64(ef.name),
 				ef.type, ef.pattern.load(), +ef.waiters)));
 			break;
 		}
@@ -271,7 +254,7 @@ void kernel_explorer::Update()
 	idm::select<named_thread<ppu_thread>>([&](u32 id, ppu_thread& ppu)
 	{
 		lv2_types.back().count++;
-		l_addTreeChild(lv2_types.back().node, qstr(fmt::format("PPU Thread: ID = 0x%08x '%s'", id, *ppu.ppu_tname.load())));
+		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"PPU Thread: ID = 0x%08x “%s”", id, *ppu.ppu_tname.load())));
 	});
 
 	lv2_types.emplace_back(l_addTreeChild(root, "SPU Threads"));
@@ -279,7 +262,7 @@ void kernel_explorer::Update()
 	idm::select<named_thread<spu_thread>>([&](u32 /*id*/, spu_thread& spu)
 	{
 		lv2_types.back().count++;
-		l_addTreeChild(lv2_types.back().node, qstr(fmt::format("SPU Thread: ID = 0x%08x '%s'", spu.lv2_id, *spu.spu_tname.load())));
+		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"SPU Thread: ID = 0x%08x “%s”", spu.lv2_id, *spu.spu_tname.load())));
 	});
 
 	lv2_types.emplace_back(l_addTreeChild(root, "SPU Thread Groups"));
@@ -287,7 +270,7 @@ void kernel_explorer::Update()
 	idm::select<lv2_spu_group>([&](u32 id, lv2_spu_group& tg)
 	{
 		lv2_types.back().count++;
-		l_addTreeChild(lv2_types.back().node, qstr(fmt::format("SPU Thread Group: ID = 0x%08x '%s'", id, tg.name)));
+		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"SPU Thread Group: ID = 0x%08x “%s”", id, tg.name)));
 	});
 
 	lv2_types.emplace_back(l_addTreeChild(root, "File Descriptors"));
@@ -295,7 +278,7 @@ void kernel_explorer::Update()
 	idm::select<lv2_fs_object>([&](u32 id, lv2_fs_object& fo)
 	{
 		lv2_types.back().count++;
-		l_addTreeChild(lv2_types.back().node, qstr(fmt::format("FD: ID = 0x%08x '%s'", id, fo.name.data())));
+		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"FD: ID = 0x%08x “%s”", id, fo.name.data())));
 	});
 
 	for (auto&& entry : lv2_types)


### PR DESCRIPTION
* Turns out the syscall does return a value from quick reversing: 0 if a context switch occured, 1 if nothing happend, although the returned value is ignored by known ps3 compilers.
* Fixed a regression from #6933 which made the condition `prio != -4` always evaluate to true, leading to false early returns from yield.
 * Uncomment sys_ppu_thread_stop/restart as their handlers functions exist.
* Move name64 helper to lv2_obj::name64, use std::string_view instead of temporary NTS string.
* Use common initial sequance in v128 to partially obey 'strict type aliasing'.