### PR TITLE
Fix lv2 sys_lwcond/sys_lwmutex kernel explorer names

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
@@ -18,7 +18,7 @@ error_code sys_lwcond_create(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, vm::
 	attrs->pshared  = SYS_SYNC_NOT_PROCESS_SHARED;
 	attrs->name_u64 = attr->name_u64;
 
-	if (auto res = g_cfg.core.hle_lwmutex ? sys_cond_create(ppu, out_id, lwmutex->sleep_queue, attrs) : _sys_lwcond_create(ppu, out_id, lwmutex->sleep_queue, lwcond, attr->name_u64))
+	if (auto res = g_cfg.core.hle_lwmutex ? sys_cond_create(ppu, out_id, lwmutex->sleep_queue, attrs) : _sys_lwcond_create(ppu, out_id, lwmutex->sleep_queue, lwcond, std::bit_cast<be_t<u64>>(attr->name_u64)))
 	{
 		return res;
 	}

--- a/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
@@ -41,7 +41,7 @@ error_code sys_lwmutex_create(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex, v
 	attrs->flags     = 0;
 	attrs->name_u64  = attr->name_u64;
 
-	if (error_code res = g_cfg.core.hle_lwmutex ? sys_mutex_create(ppu, out_id, attrs) : _sys_lwmutex_create(ppu, out_id, protocol, lwmutex, 0x80000001, attr->name_u64))
+	if (error_code res = g_cfg.core.hle_lwmutex ? sys_mutex_create(ppu, out_id, attrs) : _sys_lwmutex_create(ppu, out_id, protocol, lwmutex, 0x80000001, std::bit_cast<be_t<u64>>(attr->name_u64)))
 	{
 		return res;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -13,7 +13,7 @@ error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmut
 {
 	vm::temporary_unlock(ppu);
 
-	sys_lwcond.warning(u8"_sys_lwcond_create(lwcond_id=*0x%x, lwmutex_id=0x%x, control=*0x%x, name=0x%llx (“%s”))", lwcond_id, lwmutex_id, control, name, lv2_obj::name64(name));
+	sys_lwcond.warning(u8"_sys_lwcond_create(lwcond_id=*0x%x, lwmutex_id=0x%x, control=*0x%x, name=0x%llx (“%s”))", lwcond_id, lwmutex_id, control, name, lv2_obj::name64(std::bit_cast<be_t<u64>>(name)));
 
 	u32 protocol;
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.h
@@ -25,7 +25,7 @@ struct lv2_lwcond final : lv2_obj
 {
 	static const u32 id_base = 0x97000000;
 
-	const u64 name;
+	const be_t<u64> name;
 	const u32 lwid;
 	const u32 protocol;
 	vm::ptr<sys_lwcond_t> control;
@@ -35,7 +35,7 @@ struct lv2_lwcond final : lv2_obj
 	std::deque<cpu_thread*> sq;
 
 	lv2_lwcond(u64 name, u32 lwid, u32 protocol, vm::ptr<sys_lwcond_t> control)
-		: name(name)
+		: name(std::bit_cast<be_t<u64>>(name))
 		, lwid(lwid)
 		, protocol(protocol)
 		, control(control)

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -12,7 +12,7 @@ error_code _sys_lwmutex_create(ppu_thread& ppu, vm::ptr<u32> lwmutex_id, u32 pro
 {
 	vm::temporary_unlock(ppu);
 
-	sys_lwmutex.warning(u8"_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, has_name=0x%x, name=0x%llx (“%s”))", lwmutex_id, protocol, control, has_name, name, lv2_obj::name64(name));
+	sys_lwmutex.warning(u8"_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, has_name=0x%x, name=0x%llx (“%s”))", lwmutex_id, protocol, control, has_name, name, lv2_obj::name64(std::bit_cast<be_t<u64>>(name)));
 
 	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_RETRY && protocol != SYS_SYNC_PRIORITY)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -57,7 +57,7 @@ struct lv2_lwmutex final : lv2_obj
 
 	const u32 protocol;
 	const vm::ptr<sys_lwmutex_t> control;
-	const u64 name;
+	const be_t<u64> name;
 
 	shared_mutex mutex;
 	atomic_t<s32> signaled{0};
@@ -66,7 +66,7 @@ struct lv2_lwmutex final : lv2_obj
 	lv2_lwmutex(u32 protocol, vm::ptr<sys_lwmutex_t> control, u64 name)
 		: protocol(protocol)
 		, control(control)
-		, name(name)
+		, name(std::bit_cast<be_t<u64>>(name))
 	{
 	}
 };

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -82,7 +82,7 @@ s32 sys_ppu_thread_yield(ppu_thread& ppu)
 {
 	sys_ppu_thread.trace("sys_ppu_thread_yield()");
 
-	// Return 1 on no-op, 0 on successful context switch
+	// Return 0 on successful context switch, 1 otherwise
 	return +!lv2_obj::yield(ppu);
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -159,7 +159,7 @@ public:
 		return awake_unlocked(thread, prio);
 	}
 
-	// Returns true and success, false if did nothing
+	// Returns true on successful context switch, false otherwise
 	static bool yield(cpu_thread& thread)
 	{
 		vm::temporary_unlock(thread);


### PR DESCRIPTION
liblv2.sprx's sys_lwmutex/lwcond_create functions load the attribute's name (type=char[8]) via `ld` (big endian 64-bit) instruction in LLE.
Then name (type=u64) argument passed to the syscalls _sys_lwmutex/lwcond_create  which treat it as big endian as well on ps3 fw, so we need to byteswap it as well before reading as a NTS-like string.
Of course this also means that our HLE sys_lwcond/lwmutex_create liblv2 functions also need modification to byteswap when passing name argument to the syscalls.
This applies to related log messages as well.

Before:
![image](https://user-images.githubusercontent.com/18193363/76976188-4f714900-693c-11ea-8c4a-4e04433f3ef0.png)
After:
![image](https://user-images.githubusercontent.com/18193363/76976761-15ed0d80-693d-11ea-81f6-9907f1a10b82.png)
