### PR TITLE
Minor improvements for debugging tools

### DIFF
--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -80,7 +80,7 @@ void debugger_list::ShowAddress(u32 addr)
 	{
 		const bool is_spu = cpu->id_type() != 1;
 		const u32 cpu_offset = is_spu ? static_cast<spu_thread&>(*cpu).offset : 0;
-		const u32 address_limits = is_spu ? 0x3ffff : ~0;
+		const u32 address_limits = (is_spu ? 0x3fffc : ~3);
 		m_pc &= address_limits;
 		m_disasm->offset = vm::get_super_ptr(cpu_offset);
 		for (uint i = 0, count = 4; i<m_item_count; ++i, m_pc = (m_pc + count) & address_limits)

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -73,7 +73,7 @@ void debugger_list::ShowAddress(u32 addr)
 	{
 		for (uint i = 0; i < m_item_count; ++i, m_pc += 4)
 		{
-			item(i)->setText(qstr(fmt::format("[%08x] illegal address", m_pc)));
+			item(i)->setText(qstr(fmt::format("   [%08x] illegal address", m_pc)));
 		}
 	}
 	else
@@ -87,14 +87,14 @@ void debugger_list::ShowAddress(u32 addr)
 		{
 			if (!vm::check_addr(cpu_offset + m_pc, 4))
 			{
-				item(i)->setText((IsBreakpoint(m_pc) ? ">>> " : "    ") + qstr(fmt::format("[%08x] illegal address", m_pc)));
+				item(i)->setText((IsBreakpoint(m_pc) ? ">> " : "   ") + qstr(fmt::format("[%08x] illegal address", m_pc)));
 				count = 4;
 				continue;
 			}
 
 			count = m_disasm->disasm(m_disasm->dump_pc = m_pc);
 
-			item(i)->setText((IsBreakpoint(m_pc) ? ">>> " : "    ") + qstr(m_disasm->last_opcode));
+			item(i)->setText((IsBreakpoint(m_pc) ? ">> " : "   ") + qstr(m_disasm->last_opcode));
 
 			if (cpu->is_paused() && m_pc == GetPc())
 			{


### PR DESCRIPTION
* Fix a segfault when viewing unmapped memory as image in memory viewer, simply do nothing in this case. Also use super ptr because non-emu threads do not support rsx access violation handling.
* Remove one '>' or space from the disassembler view, there were 4 characters reserved only for breakpoints which looked weird imo, now there are only 3.
Also make it consistent with 'no thread' view, add the remaining 3 spaces there as well.
* Fix memory leaks regarding wrong usage of QImage passed raw pointers in rsx debugger and memory image viewer.
* Fix a corner case when viewing unaligned spu memory at the end of SPU LS by force aligning the address to 4 bytes. For non-aligned memory view the proper memory viewer tool should be used instead of the disassembler.
* Avoid a segfault when reading ppu stack contents in debugger.
