### PR TITLE
cellSaveData: Add some error checks and default values of some members

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -698,6 +698,8 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 		if (funcList)
 		{
+			listSet->focusPosition = CELL_SAVEDATA_FOCUSPOS_LISTHEAD;
+
 			// List Callback
 			funcList(ppu, result, listGet, listSet);
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -77,15 +77,15 @@ namespace
 {
 	struct savedata_context
 	{
-		CellSaveDataCBResult result;
-		CellSaveDataListGet  listGet;
-		CellSaveDataListSet  listSet;
-		CellSaveDataFixedSet fixedSet;
-		CellSaveDataStatGet  statGet;
-		CellSaveDataStatSet  statSet;
-		CellSaveDataFileGet  fileGet;
-		CellSaveDataFileSet  fileSet;
-		CellSaveDataDoneGet  doneGet;
+		alignas(16) CellSaveDataCBResult result;
+		alignas(16) CellSaveDataListGet  listGet;
+		alignas(16) CellSaveDataListSet  listSet;
+		alignas(16) CellSaveDataFixedSet fixedSet;
+		alignas(16) CellSaveDataStatGet  statGet;
+		alignas(16) CellSaveDataStatSet  statSet;
+		alignas(16) CellSaveDataFileGet  fileGet;
+		alignas(16) CellSaveDataFileSet  fileSet;
+		alignas(16) CellSaveDataDoneGet  doneGet;
 	};
 }
 
@@ -704,6 +704,8 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		{
 			listSet->focusPosition = CELL_SAVEDATA_FOCUSPOS_LISTHEAD;
 
+			std::memset(result.get_ptr(), 0, ::offset32(&CellSaveDataCBResult::userdata));
+
 			// List Callback
 			funcList(ppu, result, listGet, listSet);
 
@@ -962,6 +964,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				doneGet->excResult = CELL_SAVEDATA_ERROR_NODATA;
 			}
 
+			std::memset(result.get_ptr(), 0, ::offset32(&CellSaveDataCBResult::userdata));
 			funcDone(ppu, result, doneGet);
 		};
 
@@ -1059,6 +1062,8 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		if (funcFixed)
 		{
 			lv2_sleep(ppu, 250);
+
+			std::memset(result.get_ptr(), 0, ::offset32(&CellSaveDataCBResult::userdata));
 
 			// Fixed Callback
 			funcFixed(ppu, result, listGet, fixedSet);
@@ -1358,6 +1363,8 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		statGet->sysSizeKB = 35; // always reported as 35 regardless of actual file sizes
 		statGet->sizeKB = !save_entry.isNew ? ::narrow<s32>((size_bytes / 1024) + statGet->sysSizeKB) : 0;
 
+		std::memset(result.get_ptr(), 0, ::offset32(&CellSaveDataCBResult::userdata));
+
 		// Stat Callback
 		funcStat(ppu, result, statGet, statSet);
 
@@ -1516,6 +1523,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 	{
 		std::memset(fileSet.get_ptr(), 0, fileSet.size());
 		std::memset(fileGet->reserved, 0, sizeof(fileGet->reserved));
+		std::memset(result.get_ptr(), 0, ::offset32(&CellSaveDataCBResult::userdata));
 
 		funcFile(ppu, result, fileGet, fileSet);
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1984,6 +1984,11 @@ static NEVER_INLINE error_code savedata_get_list_item(vm::cptr<char> dirName, vm
 
 		for (const auto& entry : fs::dir(save_path))
 		{
+			if (entry.is_directory)
+			{
+				continue;
+			}
+
 			size_kbytes += ::narrow<u32>((entry.size + 1023) / 1024); // firmware rounds this value up
 		}
 

--- a/rpcs3/Emu/Cell/Modules/cellUserInfo.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellUserInfo.cpp
@@ -33,7 +33,8 @@ error_code cellUserInfoGetStat(u32 id, vm::ptr<CellUserInfoUserStat> stat)
 
 	if (id > CELL_SYSUTIL_USERID_MAX)
 	{
-		return CELL_USERINFO_ERROR_NOUSER;
+		// ****** sysutil userinfo parameter error : 1 ******
+		return {CELL_USERINFO_ERROR_PARAM, "1"};
 	}
 
 	if (id == CELL_SYSUTIL_USERID_CURRENT)
@@ -41,9 +42,6 @@ error_code cellUserInfoGetStat(u32 id, vm::ptr<CellUserInfoUserStat> stat)
 		// We want the int value, not the string.
 		id = Emu.GetUsrId();
 	}
-
-	if (!stat)
-		return CELL_USERINFO_ERROR_PARAM;
 
 	const std::string& path = vfs::get(fmt::format("/dev_hdd0/home/%08d/", id));
 
@@ -61,8 +59,11 @@ error_code cellUserInfoGetStat(u32 id, vm::ptr<CellUserInfoUserStat> stat)
 		return CELL_USERINFO_ERROR_INTERNAL;
 	}
 
-	stat->id = id;
-	strcpy_trunc(stat->name, f.to_string());
+	if (stat)
+	{
+		stat->id = id;
+		strcpy_trunc(stat->name, f.to_string());
+	}
 
 	return CELL_OK;
 }


### PR DESCRIPTION
* Add CELL_SAVEDATA_ERROR_NOUSER if user does not exist, check if userId is greater than CELL_SYSUTIL_USERID_MAX (param error 91).
* Set listSet->focusPosition to LISTHEAD by default, REd.
* Add error checks for cellSaveData(User)GetListItem: check dirName for nullptr, name format, id > CELL_SYSUTIL_USERID_MAX, user existence.
 * Allow stat == nullptr in cellUserInfoGetStat, fix error code of id > CELL_SYSUTIL_USERID_MAX to param error 1 (REd).
* Skip directory items in savedata_get_list_item.
* memset 0 setBuf->buf (to bufSize) before funcStat if the savedata direcory is not new.
* memset 0 setBuf->buf (to bufSize) if listGet->dirNum became non-zero (listGet->dirListNum can be zero yet memset still occurs) .
* Clear traces of setList setup in setBuf->buf before funcStat (after funcFixed/List, only if listGet->dirNum != 0, callback can hack this value and prevent the memset). (last 3 points were tested on realhw)
* Ensure 16-byte aligned g_savedata_context members, store zeroes in CBResult args except userdata before every callback.