### PR TITLE
kernel explorer: Implement ability to view lwmutex owner

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_spinlock.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_spinlock.cpp
@@ -28,7 +28,7 @@ error_code sys_spinlock_lock(ppu_thread& ppu, vm::ptr<atomic_be_t<u32>> lock)
 		}
 	}
 
-	return not_an_error(ppu.gpr[3]);
+	return CELL_OK;
 }
 
 s32 sys_spinlock_trylock(vm::ptr<atomic_be_t<u32>> lock)

--- a/rpcs3/Emu/Cell/PPUFunction.h
+++ b/rpcs3/Emu/Cell/PPUFunction.h
@@ -9,6 +9,7 @@ using ppu_function_t = bool(*)(ppu_thread&);
 	const auto old_f = ppu.current_function;\
 	if (!old_f) ppu.last_function = #func;\
 	ppu.current_function = #func;\
+	ppu.syscall_r3 = ppu.gpr[3];\
 	ppu_func_detail::do_call(ppu, func);\
 	ppu.current_function = old_f;\
 	ppu.cia += 4;\

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -432,6 +432,7 @@ std::string ppu_thread::dump() const
 		ret += "Current function: ";
 		ret += _func;
 		ret += '\n';
+		fmt::append(ret, "syscall r3: 0x%llx\n", syscall_r3);
 	}
 	else if (is_paused())
 	{

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -189,6 +189,7 @@ public:
 	cmd64 cmd_get(u32 index) { return cmd_queue[cmd_queue.peek() + index].load(); }
 
 	u64 start_time{0}; // Sleep start timepoint
+	u64 syscall_r3{0}; // Save r3 before syscalls
 	const char* current_function{}; // Current function name for diagnosis, optimized for speed.
 	const char* last_function{}; // Sticky copy of current_function, is not cleared on function return
 

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -95,13 +95,14 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 	sys_event_flag.trace("sys_event_flag_wait(id=0x%x, bitptn=0x%llx, mode=0x%x, result=*0x%x, timeout=0x%llx)", id, bitptn, mode, result, timeout);
 
 	// Fix function arguments for external access
+	// TODO: Avoid using registers
 	ppu.gpr[3] = -1;
 	ppu.gpr[4] = bitptn;
 	ppu.gpr[5] = mode;
 	ppu.gpr[6] = 0;
 
 	// Always set result
-	if (result) *result = ppu.gpr[6];
+	if (result) *result = 0;
 
 	if (!lv2_event_flag::check_mode(mode))
 	{

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -271,10 +271,10 @@ void kernel_explorer::Update()
 
 	lv2_types.emplace_back(l_addTreeChild(root, "Memory Containers"));
 
-	idm::select<lv2_memory_container>([&](u32 id, lv2_memory_container&)
+	idm::select<lv2_memory_container>([&](u32 id, lv2_memory_container& container)
 	{
 		lv2_types.back().count++;
-		l_addTreeChild(lv2_types.back().node, qstr(fmt::format("Memory Container: ID = 0x%08x", id)));
+		l_addTreeChild(lv2_types.back().node, qstr(fmt::format("Memory Container: ID = 0x%08x, total size = 0x%x, used = 0x%x", id, container.size, +container.used)));
 	});
 
 	lv2_types.emplace_back(l_addTreeChild(root, "PPU Threads"));

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -205,7 +205,35 @@ void kernel_explorer::Update()
 		case SYS_LWMUTEX_OBJECT:
 		{
 			auto& lwm = static_cast<lv2_lwmutex&>(obj);
-			l_addTreeChild(node, qstr(fmt::format(u8"LWMutex: ID = 0x%08x “%s”, Wq = %zu", id, lv2_obj::name64(lwm.name), lwm.sq.size())));
+			std::string owner_str = "unknown"; // Either invalid state or the lwmutex control data was moved from
+			sys_lwmutex_t lwm_data{};
+
+			if (lwm.control.try_read(lwm_data))
+			{
+				switch (const u32 owner = lwm_data.vars.owner)
+				{
+				case lwmutex_free: owner_str = "free"; break;
+				//case lwmutex_dead: owner_str = "dead"; break;
+				case lwmutex_reserved: owner_str = "reserved"; break;
+				default:
+				{
+					if (owner >= ppu_thread::id_base && owner <= ppu_thread::id_base + ppu_thread::id_step - 1)
+					{
+						owner_str = fmt::format("0x%x", owner);
+					}
+
+					break;
+				}			
+				}
+			}
+			else
+			{
+				l_addTreeChild(node, qstr(fmt::format(u8"LWMutex: ID = 0x%08x “%s”, Wq = %zu (Couldn't extract control data)", id, lv2_obj::name64(lwm.name), lwm.sq.size())));
+				break;
+			}
+
+			l_addTreeChild(node, qstr(fmt::format(u8"LWMutex: ID = 0x%08x “%s”,%s Owner = %s, Locks = %u, Wq = %zu", id, lv2_obj::name64(lwm.name),
+					(lwm_data.attribute & SYS_SYNC_RECURSIVE) ? " Recursive," : "", owner_str, lwm_data.recursive_count, lwm.sq.size())));
 			break;
 		}
 		case SYS_TIMER_OBJECT:


### PR DESCRIPTION
* Implement the ability to view lwmutex owner and lock count, this is a debugging feature.
* Do not lose r3's content in syscalls to allow to get lv2 sync objects id by looking at r3 whenever a syscall happens.