### PR TITLE
Fix Welcome Dialog interfering with Update Manager

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -1266,6 +1266,7 @@
     <ClCompile Include="rpcs3qt\breakpoint_handler.cpp" />
     <ClCompile Include="rpcs3qt\breakpoint_list.cpp" />
     <ClCompile Include="rpcs3qt\cheat_manager.cpp" />
+    <ClCompile Include="rpcs3qt\curl_handle.cpp" />
     <ClCompile Include="rpcs3qt\custom_dialog.cpp" />
     <ClCompile Include="rpcs3qt\debugger_list.cpp" />
     <ClCompile Include="rpcs3qt\gui_application.cpp" />
@@ -1785,6 +1786,7 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
     </CustomBuild>
     <ClInclude Include="rpcs3qt\category.h" />
+    <ClInclude Include="rpcs3qt\curl_handle.h" />
     <ClInclude Include="rpcs3qt\custom_dock_widget.h" />
     <CustomBuild Include="rpcs3qt\debugger_list.h">
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -883,6 +883,9 @@
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_update_manager.cpp">
       <Filter>Generated Files\Debug - LLVM</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\curl_handle.cpp">
+      <Filter>rpcs3</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="\rpcs3qt\*.h">
@@ -983,6 +986,9 @@
     </ClInclude>
     <ClInclude Include="rpcs3qt\category.h">
       <Filter>Gui\game list</Filter>
+    </ClInclude>
+    <ClInclude Include="rpcs3qt\curl_handle.h">
+      <Filter>rpcs3</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -5,6 +5,7 @@
 	breakpoint_list.cpp
 	cg_disasm_window.cpp
 	cheat_manager.cpp
+	curl_handle.cpp
 	custom_dialog.cpp
 	debugger_frame.cpp
 	debugger_list.cpp

--- a/rpcs3/rpcs3qt/curl_handle.cpp
+++ b/rpcs3/rpcs3qt/curl_handle.cpp
@@ -1,0 +1,24 @@
+﻿#include "stdafx.h"
+#include "curl_handle.h"
+#include "Emu/System.h"
+
+curl_handle::curl_handle(QObject* parent) : QObject(parent)
+{
+	m_curl = curl_easy_init();
+
+#ifdef _WIN32
+	// This shouldn't be needed on linux
+	const std::string path_to_cert = Emulator::GetEmuDir() + "cacert.pem";
+	curl_easy_setopt(m_curl, CURLOPT_CAINFO, path_to_cert.c_str());
+#endif
+}
+
+curl_handle::~curl_handle()
+{
+	curl_easy_cleanup(m_curl);
+}
+
+CURL* curl_handle::get_curl()
+{
+	return m_curl;
+}

--- a/rpcs3/rpcs3qt/curl_handle.h
+++ b/rpcs3/rpcs3qt/curl_handle.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+#include <QObject>
+
+#ifndef CURL_STATICLIB
+#define CURL_STATICLIB
+#endif
+#include <curl/curl.h>
+
+class curl_handle : public QObject
+{
+private:
+	CURL* m_curl = nullptr;
+
+public:
+	curl_handle(QObject* parent = nullptr);
+	~curl_handle();
+
+	CURL* get_curl();
+};

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -5,6 +5,7 @@
 #include <QPainter>
 #include <QJsonObject>
 
+class curl_handle;
 class gui_settings;
 class progress_dialog;
 
@@ -40,7 +41,7 @@ private:
 	std::atomic<bool> m_curl_result = false;
 	std::atomic<bool> m_curl_abort = false;
 	double m_actual_dwnld_size = -1.0;
-	void* m_curl = nullptr;
+	curl_handle* m_curl = nullptr;
 	QByteArray m_curl_buf;
 	progress_dialog* m_progress_dialog = nullptr;
 	std::shared_ptr<gui_settings> m_xgui_settings;

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -386,80 +386,6 @@ QString game_list_frame::GetLastPlayedBySerial(const QString& serial)
 	return m_persistent_settings->GetLastPlayed(serial);
 }
 
-QString game_list_frame::GetPlayTimeByMs(int elapsed_ms)
-{
-	if (elapsed_ms <= 0)
-	{
-		return "";
-	}
-
-	const qint64 elapsed_seconds = (elapsed_ms / 1000) + ((elapsed_ms % 1000) > 0 ? 1 : 0);
-	const qint64 hours_played    = elapsed_seconds / 3600;
-	const qint64 minutes_played  = (elapsed_seconds % 3600) / 60;
-	const qint64 seconds_played  = (elapsed_seconds % 3600) % 60;
-
-	// For anyone who was wondering why there need to be so many cases:
-	// 1. Using variables won't work for future localization due to varying sentence structure in different languages.
-	// 2. The provided Qt functionality only works if localization is already enabled
-	// 3. The provided Qt functionality only works for single variables
-
-	if (hours_played <= 0)
-	{
-		if (minutes_played <= 0)
-		{
-			if (seconds_played == 1)
-			{
-				return tr("%0 second").arg(seconds_played);
-			}
-			return tr("%0 seconds").arg(seconds_played);
-		}
-
-		if (seconds_played <= 0)
-		{
-			if (minutes_played == 1)
-			{
-				return tr("%0 minute").arg(minutes_played);
-			}
-			return tr("%0 minutes").arg(minutes_played);
-		}
-		if (minutes_played == 1 && seconds_played == 1)
-		{
-			return tr("%0 minute and %1 second").arg(minutes_played).arg(seconds_played);
-		}
-		if (minutes_played == 1)
-		{
-			return tr("%0 minute and %1 seconds").arg(minutes_played).arg(seconds_played);
-		}
-		if (seconds_played == 1)
-		{
-			return tr("%0 minutes and %1 second").arg(minutes_played).arg(seconds_played);
-		}
-		return tr("%0 minutes and %1 seconds").arg(minutes_played).arg(seconds_played);
-	}
-
-	if (minutes_played <= 0)
-	{
-		if (hours_played == 1)
-		{
-			return tr("%0 hour").arg(hours_played);
-		}
-		return tr("%0 hours").arg(hours_played);
-	}
-	if (hours_played == 1 && minutes_played == 1)
-	{
-		return tr("%0 hour and %1 minute").arg(hours_played).arg(minutes_played);
-	}
-	if (hours_played == 1)
-	{
-		return tr("%0 hour and %1 minutes").arg(hours_played).arg(minutes_played);
-	}
-	if (minutes_played == 1)
-	{
-		return tr("%0 hours and %1 minute").arg(hours_played).arg(minutes_played);
-	}
-	return tr("%0 hours and %1 minutes").arg(hours_played).arg(minutes_played);
-}
-
 std::string game_list_frame::GetCacheDirBySerial(const std::string& serial)
 {
 	return fs::get_cache_dir() + "cache/" + serial;
@@ -2098,7 +2024,7 @@ void game_list_frame::PopulateGameList()
 		m_game_list->setItem(row, gui::column_sound,      new custom_table_widget_item(GetStringFromU32(game->info.sound_format, localized.sound.format, true)));
 		m_game_list->setItem(row, gui::column_parental,   new custom_table_widget_item(GetStringFromU32(game->info.parental_lvl, localized.parental.level), Qt::UserRole, game->info.parental_lvl));
 		m_game_list->setItem(row, gui::column_last_play,  new custom_table_widget_item(locale.toString(last_played, gui::persistent::last_played_date_format_new), Qt::UserRole, last_played));
-		m_game_list->setItem(row, gui::column_playtime,   new custom_table_widget_item(GetPlayTimeByMs(elapsed_ms), Qt::UserRole, elapsed_ms));
+		m_game_list->setItem(row, gui::column_playtime,   new custom_table_widget_item(localized.GetVerboseTimeByMs(elapsed_ms), Qt::UserRole, elapsed_ms));
 		m_game_list->setItem(row, gui::column_compat,     compat_item);
 
 		if (selected_item == game->info.icon_path)

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -113,7 +113,6 @@ private:
 	bool CreatePPUCache(const game_info& game);
 
 	QString GetLastPlayedBySerial(const QString& serial);
-	QString GetPlayTimeByMs(int elapsed_ms);
 	std::string GetCacheDirBySerial(const std::string& serial);
 	std::string GetDataDirBySerial(const std::string& serial);
 	std::string CurrentSelectionIconPath();

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -69,15 +69,15 @@ void gui_application::Init()
 	// Create connects to propagate events throughout Gui.
 	InitializeConnects();
 
-	if (m_main_window)
-	{
-		m_main_window->Init();
-	}
-
 	if (m_gui_settings->GetValue(gui::ib_show_welcome).toBool())
 	{
 		welcome_dialog* welcome = new welcome_dialog();
 		welcome->exec();
+	}
+
+	if (m_main_window)
+	{
+		m_main_window->Init();
 	}
 
 #ifdef WITH_DISCORD_RPC

--- a/rpcs3/rpcs3qt/localized.cpp
+++ b/rpcs3/rpcs3qt/localized.cpp
@@ -3,3 +3,78 @@
 Localized::Localized()
 {
 }
+
+QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms) const
+{
+	if (elapsed_ms <= 0)
+	{
+		return "";
+	}
+
+	const qint64 elapsed_seconds = (elapsed_ms / 1000) + ((elapsed_ms % 1000) > 0 ? 1 : 0);
+
+	const qint64 hours   = elapsed_seconds / 3600;
+	const qint64 minutes = (elapsed_seconds % 3600) / 60;
+	const qint64 seconds = (elapsed_seconds % 3600) % 60;
+
+	// For anyone who was wondering why there need to be so many cases:
+	// 1. Using variables won't work for future localization due to varying sentence structure in different languages.
+	// 2. The provided Qt functionality only works if localization is already enabled
+	// 3. The provided Qt functionality only works for single variables
+
+	if (hours <= 0)
+	{
+		if (hours <= 0)
+		{
+			if (seconds == 1)
+			{
+				return tr("%0 second").arg(seconds);
+			}
+			return tr("%0 seconds").arg(seconds);
+		}
+
+		if (seconds <= 0)
+		{
+			if (minutes == 1)
+			{
+				return tr("%0 minute").arg(minutes);
+			}
+			return tr("%0 minutes").arg(minutes);
+		}
+		if (minutes == 1 && seconds == 1)
+		{
+			return tr("%0 minute and %1 second").arg(minutes).arg(seconds);
+		}
+		if (minutes == 1)
+		{
+			return tr("%0 minute and %1 seconds").arg(minutes).arg(seconds);
+		}
+		if (seconds == 1)
+		{
+			return tr("%0 minutes and %1 second").arg(minutes).arg(seconds);
+		}
+		return tr("%0 minutes and %1 seconds").arg(minutes).arg(seconds);
+	}
+
+	if (minutes <= 0)
+	{
+		if (hours == 1)
+		{
+			return tr("%0 hour").arg(hours);
+		}
+		return tr("%0 hours").arg(hours);
+	}
+	if (hours == 1 && minutes == 1)
+	{
+		return tr("%0 hour and %1 minute").arg(hours).arg(minutes);
+	}
+	if (hours == 1)
+	{
+		return tr("%0 hour and %1 minutes").arg(hours).arg(minutes);
+	}
+	if (minutes == 1)
+	{
+		return tr("%0 hours and %1 minute").arg(hours).arg(minutes);
+	}
+	return tr("%0 hours and %1 minutes").arg(hours).arg(minutes);
+}

--- a/rpcs3/rpcs3qt/localized.h
+++ b/rpcs3/rpcs3qt/localized.h
@@ -17,6 +17,8 @@ public:
 
 	Localized();
 
+	QString GetVerboseTimeByMs(qint64 elapsed_ms) const;
+
 	const struct category // (see PARAM.SFO in psdevwiki.com) TODO: Disc Categories
 	{
 		// PS3 bootable

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -526,7 +526,7 @@ void main_window::HandlePackageInstallation(QStringList file_paths)
 
 			// Update progress window
 			double pval = progress;
-			pval < 0 ? pval += 1. : pval;
+			if (pval < 0) pval += 1.;
 			pdlg.SetValue(static_cast<int>(pval * pdlg.maximum()));
 			QCoreApplication::processEvents();
 		}
@@ -660,8 +660,8 @@ void main_window::HandlePupInstallation(QString file_path)
 		updatefilenames.end());
 
 	std::string version_string = pup.get_file(0x100).to_string();
-	size_t version_pos = version_string.find('\n');
-	if (version_pos != umax)
+
+	if (const size_t version_pos = version_string.find('\n'); version_pos != umax)
 	{
 		version_string.erase(version_pos);
 	}
@@ -824,7 +824,7 @@ void main_window::RepaintThumbnailIcons()
 {
 	const QColor new_color = gui::utils::get_label_color("thumbnail_icon_color");
 
-	auto icon = [&new_color](const QString& path)
+	const auto icon = [&new_color](const QString& path)
 	{
 		return gui::utils::get_colorized_icon(QPixmap::fromImage(gui::utils::get_opaque_image_area(path)), Qt::black, new_color);
 	};
@@ -847,7 +847,7 @@ void main_window::RepaintToolBarIcons()
 {
 	const QColor new_color = gui::utils::get_label_color("toolbar_icon_color");
 
-	auto icon = [&new_color](const QString& path)
+	const auto icon = [&new_color](const QString& path)
 	{
 		return gui::utils::get_colorized_icon(QIcon(path), Qt::black, new_color);
 	};

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1,6 +1,6 @@
-﻿#include <QMessageBox>
-#include <QFileDialog>
+﻿#include "stdafx.h"
 
+#include "main_window.h"
 #include "qt_utils.h"
 #include "vfs_dialog.h"
 #include "save_manager_dialog.h"
@@ -16,7 +16,6 @@
 #include "memory_string_searcher.h"
 #include "memory_viewer_panel.h"
 #include "rsx_debugger.h"
-#include "main_window.h"
 #include "about_dialog.h"
 #include "pad_settings_dialog.h"
 #include "progress_dialog.h"
@@ -31,8 +30,9 @@
 #include <QScreen>
 #include <QDirIterator>
 #include <QMimeData>
+#include <QMessageBox>
+#include <QFileDialog>
 
-#include "stdafx.h"
 #include "rpcs3_version.h"
 #include "Emu/System.h"
 #include "Emu/system_config.h"

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -107,7 +107,7 @@ void update_manager::check_for_updates(bool automatic, QWidget* parent)
 	connect(m_progress_dialog, &QProgressDialog::canceled, [this]() { m_curl_abort = true; });
 	connect(m_progress_dialog, &QProgressDialog::finished, m_progress_dialog, &QProgressDialog::deleteLater);
 
-	const std::string request_url = m_update_url + rpcs3::get_commit_and_hash().second;
+	const std::string request_url = "https://update.rpcs3.net/?api=v1&c=" + rpcs3::get_commit_and_hash().second;
 	curl_easy_setopt(m_curl, CURLOPT_URL, request_url.c_str());
 	curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
 	curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, this);
@@ -500,7 +500,7 @@ bool update_manager::handle_rpcs3()
 	size_t outBufferSize = 0;
 
 	// Creates temp folder for moving active files
-	const std::string tmp_folder = Emulator::GetEmuDir() + m_tmp_folder;
+	const std::string tmp_folder = Emulator::GetEmuDir() + "rpcs3_old/";
 	fs::create_dir(tmp_folder);
 
 	for (UInt32 i = 0; i < db.NumFiles; i++)

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -223,9 +223,12 @@ bool update_manager::handle_json(bool automatic)
 	const QDateTime cur_date = hash_found ? QDateTime::fromString(json_data["current_build"]["datetime"].toString(), date_fmt) : QDateTime::currentDateTimeUtc();
 	const QDateTime lts_date = QDateTime::fromString(latest["datetime"].toString(), date_fmt);
 
+	const QString cur_str = cur_date.toString(date_fmt);
+	const QString lts_str = lts_date.toString(date_fmt);
+
 	const qint64 diff_msec = cur_date.msecsTo(lts_date);
 
-	update_log.notice("Current: %s, latest: %s, difference: %lld ms", cur_date.toString().toStdString(), lts_date.toString().toStdString(), diff_msec);
+	update_log.notice("Current: %s, latest: %s, difference: %lld ms", cur_str.toStdString(), lts_str.toStdString(), diff_msec);
 
 	Localized localized;
 
@@ -235,16 +238,16 @@ bool update_manager::handle_json(bool automatic)
 	{
 		message = tr("A new version of RPCS3 is available!\n\nCurrent version: %0 (%1)\nLatest version: %2 (%3)\nYour version is %4 old.\n\nDo you want to update?")
 			.arg(json_data["current_build"]["version"].toString())
-			.arg(cur_date.toString(date_fmt))
+			.arg(cur_str)
 			.arg(latest["version"].toString())
-			.arg(lts_date.toString(date_fmt))
+			.arg(lts_str)
 			.arg(localized.GetVerboseTimeByMs(diff_msec));
 	}
 	else
 	{
 		message = tr("You're currently using a custom or PR build.\n\nLatest version: %0 (%1)\nThe latest version is %2 old.\n\nDo you want to update to the latest official RPCS3 version?")
 			.arg(latest["version"].toString())
-			.arg(lts_date.toString(date_fmt))
+			.arg(lts_str)
 			.arg(localized.GetVerboseTimeByMs(std::abs(diff_msec)));
 	}
 

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -179,7 +179,9 @@ bool update_manager::handle_json(bool automatic)
 		}
 	}
 
+	const auto& current = json_data["current_build"];
 	const auto& latest = json_data["latest_build"];
+
 	if (!latest.isObject())
 	{
 		update_log.error("JSON doesn't contain latest_build section");
@@ -200,7 +202,7 @@ bool update_manager::handle_json(bool automatic)
 	// Check that every bit of info we need is there
 	if (!latest[os].isObject() || !latest[os]["download"].isString() || !latest[os]["size"].isDouble() || !latest[os]["checksum"].isString() || !latest["version"].isString() ||
 	    !latest["datetime"].isString() ||
-	    (hash_found && (!json_data["current_build"].isObject() || !json_data["current_build"]["version"].isString() || !json_data["current_build"]["datetime"].isString())))
+	    (hash_found && (!current.isObject() || !current["version"].isString() || !current["datetime"].isString())))
 	{
 		update_log.error("Some information seems unavailable");
 		return false;
@@ -220,7 +222,7 @@ bool update_manager::handle_json(bool automatic)
 	// Calculate how old the build is
 	const QString date_fmt = QStringLiteral("yyyy-MM-dd hh:mm:ss");
 
-	const QDateTime cur_date = hash_found ? QDateTime::fromString(json_data["current_build"]["datetime"].toString(), date_fmt) : QDateTime::currentDateTimeUtc();
+	const QDateTime cur_date = hash_found ? QDateTime::fromString(current["datetime"].toString(), date_fmt) : QDateTime::currentDateTimeUtc();
 	const QDateTime lts_date = QDateTime::fromString(latest["datetime"].toString(), date_fmt);
 
 	const QString cur_str = cur_date.toString(date_fmt);
@@ -237,7 +239,7 @@ bool update_manager::handle_json(bool automatic)
 	if (hash_found)
 	{
 		message = tr("A new version of RPCS3 is available!\n\nCurrent version: %0 (%1)\nLatest version: %2 (%3)\nYour version is %4 old.\n\nDo you want to update?")
-			.arg(json_data["current_build"]["version"].toString())
+			.arg(current["version"].toString())
 			.arg(cur_str)
 			.arg(latest["version"].toString())
 			.arg(lts_str)

--- a/rpcs3/rpcs3qt/update_manager.h
+++ b/rpcs3/rpcs3qt/update_manager.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QByteArray>
 
+class curl_handle;
 class progress_dialog;
 
 class update_manager final :  public QObject
@@ -15,7 +16,7 @@ private:
 	progress_dialog* m_progress_dialog = nullptr;
 	QWidget* m_parent                  = nullptr;
 
-	void* m_curl = nullptr;
+	curl_handle* m_curl = nullptr;
 	QByteArray m_curl_buf;
 	std::atomic<bool> m_curl_abort = false;
 	std::atomic<bool> m_curl_result = false;

--- a/rpcs3/rpcs3qt/update_manager.h
+++ b/rpcs3/rpcs3qt/update_manager.h
@@ -11,9 +11,6 @@ class update_manager final :  public QObject
 	Q_OBJECT
 
 private:
-	const std::string m_update_url = "https://update.rpcs3.net/?api=v1&c=";
-	const std::string m_tmp_folder = "/rpcs3_old/";
-
 	std::atomic<bool> m_update_dialog  = false;
 	progress_dialog* m_progress_dialog = nullptr;
 	QWidget* m_parent                  = nullptr;


### PR DESCRIPTION
- The welcome dialog is now shown before showing anything else.
- The auto update will be delayed until the welcome dialog was closed

Furthermore:
- Simplifies some code and fixes a log message in the update manager
- Unifies the displayed (translateable) string for verbose time displays (Last played in game list and time difference in update manager message box)