### PR TITLE
Fix build with Qt 5.15+

### DIFF
--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp
@@ -3,6 +3,7 @@
 #include <QColorDialog>
 #include <QPainter>
 #include <QPixmap>
+#include <QPainterPath>
 
 pad_led_settings_dialog::pad_led_settings_dialog(const int& colorR, const int& colorG, const int& colorB, const bool& led_low_battery_blink, const bool& led_battery_indicator, const int& led_battery_indicator_brightness, QDialog * parent)
     : QDialog(parent)


### PR DESCRIPTION
fix build with Qt 5.15

~~~
[ 96%] Building CXX object rpcs3/rpcs3qt/CMakeFiles/rpcs3_ui.dir/save_data_info_dialog.cpp.o
/tmp/makepkg/sl1-rpcs3-git/src/rpcs3/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp: In member function 'void pad_led_settings_dialog::redraw_color_sample()':
/tmp/makepkg/sl1-rpcs3-git/src/rpcs3/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp:82:15: error: aggregate 'QPainterPath path' has incomplete type and cannot be defined
   82 |  QPainterPath path;
      |               ^~~~
~~~