### PR TITLE
Another fixup after #7826

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -64,9 +64,9 @@ error_code _sys_lwmutex_destroy(ppu_thread& ppu, u32 lwmutex_id)
 		}
 
 		// Wait for all lwcond waiters to quit
-		if (const s32 old = mutex->lwcond_waiters; old & 0x7fff'ffff)
+		if (const s32 old = mutex->lwcond_waiters; old != INT32_MIN)
 		{
-			if (old > 0)
+			if (old >= 0)
 			{
 				// Sleep queue is no longer empty
 				// Was set to positive value to announce it


### PR DESCRIPTION
If lwcond_waiters became zero after was set to be destroyed ibefore it t means that destroyed bit was turned off and all lwcond waiters quit (but lwmutex sleep queue state is unknown), so need to recheck lwmutex sleep queue and set/relock destroyed bit in this case to ensure it stays this way.