### PR TITLE
_sys_lwcond_signal: Make mode 3 respect ordering of the sleep queue

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwmutex_.cpp
@@ -178,7 +178,7 @@ error_code sys_lwmutex_lock(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex, u64
 		// locking succeeded
 		auto old = lwmutex->vars.owner.exchange(tid);
 
-		if (old != lwmutex_reserved)
+		if (old != lwmutex_reserved && old >> 24 != 1)
 		{
 			fmt::throw_exception("Locking failed (lwmutex=*0x%x, owner=0x%x)" HERE, lwmutex, old);
 		}
@@ -308,7 +308,7 @@ error_code sys_lwmutex_trylock(ppu_thread& ppu, vm::ptr<sys_lwmutex_t> lwmutex)
 			// locking succeeded
 			auto old = lwmutex->vars.owner.exchange(tid);
 
-			if (old != lwmutex_reserved)
+			if (old != lwmutex_reserved && old >> 24 != 1)
 			{
 				fmt::throw_exception("Locking failed (lwmutex=*0x%x, owner=0x%x)" HERE, lwmutex, old);
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -151,7 +151,8 @@ error_code sys_cond_signal_to(ppu_thread& ppu, u32 cond_id, u32 thread_id)
 
 	const auto cond = idm::check<lv2_obj, lv2_cond>(cond_id, [&](lv2_cond& cond) -> int
 	{
-		if (!idm::check_unlocked<named_thread<ppu_thread>>(thread_id))
+		if (const auto cpu = idm::check_unlocked<named_thread<ppu_thread>>(thread_id);
+			!cpu || cpu->joiner == ppu_join_status::exited)
 		{
 			return -1;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -87,9 +87,13 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u3
 
 	const auto cond = idm::check<lv2_obj, lv2_lwcond>(lwcond_id, [&](lv2_lwcond& cond) -> int
 	{
-		if (ppu_thread_id != umax && !idm::check_unlocked<named_thread<ppu_thread>>(ppu_thread_id))
+		if (ppu_thread_id != umax)
 		{
-			return -1;
+			if (const auto cpu = idm::check_unlocked<named_thread<ppu_thread>>(ppu_thread_id);
+				!cpu || cpu->joiner == ppu_join_status::exited)
+			{
+				return -1;
+			}
 		}
 
 		lv2_lwmutex* mutex;
@@ -136,13 +140,25 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u3
 					static_cast<ppu_thread*>(result)->gpr[3] = CELL_EBUSY;
 				}
 
-				if (mode == 1)
+				if (mode != 2)
 				{
 					verify(HERE), !mutex->signaled;
 					std::lock_guard lock(mutex->mutex);
-					verify(HERE), mutex->add_waiter(result);
+
+					if (mode == 3 && !mutex->sq.empty()) [[unlikely]]
+					{
+						// Respect ordering of the sleep queue
+						mutex->sq.emplace_back(result);
+						result = mutex->schedule<ppu_thread>(mutex->sq, mutex->protocol);
+					}
+					else if (mode == 1)
+					{
+						verify(HERE), mutex->add_waiter(result);
+						result = nullptr;
+					}
 				}
-				else
+
+				if (result)
 				{
 					cond.awake(result);
 				}

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -76,7 +76,7 @@ struct lv2_lwmutex final : lv2_obj
 	{
 		if (const auto old = lwcond_waiters.fetch_op([](s32& val)
 		{
-			if (val + 0u <= INT32_MIN + 0u)
+			if (val + 0u <= 1u << 31)
 			{
 				// Value was either positive or INT32_MIN
 				return false;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2645,7 +2645,7 @@ namespace rsx
 		case frame_limit_type::_50: limit = 50.; break;
 		case frame_limit_type::_60: limit = 60.; break;
 		case frame_limit_type::_30: limit = 30.; break;
-		case frame_limit_type::_auto: limit = g_cfg.video.vblank_rate; break; // TODO
+		case frame_limit_type::_auto: limit = static_cast<double>(g_cfg.video.vblank_rate); break;
 		default:
 			break;
 		}


### PR DESCRIPTION
In realhw this mode uses the lwmutex only to emplace the thread into the lwmutex sleep queue and then unlock immediatly the lwmutex, it means the ordering of the current lwmutex sleep queue needs to be respected. 
Also followup for #7663 in sys_lwcond and sys_cond reagrding ppu threads existence checks.