### PR TITLE
Make sceNpDrmProcessExitSpawn(2) execute sys_game calls correctly

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -595,7 +595,7 @@ error_code sceNpDrmProcessExitSpawn(ppu_thread& ppu, vm::cptr<u8> klicensee, vm:
 		return error;
 	}
 
-	sys_game_process_exitspawn(ppu, path, argv, envp, data, data_size, prio, flags);
+	ppu_execute<&sys_game_process_exitspawn>(ppu, path, argv, envp, data, data_size, prio, flags);
 	return CELL_OK;
 }
 
@@ -608,7 +608,7 @@ error_code sceNpDrmProcessExitSpawn2(ppu_thread& ppu, vm::cptr<u8> klicensee, vm
 		return error;
 	}
 
-	sys_game_process_exitspawn2(ppu, path, argv, envp, data, data_size, prio, flags);
+	ppu_execute<&sys_game_process_exitspawn2>(ppu, path, argv, envp, data, data_size, prio, flags);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -143,7 +143,7 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 		return false;
 	});
 
-	if (!mutex)
+	if (!mutex || ppu.gpr[3] == CELL_ESRCH)
 	{
 		return CELL_ESRCH;
 	}


### PR DESCRIPTION
I was surprised to see sysPrxForUser (liblv2 HLE related) channel in the log even when liblv2.sprx is LLEd by default, then I relalized we were calling the HLE handlers of sys_game_process_exitspawn(2) unconditionally.
Hopefully I've written it right.