### PR TITLE
sys_prx Improvements

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -117,11 +117,27 @@ struct sys_prx_get_module_list_option_t
 	be_t<u32> unk; // 0
 };
 
+enum : u32
+{
+	SYS_PRX_RESIDENT = 0,
+	SYS_PRX_NO_RESIDENT = 1,
+};
+
+// Unofficial names for PRX state
+enum : u32
+{
+	PRX_STATE_INITIALIZED,
+	PRX_STATE_STARTING, // In-between state between initialized and started (internal)
+	PRX_STATE_STARTED,
+	PRX_STATE_STOPPING, // In-between state between started and stopped (internal)
+	PRX_STATE_STOPPED, // Last state, the module cannot be restarted
+};
+
 struct lv2_prx final : lv2_obj, ppu_module
 {
 	static const u32 id_base = 0x23000000;
 
-	atomic_t<bool> is_started = false;
+	atomic_t<u32> state = PRX_STATE_INITIALIZED;
 
 	std::unordered_map<u32, u32> specials;
 	std::unordered_map<u32, void*> imports;


### PR DESCRIPTION
* Implement sys_prx_get_module_list: Used by sys_prx_exitspawn_with_level to get list of modules and call sys_prx_stop_module for each module id, which (I think) is used by exitspawn functions and normal prcosess exit.
* Add missing logic and error codes for sys_prx_start/stop/unload_module.