### PR TITLE
PPU LLVM: Add relocation 5 for ADDIS

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_prx_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_prx_.cpp
@@ -29,6 +29,8 @@ static void entryx(ppu_thread& ppu, vm::ptr<sys_prx_start_stop_module_option_t> 
 		*res = opt->entry(ppu, args, argp);
 		return;
 	}
+
+	*res = 0;
 }
 
 error_code sys_prx_load_module(ppu_thread& ppu, vm::cptr<char> path, u64 flags, vm::ptr<sys_prx_load_module_option_t> pOpt)

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1757,7 +1757,7 @@ void PPUTranslator::ADDIC(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -1774,7 +1774,7 @@ void PPUTranslator::ADDI(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -1787,7 +1787,7 @@ void PPUTranslator::ADDIS(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16 << 16);
 
-	if (m_rel && m_rel->type == 6)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = m_ir->CreateShl(SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>()), 16);
 		m_rel = nullptr;
@@ -2090,7 +2090,7 @@ void PPUTranslator::ORI(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.uimm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = ZExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -2103,13 +2103,7 @@ void PPUTranslator::ORIS(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.uimm16 << 16);
 
-	if (m_rel && m_rel->type == 5)
-	{
-		imm = m_ir->CreateShl(ZExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>()), 16);
-		m_rel = nullptr;
-	}
-
-	if (m_rel && m_rel->type == 6)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = m_ir->CreateShl(ZExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>()), 16);
 		m_rel = nullptr;
@@ -3382,7 +3376,7 @@ void PPUTranslator::LWZ(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3395,7 +3389,7 @@ void PPUTranslator::LWZU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3410,7 +3404,7 @@ void PPUTranslator::LBZ(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3423,7 +3417,7 @@ void PPUTranslator::LBZU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3438,7 +3432,7 @@ void PPUTranslator::STW(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3462,7 +3456,7 @@ void PPUTranslator::STWU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3477,7 +3471,7 @@ void PPUTranslator::STB(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3490,7 +3484,7 @@ void PPUTranslator::STBU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3505,7 +3499,7 @@ void PPUTranslator::LHZ(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3518,7 +3512,7 @@ void PPUTranslator::LHZU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3533,7 +3527,7 @@ void PPUTranslator::LHA(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3546,7 +3540,7 @@ void PPUTranslator::LHAU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3561,7 +3555,7 @@ void PPUTranslator::STH(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3574,7 +3568,7 @@ void PPUTranslator::STHU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3605,7 +3599,7 @@ void PPUTranslator::LFS(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3618,7 +3612,7 @@ void PPUTranslator::LFSU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3633,7 +3627,7 @@ void PPUTranslator::LFD(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3646,7 +3640,7 @@ void PPUTranslator::LFDU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3661,7 +3655,7 @@ void PPUTranslator::STFS(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3674,7 +3668,7 @@ void PPUTranslator::STFSU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3689,7 +3683,7 @@ void PPUTranslator::STFD(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;
@@ -3702,7 +3696,7 @@ void PPUTranslator::STFDU(ppu_opcode_t op)
 {
 	Value* imm = m_ir->getInt64(op.simm16);
 
-	if (m_rel && m_rel->type == 4)
+	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{
 		imm = SExt(ReadMemory(GetAddr(+2), GetType<u16>()), GetType<u64>());
 		m_rel = nullptr;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2258,7 +2258,7 @@ namespace rsx
 	{
 		const u64 current_time = get_system_time();
 
-		if (recovered_fifo_cmds_history.size() == 20u)
+		if (recovered_fifo_cmds_history.size() == 9u)
 		{
 			const auto cmd_info = recovered_fifo_cmds_history.front();
 


### PR DESCRIPTION
* Add more u16 relocations (4, 5, 6) support for instructions which already supported atleast one of them inclusing ADDIS as mentioned in #7855.
* More strict infinite desync detection, 
* Fix sys_prx_start/stop_module in liblv2.sprx HLE, add missing result reset.