### PR TITLE
Gives ANSI path to curl CURLOPT_CAINFO

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -1,4 +1,4 @@
-#include "StrFmt.h"
+﻿#include "StrFmt.h"
 #include "BEType.h"
 #include "StrUtil.h"
 #include "cfmt.h"
@@ -12,6 +12,47 @@
 #include <Windows.h>
 #else
 #include <errno.h>
+#endif
+
+#ifdef _WIN32
+std::string wchar_to_utf8(wchar_t *src)
+{
+	std::string utf8_string;
+	auto tmp_size = WideCharToMultiByte(CP_UTF8, 0, src, -1, nullptr, 0, nullptr, nullptr);
+	utf8_string.resize(tmp_size);
+	WideCharToMultiByte(CP_UTF8, 0, src, -1, utf8_string.data(), tmp_size, nullptr, nullptr);
+	return utf8_string;
+}
+
+std::string wchar_path_to_ansi_path(const std::wstring& src)
+{
+	std::wstring buf_short;
+	std::string buf_final;
+
+	// Get the short path from the wide char path(short path should only contain ansi characters)
+	auto tmp_size = GetShortPathNameW(src.data(), nullptr, 0);
+	buf_short.resize(tmp_size);
+	GetShortPathNameW(src.data(), buf_short.data(), tmp_size);
+
+	// Convert wide char to ansi
+	tmp_size = WideCharToMultiByte(CP_ACP, 0, buf_short.data(), -1, nullptr, 0, nullptr, nullptr);
+	buf_final.resize(tmp_size);
+	WideCharToMultiByte(CP_ACP, 0, buf_short.data(), -1, buf_final.data(), tmp_size, nullptr, nullptr);
+
+	return buf_final;
+}
+
+std::string utf8_path_to_ansi_path(const std::string& src)
+{
+	std::wstring buf_wide;
+
+	// Converts the utf-8 path to wide char
+	auto tmp_size = MultiByteToWideChar(CP_UTF8, 0, src.c_str(), -1, nullptr, 0);
+	buf_wide.resize(tmp_size);
+	MultiByteToWideChar(CP_UTF8, 0, src.c_str(), -1, buf_wide.data(), tmp_size);
+
+	return wchar_path_to_ansi_path(buf_wide);
+}
 #endif
 
 template <>

--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -7,6 +7,12 @@
 #include <functional>
 #include <string_view>
 
+#ifdef _WIN32
+std::string wchar_to_utf8(wchar_t *src);
+std::string wchar_path_to_ansi_path(const std::wstring& src);
+std::string utf8_path_to_ansi_path(const std::string& src);
+#endif
+
 // Copy null-terminated string from a std::string or a char array to a char array with truncation
 template <typename D, typename T>
 inline void strcpy_trunc(D& dst, const T& src)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -655,6 +655,18 @@ std::string Emulator::GetHdd1Dir()
 	return fmt::replace_all(g_cfg.vfs.dev_hdd1, "$(EmulatorDir)", GetEmuDir());
 }
 
+#ifdef _WIN32
+std::string Emulator::GetExeDir()
+{
+	wchar_t buffer[32767];
+	GetModuleFileNameW(nullptr, buffer, sizeof(buffer)/2);
+
+	std::string path_to_exe = wchar_to_utf8(buffer);
+	size_t last = path_to_exe.find_last_of("\\");
+	return last == std::string::npos ? std::string("") : path_to_exe.substr(0, last+1);
+}
+#endif
+
 std::string Emulator::GetSfoDirFromGamePath(const std::string& game_path, const std::string& user, const std::string& title_id)
 {
 	if (fs::is_file(game_path + "/PS3_DISC.SFB"))

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -179,6 +179,10 @@ private:
 	void LimitCacheSize();
 
 public:
+#ifdef _WIN32
+	static std::string GetExeDir();
+#endif
+
 	static std::string GetEmuDir();
 	static std::string GetHddDir();
 	static std::string GetHdd1Dir();

--- a/rpcs3/rpcs3qt/curl_handle.cpp
+++ b/rpcs3/rpcs3qt/curl_handle.cpp
@@ -2,14 +2,20 @@
 #include "curl_handle.h"
 #include "Emu/System.h"
 
+#ifdef _WIN32
+#include "Utilities/StrUtil.h"
+#endif
+
 curl_handle::curl_handle(QObject* parent) : QObject(parent)
 {
 	m_curl = curl_easy_init();
 
 #ifdef _WIN32
 	// This shouldn't be needed on linux
-	const std::string path_to_cert = Emulator::GetEmuDir() + "cacert.pem";
-	curl_easy_setopt(m_curl, CURLOPT_CAINFO, path_to_cert.c_str());
+	const std::string path_to_cert = Emulator::GetExeDir() + "cacert.pem";
+	const std::string ansi_path = utf8_path_to_ansi_path(path_to_cert);
+
+	curl_easy_setopt(m_curl, CURLOPT_CAINFO, ansi_path.data());
 #endif
 }
 


### PR DESCRIPTION
Roundabout way of getting ansi path out of utf-8 path but tested and it works.
This should fixes issues where `Problem with the SSL CA cert (path? access rights?)` error was reported.