### PR TITLE
cmake: Fix windeployqt command line for release builds

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -135,7 +135,7 @@ elseif(UNIX)
 elseif(WIN32)
 	add_custom_command(TARGET rpcs3 POST_BUILD
 			COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_SOURCE_DIR}/bin" "$<TARGET_FILE_DIR:rpcs3>"
-			COMMAND "${Qt5_DIR}/../../../bin/windeployqt" --no-angle --no-compiler-runtime --no-opengl-sw --no-patchqt --no-svg --no-translations --no-quick --plugindir "$<TARGET_FILE_DIR:rpcs3>/qt/plugins" "$<TARGET_FILE:rpcs3>")
+			COMMAND "${Qt5_DIR}/../../../bin/windeployqt" --no-angle --no-compiler-runtime --no-opengl-sw --no-patchqt --no-svg --no-translations --no-quick --plugindir "$<TARGET_FILE_DIR:rpcs3>/qt/plugins" --release "$<TARGET_FILE:rpcs3>")
 endif()
 
 # Unix installation


### PR DESCRIPTION
Same as https://github.com/RPCS3/rpcs3/commit/a5ba4a18dfed96a24e98c512013322aae385559e but for cmake