### PR TITLE
Change target to the correct commit SHA on RPCS3/RPCS3-binaries-win side

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ jobs:
         repositoryName: 'RPCS3/rpcs3-binaries-win'
         releaseNotesFilePath: 'GitHubReleaseMessage.txt'
         action: 'create'
-        target: '$(Build.SourceVersion)'
+        target: '7d09e3be30805911226241afbb14f8cdc2eb054e'
         tagSource: 'userSpecifiedTag'
         tag: 'build-$(Build.SourceVersion)'
         title: $(AVVER)


### PR DESCRIPTION
See azure docs
> Target | (Required) This is the commit SHA for which the GitHub release will be created. E.g. 48b11d8d6e92a22e3e9563a3f643699c16fd6e27. You can also use variables here.