### PR TITLE
RSX: Restrict analyser loop error

### DIFF
--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -49,6 +49,7 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 	{
 		u32 current_instruction = start;
 		std::set<u32> conditional_targets;
+		bool has_printed_error = false;
 
 		while (true)
 		{
@@ -58,8 +59,12 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 			{
 				if (!fast_exit)
 				{
-					// This can be harmless if a dangling RET was encountered before
-					rsx_log.error("vp_analyser: Possible infinite loop detected");
+					if (!has_printed_error) 
+					{
+						// This can be harmless if a dangling RET was encountered before
+						rsx_log.error("vp_analyser: Possible infinite loop detected");
+						has_printed_error = true;
+					}
 					current_instruction++;
 					continue;
 				}


### PR DESCRIPTION
log spam from analyzer was lowering fps in R&C and maybe others (Resistance 3?). In this case there was a huge FPS boost from 23 to 66fps. This stops the output to be less/once a loop rather than every instruction. 
Games that spam this should improve. 
**RSX: vp_analyser: Possible infinite loop detected**

<details>
  <summary>Before</summary><p>

  ![](https://user-images.githubusercontent.com/17715080/77801725-319c9600-7058-11ea-8051-006c56d23db2.png)

</p>
</details>
<details>
  <summary>After</summary><p>

  ![](https://user-images.githubusercontent.com/17715080/77801742-35c8b380-7058-11ea-9298-681c785a6541.png)

</p>
</details>