### PR TITLE
Allow using system libcurl

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -413,11 +413,18 @@ endif()
 # LLVM
 include(llvm.cmake)
 
-# Wolfssl
-add_subdirectory(wolfssl EXCLUDE_FROM_ALL)
-
-# Libcurl
-add_subdirectory(curl EXCLUDE_FROM_ALL)
+# CURL
+if(USE_SYSTEM_CURL)
+	message("-- RPCS3: using shared libcurl")
+	find_package(CURL REQUIRED)
+	add_library(wolfssl-3-static INTERFACE)
+	add_library(libcurl INTERFACE)
+	target_link_libraries(libcurl INTERFACE CURL::libcurl)
+else()
+	message("-- RPCS3: building libcurl + wolfssl submodules")
+	add_subdirectory(wolfssl EXCLUDE_FROM_ALL)
+	add_subdirectory(curl EXCLUDE_FROM_ALL)
+endif()
 
 # add nice ALIAS targets for ease of use
 add_library(3rdparty::libusb ALIAS usb-1.0-static)


### PR DESCRIPTION
ABI is not an issue on rolling distributions (e.g., Arch, FreeBSD) because packages are frequently rebuilt. libcurl upstream frequently publishes vulnerability fixes, so I'd prefer to avoid chasing updates downstream.

See [example build log](https://github.com/RPCS3/rpcs3/files/4396158/rpcs3-0.0.9.10053.log).

