### PR TITLE
rsx: Batch vp program load methods, improve vertex/fp program invalidation

### DIFF
--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -51,10 +51,7 @@ namespace rsx
 			std::unordered_set<u64>& mem_changes = frame_capture.replay_commands.back().memory_state;
 
 			// capture fragment shader mem
-			const u32 shader_program = method_registers.shader_program_address();
-
-			const u32 program_location = (shader_program & 0x3) - 1;
-			const u32 program_offset   = (shader_program & ~0x3);
+			const auto [program_offset, program_location] = method_registers.shader_program_address();
 
 			const u32 addr          = get_address(program_offset, program_location, HERE);
 			const auto program_info = program_hash_util::fragment_program_utils::analyse_fragment_program(vm::base(addr));

--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -55,3 +55,11 @@ void stream_vector(void *dst, u32 x, u32 y, u32 z, u32 w);
  * Stream a 128 bits vector from src to dst.
  */
 void stream_vector_from_memory(void *dst, void *src);
+
+/**
+ * Stream and swap data in u32 units.
+ */
+template <bool unaligned = false>
+void stream_data_to_memory_swapped_u32(void *dst, const void *src, u32 vertex_count, u8 stride);
+
+

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -614,13 +614,6 @@ namespace rsx
 			if (auto method = methods[reg])
 			{
 				method(this, reg, value);
-
-				if (invalid_command_interrupt_raised)
-				{
-					fifo_ctrl->abort();
-					recover_fifo();
-					return;
-				}
 			}
 		}
 		while (fifo_ctrl->read_unsafe(command));

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -524,32 +524,44 @@ namespace rsx
 					rsx::frame_capture_data::replay_command replay_cmd;
 					replay_cmd.rsx_command = std::make_pair((reg << 2) | (1u << 18), value);
 
-					frame_capture.replay_commands.push_back(replay_cmd);
-					auto it = frame_capture.replay_commands.back();
+					auto& commands = frame_capture.replay_commands;
+					commands.push_back(replay_cmd);
 
 					switch (reg)
 					{
 					case NV3089_IMAGE_IN:
-						capture::capture_image_in(this, it);
+						capture::capture_image_in(this, commands.back());
 						break;
 					case NV0039_BUFFER_NOTIFY:
-						capture::capture_buffer_notify(this, it);
+						capture::capture_buffer_notify(this, commands.back());
 						break;
 					default:
 					{
-						// Use legacy logic for NV308A_COLOR - enqueue leading command with count
+						static constexpr std::array<std::pair<u32, u32>, 2> ranges
+						{{
+							{NV308A_COLOR, 0x700},
+							{NV4097_SET_TRANSFORM_PROGRAM, 32}
+						}};
+
+						// Use legacy logic - enqueue leading command with count
 						// Then enqueue each command arg alone with a no-op command
-						if (reg >= NV308A_COLOR && reg < NV308A_COLOR + 0x700)
+						for (const auto& range : ranges)
 						{
-							const u32 remaining = std::min<u32>(fifo_ctrl->get_remaining_args_count(), (NV308A_COLOR + 0x700) - reg);
-
-							it.rsx_command.first = (fifo_ctrl->last_cmd() & RSX_METHOD_NON_INCREMENT_CMD_MASK) | (reg << 2) | (remaining << 18);
-
-							for (u32 i = 0; i < remaining && fifo_ctrl->get_pos() + (i + 1) * 4 != (ctrl->put & ~3); i++)
+							if (reg >= range.first && reg < range.first + range.second)
 							{
-								replay_cmd.rsx_command = std::make_pair(0, vm::read32(fifo_ctrl->get_current_arg_ptr() + (i + 1) * 4));
+								const u32 remaining = std::min<u32>(fifo_ctrl->get_remaining_args_count() + 1,
+									(fifo_ctrl->last_cmd() & RSX_METHOD_NON_INCREMENT_CMD_MASK) ? UINT32_MAX : (range.first + range.second) - reg);
 
-								frame_capture.replay_commands.push_back(replay_cmd);
+								commands.back().rsx_command.first = (fifo_ctrl->last_cmd() & RSX_METHOD_NON_INCREMENT_CMD_MASK) | (reg << 2) | (remaining << 18);
+
+								for (u32 i = 1; i < remaining && fifo_ctrl->get_pos() + (i - 1) * 4 != (ctrl->put & ~3); i++)
+								{
+									replay_cmd.rsx_command = std::make_pair(0, vm::read32(fifo_ctrl->get_current_arg_ptr() + (i * 4)));
+
+									commands.push_back(replay_cmd);
+								}
+
+								break;
 							}
 						}
 

--- a/rpcs3/Emu/RSX/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/RSXFragmentProgram.h
@@ -230,6 +230,7 @@ struct RSXFragmentProgram
 	void *addr;
 	u32 offset;
 	u32 ucode_length;
+	u32 total_length;
 	u32 ctrl;
 	u16 unnormalized_coords;
 	u16 redirected_textures;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2277,7 +2277,7 @@ namespace rsx
 		fifo_ctrl->set_get(restore_point);
 		fifo_ret_addr = saved_fifo_ret;
 		std::this_thread::sleep_for(1ms);
-		invalid_command_interrupt_raised = false;
+		fifo_ctrl->abort();
 
 		if (std::exchange(in_begin_end, false) && !rsx::method_registers.current_draw_clause.empty())
 		{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1585,10 +1585,7 @@ namespace rsx
 		m_graphics_state &= ~(rsx::pipeline_state::fragment_program_dirty);
 		auto &result = current_fragment_program = {};
 
-		const u32 shader_program = rsx::method_registers.shader_program_address();
-
-		const u32 program_location = (shader_program & 0x3) - 1;
-		const u32 program_offset = (shader_program & ~0x3);
+		const auto [program_offset, program_location] = method_registers.shader_program_address();
 
 		result.addr = vm::base(rsx::get_address(program_offset, program_location, HERE));
 		current_fp_metadata = program_hash_util::fragment_program_utils::analyse_fragment_program(result.addr);
@@ -1596,6 +1593,7 @@ namespace rsx
 		result.addr = (static_cast<u8*>(result.addr) + current_fp_metadata.program_start_offset);
 		result.offset = program_offset + current_fp_metadata.program_start_offset;
 		result.ucode_length = current_fp_metadata.program_ucode_length;
+		result.total_length = result.ucode_length + current_fp_metadata.program_start_offset;
 		result.valid = true;
 		result.ctrl = rsx::method_registers.shader_control() & (CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS | CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT);
 		result.texcoord_control_mask = rsx::method_registers.texcoord_control_mask();
@@ -1735,6 +1733,22 @@ namespace rsx
 				rsx_log.error("FS exports depth component but depth test is disabled (INVALID_OPERATION)");
 			}
 		}
+	}
+
+	bool thread::invalidate_fragment_program(u32 dst_dma, u32 dst_offset, u32 size)
+	{
+		const auto [shader_offset, shader_dma] = rsx::method_registers.shader_program_address();
+
+		if ((dst_dma & CELL_GCM_LOCATION_MAIN) == shader_dma &&
+		address_range::start_length(shader_offset, current_fragment_program.total_length).overlaps(
+			address_range::start_length(dst_offset, size))) [[unlikely]]
+		{
+			// Data overlaps
+			m_graphics_state |= rsx::pipeline_state::fragment_program_dirty;
+			return true;
+		}
+
+		return false;
 	}
 
 	void thread::reset()

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -711,6 +711,8 @@ namespace rsx
 		 * returns whether surface is a render target and surface pitch in native format
 		 */
 		void get_current_fragment_program(const std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, rsx::limits::fragment_textures_count>& sampler_descriptors);
+	public:
+		bool invalidate_fragment_program(u32 dst_dma, u32 dst_offset, u32 size);
 
 	public:
 		u64 target_rsx_flip_time = 0;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -723,7 +723,6 @@ namespace rsx
 		bool capture_current_frame = false;
 
 	public:
-		bool invalid_command_interrupt_raised = false;
 		bool sync_point_request = false;
 		bool in_begin_end = false;
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1586,6 +1586,8 @@ namespace rsx
 	{
 		// Reset all regsiters
 		registers.fill(0);
+		transform_program.fill(0);
+		transform_constants = {};
 
 		// Special values set at initialization, these are not set by a context reset
 		registers[NV4097_SET_SHADER_PROGRAM] = (0 << 2) | (CELL_GCM_LOCATION_LOCAL + 1);

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -43,7 +43,7 @@ namespace rsx
 		const u32 cmd = rsx->get_fifo_cmd();
 		rsx_log.error("Invalid RSX method 0x%x (arg=0x%x, start=0x%x, count=0x%x, non-inc=%s)", _reg << 2, arg,
 		cmd & 0xfffc, (cmd >> 18) & 0x7ff, !!(cmd & RSX_METHOD_NON_INCREMENT_CMD));
-		rsx->invalid_command_interrupt_raised = true;
+		rsx->recover_fifo();
 	}
 
 	void trace_method(thread* rsx, u32 _reg, u32 arg)
@@ -541,7 +541,7 @@ namespace rsx
 				if (rsx::method_registers.current_draw_clause.primitive == rsx::primitive_type::invalid)
 				{
 					// Recover from invalid primitive only if draw clause is not empty
-					rsxthr->invalid_command_interrupt_raised = true;
+					rsxthr->recover_fifo();
 
 					rsx_log.error("NV4097_SET_BEGIN_END aborted due to invalid primitive!");
 					return;
@@ -755,7 +755,7 @@ namespace rsx
 			{
 				// Ignore invalid value, recover
 				method_registers.registers[reg] = method_registers.register_previous_value;
-				rsx->invalid_command_interrupt_raised = true;
+				rsx->recover_fifo();
 
 				rsx_log.error("Invalid NV4097_SET_INDEX_ARRAY_DMA value: 0x%x", arg);
 			}

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1331,9 +1331,10 @@ namespace rsx
 			return decode<NV4097_SET_VERTEX_DATA_BASE_INDEX>().vertex_data_base_index();
 		}
 
-		u32 shader_program_address() const
+		std::pair<u32, u32> shader_program_address() const
 		{
-			return decode<NV4097_SET_SHADER_PROGRAM>().shader_program_address();
+			const u32 shader_address = decode<NV4097_SET_SHADER_PROGRAM>().shader_program_address();
+			return { shader_address & ~3, (shader_address & 3) - 1 };
 		}
 
 		u32 transform_program_start() const

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -1610,20 +1610,14 @@ namespace rsx
 			return u16(registers[NV308A_SIZE_OUT] & 0xFFFF);
 		}
 
-		u32 transform_program_load()
+		u32 transform_program_load() const
 		{
 			return registers[NV4097_SET_TRANSFORM_PROGRAM_LOAD];
 		}
 
-		void commit_4_transform_program_instructions(u32 index)
+		void transform_program_load_set(u32 value)
 		{
-			u32& load = registers[NV4097_SET_TRANSFORM_PROGRAM_LOAD];
-
-			transform_program[load * 4] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4];
-			transform_program[load * 4 + 1] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 1];
-			transform_program[load * 4 + 2] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 2];
-			transform_program[load * 4 + 3] = registers[NV4097_SET_TRANSFORM_PROGRAM + index * 4 + 3];
-			load++;
+			registers[NV4097_SET_TRANSFORM_PROGRAM_LOAD] = value;
 		}
 
 		u32 transform_constant_load()

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -541,8 +541,6 @@ namespace rsx
 			vertex_textures(fill_array<vertex_texture>(registers, std::make_index_sequence<4>())),
 			vertex_arrays_info(fill_array<data_array_format_info>(registers, std::make_index_sequence<16>()))
 		{
-			//NOTE: Transform constants persist through a context reset (NPEB00913)
-			transform_constants = {};
 		}
 
 		~rsx_state() = default;


### PR DESCRIPTION
* Batch vertex program load methods.
* Detect data changes of vertex program.
* Remove `rsx::thread::invalid_command_interrupt_raised` flag.
* Reset vertex program/constants at each boot.
* Add more conditions to fragment data program invalidation in NV308A_COLOR. (and fixes a regression from #7846), and add more invalidation checks for IMAGE_IN and BUFFER_NOTIFY.
TODO: Comapre raw fragment shader data in case changed by memcpy etc.