### PR TITLE
Try to make log silencing dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ yaml-cpp.pc
 # libusb
 /3rdparty/libusb_cmake/config.h
 /3rdparty/libusb_cmake/libusb-1.0.pc
+
+# ssl certificate
+cacert.pem

--- a/Utilities/Config.cpp
+++ b/Utilities/Config.cpp
@@ -344,12 +344,7 @@ void cfg::set_entry::from_default()
 
 void cfg::log_entry::set_map(std::map<std::string, logs::level>&& map)
 {
-	logs::reset();
-
-	for (auto&& pair : (m_map = std::move(map)))
-	{
-		logs::set_level(pair.first, pair.second);
-	}
+	m_map = std::move(map);
 }
 
 void cfg::log_entry::from_default()

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -74,7 +74,7 @@
 #include "sync.h"
 #include "util/logs.hpp"
 
-LOG_CHANNEL(sig_log);
+LOG_CHANNEL(sig_log, "SIG");
 LOG_CHANNEL(sys_log, "SYS");
 LOG_CHANNEL(vm_log, "VM");
 

--- a/rpcs3/Crypto/key_vault.cpp
+++ b/rpcs3/Crypto/key_vault.cpp
@@ -706,7 +706,7 @@ SELF_KEY KeyVault::FindSelfKey(u32 type, u16 revision, u64 version)
 	// Empty key.
 	SELF_KEY key(0, 0, 0, 0, "", "", "", "", 0);
 
-	key_vault_log.notice("FindSelfKey: Type:0x%x, Revision:0x%x, Version:0x%x", type, revision, version);
+	key_vault_log.trace("FindSelfKey: Type:0x%x, Revision:0x%x, Version:0x%x", type, revision, version);
 
 	// Check SELF type.
 	switch (type)

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -175,10 +175,6 @@ public:
 	bool BootRsxCapture(const std::string& path);
 	bool InstallPkg(const std::string& path);
 
-private:
-	void LimitCacheSize();
-
-public:
 #ifdef _WIN32
 	static std::string GetExeDir();
 #endif
@@ -214,6 +210,11 @@ public:
 	std::string GetFormattedTitle(double fps) const;
 
 	u32 GetMaxThreads() const;
+
+	void ConfigureLogs();
+
+private:
+	void LimitCacheSize();
 };
 
 extern Emulator Emu;

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -263,7 +263,7 @@ struct cfg_root : cfg::node
 		cfg::_bool show_shader_compilation_hint{ this, "Show shader compilation hint", true, true };
 		cfg::_bool use_native_interface{ this, "Use native user interface", true };
 		cfg::string gdb_server{ this, "GDB Server", "127.0.0.1:2345" };
-		cfg::_bool silence_all_logs{ this, "Silence All Logs", false, false };
+		cfg::_bool silence_all_logs{ this, "Silence All Logs", false, true };
 		cfg::string title_format{ this, "Window Title Format", "FPS: %F | %R | %V | %T [%t]", true };
 	
 	} misc{ this };

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -468,6 +468,10 @@
     <ClInclude Include="..\Utilities\mutex.h" />
     <ClInclude Include="..\Utilities\sema.h" />
     <ClInclude Include="..\Utilities\sync.h" />
+    <ClInclude Include="util\atomic2.hpp" />
+    <ClInclude Include="util\endian.hpp" />
+    <ClInclude Include="util\fixed_typemap.hpp" />
+    <ClInclude Include="util\init_mutex.hpp" />
     <ClInclude Include="util\logs.hpp" />
     <ClInclude Include="..\Utilities\File.h" />
     <ClInclude Include="..\Utilities\Config.h" />
@@ -701,6 +705,9 @@
     <ClInclude Include="restore_new.h" />
     <ClInclude Include="rpcs3_version.h" />
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="util\shared_cptr.hpp" />
+    <ClInclude Include="util\typeindices.hpp" />
+    <ClInclude Include="util\yaml.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\3rdparty\libpng.vcxproj">

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -140,9 +140,6 @@
     <ClCompile Include="..\Utilities\StrFmt.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
-    <ClCompile Include="util\logs.cpp">
-      <Filter>Utilities</Filter>
-    </ClCompile>
     <ClCompile Include="Emu\RSX\GSRender.cpp">
       <Filter>Emu\GPU\RSX</Filter>
     </ClCompile>
@@ -866,19 +863,10 @@
     <ClCompile Include="util\atomic.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
-    <ClCompile Include="util\atomic2.cpp">
-      <Filter>Utilities</Filter>
-    </ClCompile>
     <ClCompile Include="util\yaml.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
     <ClCompile Include="util\cereal.cpp">
-      <Filter>Utilities</Filter>
-    </ClCompile>
-    <ClCompile Include="util\yaml.hpp">
-      <Filter>Utilities</Filter>
-    </ClCompile>
-    <ClCompile Include="util\shared_cptr.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
     <ClCompile Include="util\fixed_typemap.cpp">
@@ -928,6 +916,15 @@
     </ClCompile>
     <ClCompile Include="Emu\RSX\Overlays\overlay_osk_panel.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClCompile>
+    <ClCompile Include="util\atomic2.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
+    <ClCompile Include="util\logs.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
+    <ClCompile Include="util\shared_cptr.cpp">
+      <Filter>Utilities</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1034,9 +1031,6 @@
       <Filter>Utilities</Filter>
     </ClInclude>
     <ClInclude Include="..\Utilities\Timer.h">
-      <Filter>Utilities</Filter>
-    </ClInclude>
-    <ClInclude Include="util\logs.hpp">
       <Filter>Utilities</Filter>
     </ClInclude>
     <ClInclude Include="Emu\RSX\Null\NullGSRender.h">
@@ -1764,6 +1758,30 @@
     </ClInclude>
     <ClInclude Include="Emu\RSX\Overlays\overlay_osk_panel.h">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClInclude>
+    <ClInclude Include="util\yaml.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="util\atomic2.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="util\endian.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="util\fixed_typemap.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="util\init_mutex.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="util\logs.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="util\shared_cptr.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="util\typeindices.hpp">
+      <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -427,6 +427,7 @@ void gui_application::OnChangeStyleSheetRequest(const QString& path)
 
 void gui_application::OnEmuSettingsChange()
 {
+	Emu.ConfigureLogs();
 	rsx::overlays::reset_performance_overlay();
 }
 

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -208,6 +208,14 @@ namespace logs
 		}
 	}
 
+	void set_channel_levels(const std::map<std::string, logs::level>& map)
+	{
+		for (auto&& pair : map)
+		{
+			logs::set_level(pair.first, pair.second);
+		}
+	}
+
 	std::vector<std::string> get_channels()
 	{
 		std::vector<std::string> result;

--- a/rpcs3/util/logs.hpp
+++ b/rpcs3/util/logs.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <atomic>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -131,6 +132,9 @@ namespace logs
 
 	// Log level control: get channel level
 	level get_level(const std::string&);
+
+	// Log level control: set specific channels to level::fatal
+	void set_channel_levels(const std::map<std::string, logs::level>& map);
 
 	// Get all registered log channels
 	std::vector<std::string> get_channels();


### PR DESCRIPTION
#### Log:
It is possible to change log levels for all the log channels by editing the config file.
Previously, the log levels were applied whenever a config file was decoded.
This meant that we updated the log channels whenever any config file, either global or custom, was read. Apart from being suboptimal in the first place, this also meant that changing the "Silence All Logs" option was ignored whenever a config was changed.
So what did I do to improve the situation?
- The channel map will only be applied to the log channels when we actually apply a config
- Custom configs do not override the global setting anymore and vice-versa

#### TODO:
Figure out a better way to apply the interaction between silencing and changing levels:
- At rpcs3 boot ?
- Can custom configs also non-cell-channels, like GUI or others?

#### Misc changes:
- Added some recent missing files to the visual studio project
- Changed sig_log to SIG
- Changed log level of some keyvault message to trace to stop spam when opening the settings dialog
- Added cacert.pem to gitignore, because I have it in my working directory for testing