### PR TITLE
Fix alignment on embedded spu elf searching

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1158,7 +1158,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	ppu_initialize_modules(link);
 
 	// Embedded SPU elf patching
-	for (u32 i = _main->segs[0].addr; i < (_main->segs[0].addr + _main->segs[0].size); i += 4)
+	for (u32 i = _main->segs[0].addr; i < (_main->segs[0].addr + _main->segs[0].size); i += 128)
 	{
 		uchar* elf_header = vm::_ptr<u8>(i);
 		const spu_exec_object obj(fs::file(vm::base(vm::cast(i, HERE)), (_main->segs[0].addr + _main->segs[0].size) - i));


### PR DESCRIPTION
Embedded spu elfs are actually 128 byte (1024 bit) aligned, not 4 byte (32 bit) aligned like I thought earlier.

I was mislead earlier since the word ELF appears in binaries at 32 bit alignment sometimes, but these weren't true elf headers, just the word ELF on its own.

This shouldn't really impact anything beyond making games boot ever so slightly faster.