### PR TITLE
Fix sys_rwlock_wlock timeout event

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -371,6 +371,10 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 
 					lv2_obj::awake_all();
 				}
+				else if (rwlock->rq.empty() && rwlock->wq.empty())
+				{
+					rwlock->owner &= -2;
+				}
 
 				ppu.gpr[3] = CELL_ETIMEDOUT;
 				break;


### PR DESCRIPTION
As long as owner LSB is set sys_rwlock_tryrlock and sys_rwlock_rlock would think the rwlock is unavailable, so clear this bit on last writer waiter so the readers can see its availabilty again.
Heck, sys_rwlock_rlock can wait forever waiting for a non-existing writer to quit in this case.