### PR TITLE
Debugger improvements

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1505,7 +1505,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context) no
 		{
 			if (!access_violation_recovered)
 			{
-				vm_log.notice("\n%s", cpu->dump());
+				vm_log.notice("\n%s", cpu->dump_all());
 				vm_log.error("Access violation %s location 0x%x (%s)", is_writing ? "writing" : "reading", addr, (is_writing && vm::check_addr(addr)) ? "read-only memory" : "unmapped memory");
 			}
 
@@ -1536,7 +1536,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context) no
 
 	if (cpu && !access_violation_recovered)
 	{
-		vm_log.notice("\n%s", cpu->dump());
+		vm_log.notice("\n%s", cpu->dump_all());
 	}
 
 	// Note: a thread may access violate more than once after hack_alloc recovery
@@ -1617,7 +1617,7 @@ static LONG exception_filter(PEXCEPTION_POINTERS pExp) noexcept
 
 		if (const auto cpu = get_current_cpu_thread())
 		{
-			sys_log.notice("\n%s", cpu->dump());
+			sys_log.notice("\n%s", cpu->dump_all());
 		}
 	}
 
@@ -1746,7 +1746,7 @@ static void signal_handler(int sig, siginfo_t* info, void* uct) noexcept
 
 	if (const auto cpu = get_current_cpu_thread())
 	{
-		sys_log.notice("\n%s", cpu->dump());
+		sys_log.notice("\n%s", cpu->dump_all());
 	}
 
 	std::string msg = fmt::format("Segfault %s location %p at %p.\n", cause, info->si_addr, RIP(context));

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -412,7 +412,7 @@ void cpu_thread::operator()()
 		{
 			if (_this)
 			{
-				sys_log.warning("CPU Thread '%s' terminated abnormally:\n%s", name, _this->dump());
+				sys_log.warning("CPU Thread '%s' terminated abnormally:\n%s", name, _this->dump_all());
 				cleanup();
 			}
 		}
@@ -599,7 +599,27 @@ std::string cpu_thread::get_name() const
 	}
 }
 
-std::string cpu_thread::dump() const
+std::string cpu_thread::dump_all() const
+{
+	return {};
+}
+
+std::string cpu_thread::dump_regs() const
+{
+	return {};
+}
+
+std::string cpu_thread::dump_callstack() const
+{
+	return {};
+}
+
+std::vector<u32> cpu_thread::dump_callstack_list() const
+{
+	return {};
+}
+
+std::string cpu_thread::dump_misc() const
 {
 	return fmt::format("Type: %s\n" "State: %s\n", typeid(*this).name(), state.load());
 }

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -1,7 +1,9 @@
-#pragma once
+﻿#pragma once
 
 #include "../Utilities/Thread.h"
 #include "../Utilities/bit_set.h"
+
+#include <vector>
 
 // Thread state flags
 enum class cpu_flag : u32
@@ -91,8 +93,20 @@ public:
 	// Get thread name (as assigned to named_thread)
 	std::string get_name() const;
 
-	// Get CPU state dump
-	virtual std::string dump() const;
+	// Get CPU state dump (everything)
+	virtual std::string dump_all() const = 0;
+
+	// Get CPU register dump
+	virtual std::string dump_regs() const;
+
+	// Get CPU call stack dump
+	virtual std::string dump_callstack() const;
+
+	// Get CPU call stack list
+	virtual std::vector<u32> dump_callstack_list() const;
+
+	// Get CPU dump of misc information
+	virtual std::string dump_misc() const;
 
 	// Thread entry point function
 	virtual void cpu_task() = 0;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -58,6 +58,7 @@
 
 #include <thread>
 #include <cfenv>
+#include <cctype>
 
 const bool s_use_ssse3 = utils::has_ssse3();
 
@@ -368,9 +369,96 @@ extern bool ppu_patch(u32 addr, u32 value)
 	return true;
 }
 
-std::string ppu_thread::dump() const
+std::string ppu_thread::dump_all() const
 {
-	std::string ret = cpu_thread::dump();
+	std::string ret = cpu_thread::dump_misc() + '\n';
+
+	ret += dump_misc() + '\n';
+	ret += dump_regs() + '\n';
+	ret += dump_callstack();
+
+	return ret;
+}
+
+std::string ppu_thread::dump_regs() const
+{
+	std::string ret;
+
+	for (uint i = 0; i < 32; ++i) fmt::append(ret, "GPR[%d] = 0x%llx\n", i, gpr[i]);
+	for (uint i = 0; i < 32; ++i) fmt::append(ret, "FPR[%d] = %.6G\n", i, fpr[i]);
+	for (uint i = 0; i < 32; ++i) fmt::append(ret, "VR[%d] = %s [x: %g y: %g z: %g w: %g]\n", i, vr[i], vr[i]._f[3], vr[i]._f[2], vr[i]._f[1], vr[i]._f[0]);
+
+	fmt::append(ret, "CR = 0x%08x\n", cr.pack());
+	fmt::append(ret, "LR = 0x%llx\n", lr);
+	fmt::append(ret, "CTR = 0x%llx\n", ctr);
+	fmt::append(ret, "VRSAVE = 0x%08x\n", vrsave);
+	fmt::append(ret, "XER = [CA=%u | OV=%u | SO=%u | CNT=%u]\n", xer.ca, xer.ov, xer.so, xer.cnt);
+	fmt::append(ret, "VSCR = [SAT=%u | NJ=%u]\n", sat, nj);
+	fmt::append(ret, "FPSCR = [FL=%u | FG=%u | FE=%u | FU=%u]\n", fpscr.fl, fpscr.fg, fpscr.fe, fpscr.fu);
+
+	return ret;
+}
+
+std::string ppu_thread::dump_callstack() const
+{
+	std::string ret;
+
+	fmt::append(ret, "Call stack:\n=========\n0x%08x (0x0) called\n", cia);
+
+	for (u32 sp : dump_callstack_list())
+	{
+		// TODO: function addresses too
+		fmt::append(ret, "> from 0x%04llx (0x0)\n", vm::read64(static_cast<u32>(sp + 16)));
+	}
+
+	return ret;
+}
+
+std::vector<u32> ppu_thread::dump_callstack_list() const
+{
+	//std::shared_lock rlock(vm::g_mutex); // Needs optimizations
+
+	// Determine stack range
+	const u32 stack_ptr = static_cast<u32>(gpr[1]);
+
+	if (!vm::check_addr(stack_ptr, 1, vm::page_writable))
+	{
+		// Normally impossible unless the code does not follow ABI rules
+		return {};
+	}
+
+	u32 stack_min = stack_ptr & ~0xfff;
+	u32 stack_max = stack_min + 4096;
+
+	while (stack_min && vm::check_addr(stack_min - 4096, 4096, vm::page_writable))
+	{
+		stack_min -= 4096;
+	}
+
+	while (stack_max + 4096 && vm::check_addr(stack_max, 4096, vm::page_writable))
+	{
+		stack_max += 4096;
+	}
+
+	std::vector<u32> call_stack_list;
+
+	for (
+		u64 sp = *vm::get_super_ptr<u64>(stack_ptr);
+		sp >= stack_min && std::max(sp, sp + 0x200) < stack_max;
+		sp = *vm::get_super_ptr<u64>(static_cast<u32>(sp))
+		)
+	{
+		// TODO: function addresses too
+		call_stack_list.push_back(*vm::get_super_ptr<u64>(static_cast<u32>(sp + 16)));
+	}
+
+	return call_stack_list;
+}
+
+std::string ppu_thread::dump_misc() const
+{
+	std::string ret;
+
 	fmt::append(ret, "Priority: %d\n", +prio);
 	fmt::append(ret, "Stack: 0x%x..0x%x\n", stack_addr, stack_addr + stack_size - 1);
 	fmt::append(ret, "Joiner: %s\n", joiner.load());
@@ -411,51 +499,6 @@ std::string ppu_thread::dump() const
 	{
 		ret += '\n';
 	}
-
-	ret += "\nRegisters:\n=========\n";
-	for (uint i = 0; i < 32; ++i) fmt::append(ret, "GPR[%d] = 0x%llx\n", i, gpr[i]);
-	for (uint i = 0; i < 32; ++i) fmt::append(ret, "FPR[%d] = %.6G\n", i, fpr[i]);
-	for (uint i = 0; i < 32; ++i) fmt::append(ret, "VR[%d] = %s [x: %g y: %g z: %g w: %g]\n", i, vr[i], vr[i]._f[3], vr[i]._f[2], vr[i]._f[1], vr[i]._f[0]);
-
-	fmt::append(ret, "CR = 0x%08x\n", cr.pack());
-	fmt::append(ret, "LR = 0x%llx\n", lr);
-	fmt::append(ret, "CTR = 0x%llx\n", ctr);
-	fmt::append(ret, "VRSAVE = 0x%08x\n", vrsave);
-	fmt::append(ret, "XER = [CA=%u | OV=%u | SO=%u | CNT=%u]\n", xer.ca, xer.ov, xer.so, xer.cnt);
-	fmt::append(ret, "VSCR = [SAT=%u | NJ=%u]\n", sat, nj);
-	fmt::append(ret, "FPSCR = [FL=%u | FG=%u | FE=%u | FU=%u]\n", fpscr.fl, fpscr.fg, fpscr.fe, fpscr.fu);
-	fmt::append(ret, "\nCall stack:\n=========\n0x%08x (0x0) called\n", cia);
-
-	//std::shared_lock rlock(vm::g_mutex); // Needs optimizations
-
-	// Determine stack range
-	u32 stack_ptr = static_cast<u32>(gpr[1]);
-
-	if (!vm::check_addr(stack_ptr, 1, vm::page_writable))
-	{
-		// Normally impossible unless the code does not follow ABI rules
-		return ret;
-	}
-
-	u32 stack_min = stack_ptr & ~0xfff;
-	u32 stack_max = stack_min + 4096;
-
-	while (stack_min && vm::check_addr(stack_min - 4096, 4096, vm::page_writable))
-	{
-		stack_min -= 4096;
-	}
-
-	while (stack_max + 4096 && vm::check_addr(stack_max, 4096, vm::page_writable))
-	{
-		stack_max += 4096;
-	}
-
-	for (u64 sp = *vm::get_super_ptr<u64>(stack_ptr); sp >= stack_min && std::max(sp, sp + 0x200) < stack_max; sp = *vm::get_super_ptr<u64>(static_cast<u32>(sp)))
-	{
-		// TODO: print also function addresses
-		fmt::append(ret, "> from 0x%08llx (0x0)\n", *vm::get_super_ptr<u64>(static_cast<u32>(sp + 16)));
-	}
-
 	return ret;
 }
 

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -53,7 +53,11 @@ public:
 	static const u32 id_step = 1;
 	static const u32 id_count = 2048;
 
-	virtual std::string dump() const override;
+	virtual std::string dump_all() const override;
+	virtual std::string dump_regs() const override;
+	virtual std::string dump_callstack() const override;
+	virtual std::vector<u32> dump_callstack_list() const override;
+	virtual std::string dump_misc() const override;
 	virtual void cpu_task() override final;
 	virtual void cpu_sleep() override;
 	virtual void cpu_mem() override;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1009,9 +1009,41 @@ spu_imm_table_t::spu_imm_table_t()
 	}
 }
 
-std::string spu_thread::dump() const
+std::string spu_thread::dump_all() const
 {
-	std::string ret = cpu_thread::dump();
+	std::string ret = cpu_thread::dump_misc() + '\n';
+
+	ret += dump_misc() + '\n';
+	ret += dump_regs();
+
+	return ret;
+}
+
+std::string spu_thread::dump_regs() const
+{
+	std::string ret;
+
+	for (u32 i = 0; i < 128; i++)
+	{
+		fmt::append(ret, "\nGPR[%d] = %s", i, gpr[i]);
+	}
+
+	return ret;
+}
+
+std::string spu_thread::dump_callstack() const
+{
+	return {};
+}
+
+std::vector<u32> spu_thread::dump_callstack_list() const
+{
+	return {};
+}
+
+std::string spu_thread::dump_misc() const
+{
+	std::string ret;
 
 	fmt::append(ret, "\nBlock Weight: %u (Retreats: %u)", block_counter, block_failure);
 
@@ -1028,7 +1060,6 @@ std::string spu_thread::dump() const
 		// Print chunk address from lowest 16 bits
 		fmt::append(ret, "...chunk-0x%05x", (name & 0xffff) * 4);
 	}
-
 	fmt::append(ret, "\n[%s]", ch_mfc_cmd);
 	fmt::append(ret, "\nLocal Storage: 0x%08x..0x%08x", offset, offset + 0x3ffff);
 	fmt::append(ret, "\nTag Mask: 0x%08x", ch_tag_mask);
@@ -1045,13 +1076,6 @@ std::string spu_thread::dump() const
 		{
 			fmt::append(ret, "\n[-]");
 		}
-	}
-
-	ret += "\nRegisters:\n=========";
-
-	for (u32 i = 0; i < 128; i++)
-	{
-		fmt::append(ret, "\nGPR[%d] = %s", i, gpr[i]);
 	}
 
 	return ret;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -498,7 +498,11 @@ public:
 class spu_thread : public cpu_thread
 {
 public:
-	virtual std::string dump() const override;
+	virtual std::string dump_all() const override;
+	virtual std::string dump_regs() const override;
+	virtual std::string dump_callstack() const override;
+	virtual std::vector<u32> dump_callstack_list() const override;
+	virtual std::string dump_misc() const override;
 	virtual void cpu_task() override final;
 	virtual void cpu_mem() override;
 	virtual void cpu_unmem() override;

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -363,6 +363,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_call_stack_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_cg_disasm_window.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -594,6 +599,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug\moc_breakpoint_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_call_stack_list.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
@@ -853,6 +863,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_call_stack_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_cg_disasm_window.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
@@ -1088,6 +1103,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_call_stack_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_cg_disasm_window.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -1301,6 +1321,7 @@
     <ClCompile Include="rpcs3qt\about_dialog.cpp" />
     <ClCompile Include="rpcs3qt\breakpoint_handler.cpp" />
     <ClCompile Include="rpcs3qt\breakpoint_list.cpp" />
+    <ClCompile Include="rpcs3qt\call_stack_list.cpp" />
     <ClCompile Include="rpcs3qt\cheat_manager.cpp" />
     <ClCompile Include="rpcs3qt\curl_handle.cpp" />
     <ClCompile Include="rpcs3qt\custom_dialog.cpp" />
@@ -1786,6 +1807,24 @@
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">Moc%27ing %(Identity)...</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\call_stack_list.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB "-DBRANCH=$(BRANCH)" -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\minidx12\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtOpenGL" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtQml" "-I$(QTDIR)\include\QtNetwork" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\custom_dialog.h">
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -646,6 +646,9 @@
     <ClCompile Include="rpcs3qt\breakpoint_list.cpp">
       <Filter>Gui\debugger</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\call_stack_list.cpp">
+      <Filter>Gui\debugger</Filter>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_breakpoint_list.cpp">
       <Filter>Generated Files\Release - LLVM</Filter>
     </ClCompile>
@@ -656,6 +659,18 @@
       <Filter>Generated Files\Release</Filter>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_breakpoint_list.cpp">
+      <Filter>Generated Files\Debug - LLVM</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_call_stack_list.cpp">
+      <Filter>Generated Files\Release - LLVM</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_call_stack_list.cpp">
+      <Filter>Generated Files\Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_call_stack_list.cpp">
+      <Filter>Generated Files\Release</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_call_stack_list.cpp">
       <Filter>Generated Files\Debug - LLVM</Filter>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\qrc_windows.cpp">
@@ -1155,6 +1170,9 @@
       <Filter>Gui\debugger</Filter>
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\breakpoint_list.h">
+      <Filter>Gui\debugger</Filter>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\call_stack_list.h">
       <Filter>Gui\debugger</Filter>
     </CustomBuild>
     <CustomBuild Include="windows.qrc">

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -3,6 +3,7 @@
 	auto_pause_settings_dialog.cpp
 	breakpoint_handler.cpp
 	breakpoint_list.cpp
+	call_stack_list.cpp
 	cg_disasm_window.cpp
 	cheat_manager.cpp
 	curl_handle.cpp

--- a/rpcs3/rpcs3qt/breakpoint_list.h
+++ b/rpcs3/rpcs3qt/breakpoint_list.h
@@ -22,7 +22,7 @@ public:
 	QColor m_text_color_bp;
 	QColor m_color_bp;
 Q_SIGNALS:
-	void RequestShowAddress(u32 addr);
+	void RequestShowAddress(u32 addr, bool force = false);
 public Q_SLOTS:
 	void HandleBreakpointRequest(u32 addr);
 private Q_SLOTS:

--- a/rpcs3/rpcs3qt/call_stack_list.cpp
+++ b/rpcs3/rpcs3qt/call_stack_list.cpp
@@ -1,0 +1,37 @@
+﻿#include "call_stack_list.h"
+
+constexpr auto qstr = QString::fromStdString;
+
+call_stack_list::call_stack_list(QWidget* parent) : QListWidget(parent)
+{
+	setEditTriggers(QAbstractItemView::NoEditTriggers);
+	setContextMenuPolicy(Qt::CustomContextMenu);
+	setSelectionMode(QAbstractItemView::ExtendedSelection);
+
+	// connects
+	connect(this, &QListWidget::itemDoubleClicked, this, &call_stack_list::OnCallStackListDoubleClicked);
+}
+
+void call_stack_list::UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_ptr<CPUDisAsm> disasm)
+{
+	this->cpu = cpu;
+}
+
+void call_stack_list::HandleUpdate(std::vector<u32> call_stack)
+{
+	clear();
+
+	for (auto addr : call_stack)
+	{
+		const QString call_stack_item_text = qstr(fmt::format("0x%08llx", addr));
+		QListWidgetItem* callStackItem = new QListWidgetItem(call_stack_item_text);
+		callStackItem->setData(Qt::UserRole, { addr });
+		addItem(callStackItem);
+	}
+}
+
+void call_stack_list::OnCallStackListDoubleClicked()
+{
+	const u32 address = currentItem()->data(Qt::UserRole).value<u32>();
+	Q_EMIT RequestShowAddress(address);
+}

--- a/rpcs3/rpcs3qt/call_stack_list.h
+++ b/rpcs3/rpcs3qt/call_stack_list.h
@@ -1,0 +1,26 @@
+﻿#pragma once
+
+#include "stdafx.h"
+
+#include "Emu/CPU/CPUThread.h"
+#include "Emu/CPU/CPUDisAsm.h"
+
+#include <QListWidget>
+
+class call_stack_list : public QListWidget
+{
+	Q_OBJECT
+
+public:
+	call_stack_list(QWidget* parent);
+	void UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_ptr<CPUDisAsm> disasm);
+
+Q_SIGNALS:
+	void RequestShowAddress(u32 addr);
+public Q_SLOTS:
+	void HandleUpdate(std::vector<u32> call_stack);
+private Q_SLOTS:
+	void OnCallStackListDoubleClicked();
+private:
+	std::weak_ptr<cpu_thread> cpu;
+};

--- a/rpcs3/rpcs3qt/call_stack_list.h
+++ b/rpcs3/rpcs3qt/call_stack_list.h
@@ -16,7 +16,7 @@ public:
 	void UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_ptr<CPUDisAsm> disasm);
 
 Q_SIGNALS:
-	void RequestShowAddress(u32 addr);
+	void RequestShowAddress(u32 addr, bool force = false);
 public Q_SLOTS:
 	void HandleUpdate(std::vector<u32> call_stack);
 private Q_SLOTS:

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -84,16 +84,23 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 	hbox_b_main->addWidget(m_choice_units);
 	hbox_b_main->addStretch();
 
-	//Registers
+	// Misc state
+	m_misc_state = new QTextEdit(this);
+	m_misc_state->setLineWrapMode(QTextEdit::NoWrap);
+	m_misc_state->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+
+	// Registers
 	m_regs = new QTextEdit(this);
 	m_regs->setLineWrapMode(QTextEdit::NoWrap);
 	m_regs->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
 
 	m_debugger_list->setFont(m_mono);
+	m_misc_state->setFont(m_mono);
 	m_regs->setFont(m_mono);
 
 	m_right_splitter = new QSplitter(this);
 	m_right_splitter->setOrientation(Qt::Vertical);
+	m_right_splitter->addWidget(m_misc_state);
 	m_right_splitter->addWidget(m_regs);
 	m_right_splitter->addWidget(m_breakpoint_list);
 	m_right_splitter->setStretchFactor(0, 1);
@@ -416,22 +423,30 @@ void debugger_frame::DoUpdate()
 	}
 
 	ShowPC();
-	WriteRegs();
+	WritePanels();
 }
 
-void debugger_frame::WriteRegs()
+void debugger_frame::WritePanels()
 {
 	const auto cpu = this->cpu.lock();
 
 	if (!cpu)
 	{
+		m_misc_state->clear();
 		m_regs->clear();
 		return;
 	}
 
-	int loc = m_regs->verticalScrollBar()->value();
+	int loc;
+
+	loc = m_regs->verticalScrollBar()->value();
+	m_misc_state->clear();
+	m_misc_state->setText(qstr(cpu->dump_misc()));
+	m_misc_state->verticalScrollBar()->setValue(loc);
+
+	loc = m_regs->verticalScrollBar()->value();
 	m_regs->clear();
-	m_regs->setText(qstr(cpu->dump()));
+	m_regs->setText(qstr(cpu->dump_regs()));
 	m_regs->verticalScrollBar()->setValue(loc);
 }
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -5,6 +5,7 @@
 #include "debugger_list.h"
 #include "breakpoint_list.h"
 #include "breakpoint_handler.h"
+#include "call_stack_list.h"
 #include "qt_utils.h"
 
 #include "Emu/System.h"
@@ -48,10 +49,12 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 	hbox_b_main->setContentsMargins(0, 0, 0, 0);
 
 	m_breakpoint_handler = new breakpoint_handler();
+	m_breakpoint_list = new breakpoint_list(this, m_breakpoint_handler);
+
 	m_debugger_list = new debugger_list(this, settings, m_breakpoint_handler);
 	m_debugger_list->installEventFilter(this);
 
-	m_breakpoint_list = new breakpoint_list(this, m_breakpoint_handler);
+	m_call_stack_list = new call_stack_list(this);
 
 	m_choice_units = new QComboBox(this);
 	m_choice_units->setSizeAdjustPolicy(QComboBox::AdjustToContents);
@@ -97,13 +100,20 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 	m_debugger_list->setFont(m_mono);
 	m_misc_state->setFont(m_mono);
 	m_regs->setFont(m_mono);
+	m_call_stack_list->setFont(m_mono);
 
 	m_right_splitter = new QSplitter(this);
 	m_right_splitter->setOrientation(Qt::Vertical);
 	m_right_splitter->addWidget(m_misc_state);
 	m_right_splitter->addWidget(m_regs);
+	m_right_splitter->addWidget(m_call_stack_list);
 	m_right_splitter->addWidget(m_breakpoint_list);
-	m_right_splitter->setStretchFactor(0, 1);
+
+	// Set relative sizes for widgets
+	m_right_splitter->setStretchFactor(0, 2); // misc state
+	m_right_splitter->setStretchFactor(1, 8); // registers
+	m_right_splitter->setStretchFactor(2, 3); // call stack
+	m_right_splitter->setStretchFactor(3, 1); // breakpoint list
 
 	m_splitter = new QSplitter(this);
 	m_splitter->addWidget(m_debugger_list);
@@ -160,6 +170,9 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 
 	connect(m_debugger_list, &debugger_list::BreakpointRequested, m_breakpoint_list, &breakpoint_list::HandleBreakpointRequest);
 	connect(m_breakpoint_list, &breakpoint_list::RequestShowAddress, m_debugger_list, &debugger_list::ShowAddress);
+
+	connect(this, &debugger_frame::CallStackUpdateRequested, m_call_stack_list, &call_stack_list::HandleUpdate);
+	connect(m_call_stack_list, &call_stack_list::RequestShowAddress, m_debugger_list, &debugger_list::ShowAddress);
 
 	m_debugger_list->ShowAddress(m_debugger_list->m_pc);
 	UpdateUnitList();
@@ -409,6 +422,7 @@ void debugger_frame::OnSelectUnit()
 
 	m_debugger_list->UpdateCPUData(this->cpu, m_disasm);
 	m_breakpoint_list->UpdateCPUData(this->cpu, m_disasm);
+	m_call_stack_list->UpdateCPUData(this->cpu, m_disasm);
 	DoUpdate();
 	UpdateUI();
 }
@@ -448,6 +462,8 @@ void debugger_frame::WritePanels()
 	m_regs->clear();
 	m_regs->setText(qstr(cpu->dump_regs()));
 	m_regs->verticalScrollBar()->setValue(loc);
+
+	Q_EMIT CallStackUpdateRequested(cpu->dump_callstack_list());
 }
 
 void debugger_frame::ShowGotoAddressDialog()
@@ -558,6 +574,11 @@ u64 debugger_frame::EvaluateExpression(const QString& expression)
 void debugger_frame::ClearBreakpoints()
 {
 	m_breakpoint_list->ClearBreakpoints();
+}
+
+void debugger_frame::ClearCallStack()
+{
+	Q_EMIT CallStackUpdateRequested({});
 }
 
 void debugger_frame::ShowPC()

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -15,6 +15,7 @@ class gui_settings;
 class debugger_list;
 class breakpoint_list;
 class breakpoint_handler;
+class call_stack_list;
 
 class debugger_frame : public custom_dock_widget
 {
@@ -53,6 +54,8 @@ class debugger_frame : public custom_dock_widget
 	breakpoint_list* m_breakpoint_list;
 	breakpoint_handler* m_breakpoint_handler;
 
+	call_stack_list* m_call_stack_list;
+
 	std::shared_ptr<gui_settings> xgui_settings;
 
 public:
@@ -71,6 +74,7 @@ public:
 	void ShowGotoAddressDialog();
 	u64 EvaluateExpression(const QString& expression);
 	void ClearBreakpoints(); // Fallthrough method into breakpoint_list.
+	void ClearCallStack();
 
 	/** Needed so key press events work when other objects are selected in debugger_frame. */
 	bool eventFilter(QObject* object, QEvent* event) override; 
@@ -83,6 +87,7 @@ protected:
 
 Q_SIGNALS:
 	void DebugFrameClosed();
+	void CallStackUpdateRequested(std::vector<u32> call_stack);
 
 public Q_SLOTS:
 	void DoStep(bool stepOver = false);

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -27,6 +27,7 @@ class debugger_frame : public custom_dock_widget
 	debugger_list* m_debugger_list;
 	QSplitter* m_right_splitter;
 	QFont m_mono;
+	QTextEdit* m_misc_state;
 	QTextEdit* m_regs;
 	QPushButton* m_go_to_addr;
 	QPushButton* m_go_to_pc;
@@ -65,7 +66,7 @@ public:
 
 	u32 GetPc() const;
 	void DoUpdate();
-	void WriteRegs();
+	void WritePanels();
 	void EnableButtons(bool enable);
 	void ShowGotoAddressDialog();
 	u64 EvaluateExpression(const QString& expression);

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -28,7 +28,7 @@ public:
 	debugger_list(QWidget* parent, std::shared_ptr<gui_settings> settings, breakpoint_handler* handler);
 	void UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_ptr<CPUDisAsm> disasm);
 public Q_SLOTS:
-	void ShowAddress(u32 addr);
+	void ShowAddress(u32 addr, bool force = false);
 protected:
 	void keyPressEvent(QKeyEvent* event) override;
 	void mouseDoubleClickEvent(QMouseEvent* event) override;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -991,6 +991,7 @@ void main_window::OnEmuStop()
 
 	m_debugger_frame->EnableButtons(false);
 	m_debugger_frame->ClearBreakpoints();
+	m_debugger_frame->ClearCallStack();
 
 	ui->sysPauseAct->setText(Emu.IsReady() ? tr("&Play\tCtrl+E") : tr("&Resume\tCtrl+E"));
 	ui->sysPauseAct->setIcon(m_icon_play);

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -1,6 +1,7 @@
 ﻿#include "stdafx.h"
 #include "Utilities/mutex.h"
 #include "Emu/Memory/vm_locking.h"
+#include "Emu/Memory/vm.h"
 
 #include "memory_viewer_panel.h"
 
@@ -233,7 +234,9 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent)
 
 	//Fill the QTextEdits
 	ShowMemory();
-	setFixedSize(sizeHint());
+
+	setFixedWidth(sizeHint().width());
+	setMinimumHeight(hbox_tools->sizeHint().height());
 }
 
 memory_viewer_panel::~memory_viewer_panel()
@@ -253,6 +256,29 @@ void memory_viewer_panel::wheelEvent(QWheelEvent *event)
 
 	m_addr_line->setText(qstr(fmt::format("%08x", m_addr)));
 	ShowMemory();
+}
+
+void memory_viewer_panel::resizeEvent(QResizeEvent *event)
+{
+	QDialog::resizeEvent(event);
+
+	if (event->oldSize().height() != -1)
+		m_height_leftover += event->size().height() - event->oldSize().height();
+
+	const auto font_height = m_fontMetrics->height();
+
+	if (m_height_leftover >= font_height)
+	{
+		m_height_leftover -= font_height;
+		++m_rowcount;
+		ShowMemory();
+	}
+	else if (m_height_leftover < -font_height)
+	{
+		m_height_leftover += font_height;
+		--m_rowcount;
+		ShowMemory();
+	}
 }
 
 void memory_viewer_panel::ShowMemory()

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -11,6 +11,7 @@ class memory_viewer_panel : public QDialog
 	u32 m_addr;
 	u32 m_colcount;
 	u32 m_rowcount;
+	s32 m_height_leftover{};
 
 	QLineEdit* m_addr_line;
 
@@ -25,7 +26,8 @@ public:
 	memory_viewer_panel(QWidget* parent);
 	~memory_viewer_panel();
 
-	virtual void wheelEvent(QWheelEvent *event);
+	void wheelEvent(QWheelEvent *event) override;
+	void resizeEvent(QResizeEvent *event) override;
 
 	virtual void ShowMemory();
 	void SetPC(const uint pc);


### PR DESCRIPTION
* Made Memory Viewer resizeable
* Created Call Stack panel with clickable addresses
* Split register & misc CPU info to separate panels
* Tweaked relative sizes of all panels to be `registers` > `call stack` > `misc state` > `break point list`.
* String & hex previews for register pointers in register dump (heuristic checks for pointers within 2 levels)
* Don't move entire asm listing if it's not needed

![image](https://user-images.githubusercontent.com/6632271/77976016-79474a00-7304-11ea-9c5e-a1997f5b3ee4.png)
