### PR TITLE
rsx: Implement DECR memory layout

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -186,7 +186,8 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 	dmaControl.put = 0;
 	dmaControl.ref = 0; // Set later to -1 by cellGcmSys
 
-	if (false/*system_mode == CELL_GCM_SYSTEM_MODE_IOMAP_512MB*/)
+	if ((true/*system_mode & something*/ || g_cfg.video.decr_memory_layout)
+		&& g_cfg.core.debug_console_mode)
 		rsx::get_current_renderer()->main_mem_size = 0x20000000; //512MB
 	else
 		rsx::get_current_renderer()->main_mem_size = 0x10000000; //256MB

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -134,6 +134,7 @@ struct cfg_root : cfg::node
 		cfg::_int<0, 30000000> driver_recovery_timeout{ this, "Driver Recovery Timeout", 1000000, true };
 		cfg::_int<0, 16667> driver_wakeup_delay{ this, "Driver Wake-Up Delay", 1, true };
 		cfg::_int<1, 1800> vblank_rate{ this, "Vblank Rate", 60, true }; // Changing this from 60 may affect game speed in unexpected ways
+		cfg::_bool decr_memory_layout{ this, "DECR memory layout", false}; // Force enable increased allowed main memory range as DECR console 
 
 		struct node_vk : cfg::node
 		{


### PR DESCRIPTION
Force allowed rsx main memory range to be 512mb, only if debug console mode is enabled.
This is compatible with rsx capture, ps3 memory availability, FIFO registers and commands address clamping, rsx method registers offset clamping and many more.
This is somethong that rsx allows in realhw but was forcefully disabled in gcm. (TODO..)