### PR TITLE
rsx: Misc cleanup

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2322,9 +2322,10 @@ void VKGSRender::begin_conditional_rendering(const std::vector<rsx::reports::occ
 			VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, dst_stage,
 			VK_ACCESS_SHADER_WRITE_BIT, dst_access);
 	}
-	else
+	else if (m_program)
 	{
-		rsx_log.error("Dubious query data pushed to cond render!, Please report to developers(q.pending=%d)", sources.front()->pending);
+		// This can sometimes happen when shaders are compiling, only log if there is a program hit
+		rsx_log.warning("Dubious query data pushed to cond render!, Please report to developers(q.pending=%d)", sources.front()->pending);
 	}
 
 	rsx::thread::begin_conditional_rendering(sources);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -3228,11 +3228,7 @@ public:
 
 		bool check_query_status(u32 index)
 		{
-			// NOTE: Keeps NVIDIA driver from using partial results as they are broken (always returns true)
-			const VkQueryResultFlags flags =
-				(vk::get_driver_vendor() == vk::driver_vendor::NVIDIA ? 0 : VK_QUERY_RESULT_PARTIAL_BIT);
-
-			return poke_query(query_slot_status[index], index, flags);
+			return poke_query(query_slot_status[index], index, VK_QUERY_RESULT_PARTIAL_BIT);
 		}
 
 		u32 get_query_result(u32 index)
@@ -3240,13 +3236,9 @@ public:
 			// Check for cached result
 			auto& query_info = query_slot_status[index];
 
-			// Wait for full result on NVIDIA to avoid getting garbage results
-			const VkQueryResultFlags flags =
-				(vk::get_driver_vendor() == vk::driver_vendor::NVIDIA ? VK_QUERY_RESULT_WAIT_BIT : VK_QUERY_RESULT_PARTIAL_BIT);
-
 			while (!query_info.ready)
 			{
-				poke_query(query_info, index, flags);
+				poke_query(query_info, index, VK_QUERY_RESULT_PARTIAL_BIT);
 			}
 
 			return query_info.any_passed ? 1 : 0;

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -194,28 +194,6 @@ namespace vk
 			attachment_references.push_back({ attachment_count, dsv_layout });
 		}
 
-		VkSubpassDependency null_subpass_dependencies[2] =
-		{
-			{
-				.srcSubpass = VK_SUBPASS_EXTERNAL,
-				.dstSubpass = 0,
-				.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-				.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-				.srcAccessMask = 0,
-				.dstAccessMask = 0,
-				.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT
-			},
-			{
-				.srcSubpass = 0,
-				.dstSubpass = VK_SUBPASS_EXTERNAL,
-				.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-				.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-				.srcAccessMask = 0,
-				.dstAccessMask = 0,
-				.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT
-			}
-		};
-
 		VkSubpassDescription subpass = {};
 		subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 		subpass.colorAttachmentCount = attachment_count;
@@ -228,19 +206,6 @@ namespace vk
 		rp_info.pAttachments = attachments.data();
 		rp_info.subpassCount = 1;
 		rp_info.pSubpasses = &subpass;
-
-		if (vk::get_driver_vendor() == vk::driver_vendor::RADV)
-		{
-			// So, according to spec, if you do not explicitly define the relationship between a subpass and its neighbours,
-			// a full pipeline barrier will be inserted for you, which is awful for performance.
-			// However, only RADV seems to do this and it does not work for other vendors.
-			// NVIDIA specifically slows to a crawl even with a TOP_OF_PIPE->TOP_OF_PIPE dependency with no dependent access.
-			// RPCS3 does not actually want to declare any dependency here, we have explicit pipeline barriers for our tasks.
-			// Workaround: Only provide this null dep chain for RADV
-
-			rp_info.dependencyCount = 2;
-			rp_info.pDependencies = null_subpass_dependencies;
-		}
 
 		VkRenderPass result;
 		CHECK_RESULT(vkCreateRenderPass(dev, &rp_info, NULL, &result));


### PR DESCRIPTION
- Remove obsolete RADV workaround fixed in newer spec version.
- Remove obsolete NVIDIA workaround fixed in newer drivers.
- Reduce unwanted log spam when compiling shaders.

Fixes https://github.com/RPCS3/rpcs3/issues/7896
Fixes https://github.com/RPCS3/rpcs3/issues/7897