### PR TITLE
Linguistic changes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -88,18 +88,18 @@ void fmt_class_string<CellSysutilLang>::format(std::string& out, u64 arg)
 		case CELL_SYSUTIL_LANG_GERMAN: return "German";
 		case CELL_SYSUTIL_LANG_ITALIAN: return "Italian";
 		case CELL_SYSUTIL_LANG_DUTCH: return "Dutch";
-		case CELL_SYSUTIL_LANG_PORTUGUESE_PT: return "Portuguese (PT)";
+		case CELL_SYSUTIL_LANG_PORTUGUESE_PT: return "Portuguese (Portugal)";
 		case CELL_SYSUTIL_LANG_RUSSIAN: return "Russian";
 		case CELL_SYSUTIL_LANG_KOREAN: return "Korean";
-		case CELL_SYSUTIL_LANG_CHINESE_T: return "Chinese (Trad.)";
-		case CELL_SYSUTIL_LANG_CHINESE_S: return "Chinese (Simp.)";
+		case CELL_SYSUTIL_LANG_CHINESE_T: return "Chinese (Traditional)";
+		case CELL_SYSUTIL_LANG_CHINESE_S: return "Chinese (Simplified)";
 		case CELL_SYSUTIL_LANG_FINNISH: return "Finnish";
 		case CELL_SYSUTIL_LANG_SWEDISH: return "Swedish";
 		case CELL_SYSUTIL_LANG_DANISH: return "Danish";
 		case CELL_SYSUTIL_LANG_NORWEGIAN: return "Norwegian";
 		case CELL_SYSUTIL_LANG_POLISH: return "Polish";
 		case CELL_SYSUTIL_LANG_ENGLISH_GB: return "English (UK)";
-		case CELL_SYSUTIL_LANG_PORTUGUESE_BR: return "Portuguese (BR)";
+		case CELL_SYSUTIL_LANG_PORTUGUESE_BR: return "Portuguese (Brazil)";
 		case CELL_SYSUTIL_LANG_TURKISH: return "Turkish";
 		}
 

--- a/rpcs3/Emu/Io/KeyboardHandler.cpp
+++ b/rpcs3/Emu/Io/KeyboardHandler.cpp
@@ -11,28 +11,28 @@ void fmt_class_string<CellKbMappingType>::format(std::string& out, u64 arg)
 		{
 		case CELL_KB_MAPPING_101: return "English keyboard (US standard)";
 		case CELL_KB_MAPPING_106: return "Japanese keyboard";
-		case CELL_KB_MAPPING_106_KANA: return "Japanese keyboard(Kana state)";
+		case CELL_KB_MAPPING_106_KANA: return "Japanese keyboard (Kana state)";
 		case CELL_KB_MAPPING_GERMAN_GERMANY: return "German keyboard";
 		case CELL_KB_MAPPING_SPANISH_SPAIN: return "Spanish keyboard";
 		case CELL_KB_MAPPING_FRENCH_FRANCE: return "French keyboard";
 		case CELL_KB_MAPPING_ITALIAN_ITALY: return "Italian keyboard";
 		case CELL_KB_MAPPING_DUTCH_NETHERLANDS: return "Dutch keyboard";
-		case CELL_KB_MAPPING_PORTUGUESE_PORTUGAL: return "Portuguese keyboard(Portugal)";
+		case CELL_KB_MAPPING_PORTUGUESE_PORTUGAL: return "Portuguese keyboard (Portugal)";
 		case CELL_KB_MAPPING_RUSSIAN_RUSSIA: return "Russian keyboard";
-		case CELL_KB_MAPPING_ENGLISH_UK: return "English keyboard(UK standard)";
+		case CELL_KB_MAPPING_ENGLISH_UK: return "English keyboard (UK standard)";
 		case CELL_KB_MAPPING_KOREAN_KOREA: return "Korean keyboard";
 		case CELL_KB_MAPPING_NORWEGIAN_NORWAY: return "Norwegian keyboard";
 		case CELL_KB_MAPPING_FINNISH_FINLAND: return "Finnish keyboard";
 		case CELL_KB_MAPPING_DANISH_DENMARK: return "Danish keyboard";
 		case CELL_KB_MAPPING_SWEDISH_SWEDEN: return "Swedish keyboard";
-		case CELL_KB_MAPPING_CHINESE_TRADITIONAL: return "Chinese keyboard(Traditional)";
-		case CELL_KB_MAPPING_CHINESE_SIMPLIFIED: return "Chinese keyboard(Simplified)";
-		case CELL_KB_MAPPING_SWISS_FRENCH_SWITZERLAND: return "French keyboard(Switzerland)";
-		case CELL_KB_MAPPING_SWISS_GERMAN_SWITZERLAND: return "German keyboard(Switzerland)";
-		case CELL_KB_MAPPING_CANADIAN_FRENCH_CANADA: return "French keyboard(Canada)";
-		case CELL_KB_MAPPING_BELGIAN_BELGIUM: return "French keyboard(Belgium)";
+		case CELL_KB_MAPPING_CHINESE_TRADITIONAL: return "Chinese keyboard (Traditional)";
+		case CELL_KB_MAPPING_CHINESE_SIMPLIFIED: return "Chinese keyboard (Simplified)";
+		case CELL_KB_MAPPING_SWISS_FRENCH_SWITZERLAND: return "French keyboard (Switzerland)";
+		case CELL_KB_MAPPING_SWISS_GERMAN_SWITZERLAND: return "German keyboard (Switzerland)";
+		case CELL_KB_MAPPING_CANADIAN_FRENCH_CANADA: return "French keyboard (Canada)";
+		case CELL_KB_MAPPING_BELGIAN_BELGIUM: return "French keyboard (Belgium)";
 		case CELL_KB_MAPPING_POLISH_POLAND: return "Polish keyboard";
-		case CELL_KB_MAPPING_PORTUGUESE_BRAZIL: return "Portuguese keyboard(Brazil)";
+		case CELL_KB_MAPPING_PORTUGUESE_BRAZIL: return "Portuguese keyboard (Brazil)";
 		case CELL_KB_MAPPING_TURKISH_TURKEY: return "Turkish keyboard";
 		}
 

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -170,7 +170,7 @@ void game_compatibility::RequestCompatibility(bool online)
 	compat_log.notice("Beginning compatibility database download from: %s", m_url);
 
 	// Show Progress
-	m_progress_dialog = new progress_dialog(tr("Downloading Database"), tr("Please wait ..."), tr("Abort"), 0, 100, true);
+	m_progress_dialog = new progress_dialog(tr("Downloading Database"), tr("Please wait..."), tr("Abort"), 0, 100, true);
 	m_progress_dialog->show();
 
 	curl_easy_setopt(m_curl->get_curl(), CURLOPT_URL, m_url.c_str());

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -941,11 +941,7 @@
     <string>Open</string>
    </property>
    <property name="toolTip">
-<<<<<<< HEAD
     <string>Boot a game</string>
-=======
-    <string>Boot selected game</string>
->>>>>>> b2a2ca3c3... Restoring the old wording for popup tooltips.
    </property>
   </action>
   <action name="showCatOtherAct">

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -383,7 +383,7 @@
     <string>Install .pkg</string>
    </property>
    <property name="toolTip">
-    <string>Install an application from a .pkg file</string>
+    <string>Install application from a .pkg file</string>
    </property>
   </action>
   <action name="bootInstallPupAct">
@@ -941,7 +941,11 @@
     <string>Open</string>
    </property>
    <property name="toolTip">
+<<<<<<< HEAD
     <string>Boot a game</string>
+=======
+    <string>Boot selected game</string>
+>>>>>>> b2a2ca3c3... Restoring the old wording for popup tooltips.
    </property>
   </action>
   <action name="showCatOtherAct">

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -383,7 +383,7 @@
     <string>Install .pkg</string>
    </property>
    <property name="toolTip">
-    <string>Install application from pkg file</string>
+    <string>Install an application from a .pkg file.</string>
    </property>
   </action>
   <action name="bootInstallPupAct">
@@ -391,7 +391,7 @@
     <string>Install Firmware</string>
    </property>
    <property name="toolTip">
-    <string>Install firmware from PS3UPDAT.PUP</string>
+    <string>Install a firmware from PS3UPDAT.PUP.</string>
    </property>
   </action>
   <action name="sysPauseAct">
@@ -406,7 +406,7 @@
     <string>Pause</string>
    </property>
    <property name="toolTip">
-    <string>Start Emulation</string>
+    <string>Starts the emulation.</string>
    </property>
   </action>
   <action name="sysStopAct">
@@ -421,7 +421,7 @@
     <string>Stop</string>
    </property>
    <property name="toolTip">
-    <string>Stop Emulation</string>
+    <string>Stops the emulation.</string>
    </property>
   </action>
   <action name="sysSendOpenMenuAct">
@@ -445,7 +445,7 @@
     <string>CPU</string>
    </property>
    <property name="toolTip">
-    <string>Configure CPU</string>
+    <string>Configure the CPU setting.</string>
    </property>
   </action>
   <action name="confGPUAct">
@@ -453,7 +453,7 @@
     <string>GPU</string>
    </property>
    <property name="toolTip">
-    <string>Configure Graphics</string>
+    <string>Configure the graphic settings.</string>
    </property>
   </action>
   <action name="confPadsAct">
@@ -464,7 +464,7 @@
     <string>Pads</string>
    </property>
    <property name="toolTip">
-    <string>Configure Controls</string>
+    <string>Configure the control settings.</string>
    </property>
   </action>
   <action name="confAudioAct">
@@ -472,7 +472,7 @@
     <string>Audio</string>
    </property>
    <property name="toolTip">
-    <string>Configure Audio</string>
+    <string>Configure the audio settings.</string>
    </property>
   </action>
   <action name="confIOAct">
@@ -480,7 +480,7 @@
     <string>Input/Output</string>
    </property>
    <property name="toolTip">
-    <string>Configure Input/Output</string>
+    <string>Configure the Input/Output settings.</string>
    </property>
   </action>
   <action name="confSystemAct">
@@ -488,7 +488,7 @@
     <string>System</string>
    </property>
    <property name="toolTip">
-    <string>Configure System</string>
+    <string>Configure the system settings.</string>
    </property>
   </action>
   <action name="confAutopauseManagerAct">
@@ -499,7 +499,7 @@
     <string>Auto Pause</string>
    </property>
    <property name="toolTip">
-    <string>Configure Auto Pause</string>
+    <string>Configure the Auto Pause function.</string>
    </property>
   </action>
   <action name="exitAct">
@@ -507,10 +507,10 @@
     <string>Exit</string>
    </property>
    <property name="toolTip">
-    <string>Exit RPCS3</string>
+    <string>Exits RPCS3.</string>
    </property>
    <property name="statusTip">
-    <string>Exit the application</string>
+    <string>Exit the application.</string>
    </property>
   </action>
   <action name="confSavedataManagerAct">
@@ -521,7 +521,7 @@
     <string>Save Data</string>
    </property>
    <property name="toolTip">
-    <string>Manage Save Data</string>
+    <string>Manage your saved data.</string>
    </property>
   </action>
   <action name="actionManage_Trophy_Data">
@@ -532,7 +532,7 @@
     <string>Trophies</string>
    </property>
    <property name="toolTip">
-    <string>Manage Trophies</string>
+    <string>Manage your trophies.</string>
    </property>
   </action>
   <action name="actionManage_Users">
@@ -540,7 +540,7 @@
     <string>User Accounts</string>
    </property>
    <property name="toolTip">
-    <string>Manage User Accounts</string>
+    <string>Manage your user accounts.</string>
    </property>
   </action>
   <action name="toolsCgDisasmAct">
@@ -845,7 +845,7 @@
     <string>Start</string>
    </property>
    <property name="toolTip">
-    <string>Start emulation</string>
+    <string>Start the emulation.</string>
    </property>
   </action>
   <action name="toolbar_stop">
@@ -857,7 +857,7 @@
     <string>Stop</string>
    </property>
    <property name="toolTip">
-    <string>Stop emulation</string>
+    <string>Stop the emulation.</string>
    </property>
   </action>
   <action name="toolbar_config">
@@ -869,7 +869,7 @@
     <string>Config</string>
    </property>
    <property name="toolTip">
-    <string>Configure the emulator</string>
+    <string>Configure the emulator.</string>
    </property>
   </action>
   <action name="toolbar_controls">
@@ -881,7 +881,7 @@
     <string>Pads</string>
    </property>
    <property name="toolTip">
-    <string>Configure controls</string>
+    <string>Configure your controls.</string>
    </property>
   </action>
   <action name="toolbar_fullscreen">
@@ -893,7 +893,7 @@
     <string>FullScr</string>
    </property>
    <property name="toolTip">
-    <string>Toggle fullscreen</string>
+    <string>Toggle fullscreen.</string>
    </property>
   </action>
   <action name="toolbar_list">
@@ -905,7 +905,7 @@
     <string>List</string>
    </property>
    <property name="toolTip">
-    <string>Switch to list mode</string>
+    <string>Switch to list mode.</string>
    </property>
   </action>
   <action name="toolbar_grid">
@@ -917,7 +917,7 @@
     <string>Grid</string>
    </property>
    <property name="toolTip">
-    <string>Switch to grid mode</string>
+    <string>Switch to grid mode.</string>
    </property>
   </action>
   <action name="toolbar_refresh">
@@ -929,7 +929,7 @@
     <string>Refresh</string>
    </property>
    <property name="toolTip">
-    <string>Refresh gamelist</string>
+    <string>Refresh the gamelist.</string>
    </property>
   </action>
   <action name="toolbar_open">
@@ -941,7 +941,7 @@
     <string>Open</string>
    </property>
    <property name="toolTip">
-    <string>Boot game</string>
+    <string>Boot the selected game.</string>
    </property>
   </action>
   <action name="showCatOtherAct">

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -383,7 +383,7 @@
     <string>Install .pkg</string>
    </property>
    <property name="toolTip">
-    <string>Install an application from a .pkg file.</string>
+    <string>Install an application from a .pkg file</string>
    </property>
   </action>
   <action name="bootInstallPupAct">
@@ -391,7 +391,7 @@
     <string>Install Firmware</string>
    </property>
    <property name="toolTip">
-    <string>Install a firmware from PS3UPDAT.PUP.</string>
+    <string>Install a firmware from PS3UPDAT.PUP</string>
    </property>
   </action>
   <action name="sysPauseAct">
@@ -406,7 +406,7 @@
     <string>Pause</string>
    </property>
    <property name="toolTip">
-    <string>Starts the emulation.</string>
+    <string>Starts the emulation</string>
    </property>
   </action>
   <action name="sysStopAct">
@@ -421,7 +421,7 @@
     <string>Stop</string>
    </property>
    <property name="toolTip">
-    <string>Stops the emulation.</string>
+    <string>Stops the emulation</string>
    </property>
   </action>
   <action name="sysSendOpenMenuAct">
@@ -445,7 +445,7 @@
     <string>CPU</string>
    </property>
    <property name="toolTip">
-    <string>Configure the CPU setting.</string>
+    <string>Configure the CPU settings</string>
    </property>
   </action>
   <action name="confGPUAct">
@@ -453,7 +453,7 @@
     <string>GPU</string>
    </property>
    <property name="toolTip">
-    <string>Configure the graphic settings.</string>
+    <string>Configure the graphic settings</string>
    </property>
   </action>
   <action name="confPadsAct">
@@ -464,7 +464,7 @@
     <string>Pads</string>
    </property>
    <property name="toolTip">
-    <string>Configure the control settings.</string>
+    <string>Configure the control settings</string>
    </property>
   </action>
   <action name="confAudioAct">
@@ -472,7 +472,7 @@
     <string>Audio</string>
    </property>
    <property name="toolTip">
-    <string>Configure the audio settings.</string>
+    <string>Configure the audio settings</string>
    </property>
   </action>
   <action name="confIOAct">
@@ -480,7 +480,7 @@
     <string>Input/Output</string>
    </property>
    <property name="toolTip">
-    <string>Configure the Input/Output settings.</string>
+    <string>Configure the Input/Output settings</string>
    </property>
   </action>
   <action name="confSystemAct">
@@ -488,7 +488,7 @@
     <string>System</string>
    </property>
    <property name="toolTip">
-    <string>Configure the system settings.</string>
+    <string>Configure the system settings</string>
    </property>
   </action>
   <action name="confAutopauseManagerAct">
@@ -499,7 +499,7 @@
     <string>Auto Pause</string>
    </property>
    <property name="toolTip">
-    <string>Configure the Auto Pause function.</string>
+    <string>Configure the Auto Pause function</string>
    </property>
   </action>
   <action name="exitAct">
@@ -507,7 +507,7 @@
     <string>Exit</string>
    </property>
    <property name="toolTip">
-    <string>Exits RPCS3.</string>
+    <string>Exits RPCS3</string>
    </property>
    <property name="statusTip">
     <string>Exit the application.</string>
@@ -521,7 +521,7 @@
     <string>Save Data</string>
    </property>
    <property name="toolTip">
-    <string>Manage your saved data.</string>
+    <string>Manage your saved data</string>
    </property>
   </action>
   <action name="actionManage_Trophy_Data">
@@ -532,7 +532,7 @@
     <string>Trophies</string>
    </property>
    <property name="toolTip">
-    <string>Manage your trophies.</string>
+    <string>Manage your trophies</string>
    </property>
   </action>
   <action name="actionManage_Users">
@@ -540,7 +540,7 @@
     <string>User Accounts</string>
    </property>
    <property name="toolTip">
-    <string>Manage your user accounts.</string>
+    <string>Manage the user accounts</string>
    </property>
   </action>
   <action name="toolsCgDisasmAct">
@@ -845,7 +845,7 @@
     <string>Start</string>
    </property>
    <property name="toolTip">
-    <string>Start the emulation.</string>
+    <string>Start the emulation</string>
    </property>
   </action>
   <action name="toolbar_stop">
@@ -857,7 +857,7 @@
     <string>Stop</string>
    </property>
    <property name="toolTip">
-    <string>Stop the emulation.</string>
+    <string>Stop the emulation</string>
    </property>
   </action>
   <action name="toolbar_config">
@@ -869,7 +869,7 @@
     <string>Config</string>
    </property>
    <property name="toolTip">
-    <string>Configure the emulator.</string>
+    <string>Configure the emulator</string>
    </property>
   </action>
   <action name="toolbar_controls">
@@ -881,7 +881,7 @@
     <string>Pads</string>
    </property>
    <property name="toolTip">
-    <string>Configure your controls.</string>
+    <string>Configure your controls</string>
    </property>
   </action>
   <action name="toolbar_fullscreen">
@@ -893,7 +893,7 @@
     <string>FullScr</string>
    </property>
    <property name="toolTip">
-    <string>Toggle fullscreen.</string>
+    <string>Toggle fullscreen</string>
    </property>
   </action>
   <action name="toolbar_list">
@@ -905,7 +905,7 @@
     <string>List</string>
    </property>
    <property name="toolTip">
-    <string>Switch to list mode.</string>
+    <string>Switch to list mode</string>
    </property>
   </action>
   <action name="toolbar_grid">
@@ -917,7 +917,7 @@
     <string>Grid</string>
    </property>
    <property name="toolTip">
-    <string>Switch to grid mode.</string>
+    <string>Switch to grid mode</string>
    </property>
   </action>
   <action name="toolbar_refresh">
@@ -929,7 +929,7 @@
     <string>Refresh</string>
    </property>
    <property name="toolTip">
-    <string>Refresh the gamelist.</string>
+    <string>Refresh the gamelist</string>
    </property>
   </action>
   <action name="toolbar_open">
@@ -941,7 +941,7 @@
     <string>Open</string>
    </property>
    <property name="toolTip">
-    <string>Boot the selected game.</string>
+    <string>Boot the selected game</string>
    </property>
   </action>
   <action name="showCatOtherAct">

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -941,7 +941,7 @@
     <string>Open</string>
    </property>
    <property name="toolTip">
-    <string>Boot selected game</string>
+    <string>Boot a game</string>
    </property>
   </action>
   <action name="showCatOtherAct">

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -383,7 +383,7 @@
     <string>Install .pkg</string>
    </property>
    <property name="toolTip">
-    <string>Install an application from a .pkg file</string>
+    <string>Install application from a .pkg file</string>
    </property>
   </action>
   <action name="bootInstallPupAct">
@@ -391,7 +391,7 @@
     <string>Install Firmware</string>
    </property>
    <property name="toolTip">
-    <string>Install a firmware from PS3UPDAT.PUP</string>
+    <string>Install firmware from PS3UPDAT.PUP</string>
    </property>
   </action>
   <action name="sysPauseAct">
@@ -406,7 +406,7 @@
     <string>Pause</string>
    </property>
    <property name="toolTip">
-    <string>Starts the emulation</string>
+    <string>Start emulation</string>
    </property>
   </action>
   <action name="sysStopAct">
@@ -421,7 +421,7 @@
     <string>Stop</string>
    </property>
    <property name="toolTip">
-    <string>Stops the emulation</string>
+    <string>Stop emulation</string>
    </property>
   </action>
   <action name="sysSendOpenMenuAct">
@@ -445,7 +445,7 @@
     <string>CPU</string>
    </property>
    <property name="toolTip">
-    <string>Configure the CPU settings</string>
+    <string>Configure CPU</string>
    </property>
   </action>
   <action name="confGPUAct">
@@ -453,7 +453,7 @@
     <string>GPU</string>
    </property>
    <property name="toolTip">
-    <string>Configure the graphic settings</string>
+    <string>Configure graphics</string>
    </property>
   </action>
   <action name="confPadsAct">
@@ -464,7 +464,7 @@
     <string>Pads</string>
    </property>
    <property name="toolTip">
-    <string>Configure the control settings</string>
+    <string>Configure controls</string>
    </property>
   </action>
   <action name="confAudioAct">
@@ -472,7 +472,7 @@
     <string>Audio</string>
    </property>
    <property name="toolTip">
-    <string>Configure the audio settings</string>
+    <string>Configure audio</string>
    </property>
   </action>
   <action name="confIOAct">
@@ -480,7 +480,7 @@
     <string>Input/Output</string>
    </property>
    <property name="toolTip">
-    <string>Configure the Input/Output settings</string>
+    <string>Configure Input/Output</string>
    </property>
   </action>
   <action name="confSystemAct">
@@ -488,7 +488,7 @@
     <string>System</string>
    </property>
    <property name="toolTip">
-    <string>Configure the system settings</string>
+    <string>Configure system</string>
    </property>
   </action>
   <action name="confAutopauseManagerAct">
@@ -507,7 +507,7 @@
     <string>Exit</string>
    </property>
    <property name="toolTip">
-    <string>Exits RPCS3</string>
+    <string>Exit RPCS3</string>
    </property>
    <property name="statusTip">
     <string>Exit the application.</string>
@@ -521,7 +521,7 @@
     <string>Save Data</string>
    </property>
    <property name="toolTip">
-    <string>Manage your saved data</string>
+    <string>Manage save data</string>
    </property>
   </action>
   <action name="actionManage_Trophy_Data">
@@ -532,7 +532,7 @@
     <string>Trophies</string>
    </property>
    <property name="toolTip">
-    <string>Manage your trophies</string>
+    <string>Manage trophies</string>
    </property>
   </action>
   <action name="actionManage_Users">
@@ -540,7 +540,7 @@
     <string>User Accounts</string>
    </property>
    <property name="toolTip">
-    <string>Manage the user accounts</string>
+    <string>Manage user accounts</string>
    </property>
   </action>
   <action name="toolsCgDisasmAct">
@@ -845,7 +845,7 @@
     <string>Start</string>
    </property>
    <property name="toolTip">
-    <string>Start the emulation</string>
+    <string>Start emulation</string>
    </property>
   </action>
   <action name="toolbar_stop">
@@ -857,7 +857,7 @@
     <string>Stop</string>
    </property>
    <property name="toolTip">
-    <string>Stop the emulation</string>
+    <string>Stop emulation</string>
    </property>
   </action>
   <action name="toolbar_config">
@@ -881,7 +881,7 @@
     <string>Pads</string>
    </property>
    <property name="toolTip">
-    <string>Configure your controls</string>
+    <string>Configure controls</string>
    </property>
   </action>
   <action name="toolbar_fullscreen">
@@ -929,7 +929,7 @@
     <string>Refresh</string>
    </property>
    <property name="toolTip">
-    <string>Refresh the gamelist</string>
+    <string>Refresh gamelist</string>
    </property>
   </action>
   <action name="toolbar_open">
@@ -941,7 +941,7 @@
     <string>Open</string>
    </property>
    <property name="toolTip">
-    <string>Boot the selected game</string>
+    <string>Boot selected game</string>
    </property>
   </action>
   <action name="showCatOtherAct">

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -383,7 +383,7 @@
     <string>Install .pkg</string>
    </property>
    <property name="toolTip">
-    <string>Install application from a .pkg file</string>
+    <string>Install an application from a .pkg file</string>
    </property>
   </action>
   <action name="bootInstallPupAct">

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -499,7 +499,7 @@
     <string>Auto Pause</string>
    </property>
    <property name="toolTip">
-    <string>Configure the Auto Pause function</string>
+    <string>Configure Auto Pause</string>
    </property>
   </action>
   <action name="exitAct">

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -391,7 +391,7 @@
         <item>
          <widget class="QGroupBox" name="gb_left_stick">
           <property name="title">
-           <string>Left Analog</string>
+           <string>Left Stick</string>
           </property>
           <layout class="QVBoxLayout" name="gb_left_stick_layout">
            <property name="leftMargin">
@@ -1815,7 +1815,7 @@
         <item>
          <widget class="QGroupBox" name="gb_right_stick">
           <property name="title">
-           <string>Right Analog</string>
+           <string>Right Stick</string>
           </property>
           <layout class="QVBoxLayout" name="gb_right_stick_layout">
            <property name="leftMargin">
@@ -2074,7 +2074,7 @@
             <item>
              <widget class="QGroupBox" name="gb_sticks">
               <property name="title">
-               <string>Analog Deadzones</string>
+               <string>Analog Stick Deadzones</string>
               </property>
               <layout class="QHBoxLayout" name="gb_sticks_layout">
                <property name="leftMargin">

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1378,14 +1378,14 @@
             <item>
              <widget class="QRadioButton" name="enterButtonAssignCircle">
               <property name="text">
-               <string notr="true">Enter with circle</string>
+               <string notr="true">Enter with the Circle button</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QRadioButton" name="enterButtonAssignCross">
               <property name="text">
-               <string notr="true">Enter with cross</string>
+               <string notr="true">Enter with the Cross button</string>
               </property>
              </widget>
             </item>
@@ -2423,7 +2423,7 @@
                 <item>
                  <widget class="QPushButton" name="reset_button_game_window_title_format">
                   <property name="toolTip">
-                   <string>Reset the game window title to default</string>
+                   <string>Reset the game window title to default.</string>
                   </property>
                   <property name="text">
                    <string>Reset</string>
@@ -2433,7 +2433,7 @@
                 <item>
                  <widget class="QPushButton" name="edit_button_game_window_title_format">
                   <property name="toolTip">
-                   <string>Edit the game window title</string>
+                   <string>Edit the game window title.</string>
                   </property>
                   <property name="text">
                    <string>Edit</string>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2423,7 +2423,7 @@
                 <item>
                  <widget class="QPushButton" name="reset_button_game_window_title_format">
                   <property name="toolTip">
-                   <string>Reset the game window title to default.</string>
+                   <string>Reset the game window title to default</string>
                   </property>
                   <property name="text">
                    <string>Reset</string>
@@ -2433,7 +2433,7 @@
                 <item>
                  <widget class="QPushButton" name="edit_button_game_window_title_format">
                   <property name="toolTip">
-                   <string>Edit the game window title.</string>
+                   <string>Edit the game window title</string>
                   </property>
                   <property name="text">
                    <string>Edit</string>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -134,7 +134,7 @@ public:
 		const QString anti_aliasing              = tr("Emulate PS3 multisampling layout.\nCan fix some otherwise difficult to solve graphics glitches.\nLow to moderate performance hit depending on your GPU hardware.");
 		const QString anisotropic_filter         = tr("Higher values increase sharpness of textures on sloped surfaces at the cost of GPU resources.\nModern GPUs can handle this setting just fine even at 16x.\nKeep this on Automatic if you want to use the original setting used by a real PS3.");
 		const QString resolution_scale           = tr("Scales the game's resolution by the given percentage.\nThe base resolution is always 1280x720.\nSet this value to 100% if you want to use the normal Resolution options.");
-		const QString minimum_scalable_dimension = tr("Only framebuffers greater than this size will be upscaled.\nIncreasing this value might fix problems with missing graphics when upscaling, especially when Write Color Buffers is enabled.\nDo not touch this setting if you are unsure.");
+		const QString minimum_scalable_dimension = tr("Only framebuffers greater than this size will be upscaled.\nIncreasing this value might fix problems with missing graphics when upscaling, especially when Write Color Buffers is enabled.\nIf unsure, don't change this option.");
 		const QString dump_color                 = tr("Enable this option if you get missing graphics or broken lighting ingame.\nMight degrade performance and introduce stuttering in some cases.\nRequired for Demon's Souls.");
 		const QString vsync                      = tr("By having this off you might obtain a higher frame rate at the cost of tearing artifacts in the game.");
 		const QString strict_rendering_mode      = tr("Enforces strict compliance to the API specification.\nMight result in degraded performance in some games.\nCan resolve rare cases of missing graphics and flickering.\nIf unsure, don't use this option.");
@@ -180,8 +180,8 @@ public:
 		// system
 
 		const QString system_language         = tr("Some games may fail to boot if the system language is not available in the game itself.\nOther games will switch language automatically to what is selected here.\nIt is recommended leaving this on a language supported by the game.");
-		const QString keyboard_type           = tr(" Sets the used keyboard layout.\nCurrently only US, Japanese and German layouts are fully supported at this moment.");
-		const QString enter_button_assignment = tr("The button used for enter/accept/confirm in system dialogs.\nChange this to use the circle button instead, which is the default configuration on Japanese systems and in many Japanese games.\nIn these cases having the cross button assigned can often lead to confusion.");
+		const QString keyboard_type           = tr("Sets the used keyboard layout.\nCurrently only US, Japanese and German layouts are fully supported at this moment.");
+		const QString enter_button_assignment = tr("The button used for enter/accept/confirm in system dialogs.\nChange this to use the Circle button instead, which is the default configuration on Japanese systems and in many Japanese games.\nIn these cases having the cross button assigned can often lead to confusion.");
 		const QString enable_host_root        = tr("Required for some Homebrew.\nIf unsure, don't use this option.");
 		const QString limit_cache_size        = tr("Automatically removes older files from disk cache on boot if it grows larger than the specified value.\nGames can use the cache folder to temporarily store data outside of system memory. It is not used for long-term storage.");
 	} settings;
@@ -189,7 +189,7 @@ public:
 	const struct gamepad_settings
 	{
 		const QString null        = tr("This controller is disabled and will appear as disconnected to software. Choose another handler to enable it.");
-		const QString keyboard    = tr("While it is possible to use a keyboard as a pad in RPCS3, the use of an actual controller is strongly recommended. To bind mouse movement to a button or joystick, click on the desired button to activate it, then click and hold while dragging the mouse to a direction");
+		const QString keyboard    = tr("While it is possible to use a keyboard as a pad in RPCS3, the use of an actual controller is strongly recommended. To bind mouse movement to a button or joystick, click on the desired button to activate it, then click and hold while dragging the mouse to a direction.");
 		const QString ds3_windows = tr("In order to use the DualShock 3 handler, you need to install the official DualShock 3 driver first.\nSee the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.");
 		const QString ds3_linux   = tr("In order to use the DualShock 3 handler, you might need to add udev rules to let RPCS3 access the controller.\nSee the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.");
 		const QString ds3_other   = tr("The DualShock 3 handler is recommended for official DualShock 3 controllers.");

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -173,9 +173,9 @@ public:
 
 		const QString net_status = tr("If set to Connected, RPCS3 will allow programs to use your internet connection.");
 		const QString psn_status = tr("If set to Simulated, RPCS3 will fake PSN connection as best as it can.");
-		const QString dns        = tr("DNS used to resolve hostnames by applications");
-		const QString psn_npid   = tr("Identifier representing your account");
-		const QString dns_swap   = tr("DNS Swap List");
+		const QString dns        = tr("DNS used to resolve hostnames by applications.");
+		const QString psn_npid   = tr("Identifier representing your PSN account.");
+		const QString dns_swap   = tr("DNS Swap List.");
 
 		// system
 
@@ -189,7 +189,7 @@ public:
 	const struct gamepad_settings
 	{
 		const QString null        = tr("This controller is disabled and will appear as disconnected to software. Choose another handler to enable it.");
-		const QString keyboard    = tr("While it is possible to use a keyboard as a pad in RPCS3, the use of an actual controller is strongly recommended. To bind mouse movement to a button or joystick, click on the desired button to activate it, then click and hold while dragging the mouse to a direction.");
+		const QString keyboard    = tr("While it is possible to use a keyboard as a pad in RPCS3, the use of an actual controller is strongly recommended.\nTo bind mouse movement to a button or joystick, click on the desired button to activate it, then click and hold while dragging the mouse to a direction.");
 		const QString ds3_windows = tr("In order to use the DualShock 3 handler, you need to install the official DualShock 3 driver first.\nSee the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.");
 		const QString ds3_linux   = tr("In order to use the DualShock 3 handler, you might need to add udev rules to let RPCS3 access the controller.\nSee the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.");
 		const QString ds3_other   = tr("The DualShock 3 handler is recommended for official DualShock 3 controllers.");

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -78,7 +78,7 @@ public:
 		const QString set_daz_and_ftz              = tr("Never use this.");
 		const QString accurate_getllar             = tr("Never use this.");
 		const QString accurate_putlluc             = tr("Never use this.");
-		const QString accurate_ppu_fma             = tr("Enables extra accuracy on FMA instructions, which can be needed by some games.\nIt can impact performance negatively on CPUs without FMA acceleration support");
+		const QString accurate_ppu_fma             = tr("Enables extra accuracy on FMA instructions, which can be needed by some games.\nIt can impact performance negatively on CPUs without FMA acceleration support.");
 		const QString accurate_rsx_access          = tr("Never use this.");
 		const QString hook_static_functions        = tr("Allows to hook some functions like 'memcpy' replacing them with high-level implementations. May do nothing or break things. Experimental.");
 		const QString gl_legacy_buffers            = tr("Enables use of classic OpenGL buffers which allows capturing tools to work with RPCS3 e.g RenderDoc.\nIf unsure, don't use this option.");

--- a/rpcs3/rpcs3qt/trophy_notification_frame.cpp
+++ b/rpcs3/rpcs3qt/trophy_notification_frame.cpp
@@ -50,7 +50,7 @@ trophy_notification_frame::trophy_notification_frame(const std::vector<uchar>& i
 	default: break;
 	}
 
-	trophyName->setText(tr("You have earned the %1 trophy\n").arg(trophyType) + qstr(trophy.name));
+	trophyName->setText(tr("You have earned the %1 trophy.\n").arg(trophyType) + qstr(trophy.name));
 	trophyName->setAutoFillBackground(true);
 	trophyName->setPalette(black_background);
 


### PR DESCRIPTION
 - Extended the names of the XMB's languages (what was the reason why these were shortened?).
 - Added some missing spaces before the parentheses in the keyboard options.
 - Fixed some typos.
 - Tweaked the wording of the tooltips and added some ending periods.
 - Changed a couple of terms to follow the official namings. I have other official naming changes, but I'm unsure if those are interesting or not for the team, so I haven't added them into the PR.
 - Changed one tooltip so the "If unsure..." structure is followed.