### PR TITLE
Fix sys_cond_destroy

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -56,6 +56,7 @@ error_code sys_cond_destroy(ppu_thread& ppu, u32 cond_id)
 			return CELL_EBUSY;
 		}
 
+		cond.mutex->cond_count--;
 		return {};
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_cond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.h
@@ -40,11 +40,6 @@ struct lv2_cond final : lv2_obj
 	{
 		this->mutex->cond_count++;
 	}
-
-	~lv2_cond()
-	{
-		this->mutex->cond_count--;
-	}
 };
 
 class ppu_thread;


### PR DESCRIPTION
Don't rely on misleading reference count of lv2_cond to end before declaring that the cond var is detached from mutex, instead do it immediatly in sys_cond_destroy.