### PR TITLE
Util: Add FMA and INVARIANT_TSC detection

### DIFF
--- a/Utilities/sysinfo.h
+++ b/Utilities/sysinfo.h
@@ -47,6 +47,12 @@ namespace utils
 
 	bool has_clwb();
 
+	bool has_invariant_tsc();
+
+	bool has_fma3();
+
+	bool has_fma4();
+
 	std::string get_cpu_brand();
 
 	std::string get_system_info();


### PR DESCRIPTION
Adds detection for FMA3 and FMA4, along with INVARIANT_TSC

These aren't used anywhere yet.

Fixes https://github.com/RPCS3/rpcs3/issues/7916