### PR TITLE
sys_ppu_thread: reduce global memory stats after thread creation

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1577,7 +1577,7 @@ void ppu_load_exec(const ppu_exec_object& elf)
 		mem_size += 0xC000000;
 	}
 
-	g_fxo->init<lv2_memory_container>(mem_size);
+	g_fxo->init<lv2_memory_container>(mem_size)->used += primary_stacksize;
 
 	ppu->cmd_push({ppu_cmd::initialize, 0});
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -12,6 +12,7 @@
 #include "SPURecompiler.h"
 #include "lv2/sys_sync.h"
 #include "lv2/sys_prx.h"
+#include "lv2/sys_memory.h"
 #include "Emu/GDB.h"
 
 #ifdef LLVM_AVAILABLE
@@ -747,6 +748,11 @@ ppu_thread::~ppu_thread()
 {
 	// Deallocate Stack Area
 	vm::dealloc_verbose_nothrow(stack_addr, vm::stack);
+
+	if (const auto dct = g_fxo->get<lv2_memory_container>())
+	{
+		dct->used -= stack_size;
+	}
 }
 
 ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u32 prio, int detached)


### PR DESCRIPTION
Stack size specified seems to be one-to-one with reduced memory stats after ppu thread creation, even if isn't 64k aligned. So implement this functionality.