### PR TITLE
Optimize utils::get_tsc_freq()

### DIFF
--- a/Utilities/sysinfo.cpp
+++ b/Utilities/sysinfo.cpp
@@ -269,7 +269,7 @@ static constexpr ullong round_tsc(ullong val)
 
 ullong utils::get_tsc_freq()
 {
-	const ullong cal_tsc = []() -> ullong
+	static const ullong cal_tsc = []() -> ullong
 	{
 		if (!has_invariant_tsc())
 			return 0;


### PR DESCRIPTION
Save first TSC value and reuse it.