### PR TITLE
sys_rsx: Minor atomicity fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -37,7 +37,7 @@ struct RsxDriverInfo
 
 	be_t<u32> unk7;          // 0x12B8
 	be_t<u32> unk8;          // 0x12BC
-	be_t<u32> handlers;      // 0x12C0 -- flags showing which handlers are set
+	atomic_be_t<u32> handlers; // 0x12C0 -- flags showing which handlers are set
 	be_t<u32> unk9;          // 0x12C4
 	be_t<u32> unk10;         // 0x12C8
 	be_t<u32> userCmdParam;  // 0x12CC
@@ -60,6 +60,18 @@ enum : u64
 {
 	// Unused
 	SYS_RSX_IO_MAP_IS_STRICT = 1ull << 60
+};
+
+// Unofficial event names
+enum : u64
+{
+	//SYS_RSX_EVENT_GRAPHICS_ERROR = 1 << 0,
+	SYS_RSX_EVENT_VBLANK = 1 << 1,
+	SYS_RSX_EVENT_FLIP_BASE = 1 << 3,
+	SYS_RSX_EVENT_QUEUE_BASE = 1 << 5,
+	SYS_RSX_EVENT_USER_CMD = 1 << 7,
+	SYS_RSX_EVENT_SECOND_VBLANK_BASE = 1 << 10,
+	SYS_RSX_EVENT_UNMAPPED_BASE = 1ull << 32,
 };
 
 struct RsxDmaControl

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -22,7 +22,7 @@ struct RsxDriverInfo
 	struct Head
 	{
 		be_t<u64> lastFlipTime;    // 0x0 last flip time
-		be_t<u32> flipFlags;       // 0x8 flags to handle flip/queue
+		atomic_be_t<u32> flipFlags; // 0x8 flags to handle flip/queue
 		be_t<u32> offset;          // 0xC
 		be_t<u32> flipBufferId;    // 0x10
 		be_t<u32> lastQueuedBufferId; // 0x14 todo: this is definately not this variable but its 'unused' so im using it for queueId to pass to flip handler
@@ -30,7 +30,7 @@ struct RsxDriverInfo
 		be_t<u32> unk6;            // 0x18 possible low bits of time stamp?  used in getlastVBlankTime
 		be_t<u64> lastSecondVTime; // 0x20 last time for second vhandler freq
 		be_t<u64> unk4;            // 0x28
-		be_t<u64> vBlankCount;     // 0x30
+		atomic_be_t<u64> vBlankCount;     // 0x30
 		be_t<u32> unk;             // 0x38 possible u32, 'flip field', top/bottom for interlaced
 		be_t<u32> unk5;            // 0x3C possible high bits of time stamp? used in getlastVBlankTime
 	} head[8]; // size = 0x40, 0x200
@@ -114,6 +114,9 @@ struct lv2_rsx_config
 	u32 context_base{};
 	u32 device_addr{};
 	u32 driver_info{};
+	u32 dma_address{};
+
+	void send_event(u64, u64, u64) const;
 };
 
 // SysCalls

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -431,7 +431,7 @@ namespace rsx
 					if (performance_counters.state == FIFO_state::running)
 					{
 						performance_counters.FIFO_idle_timestamp = get_system_time();
-						sync_point_request = true;
+						sync_point_request.release(true);
 					}
 
 					performance_counters.state = FIFO_state::spinning;
@@ -450,7 +450,7 @@ namespace rsx
 					if (performance_counters.state == FIFO_state::running)
 					{
 						performance_counters.FIFO_idle_timestamp = get_system_time();
-						sync_point_request = true;
+						sync_point_request.release(true);
 					}
 
 					performance_counters.state = FIFO_state::spinning;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -615,7 +615,7 @@ namespace rsx
 			{
 				restore_point = ctrl->get;
 				saved_fifo_ret = fifo_ret_addr;
-				sync_point_request = false;
+				sync_point_request.release(false);
 			}
 
 			// Execute backend-local tasks first
@@ -2425,7 +2425,7 @@ namespace rsx
 					{
 						// Each 64 entries are grouped by a bit
 						const u64 io_event = 0x100000000ull << i;
-						sys_event_port_send(g_fxo->get<lv2_rsx_config>()->rsx_event_port, 0, io_event, to_unmap);
+						g_fxo->get<lv2_rsx_config>()->send_event(0, io_event, to_unmap);
 					}
 				}
 			}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2424,7 +2424,7 @@ namespace rsx
 					if (u64 to_unmap = unmap_status[i])
 					{
 						// Each 64 entries are grouped by a bit
-						const u64 io_event = 0x100000000ull << i;
+						const u64 io_event = SYS_RSX_EVENT_UNMAPPED_BASE << i;
 						g_fxo->get<lv2_rsx_config>()->send_event(0, io_event, to_unmap);
 					}
 				}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -725,7 +725,7 @@ namespace rsx
 		bool capture_current_frame = false;
 
 	public:
-		bool sync_point_request = false;
+		atomic_t<bool> sync_point_request = false;
 		bool in_begin_end = false;
 
 		struct desync_fifo_cmd_info

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -50,7 +50,7 @@ namespace rsx
 
 		void semaphore_acquire(thread* rsx, u32 /*_reg*/, u32 arg)
 		{
-			rsx->sync_point_request = true;
+			rsx->sync_point_request.release(true);
 			const u32 addr = get_address(method_registers.semaphore_offset_406e(), method_registers.semaphore_context_dma_406e(), HERE);
 
 			const auto& sema = vm::_ref<atomic_be_t<u32>>(addr);
@@ -132,7 +132,7 @@ namespace rsx
 			if (const bool is_flip_sema = (offset == 0x10 && ctxt == CELL_GCM_CONTEXT_DMA_SEMAPHORE_R);
 				!is_flip_sema)
 			{
-				rsx->sync_point_request = true;
+				rsx->sync_point_request.release(true);
 			}
 
 			const u32 addr = get_address(offset, ctxt, HERE);


### PR DESCRIPTION
* Write FIFO get+put atomically in FIFO start command.
* Reset and set flip flip flags atomically, the gcm methods neither use a lock so it's a expected that sys_rsx will handle synchronization.
* Always wait for sys_rsx events to be sent, EBUSY is not a success error code! (EBUSY means the event queue is full by the time of sending the event)
* Optimize vblank events by squashing it into one event instead of two.
* Send events only if they are masked by gcm.