### PR TITLE
sys_ppu_thread_create: read function descriptor immediately and save it

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_ppu_thread_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_ppu_thread_.cpp
@@ -137,7 +137,7 @@ error_code sys_ppu_thread_create(ppu_thread& ppu, vm::ptr<u64> thread_id, u32 en
 	}
 
 	// Call the syscall
-	if (error_code res = _sys_ppu_thread_create(thread_id, vm::make_var(ppu_thread_param_t{ entry, tls_addr + 0x7030 }), arg, 0, prio, stacksize, flags, threadname))
+	if (error_code res = _sys_ppu_thread_create(thread_id, vm::make_var(ppu_thread_param_t{ vm::cast(entry), tls_addr + 0x7030 }), arg, 0, prio, stacksize, flags, threadname))
 	{
 		return res;
 	}

--- a/rpcs3/Emu/Cell/PPUCallback.h
+++ b/rpcs3/Emu/Cell/PPUCallback.h
@@ -2,6 +2,8 @@
 
 #include "Emu/Cell/PPUThread.h"
 
+struct ppu_func_opd_t;
+
 namespace ppu_cb_detail
 {
 	enum _func_arg_type
@@ -179,11 +181,17 @@ namespace vm
 	template<typename AT, typename RT, typename... T>
 	FORCE_INLINE RT _ptr_base<RT(T...), AT>::operator()(ppu_thread& CPU, T... args) const
 	{
-		const auto data = vm::_ptr<u32>(vm::cast(m_addr, HERE));
-		const u32 pc = data[0];
-		const u32 rtoc = data[1];
+		const auto data = vm::_ptr<ppu_func_opd_t>(vm::cast(m_addr, HERE));
+		const u32 pc = data->addr;
+		const u32 rtoc = data->rtoc;
 
 		return ppu_cb_detail::_func_caller<RT, T...>::call(CPU, pc, rtoc, args...);
+	}
+
+	template<typename AT, typename RT, typename... T>
+	FORCE_INLINE const ppu_func_opd_t& _ptr_base<RT(T...), AT>::opd() const
+	{
+		return vm::_ref<ppu_func_opd_t>(vm::cast(m_addr, HERE));
 	}
 }
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -602,6 +602,12 @@ void ppu_thread::cpu_task()
 			cmd_pop(), ppu_function_manager::get().at(arg)(*this);
 			break;
 		}
+		case ppu_cmd::opd_call:
+		{
+			const ppu_func_opd_t opd = cmd_get(1).as<ppu_func_opd_t>(); 
+			cmd_pop(1), fast_call(opd.addr, opd.rtoc);
+			break;
+		}
 		case ppu_cmd::ptr_call:
 		{
 			const ppu_function_t func = cmd_get(1).as<ppu_function_t>();
@@ -747,6 +753,7 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 	, stack_size(param.stack_size)
 	, stack_addr(param.stack_addr)
 	, joiner(detached != 0 ? ppu_join_status::detached : ppu_join_status::joinable)
+	, entry_func(param.entry)
 	, start_time(get_guest_system_time())
 	, ppu_tname(stx::shared_cptr<std::string>::make(name))
 {
@@ -760,13 +767,8 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 		cmd_list
 		({
 		    {ppu_cmd::set_args, 2}, param.arg0, param.arg1,
-		    {ppu_cmd::lle_call, param.entry},
+		    {ppu_cmd::opd_call, 0}, std::bit_cast<u64>(entry_func),
 		});
-	}
-	else
-	{
-		// Save entry for further use (interrupt handler workaround)
-		gpr[2] = param.entry;
 	}
 
 	// Trigger the scheduler

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1001,9 +1001,9 @@ std::string spu_thread::dump_regs() const
 	fmt::append(ret, "Event Mask: 0x%x\n", +ch_event_mask);
 
 	if (const u32 addr = raddr)
-		fmt::append(ret, "Resrvation Addr: 0x%x\n", addr);
+		fmt::append(ret, "Reservation Addr: 0x%x\n", addr);
 	else
-		fmt::append(ret, "Resrvation Addr: none\n");
+		fmt::append(ret, "Reservation Addr: none\n");
 
 	fmt::append(ret, "Interrupts Enabled: %s\n", interrupts_enabled.load());
 	fmt::append(ret, "Inbound Mailbox: %s\n", ch_in_mbox);

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -15,7 +15,7 @@ void lv2_int_serv::exec()
 	({
 		{ ppu_cmd::reset_stack, 0 },
 		{ ppu_cmd::set_args, 2 }, arg1, arg2,
-		{ ppu_cmd::lle_call, 2 },
+		{ ppu_cmd::opd_call, 0 }, std::bit_cast<u64>(thread->entry_func),
 		{ ppu_cmd::sleep, 0 }
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -5,6 +5,7 @@
 
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
+#include "Emu/Cell/PPUCallback.h"
 #include "sys_event.h"
 #include "sys_process.h"
 #include "sys_mmapper.h"
@@ -362,6 +363,8 @@ error_code _sys_ppu_thread_create(vm::ptr<u64> thread_id, vm::ptr<ppu_thread_par
 		return CELL_EPERM;
 	}
 
+	const ppu_func_opd_t entry = param->entry.opd();
+
 	// Clean some detached thread (hack)
 	g_fxo->get<ppu_thread_cleaner>()->clean(0);
 
@@ -408,7 +411,7 @@ error_code _sys_ppu_thread_create(vm::ptr<u64> thread_id, vm::ptr<ppu_thread_par
 		p.stack_addr = stack_base;
 		p.stack_size = stack_size;
 		p.tls_addr = param->tls;
-		p.entry = param->entry;
+		p.entry = entry;
 		p.arg0 = arg;
 		p.arg1 = unk;
 
@@ -423,7 +426,7 @@ error_code _sys_ppu_thread_create(vm::ptr<u64> thread_id, vm::ptr<ppu_thread_par
 	}
 
 	*thread_id = tid;
-	sys_ppu_thread.warning(u8"_sys_ppu_thread_create(): Thread “%s” created (id=0x%x)", ppu_name, tid);
+	sys_ppu_thread.warning(u8"_sys_ppu_thread_create(): Thread “%s” created (id=0x%x, func=*0x%x, rtoc=0x%x)", ppu_name, tid, entry.addr, entry.rtoc);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.h
@@ -26,7 +26,7 @@ struct sys_ppu_thread_stack_t
 
 struct ppu_thread_param_t
 {
-	be_t<u32> entry; // vm::bptr<void(u64)>
+	vm::bptr<void(u64)> entry;
 	be_t<u32> tls; // vm::bptr<void>
 };
 

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -5,6 +5,7 @@
 #include "vm.h"
 
 class ppu_thread;
+struct ppu_func_opd_t;
 
 namespace vm
 {
@@ -262,6 +263,7 @@ namespace vm
 
 		// Callback; defined in PPUCallback.h, passing context is mandatory
 		RT operator()(ppu_thread& ppu, T... args) const;
+		const ppu_func_opd_t& opd() const;
 	};
 
 	template<typename AT, typename RT, typename... T>


### PR DESCRIPTION
Function descriptor should be read immediatly in _sys_ppu_thread_create by the calling thread, in interrupt thread it occurs every interrupt is being sent and in other ppu thread types its being done asynchronously by the created thread which both are wrong.
In theory it protects against cases where the function descriptor is being overwritten after the creating thread syscall ended but shouldn't happen in reality in games iirc, so it's just an accuracy improvement. 

Also log ppu thread start entry, example: `_sys_ppu_thread_create(): Thread “LIBDG_dummyflip” created (id=0x1000011, func=*0xf8cdc, rtoc=0x3df5e8)`