### PR TITLE
Tweak TSC calibration

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -3278,7 +3278,7 @@ void fmt_class_string<spu_channel>::format(std::string& out, u64 arg)
 	}
 	else
 	{
-		out += "empty"; 
+		out += "empty";
 	}
 }
 


### PR DESCRIPTION
I realized that the calibration was more accurate than I initially thought, and the TSC frequency rarely equals CPU frequency.