### PR TITLE
Show state of Accurate LLVM DFMA option in GUI for CPUs that support FMA

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -931,15 +931,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->debugConsoleMode, emu_settings_type::DebugConsoleMode);
 	SubscribeTooltip(ui->debugConsoleMode, tooltips.settings.debug_console_mode);
 
-	if (utils::has_fma3() || utils::has_fma4()) 
-	{
-		ui->accurateLLVMdfma->setDisabled(true);
-	}
-	else 
-	{
-		m_emu_settings->EnhanceCheckBox(ui->accurateLLVMdfma, emu_settings_type::AccurateLLVMdfma);
-		SubscribeTooltip(ui->accurateLLVMdfma, tooltips.settings.accurate_llvm_dfma);
-	}
+	m_emu_settings->EnhanceCheckBox(ui->accurateLLVMdfma, emu_settings_type::AccurateLLVMdfma);
+	SubscribeTooltip(ui->accurateLLVMdfma, tooltips.settings.accurate_llvm_dfma);
+	ui->accurateLLVMdfma->setDisabled(utils::has_fma3() || utils::has_fma4());
 
 	m_emu_settings->EnhanceCheckBox(ui->silenceAllLogs, emu_settings_type::SilenceAllLogs);
 	SubscribeTooltip(ui->silenceAllLogs, tooltips.settings.silence_all_logs);

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -78,7 +78,7 @@ public:
 		const QString set_daz_and_ftz              = tr("Never use this.");
 		const QString accurate_getllar             = tr("Never use this.");
 		const QString accurate_putlluc             = tr("Never use this.");
-		const QString accurate_llvm_dfma           = tr("Improves extra accuracy on FMA instructions' at the cost of performance.\nWhile disabling it might give a decent performance boost, it may also introduce subtle bugs that otherwise do not occur.");
+		const QString accurate_llvm_dfma           = tr("Provides extra accuracy on FMA instructions at the cost of performance.\nWhile disabling it might give a decent performance boost if your CPU doesn't support FMA, it may also introduce subtle bugs that otherwise do not occur.\nYou can't disable it if your CPU supports FMA.");
 		const QString accurate_rsx_access          = tr("Never use this.");
 		const QString hook_static_functions        = tr("Allows to hook some functions like 'memcpy' replacing them with high-level implementations. May do nothing or break things. Experimental.");
 		const QString gl_legacy_buffers            = tr("Enables use of classic OpenGL buffers which allows capturing tools to work with RPCS3 e.g RenderDoc.\nIf unsure, don't use this option.");


### PR DESCRIPTION
Follow-up to #7981

If you had a CPU with FMA support, the option was greyed out and it was showed as unchecked. This PR aims to fix that. It also tweaks the tooltip for the option a bit to reflect that you can't disable it if your CPU has FMA support, and simplifies the code.

Master:
![Before](https://user-images.githubusercontent.com/16805474/78948688-92d45880-7a9f-11ea-9524-8b913e996492.png)

This PR:
![After](https://user-images.githubusercontent.com/16805474/78948711-a7185580-7a9f-11ea-9058-5389823eab48.png)


Waiting for my `Amazing Contribution` label, tyvm