### PR TITLE
sys_rsx: Implement cellGcmSysGetLastVBlankTime, add some error checks

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -266,7 +266,7 @@ error_code cellGcmBindTile(u8 index)
 		return CELL_GCM_ERROR_INVALID_VALUE;
 	}
 
-	rsx::get_current_renderer()->tiles[index].binded = true;
+	rsx::get_current_renderer()->tiles[index].bound = true;
 
 	return CELL_OK;
 }
@@ -281,7 +281,7 @@ error_code cellGcmBindZcull(u8 index, u32 offset, u32 width, u32 height, u32 cul
 		return CELL_GCM_ERROR_INVALID_VALUE;
 	}
 
-	rsx::get_current_renderer()->zculls[index].binded = true;
+	rsx::get_current_renderer()->zculls[index].bound = true;
 
 	return CELL_OK;
 }
@@ -701,7 +701,7 @@ void cellGcmSetZcull(u8 index, u32 offset, u32 width, u32 height, u32 cullStart,
 	zcull.sFunc = sFunc;
 	zcull.sRef = sRef;
 	zcull.sMask = sMask;
-	zcull.binded = (zCullFormat > 0);
+	zcull.bound = (zCullFormat > 0);
 
 	vm::_ptr<CellGcmZcullInfo>(gcm_cfg->zculls_addr)[index] = zcull.pack();
 }
@@ -715,7 +715,7 @@ error_code cellGcmUnbindTile(u8 index)
 		return CELL_GCM_ERROR_INVALID_VALUE;
 	}
 
-	rsx::get_current_renderer()->tiles[index].binded = false;
+	rsx::get_current_renderer()->tiles[index].bound = false;
 
 	return CELL_OK;
 }
@@ -729,7 +729,7 @@ error_code cellGcmUnbindZcull(u8 index)
 		return CELL_GCM_ERROR_INVALID_VALUE;
 	}
 
-	rsx::get_current_renderer()->zculls[index].binded = false;
+	rsx::get_current_renderer()->zculls[index].bound = false;
 
 	return CELL_OK;
 }
@@ -1301,7 +1301,7 @@ error_code cellGcmSetTile(u8 index, u8 location, u32 offset, u32 size, u32 pitch
 	tile.comp = comp;
 	tile.base = base;
 	tile.bank = bank;
-	tile.binded = (pitch > 0);
+	tile.bound = (pitch > 0);
 
 	vm::_ptr<CellGcmTileInfo>(gcm_cfg->tiles_addr)[index] = tile.pack();
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -309,6 +309,11 @@ error_code sys_rsx_context_iomap(u32 context_id, u32 io, u32 ea, u32 size, u64 f
 		return CELL_EINVAL;
 	}
 
+	if (!render->is_fifo_idle())
+	{
+		sys_rsx.warning("sys_rsx_context_iomap(): RSX is not idle while mapping io");
+	}
+
 	vm::reader_lock rlock;
 
 	for (u32 addr = ea, end = ea + size; addr < end; addr += 0x100000)
@@ -353,6 +358,11 @@ error_code sys_rsx_context_iounmap(u32 context_id, u32 io, u32 size)
 			render->main_mem_size < io + u64{size})
 	{
 		return CELL_EINVAL;
+	}
+
+	if (!render->is_fifo_idle())
+	{
+		sys_rsx.warning("sys_rsx_context_iounmap(): RSX is not idle while unmapping io");
 	}
 
 	vm::reader_lock rlock;
@@ -549,6 +559,11 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 
 		verify(HERE), a3 < std::size(render->tiles);
 
+		if (!render->is_fifo_idle())
+		{
+			sys_rsx.warning("sys_rsx_context_attribute(): RSX is not idle while setting tile");
+		}
+
 		auto& tile = render->tiles[a3];
 
 		const u32 location = ((a4 >> 32) & 0x3) - 1;
@@ -628,6 +643,11 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		//a6 low = status1 = (0x2000 << 0) | (0x20 << 16);
 
 		verify(HERE), a3 < std::size(render->zculls);
+
+		if (!render->is_fifo_idle())
+		{
+			sys_rsx.warning("sys_rsx_context_attribute(): RSX is not idle while setting zcull");
+		}
 
 		const u32 offset = (a5 & 0xFFFFFFFF);
 		const bool binded = (a6 & 0xFFFFFFFF) != 0;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -260,6 +260,7 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 	render->current_display_buffer = 0;
 	render->label_addr = vm::cast(*lpar_reports, HERE);
 	render->device_addr = rsx_cfg->device_addr;
+	render->dma_address = rsx_cfg->dma_address;
 	render->local_mem_size = rsx_cfg->memory_size;
 	render->init(vm::cast(*lpar_dma_control, HERE));
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -573,11 +573,11 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		const u32 comp = ((a5 & 0xFFFFFFFF) >> 26) & 0xF;
 		const u32 base = (a5 & 0xFFFFFFFF) & 0x7FF;
 		const u32 bank = (((a4 >> 32) & 0xFFFFFFFF) >> 4) & 0xF;
-		const bool binded = ((a4 >> 32) & 0x3) != 0;
+		const bool bound = ((a4 >> 32) & 0x3) != 0;
 
 		const auto range = utils::address_range::start_length(offset, size);
 
-		if (binded)
+		if (bound)
 		{
 			if (!size || !pitch)
 			{
@@ -604,12 +604,12 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 
 		std::lock_guard lock(s_rsxmem_mtx);
 
-		// When tile is going to be unbinded, we can use it as a hint that the address will no longer be used as a surface and can be removed/invalidated
+		// When tile is going to be unbound, we can use it as a hint that the address will no longer be used as a surface and can be removed/invalidated
 		// Todo: There may be more checks such as format/size/width can could be done
-		if (tile.binded && !binded)
+		if (tile.bound && !bound)
 			render->notify_tile_unbound(static_cast<u32>(a3));
 
-		if (location == CELL_GCM_LOCATION_MAIN && binded)
+		if (location == CELL_GCM_LOCATION_MAIN && bound)
 		{
 			vm::reader_lock rlock;
 
@@ -629,7 +629,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		tile.comp = comp;
 		tile.base = base;
 		tile.bank = base;
-		tile.binded = binded;
+		tile.bound = bound;
 	}
 	break;
 
@@ -650,9 +650,9 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		}
 
 		const u32 offset = (a5 & 0xFFFFFFFF);
-		const bool binded = (a6 & 0xFFFFFFFF) != 0;
+		const bool bound = (a6 & 0xFFFFFFFF) != 0;
 
-		if (binded)
+		if (bound)
 		{
 			if (offset >= render->local_mem_size)
 			{
@@ -678,7 +678,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		zcull.sFunc = ((a6 >> 32) >> 12) & 0xF;
 		zcull.sRef = ((a6 >> 32) >> 16) & 0xFF;
 		zcull.sMask = ((a6 >> 32) >> 24) & 0xFF;
-		zcull.binded = binded;
+		zcull.bound = bound;
 	}
 	break;
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -625,8 +625,16 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 
 		// todo: this is wrong and should be 'second' vblank handler and freq, but since currently everything is reported as being 59.94, this should be fine
 		vm::_ref<u32>(render->device_addr + 0x30) = 1;
+
+		const u64 current_time = rsxTimeStamp();
+
+		driverInfo.head[a3].lastSecondVTime = current_time;
+
+		// Note: not atomic
+		driverInfo.head[a3].lastVTimeLow = static_cast<u32>(current_time);
+		driverInfo.head[a3].lastVTimeHigh = static_cast<u32>(current_time >> 32);
+
 		driverInfo.head[a3].vBlankCount++;
-		driverInfo.head[a3].lastSecondVTime = rsxTimeStamp();
 
 		u64 event_flags = SYS_RSX_EVENT_VBLANK;
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -74,7 +74,7 @@ void lv2_rsx_config::send_event(u64 data1, u64 event_flags, u64 data3) const
 		// Wait a bit before resending event
 		thread_ctrl::wait_for(100);
 
-		if (cpu && cpu->check_state())
+		if (Emu.IsStopped() || (cpu && cpu->check_state()))
 		{
 			error = 0;
 			break;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -117,6 +117,11 @@ struct RsxDisplayInfo
 	be_t<u32> pitch;
 	be_t<u32> width;
 	be_t<u32> height;
+
+	bool valid() const
+	{
+		return height != 0u && width != 0u;
+	}
 };
 
 struct lv2_rsx_config

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -27,12 +27,12 @@ struct RsxDriverInfo
 		be_t<u32> flipBufferId;    // 0x10
 		be_t<u32> lastQueuedBufferId; // 0x14 todo: this is definately not this variable but its 'unused' so im using it for queueId to pass to flip handler
 		be_t<u32> unk3;            // 0x18
-		be_t<u32> unk6;            // 0x18 possible low bits of time stamp?  used in getlastVBlankTime
+		be_t<u32> lastVTimeLow;    // 0x1C last time for first vhandler freq (low 32-bits)
 		be_t<u64> lastSecondVTime; // 0x20 last time for second vhandler freq
 		be_t<u64> unk4;            // 0x28
-		atomic_be_t<u64> vBlankCount;     // 0x30
+		atomic_be_t<u64> vBlankCount; // 0x30
 		be_t<u32> unk;             // 0x38 possible u32, 'flip field', top/bottom for interlaced
-		be_t<u32> unk5;            // 0x3C possible high bits of time stamp? used in getlastVBlankTime
+		be_t<u32> lastVTimeHigh;   // 0x3C last time for first vhandler freq (high 32-bits)
 	} head[8]; // size = 0x40, 0x200
 
 	be_t<u32> unk7;          // 0x12B8

--- a/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_capture.cpp
@@ -371,8 +371,8 @@ namespace rsx
 				auto& tstate = tilestate.tiles[i];
 				tstate.tile = tile.tile;
 				tstate.limit = tile.limit;
-				tstate.pitch = rsx->tiles[i].binded ? u32{tile.pitch} : 0;
-				tstate.format = rsx->tiles[i].binded ? u32{tile.format} : 0;
+				tstate.pitch = rsx->tiles[i].bound ? u32{tile.pitch} : 0;
+				tstate.format = rsx->tiles[i].bound ? u32{tile.format} : 0;
 			}
 
 			for (u32 i = 0; i < limits::zculls_count; ++i)
@@ -383,8 +383,8 @@ namespace rsx
 				zcstate.size = zc.size;
 				zcstate.start = zc.start;
 				zcstate.offset = zc.offset;
-				zcstate.status0 = rsx->zculls[i].binded ? u32{zc.status0} : 0;
-				zcstate.status1 = rsx->zculls[i].binded ? u32{zc.status1} : 0;
+				zcstate.status0 = rsx->zculls[i].bound ? u32{zc.status0} : 0;
+				zcstate.status1 = rsx->zculls[i].bound ? u32{zc.status1} : 0;
 			}
 
 			const u64 tsnum = XXH64(&tilestate, sizeof(frame_capture_data::tile_state), 0);

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -200,7 +200,7 @@ namespace rsx
 					continue;
 
 				// wait until rsx idle and at our first 'stop' to apply state
-				while (!Emu.IsStopped() && (render->ctrl->get != render->ctrl->put) && (render->ctrl->get != fifo_stops[stopIdx]))
+				while (!Emu.IsStopped() && !render->is_fifo_idle() && (render->ctrl->get != fifo_stops[stopIdx]))
 				{
 					while (Emu.IsPaused())
 						std::this_thread::sleep_for(10ms);
@@ -222,7 +222,7 @@ namespace rsx
 			u32 end = fifo_stops.back();
 			render->ctrl->put = end;
 
-			while (render->ctrl->get != end && !Emu.IsStopped())
+			while (!render->is_fifo_idle() && !Emu.IsStopped())
 			{
 				while (Emu.IsPaused())
 					std::this_thread::sleep_for(10ms);

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -189,13 +189,21 @@ namespace rsx
 				for (u32 i = 0; i < renderer->display_buffers_count; ++i)
 				{
 					const auto& buffer = renderer->display_buffers[i];
-					const u32 pitch = buffer.pitch? static_cast<u32>(buffer.pitch) : g_fxo->get<rsx::avconf>()->get_bpp() * buffer.width;
+
+					if (!buffer.valid())
+					{
+						continue;
+					}
+
+					const u32 bpp = g_fxo->get<rsx::avconf>()->get_bpp();
+
+					const u32 pitch = buffer.pitch ? +buffer.pitch : bpp * buffer.width;
 					if (pitch != dst_pitch)
 					{
 						continue;
 					}
 
-					const auto buffer_range = address_range::start_length(rsx::constants::local_mem_base + buffer.offset, pitch * buffer.height);
+					const auto buffer_range = address_range::start_length(rsx::get_address(buffer.offset, CELL_GCM_LOCATION_LOCAL, HERE), pitch * (buffer.height - 1) + (buffer.width * bpp));
 					if (dst_range.inside(buffer_range))
 					{
 						// Match found

--- a/rpcs3/Emu/RSX/GCM.h
+++ b/rpcs3/Emu/RSX/GCM.h
@@ -111,7 +111,7 @@ struct GcmZcullInfo
 	u32 sFunc;
 	u32 sRef;
 	u32 sMask;
-	bool binded = false;
+	bool bound = false;
 
 	CellGcmZcullInfo pack() const
 	{
@@ -137,7 +137,7 @@ struct GcmTileInfo
 	u32 comp;
 	u32 base;
 	u32 bank;
-	bool binded = false;
+	bool bound = false;
 
 	CellGcmTileInfo pack() const
 	{

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -291,7 +291,7 @@ namespace gl
 		glReadPixels(coord.x, coord.y, coord.width, coord.height, static_cast<GLenum>(format_), static_cast<GLenum>(type_), nullptr);
 	}
 
-	fbo fbo::get_binded_draw_buffer()
+	fbo fbo::get_bound_draw_buffer()
 	{
 		GLint value;
 		glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &value);
@@ -299,7 +299,7 @@ namespace gl
 		return{ static_cast<GLuint>(value) };
 	}
 
-	fbo fbo::get_binded_read_buffer()
+	fbo fbo::get_bound_read_buffer()
 	{
 		GLint value;
 		glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &value);
@@ -307,7 +307,7 @@ namespace gl
 		return{ static_cast<GLuint>(value) };
 	}
 
-	fbo fbo::get_binded_buffer()
+	fbo fbo::get_bound_buffer()
 	{
 		GLint value;
 		glGetIntegerv(GL_FRAMEBUFFER_BINDING, &value);

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -2382,9 +2382,9 @@ public:
 		void copy_to(void* pixels, coordi coord, gl::texture::format format_, gl::texture::type type_, class pixel_pack_settings pixel_settings = pixel_pack_settings()) const;
 		void copy_to(const buffer& buf, coordi coord, gl::texture::format format_, gl::texture::type type_, class pixel_pack_settings pixel_settings = pixel_pack_settings()) const;
 
-		static fbo get_binded_draw_buffer();
-		static fbo get_binded_read_buffer();
-		static fbo get_binded_buffer();
+		static fbo get_bound_draw_buffer();
+		static fbo get_bound_read_buffer();
+		static fbo get_bound_buffer();
 
 		GLuint id() const;
 		void set_id(GLuint id);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2262,6 +2262,11 @@ namespace rsx
 		zcull_ctrl->on_sync_hint(args);
 	}
 
+	bool thread::is_fifo_idle() const
+	{
+		return ctrl->get == (ctrl->put & ~3);
+	}
+
 	void thread::flush_fifo()
 	{
 		// Make sure GET value is exposed before sync points

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1771,7 +1771,7 @@ namespace rsx
 	{
 		for (GcmTileInfo &tile : tiles)
 		{
-			if (!tile.binded || (tile.location & 1) != (location & 1))
+			if (!tile.bound || (tile.location & 1) != (location & 1))
 			{
 				continue;
 			}
@@ -2136,7 +2136,7 @@ namespace rsx
 				//Find zeta address in bound zculls
 				for (const auto& zcull : zculls)
 				{
-					if (zcull.binded)
+					if (zcull.bound)
 					{
 						const u32 rsx_address = rsx::get_address(zcull.offset, CELL_GCM_LOCATION_LOCAL, HERE);
 						if (rsx_address == zeta_address)

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -622,6 +622,7 @@ namespace rsx
 		u32 restore_point = 0;
 		atomic_t<u32> external_interrupt_lock{ 0 };
 		atomic_t<bool> external_interrupt_ack{ false };
+		bool is_fifo_idle() const;
 		void flush_fifo();
 		void recover_fifo();
 		static void fifo_wake_delay(u64 div = 1);

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -618,6 +618,7 @@ namespace rsx
 
 	public:
 		RsxDmaControl* ctrl = nullptr;
+		u32 dma_address{0};
 		rsx_iomap_table iomap_table;
 		u32 restore_point = 0;
 		atomic_t<u32> external_interrupt_lock{ 0 };

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -45,7 +45,9 @@ namespace rsx
 		void set_reference(thread* rsx, u32 _reg, u32 arg)
 		{
 			rsx->sync();
-			rsx->ctrl->ref.exchange(arg);
+
+			// Write ref+get atomically (get will be written again with the same value at command end)
+			vm::_ref<atomic_be_t<u64>>(rsx->dma_address + ::offset32(&RsxDmaControl::get)).store(u64{rsx->fifo_ctrl->get_pos()} << 32 | arg);
 		}
 
 		void semaphore_acquire(thread* rsx, u32 /*_reg*/, u32 arg)


### PR DESCRIPTION
* Implement LLE cellGcmSysGetLastVBlankTime.
* Check zcull/tiles offset if bigger than memory limits of MAIN/LOCAL memory.
* Check memory mapping of offset if location is MAIN.
* Check pitch/size for 0 as coming from hw tests.
* In addition: fix 'bound' check of tiles, seem to rely on the bits location is in. (0 means not bound, anything else is bound)
* Add locks for zcull/tiles/displaybuffer binding.
* Fix vblank thread stop regression from #7978, add missing emulation state check in EBUSY wait loop.
* Fix get_optimal_blit_target_properties for local memory.
* Write FIFO ref+get atomically.
* Warn if RSX is not idle during crucial points.