### PR TITLE
Implement ::as_rvalue

### DIFF
--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -167,6 +167,24 @@ using get_uint_t = typename get_int_impl<N>::utype;
 template <std::size_t N>
 using get_sint_t = typename get_int_impl<N>::stype;
 
+template <typename T>
+T as_rvalue(T&& obj)
+{
+	return obj;
+}
+
+template <typename T>
+T as_rvalue(const T& obj)
+{
+	return obj;
+}
+
+template <typename T>
+T as_rvalue(const volatile T& obj)
+{
+	return obj;
+}
+
 // Formatting helper, type-specific preprocessing for improving safety and functionality
 template <typename T, typename = void>
 struct fmt_unveil;

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -846,7 +846,7 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 		c->jmp(imm_ptr(spu_runtime::tr_dispatch));
 	}
 
-	for (auto&& work : decltype(after)(std::move(after)))
+	for (auto&& work : ::as_rvalue(std::move(after)))
 	{
 		work();
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -476,7 +476,7 @@ error_code sys_usbd_finalize(ppu_thread& ppu, u32 handle)
 	usbh->is_init = false;
 
 	// Forcefully awake all waiters
-	for (auto& cpu : decltype(usbh->sq)(std::move(usbh->sq)))
+	for (auto& cpu : ::as_rvalue(std::move(usbh->sq)))
 	{
 		// Special ternimation signal value
 		cpu->gpr[4] = 4;

--- a/rpcs3/Emu/IdManager.h
+++ b/rpcs3/Emu/IdManager.h
@@ -574,7 +574,7 @@ public:
 
 			if (const auto found = find_id<T, Get>(id))
 			{
-				ptr = std::static_pointer_cast<Get>(std::move(found->second));
+				ptr = std::static_pointer_cast<Get>(::as_rvalue(std::move(found->second)));
 			}
 		}
 
@@ -594,7 +594,7 @@ public:
 			if constexpr (std::is_void_v<FRT>)
 			{
 				func(*_ptr);
-				return std::static_pointer_cast<Get>(std::move(found->second));
+				return std::static_pointer_cast<Get>(::as_rvalue(std::move(found->second)));
 			}
 			else
 			{
@@ -606,7 +606,7 @@ public:
 					return {{found->second, _ptr}, std::move(ret)};
 				}
 
-				return {std::static_pointer_cast<Get>(std::move(found->second)), std::move(ret)};
+				return {std::static_pointer_cast<Get>(::as_rvalue(std::move(found->second))), std::move(ret)};
 			}
 		}
 


### PR DESCRIPTION
Fixes huge regression from #7998 because std::static_pointer_cast doesnt have rvalue reference overloads yet.