### PR TITLE
CI: Auto update LLVM and GLSLANG when those releases change

### DIFF
--- a/.ci/setup-windows.sh
+++ b/.ci/setup-windows.sh
@@ -17,9 +17,7 @@ QT_WINE_URL="${QT_HOST}${QT_PREFIX}qtwinextras${QT_SUFFIX}"
 QT_DECL_URL="${QT_HOST}${QT_PREFIX}qtdeclarative${QT_SUFFIX}"
 QT_TOOL_URL="${QT_HOST}${QT_PREFIX}qttools${QT_SUFFIX}"
 LLVMLIBS_URL='https://github.com/RPCS3/llvm-mirror/releases/download/custom-build-win/llvmlibs_mt.7z'
-LLVM_SHA="773273312b6bfe0c361b3780e175ab2935f8d10558431420dee2a1414ee965d0"
 GLSLANG_URL='https://github.com/RPCS3/glslang/releases/download/custom-build-win/glslanglibs_mt.7z'
-GLSLANG_SHA="b2f47a20239eddd423257c10258e1c7889a5bb7d66773460e3a87b4dbead7c1d"
 VULKAN_SDK_URL="https://sdk.lunarg.com/sdk/download/${VULKAN_VER}/windows/VulkanSDK-${VULKAN_VER}-Installer.exe"
 
 DEP_URLS="         \
@@ -76,8 +74,8 @@ for url in $DEP_URLS; do
     # shellcheck disable=SC1003
     case "$url" in
     *qt*) checksum=$(curl -L "${url}.sha1"); algo="sha1"; outDir='C:\Qt\' ;;
-    *llvm*) checksum="$LLVM_SHA"; algo="sha256"; outDir="." ;;
-    *glslang*) checksum="$GLSLANG_SHA"; algo=sha256; outDir="./lib/Release - LLVM-x64" ;;
+    *llvm*) checksum=$(curl -L "${url}.sha256"); algo="sha256"; outDir="." ;;
+    *glslang*) checksum=$(curl -L "${url}.sha256"); algo="sha256"; outDir="./lib/Release - LLVM-x64" ;;
     *Vulkan*)
         # Vulkan setup needs to be run in batch environment
         # Need to subshell this or else it doesn't wait


### PR DESCRIPTION
This allows the Continuous Integration System to continuously integrate the latest libs from dependencies.

Relies on https://github.com/RPCS3/glslang/pull/1 being merged.