### PR TITLE
SPU debugger: Implement blocking functions dumping

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1236,7 +1236,7 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, T reg_value)
 	if (result)
 	{
 		res.release(old_time + 128);
-		vm::reservation_notifier(addr, sizeof(u64)).notify_all();
+		vm::reservation_notifier(addr, sizeof(T)).notify_all();
 	}
 	else
 	{

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -619,6 +619,9 @@ public:
 
 	std::array<v128, 0x4000> stack_mirror; // Return address information
 
+	const char* current_func{}; // Current STOP or RDCH blocking function
+	u64 start_time{}; // Starting time of STOP or RDCH bloking function
+
 	void push_snr(u32 number, u32 value);
 	void do_dma_transfer(const spu_mfc_cmd& args);
 	bool do_dma_check(const spu_mfc_cmd& args);
@@ -667,5 +670,18 @@ public:
 		}
 
 		return -1;
+	}
+};
+
+class spu_function_logger
+{
+	spu_thread& spu;
+
+public:
+	spu_function_logger(spu_thread& spu, const char* func);
+
+	~spu_function_logger()
+	{
+		spu.start_time = 0;
 	}
 };


### PR DESCRIPTION
Dump current blocking SPU functions, currently includes two functions: sys_spu_thread_receive_event and MFC events reading.
Also show the amount of time each thread spends on it from the time the function starts until current time.
Allows to detect some SPU deadlocks for example.