### PR TITLE
Add fallthrough attribute

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -851,6 +851,7 @@ error_code cellVdecGetPicture(u32 handle, vm::cptr<CellVdecPicFormat> format, vm
 		{
 		case AV_PIX_FMT_YUVJ420P:
 			cellVdec.error("cellVdecGetPicture(): experimental AVPixelFormat (%d). This may cause suboptimal video quality.", frame->format);
+			[[fallthrough]];
 		case AV_PIX_FMT_YUV420P:
 			in_f = alpha_plane ? AV_PIX_FMT_YUVA420P : static_cast<AVPixelFormat>(frame->format);
 			break;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2130,7 +2130,7 @@ bool spu_thread::process_mfc_cmd()
 			break;
 		}
 
-		// Fallthrough
+		[[fallthrough]];
 	}
 	case MFC_PUT_CMD:
 	case MFC_PUTB_CMD:

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -85,6 +85,7 @@ void FragmentProgramDecompiler::SetDst(std::string code, u32 flags)
 				// NOTE: Sometimes varying inputs from VS are out of range so do not exempt any input types, unless fp16 (Naruto UNS)
 				if (dst.fp16 && src0.fp16 && src0.reg_type == RSX_FP_REGISTER_TYPE_TEMP)
 					break;
+				[[fallthrough]];
 			default:
 			{
 				// fp16 precsion flag on f32 register; ignore
@@ -942,6 +943,7 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 		//Untested, should be x2d followed by TEX
 		AddX2d();
 		AddCode(Format("x2d = $0.xyxy + $1.xxxx * $2.xzxz + $1.yyyy * $2.ywyw;", true));
+		[[fallthrough]];
 	case RSX_FP_OPCODE_TEX:
 		AddTex();
 		switch (m_prog.get_texture_dimension(dst.tex_num))
@@ -974,6 +976,7 @@ bool FragmentProgramDecompiler::handle_tex_srb(u32 opcode)
 		//Untested, should be x2d followed by TXP
 		AddX2d();
 		AddCode(Format("x2d = $0.xyxy + $1.xxxx * $2.xzxz + $1.yyyy * $2.ywyw;", true));
+		[[fallthrough]];
 	case RSX_FP_OPCODE_TXP:
 		AddTex();
 		switch (m_prog.get_texture_dimension(dst.tex_num))

--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.h
@@ -241,7 +241,7 @@ protected:
 	/** insert declaration of shader constants.
 	*/
 	virtual void insertConstants(std::stringstream &OS) = 0;
-	/** insert helper functin definitions.
+	/** insert helper function definitions.
 	*/
 	virtual void insertGlobalFunctions(std::stringstream &OS) = 0;
 	/** insert beginning of main (signature, temporary declaration...)

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -104,12 +104,12 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 			{
 				d0.HEX = instruction._u32[0];
 				static_jump = (d0.cond == 0x7);
-				// Fall through
+				[[fallthrough]];
 			}
 			case RSX_SCA_OPCODE_BRB:
 			{
 				function_call = false;
-				// Fall through
+				[[fallthrough]];
 			}
 			case RSX_SCA_OPCODE_CAL:
 			case RSX_SCA_OPCODE_CLI:

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -430,7 +430,7 @@ u32 get_row_pitch_in_block(u16 block_size_in_bytes, u16 width_in_block, size_t a
 }
 
 /**
- * Since rsx ignore unused dimensionnality some app set them to 0.
+ * Since rsx ignore unused dimensionality some app set them to 0.
  * Use 1 value instead to be more general.
  */
 template<typename RsxTextureType>

--- a/rpcs3/Emu/RSX/Common/ring_buffer_helper.h
+++ b/rpcs3/Emu/RSX/Common/ring_buffer_helper.h
@@ -4,7 +4,7 @@
 
 /**
  * Ring buffer memory helper :
- * There are 2 "pointers" (offset inside a memory buffer to be provided by class derrivative)
+ * There are 2 "pointers" (offset inside a memory buffer to be provided by class derivative)
  * PUT pointer "points" to the start of allocatable space.
  * GET pointer "points" to the start of memory in use by the GPU.
  * Space between GET and PUT is used by the GPU ; this structure check that this memory is not overwritten.

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1821,7 +1821,7 @@ namespace rsx
 				case rsx::texture_upload_context::shader_read:
 					if (!result.image_handle)
 						break;
-					// Conditional fallthrough
+					[[fallthrough]];
 				default:
 					return result;
 				}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2559,7 +2559,7 @@ namespace rsx
 			{
 				verify(HERE), !dest_texture;
 
-				// Need to calculate the minium required size that will fit the data, anchored on the rsx_address
+				// Need to calculate the minimum required size that will fit the data, anchored on the rsx_address
 				// If the application starts off with an 'inseted' section, the guessed dimensions may not fit!
 				const u32 write_end = dst_address + dst_payload_length;
 				u32 block_end = dst_base_address + (dst.pitch * dst_dimensions.height);

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -43,12 +43,14 @@ namespace gl
 			// Note : maybe add is signed on gl
 		case rsx::blend_equation::add_signed:
 			rsx_log.trace("blend equation add_signed used. Emulating using FUNC_ADD");
+			[[fallthrough]];
 		case rsx::blend_equation::add: return GL_FUNC_ADD;
 		case rsx::blend_equation::min: return GL_MIN;
 		case rsx::blend_equation::max: return GL_MAX;
 		case rsx::blend_equation::substract: return GL_FUNC_SUBTRACT;
 		case rsx::blend_equation::reverse_substract_signed:
 			rsx_log.trace("blend equation reverse_subtract_signed used. Emulating using FUNC_REVERSE_SUBTRACT");
+			[[fallthrough]];
 		case rsx::blend_equation::reverse_substract: return GL_FUNC_REVERSE_SUBTRACT;
 		case rsx::blend_equation::reverse_add_signed:
 		default:

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -508,7 +508,7 @@ void GLGSRender::clear_surface(u32 arg)
 			{
 				verify(HERE), mask;
 
-				// Only one aspect was cleared. Make sure to memory intialize the other before removing dirty flag
+				// Only one aspect was cleared. Make sure to memory initialize the other before removing dirty flag
 				if (arg == 1)
 				{
 					// Depth was cleared, initialize stencil

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -549,7 +549,7 @@ void GLGSRender::clear_surface(u32 arg)
 		case rsx::surface_color_format::g8b8:
 		{
 			colormask = rsx::get_g8b8_r8g8_colormask(colormask);
-			// Fall through
+			[[fallthrough]];
 		}
 		default:
 		{

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -366,6 +366,7 @@ namespace gl
 						{
 						default:
 							rsx_log.error("gl::fence sync returned unknown error 0x%X", err);
+							[[fallthrough]];
 						case GL_ALREADY_SIGNALED:
 						case GL_CONDITION_SATISFIED:
 							done = true;

--- a/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
+++ b/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
@@ -44,7 +44,7 @@ struct GLTraits
 			.bind_fragment_data_location("ocol3", 3)
 			.link();
 
-		// Progam locations are guaranteed to not change after linking
+		// Program locations are guaranteed to not change after linking
 		// Texture locations are simply bound to the TIUs so this can be done once
 		for (int i = 0; i < rsx::limits::fragment_textures_count; ++i)
 		{

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -586,6 +586,7 @@ namespace gl
 			{
 			default:
 				rsx_log.error("Unknown remap function 0x%X", remap_lookup[channel]);
+				[[fallthrough]];
 			case CELL_GCM_TEXTURE_REMAP_REMAP:
 				remap_values[channel] = swizzle_remap[remap_inputs[channel]];
 				break;

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -450,7 +450,7 @@ namespace rsx
 
 					total_threads = CPUStats::get_thread_count();
 
-					// fallthrough
+					[[fallthrough]];
 				}
 				case detail_level::medium:
 				{
@@ -473,14 +473,14 @@ namespace rsx
 					spu_usage = std::clamp(cpu_usage * spu_cycles / total_cycles, 0.f, 100.f);
 					rsx_usage = std::clamp(cpu_usage * rsx_cycles / total_cycles, 0.f, 100.f);
 
-					// fallthrough
+					[[fallthrough]];
 				}
 				case detail_level::low:
 				{
 					if (cpu_usage < 0.)
 						cpu_usage = static_cast<f32>(m_cpu_stats.get_usage());
 
-					// fallthrough
+					[[fallthrough]];
 				}
 				case detail_level::minimal:
 				{

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -120,7 +120,7 @@ namespace rsx
 				if (m_no_saves)
 					break;
 				return_code = m_list->get_selected_index();
-				// Fall through
+				[[fallthrough]];
 			case pad_button::circle:
 				close(true, true);
 				break;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -703,6 +703,7 @@ namespace rsx
 			{
 			default:
 				rsx_log.error("bad clip plane control (0x%x)", static_cast<u8>(clip_plane_control[index]));
+				[[fallthrough]];
 
 			case rsx::user_clip_plane_op::disable:
 				clip_enabled_flags[index] = 0;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1092,7 +1092,7 @@ void VKGSRender::clear_surface(u32 mask)
 
 				if (!g_cfg.video.read_depth_buffer)
 				{
-					// Only one aspect was cleared. Make sure to memory intialize the other before removing dirty flag
+					// Only one aspect was cleared. Make sure to memory initialize the other before removing dirty flag
 					if (mask == 1)
 					{
 						// Depth was cleared, initialize stencil

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -162,11 +162,13 @@ namespace vk
 		{
 		case rsx::blend_equation::add_signed:
 			rsx_log.trace("blend equation add_signed used. Emulating using FUNC_ADD");
+			[[fallthrough]];
 		case rsx::blend_equation::add:
 			return VK_BLEND_OP_ADD;
 		case rsx::blend_equation::substract: return VK_BLEND_OP_SUBTRACT;
 		case rsx::blend_equation::reverse_substract_signed:
 			rsx_log.trace("blend equation reverse_subtract_signed used. Emulating using FUNC_REVERSE_SUBTRACT");
+			[[fallthrough]];
 		case rsx::blend_equation::reverse_substract: return VK_BLEND_OP_REVERSE_SUBTRACT;
 		case rsx::blend_equation::min: return VK_BLEND_OP_MIN;
 		case rsx::blend_equation::max: return VK_BLEND_OP_MAX;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -19,7 +19,7 @@ namespace rsx
 {
 	enum protection_policy
 	{
-		protect_policy_one_page,     //Only guard one page, preferrably one where this section 'wholly' fits
+		protect_policy_one_page,     //Only guard one page, preferably one where this section 'wholly' fits
 		protect_policy_conservative, //Guards as much memory as possible that is guaranteed to only be covered by the defined range without sharing
 		protect_policy_full_range    //Guard the full memory range. Shared pages may be invalidated by access outside the object we're guarding
 	};

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -158,6 +158,7 @@ namespace rsx
 			{
 			default:
 				rsx_log.error("Invalid AV format 0x%x", format);
+				[[fallthrough]];
 			case 0: // CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8R8G8B8:
 			case 1: // CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8B8G8R8:
 				return CELL_GCM_TEXTURE_A8R8G8B8;
@@ -172,6 +173,7 @@ namespace rsx
 			{
 			default:
 				rsx_log.error("Invalid AV format 0x%x", format);
+				[[fallthrough]];
 			case 0: // CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8R8G8B8:
 			case 1: // CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8B8G8R8:
 				return 4;

--- a/rpcs3/rpcs3qt/cheat_manager.cpp
+++ b/rpcs3/rpcs3qt/cheat_manager.cpp
@@ -304,6 +304,7 @@ bool cheat_engine::resolve_script(u32& final_offset, const u32 offset, const std
 					return false;
 
 				do_operation(cur_op, final_offset, res_value);
+				break;
 			}
 			case '+':
 				cur_op = operand_add;

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -809,6 +809,7 @@ const char* rsx_debugger::ParseGCMEnum(u32 value, u32 type)
 	case a + m * 14: \
 	case a + m * 15: \
 	index = (cmd - a) / m; \
+	[[fallthrough]]; \
 	case a \
 
 QString rsx_debugger::DisAsmCommand(u32 cmd, u32 count, u32 ioAddr)


### PR DESCRIPTION
Fix warnings found with `-Wimplicit-fallthrough=5`

@RipleyTom Can you confirm the fallthrough is expected in `rpcs3/rpcs3qt/cheat_manager.cpp`? It looks a bit suspicious to me but since I didn't take the time to understand your code, I don't really know.