### PR TITLE
cmake: Add support for target_precompiled_headers if available

### DIFF
--- a/.ci/build-linux.sh
+++ b/.ci/build-linux.sh
@@ -40,9 +40,10 @@ export CFLAGS="$CFLAGS -fuse-ld=${LINKER}"
 
 cmake ..                                               \
     -DCMAKE_INSTALL_PREFIX=/usr                        \
-    -DBUILD_LLVM_SUBMODULE=OFF -DUSE_COTIRE=OFF        \
+    -DBUILD_LLVM_SUBMODULE=OFF                         \
     -DLLVM_DIR=llvmlibs/lib/cmake/llvm/                \
     -DUSE_NATIVE_INSTRUCTIONS=OFF                      \
+    -DUSE_PRECOMPILED_HEADERS=OFF                      \
     -DCMAKE_C_FLAGS="$CFLAGS"                          \
     -DCMAKE_CXX_FLAGS="$CFLAGS"                        \
     -DCMAKE_AR="$AR"                                   \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(USE_LIBEVDEV "libevdev-based joystick support" ON)
 option(USE_DISCORD_RPC "Discord rich presence integration" ON)
 option(USE_SYSTEM_ZLIB "Prefer system ZLIB instead of the builtin one" ON)
 option(USE_VULKAN "Vulkan render backend" ON)
-option(USE_COTIRE "Use precompiled headers" ON)
+option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/rpcs3/cmake_modules")
 

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -1,6 +1,8 @@
 ﻿cmake_minimum_required(VERSION 3.8.2)
 
-include(cotire)
+if(USE_PRECOMPILED_HEADERS AND NOT COMMAND target_precompile_headers)
+	include(cotire)
+endif()
 
 # Generate git-version.h at build time.
 include(${CMAKE_CURRENT_SOURCE_DIR}/git-version.cmake)
@@ -110,12 +112,16 @@ else()
 	target_link_libraries(rpcs3 ${CMAKE_DL_LIBS})
 endif()
 
-if(USE_COTIRE)
-	set_target_properties(rpcs3 PROPERTIES
-		COTIRE_CXX_PREFIX_HEADER_INIT "${RPCS3_SRC_DIR}/stdafx.h"
-		COTIRE_ADD_UNITY_BUILD OFF)
+if(USE_PRECOMPILED_HEADERS)
+	if(COMMAND target_precompile_headers)
+		target_precompile_headers(rpcs3 PRIVATE "${RPCS3_SRC_DIR}/stdafx.h")
+	else()
+		set_target_properties(rpcs3 PROPERTIES
+			COTIRE_CXX_PREFIX_HEADER_INIT "${RPCS3_SRC_DIR}/stdafx.h"
+			COTIRE_ADD_UNITY_BUILD OFF)
 
-	cotire(rpcs3)
+		cotire(rpcs3)
+	endif()
 endif()
 
 # Copy icons to executable directory

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -457,13 +457,17 @@ target_link_libraries(rpcs3_emu
 )
 
 
-if (USE_COTIRE)
-	# Setup cotire
-	option(UNITY_BUILD_EMU "Use unity build for rpcs3_emu target" OFF)
+if (USE_PRECOMPILED_HEADERS)
+	if (COMMAND target_precompile_headers)
+		target_precompile_headers(rpcs3_emu PRIVATE "${RPCS3_SRC_DIR}/stdafx.h")
+	else()
+		# Setup cotire
+		option(UNITY_BUILD_EMU "Use unity build for rpcs3_emu target" OFF)
 
-	set_target_properties(rpcs3_emu PROPERTIES
-		COTIRE_CXX_PREFIX_HEADER_INIT "${RPCS3_SRC_DIR}/stdafx.h"
-		COTIRE_ADD_UNITY_BUILD ${UNITY_BUILD_EMU})
+		set_target_properties(rpcs3_emu PROPERTIES
+			COTIRE_CXX_PREFIX_HEADER_INIT "${RPCS3_SRC_DIR}/stdafx.h"
+			COTIRE_ADD_UNITY_BUILD ${UNITY_BUILD_EMU})
 
-	cotire(rpcs3_emu)
+		cotire(rpcs3_emu)
+	endif()
 endif()


### PR DESCRIPTION
From [cotire's README.md](https://github.com/sakra/cotire/blob/master/README.md):

> The functionality provided by cotire has been superseded by features added to CMake 3.16. Support for pre-compiling and unity builds is now built into CMake. Thus, there will not be any further updates or support for this project.

With CMake 3.16, `target_precompile_headers` can be used to replace cotire's pre-compiling functionality.