### PR TITLE
rsx: Fix is_fifo_idle with hle gcm

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2265,7 +2265,7 @@ namespace rsx
 
 	bool thread::is_fifo_idle() const
 	{
-		return ctrl->get == (ctrl->put & ~3);
+		return ctrl == nullptr || ctrl->get == (ctrl->put & ~3);
 	}
 
 	void thread::flush_fifo()


### PR DESCRIPTION
is_fifo_idle() is called inside _cellGcmInitBody before rsx::thread::ctrl is initialized