### PR TITLE
Implement sys_isolated_spu

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -436,6 +436,12 @@ error_code npDrmIsAvailable(vm::cptr<u8> k_licensee_addr, vm::cptr<char> drm_pat
 		sceNp.notice("npDrmIsAvailable(): KLicense key %s", *reinterpret_cast<be_t<v128, 1>*>(k_licensee.data()));
 	}
 
+	if (Emu.GetCat() == "PE")
+	{
+		std::copy_n(NP_PSP_KEY_2, std::size(NP_PSP_KEY_2), k_licensee.begin());
+		sceNp.success("npDrmIsAvailable(): PSP remaster KLicense key apllied.");
+	}
+
 	const std::string enc_drm_path(drm_path.get_ptr(), std::find(drm_path.get_ptr(), drm_path.get_ptr() + 0x100, '\0'));
 
 	sceNp.warning(u8"npDrmIsAvailable(): drm_path=“%s”", enc_drm_path);

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -17,7 +17,7 @@ inline void try_start(spu_thread& spu)
 			return false;
 		}
 
-		value.status = SPU_STATUS_RUNNING;
+		value.status = SPU_STATUS_RUNNING | (value.status & SPU_STATUS_IS_ISOLATED);
 		return true;
 	}).second)
 	{

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1659,6 +1659,9 @@ void spu_recompiler::RDCH(spu_opcode_t op)
 	{
 		const XmmLink& vr = XmmAlloc();
 		c->movzx(*addr, SPU_OFF_8(interrupts_enabled));
+		c->movzx(arg1->r32(), SPU_OFF_8(is_isolated));
+		c->shl(arg1->r32(), 1);
+		c->or_(addr->r32(), arg1->r32());
 		c->movd(vr, *addr);
 		c->pslldq(vr, 12);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vr);

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -5500,6 +5500,7 @@ public:
 		case SPU_RdMachStat:
 		{
 			res.value = m_ir->CreateZExt(m_ir->CreateLoad(spu_ptr<u8>(&spu_thread::interrupts_enabled)), get_type<u32>());
+			res.value = m_ir->CreateOr(res.value, m_ir->CreateShl(m_ir->CreateZExt(m_ir->CreateLoad(spu_ptr<u8>(&spu_thread::is_isolated)), get_type<u32>()), m_ir->getInt32(1)));
 			break;
 		}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1131,8 +1131,8 @@ void spu_thread::cpu_init()
 		mfc_prxy_write_state = {};
 	}
 
+	status_npc.raw() = {is_isolated ? SPU_STATUS_IS_ISOLATED : 0, 0};
 	run_ctrl.raw() = 0;
-	status_npc.raw() = {};
 
 	int_ctrl[0].clear();
 	int_ctrl[1].clear();
@@ -1218,7 +1218,7 @@ void spu_thread::cpu_task()
 			name_cache = cpu->spu_tname.load();
 		}
 
-		return fmt::format("%sSPU[0x%07x] Thread (%s) [0x%05x]", cpu->offset >= RAW_SPU_BASE_ADDR ? "Raw" : "", cpu->lv2_id, *name_cache.get(), cpu->pc);
+		return fmt::format("%sSPU[0x%07x] Thread (%s) [0x%05x]", cpu->offset >= RAW_SPU_BASE_ADDR ? cpu->is_isolated ? "Iso" : "Raw" : "", cpu->lv2_id, *name_cache.get(), cpu->pc);
 	};
 
 	if (jit)
@@ -1286,8 +1286,9 @@ spu_thread::~spu_thread()
 	}
 }
 
-spu_thread::spu_thread(vm::addr_t ls, lv2_spu_group* group, u32 index, std::string_view name, u32 lv2_id)
+spu_thread::spu_thread(vm::addr_t ls, lv2_spu_group* group, u32 index, std::string_view name, u32 lv2_id, bool is_isolated)
 	: cpu_thread(idm::last_id())
+	, is_isolated(is_isolated)
 	, index(index)
 	, offset(ls)
 	, group(group)
@@ -2591,9 +2592,8 @@ s64 spu_thread::get_ch_value(u32 ch)
 
 	case SPU_RdMachStat:
 	{
-		// HACK: "Not isolated" status
 		// Return SPU Interrupt status in LSB
-		return interrupts_enabled == true;
+		return u32{interrupts_enabled} | (u32{is_isolated} << 1);
 	}
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -100,14 +100,14 @@ enum : u64
 	SPU_INT2_STAT_SPU_MAILBOX_THRESHOLD_INT    = (1ull << 4),
 };
 
-enum
+enum : u32
 {
 	SPU_RUNCNTL_STOP_REQUEST = 0,
 	SPU_RUNCNTL_RUN_REQUEST  = 1,
 };
 
 // SPU Status Register bits (not accurate)
-enum
+enum : u32
 {
 	SPU_STATUS_STOPPED             = 0x0,
 	SPU_STATUS_RUNNING             = 0x1,
@@ -115,6 +115,7 @@ enum
 	SPU_STATUS_STOPPED_BY_HALT     = 0x4,
 	SPU_STATUS_WAITING_FOR_CHANNEL = 0x8,
 	SPU_STATUS_SINGLE_STEP         = 0x10,
+	SPU_STATUS_IS_ISOLATED         = 0x80,
 };
 
 enum : u32
@@ -514,7 +515,7 @@ public:
 	static const u32 id_step = 1;
 	static const u32 id_count = 2048;
 
-	spu_thread(vm::addr_t ls, lv2_spu_group* group, u32 index, std::string_view name, u32 lv2_id);
+	spu_thread(vm::addr_t ls, lv2_spu_group* group, u32 index, std::string_view name, u32 lv2_id, bool is_isolated = false);
 
 	u32 pc = 0;
 
@@ -592,8 +593,8 @@ public:
 		u32 npc; // SPU Next Program Counter register
 	};
 
+	const bool is_isolated;
 	atomic_t<status_npc_sync_var> status_npc;
-
 	std::array<spu_int_ctrl_t, 3> int_ctrl; // SPU Class 0, 1, 2 Interrupt Management
 
 	std::array<std::pair<u32, std::weak_ptr<lv2_event_queue>>, 32> spuq; // Event Queue Keys for SPU Thread

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -56,7 +56,9 @@ void fmt_class_string<ppu_syscall_code>::format(std::string& out, u64 arg)
 
 static bool null_func(ppu_thread& ppu)
 {
-	ppu_log.todo("Unimplemented syscall %s -> CELL_OK", ppu_syscall_code(ppu.gpr[11]));
+	ppu_log.todo("Unimplemented syscall %s -> CELL_OK (r3=0x%llx, r4=0x%x, r5=0x%llx, r6=0x%llx, r7=0x%llx, r8=0x%llx, r9=0x%llx, r10=0x%llx)", ppu_syscall_code(ppu.gpr[11]),
+		ppu.gpr[3], ppu.gpr[4], ppu.gpr[5], ppu.gpr[6], ppu.gpr[7], ppu.gpr[8], ppu.gpr[9], ppu.gpr[10]);
+
 	ppu.gpr[3] = 0;
 	ppu.cia += 4;
 	return false;

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -289,17 +289,17 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	null_func, null_func, null_func, null_func, null_func,  //224  UNS
 	null_func, null_func, null_func, null_func, null_func,  //229  UNS?
 
-	null_func,//BIND_FUNC(sys_isolated_spu_create)          //230 (0x0E6)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_destroy)         //231 (0x0E7)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_start)           //232 (0x0E8)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_create_interrupt_tag) //233 (0x0E9)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_set_int_mask)    //234 (0x0EA)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_get_int_mask)    //235 (0x0EB)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_set_int_stat)    //236 (0x0EC)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_get_int_stat)    //237 (0x0ED)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_set_spu_cfg)     //238 (0x0EE)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_get_spu_cfg)     //239 (0x0EF)  ROOT
-	null_func,//BIND_FUNC(sys_isolated_spu_read_puint_mb)   //240 (0x0F0)  ROOT
+	BIND_FUNC(sys_isolated_spu_create),                     //230 (0x0E6)  ROOT
+	BIND_FUNC(sys_isolated_spu_destroy),                    //231 (0x0E7)  ROOT
+	BIND_FUNC(sys_isolated_spu_start),                      //232 (0x0E8)  ROOT
+	BIND_FUNC(sys_isolated_spu_create_interrupt_tag),       //233 (0x0E9)  ROOT
+	BIND_FUNC(sys_isolated_spu_set_int_mask),               //234 (0x0EA)  ROOT
+	BIND_FUNC(sys_isolated_spu_get_int_mask),               //235 (0x0EB)  ROOT
+	BIND_FUNC(sys_isolated_spu_set_int_stat),               //236 (0x0EC)  ROOT
+	BIND_FUNC(sys_isolated_spu_get_int_stat),               //237 (0x0ED)  ROOT
+	BIND_FUNC(sys_isolated_spu_set_spu_cfg),                //238 (0x0EE)  ROOT
+	BIND_FUNC(sys_isolated_spu_get_spu_cfg),                //239 (0x0EF)  ROOT
+	BIND_FUNC(sys_isolated_spu_read_puint_mb),              //240 (0x0F0)  ROOT
 	uns_func, uns_func, uns_func,                           //241-243 ROOT  UNS
 	null_func,//BIND_FUNC(sys_spu_thread_group_system_set_next_group) //244 (0x0F4)  ROOT
 	null_func,//BIND_FUNC(sys_spu_thread_group_system_unset_next_group) //245 (0x0F5)  ROOT
@@ -778,9 +778,9 @@ const std::array<ppu_function_t, 1024> s_ppu_syscall_table
 	null_func,//BIND_FUNC(sys_ss_update_manager)            //863  ROOT
 	null_func,//BIND_FUNC(sys_ss_sec_hw_framework)          //864  DBG
 	BIND_FUNC(sys_ss_random_number_generator),              //865 (0x361)
-	null_func,//BIND_FUNC(sys_ss_secure_rtc)                //866  ROOT
+	BIND_FUNC(sys_ss_secure_rtc),                           //866  ROOT
 	null_func,//BIND_FUNC(sys_ss_appliance_info_manager)    //867  ROOT
-	null_func,//BIND_FUNC(sys_ss_individual_info_manager)   //868  ROOT / DBG  AUTHID
+	BIND_FUNC(sys_ss_individual_info_manager),              //868  ROOT / DBG  AUTHID
 	null_func,//BIND_FUNC(sys_ss_factory_data_manager)      //869  ROOT
 	BIND_FUNC(sys_ss_get_console_id),                       //870 (0x366)
 	BIND_FUNC(sys_ss_access_control_engine),                //871 (0x367)  DBG

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -380,3 +380,15 @@ error_code sys_raw_spu_read_puint_mb(ppu_thread&, u32 id, vm::ptr<u32> value);
 error_code sys_raw_spu_set_spu_cfg(ppu_thread&, u32 id, u32 value);
 error_code sys_raw_spu_get_spu_cfg(ppu_thread&, u32 id, vm::ptr<u32> value);
 error_code sys_raw_spu_recover_page_fault(ppu_thread&, u32 id);
+
+error_code sys_isolated_spu_create(ppu_thread&, vm::ptr<u32> id, vm::ptr<void> image, u64 arg1, u64 arg2, u64 arg3, u64 arg4);
+error_code sys_isolated_spu_start(ppu_thread&, u32 id);
+error_code sys_isolated_spu_destroy(ppu_thread& ppu, u32 id);
+error_code sys_isolated_spu_create_interrupt_tag(ppu_thread&, u32 id, u32 class_id, u32 hwthread, vm::ptr<u32> intrtag);
+error_code sys_isolated_spu_set_int_mask(ppu_thread&, u32 id, u32 class_id, u64 mask);
+error_code sys_isolated_spu_get_int_mask(ppu_thread&, u32 id, u32 class_id, vm::ptr<u64> mask);
+error_code sys_isolated_spu_set_int_stat(ppu_thread&, u32 id, u32 class_id, u64 stat);
+error_code sys_isolated_spu_get_int_stat(ppu_thread&, u32 id, u32 class_id, vm::ptr<u64> stat);
+error_code sys_isolated_spu_read_puint_mb(ppu_thread&, u32 id, vm::ptr<u32> value);
+error_code sys_isolated_spu_set_spu_cfg(ppu_thread&, u32 id, u32 value);
+error_code sys_isolated_spu_get_spu_cfg(ppu_thread&, u32 id, vm::ptr<u32> value);

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -190,3 +190,24 @@ error_code sys_ss_virtual_trm_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4
 
 	return CELL_OK;
 }
+
+error_code sys_ss_individual_info_manager(u64 pkg_id, u64 a2, vm::ptr<u64> out_size, u64 a4, u64 a5, u64 a6)
+{
+	sys_ss.todo("sys_ss_individual_info_manager(pkg=0x%llx, a2=0x%llx, out_size=*0x%llx, a4=0x%llx, a5=0x%llx, a6=0x%llx)", pkg_id, a2, out_size, a4, a5, a6);
+
+	switch (pkg_id)
+	{
+	// Read EID
+	case 0x17002:
+	{
+		// TODO
+		vm::_ref<u64>(a5) = a4; // Write back size of buffer
+		break;
+	}
+	// Get EID size
+	case 0x17001: *out_size = 0x100; break;
+	default: break;
+	}
+
+	return CELL_OK;
+}

--- a/rpcs3/Emu/Cell/lv2/sys_ss.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.h
@@ -29,3 +29,4 @@ error_code sys_ss_get_cache_of_flash_ext_flag(vm::ptr<u64> flag);
 error_code sys_ss_get_boot_device(vm::ptr<u64> dev);
 error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64 a5, u64 a6);
 error_code sys_ss_virtual_trm_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4);
+error_code sys_ss_individual_info_manager(u64 pkg_id, u64 a2, vm::ptr<u64> out_size, u64 a4, u64, u64 a5);


### PR DESCRIPTION
Isolated SPUs are similar to raw SPU with most of the difference lying inside sys_isolated_spu_create.
Gets PSP resmaster emulator a bit further.