### PR TITLE
More Maintenance

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -1483,6 +1483,7 @@
     <ClCompile Include="rpcs3qt\breakpoint_list.cpp" />
     <ClCompile Include="rpcs3qt\call_stack_list.cpp" />
     <ClCompile Include="rpcs3qt\cheat_manager.cpp" />
+    <ClCompile Include="rpcs3qt\config_adapter.cpp" />
     <ClCompile Include="rpcs3qt\curl_handle.cpp" />
     <ClCompile Include="rpcs3qt\custom_dialog.cpp" />
     <ClCompile Include="rpcs3qt\debugger_list.cpp" />
@@ -2026,6 +2027,7 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
     </CustomBuild>
     <ClInclude Include="rpcs3qt\category.h" />
+    <ClInclude Include="rpcs3qt\config_adapter.h" />
     <ClInclude Include="rpcs3qt\curl_handle.h" />
     <ClInclude Include="rpcs3qt\custom_dock_widget.h" />
     <CustomBuild Include="rpcs3qt\debugger_list.h">

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -1039,6 +1039,9 @@
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_render_creator.cpp">
       <Filter>Generated Files\Debug - LLVM</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\config_adapter.cpp">
+      <Filter>Gui\settings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="\rpcs3qt\*.h">
@@ -1129,6 +1132,9 @@
       <Filter>rpcs3</Filter>
     </ClInclude>
     <ClInclude Include="rpcs3qt\emu_settings_type.h">
+      <Filter>Gui\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="rpcs3qt\config_adapter.h">
       <Filter>Gui\settings</Filter>
     </ClInclude>
   </ItemGroup>

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -6,6 +6,7 @@
 	call_stack_list.cpp
 	cg_disasm_window.cpp
 	cheat_manager.cpp
+	config_adapter.cpp
 	curl_handle.cpp
 	custom_dialog.cpp
 	debugger_frame.cpp

--- a/rpcs3/rpcs3qt/config_adapter.cpp
+++ b/rpcs3/rpcs3qt/config_adapter.cpp
@@ -1,0 +1,66 @@
+﻿#pragma once
+
+#include <QStringList>
+
+#include "config_adapter.h"
+#include "Emu/system_config.h"
+
+// Helper methods to interact with YAML and the config settings.
+namespace cfg_adapter
+{
+	static cfg::_base& get_cfg(cfg::_base& root, const std::string& name)
+	{
+		if (root.get_type() == cfg::type::node)
+		{
+			for (const auto& pair : static_cast<cfg::node&>(root).get_nodes())
+			{
+				if (pair.first == name)
+				{
+					return *pair.second;
+				}
+			}
+		}
+
+		fmt::throw_exception("Node not found: %s", name);
+	}
+
+	static cfg::_base& get_cfg(cfg::_base& root, cfg_location::const_iterator begin, cfg_location::const_iterator end)
+	{
+		return begin == end ? root : get_cfg(get_cfg(root, *begin), begin + 1, end);
+	}
+
+	YAML::Node get_node(const YAML::Node& node, cfg_location::const_iterator begin, cfg_location::const_iterator end)
+	{
+		return begin == end ? node : get_node(node[*begin], begin + 1, end); // TODO
+	}
+
+	YAML::Node get_node(const YAML::Node& node, cfg_location loc)
+	{
+		return get_node(node, loc.cbegin(), loc.cend());
+	}
+
+	QStringList get_options(cfg_location location)
+	{
+		QStringList values;
+		auto begin = location.cbegin();
+		auto end = location.cend();
+		for (const auto& v : cfg_adapter::get_cfg(g_cfg, begin, end).to_list())
+		{
+			values.append(QString::fromStdString(v));
+		}
+		return values;
+	}
+	
+	static bool get_is_dynamic(cfg_location location)
+	{
+		auto begin = location.cbegin();
+		auto end = location.cend();
+		return cfg_adapter::get_cfg(g_cfg, begin, end).get_is_dynamic();
+	}
+	
+	bool get_is_dynamic(emu_settings_type type)
+	{
+		const cfg_location loc = settings_location[type];
+		return get_is_dynamic(loc);
+	}
+}

--- a/rpcs3/rpcs3qt/config_adapter.h
+++ b/rpcs3/rpcs3qt/config_adapter.h
@@ -1,0 +1,21 @@
+﻿#pragma once
+
+#include <QStringList>
+
+#include "emu_settings_type.h"
+#include "yaml-cpp/yaml.h"
+
+// Helper methods to interact with YAML and the config settings.
+namespace cfg_adapter
+{
+	YAML::Node get_node(const YAML::Node& node, cfg_location::const_iterator begin, cfg_location::const_iterator end);
+
+	/** Syntactic sugar to get a setting at a given config location. */
+	YAML::Node get_node(const YAML::Node& node, cfg_location loc);
+
+	/** Returns possible options for values for some particular setting.*/
+	QStringList get_options(cfg_location location);
+	
+	/** Returns dynamic property for some particular setting.*/
+	bool get_is_dynamic(emu_settings_type type);
+}

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -11,14 +11,10 @@
 #include <QButtonGroup>
 #include <QCheckBox>
 #include <QStringList>
-#include <QMap>
 #include <QComboBox>
 #include <QSpinBox>
 
 constexpr auto qstr = QString::fromStdString;
-
-// Node location
-using cfg_location = std::vector<const char*>;
 
 class emu_settings : public QObject
 {
@@ -89,152 +85,10 @@ public:
 	/** Get a localized and therefore freely adjustable version of the string used in config.yml.*/
 	QString GetLocalizedSetting(const QString& original, emu_settings_type type, int index) const;
 
-	bool GetIsDynamicConfig(emu_settings_type type);
-
 public Q_SLOTS:
 	/** Writes the unsaved settings to file.  Used in settings dialog on accept.*/
 	void SaveSettings();
 private:
-	/** A helper map that keeps track of where a given setting type is located*/
-	const QMap<emu_settings_type, cfg_location> m_settings_location =
-	{
-		// Core Tab
-		{ emu_settings_type::PPUDecoder,               { "Core", "PPU Decoder"}},
-		{ emu_settings_type::SPUDecoder,               { "Core", "SPU Decoder"}},
-		{ emu_settings_type::LibLoadOptions,           { "Core", "Lib Loader"}},
-		{ emu_settings_type::HookStaticFuncs,          { "Core", "Hook static functions"}},
-		{ emu_settings_type::EnableThreadScheduler,    { "Core", "Enable thread scheduler"}},
-		{ emu_settings_type::LowerSPUThreadPrio,       { "Core", "Lower SPU thread priority"}},
-		{ emu_settings_type::SPULoopDetection,         { "Core", "SPU loop detection"}},
-		{ emu_settings_type::PreferredSPUThreads,      { "Core", "Preferred SPU Threads"}},
-		{ emu_settings_type::PPUDebug,                 { "Core", "PPU Debug"}},
-		{ emu_settings_type::SPUDebug,                 { "Core", "SPU Debug"}},
-		{ emu_settings_type::MaxLLVMThreads,           { "Core", "Max LLVM Compile Threads"}},
-		{ emu_settings_type::EnableTSX,                { "Core", "Enable TSX"}},
-		{ emu_settings_type::AccurateGETLLAR,          { "Core", "Accurate GETLLAR"}},
-		{ emu_settings_type::AccuratePUTLLUC,          { "Core", "Accurate PUTLLUC"}},
-		{ emu_settings_type::AccurateLLVMdfma,         { "Core", "LLVM Accurate DFMA"}},
-		{ emu_settings_type::AccurateRSXAccess,        { "Core", "Accurate RSX reservation access"}},
-		{ emu_settings_type::AccurateXFloat,           { "Core", "Accurate xfloat"}},
-		{ emu_settings_type::SetDAZandFTZ,             { "Core", "Set DAZ and FTZ"}},
-		{ emu_settings_type::SPUBlockSize,             { "Core", "SPU Block Size"}},
-		{ emu_settings_type::SPUCache,                 { "Core", "SPU Cache"}},
-		{ emu_settings_type::DebugConsoleMode,         { "Core", "Debug Console Mode"}},
-		{ emu_settings_type::MaxSPURSThreads,          { "Core", "Max SPURS Threads"}},
-		{ emu_settings_type::SleepTimersAccuracy,      { "Core", "Sleep Timers Accuracy"}},
-		{ emu_settings_type::ClocksScale,              { "Core", "Clocks scale"}},
-
-		// Graphics Tab
-		{ emu_settings_type::Renderer,                   { "Video", "Renderer"}},
-		{ emu_settings_type::Resolution,                 { "Video", "Resolution"}},
-		{ emu_settings_type::AspectRatio,                { "Video", "Aspect ratio"}},
-		{ emu_settings_type::FrameLimit,                 { "Video", "Frame limit"}},
-		{ emu_settings_type::MSAA,                       { "Video", "MSAA"}},
-		{ emu_settings_type::LogShaderPrograms,          { "Video", "Log shader programs"}},
-		{ emu_settings_type::WriteDepthBuffer,           { "Video", "Write Depth Buffer"}},
-		{ emu_settings_type::WriteColorBuffers,          { "Video", "Write Color Buffers"}},
-		{ emu_settings_type::ReadColorBuffers,           { "Video", "Read Color Buffers"}},
-		{ emu_settings_type::ReadDepthBuffer,            { "Video", "Read Depth Buffer"}},
-		{ emu_settings_type::VSync,                      { "Video", "VSync"}},
-		{ emu_settings_type::DebugOutput,                { "Video", "Debug output"}},
-		{ emu_settings_type::DebugOverlay,               { "Video", "Debug overlay"}},
-		{ emu_settings_type::LegacyBuffers,              { "Video", "Use Legacy OpenGL Buffers"}},
-		{ emu_settings_type::GPUTextureScaling,          { "Video", "Use GPU texture scaling"}},
-		{ emu_settings_type::StretchToDisplayArea,       { "Video", "Stretch To Display Area"}},
-		{ emu_settings_type::ForceHighpZ,                { "Video", "Force High Precision Z buffer"}},
-		{ emu_settings_type::StrictRenderingMode,        { "Video", "Strict Rendering Mode"}},
-		{ emu_settings_type::DisableVertexCache,         { "Video", "Disable Vertex Cache"}},
-		{ emu_settings_type::DisableOcclusionQueries,    { "Video", "Disable ZCull Occlusion Queries"}},
-		{ emu_settings_type::DisableFIFOReordering,      { "Video", "Disable FIFO Reordering"}},
-		{ emu_settings_type::StrictTextureFlushing,      { "Video", "Strict Texture Flushing"}},
-		{ emu_settings_type::ForceCPUBlitEmulation,      { "Video", "Force CPU Blit"}},
-		{ emu_settings_type::DisableOnDiskShaderCache,   { "Video", "Disable On-Disk Shader Cache"}},
-		{ emu_settings_type::DisableVulkanMemAllocator,  { "Video", "Disable Vulkan Memory Allocator"}},
-		{ emu_settings_type::DisableAsyncShaderCompiler, { "Video", "Disable Asynchronous Shader Compiler"}},
-		{ emu_settings_type::MultithreadedRSX,           { "Video", "Multithreaded RSX"}},
-		{ emu_settings_type::RelaxedZCULL,               { "Video", "Relaxed ZCULL Sync"}},
-		{ emu_settings_type::AnisotropicFilterOverride,  { "Video", "Anisotropic Filter Override"}},
-		{ emu_settings_type::ResolutionScale,            { "Video", "Resolution Scale"}},
-		{ emu_settings_type::MinimumScalableDimension,   { "Video", "Minimum Scalable Dimension"}},
-		{ emu_settings_type::VulkanAdapter,              { "Video", "Vulkan", "Adapter"}},
-		{ emu_settings_type::VBlankRate,                 { "Video", "Vblank Rate"}},
-		{ emu_settings_type::DriverWakeUpDelay,          { "Video", "Driver Wake-Up Delay"}},
-
-		// Performance Overlay
-		{ emu_settings_type::PerfOverlayEnabled,               { "Video", "Performance Overlay", "Enabled" } },
-		{ emu_settings_type::PerfOverlayFramerateGraphEnabled, { "Video", "Performance Overlay", "Enable Framerate Graph" } },
-		{ emu_settings_type::PerfOverlayFrametimeGraphEnabled, { "Video", "Performance Overlay", "Enable Frametime Graph" } },
-		{ emu_settings_type::PerfOverlayDetailLevel,           { "Video", "Performance Overlay", "Detail level" } },
-		{ emu_settings_type::PerfOverlayPosition,              { "Video", "Performance Overlay", "Position" } },
-		{ emu_settings_type::PerfOverlayUpdateInterval,        { "Video", "Performance Overlay", "Metrics update interval (ms)" } },
-		{ emu_settings_type::PerfOverlayFontSize,              { "Video", "Performance Overlay", "Font size (px)" } },
-		{ emu_settings_type::PerfOverlayOpacity,               { "Video", "Performance Overlay", "Opacity (%)" } },
-		{ emu_settings_type::PerfOverlayMarginX,               { "Video", "Performance Overlay", "Horizontal Margin (px)" } },
-		{ emu_settings_type::PerfOverlayMarginY,               { "Video", "Performance Overlay", "Vertical Margin (px)" } },
-		{ emu_settings_type::PerfOverlayCenterX,               { "Video", "Performance Overlay", "Center Horizontally" } },
-		{ emu_settings_type::PerfOverlayCenterY,               { "Video", "Performance Overlay", "Center Vertically" } },
-
-		// Shader Loading Dialog
-		{ emu_settings_type::ShaderLoadBgEnabled,      { "Video", "Shader Loading Dialog", "Allow custom background" } },
-		{ emu_settings_type::ShaderLoadBgDarkening,    { "Video", "Shader Loading Dialog", "Darkening effect strength" } },
-		{ emu_settings_type::ShaderLoadBgBlur,         { "Video", "Shader Loading Dialog", "Blur effect strength" } },
-
-		// Audio
-		{ emu_settings_type::AudioRenderer,           { "Audio", "Renderer"}},
-		{ emu_settings_type::DumpToFile,              { "Audio", "Dump to file"}},
-		{ emu_settings_type::ConvertTo16Bit,          { "Audio", "Convert to 16 bit"}},
-		{ emu_settings_type::DownmixStereo,           { "Audio", "Downmix to Stereo"}},
-		{ emu_settings_type::MasterVolume,            { "Audio", "Master Volume"}},
-		{ emu_settings_type::EnableBuffering,         { "Audio", "Enable Buffering"}},
-		{ emu_settings_type::AudioBufferDuration,     { "Audio", "Desired Audio Buffer Duration"}},
-		{ emu_settings_type::EnableTimeStretching,    { "Audio", "Enable Time Stretching"}},
-		{ emu_settings_type::TimeStretchingThreshold, { "Audio", "Time Stretching Threshold"}},
-		{ emu_settings_type::MicrophoneType,          { "Audio", "Microphone Type" }},
-		{ emu_settings_type::MicrophoneDevices,       { "Audio", "Microphone Devices" }},
-
-		// Input / Output
-		{ emu_settings_type::PadHandler,      { "Input/Output", "Pad"}},
-		{ emu_settings_type::KeyboardHandler, { "Input/Output", "Keyboard"}},
-		{ emu_settings_type::MouseHandler,    { "Input/Output", "Mouse"}},
-		{ emu_settings_type::Camera,          { "Input/Output", "Camera"}},
-		{ emu_settings_type::CameraType,      { "Input/Output", "Camera type"}},
-		{ emu_settings_type::Move,            { "Input/Output", "Move" }},
-
-		// Misc
-		{ emu_settings_type::ExitRPCS3OnFinish,         { "Miscellaneous", "Exit RPCS3 when process finishes" }},
-		{ emu_settings_type::StartOnBoot,               { "Miscellaneous", "Automatically start games after boot" }},
-		{ emu_settings_type::StartGameFullscreen,       { "Miscellaneous", "Start games in fullscreen mode"}},
-		{ emu_settings_type::PreventDisplaySleep,       { "Miscellaneous", "Prevent display sleep while running games"}},
-		{ emu_settings_type::ShowTrophyPopups,          { "Miscellaneous", "Show trophy popups"}},
-		{ emu_settings_type::ShowWelcomeScreen,         { "Miscellaneous", "Show Welcome Screen"}},
-		{ emu_settings_type::UseNativeInterface,        { "Miscellaneous", "Use native user interface"}},
-		{ emu_settings_type::ShowShaderCompilationHint, { "Miscellaneous", "Show shader compilation hint"}},
-		{ emu_settings_type::SilenceAllLogs,            { "Miscellaneous", "Silence All Logs" }},
-		{ emu_settings_type::WindowTitleFormat,         { "Miscellaneous", "Window Title Format" }},
-
-		// Networking
-		{ emu_settings_type::InternetStatus, { "Net", "Internet enabled"}},
-		{ emu_settings_type::DNSAddress,     { "Net", "DNS address"}},
-		{ emu_settings_type::IpSwapList,     { "Net", "IP swap list"}},
-		{ emu_settings_type::PSNStatus,      { "Net", "PSN status"}},
-		{ emu_settings_type::PSNNPID,        { "Net", "NPID"}},
-
-		// System
-		{ emu_settings_type::Language,              { "System", "Language"}},
-		{ emu_settings_type::KeyboardType,          { "System", "Keyboard Type"} },
-		{ emu_settings_type::EnterButtonAssignment, { "System", "Enter button assignment"}},
-		{ emu_settings_type::EnableHostRoot,        { "VFS", "Enable /host_root/"}},
-		{ emu_settings_type::LimitCacheSize,        { "VFS", "Limit disk cache size"}},
-		{ emu_settings_type::MaximumCacheSize,      { "VFS", "Disk cache maximum size (MB)"}},
-
-		// Virtual File System
-		{ emu_settings_type::emulatorLocation,   { "VFS", "$(EmulatorDir)"}},
-		{ emu_settings_type::dev_hdd0Location,   { "VFS", "/dev_hdd0/" }},
-		{ emu_settings_type::dev_hdd1Location,   { "VFS", "/dev_hdd1/" }},
-		{ emu_settings_type::dev_flashLocation,  { "VFS", "/dev_flash/"}},
-		{ emu_settings_type::dev_usb000Location, { "VFS", "/dev_usb000/"}},
-	};
-
 	YAML::Node m_defaultSettings; // The default settings as a YAML node.
 	YAML::Node m_currentSettings; // The current settings as a YAML node.
 	std::string m_title_id;

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -1,5 +1,10 @@
 ﻿#pragma once
 
+#include <QMap>
+
+// Node location
+using cfg_location = std::vector<const char*>;
+
 enum class emu_settings_type
 {
 	// Core
@@ -137,4 +142,144 @@ enum class emu_settings_type
 	dev_hdd1Location,
 	dev_flashLocation,
 	dev_usb000Location,
+};
+
+/** A helper map that keeps track of where a given setting type is located*/
+static const QMap<emu_settings_type, cfg_location> settings_location =
+{
+	// Core Tab
+	{ emu_settings_type::PPUDecoder,               { "Core", "PPU Decoder"}},
+	{ emu_settings_type::SPUDecoder,               { "Core", "SPU Decoder"}},
+	{ emu_settings_type::LibLoadOptions,           { "Core", "Lib Loader"}},
+	{ emu_settings_type::HookStaticFuncs,          { "Core", "Hook static functions"}},
+	{ emu_settings_type::EnableThreadScheduler,    { "Core", "Enable thread scheduler"}},
+	{ emu_settings_type::LowerSPUThreadPrio,       { "Core", "Lower SPU thread priority"}},
+	{ emu_settings_type::SPULoopDetection,         { "Core", "SPU loop detection"}},
+	{ emu_settings_type::PreferredSPUThreads,      { "Core", "Preferred SPU Threads"}},
+	{ emu_settings_type::PPUDebug,                 { "Core", "PPU Debug"}},
+	{ emu_settings_type::SPUDebug,                 { "Core", "SPU Debug"}},
+	{ emu_settings_type::MaxLLVMThreads,           { "Core", "Max LLVM Compile Threads"}},
+	{ emu_settings_type::EnableTSX,                { "Core", "Enable TSX"}},
+	{ emu_settings_type::AccurateGETLLAR,          { "Core", "Accurate GETLLAR"}},
+	{ emu_settings_type::AccuratePUTLLUC,          { "Core", "Accurate PUTLLUC"}},
+	{ emu_settings_type::AccurateLLVMdfma,         { "Core", "LLVM Accurate DFMA"}},
+	{ emu_settings_type::AccurateRSXAccess,        { "Core", "Accurate RSX reservation access"}},
+	{ emu_settings_type::AccurateXFloat,           { "Core", "Accurate xfloat"}},
+	{ emu_settings_type::SetDAZandFTZ,             { "Core", "Set DAZ and FTZ"}},
+	{ emu_settings_type::SPUBlockSize,             { "Core", "SPU Block Size"}},
+	{ emu_settings_type::SPUCache,                 { "Core", "SPU Cache"}},
+	{ emu_settings_type::DebugConsoleMode,         { "Core", "Debug Console Mode"}},
+	{ emu_settings_type::MaxSPURSThreads,          { "Core", "Max SPURS Threads"}},
+	{ emu_settings_type::SleepTimersAccuracy,      { "Core", "Sleep Timers Accuracy"}},
+	{ emu_settings_type::ClocksScale,              { "Core", "Clocks scale"}},
+
+	// Graphics Tab
+	{ emu_settings_type::Renderer,                   { "Video", "Renderer"}},
+	{ emu_settings_type::Resolution,                 { "Video", "Resolution"}},
+	{ emu_settings_type::AspectRatio,                { "Video", "Aspect ratio"}},
+	{ emu_settings_type::FrameLimit,                 { "Video", "Frame limit"}},
+	{ emu_settings_type::MSAA,                       { "Video", "MSAA"}},
+	{ emu_settings_type::LogShaderPrograms,          { "Video", "Log shader programs"}},
+	{ emu_settings_type::WriteDepthBuffer,           { "Video", "Write Depth Buffer"}},
+	{ emu_settings_type::WriteColorBuffers,          { "Video", "Write Color Buffers"}},
+	{ emu_settings_type::ReadColorBuffers,           { "Video", "Read Color Buffers"}},
+	{ emu_settings_type::ReadDepthBuffer,            { "Video", "Read Depth Buffer"}},
+	{ emu_settings_type::VSync,                      { "Video", "VSync"}},
+	{ emu_settings_type::DebugOutput,                { "Video", "Debug output"}},
+	{ emu_settings_type::DebugOverlay,               { "Video", "Debug overlay"}},
+	{ emu_settings_type::LegacyBuffers,              { "Video", "Use Legacy OpenGL Buffers"}},
+	{ emu_settings_type::GPUTextureScaling,          { "Video", "Use GPU texture scaling"}},
+	{ emu_settings_type::StretchToDisplayArea,       { "Video", "Stretch To Display Area"}},
+	{ emu_settings_type::ForceHighpZ,                { "Video", "Force High Precision Z buffer"}},
+	{ emu_settings_type::StrictRenderingMode,        { "Video", "Strict Rendering Mode"}},
+	{ emu_settings_type::DisableVertexCache,         { "Video", "Disable Vertex Cache"}},
+	{ emu_settings_type::DisableOcclusionQueries,    { "Video", "Disable ZCull Occlusion Queries"}},
+	{ emu_settings_type::DisableFIFOReordering,      { "Video", "Disable FIFO Reordering"}},
+	{ emu_settings_type::StrictTextureFlushing,      { "Video", "Strict Texture Flushing"}},
+	{ emu_settings_type::ForceCPUBlitEmulation,      { "Video", "Force CPU Blit"}},
+	{ emu_settings_type::DisableOnDiskShaderCache,   { "Video", "Disable On-Disk Shader Cache"}},
+	{ emu_settings_type::DisableVulkanMemAllocator,  { "Video", "Disable Vulkan Memory Allocator"}},
+	{ emu_settings_type::DisableAsyncShaderCompiler, { "Video", "Disable Asynchronous Shader Compiler"}},
+	{ emu_settings_type::MultithreadedRSX,           { "Video", "Multithreaded RSX"}},
+	{ emu_settings_type::RelaxedZCULL,               { "Video", "Relaxed ZCULL Sync"}},
+	{ emu_settings_type::AnisotropicFilterOverride,  { "Video", "Anisotropic Filter Override"}},
+	{ emu_settings_type::ResolutionScale,            { "Video", "Resolution Scale"}},
+	{ emu_settings_type::MinimumScalableDimension,   { "Video", "Minimum Scalable Dimension"}},
+	{ emu_settings_type::VulkanAdapter,              { "Video", "Vulkan", "Adapter"}},
+	{ emu_settings_type::VBlankRate,                 { "Video", "Vblank Rate"}},
+	{ emu_settings_type::DriverWakeUpDelay,          { "Video", "Driver Wake-Up Delay"}},
+
+	// Performance Overlay
+	{ emu_settings_type::PerfOverlayEnabled,               { "Video", "Performance Overlay", "Enabled" } },
+	{ emu_settings_type::PerfOverlayFramerateGraphEnabled, { "Video", "Performance Overlay", "Enable Framerate Graph" } },
+	{ emu_settings_type::PerfOverlayFrametimeGraphEnabled, { "Video", "Performance Overlay", "Enable Frametime Graph" } },
+	{ emu_settings_type::PerfOverlayDetailLevel,           { "Video", "Performance Overlay", "Detail level" } },
+	{ emu_settings_type::PerfOverlayPosition,              { "Video", "Performance Overlay", "Position" } },
+	{ emu_settings_type::PerfOverlayUpdateInterval,        { "Video", "Performance Overlay", "Metrics update interval (ms)" } },
+	{ emu_settings_type::PerfOverlayFontSize,              { "Video", "Performance Overlay", "Font size (px)" } },
+	{ emu_settings_type::PerfOverlayOpacity,               { "Video", "Performance Overlay", "Opacity (%)" } },
+	{ emu_settings_type::PerfOverlayMarginX,               { "Video", "Performance Overlay", "Horizontal Margin (px)" } },
+	{ emu_settings_type::PerfOverlayMarginY,               { "Video", "Performance Overlay", "Vertical Margin (px)" } },
+	{ emu_settings_type::PerfOverlayCenterX,               { "Video", "Performance Overlay", "Center Horizontally" } },
+	{ emu_settings_type::PerfOverlayCenterY,               { "Video", "Performance Overlay", "Center Vertically" } },
+
+	// Shader Loading Dialog
+	{ emu_settings_type::ShaderLoadBgEnabled,      { "Video", "Shader Loading Dialog", "Allow custom background" } },
+	{ emu_settings_type::ShaderLoadBgDarkening,    { "Video", "Shader Loading Dialog", "Darkening effect strength" } },
+	{ emu_settings_type::ShaderLoadBgBlur,         { "Video", "Shader Loading Dialog", "Blur effect strength" } },
+
+	// Audio
+	{ emu_settings_type::AudioRenderer,           { "Audio", "Renderer"}},
+	{ emu_settings_type::DumpToFile,              { "Audio", "Dump to file"}},
+	{ emu_settings_type::ConvertTo16Bit,          { "Audio", "Convert to 16 bit"}},
+	{ emu_settings_type::DownmixStereo,           { "Audio", "Downmix to Stereo"}},
+	{ emu_settings_type::MasterVolume,            { "Audio", "Master Volume"}},
+	{ emu_settings_type::EnableBuffering,         { "Audio", "Enable Buffering"}},
+	{ emu_settings_type::AudioBufferDuration,     { "Audio", "Desired Audio Buffer Duration"}},
+	{ emu_settings_type::EnableTimeStretching,    { "Audio", "Enable Time Stretching"}},
+	{ emu_settings_type::TimeStretchingThreshold, { "Audio", "Time Stretching Threshold"}},
+	{ emu_settings_type::MicrophoneType,          { "Audio", "Microphone Type" }},
+	{ emu_settings_type::MicrophoneDevices,       { "Audio", "Microphone Devices" }},
+
+	// Input / Output
+	{ emu_settings_type::PadHandler,      { "Input/Output", "Pad"}},
+	{ emu_settings_type::KeyboardHandler, { "Input/Output", "Keyboard"}},
+	{ emu_settings_type::MouseHandler,    { "Input/Output", "Mouse"}},
+	{ emu_settings_type::Camera,          { "Input/Output", "Camera"}},
+	{ emu_settings_type::CameraType,      { "Input/Output", "Camera type"}},
+	{ emu_settings_type::Move,            { "Input/Output", "Move" }},
+
+	// Misc
+	{ emu_settings_type::ExitRPCS3OnFinish,         { "Miscellaneous", "Exit RPCS3 when process finishes" }},
+	{ emu_settings_type::StartOnBoot,               { "Miscellaneous", "Automatically start games after boot" }},
+	{ emu_settings_type::StartGameFullscreen,       { "Miscellaneous", "Start games in fullscreen mode"}},
+	{ emu_settings_type::PreventDisplaySleep,       { "Miscellaneous", "Prevent display sleep while running games"}},
+	{ emu_settings_type::ShowTrophyPopups,          { "Miscellaneous", "Show trophy popups"}},
+	{ emu_settings_type::ShowWelcomeScreen,         { "Miscellaneous", "Show Welcome Screen"}},
+	{ emu_settings_type::UseNativeInterface,        { "Miscellaneous", "Use native user interface"}},
+	{ emu_settings_type::ShowShaderCompilationHint, { "Miscellaneous", "Show shader compilation hint"}},
+	{ emu_settings_type::SilenceAllLogs,            { "Miscellaneous", "Silence All Logs" }},
+	{ emu_settings_type::WindowTitleFormat,         { "Miscellaneous", "Window Title Format" }},
+
+	// Networking
+	{ emu_settings_type::InternetStatus, { "Net", "Internet enabled"}},
+	{ emu_settings_type::DNSAddress,     { "Net", "DNS address"}},
+	{ emu_settings_type::IpSwapList,     { "Net", "IP swap list"}},
+	{ emu_settings_type::PSNStatus,      { "Net", "PSN status"}},
+	{ emu_settings_type::PSNNPID,        { "Net", "NPID"}},
+
+	// System
+	{ emu_settings_type::Language,              { "System", "Language"}},
+	{ emu_settings_type::KeyboardType,          { "System", "Keyboard Type"} },
+	{ emu_settings_type::EnterButtonAssignment, { "System", "Enter button assignment"}},
+	{ emu_settings_type::EnableHostRoot,        { "VFS", "Enable /host_root/"}},
+	{ emu_settings_type::LimitCacheSize,        { "VFS", "Limit disk cache size"}},
+	{ emu_settings_type::MaximumCacheSize,      { "VFS", "Disk cache maximum size (MB)"}},
+
+	// Virtual File System
+	{ emu_settings_type::emulatorLocation,   { "VFS", "$(EmulatorDir)"}},
+	{ emu_settings_type::dev_hdd0Location,   { "VFS", "/dev_hdd0/" }},
+	{ emu_settings_type::dev_hdd1Location,   { "VFS", "/dev_hdd1/" }},
+	{ emu_settings_type::dev_flashLocation,  { "VFS", "/dev_flash/"}},
+	{ emu_settings_type::dev_usb000Location, { "VFS", "/dev_usb000/"}},
 };


### PR DESCRIPTION
- Move m_settings_type map to emu_settings_type.h
- Move cfg_adapter stuff from emu_settings to its own file

This makes it easier to use the mentioned code in other classes and also cleans up emu_settings in the process.