### PR TITLE
Minor sys_rsx fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -407,7 +407,8 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 
 	if (!rsx_cfg->context_base || context_id != 0x55555555)
 	{
-		return CELL_EINVAL;
+		sys_rsx.error("sys_rsx_context_attribute(): invalid context failure (context_id=0x%x)", context_id);
+		return CELL_OK; // Actually returns CELL_OK, cellGCmSys seem to be relying on this as well
 	}
 
 	auto &driverInfo = vm::_ref<RsxDriverInfo>(rsx_cfg->driver_info);

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -651,7 +651,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		}
 
 		const u32 width = ((a4 & 0xFFFFFFFF) >> 22) << 6;
-		const u32 height = ((a4 & 0xFFFFFFFF) >> 6) << 6;
+		const u32 height = ((a4 & 0x0000FFFF) >> 6) << 6;
 		const u32 cullStart = (a5 >> 32) & ~0xFFF;
 		const u32 offset = (a5 & 0x0FFFFFFF);
 		const bool bound = (a6 & 0xFFFFFFFF) != 0;


### PR DESCRIPTION
* Fix error code instead of success on invalid context, did some RE on this. cellGcmSys code documentation seems to rely on this as well by not mentioning what happens if cellGcmSys is not intialized when calling specific functions even though they always use the syscall.
* Fix sys_rsx zcull bind command height. Fixes a regression from #8065. 