### PR TITLE
Move RSX capture to Utilities menu and add drag and drop confirmation dialogs

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -28,7 +28,7 @@ class GSRender;
 
 #define CMD_DEBUG 0
 
-std::atomic<bool> user_asked_for_frame_capture = false;
+std::atomic<bool> g_user_asked_for_frame_capture = false;
 rsx::frame_trace_data frame_debug;
 rsx::frame_capture_data frame_capture;
 
@@ -309,7 +309,7 @@ namespace rsx
 
 		m_graphics_state = pipeline_state::all_dirty;
 
-		user_asked_for_frame_capture = false;
+		g_user_asked_for_frame_capture = false;
 
 		if (g_cfg.misc.use_native_interface && (g_cfg.video.renderer == video_renderer::opengl || g_cfg.video.renderer == video_renderer::vulkan))
 		{
@@ -2558,7 +2558,7 @@ namespace rsx
 	void thread::on_frame_end(u32 buffer, bool forced)
 	{
 		// Marks the end of a frame scope GPU-side
-		if (user_asked_for_frame_capture.exchange(false) && !capture_current_frame)
+		if (g_user_asked_for_frame_capture.exchange(false) && !capture_current_frame)
 		{
 			capture_current_frame = true;
 			frame_debug.reset();

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -28,7 +28,7 @@
 extern u64 get_guest_system_time();
 extern u64 get_system_time();
 
-extern std::atomic<bool> user_asked_for_frame_capture;
+extern std::atomic<bool> g_user_asked_for_frame_capture;
 extern rsx::frame_trace_data frame_debug;
 extern rsx::frame_capture_data frame_capture;
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -28,7 +28,6 @@
 #include <atomic>
 
 constexpr auto qstr = QString::fromStdString;
-extern std::atomic<bool> user_asked_for_frame_capture;
 
 debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *parent)
 	: custom_dock_widget(tr("Debugger"), parent), xgui_settings(settings)
@@ -69,7 +68,6 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 
 	m_go_to_addr = new QPushButton(tr("Go To Address"), this);
 	m_go_to_pc = new QPushButton(tr("Go To PC"), this);
-	m_btn_capture = new QPushButton(tr("RSX Capture"), this);
 	m_btn_step = new QPushButton(tr("Step"), this);
 	m_btn_step_over = new QPushButton(tr("Step Over"), this);
 	m_btn_run = new QPushButton(RunString, this);
@@ -80,7 +78,6 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 
 	hbox_b_main->addWidget(m_go_to_addr);
 	hbox_b_main->addWidget(m_go_to_pc);
-	hbox_b_main->addWidget(m_btn_capture);
 	hbox_b_main->addWidget(m_btn_step);
 	hbox_b_main->addWidget(m_btn_step_over);
 	hbox_b_main->addWidget(m_btn_run);
@@ -131,11 +128,6 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 
 	connect(m_go_to_addr, &QAbstractButton::clicked, this, &debugger_frame::ShowGotoAddressDialog);
 	connect(m_go_to_pc, &QAbstractButton::clicked, this, &debugger_frame::ShowPC);
-
-	connect(m_btn_capture, &QAbstractButton::clicked, [this]()
-	{
-		user_asked_for_frame_capture = true;
-	});
 
 	connect(m_btn_step, &QAbstractButton::clicked, this, &debugger_frame::DoStep);
 	connect(m_btn_step_over, &QAbstractButton::clicked, [this]() { DoStep(true); });
@@ -300,8 +292,6 @@ u32 debugger_frame::GetPc() const
 void debugger_frame::UpdateUI()
 {
 	UpdateUnitList();
-
-	m_btn_capture->setEnabled(Emu.IsRunning() || Emu.IsPaused());
 
 	if (m_no_thread_selected) return;
 

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -32,7 +32,6 @@ class debugger_frame : public custom_dock_widget
 	QTextEdit* m_regs;
 	QPushButton* m_go_to_addr;
 	QPushButton* m_go_to_pc;
-	QPushButton* m_btn_capture;
 	QPushButton* m_btn_step;
 	QPushButton* m_btn_step_over;
 	QPushButton* m_btn_run;

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -817,36 +817,6 @@ void game_list_frame::itemSelectionChangedSlot()
 	Q_EMIT NotifyGameSelection(game);
 }
 
-bool game_list_frame::GetBootConfirmation(const gui_save& gui_save_entry)
-{
-	if (m_gui_settings && !Emu.IsStopped())
-	{
-		QString title = tr("Close Running Game?");
-		QString message = tr("Performing this action will close the current game.\nDo you really want to continue?\n\nAny unsaved progress will be lost!\n");
-
-		if (gui_save_entry == gui::ib_confirm_boot)
-		{
-			message = tr("Booting another game will close the current game.\nDo you really want to boot another game?\n\nAny unsaved progress will be lost!\n");
-		}
-		else if (gui_save_entry == gui::ib_confirm_exit)
-		{
-			title = tr("Exit RPCS3?");
-			message = tr("A game is currently running. Do you really want to close RPCS3?\n\nAny unsaved progress will be lost!\n");
-		}
-
-		int result = QMessageBox::Yes;
-
-		m_gui_settings->ShowConfirmationBox(title, message, gui_save_entry, &result, this);
-
-		if (result != QMessageBox::Yes)
-		{
-			return false;
-		}
-	}
-
-	return true;
-}
-
 void game_list_frame::ShowContextMenu(const QPoint &pos)
 {
 	QPoint global_pos;
@@ -1071,7 +1041,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	});
 	connect(create_ppu_cache, &QAction::triggered, [gameinfo, this]
 	{
-		if (GetBootConfirmation())
+		if (m_gui_settings->GetBootConfirmation(this))
 		{
 			CreatePPUCache(gameinfo);
 		}
@@ -1431,7 +1401,7 @@ void game_list_frame::BatchCreatePPUCaches()
 		return;
 	}
 
-	if (!GetBootConfirmation())
+	if (!m_gui_settings->GetBootConfirmation(this))
 	{
 		return;
 	}

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -69,8 +69,6 @@ public:
 
 	void SetShowHidden(bool show);
 
-	bool GetBootConfirmation(const gui_save& gui_save_entry = gui_save());
-
 public Q_SLOTS:
 	void BatchCreatePPUCaches();
 	void BatchRemovePPUCaches();

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -3,6 +3,8 @@
 #include "qt_utils.h"
 #include "localized.h"
 
+#include "Emu/System.h"
+
 #include <QCheckBox>
 #include <QCoreApplication>
 #include <QMessageBox>
@@ -215,6 +217,36 @@ void gui_settings::ShowConfirmationBox(const QString& title, const QString& text
 void gui_settings::ShowInfoBox(const QString& title, const QString& text, const gui_save& entry, QWidget* parent = nullptr)
 {
 	ShowBox(false, title, text, entry, nullptr, parent, false);
+}
+
+bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save_entry)
+{
+	if (!Emu.IsStopped())
+	{
+		QString title = tr("Close Running Game?");
+		QString message = tr("Performing this action will close the current game.\nDo you really want to continue?\n\nAny unsaved progress will be lost!\n");
+
+		if (gui_save_entry == gui::ib_confirm_boot)
+		{
+			message = tr("Booting another game will close the current game.\nDo you really want to boot another game?\n\nAny unsaved progress will be lost!\n");
+		}
+		else if (gui_save_entry == gui::ib_confirm_exit)
+		{
+			title = tr("Exit RPCS3?");
+			message = tr("A game is currently running. Do you really want to close RPCS3?\n\nAny unsaved progress will be lost!\n");
+		}
+
+		int result = QMessageBox::Yes;
+
+		ShowConfirmationBox(title, message, gui_save_entry, &result, parent);
+
+		if (result != QMessageBox::Yes)
+		{
+			return false;
+		}
+	}
+
+	return true;
 }
 
 void gui_settings::SetGamelistColVisibility(int col, bool val)

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -239,6 +239,7 @@ public:
 
 	void ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent);
 	void ShowInfoBox(const QString& title, const QString& text, const gui_save& entry, QWidget* parent);
+	bool GetBootConfirmation(QWidget* parent, const gui_save& gui_save_entry = gui_save());
 
 	logs::level GetLogLevel();
 	bool GetGamelistColVisibility(int col);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -50,6 +50,8 @@
 
 LOG_CHANNEL(gui_log, "GUI");
 
+extern std::atomic<bool> g_user_asked_for_frame_capture;
+
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 main_window::main_window(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget *parent)
@@ -1088,6 +1090,7 @@ void main_window::EnableMenus(bool enabled)
 	ui->toolsmemory_viewerAct->setEnabled(enabled);
 	ui->toolsRsxDebuggerAct->setEnabled(enabled);
 	ui->toolsStringSearchAct->setEnabled(enabled);
+	ui->actionCreate_RSX_Capture->setEnabled(enabled);
 }
 
 void main_window::BootRecentAction(const QAction* act)
@@ -1359,6 +1362,10 @@ void main_window::CreateConnects()
 	connect(ui->bootElfAct, &QAction::triggered, this, &main_window::BootElf);
 	connect(ui->bootGameAct, &QAction::triggered, this, &main_window::BootGame);
 	connect(ui->actionopen_rsx_capture, &QAction::triggered, [this](){ BootRsxCapture(); });
+	connect(ui->actionCreate_RSX_Capture, &QAction::triggered, []()
+	{
+		g_user_asked_for_frame_capture = true;
+	});
 
 	connect(ui->addGamesAct, &QAction::triggered, [this]()
 	{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2148,9 +2148,9 @@ Check data for valid file types and cache their paths if necessary
 @param savePaths = flag for path caching
 @returns validity of file type
 */
-int main_window::IsValidFile(const QMimeData& md, QStringList* drop_paths)
+main_window::drop_type main_window::IsValidFile(const QMimeData& md, QStringList* drop_paths)
 {
-	int drop_type = drop_type::drop_error;
+	auto drop_type = drop_type::drop_error;
 
 	const QList<QUrl> list = md.urls(); // get list of all the dropped file urls
 
@@ -2229,8 +2229,11 @@ void main_window::dropEvent(QDropEvent* event)
 	switch (IsValidFile(*event->mimeData(), &drop_paths)) // get valid file paths and drop type
 	{
 	case drop_type::drop_error:
+	{
 		break;
+	}
 	case drop_type::drop_pkg: // install the packages
+	{
 		if (drop_paths.count() > 1)
 		{
 			pkg_install_dialog dlg(drop_paths, this);
@@ -2249,10 +2252,14 @@ void main_window::dropEvent(QDropEvent* event)
 			InstallPackages(drop_paths, true);
 		}
 		break;
+	}
 	case drop_type::drop_pup: // install the firmware
+	{
 		InstallPup(drop_paths.first());
 		break;
+	}
 	case drop_type::drop_rap: // import rap files to exdata dir
+	{
 		for (const auto& rap : drop_paths)
 		{
 			const std::string rapname = sstr(QFileInfo(rap).fileName());
@@ -2270,14 +2277,18 @@ void main_window::dropEvent(QDropEvent* event)
 		// Refresh game list since we probably unlocked some games now.
 		m_game_list_frame->Refresh(true);
 		break;
+	}
 	case drop_type::drop_dir: // import valid games to gamelist (games.yaml)
+	{
 		for (const auto& path : drop_paths)
 		{
 			AddGamesFromDir(path);
 		}
 		m_game_list_frame->Refresh(true);
 		break;
+	}
 	case drop_type::drop_game: // import valid games to gamelist (games.yaml)
+	{
 		if (const auto error = Emu.BootGame(sstr(drop_paths.first()), "", true); error != game_boot_result::no_errors)
 		{
 			gui_log.error("Boot failed: reason: %s, path: %s", error, sstr(drop_paths.first()));
@@ -2289,18 +2300,23 @@ void main_window::dropEvent(QDropEvent* event)
 			m_game_list_frame->Refresh(true);
 		}
 		break;
+	}
 	case drop_type::drop_rrc: // replay a rsx capture file
+	{
 		BootRsxCapture(sstr(drop_paths.first()));
 		break;
+	}
 	default:
+	{
 		gui_log.warning("Invalid dropType in gamelist dropEvent");
 		break;
+	}
 	}
 }
 
 void main_window::dragEnterEvent(QDragEnterEvent* event)
 {
-	if (IsValidFile(*event->mimeData()))
+	if (IsValidFile(*event->mimeData()) != drop_type::drop_error)
 	{
 		event->accept();
 	}
@@ -2308,7 +2324,7 @@ void main_window::dragEnterEvent(QDragEnterEvent* event)
 
 void main_window::dragMoveEvent(QDragMoveEvent* event)
 {
-	if (IsValidFile(*event->mimeData()))
+	if (IsValidFile(*event->mimeData()) != drop_type::drop_error)
 	{
 		event->accept();
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -300,7 +300,7 @@ void main_window::show_boot_error(game_boot_result status)
 
 void main_window::Boot(const std::string& path, const std::string& title_id, bool direct, bool add_only, bool force_global_config)
 {
-	if (!m_game_list_frame->GetBootConfirmation(gui::ib_confirm_boot))
+	if (!m_gui_settings->GetBootConfirmation(this, gui::ib_confirm_boot))
 	{
 		return;
 	}
@@ -419,7 +419,7 @@ void main_window::BootRsxCapture(std::string path)
 		path = sstr(file_path);
 	}
 
-	if (!m_game_list_frame->GetBootConfirmation())
+	if (!m_gui_settings->GetBootConfirmation(this))
 	{
 		return;
 	}
@@ -476,7 +476,7 @@ void main_window::HandlePackageInstallation(QStringList file_paths)
 		return;
 	}
 
-	if (!m_game_list_frame->GetBootConfirmation())
+	if (!m_gui_settings->GetBootConfirmation(this))
 	{
 		return;
 	}
@@ -603,7 +603,7 @@ void main_window::HandlePupInstallation(QString file_path)
 		return;
 	}
 
-	if (!m_game_list_frame->GetBootConfirmation())
+	if (!m_gui_settings->GetBootConfirmation(this))
 	{
 		return;
 	}
@@ -765,7 +765,7 @@ void main_window::DecryptSPRXLibraries()
 		return;
 	}
 	
-	if (!m_game_list_frame->GetBootConfirmation())
+	if (!m_gui_settings->GetBootConfirmation(this))
 	{
 		return;
 	}
@@ -2049,7 +2049,7 @@ void main_window::RemoveFirmwareCache()
 
 void main_window::CreateFirmwareCache()
 {
-	if (!m_game_list_frame->GetBootConfirmation())
+	if (!m_gui_settings->GetBootConfirmation(this))
 	{
 		return;
 	}
@@ -2093,7 +2093,7 @@ void main_window::mouseDoubleClickEvent(QMouseEvent *event)
 */
 void main_window::closeEvent(QCloseEvent* closeEvent)
 {
-	if (!m_game_list_frame->GetBootConfirmation(gui::ib_confirm_exit))
+	if (!m_gui_settings->GetBootConfirmation(this, gui::ib_confirm_exit))
 	{
 		closeEvent->ignore();
 		return;
@@ -2280,7 +2280,7 @@ void main_window::dropEvent(QDropEvent* event)
 	}
 	case drop_type::drop_dir: // import valid games to gamelist (games.yaml)
 	{
-		if (!m_game_list_frame->GetBootConfirmation())
+		if (!m_gui_settings->GetBootConfirmation(this))
 		{
 			return;
 		}
@@ -2293,7 +2293,7 @@ void main_window::dropEvent(QDropEvent* event)
 	}
 	case drop_type::drop_game: // import valid games to gamelist (games.yaml)
 	{
-		if (!m_game_list_frame->GetBootConfirmation())
+		if (!m_gui_settings->GetBootConfirmation(this))
 		{
 			return;
 		}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2280,6 +2280,10 @@ void main_window::dropEvent(QDropEvent* event)
 	}
 	case drop_type::drop_dir: // import valid games to gamelist (games.yaml)
 	{
+		if (!m_game_list_frame->GetBootConfirmation())
+		{
+			return;
+		}
 		for (const auto& path : drop_paths)
 		{
 			AddGamesFromDir(path);
@@ -2289,6 +2293,10 @@ void main_window::dropEvent(QDropEvent* event)
 	}
 	case drop_type::drop_game: // import valid games to gamelist (games.yaml)
 	{
+		if (!m_game_list_frame->GetBootConfirmation())
+		{
+			return;
+		}
 		if (const auto error = Emu.BootGame(sstr(drop_paths.first()), "", true); error != game_boot_result::no_errors)
 		{
 			gui_log.error("Boot failed: reason: %s, path: %s", error, sstr(drop_paths.first()));

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -62,7 +62,7 @@ class main_window : public QMainWindow
 	QStringList m_vulkan_adapters;
 #endif
 
-	enum drop_type
+	enum class drop_type
 	{
 		drop_error,
 		drop_pkg,
@@ -137,7 +137,7 @@ private:
 	void InstallPup(QString filePath = "");
 	void HandlePupInstallation(QString file_path = "");
 
-	int IsValidFile(const QMimeData& md, QStringList* drop_paths = nullptr);
+	drop_type IsValidFile(const QMimeData& md, QStringList* drop_paths = nullptr);
 	void AddGamesFromDir(const QString& path);
 
 	QAction* CreateRecentAction(const q_string_pair& entry, const uint& sc_idx);

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -141,7 +141,7 @@
      <x>0</x>
      <y>0</y>
      <width>1058</width>
-     <height>26</height>
+     <height>22</height>
     </rect>
    </property>
    <property name="contextMenuPolicy">
@@ -250,7 +250,10 @@
     <addaction name="toolsStringSearchAct"/>
     <addaction name="separator"/>
     <addaction name="toolsDecryptSprxLibsAct"/>
+    <addaction name="separator"/>
     <addaction name="actionopen_rsx_capture"/>
+    <addaction name="separator"/>
+    <addaction name="actionCreate_RSX_Capture"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -1055,6 +1058,14 @@
   <action name="createFirmwareCacheAct">
    <property name="text">
     <string>Create Firmware Cache</string>
+   </property>
+  </action>
+  <action name="actionCreate_RSX_Capture">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Create RSX Capture</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
- Moves the "RSX Capture" button from the debugger to "Utilities->Create RSX Capture"
- Adds confirmation dialogs that prevent accidentally closing the running game by drag and drop
- some minor refactoring