### PR TITLE
Some vm memory access refactoring

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -144,7 +144,7 @@ error_code cellAudioOutGetState(u32 audioOut, u32 deviceIndex, vm::ptr<CellAudio
 			// Although it was constant on my tests so let's write that
 			_state.state = 0x10;
 			_state.soundMode.layout = 0xD00C1680;
-			std::memcpy(state.get_ptr(), &_state, state.size());
+			state.write(_state);
 			return CELL_OK;
 		}
 
@@ -171,7 +171,7 @@ error_code cellAudioOutGetState(u32 audioOut, u32 deviceIndex, vm::ptr<CellAudio
 		return CELL_AUDIO_OUT_ERROR_ILLEGAL_PARAMETER;
 	}
 
-	std::memcpy(state.get_ptr(), &_state, state.size());
+	state.write(_state);
 	return CELL_OK;
 }
 
@@ -239,7 +239,7 @@ error_code cellAudioOutGetConfiguration(u32 audioOut, vm::ptr<CellAudioOutConfig
 		return CELL_AUDIO_OUT_ERROR_ILLEGAL_PARAMETER;
 	}
 
-	std::memcpy(config.get_ptr(), &_config, config.size());
+	config.write(_config);
 	return CELL_OK;
 }
 
@@ -304,7 +304,7 @@ error_code cellAudioOutGetDeviceInfo(u32 audioOut, u32 deviceIndex, vm::ptr<Cell
 	_info.availableModes[1].fs = CELL_AUDIO_OUT_FS_48KHZ;
 	_info.availableModes[1].layout = CELL_AUDIO_OUT_SPEAKER_LAYOUT_2CH;
 
-	std::memcpy(info.get_ptr(), &_info, info.size());
+	info.write(_info);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellSearch.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSearch.cpp
@@ -851,7 +851,7 @@ error_code cellSearchGetContentIdByOffset(CellSearchId searchId, s32 offset, vm:
 
 		if (outTimeInfo)
 		{
-			std::memcpy(outTimeInfo.get_ptr(), &content_id.second->timeInfo, sizeof(content_id.second->timeInfo));
+			outTimeInfo.write(content_id.second->timeInfo);
 		}
 
 	}

--- a/rpcs3/Emu/Cell/Modules/cellSearch.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSearch.cpp
@@ -660,32 +660,32 @@ error_code cellSearchGetContentInfoByOffset(CellSearchId searchId, s32 offset, v
 		switch (content_info->type)
 		{
 		case CELL_SEARCH_CONTENTTYPE_MUSIC:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.music, sizeof(content_info->data.music));
+			vm::write<CellSearchMusicInfo>(infoBuffer.addr(), content_info->data.music);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_PHOTO:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.photo, sizeof(content_info->data.photo));
+			vm::write<CellSearchPhotoInfo>(infoBuffer.addr(), content_info->data.photo);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_VIDEO:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.video, sizeof(content_info->data.photo));
+			vm::write<CellSearchVideoInfo>(infoBuffer.addr(), content_info->data.video);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_MUSICLIST:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.music_list, sizeof(content_info->data.music_list));
+			vm::write<CellSearchMusicListInfo>(infoBuffer.addr(), content_info->data.music_list);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_PHOTOLIST:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.photo_list, sizeof(content_info->data.photo_list));
+			vm::write<CellSearchPhotoListInfo>(infoBuffer.addr(), content_info->data.photo_list);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_VIDEOLIST:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.video_list, sizeof(content_info->data.video_list));
+			vm::write<CellSearchVideoListInfo>(infoBuffer.addr(), content_info->data.video_list);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_SCENE:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.scene, sizeof(content_info->data.scene));
+			vm::write<CellSearchVideoSceneInfo>(infoBuffer.addr(), content_info->data.scene);
 			break;
 		default:
 			return CELL_SEARCH_ERROR_GENERIC;
 		}
 
 		const u128 content_id_128 = content_id.first;
-		*outContentType = content_info->type;
+		outContentType.write(content_info->type);
 		std::memcpy(outContentId->data, &content_id_128, CELL_SEARCH_CONTENT_ID_SIZE);
 	}
 	else // content ID not found, perform a search first
@@ -729,31 +729,31 @@ error_code cellSearchGetContentInfoByContentId(vm::cptr<CellSearchContentId> con
 		switch (content_info->type)
 		{
 		case CELL_SEARCH_CONTENTTYPE_MUSIC:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.music, sizeof(content_info->data.music));
+			vm::write<CellSearchMusicInfo>(infoBuffer.addr(), content_info->data.music);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_PHOTO:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.photo, sizeof(content_info->data.photo));
+			vm::write<CellSearchPhotoInfo>(infoBuffer.addr(), content_info->data.photo);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_VIDEO:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.video, sizeof(content_info->data.photo));
+			vm::write<CellSearchVideoInfo>(infoBuffer.addr(), content_info->data.video);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_MUSICLIST:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.music_list, sizeof(content_info->data.music_list));
+			vm::write<CellSearchMusicListInfo>(infoBuffer.addr(), content_info->data.music_list);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_PHOTOLIST:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.photo_list, sizeof(content_info->data.photo_list));
+			vm::write<CellSearchPhotoListInfo>(infoBuffer.addr(), content_info->data.photo_list);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_VIDEOLIST:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.video_list, sizeof(content_info->data.video_list));
+			vm::write<CellSearchVideoListInfo>(infoBuffer.addr(), content_info->data.video_list);
 			break;
 		case CELL_SEARCH_CONTENTTYPE_SCENE:
-			std::memcpy(infoBuffer.get_ptr(), &content_info->data.scene, sizeof(content_info->data.scene));
+			vm::write<CellSearchVideoSceneInfo>(infoBuffer.addr(), content_info->data.scene);
 			break;
 		default:
 			return CELL_SEARCH_ERROR_GENERIC;
 		}
 
-		*outContentType = content_info->type;
+		outContentType.write(content_info->type);
 	}
 	else // content ID not found, perform a search first
 	{
@@ -846,7 +846,7 @@ error_code cellSearchGetContentIdByOffset(CellSearchId searchId, s32 offset, vm:
 	{
 		auto& content_id = searchObject->content_ids.at(offset);
 		const u128 content_id_128 = content_id.first;
-		*outContentType = content_id.second->type;
+		outContentType.write(content_id.second->type);
 		std::memcpy(outContentId->data, &content_id_128, CELL_SEARCH_CONTENT_ID_SIZE);
 
 		if (outTimeInfo)
@@ -936,7 +936,7 @@ error_code cellSearchGetContentInfoPath(vm::cptr<CellSearchContentId> contentId,
 	auto found = content_map->find(id);
 	if(found != content_map->end())
 	{
-		std::memcpy(infoPath.get_ptr(), &found->second->infoPath, sizeof(found->second->infoPath));
+		infoPath.write(found->second->infoPath);
 	}
 	else
 	{

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -2505,7 +2505,7 @@ error_code sceNpManagerGetOnlineId(vm::ptr<SceNpOnlineId> onlineId)
 		return SCE_NP_ERROR_INVALID_STATE;
 	}
 
-	memcpy(onlineId.get_ptr(), &nph->get_online_id(), onlineId.size());
+	onlineId.write(nph->get_online_id());
 
 	return CELL_OK;
 }
@@ -2536,7 +2536,7 @@ error_code sceNpManagerGetNpId(ppu_thread& ppu, vm::ptr<SceNpId> npId)
 		return SCE_NP_ERROR_INVALID_STATE;
 	}
 
-	memcpy(npId.get_ptr(), &nph->get_npid(), npId.size());
+	npId.write(nph->get_npid());
 
 	return CELL_OK;
 }
@@ -2567,7 +2567,7 @@ error_code sceNpManagerGetOnlineName(vm::ptr<SceNpOnlineName> onlineName)
 		return SCE_NP_ERROR_INVALID_STATE;
 	}
 
-	memcpy(onlineName.get_ptr(), &nph->get_online_name(), onlineName.size());
+	onlineName.write(nph->get_online_name());
 
 	return CELL_OK;
 }
@@ -2598,7 +2598,7 @@ error_code sceNpManagerGetAvatarUrl(vm::ptr<SceNpAvatarUrl> avatarUrl)
 		return SCE_NP_ERROR_INVALID_STATE;
 	}
 
-	memcpy(avatarUrl.get_ptr(), &nph->get_avatar_url(), avatarUrl.size());
+	avatarUrl.write(nph->get_avatar_url());
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/PPUCallback.h
+++ b/rpcs3/Emu/Cell/PPUCallback.h
@@ -181,17 +181,17 @@ namespace vm
 	template<typename AT, typename RT, typename... T>
 	FORCE_INLINE RT _ptr_base<RT(T...), AT>::operator()(ppu_thread& CPU, T... args) const
 	{
-		const auto data = vm::_ptr<ppu_func_opd_t>(vm::cast(m_addr, HERE));
-		const u32 pc = data->addr;
-		const u32 rtoc = data->rtoc;
+		const auto data = vm::read<ppu_func_opd_t>(vm::cast(m_addr, HERE));
+		const u32 pc = data.addr;
+		const u32 rtoc = data.rtoc;
 
 		return ppu_cb_detail::_func_caller<RT, T...>::call(CPU, pc, rtoc, args...);
 	}
 
 	template<typename AT, typename RT, typename... T>
-	FORCE_INLINE const ppu_func_opd_t& _ptr_base<RT(T...), AT>::opd() const
+	FORCE_INLINE ppu_func_opd_t _ptr_base<RT(T...), AT>::opd() const
 	{
-		return vm::_ref<ppu_func_opd_t>(vm::cast(m_addr, HERE));
+		return vm::read<ppu_func_opd_t>(vm::cast(m_addr, HERE));
 	}
 }
 

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -3449,7 +3449,7 @@ bool ppu_interpreter::LBZX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LVX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = (op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb]) & ~0xfull;
-	ppu.vr[op.vd] = vm::_ref<v128>(vm::cast(addr, HERE));
+	ppu.vr[op.vd] = vm::read<v128, false>(vm::cast(addr, HERE));
 	return true;
 }
 
@@ -3649,7 +3649,7 @@ bool ppu_interpreter::STBX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STVX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = (op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb]) & ~0xfull;
-	vm::_ref<v128>(vm::cast(addr, HERE)) = ppu.vr[op.vs];
+	vm::write<v128, false>(vm::cast(addr, HERE), ppu.vr[op.vs]);
 	return true;
 }
 
@@ -3781,7 +3781,7 @@ bool ppu_interpreter::MFSPR(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LWAX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.gpr[op.rd] = static_cast<s32>(vm::read32(vm::cast(addr, HERE)));
+	ppu.gpr[op.rd] = vm::read<s32>(vm::cast(addr, HERE));
 	return true;
 }
 
@@ -3793,14 +3793,14 @@ bool ppu_interpreter::DST(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LHAX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.gpr[op.rd] = static_cast<s16>(vm::read16(vm::cast(addr, HERE)));
+	ppu.gpr[op.rd] = vm::read<s16>(vm::cast(addr, HERE));
 	return true;
 }
 
 bool ppu_interpreter::LVXL(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = (op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb]) & ~0xfull;
-	ppu.vr[op.vd] = vm::_ref<v128>(vm::cast(addr, HERE));
+	ppu.vr[op.vd] = vm::read<v128, false>(vm::cast(addr, HERE));
 	return true;
 }
 
@@ -3821,7 +3821,7 @@ bool ppu_interpreter::MFTB(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LWAUX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.gpr[op.rd] = static_cast<s32>(vm::read32(vm::cast(addr, HERE)));
+	ppu.gpr[op.rd] = vm::read<s32>(vm::cast(addr, HERE));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -3834,7 +3834,7 @@ bool ppu_interpreter::DSTST(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LHAUX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.gpr[op.rd] = static_cast<s16>(vm::read16(vm::cast(addr, HERE)));
+	ppu.gpr[op.rd] = vm::read<s16>(vm::cast(addr, HERE));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -3968,7 +3968,7 @@ bool ppu_interpreter::LVLX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LDBRX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.gpr[op.rd] = vm::_ref<le_t<u64>>(vm::cast(addr, HERE));
+	ppu.gpr[op.rd] = vm::read<le_t<u64>>(vm::cast(addr, HERE));
 	return true;
 }
 
@@ -3978,14 +3978,14 @@ bool ppu_interpreter::LSWX(ppu_thread& ppu, ppu_opcode_t op)
 	u32 count = ppu.xer.cnt & 0x7f;
 	for (; count >= 4; count -= 4, addr += 4, op.rd = (op.rd + 1) & 31)
 	{
-		ppu.gpr[op.rd] = vm::_ref<u32>(vm::cast(addr, HERE));
+		ppu.gpr[op.rd] = vm::read32(vm::cast(addr, HERE));
 	}
 	if (count)
 	{
 		u32 value = 0;
 		for (u32 byte = 0; byte < count; byte++)
 		{
-			u32 byte_value = vm::_ref<u8>(vm::cast(addr + byte, HERE));
+			u32 byte_value = vm::read8(vm::cast(addr + byte, HERE));
 			value |= byte_value << ((3 ^ byte) * 8);
 		}
 		ppu.gpr[op.rd] = value;
@@ -3996,14 +3996,14 @@ bool ppu_interpreter::LSWX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LWBRX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.gpr[op.rd] = vm::_ref<le_t<u32>>(vm::cast(addr, HERE));
+	ppu.gpr[op.rd] = vm::read<le_t<u32>>(vm::cast(addr, HERE));
 	return true;
 }
 
 bool ppu_interpreter::LFSX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.fpr[op.frd] = vm::_ref<f32>(vm::cast(addr, HERE));
+	ppu.fpr[op.frd] = vm::read<f32>(vm::cast(addr, HERE));
 	return true;
 }
 
@@ -4064,7 +4064,7 @@ bool ppu_interpreter::LSWI(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LFSUX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + ppu.gpr[op.rb];
-	ppu.fpr[op.frd] = vm::_ref<f32>(vm::cast(addr, HERE));
+	ppu.fpr[op.frd] = vm::read<f32>(vm::cast(addr, HERE));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4078,14 +4078,14 @@ bool ppu_interpreter::SYNC(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LFDX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.fpr[op.frd] = vm::_ref<f64>(vm::cast(addr, HERE));
+	ppu.fpr[op.frd] = vm::read<f64>(vm::cast(addr, HERE));
 	return true;
 }
 
 bool ppu_interpreter::LFDUX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + ppu.gpr[op.rb];
-	ppu.fpr[op.frd] = vm::_ref<f64>(vm::cast(addr, HERE));
+	ppu.fpr[op.frd] = vm::read<f64>(vm::cast(addr, HERE));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4100,7 +4100,7 @@ bool ppu_interpreter::STVLX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STDBRX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	vm::_ref<le_t<u64>>(vm::cast(addr, HERE)) = ppu.gpr[op.rs];
+	vm::write<le_t<u64>>(vm::cast(addr, HERE), ppu.gpr[op.rs]);
 	return true;
 }
 
@@ -4127,14 +4127,14 @@ bool ppu_interpreter::STSWX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STWBRX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	vm::_ref<le_t<u32>>(vm::cast(addr, HERE)) = static_cast<u32>(ppu.gpr[op.rs]);
+	vm::write<le_t<u32>>(vm::cast(addr, HERE), static_cast<u32>(ppu.gpr[op.rs]));
 	return true;
 }
 
 bool ppu_interpreter::STFSX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	vm::_ref<f32>(vm::cast(addr, HERE)) = static_cast<float>(ppu.fpr[op.frs]);
+	vm::write<f32>(vm::cast(addr, HERE), static_cast<f32>(ppu.fpr[op.frs]));
 	return true;
 }
 
@@ -4148,7 +4148,7 @@ bool ppu_interpreter::STVRX(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STFSUX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + ppu.gpr[op.rb];
-	vm::_ref<f32>(vm::cast(addr, HERE)) = static_cast<float>(ppu.fpr[op.frs]);
+	vm::write<f32>(vm::cast(addr, HERE), static_cast<f32>(ppu.fpr[op.frs]));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4186,14 +4186,14 @@ bool ppu_interpreter::STSWI(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STFDX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	vm::_ref<f64>(vm::cast(addr, HERE)) = ppu.fpr[op.frs];
+	vm::write<f64>(vm::cast(addr, HERE), ppu.fpr[op.frs]);
 	return true;
 }
 
 bool ppu_interpreter::STFDUX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + ppu.gpr[op.rb];
-	vm::_ref<f64>(vm::cast(addr, HERE)) = ppu.fpr[op.frs];
+	vm::write<f64>(vm::cast(addr, HERE), ppu.fpr[op.frs]);
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4206,7 +4206,7 @@ bool ppu_interpreter::LVLXL(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LHBRX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	ppu.gpr[op.rd] = vm::_ref<le_t<u16>>(vm::cast(addr, HERE));
+	ppu.gpr[op.rd] = vm::read<le_t<u16>>(vm::cast(addr, HERE));
 	return true;
 }
 
@@ -4293,7 +4293,7 @@ bool ppu_interpreter::STVLXL(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STHBRX(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + ppu.gpr[op.rb] : ppu.gpr[op.rb];
-	vm::_ref<le_t<u16>>(vm::cast(addr, HERE)) = static_cast<u16>(ppu.gpr[op.rs]);
+	vm::write<le_t<u16>>(vm::cast(addr, HERE), static_cast<u16>(ppu.gpr[op.rs]));
 	return true;
 }
 
@@ -4429,14 +4429,14 @@ bool ppu_interpreter::LHZU(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LHA(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + op.simm16 : op.simm16;
-	ppu.gpr[op.rd] = static_cast<s16>(vm::read16(vm::cast(addr, HERE)));
+	ppu.gpr[op.rd] = vm::read<s16>(vm::cast(addr, HERE));
 	return true;
 }
 
 bool ppu_interpreter::LHAU(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + op.simm16;
-	ppu.gpr[op.rd] = static_cast<s16>(vm::read16(vm::cast(addr, HERE)));
+	ppu.gpr[op.rd] = vm::read<s16>(vm::cast(addr, HERE));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4479,14 +4479,14 @@ bool ppu_interpreter::STMW(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LFS(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + op.simm16 : op.simm16;
-	ppu.fpr[op.frd] = vm::_ref<f32>(vm::cast(addr, HERE));
+	ppu.fpr[op.frd] = vm::read<f32>(vm::cast(addr, HERE));
 	return true;
 }
 
 bool ppu_interpreter::LFSU(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + op.simm16;
-	ppu.fpr[op.frd] = vm::_ref<f32>(vm::cast(addr, HERE));
+	ppu.fpr[op.frd] = vm::read<f32>(vm::cast(addr, HERE));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4494,14 +4494,14 @@ bool ppu_interpreter::LFSU(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LFD(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + op.simm16 : op.simm16;
-	ppu.fpr[op.frd] = vm::_ref<f64>(vm::cast(addr, HERE));
+	ppu.fpr[op.frd] = vm::read<f64>(vm::cast(addr, HERE));
 	return true;
 }
 
 bool ppu_interpreter::LFDU(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + op.simm16;
-	ppu.fpr[op.frd] = vm::_ref<f64>(vm::cast(addr, HERE));
+	ppu.fpr[op.frd] = vm::read<f64>(vm::cast(addr, HERE));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4509,14 +4509,14 @@ bool ppu_interpreter::LFDU(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STFS(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + op.simm16 : op.simm16;
-	vm::_ref<f32>(vm::cast(addr, HERE)) = static_cast<float>(ppu.fpr[op.frs]);
+	vm::write<f32>(vm::cast(addr, HERE), static_cast<f32>(ppu.fpr[op.frs]));
 	return true;
 }
 
 bool ppu_interpreter::STFSU(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + op.simm16;
-	vm::_ref<f32>(vm::cast(addr, HERE)) = static_cast<float>(ppu.fpr[op.frs]);
+	vm::write<f32>(vm::cast(addr, HERE), static_cast<f32>(ppu.fpr[op.frs]));
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4524,14 +4524,14 @@ bool ppu_interpreter::STFSU(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::STFD(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = op.ra ? ppu.gpr[op.ra] + op.simm16 : op.simm16;
-	vm::_ref<f64>(vm::cast(addr, HERE)) = ppu.fpr[op.frs];
+	vm::write<f64>(vm::cast(addr, HERE), ppu.fpr[op.frs]);
 	return true;
 }
 
 bool ppu_interpreter::STFDU(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = ppu.gpr[op.ra] + op.simm16;
-	vm::_ref<f64>(vm::cast(addr, HERE)) = ppu.fpr[op.frs];
+	vm::write<f64>(vm::cast(addr, HERE), ppu.fpr[op.frs]);
 	ppu.gpr[op.ra] = addr;
 	return true;
 }
@@ -4554,7 +4554,7 @@ bool ppu_interpreter::LDU(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::LWA(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const u64 addr = (op.simm16 & ~3) + (op.ra ? ppu.gpr[op.ra] : 0);
-	ppu.gpr[op.rd] = static_cast<s32>(vm::read32(vm::cast(addr, HERE)));
+	ppu.gpr[op.rd] = vm::read<s32>(vm::cast(addr, HERE));
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -403,21 +403,21 @@ static void ppu_patch_refs(std::vector<ppu_reloc>* out_relocs, u32 fref, u32 fad
 		{
 		case 1:
 		{
-			const u32 value = vm::_ref<u32>(ref->addr) = rdata;
+			const u32 value = vm::write32(ref->addr, rdata);
 			ppu_loader.trace("**** REF(1): 0x%x <- 0x%x", ref->addr, value);
 			break;
 		}
 
 		case 4:
 		{
-			const u16 value = vm::_ref<u16>(ref->addr) = static_cast<u16>(rdata);
+			const u16 value = vm::write16(ref->addr, static_cast<u16>(rdata));
 			ppu_loader.trace("**** REF(4): 0x%x <- 0x%04x (0x%llx)", ref->addr, value, faddr);
 			break;
 		}
 
 		case 6:
 		{
-			const u16 value = vm::_ref<u16>(ref->addr) = static_cast<u16>(rdata >> 16) + (rdata & 0x8000 ? 1 : 0);
+			const u16 value = vm::write16(ref->addr, static_cast<u16>(rdata >> 16) + (rdata & 0x8000 ? 1 : 0));
 			ppu_loader.trace("**** REF(6): 0x%x <- 0x%04x (0x%llx)", ref->addr, value, faddr);
 			break;
 		}
@@ -835,28 +835,28 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 				{
 				case 1: // R_PPC64_ADDR32
 				{
-					const u32 value = vm::_ref<u32>(raddr) = static_cast<u32>(rdata);
+					const u32 value = vm::write32(raddr, static_cast<u32>(rdata));
 					ppu_loader.trace("**** RELOCATION(1): 0x%x <- 0x%08x (0x%llx)", raddr, value, rdata);
 					break;
 				}
 
 				case 4: //R_PPC64_ADDR16_LO
 				{
-					const u16 value = vm::_ref<u16>(raddr) = static_cast<u16>(rdata);
+					const u16 value = vm::write16(raddr, static_cast<u16>(rdata));
 					ppu_loader.trace("**** RELOCATION(4): 0x%x <- 0x%04x (0x%llx)", raddr, value, rdata);
 					break;
 				}
 
 				case 5: //R_PPC64_ADDR16_HI
 				{
-					const u16 value = vm::_ref<u16>(raddr) = static_cast<u16>(rdata >> 16);
+					const u16 value = vm::write16(raddr, static_cast<u16>(rdata >> 16));
 					ppu_loader.trace("**** RELOCATION(5): 0x%x <- 0x%04x (0x%llx)", raddr, value, rdata);
 					break;
 				}
 
 				case 6: //R_PPC64_ADDR16_HA
 				{
-					const u16 value = vm::_ref<u16>(raddr) = static_cast<u16>(rdata >> 16) + (rdata & 0x8000 ? 1 : 0);
+					const u16 value = vm::write16(raddr, static_cast<u16>(rdata >> 16) + (rdata & 0x8000 ? 1 : 0));
 					ppu_loader.trace("**** RELOCATION(6): 0x%x <- 0x%04x (0x%llx)", raddr, value, rdata);
 					break;
 				}
@@ -877,14 +877,14 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 
 				case 38: //R_PPC64_ADDR64
 				{
-					const u64 value = vm::_ref<u64>(raddr) = rdata;
+					const u64 value = vm::write64(raddr, rdata);
 					ppu_loader.trace("**** RELOCATION(38): 0x%x <- 0x%016llx (0x%llx)", raddr, value, rdata);
 					break;
 				}
 
 				case 44: //R_PPC64_REL64
 				{
-					const u64 value = vm::_ref<u64>(raddr) = rdata - raddr;
+					const u64 value = vm::write64(raddr, rdata - raddr);
 					ppu_loader.trace("**** RELOCATION(44): 0x%x <- 0x%016llx (0x%llx)", raddr, value, rdata);
 					break;
 				}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -620,8 +620,8 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::lle_call:
 		{
-			const vm::ptr<u32> opd(arg < 32 ? vm::cast(gpr[arg]) : vm::cast(arg));
-			cmd_pop(), fast_call(opd[0], opd[1]);
+			const ppu_func_opd_t opd = vm::read<ppu_func_opd_t>(arg < 32 ? vm::cast(gpr[arg]) : vm::cast(arg));
+			cmd_pop(), fast_call(opd.addr, opd.rtoc);
 			break;
 		}
 		case ppu_cmd::hle_call:
@@ -947,7 +947,7 @@ u32 ppu_thread::stack_push(u32 size, u32 align_v)
 		else
 		{
 			const u32 addr = static_cast<u32>(context.gpr[1]);
-			vm::_ref<nse_t<u32>>(addr + size) = old_pos;
+			vm::write<nse_t<u32>>(addr + size, old_pos);
 			std::memset(vm::base(addr), 0, size);
 			return addr;
 		}
@@ -968,7 +968,7 @@ void ppu_thread::stack_pop_verbose(u32 addr, u32 size) noexcept
 			return;
 		}
 
-		context.gpr[1] = vm::_ref<nse_t<u32>>(static_cast<u32>(context.gpr[1]) + size);
+		context.gpr[1] = vm::read<nse_t<u32>>(static_cast<u32>(context.gpr[1]) + size);
 		return;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -24,7 +24,7 @@ error_code sys_cond_create(ppu_thread& ppu, vm::ptr<u32> cond_id, u32 mutex_id, 
 		return CELL_ESRCH;
 	}
 
-	const auto _attr = *attr;
+	const auto _attr = attr.read();
 
 	if (auto error = lv2_obj::create<lv2_cond>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -24,7 +24,7 @@ error_code sys_event_flag_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<sys_e
 		return CELL_EFAULT;
 	}
 
-	const auto _attr = *attr;
+	const auto _attr = attr.read();
 
 	const u32 protocol = _attr.protocol;
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -22,7 +22,7 @@ error_code sys_mutex_create(ppu_thread& ppu, vm::ptr<u32> mutex_id, vm::ptr<sys_
 		return CELL_EFAULT;
 	}
 
-	const auto _attr = *attr;
+	const auto _attr = attr.read();
 
 	switch (_attr.protocol)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -1560,7 +1560,7 @@ error_code sys_net_bnet_setsockopt(ppu_thread& ppu, s32 s, s32 level, s32 optnam
 
 		if (optlen >= sizeof(int))
 		{
-			native_int = vm::_ref<s32>(optval.addr());
+			native_int = vm::read<s32>(optval.addr());
 		}
 		else
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -719,7 +719,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		driverInfo.head[1].flipBufferId = static_cast<u32>(a3);
 
 		// seems gcmSysWaitLabel uses this offset, so lets set it to 0 every flip
-		vm::_ref<u32>(render->label_addr + 0x10) = 0;
+		vm::write32(render->label_addr + 0x10, 0);
 
 		rsx_cfg->send_event(0, SYS_RSX_EVENT_FLIP_BASE << 1, 0);
 		break;
@@ -730,7 +730,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		verify(HERE), a3 < 2;
 
 		// todo: this is wrong and should be 'second' vblank handler and freq, but since currently everything is reported as being 59.94, this should be fine
-		vm::_ref<u32>(render->device_addr + 0x30) = 1;
+		vm::write32(render->device_addr + 0x30, 1);
 
 		const u64 current_time = rsxTimeStamp();
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -407,8 +407,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 
 	if (!rsx_cfg->context_base || context_id != 0x55555555)
 	{
-		sys_rsx.error("sys_rsx_context_attribute(): invalid context failure (context_id=0x%x)", context_id);
-		return CELL_OK; // Actually returns CELL_OK, cellGCmSys seem to be relying on this as well
+		return CELL_EINVAL;
 	}
 
 	auto &driverInfo = vm::_ref<RsxDriverInfo>(rsx_cfg->driver_info);

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -22,7 +22,7 @@ error_code sys_rwlock_create(ppu_thread& ppu, vm::ptr<u32> rw_lock_id, vm::ptr<s
 		return CELL_EFAULT;
 	}
 
-	const auto _attr = *attr;
+	const auto _attr = attr.read();
 
 	const u32 protocol = _attr.protocol;
 

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -28,7 +28,7 @@ error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sy
 		return CELL_EINVAL;
 	}
 
-	const auto _attr = *attr;
+	const auto _attr = attr.read();
 
 	const u32 protocol = _attr.protocol;
 

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -201,7 +201,7 @@ error_code sys_ss_individual_info_manager(u64 pkg_id, u64 a2, vm::ptr<u64> out_s
 	case 0x17002:
 	{
 		// TODO
-		vm::_ref<u64>(a5) = a4; // Write back size of buffer
+		vm::write64(vm::cast(a5, HERE), a4); // Write back size of buffer
 		break;
 	}
 	// Get EID size

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -775,7 +775,7 @@ error_code sys_usbd_isochronous_transfer_data(u32 handle, u32 id_pipe, vm::ptr<U
 	const auto& pipe = usbh->get_pipe(id_pipe);
 	auto& transfer   = usbh->get_transfer(id_transfer);
 
-	memcpy(&transfer.iso_request, iso_request.get_ptr(), sizeof(UsbDeviceIsoRequest));
+	transfer.iso_request = iso_request.read();
 	pipe.device->isochronous_transfer(&transfer);
 
 	// returns an identifier specific to the transfer
@@ -795,8 +795,8 @@ error_code sys_usbd_get_transfer_status(u32 handle, u32 id_transfer, u32 unk1, v
 
 	auto& transfer = usbh->get_transfer(id_transfer);
 
-	*result = transfer.result;
-	*count  = transfer.count;
+	result.write(transfer.result);
+	count.write(transfer.count);
 
 	return CELL_OK;
 }
@@ -814,8 +814,8 @@ error_code sys_usbd_get_isochronous_transfer_status(u32 handle, u32 id_transfer,
 
 	auto& transfer = usbh->get_transfer(id_transfer);
 
-	*result = transfer.result;
-	memcpy(request.get_ptr(), &transfer.iso_request, sizeof(UsbDeviceIsoRequest));
+	result.write(transfer.result);
+	request.write(transfer.iso_request);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -263,7 +263,7 @@ namespace vm
 
 		// Callback; defined in PPUCallback.h, passing context is mandatory
 		RT operator()(ppu_thread& ppu, T... args) const;
-		const ppu_func_opd_t& opd() const;
+		ppu_func_opd_t opd() const;
 	};
 
 	template<typename AT, typename RT, typename... T>

--- a/rpcs3/Emu/Memory/vm_var.h
+++ b/rpcs3/Emu/Memory/vm_var.h
@@ -53,7 +53,7 @@ namespace vm
 		_var_base(const T& right)
 		    : _var_base()
 		{
-			std::memcpy(pointer::get_ptr(), &right, sizeof(T));
+			pointer::write(right);
 		}
 
 		~_var_base()


### PR DESCRIPTION
Implement vm::read/write, wrappers for safe access of vm memory for simple read/write operations.
And a revertation of a wrong change in #8081.