### PR TITLE
SPU DMA: more tuning for mov_rdata_avx

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -556,7 +556,7 @@ public:
 
 	// Reservation Data
 	u64 rtime = 0;
-	std::array<v128, 8> rdata{};
+	alignas(64) std::array<v128, 8> rdata{};
 	u32 raddr = 0;
 
 	u32 srr0;


### PR DESCRIPTION
Tuning for compiling for more CPU variants, such as znver1 or ivybridge (mainly for GCC).