### PR TITLE
Lööp of fixups

### DIFF
--- a/Utilities/address_range.h
+++ b/Utilities/address_range.h
@@ -60,21 +60,26 @@ namespace utils
 			return (start1 >= start2 && end1 <= end2);
 		}
 
-		address_range(u32 _start, u32 _end) : start(_start), end(_end) {}
+		constexpr address_range(u32 _start, u32 _end) : start(_start), end(_end) {}
 
 	public:
 		// Constructors
-		address_range() = default;
-		address_range(const address_range &other) : start(other.start), end(other.end) {}
+		constexpr address_range() = default;
+		constexpr address_range(const address_range &other) : start(other.start), end(other.end) {}
 
-		static inline address_range start_length(u32 _start, u32 _length)
+		static constexpr address_range start_length(u32 _start, u32 _length)
 		{
-			return address_range(_start, _start + (_length - 1));
+			if (!_length)
+			{
+				return {};
+			}
+
+			return {_start, _start + (_length - 1)};
 		}
 
-		static inline address_range start_end(u32 _start, u32 _end)
+		static constexpr address_range start_end(u32 _start, u32 _end)
 		{
-			return address_range(_start, _end);
+			return {_start, _end};
 		}
 
 		// Length

--- a/rpcs3/Emu/Cell/MFC.cpp
+++ b/rpcs3/Emu/Cell/MFC.cpp
@@ -62,5 +62,7 @@ void fmt_class_string<spu_mfc_cmd>::format(std::string& out, u64 arg)
 {
 	const auto& cmd = get_object(arg);
 
-	fmt::append(out, "%s #%02u 0x%05x:0x%08x 0x%x", cmd.cmd, cmd.tag, cmd.lsa, cmd.eah * 0x100000000ull + cmd.eal, cmd.size);
+	const u8 tag = cmd.tag;
+
+	fmt::append(out, "%s #%02u 0x%05x:0x%08llx 0x%x%s", cmd.cmd, tag & 0x7f, cmd.lsa, u64{cmd.eah} << 32 | cmd.eal, cmd.size, (tag & 0x80) ? " (stalled)" : "");
 }

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1041,7 +1041,9 @@ static T ppu_load_acquire_reservation(ppu_thread& ppu, u32 addr)
 		}
 		else
 		{
+			ppu.state += cpu_flag::wait;
 			std::this_thread::yield();
+			ppu.check_state();
 		}
 	}())
 	{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -77,7 +77,7 @@ void fmt_class_string<ppu_join_status>::format(std::string& out, u64 arg)
 	{
 		switch (js)
 		{
-		case ppu_join_status::joinable: return "";
+		case ppu_join_status::joinable: return "none";
 		case ppu_join_status::detached: return "detached";
 		case ppu_join_status::zombie: return "zombie";
 		case ppu_join_status::exited: return "exited";

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -788,14 +788,11 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 
 	gpr[13] = param.tls_addr;
 
-	if (detached >= 0 && id != id_base)
+	if (detached >= 0)
 	{
-		// Initialize thread entry point
-		cmd_list
-		({
-		    {ppu_cmd::set_args, 2}, param.arg0, param.arg1,
-		    {ppu_cmd::opd_call, 0}, std::bit_cast<u64>(entry_func),
-		});
+		// Initialize thread args
+		gpr[3] = param.arg0;
+		gpr[4] = param.arg1;
 	}
 
 	// Trigger the scheduler

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -15,7 +15,7 @@ void lv2_int_serv::exec()
 	({
 		{ ppu_cmd::reset_stack, 0 },
 		{ ppu_cmd::set_args, 2 }, arg1, arg2,
-		{ ppu_cmd::opd_call, 0 }, std::bit_cast<u64>(thread->entry_func),
+		{ ppu_cmd::opd_call, 0 }, thread->entry_func,
 		{ ppu_cmd::sleep, 0 }
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -277,6 +277,8 @@ error_code sys_ppu_thread_get_priority(u32 thread_id, vm::ptr<s32> priop)
 	// Clean some detached thread (hack)
 	g_fxo->get<ppu_thread_cleaner>()->clean(0);
 
+	u32 prio;
+
 	const auto thread = idm::check<named_thread<ppu_thread>>(thread_id, [&](ppu_thread& thread)
 	{
 		if (thread.joiner == ppu_join_status::exited)
@@ -284,7 +286,7 @@ error_code sys_ppu_thread_get_priority(u32 thread_id, vm::ptr<s32> priop)
 			return false;
 		}
 
-		*priop = thread.prio;
+		prio = thread.prio;
 		return true;
 	});
 
@@ -293,6 +295,7 @@ error_code sys_ppu_thread_get_priority(u32 thread_id, vm::ptr<s32> priop)
 		return CELL_ESRCH;
 	}
 
+	*priop = prio;
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -26,10 +26,7 @@ error_code sys_rwlock_create(ppu_thread& ppu, vm::ptr<u32> rw_lock_id, vm::ptr<s
 
 	const u32 protocol = _attr.protocol;
 
-	if (protocol == SYS_SYNC_PRIORITY_INHERIT)
-		sys_rwlock.todo("sys_rwlock_create(): SYS_SYNC_PRIORITY_INHERIT");
-
-	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_PRIORITY && protocol != SYS_SYNC_PRIORITY_INHERIT)
+	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_PRIORITY)
 	{
 		sys_rwlock.error("sys_rwlock_create(): unknown protocol (0x%x)", protocol);
 		return CELL_EINVAL;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -25,6 +25,28 @@ LOG_CHANNEL(sys_spu);
 
 extern u64 get_timebased_time();
 
+template <>
+void fmt_class_string<spu_group_status>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](spu_group_status value)
+	{
+		switch (value)
+		{
+		case SPU_THREAD_GROUP_STATUS_NOT_INITIALIZED: return "uninitialized";
+		case SPU_THREAD_GROUP_STATUS_INITIALIZED: return "initialized";
+		case SPU_THREAD_GROUP_STATUS_READY: return "ready";
+		case SPU_THREAD_GROUP_STATUS_WAITING: return "waiting";
+		case SPU_THREAD_GROUP_STATUS_SUSPENDED: return "suspended";
+		case SPU_THREAD_GROUP_STATUS_WAITING_AND_SUSPENDED: return "waiting and suspended";
+		case SPU_THREAD_GROUP_STATUS_RUNNING: return "running";
+		case SPU_THREAD_GROUP_STATUS_STOPPED: return "stopped";
+		case SPU_THREAD_GROUP_STATUS_UNKNOWN: break;
+		}
+
+		return unknown;
+	});
+}
+
 void sys_spu_image::load(const fs::file& stream)
 {
 	const spu_exec_object obj{stream, 0, elf_opt::no_sections + elf_opt::no_data};

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -48,7 +48,7 @@ enum
 	SYS_SPU_THREAD_GROUP_LOG_GET_STATUS = 0x2,
 };
 
-enum : u32
+enum spu_group_status : u32
 {
 	SPU_THREAD_GROUP_STATUS_NOT_INITIALIZED,
 	SPU_THREAD_GROUP_STATUS_INITIALIZED,
@@ -263,7 +263,7 @@ struct lv2_spu_group
 
 	atomic_t<u32> init; // Initialization Counter
 	atomic_t<s32> prio; // SPU Thread Group Priority
-	atomic_t<u32> run_state; // SPU Thread Group State
+	atomic_t<spu_group_status> run_state; // SPU Thread Group State
 	atomic_t<s32> exit_status; // SPU Thread Group Exit Status
 	atomic_t<u32> join_state; // flags used to detect exit cause and signal
 	atomic_t<u32> running; // Number of running threads

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -282,7 +282,7 @@ void kernel_explorer::Update()
 	idm::select<named_thread<ppu_thread>>([&](u32 id, ppu_thread& ppu)
 	{
 		lv2_types.back().count++;
-		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"PPU Thread: ID = 0x%08x “%s”", id, *ppu.ppu_tname.load())));
+		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"PPU: ID = 0x%07x “%s”, priority = %d, joiner = %s, state = %s", id, *ppu.ppu_tname.load(), +ppu.prio, ppu.joiner.load(), ppu.state.load())));
 	});
 
 	lv2_types.emplace_back(l_addTreeChild(root, "SPU Threads"));
@@ -290,7 +290,7 @@ void kernel_explorer::Update()
 	idm::select<named_thread<spu_thread>>([&](u32 /*id*/, spu_thread& spu)
 	{
 		lv2_types.back().count++;
-		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"SPU Thread: ID = 0x%08x “%s”", spu.lv2_id, *spu.spu_tname.load())));
+		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"SPU: ID = 0x%07x “%s”, state = %s", spu.lv2_id, *spu.spu_tname.load(), spu.state.load())));
 	});
 
 	lv2_types.emplace_back(l_addTreeChild(root, "SPU Thread Groups"));
@@ -298,7 +298,7 @@ void kernel_explorer::Update()
 	idm::select<lv2_spu_group>([&](u32 id, lv2_spu_group& tg)
 	{
 		lv2_types.back().count++;
-		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"SPU Thread Group: ID = 0x%08x “%s”", id, tg.name)));
+		l_addTreeChild(lv2_types.back().node, qstr(fmt::format(u8"SPU Group: ID = 0x%07x “%s”, status = %s, priority = %d, type = 0x%x", id, tg.name, tg.run_state.load(), +tg.prio, tg.type)));
 	});
 
 	lv2_types.emplace_back(l_addTreeChild(root, "File Descriptors"));


### PR DESCRIPTION
* Fix cpu_flag::pause check in SPU GETLLAR (affects TSX), fixes #8116 .
* Return error code on PRIORITY_INHERIT protocol for sys_rwlock, this protocol is not allowed for it.
* Fix address_range::start_length(0, 0) constructor (created a valid range of 0...UINT32_MAX where it should be an invalid range), also make constructors constexpr.
* Make spu_mfc_cmd fmt properly show stalled commands.
* Fix sys_ppu_thread_get_priority page faults.
* Fix sys_ppu_thread_start error checking.
* Fix sys_ppu_thread_create when the created thread has the same id as ppu_thread::id_base, can happen when the main thread exited (by sys_ppu_thread_exit) before the thread created. (valid situation)
* Add more information about SPU/PPU threads in kernel explorer.