### PR TITLE
PPU: Use a memory barrier in DCBF/DCBST

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -3436,6 +3436,7 @@ bool ppu_interpreter::LDARX(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::DCBF(ppu_thread& ppu, ppu_opcode_t op)
 {
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 	return true;
 }
 
@@ -3699,6 +3700,7 @@ bool ppu_interpreter::MULLW(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::DCBTST(ppu_thread& ppu, ppu_opcode_t op)
 {
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -2497,6 +2497,7 @@ void PPUTranslator::LDUX(ppu_opcode_t op)
 
 void PPUTranslator::DCBST(ppu_opcode_t op)
 {
+	m_ir->CreateFence(AtomicOrdering::SequentiallyConsistent);
 }
 
 void PPUTranslator::LWZUX(ppu_opcode_t op)
@@ -2555,6 +2556,7 @@ void PPUTranslator::LDARX(ppu_opcode_t op)
 
 void PPUTranslator::DCBF(ppu_opcode_t op)
 {
+	m_ir->CreateFence(AtomicOrdering::SequentiallyConsistent);
 }
 
 void PPUTranslator::LBZX(ppu_opcode_t op)


### PR DESCRIPTION
* DCBF/DCBST should flush memory of the cache line specified, so let's go a bit further and add a full memory barrier instead. for testing on ppu llvm: clear ppu cache and formware cache.