### PR TITLE
SPU GETLLAR: Don't use loop detection for TSX

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -456,6 +456,10 @@ std::string ppu_thread::dump_regs() const
 	fmt::append(ret, "XER = [CA=%u | OV=%u | SO=%u | CNT=%u]\n", xer.ca, xer.ov, xer.so, xer.cnt);
 	fmt::append(ret, "VSCR = [SAT=%u | NJ=%u]\n", sat, nj);
 	fmt::append(ret, "FPSCR = [FL=%u | FG=%u | FE=%u | FU=%u]\n", fpscr.fl, fpscr.fg, fpscr.fe, fpscr.fu);
+	if (const u32 addr = raddr)
+		fmt::append(ret, "Reservation Addr = 0x%x", addr);
+	else
+		fmt::append(ret, "Reservation Addr = none");
 
 	return ret;
 }
@@ -666,6 +670,7 @@ void ppu_thread::cpu_task()
 
 void ppu_thread::cpu_sleep()
 {
+	raddr = 0; // Clear reservation
 	vm::temporary_unlock(*this);
 	lv2_obj::awake(this);
 }

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1785,20 +1785,10 @@ bool spu_thread::process_mfc_cmd()
 		const u32 addr = ch_mfc_cmd.eal & -128;
 		const auto& data = vm::_ref<decltype(rdata)>(addr);
 
-		if (addr == raddr && g_cfg.core.spu_loop_detection && rtime == vm::reservation_acquire(addr, 128) && cmp_rdata(rdata, data))
+		if (addr == raddr && !g_use_rtm && g_cfg.core.spu_loop_detection && rtime == vm::reservation_acquire(addr, 128) && cmp_rdata(rdata, data))
 		{
-			if (g_use_rtm)
-			{
-				state += cpu_flag::wait;
-			}
-
 			// Spinning, might as well yield cpu resources
 			std::this_thread::yield();
-
-			if (test_stopped())
-			{
-				return false;
-			}
 		}
 
 		auto& dst = _ref<decltype(rdata)>(ch_mfc_cmd.lsa & 0x3ff80);

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1109,9 +1109,16 @@ void lv2_obj::sleep_unlocked(cpu_thread& thread, u64 timeout)
 		}
 
 		// Find and remove the thread
-		unqueue(g_ppu, ppu);
+		if (!unqueue(g_ppu, ppu))
+		{
+			// Already sleeping
+			ppu_log.trace("sleep(): called on already sleeping thread.");
+			return;
+		}
+
 		unqueue(g_pending, ppu);
 
+		ppu->raddr = 0; // Clear reservation
 		ppu->start_time = start_time;
 	}
 


### PR DESCRIPTION
* Loop detection in GETLLRAR was causing transactions failres on TSX path which are not present on non-TSX path.
* Clear PPU reservation on context switch, ensure that no more than 2 PPU reservations are active at a time as realhw.

Attempts to address #8133.