### PR TITLE
rsx_cache: Fix lock on protect_policy_one_page

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1938,7 +1938,7 @@ namespace rsx
 				continue;
 			}
 
-			rsx::vertex_base_type type = {};
+			rsx::vertex_base_type type;
 			s32 size = 0;
 			s32 attrib0 = 0;
 			s32 attrib1 = 0;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -72,12 +72,11 @@ namespace rsx
 					locked_range.start = block_start;
 					locked_range.end = block_end;
 				}
-
-				if (guard_policy == protect_policy_one_page)
-				{
-					// protect exactly one page
-					locked_range.set_length(4096u);
-				}
+			}
+			else if (guard_policy == protect_policy_one_page)
+			{
+				// protect exactly one page
+				locked_range.set_length(4096u);
 			}
 
 			AUDIT( (locked_range.start == page_start(range.start)) || (locked_range.start == next_page(range.start)) );

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -601,7 +601,7 @@ namespace rsx
 
 	static inline const u16 apply_inverse_resolution_scale(u16 value, bool clamp)
 	{
-		u16 result = value;
+		u16 result;
 
 		if (clamp)
 			result = static_cast<u16>(std::max((value * 100) / get_resolution_scale_percent(), 1));


### PR DESCRIPTION
`protect_policy_one_page` case was not being handled because it was nested in such a way that made it unreachable code