### PR TITLE
Add fs::error for when disk is full

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -129,6 +129,7 @@ static fs::error to_error(DWORD e)
 	case ERROR_DIR_NOT_EMPTY: return fs::error::notempty;
 	case ERROR_NOT_READY: return fs::error::noent;
 	case ERROR_FILENAME_EXCED_RANGE: return fs::error::toolong;
+	case ERROR_DISK_FULL: return fs::error::nospace;
 	default: return fs::error::unknown;
 	}
 }
@@ -170,6 +171,7 @@ static fs::error to_error(int e)
 	case ENOTEMPTY: return fs::error::notempty;
 	case EROFS: return fs::error::readonly;
 	case EISDIR: return fs::error::isdir;
+	case ENOSPC: return fs::error::nospace;
 	default: return fs::error::unknown;
 	}
 }
@@ -1818,6 +1820,7 @@ void fmt_class_string<fs::error>::format(std::string& out, u64 arg)
 		case fs::error::readonly: return "Read only";
 		case fs::error::isdir: return "Is a directory";
 		case fs::error::toolong: return "Path too long";
+		case fs::error::nospace: return "Not enough space on the device";
 		case fs::error::unknown: return "Unknown system error";
 		}
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -516,6 +516,7 @@ namespace fs
 		readonly,
 		isdir,
 		toolong,
+		nospace,
 		unknown
 	};
 


### PR DESCRIPTION
Should be less cryptic than 0x70 or 0x1C.