### PR TITLE
Minor sys_cond/sys_event fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -1300,7 +1300,7 @@ void camera_context::operator()()
 						data3 = 0;	// unused
 					}
 
-					if (queue->send(evt_data.source, CELL_CAMERA_FRAME_UPDATE, data2, data3)) [[likely]]
+					if (queue->send(evt_data.source, CELL_CAMERA_FRAME_UPDATE, data2, data3) == CELL_OK) [[likely]]
 					{
 						++frame_num;
 					}
@@ -1347,7 +1347,7 @@ void camera_context::send_attach_state(bool attached)
 
 			if (auto queue = lv2_event_queue::find(key))
 			{
-				if (queue->send(evt_data.source, attached ? CELL_CAMERA_ATTACH : CELL_CAMERA_DETACH, 0, 0)) [[likely]]
+				if (queue->send(evt_data.source, attached ? CELL_CAMERA_ATTACH : CELL_CAMERA_DETACH, 0, 0) == CELL_OK) [[likely]]
 				{
 					is_attached = attached;
 				}

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -123,7 +123,7 @@ error_code sys_cond_signal_all(ppu_thread& ppu, u32 cond_id)
 			cpu_thread* result = nullptr;
 			cond.waiters -= ::size32(cond.sq);
 
-			while (const auto cpu = cond.schedule<ppu_thread>(cond.sq, cond.mutex->protocol))
+			while (const auto cpu = cond.schedule<ppu_thread>(cond.sq, SYS_SYNC_PRIORITY))
 			{
 				if (cond.mutex->try_own(*cpu, cpu->id))
 				{

--- a/rpcs3/Emu/Cell/lv2/sys_config.h
+++ b/rpcs3/Emu/Cell/lv2/sys_config.h
@@ -180,7 +180,7 @@ private:
 	{
 		if (auto sptr = queue.lock())
 		{
-			return sptr->send(source, d1, d2, d3);
+			return sptr->send(source, d1, d2, d3) == CELL_OK;
 		}
 		return false;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -99,9 +99,9 @@ struct lv2_event_queue final : public lv2_obj
 	{
 	}
 
-	bool send(lv2_event);
+	CellError send(lv2_event);
 
-	bool send(u64 source, u64 d1, u64 d2, u64 d3)
+	CellError send(u64 source, u64 d1, u64 d2, u64 d3)
 	{
 		return send(std::make_tuple(source, d1, d2, d3));
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -377,8 +377,8 @@ error_code sys_event_flag_cancel(ppu_thread& ppu, u32 id, vm::ptr<u32> num)
 		// Set count
 		value = ::size32(flag->sq);
 
-		// Signal all threads to return CELL_ECANCELED
-		while (auto thread = flag->schedule<ppu_thread>(flag->sq, flag->protocol))
+		// Signal all threads to return CELL_ECANCELED (protocol does not matter)
+		for (auto thread : ::as_rvalue(std::move(flag->sq)))
 		{
 			auto& ppu = static_cast<ppu_thread&>(*thread);
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -231,7 +231,7 @@ error_code _sys_lwcond_signal_all(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 
 			u32 result = 0;
 
-			while (const auto cpu = cond.schedule<ppu_thread>(cond.sq, cond.protocol))
+			for (const auto cpu : ::as_rvalue(std::move(cond.sq)))
 			{
 				cond.waiters--;
 

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -363,7 +363,7 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 					});
 
 					// Protocol doesn't matter here since they are all enqueued anyways
-					while (auto cpu = rwlock->schedule<ppu_thread>(rwlock->rq, SYS_SYNC_FIFO))
+					for (auto cpu : ::as_rvalue(std::move(rwlock->rq)))
 					{
 						rwlock->append(cpu);
 					}
@@ -456,7 +456,7 @@ error_code sys_rwlock_wunlock(ppu_thread& ppu, u32 rw_lock_id)
 		}
 		else if (auto readers = rwlock->rq.size())
 		{
-			while (auto cpu = rwlock->schedule<ppu_thread>(rwlock->rq, SYS_SYNC_FIFO))
+			for (auto cpu : ::as_rvalue(std::move(rwlock->rq)))
 			{
 				rwlock->append(cpu);
 			}


### PR DESCRIPTION
* Fix forced lv2 event queue destruction, ~~empty sleep queue after awakening~~ add last existence check under mutex on event sending. This matters for event sending which either does not check for `lv2_event_queue::check` or does check but not under IDM mutex such as threaded SPU events sending "syscalls", sys_timer events, cellAudio events, etc.
Fixes a case where a waiter gets ECANCELLED and after it returnes from the syscall, in ppu r4-r7 registers for is changing, lv2_obj::awake if forced called on him.
For SPU thread a similar modification occurs in mailbox and cpu flags state even after the thread finished the syscall.
* Use SYS_SYNC_PRIORITY protocol in sys_cond_signal_all to signal threads, documentation says when signalling all threads the first thread to try acquiring the mutex is the one selected by the "kernel's scheduler order" which is the SYS_SYNC_PRIORITY protocol.
* Some other minor optimizations.