### PR TITLE
rsx: Fix alpha ref

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -742,7 +742,7 @@ namespace rsx
 	{
 		//TODO: Properly support alpha-to-coverage and alpha-to-one behavior in shaders
 		auto fragment_alpha_func = rsx::method_registers.alpha_func();
-		auto alpha_ref = rsx::method_registers.alpha_ref() / 255.f;
+		auto alpha_ref = rsx::method_registers.alpha_ref();
 		auto rop_control = rsx::method_registers.alpha_test_enabled()? 1u : 0u;
 
 		if (rsx::method_registers.msaa_alpha_to_coverage_enabled() && !backend_config.supports_hw_a2c)

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -2521,15 +2521,26 @@ struct registers_decoder<NV4097_SET_ALPHA_REF>
 	public:
 		decoded_type(u32 value) : value(value) {}
 
-		u8 alpha_ref() const
+		f32 alpha_ref8() const
 		{
-			return bf_decoder<0, 8>(value);
+			return bf_decoder<0, 8>(value) / 255.f;
+		}
+
+		f32 alpha_ref16() const
+		{
+			return rsx::decode_fp16(bf_decoder<0, 16>(value));
+		}
+
+		f32 alpha_ref32() const
+		{
+			return std::bit_cast<f32>(value);
 		}
 	};
 
 	static std::string dump(decoded_type &&decoded_values)
 	{
-		return "Alpha: ref = " + std::to_string(decoded_values.alpha_ref());
+		return "Alpha: ref unorm8 = " + std::to_string(decoded_values.alpha_ref8()) +
+			" f16 = " + std::to_string(decoded_values.alpha_ref16());
 	}
 };
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -654,7 +654,14 @@ namespace rsx
 
 		bool alpha_test_enabled() const
 		{
-			return decode<NV4097_SET_ALPHA_TEST_ENABLE>().alpha_test_enabled();
+			switch (surface_color())
+			{
+			case rsx::surface_color_format::x32:
+			case rsx::surface_color_format::w32z32y32x32:
+				return false;
+			default:
+				return decode<NV4097_SET_ALPHA_TEST_ENABLE>().alpha_test_enabled();
+			}
 		}
 
 		bool stencil_test_enabled() const
@@ -1104,9 +1111,18 @@ namespace rsx
 			return decode<NV4097_SET_POINT_SPRITE_CONTROL>().enabled();
 		}
 
-		u8 alpha_ref() const
+		f32 alpha_ref() const
 		{
-			return decode<NV4097_SET_ALPHA_REF>().alpha_ref();
+			switch (surface_color())
+			{
+			case rsx::surface_color_format::x32:
+			case rsx::surface_color_format::w32z32y32x32:
+				return decode<NV4097_SET_ALPHA_REF>().alpha_ref32();
+			case rsx::surface_color_format::w16z16y16x16:
+				return decode<NV4097_SET_ALPHA_REF>().alpha_ref16();
+			default:
+				return decode<NV4097_SET_ALPHA_REF>().alpha_ref8();
+			}
 		}
 
 		surface_target surface_color_target() const


### PR DESCRIPTION
A very strange observation I made when working on https://github.com/RPCS3/rpcs3/issues/4172 was that the game is clamping alpha output to not go below 0.1 but alpha test setup is checking for alpha greater than 0 causing all pixels to pass. Inspecting the RSX replay dump shows that the game is setting fp16 values in alpha ref which means the ROP output register is likely compared directly to the alpha ref register directly and therefore format must be converted to match ROP format.
This allows for alpha ref to be greater than 1 or even negative values when rendering into a floating point texture.
f32 rendering is known to not work correctly with blending and is of no consequence.

Fixes https://github.com/RPCS3/rpcs3/issues/4172