### PR TITLE
Don't load custom configs when adding games

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -848,8 +848,8 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		m_title_id = psf::get_string(_psf, "TITLE_ID");
 		m_cat = psf::get_string(_psf, "CATEGORY");
 
-		std::string version_app  = psf::get_string(_psf, "APP_VER", "Unknown");
-		std::string version_disc = psf::get_string(_psf, "VERSION", "Unknown");
+		const std::string version_app  = psf::get_string(_psf, "APP_VER", "Unknown");
+		const std::string version_disc = psf::get_string(_psf, "VERSION", "Unknown");
 
 		if (!_psf.empty() && m_cat.empty())
 		{
@@ -862,7 +862,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		sys_log.notice("Category: %s", GetCat());
 		sys_log.notice("Version: %s / %s", version_app, version_disc);
 
-		if (!force_global_config)
+		if (!add_only && !force_global_config)
 		{
 			const std::string config_path_new = GetCustomConfigPath(m_title_id);
 			const std::string config_path_old = GetCustomConfigPath(m_title_id, true);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -59,8 +59,8 @@ class Emulator final
 
 	EmuCallbacks m_cb;
 
-	atomic_t<u64> m_pause_start_time; // set when paused
-	atomic_t<u64> m_pause_amend_time; // increased when resumed
+	atomic_t<u64> m_pause_start_time{0}; // set when paused
+	atomic_t<u64> m_pause_amend_time{0}; // increased when resumed
 
 	std::string m_path;
 	std::string m_path_old;


### PR DESCRIPTION
We should always use the global config when adding games.
The VFS stuff for example is only supposed to be read from the global config.
There is no need to load any custom config anyway.