### PR TITLE
rsx: Vertex decompiler fixup

### DIFF
--- a/rpcs3/Emu/RSX/Common/Interpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Common/Interpreter/VertexInterpreter.glsl
@@ -239,9 +239,13 @@ void write_sca(in float value)
 
 	if (d3.sca_dst_tmp == 0x3f)
 	{
-		if (d3.dst != 0x1f)
+		if (!d0.vec_result)
 		{
 			reg_mov(dest[d3.dst], vec4(value), d3.sca_mask);
+		}
+		else
+		{
+			reg_mov(cc[d0.cond_reg_sel_1], vec4(value), d3.sca_mask);
 		}
 	}
 	else
@@ -266,10 +270,7 @@ void write_vec(in vec4 value)
 
 	if (d0.dst_tmp == 0x3f && !d0.vec_result)
 	{
-		if (d0.cond_update_enable_1)
-		{
-			reg_mov(cc[d0.cond_reg_sel_1], value, write_mask);
-		}
+		reg_mov(cc[d0.cond_reg_sel_1], value, write_mask);
 	}
 	else
 	{

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -178,7 +178,7 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 		}
 	};
 
-	if (g_cfg.video.log_programs)
+	if (g_cfg.video.debug_program_analyser)
 	{
 		fs::file dump(fs::get_cache_dir() + "shaderlog/vp_analyser.bin", fs::rewrite);
 		dump.write(&entry, 4);

--- a/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/VertexProgramDecompiler.cpp
@@ -45,7 +45,7 @@ std::string VertexProgramDecompiler::GetDST(bool is_sca)
 	// ARL writes to special integer registers
 	const bool is_address_reg = !is_sca && (d1.vec_opcode == RSX_VEC_OPCODE_ARL);
 	const auto tmp_index = is_sca ? d3.sca_dst_tmp : d0.dst_tmp;
-	const bool is_result = is_sca ? (tmp_index == 0x3f) : d0.vec_result;
+	const bool is_result = is_sca ? !d0.vec_result : d0.vec_result;
 
 	if (is_result)
 	{

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -129,6 +129,7 @@ struct cfg_root : cfg::node
 		cfg::_bool multithreaded_rsx{ this, "Multithreaded RSX", false };
 		cfg::_bool relaxed_zcull_sync{ this, "Relaxed ZCULL Sync", false };
 		cfg::_bool enable_3d{ this, "Enable 3D", false };
+		cfg::_bool debug_program_analyser{ this, "Debug Program Analyser", false };
 		cfg::_int<1, 8> consecutive_frames_to_draw{ this, "Consecutive Frames To Draw", 1, true};
 		cfg::_int<1, 8> consecutive_frames_to_skip{ this, "Consecutive Frames To Skip", 1, true};
 		cfg::_int<50, 800> resolution_scale_percent{ this, "Resolution Scale", 100 };


### PR DESCRIPTION
Disables writing to output registers from SCA instructions. A bit to toggle output from SCA has not been identified, but there is evidence of titles where dst tmp write is invalid but vector output bit is set. This means there are only two options:
a. SCA opcodes cannot write to output.
b. SCA opcodes share the vector output bit in exclusive fashion.
I am not able to find any games that write to output mask using SCA opcodes, so please test this for regressions, it can break everything.

EDIT: It appears option b is the correct one. Option a causes some regressions in Portal 2, GOW3, etc

Fixes https://github.com/RPCS3/rpcs3/issues/4196