### PR TITLE
vk: Disable spirv optimizations

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
@@ -182,12 +182,12 @@ namespace vk
 				options.optimizeSize = true;
 				glslang::GlslangToSpv(*program.getIntermediate(lang), spv, &options);
 
-				// Now we optimize
-				spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_0);
-				optimizer.RegisterPass(spvtools::CreateUnifyConstantPass());      // Remove duplicate constants
-				optimizer.RegisterPass(spvtools::CreateMergeReturnPass());        // Huge savings in vertex interpreter and likely normal vertex shaders
-				optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());      // Remove dead code
-				optimizer.Run(spv.data(), spv.size(), &spv);
+				// Now we optimize (disabled)
+				//spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_0);
+				//optimizer.RegisterPass(spvtools::CreateUnifyConstantPass());      // Remove duplicate constants
+				//optimizer.RegisterPass(spvtools::CreateMergeReturnPass());        // Huge savings in vertex interpreter and likely normal vertex shaders
+				//optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());      // Remove dead code
+				//optimizer.Run(spv.data(), spv.size(), &spv);
 			}
 		}
 		else


### PR DESCRIPTION
- Causes crashing in drivers when compiling shaders. Needs further investigation.

Fixes https://github.com/RPCS3/rpcs3/issues/8170