### PR TITLE
sys_spu: Improve sys_spu_thread_get_exit_status and reset group exit status in group start

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -599,6 +599,8 @@ public:
 
 	std::array<std::pair<u32, std::weak_ptr<lv2_event_queue>>, 32> spuq; // Event Queue Keys for SPU Thread
 	std::weak_ptr<lv2_event_queue> spup[64]; // SPU Ports
+	spu_channel exit_status{}; // Threaded SPU exit status (not a channel, but the interface fits)
+	u32 last_exit_status; // Value to be written in exit_status after checking group termination
 
 	const u32 index; // SPU index
 	const u32 offset; // SPU LS offset

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -453,7 +453,7 @@ error_code sys_spu_thread_set_argument(ppu_thread& ppu, u32 id, vm::ptr<sys_spu_
 	return CELL_OK;
 }
 
-error_code sys_spu_thread_get_exit_status(ppu_thread& ppu, u32 id, vm::ptr<u32> status)
+error_code sys_spu_thread_get_exit_status(ppu_thread& ppu, u32 id, vm::ptr<s32> status)
 {
 	vm::temporary_unlock(ppu);
 
@@ -466,9 +466,11 @@ error_code sys_spu_thread_get_exit_status(ppu_thread& ppu, u32 id, vm::ptr<u32> 
 		return CELL_ESRCH;
 	}
 
-	if (thread->status_npc.load().status & SPU_STATUS_STOPPED_BY_STOP)
+	const u64 exit_status = thread->exit_status.data.load();
+
+	if (exit_status & spu_channel::bit_count)
 	{
-		*status = thread->ch_out_mbox.get_value();
+		*status = static_cast<s32>(exit_status);
 		return CELL_OK;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -691,6 +691,7 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 	const u32 max_threads = group->max_run;
 
 	group->join_state = 0;
+	group->exit_status = 0;
 	group->running = max_threads;
 	group->set_terminate = false;
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -68,6 +68,16 @@ enum : s32
 	SYS_SPU_SEGMENT_TYPE_INFO = 4,
 };
 
+enum : u32
+{
+	SYS_SPU_THREAD_STOP_YIELD                = 0x0100,
+	SYS_SPU_THREAD_STOP_GROUP_EXIT           = 0x0101,
+	SYS_SPU_THREAD_STOP_THREAD_EXIT          = 0x0102,
+	SYS_SPU_THREAD_STOP_RECEIVE_EVENT        = 0x0110,
+	SYS_SPU_THREAD_STOP_TRY_RECEIVE_EVENT    = 0x0111,
+	SYS_SPU_THREAD_STOP_SWITCH_SYSTEM_MODULE = 0x0120,
+};
+
 struct sys_spu_thread_group_attribute
 {
 	be_t<u32> nsize; // name length including NULL terminator
@@ -367,7 +377,7 @@ error_code sys_spu_thread_connect_event(ppu_thread&, u32 id, u32 eq, u32 et, u8 
 error_code sys_spu_thread_disconnect_event(ppu_thread&, u32 id, u32 event_type, u8 spup);
 error_code sys_spu_thread_bind_queue(ppu_thread&, u32 id, u32 spuq, u32 spuq_num);
 error_code sys_spu_thread_unbind_queue(ppu_thread&, u32 id, u32 spuq_num);
-error_code sys_spu_thread_get_exit_status(ppu_thread&, u32 id, vm::ptr<u32> status);
+error_code sys_spu_thread_get_exit_status(ppu_thread&, u32 id, vm::ptr<s32> status);
 error_code sys_spu_thread_recover_page_fault(ppu_thread&, u32 id);
 
 error_code sys_raw_spu_create(ppu_thread&, vm::ptr<u32> id, vm::ptr<void> attr);


### PR DESCRIPTION
* Fix ESTAT check of sys_spu_thread_get_exit_status, its enough for exit status to be written once by sys_spu_thread_exit for it to report CELL_OK and last thread exit status as long as the group lives. even after the SPU is restarted and currently running.
* When the last SPU thread in the group exits by sys_spu_thread_exit, set the exit status in conjunction with group state changes, I do not know if this is guarenteed by realhw as well but its better to be safe.
* Write 0 into the group exit status when it's (re)started, this affects the value returned in sys_spu_thread_group_join when SYS_SPU_THREAD_GROUP_JOIN_ALL_THREADS_EXIT is the termination cause.

Testcase : https://github.com/elad335/myps3tests/tree/master/spu_tests/sys_spu_thread_get_exit_status

Results on current master :

```
sys_spu_thread_get_exit_status(error ESTAT, line=58)
thread status: 0x80000000, group status: 0x1, cause: 0x1
sys_spu_thread_get_exit_status(error ok, line=58)
thread status: 0x2, group status: 0x1, cause: 0x2
sys_spu_thread_get_exit_status(error ESTAT, line=58)
thread status: 0x80000000, group status: 0x3, cause: 0x1
sys_spu_thread_get_exit_status(error ok, line=58)
thread status: 0x4, group status: 0x3, cause: 0x2
sys_spu_thread_get_exit_status(error ESTAT, line=58)
thread status: 0x80000000, group status: 0x5, cause: 0x1
sys_spu_thread_get_exit_status(error ok, line=58)
thread status: 0x6, group status: 0x5, cause: 0x2
```

Results on pull request and realhw:
```
sys_spu_thread_get_exit_status(error ESTAT, line=68)
thread status: 0x80000000, group status: 0x1, cause: 0x1
sys_spu_thread_get_exit_status(error ok, line=68)
thread status: 0x2, group status: 0x0, cause: 0x2
sys_spu_thread_get_exit_status(error ok, line=68)
thread status: 0x2, group status: 0x3, cause: 0x1
sys_spu_thread_get_exit_status(error ok, line=68)
thread status: 0x4, group status: 0x0, cause: 0x2
sys_spu_thread_get_exit_status(error ok, line=68)
thread status: 0x4, group status: 0x5, cause: 0x1
sys_spu_thread_get_exit_status(error ok, line=68)
thread status: 0x6, group status: 0x0, cause: 0x2
sys_spu_thread_get_exit_status(error ok, line=60)
thread status: 0x6, group status: 0x6, cause: 0x4
sys_spu_thread_get_exit_status(error ok, line=60)
thread status: 0x6, group status: 0x0, cause: 0x2
```

I used all the 3 ways to terminate spu group in the test.