### PR TITLE
rsx: Fix NOP shader passing

### DIFF
--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -340,6 +340,8 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 		// Check for opcode high bit which indicates a branch instructions (opcode 0x40...0x45)
 		if (inst._u32[2] & (1 << 23))
 		{
+			// NOTE: Jump instructions are not yet proved to work outside of loops and if/else blocks
+			// Otherwise we would need to follow the execution chain
 			result.has_branch_instructions = true;
 		}
 		else
@@ -348,7 +350,9 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 			if (opcode)
 			{
 				if (result.program_start_offset == umax)
+				{
 					result.program_start_offset = index * 16;
+				}
 
 				switch (opcode)
 				{
@@ -402,7 +406,8 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 			if (result.program_start_offset == umax)
 			{
 				result.program_start_offset = index * 16;
-				result.program_constants_buffer_length = 16;
+				result.program_ucode_length = 16;
+				result.is_nop_shader = true;
 			}
 
 			break;

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -53,6 +53,7 @@ namespace program_hash_util
 
 			bool has_pack_instructions;
 			bool has_branch_instructions;
+			bool is_nop_shader;           // Does this affect Z-pass testing???
 		};
 
 		/**


### PR DESCRIPTION
NOP shaders are used to stub rendering when a pass is supposed to be disabled. It is unclear whether they affect other parts of the pipeline such as Z pass testing.

Fixes https://github.com/RPCS3/rpcs3/issues/8170