### PR TITLE
sys_spu: Minor cleanup of group termination process

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -983,7 +983,6 @@ void spu_thread::cpu_stop()
 		{
 			{
 				std::lock_guard lock(group->mutex);
-				group->stop_count++;
 				group->run_state = SPU_THREAD_GROUP_STATUS_INITIALIZED;
 
 				if (!group->join_state)
@@ -1010,17 +1009,20 @@ void spu_thread::cpu_stop()
 					exit_status.set_value(last_exit_status);
 				}
 
+				group->stop_count++;
+
 				if (const auto ppu = std::exchange(group->waiter, nullptr))
 				{
 					// Send exit status directly to the joining thread
 					ppu->gpr[4] = group->join_state;
 					ppu->gpr[5] = group->exit_status;
 					group->join_state.release(0);
+					lv2_obj::awake(ppu);
 				}
 			}
 
 			// Notify on last thread stopped
-			group->cond.notify_all();
+			group->stop_count.notify_all();
 		}
 		else if (status_npc.load().status >> 16 == SYS_SPU_THREAD_STOP_THREAD_EXIT)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -410,11 +410,6 @@ error_code sys_event_flag_get(ppu_thread& ppu, u32 id, vm::ptr<u64> flags)
 
 	sys_event_flag.trace("sys_event_flag_get(id=0x%x, flags=*0x%x)", id, flags);
 
-	if (!flags)
-	{
-		return CELL_EFAULT;
-	}
-
 	const auto flag = idm::check<lv2_obj, lv2_event_flag>(id, [](lv2_event_flag& flag)
 	{
 		return +flag.pattern;
@@ -422,8 +417,13 @@ error_code sys_event_flag_get(ppu_thread& ppu, u32 id, vm::ptr<u64> flags)
 
 	if (!flag)
 	{
-		*flags = 0;
+		if (flags) *flags = 0;
 		return CELL_ESRCH;
+	}
+
+	if (!flags)
+	{
+		return CELL_EFAULT;
 	}
 
 	*flags = flag.ret;

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -265,11 +265,6 @@ error_code sys_semaphore_get_value(ppu_thread& ppu, u32 sem_id, vm::ptr<s32> cou
 
 	sys_semaphore.trace("sys_semaphore_get_value(sem_id=0x%x, count=*0x%x)", sem_id, count);
 
-	if (!count)
-	{
-		return CELL_EFAULT;
-	}
-
 	const auto sema = idm::check<lv2_obj, lv2_sema>(sem_id, [](lv2_sema& sema)
 	{
 		return std::max<s32>(0, sema.val);
@@ -278,6 +273,11 @@ error_code sys_semaphore_get_value(ppu_thread& ppu, u32 sem_id, vm::ptr<s32> cou
 	if (!sema)
 	{
 		return CELL_ESRCH;
+	}
+
+	if (!count)
+	{
+		return CELL_EFAULT;
 	}
 
 	*count = sema.ret;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -482,11 +482,11 @@ error_code sys_spu_thread_get_exit_status(ppu_thread& ppu, u32 id, vm::ptr<s32> 
 		return CELL_ESRCH;
 	}
 
-	const u64 exit_status = thread->exit_status.data.load();
+	u32 data;
 
-	if (exit_status & spu_channel::bit_count)
+	if (thread->exit_status.try_read(data))
 	{
-		*status = static_cast<s32>(exit_status);
+		*status = static_cast<s32>(data);
 		return CELL_OK;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -978,10 +978,11 @@ error_code sys_spu_thread_group_terminate(ppu_thread& ppu, u32 id, s32 value)
 	{
 		// Wait for termination, only then return error code
 		const u64 last_stop = group->stop_count;
+		lock.unlock();
 
 		while (group->stop_count == last_stop)
 		{
-			group->cond.wait(lock);
+			group->stop_count.wait(last_stop);
 		}
 
 		return CELL_ESTAT;
@@ -1010,10 +1011,11 @@ error_code sys_spu_thread_group_terminate(ppu_thread& ppu, u32 id, s32 value)
 
 	// Wait until the threads are actually stopped
 	const u64 last_stop = group->stop_count;
+	lock.unlock();
 
 	while (group->stop_count == last_stop)
 	{
-		group->cond.wait(lock);
+		group->stop_count.wait(last_stop);
 	}
 
 	return CELL_OK;
@@ -1065,28 +1067,23 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 		else
 		{
 			// Subscribe to receive status in r4-r5
-			ppu.gpr[4] = 0;
 			group->waiter = &ppu;
 		}
 
 		lv2_obj::sleep(ppu);
+		lock.unlock();
 
-		while (!ppu.gpr[4])
+		while (!ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			if (ppu.is_stopped())
 			{
 				return 0;
 			}
 
-			group->cond.wait(lock);
+			thread_ctrl::wait();
 		}
 	}
 	while (0);
-
-	if (ppu.test_stopped())
-	{
-		return 0;
-	}
 
 	if (!cause)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -278,7 +278,6 @@ struct lv2_spu_group
 	atomic_t<s32> exit_status; // SPU Thread Group Exit Status
 	atomic_t<u32> join_state; // flags used to detect exit cause and signal
 	atomic_t<u32> running; // Number of running threads
-	cond_variable cond; // used to signal waiting PPU thread
 	atomic_t<u64> stop_count;
 	class ppu_thread* waiter = nullptr;
 	bool set_terminate = false;


### PR DESCRIPTION
* After #8182, the conditional variable is no longer needed and can be replaced with waitable atomics signaling and direct lv2_obj::awake for joining thread so it won't need to awake itself manually using ppu.test_stopped() afterwards.
* Add short sleep in sys_spu_thread_group_terminate to emulate PPU waiting on a sys_cond_t for a termination signal as realhw.
* Implement spu_channel_(4_t)::try_read(), reading the channel's content without modification, cleaning up some code.
* Minor EFAULT fix in sys_semaphore_get_value/sys_event_flag_get.