### PR TITLE
PPU interpreters: Implement AltiVec (vector) NaN precedence and data preservation

### DIFF
--- a/Utilities/BEType.h
+++ b/Utilities/BEType.h
@@ -312,6 +312,16 @@ union alignas(16) v128
 		return fromV(_mm_cmpeq_epi32(left.vi, right.vi));
 	}
 
+	static inline v128 eq32f(const v128& left, const v128& right)
+	{
+		return fromF(_mm_cmpeq_ps(left.vf, right.vf));
+	}
+
+	static inline v128 eq64f(const v128& left, const v128& right)
+	{
+		return fromD(_mm_cmpeq_pd(left.vd, right.vd));
+	}
+
 	bool operator==(const v128& right) const
 	{
 		return _u64[0] == right._u64[0] && _u64[1] == right._u64[1];


### PR DESCRIPTION
If any of the operands is a NaN of any kind it is 'quited' (MSB of fraction is set) and returned with the following ordering of selection between the NaNs: VA, VB, VC, result of operation.
The resulted NaN of operation is returned as a NaN if none of the arguments is a NaN.
Sign and fraction bits (other than NaN's signaling bit) are preserved across operands in all instructions.
It's not implemented at PPU LLVM atm.
 