### PR TITLE
Some minor fixes and refactoring

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -238,7 +238,7 @@ void fmt_class_string<bool>::format(std::string& out, u64 arg)
 template <>
 void fmt_class_string<v128>::format(std::string& out, u64 arg)
 {
-	const v128& vec = get_object(arg);
+	const v128 vec = get_object(arg);
 	fmt::append(out, "0x%016llx%016llx", vec._u64[1], vec._u64[0]);
 }
 

--- a/rpcs3/Emu/Cell/Modules/sysPrxForUser.h
+++ b/rpcs3/Emu/Cell/Modules/sysPrxForUser.h
@@ -63,7 +63,7 @@ error_code sys_lwcond_create(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, vm::
 error_code sys_lwcond_destroy(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond);
 error_code sys_lwcond_signal(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond);
 error_code sys_lwcond_signal_all(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond);
-error_code sys_lwcond_signal_to(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond, u32 ppu_thread_id);
+error_code sys_lwcond_signal_to(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond, u64 ppu_thread_id);
 error_code sys_lwcond_wait(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond, u64 timeout);
 
 error_code sys_ppu_thread_create(ppu_thread& ppu, vm::ptr<u64> thread_id, u32 entry, u64 arg, s32 prio, u32 stacksize, u64 flags, vm::cptr<char> threadname);

--- a/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
@@ -59,7 +59,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 
 	if ((lwmutex->attribute & SYS_SYNC_ATTR_PROTOCOL_MASK) == SYS_SYNC_RETRY)
 	{
-		return _sys_lwcond_signal(ppu, lwcond->lwcond_queue, 0, -1, 2);
+		return _sys_lwcond_signal(ppu, lwcond->lwcond_queue, 0, UINT32_MAX, 2);
 	}
 
 	if (lwmutex->vars.owner.load() == ppu.id)
@@ -68,7 +68,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 		lwmutex->all_info++;
 
 		// call the syscall
-		if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, -1, 1))
+		if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, UINT32_MAX, 1))
 		{
 			if (ppu.test_stopped())
 			{
@@ -96,7 +96,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 		}
 
 		// call the syscall
-		return _sys_lwcond_signal(ppu, lwcond->lwcond_queue, 0, -1, 2);
+		return _sys_lwcond_signal(ppu, lwcond->lwcond_queue, 0, UINT32_MAX, 2);
 	}
 
 	// if locking succeeded
@@ -107,7 +107,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 	});
 
 	// call the syscall
-	if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, -1, 3))
+	if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, UINT32_MAX, 3))
 	{
 		if (ppu.test_stopped())
 		{
@@ -202,9 +202,9 @@ error_code sys_lwcond_signal_all(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 	return res;
 }
 
-error_code sys_lwcond_signal_to(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u32 ppu_thread_id)
+error_code sys_lwcond_signal_to(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u64 ppu_thread_id)
 {
-	sysPrxForUser.trace("sys_lwcond_signal_to(lwcond=*0x%x, ppu_thread_id=0x%x)", lwcond, ppu_thread_id);
+	sysPrxForUser.trace("sys_lwcond_signal_to(lwcond=*0x%x, ppu_thread_id=0x%llx)", lwcond, ppu_thread_id);
 
 	if (g_cfg.core.hle_lwmutex)
 	{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -446,7 +446,8 @@ std::string ppu_thread::dump_regs() const
 
 	for (uint i = 0; i < 32; ++i)
 	{
-		fmt::append(ret, "v%d%s: %s [x: %g y: %g z: %g w: %g]\n", i, i <= 9 ? " " : "", vr[i], vr[i]._f[3], vr[i]._f[2], vr[i]._f[1], vr[i]._f[0]);
+		const auto _vr = vr[i];
+		fmt::append(ret, "v%d%s: %s [x: %g y: %g z: %g w: %g]\n", i, i <= 9 ? " " : "", _vr, _vr._f[3], _vr._f[2], _vr._f[1], _vr._f[0]);
 	}
 
 	fmt::append(ret, "CR: 0x%08x\n", cr.pack());

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -671,7 +671,6 @@ void ppu_thread::cpu_task()
 
 void ppu_thread::cpu_sleep()
 {
-	raddr = 0; // Clear reservation
 	vm::temporary_unlock(*this);
 	lv2_obj::awake(this);
 }

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -629,8 +629,8 @@ public:
 	atomic_t<status_npc_sync_var> status_npc;
 	std::array<spu_int_ctrl_t, 3> int_ctrl; // SPU Class 0, 1, 2 Interrupt Management
 
-	std::array<std::pair<u32, std::weak_ptr<lv2_event_queue>>, 32> spuq; // Event Queue Keys for SPU Thread
-	std::weak_ptr<lv2_event_queue> spup[64]; // SPU Ports
+	std::array<std::pair<u32, std::shared_ptr<lv2_event_queue>>, 32> spuq; // Event Queue Keys for SPU Thread
+	std::shared_ptr<lv2_event_queue> spup[64]; // SPU Ports
 	spu_channel exit_status{}; // Threaded SPU exit status (not a channel, but the interface fits)
 	atomic_t<u32> last_exit_status; // Value to be written in exit_status after checking group termination
 

--- a/rpcs3/Emu/Cell/lv2/sys_config.h
+++ b/rpcs3/Emu/Cell/lv2/sys_config.h
@@ -174,13 +174,13 @@ private:
 	u32 idm_id;
 
 	// queue for service/io event notifications
-	const std::weak_ptr<lv2_event_queue> queue;
+	const std::shared_ptr<lv2_event_queue> queue;
 
 	bool send_queue_event(u64 source, u64 d1, u64 d2, u64 d3) const
 	{
-		if (auto sptr = queue.lock())
+		if (queue)
 		{
-			return sptr->send(source, d1, d2, d3) == 0;
+			return queue->send(source, d1, d2, d3) == 0;
 		}
 		return false;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -110,8 +110,10 @@ struct lv2_event_queue final : public lv2_obj
 	static std::shared_ptr<lv2_event_queue> find(u64 ipc_key);
 
 	// Check queue ptr validity (use 'exists' member)
-	static bool check(const std::weak_ptr<lv2_event_queue>&);
-	static bool check(const std::shared_ptr<lv2_event_queue>&);
+	static inline bool check(const std::shared_ptr<lv2_event_queue>& sptr)
+	{
+		return sptr && sptr->exists;
+	}
 };
 
 struct lv2_event_port final : lv2_obj
@@ -121,7 +123,7 @@ struct lv2_event_port final : lv2_obj
 	const s32 type; // Port type, must be SYS_EVENT_PORT_LOCAL
 	const u64 name; // Event source (generated from id and process id if not set)
 
-	std::weak_ptr<lv2_event_queue> queue; // Event queue this port is connected to
+	std::shared_ptr<lv2_event_queue> queue; // Event queue this port is connected to
 
 	lv2_event_port(s32 type, u64 name)
 		: type(type)

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.h
@@ -50,6 +50,6 @@ class ppu_thread;
 
 error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmutex_id, vm::ptr<sys_lwcond_t> control, u64 name);
 error_code _sys_lwcond_destroy(ppu_thread& ppu, u32 lwcond_id);
-error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u32 ppu_thread_id, u32 mode);
+error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u64 ppu_thread_id, u32 mode);
 error_code _sys_lwcond_signal_all(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u32 mode);
 error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u64 timeout);

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -727,13 +727,13 @@ error_code sys_mmapper_enable_page_fault_notification(ppu_thread& ppu, u32 start
 	return CELL_OK;
 }
 
-error_code mmapper_thread_recover_page_fault(u32 id)
+error_code mmapper_thread_recover_page_fault(cpu_thread* cpu)
 {
 	// We can only wake a thread if it is being suspended for a page fault.
 	auto pf_events = g_fxo->get<page_fault_event_entries>();
 	{
 		std::lock_guard pf_lock(pf_events->pf_mutex);
-		auto pf_event_ind = pf_events->events.find(id);
+		const auto pf_event_ind = pf_events->events.find(cpu);
 
 		if (pf_event_ind == pf_events->events.end())
 		{
@@ -744,6 +744,15 @@ error_code mmapper_thread_recover_page_fault(u32 id)
 		pf_events->events.erase(pf_event_ind);
 	}
 
-	pf_events->cond.notify_all();
+	if (cpu->id_type() == 1u)
+	{
+		lv2_obj::awake(cpu);
+	}
+	else
+	{
+		cpu->state += cpu_flag::signal;
+		cpu->notify();
+	}
+
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.h
@@ -42,11 +42,12 @@ enum : u64
 	SYS_MEMORY_PAGE_FAULT_TYPE_RAW_SPU     = 0x2ULL,
 };
 
+struct lv2_event_queue;
+
 struct page_fault_notification_entry
 {
 	u32 start_addr; // Starting address of region to monitor.
-	u32 event_queue_id; // Queue to be notified.
-	u32 port_id; // Port used to notify the queue.
+	std::shared_ptr<lv2_event_queue> port; // Port used to notify the queue.
 };
 
 // Used to hold list of queues to be notified on page fault event.

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.h
@@ -59,10 +59,9 @@ struct page_fault_notification_entries
 
 struct page_fault_event_entries
 {
-	// First = thread id, second = addr
-	std::unordered_map<u32, u32> events;
+	// First = thread, second = addr
+	std::unordered_map<class cpu_thread*, u32> events;
 	shared_mutex pf_mutex;
-	cond_variable cond;
 };
 
 struct mmapper_unk_entry_struct0
@@ -77,7 +76,7 @@ struct mmapper_unk_entry_struct0
 // Aux
 class ppu_thread;
 
-error_code mmapper_thread_recover_page_fault(u32 id);
+error_code mmapper_thread_recover_page_fault(cpu_thread* cpu);
 
 // SysCalls
 error_code sys_mmapper_allocate_address(ppu_thread&, u64 size, u64 flags, u64 alignment, vm::ptr<u32> alloc_addr);

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -551,7 +551,7 @@ error_code sys_ppu_thread_recover_page_fault(u32 thread_id)
 		return CELL_ESRCH;
 	}
 
-	return mmapper_thread_recover_page_fault(thread_id);
+	return mmapper_thread_recover_page_fault(thread.ptr.get());
 }
 
 error_code sys_ppu_thread_get_page_fault_context(u32 thread_id, vm::ptr<sys_ppu_thread_icontext_t> ctxt)
@@ -572,7 +572,7 @@ error_code sys_ppu_thread_get_page_fault_context(u32 thread_id, vm::ptr<sys_ppu_
 	auto pf_events = g_fxo->get<page_fault_event_entries>();
 	std::shared_lock lock(pf_events->pf_mutex);
 
-	const auto evt = pf_events->events.find(thread_id);
+	const auto evt = pf_events->events.find(thread.ptr.get());
 	if (evt == pf_events->events.end())
 	{
 		return CELL_EINVAL;

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -122,10 +122,12 @@ struct RsxDisplayInfo
 	}
 };
 
+struct lv2_event_queue;
+
 struct lv2_rsx_config
 {
 	u32 memory_size{};
-	u32 rsx_event_port{};
+	std::shared_ptr<lv2_event_queue> event_port;
 	u32 context_base{};
 	u32 device_addr{};
 	u32 driver_info{};

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1787,7 +1787,7 @@ error_code sys_spu_thread_recover_page_fault(ppu_thread& ppu, u32 id)
 		return CELL_ESRCH;
 	}
 
-	return mmapper_thread_recover_page_fault(id);
+	return mmapper_thread_recover_page_fault(thread);
 }
 
 error_code sys_raw_spu_recover_page_fault(ppu_thread& ppu, u32 id)
@@ -1803,7 +1803,7 @@ error_code sys_raw_spu_recover_page_fault(ppu_thread& ppu, u32 id)
 		return CELL_ESRCH;
 	}
 
-	return mmapper_thread_recover_page_fault(id);
+	return mmapper_thread_recover_page_fault(thread.get());
 }
 
 error_code sys_raw_spu_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<void> attr)

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1567,8 +1567,7 @@ error_code sys_spu_thread_bind_queue(ppu_thread& ppu, u32 id, u32 spuq, u32 spuq
 	for (auto& v : thread->spuq)
 	{
 		// Check if the entry is assigned at all
-		if (const decltype(v.second) test{};
-			!v.second.owner_before(test) && !test.owner_before(v.second))
+		if (!v.second)
 		{
 			if (!q)
 			{
@@ -1578,8 +1577,7 @@ error_code sys_spu_thread_bind_queue(ppu_thread& ppu, u32 id, u32 spuq, u32 spuq
 			continue;
 		}
 
-		if (v.first == spuq_num ||
-			(!v.second.owner_before(queue) && !queue.owner_before(v.second)))
+		if (v.first == spuq_num || v.second == queue)
 		{
 			return CELL_EBUSY;
 		}
@@ -1617,8 +1615,7 @@ error_code sys_spu_thread_unbind_queue(ppu_thread& ppu, u32 id, u32 spuq_num)
 			continue;
 		}
 
-		if (const decltype(v.second) test{};
-			!v.second.owner_before(test) && !test.owner_before(v.second))
+		if (!v.second)
 		{
 			continue;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1893,6 +1893,7 @@ error_code sys_isolated_spu_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<voi
 	sys_spu_image img;
 	img.load(obj);
 
+	// TODO: Do not create ID
 	auto image_info = idm::get<lv2_obj, lv2_spu_image>(img.entry_point);
 	img.deploy(ls_addr, image_info->segs.get_ptr(), image_info->nsegs);
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -288,9 +288,9 @@ struct lv2_spu_group
 	std::array<std::pair<sys_spu_image, std::vector<sys_spu_segment>>, 8> imgs; // SPU Images
 	std::array<std::array<u64, 4>, 8> args; // SPU Thread Arguments
 
-	std::weak_ptr<lv2_event_queue> ep_run; // port for SYS_SPU_THREAD_GROUP_EVENT_RUN events
-	std::weak_ptr<lv2_event_queue> ep_exception; // TODO: SYS_SPU_THREAD_GROUP_EVENT_EXCEPTION
-	std::weak_ptr<lv2_event_queue> ep_sysmodule; // TODO: SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE
+	std::shared_ptr<lv2_event_queue> ep_run; // port for SYS_SPU_THREAD_GROUP_EVENT_RUN events
+	std::shared_ptr<lv2_event_queue> ep_exception; // TODO: SYS_SPU_THREAD_GROUP_EVENT_EXCEPTION
+	std::shared_ptr<lv2_event_queue> ep_sysmodule; // TODO: SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE
 
 	lv2_spu_group(std::string name, u32 num, s32 prio, s32 type, lv2_memory_container* ct, bool uses_scheduler, u32 mem_size)
 		: name(std::move(name))
@@ -314,25 +314,25 @@ struct lv2_spu_group
 
 	void send_run_event(u64 data1, u64 data2, u64 data3)
 	{
-		if (const auto queue = ep_run.lock())
+		if (ep_run)
 		{
-			queue->send(SYS_SPU_THREAD_GROUP_EVENT_RUN_KEY, data1, data2, data3);
+			ep_run->send(SYS_SPU_THREAD_GROUP_EVENT_RUN_KEY, data1, data2, data3);
 		}
 	}
 
 	void send_exception_event(u64 data1, u64 data2, u64 data3)
 	{
-		if (const auto queue = ep_exception.lock())
+		if (ep_exception)
 		{
-			queue->send(SYS_SPU_THREAD_GROUP_EVENT_EXCEPTION_KEY, data1, data2, data3);
+			ep_exception->send(SYS_SPU_THREAD_GROUP_EVENT_EXCEPTION_KEY, data1, data2, data3);
 		}
 	}
 
 	void send_sysmodule_event(u64 data1, u64 data2, u64 data3)
 	{
-		if (const auto queue = ep_sysmodule.lock())
+		if (ep_sysmodule)
 		{
-			queue->send(SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE_KEY, data1, data2, data3);
+			ep_sysmodule->send(SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE_KEY, data1, data2, data3);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -93,13 +93,11 @@ public:
 	template <typename T, typename E>
 	static bool unqueue(std::deque<T*>& queue, const E& object)
 	{
-		for (auto found = queue.cbegin(), end = queue.cend(); found != end; found++)
+		if (auto end = queue.cend(), it = std::find(queue.cbegin(), end, object);
+			it != end)
 		{
-			if (*found == object)
-			{
-				queue.erase(found);
-				return true;
-			}
+			queue.erase(it);
+			return true;
 		}
 
 		return false;

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -33,9 +33,9 @@ void lv2_timer_context::operator()()
 					continue;
 				}
 
-				if (const auto queue = port.lock())
+				if (port)
 				{
-					queue->send(source, data1, data2, next);
+					port->send(source, data1, data2, next);
 				}
 
 				if (period)
@@ -165,7 +165,7 @@ error_code _sys_timer_start(ppu_thread& ppu, u32 timer_id, u64 base_time, u64 pe
 			return CELL_EBUSY;
 		}
 
-		if (timer.port.expired())
+		if (!lv2_event_queue::check(timer.port))
 		{
 			return CELL_ENOTCONN;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_timer.h
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.h
@@ -30,7 +30,7 @@ struct lv2_timer_context : lv2_obj
 	shared_mutex mutex;
 	atomic_t<u32> state{SYS_TIMER_STATE_STOP};
 
-	std::weak_ptr<lv2_event_queue> port;
+	std::shared_ptr<lv2_event_queue> port;
 	u64 source;
 	u64 data1;
 	u64 data2;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2152,9 +2152,6 @@ namespace rsx
 
 	void thread::check_zcull_status(bool framebuffer_swap)
 	{
-		if (g_cfg.video.disable_zcull_queries)
-			return;
-
 		if (framebuffer_swap)
 		{
 			zcull_surface_active = false;
@@ -2186,9 +2183,6 @@ namespace rsx
 
 	void thread::clear_zcull_stats(u32 type)
 	{
-		if (g_cfg.video.disable_zcull_queries)
-			return;
-
 		zcull_ctrl->clear(this, type);
 	}
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -123,7 +123,7 @@ struct cfg_root : cfg::node
 		cfg::_bool stretch_to_display_area{ this, "Stretch To Display Area", false, true };
 		cfg::_bool force_high_precision_z_buffer{ this, "Force High Precision Z buffer" };
 		cfg::_bool strict_rendering_mode{ this, "Strict Rendering Mode" };
-		cfg::_bool disable_zcull_queries{ this, "Disable ZCull Occlusion Queries", false };
+		cfg::_bool disable_zcull_queries{ this, "Disable ZCull Occlusion Queries", false, true };
 		cfg::_bool disable_vertex_cache{ this, "Disable Vertex Cache", false };
 		cfg::_bool disable_FIFO_reordering{ this, "Disable FIFO Reordering", false };
 		cfg::_bool frame_skip_enabled{ this, "Enable Frame Skip", false, true };


### PR DESCRIPTION
* sys_ppu_thread_t expands to u64 type, although most ppu syscalls ignore the upper 32-bits of value due to it being ignored when obtaining the underlying PPU object ptr, they are not ignored by both _sys_lwcond_signal syscall and liblv2.sprx's function sys_lwcond_signal_to. The comparison of "invalid PPU id" is 64-bit and the value must be UINT32_MAX. probably because the macro SYS_PPU_THREAD_ID_INVALID also expands to UINT32_MAX.
* Make "Disable ZCull Occlusion" setting dynamic.
* Limit total process sys_vm's virtual memory to 256MB, even for debug console mode.
* Some more syscalls page faults notifications fixes.
* Do not create ghost event port IDs in lv2 as realhw.
* Remove std::weak_ptr usage in sys_event_queue as it is no longer needed.
* Rewrite page fault thread notifications:
   Fix a corner case where SPU thread has the same ID as a PPU thread.
   Fix a potential deadlock on Emu.Stop() while sending event in EBUSY loop.
   Thread specific notifications.
* Fix and rewite vm::check_addr():
   Fixes a corner case when passing arguments [addr=0, size=0] or when [addr % 4096 != 0, size=0].
   Optimizations added.
* Update ppu_thread::start_time when ppu suspends.