### PR TITLE
PPU: Implement PPU Traps Stubbing option

### DIFF
--- a/Utilities/Config.cpp
+++ b/Utilities/Config.cpp
@@ -65,6 +65,13 @@ bool cfg::try_to_int64(s64* out, const std::string& value, s64 min, s64 max)
 	const char* start = &value.front();
 	const char* end = &value.back() + 1;
 	int base = 10;
+	int sign = +1;
+
+	if (start[0] == '-')
+	{
+		sign = -1;
+		start += 1;
+	}
 
 	if (start[0] == '0' && (start[1] == 'x' || start[1] == 'X'))
 	{
@@ -75,11 +82,13 @@ bool cfg::try_to_int64(s64* out, const std::string& value, s64 min, s64 max)
 
 	const auto ret = std::from_chars(start, end, result, base);
 
-	if (ret.ec != std::errc() || ret.ptr != end)
+	if (ret.ec != std::errc() || ret.ptr != end || (start[0] == '-' && sign < 0))
 	{
 		if (out) cfg_log.error("cfg::try_to_int('%s'): invalid integer", value);
 		return false;
 	}
+
+	result *= sign;
 
 	if (result < min || result > max)
 	{

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -336,7 +336,7 @@ extern u32 ppu_lwarx(ppu_thread& ppu, u32 addr);
 extern u64 ppu_ldarx(ppu_thread& ppu, u32 addr);
 extern bool ppu_stwcx(ppu_thread& ppu, u32 addr, u32 reg_value);
 extern bool ppu_stdcx(ppu_thread& ppu, u32 addr, u64 reg_value);
-
+extern void ppu_trap(ppu_thread& ppu, u64 addr);
 
 
 class ppu_scale_table_t
@@ -2903,7 +2903,8 @@ bool ppu_interpreter::TDI(ppu_thread& ppu, ppu_opcode_t op)
 		((op.bo & 0x2) && a_ < b_) ||
 		((op.bo & 0x1) && a_ > b_))
 	{
-		fmt::throw_exception("Trap!" HERE);
+		ppu_trap(ppu, ppu.cia);
+		return false;
 	}
 
 	return true;
@@ -2920,7 +2921,8 @@ bool ppu_interpreter::TWI(ppu_thread& ppu, ppu_opcode_t op)
 		((op.bo & 0x2) && a_ < b_) ||
 		((op.bo & 0x1) && a_ > b_))
 	{
-		fmt::throw_exception("Trap!" HERE);
+		ppu_trap(ppu, ppu.cia);
+		return false;
 	}
 
 	return true;
@@ -3261,7 +3263,8 @@ bool ppu_interpreter::TW(ppu_thread& ppu, ppu_opcode_t op)
 		(static_cast<u32>(a) < static_cast<u32>(b) && (op.bo & 0x2)) ||
 		(static_cast<u32>(a) > static_cast<u32>(b) && (op.bo & 0x1)))
 	{
-		fmt::throw_exception("Trap!" HERE);
+		ppu_trap(ppu, ppu.cia);
+		return false;
 	}
 
 	return true;
@@ -3474,7 +3477,8 @@ bool ppu_interpreter::TD(ppu_thread& ppu, ppu_opcode_t op)
 		((op.bo & 0x2) && a_ < b_) ||
 		((op.bo & 0x1) && a_ > b_))
 	{
-		fmt::throw_exception("Trap!" HERE);
+		ppu_trap(ppu, ppu.cia);
+		return false;
 	}
 
 	return true;

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -52,6 +52,7 @@ struct cfg_root : cfg::node
 		cfg::_bool spu_approx_xfloat{ this, "Approximate xfloat", true };
 		cfg::_bool llvm_accurate_dfma{ this, "LLVM Accurate DFMA", true }; // Enable accurate double-precision FMA for CPUs which do not support it natively
 		cfg::_bool llvm_ppu_accurate_vector_nan{ this, "PPU LLVM Accurate Vector NaN values", false };
+		cfg::_int<-64, 64> stub_ppu_traps{ this, "Stub PPU Traps", 0, true }; // Hack, skip PPU traps for rare cases where the trap is continueable (specify relative instructions to skip)
 
 		cfg::_bool debug_console_mode{ this, "Debug Console Mode", false }; // Debug console emulation, not recommended
 		cfg::_enum<lib_loading_type> lib_loading{ this, "Lib Loader", lib_loading_type::liblv2only };


### PR DESCRIPTION
Works both on PPU interpreters and LLVM recompiler, when the setting's value is zero the stubbing is disabled and the old exception is raised.
When the setting's value is non-zero it jumps the amount of instructions from the address of the PPU trap.
Range of 64 instructions forwards (positive) and backwards (negative) can be specified.
The Last Of Us and Uncharted Series need the value to be 1 for it to work properly.  
Implements #5700. 