### PR TITLE
gl: Refactor shader compilation

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLCompute.h
+++ b/rpcs3/Emu/RSX/GL/GLCompute.h
@@ -44,8 +44,7 @@ namespace gl
         {
             if (!compiled)
             {
-                m_shader.create(gl::glsl::shader::type::compute);
-                m_shader.source(m_src);
+                m_shader.create(gl::glsl::shader::type::compute, m_src);
                 m_shader.compile();
 
                 m_program.create();

--- a/rpcs3/Emu/RSX/GL/GLCompute.h
+++ b/rpcs3/Emu/RSX/GL/GLCompute.h
@@ -44,7 +44,7 @@ namespace gl
         {
             if (!compiled)
             {
-                m_shader.create(gl::glsl::shader::type::compute, m_src);
+                m_shader.create(::glsl::program_domain::glsl_compute_program, m_src);
                 m_shader.compile();
 
                 m_program.create();

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -2,7 +2,6 @@
 #include "GLFragmentProgram.h"
 
 #include "Emu/System.h"
-#include "GLHelpers.h"
 #include "GLFragmentProgram.h"
 #include "GLCommonDecompiler.h"
 #include "../GCM.h"
@@ -341,7 +340,8 @@ GLFragmentProgram::~GLFragmentProgram()
 void GLFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 {
 	u32 size;
-	GLFragmentDecompilerThread decompiler(shader, parr, prog, size);
+	std::string source;
+	GLFragmentDecompilerThread decompiler(source, parr, prog, size);
 
 	if (!g_cfg.video.disable_native_float16)
 	{
@@ -365,55 +365,18 @@ void GLFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 			FragmentConstantOffsetCache.push_back(offset);
 		}
 	}
+
+	shader.create(gl::glsl::shader::type::fragment, source);
 }
 
 void GLFragmentProgram::Compile()
 {
-	if (id)
-	{
-		glDeleteShader(id);
-	}
-
-	id = glCreateShader(GL_FRAGMENT_SHADER);
-
-	const char* str = shader.c_str();
-	const int strlen = ::narrow<int>(shader.length());
-
-	fs::file(fs::get_cache_dir() + "shaderlog/FragmentProgram" + std::to_string(id) + ".glsl", fs::rewrite).write(str);
-
-	glShaderSource(id, 1, &str, &strlen);
-	glCompileShader(id);
-
-	GLint compileStatus = GL_FALSE;
-	glGetShaderiv(id, GL_COMPILE_STATUS, &compileStatus); // Determine the result of the glCompileShader call
-	if (compileStatus != GL_TRUE) // If the shader failed to compile...
-	{
-		GLint infoLength;
-		glGetShaderiv(id, GL_INFO_LOG_LENGTH, &infoLength); // Retrieve the length in bytes (including trailing NULL) of the shader info log
-
-		if (infoLength > 0)
-		{
-			GLsizei len;
-			char* buf = new char[infoLength]; // Buffer to store infoLog
-
-			glGetShaderInfoLog(id, infoLength, &len, buf); // Retrieve the shader info log into our buffer
-			rsx_log.error("Failed to compile shader: %s", buf); // Write log to the console
-
-			delete[] buf;
-		}
-
-		rsx_log.notice("%s", shader); // Log the text of the shader that failed to compile
-		Emu.Pause(); // Pause the emulator, we can't really continue from here
-	}
+	shader.compile();
+	id = shader.id();
 }
 
 void GLFragmentProgram::Delete()
 {
-	shader.clear();
-
-	if (id)
-	{
-		glDeleteShader(id);
-		id = 0;
-	}
+	shader.remove();
+	id = 0;
 }

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -366,7 +366,7 @@ void GLFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 		}
 	}
 
-	shader.create(gl::glsl::shader::type::fragment, source);
+	shader.create(::glsl::program_domain::glsl_fragment_program, source);
 }
 
 void GLFragmentProgram::Compile()

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
@@ -2,6 +2,7 @@
 #include "../Common/FragmentProgramDecompiler.h"
 #include "../Common/GLSLTypes.h"
 #include "Emu/RSX/RSXFragmentProgram.h"
+#include "GLHelpers.h"
 
 namespace glsl
 {
@@ -56,8 +57,8 @@ public:
 	~GLFragmentProgram();
 
 	ParamArray parr;
-	u32 id = 0;
-	std::string shader;
+	u32 id;
+	gl::glsl::shader shader;
 	std::vector<size_t> FragmentConstantOffsetCache;
 
 	/**

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -2407,6 +2407,7 @@ public:
 		class shader
 		{
 		public:
+			std::string source;
 			enum class type
 			{
 				fragment = GL_FRAGMENT_SHADER,
@@ -2415,12 +2416,10 @@ public:
 			};
 
 		private:
-
 			GLuint m_id = GL_NONE;
 			type shader_type = type::vertex;
 
 		public:
-
 			shader() = default;
 
 			shader(GLuint id)
@@ -2428,15 +2427,9 @@ public:
 				set_id(id);
 			}
 
-			shader(type type_)
-			{
-				create(type_);
-			}
-
 			shader(type type_, const std::string& src)
 			{
-				create(type_);
-				source(src);
+				create(type_, src);
 			}
 
 			~shader()
@@ -2445,24 +2438,18 @@ public:
 					remove();
 			}
 
-			void recreate(type type_)
+			void create(type type_, const std::string& src)
 			{
-				if (created())
-					remove();
-
-				create(type_);
-			}
-
-			void create(type type_)
-			{
-				m_id = glCreateShader(static_cast<GLenum>(type_));
 				shader_type = type_;
+				source = src;
 			}
 
-			void source(const std::string& src) const
+			shader& compile()
 			{
-				const char* str = src.c_str();
-				const GLint length = ::narrow<GLint>(src.length());
+				m_id = glCreateShader(static_cast<GLenum>(shader_type));
+				const char* str = source.c_str();
+				const GLint length = ::narrow<GLint>(source.length());
+
 				if (g_cfg.video.log_programs)
 				{
 					std::string base_name;
@@ -2483,10 +2470,6 @@ public:
 				}
 
 				glShaderSource(m_id, 1, &str, &length);
-			}
-
-			shader& compile()
-			{
 				glCompileShader(m_id);
 
 				GLint status = GL_FALSE;
@@ -2768,7 +2751,7 @@ public:
 				}
 			}
 
-			uint id() const
+			GLuint id() const
 			{
 				return m_id;
 			}

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -55,10 +55,10 @@ namespace gl
 		{
 			if (!compiled)
 			{
-				fs.create(gl::glsl::shader::type::fragment, fs_src);
+				fs.create(::glsl::program_domain::glsl_fragment_program, fs_src);
 				fs.compile();
 
-				vs.create(gl::glsl::shader::type::vertex, vs_src);
+				vs.create(::glsl::program_domain::glsl_vertex_program, vs_src);
 				vs.compile();
 
 				program_handle.create();

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -55,12 +55,10 @@ namespace gl
 		{
 			if (!compiled)
 			{
-				fs.create(gl::glsl::shader::type::fragment);
-				fs.source(fs_src);
+				fs.create(gl::glsl::shader::type::fragment, fs_src);
 				fs.compile();
 
-				vs.create(gl::glsl::shader::type::vertex);
-				vs.source(vs_src);
+				vs.create(gl::glsl::shader::type::vertex, vs_src);
 				vs.compile();
 
 				program_handle.create();

--- a/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
+++ b/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
@@ -79,8 +79,8 @@ struct GLTraits
 		rsx_log.notice("*** vp id = %d", vertexProgramData.id);
 		rsx_log.notice("*** fp id = %d", fragmentProgramData.id);
 
-		rsx_log.notice("*** vp shader = \n%s", vertexProgramData.shader.source.c_str());
-		rsx_log.notice("*** fp shader = \n%s", fragmentProgramData.shader.source.c_str());
+		rsx_log.notice("*** vp shader = \n%s", vertexProgramData.shader.get_source().c_str());
+		rsx_log.notice("*** fp shader = \n%s", fragmentProgramData.shader.get_source().c_str());
 
 		return result;
 	}

--- a/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
+++ b/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
@@ -75,12 +75,14 @@ struct GLTraits
 		result->uniforms[0] = GL_STREAM_BUFFER_START + 0;
 		result->uniforms[1] = GL_STREAM_BUFFER_START + 1;
 
-		rsx_log.notice("*** prog id = %d", result->id());
-		rsx_log.notice("*** vp id = %d", vertexProgramData.id);
-		rsx_log.notice("*** fp id = %d", fragmentProgramData.id);
-
-		rsx_log.notice("*** vp shader = \n%s", vertexProgramData.shader.get_source().c_str());
-		rsx_log.notice("*** fp shader = \n%s", fragmentProgramData.shader.get_source().c_str());
+		if (g_cfg.video.log_programs)
+		{
+			rsx_log.notice("*** prog id = %d", result->id());
+			rsx_log.notice("*** vp id = %d", vertexProgramData.id);
+			rsx_log.notice("*** fp id = %d", fragmentProgramData.id);
+			rsx_log.notice("*** vp shader = \n%s", vertexProgramData.shader.get_source().c_str());
+			rsx_log.notice("*** fp shader = \n%s", fragmentProgramData.shader.get_source().c_str());
+		}
 
 		return result;
 	}

--- a/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
+++ b/rpcs3/Emu/RSX/GL/GLProgramBuffer.h
@@ -79,8 +79,8 @@ struct GLTraits
 		rsx_log.notice("*** vp id = %d", vertexProgramData.id);
 		rsx_log.notice("*** fp id = %d", fragmentProgramData.id);
 
-		rsx_log.notice("*** vp shader = \n%s", vertexProgramData.shader.c_str());
-		rsx_log.notice("*** fp shader = \n%s", fragmentProgramData.shader.c_str());
+		rsx_log.notice("*** vp shader = \n%s", vertexProgramData.shader.source.c_str());
+		rsx_log.notice("*** fp shader = \n%s", fragmentProgramData.shader.source.c_str());
 
 		return result;
 	}

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
@@ -12,16 +12,16 @@ namespace gl
 
 	namespace interpreter
 	{
-		void texture_pool_allocator::create(shader::type domain)
+		void texture_pool_allocator::create(::glsl::program_domain domain)
 		{
 			GLenum pname;
 			switch (domain)
 			{
 			default:
 				rsx_log.fatal("Unexpected program domain %d", static_cast<int>(domain));
-			case shader::type::vertex:
+			case ::glsl::program_domain::glsl_vertex_program:
 				pname = GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS; break;
-			case shader::type::fragment:
+			case ::glsl::program_domain::glsl_fragment_program:
 				pname = GL_MAX_TEXTURE_IMAGE_UNITS; break;
 			}
 
@@ -150,7 +150,7 @@ namespace gl
 		builder << program_common::interpreter::get_vertex_interpreter();
 		const std::string s = builder.str();
 
-		m_vs.create(glsl::shader::type::vertex, s);
+		m_vs.create(::glsl::program_domain::glsl_vertex_program, s);
 		m_vs.compile();
 	}
 
@@ -160,7 +160,7 @@ namespace gl
 		auto& allocator = prog_data.allocator;
 		if (compiler_options & program_common::interpreter::COMPILER_OPT_ENABLE_TEXTURES)
 		{
-			allocator.create(glsl::shader::type::fragment);
+			allocator.create(::glsl::program_domain::glsl_fragment_program);
 			if (allocator.max_image_units >= 32)
 			{
 				// 16 + 4 + 4 + 4
@@ -302,7 +302,7 @@ namespace gl
 		builder << program_common::interpreter::get_fragment_interpreter();
 		const std::string s = builder.str();
 
-		prog_data.fs.create(glsl::shader::type::fragment, s);
+		prog_data.fs.create(::glsl::program_domain::glsl_fragment_program, s);
 		prog_data.fs.compile();
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
@@ -150,8 +150,7 @@ namespace gl
 		builder << program_common::interpreter::get_vertex_interpreter();
 		const std::string s = builder.str();
 
-		m_vs.create(glsl::shader::type::vertex);
-		m_vs.source(s);
+		m_vs.create(glsl::shader::type::vertex, s);
 		m_vs.compile();
 	}
 
@@ -303,8 +302,7 @@ namespace gl
 		builder << program_common::interpreter::get_fragment_interpreter();
 		const std::string s = builder.str();
 
-		prog_data.fs.create(glsl::shader::type::fragment);
-		prog_data.fs.source(s);
+		prog_data.fs.create(glsl::shader::type::fragment, s);
 		prog_data.fs.compile();
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.h
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.h
@@ -1,9 +1,12 @@
 ﻿#pragma once
 #include "GLHelpers.h"
 #include "../Common/ProgramStateCache.h"
+#include "../Common/TextureUtils.h"
 
 namespace gl
 {
+	using namespace ::glsl;
+
 	namespace interpreter
 	{
 		using program_metadata = program_hash_util::fragment_program_utils::fragment_program_metadata;
@@ -48,7 +51,7 @@ namespace gl
 			int used = 0;
 			std::vector<texture_pool> pools;
 
-			void create(::gl::glsl::shader::type domain);
+			void create(::glsl::program_domain domain);
 			void allocate(int size);
 		};
 

--- a/rpcs3/Emu/RSX/GL/GLTextOut.h
+++ b/rpcs3/Emu/RSX/GL/GLTextOut.h
@@ -52,10 +52,10 @@ namespace gl
 				"}\n"
 			};
 
-			m_fs.create(gl::glsl::shader::type::fragment, fs);
+			m_fs.create(::glsl::program_domain::glsl_fragment_program, fs);
 			m_fs.compile();
 
-			m_vs.create(gl::glsl::shader::type::vertex, vs);
+			m_vs.create(::glsl::program_domain::glsl_vertex_program, vs);
 			m_vs.compile();
 
 			m_program.create();

--- a/rpcs3/Emu/RSX/GL/GLTextOut.h
+++ b/rpcs3/Emu/RSX/GL/GLTextOut.h
@@ -52,12 +52,10 @@ namespace gl
 				"}\n"
 			};
 
-			m_fs.create(gl::glsl::shader::type::fragment);
-			m_fs.source(fs);
+			m_fs.create(gl::glsl::shader::type::fragment, fs);
 			m_fs.compile();
 
-			m_vs.create(gl::glsl::shader::type::vertex);
-			m_vs.source(vs);
+			m_vs.create(gl::glsl::shader::type::vertex, vs);
 			m_vs.compile();
 
 			m_program.create();

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -4,7 +4,6 @@
 #include "Emu/System.h"
 
 #include "GLCommonDecompiler.h"
-#include "GLHelpers.h"
 #include "../Common/GLSLCommon.h"
 
 #include <algorithm>
@@ -267,55 +266,21 @@ GLVertexProgram::~GLVertexProgram()
 
 void GLVertexProgram::Decompile(const RSXVertexProgram& prog)
 {
-	GLVertexDecompilerThread decompiler(prog, shader, parr);
+	std::string source;
+	GLVertexDecompilerThread decompiler(prog, source, parr);
 	decompiler.Task();
+
+	shader.create(gl::glsl::shader::type::vertex, source);
 }
 
 void GLVertexProgram::Compile()
 {
-	if (id)
-	{
-		glDeleteShader(id);
-	}
-
-	id = glCreateShader(GL_VERTEX_SHADER);
-
-	const char* str = shader.c_str();
-	const int strlen = ::narrow<int>(shader.length());
-
-	if (g_cfg.video.log_programs)
-		fs::file(fs::get_cache_dir() + "shaderlog/VertexProgram" + std::to_string(id) + ".glsl", fs::rewrite).write(str);
-
-	glShaderSource(id, 1, &str, &strlen);
-	glCompileShader(id);
-
-	GLint r = GL_FALSE;
-	glGetShaderiv(id, GL_COMPILE_STATUS, &r);
-	if (r != GL_TRUE)
-	{
-		glGetShaderiv(id, GL_INFO_LOG_LENGTH, &r);
-
-		if (r)
-		{
-			char* buf = new char[r + 1]();
-			GLsizei len;
-			glGetShaderInfoLog(id, r, &len, buf);
-			rsx_log.error("Failed to compile vertex shader: %s", buf);
-			delete[] buf;
-		}
-
-		rsx_log.notice("%s", shader.c_str());
-		Emu.Pause();
-	}
+	shader.compile();
+	id = shader.id();
 }
 
 void GLVertexProgram::Delete()
 {
-	shader.clear();
-
-	if (id)
-	{
-		glDeleteShader(id);
-		id = 0;
-	}
+	shader.remove();
+	id = 0;
 }

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -270,7 +270,7 @@ void GLVertexProgram::Decompile(const RSXVertexProgram& prog)
 	GLVertexDecompilerThread decompiler(prog, source, parr);
 	decompiler.Task();
 
-	shader.create(gl::glsl::shader::type::vertex, source);
+	shader.create(::glsl::program_domain::glsl_vertex_program, source);
 }
 
 void GLVertexProgram::Compile()

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include "../Common/VertexProgramDecompiler.h"
 #include "Emu/RSX/RSXVertexProgram.h"
+#include "GLHelpers.h"
 
 enum
 {
@@ -48,15 +49,14 @@ public:
 };
 
 class GLVertexProgram
-{ 
+{
 public:
 	GLVertexProgram();
 	~GLVertexProgram();
 
 	ParamArray parr;
-	u32 id = 0;
-	std::string shader;
-	bool interleaved;
+	u32 id;
+	gl::glsl::shader shader;
 
 	void Decompile(const RSXVertexProgram& prog);
 	void Compile();


### PR DESCRIPTION
More work towards the OpenGL render, refactors all shader compilation code into using the unique `gl::glsl::shader` path

gl: Refactor shader compilation

- Refactors the three existing shader compilation paths into an unique `gl::glsl::compile` path
- `GLVertexProgram`: Removes unused `interleaved` var
- `gl::glsl::shader`: Stores shader source on struct for usage in other places
- `gl::glsl::shader`: Remove `recreate()` and partial constructors

gl: Refactor shader type usage

- Removes duplicated `type` in `gl::glsl::shader` in favor of Common `glsl::program_domain` types: stores program_domain in the `gl::glsl::shader` struct and converts to OpenGL specific GLenum when needed

gl: Only log shaders if g_cfg.video.log_programs is enabled