### PR TITLE
rsx: Fix data written to RSX semaphores and the initial data of them

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -204,8 +204,8 @@ error_code sys_rsx_context_allocate(vm::ptr<u32> context_id, vm::ptr<u64> lpar_d
 	for (int i = 0; i < 256; ++i)
 	{
 		reports.semaphore[i].val = 0x1337C0D3;
-		reports.semaphore[i].pad = 0x1337BABE;
-		reports.semaphore[i].timestamp = -1; // technically different but should be fine
+		reports.semaphore[i].zero = 0x1337BABE;
+		reports.semaphore[i].zero2 = 0x1337BEEF1337F001;
 	}
 
 	for (int i = 0; i < 2048; ++i)

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -87,8 +87,8 @@ struct RsxDmaControl
 struct alignas(16) RsxSemaphore
 {
 	be_t<u32> val;
-	be_t<u32> pad;
-	be_t<u64> timestamp;
+	be_t<u32> zero;
+	be_t<u64> zero2;
 };
 
 struct alignas(16) RsxNotify


### PR DESCRIPTION
Turns out SMEAPHORE_RELEASE writes 16-byte of aligned data instead of 4-bytes, the rest of the bytes are filled with zeroes.
Similarly texture and backend labels write zeroes as well for the rest of the 12 bytes of data and not rsx timestamp as it used to thought of.
Also fix the initial data of the upper 8 bytes of semaphores, they are not initilaized to UINT64_MAX but special values as a "joke" of Sony. (if you look at the values you'll see...)

testcase : https://github.com/elad335/myps3tests/blob/master/rsx_tests/FIFO%20Semaphores%20data/expected.txt
The first buffer output is of the initial data of 6 semaphores, the second is of the first 3 semaphores used in the first output after SEMEPHORE_RELEASE, texture weite label and backend write label.