### PR TITLE
gl: Check for GL_EXT_depth_bounds_test

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -162,7 +162,7 @@ void GLGSRender::update_draw_state()
 		gl_state.depth_func(gl::comparison_op(rsx::method_registers.depth_func()));
 	}
 
-	if (glDepthBoundsEXT && (gl_state.enable(rsx::method_registers.depth_bounds_test_enabled(), GL_DEPTH_BOUNDS_TEST_EXT)))
+	if (gl::get_driver_caps().EXT_depth_bounds_test && (gl_state.enable(rsx::method_registers.depth_bounds_test_enabled(), GL_DEPTH_BOUNDS_TEST_EXT)))
 	{
 		gl_state.depth_bounds(rsx::method_registers.depth_bounds_min(), rsx::method_registers.depth_bounds_max());
 	}

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -77,6 +77,7 @@ namespace gl
 	{
 	public:
 		bool EXT_dsa_supported = false;
+		bool EXT_depth_bounds_test = false;
 		bool ARB_dsa_supported = false;
 		bool ARB_buffer_storage_supported = false;
 		bool ARB_texture_buffer_supported = false;
@@ -106,7 +107,7 @@ namespace gl
 
 		void initialize()
 		{
-			int find_count = 11;
+			int find_count = 12;
 			int ext_count = 0;
 			glGetIntegerv(GL_NUM_EXTENSIONS, &ext_count);
 
@@ -189,6 +190,13 @@ namespace gl
 				if (check(ext_name, "GL_ARB_compute_shader"))
 				{
 					ARB_compute_shader_supported = true;
+					find_count--;
+					continue;
+				}
+
+				if (check(ext_name, "GL_EXT_depth_bounds_test"))
+				{
+					EXT_depth_bounds_test = true;
 					find_count--;
 					continue;
 				}


### PR DESCRIPTION
Avoid glEnable/glDisable GL_DEPTH_BOUNDS_TEST_EXT flood that returns 
GL_INVALID_ENUM if the feature isn't supported