### PR TITLE
gl: Restrict insert_vertex_input_fetch workaround to Intel proprietary

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.h
@@ -252,7 +252,8 @@ namespace glsl
 
 		"#define get_s16(v, s) preserve_sign_s16(get_bits(v, s))\n\n";
 
-		//For intel GPUs which cannot access vectors in indexed mode (driver bug? or glsl version too low?)
+		// For intel GPUs which cannot access vectors in indexed mode (driver bug? or glsl version too low?)
+		// Note: Tested on Mesa iris with HD 530 and compilant path works fine, may be a bug on Windows proprietary drivers
 		if (!glsl4_compliant)
 		{
 			OS <<

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -109,6 +109,9 @@ namespace gl
 			int find_count = 11;
 			int ext_count = 0;
 			glGetIntegerv(GL_NUM_EXTENSIONS, &ext_count);
+			std::string vendor_string = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+			std::string version_string = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+			std::string renderer_string = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
 
 			for (int i = 0; i < ext_count; i++)
 			{
@@ -194,8 +197,13 @@ namespace gl
 				}
 			}
 
+			// Check GL_VERSION and GL_RENDERER for the presence of Mesa
+			if (version_string.find("Mesa") != umax || renderer_string.find("Mesa") != umax)
+			{
+				vendor_MESA = true;
+			}
+
 			// Workaround for intel drivers which have terrible capability reporting
-			std::string vendor_string = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
 			if (!vendor_string.empty())
 			{
 				std::transform(vendor_string.begin(), vendor_string.end(), vendor_string.begin(), ::tolower);
@@ -203,10 +211,10 @@ namespace gl
 			else
 			{
 				rsx_log.error("Failed to get vendor string from driver. Are we missing a context?");
-				vendor_string = "intel"; //lowest acceptable value
+				vendor_string = "intel"; // lowest acceptable value
 			}
 
-			if (vendor_string.find("intel") != umax)
+			if (!vendor_MESA && vendor_string.find("intel") != umax)
 			{
 				int version_major = 0;
 				int version_minor = 0;
@@ -230,13 +238,9 @@ namespace gl
 				if (!EXT_dsa_supported && glGetTextureImageEXT && glTextureBufferRangeEXT)
 					EXT_dsa_supported = true;
 			}
-			else if (vendor_string.find("nvidia") != umax)
+			else if (!vendor_MESA && vendor_string.find("nvidia") != umax)
 			{
 				vendor_NVIDIA = true;
-			}
-			else if (vendor_string.find("x.org") != umax)
-			{
-				vendor_MESA = true;
 			}
 #ifdef _WIN32
 			else if (vendor_string.find("amd") != umax || vendor_string.find("ati") != umax)


### PR DESCRIPTION
gl: Restrict insert_vertex_input_fetch workaround to Intel proprietary
- It works fine on Mesa iris
- Fixes detection of Mesa as recent Mesa does not have "x.org" on vendor string, allowing vendor_MESA to become true instead of vendor_INTEL on Mesa Intel

Tested on Yakuza 0 Demo which generates dozens of shaders using the compilant path in insert_vertex_input_fetch and game does not crash nor any difference is graphics is noticeable