### PR TITLE
SPU MFC: Fix SN interrupts, Implement MFC_SDCRZ_CMD

### DIFF
--- a/rpcs3/Emu/Cell/MFC.h
+++ b/rpcs3/Emu/Cell/MFC.h
@@ -27,6 +27,12 @@ enum MFC : u8
 	MFC_LIST_MASK    = 0x04,
 	MFC_START_MASK   = 0x08,
 	MFC_RESULT_MASK  = 0x10, // ???
+
+	MFC_SDCRT_CMD   = 0x80,
+	MFC_SDCRTST_CMD = 0x81,
+	MFC_SDCRZ_CMD   = 0x89,
+	MFC_SDCRS_CMD   = 0x8D,
+	MFC_SDCRF_CMD   = 0x8F,
 };
 
 // Atomic Status Update

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -50,6 +50,12 @@ bool spu_thread::read_reg(const u32 addr, u32& value)
 
 		switch (cmd.cmd)
 		{
+		case MFC_SDCRT_CMD:
+		case MFC_SDCRTST_CMD:
+		{
+			value = MFC_PPU_DMA_CMD_ENQUEUE_SUCCESSFUL;
+			return true;
+		}
 		case MFC_SNDSIG_CMD:
 		case MFC_SNDSIGB_CMD:
 		case MFC_SNDSIGF_CMD:
@@ -77,6 +83,7 @@ bool spu_thread::read_reg(const u32 addr, u32& value)
 		case MFC_GETS_CMD:
 		case MFC_GETBS_CMD:
 		case MFC_GETFS_CMD:
+		case MFC_SDCRZ_CMD:
 		{
 			if (cmd.size)
 			{

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -112,11 +112,7 @@ void spu_interpreter::set_interrupt_status(spu_thread& spu, spu_opcode_t op)
 		spu.set_interrupt_status(false);
 	}
 
-	if (spu.interrupts_enabled && (spu.ch_event_mask & spu.ch_event_stat & SPU_EVENT_INTR_IMPLEMENTED) > 0)
-	{
-		spu.interrupts_enabled = false;
-		spu.srr0 = std::exchange(spu.pc, 0);
-	}
+	spu.check_mfc_interrupts(spu.pc);
 }
 
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -5803,6 +5803,11 @@ public:
 
 				switch (u64 cmd = ci->getZExtValue())
 				{
+				case MFC_SDCRT_CMD:
+				case MFC_SDCRTST_CMD:
+				{
+					return;
+				}
 				case MFC_GETLLAR_CMD:
 				case MFC_PUTLLC_CMD:
 				case MFC_PUTLLUC_CMD:
@@ -5816,6 +5821,7 @@ public:
 				case MFC_GETL_CMD:
 				case MFC_GETLB_CMD:
 				case MFC_GETLF_CMD:
+				case MFC_SDCRZ_CMD:
 				{
 					// TODO
 					m_ir->CreateBr(next);
@@ -6000,6 +6006,10 @@ public:
 				case MFC_GETL_CMD:
 				case MFC_GETLB_CMD:
 				case MFC_GETLF_CMD:
+				{
+					break;
+				}
+				case MFC_SDCRZ_CMD:
 				{
 					break;
 				}

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2816,6 +2816,8 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 
 	case MFC_WrListStallAck:
 	{
+		value &= 0x1f;
+
 		// Reset stall status for specified tag
 		const u32 tag_mask = utils::rol32(1, value);
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -669,6 +669,7 @@ public:
 	u32 get_events(bool waiting = false);
 	void set_events(u32 mask);
 	void set_interrupt_status(bool enable);
+	bool check_mfc_interrupts(u32 nex_pc);
 	u32 get_ch_count(u32 ch);
 	s64 get_ch_value(u32 ch);
 	bool set_ch_value(u32 ch, u32 value);


### PR DESCRIPTION
* Deliver SPU interrupts immediately as they are received. L.A. Noire expects this as it executes code relying on occurence of previous interrupt after certain actions making sure the interrupt has occured on realhw. (e.g. reading MFC stalled status)
When we didn't execute the interrupt in time, the code relying on this received unwritten MFC data which eventually made it crash.

* After the above fix, the game was going a bit further and started executing MFC_SDCRZ_CMD. (sets all EA memory to zeroes) 
arguments seem valid. Implementing this command made it finally boot.

![image](https://user-images.githubusercontent.com/18193363/82127405-eb43f780-97bb-11ea-8f7d-42ded310aaa5.png)

Fixes #8064, note that PPU interpreter fast/precise and LLE libvdec.sprx are still required for it to proceed after the first logos.