### PR TITLE
rsx/fp: Fix precision clamping on MAD instruction

### DIFF
--- a/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Common/FragmentProgramDecompiler.cpp
@@ -644,6 +644,21 @@ template<typename T> std::string FragmentProgramDecompiler::GetSRC(T src)
 		break;
 	}
 
+	if (apply_precision_modifier && !src.neg)
+	{
+		if constexpr (!std::is_same<T, SRC0>::value)
+		{
+			if (dst.opcode == RSX_FP_OPCODE_MAD)
+			{
+				// Hardware tests show special behavior on MAD operation
+				// Only src0 obeys precision modifier (sat tested)
+				// Results: 1 * 100 + 0  = 100, 1 * 1 + 100 = 100, 100 * 1 + 0 = 1
+				// NOTE: Neg modifier seems to break this rule; 1 * -100 + 0 = -1 not -99
+				apply_precision_modifier = false;
+			}
+		}
+	}
+
 	static const char f[4] = { 'x', 'y', 'z', 'w' };
 
 	std::string swizzle;


### PR DESCRIPTION
RSX MAD instruction appears to be broken. Unlike other instructions, for this one only arg0 has clamping applied to it. However, when neg flag is set, the precision clamping works correctly. For example, consider this set of inputs (input clamping is set to [0,1] for all cases):
a) 1 * 100 + 0 = 100
b) 100 * 1 + 0 = 1
c) 1 * -100 + 0 = -1
d) 1* 1 + 100 = 101
etc

This fixes some rare graphical glitches such as the sea in one piece pirate warriors and the sky in GTA V. Also fixes post-processing in Crysis.

Fixes https://github.com/RPCS3/rpcs3/issues/2262