### PR TITLE
SPU reservations (TSX): Remove wait flag in PUTQLLUC

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1713,6 +1713,8 @@ void spu_thread::do_putlluc(const spu_mfc_cmd& args)
 			mov_rdata(vm::_ref<decltype(rdata)>(addr), to_write);
 			vm::reservation_acquire(addr, 128) += 64;
 		}
+
+		+test_stopped();
 	}
 	else
 	{


### PR DESCRIPTION
PUTQLLUC may be executed inside do_mfc() which may execute more commands, wait flat needs to be cleared before them otherwise the SPU thread execution is not tracked by cpu_suspend lock which may result in a data race.
In PUTLLUC it doesn't change anything as other commands can't be executed after it.