### PR TITLE
Add FreeBSD to CI

### DIFF
--- a/.ci/build-freebsd.sh
+++ b/.ci/build-freebsd.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -ex
 
+ccache -s # debug
+
 # Pull all the submodules except llvm
 # Note: Tried to use git submodule status, but it takes over 20 seconds
 # shellcheck disable=SC2046
@@ -29,3 +31,5 @@ CONFIGURE_ARGS="
 # shellcheck disable=SC2086
 cmake -B build -G Ninja $CONFIGURE_ARGS
 cmake --build build
+
+ccache -s # debug

--- a/.ci/build-freebsd.sh
+++ b/.ci/build-freebsd.sh
@@ -1,0 +1,31 @@
+#!/bin/sh -ex
+
+# Pull all the submodules except llvm
+# Note: Tried to use git submodule status, but it takes over 20 seconds
+# shellcheck disable=SC2046
+git submodule -q update --init $(awk '/path/ && !/llvm/ { print $3 }' .gitmodules)
+
+# XXX Drop after Travis upgrades FreeBSD to 12.2 (see also .ci/install-freebsd.sh)
+case $(${CXX:-c++} --version) in
+    *version\ 8.0.*)
+	fetch https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/libcxx-10.0.0.src.tar.xz
+	tar xf libcxx-10.0.0.src.tar.xz
+	export CC=clang10 CXX=clang++10
+	export CXXFLAGS="$CXXFLAGS -nostdinc++ -isystem $PWD/libcxx-10.0.0.src/include"
+	;;
+esac
+
+CONFIGURE_ARGS="
+	-DCMAKE_C_COMPILER_LAUNCHER=ccache
+	-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+	-DWITH_LLVM=OFF
+	-DUSE_PRECOMPILED_HEADERS=OFF
+	-DUSE_NATIVE_INSTRUCTIONS=OFF
+	-DUSE_SYSTEM_FFMPEG=ON
+	-DUSE_SYSTEM_CURL=ON
+	-DUSE_SYSTEM_LIBPNG=ON
+"
+
+# shellcheck disable=SC2086
+cmake -B build -G Ninja $CONFIGURE_ARGS
+cmake --build build

--- a/.ci/install-freebsd.sh
+++ b/.ci/install-freebsd.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S su -m root -ex
+# NOTE: this script is run under root permissions
+# shellcheck shell=sh disable=SC2096
+
+# RPCS3 often needs recent Qt5 and Vulkan-Headers
+sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
+
+export ASSUME_ALWAYS_YES=true
+pkg info # debug
+
+# XXX Drop after Travis upgrades FreeBSD to 12.2 (see also .ci/build-freebsd.sh)
+case $(${CXX:-c++} --version) in
+    *version\ 8.0.*)
+	pkg install llvm10
+	;;
+esac
+
+# Mandatory dependencies (qt5-dbus and qt5-gui are pulled via qt5-widgets)
+pkg install ccache cmake ninja qt5-qmake qt5-buildtools qt5-widgets qt5-concurrent glew openal-soft ffmpeg
+
+# Optional dependencies (libevdev is pulled by qt5-gui)
+pkg install pkgconf alsa-lib pulseaudio sdl2 evdev-proto vulkan-headers vulkan-loader

--- a/.ci/install-freebsd.sh
+++ b/.ci/install-freebsd.sh
@@ -16,7 +16,7 @@ case $(${CXX:-c++} --version) in
 esac
 
 # Mandatory dependencies (qt5-dbus and qt5-gui are pulled via qt5-widgets)
-pkg install ccache cmake ninja qt5-qmake qt5-buildtools qt5-widgets qt5-concurrent glew openal-soft ffmpeg
+pkg install git ccache cmake ninja qt5-qmake qt5-buildtools qt5-widgets qt5-concurrent glew openal-soft ffmpeg
 
 # Optional dependencies (libevdev is pulled by qt5-gui)
 pkg install pkgconf alsa-lib pulseaudio sdl2 evdev-proto vulkan-headers vulkan-loader

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,19 @@
+env:
+  CIRRUS_CLONE_DEPTH: 0 # Unshallow clone to obtain proper GIT_VERSION
+
+freebsd_task:
+  matrix:
+    - name: FreeBSD 12.2 (snapshot)
+      freebsd_instance:
+        image_family: freebsd-12-1-snap
+        cpu: 8
+        memory: 8G
+  env:
+    CCACHE_MAXSIZE: 300M # 3x clean build, rounded
+    CCACHE_DIR: /tmp/ccache_dir
+  ccache_cache:
+    folder: /tmp/ccache_dir
+  packages_cache:
+    folder: /var/cache/pkg
+  install_script: "sh -ex ./.ci/install-freebsd.sh"
+  script: "./.ci/build-freebsd.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ jobs:
           compiler: clang
           install: "docker pull rpcs3/rpcs3-travis-xenial:1.4"
           script: 'travis_wait docker run -v $(pwd):/rpcs3 -v "$HOME/.ccache":/root/.ccache --env-file .ci/travis.env rpcs3/rpcs3-travis-xenial:1.4 /rpcs3/.ci/build-linux.sh'
-        - os: freebsd
-          compiler: clang
-          cache: ccache
-          install: "./.ci/install-freebsd.sh"
-          script: "./.ci/build-freebsd.sh"
+        # - os: freebsd
+        #   compiler: clang
+        #   cache: ccache
+        #   install: "./.ci/install-freebsd.sh"
+        #   script: "./.ci/build-freebsd.sh"
         # - os: osx
         #   osx_image: xcode11.3
         #   addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ jobs:
           compiler: clang
           install: "docker pull rpcs3/rpcs3-travis-xenial:1.4"
           script: 'travis_wait docker run -v $(pwd):/rpcs3 -v "$HOME/.ccache":/root/.ccache --env-file .ci/travis.env rpcs3/rpcs3-travis-xenial:1.4 /rpcs3/.ci/build-linux.sh'
+        - os: freebsd
+          compiler: clang
+          cache: ccache
+          install: "./.ci/install-freebsd.sh"
+          script: "./.ci/build-freebsd.sh"
         # - os: osx
         #   osx_image: xcode11.3
         #   addons:


### PR DESCRIPTION
TravisCI [supports](https://github.com/travis-ci/travis-build/pulls?q=is%3Apr+freebsd+is%3Aclosed) FreeBSD nowadays. Let's see how well it works. Fixes #7885

Caveats:
- `pkg` addon maybe missing on job runners, so install manually
- `ccache` maybe not installed/configured, so do manually like on `osx`
- LLVM needs hooking into `cache: directories`, so disabled for now to avoid long builds
