### PR TITLE
PPU: Implement support for 128-byte reservations coherency

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -194,6 +194,8 @@ public:
 	u32 raddr{0}; // Reservation addr
 	u64 rtime{0};
 	u64 rdata{0}; // Reservation data
+	alignas(64) std::byte full_rdata[128]{}; // Full reservation data
+	bool use_full_rdata{};
 
 	atomic_t<s32> prio{0}; // Thread priority (0..3071)
 	const u32 stack_size; // Stack size

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -2527,6 +2527,12 @@ void PPUTranslator::MFOCRF(ppu_opcode_t op)
 
 void PPUTranslator::LWARX(ppu_opcode_t op)
 {
+	if (g_cfg.core.ppu_128_reservations_loop_max_length > 0)
+	{
+		// CIA will be used in lwarx handler
+		m_ir->CreateStore(Trunc(GetAddr(), GetType<u32>()), m_ir->CreateStructGEP(nullptr, m_thread, static_cast<uint>(&m_cia - m_locals)), true);
+	}
+
 	SetGpr(op.rd, Call(GetType<u32>(), "__lwarx", m_thread, op.ra ? m_ir->CreateAdd(GetGpr(op.ra), GetGpr(op.rb)) : GetGpr(op.rb)));
 }
 
@@ -2663,6 +2669,12 @@ void PPUTranslator::MULHW(ppu_opcode_t op)
 
 void PPUTranslator::LDARX(ppu_opcode_t op)
 {
+	if (g_cfg.core.ppu_128_reservations_loop_max_length > 0)
+	{
+		// CIA will be used in ldarx handler
+		m_ir->CreateStore(Trunc(GetAddr(), GetType<u32>()), m_ir->CreateStructGEP(nullptr, m_thread, static_cast<uint>(&m_cia - m_locals)), true);
+	}
+
 	SetGpr(op.rd, Call(GetType<u64>(), "__ldarx", m_thread, op.ra ? m_ir->CreateAdd(GetGpr(op.ra), GetGpr(op.rb)) : GetGpr(op.rb)));
 }
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -669,7 +669,7 @@ public:
 
 	// Reservation Data
 	u64 rtime = 0;
-	alignas(64) std::array<v128, 8> rdata{};
+	alignas(64) std::byte rdata[128]{};
 	u32 raddr = 0;
 
 	u32 srr0;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -273,7 +273,7 @@ namespace vm
 	{
 		if (auto& ptr = g_tls_locked)
 		{
-			*ptr = nullptr;
+			ptr->release(nullptr);
 			ptr = nullptr;
 
 			if (cpu.state & cpu_flag::memory)

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -54,6 +54,7 @@ struct cfg_root : cfg::node
 		cfg::_bool spu_approx_xfloat{ this, "Approximate xfloat", true };
 		cfg::_bool llvm_accurate_dfma{ this, "LLVM Accurate DFMA", true }; // Enable accurate double-precision FMA for CPUs which do not support it natively
 		cfg::_bool llvm_ppu_jm_handling{ this, "PPU LLVM Java Mode Handling", false }; // Respect current Java Mode for alti-vec ops by PPU LLVM 
+		cfg::_int<-1, 14> ppu_128_reservations_loop_max_length{ this, "Accurate PPU 128-byte Reservation Op Max Length", 0, true }; // -1: Always accurate, 0: Never accurate, 1-14: max accurate loop length
 		cfg::_bool llvm_ppu_accurate_vector_nan{ this, "PPU LLVM Accurate Vector NaN values", false };
 		cfg::_int<-64, 64> stub_ppu_traps{ this, "Stub PPU Traps", 0, true }; // Hack, skip PPU traps for rare cases where the trap is continueable (specify relative instructions to skip)
 


### PR DESCRIPTION
Implement support for 128-byte reservation load and store coherency when using the added setting "Accurate PPU 128-byte reservations".
An additional setting "Inaccurate PPU reservations loop instructions count" was added to use accurate path only for long reservations loop if enabled, when specifing 0 for it it's always accurate. (the setting is ignored if accurate 128-byte reservations are disabled)
Accurate 128-byte reservations make the reservation op fail if memory of the whole cache line has changed during the reservation op, not just the pointed 4/8 bytes by LWARX/LDARX, and makes it possible to store in STDCX/STWCX using a different address inside the same cache line as this hw test proves :  https://github.com/elad335/myps3tests/blob/master/spu_tests/atomic%20reservations%20tests/expected.txt
Another improvement is that even when this setting is disabled, all reservations op will track 8-byte reservations even for LWARX instruction so that's another accuracy improvement.

I've seen this used by a few functions in libsre.sprx where the reservations op also loads from memory of the other bytes of the cache line between load/store reservation loop bounds such as  cellSyncLFQueue functions.