### PR TITLE
vk: Implement masked stencil buffer clears

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -944,7 +944,7 @@ void VKGSRender::end()
 
 		// TODO: Stencil transfer
 		ds->old_contents[0].init_transfer(ds);
-		m_depth_converter->run(*m_current_command_buffer,
+		vk::get_overlay_pass<vk::depth_convert_pass>()->run(*m_current_command_buffer,
 			ds->old_contents[0].src_rect(),
 			ds->old_contents[0].dst_rect(),
 			src->get_view(0xAAE4, rsx::default_remap_vector),

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -360,10 +360,6 @@ private:
 	std::unique_ptr<vk::buffer_view> null_buffer_view;
 
 	std::unique_ptr<vk::text_writer> m_text_writer;
-	std::unique_ptr<vk::depth_convert_pass> m_depth_converter;
-	std::unique_ptr<vk::ui_overlay_renderer> m_ui_renderer;
-	std::unique_ptr<vk::attachment_clear_pass> m_attachment_clear_pass;
-	std::unique_ptr<vk::video_out_calibration_pass> m_video_output_pass;
 
 	std::unique_ptr<vk::buffer> m_cond_render_buffer;
 	u64 m_cond_render_sync_tag = 0;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -72,6 +72,7 @@ namespace vk
 	std::unordered_map<VkImageViewType, std::unique_ptr<image_view>> g_null_image_views;
 	std::unordered_map<u32, std::unique_ptr<image>> g_typeless_textures;
 	std::unordered_map<u32, std::unique_ptr<vk::compute_task>> g_compute_tasks;
+	std::unordered_map<u32, std::unique_ptr<vk::overlay_pass>> g_overlay_passes;
 
 	// General purpose upload heap
 	// TODO: Clean this up and integrate cleanly with VKGSRender
@@ -384,10 +385,19 @@ namespace vk
 		}
 	}
 
+	void reset_overlay_passes()
+	{
+		for (const auto& p : g_overlay_passes)
+		{
+			p.second->free_resources();
+		}
+	}
+
 	void reset_global_resources()
 	{
 		vk::reset_compute_tasks();
 		vk::reset_resolve_resources();
+		vk::reset_overlay_passes();
 
 		g_upload_heap.reset_allocation_stats();
 	}
@@ -420,8 +430,13 @@ namespace vk
 		{
 			p.second->destroy();
 		}
-
 		g_compute_tasks.clear();
+
+		for (const auto& p : g_overlay_passes)
+		{
+			p.second->destroy();
+		}
+		g_overlay_passes.clear();
 	}
 
 	vk::mem_allocator_base* get_current_mem_allocator()


### PR DESCRIPTION
Partial stencil buffer clears were not implemented. This is for example where a game can choose to clear only some bits from the stencil buffer. Vulkan does not support masked stencil clears natively, it has to be implemented as a graphics operation.

Also refactors vulkan overlay passes to use global resource system instead of forcing the render backend to own all of them and manage lifetimes.

Fixes https://github.com/RPCS3/rpcs3/issues/5079