### PR TITLE
PPU disasm: do not disassmble non-executable memory

### DIFF
--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -2318,5 +2318,5 @@ void PPUDisAsm::UNK(ppu_opcode_t op)
 		}
 	}
 
-	Write(fmt::format("Unknown/Illegal opcode! (0x%08x)", op.opcode));
+	Write("?? ??");
 }

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -966,8 +966,8 @@ public:
 		DisAsm("fms", spu_reg_name[op.rt4], spu_reg_name[op.ra], spu_reg_name[op.rb], spu_reg_name[op.rc]);
 	}
 
-	void UNK(spu_opcode_t op)
+	void UNK(spu_opcode_t /*op*/)
 	{
-		Write(fmt::format("Unknown/Illegal opcode! (0x%08x)", op.opcode));
+		Write("?? ??");
 	}
 };

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -82,7 +82,7 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 		u32 pc = m_pc;
 		for (uint i = 0; i < m_item_count; ++i, pc += 4)
 		{
-			item(i)->setText(qstr(fmt::format("   [%08x] illegal address", pc)));
+			item(i)->setText(qstr(fmt::format("   [%08x]  ?? ?? ?? ??:", pc)));
 		}
 	}
 	else
@@ -98,7 +98,7 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 		{
 			if (!vm::check_addr(cpu_offset + pc, 4))
 			{
-				item(i)->setText((IsBreakpoint(pc) ? ">> " : "   ") + qstr(fmt::format("[%08x] illegal address", pc)));
+				item(i)->setText((IsBreakpoint(pc) ? ">> " : "   ") + qstr(fmt::format("[%08x]  ?? ?? ?? ??:", pc)));
 				count = 4;
 				continue;
 			}

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -103,6 +103,18 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 				continue;
 			}
 
+			if (!is_spu && !vm::check_addr(cpu_offset + pc, 4, vm::page_executable))
+			{
+				const u32 data = *vm::get_super_ptr<atomic_be_t<u32>>(cpu_offset + pc);
+				item(i)->setText((IsBreakpoint(pc) ? ">> " : "   ") + qstr(fmt::format("[%08x]  %02x %02x %02x %02x:", pc,
+				static_cast<u8>(data >> 24),
+				static_cast<u8>(data >> 16),
+				static_cast<u8>(data >> 8),
+				static_cast<u8>(data >> 0))));
+				count = 4;
+				continue;
+			}
+
 			count = m_disasm->disasm(m_disasm->dump_pc = pc);
 
 			item(i)->setText((IsBreakpoint(pc) ? ">> " : "   ") + qstr(m_disasm->last_opcode));

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -188,7 +188,16 @@ void kernel_explorer::Update()
 		case SYS_PRX_OBJECT:
 		{
 			auto& prx = static_cast<lv2_prx&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("PRX: ID = 0x%08x '%s'", id, prx.name)));
+			const u32 addr0 = !prx.segs.empty() ? prx.segs[0].addr : 0;
+
+			if (!addr0)
+			{
+				l_addTreeChild(node, qstr(fmt::format("PRX: ID = 0x%08x '%s' (HLE)", id, prx.name)));
+				break;
+			}
+
+			const u32 end0 = addr0 + prx.segs[0].size - 1;
+			l_addTreeChild(node, qstr(fmt::format("PRX: ID = 0x%08x '%s', seg0 = [0x%x...0x%x]", id, prx.name, addr0, end0)));
 			break;
 		}
 		case SYS_SPUPORT_OBJECT:
@@ -199,7 +208,7 @@ void kernel_explorer::Update()
 		case SYS_OVERLAY_OBJECT:
 		{
 			auto& ovl = static_cast<lv2_overlay&>(obj);
-			l_addTreeChild(node, qstr(fmt::format("OVL: ID = 0x%08x '%s'", id, ovl.name)));
+			l_addTreeChild(node, qstr(fmt::format("OVL: ID = 0x%08x '%s', seg0 = [0x%x...0x%x]", id, ovl.name, ovl.segs[0].addr, ovl.segs[0].addr + ovl.segs[0].size - 1)));
 			break;
 		}
 		case SYS_LWMUTEX_OBJECT:


### PR DESCRIPTION
* Distinguish between executable code and data-only memory by not disassembling data-only memory at all.
* Add information about first PRX/overlay segment in kernel explorer, this is an executable code segement.