### PR TITLE
[CI,Windows] Build SPIRV-Tools separately

### DIFF
--- a/.ci/setup-windows.sh
+++ b/.ci/setup-windows.sh
@@ -35,7 +35,7 @@ DEP_URLS="         \
 # Pull all the submodules except llvm, since it is built separately and we just download that build
 # Note: Tried to use git submodule status, but it takes over 20 seconds
 # shellcheck disable=SC2046
-git submodule -q update --init $(awk '/path/ && !/llvm/ { print $3 }' .gitmodules)
+git submodule -q update --init --depth 1 $(awk '/path/ && !/llvm/ { print $3 }' .gitmodules)
 
 # Git bash doesn't have rev, so here it is
 rev()

--- a/Vulkan/spirv-tools-build/spirv-tools-build.vcxproj
+++ b/Vulkan/spirv-tools-build/spirv-tools-build.vcxproj
@@ -38,31 +38,32 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
     <CmakeGenerator>"Visual Studio $(VisualStudioVersion.Substring(0,2))"</CmakeGenerator>
-    <CmakeCLI>cmake -G $(CmakeGenerator) -A x64 -DCMAKE_CONFIGURATION_TYPES="Debug;Release" -DCMAKE_CXX_STANDARD=20 -DLLVM_USE_CRT_DEBUG=MTd -DLLVM_USE_CRT_RELEASE=MT -DSPIRV-Headers_SOURCE_DIR=$(SolutionDir)/Vulkan/spirv-headers ../spirv-tools</CmakeCLI>
+    <CmakeCLI>cmake -G $(CmakeGenerator) -A x64 -DCMAKE_CONFIGURATION_TYPES="Debug;Release" -DCMAKE_CXX_STANDARD=20 -DLLVM_USE_CRT_DEBUG=MTd -DLLVM_USE_CRT_RELEASE=MT -DSPIRV-Headers_SOURCE_DIR=$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../spirv-headers')) ../spirv-tools</CmakeCLI>
+    <PropsAbsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\common_default.props'))</PropsAbsPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <NMakeBuildCommandLine>
       $(CmakeCLI)
-      msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m</NMakeBuildCommandLine>
+      msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>
       $(CmakeCLI)
-      msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m</NMakeReBuildCommandLine>
+      msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>
       $(CmakeCLI)
-      msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m</NMakeCleanCommandLine>
+      msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m</NMakeCleanCommandLine>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <NMakeBuildCommandLine>
       $(CmakeCLI)
-      msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
+      msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m
     </NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>
       $(CmakeCLI)
-      msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
+      msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m
     </NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>
       $(CmakeCLI)
-      msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
+      msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m
     </NMakeCleanCommandLine>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,10 +71,18 @@ jobs:
     - bash: .ci/export-azure-vars.sh
       displayName: Export Variables
 
+    - task: MSBuild@1
+      inputs:
+        solution: './Vulkan/spirv-tools-build/spirv-tools-build.vcxproj'
+        maximumCpuCount: true
+        platform: x64
+        configuration: 'Release'
+      displayName: Compile SPIRV-Tools
+
     - task: VSBuild@1
       inputs:
         solution: 'rpcs3.sln'
-        msbuildArgs: '/m'
+        maximumCpuCount: true
         platform: x64
         configuration: 'Release - LLVM'
       displayName: Compile RPCS3

--- a/rpcs3.sln
+++ b/rpcs3.sln
@@ -284,15 +284,10 @@ Global
 		{DA6F56B4-06A4-441D-AD70-AC5A7D51FADB}.Release|x64.ActiveCfg = Release|x64
 		{DA6F56B4-06A4-441D-AD70-AC5A7D51FADB}.Release|x64.Build.0 = Release|x64
 		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Debug - LLVM|x64.ActiveCfg = Debug|x64
-		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Debug - LLVM|x64.Build.0 = Debug|x64
 		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Debug - MemLeak|x64.ActiveCfg = Debug|x64
-		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Debug - MemLeak|x64.Build.0 = Debug|x64
 		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Debug|x64.ActiveCfg = Debug|x64
-		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Debug|x64.Build.0 = Debug|x64
 		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Release - LLVM|x64.ActiveCfg = Release|x64
-		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Release - LLVM|x64.Build.0 = Release|x64
 		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Release|x64.ActiveCfg = Release|x64
-		{4CBD3DDD-5555-49A4-A44D-DD3D8CB516A1}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Also, I think that if a single Intermediate dir is created it could be cached along with libs and bin folders to drastically speed up compilation, thou it would require not updating cache on Pull Requests at all or creating a separate cache per Pull Request and using either PR specific cache or falling back to the general cache on the first PR build if that is possible to do with azure at all.

EDIT:
I will try to do that in another PR so no longer WIP.