### PR TITLE
IDM: Implement IDs creation/destruction invalidation counter

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -60,6 +60,7 @@ public:
 	static const u32 id_base = 0x01000000; // TODO (used to determine thread type)
 	static const u32 id_step = 1;
 	static const u32 id_count = 2048;
+	static constexpr std::pair<u32, u32> id_invl_range = {12, 12};
 
 	virtual std::string dump_all() const override;
 	virtual std::string dump_regs() const override;

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -147,6 +147,7 @@ error_code sys_mmapper_allocate_shared_memory(ppu_thread& ppu, u64 ipc_key, u32 
 
 	if (auto error = create_lv2_shm(ipc_key != SYS_MMAPPER_NO_SHM_KEY, ipc_key, size, flags & SYS_MEMORY_PAGE_SIZE_64K ? 0x10000 : 0x100000, flags, dct))
 	{
+		dct->used -= size;
 		return error;
 	}
 
@@ -216,6 +217,7 @@ error_code sys_mmapper_allocate_shared_memory_from_container(ppu_thread& ppu, u6
 
 	if (auto error = create_lv2_shm(ipc_key != SYS_MMAPPER_NO_SHM_KEY, ipc_key, size, flags & SYS_MEMORY_PAGE_SIZE_64K ? 0x10000 : 0x100000, flags, ct.ptr.get()))
 	{
+		ct->used -= size;
 		return error;
 	}
 
@@ -319,6 +321,7 @@ error_code sys_mmapper_allocate_shared_memory_ext(ppu_thread& ppu, u64 ipc_key, 
 
 	if (auto error = create_lv2_shm<true>(true, ipc_key, size, flags & SYS_MEMORY_PAGE_SIZE_64K ? 0x10000 : 0x100000, flags, dct))
 	{
+		dct->used -= size;
 		return error;
 	}
 
@@ -430,6 +433,7 @@ error_code sys_mmapper_allocate_shared_memory_from_container_ext(ppu_thread& ppu
 
 	if (auto error = create_lv2_shm<true>(true, ipc_key, size, flags & SYS_MEMORY_PAGE_SIZE_64K ? 0x10000 : 0x100000, flags, ct.ptr.get()))
 	{
+		ct->used -= size;
 		return error;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -260,6 +260,7 @@ struct lv2_spu_group
 	static const u32 id_base = 0x04000100;
 	static const u32 id_step = 0x100;
 	static const u32 id_count = 255;
+	static constexpr std::pair<u32, u32> id_invl_range = {0, 8};
 
 	const std::string name;
 	const u32 id;

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -66,6 +66,7 @@ struct lv2_obj
 
 	static const u32 id_step = 0x100;
 	static const u32 id_count = 8192;
+	static constexpr std::pair<u32, u32> id_invl_range = {0, 8};
 
 private:
 	enum thread_cmd : s32

--- a/rpcs3/Emu/IdManager.cpp
+++ b/rpcs3/Emu/IdManager.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "IdManager.h"
 #include "Utilities/Thread.h"
 
@@ -7,7 +7,7 @@ shared_mutex id_manager::g_mutex;
 thread_local DECLARE(idm::g_id);
 DECLARE(idm::g_map);
 
-id_manager::id_map::pointer idm::allocate_id(const id_manager::id_key& info, u32 base, u32 step, u32 count)
+id_manager::id_map::pointer idm::allocate_id(const id_manager::id_key& info, u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range)
 {
 	// Base type id is stored in value
 	auto& vec = g_map[info.value()];
@@ -32,8 +32,10 @@ id_manager::id_map::pointer idm::allocate_id(const id_manager::id_key& info, u32
 		// Look for free ID
 		if (!ptr->second)
 		{
-			g_id = next;
-			ptr->first = id_manager::id_key(next, info.type());
+			// Incremenet ID invalidation counter
+			const u32 id = next | ((ptr->first + (1u << invl_range.first)) & (invl_range.second ? (((1u << invl_range.second) - 1) << invl_range.first) : 0));
+			g_id = id;
+			ptr->first = id_manager::id_key(id, info.type());
 			return ptr;
 		}
 	}

--- a/rpcs3/Emu/IdManager.h
+++ b/rpcs3/Emu/IdManager.h
@@ -18,22 +18,39 @@ namespace id_manager
 	{
 		static_assert(sizeof(T) == 0, "ID object must specify: id_base, id_step, id_count");
 
-		static const u32 base    = 1;     // First ID (N = 0)
-		static const u32 step    = 1;     // Any ID: N * id_step + id_base
-		static const u32 count   = 65535; // Limit: N < id_count
-		static const u32 invalid = 0;
+		static constexpr u32 base    = 1;     // First ID (N = 0)
+		static constexpr u32 step    = 1;     // Any ID: N * id_step + id_base
+		static constexpr u32 count   = 65535; // Limit: N < id_count
+		static constexpr u32 invalid = 0;
+		static constexpr std::pair<u32, u32> invl_range{0, 0};
+	};
+
+	template <typename T, typename = void>
+	struct invl_range_extract_impl
+	{
+		static constexpr std::pair<u32, u32> invl_range{0, 0};
+	};
+
+	template <typename T>
+	struct invl_range_extract_impl<T, std::void_t<decltype(&T::id_invl_range)>>
+	{
+		static constexpr std::pair<u32, u32> invl_range = T::id_invl_range;
 	};
 
 	template <typename T>
 	struct id_traits<T, std::void_t<decltype(&T::id_base), decltype(&T::id_step), decltype(&T::id_count)>>
 	{
-		static const u32 base    = T::id_base;
-		static const u32 step    = T::id_step;
-		static const u32 count   = T::id_count;
-		static const u32 invalid = -+!base;
+		static constexpr u32 base    = T::id_base;
+		static constexpr u32 step    = T::id_step;
+		static constexpr u32 count   = T::id_count;
+		static constexpr u32 invalid = -+!base;
 
-		// Note: full 32 bits range cannot be used at current implementation
+		static constexpr std::pair<u32, u32> invl_range = invl_range_extract_impl<T>::invl_range;
+
 		static_assert(count && step && u64{step} * (count - 1) + base < u64{UINT32_MAX} + (base != 0 ? 1 : 0), "ID traits: invalid object range");
+	
+		// TODO: Add more conditions
+		static_assert(!invl_range.second || (u64{invl_range.second} + invl_range.first <= 32 /*....*/ ));
 	};
 
 	// Correct usage testing
@@ -138,8 +155,10 @@ class idm
 	{
 		using traits = id_manager::id_traits<T>;
 
+		constexpr u32 mask_out = ((1u << traits::invl_range.second) - 1) << traits::invl_range.first;
+
 		// Note: if id is lower than base, diff / step will be higher than count
-		u32 diff = id - traits::base;
+		u32 diff = (id & ~mask_out) - traits::base;
 
 		if (diff % traits::step)
 		{
@@ -230,7 +249,7 @@ class idm
 	};
 
 	// Prepare new ID (returns nullptr if out of resources)
-	static id_manager::id_map::pointer allocate_id(const id_manager::id_key& info, u32 base, u32 step, u32 count);
+	static id_manager::id_map::pointer allocate_id(const id_manager::id_key& info, u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range);
 
 	// Find ID (additionally check type if types are not equal)
 	template <typename T, typename Type>
@@ -258,7 +277,10 @@ class idm
 		{
 			if (std::is_same<T, Type>::value || data.first.type() == get_type<Type>())
 			{
-				return &data;
+				if (!id_manager::id_traits<Type>::invl_range.second || data.first.value() == id)
+				{
+					return &data;
+				}
 			}
 		}
 
@@ -280,7 +302,7 @@ class idm
 		// Allocate new id
 		std::lock_guard lock(id_manager::g_mutex);
 
-		if (auto* place = allocate_id(info, traits::base, traits::step, traits::count))
+		if (auto* place = allocate_id(info, traits::base, traits::step, traits::count, traits::invl_range))
 		{
 			// Get object, store it
 			place->second = provider();


### PR DESCRIPTION
When destructing an object belongs to the following group: lv2_obj, lv2_spu_group, ppu_thread 
 (and may be more lv2 types) the ID value of the object is guaranteed to not reappear for atleast 256 creations from the same object type.

This means that in code like so:
```
sys_ppu_thread_t ppu_id, ppu_id2;
sys_ppu_thread_create(&ppu_id, ...);
u64 ret;
sys_spu_thread_join(ppu_id, &ret);
sys_ppu_thread_create(&ppu_id2, ...);

int prio;
assert(ppu_id != ppu_id2 && sys_ppu_thread_get_priority(ppu_id, &prio) == ESRCH);
```
The assert will never trigger, assuming no other thread is executing sys_ppu_thread_create at the time.

In realhw bits 16-23 are incremeneted each time for this purpose, although we use those bits for object indexing so use bits 0-7 for this instead.
After 256 times of incrementation of the same value it wraps around.
Testcase : https://github.com/elad335/myps3tests/tree/master/ppu_tests/IDM%20IDs%20invalidations

In the testcase, first creating two objects in a row without any destruction then performing couples of creation+destruction and then printing all IDs generated.
You can see that the difference between the first two IDs and the following ones are in completely different bit positions. (except for PPU ids where a little different but similar thing happens)

Second commit contains fix for possible memory leak on error of sys_mmapper lv2_memory allocation syscalls (minor change).
