### PR TITLE
[MSVC 16.6] Microsoft.MakeFile.Targets(46,5) :thisisfine:

### DIFF
--- a/Vulkan/glslang-build/glslang-build.vcxproj
+++ b/Vulkan/glslang-build/glslang-build.vcxproj
@@ -41,27 +41,21 @@
     <CmakeCLI>cmake -G $(CmakeGenerator) -A x64 -DCMAKE_CONFIGURATION_TYPES="Debug;Release" -DCMAKE_CXX_STANDARD=20 -DLLVM_USE_CRT_DEBUG=MTd -DLLVM_USE_CRT_RELEASE=MT ../glslang</CmakeCLI>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <NMakeBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m</NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeReBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m</NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>
-      $(CmakeCLI)
+    <NMakeCleanCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m</NMakeCleanCommandLine>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <NMakeBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeReBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>
-      $(CmakeCLI)
+    <NMakeCleanCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeCleanCommandLine>
   </PropertyGroup>

--- a/Vulkan/spirv-tools-build/spirv-tools-build.vcxproj
+++ b/Vulkan/spirv-tools-build/spirv-tools-build.vcxproj
@@ -42,27 +42,21 @@
     <PropsAbsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\common_default.props'))</PropsAbsPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <NMakeBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m</NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeReBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m</NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>
-      $(CmakeCLI)
+    <NMakeCleanCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m</NMakeCleanCommandLine>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <NMakeBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m
     </NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeReBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m
     </NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>
-      $(CmakeCLI)
+    <NMakeCleanCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(PropsAbsPath) /m
     </NMakeCleanCommandLine>
   </PropertyGroup>

--- a/llvm_build/llvm_build.vcxproj
+++ b/llvm_build/llvm_build.vcxproj
@@ -41,31 +41,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <NMakePreprocessorDefinitions>
     </NMakePreprocessorDefinitions>
-    <NMakeBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeReBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>
-      $(CmakeCLI)
+    <NMakeCleanCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Debug /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeCleanCommandLine>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <NMakePreprocessorDefinitions />
-    <NMakeBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:build /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>
-      $(CmakeCLI)
+    <NMakeReBuildCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:rebuild /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>
-      $(CmakeCLI)
+    <NMakeCleanCommandLine>$(CmakeCLI)
       msbuild.exe ALL_BUILD.vcxproj /t:clean /p:Configuration=Release /p:ForceImportBeforeCppTargets=$(SolutionDir)common_default.props /m
     </NMakeCleanCommandLine>
   </PropertyGroup>


### PR DESCRIPTION
Should fix `Microsoft.MakeFile.Targets(46,5)` error on Visual Studio 16.6 when building `_BULD_BEFORE` projects. If it does not ping me.