### PR TITLE
SPU: Fix page faults notifications (non-TSX)

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1273,6 +1273,7 @@ namespace vm
 
 			std::memset(g_reservations, 0, sizeof(g_reservations));
 			std::memset(g_shareable, 0, sizeof(g_shareable));
+			std::memset(g_range_locks.data(), 0, sizeof(g_range_locks));
 		}
 	}
 

--- a/rpcs3/Emu/Memory/vm_reservation.h
+++ b/rpcs3/Emu/Memory/vm_reservation.h
@@ -26,18 +26,23 @@ namespace vm
 		return *reinterpret_cast<atomic_t<u64>*>(g_reservations + (addr & 0xff80) / 2);
 	}
 
-	void reservation_lock_internal(atomic_t<u64>&);
+	bool reservation_lock_internal(u32, atomic_t<u64>&);
 
 	inline atomic_t<u64>& reservation_lock(u32 addr, u32 size)
 	{
-		auto& res = vm::reservation_acquire(addr, size);
+		auto res = &vm::reservation_acquire(addr, size);
 
-		if (res.bts(0)) [[unlikely]]
+		if (res->bts(0)) [[unlikely]]
 		{
-			reservation_lock_internal(res);
+			static atomic_t<u64> no_lock{};
+
+			if (!reservation_lock_internal(addr, *res))
+			{
+				res = &no_lock;
+			}
 		}
 
-		return res;
+		return *res;
 	}
 
 	inline bool reservation_trylock(atomic_t<u64>& res, u64 rtime)


### PR DESCRIPTION
* Do not ever lock vm memory that is meant to be page faulted on or unmapped memory in general, this bug always existed but #8008 added another single case where the bug finally made it crash GT6.

Fixes #8109.

