### PR TITLE
[CI, Cache] Add proper cache versioning

### DIFF
--- a/.ci/get_keys-windows.sh
+++ b/.ci/get_keys-windows.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+
+curl -L -o "./llvm.lock" "https://github.com/RPCS3/llvm-mirror/releases/download/custom-build-win/llvmlibs_mt.7z.sha256"
+curl -L -o "./glslang.lock" "https://github.com/RPCS3/glslang/releases/download/custom-build-win/glslanglibs_mt.7z.sha256"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,10 +59,15 @@ jobs:
     vmImage: "windows-latest"
 
   steps:
+    - bash: .ci/get_keys-windows.sh
+      displayName: Get Cache Keys
+
     - task: Cache@2
       inputs:
-        key: $(Agent.OS) | $(COMPILER)
+        key: $(Agent.OS) | $(COMPILER) | "$(QT_VER)" | $(VULKAN_SDK_SHA) | llvm.lock | glslang.lock
         path: $(CACHE_DIR)
+        restoreKeys: |
+          $(Agent.OS) | $(COMPILER)
       displayName: Cache
 
     - bash: .ci/setup-windows.sh


### PR DESCRIPTION
Adds per dependency cache.

EDIT:
all hashes and version numbers can be combined and used as a single key then all deps can be in a single cache but the pros and cons of that are questionable.

EDIT:
trying singe cache with proper versioning

EDIT:
seems like deps don't update often so it is probably better to do a single cache with fallback.