### PR TITLE
SPU LLVM: implement get_segment_base()

### DIFF
--- a/rpcs3/Emu/Cell/MFC.cpp
+++ b/rpcs3/Emu/Cell/MFC.cpp
@@ -45,6 +45,12 @@ void fmt_class_string<MFC>::format(std::string& out, u64 arg)
 		case MFC_EIEIO_CMD: return "EIEIO";
 		case MFC_SYNC_CMD: return "SYNC";
 
+		case MFC_SDCRT_CMD: return "SDCRT";
+		case MFC_SDCRTST_CMD: return "SDCRTST";
+		case MFC_SDCRZ_CMD: return "SDCRZ";
+		case MFC_SDCRS_CMD: return "SDCRS";
+		case MFC_SDCRF_CMD: return "SDCRF";
+
 		case MFC_BARRIER_MASK:
 		case MFC_FENCE_MASK:
 		case MFC_LIST_MASK:

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -999,7 +999,7 @@ void spu_thread::cpu_stop()
 							|| status != thread->last_exit_status;)
 						{
 							_mm_pause();
-						} 
+						}
 					}
 				}
 
@@ -1728,7 +1728,7 @@ void spu_thread::do_putlluc(const spu_mfc_cmd& args)
 			vm::reservation_acquire(addr, 128) += 64;
 		}
 
-		+test_stopped();
+		static_cast<void>(test_stopped());
 	}
 	else
 	{


### PR DESCRIPTION
This PR works around a rare LLVM bug causing SPU LLVM crash on Windows. New approach is also better for future SPU LLVM object retention.