### PR TITLE
rsx: Improve surface cache resource management

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -305,7 +305,8 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 	m_gl_texture_cache.on_frame_end();
 	m_vertex_cache->purge();
 
-	auto removed_textures = m_rtts.free_invalidated();
+	gl::command_context cmd{ gl_state };
+	auto removed_textures = m_rtts.free_invalidated(cmd);
 	m_framebuffer_cache.remove_if([&](auto& fbo)
 	{
 		if (fbo.unused_check_count() >= 2) return true; // Remove if stale

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -355,8 +355,14 @@ struct gl_render_targets : public rsx::surface_store<gl_render_target_traits>
 		invalidated_resources.clear();
 	}
 
-	std::vector<GLuint> free_invalidated()
+	std::vector<GLuint> free_invalidated(gl::command_context& cmd)
 	{
+		// Do not allow more than 256M of RSX memory to be used by RTTs
+		if (check_memory_overload(256 * 0x100000))
+		{
+			handle_memory_overload(cmd);
+		}
+
 		std::vector<GLuint> removed;
 		invalidated_resources.remove_if([&](auto &rtt)
 		{

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -105,7 +105,7 @@ void VKGSRender::advance_queued_frames()
 	check_present_status();
 
 	// m_rtts storage is double buffered and should be safe to tag on frame boundary
-	m_rtts.free_invalidated();
+	m_rtts.free_invalidated(*m_current_command_buffer);
 
 	// Texture cache is also double buffered to prevent use-after-free
 	m_texture_cache.on_frame_end();

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -870,8 +870,19 @@ namespace rsx
 			invalidated_resources.clear();
 		}
 
-		void free_invalidated()
+		void free_invalidated(vk::command_buffer& cmd)
 		{
+			// Do not allow more than 256M of RSX memory to be used by RTTs
+			if (check_memory_overload(256 * 0x100000))
+			{
+				if (!cmd.is_recording())
+				{
+					cmd.begin();
+				}
+
+				handle_memory_overload(cmd);
+			}
+
 			const u64 last_finished_frame = vk::get_last_completed_frame_id();
 			invalidated_resources.remove_if([&](std::unique_ptr<vk::render_target> &rtt)
 			{


### PR DESCRIPTION
- Do not allocate too many surface objects. This is a problem in games using dynamic memory allocators that can make it rare for a surface to fall on the same address twice, keeping zombie RTVs and DSVs alive much longer than needed.
- Current limit used is 256M of virtual VRAM which is impossible on retail PS3 and is a good indicator to start removing unnecessary data.

Fixes https://github.com/RPCS3/rpcs3/issues/6253