### PR TITLE
XAudio2: turn down the volume

### DIFF
--- a/rpcs3/Emu/Audio/XAudio2/XAudio2Backend.cpp
+++ b/rpcs3/Emu/Audio/XAudio2/XAudio2Backend.cpp
@@ -111,7 +111,7 @@ void XAudio2Backend::Open(u32 /* num_buffers */)
 	}
 
 	AUDIT(m_source_voice != nullptr);
-	m_source_voice->SetVolume(channels == 2 ? 1.0f : 4.0f);
+	m_source_voice->SetVolume(1.0f);
 }
 
 bool XAudio2Backend::IsPlaying()


### PR DESCRIPTION
I was wondering why my games were inexplicably loud, even when I went down to 20%.
Thanks to @Nekotekina I found out, that the volume in the XAudio2 backend was set to 400% for some reason.

By setting the volume to 100% the games now finally sound normal again and the master volume slider works as expected.