### PR TITLE
rsx: Fix fragment state updates

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -112,6 +112,17 @@ namespace rsx
 		result_zcull_intr = 2
 	};
 
+	enum ROP_control : u32
+	{
+		alpha_test_enable       = (1u << 0),
+		framebuffer_srgb_enable = (1u << 1),
+		csaa_enable             = (1u << 4),
+		msaa_mask_enable        = (1u << 5),
+		msaa_config_mask        = (3u << 6),
+		polygon_stipple_enable  = (1u << 9),
+		alpha_func_mask         = (7u << 16)
+	};
+
 	u32 get_vertex_type_size_on_host(vertex_base_type type, u32 size);
 
 	// TODO: Replace with std::source_location in c++20

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -3121,7 +3121,7 @@ namespace rsx
 		bind<NV4097_SET_INDEX_ARRAY_DMA, nv4097::check_index_array_dma>();
 		bind<NV4097_SET_BLEND_EQUATION, nv4097::set_blend_equation>();
 		bind<NV4097_SET_POLYGON_STIPPLE, nv4097::notify_state_changed<fragment_state_dirty>>();
-		bind_array<NV4097_SET_POLYGON_STIPPLE, 1, 32, nv4097::notify_state_changed<polygon_stipple_pattern_dirty>>();
+		bind_array<NV4097_SET_POLYGON_STIPPLE_PATTERN, 1, 32, nv4097::notify_state_changed<polygon_stipple_pattern_dirty>>();
 
 		//NV308A (0xa400..0xbffc!)
 		bind_range<NV308A_COLOR + (256 * 0), 1, 256, nv308a::color, 256 * 0>();


### PR DESCRIPTION
- Fix copypasta for SET_POLYGON_STIPPLE_PATTERN vs SET_POLYGON_STIPPLE method binding. This is a regression from stippled rendering PR.
- Use proper enums for ROP_control bits to avoid confusion.

Fixes https://github.com/RPCS3/rpcs3/issues/8332