### PR TITLE
Avoid some useless checks

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -332,14 +332,13 @@ void cpu_thread::operator()()
 	{
 		thread_ctrl::set_thread_affinity_mask(thread_ctrl::get_affinity_mask(id_type() == 1 ? thread_class::ppu : thread_class::spu));
 	}
-
-	if (g_cfg.core.lower_spu_priority && id_type() == 2)
-	{
-		thread_ctrl::set_native_priority(-1);
-	}
-
 	if (id_type() == 2)
 	{
+		if (g_cfg.core.lower_spu_priority)
+		{
+			thread_ctrl::set_native_priority(-1);
+		}
+	
 		// force input/output denormals to zero for SPU threads (FTZ/DAZ)
 		_mm_setcsr( _mm_getcsr() | 0x8040 );
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1892,7 +1892,7 @@ static void ppu_initialize2(jit_compiler& jit, const ppu_module& module_part, co
 			}
 		}
 
-		legacy::PassManager mpm;
+		//legacy::PassManager mpm;
 
 		// Remove unused functions, structs, global variables, etc
 		//mpm.add(createStripDeadPrototypesPass());

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -274,10 +274,10 @@ const auto spu_putllc_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, const
 	Label skip = c.newLabel();
 	Label next = c.newLabel();
 
-	if (utils::has_avx() && !s_tsx_avx)
-	{
-		c.vzeroupper();
-	}
+	//if (utils::has_avx() && !s_tsx_avx)
+	//{
+	//	c.vzeroupper();
+	//}
 
 	// Create stack frame if necessary (Windows ABI has only 6 volatile vector registers)
 	c.push(x86::rbp);
@@ -566,10 +566,10 @@ const auto spu_putlluc_tx = build_function_asm<u32(*)(u32 raddr, const void* rda
 	Label skip = c.newLabel();
 	Label next = c.newLabel();
 
-	if (utils::has_avx() && !s_tsx_avx)
-	{
-		c.vzeroupper();
-	}
+	//if (utils::has_avx() && !s_tsx_avx)
+	//{
+	//	c.vzeroupper();
+	//}
 
 	// Create stack frame if necessary (Windows ABI has only 6 volatile vector registers)
 	c.push(x86::rbp);

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -69,8 +69,7 @@ LOG_CHANNEL(sys_log, "SYS");
 		static char* argv[] = {+s_argv0};
 		app.reset(new QApplication{argc, argv});
 	}
-
-	if (!local)
+	else
 	{
 		fprintf(stderr, "RPCS3: %s\n", text.c_str());
 	}

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -320,15 +320,18 @@ void kernel_explorer::Update()
 
 	for (auto&& entry : lv2_types)
 	{
-		if (entry.node && entry.count)
+		if (entry.node)
 		{
-			// Append object count
-			entry.node->setText(0, entry.node->text(0) + qstr(fmt::format(" (%zu)", entry.count)));
-		}
-		else if (entry.node)
-		{
-			// Delete node otherwise
-			delete entry.node;
+			if (entry.count)
+			{
+				// Append object count
+				entry.node->setText(0, entry.node->text(0) + qstr(fmt::format(" (%zu)", entry.count)));
+			}
+			else
+			{
+				// Delete node otherwise
+				delete entry.node;
+			}
 		}
 	}
 


### PR DESCRIPTION
* Avoid double check for id_type in ```CPUThread.cpp```
* Comment out unused object construction in ```PPUThread.cpp```
* Comment out 'never-true' condition in ```SPUThread.cpp```
```s_tsx_avx``` contains avx capability. Since avx is a processor feature, it can't be changed on runtime. It means, that by the time this line is executed, values are the same.
* Avoid double check in ```report_fatal_error``` in ```main.cpp```
* Avoid double check in ```kernel_explorer::Update()```