### PR TITLE
SPU/sys_cond/mutex/event: Implement lv2_obj::on_id_create(), Write into SPU inbound mailbox under mutex

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -3028,7 +3028,6 @@ bool spu_thread::stop_and_signal(u32 code)
 
 			if (!lv2_event_queue::check(queue))
 			{
-				check_state();
 				return ch_in_mbox.set_values(1, CELL_EINVAL), true;
 			}
 
@@ -3036,7 +3035,6 @@ bool spu_thread::stop_and_signal(u32 code)
 
 			if (!queue->exists)
 			{
-				check_state();
 				return ch_in_mbox.set_values(1, CELL_EINVAL), true;
 			}
 
@@ -3065,7 +3063,6 @@ bool spu_thread::stop_and_signal(u32 code)
 				const auto data3 = static_cast<u32>(std::get<3>(event));
 				ch_in_mbox.set_values(4, CELL_OK, data1, data2, data3);
 				queue->events.pop_front();
-				check_state();
 				return true;
 			}
 		}
@@ -3113,7 +3110,6 @@ bool spu_thread::stop_and_signal(u32 code)
 			}
 		}
 
-		check_state();
 		return true;
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2603,21 +2603,23 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 					fmt::throw_exception("sys_spu_thread_send_event(value=0x%x, spup=%d): Out_MBox is empty" HERE, value, spup);
 				}
 
-				if (u32 count = ch_in_mbox.get_count())
-				{
-					fmt::throw_exception("sys_spu_thread_send_event(value=0x%x, spup=%d): In_MBox is not empty (count=%d)" HERE, value, spup, count);
-				}
-
 				spu_log.trace("sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x)", spup, value & 0x00ffffff, data);
 
-				const auto queue = (std::lock_guard{group->mutex}, this->spup[spup].lock());
+				std::lock_guard lock(group->mutex);
 
-				const auto res = !queue ? CELL_ENOTCONN :
+				const auto queue = this->spup[spup].lock();
+
+				const auto res = ch_in_mbox.get_count() ? CELL_EBUSY :
+					!queue ? CELL_ENOTCONN :
 					queue->send(SYS_SPU_THREAD_EVENT_USER_KEY, lv2_id, (u64{spup} << 32) | (value & 0x00ffffff), data);
 
-				if (res == CELL_ENOTCONN)
+				if (ch_in_mbox.get_count())
 				{
-					spu_log.warning("sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x): event queue not connected", spup, (value & 0x00ffffff), data);
+					spu_log.warning("sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x): In_MBox is not empty (%d)", spup, (value & 0x00ffffff), data, ch_in_mbox.get_count());
+				}
+				else if (res == CELL_ENOTCONN)
+				{
+					spu_log.warning("sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x): error (%s)", spup, (value & 0x00ffffff), data, res);
 				}
 
 				ch_in_mbox.set_values(1, res);
@@ -2659,17 +2661,19 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 					fmt::throw_exception("sys_event_flag_set_bit(value=0x%x (flag=%d)): Out_MBox is empty" HERE, value, flag);
 				}
 
-				if (u32 count = ch_in_mbox.get_count())
-				{
-					fmt::throw_exception("sys_event_flag_set_bit(value=0x%x (flag=%d)): In_MBox is not empty (%d)" HERE, value, flag, count);
-				}
-
 				spu_log.trace("sys_event_flag_set_bit(id=%d, value=0x%x (flag=%d))", data, value, flag);
 
-				// Use the syscall to set flag
-				const auto res = sys_event_flag_set(data, 1ull << flag);
-				ch_in_mbox.set_values(1, res);
+				std::lock_guard lock(group->mutex);
 
+				// Use the syscall to set flag
+				const auto res = ch_in_mbox.get_count() ? CELL_EBUSY : 0u + sys_event_flag_set(data, 1ull << flag);
+
+				if (res == CELL_EBUSY)
+				{
+					spu_log.warning("sys_event_flag_set_bit(value=0x%x (flag=%d)): In_MBox is not empty (%d)", value, flag, ch_in_mbox.get_count());
+				}
+
+				ch_in_mbox.set_values(1, res);
 				return true;
 			}
 			else if (code == 192)

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -205,16 +205,35 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 
 	sys_cond.trace("sys_cond_wait(cond_id=0x%x, timeout=%lld)", cond_id, timeout);
 
-	const auto cond = idm::get<lv2_obj, lv2_cond>(cond_id, [&](lv2_cond& cond)
+	// Further function result
+	ppu.gpr[3] = CELL_OK;
+
+	const auto cond = idm::get<lv2_obj, lv2_cond>(cond_id, [&](lv2_cond& cond) -> s64
 	{
-		if (cond.mutex->owner >> 1 == ppu.id)
+		if (cond.mutex->owner >> 1 != ppu.id)
 		{
-			// Add a "promise" to add a waiter
-			cond.waiters++;
+			return -1;
 		}
 
+		std::lock_guard lock(cond.mutex->mutex);
+
+		// Register waiter
+		cond.sq.emplace_back(&ppu);
+		cond.waiters++;
+
+		// Unlock the mutex
+		const auto count = cond.mutex->lock_count.exchange(0);
+
+		if (auto cpu = cond.mutex->reown<ppu_thread>())
+		{
+			cond.mutex->append(cpu);
+		}
+
+		// Sleep current thread and schedule mutex waiter
+		cond.sleep(ppu, timeout);
+
 		// Save the recursive value
-		return cond.mutex->lock_count.load();
+		return count;
 	});
 
 	if (!cond)
@@ -222,31 +241,9 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 		return CELL_ESRCH;
 	}
 
-	// Verify ownership
-	if (cond->mutex->owner >> 1 != ppu.id)
+	if (cond.ret < 0)
 	{
 		return CELL_EPERM;
-	}
-	else
-	{
-		// Further function result
-		ppu.gpr[3] = CELL_OK;
-
-		std::lock_guard lock(cond->mutex->mutex);
-
-		// Register waiter
-		cond->sq.emplace_back(&ppu);
-
-		// Unlock the mutex
-		cond->mutex->lock_count = 0;
-
-		if (auto cpu = cond->mutex->reown<ppu_thread>())
-		{
-			cond->mutex->append(cpu);
-		}
-
-		// Sleep current thread and schedule mutex waiter
-		cond->sleep(ppu, timeout);
 	}
 
 	while (!ppu.state.test_and_reset(cpu_flag::signal))

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -59,7 +59,7 @@ error_code sys_cond_destroy(ppu_thread& ppu, u32 cond_id)
 			return CELL_EBUSY;
 		}
 
-		cond.mutex->cond_count--;
+		cond.mutex->obj_count.atomic_op([](typename lv2_mutex::count_info& info){ info.cond_count--; });
 		return {};
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -85,7 +85,7 @@ struct lv2_event_queue final : public lv2_obj
 	const u64 key;
 	const s32 size;
 
-	atomic_t<bool> exists = true; // Existence validation (workaround for shared-ptr ref-counting)
+	atomic_t<u32> exists = 0; // Existence validation (workaround for shared-ptr ref-counting)
 	shared_mutex mutex;
 	std::deque<lv2_event> events;
 	std::deque<cpu_thread*> sq;
@@ -112,6 +112,12 @@ struct lv2_event_queue final : public lv2_obj
 	// Check queue ptr validity (use 'exists' member)
 	static bool check(const std::weak_ptr<lv2_event_queue>&);
 	static bool check(const std::shared_ptr<lv2_event_queue>&);
+
+	CellError on_id_create()
+	{
+		exists++;
+		return {};
+	}
 };
 
 struct lv2_event_port final : lv2_obj

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -231,7 +231,7 @@ error_code _sys_lwcond_signal_all(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 
 			u32 result = 0;
 
-			for (const auto cpu : ::as_rvalue(std::move(cond.sq)))
+			while (const auto cpu = cond.schedule<ppu_thread>(cond.sq, cond.protocol))
 			{
 				cond.waiters--;
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -88,7 +88,17 @@ error_code sys_mutex_destroy(ppu_thread& ppu, u32 mutex_id)
 			return CELL_EBUSY;
 		}
 
-		if (mutex.cond_count)
+		if (!mutex.obj_count.fetch_op([](typename lv2_mutex::count_info& info)
+		{
+			if (info.cond_count)
+			{
+				return false;
+			}
+
+			// Decrement mutex copies count
+			info.mutex_count--;
+			return true;
+		}).second)
 		{
 			return CELL_EPERM;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -33,10 +33,16 @@ struct lv2_mutex final : lv2_obj
 	const u64 name;
 	const s32 flags;
 
+	struct alignas(8) count_info
+	{
+		u32 mutex_count; // Mutex copies count (0 means doesn't exist anymore)
+		u32 cond_count; // Condition Variables
+	};
+
 	shared_mutex mutex;
-	atomic_t<u32> owner{0}; // Owner Thread ID
+	atomic_t<u32> owner{0};
 	atomic_t<u32> lock_count{0}; // Recursive Locks
-	atomic_t<u32> cond_count{0}; // Condition Variables
+	atomic_t<count_info> obj_count{};
 	std::deque<cpu_thread*> sq;
 
 	lv2_mutex(u32 protocol, u32 recursive, u32 shared, u32 adaptive, u64 key, s32 flags, u64 name)
@@ -48,6 +54,12 @@ struct lv2_mutex final : lv2_obj
 		, name(name)
 		, flags(flags)
 	{
+	}
+
+	CellError on_id_create()
+	{
+		obj_count.atomic_op([](count_info& info){ info.mutex_count++; });
+		return {};
 	}
 
 	CellError try_lock(u32 id)

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -292,7 +292,7 @@ void kernel_explorer::Update()
 		{
 			auto& mutex = static_cast<lv2_mutex&>(obj);
 			add_leaf(node, qstr(fmt::format(u8"Mutex 0x%08x: “%s”, %s,%s Owner: %#x, Locks: %u, Key: %#llx, Conds: %u, Wq: %zu", id, lv2_obj::name64(mutex.name), mutex.protocol,
-				mutex.recursive == SYS_SYNC_RECURSIVE ? " Recursive," : "", mutex.owner >> 1, +mutex.lock_count, mutex.key, +mutex.cond_count, mutex.sq.size())));
+				mutex.recursive == SYS_SYNC_RECURSIVE ? " Recursive," : "", mutex.owner >> 1, +mutex.lock_count, mutex.key, mutex.obj_count.load().cond_count, mutex.sq.size())));
 			break;
 		}
 		case SYS_COND_OBJECT:


### PR DESCRIPTION
* ~~Revert a change in #8140 where the protocol was changed to PRIORITY, I will revert it for now as it is probably the cause for the regressions and I haven't hw test it.~~
* Because #7999 and #7931 made the destroy syscalls of sys_event_queue and sys_cond execute destruction code instead of the destructor, IPC support has been broken because with IPC you can have multiple copies (multiple IDs) of the same object and destroy syscall is destroying one ID at a time. The destruction code must happen on last ID destroyed, so you use an existence counter and increment it in lv2_obj::on_id_create(), decrement on destroy syscall and execute destruction code when it becomes 0.
* Fix race between sys_cond_create and sys_mutex_destroy which could lead to a conditional variable creation without any mutex attached to it! this is a nice "side effect" of the above fix because of the added last mutex existence check in lv2_cond::on_id_create() under writer IDM lock on conditional variable creation which was lacking.
* Fix minor race in sys_cond_wait which could lead to a spurious EBUSY in sys_cond_destroy.
* Write into SPU inbound mailbox under mutex, Implement EBUSY error on non-empty mailbox
 in sys_spu_thread_send_event/sys_event_flag_set_bit.

Issues to test:

- [x] #8267
- [x] #8331