### PR TITLE
Implement Caret upwards and downwards move in overlay_edit_text

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
@@ -28,9 +28,109 @@ namespace rsx
 				break;
 			}
 			case up:
-			case down:
-				// TODO
+			{
+				if (caret_position == 0)
+				{
+					break;
+				}
+				u64 current_line_start = text.rfind('\n', caret_position - 1); // search from previous char
+				if (current_line_start == std::string::npos)
+				{
+					// This is the first line, so caret moves to the very beginning
+					caret_position = 0;
+					refresh();
+					break;
+				}
+				else
+				{
+					// if line is not first, than caret should move forward as find result points to '\n'
+					current_line_start += 1;
+				}
+				const u64 caret_pos_in_line = caret_position - current_line_start;
+				const u64 prev_line_end     = current_line_start - 2; // ignore current char and \n before it
+				u64 prev_line_start         = text.rfind('\n', prev_line_end);
+				if (prev_line_start == std::string::npos)
+				{
+					// if previous line is the first line, there is no '\n' at the beginning
+					prev_line_start = 0;
+				}
+				else
+				{
+					// if previous line is not first, than caret should move forward as find result points to '\n'
+					prev_line_start += 1;
+				}
+				const u64 prev_line_length = prev_line_end - prev_line_start + 1; // delta in indexes requires +1
+				// TODO : Save caret position to some kind of buffer, so after switching back and forward, caret would be on initial position
+				if (prev_line_length < caret_pos_in_line)
+				{
+					// Previous line is shorter than current caret position, so caret moves to the very end of the previous line
+					caret_position = prev_line_end + 1;
+				}
+				else
+				{
+					// Previous line is longer than current caret position, so caret moves from prev_line_beginning the exact same distance as in current line
+					caret_position = prev_line_start + caret_pos_in_line;
+				}
+				refresh();
 				break;
+			}
+			case down:
+			{
+				if (caret_position == text.length())
+				{
+					break;
+				}
+				u64 current_line_end = text.find('\n', caret_position);
+				if (current_line_end == std::string::npos)
+				{
+					// This is the last line, so caret moves to the very end
+					caret_position = text.length();
+					refresh();
+					break;
+				}
+				else
+				{
+					// move to the last character of the current line
+					current_line_end -= 1;
+				}
+				u64 current_line_start = text.rfind('\n', current_line_end);
+				if (current_line_start == std::string::npos)
+				{
+					// if current line is the first one - there is no '\n' before it, so line starts from index 0
+					current_line_start = 0;
+				}
+				else
+				{
+					// if line is not first, than caret should move forward as find result points to '\n'
+					current_line_start += 1;
+				}
+				const u64 caret_pos_in_line = caret_position - current_line_start;
+				const u64 next_line_start   = current_line_end + 2; // ignore last char and '\n'
+				u64 next_line_end           = text.find('\n', next_line_start);
+				if (next_line_end == std::string::npos)
+				{
+					// if next line is the last line, there is no '\n' at the end, so next_line_end is set to text end
+					next_line_end = text.length() - 1;
+				}
+				else
+				{
+					next_line_end -= 1; // move to the last char in the line, as find result points to '\n'
+				}
+				const u64 next_line_length = next_line_end - next_line_start + 1; // delta in indexes requires +1
+				// TODO : Save caret position to some kind of buffer, so after switching back and forward, caret would be on initial position
+				if (next_line_length < caret_pos_in_line)
+				{
+					// Next line is shorter than current caret position, so caret moves to the very end of the next line
+					caret_position = next_line_end + 1;
+				}
+				else
+				{
+					// Next line is longer than current caret position, so caret moves from next_line_start the exact same distance as in current line
+					caret_position = next_line_start + caret_pos_in_line;
+				}
+				refresh();
+				break;
+			}
 			}
 		}
 


### PR DESCRIPTION
I've found a TODO in code and decided to implement this piece of code.

In theory this should allow users to move caret up and down in text edit, but I didn't test it myself. 
So if someone tells the solution is working, than it's proper. :)

To test just run any working game with overlay with multiline text and try to move caret up and down.

I request @elad335 review.