### PR TITLE
Add Cirrus Free BSD badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ RPCS3
 
 [![Build Status](https://travis-ci.org/RPCS3/rpcs3.svg?branch=master)](https://travis-ci.org/RPCS3/rpcs3)
 [![Build Status](https://dev.azure.com/nekotekina/nekotekina/_apis/build/status/RPCS3.rpcs3?branchName=master)](https://dev.azure.com/nekotekina/nekotekina/_build/latest?definitionId=4&branchName=master)
+[![Build Status](https://api.cirrus-ci.com/github/RPCS3/rpcs3.svg?task=FreeBSD%2012.2%20(snapshot))](https://cirrus-ci.com/github/RPCS3/rpcs3)
 
 The world's first free and open-source PlayStation 3 emulator/debugger, written in C++ for Windows and Linux.
 


### PR DESCRIPTION
#8261 Introduced Free BSD builds via Cirrus CI. 
While Azure and Travis have their badges on the main page, Cirrus was left abandoned.
This PR adds a badge. 

[![Build Status](https://api.cirrus-ci.com/github/RPCS3/rpcs3.svg?task=FreeBSD%2012.2%20(snapshot))](https://cirrus-ci.com/github/RPCS3/rpcs3)