### PR TITLE
rsx/fp: Separate SRC precision modifiers

### DIFF
--- a/rpcs3/Emu/RSX/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/RSXFragmentProgram.h
@@ -158,8 +158,9 @@ union SRC1
 		u32 swizzle_w        : 2;
 		u32 neg              : 1;
 		u32 abs              : 1;
-		u32 input_prec_mod   : 3; // Looks to be a precision clamping modifier affecting all inputs (tested with Dark Souls II)
-		u32                  : 6;
+		u32 src0_prec_mod    : 3; // Precision modifier for src0 (many games)
+		u32 src1_prec_mod    : 3; // Precision modifier for src1 (CoD:MW series)
+		u32 src2_prec_mod    : 3; // Precision modifier for src2 (unproven, should affect MAD instruction)
 		u32 scale            : 3;
 		u32 opcode_is_branch : 1;
 	};


### PR DESCRIPTION
SRC0, SRC1 and SRC2 have different bits for precision modifiers all stored inside SRC1. This explains the strange observed behavior of the MAD instruction which has 3 inputs.

Fixes https://github.com/RPCS3/rpcs3/issues/6088
Fixes https://github.com/RPCS3/rpcs3/issues/6187
Fixes https://github.com/RPCS3/rpcs3/issues/6460
Fixes https://github.com/RPCS3/rpcs3/issues/6611
Fixes https://github.com/RPCS3/rpcs3/issues/6626
Fixes https://github.com/RPCS3/rpcs3/issues/6641
Fixes https://github.com/RPCS3/rpcs3/issues/7295
Fixes https://github.com/RPCS3/rpcs3/issues/7455
Fixes https://github.com/RPCS3/rpcs3/issues/7812
Fixes https://github.com/RPCS3/rpcs3/issues/7920
Fixes https://github.com/RPCS3/rpcs3/issues/8245
Fixes https://github.com/RPCS3/rpcs3/issues/8288
Fixes https://github.com/RPCS3/rpcs3/issues/8354