### PR TITLE
Unify Azure artifacts names and Produce them only on successful build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,8 @@ jobs:
     displayName: Docker setup and build
 
   - publish: $(Build.ArtifactStagingDirectory)
-    condition: eq(variables['COMPILER'], 'gcc')
+    condition: and(succeeded(), eq(variables['COMPILER'], 'gcc'))
+    artifact: RPCS3 for Linux
 
 - job: Windows_Build
   variables:
@@ -96,7 +97,8 @@ jobs:
       displayName: Pack up build artifacts
 
     - publish: $(Build.ArtifactStagingDirectory)
-      artifact: Windows App Bundle
+      condition: succeeded()
+      artifact: RPCS3 for Windows
 
     - task: GitHubRelease@1
       condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/44116740/83957213-d0225000-a86e-11ea-9d5d-de032f369bf6.png)

After: 
![image](https://user-images.githubusercontent.com/44116740/83985244-17791100-a941-11ea-890d-6a10be9e235d.png)

I was curious about, why artifacts have non-unified names. 
And accidentally found that artifacts are produced on any build results, even on failure.

I've made the title "RPCS3 for [platform]"

Feel free to suggest your Bundle Name.