### PR TITLE
Emu/overlay: ingame native overlay PPU compilation

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -23,6 +23,7 @@
 #include "util/sysinfo.hpp"
 
 extern atomic_t<const char*> g_progr;
+extern atomic_t<bool> g_progr_show;
 extern atomic_t<u32> g_progr_ptotal;
 extern atomic_t<u32> g_progr_pdone;
 
@@ -426,6 +427,7 @@ void spu_cache::initialize()
 
 		g_progr = "Building SPU cache...";
 		g_progr_ptotal += ::size32(func_list);
+		g_progr_show = true;
 
 		worker_count = Emu.GetMaxThreads();
 	}
@@ -523,6 +525,11 @@ void spu_cache::initialize()
 	for (u32 i = 0; i < workers.size(); i++)
 	{
 		spu_log.notice("SPU Runtime: Worker %u built %u programs.", i + 1, workers[i]);
+	}
+
+	if (g_cfg.core.spu_decoder == spu_decoder_type::asmjit || g_cfg.core.spu_decoder == spu_decoder_type::llvm)
+	{
+		g_progr_show = false;
 	}
 
 	if (Emu.IsStopped())

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -209,11 +209,7 @@ namespace rsx
 				btn_cancel.translate(0, offset);
 			}
 
-			text_display.set_text(text);
-
-			u16 text_w, text_h;
-			text_display.measure_text(text_w, text_h);
-			text_display.translate(0, -(text_h - 16));
+			set_text(text);
 
 			switch (type.button_type.unshifted())
 			{
@@ -304,6 +300,15 @@ namespace rsx
 			}
 
 			return CELL_OK;
+		}
+
+		void message_dialog::set_text(const std::string& text)
+		{
+			u16 text_w, text_h;
+			text_display.set_pos(90, 364);
+			text_display.set_text(text);
+			text_display.measure_text(text_w, text_h);
+			text_display.translate(0, -(text_h - 16));
 		}
 
 		u32 message_dialog::progress_bar_count()

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
@@ -35,6 +35,8 @@ namespace rsx
 
 			error_code show(bool is_blocking, const std::string& text, const MsgDialogType& type, std::function<void(s32 status)> on_close);
 
+			void set_text(const std::string& text);
+
 			u32 progress_bar_count();
 			void progress_bar_set_taskbar_index(s32 index);
 			error_code progress_bar_set_message(u32 index, const std::string& msg);


### PR DESCRIPTION
Show native overlay for ingame ppu and spu module compilation.
A good testcase is NGS2.

~~This does not affect the initial ppu/spu compilation before the game starts, as I haven't figured out how to draw overlays before the rsx was initialized.~~

TODO:
- [x] The thing doesn't redraw when we update the progress bar. 
- [x] ~~Alternatively use something like the shader compile hint, which isn't as invasive during gameplay~~