### PR TITLE
Workaround broken Azure badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ RPCS3
 =====
 
 [![Build Status](https://travis-ci.org/RPCS3/rpcs3.svg?branch=master)](https://travis-ci.org/RPCS3/rpcs3)
-[![Build Status](https://dev.azure.com/nekotekina/nekotekina/_apis/build/status/RPCS3.rpcs3?branchName=master)](https://dev.azure.com/nekotekina/nekotekina/_build/latest?definitionId=4&branchName=master)
+[![Build Status](https://dev.azure.com/nekotekina/nekotekina/_apis/build/status/RPCS3.rpcs3?branchName=master)](https://dev.azure.com/nekotekina/nekotekina/_build?definitionId=4&branchName=master)
 [![Build Status](https://api.cirrus-ci.com/github/RPCS3/rpcs3.svg?task=FreeBSD%2012.2%20(snapshot))](https://cirrus-ci.com/github/RPCS3/rpcs3)
 
 The world's first free and open-source PlayStation 3 emulator/debugger, written in C++ for Windows and Linux.


### PR DESCRIPTION
Looks like Azure has broken API a bit, so link to the full list of the latest builds in the meantime