### PR TITLE
sys_memory: Improve allocation/deallocation syscalls

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_memory.h
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.h
@@ -76,21 +76,6 @@ struct lv2_memory_container
 	}
 };
 
-struct lv2_memory_alloca
-{
-	static const u32 id_base = 0x1;
-	static const u32 id_step = 0x1;
-	static const u32 id_count = 0x2000;
-
-	const u32 size; // Memory size
-	const u32 align; // Alignment required
-	const u64 flags;
-	const std::shared_ptr<lv2_memory_container> ct;
-	const std::shared_ptr<utils::shm> shm;
-
-	lv2_memory_alloca(u32 size, u32 align, u64 flags, const std::shared_ptr<lv2_memory_container>& ct);
-};
-
 struct sys_memory_user_memory_stat_t
 {
 	be_t<u32> a; // 0x0


### PR DESCRIPTION
* Do not iterate through all allocations from sys_memory_allocate_from_container everytime sys_memory_free is called in order to search allocation's associated memory container, instead use atomic lookup table.
* Remove lv2_memory_alloca which used to track sys_memory_allocate_from_container allocations, no longer needed.
* Add missing EALIGN error checks in sys_memory_allocate(_from_contao
iner) syscalls where this error code is returned if size is 0 according to reversing.
* Fixes a case where sys_memory_free could deallocate PPU stack memory where it shouldn't be able to.
* Fix race condition in sys_memory_free syscall where the returned memory could get into the main memory container instead of the one selected by sys_memory_allocate_from_container, this race can occure because idm::select contianer searching was not atomic with deallocation.
Race example:
```
u32 addr_thr1;
u32 addr_thr2;

Thread 1:
sys_memory_allocate(..., &addr_thr1);
Thread 2:
sys_memory_free(addr_thr1);
sys_memory_allocate_from_conatiner(..., &addr_thr2);
Thread 1:
sys_memory_free(addr_thr1); // if addr_thr1 == addr_thr2, the race can happen here.
```