### PR TITLE
cellAudio: Fix event queue attachment

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.h
@@ -6,6 +6,8 @@
 #include "Emu/Audio/AudioBackend.h"
 #include "Emu/Audio/AudioDumper.h"
 
+struct lv2_event_queue;
+
 // Error codes
 enum CellAudioError : u32
 {
@@ -358,7 +360,7 @@ public:
 		u8 start_period; // Starting event_period
 		u32 flags; // iFlags
 		u64 source; // Event source
-		u64 key; // Key
+		std::weak_ptr<lv2_event_queue> port; // Underlying event port
 	};
 
 	std::vector<key_info> keys;


### PR DESCRIPTION
1. cellAudioSetNotifyEventQueue has error checking similar to sys_event_queue_connect_ipc - the events queue key must be valid when connecting, if the original previous attached event queue associated with the same event key has been destroyed the function is allowed to rebind the same key as if the previous event queue was never bound.

2. cellAudioRemoveNotifyEventQueue has similar error checking to sys_event_port_disconnect - if the originally associatyed event queue specified with the same key as the current argument has been destroyed, this funcion returns an error as if the previous key was never bound.

3. If the original event queue associated with `x` key value has been destroyed, but later on a newer event queue with the same `x` key has been created, cellAudio events will not be received for it. (see sys_event_queue_receive line in the test results)

Testcase: https://github.com/elad335/myps3tests/blob/master/ppu_tests/cellAudioSetNotifyEventQueue%20(2)/expected.txt

realps3 output:
```
event:
[000] | 01 00 03 00 | 0E 0F 10 0A |
[008] | 00 00 00 00 | 00 00 00 00 |
[010] | 00 00 00 00 | 00 00 00 00 |
[018] | 00 00 00 00 | 00 00 00 00 |
sys_event_queue_receive(error ETIMEDOUT, line=74)
event:
[000] | 80 00 00 00 | 00 89 89 C0 |
[008] | 80 00 00 00 | 00 4F 24 80 |
[010] | 80 00 00 00 | 00 34 F9 18 |
[018] | 80 00 00 00 | 00 89 CB 00 |
cellAudioRemoveNotifyEventQueue(error 0x80310709, line=77)
event:
[000] | 01 00 03 00 | 0E 10 10 0A |
[008] | 00 00 00 00 | 00 00 00 00 |
[010] | 00 00 00 00 | 00 00 00 00 |
[018] | 00 00 00 00 | 00 00 00 00 |
cellAudioSetNotifyEventQueue(error ok, line=85)
cellAudioRemoveNotifyEventQueue(error ok, line=87)
```

current master:
```event:
[000] | 00 00 00 01 | 0E 00 00 00 |
[008] | 00 00 00 00 | 00 00 00 00 |
[010] | 00 00 00 00 | 00 00 00 00 |
[018] | 00 00 00 00 | 00 00 00 00 |
sys_event_queue_receive(error ok, line=74)
event:
[000] | 00 00 00 01 | 0E 00 00 00 |
[008] | 00 00 00 00 | 00 00 00 00 |
[010] | 00 00 00 00 | 00 00 00 00 |
[018] | 00 00 00 00 | 00 00 00 00 |
cellAudioRemoveNotifyEventQueue(error ok, line=77)
event:
[000] | 00 00 00 01 | 0E 00 01 00 |
[008] | 00 00 00 00 | 00 00 00 00 |
[010] | 00 00 00 00 | 00 00 00 00 |
[018] | 00 00 00 00 | 00 00 00 00 |
cellAudioSetNotifyEventQueue(error 0x80310709, line=85)
cellAudioRemoveNotifyEventQueue(error ok, line=87)
```