### PR TITLE
patch manager: import and delete patches

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -224,7 +224,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, bool im
 				info.hash        = main_key;
 				info.version     = version;
 
-				if (const auto title_node = patches_entry.second["Title"])
+				if (const auto title_node = patches_entry.second["Game Title"])
 				{
 					info.title = title_node.Scalar();
 				}
@@ -239,7 +239,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, bool im
 					info.author = author_node.Scalar();
 				}
 
-				if (const auto patch_version_node = patches_entry.second["Version"])
+				if (const auto patch_version_node = patches_entry.second["Patch Version"])
 				{
 					info.patch_version = patch_version_node.Scalar();
 				}
@@ -715,11 +715,11 @@ bool patch_engine::save_patches(const patch_map& patches, const std::string& pat
 			out << description;
 			out << YAML::BeginMap;
 
-			if (!info.title.empty())         out << "Title"   << info.title;
-			if (!info.serials.empty())       out << "Serials" << info.serials;
-			if (!info.author.empty())        out << "Author"  << info.author;
-			if (!info.patch_version.empty()) out << "Version" << info.patch_version;
-			if (!info.notes.empty())         out << "Notes"   << info.notes;
+			if (!info.title.empty())         out << "Game Title"    << info.title;
+			if (!info.serials.empty())       out << "Serials"       << info.serials;
+			if (!info.author.empty())        out << "Author"        << info.author;
+			if (!info.patch_version.empty()) out << "Patch Version" << info.patch_version;
+			if (!info.notes.empty())         out << "Notes"         << info.notes;
 
 			out << "Patch";
 			out << YAML::BeginSeq;

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -30,7 +30,11 @@ public:
 	{
 		patch_type type = patch_type::load;
 		u32 offset = 0;
-		u64 value = 0;
+		union
+		{
+			u64 long_value;
+			f64 double_value;
+		} value { 0 };
 	};
 
 	struct patch_info
@@ -78,23 +82,30 @@ public:
 	//   Patches:
 	//     60fps:
 	//       Author: Batman bin Suparman
+	//       Version: 1.3
 	//       Notes: This is super
 	//       Patch:
 	//         - [ be32, 0x000e522c, 0x995d0072 ]
 	//         - [ be32, 0x000e5234, 0x995d0074 ]
-	static void load(patch_map& patches, const std::string& path);
+	static bool load(patch_map& patches, const std::string& path, bool importing = false, std::stringstream* log_messages = nullptr);
 
 	// Read and add a patch node to the patch info
-	static void read_patch_node(patch_info& info, YAML::Node node, const YAML::Node& root);
+	static bool read_patch_node(patch_info& info, YAML::Node node, const YAML::Node& root, std::stringstream* log_messages = nullptr);
 
 	// Get the patch type of a patch node
 	static patch_type get_patch_type(YAML::Node node);
 
 	// Add the data of a patch node
-	static void add_patch_data(YAML::Node node, patch_info& info, u32 modifier, const YAML::Node& root);
+	static bool add_patch_data(YAML::Node node, patch_info& info, u32 modifier, const YAML::Node& root, std::stringstream* log_messages = nullptr);
 
 	// Save to patch_config.yml
 	static void save_config(const patch_map& patches_map, bool enable_legacy_patches);
+
+	// Save a patch file
+	static bool save_patches(const patch_map& patches, const std::string& path);
+
+	// Create or append patches to a file
+	static bool import_patches(const patch_map& patches, const std::string& path);
 
 	// Load patch_config.yml
 	static patch_config_map load_config(bool& enable_legacy_patches);

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -74,6 +74,9 @@ public:
 	// Returns the directory in which patch_config.yml is located
 	static std::string get_patch_config_path();
 
+	// Returns the filepath for the imported_patch.yml
+	static std::string get_imported_patch_path();
+
 	// Load from file and append to specified patches map
 	// Example entry:
 	//
@@ -107,6 +110,9 @@ public:
 
 	// Create or append patches to a file
 	static bool import_patches(const patch_map& patches, const std::string& path, std::stringstream* log_messages = nullptr);
+
+	// Remove a patch from a file
+	static bool remove_patch(const patch_info& info);
 
 	// Load patch_config.yml
 	static patch_config_map load_config(bool& enable_legacy_patches);

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -79,11 +79,11 @@ public:
 	// PPU-8007056e52279bea26c15669d1ee08c2df321d00:
 	//   Patches:
 	//     60fps:
-	//       Title: Fancy Game
+	//       Game Title: Fancy Game
 	//       Serials: ABCD12345, SUPA13337 v.1.3
 	//       Author: Batman bin Suparman
-	//       Version: 1.3
 	//       Notes: This is super
+	//       Patch Version: 1.3
 	//       Patch:
 	//         - [ be32, 0x000e522c, 0x995d0072 ]
 	//         - [ be32, 0x000e5234, 0x995d0074 ]

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -109,7 +109,7 @@ public:
 	static bool save_patches(const patch_map& patches, const std::string& path, std::stringstream* log_messages = nullptr);
 
 	// Create or append patches to a file
-	static bool import_patches(const patch_map& patches, const std::string& path, std::stringstream* log_messages = nullptr);
+	static bool import_patches(const patch_map& patches, const std::string& path, size_t& count, size_t& total, std::stringstream* log_messages = nullptr);
 
 	// Remove a patch from a file
 	static bool remove_patch(const patch_info& info);

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -9,6 +9,7 @@
 
 enum class patch_type
 {
+	invalid,
 	load,
 	byte,
 	le16,

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -49,6 +49,7 @@ public:
 		std::string patch_version;
 		std::string author;
 		std::string notes;
+		std::string source_path;
 		bool enabled = false;
 
 		// Redundant information for accessibility (see patch_container)

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -31,6 +31,7 @@ public:
 	{
 		patch_type type = patch_type::load;
 		u32 offset = 0;
+		std::string original_value; // Used for import consistency (avoid rounding etc.)
 		union
 		{
 			u64 long_value;

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -43,30 +43,28 @@ public:
 		// Patch information
 		std::vector<patch_engine::patch_data> data_list;
 		std::string description;
+		std::string title;
+		std::string serials;
 		std::string patch_version;
 		std::string author;
 		std::string notes;
 		bool enabled = false;
 
-		// Redundant information for accessibility (see patch_title_info)
+		// Redundant information for accessibility (see patch_container)
 		std::string hash;
 		std::string version;
-		std::string title;
-		std::string serials;
 		bool is_legacy = false;
 	};
 
-	struct patch_title_info
+	struct patch_container
 	{
 		std::unordered_map<std::string /*description*/, patch_engine::patch_info> patch_info_map;
 		std::string hash;
 		std::string version;
-		std::string title;
-		std::string serials;
 		bool is_legacy = false;
 	};
 
-	using patch_map = std::unordered_map<std::string /*hash*/, patch_title_info>;
+	using patch_map = std::unordered_map<std::string /*hash*/, patch_container>;
 	using patch_config_map = std::unordered_map<std::string /*hash*/, std::unordered_map<std::string /*description*/, bool /*enabled*/>>;
 
 	patch_engine();
@@ -78,10 +76,10 @@ public:
 	// Example entry:
 	//
 	// PPU-8007056e52279bea26c15669d1ee08c2df321d00:
-	//   Title: Fancy Game
-	//   Serials: ABCD12345, SUPA13337 v.1.3
 	//   Patches:
 	//     60fps:
+	//       Title: Fancy Game
+	//       Serials: ABCD12345, SUPA13337 v.1.3
 	//       Author: Batman bin Suparman
 	//       Version: 1.3
 	//       Notes: This is super

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -102,10 +102,10 @@ public:
 	static void save_config(const patch_map& patches_map, bool enable_legacy_patches);
 
 	// Save a patch file
-	static bool save_patches(const patch_map& patches, const std::string& path);
+	static bool save_patches(const patch_map& patches, const std::string& path, std::stringstream* log_messages = nullptr);
 
 	// Create or append patches to a file
-	static bool import_patches(const patch_map& patches, const std::string& path);
+	static bool import_patches(const patch_map& patches, const std::string& path, std::stringstream* log_messages = nullptr);
 
 	// Load patch_config.yml
 	static patch_config_map load_config(bool& enable_legacy_patches);

--- a/Utilities/version.cpp
+++ b/Utilities/version.cpp
@@ -67,7 +67,7 @@ namespace utils
 		int vnum2 = 0;
 
 		// Loop until both strings are processed
-		for (int i = 0, j = 0; (i < v1.length() || j < v2.length());)
+		for (size_t i = 0, j = 0; (i < v1.length() || j < v2.length());)
 		{
 			// Storing numeric part of version 1 in vnum1
 			while (i < v1.length() && v1[i] != '.')

--- a/Utilities/version.cpp
+++ b/Utilities/version.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "version.h"
 
+#include <regex>
+
 namespace utils
 {
 	std::string to_string(version_type type)
@@ -47,5 +49,52 @@ namespace utils
 		}
 
 		return version;
+	}
+
+	// Based on https://www.geeksforgeeks.org/compare-two-version-numbers/
+	int compare_versions(const std::string& v1, const std::string& v2, bool& ok)
+	{
+		// Check if both version strings are valid
+		ok = std::regex_match(v1, std::regex("[0-9.]*")) && std::regex_match(v2, std::regex("[0-9.]*"));
+
+		if (!ok)
+		{
+			return -1;
+		}
+
+		// vnum stores each numeric part of version
+		int vnum1 = 0;
+		int vnum2 = 0;
+
+		// Loop until both strings are processed
+		for (int i = 0, j = 0; (i < v1.length() || j < v2.length());)
+		{
+			// Storing numeric part of version 1 in vnum1
+			while (i < v1.length() && v1[i] != '.')
+			{
+				vnum1 = vnum1 * 10 + (v1[i] - '0');
+				i++;
+			}
+
+			// Storing numeric part of version 2 in vnum2
+			while (j < v2.length() && v2[j] != '.')
+			{
+				vnum2 = vnum2 * 10 + (v2[j] - '0');
+				j++;
+			}
+
+			if (vnum1 > vnum2)
+				return 1;
+
+			if (vnum2 > vnum1)
+				return -1;
+
+			// If equal, reset variables and go for next numeric part
+			vnum1 = vnum2 = 0;
+			i++;
+			j++;
+		}
+
+		return 0;
 	}
 }

--- a/Utilities/version.h
+++ b/Utilities/version.h
@@ -69,4 +69,7 @@ namespace utils
 		uint to_hex() const;
 		std::string to_string() const;
 	};
+
+	// Generic version comparison (e.g. 0.0.5 vs 1.3)
+	int compare_versions(const std::string& v1, const std::string& v2, bool& ok);
 }

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -133,6 +133,11 @@ void patch_manager_dialog::populate_tree()
 		// Add patch items
 		for (const auto& [description, patch] : container.patch_info_map)
 		{
+			if (patch.is_legacy)
+			{
+				continue;
+			}
+
 			const QString q_title   = patch.title.empty() ? tr("Unknown Title") : QString::fromStdString(patch.title);
 			const QString q_serials = patch.serials.empty() ? tr("Unknown Version") : QString::fromStdString(patch.serials);
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -87,17 +87,28 @@ void patch_manager_dialog::load_patches()
 {
 	m_map.clear();
 
+	// NOTE: Make sure to load these in the same order as they are applied on boot
+
 	// Legacy path (in case someone puts it there)
 	patch_engine::load(m_map, fs::get_config_dir() + "patch.yml");
 
 	// New paths
+	const std::string imports_path = patch_engine::get_imported_patch_path();
 	const std::string patches_path = fs::get_config_dir() + "patches/";
-	const QStringList filters      = QStringList() << "*patch.yml";
+	const QStringList filters      = QStringList() << "*_patch.yml";
 	const QStringList path_list    = QDir(QString::fromStdString(patches_path)).entryList(filters);
+
+	patch_engine::load(m_map, patches_path + "patch.yml");
+	patch_engine::load(m_map, imports_path);
 
 	for (const auto& path : path_list)
 	{
-		patch_engine::load(m_map, patches_path + path.toStdString());
+		const std::string patch_path = patches_path + path.toStdString();
+
+		if (patch_path != imports_path)
+		{
+			patch_engine::load(m_map, patch_path);
+		}
 	}
 }
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -424,7 +424,9 @@ void patch_manager_dialog::dropEvent(QDropEvent* event)
 			{
 				static const std::string imported_patch_yml_path = fs::get_config_dir() + "patches/imported_patch.yml";
 
-				if (patch_engine::import_patches(patches, imported_patch_yml_path))
+				log_message.clear();
+
+				if (patch_engine::import_patches(patches, imported_patch_yml_path, &log_message))
 				{
 					refresh();
 					QMessageBox::information(this, tr("Import successful"), tr("The patch file was imported to:\n%0").arg(QString::fromStdString(imported_patch_yml_path)));

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -356,6 +356,29 @@ void patch_manager_dialog::on_custom_context_menu_requested(const QPoint &pos)
 			}
 		});
 	}
+	else
+	{
+		// Find the patch for this item and add menu items accordingly
+		const std::string hash = item->data(0, hash_role).toString().toStdString();
+		const std::string description = item->data(0, description_role).toString().toStdString();
+
+		if (m_map.find(hash) != m_map.end())
+		{
+			const auto& container = m_map.at(hash);
+
+			if (!container.is_legacy && container.patch_info_map.find(description) != container.patch_info_map.end())
+			{
+				const auto info = container.patch_info_map.at(description);
+
+				QAction* open_filepath = new QAction("Show Patch File");
+				menu->addAction(open_filepath);
+				connect(open_filepath, &QAction::triggered, this, [info](bool)
+				{
+					gui::utils::open_dir(info.source_path);
+				});
+			}
+		}
+	}
 
 	menu->exec(ui->patch_tree->viewport()->mapToGlobal(pos));
 }

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -540,14 +540,28 @@ void patch_manager_dialog::dropEvent(QDropEvent* event)
 
 				log_message.clear();
 
-				if (patch_engine::import_patches(patches, imported_patch_yml_path, &log_message))
+				size_t count = 0;
+				size_t total = 0;
+
+				if (patch_engine::import_patches(patches, imported_patch_yml_path, count, total, &log_message))
 				{
 					refresh();
-					QMessageBox::information(this, tr("Import successful"), tr("The patch file was imported to:\n%0").arg(QString::fromStdString(imported_patch_yml_path)));
+					const QString msg = log_message.str().empty() ? "-" : QString::fromStdString(log_message.str());
+
+					if (count == 0)
+					{
+						QMessageBox::warning(this, tr("Nothing to import"), tr("None of the found %0 patches were imported.\n\nLog:\n\n%2")
+							.arg(total).arg(msg));
+					}
+					else
+					{
+						QMessageBox::information(this, tr("Import successful"), tr("Imported %0/%1 patches to:\n%2\n\nLog:\n\n%3")
+							.arg(count).arg(total).arg(QString::fromStdString(imported_patch_yml_path)).arg(msg));
+					}
 				}
 				else
 				{
-					QMessageBox::information(this, tr("Import failed"), tr("The patch file was not imported.\nPlease see the log for more information."));
+					QMessageBox::warning(this, tr("Import failed"), tr("The patch file was not imported.\n\nLog:\n\n").arg(QString::fromStdString(log_message.str())));
 				}
 			}
 			else
@@ -558,7 +572,7 @@ void patch_manager_dialog::dropEvent(QDropEvent* event)
 		else
 		{
 			patch_log.error("Errors found in patch file %s", path);
-			QMessageBox::warning(this, tr("Validation failed"), tr("Errors were found in the patch file. Log:\n\n") + QString::fromStdString(log_message.str()));
+			QMessageBox::warning(this, tr("Validation failed"), tr("Errors were found in the patch file.\n\nLog:\n\n%0").arg(QString::fromStdString(log_message.str())));
 		}
 	}
 }

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -87,28 +87,20 @@ void patch_manager_dialog::load_patches()
 {
 	m_map.clear();
 
-	// NOTE: Make sure to load these in the same order as they are applied on boot
+	// NOTE: Make sure these paths are loaded in the same order as they are applied on boot
 
-	// Legacy path (in case someone puts it there)
-	patch_engine::load(m_map, fs::get_config_dir() + "patch.yml");
-
-	// New paths
-	const std::string imports_path = patch_engine::get_imported_patch_path();
 	const std::string patches_path = fs::get_config_dir() + "patches/";
 	const QStringList filters      = QStringList() << "*_patch.yml";
-	const QStringList path_list    = QDir(QString::fromStdString(patches_path)).entryList(filters);
 
-	patch_engine::load(m_map, patches_path + "patch.yml");
-	patch_engine::load(m_map, imports_path);
+	QStringList path_list;
+	path_list << "patch.yml";
+	path_list << "imported_patch.yml";
+	path_list << QDir(QString::fromStdString(patches_path)).entryList(filters);
+	path_list.removeDuplicates(); // make sure to load patch.yml and imported_patch.yml only once
 
 	for (const auto& path : path_list)
 	{
-		const std::string patch_path = patches_path + path.toStdString();
-
-		if (patch_path != imports_path)
-		{
-			patch_engine::load(m_map, patch_path);
-		}
+		patch_engine::load(m_map, patches_path + path.toStdString());
 	}
 }
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -2,6 +2,8 @@
 
 #include <QDialog>
 #include <QTreeWidgetItem>
+#include <QDragMoveEvent>
+#include <QMimeData>
 
 #include "Utilities/bin_patch.h"
 
@@ -26,14 +28,21 @@ private Q_SLOTS:
 	void on_legacy_patches_enabled(int state);
 
 private:
+	void refresh();
 	void load_patches();
 	void populate_tree();
-	void save();
-
+	void save_config();
 	void update_patch_info(const patch_engine::patch_info& info);
+	bool is_valid_file(const QMimeData& md, QStringList* drop_paths = nullptr);
 
 	patch_engine::patch_map m_map;
 	bool m_legacy_patches_enabled = false;
 
 	Ui::patch_manager_dialog *ui;
+
+protected:
+	void dropEvent(QDropEvent* event) override;
+	void dragEnterEvent(QDragEnterEvent* event) override;
+	void dragMoveEvent(QDragMoveEvent* event) override;
+	void dragLeaveEvent(QDragLeaveEvent* event) override;
 };

--- a/rpcs3/rpcs3qt/patch_manager_dialog.ui
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.ui
@@ -109,7 +109,7 @@
           <item>
            <widget class="QGroupBox" name="gb_title">
             <property name="title">
-             <string>Title</string>
+             <string>Game Title</string>
             </property>
             <layout class="QVBoxLayout" name="title_layout">
              <item>

--- a/rpcs3/rpcs3qt/patch_manager_dialog.ui
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.ui
@@ -10,6 +10,9 @@
     <height>659</height>
    </rect>
   </property>
+  <property name="acceptDrops">
+   <bool>true</bool>
+  </property>
   <property name="windowTitle">
    <string>Patch Manager</string>
   </property>

--- a/rpcs3/util/yaml.cpp
+++ b/rpcs3/util/yaml.cpp
@@ -1,4 +1,5 @@
 ﻿#include "util/yaml.hpp"
+#include "Utilities/types.h"
 
 std::pair<YAML::Node, std::string> yaml_load(const std::string& from)
 {
@@ -15,3 +16,21 @@ std::pair<YAML::Node, std::string> yaml_load(const std::string& from)
 
 	return{result, ""};
 }
+
+template <typename T>
+T get_yaml_node_value(YAML::Node node, std::string& error_message)
+{
+	try
+	{
+		return node.as<T>();
+	}
+	catch (const std::exception& e)
+	{
+		error_message = e.what();
+	}
+
+	return {};
+}
+
+template u64 get_yaml_node_value<u64>(YAML::Node, std::string&);
+template f64 get_yaml_node_value<f64>(YAML::Node, std::string&);

--- a/rpcs3/util/yaml.hpp
+++ b/rpcs3/util/yaml.hpp
@@ -18,3 +18,7 @@
 
 // Load from string and consume exception
 std::pair<YAML::Node, std::string> yaml_load(const std::string& from);
+
+// Use try/catch in YAML::Node::as<T>() instead of YAML::Node::as<T>(fallback) in order to get an error message
+template <typename T>
+T get_yaml_node_value(YAML::Node node, std::string& error_message);


### PR DESCRIPTION
Allows dropping a single *patch.yml into the patch manager.
The options are a simple validation, or an import (including validation).

Imported files are appended to "patches/imported_patch.yml".

If two same patches are found, it is only overwritten if the Version of the new patch is bigger.