### PR TITLE
Fix debugger breakpoints

### DIFF
--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -79,6 +79,8 @@ void breakpoint_list::AddBreakpoint(u32 pc)
 	pcVariant.setValue(pc);
 	breakpointItem->setData(Qt::UserRole, pcVariant);
 	addItem(breakpointItem);
+
+	Q_EMIT RequestShowAddress(pc);
 }
 
 /**

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -82,10 +82,9 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 
 	if (!cpu)
 	{
-		u32 pc = m_pc;
-		for (uint i = 0; i < m_item_count; ++i, pc += 4)
+		for (uint i = 0; i < m_item_count; ++i)
 		{
-			item(i)->setText(qstr(fmt::format("   [%08x]  ?? ?? ?? ??:", pc)));
+			item(i)->setText(qstr(fmt::format("   [%08x]  ?? ?? ?? ??:", 0)));
 			item(i)->setForeground(default_foreground);
 			item(i)->setBackground(default_background);
 		}


### PR DESCRIPTION
* Fix an old regression from #7905 which made breakpoints literally not appear after setting them, they would only appear after scrolling which triggers the missing call to `ShowAddress`. Because this function is also responsible for refreshing breakpoints viewing list.
* Fix foreground/background color of text when encountering non-execuable memory, this bug always existed and can be reproduced by simply jumping to address 0 after setting a breakpoint. you would see that the breakpoints colors are still placed.