### PR TITLE
std header guard in BEType.h

### DIFF
--- a/Utilities/BEType.h
+++ b/Utilities/BEType.h
@@ -1,4 +1,5 @@
-﻿#pragma once
+﻿#ifndef BETYPE_H_GUARD
+#define BETYPE_H_GUARD
 
 #include "types.h"
 #include "util/endian.hpp"
@@ -505,3 +506,5 @@ struct fmt_unveil<se_t<T, Se, Align>, void>
 		return fmt_unveil<T>::get(arg);
 	}
 };
+
+#endif // BETYPE_H_GUARD


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/8443

It's the issue where #pragma once gets ignored in files with utf-8 with bom signatures by gcc:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56549