### PR TITLE
SPU LLVM: Avoid bad optimization in FCGT

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7350,7 +7350,6 @@ public:
 		{
 			v128 data = get_const_vector(cv, m_pos, 5000);
 			bool safe_int_compare = true;
-			bool safe_simple_compare = true;
 
 			for (u32 i = 0; i < 4; i++)
 			{
@@ -7367,27 +7366,11 @@ public:
 					// this optimization for values outside of the range of x86 floating point hardware.
 					safe_int_compare = false;
 				}
-
-				if (absolute_float_bits < 0x7f7fffffu)
-				{
-					// Zero or a float in normalized range for x86
-					continue;
-				}
-				else
-				{
-					safe_simple_compare = false;
-				}
 			}
 
 			if (safe_int_compare)
 			{
 				set_vr(op.rt, sext<s32[4]>(bitcast<s32[4]>(a) > bitcast<s32[4]>(b)));
-				return;
-			}
-
-			if (safe_simple_compare)
-			{
-				set_vr(op.rt, sext<s32[4]>(fcmp_uno(a > b)));
 				return;
 			}
 		}

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7354,8 +7354,6 @@ public:
 			for (u32 i = 0; i < 4; i++)
 			{
 				const u32 exponent = data._u32[i] & 0x7f800000u;
-				const u32 sign_bit = data._u32[i] & 0x80000000u;
-				const u32 absolute_float_bits = data._u32[i] & 0x7fffffffu;
 
 				if (data._u32[i] >= 0x7f7fffffu || !exponent)
 				{


### PR DESCRIPTION
This optimization had some corner cases with -x86(NaN), removing.
Fixes a regression in Ratchet And Clank: TOD.