### PR TITLE
rsx: Account for subpixel precision when converting DST coordinates to SRC coordinates

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -588,7 +588,7 @@ namespace gl
 					// Dimensions were given in 'dst' space. Work out the real source coordinates
 					const auto src_bpp = slice.src->pitch() / slice.src->width();
 					src_x = (src_x * dst_bpp) / src_bpp;
-					src_w = (src_w * dst_bpp) / src_bpp;
+					src_w = ::aligned_div<u16>(src_w * dst_bpp, src_bpp);
 				}
 
 				if (auto surface = dynamic_cast<gl::render_target*>(slice.src))

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -586,7 +586,7 @@ namespace vk
 					// Dimensions were given in 'dst' space. Work out the real source coordinates
 					const auto src_bpp = vk::get_format_texel_width(section.src->format());
 					src_x = (src_x * dst_bpp) / src_bpp;
-					src_w = (src_w * dst_bpp) / src_bpp;
+					src_w = ::aligned_div<u16>(src_w * dst_bpp, src_bpp);
 
 					transform &= ~(rsx::surface_transform::coordinate_transform);
 				}


### PR DESCRIPTION
When extracting a 1x1 texture from another texture of a different format, width conversion can result in a dimension of 0 if the extracted texel in DST is not a full texel in SRC.

Fixes https://github.com/RPCS3/rpcs3/issues/7274