### PR TITLE
Improve auto-updater messages

### DIFF
--- a/rpcs3/rpcs3qt/localized.cpp
+++ b/rpcs3/rpcs3qt/localized.cpp
@@ -4,7 +4,7 @@ Localized::Localized()
 {
 }
 
-QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms) const
+QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days) const
 {
 	if (elapsed_ms <= 0)
 	{
@@ -13,14 +13,43 @@ QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms) const
 
 	const qint64 elapsed_seconds = (elapsed_ms / 1000) + ((elapsed_ms % 1000) > 0 ? 1 : 0);
 
-	const qint64 hours   = elapsed_seconds / 3600;
-	const qint64 minutes = (elapsed_seconds % 3600) / 60;
-	const qint64 seconds = (elapsed_seconds % 3600) % 60;
+	qint64 hours = elapsed_seconds / 3600;
 
 	// For anyone who was wondering why there need to be so many cases:
 	// 1. Using variables won't work for future localization due to varying sentence structure in different languages.
 	// 2. The provided Qt functionality only works if localization is already enabled
 	// 3. The provided Qt functionality only works for single variables
+
+	if (show_days && hours >= 24)
+	{
+		const qint64 days  = hours / 24;
+		hours = hours % 24;
+
+		if (hours <= 0)
+		{
+			if (days == 1)
+			{
+				return tr("%0 day").arg(days);
+			}
+			return tr("%0 days").arg(days);
+		}
+		if (days == 1 && hours == 1)
+		{
+			return tr("%0 day and %1 hour").arg(days).arg(hours);
+		}
+		if (days == 1)
+		{
+			return tr("%0 day and %1 hours").arg(days).arg(hours);
+		}
+		if (hours == 1)
+		{
+			return tr("%0 days and %1 hour").arg(days).arg(hours);
+		}
+		return tr("%0 days and %1 hours").arg(days).arg(hours);
+	}
+
+	const qint64 minutes = (elapsed_seconds % 3600) / 60;
+	const qint64 seconds = (elapsed_seconds % 3600) % 60;
 
 	if (hours <= 0)
 	{

--- a/rpcs3/rpcs3qt/localized.h
+++ b/rpcs3/rpcs3qt/localized.h
@@ -17,7 +17,7 @@ public:
 
 	Localized();
 
-	QString GetVerboseTimeByMs(qint64 elapsed_ms) const;
+	QString GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days = false) const;
 
 	const struct category // (see PARAM.SFO in psdevwiki.com) TODO: Disc Categories
 	{

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -234,14 +234,14 @@ bool update_manager::handle_json(bool automatic)
 			.arg(cur_str)
 			.arg(latest["version"].toString())
 			.arg(lts_str)
-			.arg(localized.GetVerboseTimeByMs(diff_msec));
+			.arg(localized.GetVerboseTimeByMs(diff_msec, true));
 	}
 	else
 	{
 		message = tr("You're currently using a custom or PR build.\n\nLatest version: %0 (%1)\nThe latest version is %2 old.\n\nDo you want to update to the latest official RPCS3 version?")
 			.arg(latest["version"].toString())
 			.arg(lts_str)
-			.arg(localized.GetVerboseTimeByMs(std::abs(diff_msec)));
+			.arg(localized.GetVerboseTimeByMs(std::abs(diff_msec), true));
 	}
 
 	if (QMessageBox::question(m_progress_dialog, tr("Update Available"), message, QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
@@ -598,7 +598,7 @@ bool update_manager::handle_rpcs3()
 		return false;
 #endif
 
-	QMessageBox::information(m_parent, tr("Auto-updater"), tr("Update successful!"));
+	QMessageBox::information(m_parent, tr("Auto-updater"), tr("Update successful!\nRPCS3 will now restart."));
 
 #ifdef _WIN32
 	const int ret = _wexecl(wchar_orig_path.data(), wchar_orig_path.data(), L"--updating", nullptr);


### PR DESCRIPTION
- Add "RPCS3 will now restart." hint to success message
- Use days to measure time greater than 24 hours
  Example: "53 days and 12 hours" instead of "1284 hours and 12 minutes"