### PR TITLE
Qt: simplify GetVerboseTimeByMs logic

### DIFF
--- a/rpcs3/rpcs3qt/localized.cpp
+++ b/rpcs3/rpcs3qt/localized.cpp
@@ -29,19 +29,11 @@ QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days) const
 		{
 			return tr("%n day(s)", "", days);
 		}
-		if (days == 1 && hours == 1)
-		{
-			return tr("%0 day and %1 hour").arg(days).arg(hours);
-		}
 		if (days == 1)
 		{
-			return tr("%0 day and %1 hours").arg(days).arg(hours);
+			return tr("%0 day and %n hour(s)", "", hours).arg(days);
 		}
-		if (hours == 1)
-		{
-			return tr("%0 days and %1 hour").arg(days).arg(hours);
-		}
-		return tr("%0 days and %1 hours").arg(days).arg(hours);
+		return tr("%0 days and %n hour(s)", "", hours).arg(days);
 	}
 
 	const qint64 minutes = (elapsed_seconds % 3600) / 60;
@@ -58,19 +50,13 @@ QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days) const
 		{
 			return tr("%n minute(s)", "", minutes);
 		}
-		if (minutes == 1 && seconds == 1)
-		{
-			return tr("%0 minute and %1 second").arg(minutes).arg(seconds);
-		}
+
 		if (minutes == 1)
 		{
-			return tr("%0 minute and %1 seconds").arg(minutes).arg(seconds);
+			return tr("%0 minute and %n second(s)", "", seconds).arg(minutes);
 		}
-		if (seconds == 1)
-		{
-			return tr("%0 minutes and %1 second").arg(minutes).arg(seconds);
-		}
-		return tr("%0 minutes and %1 seconds").arg(minutes).arg(seconds);
+		
+        return tr("%0 minutes and %n second(s)", "", seconds).arg(minutes);
 	}
 
 	if (minutes <= 0)

--- a/rpcs3/rpcs3qt/localized.cpp
+++ b/rpcs3/rpcs3qt/localized.cpp
@@ -27,11 +27,7 @@ QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days) const
 
 		if (hours <= 0)
 		{
-			if (days == 1)
-			{
-				return tr("%0 day").arg(days);
-			}
-			return tr("%0 days").arg(days);
+			return tr("%n day(s)", "", days);
 		}
 		if (days == 1 && hours == 1)
 		{
@@ -55,20 +51,12 @@ QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days) const
 	{
 		if (minutes <= 0)
 		{
-			if (seconds == 1)
-			{
-				return tr("%0 second").arg(seconds);
-			}
-			return tr("%0 seconds").arg(seconds);
+			return tr("%n second(s)", "", seconds);
 		}
 
 		if (seconds <= 0)
 		{
-			if (minutes == 1)
-			{
-				return tr("%0 minute").arg(minutes);
-			}
-			return tr("%0 minutes").arg(minutes);
+			return tr("%n minute(s)", "", minutes);
 		}
 		if (minutes == 1 && seconds == 1)
 		{
@@ -87,11 +75,7 @@ QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days) const
 
 	if (minutes <= 0)
 	{
-		if (hours == 1)
-		{
-			return tr("%0 hour").arg(hours);
-		}
-		return tr("%0 hours").arg(hours);
+		return tr("%n hour(s)", "", hours);
 	}
 	if (hours == 1 && minutes == 1)
 	{

--- a/rpcs3/rpcs3qt/localized.cpp
+++ b/rpcs3/rpcs3qt/localized.cpp
@@ -63,17 +63,11 @@ QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days) const
 	{
 		return tr("%n hour(s)", "", hours);
 	}
-	if (hours == 1 && minutes == 1)
-	{
-		return tr("%0 hour and %1 minute").arg(hours).arg(minutes);
-	}
+
 	if (hours == 1)
 	{
-		return tr("%0 hour and %1 minutes").arg(hours).arg(minutes);
+		return tr("%0 hour and %n minute(s)", "", minutes).arg(hours);
 	}
-	if (minutes == 1)
-	{
-		return tr("%0 hours and %1 minute").arg(hours).arg(minutes);
-	}
-	return tr("%0 hours and %1 minutes").arg(hours).arg(minutes);
+	
+	return tr("%0 hours and %n minute(s)", "", minutes).arg(hours);
 }


### PR DESCRIPTION
I noticed there is many if else cases in the file rpcs3/rpcs3qt/localized.cpp.
This file generates messages when there is a update available and compute the diff time in order to print it.
[QT Linguist](https://doc.qt.io/qt-5/i18n-source-translation.html#handling-plurals) suggest to write them like

```
tr("%n message(s) saved", "", n)
```

instead of

```
n == 1 ? tr("%n message saved") : tr("%n messages saved")
```

This PR is intended to fix that.