### PR TITLE
rsx: Fix memory operations on non-standard formats

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -568,6 +568,11 @@ void GLGSRender::clear_surface(u32 arg)
 
 	if (auto colormask = (arg & 0xf0))
 	{
+		u8 clear_a = rsx::method_registers.clear_color_a();
+		u8 clear_r = rsx::method_registers.clear_color_r();
+		u8 clear_g = rsx::method_registers.clear_color_g();
+		u8 clear_b = rsx::method_registers.clear_color_b();
+
 		switch (rsx::method_registers.surface_color())
 		{
 		case rsx::surface_color_format::x32:
@@ -579,16 +584,22 @@ void GLGSRender::clear_surface(u32 arg)
 		}
 		case rsx::surface_color_format::g8b8:
 		{
+			rsx::get_g8b8_clear_color(clear_r, clear_g, clear_b, clear_a);
 			colormask = rsx::get_g8b8_r8g8_colormask(colormask);
-			[[fallthrough]];
+			break;
 		}
-		default:
+		case rsx::surface_color_format::a8b8g8r8:
+		case rsx::surface_color_format::x8b8g8r8_o8b8g8r8:
+		case rsx::surface_color_format::x8b8g8r8_z8b8g8r8:
 		{
-			u8 clear_a = rsx::method_registers.clear_color_a();
-			u8 clear_r = rsx::method_registers.clear_color_r();
-			u8 clear_g = rsx::method_registers.clear_color_g();
-			u8 clear_b = rsx::method_registers.clear_color_b();
+			rsx::get_abgr8_clear_color(clear_r, clear_g, clear_b, clear_a);
+			colormask = rsx::get_abgr8_colormask(colormask);
+			break;
+		}
+		}
 
+		if (colormask)
+		{
 			gl_state.clear_color(clear_r, clear_g, clear_b, clear_a);
 			mask |= GLenum(gl::buffers::color);
 
@@ -601,8 +612,6 @@ void GLGSRender::clear_surface(u32 arg)
 			}
 
 			update_color = true;
-			break;
-		}
 		}
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -953,6 +953,7 @@ namespace gl
 			case CELL_GCM_TEXTURE_R5G6B5:
 				return (ifmt == gl::texture::internal_format::rgb565);
 			case CELL_GCM_TEXTURE_A8R8G8B8:
+			case CELL_GCM_TEXTURE_D8R8G8B8:
 				return (ifmt == gl::texture::internal_format::rgba8 ||
 						ifmt == gl::texture::internal_format::depth24_stencil8 ||
 						ifmt == gl::texture::internal_format::depth32f_stencil8);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1130,33 +1130,45 @@ void VKGSRender::clear_surface(u32 mask)
 		if (!m_draw_buffers.empty())
 		{
 			bool use_fast_clear = false;
-			bool ignore_clear = false;
+			u8 clear_a = rsx::method_registers.clear_color_a();
+			u8 clear_r = rsx::method_registers.clear_color_r();
+			u8 clear_g = rsx::method_registers.clear_color_g();
+			u8 clear_b = rsx::method_registers.clear_color_b();
+
 			switch (rsx::method_registers.surface_color())
 			{
 			case rsx::surface_color_format::x32:
 			case rsx::surface_color_format::w16z16y16x16:
 			case rsx::surface_color_format::w32z32y32x32:
+			{
 				//NOP
-				ignore_clear = true;
+				colormask = 0;
 				break;
+			}
 			case rsx::surface_color_format::g8b8:
+			{
+				rsx::get_g8b8_clear_color(clear_r, clear_g, clear_b, clear_a);
 				colormask = rsx::get_g8b8_r8g8_colormask(colormask);
 				use_fast_clear = (colormask == (0x10 | 0x20));
-				ignore_clear = (colormask == 0);
-				colormask |= (0x40 | 0x80);
 				break;
+			}
+			case rsx::surface_color_format::a8b8g8r8:
+			case rsx::surface_color_format::x8b8g8r8_o8b8g8r8:
+			case rsx::surface_color_format::x8b8g8r8_z8b8g8r8:
+			{
+				rsx::get_abgr8_clear_color(clear_r, clear_g, clear_b, clear_a);
+				colormask = rsx::get_abgr8_colormask(colormask);
+				break;
+			}
 			default:
+			{
 				use_fast_clear = (colormask == (0x10 | 0x20 | 0x40 | 0x80));
 				break;
 			}
+			}
 
-			if (!ignore_clear)
+			if (colormask)
 			{
-				u8 clear_a = rsx::method_registers.clear_color_a();
-				u8 clear_r = rsx::method_registers.clear_color_r();
-				u8 clear_g = rsx::method_registers.clear_color_g();
-				u8 clear_b = rsx::method_registers.clear_color_b();
-
 				color_clear_values.color.float32[0] = static_cast<float>(clear_r) / 255;
 				color_clear_values.color.float32[1] = static_cast<float>(clear_g) / 255;
 				color_clear_values.color.float32[2] = static_cast<float>(clear_b) / 255;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1334,6 +1334,7 @@ namespace vk
 			case CELL_GCM_TEXTURE_R5G6B5:
 				return (vk_format == VK_FORMAT_R5G6B5_UNORM_PACK16);
 			case CELL_GCM_TEXTURE_A8R8G8B8:
+			case CELL_GCM_TEXTURE_D8R8G8B8:
 				return (vk_format == VK_FORMAT_B8G8R8A8_UNORM || vk_format == VK_FORMAT_D24_UNORM_S8_UINT || vk_format == VK_FORMAT_D32_SFLOAT_S8_UINT);
 			case CELL_GCM_TEXTURE_B8:
 				return (vk_format == VK_FORMAT_R8_UNORM);

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -737,12 +737,36 @@ namespace rsx
 		return result;
 	}
 
-	static inline void get_g8b8_r8g8_colormask(bool &red, bool &green, bool &blue, bool &alpha)
+	static inline void get_g8b8_r8g8_colormask(bool &red, bool &/*green*/, bool &blue, bool &alpha)
 	{
 		red = blue;
-		green = green;
 		blue = false;
 		alpha = false;
+	}
+
+	static inline void get_g8b8_clear_color(u8& red, u8& /*green*/, u8& blue, u8& /*alpha*/)
+	{
+		red = blue;
+	}
+
+	static inline u32 get_abgr8_colormask(u32 mask)
+	{
+		u32 result = 0;
+		if (mask & 0x10) result |= 0x40;
+		if (mask & 0x20) result |= 0x20;
+		if (mask & 0x40) result |= 0x10;
+		if (mask & 0x80) result |= 0x80;
+		return result;
+	}
+
+	static inline void get_abgr8_colormask(bool& red, bool& /*green*/, bool& blue, bool& /*alpha*/)
+	{
+		std::swap(red, blue);
+	}
+
+	static inline void get_abgr8_clear_color(u8& red, u8& /*green*/, u8& blue, u8& /*alpha*/)
+	{
+		std::swap(red, blue);
 	}
 
 	static inline color4f decode_border_color(u32 colorref)


### PR DESCRIPTION
Colormask and clear color data seems to literally follow the physical memory layout. This means for example, if you pass the same colormask or clear data mask for ABGR vs ARGB you get the same data written to memory because the decoding step is changed to mirror the format layout. This was initially noted for G8B8 format needed for TLOU to render the window correctly, but no tests were made for other formats.

Fixes https://github.com/RPCS3/rpcs3/issues/7277