### PR TITLE
Windows: Distinguish Left and Right Modifiers

### DIFF
--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -217,9 +217,11 @@ void keyboard_pad_handler::processKeyEvent(QKeyEvent* event, bool pressed)
 	};
 
 	// We need to ignore keys when using rpcs3 keyboard shortcuts
+	// NOTE: needs to be updated with gs_frame::keyPressEvent
 	switch (event->key())
 	{
 	case Qt::Key_Escape:
+	case Qt::Key_F12:
 		break;
 	case Qt::Key_L:
 	case Qt::Key_Return:

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -132,35 +132,6 @@ void keyboard_pad_handler::Key(const u32 code, bool pressed, u16 value)
 	}
 }
 
-int keyboard_pad_handler::GetModifierCode(QKeyEvent* e)
-{
-	switch (e->key())
-	{
-	case Qt::Key_Control:
-	case Qt::Key_Alt:
-	case Qt::Key_AltGr:
-	case Qt::Key_Shift:
-	case Qt::Key_Meta:
-	case Qt::Key_NumLock:
-		return 0;
-	default:
-		break;
-	}
-
-	if (e->modifiers() == Qt::ControlModifier)
-		return Qt::ControlModifier;
-	else if (e->modifiers() == Qt::AltModifier)
-		return Qt::AltModifier;
-	else if (e->modifiers() == Qt::MetaModifier)
-		return Qt::MetaModifier;
-	else if (e->modifiers() == Qt::ShiftModifier)
-		return Qt::ShiftModifier;
-	else if (e->modifiers() == Qt::KeypadModifier)
-		return Qt::KeypadModifier;
-
-	return 0;
-}
-
 bool keyboard_pad_handler::eventFilter(QObject* target, QEvent* ev)
 {
 	// !m_target is for future proofing when gsrender isn't automatically initialized on load.

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -190,9 +190,8 @@ void keyboard_pad_handler::processKeyEvent(QKeyEvent* event, bool pressed)
 		return;
 	}
 
-	auto handleKey = [this, pressed, event]()
+	auto handle_key = [this, pressed, event]()
 	{
-		const QString name = qstr(GetKeyName(event));
 		QStringList list = GetKeyNames(event);
 		if (list.isEmpty())
 			return;
@@ -200,6 +199,8 @@ void keyboard_pad_handler::processKeyEvent(QKeyEvent* event, bool pressed)
 		const bool is_num_key = list.contains("Num");
 		if (is_num_key)
 			list.removeAll("Num");
+
+		const QString name = qstr(GetKeyName(event));
 
 		// TODO: Edge case: switching numlock keeps numpad keys pressed due to now different modifier
 
@@ -226,17 +227,17 @@ void keyboard_pad_handler::processKeyEvent(QKeyEvent* event, bool pressed)
 	case Qt::Key_L:
 	case Qt::Key_Return:
 		if (event->modifiers() != Qt::AltModifier)
-			handleKey();
+			handle_key();
 		break;
 	case Qt::Key_P:
 	case Qt::Key_S:
 	case Qt::Key_R:
 	case Qt::Key_E:
 		if (event->modifiers() != Qt::ControlModifier)
-			handleKey();
+			handle_key();
 		break;
 	default:
-		handleKey();
+		handle_key();
 		break;
 	}
 	event->ignore();
@@ -472,6 +473,12 @@ QStringList keyboard_pad_handler::GetKeyNames(const QKeyEvent* keyEvent)
 		list.append(QKeySequence(keyEvent->key() | Qt::KeypadModifier).toString(QKeySequence::NativeText));
 	}
 
+	// Handle special cases
+	if (const std::string name = native_scan_code_to_string(keyEvent->nativeScanCode()); !name.empty())
+	{
+		list.append(qstr(name));
+	}
+
 	switch (keyEvent->key())
 	{
 	case Qt::Key_Alt:
@@ -500,6 +507,12 @@ QStringList keyboard_pad_handler::GetKeyNames(const QKeyEvent* keyEvent)
 
 std::string keyboard_pad_handler::GetKeyName(const QKeyEvent* keyEvent)
 {
+	// Handle special cases first
+	if (const std::string name = native_scan_code_to_string(keyEvent->nativeScanCode()); !name.empty())
+	{
+		return name;
+	}
+
 	switch (keyEvent->key())
 	{
 	case Qt::Key_Alt:
@@ -534,6 +547,8 @@ u32 keyboard_pad_handler::GetKeyCode(const QString& keyName)
 {
 	if (keyName.isEmpty())
 		return 0;
+	else if (const int native_scan_code = native_scan_code_from_string(sstr(keyName)); native_scan_code >= 0)
+		return Qt::Key_unknown + native_scan_code; // Special cases that can't be expressed with Qt::Key
 	else if (keyName == "Alt")
 		return Qt::Key_Alt;
 	else if (keyName == "AltGr")
@@ -546,14 +561,56 @@ u32 keyboard_pad_handler::GetKeyCode(const QString& keyName)
 		return Qt::Key_Meta;
 
 	QKeySequence seq(keyName);
-	u32 keyCode = 0;
+	u32 key_code = 0;
 
 	if (seq.count() == 1)
-		keyCode = seq[0];
+		key_code = seq[0];
 	else
 		input_log.notice("GetKeyCode(%s): seq.count() = %d", sstr(keyName), seq.count());
 
-	return keyCode;
+	return key_code;
+}
+
+int keyboard_pad_handler::native_scan_code_from_string(const std::string& key)
+{
+	// NOTE: Qt throws a Ctrl key at us when using Alt Gr, so there is no point in distinguishing left and right Alt at the moment
+#ifdef _WIN32
+	if (key == "Shift Left")
+		return 42;
+	else if (key == "Shift Right")
+		return 54;
+	else if (key == "Ctrl Left")
+		return 29;
+	else if (key == "Ctrl Right")
+		return 285;
+#else
+		// TODO
+#endif
+	return -1;
+}
+
+std::string keyboard_pad_handler::native_scan_code_to_string(int native_scan_code)
+{
+	switch (native_scan_code)
+	{
+#ifdef _WIN32
+	// NOTE: the other Qt function "nativeVirtualKey" does not distinguish between VK_SHIFT and VK_RSHIFT key in Qt at the moment
+	// NOTE: Qt throws a Ctrl key at us when using Alt Gr, so there is no point in distinguishing left and right Alt at the moment
+	case 42:
+		return "Shift Left";
+	case 54:
+		return "Shift Right";
+	case 29:
+		return "Ctrl Left";
+	case 285:
+		return "Ctrl Right";
+#else
+	// TODO
+	// NOTE for MacOs: nativeScanCode may not work
+#endif
+	default:
+		return "";
+	}
 }
 
 bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device)

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -95,7 +95,6 @@ public:
 
 protected:
 	void Key(const u32 code, bool pressed, u16 value = 255);
-	int GetModifierCode(QKeyEvent* e);
 
 private:
 	QWindow* m_target = nullptr;

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -93,6 +93,9 @@ public:
 	u32 GetKeyCode(const std::string& keyName);
 	u32 GetKeyCode(const QString& keyName);
 
+	static int native_scan_code_from_string(const std::string& key);
+	static std::string native_scan_code_to_string(int native_scan_code);
+
 protected:
 	void Key(const u32 code, bool pressed, u16 value = 255);
 

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -116,6 +116,8 @@ void gs_frame::showEvent(QShowEvent *event)
 
 void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 {
+	// NOTE: needs to be updated with keyboard_pad_handler::processKeyEvent
+
 	switch (keyEvent->key())
 	{
 	case Qt::Key_L:

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -106,8 +106,8 @@ void gs_frame::showEvent(QShowEvent *event)
 {
 	// we have to calculate new window positions, since the frame is only known once the window was created
 	// the left and right margins are too big on my setup for some reason yet unknown, so we'll have to ignore them
-	int x = geometry().left(); //std::max(geometry().left(), frameMargins().left());
-	int y = std::max(geometry().top(), frameMargins().top());
+	const int x = geometry().left(); //std::max(geometry().left(), frameMargins().left());
+	const int y = std::max(geometry().top(), frameMargins().top());
 
 	setPosition(x, y);
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -413,7 +413,7 @@ void pad_settings_dialog::InitButtons()
 	// Use timer to get button input
 	connect(&m_timer_input, &QTimer::timeout, [this, callback, fail_callback]()
 	{
-		std::vector<std::string> buttons =
+		const std::vector<std::string> buttons =
 		{
 			m_cfg_entries[button_ids::id_pad_l2].key, m_cfg_entries[button_ids::id_pad_r2].key, m_cfg_entries[button_ids::id_pad_lstick_left].key,
 			m_cfg_entries[button_ids::id_pad_lstick_right].key, m_cfg_entries[button_ids::id_pad_lstick_down].key, m_cfg_entries[button_ids::id_pad_lstick_up].key,
@@ -443,7 +443,7 @@ void pad_settings_dialog::InitButtons()
 
 void pad_settings_dialog::SetPadData(u32 large_motor, u32 small_motor)
 {
-	QColor led_color(m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
+	const QColor led_color(m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB);
 	m_handler->SetPadData(m_device_name, large_motor, small_motor, led_color.red(), led_color.green(), led_color.blue(), static_cast<bool>(m_handler_cfg.led_battery_indicator), m_handler_cfg.led_battery_indicator_brightness);
 }
 


### PR DESCRIPTION
- Windows only for now
- Works for Ctrl Left and Right
- Works for Shift Left and Right

Keep in mind that you most likely can't press both Ctrl keys or both shift keys at the same time.
Sadly I could not find a way to properly distinguish Alt left and right with this method.

Should fix parts of #3393 for windows users