### PR TITLE
Fix pad settings crash during firmware compilation

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -160,8 +160,6 @@ static bool ds3_input_to_pad(const u32 port_no, be_t<u16>& digital_buttons, be_t
 
 	const auto handler = pad::get_current_handler();
 
-	const PadInfo& rinfo = handler->GetInfo();
-
 	auto& pads = handler->GetPads();
 	auto pad = pads[port_no];
 
@@ -249,9 +247,6 @@ static bool ds3_input_to_ext(const u32 port_no, CellGemExtPortData& ext)
 	const auto handler = pad::get_current_handler();
 
 	auto& pads = handler->GetPads();
-
-	const PadInfo& rinfo = handler->GetInfo();
-
 	auto pad = pads[port_no];
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
@@ -283,7 +278,7 @@ static bool mouse_input_to_pad(const u32 mouse_no, be_t<u16>& digital_buttons, b
 
 	std::scoped_lock lock(handler->mutex);
 
-	if (!handler || mouse_no >= handler->GetMice().size())
+	if (mouse_no >= handler->GetMice().size())
 	{
 		return false;
 	}
@@ -316,7 +311,7 @@ static bool mouse_pos_to_gem_image_state(const u32 mouse_no, vm::ptr<CellGemImag
 
 	std::scoped_lock lock(handler->mutex);
 
-	if (!gem_image_state || !handler || mouse_no >= handler->GetMice().size())
+	if (!gem_image_state || mouse_no >= handler->GetMice().size())
 	{
 		return false;
 	}
@@ -346,7 +341,7 @@ static bool mouse_pos_to_gem_state(const u32 mouse_no, vm::ptr<CellGemState>& ge
 
 	std::scoped_lock lock(handler->mutex);
 
-	if (!gem_state || !handler || mouse_no >= handler->GetMice().size())
+	if (!gem_state || mouse_no >= handler->GetMice().size())
 	{
 		return false;
 	}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -38,8 +38,6 @@ struct EmuCallbacks
 	std::function<void()> on_stop;
 	std::function<void()> on_ready;
 	std::function<void(bool)> exit; // (force_quit) close RPCS3
-	std::function<void(const std::string&)> reset_pads;
-	std::function<void(bool)> enable_pads;
 	std::function<void(s32, s32)> handle_taskbar_progress; // (type, value) type: 0 for reset, 1 for increment, 2 for set_limit
 	std::function<void()> init_kb_handler;
 	std::function<void()> init_mouse_handler;

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -21,6 +21,9 @@ namespace pad
 	atomic_t<pad_thread*> g_current = nullptr;
 	std::recursive_mutex g_pad_mutex;
 	std::string g_title_id;
+	atomic_t<bool> g_reset{false};
+	atomic_t<bool> g_enabled{false};
+	atomic_t<bool> g_active;
 }
 
 struct pad_setting
@@ -43,7 +46,7 @@ pad_thread::pad_thread(void *_curthread, void *_curwindow, std::string_view titl
 pad_thread::~pad_thread()
 {
 	pad::g_current = nullptr;
-	active = false;
+	pad::g_active = false;
 	thread->join();
 
 	handlers.clear();
@@ -167,17 +170,6 @@ void pad_thread::SetRumble(const u32 pad, u8 largeMotor, bool smallMotor)
 	}
 }
 
-void pad_thread::Reset(std::string_view title_id)
-{
-	pad::g_title_id = title_id;
-	reset = active.load();
-}
-
-void pad_thread::SetEnabled(bool enabled)
-{
-	is_enabled = enabled;
-}
-
 void pad_thread::SetIntercepted(bool intercepted)
 {
 	if (intercepted)
@@ -193,16 +185,16 @@ void pad_thread::SetIntercepted(bool intercepted)
 
 void pad_thread::ThreadFunc()
 {
-	active = true;
-	while (active)
+	pad::g_active = true;
+	while (pad::g_active)
 	{
-		if (!is_enabled)
+		if (!pad::g_enabled)
 		{
 			std::this_thread::sleep_for(1ms);
 			continue;
 		}
 
-		if (reset && reset.exchange(false))
+		if (pad::g_reset && pad::g_reset.exchange(false))
 		{
 			Init();
 		}

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -57,16 +57,7 @@ EmuCallbacks main_application::CreateCallbacks()
 {
 	EmuCallbacks callbacks;
 
-	callbacks.reset_pads = [this](const std::string& title_id)
-	{
-		pad::get_current_handler()->Reset(title_id);
-	};
-	callbacks.enable_pads = [this](bool enable)
-	{
-		pad::get_current_handler()->SetEnabled(enable);
-	};
-
-	callbacks.init_kb_handler = [=, this]()
+	callbacks.init_kb_handler = [this]()
 	{
 		switch (keyboard_handler type = g_cfg.io.keyboard)
 		{
@@ -86,7 +77,7 @@ EmuCallbacks main_application::CreateCallbacks()
 		}
 	};
 
-	callbacks.init_mouse_handler = [=, this]()
+	callbacks.init_mouse_handler = [this]()
 	{
 		switch (mouse_handler type = g_cfg.io.mouse)
 		{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1488,24 +1488,8 @@ void main_window::CreateConnects()
 
 	auto open_pad_settings = [this]
 	{
-		if (!Emu.IsStopped())
-		{
-			Emu.GetCallbacks().enable_pads(false);
-		}
 		pad_settings_dialog dlg(this);
-		connect(&dlg, &QDialog::finished, [this](int/* result*/)
-		{
-			if (Emu.IsStopped())
-			{
-				return;
-			}
-			Emu.GetCallbacks().reset_pads(Emu.GetTitleID());
-		});
 		dlg.exec();
-		if (!Emu.IsStopped())
-		{
-			Emu.GetCallbacks().enable_pads(true);
-		}
 	};
 
 	connect(ui->confPadsAct, &QAction::triggered, open_pad_settings);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -58,6 +58,8 @@ inline bool CreateConfigFile(const QString& dir, const QString& name)
 pad_settings_dialog::pad_settings_dialog(QWidget *parent, const GameInfo *game)
 	: QDialog(parent), ui(new Ui::pad_settings_dialog)
 {
+	pad::set_enabled(false);
+
 	ui->setupUi(this);
 
 	// load input config
@@ -207,6 +209,13 @@ pad_settings_dialog::pad_settings_dialog(QWidget *parent, const GameInfo *game)
 pad_settings_dialog::~pad_settings_dialog()
 {
 	delete ui;
+
+	if (!Emu.IsStopped())
+	{
+		pad::reset(Emu.GetTitleID());
+	}
+
+	pad::set_enabled(true);
 }
 
 void pad_settings_dialog::InitButtons()
@@ -1451,8 +1460,10 @@ bool pad_settings_dialog::GetIsLddPad(int index) const
 	if (index >= 0 && !Emu.IsStopped() && (m_title_id.empty() || m_title_id == Emu.GetTitleID()))
 	{
 		std::lock_guard lock(pad::g_pad_mutex);
-		const auto handler = pad::get_current_handler();
-		return handler && handler->GetPads().at(index)->ldd;
+		if (const auto handler = pad::get_current_handler(true))
+		{
+			return handler->GetPads().at(index)->ldd;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
fixes #5908

This should also fix a theoretical issue that would allow pads to be enabled if the emu started after the pad settings dialog was opened.