### PR TITLE
cellSaveData: Emulate PPU processing of auto/list post-fixed callback

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1120,6 +1120,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			{
 				if (operation != SAVEDATA_OP_FIXED_SAVE && operation != SAVEDATA_OP_FIXED_LOAD && operation != SAVEDATA_OP_FIXED_DELETE)
 				{
+					lv2_sleep(ppu, 5000);
 					break;
 				}
 
@@ -1161,6 +1162,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				break;
 			}
 			case CELL_SAVEDATA_OPTION_NOCONFIRM:
+				lv2_sleep(ppu, 5000);
 				break;
 
 			default :


### PR DESCRIPTION
Savedata processing time means calling PPU thread should be asleep until complete, waiting for VSH thread(s) to respond. Let other PPU threads execute code meanwhile as some games rely on this feature.
 
Fixes #7182 