### PR TITLE
patch_manager 1.2

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -292,7 +292,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, bool im
 						if (app_versions.empty())
 						{
 							append_log_message(log_messages, fmt::format("Error: Skipping %s: empty Sequence (title: %s, patch: %s, key: %s)", serial, title, description, main_key));
-							patch_log.error("Skipping %s: empty Sequence (title: %s, patch: %s, key: %s, file: %s)", serial,title, description, main_key, path);
+							patch_log.error("Skipping %s: empty Sequence (title: %s, patch: %s, key: %s, file: %s)", serial, title, description, main_key, path);
 							is_valid = false;
 						}
 						else
@@ -315,7 +315,26 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, bool im
 
 			if (const auto notes_node = patches_entry.second["Notes"])
 			{
-				info.notes = notes_node.Scalar();
+				if (notes_node.IsSequence())
+				{
+					for (const auto note : notes_node)
+					{
+						if (note && note.IsScalar())
+						{
+							info.notes += note.Scalar();
+						}
+						else
+						{
+							append_log_message(log_messages, fmt::format("Error: Skipping sequenced Note (patch: %s, key: %s)", description, main_key));
+							patch_log.error("Skipping sequenced Note (patch: %s, key: %s, file: %s)", description, main_key, path);
+							is_valid = false;
+						}
+					}
+				}
+				else
+				{
+					info.notes = notes_node.Scalar();
+				}
 			}
 
 			if (const auto patch_group_node = patches_entry.second["Group"])

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -563,15 +563,35 @@ std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 file
 
 		for (const auto& [title, serials] : patch.titles)
 		{
-			if (serials.find(serial) != serials.end())
+			std::string found_serial;
+
+			if (serials.find(patch_key::all) != serials.end())
 			{
-				if (const auto& app_versions = serials.at(serial); app_versions.find(app_version) != app_versions.end())
+				found_serial = patch_key::all;
+			}
+			else if (serials.find(serial) != serials.end())
+			{
+				found_serial = serial;
+			}
+
+			if (!found_serial.empty())
+			{
+				const auto& app_versions = serials.at(found_serial);
+				std::string found_app_version;
+
+				if (app_versions.find(patch_key::all) != app_versions.end())
 				{
-					if (app_versions.at(app_version))
-					{
-						enabled = true;
-						break;
-					}
+					found_app_version = patch_key::all;
+				}
+				else if (app_versions.find(app_version) != app_versions.end())
+				{
+					found_app_version = app_version;
+				}
+
+				if (!found_app_version.empty() && app_versions.at(found_app_version))
+				{
+					enabled = true;
+					break;
 				}
 			}
 		}

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -245,9 +245,29 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, bool im
 						continue;
 					}
 
+					const bool title_is_all_key = title == patch_key::all;
+
 					for (const auto serial_node : game_node.second)
 					{
 						const std::string& serial = serial_node.first.Scalar();
+
+						if (serial == patch_key::all)
+						{
+							if (!title_is_all_key)
+							{
+								append_log_message(log_messages, fmt::format("Error: Using '%s' as serial is not allowed for titles other than '%s' (title: %s, patch: %s, key: %s)", patch_key::all, patch_key::all, title, description, main_key));
+								patch_log.error("Error: Using '%s' as serial is not allowed for titles other than '%s' (title: %s, patch: %s, key: %s, file: %s)", patch_key::all, patch_key::all, title, description, main_key, path);
+								is_valid = false;
+								continue;
+							}
+						}
+						else if (title_is_all_key)
+						{
+							append_log_message(log_messages, fmt::format("Error: Only '%s' is allowed as serial if the title is '%s' (serial: %s, patch: %s, key: %s)", patch_key::all, patch_key::all, serial, description, main_key));
+							patch_log.error("Error: Only '%s' is allowed as serial if the title is '%s' (serial: %s, patch: %s, key: %s, file: %s)", patch_key::all, patch_key::all, serial, description, main_key, path);
+							is_valid = false;
+							continue;
+						}
 
 						if (const auto yml_type = serial_node.second.Type(); yml_type != YAML::NodeType::Sequence)
 						{

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -568,13 +568,13 @@ std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 file
 		{
 			std::string found_serial;
 
-			if (serials.find(patch_key::all) != serials.end())
-			{
-				found_serial = patch_key::all;
-			}
-			else if (serials.find(serial) != serials.end())
+			if (serials.find(serial) != serials.end())
 			{
 				found_serial = serial;
+			}
+			else if (serials.find(patch_key::all) != serials.end())
+			{
+				found_serial = patch_key::all;
 			}
 
 			if (!found_serial.empty())
@@ -582,13 +582,13 @@ std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 file
 				const auto& app_versions = serials.at(found_serial);
 				std::string found_app_version;
 
-				if (app_versions.find(patch_key::all) != app_versions.end())
-				{
-					found_app_version = patch_key::all;
-				}
-				else if (app_versions.find(app_version) != app_versions.end())
+				if (app_versions.find(app_version) != app_versions.end())
 				{
 					found_app_version = app_version;
+				}
+				else if (app_versions.find(patch_key::all) != app_versions.end())
+				{
+					found_app_version = patch_key::all;
 				}
 
 				if (!found_app_version.empty() && app_versions.at(found_app_version))

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -551,6 +551,9 @@ std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 file
 	const auto serial = Emu.GetTitleID();
 	const auto app_version = Emu.GetAppVersion();
 
+	// Only one patch per patch group is allowed
+	std::set<std::string> applied_groups;
+
 	// Apply modifications sequentially
 	for (const auto& [description, patch] : container.patch_info_map)
 	{
@@ -599,6 +602,16 @@ std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 file
 		if (!enabled)
 		{
 			continue;
+		}
+
+		if (!patch.patch_group.empty())
+		{
+			if (applied_groups.contains(patch.patch_group))
+			{
+				continue;
+			}
+
+			applied_groups.insert(patch.patch_group);
 		}
 
 		size_t applied = 0;

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -130,7 +130,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, bool im
 
 		if (version != patch_engine_version)
 		{
-			append_log_message(log_messages, fmt::format("Error: File version %s does not match patch engine target version %s", version, patch_engine_version));
+			append_log_message(log_messages, fmt::format("Error: File version %s does not match patch engine target version %s (file: %s)", version, patch_engine_version, path));
 			patch_log.error("File version %s does not match patch engine target version %s (file: %s)", version, patch_engine_version, path);
 			return false;
 		}
@@ -140,8 +140,8 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, bool im
 	}
 	else if (importing)
 	{
-		append_log_message(log_messages, fmt::format("Error: No 'Version' entry found. Patch engine version = %s", patch_engine_version));
-		patch_log.error("Patch engine version %s: No 'Version' entry found for file %s", patch_engine_version, path);
+		append_log_message(log_messages, fmt::format("Error: No 'Version' entry found. Patch engine version = %s (file: %s)", patch_engine_version, path));
+		patch_log.error("No 'Version' entry found. Patch engine version = %s (file: %s)", patch_engine_version, path);
 		return false;
 	}
 	else

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -548,18 +548,18 @@ void patch_engine::append_title_patches(const std::string& title_id)
 	load(m_map, fs::get_config_dir() + "patches/" +  title_id + "_patch.yml");
 }
 
-std::size_t patch_engine::apply(const std::string& name, u8* dst) const
+std::size_t patch_engine::apply(const std::string& name, u8* dst)
 {
 	return apply_patch<false>(name, dst, 0, 0);
 }
 
-std::size_t patch_engine::apply_with_ls_check(const std::string& name, u8* dst, u32 filesz, u32 ls_addr) const
+std::size_t patch_engine::apply_with_ls_check(const std::string& name, u8* dst, u32 filesz, u32 ls_addr)
 {
 	return apply_patch<true>(name, dst, filesz, ls_addr);
 }
 
 template <bool check_local_storage>
-std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 filesz, u32 ls_addr) const
+std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 filesz, u32 ls_addr)
 {
 	if (m_map.find(name) == m_map.cend())
 	{
@@ -570,9 +570,6 @@ std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 file
 	const auto& container = m_map.at(name);
 	const auto serial = Emu.GetTitleID();
 	const auto app_version = Emu.GetAppVersion();
-
-	// Only one patch per patch group is allowed
-	std::set<std::string> applied_groups;
 
 	// Apply modifications sequentially
 	for (const auto& [description, patch] : container.patch_info_map)
@@ -626,12 +623,12 @@ std::size_t patch_engine::apply_patch(const std::string& name, u8* dst, u32 file
 
 		if (!patch.patch_group.empty())
 		{
-			if (applied_groups.contains(patch.patch_group))
+			if (m_applied_groups.contains(patch.patch_group))
 			{
 				continue;
 			}
 
-			applied_groups.insert(patch.patch_group);
+			m_applied_groups.insert(patch.patch_group);
 		}
 
 		size_t applied = 0;

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -7,6 +7,11 @@
 
 #include "util/yaml.hpp"
 
+namespace patch_key
+{
+	static const std::string all = "All";
+}
+
 enum class patch_type
 {
 	invalid,
@@ -81,19 +86,6 @@ public:
 	static std::string get_imported_patch_path();
 
 	// Load from file and append to specified patches map
-	// Example entry:
-	//
-	// PPU-8007056e52279bea26c15669d1ee08c2df321d00:
-	//   Patches:
-	//     60fps:
-	//       Game Title: Fancy Game
-	//       Serials: ABCD12345, SUPA13337 v.1.3
-	//       Author: Batman bin Suparman
-	//       Notes: This is super
-	//       Patch Version: 1.3
-	//       Patch:
-	//         - [ be32, 0x000e522c, 0x995d0072 ]
-	//         - [ be32, 0x000e5234, 0x995d0074 ]
 	static bool load(patch_map& patches, const std::string& path, bool importing = false, std::stringstream* log_messages = nullptr);
 
 	// Read and add a patch node to the patch info

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -38,36 +38,39 @@ public:
 			f64 double_value;
 		} value { 0 };
 	};
+	
+	using patch_app_versions = std::unordered_map<std::string /*app_version*/, bool /*enabled*/>;
+	using patch_serials = std::unordered_map<std::string /*serial*/, patch_app_versions>;
+	using patch_titles = std::unordered_map<std::string /*serial*/, patch_serials>;
 
 	struct patch_info
 	{
 		// Patch information
-		std::vector<patch_engine::patch_data> data_list;
+		std::vector<patch_data> data_list;
+		patch_titles titles;
 		std::string description;
-		std::string title;
-		std::string serials;
 		std::string patch_version;
+		std::string patch_group;
 		std::string author;
 		std::string notes;
 		std::string source_path;
-		bool enabled = false;
 
 		// Redundant information for accessibility (see patch_container)
 		std::string hash;
 		std::string version;
 		bool is_legacy = false;
+		bool is_enabled = false; // only for legacy patches
 	};
 
 	struct patch_container
 	{
-		std::unordered_map<std::string /*description*/, patch_engine::patch_info> patch_info_map;
+		std::unordered_map<std::string /*description*/, patch_info> patch_info_map;
 		std::string hash;
 		std::string version;
 		bool is_legacy = false;
 	};
 
 	using patch_map = std::unordered_map<std::string /*hash*/, patch_container>;
-	using patch_config_map = std::unordered_map<std::string /*hash*/, std::unordered_map<std::string /*description*/, bool /*enabled*/>>;
 
 	patch_engine();
 
@@ -115,7 +118,7 @@ public:
 	static bool remove_patch(const patch_info& info);
 
 	// Load patch_config.yml
-	static patch_config_map load_config(bool& enable_legacy_patches);
+	static patch_map load_config(bool& enable_legacy_patches);
 
 	// Load from file and append to member patches map
 	void append_global_patches();

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -119,10 +119,10 @@ public:
 	void append_title_patches(const std::string& title_id);
 
 	// Apply patch (returns the number of entries applied)
-	std::size_t apply(const std::string& name, u8* dst) const;
+	std::size_t apply(const std::string& name, u8* dst);
 
 	// Apply patch with a check that the address exists in SPU local storage
-	std::size_t apply_with_ls_check(const std::string& name, u8* dst, u32 filesz, u32 ls_addr) const;
+	std::size_t apply_with_ls_check(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
 
 private:
 	// Load from file and append to member patches map
@@ -130,8 +130,11 @@ private:
 
 	// Internal: Apply patch (returns the number of entries applied)
 	template <bool check_local_storage>
-	std::size_t apply_patch(const std::string& name, u8* dst, u32 filesz, u32 ls_addr) const;
+	std::size_t apply_patch(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
 
 	// Database
 	patch_map m_map;
+
+	// Only one patch per patch group can be applied
+	std::set<std::string> m_applied_groups;
 };

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -850,7 +850,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		m_title_id = psf::get_string(_psf, "TITLE_ID");
 		m_cat = psf::get_string(_psf, "CATEGORY");
 
-		const std::string version_app  = psf::get_string(_psf, "APP_VER", "Unknown");
+		m_app_version = psf::get_string(_psf, "APP_VER", "Unknown");
 		const std::string version_disc = psf::get_string(_psf, "VERSION", "Unknown");
 
 		if (!_psf.empty() && m_cat.empty())
@@ -862,7 +862,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		sys_log.notice("Title: %s", GetTitle());
 		sys_log.notice("Serial: %s", GetTitleID());
 		sys_log.notice("Category: %s", GetCat());
-		sys_log.notice("Version: %s / %s", version_app, version_disc);
+		sys_log.notice("Version: %s / %s", GetAppVersion(), version_disc);
 
 		if (!add_only && !force_global_config)
 		{

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -64,6 +64,7 @@ class Emulator final
 	std::string m_path_old;
 	std::string m_title_id;
 	std::string m_title;
+	std::string m_app_version;
 	std::string m_cat;
 	std::string m_dir;
 	std::string m_sfo_dir;
@@ -129,6 +130,11 @@ public:
 	const std::string GetTitleAndTitleID() const
 	{
 		return m_title + (m_title_id.empty() ? "" : " [" + m_title_id + "]");
+	}
+
+	const std::string& GetAppVersion() const
+	{
+		return m_app_version;
 	}
 
 	const std::string& GetCat() const

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2230,3 +2230,8 @@ void game_list_frame::SetShowCompatibilityInGrid(bool show)
 	RepaintIcons();
 	m_gui_settings->SetValue(gui::gl_draw_compat, show);
 }
+
+QList<game_info> game_list_frame::GetGameInfo() const
+{
+	return m_game_data;
+}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1946,20 +1946,13 @@ void game_list_frame::PopulateGameList()
 		}
 
 		// Version
-		QString app_version = qstr(game->info.app_ver);
-		const QString unknown = localized.category.unknown;
-
-		if (app_version == unknown)
-		{
-			// Fall back to Disc/Pkg Revision
-			app_version = qstr(game->info.version);
-		}
+		QString app_version = qstr(GetGameVersion(game));
 
 		if (game->info.bootable && !game->compat.latest_version.isEmpty())
 		{
 			// If the app is bootable and the compat database contains info about the latest patch version:
 			// add a hint for available software updates if the app version is unknown or lower than the latest version.
-			if (app_version == unknown || game->compat.latest_version.toDouble() > app_version.toDouble())
+			if (app_version == localized.category.unknown || game->compat.latest_version.toDouble() > app_version.toDouble())
 			{
 				app_version = tr("%0 (Update available: %1)").arg(app_version, game->compat.latest_version);
 			}
@@ -2234,4 +2227,15 @@ void game_list_frame::SetShowCompatibilityInGrid(bool show)
 QList<game_info> game_list_frame::GetGameInfo() const
 {
 	return m_game_data;
+}
+
+std::string game_list_frame::GetGameVersion(const game_info& game)
+{
+	if (game->info.app_ver == sstr(Localized().category.unknown))
+	{
+		// Fall back to Disc/Pkg Revision
+		return game->info.version;
+	}
+
+	return game->info.app_ver;
 }

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -69,6 +69,8 @@ public:
 
 	void SetShowHidden(bool show);
 
+	QList<game_info> GetGameInfo() const;
+
 public Q_SLOTS:
 	void BatchCreatePPUCaches();
 	void BatchRemovePPUCaches();

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -71,6 +71,9 @@ public:
 
 	QList<game_info> GetGameInfo() const;
 
+	// Returns the visible version string in the game list
+	static std::string GetGameVersion(const game_info& game);
+
 public Q_SLOTS:
 	void BatchCreatePPUCaches();
 	void BatchRemovePPUCaches();

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1535,7 +1535,18 @@ void main_window::CreateConnects()
 
 	connect(ui->actionManage_Game_Patches, &QAction::triggered, [this]
 	{
-		patch_manager_dialog patch_manager(m_gui_settings, this);
+		std::unordered_map<std::string, std::set<std::string>> games;
+		if (m_game_list_frame)
+		{
+			for (const auto game : m_game_list_frame->GetGameInfo())
+			{
+				if (game)
+				{
+					games[game->info.serial].insert(game->info.app_ver);
+				}
+			}
+		}
+		patch_manager_dialog patch_manager(m_gui_settings, games, this);
 		patch_manager.exec();
  	});
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1542,7 +1542,7 @@ void main_window::CreateConnects()
 			{
 				if (game)
 				{
-					games[game->info.serial].insert(game->info.app_ver);
+					games[game->info.serial].insert(game_list_frame::GetGameVersion(game));
 				}
 			}
 		}

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -560,7 +560,7 @@ void patch_manager_dialog::on_custom_context_menu_requested(const QPoint &pos)
 						{
 							patch_log.error("Could not remove patch %s: %s from %s", info.hash, info.description, info.source_path);
 							refresh(); // Refresh before showing the dialog
-							QMessageBox::warning(this, tr("Failure"), tr("The patch could not be removed!"));
+							QMessageBox::critical(this, tr("Failure"), tr("The patch could not be removed!"));
 						}
 					});
 
@@ -706,18 +706,18 @@ void patch_manager_dialog::dropEvent(QDropEvent* event)
 
 					if (count == 0)
 					{
-						QMessageBox::warning(this, tr("Nothing to import"), tr("None of the found %0 patches were imported.\n\nLog:\n\n%2")
+						QMessageBox::warning(this, tr("Nothing to import"), tr("None of the found %0 patches were imported.\n\nLog:\n%2")
 							.arg(total).arg(msg));
 					}
 					else
 					{
-						QMessageBox::information(this, tr("Import successful"), tr("Imported %0/%1 patches to:\n%2\n\nLog:\n\n%3")
+						QMessageBox::information(this, tr("Import successful"), tr("Imported %0/%1 patches to:\n%2\n\nLog:\n%3")
 							.arg(count).arg(total).arg(QString::fromStdString(imported_patch_yml_path)).arg(msg));
 					}
 				}
 				else
 				{
-					QMessageBox::warning(this, tr("Import failed"), tr("The patch file was not imported.\n\nLog:\n\n").arg(QString::fromStdString(log_message.str())));
+					QMessageBox::critical(this, tr("Import failed"), tr("The patch file could not be imported.\n\nLog:\n%0").arg(QString::fromStdString(log_message.str())));
 				}
 			}
 			else
@@ -728,7 +728,7 @@ void patch_manager_dialog::dropEvent(QDropEvent* event)
 		else
 		{
 			patch_log.error("Errors found in patch file %s", path);
-			QMessageBox::warning(this, tr("Validation failed"), tr("Errors were found in the patch file.\n\nLog:\n\n%0").arg(QString::fromStdString(log_message.str())));
+			QMessageBox::critical(this, tr("Validation failed"), tr("Errors were found in the patch file.\n\nLog:\n%0").arg(QString::fromStdString(log_message.str())));
 		}
 	}
 }

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -332,7 +332,7 @@ void patch_manager_dialog::filter_patches(const QString& term)
 				const std::string app_version = item->data(0, app_version_role).toString().toStdString();
 
 				if (serial != patch_key::all &&
-					(m_owned_games.find(serial) == m_owned_games.end() || !m_owned_games.at(serial).contains(app_version)))
+					(m_owned_games.find(serial) == m_owned_games.end() || (app_version != patch_key::all && !m_owned_games.at(serial).contains(app_version))))
 				{
 					item->setHidden(true);
 					return 0;

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -249,9 +249,12 @@ void patch_manager_dialog::populate_tree()
 						{
 							if (auto only_match = matches.count() == 1 ? matches[0] : nullptr)
 							{
-								only_match->setText(0, q_description + QStringLiteral(" (1)"));
+								only_match->setText(0, q_description + QStringLiteral(" (01)"));
 							}
-							visible_description += QStringLiteral(" (") + QString::number(matches.count() + 1) + QStringLiteral(")");
+							const int counter = matches.count() + 1;
+							visible_description += QStringLiteral(" (");
+							if (counter < 10) visible_description += '0';
+							visible_description += QString::number(counter) + ')';
 						}
 
 						QTreeWidgetItem* patch_level_item = new QTreeWidgetItem();

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -315,7 +315,8 @@ void patch_manager_dialog::filter_patches(const QString& term)
 				const std::string serial = item->data(0, serial_role).toString().toStdString();
 				const std::string app_version = item->data(0, app_version_role).toString().toStdString();
 
-				if (m_owned_games.find(serial) == m_owned_games.end() || !m_owned_games.at(serial).contains(app_version))
+				if (serial != patch_key::all &&
+					(m_owned_games.find(serial) == m_owned_games.end() || !m_owned_games.at(serial).contains(app_version)))
 				{
 					item->setHidden(true);
 					return 0;

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -194,7 +194,7 @@ void patch_manager_dialog::populate_tree()
 				if (!title_level_item)
 				{
 					title_level_item = new QTreeWidgetItem();
-					title_level_item->setText(0, q_title);
+					title_level_item->setText(0, title == patch_key::all ? tr_all_titles : q_title);
 					title_level_item->setData(0, title_role, q_title);
 					title_level_item->setData(0, node_level_role, node_level::title_level);
 					title_level_item->setData(0, persistance_role, true);
@@ -211,11 +211,13 @@ void patch_manager_dialog::populate_tree()
 					}
 
 					const QString q_serial = QString::fromStdString(serial);
+					const QString visible_serial = serial == patch_key::all ? tr_all_serials : q_serial;
 
 					for (const auto& [app_version, enabled] : app_versions)
 					{
 						const QString q_app_version = QString::fromStdString(app_version);
-						const QString q_serial_and_version = q_serial + QStringLiteral(" v.") + q_app_version;
+						const QString q_version_suffix = app_version == patch_key::all ? (QStringLiteral(" - ") + tr_all_versions) : (QStringLiteral(" v.") + q_app_version);
+						const QString q_serial_and_version = visible_serial + q_version_suffix;
 
 						// Find out if there is a node item for this serial
 						QTreeWidgetItem* serial_level_item = gui::utils::find_child(title_level_item, q_serial_and_version);
@@ -404,14 +406,23 @@ void patch_manager_dialog::on_item_selected(QTreeWidgetItem *current, QTreeWidge
 	}
 	case node_level::serial_level:
 	{
-		info.serial = current->data(0, serial_role).toString();
-		info.app_version = current->data(0, app_version_role).toString();
+		const QString serial = current->data(0, serial_role).toString();
+		info.serial = serial.toStdString() == patch_key::all ? tr_all_serials : serial;
+
+		const QString app_version = current->data(0, app_version_role).toString();
+		info.app_version = app_version.toStdString() == patch_key::all ? tr_all_versions : app_version;
+
 		[[fallthrough]];
 	}
 	case node_level::title_level:
+	{
+		const QString title = current->data(0, title_role).toString();
+		info.title = title.toStdString() == patch_key::all ? tr_all_titles : title;
+
+		[[fallthrough]];
+	}
 	default:
 	{
-		info.title = current->data(0, title_role).toString();
 		break;
 	}
 	}

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -18,6 +18,18 @@ class patch_manager_dialog : public QDialog
 {
 	Q_OBJECT
 
+	struct gui_patch_info
+	{
+		QString hash;
+		QString title;
+		QString serial;
+		QString app_version;
+		QString author;
+		QString notes;
+		QString description;
+		QString patch_version;
+	};
+
 public:
 	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
 	~patch_manager_dialog();
@@ -36,7 +48,7 @@ private:
 	void load_patches();
 	void populate_tree();
 	void save_config();
-	void update_patch_info(const patch_engine::patch_info& info);
+	void update_patch_info(const gui_patch_info& info);
 	bool is_valid_file(const QMimeData& md, QStringList* drop_paths = nullptr);
 
 	std::shared_ptr<gui_settings> m_gui_settings;

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -31,7 +31,7 @@ class patch_manager_dialog : public QDialog
 	};
 
 public:
-	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
+	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, QWidget* parent = nullptr);
 	~patch_manager_dialog();
 
 	int exec() override;
@@ -42,6 +42,7 @@ private Q_SLOTS:
 	void on_item_changed(QTreeWidgetItem *item, int column);
 	void on_custom_context_menu_requested(const QPoint& pos);
 	void on_legacy_patches_enabled(int state);
+	void on_show_owned_games_only(int state);
 
 private:
 	void refresh(bool restore_layout = false);
@@ -52,6 +53,9 @@ private:
 	bool is_valid_file(const QMimeData& md, QStringList* drop_paths = nullptr);
 
 	std::shared_ptr<gui_settings> m_gui_settings;
+
+	std::unordered_map<std::string, std::set<std::string>> m_owned_games;
+	bool m_show_owned_games_only = false;
 
 	patch_engine::patch_map m_map;
 	bool m_legacy_patches_enabled = false;

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -30,7 +30,7 @@ class patch_manager_dialog : public QDialog
 		QString patch_version;
 	};
 
-	const QString tr_all_titles   = tr("All titles");
+	const QString tr_all_titles   = tr("All titles - Warning: These patches will apply globally to all games. Use with caution!");
 	const QString tr_all_serials  = tr("All serials");
 	const QString tr_all_versions = tr("All versions");
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -30,6 +30,10 @@ class patch_manager_dialog : public QDialog
 		QString patch_version;
 	};
 
+	const QString tr_all_titles   = tr("All titles");
+	const QString tr_all_serials  = tr("All serials");
+	const QString tr_all_versions = tr("All versions");
+
 public:
 	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, QWidget* parent = nullptr);
 	~patch_manager_dialog();

--- a/rpcs3/rpcs3qt/patch_manager_dialog.ui
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.ui
@@ -40,23 +40,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="cb_owned_games_only">
+           <property name="text">
+            <string>Only show owned games</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="cb_enable_legacy_patches">
            <property name="text">
             <string>Enable Legacy Patches</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pb_collapse_all">
-           <property name="text">
-            <string>Collapse All</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pb_expand_all">
-           <property name="text">
-            <string>Expand All</string>
            </property>
           </widget>
          </item>

--- a/rpcs3/rpcs3qt/patch_manager_dialog.ui
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.ui
@@ -88,25 +88,6 @@
          </property>
          <layout class="QVBoxLayout" name="patch_info_gb_layout">
           <item>
-           <widget class="QGroupBox" name="gb_hash">
-            <property name="title">
-             <string>Hash</string>
-            </property>
-            <layout class="QVBoxLayout" name="hash_layout">
-             <item>
-              <widget class="QLabel" name="label_hash">
-               <property name="text">
-                <string/>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
            <widget class="QGroupBox" name="gb_title">
             <property name="title">
              <string>Game Title</string>
@@ -126,13 +107,48 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="gb_serials">
+           <widget class="QGroupBox" name="gb_serial">
             <property name="title">
-             <string>Serials</string>
+             <string>Serial</string>
             </property>
-            <layout class="QVBoxLayout" name="serials_layout">
+            <layout class="QVBoxLayout" name="serial_layout">
              <item>
-              <widget class="QLabel" name="label_serials">
+              <widget class="QLabel" name="label_serial">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="gb_app_version">
+            <property name="title">
+             <string>App Version</string>
+            </property>
+            <layout class="QVBoxLayout" name="layout_app_version">
+             <item>
+              <widget class="QLabel" name="label_app_version">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="gb_hash">
+            <property name="title">
+             <string>Hash</string>
+            </property>
+            <layout class="QVBoxLayout" name="hash_layout">
+             <item>
+              <widget class="QLabel" name="label_hash">
                <property name="text">
                 <string/>
                </property>

--- a/rpcs3/rpcs3qt/patch_manager_dialog.ui
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.ui
@@ -121,7 +121,7 @@
           <item>
            <widget class="QGroupBox" name="gb_app_version">
             <property name="title">
-             <string>App Version</string>
+             <string>Game Version</string>
             </property>
             <layout class="QVBoxLayout" name="layout_app_version">
              <item>

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -382,9 +382,73 @@ namespace gui
 		{
 			if (parent)
 			{
-				for (int i = 0; i < parent->childCount(); i++)
+				for (int i = parent->childCount() - 1; i >= 0; i--)
 				{
 					parent->removeChild(parent->child(i));
+				}
+			}
+		}
+
+		void remove_children(QTreeWidgetItem* parent, const QList<QPair<int /*role*/, QVariant /*data*/>>& criteria, bool recursive)
+		{
+			if (parent)
+			{
+				for (int i = parent->childCount() - 1; i >= 0; i--)
+				{
+					if (auto item = parent->child(i))
+					{
+						bool match = true;
+
+						for (const auto [role, data] : criteria)
+						{
+							if (item->data(0, role) != data)
+							{
+								match = false;
+								break;
+							}
+						}
+
+						if (!match)
+						{
+							parent->removeChild(item);
+						}
+						else if (recursive)
+						{
+							remove_children(item, criteria, recursive);
+						}
+					}
+				}
+			}
+		}
+
+		void sort_tree_item(QTreeWidgetItem* item, Qt::SortOrder sort_order, bool recursive)
+		{
+			if (item)
+			{
+				item->sortChildren(0, sort_order);
+
+				if (recursive)
+				{
+					for (int i = 0; i < item->childCount(); i++)
+					{
+						sort_tree_item(item->child(i), sort_order, recursive);
+					}
+				}
+			}
+		}
+
+		void sort_tree(QTreeWidget* tree, Qt::SortOrder sort_order, bool recursive)
+		{
+			if (tree)
+			{
+				tree->sortByColumn(0, sort_order);
+
+				if (recursive)
+				{
+					for (int i = 0; i < tree->topLevelItemCount(); i++)
+					{
+						sort_tree_item(tree->topLevelItem(i), sort_order, recursive);
+					}
 				}
 			}
 		}

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -71,12 +71,18 @@ namespace gui
 		QTreeWidgetItem* find_child(QTreeWidgetItem* parent, const QString& text);
 
 		// Finds all children of a QTreeWidgetItem that match the given criteria
-		QList<QTreeWidgetItem*> find_children_by_data(QTreeWidgetItem* parent, const QList<QPair<int /*role*/, QVariant /*data*/>>& criteria, bool recursive = false);
+		QList<QTreeWidgetItem*> find_children_by_data(QTreeWidgetItem* parent, const QList<QPair<int /*role*/, QVariant /*data*/>>& criteria, bool recursive);
 
 		// Constructs and adds a child to a QTreeWidgetItem
 		QTreeWidgetItem* add_child(QTreeWidgetItem* parent, const QString& text, int column = 0);
 
 		// Removes all children of a QTreeWidgetItem
 		void remove_children(QTreeWidgetItem* parent);
+
+		// Removes all children of a QTreeWidgetItem that don't match the given criteria
+		void remove_children(QTreeWidgetItem* parent, const QList<QPair<int /*role*/, QVariant /*data*/>>& criteria, bool recursive);
+
+		// Sort a QTreeWidget (currently only column 0)
+		void sort_tree(QTreeWidget* tree, Qt::SortOrder sort_order, bool recursive);
 	} // utils
 } // gui


### PR DESCRIPTION
#### DONE:
- Removed "Patches" Key
- Added optional "Group" key to avoid stupid choices in the GUI
- Changed patch dependency to Serial + AppVersion in order to avoid selection of multiple games with the same mouse click

#### TODO:
- [x] Test for legacy regressions
- [x] Test for v1.2 regressions
- [x] Test import
- [x] Add option to only show games that are in the gamelist

```
Version: 1.2

PPU-e72e715d646a94770d1902364bc66fe33b1b6606:
  30FPS:
    Games:
      Best Game Ever:
        NPUA80697: [ 01.00 ]
        NPEA00363: [ 01.00, 01.30 ]
      Best Game Never:
        NPUA80123: [ 01.00 ]
        NPEA00363: [ 01.00, 01.30 ]
    Author: Batman bin Suparman
    Patch Version: 1.0
    Group: FPS
    Notes: ABCD
    Patch:
      - [be32, 0x00010268, 0x9061009C]
      - [be32, 0x008fc864, 0x60000000]
  60FPS:
    Games:
      Best Game Ever:
        NPUA80697: [ 01.00 ]
        NPEA00363: [ 01.00, 01.30 ]
      Best Game Never:
        NPUA80123: [ 01.00 ]
        NPEA00363: [ 01.00, 01.30 ]
    Author: Batman bin Suparman
    Patch Version: 1.0
    Notes: ABCD
    Group: FPS
    Patch:
      - [be32, 0x00010268, 0x9061009C]
      - [be32, 0x008fc864, 0x60000000]
      - [bef32, 0x00012484, 0.01666667]
```