### PR TITLE
SPU LLVM: Fix WRCH instruction to WrTagMask

### DIFF
--- a/rpcs3/Emu/Cell/MFC.h
+++ b/rpcs3/Emu/Cell/MFC.h
@@ -36,7 +36,7 @@ enum MFC : u8
 };
 
 // Atomic Status Update
-enum : u32
+enum mfc_atomic_status : u32
 {
 	MFC_PUTLLC_SUCCESS = 0,
 	MFC_PUTLLC_FAILURE = 1, // reservation was lost
@@ -45,7 +45,7 @@ enum : u32
 };
 
 // MFC Write Tag Status Update Request Channel (ch23) operations
-enum : u32
+enum mfc_tag_update : u32
 {
 	MFC_TAG_UPDATE_IMMEDIATE = 0,
 	MFC_TAG_UPDATE_ANY       = 1,

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -5693,6 +5693,13 @@ public:
 		{
 			// TODO
 			m_ir->CreateStore(val.value, spu_ptr<u32>(&spu_thread::ch_tag_mask));
+			const auto next = llvm::BasicBlock::Create(m_context, "", m_function);
+			const auto _mfc = llvm::BasicBlock::Create(m_context, "", m_function);
+			m_ir->CreateCondBr(m_ir->CreateICmpNE(m_ir->CreateLoad(spu_ptr<u32>(&spu_thread::ch_tag_upd)), m_ir->getInt32(MFC_TAG_UPDATE_IMMEDIATE)), _mfc, next);
+			m_ir->SetInsertPoint(_mfc);
+			call("spu_write_channel", &exec_wrch, m_thread, m_ir->getInt32(op.ra), val.value);
+			m_ir->CreateBr(next);
+			m_ir->SetInsertPoint(next);
 			return;
 		}
 		case MFC_WrTagUpdate:

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -25,6 +25,39 @@
 #include <atomic>
 #include <thread>
 
+template <>
+void fmt_class_string<mfc_atomic_status>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](mfc_atomic_status arg)
+	{
+		switch (arg)
+		{
+		case MFC_PUTLLC_SUCCESS: return "PUTLLC";
+		case MFC_PUTLLC_FAILURE: return "PUTLLC-FAIL";
+		case MFC_PUTLLUC_SUCCESS: return "PUTLLUC";
+		case MFC_GETLLAR_SUCCESS: return "GETLLAR";
+		}
+
+		return unknown;
+	});
+}
+
+template <>
+void fmt_class_string<mfc_tag_update>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](mfc_tag_update arg)
+	{
+		switch (arg)
+		{
+		case MFC_TAG_UPDATE_IMMEDIATE: return "empty";
+		case MFC_TAG_UPDATE_ANY: return "ANY";
+		case MFC_TAG_UPDATE_ALL: return "ALL";
+		}
+
+		return unknown;
+	});
+}
+
 // Verify AVX availability for TSX transactions
 static const bool s_tsx_avx = utils::has_avx();
 
@@ -815,12 +848,14 @@ std::string spu_thread::dump_regs() const
 	fmt::append(ret, "Stall Stat: %s\n", ch_stall_stat);
 	fmt::append(ret, "Stall Mask: 0x%x\n", ch_stall_mask);
 	fmt::append(ret, "Tag Stat: %s\n", ch_tag_stat);
+	fmt::append(ret, "Tag Update: %s\n", mfc_tag_update{ch_tag_upd});
 
 	if (const u32 addr = raddr)
 		fmt::append(ret, "Reservation Addr: 0x%x\n", addr);
 	else
 		fmt::append(ret, "Reservation Addr: none\n");
 
+	fmt::append(ret, "Atomic Stat: %s\n", ch_atomic_stat); // TODO: use mfc_atomic_status formatting
 	fmt::append(ret, "Interrupts Enabled: %s\n", interrupts_enabled.load());
 	fmt::append(ret, "Inbound Mailbox: %s\n", ch_in_mbox);
 	fmt::append(ret, "Out Mailbox: %s\n", ch_out_mbox);


### PR DESCRIPTION
I was adding some more information about tag update and atomic status channels in SPU debugger, but after some testing I've noticed that the value of the tag update wasn't being cleared at points were you had expect it to be empty.
After some debugging I've found that unlike interpreters and asmjit, in LLVM tag mask writing isn't handled the way it should be and thus not updating tag status and tag update when needed.