### PR TITLE
SPU MFC: Implement MFC commands execution shuffling

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -739,6 +739,12 @@ bool cpu_thread::check_state() noexcept
 				cpu_counter::add(this);
 			}
 
+			if (state & cpu_flag::pending)
+			{
+				// Execute pending work
+				cpu_work();
+			}
+
 			if (retval)
 			{
 				cpu_on_stop();

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -21,6 +21,7 @@ enum class cpu_flag : u32
 	ret, // Callback return requested
 	signal, // Thread received a signal (HLE)
 	memory, // Thread must unlock memory mutex
+	pending, // Thread has postponed work
 
 	dbg_global_pause, // Emulation paused
 	dbg_pause, // Thread paused
@@ -168,6 +169,9 @@ public:
 
 	// Callback for cpu_flag::suspend
 	virtual void cpu_sleep() {}
+
+	// Callback for cpu_flag::pending
+	virtual void cpu_work() {}
 
 	// Callback for cpu_flag::ret
 	virtual void cpu_return() {}

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -116,7 +116,10 @@ void spu_interpreter::set_interrupt_status(spu_thread& spu, spu_opcode_t op)
 		spu.set_interrupt_status(false);
 	}
 
-	spu.check_mfc_interrupts(spu.pc);
+	if (spu.check_mfc_interrupts(spu.pc) && spu.state & cpu_flag::pending)
+	{
+		spu.do_mfc();
+	}
 }
 
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -631,6 +631,7 @@ public:
 	virtual std::string dump_misc() const override;
 	virtual void cpu_task() override final;
 	virtual void cpu_return() override;
+	virtual void cpu_work() override;
 	virtual ~spu_thread() override;
 	void cleanup();
 	void cpu_init();
@@ -667,6 +668,9 @@ public:
 	u32 mfc_size = 0;
 	u32 mfc_barrier = -1;
 	u32 mfc_fence = -1;
+
+	// Timestamp of the first postponed command (transfers shuffling related)
+	u64 mfc_last_timestamp = 0;
 
 	// MFC proxy command data
 	spu_mfc_cmd mfc_prxy_cmd;
@@ -787,7 +791,7 @@ public:
 	bool do_list_transfer(spu_mfc_cmd& args);
 	void do_putlluc(const spu_mfc_cmd& args);
 	bool do_putllc(const spu_mfc_cmd& args);
-	void do_mfc(bool wait = true);
+	void do_mfc(bool can_escape = true);
 	u32 get_mfc_completed() const;
 
 	bool process_mfc_cmd();

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -47,6 +47,8 @@ struct cfg_root : cfg::node
 		cfg::_bool spu_verification{ this, "SPU Verification", true }; // Should be enabled
 		cfg::_bool spu_cache{ this, "SPU Cache", true };
 		cfg::_bool spu_prof{ this, "SPU Profiler", false };
+		cfg::uint<0, 16> mfc_transfers_shuffling{ this, "MFC Transfers Shuffling Max Commands", 0 };
+		cfg::uint<0, 10000> mfc_transfers_timeout{ this, "MFC Transfers Timeout", 0, true};
 		cfg::_enum<tsx_usage> enable_TSX{ this, "Enable TSX", has_rtm() ? tsx_usage::enabled : tsx_usage::disabled }; // Enable TSX. Forcing this on Haswell/Broadwell CPUs should be used carefully
 		cfg::_bool spu_accurate_xfloat{ this, "Accurate xfloat", false };
 		cfg::_bool spu_approx_xfloat{ this, "Approximate xfloat", true };


### PR DESCRIPTION
A brief summary on what is MFC and what was so problematic about emulating it accurately:
The MFC (Memory Flow Controller) is what allows the SPU to perform reads and writes to memory outside of its own small memory "cache".
Unlike literally all processors, no CPU is known to be able to see the status of completion of its reads/writes, nor perform them out of order of its own execution.
Meaning if we write the value y to address x, then read from it. We expect on all processors to read the value y (assuming no concurrent writes involved) right? Wrong! SPU is the exception to this basic fundamental rule in processors.
Infact, the reads and writes the MFC is performing are executed at unpredicatable timing, without ordering to its own reads/writes (unless barriers are involved).
In Narcor Terror and The Expandables games, as a result of a bug, a dependancy of this feature developed on real ps3. The SPU thread would enqueue an MFC command which reads memory from the main memory into its memory "cache" (the local storage) but immediately afterwards write to the local storage directly as well with different values.
This is basically a race condition between the MFC and the SPU, who wouldwrite first the value? in rpcs3 it turns out to be the MFC writing the wrong value and crashing, because in rpcs3 all MFC transfers are executed exactly when you order them, like all other processors. But in real ps3 the answer differ and whos actually wins this race is the SPU, writing the correct value and continueing.
In Resonance Of Fate, something more extreme happens, where the SPU would enqueue multiple reads and a write to the same address on the local storage without any barriers, in a loop.
The correct value written to the main memory is not the one of the last command executed, but one before it.
In rpcs3 the value written is of the last command, but on ps3 the answer is "random", it may take a few attempts to finally use the correct command and continuing execition normally.

To solve both issues at the same time, we need to implement two things.
1) A way to postpone commands to not execute immedaitely.
2) Select racdomly the command to be next executed from the queue of transfers, regardless of which issued first.

I did some thought and instead of adding another thread like "MFC threads" would be a total waste of HW resources and performance would drop siginicantly.
So I made the same SPU thread execute the transfers later in its execution.
Two new settings were added: "MFC Transfers Shuffling Max Commands" (controlling max command to shuffle and postpone)
and "MFC Transfers Timeout" (timeout for enqueued commands to be executed, 0 means no timeout)

# List of fixed games:
**Resonance Of Fate (Intro -> Ingame)**
**Narco Terror (Nothing -> Ingame)**
**The Expandables: The Video Game (Nothing -> Ingame)**

For all the games fixed here set max MFC commands to 1 and MFC transfers timeout to 0.

![image](https://user-images.githubusercontent.com/18193363/85926479-6bc04280-b8a8-11ea-8f94-f1f509af9b7a.png)
![image](https://user-images.githubusercontent.com/18193363/85927106-9e6c3a00-b8ac-11ea-84c5-0f35a348e014.png)

Fixes #8513 
Fixes #5504
NOTE: Currently only implemented on SPU interpreters.