### PR TITLE
vk: Improve chip-specific workarounds and optimizations

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -55,11 +55,10 @@ namespace vk
 		table.add(0x15F7, 0x15F9, chip_class::NV_pascal); // GP100 (Tesla P100)
 		table.add(0x1B00, 0x1D80, chip_class::NV_pascal);
 		table.add(0x1D81, 0x1DBA, chip_class::NV_volta);
-		table.add(0x1E02, 0x1F51, chip_class::NV_turing); // RTX 20 series
-		table.add(0x2182, chip_class::NV_turing); // TU116
-		table.add(0x2184, chip_class::NV_turing); // TU116
-		table.add(0x1F82, chip_class::NV_turing); // TU117
-		table.add(0x1F91, chip_class::NV_turing); // TU117
+		table.add(0x1E02, 0x1F54, chip_class::NV_turing); // TU102, TU104, TU106, TU106M, TU106GL (RTX 20 series)
+		table.add(0x1F82, 0x1FB9, chip_class::NV_turing); // TU117, TU117M, TU117GL
+		table.add(0x2182, 0x21D1, chip_class::NV_turing); // TU116, TU116M, TU116GL
+		table.add(0x20B0, 0x20BE, chip_class::NV_ampere); // GA100
 
 		return table;
 	}();

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -88,7 +88,8 @@ namespace vk
 		NV_maxwell,
 		NV_pascal,
 		NV_volta,
-		NV_turing
+		NV_turing,
+		NV_ampere
 	};
 
 	enum // special remap_encoding enums
@@ -299,6 +300,7 @@ namespace vk
 				return found->second;
 			}
 
+			rsx_log.warning("Unknown chip with device ID 0x%x", device_id);
 			return default_;
 		}
 	};

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -75,6 +75,7 @@ namespace vk
 		INTEL
 	};
 
+	// Chip classes grouped by vendor in order of release
 	enum class chip_class
 	{
 		unknown,

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -519,7 +519,8 @@ namespace vk
 				case VK_FORMAT_D24_UNORM_S8_UINT:
 				{
 					const VkImageAspectFlags depth_stencil = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
-					if (vk::get_chip_family() != vk::chip_class::NV_turing)
+					if (const auto chip_family = vk::get_chip_family();
+						chip_family > vk::chip_class::NV_generic && chip_family < vk::chip_class::NV_turing)
 					{
 						auto typeless = vk::get_typeless_helper(VK_FORMAT_B8G8R8A8_UNORM, typeless_w, typeless_h);
 						change_image_layout(cmd, typeless, VK_IMAGE_LAYOUT_GENERAL);


### PR DESCRIPTION
- Invert the NVIDIA cross-aspect transfer hack to work for all GPUs before turing but nothing unknown or after.
- Add more turing GPUs to the list of known NVIDIA cards.
- Adds a warning message in log file if the current GPU is not in the chip tables.

Fixes https://github.com/RPCS3/rpcs3/issues/7774