### PR TITLE
remove redundent include in Crypto/unedat.cpp

### DIFF
--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -3,7 +3,6 @@
 #include "unedat.h"
 
 #include "Utilities/mutex.h"
-#include "util/endian.hpp"
 #include <cmath>
 
 LOG_CHANNEL(edat_log, "EDAT");


### PR DESCRIPTION
Included in Utilities/BEType.h, attempts to address #8526 