### PR TITLE
vk: Disable primitive restart for old GCN cards

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -32,7 +32,7 @@ namespace vk
 		table.add(0x15DD, chip_class::AMD_vega); // Raven Ridge
 		table.add(0x15D8, chip_class::AMD_vega); // Raven Ridge
 		table.add(0x7310, 0x731F, chip_class::AMD_navi); // Navi10
-		table.add(0x7340, 0x7340, chip_class::AMD_navi); // Navi14
+		table.add(0x7340, 0x734F, chip_class::AMD_navi); // Navi14
 
 		return table;
 	}();
@@ -88,7 +88,7 @@ namespace vk
 	VkFlags g_heap_compatible_buffer_types = 0;
 	driver_vendor g_driver_vendor = driver_vendor::unknown;
 	chip_class g_chip_class = chip_class::unknown;
-	bool g_drv_no_primitive_restart_flag = false;
+	bool g_drv_no_primitive_restart = false;
 	bool g_drv_sanitize_fp_values = false;
 	bool g_drv_disable_fence_reset = false;
 	bool g_drv_emulate_cond_render = false;
@@ -463,7 +463,7 @@ namespace vk
 	{
 		g_current_renderer = &device;
 		g_runtime_state.clear();
-		g_drv_no_primitive_restart_flag = false;
+		g_drv_no_primitive_restart = false;
 		g_drv_sanitize_fp_values = false;
 		g_drv_disable_fence_reset = false;
 		g_drv_emulate_cond_render = (g_cfg.video.relaxed_zcull_sync && !g_current_renderer->get_conditional_render_support());
@@ -480,6 +480,9 @@ namespace vk
 		switch (g_driver_vendor)
 		{
 		case driver_vendor::AMD:
+			// Primitive restart on older GCN is still broken
+			g_drv_no_primitive_restart = (g_chip_class == vk::chip_class::AMD_gcn_generic);
+			break;
 		case driver_vendor::RADV:
 			// Previous bugs with fence reset and primitive restart seem to have been fixed with newer drivers
 			break;
@@ -550,7 +553,7 @@ namespace vk
 
 	bool emulate_primitive_restart(rsx::primitive_type type)
 	{
-		if (g_drv_no_primitive_restart_flag)
+		if (g_drv_no_primitive_restart)
 		{
 			switch (type)
 			{


### PR DESCRIPTION
- Disable primitive restart for old GCN cards as it is broken in hardware.
- Also adds more Navi 14 chips to detection table.

Fixes https://github.com/RPCS3/rpcs3/issues/7746