### PR TITLE
rsx: Minor ZCULL improvements

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3611,7 +3611,11 @@ namespace rsx
 					}
 				}
 
-				update(ptimer, sync_address);
+				// There can be multiple queries all writing to the same address, loop to flush all of them
+				while (query->pending && !Emu.IsStopped())
+				{
+					update(ptimer, sync_address);
+				}
 				return result_none;
 			}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -355,7 +355,8 @@ namespace rsx
 			}
 			else
 			{
-				zcull_ctrl->read_barrier(this, cond_render_ctrl.eval_address, 4, reports::sync_no_notify);
+				// NOTE: eval_sources list is reversed with newest query first
+				zcull_ctrl->read_barrier(this, cond_render_ctrl.eval_address, cond_render_ctrl.eval_sources.front());
 				verify(HERE), !cond_render_ctrl.eval_pending();
 			}
 		}
@@ -3620,6 +3621,16 @@ namespace rsx
 			}
 
 			return result_zcull_intr;
+		}
+
+		flags32_t ZCULL_control::read_barrier(class ::rsx::thread* ptimer, u32 memory_address, occlusion_query_info* query)
+		{
+			while (query->pending && !Emu.IsStopped())
+			{
+				update(ptimer, memory_address);
+			}
+
+			return result_none;
 		}
 
 		query_search_result ZCULL_control::find_query(vm::addr_t sink_address, bool all)

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -456,6 +456,7 @@ namespace rsx
 
 			// Conditionally sync any pending writes if range overlaps
 			flags32_t read_barrier(class ::rsx::thread* ptimer, u32 memory_address, u32 memory_range, flags32_t flags);
+			flags32_t read_barrier(class ::rsx::thread* ptimer, u32 memory_address, occlusion_query_info* query);
 
 			// Call once every 'tick' to update, optional address provided to partially sync until address is processed
 			void update(class ::rsx::thread* ptimer, u32 sync_address = 0, bool hint = false);


### PR DESCRIPTION
- Fix multiple queries in queue writing to the same address.
- Add a fast variant of the read_barrier method when we already have the query object to sync.

Fixes https://github.com/RPCS3/rpcs3/issues/7785