### PR TITLE
localized.h: follow Sony Naming Conventions

### DIFF
--- a/rpcs3/rpcs3qt/localized.h
+++ b/rpcs3/rpcs3qt/localized.h
@@ -28,7 +28,7 @@ public:
 		const QString app_video = tr("Video App");
 		const QString bc_video  = tr("Broadcast Video");
 		const QString disc_game = tr("Disc Game");
-		const QString hdd_game  = tr("Downloaded Game");
+		const QString hdd_game  = tr("HDD Game");
 		const QString home      = tr("Home");
 		const QString network   = tr("Network");
 		const QString store_fe  = tr("Store");

--- a/rpcs3/rpcs3qt/localized.h
+++ b/rpcs3/rpcs3qt/localized.h
@@ -22,13 +22,13 @@ public:
 	const struct category // (see PARAM.SFO in psdevwiki.com) TODO: Disc Categories
 	{
 		// PS3 bootable
-		const QString app_music = tr("App Music");
-		const QString app_photo = tr("App Photo");
-		const QString app_tv    = tr("App TV");
-		const QString app_video = tr("App Video");
+		const QString app_music = tr("Music App");
+		const QString app_photo = tr("Photo App");
+		const QString app_tv    = tr("TV App");
+		const QString app_video = tr("Video App");
 		const QString bc_video  = tr("Broadcast Video");
 		const QString disc_game = tr("Disc Game");
-		const QString hdd_game  = tr("HDD Game");
+		const QString hdd_game  = tr("Downloaded Game");
 		const QString home      = tr("Home");
 		const QString network   = tr("Network");
 		const QString store_fe  = tr("Store");


### PR DESCRIPTION
I noticed this on https://github.com/RPCS3/rpcs3/issues/4259 
(Main Window -> (Localized) Replace the category names with either something more gramatically correct or something used in Sony Naming Conventions)