### PR TITLE
Qt: updater changes

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -393,6 +393,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_downloader.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_emu_settings.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -674,6 +679,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug\moc_debugger_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_downloader.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
@@ -983,6 +993,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_downloader.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_emu_settings.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
@@ -1268,6 +1283,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_downloader.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_emu_settings.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -1507,6 +1527,7 @@
     <ClCompile Include="rpcs3qt\curl_handle.cpp" />
     <ClCompile Include="rpcs3qt\custom_dialog.cpp" />
     <ClCompile Include="rpcs3qt\debugger_list.cpp" />
+    <ClCompile Include="rpcs3qt\downloader.cpp" />
     <ClCompile Include="rpcs3qt\fatal_error_dialog.cpp" />
     <ClCompile Include="rpcs3qt\gui_application.cpp" />
     <ClCompile Include="rpcs3qt\input_dialog.cpp" />
@@ -2252,6 +2273,24 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\microphone_creator.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\downloader.h">
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">Moc%27ing %(Identity)...</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -131,6 +131,9 @@
     <Filter Include="Gui\patch manager">
       <UniqueIdentifier>{e72a0cbe-fbcd-4a0b-8c17-a2a3b7a42258}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Gui\network">
+      <UniqueIdentifier>{bad5498c-a915-4a96-b0cc-f754c02d8e65}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -901,9 +904,6 @@
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_update_manager.cpp">
       <Filter>Generated Files\Debug - LLVM</Filter>
     </ClCompile>
-    <ClCompile Include="rpcs3qt\curl_handle.cpp">
-      <Filter>rpcs3</Filter>
-    </ClCompile>
     <ClCompile Include="rpcs3qt\screenshot_manager_dialog.cpp">
       <Filter>Gui\screenshot manager</Filter>
     </ClCompile>
@@ -1057,6 +1057,24 @@
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_patch_manager_dialog.cpp">
       <Filter>Generated Files\Debug - LLVM</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\curl_handle.cpp">
+      <Filter>Gui\network</Filter>
+    </ClCompile>
+    <ClCompile Include="rpcs3qt\downloader.cpp">
+      <Filter>Gui\network</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release - LLVM\moc_downloader.cpp">
+      <Filter>Generated Files\Release - LLVM</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_downloader.cpp">
+      <Filter>Generated Files\Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_downloader.cpp">
+      <Filter>Generated Files\Release</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_downloader.cpp">
+      <Filter>Generated Files\Debug - LLVM</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">
@@ -1140,9 +1158,6 @@
     <ClInclude Include="rpcs3qt\category.h">
       <Filter>Gui\game list</Filter>
     </ClInclude>
-    <ClInclude Include="rpcs3qt\curl_handle.h">
-      <Filter>rpcs3</Filter>
-    </ClInclude>
     <ClInclude Include="rpcs3qt\emu_settings_type.h">
       <Filter>Gui\settings</Filter>
     </ClInclude>
@@ -1157,6 +1172,9 @@
     </ClInclude>
     <ClInclude Include="QTGeneratedFiles\ui_patch_manager_dialog.h">
       <Filter>Generated Files</Filter>
+    </ClInclude>
+    <ClInclude Include="rpcs3qt\curl_handle.h">
+      <Filter>Gui\network</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -1375,6 +1393,9 @@
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\patch_manager_dialog.ui">
       <Filter>Form Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\downloader.h">
+      <Filter>Gui\network</Filter>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -11,6 +11,7 @@
 	custom_dialog.cpp
 	debugger_frame.cpp
 	debugger_list.cpp
+	downloader.cpp
 	_discord_utils.cpp
 	emu_settings.cpp
 	fatal_error_dialog.cpp

--- a/rpcs3/rpcs3qt/downloader.cpp
+++ b/rpcs3/rpcs3qt/downloader.cpp
@@ -1,0 +1,164 @@
+﻿#include "stdafx.h"
+
+#include <QApplication>
+#include <QThread>
+
+#include "downloader.h"
+#include "curl_handle.h"
+#include "progress_dialog.h"
+
+LOG_CHANNEL(network_log, "NETWORK");
+
+size_t curl_write_cb_compat(char* ptr, size_t /*size*/, size_t nmemb, void* userdata)
+{
+	downloader* download = reinterpret_cast<downloader*>(userdata);
+	return download->update_buffer(ptr, nmemb);
+}
+
+downloader::downloader(const std::string& thread_name, QWidget* parent)
+	: QObject(parent)
+	, m_parent(parent)
+	, m_thread_name(thread_name)
+{
+	m_curl = new curl_handle(this);
+}
+
+void downloader::start(const std::string& url, bool follow_location, bool show_progress_dialog, const QString& progress_dialog_title, bool keep_progress_dialog_open, int exptected_size)
+{
+	connect(this, &downloader::signal_buffer_update, this, &downloader::handle_buffer_update);
+
+	m_keep_progress_dialog_open = keep_progress_dialog_open;
+	m_curl_buf.clear();
+	m_curl_abort = false;
+
+	curl_easy_setopt(m_curl->get_curl(), CURLOPT_URL, url.c_str());
+	curl_easy_setopt(m_curl->get_curl(), CURLOPT_WRITEFUNCTION, curl_write_cb_compat);
+	curl_easy_setopt(m_curl->get_curl(), CURLOPT_WRITEDATA, this);
+	curl_easy_setopt(m_curl->get_curl(), CURLOPT_FOLLOWLOCATION, follow_location ? 1 : 0);
+
+	const auto thread = QThread::create([this]
+	{
+		const auto result = curl_easy_perform(m_curl->get_curl());
+		m_curl_success = result == CURLE_OK;
+
+		if (!m_curl_success && !m_curl_abort)
+		{
+			const std::string error = "Curl error: " + std::string{ curl_easy_strerror(result) };
+			network_log.error("%s", error);
+			Q_EMIT signal_download_error(QString::fromStdString(error));
+		}
+	});
+
+	connect(thread, &QThread::finished, this, [this]()
+	{
+		if (m_curl_abort)
+		{
+			return;
+		}
+
+		if (m_progress_dialog && (!m_keep_progress_dialog_open || !m_curl_success))
+		{
+			m_progress_dialog->close();
+			m_progress_dialog = nullptr;
+		}
+
+		if (m_curl_success)
+		{
+			Q_EMIT signal_download_finished(m_curl_buf);
+		}
+	});
+
+	if (show_progress_dialog)
+	{
+		const int maximum = exptected_size > 0 ? exptected_size : 100;
+
+		if (m_progress_dialog)
+		{
+			m_progress_dialog->setWindowTitle(progress_dialog_title);
+			m_progress_dialog->setAutoClose(!m_keep_progress_dialog_open);
+			m_progress_dialog->setMaximum(maximum);
+		}
+		else
+		{
+			m_progress_dialog = new progress_dialog(progress_dialog_title, tr("Please wait..."), tr("Abort"), 0, maximum, true, m_parent);
+			m_progress_dialog->setAutoReset(false);
+			m_progress_dialog->setAutoClose(!m_keep_progress_dialog_open);
+			m_progress_dialog->show();
+
+			// Handle abort
+			connect(m_progress_dialog, &QProgressDialog::canceled, this, [this]()
+			{
+				m_curl_abort = true;
+				close_progress_dialog();
+			});
+			connect(m_progress_dialog, &QProgressDialog::finished, m_progress_dialog, &QProgressDialog::deleteLater);
+		}
+	}
+
+	thread->setObjectName("Compat Update");
+	thread->start();
+}
+
+void downloader::update_progress_dialog(const QString& title)
+{
+	if (m_progress_dialog)
+	{
+		m_progress_dialog->setWindowTitle(title);
+	}
+}
+
+void downloader::close_progress_dialog()
+{
+	if (m_progress_dialog)
+	{
+		m_progress_dialog->close();
+		m_progress_dialog = nullptr;
+	}
+}
+
+progress_dialog* downloader::get_progress_dialog() const
+{
+	return m_progress_dialog;
+}
+
+size_t downloader::update_buffer(char* data, size_t size)
+{
+	if (m_curl_abort)
+	{
+		return 0;
+	}
+
+	const auto old_size = m_curl_buf.size();
+	const auto new_size = old_size + size;
+	m_curl_buf.resize(static_cast<int>(new_size));
+	memcpy(m_curl_buf.data() + old_size, data, size);
+
+	int max = 0;
+
+	if (m_actual_download_size < 0)
+	{
+		if (curl_easy_getinfo(m_curl->get_curl(), CURLINFO_CONTENT_LENGTH_DOWNLOAD, &m_actual_download_size) == CURLE_OK && m_actual_download_size > 0)
+		{
+			max = static_cast<int>(m_actual_download_size);
+		}
+	}
+
+	Q_EMIT signal_buffer_update(static_cast<int>(new_size), max);
+
+	return size;
+}
+
+void downloader::handle_buffer_update(int size, int max)
+{
+	if (m_curl_abort)
+	{
+		return;
+	}
+
+	if (m_progress_dialog)
+	{
+		m_progress_dialog->setMaximum(max > 0 ? max : m_progress_dialog->maximum());
+		m_progress_dialog->setValue(size);
+		QApplication::processEvents();
+	}
+}

--- a/rpcs3/rpcs3qt/downloader.h
+++ b/rpcs3/rpcs3qt/downloader.h
@@ -1,0 +1,46 @@
+﻿#pragma once
+
+#include <QObject>
+
+#include <atomic>
+
+class curl_handle;
+class progress_dialog;
+
+class downloader : public QObject
+{
+	Q_OBJECT
+
+public:
+	downloader(const std::string& thread_name, QWidget* parent = nullptr);
+
+	void start(const std::string& url, bool follow_location, bool show_progress_dialog, const QString& progress_dialog_title = "", bool keep_progress_dialog_open = false, int expected_size = -1);
+	size_t update_buffer(char* data, size_t size);
+
+	void update_progress_dialog(const QString& title);
+	void close_progress_dialog();
+
+	progress_dialog* get_progress_dialog() const;
+
+private Q_SLOTS:
+	void handle_buffer_update(int size, int max);
+
+Q_SIGNALS:
+	void signal_download_error(const QString& error);
+	void signal_download_finished(const QByteArray& data);
+	void signal_buffer_update(int size, int max);
+
+private:
+	QWidget* m_parent = nullptr;
+	std::string m_thread_name;
+
+	curl_handle* m_curl = nullptr;
+	QByteArray m_curl_buf;
+	std::atomic<bool> m_curl_abort = false;
+	std::atomic<bool> m_curl_success = false;
+	double m_actual_download_size = -1.0;
+
+	progress_dialog* m_progress_dialog = nullptr;
+	std::atomic<bool> m_keep_progress_dialog_open = false;
+	QString m_progress_dialog_title;
+};

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -95,7 +95,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 	m_game_list->installEventFilter(this);
 	m_game_list->setColumnCount(gui::column_count);
 
-	m_game_compat = std::make_unique<game_compatibility>(m_gui_settings);
+	m_game_compat = new game_compatibility(m_gui_settings, this);
 
 	m_central_widget = new QStackedWidget(this);
 	m_central_widget->addWidget(m_game_list);
@@ -143,7 +143,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 	connect(m_game_grid, &QTableWidget::itemSelectionChanged, this, &game_list_frame::itemSelectionChangedSlot);
 	connect(m_game_grid, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
 
-	connect(m_game_compat.get(), &game_compatibility::DownloadStarted, [this]()
+	connect(m_game_compat, &game_compatibility::DownloadStarted, [this]()
 	{
 		for (const auto& game : m_game_data)
 		{
@@ -151,7 +151,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 		}
 		Refresh();
 	});
-	connect(m_game_compat.get(), &game_compatibility::DownloadFinished, [this]()
+	connect(m_game_compat, &game_compatibility::DownloadFinished, [this]()
 	{
 		for (const auto& game : m_game_data)
 		{
@@ -159,14 +159,14 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 		}
 		Refresh();
 	});
-	connect(m_game_compat.get(), &game_compatibility::DownloadError, [this](const QString& error)
+	connect(m_game_compat, &game_compatibility::DownloadError, [this](const QString& error)
 	{
 		for (const auto& game : m_game_data)
 		{
 			game->compat = m_game_compat->GetCompatibility(game->info.serial);
 		}
 		Refresh();
-		QMessageBox::warning(this, tr("Warning!"), tr("Failed to retrieve the online compatibility database!\nFalling back to local database.\n\n") + tr(qPrintable(error)));
+		QMessageBox::warning(this, tr("Warning!"), tr("Failed to retrieve the online compatibility database!\nFalling back to local database.\n\n%0").arg(error));
 	});
 
 	for (int col = 0; col < m_columnActs.count(); ++col)

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -128,15 +128,15 @@ private:
 	game_info GetGameInfoFromItem(const QTableWidgetItem* item);
 
 	// Which widget we are displaying depends on if we are in grid or list mode.
-	QMainWindow* m_game_dock;
-	QStackedWidget* m_central_widget;
+	QMainWindow* m_game_dock = nullptr;
+	QStackedWidget* m_central_widget = nullptr;
 
 	// Game Grid
-	game_list_grid* m_game_grid;
+	game_list_grid* m_game_grid = nullptr;
 
 	// Game List
-	game_list* m_game_list;
-	std::unique_ptr<game_compatibility> m_game_compat;
+	game_list* m_game_list = nullptr;
+	game_compatibility* m_game_compat = nullptr;
 	QList<QAction*> m_columnActs;
 	Qt::SortOrder m_col_sort_order;
 	int m_sort_column;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -7,6 +7,7 @@
 #include "Emu/System.h"
 #include "Emu/Cell/Modules/cellScreenshot.h"
 
+#include <QCoreApplication>
 #include <QKeyEvent>
 #include <QMessageBox>
 #include <string>
@@ -84,7 +85,8 @@ gs_frame::gs_frame(const QRect& geometry, const QIcon& appIcon, const std::share
 gs_frame::~gs_frame()
 {
 #ifdef _WIN32
-	if (m_tb_progress)
+	// QWinTaskbarProgress::hide() will crash if the application is already about to close, even if the object is not null.
+	if (m_tb_progress && !QCoreApplication::closingDown())
 	{
 		m_tb_progress->hide();
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1212,7 +1212,7 @@ QAction* main_window::CreateRecentAction(const q_string_pair& entry, const uint&
 	}
 
 	// connect boot
-	connect(act, &QAction::triggered, [=, this]() {BootRecentAction(act); });
+	connect(act, &QAction::triggered, [act, this]() {BootRecentAction(act); });
 
 	return act;
 }

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -176,10 +176,35 @@ void main_window::Init()
 	// Fix possible hidden game list columns. The game list has to be visible already. Use this after show()
 	m_game_list_frame->FixNarrowColumns();
 
-#if defined(_WIN32) || defined(__linux__)
-	if (m_gui_settings->GetValue(gui::m_check_upd_start).toBool())
+	// RPCS3 Updater
+
+	QMenuBar *corner_bar = new QMenuBar(ui->menuBar);
+
+	QMenu *download_menu = new QMenu(tr("Update Available!"), corner_bar);
+	corner_bar->addMenu(download_menu);
+
+	QAction *download_action = new QAction(tr("Download Update"), download_menu);
+	connect(download_action, &QAction::triggered, this, [this]
 	{
-		m_updater.check_for_updates(true, this);
+		m_updater.update(false);
+	});
+
+	download_menu->addAction(download_action);
+	ui->menuBar->setCornerWidget(corner_bar);
+	ui->menuBar->cornerWidget()->setVisible(false);
+
+	connect(&m_updater, &update_manager::signal_update_available, this, [this](bool update_available)
+	{
+		if (ui->menuBar->cornerWidget())
+		{
+			ui->menuBar->cornerWidget()->setVisible(update_available);
+		}
+	});
+
+#if defined(_WIN32) || defined(__linux__)
+	if (const auto update_value = m_gui_settings->GetValue(gui::m_check_upd_start).toString(); update_value != "false")
+	{
+		m_updater.check_for_updates(true, update_value != "true", this);
 	}
 #endif
 }
@@ -1538,7 +1563,7 @@ void main_window::CreateConnects()
 		std::unordered_map<std::string, std::set<std::string>> games;
 		if (m_game_list_frame)
 		{
-			for (const auto game : m_game_list_frame->GetGameInfo())
+			for (const auto& game : m_game_list_frame->GetGameInfo())
 			{
 				if (game)
 				{
@@ -1675,7 +1700,7 @@ void main_window::CreateConnects()
 			QMessageBox::warning(this, tr("Auto-updater"), tr("Please stop the emulation before trying to update."));
 			return;
 		}
-		m_updater.check_for_updates(false, this);
+		m_updater.check_for_updates(false, false, this);
 	});
 
 	connect(ui->aboutAct, &QAction::triggered, [this]

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -1,6 +1,7 @@
 ﻿#include "msg_dialog_frame.h"
 #include "custom_dialog.h"
 
+#include <QCoreApplication>
 #include <QPushButton>
 #include <QFormLayout>
 
@@ -173,7 +174,8 @@ msg_dialog_frame::msg_dialog_frame() {}
 msg_dialog_frame::~msg_dialog_frame()
 {
 #ifdef _WIN32
-	if (m_tb_progress)
+	// QWinTaskbarProgress::hide() will crash if the application is already about to close, even if the object is not null.
+	if (m_tb_progress && !QCoreApplication::closingDown())
 	{
 		m_tb_progress->hide();
 	}

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -1,5 +1,6 @@
 ﻿#include "progress_dialog.h"
 
+#include <QCoreApplication>
 #include <QLabel>
 
 #ifdef _WIN32
@@ -37,7 +38,11 @@ progress_dialog::progress_dialog(const QString &windowTitle, const QString &labe
 progress_dialog::~progress_dialog()
 {
 #ifdef _WIN32
-	m_tb_progress->hide();
+	// QWinTaskbarProgress::hide() will crash if the application is already about to close, even if the object is not null.
+	if (!QCoreApplication::closingDown())
+	{
+		m_tb_progress->hide();
+	}
 #elif HAVE_QTDBUS
 	UpdateProgress(0);
 #endif

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -341,7 +341,7 @@ namespace gui
 					{
 						bool match = true;
 
-						for (const auto [role, data] : criteria)
+						for (const auto& [role, data] : criteria)
 						{
 							if (item->data(0, role) != data)
 							{

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -146,7 +146,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 #endif
 	};
 
-	connect(ui->buttonBox, &QDialogButtonBox::clicked, [=, this](QAbstractButton* button)
+	connect(ui->buttonBox, &QDialogButtonBox::clicked, [apply_configs, this](QAbstractButton* button)
 	{
 		if (button == ui->buttonBox->button(QDialogButtonBox::Save))
 		{
@@ -481,7 +481,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	ui->minimumScalableDimensionMax->setText(QString::number(ui->minimumScalableDimension->maximum()));
 	ui->minimumScalableDimensionMax->setFixedWidth(gui::utils::get_label_width(QStringLiteral("0000")));
 	ui->minimumScalableDimensionVal->setText(min_scalable_dimension(ui->minimumScalableDimension->value()));
-	connect(ui->minimumScalableDimension, &QSlider::valueChanged, [=, this](int value)
+	connect(ui->minimumScalableDimension, &QSlider::valueChanged, [min_scalable_dimension, this](int value)
 	{
 		ui->minimumScalableDimensionVal->setText(min_scalable_dimension(value));
 	});
@@ -514,14 +514,14 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	m_old_renderer = ui->renderBox->currentText();
 
-	auto set_renderer = [=, this](QString text)
+	auto set_renderer = [r_creator, this](QString text)
 	{
 		if (text.isEmpty())
 		{
 			return;
 		}
 
-		auto switchTo = [=, this](render_creator::render_info renderer)
+		auto switchTo = [r_creator, text, this](render_creator::render_info renderer)
 		{
 			// Reset other adapters to old config
 			for (const auto& render : r_creator->renderers)
@@ -579,7 +579,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	};
 
-	auto set_adapter = [=, this](QString text)
+	auto set_adapter = [r_creator, this](QString text)
 	{
 		if (text.isEmpty())
 		{
@@ -689,31 +689,31 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->microphone4Box->setEnabled(ui->microphone3Box->isEnabled() && ui->microphone3Box->currentText() != mic_none);
 	};
 
-	auto propagate_used_devices = [=, this]()
+	auto propagate_used_devices = [mic_none, change_microphone_type, this]()
 	{
 		for (u32 index = 0; index < 4; index++)
 		{
-			const QString cur_item = mics_combo[index]->currentText();
+			const QString cur_item = m_mics_combo[index]->currentText();
 			QStringList cur_list = m_emu_settings->m_microphone_creator.get_microphone_list();
 			for (u32 subindex = 0; subindex < 4; subindex++)
 			{
-				if (subindex != index && mics_combo[subindex]->currentText() != mic_none)
-					cur_list.removeOne(mics_combo[subindex]->currentText());
+				if (subindex != index && m_mics_combo[subindex]->currentText() != mic_none)
+					cur_list.removeOne(m_mics_combo[subindex]->currentText());
 			}
-			mics_combo[index]->blockSignals(true);
-			mics_combo[index]->clear();
-			mics_combo[index]->addItems(cur_list);
-			mics_combo[index]->setCurrentText(cur_item);
-			mics_combo[index]->blockSignals(false);
+			m_mics_combo[index]->blockSignals(true);
+			m_mics_combo[index]->clear();
+			m_mics_combo[index]->addItems(cur_list);
+			m_mics_combo[index]->setCurrentText(cur_item);
+			m_mics_combo[index]->blockSignals(false);
 		}
 		change_microphone_type(ui->microphoneBox->currentIndex());
 	};
 
-	auto change_microphone_device = [=, this](u32 next_index, QString text)
+	auto change_microphone_device = [mic_none, propagate_used_devices, this](u32 next_index, QString text)
 	{
 		m_emu_settings->SetSetting(emu_settings_type::MicrophoneDevices, m_emu_settings->m_microphone_creator.set_device(next_index, text));
 		if (next_index < 4 && text == mic_none)
-			mics_combo[next_index]->setCurrentText(mic_none);
+			m_mics_combo[next_index]->setCurrentText(mic_none);
 		propagate_used_devices();
 	};
 
@@ -728,14 +728,14 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	connect(ui->audioOutBox, QOverload<int>::of(&QComboBox::currentIndexChanged), enable_buffering);
 
 	// Microphone Comboboxes
-	mics_combo[0] = ui->microphone1Box;
-	mics_combo[1] = ui->microphone2Box;
-	mics_combo[2] = ui->microphone3Box;
-	mics_combo[3] = ui->microphone4Box;
-	connect(mics_combo[0], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(1, text); });
-	connect(mics_combo[1], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(2, text); });
-	connect(mics_combo[2], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(3, text); });
-	connect(mics_combo[3], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(4, text); });
+	m_mics_combo[0] = ui->microphone1Box;
+	m_mics_combo[1] = ui->microphone2Box;
+	m_mics_combo[2] = ui->microphone3Box;
+	m_mics_combo[3] = ui->microphone4Box;
+	connect(m_mics_combo[0], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(1, text); });
+	connect(m_mics_combo[1], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(2, text); });
+	connect(m_mics_combo[2], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(3, text); });
+	connect(m_mics_combo[3], &QComboBox::currentTextChanged, [=, this](const QString& text) { change_microphone_device(4, text); });
 	m_emu_settings->m_microphone_creator.refresh_list();
 	propagate_used_devices(); // Fills comboboxes list
 
@@ -748,14 +748,14 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		const auto mic = mic_sel_list[index];
 		const auto qmic = qstr(mic);
 
-		if (mic.empty() || mics_combo[index]->findText(qmic) == -1)
+		if (mic.empty() || m_mics_combo[index]->findText(qmic) == -1)
 		{
-			mics_combo[index]->setCurrentText(mic_none);
+			m_mics_combo[index]->setCurrentText(mic_none);
 			change_microphone_device(index+1, mic_none); // Ensures the value is set in config
 		}
 		else
 		{
-			mics_combo[index]->setCurrentText(qmic);
+			m_mics_combo[index]->setCurrentText(qmic);
 		}
 	}
 
@@ -969,7 +969,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	ui->wakeupDelay->setMaximum(7000); // Very large values must be entered with config.yml changes
 	ui->wakeupDelay->setPageStep(200);
 	const int wakeup_def = stoi(m_emu_settings->GetSettingDefault(emu_settings_type::DriverWakeUpDelay));
-	connect(ui->wakeupReset, &QAbstractButton::clicked, [=, this]()
+	connect(ui->wakeupReset, &QAbstractButton::clicked, [wakeup_def, this]()
 	{
 		ui->wakeupDelay->setValue(wakeup_def);
 	});
@@ -978,7 +978,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	SnapSlider(ui->vblank, 30);
 	ui->vblank->setPageStep(60);
 	const int vblank_def = stoi(m_emu_settings->GetSettingDefault(emu_settings_type::VBlankRate));
-	connect(ui->vblankReset, &QAbstractButton::clicked, [=, this]()
+	connect(ui->vblankReset, &QAbstractButton::clicked, [vblank_def, this]()
 	{
 		ui->vblank->setValue(vblank_def);
 	});
@@ -1076,7 +1076,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	ui->searchBox->setPlaceholderText(tr("Search libraries", "Library search box"));
 
-	auto on_lib_button_clicked = [=, this](int ind)
+	auto on_lib_button_clicked = [this](int ind)
 	{
 		if (ind != static_cast<int>(lib_loading_type::liblv2only))
 		{
@@ -1090,7 +1090,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	};
 
-	auto on_search_box_text_changed = [=, this](QString text)
+	auto on_search_box_text_changed = [this](QString text)
 	{
 		const QString search_term = text.toLower();
 		std::vector<QListWidgetItem*> items;
@@ -1124,7 +1124,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	connect(ui->searchBox, &QLineEdit::textChanged, on_search_box_text_changed);
 
 	// enable multiselection (there must be a better way)
-	connect(ui->lleList, &QListWidget::itemChanged, [&](QListWidgetItem* item)
+	connect(ui->lleList, &QListWidget::itemChanged, [this](QListWidgetItem* item)
 	{
 		for (auto cb : ui->lleList->selectedItems())
 		{
@@ -1356,7 +1356,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		return qstr(game_window_title);
 	};
 
-	const auto set_game_window_title = [=, this](const std::string& format)
+	const auto set_game_window_title = [get_game_window_title, this](const std::string& format)
 	{
 		const auto game_window_title_format = qstr(format);
 		const auto game_window_title = get_game_window_title(game_window_title_format);
@@ -1369,9 +1369,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->label_game_window_title_format->setToolTip(tooltip);
 	};
 
-	connect(ui->edit_button_game_window_title_format, &QAbstractButton::clicked, [=, this]()
+	connect(ui->edit_button_game_window_title_format, &QAbstractButton::clicked, [get_game_window_title, set_game_window_title, this]()
 	{
-		auto get_game_window_title_label = [=](const QString& format)
+		auto get_game_window_title_label = [get_game_window_title, set_game_window_title, this](const QString& format)
 		{
 			const QString game_window_title = get_game_window_title(format);
 
@@ -1405,7 +1405,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		input_dialog dlg(-1, edited_format, tr("Game Window Title Format", "Game window title"), get_game_window_title_label(edited_format), "", this);
 		dlg.resize(width() * .75, dlg.height());
 
-		connect(&dlg, &input_dialog::text_changed, [&](const QString& text)
+		connect(&dlg, &input_dialog::text_changed, [&edited_format, &dlg, get_game_window_title_label](const QString& text)
 		{
 			edited_format = text.simplified();
 			dlg.set_label_text(get_game_window_title_label(edited_format));
@@ -1418,7 +1418,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	});
 
-	connect(ui->reset_button_game_window_title_format, &QAbstractButton::clicked, [=, this]()
+	connect(ui->reset_button_game_window_title_format, &QAbstractButton::clicked, [set_game_window_title, this]()
 	{
 		const std::string default_game_title_format = m_emu_settings->GetSettingDefault(emu_settings_type::WindowTitleFormat);
 		m_emu_settings->SetSetting(emu_settings_type::WindowTitleFormat, default_game_title_format);
@@ -1458,7 +1458,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 		SubscribeTooltip(ui->cb_show_pup_install, tooltips.settings.show_pup_install);
 
-		SubscribeTooltip(ui->cb_check_update_start, tooltips.settings.check_update_start);
+		SubscribeTooltip(ui->gb_updates, tooltips.settings.check_update_start);
 
 		SubscribeTooltip(ui->useRichPresence, tooltips.settings.use_rich_presence);
 
@@ -1487,19 +1487,19 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		SubscribeTooltip(ui->tty_limit, tooltips.settings.tty_limit);
 
 		ui->spinbox_log_limit->setValue(m_gui_settings->GetValue(gui::l_limit).toInt());
-		connect(ui->spinbox_log_limit, &QSpinBox::editingFinished, [=, this]()
+		connect(ui->spinbox_log_limit, &QSpinBox::editingFinished, [this]()
 		{
 			m_gui_settings->SetValue(gui::l_limit, ui->spinbox_log_limit->value());
 		});
 
 		ui->spinbox_tty_limit->setValue(m_gui_settings->GetValue(gui::l_limit_tty).toInt());
-		connect(ui->spinbox_tty_limit, &QSpinBox::editingFinished, [=, this]()
+		connect(ui->spinbox_tty_limit, &QSpinBox::editingFinished, [this]()
 		{
 			m_gui_settings->SetValue(gui::l_limit_tty, ui->spinbox_tty_limit->value());
 		});
 
 		// colorize preview icons
-		auto add_colored_icon = [&](QPushButton *button, const QColor& color, const QIcon& icon = QIcon(), const QColor& iconColor = QColor())
+		auto add_colored_icon = [this](QPushButton *button, const QColor& color, const QIcon& icon = QIcon(), const QColor& iconColor = QColor())
 		{
 			QLabel* text = new QLabel(button->text());
 			text->setObjectName("color_button");
@@ -1523,7 +1523,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			button->layout()->addWidget(text);
 		};
 
-		auto add_colored_icons = [=, this]()
+		auto add_colored_icons = [add_colored_icon, this]()
 		{
 			add_colored_icon(ui->pb_gl_icon_color, m_gui_settings->GetValue(gui::gl_iconColor).value<QColor>());
 			add_colored_icon(ui->pb_sd_icon_color, m_gui_settings->GetValue(gui::sd_icon_color).value<QColor>());
@@ -1545,7 +1545,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->pb_sd_icon_color->setEnabled(enable_ui_colors);
 		ui->pb_tr_icon_color->setEnabled(enable_ui_colors);
 
-		auto apply_gui_options = [&](bool reset = false)
+		auto apply_gui_options = [this](bool reset = false)
 		{
 			if (reset)
 			{
@@ -1564,12 +1564,12 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			}
 		};
 
-		connect(ui->buttonBox, &QDialogButtonBox::accepted, [=, this]()
+		connect(ui->buttonBox, &QDialogButtonBox::accepted, [apply_gui_options, this]()
 		{
 			apply_gui_options();
 		});
 
-		connect(ui->pb_reset_default, &QAbstractButton::clicked, [=, this]
+		connect(ui->pb_reset_default, &QAbstractButton::clicked, [apply_gui_options, this]
 		{
 			if (QMessageBox::question(this, tr("Reset GUI to default?", "Reset"), tr("This will include your stylesheet as well. Do you wish to proceed?", "Reset"),
 				QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)
@@ -1587,37 +1587,37 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		connect(ui->pb_apply_config, &QAbstractButton::clicked, this, &settings_dialog::OnApplyGuiConfig);
 		connect(ui->pb_apply_stylesheet, &QAbstractButton::clicked, this, &settings_dialog::OnApplyStylesheet);
 
-		connect(ui->pb_open_folder, &QAbstractButton::clicked, [=, this]()
+		connect(ui->pb_open_folder, &QAbstractButton::clicked, [this]()
 		{
 			QDesktopServices::openUrl(m_gui_settings->GetSettingsDir());
 		});
 
-		connect(ui->cb_show_welcome, &QCheckBox::clicked, [=, this](bool val)
+		connect(ui->cb_show_welcome, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::ib_show_welcome, val);
 		});
-		connect(ui->cb_show_exit_game, &QCheckBox::clicked, [=, this](bool val)
+		connect(ui->cb_show_exit_game, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::ib_confirm_exit, val);
 		});
-		connect(ui->cb_show_boot_game, &QCheckBox::clicked, [=, this](bool val)
+		connect(ui->cb_show_boot_game, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::ib_confirm_boot, val);
 		});
-		connect(ui->cb_show_pkg_install, &QCheckBox::clicked, [=, this](bool val)
+		connect(ui->cb_show_pkg_install, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::ib_pkg_success, val);
 		});
-		connect(ui->cb_show_pup_install, &QCheckBox::clicked, [=, this](bool val)
+		connect(ui->cb_show_pup_install, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::ib_pup_success, val);
 		});
-		connect(ui->cb_check_update_start, &QCheckBox::clicked, [=, this](bool val)
+		connect(ui->cb_check_update_start, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::m_check_upd_start, val);
 		});
 
-		connect(ui->cb_custom_colors, &QCheckBox::clicked, [=, this](bool val)
+		connect(ui->cb_custom_colors, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::m_enableUIColors, val);
 			ui->pb_gl_icon_color->setEnabled(val);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1537,7 +1537,18 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->cb_show_pkg_install->setChecked(m_gui_settings->GetValue(gui::ib_pkg_success).toBool());
 		ui->cb_show_pup_install->setChecked(m_gui_settings->GetValue(gui::ib_pup_success).toBool());
 
-		ui->cb_check_update_start->setChecked(m_gui_settings->GetValue(gui::m_check_upd_start).toBool());
+		const QString updates_yes        = tr("Yes", "Updates");
+		const QString updates_background = tr("Background", "Updates");
+		const QString updates_no         = tr("No", "Updates");
+
+		ui->combo_updates->addItem(updates_yes, "true");
+		ui->combo_updates->addItem(updates_background, "background");
+		ui->combo_updates->addItem(updates_no, "false");
+		ui->combo_updates->setCurrentIndex(ui->combo_updates->findData(m_gui_settings->GetValue(gui::m_check_upd_start).toString()));
+		connect(ui->combo_updates, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [this](int index)
+		{
+			m_gui_settings->SetValue(gui::m_check_upd_start, ui->combo_updates->itemData(index));
+		});
 
 		const bool enable_ui_colors = m_gui_settings->GetValue(gui::m_enableUIColors).toBool();
 		ui->cb_custom_colors->setChecked(enable_ui_colors);
@@ -1611,10 +1622,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		connect(ui->cb_show_pup_install, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::ib_pup_success, val);
-		});
-		connect(ui->cb_check_update_start, &QCheckBox::clicked, [this](bool val)
-		{
-			m_gui_settings->SetValue(gui::m_check_upd_start, val);
 		});
 
 		connect(ui->cb_custom_colors, &QCheckBox::clicked, [this](bool val)

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -49,7 +49,7 @@ private:
 	// Gpu tab
 	QString m_old_renderer = "";
 	// Audio tab
-	QComboBox *mics_combo[4];
+	QComboBox *m_mics_combo[4];
 
 	int m_tab_index;
 	Ui::settings_dialog *ui;

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -3143,13 +3143,6 @@
                </widget>
               </item>
               <item>
-               <widget class="QCheckBox" name="cb_check_update_start">
-                <property name="text">
-                 <string>Check for updates on startup</string>
-                </property>
-               </widget>
-              </item>
-              <item>
                <spacer name="guiTabSpacerRight">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -3164,6 +3157,18 @@
                  </size>
                 </property>
                </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="gb_updates">
+             <property name="title">
+              <string>Check for updates on startup</string>
+             </property>
+             <layout class="QVBoxLayout" name="layout_gb_updates">
+              <item>
+               <widget class="QComboBox" name="combo_updates"/>
               </item>
              </layout>
             </widget>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -722,13 +722,13 @@
                 </property>
                </widget>
               </item>
-            <item>
-             <widget class="QCheckBox" name="Enable3D">
-              <property name="text">
-               <string>Enable 3D</string>
-              </property>
-             </widget>
-            </item>
+              <item>
+               <widget class="QCheckBox" name="Enable3D">
+                <property name="text">
+                 <string>Enable 3D</string>
+                </property>
+               </widget>
+              </item>
               <item>
                <widget class="QCheckBox" name="disableVertexCache">
                 <property name="text">
@@ -2041,13 +2041,13 @@
                 </property>
                </widget>
               </item>
-            <item>
-             <widget class="QCheckBox" name="DisableNativefp16">
-              <property name="text">
-               <string>Disable native float16 support</string>
-              </property>
-             </widget>
-            </item>
+              <item>
+               <widget class="QCheckBox" name="DisableNativefp16">
+                <property name="text">
+                 <string>Disable native float16 support</string>
+                </property>
+               </widget>
+              </item>
               <item>
                <widget class="QCheckBox" name="relaxedZCULL">
                 <property name="text">
@@ -2360,11 +2360,11 @@
                </widget>
               </item>
               <item>
-                <widget class="QCheckBox" name="gs_disableKbHotkeys">
-                  <property name="text">
-                    <string>Ignore keyboard hotkeys</string>
-                  </property>
-                </widget>
+               <widget class="QCheckBox" name="gs_disableKbHotkeys">
+                <property name="text">
+                 <string>Ignore keyboard hotkeys</string>
+                </property>
+               </widget>
               </item>
               <item>
                <widget class="QCheckBox" name="gs_showMouseInFullscreen">

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -163,7 +163,7 @@ public:
 		const QString show_boot_game     = tr("Shows a confirmation dialog when a game was booted while another game is running.");
 		const QString show_pkg_install   = tr("Shows a dialog when packages were installed successfully.");
 		const QString show_pup_install   = tr("Shows a dialog when firmware was installed successfully.");
-		const QString check_update_start = tr("Check if an update is available on startup.");
+		const QString check_update_start = tr("Checks if an update is available on startup and asks if you want to update.\nIf \"Background\" is selected, the check is done silently in the background and a new download option is shown in the top right corner of the menu if a new version was found.");
 		const QString use_rich_presence  = tr("Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to completely close the connection.");
 		const QString discord_state      = tr("Tell your friends what you are doing.");
 		const QString custom_colors      = tr("Prioritize custom user interface colors over properties set in stylesheet.");

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -3,7 +3,7 @@
 #include "progress_dialog.h"
 #include "localized.h"
 #include "rpcs3_version.h"
-#include "curl_handle.h"
+#include "downloader.h"
 #include "Utilities/StrUtil.h"
 #include "Crypto/sha256.h"
 #include "Emu/System.h"
@@ -35,47 +35,11 @@
 
 LOG_CHANNEL(update_log, "UPDATER");
 
-size_t curl_write_cb(char* ptr, size_t /*size*/, size_t nmemb, void* userdata)
-{
-	update_manager* upd_mgr = reinterpret_cast<update_manager*>(userdata);
-	return upd_mgr->update_buffer(ptr, nmemb);
-}
-
 update_manager::update_manager()
 {
-	m_curl = new curl_handle(this);
-
-	// We need this signal in order to update the GUI from the main thread
-	connect(this, &update_manager::signal_buffer_update, this, &update_manager::handle_buffer_update);
 }
 
-void update_manager::handle_buffer_update(int size)
-{
-	if (m_progress_dialog && m_update_dialog)
-	{
-		m_progress_dialog->setValue(size);
-		QApplication::processEvents();
-	}
-}
-
-size_t update_manager::update_buffer(char* data, size_t size)
-{
-	if (m_curl_abort)
-	{
-		return 0;
-	}
-
-	const auto old_size = m_curl_buf.size();
-	const auto new_size = old_size + size;
-	m_curl_buf.resize(static_cast<int>(new_size));
-	memcpy(m_curl_buf.data() + old_size, data, size);
-
-	Q_EMIT signal_buffer_update(static_cast<int>(new_size));
-
-	return size;
-}
-
-void update_manager::check_for_updates(bool automatic, QWidget* parent)
+void update_manager::check_for_updates(bool automatic, bool check_only, QWidget* parent)
 {
 #ifdef __linux__
 	if (automatic && !::getenv("APPIMAGE"))
@@ -85,59 +49,42 @@ void update_manager::check_for_updates(bool automatic, QWidget* parent)
 	}
 #endif
 
-	m_parent        = parent;
-	m_curl_abort    = false;
-	m_update_dialog = false;
-	m_curl_buf.clear();
+	m_parent     = parent;
+	m_downloader = new downloader("RPCS3 Updater", parent);
 
-	m_progress_dialog = new progress_dialog(tr("Checking For Updates"), tr("Please wait..."), tr("Abort"), 0, 100, true, parent);
-	m_progress_dialog->setAutoClose(false);
-	m_progress_dialog->setAutoReset(false);
-	m_progress_dialog->show();
-
-	connect(m_progress_dialog, &QProgressDialog::canceled, [this]() { m_curl_abort = true; });
-	connect(m_progress_dialog, &QProgressDialog::finished, m_progress_dialog, &QProgressDialog::deleteLater);
-
-	const std::string request_url = "https://update.rpcs3.net/?api=v1&c=" + rpcs3::get_commit_and_hash().second;
-	curl_easy_setopt(m_curl->get_curl(), CURLOPT_URL, request_url.c_str());
-	curl_easy_setopt(m_curl->get_curl(), CURLOPT_WRITEFUNCTION, curl_write_cb);
-	curl_easy_setopt(m_curl->get_curl(), CURLOPT_WRITEDATA, this);
-
-	auto thread = QThread::create([this]
+	connect(m_downloader, &downloader::signal_download_error, this, [this, automatic](const QString& /*error*/)
 	{
-		const auto curl_result = curl_easy_perform(m_curl->get_curl());
-		m_curl_result = curl_result == CURLE_OK;
-
-		if (!m_curl_result)
+		if (!automatic)
 		{
-			update_log.error("Curl error(query): %s", curl_easy_strerror(curl_result));
+			QMessageBox::warning(m_parent, tr("Auto-updater"), tr("An error occurred during the auto-updating process.\nCheck the log for more information."));
 		}
 	});
-	connect(thread, &QThread::finished, this, [this, automatic]()
-	{
-		const bool result_json = m_curl_result && handle_json(automatic);
 
-		if (!result_json && !m_curl_abort)
+	connect(m_downloader, &downloader::signal_download_finished, this, [this, automatic, check_only](const QByteArray& data)
+	{
+		const bool result_json = handle_json(automatic, check_only, data);
+
+		if (!result_json)
 		{
+			// The progress dialog is configured to stay open, so we need to close it manually if the download succeeds.
+			m_downloader->close_progress_dialog();
+
 			if (!automatic)
 			{
 				QMessageBox::warning(m_parent, tr("Auto-updater"), tr("An error occurred during the auto-updating process.\nCheck the log for more information."));
 			}
-
-			if (m_progress_dialog)
-			{
-				m_progress_dialog->close();
-				m_progress_dialog = nullptr;
-			}
 		}
+
+		Q_EMIT signal_update_available(result_json);
 	});
-	thread->setObjectName("RPCS3 Update Check");
-	thread->start();
+
+	const std::string url = "https://update.rpcs3.net/?api=v1&c=" + rpcs3::get_commit_and_hash().second;
+	m_downloader->start(url, true, !automatic, tr("Checking For Updates"), true);
 }
 
-bool update_manager::handle_json(bool automatic)
+bool update_manager::handle_json(bool automatic, bool check_only, const QByteArray& data)
 {
-	const QJsonObject json_data = QJsonDocument::fromJson(m_curl_buf).object();
+	const QJsonObject json_data = QJsonDocument::fromJson(data).object();
 	const int return_code       = json_data["return_code"].toInt(-255);
 
 	bool hash_found = true;
@@ -202,7 +149,7 @@ bool update_manager::handle_json(bool automatic)
 	if (hash_found && return_code == 0)
 	{
 		update_log.success("RPCS3 is up to date!");
-		m_progress_dialog->close();
+		m_downloader->close_progress_dialog();
 
 		if (!automatic)
 			QMessageBox::information(m_parent, tr("Auto-updater"), tr("Your version is already up to date!"));
@@ -225,11 +172,9 @@ bool update_manager::handle_json(bool automatic)
 
 	Localized localized;
 
-	QString message;
-
 	if (hash_found)
 	{
-		message = tr("A new version of RPCS3 is available!\n\nCurrent version: %0 (%1)\nLatest version: %2 (%3)\nYour version is %4 old.\n\nDo you want to update?")
+		m_update_message = tr("A new version of RPCS3 is available!\n\nCurrent version: %0 (%1)\nLatest version: %2 (%3)\nYour version is %4 old.\n\nDo you want to update?")
 			.arg(current["version"].toString())
 			.arg(cur_str)
 			.arg(latest["version"].toString())
@@ -238,73 +183,72 @@ bool update_manager::handle_json(bool automatic)
 	}
 	else
 	{
-		message = tr("You're currently using a custom or PR build.\n\nLatest version: %0 (%1)\nThe latest version is %2 old.\n\nDo you want to update to the latest official RPCS3 version?")
+		m_update_message = tr("You're currently using a custom or PR build.\n\nLatest version: %0 (%1)\nThe latest version is %2 old.\n\nDo you want to update to the latest official RPCS3 version?")
 			.arg(latest["version"].toString())
 			.arg(lts_str)
 			.arg(localized.GetVerboseTimeByMs(std::abs(diff_msec), true));
 	}
 
-	if (QMessageBox::question(m_progress_dialog, tr("Update Available"), message, QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
-	{
-		m_progress_dialog->close();
-		return true;
-	}
-
+	m_request_url   = latest[os]["download"].toString().toStdString();
 	m_expected_hash = latest[os]["checksum"].toString().toStdString();
 	m_expected_size = latest[os]["size"].toInt();
 
-	m_progress_dialog->setWindowTitle(tr("Downloading Update"));
-
-	// Download RPCS3
-	m_progress_dialog->setMaximum(m_expected_size);
-	m_progress_dialog->setValue(0);
-	m_update_dialog = true;
-
-	const std::string request_url = latest[os]["download"].toString().toStdString();
-	curl_easy_setopt(m_curl->get_curl(), CURLOPT_URL, request_url.c_str());
-	curl_easy_setopt(m_curl->get_curl(), CURLOPT_FOLLOWLOCATION, 1);
-
-	m_curl_buf.clear();
-
-	auto thread = QThread::create([this]
+	if (check_only)
 	{
-		const auto curl_result = curl_easy_perform(m_curl->get_curl());
-		m_curl_result = curl_result == CURLE_OK;
+		m_downloader->close_progress_dialog();
+		return true;
+	}
 
-		if (!m_curl_result)
+	update(automatic);
+	return true;
+}
+
+void update_manager::update(bool automatic)
+{
+	if (QMessageBox::question(m_downloader->get_progress_dialog(), tr("Update Available"), m_update_message, QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+	{
+		m_downloader->close_progress_dialog();
+		return;
+	}
+
+	m_downloader->disconnect();
+
+	connect(m_downloader, &downloader::signal_download_error, this, [this, automatic](const QString& /*error*/)
+	{
+		if (!automatic)
 		{
-			update_log.error("Curl error(download): %s", curl_easy_strerror(curl_result));
+			QMessageBox::warning(m_parent, tr("Auto-updater"), tr("An error occurred during the auto-updating process.\nCheck the log for more information."));
 		}
 	});
-	connect(thread, &QThread::finished, this, [this, automatic]()
-	{
-		const bool result_rpcs3 = m_curl_result && handle_rpcs3();
 
-		if (!result_rpcs3 && !m_curl_abort)
+	connect(m_downloader, &downloader::signal_download_finished, this, [this, automatic](const QByteArray& data)
+	{
+		const bool result_json = handle_rpcs3(data);
+
+		if (!result_json)
 		{
+			// The progress dialog is configured to stay open, so we need to close it manually if the download succeeds.
+			m_downloader->close_progress_dialog();
+
 			if (!automatic)
 			{
 				QMessageBox::warning(m_parent, tr("Auto-updater"), tr("An error occurred during the auto-updating process.\nCheck the log for more information."));
 			}
-
-			if (m_progress_dialog)
-			{
-				m_progress_dialog->close();
-				m_progress_dialog = nullptr;
-			}
 		}
-	});
-	thread->setObjectName("RPCS3 Updater");
-	thread->start();
 
-	return true;
+		Q_EMIT signal_update_available(false);
+	});
+
+	m_downloader->start(m_request_url, true, true, tr("Downloading Update"), true, m_expected_size);
 }
 
-bool update_manager::handle_rpcs3()
+bool update_manager::handle_rpcs3(const QByteArray& data)
 {
-	if (m_expected_size != m_curl_buf.size() + 0u)
+	m_downloader->update_progress_dialog(tr("Updating RPCS3"));
+
+	if (m_expected_size != data.size() + 0u)
 	{
-		update_log.error("Download size mismatch: %d expected: %d", m_curl_buf.size(), m_expected_size);
+		update_log.error("Download size mismatch: %d expected: %d", data.size(), m_expected_size);
 		return false;
 	}
 
@@ -312,7 +256,7 @@ bool update_manager::handle_rpcs3()
 	mbedtls_sha256_context ctx;
 	mbedtls_sha256_init(&ctx);
 	mbedtls_sha256_starts_ret(&ctx, 0);
-	mbedtls_sha256_update_ret(&ctx, reinterpret_cast<const unsigned char*>(m_curl_buf.data()), m_curl_buf.size());
+	mbedtls_sha256_update_ret(&ctx, reinterpret_cast<const unsigned char*>(data.data()), data.size());
 	mbedtls_sha256_finish_ret(&ctx, res_hash);
 
 	std::string res_hash_string("0000000000000000000000000000000000000000000000000000000000000000");
@@ -329,9 +273,8 @@ bool update_manager::handle_rpcs3()
 		return false;
 	}
 
-	std::string replace_path;
-
 #ifdef _WIN32
+
 	// Get executable path
 	const std::string orig_path = Emulator::GetExeDir() + "rpcs3.exe";
 
@@ -339,61 +282,6 @@ bool update_manager::handle_rpcs3()
 	const auto tmp_size = MultiByteToWideChar(CP_UTF8, 0, orig_path.c_str(), -1, nullptr, 0);
 	wchar_orig_path.resize(tmp_size);
 	MultiByteToWideChar(CP_UTF8, 0, orig_path.c_str(), -1, wchar_orig_path.data(), tmp_size);
-
-#endif
-
-#ifdef __linux__
-
-	const char* appimage_path = ::getenv("APPIMAGE");
-	if (appimage_path != nullptr)
-	{
-		replace_path = appimage_path;
-		update_log.notice("Found AppImage path: %s", appimage_path);
-	}
-	else
-	{
-		update_log.warning("Failed to find AppImage path");
-		char exe_path[PATH_MAX];
-		ssize_t len = ::readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
-
-		if (len == -1)
-		{
-			update_log.error("Failed to find executable path");
-			return false;
-		}
-
-		exe_path[len] = '\0';
-		update_log.trace("Found exec path: %s", exe_path);
-
-		replace_path = exe_path;
-	}
-
-	m_progress_dialog->setWindowTitle(tr("Updating RPCS3"));
-
-	// Move the appimage/exe and replace with new appimage
-	const std::string move_dest = replace_path + "_old";
-	fs::rename(replace_path, move_dest, true);
-	fs::file new_appimage(replace_path, fs::read + fs::write + fs::create + fs::trunc);
-	if (!new_appimage)
-	{
-		update_log.error("Failed to create new AppImage file: %s", replace_path);
-		return false;
-	}
-	if (new_appimage.write(m_curl_buf.data(), m_curl_buf.size()) != m_curl_buf.size() + 0u)
-	{
-		update_log.error("Failed to write new AppImage file: %s", replace_path);
-		return false;
-	}
-	if (fchmod(new_appimage.get_handle(), S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1)
-	{
-		update_log.error("Failed to chmod rwxrxrx %s", replace_path);
-		return false;
-	}
-	new_appimage.close();
-
-	update_log.success("Successfully updated %s!", replace_path);
-
-#elif defined(_WIN32)
 
 	char temp_path[PATH_MAX];
 
@@ -409,14 +297,12 @@ bool update_manager::handle_rpcs3()
 		update_log.error("Failed to create temporary file: %s", tmpfile_path);
 		return false;
 	}
-	if (tmpfile.write(m_curl_buf.data(), m_curl_buf.size()) != m_curl_buf.size())
+	if (tmpfile.write(data.data(), data.size()) != data.size())
 	{
 		update_log.error("Failed to write temporary file: %s", tmpfile_path);
 		return false;
 	}
 	tmpfile.close();
-
-	m_progress_dialog->setWindowTitle(tr("Updating RPCS3"));
 
 	// 7z stuff (most of this stuff is from 7z Util sample and has been reworked to be more stl friendly)
 
@@ -596,7 +482,61 @@ bool update_manager::handle_rpcs3()
 	error_free7z();
 	if (res)
 		return false;
+
+#else
+
+	std::string replace_path;
+
+	const char* appimage_path = ::getenv("APPIMAGE");
+	if (appimage_path != nullptr)
+	{
+		replace_path = appimage_path;
+		update_log.notice("Found AppImage path: %s", appimage_path);
+	}
+	else
+	{
+		update_log.warning("Failed to find AppImage path");
+		char exe_path[PATH_MAX];
+		ssize_t len = ::readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+
+		if (len == -1)
+		{
+			update_log.error("Failed to find executable path");
+			return false;
+		}
+
+		exe_path[len] = '\0';
+		update_log.trace("Found exec path: %s", exe_path);
+
+		replace_path = exe_path;
+	}
+
+	// Move the appimage/exe and replace with new appimage
+	const std::string move_dest = replace_path + "_old";
+	fs::rename(replace_path, move_dest, true);
+	fs::file new_appimage(replace_path, fs::read + fs::write + fs::create + fs::trunc);
+	if (!new_appimage)
+	{
+		update_log.error("Failed to create new AppImage file: %s", replace_path);
+		return false;
+	}
+	if (new_appimage.write(data.data(), data.size()) != data.size() + 0u)
+	{
+		update_log.error("Failed to write new AppImage file: %s", replace_path);
+		return false;
+	}
+	if (fchmod(new_appimage.get_handle(), S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1)
+	{
+		update_log.error("Failed to chmod rwxrxrx %s", replace_path);
+		return false;
+	}
+	new_appimage.close();
+
+	update_log.success("Successfully updated %s!", replace_path);
+
 #endif
+
+	m_downloader->close_progress_dialog();
 
 	QMessageBox::information(m_parent, tr("Auto-updater"), tr("Update successful!\nRPCS3 will now restart."));
 

--- a/rpcs3/rpcs3qt/update_manager.h
+++ b/rpcs3/rpcs3qt/update_manager.h
@@ -4,37 +4,30 @@
 #include <QObject>
 #include <QByteArray>
 
-class curl_handle;
-class progress_dialog;
+class downloader;
 
 class update_manager final :  public QObject
 {
 	Q_OBJECT
 
 private:
-	std::atomic<bool> m_update_dialog  = false;
-	progress_dialog* m_progress_dialog = nullptr;
-	QWidget* m_parent                  = nullptr;
+	downloader* m_downloader = nullptr;
+	QWidget* m_parent        = nullptr;
 
-	curl_handle* m_curl = nullptr;
-	QByteArray m_curl_buf;
-	std::atomic<bool> m_curl_abort = false;
-	std::atomic<bool> m_curl_result = false;
+	QString m_update_message;
 
+	std::string m_request_url;
 	std::string m_expected_hash;
 	u64 m_expected_size = 0;
 
-	bool handle_json(bool automatic);
-	bool handle_rpcs3();
+	bool handle_json(bool automatic, bool check_only, const QByteArray& data);
+	bool handle_rpcs3(const QByteArray& data);
 
 public:
 	update_manager();
-	void check_for_updates(bool automatic, QWidget* parent = nullptr);
-	size_t update_buffer(char* data, size_t size);
+	void check_for_updates(bool automatic, bool check_only, QWidget* parent = nullptr);
+	void update(bool automatic);
 
 Q_SIGNALS:
-	void signal_buffer_update(int size);
-
-private Q_SLOTS:
-	void handle_buffer_update(int size);
+	void signal_update_available(bool update_available);
 };


### PR DESCRIPTION
### General fixes
- Fixes some random crashes when closing the emulator while ppu is compiling.
- Cleans up some random code

### Updater improvements
- Refactors curl stuff into a downloader. (This will come in handy when more downloadable features are added later on)
- Adds a new option to check for updates silently, when RPCS3 is started. There will be a small menu on the top right of the emulator if an update was found.

fixes #8252
partially implements #8254