### PR TITLE
SPU MFC/LLVM: Fix WrTagUpdate channel count, Never clear tag status in WrTagUpdate, LLVM related optimizations

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1715,10 +1715,8 @@ void spu_recompiler::RCHCNT(spu_opcode_t op)
 	{
 		const XmmLink& vr = XmmAlloc();
 		const XmmLink& v1 = XmmAlloc();
-		c->movd(vr, SPU_OFF_32(ch_tag_upd));
-		c->pxor(v1, v1);
-		c->pcmpeqd(vr, v1);
-		c->psrld(vr, 31);
+		c->mov(addr->r32(), 1);
+		c->movd(vr, addr->r32());
 		c->pslldq(vr, 12);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vr);
 		return;

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -2515,7 +2515,6 @@ void spu_recompiler::WRCH(spu_opcode_t op)
 
 			c->bind(zero);
 			c->mov(SPU_OFF_32(ch_tag_upd), qw0->r32());
-			c->mov(SPU_OFF_64(ch_tag_stat), 0);
 			c->jmp(ret);
 		});
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -5585,9 +5585,7 @@ public:
 		}
 		case MFC_WrTagUpdate:
 		{
-			res.value = m_ir->CreateLoad(spu_ptr<u32>(&spu_thread::ch_tag_upd), true);
-			res.value = m_ir->CreateICmpEQ(res.value, m_ir->getInt32(0));
-			res.value = m_ir->CreateZExt(res.value, get_type<u32>());
+			res.value = m_ir->getInt32(1);
 			break;
 		}
 		case MFC_Cmd:

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2811,7 +2811,6 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 		else
 		{
 			ch_tag_upd = value;
-			ch_tag_stat.set_value(0, false);
 		}
 
 		return true;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2368,7 +2368,7 @@ u32 spu_thread::get_ch_count(u32 ch)
 	case SPU_RdInMbox:        return ch_in_mbox.get_count();
 	case MFC_RdTagStat:       return ch_tag_stat.get_count();
 	case MFC_RdListStallStat: return ch_stall_stat.get_count();
-	case MFC_WrTagUpdate:     return ch_tag_upd == 0;
+	case MFC_WrTagUpdate:     return 1;
 	case SPU_RdSigNotify1:    return ch_snr1.get_count();
 	case SPU_RdSigNotify2:    return ch_snr2.get_count();
 	case MFC_RdAtomicStat:    return ch_atomic_stat.get_count();


### PR DESCRIPTION
There were two behaviours that were undocumented regarding tag status updates that led to this pr:
- It was unclear if WrTagUpdate can clear previous tag status update in case the requested update cannot complete immediately.
- Is WrTagUpdate channel count actually depends on if theres a pending tag status update?

The results from hw testing:
* Always report channel count 1 in WrTagUpdate, because in realhw this count is just a performance hint that tells the program if it is beneficial to write a tag update at the same time or doing some other work instead. Otherwise the SPU will have to wait until the MFC internally processes the previous update request which can lead to a loss of performance.
In rpcs3 such "delay" in count is not emulated at all, report 1 immediately.

* WrTagUpdate connot clear previous tag update status, it can only write new ones when threy are available.

Testcase : https://github.com/elad335/myps3tests/tree/master/spu_tests/MFC_WrTagUpdate 

Results on realhw and pr:
```
Tag Status operation result: 0
Tag Update operation result: 0
```
Results on Master:
```
Tag Status operation result: 1
Tag Update operation result: 1
```

Other improvements:
LLVM has received a few optimizations regarding it, non-constant tag updates can now execute inside LLVM recompiler emitted code instead of calling the interpreter's equivalent function for it.