### PR TITLE
SPU LLVM: Fix barrier commands enqueuing

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6043,6 +6043,7 @@ public:
 				case MFC_SYNC_CMD:
 				{
 					m_ir->CreateStore(m_ir->getInt32(-1), pb);
+					m_ir->CreateStore(m_ir->CreateOr(m_ir->CreateLoad(pf), mask), pf);
 					break;
 				}
 				default:


### PR DESCRIPTION
This fix was missing from LLVM in https://github.com/RPCS3/rpcs3/pull/6173/commits/35fa117ccd116a1c916e78eac3f221579bbbe1a7