### PR TITLE
PPU debugger: Fix functions stack bounds check

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -627,7 +627,7 @@ std::string cpu_thread::dump_callstack() const
 	return {};
 }
 
-std::vector<u32> cpu_thread::dump_callstack_list() const
+std::vector<std::pair<u32, u32>> cpu_thread::dump_callstack_list() const
 {
 	return {};
 }

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -103,7 +103,7 @@ public:
 	virtual std::string dump_callstack() const;
 
 	// Get CPU call stack list
-	virtual std::vector<u32> dump_callstack_list() const;
+	virtual std::vector<std::pair<u32, u32>> dump_callstack_list() const;
 
 	// Get CPU dump of misc information
 	virtual std::string dump_misc() const;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -472,16 +472,16 @@ std::string ppu_thread::dump_callstack() const
 
 	fmt::append(ret, "Call stack:\n=========\n0x%08x (0x0) called\n", cia);
 
-	for (u32 sp : dump_callstack_list())
+	for (const auto& sp : dump_callstack_list())
 	{
 		// TODO: function addresses too
-		fmt::append(ret, "> from 0x%08x (0x0)\n", sp);
+		fmt::append(ret, "> from 0x%08x (r1=0x%08x)\n", sp.first, sp.second);
 	}
 
 	return ret;
 }
 
-std::vector<u32> ppu_thread::dump_callstack_list() const
+std::vector<std::pair<u32, u32>> ppu_thread::dump_callstack_list() const
 {
 	//std::shared_lock rlock(vm::g_mutex); // Needs optimizations
 
@@ -507,7 +507,7 @@ std::vector<u32> ppu_thread::dump_callstack_list() const
 		stack_max += 4096;
 	}
 
-	std::vector<u32> call_stack_list;
+	std::vector<std::pair<u32, u32>> call_stack_list;
 
 	for (
 		u64 sp = *vm::get_super_ptr<u64>(stack_ptr);
@@ -523,7 +523,7 @@ std::vector<u32> ppu_thread::dump_callstack_list() const
 		}
 
 		// TODO: function addresses too
-		call_stack_list.push_back(static_cast<u32>(addr));
+		call_stack_list.emplace_back(static_cast<u32>(addr), static_cast<u32>(sp));
 	}
 
 	return call_stack_list;

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -36,6 +36,11 @@ enum class ppu_syscall_code : u64
 {
 };
 
+enum : u32
+{
+	ppu_stack_start_offset = 0x70,
+};
+
 // ppu function descriptor
 struct ppu_func_opd_t
 {

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -70,7 +70,7 @@ public:
 	virtual std::string dump_all() const override;
 	virtual std::string dump_regs() const override;
 	virtual std::string dump_callstack() const override;
-	virtual std::vector<u32> dump_callstack_list() const override;
+	virtual std::vector<std::pair<u32, u32>> dump_callstack_list() const override;
 	virtual std::string dump_misc() const override;
 	virtual void cpu_task() override final;
 	virtual void cpu_sleep() override;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -872,7 +872,7 @@ std::string spu_thread::dump_callstack() const
 	return {};
 }
 
-std::vector<u32> spu_thread::dump_callstack_list() const
+std::vector<std::pair<u32, u32>> spu_thread::dump_callstack_list() const
 {
 	return {};
 }

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -534,7 +534,7 @@ public:
 	virtual std::string dump_all() const override;
 	virtual std::string dump_regs() const override;
 	virtual std::string dump_callstack() const override;
-	virtual std::vector<u32> dump_callstack_list() const override;
+	virtual std::vector<std::pair<u32, u32>> dump_callstack_list() const override;
 	virtual std::string dump_misc() const override;
 	virtual void cpu_task() override final;
 	virtual void cpu_mem() override;

--- a/rpcs3/rpcs3qt/call_stack_list.cpp
+++ b/rpcs3/rpcs3qt/call_stack_list.cpp
@@ -17,15 +17,15 @@ void call_stack_list::UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_p
 	this->cpu = cpu;
 }
 
-void call_stack_list::HandleUpdate(std::vector<u32> call_stack)
+void call_stack_list::HandleUpdate(std::vector<std::pair<u32, u32>> call_stack)
 {
 	clear();
 
-	for (auto addr : call_stack)
+	for (const auto& addr : call_stack)
 	{
-		const QString call_stack_item_text = qstr(fmt::format("0x%08llx", addr));
+		const QString call_stack_item_text = qstr(fmt::format("0x%08llx (r1=0x%08llx)", addr.first, addr.second));
 		QListWidgetItem* callStackItem = new QListWidgetItem(call_stack_item_text);
-		callStackItem->setData(Qt::UserRole, { addr });
+		callStackItem->setData(Qt::UserRole, { addr.first });
 		addItem(callStackItem);
 	}
 }

--- a/rpcs3/rpcs3qt/call_stack_list.h
+++ b/rpcs3/rpcs3qt/call_stack_list.h
@@ -18,7 +18,7 @@ public:
 Q_SIGNALS:
 	void RequestShowAddress(u32 addr, bool force = false);
 public Q_SLOTS:
-	void HandleUpdate(std::vector<u32> call_stack);
+	void HandleUpdate(std::vector<std::pair<u32, u32>> call_stack);
 private Q_SLOTS:
 	void OnCallStackListDoubleClicked();
 private:

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -86,7 +86,7 @@ protected:
 
 Q_SIGNALS:
 	void DebugFrameClosed();
-	void CallStackUpdateRequested(std::vector<u32> call_stack);
+	void CallStackUpdateRequested(std::vector<std::pair<u32, u32>> call_stack);
 
 public Q_SLOTS:
 	void DoStep(bool stepOver = false);


### PR DESCRIPTION
* Stack offset was wrong, could fix some issues I had in the past such as threads clearly calling functions and saving LR and r1 onto the stack yet the thread is not reported to be in a function at all by the debugger.
* Add some more validity checks.
* Show stack address of each function in the debugger.