### PR TITLE
Exitus

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1618,10 +1618,8 @@ bool Emulator::Pause()
 	idm::select<named_thread<ppu_thread>>(on_select);
 	idm::select<named_thread<spu_thread>>(on_select);
 
-	if (g_cfg.misc.prevent_display_sleep)
-	{
-		enable_display_sleep();
-	}
+	// Always Enable display sleep, not only if it was prevented.
+	enable_display_sleep();
 
 	return true;
 }
@@ -1776,10 +1774,8 @@ void Emulator::Stop(bool restart)
 
 	m_force_boot = false;
 
-	if (g_cfg.misc.prevent_display_sleep)
-	{
-		enable_display_sleep();
-	}
+	// Always Enable display sleep, not only if it was prevented.
+	enable_display_sleep();
 
 	if (do_exit || full_stop)
 	{

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1752,19 +1752,6 @@ void Emulator::Stop(bool restart)
 
 	vm::close();
 
-	if (do_exit)
-	{
-		GetCallbacks().exit(true);
-	}
-	else
-	{
-		if (full_stop)
-		{
-			GetCallbacks().exit(false);
-		}
-		Init();
-	}
-
 #ifdef LLVM_AVAILABLE
 	extern void jit_finalize();
 	jit_finalize();
@@ -1793,6 +1780,24 @@ void Emulator::Stop(bool restart)
 	{
 		enable_display_sleep();
 	}
+
+	if (do_exit || full_stop)
+	{
+		if (Quit(do_exit))
+		{
+			return;
+		}
+	}
+
+	Init();
+}
+
+bool Emulator::Quit(bool force_quit) const
+{
+	Emu.SetForceBoot(false);
+	Emu.Stop();
+
+	return GetCallbacks().exit(force_quit);
 }
 
 std::string Emulator::GetFormattedTitle(double fps) const

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1731,9 +1731,6 @@ void Emulator::Stop(bool restart)
 		}
 	});
 
-	const bool full_stop = !restart && !m_force_boot;
-	const bool do_exit   = full_stop && g_cfg.misc.autoexit;
-
 	sys_log.notice("Stopping emulator...");
 
 	GetCallbacks().on_stop();
@@ -1772,25 +1769,21 @@ void Emulator::Stop(bool restart)
 	klic.clear();
 	hdd1.clear();
 
-	m_force_boot = false;
-
 	// Always Enable display sleep, not only if it was prevented.
 	enable_display_sleep();
 
-	if (do_exit || full_stop)
+	if (Quit(g_cfg.misc.autoexit.get()))
 	{
-		if (Quit(do_exit))
-		{
-			return;
-		}
+		return;
 	}
 
+	m_force_boot = false;
 	Init();
 }
 
-bool Emulator::Quit(bool force_quit) const
+bool Emulator::Quit(bool force_quit)
 {
-	Emu.SetForceBoot(false);
+	m_force_boot = false;
 	Emu.Stop();
 
 	return GetCallbacks().exit(force_quit);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -202,7 +202,7 @@ public:
 	void Resume();
 	void Stop(bool restart = false);
 	void Restart() { Stop(true); }
-	bool Quit(bool force_quit) const;
+	bool Quit(bool force_quit);
 
 	bool IsRunning() const { return m_state == system_state::running; }
 	bool IsPaused()  const { return m_state == system_state::paused; }

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -37,7 +37,7 @@ struct EmuCallbacks
 	std::function<void()> on_resume;
 	std::function<void()> on_stop;
 	std::function<void()> on_ready;
-	std::function<void(bool)> exit; // (force_quit) close RPCS3
+	std::function<bool(bool)> exit; // (force_quit) close RPCS3
 	std::function<void(s32, s32)> handle_taskbar_progress; // (type, value) type: 0 for reset, 1 for increment, 2 for set_limit
 	std::function<void()> init_kb_handler;
 	std::function<void()> init_mouse_handler;
@@ -202,6 +202,7 @@ public:
 	void Resume();
 	void Stop(bool restart = false);
 	void Restart() { Stop(true); }
+	bool Quit(bool force_quit) const;
 
 	bool IsRunning() const { return m_state == system_state::running; }
 	bool IsPaused()  const { return m_state == system_state::paused; }

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -270,7 +270,7 @@ struct cfg_root : cfg::node
 		cfg::_bool autostart{ this, "Automatically start games after boot", true, true };
 		cfg::_bool autoexit{ this, "Exit RPCS3 when process finishes", false, true };
 		cfg::_bool start_fullscreen{ this, "Start games in fullscreen mode", false, true };
-		cfg::_bool prevent_display_sleep{ this, "Prevent display sleep while running games", true };
+		cfg::_bool prevent_display_sleep{ this, "Prevent display sleep while running games", true, true };
 		cfg::_bool show_trophy_popups{ this, "Show trophy popups", true, true };
 		cfg::_bool show_shader_compilation_hint{ this, "Show shader compilation hint", true, true };
 		cfg::_bool use_native_interface{ this, "Use native user interface", true };

--- a/rpcs3/display_sleep_control.cpp
+++ b/rpcs3/display_sleep_control.cpp
@@ -32,6 +32,11 @@ bool display_sleep_control_supported()
 
 void enable_display_sleep()
 {
+	if (!display_sleep_control_supported())
+	{
+		return;
+	}
+
 #ifdef _WIN32
 	SetThreadExecutionState(ES_CONTINUOUS);
 #elif defined(__APPLE__)
@@ -52,6 +57,11 @@ void enable_display_sleep()
 
 void disable_display_sleep()
 {
+	if (!display_sleep_control_supported())
+	{
+		return;
+	}
+
 #ifdef _WIN32
 	SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
 #elif defined(__APPLE__)

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -39,12 +39,15 @@ void headless_application::InitializeCallbacks()
 {
 	EmuCallbacks callbacks = CreateCallbacks();
 
-	callbacks.exit = [this](bool force_quit)
+	callbacks.exit = [this](bool force_quit) -> bool
 	{
 		if (force_quit)
 		{
 			quit();
+			return true;
 		}
+
+		return false;
 	};
 	callbacks.call_after = [=, this](std::function<void()> func)
 	{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -8,6 +8,7 @@
 #include "persistent_settings.h"
 #include "gs_frame.h"
 #include "gl_gs_frame.h"
+#include "display_sleep_control.h"
 
 #ifdef WITH_DISCORD_RPC
 #include "_discord_utils.h"
@@ -460,6 +461,18 @@ void gui_application::OnChangeStyleSheetRequest(const QString& path)
 
 void gui_application::OnEmuSettingsChange()
 {
+	if (Emu.IsRunning())
+	{
+		if (g_cfg.misc.prevent_display_sleep)
+		{
+			enable_display_sleep();
+		}
+		else
+		{
+			disable_display_sleep();
+		}
+	}
+
 	Emu.ConfigureLogs();
 	rsx::overlays::reset_performance_overlay();
 }

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -267,13 +267,21 @@ void gui_application::InitializeCallbacks()
 {
 	EmuCallbacks callbacks = CreateCallbacks();
 
-	callbacks.exit = [this](bool force_quit)
+	callbacks.exit = [this](bool force_quit) -> bool
 	{
 		// Close rpcs3 if closed in no-gui mode
 		if (force_quit || !m_main_window)
 		{
+			if (m_main_window)
+			{
+				// Close main window in order to save its window state
+				m_main_window->close();
+			}
 			quit();
+			return true;
 		}
+
+		return false;
 	};
 	callbacks.call_after = [this](std::function<void()> func)
 	{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -72,6 +72,7 @@ main_window::main_window(std::shared_ptr<gui_settings> gui_settings, std::shared
 
 main_window::~main_window()
 {
+	SaveWindowState();
 	delete ui;
 }
 
@@ -2140,7 +2141,7 @@ void main_window::mouseDoubleClickEvent(QMouseEvent *event)
 	}
 }
 
-/** Override the Qt close event to have the emulator stop and the application die.  May add a warning dialog in future.
+/** Override the Qt close event to have the emulator stop and the application die.
 */
 void main_window::closeEvent(QCloseEvent* closeEvent)
 {
@@ -2150,13 +2151,8 @@ void main_window::closeEvent(QCloseEvent* closeEvent)
 		return;
 	}
 
-	// Cleanly stop the emulator.
-	Emu.Stop();
-
-	SaveWindowState();
-
-	// It's possible to have other windows open, like games.  So, force the application to die.
-	QApplication::quit();
+	// Cleanly stop and quit the emulator.
+	Emu.Quit(true);
 }
 
 /**

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -66,6 +66,8 @@ main_window::main_window(std::shared_ptr<gui_settings> gui_settings, std::shared
 
 	// We have to setup the ui before using a translation
 	ui->setupUi(this);
+
+	setAttribute(Qt::WA_DeleteOnClose);
 }
 
 main_window::~main_window()
@@ -2152,10 +2154,6 @@ void main_window::closeEvent(QCloseEvent* closeEvent)
 	Emu.Stop();
 
 	SaveWindowState();
-
-	// I need the gui settings to sync, and that means having the destructor called as guiSetting's parent is main_window.
-	setAttribute(Qt::WA_DeleteOnClose);
-	QMainWindow::close();
 
 	// It's possible to have other windows open, like games.  So, force the application to die.
 	QApplication::quit();


### PR DESCRIPTION
- Remove obsolete main window close()
  The gui settings aren't part of the main window anymore
- Always save the main window state when quitting RPCS3, not only when the main window is closed by hand
- Make display sleep a dynamic setting
- Always call Emu.Quit() in order to close RPCS3
  This creates a single possible point of failure for calling quit()

This also reorders the Emu.Stop() function. Please let me know if this was done correctly.