### PR TITLE
[DRAFT] Qt: simplify some plural forms logic

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1417,7 +1417,7 @@ void game_list_frame::BatchCreatePPUCaches()
 		}
 	}
 
-	pdlg->setLabelText(tr("Created PPU Caches for %0 titles").arg(created));
+	pdlg->setLabelText(tr("Created PPU Caches for %n title(s)", "", created));
 	pdlg->setCancelButtonText(tr("OK"));
 	QApplication::beep();
 }
@@ -1458,7 +1458,7 @@ void game_list_frame::BatchRemovePPUCaches()
 		}
 	}
 
-	pdlg->setLabelText(tr("%0/%1 caches cleared").arg(removed).arg(total));
+	pdlg->setLabelText(tr("%0/%n cache(s) cleared", "", total).arg(removed));
 	pdlg->setCancelButtonText(tr("OK"));
 	QApplication::beep();
 }
@@ -1499,7 +1499,7 @@ void game_list_frame::BatchRemoveSPUCaches()
 		}
 	}
 
-	pdlg->setLabelText(tr("%0/%1 caches cleared").arg(removed).arg(total));
+	pdlg->setLabelText(tr("%0/%n cache(s) cleared", "", total).arg(removed));
 	pdlg->setCancelButtonText(tr("OK"));
 	QApplication::beep();
 }
@@ -1543,7 +1543,7 @@ void game_list_frame::BatchRemoveCustomConfigurations()
 		}
 	}
 
-	pdlg->setLabelText(tr("%0/%1 custom configurations cleared").arg(removed).arg(total));
+	pdlg->setLabelText(tr("%0/%n custom configuration(s) cleared", "", total).arg(removed));
 	pdlg->setCancelButtonText(tr("OK"));
 	QApplication::beep();
 	Refresh(true);
@@ -1588,7 +1588,7 @@ void game_list_frame::BatchRemoveCustomPadConfigurations()
 		}
 	}
 
-	pdlg->setLabelText(tr("%0/%1 custom pad configurations cleared").arg(removed).arg(total));
+	pdlg->setLabelText(tr("%0/%n custom pad configuration(s) cleared", "", total).arg(removed));
 	pdlg->setCancelButtonText(tr("OK"));
 	QApplication::beep();
 	Refresh(true);
@@ -1630,7 +1630,7 @@ void game_list_frame::BatchRemoveShaderCaches()
 		}
 	}
 
-	pdlg->setLabelText(tr("%0/%1 shader caches cleared").arg(removed).arg(total));
+	pdlg->setLabelText(tr("%0/%n shader cache(s) cleared", "", total).arg(removed));
 	pdlg->setCancelButtonText(tr("OK"));
 	QApplication::beep();
 }

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -513,7 +513,7 @@ void save_manager_dialog::UpdateDetails()
 		m_button_delete->setDisabled( !(selected > 1) );
 		m_details_title->setText(
 			selected > 1 ? tr("%n item(s) selected", "", selected) : tr("Select an item to view details")
-		)
+		);
 		m_button_folder->setDisabled(true);
 	}
 	else

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -429,7 +429,7 @@ void save_manager_dialog::OnEntriesRemove()
 		return;
 	}
 
-	if (QMessageBox::question(this, tr("Delete Confirmation"), tr("Are you sure you want to delete these %1 items?").arg(selection.size()), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
+	if (QMessageBox::question(this, tr("Delete Confirmation"), tr("Are you sure you want to delete these item(s) ?", "", selection.size()), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
 	{
 		std::sort(selection.rbegin(), selection.rend());
 		for (QModelIndex index : selection)
@@ -510,16 +510,10 @@ void save_manager_dialog::UpdateDetails()
 		m_details_details->setText("");
 		m_details_note->setText("");
 
-		if (selected > 1)
-		{
-			m_button_delete->setDisabled(false);
-			m_details_title->setText(tr("%1 items selected").arg(selected));
-		}
-		else
-		{
-			m_button_delete->setDisabled(true);
-			m_details_title->setText(tr("Select an item to view details"));
-		}
+		m_button_delete->setDisabled( !(selected > 1) );
+		m_details_title->setText(
+			selected > 1 ? tr("%n item(s) selected", "", selected) : tr("Select an item to view details")
+		)
 		m_button_folder->setDisabled(true);
 	}
 	else


### PR DESCRIPTION
To help https://github.com/RPCS3/rpcs3/issues/4259, I took care of those two things : 
- Game List Frame : Modify the strings "Created PPU Caches for %0 titles", "%0/%1 caches cleared", "%0/%1 custom configurations cleared", "%0/%1 custom pad configurations cleared", "%0/%1 shader caches cleared", so they support multiple plural forms (seems like they need extra code in the source, not the ts file, please confirm).
- Save Manager Dialog : Modify the strings "Are you sure you want to delete these %1 items?", "%1 items selected" so they support multiple plural forms.

Warning : As my PR https://github.com/RPCS3/rpcs3/pull/8473, it can be merged only if we provide an english translation file with -pluralonly.