### PR TITLE
rsx: Improve ZCULL queued requests finalization

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -597,6 +597,10 @@ void GLGSRender::clear_surface(u32 arg)
 			colormask = rsx::get_abgr8_colormask(colormask);
 			break;
 		}
+		default:
+		{
+			break;
+		}
 		}
 
 		if (colormask)

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -437,6 +437,9 @@ namespace rsx
 			void write(vm::addr_t sink, u64 timestamp, u32 type, u32 value);
 			void write(queued_report_write* writer, u64 timestamp, u32 value);
 
+			// Retire operation
+			void retire(class ::rsx::thread* ptimer, queued_report_write* writer, u32 result);
+
 		public:
 
 			ZCULL_control();


### PR DESCRIPTION
- Unifies the command completion code.
- Allows conditionals to be evaluated with a forwarder present.

Fixes https://github.com/RPCS3/rpcs3/issues/7454