### PR TITLE
vk: Inject memory barrier upon conclusion of a framebuffer feedback loop

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1313,7 +1313,7 @@ namespace vk
 
 		void insert_texture_barrier(vk::command_buffer& cmd, vk::image* tex) override
 		{
-			vk::insert_texture_barrier(cmd, tex, VK_IMAGE_LAYOUT_GENERAL);
+			vk::as_rtt(tex)->texture_barrier(cmd);
 		}
 
 		bool render_target_format_is_compatible(vk::image* tex, u32 gcm_format) override


### PR DESCRIPTION
Do not read from or write to the looping texture until previous draw call is completed using it. This is usually not much of a problem until blending operations come into play. In modern GPUs it is common for multiple draws to execute asynchronously. While the feedback loop is reading from itself, the next draw call can execute without a texture barrier if it does not self-reference leading to a race condition in the GPU threads. In such a situation draw 2 can overwrite parts of the texture being accessed as reads in draw 1. 

Fixes https://github.com/RPCS3/rpcs3/issues/7818