### PR TITLE
Scroll Area Fixis

### DIFF
--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -578,6 +578,7 @@ void pad_settings_dialog::ReactivateButtons()
 	}
 
 	ui->tabWidget->setFocusPolicy(Qt::TabFocus);
+	ui->scrollArea->setFocusPolicy(Qt::StrongFocus);
 
 	ui->chooseProfile->setFocusPolicy(Qt::WheelFocus);
 	ui->chooseHandler->setFocusPolicy(Qt::WheelFocus);
@@ -954,6 +955,7 @@ void pad_settings_dialog::OnPadButtonClicked(int id)
 	}
 
 	ui->tabWidget->setFocusPolicy(Qt::ClickFocus);
+	ui->scrollArea->setFocusPolicy(Qt::ClickFocus);
 
 	ui->chooseProfile->setFocusPolicy(Qt::ClickFocus);
 	ui->chooseHandler->setFocusPolicy(Qt::ClickFocus);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -647,7 +647,7 @@
                <number>0</number>
               </property>
               <property name="currentIndex">
-               <number>1</number>
+               <number>0</number>
               </property>
               <widget class="QWidget" name="pad_page">
                <layout class="QVBoxLayout" name="pad_page_layout">
@@ -2065,7 +2065,7 @@
             <item>
              <widget class="QStackedWidget" name="right_stack">
               <property name="currentIndex">
-               <number>1</number>
+               <number>0</number>
               </property>
               <widget class="QWidget" name="stick_page">
                <layout class="QVBoxLayout" name="stick_page_layout">


### PR DESCRIPTION
- Fix scrollArea focus during pad settings button choice.
   Assigning arrow keys for keyboard handlers was broken because of this.
- Fix pad settings resize when switching tabs.
   The window was sometimes resizing itself, which led to scrollbar issues. This might still happen in some cases.