### PR TITLE
rsx: Fix depth bounds test

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1094,6 +1094,17 @@ namespace rsx
 						break;
 					}
 				}
+
+				if (depth_buffer_unused) [[unlikely]]
+				{
+					// Check if depth bounds is active. Depth bounds test does NOT need depth test to be enabled to access the Z buffer
+					// Bind Z buffer in read mode for bounds check in this case
+					if (rsx::method_registers.depth_bounds_test_enabled() &&
+						(rsx::method_registers.depth_bounds_min() > 0.f || rsx::method_registers.depth_bounds_max() < 1.f))
+					{
+						depth_buffer_unused = false;
+					}
+				}
 			}
 
 			color_buffer_unused = !color_write_enabled || layout.target == rsx::surface_target::none;


### PR DESCRIPTION
Allow depth bounds test to access the Z buffer even when depth test is disabled. The GPU still requires hardware support for the feature to work correctly.

Fixes https://github.com/RPCS3/rpcs3/issues/7869