### PR TITLE
RSX debugger: fix command count on non-method commands

### DIFF
--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -611,7 +611,7 @@ void rsx_debugger::GetMemory()
 		if (const u32 ea = rsx::get_current_renderer()->iomap_table.get_addr(addr);
 			ea + 1)
 		{
-			u32 cmd = *vm::get_super_ptr<u32>(ea);
+			const u32 cmd = *vm::get_super_ptr<u32>(ea);
 			const u32 count = cmd & RSX_METHOD_NON_METHOD_CMD_MASK ? 0 : (cmd >> 18) & 0x7ff;
 
 			m_list_commands->setItem(i, 1, new QTableWidgetItem(qstr(fmt::format("%08x", cmd))));

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -612,12 +612,7 @@ void rsx_debugger::GetMemory()
 			ea + 1)
 		{
 			u32 cmd = *vm::get_super_ptr<u32>(ea);
-			u32 count = (cmd >> 18) & 0x7ff;
-
-			if (cmd & RSX_METHOD_NON_METHOD_CMD_MASK)
-			{
-				count = 0;
-			}
+			const u32 count = cmd & RSX_METHOD_NON_METHOD_CMD_MASK ? 0 : (cmd >> 18) & 0x7ff;
 
 			m_list_commands->setItem(i, 1, new QTableWidgetItem(qstr(fmt::format("%08x", cmd))));
 			m_list_commands->setItem(i, 2, new QTableWidgetItem(DisAsmCommand(cmd, count, addr)));

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -613,14 +613,16 @@ void rsx_debugger::GetMemory()
 		{
 			u32 cmd = *vm::get_super_ptr<u32>(ea);
 			u32 count = (cmd >> 18) & 0x7ff;
+
+			if (cmd & RSX_METHOD_NON_METHOD_CMD_MASK)
+			{
+				count = 0;
+			}
+
 			m_list_commands->setItem(i, 1, new QTableWidgetItem(qstr(fmt::format("%08x", cmd))));
 			m_list_commands->setItem(i, 2, new QTableWidgetItem(DisAsmCommand(cmd, count, addr)));
 			m_list_commands->setItem(i, 3, new QTableWidgetItem(QString::number(count)));
-
-			if(!(cmd & RSX_METHOD_NON_METHOD_CMD_MASK))
-			{
-				addr += 4 * count;
-			}
+			addr += 4 * count;
 		}
 		else
 		{


### PR DESCRIPTION
Becuase non-methods have no extra arguments their count should be displayed as 0.