### PR TITLE
Squircle

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -101,12 +101,10 @@ protected:
 	// the input values must lie in 0+
 	u16 NormalizeDirectedInput(s32 raw_value, s32 threshold, s32 maximum) const;
 
-	u16 NormalizeStickInput(u16 raw_value, int threshold, int multiplier, bool ignore_threshold = false) const;
-
 	// This function normalizes stick deadzone based on the DS3's deadzone, which is ~13%
 	// X and Y is expected to be in (-255) to 255 range, deadzone should be in terms of thumb stick range
 	// return is new x and y values in 0-255 range
-	std::tuple<u16, u16> NormalizeStickDeadzone(s32 inX, s32 inY, u32 deadzone);
+	std::tuple<u16, u16> NormalizeStickDeadzone(s32 inX, s32 inY, u32 deadzone) const;
 
 	// get clamped value between 0 and 255
 	static u16 Clamp0To255(f32 input);
@@ -143,6 +141,9 @@ public:
 
 	static std::string get_config_dir(pad_handler type, const std::string& title_id = "");
 	static std::string get_config_filename(int i, const std::string& title_id = "");
+
+	u16 NormalizeStickInput(u16 raw_value, int threshold, int multiplier, bool ignore_threshold = false) const;
+	void convert_stick_values(u16& x_out, u16& y_out, const s32& x_in, const s32& y_in, const s32& deadzone, const s32& padsquircling) const;
 
 	virtual bool Init() { return true; }
 	PadHandlerBase(pad_handler type = pad_handler::null);

--- a/rpcs3/Emu/Io/pad_config.h
+++ b/rpcs3/Emu/Io/pad_config.h
@@ -69,7 +69,8 @@ struct pad_config final : cfg::node
 	cfg::_int<0, 1000000> rstickdeadzone{ this, "Right Stick Deadzone", 0 };
 	cfg::_int<0, 1000000> ltriggerthreshold{ this, "Left Trigger Threshold", 0 };
 	cfg::_int<0, 1000000> rtriggerthreshold{ this, "Right Trigger Threshold", 0 };
-	cfg::_int<0, 1000000> padsquircling{ this, "Pad Squircling Factor", 0 };
+	cfg::_int<0, 1000000> lpadsquircling{ this, "Left Pad Squircling Factor", 0 };
+	cfg::_int<0, 1000000> rpadsquircling{ this, "Right Pad Squircling Factor", 0 };
 
 	cfg::_int<0, 255> colorR{ this, "Color Value R", 0 };
 	cfg::_int<0, 255> colorG{ this, "Color Value G", 0 };

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -262,11 +262,12 @@ void ds3_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->l3.def = button_list.at(DS3KeyCodes::L3);
 
 	// Set default misc variables
-	cfg->lstickdeadzone.def = 40; // between 0 and 255
-	cfg->rstickdeadzone.def = 40; // between 0 and 255
+	cfg->lstickdeadzone.def    = 40; // between 0 and 255
+	cfg->rstickdeadzone.def    = 40; // between 0 and 255
 	cfg->ltriggerthreshold.def = 0;  // between 0 and 255
 	cfg->rtriggerthreshold.def = 0;  // between 0 and 255
-	cfg->padsquircling.def = 0;
+	cfg->lpadsquircling.def    = 0;
+	cfg->rpadsquircling.def    = 0;
 
 	// Set color value
 	cfg->colorR.def = 0;

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -171,7 +171,8 @@ void ds4_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->rstickdeadzone.def    = 40; // between 0 and 255
 	cfg->ltriggerthreshold.def = 0;  // between 0 and 255
 	cfg->rtriggerthreshold.def = 0;  // between 0 and 255
-	cfg->padsquircling.def     = 8000;
+	cfg->lpadsquircling.def    = 8000;
+	cfg->rpadsquircling.def    = 8000;
 
 	// Set default color value
 	cfg->colorR.def = 0;

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -84,7 +84,8 @@ void evdev_joystick_handler::init_config(pad_config* cfg, const std::string& nam
 	cfg->rstickdeadzone.def    = 30; // between 0 and 255
 	cfg->ltriggerthreshold.def = 0;  // between 0 and 255
 	cfg->rtriggerthreshold.def = 0;  // between 0 and 255
-	cfg->padsquircling.def     = 5000;
+	cfg->lpadsquircling.def    = 5000;
+	cfg->rpadsquircling.def    = 5000;
 
 	// apply defaults
 	cfg->from_default();
@@ -830,18 +831,11 @@ void evdev_joystick_handler::get_mapping(const std::shared_ptr<PadDevice>& devic
 
 	const auto profile = m_dev->config;
 
-	// Normalize our two stick's axis based on the thresholds
 	u16 lx, ly, rx, ry;
 
-	// Normalize our two stick's axis based on the thresholds
-	std::tie(lx, ly) = NormalizeStickDeadzone(m_dev->stick_val[0], m_dev->stick_val[1], profile->lstickdeadzone);
-	std::tie(rx, ry) = NormalizeStickDeadzone(m_dev->stick_val[2], m_dev->stick_val[3], profile->rstickdeadzone);
-
-	if (profile->padsquircling != 0)
-	{
-		std::tie(lx, ly) = ConvertToSquirclePoint(lx, ly, profile->padsquircling);
-		std::tie(rx, ry) = ConvertToSquirclePoint(rx, ry, profile->padsquircling);
-	}
+	// Normalize and apply pad squircling
+	convert_stick_values(lx, ly, m_dev->stick_val[0], m_dev->stick_val[1], profile->lstickdeadzone, profile->lpadsquircling);
+	convert_stick_values(rx, ry, m_dev->stick_val[2], m_dev->stick_val[3], profile->rstickdeadzone, profile->rpadsquircling);
 
 	pad->m_sticks[0].m_value = lx;
 	pad->m_sticks[1].m_value = 255 - ly;

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -67,7 +67,8 @@ void mm_joystick_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->rstickdeadzone.def    = 0; // between 0 and 255
 	cfg->ltriggerthreshold.def = 0; // between 0 and 255
 	cfg->rtriggerthreshold.def = 0; // between 0 and 255
-	cfg->padsquircling.def     = 8000;
+	cfg->lpadsquircling.def    = 8000;
+	cfg->rpadsquircling.def    = 8000;
 
 	// apply defaults
 	cfg->from_default();

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -117,7 +117,8 @@ void xinput_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->rstickdeadzone.def    = XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE; // between 0 and 32767
 	cfg->ltriggerthreshold.def = XINPUT_GAMEPAD_TRIGGER_THRESHOLD;    // between 0 and 255
 	cfg->rtriggerthreshold.def = XINPUT_GAMEPAD_TRIGGER_THRESHOLD;    // between 0 and 255
-	cfg->padsquircling.def     = 8000;
+	cfg->lpadsquircling.def    = 8000;
+	cfg->rpadsquircling.def    = 8000;
 
 	// apply defaults
 	cfg->from_default();

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1007,7 +1007,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	});
 	connect(pad_configure, &QAction::triggered, [=, this]()
 	{
-		pad_settings_dialog dlg(this, &current_game);
+		pad_settings_dialog dlg(m_gui_settings, this, &current_game);
 
 		if (dlg.exec() == QDialog::Accepted && !gameinfo->hasCustomPadConfig)
 		{

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -112,6 +112,7 @@ namespace gui
 	const QString notes        = "Notes";
 	const QString titles       = "Titles";
 	const QString localization = "Localization";
+	const QString pad_settings = "PadSettings";
 
 	const QColor gl_icon_color = QColor(240, 240, 240, 255);
 
@@ -226,6 +227,8 @@ namespace gui
 	const gui_save um_active_user = gui_save(users, "active_user", "00000001");
 
 	const gui_save loc_language = gui_save(localization, "language", "en");
+
+	const gui_save pads_show_emulated = gui_save(pad_settings, "show_emulated_values", false);
 }
 
 /** Class for GUI settings..

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1530,7 +1530,7 @@ void main_window::CreateConnects()
 
 	auto open_pad_settings = [this]
 	{
-		pad_settings_dialog dlg(this);
+		pad_settings_dialog dlg(m_gui_settings, this);
 		dlg.exec();
 	};
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -881,6 +881,15 @@ void pad_settings_dialog::UpdateLabels(bool is_reset)
 		ui->stick_multi_right->setRange(std::stod(stick_multi_range_right.front()) / 100.0, std::stod(stick_multi_range_right.back()) / 100.0);
 		ui->stick_multi_right->setValue(m_handler_cfg.rstickmultiplier / 100.0);
 
+		// Update Squircle Factors
+		std::vector<std::string> squircle_range_left = m_handler_cfg.lpadsquircling.to_list();
+		ui->squircle_left->setRange(std::stoi(squircle_range_left.front()), std::stoi(squircle_range_left.back()));
+		ui->squircle_left->setValue(m_handler_cfg.lpadsquircling);
+
+		std::vector<std::string> squircle_range_right = m_handler_cfg.rpadsquircling.to_list();
+		ui->squircle_right->setRange(std::stoi(squircle_range_right.front()), std::stoi(squircle_range_right.back()));
+		ui->squircle_right->setValue(m_handler_cfg.rpadsquircling);
+
 		RepaintPreviewLabel(ui->preview_stick_left, ui->slider_stick_left->value(), ui->slider_stick_left->size().width(), lx, ly, m_handler_cfg.lstickmultiplier / 100.0);
 		RepaintPreviewLabel(ui->preview_stick_right, ui->slider_stick_right->value(), ui->slider_stick_right->size().width(), rx, ry, m_handler_cfg.rstickmultiplier / 100.0);
 
@@ -1391,6 +1400,8 @@ void pad_settings_dialog::SaveProfile()
 
 	m_handler_cfg.lstickmultiplier.set(ui->stick_multi_left->value() * 100);
 	m_handler_cfg.rstickmultiplier.set(ui->stick_multi_right->value() * 100);
+	m_handler_cfg.lpadsquircling.set(ui->squircle_left->value());
+	m_handler_cfg.rpadsquircling.set(ui->squircle_right->value());
 
 	if (m_handler->has_rumble())
 	{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -404,6 +404,7 @@ void pad_settings_dialog::InitButtons()
 		}
 
 		cfg_log.notice("get_next_button_press: %s device %s button %s pressed with value %d", m_handler->m_type, pad_name, name, val);
+
 		if (m_button_id > button_ids::id_pad_begin && m_button_id < button_ids::id_pad_end)
 		{
 			m_cfg_entries[m_button_id].key  = name;
@@ -423,6 +424,22 @@ void pad_settings_dialog::InitButtons()
 		if (m_enable_battery)
 		{
 			ui->pb_battery->setValue(0);
+		}
+		if (m_handler->has_deadzones())
+		{
+			ui->preview_trigger_left->setValue(0);
+			ui->preview_trigger_right->setValue(0);
+
+			if (m_lx != 0 || m_ly != 0)
+			{
+				m_lx = 0, m_ly = 0;
+				RepaintPreviewLabel(ui->preview_stick_left, ui->slider_stick_left->value(), ui->slider_stick_left->size().width(), m_lx, m_ly, ui->squircle_left->value(), ui->stick_multi_left->value());
+			}
+			if (m_rx != 0 || m_ry != 0)
+			{
+				m_rx = 0, m_ry = 0;
+				RepaintPreviewLabel(ui->preview_stick_right, ui->slider_stick_right->value(), ui->slider_stick_right->size().width(), m_rx, m_ry, ui->squircle_right->value(), ui->stick_multi_right->value());
+			}
 		}
 	};
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -9,6 +9,7 @@
 #include "Emu/Io/pad_config.h"
 #include "Emu/GameInfo.h"
 
+class gui_settings;
 class PadHandlerBase;
 
 namespace Ui
@@ -87,7 +88,7 @@ class pad_settings_dialog : public QDialog
 	const QString Disconnected_suffix = tr(" (disconnected)");
 
 public:
-	explicit pad_settings_dialog(QWidget *parent = nullptr, const GameInfo *game = nullptr);
+	explicit pad_settings_dialog(std::shared_ptr<gui_settings> gui_settings, QWidget *parent = nullptr, const GameInfo *game = nullptr);
 	~pad_settings_dialog();
 
 public Q_SLOTS:
@@ -105,6 +106,7 @@ private Q_SLOTS:
 private:
 	Ui::pad_settings_dialog *ui;
 	std::string m_title_id;
+	std::shared_ptr<gui_settings> m_gui_settings;
 
 	// Capabilities
 	bool m_enable_buttons{ false };

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -119,10 +119,10 @@ private:
 	std::map<int /*id*/, pad_button /*info*/> m_cfg_entries;
 
 	// Real time stick values
-	int lx = 0;
-	int ly = 0;
-	int rx = 0;
-	int ry = 0;
+	int m_lx = 0;
+	int m_ly = 0;
+	int m_rx = 0;
+	int m_ry = 0;
 
 	// Rumble
 	s32 m_min_force = 0;
@@ -171,7 +171,7 @@ private:
 	void ChangeProfile();
 
 	/** Repaints a stick deadzone preview label */
-	void RepaintPreviewLabel(QLabel* l, int deadzone, int desired_width, int x, int y, double multiplier);
+	void RepaintPreviewLabel(QLabel* l, int deadzone, int desired_width, int x, int y, int squircle, double multiplier);
 
 	std::shared_ptr<PadHandlerBase> GetHandler(pad_handler type);
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -736,13 +736,13 @@
                     <number>5</number>
                    </property>
                    <property name="topMargin">
-                    <number>9</number>
+                    <number>5</number>
                    </property>
                    <property name="rightMargin">
                     <number>5</number>
                    </property>
                    <property name="bottomMargin">
-                    <number>9</number>
+                    <number>5</number>
                    </property>
                    <item>
                     <widget class="QCheckBox" name="chb_vibration_large">
@@ -773,6 +773,47 @@
                    </item>
                   </layout>
                  </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_stick_preview">
+                  <property name="title">
+                   <string>Stick Preview</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_stick_preview_layout">
+                   <property name="leftMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>5</number>
+                   </property>
+                   <item>
+                    <widget class="QCheckBox" name="chb_show_emulated_values">
+                     <property name="text">
+                      <string>Show Emulated Values</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="pad_page_spacer">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
                 </item>
                </layout>
               </widget>

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -2157,6 +2157,84 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QGroupBox" name="gb_squircle">
+                  <property name="title">
+                   <string>Squircle Values</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="layout_squircle">
+                   <property name="leftMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>5</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="label_squircle_left">
+                     <property name="text">
+                      <string>Left</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QSpinBox" name="squircle_left">
+                     <property name="maximum">
+                      <number>1000000</number>
+                     </property>
+                     <property name="singleStep">
+                      <number>1000</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="spacer_squircle_left">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_squircle_right">
+                     <property name="text">
+                      <string>Right</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QSpinBox" name="squircle_right">
+                     <property name="maximum">
+                      <number>1000000</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="spacer_squircle_right">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QGroupBox" name="gb_sticks">
                   <property name="title">
                    <string>Analog Stick Deadzones</string>


### PR DESCRIPTION
- Adds pad squircle params to the pad settings dialog.
- Additionally shows the actual values as they would be sent to the game (red dot).

![image](https://user-images.githubusercontent.com/23019877/87254577-d6b27180-c483-11ea-9fe7-89154e955d1c.png)
