### PR TITLE
Minor fixup after #8501

### DIFF
--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -94,7 +94,7 @@ namespace std
 	{
 		static_assert(sizeof(To) == sizeof(From), "std::bit_cast<>: incompatible type size");
 
-		if constexpr (std::is_same_v<std::remove_const_t<To>, std::remove_const_t<From>> || (std::is_integral_v<From> && std::is_integral_v<To>))
+		if constexpr ((std::is_same_v<std::remove_const_t<To>, std::remove_const_t<From>> && std::is_constructible_v<To, To>) || (std::is_integral_v<From> && std::is_integral_v<To>))
 		{
 			return static_cast<To>(from);
 		}


### PR DESCRIPTION
Check if being able to explicitly construct an object from To type to To type. (assume that is a trivial constructor as std::bit_cast needs)