### PR TITLE
rsx: Brute-force removal of superseded surfaces

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -61,6 +61,9 @@ namespace rsx
 		// List of sections derived from a section that has been split and invalidated
 		std::vector<surface_type> orphaned_surfaces;
 
+		// List of sections that have been wholly inherited and invalidated
+		std::vector<surface_type> superseded_surfaces;
+
 		std::list<surface_storage_type> invalidated_resources;
 		u64 cache_tag = 1ull; // Use 1 as the start since 0 is default tag on new surfaces
 		u64 write_tag = 1ull;
@@ -410,6 +413,7 @@ namespace rsx
 
 					invalidate(object);
 					storage.erase(e.first);
+					superseded_surfaces.push_back(surface);
 				}
 			}
 		}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -329,6 +329,16 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 
 	m_gl_texture_cache.clear_ro_tex_invalidate_intr();
 
+	if (!m_rtts.superseded_surfaces.empty())
+	{
+		for (auto& surface : m_rtts.superseded_surfaces)
+		{
+			m_gl_texture_cache.discard_framebuffer_memory_region(cmd, surface->get_memory_range());
+		}
+
+		m_rtts.superseded_surfaces.clear();
+	}
+
 	const auto color_format = rsx::internals::surface_color_format_to_gl(m_framebuffer_layout.color_format);
 	for (u8 i = 0; i < rsx::limits::color_buffers_count; ++i)
 	{


### PR DESCRIPTION
The existing solution is more elegant but can easily trip on false positives.

Fixes https://github.com/RPCS3/rpcs3/issues/8075