### PR TITLE
SPU: Fixes for LS memory mirrors

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1417,7 +1417,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context) no
 			{
 				const auto& spu = static_cast<spu_thread&>(*cpu);
 
-				const u64 type = spu.offset < RAW_SPU_BASE_ADDR ?
+				const u64 type = spu.get_type() == spu_type::threaded ?
 					SYS_MEMORY_PAGE_FAULT_TYPE_SPU_THREAD :
 					SYS_MEMORY_PAGE_FAULT_TYPE_RAW_SPU;
 

--- a/rpcs3/Emu/Cell/Modules/sys_spu_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_spu_.cpp
@@ -391,7 +391,7 @@ s32 sys_raw_spu_load(s32 id, vm::cptr<char> path, vm::ptr<u32> entry)
 
 	sys_spu_image img;
 	img.load(elf_file);
-	img.deploy(RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * id, img.segs.get_ptr(), img.nsegs);
+	img.deploy(vm::_ptr<u8>(RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * id), img.segs.get_ptr(), img.nsegs);
 	img.free();
 
 	*entry = img.entry_point;
@@ -404,7 +404,7 @@ s32 sys_raw_spu_image_load(ppu_thread& ppu, s32 id, vm::ptr<sys_spu_image> img)
 	sysPrxForUser.warning("sys_raw_spu_image_load(id=%d, img=*0x%x)", id, img);
 
 	// Load SPU segments
-	img->deploy(RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * id, img->segs.get_ptr(), img->nsegs);
+	img->deploy(vm::_ptr<u8>(RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * id), img->segs.get_ptr(), img->nsegs);
 
 	// Use MMIO
 	vm::write32(RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * id + RAW_SPU_PROB_OFFSET + SPU_NPC_offs, img->entry_point);

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1659,8 +1659,8 @@ void spu_recompiler::RDCH(spu_opcode_t op)
 	{
 		const XmmLink& vr = XmmAlloc();
 		c->movzx(*addr, SPU_OFF_8(interrupts_enabled));
-		c->movzx(arg1->r32(), SPU_OFF_8(is_isolated));
-		c->shl(arg1->r32(), 1);
+		c->mov(arg1->r32(), SPU_OFF_32(thread_type));
+		c->and_(arg1->r32(), 2);
 		c->or_(addr->r32(), arg1->r32());
 		c->movd(vr, *addr);
 		c->pslldq(vr, 12);

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -5502,7 +5502,7 @@ public:
 		case SPU_RdMachStat:
 		{
 			res.value = m_ir->CreateZExt(m_ir->CreateLoad(spu_ptr<u8>(&spu_thread::interrupts_enabled)), get_type<u32>());
-			res.value = m_ir->CreateOr(res.value, m_ir->CreateShl(m_ir->CreateZExt(m_ir->CreateLoad(spu_ptr<u8>(&spu_thread::is_isolated)), get_type<u32>()), m_ir->getInt32(1)));
+			res.value = m_ir->CreateOr(res.value, m_ir->CreateAnd(m_ir->CreateLoad(spu_ptr<u32>(&spu_thread::thread_type)), m_ir->getInt32(2)));
 			break;
 		}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1180,7 +1180,7 @@ spu_thread::~spu_thread()
 	}
 
 	// Release LS mirrors area
-	utils::memory_release(ls - SPU_LS_SIZE, SPU_LS_SIZE * 3);
+	utils::memory_release(ls - (SPU_LS_SIZE * 2), SPU_LS_SIZE * 5);
 
 	// Deallocate RawSPU ID
 	if (get_type() >= spu_type::raw)
@@ -1196,9 +1196,9 @@ spu_thread::spu_thread(vm::addr_t _ls, lv2_spu_group* group, u32 index, std::str
 	, ls([&]()
 	{
 		const auto [_, shm] = vm::get(vm::any, _ls)->get(_ls);
-		const auto addr = static_cast<u8*>(utils::memory_reserve(SPU_LS_SIZE * 3));
+		const auto addr = static_cast<u8*>(utils::memory_reserve(SPU_LS_SIZE * 5));
 
-		for (u32 i = 0; i < 3; i++)
+		for (u32 i = 1; i < 4; i++)
 		{
 			// Map LS mirrors
 			const auto ptr = addr + (i * SPU_LS_SIZE);
@@ -1206,7 +1206,7 @@ spu_thread::spu_thread(vm::addr_t _ls, lv2_spu_group* group, u32 index, std::str
 		}
 
 		// Use the middle mirror
-		return addr + SPU_LS_SIZE;
+		return addr + (SPU_LS_SIZE * 2);
 	}())
 	, thread_type(group ? spu_type::threaded : is_isolated ? spu_type::isolated : spu_type::raw)
 	, offset(_ls)

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -533,6 +533,13 @@ public:
 	}
 };
 
+enum class spu_type : u32
+{
+	threaded,
+	raw,
+	isolated,
+};
+
 class spu_thread : public cpu_thread
 {
 public:
@@ -630,7 +637,6 @@ public:
 		u32 npc; // SPU Next Program Counter register
 	};
 
-	const bool is_isolated;
 	atomic_t<status_npc_sync_var> status_npc;
 	std::array<spu_int_ctrl_t, 3> int_ctrl; // SPU Class 0, 1, 2 Interrupt Management
 
@@ -640,9 +646,10 @@ public:
 	atomic_t<u32> last_exit_status; // Value to be written in exit_status after checking group termination
 
 	const u32 index; // SPU index
-	const u32 offset; // SPU LS offset
 	const std::add_pointer_t<u8> ls; // SPU LS pointer 
+	const spu_type thread_type;
 private:
+	const u32 offset; // SPU LS offset
 	lv2_spu_group* const group; // SPU Thread Group (only safe to access in the spu thread itself)
 public:
 	const u32 lv2_id; // The actual id that is used by syscalls
@@ -686,16 +693,21 @@ public:
 
 	// Convert specified SPU LS address to a pointer of specified (possibly converted to BE) type
 	template<typename T>
-	inline to_be_t<T>* _ptr(u32 lsa)
+	to_be_t<T>* _ptr(u32 lsa) const
 	{
 		return reinterpret_cast<to_be_t<T>*>(ls + lsa);
 	}
 
 	// Convert specified SPU LS address to a reference of specified (possibly converted to BE) type
 	template<typename T>
-	inline to_be_t<T>& _ref(u32 lsa)
+	to_be_t<T>& _ref(u32 lsa) const
 	{
 		return *_ptr<T>(lsa);
+	}
+
+	spu_type get_type() const
+	{
+		return thread_type;
 	}
 
 	bool read_reg(const u32 addr, u32& value);

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -108,7 +108,7 @@ void sys_spu_image::free()
 	}
 }
 
-void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
+void sys_spu_image::deploy(u8* loc, sys_spu_segment* segs, u32 nsegs)
 {
 	// Segment info dump
 	std::string dump;
@@ -129,7 +129,7 @@ void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
 		// Hash big-endian values
 		if (seg.type == SYS_SPU_SEGMENT_TYPE_COPY)
 		{
-			std::memcpy(vm::base(loc + seg.ls), vm::base(seg.addr), seg.size);
+			std::memcpy(loc + seg.ls, vm::base(seg.addr), seg.size);
 			sha1_update(&sha, reinterpret_cast<uchar*>(&seg.size), sizeof(seg.size));
 			sha1_update(&sha, reinterpret_cast<uchar*>(&seg.ls), sizeof(seg.ls));
 			sha1_update(&sha, vm::_ptr<uchar>(seg.addr), seg.size);
@@ -141,7 +141,7 @@ void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
 				spu_log.error("Unaligned SPU FILL type segment (ls=0x%x, size=0x%x)", seg.ls, seg.size);
 			}
 
-			std::fill_n(vm::_ptr<u32>(loc + seg.ls), seg.size / 4, seg.addr);
+			std::fill_n(reinterpret_cast<be_t<u32>*>(loc + seg.ls), seg.size / 4, seg.addr);
 			sha1_update(&sha, reinterpret_cast<uchar*>(&seg.size), sizeof(seg.size));
 			sha1_update(&sha, reinterpret_cast<uchar*>(&seg.ls), sizeof(seg.ls));
 			sha1_update(&sha, reinterpret_cast<uchar*>(&seg.addr), sizeof(seg.addr));
@@ -165,12 +165,12 @@ void sys_spu_image::deploy(u32 loc, sys_spu_segment* segs, u32 nsegs)
 	}
 
 	// Apply the patch
-	auto applied = g_fxo->get<patch_engine>()->apply(hash, vm::_ptr<u8>(loc));
+	auto applied = g_fxo->get<patch_engine>()->apply(hash, loc);
 
 	if (!Emu.GetTitleID().empty())
 	{
 		// Alternative patch
-		applied += g_fxo->get<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::_ptr<u8>(loc));
+		applied += g_fxo->get<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, loc);
 	}
 
 	spu_log.notice("Loaded SPU image: %s (<- %u)%s", hash, applied, dump);
@@ -726,7 +726,7 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 			auto& args = group->args[thread->lv2_id >> 24];
 			auto& img = group->imgs[thread->lv2_id >> 24];
 
-			sys_spu_image::deploy(thread->offset, img.second.data(), img.first.nsegs);
+			sys_spu_image::deploy(thread->ls, img.second.data(), img.first.nsegs);
 
 			thread->cpu_init();
 			thread->gpr[3] = v128::from64(0, args[0]);
@@ -1894,7 +1894,7 @@ error_code sys_isolated_spu_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<voi
 	img.load(obj);
 
 	auto image_info = idm::get<lv2_obj, lv2_spu_image>(img.entry_point);
-	img.deploy(ls_addr, image_info->segs.get_ptr(), image_info->nsegs);
+	img.deploy(thread->ls, image_info->segs.get_ptr(), image_info->nsegs);
 
 	thread->write_reg(ls_addr + RAW_SPU_PROB_OFFSET + SPU_NPC_offs, image_info->e_entry);
 	verify(HERE), idm::remove_verify<lv2_obj, lv2_spu_image>(img.entry_point, std::move(image_info));
@@ -1910,7 +1910,7 @@ error_code raw_spu_destroy(ppu_thread& ppu, u32 id)
 
 	auto thread = idm::get<named_thread<spu_thread>>(idm_id, [](named_thread<spu_thread>& thread)
 	{
-		if (thread.is_isolated != isolated)
+		if (thread.get_type() != (isolated ? spu_type::isolated : spu_type::raw))
 		{
 			return false;
 		}
@@ -2014,7 +2014,7 @@ error_code raw_spu_create_interrupt_tag(u32 id, u32 class_id, u32 hwthread, vm::
 
 		auto thread = idm::check_unlocked<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-		if (!thread || *thread == thread_state::aborting || thread->is_isolated != isolated)
+		if (!thread || *thread == thread_state::aborting || thread->get_type() != (isolated ? spu_type::isolated : spu_type::raw))
 		{
 			error = CELL_ESRCH;
 			return result;
@@ -2070,7 +2070,7 @@ error_code raw_spu_set_int_mask(u32 id, u32 class_id, u64 mask)
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (!thread || thread->is_isolated != isolated) [[unlikely]]
+	if (!thread || thread->get_type() != (isolated ? spu_type::isolated : spu_type::raw)) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -2109,7 +2109,7 @@ error_code raw_spu_set_int_stat(u32 id, u32 class_id, u64 stat)
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (!thread || thread->is_isolated != isolated) [[unlikely]]
+	if (!thread || thread->get_type() != (isolated ? spu_type::isolated : spu_type::raw)) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -2147,7 +2147,7 @@ error_code raw_spu_get_int_control(u32 id, u32 class_id, vm::ptr<u64> value, ato
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (!thread || thread->is_isolated != isolated) [[unlikely]]
+	if (!thread || thread->get_type() != (isolated ? spu_type::isolated : spu_type::raw)) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -2198,7 +2198,7 @@ error_code raw_spu_read_puint_mb(u32 id, vm::ptr<u32> value)
 {
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (!thread || thread->is_isolated != isolated) [[unlikely]]
+	if (!thread || thread->get_type() != (isolated ? spu_type::isolated : spu_type::raw)) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -2236,7 +2236,7 @@ error_code raw_spu_set_spu_cfg(u32 id, u32 value)
 
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (!thread || thread->is_isolated != isolated) [[unlikely]]
+	if (!thread || thread->get_type() != (isolated ? spu_type::isolated : spu_type::raw)) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -2269,7 +2269,7 @@ error_code raw_spu_get_spu_cfg(u32 id, vm::ptr<u32> value)
 {
 	const auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(id));
 
-	if (!thread || thread->is_isolated != isolated) [[unlikely]]
+	if (!thread || thread->get_type() != (isolated ? spu_type::isolated : spu_type::raw)) [[unlikely]]
 	{
 		return CELL_ESRCH;
 	}
@@ -2311,6 +2311,6 @@ error_code sys_isolated_spu_start(ppu_thread& ppu, u32 id)
 	}
 
 	// TODO: Can return ESTAT if called twice
-	thread->write_reg(thread->offset + RAW_SPU_PROB_OFFSET + SPU_RunCntl_offs, SPU_RUNCNTL_RUN_REQUEST);
+	thread->write_reg(RAW_SPU_BASE_ADDR + thread->lv2_id * RAW_SPU_OFFSET + RAW_SPU_PROB_OFFSET + SPU_RunCntl_offs, SPU_RUNCNTL_RUN_REQUEST);
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -222,7 +222,7 @@ struct sys_spu_image
 
 	void load(const fs::file& stream);
 	void free();
-	static void deploy(u32 loc, sys_spu_segment* segs, u32 nsegs);
+	static void deploy(u8* loc, sys_spu_segment* segs, u32 nsegs);
 };
 
 enum : u32

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -63,8 +63,8 @@ void breakpoint_list::AddBreakpoint(u32 pc)
 	m_breakpoint_handler->AddBreakpoint(pc);
 
 	const auto cpu = this->cpu.lock();
-	const u32 cpu_offset = cpu->id_type() != 1 ? static_cast<spu_thread&>(*cpu).offset : 0;
-	m_disasm->offset = vm::_ptr<u8>(cpu_offset);
+	const auto cpu_offset = cpu->id_type() != 1 ? static_cast<spu_thread&>(*cpu).ls : vm::g_sudo_addr;
+	m_disasm->offset = cpu_offset;
 
 	m_disasm->disasm(m_disasm->dump_pc = pc);
 

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.h
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.h
@@ -15,7 +15,7 @@ class instruction_editor_dialog : public QDialog
 
 private:
 	u32 m_pc;
-	u32 m_cpu_offset;
+	u8* m_cpu_offset;
 	CPUDisAsm* m_disasm;
 	QLineEdit* m_instr;
 	QLabel* m_preview;

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -471,18 +471,7 @@ void kernel_explorer::Update()
 
 	idm::select<named_thread<spu_thread>>([&](u32 /*id*/, spu_thread& spu)
 	{
-		std::string_view type = "threaded";
-
-		if (spu.is_isolated)
-		{
-			type = "isolated";
-		}
-		else if (spu.offset >= RAW_SPU_BASE_ADDR)
-		{
-			type = "raw";
-		}
-
-		add_leaf(find_node(m_tree, additional_nodes::spu_threads), qstr(fmt::format(u8"SPU 0x%07x: “%s”, State: %s, Type: %s", spu.lv2_id, *spu.spu_tname.load(), spu.state.load(), type)));
+		add_leaf(find_node(m_tree, additional_nodes::spu_threads), qstr(fmt::format(u8"SPU 0x%07x: “%s”, State: %s, Type: %s", spu.lv2_id, *spu.spu_tname.load(), spu.state.load(), spu.get_type())));
 	});
 
 	idm::select<lv2_spu_group>([&](u32 id, lv2_spu_group& tg)


### PR DESCRIPTION
* Hotfix for some versions of Linux which do not ensure 64k aligned allocations by non-fixed mmap after #8592.
* Fix a corner case where utils::shm::unmap_critical breaks virtual allocations on Windows.
* Make spu_thread::offset a private member, all LS accesses are going through spu_thread::_ptr<>() except in DMA transfers and MMIO.