### PR TITLE
PPU/PPU LLVM: Handle the results of VMADDFP, VNMSUBFP, truncate subno…

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -394,7 +394,7 @@ inline v128 vec_select_nan(v128 a, v128 b, Args... args)
 	return vec_select_nan(a, vec_select_nan(b, args...));
 }
 
-// Trunc denormal/subnormal values (-FLT_MIN, FLT_MIN) to 0
+// Trunc denormal/subnormal values (-FLT_MIN, FLT_MIN) to +0
 // VREFP always generates infinity giving a denormal value,
 // that causes subsequent VMADDFP/VNMSUBFP generates NaN instead of correct value.
 //

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -12,6 +12,13 @@
 #include <bit>
 #include <cmath>
 
+
+#if defined(_MSC_VER)
+#define AVX_FUNC
+#else
+#define AVX_FUNC __attribute__((__target__("avx")))
+#endif
+
 #if !defined(_MSC_VER) && defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
@@ -363,6 +370,10 @@ constexpr u32 ppu_nan_u32 = 0x7FC00000u;
 static const f32 ppu_nan_f32 = std::bit_cast<f32>(ppu_nan_u32);
 static const v128 ppu_vec_nans = v128::from32p(ppu_nan_u32);
 
+
+static const auto ZERO_M128 = _mm_set1_ps(0.0f);
+static const auto SUBNORMAL_MASK    = _mm_set1_epi32(0x7f800000u);
+
 // NaNs production precedence: NaN from Va, Vb, Vc
 // and lastly the result of the operation in case none of the operands is a NaN
 // Signaling NaNs are 'quieted' (MSB of fraction is set) with other bits of data remain the same
@@ -381,6 +392,17 @@ template <typename... Args>
 inline v128 vec_select_nan(v128 a, v128 b, Args... args)
 {
 	return vec_select_nan(a, vec_select_nan(b, args...));
+}
+
+// Trunc denormal/subnormal values (-FLT_MIN, FLT_MIN) to 0
+// VREFP always generates infinity giving a denormal value,
+// that causes subsequent VMADDFP/VNMSUBFP generates NaN instead of correct value.
+//
+extern AVX_FUNC __m128 vec_handle_subnormal(__m128 result)
+{
+	const auto val_ge_zero     = _mm_and_si128(_mm_castps_si128(result), SUBNORMAL_MASK);
+	const auto val_cmp_fltmin  = _mm_cmp_ps(_mm_castsi128_ps(val_ge_zero), ZERO_M128, _CMP_GT_OQ);
+	return _mm_and_ps(result, val_cmp_fltmin);
 }
 
 v128 vec_handle_nan(v128 result)
@@ -961,8 +983,8 @@ bool ppu_interpreter_fast::VMADDFP(ppu_thread& ppu, ppu_opcode_t op)
 	const auto a = ppu.vr[op.va].vf;
 	const auto b = ppu.vr[op.vb].vf;
 	const auto c = ppu.vr[op.vc].vf;
-	const auto result = _mm_add_ps(_mm_mul_ps(a, c), b);
-	ppu.vr[op.vd] = vec_handle_nan(result);
+	auto result = _mm_add_ps(_mm_mul_ps(a, c), b);	
+	ppu.vr[op.vd] = vec_handle_nan(vec_handle_subnormal(result));
 	return true;
 }
 
@@ -971,7 +993,9 @@ bool ppu_interpreter_precise::VMADDFP(ppu_thread& ppu, ppu_opcode_t op)
 	const auto a = ppu.vr[op.va];
 	const auto b = ppu.vr[op.vb];
 	const auto c = ppu.vr[op.vc];
-	ppu.vr[op.rd] = vec_handle_nan(v128::fma32f(a, c, b), a, b, c);
+	auto result = v128::fma32f(a, c, b);
+	result.vf    = vec_handle_subnormal(result.vf);
+	ppu.vr[op.rd] = vec_handle_nan(result, a, b, c);
 	return true;
 }
 
@@ -1462,7 +1486,7 @@ bool ppu_interpreter_fast::VNMSUBFP(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto a = _mm_sub_ps(_mm_mul_ps(ppu.vr[op.va].vf, ppu.vr[op.vc].vf), ppu.vr[op.vb].vf);
 	const auto b = _mm_set1_ps(-0.0f);
-	const auto result = _mm_xor_ps(a, b);
+	const auto result = vec_handle_subnormal(_mm_xor_ps(a, b));
 	ppu.vr[op.vd] = vec_handle_nan(result, a, b);
 	return true;
 }
@@ -1473,7 +1497,7 @@ bool ppu_interpreter_precise::VNMSUBFP(ppu_thread& ppu, ppu_opcode_t op)
 	const auto a = ppu.vr[op.va];
 	const auto c = ppu.vr[op.vc];
 	const auto b = v128::fromF(_mm_xor_ps(ppu.vr[op.vb].vf, m));
-	const auto r = v128::fromF(_mm_xor_ps(v128::fma32f(a, c, b).vf, m));
+	const auto r = v128::fromF(vec_handle_subnormal(_mm_xor_ps(v128::fma32f(a, c, b).vf, m)));
 	ppu.vr[op.rd] = vec_handle_nan(r, a, b, c);
 	return true;
 }

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -12,6 +12,13 @@
 #include <bit>
 #include <cmath>
 
+
+#if defined(_MSC_VER)
+#define AVX_FUNC
+#else
+#define AVX_FUNC __attribute__((__target__("avx")))
+#endif
+
 #if !defined(_MSC_VER) && defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
@@ -363,6 +370,11 @@ constexpr u32 ppu_nan_u32 = 0x7FC00000u;
 static const f32 ppu_nan_f32 = std::bit_cast<f32>(ppu_nan_u32);
 static const v128 ppu_vec_nans = v128::from32p(ppu_nan_u32);
 
+
+static const auto ZERO_M128 = _mm_set1_ps(0.0f);
+static const auto SUBNORMAL_MASK = _mm_set1_epi32(0x7f800000u);
+static const auto SIGN_MASK = _mm_set1_epi32(0x80000000u);
+
 // NaNs production precedence: NaN from Va, Vb, Vc
 // and lastly the result of the operation in case none of the operands is a NaN
 // Signaling NaNs are 'quieted' (MSB of fraction is set) with other bits of data remain the same
@@ -381,6 +393,18 @@ template <typename... Args>
 inline v128 vec_select_nan(v128 a, v128 b, Args... args)
 {
 	return vec_select_nan(a, vec_select_nan(b, args...));
+}
+
+// Flush denormal/subnormal values (-FLT_MIN, FLT_MIN) to 0
+// Fix issue #6296
+extern AVX_FUNC __m128 vec_handle_subnormal(__m128 result)
+{
+	const auto val_ge_zero     = _mm_and_si128(_mm_castps_si128(result), SUBNORMAL_MASK);
+	const auto sign_flag      = _mm_and_si128(_mm_castps_si128(result), SIGN_MASK);
+	const auto val_cmp_fltmin  = _mm_cmp_ps(_mm_castsi128_ps(val_ge_zero), ZERO_M128, _CMP_GT_OQ);
+	result = _mm_and_ps(result, val_cmp_fltmin);
+	result = _mm_castsi128_ps(_mm_or_si128(_mm_castps_si128(result), sign_flag));
+	return result;
 }
 
 v128 vec_handle_nan(v128 result)
@@ -958,28 +982,22 @@ bool ppu_interpreter::VLOGEFP(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter_fast::VMADDFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	// Set FTZ (Flush denormals to zero) to 1, fix issue #6296
-	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 	const auto a = ppu.vr[op.va].vf;
 	const auto b = ppu.vr[op.vb].vf;
 	const auto c = ppu.vr[op.vc].vf;
-	const auto result = _mm_add_ps(_mm_mul_ps(a, c), b);
-	ppu.vr[op.vd] = vec_handle_nan(result);
-	// Restore FTZ
-	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
+	auto result = _mm_add_ps(_mm_mul_ps(a, c), b);
+	ppu.vr[op.vd] = vec_handle_nan(vec_handle_subnormal(result));
 	return true;
 }
 
 bool ppu_interpreter_precise::VMADDFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	// Set FTZ (Flush denormals to zero) to 1, fix issue #6296
-	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 	const auto a = ppu.vr[op.va];
 	const auto b = ppu.vr[op.vb];
 	const auto c = ppu.vr[op.vc];
-	ppu.vr[op.rd] = vec_handle_nan(v128::fma32f(a, c, b), a, b, c);
-	// Restore FTZ
-	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
+	auto result = v128::fma32f(a, c, b);
+	result.vf = vec_handle_subnormal(result.vf);
+	ppu.vr[op.rd] = vec_handle_nan(result, a, b, c);
 	return true;
 }
 
@@ -1468,29 +1486,21 @@ bool ppu_interpreter::VMULOUH(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter_fast::VNMSUBFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	// Set FTZ (Flush denormals to zero) to 1, fix issue #6296
-	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 	const auto a = _mm_sub_ps(_mm_mul_ps(ppu.vr[op.va].vf, ppu.vr[op.vc].vf), ppu.vr[op.vb].vf);
 	const auto b = _mm_set1_ps(-0.0f);
-	const auto result = _mm_xor_ps(a, b);
+	const auto result = vec_handle_subnormal(_mm_xor_ps(a, b));
 	ppu.vr[op.vd] = vec_handle_nan(result, a, b);
-	// Restore FTZ
-	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
 	return true;
 }
 
 bool ppu_interpreter_precise::VNMSUBFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	// Set FTZ (Flush denormals to zero) to 1, fix issue #6296
-	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 	const auto m = _mm_set1_ps(-0.0f);
 	const auto a = ppu.vr[op.va];
 	const auto c = ppu.vr[op.vc];
 	const auto b = v128::fromF(_mm_xor_ps(ppu.vr[op.vb].vf, m));
-	const auto r = v128::fromF(_mm_xor_ps(v128::fma32f(a, c, b).vf, m));
+	const auto r = v128::fromF(vec_handle_subnormal(_mm_xor_ps(v128::fma32f(a, c, b).vf, m)));
 	ppu.vr[op.rd] = vec_handle_nan(r, a, b, c);
-	// Restore FTZ
-	_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -223,7 +223,7 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 }
 
 
-// Trunc denormal/subnormal values (-FLT_MIN, FLT_MIN) to 0
+// Trunc denormal/subnormal values (-FLT_MIN, FLT_MIN) to +0
 // VREFP always generates infinity giving a denormal value,
 // that causes subsequent VMADDFP/VNMSUBFP generates NaN instead of correct value.
 //

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -223,10 +223,8 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 }
 
 
-// Trunc denormal/subnormal values (-FLT_MIN, FLT_MIN) to +0
-// VREFP always generates infinity giving a denormal value,
-// that causes subsequent VMADDFP/VNMSUBFP generates NaN instead of correct value.
-//
+// Explicitly emits codes for flushing denormal/subnormal numbers (-FLT_MIN, FLT_MIN) to 0 
+// TODO: Emits LLVM FTZ flag instead
 Value* PPUTranslator::VecHandleSubnormal(Value* val)
 {
 	const auto zero_vec4 = ConstantVector::getSplat(4, ConstantInt::get(GetType<u32>(), 0u));

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -103,6 +103,8 @@ public:
 
 	llvm::Value* VecHandleNan(llvm::Value* val);
 
+	llvm::Value* VecHandleSubnormal(llvm::Value* val);
+
 	template <typename T>
 	auto vec_handle_nan(T&& expr)
 	{


### PR DESCRIPTION
…rmal/denormal numbers (-FLT_MIN, FLT_MIN) to 0.

The PR fixes PPU Trap errors issued by isNaN/isInf() checks which often used in Naughty Dog games [#6296](https://github.com/RPCS3/rpcs3/issues/6296).

ND games use the code like following which might do the camera control:
```
                 stfs      f1, 0x150+var_C0(r1)
                 vrefp   %vr1, %vr29
                 lvewx   %vr0, r1, r28
                 lfs       f13, -0x7F90(r30)
                 vperm   %vr0, %vr27, %vr0, %vr30
                 vspltw  %vr0, %vr0, 0
                 vmaddfp %vr12, %vr31, %vr0, %vr27
                 vnmsubfp %vr13, %vr1, %vr29, %vr24
                 vcmpgtfp. %vr0, %vr12, %vr29
                 vmaddfp %vr1, %vr13, %vr1, %vr1
                 bge       cr6, loc_92CFA0
                 vsldoi  %vr29, %vr12, %vr12, 0
		 vmaddfp %vr0, %vr1, %vr29, %vr27
		 li        r0, 0x70
		 stvx    %vr0, r1, r0
```
If the value of `vr29` is a small subnormal(denomalized) value, the `vrefp` generates an infinity. Subsequent instructions:  vnmsubfp `%vr13, %vr1, %vr29, %vr24` &  `vmaddfp %vr0, %vr1, %vr29, %vr27` generate infinity as well instead of the value: `%vr24-1` & `1-%vr27`. That cause a PPU trap error and emulator crash.
The PR addresses `VMADDFP` & `VNMSUBFP` instructions those results can be underflow and truncate to zero to fix the issue.
The PR might cause a little bit performance drop though I have optimized the code with SIMD and only handles two instructions.


