### PR TITLE
CMake: Make Wayland deselectable (enabled as default)

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -300,13 +300,15 @@ if(USE_VULKAN)
 		target_link_libraries(3rdparty_vulkan INTERFACE SPIRV SPIRV-Tools-opt Vulkan::Vulkan)
 
 		if(UNIX AND NOT APPLE)
-			find_package(Wayland)
-			if (WAYLAND_FOUND)
-				target_include_directories(3rdparty_vulkan
-					INTERFACE ${WAYLAND_INCLUDE_DIR})
+			if(USE_WAYLAND)
+				find_package(Wayland)
+				if (WAYLAND_FOUND)
+					target_include_directories(3rdparty_vulkan
+						INTERFACE ${WAYLAND_INCLUDE_DIR})
 
-				target_compile_definitions(3rdparty_vulkan
-					INTERFACE -DVK_USE_PLATFORM_WAYLAND_KHR)
+					target_compile_definitions(3rdparty_vulkan
+						INTERFACE -DVK_USE_PLATFORM_WAYLAND_KHR)
+				endif()
 			endif()
 		endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(USE_LIBEVDEV "libevdev-based joystick support" ON)
 option(USE_DISCORD_RPC "Discord rich presence integration" ON)
 option(USE_SYSTEM_ZLIB "Prefer system ZLIB instead of the builtin one" ON)
 option(USE_VULKAN "Vulkan render backend" ON)
+option(USE_WAYLAND "Wayland compositor support" ON)
 option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/rpcs3/cmake_modules")


### PR DESCRIPTION
There's a quirky edge case where enough packages are installed for WAYLAND_FOUND to be true, while it's not enough for the Vulkan renderer to link against, causing a build failure in front of the finish line. The CMake option USE_WAYLAND to toggle Wayland compositor compatibility sidesteps this issue, while not negatively affecting regular builds.

Thanks to Ani and Jotain from the official Discord!