### PR TITLE
PPU Precise/LLVM: Support NJ modes

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -359,6 +359,8 @@ public:
 }
 const g_ppu_scale_table;
 
+constexpr u32 ppu_inf_u32 = 0x7F800000u;
+static const f32 ppu_inf_f32 = std::bit_cast<f32>(ppu_inf_u32);
 constexpr u32 ppu_nan_u32 = 0x7FC00000u;
 static const f32 ppu_nan_f32 = std::bit_cast<f32>(ppu_nan_u32);
 static const v128 ppu_vec_nans = v128::from32p(ppu_nan_u32);
@@ -403,6 +405,14 @@ v128 vec_handle_nan(__m128 result, Args... args)
 	return vec_handle_nan(v128::fromF(result), v128::fromF(args)...);
 }
 
+// Flush denormals to zero if NJ is 1
+inline v128 vec_handle_denormal(ppu_thread& ppu, v128 a)
+{
+	const auto mask = v128::from32p(ppu.jm_mask);
+	const auto nz = v128::fromV(_mm_srli_epi32(v128::eq32(mask & a, v128{}).vi, 1));
+	return v128::andnot(nz, a);
+}
+
 bool ppu_interpreter::MFVSCR(ppu_thread& ppu, ppu_opcode_t op)
 {
 	ppu.vr[op.vd] = v128::from32(0, 0, 0, u32{ppu.sat} | (u32{ppu.nj} << 16));
@@ -414,6 +424,7 @@ bool ppu_interpreter::MTVSCR(ppu_thread& ppu, ppu_opcode_t op)
 	const u32 vscr = ppu.vr[op.vb]._u32[3];
 	ppu.sat = (vscr & 1) != 0;
 	ppu.nj  = (vscr & 0x10000) != 0;
+	ppu.jm_mask = ppu.nj ? ppu_inf_u32 : 0x7fff'ffff;
 	return true;
 }
 
@@ -427,10 +438,10 @@ bool ppu_interpreter::VADDCUW(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::VADDFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const auto a = ppu.vr[op.va];
-	const auto b = ppu.vr[op.vb];
+	const auto a = vec_handle_denormal(ppu, ppu.vr[op.va]);
+	const auto b = vec_handle_denormal(ppu, ppu.vr[op.vb]);
 	const auto result = v128::addfs(a, b);
-	ppu.vr[op.vd] = vec_handle_nan(result, a, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(result, a, b));
 	return true;
 }
 
@@ -958,26 +969,26 @@ bool ppu_interpreter::VLOGEFP(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter_fast::VMADDFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const auto a = ppu.vr[op.va].vf;
-	const auto b = ppu.vr[op.vb].vf;
-	const auto c = ppu.vr[op.vc].vf;
+	const auto a = vec_handle_denormal(ppu, ppu.vr[op.va]).vf;
+	const auto b = vec_handle_denormal(ppu, ppu.vr[op.vb]).vf;
+	const auto c = vec_handle_denormal(ppu, ppu.vr[op.vc]).vf;
 	const auto result = _mm_add_ps(_mm_mul_ps(a, c), b);
-	ppu.vr[op.vd] = vec_handle_nan(result);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(result));
 	return true;
 }
 
 bool ppu_interpreter_precise::VMADDFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const auto a = ppu.vr[op.va];
-	const auto b = ppu.vr[op.vb];
-	const auto c = ppu.vr[op.vc];
-	ppu.vr[op.rd] = vec_handle_nan(v128::fma32f(a, c, b), a, b, c);
+	const auto a = vec_handle_denormal(ppu, ppu.vr[op.va]);
+	const auto b = vec_handle_denormal(ppu, ppu.vr[op.vb]);
+	const auto c = vec_handle_denormal(ppu, ppu.vr[op.vc]);
+	ppu.vr[op.rd] = vec_handle_denormal(ppu, vec_handle_nan(v128::fma32f(a, c, b), a, b, c));
 	return true;
 }
 
 bool ppu_interpreter::VMAXFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	ppu.vr[op.vd] = vec_handle_nan(_mm_max_ps(ppu.vr[op.va].vf, ppu.vr[op.vb].vf));
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(_mm_max_ps(ppu.vr[op.va].vf, ppu.vr[op.vb].vf)));
 	return true;
 }
 
@@ -1123,7 +1134,7 @@ bool ppu_interpreter::VMINFP(ppu_thread& ppu, ppu_opcode_t op)
 	const auto a = ppu.vr[op.va].vf;
 	const auto b = ppu.vr[op.vb].vf;
 	const auto result = _mm_or_ps(_mm_min_ps(a, b), _mm_min_ps(b, a));
-	ppu.vr[op.vd] = vec_handle_nan(result, a, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(result, a, b));
 	return true;
 }
 
@@ -1463,18 +1474,18 @@ bool ppu_interpreter_fast::VNMSUBFP(ppu_thread& ppu, ppu_opcode_t op)
 	const auto a = _mm_sub_ps(_mm_mul_ps(ppu.vr[op.va].vf, ppu.vr[op.vc].vf), ppu.vr[op.vb].vf);
 	const auto b = _mm_set1_ps(-0.0f);
 	const auto result = _mm_xor_ps(a, b);
-	ppu.vr[op.vd] = vec_handle_nan(result, a, b);
+	ppu.vr[op.vd] = vec_handle_nan(result);
 	return true;
 }
 
 bool ppu_interpreter_precise::VNMSUBFP(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto m = _mm_set1_ps(-0.0f);
-	const auto a = ppu.vr[op.va];
-	const auto c = ppu.vr[op.vc];
+	const auto a = vec_handle_denormal(ppu, ppu.vr[op.va]);
+	const auto c = vec_handle_denormal(ppu, ppu.vr[op.vc]);
 	const auto b = v128::fromF(_mm_xor_ps(ppu.vr[op.vb].vf, m));
 	const auto r = v128::fromF(_mm_xor_ps(v128::fma32f(a, c, b).vf, m));
-	ppu.vr[op.rd] = vec_handle_nan(r, a, b, c);
+	ppu.vr[op.rd] = vec_handle_denormal(ppu, vec_handle_nan(r, a, b, c));
 	return true;
 }
 
@@ -1874,15 +1885,15 @@ bool ppu_interpreter_precise::VPKUWUS(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::VREFP(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto a = _mm_set_ps(1.0f, 1.0f, 1.0f, 1.0f);
-	const auto b = ppu.vr[op.vb].vf;
+	const auto b = vec_handle_denormal(ppu, ppu.vr[op.vb]).vf;
 	const auto result = _mm_div_ps(a, b);
-	ppu.vr[op.vd] = vec_handle_nan(result, a, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(result, a, b));
 	return true;
 }
 
 bool ppu_interpreter::VRFIM(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const auto b = ppu.vr[op.vb];
+	const auto b = vec_handle_denormal(ppu, ppu.vr[op.vb]);
 	v128 d;
 
 	for (uint w = 0; w < 4; w++)
@@ -1890,7 +1901,7 @@ bool ppu_interpreter::VRFIM(ppu_thread& ppu, ppu_opcode_t op)
 		d._f[w] = std::floor(b._f[w]);
 	}
 
-	ppu.vr[op.vd] = vec_handle_nan(d, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(d, b));
 	return true;
 }
 
@@ -1904,13 +1915,13 @@ bool ppu_interpreter::VRFIN(ppu_thread& ppu, ppu_opcode_t op)
 		d._f[w] = std::nearbyint(b._f[w]);
 	}
 
-	ppu.vr[op.vd] = vec_handle_nan(d, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(d, b));
 	return true;
 }
 
 bool ppu_interpreter::VRFIP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const auto b = ppu.vr[op.vb];
+	const auto b = vec_handle_denormal(ppu, ppu.vr[op.vb]);
 	v128 d;
 
 	for (uint w = 0; w < 4; w++)
@@ -1918,7 +1929,7 @@ bool ppu_interpreter::VRFIP(ppu_thread& ppu, ppu_opcode_t op)
 		d._f[w] = std::ceil(b._f[w]);
 	}
 
-	ppu.vr[op.vd] = vec_handle_nan(d, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(d, b));
 	return true;
 }
 
@@ -1932,7 +1943,7 @@ bool ppu_interpreter::VRFIZ(ppu_thread& ppu, ppu_opcode_t op)
 		d._f[w] = std::truncf(b._f[w]);
 	}
 
-	ppu.vr[op.vd] = vec_handle_nan(d, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(d, b));
 	return true;
 }
 
@@ -1978,9 +1989,9 @@ bool ppu_interpreter::VRLW(ppu_thread& ppu, ppu_opcode_t op)
 bool ppu_interpreter::VRSQRTEFP(ppu_thread& ppu, ppu_opcode_t op)
 {
 	const auto a = _mm_set_ps(1.0f, 1.0f, 1.0f, 1.0f);
-	const auto b = ppu.vr[op.vb].vf;
+	const auto b = vec_handle_denormal(ppu, ppu.vr[op.vb]).vf;
 	const auto result = _mm_div_ps(a, _mm_sqrt_ps(b));
-	ppu.vr[op.vd] = vec_handle_nan(result, a, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(result, a, b));
 	return true;
 }
 
@@ -2277,10 +2288,10 @@ bool ppu_interpreter::VSUBCUW(ppu_thread& ppu, ppu_opcode_t op)
 
 bool ppu_interpreter::VSUBFP(ppu_thread& ppu, ppu_opcode_t op)
 {
-	const auto a = ppu.vr[op.va];
-	const auto b = ppu.vr[op.vb];
+	const auto a = vec_handle_denormal(ppu, ppu.vr[op.va]);
+	const auto b = vec_handle_denormal(ppu, ppu.vr[op.vb]);
 	const auto result = v128::subfs(a, b);
-	ppu.vr[op.vd] = vec_handle_nan(result, a, b);
+	ppu.vr[op.vd] = vec_handle_denormal(ppu, vec_handle_nan(result, a, b));
 	return true;
 }
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1613,6 +1613,7 @@ extern void ppu_initialize(const ppu_module& info)
 				non_win32,
 				accurate_fma,
 				accurate_ppu_vector_nan,
+				java_mode_handling,
 
 				__bitset_enum_max
 			};
@@ -1629,6 +1630,10 @@ extern void ppu_initialize(const ppu_module& info)
 			if (g_cfg.core.llvm_ppu_accurate_vector_nan)
 			{
 				settings += ppu_settings::accurate_ppu_vector_nan;
+			}
+			if (g_cfg.core.llvm_ppu_jm_handling)
+			{
+				settings += ppu_settings::java_mode_handling;
 			}
 
 			// Write version, hash, CPU, settings

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -186,7 +186,10 @@ public:
 			exception, the corresponding element in the target vr is cleared to '0'. In both cases, the '0'
 			has the same sign as the denormalized or underflowing value.
 	*/
-	bool nj = false;
+	bool nj = true;
+
+	// Optimization: precomputed java-mode mask for handling denormals
+	u32 jm_mask = 0x7f80'0000;
 
 	u32 raddr{0}; // Reservation addr
 	u64 rtime{0};

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -52,9 +52,9 @@ class PPUTranslator final : public cpu_translator
 
 	llvm::Value* m_mtocr_table{};
 
-	llvm::Value* m_globals[173];
+	llvm::Value* m_globals[175];
 	llvm::Value** const m_g_cr = m_globals + 99;
-	llvm::Value* m_locals[173];
+	llvm::Value* m_locals[175];
 	llvm::Value** const m_gpr = m_locals + 3;
 	llvm::Value** const m_fpr = m_locals + 35;
 	llvm::Value** const m_vr = m_locals + 67;
@@ -77,6 +77,7 @@ class PPUTranslator final : public cpu_translator
 	DEF_VALUE(m_cnt, m_g_cnt, 170) // XER.CNT
 	DEF_VALUE(m_sat, m_g_sat, 171) // VSCR.SAT bit, sticky saturation flag
 	DEF_VALUE(m_nj, m_g_nj, 172) // VSCR.NJ bit, non-Java mode
+	DEF_VALUE(m_jm_mask, m_g_jm_mask, 174) // Java-Mode helper mask
 
 #undef DEF_VALUE
 public:
@@ -102,15 +103,14 @@ public:
 	}
 
 	llvm::Value* VecHandleNan(llvm::Value* val);
+	llvm::Value* VecHandleDenormal(llvm::Value* val);
+	llvm::Value* VecHandleResult(llvm::Value* val);
 
 	template <typename T>
-	auto vec_handle_nan(T&& expr)
+	auto vec_handle_result(T&& expr)
 	{
 		value_t<typename T::type> result;
-		if (g_cfg.core.llvm_ppu_accurate_vector_nan)
-			result.value = VecHandleNan(expr.eval(m_ir));
-		else
-			result.value = expr.eval(m_ir);
+		result.value = VecHandleResult(expr.eval(m_ir));
 		return result;
 	}
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -52,6 +52,7 @@ struct cfg_root : cfg::node
 		cfg::_bool spu_accurate_xfloat{ this, "Accurate xfloat", false };
 		cfg::_bool spu_approx_xfloat{ this, "Approximate xfloat", true };
 		cfg::_bool llvm_accurate_dfma{ this, "LLVM Accurate DFMA", true }; // Enable accurate double-precision FMA for CPUs which do not support it natively
+		cfg::_bool llvm_ppu_jm_handling{ this, "PPU LLVM Java Mode Handling", false }; // Respect current Java Mode for alti-vec ops by PPU LLVM 
 		cfg::_bool llvm_ppu_accurate_vector_nan{ this, "PPU LLVM Accurate Vector NaN values", false };
 		cfg::_int<-64, 64> stub_ppu_traps{ this, "Stub PPU Traps", 0, true }; // Hack, skip PPU traps for rare cases where the trap is continueable (specify relative instructions to skip)
 


### PR DESCRIPTION
Support enabled Non-Java mode, which originally behaves like FTZ (Flush-To-Zero) and DAZ (Denormals-Are-Zero) both enabled on x86.
On PPU Precise Interpreter both FTZ and DAZ alike behaviours are implemented without changing any setting.
On PPU LLVM only FTZ alike behaviour is supported due to serious needs of optimizations for DAZ alike behaviours, this is not enabled by default and you need the "PPU LLVM Java Mode Handling" setting to be set to true in config file.
I recommend testing this pull request with precise interpreter.

Misc:
Fixes "PPU LLVM Accurate Vector NaN values" to actually respect the settings' value on LLVM which previously was unconditionally enabled in most cases, so if you want to test PPU LLVM you may need to enable this setting as it was unconditionally enabled on master.

Fixes #6296