### PR TITLE
vk: Improve video memory management

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -660,49 +660,6 @@ namespace rsx
 				std::forward<Args>(extra_params)...);
 		}
 
-		bool check_memory_overload(u64 max_safe_memory) const
-		{
-			if (m_active_memory_used <= max_safe_memory) [[likely]]
-			{
-				return false;
-			}
-			else
-			{
-				rsx_log.warning("Surface cache is using too much memory! (%dM)", m_active_memory_used / 0x100000);
-				return true;
-			}
-		}
-
-		void handle_memory_overload(command_list_type cmd)
-		{
-			auto process_list_function = [&](std::unordered_map<u32, surface_storage_type>& data)
-			{
-				for (auto It = data.begin(); It != data.end();)
-				{
-					auto surface = Traits::get(It->second);
-					if (surface->dirty())
-					{
-						// Force memory barrier to release some resources
-						surface->memory_barrier(cmd, rsx::surface_access::read);
-					}
-					else if (!surface->test())
-					{
-						// Remove this
-						invalidate(It->second);
-						It = data.erase(It);
-					}
-					else
-					{
-						++It;
-					}
-				}
-			};
-
-			// Try and find old surfaces to remove
-			process_list_function(m_render_targets_storage);
-			process_list_function(m_depth_stencil_storage);
-		}
-
 	public:
 		/**
 		 * Update bound color and depth surface.
@@ -1121,6 +1078,53 @@ namespace rsx
 					ds.second->state_flags |= rsx::surface_state_flags::erase_bkgnd;
 				}
 			}
+		}
+
+		bool check_memory_usage(u64 max_safe_memory) const
+		{
+			if (m_active_memory_used <= max_safe_memory) [[likely]]
+			{
+				return false;
+			}
+			else
+			{
+				rsx_log.warning("Surface cache is using too much memory! (%dM)", m_active_memory_used / 0x100000);
+				return true;
+			}
+		}
+
+		bool handle_memory_pressure(command_list_type cmd, problem_severity /*severity*/)
+		{
+			auto process_list_function = [&](std::unordered_map<u32, surface_storage_type>& data)
+			{
+				for (auto It = data.begin(); It != data.end();)
+				{
+					auto surface = Traits::get(It->second);
+					if (surface->dirty())
+					{
+						// Force memory barrier to release some resources
+						surface->memory_barrier(cmd, rsx::surface_access::read);
+					}
+					else if (!surface->test())
+					{
+						// Remove this
+						invalidate(It->second);
+						It = data.erase(It);
+					}
+					else
+					{
+						++It;
+					}
+				}
+			};
+
+			const auto old_usage = m_active_memory_used;
+
+			// Try and find old surfaces to remove
+			process_list_function(m_render_targets_storage);
+			process_list_function(m_depth_stencil_storage);
+
+			return (m_active_memory_used < old_usage);
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1342,6 +1342,23 @@ namespace rsx
 			m_storage.purge_unreleased_sections();
 		}
 
+		bool handle_memory_pressure(problem_severity severity)
+		{
+			if (m_storage.m_unreleased_texture_objects)
+			{
+				m_storage.purge_unreleased_sections();
+				return true;
+			}
+
+			if (severity >= problem_severity::severe)
+			{
+				// Things are bad, previous check should have released 'unreleased' pool
+				return m_storage.purge_unlocked_sections();
+			}
+
+			return false;
+		}
+
 		image_view_type create_temporary_subresource(commandbuffer_type &cmd, deferred_subresource& desc)
 		{
 			if (!desc.do_not_cache) [[likely]]

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -358,9 +358,9 @@ struct gl_render_targets : public rsx::surface_store<gl_render_target_traits>
 	std::vector<GLuint> free_invalidated(gl::command_context& cmd)
 	{
 		// Do not allow more than 256M of RSX memory to be used by RTTs
-		if (check_memory_overload(256 * 0x100000))
+		if (check_memory_usage(256 * 0x100000))
 		{
-			handle_memory_overload(cmd);
+			handle_memory_pressure(cmd, rsx::problem_severity::moderate);
 		}
 
 		std::vector<GLuint> removed;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2114,6 +2114,16 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		flush_command_queue();
 	}
 
+	if (!m_rtts.superseded_surfaces.empty())
+	{
+		for (auto& surface : m_rtts.superseded_surfaces)
+		{
+			m_texture_cache.discard_framebuffer_memory_region(*m_current_command_buffer, surface->get_memory_range());
+		}
+
+		m_rtts.superseded_surfaces.clear();
+	}
+
 	const auto color_fmt_info = get_compatible_gcm_format(m_framebuffer_layout.color_format);
 	for (u8 index : m_draw_buffers)
 	{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -546,6 +546,9 @@ public:
 	// External callback in case we need to suddenly submit a commandlist unexpectedly, e.g in a violation handler
 	void emergency_query_cleanup(vk::command_buffer* commands);
 
+	// External callback to handle out of video memory problems
+	bool on_vram_exhausted(rsx::problem_severity severity);
+
 	// Conditional rendering
 	void begin_conditional_rendering(const std::vector<rsx::reports::occlusion_query_info*>& sources) override;
 	void end_conditional_rendering() override;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -77,9 +77,6 @@ namespace vk
 	// TODO: Clean this up and integrate cleanly with VKGSRender
 	data_heap g_upload_heap;
 
-	// Garbage collection
-	std::vector<std::unique_ptr<image>> g_deleted_typeless_textures;
-
 	VkSampler g_null_sampler = nullptr;
 
 	rsx::atomic_bitmask_t<runtime_state, u64> g_runtime_state;
@@ -335,8 +332,9 @@ namespace vk
 		{
 			if (ptr)
 			{
-				// Safely move to deleted pile
-				g_deleted_typeless_textures.emplace_back(std::move(ptr));
+				requested_width = std::max(requested_width, ptr->width());
+				requested_height = std::max(requested_height, ptr->height());
+				get_resource_manager()->dispose(ptr);
 			}
 
 			ptr.reset(create_texture());
@@ -417,7 +415,6 @@ namespace vk
 		g_upload_heap.destroy();
 
 		g_typeless_textures.clear();
-		g_deleted_typeless_textures.clear();
 
 		if (g_null_sampler)
 		{

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -104,6 +104,9 @@ void VKGSRender::advance_queued_frames()
 	// Check all other frames for completion and clear resources
 	check_present_status();
 
+	// Run video memory balancer
+	vk::vmm_check_memory_usage();
+
 	// m_rtts storage is double buffered and should be safe to tag on frame boundary
 	m_rtts.free_invalidated(*m_current_command_buffer);
 

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -936,14 +936,14 @@ namespace rsx
 		void free_invalidated(vk::command_buffer& cmd)
 		{
 			// Do not allow more than 256M of RSX memory to be used by RTTs
-			if (check_memory_overload(256 * 0x100000))
+			if (check_memory_usage(256 * 0x100000))
 			{
 				if (!cmd.is_recording())
 				{
 					cmd.begin();
 				}
 
-				handle_memory_overload(cmd);
+				handle_memory_pressure(cmd, rsx::problem_severity::moderate);
 			}
 
 			const u64 last_finished_frame = vk::get_last_completed_frame_id();

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -31,6 +31,14 @@ namespace rsx
 
 	extern atomic_t<u64> g_rsx_shared_tag;
 
+	enum class problem_severity : u8
+	{
+		low,
+		moderate,
+		severe,
+		fatal
+	};
+
 	//Base for resources with reference counting
 	class ref_counted
 	{


### PR DESCRIPTION
- Fixes a 'bug' where old textures for scratch resources were kept around without being deleted during runtime. It was assumed that there would only ever be a small number of them at any one time, but specially crafted request patterns could cause the number to keep going up forever. See https://github.com/RPCS3/rpcs3/issues/8130
- Implements out of video memory handling. If memory allocation fails, an emergency fallback is invoked that removes as many unneeded resources from the GPU memory as possible. The routines are also run at lower severity level every frame and engage once VRAM usage exceeds 75% for any of the main heaps in use.
- Includes fixup for https://github.com/RPCS3/rpcs3/issues/8075 for some code that mysteriously disappeared during rebase.

Fixes https://github.com/RPCS3/rpcs3/issues/8130