### PR TITLE
overlays: try to fix unexpected text crop

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
@@ -314,7 +314,7 @@ namespace rsx
 							skip_whitespace = false;
 						}
 
-						if (quad.x1 > max_width)
+						if (x_advance > max_width)
 						{
 							bool wrapped              = false;
 							bool non_whitespace_break = false;


### PR DESCRIPTION
### Issue:

We calculate the `max_width` in `measure_text()` based on the` x_advance` passed to `stbtt_GetPackedQuad`.
But the `render_text` method has a crop functionality that is based on `max_width` and `quad.x1` instead.

`quad.x1` is not equal to `x_advance`, which leads to a mismatch between the measuring logic and the crop logic on some occasions.

Logs:

`for (char c : "abcdefghijklmnopqrstuvwxyz") "Troph" + c;`
```
E {RSX [0x0009350]} RSX: quad.x1 > max_width for 'Trophc': x_advance=29.85 quad.x1=30.23 max_width=30
E {RSX [0x000b76c]} RSX: quad.x1 > max_width for 'Trophf': x_advance=27.47 quad.x1=28.23 max_width=28
E {RSX [0x00080d4]} RSX: quad.x1 > max_width for 'Trophk': x_advance=29.85 quad.x1=30.23 max_width=30
E {RSX [0x00028e8]} RSX: quad.x1 > max_width for 'Trophv': x_advance=29.85 quad.x1=30.23 max_width=30
E {RSX [0x0007d30]} RSX: quad.x1 > max_width for 'Trophx': x_advance=29.85 quad.x1=30.23 max_width=30
E {RSX [0x0009f54]} RSX: quad.x1 > max_width for 'Trophy': x_advance=29.85 quad.x1=30.23 max_width=30
E {RSX [0x0001000]} RSX: quad.x1 > max_width for 'Trophz': x_advance=29.85 quad.x1=30.23 max_width=30
```

For some reason this also affects alignment, unless I have some leftover changes somewhere.

#### Problem on Master (see the missing y):
![image](https://user-images.githubusercontent.com/23019877/88442374-90aac580-ce14-11ea-86c9-e951d446b494.png)

#### PR:
![image](https://user-images.githubusercontent.com/23019877/88442430-c18afa80-ce14-11ea-95de-79e33873d40b.png)
