### PR TITLE
Update types.h to fix static_cast test

### DIFF
--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -94,7 +94,7 @@ namespace std
 	{
 		static_assert(sizeof(To) == sizeof(From), "std::bit_cast<>: incompatible type size");
 
-		if constexpr ((std::is_same_v<std::remove_const_t<To>, std::remove_const_t<From>> && std::is_constructible_v<To, To>) || (std::is_integral_v<From> && std::is_integral_v<To>))
+		if constexpr ((std::is_same_v<std::remove_const_t<To>, std::remove_const_t<From>> && std::is_constructible_v<To, From>) || (std::is_integral_v<From> && std::is_integral_v<To>))
 		{
 			return static_cast<To>(from);
 		}


### PR DESCRIPTION
Hi,
First PR
Trivial fix up to resolve invalid is_constructible test (To,To) to match desired (To,From)

Just one of the changes picked up by my clang compiles so far. Obviously hasn't been a problem so far, but it removes a warning for me :)
Bigger question is probably whether this whole ifdef should be removed, given c++20 has bit_cast