### PR TITLE
Fix clang complaints about constexpr not being constant

### DIFF
--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -8,7 +8,7 @@
 LOG_CHANNEL(input_log, "Input");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 bool keyboard_pad_handler::Init()
 {

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -22,6 +22,7 @@
     <ProjectGuid>{70CD65B0-91D6-4FAE-9A7B-4AF55D0D1B12}</ProjectGuid>
     <RootNamespace>rpcs3</RootNamespace>
     <Keyword>Qt4VSv1.0</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="..\common_default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/rpcs3/rpcs3qt/about_dialog.cpp
+++ b/rpcs3/rpcs3qt/about_dialog.cpp
@@ -6,7 +6,7 @@
 #include <QDesktopServices>
 #include <QUrl>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 about_dialog::about_dialog(QWidget* parent) : QDialog(parent), ui(new Ui::about_dialog)
 {

--- a/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
@@ -10,7 +10,7 @@
 
 LOG_CHANNEL(autopause_log, "AutoPause");
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 auto_pause_settings_dialog::auto_pause_settings_dialog(QWidget *parent) : QDialog(parent)
 {

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -7,7 +7,7 @@
 
 #include <QMenu>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 breakpoint_list::breakpoint_list(QWidget* parent, breakpoint_handler* handler) : QListWidget(parent), m_breakpoint_handler(handler)
 {

--- a/rpcs3/rpcs3qt/call_stack_list.cpp
+++ b/rpcs3/rpcs3qt/call_stack_list.cpp
@@ -1,6 +1,6 @@
 ﻿#include "call_stack_list.h"
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 call_stack_list::call_stack_list(QWidget* parent) : QListWidget(parent)
 {

--- a/rpcs3/rpcs3qt/cg_disasm_window.cpp
+++ b/rpcs3/rpcs3qt/cg_disasm_window.cpp
@@ -15,7 +15,7 @@
 
 LOG_CHANNEL(gui_log, "GUI");
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 cg_disasm_window::cg_disasm_window(std::shared_ptr<gui_settings> xSettings): xgui_settings(xSettings)

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -27,7 +27,7 @@
 #include <QTimer>
 #include <atomic>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *parent)
 	: custom_dock_widget(tr("Debugger"), parent), xgui_settings(settings)

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -13,7 +13,7 @@
 
 #include <memory>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 debugger_list::debugger_list(QWidget* parent, std::shared_ptr<gui_settings> settings, breakpoint_handler* handler)
 	: QListWidget(parent)

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -14,7 +14,7 @@
 #include <QComboBox>
 #include <QSpinBox>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 class emu_settings : public QObject
 {

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -8,7 +8,7 @@
 
 LOG_CHANNEL(compat_log, "Compat");
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 game_compatibility::game_compatibility(std::shared_ptr<gui_settings> settings, QWidget* parent)

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -38,7 +38,7 @@
 
 LOG_CHANNEL(screenshot);
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 gs_frame::gs_frame(const QRect& geometry, const QIcon& appIcon, const std::shared_ptr<gui_settings>& gui_settings)
 	: QWindow(), m_gui_settings(gui_settings)

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
@@ -9,7 +9,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 extern bool ppu_patch(u32 addr, u32 value);
 

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -35,7 +35,7 @@
 #include "kernel_explorer.h"
 #include "qt_utils.h"
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 enum kernel_item_role
 {

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -24,7 +24,7 @@ extern atomic_t<s64> g_tty_size;
 extern std::array<std::deque<std::string>, 16> g_tty_input;
 extern std::mutex g_tty_mutex;
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 struct gui_listener : logs::listener
 {

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -13,7 +13,7 @@
 #include <QWheelEvent>
 #include <shared_mutex>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 memory_viewer_panel::memory_viewer_panel(QWidget* parent)
 	: QDialog(parent)

--- a/rpcs3/rpcs3qt/microphone_creator.cpp
+++ b/rpcs3/rpcs3qt/microphone_creator.cpp
@@ -4,7 +4,7 @@
 
 #include "3rdparty/OpenAL/include/alext.h"
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 microphone_creator::microphone_creator()
 {

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -13,7 +13,7 @@
 #include <QtDBus/QDBusConnection>
 #endif
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 {

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -10,7 +10,7 @@
 #include <QPushButton>
 #include <QRegExpValidator>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 osk_dialog_frame::osk_dialog_frame()
 {

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -34,7 +34,7 @@
 LOG_CHANNEL(cfg_log, "CFG");
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 inline bool CreateConfigFile(const QString& dir, const QString& name)
 {

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -11,7 +11,7 @@
 #include "Emu/System.h"
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 namespace gui
 {

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -10,7 +10,7 @@
 #include <QPushButton>
 #include <QMessageBox>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 inline std::string sstr(const QVariant& _in) { return sstr(_in.toString()); }
 

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -16,7 +16,7 @@
 
 LOG_CHANNEL(cfg_log, "CFG");
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 render_creator::render_creator(QObject *parent) : QObject(parent)
 {

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -19,7 +19,7 @@ enum GCMEnumTypes
 	CELL_GCM_PRIMITIVE_ENUM,
 };
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 namespace
 {

--- a/rpcs3/rpcs3qt/save_data_info_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_info_dialog.cpp
@@ -6,7 +6,7 @@
 #include <QHeaderView>
 #include "Emu/System.h"
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 save_data_info_dialog::save_data_info_dialog(const SaveDataEntry& save, QWidget* parent)
 	: QDialog(parent), m_entry(save)

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -9,7 +9,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 //Show up the savedata list, either to choose one to save/load or to manage saves.
 //I suggest to use function callbacks to give save data list or get save data entry. (Not implemented or stubbed)

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -25,7 +25,7 @@ LOG_CHANNEL(gui_log, "GUI");
 namespace
 {
 	// Helper converters
-	constexpr auto qstr = QString::fromStdString;
+	inline auto qstr(std::string s) { return QString::fromStdString(s); }
 	inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 	QString FormatTimestamp(u64 time)

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -36,7 +36,7 @@ LOG_CHANNEL(gui_log, "GUI");
 
 namespace
 {
-	constexpr auto qstr = QString::fromStdString;
+	inline auto qstr(std::string s) { return QString::fromStdString(s); }
 	inline std::string sstr(const QString& _in) { return _in.toUtf8().toStdString(); }
 }
 

--- a/rpcs3/rpcs3qt/trophy_notification_frame.cpp
+++ b/rpcs3/rpcs3qt/trophy_notification_frame.cpp
@@ -6,7 +6,7 @@
 
 static const int TROPHY_TIMEOUT_MS = 7500;
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 trophy_notification_frame::trophy_notification_frame(const std::vector<uchar>& imgBuffer, const SceNpTrophyDetails& trophy, int height) : QWidget()
 {

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -23,7 +23,7 @@
 #include "Utilities/File.h"
 #include "util/logs.hpp"
 
-constexpr auto qstr = QString::fromStdString;
+inline auto qstr(std::string s) { return QString::fromStdString(s); }
 
 LOG_CHANNEL(gui_log, "GUI");
 


### PR DESCRIPTION
It seems my MSVC clang compiler throws an error on the constexpr here.  As discussed in Discord, this seems like the right solution to the complaints..