### PR TITLE
PPU LLVM: Fix possible UB in ADDIS

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1904,7 +1904,7 @@ void PPUTranslator::ADDI(ppu_opcode_t op)
 
 void PPUTranslator::ADDIS(ppu_opcode_t op)
 {
-	Value* imm = m_ir->getInt64(op.simm16 << 16);
+	Value* imm = m_ir->getInt64(op.simm16 * 65536);
 
 	if (m_rel && (m_rel->type >= 4u && m_rel->type <= 6u))
 	{


### PR DESCRIPTION
Shift left negative integers is undefined behaviour, use multiplication instead, other places which do similar thing have already changed to using multplication in code such as ADDIS interpreter handler.