### PR TITLE
improve cheat manager

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -57,7 +57,7 @@ void fmt_class_string<patch_type>::format(std::string& out, u64 arg)
 
 patch_engine::patch_engine()
 {
-	const std::string patches_path = fs::get_config_dir() + "patches/";
+	const std::string patches_path = get_patches_path();
 
 	if (!fs::create_path(patches_path))
 	{
@@ -89,7 +89,7 @@ std::string patch_engine::get_patches_path()
 
 std::string patch_engine::get_imported_patch_path()
 {
-	return fs::get_config_dir() + "patches/imported_patch.yml";
+	return get_patches_path() + "imported_patch.yml";
 }
 
 static void append_log_message(std::stringstream* log_messages, const std::string& message)
@@ -554,7 +554,7 @@ void patch_engine::append_global_patches()
 	load(m_map, fs::get_config_dir() + "patch.yml");
 
 	// New patch.yml
-	load(m_map, fs::get_config_dir() + "patches/patch.yml");
+	load(m_map, get_patches_path() + "patch.yml");
 
 	// Imported patch.yml
 	load(m_map, get_imported_patch_path());
@@ -571,7 +571,7 @@ void patch_engine::append_title_patches(const std::string& title_id)
 	load(m_map, fs::get_config_dir() + "data/" + title_id + "/patch.yml");
 
 	// New patch.yml
-	load(m_map, fs::get_config_dir() + "patches/" +  title_id + "_patch.yml");
+	load(m_map, get_patches_path() + title_id + "_patch.yml");
 }
 
 std::size_t patch_engine::apply(const std::string& name, u8* dst)

--- a/Utilities/cheat_info.cpp
+++ b/Utilities/cheat_info.cpp
@@ -1,0 +1,32 @@
+﻿#include "stdafx.h"
+#include "cheat_info.h"
+#include "Config.h"
+#include "StrUtil.h"
+
+LOG_CHANNEL(log_cheat, "Cheat");
+
+bool cheat_info::from_str(const std::string& cheat_line)
+{
+	auto cheat_vec = fmt::split(cheat_line, {"@@@"}, false);
+
+	s64 val64 = 0;
+	if (cheat_vec.size() != 5 || !cfg::try_to_int64(&val64, cheat_vec[2], 0, cheat_type_max - 1))
+	{
+		log_cheat.fatal("Failed to parse cheat line");
+		return false;
+	}
+
+	game        = cheat_vec[0];
+	description = cheat_vec[1];
+	type        = cheat_type{::narrow<u8>(val64)};
+	offset      = std::stoul(cheat_vec[3]);
+	red_script  = cheat_vec[4];
+
+	return true;
+}
+
+std::string cheat_info::to_str() const
+{
+	std::string cheat_str = game + "@@@" + description + "@@@" + std::to_string(static_cast<u8>(type)) + "@@@" + std::to_string(offset) + "@@@" + red_script + "@@@";
+	return cheat_str;
+}

--- a/Utilities/cheat_info.h
+++ b/Utilities/cheat_info.h
@@ -1,0 +1,30 @@
+﻿#pragma once
+
+#include "stdafx.h"
+
+enum class cheat_type : u8
+{
+	unsigned_8_cheat,
+	unsigned_16_cheat,
+	unsigned_32_cheat,
+	unsigned_64_cheat,
+	signed_8_cheat,
+	signed_16_cheat,
+	signed_32_cheat,
+	signed_64_cheat,
+	max
+};
+
+constexpr u8 cheat_type_max = static_cast<u8>(cheat_type::max);
+
+struct cheat_info
+{
+	std::string game;
+	std::string description;
+	cheat_type type = cheat_type::max;
+	u32 offset{};
+	std::string red_script;
+
+	bool from_str(const std::string& cheat_line);
+	std::string to_str() const;
+};

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(rpcs3_emu PRIVATE
 	../util/yaml.cpp
 	../util/cereal.cpp
 	../../Utilities/bin_patch.cpp
+	../../Utilities/cheat_info.cpp
 	../../Utilities/cond.cpp
 	../../Utilities/Config.cpp
 	../../Utilities/dynamic_library.cpp

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -47,7 +47,7 @@ namespace rsx
 			text_view.align_text(overlay_element::text_align::center);
 			text_view.back_color.a = 0.f;
 
-			sliding_animation.duration = 1.5;
+			sliding_animation.duration = 1.5f;
 			sliding_animation.type = animation_type::ease_in_out_cubic;
 			sliding_animation.current = { -f32(frame.w), 0, 0 };
 			sliding_animation.end = { 0, 0, 0};

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -69,6 +69,7 @@
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\Utilities\cheat_info.cpp" />
     <ClCompile Include="Emu\Audio\ALSA\ALSABackend.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>
@@ -446,6 +447,7 @@
   <ItemGroup>
     <ClInclude Include="..\3rdparty\stblib\stb_image.h" />
     <ClInclude Include="..\Utilities\address_range.h" />
+    <ClInclude Include="..\Utilities\cheat_info.h" />
     <ClInclude Include="Emu\Audio\ALSA\ALSABackend.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug - LLVM|x64'">true</ExcludedFromBuild>

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -950,6 +950,9 @@
     <ClCompile Include="Emu\Audio\Pulse\PulseBackend.cpp">
       <Filter>Emu\Audio\Pulse</Filter>
     </ClCompile>
+    <ClCompile Include="..\Utilities\cheat_info.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -1821,6 +1824,9 @@
     </ClInclude>
     <ClInclude Include="Emu\Audio\Pulse\PulseBackend.h">
       <Filter>Emu\Audio\Pulse</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Utilities\cheat_info.h">
+      <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/cheat_manager.cpp
+++ b/rpcs3/rpcs3qt/cheat_manager.cpp
@@ -546,6 +546,7 @@ cheat_manager_dialog::cheat_manager_dialog(QWidget* parent)
 	QVBoxLayout* grp_add_cheat_layout     = new QVBoxLayout();
 	QHBoxLayout* grp_add_cheat_sub_layout = new QHBoxLayout();
 	QPushButton* btn_new_search           = new QPushButton(tr("New Search"));
+	btn_new_search->setEnabled(false);
 	btn_filter_results                    = new QPushButton(tr("Filter Results"));
 	btn_filter_results->setEnabled(false);
 	edt_cheat_search_value = new QLineEdit();
@@ -810,6 +811,18 @@ cheat_manager_dialog::cheat_manager_dialog(QWidget* parent)
 		do_the_search();
 	});
 
+	connect(edt_cheat_search_value, &QLineEdit::textChanged, this, [btn_new_search, this](const QString& text)
+	{
+		if (btn_new_search)
+		{
+			btn_new_search->setEnabled(!text.isEmpty());
+		}
+		if (btn_filter_results)
+		{
+			btn_filter_results->setEnabled(!text.isEmpty() && !offsets_found.empty());
+		}
+	});
+
 	connect(btn_filter_results, &QPushButton::clicked, [this](bool /*checked*/) { do_the_search(); });
 
 	connect(lst_search, &QListWidget::customContextMenuRequested, [this](const QPoint& loc)
@@ -989,7 +1002,7 @@ void cheat_manager_dialog::do_the_search()
 		}
 	}
 
-	btn_filter_results->setEnabled(!offsets_found.empty());
+	btn_filter_results->setEnabled(!offsets_found.empty() && edt_cheat_search_value && !edt_cheat_search_value->text().isEmpty());
 }
 
 void cheat_manager_dialog::update_cheat_list()

--- a/rpcs3/rpcs3qt/cheat_manager.cpp
+++ b/rpcs3/rpcs3qt/cheat_manager.cpp
@@ -19,6 +19,7 @@
 
 #include "util/yaml.hpp"
 #include "Utilities/StrUtil.h"
+#include "Utilities/bin_patch.h" // get_patches_path()
 
 LOG_CHANNEL(log_cheat, "Cheat");
 
@@ -109,13 +110,16 @@ std::string cheat_info::to_str() const
 
 cheat_engine::cheat_engine()
 {
-	if (fs::file cheat_file{fs::get_config_dir() + cheats_filename, fs::read + fs::create})
+	const std::string path = patch_engine::get_patches_path() + m_cheats_filename;
+
+	if (fs::file cheat_file{path, fs::read + fs::create})
 	{
 		auto [yml_cheats, error] = yaml_load(cheat_file.to_string());
 
 		if (!error.empty())
 		{
-			log_cheat.error("Error parsing %s: %s", cheats_filename, error);
+			log_cheat.error("Error parsing %s: %s", path, error);
+			return;
 		}
 
 		for (const auto& yml_cheat : yml_cheats)
@@ -133,13 +137,15 @@ cheat_engine::cheat_engine()
 	}
 	else
 	{
-		log_cheat.error("Error loading %s", cheats_filename);
+		log_cheat.error("Error loading %s", path);
 	}
 }
 
 void cheat_engine::save() const
 {
-	fs::file cheat_file(fs::get_config_dir() + cheats_filename, fs::rewrite);
+	const std::string path = patch_engine::get_patches_path() + m_cheats_filename;
+
+	fs::file cheat_file(path, fs::rewrite);
 	if (!cheat_file)
 		return;
 

--- a/rpcs3/rpcs3qt/cheat_manager.h
+++ b/rpcs3/rpcs3qt/cheat_manager.h
@@ -8,32 +8,7 @@
 #include <QComboBox>
 #include <QPushButton>
 
-enum class cheat_type : u8
-{
-	unsigned_8_cheat,
-	unsigned_16_cheat,
-	unsigned_32_cheat,
-	unsigned_64_cheat,
-	signed_8_cheat,
-	signed_16_cheat,
-	signed_32_cheat,
-	signed_64_cheat,
-	max
-};
-
-constexpr u8 cheat_type_max = static_cast<u8>(cheat_type::max);
-
-struct cheat_info
-{
-	std::string game;
-	std::string description;
-	cheat_type type = cheat_type::max;
-	u32 offset{};
-	std::string red_script;
-
-	bool from_str(const std::string& cheat_line);
-	std::string to_str() const;
-};
+#include "Utilities/cheat_info.h"
 
 class cheat_engine
 {

--- a/rpcs3/rpcs3qt/cheat_manager.h
+++ b/rpcs3/rpcs3qt/cheat_manager.h
@@ -67,7 +67,7 @@ public:
 	std::map<std::string, std::map<u32, cheat_info>> cheats;
 
 private:
-	const std::string cheats_filename = "/cheats.yml";
+	const std::string m_cheats_filename = "cheats.yml";
 };
 
 class cheat_manager_dialog : public QDialog

--- a/rpcs3/rpcs3qt/cheat_manager.h
+++ b/rpcs3/rpcs3qt/cheat_manager.h
@@ -86,7 +86,7 @@ protected:
 	void do_the_search();
 
 	template <typename T>
-	T convert_from_QString(QString& str, bool& success);
+	T convert_from_QString(const QString& str, bool& success);
 
 	template <typename T>
 	bool convert_and_search();
@@ -94,18 +94,18 @@ protected:
 	std::pair<bool, bool> convert_and_set(u32 offset);
 
 protected:
-	QTableWidget* tbl_cheats;
-	QListWidget* lst_search;
+	QTableWidget* tbl_cheats = nullptr;
+	QListWidget* lst_search = nullptr;
 
-	QLineEdit* edt_value_final;
-	QPushButton* btn_apply;
+	QLineEdit* edt_value_final = nullptr;
+	QPushButton* btn_apply = nullptr;
 
-	QLineEdit* edt_cheat_search_value;
-	QComboBox* cbx_cheat_search_type;
+	QLineEdit* edt_cheat_search_value = nullptr;
+	QComboBox* cbx_cheat_search_type = nullptr;
 
-	QPushButton* btn_filter_results;
+	QPushButton* btn_filter_results = nullptr;
 
-	u32 current_offset;
+	u32 current_offset{};
 	std::vector<u32> offsets_found;
 
 	cheat_engine g_cheat;

--- a/rpcs3/util/yaml.cpp
+++ b/rpcs3/util/yaml.cpp
@@ -1,5 +1,32 @@
 ﻿#include "util/yaml.hpp"
 #include "Utilities/types.h"
+#include "Utilities/cheat_info.h"
+#include "Utilities/Config.h"
+
+namespace YAML
+{
+	template <>
+	struct convert<cheat_info>
+	{
+		static bool decode(const Node& node, cheat_info& rhs)
+		{
+			if (node.size() != 3)
+			{
+				return false;
+			}
+
+			rhs.description = node[0].Scalar();
+			u64 type64      = 0;
+			if (!cfg::try_to_enum_value(&type64, &fmt_class_string<cheat_type>::format, node[1].Scalar()))
+				return false;
+			if (type64 >= cheat_type_max)
+				return false;
+			rhs.type       = cheat_type{::narrow<u8>(type64)};
+			rhs.red_script = node[2].Scalar();
+			return true;
+		}
+	};
+} // namespace YAML
 
 std::pair<YAML::Node, std::string> yaml_load(const std::string& from)
 {
@@ -32,5 +59,7 @@ T get_yaml_node_value(YAML::Node node, std::string& error_message)
 	return {};
 }
 
+template u32 get_yaml_node_value<u32>(YAML::Node, std::string&);
 template u64 get_yaml_node_value<u64>(YAML::Node, std::string&);
 template f64 get_yaml_node_value<f64>(YAML::Node, std::string&);
+template cheat_info get_yaml_node_value<cheat_info>(YAML::Node, std::string&);


### PR DESCRIPTION
Extracted some code from the earlier scrapped PR:

- Don't list search results if the number exceeds 10000. Otherwise memory and rendering time would rise abnormally.
- Disable search buttons if the search field is empty.
- Use enum for table columns
- Move cheats.yml to patches folder as requested by some users
- Improve yml parser errors