### PR TITLE
CI: Avoid trying to publish builds on forks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
       artifact: RPCS3 for Windows
 
     - task: GitHubRelease@1
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Name'], 'RPCS3/rpcs3'))
       inputs:
         gitHubConnection: 'RPCS3-Token'
         repositoryName: 'RPCS3/rpcs3-binaries-win'


### PR DESCRIPTION
Let's give this is shot. Seems to work in testing.