### PR TITLE
Improve error handling during config loading

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -127,7 +127,11 @@ void Emulator::Init()
 
 	if (const fs::file cfg_file{cfg_path, fs::read + fs::create})
 	{
-		g_cfg.from_string(cfg_file.to_string());
+		if (!g_cfg.from_string(cfg_file.to_string()))
+		{
+			sys_log.fatal("Failed to apply global config: %s", cfg_path);
+		}
+
 		g_cfg.name = cfg_path;
 	}
 	else
@@ -873,22 +877,37 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			if (fs::file cfg_file{ config_path_old })
 			{
 				sys_log.notice("Applying custom config: %s", config_path_old);
-				g_cfg.from_string(cfg_file.to_string());
+
+				if (!g_cfg.from_string(cfg_file.to_string()))
+				{
+					sys_log.fatal("Failed to apply custom config: %s", config_path_old);
+				}
 			}
 
 			// Load custom config-2
 			if (fs::file cfg_file{ config_path_new })
 			{
 				sys_log.notice("Applying custom config: %s", config_path_new);
-				g_cfg.from_string(cfg_file.to_string());
-				g_cfg.name = config_path_new;
+
+				if (g_cfg.from_string(cfg_file.to_string()))
+				{
+					g_cfg.name = config_path_new;
+				}
+				else
+				{
+					sys_log.fatal("Failed to apply custom config: %s", config_path_new);
+				}
 			}
 
 			// Load custom config-3
 			if (fs::file cfg_file{ m_path + ".yml" })
 			{
 				sys_log.notice("Applying custom config: %s.yml", m_path);
-				g_cfg.from_string(cfg_file.to_string());
+
+				if (!g_cfg.from_string(cfg_file.to_string()))
+				{
+					sys_log.fatal("Failed to apply custom config: %s.yml", m_path);
+				}
 			}
 		}
 

--- a/rpcs3/rpcs3qt/config_adapter.cpp
+++ b/rpcs3/rpcs3qt/config_adapter.cpp
@@ -3,6 +3,8 @@
 #include "config_adapter.h"
 #include "Emu/system_config.h"
 
+LOG_CHANNEL(cfg_log, "CFG");
+
 // Helper methods to interact with YAML and the config settings.
 namespace cfg_adapter
 {
@@ -29,7 +31,18 @@ namespace cfg_adapter
 
 	YAML::Node get_node(const YAML::Node& node, cfg_location::const_iterator begin, cfg_location::const_iterator end)
 	{
-		return begin == end ? node : get_node(node[*begin], begin + 1, end); // TODO
+		if (begin == end)
+		{
+			return node;
+		}
+
+		if (!node || !node.IsMap())
+		{
+			cfg_log.fatal("Node error. A cfg_location does not match its cfg::node");
+			return YAML::Node();
+		}
+
+		return get_node(node[*begin], begin + 1, end); // TODO
 	}
 
 	YAML::Node get_node(const YAML::Node& node, cfg_location loc)

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -500,12 +500,24 @@ QStringList emu_settings::GetSettingOptions(emu_settings_type type) const
 
 std::string emu_settings::GetSettingDefault(emu_settings_type type) const
 {
-	return cfg_adapter::get_node(m_defaultSettings, settings_location[type]).Scalar();
+	if (auto node = cfg_adapter::get_node(m_defaultSettings, settings_location[type]); node && node.IsScalar())
+	{
+		return node.Scalar();
+	}
+	
+	cfg_log.fatal("GetSettingDefault(type=%d) could not retrieve the requested node", static_cast<int>(type));
+	return "";
 }
 
 std::string emu_settings::GetSetting(emu_settings_type type) const
 {
-	return cfg_adapter::get_node(m_currentSettings, settings_location[type]).Scalar();
+	if (auto node = cfg_adapter::get_node(m_currentSettings, settings_location[type]); node && node.IsScalar())
+	{
+		return node.Scalar();
+	}
+
+	cfg_log.fatal("GetSetting(type=%d) could not retrieve the requested node", static_cast<int>(type));
+	return "";
 }
 
 void emu_settings::SetSetting(emu_settings_type type, const std::string& val)


### PR DESCRIPTION
- Do not crash if a config yml is corrupt. Log an error instead.
- When loading a corrupted config.yml in the gui, a Messagebox is shown.
- Improve error logging when loading a config yml in the Emulator