### PR TITLE
SPU/PPU LLVM: Fix cpu_translator::get_const_vector<v128>()

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -83,12 +83,31 @@ llvm::Value* cpu_translator::bitcast(llvm::Value* val, llvm::Type* type)
 }
 
 template <>
-v128 cpu_translator::get_const_vector<v128>(llvm::Constant* c, u32 a, u32 b)
+std::pair<bool, v128> cpu_translator::get_const_vector<v128>(llvm::Value* c, u32 a, u32 b)
 {
+	v128 result{};
+
+	if (!llvm::isa<llvm::Constant>(c))
+	{
+		return {false, result};
+	}
+
 	const auto t = c->getType();
 
 	if (!t->isVectorTy())
 	{
+		if (const auto ci = llvm::dyn_cast<llvm::ConstantInt>(c); ci && ci->getBitWidth() == 128)
+		{
+			auto cv = ci->getValue();
+
+			for (int i = 0; i < 128; i++)
+			{
+				result._bit[i] = cv[i];
+			}
+
+			return {true, result};
+		}
+
 		fmt::throw_exception("[0x%x, %u] Not a vector" HERE, a, b);
 	}
 
@@ -106,12 +125,16 @@ v128 cpu_translator::get_const_vector<v128>(llvm::Constant* c, u32 a, u32 b)
 			return {};
 		}
 
+		if (llvm::isa<llvm::ConstantExpr>(c))
+		{
+			// Sorry, if we cannot evaluate it we cannot use it
+			fmt::throw_exception("[0x%x, %u] Constant Expression!" HERE, a, b);
+		}
+
 		fmt::throw_exception("[0x%x, %u] Unexpected constant type" HERE, a, b);
 	}
 
 	const auto sct = t->getScalarType();
-
-	v128 result;
 
 	if (sct->isIntegerTy(8))
 	{
@@ -160,12 +183,17 @@ v128 cpu_translator::get_const_vector<v128>(llvm::Constant* c, u32 a, u32 b)
 		fmt::throw_exception("[0x%x, %u] Unexpected vector element type" HERE, a, b);
 	}
 
-	return result;
+	return {true, result};
 }
 
 template <>
 llvm::Constant* cpu_translator::make_const_vector<v128>(v128 v, llvm::Type* t)
 {
+	if (const auto ct = llvm::dyn_cast<llvm::IntegerType>(t); ct && ct->getBitWidth() == 128)
+	{
+		return llvm::ConstantInt::get(t, llvm::APInt(128, llvm::makeArrayRef(reinterpret_cast<const u64*>(v._bytes), 2)));
+	}
+
 	verify(HERE), t->isVectorTy() && llvm::cast<llvm::VectorType>(t)->getBitWidth() == 128;
 
 	const auto sct = t->getScalarType();

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -2837,7 +2837,7 @@ public:
 	}
 
 	template <typename R = v128>
-	R get_const_vector(llvm::Constant*, u32 a, u32 b);
+	std::pair<bool, R> get_const_vector(llvm::Value*, u32 a, u32 b);
 
 	template <typename T = v128>
 	llvm::Constant* make_const_vector(T, llvm::Type*);

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -947,10 +947,8 @@ void PPUTranslator::VMADDFP(ppu_opcode_t op)
 	auto [a, b, c] = get_vrs<f32[4]>(op.va, op.vb, op.vc);
 
 	// Optimization: Emit only a floating multiply if the addend is zero
-	if (auto cv = llvm::dyn_cast<llvm::Constant>(b.value))
+	if (auto [ok, data] = get_const_vector(b.value, m_addr, 2000); ok)
 	{
-		v128 data = get_const_vector(cv, m_addr, 2000);
-
 		if (data == v128{})
 		{
 			set_vr(op.vd, vec_handle_result(a * c));
@@ -1253,10 +1251,8 @@ void PPUTranslator::VNMSUBFP(ppu_opcode_t op)
 	auto [a, b, c] = get_vrs<f32[4]>(op.va, op.vb, op.vc);
 
 	// Optimization: Emit only a floating multiply if the addend is zero
-	if (const auto cv = llvm::dyn_cast<llvm::Constant>(b.value))
+	if (const auto [ok, data] = get_const_vector(b.value, m_addr, 2004); ok)
 	{
-		const v128 data = get_const_vector(cv, m_addr, 2004);
-
 		if (data == v128{})
 		{
 			set_vr(op.vd, vec_handle_result(-a * c));
@@ -1438,10 +1434,8 @@ void PPUTranslator::VSEL(ppu_opcode_t op)
 	const auto c = get_vr<u32[4]>(op.vc);
 
 	// Check if the constant mask doesn't require bit granularity
-	if (auto ci = llvm::dyn_cast<llvm::Constant>(c.value))
+	if (auto [ok, mask] = get_const_vector(c.value, m_addr, 9000); ok)
 	{
-		v128 mask = get_const_vector(ci, m_addr, 9000);
-		
 		bool sel_32 = true;
 		for (u32 i = 0; i < 4; i++)
 		{


### PR DESCRIPTION
* Add support for 128-bit integers, construct it using the base llvm::APInt.
* Fix the use of llvm::ConstantExpr, we cannot evaluate it as constant data!

Those bugs existed before but they were too rare to be noticed until #8559.
Fixes #8651 