### PR TITLE
SPU: Fix spu_thread::cpu_stop() missed executions

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -433,11 +433,21 @@ void cpu_thread::operator()()
 		if (!(state & cpu_flag::stop))
 		{
 			cpu_task();
-			state -= cpu_flag::ret;
+
+			if (state & cpu_flag::ret && state.test_and_reset(cpu_flag::ret))
+			{
+				cpu_return();
+			}
+
 			continue;
 		}
 
 		thread_ctrl::wait();
+
+		if (state & cpu_flag::ret && state.test_and_reset(cpu_flag::ret))
+		{
+			cpu_return();
+		}
 	}
 
 	// Complete cleanup gracefully

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -120,6 +120,9 @@ public:
 	// Callback for vm::temporary_unlock
 	virtual void cpu_unmem() {}
 
+	// Callback for cpu_flag::ret
+	virtual void cpu_return() {}
+
 	// Thread locker
 	class suspend_all
 	{

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -262,7 +262,7 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 			if (get_current_cpu_thread() == this)
 			{
 				// TODO
-				state += cpu_flag::stop;
+				state += cpu_flag::stop + cpu_flag::ret;
 				return true;
 			}
 
@@ -270,7 +270,7 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 
 			if (status_npc.load().status & SPU_STATUS_RUNNING)
 			{
-				state += cpu_flag::stop;
+				state += cpu_flag::stop + cpu_flag::ret;
 
 				for (status_npc_sync_var old; (old = status_npc).status & SPU_STATUS_RUNNING;)
 				{

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -621,9 +621,9 @@ public:
 	virtual void cpu_task() override final;
 	virtual void cpu_mem() override;
 	virtual void cpu_unmem() override;
+	virtual void cpu_return() override;
 	virtual ~spu_thread() override;
 	void cpu_init();
-	void cpu_stop();
 
 	static const u32 id_base = 0x02000000; // TODO (used to determine thread type)
 	static const u32 id_step = 1;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1003,7 +1003,7 @@ error_code sys_spu_thread_group_terminate(ppu_thread& ppu, u32 id, s32 value)
 	{
 		if (thread)
 		{
-			thread->state += cpu_flag::stop;
+			thread->state += cpu_flag::stop + cpu_flag::ret;
 		}
 	}
 


### PR DESCRIPTION
If the SPU thread was stopped VERY early in its execution it won't even enter spu_thread::cpu_task() which was needed for it to call spu_thread::cpu_stop().
To fix this move it to be a callback of cpu_flag::ret and add this flag to all threads' state when stopping them.
Fixes potential deadlocks in sys_spu_thread_group_join etc when cpu_stop() is not called.