### PR TITLE
lv2: Minor fix of "unspecific ppu" path of _sys_lwcond_signal

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sysPrxForUser.h
+++ b/rpcs3/Emu/Cell/Modules/sysPrxForUser.h
@@ -63,7 +63,7 @@ error_code sys_lwcond_create(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, vm::
 error_code sys_lwcond_destroy(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond);
 error_code sys_lwcond_signal(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond);
 error_code sys_lwcond_signal_all(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond);
-error_code sys_lwcond_signal_to(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond, u32 ppu_thread_id);
+error_code sys_lwcond_signal_to(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond, u64 ppu_thread_id);
 error_code sys_lwcond_wait(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond, u64 timeout);
 
 error_code sys_ppu_thread_create(ppu_thread& ppu, vm::ptr<u64> thread_id, u32 entry, u64 arg, s32 prio, u32 stacksize, u64 flags, vm::cptr<char> threadname);

--- a/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
@@ -59,7 +59,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 
 	if ((lwmutex->attribute & SYS_SYNC_ATTR_PROTOCOL_MASK) == SYS_SYNC_RETRY)
 	{
-		return _sys_lwcond_signal(ppu, lwcond->lwcond_queue, 0, -1, 2);
+		return _sys_lwcond_signal(ppu, lwcond->lwcond_queue, 0, UINT32_MAX, 2);
 	}
 
 	if (lwmutex->vars.owner.load() == ppu.id)
@@ -68,7 +68,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 		lwmutex->all_info++;
 
 		// call the syscall
-		if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, -1, 1))
+		if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, UINT32_MAX, 1))
 		{
 			if (ppu.test_stopped())
 			{
@@ -96,7 +96,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 		}
 
 		// call the syscall
-		return _sys_lwcond_signal(ppu, lwcond->lwcond_queue, 0, -1, 2);
+		return _sys_lwcond_signal(ppu, lwcond->lwcond_queue, 0, UINT32_MAX, 2);
 	}
 
 	// if locking succeeded
@@ -107,7 +107,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 	});
 
 	// call the syscall
-	if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, -1, 3))
+	if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, UINT32_MAX, 3))
 	{
 		if (ppu.test_stopped())
 		{
@@ -202,9 +202,9 @@ error_code sys_lwcond_signal_all(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 	return res;
 }
 
-error_code sys_lwcond_signal_to(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u32 ppu_thread_id)
+error_code sys_lwcond_signal_to(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u64 ppu_thread_id)
 {
-	sysPrxForUser.trace("sys_lwcond_signal_to(lwcond=*0x%x, ppu_thread_id=0x%x)", lwcond, ppu_thread_id);
+	sysPrxForUser.trace("sys_lwcond_signal_to(lwcond=*0x%x, ppu_thread_id=0x%llx)", lwcond, ppu_thread_id);
 
 	if (g_cfg.core.hle_lwmutex)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -70,11 +70,11 @@ error_code _sys_lwcond_destroy(ppu_thread& ppu, u32 lwcond_id)
 	return CELL_OK;
 }
 
-error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u32 ppu_thread_id, u32 mode)
+error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u64 ppu_thread_id, u32 mode)
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_lwcond.trace("_sys_lwcond_signal(lwcond_id=0x%x, lwmutex_id=0x%x, ppu_thread_id=0x%x, mode=%d)", lwcond_id, lwmutex_id, ppu_thread_id, mode);
+	sys_lwcond.trace("_sys_lwcond_signal(lwcond_id=0x%x, lwmutex_id=0x%x, ppu_thread_id=0x%llx, mode=%d)", lwcond_id, lwmutex_id, ppu_thread_id, mode);
 
 	// Mode 1: lwmutex was initially owned by the calling thread
 	// Mode 2: lwmutex was not owned by the calling thread and waiter hasn't been increased
@@ -87,16 +87,19 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u3
 
 	const auto cond = idm::check<lv2_obj, lv2_lwcond>(lwcond_id, [&](lv2_lwcond& cond) -> int
 	{
-		if (ppu_thread_id != umax)
+		ppu_thread* cpu = nullptr;
+
+		if (ppu_thread_id != UINT32_MAX)
 		{
-			if (const auto cpu = idm::check_unlocked<named_thread<ppu_thread>>(ppu_thread_id);
-				!cpu || cpu->joiner == ppu_join_status::exited)
+			cpu = idm::check_unlocked<named_thread<ppu_thread>>(static_cast<u32>(ppu_thread_id));
+
+			if (!cpu || cpu->joiner == ppu_join_status::exited)
 			{
 				return -1;
 			}
 		}
 
-		lv2_lwmutex* mutex;
+		lv2_lwmutex* mutex = nullptr;
 
 		if (mode != 2)
 		{
@@ -112,24 +115,8 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u3
 		{
 			std::lock_guard lock(cond.mutex);
 
-			cpu_thread* result = nullptr;
-
-			if (ppu_thread_id != umax)
-			{
-				for (auto cpu : cond.sq)
-				{
-					if (cpu->id == ppu_thread_id)
-					{
-						verify(HERE), cond.unqueue(cond.sq, cpu);
-						result = cpu;
-						break;
-					}
-				}
-			}
-			else
-			{
-				result = cond.schedule<ppu_thread>(cond.sq, cond.protocol);
-			}
+			auto result = cpu ? cond.unqueue(cond.sq, cpu) :
+				cond.schedule<ppu_thread>(cond.sq, cond.protocol);
 
 			if (result)
 			{
@@ -177,7 +164,7 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u3
 
 	if (!cond.ret)
 	{
-		if (ppu_thread_id == umax)
+		if (ppu_thread_id == UINT32_MAX)
 		{
 			if (mode == 3)
 			{

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.h
@@ -50,6 +50,6 @@ class ppu_thread;
 
 error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmutex_id, vm::ptr<sys_lwcond_t> control, u64 name);
 error_code _sys_lwcond_destroy(ppu_thread& ppu, u32 lwcond_id);
-error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u32 ppu_thread_id, u32 mode);
+error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u64 ppu_thread_id, u32 mode);
 error_code _sys_lwcond_signal_all(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u32 mode);
 error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u64 timeout);

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -97,18 +97,18 @@ public:
 
 	// Find and remove the object from the container (deque or vector)
 	template <typename T, typename E>
-	static bool unqueue(std::deque<T*>& queue, const E& object)
+	static T* unqueue(std::deque<T*>& queue, E* object)
 	{
 		for (auto found = queue.cbegin(), end = queue.cend(); found != end; found++)
 		{
 			if (*found == object)
 			{
 				queue.erase(found);
-				return true;
+				return static_cast<T*>(object);
 			}
 		}
 
-		return false;
+		return nullptr;
 	}
 
 	template <typename E, typename T>


### PR DESCRIPTION
Commit from https://github.com/RPCS3/rpcs3/pull/8227, refactored a bit. Restrict unspecific ppu path to u64(UINT32_MAX) ppu id only, before it was every id that the lower 32-bits of the id were equal to UINT32_MAX such as UINT64_MAX.