### PR TITLE
Replace ppu_module_manager Function Static with Class Static variable (static module map)

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -61,14 +61,6 @@ ppu_static_module::ppu_static_module(const char* name)
 	ppu_module_manager::register_module(this);
 }
 
-// We move the static unordered_map up into the ppu_module_manager definition
-//std::unordered_map<std::string, ppu_static_module*>& ppu_module_manager::access()
-//{
-//	static std::unordered_map<std::string, ppu_static_module*> map;
-//
-//	return map;
-//}
-
 void ppu_module_manager::register_module(ppu_static_module* _module)
 {
 	ppu_module_manager::static_module_map.emplace(_module->name, _module);

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -63,12 +63,12 @@ ppu_static_module::ppu_static_module(const char* name)
 
 void ppu_module_manager::register_module(ppu_static_module* _module)
 {
-	ppu_module_manager::static_module_map.emplace(_module->name, _module);
+	ppu_module_manager::s_module_map.emplace(_module->name, _module);
 }
 
 ppu_static_function& ppu_module_manager::access_static_function(const char* _module, u32 fnid)
 {
-	auto& res = ppu_module_manager::static_module_map.at(_module)->functions[fnid];
+	auto& res = ppu_module_manager::s_module_map.at(_module)->functions[fnid];
 
 	if (res.name)
 	{
@@ -80,7 +80,7 @@ ppu_static_function& ppu_module_manager::access_static_function(const char* _mod
 
 ppu_static_variable& ppu_module_manager::access_static_variable(const char* _module, u32 vnid)
 {
-	auto& res = ppu_module_manager::static_module_map.at(_module)->variables[vnid];
+	auto& res = ppu_module_manager::s_module_map.at(_module)->variables[vnid];
 
 	if (res.name)
 	{
@@ -92,7 +92,7 @@ ppu_static_variable& ppu_module_manager::access_static_variable(const char* _mod
 
 const ppu_static_module* ppu_module_manager::get_module(const std::string& name)
 {
-	const auto& map = ppu_module_manager::static_module_map;
+	const auto& map = ppu_module_manager::s_module_map;
 	const auto found = map.find(name);
 	return found != map.end() ? found->second : nullptr;
 }

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -71,12 +71,12 @@ ppu_static_module::ppu_static_module(const char* name)
 
 void ppu_module_manager::register_module(ppu_static_module* _module)
 {
-	ppu_module_manager::staticModuleMap.emplace(_module->name, _module);
+	ppu_module_manager::static_module_map.emplace(_module->name, _module);
 }
 
 ppu_static_function& ppu_module_manager::access_static_function(const char* _module, u32 fnid)
 {
-	auto& res = ppu_module_manager::staticModuleMap.at(_module)->functions[fnid];
+	auto& res = ppu_module_manager::static_module_map.at(_module)->functions[fnid];
 
 	if (res.name)
 	{
@@ -88,7 +88,7 @@ ppu_static_function& ppu_module_manager::access_static_function(const char* _mod
 
 ppu_static_variable& ppu_module_manager::access_static_variable(const char* _module, u32 vnid)
 {
-	auto& res = ppu_module_manager::staticModuleMap.at(_module)->variables[vnid];
+	auto& res = ppu_module_manager::static_module_map.at(_module)->variables[vnid];
 
 	if (res.name)
 	{
@@ -100,7 +100,7 @@ ppu_static_variable& ppu_module_manager::access_static_variable(const char* _mod
 
 const ppu_static_module* ppu_module_manager::get_module(const std::string& name)
 {
-	const auto& map  = ppu_module_manager::staticModuleMap;
+	const auto& map = ppu_module_manager::static_module_map;
 	const auto found = map.find(name);
 	return found != map.end() ? found->second : nullptr;
 }

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -61,21 +61,22 @@ ppu_static_module::ppu_static_module(const char* name)
 	ppu_module_manager::register_module(this);
 }
 
-std::unordered_map<std::string, ppu_static_module*>& ppu_module_manager::access()
-{
-	static std::unordered_map<std::string, ppu_static_module*> map;
-
-	return map;
-}
+// We move the static unordered_map up into the ppu_module_manager definition
+//std::unordered_map<std::string, ppu_static_module*>& ppu_module_manager::access()
+//{
+//	static std::unordered_map<std::string, ppu_static_module*> map;
+//
+//	return map;
+//}
 
 void ppu_module_manager::register_module(ppu_static_module* _module)
 {
-	access().emplace(_module->name, _module);
+	ppu_module_manager::staticModuleMap.emplace(_module->name, _module);
 }
 
 ppu_static_function& ppu_module_manager::access_static_function(const char* _module, u32 fnid)
 {
-	auto& res = access().at(_module)->functions[fnid];
+	auto& res = ppu_module_manager::staticModuleMap.at(_module)->functions[fnid];
 
 	if (res.name)
 	{
@@ -87,7 +88,7 @@ ppu_static_function& ppu_module_manager::access_static_function(const char* _mod
 
 ppu_static_variable& ppu_module_manager::access_static_variable(const char* _module, u32 vnid)
 {
-	auto& res = access().at(_module)->variables[vnid];
+	auto& res = ppu_module_manager::staticModuleMap.at(_module)->variables[vnid];
 
 	if (res.name)
 	{
@@ -99,7 +100,7 @@ ppu_static_variable& ppu_module_manager::access_static_variable(const char* _mod
 
 const ppu_static_module* ppu_module_manager::get_module(const std::string& name)
 {
-	const auto& map = access();
+	const auto& map  = ppu_module_manager::staticModuleMap;
 	const auto found = map.find(name);
 	return found != map.end() ? found->second : nullptr;
 }

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -4,6 +4,7 @@
 #include "PPUCallback.h"
 #include "ErrorCodes.h"
 #include <typeinfo>
+#include <type_traits>
 #include "Emu/Memory/vm_var.h"
 
 // Helper function
@@ -101,7 +102,8 @@ class ppu_module_manager final
 {
 	friend class ppu_static_module;
 
-	static std::unordered_map<std::string, ppu_static_module*>& access();
+	// this is now replaced by the staticModuleMap static member variable
+	//static std::unordered_map<std::string, ppu_static_module*>& access();
 
 	static void register_module(ppu_static_module*);
 
@@ -161,9 +163,10 @@ public:
 		return info;
 	}
 
+	// We need this to deal with the enumeration over all ppu_static_modules that happens in ppu_initialize_modules
 	static const auto& get()
 	{
-		return access();
+		return (const std::unordered_map<std::string, ppu_static_module*>&)staticModuleMap;
 	}
 
 	static const ppu_static_module cellAdec;
@@ -273,6 +276,9 @@ public:
 	static const ppu_static_module sys_libc;
 	static const ppu_static_module sys_lv2dbg;
 	static const ppu_static_module static_hle;
+
+private:
+	inline static std::unordered_map<std::string, ppu_static_module*> staticModuleMap;
 };
 
 template <auto* Func>

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -164,9 +164,9 @@ public:
 	}
 
 	// We need this to deal with the enumeration over all ppu_static_modules that happens in ppu_initialize_modules
-	static const auto& get()
+	static const std::unordered_map<std::string, ppu_static_module*>& get()
 	{
-		return (const std::unordered_map<std::string, ppu_static_module*>&)staticModuleMap;
+		return staticModuleMap;
 	}
 
 	static const ppu_static_module cellAdec;

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -162,7 +162,7 @@ public:
 	// We need this to deal with the enumeration over all ppu_static_modules that happens in ppu_initialize_modules
 	static const std::unordered_map<std::string, ppu_static_module*>& get()
 	{
-		return static_module_map;
+		return s_module_map;
 	}
 
 	static const ppu_static_module cellAdec;

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -274,7 +274,7 @@ public:
 	static const ppu_static_module static_hle;
 
 private:
-	inline static std::unordered_map<std::string, ppu_static_module*> static_module_map;
+	inline static std::unordered_map<std::string, ppu_static_module*> s_module_map;
 };
 
 template <auto* Func>

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -4,7 +4,6 @@
 #include "PPUCallback.h"
 #include "ErrorCodes.h"
 #include <typeinfo>
-#include <type_traits>
 #include "Emu/Memory/vm_var.h"
 
 // Helper function
@@ -102,9 +101,6 @@ class ppu_module_manager final
 {
 	friend class ppu_static_module;
 
-	// this is now replaced by the staticModuleMap static member variable
-	//static std::unordered_map<std::string, ppu_static_module*>& access();
-
 	static void register_module(ppu_static_module*);
 
 	static ppu_static_function& access_static_function(const char* _module, u32 fnid);
@@ -166,7 +162,7 @@ public:
 	// We need this to deal with the enumeration over all ppu_static_modules that happens in ppu_initialize_modules
 	static const std::unordered_map<std::string, ppu_static_module*>& get()
 	{
-		return staticModuleMap;
+		return static_module_map;
 	}
 
 	static const ppu_static_module cellAdec;
@@ -278,7 +274,7 @@ public:
 	static const ppu_static_module static_hle;
 
 private:
-	inline static std::unordered_map<std::string, ppu_static_module*> staticModuleMap;
+	inline static std::unordered_map<std::string, ppu_static_module*> static_module_map;
 };
 
 template <auto* Func>


### PR DESCRIPTION
Makes for a slightly 'cleaner' interface in my opinion, may also assist with adding thread read/write concurrency support in future if ever required (have left that out of this commit to match existing function).

Very slight performance improvements were seen in representative testing.
https://quick-bench.com/q/GMbgeNc-mZc21aqOKCofnbzPZvg

I didn't investigate whether static initialisation of the static_modules might actually be possible here, perhaps there's a way to do a constexpr / consteval of this.