### PR TITLE
CLI config override

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -122,21 +122,47 @@ void Emulator::Init()
 	g_cfg.from_default();
 	g_cfg_defaults = g_cfg.to_string();
 
-	// Reload global configuration
-	const auto cfg_path = fs::get_config_dir() + "/config.yml";
-
-	if (const fs::file cfg_file{cfg_path, fs::read + fs::create})
+	// Reload override configuration set via command line
+	if (!m_config_override_path.empty())
 	{
-		if (!g_cfg.from_string(cfg_file.to_string()))
+		if (const fs::file cfg_file{m_config_override_path, fs::read + fs::create})
 		{
-			sys_log.fatal("Failed to apply global config: %s", cfg_path);
+			if (!g_cfg.from_string(cfg_file.to_string()))
+			{
+				sys_log.fatal("Failed to apply config override: %s. Proceeding with regular configuration.", m_config_override_path);
+				m_config_override_path.clear();
+			}
+			else
+			{
+				sys_log.success("Applied config override: %s", m_config_override_path);
+				g_cfg.name = m_config_override_path;
+			}
 		}
-
-		g_cfg.name = cfg_path;
+		else
+		{
+			sys_log.fatal("Failed to access config override: %s (%s). Proceeding with regular configuration.", m_config_override_path, fs::g_tls_error);
+			m_config_override_path.clear();
+		}
 	}
-	else
+
+	// Reload global configuration
+	if (m_config_override_path.empty())
 	{
-		sys_log.fatal("Failed to access global config: %s (%s)", cfg_path, fs::g_tls_error);
+		const auto cfg_path = fs::get_config_dir() + "/config.yml";
+
+		if (const fs::file cfg_file{cfg_path, fs::read + fs::create})
+		{
+			if (!g_cfg.from_string(cfg_file.to_string()))
+			{
+				sys_log.fatal("Failed to apply global config: %s", cfg_path);
+			}
+
+			g_cfg.name = cfg_path;
+		}
+		else
+		{
+			sys_log.fatal("Failed to access global config: %s (%s)", cfg_path, fs::g_tls_error);
+		}
 	}
 
 	// Create directories (can be disabled if necessary)
@@ -868,7 +894,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		sys_log.notice("Category: %s", GetCat());
 		sys_log.notice("Version: %s / %s", GetAppVersion(), version_disc);
 
-		if (!add_only && !force_global_config)
+		if (!add_only && !force_global_config && m_config_override_path.empty())
 		{
 			const std::string config_path_new = GetCustomConfigPath(m_title_id);
 			const std::string config_path_old = GetCustomConfigPath(m_title_id, true);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -60,6 +60,7 @@ class Emulator final
 	atomic_t<u64> m_pause_start_time{0}; // set when paused
 	atomic_t<u64> m_pause_amend_time{0}; // increased when resumed
 
+	std::string m_config_override_path;
 	std::string m_path;
 	std::string m_path_old;
 	std::string m_title_id;
@@ -212,6 +213,8 @@ public:
 
 	bool HasGui() const { return m_has_gui; }
 	void SetHasGui(bool has_gui) { m_has_gui = has_gui; }
+
+	void SetConfigOverride(std::string path) { m_config_override_path = std::move(path); }
 
 	std::string GetFormattedTitle(double fps) const;
 

--- a/rpcs3/util/yaml.cpp
+++ b/rpcs3/util/yaml.cpp
@@ -38,7 +38,7 @@ std::pair<YAML::Node, std::string> yaml_load(const std::string& from)
 	}
 	catch(const std::exception& e)
 	{
-		return{YAML::Node(), std::string("YAML exception:\n") + e.what()};
+		return{YAML::Node(), std::string("YAML exception: ") + e.what()};
 	}
 
 	return{result, ""};


### PR DESCRIPTION
Add config override as cli arg: `--config <path>`
And add some more logging

With this config parameter the emulator essentially skips all other config files and only applies the config file found in the specified path. 