### PR TITLE
[WIP] Hidapi return to mainline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,8 +32,7 @@
 	ignore = dirty
 [submodule "3rdparty/hidapi"]
 	path = 3rdparty/hidapi
-	url = https://github.com/RPCS3/hidapi
-	branch = master
+	url = https://github.com/libusb/hidapi
 	ignore = dirty
 [submodule "3rdparty/pugixml"]
 	path = 3rdparty/pugixml

--- a/.gitmodules
+++ b/.gitmodules
@@ -33,6 +33,7 @@
 [submodule "3rdparty/hidapi"]
 	path = 3rdparty/hidapi
 	url = https://github.com/libusb/hidapi
+	branch = cmake-support
 	ignore = dirty
 [submodule "3rdparty/pugixml"]
 	path = 3rdparty/pugixml

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -107,30 +107,10 @@ add_subdirectory(pugixml EXCLUDE_FROM_ALL)
 
 
 # hidapi
-add_library(3rdparty_hidapi INTERFACE)
-target_include_directories(3rdparty_hidapi INTERFACE hidapi/hidapi)
-
-if(APPLE)
-	add_subdirectory(hidapi/mac EXCLUDE_FROM_ALL)
-	target_include_directories(hidapi-mac PUBLIC hidapi/hidapi)
-
-	target_link_libraries(3rdparty_hidapi INTERFACE hidapi-mac "-framework CoreFoundation" "-framework IOKit")
-elseif(CMAKE_SYSTEM MATCHES "Linux")
-	add_subdirectory(hidapi/linux EXCLUDE_FROM_ALL)
-	target_include_directories(hidapi-hidraw PUBLIC hidapi/hidapi)
-
-	target_link_libraries(3rdparty_hidapi INTERFACE hidapi-hidraw udev)
-elseif(WIN32)
-	add_subdirectory(hidapi/windows EXCLUDE_FROM_ALL)
-	target_include_directories(hidapi-hid PUBLIC hidapi/hidapi)
-
-	target_link_libraries(3rdparty_hidapi INTERFACE hidapi-hid Shlwapi.lib)
-else()
-	add_subdirectory(hidapi/libusb EXCLUDE_FROM_ALL)
-	target_include_directories(hidapi-libusb PUBLIC hidapi/hidapi)
-
-	target_link_libraries(3rdparty_hidapi INTERFACE hidapi-libusb usb)
-endif()
+message(STATUS hidapi)
+#add_library(3rdparty_hidapi INTERFACE)
+#target_include_directories(3rdparty_hidapi INTERFACE hidapi/hidapi)
+add_subdirectory(hidapi/src EXCLUDE_FROM_ALL)
 
 
 # libusb
@@ -467,7 +447,7 @@ add_library(3rdparty::flatbuffers ALIAS 3rdparty_flatbuffers)
 add_library(3rdparty::pugixml ALIAS pugixml)
 add_library(3rdparty::yaml-cpp ALIAS yaml-cpp)
 add_library(3rdparty::xxhash ALIAS xxhash)
-add_library(3rdparty::hidapi ALIAS 3rdparty_hidapi)
+#add_library(3rdparty::hidapi ALIAS hidapi)
 add_library(3rdparty::libpng ALIAS ${LIBPNG_TARGET})
 add_library(3rdparty::cereal ALIAS 3rdparty_cereal)
 add_library(3rdparty::opengl ALIAS 3rdparty_opengl)

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.8.2)
 
 if(USE_PRECOMPILED_HEADERS AND NOT COMMAND target_precompile_headers)
 	include(cotire)
@@ -83,7 +83,7 @@ set_target_properties(rpcs3
 		AUTOUIC ON)
 
 target_link_libraries(rpcs3 rpcs3_emu rpcs3_ui)
-target_link_libraries(rpcs3 3rdparty::discord-rpc 3rdparty::qt5 3rdparty::hidapi 3rdparty::libusb 3rdparty::wolfssl)
+target_link_libraries(rpcs3 3rdparty::discord-rpc 3rdparty::qt5 hidapi 3rdparty::libusb 3rdparty::wolfssl)
 target_link_libraries(rpcs3 ${ADDITIONAL_LIBS})
 
 # Win resource file

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "ds3_pad_handler.h"
 #include "Emu/Io/pad_config.h"
 
@@ -62,7 +62,11 @@ ds3_pad_handler::~ds3_pad_handler()
 			hid_close(controller->handle);
 		}
 	}
-	hid_exit();
+
+	if (hid_exit() != 0)
+	{
+		ds3_log.warning("Failed to exit hidapi for the DS3 pad handler");
+	}
 }
 
 bool ds3_pad_handler::init_usb()

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -609,7 +609,7 @@ int ds4_pad_handler::SendVibrateData(const std::shared_ptr<DS4Device>& device)
 		outputBuf[76] = (crcCalc >> 16) & 0xFF;
 		outputBuf[77] = (crcCalc >> 24) & 0xFF;
 
-		return hid_write_control(device->hidDevice, outputBuf.data(), DS4_OUTPUT_REPORT_0x11_SIZE);
+		return hid_write(device->hidDevice, outputBuf.data(), DS4_OUTPUT_REPORT_0x11_SIZE);
 	}
 	else
 	{

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -103,7 +103,7 @@ target_link_libraries(rpcs3_ui
 		rpcs3_emu
 		3rdparty::zlib 3rdparty::pugixml
 		3rdparty::discord-rpc
-		3rdparty::hidapi
+		hidapi
 		3rdparty::libusb
 		3rdparty::libpng
 		3rdparty::7z


### PR DESCRIPTION
A migration away from the custom hidapi repo that we had (for Windows DS3/DS4 rumble /light support?) back to mainline hidapi.

Also added another pair of diagnostic messages if we didn't manage to successfully call hidapi_exit which might help get more info around #5692.
Whilst in the ds3/ds4 code, I also renamed the SendVibrateData function to send_output_report since it does more than just the vibrate data. The ds3 code already appeared to be inline with this.
Also re-ordered the ds4 pad handler more in line with efficiency guidance (grouping items of the same size together).