### PR TITLE
[TESTERS NEEDED] Improve Package install menu option

### DIFF
--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -133,7 +133,7 @@ private:
 
 	static bool InstallRapFile(const QString& path, const std::string& filename);
 
-	void InstallPackages(QStringList file_paths = QStringList(), bool show_confirm = true);
+	void InstallPackages(QStringList file_paths = QStringList());
 	void HandlePackageInstallation(QStringList file_paths = QStringList());
 
 	void InstallPup(QString filePath = "");

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -131,6 +131,8 @@ private:
 	void EnableMenus(bool enabled);
 	void ShowTitleBars(bool show);
 
+	static bool InstallRapFile(const QString& path, const std::string& filename);
+
 	void InstallPackages(QStringList file_paths = QStringList(), bool show_confirm = true);
 	void HandlePackageInstallation(QStringList file_paths = QStringList());
 

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -141,7 +141,7 @@
      <x>0</x>
      <y>0</y>
      <width>1058</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <property name="contextMenuPolicy">
@@ -392,7 +392,7 @@
   </action>
   <action name="bootInstallPkgAct">
    <property name="text">
-    <string>Install .pkg</string>
+    <string>Install Packages/Raps</string>
    </property>
    <property name="toolTip">
     <string>Install application from a .pkg file</string>


### PR DESCRIPTION
#### Changes
- Renamed "Install PKG" to "Install Packages/Raps"
- The related file dialog now accepts rap files too
- The related file dialog now accepts multiple files
- The installation of multiple packages opens the same dialog as the drag and drop action.
- Rap files now overwrite the old files and throw an error if this isn't possible

#### Please test
- [x] Rap installations from drag and drop.
- [x] Single Package installation from drag and drop.
- [x] Multiple Packages installation from drag and drop.
- [x] Rap installations using the menu.
- [x] Single Package installations using the menu.
- [x] Multiple Packages installation using the menu.
- [x] Mixed Package/Rap installation using the menu.