### PR TITLE
[HOTFIX] rsx: Improve swizzled layout detection

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1089,6 +1089,7 @@ namespace rsx
 
 			gcm_format = 0;
 			pack_unpack_swap_bytes = false;
+			swizzled = false;
 
 			sync_timestamp = 0ull;
 			synchronized = false;

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -95,6 +95,11 @@ namespace gl
 				ASSERT(!managed_texture);
 			}
 
+			if (auto rtt = dynamic_cast<gl::render_target*>(image))
+			{
+				swizzled = (rtt->raster_type != rsx::surface_raster_type::linear);
+			}
+
 			flushed = false;
 			synchronized = false;
 			sync_timestamp = 0ull;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -66,6 +66,11 @@ namespace vk
 				managed_texture.reset(vram_texture);
 			}
 
+			if (auto rtt = dynamic_cast<vk::render_target*>(image))
+			{
+				swizzled = (rtt->raster_type != rsx::surface_raster_type::linear);
+			}
+
 			if (synchronized)
 			{
 				// Even if we are managing the same vram section, we cannot guarantee contents are static


### PR DESCRIPTION
- Reset swizzle flag to false automatically on section reset.
- Detect render target payload and extract swizzle information from it.

Follow-up to https://github.com/RPCS3/rpcs3/pull/8664
Fixes https://github.com/RPCS3/rpcs3/issues/8692