### PR TITLE
Utils: Add detection for Icelake-client tier AVX-512

### DIFF
--- a/Utilities/sysinfo.cpp
+++ b/Utilities/sysinfo.cpp
@@ -64,6 +64,13 @@ bool utils::has_avx512()
 	return g_value;
 }
 
+bool utils::has_avx512_icl()
+{
+	// Check AVX512IFMA, AVX512VBMI, AVX512VBMI2, AVX512VPOPCNTDQ, AVX512BITALG, AVX512VNNI, AVX512VPCLMULQDQ, AVX512GFNI, AVX512VAES (Icelake-client level support)
+	static const bool g_value = has_avx512() && (get_cpuid(7, 0)[1] & 0x00200000) == 0x00200000 && (get_cpuid(7, 0)[2] & 0x00005f42) == 0x00005f42;
+	return g_value;
+}
+
 bool utils::has_xop()
 {
 	static const bool g_value = has_avx() && get_cpuid(0x80000001, 0)[2] & 0x800;
@@ -145,12 +152,16 @@ std::string utils::get_system_info()
 	{
 		result += " | AVX";
 
-		if (has_avx2())
-		{
-			result += '+';
-		}
-
 		if (has_avx512())
+		{
+			result += "-512";
+
+			if (has_avx512_icl())
+			{
+				result += '+';
+			}
+		}
+		else if (has_avx2())
 		{
 			result += '+';
 		}

--- a/Utilities/sysinfo.h
+++ b/Utilities/sysinfo.h
@@ -43,6 +43,8 @@ namespace utils
 
 	bool has_avx512();
 
+	bool has_avx512_icl();
+
 	bool has_xop();
 
 	bool has_clwb();


### PR DESCRIPTION
Newer processors have a much wider range of AVX-512 instructions avaliable than Skylake-X does, so let's detect that.

Icelake-client tier AVX-512 Implies support for everything that Skylake-X supports (`AVX512F, AVX512CD, AVX512DQ, AVX512BW, AVX512VL`) as well as `AVX512IFMA, AVX512VBMI, AVX512VBMI2, AVX512VPOPCNTDQ, AVX512BITALG, AVX512VNNI, AVX512VPCLMULQDQ, AVX512GFNI,` and `AVX512VAES`

The logging was also changed a little. If you have AVX-512 it will now print AVX-512 in the log, rather than AVX++. Icelake-client tier support is indicated by AVX-512+.