### PR TITLE
[WIP][TESTERS NEEDED] SPU LLVM:  PUTLLC 16 Optimization

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -805,6 +805,9 @@ void spu_cache::initialize(bool build_existing_cache)
 
 		compiler->init();
 
+		// Counter for error reporting
+		u32 logged_error = 0;
+
 		// How much every thread compiled
 		uint result = 0;
 
@@ -864,6 +867,14 @@ void spu_cache::initialize(bool build_existing_cache)
 			if (func2 != func)
 			{
 				spu_log.error("[0x%05x] SPU Analyser failed, %u vs %u", func2.entry_point, func2.data.size(), size0);
+
+				if (logged_error < 2)
+				{
+					std::string log;
+					compiler->dump(func, log);
+					spu_log.notice("[0x%05x] Function: %s", func.entry_point, log);
+					logged_error++;
+				}
 			}
 			else if (!compiler->compile(std::move(func2)))
 			{

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -668,6 +668,7 @@ public:
 
 	// May be used by recompilers.
 	u8* memory_base_addr = vm::g_base_addr;
+	u8* reserv_base_addr = vm::g_reservations;
 
 	// General-Purpose Registers
 	std::array<v128, 128> gpr;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -64,7 +64,7 @@ struct EmuCallbacks
 	std::function<void()> on_ready;
 	std::function<bool()> on_missing_fw;
 	std::function<void(std::shared_ptr<atomic_t<bool>>, int)> on_emulation_stop_no_response;
-	std::function<void(std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, std::shared_ptr<void>)> on_save_state_progress;
+	std::function<void(std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, stx::atomic_ptr<std::string>*, std::shared_ptr<void>)> on_save_state_progress;
 	std::function<void(bool enabled)> enable_disc_eject;
 	std::function<void(bool enabled)> enable_disc_insert;
 	std::function<bool(bool, std::function<void()>)> try_to_quit; // (force_quit, on_exit) Try to close RPCS3

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -167,14 +167,18 @@ void progress_dialog_server::operator()()
 		const char* text1 = nullptr;
 
 		const u64 start_time = get_system_time();
+		u64 no_update_it = 0; 
 
 		// Update progress
 		while (!g_system_progress_stopping && thread_ctrl::state() != thread_state::aborting)
 		{
 			const auto& [text_new, ftotal_new, fdone_new, ftotal_bits_new, fknown_bits_new, ptotal_new, pdone_new] = get_state();
 
-			if (ftotal != ftotal_new || fdone != fdone_new || fknown_bits != fknown_bits_new || ftotal_bits != ftotal_bits_new || ptotal != ptotal_new || pdone != pdone_new || text_new != text1)
+			// Force-update every 20 seconds to update remaining time
+			if (no_update_it == 100u * 20 || ftotal != ftotal_new || fdone != fdone_new || fknown_bits != fknown_bits_new
+				|| ftotal_bits != ftotal_bits_new || ptotal != ptotal_new || pdone != pdone_new || text_new != text1)
 			{
+				no_update_it = 0;
 				ftotal = ftotal_new;
 				fdone  = fdone_new;
 				ftotal_bits = ftotal_bits_new;
@@ -307,7 +311,8 @@ void progress_dialog_server::operator()()
 				break;
 			}
 
-			thread_ctrl::wait_for(10000);
+			thread_ctrl::wait_for(10'000);
+			no_update_it++;
 		}
 
 		if (g_system_progress_stopping || thread_ctrl::state() == thread_state::aborting)

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -148,7 +148,7 @@ void headless_application::InitializeCallbacks()
 		}
 	};
 
-	callbacks.on_save_state_progress = [](std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, std::shared_ptr<void>)
+	callbacks.on_save_state_progress = [](std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, stx::atomic_ptr<std::string>*, std::shared_ptr<void>)
 	{
 	};
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -255,7 +255,7 @@ struct fatal_error_listener final : logs::listener
 
 	void log(u64 /*stamp*/, const logs::message& msg, const std::string& prefix, const std::string& text) override
 	{
-		if (msg == logs::level::fatal)
+		if (msg <= logs::level::fatal)
 		{
 			std::string _msg = "RPCS3: ";
 
@@ -289,8 +289,11 @@ struct fatal_error_listener final : logs::listener
 				OutputDebugStringA(_msg.c_str());
 			}
 #endif
-			// Pause emulation if fatal error encountered
-			Emu.Pause(true);
+			if (msg == logs::level::fatal)
+			{
+				// Pause emulation if fatal error encountered
+				Emu.Pause(true);
+			}
 		}
 	}
 };

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -51,6 +51,10 @@
 #include "Emu/RSX/VK/VKGSRender.h"
 #endif
 
+#ifdef _WIN32
+#include "Windows.h"
+#endif
+
 LOG_CHANNEL(gui_log, "GUI");
 
 [[noreturn]] void report_fatal_error(std::string_view text, bool is_html = false, bool include_help_text = true);
@@ -110,6 +114,20 @@ bool gui_application::Init()
 	if (!m_emu_settings->Init())
 	{
 		return false;
+	}
+
+#ifdef _WIN32
+	if (m_gui_settings->GetValue(gui::m_attachCommandLine).toBool())
+	{
+		if (AttachConsole(ATTACH_PARENT_PROCESS) || AllocConsole())
+		{
+			[[maybe_unused]] const auto con_out = freopen("CONOUT$", "w", stderr);
+		}
+	}
+	else
+#endif
+	{
+		m_gui_settings->SetValue(gui::m_attachCommandLine, false);
 	}
 
 	// The user might be set by cli arg. If not, set another user.

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -667,9 +667,9 @@ void gui_application::InitializeCallbacks()
 		});
 	};
 
-	callbacks.on_save_state_progress = [this](std::shared_ptr<atomic_t<bool>> closed_successfully, stx::shared_ptr<utils::serial> ar_ptr, std::shared_ptr<void> init_mtx)
+	callbacks.on_save_state_progress = [this](std::shared_ptr<atomic_t<bool>> closed_successfully, stx::shared_ptr<utils::serial> ar_ptr, stx::atomic_ptr<std::string>* code_location, std::shared_ptr<void> init_mtx)
 	{
-		Emu.CallFromMainThread([this, closed_successfully, ar_ptr, init_mtx]
+		Emu.CallFromMainThread([this, closed_successfully, ar_ptr, code_location, init_mtx]
 		{
 			const auto half_seconds = std::make_shared<int>(1);
 
@@ -678,30 +678,44 @@ void gui_application::InitializeCallbacks()
 			pdlg->setAutoClose(true);
 			pdlg->show();
 
-			QString text_base = tr("Waiting for %0 second(s), %1 written");
+			QString text_base = tr("%0 written, %1 second(s) passed%2");
 
-			pdlg->setLabelText(text_base.arg(0).arg("0B"));
+			pdlg->setLabelText(text_base.arg("0B").arg(1).arg(""));
 			pdlg->setAttribute(Qt::WA_DeleteOnClose);
 
 			QTimer* update_timer = new QTimer(pdlg);
 
-			connect(update_timer, &QTimer::timeout, [pdlg, ar_ptr, half_seconds, text_base, closed_successfully, init_mtx]()
+			connect(update_timer, &QTimer::timeout, [pdlg, ar_ptr, half_seconds, text_base, closed_successfully, code_location, init_mtx]()
 			{
-				auto init = static_cast<stx::init_mutex*>(init_mtx.get())->access();
+				std::string verbose_message;
+				usz bytes_written = 0;
 
-				if (!init)
 				{
-					pdlg->reject();
-					return;
+					auto init = static_cast<stx::init_mutex*>(init_mtx.get())->access();
+
+					if (!init)
+					{
+						pdlg->reject();
+						return;
+					}
+
+					if (auto str_ptr = code_location->load())
+					{
+						verbose_message = "\n" + *str_ptr;
+					}
+
+					*half_seconds += 1;
+
+					bytes_written = ar_ptr->get_size();
 				}
 
-				*half_seconds += 1;
-
-				const usz bytes_written = ar_ptr->get_size();
-				pdlg->setLabelText(text_base.arg(*half_seconds / 2).arg(gui::utils::format_byte_size(bytes_written)));
+				pdlg->setLabelText(text_base.arg(gui::utils::format_byte_size(bytes_written)).arg(*half_seconds / 2).arg(qstr(verbose_message)));
 
 				// 300MB -> 50%, 600MB -> 75%, 1200MB -> 87.5% etc
-				pdlg->setValue(std::clamp(static_cast<int>(100. - 100. / std::pow(2., std::fmax(0.01, bytes_written * 1. / (300 * 1024 * 1024)))), 2, 100));
+				const int percent = std::clamp(static_cast<int>(100. - 100. / std::pow(2., std::fmax(0.01, bytes_written * 1. / (300 * 1024 * 1024)))), 2, 100);
+
+				// Add a third of the remaining progress when the keyword is found
+				pdlg->setValue(verbose_message.find("Finalizing") != umax ? 100 - ((100 - percent) * 2 / 3) : percent);
 
 				if (*closed_successfully)
 				{

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -215,6 +215,7 @@ namespace gui
 
 	const gui_save m_currentStylesheet = gui_save(meta, "currentStylesheet", DefaultStylesheet);
 	const gui_save m_showDebugTab      = gui_save(meta, "showDebugTab",      false);
+	const gui_save m_attachCommandLine = gui_save(meta, "attachCommandLine", false);
 	const gui_save m_enableUIColors    = gui_save(meta, "enableUIColors",    false);
 	const gui_save m_richPresence      = gui_save(meta, "useRichPresence",   true);
 	const gui_save m_discordState      = gui_save(meta, "discordState",      "");


### PR DESCRIPTION
I've noticed that there are many SPU atomic ops which do not fully use the entire 128-byte memory provided for them, some only use a single 16-byte block for it. Usually about %20 to %35 from all of atomic ops only use one 16-byte block.
This brings up a thought: what if instead of executing full 128-byte atomic PUTLLC we can replace it with a 16-byte version of it which allows to optimize it with cmpxchg16b.
The way it detects it is by analyzing all stores/loads between PUTLLC and GETLLAR.
If all LS stores/loads are from the same type and use the same registers state as other stores/loads the pattern is detected.
Do note that if only loads were detected in the loop even if not from the same type and may use different addresses, this counts as if no memory operation was executed at all in the atomic op.
For safety all branch targets falling into GETLLAR<->PUTLLC range cancel out this optimization, although I haven't encountered such case yet.
Fixes GOWA with RSX reservations off but only for this game, as the pattern is detected well for it.

For all cases for where this optimization is detected it is as if "Accurate RSX reservations" was enabled so test this setting as well for performance comparisons as well as TSX vs no-TSX.

Turnaround of events:
* In order to complete this pull request properly, I implemented advacned cross-blocks SPU code analysis that retains pattern data across "future" and "past" code blocks. This is probably one of the most important SPU pull requests in years to come, laying the ground for many optimizations to come.