### PR TITLE
SPU LLVM: Add icelake optimized paths for SHUFB

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -2785,6 +2785,21 @@ public:
 		return result;
 	}
 
+	template <typename T1, typename T2>
+	value_t<u8[16]> gf2p8affineqb(T1 a, T2 b, u8 c)
+	{
+		value_t<u8[16]> result;
+
+		const auto data0 = a.eval(m_ir);
+		const auto data1 = b.eval(m_ir);
+
+		const auto immediate = (llvm_const_int<u8>{c});
+		const auto imm8 = immediate.eval(m_ir);
+
+		result.value = m_ir->CreateCall(get_intrinsic(llvm::Intrinsic::x86_vgf2p8affineqb_128), {data0, data1, imm8});
+		return result;
+	}
+
 	template <typename T1, typename T2, typename T3>
 	value_t<u8[16]> vperm2b(T1 a, T2 b, T3 c)
 	{

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7277,10 +7277,20 @@ public:
 		{
 			if (auto [ok, v1] = match_expr(b, byteswap(match<u8[16]>())); ok)
 			{
-				// Undo endian swapping, and rely on pshufb to re-reverse endianness
-				const auto x = avg(noncast<u8[16]>(sext<s8[16]>((c & 0xc0) == 0xc0)), noncast<u8[16]>(sext<s8[16]>((c & 0xe0) == 0xc0)));
+				// Undo endian swapping, and rely on pshufb/vperm2b to re-reverse endianness
 				const auto as = byteswap(a);
 				const auto bs = byteswap(b);
+
+				if (m_use_avx512_icl && (op.ra != op.rb || m_interp_magn))
+				{
+					const auto m = gf2p8affineqb(build<u8[16]>(0x02, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x02, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04), c, 0x7f);
+					const auto mm = select(noncast<s8[16]>(m) >= 0, splat<u8[16]>(0), m);
+					const auto ab = vperm2b(as, bs, c);
+					set_vr(op.rt4, select(noncast<s8[16]>(c) >= 0, ab, mm));
+					return;
+				}
+
+				const auto x = avg(noncast<u8[16]>(sext<s8[16]>((c & 0xc0) == 0xc0)), noncast<u8[16]>(sext<s8[16]>((c & 0xe0) == 0xc0)));
 				const auto ax = pshufb(as, c);
 				const auto bx = pshufb(bs, c);
 				set_vr(op.rt4, select(noncast<s8[16]>(c << 3) >= 0, ax, bx) | x);
@@ -7317,6 +7327,16 @@ public:
 					return;
 				}
 			}
+		}
+
+		if (m_use_avx512_icl && (op.ra != op.rb || m_interp_magn))
+		{
+			const auto m = gf2p8affineqb(build<u8[16]>(0x02, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x02, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04), c, 0x7f);
+			const auto mm = select(noncast<s8[16]>(m) >= 0, splat<u8[16]>(0), m);
+			const auto cr = eval(~c);
+			const auto ab = vperm2b(b, a, cr);
+			set_vr(op.rt4, select(noncast<s8[16]>(cr) >= 0, mm, ab));
+			return;
 		}
 
 		const auto x = avg(noncast<u8[16]>(sext<s8[16]>((c & 0xc0) == 0xc0)), noncast<u8[16]>(sext<s8[16]>((c & 0xe0) == 0xc0)));


### PR DESCRIPTION
The main trick is here is that we make use of the VGF2P8AFFINEQB instruction as a makeshift "shuffle bits" instruction. (see [this ](http://0x80.pl/articles/avx512-galois-field-for-bit-shuffling.html)for an exmaple) This instruction is intended for cryptography purposes and is only 1uop.

The intent is to handle the "special case" values of SHUFB more efficiently, that is:
```
10xxxxxx = 0x00
110xxxxx = 0xFF
111xxxxx = 0x80
```
After executing VGF2P8AFFINEQB with our mask on the SHUFB index we will get the values:
```
10xxxxxx = 0x00
110xxxxx = 0x80
111xxxxx = 0xFF
```
To fix up the results, we need to xor with 0x7F. Luckily VGF2P8AFFINEQB let's us embed that into the instruction itself, which will give us:
```
10xxxxxx = 0x7F
110xxxxx = 0xFF
111xxxxx = 0x80
```
The result for `10xxxxxx` is wrong, so we need to force it to zero. We can use a blend instruction here on our result, since the blend instruction is conditional based off of the most significant bit, and will let us fixup `10xxxxxx` while leaving the other cases alone.

Here's a breakdown of the instructions needed:
`AVX512-ICL path:`
```
1 VGF2P8AFFINEQB - 1 uop
2 Blends - 4 uops
1 ternlogd (bitwise not) - 1 uop
1 VPERM2B  - 3 uops
```

total: 9 uops, 1 constant needed (mask for VGF2P8AFFINEQB)

`generic path:`
```
2 ANDs - 2 uops
2 Compares - 2 uops
1 AVG - 1 uop
1 XOR - 1 uop
2 PSHUFB - 2 uops
1 shift left - 1 uop
1 Blend - 2 uops
1 OR - 1 uop
```
total: 12 uops, 3 constants needed ( 0xf, 0xc0, and 0xe0)

