### PR TITLE
Debugger: Fix PPU stepping on non-TSX

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -553,7 +553,7 @@ bool cpu_thread::check_state() noexcept
 		}
 		else
 		{
-			if (state0 == (cpu_flag::memory + cpu_flag::wait))
+			if (state0 & cpu_flag::memory)
 			{
 				vm::passive_lock(*this);
 				continue;


### PR DESCRIPTION
Something with unhandled non-TSX reservation pauses so stepping in this case causes a deadlock.