### PR TITLE
Debugger: Use Signed Hexadecimal formatting for immediates

### DIFF
--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -56,7 +56,23 @@ protected:
 
 	virtual u32 DisAsmBranchTarget(const s32 imm) = 0;
 
-	std::string FixOp(std::string op)
+	// TODO: Add builtin fmt helpper for best performance
+	template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+	static std::string SignedHex(T value)
+	{
+		const auto v = static_cast<std::make_signed_t<T>>(value);
+		const auto av = std::abs(v);
+
+		if (av < 10)
+		{
+			// Does not need hex
+			return fmt::format("%d", v);
+		}
+
+		return fmt::format("%s%s", v < 0 ? "-" : "", av);
+	}
+
+	static std::string FixOp(std::string op)
 	{
 		op.resize(std::max<std::size_t>(op.length(), 10), ' ');
 		return op;

--- a/rpcs3/Emu/Cell/PPCDisAsm.h
+++ b/rpcs3/Emu/Cell/PPCDisAsm.h
@@ -17,7 +17,7 @@ protected:
 	}
 	void DisAsm_V3_UIMM(const std::string& op, u32 v0, u32 v1, u32 v2, u32 uimm)
 	{
-		Write(fmt::format("%s v%d,v%d,v%d,%u #%x", FixOp(op), v0, v1, v2, uimm, uimm));
+		Write(fmt::format("%s v%d,v%d,v%d,%s", FixOp(op), v0, v1, v2, uimm));
 	}
 	void DisAsm_V3(const std::string& op, u32 v0, u32 v1, u32 v2)
 	{
@@ -25,7 +25,7 @@ protected:
 	}
 	void DisAsm_V2_UIMM(const std::string& op, u32 v0, u32 v1, u32 uimm)
 	{
-		Write(fmt::format("%s v%d,v%d,%u #%x", FixOp(op), v0, v1, uimm, uimm));
+		Write(fmt::format("%s v%d,v%d,%s", FixOp(op), v0, v1, uimm));
 	}
 	void DisAsm_V2(const std::string& op, u32 v0, u32 v1)
 	{
@@ -33,7 +33,7 @@ protected:
 	}
 	void DisAsm_V1_SIMM(const std::string& op, u32 v0, s32 simm)
 	{
-		Write(fmt::format("%s v%d,%d #%x", FixOp(op), v0, simm, simm));
+		Write(fmt::format("%s v%d,%s", FixOp(op), v0, SignedHex(simm)));
 	}
 	void DisAsm_V1(const std::string& op, u32 v0)
 	{
@@ -57,7 +57,7 @@ protected:
 	}
 	void DisAsm_INT1_R1_IMM(const std::string& op, u32 i0, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s %d,r%d,%d #%x", FixOp(op), i0, r0, imm0, imm0));
+		Write(fmt::format("%s %d,r%d,%s", FixOp(op), i0, r0, SignedHex(imm0)));
 	}
 	void DisAsm_INT1_R1_RC(const std::string& op, u32 i0, u32 r0, u32 rc)
 	{
@@ -101,11 +101,11 @@ protected:
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s%s f%d,r%d,%d #%x", FixOp(op), (rc ? "." : ""), f0, r0, imm0, imm0));
+			Write(fmt::format("%s%s f%d,r%d,%s", FixOp(op), (rc ? "." : ""), f0, r0, SignedHex(imm0)));
 			return;
 		}
 
-		Write(fmt::format("%s%s f%d,%d(r%d) #%x", FixOp(op), (rc ? "." : ""), f0, imm0, r0, imm0));
+		Write(fmt::format("%s%s f%d,%s(r%d)", FixOp(op), (rc ? "." : ""), f0, SignedHex(imm0), r0));
 	}
 	void DisAsm_F1_IMM_R1(const std::string& op, u32 f0, s32 imm0, u32 r0)
 	{
@@ -179,15 +179,15 @@ protected:
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s r%d,r%d,%d  #%x", FixOp(op), r0, r1, imm0, imm0));
+			Write(fmt::format("%s r%d,r%d,%s", FixOp(op), r0, r1, SignedHex(imm0)));
 			return;
 		}
 
-		Write(fmt::format("%s r%d,%d(r%d)  #%x", FixOp(op), r0, imm0, r1, imm0));
+		Write(fmt::format("%s r%d,%s(r%d)", FixOp(op), r0, SignedHex(imm0), r1));
 	}
 	void DisAsm_R1_IMM(const std::string& op, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s r%d,%d  #%x", FixOp(op), r0, imm0, imm0));
+		Write(fmt::format("%s r%d,%s", FixOp(op), r0, SignedHex(imm0)));
 	}
 	void DisAsm_IMM_R1(const std::string& op, s32 imm0, u32 r0)
 	{
@@ -195,7 +195,7 @@ protected:
 	}
 	void DisAsm_CR1_R1_IMM(const std::string& op, u32 cr0, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s cr%d,r%d,%d  #%x", FixOp(op), cr0, r0, imm0, imm0));
+		Write(fmt::format("%s cr%d,r%d,%s", FixOp(op), cr0, r0, SignedHex(imm0)));
 	}
 	void DisAsm_CR1_R2_RC(const std::string& op, u32 cr0, u32 r0, u32 r1, u32 rc)
 	{

--- a/rpcs3/Emu/Cell/PPUDisAsm.h
+++ b/rpcs3/Emu/Cell/PPUDisAsm.h
@@ -35,7 +35,7 @@ private:
 	}
 	void DisAsm_V3_UIMM(const std::string& op, u32 v0, u32 v1, u32 v2, u32 uimm)
 	{
-		Write(fmt::format("%s v%d,v%d,v%d,%u #%x", FixOp(op), v0, v1, v2, uimm, uimm));
+		Write(fmt::format("%s v%d,v%d,v%d,%s", FixOp(op), v0, v1, v2, uimm));
 	}
 	void DisAsm_V3(const std::string& op, u32 v0, u32 v1, u32 v2)
 	{
@@ -43,7 +43,7 @@ private:
 	}
 	void DisAsm_V2_UIMM(const std::string& op, u32 v0, u32 v1, u32 uimm)
 	{
-		Write(fmt::format("%s v%d,v%d,%u #%x", FixOp(op), v0, v1, uimm, uimm));
+		Write(fmt::format("%s v%d,v%d,%s", FixOp(op), v0, v1, uimm));
 	}
 	void DisAsm_V2(const std::string& op, u32 v0, u32 v1)
 	{
@@ -51,7 +51,7 @@ private:
 	}
 	void DisAsm_V1_SIMM(const std::string& op, u32 v0, s32 simm)
 	{
-		Write(fmt::format("%s v%d,%d #%x", FixOp(op), v0, simm, simm));
+		Write(fmt::format("%s v%d,%s", FixOp(op), v0, SignedHex(simm)));
 	}
 	void DisAsm_V1(const std::string& op, u32 v0)
 	{
@@ -75,7 +75,7 @@ private:
 	}
 	void DisAsm_INT1_R1_IMM(const std::string& op, u32 i0, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s %d,r%d,%d #%x", FixOp(op), i0, r0, imm0, imm0));
+		Write(fmt::format("%s %d,r%d,%s", FixOp(op), i0, r0, SignedHex(imm0)));
 	}
 	void DisAsm_INT1_R1_RC(const std::string& op, u32 i0, u32 r0, u32 rc)
 	{
@@ -119,11 +119,11 @@ private:
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s f%d,r%d,%d #%x", FixOp(op + (rc ? "." : "")), f0, r0, imm0, imm0));
+			Write(fmt::format("%s f%d,r%d,%s", FixOp(op + (rc ? "." : "")), f0, r0, SignedHex(imm0)));
 			return;
 		}
 
-		Write(fmt::format("%s f%d,%d(r%d) #%x", FixOp(op + (rc ? "." : "")), f0, imm0, r0, imm0));
+		Write(fmt::format("%s f%d,%s(r%d)", FixOp(op + (rc ? "." : "")), f0, SignedHex(imm0), r0));
 	}
 	void DisAsm_F1_IMM_R1(const std::string& op, u32 f0, s32 imm0, u32 r0)
 	{
@@ -197,15 +197,15 @@ private:
 	{
 		if(m_mode == CPUDisAsm_CompilerElfMode)
 		{
-			Write(fmt::format("%s r%d,r%d,%d  #%x", FixOp(op), r0, r1, imm0, imm0));
+			Write(fmt::format("%s r%d,r%d,%s", FixOp(op), r0, r1, SignedHex(imm0)));
 			return;
 		}
 
-		Write(fmt::format("%s r%d,%d(r%d)  #%x", FixOp(op), r0, imm0, r1, imm0));
+		Write(fmt::format("%s r%d,%s(r%d)", FixOp(op), r0, SignedHex(imm0), r1));
 	}
 	void DisAsm_R1_IMM(const std::string& op, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s r%d,%d  #%x", FixOp(op), r0, imm0, imm0));
+		Write(fmt::format("%s r%d,%s", FixOp(op), r0, SignedHex(imm0)));
 	}
 	void DisAsm_IMM_R1(const std::string& op, s32 imm0, u32 r0)
 	{
@@ -213,7 +213,7 @@ private:
 	}
 	void DisAsm_CR1_R1_IMM(const std::string& op, u32 cr0, u32 r0, s32 imm0)
 	{
-		Write(fmt::format("%s cr%d,r%d,%d  #%x", FixOp(op), cr0, r0, imm0, imm0));
+		Write(fmt::format("%s cr%d,r%d,%s", FixOp(op), cr0, r0, SignedHex(imm0)));
 	}
 	void DisAsm_CR1_R2_RC(const std::string& op, u32 cr0, u32 r0, u32 r1, u32 rc)
 	{

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -122,7 +122,7 @@ private:
 	}
 	void DisAsm(std::string op, const char* a1, int a2)
 	{
-		Write(fmt::format("%s %s,0x%x", FixOp(op), a1, a2));
+		Write(fmt::format("%s %s,%s", FixOp(op), a1, SignedHex(a2)));
 	}
 	void DisAsm(std::string op, int a1, int a2)
 	{
@@ -134,11 +134,11 @@ private:
 	}
 	void DisAsm(std::string op, const char* a1, int a2, const char* a3)
 	{
-		Write(fmt::format("%s %s,0x%x(%s)", FixOp(op), a1, a2, a3));
+		Write(fmt::format("%s %s,%s(%s)", FixOp(op), a1, SignedHex(a2), a3));
 	}
 	void DisAsm(std::string op, const char* a1, const char* a2, int a3)
 	{
-		Write(fmt::format("%s %s,%s,0x%x", FixOp(op), a1, a2, a3));
+		Write(fmt::format("%s %s,%s,%s", FixOp(op), a1, a2, SignedHex(a3)));
 	}
 	void DisAsm(std::string op, const char* a1, const char* a2, const char* a3, const char* a4)
 	{
@@ -819,7 +819,7 @@ public:
 	}
 	void ORBI(spu_opcode_t op)
 	{
-		DisAsm("orbi", spu_reg_name[op.rt], spu_reg_name[op.ra], op.si10);
+		DisAsm("orbi", spu_reg_name[op.rt], spu_reg_name[op.ra], static_cast<u8>(op.si10));
 	}
 	void SFI(spu_opcode_t op)
 	{
@@ -839,7 +839,7 @@ public:
 	}
 	void ANDBI(spu_opcode_t op)
 	{
-		DisAsm("andbi", spu_reg_name[op.rt], spu_reg_name[op.ra], op.si10);
+		DisAsm("andbi", spu_reg_name[op.rt], spu_reg_name[op.ra], static_cast<u8>(op.si10));
 	}
 	void AI(spu_opcode_t op)
 	{
@@ -867,7 +867,7 @@ public:
 	}
 	void XORBI(spu_opcode_t op)
 	{
-		DisAsm("xorbi", spu_reg_name[op.rt], spu_reg_name[op.ra], op.si10);
+		DisAsm("xorbi", spu_reg_name[op.rt], spu_reg_name[op.ra], static_cast<u8>(op.si10));
 	}
 	void CGTI(spu_opcode_t op)
 	{


### PR DESCRIPTION
Signed hexadecimal format rules in this pull request:
1. Values which are negative will be preceeded by a minus sign.
2. Values which their absolute value is greater than 9 will be preceeded by a `0x` prefix in addition to the above sign character rule.

Use a single representation for cleaner output with no additional represenation after '#' sign as I will readd this field in the future for a much more useful purpose.

I also took the liberty to fix SPU instructions output which use in practice 8-bit unsigned immediates but in code use op.si10 such as ANDBI.
  
PPU Examples:
 
`lwz r31, -256(r1) #ffffff00`
Will become:
`lwz r31, -0x100(r1)`

`xori r6, -8(r1) #fffffff8`
Will become:
`xori r6, -8(r1)`

`ori r3, 2(r1) #2`
Will become:
`ori r3, 2(r1)`

SPU Examples (SPU didn't use # field already):

`ai $31, 0xffffffff`
Will become
`ai $31, -1`

`andbi $6, 0xffffffb0`
Will become
`andbi $6, 0xb0`