### PR TITLE
SPU: Fix timer events

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2362,9 +2362,12 @@ u32 spu_thread::get_events(bool waiting)
 		raddr = 0;
 	}
 
-	// SPU Decrementer Event
-	if (!ch_dec_value || (ch_dec_value - (get_timebased_time() - ch_dec_start_timestamp)) >> 31)
+	// SPU Decrementer Event on underflow (use the upper 32-bits to determine it)
+	if (const u64 res = (ch_dec_value - (get_timebased_time() - ch_dec_start_timestamp)) >> 32)
 	{
+		// Set next event to the next time the decrementer underflows
+		ch_dec_start_timestamp -= res << 32;
+
 		if ((ch_event_stat & SPU_EVENT_TM) == 0)
 		{
 			ch_event_stat |= SPU_EVENT_TM;


### PR DESCRIPTION
What the SPU timers event is for: because the SPU timer is a very incapable 32-bit timer, it underflows relatively frequantely (about a little more than a minute) and when it does the event is there to notify the program to readjust its time calculations. (a bit like a carry on unsigned overflow)

What's fixed:
* The event was fired as long as the value was negative - wrong! only when underflow occurs the event should be fired and only once per undeflow. (i.e. when its value exactly becomes UINT32_MAX after 0)
* As long as ch_dec_value is 0 the event was fired (such as if  SYS_SPU_THREAD_OPTION_DEC_SYNC_TB_ENABLE was unset) - wrong! obvious bug so there's not much to discuss on it,
