### PR TITLE
ci: attempt to unbreak CI for Windows [hotfix]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
     - task: VSBuild@1
       inputs:
         solution: 'rpcs3.sln'
-        vsVersion: 16.6
+        vsVersion: 15.0
         maximumCpuCount: true
         platform: x64
         configuration: 'Release - LLVM'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
     - task: VSBuild@1
       inputs:
         solution: 'rpcs3.sln'
-        vsVersion: 15.0
+        vsVersion: '15.0'
         maximumCpuCount: true
         platform: x64
         configuration: 'Release - LLVM'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
     - task: VSBuild@1
       inputs:
         solution: 'rpcs3.sln'
-        vsVersion: '15.0'
+        msbuildArgs: '-tv:19.26'
         maximumCpuCount: true
         platform: x64
         configuration: 'Release - LLVM'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,7 @@ jobs:
     - task: VSBuild@1
       inputs:
         solution: 'rpcs3.sln'
+        vsVersion: 16.6
         maximumCpuCount: true
         platform: x64
         configuration: 'Release - LLVM'


### PR DESCRIPTION
Azure just bumped their VS Build Tools version, but compilation is broken right now on 16.7.x, so this puts us back to 16.6 until MSVC gets fixed up.

**Edit:** This is not how it works, you can only specify major versions with `vsVersion` apparently, and it will automatically pick the latest minor release from them. For some mysterious reason however it rejects `15.0`, so there's really no choice to be had here, it'll build with `16.7.x` no matter the setting. Then again, even if it did let us do `15.0`, the last minor release of the `15.x` versions is probably insufficient to build RPCS3 by now. So for now, no more Windows builds I guess?