### PR TITLE
Forces MSVC Toolkit to 14.25.28610 in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,7 @@ jobs:
         maximumCpuCount: true
         platform: x64
         configuration: 'Release - LLVM'
+        msbuildArgs: '/p:VCToolsVersion=14.25.28610'
       displayName: Compile RPCS3
 
     - bash: .ci/deploy-windows.sh


### PR DESCRIPTION
Forces toolkit to 14.25.28610 on Azure so that we don't get the build errors with templates.
It hopefully can be removed once VS 16.8 is the official image on Azure.