### PR TITLE
Fix auto exit

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1957,7 +1957,7 @@ void Emulator::Stop(bool restart)
 	// Always Enable display sleep, not only if it was prevented.
 	enable_display_sleep();
 
-	if (Quit(g_cfg.misc.autoexit.get()))
+	if (!m_force_boot && Quit(g_cfg.misc.autoexit.get()))
 	{
 		return;
 	}

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -285,7 +285,11 @@ bool gs_frame::get_mouse_lock_state()
 
 void gs_frame::close()
 {
-	Emu.Stop();
+	if (!Emu.IsStopped())
+	{
+		Emu.Stop();
+	}
+
 	Emu.CallAfter([this]() { deleteLater(); });
 }
 


### PR DESCRIPTION
- Don't quit in Emu.Stop if force boot was set.
- Don't stop the emulator in gs_frame::close when it was already stopped. This would remove the force boot flag by mistake

Fixes a regression from #8550.
Should Fix #8719