### PR TITLE
GUI: Auto-hide of mouse cursor if idle

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -75,10 +75,6 @@ gs_frame::gs_frame(const QRect& geometry, const QIcon& appIcon, const std::share
 	// Configure the mouse hide on idle timer
 	connect(&m_mousehide_timer, &QTimer::timeout, this, &gs_frame::MouseHideTimeout);
 	m_mousehide_timer.setSingleShot(true);
-	if (m_hide_mouse_after_idletime)
-	{
-		m_mousehide_timer.start(m_hide_mouse_idletime); // we start the idle timer
-	}
 
 #ifdef _WIN32
 	m_tb_button = new QWinTaskbarButton();

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -73,7 +73,7 @@ gs_frame::gs_frame(const QRect& geometry, const QIcon& appIcon, const std::share
 	connect(this, &QWindow::visibilityChanged, this, &gs_frame::HandleCursor);
 
 	// Configure the mouse hide on idle timer
-	connect(&m_mousehide_timer, &QTimer::timeout, &gs_frame::MouseHideTimeout);
+	connect(&m_mousehide_timer, &QTimer::timeout, this, &gs_frame::MouseHideTimeout);
 	m_mousehide_timer.setSingleShot(true);
 	if (m_hide_mouse_after_idletime)
 	{

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -8,7 +8,6 @@
 #include "Emu/Cell/Modules/cellScreenshot.h"
 
 #include <QCoreApplication>
-#include <QTimer>
 #include <QKeyEvent>
 #include <QMessageBox>
 #include <string>
@@ -74,7 +73,7 @@ gs_frame::gs_frame(const QRect& geometry, const QIcon& appIcon, const std::share
 	connect(this, &QWindow::visibilityChanged, this, &gs_frame::HandleCursor);
 
 	// Configure the mouse hide on idle timer
-	connect(&m_mousehide_timer, SIGNAL(timeout()), this, SLOT(MouseHideTimeout()));
+	connect(&m_mousehide_timer, &QTimer::timeout, &gs_frame::MouseHideTimeout);
 	m_mousehide_timer.setSingleShot(true);
 	if (m_hide_mouse_after_idletime)
 	{
@@ -527,7 +526,7 @@ bool gs_frame::event(QEvent* ev)
 		}
 		close();
 	}
-	if (ev->type() == QEvent::MouseMove)
+	else if (ev->type() == QEvent::MouseMove)
 	{
 		// this will make the cursor visible again if it was hidden by the mouse idle timeout
 		gs_frame::HandleCursor(visibility());

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -38,7 +38,7 @@ private:
 	bool m_disable_kb_hotkeys = false;
 	bool m_show_mouse_in_fullscreen = false;
 	bool m_hide_mouse_after_idletime = false;
-	u32 m_hide_mouse_idletime = 2000; // 2000 milliseconds)
+	u32 m_hide_mouse_idletime = 2000; // ms
 
 public:
 	gs_frame(const QRect& geometry, const QIcon& appIcon, const std::shared_ptr<gui_settings>& gui_settings);

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -5,6 +5,7 @@
 
 #include <QWindow>
 #include <QPaintEvent>
+#include <QTimer>
 
 #ifdef _WIN32
 #include <QWinTaskbarProgress>
@@ -29,12 +30,15 @@ private:
 #endif
 
 	std::shared_ptr<gui_settings> m_gui_settings;
+	QTimer m_mousehide_timer;
 
 	u64 m_frames = 0;
 	QString m_window_title;
 	bool m_disable_mouse = false;
 	bool m_disable_kb_hotkeys = false;
 	bool m_show_mouse_in_fullscreen = false;
+	bool m_hide_mouse_after_idletime = false;
+	u32 m_hide_mouse_idletime = 2000; // 2000 milliseconds)
 
 public:
 	gs_frame(const QRect& geometry, const QIcon& appIcon, const std::shared_ptr<gui_settings>& gui_settings);
@@ -75,4 +79,5 @@ protected:
 
 private Q_SLOTS:
 	void HandleCursor(QWindow::Visibility visibility);
+	void MouseHideTimeout();
 };

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -189,12 +189,12 @@ namespace gui
 	const gui_save m_discordState      = gui_save(meta, "discordState",      "");
 	const gui_save m_check_upd_start   = gui_save(meta, "checkUpdateStart",  true);
 
-	const gui_save gs_disableMouse     = gui_save(gs_frame, "disableMouse",          false);
-	const gui_save gs_disableKbHotkeys = gui_save(gs_frame, "disableKbHotkeys",      false);
-	const gui_save gs_showMouseFs      = gui_save(gs_frame, "showMouseInFullscreen", false);
-	const gui_save gs_resize           = gui_save(gs_frame, "resize",                false);
-	const gui_save gs_width            = gui_save(gs_frame, "width",                 1280);
-	const gui_save gs_height           = gui_save(gs_frame, "height",                720);
+	const gui_save gs_disableMouse      = gui_save(gs_frame, "disableMouse",          false);
+	const gui_save gs_disableKbHotkeys  = gui_save(gs_frame, "disableKbHotkeys",      false);
+	const gui_save gs_showMouseFs       = gui_save(gs_frame, "showMouseInFullscreen", false);
+	const gui_save gs_resize            = gui_save(gs_frame, "resize",                false);
+	const gui_save gs_width             = gui_save(gs_frame, "width",                 1280);
+	const gui_save gs_height            = gui_save(gs_frame, "height",                720);
 	const gui_save gs_hideMouseIdle     = gui_save(gs_frame, "hideMouseOnIdle",       false);
 	const gui_save gs_hideMouseIdleTime = gui_save(gs_frame, "hideMouseOnIdleTime",   2000);
 

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -195,6 +195,8 @@ namespace gui
 	const gui_save gs_resize           = gui_save(gs_frame, "resize",                false);
 	const gui_save gs_width            = gui_save(gs_frame, "width",                 1280);
 	const gui_save gs_height           = gui_save(gs_frame, "height",                720);
+	const gui_save gs_hideMouseIdle     = gui_save(gs_frame, "hideMouseOnIdle",       false);
+	const gui_save gs_hideMouseIdleTime = gui_save(gs_frame, "hideMouseOnIdleTime",   2000);
 
 	const gui_save tr_icon_color    = gui_save(trophy, "icon_color",    gl_icon_color);
 	const gui_save tr_icon_height   = gui_save(trophy, "icon_height",   75);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1269,14 +1269,14 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		});
 
 		ui->gs_hideMouseOnIdle->setChecked(m_gui_settings->GetValue(gui::gs_hideMouseIdle).toBool());
-		connect(ui->gs_hideMouseOnIdle, &QCheckBox::clicked, [this](bool val)
+		connect(ui->gs_hideMouseOnIdle, &QCheckBox::clicked, [this](bool checked)
 		{
-			m_gui_settings->SetValue(gui::gs_hideMouseIdle, val);
-			ui->gs_hideMouseOnIdleTime->setEnabled(val);
+			m_gui_settings->SetValue(gui::gs_hideMouseIdle, checked);
+			ui->gs_hideMouseOnIdleTime->setEnabled(checked);
 		});
-		ui->gs_hideMouseOnIdleTime->setEnabled(m_gui_settings->GetValue(gui::gs_hideMouseIdle).toBool());
+		ui->gs_hideMouseOnIdleTime->setEnabled(ui->gs_hideMouseOnIdle->checkState() == Qt::CheckState::Checked);
 		ui->gs_hideMouseOnIdleTime->setValue(m_gui_settings->GetValue(gui::gs_hideMouseIdleTime).toUInt());
-		connect(ui->gs_hideMouseOnIdleTime, &QSpinBox::editingFinished, [=, this]()
+		connect(ui->gs_hideMouseOnIdleTime, &QSpinBox::editingFinished, [this]()
 		{
 			m_gui_settings->SetValue(gui::gs_hideMouseIdleTime, ui->gs_hideMouseOnIdleTime->value());
 		});

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1268,6 +1268,19 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			m_gui_settings->SetValue(gui::gs_showMouseFs, val);
 		});
 
+		ui->gs_hideMouseOnIdle->setChecked(m_gui_settings->GetValue(gui::gs_hideMouseIdle).toBool());
+		connect(ui->gs_hideMouseOnIdle, &QCheckBox::clicked, [this](bool val)
+		{
+			m_gui_settings->SetValue(gui::gs_hideMouseIdle, val);
+			ui->gs_hideMouseOnIdleTime->setEnabled(val);
+		});
+		ui->gs_hideMouseOnIdleTime->setEnabled(m_gui_settings->GetValue(gui::gs_hideMouseIdle).toBool());
+		ui->gs_hideMouseOnIdleTime->setValue(m_gui_settings->GetValue(gui::gs_hideMouseIdleTime).toUInt());
+		connect(ui->gs_hideMouseOnIdleTime, &QSpinBox::editingFinished, [=, this]()
+		{
+			m_gui_settings->SetValue(gui::gs_hideMouseIdleTime, ui->gs_hideMouseOnIdleTime->value());
+		});
+
 		const bool enable_buttons = m_gui_settings->GetValue(gui::gs_resize).toBool();
 		ui->gs_resizeOnBoot->setChecked(enable_buttons);
 		ui->gs_width->setEnabled(enable_buttons);

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2370,7 +2370,7 @@
                    <bool>false</bool>
                   </property>
                   <property name="suffix">
-                   <string> mS</string>
+                   <string>ms</string>
                   </property>
                   <property name="minimum">
                    <number>200</number>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2345,9 +2345,48 @@
               <item>
                <widget class="QCheckBox" name="gs_showMouseInFullscreen">
                 <property name="text">
-                 <string>Show mouse cursor in Fullscreen </string>
+                 <string>Show mouse cursor in Fullscreen</string>
                 </property>
                </widget>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="layout_hideMouseOnIdle" stretch="0,0">
+                <item>
+                 <widget class="QCheckBox" name="gs_hideMouseOnIdle">
+                  <property name="text">
+                   <string>Hide mouse cursor if idle</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="gs_hideMouseOnIdleTime">
+                  <property name="accelerated">
+                   <bool>true</bool>
+                  </property>
+                  <property name="correctionMode">
+                   <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                  </property>
+                  <property name="keyboardTracking">
+                   <bool>false</bool>
+                  </property>
+                  <property name="suffix">
+                   <string> mS</string>
+                  </property>
+                  <property name="minimum">
+                   <number>200</number>
+                  </property>
+                  <property name="maximum">
+                   <number>99999</number>
+                  </property>
+                  <property name="stepType">
+                   <enum>QAbstractSpinBox::DefaultStepType</enum>
+                  </property>
+                  <property name="value">
+                   <number>2000</number>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
               <item>
                <widget class="QCheckBox" name="gs_resizeOnBoot">

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -109,6 +109,7 @@ public:
 		const QString disable_kb_hotkeys           = tr("Disables keyboard hotkeys such as Ctrl-S, Ctrl-E, Ctrl-R, Ctrl-P while the game screen is active.\nCheck this if you want to play with mouse and keyboard.");
 		const QString max_llvm_threads             = tr("Limits the maximum number of threads used for the initial PPU and SPU module compilation.\nLower this in order to increase performance of other open applications.\nThe default uses all available threads.");
 		const QString show_mouse_in_fullscreen     = tr("Shows the mouse cursor when the fullscreen mode is active.\nCurrently this may not work every time.");
+		const QString hide_mouse_on_idle           = tr("Hides the mouse cursor if no mouse movement is detected for the configured time.");
 		const QString show_shader_compilation_hint = tr("Shows 'Compiling shaders' hint using the native overlay.");
 		const QString use_native_interface         = tr("Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, the on-screen keyboard only supports the English key layout.");
 


### PR DESCRIPTION
As requested in #4502, the ability to auto-hide the cursor after a configurable timeout period.
This does not 'lock the mouse cursor within the game window boundaries', however I'm not sure that would be desirable.

With this implementation, the cursor is visible again when moved.
If alternative behaviour is desired, perhaps the 'Show Cursor in Fullscreen' could just be converted into a 'Hide Cursor in Game' setting (in which case it would hide the cursor in both windowed and fullscreen modes).

In line with the Show Cursor in Fullscreen settings, these settings are only updated when the render window is first launched, and not during the game.
This could be revised (along with the Fullscreen Cursor) if it's more desired.

Also removed what appeared to be a stray space at the end of the Fullscreen setting legend text.