### PR TITLE
cellFs/cellGame Improvements

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -961,6 +961,9 @@ error_code cellGameGetSizeKB(vm::ptr<s32> size)
 		return CELL_GAME_ERROR_PARAM;
 	}
 
+	// Always reset to 0 at start
+	*size = 0;
+
 	const auto prm = g_fxo->get<content_permission>();
 
 	const auto init = prm->init.access();
@@ -980,7 +983,6 @@ error_code cellGameGetSizeKB(vm::ptr<s32> size)
 
 		if (!fs::exists(local_dir))
 		{
-			*size = 0;
 			return CELL_OK;
 		}
 		else

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -136,6 +136,11 @@ static std::vector<SaveDataEntry> get_save_entries(const std::string& base_dir, 
 
 		for (const auto& entry2 : fs::dir(base_dir + entry.name))
 		{
+			if (entry2.is_directory)
+			{
+				continue;
+			}
+
 			save_entry.size += entry2.size;
 		}
 
@@ -643,6 +648,11 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 						for (const auto& entry2 : fs::dir(base_dir + entry.name))
 						{
+							if (entry2.is_directory)
+							{
+								continue;
+							}
+
 							save_entry2.size += entry2.size;
 						}
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -821,7 +821,14 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 
 	if (vpath.find_first_not_of('/') == umax)
 	{
-		*sb = {CELL_FS_S_IFDIR | 0444};
+		sb->mode = CELL_FS_S_IFDIR | 0711;
+		sb->uid = -1;
+		sb->gid = -1;
+		sb->atime = -1;
+		sb->mtime = -1;
+		sb->ctime = -1;
+		sb->size = 258;
+		sb->blksize = 512;
 		return CELL_OK;
 	}
 
@@ -879,7 +886,7 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 	sb->atime = info.atime;
 	sb->mtime = info.mtime;
 	sb->ctime = info.ctime;
-	sb->size = info.size;
+	sb->size = info.is_directory ? mp->block_size : info.size;
 	sb->blksize = mp->block_size;
 
 	if (mp->flags & lv2_mp_flag::read_only)

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1302,15 +1302,8 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 
 		const auto mp = lv2_fs_object::get_mp("/dev_hdd0");
 
-		fs::device_stat info;
-		if (!fs::statfs(vfs::get("/dev_hdd0"), info))
-		{
-			sys_fs.error("sys_fs_fcntl(0xc0000002): unexpected error %s", fs::g_tls_error);
-			return CELL_EIO; // ???
-		}
-
 		arg->out_block_size = mp->block_size;
-		arg->out_block_count = info.avail_free / mp->block_size;
+		arg->out_block_count = (40ull * 1024 * 1024 * 1024 - 1) / mp->block_size; // Read explanation in cellHddGameCheck
 		return CELL_OK;
 	}
 


### PR DESCRIPTION
* Fix cellGame FXO data reset, some members were not reset in verious places such as can_create and restrict_sfo_params. Unify the reset in cellGameContentPermit instead.
* Implement CELL_GAME_ERROR_EXIST error in cellGameCreateGameData on attempt to create existing gamedata. (cellGameDataCheck returned CELL_OK and not CELL_GAME_RET_NONE)
* Make block size reported as size for directories in cellFsStat/cellFsReadDir. seems the case on realhw for dev_hdd0/dev_hdd1/dev_bdvd.
* Do not expose real disk stats (HDD0) to a ps3 guest program, use hardcoded values for now instead.
* More accurate HDD1 available size calculation.
* Return sector aligned size for available drives size instead of unaligned size.
* Always reset size in cellGameGetSizeKB.
* Rewrite cellFsGetFreeSize to use LLE syscalls.