### PR TITLE
[WIP / Helpwanted] Internationalisation updates, will likely break under non-Windows

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
@@ -2,6 +2,8 @@
 #include "overlay_controls.h"
 #include "Emu/system_config.h"
 
+#include <QCoreApplication>
+
 namespace rsx
 {
 	namespace overlays
@@ -40,8 +42,8 @@ namespace rsx
 			m_accept_btn->set_pos(30, height + 20);
 			m_cancel_btn->set_pos(180, height + 20);
 
-			m_accept_btn->set_text("Select");
-			m_cancel_btn->set_text("Cancel");
+			m_accept_btn->set_text(QCoreApplication::translate("RSXOverlay","Select").toStdString());
+			m_cancel_btn->set_text(QCoreApplication::translate("RSXOverlay", "Cancel").toStdString());
 
 			m_accept_btn->set_font("Arial", 16);
 			m_cancel_btn->set_font("Arial", 16);

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -4,6 +4,8 @@
 #include "Emu/system_config.h"
 #include "Emu/Cell/ErrorCodes.h"
 
+#include <QCoreApplication>
+
 namespace rsx
 {
 	namespace overlays
@@ -197,13 +199,13 @@ namespace rsx
 				if (interactive)
 				{
 					btn_cancel.set_pos(585, btn_cancel.y);
-					btn_cancel.set_text("Cancel");
+					btn_cancel.set_text(QCoreApplication::translate("RSXOverlay", "Cancel").toStdString());
 					cancel_only = true;
 				}
 				break;
 			case CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK:
 				btn_ok.set_pos(600, btn_ok.y);
-				btn_ok.set_text("OK");
+				btn_ok.set_text(QCoreApplication::translate("RSXOverlay", "OK").toStdString());
 				interactive = true;
 				ok_only     = true;
 				break;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -3,6 +3,8 @@
 #include "Emu/RSX/RSXThread.h"
 #include "Emu/Cell/Modules/cellSysutil.h"
 
+#include <QCoreApplication>
+
 LOG_CHANNEL(osk, "OSK");
 
 namespace rsx
@@ -227,27 +229,27 @@ namespace rsx
 
 			m_btn_cancel.set_pos(frame_x, frame_y + frame_h + 10);
 			m_btn_cancel.set_size(140, 30);
-			m_btn_cancel.set_text("Cancel");
+			m_btn_cancel.set_text(QCoreApplication::translate("RSXOverlay", "Cancel").toStdString());
 			m_btn_cancel.set_text_vertical_adjust(5);
 
 			m_btn_space.set_pos(frame_x + 100, frame_y + frame_h + 10);
 			m_btn_space.set_size(100, 30);
-			m_btn_space.set_text("Space");
+			m_btn_space.set_text(QCoreApplication::translate("RSXOverlay", "Space").toStdString());
 			m_btn_space.set_text_vertical_adjust(5);
 
 			m_btn_delete.set_pos(frame_x + 200, frame_y + frame_h + 10);
 			m_btn_delete.set_size(100, 30);
-			m_btn_delete.set_text("Backspace");
+			m_btn_delete.set_text(QCoreApplication::translate("RSXOverlay", "Backspace").toStdString());
 			m_btn_delete.set_text_vertical_adjust(5);
 
 			m_btn_shift.set_pos(frame_x + 320, frame_y + frame_h + 10);
 			m_btn_shift.set_size(80, 30);
-			m_btn_shift.set_text("Shift");
+			m_btn_shift.set_text(QCoreApplication::translate("RSXOverlay", "Shift").toStdString());
 			m_btn_shift.set_text_vertical_adjust(5);
 
 			m_btn_accept.set_pos(frame_x + 400, frame_y + frame_h + 10);
 			m_btn_accept.set_size(100, 30);
-			m_btn_accept.set_text("Accept");
+			m_btn_accept.set_text(QCoreApplication::translate("RSXOverlay", "Accept").toStdString());
 			m_btn_accept.set_text_vertical_adjust(5);
 
 			m_update = true;
@@ -664,10 +666,10 @@ namespace rsx
 		{
 			if (m_password_mode)
 			{
-				return U"[Enter Password]";
+				return QCoreApplication::translate("RSXOverlay","[Enter Password]").toStdU32String();
 			}
 
-			return U"[Enter Text]";
+			return QCoreApplication::translate("RSXOverlay", "[Enter Text]").toStdU32String();
 		}
 
 		void osk_dialog::update()

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -2,6 +2,8 @@
 #include "overlay_save_dialog.h"
 #include "Utilities/date_time.h"
 
+#include <QCoreApplication>
+
 namespace rsx
 {
 	namespace overlays
@@ -176,15 +178,15 @@ namespace rsx
 
 			if (op >= 8)
 			{
-				m_description->set_text("Delete Save");
+				m_description->set_text(QCoreApplication::translate("RSXOverlay", "Delete Save").toStdString());
 			}
 			else if (op & 1)
 			{
-				m_description->set_text("Load Save");
+				m_description->set_text(QCoreApplication::translate("RSXOverlay", "Load Save").toStdString());
 			}
 			else
 			{
-				m_description->set_text("Save");
+				m_description->set_text(QCoreApplication::translate("RSXOverlay", "Save").toStdString());
 			}
 
 			const bool newpos_head = listSet && listSet->newData && listSet->newData->iconPosition == CELL_SAVEDATA_ICONPOS_HEAD;

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -2,6 +2,8 @@
 #include "overlay_trophy_notification.h"
 #include "Emu/RSX/RSXThread.h"
 
+#include <QCoreApplication>
+
 namespace rsx
 {
 	namespace overlays
@@ -121,14 +123,14 @@ namespace rsx
 			std::string trophy_message;
 			switch (trophy.trophyGrade)
 			{
-			case SCE_NP_TROPHY_GRADE_BRONZE: trophy_message = "bronze"; break;
-			case SCE_NP_TROPHY_GRADE_SILVER: trophy_message = "silver"; break;
-			case SCE_NP_TROPHY_GRADE_GOLD: trophy_message = "gold"; break;
-			case SCE_NP_TROPHY_GRADE_PLATINUM: trophy_message = "platinum"; break;
+			case SCE_NP_TROPHY_GRADE_BRONZE: trophy_message = QCoreApplication::translate("RSXOverlay", "Bronze").toStdString(); break;
+			case SCE_NP_TROPHY_GRADE_SILVER: trophy_message = QCoreApplication::translate("RSXOverlay", "Silver").toStdString(); break;
+			case SCE_NP_TROPHY_GRADE_GOLD: trophy_message = QCoreApplication::translate("RSXOverlay", "Gold").toStdString(); break;
+			case SCE_NP_TROPHY_GRADE_PLATINUM: trophy_message = QCoreApplication::translate("RSXOverlay", "Platinum").toStdString(); break;
 			default: break;
 			}
 
-			trophy_message = "You have earned the " + trophy_message + " trophy\n" + trophy.name;
+			trophy_message = QCoreApplication::translate("RSXOverlay", "You have earned the %1 trophy\n%2").arg(trophy_message.c_str()).arg(trophy.name).toStdString();
 			text_view.set_text(trophy_message);
 			text_view.auto_resize();
 

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -64,7 +64,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\3rdparty\wolfssl\;..\3rdparty\flatbuffers\include;..\3rdparty\libusb\libusb;..\3rdparty\zlib;..\llvm\include;..\llvm_build\include;$(VULKAN_SDK)\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\3rdparty\wolfssl\;..\3rdparty\flatbuffers\include;..\3rdparty\libusb\libusb;..\3rdparty\zlib;..\llvm\include;..\llvm_build\include;$(VULKAN_SDK)\Include;$(Qt5_DIR)\include;$(Qt5_DIR)\include\QtCore</AdditionalIncludeDirectories>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release - LLVM|x64'">MaxSpeed</Optimization>
     </ClCompile>
     <PreBuildEvent>

--- a/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
@@ -276,5 +276,5 @@ void AutoPauseConfigDialog::OnUpdateValue()
 	ullong value = m_id->text().toULongLong(&ok, 16);
 	const bool is_ok = ok && value <= UINT32_MAX;
 
-	m_current_converted->setText(qstr(fmt::format("Current value: %08x (%s)", u32(value), is_ok ? "OK" : "conversion failed")));
+	m_current_converted->setText(tr("Current value: %1 (%2)").arg(value,8,16).arg(is_ok ? tr("OK") : tr("Conversion failed")));
 }

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -478,7 +478,7 @@ void debugger_frame::ShowGotoAddressDialog()
 	expression_input->setFixedWidth(190);
 
 	// Ok/Cancel
-	QPushButton* button_ok = new QPushButton(tr("Ok"));
+	QPushButton* button_ok = new QPushButton(tr("OK"));
 	QPushButton* button_cancel = new QPushButton(tr("Cancel"));
 
 	hbox_address_preview_panel->addWidget(address_preview_label);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1438,7 +1438,7 @@ void game_list_frame::BatchCreatePPUCaches()
 		}
 	}
 
-	pdlg->setLabelText(tr("Created PPU Caches for %0 titles").arg(created));
+	pdlg->setLabelText(tr("Created PPU Caches for %n title(s)", "", created));
 	pdlg->setCancelButtonText(tr("OK"));
 	QApplication::beep();
 }

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
@@ -33,7 +33,7 @@ instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, c
 	QVBoxLayout* vbox_right_panel(new QVBoxLayout());
 	QHBoxLayout* hbox_b_panel(new QHBoxLayout());
 
-	QPushButton* button_ok(new QPushButton(tr("Ok")));
+	QPushButton* button_ok(new QPushButton(tr("OK")));
 	QPushButton* button_cancel(new QPushButton(tr("Cancel")));
 	button_ok->setFixedWidth(80);
 	button_cancel->setFixedWidth(80);

--- a/rpcs3/rpcs3qt/localized.cpp
+++ b/rpcs3/rpcs3qt/localized.cpp
@@ -8,102 +8,52 @@ QString Localized::GetVerboseTimeByMs(qint64 elapsed_ms, bool show_days) const
 {
 	if (elapsed_ms <= 0)
 	{
-		return "";
+		return tr("Never played");
 	}
 
 	const qint64 elapsed_seconds = (elapsed_ms / 1000) + ((elapsed_ms % 1000) > 0 ? 1 : 0);
-
 	qint64 hours = elapsed_seconds / 3600;
 
-	// For anyone who was wondering why there need to be so many cases:
-	// 1. Using variables won't work for future localization due to varying sentence structure in different languages.
-	// 2. The provided Qt functionality only works if localization is already enabled
-	// 3. The provided Qt functionality only works for single variables
-
-	if (show_days && hours >= 24)
-	{
-		const qint64 days  = hours / 24;
+	const qint64 days = hours / 24;
+	if(show_days)
 		hours = hours % 24;
-
-		if (hours <= 0)
-		{
-			if (days == 1)
-			{
-				return tr("%0 day").arg(days);
-			}
-			return tr("%0 days").arg(days);
-		}
-		if (days == 1 && hours == 1)
-		{
-			return tr("%0 day and %1 hour").arg(days).arg(hours);
-		}
-		if (days == 1)
-		{
-			return tr("%0 day and %1 hours").arg(days).arg(hours);
-		}
-		if (hours == 1)
-		{
-			return tr("%0 days and %1 hour").arg(days).arg(hours);
-		}
-		return tr("%0 days and %1 hours").arg(days).arg(hours);
-	}
-
 	const qint64 minutes = (elapsed_seconds % 3600) / 60;
 	const qint64 seconds = (elapsed_seconds % 3600) % 60;
 
-	if (hours <= 0)
-	{
-		if (minutes <= 0)
-		{
-			if (seconds == 1)
-			{
-				return tr("%0 second").arg(seconds);
-			}
-			return tr("%0 seconds").arg(seconds);
-		}
+	QString str_days = tr("%Ln day(s)", "", days);
+	QString str_hours = tr("%Ln hour(s)", "", hours);
+	QString str_minutes = tr("%Ln minute(s)", "", minutes);
+	QString str_seconds = tr("%Ln second(s)", "", seconds);
 
-		if (seconds <= 0)
+	if (show_days && days > 0)
+	{
+		if (hours == 0)
+			return str_days;
+		else
+			return tr("%0 and %1", "Days and hours").arg(str_days).arg(str_hours);
+	}
+	else
+	{
+		if (hours > 0)
 		{
-			if (minutes == 1)
+			if (minutes == 0)
+				return str_hours;
+			else
+				return tr("%0 and %1", "Hours and minutes").arg(str_hours).arg(str_minutes);
+		}
+		else
+		{
+			if (minutes > 0)
 			{
-				return tr("%0 minute").arg(minutes);
+				if (seconds != 0)
+					return tr("%0 and %1", "Minutes and seconds").arg(str_minutes).arg(str_seconds);
+				else
+					return str_minutes;
 			}
-			return tr("%0 minutes").arg(minutes);
+			else
+			{
+				return str_seconds;
+			}
 		}
-		if (minutes == 1 && seconds == 1)
-		{
-			return tr("%0 minute and %1 second").arg(minutes).arg(seconds);
-		}
-		if (minutes == 1)
-		{
-			return tr("%0 minute and %1 seconds").arg(minutes).arg(seconds);
-		}
-		if (seconds == 1)
-		{
-			return tr("%0 minutes and %1 second").arg(minutes).arg(seconds);
-		}
-		return tr("%0 minutes and %1 seconds").arg(minutes).arg(seconds);
 	}
-
-	if (minutes <= 0)
-	{
-		if (hours == 1)
-		{
-			return tr("%0 hour").arg(hours);
-		}
-		return tr("%0 hours").arg(hours);
-	}
-	if (hours == 1 && minutes == 1)
-	{
-		return tr("%0 hour and %1 minute").arg(hours).arg(minutes);
-	}
-	if (hours == 1)
-	{
-		return tr("%0 hour and %1 minutes").arg(hours).arg(minutes);
-	}
-	if (minutes == 1)
-	{
-		return tr("%0 hours and %1 minute").arg(hours).arg(minutes);
-	}
-	return tr("%0 hours and %1 minutes").arg(hours).arg(minutes);
 }

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -50,7 +50,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 	QLabel* inputCount = new QLabel(QString("%1/%2").arg(text.length()).arg(charlimit));
 
 	// Ok Button
-	QPushButton* button_ok = new QPushButton("Ok", m_dialog);
+	QPushButton* button_ok = new QPushButton(tr("OK"), m_dialog);
 
 	// Button Layout
 	QHBoxLayout* buttonsLayout = new QHBoxLayout;

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -431,7 +431,7 @@ void save_manager_dialog::OnEntriesRemove()
 		return;
 	}
 
-	if (QMessageBox::question(this, tr("Delete Confirmation"), tr("Are you sure you want to delete these %1 items?").arg(selection.size()), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
+	if (QMessageBox::question(this, tr("Delete Confirmation"), tr("Are you sure you want to delete these %n items?", "", selection.size()), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
 	{
 		std::sort(selection.rbegin(), selection.rend());
 		for (QModelIndex index : selection)

--- a/rpcs3/rpcs3qt/screenshot_preview.cpp
+++ b/rpcs3/rpcs3qt/screenshot_preview.cpp
@@ -18,7 +18,7 @@ screenshot_preview::screenshot_preview(const QString& filepath, QWidget* parent)
 
 	m_image = reader.read();
 
-	setWindowTitle(tr("Screenshot Preview"));
+	setWindowTitle(tr("Screenshot Viewer"));
 	setObjectName("screenshot_preview");
 	setContextMenuPolicy(Qt::CustomContextMenu);
 	setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1246,9 +1246,14 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	if (!game)
 	{
 		SubscribeTooltip(ui->gs_resizeOnBoot, tooltips.settings.resize_on_boot);
+		SubscribeTooltip(ui->gb_gs_height, tooltips.settings.resize_on_boot);
+		SubscribeTooltip(ui->gb_gs_width, tooltips.settings.resize_on_boot);
 		SubscribeTooltip(ui->gs_disableMouse, tooltips.settings.disable_mouse);
 		SubscribeTooltip(ui->gs_disableKbHotkeys, tooltips.settings.disable_kb_hotkeys);
 		SubscribeTooltip(ui->gs_showMouseInFullscreen, tooltips.settings.show_mouse_in_fullscreen);
+		SubscribeTooltip(ui->gs_hideMouseOnIdle, tooltips.settings.hide_mouse_on_idle);
+		SubscribeTooltip(ui->gs_hideMouseOnIdleTime, tooltips.settings.hide_mouse_on_idle);
+
 
 		ui->gs_disableMouse->setChecked(m_gui_settings->GetValue(gui::gs_disableMouse).toBool());
 		connect(ui->gs_disableMouse, &QCheckBox::clicked, [this](bool val)

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -123,11 +123,11 @@ trophy_manager_dialog::trophy_manager_dialog(std::shared_ptr<gui_settings> gui_s
 	m_game_icon_size = gui_settings::SizeFromSlider(m_game_icon_size_index);
 
 	// Checkboxes to control dialog
-	QCheckBox* check_lock_trophy = new QCheckBox(tr("Show Locked Trophies"));
+	QCheckBox* check_lock_trophy = new QCheckBox(tr("Show Not Earned Trophies"));
 	check_lock_trophy->setCheckable(true);
 	check_lock_trophy->setChecked(m_show_locked_trophies);
 
-	QCheckBox* check_unlock_trophy = new QCheckBox(tr("Show Unlocked Trophies"));
+	QCheckBox* check_unlock_trophy = new QCheckBox(tr("Show Earned Trophies"));
 	check_unlock_trophy->setCheckable(true);
 	check_unlock_trophy->setChecked(m_show_unlocked_trophies);
 
@@ -661,7 +661,7 @@ void trophy_manager_dialog::ShowContextMenu(const QPoint& pos)
 	}
 
 	QMenu* menu = new QMenu();
-	QAction* show_trophy_dir = new QAction(tr("Open Trophy Dir"), menu);
+	QAction* show_trophy_dir = new QAction(tr("Open Trophy Directory"), menu);
 
 	const int db_ind = m_game_combo->currentData().toInt();
 
@@ -857,7 +857,7 @@ void trophy_manager_dialog::PopulateTrophyTable()
 			}
 		}
 
-		const QString unlockstate = data->trop_usr->GetTrophyUnlockState(trophy_id) ? tr("Unlocked") : tr("Locked");
+		const QString unlockstate = data->trop_usr->GetTrophyUnlockState(trophy_id) ? tr("Earned") : tr("Not Earned");
 
 		custom_table_widget_item* icon_item = new custom_table_widget_item();
 		icon_item->setData(Qt::UserRole, hidden, true);

--- a/rpcs3/rpcs3qt/trophy_notification_frame.cpp
+++ b/rpcs3/rpcs3qt/trophy_notification_frame.cpp
@@ -43,14 +43,14 @@ trophy_notification_frame::trophy_notification_frame(const std::vector<uchar>& i
 	QString trophyType = "";
 	switch (trophy.trophyGrade)
 	{
-	case SCE_NP_TROPHY_GRADE_BRONZE:   trophyType = "bronze";   break;
-	case SCE_NP_TROPHY_GRADE_SILVER:   trophyType = "silver";   break;
-	case SCE_NP_TROPHY_GRADE_GOLD:     trophyType = "gold";     break;
-	case SCE_NP_TROPHY_GRADE_PLATINUM: trophyType = "platinum"; break;
+	case SCE_NP_TROPHY_GRADE_BRONZE:   trophyType = tr("Bronze");   break;
+	case SCE_NP_TROPHY_GRADE_SILVER:   trophyType = tr("Silver");   break;
+	case SCE_NP_TROPHY_GRADE_GOLD:     trophyType = tr("Gold");     break;
+	case SCE_NP_TROPHY_GRADE_PLATINUM: trophyType = tr("Platinum"); break;
 	default: break;
 	}
 
-	trophyName->setText(tr("You have earned the %1 trophy.\n").arg(trophyType) + qstr(trophy.name));
+	trophyName->setText(tr("You have earned the %1 trophy.\n%2").arg(trophyType).arg(trophy.name));
 	trophyName->setAutoFillBackground(true);
 	trophyName->setPalette(black_background);
 


### PR DESCRIPTION
NOTE: Currently missing includes to Qt5 headers for Emu under CMake
It would be great if someone could help with the CMake side of bring in the QCoreApplication Qt header.

Should help to tidy up a few more of the outstanding items in #4259.

Added QCoreApplication::translate for some of the RSX overlay components (further testing required).
Reworked Game List elapsed time to support translations, both numeric / ordering.
- This does unfortunately mean that it adds (s) until we get translations in place.
Added description 'Never played' for games with no elapsed time indicated
Renamed Unlocked->Earned, Locked->Not Earned for Trophies
Added duplicated tooltips for Resize on boot.
Added tooltip for hide mouse after idle time.
Changed capitalisation for trophies (Bronze, Silver, Gold, Platinum) to match SCE.
Renamed title for 'Screenshot Preview' to 'Screenshot Viewer'