### PR TITLE
GUI: Additional translation entries

### DIFF
--- a/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
@@ -276,5 +276,5 @@ void AutoPauseConfigDialog::OnUpdateValue()
 	ullong value = m_id->text().toULongLong(&ok, 16);
 	const bool is_ok = ok && value <= UINT32_MAX;
 
-	m_current_converted->setText(qstr(fmt::format("Current value: %08x (%s)", u32(value), is_ok ? "OK" : "conversion failed")));
+	m_current_converted->setText(tr("Current value: %1 (%2)").arg(value, 8, 16).arg(is_ok ? tr("OK") : tr("Conversion failed")));
 }

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -478,7 +478,7 @@ void debugger_frame::ShowGotoAddressDialog()
 	expression_input->setFixedWidth(190);
 
 	// Ok/Cancel
-	QPushButton* button_ok = new QPushButton(tr("Ok"));
+	QPushButton* button_ok = new QPushButton(tr("OK"));
 	QPushButton* button_cancel = new QPushButton(tr("Cancel"));
 
 	hbox_address_preview_panel->addWidget(address_preview_label);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1438,7 +1438,7 @@ void game_list_frame::BatchCreatePPUCaches()
 		}
 	}
 
-	pdlg->setLabelText(tr("Created PPU Caches for %0 titles").arg(created));
+	pdlg->setLabelText(tr("Created PPU Caches for %n title(s)", "", created));
 	pdlg->setCancelButtonText(tr("OK"));
 	QApplication::beep();
 }

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
@@ -33,7 +33,7 @@ instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, c
 	QVBoxLayout* vbox_right_panel(new QVBoxLayout());
 	QHBoxLayout* hbox_b_panel(new QHBoxLayout());
 
-	QPushButton* button_ok(new QPushButton(tr("Ok")));
+	QPushButton* button_ok(new QPushButton(tr("OK")));
 	QPushButton* button_cancel(new QPushButton(tr("Cancel")));
 	button_ok->setFixedWidth(80);
 	button_cancel->setFixedWidth(80);

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -50,7 +50,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 	QLabel* inputCount = new QLabel(QString("%1/%2").arg(text.length()).arg(charlimit));
 
 	// Ok Button
-	QPushButton* button_ok = new QPushButton("Ok", m_dialog);
+	QPushButton* button_ok = new QPushButton(tr("OK"), m_dialog);
 
 	// Button Layout
 	QHBoxLayout* buttonsLayout = new QHBoxLayout;

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -431,7 +431,7 @@ void save_manager_dialog::OnEntriesRemove()
 		return;
 	}
 
-	if (QMessageBox::question(this, tr("Delete Confirmation"), tr("Are you sure you want to delete these %1 items?").arg(selection.size()), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
+	if (QMessageBox::question(this, tr("Delete Confirmation"), tr("Are you sure you want to delete these %n items?", "", selection.size()), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
 	{
 		std::sort(selection.rbegin(), selection.rend());
 		for (QModelIndex index : selection)

--- a/rpcs3/rpcs3qt/trophy_notification_frame.cpp
+++ b/rpcs3/rpcs3qt/trophy_notification_frame.cpp
@@ -40,17 +40,17 @@ trophy_notification_frame::trophy_notification_frame(const std::vector<uchar>& i
 	trophyName->setWordWrap(true);
 	trophyName->setAlignment(Qt::AlignCenter);
 
-	QString trophyType = "";
+	QString trophy_string;
 	switch (trophy.trophyGrade)
 	{
-	case SCE_NP_TROPHY_GRADE_BRONZE:   trophyType = "bronze";   break;
-	case SCE_NP_TROPHY_GRADE_SILVER:   trophyType = "silver";   break;
-	case SCE_NP_TROPHY_GRADE_GOLD:     trophyType = "gold";     break;
-	case SCE_NP_TROPHY_GRADE_PLATINUM: trophyType = "platinum"; break;
+	case SCE_NP_TROPHY_GRADE_BRONZE:   trophy_string = tr("You have earned the Bronze trophy.\n%1").arg(trophy.name);   break;
+	case SCE_NP_TROPHY_GRADE_SILVER:   trophy_string = tr("You have earned the Silver trophy.\n%1").arg(trophy.name);   break;
+	case SCE_NP_TROPHY_GRADE_GOLD:     trophy_string = tr("You have earned the Gold trophy.\n%1").arg(trophy.name);     break;
+	case SCE_NP_TROPHY_GRADE_PLATINUM: trophy_string = tr("You have earned the Platinum trophy.\n%1").arg(trophy.name); break;
 	default: break;
 	}
 
-	trophyName->setText(tr("You have earned the %1 trophy.\n").arg(trophyType) + qstr(trophy.name));
+	trophyName->setText(trophy_string);
 	trophyName->setAutoFillBackground(true);
 	trophyName->setPalette(black_background);
 


### PR DESCRIPTION
Standardising on 'OK' for all base language uses (rather than 'Ok', or 'Okay').
It's perceived as the 'most correct' variant, and importantly having a single variant is best from a translation perspective.

Added plurality handling for multiple PPU caches created.

Added plurality handling for multiple items deleted in save manager.

Capitalised trophy grade to align with Sony terminology, and expanded to include 'You have earned ...' portion.
Brought trophy name position into translatable string (for languages that might really want to deviate from SVO)