### PR TITLE
GUI: Tooltips for mouse hide if idle and resize on boot

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1246,9 +1246,13 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	if (!game)
 	{
 		SubscribeTooltip(ui->gs_resizeOnBoot, tooltips.settings.resize_on_boot);
+		SubscribeTooltip(ui->gb_gs_height, tooltips.settings.resize_on_boot);
+		SubscribeTooltip(ui->gb_gs_width, tooltips.settings.resize_on_boot);
 		SubscribeTooltip(ui->gs_disableMouse, tooltips.settings.disable_mouse);
 		SubscribeTooltip(ui->gs_disableKbHotkeys, tooltips.settings.disable_kb_hotkeys);
 		SubscribeTooltip(ui->gs_showMouseInFullscreen, tooltips.settings.show_mouse_in_fullscreen);
+		SubscribeTooltip(ui->gs_hideMouseOnIdle, tooltips.settings.hide_mouse_on_idle);
+		SubscribeTooltip(ui->gs_hideMouseOnIdleTime, tooltips.settings.hide_mouse_on_idle);
 
 		ui->gs_disableMouse->setChecked(m_gui_settings->GetValue(gui::gs_disableMouse).toBool());
 		connect(ui->gs_disableMouse, &QCheckBox::clicked, [this](bool val)

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1245,14 +1245,11 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	// Global settings (gui_settings)
 	if (!game)
 	{
-		SubscribeTooltip(ui->gs_resizeOnBoot, tooltips.settings.resize_on_boot);
-		SubscribeTooltip(ui->gb_gs_height, tooltips.settings.resize_on_boot);
-		SubscribeTooltip(ui->gb_gs_width, tooltips.settings.resize_on_boot);
+		SubscribeTooltip(ui->gs_resizeOnBoot_widget, tooltips.settings.resize_on_boot);
 		SubscribeTooltip(ui->gs_disableMouse, tooltips.settings.disable_mouse);
 		SubscribeTooltip(ui->gs_disableKbHotkeys, tooltips.settings.disable_kb_hotkeys);
 		SubscribeTooltip(ui->gs_showMouseInFullscreen, tooltips.settings.show_mouse_in_fullscreen);
-		SubscribeTooltip(ui->gs_hideMouseOnIdle, tooltips.settings.hide_mouse_on_idle);
-		SubscribeTooltip(ui->gs_hideMouseOnIdleTime, tooltips.settings.hide_mouse_on_idle);
+		SubscribeTooltip(ui->gs_hideMouseOnIdle_widget, tooltips.settings.hide_mouse_on_idle);
 
 		ui->gs_disableMouse->setChecked(m_gui_settings->GetValue(gui::gs_disableMouse).toBool());
 		connect(ui->gs_disableMouse, &QCheckBox::clicked, [this](bool val)

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2350,119 +2350,151 @@
                </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="layout_hideMouseOnIdle" stretch="0,0">
-                <item>
-                 <widget class="QCheckBox" name="gs_hideMouseOnIdle">
-                  <property name="text">
-                   <string>Hide mouse cursor if idle</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QSpinBox" name="gs_hideMouseOnIdleTime">
-                  <property name="accelerated">
-                   <bool>true</bool>
-                  </property>
-                  <property name="correctionMode">
-                   <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
-                  </property>
-                  <property name="keyboardTracking">
-                   <bool>false</bool>
-                  </property>
-                  <property name="suffix">
-                   <string>ms</string>
-                  </property>
-                  <property name="minimum">
-                   <number>200</number>
-                  </property>
-                  <property name="maximum">
-                   <number>99999</number>
-                  </property>
-                  <property name="stepType">
-                   <enum>QAbstractSpinBox::DefaultStepType</enum>
-                  </property>
-                  <property name="value">
-                   <number>2000</number>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="gs_resizeOnBoot">
-                <property name="text">
-                 <string>Resize game window on boot</string>
-                </property>
+               <widget class="QWidget" name="gs_hideMouseOnIdle_widget" native="true">
+                <layout class="QHBoxLayout" name="gs_hideMouseOnIdle_layout" stretch="0,0">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QCheckBox" name="gs_hideMouseOnIdle">
+                   <property name="text">
+                    <string>Hide mouse cursor if idle</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSpinBox" name="gs_hideMouseOnIdleTime">
+                   <property name="accelerated">
+                    <bool>true</bool>
+                   </property>
+                   <property name="correctionMode">
+                    <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                   </property>
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="suffix">
+                    <string>ms</string>
+                   </property>
+                   <property name="minimum">
+                    <number>200</number>
+                   </property>
+                   <property name="maximum">
+                    <number>99999</number>
+                   </property>
+                   <property name="stepType">
+                    <enum>QAbstractSpinBox::DefaultStepType</enum>
+                   </property>
+                   <property name="value">
+                    <number>2000</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="gs_resolution_layout">
-                <item>
-                 <widget class="QGroupBox" name="gb_gs_width">
-                  <property name="title">
-                   <string>Width</string>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_gs_width_layout">
+               <widget class="QWidget" name="gs_resizeOnBoot_widget" native="true">
+                <layout class="QVBoxLayout" name="gs_resizeOnBoot_layout">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QCheckBox" name="gs_resizeOnBoot">
+                   <property name="text">
+                    <string>Resize game window on boot</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="gs_resolution_layout">
                    <item>
-                    <widget class="QSpinBox" name="gs_width">
-                     <property name="accelerated">
-                      <bool>true</bool>
+                    <widget class="QGroupBox" name="gb_gs_width">
+                     <property name="title">
+                      <string>Width</string>
                      </property>
-                     <property name="correctionMode">
-                      <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                     <layout class="QVBoxLayout" name="gb_gs_width_layout">
+                      <item>
+                       <widget class="QSpinBox" name="gs_width">
+                        <property name="accelerated">
+                         <bool>true</bool>
+                        </property>
+                        <property name="correctionMode">
+                         <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                        </property>
+                        <property name="keyboardTracking">
+                         <bool>false</bool>
+                        </property>
+                        <property name="minimum">
+                         <number>0</number>
+                        </property>
+                        <property name="maximum">
+                         <number>9999</number>
+                        </property>
+                        <property name="value">
+                         <number>0</number>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QGroupBox" name="gb_gs_height">
+                     <property name="title">
+                      <string>Height</string>
                      </property>
-                     <property name="keyboardTracking">
-                      <bool>false</bool>
-                     </property>
-                     <property name="minimum">
-                      <number>0</number>
-                     </property>
-                     <property name="maximum">
-                      <number>9999</number>
-                     </property>
-                     <property name="value">
-                      <number>0</number>
-                     </property>
+                     <layout class="QVBoxLayout" name="gb_gs_height_layout">
+                      <item>
+                       <widget class="QSpinBox" name="gs_height">
+                        <property name="frame">
+                         <bool>true</bool>
+                        </property>
+                        <property name="accelerated">
+                         <bool>true</bool>
+                        </property>
+                        <property name="correctionMode">
+                         <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                        </property>
+                        <property name="keyboardTracking">
+                         <bool>false</bool>
+                        </property>
+                        <property name="minimum">
+                         <number>0</number>
+                        </property>
+                        <property name="maximum">
+                         <number>9999</number>
+                        </property>
+                        <property name="value">
+                         <number>0</number>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
                     </widget>
                    </item>
                   </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="gb_gs_height">
-                  <property name="title">
-                   <string>Height</string>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_gs_height_layout">
-                   <item>
-                    <widget class="QSpinBox" name="gs_height">
-                     <property name="frame">
-                      <bool>true</bool>
-                     </property>
-                     <property name="accelerated">
-                      <bool>true</bool>
-                     </property>
-                     <property name="correctionMode">
-                      <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
-                     </property>
-                     <property name="keyboardTracking">
-                      <bool>false</bool>
-                     </property>
-                     <property name="minimum">
-                      <number>0</number>
-                     </property>
-                     <property name="maximum">
-                      <number>9999</number>
-                     </property>
-                     <property name="value">
-                      <number>0</number>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
+                 </item>
+                </layout>
+               </widget>
               </item>
              </layout>
             </widget>


### PR DESCRIPTION
The original commits for the mouse hide on idle included definitions for tooltips, but didn't assign them correctly.
This fixes that up, so that tooltips exist.

And the resize height / width settings didn't have any tooltip applied.
So this extends the current resize setting tooltip to also trigger on the height / width hover (at least indicating that they are associated with this setting).