### PR TITLE
SPU: Make GET's full and aligned cache line accesses atomic with Accurate DMA

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -5796,11 +5796,6 @@ public:
 				if (u64 cmdh = ci->getZExtValue() & ~(MFC_BARRIER_MASK | MFC_FENCE_MASK | MFC_RESULT_MASK); !g_use_rtm)
 				{
 					// TODO: don't require TSX (current implementation is TSX-only)
-					if (cmdh == MFC_GET_CMD && g_cfg.core.spu_accurate_putlluc)
-					{
-						break;
-					}
-
 					if (cmdh == MFC_PUT_CMD || cmdh == MFC_SNDSIG_CMD)
 					{
 						break;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1345,7 +1345,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 		src = zero_buf;
 	}
 
-	if ((!g_use_rtm && (!is_get || g_cfg.core.spu_accurate_putlluc)) || g_cfg.core.spu_accurate_dma)  [[unlikely]]
+	if ((!g_use_rtm && !is_get) || g_cfg.core.spu_accurate_dma)  [[unlikely]]
 	{
 		for (u32 size = args.size, size0; is_get;
 			size -= size0, dst += size0, src += size0)

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1370,8 +1370,8 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 			{
 				const u64 time0 = vm::reservation_acquire(eal, size0);
 
-				// Ignore DMA lock bits
-				if (time0 & (127 & ~vm::dma_lockb))
+				// Ignore DMA lock bit on incomplete cache line accesses
+				if (time0 & (127 - (size0 != 128 ? vm::dma_lockb : 0)))
 				{
 					continue;
 				}
@@ -1422,7 +1422,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 				}
 				}
 
-				if (time0 != vm::reservation_acquire(eal, size0))
+				if (time0 != vm::reservation_acquire(eal, size0) || (size0 == 128 && !cmp_rdata(*reinterpret_cast<decltype(spu_thread::rdata)*>(dst), *reinterpret_cast<const decltype(spu_thread::rdata)*>(src))))
 				{
 					continue;
 				}

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -42,8 +42,8 @@ struct cfg_root : cfg::node
 		cfg::_bool spu_loop_detection{ this, "SPU loop detection", true, true }; // Try to detect wait loops and trigger thread yield
 		cfg::_int<0, 6> max_spurs_threads{ this, "Max SPURS Threads", 6 }; // HACK. If less then 6, max number of running SPURS threads in each thread group.
 		cfg::_enum<spu_block_size_type> spu_block_size{ this, "SPU Block Size", spu_block_size_type::safe };
-		cfg::_bool spu_accurate_getllar{ this, "Accurate GETLLAR", false };
-		cfg::_bool spu_accurate_putlluc{ this, "Accurate PUTLLUC", false };
+		cfg::_bool spu_accurate_getllar{ this, "Accurate GETLLAR", false, true };
+		cfg::_bool spu_accurate_putlluc{ this, "Accurate PUTLLUC", false, true };
 		cfg::_bool spu_accurate_dma{ this, "Accurate SPU DMA", false };
 		cfg::_bool rsx_accurate_res_access{this, "Accurate RSX reservation access", false, true};
 		cfg::_bool spu_verification{ this, "SPU Verification", true }; // Should be enabled


### PR DESCRIPTION
From CELL BE public docs about single-copy atomicity:
the following
> _"single register accesses are always atomic:
• All byte accesses
• Halfword accesses aligned on halfword boundaries
• Word accesses aligned on word boundaries
• Doubleword accesses aligned on doubleword boundaries
• Quadword accesses aligned on quadword boundaries
• Cache line accesses by DMA commands aligned on cache line boundaries
No other accesses are guaranteed to be atomic.
An access that is not atomic is performed as a set of smaller, disjointed atomic accesses."_ 
 
(the last point) means both PUT and GET full and aligned cache lines accesses are atomic, I updated the testcase in #8822 to use GET and not GETLLAR and it works. I remember why it didnt work initially and it was my mistake.

I guess its pretty cheap and might be even cheaper to make each GET/PUT full cache line access atomic on real CELL as it issues less memory bus requests this way.

CELL BE docs recommend using such accesses as it increases performance exponantially on realhw, probably due to this reason.
I do not recommed using TSX with Accurate DMA because it tanks performance much more than on non-tsx due to transactional failures.