### PR TITLE
Implement sceNpSignaling & signaling improvements

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -40,6 +40,8 @@ enum class thread_state : u32
 	finished  // Final state, always set at the end of thread execution
 };
 
+class need_wakeup {};
+
 template <class Context>
 class named_thread;
 
@@ -413,6 +415,11 @@ public:
 			if (s == thread_state::aborting)
 			{
 				thread::notify_abort();
+			}
+
+			if constexpr (std::is_base_of_v<need_wakeup, Context>)
+			{
+				this->wake_up();
 			}
 		}
 

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -364,6 +364,7 @@ target_sources(rpcs3_emu PRIVATE
 target_sources(rpcs3_emu PRIVATE
 	NP/fb_helpers.cpp
 	NP/np_handler.cpp
+	NP/signaling_handler.cpp
 	NP/np_structs_extra.cpp
 	NP/rpcn_client.cpp
 	NP/rpcn_config.cpp

--- a/rpcs3/Emu/Cell/Modules/cellNetCtl.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellNetCtl.cpp
@@ -203,25 +203,21 @@ error_code cellNetCtlGetInfo(s32 code, vm::ptr<CellNetCtlInfo> info)
 		return CELL_NET_CTL_ERROR_NOT_CONNECTED;
 	}
 
-	if (code == CELL_NET_CTL_INFO_MTU)
+	switch (code)
 	{
-		info->mtu = 1500;
-	}
-	else if (code == CELL_NET_CTL_INFO_LINK)
-	{
-		info->link = CELL_NET_CTL_LINK_CONNECTED;
-	}
-	else if (code == CELL_NET_CTL_INFO_IP_ADDRESS)
-	{
-		strcpy_trunc(info->ip_address, np_handler::ip_to_string(nph->get_local_ip_addr()));
-	}
-	else if (code == CELL_NET_CTL_INFO_NETMASK)
-	{
-		strcpy_trunc(info->netmask, "255.255.255.255");
-	}
-	else if (code == CELL_NET_CTL_INFO_HTTP_PROXY_CONFIG)
-	{
-		info->http_proxy_config = 0;
+	case CELL_NET_CTL_INFO_DEVICE: info->device = CELL_NET_CTL_DEVICE_WIRED; break;
+	// case CELL_NET_CTL_INFO_ETHER_ADDR: std::memset(info->ether_addr.data, 0xFF, sizeof(info->ether_addr.data)); break;
+	case CELL_NET_CTL_INFO_MTU: info->mtu = 1500; break;
+	case CELL_NET_CTL_INFO_LINK: info->link = CELL_NET_CTL_LINK_CONNECTED; break;
+	case CELL_NET_CTL_INFO_LINK_TYPE: info->link_type = CELL_NET_CTL_LINK_TYPE_10BASE_FULL; break;
+	case CELL_NET_CTL_INFO_IP_CONFIG: info->ip_config = CELL_NET_CTL_IP_STATIC; break;
+	case CELL_NET_CTL_INFO_DEFAULT_ROUTE: strcpy_trunc(info->default_route, "192.168.1.1"); break;
+	case CELL_NET_CTL_INFO_PRIMARY_DNS: strcpy_trunc(info->primary_dns, "8.8.8.8"); break;
+	case CELL_NET_CTL_INFO_SECONDARY_DNS: strcpy_trunc(info->secondary_dns, "8.8.8.8"); break;
+	case CELL_NET_CTL_INFO_IP_ADDRESS: strcpy_trunc(info->ip_address, np_handler::ip_to_string(nph->get_local_ip_addr())); break;
+	case CELL_NET_CTL_INFO_NETMASK: strcpy_trunc(info->netmask, "255.255.255.255"); break;
+	case CELL_NET_CTL_INFO_HTTP_PROXY_CONFIG: info->http_proxy_config = 0; break;
+	default: cellNetCtl.error("Unsupported request: %s", InfoCodeToName(code)); break;
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellVoice.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.cpp
@@ -858,6 +858,9 @@ error_code cellVoiceReadFromOPort(u32 ops, vm::ptr<void> data, vm::ptr<u32> size
 
 	if (!oport || oport->info.portType <= CELLVOICE_PORTTYPE_IN_VOICE)
 		return CELL_VOICE_ERROR_TOPOLOGY;
+	
+	if (size)
+		*size = 0;
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/sceNp.h
+++ b/rpcs3/Emu/Cell/Modules/sceNp.h
@@ -540,6 +540,8 @@ enum
 	SCE_NP_MANAGER_STATUS_ONLINE          = 3,
 };
 
+#define SCE_NP_MANAGER_EVENT_GOT_TICKET 255
+
 // Event types
 enum
 {
@@ -1042,7 +1044,7 @@ struct SceNpEntitlementId
 };
 
 // Callback for getting the connection status
-using SceNpManagerCallback = void(s32 event, s32 result, u32 arg_addr);
+using SceNpManagerCallback = void(s32 event, s32 result, vm::ptr<void> arg);
 
 // Score data unique to the application
 struct SceNpScoreGameInfo
@@ -1318,7 +1320,7 @@ struct SceNpScoreRecordOptParam
 using SceNpCustomMenuEventHandler = s32(s32 retCode, u32 index, vm::cptr<SceNpId> npid, SceNpCustomMenuSelectedType type, vm::ptr<void> arg);
 using SceNpBasicEventHandler = s32(s32 event, s32 retCode, u32 reqId, vm::ptr<void> arg);
 using SceNpCommerceHandler = void(u32 ctx_id, u32 subject_id, s32 event, s32 error_code, vm::ptr<void> arg);
-using SceNpSignalingHandler = void(u32 ctx_id, u32 subject_id, s32 event, s32 error_code, u32 arg_addr);
+using SceNpSignalingHandler = void(u32 ctx_id, u32 subject_id, s32 event, s32 error_code, vm::ptr<void> arg);
 using SceNpFriendlistResultHandler = s32(s32 retCode, vm::ptr<void> arg);
 using SceNpMatchingHandler = void(u32 ctx_id, u32 req_id, s32 event, s32 error_code, vm::ptr<void> arg);
 using SceNpMatchingGUIHandler = void(u32 ctx_id, s32 event, s32 error_code, vm::ptr<void> arg);

--- a/rpcs3/Emu/Cell/lv2/sys_net.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net.h
@@ -380,7 +380,7 @@ struct lv2_socket final
 			CWR = (1 << 7),
 		};
 
-		static constexpr be_t<u32> U2S_sig = static_cast<u8>('U') << 24 | static_cast<u8>('2') << 16 | static_cast<u8>('S') << 8 | static_cast<u8>('0');
+		static constexpr be_t<u32> U2S_sig = (static_cast<u32>('U') << 24 | static_cast<u32>('2') << 16 | static_cast<u32>('S') << 8 | static_cast<u32>('0'));
 		static constexpr std::size_t MAX_RECEIVED_BUFFER = (1024*1024*10);
 
 		// P2P stream socket specific
@@ -412,10 +412,9 @@ struct lv2_socket final
 		u16 op_port = 0, op_vport = 0;
 		u32 op_addr = 0;
 
-		std::vector<u8> received_data; // resized if needed, on recv will give all continuous data available and move data to beginning of vector
 		u64 data_beg_seq = 0; // Seq of first byte of received_data
 		u32 data_available = 0; // Amount of continuous data available(calculated on ACK send)
-		std::map<u64, u64> data_mapping; // holds seq/size of data received
+		std::map<u64, std::vector<u8>> received_data; // holds seq/data of data received
 
 		u32 cur_seq = 0; // SEQ of next packet to be sent
 	} p2ps;

--- a/rpcs3/Emu/NP/np_structs_extra.cpp
+++ b/rpcs3/Emu/NP/np_structs_extra.cpp
@@ -160,7 +160,12 @@ namespace extra_nps
 		sceNp2.warning("maxSlot: %d", room->maxSlot);
 
 		sceNp2.warning("members: *0x%x", room->memberList.members);
-		print_room_member_data_internal(room->memberList.members.get_ptr());
+		auto cur_member = room->memberList.members;
+		while (cur_member)
+		{
+			print_room_member_data_internal(cur_member.get_ptr());
+			cur_member = cur_member->next;
+		}
 		sceNp2.warning("membersNum: %d", room->memberList.membersNum);
 		sceNp2.warning("me: *0x%x", room->memberList.me);
 		sceNp2.warning("owner: *0x%x", room->memberList.owner);

--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -120,6 +120,8 @@ enum CommandType : u16
 	SetRoomDataInternal,
 	PingRoomOwner,
 	SendRoomMessage,
+	RequestSignalingInfos,
+	RequestTicket,
 };
 
 class rpcn_client
@@ -173,6 +175,8 @@ public:
 	bool set_roomdata_internal(u32 req_id, const SceNpMatching2SetRoomDataInternalRequest* req);
 	bool ping_room_owner(u32 req_id, u64 room_id);
 	bool send_room_message(u32 req_id, const SceNpMatching2SendRoomMessageRequest* req);
+	bool req_sign_infos(u32 req_id, const std::string& npid);
+	bool req_ticket(u32 req_id, const std::string& service_id);
 
 	const std::string& get_online_name() const
 	{

--- a/rpcs3/Emu/NP/signaling_handler.cpp
+++ b/rpcs3/Emu/NP/signaling_handler.cpp
@@ -1,0 +1,630 @@
+#include "stdafx.h"
+#include "Emu/Cell/PPUModule.h"
+#include "signaling_handler.h"
+#include "Emu/IdManager.h"
+#include "Emu/System.h"
+#include "Emu/Cell/Modules/cellSysutil.h"
+#include "np_handler.h"
+#include <queue>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
+
+LOG_CHANNEL(sign_log, "Signaling");
+
+std::vector<std::pair<std::pair<u32, u16>, std::vector<u8>>> get_sign_msgs();
+s32 send_packet_from_p2p_port(const std::vector<u8>& data, const sockaddr_in& addr);
+
+template <>
+void fmt_class_string<SignalingCommand>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](auto value) {
+		switch (value)
+		{
+		case signal_ping: return "PING";
+		case signal_pong: return "PONG";
+		case signal_connect: return "CONNECT";
+		case signal_connect_ack: return "CONNECT_ACK";
+		case signal_confirm: return "CONFIRM";
+		case signal_finished: return "FINISHED";
+		case signal_finished_ack: return "FINISHED_ACK";
+		}
+
+		return unknown;
+	});
+}
+
+/////////////////////////////
+//// SIGNALING CALLBACKS ////
+/////////////////////////////
+
+void signaling_handler::set_sig_cb(u32 sig_cb_ctx, vm::ptr<SceNpSignalingHandler> sig_cb, vm::ptr<void> sig_cb_arg)
+{
+	std::lock_guard lock(data_mutex);
+	this->sig_cb_ctx = sig_cb_ctx;
+	this->sig_cb     = sig_cb;
+	this->sig_cb_arg = sig_cb_arg;
+}
+
+void signaling_handler::set_ext_sig_cb(u32 sig_cb_ctx, vm::ptr<SceNpSignalingHandler> sig_ext_cb, vm::ptr<void> sig_ext_cb_arg)
+{
+	std::lock_guard lock(data_mutex);
+	this->sig_ext_cb_ctx = sig_ext_cb_ctx;
+	this->sig_ext_cb     = sig_ext_cb;
+	this->sig_ext_cb_arg = sig_ext_cb_arg;
+}
+
+void signaling_handler::set_sig2_cb(u16 sig2_cb_ctx, vm::ptr<SceNpMatching2SignalingCallback> sig2_cb, vm::ptr<void> sig2_cb_arg)
+{
+	std::lock_guard lock(data_mutex);
+	this->sig2_cb_ctx = sig2_cb_ctx;
+	this->sig2_cb     = sig2_cb;
+	this->sig2_cb_arg = sig2_cb_arg;
+}
+
+void signaling_handler::signal_sig_callback(u32 conn_id, int event)
+{
+	if (sig_cb)
+	{
+		sysutil_register_cb([sig_cb = this->sig_cb, sig_cb_ctx = this->sig_cb_ctx, conn_id, event, sig_cb_arg = this->sig_cb_arg](ppu_thread& cb_ppu) -> s32 {
+			sig_cb(cb_ppu, sig_cb_ctx, conn_id, event, 0, sig_cb_arg);
+			return 0;
+		});
+		sign_log.notice("Called sig CB: 0x%x (conn_id: %d)", event, conn_id);
+	}
+
+	// extended callback also receives normal events
+	signal_ext_sig_callback(conn_id, event);
+}
+
+void signaling_handler::signal_ext_sig_callback(u32 conn_id, int event)
+{
+	if (sig_ext_cb)
+	{
+		sysutil_register_cb([sig_ext_cb = this->sig_ext_cb, sig_ext_cb_ctx = this->sig_ext_cb_ctx, conn_id, event, sig_ext_cb_arg = this->sig_ext_cb_arg](ppu_thread& cb_ppu) -> s32 {
+			sig_ext_cb(cb_ppu, sig_ext_cb_ctx, conn_id, event, 0, sig_ext_cb_arg);
+			return 0;
+		});
+		sign_log.notice("Called EXT sig CB: 0x%x (conn_id: %d, member_id: %d)", event, conn_id);
+	}
+}
+
+void signaling_handler::signal_sig2_callback(u64 room_id, u16 member_id, SceNpMatching2Event event)
+{
+	// Signal the callback
+	if (sig2_cb)
+	{
+		sysutil_register_cb([sig2_cb = this->sig2_cb, sig2_cb_ctx = this->sig2_cb_ctx, room_id, member_id, event, sig2_cb_arg = this->sig2_cb_arg](ppu_thread& cb_ppu) -> s32 {
+			sig2_cb(cb_ppu, sig2_cb_ctx, room_id, member_id, event, 0, sig2_cb_arg);
+			return 0;
+		});
+	}
+
+	sign_log.notice("Called sig2 CB: 0x%x (room_id: %d, member_id: %d)", event, room_id, member_id);
+}
+
+///////////////////////////////////
+//// SIGNALING MSGS PROCESSING ////
+///////////////////////////////////
+
+void signaling_handler::reschedule_packet(std::shared_ptr<signaling_info>& si, SignalingCommand cmd, std::chrono::time_point<std::chrono::system_clock> new_timepoint)
+{
+	for (auto it = qpackets.begin(); it != qpackets.end(); it++)
+	{
+		if (it->second.packet.command == cmd && it->second.sig_info == si)
+		{
+			auto new_queue  = qpackets.extract(it);
+			new_queue.key() = new_timepoint;
+			qpackets.insert(std::move(new_queue));
+			return;
+		}
+	}
+}
+
+void signaling_handler::retire_packet(std::shared_ptr<signaling_info>& si, SignalingCommand cmd)
+{
+	for (auto it = qpackets.begin(); it != qpackets.end(); it++)
+	{
+		if (it->second.packet.command == cmd && it->second.sig_info == si)
+		{
+			qpackets.erase(it);
+			return;
+		}
+	}
+}
+
+void signaling_handler::retire_all_packets(std::shared_ptr<signaling_info>& si)
+{
+	for (auto it = qpackets.begin(); it != qpackets.end();)
+	{
+		if (it->second.sig_info == si)
+			it = qpackets.erase(it);
+		else
+			it++;
+	}
+}
+
+bool signaling_handler::validate_signaling_packet(const signaling_packet* sp)
+{
+	if (sp->signature != SIGNALING_SIGNATURE)
+	{
+		sign_log.error("Received a signaling packet with an invalid signature");
+		return false;
+	}
+
+	if (sp->version != 1u && sp->version != 2u)
+	{
+		sign_log.error("Invalid version in signaling packet");
+		return false;
+	}
+
+	return true;
+}
+
+void signaling_handler::process_incoming_messages()
+{
+	auto msgs = get_sign_msgs();
+
+	for (const auto& msg : msgs)
+	{
+		if (msg.second.size() != sizeof(signaling_packet))
+		{
+			sign_log.error("Received an invalid signaling packet");
+			continue;
+		}
+
+		auto op_addr = msg.first.first;
+		auto op_port = msg.first.second;
+		auto* sp     = reinterpret_cast<const signaling_packet*>(msg.second.data());
+
+		if (!validate_signaling_packet(sp))
+			continue;
+
+		if (sign_log.enabled == logs::level::trace)
+		{
+			in_addr addr;
+			addr.s_addr = op_addr;
+
+			if (sp->version == 1u)
+			{
+				char npid_buf[17]{};
+				memcpy(npid_buf, sp->V1.npid.handle.data, 16);
+				std::string npid(npid_buf);
+				sign_log.trace("sig1 %s from %s:%d(%s)", sp->command, inet_ntoa(addr), op_port, npid);
+			}
+			else
+			{
+				sign_log.trace("sig2 %s from %s:%d(%d:%d)", sp->command, inet_ntoa(addr), op_port, sp->V2.room_id, sp->V2.member_id);
+			}
+		}
+
+		bool reply = false, schedule_repeat = false;
+		auto& sent_packet = sp->version == 1u ? sig1_packet : sig2_packet;
+
+		// Get signaling info for user to know if we should even bother looking further
+		auto si = get_signaling_ptr(sp);
+
+		if (!si && sp->version == 1u && sp->command == signal_connect)
+		{
+			// Connection can be remotely established and not mutual
+			const u32 conn_id = create_sig_infos(&sp->V1.npid);
+			si = sig1_peers.at(conn_id);
+			// Activate the connection without triggering the main CB
+			si->connStatus = SCE_NP_SIGNALING_CONN_STATUS_ACTIVE;
+			si->addr = op_addr;
+			si->port = op_port;
+			si->ext_status = ext_sign_peer;
+			// Notify extended callback that peer activated
+			signal_ext_sig_callback(conn_id, SCE_NP_SIGNALING_EVENT_EXT_PEER_ACTIVATED);
+		}
+
+		if (!si || (si->connStatus == SCE_NP_SIGNALING_CONN_STATUS_INACTIVE && sp->command != signal_finished))
+		{
+			// User is unknown to us or the connection is inactive
+			// Ignore packet unless it's a finished packet in case the finished_ack wasn't received by opponent
+			continue;
+		}
+
+		const auto now = std::chrono::system_clock::now();
+		if (si)
+			si->time_last_msg_recvd = now;
+
+		const auto setup_ping = [&]()
+		{
+			for (auto it = qpackets.begin(); it != qpackets.end(); it++)
+			{
+				if (it->second.packet.command == signal_ping && it->second.sig_info == si)
+				{
+					return;
+				}
+			}
+
+			sent_packet.command = signal_ping;
+			queue_signaling_packet(sent_packet, si, now + REPEAT_PING_DELAY);
+		};
+
+		switch (sp->command)
+		{
+		case signal_ping:
+			reply               = true;
+			schedule_repeat     = false;
+			sent_packet.command = signal_pong;
+			break;
+		case signal_pong:
+			reply           = false;
+			schedule_repeat = false;
+			reschedule_packet(si, signal_ping, now + std::chrono::seconds(15));
+			break;
+		case signal_connect:
+			reply               = true;
+			schedule_repeat     = true;
+			sent_packet.command = signal_connect_ack;
+			// connection is established
+			// TODO: notify extended callback!
+			break;
+		case signal_connect_ack:
+			reply           = true;
+			schedule_repeat = false;
+			setup_ping();
+			sent_packet.command = signal_confirm;
+			retire_packet(si, signal_connect);
+			// connection is active
+			update_si_addr(si, op_addr, op_port);
+			update_si_status(si, SCE_NP_SIGNALING_CONN_STATUS_ACTIVE);
+			break;
+		case signal_confirm:
+			reply           = false;
+			schedule_repeat = false;
+			setup_ping();
+			retire_packet(si, signal_connect_ack);
+			// connection is active
+			update_si_addr(si, op_addr, op_port);
+			update_si_status(si, SCE_NP_SIGNALING_CONN_STATUS_ACTIVE, true);
+			break;
+		case signal_finished:
+			reply               = true;
+			schedule_repeat     = false;
+			sent_packet.command = signal_finished_ack;
+			// terminate connection
+			update_si_status(si, SCE_NP_SIGNALING_CONN_STATUS_INACTIVE);
+			break;
+		case signal_finished_ack:
+			reply           = false;
+			schedule_repeat = false;
+			retire_packet(si, signal_finished);
+			break;
+		default: sign_log.error("Invalid signaling command received"); continue;
+		}
+
+		if (reply)
+		{
+			send_signaling_packet(sent_packet, op_addr, op_port);
+			if (schedule_repeat)
+				queue_signaling_packet(sent_packet, si, now + REPEAT_CONNECT_DELAY);
+		}
+	}
+}
+
+void signaling_handler::operator()()
+{
+	while (thread_ctrl::state() != thread_state::aborting)
+	{
+		std::unique_lock<std::mutex> lock(data_mutex);
+		if (qpackets.size())
+			wakey.wait_until(lock, qpackets.begin()->first);
+		else
+			wakey.wait(lock);
+
+		if (thread_ctrl::state() == thread_state::aborting)
+			return;
+
+		process_incoming_messages();
+
+		const auto now = std::chrono::system_clock::now();
+
+		for (auto it = qpackets.begin(); it != qpackets.end();)
+		{
+			if (it->first > now)
+				break;
+
+			if (it->second.sig_info->time_last_msg_recvd < now - std::chrono::seconds(60))
+			{
+				// We had no connection to opponent for 60 seconds, consider the connection dead
+				sign_log.trace("Timeout disconnection");
+				update_si_status(it->second.sig_info, SCE_NP_SIGNALING_CONN_STATUS_INACTIVE);
+				break; // qpackets will be emptied of all packets from this user so we're requeuing
+			}
+
+			// Resend the packet
+			send_signaling_packet(it->second.packet, it->second.sig_info->addr, it->second.sig_info->port);
+
+			// Reschedule another packet
+			SignalingCommand cmd = it->second.packet.command;
+			auto& si             = it->second.sig_info;
+
+			std::chrono::milliseconds delay(500);
+			switch (cmd)
+			{
+			case signal_ping:
+			case signal_pong:
+				delay = REPEAT_PING_DELAY;
+				break;
+			case signal_connect:
+			case signal_connect_ack:
+			case signal_confirm:
+				delay = REPEAT_CONNECT_DELAY;
+				break;
+			case signal_finished:
+			case signal_finished_ack:
+				delay = REPEAT_FINISHED_DELAY;
+				break;
+			}
+
+			it++;
+			reschedule_packet(si, cmd, now + delay);
+		}
+	}
+}
+
+void signaling_handler::wake_up()
+{
+	wakey.notify_one();
+}
+
+void signaling_handler::update_si_addr(std::shared_ptr<signaling_info>& si, u32 new_addr, u16 new_port)
+{
+	ASSERT(si);
+
+	if (si->addr != new_addr || si->port != new_port)
+	{
+		in_addr addr_old, addr_new;
+		addr_old.s_addr = si->addr;
+		addr_new.s_addr = new_addr;
+
+		sign_log.trace("Updated Address from %s:%d to %s:%d", inet_ntoa(addr_old), si->port, inet_ntoa(addr_new), new_port);
+		si->addr = new_addr;
+		si->port = new_port;
+	}
+}
+
+void signaling_handler::update_si_status(std::shared_ptr<signaling_info>& si, s32 new_status, bool confirm_packet)
+{
+	if (!si)
+		return;
+
+	if (si->connStatus == SCE_NP_SIGNALING_CONN_STATUS_PENDING && new_status == SCE_NP_SIGNALING_CONN_STATUS_ACTIVE)
+	{
+		si->connStatus = SCE_NP_SIGNALING_CONN_STATUS_ACTIVE;
+		ASSERT(si->version == 1u || si->version == 2u);
+		if (si->version == 1u)
+			signal_sig_callback(si->conn_id, SCE_NP_SIGNALING_EVENT_ESTABLISHED);
+		else
+			signal_sig2_callback(si->room_id, si->member_id, SCE_NP_MATCHING2_SIGNALING_EVENT_Established);
+
+		return;
+	}
+
+	if ((si->connStatus == SCE_NP_SIGNALING_CONN_STATUS_PENDING || si->connStatus == SCE_NP_SIGNALING_CONN_STATUS_ACTIVE) && new_status == SCE_NP_SIGNALING_CONN_STATUS_INACTIVE)
+	{
+		si->connStatus = SCE_NP_SIGNALING_CONN_STATUS_INACTIVE;
+		ASSERT(si->version == 1u || si->version == 2u);
+		if (si->version == 1u)
+			signal_sig_callback(si->conn_id, SCE_NP_SIGNALING_EVENT_DEAD);
+		else
+			signal_sig2_callback(si->room_id, si->member_id, SCE_NP_MATCHING2_SIGNALING_EVENT_Dead);
+
+		retire_all_packets(si);
+		return;
+	}
+
+	if (confirm_packet && si->version == 1u && si->ext_status == ext_sign_none)
+	{
+		si->ext_status = ext_sign_mutual;
+		signal_ext_sig_callback(si->conn_id, SCE_NP_SIGNALING_EVENT_EXT_MUTUAL_ACTIVATED);
+	}
+}
+
+void signaling_handler::set_self_sig_info(SceNpId& npid)
+{
+	std::lock_guard lock(data_mutex);
+	sig1_packet.V1.npid = npid;
+}
+
+void signaling_handler::set_self_sig2_info(u64 room_id, u16 member_id)
+{
+	std::lock_guard lock(data_mutex);
+	sig2_packet.V2.room_id   = room_id;
+	sig2_packet.V2.member_id = member_id;
+}
+
+void signaling_handler::send_signaling_packet(signaling_packet& sp, u32 addr, u16 port)
+{
+	std::vector<u8> packet(sizeof(signaling_packet) + sizeof(u16));
+	reinterpret_cast<le_t<u16>&>(packet.data()[0]) = 65535;
+	memcpy(packet.data() + sizeof(u16), &sp, sizeof(signaling_packet));
+
+	sockaddr_in dest;
+	memset(&dest, 0, sizeof(sockaddr_in));
+	dest.sin_family      = AF_INET;
+	dest.sin_addr.s_addr = addr;
+	dest.sin_port        = std::bit_cast<u16, be_t<u16>>(port);
+
+	sign_log.trace("Sending %s packet to %s:%d", sp.command, inet_ntoa(dest.sin_addr), port);
+
+	if (send_packet_from_p2p_port(packet, dest) == -1)
+	{
+		sign_log.error("Failed to send signaling packet to %s:%d", inet_ntoa(dest.sin_addr), port);
+	}
+}
+
+void signaling_handler::queue_signaling_packet(signaling_packet& sp, std::shared_ptr<signaling_info> si, std::chrono::time_point<std::chrono::system_clock> wakeup_time)
+{
+	queued_packet qp;
+	qp.sig_info = si;
+	qp.packet   = sp;
+	qpackets.emplace(wakeup_time, std::move(qp));
+}
+
+std::shared_ptr<signaling_info> signaling_handler::get_signaling_ptr(const signaling_packet* sp)
+{
+	// V1
+	if (sp->version == 1u)
+	{
+		char npid_buf[17]{};
+		memcpy(npid_buf, sp->V1.npid.handle.data, 16);
+		std::string npid(npid_buf);
+
+		if (!npid_to_conn_id.count(npid))
+			return nullptr;
+
+		auto conn_id = npid_to_conn_id.at(npid);
+		if (!sig1_peers.count(conn_id))
+		{
+			sign_log.error("Discrepancy in signaling 1 data");
+			return nullptr;
+		}
+
+		return sig1_peers.at(conn_id);
+	}
+
+	// V2
+	auto room_id   = sp->V2.room_id;
+	auto member_id = sp->V2.member_id;
+	if (!sig2_peers.count(room_id) || !sig2_peers.at(room_id).count(member_id))
+		return nullptr;
+
+	return sig2_peers.at(room_id).at(member_id);
+}
+
+void signaling_handler::start_sig(u32 conn_id, u32 addr, u16 port)
+{
+	std::lock_guard lock(data_mutex);
+
+	auto& sent_packet   = sig1_packet;
+	sent_packet.command = signal_connect;
+
+	auto si = sig1_peers.at(conn_id);
+
+	si->addr = addr;
+	si->port = port;
+
+	send_signaling_packet(sent_packet, si->addr, si->port);
+	queue_signaling_packet(sent_packet, si, std::chrono::system_clock::now() + REPEAT_CONNECT_DELAY);
+}
+
+void signaling_handler::start_sig2(u64 room_id, u16 member_id)
+{
+	std::lock_guard lock(data_mutex);
+
+	auto& sent_packet   = sig2_packet;
+	sent_packet.command = signal_connect;
+
+	auto si = sig2_peers.at(room_id).at(member_id);
+
+	send_signaling_packet(sent_packet, si->addr, si->port);
+	queue_signaling_packet(sent_packet, si, std::chrono::system_clock::now() + REPEAT_CONNECT_DELAY);
+}
+
+void signaling_handler::disconnect_sig2_users(u64 room_id)
+{
+	std::lock_guard lock(data_mutex);
+
+	if (!sig2_peers.count(room_id))
+		return;
+
+	auto& sent_packet = sig2_packet;
+
+	sent_packet.command = signal_finished;
+
+	for (const auto& member : sig2_peers.at(room_id))
+	{
+		auto& si = member.second;
+		if (si->connStatus != SCE_NP_SIGNALING_CONN_STATUS_INACTIVE && !si->self)
+		{
+			send_signaling_packet(sent_packet, si->addr, si->port);
+			queue_signaling_packet(sent_packet, si, std::chrono::system_clock::now() + REPEAT_FINISHED_DELAY);
+		}
+	}
+}
+
+u32 signaling_handler::create_sig_infos(const SceNpId* npid)
+{
+	ASSERT(npid->handle.term == 0);
+	std::string npid_str(reinterpret_cast<const char*>(npid->handle.data));
+
+	if (npid_to_conn_id.count(npid_str))
+	{
+		return npid_to_conn_id.at(npid_str);
+	}
+
+	const u32 conn_id = cur_conn_id++;
+	npid_to_conn_id.emplace(npid_str, conn_id);
+	sig1_peers.emplace(conn_id, std::make_shared<signaling_info>());
+	sig1_peers.at(conn_id)->version = 1;
+	sig1_peers.at(conn_id)->conn_id = conn_id;
+
+	return conn_id;
+}
+
+u32 signaling_handler::init_sig_infos(const SceNpId* npid)
+{
+	std::lock_guard lock(data_mutex);
+
+	const u32 conn_id = create_sig_infos(npid);
+
+	if (sig1_peers[conn_id]->connStatus == SCE_NP_SIGNALING_CONN_STATUS_INACTIVE)
+	{
+		sign_log.trace("Creating new sig1 connection and requesting infos from RPCN");
+		sig1_peers[conn_id]->connStatus = SCE_NP_SIGNALING_CONN_STATUS_PENDING;
+
+		// Request peer infos from RPCN
+		std::string npid_str(reinterpret_cast<const char*>(npid->handle.data));
+		const auto nph = g_fxo->get<named_thread<np_handler>>();
+		nph->req_sign_infos(npid_str, conn_id);
+	}
+	else
+	{
+		// Connection already exists(from passive connection)
+		if (sig1_peers[conn_id]->connStatus == SCE_NP_SIGNALING_CONN_STATUS_ACTIVE && sig1_peers[conn_id]->ext_status == ext_sign_peer)
+		{
+			sign_log.trace("Activating already peer activated connection");
+			sig1_peers[conn_id]->ext_status = ext_sign_mutual;
+			start_sig(conn_id, sig1_peers[conn_id]->addr, sig1_peers[conn_id]->port);
+			signal_sig_callback(conn_id, SCE_NP_SIGNALING_EVENT_ESTABLISHED);
+			signal_ext_sig_callback(conn_id, SCE_NP_SIGNALING_EVENT_EXT_MUTUAL_ACTIVATED);
+		}
+	}
+
+	return conn_id;
+}
+
+signaling_info signaling_handler::get_sig_infos(u32 conn_id)
+{
+	return *sig1_peers[conn_id];
+}
+
+void signaling_handler::set_sig2_infos(u64 room_id, u16 member_id, s32 status, u32 addr, u16 port, bool self)
+{
+	std::lock_guard lock(data_mutex);
+	if (!sig2_peers[room_id][member_id])
+		sig2_peers[room_id][member_id] = std::make_shared<signaling_info>();
+
+	auto& peer       = sig2_peers[room_id][member_id];
+	peer->connStatus = status;
+	peer->addr       = addr;
+	peer->port       = port;
+	peer->self       = self;
+	peer->version    = 2;
+	peer->room_id    = room_id;
+	peer->member_id  = member_id;
+}
+
+signaling_info signaling_handler::get_sig2_infos(u64 room_id, u16 member_id)
+{
+	std::lock_guard lock(data_mutex);
+	return *sig2_peers[room_id][member_id];
+}

--- a/rpcs3/Emu/NP/signaling_handler.h
+++ b/rpcs3/Emu/NP/signaling_handler.h
@@ -1,0 +1,151 @@
+#pragma once
+#include "Utilities/BEType.h"
+#include "Emu/Memory/vm.h"
+#include "Emu/Memory/vm_ptr.h"
+#include "Emu/Cell/Modules/sceNp.h"
+#include "Emu/Cell/Modules/sceNp2.h"
+#include "Utilities/Thread.h"
+#include <unordered_map>
+#include <condition_variable>
+#include <chrono>
+
+enum ext_signaling_status : u8
+{
+	ext_sign_none = 0,
+	ext_sign_peer = 1,
+	ext_sign_mutual = 2,
+};
+
+struct signaling_info
+{
+	s32 connStatus = SCE_NP_SIGNALING_CONN_STATUS_INACTIVE;
+	u32 addr       = 0;
+	u16 port       = 0;
+
+	// For handler
+	std::chrono::time_point<std::chrono::system_clock> time_last_msg_recvd = std::chrono::system_clock::now();
+	bool self                                                              = false;
+	u32 version                                                            = 0;
+	// Signaling
+	u32 conn_id                                                            = 0;
+	ext_signaling_status ext_status                                        = ext_sign_none;
+	// Matching2
+	u64 room_id                                                            = 0;
+	u16 member_id                                                          = 0;
+};
+
+enum SignalingCommand : u32
+{
+	signal_ping,
+	signal_pong,
+	signal_connect,
+	signal_connect_ack,
+	signal_confirm,
+	signal_finished,
+	signal_finished_ack,
+};
+
+class signaling_handler : public need_wakeup
+{
+public:
+	void operator()();
+	void wake_up();
+
+	void set_self_sig_info(SceNpId& npid);
+	void set_self_sig2_info(u64 room_id, u16 member_id);
+
+	u32 init_sig_infos(const SceNpId* npid);
+	signaling_info get_sig_infos(u32 conn_id);
+
+	void set_sig2_infos(u64 room_id, u16 member_id, s32 status, u32 addr, u16 port, bool self = false);
+	signaling_info get_sig2_infos(u64 room_id, u16 member_id);
+
+	void set_sig_cb(u32 sig_cb_ctx, vm::ptr<SceNpSignalingHandler> sig_cb, vm::ptr<void> sig_cb_arg);
+	void set_ext_sig_cb(u32 sig_cb_ctx, vm::ptr<SceNpSignalingHandler> sig_ext_cb, vm::ptr<void> sig_ext_cb_arg);
+	void set_sig2_cb(u16 sig2_cb_ctx, vm::ptr<SceNpMatching2SignalingCallback> sig2_cb, vm::ptr<void> sig2_cb_arg);
+
+	void start_sig(u32 conn_id, u32 addr, u16 port);
+
+	void start_sig2(u64 room_id, u16 member_id);
+	void disconnect_sig2_users(u64 room_id);
+
+public:
+	static constexpr auto thread_name = "Signaling Manager Thread"sv;
+
+private:
+	static constexpr auto REPEAT_CONNECT_DELAY  = std::chrono::milliseconds(200);
+	static constexpr auto REPEAT_PING_DELAY     = std::chrono::milliseconds(500);
+	static constexpr auto REPEAT_FINISHED_DELAY = std::chrono::milliseconds(500);
+	static constexpr be_t<u32> SIGNALING_SIGNATURE = (static_cast<u32>('S') << 24 | static_cast<u32>('I') << 16 | static_cast<u32>('G') << 8 | static_cast<u32>('N'));
+
+	struct signaling_packet
+	{
+		be_t<u32> signature = SIGNALING_SIGNATURE;
+		le_t<u32> version;
+		le_t<SignalingCommand> command;
+		union {
+			struct
+			{
+				SceNpId npid;
+			} V1;
+			struct
+			{
+				le_t<u64> room_id;
+				le_t<u16> member_id;
+			} V2;
+		};
+	};
+
+	struct queued_packet
+	{
+		signaling_packet packet;
+		std::shared_ptr<signaling_info> sig_info;
+	};
+
+private:
+	u32 sig_cb_ctx = 0;
+	vm::ptr<SceNpSignalingHandler> sig_cb{};
+	vm::ptr<void> sig_cb_arg{};
+
+	u32 sig_ext_cb_ctx = 0;
+	vm::ptr<SceNpSignalingHandler> sig_ext_cb{};
+	vm::ptr<void> sig_ext_cb_arg{};
+
+	u16 sig2_cb_ctx = 0;
+	vm::ptr<SceNpMatching2SignalingCallback> sig2_cb{};
+	vm::ptr<void> sig2_cb_arg{};
+
+private:
+	u32 create_sig_infos(const SceNpId* npid);
+	void update_si_addr(std::shared_ptr<signaling_info>& si, u32 new_addr, u16 new_port);
+	void update_si_status(std::shared_ptr<signaling_info>& si, s32 new_status, bool confirm_packet = false);
+	void signal_sig_callback(u32 conn_id, int event);
+	void signal_ext_sig_callback(u32 conn_id, int event);
+	void signal_sig2_callback(u64 room_id, u16 member_id, SceNpMatching2Event event);
+
+private:
+	bool validate_signaling_packet(const signaling_packet* sp);
+	void reschedule_packet(std::shared_ptr<signaling_info>& si, SignalingCommand cmd, std::chrono::time_point<std::chrono::system_clock> new_timepoint);
+	void retire_packet(std::shared_ptr<signaling_info>& si, SignalingCommand cmd);
+	void retire_all_packets(std::shared_ptr<signaling_info>& si);
+
+private:
+	std::mutex data_mutex;
+	std::condition_variable wakey;
+
+	signaling_packet sig1_packet{.version = 1u};
+	signaling_packet sig2_packet{.version = 2u};
+
+	std::map<std::chrono::time_point<std::chrono::system_clock>, queued_packet> qpackets; // (wakeup time, packet)
+
+	u32 cur_conn_id = 1;
+	std::unordered_map<std::string, u32> npid_to_conn_id;                                         // (npid, conn_id)
+	std::unordered_map<u32, std::shared_ptr<signaling_info>> sig1_peers;                          // (conn_id, sig_info)
+	std::unordered_map<u64, std::unordered_map<u16, std::shared_ptr<signaling_info>>> sig2_peers; // (room (member_id, sig_info))
+
+private:
+	void process_incoming_messages();
+	std::shared_ptr<signaling_info> get_signaling_ptr(const signaling_packet* sp);
+	void send_signaling_packet(signaling_packet& sp, u32 addr, u16 port);
+	void queue_signaling_packet(signaling_packet& sp, std::shared_ptr<signaling_info> si, std::chrono::time_point<std::chrono::system_clock> wakeup_time);
+};

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -110,6 +110,7 @@
     <ClCompile Include="Emu\system_config.cpp" />
     <ClCompile Include="Emu\NP\fb_helpers.cpp" />
     <ClCompile Include="Emu\NP\np_handler.cpp" />
+    <ClCompile Include="Emu\NP\signaling_handler.cpp" />
     <ClCompile Include="Emu\NP\np_structs_extra.cpp" />
     <ClCompile Include="Emu\NP\rpcn_client.cpp" />
     <ClCompile Include="util\atomic.cpp">
@@ -489,6 +490,7 @@
     <ClInclude Include="Emu\Io\pad_config_types.h" />
     <ClInclude Include="Emu\NP\generated\np2_structs_generated.h" />
     <ClInclude Include="Emu\NP\np_handler.h" />
+    <ClInclude Include="Emu\NP\signaling_handler.h" />
     <ClInclude Include="Emu\NP\np_structs_extra.h" />
     <ClInclude Include="Emu\NP\rpcn_client.h" />
     <ClInclude Include="Emu\NP\rpcn_config.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -932,6 +932,9 @@
     <ClCompile Include="Emu\NP\np_handler.cpp">
       <Filter>Emu\NP</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\NP\signaling_handler.cpp">
+      <Filter>Emu\NP</Filter>
+    </ClCompile>
     <ClCompile Include="Emu\RSX\Overlays\overlay_osk_panel.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
@@ -1796,6 +1799,9 @@
       <Filter>Emu\Io</Filter>
     </ClInclude>
     <ClInclude Include="Emu\NP\np_handler.h">
+      <Filter>Emu\NP</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\NP\signaling_handler.h">
       <Filter>Emu\NP</Filter>
     </ClInclude>
     <ClInclude Include="Emu\RSX\Overlays\overlay_osk_panel.h">

--- a/rpcs3/rpcs3qt/rpcn_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/rpcn_settings_dialog.cpp
@@ -37,6 +37,7 @@ rpcn_settings_dialog::rpcn_settings_dialog(QWidget* parent)
 	QPushButton* btn_chg_pass = new QPushButton(tr("Set Password"));
 	QLabel *label_token       = new QLabel(tr("Token:"));
 	m_edit_token              = new QLineEdit();
+	m_edit_token->setMaxLength(16);
 
 	QPushButton* btn_create = new QPushButton(tr("Create Account"), this);
 	QPushButton* btn_save     = new QPushButton(tr("Save"), this);
@@ -151,6 +152,12 @@ bool rpcn_settings_dialog::save_config()
 	if (!validate(npid))
 	{
 		QMessageBox::critical(this, tr("Invalid character"), tr("NPID must be between 3 and 16 characters and can only contain '-', '_' or alphanumeric characters."), QMessageBox::Ok);
+		return false;
+	}
+
+	if (!token.empty() && token.size() != 16)
+	{
+		QMessageBox::critical(this, tr("Invalid token"), tr("The token you have received should be 16 characters long."), QMessageBox::Ok);
 		return false;
 	}
 


### PR DESCRIPTION
If you want to test:
- RPCN Test server is test-np.rpcs3.net
- You need to make an account(email isn't checked, you can just click Create Account after changing host to test server)
- This server is temporary and can be taken down at any time
- Don't use the test server to connect to DeS as you won't be able to connect to other users.

What's in the PR:
- Improved signaling
Now for games that use sceNpMatching2Signaling connectivity is ensured by address negociation if negociation is possible, it should improve connectivity between nat1/2 and nat3 users(though ofc nat3/nat3 is still impossible).
- Implements sceNpSignaling
Some games use an older version of signaling and it's now implemented.
- Fixes, so many fixes!
STREAM_P2P sockets are now properly implemented, fixed many bugs all over the place.
Special thanks to dio who helped me squash those bugs through many, many hours of testing.

What games now work?
In addition to DeS and Bomberman, Scott Pilgrim multiplayer now works.