### PR TITLE
SPU: Fix acquiring reservation locks on DMA consists of multiple cache lines (Accurate DMA)

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1348,7 +1348,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 	if ((!g_use_rtm && !is_get) || g_cfg.core.spu_accurate_dma)  [[unlikely]]
 	{
 		for (u32 size = args.size, size0; is_get;
-			size -= size0, dst += size0, src += size0)
+			size -= size0, dst += size0, src += size0, eal += size0)
 		{
 			size0 = std::min<u32>(128 - (eal & 127), std::min<u32>(size, 128));
 
@@ -1470,8 +1470,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 		{
 			if (g_cfg.core.spu_accurate_dma)
 			{
-				for (u32 size0;;
-					size -= size0, dst += size0, src += size0)
+				for (u32 size0;; size -= size0, dst += size0, src += size0, eal += size0)
 				{
 					size0 = std::min<u32>(128 - (eal & 127), std::min<u32>(size, 128));
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1370,8 +1370,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 			{
 				const u64 time0 = vm::reservation_acquire(eal, size0);
 
-				// Ignore DMA lock bit on incomplete cache line accesses
-				if (time0 & (127 - (size0 != 128 ? vm::dma_lockb : 0)))
+				if (time0 & 127)
 				{
 					continue;
 				}


### PR DESCRIPTION
Sigh... forgot to increment `eal` after each sub-transfer so it tried to acquire the lock of the same address everytime even though we progressed on execution.
The testcase only ever uses 1 cache line so I din't notice that it was broken.
Should also improve the performance of each sub-tranfers as their size can be greater now (the proper size).
Much less spam of LWARX/LDARX took too long on TSX path with Accurate DMA because of it.