### PR TITLE
SPU: Make PUT transfers use SEQ-CST ordering on Accurate DMA

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1611,6 +1611,11 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 		}
 		}
 
+		if (g_cfg.core.spu_accurate_dma)
+		{
+			std::atomic_thread_fence(std::memory_order_seq_cst);
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
Two explenations:
- We execute MFC transfers immediately and report to the program that the transfer is complete, so it should really be like that.
- Although for all commands which use reservation lock bits PUT transfers appear sequantially consistent, it is not the case for PPU reads/writes which do not use the reservation lock bits.