### PR TITLE
cellMsgDialog: Convert todo -> warning for cellMsgDialogOpen and cellMsgDialogOpenSimulViewWarning

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -54,6 +54,17 @@ enum : s32
 	CELL_MSGDIALOG_BUTTON_ESCAPE  = 3,
 };
 
+// Only for use with the cellMsgDialogOpen function
+enum : u32
+{
+	CELL_MSGDIALOG_DIALOG_TYPE_ERROR    = 0 << 0,
+	CELL_MSGDIALOG_DIALOG_TYPE_NORMAL   = 1 << 0,
+	CELL_MSGDIALOG_BUTTON_TYPE_NONE     = 0 << 1,
+	CELL_MSGDIALOG_BUTTON_TYPE_YESNO    = 1 << 1,
+	CELL_MSGDIALOG_DEFAULT_CURSOR_YES   = 0 << 2,
+	CELL_MSGDIALOG_DEFAULT_CURSOR_NO    = 1 << 2,
+};
+
 enum CellMsgDialogProgressBarIndex
 {
 	CELL_MSGDIALOG_PROGRESSBAR_INDEX_SINGLE       = 0, // the only bar in a single bar dialog


### PR DESCRIPTION
This still forwards to cellMsgDialogOpen2, but recreates the button flags
based upon what is supported from testing of cellMsgDialogOpen2.

For the documented inputs this matches PS3, for undocumented input values
the PS3 appears to just ignore them, which this will also do.

Added text for SimulView also, whilst current behaviour doesn't exactly
match PS3, I believe that it's likely what we would want, differences are:
* PS3 text is not skippable
* PS3 text has TM characters, which I was unable to replicate in rpcs3