### PR TITLE
sys_process: Implement exitspawn error checking

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -359,7 +359,14 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 		}
 
 		Emu.SetForceBoot(true);
-		Emu.BootGame(path, "", true);
+
+		auto res = Emu.BootGame(path, "", true);
+
+		if (res != game_boot_result::no_errors)
+		{
+			sys_process.fatal("Failed to boot from exitspawn! (path=\"%s\", error=%s)", path, res);
+			Emu.Stop();
+		}
 	});
 
 	ppu.state += cpu_flag::dbg_global_stop;


### PR DESCRIPTION
If exitspawn failed for any reason such as the referenced file is missing the current process must exit anyways, it just won't proceed with a new process. Add logging for it.