### PR TITLE
hle: Implement ID_CURRENT_USER_HAS_NP_ACCOUNT

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -251,8 +251,9 @@ error_code cellSysutilGetSystemParamInt(CellSysutilParamId id, vm::ptr<s32> valu
 		*value = CELL_SYSUTIL_GAME_PARENTAL_LEVEL0_RESTRICT_OFF;
 	break;
 
+	// Report user has an NP account when np_psn_status is Fake or RPCN
 	case CELL_SYSUTIL_SYSTEMPARAM_ID_CURRENT_USER_HAS_NP_ACCOUNT:
-		*value = 0;
+		*value = g_cfg.net.psn_status != np_psn_status::disabled;
 	break;
 
 	case CELL_SYSUTIL_SYSTEMPARAM_ID_CAMERA_PLFREQ:


### PR DESCRIPTION
Implements `ID_CURRENT_USER_HAS_NP_ACCOUNT`, a boolean that is true when np_psn_status is either Fake or RPCN 

Fixes:
- Plex for PS3


**Before**
One could use Plex in the background but the error is non-closable 
![image](https://user-images.githubusercontent.com/10283761/92480961-87679380-f1dd-11ea-8640-906592923032.png)

**After**
Plex works without any error
![image](https://user-images.githubusercontent.com/10283761/92481036-a49c6200-f1dd-11ea-8552-1119c8a84e2a.png)
![image](https://user-images.githubusercontent.com/10283761/92481260-ffce5480-f1dd-11ea-8b4d-777f1fd3e3b0.png)

