### PR TITLE
Mouse hide and lock fixes

### DIFF
--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -323,6 +323,12 @@ bool keyboard_pad_handler::get_mouse_lock_state()
 
 void keyboard_pad_handler::mouseMoveEvent(QMouseEvent* event)
 {
+	if (!m_mouse_move_used)
+	{
+		event->ignore();
+		return;
+	}
+
 	static int movement_x = 0;
 	static int movement_y = 0;
 	static int last_pos_x = 0;
@@ -632,6 +638,7 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::
 	if (p_profile == nullptr)
 		return false;
 
+	m_mouse_move_used = false;
 	m_deadzone_x = p_profile->mouse_deadzone_x;
 	m_deadzone_y = p_profile->mouse_deadzone_y;
 	m_multi_x = p_profile->mouse_acceleration_x / 100.0;
@@ -641,13 +648,15 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::
 	m_analog_lerp_factor  = p_profile->analog_lerp_factor / 100.0f;
 	m_trigger_lerp_factor = p_profile->trigger_lerp_factor / 100.0f;
 
-	auto find_key = [&](const cfg::string& name)
+	const auto find_key = [this](const cfg::string& name)
 	{
 		int key = FindKeyCode(mouse_list, name, false);
 		if (key < 0)
 			key = GetKeyCode(name);
 		if (key < 0)
 			key = 0;
+		else if (!m_mouse_move_used && (key == mouse::move_left || key == mouse::move_right || key == mouse::move_up || key == mouse::move_down))
+			m_mouse_move_used = true;
 		return key;
 	};
 

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -101,6 +101,7 @@ protected:
 
 private:
 	QWindow* m_target = nullptr;
+	bool m_mouse_move_used = false;
 	bool get_mouse_lock_state();
 
 	std::vector<std::shared_ptr<Pad>> bindings;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -590,7 +590,7 @@ bool gs_frame::event(QEvent* ev)
 		}
 		close();
 	}
-	else if (ev->type() == QEvent::MouseMove && !m_show_mouse)
+	else if (ev->type() == QEvent::MouseMove && (!m_show_mouse || m_mousehide_timer.isActive()))
 	{
 		// This will make the cursor visible again if it was hidden by the mouse idle timeout
 		handle_cursor(visibility(), false, true);

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -107,7 +107,7 @@ public:
 		const QString resize_on_boot               = tr("Automatically resizes the game window on boot.\nThis does not change the internal game resolution.");
 		const QString show_trophy_popups           = tr("Show trophy pop-ups when a trophy is unlocked.");
 		const QString disable_mouse                = tr("Disables the activation of fullscreen mode per double-click while the game screen is active.\nCheck this if you want to play with mouse and keyboard (for example with UCR).");
-		const QString disable_kb_hotkeys           = tr("Disables keyboard hotkeys such as Ctrl-S, Ctrl-E, Ctrl-R, Ctrl-P while the game screen is active.\nCheck this if you want to play with mouse and keyboard.");
+		const QString disable_kb_hotkeys           = tr("Disables keyboard hotkeys such as Ctrl-S, Ctrl-E, Ctrl-R, Ctrl-P while the game screen is active.\nThis does not include Ctrl-L (hide and lock mouse) and Alt-Enter (toggle fullscreen).\nCheck this if you want to play with mouse and keyboard.");
 		const QString max_llvm_threads             = tr("Limits the maximum number of threads used for the initial PPU and SPU module compilation.\nLower this in order to increase performance of other open applications.\nThe default uses all available threads.");
 		const QString show_mouse_in_fullscreen     = tr("Shows the mouse cursor when the fullscreen mode is active.\nCurrently this may not work every time.");
 		const QString hide_mouse_on_idle           = tr("Hides the mouse cursor if no mouse movement is detected for the configured time.");


### PR DESCRIPTION
- Fixes restart of the mouse hide on idle timer.
- Fixes falsely locked mouse in fullscreen when no mouse move was configured by checking for mouse move assignment in the related mouseMoveEvent and skipping it appropriately.