### PR TITLE
vk: Simplify shadow comparison operations for non-integer formats

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -184,20 +184,8 @@ void VKGSRender::load_texture_env()
 
 				if (texture_format >= CELL_GCM_TEXTURE_DEPTH24_D8 && texture_format <= CELL_GCM_TEXTURE_DEPTH16_FLOAT)
 				{
-					if (m_device->get_formats_support().d24_unorm_s8)
-					{
-						// NOTE:
-						// The nvidia-specific format D24S8 has a special way of doing depth comparison that matches the PS3
-						// In case of projected shadow lookup the result of the divide operation has its Z clamped to [0-1] before comparison
-						// Most other wide formats (Z bits > 16) do not behave this way and depth greater than 1 is possible due to the use of floating point as storage
-						// Compare operations for these formats (such as D32_SFLOAT) are therefore emulated for correct results
-
-						// NOTE2:
-						// To improve reusability, DEPTH16 shadow ops are also emulated if D24S8 support is not available
-
-						compare_enabled = VK_TRUE;
-						depth_compare_mode = vk::get_compare_func(rsx::method_registers.fragment_textures[i].zfunc(), true);
-					}
+					compare_enabled = VK_TRUE;
+					depth_compare_mode = vk::get_compare_func(rsx::method_registers.fragment_textures[i].zfunc(), true);
 				}
 
 				const int aniso_override_level = g_cfg.video.anisotropic_level_override;

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -130,7 +130,7 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 			const auto mask = (1 << index);
 
-			if (!device_props.emulate_depth_compare && m_prog.shadow_textures & mask)
+			if (m_prog.shadow_textures & mask)
 			{
 				if (m_shadow_sampled_textures & mask)
 				{


### PR DESCRIPTION
Just use hardware PCF, it makes everyone's life easier.

Fixes https://github.com/RPCS3/rpcs3/issues/8805