### PR TITLE
Fix fs::copy_file on linux

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -737,7 +737,7 @@ bool fs::copy_file(const std::string& from, const std::string& to, bool overwrit
 	// sendfile will work with non-socket output (i.e. regular file) on Linux 2.6.33+
 	off_t bytes_copied = 0;
 	struct ::stat fileinfo = { 0 };
-	if (::fstat(input, &fileinfo) || ::sendfile(output, input, &bytes_copied, fileinfo.st_size))
+	if (::fstat(input, &fileinfo) == -1 || ::sendfile(output, input, &bytes_copied, fileinfo.st_size) == -1)
 #else
 #error "Native file copy implementation is missing"
 #endif

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -73,7 +73,7 @@ std::string patch_engine::get_patch_config_path()
 
 	if (!fs::create_path(config_dir))
 	{
-		patch_log.error("Could not create path: %s", patch_path);
+		patch_log.error("Could not create path: %s (%s)", patch_path, fs::g_tls_error);
 	}
 
 	return patch_path;
@@ -825,7 +825,7 @@ void patch_engine::save_config(const patch_map& patches_map, bool enable_legacy_
 	fs::file file(path, fs::rewrite);
 	if (!file)
 	{
-		patch_log.fatal("Failed to open patch config file %s", path);
+		patch_log.fatal("Failed to open patch config file %s (%s)", path, fs::g_tls_error);
 		return;
 	}
 
@@ -978,8 +978,8 @@ bool patch_engine::save_patches(const patch_map& patches, const std::string& pat
 	fs::file file(path, fs::rewrite);
 	if (!file)
 	{
-		patch_log.fatal("save_patches: Failed to open patch file %s", path);
-		append_log_message(log_messages, fmt::format("Failed to open patch file %s", path));
+		patch_log.fatal("save_patches: Failed to open patch file %s (%s)", path, fs::g_tls_error);
+		append_log_message(log_messages, fmt::format("Failed to open patch file %s (%s)", path, fs::g_tls_error));
 		return false;
 	}
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -942,10 +942,10 @@ bool patch_manager_dialog::handle_json(const QByteArray& data)
 		// Back up current patch file if possible
 		if (fs::is_file(path))
 		{
-			if (const std::string path_old = path + ".old";
-				!fs::copy_file(path, path_old, true))
+			if (const std::string back_up_path = path + ".old";
+				!fs::rename(path, back_up_path, true))
 			{
-				patch_log.error("Could not back up current patches to %s (%s)", path_old, fs::g_tls_error);
+				patch_log.error("Could not back up current patches to %s (%s)", back_up_path, fs::g_tls_error);
 				return false;
 			}
 		}

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -846,7 +846,7 @@ void patch_manager_dialog::download_update()
 		}
 		else
 		{
-			patch_log.error("Could not open patch file: %s", path);
+			patch_log.error("Could not open patch file: %s (%s)", path, fs::g_tls_error);
 			return;
 		}
 	}
@@ -945,7 +945,7 @@ bool patch_manager_dialog::handle_json(const QByteArray& data)
 			if (const std::string path_old = path + ".old";
 				!fs::copy_file(path, path_old, true))
 			{
-				patch_log.error("Could not back up current patches to %s", path_old);
+				patch_log.error("Could not back up current patches to %s (%s)", path_old, fs::g_tls_error);
 				return false;
 			}
 		}
@@ -957,7 +957,7 @@ bool patch_manager_dialog::handle_json(const QByteArray& data)
 		}
 		else
 		{
-			patch_log.error("Could not save new patches to %s", path);
+			patch_log.error("Could not save new patches to %s (%s)", path, fs::g_tls_error);
 			return false;
 		}
 


### PR DESCRIPTION
Should fix some file copy errors on linux.
reported by @AniLeo
thx @RipleyTom for finding the solution

This may fix some random issues:
- when downloading patch files and backing up the old patch files
- when installing rap files
- when some ui icons are copied around