### PR TITLE
Fix patch downloader pop up location

### DIFF
--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -73,7 +73,7 @@ patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_set
 
 	ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setText(tr("Download latest patches"));
 
-	m_downloader = new downloader(parent);
+	m_downloader = new downloader(this);
 
 	// Create connects
 	connect(ui->patch_filter, &QLineEdit::textChanged, this, &patch_manager_dialog::filter_patches);


### PR DESCRIPTION
It was spawning on top of the main window instead of the patch manager