### PR TITLE
Fix bitfield operator &=

### DIFF
--- a/Utilities/BitField.h
+++ b/Utilities/BitField.h
@@ -147,7 +147,7 @@ struct bf_t : bf_base<T, N>
 
 	bf_t& operator &=(vtype right)
 	{
-		this->m_data &= static_cast<vtype>((static_cast<utype>(right) & bf_t::vmask) << bitpos);
+		this->m_data &= static_cast<vtype>(((static_cast<utype>(right) & bf_t::vmask) << bitpos) | ~(bf_t::vmask << bitpos));
 		return *this;
 	}
 


### PR DESCRIPTION
There was I, coding innocently using bitfields, until a scary bitfield AND assign operator erased all of the value bits outside of the bitfield!
Now matches bitfield = bitfield & value as it should.