### PR TITLE
SPU: Implement events channel count, Minor Interrupts fixes

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
@@ -95,8 +95,6 @@ private:
 	void branch_set_link(u32 target);
 	void fall(spu_opcode_t op);
 
-	void get_events();
-
 public:
 	void UNK(spu_opcode_t op);
 

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -518,7 +518,7 @@ bool spu_interpreter::BISLED(spu_thread& spu, spu_opcode_t op)
 	const u32 target = spu_branch_target(spu.gpr[op.ra]._u32[3]);
 	spu.gpr[op.rt] = v128::from32r(spu_branch_target(spu.pc + 4));
 
-	if (spu.get_events())
+	if (spu.get_events().count)
 	{
 		spu.pc = target;
 		set_interrupt_status(spu, op);

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -40,6 +40,7 @@ enum registers : int
 	PPU_VRSAVE,
 	MFC_PEVENTS,
 	MFC_EVENTS_MASK,
+	MFC_EVENTS_COUNT,
 	MFC_TAG_UPD,
 	MFC_TAG_MASK,
 	MFC_ATOMIC_STAT,
@@ -113,6 +114,7 @@ register_editor_dialog::register_editor_dialog(QWidget *parent, u32 _pc, const s
 			for (int i = spu_r0; i <= spu_r127; i++) m_register_combo->addItem(qstr(fmt::format("r%d", i % 128)), i);
 			m_register_combo->addItem("MFC Pending Events", +MFC_PEVENTS);
 			m_register_combo->addItem("MFC Events Mask", +MFC_EVENTS_MASK);
+			m_register_combo->addItem("MFC Events Count", +MFC_EVENTS_COUNT);
 			m_register_combo->addItem("MFC Tag Mask", +MFC_TAG_MASK);
 			//m_register_combo->addItem("MFC Tag Update", +MFC_TAG_UPD);
 			//m_register_combo->addItem("MFC Atomic Status", +MFC_ATOMIC_STAT);
@@ -187,8 +189,9 @@ void register_editor_dialog::updateRegister(int reg)
 			const u32 reg_index = reg % 128;
 			str = fmt::format("%016llx%016llx", spu.gpr[reg_index]._u64[1], spu.gpr[reg_index]._u64[0]);
 		}
-		else if (reg == MFC_PEVENTS) str = fmt::format("%08x", +spu.ch_event_stat);
-		else if (reg == MFC_EVENTS_MASK) str = fmt::format("%08x", +spu.ch_event_mask);
+		else if (reg == MFC_PEVENTS) str = fmt::format("%08x", +spu.ch_events.load().events);
+		else if (reg == MFC_EVENTS_MASK) str = fmt::format("%08x", +spu.ch_events.load().mask);
+		else if (reg == MFC_EVENTS_COUNT) str = fmt::format("%u", +spu.ch_events.load().count);
 		else if (reg == MFC_TAG_MASK) str = fmt::format("%08x", spu.ch_tag_mask);
 		else if (reg == SPU_SRR0) str = fmt::format("%08x", spu.srr0);
 		else if (reg == SPU_SNR1) str = fmt::format("%s", spu.ch_snr1);
@@ -318,11 +321,12 @@ void register_editor_dialog::OnOkay(const std::shared_ptr<cpu_thread>& _cpu)
 			if (u32 reg_value; check_res(std::from_chars(value.c_str() + 24, value.c_str() + 32, reg_value, 16), value.c_str() + 32))
 			{
 				bool ok = true;
-				if (reg == MFC_PEVENTS && !(reg_value & ~SPU_EVENT_IMPLEMENTED)) spu.ch_event_stat = reg_value;
-				else if (reg == MFC_EVENTS_MASK && !(reg_value & ~SPU_EVENT_IMPLEMENTED)) spu.ch_event_mask = reg_value;
+				if (reg == MFC_PEVENTS && !(reg_value & ~SPU_EVENT_IMPLEMENTED)) spu.ch_events.atomic_op([&](typename spu_thread::ch_events_t& events){ events.events = reg_value; });
+				else if (reg == MFC_EVENTS_MASK && !(reg_value & ~SPU_EVENT_IMPLEMENTED)) spu.ch_events.atomic_op([&](typename spu_thread::ch_events_t& events){ events.mask = reg_value; });
+				else if (reg == MFC_EVENTS_COUNT && reg_value <= 1u) spu.ch_events.atomic_op([&](typename spu_thread::ch_events_t& events){ events.count = reg_value; });
 				else if (reg == MFC_TAG_MASK) spu.ch_tag_mask = reg_value;
-				else if (reg == SPU_SRR0) spu.srr0 = reg_value & 0x3fffc;
-				else if (reg == PC) spu.pc = reg_value & 0x3fffc;
+				else if (reg == SPU_SRR0 && !(reg_value & ~0x3fffc)) spu.srr0 = reg_value;
+				else if (reg == PC && !(reg_value & ~0x3fffc)) spu.pc = reg_value;
 				else ok = false;
 
 				if (ok) return;


### PR DESCRIPTION
The following conditions set the SPU event channel count:

- An event occurs, and the corresponding mask is 1 in the SPU Write Event Mask Channel.
- The SPU Write Event Mask Channel is written with a 1 in a bit position that corresponds to a 1.
- Enabled events are pending after a write of the SPU Write Event Acknowledgment Channel.

The following condition clear the SPU event channel count:
- Reading from SPU Read Event Status Channel.

Interrupt fixes:
Added a missing interrupt invocation check in SPU_WrEventMask in case newly masked events set the events count.