### PR TITLE
Win32 FS: Rewrite (fix) vfs::host::rename, Fix fs::utime for directories

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1616,6 +1616,116 @@ bool fs::remove_all(const std::string& path, bool remove_root)
 	return true;
 }
 
+std::string fs::escape_path(std::string_view path)
+{
+	std::string real; real.resize(path.size());
+
+#ifdef _WIN32
+	constexpr auto& delim = "/\\";
+#else
+	constexpr auto& delim = "/";
+#endif
+
+	auto get_char = [&](std::size_t& from, std::size_t& to, std::size_t count)
+	{
+		std::memcpy(&real[to], &path[from], count);
+		from += count, to += count;
+	};
+
+	std::size_t i = 0, j = -1, pos_nondelim = 0, after_delim = 0;
+
+	if (i < path.size())
+	{
+		j = 0;
+	}
+
+	for (; i < path.size();)
+	{
+		real[j] = path[i];
+#ifdef _Win32
+		if (real[j] == '\\')
+		{
+			real[j] = '/';
+		}
+#endif
+		// If the current character was preceeded by a delimiter special treatment is required:
+		// If another deleimiter is encountered, remove it (do not write it to output string)
+		// Otherwise test if it is a "." or ".." sequence.
+		if (std::exchange(after_delim, path[i] == delim[0] || path[i] == delim[1]))
+		{
+			if (!after_delim)
+			{
+				if (real[j] == '.')
+				{
+					if (i + 1 == path.size())
+					{
+						break;
+					}
+
+					get_char(i, j, 1);
+
+					switch (real[j])
+					{
+					case '.':
+					{
+						bool remove_element = true;
+						std::size_t k = 1;
+
+						for (; k + i != path.size(); k++)
+						{
+							switch (path[i + k])
+							{
+							case '.': continue;
+							case delim[0]: case delim[1]: break;
+							default: remove_element = false; break;
+							}
+						}
+
+						if (remove_element)
+						{
+							if (i == 1u)
+							{
+								j = pos_nondelim;
+								real[j] = '\0';// Ensure termination at this posistion
+								after_delim = true;
+								i += k;
+								continue;
+							}
+						}
+
+						get_char(i, j, k);
+						continue;
+					}
+					case '/':
+					{
+						i++;
+						after_delim = true;
+						continue;
+					}
+					default: get_char(i, j, 1); continue;
+					}
+				}
+
+				pos_nondelim = j;
+				get_char(i, j, 1);
+			}
+			else
+			{
+				i++;
+			}
+		}
+		else
+		{
+			get_char(i, j, 1);
+		}
+	}
+
+	if (j != umax && (real[j] == delim[0] || real[j] == delim[1])) j--; // Do not include a delmiter at the end
+
+	real.resize(j + 1);
+	return real;
+}
+
 u64 fs::get_dir_size(const std::string& path, u64 rounding_alignment)
 {
 	u64 result = 0;

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -967,7 +967,7 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 		disp = mode & fs::trunc ? TRUNCATE_EXISTING : OPEN_EXISTING;
 	}
 
-	DWORD share = 0;
+	DWORD share = FILE_SHARE_DELETE;
 	if (!(mode & fs::unread) || !(mode & fs::write))
 	{
 		share |= FILE_SHARE_READ;
@@ -975,7 +975,7 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 
 	if (!(mode & (fs::lock + fs::unread)) || !(mode & fs::write))
 	{
-		share |= FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+		share |= FILE_SHARE_WRITE;
 	}
 
 	const HANDLE handle = CreateFileW(to_wchar(path).get(), access, share, NULL, disp, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -881,7 +881,7 @@ bool fs::utime(const std::string& path, s64 atime, s64 mtime)
 
 #ifdef _WIN32
 	// Open the file
-	const auto handle = CreateFileW(to_wchar(path).get(), FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	const auto handle = CreateFileW(to_wchar(path).get(), FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_ATTRIBUTE_NORMAL, NULL);
 	if (handle == INVALID_HANDLE_VALUE)
 	{
 		g_tls_error = to_error(GetLastError());

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -498,6 +498,9 @@ namespace fs
 	// Get common cache directory
 	const std::string& get_cache_dir();
 
+	// Get real path for comparisons (TODO: investigate std::filesystem::path::compare implementation)
+	std::string escape_path(std::string_view path);
+
 	// Delete directory and all its contents recursively
 	bool remove_all(const std::string& path, bool remove_root = true);
 

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -4,6 +4,7 @@
 #include "Emu/VFS.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUModule.h"
+#include "Emu/Cell/lv2/sys_fs.h"
 
 #include "cellSysutil.h"
 #include "cellMsgDialog.h"
@@ -555,7 +556,7 @@ error_code cellGameContentPermit(vm::ptr<char[CELL_GAME_PATH_MAX]> contentInfoPa
 		psf::save_object(fs::file(perm->temp + "/PARAM.SFO", fs::rewrite), perm->sfo);
 
 		// Make temporary directory persistent (atomically)
-		if (vfs::host::rename(perm->temp, vfs::get(dir), false))
+		if (vfs::host::rename(perm->temp, vfs::get(dir), &g_mp_sys_dev_hdd0, false))
 		{
 			cellGame.success("cellGameContentPermit(): directory '%s' has been created", dir);
 

--- a/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
@@ -78,11 +78,12 @@ error_code cellGifDecOpen(PMainHandle mainHandle, PPSubHandle subHandle, PSrc sr
 	case CELL_GIFDEC_FILE:
 	{
 		// Get file descriptor and size
-		fs::file file_s(vfs::get(src->fileName.get_ptr()));
+		const auto real_path = vfs::get(src->fileName.get_ptr());
+		fs::file file_s(real_path);
 		if (!file_s) return CELL_GIFDEC_ERROR_OPEN_FILE;
 
 		current_subHandle.fileSize = file_s.size();
-		current_subHandle.fd = idm::make<lv2_fs_object, lv2_file>(src->fileName.get_ptr(), std::move(file_s), 0, 0);
+		current_subHandle.fd = idm::make<lv2_fs_object, lv2_file>(src->fileName.get_ptr(), std::move(file_s), 0, 0, real_path);
 		break;
 	}
 	}

--- a/rpcs3/Emu/Cell/Modules/cellJpgDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellJpgDec.cpp
@@ -69,11 +69,12 @@ error_code cellJpgDecOpen(u32 mainHandle, vm::ptr<u32> subHandle, vm::ptr<CellJp
 	case CELL_JPGDEC_FILE:
 	{
 		// Get file descriptor and size
-		fs::file file_s(vfs::get(src->fileName.get_ptr()));
+		const auto real_path = vfs::get(src->fileName.get_ptr());
+		fs::file file_s(real_path);
 		if (!file_s) return CELL_JPGDEC_ERROR_OPEN_FILE;
 
 		current_subHandle.fileSize = file_s.size();
-		current_subHandle.fd = idm::make<lv2_fs_object, lv2_file>(src->fileName.get_ptr(), std::move(file_s), 0, 0);
+		current_subHandle.fd = idm::make<lv2_fs_object, lv2_file>(src->fileName.get_ptr(), std::move(file_s), 0, 0, real_path);
 		break;
 	}
 	}

--- a/rpcs3/Emu/Cell/Modules/cellPngDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPngDec.cpp
@@ -432,8 +432,10 @@ error_code pngDecOpen(ppu_thread& ppu, PHandle handle, PPStream png_stream, PSrc
 	// Depending on the source type, get the first 8 bytes
 	if (source->srcSelect == CELL_PNGDEC_FILE)
 	{
+		const auto real_path = vfs::get(stream->source.fileName.get_ptr());
+
 		// Open a file stream
-		fs::file file_stream(vfs::get(stream->source.fileName.get_ptr()));
+		fs::file file_stream(real_path);
 
 		// Check if opening of the PNG file failed
 		if (!file_stream)
@@ -450,7 +452,7 @@ error_code pngDecOpen(ppu_thread& ppu, PHandle handle, PPStream png_stream, PSrc
 		}
 
 		// Get the file descriptor
-		buffer->fd = idm::make<lv2_fs_object, lv2_file>(stream->source.fileName.get_ptr(), std::move(file_stream), 0, 0);
+		buffer->fd = idm::make<lv2_fs_object, lv2_file>(stream->source.fileName.get_ptr(), std::move(file_stream), 0, 0, real_path);
 
 		// Indicate that we need to read from a file stream
 		buffer->file = true;

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -964,7 +964,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				fs::remove_all(old_path);
 
 				// Remove savedata by renaming
-				if (!vfs::host::rename(del_path, old_path, false))
+				if (!vfs::host::rename(del_path, old_path, &g_mp_sys_dev_hdd0, false))
 				{
 					fmt::throw_exception("Failed to move directory %s (%s)", del_path, fs::g_tls_error);
 				}
@@ -1917,13 +1917,13 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		fs::remove_all(old_path);
 
 		// Backup old savedata
-		if (!vfs::host::rename(dir_path, old_path, false))
+		if (!vfs::host::rename(dir_path, old_path, &g_mp_sys_dev_hdd0, false))
 		{
 			fmt::throw_exception("Failed to move directory %s (%s)", dir_path, fs::g_tls_error);
 		}
 
 		// Commit new savedata
-		if (!vfs::host::rename(new_path, dir_path, false))
+		if (!vfs::host::rename(new_path, dir_path, &g_mp_sys_dev_hdd0, false))
 		{
 			// TODO: handle the case when only commit failed at the next save load
 			fmt::throw_exception("Failed to move directory %s (%s)", new_path, fs::g_tls_error);

--- a/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
@@ -79,8 +79,6 @@ struct syscache_info
 		// Poison opened files in /dev_hdd1 to return CELL_EIO on access
 		if (remove_root)
 		{
-			std::lock_guard lock(g_mp_sys_dev_hdd1.mutex);
-
 			idm::select<lv2_fs_object, lv2_file>([](u32 id, lv2_file& file)
 			{
 				if (std::memcmp("/dev_hdd1", file.name.data(), 9) == 0)
@@ -108,6 +106,7 @@ error_code cellSysCacheClear()
 	// Clear existing cache
 	if (!cache->cache_id.empty())
 	{
+		std::lock_guard lock0(g_mp_sys_dev_hdd1.mutex);
 		cache->clear(false);
 	}
 
@@ -148,6 +147,8 @@ error_code cellSysCacheMount(vm::ptr<CellSysCacheParam> param)
 		cellSysutil.success("Mounted existing cache at %s", new_path);
 		return not_an_error(CELL_SYSCACHE_RET_OK_RELAYED);
 	}
+
+	std::lock_guard lock0(g_mp_sys_dev_hdd1.mutex);
 
 	// Clear existing cache
 	if (!cache->cache_id.empty())

--- a/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
@@ -71,7 +71,7 @@ struct syscache_info
 	void clear(bool remove_root) noexcept
 	{
 		// Clear cache
-		if (!vfs::host::remove_all(cache_root + cache_id, cache_root, remove_root))
+		if (!vfs::host::remove_all(cache_root + cache_id, cache_root, &g_mp_sys_dev_hdd1, remove_root))
 		{
 			cellSysutil.fatal("cellSysCache: failed to clear cache directory '%s%s' (%s)", cache_root, cache_id, fs::g_tls_error);
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -190,6 +190,8 @@ struct lv2_fs_object
 		name[filename.size()] = 0;
 		return name;
 	}
+
+	virtual std::string to_string() const { return {}; }
 };
 
 struct lv2_file final : lv2_fs_object
@@ -271,6 +273,19 @@ struct lv2_file final : lv2_fs_object
 
 	// Make file view from lv2_file object (for MSELF support)
 	static fs::file make_view(const std::shared_ptr<lv2_file>& _file, u64 offset);
+
+	virtual std::string to_string() const override
+	{
+		std::string_view type_s;
+		switch (type)
+		{
+		case lv2_file_type::regular: type_s = "Regular file"; break;
+		case lv2_file_type::sdata: type_s = "SDATA"; break;
+		case lv2_file_type::edata: type_s = "EDATA"; break;
+		}
+
+		return fmt::format(u8"%s, “%s”, Mode: 0x%x, Flags: 0x%x", type_s, name.data(), mode, flags);
+	}
 };
 
 struct lv2_dir final : lv2_fs_object
@@ -295,6 +310,11 @@ struct lv2_dir final : lv2_fs_object
 		}
 
 		return nullptr;
+	}
+
+	virtual std::string to_string() const override
+	{
+		return fmt::format(u8"Directory, “%s”, Entries: %u/%u", name.data(), std::min<u64>(pos, entries.size()), entries.size());
 	}
 };
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -3,9 +3,9 @@
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
 #include "Utilities/File.h"
-#include "Utilities/mutex.h"
 
 #include <string>
+#include <mutex>
 
 // Open Flags
 enum : s32
@@ -134,7 +134,8 @@ enum class lv2_mp_flag
 enum class lv2_file_type
 {
 	regular = 0,
-	npdrm,
+	sdata,
+	edata,
 };
 
 struct lv2_fs_mount_point
@@ -143,8 +144,16 @@ struct lv2_fs_mount_point
 	const u32 block_size = 4096;
 	const bs_t<lv2_mp_flag> flags{};
 
-	shared_mutex mutex;
+	mutable std::recursive_mutex mutex;
 };
+
+extern lv2_fs_mount_point g_mp_sys_dev_hdd0;
+extern lv2_fs_mount_point g_mp_sys_dev_hdd1;
+extern lv2_fs_mount_point g_mp_sys_dev_usb;
+extern lv2_fs_mount_point g_mp_sys_dev_bdvd;
+extern lv2_fs_mount_point g_mp_sys_app_home;
+extern lv2_fs_mount_point g_mp_sys_host_root;
+extern lv2_fs_mount_point g_mp_sys_dev_flash;
 
 struct lv2_fs_object
 {
@@ -185,41 +194,61 @@ struct lv2_fs_object
 
 struct lv2_file final : lv2_fs_object
 {
-	const fs::file file;
+	fs::file file;
 	const s32 mode;
 	const s32 flags;
+	std::string real_path;
 	const lv2_file_type type;
 
 	// Stream lock
 	atomic_t<u32> lock{0};
 
-	lv2_file(std::string_view filename, fs::file&& file, s32 mode, s32 flags, lv2_file_type type = {})
+	// Some variables for convinience of data restoration
+	struct save_restore_t
+	{
+		u64 seek_pos;
+		u64 atime;
+		u64 mtime;
+	} restore_data{};
+
+	lv2_file(std::string_view filename, fs::file&& file, s32 mode, s32 flags, const std::string& real_path, lv2_file_type type = {})
 		: lv2_fs_object(lv2_fs_object::get_mp(filename), filename)
 		, file(std::move(file))
 		, mode(mode)
 		, flags(flags)
+		, real_path(real_path)
 		, type(type)
 	{
 	}
 
-	lv2_file(const lv2_file& host, fs::file&& file, s32 mode, s32 flags, lv2_file_type type = {})
+	lv2_file(const lv2_file& host, fs::file&& file, s32 mode, s32 flags, const std::string& real_path, lv2_file_type type = {})
 		: lv2_fs_object(host.mp, host.name.data())
 		, file(std::move(file))
 		, mode(mode)
 		, flags(flags)
+		, real_path(real_path)
 		, type(type)
 	{
 	}
+
+	struct open_raw_result_t
+	{
+		CellError error;
+		fs::file file;
+	};
 
 	struct open_result_t
 	{
 		CellError error;
 		std::string ppath;
+		std::string real_path;
 		fs::file file;
+		lv2_file_type type;
 	};
 
 	// Open a file with wrapped logic of sys_fs_open
-	static open_result_t open(std::string_view path, s32 flags, s32 mode, const void* arg = {}, u64 size = 0);
+	static open_raw_result_t open_raw(const std::string& path, s32 flags, s32 mode, lv2_file_type type = lv2_file_type::regular, const lv2_fs_mount_point* mp = nullptr);
+	static open_result_t open(std::string_view vpath, s32 flags, s32 mode, const void* arg = {}, u64 size = 0);
 
 	// File reading with intermediate buffer
 	static u64 op_read(const fs::file& file, vm::ptr<void> buf, u64 size);

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -21,7 +21,7 @@ static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vp
 {
 	if (!src)
 	{
-		auto [fs_error, ppath, lv2_file] = lv2_file::open(vpath, 0, 0);
+		auto [fs_error, ppath, path, lv2_file, type] = lv2_file::open(vpath, 0, 0);
 
 		if (fs_error)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -156,7 +156,7 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	if (!src)
 	{
-		auto [fs_error, ppath, lv2_file] = lv2_file::open(vpath, 0, 0);
+		auto [fs_error, ppath, path0, lv2_file, type] = lv2_file::open(vpath, 0, 0);
 
 		if (fs_error)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -242,7 +242,7 @@ error_code sys_spu_image_open(ppu_thread& ppu, vm::ptr<sys_spu_image> img, vm::c
 
 	sys_spu.warning("sys_spu_image_open(img=*0x%x, path=%s)", img, path);
 
-	auto [fs_error, ppath, file] = lv2_file::open(path.get_ptr(), 0, 0);
+	auto [fs_error, ppath, path0, file, type] = lv2_file::open(path.get_ptr(), 0, 0);
 
 	if (fs_error)
 	{

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -3,12 +3,16 @@
 #include "System.h"
 #include "VFS.h"
 
+#include "Cell/lv2/sys_fs.h"
+
 #include "Utilities/mutex.h"
 #include "Utilities/StrUtil.h"
 
 #ifdef _WIN32
 #include <Windows.h>
 #endif
+
+#include <thread>
 
 struct vfs_directory
 {
@@ -706,18 +710,77 @@ std::string vfs::host::hash_path(const std::string& path, const std::string& dev
 	return fmt::format(u8"%s/＄%s%s", dev_root, fmt::base57(std::hash<std::string>()(path)), fmt::base57(__rdtsc()));
 }
 
-bool vfs::host::rename(const std::string& from, const std::string& to, bool overwrite)
+bool vfs::host::rename(const std::string& from, const std::string& to, const lv2_fs_mount_point* mp, bool overwrite)
 {
-	while (!fs::rename(from, to, overwrite))
+#ifdef _WIN32
+	constexpr auto& delim = "/\\";
+#else
+	constexpr auto& delim = "/";
+#endif
+
+	// Lock mount point, close file descriptors, retry 
+	const auto from0 = std::string_view(from).substr(0, from.find_last_not_of(delim) + 1);
+	const auto escaped_from = fs::escape_path(from);
+
+	// Lock app_home as well because it could be in the same drive as current mount point (TODO)
+	std::scoped_lock lock(mp->mutex, g_mp_sys_app_home.mutex);
+
+	auto check_path = [&](std::string_view path)
 	{
-		// Try to ignore access error in order to prevent spurious failure
+		return path.starts_with(from) && (path.size() == from.size() || path[from.size()] == delim[0] || path[from.size()] == delim[1]);
+	};
+
+	idm::select<lv2_fs_object, lv2_file>([&](u32 id, lv2_file& file)
+	{
+		if (check_path(fs::escape_path(file.real_path)))
+		{
+			verify(HERE), file.mp == mp || file.mp == &g_mp_sys_app_home;
+			file.restore_data.seek_pos = file.file.pos();
+			file.file.close(); // Actually close it!
+		}
+	});
+
+	bool res = false;
+
+	for (;; std::this_thread::yield())
+	{
+		if (fs::rename(from, to, overwrite))
+		{
+			res = true;
+			break;
+		}
+
 		if (Emu.IsStopped() || fs::g_tls_error != fs::error::acces)
 		{
-			return false;
+			res = false;
+			break;
 		}
 	}
 
-	return true;
+	const auto fs_error = fs::g_tls_error;
+
+	idm::select<lv2_fs_object, lv2_file>([&](u32 id, lv2_file& file)
+	{
+		const auto escaped_real = fs::escape_path(file.real_path);
+
+		if (check_path(escaped_real))
+		{
+			// Update internal path
+			if (res)
+			{
+				file.real_path = to + (escaped_real != escaped_from ? '/' + file.real_path.substr(from0.size()) : ""s);
+			}
+
+			// Reopen with ignored TRUNC, APPEND, CREATE and EXCL flags
+			auto res0 = lv2_file::open_raw(file.real_path, file.flags & CELL_FS_O_ACCMODE, file.mode, file.type, file.mp);
+			file.file = std::move(res0.file);
+			verify(HERE), file.file.operator bool();
+			file.file.seek(file.restore_data.seek_pos);
+		}
+	});
+
+	fs::g_tls_error = fs_error;
+	return res;
 }
 
 bool vfs::host::unlink(const std::string& path, const std::string& dev_root)
@@ -754,7 +817,7 @@ bool vfs::host::unlink(const std::string& path, const std::string& dev_root)
 #endif
 }
 
-bool vfs::host::remove_all(const std::string& path, const std::string& dev_root, bool remove_root)
+bool vfs::host::remove_all(const std::string& path, const std::string& dev_root, const lv2_fs_mount_point* mp, bool remove_root)
 {
 #ifdef _WIN32
 	if (remove_root)
@@ -762,12 +825,12 @@ bool vfs::host::remove_all(const std::string& path, const std::string& dev_root,
 		// Rename to special dummy folder which will be ignored by VFS (but opened file handles can still read or write it)
 		const std::string dummy = hash_path(path, dev_root);
 
-		if (!vfs::host::rename(path, dummy, false))
+		if (!vfs::host::rename(path, dummy, mp, false))
 		{
 			return false;
 		}
 
-		if (!vfs::host::remove_all(dummy, dev_root, false))
+		if (!vfs::host::remove_all(dummy, dev_root, mp, false))
 		{
 			return false;
 		}
@@ -802,7 +865,7 @@ bool vfs::host::remove_all(const std::string& path, const std::string& dev_root,
 			}
 			else
 			{
-				if (!vfs::host::remove_all(path + '/' + entry.name, dev_root))
+				if (!vfs::host::remove_all(path + '/' + entry.name, dev_root, mp))
 				{
 					return false;
 				}

--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <string_view>
 
+struct lv2_fs_mount_point;
+
 namespace vfs
 {
 	// Mount VFS device
@@ -24,12 +26,12 @@ namespace vfs
 		std::string hash_path(const std::string& path, const std::string& dev_root);
 
 		// Call fs::rename with retry on access error
-		bool rename(const std::string& from, const std::string& to, bool overwrite);
+		bool rename(const std::string& from, const std::string& to, const lv2_fs_mount_point* mp, bool overwrite);
 
 		// Delete file without deleting its contents, emulated with MoveFileEx on Windows
 		bool unlink(const std::string& path, const std::string& dev_root);
 
 		// Delete folder contents using rename, done atomically if remove_root is true
-		bool remove_all(const std::string& path, const std::string& dev_root, bool remove_root = true);
+		bool remove_all(const std::string& path, const std::string& dev_root, const lv2_fs_mount_point* mp, bool remove_root = true);
 	}
 }

--- a/rpcs3/Loader/TRP.cpp
+++ b/rpcs3/Loader/TRP.cpp
@@ -1,6 +1,7 @@
 ﻿#include "stdafx.h"
 #include "Emu/VFS.h"
 #include "Emu/System.h"
+#include "Emu/Cell/lv2/sys_fs.h"
 #include "TRP.h"
 #include "Crypto/sha1.h"
 #include "Utilities/StrUtil.h"
@@ -41,7 +42,11 @@ bool TRPLoader::Install(const std::string& dest, bool show)
 	{
 		trp_f.seek(entry.offset);
 		buffer.resize(entry.size);
-		if (!trp_f.read(buffer)) continue; // ???
+		if (!trp_f.read(buffer))
+		{
+			trp_log.error("Failed to read TRPEntry at: offset=0x%x, size=0x%x", entry.offset, entry.size);
+			continue; // ???
+		}
 
 		// Create the file in the temporary directory
 		success = fs::write_file(temp + vfs::escape(entry.name), fs::create + fs::excl, buffer);	
@@ -53,7 +58,7 @@ bool TRPLoader::Install(const std::string& dest, bool show)
 
 	if (success)
 	{
-		success = vfs::host::remove_all(local_path, Emu.GetHddDir(), true) || !fs::is_dir(local_path);
+		success = vfs::host::remove_all(local_path, Emu.GetHddDir(), &g_mp_sys_dev_hdd0, true) || !fs::is_dir(local_path);
 
 		if (success)
 		{

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -592,7 +592,7 @@ void kernel_explorer::Update()
 
 	idm::select<lv2_fs_object>([&](u32 id, lv2_fs_object& fo)
 	{
-		add_leaf(find_node(m_tree, additional_nodes::file_descriptors), qstr(fmt::format(u8"FD %u: “%s”", id, fo.name.data())));
+		add_leaf(find_node(m_tree, additional_nodes::file_descriptors), qstr(fmt::format("FD %u: %s", id, fo.to_string())));
 	});
 
 	// RawSPU Threads (TODO)


### PR DESCRIPTION
I've noticed that when MoveFileEx is called on a directory with opened file handles it returns an access error, it even affects one of my cellSysCache tests which was my testcase for this fix.
"Suspend" opened sys_fs file handles in such case by closing, fs::rename then reopen on the new (if succeeded) or old file path.

Partially addresses #8891 (fixes Battlefieled BC2)

Also: add guest filesystem information in kernel explorer and cellSysCache improvemenrs.