### PR TITLE
kernel-explorer: Fix lwmutex owner display

### DIFF
--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -382,13 +382,17 @@ void kernel_explorer::Update()
 				switch (const u32 owner = lwm_data.vars.owner)
 				{
 				case lwmutex_free: owner_str = "free"; break;
-				//case lwmutex_dead: owner_str = "dead"; break;
+				case lwmutex_dead: owner_str = "dead"; break;
 				case lwmutex_reserved: owner_str = "reserved"; break;
 				default:
 				{
-					if (owner >= ppu_thread::id_base && owner <= ppu_thread::id_base + ppu_thread::id_step - 1)
+					if (owner >= ppu_thread::id_base && owner <= ppu_thread::id_base + ppu_thread::id_count - 1)
 					{
 						owner_str = fmt::format("0x%x", owner);
+					}
+					else
+					{
+						fmt::append(owner_str, " (0x%x)", owner);
 					}
 
 					break;


### PR DESCRIPTION
Before it was displaying "unknown" for valid PPU ids, also display "dead" and output raw value for "unknown" owner.