### PR TITLE
kernel-explorer: Account for PPU IDs invalidation in lwmutex

### DIFF
--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -386,7 +386,7 @@ void kernel_explorer::Update()
 				case lwmutex_reserved: owner_str = "reserved"; break;
 				default:
 				{
-					if (owner >= ppu_thread::id_base && owner <= ppu_thread::id_base + ppu_thread::id_count - 1)
+					if (idm::check_unlocked<named_thread<ppu_thread>>(owner))
 					{
 						owner_str = fmt::format("0x%x", owner);
 					}


### PR DESCRIPTION
Forgot about this feature which relatively recently added, just use the original idm function instead for simplicity.