### PR TITLE
SPU LLVM: Remove redundent get_events() calls from RdEventStat

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -5387,11 +5387,6 @@ public:
 
 	static u32 exec_read_events(spu_thread* _spu)
 	{
-		if (const u32 events = _spu->get_events(_spu->ch_event_mask))
-		{
-			return events;
-		}
-
 		// TODO
 		return exec_rdch(_spu, SPU_RdEventStat);
 	}

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2669,7 +2669,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 				fmt::throw_exception("Not supported: event mask 0x%x" HERE, mask1);
 			}
 
-			while (res = get_events(mask1), !res)
+			for (; !res; res = get_events(mask1))
 			{
 				state += cpu_flag::wait;
 
@@ -2685,7 +2685,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 			return res;
 		}
 
-		while (res = get_events(mask1, true), !res)
+		for (; !res; res = get_events(mask1, true))
 		{
 			state += cpu_flag::wait;
 


### PR DESCRIPTION
Improve TSX performance a bit by avoiding TSX transactional failures caused by touching reservation data redundently.