### PR TITLE
GUI: Rephrase trophy "eraned/not earned" to "unlocked /locked"

### DIFF
--- a/rpcs3/rpcs3qt/localized_emu.h
+++ b/rpcs3/rpcs3qt/localized_emu.h
@@ -34,10 +34,10 @@ private:
 	{
 		switch (id)
 		{
-		case localized_string_id::RSX_OVERLAYS_TROPHY_BRONZE: return tr("You have earned the bronze trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
-		case localized_string_id::RSX_OVERLAYS_TROPHY_SILVER: return tr("You have earned the silver trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
-		case localized_string_id::RSX_OVERLAYS_TROPHY_GOLD: return tr("You have earned the gold trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
-		case localized_string_id::RSX_OVERLAYS_TROPHY_PLATINUM: return tr("You have earned the platinum trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
+		case localized_string_id::RSX_OVERLAYS_TROPHY_BRONZE: return tr("You have earned the Bronze trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
+		case localized_string_id::RSX_OVERLAYS_TROPHY_SILVER: return tr("You have earned the Silver trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
+		case localized_string_id::RSX_OVERLAYS_TROPHY_GOLD: return tr("You have earned the Gold trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
+		case localized_string_id::RSX_OVERLAYS_TROPHY_PLATINUM: return tr("You have earned the Platinum trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
 		case localized_string_id::RSX_OVERLAYS_COMPILING_SHADERS: return tr("Compiling shaders");
 		case localized_string_id::RSX_OVERLAYS_MSG_DIALOG_YES: return tr("Yes", "Message Dialog");
 		case localized_string_id::RSX_OVERLAYS_MSG_DIALOG_NO: return tr("No", "Message Dialog");

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -123,11 +123,11 @@ trophy_manager_dialog::trophy_manager_dialog(std::shared_ptr<gui_settings> gui_s
 	m_game_icon_size = gui_settings::SizeFromSlider(m_game_icon_size_index);
 
 	// Checkboxes to control dialog
-	QCheckBox* check_lock_trophy = new QCheckBox(tr("Show Not Earned Trophies"));
+	QCheckBox* check_lock_trophy = new QCheckBox(tr("Show Unlocked Trophies"));
 	check_lock_trophy->setCheckable(true);
 	check_lock_trophy->setChecked(m_show_locked_trophies);
 
-	QCheckBox* check_unlock_trophy = new QCheckBox(tr("Show Earned Trophies"));
+	QCheckBox* check_unlock_trophy = new QCheckBox(tr("Show Locked Trophies"));
 	check_unlock_trophy->setCheckable(true);
 	check_unlock_trophy->setChecked(m_show_unlocked_trophies);
 
@@ -857,7 +857,7 @@ void trophy_manager_dialog::PopulateTrophyTable()
 			}
 		}
 
-		const QString unlockstate = data->trop_usr->GetTrophyUnlockState(trophy_id) ? tr("Earned") : tr("Not Earned");
+		const QString unlockstate = data->trop_usr->GetTrophyUnlockState(trophy_id) ? tr("Unlocked") : tr("Locked");
 
 		custom_table_widget_item* icon_item = new custom_table_widget_item();
 		icon_item->setData(Qt::UserRole, hidden, true);


### PR DESCRIPTION
Official trophy terminology.