### PR TITLE
HLE: Use same max HDD space as in cellGame functions.

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellFs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellFs.cpp
@@ -359,8 +359,11 @@ error_code cellFsGetFreeSize(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u32> 
 
 	fs::device_stat info;
 	fs::statfs(vfs::get(path.get_ptr()), info);
+
+	const fs::cell_device_stat hdd_info(info);
+
 	*block_size  = 4096;
-	*block_count = info.avail_free / 4096;
+	*block_count = hdd_info.avail_free / 4096;
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -169,10 +169,7 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 	vm::var<CellHddGameStatGet> get;
 	vm::var<CellHddGameStatSet> set;
 
-	// 40 GB - 1 kilobyte. The reasoning is that many games take this number and multiply it by 1024, to get the amount of bytes. With 40GB exactly,
-	// this will result in an overflow, and the size would be 0, preventing the game from running. By reducing 1 kilobyte, we make sure that even
-	// after said overflow, the number would still be high enough to contain the game's data.
-	get->hddFreeSizeKB = 40 * 1024 * 1024 - 1;
+	get->hddFreeSizeKB = ::narrow<s32>(fs::max_disk_space);
 	get->isNewData = CELL_HDDGAME_ISNEWDATA_EXIST;
 	get->sysSizeKB = 0; // TODO
 	get->atime = 0; // TODO
@@ -373,7 +370,7 @@ error_code cellGameBootCheck(vm::ptr<u32> type, vm::ptr<u32> attributes, vm::ptr
 	if (size)
 	{
 		// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
-		size->hddFreeSizeKB = 40 * 1024 * 1024 - 1; // Read explanation in cellHddGameCheck
+		size->hddFreeSizeKB = ::narrow<s32>(fs::max_disk_space);
 
 		// TODO: Calculate data size for HG and DG games, if necessary.
 		size->sizeKB = CELL_GAME_SIZEKB_NOTCALC;
@@ -417,7 +414,7 @@ error_code cellGamePatchCheck(vm::ptr<CellGameContentSize> size, vm::ptr<void> r
 	if (size)
 	{
 		// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
-		size->hddFreeSizeKB = 40 * 1024 * 1024 - 1; // Read explanation in cellHddGameCheck
+		size->hddFreeSizeKB = ::narrow<s32>(fs::max_disk_space);
 
 		// TODO: Calculate data size for patch data, if necessary.
 		size->sizeKB = CELL_GAME_SIZEKB_NOTCALC;
@@ -465,7 +462,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 	if (size)
 	{
 		// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
-		size->hddFreeSizeKB = 40 * 1024 * 1024 - 1; // Read explanation in cellHddGameCheck
+		size->hddFreeSizeKB = ::narrow<s32>(fs::max_disk_space);
 
 		// TODO: Calculate data size for game data, if necessary.
 		size->sizeKB = CELL_GAME_SIZEKB_NOTCALC;
@@ -580,7 +577,7 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 	cbGet->isNewData = new_data;
 
 	// TODO: Use the free space of the computer's HDD where RPCS3 is being run.
-	cbGet->hddFreeSizeKB = 40 * 1024 * 1024 - 1; // Read explanation in cellHddGameCheck
+	cbGet->hddFreeSizeKB = ::narrow<s32>(fs::max_disk_space);
 
 	strcpy_trunc(cbGet->contentInfoPath, dir);
 	strcpy_trunc(cbGet->gameDataPath, usrdir);

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -928,7 +928,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		auto delete_save = [&]()
 		{
 			strcpy_trunc(doneGet->dirName, save_entries[selected].dirName);
-			doneGet->hddFreeSizeKB = 40 * 1024 * 1024 - 1; // Read explanation in cellHddGameCheck
+			doneGet->hddFreeSizeKB = ::narrow<s32>(fs::max_disk_space); // TODO: Use the free space of the computer's HDD where RPCS3 is being run.
 			doneGet->excResult     = CELL_OK;
 			std::memset(doneGet->reserved, 0, sizeof(doneGet->reserved));
 
@@ -1251,7 +1251,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			// funcStat is called even if the directory doesn't exist.
 		}
 
-		statGet->hddFreeSizeKB = 40 * 1024 * 1024 - 1; // Read explanation in cellHddGameCheck
+		statGet->hddFreeSizeKB = ::narrow<s32>(fs::max_disk_space); // TODO: Use the free space of the computer's HDD where RPCS3 is being run.
 		statGet->isNewData = save_entry.isNew = psf.empty();
 
 		statGet->dir.atime = save_entry.atime = dir_info.atime;

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1302,8 +1302,10 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 			return CELL_EIO; // ???
 		}
 
+		const fs::cell_device_stat hdd_info(info);
+
 		arg->out_block_size = mp->block_size;
-		arg->out_block_count = info.avail_free / mp->block_size;
+		arg->out_block_count = hdd_info.avail_free / mp->block_size;
 		return CELL_OK;
 	}
 
@@ -1899,8 +1901,10 @@ error_code sys_fs_disk_free(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u64> t
 		return {CELL_EIO, path};  // ???
 	}
 
-	*total_free = info.total_free;
-	*avail_free = info.avail_free; //Only value used by cellFsGetFreeSize
+	const fs::cell_device_stat hdd_info(info);
+
+	*total_free = hdd_info.total_free;
+	*avail_free = hdd_info.avail_free; // Only value used by cellFsGetFreeSize
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -7,6 +7,28 @@
 
 #include <string>
 
+// Helper
+
+namespace fs
+{
+	// 40 GB - 1 kilobyte. The reasoning is that many games take this number and multiply it by 1024, to get the amount of bytes. With 40GB exactly,
+	// this will result in an overflow, and the size would be 0, preventing the game from running. By reducing 1 kilobyte, we make sure that even
+	// after said overflow, the number would still be high enough to contain the game's data. (40 * 1024 * 1024) * 1024 & 0xffffffff == 0
+	constexpr u64 max_disk_space = 40 * 1024 * 1024 - 1;
+
+	struct cell_device_stat
+	{
+		u64 avail_free;
+		u64 total_free;
+
+		cell_device_stat(const fs::device_stat& info)
+		{
+			avail_free = std::min(info.avail_free, max_disk_space);
+			total_free = std::min(info.total_free, max_disk_space);
+		}
+	};
+}
+
 // Open Flags
 enum : s32
 {


### PR DESCRIPTION
@CookiePLMonster told me to look into some game that doesn't like his 10TB HDD.
So the only reason why a game will probably doesn't like big drives is because we pass it a value that's way too big for integer calculations.

So I took @Farseer2 's code and applied it to more places that i could find.

Seems to fix a game called NASCAR Unleashed.