### PR TITLE
SPU: Implement channels 70, 71, add naming for channel 69

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -2470,7 +2470,9 @@ void spu_recompiler::WRCH(spu_opcode_t op)
 		// TODO
 		break;
 	}
-	case 69:
+	case SPU_Set_Bkmk_Tag:
+	case SPU_PM_Start_Ev:
+	case SPU_PM_Stop_Ev:
 	{
 		return;
 	}

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -56,7 +56,7 @@ static constexpr const char* spu_ch_name[128] =
 	"ch41", "ch42", "ch43", "ch44", "ch45", "ch46", "ch47", "ch48",
 	"ch49", "ch50", "ch51", "ch52", "ch53", "ch54", "ch55", "ch56",
 	"ch57", "ch58", "ch59", "ch60", "ch61", "ch62", "ch63", "ch64",
-	"ch65", "ch66", "ch67", "ch68", "ch69", "ch70", "ch71", "ch72",
+	"ch65", "ch66", "ch67", "ch68", "SPU_Set_Bkmk_Tag", "SPU_PM_Start_Ev", "SPU_PM_Stop_Ev", "ch72",
 	"ch73", "ch74", "ch75", "ch76", "ch77", "ch78", "ch79", "ch80",
 	"ch81", "ch82", "ch83", "ch84", "ch85", "ch86", "ch87", "ch88",
 	"ch89", "ch90", "ch91", "ch92", "ch93", "ch94", "ch95", "ch96",

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2514,7 +2514,7 @@ u32 spu_thread::get_ch_count(u32 ch)
 	case MFC_Cmd:             return 16 - mfc_size;
 	}
 
-	fmt::throw_exception("Unknown/illegal channel (ch=%d [%s])" HERE, ch, ch < 128 ? spu_ch_name[ch] : "???");
+	fmt::throw_exception("Unknown/illegal channel in RCHCNT (ch=%d [%s])" HERE, ch, ch < 128 ? spu_ch_name[ch] : "???");
 }
 
 s64 spu_thread::get_ch_value(u32 ch)
@@ -2709,7 +2709,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 	}
 	}
 
-	fmt::throw_exception("Unknown/illegal channel (ch=%d [%s])" HERE, ch, ch < 128 ? spu_ch_name[ch] : "???");
+	fmt::throw_exception("Unknown/illegal channel in RDCH (ch=%d [%s])" HERE, ch, ch < 128 ? spu_ch_name[ch] : "???");
 }
 
 bool spu_thread::set_ch_value(u32 ch, u32 value)
@@ -3060,13 +3060,15 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 		return true;
 	}
 
-	case 69:
+	case SPU_Set_Bkmk_Tag:
+	case SPU_PM_Start_Ev:
+	case SPU_PM_Stop_Ev:
 	{
 		return true;
 	}
 	}
 
-	fmt::throw_exception("Unknown/illegal channel (ch=%d [%s], value=0x%x)" HERE, ch, ch < 128 ? spu_ch_name[ch] : "???", value);
+	fmt::throw_exception("Unknown/illegal channel in WRCH (ch=%d [%s], value=0x%x)" HERE, ch, ch < 128 ? spu_ch_name[ch] : "???", value);
 }
 
 bool spu_thread::stop_and_signal(u32 code)

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -35,6 +35,9 @@ enum : u32
 	SPU_WrOutMbox       = 28, // Write outbound mailbox contents
 	SPU_RdInMbox        = 29, // Read inbound mailbox contents
 	SPU_WrOutIntrMbox   = 30, // Write outbound interrupt mailbox contents (interrupting PPU)
+	SPU_Set_Bkmk_Tag    = 69, // Causes an event that can be logged in the performance monitor logic if enabled in the SPU
+	SPU_PM_Start_Ev     = 70, // Starts the performance monitor event if enabled
+	SPU_PM_Stop_Ev      = 71, // Stops the performance monitor event if enabled
 };
 
 // MFC Channels


### PR DESCRIPTION
They seem to be related to cellLibprof or something (performance monitoring) and are no-ops on CEX console.