### PR TITLE
sceNpTrophyRegisterContext: Improvements

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -628,7 +628,8 @@ namespace fs
 	template <typename... Args>
 	bool write_file(const std::string& path, bs_t<fs::open_mode> mode, const Args&... args)
 	{
-		if (fs::file f{path, mode})
+		// Always use write flag, remove read flag
+		if (fs::file f{path, mode + fs::write - fs::read})
 		{
 			// Write args sequentially
 			(f.write(args), ...);

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -154,6 +154,28 @@ void fmt_class_string<SceNpTrophyError>::format(std::string& out, u64 arg)
 	});
 }
 
+template <>
+void fmt_class_string<SceNpCommunicationSignature>::format(std::string& out, u64 arg)
+{
+	const auto& sign = get_object(arg);
+
+	// Format as a C byte array for ease of use
+	fmt::append(out, "{ ");
+
+	for (std::size_t i = 0;; i++)
+	{
+		if (i == std::size(sign.data) - 1)
+		{
+			fmt::append(out, "0x%02X", sign.data[i]);
+			break;
+		}
+
+		fmt::append(out, "0x%02X, ", sign.data[i]);
+	}
+
+	fmt::append(out, " }");
+}
+
 // Helpers
 
 static error_code NpTrophyGetTrophyInfo(const trophy_context_t* ctxt, s32 trophyId, SceNpTrophyDetails* details, SceNpTrophyData* data);
@@ -330,6 +352,8 @@ error_code sceNpTrophyCreateContext(vm::ptr<u32> context, vm::cptr<SceNpCommunic
 	{
 		return SCE_NP_TROPHY_ERROR_INVALID_ARGUMENT;
 	}
+
+	sceNpTrophy.notice("sceNpTrophyCreateContext(): commSign = %s", *commSign);
 
 	const auto trophy_manager = g_fxo->get<sce_np_trophy_manager>();
 

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -701,6 +701,11 @@ std::string vfs::unescape(std::string_view name)
 	return result;
 }
 
+std::string vfs::host::hash_path(const std::string& path, const std::string& dev_root)
+{
+	return fmt::format(u8"%s/＄%s%s", dev_root, fmt::base57(std::hash<std::string>()(path)), fmt::base57(__rdtsc()));
+}
+
 bool vfs::host::rename(const std::string& from, const std::string& to, bool overwrite)
 {
 	while (!fs::rename(from, to, overwrite))
@@ -725,7 +730,7 @@ bool vfs::host::unlink(const std::string& path, const std::string& dev_root)
 	else
 	{
 		// Rename to special dummy name which will be ignored by VFS (but opened file handles can still read or write it)
-		const std::string dummy = fmt::format(u8"%s/＄%s%s", dev_root, fmt::base57(std::hash<std::string>()(path)), fmt::base57(__rdtsc()));
+		const std::string dummy = hash_path(path, dev_root);
 
 		if (!fs::rename(path, dummy, true))
 		{
@@ -755,7 +760,7 @@ bool vfs::host::remove_all(const std::string& path, const std::string& dev_root,
 	if (remove_root)
 	{
 		// Rename to special dummy folder which will be ignored by VFS (but opened file handles can still read or write it)
-		const std::string dummy = fmt::format(u8"%s/＄%s%s", dev_root, fmt::base57(std::hash<std::string>()(path)), fmt::base57(__rdtsc()));
+		const std::string dummy = hash_path(path, dev_root);
 
 		if (!vfs::host::rename(path, dummy, false))
 		{

--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -21,6 +21,8 @@ namespace vfs
 	// Functions in this namespace operate on host filepaths, similar to fs::
 	namespace host
 	{
+		std::string hash_path(const std::string& path, const std::string& dev_root);
+
 		// Call fs::rename with retry on access error
 		bool rename(const std::string& from, const std::string& to, bool overwrite);
 

--- a/rpcs3/Loader/TRP.cpp
+++ b/rpcs3/Loader/TRP.cpp
@@ -1,5 +1,6 @@
 ﻿#include "stdafx.h"
 #include "Emu/VFS.h"
+#include "Emu/System.h"
 #include "TRP.h"
 #include "Crypto/sha1.h"
 #include "Utilities/StrUtil.h"
@@ -15,27 +16,58 @@ bool TRPLoader::Install(const std::string& dest, bool show)
 {
 	if (!trp_f)
 	{
+		fs::g_tls_error = fs::error::noent;
 		return false;
 	}
 
+	fs::g_tls_error = {};
+
 	const std::string& local_path = vfs::get(dest);
 
-	if (!fs::is_dir(local_path) && !fs::create_dir(local_path))
+	const auto temp = vfs::host::hash_path(local_path, Emu.GetHddDir()) + '/';
+
+	if (!fs::create_dir(temp))
 	{
 		return false;
 	}
 
 	std::vector<char> buffer(65536);
 
+	bool success = true;
 	for (const TRPEntry& entry : m_entries)
 	{
 		trp_f.seek(entry.offset);
 		buffer.resize(entry.size);
 		if (!trp_f.read(buffer)) continue; // ???
-		fs::file(local_path + '/' + entry.name, fs::rewrite).write(buffer);
+
+		// Create the file in the temporary directory
+		success = fs::write_file(temp + vfs::escape(entry.name), fs::create + fs::excl, buffer);	
+		if (!success)
+		{
+			break;
+		}
 	}
 
-	return true;
+	if (success)
+	{
+		success = vfs::host::remove_all(local_path, Emu.GetHddDir(), true);
+
+		if (success)
+		{
+			// Atomically create trophy data (overwrite existing data)
+			success = fs::rename(temp, local_path, false);
+		}
+	}
+
+	if (!success)
+	{
+		// Remove temporary directory manually on failure (removed automatically on success)
+		auto old_error = fs::g_tls_error; 
+		fs::remove_all(temp);
+		fs::g_tls_error = old_error;
+	}
+
+	return success;
 }
 
 bool TRPLoader::LoadHeader(bool show)


### PR DESCRIPTION
* Do not allow to create corrupted trophy data on failure, either create it whole or not at all. (by creating files in a a temporary directory then renaming to the trophy data directory)
* Do not use exceptions such as when file creation fails, use errors instead. (used to throw fs::file is null)
* Fix fs::g_tls_error error reporting.
* Fix filename of created files: add missing vfs::escape usage on filename.
* Implement SCE_NP_TROPHY_STATUS_NOT_INSTALLED.
* Fix error checking of callback status, do not register context in this case.