### PR TITLE
Apply patch when APP_VER is unknown

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -548,11 +548,6 @@ bool patch_engine::read_patch_node(patch_info& info, YAML::Node node, const YAML
 	return is_valid;
 }
 
-void patch_engine::append(const std::string& patch)
-{
-	load(m_map, patch);
-}
-
 void patch_engine::append_global_patches()
 {
 	// Legacy patch.yml

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -138,9 +138,6 @@ public:
 	std::size_t apply_with_ls_check(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
 
 private:
-	// Load from file and append to member patches map
-	void append(const std::string& path);
-
 	// Internal: Apply patch (returns the number of entries applied)
 	template <bool check_local_storage>
 	std::size_t apply_patch(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -923,8 +923,9 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		m_title_id = std::string(psf::get_string(_psf, "TITLE_ID"));
 		m_cat = std::string(psf::get_string(_psf, "CATEGORY"));
 
-		m_app_version = std::string(psf::get_string(_psf, "APP_VER", "Unknown"));
+		const auto version_app  = psf::get_string(_psf, "APP_VER", "Unknown");
 		const auto version_disc = psf::get_string(_psf, "VERSION", "Unknown");
+		m_app_version           = version_app == "Unknown" ? version_disc : version_app;
 
 		if (!_psf.empty() && m_cat.empty())
 		{
@@ -935,7 +936,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		sys_log.notice("Title: %s", GetTitle());
 		sys_log.notice("Serial: %s", GetTitleID());
 		sys_log.notice("Category: %s", GetCat());
-		sys_log.notice("Version: %s / %s", GetAppVersion(), version_disc);
+		sys_log.notice("Version: APP_VER=%s VERSION=%s", version_app, version_disc);
 
 		if (!add_only && !force_global_config && m_config_override_path.empty())
 		{


### PR DESCRIPTION
I forgot to check whether part of the game version is empty.
This fix should match the logic we apply in the gamelist and therefore fix some COD3 patch issue.