### PR TITLE
HLE: Implement ERROR_BROKEN in cellGameDataCheck

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -461,6 +461,14 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 	// TODO: not sure what should be checked there
 
 	const auto perm = g_fxo->get<content_permission>();
+
+	auto init = perm->init.init();
+
+	if (!init)
+	{
+		return CELL_GAME_ERROR_BUSY;
+	}
+
 	auto sfo = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
 
 	if (![&]()
@@ -476,15 +484,9 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 	{
 		if (fs::is_file(vfs::get(dir + "/PARAM.SFO"))
 		{
+			init.cancel();		
 			return CELL_GAME_ERROR_BROKEN;
 		}
-	}
-
-	const auto init = perm->init.init();
-
-	if (!init)
-	{
-		return CELL_GAME_ERROR_BUSY;
 	}
 
 	if (size)

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -482,7 +482,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 		}
 	}())
 	{
-		if (fs::is_file(vfs::get(dir + "/PARAM.SFO"))
+		if (fs::is_file(vfs::get(dir + "/PARAM.SFO")))
 		{
 			init.cancel();		
 			return CELL_GAME_ERROR_BROKEN;

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -461,6 +461,21 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 	// TODO: not sure what should be checked there
 
 	const auto perm = g_fxo->get<content_permission>();
+	auto psf = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
+
+	if (![&]()
+	{
+		switch (type)
+		{
+		case CELL_GAME_GAMETYPE_HDD: return psf::get_string(sfo, "CATEGORY", "HG") == "HG";
+		case CELL_GAME_GAMETYPE_GAMEDATA: return psf::get_string(sfo, "CATEGORY", "GD") == "GD";
+		case CELL_GAME_GAMETYPE_DISC: return psf::get_string(sfo, "CATEGORY", "DG") == "DG";
+		default: ASSUME(0);
+		}
+	}())
+	{
+		return CELL_GAME_ERROR_BROKEN;
+	}
 
 	const auto init = perm->init.init();
 
@@ -495,7 +510,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 	}
 
 	perm->exists = true;
-	perm->sfo = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
+	perm->sfo = std::move(sfo);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -461,7 +461,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 	// TODO: not sure what should be checked there
 
 	const auto perm = g_fxo->get<content_permission>();
-	auto psf = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
+	auto sfo = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
 
 	if (![&]()
 	{

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -467,14 +467,17 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 	{
 		switch (type)
 		{
-		case CELL_GAME_GAMETYPE_HDD: return psf::get_string(sfo, "CATEGORY", "HG") == "HG";
-		case CELL_GAME_GAMETYPE_GAMEDATA: return psf::get_string(sfo, "CATEGORY", "GD") == "GD";
-		case CELL_GAME_GAMETYPE_DISC: return psf::get_string(sfo, "CATEGORY", "DG") == "DG";
+		case CELL_GAME_GAMETYPE_HDD: return psf::get_string(sfo, "CATEGORY") == "HG";
+		case CELL_GAME_GAMETYPE_GAMEDATA: return psf::get_string(sfo, "CATEGORY") == "GD";
+		case CELL_GAME_GAMETYPE_DISC: return psf::get_string(sfo, "CATEGORY") == "DG";
 		default: ASSUME(0);
 		}
 	}())
 	{
-		return CELL_GAME_ERROR_BROKEN;
+		if (fs::is_file(vfs::get(dir + "/PARAM.SFO"))
+		{
+			return CELL_GAME_ERROR_BROKEN;
+		}
 	}
 
 	const auto init = perm->init.init();
@@ -503,7 +506,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 
 	perm->restrict_sfo_params = false;
 
-	if (!fs::is_dir(vfs::get(dir)))
+	if (sfo.empty())
 	{
 		cellGame.warning("cellGameDataCheck(): directory '%s' not found", dir);
 		return not_an_error(CELL_GAME_RET_NONE);

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -471,13 +471,13 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 
 	auto sfo = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
 
-	if (![&]()
+	if (psf::get_string(sfo, "CATEGORY") != [&]()
 	{
 		switch (type)
 		{
-		case CELL_GAME_GAMETYPE_HDD: return psf::get_string(sfo, "CATEGORY") == "HG";
-		case CELL_GAME_GAMETYPE_GAMEDATA: return psf::get_string(sfo, "CATEGORY") == "GD";
-		case CELL_GAME_GAMETYPE_DISC: return psf::get_string(sfo, "CATEGORY") == "DG";
+		case CELL_GAME_GAMETYPE_HDD: return "HG"sv;
+		case CELL_GAME_GAMETYPE_GAMEDATA: return "GD"sv;
+		case CELL_GAME_GAMETYPE_DISC: return "DG"sv;
 		default: ASSUME(0);
 		}
 	}())


### PR DESCRIPTION
Return this error when the game content exists but its type does not match the `type` argument, similar to how cellGameDataCheckCreate2 does this.