### PR TITLE
Qt/Input: fix default pad handler

### DIFF
--- a/rpcs3/Emu/Io/pad_config.cpp
+++ b/rpcs3/Emu/Io/pad_config.cpp
@@ -15,6 +15,13 @@ bool cfg_input::load(const std::string& title_id)
 	{
 		return from_string(cfg_file.to_string());
 	}
+	else
+	{
+		// Add keyboard by default
+		player[0]->handler.from_string(fmt::format("%s", pad_handler::keyboard));
+		player[0]->device.from_string(pad::keyboard_device_name.data());
+	}
+
 	return false;
 }
 
@@ -32,7 +39,7 @@ void cfg_input::save(const std::string& title_id)
 }
 
 
-bool pad_config::exist()
+bool pad_config::exist() const
 {
 	return fs::is_file(cfg_name);
 }
@@ -47,7 +54,7 @@ bool pad_config::load()
 	return false;
 }
 
-void pad_config::save()
+void pad_config::save() const
 {
 	fs::file(cfg_name, fs::rewrite).write(to_string());
 }

--- a/rpcs3/Emu/Io/pad_config.h
+++ b/rpcs3/Emu/Io/pad_config.h
@@ -5,6 +5,11 @@
 #include "Utilities/Config.h"
 #include "Utilities/File.h"
 
+namespace pad
+{
+	constexpr static std::string_view keyboard_device_name = "Keyboard";
+}
+
 struct cfg_player final : cfg::node
 {
 	pad_handler def_handler = pad_handler::null;
@@ -19,7 +24,7 @@ struct cfg_input final : cfg::node
 {
 	std::string cfg_name = fs::get_config_dir() + "/config_input.yml";
 
-	cfg_player player1{ this, "Player 1 Input", pad_handler::keyboard };
+	cfg_player player1{ this, "Player 1 Input", pad_handler::null };
 	cfg_player player2{ this, "Player 2 Input", pad_handler::null };
 	cfg_player player3{ this, "Player 3 Input", pad_handler::null };
 	cfg_player player4{ this, "Player 4 Input", pad_handler::null };
@@ -27,7 +32,7 @@ struct cfg_input final : cfg::node
 	cfg_player player6{ this, "Player 6 Input", pad_handler::null };
 	cfg_player player7{ this, "Player 7 Input", pad_handler::null };
 
-	cfg_player* player[7]{ &player1, &player2, &player3, &player4, &player5, &player6, &player7 }; // Thanks gcc! 
+	cfg_player* player[7]{ &player1, &player2, &player3, &player4, &player5, &player6, &player7 }; // Thanks gcc!
 
 	bool load(const std::string& title_id = "");
 	void save(const std::string& title_id = "");
@@ -98,9 +103,9 @@ struct pad_config final : cfg::node
 	cfg::_int<0, 65535> vendor_id{ this, "Vendor ID", 0 };
 	cfg::_int<0, 65535> product_id{ this, "Product ID", 0 };
 
-	bool exist();
+	bool exist() const;
 	bool load();
-	void save();
+	void save() const;
 };
 
 extern cfg_input g_cfg_input;

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -441,7 +441,7 @@ void keyboard_pad_handler::mouseWheelEvent(QWheelEvent* event)
 std::vector<std::string> keyboard_pad_handler::ListDevices()
 {
 	std::vector<std::string> list_devices;
-	list_devices.emplace_back("Keyboard");
+	list_devices.emplace_back(pad::keyboard_device_name);
 	return list_devices;
 }
 
@@ -629,7 +629,7 @@ std::string keyboard_pad_handler::native_scan_code_to_string(int native_scan_cod
 
 bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device)
 {
-	if (device != "Keyboard")
+	if (device != pad::keyboard_device_name)
 		return false;
 
 	const int index = static_cast<int>(bindings.size());

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1138,7 +1138,7 @@ void pad_settings_dialog::ChangeInputType()
 	bool force_enable = false; // enable configs even with disconnected devices
 	const int player = ui->tabWidget->currentIndex();
 	const bool is_ldd_pad = GetIsLddPad(player);
-	
+
 	std::string handler;
 	std::string device;
 	std::string profile;


### PR DESCRIPTION
We accidentally always saved keyboard to Player 1 if null was selected.
The new code will only apply keyboard by default if the config file was not found.

We do not have a need for a fallback anymore, unless we actually use RPCS3 for the first time.
Since the pad settings are dynamic, the user can change it anytime anyway.

probably fixes #8841