### PR TITLE
rsx/vk: Image handling improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -276,6 +276,16 @@ namespace rsx
 			return format_info.gcm_depth_format;
 		}
 
+		u32 get_gcm_format() const
+		{
+			return
+			(
+				is_depth_surface() ?
+					get_compatible_gcm_format(format_info.gcm_depth_format).first :
+					get_compatible_gcm_format(format_info.gcm_color_format).first
+			);
+		}
+
 		bool dirty() const
 		{
 			return (state_flags != rsx::surface_state_flags::ready) || !old_contents.empty();

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2807,15 +2807,20 @@ namespace rsx
 			if (helpers::is_gcm_depth_format(typeless_info.src_gcm_format) !=
 				helpers::is_gcm_depth_format(typeless_info.dst_gcm_format))
 			{
-				if (!typeless_info.src_is_typeless && !typeless_info.dst_is_typeless)
+				// Make the depth side typeless because the other side is guaranteed to be color
+				if (helpers::is_gcm_depth_format(typeless_info.src_gcm_format))
 				{
-					// Make the depth side typeless
-					if (helpers::is_gcm_depth_format(typeless_info.src_gcm_format))
+					// SRC is depth, transfer must be done typelessly
+					if (!typeless_info.src_is_typeless)
 					{
 						typeless_info.src_is_typeless = true;
 						typeless_info.src_gcm_format = helpers::get_sized_blit_format(src_is_argb8, false, false);
 					}
-					else
+				}
+				else
+				{
+					// DST is depth, transfer must be done typelessly
+					if (!typeless_info.dst_is_typeless)
 					{
 						typeless_info.dst_is_typeless = true;
 						typeless_info.dst_gcm_format = helpers::get_sized_blit_format(dst_is_argb8, false, false);

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -1061,19 +1061,22 @@ namespace vk
 
 			if (format != src->format())
 			{
-				const auto internal_width = src->width() * xfer_info.src_scaling_hint;
-				const auto aspect = vk::get_aspect_flags(format);
+				// Normalize input region (memory optimization)
+				const auto old_src_area = src_area;
+				src_area.y2 -= src_area.y1;
+				src_area.y1 = 0;
+				src_area.x2 = static_cast<int>(src_area.width() * xfer_info.src_scaling_hint);
+				src_area.x1 = 0;
 
 				// Transfer bits from src to typeless src
-				real_src = vk::get_typeless_helper(format, rsx::classify_format(xfer_info.src_gcm_format), static_cast<u32>(internal_width), src->height());
-				vk::change_image_layout(cmd, real_src, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, { aspect, 0, 1, 0, 1 });
-
-				vk::copy_image_typeless(cmd, src, real_src, { 0, 0, static_cast<s32>(src->width()), static_cast<s32>(src->height()) }, { 0, 0, static_cast<s32>(internal_width), static_cast<s32>(src->height()) }, 1);
-
-				src_area.x1 = static_cast<u16>(src_area.x1 * xfer_info.src_scaling_hint);
-				src_area.x2 = static_cast<u16>(src_area.x2 * xfer_info.src_scaling_hint);
+				real_src = vk::get_typeless_helper(format, rsx::classify_format(xfer_info.src_gcm_format), src_area.width(), src_area.height());
+				real_src->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+				vk::copy_image_typeless(cmd, src, real_src, old_src_area, src_area, 1);
 			}
 		}
+
+		// Save output region descriptor
+		const auto old_dst_area = dst_area;
 
 		if (xfer_info.dst_is_typeless)
 		{
@@ -1083,18 +1086,37 @@ namespace vk
 
 			if (format != dst->format())
 			{
-				const auto internal_width = dst->width() * xfer_info.dst_scaling_hint;
-				const auto aspect = vk::get_aspect_flags(format);
+				// Normalize output region (memory optimization)
+				dst_area.y2 -= dst_area.y1;
+				dst_area.y1 = 0;
+				dst_area.x2 = static_cast<int>(dst_area.width() * xfer_info.dst_scaling_hint);
+				dst_area.x1 = 0;
 
-				// Transfer bits from dst to typeless dst
-				real_dst = vk::get_typeless_helper(format, rsx::classify_format(xfer_info.dst_gcm_format), static_cast<u32>(internal_width), dst->height());
-				vk::change_image_layout(cmd, real_dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, { aspect, 0, 1, 0, 1 });
+				// Account for possibility where SRC is typeless and DST is typeless and both map to the same format
+				auto required_height = dst_area.height();
+				if (real_src != src && real_src->format() == format)
+				{
+					required_height += src_area.height();
 
-				vk::copy_image_typeless(cmd, dst, real_dst, { 0, 0, static_cast<s32>(dst->width()), static_cast<s32>(dst->height()) }, { 0, 0, static_cast<s32>(internal_width), static_cast<s32>(dst->height()) }, 1);
+					// Move the dst area just below the src area
+					dst_area.y1 += src_area.y2;
+					dst_area.y2 += src_area.y2;
+				}
 
-				dst_area.x1 = static_cast<u16>(dst_area.x1 * xfer_info.dst_scaling_hint);
-				dst_area.x2 = static_cast<u16>(dst_area.x2 * xfer_info.dst_scaling_hint);
+				real_dst = vk::get_typeless_helper(format, rsx::classify_format(xfer_info.dst_gcm_format), dst_area.width(), required_height);
 			}
+		}
+
+		// Prepare typeless resources for the operation if needed
+		if (real_src != src)
+		{
+			const auto layout = ((real_src == real_dst) ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+			real_src->change_layout(cmd, layout);
+		}
+
+		if (real_dst != dst && real_dst != real_src)
+		{
+			real_dst->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 		}
 
 		// Checks
@@ -1134,8 +1156,7 @@ namespace vk
 
 		if (real_dst != dst)
 		{
-			auto internal_width = dst->width() * xfer_info.dst_scaling_hint;
-			vk::copy_image_typeless(cmd, real_dst, dst, { 0, 0, static_cast<s32>(internal_width), static_cast<s32>(dst->height()) }, { 0, 0, static_cast<s32>(dst->width()), static_cast<s32>(dst->height()) }, 1);
+			vk::copy_image_typeless(cmd, real_dst, dst, dst_area, old_dst_area, 1);
 		}
 	}
 }


### PR DESCRIPTION
- Always force typeless copy if memory is crossing aspect boundary.
- Properly pass format_class information during RTV/DSV resource barriers.
- Improve image transfer and scaling for vulkan. This makes it possible to bind two transfers to/from the same helper resource. Also significantly optimizes transfer handling in the slow path required for scaling operations which had a ton of unnecessary transfers.

Fixes https://github.com/RPCS3/rpcs3/issues/8944
Fixes https://github.com/RPCS3/rpcs3/issues/8846