### PR TITLE
Add playtime to the value from settings

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -406,8 +406,7 @@ void gui_application::UpdatePlaytime()
 		return;
 	}
 
-	const quint64 playtime = m_persistent_settings->GetPlaytime(serial) + m_timer_playtime.restart();
-	m_persistent_settings->SetPlaytime(serial, playtime);
+	m_persistent_settings->AddPlaytime(serial, m_timer_playtime.restart());
 	m_persistent_settings->SetLastPlayed(serial, QDate::currentDate().toString(gui::persistent::last_played_date_format));
 }
 
@@ -425,8 +424,7 @@ void gui_application::StopPlaytime()
 		return;
 	}
 
-	const quint64 playtime = m_persistent_settings->GetPlaytime(serial) + m_timer_playtime.elapsed();
-	m_persistent_settings->SetPlaytime(serial, playtime);
+	m_persistent_settings->AddPlaytime(serial, m_timer_playtime.restart());
 	m_persistent_settings->SetLastPlayed(serial, QDate::currentDate().toString(gui::persistent::last_played_date_format));
 	m_timer_playtime.invalidate();
 }

--- a/rpcs3/rpcs3qt/persistent_settings.cpp
+++ b/rpcs3/rpcs3qt/persistent_settings.cpp
@@ -9,10 +9,16 @@ persistent_settings::persistent_settings(QObject* parent) : settings(parent)
 	m_settings.reset(new QSettings(ComputeSettingsDir() + gui::persistent::persistent_file_name + ".dat", QSettings::Format::IniFormat, parent));
 }
 
-void persistent_settings::SetPlaytime(const QString& serial, const quint64& elapsed)
+void persistent_settings::SetPlaytime(const QString& serial, quint64 playtime)
 {
-	m_playtime[serial] = elapsed;
-	SetValue(gui::persistent::playtime, serial, m_playtime[serial]);
+	m_playtime[serial] = playtime;
+	SetValue(gui::persistent::playtime, serial, playtime);
+}
+
+void persistent_settings::AddPlaytime(const QString& serial, quint64 elapsed)
+{
+	const quint64 playtime = GetValue(gui::persistent::playtime, serial, 0).toULongLong();
+	SetPlaytime(serial, playtime + elapsed);
 }
 
 quint64 persistent_settings::GetPlaytime(const QString& serial)

--- a/rpcs3/rpcs3qt/persistent_settings.h
+++ b/rpcs3/rpcs3qt/persistent_settings.h
@@ -37,7 +37,8 @@ public:
 	QString GetCurrentUser(const QString& fallback) const;
 
 public Q_SLOTS:
-	void SetPlaytime(const QString& serial, const quint64& elapsed);
+	void SetPlaytime(const QString& serial, quint64 playtime);
+	void AddPlaytime(const QString& serial, quint64 elapsed);
 	quint64 GetPlaytime(const QString& serial);
 
 	void SetLastPlayed(const QString& serial, const QString& date);


### PR DESCRIPTION
Fixes playtime being wiped out when running the game with `--no-gui`. Since the initial value of `m_playtime` was not being set, timers added playtime to 0.

To avoid such mistakes in the future, add playtime to the value read from settings.