### PR TITLE
mm_joystick_handler: MSVC 16.8 Preview 3.1 compiler fix

### DIFF
--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -474,11 +474,11 @@ bool mm_joystick_handler::GetMMJOYDevice(int index, MMJOYDevice* dev)
 std::shared_ptr<PadDevice> mm_joystick_handler::get_device(const std::string& device)
 {
 	if (!Init())
-		return false;
+		return nullptr;
 
 	int id = GetIDByName(device);
 	if (id < 0)
-		return false;
+		return nullptr;
 
 	std::shared_ptr<MMJOYDevice> joy_device = std::make_shared<MMJOYDevice>(m_devices.at(id));
 	return joy_device;


### PR DESCRIPTION
The latest MSVC 16.8 Preview 3.1 cl.exe no longer likes the implicit conversion from false->std::shared_ptr
But it's happy with nullptr

Not the ideal solution, but it will kick the can down the road a little.