### PR TITLE
Registers Editor: Implement PPU/SPU reservation control

### DIFF
--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -4,6 +4,7 @@
 #include "Emu/Cell/SPUThread.h"
 #include "Emu/CPU/CPUThread.h"
 #include "Emu/CPU/CPUDisAsm.h"
+#include "Emu/Memory/vm_reservation.h"
 
 #include "Emu/Cell/lv2/sys_ppu_thread.h"
 

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -127,7 +127,7 @@ register_editor_dialog::register_editor_dialog(QWidget *parent, u32 _pc, const s
 			m_register_combo->addItem("SRR0", +SPU_SRR0);
 		}
 
-		m_register_combo->addItem("Reserv Invalidation", +RESERVATIIN_LOST);
+		m_register_combo->addItem("Reserv Invalidation", +RESERVATION_LOST);
 		m_register_combo->addItem("PC", +PC);
 	}
 

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -181,6 +181,7 @@ void register_editor_dialog::updateRegister(int reg)
 		else if (reg == PPU_CTR) str = fmt::format("%016llx", ppu.ctr);
 		else if (reg == PPU_VRSAVE) str = fmt::format("%08x", ppu.vrsave);
 		else if (reg == PPU_PRIO) str = fmt::format("%08x", +ppu.prio);
+		else if (reg == RESERVATION_LOST) str = sstr(ppu.raddr ? tr("Lose reservation on OK") : tr("Reservation is inactive"));
 		else if (reg == PC) str = fmt::format("%08x", ppu.cia);
 	}
 	else
@@ -201,10 +202,9 @@ void register_editor_dialog::updateRegister(int reg)
 		else if (reg == SPU_SNR2) str = fmt::format("%s", spu.ch_snr2);
 		else if (reg == SPU_OUT_MBOX) str = fmt::format("%s", spu.ch_out_mbox);
 		else if (reg == SPU_OUT_INTR_MBOX) str = fmt::format("%s", spu.ch_out_intr_mbox);
+		else if (reg == RESERVATION_LOST) str = sstr(spu.raddr ? tr("Lose reservation on OK") : tr("Reservation is inactive"));
 		else if (reg == PC) str = fmt::format("%08x", spu.pc);
 	}
-
-	if (reg == RESERVATION_LOST) str = "Reservation is lost after \"modification\"";
 
 	m_value_line->setText(qstr(str));
 }

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -127,7 +127,7 @@ register_editor_dialog::register_editor_dialog(QWidget *parent, u32 _pc, const s
 			m_register_combo->addItem("SRR0", +SPU_SRR0);
 		}
 
-		m_register_combo->addItem("Reserv Invalidation", +RESERVATION_LOST);
+		m_register_combo->addItem("Reservation Clear", +RESERVATION_LOST);
 		m_register_combo->addItem("PC", +PC);
 	}
 


### PR DESCRIPTION
It might be super hacky (and not useful) to allow to change reservation address or acquire a reservation, BUT it is super useful to explicitly clear a reservation for debugging etc while it being not hacky.
Any value you write in the field for this "register" is valid and will cause a reservation lost, its name is "Reserv Invalidation".