### PR TITLE
MSVC bug workaround

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -8,12 +8,15 @@
 #include <vector>
 #include <algorithm>
 
-
 namespace fs
 {
 #ifdef _WIN32
+	static constexpr auto delim = "/\\";
+	static constexpr auto wdelim = L"/\\";
 	using native_handle = void*;
 #else
+	static constexpr auto delim = "/";
+	static constexpr auto wdelim = L"/";
 	using native_handle = int;
 #endif
 

--- a/rpcs3/Crypto/utils.cpp
+++ b/rpcs3/Crypto/utils.cpp
@@ -8,6 +8,7 @@
 #include <time.h>
 #include "Utilities/StrUtil.h"
 #include "Utilities/span.h"
+#include "Utilities/File.h"
 
 #include <memory>
 #include <string>
@@ -124,7 +125,7 @@ char* extract_file_name(const char* file_path, char real_file_name[MAX_PATH])
 {
 	std::string_view v(file_path);
 
-	if (auto pos = v.find_last_of("/\\"); pos != umax)
+	if (auto pos = v.find_last_of(fs::delim); pos != umax)
 	{
 		v.remove_prefix(pos + 1);
 	}

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -712,14 +712,8 @@ std::string vfs::host::hash_path(const std::string& path, const std::string& dev
 
 bool vfs::host::rename(const std::string& from, const std::string& to, const lv2_fs_mount_point* mp, bool overwrite)
 {
-#ifdef _WIN32
-	constexpr auto& delim = "/\\";
-#else
-	constexpr auto& delim = "/";
-#endif
-
 	// Lock mount point, close file descriptors, retry 
-	const auto from0 = std::string_view(from).substr(0, from.find_last_not_of(delim) + 1);
+	const auto from0 = std::string_view(from).substr(0, from.find_last_not_of(fs::delim) + 1);
 	const auto escaped_from = fs::escape_path(from);
 
 	// Lock app_home as well because it could be in the same drive as current mount point (TODO)
@@ -727,7 +721,7 @@ bool vfs::host::rename(const std::string& from, const std::string& to, const lv2
 
 	auto check_path = [&](std::string_view path)
 	{
-		return path.starts_with(from) && (path.size() == from.size() || path[from.size()] == delim[0] || path[from.size()] == delim[1]);
+		return path.starts_with(from) && (path.size() == from.size() || path[from.size()] == fs::delim[0] || path[from.size()] == fs::delim[1]);
 	};
 
 	idm::select<lv2_fs_object, lv2_file>([&](u32 id, lv2_file& file)


### PR DESCRIPTION
It seems like MSVC 16.8 preview versions do not like ref capturing of constexpr reference for some reason. Cna aslo emit better code because of more constexpr added.