### PR TITLE
vm/sys_config/sys_memory: Stack fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -5,6 +5,9 @@
 #include "Emu/Io/KeyboardHandler.h"
 #include "cellKb.h"
 
+extern void libio_sys_config_init();
+extern void libio_sys_config_end();
+
 LOG_CHANNEL(sys_io);
 
 template<>
@@ -42,6 +45,7 @@ error_code cellKbInit(u32 max_connect)
 	if (max_connect == 0 || max_connect > CELL_KB_MAX_KEYBOARDS)
 		return CELL_KB_ERROR_INVALID_PARAMETER;
 
+	libio_sys_config_init();
 	handler->Init(std::min(max_connect, 7u));
 
 	return CELL_OK;
@@ -59,6 +63,7 @@ error_code cellKbEnd()
 		return CELL_KB_ERROR_UNINITIALIZED;
 
 	// TODO
+	libio_sys_config_end();
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -6,6 +6,9 @@
 
 #include "cellMouse.h"
 
+extern void libio_sys_config_init();
+extern void libio_sys_config_end();
+
 LOG_CHANNEL(sys_io);
 
 template<>
@@ -45,6 +48,7 @@ error_code cellMouseInit(u32 max_connect)
 		return CELL_MOUSE_ERROR_INVALID_PARAMETER;
 	}
 
+	libio_sys_config_init();
 	handler->Init(std::min(max_connect, 7u));
 
 	return CELL_OK;
@@ -99,6 +103,7 @@ error_code cellMouseEnd()
 		return CELL_MOUSE_ERROR_UNINITIALIZED;
 
 	// TODO
+	libio_sys_config_end();
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -8,6 +8,9 @@
 #include "Input/product_info.h"
 #include "cellPad.h"
 
+extern void libio_sys_config_init();
+extern void libio_sys_config_end();
+
 LOG_CHANNEL(sys_io);
 
 template<>
@@ -61,6 +64,7 @@ error_code cellPadInit(u32 max_connect)
 	if (max_connect == 0 || max_connect > CELL_MAX_PADS)
 		return CELL_PAD_ERROR_INVALID_PARAMETER;
 
+	libio_sys_config_init();
 	config->max_connect = std::min<u32>(max_connect, CELL_PAD_MAX_PORT_NUM);
 	config->port_setting.fill(CELL_PAD_SETTING_PRESS_OFF | CELL_PAD_SETTING_SENSOR_OFF);
 	return CELL_OK;
@@ -77,6 +81,7 @@ error_code cellPadEnd()
 	if (!config->max_connect.exchange(0))
 		return CELL_PAD_ERROR_UNINITIALIZED;
 
+	libio_sys_config_end();
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -184,7 +184,7 @@ error_code sys_memory_get_page_attribute(u32 addr, vm::ptr<sys_page_attr_t> attr
 	}
 
 	attr->attribute = 0x40000ull; // SYS_MEMORY_PROT_READ_WRITE (TODO)
-	attr->access_right = 0xFull; // SYS_MEMORY_ACCESS_RIGHT_ANY (TODO)
+	attr->access_right = addr >> 28 == 0xdu ? SYS_MEMORY_ACCESS_RIGHT_PPU_THR : SYS_MEMORY_ACCESS_RIGHT_ANY;// (TODO)
 
 	if (vm::check_addr(addr, 1, vm::page_1m_size))
 	{

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -805,7 +805,7 @@ namespace vm
 			vm::writer_lock lock(0);
 
 			// Deallocate all memory
-			for (auto it = m_map.begin(), end = m_map.end(); !m_common && it != end;)
+			for (auto it = m_map.begin(), end = m_map.end(); it != end;)
 			{
 				const auto next = std::next(it);
 				const auto size = it->second.first;


### PR DESCRIPTION
* Implement sys_config's PPU stack for "_cfg_evt_hndlr" thread, I've discovered this through hw testing of stack spaces after calling cellPad/Kb/MouseInit, to confirm Ive looked at disassmebly as well for the exact behaviour. (one thread for all instances until they all close)
* Demi-fix for vm memory stack deallocation on stack area destructor: Always reset memory flags.
Also always clear stack memory on Emu.Stop(). (do not rely on manual cleanup)
* Fix sys_memory_get_page_attribute stack access rights to match realhw.

Testcase: https://github.com/elad335/myps3tests/tree/master/ppu_tests/print%20ppu%20stacks

Fixes #5875
Why it was fixed? the PPU written to memory outside of its stack bounds and failed on rpcs3, clearly into a poor and inactive firmware PPU stack area so it even goes unnoticed.

![image](https://user-images.githubusercontent.com/18193363/94335091-aa69b400-ffe1-11ea-9e1b-c15dc059e8f3.png)
