### PR TITLE
rsx: Improve shader decompiler output

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
@@ -183,11 +183,11 @@ namespace vk
 				glslang::GlslangToSpv(*program.getIntermediate(lang), spv, &options);
 
 				// Now we optimize
-				spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_0);
-				optimizer.RegisterPass(spvtools::CreateUnifyConstantPass());      // Remove duplicate constants
-				optimizer.RegisterPass(spvtools::CreateMergeReturnPass());        // Huge savings in vertex interpreter and likely normal vertex shaders
-				optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());      // Remove dead code
-				optimizer.Run(spv.data(), spv.size(), &spv);
+				//spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_0);
+				//optimizer.RegisterPass(spvtools::CreateUnifyConstantPass());      // Remove duplicate constants
+				//optimizer.RegisterPass(spvtools::CreateMergeReturnPass());        // Huge savings in vertex interpreter and likely normal vertex shaders
+				//optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());      // Remove dead code
+				//optimizer.Run(spv.data(), spv.size(), &spv);
 			}
 		}
 		else


### PR DESCRIPTION
- Rewrites the vertex decoder to emit much simpler and smaller code which in turn drastically speeds up link time. On GCN GPUs this can result in almost 2x speedup of shader link time which means less time wasted waiting for shaders to compile. Resulting bytecode is almost 30% smaller as well, which may help performance on low end GPUs and/or IGPs.
- Reimplements fp32->fp16 casting to use GPU native instructions. This seems to work on my AMD card correctly and still preserves INF/NaN special encoding after the cast. 10-15% instruction count savings.
- Use intrinsics wherever possible to take advantage of native hardware instructions. Replaces many shift-and operations with a single bfe and shift-or with bfi. Generates slightly smaller code but more importantly - it is much cleaner and easier to read.

To Testers: Just check if games are working the same as before. While we already found some bugs and fixed them with internal testing, bugs may still lurk.