### PR TITLE
LibUSB: Update to upstream master (and turn off YAML_CPP_INSTALL CMake property)

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -106,6 +106,36 @@ endif()
 add_subdirectory(pugixml EXCLUDE_FROM_ALL)
 
 
+# libusb
+if(CMAKE_SYSTEM MATCHES "DragonFly|FreeBSD")
+	pkg_check_modules(LIBUSB REQUIRED IMPORTED_TARGET libusb-1.0>=1.0 )
+	CMAKE_DEPENDENT_OPTION( USE_SYS_LIBUSB "Use system libusb-1.0 as shared library" ON
+			"LIBUSB_FOUND" OFF)
+else()
+	pkg_check_modules(LIBUSB IMPORTED_TARGET libusb-1.0>=1.0 )
+	CMAKE_DEPENDENT_OPTION( USE_SYS_LIBUSB "Use system libusb-1.0 as shared library" OFF
+			"LIBUSB_FOUND" OFF)
+endif()
+if(CMAKE_SYSTEM MATCHES "DragonFly|FreeBSD")
+	# Always use system libusb as reference implementation isn't supported
+	add_library(usb-1.0-shared INTERFACE)
+	target_link_libraries(usb-1.0-shared INTERFACE PkgConfig::LIBUSB)
+elseif(MSVC)
+	# Windows time.h defines timespec but doesn't add any flag for it, which makes libusb attempt to define it again
+	add_definitions(-DHAVE_STRUCT_TIMESPEC=1)
+	add_subdirectory(libusb_cmake EXCLUDE_FROM_ALL)
+else()
+	if(USE_SYS_LIBUSB)
+		# we have the system libusb and have selected to use it
+		add_library(usb-1.0-shared INTERFACE)
+		target_link_libraries(usb-1.0-shared INTERFACE PkgConfig::LIBUSB)
+	else()
+		# we don't have the system libusb, so we compile from submodule
+		add_subdirectory(libusb_cmake EXCLUDE_FROM_ALL)
+	endif()
+endif()
+
+
 # hidapi
 add_library(3rdparty_hidapi INTERFACE)
 target_include_directories(3rdparty_hidapi INTERFACE hidapi/hidapi)
@@ -133,24 +163,11 @@ else()
 endif()
 
 
-# libusb
-if(CMAKE_SYSTEM MATCHES "DragonFly|FreeBSD")
-	# Always use system libusb as reference implementation isn't supported
-	add_library(usb-1.0-static INTERFACE)
-	target_link_libraries(usb-1.0-static INTERFACE usb)
-elseif(MSVC)
-	# Windows time.h defines timespec but doesn't add any flag for it, which makes libusb attempt to define it again
-	add_definitions(-DHAVE_STRUCT_TIMESPEC=1)
-	add_subdirectory(libusb_cmake EXCLUDE_FROM_ALL)
-else()
-	add_subdirectory(libusb_cmake EXCLUDE_FROM_ALL)
-endif()
-
-
 # yaml-cpp
 # We don't want to install yaml-cpp but its cmake file doesn't have option
 # to disable it...
 # So we just install it to a different directory
+set(YAML_CPP_INSTALL OFF CACHE BOOL "Don't install YAML")
 set(CMAKE_INSTALL_PREFIX_OLD ${CMAKE_INSTALL_PREFIX})
 set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/yaml-cpp_install)
 
@@ -460,7 +477,11 @@ else()
 endif()
 
 # add nice ALIAS targets for ease of use
-add_library(3rdparty::libusb ALIAS usb-1.0-static)
+if(USE_SYS_LIBUSB)
+	add_library(3rdparty::libusb ALIAS usb-1.0-shared)
+else()
+	add_library(3rdparty::libusb ALIAS usb-1.0-static)
+endif()
 add_library(3rdparty::zlib ALIAS 3rdparty_zlib)
 add_library(3rdparty::7z ALIAS 3rdparty_7z)
 add_library(3rdparty::flatbuffers ALIAS 3rdparty_flatbuffers)

--- a/3rdparty/libusb_cmake/os.cmake
+++ b/3rdparty/libusb_cmake/os.cmake
@@ -6,6 +6,7 @@ if (CMAKE_USE_PTHREADS_INIT)
 endif()
 
 if (WIN32 OR "${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")
+	add_compile_definitions(PLATFORM_WINDOWS=1)
 	set(OS_WINDOWS 1 CACHE INTERNAL "controls config.h macro definition" FORCE)
 
 	# Enable MingW support for RC language (for CMake pre-2.8)
@@ -22,9 +23,9 @@ if (WIN32 OR "${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")
 	endif()
 
 	list(APPEND PLATFORM_SRC
-		poll_windows.c
+		events_windows.c
 		windows_usbdk.c
-		windows_nt_common.c
+		windows_common.c
 		windows_winusb.c
 		threads_windows.c
 	)
@@ -36,13 +37,14 @@ if (WIN32 OR "${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")
 	endif()
 elseif (APPLE)
 	# Apple != OSX alone
+	add_compile_definitions(PLATFORM_POSIX=1 HAVE_CLOCK_GETTIME)
 	set(OS_DARWIN 1 CACHE INTERNAL "controls config.h macro definition" FORCE)
 
 	if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
 		set(PLATFORM_SRC
 			darwin_usb.c
 			threads_posix.c
-			poll_posix.c
+			events_posix.c
 		)
 
 		find_package(IOKit REQUIRED)
@@ -72,6 +74,7 @@ int main()
 	endif()
 elseif (UNIX)
 	# Unix is for all *NIX systems including OSX
+	add_compile_definitions(PLATFORM_POSIX=1 HAVE_CLOCK_GETTIME)
 	if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
 		set(OS_LINUX 1 CACHE INTERNAL "controls config.h macro definition" FORCE)
 
@@ -79,7 +82,7 @@ elseif (UNIX)
 			linux_usbfs.c
 			linux_netlink.c
 			threads_posix.c
-			poll_posix.c
+			events_posix.c
 		)
 
 		list(APPEND LIBUSB_LIBRARIES rt)

--- a/3rdparty/libusb_static.vcxproj
+++ b/3rdparty/libusb_static.vcxproj
@@ -43,7 +43,7 @@
     <ClCompile>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>libusb\msvc;libusb\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0501;_WIN32_WINNT=0x0501;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WINVER=0x0600;_WIN32_WINNT=0x0600;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <WarningLevel>Level4</WarningLevel>
     </ClCompile>
@@ -65,11 +65,11 @@
     <ClCompile Include="libusb\libusb\descriptor.c" />
     <ClCompile Include="libusb\libusb\hotplug.c" />
     <ClCompile Include="libusb\libusb\io.c" />
-    <ClCompile Include="libusb\libusb\os\poll_windows.c" />
+    <ClCompile Include="libusb\libusb\os\events_windows.c" />
     <ClCompile Include="libusb\libusb\strerror.c" />
     <ClCompile Include="libusb\libusb\sync.c" />
     <ClCompile Include="libusb\libusb\os\threads_windows.c" />
-    <ClCompile Include="libusb\libusb\os\windows_nt_common.c" />
+    <ClCompile Include="libusb\libusb\os\windows_common.c" />
     <ClCompile Include="libusb\libusb\os\windows_usbdk.c" />
     <ClCompile Include="libusb\libusb\os\windows_winusb.c" />
   </ItemGroup>
@@ -78,13 +78,11 @@
     <ClInclude Include="libusb\libusb\hotplug.h" />
     <ClInclude Include="libusb\libusb\libusb.h" />
     <ClInclude Include="libusb\libusb\libusbi.h" />
-    <ClInclude Include="libusb\libusb\os\poll_windows.h" />
+    <ClInclude Include="libusb\libusb\os\events_windows.h" />
     <ClInclude Include="libusb\libusb\os\threads_windows.h" />
     <ClInclude Include="libusb\libusb\version.h" />
     <ClInclude Include="libusb\libusb\version_nano.h" />
     <ClInclude Include="libusb\libusb\os\windows_common.h" />
-    <ClInclude Include="libusb\libusb\os\windows_nt_common.h" />
-    <ClInclude Include="libusb\libusb\os\windows_nt_shared_types.h" />
     <ClInclude Include="libusb\libusb\os\windows_usbdk.h" />
     <ClInclude Include="libusb\libusb\os\windows_winusb.h" />
   </ItemGroup>


### PR DESCRIPTION
May resolve some outstanding issues around libusb/hidapi (i.e. DS4 not being released on rpcs3 shutdown etc..) or may not.
Fixes three outstanding compile warnings on non-Windows OS...
Re-ordered the 3rd party CMake so libusb is in file order above hidapi (just to have document flow match logical flow)

Also took this opportunity to remove the YAML INSTALL action (by setting YAML_CPP_INSTALL to OFF)
Provided capability to use system library for libusb by providing USE_SYS_LIBUSB option to CMAKE
The pkg-config is also used for FreeBSD now to find the dynamic library

Tested under:
- [X] Windows 10 2004 OS with DS4 controller
- [X] Windows 10 2004 OS with GCon3 controller
- [X] Linux (Mint 20) with DS4 controller
- [X] FreeBSD (GhostBSD) with DS4 controller

~~Further Testing desired:~~
~~- [ ] Other LibUSB devices~~
~~- [ ] Testing under 'other platforms' (FreeBSD?)~~