### PR TITLE
PPU: fixup for Accurate 128-byte reservations

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1186,7 +1186,7 @@ static T ppu_load_acquire_reservation(ppu_thread& ppu, u32 addr)
 
 		if (ppu.use_full_rdata)
 		{
-			mov_rdata(ppu.rdata, vm::_ref<spu_rdata_t>(addr & -128))
+			mov_rdata(ppu.rdata, vm::_ref<spu_rdata_t>(addr & -128));
 		}
 
 		if ((vm::reservation_acquire(addr, sizeof(T)) & mask_res) == ppu.rtime) [[likely]]

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -193,8 +193,7 @@ public:
 
 	u32 raddr{0}; // Reservation addr
 	u64 rtime{0};
-	u64 rdata{0}; // Reservation data
-	alignas(64) std::byte full_rdata[128]{}; // Full reservation data
+	alignas(64) std::byte rdata[128]{}; // Reservation data
 	bool use_full_rdata{};
 
 	atomic_t<s32> prio{0}; // Thread priority (0..3071)


### PR DESCRIPTION
Do not hardcode ppu.rdata to store the data of a specifuc address because it dies not work when the reservation store address differs from reservation load address.
Some cleanup as well, at this point PPU reservation data is identical to SPU's and in the future may even be moved entirely to cpu_thread class for shared management.