### PR TITLE
SPU: Embedded PRX/overlay image patching, Implement images dumping, Image search improvements

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -298,6 +298,7 @@ void Emulator::Init()
 
 	make_path_verbose(fs::get_cache_dir() + "shaderlog/");
 	make_path_verbose(fs::get_config_dir() + "captures/");
+	make_path_verbose(fs::get_cache_dir() + "spu_progs/");
 
 	// Initialize patch engine
 	g_fxo->init<patch_engine>()->append_global_patches();

--- a/rpcs3/Loader/ELF.h
+++ b/rpcs3/Loader/ELF.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "../../Utilities/types.h"
 #include "../../Utilities/File.h"
@@ -293,7 +293,7 @@ public:
 		header.e_curver = 1;
 		header.e_os_abi = OS != elf_os::none ? OS : this->header.e_os_abi;
 		header.e_abi_ver = this->header.e_abi_ver;
-		header.e_type = Type != elf_type::none ? Type : this->header.e_type;
+		header.e_type = Type != elf_type::none ? Type : static_cast<elf_type>(this->header.e_type);
 		header.e_machine = Machine;
 		header.e_version = 1;
 		header.e_entry = this->header.e_entry;


### PR DESCRIPTION
* Search SPU images in PRX/overlay modules, allows to patch cellSpurs' SPU images.
* Remove stupid restriction in SPU image search, check if any address contains SPU image and not just aligned 128-byte addresses.
* Dump SPU images into actual files if "SPU Debug" option is enabled in config.
* Optimize SPU image search to be extremely fast.
* Search SPU images in all PS3 binary LOAD segements, not just the first. 