### PR TITLE
Implement sys_process_is_spu_lock_line_reservation_address

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -3849,7 +3849,7 @@ s32 _cellSpursSendSignal(ppu_thread& ppu, vm::ptr<CellSpursTaskset> taskset, u32
 		else
 		{
 			signal = !!(~signalled & waiting & mask);
-			signalled |= (signal ? mask : 0);
+			signalled |= mask;
 		}
 
 		if (ppu_stwcx(ppu, addr, signalled))

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -54,7 +54,9 @@ extern ps3_process_info_t  g_ps3_process_info;
 // Auxiliary functions
 s32 process_getpid();
 s32 process_get_sdk_version(u32 pid, s32& ver);
-error_code process_is_spu_lock_line_reservation_address(u32 addr, u64 flags);
+
+enum CellError : u32;
+CellError process_is_spu_lock_line_reservation_address(u32 addr, u64 flags);
 
 // SysCalls
 s32 sys_process_getpid();


### PR DESCRIPTION
Used by cellSpurs instance creation functions to validate starting 128 byte of specfied CellSpurs address is capable of SPU reservations.
This syscall does not care if the address itself is mapped, only the 256mb region of it. (EINVAL if does not exist)

Restrictions found (EPERM):
* sys_vm memory is not allowed.
* PPU stack are is not allowed.
* Private SPU MMIO is not allowed with RawSPU flag.

Testcase : https://github.com/elad335/myps3tests/tree/master/ppu_tests/sys_process_is_spu_lock_line_reservation_address
The testcase works by finding 2 addressed in every aligned 256mb of the 4GB address space: mapped and unmapped and passses both to the syscall, when unfound it wont be passed to the syscall.
It allocates as many region types as possible, and I also tested when some were not allocated at all such as cellGcm areas privately. 

