### PR TITLE
Implement vm::reservation_op

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSpurs.h
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.h
@@ -465,6 +465,25 @@ struct alignas(128) CellSpursJobChain
 	u8 unk5[0x100 - 0xA8];
 };
 
+struct alignas(128) CellSpursJobChain_x00
+{
+	vm::bcptr<u64, u64> pc;                                                      // 0x00
+	vm::bcptr<u64, u64> linkRegister[3];                                         // 0x08
+	u8 unk0[0x3];                                                                // 0x20
+	b8 isHalted;                                                                 // 0x23
+	b8 autoReadyCount;                                                           // 0x24
+	u8 unk1[0x7];                                                                // 0x25
+	u8 val2C;                                                                    // 0x2C
+	u8 val2D;                                                                    // 0x2D
+	u8 val2E;                                                                    // 0x2E
+	u8 val2F;                                                                    // 0x2F
+	be_t<u64> urgentCmds[4];                                                     // 0x30
+	u8 unk2[0x22];                                                               // 0x50
+	be_t<u16> maxGrabbedJob;                                                     // 0x72
+	be_t<u32> workloadId;                                                        // 0x74
+	vm::bptr<CellSpurs, u64> spurs;                                              // 0x78
+};
+
 struct CellSpursJobChainInfo
 {
 	be_t<u64> urgentCommandSlot[4];                                                 // 0x00
@@ -494,7 +513,7 @@ struct alignas(8) CellSpursJobChainAttribute
 	be_t<u32> maxGrabbedJob;          // 0x0E
 	u8 priorities[8];                 // 0x10
 	be_t<u32> maxContention;          // 0x18
-	b8 autoSpuCount;                  // 0x1C 
+	b8 autoSpuCount;                  // 0x1C
 	u8 padding[3];                    // 0x1D
 	be_t<u32> tag1;                   // 0x20
 	be_t<u32> tag2;                   // 0x24
@@ -1031,7 +1050,7 @@ struct alignas(16) CellSpursTaskBinInfo
 
 struct alignas(128) CellSpursBarrier
 {
-	be_t<u32> zero;                     // 0x00 
+	be_t<u32> zero;                     // 0x00
 	be_t<u32> remained;                 // 0x04
 	u8 unk0[0x34 - 0x8];
 	vm::bptr<CellSpursTaskset> taskset; // 0x34

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -323,6 +323,13 @@ namespace vm
 		{
 			return vm::cast(other.addr(), HERE);
 		}
+
+		// Perform reinterpret cast
+		template <typename CT, typename T, typename AT, typename = decltype(reinterpret_cast<to_be_t<CT>*>(std::declval<T*>()))>
+		inline _ptr_base<to_be_t<CT>, u32> unsafe_ptr_cast(const _ptr_base<T, AT>& other)
+		{
+			return vm::cast(other.addr(), HERE);
+		}
 	}
 
 	struct null_t

--- a/rpcs3/Emu/Memory/vm_reservation.h
+++ b/rpcs3/Emu/Memory/vm_reservation.h
@@ -1,15 +1,19 @@
 #pragma once
 
 #include "vm.h"
+#include "vm_locking.h"
 #include "Utilities/cond.h"
 #include "util/atomic.hpp"
+#include <functional>
+
+extern bool g_use_rtm;
 
 namespace vm
 {
 	enum reservation_lock_bit : u64
 	{
 		stcx_lockb = 1 << 0, // Exclusive conditional reservation lock
-		dma_lockb = 1 << 1, // Inexclusive unconditional reservation lock
+		dma_lockb = 1 << 5, // Exclusive unconditional reservation lock
 		putlluc_lockb = 1 << 6, // Exclusive unconditional reservation lock
 	};
 
@@ -68,5 +72,295 @@ namespace vm
 		}
 
 		return {*res, rtime};
+	}
+
+	void reservation_op_internal(u32 addr, std::function<bool()> func);
+
+	template <typename T, typename AT = u32, typename F>
+	SAFE_BUFFERS inline auto reservation_op(_ptr_base<T, AT> ptr, F op)
+	{
+		// Atomic operation will be performed on aligned 128 bytes of data, so the data size and alignment must comply
+		static_assert(sizeof(T) <= 128 && alignof(T) == sizeof(T), "vm::reservation_op: unsupported type");
+		static_assert(std::is_trivially_copyable_v<T>, "vm::reservation_op: not triv copyable (optimization)");
+
+		// Use "super" pointer to prevent access violation handling during atomic op
+		const auto sptr = vm::get_super_ptr<T>(static_cast<u32>(ptr.addr()));
+
+		// Use 128-byte aligned addr
+		const u32 addr = static_cast<u32>(ptr.addr()) & -128;
+
+		if (g_use_rtm)
+		{
+			auto& res = vm::reservation_acquire(addr, 128);
+
+			// Stage 1: single optimistic transaction attempt
+			unsigned status = _XBEGIN_STARTED;
+
+#ifndef _MSC_VER
+			__asm__ goto ("xbegin %l[stage2];" ::: "memory" : stage2);
+#else
+			status = _xbegin();
+			if (status == _XBEGIN_STARTED)
+#endif
+			{
+				if constexpr (std::is_void_v<std::invoke_result_t<F, T&>>)
+				{
+					res += 128;
+					std::invoke(op, *sptr);
+#ifndef _MSC_VER
+					__asm__ volatile ("xend;" ::: "memory");
+#else
+					_xend();
+#endif
+					res.notify_all();
+					return;
+				}
+				else
+				{
+					if (auto result = std::invoke(op, *sptr))
+					{
+						res += 128;
+#ifndef _MSC_VER
+						__asm__ volatile ("xend;" ::: "memory");
+#else
+						_xend();
+#endif
+						res.notify_all();
+						return result;
+					}
+					else
+					{
+#ifndef _MSC_VER
+						__asm__ volatile ("xabort $1;" ::: "memory");
+#else
+						_xabort(1);
+#endif
+						// Unreachable code
+						return std::invoke_result_t<F, T&>();
+					}
+				}
+			}
+
+			stage2:
+#ifndef _MSC_VER
+			__asm__ volatile ("movl %%eax, %0;" : "=r" (status) :: "memory");
+#endif
+			if constexpr (!std::is_void_v<std::invoke_result_t<F, T&>>)
+			{
+				if (_XABORT_CODE(status))
+				{
+					// Unfortunately, actual function result is not recoverable in this case
+					return std::invoke_result_t<F, T&>();
+				}
+			}
+
+			// Touch memory if transaction failed without RETRY flag on the first attempt (TODO)
+			if (!(status & _XABORT_RETRY))
+			{
+				reinterpret_cast<atomic_t<u8>*>(sptr)->fetch_add(0);
+			}
+
+			// Stage 2: try to lock reservation first
+			res += stcx_lockb;
+
+			// Start lightened transaction (TODO: tweaking)
+			while (true)
+			{
+#ifndef _MSC_VER
+				__asm__ goto ("xbegin %l[retry];" ::: "memory" : retry);
+#else
+				status = _xbegin();
+
+				if (status != _XBEGIN_STARTED) [[unlikely]]
+				{
+					goto retry;
+				}
+#endif
+				if constexpr (std::is_void_v<std::invoke_result_t<F, T&>>)
+				{
+					std::invoke(op, *sptr);
+#ifndef _MSC_VER
+					__asm__ volatile ("xend;" ::: "memory");
+#else
+					_xend();
+#endif
+					res += 127;
+					res.notify_all();
+					return;
+				}
+				else
+				{
+					if (auto result = std::invoke(op, *sptr))
+					{
+#ifndef _MSC_VER
+						__asm__ volatile ("xend;" ::: "memory");
+#else
+						_xend();
+#endif
+						res += 127;
+						res.notify_all();
+						return result;
+					}
+					else
+					{
+#ifndef _MSC_VER
+						__asm__ volatile ("xabort $1;" ::: "memory");
+#else
+						_xabort(1);
+#endif
+						return std::invoke_result_t<F, T&>();
+					}
+				}
+
+				retry:
+#ifndef _MSC_VER
+				__asm__ volatile ("movl %%eax, %0;" : "=r" (status) :: "memory");
+#endif
+				if (!(status & _XABORT_RETRY)) [[unlikely]]
+				{
+					if constexpr (!std::is_void_v<std::invoke_result_t<F, T&>>)
+					{
+						if (_XABORT_CODE(status))
+						{
+							res -= 1;
+							return std::invoke_result_t<F, T&>();
+						}
+					}
+
+					break;
+				}
+			}
+
+			// Stage 3: all failed, heavyweight fallback (see comments at the bottom)
+			if constexpr (std::is_void_v<std::invoke_result_t<F, T&>>)
+			{
+				return vm::reservation_op_internal(addr, [&]
+				{
+					std::invoke(op, *sptr);
+					return true;
+				});
+			}
+			else
+			{
+				auto result = std::invoke_result_t<F, T&>();
+
+				vm::reservation_op_internal(addr, [&]
+				{
+					T buf = *sptr;
+
+					if ((result = std::invoke(op, buf)))
+					{
+						*sptr = buf;
+						return true;
+					}
+					else
+					{
+						return false;
+					}
+				});
+
+				return result;
+			}
+		}
+
+
+		// Perform under heavyweight lock
+		auto& res = vm::reservation_acquire(addr, 128);
+
+		res += stcx_lockb;
+
+		// Write directly if the op cannot fail
+		if constexpr (std::is_void_v<std::invoke_result_t<F, T&>>)
+		{
+			{
+				vm::writer_lock lock(addr);
+				std::invoke(op, *sptr);
+				res += 127;
+			}
+
+			res.notify_all();
+			return;
+		}
+		else
+		{
+			// Make an operational copy of data (TODO: volatile storage?)
+			auto result = std::invoke_result_t<F, T&>();
+
+			{
+				vm::writer_lock lock(addr);
+				T buf = *sptr;
+
+				if ((result = std::invoke(op, buf)))
+				{
+					// If operation succeeds, write the data back
+					*sptr = buf;
+					res += 127;
+				}
+				else
+				{
+					// Operation failed, no memory has been modified
+					res -= 1;
+					return std::invoke_result_t<F, T&>();
+				}
+			}
+
+			res.notify_all();
+			return result;
+		}
+	}
+
+	// For internal usage
+	void reservation_escape_internal();
+
+	// Read memory value in pseudo-atomic manner
+	template <typename CPU, typename T, typename AT = u32, typename F>
+	SAFE_BUFFERS inline auto reservation_peek(CPU&& cpu, _ptr_base<T, AT> ptr, F op)
+	{
+		// Atomic operation will be performed on aligned 128 bytes of data, so the data size and alignment must comply
+		static_assert(sizeof(T) <= 128 && alignof(T) == sizeof(T), "vm::reservation_peek: unsupported type");
+
+		// Use "super" pointer to prevent access violation handling during atomic op
+		const auto sptr = vm::get_super_ptr<const T>(static_cast<u32>(ptr.addr()));
+
+		// Use 128-byte aligned addr
+		const u32 addr = static_cast<u32>(ptr.addr()) & -128;
+
+		while (true)
+		{
+			if constexpr (std::is_class_v<std::remove_cvref_t<CPU>>)
+			{
+				if (cpu.test_stopped())
+				{
+					reservation_escape_internal();
+				}
+			}
+
+			const u64 rtime = vm::reservation_acquire(addr, 128);
+
+			if (rtime & 127)
+			{
+				continue;
+			}
+
+			// Observe data non-atomically and make sure no reservation updates were made
+			if constexpr (std::is_void_v<std::invoke_result_t<F, const T&>>)
+			{
+				std::invoke(op, *sptr);
+
+				if (rtime == vm::reservation_acquire(addr, 128))
+				{
+					return;
+				}
+			}
+			else
+			{
+				auto res = std::invoke(op, *sptr);
+
+				if (rtime == vm::reservation_acquire(addr, 128))
+				{
+					return res;
+				}
+			}
+		}
 	}
 } // namespace vm


### PR DESCRIPTION
This function currently doesn't have any effect on the RPCS3, but it can be helpful in theory if we are going to HLE some code such as cellSpurs. It takes a mini-transaction in it, and attempts to execute it fast with TSX. If TSX is not available, or it fails, it fallbacks to slower path.