### PR TITLE
SPU Local Storage capture

### DIFF
--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -322,18 +322,21 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 void spu_load_exec(const spu_exec_object& elf)
 {
 	auto ls0 = vm::cast(vm::falloc(RAW_SPU_BASE_ADDR, SPU_LS_SIZE, vm::spu));
-	auto spu = idm::make_ptr<named_thread<spu_thread>>("TEST_SPU", ls0, nullptr, 0, "", 0);
 
 	spu_thread::g_raw_spu_ctr++;
-	spu_thread::g_raw_spu_id[0] = spu->id;
 
 	for (const auto& prog : elf.progs)
 	{
 		if (prog.p_type == 0x1u /* LOAD */ && prog.p_memsz)
 		{
-			std::memcpy(spu->_ptr<void>(prog.p_vaddr), prog.bin.data(), prog.p_filesz);
+			std::memcpy(vm::base(ls0 + prog.p_vaddr), prog.bin.data(), prog.p_filesz);
 		}
 	}
 
+	auto spu = idm::make_ptr<named_thread<spu_thread>>("TEST_SPU", ls0, nullptr, 0, "", 0);
+
+	spu_thread::g_raw_spu_id[0] = spu->id;
+
 	spu->status_npc = {SPU_STATUS_RUNNING, elf.header.e_entry};
+	atomic_storage<u32>::release(spu->pc, elf.header.e_entry);
 }

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -770,6 +770,8 @@ public:
 
 	void fast_call(u32 ls_addr);
 
+	bool capture_local_storage() const;
+
 	// Convert specified SPU LS address to a pointer of specified (possibly converted to BE) type
 	template<typename T>
 	to_be_t<T>* _ptr(u32 lsa) const

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1630,7 +1630,11 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 
 		if ((m_force_boot || g_cfg.misc.autostart) && IsReady())
 		{
-			Run(true);
+			if (ppu_exec == elf_error::ok)
+			{
+				Run(true);
+			}
+
 			m_force_boot = false;
 		}
 		else if (IsPaused())
@@ -1674,14 +1678,12 @@ void Emulator::Run(bool start_playtime)
 
 	ConfigureLogs();
 
-	auto on_select = [](u32, cpu_thread& cpu)
+	// Run main thread
+	idm::check<named_thread<ppu_thread>>(ppu_thread::id_base, [](cpu_thread& cpu)
 	{
 		cpu.state -= cpu_flag::stop;
 		cpu.notify();
-	};
-
-	idm::select<named_thread<ppu_thread>>(on_select);
-	idm::select<named_thread<spu_thread>>(on_select);
+	});
 
 	if (g_cfg.misc.prevent_display_sleep)
 	{

--- a/rpcs3/Loader/ELF.h
+++ b/rpcs3/Loader/ELF.h
@@ -113,7 +113,7 @@ struct elf_prog final : elf_phdr<en_t, sz_t>
 		base::p_vaddr = vaddr;
 		base::p_memsz = memsz;
 		base::p_align = align;
-		base::p_filesz = static_cast<sz_t>(bin.size());
+		base::p_filesz = static_cast<sz_t>(this->bin.size());
 		base::p_paddr = 0;
 		base::p_offset = -1;
 	}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -234,7 +234,9 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 
 	const u32 pc = m_debugger_list->m_pc + i * 4;
 
-	if (QApplication::keyboardModifiers() & Qt::ControlModifier)
+	const auto modifiers = QApplication::keyboardModifiers();
+
+	if (modifiers & Qt::ControlModifier)
 	{
 		switch (event->key())
 		{
@@ -261,7 +263,21 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 			dlg->show();
 			return;
 		}
+		case Qt::Key_S:
+		{
+			if (modifiers & Qt::AltModifier)
+			{
+				const auto cpu = this->cpu.lock();
 
+				if (!cpu || cpu->id_type() == 1)
+				{
+					return;
+				}
+
+				static_cast<spu_thread*>(cpu.get())->capture_local_storage();
+			}
+			return;
+		}
 		case Qt::Key_F10:
 		{
 			DoStep(true);


### PR DESCRIPTION
Press alt+s to capture SPU memory to an executable SPU ELF when selected on the debugger. It even works with Ghidra and it detects functions in it, mostly useful for dumping CellSpurs workloads because they are raw function data with no SPU image.

Other improvements:
* Fixed direct SPU ELF loading (don't start SPU thread in this case).
* Add a bit more info to SPURS kernel explorer.

Implements https://github.com/RPCS3/rpcs3/issues/7317