### PR TITLE
FIX: MAX_PATH is used within Windows headers, we should use a different define internally

### DIFF
--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -692,7 +692,7 @@ bool extract_all_data(const fs::file* input, const fs::file* output, const char*
 		}
 
 		// Perform header validation (EDAT only).
-		char real_file_name[MAX_PATH];
+		char real_file_name[CRYPTO_MAX_PATH];
 		extract_file_name(input_file_name, real_file_name);
 		if (!validate_npd_hashes(real_file_name, devklic, &NPD, verbose))
 		{
@@ -798,7 +798,7 @@ bool VerifyEDATHeaderWithKLicense(const fs::file& input, const std::string& inpu
 	}
 
 	// Perform header validation (EDAT only).
-	char real_file_name[MAX_PATH];
+	char real_file_name[CRYPTO_MAX_PATH];
 	extract_file_name(input_file_name.c_str(), real_file_name);
 	if (!validate_npd_hashes(real_file_name, custom_klic, &NPD, false))
 	{

--- a/rpcs3/Crypto/utils.cpp
+++ b/rpcs3/Crypto/utils.cpp
@@ -121,7 +121,7 @@ void cmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, int in_
 	aes_cmac(&ctx, in_len, in, hash);
 }
 
-char* extract_file_name(const char* file_path, char real_file_name[MAX_PATH])
+char* extract_file_name(const char* file_path, char real_file_name[CRYPTO_MAX_PATH])
 {
 	std::string_view v(file_path);
 
@@ -130,7 +130,7 @@ char* extract_file_name(const char* file_path, char real_file_name[MAX_PATH])
 		v.remove_prefix(pos + 1);
 	}
 
-	gsl::span r(real_file_name, MAX_PATH);
+	gsl::span r(real_file_name, CRYPTO_MAX_PATH);
 	strcpy_trunc(r, v);
 	return real_file_name;
 }

--- a/rpcs3/Crypto/utils.h
+++ b/rpcs3/Crypto/utils.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // Copyright (C) 2014       Hykem <hykem@hotmail.com>
 // Licensed under the terms of the GNU GPL, version 3
@@ -6,13 +6,13 @@
 
 #include "../../Utilities/types.h"
 
-#define MAX_PATH 4096
-
 #include <stdlib.h>
 #include "aes.h"
 #include "sha1.h"
 #include "lz.h"
 #include "ec.h"
+
+enum { CRYPTO_MAX_PATH = 4096 };
 
 // Auxiliary functions (endian swap, xor, and file name).
 inline u16 swap16(u16 i)
@@ -42,7 +42,7 @@ inline u64 swap64(u64 i)
 #endif
 }
 
-char* extract_file_name(const char* file_path, char real_file_name[MAX_PATH]);
+char* extract_file_name(const char* file_path, char real_file_name[CRYPTO_MAX_PATH]);
 
 // Hex string conversion auxiliary functions.
 u64 hex_to_u64(const char* hex_str);


### PR DESCRIPTION
Replace MAX_PATH usage with enum CRYPTO_MAX_PATH, this prevents the redefine warning, and ensures that we don't mess up other usages (which will likely want MAX_PATH as 260, like Windows defines, not 4096 like we do).
The replacement has been done based on what MSVC was telling me the define values were at each point (i.e. whether we wanted it or not, these usages were using our 4906 value, not the 260 value from Windows)