### PR TITLE
SPU: Validate reservation in GET commands (Accurate DMA)

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1434,7 +1434,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 				}
 				}
 
-				if (time0 != vm::reservation_acquire(eal, size0) || (size0 == 128 && !cmp_rdata(*reinterpret_cast<spu_rdata_t*>(dst), *reinterpret_cast<const spu_rdata_t*>(src))))
+				if (time0 != vm::reservation_acquire(eal, size0) || (size0 == 128 && !cmp_rdata(*reinterpret_cast<spu_rdata_t*>(dst0), *reinterpret_cast<const spu_rdata_t*>(src))))
 				{
 					continue;
 				}

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1378,7 +1378,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 					continue;
 				}
 
-				if (ppu.raddr == (eal & -128) && time0 != rtime)
+				if (raddr == (eal & -128) && time0 != rtime)
 				{
 					// Validate rtime for read data
 					set_events(SPU_EVENT_LR);

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1421,7 +1421,7 @@ void spu_thread::do_dma_transfer(const spu_mfc_cmd& args)
 					auto src1 = src;
 					auto size1 = size0;
 
-					while (_size)
+					while (size1)
 					{
 						*reinterpret_cast<v128*>(dst1) = *reinterpret_cast<const v128*>(src1);
 


### PR DESCRIPTION
This originally striked me as I realized PPU accurate 128byte reservation mode does not work properly when there are two or more loads from the same address in the atomic loop. Why? because if one loads reads data X and the other reads data Y, if the reservation data there is X for example, meaning the data was changed twice by other thread (X ->Y ->X) the reservation store can even succeed in this case on rpcs3 although clearly the writes occured and the reservation store should fail in this case.

Now this pr doesnt fix, but it fixes a similar case in SPU side, where someone can use GET inside an atomic loop (essentialy reading the data twice as GETLLAR already read it) so add reservation validation checks there if this case is encountered.

Only affects Accurate SPU DMA as mentioned in the title.