### PR TITLE
PPU: Handle cache line inconsistencies (PPU 128 reservations)

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -2527,10 +2527,13 @@ void PPUTranslator::MFOCRF(ppu_opcode_t op)
 
 void PPUTranslator::LWARX(ppu_opcode_t op)
 {
-	if (g_cfg.core.ppu_128_reservations_loop_max_length > 0)
+	if (g_cfg.core.ppu_128_reservations_loop_max_length)
 	{
-		// CIA will be used in lwarx handler
-		m_ir->CreateStore(Trunc(GetAddr(), GetType<u32>()), m_ir->CreateStructGEP(nullptr, m_thread, static_cast<uint>(&m_cia - m_locals)), true);
+		RegStore(Trunc(GetAddr()), m_cia);
+		FlushRegisters();
+		Call(GetType<void>(), "__resinterp", m_thread)->setTailCallKind(llvm::CallInst::TCK_Tail);
+		m_ir->CreateRetVoid();
+		return;
 	}
 
 	SetGpr(op.rd, Call(GetType<u32>(), "__lwarx", m_thread, op.ra ? m_ir->CreateAdd(GetGpr(op.ra), GetGpr(op.rb)) : GetGpr(op.rb)));
@@ -2669,10 +2672,13 @@ void PPUTranslator::MULHW(ppu_opcode_t op)
 
 void PPUTranslator::LDARX(ppu_opcode_t op)
 {
-	if (g_cfg.core.ppu_128_reservations_loop_max_length > 0)
+	if (g_cfg.core.ppu_128_reservations_loop_max_length)
 	{
-		// CIA will be used in ldarx handler
-		m_ir->CreateStore(Trunc(GetAddr(), GetType<u32>()), m_ir->CreateStructGEP(nullptr, m_thread, static_cast<uint>(&m_cia - m_locals)), true);
+		RegStore(Trunc(GetAddr()), m_cia);
+		FlushRegisters();
+		Call(GetType<void>(), "__resinterp", m_thread)->setTailCallKind(llvm::CallInst::TCK_Tail);
+		m_ir->CreateRetVoid();
+		return;
 	}
 
 	SetGpr(op.rd, Call(GetType<u64>(), "__ldarx", m_thread, op.ra ? m_ir->CreateAdd(GetGpr(op.ra), GetGpr(op.rb)) : GetGpr(op.rb)));


### PR DESCRIPTION
First followup to #9062, on PPU side.
You may need to remove PPU LLVM cache if you played X game with accurate PPU 128 reservations before. (i.e. if you have its cache)