### PR TITLE
Fix ppu_execute<Func> for forced HLE functions

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -530,6 +530,9 @@ static auto ppu_load_exports(ppu_linkage_info* link, u32 exports_start, u32 expo
 					const u32 _entry = vm::read32(faddr);
 					const u32 target = ppu_function_manager::addr + 8 * _sf->index;
 
+					// Set exported function
+					flink.export_addr = target;
+
 					if ((target <= _entry && _entry - target <= 0x2000000) || (target > _entry && target - _entry < 0x2000000))
 					{
 						// Use relative branch


### PR DESCRIPTION
export_addr was 0x0 and caused an access violation in this case, noticed when doing cellSpurs function tests.