### PR TITLE
PPU Debugger: Improve move GPR from/to CR registers instructions

### DIFF
--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -1328,7 +1328,18 @@ void PPUDisAsm::MFOCRF(ppu_opcode_t op)
 {
 	if (op.l11)
 	{
-		DisAsm_R1_IMM("mfocrf", op.rd, op.crm);
+		const u8 crm = static_cast<u8>(op.crm);
+		const int cr = std::countl_zero<u8>(crm);
+
+		if (cr >= 8 || crm & (crm - 1))
+		{
+			// Note: invalid form
+			DisAsm_R1_IMM("mfocrf", op.rd, crm);
+		}
+		else
+		{
+			DisAsm_R1_CR1("mfocrf", op.rd, cr);
+		}
 	}
 	else
 	{
@@ -1495,13 +1506,24 @@ void PPUDisAsm::ADDE(ppu_opcode_t op)
 
 void PPUDisAsm::MTOCRF(ppu_opcode_t op)
 {
-	if (op.l11)
+	const u8 crm = static_cast<u8>(op.crm);
+
+	if (!op.l11 && crm == 0xff)
 	{
-		DisAsm_INT1_R1("mtocrf", op.crm, op.rs);
+		DisAsm_R1("mtcr", op.rs);
+		return;
+	}
+
+	const int cr = std::countl_zero<u8>(crm);
+	const auto name = op.l11 ? "mtocrf" : "mtcrf";
+
+	if (cr >= 8 || crm & (crm - 1))
+	{
+		DisAsm_INT1_R1(name, crm, op.rs);
 	}
 	else
 	{
-		DisAsm_INT1_R1("mtcrf", op.crm, op.rs);
+		DisAsm_CR1_R1(name, cr, op.rs);
 	}
 }
 

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -1529,7 +1529,7 @@ void PPUDisAsm::MTOCRF(ppu_opcode_t op)
 
 void PPUDisAsm::STDX(ppu_opcode_t op)
 {
-	DisAsm_R3("stdx.", op.rs, op.ra, op.rb);
+	DisAsm_R3("stdx", op.rs, op.ra, op.rb);
 }
 
 void PPUDisAsm::STWCX(ppu_opcode_t op)

--- a/rpcs3/Emu/Cell/PPUDisAsm.h
+++ b/rpcs3/Emu/Cell/PPUDisAsm.h
@@ -219,6 +219,14 @@ private:
 	{
 		Write(fmt::format("%s%s cr%d,r%d,r%d", FixOp(op), (rc ? "." : ""), cr0, r0, r1));
 	}
+	void DisAsm_CR1_R1(const std::string& op, u32 cr0, u32 r0)
+	{
+		Write(fmt::format("%s cr%d,r%d", FixOp(op), cr0, r0));
+	}
+	void DisAsm_R1_CR1(const std::string& op, u32 r0, u32 cr0)
+	{
+		Write(fmt::format("%s r%d,cr%d", FixOp(op), r0, cr0));
+	}
 	void DisAsm_CR1_R2(const std::string& op, u32 cr0, u32 r0, u32 r1)
 	{
 		DisAsm_CR1_R2_RC(op, cr0, r0, r1, false);


### PR DESCRIPTION
* Display MTCR mnemonic, when crm is UINT8_MAX.
* When a single bit only is set in crm, display cr field instead of mask. such as `mfocrf r0, cr4` or `mtcrf cr4, r0`.
* STDX does not alter cr0 hence it doesn't need a dot after its name, seems like a typo from STDCX which does need it.