### PR TITLE
SPU: Touch unmapped memory in reservation mismatch

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2176,6 +2176,11 @@ bool spu_thread::do_putllc(const spu_mfc_cmd& args)
 			}
 		}
 
+		if (!vm::check_addr(addr, 1, vm::page_writable))
+		{
+			vm::_ref<atomic_t<u8>>(addr) += 0; // Access violate
+		}
+
 		raddr = 0;
 		return false;
 	}


### PR DESCRIPTION
Do not allow to proceed after an invalid address was passed to PUTLLC, trigger page fault notification for page fault enabled memory.
Similar to how I made PPU do this.