### PR TITLE
vk: Add VK_FORMAT_D32_SFLOAT to format conversion table

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -451,6 +451,7 @@ namespace vk
 			return{ false, 1 };
 			//Depth
 		case VK_FORMAT_D16_UNORM:
+		case VK_FORMAT_D32_SFLOAT:
 			return{ true, 2 };
 		case VK_FORMAT_D32_SFLOAT_S8_UINT:
 		case VK_FORMAT_D24_UNORM_S8_UINT:


### PR DESCRIPTION
- This format is required to emulate RSX_FORMAT_CLASS_D16_FLOAT

Fixes https://github.com/RPCS3/rpcs3/issues/9057