### PR TITLE
libusb: support hotplug

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -565,7 +565,7 @@ const std::array<std::pair<ppu_function_t, std::string_view>, 1024> g_ppu_syscal
 	null_func,//BIND_SYSC(sys_ubsd_...),                    //555 (0x22B)
 	BIND_SYSC(sys_usbd_get_device_speed),                   //556 (0x22C)
 	null_func,//BIND_SYSC(sys_ubsd_...),                    //557 (0x22D)
-	null_func,//BIND_SYSC(sys_ubsd_...),                    //558 (0x22E)
+	BIND_SYSC(sys_usbd_unregister_extra_ldd),               //558 (0x22E)
 	BIND_SYSC(sys_usbd_register_extra_ldd),                 //559 (0x22F)
 	null_func,//BIND_SYSC(sys_...),                         //560 (0x230)  ROOT
 	null_func,//BIND_SYSC(sys_...),                         //561 (0x231)  ROOT

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.h
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.h
@@ -32,6 +32,13 @@ enum SysUsbdEvents : u32
 	SYS_USBD_TERMINATE         = 0x04,
 };
 
+enum SysUsbdSpeed : u8
+{
+	SYS_USBD_DEVICE_SPEED_LS  = 0x00,
+	SYS_USBD_DEVICE_SPEED_FS  = 0x01,
+	SYS_USBD_DEVICE_SPEED_HS  = 0x02,
+};
+
 // PS3 internal structures
 struct UsbInternalDevice
 {
@@ -64,21 +71,22 @@ error_code sys_usbd_get_device_list(u32 handle, vm::ptr<UsbInternalDevice> devic
 error_code sys_usbd_get_descriptor_size(u32 handle, u32 device_handle);
 error_code sys_usbd_get_descriptor(u32 handle, u32 device_handle, vm::ptr<void> descriptor, u32 desc_size);
 error_code sys_usbd_register_ldd(u32 handle, vm::ptr<char> s_product, u16 slen_product);
-error_code sys_usbd_unregister_ldd();
+error_code sys_usbd_unregister_ldd(u32 handle, vm::ptr<char> s_product, u16 slen_product);
 error_code sys_usbd_open_pipe(u32 handle, u32 device_handle, u32 unk1, u64 unk2, u64 unk3, u32 endpoint, u64 unk4);
 error_code sys_usbd_open_default_pipe(u32 handle, u32 device_handle);
 error_code sys_usbd_close_pipe(u32 handle, u32 pipe_handle);
 error_code sys_usbd_receive_event(ppu_thread& ppu, u32 handle, vm::ptr<u64> arg1, vm::ptr<u64> arg2, vm::ptr<u64> arg3);
-error_code sys_usbd_detect_event();
+error_code sys_usbd_detect_event(u32 handle);
 error_code sys_usbd_attach(u32 handle);
 error_code sys_usbd_transfer_data(u32 handle, u32 id_pipe, vm::ptr<u8> buf, u32 buf_size, vm::ptr<UsbDeviceRequest> request, u32 type_transfer);
 error_code sys_usbd_isochronous_transfer_data(u32 handle, u32 id_pipe, vm::ptr<UsbDeviceIsoRequest> iso_request);
 error_code sys_usbd_get_transfer_status(u32 handle, u32 id_transfer, u32 unk1, vm::ptr<u32> result, vm::ptr<u32> count);
 error_code sys_usbd_get_isochronous_transfer_status(u32 handle, u32 id_transfer, u32 unk1, vm::ptr<UsbDeviceIsoRequest> request, vm::ptr<u32> result);
-error_code sys_usbd_get_device_location();
-error_code sys_usbd_send_event();
+error_code sys_usbd_get_device_location(u32 handle, u32 device_handle, vm::ptr<u8> location);
+error_code sys_usbd_send_event(u32 handle);
 error_code sys_usbd_event_port_send(u32 handle, u64 arg1, u64 arg2, u64 arg3);
-error_code sys_usbd_allocate_memory();
-error_code sys_usbd_free_memory();
-error_code sys_usbd_get_device_speed();
+error_code sys_usbd_allocate_memory(u32 handle, vm::pptr<void> ptr, size_t size);
+error_code sys_usbd_free_memory(u32 handle, vm::ptr<void> ptr);
+error_code sys_usbd_get_device_speed(u32 handle, u32 device_handle, vm::ptr<u8> speed);
 error_code sys_usbd_register_extra_ldd(u32 handle, vm::ptr<char> s_product, u16 slen_product, u16 id_vendor, u16 id_product_min, u16 id_product_max);
+error_code sys_usbd_unregister_extra_ldd(u32 handle, vm::ptr<char> s_product, u16 slen_product);

--- a/rpcs3/Emu/Io/GHLtar.cpp
+++ b/rpcs3/Emu/Io/GHLtar.cpp
@@ -3,13 +3,15 @@
 #include "stdafx.h"
 #include "GHLtar.h"
 #include "Emu/Cell/lv2/sys_usbd.h"
+#include "Emu/system_config.h"
 #include "Input/pad_thread.h"
 
 LOG_CHANNEL(ghltar_log);
 
-usb_device_ghltar::usb_device_ghltar()
+usb_device_ghltar_emu::usb_device_ghltar_emu() : usb_device_emulated("Emulated USB Guitar Hero Live Guitar")
 {
-	device        = UsbDescriptorNode(USB_DESCRIPTOR_DEVICE, UsbDeviceDescriptor{0x0200, 0x00, 0x00, 0x00, 0x20, 0x12BA, 0x074B, 0x0100, 0x01, 0x02, 0x00, 0x01});
+	instance_num  = claim_next_available_instance_num();
+	device        = UsbDescriptorNode(USB_DESCRIPTOR_DEVICE, UsbDeviceDescriptor{0x0200, 0x00, 0x00, 0x00, 0x20, 0x12BA, 0x074B, 0x0100, 0x01, 0x02, instance_num, 0x01});
 	auto& config0 = device.add_node(UsbDescriptorNode(USB_DESCRIPTOR_CONFIG, UsbDeviceConfiguration{0x0029, 0x01, 0x01, 0x00, 0x80, 0x96}));
 	config0.add_node(UsbDescriptorNode(USB_DESCRIPTOR_INTERFACE, UsbDeviceInterface{0x00, 0x00, 0x02, 0x03, 0x00, 0x00, 0x00}));
 	config0.add_node(UsbDescriptorNode(USB_DESCRIPTOR_HID, UsbDeviceHID{0x0111, 0x00, 0x01, 0x22, 0x001d}));
@@ -17,11 +19,24 @@ usb_device_ghltar::usb_device_ghltar()
 	config0.add_node(UsbDescriptorNode(USB_DESCRIPTOR_ENDPOINT, UsbDeviceEndpoint{0x01, 0x03, 0x0020, 0x01}));
 }
 
-usb_device_ghltar::~usb_device_ghltar()
+usb_device_ghltar_emu::~usb_device_ghltar_emu()
 {
+	release_instance_num(instance_num);
 }
 
-void usb_device_ghltar::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)
+std::shared_ptr<usb_device> usb_device_ghltar_emu::make_instance()
+{
+	return std::make_shared<usb_device_ghltar_emu>();
+}
+
+u16 usb_device_ghltar_emu::get_num_emu_devices()
+{
+	//TODO: we should really support more than just one Guitar Hero Live guitar
+	// but at the moment this is just an enable / disable boolean we (implicitly) cast to an int
+	return g_cfg.io.ghltar_emulate.get();
+}
+
+void usb_device_ghltar_emu::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)
 {
 	transfer->fake = true;
 
@@ -45,7 +60,7 @@ void usb_device_ghltar::control_transfer(u8 bmRequestType, u8 bRequest, u16 wVal
 	}
 }
 
-void usb_device_ghltar::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer)
+void usb_device_ghltar_emu::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer)
 {
 	transfer->fake            = true;
 	transfer->expected_count  = buf_size;

--- a/rpcs3/Emu/Io/GHLtar.h
+++ b/rpcs3/Emu/Io/GHLtar.h
@@ -2,12 +2,18 @@
 
 #include "Emu/Io/usb_device.h"
 
-class usb_device_ghltar : public usb_device_emulated
+class usb_device_ghltar_emu : public usb_device_emulated
 {
 public:
-	usb_device_ghltar();
-	~usb_device_ghltar();
+	usb_device_ghltar_emu();
+	~usb_device_ghltar_emu();
+
+	static std::shared_ptr<usb_device> make_instance();
 
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
+	static u16 get_num_emu_devices();
+private:
+	u8 instance_num;
+	static u32 emulated_instances; // bit field for currently existing instances of emulated devices
 };

--- a/rpcs3/Emu/Io/Skylander.h
+++ b/rpcs3/Emu/Io/Skylander.h
@@ -17,16 +17,21 @@ struct sky_portal
 
 extern sky_portal g_skylander;
 
-class usb_device_skylander : public usb_device_emulated
+class usb_device_skylander_emu : public usb_device_emulated
 {
 public:
-	usb_device_skylander();
-	~usb_device_skylander();
+	usb_device_skylander_emu();
+	~usb_device_skylander_emu();
+
+	static std::shared_ptr<usb_device> make_instance();
 
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
-
+	static u16 get_num_emu_devices();
 protected:
 	u8 interrupt_counter = 0;
 	std::queue<std::array<u8, 32>> q_queries;
+private:
+	u8 instance_num;
+	static u32 emulated_instances; // bit field for currently existing instances of emulated devices
 };

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -245,6 +245,8 @@ struct cfg_root : cfg::node
 		cfg::_enum<camera_handler> camera{ this, "Camera", camera_handler::null };
 		cfg::_enum<fake_camera_type> camera_type{ this, "Camera type", fake_camera_type::unknown };
 		cfg::_enum<move_handler> move{ this, "Move", move_handler::null };
+		cfg::_bool ghltar_emulate{ this, "Guitar Hero Live", false, true };
+		cfg::_bool skylander_emulate{ this, "Skylander", false, true };
 	} io{ this };
 
 	struct node_sys : cfg::node

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -114,6 +114,8 @@ enum class emu_settings_type
 	Camera,
 	CameraType,
 	Move,
+	GHLtarEmulate,
+	SkylanderEmulate,
 
 	// Misc
 	ExitRPCS3OnFinish,
@@ -252,11 +254,13 @@ static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::MicrophoneDevices,       { "Audio", "Microphone Devices" }},
 
 	// Input / Output
-	{ emu_settings_type::KeyboardHandler, { "Input/Output", "Keyboard"}},
-	{ emu_settings_type::MouseHandler,    { "Input/Output", "Mouse"}},
-	{ emu_settings_type::Camera,          { "Input/Output", "Camera"}},
-	{ emu_settings_type::CameraType,      { "Input/Output", "Camera type"}},
-	{ emu_settings_type::Move,            { "Input/Output", "Move" }},
+	{ emu_settings_type::KeyboardHandler,  { "Input/Output", "Keyboard"}},
+	{ emu_settings_type::MouseHandler,     { "Input/Output", "Mouse"}},
+	{ emu_settings_type::Camera,           { "Input/Output", "Camera"}},
+	{ emu_settings_type::CameraType,       { "Input/Output", "Camera type"}},
+	{ emu_settings_type::Move,             { "Input/Output", "Move" }},
+	{ emu_settings_type::GHLtarEmulate,    { "Input/Output", "Guitar Hero Live"}},
+	{ emu_settings_type::SkylanderEmulate, { "Input/Output", "Skylander"}},
 
 	// Misc
 	{ emu_settings_type::ExitRPCS3OnFinish,         { "Miscellaneous", "Exit RPCS3 when process finishes" }},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -821,6 +821,13 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceComboBox(ui->moveBox, emu_settings_type::Move);
 	SubscribeTooltip(ui->gb_move_handler, tooltips.settings.move);
 
+	m_emu_settings->EnhanceCheckBox(ui->ghltarEmulateBox, emu_settings_type::GHLtarEmulate);
+	SubscribeTooltip(ui->gb_ghltar_emulate, tooltips.settings.ghltar_emu);
+
+	m_emu_settings->EnhanceCheckBox(ui->skylanderEmulateBox, emu_settings_type::SkylanderEmulate);
+	SubscribeTooltip(ui->gb_skylander_emulate, tooltips.settings.skylander_emu);
+
+
 	//     _____           _                   _______    _
 	//    / ____|         | |                 |__   __|  | |
 	//   | (___  _   _ ___| |_ ___ _ __ ___      | | __ _| |__

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1264,7 +1264,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="inputTab_layout">
        <item>
-        <layout class="QHBoxLayout" name="inputTabLayoutTop" stretch="1,1,1">
+        <layout class="QHBoxLayout" name="inputTabLayout1" stretch="1,1,1">
          <item>
           <widget class="QGroupBox" name="gb_keyboard_handler">
            <property name="title">
@@ -1304,7 +1304,7 @@
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="inputTabLayoutBottom" stretch="1,1,1">
+        <layout class="QHBoxLayout" name="inputTabLayout2" stretch="1,1,1">
          <item>
           <widget class="QGroupBox" name="gb_mouse_handler">
            <property name="title">
@@ -1331,6 +1331,45 @@
          </item>
          <item>
           <widget class="QWidget" name="inputTabSpacerWidget" native="true"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="inputTabLayout3" stretch="1,1,1">
+         <item>
+          <widget class="QGroupBox" name="gb_ghltar_emulate">
+           <property name="title">
+            <string>Guitar Hero Live Guitar Emulate</string>
+           </property>
+           <layout class="QVBoxLayout" name="gb_mouse_handler_layout_2">
+            <item>
+             <widget class="QCheckBox" name="ghltarEmulateBox">
+              <property name="text">
+               <string>Emulate Device</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="gb_skylander_emulate">
+           <property name="title">
+            <string>Skylander Emulate</string>
+           </property>
+           <layout class="QVBoxLayout" name="gb_camera_setting_layout_2">
+            <item>
+             <widget class="QCheckBox" name="skylanderEmulateBox">
+              <property name="text">
+               <string>Emulate Device</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="inputTabSpacerWidget_2" native="true"/>
          </item>
         </layout>
        </item>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -181,6 +181,8 @@ public:
 		const QString camera            = tr("Camera support is not implemented, leave this on null.");
 		const QString camera_type       = tr("Camera support is not implemented, leave this on unknown.");
 		const QString move              = tr("PlayStation Move support.\nFake: Experimental! This maps Move controls to DS3 controller mappings.\nMouse: Emulate PSMove with Mouse handler.");
+		const QString ghltar_emu        = tr("Emulate Guitar Hero Live Guitar.\nIf checked, emulated device will be present.\nIf unchecked, emulated device will not be present.");
+		const QString skylander_emu     = tr("Emulate Skylander Portal.\nIf checked, emulated device will be present.\nIf unchecked, emulated device will not be present.");
 
 		// network
 


### PR DESCRIPTION
Hotplug events in libusb aren't supported in Windows or FreeBSD at this time.
So have implemented this as a periodic scan of USB devices for a change.

- migrated from lambda calls to const whitelist structure, and have merged the emulation aspect into this
- have added the framework to have several emulated devices included, not just one such device. However there is still work left for this.
- added syscall for unregister_extra_ldd
- added additional arguments for other sysusbd syscalls
- tidied up the libusb device handling, so that we release interfaces that we've claimed, and cancel transfers before terminating
- added string name to USB devices to allow for easier tracking of which devices are loaded
- renamed usb_device_skylander -> usb_device_skylander_emu to better represent that it is emulated
- renamed usb_device_ghltar -> usb_device_ghltar_emu to better represent that it is emulated

Fixes #9071