### PR TITLE
SPU Debugger Improvements: Add MR mnemonics, constants propagation and more

### DIFF
--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -61,6 +61,13 @@ protected:
 	static std::string SignedHex(T value)
 	{
 		const auto v = static_cast<std::make_signed_t<T>>(value);
+
+		if (v == std::numeric_limits<std::make_signed_t<T>>::min())
+		{
+			// for INTx_MIN
+			return fmt::format("-0x%x", v);
+		}
+
 		const auto av = std::abs(v);
 
 		if (av < 10)

--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -1,11 +1,179 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "SPUDisAsm.h"
+#include "SPUAnalyser.h"
+#include "SPUThread.h"
 
 constexpr spu_decoder<SPUDisAsm> s_spu_disasm;
+constexpr spu_decoder<spu_itype> s_spu_itype;
+constexpr spu_decoder<spu_iflag> s_spu_iflag;
 
 u32 SPUDisAsm::disasm(u32 pc)
 {
 	const u32 op = *reinterpret_cast<const be_t<u32>*>(offset + pc);
 	(this->*(s_spu_disasm.decode(op)))({ op });
 	return 4;
+}
+
+std::pair<bool, v128> SPUDisAsm::try_get_const_value(u32 reg, u32 pc) const
+{
+	if (pc == umax)
+	{
+		pc = dump_pc;
+	}
+
+	// Scan LS backwards from this instruction (until PC=0)
+	// Search for the first register modification or branch instruction
+
+	for (s32 i = pc - 4; i >= 0; i -= 4)
+	{
+		const u32 opcode = *reinterpret_cast<const be_t<u32>*>(offset + i);
+		const spu_opcode_t op0{ opcode };
+
+		const auto type = s_spu_itype.decode(opcode);
+
+		if (type & spu_itype::branch || type == spu_itype::UNK || !opcode)
+		{
+			return {};
+		}
+
+		const auto flag = s_spu_iflag.decode(opcode);
+
+		// TODO: It detects spurious register modifications
+		if (u32 dst = type & spu_itype::_quadrop ? +op0.rt4 : +op0.rt; dst == reg)
+		{
+			// Note: It's not 100% reliable because it won't detect branch targets within [i, dump_pc] range (e.g. if-else statement for command's value)
+			switch (type)
+			{
+			case spu_itype::IL:
+			{
+				return { true, v128::from32p(op0.si16) };
+			}
+			case spu_itype::ILA:
+			{
+				return { true, v128::from32p(op0.i18) };
+			}
+			case spu_itype::ILHU:
+			{
+				return { true, v128::from32p(op0.i16 << 16) };
+			}
+			case spu_itype::FSMBI:
+			{
+				v128 res;
+
+				for (s32 i = 0; i < 16; i++)
+				{
+					res._u8[i] = (op0.i16 & (1 << i)) ? 0xFF : 0x00; 
+				}
+
+				return { true, res };
+			}
+			case spu_itype::IOHL:
+			{
+				// Avoid multi-recursion for now
+				if (dump_pc != pc)
+				{
+					return {};
+				}
+
+				if (i >= 4)
+				{
+					// Search for ILHU+IOHL pattern (common pattern for 32-bit constants formation)
+					// But don't limit to it
+					const auto [is_const, value] = try_get_const_value(reg, i);
+
+					if (is_const)
+					{
+						return { true, value | v128::from32p(op0.i16) };
+					}
+				}
+
+				return {};
+			}
+			case spu_itype::STQA:
+			case spu_itype::STQD:
+			case spu_itype::STQR:
+			case spu_itype::STQX:
+			case spu_itype::WRCH:
+			{
+				// Do not modify RT
+				break;
+			}
+			default: return {};
+			}
+		}
+	}
+
+	return {};
+}
+
+void SPUDisAsm::WRCH(spu_opcode_t op)
+{
+	const auto [is_const, value] = try_get_const_value(op.rt);
+
+	if (is_const)
+	{
+		switch (op.ra)
+		{
+		case MFC_Cmd:
+		{
+			DisAsm("wrch", spu_ch_name[op.ra], fmt::format("%s #%s", spu_reg_name[op.rt], MFC(value._u8[12])).c_str());
+			return;
+		}
+		case MFC_WrListStallAck:
+		case MFC_WrTagMask:
+		{
+			const u32 v = value._u32[3];
+			if (v && !(v & (v - 1)))
+				DisAsm("wrch", spu_ch_name[op.ra], fmt::format("%s #%s (tag=%u)", spu_reg_name[op.rt], SignedHex(v), std::countr_zero(v)).c_str()); // Single-tag mask
+			else
+				DisAsm("wrch", spu_ch_name[op.ra], fmt::format("%s #%s", spu_reg_name[op.rt], SignedHex(v)).c_str()); // Multi-tag mask (or zero)
+			return;
+		}
+		case MFC_EAH:
+		{
+			DisAsm("wrch", spu_ch_name[op.ra], fmt::format("%s #%s", spu_reg_name[op.rt], SignedHex(value._u32[3])).c_str());
+			return;
+		}
+		case MFC_Size:
+		{
+			DisAsm("wrch", spu_ch_name[op.ra], fmt::format("%s #%s", spu_reg_name[op.rt], SignedHex(value._u16[6])).c_str());
+			return;
+		}
+		case MFC_TagID:
+		{
+			DisAsm("wrch", spu_ch_name[op.ra], fmt::format("%s #%u", spu_reg_name[op.rt], value._u8[12]).c_str());
+			return;
+		}
+		case MFC_WrTagUpdate:
+		{
+			const auto upd = fmt::format("%s", mfc_tag_update(value._u32[3]));
+			DisAsm("wrch", spu_ch_name[op.ra], fmt::format("%s #%s", spu_reg_name[op.rt], upd == "empty" ? "IMMEDIATE" : upd).c_str());
+			return;
+		}
+		default:
+		{
+			DisAsm("wrch", spu_ch_name[op.ra], fmt::format("%s #%s", spu_reg_name[op.rt], SignedHex(value._u32[3])).c_str());
+			return;
+		}
+		}
+	}
+
+	DisAsm("wrch", spu_ch_name[op.ra], spu_reg_name[op.rt]);
+}
+
+void SPUDisAsm::IOHL(spu_opcode_t op)
+{
+	const auto [is_const, value] = try_get_const_value(op.rt);
+
+	if (is_const)
+	{
+		// Only print constant for a 4 equal 32-bit constants array
+		if (value == v128::from32p(value._u32[0]))
+		{
+			DisAsm("iohl", spu_reg_name[op.rt], fmt::format("%s #%s", SignedHex(+op.i16), (value._u32[0] | op.i16)).c_str());
+			return;
+		}
+	}
+
+	DisAsm("iohl", spu_reg_name[op.rt], op.i16);
 }

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -157,6 +157,7 @@ private:
 
 public:
 	u32 disasm(u32 pc) override;
+	std::pair<bool, v128> try_get_const_value(u32 reg, u32 pc = -1) const;
 
 	//0 - 10
 	void STOP(spu_opcode_t op)
@@ -303,10 +304,9 @@ public:
 	{
 		DisAsm("mtspr", spu_spreg_name[op.ra], spu_reg_name[op.rt]);
 	}
-	void WRCH(spu_opcode_t op)
-	{
-		DisAsm("wrch", spu_ch_name[op.ra], spu_reg_name[op.rt]);
-	}
+
+	void WRCH(spu_opcode_t op);
+
 	void BIZ(spu_opcode_t op)
 	{
 		DisAsm("biz", op.de, spu_reg_name[op.rt], spu_reg_name[op.ra]);
@@ -810,10 +810,8 @@ public:
 	{
 		DisAsm("ilh", spu_reg_name[op.rt], op.i16);
 	}
-	void IOHL(spu_opcode_t op)
-	{
-		DisAsm("iohl", spu_reg_name[op.rt], op.i16);
-	}
+
+	void IOHL(spu_opcode_t op);
 
 	//0 - 7
 	void ORI(spu_opcode_t op)

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -481,6 +481,13 @@ public:
 	}
 	void SHLQBYI(spu_opcode_t op)
 	{
+		if (!op.si7)
+		{
+			// Made-up mnemonic: as MR on PPU
+			DisAsm("mr", spu_reg_name[op.rt], spu_reg_name[op.ra]);
+			return;
+		}
+
 		DisAsm("shlqbyi", spu_reg_name[op.rt], spu_reg_name[op.ra], op.si7);
 	}
 	void NOP(spu_opcode_t op)
@@ -811,6 +818,13 @@ public:
 	//0 - 7
 	void ORI(spu_opcode_t op)
 	{
+		if (!op.si10)
+		{
+			// Made-up mnemonic: as MR on PPU
+			DisAsm("mr", spu_reg_name[op.rt], spu_reg_name[op.ra]);
+			return;
+		}
+
 		DisAsm("ori", spu_reg_name[op.rt], spu_reg_name[op.ra], op.si10);
 	}
 	void ORHI(spu_opcode_t op)

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2473,7 +2473,7 @@ bool spu_thread::process_mfc_cmd()
 	}
 
 	spu::scheduler::concurrent_execution_watchdog watchdog(*this);
-	spu_log.trace("DMAC: [%s]", ch_mfc_cmd);
+	spu_log.trace("DMAC: (%s)", ch_mfc_cmd);
 
 	switch (ch_mfc_cmd.cmd)
 	{
@@ -2848,7 +2848,7 @@ void spu_thread::set_interrupt_status(bool enable)
 
 u32 spu_thread::get_ch_count(u32 ch)
 {
-	spu_log.trace("get_ch_count(ch=%d [%s])", ch, ch < 128 ? spu_ch_name[ch] : "???");
+	if (ch < 128) spu_log.trace("get_ch_count(ch=%s)", spu_ch_name[ch]);
 
 	switch (ch)
 	{
@@ -2889,13 +2889,13 @@ u32 spu_thread::get_ch_count(u32 ch)
 	}
 
 	verify(HERE), ch < 128u;
-	spu_log.error("Unknown/illegal channel in RCHCNT (ch=%d [%s])", ch, spu_ch_name[ch]);
+	spu_log.error("Unknown/illegal channel in RCHCNT (ch=%s)", spu_ch_name[ch]);
 	return 0; // Default count
 }
 
 s64 spu_thread::get_ch_value(u32 ch)
 {
-	spu_log.trace("get_ch_value(ch=%d [%s])", ch, ch < 128 ? spu_ch_name[ch] : "???");
+	if (ch < 128) spu_log.trace("get_ch_value(ch=%s)", spu_ch_name[ch]);
 
 	auto read_channel = [&](spu_channel& channel) -> s64
 	{
@@ -3090,7 +3090,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 
 bool spu_thread::set_ch_value(u32 ch, u32 value)
 {
-	spu_log.trace("set_ch_value(ch=%d [%s], value=0x%x)", ch, ch < 128 ? spu_ch_name[ch] : "???", value);
+	if (ch < 128) spu_log.trace("set_ch_value(ch=%s, value=0x%x)", spu_ch_name[ch], value);
 
 	switch (ch)
 	{

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -136,16 +136,13 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 	{
 		if (const auto cpu = this->cpu.lock())
 		{
-			if (m_btn_run->text() == RunString && cpu->state.test_and_reset(cpu_flag::dbg_pause))
+			// Alter dbg_pause bit state (disable->enable, enable->disable)
+			const auto old = cpu->state.xor_fetch(cpu_flag::dbg_pause);
+
+			// Notify only if no pause flags are set after this change
+			if (!(old & (cpu_flag::dbg_pause + cpu_flag::dbg_global_pause)))
 			{
-				if (!(cpu->state & (cpu_flag::dbg_pause + cpu_flag::dbg_global_pause)))
-				{
-					cpu->notify();
-				}
-			}
-			else
-			{
-				cpu->state += cpu_flag::dbg_pause;
+				cpu->notify();
 			}
 		}
 		UpdateUI();

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -352,6 +352,8 @@ void debugger_frame::UpdateUI()
 	}
 }
 
+Q_DECLARE_METATYPE(std::weak_ptr<cpu_thread>);
+
 void debugger_frame::UpdateUnitList()
 {
 	const u64 threads_created = cpu_thread::g_threads_created;
@@ -373,9 +375,11 @@ void debugger_frame::UpdateUnitList()
 	m_choice_units->clear();
 	m_choice_units->addItem(NoThreadString);
 
-	const auto on_select = [&](u32, cpu_thread& cpu)
+	const auto on_select = [&](u32 id, cpu_thread& cpu)
 	{
-		QVariant var_cpu = QVariant::fromValue<void*>(&cpu);
+		QVariant var_cpu = QVariant::fromValue<std::weak_ptr<cpu_thread>>(
+			id >> 24 == 1 ? static_cast<std::weak_ptr<cpu_thread>>(idm::get_unlocked<named_thread<ppu_thread>>(id)) : idm::get_unlocked<named_thread<spu_thread>>(id));
+
 		m_choice_units->addItem(qstr(cpu.get_name()), var_cpu);
 		if (old_cpu == var_cpu) m_choice_units->setCurrentIndex(m_choice_units->count() - 1);
 	};
@@ -405,21 +409,24 @@ void debugger_frame::OnSelectUnit()
 
 	if (!m_no_thread_selected)
 	{
-		const auto on_select = [&](u32, cpu_thread& cpu)
+		if (const auto cpu0 = m_choice_units->currentData().value<std::weak_ptr<cpu_thread>>().lock())
 		{
-			cpu_thread* data = static_cast<cpu_thread*>(m_choice_units->currentData().value<void*>());
-			return data == &cpu;
-		};
-
-		if (auto ppu = idm::select<named_thread<ppu_thread>>(on_select))
-		{
-			m_disasm = std::make_unique<PPUDisAsm>(CPUDisAsm_InterpreterMode);
-			cpu = ppu.ptr;
-		}
-		else if (auto spu1 = idm::select<named_thread<spu_thread>>(on_select))
-		{
-			m_disasm = std::make_unique<SPUDisAsm>(CPUDisAsm_InterpreterMode);
-			cpu = spu1.ptr;
+			if (cpu0->id_type() == 1)
+			{
+				if (cpu0.get() == idm::check<named_thread<ppu_thread>>(cpu0->id))
+				{
+					cpu = cpu0;
+					m_disasm = std::make_unique<PPUDisAsm>(CPUDisAsm_InterpreterMode);
+				}
+			}
+			else
+			{
+				if (cpu0.get() == idm::check<named_thread<spu_thread>>(cpu0->id))
+				{
+					cpu = cpu0;
+					m_disasm = std::make_unique<SPUDisAsm>(CPUDisAsm_InterpreterMode);
+				}
+			}
 		}
 	}
 

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -571,8 +571,8 @@ void kernel_explorer::Update()
 					};
 
 					const auto& winfo = spurs.wklInfo(wid);
-					add_leaf(wkl_tree, qstr(fmt::format("Contention: %u/%u (pending: %u), Image: *0x%x (size: 0x%x), Priority (BE64): %016x", contention(spurs.wklCurrentContention[wid % 16])
-						, contention(spurs.wklMaxContention[wid % 16]), contention(spurs.wklPendingContention[wid % 16]), +winfo.addr, winfo.size, std::bit_cast<be_t<u64>>(winfo.priority))));
+					add_leaf(wkl_tree, qstr(fmt::format("Contention: %u/%u (pending: %u), Image: *0x%x (size: 0x%x, arg: 0x%x), Priority (BE64): %016x", contention(spurs.wklCurrentContention[wid % 16])
+						, contention(spurs.wklMaxContention[wid % 16]), contention(spurs.wklPendingContention[wid % 16]), +winfo.addr, winfo.size, winfo.arg, std::bit_cast<be_t<u64>>(winfo.priority))));
 				}
 
 				add_leaf(spurs_tree, qstr(fmt::format("Handler Info: PPU0: 0x%x, PPU1: 0x%x, DirtyState: %u, Waiting: %u, Exiting: %u", spurs.ppu0, spurs.ppu1


### PR DESCRIPTION
* Add made-up MR mnemonic for [ORI x, y, 0] and [SHLQBYI x, y, 0] instructions. MR as in "move register" as the PowerPC mnemonic.
* Optimize debugger thread context update a bit by not iterating over all CELL threads, only the single relevant thread ID to us.
* Detect simple constant command propagation in WRCH and a few more instructoios which should work in most of the cases.
* Add SPURS workload argument in kernel-explorer.
* Cleanup SPU channels logging. (rely entirely on spu_ch_name)
* Fix bug in CPUDisAsm::SignedHex regarding INTx_MIN.