### PR TITLE
Revert "Fix debug build gcc/clang linker."

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -19,11 +19,8 @@ sys_vm_t::sys_vm_t(u32 _addr, u32 vsize, lv2_memory_container* ct, u32 psize)
 
 sys_vm_t::~sys_vm_t()
 {
-	// Debug build : gcc and clang can not find the static var if retrieved directly in "release" function
-	constexpr auto invalid = id_manager::id_traits<sys_vm_t>::invalid;
-
 	// Free ID
-	g_ids[addr >> 28].release(invalid);
+	g_ids[addr >> 28].release(id_manager::id_traits<sys_vm_t>::invalid);
 }
 
 LOG_CHANNEL(sys_vm);


### PR DESCRIPTION
This reverts commit 4599d5841353fdf8096191c30a592fedc844efce.

The issue this works around was fixed in 3265772 ("idm: Implement
creation/destruction invalidation counter") by making the variables
constexpr.

Fixes #6896