### PR TITLE
Vm and atomic improvements

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1970,7 +1970,7 @@ bool thread_base::finalize(thread_state result_state) noexcept
 
 void thread_base::finalize() noexcept
 {
-	atomic_storage_futex::set_wait_callback([](const void*){ return true; });
+	atomic_storage_futex::set_wait_callback(nullptr);
 	g_tls_log_prefix = []() -> std::string { return {}; };
 	thread_ctrl::g_tls_this_thread = nullptr;
 }

--- a/Utilities/VirtualMemory.h
+++ b/Utilities/VirtualMemory.h
@@ -81,5 +81,8 @@ namespace utils
 		{
 			return m_flags;
 		}
+
+		// Another userdata
+		u64 info = 0;
 	};
 }

--- a/Utilities/cond.cpp
+++ b/Utilities/cond.cpp
@@ -12,7 +12,7 @@ void cond_variable::imp_wait(u32 _old, u64 _timeout) noexcept
 	verify(HERE), _old;
 
 	// Wait with timeout
-	m_value.wait<c_signal_mask>(_old, atomic_wait_timeout{_timeout > max_timeout ? UINT64_MAX : _timeout * 1000});
+	m_value.wait(_old, c_signal_mask, atomic_wait_timeout{_timeout > max_timeout ? UINT64_MAX : _timeout * 1000});
 
 	// Cleanup
 	m_value.atomic_op([](u32& value)

--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -304,6 +304,11 @@ struct alignas(16) u128
 	{
 	}
 
+	constexpr explicit operator bool() const noexcept
+	{
+		return !!(lo | hi);
+	}
+
 	friend u128 operator+(const u128& l, const u128& r)
 	{
 		u128 value;
@@ -381,6 +386,28 @@ struct alignas(16) u128
 	{
 		u128 value = *this;
 		_subborrow_u64(_subborrow_u64(0, 1, lo, &lo), 0, hi, &hi);
+		return value;
+	}
+
+	u128 operator<<(u128 shift_value)
+	{
+		const u64 v0 = lo << (shift_value.lo & 63);
+		const u64 v1 = __shiftleft128(lo, hi, shift_value.lo);
+
+		u128 value;
+		value.lo = (shift_value.lo & 64) ? 0 : v0;
+		value.hi = (shift_value.lo & 64) ? v0 : v1;
+		return value;
+	}
+
+	u128 operator>>(u128 shift_value)
+	{
+		const u64 v0 = hi >> (shift_value.lo & 63);
+		const u64 v1 = __shiftright128(lo, hi, shift_value.lo);
+
+		u128 value;
+		value.lo = (shift_value.lo & 64) ? v0 : v1;
+		value.hi = (shift_value.lo & 64) ? 0 : v0;
 		return value;
 	}
 

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -339,10 +339,6 @@ target_link_libraries(rpcs3_emu
 	PRIVATE
 		3rdparty::stblib 3rdparty::libpng)
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-	target_link_libraries(rpcs3_emu PUBLIC -latomic)
-endif()
-
 
 # CPU
 target_sources(rpcs3_emu PRIVATE

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1378,10 +1378,14 @@ const auto ppu_stcx_accurate_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime
 
 	// Begin transaction
 	Label tx0 = build_transaction_enter(c, fall, x86::r12d, 4);
+	c.bt(x86::dword_ptr(args[2], ::offset32(&spu_thread::state) - ::offset32(&ppu_thread::rdata)), static_cast<u32>(cpu_flag::pause));
+	c.mov(x86::eax, _XABORT_EXPLICIT);
+	c.jc(fall);
 	c.xbegin(tx0);
 	c.mov(x86::rax, x86::qword_ptr(x86::rbx));
-	c.test(x86::eax, 127);
+	c.test(x86::eax, vm::rsrv_unique_lock);
 	c.jnz(skip);
+	c.and_(x86::rax, -128);
 	c.cmp(x86::rax, x86::r13);
 	c.jne(fail);
 
@@ -1471,19 +1475,19 @@ const auto ppu_stcx_accurate_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime
 	Label fall2 = c.newLabel();
 	Label fail2 = c.newLabel();
 	Label fail3 = c.newLabel();
+	Label fail4 = c.newLabel();
 
 	// Lightened transaction: only compare and swap data
 	c.bind(next);
 
 	// Try to "lock" reservation
-	c.mov(x86::eax, 1);
-	c.lock().xadd(x86::qword_ptr(x86::rbx), x86::rax);
-	c.test(x86::eax, vm::rsrv_unique_lock);
-	c.jnz(fall2);
-
-	// Allow only first shared lock to proceed
+	c.mov(x86::rax, x86::qword_ptr(x86::rbx));
+	c.and_(x86::r13, -128);
 	c.cmp(x86::rax, x86::r13);
 	c.jne(fail2);
+	c.add(x86::r13, vm::rsrv_unique_lock);
+	c.lock().cmpxchg(x86::qword_ptr(x86::rbx), x86::r13);
+	c.jnz(next);
 
 	Label tx1 = build_transaction_enter(c, fall2, x86::r12d, 666);
 	c.prefetchw(x86::byte_ptr(x86::rbp, 0));
@@ -1493,9 +1497,10 @@ const auto ppu_stcx_accurate_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime
 	c.bt(x86::dword_ptr(args[2], ::offset32(&ppu_thread::state) - ::offset32(&ppu_thread::rdata)), static_cast<u32>(cpu_flag::pause));
 	c.jc(fall2);
 	c.mov(x86::rax, x86::qword_ptr(x86::rbx));
-	c.and_(x86::rax, -128);
+	c.test(x86::eax, vm::rsrv_shared_mask);
+	c.jnz(fall2);
 	c.cmp(x86::rax, x86::r13);
-	c.jne(fail2);
+	c.jne(fail4);
 	c.xbegin(tx1);
 
 	if (s_tsx_avx)
@@ -1535,7 +1540,7 @@ const auto ppu_stcx_accurate_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime
 	c.mov(x86::qword_ptr(x86::rbp, args[0], 1, 0), args[3]);
 
 	c.xend();
-	c.lock().add(x86::qword_ptr(x86::rbx), 127);
+	c.lock().add(x86::qword_ptr(x86::rbx), 64);
 	c.mov(x86::eax, x86::r12d);
 	c.jmp(_ret);
 
@@ -1569,8 +1574,11 @@ const auto ppu_stcx_accurate_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime
 	c.mov(x86::eax, -1);
 	c.jmp(_ret);
 
+	c.bind(fail4);
+	c.lock().sub(x86::qword_ptr(x86::rbx), vm::rsrv_unique_lock);
+	//c.jmp(fail2);
+
 	c.bind(fail2);
-	c.lock().sub(x86::qword_ptr(x86::rbx), 1);
 	c.xor_(x86::eax, x86::eax);
 	//c.jmp(_ret);
 
@@ -1681,16 +1689,16 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 				}
 				}
 
-				return cpu_thread::suspend_all(&ppu, [&]
+				return cpu_thread::suspend_all<+1>(&ppu, [&]
 				{
 					if ((res & -128) == rtime && cmp_rdata(ppu.rdata, vm::_ref<spu_rdata_t>(addr & -128)))
 					{
 						data.release(reg_value);
-						res += 127;
+						res += 64;
 						return true;
 					}
 
-					res -= 1;
+					res -= vm::rsrv_unique_lock;
 					return false;
 				});
 			}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1219,9 +1219,9 @@ static T ppu_load_acquire_reservation(ppu_thread& ppu, u32 addr)
 		}
 		else
 		{
-			ppu.state += cpu_flag::wait + cpu_flag::temp;
+			ppu.state += cpu_flag::wait;
 			std::this_thread::yield();
-			verify(HERE), !ppu.check_state();
+			ppu.check_state();
 		}
 	}())
 	{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1199,7 +1199,7 @@ static T ppu_load_acquire_reservation(ppu_thread& ppu, u32 addr)
 				verify(HERE), cpu_thread::if_suspended<-1>(&ppu, [&]()
 				{
 					// Guaranteed success
-					ppu.rtime = vm::reservation_acquire(addr, sizeof(T)) & -128;
+					ppu.rtime = vm::reservation_acquire(addr, sizeof(T));
 					mov_rdata(ppu.rdata, *vm::get_super_ptr<spu_rdata_t>(addr & -128));
 				});
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2651,17 +2651,9 @@ bool spu_thread::process_mfc_cmd()
 			}
 			else
 			{
-				if (g_use_rtm)
-				{
-					state += cpu_flag::wait + cpu_flag::temp;
-				}
-
+				state += cpu_flag::wait + cpu_flag::temp;
 				std::this_thread::yield();
-
-				if (g_use_rtm)
-				{
-					verify(HERE), !check_state();
-				}
+				!check_state();
 			}
 		}())
 		{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -398,10 +398,14 @@ const auto spu_putllc_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, void*
 
 	// Begin transaction
 	Label tx0 = build_transaction_enter(c, fall, x86::r12d, 4);
+	c.bt(x86::dword_ptr(args[2], ::offset32(&spu_thread::state) - ::offset32(&spu_thread::rdata)), static_cast<u32>(cpu_flag::pause));
+	c.mov(x86::eax, _XABORT_EXPLICIT);
+	c.jc(fall);
 	c.xbegin(tx0);
 	c.mov(x86::rax, x86::qword_ptr(x86::rbx));
-	c.test(x86::eax, 127);
+	c.test(x86::eax, vm::rsrv_unique_lock);
 	c.jnz(skip);
+	c.and_(x86::rax, -128);
 	c.cmp(x86::rax, x86::r13);
 	c.jne(fail);
 
@@ -506,19 +510,19 @@ const auto spu_putllc_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, void*
 	Label fall2 = c.newLabel();
 	Label fail2 = c.newLabel();
 	Label fail3 = c.newLabel();
+	Label fail4 = c.newLabel();
 
 	// Lightened transaction: only compare and swap data
 	c.bind(next);
 
 	// Try to "lock" reservation
-	c.mov(x86::eax, 1);
-	c.lock().xadd(x86::qword_ptr(x86::rbx), x86::rax);
-	c.test(x86::eax, vm::rsrv_unique_lock);
-	c.jnz(fail3);
-
-	// Allow only first shared lock to proceed
+	c.mov(x86::rax, x86::qword_ptr(x86::rbx));
+	c.and_(x86::r13, -128);
 	c.cmp(x86::rax, x86::r13);
 	c.jne(fail2);
+	c.add(x86::r13, vm::rsrv_unique_lock);
+	c.lock().cmpxchg(x86::qword_ptr(x86::rbx), x86::r13);
+	c.jnz(next);
 
 	Label tx1 = build_transaction_enter(c, fall2, x86::r12d, 666);
 	c.prefetchw(x86::byte_ptr(x86::rbp, 0));
@@ -528,9 +532,10 @@ const auto spu_putllc_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, void*
 	c.bt(x86::dword_ptr(args[2], ::offset32(&spu_thread::state) - ::offset32(&spu_thread::rdata)), static_cast<u32>(cpu_flag::pause));
 	c.jc(fall2);
 	c.mov(x86::rax, x86::qword_ptr(x86::rbx));
-	c.and_(x86::rax, -128);
+	c.test(x86::eax, vm::rsrv_shared_mask);
+	c.jnz(fall2);
 	c.cmp(x86::rax, x86::r13);
-	c.jne(fail2);
+	c.jne(fail4);
 	c.xbegin(tx1);
 
 	if (s_tsx_avx)
@@ -586,7 +591,7 @@ const auto spu_putllc_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, void*
 	}
 
 	c.xend();
-	c.lock().add(x86::qword_ptr(x86::rbx), 127);
+	c.lock().add(x86::qword_ptr(x86::rbx), 64);
 	c.mov(x86::eax, x86::r12d);
 	c.jmp(_ret);
 
@@ -620,8 +625,11 @@ const auto spu_putllc_tx = build_function_asm<u32(*)(u32 raddr, u64 rtime, void*
 	c.mov(x86::eax, -1);
 	c.jmp(_ret);
 
+	c.bind(fail4);
+	c.lock().sub(x86::qword_ptr(x86::rbx), vm::rsrv_unique_lock);
+	//c.jmp(fail2);
+
 	c.bind(fail2);
-	c.lock().sub(x86::qword_ptr(x86::rbx), 1);
 	c.xor_(x86::eax, x86::eax);
 	//c.jmp(_ret);
 
@@ -772,10 +780,7 @@ const auto spu_putlluc_tx = build_function_asm<u32(*)(u32 raddr, const void* rda
 	c.bind(next);
 
 	// Lock reservation
-	c.mov(x86::eax, 1);
-	c.lock().xadd(x86::qword_ptr(x86::rbx), x86::rax);
-	c.test(x86::eax, vm::rsrv_unique_lock);
-	c.jnz(fall2);
+	c.lock().add(x86::qword_ptr(x86::rbx), 1);
 
 	Label tx1 = build_transaction_enter(c, fall2, x86::r12d, 666);
 	c.prefetchw(x86::byte_ptr(x86::rbp, 0));
@@ -783,6 +788,9 @@ const auto spu_putlluc_tx = build_function_asm<u32(*)(u32 raddr, const void* rda
 
 	// Check pause flag
 	c.bt(x86::dword_ptr(args[2], ::offset32(&cpu_thread::state)), static_cast<u32>(cpu_flag::pause));
+	c.jc(fall2);
+	// Check contention
+	c.test(x86::qword_ptr(x86::rbx), 127 - 1);
 	c.jc(fall2);
 	c.xbegin(tx1);
 
@@ -2292,12 +2300,12 @@ bool spu_thread::do_putllc(const spu_mfc_cmd& args)
 						if (cmp_rdata(rdata, data))
 						{
 							mov_rdata(data, to_write);
-							res += 127;
+							res += 64;
 							return true;
 						}
 					}
 
-					res -= 1;
+					res -= vm::rsrv_unique_lock;
 					return false;
 				});
 
@@ -2397,7 +2405,7 @@ void do_cell_atomic_128_store(u32 addr, const void* to_write)
 		if (result == 0)
 		{
 			// Execute with increased priority
-			cpu_thread::suspend_all<+1>(cpu, [&]
+			cpu_thread::suspend_all<0>(cpu, [&]
 			{
 				mov_rdata(vm::_ref<spu_rdata_t>(addr), *static_cast<const spu_rdata_t*>(to_write));
 				vm::reservation_acquire(addr, 128) += 127;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -3060,7 +3060,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 					return -1;
 				}
 
-				vm::reservation_notifier(raddr, 128).wait<UINT64_MAX & -128>(rtime, atomic_wait_timeout{100'000});
+				vm::reservation_notifier(raddr, 128).wait(rtime, -128, atomic_wait_timeout{100'000});
 			}
 
 			check_state();

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -678,6 +678,9 @@ public:
 	alignas(64) std::byte rdata[128]{};
 	u32 raddr = 0;
 
+	// Range Lock pointer
+	atomic_t<u64, 64>* range_lock{};
+
 	u32 srr0;
 	u32 ch_tag_upd;
 	u32 ch_tag_mask;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -55,7 +55,7 @@ namespace vm
 	alignas(4096) atomic_t<u8> g_shareable[65536]{0};
 
 	// Memory locations
-	std::vector<std::shared_ptr<block_t>> g_locations;
+	alignas(64) std::vector<std::shared_ptr<block_t>> g_locations;
 
 	// Memory mutex core
 	shared_mutex g_mutex;
@@ -68,7 +68,12 @@ namespace vm
 
 	// Memory mutex: passive locks
 	std::array<atomic_t<cpu_thread*>, g_cfg.core.ppu_threads.max> g_locks{};
-	std::array<atomic_t<u64>, 6> g_range_locks{};
+
+	// Range lock slot allocation bits
+	atomic_t<u64> g_range_lock_bits{};
+
+	// Memory range lock slots (sparse atomics)
+	atomic_t<u64, 64> g_range_lock_set[64]{};
 
 	// Page information
 	struct memory_page
@@ -126,45 +131,131 @@ namespace vm
 		}
 	}
 
-	static atomic_t<u64>* _register_range_lock(const u64 lock_info)
+	atomic_t<u64, 64>* alloc_range_lock()
 	{
+		const auto [bits, ok] = g_range_lock_bits.fetch_op([](u64& bits)
+		{
+			if (~bits) [[likely]]
+			{
+				bits |= bits + 1;
+				return true;
+			}
+
+			return false;
+		});
+
+		if (!ok) [[unlikely]]
+		{
+			fmt::throw_exception("Out of range lock bits");
+		}
+
+		g_mutex.lock_unlock();
+
+		return &g_range_lock_set[std::countr_one(bits)];
+	}
+
+	void range_lock_internal(atomic_t<u64, 64>* range_lock, u32 begin, u32 size)
+	{
+		perf_meter<"RHW_LOCK"_u64> perf0;
+
 		while (true)
 		{
-			for (auto& lock : g_range_locks)
+			std::shared_lock lock(g_mutex);
+
+			u32 test = 0;
+
+			for (u32 i = begin / 4096, max = (begin + size - 1) / 4096; i <= max; i++)
 			{
-				if (!lock && lock.compare_and_swap_test(0, lock_info))
+				if (!(g_pages[i].flags & (vm::page_readable)))
 				{
-					return &lock;
+					test = i * 4096;
+					break;
 				}
 			}
+
+			if (test)
+			{
+				lock.unlock();
+
+				// Try tiggering a page fault (write)
+				// TODO: Read memory if needed
+				vm::_ref<atomic_t<u8>>(test) += 0;
+				continue;
+			}
+
+			range_lock->release(begin | u64{size} << 32);
+			return;
 		}
 	}
 
-	static void _lock_shareable_cache(u8 /*value*/, u32 addr /*mutable*/, u32 end /*mutable*/)
+	void free_range_lock(atomic_t<u64, 64>* range_lock) noexcept
 	{
-		// Special value to block new range locks
-		g_addr_lock = addr | u64{end - addr} << 32;
+		if (range_lock < g_range_lock_set || range_lock >= std::end(g_range_lock_set))
+		{
+			fmt::throw_exception("Invalid range lock" HERE);
+		}
 
-		// Convert to 64K-page numbers
-		addr >>= 16;
-		end >>= 16;
+		range_lock->release(0);
+
+		std::shared_lock lock(g_mutex);
+
+		// Use ptr difference to determine location
+		const auto diff = range_lock - g_range_lock_set;
+		g_range_lock_bits &= ~(1ull << diff);
+	}
+
+	template <typename F>
+	FORCE_INLINE static u64 for_all_range_locks(F func)
+	{
+		u64 result = 0;
+
+		for (u64 bits = g_range_lock_bits.load(); bits; bits &= bits - 1)
+		{
+			const u32 id = std::countr_zero(bits);
+
+			const u64 lock_val = g_range_lock_set[id].load();
+
+			if (const u32 size = static_cast<u32>(lock_val >> 32)) [[unlikely]]
+			{
+				const u32 addr = static_cast<u32>(lock_val);
+
+				result += func(addr, size);
+			}
+		}
+
+		return result;
+	}
+
+	static void _lock_shareable_cache(u8 value, u32 addr, u32 size)
+	{
+		// Block new range locks
+		g_addr_lock = addr | u64{size} << 32;
+
+		ASSUME(size);
+
+		const auto range = utils::address_range::start_length(addr, size);
 
 		// Wait for range locks to clear
-		for (auto& lock : g_range_locks)
+		while (value)
 		{
-			while (const u64 _lock = lock.load())
+			const u64 bads = for_all_range_locks([&](u32 addr2, u32 size2)
 			{
-				if (const u32 lock_page = static_cast<u32>(_lock) >> 16)
+				ASSUME(size2);
+
+				if (range.overlaps(utils::address_range::start_length(addr2, size2))) [[unlikely]]
 				{
-					if (lock_page < addr || lock_page >= end)
-					{
-						// Ignoreable range lock
-						break;
-					}
+					return 1;
 				}
 
-				_mm_pause();
+				return 0;
+			});
+
+			if (!bads)
+			{
+				return;
 			}
+
+			_mm_pause();
 		}
 	}
 
@@ -201,82 +292,6 @@ namespace vm
 
 				cpu.state += cpu_flag::wait;
 			}
-		}
-	}
-
-	atomic_t<u64>* range_lock(u32 addr, u32 end)
-	{
-		static const auto test_addr = [](u64 target, u32 addr, u32 end) -> u64
-		{
-			if (const u32 target_size = static_cast<u32>(target >> 32))
-			{
-				// Shareable info is being modified
-				const u32 target_addr = static_cast<u32>(target);
-
-				if (addr >= target_addr + target_size || end <= target_addr)
-				{
-					// Outside of the locked range: proceed normally
-					if (g_shareable[addr >> 16])
-					{
-						addr &= 0xffff;
-						end = ((end - 1) & 0xffff) + 1;
-					}
-
-					return u64{end} << 32 | addr;
-				}
-
-				return 0;
-			}
-
-			if (g_shareable[target >> 16])
-			{
-				// Target within shareable memory range
-				target &= 0xffff;
-			}
-
-			if (g_shareable[addr >> 16])
-			{
-				// Track shareable memory locks in 0x0..0xffff address range
-				addr &= 0xffff;
-				end = ((end - 1) & 0xffff) + 1;
-			}
-
-			if (addr > target || end <= target)
-			{
-				return u64{end} << 32 | addr;
-			}
-
-			return 0;
-		};
-
-		if (u64 _a1 = test_addr(g_addr_lock.load(), addr, end)) [[likely]]
-		{
-			// Optimistic path (hope that address range is not locked)
-			const auto _ret = _register_range_lock(_a1);
-
-			if (_a1 == test_addr(g_addr_lock.load(), addr, end) && !!(g_pages[addr / 4096].flags & page_readable)) [[likely]]
-			{
-				return _ret;
-			}
-
-			*_ret = 0;
-		}
-
-		while (true)
-		{
-			std::shared_lock lock(g_mutex);
-
-			if (!(g_pages[addr / 4096].flags & page_readable))
-			{
-				lock.unlock();
-
-				// Try tiggering a page fault (write)
-				// TODO: Read memory if needed
-				vm::_ref<atomic_t<u8>>(addr) += 0;
-				continue;
-			}
-
-			return _register_range_lock(test_addr(UINT32_MAX, addr, end));
 		}
 	}
 
@@ -401,7 +416,7 @@ namespace vm
 				}
 			}
 
-			g_addr_lock = addr;
+			g_addr_lock = addr | (u64{128} << 32);
 
 			if (g_shareable[addr >> 16])
 			{
@@ -409,26 +424,34 @@ namespace vm
 				addr = addr & 0xffff;
 			}
 
-			for (auto& lock : g_range_locks)
+			const auto range = utils::address_range::start_length(addr, 128);
+
+			while (true)
 			{
-				while (true)
+				const u64 bads = for_all_range_locks([&](u32 addr2, u32 size2)
 				{
-					const u64 value = lock;
-
-					// Test beginning address
-					if (static_cast<u32>(value) > addr)
+					// TODO (currently not possible): handle 2 64K pages (inverse range), or more pages
+					if (g_shareable[addr2 >> 16])
 					{
-						break;
+						addr2 &= 0xffff;
 					}
 
-					// Test end address
-					if (static_cast<u32>(value >> 32) <= addr)
+					ASSUME(size2);
+
+					if (range.overlaps(utils::address_range::start_length(addr2, size2))) [[unlikely]]
 					{
-						break;
+						return 1;
 					}
 
-					_mm_pause();
+					return 0;
+				});
+
+				if (!bads) [[likely]]
+				{
+					break;
 				}
+
+				_mm_pause();
 			}
 
 			for (auto lock = g_locks.cbegin(), end = lock + g_cfg.core.ppu_threads; lock != end; lock++)
@@ -538,7 +561,7 @@ namespace vm
 		}
 	}
 
-	static void _page_map(u32 addr, u8 flags, u32 size, utils::shm* shm)
+	static void _page_map(u32 addr, u8 flags, u32 size, utils::shm* shm, std::pair<const u32, std::pair<u32, std::shared_ptr<utils::shm>>>* (*search_shm)(vm::block_t* block, utils::shm* shm))
 	{
 		if (!size || (size | addr) % 4096 || flags & page_allocated)
 		{
@@ -553,13 +576,38 @@ namespace vm
 			}
 		}
 
-		if (shm && shm->flags() != 0)
+		if (shm && shm->flags() != 0 && shm->info++)
 		{
-			_lock_shareable_cache(1, addr, addr + size);
+			// Memory mirror found, map its range as shareable
+			_lock_shareable_cache(1, addr, size);
 
 			for (u32 i = addr / 65536; i < addr / 65536 + size / 65536; i++)
 			{
-				g_shareable[i] = 1;
+				g_shareable[i].release(1);
+			}
+
+			// Check ref counter (using unused member info for it)
+			if (shm->info == 2)
+			{
+				// Find another mirror and map it as shareable too
+				for (auto& ploc : g_locations)
+				{
+					if (auto loc = ploc.get())
+					{
+						if (auto pp = search_shm(loc, shm))
+						{
+							auto& [size2, ptr] = pp->second;
+
+							// Relock cache
+							_lock_shareable_cache(1, pp->first, size2);
+
+							for (u32 i = pp->first / 65536; i < pp->first / 65536 + size2 / 65536; i++)
+							{
+								g_shareable[i].release(1);
+							}
+						}
+					}
+				}
 			}
 
 			// Unlock
@@ -702,13 +750,14 @@ namespace vm
 			}
 		}
 
-		if (g_shareable[addr >> 16])
+		if (shm && shm->flags() != 0 && (--shm->info || g_shareable[addr >> 16]))
 		{
-			_lock_shareable_cache(0, addr, addr + size);
+			// Remove mirror from shareable cache
+			_lock_shareable_cache(0, addr, size);
 
 			for (u32 i = addr / 65536; i < addr / 65536 + size / 65536; i++)
 			{
-				g_shareable[i] = 0;
+				g_shareable[i].release(0);
 			}
 
 			// Unlock
@@ -844,8 +893,28 @@ namespace vm
 			verify(HERE), !g_pages[addr / 4096 + size / 4096 - 1].flags.exchange(page_allocated);
 		}
 
-		// Map "real" memory pages
-		_page_map(page_addr, flags, page_size, shm.get());
+		// Map "real" memory pages; provide a function to search for mirrors with private member access
+		_page_map(page_addr, flags, page_size, shm.get(), [](vm::block_t* _this, utils::shm* shm)
+		{
+			decltype(m_map)::value_type* result = nullptr;
+
+			// Check eligibility
+			if (!_this || !(SYS_MEMORY_PAGE_SIZE_MASK & _this->flags) || _this->addr < 0x20000000 || _this->addr >= 0xC0000000)
+			{
+				return result;
+			}
+
+			for (auto& pp : _this->m_map)
+			{
+				if (pp.second.second.get() == shm)
+				{
+					// Found match
+					return &pp;
+				}
+			}
+
+			return result;
+		});
 
 		// Add entry
 		m_map[addr] = std::make_pair(size, std::move(shm));
@@ -1368,7 +1437,8 @@ namespace vm
 
 			std::memset(g_reservations, 0, sizeof(g_reservations));
 			std::memset(g_shareable, 0, sizeof(g_shareable));
-			std::memset(g_range_locks.data(), 0, sizeof(g_range_locks));
+			std::memset(g_range_lock_set, 0, sizeof(g_range_lock_set));
+			g_range_lock_bits = 0;
 		}
 	}
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -510,7 +510,18 @@ namespace vm
 	{
 		for (u64 i = 0;; i++)
 		{
-			if (!(res & rsrv_unique_lock)) [[likely]]
+			auto [_oldd, _ok] = res.fetch_op([&](u64& r)
+			{
+				if (r & rsrv_unique_lock)
+				{
+					return false;
+				}
+
+				r += 1;
+				return true;
+			});
+
+			if (_ok) [[likely]]
 			{
 				return;
 			}

--- a/rpcs3/Emu/Memory/vm_locking.h
+++ b/rpcs3/Emu/Memory/vm_locking.h
@@ -11,9 +11,44 @@ namespace vm
 
 	extern thread_local atomic_t<cpu_thread*>* g_tls_locked;
 
+	extern atomic_t<u64> g_addr_lock;
+
 	// Register reader
 	void passive_lock(cpu_thread& cpu);
-	atomic_t<u64>* range_lock(u32 begin, u32 end);
+
+	// Register range lock for further use
+	atomic_t<u64, 64>* alloc_range_lock();
+
+	void range_lock_internal(atomic_t<u64, 64>* range_lock, u32 begin, u32 size);
+
+	// Lock memory range
+	FORCE_INLINE void range_lock(atomic_t<u64, 64>* range_lock, u32 begin, u32 size)
+	{
+		const u64 lock_val = g_addr_lock.load();
+		const u64 lock_addr = static_cast<u32>(lock_val); // -> u64
+		const u32 lock_size = static_cast<u32>(lock_val >> 32);
+
+		if (u64{begin} + size <= lock_addr || begin >= lock_addr + lock_size) [[likely]]
+		{
+			// Optimistic locking
+			range_lock->release(begin | (u64{size} << 32));
+
+			const u64 new_lock_val = g_addr_lock.load();
+
+			if (!new_lock_val || new_lock_val == lock_val) [[likely]]
+			{
+				return;
+			}
+
+			range_lock->release(0);
+		}
+
+		// Fallback to slow path
+		range_lock_internal(range_lock, begin, size);
+	}
+
+	// Release it
+	void free_range_lock(atomic_t<u64, 64>*) noexcept;
 
 	// Unregister reader
 	void passive_unlock(cpu_thread& cpu);

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -27,6 +27,7 @@ private:
 
 public:
 	static void set_wait_callback(bool(*cb)(const void* data));
+	static void set_notify_callback(void(*cb)(const void* data, u64 progress));
 	static void raw_notify(const void* data);
 };
 


### PR DESCRIPTION
Atomic improvement aims to improve TSX performance by reducing waiting time on some heavy thread notification.

VM changes try to get rid of reservation_lock and reduce the concept of reservation bits as simple contention counter (currently they are split to "unique lock" and "shared lock counter").

In the meantime, some improvements for Non-TSX were made and significantly improved PUT performance (writes from SPU to main memory).

Please test for regressions.