### PR TITLE
Qt: Add "Configure Game Patches" to game list

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -12,6 +12,7 @@
 #include "gui_settings.h"
 #include "game_list.h"
 #include "game_list_grid.h"
+#include "patch_manager_dialog.h"
 
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
@@ -916,6 +917,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	QAction* pad_configure = menu.addAction(gameinfo->hasCustomPadConfig
 		? tr("&Change Custom Gamepad Configuration")
 		: tr("&Create Custom Gamepad Configuration"));
+	QAction* configure_patches = menu.addAction(tr("&Configure Game Patches"));
 	QAction* create_ppu_cache = menu.addAction(tr("&Create PPU Cache"));
 	menu.addSeparator();
 	QAction* rename_title = menu.addAction(tr("&Rename In Game List"));
@@ -1094,6 +1096,19 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 					: tr("Failed to remove %0 from drive!\nPath: %1").arg(name).arg(qstr(current_game.path)));
 			}
 		}
+	});
+	connect(configure_patches, &QAction::triggered, [this, current_game, gameinfo]()
+	{
+		std::unordered_map<std::string, std::set<std::string>> games;
+		for (const auto& game : m_game_data)
+		{
+			if (game)
+			{
+				games[game->info.serial].insert(game_list_frame::GetGameVersion(game));
+			}
+		}
+		patch_manager_dialog patch_manager(m_gui_settings, games, current_game.serial, this);
+		patch_manager.exec();
 	});
 	connect(open_game_folder, &QAction::triggered, [current_game]()
 	{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1649,7 +1649,7 @@ void main_window::CreateConnects()
 				}
 			}
 		}
-		patch_manager_dialog patch_manager(m_gui_settings, games, this);
+		patch_manager_dialog patch_manager(m_gui_settings, games, "", this);
 		patch_manager.exec();
  	});
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -52,7 +52,7 @@ enum node_level : int
 	patch_level
 };
 
-patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, QWidget* parent)
+patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, const std::string& search_term, QWidget* parent)
 	: QDialog(parent)
 	, m_gui_settings(gui_settings)
 	, m_owned_games(std::move(games))
@@ -68,6 +68,7 @@ patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_set
 	m_show_owned_games_only = m_gui_settings->GetValue(gui::pm_show_owned).toBool();
 
 	// Initialize gui controls
+	ui->patch_filter->setText(QString::fromStdString(search_term));
 	ui->cb_enable_legacy_patches->setChecked(m_legacy_patches_enabled);
 	ui->cb_owned_games_only->setChecked(m_show_owned_games_only);
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -36,7 +36,7 @@ class patch_manager_dialog : public QDialog
 	const QString tr_all_versions = tr("All versions");
 
 public:
-	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, QWidget* parent = nullptr);
+	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, const std::string& search_term, QWidget* parent = nullptr);
 	~patch_manager_dialog();
 
 	int exec() override;


### PR DESCRIPTION
Adds "Configure Game Patches" option to the game list context menu.
This simply opens the patch manager with the title ID preselected as search term.