### PR TITLE
cellSysutilGetLicenseArea: Stub international IDs

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutilMisc.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutilMisc.cpp
@@ -9,6 +9,9 @@ s32 cellSysutilGetLicenseArea()
 {
 	cellSysutilMisc.warning("cellSysutilGetLicenseArea()");
 
+	// TODO: These values should be read from the Console Region setting, rather than from the Game ID
+	// Detecting license area from MRTC and NPIA title IDs is not possible for example
+	// Also, there are some games where title ID region doesn't match content ID region 
 	switch (const char region = Emu.GetTitleID().size() >= 3u ? Emu.GetTitleID().at(2) : '\0')
 	{
 	case 'J': return CELL_SYSUTIL_LICENSE_AREA_J;
@@ -17,6 +20,7 @@ s32 cellSysutilGetLicenseArea()
 	case 'H': return CELL_SYSUTIL_LICENSE_AREA_H;
 	case 'K': return CELL_SYSUTIL_LICENSE_AREA_K;
 	case 'A': return CELL_SYSUTIL_LICENSE_AREA_C;
+	case 'I': return CELL_SYSUTIL_LICENSE_AREA_J; // International content (NPIA)
 	default: cellSysutilMisc.todo("Unknown license area: %s", Emu.GetTitleID()); return CELL_SYSUTIL_LICENSE_AREA_OTHER;
 	}
 }


### PR DESCRIPTION
```
// TODO: These values should be read from the Console Region setting, rather than from the Game ID	
// Detecting license area from MRTC and NPIA title IDs is not possible for example
// Also, there are some games where title ID region doesn't match content ID region 
```

Until a proper implementation is done following the console's own region, instead of extracting a region from the Title ID

Allows **Life with Playstation** v1.00 (Folding@Home) to go "Ingame"

![image](https://user-images.githubusercontent.com/10283761/97662877-18394d80-1a70-11eb-9354-f10b54071fff.png)
