### PR TITLE
DS3/DS4/DualSense: enumerate devices periodically

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -60,6 +60,7 @@ set(RPCS3_SRC
 	Input/ds4_pad_handler.cpp
 	Input/dualsense_pad_handler.cpp
 	Input/evdev_joystick_handler.cpp
+	Input/hid_pad_handler.cpp
 	Input/keyboard_pad_handler.cpp
 	Input/mm_joystick_handler.cpp
 	Input/pad_thread.cpp

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -85,7 +85,7 @@ error_code cellPadEnd()
 	return CELL_OK;
 }
 
-void clear_pad_buffer(const std::shared_ptr<Pad> pad)
+void clear_pad_buffer(const std::shared_ptr<Pad>& pad)
 {
 	if (!pad)
 		return;
@@ -159,7 +159,6 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto pad = pads[port_no];
-	const auto setting = config->port_setting[port_no];
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
 		return CELL_PAD_ERROR_NO_DEVICE;
@@ -172,6 +171,7 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 		return CELL_OK;
 	}
 
+	const auto setting = config->port_setting[port_no];
 	bool btnChanged = false;
 
 	if (rinfo.ignore_input)

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -12,8 +12,9 @@
 #include <memory>
 #include <unordered_map>
 
-struct PadDevice
+class PadDevice
 {
+public:
 	pad_config* config{ nullptr };
 };
 

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -219,6 +219,7 @@ void ds3_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 	}
 	if (!got_report)
 	{
+		ds3_log.error("check_add_device: hid_get_feature_report failed! Reason: %s", hid_error(hidDevice));
 		hid_close(hidDevice);
 		return;
 	}
@@ -241,6 +242,12 @@ void ds3_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 	device->hidDevice = hidDevice;
 
 	send_output_report(device);
+
+#ifdef _WIN32
+	ds3_log.notice("Added device: report_id=%d, serial='%s', path='%s'", device->report_id, serial, device->path);
+#else
+	ds3_log.notice("Added device: serial='%s', path='%s'", serial, device->path);
+#endif
 }
 
 ds3_pad_handler::DataStatus ds3_pad_handler::get_data(ds3_device* ds3dev)

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -222,6 +222,7 @@ void ds3_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 		hid_close(hidDevice);
 		return;
 	}
+	device->report_id = buf[0];
 #endif
 
 	{
@@ -236,7 +237,6 @@ void ds3_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 		return;
 	}
 
-	device->report_id = buf[0];
 	device->path      = path;
 	device->hidDevice = hidDevice;
 

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -4,7 +4,11 @@
 
 LOG_CHANNEL(ds3_log, "DS3");
 
-ds3_pad_handler::ds3_pad_handler() : PadHandlerBase(pad_handler::ds3)
+constexpr u16 DS3_VID = 0x054C;
+constexpr u16 DS3_PID = 0x0268;
+
+ds3_pad_handler::ds3_pad_handler()
+    : hid_pad_handler(pad_handler::ds3, DS3_VID, {DS3_PID})
 {
 	button_list =
 	{
@@ -51,125 +55,22 @@ ds3_pad_handler::ds3_pad_handler() : PadHandlerBase(pad_handler::ds3)
 
 ds3_pad_handler::~ds3_pad_handler()
 {
-	for (auto& controller : controllers)
+	for (auto& controller : m_controllers)
 	{
-		if (controller->handle)
+		if (controller.second && controller.second->hidDevice)
 		{
 			// Disable blinking and vibration
-			controller->large_motor = 0;
-			controller->small_motor = 0;
-			send_output_report(controller);
-			hid_close(controller->handle);
+			controller.second->large_motor = 0;
+			controller.second->small_motor = 0;
+			send_output_report(controller.second.get());
 		}
 	}
-	hid_exit();
-}
-
-bool ds3_pad_handler::init_usb()
-{
-	if (hid_init() != 0)
-	{
-		ds3_log.fatal("Failed to init hidapi for the DS3 pad handler");
-		return false;
-	}
-	return true;
-}
-
-bool ds3_pad_handler::Init()
-{
-	if (is_init)
-		return true;
-
-	if (!init_usb())
-		return false;
-
-	bool warn_about_drivers = false;
-
-	// Uses libusb for windows as hidapi will never work with UsbHid driver for the ds3 and it won't work with WinUsb either(windows hid api needs the UsbHid in the driver stack as far as I can tell)
-	// For other os use hidapi and hope for the best!
-	hid_device_info* hid_info = hid_enumerate(DS3_VID, DS3_PID);
-	hid_device_info* head = hid_info;
-	while (hid_info)
-	{
-		hid_device *handle = hid_open_path(hid_info->path);
-
-#ifdef _WIN32
-		u8 buf[0xFF];
-		buf[0] = 0xF2;
-		bool got_report = false;
-		if (handle)
-		{
-			got_report = hid_get_feature_report(handle, buf, 0xFF) >= 0;
-			if (!got_report)
-			{
-				buf[0] = 0;
-				got_report = hid_get_feature_report(handle, buf, 0xFF) >= 0;
-			}
-		}
-		if (got_report)
-#else
-		if(handle)
-#endif
-		{
-			std::shared_ptr<ds3_device> ds3dev = std::make_shared<ds3_device>();
-			ds3dev->device = hid_info->path;
-			ds3dev->handle = handle;
-#ifdef _WIN32
-			ds3dev->report_id = buf[0];
-#endif
-			controllers.emplace_back(ds3dev);
-		}
-		else
-		{
-			if (handle)
-				hid_close(handle);
-
-			warn_about_drivers = true;
-		}
-		hid_info = hid_info->next;
-	}
-
-	hid_free_enumeration(head);
-
-	if (warn_about_drivers)
-	{
-		ds3_log.error("One or more DS3 pads were detected but couldn't be interacted with directly");
-#if defined(_WIN32) || defined(__linux__)
-		ds3_log.error("Check https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration for intructions on how to solve this issue");
-#endif
-	}
-	else if (controllers.empty())
-	{
-		ds3_log.warning("No controllers found!");
-	}
-	else
-	{
-		ds3_log.success("Controllers found: %d", controllers.size());
-	}
-
-	is_init = true;
-	return true;
-}
-
-std::vector<std::string> ds3_pad_handler::ListDevices()
-{
-	std::vector<std::string> ds3_pads_list;
-
-	if (!Init())
-		return ds3_pads_list;
-
-	for (usz i = 1; i <= controllers.size(); ++i) // Controllers 1-n in GUI
-	{
-		ds3_pads_list.emplace_back(m_name_string + std::to_string(i));
-	}
-
-	return ds3_pads_list;
 }
 
 void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 /* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
-	std::shared_ptr<ds3_device> device = get_ds3_device(padId);
-	if (device == nullptr || device->handle == nullptr)
+	std::shared_ptr<ds3_device> device = get_hid_device(padId);
+	if (device == nullptr || device->hidDevice == nullptr)
 		return;
 
 	// Set the device's motor speeds to our requested values 0-255
@@ -192,13 +93,13 @@ void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 s
 	}
 
 	// Start/Stop the engines :)
-	send_output_report(device);
+	send_output_report(device.get());
 }
 
-void ds3_pad_handler::send_output_report(const std::shared_ptr<ds3_device>& ds3dev)
+int ds3_pad_handler::send_output_report(ds3_device* ds3dev)
 {
-	if (!ds3dev)
-		return;
+	if (!ds3dev || !ds3dev->hidDevice)
+		return -2;
 
 #ifdef _WIN32
 	u8 report_buf[] = {
@@ -223,23 +124,7 @@ void ds3_pad_handler::send_output_report(const std::shared_ptr<ds3_device>& ds3d
 	report_buf[5] = ds3dev->small_motor;
 #endif
 
-	hid_write(ds3dev->handle, report_buf, sizeof(report_buf));
-}
-
-std::shared_ptr<ds3_pad_handler::ds3_device> ds3_pad_handler::get_ds3_device(const std::string& padId)
-{
-	if (!Init())
-		return nullptr;
-
-	const usz pos = padId.find(m_name_string);
-	if (pos == umax)
-		return nullptr;
-
-	const int pad_number = std::stoi(padId.substr(pos + 9));
-	if (pad_number > 0 && pad_number + 0u <= controllers.size())
-		return controllers[static_cast<usz>(pad_number) - 1];
-
-	return nullptr;
+	return hid_write(ds3dev->hidDevice, report_buf, sizeof(report_buf));
 }
 
 void ds3_pad_handler::init_config(pad_config* cfg, const std::string& name)
@@ -293,18 +178,83 @@ void ds3_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-ds3_pad_handler::DS3Status ds3_pad_handler::get_data(const std::shared_ptr<ds3_device>& ds3dev)
+void ds3_pad_handler::check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view wide_serial)
+{
+	if (!hidDevice)
+	{
+		return;
+	}
+
+	ds3_device* device = nullptr;
+
+	for (auto& controller : m_controllers)
+	{
+		ensure(controller.second);
+
+		if (!controller.second->hidDevice)
+		{
+			device = controller.second.get();
+			break;
+		}
+	}
+
+	if (!device)
+	{
+		return;
+	}
+
+	std::string serial;
+
+	// Uses libusb for windows as hidapi will never work with UsbHid driver for the ds3 and it won't work with WinUsb either(windows hid api needs the UsbHid in the driver stack as far as I can tell)
+	// For other os use hidapi and hope for the best!
+#ifdef _WIN32
+	u8 buf[0xFF];
+	buf[0] = 0xF2;
+
+	bool got_report = hid_get_feature_report(hidDevice, buf, 0xFF) >= 0;
+	if (!got_report)
+	{
+		buf[0]     = 0;
+		got_report = hid_get_feature_report(hidDevice, buf, 0xFF) >= 0;
+	}
+	if (!got_report)
+	{
+		hid_close(hidDevice);
+		return;
+	}
+#endif
+
+	{
+		for (wchar_t ch : wide_serial)
+			serial += static_cast<uchar>(ch);
+	}
+
+	if (hid_set_nonblocking(hidDevice, 1) == -1)
+	{
+		ds3_log.error("check_add_device: hid_set_nonblocking failed! Reason: %s", hid_error(hidDevice));
+		hid_close(hidDevice);
+		return;
+	}
+
+	device->report_id = buf[0];
+	device->path      = path;
+	device->hidDevice = hidDevice;
+
+	send_output_report(device);
+}
+
+ds3_pad_handler::DataStatus ds3_pad_handler::get_data(ds3_device* ds3dev)
 {
 	if (!ds3dev)
-		return DS3Status::Disconnected;
+		return DataStatus::ReadError;
 
 	auto& dbuf = ds3dev->buf;
 
 #ifdef _WIN32
 	dbuf[0] = ds3dev->report_id;
-	const int result = hid_get_feature_report(ds3dev->handle, dbuf, sizeof(dbuf));
+	const int result = hid_get_feature_report(ds3dev->hidDevice, dbuf, sizeof(dbuf));
 #else
-	const int result = hid_read(ds3dev->handle, dbuf, sizeof(dbuf));
+	const int result = hid_read(ds3dev->hidDevice, dbuf, sizeof(dbuf));
 #endif
 
 	if (result > 0)
@@ -315,27 +265,27 @@ ds3_pad_handler::DS3Status ds3_pad_handler::get_data(const std::shared_ptr<ds3_d
 		if (dbuf[0] == 0x01 && dbuf[1] != 0xFF)
 #endif
 		{
-			return DS3Status::NewData;
+			return DataStatus::NewData;
 		}
 		else
 		{
 			ds3_log.warning("Unknown packet received:0x%02x", dbuf[0]);
-			return DS3Status::Connected;
+			return DataStatus::NoNewData;
 		}
 	}
 	else
 	{
 		if (result == 0)
-			return DS3Status::Connected;
+			return DataStatus::NoNewData;
 	}
 
-	return DS3Status::Disconnected;
+	return DataStatus::ReadError;
 }
 
 std::unordered_map<u64, u16> ds3_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
 	std::unordered_map<u64, u16> key_buf;
-	auto dev = std::static_pointer_cast<ds3_device>(device);
+	ds3_device* dev = static_cast<ds3_device*>(device.get());
 	if (!dev)
 		return key_buf;
 
@@ -400,7 +350,7 @@ pad_preview_values ds3_pad_handler::get_preview_values(const std::unordered_map<
 
 void ds3_pad_handler::get_extended_info(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad)
 {
-	auto ds3dev = std::static_pointer_cast<ds3_device>(device);
+	ds3_device* ds3dev = static_cast<ds3_device*>(device.get());
 	if (!ds3dev || !pad)
 		return;
 
@@ -436,15 +386,6 @@ void ds3_pad_handler::get_extended_info(const std::shared_ptr<PadDevice>& device
 	//pad->m_sensors[1].m_value = polish_value(pad->m_sensors[1].m_value, 226, 226, 512, 512, 0, 1023);
 	//pad->m_sensors[2].m_value = polish_value(pad->m_sensors[2].m_value, 113, 113, 512, 512, 0, 1023);
 	//pad->m_sensors[3].m_value = polish_value(pad->m_sensors[3].m_value, 1, 1, 512, 512, 0, 1023);
-}
-
-std::shared_ptr<PadDevice> ds3_pad_handler::get_device(const std::string& device)
-{
-	std::shared_ptr<ds3_device> ds3device = get_ds3_device(device);
-	if (ds3device == nullptr || ds3device->handle == nullptr)
-		return nullptr;
-
-	return ds3device;
 }
 
 bool ds3_pad_handler::get_is_left_trigger(u64 keyCode)
@@ -487,56 +428,43 @@ bool ds3_pad_handler::get_is_right_stick(u64 keyCode)
 
 PadHandlerBase::connection ds3_pad_handler::update_connection(const std::shared_ptr<PadDevice>& device)
 {
-	auto dev = std::static_pointer_cast<ds3_device>(device);
-	if (!dev)
+	ds3_device* dev = static_cast<ds3_device*>(device.get());
+	if (!dev || dev->path.empty())
 		return connection::disconnected;
 
-	if (dev->handle == nullptr)
+	if (dev->hidDevice == nullptr)
 	{
-		hid_device* devhandle = hid_open_path(dev->device.c_str());
-		if (!devhandle)
+		hid_device* devhandle = hid_open_path(dev->path.c_str());
+		if (devhandle)
+		{
+			if (hid_set_nonblocking(devhandle, 1) == -1)
+			{
+				ds3_log.error("Reconnecting Device %s: hid_set_nonblocking failed with error %s", dev->path, hid_error(devhandle));
+			}
+			dev->hidDevice = devhandle;
+		}
+		else
 		{
 			return connection::disconnected;
 		}
-
-		dev->handle = devhandle;
 	}
 
-	switch (get_data(dev))
+	if (get_data(dev) == DataStatus::ReadError)
 	{
-	case DS3Status::Disconnected:
-	{
-		if (dev->status == DS3Status::Connected)
-		{
-			dev->status = DS3Status::Disconnected;
-			hid_close(dev->handle);
-			dev->handle = nullptr;
-		}
-		return connection::disconnected;
-	}
-	case DS3Status::Connected:
-	{
-		if (dev->status == DS3Status::Disconnected)
-		{
-			dev->status = DS3Status::Connected;
-		}
+		// this also can mean disconnected, either way deal with it on next loop and reconnect
+		hid_close(dev->hidDevice);
+		dev->hidDevice = nullptr;
+
 		return connection::no_data;
 	}
-	case DS3Status::NewData:
-	{
-		return connection::connected;
-	}
-	default:
-		break;
-	}
 
-	return connection::disconnected;
+	return connection::connected;
 }
 
 void ds3_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad)
 {
-	auto dev = std::static_pointer_cast<ds3_device>(device);
-	if (!dev || !pad)
+	ds3_device* dev = static_cast<ds3_device*>(device.get());
+	if (!dev || !dev->hidDevice || !pad)
 		return;
 
 	if (dev->large_motor != pad->m_vibrateMotors[0].m_value || dev->small_motor != pad->m_vibrateMotors[1].m_value)

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -7,7 +7,6 @@
 class ds3_device : public HidDevice
 {
 public:
-	u8 buf[64]{0};
 #ifdef _WIN32
 	u8 report_id = 0;
 #endif

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -1,12 +1,19 @@
 #pragma once
 
-#include "Emu/Io/PadHandler.h"
-
-#include "hidapi.h"
+#include "hid_pad_handler.h"
 
 #include <unordered_map>
 
-class ds3_pad_handler final : public PadHandlerBase
+class ds3_device : public HidDevice
+{
+public:
+	u8 buf[64]{0};
+#ifdef _WIN32
+	u8 report_id = 0;
+#endif
+};
+
+class ds3_pad_handler final : public hid_pad_handler<ds3_device>
 {
 	enum DS3KeyCodes
 	{
@@ -64,60 +71,24 @@ class ds3_pad_handler final : public PadHandlerBase
 		DS3_ENDPOINT_IN = 0x81
 	};
 
-	enum DS3Status : u8
-	{
-		Disconnected,
-		Connected,
-		NewData
-	};
-
-	struct ds3_device : public PadDevice
-	{
-		std::string device = {};
-		hid_device *handle = nullptr;
-		u8 buf[64]{ 0 };
-		u8 large_motor = 0;
-		u8 small_motor = 0;
-		u8 status = DS3Status::Disconnected;
-#ifdef _WIN32
-		u8 report_id = 0;
-#endif
-	};
-
-	const u16 DS3_VID = 0x054C;
-	const u16 DS3_PID = 0x0268;
-
 #ifdef _WIN32
 	const u8 DS3_HID_OFFSET = 0x01;
 #else
 	const u8 DS3_HID_OFFSET = 0x00;
 #endif
 
-	// pseudo 'controller id' to keep track of unique controllers
-	std::vector<std::shared_ptr<ds3_device>> controllers;
-
 public:
 	ds3_pad_handler();
 	~ds3_pad_handler();
 
-	bool Init() override;
-
-	std::vector<std::string> ListDevices() override;
 	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:
-	std::shared_ptr<ds3_device> get_ds3_device(const std::string& padId);
-	ds3_pad_handler::DS3Status get_data(const std::shared_ptr<ds3_device>& ds3dev);
-	void send_output_report(const std::shared_ptr<ds3_device>& ds3dev);
+	ds3_pad_handler::DataStatus get_data(ds3_device* ds3dev);
+	int send_output_report(ds3_device* ds3dev);
+	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial);
 
-private:
-	bool init_usb();
-
-private:
-	bool is_init = false;
-
-	std::shared_ptr<PadDevice> get_device(const std::string& device) override;
 	bool get_is_left_trigger(u64 keyCode) override;
 	bool get_is_right_trigger(u64 keyCode) override;
 	bool get_is_left_stick(u64 keyCode) override;

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -84,9 +84,9 @@ public:
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:
-	ds3_pad_handler::DataStatus get_data(ds3_device* ds3dev);
-	int send_output_report(ds3_device* ds3dev);
-	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial);
+	ds3_pad_handler::DataStatus get_data(ds3_device* ds3dev) override;
+	int send_output_report(ds3_device* ds3dev) override;
+	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial) override;
 
 	bool get_is_left_trigger(u64 keyCode) override;
 	bool get_is_right_trigger(u64 keyCode) override;

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -190,7 +190,7 @@ u32 ds4_pad_handler::get_battery_level(const std::string& padId)
 	{
 		return 0;
 	}
-	return std::min<u32>(device->batteryLevel * 10, 100);
+	return std::min<u32>(device->battery_level * 10, 100);
 }
 
 void ds4_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness)
@@ -221,7 +221,7 @@ void ds4_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 s
 	// Set new LED color
 	if (battery_led)
 	{
-		const u32 combined_color = get_battery_color(device->batteryLevel, battery_led_brightness);
+		const u32 combined_color = get_battery_color(device->battery_level, battery_led_brightness);
 		device->config->colorR.set(combined_color >> 8);
 		device->config->colorG.set(combined_color & 0xff);
 		device->config->colorB.set(0);
@@ -372,7 +372,7 @@ bool ds4_pad_handler::GetCalibrationData(DS4Device* ds4Dev)
 	}
 
 	std::array<u8, 64> buf;
-	if (ds4Dev->btCon)
+	if (ds4Dev->bt_controller)
 	{
 		for (int tries = 0; tries < 3; ++tries)
 		{
@@ -411,9 +411,9 @@ bool ds4_pad_handler::GetCalibrationData(DS4Device* ds4Dev)
 		}
 	}
 
-	ds4Dev->calibData[CalibIndex::PITCH].bias = read_s16(&buf[1]);
-	ds4Dev->calibData[CalibIndex::YAW].bias = read_s16(&buf[3]);
-	ds4Dev->calibData[CalibIndex::ROLL].bias = read_s16(&buf[5]);
+	ds4Dev->calib_data[CalibIndex::PITCH].bias = read_s16(&buf[1]);
+	ds4Dev->calib_data[CalibIndex::YAW].bias   = read_s16(&buf[3]);
+	ds4Dev->calib_data[CalibIndex::ROLL].bias  = read_s16(&buf[5]);
 
 	s16 pitchPlus, pitchNeg, rollPlus, rollNeg, yawPlus, yawNeg;
 
@@ -450,14 +450,14 @@ bool ds4_pad_handler::GetCalibrationData(DS4Device* ds4Dev)
 
 	const s32 gyroSpeedScale = read_s16(&buf[19]) + read_s16(&buf[21]);
 
-	ds4Dev->calibData[CalibIndex::PITCH].sens_numer = gyroSpeedScale * DS4_GYRO_RES_PER_DEG_S;
-	ds4Dev->calibData[CalibIndex::PITCH].sens_denom = pitchPlus - pitchNeg;
+	ds4Dev->calib_data[CalibIndex::PITCH].sens_numer = gyroSpeedScale * DS4_GYRO_RES_PER_DEG_S;
+	ds4Dev->calib_data[CalibIndex::PITCH].sens_denom = pitchPlus - pitchNeg;
 
-	ds4Dev->calibData[CalibIndex::YAW].sens_numer = gyroSpeedScale * DS4_GYRO_RES_PER_DEG_S;
-	ds4Dev->calibData[CalibIndex::YAW].sens_denom = yawPlus - yawNeg;
+	ds4Dev->calib_data[CalibIndex::YAW].sens_numer = gyroSpeedScale * DS4_GYRO_RES_PER_DEG_S;
+	ds4Dev->calib_data[CalibIndex::YAW].sens_denom = yawPlus - yawNeg;
 
-	ds4Dev->calibData[CalibIndex::ROLL].sens_numer = gyroSpeedScale * DS4_GYRO_RES_PER_DEG_S;
-	ds4Dev->calibData[CalibIndex::ROLL].sens_denom = rollPlus - rollNeg;
+	ds4Dev->calib_data[CalibIndex::ROLL].sens_numer = gyroSpeedScale * DS4_GYRO_RES_PER_DEG_S;
+	ds4Dev->calib_data[CalibIndex::ROLL].sens_denom = rollPlus - rollNeg;
 
 	const s16 accelXPlus = read_s16(&buf[23]);
 	const s16 accelXNeg  = read_s16(&buf[25]);
@@ -467,27 +467,27 @@ bool ds4_pad_handler::GetCalibrationData(DS4Device* ds4Dev)
 	const s16 accelZNeg  = read_s16(&buf[33]);
 
 	const s32 accelXRange = accelXPlus - accelXNeg;
-	ds4Dev->calibData[CalibIndex::X].bias = accelXPlus - accelXRange / 2;
-	ds4Dev->calibData[CalibIndex::X].sens_numer = 2 * DS4_ACC_RES_PER_G;
-	ds4Dev->calibData[CalibIndex::X].sens_denom = accelXRange;
+	ds4Dev->calib_data[CalibIndex::X].bias       = accelXPlus - accelXRange / 2;
+	ds4Dev->calib_data[CalibIndex::X].sens_numer = 2 * DS4_ACC_RES_PER_G;
+	ds4Dev->calib_data[CalibIndex::X].sens_denom = accelXRange;
 
 	const s32 accelYRange = accelYPlus - accelYNeg;
-	ds4Dev->calibData[CalibIndex::Y].bias = accelYPlus - accelYRange / 2;
-	ds4Dev->calibData[CalibIndex::Y].sens_numer = 2 * DS4_ACC_RES_PER_G;
-	ds4Dev->calibData[CalibIndex::Y].sens_denom = accelYRange;
+	ds4Dev->calib_data[CalibIndex::Y].bias       = accelYPlus - accelYRange / 2;
+	ds4Dev->calib_data[CalibIndex::Y].sens_numer = 2 * DS4_ACC_RES_PER_G;
+	ds4Dev->calib_data[CalibIndex::Y].sens_denom = accelYRange;
 
 	const s32 accelZRange = accelZPlus - accelZNeg;
-	ds4Dev->calibData[CalibIndex::Z].bias = accelZPlus - accelZRange / 2;
-	ds4Dev->calibData[CalibIndex::Z].sens_numer = 2 * DS4_ACC_RES_PER_G;
-	ds4Dev->calibData[CalibIndex::Z].sens_denom = accelZRange;
+	ds4Dev->calib_data[CalibIndex::Z].bias       = accelZPlus - accelZRange / 2;
+	ds4Dev->calib_data[CalibIndex::Z].sens_numer = 2 * DS4_ACC_RES_PER_G;
+	ds4Dev->calib_data[CalibIndex::Z].sens_denom = accelZRange;
 
 	// Make sure data 'looks' valid, dongle will report invalid calibration data with no controller connected
 
-	for (const auto& data : ds4Dev->calibData)
+	for (const auto& data : ds4Dev->calib_data)
 	{
 		if (data.sens_denom == 0)
 		{
-			ds4_log.error("GetCalibrationData: Failure: sensDenom == 0");
+			ds4_log.error("GetCalibrationData: Failure: sens_denom == 0");
 			return false;
 		}
 	}
@@ -546,7 +546,7 @@ void ds4_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 	}
 	else
 	{
-		device->btCon = true;
+		device->bt_controller = true;
 		for (wchar_t ch : wide_serial)
 			serial += static_cast<uchar>(ch);
 	}
@@ -569,10 +569,12 @@ void ds4_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 		return;
 	}
 
-	device->hasCalibData  = true;
-	device->path         = path;
+	device->has_calib_data = true;
+	device->path           = path;
 
 	send_output_report(device);
+
+	ds4_log.notice("Added device: bluetooth=%d, serial='%s', path='%s'", device->bt_controller, serial, device->path);
 }
 
 ds4_pad_handler::~ds4_pad_handler()
@@ -602,7 +604,7 @@ int ds4_pad_handler::send_output_report(DS4Device* device)
 
 	std::array<u8, 78> outputBuf{0};
 	// write rumble state
-	if (device->btCon)
+	if (device->bt_controller)
 	{
 		outputBuf[0] = 0x11;
 		outputBuf[1] = 0xC4;
@@ -653,7 +655,7 @@ ds4_pad_handler::DataStatus ds4_pad_handler::get_data(DS4Device* device)
 
 	std::array<u8, 78> buf{};
 
-	const int res = hid_read(device->hidDevice, buf.data(), device->btCon ? 78 : 64);
+	const int res = hid_read(device->hidDevice, buf.data(), device->bt_controller ? 78 : 64);
 	if (res == -1)
 	{
 		// looks like controller disconnected or read error
@@ -665,7 +667,7 @@ ds4_pad_handler::DataStatus ds4_pad_handler::get_data(DS4Device* device)
 		return DataStatus::NoNewData;
 
 	// bt controller sends this until 0x02 feature report is sent back (happens on controller init/restart)
-	if (device->btCon && buf[0] == 0x1)
+	if (device->bt_controller && buf[0] == 0x1)
 	{
 		// tells controller to send 0x11 reports
 		std::array<u8, 64> buf_error{};
@@ -679,7 +681,7 @@ ds4_pad_handler::DataStatus ds4_pad_handler::get_data(DS4Device* device)
 
 	int offset = 0;
 	// check report and set offset
-	if (device->btCon && buf[0] == 0x11 && res == 78)
+	if (device->bt_controller && buf[0] == 0x11 && res == 78)
 	{
 		offset = 2;
 
@@ -693,12 +695,12 @@ ds4_pad_handler::DataStatus ds4_pad_handler::get_data(DS4Device* device)
 			return DataStatus::NoNewData;
 		}
 	}
-	else if (!device->btCon && buf[0] == 0x01 && res == 64)
+	else if (!device->bt_controller && buf[0] == 0x01 && res == 64)
 	{
 		// Ds4 Dongle uses this bit to actually report whether a controller is connected
 		const bool connected = (buf[31] & 0x04) ? false : true;
-		if (connected && !device->hasCalibData)
-			device->hasCalibData = GetCalibrationData(device);
+		if (connected && !device->has_calib_data)
+			device->has_calib_data = GetCalibrationData(device);
 
 		offset = 0;
 	}
@@ -706,16 +708,16 @@ ds4_pad_handler::DataStatus ds4_pad_handler::get_data(DS4Device* device)
 		return DataStatus::NoNewData;
 
 	const int battery_offset = offset + DS4_INPUT_REPORT_BATTERY_OFFSET;
-	device->cableState = (buf[battery_offset] >> 4) & 0x01;
-	device->batteryLevel = buf[battery_offset] & 0x0F;
+	device->cable_state = (buf[battery_offset] >> 4) & 0x01;
+	device->battery_level = buf[battery_offset] & 0x0F;
 
-	if (device->hasCalibData)
+	if (device->has_calib_data)
 	{
 		int calibOffset = offset + DS4_INPUT_REPORT_GYRO_X_OFFSET;
 		for (int i = 0; i < CalibIndex::COUNT; ++i)
 		{
 			const s16 rawValue = read_s16(&buf[calibOffset]);
-			const s16 calValue = apply_calibration(rawValue, device->calibData[i]);
+			const s16 calValue = apply_calibration(rawValue, device->calib_data[i]);
 			buf[calibOffset++] = (static_cast<u16>(calValue) >> 0) & 0xFF;
 			buf[calibOffset++] = (static_cast<u16>(calValue) >> 8) & 0xFF;
 		}
@@ -794,8 +796,8 @@ PadHandlerBase::connection ds4_pad_handler::update_connection(const std::shared_
 				ds4_log.error("Reconnecting Device %s: hid_set_nonblocking failed with error %s", ds4_dev->path, hid_error(dev));
 			}
 			ds4_dev->hidDevice = dev;
-			if (!ds4_dev->hasCalibData)
-				ds4_dev->hasCalibData = GetCalibrationData(ds4_dev);
+			if (!ds4_dev->has_calib_data)
+				ds4_dev->has_calib_data = GetCalibrationData(ds4_dev);
 		}
 		else
 		{
@@ -824,8 +826,8 @@ void ds4_pad_handler::get_extended_info(const std::shared_ptr<PadDevice>& device
 
 	auto buf = ds4_device->padData;
 
-	pad->m_battery_level = ds4_device->batteryLevel;
-	pad->m_cable_state = ds4_device->cableState;
+	pad->m_battery_level = ds4_device->battery_level;
+	pad->m_cable_state   = ds4_device->cable_state;
 
 	// these values come already calibrated, all we need to do is convert to ds3 range
 
@@ -864,14 +866,14 @@ void ds4_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, c
 
 	// Attempt to send rumble no matter what
 	const int idx_l = config->switch_vibration_motors ? 1 : 0;
-	const int idx_s  = config->switch_vibration_motors ? 0 : 1;
+	const int idx_s = config->switch_vibration_motors ? 0 : 1;
 
 	const int speed_large = config->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : vibration_min;
-	const int speed_small  = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : vibration_min;
+	const int speed_small = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : vibration_min;
 
-	const bool wireless = ds4_dev->cableState < 1;
-	const bool lowBattery = ds4_dev->batteryLevel < 2;
-	const bool isBlinking  = ds4_dev->led_delay_on > 0 || ds4_dev->led_delay_off > 0;
+	const bool wireless   = ds4_dev->cable_state < 1;
+	const bool lowBattery = ds4_dev->battery_level < 2;
+	const bool isBlinking = ds4_dev->led_delay_on > 0 || ds4_dev->led_delay_off > 0;
 
 	// Blink LED when battery is low
 	if (config->led_low_battery_blink)
@@ -896,9 +898,9 @@ void ds4_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, c
 	if (config->led_battery_indicator)
 	{
 		// This makes sure that the LED color doesn't update every 1ms. DS4 only reports battery level in 10% increments
-		if (ds4_dev->last_battery_level != ds4_dev->batteryLevel)
+		if (ds4_dev->last_battery_level != ds4_dev->battery_level)
 		{
-			const u32 combined_color = get_battery_color(ds4_dev->batteryLevel, config->led_battery_indicator_brightness);
+			const u32 combined_color = get_battery_color(ds4_dev->battery_level, config->led_battery_indicator_brightness);
 			config->colorR.set(combined_color >> 8);
 			config->colorG.set(combined_color & 0xff);
 			config->colorB.set(0);

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -11,12 +11,9 @@ public:
 	bool btCon{false};
 	bool hasCalibData{false};
 	std::array<CalibData, CalibIndex::COUNT> calibData{};
-	bool newVibrateData{true};
-	std::array<u8, 64> padData{};
 	u8 batteryLevel{0};
 	u8 last_battery_level{0};
 	u8 cableState{0};
-	bool is_initialized{false};
 };
 
 class ds4_pad_handler final : public hid_pad_handler<DS4Device>

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -71,7 +71,7 @@ private:
 	u32 get_battery_color(u8 battery_level, int brightness);
 
 	// Copies data into padData if status is NewData, otherwise buffer is untouched
-	DataStatus GetRawData(DS4Device* ds4Device);
+	DataStatus get_data(DS4Device* ds4Device);
 	// This function gets us usuable buffer from the rawbuffer of padData
 	bool GetCalibrationData(DS4Device* ds4Device);
 	int send_output_report(DS4Device* device);

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -8,12 +8,12 @@
 class DS4Device : public HidDevice
 {
 public:
-	bool btCon{false};
-	bool hasCalibData{false};
-	std::array<CalibData, CalibIndex::COUNT> calibData{};
-	u8 batteryLevel{0};
+	bool bt_controller{false};
+	bool has_calib_data{false};
+	std::array<CalibData, CalibIndex::COUNT> calib_data{};
+	u8 battery_level{0};
 	u8 last_battery_level{0};
-	u8 cableState{0};
+	u8 cable_state{0};
 };
 
 class ds4_pad_handler final : public hid_pad_handler<DS4Device>

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -67,13 +67,13 @@ public:
 private:
 	u32 get_battery_color(u8 battery_level, int brightness);
 
-	// Copies data into padData if status is NewData, otherwise buffer is untouched
-	DataStatus get_data(DS4Device* ds4Device);
 	// This function gets us usuable buffer from the rawbuffer of padData
 	bool GetCalibrationData(DS4Device* ds4Device);
-	int send_output_report(DS4Device* device);
 
-	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial);
+	// Copies data into padData if status is NewData, otherwise buffer is untouched
+	DataStatus get_data(DS4Device* ds4Device) override;
+	int send_output_report(DS4Device* device) override;
+	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial) override;
 
 	bool get_is_left_trigger(u64 keyCode) override;
 	bool get_is_right_trigger(u64 keyCode) override;

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -1,12 +1,25 @@
 #pragma once
 
-#include "Emu/Io/PadHandler.h"
+#include "hid_pad_handler.h"
 #include "Utilities/CRC.h"
-#include "hidapi.h"
 
 #include <unordered_map>
 
-class ds4_pad_handler final : public PadHandlerBase
+class DS4Device : public HidDevice
+{
+public:
+	bool btCon{false};
+	bool hasCalibData{false};
+	std::array<CalibData, CalibIndex::COUNT> calibData{};
+	bool newVibrateData{true};
+	std::array<u8, 64> padData{};
+	u8 batteryLevel{0};
+	u8 last_battery_level{0};
+	u8 cableState{0};
+	bool is_initialized{false};
+};
+
+class ds4_pad_handler final : public hid_pad_handler<DS4Device>
 {
 	// These are all the possible buttons on a standard DS4 controller
 	// The touchpad is restricted to its button for now (or forever?)
@@ -46,105 +59,25 @@ class ds4_pad_handler final : public PadHandlerBase
 		KeyCodeCount
 	};
 
-	enum DS4CalibIndex
-	{
-		// gyro
-		PITCH = 0,
-		YAW,
-		ROLL,
-
-		// accel
-		X,
-		Y,
-		Z,
-		COUNT
-	};
-
-	struct DS4CalibData
-	{
-		s16 bias;
-		s32 sensNumer;
-		s32 sensDenom;
-	};
-
-	enum class DS4DataStatus
-	{
-		NewData,
-		NoNewData,
-		ReadError,
-	};
-
-	struct DS4Device : public PadDevice
-	{
-		hid_device* hidDevice{ nullptr };
-		std::string path{ "" };
-		bool btCon{ false };
-		bool hasCalibData{ false };
-		std::array<DS4CalibData, DS4CalibIndex::COUNT> calibData{};
-		bool newVibrateData{ true };
-		u8 largeVibrate{ 0 };
-		u8 smallVibrate{ 0 };
-		std::array<u8, 64> padData{};
-		u8 batteryLevel{ 0 };
-		u8 last_battery_level { 0 };
-		u8 cableState{ 0 };
-		u8 led_delay_on{ 0 };
-		u8 led_delay_off{ 0 };
-		bool is_initialized{ false };
-	};
-
-	const u16 DS4_VID = 0x054C;
-
-	// pid's of connected ds4
-	const std::array<u16, 3> ds4Pids = { { 0xBA0, 0x5C4, 0x09CC } };
-
-	// pseudo 'controller id' to keep track of unique controllers
-	std::map<std::string, std::shared_ptr<DS4Device>> controllers;
-	CRCPP::CRC::Table<u32, 32> crcTable{ CRCPP::CRC::CRC_32() };
-
 public:
 	ds4_pad_handler();
 	~ds4_pad_handler();
 
-	bool Init() override;
-	void ThreadProc() override;
-
-	std::vector<std::string> ListDevices() override;
 	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:
-	bool is_init = false;
-	DS4DataStatus status;
-	std::chrono::system_clock::time_point m_last_enumeration;
-	std::set<std::string> m_last_enumerated_devices;
-	void enumerate_devices();
 	u32 get_battery_color(u8 battery_level, int brightness);
 
-private:
-	std::shared_ptr<DS4Device> GetDS4Device(const std::string& padId);
 	// Copies data into padData if status is NewData, otherwise buffer is untouched
-	DS4DataStatus GetRawData(const std::shared_ptr<DS4Device>& ds4Device);
+	DataStatus GetRawData(DS4Device* ds4Device);
 	// This function gets us usuable buffer from the rawbuffer of padData
-	bool GetCalibrationData(const std::shared_ptr<DS4Device>& ds4Device);
-	void CheckAddDevice(hid_device* hidDevice, std::string_view path, std::wstring_view serial);
-	int send_output_report(const std::shared_ptr<DS4Device>& device);
-	inline s16 ApplyCalibration(s32 rawValue, const DS4CalibData& calibData)
-	{
-		const s32 biased = rawValue - calibData.bias;
-		const s32 quot = calibData.sensNumer / calibData.sensDenom;
-		const s32 rem = calibData.sensNumer % calibData.sensDenom;
-		const s32 output = (quot * biased) + ((rem * biased) / calibData.sensDenom);
+	bool GetCalibrationData(DS4Device* ds4Device);
+	int send_output_report(DS4Device* device);
 
-		if (output > INT16_MAX)
-			return INT16_MAX;
-		else if (output < INT16_MIN)
-			return INT16_MIN;
-		else return static_cast<s16>(output);
-	}
+	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial);
 
-	std::shared_ptr<PadDevice> get_device(const std::string& device) override;
 	bool get_is_left_trigger(u64 keyCode) override;
 	bool get_is_right_trigger(u64 keyCode) override;
 	bool get_is_left_stick(u64 keyCode) override;

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -918,10 +918,10 @@ int dualsense_pad_handler::send_output_report(DualSenseDevice* device)
 void dualsense_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad)
 {
 	DualSenseDevice* dualsense_dev = static_cast<DualSenseDevice*>(device.get());
-	if (!dualsense_dev || !dualsense_dev->hidDevice || !pad)
+	if (!dualsense_dev || !dualsense_dev->hidDevice || !dualsense_dev->config || !pad)
 		return;
 
-	auto config = dualsense_dev->config;
+	pad_config* config = dualsense_dev->config;
 
 	// Attempt to send rumble no matter what
 	const int idx_l = config->switch_vibration_motors ? 1 : 0;
@@ -930,16 +930,16 @@ void dualsense_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& dev
 	const int speed_large = config->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : vibration_min;
 	const int speed_small = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : vibration_min;
 
-	dualsense_dev->newVibrateData |= dualsense_dev->large_motor != speed_large || dualsense_dev->small_motor != speed_small;
+	dualsense_dev->new_output_data |= dualsense_dev->large_motor != speed_large || dualsense_dev->small_motor != speed_small;
 
 	dualsense_dev->large_motor = speed_large;
 	dualsense_dev->small_motor = speed_small;
 
-	if (dualsense_dev->newVibrateData)
+	if (dualsense_dev->new_output_data)
 	{
 		if (send_output_report(dualsense_dev) >= 0)
 		{
-			dualsense_dev->newVibrateData = false;
+			dualsense_dev->new_output_data = false;
 		}
 	}
 }

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -19,8 +19,6 @@ public:
 	bool has_calib_data{false};
 	std::array<CalibData, CalibIndex::COUNT> calib_data{};
 	DualSenseDataMode dataMode{DualSenseDataMode::Simple};
-	std::array<u8, 64> padData{};
-	bool newVibrateData{true};
 	bool init_lightbar{true};
 	bool update_lightbar{true};
 	bool update_player_leds{true};

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -69,11 +69,12 @@ public:
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:
-	DataStatus get_data(DualSenseDevice* dualsenseDevice);
 	bool get_calibration_data(DualSenseDevice* dualsense_device);
 
-	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view wide_serial);
-	int send_output_report(DualSenseDevice* device);
+	DataStatus get_data(DualSenseDevice* dualsenseDevice) override;
+	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view wide_serial) override;
+	int send_output_report(DualSenseDevice* device) override;
+
 	bool get_is_left_trigger(u64 keyCode) override;
 	bool get_is_right_trigger(u64 keyCode) override;
 	bool get_is_left_stick(u64 keyCode) override;

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -14,11 +14,11 @@ public:
 		Enhanced
 	};
 
-	bool btCon{false};
+	bool bt_controller{false};
 	u8 bt_sequence{0};
 	bool has_calib_data{false};
 	std::array<CalibData, CalibIndex::COUNT> calib_data{};
-	DualSenseDataMode dataMode{DualSenseDataMode::Simple};
+	DualSenseDataMode data_mode{DualSenseDataMode::Simple};
 	bool init_lightbar{true};
 	bool update_lightbar{true};
 	bool update_player_leds{true};

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -1,12 +1,32 @@
 #pragma once
 
-#include "Emu/Io/PadHandler.h"
+#include "hid_pad_handler.h"
 #include "Utilities/CRC.h"
-#include "hidapi.h"
 
 #include <unordered_map>
 
-class dualsense_pad_handler final : public PadHandlerBase
+class DualSenseDevice : public HidDevice
+{
+public:
+	enum class DualSenseDataMode
+	{
+		Simple,
+		Enhanced
+	};
+
+	bool btCon{false};
+	u8 bt_sequence{0};
+	bool has_calib_data{false};
+	std::array<CalibData, CalibIndex::COUNT> calib_data{};
+	DualSenseDataMode dataMode{DualSenseDataMode::Simple};
+	std::array<u8, 64> padData{};
+	bool newVibrateData{true};
+	bool init_lightbar{true};
+	bool update_lightbar{true};
+	bool update_player_leds{true};
+};
+
+class dualsense_pad_handler final : public hid_pad_handler<DualSenseDevice>
 {
 	enum DualSenseKeyCodes
 	{
@@ -43,102 +63,19 @@ class dualsense_pad_handler final : public PadHandlerBase
 		KeyCodeCount
 	};
 
-	enum DualSenseCalibIndex
-	{
-		// gyro
-		PITCH = 0,
-		YAW,
-		ROLL,
-
-		// accel
-		X,
-		Y,
-		Z,
-		COUNT
-	};
-
-	enum class DualSenseDataStatus
-	{
-		NewData,
-		NoNewData,
-		ReadError,
-	};
-
-	enum class DualSenseDataMode
-	{
-		Simple,
-		Enhanced
-	};
-
-	struct DualSenseCalibData
-	{
-		s16 bias;
-		s32 sens_numer;
-		s32 sens_denom;
-	};
-
-	struct DualSenseDevice : public PadDevice
-	{
-		hid_device* hidDevice{ nullptr };
-		std::string path{ "" };
-		bool btCon{ false };
-		u8 bt_sequence{ 0 };
-		bool has_calib_data{false};
-		std::array<DualSenseCalibData, DualSenseCalibIndex::COUNT> calib_data{};
-		DualSenseDataMode dataMode{ DualSenseDataMode::Simple };
-		std::array<u8, 64> padData{};
-		bool newVibrateData{true};
-		u8 largeVibrate{0};
-		u8 smallVibrate{0};
-		bool init_lightbar{true};
-		bool update_lightbar{true};
-		bool update_player_leds{true};
-	};
-
-	const u16 DUALSENSE_VID = 0x054C;
-	const u16 DUALSENSE_PID = 0x0CE6;
-
-	std::unordered_map<std::string, std::shared_ptr<DualSenseDevice>> controllers;
-	CRCPP::CRC::Table<u32, 32> crcTable{CRCPP::CRC::CRC_32()};
-
 public:
 	dualsense_pad_handler();
 	~dualsense_pad_handler();
 
-	bool Init() override;
-
-	std::vector<std::string> ListDevices() override;
 	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:
-	bool is_init = false;
-	DualSenseDataStatus status;
+	DataStatus get_data(DualSenseDevice* dualsenseDevice);
+	bool get_calibration_data(DualSenseDevice* dualsense_device);
 
-private:
-	std::shared_ptr<DualSenseDevice> GetDualSenseDevice(const std::string& padId);
-
-	DualSenseDataStatus GetRawData(const std::shared_ptr<DualSenseDevice>& dualsenseDevice);
-	bool get_calibration_data(const std::shared_ptr<DualSenseDevice>& dualsense_device);
-
-	inline s16 apply_calibration(s32 rawValue, const DualSenseCalibData& calib_data)
-	{
-		const s32 biased = rawValue - calib_data.bias;
-		const s32 quot   = calib_data.sens_numer / calib_data.sens_denom;
-		const s32 rem    = calib_data.sens_numer % calib_data.sens_denom;
-		const s32 output = (quot * biased) + ((rem * biased) / calib_data.sens_denom);
-
-		if (output > INT16_MAX)
-			return INT16_MAX;
-		else if (output < INT16_MIN)
-			return INT16_MIN;
-		else
-			return static_cast<s16>(output);
-	}
-
-	void CheckAddDevice(hid_device* hidDevice, hid_device_info* hidDevInfo);
-	int send_output_report(const std::shared_ptr<DualSenseDevice>& device);
-	std::shared_ptr<PadDevice> get_device(const std::string& device) override;
+	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view wide_serial);
+	int send_output_report(DualSenseDevice* device);
 	bool get_is_left_trigger(u64 keyCode) override;
 	bool get_is_right_trigger(u64 keyCode) override;
 	bool get_is_left_stick(u64 keyCode) override;

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -136,7 +136,7 @@ std::string evdev_joystick_handler::get_device_name(const libevdev* dev)
 
 bool evdev_joystick_handler::update_device(const std::shared_ptr<PadDevice>& device)
 {
-	auto evdev_device = std::static_pointer_cast<EvdevDevice>(device);
+	EvdevDevice* evdev_device = static_cast<EvdevDevice*>(device.get());
 	if (!evdev_device)
 		return false;
 
@@ -193,7 +193,7 @@ void evdev_joystick_handler::Close()
 {
 	for (auto& binding : bindings)
 	{
-		auto evdev_device = std::static_pointer_cast<EvdevDevice>(binding.first);
+		EvdevDevice* evdev_device = static_cast<EvdevDevice*>(binding.first.get());
 		if (evdev_device)
 		{
 			auto& dev = evdev_device->device;
@@ -424,7 +424,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 // https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
 // https://github.com/reicast/reicast-emulator/blob/master/core/linux-dist/evdev.cpp
 // http://www.infradead.org/~mchehab/kernel_docs_pdf/linux-input.pdf
-void evdev_joystick_handler::SetRumble(std::shared_ptr<EvdevDevice> device, u16 large, u16 small)
+void evdev_joystick_handler::SetRumble(EvdevDevice* device, u16 large, u16 small)
 {
 	if (!device || !device->has_rumble || device->effect_id == -2)
 		return;
@@ -658,7 +658,7 @@ int evdev_joystick_handler::add_device(const std::string& device, const std::sha
 				// It's a joystick. Now let's make sure we don't already have this one.
 				if (std::any_of(bindings.begin(), bindings.end(), [&path](std::pair<std::shared_ptr<PadDevice>, std::shared_ptr<Pad>> binding)
 				{
-					const auto device = std::static_pointer_cast<EvdevDevice>(binding.first);
+					EvdevDevice* device = static_cast<EvdevDevice*>(binding.first.get());
 					return device && path == device->path;
 				}))
 				{
@@ -703,7 +703,7 @@ PadHandlerBase::connection evdev_joystick_handler::update_connection(const std::
 	if (!update_device(device))
 		return connection::disconnected;
 
-	auto evdev_device = std::static_pointer_cast<EvdevDevice>(device);
+	EvdevDevice* evdev_device = static_cast<EvdevDevice*>(device.get());
 	if (!evdev_device || !evdev_device->device)
 		return connection::disconnected;
 
@@ -859,7 +859,7 @@ void evdev_joystick_handler::get_mapping(const std::shared_ptr<PadDevice>& devic
 
 void evdev_joystick_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad)
 {
-	auto evdev_device = std::static_pointer_cast<EvdevDevice>(device);
+	EvdevDevice* evdev_device = static_cast<EvdevDevice*>(device.get());
 	if (!evdev_device)
 		return;
 

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -517,7 +517,7 @@ void evdev_joystick_handler::SetPadData(const std::string& padId, u32 largeMotor
 		return;
 	}
 
-	SetRumble(dev, largeMotor, smallMotor);
+	SetRumble(static_cast<EvdevDevice*>(dev.get()), largeMotor, smallMotor);
 }
 
 int evdev_joystick_handler::GetButtonInfo(const input_event& evt, const std::shared_ptr<EvdevDevice>& device, int& value)

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -374,7 +374,7 @@ private:
 	int add_device(const std::string& device, const std::shared_ptr<Pad>& pad, bool in_settings = false);
 	int GetButtonInfo(const input_event& evt, const std::shared_ptr<EvdevDevice>& device, int& button_code);
 	std::unordered_map<u64, std::pair<u16, bool>> GetButtonValues(const std::shared_ptr<EvdevDevice>& device);
-	void SetRumble(std::shared_ptr<EvdevDevice> device, u16 large, u16 small);
+	void SetRumble(EvdevDevice* device, u16 large, u16 small);
 
 	// Search axis_orientations map for the direction by index, returns -1 if not found, 0 for positive and 1 for negative
 	int FindAxisDirection(const std::unordered_map<int, bool>& map, int index);

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -1,5 +1,6 @@
 #include "hid_pad_handler.h"
 #include "ds4_pad_handler.h"
+#include "dualsense_pad_handler.h"
 #include "util/logs.hpp"
 
 #include <algorithm>
@@ -198,3 +199,4 @@ std::shared_ptr<PadDevice> hid_pad_handler<Device>::get_device(const std::string
 }
 
 template class hid_pad_handler<DS4Device>;
+template class hid_pad_handler<DualSenseDevice>;

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -1,4 +1,5 @@
 #include "hid_pad_handler.h"
+#include "ds3_pad_handler.h"
 #include "ds4_pad_handler.h"
 #include "dualsense_pad_handler.h"
 #include "util/logs.hpp"
@@ -198,5 +199,6 @@ std::shared_ptr<PadDevice> hid_pad_handler<Device>::get_device(const std::string
 	return get_hid_device(device);
 }
 
+template class hid_pad_handler<ds3_device>;
 template class hid_pad_handler<DS4Device>;
 template class hid_pad_handler<DualSenseDevice>;

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -40,7 +40,6 @@ hid_pad_handler<Device>::~hid_pad_handler()
 		{
 			hid_log.error("hid_exit failed!");
 		}
-		hid_log.error("hid_exit !");
 	}
 }
 

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -28,7 +28,7 @@ hid_pad_handler<Device>::~hid_pad_handler()
 
 	if (hid_exit() != 0)
 	{
-		hid_log.error("hid_exit failed!");
+		hid_log.error("%s hid_exit failed!", m_type);
 	}
 }
 
@@ -40,7 +40,7 @@ bool hid_pad_handler<Device>::Init()
 
 	const int res = hid_init();
 	if (res != 0)
-		fmt::throw_exception("hidapi-init error.threadproc");
+		fmt::throw_exception("%s hidapi-init error.threadproc", m_type);
 
 	for (size_t i = 1; i <= MAX_GAMEPADS; i++) // Controllers 1-n in GUI
 	{
@@ -146,7 +146,7 @@ void hid_pad_handler<Device>::enumerate_devices()
 			}
 			else
 			{
-				hid_log.error("hid_open_path failed! Reason: %s", hid_error(dev));
+				hid_log.error("%s hid_open_path failed! Reason: %s", m_type, hid_error(dev));
 				warn_about_drivers = true;
 			}
 		}
@@ -154,7 +154,7 @@ void hid_pad_handler<Device>::enumerate_devices()
 
 	if (warn_about_drivers)
 	{
-		hid_log.error("One or more pads were detected but couldn't be interacted with directly");
+		hid_log.error("One or more %s pads were detected but couldn't be interacted with directly", m_type);
 #if defined(_WIN32) || defined(__linux__)
 		hid_log.error("Check https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration for intructions on how to solve this issue");
 #endif
@@ -164,11 +164,11 @@ void hid_pad_handler<Device>::enumerate_devices()
 		const size_t count = std::count_if(m_controllers.cbegin(), m_controllers.cend(), [](const auto& c) { return c.second && c.second->hidDevice; });
 		if (count > 0)
 		{
-			hid_log.success("Controllers found: %d", count);
+			hid_log.success("%s Controllers found: %d", m_type, count);
 		}
 		else
 		{
-			hid_log.warning("No controllers found!");
+			hid_log.warning("No %s controllers found!", m_type);
 		}
 	}
 }

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -1,0 +1,200 @@
+#include "hid_pad_handler.h"
+#include "ds4_pad_handler.h"
+#include "util/logs.hpp"
+
+#include <algorithm>
+#include <memory>
+
+LOG_CHANNEL(hid_log, "HID");
+
+template <class Device>
+hid_pad_handler<Device>::hid_pad_handler(pad_handler type, u16 vid, std::vector<u16> pids)
+    : PadHandlerBase(type), m_vid(vid), m_pids(std::move(pids))
+{
+};
+
+template <class Device>
+hid_pad_handler<Device>::~hid_pad_handler()
+{
+	for (auto& controller : m_controllers)
+	{
+		if (controller.second && controller.second->hidDevice)
+		{
+			hid_close(controller.second->hidDevice);
+		}
+	}
+
+	if (hid_exit() != 0)
+	{
+		hid_log.error("hid_exit failed!");
+	}
+}
+
+template <class Device>
+bool hid_pad_handler<Device>::Init()
+{
+	if (m_is_init)
+		return true;
+
+	const int res = hid_init();
+	if (res != 0)
+		fmt::throw_exception("hidapi-init error.threadproc");
+
+	for (size_t i = 1; i <= MAX_GAMEPADS; i++) // Controllers 1-n in GUI
+	{
+		m_controllers.emplace(m_name_string + std::to_string(i), std::make_shared<Device>());
+	}
+
+	enumerate_devices();
+
+	m_is_init = true;
+	return true;
+}
+
+template <class Device>
+void hid_pad_handler<Device>::ThreadProc()
+{
+	const auto now     = std::chrono::system_clock::now();
+	const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_enumeration).count();
+	if (elapsed > 2000)
+	{
+		m_last_enumeration = now;
+		enumerate_devices();
+	}
+
+	PadHandlerBase::ThreadProc();
+}
+
+template <class Device>
+std::vector<std::string> hid_pad_handler<Device>::ListDevices()
+{
+	std::vector<std::string> pads_list;
+
+	if (!Init())
+		return pads_list;
+
+	for (const auto& controller : m_controllers) // Controllers 1-n in GUI
+	{
+		pads_list.emplace_back(controller.first);
+	}
+
+	return pads_list;
+}
+
+template <class Device>
+void hid_pad_handler<Device>::enumerate_devices()
+{
+	std::set<std::string> device_paths;
+	std::map<std::string, std::wstring_view> serials;
+
+	for (const auto& pid : m_pids)
+	{
+		hid_device_info* dev_info = hid_enumerate(m_vid, pid);
+		hid_device_info* head     = dev_info;
+		while (dev_info)
+		{
+			ensure(dev_info->path != nullptr);
+			device_paths.insert(dev_info->path);
+			serials[dev_info->path] = dev_info->serial_number ? std::wstring_view(dev_info->serial_number) : std::wstring_view{};
+			dev_info                = dev_info->next;
+		}
+		hid_free_enumeration(head);
+	}
+
+	if (m_last_enumerated_devices == device_paths)
+	{
+		return;
+	}
+
+	m_last_enumerated_devices = device_paths;
+
+	// Scrap devices that are not in the new list
+	for (auto& controller : m_controllers)
+	{
+		if (controller.second && !controller.second->path.empty() && !device_paths.contains(controller.second->path))
+		{
+			hid_close(controller.second->hidDevice);
+			pad_config* config = controller.second->config;
+			controller.second.reset(new Device());
+			controller.second->config = config;
+		}
+	}
+
+	bool warn_about_drivers = false;
+
+	// Find and add new devices
+	for (const auto& path : device_paths)
+	{
+		// Check if we already have this controller
+		const auto it_found = std::find_if(m_controllers.cbegin(), m_controllers.cend(), [path](const auto& c) { return c.second && c.second->path == path; });
+
+		if (it_found == m_controllers.cend())
+		{
+			// Check if we have at least one virtual controller left
+			const auto it_free = std::find_if(m_controllers.cbegin(), m_controllers.cend(), [](const auto& c) { return !c.second || !c.second->hidDevice; });
+			if (it_free == m_controllers.cend())
+			{
+				break;
+			}
+
+			hid_device* dev = hid_open_path(path.c_str());
+			if (dev)
+			{
+				check_add_device(dev, path, serials[path]);
+			}
+			else
+			{
+				hid_log.error("hid_open_path failed! Reason: %s", hid_error(dev));
+				warn_about_drivers = true;
+			}
+		}
+	}
+
+	if (warn_about_drivers)
+	{
+		hid_log.error("One or more pads were detected but couldn't be interacted with directly");
+#if defined(_WIN32) || defined(__linux__)
+		hid_log.error("Check https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration for intructions on how to solve this issue");
+#endif
+	}
+	else
+	{
+		const size_t count = std::count_if(m_controllers.cbegin(), m_controllers.cend(), [](const auto& c) { return c.second && c.second->hidDevice; });
+		if (count > 0)
+		{
+			hid_log.success("Controllers found: %d", count);
+		}
+		else
+		{
+			hid_log.warning("No controllers found!");
+		}
+	}
+}
+
+template <class Device>
+std::shared_ptr<Device> hid_pad_handler<Device>::get_hid_device(const std::string& padId)
+{
+	if (!Init())
+		return nullptr;
+
+	std::shared_ptr<Device> device = nullptr;
+
+	// Controllers 1-n in GUI
+	for (auto& cur_control : m_controllers)
+	{
+		if (padId == cur_control.first)
+		{
+			return cur_control.second;
+		}
+	}
+
+	return nullptr;
+}
+
+template <class Device>
+std::shared_ptr<PadDevice> hid_pad_handler<Device>::get_device(const std::string& device)
+{
+	return get_hid_device(device);
+}
+
+template class hid_pad_handler<DS4Device>;

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -31,6 +31,8 @@ class HidDevice : public PadDevice
 public:
 	hid_device* hidDevice{nullptr};
 	std::string path{""};
+	std::array<u8, 64> padData{};
+	bool new_output_data{true};
 	u8 large_motor{0};
 	u8 small_motor{0};
 	u8 led_delay_on{0};

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -5,6 +5,8 @@
 
 #include "hidapi.h"
 
+#include <algorithm>
+
 struct CalibData
 {
 	s16 bias;
@@ -84,12 +86,7 @@ protected:
 		const s32 rem    = calibData.sens_numer % calibData.sens_denom;
 		const s32 output = (quot * biased) + ((rem * biased) / calibData.sens_denom);
 
-		if (output > INT16_MAX)
-			return INT16_MAX;
-		else if (output < INT16_MIN)
-			return INT16_MIN;
-		else
-			return static_cast<s16>(output);
+		return static_cast<s16>(std::clamp<s32>(output, INT16_MIN, INT16_MAX));
 	}
 
 	inline s16 read_s16(const void* buf)

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -31,8 +31,8 @@ class HidDevice : public PadDevice
 public:
 	hid_device* hidDevice{nullptr};
 	std::string path{""};
-	u8 largeVibrate{0};
-	u8 smallVibrate{0};
+	u8 large_motor{0};
+	u8 small_motor{0};
 	u8 led_delay_on{0};
 	u8 led_delay_off{0};
 };
@@ -72,6 +72,8 @@ protected:
 	std::shared_ptr<Device> get_hid_device(const std::string& padId);
 
 	virtual void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial) = 0;
+	virtual int send_output_report(Device* device) = 0;
+	virtual DataStatus get_data(Device* device) = 0;
 
 	inline s16 apply_calibration(s32 rawValue, const CalibData& calibData)
 	{

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "Emu/Io/PadHandler.h"
+#include "Utilities/CRC.h"
+
+#include "hidapi.h"
+
+struct CalibData
+{
+	s16 bias;
+	s32 sens_numer;
+	s32 sens_denom;
+};
+
+enum CalibIndex
+{
+	// gyro
+	PITCH = 0,
+	YAW,
+	ROLL,
+
+	// accel
+	X,
+	Y,
+	Z,
+	COUNT
+};
+
+class HidDevice : public PadDevice
+{
+public:
+	hid_device* hidDevice{nullptr};
+	std::string path{""};
+	u8 largeVibrate{0};
+	u8 smallVibrate{0};
+	u8 led_delay_on{0};
+	u8 led_delay_off{0};
+};
+
+template <class Device>
+class hid_pad_handler : public PadHandlerBase
+{
+public:
+	hid_pad_handler(pad_handler type, u16 vid, std::vector<u16> pids);
+	~hid_pad_handler();
+
+	bool Init() override;
+	void ThreadProc() override;
+	std::vector<std::string> ListDevices() override;
+
+protected:
+	enum class DataStatus
+	{
+		NewData,
+		NoNewData,
+		ReadError,
+	};
+
+	CRCPP::CRC::Table<u32, 32> crcTable{CRCPP::CRC::CRC_32()};
+
+	u16 m_vid;
+	std::vector<u16> m_pids;
+
+	// pseudo 'controller id' to keep track of unique controllers
+	std::map<std::string, std::shared_ptr<Device>> m_controllers;
+
+	bool m_is_init = false;
+	std::chrono::system_clock::time_point m_last_enumeration;
+	std::set<std::string> m_last_enumerated_devices;
+
+	void enumerate_devices();
+	std::shared_ptr<Device> get_hid_device(const std::string& padId);
+
+	virtual void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial) = 0;
+
+	inline s16 apply_calibration(s32 rawValue, const CalibData& calibData)
+	{
+		const s32 biased = rawValue - calibData.bias;
+		const s32 quot   = calibData.sens_numer / calibData.sens_denom;
+		const s32 rem    = calibData.sens_numer % calibData.sens_denom;
+		const s32 output = (quot * biased) + ((rem * biased) / calibData.sens_denom);
+
+		if (output > INT16_MAX)
+			return INT16_MAX;
+		else if (output < INT16_MIN)
+			return INT16_MIN;
+		else
+			return static_cast<s16>(output);
+	}
+
+	inline s16 read_s16(const void* buf)
+	{
+		return *reinterpret_cast<const s16*>(buf);
+	}
+
+	inline u32 read_u32(const void* buf)
+	{
+		return *reinterpret_cast<const u32*>(buf);
+	}
+
+private:
+	std::shared_ptr<PadDevice> get_device(const std::string& device) override;
+};

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -125,7 +125,7 @@ std::array<u32, PadHandlerBase::button::button_count> mm_joystick_handler::get_m
 {
 	std::array<u32, button::button_count> mapping{ 0 };
 
-	auto joy_device = std::static_pointer_cast<MMJOYDevice>(device);
+	MMJOYDevice* joy_device = static_cast<MMJOYDevice*>(device.get());
 	if (!joy_device)
 		return mapping;
 
@@ -429,7 +429,7 @@ std::unordered_map<u64, u16> mm_joystick_handler::GetButtonValues(const JOYINFOE
 
 std::unordered_map<u64, u16> mm_joystick_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
-	auto dev = std::static_pointer_cast<MMJOYDevice>(device);
+	MMJOYDevice* dev = static_cast<MMJOYDevice*>(device.get());
 	if (!dev)
 		return std::unordered_map<u64, u16>();
 	return GetButtonValues(dev->device_info, dev->device_caps);
@@ -508,14 +508,14 @@ bool mm_joystick_handler::get_is_right_stick(u64 keyCode)
 
 PadHandlerBase::connection mm_joystick_handler::update_connection(const std::shared_ptr<PadDevice>& device)
 {
-	auto dev = std::static_pointer_cast<MMJOYDevice>(device);
+	MMJOYDevice* dev = static_cast<MMJOYDevice*>(device.get());
 	if (!dev)
 		return connection::disconnected;
 
 	const auto old_status = dev->device_status;
 	dev->device_status    = joyGetPosEx(dev->device_id, &dev->device_info);
 
-	if (dev->device_status == JOYERR_NOERROR && (old_status == JOYERR_NOERROR || GetMMJOYDevice(dev->device_id, dev.get())))
+	if (dev->device_status == JOYERR_NOERROR && (old_status == JOYERR_NOERROR || GetMMJOYDevice(dev->device_id, dev)))
 	{
 		return connection::connected;
 	}

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -104,7 +104,7 @@ void pad_thread::Init()
 		const bool is_ldd_pad = pad_settings[i].ldd_handle == static_cast<s32>(i);
 		const auto handler_type = is_ldd_pad ? pad_handler::null : g_cfg_input.player[i]->handler.get();
 
-		if (handlers.count(handler_type) != 0)
+		if (handlers.contains(handler_type))
 		{
 			cur_pad_handler = handlers[handler_type];
 		}

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -162,7 +162,7 @@ int xinput_pad_handler::GetDeviceNumber(const std::string& padId)
 std::unordered_map<u64, u16> xinput_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
 	PadButtonValues values;
-	auto dev = std::static_pointer_cast<XInputDevice>(device);
+	XInputDevice* dev = static_cast<XInputDevice*>(device.get());
 	if (!dev || dev->state != ERROR_SUCCESS) // the state has to be aquired with update_connection before calling this function
 		return values;
 
@@ -426,7 +426,7 @@ bool xinput_pad_handler::get_is_right_stick(u64 keyCode)
 
 PadHandlerBase::connection xinput_pad_handler::update_connection(const std::shared_ptr<PadDevice>& device)
 {
-	auto dev = std::static_pointer_cast<XInputDevice>(device);
+	XInputDevice* dev = static_cast<XInputDevice*>(device.get());
 	if (!dev)
 		return connection::disconnected;
 
@@ -451,7 +451,7 @@ PadHandlerBase::connection xinput_pad_handler::update_connection(const std::shar
 
 void xinput_pad_handler::get_extended_info(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad)
 {
-	auto dev = std::static_pointer_cast<XInputDevice>(device);
+	XInputDevice* dev = static_cast<XInputDevice*>(device.get());
 	if (!dev || !pad)
 		return;
 
@@ -478,7 +478,7 @@ void xinput_pad_handler::get_extended_info(const std::shared_ptr<PadDevice>& dev
 
 void xinput_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad)
 {
-	auto dev = std::static_pointer_cast<XInputDevice>(device);
+	XInputDevice* dev = static_cast<XInputDevice*>(device.get());
 	if (!dev || !pad)
 		return;
 

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -332,6 +332,7 @@
   <ItemGroup>
     <ClCompile Include="display_sleep_control.cpp" />
     <ClCompile Include="Input\dualsense_pad_handler.cpp" />
+    <ClCompile Include="Input\hid_pad_handler.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="main_application.cpp" />
     <ClCompile Include="Input\basic_keyboard_handler.cpp" />
@@ -1641,6 +1642,7 @@
     <ClInclude Include="Input\ds4_pad_handler.h" />
     <ClInclude Include="Input\dualsense_pad_handler.h" />
     <ClInclude Include="Input\evdev_joystick_handler.h" />
+    <ClInclude Include="Input\hid_pad_handler.h" />
     <ClInclude Include="Input\keyboard_pad_handler.h" />
     <CustomBuild Include="rpcs3qt\gs_frame.h">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing gs_frame.h...</Message>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -1105,6 +1105,9 @@
     <ClCompile Include="QTGeneratedFiles\Debug - LLVM\moc_log_viewer.cpp">
       <Filter>Generated Files\Debug - LLVM</Filter>
     </ClCompile>
+    <ClCompile Include="Input\hid_pad_handler.cpp">
+      <Filter>Io</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">
@@ -1229,6 +1232,9 @@
     </ClInclude>
     <ClInclude Include="rpcs3qt\progress_dialog.h">
       <Filter>Gui\misc dialogs</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\hid_pad_handler.h">
+      <Filter>Io</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -102,7 +102,7 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 	connect(ui->chooseHandler, &QComboBox::currentTextChanged, this, &pad_settings_dialog::ChangeInputType);
 
 	// Combobox: Devices
-	connect(ui->chooseDevice, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index)
+	connect(ui->chooseDevice, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index)
 	{
 		if (index < 0)
 		{
@@ -119,7 +119,7 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 	});
 
 	// Combobox: Profiles
-	connect(ui->chooseProfile, &QComboBox::currentTextChanged, [this](const QString& prof)
+	connect(ui->chooseProfile, &QComboBox::currentTextChanged, this, [this](const QString& prof)
 	{
 		if (prof.isEmpty())
 		{
@@ -136,7 +136,7 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 	});
 
 	// Pushbutton: Add Profile
-	connect(ui->b_addProfile, &QAbstractButton::clicked, [this]()
+	connect(ui->b_addProfile, &QAbstractButton::clicked, this, [this]()
 	{
 		const int i = ui->tabWidget->currentIndex();
 
@@ -175,7 +175,7 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 
 	ui->buttonBox->button(QDialogButtonBox::Reset)->setText(tr("Filter Noise"));
 
-	connect(ui->buttonBox, &QDialogButtonBox::clicked, [this](QAbstractButton* button)
+	connect(ui->buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button)
 	{
 		if (button == ui->buttonBox->button(QDialogButtonBox::Save))
 		{
@@ -304,7 +304,7 @@ void pad_settings_dialog::InitButtons()
 
 	connect(m_pad_buttons, &QButtonGroup::idClicked, this, &pad_settings_dialog::OnPadButtonClicked);
 
-	connect(&m_timer, &QTimer::timeout, [this]()
+	connect(&m_timer, &QTimer::timeout, this, [this]()
 	{
 		if (--m_seconds <= 0)
 		{
@@ -314,7 +314,7 @@ void pad_settings_dialog::InitButtons()
 		m_pad_buttons->button(m_button_id)->setText(tr("[ Waiting %1 ]").arg(m_seconds));
 	});
 
-	connect(ui->chb_vibration_large, &QCheckBox::clicked, [this](bool checked)
+	connect(ui->chb_vibration_large, &QCheckBox::clicked, this, [this](bool checked)
 	{
 		if (!checked)
 		{
@@ -330,7 +330,7 @@ void pad_settings_dialog::InitButtons()
 		});
 	});
 
-	connect(ui->chb_vibration_small, &QCheckBox::clicked, [this](bool checked)
+	connect(ui->chb_vibration_small, &QCheckBox::clicked, this, [this](bool checked)
 	{
 		if (!checked)
 		{
@@ -346,7 +346,7 @@ void pad_settings_dialog::InitButtons()
 		});
 	});
 
-	connect(ui->chb_vibration_switch, &QCheckBox::clicked, [this](bool checked)
+	connect(ui->chb_vibration_switch, &QCheckBox::clicked, this, [this](bool checked)
 	{
 		checked ? SetPadData(m_min_force, m_max_force)
 		        : SetPadData(m_max_force, m_min_force);
@@ -363,18 +363,18 @@ void pad_settings_dialog::InitButtons()
 		});
 	});
 
-	connect(ui->slider_stick_left, &QSlider::valueChanged, [&](int value)
+	connect(ui->slider_stick_left, &QSlider::valueChanged, this, [&](int value)
 	{
 		RepaintPreviewLabel(ui->preview_stick_left, value, ui->slider_stick_left->size().width(), m_lx, m_ly, ui->squircle_left->value(), ui->stick_multi_left->value());
 	});
 
-	connect(ui->slider_stick_right, &QSlider::valueChanged, [&](int value)
+	connect(ui->slider_stick_right, &QSlider::valueChanged, this, [&](int value)
 	{
 		RepaintPreviewLabel(ui->preview_stick_right, value, ui->slider_stick_right->size().width(), m_rx, m_ry, ui->squircle_right->value(), ui->stick_multi_right->value());
 	});
 
 	// Open LED settings
-	connect(ui->b_led_settings, &QPushButton::clicked, [this]()
+	connect(ui->b_led_settings, &QPushButton::clicked, this, [this]()
 	{
 		// Allow LED battery indication while the dialog is open
 		m_handler->SetPadData(m_device_name, 0, 0, m_handler_cfg.colorR, m_handler_cfg.colorG, m_handler_cfg.colorB, m_handler_cfg.led_battery_indicator.get(), m_handler_cfg.led_battery_indicator_brightness);
@@ -462,7 +462,7 @@ void pad_settings_dialog::InitButtons()
 	};
 
 	// Use timer to get button input
-	connect(&m_timer_input, &QTimer::timeout, [this, callback, fail_callback]()
+	connect(&m_timer_input, &QTimer::timeout, this, [this, callback, fail_callback]()
 	{
 		const std::vector<std::string> buttons =
 		{
@@ -475,7 +475,7 @@ void pad_settings_dialog::InitButtons()
 	});
 
 	// Use timer to refresh pad connection status
-	connect(&m_timer_pad_refresh, &QTimer::timeout, [this]()
+	connect(&m_timer_pad_refresh, &QTimer::timeout, this, [this]()
 	{
 		for (int i = 0; i < ui->chooseDevice->count(); i++)
 		{
@@ -1193,6 +1193,7 @@ void pad_settings_dialog::ChangeInputType()
 
 	// Get this player's current handler and it's currently available devices
 	m_handler = GetHandler(g_cfg_input.player[player]->handler);
+	ensure(m_handler);
 	const auto device_list = m_handler->ListDevices();
 
 	// Localized tooltips


### PR DESCRIPTION
Calls hid_enumerate periodically and updates the virtual DS4 list accordingly.
In order for this to work, I had to change the logic a little bit to always register 7 vitual DS4 controllers in the handler.
Currently, devices will be assigned to the 7 slots based on the order of enumeration, and whenever a device is disconnected, its slot gets unoccupied and is free to connect to the next unknown device.
Controllers that stay connected should not change positions.

This can probably be improved by additionally saving the serial/path to the config in the future.

fixes #9130