### PR TITLE
Log Qt version

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -374,9 +374,16 @@ int main(int argc, char** argv)
 		os.m.ch  = nullptr;
 		os.m.sev = logs::level::notice;
 		os.stamp = 0;
-		os.text = utils::get_OS_version();
+		os.text  = utils::get_OS_version();
 
-		logs::set_init({std::move(ver), std::move(os)});
+		// Write Qt version
+		logs::stored_message qt;
+		qt.m.ch  = nullptr;
+		qt.m.sev = (strcmp(QT_VERSION_STR, qVersion()) != 0) ? logs::level::error : logs::level::notice;
+		qt.stamp = 0;
+		qt.text  = fmt::format("Qt version: Compiled against Qt %s | Run-time uses Qt %s", QT_VERSION_STR, qVersion());
+
+		logs::set_init({std::move(ver), std::move(os), std::move(qt)});
 	}
 
 #ifdef _WIN32


### PR DESCRIPTION
Logs something like this:

_RPCS3 v0.0.13-11151-09a9d084 Alpha | vCheck | Firmware version: 4.86
Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz | 8 Threads | 31.82 GiB RAM | TSC: 1.992GHz | AVX+ | FMA3
Operating system: Windows, Major: 10, Minor: 0, Build: 19041, Service Pack: none, Compatibility mode: 0
**Qt version: Compiled against Qt 5.15.1 | Run-time uses Qt 5.15.1**_

The versions can be different, but I don't have a proper setup to test it right now.
You could probably test it by compiling it with Qt 5.14.2 and then run it with Qt 5.15.1 dlls.