### PR TITLE
Refactoring, bugfixes and fix emulation stopping

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1529,14 +1529,14 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context) no
 			else
 			{
 				// Wait until the thread is recovered
-				while (!cpu->state.test_and_reset(cpu_flag::signal))
+				while (auto state = cpu->state.fetch_sub(cpu_flag::signal))
 				{
-					if (cpu->is_stopped())
+					if (is_stopped(state) || state & cpu_flag::signal)
 					{
 						break;
 					}
 
-					thread_ctrl::wait();
+					thread_ctrl::wait_on(cpu->state, state);
 				}
 			}
 

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -25,6 +25,18 @@ enum class cpu_flag : u32
 	__bitset_enum_max
 };
 
+// Test stopped state
+constexpr bool is_stopped(bs_t<cpu_flag> state)
+{
+	return !!(state & (cpu_flag::stop + cpu_flag::exit));
+}
+
+// Test paused state
+constexpr bool is_paused(bs_t<cpu_flag> state)
+{
+	return !!(state & (cpu_flag::suspend + cpu_flag::dbg_global_pause + cpu_flag::dbg_pause));
+}
+
 class cpu_thread
 {
 public:
@@ -60,16 +72,25 @@ public:
 		return false;
 	}
 
-	// Test stopped state
-	bool is_stopped() const
+	// Wrappers
+	static constexpr bool is_stopped(bs_t<cpu_flag> s)
 	{
-		return !!(state & (cpu_flag::stop + cpu_flag::exit));
+		return ::is_stopped(s);
 	}
 
-	// Test paused state
+	static constexpr bool is_paused(bs_t<cpu_flag> s)
+	{
+		return ::is_paused(s);
+	}
+
+	bool is_stopped() const
+	{
+		return ::is_stopped(state);
+	}
+
 	bool is_paused() const
 	{
-		return !!(state & (cpu_flag::suspend + cpu_flag::dbg_global_pause + cpu_flag::dbg_pause));
+		return ::is_paused(state);
 	}
 
 	bool has_pause_flag() const
@@ -122,7 +143,10 @@ public:
 	virtual void cpu_return() {}
 
 	// Callback for thread_ctrl::wait or RSX wait
-	virtual void cpu_wait();
+	virtual void cpu_wait(bs_t<cpu_flag> flags);
+
+	// Callback for function abortion stats on Emu.Stop()
+	virtual void cpu_on_stop() {}
 
 	// For internal use
 	struct suspend_work

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1162,7 +1162,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				// Reschedule after a blocking dialog returns
 				if (ppu.check_state())
 				{
-					return 0;
+					return {};
 				}
 
 				if (res != CELL_OK)

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -413,7 +413,7 @@ error_code cellSysutilCheckCallback(ppu_thread& ppu)
 
 		if (ppu.is_stopped())
 		{
-			return 0;
+			return {};
 		}
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -673,7 +673,7 @@ static error_code vdecOpen(ppu_thread& ppu, T type, U res, vm::cptr<CellVdecCb> 
 	});
 
 	thrd->state -= cpu_flag::stop;
-	thread_ctrl::notify(*thrd);
+	thrd->state.notify_one(cpu_flag::stop);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -628,11 +628,11 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 		for (u32 old_value; current < until && (old_value = *queued);
 			current = get_system_time())
 		{
-			queued->wait(old_value, atomic_wait_timeout{(until - current) * 1000});
+			thread_ctrl::wait_on(*queued, old_value, until - current);
 
 			if (ppu.is_stopped())
 			{
-				return 0;
+				return {};
 			}
 		}
 	}

--- a/rpcs3/Emu/Cell/PPUFunction.h
+++ b/rpcs3/Emu/Cell/PPUFunction.h
@@ -13,6 +13,7 @@ using ppu_function_t = bool(*)(ppu_thread&);
 	ppu.current_function = #func;\
 	std::memcpy(ppu.syscall_args, ppu.gpr + 3, sizeof(ppu.syscall_args)); \
 	ppu_func_detail::do_call(ppu, func);\
+	static_cast<void>(ppu.test_stopped());\
 	ppu.current_function = old_f;\
 	ppu.cia += 4;\
 	__VA_ARGS__;\

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -124,6 +124,7 @@ public:
 	virtual std::string dump_misc() const override;
 	virtual void cpu_task() override final;
 	virtual void cpu_sleep() override;
+	virtual void cpu_on_stop() override;
 	virtual ~ppu_thread() override;
 
 	ppu_thread(const ppu_thread_params&, std::string_view name, u32 prio, int detached = 0);
@@ -257,6 +258,7 @@ public:
 	void cmd_pop(u32 = 0);
 	cmd64 cmd_wait(); // Empty command means caller must return, like true from cpu_thread::check_status().
 	cmd64 cmd_get(u32 index) { return cmd_queue[cmd_queue.peek() + index].load(); }
+	atomic_t<u32> cmd_notify = 0;
 
 	const ppu_func_opd_t entry_func;
 	u64 start_time{0}; // Sleep start timepoint

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -20,7 +20,7 @@ inline void try_start(spu_thread& spu)
 	}).second)
 	{
 		spu.state -= cpu_flag::stop;
-		thread_ctrl::notify(static_cast<named_thread<spu_thread>&>(spu));
+		spu.state.notify_one(cpu_flag::stop);
 	}
 };
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9076,7 +9076,7 @@ struct spu_llvm
 			{
 				// Interrupt profiler thread and put it to sleep
 				static_cast<void>(prof_mutex.reset());
-				atomic_wait::list(registered).wait(); // TODO
+				thread_ctrl::wait_on(registered, nullptr);
 				continue;
 			}
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -305,7 +305,7 @@ public:
 				return -1;
 			}
 
-			data.wait(bit_wait);
+			thread_ctrl::wait_on(data, bit_wait);
 		}
 	}
 
@@ -345,7 +345,7 @@ public:
 				return false;
 			}
 
-			data.wait(state);
+			thread_ctrl::wait_on(data, state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1361,11 +1361,7 @@ void lv2_obj::schedule_all()
 				ppu_log.trace("schedule(): %s", target->id);
 				target->state ^= (cpu_flag::signal + cpu_flag::suspend);
 				target->start_time = 0;
-
-				if (target != get_current_cpu_thread())
-				{
-					target->notify();
-				}
+				target->state.notify_one(cpu_flag::signal + cpu_flag::suspend);
 			}
 		}
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -19,7 +19,8 @@ void lv2_int_serv::exec()
 		{ ppu_cmd::sleep, 0 }
 	});
 
-	thread_ctrl::notify(*thread);
+	thread->cmd_notify++;
+	thread->cmd_notify.notify_one();
 }
 
 bool ppu_thread_exit(ppu_thread& ppu);
@@ -32,7 +33,8 @@ void lv2_int_serv::join()
 		std::bit_cast<u64>(&ppu_thread_exit)
 	});
 
-	thread_ctrl::notify(*thread);
+	thread->cmd_notify++;
+	thread->cmd_notify.notify_one();
 	(*thread)();
 
 	idm::remove_verify<named_thread<ppu_thread>>(thread->id, static_cast<std::weak_ptr<named_thread<ppu_thread>>>(thread));
@@ -114,7 +116,7 @@ error_code _sys_interrupt_thread_establish(ppu_thread& ppu, vm::ptr<u32> ih, u32
 		result = std::make_shared<lv2_int_serv>(it, arg1, arg2);
 		tag->handler = result;
 		it->state -= cpu_flag::stop;
-		thread_ctrl::notify(*it);
+		it->state.notify_one(cpu_flag::stop);
 		return result;
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -770,7 +770,7 @@ error_code mmapper_thread_recover_page_fault(cpu_thread* cpu)
 	else
 	{
 		cpu->state += cpu_flag::signal;
-		cpu->notify();
+		cpu->state.notify_one(cpu_flag::signal);
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -185,7 +185,7 @@ error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr
 
 	if (ppu.test_stopped())
 	{
-		return 0;
+		return {};
 	}
 
 	// Get the exit status from the register
@@ -533,7 +533,8 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 	}
 	else
 	{
-		thread_ctrl::notify(*thread);
+		thread->cmd_notify++;
+		thread->cmd_notify.notify_one();
 
 		// Dirty hack for sound: confirm the creation of _mxr000 event queue
 		if (*thread->ppu_tname.load() == "_cellsurMixerMain"sv)
@@ -548,7 +549,7 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 			{
 				if (ppu.is_stopped())
 				{
-					return 0;
+					return {};
 				}
 
 				thread_ctrl::wait_for(50000);

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -350,9 +350,14 @@ void _sys_process_exit(ppu_thread& ppu, s32 status, u32 arg2, u32 arg3)
 	});
 
 	// Wait for GUI thread
-	while (!ppu.is_stopped())
+	while (auto state = +ppu.state)
 	{
-		thread_ctrl::wait();
+		if (is_stopped(state))
+		{
+			break;
+		}
+
+		thread_ctrl::wait_on(ppu.state, state);
 	}
 }
 
@@ -437,9 +442,14 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 	});
 
 	// Wait for GUI thread
-	while (!ppu.is_stopped())
+	while (auto state = +ppu.state)
 	{
-		thread_ctrl::wait();
+		if (is_stopped(state))
+		{
+			break;
+		}
+
+		thread_ctrl::wait_on(ppu.state, state);
 	}
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -65,7 +65,7 @@ void lv2_rsx_config::send_event(u64 data1, u64 event_flags, u64 data3) const
 		thread_ctrl::wait_for(100);
 
 		if (cpu && cpu->id_type() == 0x55)
-			cpu->cpu_wait();
+			cpu->cpu_wait({});
 
 		if (Emu.IsStopped() || (cpu && cpu->check_state()))
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -722,14 +722,19 @@ error_code sys_usbd_receive_event(ppu_thread& ppu, u32 handle, vm::ptr<u64> arg1
 		usbh->sq.emplace_back(&ppu);
 	}
 
-	while (!ppu.state.test_and_reset(cpu_flag::signal))
+	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
 	{
-		if (ppu.is_stopped())
+		if (is_stopped(state))
 		{
-			return 0;
+			return {};
 		}
 
-		thread_ctrl::wait();
+		if (state & cpu_flag::signal)
+		{
+			break;
+		}
+
+		thread_ctrl::wait_on(ppu.state, state);
 	}
 
 	*arg1 = ppu.gpr[4];

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -747,7 +747,7 @@ bool gdb_thread::cmd_vcont(gdb_cmd& cmd)
 		if (Emu.IsPaused()) {
 			Emu.Resume();
 		} else {
-			thread_ctrl::notify(*ppu);
+			ppu->state.notify_one();
 		}
 		wait_with_interrupts();
 		//we are in all-stop mode

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -530,7 +530,7 @@ namespace rsx
 		on_exit();
 	}
 
-	void thread::cpu_wait()
+	void thread::cpu_wait(bs_t<cpu_flag>)
 	{
 		if (external_interrupt_lock)
 		{
@@ -604,7 +604,7 @@ namespace rsx
 									{ ppu_cmd::sleep, 0 }
 								});
 
-								thread_ctrl::notify(*intr_thread);
+								intr_thread->cmd_notify.notify_one();
 							}
 						}
 						else
@@ -3079,7 +3079,8 @@ namespace rsx
 				{ ppu_cmd::sleep, 0 }
 			});
 
-			thread_ctrl::notify(*intr_thread);
+			intr_thread->cmd_notify++;
+			intr_thread->cmd_notify.notify_one();
 		}
 	}
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -657,7 +657,7 @@ namespace rsx
 		u32 get_fifo_cmd() const;
 	
 		std::string dump_regs() const override;
-		void cpu_wait() override;
+		void cpu_wait(bs_t<cpu_flag> old) override;
 
 		// Performance approximation counters
 		struct

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -90,7 +90,7 @@ namespace rsx
 
 						while (rsx->is_paused())
 						{
-							rsx->cpu_wait();
+							rsx->cpu_wait({});
 						}
 
 						// Reset
@@ -107,7 +107,7 @@ namespace rsx
 					}
 				}
 
-				rsx->cpu_wait();
+				rsx->cpu_wait({});
 			}
 
 			rsx->fifo_wake_delay();
@@ -1608,7 +1608,8 @@ namespace rsx
 				{ ppu_cmd::sleep, 0 }
 			});
 
-			thread_ctrl::notify(*rsx->intr_thread);
+			rsx->intr_thread->cmd_notify++;
+			rsx->intr_thread->cmd_notify.notify_one();
 		}
 	}
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -161,7 +161,7 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *
 			// Notify only if no pause flags are set after this change
 			if (!(old & s_pause_flags))
 			{
-				cpu->notify();
+				cpu->state.notify_one(s_pause_flags);
 			}
 		}
 		UpdateUI();
@@ -852,7 +852,7 @@ void debugger_frame::DoStep(bool stepOver)
 				if (!should_step_over) state += cpu_flag::dbg_step;
 			});
 
-			cpu->notify();
+			cpu->state.notify_one(s_pause_flags);
 		}
 	}
 


### PR DESCRIPTION
## Enhancements
* Use atomic waitables instead instead of global thread notifications as often as possible.
* Add ::is_stopped() and and ::is_paued() which can be used in atomic loops and with atomic wait. (constexpr cpu flags test functions)
* Function time statistics at Emu.Stop() restored. (instead of current "X syscall failed with 0x00000000 : 0")

## Bugfixes
* Fix notification bug of sys_spu_thread_group_exit/terminate. (old bug, enhanced by #9117)
* Fix emulation stopping bugs.