### PR TITLE
Waiting on multiple atomics (waitable atomic list)

### DIFF
--- a/Utilities/sync.h
+++ b/Utilities/sync.h
@@ -16,6 +16,7 @@
 #include <linux/futex.h>
 #include <sys/time.h>
 #include <unistd.h>
+#include <fcntl.h>
 #endif
 #include <algorithm>
 #include <ctime>

--- a/rpcs3/util/atomic.cpp
+++ b/rpcs3/util/atomic.cpp
@@ -1198,7 +1198,12 @@ atomic_wait_engine::notify_all(const void* data, u32 size, __m128i mask, __m128i
 		// Cleanup locked notifiers
 		for (u64 bits = lock; bits; bits &= bits - 1)
 		{
-			cond_free(lock_ids[std::countr_zero(bits)]);
+			const u32 id = std::countr_zero(bits);
+
+			if (u32 cond_id = lock_ids[id])
+			{
+				cond_free(cond_id);
+			}
 		}
 
 		s_tls_notify_cb(data, -1);

--- a/rpcs3/util/atomic.cpp
+++ b/rpcs3/util/atomic.cpp
@@ -22,11 +22,11 @@ static constexpr uint s_hashtable_power = 16;
 // Total number of entries, should be a power of 2.
 static constexpr std::uintptr_t s_hashtable_size = 1u << s_hashtable_power;
 
-// Pointer mask without bits used as hash, assuming signed 48-bit pointers.
-static constexpr u64 s_pointer_mask = s_hashtable_power > 7 ? 0xffff'ffff'ffff & ~((s_hashtable_size - 1)) : 0xffff'ffff'ffff;
+// Pointer mask without bits used as hash, assuming 47-bit pointers.
+static constexpr u64 s_pointer_mask = s_hashtable_power > 7 ? 0x7fff'ffff'ffff & ~((s_hashtable_size - 1)) : 0x7fff'ffff'ffff;
 
-// Max number of waiters is 32767.
-static constexpr u64 s_waiter_mask = s_hashtable_power > 7 ? 0x7fff'0000'0000'0000 : 0x7f00'0000'0000'0000;
+// Max number of waiters is 65535.
+static constexpr u64 s_waiter_mask = s_hashtable_power > 7 ? 0x7fff'8000'0000'0000 : 0x7f80'0000'0000'0000;
 
 // Bit indicates that more than one.
 static constexpr u64 s_collision_bit = 0x8000'0000'0000'0000;


### PR DESCRIPTION
It's like poll or WaitForMultipleObjects, although there is no way to make them inter-operable.
Both atomics should belong to the same homebrew type atomic_t.