### PR TITLE
Set AccountAge to 18

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -2737,6 +2737,8 @@ error_code sceNpManagerGetAccountAge(vm::ptr<s32> age)
 		return SCE_NP_ERROR_INVALID_STATE;
 	}
 
+	*age = 18;
+
 	return CELL_OK;
 }
 
@@ -2807,7 +2809,7 @@ error_code sceNpManagerGetChatRestrictionFlag(vm::ptr<s32> isRestricted)
 
 error_code sceNpManagerGetCachedInfo(CellSysutilUserId userId, vm::ptr<SceNpManagerCacheParam> param)
 {
-	sceNp.todo("sceNpManagerGetChatRestrictionFlag(userId=%d, param=*0x%x)", userId, param);
+	sceNp.todo("sceNpManagerGetCachedInfo(userId=%d, param=*0x%x)", userId, param);
 
 	const auto nph = g_fxo->get<named_thread<np_handler>>();
 


### PR DESCRIPTION
This change fixes the age restrictions for online features in Skate 3. Details of discussion with @RipleyTom are here https://discordapp.com/channels/272035812277878785/738838647176036393/774519382302392322

* Set age in GetAccountAge to 18, this matches the other parental control functions in sceNpManager.
* Fix incorrect function in log message

![image](https://user-images.githubusercontent.com/1286822/98437098-51dc0b00-20a5-11eb-9211-94752bbb4db7.png)
