### PR TITLE
Debugger: Implement SPU callstack, fix PPU callstack

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -792,7 +792,7 @@ public:
 	template<typename T>
 	to_be_t<T>* _ptr(u32 lsa) const
 	{
-		return reinterpret_cast<to_be_t<T>*>(ls + lsa);
+		return reinterpret_cast<to_be_t<T>*>(ls + (lsa % SPU_LS_SIZE));
 	}
 
 	// Convert specified SPU LS address to a reference of specified (possibly converted to BE) type


### PR DESCRIPTION
* In PPU, leaf functions do not need to save LR, we had a workaround for it by not reading first function call so the callstack would not be empty for it.
But this is wrong as it always skips one function call, so, for leaf functions use LR directly and place it on top of the callstack list.
* Implement SPU callstack, with the same fix from PPU. 