### PR TITLE
Debugger: Improve SPU/PPU callstack handling a bit

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -591,7 +591,13 @@ std::vector<std::pair<u32, u32>> ppu_thread::dump_callstack_list() const
 
 		auto is_invalid = [](u64 addr)
 		{
-			return (addr > UINT32_MAX || addr % 4 || !vm::check_addr(static_cast<u32>(addr), 1, vm::page_executable));
+			if (addr > UINT32_MAX || addr % 4 || !vm::check_addr(static_cast<u32>(addr), 1, vm::page_executable))
+			{
+				return true;
+			}
+
+			// Ignore HLE stop address
+			return addr == ppu_function_manager::addr + 8;
 		};
 
 		if (is_invalid(addr))

--- a/rpcs3/rpcs3qt/call_stack_list.cpp
+++ b/rpcs3/rpcs3qt/call_stack_list.cpp
@@ -23,7 +23,7 @@ void call_stack_list::HandleUpdate(std::vector<std::pair<u32, u32>> call_stack)
 
 	for (const auto& addr : call_stack)
 	{
-		const QString call_stack_item_text = qstr(fmt::format("0x%08llx (r1=0x%08llx)", addr.first, addr.second));
+		const QString call_stack_item_text = qstr(fmt::format("0x%08llx (sp=0x%08llx)", addr.first, addr.second));
 		QListWidgetItem* callStackItem = new QListWidgetItem(call_stack_item_text);
 		callStackItem->setData(Qt::UserRole, { addr.first });
 		addItem(callStackItem);

--- a/rpcs3/rpcs3qt/kernel_explorer.h
+++ b/rpcs3/rpcs3qt/kernel_explorer.h
@@ -21,6 +21,7 @@ class kernel_explorer : public QDialog
 		spu_thread_groups,
 		rsx_contexts,
 		file_descriptors,
+		process_info,
 	};
 
 public:


### PR DESCRIPTION
* Make SPU code address checks check destination code validity (STOP 0x0 is considered invalid). replacement for PPU functionality where its checking vm::page_executable. This fixes thinking stuff like zero initilizaed LR save area is valid which is very common especially at the end of SPU stack.
* Ignore PPU HLE stop address, it has no use for us.
* Add some process information in kernel-explorer.