### PR TITLE
Hotfix for shm->map_self()

### DIFF
--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -254,8 +254,32 @@ namespace utils
 
 		return nullptr;
 #else
-		const u64 ptr64 = reinterpret_cast<u64>(ptr);
-		return static_cast<u8*>(::mmap(reinterpret_cast<void*>(ptr64 & -0x10000), m_size, +prot, MAP_SHARED | (ptr ? MAP_FIXED : 0), m_file, 0));
+		const u64 ptr64 = reinterpret_cast<u64>(ptr) & -0x10000;
+
+		if (ptr64)
+		{
+			return reinterpret_cast<u8*>(reinterpret_cast<u64>(::mmap(reinterpret_cast<void*>(ptr64), m_size, +prot, MAP_SHARED | MAP_FIXED, m_file, 0)));
+		}
+		else
+		{
+			const u64 res64 = reinterpret_cast<u64>(::mmap(reinterpret_cast<void*>(ptr64), m_size + 0xe000, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0));
+
+			const u64 aligned = ::align(res64, 0x10000);
+			const auto result = ::mmap(reinterpret_cast<void*>(aligned), m_size, +prot, MAP_SHARED | MAP_FIXED, m_file, 0);
+
+			// Now cleanup remnants
+			if (aligned > res64)
+			{
+				verify(HERE), ::munmap(reinterpret_cast<void*>(res64), aligned - res64) == 0;
+			}
+
+			if (aligned < res64 + 0xe000)
+			{
+				verify(HERE), ::munmap(reinterpret_cast<void*>(aligned + m_size), (res64 + 0xe000) - (aligned)) == 0;
+			}
+
+			return reinterpret_cast<u8*>(result);
+		}
 #endif
 	}
 


### PR DESCRIPTION
Make sure mmap returns 64K-aligned results, as on Windows.
Does not affect Windows, but RPCS3 relies on this logic so need a little workaround.