### PR TITLE
Make SPU Debugger usable by humans

### DIFF
--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -7,7 +7,7 @@ enum CPUDisAsmMode
 {
 	CPUDisAsm_DumpMode,
 	CPUDisAsm_InterpreterMode,
-	//CPUDisAsm_NormalMode,
+	CPUDisAsm_NormalMode,
 	CPUDisAsm_CompilerElfMode,
 };
 
@@ -21,24 +21,36 @@ protected:
 		switch(m_mode)
 		{
 			case CPUDisAsm_DumpMode:
+			{
 				last_opcode = fmt::format("\t%08x:\t%02x %02x %02x %02x\t%s\n", dump_pc,
 					offset[dump_pc],
 					offset[dump_pc + 1],
 					offset[dump_pc + 2],
 					offset[dump_pc + 3], value);
-			break;
+				break;
+			}
 
 			case CPUDisAsm_InterpreterMode:
+			{
 				last_opcode = fmt::format("[%08x]  %02x %02x %02x %02x: %s", dump_pc,
 					offset[dump_pc],
 					offset[dump_pc + 1],
 					offset[dump_pc + 2],
 					offset[dump_pc + 3], value);
-			break;
+				break;
+			}
 
 			case CPUDisAsm_CompilerElfMode:
-				last_opcode = value + "\n";
-			break;
+			{
+				last_opcode = value + '\n';
+				break;
+			}
+			case CPUDisAsm_NormalMode:
+			{
+				last_opcode = value;
+				break;
+			}
+			default: ASSUME(0);
 		}
 	}
 
@@ -79,9 +91,13 @@ protected:
 		return fmt::format("%s%s", v < 0 ? "-" : "", av);
 	}
 
-	static std::string FixOp(std::string op)
+	std::string FixOp(std::string op) const
 	{
-		op.resize(std::max<std::size_t>(op.length(), 10), ' ');
+		if (m_mode != CPUDisAsm_NormalMode)
+		{
+			op.resize(std::max<std::size_t>(op.length(), 10), ' ');
+		}
+
 		return op;
 	}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -11,6 +11,7 @@
 #include "PPUInterpreter.h"
 #include "PPUAnalyser.h"
 #include "PPUModule.h"
+#include "PPUDisAsm.h"
 #include "SPURecompiler.h"
 #include "lv2/sys_sync.h"
 #include "lv2/sys_prx.h"
@@ -482,7 +483,11 @@ std::string ppu_thread::dump_regs() const
 				}
 				else
 				{
-					fmt::append(ret, " -> function-code");
+					PPUDisAsm dis_asm(CPUDisAsm_NormalMode);
+					dis_asm.offset = vm::g_sudo_addr;
+					dis_asm.dump_pc = reg;
+					dis_asm.disasm(reg);
+					fmt::append(ret, " -> %s", dis_asm.last_opcode);
 				}
 			}
 			else if (std::isprint(static_cast<u8>(buf_tmp[0])) && std::isprint(static_cast<u8>(buf_tmp[1])) && std::isprint(static_cast<u8>(buf_tmp[2])))

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -97,7 +97,11 @@ private:
 private:
 	std::string& FixOp(std::string& op)
 	{
-		op.append(std::max<int>(10 - ::narrow<int>(op.size()), 0),' ');
+		if (m_mode != CPUDisAsm_NormalMode)
+		{
+			op.append(std::max<int>(10 - ::narrow<int>(op.size()), 0), ' ');
+		}
+
 		return op;
 	}
 	void DisAsm(const char* op)

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -778,6 +778,7 @@ public:
 	void set_events(u32 bits);
 	void set_interrupt_status(bool enable);
 	bool check_mfc_interrupts(u32 nex_pc);
+	bool is_exec_code(u32 addr) const; // Only a hint, do not rely on it other than debugging purposes
 	u32 get_ch_count(u32 ch);
 	s64 get_ch_value(u32 ch);
 	bool set_ch_value(u32 ch, u32 value);


### PR DESCRIPTION
* If all 4 32-bit pieces of the 128-bite GPR register are equal, print in short 32-bit format and add '$' after it. (most of the time)
* For insertation masks: do not print the original value which are :think-hang:, print a comment describing it instead. 
* Executable code pointers show first instruction (full diassembly of it) they are pointing, the same technique has been applied for PPU instead of commenting "function-code" after it.
For this feature...
* Improve SPU executable code detection, make it much more reliable. (applies for callstack code as well)


**Before:**
![image](https://user-images.githubusercontent.com/18193363/98695550-6eb16080-237b-11eb-95b7-4d9ad15667c3.png)
![image](https://user-images.githubusercontent.com/18193363/98695614-7d981300-237b-11eb-9537-4c6585a0c4cc.png)
**After:**
![image](https://user-images.githubusercontent.com/18193363/98695123-f480dc00-237a-11eb-9b8d-440592c8779a.png)
![image](https://user-images.githubusercontent.com/18193363/98695174-04002500-237b-11eb-9215-1136fd7593e8.png)