### PR TITLE
Debugger: Improve SPU/PPU vector registers further, Implement broadcasting for Registers Editor

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -513,9 +513,24 @@ std::string ppu_thread::dump_regs() const
 		fmt::append(ret, "f%d%s: %.6G\n", i, i <= 9 ? " " : "", fpr[i]);
 	}
 
-	for (uint i = 0; i < 32; ++i)
+	for (uint i = 0; i < 32; ++i, ret += '\n')
 	{
-		fmt::append(ret, "v%d%s: %s [x: %g y: %g z: %g w: %g]\n", i, i <= 9 ? " " : "", vr[i], vr[i]._f[3], vr[i]._f[2], vr[i]._f[1], vr[i]._f[0]);
+		fmt::append(ret, "v%d%s: ", i, i <= 9 ? " " : "");
+ 
+		const auto r = vr[i];
+		const u32 i3 = r.u32r[0];
+
+		if (v128::from32p(i3) == r)
+		{
+			// Shortand formatting
+			fmt::append(ret, "%08x", i3);
+			fmt::append(ret, " [x: %g]", r.fr[0]);
+		}
+		else
+		{
+			fmt::append(ret, "%08x %08x %08x %08x", r.u32r[0], r.u32r[1], r.u32r[2], r.u32r[3]);
+			fmt::append(ret, " [x: %g y: %g z: %g w: %g]", r.fr[0], r.fr[1], r.fr[2], r.fr[3]);
+		}
 	}
 
 	fmt::append(ret, "CR: 0x%08x\n", cr.pack());

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1202,7 +1202,7 @@ std::string spu_thread::dump_regs() const
 
 		if (auto [size, dst, src] = SPUDisAsm::try_get_insert_mask_info(r); size)
 		{
-			// Special: insertation masks
+			// Special: insertion masks
 
 			const std::string_view type =
 				size == 1 ? "byte" :
@@ -1222,12 +1222,14 @@ std::string spu_thread::dump_regs() const
 		if (v128::from32p(i3) == r)
 		{
 			// Shortand formatting
-			fmt::append(ret, "0x%08x$", i3);
+			fmt::append(ret, "%08x", i3);
 		}
 		else
 		{
-			fmt::append(ret, "%s", r);
+			fmt::append(ret, "%08x %08x %08x %08x", r.u32r[0], r.u32r[1], r.u32r[2], r.u32r[3]);
 		}
+
+		// TODO: SPU floats fomatting
 
 		if (i3 >= 0x80 && is_exec_code(i3))
 		{


### PR DESCRIPTION
* Improve vector registers display.
* Similar to #9236, if all 4 32-bit pieces of SPU register are equal to each other display a single piece with '$' after it.
This also works for register modification: e.g. `1$` is the same as `0x00000001000000010000000100000001`