### PR TITLE
SPU Debugger: Implement float registers view + General debugger fixes

### DIFF
--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -218,6 +218,12 @@ typename SPUDisAsm::insert_mask_info SPUDisAsm::try_get_insert_mask_info(v128 ma
 		return {};
 	}
 
+	if (size == 16)
+	{
+		// 0x0, 0x1, 0x2, .. 0xE, 0xF is not allowed
+		return {};
+	}
+
 	// [type size, dst index, src index]
 	return {size, first / size, src_first / size};
 }

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1194,9 +1194,11 @@ std::string spu_thread::dump_regs() const
 {
 	std::string ret;
 
+	const bool floats_only = debugger_float_mode.load();
+
 	for (u32 i = 0; i < 128; i++, ret += '\n')
 	{
-		fmt::append(ret, "r%d: ", i);
+		fmt::append(ret, "%s: ", spu_reg_name[i]);
 
 		const auto r = gpr[i];
 
@@ -1217,9 +1219,25 @@ std::string spu_thread::dump_regs() const
 			}
 		}
 
-		const u32 i3 = r._u32[3];
+		auto to_f64 = [](u32 bits)
+		{
+			const u32 abs = bits & 0x7fff'ffff;
+			constexpr u32 mask = (1 << 23) - 1;
+			return std::copysign(abs <= mask ? 0 : std::exp2(static_cast<int>(abs >> 23) - 127) * (1.0 + (abs & mask) / f64{mask + 1}), bits >> 31 ? -1 : 1);
+		};
 
-		if (v128::from32p(i3) == r)
+		const double array[]{to_f64(r.u32r[0]), to_f64(r.u32r[1]), to_f64(r.u32r[2]), to_f64(r.u32r[3])};
+
+		const u32 i3 = r._u32[3];
+		const bool is_packed = v128::from32p(i3) == r;
+
+		if (floats_only)
+		{
+			fmt::append(ret, "%s, %s, %s, %s", array[0], array[1], array[2], array[3]);
+			continue;
+		}
+
+		if (is_packed)
 		{
 			// Shortand formatting
 			fmt::append(ret, "%08x", i3);
@@ -1229,8 +1247,6 @@ std::string spu_thread::dump_regs() const
 			fmt::append(ret, "%08x %08x %08x %08x", r.u32r[0], r.u32r[1], r.u32r[2], r.u32r[3]);
 		}
 
-		// TODO: SPU floats fomatting
-
 		if (i3 >= 0x80 && is_exec_code(i3))
 		{
 			SPUDisAsm dis_asm(CPUDisAsm_NormalMode);
@@ -1238,6 +1254,18 @@ std::string spu_thread::dump_regs() const
 			dis_asm.dump_pc = i3;
 			dis_asm.disasm(i3);
 			fmt::append(ret, " -> %s", dis_asm.last_opcode);
+		}
+
+		if (std::any_of(std::begin(array), std::end(array), [](f64 v){ return v != 0; }))
+		{
+			if (is_packed)
+			{
+				fmt::append(ret, " (%s)", array[0]);
+			}
+			else
+			{
+				fmt::append(ret, " (%s, %s, %s, %s)", array[0], array[1], array[2], array[3]);
+			}
 		}
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1223,7 +1223,7 @@ std::string spu_thread::dump_regs() const
 		{
 			const u32 abs = bits & 0x7fff'ffff;
 			constexpr u32 mask = (1 << 23) - 1;
-			return std::copysign(abs <= mask ? 0 : std::exp2(static_cast<int>(abs >> 23) - 127) * (1.0 + (abs & mask) / f64{mask + 1}), bits >> 31 ? -1 : 1);
+			return std::copysign(abs <= mask ? 0 : std::ldexp(1.0 + (abs & mask) / f64{mask + 1}, static_cast<int>(abs >> 23) - 127), bits >> 31 ? -1 : 1);
 		};
 
 		const double array[]{to_f64(r.u32r[0]), to_f64(r.u32r[1]), to_f64(r.u32r[2]), to_f64(r.u32r[3])};
@@ -1233,7 +1233,7 @@ std::string spu_thread::dump_regs() const
 
 		if (floats_only)
 		{
-			fmt::append(ret, "%s, %s, %s, %s", array[0], array[1], array[2], array[3]);
+			fmt::append(ret, "%g, %g, %g, %g", array[0], array[1], array[2], array[3]);
 			continue;
 		}
 
@@ -1260,11 +1260,11 @@ std::string spu_thread::dump_regs() const
 		{
 			if (is_packed)
 			{
-				fmt::append(ret, " (%s)", array[0]);
+				fmt::append(ret, " (%g)", array[0]);
 			}
 			else
 			{
-				fmt::append(ret, " (%s, %s, %s, %s)", array[0], array[1], array[2], array[3]);
+				fmt::append(ret, " (%g, %g, %g, %g)", array[0], array[1], array[2], array[3]);
 			}
 		}
 	}

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1222,8 +1222,8 @@ std::string spu_thread::dump_regs() const
 		auto to_f64 = [](u32 bits)
 		{
 			const u32 abs = bits & 0x7fff'ffff;
-			constexpr u32 mask = (1 << 23) - 1;
-			return std::copysign(abs <= mask ? 0 : std::ldexp(1.0 + (abs & mask) / f64{mask + 1}, static_cast<int>(abs >> 23) - 127), bits >> 31 ? -1 : 1);
+			constexpr u32 scale = (1 << 23);
+			return std::copysign(abs < scale ? 0 : std::ldexp((scale + (abs % scale)) / f64{scale}, static_cast<int>(abs >> 23) - 127), bits >> 31 ? -1 : 1);
 		};
 
 		const double array[]{to_f64(r.u32r[0]), to_f64(r.u32r[1]), to_f64(r.u32r[2]), to_f64(r.u32r[3])};

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -764,6 +764,8 @@ public:
 	const char* current_func{}; // Current STOP or RDCH blocking function
 	u64 start_time{}; // Starting time of STOP or RDCH bloking function
 
+	atomic_t<u8> debugger_float_mode = 0;
+
 	void push_snr(u32 number, u32 value);
 	static void do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8* ls);
 	bool do_dma_check(const spu_mfc_cmd& args);

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -224,7 +224,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 	const auto cpu = this->cpu.lock();
 	int i = m_debugger_list->currentRow();
 
-	if (!isActiveWindow() || i < 0 || !cpu || m_no_thread_selected)
+	if (!isActiveWindow() || !cpu || m_no_thread_selected)
 	{
 		return;
 	}
@@ -250,6 +250,11 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 		{
 		case Qt::Key_E:
 		{
+			if (i < 0)
+			{
+				return;
+			}
+
 			instruction_editor_dialog* dlg = new instruction_editor_dialog(this, pc, cpu, m_disasm.get());
 			dlg->show();
 			return;
@@ -266,7 +271,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 		}
 		case Qt::Key_R:
 		{
-			register_editor_dialog* dlg = new register_editor_dialog(this, pc, cpu, m_disasm.get());
+			register_editor_dialog* dlg = new register_editor_dialog(this, cpu, m_disasm.get());
 			dlg->show();
 			return;
 		}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -349,7 +349,7 @@ void debugger_frame::UpdateUI()
 	{
 		const auto cia = GetPc();
 		const auto size_context = cpu->id_type() == 1 ? sizeof(ppu_thread) : sizeof(spu_thread);
-		
+
 		if (m_last_pc != cia || m_last_query_state.size() != size_context || std::memcmp(m_last_query_state.data(), cpu.get(), size_context))
 		{
 			// Copy thread data

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -229,7 +229,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 		return;
 	}
 
-	const u32 pc = m_debugger_list->m_pc + i * 4;
+	const u32 pc = i >= 0 ? m_debugger_list->m_pc + i * 4 : GetPc();
 
 	const auto modifiers = QApplication::keyboardModifiers();
 
@@ -250,11 +250,6 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 		{
 		case Qt::Key_E:
 		{
-			if (i < 0)
-			{
-				return;
-			}
-
 			instruction_editor_dialog* dlg = new instruction_editor_dialog(this, pc, cpu, m_disasm.get());
 			dlg->show();
 			return;

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -254,6 +254,16 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 			dlg->show();
 			return;
 		}
+		case Qt::Key_F:
+		{
+			if (cpu->id_type() != 2)
+			{
+				return;
+			}
+
+			static_cast<spu_thread*>(cpu.get())->debugger_float_mode ^= 1; // Switch mode
+			return;
+		}
 		case Qt::Key_R:
 		{
 			register_editor_dialog* dlg = new register_editor_dialog(this, pc, cpu, m_disasm.get());
@@ -264,9 +274,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 		{
 			if (modifiers & Qt::AltModifier)
 			{
-				const auto cpu = this->cpu.lock();
-
-				if (!cpu || cpu->id_type() != 2)
+				if (cpu->id_type() != 2)
 				{
 					return;
 				}

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -43,7 +43,7 @@ class debugger_frame : public custom_dock_widget
 	u64 m_threads_created = 0;
 	u64 m_threads_deleted = 0;
 	u32 m_last_pc = -1;
-	u32 m_last_stat = 0;
+	std::vector<char> m_last_query_state;
 	u32 m_last_step_over_breakpoint = -1;
 	bool m_no_thread_selected = true;
 

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -55,9 +55,8 @@ enum registers : int
 	PC,
 };
 
-register_editor_dialog::register_editor_dialog(QWidget *parent, u32 _pc, const std::shared_ptr<cpu_thread>& _cpu, CPUDisAsm* _disasm)
+register_editor_dialog::register_editor_dialog(QWidget *parent, const std::shared_ptr<cpu_thread>& _cpu, CPUDisAsm* _disasm)
 	: QDialog(parent)
-	, m_pc(_pc)
 	, m_disasm(_disasm)
 	, cpu(_cpu)
 {

--- a/rpcs3/rpcs3qt/register_editor_dialog.h
+++ b/rpcs3/rpcs3qt/register_editor_dialog.h
@@ -13,7 +13,6 @@ class register_editor_dialog : public QDialog
 {
 	Q_OBJECT
 
-	u32 m_pc;
 	CPUDisAsm* m_disasm;
 	QComboBox* m_register_combo;
 	QLineEdit* m_value_line;
@@ -22,7 +21,7 @@ public:
 	std::weak_ptr<cpu_thread> cpu;
 
 public:
-	register_editor_dialog(QWidget *parent, u32 _pc, const std::shared_ptr<cpu_thread>& _cpu, CPUDisAsm* _disasm);
+	register_editor_dialog(QWidget *parent, const std::shared_ptr<cpu_thread>& _cpu, CPUDisAsm* _disasm);
 
 private:
 	void OnOkay(const std::shared_ptr<cpu_thread>& _cpu);


### PR DESCRIPTION
* New SPU floating point view of registers, by default it resides after the hexadecimal view. This is real SPU float format and not the x86 float! values such as infinities or NaNs do not exist for it andthere bit representatios in x86 will be presented as huge-ass numbers in SPU debugger. Same as for x86 denormals, its bit pattern is displayed as zero.
e.g.
 https://user-images.githubusercontent.com/18193363/99120407-7aaf5380-2603-11eb-92fb-78958412d997.PNG

* Adds a new "floats only mode" after pressing F, it switches to clean view of registers state in floats only format. This required a few  bugfixes to work properly... (described below) https://user-images.githubusercontent.com/18193363/99120376-7125eb80-2603-11eb-87d8-309555b627ef.png

* Fixed debugger shortucts, no longer needs to select on thread's instructions for it to work. (but the debugger window needs to be active)

* Always update thread state if any change to the thread context was made! this fixes corner cases such thread executing a syscall in loop with registers bieng updated with brief short of time in other instructions not showing changes in debugger while running. Or a switch from SPU/PPU thread to another SPU/PPU thread with the same PC value could have not made any update!
Also required for "floats-only" mode switch and registers editor to show changes.
