### PR TITLE
Memory locking refactoring

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -262,6 +262,9 @@ public:
 	// Miscellaneous
 	static u64 get_thread_affinity_mask();
 
+	// Get current thread stack addr and size
+	static std::pair<void*, std::size_t> get_thread_stack();
+
 private:
 	// Miscellaneous
 	static const u64 process_affinity_mask;

--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -434,7 +434,7 @@ error_code cellCameraOpenEx(s32 dev_num, vm::ptr<CellCameraInfoEx> info)
 
 	if (info->read_mode != CELL_CAMERA_READ_DIRECT && !info->buffer)
 	{
-		info->buffer = vm::cast(vm::alloc(vbuf_size, vm::memory_location_t::main));
+		info->buffer = vm::cast(vm::alloc(vbuf_size, vm::main));
 		info->bytesize = vbuf_size;
 	}
 
@@ -480,7 +480,7 @@ error_code cellCameraClose(s32 dev_num)
 		return CELL_CAMERA_ERROR_NOT_OPEN;
 	}
 
-	vm::dealloc(g_camera->info.buffer.addr(), vm::memory_location_t::main);
+	vm::dealloc(g_camera->info.buffer.addr(), vm::main);
 	g_camera->is_open = false;
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -28,7 +28,7 @@ inline void try_start(spu_thread& spu)
 
 bool spu_thread::read_reg(const u32 addr, u32& value)
 {
-	const u32 offset = addr - this->offset - RAW_SPU_PROB_OFFSET;
+	const u32 offset = addr - (RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * index) - RAW_SPU_PROB_OFFSET;
 
 	spu_log.trace("RawSPU[%u]: Read32(0x%x, offset=0x%x)", index, addr, offset);
 
@@ -165,7 +165,7 @@ bool spu_thread::read_reg(const u32 addr, u32& value)
 
 bool spu_thread::write_reg(const u32 addr, const u32 value)
 {
-	const u32 offset = addr - this->offset - RAW_SPU_PROB_OFFSET;
+	const u32 offset = addr - (RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * index) - RAW_SPU_PROB_OFFSET;
 
 	spu_log.trace("RawSPU[%u]: Write32(0x%x, offset=0x%x, value=0x%x)", index, addr, offset, value);
 
@@ -321,7 +321,7 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 
 void spu_load_exec(const spu_exec_object& elf)
 {
-	auto ls0 = vm::cast(vm::falloc(RAW_SPU_BASE_ADDR, SPU_LS_SIZE, vm::spu));
+	auto ls0 = vm::addr_t{RAW_SPU_BASE_ADDR};
 
 	spu_thread::g_raw_spu_ctr++;
 
@@ -333,7 +333,7 @@ void spu_load_exec(const spu_exec_object& elf)
 		}
 	}
 
-	auto spu = idm::make_ptr<named_thread<spu_thread>>("TEST_SPU", ls0, nullptr, 0, "", 0);
+	auto spu = idm::make_ptr<named_thread<spu_thread>>("TEST_SPU", nullptr, 0, "", 0);
 
 	spu_thread::g_raw_spu_id[0] = spu->id;
 

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -58,12 +58,13 @@ error_code sys_memory_allocate(cpu_thread& cpu, u32 size, u64 flags, vm::ptr<u32
 
 	if (const auto area = vm::reserve_map(align == 0x10000 ? vm::user64k : vm::user1m, 0, ::align(size, 0x10000000), 0x401))
 	{
-		if (u32 addr = area->alloc(size, align))
+		if (u32 addr = area->alloc(size, nullptr, align))
 		{
 			verify(HERE), !g_fxo->get<sys_memory_address_table>()->addrs[addr >> 16].exchange(dct);
 
 			if (alloc_addr)
 			{
+				vm::lock_sudo(addr, size);
 				*alloc_addr = addr;
 				return CELL_OK;
 			}
@@ -134,6 +135,7 @@ error_code sys_memory_allocate_from_container(cpu_thread& cpu, u32 size, u32 cid
 
 			if (alloc_addr)
 			{
+				vm::lock_sudo(addr, size);
 				*alloc_addr = addr;
 				return CELL_OK;
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -77,6 +77,7 @@ error_code sys_vm_memory_map(ppu_thread& ppu, u32 vsize, u32 psize, u32 cid, u64
 	{
 		// Alloc all memory (shall not fail)
 		verify(HERE), area->alloc(vsize);
+		vm::lock_sudo(area->addr, vsize);
 
 		idm::make<sys_vm_t>(area->addr, vsize, ct, psize);
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -733,11 +733,17 @@ namespace vm
 			rsxthr->on_notify_memory_mapped(addr, size);
 		}
 
+		auto prot = utils::protection::rw;
+		if (~flags & page_writable)
+			prot = utils::protection::ro;
+		if (~flags & page_readable)
+			prot = utils::protection::no;
+
 		if (!shm)
 		{
-			utils::memory_protect(g_base_addr + addr, size, utils::protection::rw);
+			utils::memory_protect(g_base_addr + addr, size, prot);
 		}
-		else if (shm->map_critical(g_base_addr + addr) != g_base_addr + addr || shm->map_critical(g_sudo_addr + addr) != g_sudo_addr + addr)
+		else if (shm->map_critical(g_base_addr + addr, prot) != g_base_addr + addr || shm->map_critical(g_sudo_addr + addr) != g_sudo_addr + addr)
 		{
 			fmt::throw_exception("Memory mapping failed - blame Windows (addr=0x%x, size=0x%x, flags=0x%x)", addr, size, flags);
 		}

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -763,18 +763,6 @@ namespace vm
 
 		// Unlock
 		g_range_lock.release(0);
-
-		perf_meter<"PAGE_LCK"_u64> perf1;
-
-		if (!g_use_rtm)
-		{
-			perf1.reset();
-		}
-		else if (!utils::memory_lock(g_sudo_addr + addr, size))
-		{
-			vm_log.error("Failed to lock memory. Consider increasing your system limits.\n"
-				"addr=0x%x, size=0x%x, shm=%d, shm:[f=%d,l=%u]", addr, size, +!!shm, shm ? shm->flags() : 0, shm ? shm->info : 0);
-		}
 	}
 
 	bool page_protect(u32 addr, u32 size, u8 flags_test, u8 flags_set, u8 flags_clear)
@@ -1009,7 +997,7 @@ namespace vm
 			fmt::throw_exception("Invalid memory location (%u)" HERE, +location);
 		}
 
-		return block->alloc(size, align);
+		return block->alloc(size, nullptr, align);
 	}
 
 	u32 falloc(u32 addr, u32 size, memory_location_t location)
@@ -1050,6 +1038,19 @@ namespace vm
 		{
 			vm_log.error("vm::dealloc(): deallocation failed (addr=0x%x)\n", addr);
 			return;
+		}
+	}
+
+	void lock_sudo(u32 addr, u32 size)
+	{
+		perf_meter<"PAGE_LCK"_u64> perf;
+
+		verify("lock_sudo" HERE), addr % 4096 == 0;
+		verify("lock_sudo" HERE), size % 4096 == 0;
+
+		if (!utils::memory_lock(g_sudo_addr + addr, size))
+		{
+			vm_log.error("Failed to lock sudo memory (addr=0x%x, size=0x%x). Consider increasing your system limits.", addr, size);
 		}
 	}
 
@@ -1108,12 +1109,13 @@ namespace vm
 		, size(size)
 		, flags(flags)
 	{
-		if (flags & 0x100)
+		if (flags & 0x100 || flags & 0x20)
 		{
-			// Special path for 4k-aligned pages
+			// Special path for whole-allocated areas allowing 4k granularity
 			m_common = std::make_shared<utils::shm>(size);
-			verify(HERE), m_common->map_critical(vm::base(addr), utils::protection::no) == vm::base(addr);
-			verify(HERE), m_common->map_critical(vm::get_super_ptr(addr)) == vm::get_super_ptr(addr);
+			m_common->map_critical(vm::base(addr), utils::protection::no);
+			m_common->map_critical(vm::get_super_ptr(addr));
+			lock_sudo(addr, size);
 		}
 	}
 
@@ -1131,7 +1133,6 @@ namespace vm
 				it = next;
 			}
 
-			// Special path for 4k-aligned pages
 			if (m_common)
 			{
 				m_common->unmap_critical(vm::base(addr));
@@ -1140,15 +1141,13 @@ namespace vm
 		}
 	}
 
-	u32 block_t::alloc(const u32 orig_size, u32 align, const std::shared_ptr<utils::shm>* src, u64 flags)
+	u32 block_t::alloc(const u32 orig_size, const std::shared_ptr<utils::shm>* src, u32 align, u64 flags)
 	{
 		if (!src)
 		{
 			// Use the block's flags
 			flags = this->flags;
 		}
-
-		vm::writer_lock lock(0);
 
 		// Determine minimal alignment
 		const u32 min_page_size = flags & 0x100 ? 0x1000 : 0x10000;
@@ -1187,7 +1186,11 @@ namespace vm
 		else if (src)
 			shm = *src;
 		else
+		{
 			shm = std::make_shared<utils::shm>(size);
+		}
+
+		vm::writer_lock lock(0);
 
 		// Search for an appropriate place (unoptimized)
 		for (u32 addr = ::align(this->addr, align); u64{addr} + size <= u64{this->addr} + this->size; addr += align)
@@ -1208,8 +1211,6 @@ namespace vm
 			// Use the block's flags
 			flags = this->flags;
 		}
-
-		vm::writer_lock lock(0);
 
 		// Determine minimal alignment
 		const u32 min_page_size = flags & 0x100 ? 0x1000 : 0x10000;
@@ -1242,7 +1243,11 @@ namespace vm
 		else if (src)
 			shm = *src;
 		else
+		{
 			shm = std::make_shared<utils::shm>(size);
+		}
+
+		vm::writer_lock lock(0);
 
 		if (!try_alloc(addr, pflags, size, std::move(shm)))
 		{
@@ -1289,7 +1294,7 @@ namespace vm
 		}
 	}
 
-	std::pair<u32, std::shared_ptr<utils::shm>> block_t::get(u32 addr, u32 size)
+	std::pair<u32, std::shared_ptr<utils::shm>> block_t::peek(u32 addr, u32 size)
 	{
 		if (addr < this->addr || addr + u64{size} > this->addr + u64{this->size})
 		{
@@ -1602,12 +1607,12 @@ namespace vm
 
 			g_locations =
 			{
-				std::make_shared<block_t>(0x00010000, 0x1FFF0000, 0x200), // main
+				std::make_shared<block_t>(0x00010000, 0x1FFF0000, 0x220), // main
 				std::make_shared<block_t>(0x20000000, 0x10000000, 0x201), // user 64k pages
 				nullptr, // user 1m pages
 				nullptr, // rsx context
-				std::make_shared<block_t>(0xC0000000, 0x10000000), // video
-				std::make_shared<block_t>(0xD0000000, 0x10000000, 0x111), // stack
+				std::make_shared<block_t>(0xC0000000, 0x10000000, 0x220), // video
+				std::make_shared<block_t>(0xD0000000, 0x10000000, 0x131), // stack
 				std::make_shared<block_t>(0xE0000000, 0x20000000), // SPU reserved
 			};
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1313,10 +1313,10 @@ namespace vm
 			return {addr, nullptr};
 		}
 
-		// Special path
+		// Special case
 		if (m_common)
 		{
-			return {this->addr, m_common};
+			return {addr, nullptr};
 		}
 
 		// Range check

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -76,7 +76,7 @@ namespace vm
 			return check_addr(addr, flags, Size);
 		}
 
-		return !(~g_pages[addr / 4096].flags & (flags | page_allocated)); 
+		return !(~g_pages[addr / 4096].flags & (flags | page_allocated));
 	}
 
 	// Search and map memory in specified memory location (min alignment is 0x10000)
@@ -90,6 +90,9 @@ namespace vm
 
 	// dealloc() with no return value and no exceptions
 	void dealloc_verbose_nothrow(u32 addr, memory_location_t location = any) noexcept;
+
+	// utils::memory_lock wrapper for locking sudo memory
+	void lock_sudo(u32 addr, u32 size);
 
 	// Object that handles memory allocations inside specific constant bounds ("location")
 	class block_t final
@@ -113,7 +116,7 @@ namespace vm
 		const u64 flags; // Currently unused
 
 		// Search and map memory (min alignment is 0x10000)
-		u32 alloc(u32 size, u32 align = 0x10000, const std::shared_ptr<utils::shm>* = nullptr, u64 flags = 0);
+		u32 alloc(u32 size, const std::shared_ptr<utils::shm>* = nullptr, u32 align = 0x10000, u64 flags = 0);
 
 		// Try to map memory at fixed location
 		u32 falloc(u32 addr, u32 size, const std::shared_ptr<utils::shm>* = nullptr, u64 flags = 0);
@@ -122,7 +125,7 @@ namespace vm
 		u32 dealloc(u32 addr, const std::shared_ptr<utils::shm>* = nullptr);
 
 		// Get memory at specified address (if size = 0, addr assumed exact)
-		std::pair<u32, std::shared_ptr<utils::shm>> get(u32 addr, u32 size = 0);
+		std::pair<u32, std::shared_ptr<utils::shm>> peek(u32 addr, u32 size = 0);
 
 		// Get allocated memory count
 		u32 used();


### PR DESCRIPTION
Some description you can see in commits.

Memory locking in this context means certain pages will not be swapped and stay in memory. It does not increase memory consumption, because the same physical memory will be allocated nevertheless. However, it makes "touching" memory for TSX unnecessary because TSX transactions cannot work if certain memory pages are not initializes.