### PR TITLE
Fix SPU count limit

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1868,11 +1868,11 @@ void spu_thread::do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8*
 			{
 				if (is_get)
 				{
-					std::memmove(this->ls + offset, spu.ls + offset, args.size); // memmove for cases which transfers happen in the same SPU for now
+					std::memmove(_this->ls + offset, spu.ls + offset, args.size); // memmove for cases which transfers happen in the same SPU for now
 				}
 				else if (args.cmd != MFC_SDCRZ_CMD)
 				{
-					std::memmove(spu.ls + offset, this->ls + offset, args.size);
+					std::memmove(spu.ls + offset, _this->ls + offset, args.size);
 				}
 				else
 				{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1384,10 +1384,19 @@ std::string spu_thread::dump_misc() const
 		fmt::append(ret, "...chunk-0x%05x", (name & 0xffff) * 4);
 	}
 
-	const u32 offset = group ? SPU_FAKE_BASE_ADDR + (id & 0xffffff) * SPU_LS_SIZE : RAW_SPU_BASE_ADDR + index * RAW_SPU_OFFSET;
+	const u64 offset = !group ? RAW_SPU_BASE_ADDR + index * RAW_SPU_OFFSET :
+		(g_cfg.core.spu_debug_local_storage ? SPU_FAKE_BASE_ADDR + u64{id & 0xffffff} * SPU_LS_SIZE : UINT64_MAX);
 
 	fmt::append(ret, "\n[%s]", ch_mfc_cmd);
-	fmt::append(ret, "\nLocal Storage: 0x%08x..0x%08x", offset, offset + 0x3ffff);
+
+	if (offset < RAW_SPU_BASE_ADDR)
+	{
+		fmt::append(ret, "\nLocal Storage: 0x%08x..0x%08x", offset, offset + 0x3ffff);
+	}
+	else
+	{
+		fmt::append(ret, "\nLocal Storage: N/A");
+	}
 
 	if (const u64 _time = start_time)
 	{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1866,7 +1866,7 @@ void spu_thread::do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8*
 
 			if (offset <= SPU_LS_SIZE - args.size) // LS access
 			{
-				if (is_get);
+				if (is_get)
 				{
 					std::memmove(this->ls + offset, spu.ls + offset, size); // memmove for cases which transfers happen in the same SPU for now
 				}

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1868,15 +1868,15 @@ void spu_thread::do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8*
 			{
 				if (is_get)
 				{
-					std::memmove(this->ls + offset, spu.ls + offset, size); // memmove for cases which transfers happen in the same SPU for now
+					std::memmove(this->ls + offset, spu.ls + offset, args.size); // memmove for cases which transfers happen in the same SPU for now
 				}
 				else if (args.cmd != MFC_SDCRZ_CMD)
 				{
-					std::memmove(spu.ls + offset, this->ls + offset, size);
+					std::memmove(spu.ls + offset, this->ls + offset, args.size);
 				}
 				else
 				{
-					std::memset(spu.ls + offset, 0, size);
+					std::memset(spu.ls + offset, 0, args.size);
 				}
 
 				return;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -636,7 +636,7 @@ public:
 
 	static const u32 id_base = 0x02000000; // TODO (used to determine thread type)
 	static const u32 id_step = 1;
-	static const u32 id_count = (0xF0000000 - SPU_FAKE_BASE_ADDR) / SPU_LS_SIZE;
+	static const u32 id_count = 255 * 6 + 5;
 
 	spu_thread(lv2_spu_group* group, u32 index, std::string_view name, u32 lv2_id, bool is_isolated = false, u32 option = 0);
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -681,8 +681,13 @@ error_code sys_spu_thread_group_destroy(ppu_thread& ppu, u32 id)
 	{
 		if (auto thread = t.get())
 		{
-			// Deallocate LS
-			vm::get(vm::spu)->dealloc(SPU_FAKE_BASE_ADDR + SPU_LS_SIZE * (thread->id & 0xffffff), &thread->shm);
+			const u64 faddr = SPU_FAKE_BASE_ADDR + SPU_LS_SIZE * u64{thread->id & 0xffffff};
+
+			if (faddr < RAW_SPU_BASE_ADDR && g_cfg.core.spu_debug_local_storage)
+			{
+				// Deallocate LS
+				vm::get(vm::spu)->dealloc(static_cast<u32>(faddr), &thread->shm);
+			}
 
 			// Remove ID from IDM (destruction will occur in group destructor)
 			idm::remove<named_thread<spu_thread>>(thread->id);

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -53,6 +53,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<tsx_usage> enable_TSX{ this, "Enable TSX", has_rtm() ? tsx_usage::enabled : tsx_usage::disabled }; // Enable TSX. Forcing this on Haswell/Broadwell CPUs should be used carefully
 		cfg::_bool spu_accurate_xfloat{ this, "Accurate xfloat", false };
 		cfg::_bool spu_approx_xfloat{ this, "Approximate xfloat", true };
+		cfg::_bool spu_debug_local_storage{ this, "SPU LS Debug", true }; // Hack for debugging, causes minor inaccuracies in relation to vm::spu memory layout.
 		cfg::_bool llvm_accurate_dfma{ this, "LLVM Accurate DFMA", true }; // Enable accurate double-precision FMA for CPUs which do not support it natively
 		cfg::_bool llvm_ppu_jm_handling{ this, "PPU LLVM Java Mode Handling", false }; // Respect current Java Mode for alti-vec ops by PPU LLVM
 		cfg::_int<-1, 14> ppu_128_reservations_loop_max_length{ this, "Accurate PPU 128-byte Reservation Op Max Length", 0, true }; // -1: Always accurate, 0: Never accurate, 1-14: max accurate loop length


### PR DESCRIPTION
Old bug, related to spu groups count limit.
In the past it caused vm::main alloc LS failures, at current master it causes spu idm::create failures.