### PR TITLE
Pushing master AppImage Artifacts to GitHub Releases via Azure

### DIFF
--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -41,7 +41,6 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     COMM_HASH="$(git rev-parse --short=8 HEAD)"
     RPCS3_APPIMAGE="rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}_linux64.AppImage"
 
-    curl -sLO https://github.com/hcorion/uploadtool/raw/master/upload.sh
     mv ./RPCS3*.AppImage "$RPCS3_APPIMAGE"
 
     # If we're building using Azure Pipelines, let's copy over the AppImage artifact
@@ -50,16 +49,9 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     fi
 
     FILESIZE=$(stat -c %s ./rpcs3*.AppImage)
-    SHA256SUM=$(sha256sum ./rpcs3*.AppImage)
-    if [ -n "$GITHUB_TOKEN" ]; then
-        unset TRAVIS_REPO_SLUG
-        REPO_SLUG=RPCS3/rpcs3-binaries-linux \
-            UPLOADTOOL_BODY="$SHA256SUM;${FILESIZE}B"\
-            RELEASE_NAME=build-${TRAVIS_COMMIT}\
-            RELEASE_TITLE=${COMM_TAG}-${COMM_COUNT}\
-            REPO_COMMIT=d812f1254a1157c80fd402f94446310560f54e5f\
-            bash upload.sh rpcs3*.AppImage
-    fi
+    SHA256SUM=$(sha256sum ./rpcs3*.AppImage | awk '{ print $1 }')
+    echo "${SHA256SUM};${FILESIZE}B" > /rpcs3/GitHubReleaseMessage.txt
+    
 fi
 
 if [ "$DEPLOY_PPA" = "true" ]; then

--- a/.ci/github-upload.sh
+++ b/.ci/github-upload.sh
@@ -7,7 +7,7 @@ generate_post_data()
     cat <<EOF
     {
     "tag_name": "build-${BUILD_SOURCEVERSION}",
-    "target_commitish": "7d09e3be30805911226241afbb14f8cdc2eb054e",
+    "target_commitish": "${UPLOAD_COMMIT_HASH}",
     "name": "${AVVER}",
     "body": "$body",
     "draft": false,
@@ -16,12 +16,10 @@ generate_post_data()
 EOF
 }
 
-repo_full_name="RPCS3/rpcs3-binaries-win"
-
 curl -s \
     -H "Authorization: token ${RPCS3_TOKEN}" \
     -H "Accept: application/vnd.github.v3+json" \
-    --data "$(generate_post_data)" "https://api.github.com/repos/$repo_full_name/releases" >> release.json
+    --data "$(generate_post_data)" "https://api.github.com/repos/$UPLOAD_REPO_FULL_NAME/releases" >> release.json
 
 cat release.json
 id=$(grep '"id"' release.json | cut -d ':' -f2 | head -n1 | awk '{$1=$1;print}')
@@ -35,7 +33,7 @@ upload_file()
         -H "Accept: application/vnd.github.v3+json" \
         -H "Content-Type: application/octet-stream" \
         --data-binary @"$2"/"$3" \
-        "https://uploads.github.com/repos/$repo_full_name/releases/$1/assets?name=$3"
+        "https://uploads.github.com/repos/$UPLOAD_REPO_FULL_NAME/releases/$1/assets?name=$3"
 }
 
 for file in "$ARTIFACT_DIR"/*; do

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,8 @@ jobs:
   variables:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     IS_AZURE: true
+    UPLOAD_COMMIT_HASH: d812f1254a1157c80fd402f94446310560f54e5f
+    UPLOAD_REPO_FULL_NAME: "RPCS3/rpcs3-binaries-linux"
   pool:
     vmImage: 'ubuntu-latest'
   steps:
@@ -40,12 +42,16 @@ jobs:
         rpcs3/rpcs3-travis-xenial:1.6 \
         /rpcs3/.ci/build-linux.sh
     displayName: Docker setup and build
-    env:
-      GITHUB_TOKEN: $(RPCS3-Token)
 
   - publish: $(Build.ArtifactStagingDirectory)
     condition: and(succeeded(), eq(variables['COMPILER'], 'gcc'))
     artifact: RPCS3 for Linux
+
+  - bash: .ci/github-upload.sh
+    condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Name'], 'RPCS3/rpcs3'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['COMPILER'], 'gcc'))
+    displayName: Push build to GitHub
+    env:
+      RPCS3_TOKEN: $(RPCS3-Token)
 
 - job: Windows_Build
   variables:
@@ -57,6 +63,8 @@ jobs:
     VULKAN_SDK_SHA: 'b64471f3a720e649c1fae6535ea83b8c642655ebed1485bfdf15bf4d88f746d9'
     VULKAN_SDK: C:\VulkanSDK\$(VULKAN_VER)
     CACHE_DIR: ./cache
+    UPLOAD_COMMIT_HASH: 7d09e3be30805911226241afbb14f8cdc2eb054e
+    UPLOAD_REPO_FULL_NAME: "RPCS3/rpcs3-binaries-win"
 
   pool:
     vmImage: "windows-latest"
@@ -103,7 +111,7 @@ jobs:
       condition: succeeded()
       artifact: RPCS3 for Windows
 
-    - bash: .ci/github-upload-windows.sh
+    - bash: .ci/github-upload.sh
       condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.Repository.Name'], 'RPCS3/rpcs3'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       displayName: Push build to GitHub
       env:


### PR DESCRIPTION
Since Travis CI's new free plan is not sustainable, we're switching entirely to Azure for our Linux builds, which means we need to upload via Azure, instead of via Travis.

Example of uploaded build available here: https://github.com/hcorion/rpcs3-linux-builds/releases/tag/build-89512b1ede27c4e55fb763c0dfd340fb3e8cbe5d

In addition, the body of the GitHub release now no longer has the filename at the end of the hash.