### PR TITLE
Clean thread pool at exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 RPCS3
 =====
 
-[![Travis (.org) branch](https://img.shields.io/travis/RPCS3/rpcs3/master?label=Travis%20CI&logo=travis)](https://travis-ci.org/RPCS3/rpcs3)
 [![Azure Build Status](https://dev.azure.com/nekotekina/nekotekina/_apis/build/status/RPCS3.rpcs3?branchName=master)](https://dev.azure.com/nekotekina/nekotekina/_build?definitionId=4&branchName=master)
 [![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/RPCS3/rpcs3?label=Cirrus%20CI%20(FreeBSD)&logo=cirrus-ci)](https://cirrus-ci.com/github/RPCS3/rpcs3)
 [![RPCS3 discord server](https://img.shields.io/discord/272035812277878785?color=%237289DA&label=RPCS3%20Discord&logo=discord&logoColor=white)](https://discord.me/rpcs3)

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -42,7 +42,6 @@ namespace atomic_wait
 		byteswap = 1 << 6, // Perform byteswap on both arguments and masks when applicable
 	};
 
-	constexpr op_flag op_ne = {};
 	constexpr op_flag op_be = std::endian::native == std::endian::little ? op_flag::byteswap : op_flag{0};
 	constexpr op_flag op_le = std::endian::native == std::endian::little ? op_flag{0} : op_flag::byteswap;
 
@@ -60,6 +59,8 @@ namespace atomic_wait
 	{
 		return op{static_cast<u8>(static_cast<u8>(lhs) | static_cast<u8>(rhs))};
 	}
+
+	constexpr op op_ne = op::eq | op_flag::inverse;
 
 	struct info
 	{

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -88,7 +88,7 @@ namespace atomic_wait
 		template <typename T>
 		constexpr void set_value(T value = T{})
 		{
-			old = get_value<T>();
+			old = get_value<T>(value);
 		}
 
 		template <typename T>
@@ -146,13 +146,13 @@ namespace atomic_wait
 		constexpr list(atomic_t<U, Align>&... vars)
 			: m_info{{&vars.raw(), sizeof(U), info::get_value<U>(), info::get_mask<U>()}...}
 		{
-			static_assert(sizeof...(U) <= Max);
+			static_assert(sizeof...(U) == Max, "Inconsistent amount of atomics.");
 		}
 
 		template <typename... U>
 		constexpr list& values(U... values)
 		{
-			static_assert(sizeof...(U) <= Max);
+			static_assert(sizeof...(U) == Max, "Inconsistent amount of values.");
 
 			auto* ptr = m_info;
 			((ptr++)->template set_value<T>(values), ...);
@@ -160,9 +160,9 @@ namespace atomic_wait
 		}
 
 		template <typename... U>
-		constexpr list& masks(T... masks)
+		constexpr list& masks(U... masks)
 		{
-			static_assert(sizeof...(U) <= Max);
+			static_assert(sizeof...(U) <= Max, "Too many masks.");
 
 			auto* ptr = m_info;
 			((ptr++)->template set_mask<T>(masks), ...);


### PR DESCRIPTION
Make sure thread handles are collected and TLS destructors are executed as well.