### PR TITLE
gl: Minor fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -292,6 +292,9 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 
 	if (g_cfg.video.overlay)
 	{
+		// Disable depth test
+		gl_state.depth_func(GL_ALWAYS);
+
 		gl::screen.bind();
 		glViewport(0, 0, m_frame->client_width(), m_frame->client_height());
 

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -14,7 +14,7 @@ gl_gs_frame::gl_gs_frame(const QRect& geometry, const QIcon& appIcon, const std:
 	m_format.setMajorVersion(4);
 	m_format.setMinorVersion(3);
 	m_format.setProfile(QSurfaceFormat::CoreProfile);
-	m_format.setDepthBufferSize(16);
+	m_format.setDepthBufferSize(0);
 	m_format.setSwapBehavior(QSurfaceFormat::SwapBehavior::DoubleBuffer);
 	if (g_cfg.video.debug_output)
 	{


### PR DESCRIPTION
- Disable depth test before rendering to the default framebuffer
- Remove the depth buffer from the default framebuffer as we do not need it and its a waste of VRAM.

Fixes https://github.com/RPCS3/rpcs3/issues/9185