### PR TITLE
vm adjustments

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -289,8 +289,8 @@ namespace vm
 			return;
 		}
 
-		// Limit to 256 MiB at once; make sure if it operates on big amount of data, it's page-aligned
-		if (size > 256 * 1024 * 1024 || (size > 65536 && size % 4096))
+		// Limit to <512 MiB at once; make sure if it operates on big amount of data, it's page-aligned
+		if (size >= 512 * 1024 * 1024 || (size > 65536 && size % 4096))
 		{
 			fmt::throw_exception("Failed to lock range (flags=0x%x, addr=0x%x, size=0x%x)" HERE, flags >> 32, addr, size);
 		}
@@ -827,8 +827,6 @@ namespace vm
 						safe_bits |= range_readable;
 					if (old_val & start_value & page_writable && safe_bits & range_readable)
 						safe_bits |= range_writable;
-					if (old_val & start_value & page_executable && safe_bits & range_readable)
-						safe_bits |= range_executable;
 
 					// Protect range locks from observing changes in memory protection
 					_lock_main_range_lock(safe_bits, start * 4096, page_size);

--- a/rpcs3/Emu/Memory/vm_locking.h
+++ b/rpcs3/Emu/Memory/vm_locking.h
@@ -13,16 +13,16 @@ namespace vm
 
 	enum range_lock_flags : u64
 	{
-		/* flags (3 bits, RWX) */
+		/* flags (3 bits, W + R + Reserved) */
 
-		range_readable = 4ull << 61,
-		range_writable = 2ull << 61,
-		range_executable = 1ull << 61,
+		range_writable = 4ull << 61,
+		range_readable = 2ull << 61,
+		range_reserved = 1ull << 61,
 		range_full_mask = 7ull << 61,
 
 		/* flag combinations with special meaning */
 
-		range_locked = 1ull << 61, // R+W as well, but being exclusively accessed (size extends addr)
+		range_locked = 4ull << 61, // R+W as well, but being exclusively accessed (size extends addr)
 		range_allocation = 0, // Allocation, no safe access, g_shmem may change at ANY location
 
 		range_pos = 61,


### PR DESCRIPTION
Restore "memory lock" limit to <512MiB.
I originally planned to split huge allocation in chunks, but it can be done later.
This should fix some regressions.