### PR TITLE
rsx: Improve upscaling compatibility

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2758,48 +2758,24 @@ namespace rsx
 				}
 			}
 
-			if (rsx::get_resolution_scale_percent() != 100)
-			{
-				const f32 resolution_scale = rsx::get_resolution_scale();
-				if (src_is_render_target)
-				{
-					if (src_subres.surface->get_surface_width(rsx::surface_metrics::pixels) > g_cfg.video.min_scalable_dimension)
-					{
-						src_area.x1 = static_cast<u16>(src_area.x1 * resolution_scale);
-						src_area.x2 = static_cast<u16>(src_area.x2 * resolution_scale);
-					}
-
-					if (src_subres.surface->get_surface_height(rsx::surface_metrics::pixels) > g_cfg.video.min_scalable_dimension)
-					{
-						src_area.y1 = static_cast<u16>(src_area.y1 * resolution_scale);
-						src_area.y2 = static_cast<u16>(src_area.y2 * resolution_scale);
-					}
-				}
-
-				if (dst_is_render_target)
-				{
-					if (dst_subres.surface->get_surface_width(rsx::surface_metrics::pixels) > g_cfg.video.min_scalable_dimension)
-					{
-						dst_area.x1 = static_cast<u16>(dst_area.x1 * resolution_scale);
-						dst_area.x2 = static_cast<u16>(dst_area.x2 * resolution_scale);
-					}
-
-					if (dst_subres.surface->get_surface_height(rsx::surface_metrics::pixels) > g_cfg.video.min_scalable_dimension)
-					{
-						dst_area.y1 = static_cast<u16>(dst_area.y1 * resolution_scale);
-						dst_area.y2 = static_cast<u16>(dst_area.y2 * resolution_scale);
-					}
-				}
-			}
-
 			if (src_is_render_target)
 			{
+				const auto surface_width = src_subres.surface->get_surface_width(rsx::surface_metrics::pixels);
+				const auto surface_height = src_subres.surface->get_surface_height(rsx::surface_metrics::pixels);
+				std::tie(src_area.x1, src_area.y1) = rsx::apply_resolution_scale<false>(src_area.x1, src_area.y1, surface_width, surface_height);
+				std::tie(src_area.x2, src_area.y2) = rsx::apply_resolution_scale<true>(src_area.x2, src_area.y2, surface_width, surface_height);
+
 				// The resource is of surface type; possibly disabled AA emulation
 				src_subres.surface->transform_blit_coordinates(rsx::surface_access::transfer, src_area);
 			}
 
 			if (dst_is_render_target)
 			{
+				const auto surface_width = dst_subres.surface->get_surface_width(rsx::surface_metrics::pixels);
+				const auto surface_height = dst_subres.surface->get_surface_height(rsx::surface_metrics::pixels);
+				std::tie(dst_area.x1, dst_area.y1) = rsx::apply_resolution_scale<false>(dst_area.x1, dst_area.y1, surface_width, surface_height);
+				std::tie(dst_area.x2, dst_area.y2) = rsx::apply_resolution_scale<true>(dst_area.x2, dst_area.y2, surface_width, surface_height);
+
 				// The resource is of surface type; possibly disabled AA emulation
 				dst_subres.surface->transform_blit_coordinates(rsx::surface_access::transfer, dst_area);
 			}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1483,8 +1483,8 @@ namespace rsx
 			framebuffer_status_valid = true;
 		}
 
-		std::tie(region.x1, region.y1) = rsx::apply_resolution_scale<false>(x1, y1);
-		std::tie(region.x2, region.y2) = rsx::apply_resolution_scale<true>(x2, y2);
+		std::tie(region.x1, region.y1) = rsx::apply_resolution_scale<false>(x1, y1, m_framebuffer_layout.width, m_framebuffer_layout.height);
+		std::tie(region.x2, region.y2) = rsx::apply_resolution_scale<true>(x2, y2, m_framebuffer_layout.width, m_framebuffer_layout.height);
 
 		return true;
 	}
@@ -1765,8 +1765,6 @@ namespace rsx
 			// Set high word of the control mask to store point sprite control
 			result.texcoord_control_mask |= u32(method_registers.point_sprite_control_mask()) << 16;
 		}
-
-		const auto resolution_scale = rsx::get_resolution_scale();
 
 		for (u32 i = 0; i < rsx::limits::fragment_textures_count; ++i)
 		{

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -591,15 +591,9 @@ namespace rsx
 	template <bool clamp = false>
 	static inline const std::pair<u16, u16> apply_resolution_scale(u16 width, u16 height, u16 ref_width = 0, u16 ref_height = 0)
 	{
-		u16 ref;
-		if (width > height) [[likely]]
-		{
-			ref = (ref_width) ? ref_width : width;
-		}
-		else
-		{
-			ref = (ref_height) ? ref_height : height;
-		}
+		ref_width = (ref_width)? ref_width : width;
+		ref_height = (ref_height)? ref_height : height;
+		const u16 ref = std::max(ref_width, ref_height);
 
 		if (ref > g_cfg.video.min_scalable_dimension)
 		{


### PR DESCRIPTION
Adds the following fixes for derived sub-surfaces (e.g data cast from 2D to 3D or 2D to cubemap):
- Base the upscaling on the real source and not the "attr" parameter.
- In case of reconstruction, the source is much larger than the subslice in "attr"

These fixes improve upscaling compatibility without requiring large threshold values which can break visuals in some other ways. This is a companion PR to https://github.com/RPCS3/rpcs3/pull/9281. The combined results have upscaled bits that closely match what the layout at default resolution is. This will not fix all upscaling issues, you still cannot (and never will be able to) upscale the individual bytes comprising a floating point value separately.

Fixes https://github.com/RPCS3/rpcs3/issues/9318