### PR TITLE
stdafx.h: remove BOM from custom included headers

### DIFF
--- a/Utilities/BEType.h
+++ b/Utilities/BEType.h
@@ -1,5 +1,4 @@
-﻿#ifndef BETYPE_H_GUARD
-#define BETYPE_H_GUARD
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include "types.h"
 #include "util/endian.hpp"
@@ -510,5 +509,3 @@ struct fmt_unveil<se_t<T, Se, Align>, void>
 
 static_assert(be_t<u16>(1) + be_t<u32>(2) + be_t<u64>(3) == 6);
 static_assert(le_t<u16>(1) + le_t<u32>(2) + le_t<u64>(3) == 6);
-
-#endif // BETYPE_H_GUARD

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -1,4 +1,4 @@
-#pragma once
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include "types.h"
 #include "bit_set.h"

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -1,4 +1,4 @@
-#pragma once
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include "types.h"
 

--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #ifdef _MSC_VER
 #include <intrin.h>

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -598,7 +598,7 @@ int validate_npd_hashes(const char* file_name, const u8* klicensee, NPD_HEADER *
 
 	// Hash with NPDRM_OMAC_KEY_3 and compare with title_hash.
 	// Try to ignore case sensivity with file extension
-	title_hash_result = 
+	title_hash_result =
 		cmac_hash_compare(NP_OMAC_KEY_3, 0x10, buf.get(), buf_len, npd->title_hash, 0x10) ||
 		cmac_hash_compare(NP_OMAC_KEY_3, 0x10, buf_lower.get(), buf_len, npd->title_hash, 0x10) ||
 		cmac_hash_compare(NP_OMAC_KEY_3, 0x10, buf_upper.get(), buf_len, npd->title_hash, 0x10);
@@ -922,7 +922,7 @@ bool EDATADecrypter::ReadHeader()
 
 			if (dec_key == v128{})
 			{
-				edat_log.warning("EDAT: Empty Dec key for local actívation!");
+				edat_log.warning("EDAT: Empty Dec key for local activation!");
 			}
 		}
 		else if ((npdHeader.license & 0x1) == 0x1)      // Type 1: Use network activation.

--- a/rpcs3/stdafx.cpp
+++ b/rpcs3/stdafx.cpp
@@ -1,1 +1,5 @@
+// No BOM and only basic ASCII in this file, or a neko will die
 #include "stdafx.h"
+
+static_assert(be_t<u16>(1) + be_t<u32>(2) + be_t<u64>(3) == 6);
+static_assert(le_t<u16>(1) + le_t<u32>(2) + le_t<u64>(3) == 6);

--- a/rpcs3/stdafx.h
+++ b/rpcs3/stdafx.h
@@ -1,4 +1,4 @@
-#pragma once
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #ifdef MSVC_CRT_MEMLEAK_DETECTION
 	#define _CRTDBG_MAP_ALLOC

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include "Utilities/types.h"
 #include <functional>

--- a/rpcs3/util/endian.hpp
+++ b/rpcs3/util/endian.hpp
@@ -1,5 +1,4 @@
-﻿#ifndef ENDIAN_HPP_GUARD
-#define ENDIAN_HPP_GUARD
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include <cstdint>
 #include "Utilities/types.h"
@@ -492,5 +491,3 @@ public:
 		}
 	};
 }
-
-#endif // ENDIAN_HPP_GUARD

--- a/rpcs3/util/logs.hpp
+++ b/rpcs3/util/logs.hpp
@@ -1,4 +1,4 @@
-#pragma once
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include <cstdint>
 #include <atomic>

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include <cstdint>
 #include <memory>
@@ -9,10 +9,12 @@ namespace stx
 	template <typename T, typename U>
 	constexpr bool is_same_ptr() noexcept
 	{
-		// Should be possible if constexpr bit_cast is available?
+		// I would like to make it a trait if there is some trick.
+		// And believe it shall possible with constexpr bit_cast.
 		// Otherwise I hope it will compile in null code anyway.
 		const auto u = reinterpret_cast<U*>(0x11223344556);
-		return static_cast<T*>(u) == static_cast<void*>(u);
+		const volatile void* x = u;
+		return static_cast<T*>(u) == x;
 	}
 
 	// TODO


### PR DESCRIPTION
Try to fix and guard against future issues with precompiled headers with certain files.