### PR TITLE
rsx: Fix uncaught depth-func changes

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1360,6 +1360,7 @@ namespace rsx
 		{
 		case NV4097_SET_DEPTH_TEST_ENABLE:
 		case NV4097_SET_DEPTH_MASK:
+		case NV4097_SET_DEPTH_FUNC:
 		{
 			evaluate_depth_buffer_state();
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -3138,6 +3138,7 @@ namespace rsx
 		bind<NV4097_SET_ZPASS_PIXEL_COUNT_ENABLE, nv4097::set_zcull_pixel_count_enable>();
 		bind<NV4097_CLEAR_ZCULL_SURFACE, nv4097::clear_zcull>();
 		bind<NV4097_SET_DEPTH_TEST_ENABLE, nv4097::set_surface_options_dirty_bit>();
+		bind<NV4097_SET_DEPTH_FUNC, nv4097::set_surface_options_dirty_bit>();
 		bind<NV4097_SET_STENCIL_TEST_ENABLE, nv4097::set_surface_options_dirty_bit>();
 		bind<NV4097_SET_DEPTH_MASK, nv4097::set_surface_options_dirty_bit>();
 		bind<NV4097_SET_COLOR_MASK, nv4097::set_surface_options_dirty_bit>();


### PR DESCRIPTION
- Depth func of always or never usually disqualifies depth testing. Invalidate contested surfaces when depth func is changed.

Fixes https://github.com/RPCS3/rpcs3/issues/8668
Fixes https://github.com/RPCS3/rpcs3/issues/8619
Fixes https://github.com/RPCS3/rpcs3/issues/8740