### PR TITLE
 Debugger: Implement code flow tracking

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -809,6 +809,28 @@ std::string cpu_thread::get_name() const
 	}
 }
 
+u32 cpu_thread::get_pc() const
+{
+	const u32* pc = nullptr;
+
+	switch (id_type())
+	{
+	case 1:
+	{
+		pc = &static_cast<const ppu_thread*>(this)->cia;
+		break;
+	}
+	case 2:
+	{
+		pc = &static_cast<const spu_thread*>(this)->pc;
+		break;
+	}
+	default: break;
+	}
+
+	return pc ? atomic_storage<u32>::load(*pc) : UINT32_MAX;
+}
+
 std::string cpu_thread::dump_all() const
 {
 	return {};

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -84,6 +84,8 @@ public:
 		return id >> 24;
 	}
 
+	u32 get_pc() const;
+
 	void notify();
 
 private:

--- a/rpcs3/Emu/Cell/PPUOpcodes.h
+++ b/rpcs3/Emu/Cell/PPUOpcodes.h
@@ -72,6 +72,8 @@ constexpr u32 ppu_decode(u32 inst)
 	return ((inst >> 26) | (inst << 6)) & 0x1ffff; // Rotate + mask
 }
 
+std::array<u32, 2> op_branch_targets(u32 pc, ppu_opcode_t op);
+
 // PPU decoder object. D provides functions. T is function pointer type returned.
 template <typename D, typename T = decltype(&D::UNK)>
 class ppu_decoder

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -422,6 +422,31 @@ extern bool ppu_patch(u32 addr, u32 value)
 	return true;
 }
 
+std::array<u32, 2> op_branch_targets(u32 pc, ppu_opcode_t op)
+{
+	std::array<u32, 2> res{pc + 4, UINT32_MAX};
+
+	switch (const auto type = g_ppu_itype.decode(op.opcode))
+	{
+	case ppu_itype::B:
+	case ppu_itype::BC:
+	{
+		res[type == ppu_itype::BC ? 1 : 0] = ((op.aa ? 0 : pc) + (type == ppu_itype::B ? +op.bt24 : +op.bt14));
+		break;
+	}
+	case ppu_itype::BCCTR:
+	case ppu_itype::BCLR:
+	case ppu_itype::UNK:
+	{
+		res[0] = UINT32_MAX;
+		break;
+	}
+	default: break;
+	}
+
+	return res;
+}
+
 std::string ppu_thread::dump_all() const
 {
 	std::string ret = cpu_thread::dump_misc();

--- a/rpcs3/Emu/Cell/SPUOpcodes.h
+++ b/rpcs3/Emu/Cell/SPUOpcodes.h
@@ -41,6 +41,8 @@ static u32 spu_decode(u32 inst)
 	return inst >> 21;
 }
 
+std::array<u32, 2> op_branch_targets(u32 pc, spu_opcode_t op);
+
 // SPU decoder object. D provides functions. T is function pointer type returned.
 template <typename D, typename T = decltype(&D::UNK)>
 class spu_decoder

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -66,7 +66,6 @@ public:
 	void UpdateUI();
 	void UpdateUnitList();
 
-	u32 GetPc() const;
 	void DoUpdate();
 	void WritePanels();
 	void EnableButtons(bool enable);

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -134,7 +134,7 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 
 void debugger_list::keyPressEvent(QKeyEvent* event)
 {
-	if (!isActiveWindow() || currentRow() < 0 || !this->cpu.lock())
+	if (!isActiveWindow())
 	{
 		return;
 	}

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -34,28 +34,6 @@ void debugger_list::UpdateCPUData(std::weak_ptr<cpu_thread> cpu, std::shared_ptr
 	m_disasm = disasm;
 }
 
-u32 debugger_list::GetPc() const
-{
-	const auto cpu = this->cpu.lock();
-
-	if (!cpu)
-	{
-		return 0;
-	}
-
-	if (cpu->id_type() == 1)
-	{
-		return static_cast<ppu_thread*>(cpu.get())->cia;
-	}
-
-	if (cpu->id_type() == 2)
-	{
-		return static_cast<spu_thread*>(cpu.get())->pc;
-	}
-
-	return 0;
-}
-
 u32 debugger_list::GetCenteredAddress(u32 address) const
 {
 	return address - ((m_item_count / 2) * 4);
@@ -110,7 +88,7 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 
 		for (uint i = 0, count = 4; i<m_item_count; ++i, pc = (pc + count) & address_limits)
 		{
-			if (cpu->is_paused() && pc == GetPc())
+			if (cpu->is_paused() && pc == cpu->get_pc())
 			{
 				item(i)->setForeground(m_text_color_pc);
 				item(i)->setBackground(m_color_pc);

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -38,7 +38,6 @@ private:
 	/**
 	* It really upsetted me I had to copy this code to make debugger_list/frame not circularly dependent.
 	*/
-	u32 GetPc() const;
 	u32 GetCenteredAddress(u32 address) const;
 
 	std::shared_ptr<gui_settings> xgui_settings;


### PR DESCRIPTION
* Fix+optimize+rewrite debugger GetPc() function to be able to use to use raw ptr and instead of locking weak ptr, unknown PC returns UINT32_MAX instead of 0, decleration moved to cpu_thread class and removed duplicates.
* Code flow tracker has been implemented, pressing N proceeds to "next instruction" on thread's instruction according to code flow.
The specificdation for it is as follows: 
1 - Unconditional branches with known branch target proceed to branch target, conditional branches always the branch target even if the condition would not be met in realtime execution.
2 - Indirect branches (unknown targets) do not proceed to any instruction and pressing N does nothing for them.
3 - Other instructions such as NOP proceed to pc + 4.
 
Useful to detect loops, go to to a branch target without copying its address to the "Go To" dialog such as in "bl ppu-func-addr", see where functions end.  