### PR TITLE
rsx: Separate program environment state from program ucode state

### DIFF
--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -466,15 +466,6 @@ bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, con
 		binary1.shadow_textures != binary2.shadow_textures || binary1.redirected_textures != binary2.redirected_textures)
 		return false;
 
-	for (u8 index = 0; index < 16; ++index)
-	{
-		if (binary1.textures_alpha_kill[index] != binary2.textures_alpha_kill[index])
-			return false;
-
-		if (binary1.textures_zfunc[index] != binary2.textures_zfunc[index])
-			return false;
-	}
-
 	const void* instBuffer1 = binary1.get_data();
 	const void* instBuffer2 = binary2.get_data();
 	size_t instIndex = 0;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -648,7 +648,7 @@ bool GLGSRender::load_program()
 {
 	const auto shadermode = g_cfg.video.shadermode.get();
 
-	if ((m_interpreter_state = (m_graphics_state & rsx::pipeline_state::invalidate_pipeline_bits)))
+	if (m_graphics_state & rsx::pipeline_state::invalidate_pipeline_bits)
 	{
 		get_current_fragment_program(fs_sampler_state);
 		verify(HERE), current_fragment_program.valid;

--- a/rpcs3/Emu/RSX/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/RSXFragmentProgram.h
@@ -279,8 +279,6 @@ struct RSXFragmentProgram
 	u32 texcoord_control_mask = 0;
 
 	float texture_scale[16][4];
-	u8 textures_alpha_kill[16];
-	u8 textures_zfunc[16];
 
 	bool valid = false;
 
@@ -303,8 +301,6 @@ struct RSXFragmentProgram
 	RSXFragmentProgram()
 	{
 		std::memset(texture_scale, 0, sizeof(float) * 16 * 4);
-		std::memset(textures_alpha_kill, 0, sizeof(u8) * 16);
-		std::memset(textures_zfunc, 0, sizeof(u8) * 16);
 	}
 
 	static RSXFragmentProgram clone(const RSXFragmentProgram& prog)

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -110,24 +110,28 @@ namespace rsx
 
 	enum pipeline_state : u32
 	{
-		fragment_program_dirty = 0x1,        // Fragment program changed
-		vertex_program_dirty = 0x2,          // Vertex program changed
-		fragment_state_dirty = 0x4,          // Fragment state changed (alpha test, etc)
-		vertex_state_dirty = 0x8,            // Vertex state changed (scale_offset, clip planes, etc)
-		transform_constants_dirty = 0x10,    // Transform constants changed
-		fragment_constants_dirty = 0x20,     // Fragment constants changed
-		framebuffer_reads_dirty = 0x40,      // Framebuffer contents changed
-		fragment_texture_state_dirty = 0x80, // Fragment texture parameters changed
-		vertex_texture_state_dirty = 0x100,  // Fragment texture parameters changed
-		scissor_config_state_dirty = 0x200,  // Scissor region changed
-		zclip_config_state_dirty = 0x400,    // Viewport Z clip changed
+		fragment_program_ucode_dirty = 0x1,   // Fragment program ucode changed
+		vertex_program_ucode_dirty = 0x2,     // Vertex program ucode changed
+		fragment_program_state_dirty = 0x4,   // Fragment program state changed
+		vertex_program_state_dirty = 0x8,     // Vertex program state changed
+		fragment_state_dirty = 0x10,          // Fragment state changed (alpha test, etc)
+		vertex_state_dirty = 0x20,            // Vertex state changed (scale_offset, clip planes, etc)
+		transform_constants_dirty = 0x40,     // Transform constants changed
+		fragment_constants_dirty = 0x80,      // Fragment constants changed
+		framebuffer_reads_dirty = 0x100,      // Framebuffer contents changed
+		fragment_texture_state_dirty = 0x200, // Fragment texture parameters changed
+		vertex_texture_state_dirty = 0x400,   // Fragment texture parameters changed
+		scissor_config_state_dirty = 0x800,   // Scissor region changed
+		zclip_config_state_dirty = 0x1000,    // Viewport Z clip changed
 
-		scissor_setup_invalid = 0x800,       // Scissor configuration is broken
-		scissor_setup_clipped = 0x1000,      // Scissor region is cropped by viewport constraint
+		scissor_setup_invalid = 0x2000,       // Scissor configuration is broken
+		scissor_setup_clipped = 0x4000,       // Scissor region is cropped by viewport constraint
 
-		polygon_stipple_pattern_dirty = 0x2000,  // Rasterizer stippling pattern changed
-		line_stipple_pattern_dirty = 0x4000,     // Line stippling pattern changed
+		polygon_stipple_pattern_dirty = 0x8000,  // Rasterizer stippling pattern changed
+		line_stipple_pattern_dirty = 0x10000,    // Line stippling pattern changed
 
+		fragment_program_dirty = fragment_program_ucode_dirty | fragment_program_state_dirty,
+		vertex_program_dirty = vertex_program_ucode_dirty | vertex_program_state_dirty,
 		invalidate_pipeline_bits = fragment_program_dirty | vertex_program_dirty,
 		invalidate_zclip_bits = vertex_state_dirty | zclip_config_state_dirty,
 		memory_barrier_bits = framebuffer_reads_dirty,
@@ -767,7 +771,13 @@ namespace rsx
 		RSXVertexProgram current_vertex_program = {};
 		RSXFragmentProgram current_fragment_program = {};
 
-		void get_current_vertex_program(const std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, rsx::limits::vertex_textures_count>& sampler_descriptors, bool skip_textures = false, bool skip_vertex_inputs = true);
+		// Prefetch and analyze the currently active fragment program ucode
+		void prefetch_fragment_program();
+
+		// Prefetch and analyze the currently active vertex program ucode
+		void prefetch_vertex_program();
+
+		void get_current_vertex_program(const std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, rsx::limits::vertex_textures_count>& sampler_descriptors);
 
 		/**
 		 * Gets current fragment program and associated fragment state

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -152,8 +152,11 @@ void VKGSRender::load_texture_env()
 		surface_store_tag = m_rtts.cache_tag;
 	}
 
-	for (int i = 0; i < rsx::limits::fragment_textures_count; ++i)
+	for (u32 textures_ref = current_fp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
 	{
+		if (!(textures_ref & 1))
+			continue;
+
 		if (!fs_sampler_state[i])
 			fs_sampler_state[i] = std::make_unique<vk::texture_cache::sampled_image_descriptor>();
 
@@ -289,8 +292,11 @@ void VKGSRender::load_texture_env()
 		}
 	}
 
-	for (int i = 0; i < rsx::limits::vertex_textures_count; ++i)
+	for (u32 textures_ref = current_vp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
 	{
+		if (!(textures_ref & 1))
+			continue;
+
 		if (!vs_sampler_state[i])
 			vs_sampler_state[i] = std::make_unique<vk::texture_cache::sampled_image_descriptor>();
 
@@ -357,217 +363,217 @@ void VKGSRender::load_texture_env()
 
 void VKGSRender::bind_texture_env()
 {
-	for (int i = 0; i < rsx::limits::fragment_textures_count; ++i)
+	for (u32 textures_ref = current_fp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
 	{
-		if (current_fp_metadata.referenced_textures_mask & (1 << i))
+		if (!(textures_ref & 1))
+			continue;
+
+		vk::image_view* view = nullptr;
+		auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
+
+		if (rsx::method_registers.fragment_textures[i].enabled() &&
+			sampler_state->validate())
 		{
-			vk::image_view* view = nullptr;
-			auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
-
-			if (rsx::method_registers.fragment_textures[i].enabled() &&
-				sampler_state->validate())
+			if (view = sampler_state->image_handle; !view)
 			{
-				if (view = sampler_state->image_handle; !view)
-				{
-					//Requires update, copy subresource
-					view = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
-				}
-				else
-				{
-					switch (auto raw = view->image(); raw->current_layout)
-					{
-					default:
-					//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
-						break;
-					case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
-						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst;
-						raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-						break;
-					case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
-						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_src;
-						raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-						break;
-					case VK_IMAGE_LAYOUT_GENERAL:
-						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
-						if (!sampler_state->is_cyclic_reference)
-						{
-							// This was used in a cyclic ref before, but is missing a barrier
-							// No need for a full stall, use a custom barrier instead
-							VkPipelineStageFlags src_stage;
-							VkAccessFlags src_access;
-							if (raw->aspect() == VK_IMAGE_ASPECT_COLOR_BIT)
-							{
-								src_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-								src_access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-							}
-							else
-							{
-								src_stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-								src_access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-							}
-
-							vk::insert_image_memory_barrier(
-								*m_current_command_buffer,
-								raw->value,
-								VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-								src_stage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-								src_access, VK_ACCESS_SHADER_READ_BIT,
-								{ raw->aspect(), 0, 1, 0, 1 });
-
-							raw->current_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-						}
-						break;
-					case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
-					case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
-						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage, !sampler_state->is_cyclic_reference;
-						raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-						break;
-					}
-				}
-			}
-
-			if (view) [[likely]]
-			{
-				m_program->bind_uniform({ fs_sampler_handles[i]->value, view->value, view->image()->current_layout },
-					i,
-					::glsl::program_domain::glsl_fragment_program,
-					m_current_frame->descriptor_set);
-
-				if (current_fragment_program.redirected_textures & (1 << i))
-				{
-					// Stencil mirror required
-					auto root_image = static_cast<vk::viewable_image*>(view->image());
-					auto stencil_view = root_image->get_view(0xAAE4, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
-
-					if (!m_stencil_mirror_sampler)
-					{
-						m_stencil_mirror_sampler = std::make_unique<vk::sampler>(*m_device,
-							VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
-							VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
-							VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
-							VK_FALSE, 0.f, 1.f, 0.f, 0.f,
-							VK_FILTER_NEAREST, VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST,
-							VK_BORDER_COLOR_INT_OPAQUE_BLACK);
-					}
-
-					m_program->bind_uniform({ m_stencil_mirror_sampler->value, stencil_view->value, stencil_view->image()->current_layout },
-						i,
-						::glsl::program_domain::glsl_fragment_program,
-						m_current_frame->descriptor_set,
-						true);
-				}
+				//Requires update, copy subresource
+				view = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
 			}
 			else
 			{
-				const VkImageViewType view_type = vk::get_view_type(current_fragment_program.get_texture_dimension(i));
+				switch (auto raw = view->image(); raw->current_layout)
+				{
+				default:
+				//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+					break;
+				case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+					verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst;
+					raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+					break;
+				case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+					verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_src;
+					raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+					break;
+				case VK_IMAGE_LAYOUT_GENERAL:
+					verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
+					if (!sampler_state->is_cyclic_reference)
+					{
+						// This was used in a cyclic ref before, but is missing a barrier
+						// No need for a full stall, use a custom barrier instead
+						VkPipelineStageFlags src_stage;
+						VkAccessFlags src_access;
+						if (raw->aspect() == VK_IMAGE_ASPECT_COLOR_BIT)
+						{
+							src_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+							src_access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+						}
+						else
+						{
+							src_stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+							src_access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+						}
+
+						vk::insert_image_memory_barrier(
+							*m_current_command_buffer,
+							raw->value,
+							VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+							src_stage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+							src_access, VK_ACCESS_SHADER_READ_BIT,
+							{ raw->aspect(), 0, 1, 0, 1 });
+
+						raw->current_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+					}
+					break;
+				case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+				case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+					verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
+					raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+					break;
+				}
+			}
+		}
+
+		if (view) [[likely]]
+		{
+			m_program->bind_uniform({ fs_sampler_handles[i]->value, view->value, view->image()->current_layout },
+				i,
+				::glsl::program_domain::glsl_fragment_program,
+				m_current_frame->descriptor_set);
+
+			if (current_fragment_program.redirected_textures & (1 << i))
+			{
+				// Stencil mirror required
+				auto root_image = static_cast<vk::viewable_image*>(view->image());
+				auto stencil_view = root_image->get_view(0xAAE4, rsx::default_remap_vector, VK_IMAGE_ASPECT_STENCIL_BIT);
+
+				if (!m_stencil_mirror_sampler)
+				{
+					m_stencil_mirror_sampler = std::make_unique<vk::sampler>(*m_device,
+						VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+						VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+						VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+						VK_FALSE, 0.f, 1.f, 0.f, 0.f,
+						VK_FILTER_NEAREST, VK_FILTER_NEAREST, VK_SAMPLER_MIPMAP_MODE_NEAREST,
+						VK_BORDER_COLOR_INT_OPAQUE_BLACK);
+				}
+
+				m_program->bind_uniform({ m_stencil_mirror_sampler->value, stencil_view->value, stencil_view->image()->current_layout },
+					i,
+					::glsl::program_domain::glsl_fragment_program,
+					m_current_frame->descriptor_set,
+					true);
+			}
+		}
+		else
+		{
+			const VkImageViewType view_type = vk::get_view_type(current_fragment_program.get_texture_dimension(i));
+			m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer, view_type)->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL },
+				i,
+				::glsl::program_domain::glsl_fragment_program,
+				m_current_frame->descriptor_set);
+
+			if (current_fragment_program.redirected_textures & (1 << i))
+			{
 				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer, view_type)->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL },
 					i,
 					::glsl::program_domain::glsl_fragment_program,
-					m_current_frame->descriptor_set);
-
-				if (current_fragment_program.redirected_textures & (1 << i))
-				{
-					m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer, view_type)->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL },
-						i,
-						::glsl::program_domain::glsl_fragment_program,
-						m_current_frame->descriptor_set,
-						true);
-				}
+					m_current_frame->descriptor_set,
+					true);
 			}
 		}
 	}
 
-	for (int i = 0; i < rsx::limits::vertex_textures_count; ++i)
+	for (u32 textures_ref = current_vp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
 	{
-		if (current_vp_metadata.referenced_textures_mask & (1 << i))
+		if (!(textures_ref & 1))
+			continue;
+
+		if (!rsx::method_registers.vertex_textures[i].enabled())
 		{
-			if (!rsx::method_registers.vertex_textures[i].enabled())
-			{
-				const auto view_type = vk::get_view_type(current_vertex_program.get_texture_dimension(i));
-				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer, view_type)->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL },
-					i,
-					::glsl::program_domain::glsl_vertex_program,
-					m_current_frame->descriptor_set);
-
-				continue;
-			}
-
-			auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(vs_sampler_state[i].get());
-			auto image_ptr = sampler_state->image_handle;
-
-			if (!image_ptr && sampler_state->validate())
-			{
-				image_ptr = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
-				m_vertex_textures_dirty[i] = true;
-			}
-
-			if (!image_ptr)
-			{
-				rsx_log.error("Texture upload failed to vtexture index %d. Binding null sampler.", i);
-				const auto view_type = vk::get_view_type(current_vertex_program.get_texture_dimension(i));
-
-				m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer, view_type)->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL },
-					i,
-					::glsl::program_domain::glsl_vertex_program,
-					m_current_frame->descriptor_set);
-
-				continue;
-			}
-
-			switch (auto raw = image_ptr->image(); raw->current_layout)
-			{
-			default:
-			//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
-				break;
-			case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
-				verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst;
-				raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-				break;
-			case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
-				verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_src;
-				raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-				break;
-			case VK_IMAGE_LAYOUT_GENERAL:
-				verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
-				if (!sampler_state->is_cyclic_reference)
-				{
-					// Custom barrier, see similar block in FS stage
-					VkPipelineStageFlags src_stage;
-					VkAccessFlags src_access;
-					if (raw->aspect() == VK_IMAGE_ASPECT_COLOR_BIT)
-					{
-						src_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-						src_access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-					}
-					else
-					{
-						src_stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-						src_access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-					}
-
-					vk::insert_image_memory_barrier(
-						*m_current_command_buffer,
-						raw->value,
-						VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-						src_stage, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
-						src_access, VK_ACCESS_SHADER_READ_BIT,
-						{ raw->aspect(), 0, 1, 0, 1 });
-
-					raw->current_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-				}
-				break;
-			case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
-			case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
-				verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
-				raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-				break;
-			}
-
-			m_program->bind_uniform({ vs_sampler_handles[i]->value, image_ptr->value, image_ptr->image()->current_layout },
+			const auto view_type = vk::get_view_type(current_vertex_program.get_texture_dimension(i));
+			m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer, view_type)->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL },
 				i,
 				::glsl::program_domain::glsl_vertex_program,
 				m_current_frame->descriptor_set);
+
+			continue;
 		}
+
+		auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(vs_sampler_state[i].get());
+		auto image_ptr = sampler_state->image_handle;
+
+		if (!image_ptr && sampler_state->validate())
+		{
+			image_ptr = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
+			m_vertex_textures_dirty[i] = true;
+		}
+
+		if (!image_ptr)
+		{
+			rsx_log.error("Texture upload failed to vtexture index %d. Binding null sampler.", i);
+			const auto view_type = vk::get_view_type(current_vertex_program.get_texture_dimension(i));
+
+			m_program->bind_uniform({ vk::null_sampler(), vk::null_image_view(*m_current_command_buffer, view_type)->value, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL },
+				i,
+				::glsl::program_domain::glsl_vertex_program,
+				m_current_frame->descriptor_set);
+
+			continue;
+		}
+
+		switch (auto raw = image_ptr->image(); raw->current_layout)
+		{
+		default:
+		//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+			break;
+		case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+			verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst;
+			raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+			break;
+		case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+			verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_src;
+			raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+			break;
+		case VK_IMAGE_LAYOUT_GENERAL:
+			verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
+			if (!sampler_state->is_cyclic_reference)
+			{
+				// Custom barrier, see similar block in FS stage
+				VkPipelineStageFlags src_stage;
+				VkAccessFlags src_access;
+				if (raw->aspect() == VK_IMAGE_ASPECT_COLOR_BIT)
+				{
+					src_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+					src_access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+				}
+				else
+				{
+					src_stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+					src_access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+				}
+
+				vk::insert_image_memory_barrier(
+					*m_current_command_buffer,
+					raw->value,
+					VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+					src_stage, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
+					src_access, VK_ACCESS_SHADER_READ_BIT,
+					{ raw->aspect(), 0, 1, 0, 1 });
+
+				raw->current_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			}
+			break;
+		case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+		case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+			verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
+			raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+			break;
+		}
+
+		m_program->bind_uniform({ vs_sampler_handles[i]->value, image_ptr->value, image_ptr->image()->current_layout },
+			i,
+			::glsl::program_domain::glsl_vertex_program,
+			m_current_frame->descriptor_set);
 	}
 }
 
@@ -605,81 +611,81 @@ void VKGSRender::bind_interpreter_texture_env()
 	std::advance(end, 16);
 	std::fill(start, end, fallback);
 
-	for (int i = 0; i < rsx::limits::fragment_textures_count; ++i)
+	for (u32 textures_ref = current_fp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
 	{
-		if (current_fp_metadata.referenced_textures_mask & (1 << i))
+		if (!(textures_ref & 1))
+			continue;
+
+		vk::image_view* view = nullptr;
+		auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
+
+		if (rsx::method_registers.fragment_textures[i].enabled() &&
+			sampler_state->validate())
 		{
-			vk::image_view* view = nullptr;
-			auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
-
-			if (rsx::method_registers.fragment_textures[i].enabled() &&
-				sampler_state->validate())
+			if (view = sampler_state->image_handle; !view)
 			{
-				if (view = sampler_state->image_handle; !view)
+				//Requires update, copy subresource
+				view = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
+			}
+			else
+			{
+				switch (auto raw = view->image(); raw->current_layout)
 				{
-					//Requires update, copy subresource
-					view = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
-				}
-				else
-				{
-					switch (auto raw = view->image(); raw->current_layout)
+				default:
+					//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+					break;
+				case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+					verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst;
+					raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+					break;
+				case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+					verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_src;
+					raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+					break;
+				case VK_IMAGE_LAYOUT_GENERAL:
+					verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
+					if (!sampler_state->is_cyclic_reference)
 					{
-					default:
-						//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
-						break;
-					case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
-						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst;
-						raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-						break;
-					case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
-						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::blit_engine_src;
-						raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-						break;
-					case VK_IMAGE_LAYOUT_GENERAL:
-						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage;
-						if (!sampler_state->is_cyclic_reference)
+						// This was used in a cyclic ref before, but is missing a barrier
+						// No need for a full stall, use a custom barrier instead
+						VkPipelineStageFlags src_stage;
+						VkAccessFlags src_access;
+						if (raw->aspect() == VK_IMAGE_ASPECT_COLOR_BIT)
 						{
-							// This was used in a cyclic ref before, but is missing a barrier
-							// No need for a full stall, use a custom barrier instead
-							VkPipelineStageFlags src_stage;
-							VkAccessFlags src_access;
-							if (raw->aspect() == VK_IMAGE_ASPECT_COLOR_BIT)
-							{
-								src_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-								src_access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-							}
-							else
-							{
-								src_stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-								src_access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-							}
-
-							vk::insert_image_memory_barrier(
-								*m_current_command_buffer,
-								raw->value,
-								VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-								src_stage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-								src_access, VK_ACCESS_SHADER_READ_BIT,
-								{ raw->aspect(), 0, 1, 0, 1 });
-
-							raw->current_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+							src_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+							src_access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 						}
-						break;
-					case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
-					case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
-						verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage, !sampler_state->is_cyclic_reference;
-						raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-						break;
+						else
+						{
+							src_stage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+							src_access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+						}
+
+						vk::insert_image_memory_barrier(
+							*m_current_command_buffer,
+							raw->value,
+							VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+							src_stage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+							src_access, VK_ACCESS_SHADER_READ_BIT,
+							{ raw->aspect(), 0, 1, 0, 1 });
+
+						raw->current_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 					}
+					break;
+				case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+				case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+					verify(HERE), sampler_state->upload_context == rsx::texture_upload_context::framebuffer_storage, !sampler_state->is_cyclic_reference;
+					raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+					break;
 				}
 			}
+		}
 
-			if (view)
-			{
-				const int offsets[] = { 0, 16, 48, 32 };
-				auto& sampled_image_info = texture_env[offsets[static_cast<u32>(sampler_state->image_type)] + i];
-				sampled_image_info = { fs_sampler_handles[i]->value, view->value, view->image()->current_layout };
-			}
+		if (view)
+		{
+			const int offsets[] = { 0, 16, 48, 32 };
+			auto& sampled_image_info = texture_env[offsets[static_cast<u32>(sampler_state->image_type)] + i];
+			sampled_image_info = { fs_sampler_handles[i]->value, view->value, view->image()->current_layout };
 		}
 	}
 
@@ -867,6 +873,9 @@ void VKGSRender::emit_geometry(u32 sub_index)
 
 void VKGSRender::begin()
 {
+	// Save shader state now before prefetch and loading happens
+	m_interpreter_state = (m_graphics_state & rsx::pipeline_state::invalidate_pipeline_bits);
+
 	rsx::thread::begin();
 
 	if (skip_current_frame || swapchain_unavailable || cond_render_ctrl.disable_rendering())

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1467,7 +1467,7 @@ void VKGSRender::do_local_task(rsx::FIFO_state state)
 
 bool VKGSRender::load_program()
 {
-	if ((m_interpreter_state = (m_graphics_state & rsx::pipeline_state::invalidate_pipeline_bits)))
+	if (m_graphics_state & rsx::pipeline_state::invalidate_pipeline_bits)
 	{
 		get_current_fragment_program(fs_sampler_state);
 		verify(HERE), current_fragment_program.valid;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -414,8 +414,8 @@ namespace rsx
 			u16 fp_lighting_flags;
 			u16 fp_shadow_textures;
 			u16 fp_redirected_textures;
-			u16 fp_alphakill_mask;
-			u64 fp_zfunc_mask;
+			u16 unused_0;             // Retained for binary compatibility
+			u64 unused_1;             // Retained for binary compatibility
 
 			pipeline_storage_type pipeline_properties;
 		};
@@ -665,8 +665,6 @@ namespace rsx
 			state_hash ^= rpcs3::hash_base<u16>(data.fp_lighting_flags);
 			state_hash ^= rpcs3::hash_base<u16>(data.fp_shadow_textures);
 			state_hash ^= rpcs3::hash_base<u16>(data.fp_redirected_textures);
-			state_hash ^= rpcs3::hash_base<u16>(data.fp_alphakill_mask);
-			state_hash ^= rpcs3::hash_base<u64>(data.fp_zfunc_mask);
 
 			std::string pipeline_file_name = fmt::format("%llX+%llX+%llX+%llX.bin", data.vertex_program_hash, data.fragment_program_hash, data.pipeline_storage_hash, state_hash);
 			std::string pipeline_path = root_path + "/pipelines/" + pipeline_class_name + "/" + version_prefix + "/" + pipeline_file_name;
@@ -740,12 +738,6 @@ namespace rsx
 			fp.shadow_textures = data.fp_shadow_textures;
 			fp.redirected_textures = data.fp_redirected_textures;
 
-			for (u8 index = 0; index < 16; ++index)
-			{
-				fp.textures_alpha_kill[index] = (data.fp_alphakill_mask & (1 << index))? 1: 0;
-				fp.textures_zfunc[index] = (data.fp_zfunc_mask >> (index << 2)) & 0xF;
-			}
-
 			return std::make_tuple(pipeline, vp, fp);
 		}
 
@@ -789,12 +781,6 @@ namespace rsx
 			data_block.fp_lighting_flags = u16(fp.two_sided_lighting);
 			data_block.fp_shadow_textures = fp.shadow_textures;
 			data_block.fp_redirected_textures = fp.redirected_textures;
-
-			for (u8 index = 0; index < 16; ++index)
-			{
-				data_block.fp_alphakill_mask |= u32(fp.textures_alpha_kill[index] & 0x1) << index;
-				data_block.fp_zfunc_mask |= u64(fp.textures_zfunc[index] & 0xF) << (index << 2);
-			}
 
 			return data_block;
 		}

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -481,7 +481,7 @@ namespace rsx
 				stream_data_to_memory_swapped_u32<true>(&rsx::method_registers.transform_program[load_pos * 4 + index % 4]
 					, vm::base(rsx->fifo_ctrl->get_current_arg_ptr()), rcount, 4);
 
-				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty;
+				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_ucode_dirty;
 				rsx::method_registers.transform_program_load_set(load_pos + ((rcount + index % 4) / 4));
 				rsx->fifo_ctrl->skip_methods(count - 1);
 			}
@@ -491,7 +491,7 @@ namespace rsx
 		{
 			if (method_registers.registers[reg] != method_registers.register_previous_value)
 			{
-				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty;
+				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_ucode_dirty;
 			}
 		}
 
@@ -499,7 +499,7 @@ namespace rsx
 		{
 			if (method_registers.registers[reg] != method_registers.register_previous_value)
 			{
-				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty | rsx::pipeline_state::fragment_program_dirty;
+				rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_state_dirty;
 			}
 		}
 
@@ -683,7 +683,7 @@ namespace rsx
 
 		void set_shader_program_dirty(thread* rsx, u32, u32)
 		{
-			rsx->m_graphics_state |= rsx::pipeline_state::fragment_program_dirty;
+			rsx->m_graphics_state |= rsx::pipeline_state::fragment_program_ucode_dirty;
 		}
 
 		void set_surface_dirty_bit(thread* rsx, u32 reg, u32 arg)
@@ -863,7 +863,7 @@ namespace rsx
 
 				if (rsx->current_fp_metadata.referenced_textures_mask & (1 << index))
 				{
-					rsx->m_graphics_state |= rsx::pipeline_state::fragment_program_dirty;
+					rsx->m_graphics_state |= rsx::pipeline_state::fragment_program_state_dirty;
 				}
 			}
 		};
@@ -877,7 +877,7 @@ namespace rsx
 
 				if (rsx->current_vp_metadata.referenced_textures_mask & (1 << index))
 				{
-					rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_dirty;
+					rsx->m_graphics_state |= rsx::pipeline_state::vertex_program_state_dirty;
 				}
 			}
 		};
@@ -3156,6 +3156,10 @@ namespace rsx
 		bind<NV4097_WAIT_FOR_IDLE, nv4097::sync>();
 		bind<NV4097_INVALIDATE_L2, nv4097::set_shader_program_dirty>();
 		bind<NV4097_SET_SHADER_PROGRAM, nv4097::set_shader_program_dirty>();
+		bind<NV4097_SET_SHADER_CONTROL, nv4097::notify_state_changed<fragment_program_state_dirty>>();
+		bind_array<NV4097_SET_TEX_COORD_CONTROL, 1, 10, nv4097::notify_state_changed<fragment_program_state_dirty>>();
+		bind<NV4097_SET_TWO_SIDE_LIGHT_EN, nv4097::notify_state_changed<fragment_program_state_dirty>>();
+		bind<NV4097_SET_POINT_SPRITE_CONTROL, nv4097::notify_state_changed<fragment_program_state_dirty>>();
 		bind<NV4097_SET_TRANSFORM_PROGRAM_START, nv4097::set_transform_program_start>();
 		bind<NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK, nv4097::set_vertex_attribute_output_mask>();
 		bind<NV4097_SET_VERTEX_DATA_BASE_OFFSET, nv4097::set_vertex_base_offset>();


### PR DESCRIPTION
This enables two optimizations I have wanted to finish for a long time:
- Allows for conservative texture uploads
- Allows to update a program object without running full ucode analysis for no reason

The changes result in a modest performance uplift in games that are fully RSX limited (99% RSX load) of upto ~5% from tested configurations.