### PR TITLE
vk: Properly register D32_SFLOAT as a depth-stencil format

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -92,6 +92,7 @@ namespace vk
 		switch (surface_format)
 		{
 		case VK_FORMAT_D16_UNORM:
+		case VK_FORMAT_D32_SFLOAT:
 		case VK_FORMAT_D24_UNORM_S8_UINT:
 		case VK_FORMAT_D32_SFLOAT_S8_UINT:
 			key |= (u64(surface_format) << 8);


### PR DESCRIPTION
Adds a missing switch case from depth-float integration.

Fixes https://github.com/RPCS3/rpcs3/issues/9359