### PR TITLE
Firmware libraries settings overhaul

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1390,12 +1390,12 @@ void ppu_load_exec(const ppu_exec_object& elf)
 	// Module list to load at startup
 	std::set<std::string> load_libs;
 
-	if ((g_cfg.core.lib_loading != lib_loading_type::hybrid && g_cfg.core.lib_loading != lib_loading_type::manual) || g_cfg.core.load_libraries.get_set().count("liblv2.sprx"))
+	if (g_cfg.core.libraries_control.get_set().count("liblv2.sprx:lle") || !g_cfg.core.libraries_control.get_set().count("liblv2.sprx:hle"))
 	{
 		// Will load libsysmodule.sprx internally
 		load_libs.emplace("liblv2.sprx");
 	}
-	else if (g_cfg.core.lib_loading == lib_loading_type::hybrid)
+	else if (g_cfg.core.libraries_control.get_set().count("libsysmodule.sprx:lle") || !g_cfg.core.libraries_control.get_set().count("libsysmodule.sprx:hle"))
 	{
 		// Load only libsysmodule.sprx
 		load_libs.emplace("libsysmodule.sprx");

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -21,7 +21,7 @@ extern void ppu_initialize(const ppu_module&);
 
 LOG_CHANNEL(sys_prx);
 
-extern const std::unordered_map<std::string_view, int> g_prx_list
+extern const std::map<std::string_view, int> g_prx_list
 {
 	{ "libaacenc.sprx", 0 },
 	{ "libaacenc_spurs.sprx", 0 },
@@ -205,17 +205,20 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	if (is_firmware_sprx)
 	{
-		// First condition, LLE for selected libs
-		ignore = g_cfg.core.load_libraries.get_set().count(name) == 0;
-
-		if (g_cfg.core.lib_loading != lib_loading_type::liblv2list && g_cfg.core.lib_loading != lib_loading_type::manual)
+		if (g_cfg.core.libraries_control.get_set().count(name + ":lle"))
 		{
-			// Override list setting condition for liblv2only
-			// For the other modes g_prx_list is a second condition which filters HLE selected libs by list setting
-			if (ignore || g_cfg.core.lib_loading == lib_loading_type::liblv2only)
-			{
-				ignore = g_prx_list.at(name) != 0;
-			}
+			// Force LLE
+			ignore = false;
+		}
+		else if (g_cfg.core.libraries_control.get_set().count(name + ":hle"))
+		{
+			// Force HLE
+			ignore = true;
+		}
+		else
+		{
+			// Use list
+			ignore = g_prx_list.at(name) != 0;
 		}
 	}
 	else if (vpath0.starts_with("/"))

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1076,10 +1076,20 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			// Force LLVM recompiler
 			g_cfg.core.ppu_decoder.from_default();
 
-			// Force lib loading mode
-			g_cfg.core.lib_loading.from_string("Manually load selected libraries");
-			ensure(g_cfg.core.lib_loading == lib_loading_type::manual);
-			g_cfg.core.load_libraries.from_default();
+			// Force LLE lib loading mode
+			g_cfg.core.libraries_control.set_set([]()
+			{
+				std::set<std::string> set;
+
+				extern const std::map<std::string_view, int> g_prx_list;
+
+				for (const auto& lib : g_prx_list)
+				{
+					set.emplace(std::string(lib.first) + ":lle");
+				}
+
+				return set;
+			}());
 
 			// Fake arg (workaround)
 			argv.resize(1);
@@ -1359,10 +1369,6 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			sys_log.notice("PS1 Game: %s, %s", m_title_id, m_title);
 
 			const std::string game_path = "/dev_hdd0/game/" + m_path.substr(hdd0_game.size(), 9);
-
-			sys_log.notice("Forcing manual lib loading mode");
-			g_cfg.core.lib_loading.from_string(fmt::format("%s", lib_loading_type::manual));
-			g_cfg.core.load_libraries.from_list({});
 
 			argv.resize(9);
 			argv[0] = "/dev_flash/ps1emu/ps1_newemu.self";

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -60,9 +60,8 @@ struct cfg_root : cfg::node
 		cfg::_int<-64, 64> stub_ppu_traps{ this, "Stub PPU Traps", 0, true }; // Hack, skip PPU traps for rare cases where the trap is continueable (specify relative instructions to skip)
 
 		cfg::_bool debug_console_mode{ this, "Debug Console Mode", false }; // Debug console emulation, not recommended
-		cfg::_enum<lib_loading_type> lib_loading{ this, "Lib Loader", lib_loading_type::liblv2only };
 		cfg::_bool hook_functions{ this, "Hook static functions" };
-		cfg::set_entry load_libraries{ this, "Load libraries" };
+		cfg::set_entry libraries_control{ this, "Libraries Control" }; // Override HLE/LLE behaviour of selected libs
 		cfg::_bool hle_lwmutex{ this, "HLE lwmutex" }; // Force alternative lwmutex/lwcond implementation
 		cfg::uint64 spu_llvm_lower_bound{ this, "SPU LLVM Lower Bound" };
 		cfg::uint64 spu_llvm_upper_bound{ this, "SPU LLVM Upper Bound", 0xffffffffffffffff };

--- a/rpcs3/Emu/system_config_types.cpp
+++ b/rpcs3/Emu/system_config_types.cpp
@@ -356,24 +356,6 @@ void fmt_class_string<move_handler>::format(std::string& out, u64 arg)
 }
 
 template <>
-void fmt_class_string<lib_loading_type>::format(std::string& out, u64 arg)
-{
-	format_enum(out, arg, [](lib_loading_type value)
-	{
-		switch (value)
-		{
-		case lib_loading_type::manual: return "Manually load selected libraries";
-		case lib_loading_type::hybrid: return "Load automatic and manual selection";
-		case lib_loading_type::liblv2only: return "Load liblv2.sprx only";
-		case lib_loading_type::liblv2both: return "Load liblv2.sprx and manual selection";
-		case lib_loading_type::liblv2list: return "Load liblv2.sprx and strict selection";
-		}
-
-		return unknown;
-	});
-}
-
-template <>
 void fmt_class_string<ppu_decoder_type>::format(std::string& out, u64 arg)
 {
 	format_enum(out, arg, [](ppu_decoder_type type)

--- a/rpcs3/Emu/system_config_types.h
+++ b/rpcs3/Emu/system_config_types.h
@@ -22,15 +22,6 @@ enum class spu_block_size_type
 	giga,
 };
 
-enum class lib_loading_type
-{
-	manual,
-	hybrid,
-	liblv2only,
-	liblv2both,
-	liblv2list,
-};
-
 enum class sleep_timers_accuracy_level
 {
 	_as_host,

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -56,7 +56,7 @@ public:
 	/** Connects a button group with the target settings type*/
 	void EnhanceRadioButton(QButtonGroup* button_group, emu_settings_type type);
 
-	std::vector<std::string> GetLoadedLibraries();
+	std::vector<std::string> GetLibrariesControl();
 	void SaveSelectedLibraries(const std::vector<std::string>& libs);
 
 	/** Returns the valid options for a given setting.*/

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -10,7 +10,6 @@ enum class emu_settings_type
 	// Core
 	PPUDecoder,
 	SPUDecoder,
-	LibLoadOptions,
 	HookStaticFuncs,
 	EnableThreadScheduler,
 	LowerSPUThreadPrio,
@@ -156,7 +155,6 @@ static const QMap<emu_settings_type, cfg_location> settings_location =
 	// Core Tab
 	{ emu_settings_type::PPUDecoder,               { "Core", "PPU Decoder"}},
 	{ emu_settings_type::SPUDecoder,               { "Core", "SPU Decoder"}},
-	{ emu_settings_type::LibLoadOptions,           { "Core", "Lib Loader"}},
 	{ emu_settings_type::HookStaticFuncs,          { "Core", "Hook static functions"}},
 	{ emu_settings_type::EnableThreadScheduler,    { "Core", "Enable thread scheduler"}},
 	{ emu_settings_type::LowerSPUThreadPrio,       { "Core", "Lower SPU thread priority"}},

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1905,86 +1905,6 @@
             </widget>
            </item>
            <item>
-            <widget class="QGroupBox" name="gb_lib_settings">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="title">
-              <string>Firmware Settings</string>
-             </property>
-             <layout class="QVBoxLayout" name="lib_settings_layout">
-              <item>
-               <widget class="QRadioButton" name="lib_manu">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string notr="true">Manually load selected libraries</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="lib_both">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string notr="true">Load automatic and manual selection</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="lib_lv2">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string notr="true">Load liblv2.sprx only</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="lib_lv2b">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string notr="true">Load liblv2.sprx and manual selection</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="lib_lv2l">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string notr="true">Load liblv2.sprx and strict selection</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
             <spacer name="advancedTabSpacerLeft">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -2014,6 +1934,22 @@
              </property>
              <layout class="QVBoxLayout" name="gb_libs_layout">
               <item>
+               <widget class="QListWidget" name="hleList">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="selectionMode">
+                 <enum>QAbstractItemView::ExtendedSelection</enum>
+                </property>
+                <property name="viewMode">
+                 <enum>QListView::ListMode</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QListWidget" name="lleList">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -2030,14 +1966,25 @@
                </widget>
               </item>
               <item>
-               <widget class="QLineEdit" name="searchBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+               <layout class="QHBoxLayout" name="gb_lleLibs_layout" stretch="1,0">
+                <property name="spacing">
+                 <number>6</number>
                 </property>
-               </widget>
+                <property name="sizeConstraint">
+                 <enum>QLayout::SetNoConstraint</enum>
+                </property>
+                <item>
+                 <widget class="QLineEdit" name="searchBox">
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="resetLleList">
+                  <property name="text">
+                   <string>Reset</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
              </layout>
             </widget>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <QString>
 #include <QObject>
@@ -19,11 +19,10 @@ public:
 	{
 		// advanced
 
-		const QString libraries_manual             = tr("Allows the user to manually choose the LLE libraries to load.\nIf unsure, don't use this option. Nothing will work if you use this.");
-		const QString libraries_both               = tr("Load libsysmodule.sprx and chosen list of libraries. Option for backward compatibility.\nIf unsure, don't use this option.");
-		const QString libraries_liblv2both         = tr("Loads liblv2.sprx and chosen list of libraries.\nIf unsure, don't use this option.");
-		const QString libraries_liblv2list         = tr("Loads liblv2.sprx and nothing but selected libraries.\nDon't use this option.");
-		const QString libraries_liblv2             = tr("This closely emulates how games can load and unload system module files on a real PlayStation 3.\nSome games require this.\nThis is the preferred option.");
+		const QString lle_list                     = tr("This libraries group are LLEd by default (lower list), selection will switch to HLE.\nLLE - \"Low Level Emulated\", function code inside the selected SPRX file will be used for exported firmware functions.\nHLE - \"High Level Emulated\", alternative emulator code will be used instead for exported firmware functions.\nIf choosen wrongly, games will not work! If unsure, leave both lists' selection empty.");
+		const QString hle_list                     = tr("This libraries group are HLEd by default (upper list), selection will switch to LLE.\nLLE - \"Low Level Emulated\", function code inside the selected SPRX file will be used for exported firmware functions.\nHLE - \"High Level Emulated\", alternative emulator code will be used instead for exported firmware functions.\nIf choosen wrongly, games will not work! If unsure, leave both lists' selection empty.");
+		const QString lib_default_hle              = tr("Select to LLE. (HLE by default)");
+		const QString lib_default_lle              = tr("Select to HLE. (LLE by default)");
 
 		const QString debug_console_mode           = tr("Increases the amount of usable system memory to match a DECR console and more.\nCauses some software to behave differently than on retail hardware.");
 		const QString silence_all_logs             = tr("Stop writing any logs after game startup. Don't use unless you believe it's necessary.");


### PR DESCRIPTION
* Remove all lib loading types. E.g. "liblv2.sprx only" etc, replace their usage with two lists. Empty lists is default fw loading behaviour.
Selecting an SPRX file via HLE-default list will LLE it, selecting an SPRX file via HLE-default list will LLE it.
As a nice side effect makes HLEing of libs simpler than ever by selecting them in list such as SPURS or GCM. (if they are LLEd by default).
Previously you had to use manual list type and randomly select LLE-by-defaults libs until the game works, only then unselect the lib you want to HLE.
* Minor libsysmodule.sprx loading fix.
* Fixed LLVM compilation of firmware. (simply didn't compile after installation)
* Handle invalid settings in EnhanceRadioButton (GUI button groups), select default setting button instead of selecting nothing.
* Fixed g_prx_list sorting by using std::map instead of std::unordered_map.
* Fixed PS1 classics. fixes #9394 
* Added a reset button for libraries list.

MISC:
closes #6442 