### PR TITLE
Remove ASSUME macro

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -264,6 +264,19 @@ void fmt_class_string<src_loc>::format(std::string& out, u64 arg)
 	{
 		out += ')';
 	}
+
+	// Print error code (may be irrelevant)
+#ifdef _WIN32
+	if (DWORD error = GetLastError())
+	{
+		fmt::append(out, " (e=0x%08x[%u])", error, error);
+	}
+#else
+	if (int error = errno)
+	{
+		fmt::append(out, " (errno=%d)", error);
+	}
+#endif
 }
 
 namespace fmt
@@ -271,27 +284,13 @@ namespace fmt
 	void raw_verify_error(const src_loc& loc)
 	{
 		std::string out{"Verification failed"};
-
-		// Print error code (may be irrelevant)
-#ifdef _WIN32
-		if (DWORD error = GetLastError())
-		{
-			fmt::append(out, " (e=%#x):", error);
-		}
-#else
-		if (int error = errno)
-		{
-			fmt::append(out, " (e=%d):", error);
-		}
-#endif
-
 		fmt::append(out, "%s", loc);
 		thread_ctrl::emergency_exit(out);
 	}
 
 	void raw_narrow_error(const src_loc& loc, const fmt_type_info* sup, u64 arg)
 	{
-		std::string out{"Narrow error"};
+		std::string out{"Narrowing error"};
 
 		if (sup)
 		{

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -372,8 +372,6 @@ public:
 	// Try to abort by assigning thread_state::aborting (UB if assigning different state)
 	named_thread& operator=(thread_state s)
 	{
-		ASSUME(s == thread_state::aborting);
-
 		if (s == thread_state::aborting && thread::m_sync.fetch_op([](u64& v){ return !(v & 3) && (v |= 1); }).second)
 		{
 			if (s == thread_state::aborting)

--- a/Utilities/typemap.h
+++ b/Utilities/typemap.h
@@ -372,7 +372,6 @@ namespace utils
 		template <typename D = std::remove_reference_t<T>>
 		auto get() const noexcept
 		{
-			ASSUME(m_block->m_type != 0);
 			return m_block->get_ptr<T>();
 		}
 

--- a/Utilities/types.h
+++ b/Utilities/types.h
@@ -29,28 +29,13 @@
 #endif
 
 #ifdef _MSC_VER
-
-#define ASSUME(...) ((__VA_ARGS__) ? void() : __assume(0))  // MSVC __assume ignores side-effects
 #define SAFE_BUFFERS __declspec(safebuffers)
 #define NEVER_INLINE __declspec(noinline)
 #define FORCE_INLINE __forceinline
-
 #else // not _MSC_VER
-
-#ifdef __clang__
-#if defined(__has_builtin) && __has_builtin(__builtin_assume)
-#define ASSUME(...) ((__VA_ARGS__) ? void() : __builtin_assume(0)) // __builtin_assume (supported by modern clang) ignores side-effects
-#endif
-#endif
-
-#ifndef ASSUME // gcc and old clang
-#define ASSUME(...) ((__VA_ARGS__) ? void() : __builtin_unreachable())  // note: the compiler will generate code to evaluate "cond" if the expression is opaque
-#endif
-
 #define SAFE_BUFFERS __attribute__((no_stack_protector))
 #define NEVER_INLINE __attribute__((noinline)) inline
 #define FORCE_INLINE __attribute__((always_inline)) inline
-
 #endif // _MSC_VER
 
 #define CHECK_SIZE(type, size) static_assert(sizeof(type) == size, "Invalid " #type " type size")

--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -18,7 +18,7 @@ protected:
 
 	virtual void Write(const std::string& value)
 	{
-		switch(m_mode)
+		switch (m_mode)
 		{
 			case CPUDisAsm_DumpMode:
 			{
@@ -50,7 +50,7 @@ protected:
 				last_opcode = value;
 				break;
 			}
-			default: ASSUME(0);
+			default: fmt::throw_exception("Unreachable");
 		}
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -594,7 +594,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 		case CELL_GAME_GAMETYPE_HDD: return "HG"sv;
 		case CELL_GAME_GAMETYPE_GAMEDATA: return "GD"sv;
 		case CELL_GAME_GAMETYPE_DISC: return "DG"sv;
-		default: ASSUME(0);
+		default: fmt::throw_exception("Unreachable");
 		}
 	}())
 	{

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -367,7 +367,7 @@ static s32 savedata_check_args(u32 operation, u32 version, vm::cptr<char> dirNam
 			return 4;
 		}
 		case 0: break;
-		default: ASSUME(0);
+		default: fmt::throw_exception("Unreachable");
 		}
 	}
 
@@ -426,7 +426,7 @@ static s32 savedata_check_args(u32 operation, u32 version, vm::cptr<char> dirNam
 						return 17;
 					}
 					case 0: break;
-					default: ASSUME(0);
+					default: fmt::throw_exception("Unreachable");
 					}
 				}
 
@@ -776,7 +776,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 					break;
 				}
 				case 0: break;
-				default: ASSUME(0);
+				default: fmt::throw_exception("Unreachable");
 				}
 
 				selected_list.emplace(listSet->fixedList[i].dirName);
@@ -826,7 +826,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 					break;
 				}
 				case 0: break;
-				default: ASSUME(0);
+				default: fmt::throw_exception("Unreachable");
 				}
 			}
 
@@ -858,7 +858,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 					break;
 				}
 				case 0: break;
-				default: ASSUME(0);
+				default: fmt::throw_exception("Unreachable");
 				}
 
 				const std::string dirStr = listSet->focusDirName.get_ptr();
@@ -1114,7 +1114,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				return {CELL_SAVEDATA_ERROR_PARAM, "28"};
 			}
 			case 0: break;
-			default: ASSUME(0);
+			default: fmt::throw_exception("Unreachable");
 			}
 
 			const std::string dirStr = fixedSet->dirName.get_ptr();
@@ -1973,7 +1973,7 @@ static NEVER_INLINE error_code savedata_get_list_item(vm::cptr<char> dirName, vm
 		return {CELL_SAVEDATA_ERROR_PARAM, "109"};
 	}
 	case 0: break;
-	default: ASSUME(0);
+	default: fmt::throw_exception("Unreachable");
 	}
 
 	const std::string base_dir = fmt::format("/dev_hdd0/home/%08u/savedata/", userId);

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -10,7 +10,7 @@
 
 LOG_CHANNEL(ppu_validator);
 
-constexpr ppu_decoder<ppu_itype> s_ppu_itype;
+const ppu_decoder<ppu_itype> s_ppu_itype;
 
 template<>
 void fmt_class_string<ppu_attr>::format(std::string& out, u64 arg)

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -2,7 +2,7 @@
 #include "PPUDisAsm.h"
 #include "PPUFunction.h"
 
-constexpr ppu_decoder<PPUDisAsm> s_ppu_disasm;
+const ppu_decoder<PPUDisAsm> s_ppu_disasm;
 
 u32 PPUDisAsm::disasm(u32 pc)
 {

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -69,7 +69,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x1: info.first = "ble"; break;
 		case 0x2: info.first = "bne"; break;
 		case 0x3: info.first = "bns"; break;
-		default: ASSUME(0); break;
+		default: fmt::throw_exception("Unreachable");
 		}
 		break;
 	}
@@ -82,7 +82,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x1: info.first = "ble"; break;
 		case 0x2: info.first = "bne"; break;
 		case 0x3: info.first = "bns"; break;
-		default: ASSUME(0); break;
+		default: fmt::throw_exception("Unreachable");
 		}
 		break;
 	}
@@ -95,7 +95,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x1: info.first = "ble"; break;
 		case 0x2: info.first = "bne"; break;
 		case 0x3: info.first = "bns"; break;
-		default: ASSUME(0); break;
+		default: fmt::throw_exception("Unreachable");
 		}
 		break;
 	}
@@ -107,7 +107,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x1: info.first = "bgt"; break;
 		case 0x2: info.first = "beq"; break;
 		case 0x3: info.first = "bso"; break;
-		default: ASSUME(0); break;
+		default: fmt::throw_exception("Unreachable");
 		}
 		break;
 	}
@@ -120,7 +120,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x1: info.first = "bgt"; break;
 		case 0x2: info.first = "beq"; break;
 		case 0x3: info.first = "bso"; break;
-		default: ASSUME(0); break;
+		default: fmt::throw_exception("Unreachable");
 		}
 		break;
 	}
@@ -133,7 +133,7 @@ constexpr std::pair<const char*, char> get_BC_info(u32 bo, u32 bi)
 		case 0x1: info.first = "bgt"; break;
 		case 0x2: info.first = "beq"; break;
 		case 0x3: info.first = "bso"; break;
-		default: ASSUME(0); break;
+		default: fmt::throw_exception("Unreachable");
 		}
 		break;
 	}

--- a/rpcs3/Emu/Cell/PPUDisAsm.h
+++ b/rpcs3/Emu/Cell/PPUDisAsm.h
@@ -24,7 +24,7 @@ private:
 		case 0x1: return "gt";
 		case 0x2: return "eq";
 		case 0x3: return "so";
-		default: ASSUME(0); return {};
+		default: fmt::throw_exception("Unreachable");
 		}
 	}
 
@@ -284,7 +284,7 @@ private:
 	{
 		Write(fmt::format("%s cr%d[%s],0x%x ", FixOp(op), bi / 4, get_partial_BI_field(bi), pc));
 	}
-	
+
 public:
 	u32 disasm(u32 pc) override;
 

--- a/rpcs3/Emu/Cell/PPUOpcodes.h
+++ b/rpcs3/Emu/Cell/PPUOpcodes.h
@@ -103,7 +103,7 @@ class ppu_decoder
 	};
 
 	// Fill lookup table
-	constexpr void fill_table(u32 main_op, u32 count, u32 sh, std::initializer_list<instruction_info> entries)
+	void fill_table(u32 main_op, u32 count, u32 sh, std::initializer_list<instruction_info> entries) noexcept
 	{
 		if (sh < 11)
 		{
@@ -132,7 +132,7 @@ class ppu_decoder
 	}
 
 public:
-	constexpr ppu_decoder()
+	ppu_decoder() noexcept
 	{
 		for (auto& x : m_table)
 		{
@@ -576,12 +576,12 @@ public:
 		});
 	}
 
-	const std::array<T, 0x20000>& get_table() const
+	const std::array<T, 0x20000>& get_table() const noexcept
 	{
 		return m_table;
 	}
 
-	T decode(u32 inst) const
+	T decode(u32 inst) const noexcept
 	{
 		return m_table[ppu_decode(inst)];
 	}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -105,9 +105,9 @@ void fmt_class_string<ppu_join_status>::format(std::string& out, u64 arg)
 	});
 }
 
-constexpr ppu_decoder<ppu_interpreter_precise> g_ppu_interpreter_precise;
-constexpr ppu_decoder<ppu_interpreter_fast> g_ppu_interpreter_fast;
-constexpr ppu_decoder<ppu_itype> g_ppu_itype;
+const ppu_decoder<ppu_interpreter_precise> g_ppu_interpreter_precise;
+const ppu_decoder<ppu_interpreter_fast> g_ppu_interpreter_fast;
+const ppu_decoder<ppu_itype> g_ppu_itype;
 
 extern void ppu_initialize();
 extern void ppu_initialize(const ppu_module& info);

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -10,8 +10,8 @@
 
 using namespace llvm;
 
-constexpr ppu_decoder<PPUTranslator> s_ppu_decoder;
-constexpr ppu_decoder<ppu_iname> s_ppu_iname;
+const ppu_decoder<PPUTranslator> s_ppu_decoder;
+const ppu_decoder<ppu_iname> s_ppu_iname;
 
 PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_module& info, ExecutionEngine& engine)
 	: cpu_translator(_module, false)

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -23,8 +23,8 @@
 #define SPU_OFF_16(x, ...) asmjit::x86::word_ptr(*cpu, offset32(&spu_thread::x, ##__VA_ARGS__))
 #define SPU_OFF_8(x, ...) asmjit::x86::byte_ptr(*cpu, offset32(&spu_thread::x, ##__VA_ARGS__))
 
-constexpr spu_decoder<spu_interpreter_fast> g_spu_interpreter_fast; // TODO: avoid
-constexpr spu_decoder<spu_recompiler> s_spu_decoder;
+extern const spu_decoder<spu_interpreter_fast> g_spu_interpreter_fast{}; // TODO: avoid
+const spu_decoder<spu_recompiler> s_spu_decoder;
 
 extern u64 get_timebased_time();
 

--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -88,7 +88,7 @@ std::pair<bool, v128> SPUDisAsm::try_get_const_value(u32 reg, u32 pc) const
 					case spu_itype::CHD: size = 2; break;
 					case spu_itype::CWD: size = 4; break;
 					case spu_itype::CDD: size = 8; break;
-					default: ASSUME(0);
+					default: fmt::throw_exception("Unreachable");
 					}
 
 					const u32 index = (~op0.i7 & 0xf) / size;
@@ -100,7 +100,7 @@ std::pair<bool, v128> SPUDisAsm::try_get_const_value(u32 reg, u32 pc) const
 					case 2: res._u16[index] = 0x0203; break;
 					case 4: res._u32[index] = 0x00010203; break;
 					case 8: res._u64[index] = 0x0001020304050607ull; break;
-					default: ASSUME(0);
+					default: fmt::throw_exception("Unreachable");
 					}
 
 					return {true, res};

--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -3,9 +3,9 @@
 #include "SPUAnalyser.h"
 #include "SPUThread.h"
 
-constexpr spu_decoder<SPUDisAsm> s_spu_disasm;
-constexpr spu_decoder<spu_itype> s_spu_itype;
-constexpr spu_decoder<spu_iflag> s_spu_iflag;
+const spu_decoder<SPUDisAsm> s_spu_disasm;
+const spu_decoder<spu_itype> s_spu_itype;
+const spu_decoder<spu_iflag> s_spu_iflag;
 
 u32 SPUDisAsm::disasm(u32 pc)
 {

--- a/rpcs3/Emu/Cell/SPUOpcodes.h
+++ b/rpcs3/Emu/Cell/SPUOpcodes.h
@@ -56,14 +56,14 @@ class spu_decoder
 		u32 value;
 		T pointer;
 
-		constexpr instruction_info(u32 m, u32 v, T p)
+		instruction_info(u32 m, u32 v, T p) noexcept
 			: magn(m)
 			, value(v)
 			, pointer(p)
 		{
 		}
 
-		constexpr instruction_info(u32 m, u32 v, const T* p)
+		instruction_info(u32 m, u32 v, const T* p) noexcept
 			: magn(m)
 			, value(v)
 			, pointer(*p)
@@ -72,7 +72,7 @@ class spu_decoder
 	};
 
 public:
-	constexpr spu_decoder()
+	spu_decoder() noexcept
 	{
 		const std::initializer_list<instruction_info> instructions
 		{
@@ -291,12 +291,12 @@ public:
 		}
 	}
 
-	const std::array<T, 2048>& get_table() const
+	const std::array<T, 2048>& get_table() const noexcept
 	{
 		return m_table;
 	}
 
-	T decode(u32 inst) const
+	T decode(u32 inst) const noexcept
 	{
 		return m_table[spu_decode(inst)];
 	}

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -22,12 +22,12 @@ extern atomic_t<const char*> g_progr;
 extern atomic_t<u32> g_progr_ptotal;
 extern atomic_t<u32> g_progr_pdone;
 
-constexpr spu_decoder<spu_itype> s_spu_itype;
-constexpr spu_decoder<spu_iname> s_spu_iname;
-constexpr spu_decoder<spu_iflag> s_spu_iflag;
+const spu_decoder<spu_itype> s_spu_itype;
+const spu_decoder<spu_iname> s_spu_iname;
+const spu_decoder<spu_iflag> s_spu_iflag;
 
-constexpr spu_decoder<spu_interpreter_precise> g_spu_interpreter_precise;
-constexpr spu_decoder<spu_interpreter_fast> g_spu_interpreter_fast;
+extern const spu_decoder<spu_interpreter_precise> g_spu_interpreter_precise{};
+extern const spu_decoder<spu_interpreter_fast> g_spu_interpreter_fast;
 
 extern u64 get_timebased_time();
 
@@ -8799,7 +8799,7 @@ std::unique_ptr<spu_recompiler_base> spu_recompiler_base::make_llvm_recompiler(u
 	return std::make_unique<spu_llvm_recompiler>(magn);
 }
 
-constexpr spu_decoder<spu_llvm_recompiler> g_spu_llvm_decoder;
+const spu_decoder<spu_llvm_recompiler> g_spu_llvm_decoder;
 
 decltype(&spu_llvm_recompiler::UNK) spu_llvm_recompiler::decode(u32 op)
 {

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -291,7 +291,7 @@ void do_cell_atomic_128_store(u32 addr, const void* to_write);
 
 extern thread_local u64 g_tls_fault_spu;
 
-constexpr spu_decoder<spu_itype> s_spu_itype;
+const spu_decoder<spu_itype> s_spu_itype;
 
 namespace spu
 {

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -3516,8 +3516,6 @@ retry:
 
 void spu_thread::set_events(u32 bits)
 {
-	ASSUME(!(bits & ~0xffff));
-
 	if (ch_events.atomic_op([&](ch_events_t& events)
 	{
 		events.events |= bits;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1271,7 +1271,7 @@ error_code sys_spu_thread_write_ls(ppu_thread& ppu, u32 id, u32 lsa, u64 value, 
 	case 2: thread->_ref<u16>(lsa) = static_cast<u16>(value); break;
 	case 4: thread->_ref<u32>(lsa) = static_cast<u32>(value); break;
 	case 8: thread->_ref<u64>(lsa) = value; break;
-	default: ASSUME(0);
+	default: fmt::throw_exception("Unreachable");
 	}
 
 	return CELL_OK;
@@ -1314,7 +1314,7 @@ error_code sys_spu_thread_read_ls(ppu_thread& ppu, u32 id, u32 lsa, vm::ptr<u64>
 	case 2: *value = thread->_ref<u16>(lsa); break;
 	case 4: *value = thread->_ref<u32>(lsa); break;
 	case 8: *value = thread->_ref<u64>(lsa); break;
-	default: ASSUME(0);
+	default: fmt::throw_exception("Unreachable");
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -310,8 +310,6 @@ namespace vm
 		{
 			to_clear = for_all_range_locks(to_clear, [&](u32 addr2, u32 size2)
 			{
-				ASSUME(size2);
-
 				if (range.overlaps(utils::address_range::start_length(addr2, size2))) [[unlikely]]
 				{
 					return 1;

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -862,8 +862,7 @@ namespace rsx
 		case rsx::surface_antialiasing::square_rotated_4_samples:
 			return 4;
 		default:
-			ASSUME(0);
-			return 0;
+			fmt::throw_exception("Unreachable");
 		}
 	}
 
@@ -1083,7 +1082,7 @@ namespace rsx
 		case rsx::surface_depth_format2::z24s8_float:
 			return{ CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT, true };
 		default:
-			ASSUME(0);
+			fmt::throw_exception("Unreachable");
 		}
 	}
 

--- a/rpcs3/Emu/RSX/Common/texture_cache_checker.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_checker.h
@@ -40,7 +40,7 @@ namespace rsx {
 				case utils::protection::no: return no > 0;
 				case utils::protection::ro: return no == 0 && ro > 0;
 				case utils::protection::rw: return no == 0 && ro == 0;
-				default: ASSUME(0);
+				default: fmt::throw_exception("Unreachable");
 				}
 			}
 
@@ -50,7 +50,7 @@ namespace rsx {
 				{
 				case utils::protection::no: if (no++ == UINT8_MAX) fmt::throw_exception("add(protection::no) overflow with NO==%d", UINT8_MAX); return;
 				case utils::protection::ro: if (ro++ == UINT8_MAX) fmt::throw_exception("add(protection::ro) overflow with RO==%d", UINT8_MAX); return;
-				default: ASSUME(0);
+				default: fmt::throw_exception("Unreachable");
 				}
 			}
 
@@ -60,7 +60,7 @@ namespace rsx {
 				{
 				case utils::protection::no: if (no-- == 0) fmt::throw_exception("remove(protection::no) overflow with NO==0"); return;
 				case utils::protection::ro: if (ro-- == 0) fmt::throw_exception("remove(protection::ro) overflow with RO==0"); return;
-				default: ASSUME(0);
+				default: fmt::throw_exception("Unreachable");
 				}
 			}
 		};

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -694,7 +694,6 @@ namespace gl
 				}
 				default:
 				{
-					ASSUME(0);
 					fmt::throw_exception("Unreachable");
 				}
 				}

--- a/rpcs3/Emu/RSX/RSXOffload.cpp
+++ b/rpcs3/Emu/RSX/RSXOffload.cpp
@@ -61,7 +61,7 @@ namespace rsx
 						rsx::get_current_renderer()->renderctl(job.aux_param0, job.src);
 						break;
 					}
-					default: ASSUME(0); fmt::throw_exception("Unreachable");
+					default: fmt::throw_exception("Unreachable");
 					}
 
 					m_processed_count.release(m_processed_count + 1);
@@ -224,7 +224,6 @@ namespace rsx
 			range = get_index_count(static_cast<rsx::primitive_type>(m_current_job->aux_param0), m_current_job->length);
 			break;
 		default:
-			ASSUME(0);
 			fmt::throw_exception("Unreachable");
 		}
 

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -39,7 +39,7 @@ namespace rsx
 		case rsx::texture_dimension::dimension3d: return rsx::texture_dimension_extended::texture_dimension_3d;
 		case rsx::texture_dimension::dimension2d: return cubemap() ? rsx::texture_dimension_extended::texture_dimension_cubemap : rsx::texture_dimension_extended::texture_dimension_2d;
 
-		default: ASSUME(0);
+		default: fmt::throw_exception("Unreachable");
 		}
 	}
 
@@ -351,7 +351,7 @@ namespace rsx
 		case rsx::texture_dimension::dimension3d: return rsx::texture_dimension_extended::texture_dimension_3d;
 		case rsx::texture_dimension::dimension2d: return cubemap() ? rsx::texture_dimension_extended::texture_dimension_cubemap : rsx::texture_dimension_extended::texture_dimension_2d;
 
-		default: ASSUME(0);
+		default: fmt::throw_exception("Unreachable");
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -16,7 +16,7 @@ namespace vk
 			return VK_IMAGE_VIEW_TYPE_CUBE;
 		case rsx::texture_dimension_extended::texture_dimension_3d:
 			return VK_IMAGE_VIEW_TYPE_3D;
-		default: ASSUME(0);
+		default: fmt::throw_exception("Unreachable");
 		};
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -79,9 +79,9 @@ namespace vk
 		case rsx::texture_minify_filter::linear_linear: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR, true };
 		case rsx::texture_minify_filter::convolution_min: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, false };
 		default:
-			ASSUME(0);
 			break;
 		}
+
 		fmt::throw_exception("Invalid min filter");
 	}
 
@@ -93,9 +93,9 @@ namespace vk
 		case rsx::texture_magnify_filter::linear: return VK_FILTER_LINEAR;
 		case rsx::texture_magnify_filter::convolution_mag: return VK_FILTER_LINEAR;
 		default:
-			ASSUME(0);
 			break;
 		}
+
 		fmt::throw_exception("Invalid mag filter (0x%x)", static_cast<u32>(mag_filter));
 	}
 
@@ -147,10 +147,10 @@ namespace vk
 		case rsx::texture_wrap_mode::mirror_once_border: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
 		case rsx::texture_wrap_mode::mirror_once_clamp: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
 		default:
-			ASSUME(0);
 			break;
 		}
-		fmt::throw_exception("unhandled texture clamp mode");
+
+		fmt::throw_exception("Unhandled texture clamp mode");
 	}
 
 	float max_aniso(rsx::texture_max_anisotropy gcm_aniso)
@@ -166,7 +166,6 @@ namespace vk
 		case rsx::texture_max_anisotropy::x12: return 12.0f;
 		case rsx::texture_max_anisotropy::x16: return 16.0f;
 		default:
-			ASSUME(0);
 			break;
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -1662,8 +1662,7 @@ private:
 					info.viewType = VK_IMAGE_VIEW_TYPE_3D;
 					break;
 				default:
-					ASSUME(0);
-					break;
+					fmt::throw_exception("Unreachable");
 				}
 
 				info.subresourceRange.layerCount = resource->info.arrayLayers;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1146,8 +1146,7 @@ namespace vk
 				layer = 1;
 				break;
 			default:
-				ASSUME(0);
-				break;
+				fmt::throw_exception("Unreachable");
 			}
 
 			auto *image = new vk::viewable_image(*m_device, m_memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -76,8 +76,8 @@ namespace rsx
 			return (rhs == surface_depth_format2::z16_uint || rhs == surface_depth_format2::z16_float);
 		case surface_depth_format::z24s8:
 			return (rhs == surface_depth_format2::z24s8_uint || rhs == surface_depth_format2::z24s8_float);
-		default:
-			ASSUME(0);
+		[[unlikely]] default:
+			return false;
 		}
 	}
 

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -213,7 +213,7 @@ namespace rsx
 			case section_bounds::confirmed_range:
 				return confirmed_range.valid() ? confirmed_range : cpu_range;
 			default:
-				ASSUME(0);
+				fmt::throw_exception("Unreachable");
 			}
 		}
 


### PR DESCRIPTION
It's extremely dangerous "feature" and I'm glad it's so rarely used. **But half of its uses are horrible misuses for some reason.**

I checked some code MSVC generates in small switches. It basically resembles if-else-if chain. Adding a little more at the end can't alter its performance. More clever compilers (gcc/clang) just throw away default path if full range (like, 4 values) is covered.