### PR TITLE
Another attempt to implement is_same_ptr() trait

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1,7 +1,6 @@
 #include "File.h"
 #include "mutex.h"
 #include "StrFmt.h"
-#include "BEType.h"
 #include "Crypto/sha1.h"
 
 #include <unordered_map>

--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -1,8 +1,9 @@
 #include "StrFmt.h"
-#include "BEType.h"
 #include "StrUtil.h"
 #include "cfmt.h"
+#include "util/endian.hpp"
 #include "util/logs.hpp"
+#include "util/v128.hpp"
 
 #include <algorithm>
 #include <string_view>

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -119,6 +119,17 @@ struct fmt_unveil<b8, void>
 	}
 };
 
+template <typename T, bool Se, std::size_t Align>
+struct fmt_unveil<se_t<T, Se, Align>, void>
+{
+	using type = typename fmt_unveil<T>::type;
+
+	static inline auto get(const se_t<T, Se, Align>& arg)
+	{
+		return fmt_unveil<T>::get(arg);
+	}
+};
+
 // String type format provider, also type classifier (format() called if an argument is formatted as "%s")
 template <typename T, typename = void>
 struct fmt_class_string

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1296,7 +1296,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context) no
 
 			if (op != X64OP_LOAD_BE)
 			{
-				value = se_storage<u32>::swap(value);
+				value = stx::se_storage<u32>::swap(value);
 			}
 
 			if (op == X64OP_LOAD_CMP)
@@ -1338,7 +1338,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context) no
 			}
 
 			u32 val32 = static_cast<u32>(reg_value);
-			if (!thread->write_reg(addr, op == X64OP_STORE ? se_storage<u32>::swap(val32) : val32))
+			if (!thread->write_reg(addr, op == X64OP_STORE ? stx::se_storage<u32>::swap(val32) : val32))
 			{
 				return false;
 			}

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -4,6 +4,9 @@
 #include "version.h"
 #include "Emu/System.h"
 
+#include "util/types.hpp"
+#include "util/endian.hpp"
+
 LOG_CHANNEL(patch_log, "PAT");
 
 namespace config_key

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -1,10 +1,10 @@
 ﻿#pragma once
 
-#include "BEType.h"
 #include <vector>
 #include <string>
 #include <unordered_map>
 
+#include "util/types.hpp"
 #include "util/yaml.hpp"
 
 namespace patch_key
@@ -53,7 +53,7 @@ public:
 			f64 double_value;
 		} value { 0 };
 	};
-	
+
 	using patch_app_versions = std::unordered_map<std::string /*app_version*/, bool /*enabled*/>;
 	using patch_serials = std::unordered_map<std::string /*serial*/, patch_app_versions>;
 	using patch_titles = std::unordered_map<std::string /*serial*/, patch_serials>;

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -5,6 +5,8 @@
 #include "Utilities/mutex.h"
 #include <cmath>
 
+#include "util/v128.hpp"
+
 LOG_CHANNEL(edat_log, "EDAT");
 
 // Static variables are being modified concurrently in ec.cpp, for now use a mutex

--- a/rpcs3/Crypto/unedat.h
+++ b/rpcs3/Crypto/unedat.h
@@ -4,8 +4,9 @@
 
 #include "utils.h"
 
-#include "Utilities/BEType.h"
 #include "Utilities/File.h"
+
+#include "util/v128.hpp"
 
 constexpr u32 SDAT_FLAG = 0x01000000;
 constexpr u32 EDAT_COMPRESSED_FLAG = 0x00000001;

--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
 #include <sstream>
 #include <iomanip>
 
@@ -96,7 +95,7 @@ struct PKGExtHeader
 	be_t<u32> ext_hdr_size;                     // Extended header size. ex: 0x40
 	be_t<u32> ext_data_size;                    // ex: 0x180
 	be_t<u32> main_and_ext_headers_hmac_offset; // ex: 0x100
-	be_t<u32> metadata_header_hmac_offset;      // ex: 0x360, 0x390, 0x490 
+	be_t<u32> metadata_header_hmac_offset;      // ex: 0x360, 0x390, 0x490
 	be_t<u64> tail_offset;                      // tail size seams to be always 0x1A0
 	be_t<u32> padding1;
 	be_t<u32> pkg_key_id;                       // Id of the AES key used for decryption. PSP = 0x1, PSVita = 0xC0000002, PSM = 0xC0000004

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -3,12 +3,13 @@
 #include "sha1.h"
 #include "utils.h"
 #include "unself.h"
-#include "Utilities/BEType.h"
 #include "Emu/VFS.h"
 #include "Emu/System.h"
 
 #include <algorithm>
 #include <zlib.h>
+
+#include "util/v128.hpp"
 
 inline u8 Read8(const fs::file& f)
 {

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -26,7 +26,6 @@
 
 #include "util/types.hpp"
 #include "Utilities/StrFmt.h"
-#include "Utilities/BEType.h"
 #include "Utilities/BitField.h"
 #include "util/logs.hpp"
 #include "Utilities/JIT.h"
@@ -37,6 +36,8 @@
 #include <set>
 #include <array>
 #include <vector>
+
+#include "util/v128.hpp"
 
 enum class i2 : char
 {

--- a/rpcs3/Emu/Cell/Modules/cellAudio.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.h
@@ -174,7 +174,7 @@ struct audio_port
 		return addr.addr() + position(offset) * buf_size();
 	}
 
-	to_be_t<float>* get_vm_ptr(s32 offset = 0) const
+	be_t<f32>* get_vm_ptr(s32 offset = 0) const
 	{
 		return vm::_ptr<f32>(buf_addr(offset));
 	}

--- a/rpcs3/Emu/Cell/Modules/cellAudioIn.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudioIn.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "Utilities/BEType.h"
+#include "util/types.hpp"
+#include "util/endian.hpp"
 
 // Error codes
 enum CellAudioInError

--- a/rpcs3/Emu/Cell/Modules/cellGem.h
+++ b/rpcs3/Emu/Cell/Modules/cellGem.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
-
 static const float CELL_GEM_SPHERE_RADIUS_MM = 22.5f;
 
 // Error codes

--- a/rpcs3/Emu/Cell/Modules/cellJpgDec.h
+++ b/rpcs3/Emu/Cell/Modules/cellJpgDec.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
-
 //Return Codes
 enum CellJpgDecError : u32
 {

--- a/rpcs3/Emu/Cell/Modules/cellKb.h
+++ b/rpcs3/Emu/Cell/Modules/cellKb.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
 #include "Emu/Io/Keyboard.h"
 
 enum CellKbError : u32

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
 #include "Utilities/Thread.h"
 
 #include "3rdparty/OpenAL/include/alext.h"

--- a/rpcs3/Emu/Cell/Modules/cellMouse.h
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
-
 enum CellMouseError : u32
 {
 	CELL_MOUSE_ERROR_FATAL                      = 0x80121201,

--- a/rpcs3/Emu/Cell/Modules/cellPad.h
+++ b/rpcs3/Emu/Cell/Modules/cellPad.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
 #include <array>
 
 enum CellPadError : u32

--- a/rpcs3/Emu/Cell/Modules/cellResc.h
+++ b/rpcs3/Emu/Cell/Modules/cellResc.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
-
 enum CellRescError : u32
 {
 	CELL_RESC_ERROR_NOT_INITIALIZED   = 0x80210301,

--- a/rpcs3/Emu/Cell/Modules/cellRtc.h
+++ b/rpcs3/Emu/Cell/Modules/cellRtc.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.h
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.h
@@ -3,6 +3,8 @@
 #include "stdafx.h"
 #include <Emu/Memory/vm_ptr.h>
 
+#include "util/v128.hpp"
+
 // Return codes
 enum CellSaveDataError : u32
 {

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -15,6 +15,8 @@
 #include "sysPrxForUser.h"
 #include "cellSpurs.h"
 
+#include "util/v128.hpp"
+
 LOG_CHANNEL(cellSpurs);
 
 template <>

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.h
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.h
@@ -2,7 +2,7 @@
 
 #include "cellSync.h"
 
-
+#include "util/v128.hpp"
 
 struct CellSpurs;
 struct CellSpursTaskset;

--- a/rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpursSpu.cpp
@@ -13,6 +13,8 @@
 #include <thread>
 #include <mutex>
 
+#include "util/v128.hpp"
+
 LOG_CHANNEL(cellSpurs);
 
 //----------------------------------------------------------------------------

--- a/rpcs3/Emu/Cell/Modules/cellSubDisplay.h
+++ b/rpcs3/Emu/Cell/Modules/cellSubDisplay.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
-
 // Return Codes
 enum CellSubDisplayError : u32
 {

--- a/rpcs3/Emu/Cell/Modules/cellVdec.h
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
-
 // Error Codes
 enum CellVdecError : u32
 {

--- a/rpcs3/Emu/Cell/Modules/cellVpost.h
+++ b/rpcs3/Emu/Cell/Modules/cellVpost.h
@@ -18,8 +18,6 @@ extern "C"
 #pragma GCC diagnostic pop
 #endif
 
-#include "Utilities/BEType.h"
-
 // Error Codes
 enum CellVpostError : u32
 {

--- a/rpcs3/Emu/Cell/Modules/libsynth2.h
+++ b/rpcs3/Emu/Cell/Modules/libsynth2.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
-
 // Error Codes
 enum CellSoundSynth2Error : u32
 {

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -15,6 +15,8 @@
 #include "Emu/NP/np_handler.h"
 #include "Emu/NP/np_contexts.h"
 
+#include "util/v128.hpp"
+
 LOG_CHANNEL(sceNp);
 
 template <>

--- a/rpcs3/Emu/Cell/Modules/sceNp.h
+++ b/rpcs3/Emu/Cell/Modules/sceNp.h
@@ -3,8 +3,6 @@
 #include "cellRtc.h"
 #include "Emu/Cell/ErrorCodes.h"
 
-#include "Utilities/BEType.h"
-
 error_code sceNpInit(u32 poolsize, vm::ptr<void> poolptr);
 error_code sceNpTerm();
 

--- a/rpcs3/Emu/Cell/Modules/sceNpClans.h
+++ b/rpcs3/Emu/Cell/Modules/sceNpClans.h
@@ -2,8 +2,6 @@
 
 #include "sceNp.h"
 
-#include "Utilities/BEType.h"
-
 // Return codes
 enum SceNpClansError : u32
 {

--- a/rpcs3/Emu/Cell/Modules/sceNpCommerce2.h
+++ b/rpcs3/Emu/Cell/Modules/sceNpCommerce2.h
@@ -2,8 +2,6 @@
 
 #include "cellRtc.h"
 
-#include "Utilities/BEType.h"
-
 // Return codes
 enum SceNpCommerce2Error
 {

--- a/rpcs3/Emu/Cell/Modules/sceNpTus.h
+++ b/rpcs3/Emu/Cell/Modules/sceNpTus.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Utilities/BEType.h"
-
 #include "cellRtc.h"
 #include "sceNp.h"
 

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -3,9 +3,10 @@
 #include <string>
 #include <map>
 #include <set>
+#include "util/types.hpp"
+#include "util/endian.hpp"
 
 #include "Utilities/bit_set.h"
-#include "Utilities/BEType.h"
 #include "PPUOpcodes.h"
 
 // PPU Function Attributes

--- a/rpcs3/Emu/Cell/PPUCallback.h
+++ b/rpcs3/Emu/Cell/PPUCallback.h
@@ -2,6 +2,8 @@
 
 #include "Emu/Cell/PPUThread.h"
 
+#include "util/v128.hpp"
+
 struct ppu_func_opd_t;
 
 namespace ppu_cb_detail

--- a/rpcs3/Emu/Cell/PPUFunction.h
+++ b/rpcs3/Emu/Cell/PPUFunction.h
@@ -2,6 +2,8 @@
 
 #include "PPUThread.h"
 
+#include "util/v128.hpp"
+
 using ppu_function_t = bool(*)(ppu_thread&);
 
 // BIND_FUNC macro "converts" any appropriate HLE function to ppu_function_t, binding it to PPU thread context.

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 
 #include "util/asm.hpp"
+#include "util/v128.hpp"
 
 #if !defined(_MSC_VER) && defined(__clang__)
 #pragma GCC diagnostic push

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -66,6 +66,7 @@
 #include <cctype>
 #include "util/asm.hpp"
 #include "util/vm.hpp"
+#include "util/v128.hpp"
 
 const bool s_use_ssse3 = utils::has_ssse3();
 
@@ -1240,8 +1241,8 @@ static T ppu_load_acquire_reservation(ppu_thread& ppu, u32 addr)
 			const auto inst = vm::_ptr<const nse_t<u32>>(cia);
 
 			// Search for STWCX or STDCX nearby (LDARX-STWCX and LWARX-STDCX loops will use accurate 128-byte reservations)
-			constexpr u32 store_cond = se_storage<u32>::swap(sizeof(T) == 8 ? 0x7C00012D : 0x7C0001AD);
-			constexpr u32 mask = se_storage<u32>::swap(0xFC0007FF);
+			constexpr u32 store_cond = stx::se_storage<u32>::swap(sizeof(T) == 8 ? 0x7C00012D : 0x7C0001AD);
+			constexpr u32 mask = stx::se_storage<u32>::swap(0xFC0007FF);
 
 			const auto store_vec = v128::from32p(store_cond);
 			const auto mask_vec = v128::from32p(mask);

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -4,6 +4,8 @@
 #include "../Memory/vm_ptr.h"
 #include "Utilities/lockless.h"
 
+#include "util/v128.hpp"
+
 LOG_CHANNEL(ppu_log, "PPU");
 
 enum class ppu_cmd : u32

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -5,7 +5,10 @@
 #include "PPUThread.h"
 #include "PPUInterpreter.h"
 
+#include "util/types.hpp"
+#include "util/endian.hpp"
 #include "util/logs.hpp"
+#include "util/v128.hpp"
 #include <algorithm>
 
 using namespace llvm;

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -6,6 +6,8 @@
 #include "PPUOpcodes.h"
 #include "PPUAnalyser.h"
 
+#include "util/types.hpp"
+
 class PPUTranslator final : public cpu_translator
 {
 	// PPU Module

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -12,6 +12,7 @@
 #include "Crypto/sha1.h"
 
 #include "util/asm.hpp"
+#include "util/v128.hpp"
 
 #include <cmath>
 #include <mutex>

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.h
@@ -5,6 +5,8 @@
 
 #include <functional>
 
+#include "util/v128.hpp"
+
 // SPU ASMJIT Recompiler
 class spu_recompiler : public spu_recompiler_base
 {

--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -7,6 +7,8 @@ const spu_decoder<SPUDisAsm> s_spu_disasm;
 const spu_decoder<spu_itype> s_spu_itype;
 const spu_decoder<spu_iflag> s_spu_iflag;
 
+#include "util/v128.hpp"
+
 u32 SPUDisAsm::disasm(u32 pc)
 {
 	const u32 op = *reinterpret_cast<const be_t<u32>*>(offset + pc);

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -3,6 +3,8 @@
 #include "PPCDisAsm.h"
 #include "SPUOpcodes.h"
 
+#include "util/v128.hpp"
+
 static constexpr const char* spu_reg_name[128] =
 {
 	"lr", "sp", "r2", "r3", "r4", "r5", "r6", "r7",

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -7,6 +7,7 @@
 #include "Emu/Cell/Common.h"
 
 #include "util/asm.hpp"
+#include "util/v128.hpp"
 
 #include <cmath>
 #include <cfenv>

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -18,6 +18,8 @@
 #include <mutex>
 #include <thread>
 
+#include "util/v128.hpp"
+
 extern atomic_t<const char*> g_progr;
 extern atomic_t<u32> g_progr_ptotal;
 extern atomic_t<u32> g_progr_pdone;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -31,6 +31,7 @@
 #include <shared_mutex>
 #include "util/vm.hpp"
 #include "util/asm.hpp"
+#include "util/v128.hpp"
 
 using spu_rdata_t = decltype(spu_thread::rdata);
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -4,9 +4,10 @@
 #include "Emu/Cell/SPUInterpreter.h"
 #include "Emu/Memory/vm.h"
 #include "MFC.h"
-#include "Utilities/BEType.h"
 
 #include <map>
+#include "util/v128.hpp"
+#include "util/to_endian.hpp"
 
 LOG_CHANNEL(spu_log, "SPU");
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -78,7 +78,7 @@ namespace vm
 	atomic_t<u64, 64> g_range_lock_set[64]{};
 
 	// Memory pages
-	std::array<memory_page, 0x100000000 / 4096> g_pages{};
+	std::array<memory_page, 0x100000000 / 4096> g_pages;
 
 	std::pair<bool, u64> try_reservation_update(u32 addr)
 	{
@@ -1635,6 +1635,8 @@ namespace vm
 			g_exec_addr, g_exec_addr + 0x200000000 - 1,
 			g_stat_addr, g_stat_addr + UINT32_MAX,
 			g_reservations, g_reservations + sizeof(g_reservations) - 1);
+
+			std::memset(&g_pages, 0, sizeof(g_pages));
 
 			g_locations =
 			{

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -4,7 +4,8 @@
 #include <memory>
 #include "util/types.hpp"
 #include "Utilities/StrFmt.h"
-#include "Utilities/BEType.h"
+
+#include "util/to_endian.hpp"
 
 namespace utils
 {

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "util/types.hpp"
-#include "Utilities/BEType.h"
+#include "util/to_endian.hpp"
 #include "vm.h"
 
 class ppu_thread;

--- a/rpcs3/Emu/Memory/vm_ref.h
+++ b/rpcs3/Emu/Memory/vm_ref.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <type_traits>
-#include "Utilities/BEType.h"
 #include "vm.h"
+
+#include "util/to_endian.hpp"
 
 namespace vm
 {

--- a/rpcs3/Emu/Memory/vm_var.h
+++ b/rpcs3/Emu/Memory/vm_var.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "vm_ptr.h"
-#include "Utilities/BEType.h"
+
+#include "util/to_endian.hpp"
 
 namespace vm
 {

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -7,7 +7,6 @@
 #include "rpcn_client.h"
 #include "np_structs_extra.h"
 #include "Utilities/StrUtil.h"
-#include "Utilities/BEType.h"
 #include "Utilities/Thread.h"
 #include "Emu/IdManager.h"
 #include "Emu/System.h"

--- a/rpcs3/Emu/NP/signaling_handler.h
+++ b/rpcs3/Emu/NP/signaling_handler.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "Utilities/BEType.h"
 #include "Emu/Memory/vm.h"
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/Modules/sceNp.h"

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -4,7 +4,8 @@
 #include "Utilities/sysinfo.h"
 #include "../RSXThread.h"
 
-#include <limits>
+#include "util/v128.hpp"
+#include "util/to_endian.hpp"
 
 #define DEBUG_VERTEX_STREAMING 0
 
@@ -667,7 +668,7 @@ void write_vertex_array_data_to_buffer(gsl::span<std::byte> raw_dst_span, gsl::s
 			u32 src_value;
 			memcpy(&src_value, src_ptr.subspan(attribute_src_stride * i).data(), sizeof(u32));
 
-			if (swap_endianness) src_value = se_storage<u32>::swap(src_value);
+			if (swap_endianness) src_value = stx::se_storage<u32>::swap(src_value);
 
 			const auto& decoded_vector                 = decode_cmp_vector(src_value);
 			dst_span[i * dst_stride / sizeof(u16)] = decoded_vector[0];

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -3,6 +3,7 @@
 #include "Emu/system_config.h"
 
 #include <stack>
+#include "util/v128.hpp"
 
 using namespace program_hash_util;
 

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -519,7 +519,8 @@
     <ClInclude Include="Emu\system_config.h" />
     <ClInclude Include="Emu\system_config_types.h" />
     <ClInclude Include="util\atomic.hpp" />
-    <ClInclude Include="..\Utilities\BEType.h" />
+    <ClInclude Include="util\v128.hpp" />
+    <ClInclude Include="util\to_endian.hpp" />
     <ClInclude Include="..\Utilities\bin_patch.h" />
     <ClInclude Include="..\Utilities\BitField.h" />
     <ClInclude Include="..\Utilities\bit_set.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1069,7 +1069,10 @@
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\Utilities\BEType.h">
+    <ClInclude Include="util\v128.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="util\to_endian.hpp">
       <Filter>Utilities</Filter>
     </ClInclude>
     <ClInclude Include="..\Utilities\StrFmt.h">

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -44,6 +44,8 @@ DYNAMIC_IMPORT("ntdll.dll", NtSetTimerResolution, NTSTATUS(ULONG DesiredResoluti
 #include <thread>
 #include <charconv>
 
+#include "util/v128.hpp"
+
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 static semaphore<> s_qt_init;

--- a/rpcs3/rpcs3qt/cheat_manager.cpp
+++ b/rpcs3/rpcs3qt/cheat_manager.cpp
@@ -18,6 +18,7 @@
 #include "Emu/Cell/PPUFunction.h"
 
 #include "util/yaml.hpp"
+#include "util/to_endian.hpp"
 #include "Utilities/StrUtil.h"
 #include "Utilities/bin_patch.h" // get_patches_path()
 

--- a/rpcs3/rpcs3qt/register_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/register_editor_dialog.cpp
@@ -14,6 +14,8 @@
 #include <QMessageBox>
 #include <charconv>
 
+#include "util/v128.hpp"
+
 constexpr auto qstr = QString::fromStdString;
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 inline std::string sstr(const QVariant& _in) { return sstr(_in.toString()); }

--- a/rpcs3/rpcs3qt/skylander_dialog.cpp
+++ b/rpcs3/rpcs3qt/skylander_dialog.cpp
@@ -3,7 +3,6 @@
 #include "Crypto/md5.h"
 #include "Crypto/aes.h"
 #include "skylander_dialog.h"
-#include "Utilities/BEType.h"
 #include "Emu/Io/Skylander.h"
 
 #include <QLabel>

--- a/rpcs3/stdafx.h
+++ b/rpcs3/stdafx.h
@@ -14,8 +14,8 @@
 #endif
 
 #include "util/types.hpp"
-#include "Utilities/BEType.h"
 #include "util/atomic.hpp"
+#include "util/endian.hpp"
 #include "Utilities/StrFmt.h"
 #include "Utilities/File.h"
 #include "util/logs.hpp"

--- a/rpcs3/util/to_endian.hpp
+++ b/rpcs3/util/to_endian.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "util/types.hpp"
+#include "util/endian.hpp"
+
+union v128;
+
+// Type converter: converts native endianness arithmetic/enum types to appropriate se_t<> type
+template <typename T, bool Se, typename = void>
+struct to_se
+{
+	template <typename T2, typename = void>
+	struct to_se_
+	{
+		using type = T2;
+	};
+
+	template <typename T2>
+	struct to_se_<T2, std::enable_if_t<std::is_arithmetic<T2>::value || std::is_enum<T2>::value>>
+	{
+		using type = std::conditional_t<(sizeof(T2) > 1), se_t<T2, Se>, T2>;
+	};
+
+	// Convert arithmetic and enum types
+	using type = typename to_se_<T>::type;
+};
+
+template <bool Se>
+struct to_se<v128, Se>
+{
+	using type = se_t<v128, Se, 16>;
+};
+
+template <bool Se>
+struct to_se<u128, Se>
+{
+	using type = se_t<u128, Se>;
+};
+
+template <bool Se>
+struct to_se<s128, Se>
+{
+	using type = se_t<s128, Se>;
+};
+
+template <typename T, bool Se>
+struct to_se<const T, Se, std::enable_if_t<!std::is_array<T>::value>>
+{
+	// Move const qualifier
+	using type = const typename to_se<T, Se>::type;
+};
+
+template <typename T, bool Se>
+struct to_se<volatile T, Se, std::enable_if_t<!std::is_array<T>::value && !std::is_const<T>::value>>
+{
+	// Move volatile qualifier
+	using type = volatile typename to_se<T, Se>::type;
+};
+
+template <typename T, bool Se>
+struct to_se<T[], Se>
+{
+	// Move array qualifier
+	using type = typename to_se<T, Se>::type[];
+};
+
+template <typename T, bool Se, std::size_t N>
+struct to_se<T[N], Se>
+{
+	// Move array qualifier
+	using type = typename to_se<T, Se>::type[N];
+};
+
+// BE/LE aliases for to_se<>
+template <typename T>
+using to_be_t = typename to_se<T, std::endian::little == std::endian::native>::type;
+template <typename T>
+using to_le_t = typename to_se<T, std::endian::big == std::endian::native>::type;

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -213,6 +213,28 @@ namespace fmt
 template <typename T, std::size_t Align>
 class atomic_t;
 
+namespace stx
+{
+	template <typename T, bool Se, std::size_t Align>
+	class se_t;
+}
+
+using stx::se_t;
+
+// se_t<> with native endianness
+template <typename T, std::size_t Align = alignof(T)>
+using nse_t = se_t<T, false, Align>;
+
+template <typename T, std::size_t Align = alignof(T)>
+using be_t = se_t<T, std::endian::little == std::endian::native, Align>;
+template <typename T, std::size_t Align = alignof(T)>
+using le_t = se_t<T, std::endian::big == std::endian::native, Align>;
+
+template <typename T, std::size_t Align = alignof(T)>
+using atomic_be_t = atomic_t<be_t<T>, Align>;
+template <typename T, std::size_t Align = alignof(T)>
+using atomic_le_t = atomic_t<le_t<T>, Align>;
+
 // Extract T::simple_type if available, remove cv qualifiers
 template <typename T, typename = void>
 struct simple_type_helper

--- a/rpcs3/util/v128.hpp
+++ b/rpcs3/util/v128.hpp
@@ -1,17 +1,9 @@
 #pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include "util/types.hpp"
-#include "util/endian.hpp"
-#include <cstring>
 #include <cmath>
 
-#if __has_include(<bit>)
-#include <bit>
-#else
-#include <type_traits>
-#endif
-
-// 128-bit vector type and also se_storage<> storage type
+// 128-bit vector type
 union alignas(16) v128
 {
 	uchar _bytes[16];
@@ -405,107 +397,3 @@ inline v128 operator~(const v128& other)
 {
 	return other ^ v128::from32p(UINT32_MAX); // XOR with ones
 }
-
-using stx::se_t;
-using stx::se_storage;
-
-// se_t<> with native endianness
-template <typename T, std::size_t Align = alignof(T)>
-using nse_t = se_t<T, false, Align>;
-
-template <typename T, std::size_t Align = alignof(T)>
-using be_t = se_t<T, std::endian::little == std::endian::native, Align>;
-template <typename T, std::size_t Align = alignof(T)>
-using le_t = se_t<T, std::endian::big == std::endian::native, Align>;
-
-// Type converter: converts native endianness arithmetic/enum types to appropriate se_t<> type
-template <typename T, bool Se, typename = void>
-struct to_se
-{
-	template <typename T2, typename = void>
-	struct to_se_
-	{
-		using type = T2;
-	};
-
-	template <typename T2>
-	struct to_se_<T2, std::enable_if_t<std::is_arithmetic<T2>::value || std::is_enum<T2>::value>>
-	{
-		using type = std::conditional_t<(sizeof(T2) > 1), se_t<T2, Se>, T2>;
-	};
-
-	// Convert arithmetic and enum types
-	using type = typename to_se_<T>::type;
-};
-
-template <bool Se>
-struct to_se<v128, Se>
-{
-	using type = se_t<v128, Se>;
-};
-
-template <bool Se>
-struct to_se<u128, Se>
-{
-	using type = se_t<u128, Se>;
-};
-
-template <bool Se>
-struct to_se<s128, Se>
-{
-	using type = se_t<s128, Se>;
-};
-
-template <typename T, bool Se>
-struct to_se<const T, Se, std::enable_if_t<!std::is_array<T>::value>>
-{
-	// Move const qualifier
-	using type = const typename to_se<T, Se>::type;
-};
-
-template <typename T, bool Se>
-struct to_se<volatile T, Se, std::enable_if_t<!std::is_array<T>::value && !std::is_const<T>::value>>
-{
-	// Move volatile qualifier
-	using type = volatile typename to_se<T, Se>::type;
-};
-
-template <typename T, bool Se>
-struct to_se<T[], Se>
-{
-	// Move array qualifier
-	using type = typename to_se<T, Se>::type[];
-};
-
-template <typename T, bool Se, std::size_t N>
-struct to_se<T[N], Se>
-{
-	// Move array qualifier
-	using type = typename to_se<T, Se>::type[N];
-};
-
-// BE/LE aliases for to_se<>
-template <typename T>
-using to_be_t = typename to_se<T, std::endian::little == std::endian::native>::type;
-template <typename T>
-using to_le_t = typename to_se<T, std::endian::big == std::endian::native>::type;
-
-// BE/LE aliases for atomic_t
-template <typename T, std::size_t Align = alignof(T)>
-using atomic_be_t = atomic_t<be_t<T>, Align>;
-template <typename T, std::size_t Align = alignof(T)>
-using atomic_le_t = atomic_t<le_t<T>, Align>;
-
-template <typename T, bool Se, std::size_t Align>
-struct fmt_unveil<se_t<T, Se, Align>, void>
-{
-	using type = typename fmt_unveil<T>::type;
-
-	static inline auto get(const se_t<T, Se, Align>& arg)
-	{
-		return fmt_unveil<T>::get(arg);
-	}
-};
-
-static_assert(be_t<u16>(1) + be_t<u32>(2) + be_t<u64>(3) == 6);
-static_assert(le_t<u16>(1) + le_t<u32>(2) + le_t<u64>(3) == 6);


### PR DESCRIPTION
It's necessary to exploit the fact that the absolutely majority of actual inheritance is linear, in a sense, that a casting between base and derived class is a no-op with the same numeric pointer value.

It's exploited by custom shared_ptr<> implementation which always contains its control block at the negative offset, and has only one pointer inside (unlike STL shared_pointer which is double sized).