### PR TITLE
rsx: Minor restructuring

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "texture_cache_utils.h"
 #include "texture_cache_predictor.h"
 #include "texture_cache_helpers.h"
 

--- a/rpcs3/Emu/RSX/Common/texture_cache_types.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_types.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include "Emu/system_config.h"
+
+namespace rsx
+{
+	/**
+	 * Helper enums/structs
+	 */
+	enum invalidation_chain_policy
+	{
+		invalidation_chain_none,         // No chaining: Only sections that overlap the faulting page get invalidated.
+		invalidation_chain_full,         // Full chaining: Sections overlapping the faulting page get invalidated, as well as any sections overlapping invalidated sections.
+		invalidation_chain_nearby        // Invalidations chain if they are near to the fault (<X pages away)
+	};
+
+	enum invalidation_chain_direction
+	{
+		chain_direction_both,
+		chain_direction_forward,  // Only higher-base-address sections chain (unless they overlap the fault)
+		chain_direction_backward, // Only lower-base-address pages chain (unless they overlap the fault)
+	};
+
+	enum texture_create_flags
+	{
+		default_component_order = 0,
+		native_component_order = 1,
+		swapped_native_component_order = 2,
+	};
+
+	enum memory_read_flags
+	{
+		flush_always = 0,
+		flush_once = 1
+	};
+
+	struct invalidation_cause
+	{
+		enum enum_type
+		{
+			invalid = 0,
+			read,
+			deferred_read,
+			write,
+			deferred_write,
+			unmap, // fault range is being unmapped
+			reprotect, // we are going to reprotect the fault range
+			superseded_by_fbo, // used by texture_cache::locked_memory_region
+			committed_as_fbo   // same as superseded_by_fbo but without locking or preserving page flags
+		} cause;
+
+		constexpr bool valid() const
+		{
+			return cause != invalid;
+		}
+
+		constexpr bool is_read() const
+		{
+			AUDIT(valid());
+			return (cause == read || cause == deferred_read);
+		}
+
+		constexpr bool deferred_flush() const
+		{
+			AUDIT(valid());
+			return (cause == deferred_read || cause == deferred_write);
+		}
+
+		constexpr bool destroy_fault_range() const
+		{
+			AUDIT(valid());
+			return (cause == unmap);
+		}
+
+		constexpr bool keep_fault_range_protection() const
+		{
+			AUDIT(valid());
+			return (cause == unmap || cause == reprotect || cause == superseded_by_fbo);
+		}
+
+		constexpr bool skip_fbos() const
+		{
+			AUDIT(valid());
+			return (cause == superseded_by_fbo || cause == committed_as_fbo);
+		}
+
+		constexpr bool skip_flush() const
+		{
+			AUDIT(valid());
+			return (cause == unmap) || (!g_cfg.video.strict_texture_flushing && cause == superseded_by_fbo);
+		}
+
+		constexpr invalidation_cause undefer() const
+		{
+			AUDIT(deferred_flush());
+			if (cause == deferred_read)
+				return read;
+			else if (cause == deferred_write)
+				return write;
+			else
+				fmt::throw_exception("Unreachable");
+		}
+
+		constexpr invalidation_cause defer() const
+		{
+			AUDIT(!deferred_flush());
+			if (cause == read)
+				return deferred_read;
+			else if (cause == write)
+				return deferred_write;
+			else
+				fmt::throw_exception("Unreachable");
+		}
+
+		constexpr invalidation_cause() : cause(invalid) {}
+		constexpr invalidation_cause(enum_type _cause) : cause(_cause) {}
+		operator enum_type&() { return cause; }
+		constexpr operator enum_type() const { return cause; }
+	};
+}

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../rsx_cache.h"
+#include "texture_cache_types.h"
 #include "texture_cache_predictor.h"
 #include "TextureUtils.h"
 
@@ -9,122 +10,6 @@
 
 namespace rsx
 {
-	/**
-	 * Helper enums/structs
-	 */
-	enum invalidation_chain_policy
-	{
-		invalidation_chain_none,         // No chaining: Only sections that overlap the faulting page get invalidated.
-		invalidation_chain_full,         // Full chaining: Sections overlapping the faulting page get invalidated, as well as any sections overlapping invalidated sections.
-		invalidation_chain_nearby        // Invalidations chain if they are near to the fault (<X pages away)
-	};
-
-	enum invalidation_chain_direction
-	{
-		chain_direction_both,
-		chain_direction_forward,  // Only higher-base-address sections chain (unless they overlap the fault)
-		chain_direction_backward, // Only lower-base-address pages chain (unless they overlap the fault)
-	};
-
-	enum texture_create_flags
-	{
-		default_component_order = 0,
-		native_component_order = 1,
-		swapped_native_component_order = 2,
-	};
-
-	enum memory_read_flags
-	{
-		flush_always = 0,
-		flush_once = 1
-	};
-
-	struct invalidation_cause
-	{
-		enum enum_type
-		{
-			invalid = 0,
-			read,
-			deferred_read,
-			write,
-			deferred_write,
-			unmap, // fault range is being unmapped
-			reprotect, // we are going to reprotect the fault range
-			superseded_by_fbo, // used by texture_cache::locked_memory_region
-			committed_as_fbo   // same as superseded_by_fbo but without locking or preserving page flags
-		} cause;
-
-		constexpr bool valid() const
-		{
-			return cause != invalid;
-		}
-
-		constexpr bool is_read() const
-		{
-			AUDIT(valid());
-			return (cause == read || cause == deferred_read);
-		}
-
-		constexpr bool deferred_flush() const
-		{
-			AUDIT(valid());
-			return (cause == deferred_read || cause == deferred_write);
-		}
-
-		constexpr bool destroy_fault_range() const
-		{
-			AUDIT(valid());
-			return (cause == unmap);
-		}
-
-		constexpr bool keep_fault_range_protection() const
-		{
-			AUDIT(valid());
-			return (cause == unmap || cause == reprotect || cause == superseded_by_fbo);
-		}
-
-		constexpr bool skip_fbos() const
-		{
-			AUDIT(valid());
-			return (cause == superseded_by_fbo || cause == committed_as_fbo);
-		}
-
-		constexpr bool skip_flush() const
-		{
-			AUDIT(valid());
-			return (cause == unmap) || (!g_cfg.video.strict_texture_flushing && cause == superseded_by_fbo);
-		}
-
-		constexpr invalidation_cause undefer() const
-		{
-			AUDIT(deferred_flush());
-			if (cause == deferred_read)
-				return read;
-			else if (cause == deferred_write)
-				return write;
-			else
-				fmt::throw_exception("Unreachable");
-		}
-
-		constexpr invalidation_cause defer() const
-		{
-			AUDIT(!deferred_flush());
-			if (cause == read)
-				return deferred_read;
-			else if (cause == write)
-				return deferred_write;
-			else
-				fmt::throw_exception("Unreachable");
-		}
-
-		constexpr invalidation_cause() : cause(invalid) {}
-		constexpr invalidation_cause(enum_type _cause) : cause(_cause) {}
-		operator enum_type&() { return cause; }
-		constexpr operator enum_type() const { return cause; }
-	};
-
-
-
 	/**
 	 * List structure used in Ranged Storage Blocks
 	 * List of Arrays

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -612,10 +612,10 @@ void GLGSRender::end()
 		return;
 	}
 
+	analyse_current_rsx_pipeline();
 	m_frame_stats.setup_time += m_profiler.duration();
 
 	// Active texture environment is used to decode shaders
-	m_profiler.start();
 	load_texture_env();
 	m_frame_stats.textures_upload_time += m_profiler.duration();
 

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "GLGSRender.h"
+#include "../rsx_methods.h"
 #include "../Common/BufferUtils.h"
 
 namespace gl

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -5,6 +5,7 @@
 #include "GLCompute.h"
 #include "GLVertexProgram.h"
 #include "Emu/Memory/vm_locking.h"
+#include "Emu/RSX/rsx_methods.h"
 
 #define DUMP_VERTEX_DATA 0
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "GLGSRender.h"
+#include "Emu/RSX/rsx_methods.h"
 
 color_format rsx::internals::surface_color_format_to_gl(rsx::surface_color_format color_format)
 {

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
@@ -3,6 +3,7 @@
 #include "GLGSRender.h"
 #include "GLVertexProgram.h"
 #include "GLFragmentProgram.h"
+#include "../rsx_methods.h"
 #include "../Common/ShaderInterpreter.h"
 #include "../Common/GLSLCommon.h"
 

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
-#include "GLGSRender.h"
 #include "../Common/BufferUtils.h"
+#include "../rsx_methods.h"
+#include "GLGSRender.h"
 #include "GLHelpers.h"
 
 namespace

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -360,16 +360,6 @@ namespace rsx
 			}
 		}
 
-		if (m_graphics_state & rsx::pipeline_state::fragment_program_ucode_dirty)
-		{
-			// Request for update of fragment constants if the program block is invalidated
-			m_graphics_state |= rsx::pipeline_state::fragment_constants_dirty;
-		}
-
-		// Preload the GPU programs for this draw call if needed
-		prefetch_vertex_program();
-		prefetch_fragment_program();
-
 		in_begin_end = true;
 	}
 
@@ -1573,6 +1563,18 @@ namespace rsx
 				}
 			}
 		}
+	}
+
+	void thread::analyse_current_rsx_pipeline()
+	{
+		if (m_graphics_state & rsx::pipeline_state::fragment_program_ucode_dirty)
+		{
+			// Request for update of fragment constants if the program block is invalidated
+			m_graphics_state |= rsx::pipeline_state::fragment_constants_dirty;
+		}
+
+		prefetch_vertex_program();
+		prefetch_fragment_program();
 	}
 
 	void thread::get_current_vertex_program(const std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, rsx::limits::vertex_textures_count>& sampler_descriptors)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -17,6 +17,7 @@
 #include "Utilities/StrUtil.h"
 
 #include <cereal/archives/binary.hpp>
+#include <cereal/types/unordered_map.hpp>
 
 #include "util/asm.hpp"
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -12,9 +12,8 @@
 #include "RSXOffload.h"
 #include "RSXVertexProgram.h"
 #include "RSXFragmentProgram.h"
-#include "rsx_methods.h"
 #include "rsx_utils.h"
-#include "Common/texture_cache_utils.h"
+#include "Common/texture_cache_types.h"
 
 #include "Utilities/Thread.h"
 #include "Utilities/geometry.h"

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -773,6 +773,9 @@ namespace rsx
 		RSXVertexProgram current_vertex_program = {};
 		RSXFragmentProgram current_fragment_program = {};
 
+		// Runs shader prefetch and resolves pipeline status flags
+		void analyse_current_rsx_pipeline();
+
 		// Prefetch and analyze the currently active fragment program ucode
 		void prefetch_fragment_program();
 
@@ -783,8 +786,6 @@ namespace rsx
 
 		/**
 		 * Gets current fragment program and associated fragment state
-		 * get_surface_info is a helper takes 2 parameters: rsx_texture_address and surface_is_depth
-		 * returns whether surface is a render target and surface pitch in native format
 		 */
 		void get_current_fragment_program(const std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, rsx::limits::fragment_textures_count>& sampler_descriptors);
 

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
-#include "VKGSRender.h"
 #include "../Common/BufferUtils.h"
+#include "../rsx_methods.h"
+#include "VKGSRender.h"
 
 namespace vk
 {

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -894,6 +894,8 @@ void VKGSRender::end()
 		return;
 	}
 
+	m_profiler.start();
+
 	// Check for frame resource status here because it is possible for an async flip to happen between begin/end
 	if (m_current_frame->flags & frame_context_state::dirty) [[unlikely]]
 	{
@@ -916,7 +918,8 @@ void VKGSRender::end()
 		m_current_frame->flags &= ~frame_context_state::dirty;
 	}
 
-	m_profiler.start();
+	analyse_current_rsx_pipeline();
+	m_frame_stats.setup_time += m_profiler.duration();
 
 	load_texture_env();
 	m_frame_stats.textures_upload_time += m_profiler.duration();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -6,6 +6,7 @@
 #include "VKRenderPass.h"
 #include "VKResourceManager.h"
 #include "VKCommandStream.h"
+#include "Emu/RSX/rsx_methods.h"
 #include "Emu/Memory/vm_locking.h"
 
 namespace vk

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -10,6 +10,7 @@
 #include "VKCommandStream.h"
 #include "VKRenderPass.h"
 
+#include "Emu/RSX/rsx_methods.h"
 #include "Utilities/mutex.h"
 #include "Utilities/lockless.h"
 

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -3,8 +3,10 @@
 #include "VKVertexProgram.h"
 #include "VKFragmentProgram.h"
 #include "VKGSRender.h"
+
 #include "../Common/GLSLCommon.h"
 #include "../Common/ShaderInterpreter.h"
+#include "../rsx_methods.h"
 
 namespace vk
 {

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "VKGSRender.h"
-#include "../rsx_methods.h"
 #include "../Common/BufferUtils.h"
+#include "../rsx_methods.h"
 
 namespace vk
 {

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -13,9 +13,6 @@
 #include "rsx_utils.h"
 #include "Utilities/geometry.h"
 
-#include <cereal/types/array.hpp>
-#include <cereal/types/unordered_map.hpp>
-
 extern u64 get_system_time();
 extern bool is_primitive_disjointed(rsx::primitive_type);
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -36,6 +36,7 @@
 #include "util/logs.hpp"
 
 #include "cereal/archives/binary.hpp"
+#include <cereal/types/unordered_map.hpp>
 
 #include <thread>
 #include <typeinfo>


### PR DESCRIPTION
- Move shader prefetch+analysis code execution point to draw call end.
- Avoid including complex template headers if not needed.

Fixes https://github.com/RPCS3/rpcs3/issues/9393