### PR TITLE
PRX loader: Fix libfs_155.sprx loading

### DIFF
--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -593,6 +593,8 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 		// Grope for OPD section (TODO: optimization, better constraints)
 		for (const auto& seg : segs)
 		{
+			if (!seg.addr) continue;
+
 			for (vm::cptr<u32> ptr = vm::cast(seg.addr); ptr.addr() < seg.addr + seg.size; ptr++)
 			{
 				if (ptr[0] >= start && ptr[0] < end && ptr[0] % 4 == 0 && ptr[1] == toc)
@@ -616,6 +618,8 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 	// Find references indiscriminately
 	for (const auto& seg : segs)
 	{
+		if (!seg.addr) continue;
+
 		for (vm::cptr<u32> ptr = vm::cast(seg.addr); ptr.addr() < seg.addr + seg.size; ptr++)
 		{
 			const u32 value = *ptr;
@@ -627,6 +631,8 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 
 			for (const auto& _seg : segs)
 			{
+				if (!_seg.addr) continue;
+
 				if (value >= _seg.addr && value < _seg.addr + _seg.size)
 				{
 					addr_heap.emplace(value);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2324,9 +2324,10 @@ extern void ppu_initialize(const ppu_module& info)
 		globals.emplace_back(fmt::format("__cptr%x", suffix), reinterpret_cast<u64>(vm::g_exec_addr));
 
 		// Initialize segments for relocations
-		for (u32 i = 0; i < info.segs.size(); i++)
+		for (u32 i = 0, num = 0; i < info.segs.size(); i++)
 		{
-			globals.emplace_back(fmt::format("__seg%u_%x", i, suffix), info.segs[i].addr);
+			if (!info.segs[i].addr) continue;
+			globals.emplace_back(fmt::format("__seg%u_%x", num++, suffix), info.segs[i].addr);
 		}
 
 		link_workload.emplace_back(obj_name, false);
@@ -2490,6 +2491,7 @@ extern void ppu_initialize(const ppu_module& info)
 
 			for (const auto& seg : info.segs)
 			{
+				if (!seg.addr) continue;
 				*jit_mod.vars[index++] = seg.addr;
 			}
 		}

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -70,6 +70,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_mo
 	// Create segment variables
 	for (const auto& seg : m_info.segs)
 	{
+		if (!seg.addr) continue;
 		auto gv = new GlobalVariable(*_module, GetType<u64>(), true, GlobalValue::ExternalLinkage, 0, fmt::format("__seg%u_%x", m_segs.size(), gsuffix));
 		gv->setInitializer(ConstantInt::get(GetType<u64>(), seg.addr));
 		gv->setExternallyInitialized(true);

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -750,6 +750,7 @@ error_code _sys_prx_get_module_info(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<
 		u32 i = 0;
 		for (; i < prx->segs.size() && i < pOpt->info->segments_num; i++)
 		{
+			if (!prx->segs[i].addr) continue; // TODO: Check this
 			pOpt->info->segments[i].index = i;
 			pOpt->info->segments[i].base = prx->segs[i].addr;
 			pOpt->info->segments[i].filesz = prx->segs[i].filesz;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1150,11 +1150,6 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 						// Check .sprx filename
 						if (fmt::to_upper(entry.name).ends_with(".SPRX"))
 						{
-							if (entry.name == "libfs_155.sprx")
-							{
-								continue;
-							}
-
 							// Get full path
 							file_queue.emplace_back(dir_queue[i] + entry.name, 0);
 							g_progr_ftotal++;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1224,6 +1224,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 							{
 								lock.unlock();
 								ppu_initialize(*prx);
+								idm::remove<lv2_obj, lv2_prx>(idm::last_id());
 								lock.lock();
 								ppu_unload_prx(*prx);
 								g_progr_fdone++;


### PR DESCRIPTION
It used to crash on referencing "non-existing" segment index because we did not push all LOAD segments as it expects.
Remove its hack from firmware installation as well.

More stuff:
* Fix IDM IDs leak in firmware installation.
* Add some asserts for cases where relocation offset in segment is out of range, also works on "empty" LOAD segments.