### PR TITLE
rsx: Misc fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -69,6 +69,8 @@ namespace rsx
 		rsx::texture_dimension_extended image_type = texture_dimension_extended::texture_dimension_2d;
 		rsx::format_class format_class = RSX_FORMAT_CLASS_UNDEFINED;
 		bool is_cyclic_reference = false;
+		u32 ref_address = 0;
+		u64 surface_cache_tag = 0;
 		f32 scale_x = 1.f;
 		f32 scale_y = 1.f;
 

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -796,8 +796,6 @@ namespace rsx
 				{
 					invalidate(It->second);
 					m_render_targets_storage.erase(It);
-
-					cache_tag = rsx::get_shared_tag();
 					return;
 				}
 			}
@@ -808,8 +806,6 @@ namespace rsx
 				{
 					invalidate(It->second);
 					m_depth_stencil_storage.erase(It);
-
-					cache_tag = rsx::get_shared_tag();
 					return;
 				}
 			}
@@ -1031,11 +1027,6 @@ namespace rsx
 				// Skip any further updates as all active surfaces have been updated
 				m_skip_write_updates = true;
 			}
-		}
-
-		void notify_memory_structure_changed()
-		{
-			cache_tag = rsx::get_shared_tag();
 		}
 
 		void invalidate_all()

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -269,8 +269,8 @@ namespace rsx
 			 * Optionally returns a second variable that contains the surface reference.
 			 * The surface reference can be used to insert a texture barrier or inject a deferred resource
 			 */
-			template <typename surface_store_type>
-			std::pair<bool, typename surface_store_type::surface_type> is_expired(surface_store_type& surface_cache)
+			template <typename surface_store_type, typename surface_type = typename surface_store_type::surface_type>
+			std::pair<bool, surface_type> is_expired(surface_store_type& surface_cache)
 			{
 				if (upload_context != rsx::texture_upload_context::framebuffer_storage ||
 					surface_cache_tag == surface_cache.cache_tag)
@@ -282,13 +282,13 @@ namespace rsx
 				auto ref_image = image_handle ? image_handle->image() : external_subresource_desc.external_handle;
 				if (ref_image)
 				{
-					if (auto as_rtt = dynamic_cast<surface_store_type::surface_type>(ref_image);
-						as_rtt && as_rtt == surface_cache.get_surface_at(ref_address))
+					if (auto surface = dynamic_cast<surface_type>(ref_image);
+						surface && surface == surface_cache.get_surface_at(ref_address))
 					{
 						// Fast sync
 						surface_cache_tag = surface_cache.cache_tag;
 						is_cyclic_reference = surface_cache.address_is_bound(ref_address);
-						return { false, as_rtt };
+						return { false, surface };
 					}
 				}
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -276,15 +276,6 @@ void GLGSRender::on_init_thread()
 
 	m_vao.element_array_buffer = *m_index_ring_buffer;
 
-	if (g_cfg.video.overlay)
-	{
-		if (gl_caps.ARB_shader_draw_parameters_supported)
-		{
-			m_text_printer.init();
-			m_text_printer.set_enabled(true);
-		}
-	}
-
 	int image_unit = 0;
 	for (auto &sampler : m_fs_sampler_states)
 	{

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -132,7 +132,6 @@ private:
 	gl::vao m_vao;
 
 	shared_mutex m_sampler_mutex;
-	u64 surface_store_tag = 0;
 	atomic_t<bool> m_samplers_dirty = {true};
 	std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, rsx::limits::fragment_textures_count> fs_sampler_state = {};
 	std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, rsx::limits::vertex_textures_count> vs_sampler_state = {};

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -290,8 +290,14 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 		}
 	}
 
-	if (g_cfg.video.overlay)
+	if (g_cfg.video.overlay && gl::get_driver_caps().ARB_shader_draw_parameters_supported)
 	{
+		if (!m_text_printer.is_enabled())
+		{
+			m_text_printer.init();
+			m_text_printer.set_enabled(true);
+		}
+
 		// Disable depth test
 		gl_state.depth_func(GL_ALWAYS);
 

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -319,9 +319,13 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 		const auto num_misses = m_gl_texture_cache.get_num_cache_misses();
 		const auto num_unavoidable = m_gl_texture_cache.get_num_unavoidable_hard_faults();
 		const auto cache_miss_ratio = static_cast<u32>(ceil(m_gl_texture_cache.get_cache_miss_ratio() * 100));
+		const auto num_texture_upload = m_gl_texture_cache.get_texture_upload_calls_this_frame();
+		const auto num_texture_upload_miss = m_gl_texture_cache.get_texture_upload_misses_this_frame();
+		const auto texture_upload_miss_ratio = m_gl_texture_cache.get_texture_upload_miss_percentage();
 		m_text_printer.print_text(0, 126, m_frame->client_width(), m_frame->client_height(), fmt::format("Unreleased textures: %7d", num_dirty_textures));
 		m_text_printer.print_text(0, 144, m_frame->client_width(), m_frame->client_height(), fmt::format("Texture memory: %12dM", texture_memory_size));
 		m_text_printer.print_text(0, 162, m_frame->client_width(), m_frame->client_height(), fmt::format("Flush requests: %12d  = %2d (%3d%%) hard faults, %2d unavoidable, %2d misprediction(s), %2d speculation(s)", num_flushes, num_misses, cache_miss_ratio, num_unavoidable, num_mispredict, num_speculate));
+		m_text_printer.print_text(0, 180, m_frame->client_width(), m_frame->client_height(), fmt::format("Texture uploads: %15u (%u from CPU - %02u%%)", num_texture_upload, num_texture_upload_miss, texture_upload_miss_ratio));
 	}
 
 	m_frame->flip(m_context);

--- a/rpcs3/Emu/RSX/GL/GLTextOut.h
+++ b/rpcs3/Emu/RSX/GL/GLTextOut.h
@@ -118,6 +118,11 @@ namespace gl
 			enabled = state;
 		}
 
+		bool is_enabled()
+		{
+			return enabled;
+		}
+
 		void print_text(int x, int y, int target_w, int target_h, const std::string &text, color4f color = { 0.3f, 1.f, 0.3f, 1.f })
 		{
 			if (!enabled) return;

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -964,7 +964,7 @@ namespace gl
 			section.set_view_flags(flags);
 		}
 
-		void insert_texture_barrier(gl::command_context&, gl::texture*) override
+		void insert_texture_barrier(gl::command_context&, gl::texture*, bool) override
 		{
 			auto &caps = gl::get_driver_caps();
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -478,7 +478,6 @@ namespace rsx
 		on_init_thread();
 
 		method_registers.init();
-		m_profiler.enabled = !!g_cfg.video.overlay;
 
 		if (!zcull_ctrl)
 		{
@@ -2843,6 +2842,7 @@ namespace rsx
 
 		// Reset current stats
 		m_frame_stats = {};
+		m_profiler.enabled = !!g_cfg.video.overlay;
 	}
 
 	void thread::request_emu_flip(u32 buffer)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -477,13 +477,6 @@ VKGSRender::VKGSRender() : GSRender()
 	vk::initialize_compiler_context();
 	vk::initialize_pipe_compiler(g_cfg.video.shader_compiler_threads_count);
 
-	if (g_cfg.video.overlay)
-	{
-		auto key = vk::get_renderpass_key(m_swapchain->get_surface_format());
-		m_text_writer = std::make_unique<vk::text_writer>();
-		m_text_writer->init(*m_device, vk::get_renderpass(*m_device, key));
-	}
-
 	m_prog_buffer = std::make_unique<vk::program_cache>
 	(
 		[this](const vk::pipeline_props& props, const RSXVertexProgram& vp, const RSXFragmentProgram& fp)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1016,7 +1016,7 @@ void VKGSRender::on_init_thread()
 	if (!m_overlay_manager)
 	{
 		m_frame->hide();
-		m_shaders_cache->load(nullptr, *m_device, pipeline_layout);
+		m_shaders_cache->load(nullptr, pipeline_layout);
 		m_frame->show();
 	}
 	else
@@ -1024,7 +1024,7 @@ void VKGSRender::on_init_thread()
 		rsx::shader_loading_dialog_native dlg(this);
 
 		// TODO: Handle window resize messages during loading on GPUs without OUT_OF_DATE_KHR support
-		m_shaders_cache->load(&dlg, *m_device, pipeline_layout);
+		m_shaders_cache->load(&dlg, pipeline_layout);
 	}
 }
 
@@ -1634,7 +1634,7 @@ bool VKGSRender::load_program()
 		vertex_program.skip_vertex_input_check = true;
 		fragment_program.unnormalized_coords = 0;
 		m_program = m_prog_buffer->get_graphics_pipeline(vertex_program, fragment_program, properties,
-			shadermode != shader_mode::recompiler, true, *m_device, pipeline_layout);
+			shadermode != shader_mode::recompiler, true, pipeline_layout);
 
 		vk::leave_uninterruptible();
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -371,7 +371,6 @@ private:
 	u64 m_cond_render_sync_tag = 0;
 
 	shared_mutex m_sampler_mutex;
-	u64 surface_store_tag = 0;
 	atomic_t<bool> m_samplers_dirty = { true };
 	std::unique_ptr<vk::sampler> m_stencil_mirror_sampler;
 	std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, rsx::limits::fragment_textures_count> fs_sampler_state = {};

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -190,7 +190,7 @@ void VKGSRender::frame_context_cleanup(vk::frame_context_t *ctx, bool free_resou
 
 	if (free_resources)
 	{
-		if (g_cfg.video.overlay)
+		if (m_text_writer)
 		{
 			m_text_writer->reset_descriptors();
 		}
@@ -730,6 +730,13 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 
 		if (g_cfg.video.overlay)
 		{
+			if (!m_text_writer)
+			{
+				auto key = vk::get_renderpass_key(m_swapchain->get_surface_format());
+				m_text_writer = std::make_unique<vk::text_writer>();
+				m_text_writer->init(*m_device, vk::get_renderpass(*m_device, key));
+			}
+
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0,   0, direct_fbo->width(), direct_fbo->height(), fmt::format("RSX Load:                 %3d%%", get_load()));
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0,  18, direct_fbo->width(), direct_fbo->height(), fmt::format("draw calls: %17d", info.stats.draw_calls));
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0,  36, direct_fbo->width(), direct_fbo->height(), fmt::format("draw call setup: %12dus", info.stats.setup_time));

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -754,10 +754,14 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 			const auto num_misses = m_texture_cache.get_num_cache_misses();
 			const auto num_unavoidable = m_texture_cache.get_num_unavoidable_hard_faults();
 			const auto cache_miss_ratio = static_cast<u32>(ceil(m_texture_cache.get_cache_miss_ratio() * 100));
+			const auto num_texture_upload = m_texture_cache.get_texture_upload_calls_this_frame();
+			const auto num_texture_upload_miss = m_texture_cache.get_texture_upload_misses_this_frame();
+			const auto texture_upload_miss_ratio = m_texture_cache.get_texture_upload_miss_percentage();
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 144, direct_fbo->width(), direct_fbo->height(), fmt::format("Unreleased textures: %8d", num_dirty_textures));
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 162, direct_fbo->width(), direct_fbo->height(), fmt::format("Texture cache memory: %7dM", texture_memory_size));
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 180, direct_fbo->width(), direct_fbo->height(), fmt::format("Temporary texture memory: %3dM", tmp_texture_memory_size));
 			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 198, direct_fbo->width(), direct_fbo->height(), fmt::format("Flush requests: %13d  = %2d (%3d%%) hard faults, %2d unavoidable, %2d misprediction(s), %2d speculation(s)", num_flushes, num_misses, cache_miss_ratio, num_unavoidable, num_mispredict, num_speculate));
+			m_text_writer->print_text(*m_current_command_buffer, *direct_fbo, 0, 216, direct_fbo->width(), direct_fbo->height(), fmt::format("Texture uploads: %14u (%u from CPU - %02u%%)", num_texture_upload, num_texture_upload_miss, texture_upload_miss_ratio));
 		}
 
 		direct_fbo->release();

--- a/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
@@ -50,7 +50,7 @@ namespace vk
 				const vk::pipeline_props& pipelineProperties,
 				bool compile_async,
 				std::function<pipeline_type*(pipeline_storage_type&)> callback,
-				VkDevice dev, VkPipelineLayout common_pipeline_layout)
+				VkPipelineLayout common_pipeline_layout)
 		{
 			const auto compiler_flags = compile_async ? vk::pipe_compiler::COMPILE_DEFERRED : vk::pipe_compiler::COMPILE_INLINE;
 			VkShaderModule modules[2] = { vertexProgramData.handle, fragmentProgramData.handle };

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -66,7 +66,7 @@ namespace vk
 			CHECK_RESULT(vkCreatePipelineLayout(dev, &layout_info, nullptr, &m_pipeline_layout));
 		}
 
-		void init_program(vk::render_device &dev)
+		void init_program()
 		{
 			std::string vs =
 			{
@@ -266,7 +266,7 @@ namespace vk
 			m_uniform_buffer_size = 983040;
 
 			init_descriptor_set(dev);
-			init_program(dev);
+			init_program();
 
 			GlyphManager glyph_source;
 			auto points = glyph_source.generate_point_map();

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1300,8 +1300,14 @@ namespace vk
 			section.set_view_flags(expected_flags);
 		}
 
-		void insert_texture_barrier(vk::command_buffer& cmd, vk::image* tex) override
+		void insert_texture_barrier(vk::command_buffer& cmd, vk::image* tex, bool strong_ordering) override
 		{
+			if (!strong_ordering && tex->current_layout == VK_IMAGE_LAYOUT_GENERAL)
+			{
+				// A previous barrier already exists, do nothing
+				return;
+			}
+
 			vk::as_rtt(tex)->texture_barrier(cmd);
 		}
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -126,7 +126,7 @@ struct cfg_root : cfg::node
 		cfg::_bool log_programs{ this, "Log shader programs" };
 		cfg::_bool vsync{ this, "VSync" };
 		cfg::_bool debug_output{ this, "Debug output" };
-		cfg::_bool overlay{ this, "Debug overlay" };
+		cfg::_bool overlay{ this, "Debug overlay", false, true };
 		cfg::_bool gl_legacy_buffers{ this, "Use Legacy OpenGL Buffers" };
 		cfg::_bool use_gpu_texture_scaling{ this, "Use GPU texture scaling", false };
 		cfg::_bool stretch_to_display_area{ this, "Stretch To Display Area", false, true };


### PR DESCRIPTION
- Do not leak descriptor references because previous shader did not use a texture that was bound from surface cache.
- Optimize framebuffer resource fetch by adding a simple fast path.
- Add texture upload stats to the debug overlay.
- Make debug overlay a dynamic option by lazy initializing GPU resources.