### PR TITLE
GUI: Improve PS3 decryption tool

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1127,17 +1127,14 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	{
 		const QString custom_title = m_persistent_settings->GetValue(gui::persistent::titles, serial, "").toString();
 		const QString old_title = custom_title.isEmpty() ? name : custom_title;
-		QString new_title;
 
 		input_dialog dlg(128, old_title, tr("Rename Title"), tr("%0\n%1\n\nYou can clear the line in order to use the original title.").arg(name).arg(serial), name, this);
 		dlg.move(global_pos);
-		connect(&dlg, &input_dialog::text_changed, [&new_title](const QString& text)
-		{
-			new_title = text.simplified();
-		});
 
 		if (dlg.exec() == QDialog::Accepted)
 		{
+			const QString new_title = dlg.get_input_text().simplified();
+
 			if (new_title.isEmpty() || new_title == name)
 			{
 				m_titles.remove(serial);

--- a/rpcs3/rpcs3qt/input_dialog.h
+++ b/rpcs3/rpcs3qt/input_dialog.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <QDialog>
-#include <QLabel>
+#include <QDialogButtonBox>
+
+class QLabel;
+class QLineEdit;
+class QValidator;
 
 class input_dialog : public QDialog
 {
@@ -12,9 +16,16 @@ public:
 	~input_dialog();
 
 	void set_label_text(const QString& text);
+	void set_validator(const QValidator* validator);
+	void set_clear_button_enabled(bool enable);
+	void set_input_font(const QFont& font, bool fix_width, char sample = '\0');
+	void set_button_enabled(QDialogButtonBox::StandardButton id, bool enabled);
+	QString get_input_text() const;
 
 private:
 	QLabel* m_label = nullptr;
+	QLineEdit* m_input = nullptr;
+	QDialogButtonBox* m_button_box = nullptr;
 	QString m_text;
 
 Q_SIGNALS:

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -126,9 +126,11 @@ namespace gui
 			return dummy_font.font();
 		}
 
-		int get_label_width(const QString& text)
+		int get_label_width(const QString& text, const QFont* font)
 		{
-			return QLabel(text).sizeHint().width();
+			QLabel l(text);
+			if (font) l.setFont(*font);
+			return l.sizeHint().width();
 		}
 
 		QImage get_opaque_image_area(const QString& path)

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -44,7 +44,7 @@ namespace gui
 		QFont get_label_font(const QString& object_name);
 
 		// Returns the width of the text
-		int get_label_width(const QString& text);
+		int get_label_width(const QString& text, const QFont* font = nullptr);
 
 		// Returns the part of the image loaded from path that is inside the bounding box of its opaque areas
 		QImage get_opaque_image_area(const QString& path);


### PR DESCRIPTION
* Allow to decrypt binaries even if a game is running in the background, do not stop it. Also take advantage of when a game is running and try to extract another KLIC from it.
* If decryption failed due to missing key licence (KLIC), pop a dialog to enter it manually. It's 32 characters long in hex and is logged with the games it's being used in sceNpDrmIsAvailable and few other sceNpDrm functions. Try to decrypt one more time with specified KLIC.