### PR TITLE
Link the memory viewer with the debugger

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1,6 +1,7 @@
 #include "debugger_frame.h"
 #include "register_editor_dialog.h"
 #include "instruction_editor_dialog.h"
+#include "memory_viewer_panel.h"
 #include "gui_settings.h"
 #include "debugger_list.h"
 #include "breakpoint_list.h"
@@ -311,6 +312,28 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 			if (auto pos = std::basic_string_view<u32>(res.data(), 2).find_last_not_of(UINT32_MAX); pos != umax)
 				m_debugger_list->ShowAddress(res[pos] - std::max(i, 0) * 4, true);
 
+			return;
+		}
+		case Qt::Key_M:
+		{
+			// Memory viewer
+
+			u32 addr = pc;
+
+			if (auto spu = static_cast<const spu_thread*>(cpu->id_type() == 2 ? cpu.get() : nullptr))
+			{
+				if (spu->get_type() != spu_type::threaded)
+				{
+					addr += RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * spu->index;
+				}
+				else
+				{
+					addr += SPU_FAKE_BASE_ADDR + SPU_LS_SIZE * (spu->id & 0xffffff);
+				}
+			}
+
+			auto mvp = new memory_viewer_panel(this, addr);
+			mvp->show();
 			return;
 		}
 		case Qt::Key_F10:

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -15,14 +15,14 @@
 
 constexpr auto qstr = QString::fromStdString;
 
-memory_viewer_panel::memory_viewer_panel(QWidget* parent)
+memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr)
 	: QDialog(parent)
+	, m_addr(addr)
 {
 	setWindowTitle(tr("Memory Viewer"));
 	setObjectName("memory_viewer");
 	setAttribute(Qt::WA_DeleteOnClose);
 	exit = false;
-	m_addr = 0;
 	m_colcount = 16;
 	m_rowcount = 16;
 	int pSize = 10;
@@ -47,6 +47,7 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent)
 	QHBoxLayout* hbox_tools_mem_addr = new QHBoxLayout();
 	m_addr_line = new QLineEdit(this);
 	m_addr_line->setPlaceholderText("00000000");
+	m_addr_line->setText(qstr(fmt::format("%08x", m_addr)));
 	m_addr_line->setFont(mono);
 	m_addr_line->setMaxLength(8);
 	m_addr_line->setFixedWidth(75);

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -28,7 +28,7 @@ private:
 
 public:
 	bool exit;
-	memory_viewer_panel(QWidget* parent);
+	memory_viewer_panel(QWidget* parent, u32 addr = 0);
 	~memory_viewer_panel();
 
 	void wheelEvent(QWheelEvent *event) override;


### PR DESCRIPTION
* Press M while the debugger is running to launch the memory viewer from it. When the memoy viewer is being launched from the debugger a magical thing happens: it passes to it the address of current instruction selected on the debugger. (or the current PC if none was selected)
It also works with SPUs and the debugger calculates the address of the LS shadow copy in vm and adds it to the address before then passing it to the memory viewer.