### PR TITLE
Debugger fixes

### DIFF
--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -16,6 +16,7 @@ class CPUDisAsm
 {
 protected:
 	const CPUDisAsmMode m_mode;
+	const std::add_pointer_t<const u8> m_offset;
 
 	virtual void Write(const std::string& value)
 	{
@@ -24,20 +25,20 @@ protected:
 			case CPUDisAsm_DumpMode:
 			{
 				last_opcode = fmt::format("\t%08x:\t%02x %02x %02x %02x\t%s\n", dump_pc,
-					offset[dump_pc],
-					offset[dump_pc + 1],
-					offset[dump_pc + 2],
-					offset[dump_pc + 3], value);
+					m_offset[dump_pc],
+					m_offset[dump_pc + 1],
+					m_offset[dump_pc + 2],
+					m_offset[dump_pc + 3], value);
 				break;
 			}
 
 			case CPUDisAsm_InterpreterMode:
 			{
 				last_opcode = fmt::format("[%08x]  %02x %02x %02x %02x: %s", dump_pc,
-					offset[dump_pc],
-					offset[dump_pc + 1],
-					offset[dump_pc + 2],
-					offset[dump_pc + 3], value);
+					m_offset[dump_pc],
+					m_offset[dump_pc + 1],
+					m_offset[dump_pc + 2],
+					m_offset[dump_pc + 3], value);
 				break;
 			}
 
@@ -58,12 +59,11 @@ protected:
 public:
 	std::string last_opcode;
 	u32 dump_pc;
-	const u8* offset;
 
 protected:
-	CPUDisAsm(CPUDisAsmMode mode)
+	CPUDisAsm(CPUDisAsmMode mode, const u8* offset)
 		: m_mode(mode)
-		, offset(0)
+		, m_offset(offset)
 	{
 	}
 

--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -17,6 +17,7 @@ class CPUDisAsm
 protected:
 	const CPUDisAsmMode m_mode;
 	const std::add_pointer_t<const u8> m_offset;
+	u32 m_op = 0;
 
 	virtual void Write(const std::string& value)
 	{
@@ -25,20 +26,20 @@ protected:
 			case CPUDisAsm_DumpMode:
 			{
 				last_opcode = fmt::format("\t%08x:\t%02x %02x %02x %02x\t%s\n", dump_pc,
-					m_offset[dump_pc],
-					m_offset[dump_pc + 1],
-					m_offset[dump_pc + 2],
-					m_offset[dump_pc + 3], value);
+					static_cast<u8>(m_op >> 24),
+					static_cast<u8>(m_op >> 16),
+					static_cast<u8>(m_op >> 8),
+					static_cast<u8>(m_op >> 0), value);
 				break;
 			}
 
 			case CPUDisAsm_InterpreterMode:
 			{
 				last_opcode = fmt::format("[%08x]  %02x %02x %02x %02x: %s", dump_pc,
-					m_offset[dump_pc],
-					m_offset[dump_pc + 1],
-					m_offset[dump_pc + 2],
-					m_offset[dump_pc + 3], value);
+					static_cast<u8>(m_op >> 24),
+					static_cast<u8>(m_op >> 16),
+					static_cast<u8>(m_op >> 8),
+					static_cast<u8>(m_op >> 0), value);
 				break;
 			}
 

--- a/rpcs3/Emu/Cell/PPCDisAsm.h
+++ b/rpcs3/Emu/Cell/PPCDisAsm.h
@@ -5,7 +5,7 @@
 class PPCDisAsm : public CPUDisAsm
 {
 protected:
-	PPCDisAsm(CPUDisAsmMode mode) : CPUDisAsm(mode)
+	PPCDisAsm(CPUDisAsmMode mode, const u8* offset) : CPUDisAsm(mode, offset)
 	{
 	}
 

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -7,8 +7,8 @@ const ppu_decoder<PPUDisAsm> s_ppu_disasm;
 u32 PPUDisAsm::disasm(u32 pc)
 {
 	dump_pc = pc;
-	const u32 op = *reinterpret_cast<const be_t<u32>*>(m_offset + pc);
-	(this->*(s_ppu_disasm.decode(op)))({ op });
+	m_op = *reinterpret_cast<const atomic_be_t<u32>*>(m_offset + pc);
+	(this->*(s_ppu_disasm.decode(m_op)))({ m_op });
 	return 4;
 }
 

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -6,7 +6,8 @@ const ppu_decoder<PPUDisAsm> s_ppu_disasm;
 
 u32 PPUDisAsm::disasm(u32 pc)
 {
-	const u32 op = *reinterpret_cast<const be_t<u32>*>(offset + pc);
+	dump_pc = pc;
+	const u32 op = *reinterpret_cast<const be_t<u32>*>(m_offset + pc);
 	(this->*(s_ppu_disasm.decode(op)))({ op });
 	return 4;
 }

--- a/rpcs3/Emu/Cell/PPUDisAsm.h
+++ b/rpcs3/Emu/Cell/PPUDisAsm.h
@@ -6,7 +6,7 @@
 class PPUDisAsm final : public PPCDisAsm
 {
 public:
-	PPUDisAsm(CPUDisAsmMode mode) : PPCDisAsm(mode)
+	PPUDisAsm(CPUDisAsmMode mode, const u8* offset) : PPCDisAsm(mode, offset)
 	{
 	}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -500,9 +500,7 @@ std::string ppu_thread::dump_regs() const
 				}
 				else
 				{
-					PPUDisAsm dis_asm(CPUDisAsm_NormalMode);
-					dis_asm.offset = vm::g_sudo_addr;
-					dis_asm.dump_pc = reg;
+					PPUDisAsm dis_asm(CPUDisAsm_NormalMode, vm::g_sudo_addr);
 					dis_asm.disasm(reg);
 					fmt::append(ret, " -> %s", dis_asm.last_opcode);
 				}

--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -11,7 +11,8 @@ const spu_decoder<spu_iflag> s_spu_iflag;
 
 u32 SPUDisAsm::disasm(u32 pc)
 {
-	const u32 op = *reinterpret_cast<const be_t<u32>*>(offset + pc);
+	dump_pc = pc;
+	const u32 op = *reinterpret_cast<const be_t<u32>*>(m_offset + pc);
 	(this->*(s_spu_disasm.decode(op)))({ op });
 	return 4;
 }
@@ -33,7 +34,7 @@ std::pair<bool, v128> SPUDisAsm::try_get_const_value(u32 reg, u32 pc) const
 
 	for (s32 i = pc - 4; i >= 0; i -= 4)
 	{
-		const u32 opcode = *reinterpret_cast<const be_t<u32>*>(offset + i);
+		const u32 opcode = *reinterpret_cast<const be_t<u32>*>(m_offset + i);
 		const spu_opcode_t op0{ opcode };
 
 		const auto type = s_spu_itype.decode(opcode);

--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -12,8 +12,8 @@ const spu_decoder<spu_iflag> s_spu_iflag;
 u32 SPUDisAsm::disasm(u32 pc)
 {
 	dump_pc = pc;
-	const u32 op = *reinterpret_cast<const be_t<u32>*>(m_offset + pc);
-	(this->*(s_spu_disasm.decode(op)))({ op });
+	m_op = *reinterpret_cast<const atomic_be_t<u32>*>(m_offset + pc);
+	(this->*(s_spu_disasm.decode(m_op)))({ m_op });
 	return 4;
 }
 

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -71,7 +71,7 @@ static constexpr const char* spu_ch_name[128] =
 class SPUDisAsm final : public PPCDisAsm
 {
 public:
-	SPUDisAsm(CPUDisAsmMode mode) : PPCDisAsm(mode)
+	SPUDisAsm(CPUDisAsmMode mode, const u8* offset) : PPCDisAsm(mode, offset)
 	{
 	}
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -3146,8 +3146,7 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point)
 
 void spu_recompiler_base::dump(const spu_program& result, std::string& out)
 {
-	SPUDisAsm dis_asm(CPUDisAsm_DumpMode);
-	dis_asm.offset = reinterpret_cast<const u8*>(result.data.data()) - result.lower_bound;
+	SPUDisAsm dis_asm(CPUDisAsm_DumpMode, reinterpret_cast<const u8*>(result.data.data()) - result.lower_bound);
 
 	std::string hash;
 	{
@@ -3166,7 +3165,6 @@ void spu_recompiler_base::dump(const spu_program& result, std::string& out)
 	{
 		for (u32 pos = bb.first, end = bb.first + bb.second.size * 4; pos < end; pos += 4)
 		{
-			dis_asm.dump_pc = pos;
 			dis_asm.disasm(pos);
 			fmt::append(out, ">%s\n", dis_asm.last_opcode);
 		}

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1288,9 +1288,7 @@ std::string spu_thread::dump_regs() const
 
 		if (i3 >= 0x80 && is_exec_code(i3))
 		{
-			SPUDisAsm dis_asm(CPUDisAsm_NormalMode);
-			dis_asm.offset = ls;
-			dis_asm.dump_pc = i3;
+			SPUDisAsm dis_asm(CPUDisAsm_NormalMode, ls);
 			dis_asm.disasm(i3);
 			fmt::append(ret, " -> %s", dis_asm.last_opcode);
 		}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1807,8 +1807,7 @@ void Emulator::Resume()
 	// Print and reset debug data collected
 	if (m_state == system_state::paused && g_cfg.core.ppu_debug)
 	{
-		PPUDisAsm dis_asm(CPUDisAsm_DumpMode);
-		dis_asm.offset = vm::g_sudo_addr;
+		PPUDisAsm dis_asm(CPUDisAsm_DumpMode, vm::g_sudo_addr);
 
 		std::string dump;
 
@@ -1818,7 +1817,6 @@ void Emulator::Resume()
 			{
 				if (auto& data = *reinterpret_cast<be_t<u32>*>(vm::g_stat_addr + i))
 				{
-					dis_asm.dump_pc = i;
 					dis_asm.disasm(i);
 					fmt::append(dump, "\n\t'%08X' %s", data, dis_asm.last_opcode);
 					data = 0;

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -86,18 +86,21 @@ void breakpoint_list::AddBreakpoint(u32 pc)
 */
 void breakpoint_list::HandleBreakpointRequest(u32 loc)
 {
+	const auto cpu = this->cpu.lock();
+
+	if (!cpu || cpu->id_type() != 1 || !vm::check_addr(loc, vm::page_allocated | vm::page_executable))
+	{
+		// TODO: SPU breakpoints
+		return;
+	}
+
 	if (m_breakpoint_handler->HasBreakpoint(loc))
 	{
 		RemoveBreakpoint(loc);
 	}
 	else
 	{
-		const auto cpu = this->cpu.lock();
-
-		if (cpu->id_type() == 1 && vm::check_addr(loc, vm::page_allocated | vm::page_executable))
-		{
-			AddBreakpoint(loc);
-		}
+		AddBreakpoint(loc);
 	}
 }
 

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -63,10 +63,8 @@ void breakpoint_list::AddBreakpoint(u32 pc)
 	m_breakpoint_handler->AddBreakpoint(pc);
 
 	const auto cpu = this->cpu.lock();
-	const auto cpu_offset = cpu->id_type() == 2 ? static_cast<spu_thread&>(*cpu).ls : vm::g_sudo_addr;
-	m_disasm->offset = cpu_offset;
 
-	m_disasm->disasm(m_disasm->dump_pc = pc);
+	m_disasm->disasm(pc);
 
 	QString breakpointItemText = qstr(m_disasm->last_opcode);
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -418,10 +418,8 @@ void debugger_frame::UpdateUnitList()
 		return;
 	}
 
+	const int old_size = m_choice_units->count();
 	QVariant old_cpu = m_choice_units->currentData();
-
-	m_choice_units->clear();
-	m_choice_units->addItem(NoThreadString);
 
 	const auto on_select = [&](u32 id, cpu_thread& cpu)
 	{
@@ -435,8 +433,17 @@ void debugger_frame::UpdateUnitList()
 	{
 		const QSignalBlocker blocker(m_choice_units);
 
+		m_choice_units->clear();
+		m_choice_units->addItem(NoThreadString);
+
 		idm::select<named_thread<ppu_thread>>(on_select);
 		idm::select<named_thread<spu_thread>>(on_select);
+
+		if (m_choice_units->count() > 1 && old_size <= 1)
+		{
+			// Select the first thread after "No Thread", usually the PPU main thread
+			m_choice_units->setCurrentIndex(1);
+		}
 	}
 
 	OnSelectUnit();

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -465,7 +465,7 @@ void debugger_frame::OnSelectUnit()
 				if (cpu0.get() == idm::check<named_thread<ppu_thread>>(cpu0->id))
 				{
 					cpu = cpu0;
-					m_disasm = std::make_unique<PPUDisAsm>(CPUDisAsm_InterpreterMode);
+					m_disasm = std::make_unique<PPUDisAsm>(CPUDisAsm_InterpreterMode, vm::g_sudo_addr);
 				}
 			}
 			else if (cpu0->id_type() == 2)
@@ -473,7 +473,7 @@ void debugger_frame::OnSelectUnit()
 				if (cpu0.get() == idm::check<named_thread<spu_thread>>(cpu0->id))
 				{
 					cpu = cpu0;
-					m_disasm = std::make_unique<SPUDisAsm>(CPUDisAsm_InterpreterMode);
+					m_disasm = std::make_unique<SPUDisAsm>(CPUDisAsm_InterpreterMode, static_cast<const spu_thread*>(cpu0.get())->ls);
 				}
 			}
 		}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -229,7 +229,8 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 		return;
 	}
 
-	const u32 pc = i >= 0 ? m_debugger_list->m_pc + i * 4 : cpu->get_pc();
+	const u32 address_limits = (cpu->id_type() != 1 ? 0x3fffc : ~3);
+	const u32 pc = (i >= 0 ? m_debugger_list->m_pc + i * 4 : cpu->get_pc()) & address_limits;
 
 	const auto modifiers = QApplication::keyboardModifiers();
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -302,7 +302,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 			{
 				be_t<ppu_opcode_t> op{};
 
-				if (vm::try_access(pc, &op, 4, false))
+				if (vm::check_addr(pc, vm::page_executable) && vm::try_access(pc, &op, 4, false))
 					res = op_branch_targets(pc, op);
 
 				break;

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -224,7 +224,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 	const auto cpu = this->cpu.lock();
 	int i = m_debugger_list->currentRow();
 
-	if (!isActiveWindow() || !cpu || m_no_thread_selected)
+	if (!isActiveWindow() || !cpu)
 	{
 		return;
 	}
@@ -354,8 +354,6 @@ void debugger_frame::UpdateUI()
 {
 	UpdateUnitList();
 
-	if (m_no_thread_selected) return;
-
 	const auto cpu = this->cpu.lock();
 
 	if (!cpu)
@@ -447,18 +445,22 @@ void debugger_frame::UpdateUnitList()
 
 void debugger_frame::OnSelectUnit()
 {
-	if (m_choice_units->count() < 1 || m_current_choice == m_choice_units->currentText()) return;
+	if (m_choice_units->count() < 1) return;
 
-	m_current_choice = m_choice_units->currentText();
-	m_no_thread_selected = m_current_choice == NoThreadString;
-	m_debugger_list->m_no_thread_selected = m_no_thread_selected;
+	const auto weak = m_choice_units->currentData().value<std::weak_ptr<cpu_thread>>();
+
+	if (!weak.owner_before(cpu) && !cpu.owner_before(weak))
+	{
+		// They match, nothing to do.
+		return;
+	}
 
 	m_disasm.reset();
 	cpu.reset();
 
-	if (!m_no_thread_selected)
+	if (!weak.expired())
 	{
-		if (const auto cpu0 = m_choice_units->currentData().value<std::weak_ptr<cpu_thread>>().lock())
+		if (const auto cpu0 = weak.lock())
 		{
 			if (cpu0->id_type() == 1)
 			{
@@ -479,7 +481,7 @@ void debugger_frame::OnSelectUnit()
 		}
 	}
 
-	EnableButtons(!m_no_thread_selected);
+	EnableButtons(true);
 
 	m_debugger_list->UpdateCPUData(this->cpu, m_disasm);
 	m_breakpoint_list->UpdateCPUData(this->cpu, m_disasm);
@@ -696,7 +698,7 @@ void debugger_frame::EnableUpdateTimer(bool enable)
 
 void debugger_frame::EnableButtons(bool enable)
 {
-	if (m_no_thread_selected) enable = false;
+	if (cpu.expired()) enable = false;
 
 	m_go_to_addr->setEnabled(enable);
 	m_go_to_pc->setEnabled(enable);

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -36,7 +36,6 @@ class debugger_frame : public custom_dock_widget
 	QPushButton* m_btn_step_over;
 	QPushButton* m_btn_run;
 	QComboBox* m_choice_units;
-	QString m_current_choice;
 	QTimer* m_update;
 	QSplitter* m_splitter;
 
@@ -45,7 +44,6 @@ class debugger_frame : public custom_dock_widget
 	u32 m_last_pc = -1;
 	std::vector<char> m_last_query_state;
 	u32 m_last_step_over_breakpoint = -1;
-	bool m_no_thread_selected = true;
 
 	std::shared_ptr<CPUDisAsm> m_disasm;
 	std::weak_ptr<cpu_thread> cpu;

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -39,8 +39,8 @@ class debugger_frame : public custom_dock_widget
 	QTimer* m_update;
 	QSplitter* m_splitter;
 
-	u64 m_threads_created = 0;
-	u64 m_threads_deleted = 0;
+	u64 m_threads_created = -1;
+	u64 m_threads_deleted = -1;
 	u32 m_last_pc = -1;
 	std::vector<char> m_last_query_state;
 	u32 m_last_step_over_breakpoint = -1;

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -149,7 +149,7 @@ void debugger_list::keyPressEvent(QKeyEvent* event)
 
 void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
 {
-	if (event->button() == Qt::LeftButton && !Emu.IsStopped() && !m_no_thread_selected)
+	if (event->button() == Qt::LeftButton)
 	{
 		int i = currentRow();
 		if (i < 0) return;

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -68,7 +68,7 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 	const auto default_foreground = palette().color(foregroundRole());
 	const auto default_background = palette().color(backgroundRole());
 
-	if (!cpu)
+	if (!cpu || !m_disasm)
 	{
 		for (uint i = 0; i < m_item_count; ++i)
 		{
@@ -80,10 +80,8 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 	else
 	{
 		const bool is_spu = cpu->id_type() != 1;
-		const auto cpu_offset = cpu->id_type() != 1 ? static_cast<spu_thread&>(*cpu).ls : vm::g_sudo_addr;
 		const u32 address_limits = (is_spu ? 0x3fffc : ~3);
 		m_pc &= address_limits;
-		m_disasm->offset = cpu_offset;
 		u32 pc = m_pc;
 
 		for (uint i = 0, count = 4; i<m_item_count; ++i, pc = (pc + count) & address_limits)
@@ -123,7 +121,7 @@ void debugger_list::ShowAddress(u32 addr, bool force)
 				continue;
 			}
 
-			count = m_disasm->disasm(m_disasm->dump_pc = pc);
+			count = m_disasm->disasm(pc);
 
 			item(i)->setText((IsBreakpoint(pc) ? ">> " : "   ") + qstr(m_disasm->last_opcode));
 		}

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -16,7 +16,6 @@ class debugger_list : public QListWidget
 public:
 	u32 m_pc = 0;
 	u32 m_item_count = 30;
-	bool m_no_thread_selected;
 	QColor m_color_bp;
 	QColor m_color_pc;
 	QColor m_text_color_bp;


### PR DESCRIPTION
* Remove m_current_choice for change of thread detection (replace with std::weak_ptr::owner_before()). It's not correct to rely on thread name entry. In extreme corner cases a newly thread can be created, old destroyed with the same entry name. (reoccuring LV2 SPU/PPU ID)
* Remove m_no_thread_selected, can be easily replaced with std::weak_pt::expired() function and is more accurate this way.
* In HandleBreakpointRequest: only remove breakpoint on valid PPU thread and not any thread! also fix potential nullptr deref if thread has recently been destroyed.
* PPU memory must be exec memory when using debugger's "Next Instruction" feature.
* Read instruction data once in disassmblers: Memory is volatile and may be changed by guest threads, ensure the decoded instruction matches with the data.
* Mask PC in debugger_frame::keyPressEvent for SPU to SPU LS bounds. This is needed for some features to work correctly.
* Cleanup disassmbler classes a bit, make them have a more natural interface.
* Switch from NoThread when the emulation is running the first thread after it.