### PR TITLE
GUI: Polish the memory viewer

### DIFF
--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -52,9 +52,10 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr)
 	m_addr_line->setPlaceholderText("00000000");
 	m_addr_line->setText(qstr(fmt::format("%08x", m_addr)));
 	m_addr_line->setFont(mono);
-	m_addr_line->setMaxLength(8);
+	m_addr_line->setMaxLength(10);
 	m_addr_line->setFixedWidth(75);
 	m_addr_line->setFocus();
+	m_addr_line->setValidator(new QRegExpValidator(QRegExp("^([0][xX])?[a-fA-F0-9]{0,8}$")));
 	hbox_tools_mem_addr->addWidget(m_addr_line);
 	tools_mem_addr->setLayout(hbox_tools_mem_addr);
 
@@ -207,7 +208,8 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr)
 	connect(m_addr_line, &QLineEdit::returnPressed, [this]()
 	{
 		bool ok;
-		m_addr = m_addr_line->text().toULong(&ok, 16); 
+		const QString text = m_addr_line->text();
+		m_addr = (text.startsWith("0x", Qt::CaseInsensitive) ? text.right(text.size() - 2) : text).toULong(&ok, 16); 
 		m_addr -= m_addr % (m_colcount * 4); // Align by amount of bytes in a row
 		m_addr_line->setText(QString("%1").arg(m_addr, 8, 16, QChar('0')));	// get 8 digits in input line
 		ShowMemory();

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -26,6 +26,9 @@ private:
 
 	QFontMetrics* m_fontMetrics;
 
+	std::string getHeaderAtAddr(u32 addr);
+	void scroll(s32 steps);
+
 public:
 	bool exit;
 	memory_viewer_panel(QWidget* parent, u32 addr = 0);


### PR DESCRIPTION
* Group bytes in 4-byte groups. (words)
* Add SPU local storage start headers.
* Address is always aligned to the amount of bytes in a row.
* Make memory viewer address accept "0x" and "0X" prefixes, max length has been extended to 10 characters but because of the added hexadecimal regexp validator without the prefix it will allow only 8 hex characters.

![image](https://user-images.githubusercontent.com/18193363/102501904-a0a69880-4086-11eb-92d6-17ca98cf4163.png)
