### PR TITLE
vk: Register ampere GPU PCI IDs

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -61,6 +61,7 @@ namespace vk
 		table.add(0x1F82, 0x1FB9, chip_class::NV_turing); // TU117, TU117M, TU117GL
 		table.add(0x2182, 0x21D1, chip_class::NV_turing); // TU116, TU116M, TU116GL
 		table.add(0x20B0, 0x20BE, chip_class::NV_ampere); // GA100
+		table.add(0x2204, 0x25AF, chip_class::NV_ampere); // GA10x (RTX 30 series)
 
 		return table;
 	}();


### PR DESCRIPTION
Somehow nobody noticed that ampere cards were not registered correctly. Only GA100 was added to the quirks table.