### PR TITLE
GUI: Rewrite GOTO address tools in debugger tools

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -440,12 +440,6 @@ void debugger_frame::UpdateUnitList()
 
 		idm::select<named_thread<ppu_thread>>(on_select);
 		idm::select<named_thread<spu_thread>>(on_select);
-
-		if (m_choice_units->count() > 1 && old_size <= 1)
-		{
-			// Select the first thread after "No Thread", usually the PPU main thread
-			m_choice_units->setCurrentIndex(1);
-		}
 	}
 
 	OnSelectUnit();

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -53,10 +53,10 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr)
 	m_addr_line->setPlaceholderText("00000000");
 	m_addr_line->setText(qstr(fmt::format("%08x", m_addr)));
 	m_addr_line->setFont(mono);
-	m_addr_line->setMaxLength(10);
+	m_addr_line->setMaxLength(18);
 	m_addr_line->setFixedWidth(75);
 	m_addr_line->setFocus();
-	m_addr_line->setValidator(new QRegExpValidator(QRegExp("^([0][xX])?[a-fA-F0-9]{0,8}$")));
+	m_addr_line->setValidator(new QRegExpValidator(QRegExp("^(0[xX])?0*[a-fA-F0-9]{0,8}$")));
 	hbox_tools_mem_addr->addWidget(m_addr_line);
 	tools_mem_addr->setLayout(hbox_tools_mem_addr);
 
@@ -209,9 +209,11 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr)
 	// Events
 	connect(m_addr_line, &QLineEdit::returnPressed, [this]()
 	{
-		bool ok;
+		bool ok = false;
 		const QString text = m_addr_line->text();
-		m_addr = (text.startsWith("0x", Qt::CaseInsensitive) ? text.right(text.size() - 2) : text).toULong(&ok, 16);
+		const u32 addr = (text.startsWith("0x", Qt::CaseInsensitive) ? text.right(text.size() - 2) : text).toULong(&ok, 16);
+		if (!ok) return;
+
 		m_addr -= m_addr % (m_colcount * 4); // Align by amount of bytes in a row
 		m_addr_line->setText(QString("%1").arg(m_addr, 8, 16, QChar('0')));	// get 8 digits in input line
 		ShowMemory();

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -63,9 +63,28 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr)
 	// Tools: Memory Viewer Options: Words
 	QGroupBox* tools_mem_words = new QGroupBox(tr("Words"));
 	QHBoxLayout* hbox_tools_mem_words = new QHBoxLayout();
-	QSpinBox* sb_words = new QSpinBox(this);
-	sb_words->setRange(1, 4);
-	sb_words->setValue(4);
+
+	class words_spin_box : public QSpinBox
+	{
+	public:
+		words_spin_box(QWidget* parent = nullptr) : QSpinBox(parent) {}
+		~words_spin_box() override {};
+
+	private:
+		int valueFromText(const QString &text) const override
+		{
+			return std::countr_zero(text.toULong());
+		}
+
+		QString textFromValue(int value) const override
+		{
+			return tr("%0").arg(1 << value);
+		}
+	};
+
+	words_spin_box* sb_words = new words_spin_box(this);
+	sb_words->setRange(0, 2);
+	sb_words->setValue(2);
 	hbox_tools_mem_words->addWidget(sb_words);
 	tools_mem_words->setLayout(hbox_tools_mem_words);
 
@@ -220,7 +239,7 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr)
 	});
 	connect(sb_words, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=, this]()
 	{
-		m_colcount = sb_words->value();
+		m_colcount = 1 << sb_words->value();
 		ShowMemory();
 	});
 

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -305,10 +305,20 @@ std::string memory_viewer_panel::getHeaderAtAddr(u32 addr)
 		if (u32 raw_spu_index = (spu_boundary - RAW_SPU_BASE_ADDR) / SPU_LS_SIZE; raw_spu_index < 5)
 		{
 			spu = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(raw_spu_index));
+
+			if (spu && spu->get_type() == spu_type::threaded)
+			{
+				spu.reset();
+			}
 		}
 		else if (u32 spu_index = (spu_boundary - SPU_FAKE_BASE_ADDR) / SPU_LS_SIZE; spu_index < spu_thread::id_count)
 		{
 			spu = idm::get<named_thread<spu_thread>>(spu_thread::id_base | spu_index);
+
+			if (spu && spu->get_type() != spu_type::threaded)
+			{
+				spu.reset();
+			}
 		}
 
 		if (spu)

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -48,8 +48,9 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 	m_addr_line = new QLineEdit();
 	m_addr_line->setFont(mono);
 	m_addr_line->setPlaceholderText("00000000");
-	m_addr_line->setMaxLength(8);
+	m_addr_line->setMaxLength(18);
 	m_addr_line->setFixedWidth(l.sizeHint().width());
+	m_addr_line->setValidator(new QRegExpValidator(QRegExp("^(0[xX])?0*[a-fA-F0-9]{0,8}$")));
 	setFocusProxy(m_addr_line);
 
 	QHBoxLayout* hbox_controls_addr = new QHBoxLayout();
@@ -234,8 +235,10 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 	});
 	connect(m_addr_line, &QLineEdit::returnPressed, [this]()
 	{
-		bool ok;
-		m_addr = m_addr_line->text().toULong(&ok, 16);
+		bool ok = false;
+		const u32 addr = static_cast<u32>(m_addr_line->text().toULong(&ok, 16));
+
+		if (ok) m_addr = addr;
 		UpdateInformation();
 	});
 	connect(m_list_captured_draw_calls, &QTableWidget::itemClicked, this, &rsx_debugger::OnClickDrawCalls);


### PR DESCRIPTION
* Add the same fixes as memory viewer for rsx debugger and main debugger as #9453. Modified regexp validator to allow endless amount of leftmost zeroes. (until max length is reached)
* Extent max length to 18 to allow 64-bit hexadecimal (16) with hex prefix (2).
* Remove address preview in the main debugger's Goto address dialog.
* Limit SPU address on the main debugger to 0xfffff and less in regexp validator. (stuff like 0x0000000000fffff still works but 0x100000 is not allowed to type)
* memory viewer: Only allow "words" steps in powers of 2.
* Default to current PC/address instead of 0 address on failure to evaluate text in lineedit. (such as empty text or "0x" prefix alone)
* Print SPU reservation data in the debugger.