### PR TITLE
Emu: implement on_exit callback

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1979,13 +1979,13 @@ bool Emulator::Quit(bool force_quit)
 {
 	m_force_boot = false;
 
-	// Deinitialize object manager to prevent any hanging objects at program exit
-	if (force_quit)
+	// The callback is only used if we actually quit RPCS3
+	const auto on_exit = []()
 	{
+		// Deinitialize object manager to prevent any hanging objects at program exit
 		*g_fxo = {};
-	}
-
-	return GetCallbacks().exit(force_quit);
+	};
+	return GetCallbacks().try_to_quit(force_quit, on_exit);
 }
 
 std::string Emulator::GetFormattedTitle(double fps) const

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -42,7 +42,7 @@ struct EmuCallbacks
 	std::function<void()> on_stop;
 	std::function<void()> on_ready;
 	std::function<bool()> on_missing_fw;
-	std::function<bool(bool)> exit; // (force_quit) close RPCS3
+	std::function<bool(bool, std::function<void()>)> try_to_quit; // (force_quit, on_exit) Try to close RPCS3
 	std::function<void(s32, s32)> handle_taskbar_progress; // (type, value) type: 0 for reset, 1 for increment, 2 for set_limit
 	std::function<void()> init_kb_handler;
 	std::function<void()> init_mouse_handler;

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -39,10 +39,15 @@ void headless_application::InitializeCallbacks()
 {
 	EmuCallbacks callbacks = CreateCallbacks();
 
-	callbacks.exit = [this](bool force_quit) -> bool
+	callbacks.try_to_quit = [this](bool force_quit, std::function<void()> on_exit) -> bool
 	{
 		if (force_quit)
 		{
+			if (on_exit)
+			{
+				on_exit();
+			}
+
 			quit();
 			return true;
 		}

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -283,11 +283,16 @@ void gui_application::InitializeCallbacks()
 {
 	EmuCallbacks callbacks = CreateCallbacks();
 
-	callbacks.exit = [this](bool force_quit) -> bool
+	callbacks.try_to_quit = [this](bool force_quit, std::function<void()> on_exit) -> bool
 	{
 		// Close rpcs3 if closed in no-gui mode
 		if (force_quit || !m_main_window)
 		{
+			if (on_exit)
+			{
+				on_exit();
+			}
+
 			if (m_main_window)
 			{
 				// Close main window in order to save its window state


### PR DESCRIPTION
This should harden our exit process, while also fixing g_fxo deinitialization in no-gui mode.