### PR TITLE
vk: Fixup for renderpass issues

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -272,4 +272,10 @@ namespace vk
 	{
 		return g_current_renderpass[cmd].pass != VK_NULL_HANDLE;
 	}
+
+	void renderpass_op(VkCommandBuffer cmd, const renderpass_op_callback_t& op)
+	{
+		const auto& active = g_current_renderpass[cmd];
+		op(cmd, active.pass, active.fbo);
+	}
 }

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.h
@@ -17,4 +17,7 @@ namespace vk
 	void begin_renderpass(VkCommandBuffer cmd, VkRenderPass pass, VkFramebuffer target, const coordu& framebuffer_region);
 	void end_renderpass(VkCommandBuffer cmd);
 	bool is_renderpass_open(VkCommandBuffer cmd);
+
+	using renderpass_op_callback_t = std::function<void(VkCommandBuffer, VkRenderPass, VkFramebuffer)>;
+	void renderpass_op(VkCommandBuffer cmd, const renderpass_op_callback_t& op);
 }


### PR DESCRIPTION
Partially reverts https://github.com/RPCS3/rpcs3/commit/0a865bd9dcad8a6cf2bdb2a867e2cf23baef58ea

Technical information
Validation layers validate a bound pipeline against the active renderpass. The old render pipeline would bind a new pipeline, then end the active renderpass (if mismatched) and start a new one (the correct one) which could trigger errors and undefined driver behavior. The new approach cleanly stops the active renderpass if it is mismatched and binds the draw call requirements outside any renderpass which solves the spec violation.

Fixes https://github.com/RPCS3/rpcs3/issues/9456
Fixes https://github.com/RPCS3/rpcs3/issues/9457