### PR TITLE
Revert partially "Implement util/auto_typemap.hpp"

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2114,15 +2114,15 @@ void Emulator::ConfigurePPUCache()
 }
 
 template <>
-void stx::manual_fixed_typemap<void>::init_reporter(const char* name, unsigned long long created) const noexcept
+void stx::manual_fixed_typemap<void>::init_reporter(unsigned long long created) const noexcept
 {
-	sys_log.notice("[ord:%u] Object '%s' was created", created, name);
+	sys_log.notice("[ord:%u] Object was created", created);
 }
 
 template <>
-void stx::manual_fixed_typemap<void>::destroy_reporter(const char* name, unsigned long long created) const noexcept
+void stx::manual_fixed_typemap<void>::destroy_reporter(unsigned long long created) const noexcept
 {
-	sys_log.notice("[ord:%u] Object '%s' is destroying", created, name);
+	sys_log.notice("[ord:%u] Object is destroying", created);
 }
 
 Emulator Emu;


### PR DESCRIPTION
This reverts 'rpcs3/stdafx.h' in commit 567d23d856473297541ea189f67cafa0d5b1b3eb.

Issue : 
```
[ 82%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/PPUTranslator.cpp.o
cc1plus: warning: /home/marin_baron/build/rpcs3/gcc/debug/rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/cmake_pch.hxx.gch: not used because `__GXX_RTTI' not defined [-Winvalid-pch]
[ 82%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/RawSPUThread.cpp.o
[ 82%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/SPUAnalyser.cpp.o
In file included from /mnt/z97-a/mnt/crucial_p1/Git/rpcs3/rpcs3/stdafx.h:11,
                 from /home/marin_baron/build/rpcs3/gcc/debug/rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/cmake_pch.hxx:5,
                 from <command-line>:
/mnt/z97-a/mnt/crucial_p1/Git/rpcs3/rpcs3/util/fixed_typemap.hpp: In static member function ‘static stx::manual_fixed_typemap< <template-parameter-1-1>, Report>::typeinfo stx::manual_fixed_typemap< <template-parameter-1-1>, Report>::typeinfo::make_typeinfo()’:
/mnt/z97-a/mnt/crucial_p1/Git/rpcs3/rpcs3/util/fixed_typemap.hpp:63:27: error: cannot use ‘typeid’ with ‘-fno-rtti’
   63 |     r.type_name = typeid(T).name();
      |                           ^
[ 82%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/SPUASMJITRecompiler.cpp.o
[ 82%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/SPUDisAsm.cpp.o
[ 82%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/SPUInterpreter.cpp.o
[ 84%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/SPURecompiler.cpp.o
[ 84%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/SPUThread.cpp.o
[ 84%] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/lv2/lv2.cpp.o
In file included from /mnt/z97-a/mnt/crucial_p1/Git/rpcs3/rpcs3/stdafx.h:11,
                 from /home/marin_baron/build/rpcs3/gcc/debug/rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/cmake_pch.hxx:5,
                 from <command-line>:
/mnt/z97-a/mnt/crucial_p1/Git/rpcs3/rpcs3/util/fixed_typemap.hpp: In static member function ‘static stx::manual_fixed_typemap< <template-parameter-1-1>, Report>::typeinfo stx::manual_fixed_typemap< <template-parameter-1-1>, Report>::typeinfo::make_typeinfo()’:
/mnt/z97-a/mnt/crucial_p1/Git/rpcs3/rpcs3/util/fixed_typemap.hpp:63:27: error: cannot use ‘typeid’ with ‘-fno-rtti’
   63 |     r.type_name = typeid(T).name();
      |                           ^
...
...
make[2]: *** [rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/build.make:409: rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/__/__/Utilities/JIT.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/build.make:949: rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/PPUTranslator.cpp.o] Error 1
```

My first attempt was to reactivate RTTI for the two files : 
```
[ 98%] Linking CXX executable ../bin/rpcs3
/usr/bin/ld: Emu/librpcs3_emu.a(JIT.cpp.o):(.data.rel.ro._ZTI11ObjectCache[_ZTI11ObjectCache]+0x10): undefined reference to `typeinfo for llvm::ObjectCache'
/usr/bin/ld: Emu/librpcs3_emu.a(JIT.cpp.o):(.data.rel.ro._ZTI14MemoryManager2[_ZTI14MemoryManager2]+0x10): undefined reference to `typeinfo for llvm::RTDyldMemoryManager'
/usr/bin/ld: Emu/librpcs3_emu.a(JIT.cpp.o):(.data.rel.ro._ZTI14MemoryManager1[_ZTI14MemoryManager1]+0x10): undefined reference to `typeinfo for llvm::RTDyldMemoryManager'
collect2: error: ld returned 1 exit status
make[2]: *** [rpcs3/CMakeFiles/rpcs3.dir/build.make:470: bin/rpcs3] Error 1
```

My second was to split the RTTI usage from header (could be pain to maintain specialisation with lambda): 
```
(anonymous namespace)::search_info                                                                                                                                                                                 
avconf_manager
browser_info
cell_resc_manager
content_permission
fs_aio_manager
gcm_config
gem_camera_shared
gem_config
ime_jp_manager
KeyboardHandlerBase
libio_sys_config
loaded_npdrm_keys
lv2_config
lv2_config_service_event::get_next_id()::service_event_id
lv2_memory_container
lv2_rsx_config
MouseHandlerBase
msg_info
music_decode2
music_decode
music_state
named_thread<(anonymous namespace)::progress_dialog_server> 
named_thread<camera_context> 
named_thread<cell_audio_thread> 
named_thread<cellNetCtlNetStartDialogLoadAsync(vm::_ptr_base<CellNetCtlNetStartDialogParam const, unsigned int>)::{lambda()#1}> 
named_thread<cpu_prof> 
named_thread<Emulator::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, bool)::{lambda()#2}> 
named_thread<gdb_thread> 
named_thread<mic_context>
named_thread<msg_dlg_thread_info> 
named_thread<network_thread> 
named_thread<np_handler> 
named_thread<ppu_syscall_usage> 
named_thread<rsx::dma_manager::offload_thread> 
named_thread<rsx::overlays::message_dialog::show(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MsgDialogType const&, std::function<void (int)>)::{lambda()#1}> 
named_thread<rsx::overlays::osk_dialog::Create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char16_t, std::char_traits<char16_t>, std::allocator<char16_t> > const&, char16_t*, unsigned int, unsigned int, unsigned int, unsigned int)::{lambda()#1}> 
named_thread<rsx::rsx_replay_thread> 
named_thread<rsx::thread::on_task()::{lambda()#2}> 
named_thread<signaling_handler> 
named_thread<spu_llvm> 
named_thread<tcp_timeout_monitor> 
named_thread<usb_handler_thread> 
osk_info
pad_info
pad_thread
page_fault_event_entries
page_fault_notification_entries
patch_engine
ppu_initialize(ppu_module const&)::jit_core_allocator
ppu_initialize(ppu_module const&)::jit_module_manager
ppu_initialize(ppu_module const&)::thread_index_allocator
ppu_linkage_info
ppu_module
ppu_thread_cleaner
rec_info
rsx::avconf
rsx::dma_manager
rsx::overlays::display_manager
rsx::thread
rudp_info
savedata_mutex
sce_np_clans_manager
sce_np_sns_manager
sce_np_trophy_manager
sce_np_tus_manager
sce_np_util_manager
screenshot_manager
spu_cache
spu_runtime
ssl_manager
statichle_handler
std::unordered_map<unsigned int, unsigned int, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, unsigned int> > > 
std::unordered_map<unsigned long, std::shared_ptr<(anonymous namespace)::search_content_t>, std::hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, std::shared_ptr<(anonymous namespace)::search_content_t> > > > 
syscache_info
sys_memory_address_table
sys_spu_thread_group_log(ppu_thread&, int, vm::_ptr_base<stx::se_t<int, true, 4ul>, unsigned int>)::spu_group_log_state_t
sysutil_cb_manager
sys_vm_global_t
vfs_manager
voice_manager
```

I noticed that @RipleyTom disabled precompiled  headers in #9499 but I guess we could reactivate it ?