### PR TITLE
Improves skylander portal emulator

### DIFF
--- a/rpcs3/Emu/Io/Skylander.cpp
+++ b/rpcs3/Emu/Io/Skylander.cpp
@@ -4,38 +4,191 @@
 
 LOG_CHANNEL(skylander_log, "skylander");
 
-sky_portal g_skylander;
+sky_portal g_skyportal;
 
-void sky_portal::sky_load()
+void skylander::save()
 {
 	if (!sky_file)
 	{
-		skylander_log.error("Tried to load skylander but no skylander is active");
+		skylander_log.error("Tried to save skylander to file but no skylander is active!");
 		return;
 	}
 
 	{
-		std::lock_guard lock(sky_mutex);
-
 		sky_file.seek(0, fs::seek_set);
-		sky_file.read(sky_dump, 0x40 * 0x10);
+		sky_file.write(data.data(), 0x40 * 0x10);
 	}
 }
 
-void sky_portal::sky_save()
+void sky_portal::activate()
 {
-	if (!sky_file)
+	std::lock_guard lock(sky_mutex);
+	if (activated)
 	{
-		skylander_log.error("Tried to save skylander to file but no skylander is active");
+		// If the portal was already active no change is needed
 		return;
 	}
 
+	// If not we need to advertise change to all the figures present on the portal
+	for (auto& s : skylanders)
 	{
-		std::lock_guard lock(sky_mutex);
-
-		sky_file.seek(0, fs::seek_set);
-		sky_file.write(sky_dump, 0x40 * 0x10);
+		if (s.status & 1)
+		{
+			s.queued_status.push(3);
+			s.queued_status.push(1);
+		}
 	}
+
+	activated = true;
+}
+
+void sky_portal::deactivate()
+{
+	std::lock_guard lock(sky_mutex);
+
+	for (auto& s : skylanders)
+	{
+		// check if at the end of the updates there would be a figure on the portal
+		if (!s.queued_status.empty())
+		{
+			s.status        = s.queued_status.back();
+			s.queued_status = std::queue<u8>();
+		}
+
+		s.status &= 1;
+	}
+
+	activated = false;
+}
+
+void sky_portal::set_leds(u8 r, u8 g, u8 b)
+{
+	std::lock_guard lock(sky_mutex);
+	this->r = r;
+	this->g = g;
+	this->b = b;
+}
+
+void sky_portal::get_status(u8* reply_buf)
+{
+	std::lock_guard lock(sky_mutex);
+
+	u16 status = 0;
+
+	for (int i = 7; i >= 0; i--)
+	{
+		auto& s = skylanders[i];
+
+		if (!s.queued_status.empty())
+		{
+			s.status = s.queued_status.front();
+			s.queued_status.pop();
+		}
+
+		status <<= 2;
+		status |= s.status;
+	}
+
+	memset(reply_buf, 0, 0x20);
+	reply_buf[0]                               = 0x53;
+	reinterpret_cast<le_t<u16>&>(reply_buf[1]) = status;
+	reply_buf[5]                               = interrupt_counter++;
+	reply_buf[6]                               = 0x01;
+}
+
+void sky_portal::query_block(u8 sky_num, u8 block, u8* reply_buf)
+{
+	std::lock_guard lock(sky_mutex);
+
+	const auto& thesky = skylanders[sky_num];
+
+	reply_buf[0] = 'Q';
+	reply_buf[2] = block;
+	if (thesky.status & 1)
+	{
+		reply_buf[1] = (0x10 | sky_num);
+		memcpy(reply_buf + 3, thesky.data.data() + (16 * block), 16);
+	}
+	else
+	{
+		reply_buf[1] = sky_num;
+	}
+}
+
+void sky_portal::write_block(u8 sky_num, u8 block, const u8* to_write_buf, u8* reply_buf)
+{
+	std::lock_guard lock(sky_mutex);
+
+	auto& thesky = skylanders[sky_num];
+
+	reply_buf[0] = 'W';
+	reply_buf[2] = block;
+
+	if (thesky.status & 1)
+	{
+		reply_buf[1] = (0x10 | sky_num);
+		memcpy(thesky.data.data() + (block * 16), to_write_buf, 16);
+		thesky.save();
+	}
+	else
+	{
+		reply_buf[1] = sky_num;
+	}
+}
+
+bool sky_portal::remove_skylander(u8 sky_num)
+{
+	std::lock_guard lock(sky_mutex);
+	auto& thesky = skylanders[sky_num];
+
+	if (thesky.status & 1)
+	{
+		thesky.status = 2;
+		thesky.queued_status.push(2);
+		thesky.queued_status.push(0);
+		thesky.sky_file.close();
+		return true;
+	}
+
+	return false;
+}
+
+u8 sky_portal::load_skylander(u8* buf, fs::file in_file)
+{
+	std::lock_guard lock(sky_mutex);
+
+	u32 sky_serial = reinterpret_cast<le_t<u32>&>(buf[0]);
+	u8 found_slot  = 0xFF;
+
+	// mimics spot retaining on the portal
+	for (auto i = 0; i < 8; i++)
+	{
+		if ((skylanders[i].status & 1) == 0)
+		{
+			if (skylanders[i].last_id == sky_serial)
+			{
+				found_slot = i;
+				break;
+			}
+
+			if (i < found_slot)
+			{
+				found_slot = i;
+			}
+		}
+	}
+
+	ensure(found_slot != 0xFF);
+
+	auto& thesky = skylanders[found_slot];
+	memcpy(thesky.data.data(), buf, thesky.data.size());
+	thesky.sky_file = std::move(in_file);
+	thesky.status   = 3;
+	thesky.queued_status.push(3);
+	thesky.queued_status.push(1);
+	thesky.last_id = sky_serial;
+
+	return found_slot;
 }
 
 usb_device_skylander::usb_device_skylander()
@@ -74,67 +227,76 @@ void usb_device_skylander::control_transfer(u8 bmRequestType, u8 bRequest, u16 w
 			switch (buf[0])
 			{
 			case 'A':
+			{
 				// Activate command
-				ensure(buf_size == 2);
+				ensure(buf_size == 2 || buf_size == 32);
 				q_result = {0x41, buf[1], 0xFF, 0x77, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				    0x00, 0x00};
-
 				q_queries.push(q_result);
+				g_skyportal.activate();
 				break;
+			}
 			case 'C':
+			{
 				// Set LEDs colour
-				ensure(buf_size == 4);
+				ensure(buf_size == 4 || buf_size == 32);
+				g_skyportal.set_leds(buf[1], buf[2], buf[3]);
 				break;
+			}
 			case 'M':
+			{
+				// ?
 				q_result[0] = 0x4D;
 				q_result[1] = buf[1];
 				q_queries.push(q_result);
 				break;
+			}
 			case 'Q':
+			{
 				// Queries a block
-				ensure(buf_size == 3);
+				ensure(buf_size == 3 || buf_size == 32);
 
-				q_result[0] = 'Q';
-				q_result[1] = 0x10;
-				q_result[2] = buf[2];
+				const u8 sky_num = buf[1] & 0xF;
+				ensure(sky_num < 8);
+				const u8 block = buf[2];
+				ensure(block < 0x40);
 
-				{
-					std::lock_guard lock(g_skylander.sky_mutex);
-					memcpy(q_result.data() + 3, g_skylander.sky_dump + (16 * buf[2]), 16);
-				}
-
+				g_skyportal.query_block(sky_num, block, q_result.data());
 				q_queries.push(q_result);
 				break;
+			}
 			case 'R':
-				// Reset
-				ensure(buf_size == 2);
+			{
+				// Shutdowns the portal
+				ensure(buf_size == 2 || buf_size == 32);
 				q_result = {
 				    0x52, 0x02, 0x0A, 0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 				q_queries.push(q_result);
+				g_skyportal.deactivate();
 				break;
+			}
 			case 'S':
+			{
 				// ?
-				ensure(buf_size == 1);
+				ensure(buf_size == 1 || buf_size == 32);
 				break;
+			}
 			case 'W':
-				// Write a block
-				ensure(buf_size == 19);
-				q_result[0] = 'W';
-				q_result[1] = 0x10;
-				q_result[2] = buf[2];
+			{
+				// Writes a block
+				ensure(buf_size == 19 || buf_size == 32);
 
-				{
-					std::lock_guard lock(g_skylander.sky_mutex);
-					memcpy(g_skylander.sky_dump + (buf[2] * 16), &buf[3], 16);
-				}
+				const u8 sky_num = buf[1] & 0xF;
+				ensure(sky_num < 8);
+				const u8 block = buf[2];
+				ensure(block < 0x40);
 
-				g_skylander.sky_save();
-
+				g_skyportal.write_block(sky_num, block, &buf[3], q_result.data());
 				q_queries.push(q_result);
 				break;
+			}
 			default: skylander_log.error("Unhandled Query Type: 0x%02X", buf[0]); break;
 			}
-
 			break;
 		}
 		break;
@@ -152,8 +314,8 @@ void usb_device_skylander::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoin
 	transfer->fake            = true;
 	transfer->expected_count  = buf_size;
 	transfer->expected_result = HC_CC_NOERR;
-	// Interrupt transfers are slow(6ms, TODO accurate measurement)
-	transfer->expected_time = get_timestamp() + 6000;
+	// Interrupt transfers are slow(~22ms)
+	transfer->expected_time = get_timestamp() + 22000;
 
 	if (!q_queries.empty())
 	{
@@ -162,15 +324,6 @@ void usb_device_skylander::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoin
 	}
 	else
 	{
-		std::lock_guard lock(g_skylander.sky_mutex);
-		memset(buf, 0, 0x20);
-		buf[0] = 0x53;
-		// Varies per skylander type
-		buf[1] = (g_skylander.sky_file && !g_skylander.sky_reload) ? 1 : 0;
-
-		buf[5] = interrupt_counter++;
-		buf[6] = 0x01;
-
-		g_skylander.sky_reload = false;
+		g_skyportal.get_status(buf);
 	}
 }

--- a/rpcs3/rpcs3qt/skylander_dialog.h
+++ b/rpcs3/rpcs3qt/skylander_dialog.h
@@ -1,11 +1,24 @@
 #pragma once
 
+#include <optional>
 #include "util/types.hpp"
 
 #include <QDialog>
-#include <QPushButton>
-#include <QComboBox>
 #include <QLineEdit>
+
+constexpr auto UI_SKY_NUM = 4;
+
+class skylander_creator_dialog : public QDialog
+{
+	Q_OBJECT
+
+public:
+	skylander_creator_dialog(QWidget* parent);
+	QString get_file_path() const;
+
+protected:
+	QString file_path;
+};
 
 class skylander_dialog : public QDialog
 {
@@ -20,38 +33,16 @@ public:
 	void operator=(skylander_dialog const&) = delete;
 
 protected:
-	// Checks if the skylander is initialized
-	bool is_initialized();
-	// Update the edits from skylander loaded in memory
+	void clear_skylander(u8 slot);
+	void create_skylander(u8 slot);
+	void load_skylander(u8 slot);
+	void load_skylander_path(u8 slot, const QString& path);
+
 	void update_edits();
-	// Parse edits and apply them to skylander in memory
-	void process_edits();
-
-	// Creates a new skylander
-	void new_skylander();
-	// Loads a skylander
-	void load_skylander();
-
-	u16 skylander_crc16(u16 init_value, const u8* buffer, u32 size);
-	// Get hash used for encryption of block
-	void get_hash(u8 block, std::array<u8, 16>& res_hash);
-	// encrypt a block to memory
-	void set_block(const u8 block, const std::array<u8, 16>& to_encrypt);
-	// decrypt a block in memory
-	void get_block(const u8 block, std::array<u8, 16>& decrypted);
-
-	// get the active Area(0x08 or 0x24)
-	u8 get_active_block();
-
-	void set_checksums();
 
 protected:
-	QLineEdit* edit_curfile    = nullptr;
-	QComboBox* combo_skylist   = nullptr;
-	QLineEdit* edit_skyid      = nullptr;
-	QLineEdit* edit_skyxp      = nullptr;
-	QLineEdit* edit_skymoney   = nullptr;
-	QPushButton* button_update = nullptr;
+	QLineEdit* edit_skylanders[UI_SKY_NUM]{};
+	static std::optional<std::tuple<u8, u16, u16>> sky_slots[UI_SKY_NUM];
 
 private:
 	static skylander_dialog* inst;


### PR DESCRIPTION
Adds support for queries in Skylanders Spyro's Adventure.
Adds support for up to 4 Skylanders at the same time(this can theoretically be pushed to 8 but I don't think any game takes advantage of it).
Improves accuracy of status commands.
Improves overall UI(cleaner main interface, automatic file naming, combobox with search included).

Closes https://github.com/RPCS3/rpcs3/issues/8144 and https://github.com/RPCS3/rpcs3/issues/7101 .
