### PR TITLE
rsx: Fix some silly regressions

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -761,24 +761,6 @@ namespace rsx
 			if (_It != m_depth_stencil_storage.end())
 				return Traits::get(_It->second);
 
-			fmt::throw_exception("Unreachable");
-		}
-
-		surface_type get_color_surface_at(u32 address)
-		{
-			auto It = m_render_targets_storage.find(address);
-			if (It != m_render_targets_storage.end())
-				return Traits::get(It->second);
-
-			return nullptr;
-		}
-
-		surface_type get_depth_stencil_surface_at(u32 address)
-		{
-			auto It = m_depth_stencil_storage.find(address);
-			if (It != m_depth_stencil_storage.end())
-				return Traits::get(It->second);
-
 			return nullptr;
 		}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1887,13 +1887,24 @@ namespace rsx
 						texture_control |= (float_en << texture_control_bits::DEPTH_FLOAT);
 						break;
 					}
-					case CELL_GCM_TEXTURE_X16: // A simple way to quickly read DEPTH16 data without shadow comparison
+					case CELL_GCM_TEXTURE_X16:
+					{
+						// A simple way to quickly read DEPTH16 data without shadow comparison
+						break;
+					}
 					case CELL_GCM_TEXTURE_DEPTH16:
 					case CELL_GCM_TEXTURE_DEPTH24_D8:
 					case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
 					case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
 					{
-						// Supported formats, nothing to do
+						// Natively supported Z formats with shadow comparison feature
+						const auto compare_mode = tex.zfunc();
+						if (!tex.alpha_kill_enabled() &&
+							compare_mode < rsx::comparison_function::always &&
+							compare_mode > rsx::comparison_function::never)
+						{
+							current_fragment_program.shadow_textures |= (1 << i);
+						}
 						break;
 					}
 					default:


### PR DESCRIPTION
- Return null if surface does not exist instead of throwing.
- Revert an inadvertent deletion for supported Z formats which broke shadowmaps.

Fixes https://github.com/RPCS3/rpcs3/issues/9509
Fixes https://github.com/RPCS3/rpcs3/issues/9474