### PR TITLE
Warnings: Micro fixes

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2389,7 +2389,7 @@ u64 thread_base::get_cycles()
 	}
 }
 
-void thread_ctrl::emergency_exit(std::string_view reason)
+[[noreturn]] void thread_ctrl::emergency_exit(std::string_view reason)
 {
 	sig_log.fatal("Thread terminated due to fatal error: %s", reason);
 

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2425,7 +2425,7 @@ u64 thread_base::get_cycles()
 #ifdef _WIN32
 		_endthreadex(0);
 #else
-		pthread_exit(0);
+		pthread_exit(nullptr);
 #endif
 	}
 

--- a/rpcs3/cmake_modules/ConfigureCompiler.cmake
+++ b/rpcs3/cmake_modules/ConfigureCompiler.cmake
@@ -31,6 +31,8 @@ else()
 	add_compile_options(-Werror=sign-compare)
 	add_compile_options(-Werror=reorder)
 
+	add_compile_options(-Wno-return-type)
+
 	#TODO Clean the code so these are removed
 	add_compile_options(-Wno-unused-variable)
 	add_compile_options(-Wno-unknown-pragmas)

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -8,7 +8,7 @@ namespace stx
 {
 #ifdef __clang__
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundefined_var_template"
+#pragma clang diagnostic ignored "-Wundefined-var-template"
 #endif
 
 	// Not defined anywhere (and produces a useless warning)


### PR DESCRIPTION
The return-type warning was spammed everywhere, and was caused by custom exception thing. Best to just disable.
Marking noreturn seems to have left some warnings in, but i cant track them down in compiler explorer (I'm probably just blind).

@Nekotekina The other thing I would really like to get in here is a new indexer for v128 bit vectors, since you marked the old one deprecated. Whenever rpcs3 is updated it nukes my whole terminal because of the warnings. Do you have a plan for replacing it, or perhaps some instructions for someone else to be able to change it?