### PR TITLE
SPU LLVM: Fix edgecase in icelake codegen

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7299,15 +7299,6 @@ public:
 				const auto as = byteswap(a);
 				const auto bs = byteswap(b);
 
-				if (m_use_avx512_icl && (op.ra != op.rb || m_interp_magn))
-				{
-					const auto m = gf2p8affineqb(build<u8[16]>(0x02, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x02, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04), c, 0x7f);
-					const auto mm = select(noncast<s8[16]>(m) >= 0, splat<u8[16]>(0), m);
-					const auto ab = vperm2b(as, bs, c);
-					set_vr(op.rt4, select(noncast<s8[16]>(c) >= 0, ab, mm));
-					return;
-				}
-
 				const auto x = avg(noncast<u8[16]>(sext<s8[16]>((c & 0xc0) == 0xc0)), noncast<u8[16]>(sext<s8[16]>((c & 0xe0) == 0xc0)));
 				const auto ax = pshufb(as, c);
 				const auto bx = pshufb(bs, c);
@@ -7350,7 +7341,7 @@ public:
 		if (m_use_avx512_icl && (op.ra != op.rb || m_interp_magn))
 		{
 			const auto m = gf2p8affineqb(build<u8[16]>(0x02, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x02, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04), c, 0x7f);
-			const auto mm = select(noncast<s8[16]>(m) >= 0, splat<u8[16]>(0), m);
+			const auto mm = select(noncast<s8[16]>(c << 1) >= 0, splat<u8[16]>(0), m);
 			const auto cr = eval(~c);
 			const auto ab = vperm2b(b, a, cr);
 			set_vr(op.rt4, select(noncast<s8[16]>(cr) >= 0, mm, ab));


### PR DESCRIPTION
Fixes bad codegen on the icelake path. I'm pretty sure there's a better solution but debugging this without hardware that can actually run these instructions is way too sadistic.

I'll revisit this later once I get a tigerlake laptop.

Fixes: https://github.com/RPCS3/rpcs3/issues/9254