### PR TITLE
memory viewer: Implement SPU mode, fix address GOTO

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -320,22 +320,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 		case Qt::Key_M:
 		{
 			// Memory viewer
-
-			u32 addr = pc;
-
-			if (auto spu = static_cast<const spu_thread*>(cpu->id_type() == 2 ? cpu.get() : nullptr))
-			{
-				if (spu->get_type() != spu_type::threaded)
-				{
-					addr += RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * spu->index;
-				}
-				else
-				{
-					addr += SPU_FAKE_BASE_ADDR + SPU_LS_SIZE * (spu->id & 0xffffff);
-				}
-			}
-
-			auto mvp = new memory_viewer_panel(this, addr);
+			auto mvp = new memory_viewer_panel(this, pc, cpu);
 			mvp->show();
 			return;
 		}

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -10,12 +10,19 @@
 
 #include <string>
 
+class cpu_thread;
+
+namespace utils
+{
+	class shm;
+}
+
 class memory_viewer_panel : public QDialog
 {
 	Q_OBJECT
 
 public:
-	memory_viewer_panel(QWidget* parent, u32 addr = 0);
+	memory_viewer_panel(QWidget* parent, u32 addr = 0, const std::shared_ptr<cpu_thread>& cpu = nullptr);
 	~memory_viewer_panel();
 
 	enum class color_format : int
@@ -44,11 +51,22 @@ private:
 
 	QFontMetrics* m_fontMetrics;
 
+	enum class thread_type
+	{
+		ppu,
+		spu,
+		//rsx
+	};
+
+	const thread_type m_type;
+	const std::shared_ptr<utils::shm> m_spu_shm;
+	const u32 m_addr_mask;
+
 	std::string getHeaderAtAddr(u32 addr);
 	void scroll(s32 steps);
 	void SetPC(const uint pc);
 
 	virtual void ShowMemory();
 
-	static void ShowImage(QWidget* parent, u32 addr, color_format format, u32 sizex, u32 sizey, bool flipv);
+	void ShowImage(QWidget* parent, u32 addr, color_format format, u32 sizex, u32 sizey, bool flipv);
 };


### PR DESCRIPTION
### Features:
* 0..SPU_LS_MAX_ADDRESS addressing with wraparound as the main debugger. (instead of the ugly 0xe8000000 sfuff)
* Title of viewer window contains SPU name.
* Memory of the SPU is valid and is saved even after the SPU thread has been destroyed.
* Press M while selecting an SPU thread to pop up the "SPU" type memory viewer.
* SPU regexp validator as the main debugger has been used for address typing.

### Bugfixes
* Typing an address didn't work well.
* Address was not always aligned in cases when changing Words count.

https://user-images.githubusercontent.com/18193363/103304516-80c18e00-4a11-11eb-9056-c364dd64111b.png
