### PR TITLE
Build: Update required clang/Qt version

### DIFF
--- a/3rdparty/qt5.cmake
+++ b/3rdparty/qt5.cmake
@@ -1,11 +1,13 @@
 add_library(3rdparty_qt5 INTERFACE)
 
-find_package(Qt5 5.14 CONFIG COMPONENTS Widgets Concurrent)
+set(QT_MIN_VER 5.15.2)
+
+find_package(Qt5 ${QT_MIN_VER} CONFIG COMPONENTS Widgets Concurrent)
 if(WIN32)
-	find_package(Qt5 5.14 COMPONENTS WinExtras REQUIRED)
+	find_package(Qt5 ${QT_MIN_VER} COMPONENTS WinExtras REQUIRED)
 	target_link_libraries(3rdparty_qt5 INTERFACE Qt5::Widgets Qt5::WinExtras Qt5::Concurrent)
 else()
-	find_package(Qt5 5.14 COMPONENTS DBus Gui)
+	find_package(Qt5 ${QT_MIN_VER} COMPONENTS DBus Gui)
 	if(Qt5DBus_FOUND)
 		target_link_libraries(3rdparty_qt5 INTERFACE Qt5::Widgets Qt5::DBus Qt5::Concurrent)
 		target_compile_definitions(3rdparty_qt5 INTERFACE -DHAVE_QTDBUS)
@@ -16,16 +18,12 @@ else()
 endif()
 
 if(NOT Qt5Widgets_FOUND)
-	if(Qt5Widgets_VERSION VERSION_LESS 5.14.0)
-		message("Minimum supported Qt5 version is 5.14.0! You have version ${Qt5Widgets_VERSION} installed, please upgrade!")
+	if(Qt5Widgets_VERSION VERSION_LESS ${QT_MIN_VER})
+		message("Minimum supported Qt5 version is ${QT_MIN_VER}! You have version ${Qt5Widgets_VERSION} installed, please upgrade!")
 		if(CMAKE_SYSTEM MATCHES "Linux")
 			message(FATAL_ERROR "Most distros do not provide an up-to-date version of Qt.
 If you're on Ubuntu or Linux Mint, there are PPAs you can use to install one of the latest qt5 versions.
-		https://launchpad.net/~beineri/+archive/ubuntu/opt-qt-5.14.1-bionic
-		https://launchpad.net/~beineri/+archive/ubuntu/opt-qt-5.14.1-xenial
-just make sure to run
-	source /opt/qt514/bin/qt514-env.sh
-before re-running cmake")
+Find the correct ppa at https://launchpad.net/~beineri and follow the instructions.")
 		elseif(WIN32)
 			message(FATAL_ERROR "You can download the latest version of Qt5 here: https://www.qt.io/download-open-source/")
 		else()
@@ -35,7 +33,7 @@ before re-running cmake")
 
 	message("CMake was unable to find Qt5!")
 	if(WIN32)
-		message(FATAL_ERROR "Make sure the QTDIR env variable has been set properly. (for example C:\\Qt\\5.14.1\\msvc2017_64\\)
+		message(FATAL_ERROR "Make sure the QTDIR env variable has been set properly. (for example C:\\Qt\\${QT_MIN_VER}\\msvc2019_64\\)
 You can also try setting the Qt5_DIR preprocessor definiton.")
 	elseif(CMAKE_SYSTEM MATCHES "Linux")
 		message(FATAL_ERROR "Make sure to install your distro's qt5 package!")

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,7 +19,7 @@ Other instructions may be found [here](https://wiki.rpcs3.net/index.php?title=Bu
 
 These are the essentials tools to build RPCS3 on Linux. Some of them can be installed through your favorite package manager.
 
-* Clang 9+ or GCC 9+
+* Clang 11+ or GCC 9+
 * [CMake 3.14.1+](https://www.cmake.org/download/)
 * [Qt 5.15.2](https://www.qt.io/download-qt-installer)
 * [Vulkan SDK 1.1.126+](https://vulkan.lunarg.com/sdk/home) (See "Install the SDK" [here](https://vulkan.lunarg.com/doc/sdk/latest/linux/getting_started.html))


### PR DESCRIPTION
Seems this got missed when updating the build guide and whatnot. This actually threw me off as I tried to build in WSL (Ubuntu 20.04), and I got some Qt errors, because I didn't realize the packaged version was too old (it didn't use to be :p).

So this should help people be aware of when they need the PPA better.