### PR TITLE
rsx: Attach RSX state to RSX instance

### DIFF
--- a/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.cpp
@@ -11,6 +11,18 @@
 
 namespace rsx
 {
+	void frame_capture_data::reset()
+	{
+		magic = FRAME_CAPTURE_MAGIC;
+		version = FRAME_CAPTURE_VERSION;
+		tile_map.clear();
+		memory_map.clear();
+		replay_commands.clear();
+
+		const auto rsx = rsx::get_current_renderer();
+		method_regs = rsx ? rsx->method_regs : rsx::rsx_state{};
+	}
+
 	be_t<u32> rsx_replay_thread::allocate_context()
 	{
 		u32 buffer_size = 4;
@@ -177,7 +189,7 @@ namespace rsx
 		while (!Emu.IsStopped())
 		{
 			// Load registers while the RSX is still idle
-			method_registers = frame->reg_state;
+			get_current_renderer()->method_regs = frame->method_regs;
 			atomic_fence_seq_cst();
 
 			// start up fifo buffer by dumping the put ptr to first stop

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.h
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.h
@@ -154,7 +154,7 @@ namespace rsx
 		// actual command queue to hold everything above
 		std::vector<replay_command> replay_commands;
 		// Initial registers state at the beginning of the capture
-		rsx::rsx_state reg_state;
+		rsx::rsx_state method_regs;
 
 		template<typename Archive>
 		void serialize(Archive & ar)
@@ -166,18 +166,10 @@ namespace rsx
 			ar(memory_data_map);
 			ar(display_buffers_map);
 			ar(replay_commands);
-			ar(reg_state);
+			ar(method_regs);
 		}
 
-		void reset()
-		{
-			magic = FRAME_CAPTURE_MAGIC;
-			version = FRAME_CAPTURE_VERSION;
-			tile_map.clear();
-			memory_map.clear();
-			replay_commands.clear();
-			reg_state = method_registers;
-		}
+		void reset();
 	};
 
 

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -139,12 +139,12 @@ void GLGSRender::update_draw_state()
 
 	for (int index = 0; index < m_rtts.get_color_surface_count(); ++index)
 	{
-		bool color_mask_b = rsx::method_registers.color_mask_b(index);
-		bool color_mask_g = rsx::method_registers.color_mask_g(index);
-		bool color_mask_r = rsx::method_registers.color_mask_r(index);
-		bool color_mask_a = rsx::method_registers.color_mask_a(index);
+		bool color_mask_b = method_regs.color_mask_b(index);
+		bool color_mask_g = method_regs.color_mask_g(index);
+		bool color_mask_r = method_regs.color_mask_r(index);
+		bool color_mask_a = method_regs.color_mask_a(index);
 
-		if (rsx::method_registers.surface_color() == rsx::surface_color_format::g8b8)
+		if (method_regs.surface_color() == rsx::surface_color_format::g8b8)
 		{
 			//Map GB components onto RG
 			rsx::get_g8b8_r8g8_colormask(color_mask_r, color_mask_g, color_mask_b, color_mask_a);
@@ -153,69 +153,69 @@ void GLGSRender::update_draw_state()
 		gl_state.color_maski(index, color_mask_r, color_mask_g, color_mask_b, color_mask_a);
 	}
 
-	gl_state.depth_mask(rsx::method_registers.depth_write_enabled());
-	gl_state.stencil_mask(rsx::method_registers.stencil_mask());
+	gl_state.depth_mask(method_regs.depth_write_enabled());
+	gl_state.stencil_mask(method_regs.stencil_mask());
 
-	gl_state.enable(rsx::method_registers.depth_clamp_enabled() || !rsx::method_registers.depth_clip_enabled(), GL_DEPTH_CLAMP);
+	gl_state.enable(method_regs.depth_clamp_enabled() || !method_regs.depth_clip_enabled(), GL_DEPTH_CLAMP);
 
-	if (gl_state.enable(rsx::method_registers.depth_test_enabled(), GL_DEPTH_TEST))
+	if (gl_state.enable(method_regs.depth_test_enabled(), GL_DEPTH_TEST))
 	{
-		gl_state.depth_func(gl::comparison_op(rsx::method_registers.depth_func()));
+		gl_state.depth_func(gl::comparison_op(method_regs.depth_func()));
 	}
 
-	if (gl::get_driver_caps().EXT_depth_bounds_test && (gl_state.enable(rsx::method_registers.depth_bounds_test_enabled(), GL_DEPTH_BOUNDS_TEST_EXT)))
+	if (gl::get_driver_caps().EXT_depth_bounds_test && (gl_state.enable(method_regs.depth_bounds_test_enabled(), GL_DEPTH_BOUNDS_TEST_EXT)))
 	{
-		gl_state.depth_bounds(rsx::method_registers.depth_bounds_min(), rsx::method_registers.depth_bounds_max());
+		gl_state.depth_bounds(method_regs.depth_bounds_min(), method_regs.depth_bounds_max());
 	}
 
 	if (gl::get_driver_caps().NV_depth_buffer_float_supported)
 	{
-		gl_state.depth_range(rsx::method_registers.clip_min(), rsx::method_registers.clip_max());
+		gl_state.depth_range(method_regs.clip_min(), method_regs.clip_max());
 	}
 
-	gl_state.enable(rsx::method_registers.dither_enabled(), GL_DITHER);
+	gl_state.enable(method_regs.dither_enabled(), GL_DITHER);
 
-	if (gl_state.enable(rsx::method_registers.stencil_test_enabled(), GL_STENCIL_TEST))
+	if (gl_state.enable(method_regs.stencil_test_enabled(), GL_STENCIL_TEST))
 	{
-		glStencilFunc(gl::comparison_op(rsx::method_registers.stencil_func()),
-			rsx::method_registers.stencil_func_ref(),
-			rsx::method_registers.stencil_func_mask());
+		glStencilFunc(gl::comparison_op(method_regs.stencil_func()),
+			method_regs.stencil_func_ref(),
+			method_regs.stencil_func_mask());
 
-		glStencilOp(gl::stencil_op(rsx::method_registers.stencil_op_fail()), gl::stencil_op(rsx::method_registers.stencil_op_zfail()),
-			gl::stencil_op(rsx::method_registers.stencil_op_zpass()));
+		glStencilOp(gl::stencil_op(method_regs.stencil_op_fail()), gl::stencil_op(method_regs.stencil_op_zfail()),
+			gl::stencil_op(method_regs.stencil_op_zpass()));
 
-		if (rsx::method_registers.two_sided_stencil_test_enabled())
+		if (method_regs.two_sided_stencil_test_enabled())
 		{
-			glStencilMaskSeparate(GL_BACK, rsx::method_registers.back_stencil_mask());
+			glStencilMaskSeparate(GL_BACK, method_regs.back_stencil_mask());
 
-			glStencilFuncSeparate(GL_BACK, gl::comparison_op(rsx::method_registers.back_stencil_func()),
-				rsx::method_registers.back_stencil_func_ref(), rsx::method_registers.back_stencil_func_mask());
+			glStencilFuncSeparate(GL_BACK, gl::comparison_op(method_regs.back_stencil_func()),
+				method_regs.back_stencil_func_ref(), method_regs.back_stencil_func_mask());
 
-			glStencilOpSeparate(GL_BACK, gl::stencil_op(rsx::method_registers.back_stencil_op_fail()),
-				gl::stencil_op(rsx::method_registers.back_stencil_op_zfail()), gl::stencil_op(rsx::method_registers.back_stencil_op_zpass()));
+			glStencilOpSeparate(GL_BACK, gl::stencil_op(method_regs.back_stencil_op_fail()),
+				gl::stencil_op(method_regs.back_stencil_op_zfail()), gl::stencil_op(method_regs.back_stencil_op_zpass()));
 		}
 	}
 
 	bool mrt_blend_enabled[] =
 	{
-		rsx::method_registers.blend_enabled(),
-		rsx::method_registers.blend_enabled_surface_1(),
-		rsx::method_registers.blend_enabled_surface_2(),
-		rsx::method_registers.blend_enabled_surface_3()
+		method_regs.blend_enabled(),
+		method_regs.blend_enabled_surface_1(),
+		method_regs.blend_enabled_surface_2(),
+		method_regs.blend_enabled_surface_3()
 	};
 
 	if (mrt_blend_enabled[0] || mrt_blend_enabled[1] || mrt_blend_enabled[2] || mrt_blend_enabled[3])
 	{
-		glBlendFuncSeparate(gl::blend_factor(rsx::method_registers.blend_func_sfactor_rgb()),
-			gl::blend_factor(rsx::method_registers.blend_func_dfactor_rgb()),
-			gl::blend_factor(rsx::method_registers.blend_func_sfactor_a()),
-			gl::blend_factor(rsx::method_registers.blend_func_dfactor_a()));
+		glBlendFuncSeparate(gl::blend_factor(method_regs.blend_func_sfactor_rgb()),
+			gl::blend_factor(method_regs.blend_func_dfactor_rgb()),
+			gl::blend_factor(method_regs.blend_func_sfactor_a()),
+			gl::blend_factor(method_regs.blend_func_dfactor_a()));
 
-		auto blend_colors = rsx::get_constant_blend_colors();
+		auto blend_colors = method_regs.get_constant_blend_colors();
 		glBlendColor(blend_colors[0], blend_colors[1], blend_colors[2], blend_colors[3]);
 
-		glBlendEquationSeparate(gl::blend_equation(rsx::method_registers.blend_equation_rgb()),
-			gl::blend_equation(rsx::method_registers.blend_equation_a()));
+		glBlendEquationSeparate(gl::blend_equation(method_regs.blend_equation_rgb()),
+			gl::blend_equation(method_regs.blend_equation_a()));
 	}
 
 	gl_state.enablei(mrt_blend_enabled[0], GL_BLEND, 0);
@@ -223,34 +223,34 @@ void GLGSRender::update_draw_state()
 	gl_state.enablei(mrt_blend_enabled[2], GL_BLEND, 2);
 	gl_state.enablei(mrt_blend_enabled[3], GL_BLEND, 3);
 
-	if (gl_state.enable(rsx::method_registers.logic_op_enabled(), GL_COLOR_LOGIC_OP))
+	if (gl_state.enable(method_regs.logic_op_enabled(), GL_COLOR_LOGIC_OP))
 	{
-		gl_state.logic_op(gl::logic_op(rsx::method_registers.logic_operation()));
+		gl_state.logic_op(gl::logic_op(method_regs.logic_operation()));
 	}
 
-	gl_state.line_width(rsx::method_registers.line_width());
-	gl_state.enable(rsx::method_registers.line_smooth_enabled(), GL_LINE_SMOOTH);
+	gl_state.line_width(method_regs.line_width());
+	gl_state.enable(method_regs.line_smooth_enabled(), GL_LINE_SMOOTH);
 
-	gl_state.enable(rsx::method_registers.poly_offset_point_enabled(), GL_POLYGON_OFFSET_POINT);
-	gl_state.enable(rsx::method_registers.poly_offset_line_enabled(), GL_POLYGON_OFFSET_LINE);
-	gl_state.enable(rsx::method_registers.poly_offset_fill_enabled(), GL_POLYGON_OFFSET_FILL);
+	gl_state.enable(method_regs.poly_offset_point_enabled(), GL_POLYGON_OFFSET_POINT);
+	gl_state.enable(method_regs.poly_offset_line_enabled(), GL_POLYGON_OFFSET_LINE);
+	gl_state.enable(method_regs.poly_offset_fill_enabled(), GL_POLYGON_OFFSET_FILL);
 
 	//offset_bias is the constant factor, multiplied by the implementation factor R
 	//offset_scale is the slope factor, multiplied by the triangle slope factor M
-	gl_state.polygon_offset(rsx::method_registers.poly_offset_scale(), rsx::method_registers.poly_offset_bias());
+	gl_state.polygon_offset(method_regs.poly_offset_scale(), method_regs.poly_offset_bias());
 
-	if (gl_state.enable(rsx::method_registers.cull_face_enabled(), GL_CULL_FACE))
+	if (gl_state.enable(method_regs.cull_face_enabled(), GL_CULL_FACE))
 	{
-		gl_state.cull_face(gl::cull_face(rsx::method_registers.cull_face_mode()));
+		gl_state.cull_face(gl::cull_face(method_regs.cull_face_mode()));
 	}
 
-	gl_state.front_face(gl::front_face(rsx::method_registers.front_face_mode()));
+	gl_state.front_face(gl::front_face(method_regs.front_face_mode()));
 
 	// Sample control
 	// TODO: MinSampleShading
-	//gl_state.enable(rsx::method_registers.msaa_enabled(), GL_MULTISAMPLE);
-	//gl_state.enable(rsx::method_registers.msaa_alpha_to_coverage_enabled(), GL_SAMPLE_ALPHA_TO_COVERAGE);
-	//gl_state.enable(rsx::method_registers.msaa_alpha_to_one_enabled(), GL_SAMPLE_ALPHA_TO_ONE);
+	//gl_state.enable(method_regs.msaa_enabled(), GL_MULTISAMPLE);
+	//gl_state.enable(method_regs.msaa_alpha_to_coverage_enabled(), GL_SAMPLE_ALPHA_TO_COVERAGE);
+	//gl_state.enable(method_regs.msaa_alpha_to_one_enabled(), GL_SAMPLE_ALPHA_TO_ONE);
 
 	//TODO
 	//NV4097_SET_ANISO_SPREAD
@@ -287,12 +287,12 @@ void GLGSRender::load_texture_env()
 		auto sampler_state = static_cast<gl::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
 		if (m_samplers_dirty || m_textures_dirty[i] || m_gl_texture_cache.test_if_descriptor_expired(cmd, m_rtts, sampler_state))
 		{
-			if (rsx::method_registers.fragment_textures[i].enabled())
+			if (method_regs.fragment_textures[i].enabled())
 			{
-				*sampler_state = m_gl_texture_cache.upload_texture(cmd, rsx::method_registers.fragment_textures[i], m_rtts);
+				*sampler_state = m_gl_texture_cache.upload_texture(cmd, method_regs.fragment_textures[i], m_rtts);
 
 				if (m_textures_dirty[i])
-					m_fs_sampler_states[i].apply(rsx::method_registers.fragment_textures[i], fs_sampler_state[i].get());
+					m_fs_sampler_states[i].apply(method_regs.fragment_textures[i], fs_sampler_state[i].get());
 			}
 			else
 			{
@@ -314,12 +314,12 @@ void GLGSRender::load_texture_env()
 		auto sampler_state = static_cast<gl::texture_cache::sampled_image_descriptor*>(vs_sampler_state[i].get());
 		if (m_samplers_dirty || m_vertex_textures_dirty[i] || m_gl_texture_cache.test_if_descriptor_expired(cmd, m_rtts, sampler_state))
 		{
-			if (rsx::method_registers.vertex_textures[i].enabled())
+			if (method_regs.vertex_textures[i].enabled())
 			{
-				*sampler_state = m_gl_texture_cache.upload_texture(cmd, rsx::method_registers.vertex_textures[i], m_rtts);
+				*sampler_state = m_gl_texture_cache.upload_texture(cmd, method_regs.vertex_textures[i], m_rtts);
 
 				if (m_vertex_textures_dirty[i])
-					m_vs_sampler_states[i].apply(rsx::method_registers.vertex_textures[i], vs_sampler_state[i].get());
+					m_vs_sampler_states[i].apply(method_regs.vertex_textures[i], vs_sampler_state[i].get());
 			}
 			else
 				*sampler_state = {};
@@ -346,7 +346,7 @@ void GLGSRender::bind_texture_env()
 		gl::texture_view* view = nullptr;
 		auto sampler_state = static_cast<gl::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
 
-		if (rsx::method_registers.fragment_textures[i].enabled() &&
+		if (method_regs.fragment_textures[i].enabled() &&
 			sampler_state->validate())
 		{
 			if (view = sampler_state->image_handle; !view) [[unlikely]]
@@ -389,7 +389,7 @@ void GLGSRender::bind_texture_env()
 		auto sampler_state = static_cast<gl::texture_cache::sampled_image_descriptor*>(vs_sampler_state[i].get());
 		_SelectTexture(GL_VERTEX_TEXTURES_START + i);
 
-		if (rsx::method_registers.vertex_textures[i].enabled() &&
+		if (method_regs.vertex_textures[i].enabled() &&
 			sampler_state->validate())
 		{
 			if (sampler_state->image_handle) [[likely]]
@@ -432,22 +432,22 @@ void GLGSRender::emit_geometry(u32 sub_index)
 			// Execute remainining pipeline barriers with NOP draw
 			do
 			{
-				rsx::method_registers.current_draw_clause.execute_pipeline_dependencies();
+				method_regs.current_draw_clause.execute_pipeline_dependencies();
 			}
-			while (rsx::method_registers.current_draw_clause.next());
+			while (method_regs.current_draw_clause.next());
 
-			rsx::method_registers.current_draw_clause.end();
+			method_regs.current_draw_clause.end();
 			return;
 		}
 	}
 	else
 	{
-		if (rsx::method_registers.current_draw_clause.execute_pipeline_dependencies() & rsx::vertex_base_changed)
+		if (method_regs.current_draw_clause.execute_pipeline_dependencies() & rsx::vertex_base_changed)
 		{
 			// Rebase vertex bases instead of
 			for (auto &info : m_vertex_layout.interleaved_blocks)
 			{
-				const auto vertex_base_offset = rsx::method_registers.vertex_data_base_offset();
+				const auto vertex_base_offset = method_regs.vertex_data_base_offset();
 				info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info.base_offset), info.memory_location);
 			}
 		}
@@ -456,7 +456,7 @@ void GLGSRender::emit_geometry(u32 sub_index)
 	if (manually_flush_ring_buffers)
 	{
 		//Use approximations to reserve space. This path is mostly for debug purposes anyway
-		u32 approx_vertex_count = rsx::method_registers.current_draw_clause.get_elements_count();
+		u32 approx_vertex_count = method_regs.current_draw_clause.get_elements_count();
 		u32 approx_working_buffer_size = approx_vertex_count * 256;
 
 		//Allocate 256K heap if we have no approximation at this time (inlined array)
@@ -474,18 +474,18 @@ void GLGSRender::emit_geometry(u32 sub_index)
 		return;
 	}
 
-	const GLenum draw_mode = gl::draw_mode(rsx::method_registers.current_draw_clause.primitive);
+	const GLenum draw_mode = gl::draw_mode(method_regs.current_draw_clause.primitive);
 	update_vertex_env(upload_info);
 
 	if (!upload_info.index_info)
 	{
-		if (rsx::method_registers.current_draw_clause.is_single_draw())
+		if (method_regs.current_draw_clause.is_single_draw())
 		{
 			glDrawArrays(draw_mode, 0, upload_info.vertex_draw_count);
 		}
 		else
 		{
-			const auto subranges = rsx::method_registers.current_draw_clause.get_subranges();
+			const auto subranges = method_regs.current_draw_clause.get_subranges();
 			const auto draw_count = subranges.size();
 			const auto driver_caps = gl::get_driver_caps();
 			bool use_draw_arrays_fallback = false;
@@ -538,22 +538,22 @@ void GLGSRender::emit_geometry(u32 sub_index)
 	{
 		const GLenum index_type = std::get<0>(*upload_info.index_info);
 		const u32 index_offset = std::get<1>(*upload_info.index_info);
-		const bool restarts_valid = gl::is_primitive_native(rsx::method_registers.current_draw_clause.primitive) && !rsx::method_registers.current_draw_clause.is_disjoint_primitive;
+		const bool restarts_valid = gl::is_primitive_native(method_regs.current_draw_clause.primitive) && !method_regs.current_draw_clause.is_disjoint_primitive;
 
-		if (gl_state.enable(restarts_valid && rsx::method_registers.restart_index_enabled(), GL_PRIMITIVE_RESTART))
+		if (gl_state.enable(restarts_valid && method_regs.restart_index_enabled(), GL_PRIMITIVE_RESTART))
 		{
 			glPrimitiveRestartIndex((index_type == GL_UNSIGNED_SHORT) ? 0xffff : 0xffffffff);
 		}
 
 		m_index_ring_buffer->bind();
 
-		if (rsx::method_registers.current_draw_clause.is_single_draw())
+		if (method_regs.current_draw_clause.is_single_draw())
 		{
 			glDrawElements(draw_mode, upload_info.vertex_draw_count, index_type, reinterpret_cast<GLvoid*>(u64{index_offset}));
 		}
 		else
 		{
-			const auto subranges = rsx::method_registers.current_draw_clause.get_subranges();
+			const auto subranges = method_regs.current_draw_clause.get_subranges();
 			const auto draw_count = subranges.size();
 			const u32 type_scale = (index_type == GL_UNSIGNED_SHORT) ? 1 : 2;
 			uptr index_ptr = index_offset;
@@ -565,7 +565,7 @@ void GLGSRender::emit_geometry(u32 sub_index)
 
 			for (const auto &range : subranges)
 			{
-				const auto index_size = get_index_count(rsx::method_registers.current_draw_clause.primitive, range.count);
+				const auto index_size = get_index_count(method_regs.current_draw_clause.primitive, range.count);
 				counts[dst_index] = index_size;
 				offsets[dst_index++] = reinterpret_cast<const GLvoid*>(index_ptr);
 
@@ -651,13 +651,13 @@ void GLGSRender::end()
 		m_program->validate();
 	}
 
-	rsx::method_registers.current_draw_clause.begin();
+	method_regs.current_draw_clause.begin();
 	u32 subdraw = 0u;
 	do
 	{
 		emit_geometry(subdraw++);
 	}
-	while (rsx::method_registers.current_draw_clause.next());
+	while (method_regs.current_draw_clause.next());
 
 	m_rtts.on_write(m_framebuffer_layout.color_write_enabled.data(), m_framebuffer_layout.zeta_write_enabled);
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -99,39 +99,6 @@ u8 rsx::internals::get_pixel_size(rsx::surface_depth_format format)
 	fmt::throw_exception("Unknown depth format");
 }
 
-namespace
-{
-	std::array<u32, 4> get_offsets()
-	{
-		return{
-			rsx::method_registers.surface_a_offset(),
-			rsx::method_registers.surface_b_offset(),
-			rsx::method_registers.surface_c_offset(),
-			rsx::method_registers.surface_d_offset(),
-		};
-	}
-
-	std::array<u32, 4> get_locations()
-	{
-		return{
-			rsx::method_registers.surface_a_dma(),
-			rsx::method_registers.surface_b_dma(),
-			rsx::method_registers.surface_c_dma(),
-			rsx::method_registers.surface_d_dma(),
-		};
-	}
-
-	std::array<u32, 4> get_pitchs()
-	{
-		return{
-			rsx::method_registers.surface_a_pitch(),
-			rsx::method_registers.surface_b_pitch(),
-			rsx::method_registers.surface_c_pitch(),
-			rsx::method_registers.surface_d_pitch(),
-		};
-	}
-}
-
 void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool skip_reading)
 {
 	const bool clipped_scissor = (context == rsx::framebuffer_creation_context::context_draw);
@@ -293,7 +260,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool sk
 		}
 	}
 
-	switch (rsx::method_registers.surface_color_target())
+	switch (method_regs.surface_color_target())
 	{
 	case rsx::surface_target::none: break;
 

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -617,7 +617,7 @@ namespace rsx
 			const u32 reg = (command.reg & 0xffff) >> 2;
 			const u32 value = command.value;
 
-			method_registers.decode(reg, value);
+			method_regs.decode(reg, value);
 
 			if (auto method = methods[reg])
 			{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -615,6 +615,8 @@ namespace rsx
 		// FIFO
 	public:
 		std::unique_ptr<FIFO::FIFO_control> fifo_ctrl;
+		rsx_state method_regs;
+
 	protected:
 		FIFO::flattening_helper m_flattener;
 		u32 fifo_ret_addr = RSX_CALL_STACK_EMPTY;
@@ -837,7 +839,7 @@ namespace rsx
 		gsl::span<const gsl::byte> get_raw_index_array(const draw_clause& draw_indexed_clause) const;
 
 		std::variant<draw_array_command, draw_indexed_array_command, draw_inlined_array>
-		get_draw_command(const rsx::rsx_state& state) const;
+		get_draw_command() const;
 
 		/**
 		* Immediate mode rendering requires a temp push buffer to hold attrib values

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -714,7 +714,7 @@ namespace vk
 		}
 		else
 		{
-			if (!rsx::method_registers.depth_write_enabled() && current_layout == new_layout)
+			if (!rsx::get_current_renderer()->method_regs.depth_write_enabled() && current_layout == new_layout)
 			{
 				// Nothing to do
 				return;

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -557,10 +557,12 @@ namespace vk
 		pipeline_key key;
 		key.compiler_opt = 0;
 		key.properties = properties;
+	
+		const auto& method_regs = rsx::get_current_renderer()->method_regs;
 
-		if (rsx::method_registers.alpha_test_enabled()) [[unlikely]]
+		if (method_regs.alpha_test_enabled()) [[unlikely]]
 		{
-			switch (rsx::method_registers.alpha_func())
+			switch (method_regs.alpha_func())
 			{
 			case rsx::comparison_function::always:
 				break;
@@ -587,13 +589,13 @@ namespace vk
 			}
 		}
 
-		if (rsx::method_registers.shader_control() & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_DEPTH_EXPORT;
-		if (rsx::method_registers.shader_control() & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_F32_EXPORT;
-		if (rsx::method_registers.shader_control() & RSX_SHADER_CONTROL_USES_KIL) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_KIL;
+		if (method_regs.shader_control() & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_DEPTH_EXPORT;
+		if (method_regs.shader_control() & CELL_GCM_SHADER_CONTROL_32_BITS_EXPORTS) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_F32_EXPORT;
+		if (method_regs.shader_control() & RSX_SHADER_CONTROL_USES_KIL) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_KIL;
 		if (metadata.referenced_textures_mask) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_TEXTURES;
 		if (metadata.has_branch_instructions) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_FLOW_CTRL;
 		if (metadata.has_pack_instructions) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_PACKING;
-		if (rsx::method_registers.polygon_stipple_enabled()) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_STIPPLING;
+		if (method_regs.polygon_stipple_enabled()) key.compiler_opt |= program_common::interpreter::COMPILER_OPT_ENABLE_STIPPLING;
 
 		if (m_current_key == key) [[likely]]
 		{

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -815,7 +815,7 @@ enum
 };
 
 // GPU Class Handles
-enum
+enum CellGcmLocation : u32
 {
 	CELL_GCM_CONTEXT_DMA_MEMORY_FRAME_BUFFER = 0xFEED0000, // Local memory
 	CELL_GCM_CONTEXT_DMA_MEMORY_HOST_BUFFER = 0xFEED0001, // Main memory

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -563,6 +563,8 @@ namespace rsx
 				);
 		}
 
+		std::array<float, 4> get_constant_blend_colors();
+
 		u16 viewport_width() const
 		{
 			return decode<NV4097_SET_VIEWPORT_HORIZONTAL>().width();
@@ -1727,6 +1729,5 @@ namespace rsx
 		}
 	};
 
-	extern rsx_state method_registers;
 	extern std::array<rsx_method_t, 0x10000 / 4> methods;
 }

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -79,24 +79,24 @@ namespace rsx
 	}
 
 	//Convert decoded integer values for CONSTANT_BLEND_FACTOR into f32 array in 0-1 range
-	std::array<float, 4> get_constant_blend_colors()
+	std::array<float, 4> rsx_state::get_constant_blend_colors()
 	{
 		//TODO: check another color formats (probably all integer formats with > 8-bits wide channels)
-		if (rsx::method_registers.surface_color() == rsx::surface_color_format::w16z16y16x16)
+		if (surface_color() == rsx::surface_color_format::w16z16y16x16)
 		{
-			u16 blend_color_r = rsx::method_registers.blend_color_16b_r();
-			u16 blend_color_g = rsx::method_registers.blend_color_16b_g();
-			u16 blend_color_b = rsx::method_registers.blend_color_16b_b();
-			u16 blend_color_a = rsx::method_registers.blend_color_16b_a();
+			u16 blend_color_r = blend_color_16b_r();
+			u16 blend_color_g = blend_color_16b_g();
+			u16 blend_color_b = blend_color_16b_b();
+			u16 blend_color_a = blend_color_16b_a();
 
 			return { blend_color_r / 65535.f, blend_color_g / 65535.f, blend_color_b / 65535.f, blend_color_a / 65535.f };
 		}
 		else
 		{
-			u8 blend_color_r = rsx::method_registers.blend_color_8b_r();
-			u8 blend_color_g = rsx::method_registers.blend_color_8b_g();
-			u8 blend_color_b = rsx::method_registers.blend_color_8b_b();
-			u8 blend_color_a = rsx::method_registers.blend_color_8b_a();
+			u8 blend_color_r = blend_color_8b_r();
+			u8 blend_color_g = blend_color_8b_g();
+			u8 blend_color_b = blend_color_8b_b();
+			u8 blend_color_a = blend_color_8b_a();
 
 			return { blend_color_r / 255.f, blend_color_g / 255.f, blend_color_b / 255.f, blend_color_a / 255.f };
 		}

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -455,12 +455,8 @@ namespace rsx
 	void clip_image(u8 *dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch);
 	void clip_image_may_overlap(u8 *dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch, u8* buffer);
 
-	std::array<float, 4> get_constant_blend_colors();
-
-	/**
-	 * Shuffle texel layout from xyzw to wzyx
-	 * TODO: Variable src/dst and optional se conversion
-	 */
+	// Shuffle texel layout from xyzw to wzyx
+	// TODO: Variable src/dst and optional se conversion
 	template <typename T>
 	void shuffle_texel_data_wzyx(void* data, u16 row_pitch_in_bytes, u16 row_length_in_texels, u16 num_rows)
 	{


### PR DESCRIPTION
Allow each rsx::thread to have its own registers state, required by VSH/multi-process.