### PR TITLE
VFS: Escape path components which end with space or period

### DIFF
--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -450,6 +450,24 @@ std::string vfs::escape(std::string_view name, bool escape_slash)
 			result += c;
 			break;
 		}
+		case '.':
+		case ' ':
+		{
+			if (!get_char(i + 1))
+			{
+				switch (c)
+				{
+				// Directory name ended with a space or a period, not allowed on Windows.
+				case '.': result += reinterpret_cast<const char*>(u8"．"); break;
+				case ' ': result += reinterpret_cast<const char*>(u8"＿"); break;
+				}
+
+				break;
+			}
+
+			result += c;
+			break;
+		}
 		case char2{u8"！"[0]}:
 		{
 			// Escape full-width characters 0xFF01..0xFF5e with ！ (0xFF01)
@@ -584,6 +602,11 @@ std::string vfs::unescape(std::string_view name)
 
 						i += 3;
 						continue;
+					}
+					case char2{u8"＿"[2]}:
+					{
+						result += ' ';
+						break;
 					}
 					case char2{u8"．"[2]}:
 					{


### PR DESCRIPTION
Directories and files' name is not allowed to end with a space or a period on Windows.