### PR TITLE
rsx: Shaders cache fixes and optimizations

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -733,9 +733,18 @@ namespace fs
 		// Always use write flag, remove read flag
 		if (fs::file f{path, mode + fs::write - fs::read})
 		{
-			// Write args sequentially
-			(f.write(args), ...);
-			return true;
+			if constexpr (sizeof...(args) == 2u && (std::is_pointer_v<Args> || ...))
+			{
+				// Specialization for [const void*, usz] args
+				f.write(args...);
+				return true;
+			}
+			else
+			{
+				// Write args sequentially
+				(f.write(args), ...);
+				return true;
+			}
 		}
 
 		return false;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -596,9 +596,9 @@ namespace rsx
 				return;
 			}
 
-			u32 entry_count = 0;
 			std::vector<fs::dir_entry> entries;
-			for (auto It = root.begin(); It != root.end(); ++It, entry_count++)
+
+			for (auto&& tmp : root)
 			{
 				if (tmp.is_directory)
 					continue;
@@ -606,7 +606,9 @@ namespace rsx
 				entries.push_back(tmp);
 			}
 
-			if ((entry_count = ::size32(entries)) <= 2)
+			u32 entry_count = ::size32(entries);
+
+			if (!entry_count)
 				return;
 
 			root.rewind();


### PR DESCRIPTION
## Bugfixes
* Fixed crash whenever files are missing from the cache.
* Fixed crash whenever files are empty.
* Fixed crash whenever file creation/overwrite of cache files failed. (handled by fs::write_file)
* Fixed crash whenever there are any subdirectories inside the pipelines cache directories. (didnt check whether filesystem entry is a file or directory, treated directories as files)
* Fixed shader cache of 2 or less pipelines.

## Enhancements
* Add some optimizations in compiling shaders. (move constructors, remove redundant copies of buffers, copy elision etc) 
* Overwrite invalid shader cache files if encountered such, restoring proper cache state and allowing the cache to be usable again.
* Make FP shader data loading lock-free.

Fixes #9529 