### PR TITLE
File utils: Allow empty read/writes on null handle

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -272,7 +272,8 @@ namespace fs
 			const char* file = __builtin_FILE(),
 			const char* func = __builtin_FUNCTION()) const
 		{
-			if (!m_file) return (count ? (xnull({line, col, file, func}), 0) : 0);
+			if (!count) return 0;
+			if (!m_file) return xnull({line, col, file, func});
 			return m_file->read(buffer, count);
 		}
 
@@ -283,7 +284,8 @@ namespace fs
 			const char* file = __builtin_FILE(),
 			const char* func = __builtin_FUNCTION()) const
 		{
-			if (!m_file) return (count ? (xnull({line, col, file, func}), 0) : 0);
+			if (!count) return 0;
+			if (!m_file) return xnull({line, col, file, func});
 			return m_file->write(buffer, count);
 		}
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -272,7 +272,7 @@ namespace fs
 			const char* file = __builtin_FILE(),
 			const char* func = __builtin_FUNCTION()) const
 		{
-			if (!m_file) xnull({line, col, file, func});
+			if (!m_file) return (count ? (xnull({line, col, file, func}), 0) : 0);
 			return m_file->read(buffer, count);
 		}
 
@@ -283,7 +283,7 @@ namespace fs
 			const char* file = __builtin_FILE(),
 			const char* func = __builtin_FUNCTION()) const
 		{
-			if (!m_file) xnull({line, col, file, func});
+			if (!m_file) return (count ? (xnull({line, col, file, func}), 0) : 0);
 			return m_file->write(buffer, count);
 		}
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -273,7 +273,7 @@ namespace fs
 			const char* func = __builtin_FUNCTION()) const
 		{
 			if (!count) return 0;
-			if (!m_file) return xnull({line, col, file, func});
+			if (!m_file) xnull({line, col, file, func});
 			return m_file->read(buffer, count);
 		}
 
@@ -285,7 +285,7 @@ namespace fs
 			const char* func = __builtin_FUNCTION()) const
 		{
 			if (!count) return 0;
-			if (!m_file) return xnull({line, col, file, func});
+			if (!m_file) xnull({line, col, file, func});
 			return m_file->write(buffer, count);
 		}
 


### PR DESCRIPTION
Seems fine and could be useful to not die on an operation that is a NO-OP by itself. Any objections?