### PR TITLE
Docs: Update BUILDING.md (Fedora)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -82,7 +82,7 @@ sudo apt-get install cmake
 
 #### Fedora
 
-    sudo dnf install alsa-lib-devel cmake glew glew-devel libatomic libevdev-devel libudev-devel openal-devel qt5-devel qt5-qtbase-private-devel vulkan-devel
+    sudo dnf install alsa-lib-devel cmake glew glew-devel libatomic libevdev-devel libudev-devel openal-devel qt5-qtbase-devel qt5-qtbase-private-devel vulkan-devel
 
 #### OpenSUSE
 


### PR DESCRIPTION
The package `qt5-devel` isn't available, but the `qt5-qtbase-devel` package is :smile: 

Before:
```
[root@workstation ~]# dnf install alsa-lib-devel cmake glew glew-devel libatomic libevdev-devel libudev-devel openal-devel qt5-devel qt5-qtbase-private-devel vulkan-devel
Last metadata expiration check: 0:06:39 ago on Mon 04 Jan 2021 08:00:59 PM CST.

Package alsa-lib-devel-1.2.4-5.fc33.x86_64 is already installed.
Package cmake-3.18.4-2.fc33.x86_64 is already installed.
Package glew-2.1.0-8.fc33.x86_64 is already installed.
Package libatomic-10.2.1-9.fc33.i686 is already installed.
Package libatomic-10.2.1-9.fc33.x86_64 is already installed.
Package systemd-devel-246.7-2.fc33.x86_64 is already installed.
No match for argument: qt5-devel
Package vulkan-loader-devel-1.2.148.1-1.fc33.x86_64 is already installed.
Error: Unable to find a match: qt5-devel
[root@workstation ~]#
```
After:
```
[root@workstation ~]# dnf install alsa-lib-devel cmake glew glew-devel libatomic libevdev-devel libudev-devel openal-devel qt5-qtbase-devel qt5-qtbase-private-devel vulkan-devel
[...]
Installed:
  cups-devel-1:2.3.3op1-1.fc33.x86_64            glew-devel-2.1.0-8.fc33.x86_64  libevdev-devel-1.9.1-3.fc33.x86_64  openal-soft-devel-1.19.1-9.fc33.x86_64 
  qt5-qtbase-private-devel-5.15.2-2.fc33.x86_64 

Complete!
[root@workstation ~]# 
```
Build verified working on Fedora 33 with 187216096d464ff8755f7885c3c109710d549895