### PR TITLE
Utils: Rewrite fmt::split

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -418,32 +418,41 @@ std::string fmt::replace_all(const std::string& src, const std::string& from, co
 	return target;
 }
 
-std::vector<std::string> fmt::split(const std::string& source, std::initializer_list<std::string> separators, bool is_skip_empty)
+std::vector<std::string> fmt::split(std::string_view source, std::initializer_list<std::string_view> separators, bool is_skip_empty)
 {
 	std::vector<std::string> result;
 
-	usz cursor_begin = 0;
-
-	for (usz cursor_end = 0; cursor_end < source.length(); ++cursor_end)
+	for (usz index = 0; index < source.size();)
 	{
+		usz pos = -1;
+		usz sep_size = 0;
+
 		for (auto& separator : separators)
 		{
-			if (strncmp(source.c_str() + cursor_end, separator.c_str(), separator.length()) == 0)
+			if (usz pos0 = source.find(separator, index); pos0 != umax)
 			{
-				std::string candidate = source.substr(cursor_begin, cursor_end - cursor_begin);
-				if (!is_skip_empty || !candidate.empty())
-					result.push_back(candidate);
-
-				cursor_begin = cursor_end + separator.length();
-				cursor_end   = cursor_begin - 1;
+				pos = pos0;
+				sep_size = separator.size();
 				break;
 			}
 		}
-	}
 
-	if (cursor_begin != source.length())
-	{
-		result.push_back(source.substr(cursor_begin));
+		if (!sep_size)
+		{
+			result.emplace_back(&source[index], source.size() - index);
+			return result;
+		}
+
+		std::string_view piece = {&source[index], pos - index};
+
+		index = pos + sep_size;
+
+		if (piece.empty() && is_skip_empty)
+		{
+			continue;
+		}
+
+		result.emplace_back(std::string(piece));
 	}
 
 	return result;

--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -75,7 +75,7 @@ namespace fmt
 		return src;
 	}
 
-	std::vector<std::string> split(const std::string& source, std::initializer_list<std::string> separators, bool is_skip_empty = true);
+	std::vector<std::string> split(std::string_view source, std::initializer_list<std::string_view> separators, bool is_skip_empty = true);
 	std::string trim(const std::string& source, const std::string& values = " \t");
 
 	template <typename T>

--- a/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
@@ -45,7 +45,7 @@ avconf_manager::avconf_manager()
 {
 	u32 curindex = 0;
 
-	auto mic_list = fmt::split(g_cfg.audio.microphone_devices, {"@@@"});
+	auto mic_list = fmt::split(g_cfg.audio.microphone_devices.to_string(), {"@@@"});
 	if (!mic_list.empty())
 	{
 		switch (g_cfg.audio.microphone_type)

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -125,7 +125,7 @@ void mic_context::operator()()
 
 void mic_context::load_config_and_init()
 {
-	auto device_list = fmt::split(g_cfg.audio.microphone_devices, {"@@@"});
+	auto device_list = fmt::split(g_cfg.audio.microphone_devices.to_string(), {"@@@"});
 
 	if (!device_list.empty() && mic_list.empty())
 	{


### PR DESCRIPTION
### Enhancements
* string_view, string_view, string view! (replacing std::string)
* Use c++ functions instead of c functions.
* Make it super fast.