### PR TITLE
Place TTY output in log when stopping emulation

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -249,7 +249,8 @@ void fmt_class_string<SceNpCommunicationId>::format(std::string& out, u64 arg)
 {
 	const auto& id = get_object(arg);
 
-	fmt::append(out, "{ data='%s', term='%s' (0x%x), num=%d, dummy=%d }", id.data, std::isprint(id.data[9]) ? fmt::format("%c", id.data[9]) : "", id.data[9], id.num, id.dummy);
+	const u8 term = id.data[9];
+	fmt::append(out, "{ data='%s', term='%s' (0x%x), num=%d, dummy=%d }", id.data, std::isprint(term) ? fmt::format("%c", term) : "", term, id.num, id.dummy);
 }
 
 // Helpers

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -139,6 +139,8 @@ class Emulator final
 
 	bool m_state_inspection_savestate = false;
 
+	usz m_tty_file_init_pos = umax;
+
 	std::vector<std::shared_ptr<atomic_t<u32>>> m_pause_msgs_refs;
 
 	std::vector<std::function<void()>> deferred_deserialization;


### PR DESCRIPTION
## Enhancements
~~* Parse TTY.log at the end of rpcs3.log anytime emulation is stopped.~~
~~* Add TTY headers between each application boot.~~
~~* Replace std::stringstream with std::string (GUI TTY), faster processing.~~

~~## Bugfixes~~
~~* Use the same file descriptor for GUI TTY and sys_tty. This fixes a situation where buffers are not flushed from the filesystem onto the disk, resulting in missing lines in GUI. TTY.log file itself remains so if rpcs3 crashed the user can still see TTY output.~~


Ouput TTY data of the emulation session when stopping emulation.