### PR TITLE
deprecated

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -139,6 +139,8 @@ struct vdec_context final
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
+		// TODO: This function should be removed at some point, since ffmpeg does it automatically now.
+		//       We'll keep it for compatibility for now until more system ffmpeg libs are up to date.
 		avcodec_register_all();
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -1570,6 +1570,7 @@
     <ClCompile Include="rpcs3qt\config_adapter.cpp" />
     <ClCompile Include="rpcs3qt\curl_handle.cpp" />
     <ClCompile Include="rpcs3qt\custom_dialog.cpp" />
+    <ClCompile Include="rpcs3qt\custom_table_widget_item.cpp" />
     <ClCompile Include="rpcs3qt\debugger_list.cpp" />
     <ClCompile Include="rpcs3qt\downloader.cpp" />
     <ClCompile Include="rpcs3qt\fatal_error_dialog.cpp" />

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -1108,6 +1108,9 @@
     <ClCompile Include="Input\dualsense_pad_handler.cpp">
       <Filter>Io\DualSense</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\custom_table_widget_item.cpp">
+      <Filter>Gui\game list</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRC_FILES
 	config_adapter.cpp
 	curl_handle.cpp
 	custom_dialog.cpp
+	custom_table_widget_item.cpp
 	debugger_frame.cpp
 	debugger_list.cpp
 	downloader.cpp

--- a/rpcs3/rpcs3qt/custom_table_widget_item.cpp
+++ b/rpcs3/rpcs3qt/custom_table_widget_item.cpp
@@ -1,0 +1,72 @@
+#include "custom_table_widget_item.h"
+#include "Utilities/StrFmt.h"
+
+#include <QDateTime>
+
+custom_table_widget_item::custom_table_widget_item(const std::string& text, int sort_role, const QVariant& sort_value)
+    : QTableWidgetItem(QString::fromStdString(text).simplified()) // simplified() forces single line text
+{
+	if (sort_role != Qt::DisplayRole)
+	{
+		setData(sort_role, sort_value, true);
+	}
+}
+
+custom_table_widget_item::custom_table_widget_item(const QString& text, int sort_role, const QVariant& sort_value)
+    : QTableWidgetItem(text.simplified()) // simplified() forces single line text
+{
+	if (sort_role != Qt::DisplayRole)
+	{
+		setData(sort_role, sort_value, true);
+	}
+}
+
+bool custom_table_widget_item::operator<(const QTableWidgetItem& other) const
+{
+	if (m_sort_role == Qt::DisplayRole)
+	{
+		return QTableWidgetItem::operator<(other);
+	}
+
+	const QVariant data_l       = data(m_sort_role);
+	const QVariant data_r       = other.data(m_sort_role);
+	const QVariant::Type type_l = data_l.type();
+	const QVariant::Type type_r = data_r.type();
+
+	assert(type_l == type_r);
+
+	switch (type_l)
+	{
+	case QVariant::Type::Bool:
+	case QVariant::Type::Int:
+		return data_l.toInt() < data_r.toInt();
+	case QVariant::Type::UInt:
+		return data_l.toUInt() < data_r.toUInt();
+	case QVariant::Type::LongLong:
+		return data_l.toLongLong() < data_r.toLongLong();
+	case QVariant::Type::ULongLong:
+		return data_l.toULongLong() < data_r.toULongLong();
+	case QVariant::Type::Double:
+		return data_l.toDouble() < data_r.toDouble();
+	case QVariant::Type::Date:
+		return data_l.toDate() < data_r.toDate();
+	case QVariant::Type::Time:
+		return data_l.toTime() < data_r.toTime();
+	case QVariant::Type::DateTime:
+		return data_l.toDateTime() < data_r.toDateTime();
+	case QVariant::Type::Char:
+	case QVariant::Type::String:
+		return data_l.toString() < data_r.toString();
+	default:
+		fmt::throw_exception("Unimplemented type %s", QVariant::typeToName(type_l));
+	}
+}
+
+void custom_table_widget_item::setData(int role, const QVariant& value, bool assign_sort_role)
+{
+	if (assign_sort_role)
+	{
+		m_sort_role = role;
+	}
+	QTableWidgetItem::setData(role, value);
+}

--- a/rpcs3/rpcs3qt/custom_table_widget_item.h
+++ b/rpcs3/rpcs3qt/custom_table_widget_item.h
@@ -11,41 +11,10 @@ public:
 	using QTableWidgetItem::setData;
 
 	custom_table_widget_item(){}
-	custom_table_widget_item(const std::string& text, int sort_role = Qt::DisplayRole, const QVariant& sort_value = 0)
-	: QTableWidgetItem(QString::fromStdString(text).simplified()) // simplified() forces single line text
-	{
-		if (sort_role != Qt::DisplayRole)
-		{
-			setData(sort_role, sort_value, true);
-		}
-	}
-	custom_table_widget_item(const QString& text, int sort_role = Qt::DisplayRole, const QVariant& sort_value = 0)
-	: QTableWidgetItem(text.simplified()) // simplified() forces single line text
-	{
-		if (sort_role != Qt::DisplayRole)
-		{
-			setData(sort_role, sort_value, true);
-		}
-	}
+	custom_table_widget_item(const std::string& text, int sort_role = Qt::DisplayRole, const QVariant& sort_value = 0);
+	custom_table_widget_item(const QString& text, int sort_role = Qt::DisplayRole, const QVariant& sort_value = 0);
 
-	bool operator <(const QTableWidgetItem& other) const
-	{
-#ifndef _MSC_VER
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-		return data(m_sort_role) < other.data(m_sort_role);
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif
-	}
+	bool operator<(const QTableWidgetItem& other) const;
 
-	void setData(int role, const QVariant& value, bool assign_sort_role)
-	{
-		if (assign_sort_role)
-		{
-			m_sort_role = role;
-		}
-		QTableWidgetItem::setData(role, value);
-	}
+	void setData(int role, const QVariant& value, bool assign_sort_role);
 };

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -12,14 +12,7 @@ class game_list : public QTableWidget
 private:
 	void mousePressEvent(QMouseEvent *event) override
 	{
-#ifndef _MSC_VER
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-		if (!indexAt(event->pos()).isValid() || itemAt(event->pos())->data(Qt::UserRole) < 0)
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif
+		if (!indexAt(event->pos()).isValid() || !itemAt(event->pos())->data(Qt::UserRole).isValid())
 		{
 			clearSelection();
 			setCurrentItem(nullptr); // Needed for currentItemChanged


### PR DESCRIPTION
- Fixes some ugly Qt deprecation warnings by adding ugly code that supposedly is the proper way to do it.
- Removes avcodec_register_all which apparently is not needed anymore in newer ffmpeg versions (probably needs some testing).