### PR TITLE
vm: Remove vm::dealloc_verbose_nothrow

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_io_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_io_.cpp
@@ -19,7 +19,7 @@ struct libio_sys_config
 	{
 		if (stack_addr)
 		{
-			vm::dealloc_verbose_nothrow(stack_addr, vm::stack);
+			ensure(vm::dealloc(stack_addr, vm::stack));
 		}
 	}
 };

--- a/rpcs3/Emu/Cell/Modules/sys_ppu_thread_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_ppu_thread_.cpp
@@ -58,7 +58,7 @@ static void ppu_free_tls(u32 addr)
 	if (addr < s_tls_area || i >= s_tls_max || (addr - s_tls_area) % s_tls_size)
 	{
 		// Alternative TLS allocation detected
-		vm::dealloc_verbose_nothrow(addr, vm::main);
+		ensure(vm::dealloc(addr, vm::main));
 		return;
 	}
 

--- a/rpcs3/Emu/Cell/Modules/sys_spu_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_spu_.cpp
@@ -362,7 +362,7 @@ error_code sys_spu_image_close(ppu_thread& ppu, vm::ptr<sys_spu_image> img)
 	if (img->type == SYS_SPU_IMAGE_TYPE_USER)
 	{
 		//_sys_free(img->segs.addr());
-		vm::dealloc_verbose_nothrow(img->segs.addr(), vm::main);
+		vm::dealloc(img->segs.addr(), vm::main);
 	}
 	else if (img->type == SYS_SPU_IMAGE_TYPE_KERNEL)
 	{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -910,7 +910,7 @@ void ppu_thread::exec_task()
 ppu_thread::~ppu_thread()
 {
 	// Deallocate Stack Area
-	vm::dealloc_verbose_nothrow(stack_addr, vm::stack);
+	ensure(vm::dealloc(stack_addr, vm::stack));
 
 	if (const auto dct = g_fxo->get<lv2_memory_container>())
 	{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1690,7 +1690,7 @@ spu_thread::~spu_thread()
 	if (!group)
 	{
 		// Deallocate local storage (thread groups are handled in sys_spu.cpp)
-		vm::dealloc_verbose_nothrow(RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * index, vm::spu);
+		ensure(vm::dealloc(RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * index, vm::spu));
 	}
 
 	// Release LS mirrors area

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -106,7 +106,8 @@ void sys_spu_image::free()
 {
 	if (type == SYS_SPU_IMAGE_TYPE_KERNEL)
 	{
-		vm::dealloc_verbose_nothrow(segs.addr(), vm::main);
+		// TODO: Remove, should be handled by syscalls
+		ensure(vm::dealloc(segs.addr(), vm::main));
 	}
 }
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -998,51 +998,40 @@ namespace vm
 
 		if (!block)
 		{
-			fmt::throw_exception("Invalid memory location (%u)", +location);
+			vm_log.error("vm::alloc(): Invalid memory location (%u)", +location);
+			ensure(location < memory_location_max); // The only allowed locations to fail
+			return 0;
 		}
 
 		return block->alloc(size, nullptr, align);
 	}
 
-	u32 falloc(u32 addr, u32 size, memory_location_t location)
+	u32 falloc(u32 addr, u32 size, memory_location_t location, const std::shared_ptr<utils::shm>* src)
 	{
 		const auto block = get(location, addr);
 
 		if (!block)
 		{
-			fmt::throw_exception("Invalid memory location (%u, addr=0x%x)", +location, addr);
+			vm_log.error("vm::falloc(): Invalid memory location (%u, addr=0x%x)", +location, addr);
+			ensure(location == any || location < memory_location_max); // The only allowed locations to fail
+			return 0;
 		}
 
-		return block->falloc(addr, size);
+		return block->falloc(addr, size, src);
 	}
 
-	u32 dealloc(u32 addr, memory_location_t location)
+	u32 dealloc(u32 addr, memory_location_t location, const std::shared_ptr<utils::shm>* src)
 	{
 		const auto block = get(location, addr);
 
 		if (!block)
 		{
-			fmt::throw_exception("Invalid memory location (%u, addr=0x%x)", +location, addr);
+			vm_log.error("vm::dealloc(): Invalid memory location (%u, addr=0x%x)", +location, addr);
+			ensure(location == any || location < memory_location_max); // The only allowed locations to fail
+			return 0;
 		}
 
-		return block->dealloc(addr);
-	}
-
-	void dealloc_verbose_nothrow(u32 addr, memory_location_t location) noexcept
-	{
-		const auto block = get(location, addr);
-
-		if (!block)
-		{
-			vm_log.error("vm::dealloc(): invalid memory location (%u, addr=0x%x)\n", +location, addr);
-			return;
-		}
-
-		if (!block->dealloc(addr))
-		{
-			vm_log.error("vm::dealloc(): deallocation failed (addr=0x%x)\n", addr);
-			return;
-		}
+		return block->dealloc(addr, src);
 	}
 
 	void lock_sudo(u32 addr, u32 size)

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -81,13 +81,10 @@ namespace vm
 	u32 alloc(u32 size, memory_location_t location, u32 align = 0x10000);
 
 	// Map memory at specified address (in optionally specified memory location)
-	u32 falloc(u32 addr, u32 size, memory_location_t location = any);
+	u32 falloc(u32 addr, u32 size, memory_location_t location = any, const std::shared_ptr<utils::shm>* src = nullptr);
 
 	// Unmap memory at specified address (in optionally specified memory location), return size
-	u32 dealloc(u32 addr, memory_location_t location = any);
-
-	// dealloc() with no return value and no exceptions
-	void dealloc_verbose_nothrow(u32 addr, memory_location_t location = any) noexcept;
+	u32 dealloc(u32 addr, memory_location_t location = any, const std::shared_ptr<utils::shm>* src = nullptr);
 
 	// utils::memory_lock wrapper for locking sudo memory
 	void lock_sudo(u32 addr, u32 size);

--- a/rpcs3/Emu/Memory/vm_var.h
+++ b/rpcs3/Emu/Memory/vm_var.h
@@ -16,7 +16,7 @@ namespace vm
 
 		static inline void dealloc(u32 addr, u32 size = 0) noexcept
 		{
-			return vm::dealloc_verbose_nothrow(addr, Location);
+			ensure(vm::dealloc(addr, Location));
 		}
 	};
 


### PR DESCRIPTION
This function promotes "silent" failures of deallocation without error checking by the caller, which is a bad practice.

### Enhancements
* Add shm arg for falloc and dealloc functions, both for different reasons: 
dealloc: It may be important sometimes to check if shm matches with the targeted memory to be deallocated, aborting deallocation if not.
falloc: Allow to allocate shm at specific address with this function.
* Do not throw if vm::falloc, vm::dealloc and vm::alloc were called with invalid address but with vm::any location or lower than vm::memory_location_max, this is important for proper error checking by the caller.