### PR TITLE
[+HOTFIX!] memory viewer: Close all instances after emulation exit

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -320,8 +320,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 		case Qt::Key_M:
 		{
 			// Memory viewer
-			auto mvp = new memory_viewer_panel(this, pc, cpu);
-			mvp->show();
+			idm::make<memory_viewer_handle>(this, pc, cpu);
 			return;
 		}
 		case Qt::Key_F10:

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1839,8 +1839,8 @@ void main_window::CreateConnects()
 
 	connect(ui->toolsmemory_viewerAct, &QAction::triggered, [this]
 	{
-		memory_viewer_panel* mvp = new memory_viewer_panel(this);
-		mvp->show();
+		if (!Emu.IsStopped())
+			idm::make<memory_viewer_handle>(this);
 	});
 
 	connect(ui->toolsRsxDebuggerAct, &QAction::triggered, [this]

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -30,7 +30,6 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr, const std::s
 	setWindowTitle(m_type != thread_type::spu ? tr("Memory Viewer") : tr("Memory Viewer Of %0").arg(qstr(cpu->get_name())));
 
 	setObjectName("memory_viewer");
-	setAttribute(Qt::WA_DeleteOnClose);
 	m_colcount = 4;
 	m_rowcount = 16;
 	int pSize = 10;
@@ -260,6 +259,15 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr, const std::s
 	});
 
 	setFixedWidth(sizeHint().width());
+
+	// Show by default
+	show();
+
+	// Expected to be created by IDM, emulation stop will close it
+	connect(this, &memory_viewer_panel::finished, [id = idm::last_id()](int)
+	{
+		idm::remove<memory_viewer_handle>(id);
+	});
 }
 
 memory_viewer_panel::~memory_viewer_panel()

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -70,3 +70,22 @@ private:
 
 	void ShowImage(QWidget* parent, u32 addr, color_format format, u32 sizex, u32 sizey, bool flipv);
 };
+
+// Lifetime management with IDM
+struct memory_viewer_handle
+{
+	static constexpr u32 id_base = 1;
+	static constexpr u32 id_step = 1;
+	static constexpr u32 id_count = 2048;
+
+	template <typename... Args>
+	memory_viewer_handle(Args&&... args)
+		: m_mvp(new memory_viewer_panel(std::forward<Args>(args)...))
+	{
+	}
+
+	~memory_viewer_handle() { m_mvp->deleteLater(); }
+
+private:
+	const std::add_pointer_t<memory_viewer_panel> m_mvp;
+};

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -374,6 +374,10 @@ namespace utils
 				// Mapped already, nothing to do.
 				this->unmap(mapped);
 			}
+			else
+			{
+				ptr = mapped;
+			}
 		}
 
 		return static_cast<u8*>(ptr);


### PR DESCRIPTION
## Enhancmenets
* Close all memory viewer instances after emulation exit.
## Bugfixes
* Hotfix for utils::shm::map_self after #9578 