### PR TITLE
Memory: use MADV_DONTDUMP if available (Linux)

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1659,7 +1659,7 @@ namespace vm
 		g_locations.clear();
 
 		utils::memory_decommit(g_base_addr, 0x200000000);
-		utils::memory_decommit(g_exec_addr, 0x100000000);
+		utils::memory_decommit(g_exec_addr, 0x200000000);
 		utils::memory_decommit(g_stat_addr, 0x100000000);
 	}
 }

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -461,7 +461,7 @@ namespace utils
 			return;
 		}
 #else
-		::mmap(reinterpret_cast<void*>(target), m_size, PROT_NONE, MAP_FIXED | MAP_ANON | MAP_PRIVATE | c_map_noreserve, -1, 0);
+		ensure(::mprotect(target, m_size, PROT_NONE) != -1);
 #endif
 	}
 


### PR DESCRIPTION
Also refactor other madvise() usage.
gcore from working game is now "only" ~15 G uncompressed (~282 M in zip).
Probably there is a room for further optimization.