### PR TITLE
memory viewer: Implement RSX mode

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -43,7 +43,7 @@ namespace rsx
 {
 	std::function<bool(u32 addr, bool is_writing)> g_access_violation_handler;
 
-	u32 get_address(u32 offset, u32 location, u32 line, u32 col, const char* file, const char* func)
+	u32 get_address(u32 offset, u32 location, bool allow_failure, u32 line, u32 col, const char* file, const char* func)
 	{
 		const auto render = get_current_renderer();
 		std::string_view msg;
@@ -148,6 +148,11 @@ namespace rsx
 			msg = "Invalid location!"sv;
 			break;
 		}
+		}
+
+		if (allow_failure)
+		{
+			return 0;
 		}
 
 		fmt::throw_exception("rsx::get_address(offset=0x%x, location=0x%x): %s%s", offset, location, msg, src_loc{line, col, file, func});

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -172,7 +172,7 @@ namespace rsx
 
 	u32 get_vertex_type_size_on_host(vertex_base_type type, u32 size);
 
-	u32 get_address(u32 offset, u32 location,
+	u32 get_address(u32 offset, u32 location, bool allow_failure = false,
 		u32 line = __builtin_LINE(),
 		u32 col = __builtin_COLUMN(),
 		const char* file = __builtin_FILE(),

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -27,6 +27,9 @@ namespace rsx
 
 enum class system_state : u32;
 
+class instruction_editor_dialog;
+class register_editor_dialog;
+
 class debugger_frame : public custom_dock_widget
 {
 	Q_OBJECT
@@ -62,12 +65,15 @@ class debugger_frame : public custom_dock_widget
 
 	breakpoint_list* m_breakpoint_list;
 	breakpoint_handler* m_breakpoint_handler;
-
 	call_stack_list* m_call_stack_list;
+	instruction_editor_dialog* m_inst_editor = nullptr;
+	register_editor_dialog* m_reg_editor = nullptr;
 
 	std::shared_ptr<gui_settings> xgui_settings;
 
 	cpu_thread* get_cpu();
+	std::function<cpu_thread*()> make_check_cpu(cpu_thread* cpu);
+
 public:
 	explicit debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *parent = 0);
 

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.h
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.h
@@ -22,10 +22,10 @@ private:
 	QLineEdit* m_instr;
 	QLabel* m_preview;
 
-public:
-	std::shared_ptr<cpu_thread> m_cpu;
+	const std::function<cpu_thread*()> m_get_cpu;
 
-	instruction_editor_dialog(QWidget *parent, u32 _pc, const std::shared_ptr<cpu_thread>& _cpu, CPUDisAsm* _disasm);
+public:
+	instruction_editor_dialog(QWidget *parent, u32 _pc, CPUDisAsm* _disasm, std::function<cpu_thread*()> func);
 
 	void updatePreview();
 };

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -149,9 +149,8 @@ static QTreeWidgetItem* add_solid_node(QTreeWidget* tree, QTreeWidgetItem *paren
 	return node;
 }
 
-kernel_explorer::kernel_explorer(QWidget* parent, std::function<void()> on_destroy)
+kernel_explorer::kernel_explorer(QWidget* parent)
 	: QDialog(parent)
-	, m_on_destroy(on_destroy)
 {
 	setWindowTitle(tr("Kernel Explorer"));
 	setObjectName("kernel_explorer");
@@ -180,11 +179,6 @@ kernel_explorer::kernel_explorer(QWidget* parent, std::function<void()> on_destr
 	connect(button_refresh, &QAbstractButton::clicked, this, &kernel_explorer::Update);
 
 	Update();
-}
-
-kernel_explorer::~kernel_explorer()
-{
-	m_on_destroy();
 }
 
 void kernel_explorer::Update()

--- a/rpcs3/rpcs3qt/kernel_explorer.h
+++ b/rpcs3/rpcs3qt/kernel_explorer.h
@@ -26,12 +26,10 @@ class kernel_explorer : public QDialog
 	};
 
 public:
-	kernel_explorer(QWidget* parent, std::function<void()> on_destroy);
-	~kernel_explorer();
+	kernel_explorer(QWidget* parent);
 
 private:
 	QTreeWidget* m_tree;
-	std::function<void()> m_on_destroy;
 
 private Q_SLOTS:
 	void Update();

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1827,10 +1827,8 @@ void main_window::CreateConnects()
 	{
 		if (!m_kernel_explorer)
 		{
-			m_kernel_explorer = new kernel_explorer(this, [this]()
-			{
-				m_kernel_explorer = nullptr;
-			});
+			m_kernel_explorer = new kernel_explorer(this);
+			connect(m_kernel_explorer, &QDialog::finished, this, [this]() { m_kernel_explorer = nullptr; });
 		}
 
 		m_kernel_explorer->show();

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -5,6 +5,8 @@
 #include "memory_viewer_panel.h"
 
 #include "Emu/Cell/SPUThread.h"
+#include "Emu/RSX/RSXThread.h"
+#include "Emu/RSX/rsx_utils.h"
 #include "Emu/IdManager.h"
 #include <QVBoxLayout>
 #include <QPushButton>
@@ -20,14 +22,35 @@
 
 constexpr auto qstr = QString::fromStdString;
 
-memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr, const std::shared_ptr<cpu_thread>& cpu)
+memory_viewer_panel::memory_viewer_panel(QWidget* parent, u32 addr, std::function<cpu_thread*()> func)
 	: QDialog(parent)
 	, m_addr(addr)
-	, m_type(!cpu || cpu->id_type() == 1 ? thread_type::ppu : thread_type::spu)
-	, m_spu_shm(m_type == thread_type::spu ? static_cast<spu_thread*>(cpu.get())->shm : nullptr)
+	, m_get_cpu(std::move(func))
+	, m_type([&]()
+	{
+		const auto cpu = m_get_cpu();
+
+		if (!cpu) return thread_type::none;
+		if (cpu->id_type() == 1) return thread_type::ppu;
+		if (cpu->id_type() == 0x55) return thread_type::rsx;
+		if (cpu->id_type() == 2) return thread_type::spu;
+
+		fmt::throw_exception("Unknown CPU type (0x%x)", cpu->id_type());
+	}())
+	, m_rsx(m_type == thread_type::rsx ? static_cast<rsx::thread*>(m_get_cpu()) : nullptr)
+	, m_spu_shm([&]()
+	{
+		const auto cpu = m_get_cpu();
+		return cpu && m_type == thread_type::spu ? static_cast<spu_thread*>(cpu)->shm : nullptr;
+	}())
 	, m_addr_mask(m_type == thread_type::spu ? SPU_LS_SIZE - 1 : ~0)
 {
-	setWindowTitle(m_type != thread_type::spu ? tr("Memory Viewer") : tr("Memory Viewer Of %0").arg(qstr(cpu->get_name())));
+	const auto cpu = m_get_cpu();
+
+	setWindowTitle(
+		cpu && m_type == thread_type::spu ? tr("Memory Viewer Of %0").arg(qstr(cpu->get_name())) :
+		cpu && m_type == thread_type::rsx ? tr("Memory Viewer Of RSX[0x55555555]") :
+		tr("Memory Viewer"));
 
 	setObjectName("memory_viewer");
 	m_colcount = 4;
@@ -361,6 +384,83 @@ std::string memory_viewer_panel::getHeaderAtAddr(u32 addr)
 	return {};
 }
 
+void* memory_viewer_panel::to_ptr(u32 addr, u32 size)
+{
+	if (m_type >= thread_type::spu && !m_get_cpu())
+	{
+		return nullptr;
+	}
+
+	if (!size)
+	{
+		return nullptr;
+	}
+
+	switch (m_type)
+	{
+	case thread_type::none:
+	case thread_type::ppu:
+	{
+		if (vm::check_addr(addr, 0, size))
+		{
+			return vm::get_super_ptr(addr);
+		}
+
+		break;
+	}
+	case thread_type::spu:
+	{
+		if (size <= SPU_LS_SIZE && SPU_LS_SIZE - size >= (addr % SPU_LS_SIZE))
+		{
+			return m_spu_shm->map_self() + (addr % SPU_LS_SIZE);
+		}
+
+		break;
+	}
+	case thread_type::rsx:
+	{
+		u32 final_addr = 0;
+
+		if (size > 0x2000'0000 || rsx::constants::local_mem_base + 0x1000'0000 - size < addr)
+		{
+			break;
+		}
+
+		for (u32 i = addr; i >> 20 <= (addr + size - 1) >> 20; i += 0x100000)
+		{
+			const u32 temp = rsx::get_address(i, i < rsx::constants::local_mem_base ? CELL_GCM_LOCATION_MAIN : CELL_GCM_LOCATION_LOCAL, true);
+
+			if (!temp)
+			{
+				// Failure
+				final_addr = 0;
+				break;
+			}
+			else if (!final_addr)
+			{
+				// First time, save starting address for later checks
+				final_addr = temp;
+			}
+			else if (final_addr != temp - (i - addr))
+			{
+				// TODO: Non-contiguous memory
+				final_addr = 0;
+				break;
+			}
+		}
+
+		if (vm::check_addr(final_addr, 0, size))
+		{
+			return vm::get_super_ptr(final_addr);
+		}
+
+		break;
+	}
+	default: break;
+	}
+
+	return nullptr;
+}
 void memory_viewer_panel::ShowMemory()
 {
 	QString t_mem_addr_str;
@@ -436,9 +536,9 @@ void memory_viewer_panel::ShowMemory()
 
 			u32 addr = (m_addr + (row - spu_passed) * m_colcount * 4 + col * 4) & m_addr_mask;
 
-			if (m_spu_shm || vm::check_addr(addr, 0, 4))
+			if (auto ptr = this->to_ptr(addr))
 			{
-				const be_t<u32> rmem = m_spu_shm ? *reinterpret_cast<be_t<u32>*>(m_spu_shm->map_self() + addr) : *vm::get_super_ptr<u32>(addr);
+				const be_t<u32> rmem = *reinterpret_cast<be_t<u32>*>(ptr);
 				t_mem_hex_str += qstr(fmt::format("%02x %02x %02x %02x",
 					static_cast<u8>(rmem >> 24),
 					static_cast<u8>(rmem >> 16),
@@ -484,26 +584,17 @@ void memory_viewer_panel::SetPC(const uint pc)
 
 void memory_viewer_panel::ShowImage(QWidget* parent, u32 addr, color_format format, u32 width, u32 height, bool flipv)
 {
-	const u64 memsize = 4ull * width * height;
-
-	if (!memsize || memsize > m_addr_mask)
-	{
-		return;
-	}
+	// If exceeds 32-bits it is invalid as well, UINT32_MAX always fails checks
+	const u32 memsize = static_cast<u32>(std::min<u64>(4ull * width * height, UINT32_MAX));
 
 	std::shared_lock rlock(vm::g_mutex);
 
-	if (!m_spu_shm && !vm::check_addr(addr, 0, static_cast<u32>(memsize)))
-	{
-		return;
-	}
+	const auto originalBuffer  = static_cast<u8*>(this->to_ptr(addr, memsize));
+	const auto convertedBuffer = new (std::nothrow) u8[memsize];
 
-	const auto originalBuffer  = m_spu_shm ? (m_spu_shm->map_self() + addr) : vm::get_super_ptr<const u8>(addr);
-	const auto convertedBuffer = new (std::nothrow) u8[static_cast<u32>(memsize)];
-
-	if (!convertedBuffer)
+	if (!originalBuffer || !convertedBuffer)
 	{
-		// OOM, give up
+		// OOM or invalid memory address, give up
 		return;
 	}
 

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -17,12 +17,17 @@ namespace utils
 	class shm;
 }
 
+namespace rsx
+{
+	class thread;
+}
+
 class memory_viewer_panel : public QDialog
 {
 	Q_OBJECT
 
 public:
-	memory_viewer_panel(QWidget* parent, u32 addr = 0, const std::shared_ptr<cpu_thread>& cpu = nullptr);
+	memory_viewer_panel(QWidget* parent, u32 addr = 0, std::function<cpu_thread*()> func = []() -> cpu_thread* { return {}; });
 	~memory_viewer_panel();
 
 	enum class color_format : int
@@ -53,17 +58,21 @@ private:
 
 	enum class thread_type
 	{
+		none,
 		ppu,
 		spu,
-		//rsx
+		rsx,
 	};
 
+	const std::function<cpu_thread*()> m_get_cpu;
 	const thread_type m_type;
+	const std::add_pointer_t<rsx::thread> m_rsx;
 	const std::shared_ptr<utils::shm> m_spu_shm;
 	const u32 m_addr_mask;
 
 	std::string getHeaderAtAddr(u32 addr);
 	void scroll(s32 steps);
+	void* to_ptr(u32 addr, u32 size = 1);
 	void SetPC(const uint pc);
 
 	virtual void ShowMemory();
@@ -84,7 +93,7 @@ struct memory_viewer_handle
 	{
 	}
 
-	~memory_viewer_handle() { m_mvp->deleteLater(); }
+	~memory_viewer_handle() { m_mvp->close(); m_mvp->deleteLater(); }
 
 private:
 	const std::add_pointer_t<memory_viewer_panel> m_mvp;

--- a/rpcs3/rpcs3qt/register_editor_dialog.h
+++ b/rpcs3/rpcs3qt/register_editor_dialog.h
@@ -19,13 +19,13 @@ class register_editor_dialog : public QDialog
 	QComboBox* m_register_combo;
 	QLineEdit* m_value_line;
 
+	const std::function<cpu_thread*()> m_get_cpu;
+
 public:
-	register_editor_dialog(QWidget *parent, const std::shared_ptr<cpu_thread>& _cpu, CPUDisAsm* _disasm);
+	register_editor_dialog(QWidget *parent, CPUDisAsm* _disasm, std::function<cpu_thread*()> func);
 
 private:
 	void OnOkay();
-
-	std::shared_ptr<cpu_thread> m_cpu;
 
 private Q_SLOTS:
 	void updateRegister(int reg);


### PR DESCRIPTION
## Enhancements
* Implement RSX memory manager hook,
* Set the ground for RSX modes of register editor and instruction editor, do not use shared ptrs directly.
* Make register editor and instruction editor modeless to allow to copypaste values from thread context etc in the background. (they close automatically after switching thread)

## Bugfixes
* Fixed crash when viewing an image that was out of bounds of SPU LS.