### PR TITLE
vk: Enable use of a passthrough DMA layer if supported

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -297,6 +297,55 @@ struct copy_rgb655_block_swizzled
 namespace
 {
 	/**
+	 * Generates copy instructions required to build the texture GPU side without actually copying anything.
+	 * Returns a set of addresses and data lengths to use. This can be used to generate a GPU task to avoid CPU doing the heavy lifting.
+	 */
+	std::vector<rsx::memory_transfer_cmd>
+	build_transfer_cmds(const void* src, u16 block_size_in_bytes, u16 width_in_block, u16 row_count, u16 depth, u8 border, u32 dst_pitch_in_block, u32 src_pitch_in_block)
+	{
+		std::vector<rsx::memory_transfer_cmd> result;
+
+		if (src_pitch_in_block == dst_pitch_in_block && !border)
+		{
+			// Fast copy
+			rsx::memory_transfer_cmd cmd;
+			cmd.src = src;
+			cmd.dst = nullptr;
+			cmd.length = src_pitch_in_block * block_size_in_bytes * row_count * depth;
+			return { cmd };
+		}
+
+		const u32 width_in_bytes = width_in_block * block_size_in_bytes;
+		const u32 src_pitch_in_bytes = src_pitch_in_block * block_size_in_bytes;
+		const u32 dst_pitch_in_bytes = dst_pitch_in_block * block_size_in_bytes;
+
+		const u32 h_porch = border * block_size_in_bytes;
+		const u32 v_porch = src_pitch_in_bytes * border;
+
+		auto src_ = static_cast<const char*>(src) + h_porch;
+		auto dst_ = static_cast<const char*>(nullptr);
+
+		for (int layer = 0; layer < depth; ++layer)
+		{
+			// Front
+			src_ += v_porch;
+
+			for (int row = 0; row < row_count; ++row)
+			{
+				rsx::memory_transfer_cmd cmd{ dst_, src_, width_in_bytes };
+				result.push_back(cmd);
+				src_ += src_pitch_in_bytes;
+				dst_ += dst_pitch_in_bytes;
+			}
+
+			// Back
+			src_ += v_porch;
+		}
+
+		return result;
+	}
+
+	/**
 	 * Texture upload template.
 	 *
 	 * Source textures are stored as following (for power of 2 textures):
@@ -533,7 +582,7 @@ namespace rsx
 		return get_subresources_layout_impl(texture);
 	}
 
-	texture_memory_info upload_texture_subresource(gsl::span<std::byte> dst_buffer, const rsx::subresource_layout& src_layout, int format, bool is_swizzled, const texture_uploader_capabilities& caps)
+	texture_memory_info upload_texture_subresource(gsl::span<std::byte> dst_buffer, const rsx::subresource_layout& src_layout, int format, bool is_swizzled, texture_uploader_capabilities& caps)
 	{
 		u16 w = src_layout.width_in_block;
 		u16 h = src_layout.height_in_block;
@@ -644,6 +693,11 @@ namespace rsx
 				// Remove the VTC tiling to support ATI and Vulkan.
 				copy_unmodified_block_vtc::copy_mipmap_level(as_span_workaround<u64>(dst_buffer), as_const_span<const u64>(src_layout.data), w, h, depth, get_row_pitch_in_block<u64>(w, caps.alignment), src_layout.pitch_in_block);
 			}
+			else if (caps.supports_zero_copy)
+			{
+				result.require_upload = true;
+				result.deferred_cmds = build_transfer_cmds(src_layout.data.data(), 8, w, h, depth, 0, get_row_pitch_in_block<u64>(w, caps.alignment), src_layout.pitch_in_block);
+			}
 			else
 			{
 				copy_unmodified_block::copy_mipmap_level(as_span_workaround<u64>(dst_buffer), as_const_span<const u64>(src_layout.data), 1, w, h, depth, 0, get_row_pitch_in_block<u64>(w, caps.alignment), src_layout.pitch_in_block);
@@ -661,6 +715,11 @@ namespace rsx
 				// Remove the VTC tiling to support ATI and Vulkan.
 				copy_unmodified_block_vtc::copy_mipmap_level(as_span_workaround<u128>(dst_buffer), as_const_span<const u128>(src_layout.data), w, h, depth, get_row_pitch_in_block<u128>(w, caps.alignment), src_layout.pitch_in_block);
 			}
+			else if (caps.supports_zero_copy)
+			{
+				result.require_upload = true;
+				result.deferred_cmds = build_transfer_cmds(src_layout.data.data(), 16, w, h, depth, 0, get_row_pitch_in_block<u128>(w, caps.alignment), src_layout.pitch_in_block);
+			}
 			else
 			{
 				copy_unmodified_block::copy_mipmap_level(as_span_workaround<u128>(dst_buffer), as_const_span<const u128>(src_layout.data), 1, w, h, depth, 0, get_row_pitch_in_block<u128>(w, caps.alignment), src_layout.pitch_in_block);
@@ -676,57 +735,73 @@ namespace rsx
 		{
 			if (word_size == 1)
 			{
-				if (is_swizzled)
-					copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u8>(dst_buffer), as_const_span<const u8>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
-				else
-					copy_unmodified_block::copy_mipmap_level(as_span_workaround<u8>(dst_buffer), as_const_span<const u8>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
-			}
-			else if (caps.supports_byteswap)
-			{
-				result.require_swap = true;
-				result.element_size = word_size;
-				result.block_length = words_per_block;
-
-				if (word_size == 2)
+				if (caps.supports_zero_copy)
 				{
-					if (is_swizzled)
-					{
-						if (((word_size * words_per_block) & 3) == 0 && caps.supports_hw_deswizzle)
-						{
-							result.require_deswizzle = true;
-						}
-					}
-
-					if (is_swizzled && !result.require_deswizzle)
-						copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const u16>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
-					else
-						copy_unmodified_block::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const u16>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					result.require_upload = true;
+					result.deferred_cmds = build_transfer_cmds(src_layout.data.data(), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
 				}
-				else if (word_size == 4)
+				else if (is_swizzled)
 				{
-					result.require_deswizzle = (is_swizzled && caps.supports_hw_deswizzle);
-
-					if (is_swizzled && !caps.supports_hw_deswizzle)
-						copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const u32>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
-					else
-						copy_unmodified_block::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const u32>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u8>(dst_buffer), as_const_span<const u8>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
+				}
+				else
+				{
+					copy_unmodified_block::copy_mipmap_level(as_span_workaround<u8>(dst_buffer), as_const_span<const u8>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
 				}
 			}
 			else
 			{
-				if (word_size == 2)
+				bool require_cpu_swizzle = !caps.supports_hw_deswizzle;
+				bool require_cpu_byteswap = !caps.supports_byteswap;
+
+				if (is_swizzled && caps.supports_hw_deswizzle)
 				{
-					if (is_swizzled)
-						copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const be_t<u16>>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
+					if (word_size == 4 || (((word_size * words_per_block) & 3) == 0))
+					{
+						result.require_deswizzle = true;
+					}
 					else
-						copy_unmodified_block::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const be_t<u16>>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					{
+						require_cpu_swizzle = true;
+					}
 				}
-				else if (word_size == 4)
+
+				if (!require_cpu_byteswap && !require_cpu_swizzle)
 				{
-					if (is_swizzled)
-						copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const be_t<u32>>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
-					else
-						copy_unmodified_block::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const be_t<u32>>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					result.require_deswizzle = is_swizzled;
+					result.require_swap = true;
+					result.element_size = word_size;
+
+					if (caps.supports_zero_copy)
+					{
+						result.require_upload = true;
+						result.deferred_cmds = build_transfer_cmds(src_layout.data.data(), word_size * words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					}
+					else if (word_size == 2)
+					{
+						copy_unmodified_block::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const u16>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					}
+					else if (word_size == 4)
+					{
+						copy_unmodified_block::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const u32>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					}
+				}
+				else
+				{
+					if (word_size == 2)
+					{
+						if (is_swizzled)
+							copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const be_t<u16>>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
+						else
+							copy_unmodified_block::copy_mipmap_level(as_span_workaround<u16>(dst_buffer), as_const_span<const be_t<u16>>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					}
+					else if (word_size == 4)
+					{
+						if (is_swizzled)
+							copy_unmodified_block_swizzled::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const be_t<u32>>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block);
+						else
+							copy_unmodified_block::copy_mipmap_level(as_span_workaround<u32>(dst_buffer), as_const_span<const be_t<u32>>(src_layout.data), words_per_block, w, h, depth, src_layout.border, dst_pitch_in_block, src_layout.pitch_in_block);
+					}
 				}
 			}
 		}

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -112,12 +112,22 @@ namespace rsx
 		u32 pitch_in_block;
 	};
 
+	struct memory_transfer_cmd
+	{
+		const void* dst;
+		const void* src;
+		u32 length;
+	};
+
 	struct texture_memory_info
 	{
 		int element_size;
 		int block_length;
 		bool require_swap;
 		bool require_deswizzle;
+		bool require_upload;
+
+		std::vector<memory_transfer_cmd> deferred_cmds;
 	};
 
 	struct texture_uploader_capabilities
@@ -125,6 +135,7 @@ namespace rsx
 		bool supports_byteswap;
 		bool supports_vtc_decoding;
 		bool supports_hw_deswizzle;
+		bool supports_zero_copy;
 		usz alignment;
 	};
 
@@ -143,7 +154,7 @@ namespace rsx
 	std::vector<subresource_layout> get_subresources_layout(const rsx::fragment_texture &texture);
 	std::vector<subresource_layout> get_subresources_layout(const rsx::vertex_texture &texture);
 
-	texture_memory_info upload_texture_subresource(gsl::span<std::byte> dst_buffer, const subresource_layout &src_layout, int format, bool is_swizzled, const texture_uploader_capabilities& caps);
+	texture_memory_info upload_texture_subresource(gsl::span<std::byte> dst_buffer, const subresource_layout &src_layout, int format, bool is_swizzled, texture_uploader_capabilities& caps);
 
 	u8 get_format_block_size_in_bytes(int format);
 	u8 get_format_block_size_in_texel(int format);

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -67,7 +67,7 @@ namespace gl
 		case CELL_GCM_TEXTURE_A1R5G5B5: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_1_5_5_5_REV);
 		case CELL_GCM_TEXTURE_A4R4G4B4: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_4_4_4_4);
 		case CELL_GCM_TEXTURE_R5G6B5: return std::make_tuple(GL_RGB, GL_UNSIGNED_SHORT_5_6_5);
-		case CELL_GCM_TEXTURE_A8R8G8B8: return std::make_tuple(GL_BGRA, GL_UNSIGNED_INT_8_8_8_8);
+		case CELL_GCM_TEXTURE_A8R8G8B8: return std::make_tuple(GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV);
 		case CELL_GCM_TEXTURE_G8B8: return std::make_tuple(GL_RG, GL_UNSIGNED_BYTE);
 		case CELL_GCM_TEXTURE_R6G5B5: return std::make_tuple(GL_RGB, GL_UNSIGNED_SHORT_5_6_5);
 		case CELL_GCM_TEXTURE_DEPTH24_D8: return std::make_tuple(GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8);
@@ -81,7 +81,7 @@ namespace gl
 		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT: return std::make_tuple(GL_RGBA, GL_FLOAT);
 		case CELL_GCM_TEXTURE_X32_FLOAT: return std::make_tuple(GL_RED, GL_FLOAT);
 		case CELL_GCM_TEXTURE_D1R5G5B5: return std::make_tuple(GL_BGRA, GL_UNSIGNED_SHORT_1_5_5_5_REV);
-		case CELL_GCM_TEXTURE_D8R8G8B8: return std::make_tuple(GL_BGRA, GL_UNSIGNED_INT_8_8_8_8);
+		case CELL_GCM_TEXTURE_D8R8G8B8: return std::make_tuple(GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV);
 		case CELL_GCM_TEXTURE_Y16_X16_FLOAT: return std::make_tuple(GL_RG, GL_HALF_FLOAT);
 		case CELL_GCM_TEXTURE_COMPRESSED_DXT1: return std::make_tuple(GL_COMPRESSED_RGBA_S3TC_DXT1_EXT, GL_UNSIGNED_BYTE);
 		case CELL_GCM_TEXTURE_COMPRESSED_DXT23: return std::make_tuple(GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, GL_UNSIGNED_BYTE);
@@ -714,11 +714,6 @@ namespace gl
 
 			switch (gl_type)
 			{
-			case GL_UNSIGNED_INT_8_8_8_8:
-				// NOTE: GL_UNSIGNED_INT_8_8_8_8 is already a swapped type
-				// TODO: Remove reliance on format and type checks when compute acceleration is implemented
-				apply_settings = false;
-				break;
 			case GL_BYTE:
 			case GL_UNSIGNED_BYTE:
 				// Multi-channel format uploaded one byte at a time. This is due to poor driver support for formats like GL_UNSIGNED SHORT_8_8

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -645,7 +645,7 @@ namespace gl
 			const std::vector<rsx::subresource_layout> &input_layouts,
 			bool is_swizzled, GLenum gl_format, GLenum gl_type, std::vector<std::byte>& staging_buffer)
 	{
-		rsx::texture_uploader_capabilities caps{ true, false, false, 4 };
+		rsx::texture_uploader_capabilities caps{ true, false, false, false, 4 };
 
 		pixel_unpack_settings unpack_settings;
 		unpack_settings.row_length(0).alignment(4);

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -281,12 +281,17 @@ namespace vk
 	void create_dma_block(std::unique_ptr<dma_block>& block)
 	{
 #ifdef _WIN32
-		if (g_render_device->get_external_memory_host_support())
+		const bool allow_host_buffers = true;
+#else
+		// Anything running on AMDGPU kernel driver will not work due to the check for fd-backed memory allocations
+		const auto vendor = g_render_device->gpu().get_driver_vendor();
+		const bool allow_host_buffers = (vendor != driver_vendor::AMD && vendor != driver_vendor::RADV);
+#endif
+		if (g_render_device->get_external_memory_host_support() && allow_host_buffers)
 		{
 			block.reset(new dma_block_EXT());
 		}
 		else
-#endif
 		{
 			block.reset(new dma_block());
 		}

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -10,11 +10,11 @@
 
 namespace vk
 {
-	static constexpr usz s_dma_block_length = 0x00001000;//0x01000000;
-	static constexpr u32 s_dma_block_mask   = 0xFFFFF000;//0xFF000000;
-	//static constexpr u32 s_dma_offset_mask  = 0x00000FFF;//0x00FFFFFF;
+	static constexpr usz s_dma_block_length = 0x00010000;
+	static constexpr u32 s_dma_block_mask   = 0xFFFF0000;
+	//static constexpr u32 s_dma_offset_mask  = 0x0000FFFF;
 
-	static constexpr u32 s_page_size = 16384;
+	static constexpr u32 s_page_size = 65536;
 	static constexpr u32 s_page_align = s_page_size - 1;
 	static constexpr u32 s_pages_per_entry = 32;
 	static constexpr u32 s_bits_per_page = 2;

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -280,8 +280,16 @@ namespace vk
 
 	void create_dma_block(std::unique_ptr<dma_block>& block)
 	{
-		// TODO
-		block.reset(new dma_block_EXT());
+#ifdef _WIN32
+		if (g_render_device->get_external_memory_host_support())
+		{
+			block.reset(new dma_block_EXT());
+		}
+		else
+#endif
+		{
+			block.reset(new dma_block());
+		}
 	}
 
 	std::pair<u32, vk::buffer*> map_dma(const command_buffer& cmd, u32 local_address, u32 length)

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -225,24 +225,6 @@ namespace vk
 
 	bool test_host_pointer(u32 base_address, usz length)
 	{
-#if 0 // Unusable due to vm locks
-		auto block = vm::get(vm::any, base_address);
-		ensure(block);
-
-		if ((block->addr + block->size) < (base_address + length))
-		{
-			return false;
-		}
-
-		if (block->flags & 0x120)
-		{
-			return true;
-		}
-
-		auto range_info = block->peek(base_address, u32(length));
-		return !!range_info.second;
-#endif
-
 #ifdef _WIN32
 		MEMORY_BASIC_INFORMATION mem_info;
 		if (!::VirtualQuery(vm::get_super_ptr<const void>(base_address), &mem_info, sizeof(mem_info)))
@@ -263,7 +245,8 @@ namespace vk
 
 #ifdef _WIN32
 		const bool allow_host_buffers = (vendor == driver_vendor::NVIDIA) ?
-			test_host_pointer(base_address, expected_length) :
+			//test_host_pointer(base_address, expected_length) :
+			rsx::get_location(base_address) == CELL_GCM_LOCATION_LOCAL : // NVIDIA workaround
 			true;
 #else
 		// Anything running on AMDGPU kernel driver will not work due to the check for fd-backed memory allocations		

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -178,7 +178,7 @@ namespace vk
 		return inheritance_info.parent->head();
 	}
 
-	void dma_block::set_parent(command_buffer& cmd, dma_block* parent)
+	void dma_block::set_parent(const command_buffer& cmd, dma_block* parent)
 	{
 		ensure(parent);
 		if (inheritance_info.parent == parent)
@@ -206,7 +206,7 @@ namespace vk
 		}
 	}
 
-	void dma_block::extend(command_buffer& cmd, const render_device &dev, usz new_size)
+	void dma_block::extend(const command_buffer& cmd, const render_device &dev, usz new_size)
 	{
 		ensure(allocated_memory);
 		if (new_size <= allocated_memory->size())
@@ -244,7 +244,7 @@ namespace vk
 		return (allocated_memory) ? allocated_memory->size() : 0;
 	}
 
-	std::pair<u32, vk::buffer*> map_dma(command_buffer& cmd, u32 local_address, u32 length)
+	std::pair<u32, vk::buffer*> map_dma(const command_buffer& cmd, u32 local_address, u32 length)
 	{
 		const auto map_range = utils::address_range::start_length(local_address, length);
 		const auto first_block = (local_address & s_dma_block_mask);

--- a/rpcs3/Emu/RSX/VK/VKDMA.h
+++ b/rpcs3/Emu/RSX/VK/VKDMA.h
@@ -7,6 +7,7 @@ namespace vk
 	std::pair<u32, vk::buffer*> map_dma(const command_buffer& cmd, u32 local_address, u32 length);
 	void load_dma(u32 local_address, u32 length);
 	void flush_dma(u32 local_address, u32 length);
+	void unmap_dma(u32 local_address, u32 length);
 
 	void clear_dma_resources();
 

--- a/rpcs3/Emu/RSX/VK/VKDMA.h
+++ b/rpcs3/Emu/RSX/VK/VKDMA.h
@@ -12,6 +12,7 @@ namespace vk
 
 	class dma_block
 	{
+	protected:
 		enum page_bits
 		{
 			synchronized = 0,
@@ -30,8 +31,9 @@ namespace vk
 		std::unique_ptr<buffer> allocated_memory;
 		std::vector<u64> page_info;
 
-		void* map_range(const utils::address_range& range);
-		void unmap();
+		virtual void allocate(const render_device& dev, usz size);
+		virtual void* map_range(const utils::address_range& range);
+		virtual void unmap();
 
 		void set_page_bit(u32 page, u64 bits);
 		bool test_page_bit(u32 page, u64 bits);
@@ -40,10 +42,10 @@ namespace vk
 
 	public:
 
-		void init(const render_device& dev, u32 addr, usz size);
-		void init(dma_block* parent, u32 addr, usz size);
-		void flush(const utils::address_range& range);
-		void load(const utils::address_range& range);
+		virtual void init(const render_device& dev, u32 addr, usz size);
+		virtual void init(dma_block* parent, u32 addr, usz size);
+		virtual void flush(const utils::address_range& range);
+		virtual void load(const utils::address_range& range);
 		std::pair<u32, buffer*> get(const utils::address_range& range);
 
 		u32 start() const;
@@ -52,7 +54,19 @@ namespace vk
 
 		dma_block* head();
 		const dma_block* head() const;
-		void set_parent(const command_buffer& cmd, dma_block* parent);
-		void extend(const command_buffer& cmd, const render_device& dev, usz new_size);
+		virtual void set_parent(const command_buffer& cmd, dma_block* parent);
+		virtual void extend(const command_buffer& cmd, const render_device& dev, usz new_size);
+	};
+
+	class dma_block_EXT: public dma_block
+	{
+	private:
+		void allocate(const render_device& dev, usz size) override;
+		void* map_range(const utils::address_range& range) override;
+		void unmap() override;
+
+	public:
+		void flush(const utils::address_range& range) override;
+		void load(const utils::address_range& range) override;
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKDMA.h
+++ b/rpcs3/Emu/RSX/VK/VKDMA.h
@@ -4,7 +4,7 @@
 
 namespace vk
 {
-	std::pair<u32, vk::buffer*> map_dma(command_buffer& cmd, u32 local_address, u32 length);
+	std::pair<u32, vk::buffer*> map_dma(const command_buffer& cmd, u32 local_address, u32 length);
 	void load_dma(u32 local_address, u32 length);
 	void flush_dma(u32 local_address, u32 length);
 
@@ -52,7 +52,7 @@ namespace vk
 
 		dma_block* head();
 		const dma_block* head() const;
-		void set_parent(command_buffer& cmd, dma_block* parent);
-		void extend(command_buffer& cmd, const render_device& dev, usz new_size);
+		void set_parent(const command_buffer& cmd, dma_block* parent);
+		void extend(const command_buffer& cmd, const render_device& dev, usz new_size);
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKDMA.h
+++ b/rpcs3/Emu/RSX/VK/VKDMA.h
@@ -13,13 +13,6 @@ namespace vk
 	class dma_block
 	{
 	protected:
-		enum page_bits
-		{
-			synchronized = 0,
-			dirty = 1,
-			nocache = 3
-		};
-
 		struct
 		{
 			dma_block* parent = nullptr;
@@ -29,18 +22,16 @@ namespace vk
 
 		u32 base_address = 0;
 		std::unique_ptr<buffer> allocated_memory;
-		std::vector<u64> page_info;
 
 		virtual void allocate(const render_device& dev, usz size);
+		virtual void free();
 		virtual void* map_range(const utils::address_range& range);
 		virtual void unmap();
 
-		void set_page_bit(u32 page, u64 bits);
-		bool test_page_bit(u32 page, u64 bits);
-		void mark_dirty(const utils::address_range& range);
-		void set_page_info(u32 page_offset, const std::vector<u64>& bits);
-
 	public:
+
+		dma_block() = default;
+		virtual ~dma_block();
 
 		virtual void init(const render_device& dev, u32 addr, usz size);
 		virtual void init(dma_block* parent, u32 addr, usz size);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -70,7 +70,6 @@ namespace vk
 		vk::clear_resolve_helpers();
 		vk::clear_dma_resources();
 		vk::vmm_reset();
-		vk::get_resource_manager()->destroy();
 		vk::clear_scratch_resources();
 
 		vk::get_upload_heap()->destroy();
@@ -86,6 +85,9 @@ namespace vk
 			p.second->destroy();
 		}
 		g_overlay_passes.clear();
+
+		// This must be the last item destroyed
+		vk::get_resource_manager()->destroy();
 	}
 
 	const vk::render_device *get_current_renderer()
@@ -262,8 +264,6 @@ namespace vk
 	{
 		return (g_num_processed_frames > 0)? g_num_processed_frames - 1: 0;
 	}
-
-
 
 	void do_query_cleanup(vk::command_buffer& cmd)
 	{

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -68,7 +68,7 @@ namespace vk
 	* Then copy all layers into dst_image.
 	* dst_image must be in TRANSFER_DST_OPTIMAL layout and upload_buffer have TRANSFER_SRC_BIT usage flag.
 	*/
-	void copy_mipmaped_image_using_buffer(VkCommandBuffer cmd, vk::image* dst_image,
+	void copy_mipmaped_image_using_buffer(const vk::command_buffer& cmd, vk::image* dst_image,
 		const std::vector<rsx::subresource_layout>& subresource_layout, int format, bool is_swizzled, u16 mipmap_count,
 		VkImageAspectFlags flags, vk::data_heap &upload_heap, u32 heap_align = 0);
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -138,7 +138,7 @@ namespace vk
 
 		// Create event object for this transfer and queue signal op
 		dma_fence = std::make_unique<vk::event>(*m_device);
-		dma_fence->signal(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT);
+		dma_fence->signal(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_WRITE_BIT);
 
 		// Set cb flag for queued dma operations
 		cmd.set_flag(vk::command_buffer::cb_has_dma_transfer);

--- a/rpcs3/Emu/RSX/VK/vkutils/barriers.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/barriers.cpp
@@ -53,14 +53,18 @@ namespace vk
 		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 1, &barrier, 0, nullptr);
 	}
 
-	void insert_execution_barrier(VkCommandBuffer cmd, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage)
+	void insert_global_memory_barrier(VkCommandBuffer cmd, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_access, VkAccessFlags dst_access)
 	{
 		if (vk::is_renderpass_open(cmd))
 		{
 			vk::end_renderpass(cmd);
 		}
 
-		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 0, nullptr);
+		VkMemoryBarrier barrier = {};
+		barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+		barrier.srcAccessMask = src_access;
+		barrier.dstAccessMask = dst_access;
+		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 1, &barrier, 0, nullptr, 0, nullptr);
 	}
 
 	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range)

--- a/rpcs3/Emu/RSX/VK/vkutils/barriers.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/barriers.h
@@ -17,7 +17,9 @@ namespace vk
 		VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask,
 		const VkImageSubresourceRange& range);
 
-	void insert_execution_barrier(VkCommandBuffer cmd,
+	void insert_global_memory_barrier(VkCommandBuffer cmd,
 		VkPipelineStageFlags src_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-		VkPipelineStageFlags dst_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+		VkPipelineStageFlags dst_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+		VkAccessFlags src_access = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT,
+		VkAccessFlags dst_access = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/buffer_object.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/buffer_object.cpp
@@ -91,7 +91,7 @@ namespace vk
 
 			VkMemoryHostPointerPropertiesEXT memory_properties{};
 			memory_properties.sType = VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT;
-			memory_map.getMemoryHostPointerPropertiesEXT(dev, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_pointer, &memory_properties);
+			CHECK_RESULT(memory_map.getMemoryHostPointerPropertiesEXT(dev, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_pointer, &memory_properties));
 
 			VkMemoryRequirements memory_reqs;
 			vkGetBufferMemoryRequirements(m_device, value, &memory_reqs);
@@ -110,7 +110,7 @@ namespace vk
 			}
 
 			memory = std::make_unique<memory_block_host>(m_device, host_pointer, size, memory_type_index);
-			vkBindBufferMemory(dev, value, memory->get_vk_device_memory(), memory->get_vk_device_memory_offset());
+			CHECK_RESULT(vkBindBufferMemory(dev, value, memory->get_vk_device_memory(), memory->get_vk_device_memory_offset()));
 		}
 
 		buffer::~buffer()

--- a/rpcs3/Emu/RSX/VK/vkutils/buffer_object.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/buffer_object.h
@@ -30,6 +30,7 @@ namespace vk
 		std::unique_ptr<vk::memory_block> memory;
 
 		buffer(const vk::render_device& dev, u64 size, u32 memory_type_index, u32 access_flags, VkBufferUsageFlags usage, VkBufferCreateFlags flags);
+		buffer(const vk::render_device& dev, VkBufferUsageFlags usage, void* host_pointer, u64 size);
 		~buffer();
 
 		void* map(u64 offset, u64 size);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -56,6 +56,7 @@ namespace vk
 
 		stencil_export_support           = device_extensions.is_supported(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
 		conditional_render_support       = device_extensions.is_supported(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
+		external_memory_host_support = device_extensions.is_supported(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
 		unrestricted_depth_range_support = device_extensions.is_supported(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
 	}
 
@@ -262,6 +263,11 @@ namespace vk
 			requested_extensions.push_back(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
 		}
 
+		if (pgpu->external_memory_host_support)
+		{
+			requested_extensions.push_back(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+		}
+
 		enabled_features.robustBufferAccess = VK_TRUE;
 		enabled_features.fullDrawIndexUint32 = VK_TRUE;
 		enabled_features.independentBlend = VK_TRUE;
@@ -361,6 +367,11 @@ namespace vk
 		memory_map = vk::get_memory_mapping(pdev);
 		m_formats_support = vk::get_optimal_tiling_supported_formats(pdev);
 		m_pipeline_binding_table = vk::get_pipeline_binding_table(pdev);
+
+		if (pgpu->external_memory_host_support)
+		{
+			memory_map.getMemoryHostPointerPropertiesEXT = reinterpret_cast<PFN_vkGetMemoryHostPointerPropertiesEXT>(vkGetDeviceProcAddr(dev, "vkGetMemoryHostPointerPropertiesEXT"));
+		}
 
 		if (g_cfg.video.disable_vulkan_mem_allocator)
 			m_allocator = std::make_unique<vk::mem_allocator_vk>(dev, pdev);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -265,6 +265,7 @@ namespace vk
 
 		if (pgpu->external_memory_host_support)
 		{
+			requested_extensions.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
 			requested_extensions.push_back(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
 		}
 
@@ -482,6 +483,11 @@ namespace vk
 	bool render_device::get_unrestricted_depth_range_support() const
 	{
 		return pgpu->unrestricted_depth_range_support;
+	}
+
+	bool render_device::get_external_memory_host_support() const
+	{
+		return pgpu->external_memory_host_support;
 	}
 
 	mem_allocator_base* render_device::get_allocator() const

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -115,6 +115,7 @@ namespace vk
 		bool get_alpha_to_one_support() const;
 		bool get_conditional_render_support() const;
 		bool get_unrestricted_depth_range_support() const;
+		bool get_external_memory_host_support() const;
 
 		mem_allocator_base* get_allocator() const;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -30,6 +30,8 @@ namespace vk
 	{
 		u32 host_visible_coherent;
 		u32 device_local;
+
+		PFN_vkGetMemoryHostPointerPropertiesEXT getMemoryHostPointerPropertiesEXT;
 	};
 
 	class physical_device
@@ -47,6 +49,7 @@ namespace vk
 
 		bool stencil_export_support = false;
 		bool conditional_render_support = false;
+		bool external_memory_host_support = false;
 		bool unrestricted_depth_range_support = false;
 
 		friend class render_device;

--- a/rpcs3/Emu/RSX/VK/vkutils/instance.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/instance.hpp
@@ -149,6 +149,11 @@ namespace vk
 				{
 					extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 				}
+
+				if (support.is_supported(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME))
+				{
+					extensions.push_back(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
+				}
 #ifdef _WIN32
 				extensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #elif defined(__APPLE__)

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -82,21 +82,44 @@ namespace vk
 	struct memory_block
 	{
 		memory_block(VkDevice dev, u64 block_sz, u64 alignment, u32 memory_type_index);
-		~memory_block();
+		virtual ~memory_block();
 
-		VkDeviceMemory get_vk_device_memory();
-		u64 get_vk_device_memory_offset();
+		virtual VkDeviceMemory get_vk_device_memory();
+		virtual u64 get_vk_device_memory_offset();
 
-		void* map(u64 offset, u64 size);
-		void unmap();
+		virtual void* map(u64 offset, u64 size);
+		virtual void unmap();
 
 		memory_block(const memory_block&) = delete;
 		memory_block(memory_block&&)      = delete;
 
+	protected:
+		memory_block() = default;
+
 	private:
 		VkDevice m_device;
-		vk::mem_allocator_base* m_mem_allocator;
+		vk::mem_allocator_base* m_mem_allocator = nullptr;
 		mem_allocator_base::mem_handle_t m_mem_handle;
+	};
+
+	struct memory_block_host : public memory_block
+	{
+		memory_block_host(VkDevice dev, void* host_pointer, u64 size, u32 memory_type_index);
+		~memory_block_host();
+
+		VkDeviceMemory get_vk_device_memory() override;
+		u64 get_vk_device_memory_offset() override;
+		void* map(u64 offset, u64 size) override;
+		void unmap() override;
+
+		memory_block_host(const memory_block_host&) = delete;
+		memory_block_host(memory_block_host&&) = delete;
+		memory_block_host() = delete;
+
+	private:
+		VkDevice m_device;
+		VkDeviceMemory m_mem_handle;
+		void* m_host_pointer;
 	};
 
 	void vmm_notify_memory_allocated(void* handle, u32 memory_type, u64 memory_size);

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
@@ -103,7 +103,7 @@ namespace vk
 		}
 	}
 
-	void event::signal(const command_buffer& cmd, VkPipelineStageFlags stages)
+	void event::signal(const command_buffer& cmd, VkPipelineStageFlags stages, VkAccessFlags access)
 	{
 		if (m_vk_event) [[likely]]
 		{
@@ -111,7 +111,7 @@ namespace vk
 		}
 		else
 		{
-			insert_execution_barrier(cmd, stages, VK_PIPELINE_STAGE_TRANSFER_BIT);
+			insert_global_memory_barrier(cmd, stages, VK_PIPELINE_STAGE_TRANSFER_BIT, access, VK_ACCESS_TRANSFER_WRITE_BIT);
 			vkCmdFillBuffer(cmd, m_buffer->value, 0, 4, 0xDEADBEEF);
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -37,7 +37,7 @@ namespace vk
 	public:
 		event(const render_device& dev);
 		~event();
-		void signal(const command_buffer& cmd, VkPipelineStageFlags stages);
+		void signal(const command_buffer& cmd, VkPipelineStageFlags stages, VkAccessFlags access);
 		VkResult status() const;
 	};
 

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -221,12 +221,18 @@ namespace utils
 	void memory_protect(void* pointer, usz size, protection prot)
 	{
 #ifdef _WIN32
+
+		DWORD old;
+		if (::VirtualProtect(pointer, size, +prot, &old))
+		{
+			return;
+		}
+
 		for (u64 addr = reinterpret_cast<u64>(pointer), end = addr + size; addr < end;)
 		{
 			const u64 boundary = (addr + 0x10000) & -0x10000;
 			const u64 block_size = std::min(boundary, end) - addr;
 
-			DWORD old;
 			if (!::VirtualProtect(reinterpret_cast<LPVOID>(addr), block_size, +prot, &old))
 			{
 				fmt::throw_exception("VirtualProtect failed (%p, 0x%x, addr=0x%x, error=%#x)", pointer, size, addr, GetLastError());


### PR DESCRIPTION
This PR allows the GPU to read and write directly into host allocated memory which can give some performance improvements in some cases. It also includes misc fixes in other areas to tighten up the supporting implementation.
Summary
- Redirects all texture upload routines to use the pre-existing DMA emulation mechanism
- Solves a RAW hazard when extending/merging DMA sections by just discarding contents altogether
- Allows special DMA block that is passthrough to the physical GPU
- Fixes a synchronization leak in custom AMD GPU event object
- Adds a hotpath for utils::memory_protect that I found when profiling. There is a decent performance uplift from just assuming the whole range is likely contiguous and falling back to chunked protection in case of failure.

TODO
- [x] Unbreak OpenGL, needs further testing.
- [x] Poor performance in some cases when using RADV
- [x] Investigate NVIDIA problems and exclude if no solution is found.
- [x] Investigate data corruption and crashing when using DMA layer (old bug)
- [x] GT5 texture mangling