### PR TITLE
SPU LLVM: Optimize FSM following comparison

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6463,6 +6463,23 @@ public:
 
 	void FSM(spu_opcode_t op)
 	{
+		// FSM following a comparison instruction
+		if (match_vr<s8[16], s16[8], s32[4], s64[2]>(op.ra, [&](auto c, auto MP)
+		{
+			using VT = typename decltype(MP)::type;
+
+			if (auto [ok, x] = match_expr(c, sext<VT>(match<bool[std::extent_v<VT>]>())); ok)
+			{
+					set_vr(op.rt, (splat_scalar(c)));
+					return true;
+			}
+
+			return false;
+		}))
+		{
+			return;
+		}
+
 		const auto v = extract(get_vr(op.ra), 3);
 		const auto m = bitcast<bool[4]>(trunc<i4>(v));
 		set_vr(op.rt, sext<s32[4]>(m));


### PR DESCRIPTION
FSM following a comparison instruction can be optimized to a single shuffle. In Wipeout HD we can hit this optimization 394/410 times. 

<details>
  <summary>Codegen before optimization</summary>

![FSMbefore](https://user-images.githubusercontent.com/26352541/104835965-2aa97300-5878-11eb-8206-53dbb9f01c2d.png)

</details>

<details>
  <summary>Codegen after optimization</summary>

![FSMafter](https://user-images.githubusercontent.com/26352541/104835964-29784600-5878-11eb-9c98-6c773e4b92d8.png)

</details>