### PR TITLE
SPU LLVM: add splat_scalar helper

### DIFF
--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -262,7 +262,7 @@ namespace utils
 		m_file = -1;
 
 		// Try to use 2MB pages for 2M-aligned shm
-		if constexpr (c_mfd_huge_2mb)
+		if constexpr (c_mfd_huge_2mb != 0)
 		{
 			if (m_size % 0x200000 == 0 && flags & 2)
 			{


### PR DESCRIPTION
Removes redundant repetitive arguments for zshuffle in some cases.