### PR TITLE
Fix _DEBUG macro in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ endif()
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 	add_definitions(-DNDEBUG)
+elseif(NOT MSVC)
+	add_definitions(-D_DEBUG)
 endif()
 
 if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -297,7 +297,18 @@ namespace fmt
 			raw_throw_exception({line, col, file, func}, reinterpret_cast<const char*>(fmt), type_list, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...});
 		}
 
-		[[noreturn]] ~throw_exception() { std::abort(); } // Unreachable
+#ifdef _DEBUG
+		[[noreturn]] ~throw_exception()
+		{
+#ifdef _MSC_VER
+			__assume(false);
+#else
+			__builtin_unreachable();
+#endif
+		}
+#else
+		[[noreturn]] ~throw_exception();
+#endif
 	};
 
 	template <typename CharT, usz N, typename... Args>

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -590,7 +590,7 @@ namespace rsx
 
 					// Sanity checks
 					AUDIT(exclusion_range.is_page_range());
-					AUDIT(data.cause.is_read() && !excluded->is_flushable() || data.cause.skip_fbos() || !exclusion_range.overlaps(data.fault_range));
+					AUDIT((data.cause.is_read() && !excluded->is_flushable()) || data.cause.skip_fbos() || !exclusion_range.overlaps(data.fault_range));
 
 					// Apply exclusion
 					ranges_to_unprotect.exclude(exclusion_range);
@@ -932,7 +932,7 @@ namespace rsx
 				else
 				{
 					// This is a read and all overlapping sections were RO and were excluded (except for cause == superseded_by_fbo)
-					AUDIT(cause.skip_fbos() || cause.is_read() && !result.sections_to_exclude.empty());
+					AUDIT(cause.skip_fbos() || (cause.is_read() && !result.sections_to_exclude.empty()));
 
 					// We did not handle this violation
 					result.clear_sections();


### PR DESCRIPTION
Add _DEBUG in debug mode for consistency (only MSVC does this normally).
This also has an effect on enabling AUDIT macro in Debug mode on other compilers.