### PR TITLE
Fix fmt::throw_exception destructor v2

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1055,14 +1055,17 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 
 		u64 seek(s64 offset, seek_mode whence) override
 		{
+			if (whence > seek_end)
+			{
+				fmt::throw_exception("Invalid whence (0x%x)", whence);
+			}
+
 			LARGE_INTEGER pos;
 			pos.QuadPart = offset;
 
 			const DWORD mode =
 				whence == seek_set ? FILE_BEGIN :
-				whence == seek_cur ? FILE_CURRENT :
-				whence == seek_end ? FILE_END :
-				(fmt::throw_exception("Invalid whence (0x%x)", whence), 0);
+				whence == seek_cur ? FILE_CURRENT : FILE_END;
 
 			if (!SetFilePointerEx(m_handle, pos, &pos, mode))
 			{
@@ -1196,11 +1199,14 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 
 		u64 seek(s64 offset, seek_mode whence) override
 		{
+			if (whence > seek_end)
+			{
+				fmt::throw_exception("Invalid whence (0x%x)", whence);
+			}
+
 			const int mode =
 				whence == seek_set ? SEEK_SET :
-				whence == seek_cur ? SEEK_CUR :
-				whence == seek_end ? SEEK_END :
-				(fmt::throw_exception("Invalid whence (0x%x)", whence), 0);
+				whence == seek_cur ? SEEK_CUR : SEEK_END;
 
 			const auto result = ::lseek(m_fd, offset, mode);
 

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -297,17 +297,15 @@ namespace fmt
 			raw_throw_exception({line, col, file, func}, reinterpret_cast<const char*>(fmt), type_list, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...});
 		}
 
-#ifdef _DEBUG
+#ifndef _MSC_VER
+#if defined(_DEBUG)
 		[[noreturn]] ~throw_exception()
 		{
-#ifdef _MSC_VER
-			__assume(false);
-#else
 			__builtin_unreachable();
-#endif
 		}
 #else
 		[[noreturn]] ~throw_exception();
+#endif
 #endif
 	};
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -126,11 +126,16 @@ static u64& ppu_ref(u32 addr)
 // Get interpreter cache value
 static u64 ppu_cache(u32 addr)
 {
+	if (g_cfg.core.ppu_decoder > ppu_decoder_type::fast)
+	{
+		fmt::throw_exception("Invalid PPU decoder");
+	}
+
 	// Select opcode table
 	const auto& table = *(
-		g_cfg.core.ppu_decoder == ppu_decoder_type::precise ? &g_ppu_interpreter_precise.get_table() :
-		g_cfg.core.ppu_decoder == ppu_decoder_type::fast ? &g_ppu_interpreter_fast.get_table() :
-		(fmt::throw_exception("Invalid PPU decoder"), nullptr));
+		g_cfg.core.ppu_decoder == ppu_decoder_type::precise
+		? &g_ppu_interpreter_precise.get_table()
+		: &g_ppu_interpreter_fast.get_table());
 
 	return reinterpret_cast<uptr>(table[ppu_decode(vm::read32(addr))]);
 }

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -1188,11 +1188,15 @@ void spu_recompiler_base::branch(spu_thread& spu, void*, u8* rip)
 
 void spu_recompiler_base::old_interpreter(spu_thread& spu, void* ls, u8* rip)
 {
+	if (g_cfg.core.spu_decoder > spu_decoder_type::fast)
+	{
+		fmt::throw_exception("Invalid SPU decoder");
+	}
+
 	// Select opcode table
-	const auto& table = *(
-		g_cfg.core.spu_decoder == spu_decoder_type::precise ? &g_spu_interpreter_precise.get_table() :
-		g_cfg.core.spu_decoder == spu_decoder_type::fast ? &g_spu_interpreter_fast.get_table() :
-		(fmt::throw_exception("Invalid SPU decoder"), nullptr));
+	const auto& table = *(g_cfg.core.spu_decoder == spu_decoder_type::precise
+		? &g_spu_interpreter_precise.get_table()
+		: &g_spu_interpreter_fast.get_table());
 
 	// LS pointer
 	const auto base = static_cast<const u8*>(ls);

--- a/rpcs3/Emu/system_config_types.h
+++ b/rpcs3/Emu/system_config_types.h
@@ -1,16 +1,16 @@
 #pragma once
 
-enum class ppu_decoder_type
+enum class ppu_decoder_type : unsigned
 {
-	precise,
-	fast,
+	precise = 0, // Don't change (0)
+	fast, // Don't change (1)
 	llvm,
 };
 
-enum class spu_decoder_type
+enum class spu_decoder_type : unsigned
 {
-	precise,
-	fast,
+	precise = 0, // Don't change (0)
+	fast, // Don't change (1)
 	asmjit,
 	llvm,
 };


### PR DESCRIPTION
Remove explicit destructor for MSVC.
~~Check `__OPTIMIZE__` for other compilers.~~

Second commit may address linkage errors which are currently not supposed to happen.