### PR TITLE
Qt: hotfix for downloader

### DIFF
--- a/rpcs3/rpcs3qt/downloader.cpp
+++ b/rpcs3/rpcs3qt/downloader.cpp
@@ -21,14 +21,13 @@ downloader::downloader(QWidget* parent)
 	, m_parent(parent)
 	, m_curl(new curl_handle(this))
 {
-	connect(this, &downloader::signal_buffer_update, this, &downloader::handle_buffer_update);
 }
 
 downloader::~downloader()
 {
-	m_curl_abort = true;
 	if (m_thread && m_thread->isRunning())
 	{
+		m_curl_abort = true;
 		m_thread->wait();
 	}
 }
@@ -37,9 +36,9 @@ void downloader::start(const std::string& url, bool follow_location, bool show_p
 {
 	if (m_thread)
 	{
-		m_curl_abort = true;
 		if (m_thread->isRunning())
 		{
+			m_curl_abort = true;
 			m_thread->wait();
 		}
 		m_thread->deleteLater();
@@ -85,6 +84,10 @@ void downloader::start(const std::string& url, bool follow_location, bool show_p
 			Q_EMIT signal_download_finished(m_curl_buf);
 		}
 	});
+
+	// The downloader's signals are expected to be disconnected and customized before start is called.
+	// Therefore we need to (re)connect its signal(s) here and not in the constructor.
+	connect(this, &downloader::signal_buffer_update, this, &downloader::handle_buffer_update);
 
 	if (show_progress_dialog)
 	{


### PR DESCRIPTION
I accidentally broke the download progress bar in the last related PR.
I should've put more trust in the sanity of the younger version of myself.
This should fix it.