### PR TITLE
PPU LLVM upgrade (v4-kusa)

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -229,6 +229,7 @@ asmjit::Runtime& asmjit::get_global_runtime()
 			if (!p || m_pos > m_max) [[unlikely]]
 			{
 				*dst = nullptr;
+				jit_log.fatal("Out of memory (static asmjit)");
 				return asmjit::kErrorNoVirtualMemory;
 			}
 

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -188,7 +188,7 @@ void audio_ringbuffer::enqueue(const float* in_buffer)
 	const bool success = backend->AddData(buf, AUDIO_BUFFER_SAMPLES * cfg.audio_channels);
 	if (!success)
 	{
-		cellAudio.error("Could not enqueue buffer onto audio backend. Attempting to recover...");
+		cellAudio.warning("Could not enqueue buffer onto audio backend. Attempting to recover...");
 		flush();
 		return;
 	}

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -529,11 +529,15 @@ namespace ppu_patterns
 	};
 }
 
-void ppu_module::analyse(u32 lib_toc, u32 entry)
+void ppu_module::analyse(u32 lib_toc, u32 entry, u32 end)
 {
 	// Assume first segment is executable
 	const u32 start = segs[0].addr;
-	const u32 end = segs[0].addr + segs[0].size;
+
+	if (end == umax)
+	{
+		end = segs[0].addr + segs[0].size;
+	}
 
 	// Known TOCs (usually only 1)
 	std::unordered_set<u32> TOCs;
@@ -1565,6 +1569,12 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 			block.size = size;
 			block.toc  = func.toc;
 			ppu_log.trace("Block __0x%x added (func=0x%x, size=0x%x, toc=0x%x)", block.addr, _, block.size, block.toc);
+
+			if (!entry)
+			{
+				// Workaround for SPRX: update end to the last found function
+				end = block.addr + block.size;
+			}
 		}
 	}
 

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -3,6 +3,7 @@
 
 #include "PPUOpcodes.h"
 #include "PPUModule.h"
+#include "Emu/system_config.h"
 
 #include <unordered_set>
 #include "util/yaml.hpp"
@@ -577,7 +578,6 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 		func_queue.emplace_back(func);
 		func.addr = addr;
 		func.toc = toc;
-		func.name = fmt::format("__0x%x", func.addr);
 		ppu_log.trace("Function 0x%x added (toc=0x%x)", addr, toc);
 		return func;
 	};
@@ -1432,7 +1432,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 		// Just ensure that functions don't overlap
 		if (func.addr + func.size > next)
 		{
-			ppu_log.warning("Function overlap: [0x%x] 0x%x -> 0x%x", func.addr, func.size, next - func.addr);
+			ppu_log.trace("Function overlap: [0x%x] 0x%x -> 0x%x", func.addr, func.size, next - func.addr);
 			continue; //func.size = next - func.addr;
 
 			// Also invalidate blocks
@@ -1502,7 +1502,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 
 			if (_ptr.addr() >= next)
 			{
-				ppu_log.warning("Function gap: [0x%x] 0x%x bytes at 0x%x", func.addr, next - start, start);
+				ppu_log.trace("Function gap: [0x%x] 0x%x bytes at 0x%x", func.addr, next - start, start);
 				break;
 			}
 		}
@@ -1522,15 +1522,200 @@ void ppu_module::analyse(u32 lib_toc, u32 entry)
 		}
 	}
 
-	// Convert map to vector (destructive)
-	for (auto&& pair : fmap)
+	ppu_log.notice("Function analysis: %zu functions (%zu enqueued)", fmap.size(), func_queue.size());
+
+	// Decompose functions to basic blocks
+	for (auto&& [_, func] : as_rvalue(std::move(fmap)))
 	{
-		auto& func = pair.second;
-		ppu_log.trace("Function %s (size=0x%x, toc=0x%x, attr %#x)", func.name, func.size, func.toc, func.attr);
-		funcs.emplace_back(std::move(func));
+		for (auto [addr, size] : func.blocks)
+		{
+			if (!size)
+			{
+				continue;
+			}
+
+			auto& block = fmap[addr];
+
+			if (block.addr || block.size)
+			{
+				ppu_log.trace("Block __0x%x exists (size=0x%x)", block.addr, block.size);
+				continue;
+			}
+
+			block.addr = addr;
+			block.size = size;
+			block.toc  = func.toc;
+			ppu_log.trace("Block __0x%x added (func=0x%x, size=0x%x, toc=0x%x)", block.addr, _, block.size, block.toc);
+		}
 	}
 
-	ppu_log.notice("Function analysis: %zu functions (%zu enqueued)", funcs.size(), func_queue.size());
+	// Simple callable block analysis
+	std::vector<std::pair<u32, u32>> block_queue;
+	block_queue.reserve(128000);
+
+	std::unordered_set<u32> block_set;
+
+	u32 exp = start;
+	u32 lim = end;
+
+	// Start with full scan
+	block_queue.emplace_back(exp, lim);
+
+	// block_queue may grow
+	for (usz i = 0; i < block_queue.size(); i++)
+	{
+		std::tie(exp, lim) = block_queue[i];
+
+		if (lim == 0)
+		{
+			// Find next function
+			const auto found = fmap.upper_bound(exp);
+
+			if (found != fmap.cend())
+			{
+				lim = found->first;
+			}
+
+			ppu_log.trace("Block rescan: addr=0x%x, lim=0x%x", exp, lim);
+		}
+
+		while (exp < lim)
+		{
+			u32 i_pos = exp;
+
+			bool is_good = true;
+
+			for (; i_pos < lim; i_pos += 4)
+			{
+				const u32 opc = vm::_ref<u32>(i_pos);
+
+				switch (auto type = s_ppu_itype.decode(opc))
+				{
+				case ppu_itype::UNK:
+				case ppu_itype::ECIWX:
+				case ppu_itype::ECOWX:
+				{
+					// Seemingly bad instruction, skip this block
+					is_good = false;
+					break;
+				}
+				case ppu_itype::TD:
+				case ppu_itype::TDI:
+				case ppu_itype::TW:
+				case ppu_itype::TWI:
+				case ppu_itype::B:
+				case ppu_itype::BC:
+				{
+					if (type == ppu_itype::B || type == ppu_itype::BC)
+					{
+						if (entry == 0 && ppu_opcode_t{opc}.aa)
+						{
+							// Ignore absolute branches in PIC (PRX)
+							is_good = false;
+							break;
+						}
+
+						const u32 target = (opc & 2 ? 0 : i_pos) + (type == ppu_itype::B ? +ppu_opcode_t{opc}.bt24 : +ppu_opcode_t{opc}.bt14);
+
+						if (target < start || target >= end)
+						{
+							// Sanity check
+							is_good = false;
+							break;
+						}
+
+						const auto found = fmap.find(target);
+
+						if (target != i_pos && found == fmap.cend())
+						{
+							if (block_set.count(target) == 0)
+							{
+								ppu_log.trace("Block target found: 0x%x (i_pos=0x%x)", target, i_pos);
+								block_queue.emplace_back(target, 0);
+								block_set.emplace(target);
+							}
+						}
+					}
+
+					[[fallthrough]];
+				}
+				case ppu_itype::BCCTR:
+				case ppu_itype::BCLR:
+				case ppu_itype::SC:
+				{
+					if (type == ppu_itype::SC && opc != ppu_instructions::SC(0))
+					{
+						// Strict garbage filter
+						is_good = false;
+						break;
+					}
+
+					if (type == ppu_itype::BCCTR && opc & 0xe000)
+					{
+						// Garbage filter
+						is_good = false;
+						break;
+					}
+
+					if (type == ppu_itype::BCLR && opc & 0xe000)
+					{
+						// Garbage filter
+						is_good = false;
+						break;
+					}
+
+					// Good block terminator found, add single block
+					break;
+				}
+				default:
+				{
+					// Normal instruction: keep scanning
+					continue;
+				}
+				}
+
+				break;
+			}
+
+			if (i_pos < lim)
+			{
+				i_pos += 4;
+			}
+
+			if (is_good)
+			{
+				auto& block = fmap[exp];
+
+				if (!block.addr)
+				{
+					block.addr = exp;
+					block.size = i_pos - exp;
+					ppu_log.trace("Block __0x%x added (size=0x%x)", block.addr, block.size);
+				}
+			}
+
+			exp = i_pos;
+		}
+	}
+
+	// Remove overlaps in blocks
+	for (auto it = fmap.begin(), end = fmap.end(); it != fmap.end(); it++)
+	{
+		const auto next = std::next(it);
+
+		if (next != end && next->first < it->first + it->second.size)
+		{
+			it->second.size = next->first - it->first;
+		}
+	}
+
+	// Convert map to vector (destructive)
+	for (auto&& pair : as_rvalue(std::move(fmap)))
+	{
+		funcs.emplace_back(std::move(pair.second));
+	}
+
+	ppu_log.notice("Block analysis: %zu blocks (%zu enqueued)", funcs.size(), block_queue.size());
 }
 
 void ppu_acontext::UNK(ppu_opcode_t op)

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -89,7 +89,7 @@ struct ppu_module
 		secs = info.secs;
 	}
 
-	void analyse(u32 lib_toc, u32 entry);
+	void analyse(u32 lib_toc, u32 entry, u32 end = -1);
 	void validate(u32 reloc);
 };
 

--- a/rpcs3/Emu/Cell/PPUFunction.h
+++ b/rpcs3/Emu/Cell/PPUFunction.h
@@ -256,7 +256,7 @@ class ppu_function_manager
 	};
 
 	// Access global function list
-	static std::vector<ppu_function_t>& access();
+	static std::vector<ppu_function_t>& access(bool ghc = false);
 
 	static u32 add_function(ppu_function_t function);
 
@@ -276,9 +276,9 @@ public:
 	}
 
 	// Read all registered functions
-	static inline const auto& get()
+	static inline const auto& get(bool llvm = false)
 	{
-		return access();
+		return access(llvm);
 	}
 
 	static inline u32 func_addr(u32 index)

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -467,7 +467,7 @@ static auto ppu_load_exports(ppu_linkage_info* link, u32 exports_start, u32 expo
 
 				if (i < lib.num_func)
 				{
-					ppu_loader.notice("** Special: [%s] at 0x%x", ppu_get_function_name({}, nid), addr);
+					ppu_loader.notice("** Special: [%s] at 0x%x [0x%x, 0x%x]", ppu_get_function_name({}, nid), addr, vm::_ref<u32>(addr), vm::_ref<u32>(addr + 4));
 				}
 				else
 				{

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -244,7 +244,7 @@ static void ppu_initialize_modules(ppu_linkage_info* link)
 	};
 
 	// Initialize double-purpose fake OPD array for HLE functions
-	const auto& hle_funcs = ppu_function_manager::get();
+	const auto& hle_funcs = ppu_function_manager::get(g_cfg.core.ppu_decoder == ppu_decoder_type::llvm);
 
 	// Allocate memory for the array (must be called after fixed allocations)
 	ppu_function_manager::addr = vm::alloc(::size32(hle_funcs) * 8, vm::main);

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1058,7 +1058,7 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 		prx->specials = ppu_load_exports(link, lib_info->exports_start, lib_info->exports_end);
 		prx->imports = ppu_load_imports(prx->relocs, link, lib_info->imports_start, lib_info->imports_end);
 		std::stable_sort(prx->relocs.begin(), prx->relocs.end());
-		prx->analyse(lib_info->toc, 0);
+		prx->analyse(lib_info->toc, 0, std::min<u32>(lib_info.addr(), prx->segs[0].addr + prx->segs[0].size));
 	}
 	else
 	{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2561,7 +2561,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 	usz fpos = 0;
 
 	// Difference between function name and current location
-	const u32 reloc = info.name.empty() ? 0 : info.segs.at(0).addr;
+	const u32 reloc = info.relocs.empty() ? 0 : info.segs.at(0).addr;
 
 	// Info sent to threads
 	std::vector<std::pair<std::string, ppu_module>> workload;

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -267,6 +267,8 @@ public:
 	// Thread name
 	atomic_ptr<std::string> ppu_tname;
 
+	u64 saved_native_sp = 0; // Host thread's stack pointer for emulated longjmp
+
 	u64 last_ftsc = 0;
 	u64 last_ftime = 0;
 	u32 last_faddr = 0;

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1975,7 +1975,6 @@ void PPUTranslator::SC(ppu_opcode_t op)
 
 		if (index < 1024)
 		{
-			// Call the syscall directly
 			Call(GetType<void>(), fmt::format("%s", ppu_syscall_code(index)), m_thread)->setTailCallKind(llvm::CallInst::TCK_Tail);
 			m_ir->CreateRetVoid();
 			return;
@@ -2491,7 +2490,6 @@ void PPUTranslator::MFOCRF(ppu_opcode_t op)
 
 		if (pos >= 8 || 0x80u >> pos != op.crm)
 		{
-			CompilationError("MFOCRF: Undefined behaviour");
 			SetGpr(op.rd, UndefValue::get(GetType<u64>()));
 			return;
 		}
@@ -2771,7 +2769,6 @@ void PPUTranslator::MTOCRF(ppu_opcode_t op)
 
 		if (pos >= 8 || 0x80u >> pos != op.crm)
 		{
-			CompilationError("MTOCRF: Undefined behaviour");
 			return;
 		}
 	}
@@ -3220,7 +3217,6 @@ void PPUTranslator::LDBRX(ppu_opcode_t op)
 
 void PPUTranslator::LSWX(ppu_opcode_t op)
 {
-	CompilationError("Unsupported instruction LSWX. Please report.");
 	Call(GetType<void>(), "__lswx_not_supported", m_ir->getInt32(op.rd), RegLoad(m_cnt), op.ra ? m_ir->CreateAdd(GetGpr(op.ra), GetGpr(op.rb)) : GetGpr(op.rb));
 }
 
@@ -3338,7 +3334,6 @@ void PPUTranslator::STDBRX(ppu_opcode_t op)
 
 void PPUTranslator::STSWX(ppu_opcode_t op)
 {
-	CompilationError("Unsupported instruction STSWX. Please report.");
 	Call(GetType<void>(), "__stswx_not_supported", m_ir->getInt32(op.rs), RegLoad(m_cnt), op.ra ? m_ir->CreateAdd(GetGpr(op.ra), GetGpr(op.rb)) : GetGpr(op.rb));
 }
 
@@ -4154,8 +4149,6 @@ void PPUTranslator::FNMADDS(ppu_opcode_t op)
 
 void PPUTranslator::MTFSB1(ppu_opcode_t op)
 {
-	CompilationError("MTFSB1");
-
 	SetFPSCRBit(op.crbd, m_ir->getTrue(), true);
 
 	if (op.rc) SetCrFieldFPCC(1);
@@ -4163,8 +4156,6 @@ void PPUTranslator::MTFSB1(ppu_opcode_t op)
 
 void PPUTranslator::MCRFS(ppu_opcode_t op)
 {
-	CompilationError("MCRFS");
-
 	const auto lt = GetFPSCRBit(op.crfs * 4 + 0);
 	const auto gt = GetFPSCRBit(op.crfs * 4 + 1);
 	const auto eq = GetFPSCRBit(op.crfs * 4 + 2);
@@ -4174,8 +4165,6 @@ void PPUTranslator::MCRFS(ppu_opcode_t op)
 
 void PPUTranslator::MTFSB0(ppu_opcode_t op)
 {
-	CompilationError("MTFSB0");
-
 	SetFPSCRBit(op.crbd, m_ir->getFalse(), false);
 
 	if (op.rc) SetCrFieldFPCC(1);
@@ -4183,8 +4172,6 @@ void PPUTranslator::MTFSB0(ppu_opcode_t op)
 
 void PPUTranslator::MTFSFI(ppu_opcode_t op)
 {
-	CompilationError("MTFSFI");
-
 	SetFPSCRBit(op.crfd * 4 + 0, m_ir->getInt1((op.i & 8) != 0), false);
 	if (op.crfd != 0) SetFPSCRBit(op.crfd * 4 + 1, m_ir->getInt1((op.i & 4) != 0), false);
 	if (op.crfd != 0) SetFPSCRBit(op.crfd * 4 + 2, m_ir->getInt1((op.i & 2) != 0), false);
@@ -4195,8 +4182,6 @@ void PPUTranslator::MTFSFI(ppu_opcode_t op)
 
 void PPUTranslator::MFFS(ppu_opcode_t op)
 {
-	ppu_log.warning("LLVM: [0x%08x] Warning: MFFS", m_addr + (m_reloc ? m_reloc->addr : 0));
-
 	Value* result = m_ir->getInt64(0);
 
 	for (u32 i = 16; i < 20; i++)
@@ -4211,8 +4196,6 @@ void PPUTranslator::MFFS(ppu_opcode_t op)
 
 void PPUTranslator::MTFSF(ppu_opcode_t op)
 {
-	ppu_log.warning("LLVM: [0x%08x] Warning: MTFSF", m_addr + (m_reloc ? m_reloc->addr : 0));
-
 	const auto value = GetFpr(op.frb, 32, true);
 
 	for (u32 i = 16; i < 20; i++)

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -27,7 +27,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_mo
 	cpu_translator::initialize(context, engine);
 
 	// There is no weak linkage on JIT, so let's create variables with different names for each module part
-	const u32 gsuffix = m_info.name.empty() ? info.funcs[0].addr : info.funcs[0].addr - m_info.segs[0].addr;
+	const u32 gsuffix = m_info.relocs.empty() ? info.funcs[0].addr : info.funcs[0].addr - m_info.segs[0].addr;
 
 	// Memory base
 	m_base = new GlobalVariable(*_module, ArrayType::get(GetType<char>(), 0x100000000)->getPointerTo(), true, GlobalValue::ExternalLinkage, 0, fmt::format("__mptr%x", gsuffix));
@@ -130,7 +130,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_mo
 		}
 	}
 
-	if (!m_info.name.empty())
+	if (!m_info.relocs.empty())
 	{
 		m_reloc = &m_info.segs[0];
 	}

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -2961,8 +2961,15 @@ void PPUTranslator::ADD(ppu_opcode_t op)
 	const auto b = GetGpr(op.rb);
 	const auto result = m_ir->CreateAdd(a, b);
 	SetGpr(op.rd, result);
+
+	if (op.oe)
+	{
+		//const auto s = m_ir->CreateCall(get_intrinsic<u64>(llvm::Intrinsic::sadd_with_overflow), {a, b});
+		//SetOverflow(m_ir->CreateExtractValue(s, {1}));
+		SetOverflow(m_ir->CreateICmpSLT(m_ir->CreateAnd(m_ir->CreateXor(a, m_ir->CreateNot(b)), m_ir->CreateXor(a, result)), m_ir->getInt64(0)));
+	}
+
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__add_get_ov", a, b));
 }
 
 void PPUTranslator::DCBT(ppu_opcode_t op)

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -36,18 +36,17 @@ class PPUTranslator final : public cpu_translator
 
 	/* Variables */
 
-	// Segments
-	std::vector<llvm::GlobalVariable*> m_segs;
-
 	// Memory base
-	llvm::GlobalVariable* m_base;
-	llvm::Value* m_base_loaded;
+	llvm::Value* m_base;
 
 	// Thread context
 	llvm::Value* m_thread;
 
 	// Callable functions
-	llvm::GlobalVariable* m_call;
+	llvm::Value* m_exec;
+
+	// Segment 0 address
+	llvm::Value* m_seg0;
 
 	// Thread context struct
 	llvm::StructType* m_thread_type;

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -32,6 +32,7 @@ struct cfg_root : cfg::node
 		cfg::_bool llvm_logs{ this, "Save LLVM logs" };
 		cfg::string llvm_cpu{ this, "Use LLVM CPU" };
 		cfg::_int<0, INT32_MAX> llvm_threads{ this, "Max LLVM Compile Threads", 0 };
+		cfg::_bool ppu_llvm_greedy_mode{ this, "PPU LLVM Greedy Mode", false, false };
 		cfg::_bool thread_scheduler_enabled{ this, "Enable thread scheduler", thread_scheduler_enabled_def };
 		cfg::_bool set_daz_and_ftz{ this, "Set DAZ and FTZ", false };
 		cfg::_enum<spu_decoder_type> spu_decoder{ this, "SPU Decoder", spu_decoder_type::llvm };


### PR DESCRIPTION
1) Added additional analyser layer which could possibly inflate cache size, but it didn't happen. Please report if you get unusually big executable cache with v4-kusa.
2) Added nounwind attribute to compiled function. It reduced their size significantly.
3) Compiled certain rare functions with "no branch tables" on per-instruction basis.
4) Optimized small blocks with 1-3 instructions, without a terminator: removed state checks for them.
5) Fixed some minor bugs and implemented rare instruction (ADD with overflow check).
6) Removed some silly global variables. Now compiled functions receive 7 parameters, such as mem ptr and some PPU regs.
7) Used GHC calling convention: it allows to pass a lot of arguments and saves no registers.
8) Implemented ppu_escape as very fast equivalent to longjmp, but only works with GHC CC gate.
9) Added __unused yet__ greedy mode flag. It will compile every instruction plus it will allow breakpoints by injecting path buffer into every compiled entity, in order to enable __fast__ breakpoints with PPU LLVM, and also as a last resort compatibility measure.