### PR TITLE
Remove SPU and PPU destructors

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -234,6 +234,23 @@ public:
 		_wait_for(-1, true);
 	}
 
+	// Wait for both thread sync var and provided atomic var
+	template <typename T, atomic_wait::op op = atomic_wait::op::eq, typename U>
+	static inline void wait_on(T& wait, U old, u64 usec = -1)
+	{
+		auto _this = g_tls_this_thread;
+
+		if (_this->m_sync.bit_test_reset(2))
+		{
+			return;
+		}
+
+		atomic_wait::list<2> list{};
+		list.set<0, op>(wait, old);
+		list.set<1>(_this->m_sync, 0, 4 + 1);
+		list.wait(atomic_wait_timeout{usec <= 0xffff'ffff'ffff'ffff / 1000 ? usec * 1000 : 0xffff'ffff'ffff'ffff});
+	}
+
 	// Exit.
 	[[noreturn]] static void emergency_exit(std::string_view reason);
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -914,15 +914,6 @@ void ppu_thread::exec_task()
 
 ppu_thread::~ppu_thread()
 {
-	// Deallocate Stack Area
-	ensure(vm::dealloc(stack_addr, vm::stack));
-
-	if (const auto dct = g_fxo->get<lv2_memory_container>())
-	{
-		dct->used -= stack_size;
-	}
-
-	perf_log.notice("Perf stats for STCX reload: successs %u, failure %u", last_succ, last_fail);
 }
 
 ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u32 prio, int detached)

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -634,6 +634,7 @@ public:
 	virtual void cpu_task() override final;
 	virtual void cpu_return() override;
 	virtual ~spu_thread() override;
+	void cleanup();
 	void cpu_init();
 
 	static const u32 id_base = 0x02000000; // TODO (used to determine thread type)

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -22,18 +22,14 @@ void lv2_int_serv::exec()
 	thread_ctrl::notify(*thread);
 }
 
-bool interrupt_thread_exit(ppu_thread& ppu)
-{
-	ppu.state += cpu_flag::exit;
-	return false;
-}
+bool ppu_thread_exit(ppu_thread& ppu);
 
 void lv2_int_serv::join()
 {
 	thread->cmd_list
 	({
 		{ ppu_cmd::ptr_call, 0 },
-		std::bit_cast<u64>(&interrupt_thread_exit)
+		std::bit_cast<u64>(&ppu_thread_exit)
 	});
 
 	thread_ctrl::notify(*thread);

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -2,6 +2,7 @@
 #include "sys_ppu_thread.h"
 
 #include "Emu/IdManager.h"
+#include "Emu/perf_meter.hpp"
 
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
@@ -35,6 +36,22 @@ struct ppu_thread_cleaner
 		}
 	}
 };
+
+bool ppu_thread_exit(ppu_thread& ppu)
+{
+	ppu.state += cpu_flag::exit + cpu_flag::wait;
+	
+	// Deallocate Stack Area
+	ensure(vm::dealloc(ppu.stack_addr, vm::stack) == ppu.stack_size);
+
+	if (const auto dct = g_fxo->get<lv2_memory_container>())
+	{
+		dct->used -= ppu.stack_size;
+	}
+
+	perf_log.notice("Perf stats for STCX reload: successs %u, failure %u", ppu.last_succ, ppu.last_fail);
+	return false;
+}
 
 void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode)
 {
@@ -77,10 +94,15 @@ void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode)
 		ppu.state -= cpu_flag::suspend;
 	}
 
-	if (old_status == ppu_join_status::detached)
+	g_fxo->get<ppu_thread_cleaner>()->clean(old_status == ppu_join_status::detached ? ppu.id : 0);
+
+	if (old_status == ppu_join_status::joinable)
 	{
-		g_fxo->get<ppu_thread_cleaner>()->clean(ppu.id);
+		// Wait for termination
+		ppu.joiner.wait(ppu_join_status::zombie);
 	}
+
+	ppu_thread_exit(ppu);
 }
 
 s32 sys_ppu_thread_yield(ppu_thread& ppu)
@@ -114,7 +136,7 @@ error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr
 			if (value == ppu_join_status::zombie)
 			{
 				value = ppu_join_status::exited;
-				return CELL_EBUSY;
+				return CELL_EAGAIN;
 			}
 
 			if (value == ppu_join_status::exited)
@@ -135,6 +157,10 @@ error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr
 		{
 			lv2_obj::sleep(ppu);
 		}
+		else if (result == CELL_EAGAIN)
+		{
+			thread.joiner.notify_one();
+		}
 
 		return result;
 	});
@@ -144,7 +170,7 @@ error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr
 		return CELL_ESRCH;
 	}
 
-	if (thread.ret && thread.ret != CELL_EBUSY)
+	if (thread.ret && thread.ret != CELL_EAGAIN)
 	{
 		return thread.ret;
 	}
@@ -183,7 +209,7 @@ error_code sys_ppu_thread_detach(ppu_thread& ppu, u32 thread_id)
 
 	const auto thread = idm::check<named_thread<ppu_thread>>(thread_id, [&](ppu_thread& thread) -> CellError
 	{
-		return thread.joiner.atomic_op([](ppu_join_status& value) -> CellError
+		CellError result = thread.joiner.atomic_op([](ppu_join_status& value) -> CellError
 		{
 			if (value == ppu_join_status::zombie)
 			{
@@ -209,6 +235,13 @@ error_code sys_ppu_thread_detach(ppu_thread& ppu, u32 thread_id)
 			value = ppu_join_status::detached;
 			return {};
 		});
+
+		if (result == CELL_EAGAIN)
+		{
+			thread.joiner.notify_one();
+		}
+
+		return result;
 	});
 
 	if (!thread)
@@ -223,7 +256,8 @@ error_code sys_ppu_thread_detach(ppu_thread& ppu, u32 thread_id)
 
 	if (thread.ret == CELL_EAGAIN)
 	{
-		ensure(idm::remove<named_thread<ppu_thread>>(thread_id));
+		g_fxo->get<ppu_thread_cleaner>()->clean(thread_id);
+		g_fxo->get<ppu_thread_cleaner>()->clean(0);
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -99,7 +99,7 @@ void _sys_ppu_thread_exit(ppu_thread& ppu, u64 errorcode)
 	if (old_status == ppu_join_status::joinable)
 	{
 		// Wait for termination
-		ppu.joiner.wait(ppu_join_status::zombie);
+		thread_ctrl::wait_on(ppu.joiner, ppu_join_status::zombie);
 	}
 
 	ppu_thread_exit(ppu);


### PR DESCRIPTION
## Enhancements
* Allow to hold smart pointers of SPU and PPU outside of IDM, need not worrying about delaying the destructors.
## Bugfixes
* PPU exit syscall delayed stack memory deallocation to the destructor of PPU, causing stack to not be released for some time or not at all with detached PPU thread.
* Fix race-condition in SPU LS mapping and unmapping.