### PR TITLE
rsx/gui: Delay game window pop-up until first frame

### DIFF
--- a/rpcs3/Emu/RSX/GSRender.cpp
+++ b/rpcs3/Emu/RSX/GSRender.cpp
@@ -25,14 +25,6 @@ GSRender::~GSRender()
 	}
 }
 
-void GSRender::on_init_rsx()
-{
-	if (m_frame)
-	{
-		m_frame->show();
-	}
-}
-
 void GSRender::on_init_thread()
 {
 	if (m_frame)

--- a/rpcs3/Emu/RSX/GSRender.cpp
+++ b/rpcs3/Emu/RSX/GSRender.cpp
@@ -20,7 +20,6 @@ GSRender::~GSRender()
 
 	if (m_frame)
 	{
-		m_frame->hide();
 		m_frame->close();
 	}
 }

--- a/rpcs3/Emu/RSX/GSRender.h
+++ b/rpcs3/Emu/RSX/GSRender.h
@@ -26,7 +26,6 @@ public:
 	GSRender();
 	~GSRender() override;
 
-	void on_init_rsx() override;
 	void on_init_thread() override;
 	void on_exit() override;
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2039,7 +2039,6 @@ namespace rsx
 
 		std::memset(display_buffers, 0, sizeof(display_buffers));
 
-		on_init_rsx();
 		m_rsx_thread_exiting = false;
 	}
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -809,7 +809,6 @@ namespace rsx
 		virtual void end();
 		virtual void execute_nop_draw();
 
-		virtual void on_init_rsx() = 0;
 		virtual void on_init_thread() = 0;
 		virtual void on_frame_end(u32 buffer, bool forced = false);
 		virtual void flip(const display_flip_info_t& info) = 0;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -286,12 +286,17 @@ bool gs_frame::get_mouse_lock_state()
 
 void gs_frame::close()
 {
-	if (!Emu.IsStopped())
+	Emu.CallAfter([this]()
 	{
-		Emu.Stop();
-	}
+		QWindow::hide(); // Workaround
 
-	Emu.CallAfter([this]() { deleteLater(); });
+		if (!Emu.IsStopped())
+		{
+			Emu.Stop();
+		}
+
+		deleteLater();
+	});
 }
 
 bool gs_frame::shown()

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -301,7 +301,7 @@ bool gs_frame::shown()
 
 void gs_frame::hide()
 {
-	Emu.CallAfter([this]() {QWindow::hide(); });
+	Emu.CallAfter([this]() { QWindow::hide(); });
 }
 
 void gs_frame::show()
@@ -398,6 +398,14 @@ int gs_frame::client_height()
 void gs_frame::flip(draw_context_t, bool /*skip_frame*/)
 {
 	static Timer fps_t;
+
+	if (!m_flip_showed_frame)
+	{
+		// Show on first flip
+		m_flip_showed_frame = true;
+		show();
+		fps_t.Start();
+	}
 
 	++m_frames;
 

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -45,6 +45,7 @@ private:
 	bool m_show_mouse_in_fullscreen = false;
 	bool m_hide_mouse_after_idletime = false;
 	u32 m_hide_mouse_idletime = 2000; // ms
+	bool m_flip_showed_frame = false;
 
 public:
 	gs_frame(const QRect& geometry, const QIcon& appIcon, const std::shared_ptr<gui_settings>& gui_settings);


### PR DESCRIPTION
Removes that initial white screen on boot of every game, even for "Nothing" games or testcases which init rsx but with no frames rendered.
Some games take between half-second to few seconds until this screen changes, when there are no shaders to compile at boot.
It only causes confusion in showing this "frame" for frames the game actually rendered.

## Bugfixes 
* Fixed off-by-one bug in FPS counter of first frame, this fixes stuff like Loadable games clearly displayed a single frame but fps counter is 0.00
* Improve GS frame exit workaround. 