### PR TITLE
spu: Restore workers priority after initialization

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -521,6 +521,9 @@ void spu_cache::initialize()
 			result++;
 		}
 
+		// Restore default priority
+		thread_ctrl::set_native_priority(0);
+
 		return result;
 	});
 


### PR DESCRIPTION
Priority is being lowered on initialization but not restored to 0 after initial cache is built.