### PR TITLE
PPU LLVM: implement ppu_finalize

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -15,6 +15,7 @@
 extern std::shared_ptr<lv2_overlay> ppu_load_overlay(const ppu_exec_object&, const std::string& path);
 
 extern void ppu_initialize(const ppu_module&);
+extern void ppu_finalize(const ppu_module&);
 
 LOG_CHANNEL(sys_overlay);
 
@@ -117,6 +118,8 @@ error_code sys_overlay_unload_module(u32 ovlmid)
 	{
 		vm::dealloc(seg.addr);
 	}
+
+	ppu_finalize(*_main);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -18,6 +18,7 @@
 extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, const std::string&);
 extern void ppu_unload_prx(const lv2_prx& prx);
 extern void ppu_initialize(const ppu_module&);
+extern void ppu_finalize(const ppu_module&);
 
 LOG_CHANNEL(sys_prx);
 
@@ -589,6 +590,8 @@ error_code _sys_prx_unload_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sy
 	}
 
 	ppu_unload_prx(*prx);
+
+	ppu_finalize(*prx);
 
 	//s32 result = prx->exit ? prx->exit() : CELL_OK;
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -69,6 +69,7 @@ atomic_t<u64> g_watchdog_hold_ctr{0};
 extern void ppu_load_exec(const ppu_exec_object&);
 extern void spu_load_exec(const spu_exec_object&);
 extern void ppu_initialize(const ppu_module&);
+extern void ppu_finalize(const ppu_module&);
 extern void ppu_unload_prx(const lv2_prx&);
 extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, const std::string&);
 
@@ -1227,6 +1228,8 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 								idm::remove<lv2_obj, lv2_prx>(idm::last_id());
 								lock.lock();
 								ppu_unload_prx(*prx);
+								lock.unlock();
+								ppu_finalize(*prx);
 								g_progr_fdone++;
 								continue;
 							}


### PR DESCRIPTION
In the old times, we had fixed memory area to store all the executable code and it was so trivially implemented that deallocating something from it was nearly impossible.

Now it's different, but proper deallocation is still a missing piece. Can probably help some games which use a huge amount of sprx modules.