### PR TITLE
GUI: Improve missing firmware handling

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -22,6 +22,7 @@ extern void ppu_finalize(const ppu_module&);
 
 LOG_CHANNEL(sys_prx);
 
+// <string: firmware sprx, int: should hle if 1>
 extern const std::map<std::string_view, int> g_prx_list
 {
 	{ "libaacenc.sprx", 0 },

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1647,9 +1647,24 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			{
 				if (!fs::is_file(g_cfg.vfs.get_dev_flash() + "sys/external/liblv2.sprx"))
 				{
-					if (!GetCallbacks().on_missing_fw())
+					const auto libs = g_cfg.core.libraries_control.get_set();
+
+					extern const std::map<std::string_view, int> g_prx_list;
+
+					// Check if there are any firmware SPRX which may be LLEd during emulation 
+					// Don't prompt GUI confirmation if there aren't any
+					if (std::any_of(g_prx_list.begin(), g_prx_list.end(), [&libs](auto& lib)
+					{
+						return libs.count(std::string(lib.first) + ":lle") || (!lib.second && !libs.count(std::string(lib.first) + ":hle"));
+					}))
 					{
 						Stop();
+
+						CallAfter([this]()
+						{
+							GetCallbacks().on_missing_fw();
+						});
+
 						return game_boot_result::firmware_missing;
 					}
 				}

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -357,7 +357,7 @@ void gui_application::InitializeCallbacks()
 	callbacks.on_missing_fw = [this]()
 	{
 		if (!m_main_window) return false;
-		return m_gui_settings->GetBootConfirmation(m_main_window, gui::ib_confirm_fw);
+		return m_main_window->OnMissingFw();
 	};
 
 	callbacks.handle_taskbar_progress = [this](s32 type, s32 value)

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -222,14 +222,6 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 			title = tr("Exit RPCS3?");
 			message = tr("A game is currently running. Do you really want to close RPCS3?\n\nAny unsaved progress will be lost!\n");
 		}
-		else if (gui_save_entry == gui::ib_confirm_fw)
-		{
-			title = tr("Missing Firmware Detected!");
-			message = tr("Install the PS3 Firmware (Menu: File -> Install Firmware)."
-				"\n<br>For more information read the <a href=\"https://rpcs3.net/quickstart\">quickstart guide</a>."
-				"\nCommercial games do not work without firmware! Do you wish to continue!?");
-			icon = QMessageBox::Critical;
-		}
 
 		int result = QMessageBox::Yes;
 

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -121,7 +121,6 @@ namespace gui
 	const gui_save ib_show_welcome = gui_save(main_window, "infoBoxEnabledWelcome",    true);
 	const gui_save ib_confirm_exit = gui_save(main_window, "confirmationBoxExitGame",  true);
 	const gui_save ib_confirm_boot = gui_save(main_window, "confirmationBoxBootGame",  true);
-	const gui_save ib_confirm_fw   = gui_save(main_window, "confirmationMissingFW",    true);
 
 	const gui_save fd_install_pkg  = gui_save(main_window, "lastExplorePathPKG",  "");
 	const gui_save fd_install_pup  = gui_save(main_window, "lastExplorePathPUP",  "");

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -84,6 +84,7 @@ public:
 	bool Init();
 	~main_window();
 	QIcon GetAppIcon();
+	bool OnMissingFw();
 
 Q_SIGNALS:
 	void RequestLanguageChange(const QString& language);

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -19,8 +19,8 @@ public:
 	{
 		// advanced
 
-		const QString lle_list                     = tr("These libraries are LLE'd by default (lower list), selection will switch to HLE.\nLLE - \"Low Level Emulated\", function code inside the selected SPRX file will be used for exported firmware functions.\nHLE - \"High Level Emulated\", alternative emulator code will be used instead for exported firmware functions.\nIf choosen wrongly, games will not work! If unsure, leave both lists' selection empty.");
-		const QString hle_list                     = tr("These libraries are HLE'd by default (upper list), selection will switch to LLE.\nLLE - \"Low Level Emulated\", function code inside the selected SPRX file will be used for exported firmware functions.\nHLE - \"High Level Emulated\", alternative emulator code will be used instead for exported firmware functions.\nIf choosen wrongly, games will not work! If unsure, leave both lists' selection empty.");
+		const QString lle_list                     = tr("These libraries are LLE'd by default (lower list), selection will switch to HLE.\nLLE - \"Low Level Emulated\", function code inside the selected SPRX file will be used for exported firmware functions.\nHLE - \"High Level Emulated\", alternative emulator code will be used instead for exported firmware functions.\nIf choosen wrongly, games will not work! If unsure, leave both lists empty. HLEing all SPRX allows to boot without firmware installed. (experimental)");
+		const QString hle_list                     = tr("These libraries are HLE'd by default (upper list), selection will switch to LLE.\nLLE - \"Low Level Emulated\", function code inside the selected SPRX file will be used for exported firmware functions.\nHLE - \"High Level Emulated\", alternative emulator code will be used instead for exported firmware functions.\nIf choosen wrongly, games will not work! If unsure, leave both lists empty. HLEing all SPRX allows to boot without firmware installed. (experimental)");
 		const QString lib_default_hle              = tr("Select to LLE. (HLE by default)");
 		const QString lib_default_lle              = tr("Select to HLE. (LLE by default)");
 


### PR DESCRIPTION
## Enhancements
* Install PS3UPDAT.PUP at the spot when booting games whenever firmware is missing. The option to boot games without firmware is still supported when all firmware SPRX are HLEd in firmware settings.
* Pop-up a confirmation dialog in firmware installation if firmware is already installed and log it.
## Screenshots:

![unknown (1)](https://user-images.githubusercontent.com/18193363/106036300-d30fd080-60dd-11eb-8718-e99230d1901e.png)
![image](https://user-images.githubusercontent.com/18193363/108876571-083d0f00-7607-11eb-916f-1385b28f8d0d.png)

