### PR TITLE
Fix minor issue with usage of STL thread::hardware_concurrency()

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2518,7 +2518,7 @@ u64 thread_ctrl::get_affinity_mask(thread_class group)
 {
 	detect_cpu_layout();
 
-	if (const auto thread_count = std::thread::hardware_concurrency())
+	if (const auto thread_count = utils::get_thread_count())
 	{
 		const u64 all_cores_mask = process_affinity_mask;
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2130,7 +2130,7 @@ extern void ppu_initialize(const ppu_module& info)
 
 		static s32 limit()
 		{
-			return static_cast<s32>(std::thread::hardware_concurrency());
+			return static_cast<s32>(utils::get_thread_count());
 		}
 	};
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9035,7 +9035,7 @@ struct spu_llvm
 
 		u32 worker_count = 1;
 
-		if (uint hc = std::thread::hardware_concurrency(); hc >= 12)
+		if (uint hc = utils::get_thread_count(); hc >= 12)
 		{
 			worker_count = hc - 10;
 		}

--- a/rpcs3/Emu/RSX/GL/GLPipelineCompiler.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPipelineCompiler.cpp
@@ -4,6 +4,8 @@
 
 #include <thread>
 
+#include "util/sysinfo.hpp"
+
 namespace gl
 {
 	// Global list of worker threads
@@ -97,7 +99,7 @@ namespace gl
 		if (num_worker_threads == 0)
 		{
 			// Select optimal number of compiler threads
-			const auto hw_threads = std::thread::hardware_concurrency();
+			const auto hw_threads = utils::get_thread_count();
 			if (hw_threads > 12)
 			{
 				num_worker_threads = 6;

--- a/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
@@ -6,6 +6,8 @@
 
 #include <thread>
 
+#include "util/sysinfo.hpp"
+
 namespace vk
 {
 	// Global list of worker threads
@@ -186,7 +188,7 @@ namespace vk
 		if (num_worker_threads == 0)
 		{
 			// Select optimal number of compiler threads
-			const auto hw_threads = std::thread::hardware_concurrency();
+			const auto hw_threads = utils::get_thread_count();
 			if (hw_threads > 12)
 			{
 				num_worker_threads = 6;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -16,6 +16,7 @@
 #include <unordered_map>
 
 #include "util/vm.hpp"
+#include "util/sysinfo.hpp"
 
 namespace rsx
 {
@@ -628,7 +629,7 @@ namespace rsx
 
 			// Preload everything needed to compile the shaders
 			unpacked_type unpacked;
-			uint nb_workers = g_cfg.video.renderer == video_renderer::vulkan ? std::thread::hardware_concurrency() : 1;
+			uint nb_workers = g_cfg.video.renderer == video_renderer::vulkan ? utils::get_thread_count() : 1;
 
 			load_shaders(nb_workers, unpacked, directory_path, entries, entry_count, dlg);
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2023,7 +2023,8 @@ std::string Emulator::GetFormattedTitle(double fps) const
 u32 Emulator::GetMaxThreads() const
 {
 	const u32 max_threads = static_cast<u32>(g_cfg.core.llvm_threads);
-	const u32 thread_count = max_threads > 0 ? std::min(max_threads, std::thread::hardware_concurrency()) : std::thread::hardware_concurrency();
+	const u32 hw_threads = utils::get_thread_count();
+	const u32 thread_count = max_threads > 0 ? std::min(max_threads, hw_threads) : hw_threads;
 	return thread_count;
 }
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1145,9 +1145,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	// Comboboxes
 
-	m_emu_settings->EnhanceComboBox(ui->maxLLVMThreads, emu_settings_type::MaxLLVMThreads, true, true, std::thread::hardware_concurrency());
+	m_emu_settings->EnhanceComboBox(ui->maxLLVMThreads, emu_settings_type::MaxLLVMThreads, true, true, utils::get_thread_count());
 	SubscribeTooltip(ui->gb_max_llvm, tooltips.settings.max_llvm_threads);
-	ui->maxLLVMThreads->setItemText(ui->maxLLVMThreads->findData(0), tr("All (%1)", "Max LLVM threads").arg(std::thread::hardware_concurrency()));
+	ui->maxLLVMThreads->setItemText(ui->maxLLVMThreads->findData(0), tr("All (%1)", "Max LLVM threads").arg(utils::get_thread_count()));
 
 	m_emu_settings->EnhanceComboBox(ui->perfOverlayDetailLevel, emu_settings_type::PerfOverlayDetailLevel);
 	SubscribeTooltip(ui->perf_overlay_detail_level, tooltips.settings.perf_overlay_detail_level);

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -409,13 +409,18 @@ u64 utils::get_total_memory()
 
 u32 utils::get_thread_count()
 {
+	static const u32 g_count = []()
+	{
 #ifdef _WIN32
-	::SYSTEM_INFO sysInfo;
-	::GetNativeSystemInfo(&sysInfo);
-	return sysInfo.dwNumberOfProcessors;
+		::SYSTEM_INFO sysInfo;
+		::GetNativeSystemInfo(&sysInfo);
+		return sysInfo.dwNumberOfProcessors;
 #else
-	return ::sysconf(_SC_NPROCESSORS_ONLN);
+		return ::sysconf(_SC_NPROCESSORS_ONLN);
 #endif
+	}();
+
+	return g_count;
 }
 
 u32 utils::get_cpu_family()


### PR DESCRIPTION
If the implementation does not implement/support this function, for whatever reason, it can return 0.