### PR TITLE
Implement OVL (overlay) loading mode

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -431,6 +431,11 @@ void cpu_thread::operator()()
 
 	while (!g_fxo->get<cpu_profiler>())
 	{
+		if (Emu.IsStopped())
+		{
+			return;
+		}
+
 		// Can we have a little race, right? First thread is started concurrently with g_fxo->init()
 		std::this_thread::sleep_for(1ms);
 	}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2082,7 +2082,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_
 	std::vector<std::pair<std::string, u64>> file_queue;
 	file_queue.reserve(2000);
 
-	// Find all .sprx files recursively (TODO: process .mself files)
+	// Find all .sprx files recursively
 	for (usz i = 0; i < dir_queue.size(); i++)
 	{
 		if (Emu.IsStopped())


### PR DESCRIPTION
* Allow to load OVL alone.
* Add error checks in ppu_load_exec(), do not crash on error. I encountered such crash when loading an overlay module.
* Fix crash on exit from standalone PRX mode, allow kernel explorer to work with it as well for the added OVL mode.