### PR TITLE
Fix ppu compilation progress dialog

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -114,6 +114,7 @@ public:
 	virtual void ProgressBarSetMsg(u32 progressBarIndex, const std::string& msg) = 0;
 	virtual void ProgressBarReset(u32 progressBarIndex) = 0;
 	virtual void ProgressBarInc(u32 progressBarIndex, u32 delta) = 0;
+	virtual void ProgressBarSetValue(u32 progressBarIndex, u32 value) = 0;
 	virtual void ProgressBarSetLimit(u32 index, u32 limit) = 0;
 
 	void ProgressBarSetTaskbarIndex(s32 index)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -368,7 +368,6 @@ namespace
 				u32 fdone = 0;
 				u32 ptotal = 0;
 				u32 pdone = 0;
-				u32 value = 0;
 
 				// Update progress
 				while (thread_ctrl::state() != thread_state::aborting)
@@ -383,12 +382,7 @@ namespace
 						// Compute new progress in percents
 						const u32 total = ftotal + ptotal;
 						const u32 done = fdone + pdone;
-						const u32 new_value = static_cast<u32>(double(done) * 100. / double(total ? total : 1));
-
-						// Compute the difference
-						const u32 delta = new_value > value ? new_value - value : 0;
-
-						value += delta;
+						const double value = double(done) * 100. / double(total ? total : 1);
 
 						// Changes detected, send update
 						Emu.CallAfter([=]()
@@ -404,7 +398,7 @@ namespace
 							{
 								dlg->SetMsg(+g_progr);
 								dlg->ProgressBarSetMsg(0, progr);
-								dlg->ProgressBarInc(0, delta);
+								dlg->ProgressBarSetValue(0, std::floor(value));
 							}
 						});
 					}

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -271,6 +271,37 @@ void msg_dialog_frame::ProgressBarInc(u32 index, u32 delta)
 	}
 }
 
+void msg_dialog_frame::ProgressBarSetValue(u32 index, u32 value)
+{
+	if (!m_dialog)
+	{
+		return;
+	}
+
+	if (index == 0 && m_gauge1)
+	{
+		m_gauge1->setValue(std::min(static_cast<int>(value), m_gauge1->maximum()));
+	}
+
+	if (index == 1 && m_gauge2)
+	{
+		m_gauge2->setValue(std::min(static_cast<int>(value), m_gauge2->maximum()));
+	}
+
+	if (index == taskbar_index + 0u || taskbar_index == -1)
+	{
+#ifdef _WIN32
+		if (m_tb_progress)
+		{
+			m_tb_progress->setValue(std::min(static_cast<int>(value), m_tb_progress->maximum()));
+		}
+#elif HAVE_QTDBUS
+		m_progress_value = std::min(static_cast<int>(value), m_gauge_max);
+		UpdateProgress(m_progress_value);
+#endif
+	}
+}
+
 void msg_dialog_frame::ProgressBarSetLimit(u32 index, u32 limit)
 {
 	if (!m_dialog)

--- a/rpcs3/rpcs3qt/msg_dialog_frame.h
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.h
@@ -44,6 +44,7 @@ public:
 	virtual void ProgressBarSetMsg(u32 progressBarIndex, const std::string& msg) override;
 	virtual void ProgressBarReset(u32 progressBarIndex) override;
 	virtual void ProgressBarInc(u32 progressBarIndex, u32 delta) override;
+	virtual void ProgressBarSetValue(u32 progressBarIndex, u32 value) override;
 	virtual void ProgressBarSetLimit(u32 index, u32 limit) override;
 #ifdef HAVE_QTDBUS
 private:


### PR DESCRIPTION
We could only increase the value because we completely based the dialog on cellMsgDialog.
This led to an issue where the dialog would increase its maximum and thus decrease the current percentage.
It then couldn't decrease and was stuck on the old percentage.