### PR TITLE
60fps shader loading dialog

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.cpp
@@ -65,6 +65,22 @@ namespace rsx
 		});
 	}
 
+	void shader_loading_dialog::set_value(u32 index, u32 value)
+	{
+		if (!dlg)
+		{
+			return;
+		}
+
+		ref_cnt++;
+
+		Emu.CallAfter([&, index, value]()
+		{
+			dlg->ProgressBarSetValue(index, value);
+			ref_cnt--;
+		});
+	}
+
 	void shader_loading_dialog::set_limit(u32 index, u32 limit)
 	{
 		if (!dlg)

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.h
@@ -12,6 +12,7 @@ namespace rsx
 		virtual void create(const std::string& msg, const std::string& title);
 		virtual void update_msg(u32 index, const std::string& msg);
 		virtual void inc_value(u32 index, u32 value);
+		virtual void set_value(u32 index, u32 value);
 		virtual void set_limit(u32 index, u32 limit);
 		virtual void refresh();
 		virtual void close();

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
@@ -38,6 +38,12 @@ namespace rsx
 		owner->flip({});
 	}
 
+	void shader_loading_dialog_native::set_value(u32 index, u32 value)
+	{
+		dlg->progress_bar_set_value(index, static_cast<f32>(value));
+		owner->flip({});
+	}
+
 	void shader_loading_dialog_native::set_limit(u32 index, u32 limit)
 	{
 		dlg->progress_bar_set_limit(index, limit);

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.h
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.h
@@ -23,6 +23,7 @@ namespace rsx
 		void create(const std::string& msg, const std::string&/* title*/) override;
 		void update_msg(u32 index, const std::string& msg) override;
 		void inc_value(u32 index, u32 value) override;
+		void set_value(u32 index, u32 value) override;
 		void set_limit(u32 index, u32 limit) override;
 		void refresh() override;
 		void close() override;

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -324,6 +324,22 @@ namespace rsx
 			return CELL_OK;
 		}
 
+		error_code message_dialog::progress_bar_set_value(u32 index, f32 value)
+		{
+			if (index >= num_progress_bars)
+				return CELL_MSGDIALOG_ERROR_PARAM;
+
+			if (index == 0)
+				progress_1.set_value(value);
+			else
+				progress_2.set_value(value);
+
+			if (index == static_cast<u32>(taskbar_index) || taskbar_index == -1)
+				Emu.GetCallbacks().handle_taskbar_progress(3, static_cast<s32>(value));
+
+			return CELL_OK;
+		}
+
 		error_code message_dialog::progress_bar_reset(u32 index)
 		{
 			if (index >= num_progress_bars)

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
@@ -39,6 +39,7 @@ namespace rsx
 			void progress_bar_set_taskbar_index(s32 index);
 			error_code progress_bar_set_message(u32 index, const std::string& msg);
 			error_code progress_bar_increment(u32 index, f32 value);
+			error_code progress_bar_set_value(u32 index, f32 value);
 			error_code progress_bar_reset(u32 index);
 			error_code progress_bar_set_limit(u32 index, u32 limit);
 		};

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -521,10 +521,10 @@ namespace rsx
 
 					worker(stop_at);
 
-					// Only update the screen at about 10fps since updating it everytime slows down the process
+					// Only update the screen at about 60fps since updating it everytime slows down the process
 					steady_clock::time_point now = steady_clock::now();
 					processed_since_last_update += inc;
-					if ((std::chrono::duration_cast<std::chrono::milliseconds>(now - last_update) > 100ms) || (stop_at == entry_count))
+					if ((std::chrono::duration_cast<std::chrono::milliseconds>(now - last_update) > 16ms) || (stop_at == entry_count))
 					{
 						dlg->update_msg(step, get_message(step, stop_at, entry_count));
 						dlg->inc_value(step, processed_since_last_update);
@@ -544,7 +544,7 @@ namespace rsx
 				u32 last_update_progress = 0;
 				while ((current_progress < entry_count) && !Emu.IsStopped())
 				{
-					std::this_thread::sleep_for(100ms); // Around 10fps should be good enough
+					std::this_thread::sleep_for(16ms); // Around 60fps should be good enough
 
 					current_progress = std::min(processed.load(), entry_count);
 					processed_since_last_update = current_progress - last_update_progress;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -506,30 +506,25 @@ namespace rsx
 
 		void await_workers(uint nb_workers, u8 step, std::function<void(u32)>& worker, atomic_t<u32>& processed, u32 entry_count, shader_loading_dialog* dlg)
 		{
-			u32 processed_since_last_update = 0;
-
 			if (nb_workers == 1)
 			{
 				steady_clock::time_point last_update;
 
-				// Call the worker function directly, stoping it prematurely to be able update the screen
-				u8 inc = 10;
+				// Call the worker function directly, stopping it prematurely to be able update the screen
 				u32 stop_at = 0;
 				do
 				{
-					stop_at = std::min(stop_at + inc, entry_count);
+					stop_at = std::min(stop_at + 10, entry_count);
 
 					worker(stop_at);
 
 					// Only update the screen at about 60fps since updating it everytime slows down the process
 					steady_clock::time_point now = steady_clock::now();
-					processed_since_last_update += inc;
 					if ((std::chrono::duration_cast<std::chrono::milliseconds>(now - last_update) > 16ms) || (stop_at == entry_count))
 					{
 						dlg->update_msg(step, get_message(step, stop_at, entry_count));
-						dlg->inc_value(step, processed_since_last_update);
+						dlg->set_value(step, stop_at);
 						last_update = now;
-						processed_since_last_update = 0;
 					}
 				} while (stop_at < entry_count && !Emu.IsStopped());
 			}
@@ -547,13 +542,12 @@ namespace rsx
 					std::this_thread::sleep_for(16ms); // Around 60fps should be good enough
 
 					current_progress = std::min(processed.load(), entry_count);
-					processed_since_last_update = current_progress - last_update_progress;
-					last_update_progress = current_progress;
 
-					if (processed_since_last_update > 0)
+					if (last_update_progress != current_progress)
 					{
+						last_update_progress = current_progress;
 						dlg->update_msg(step, get_message(step, current_progress, entry_count));
-						dlg->inc_value(step, processed_since_last_update);
+						dlg->set_value(step, current_progress);
 					}
 				}
 			}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -45,7 +45,7 @@ struct EmuCallbacks
 	std::function<void()> on_ready;
 	std::function<bool()> on_missing_fw;
 	std::function<bool(bool, std::function<void()>)> try_to_quit; // (force_quit, on_exit) Try to close RPCS3
-	std::function<void(s32, s32)> handle_taskbar_progress; // (type, value) type: 0 for reset, 1 for increment, 2 for set_limit
+	std::function<void(s32, s32)> handle_taskbar_progress; // (type, value) type: 0 for reset, 1 for increment, 2 for set_limit, 3 for set_value
 	std::function<void()> init_kb_handler;
 	std::function<void()> init_mouse_handler;
 	std::function<void(std::string_view title_id)> init_pad_handler;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -645,6 +645,19 @@ void gs_frame::progress_reset(bool reset_limit)
 	}
 }
 
+void gs_frame::progress_set_value(int value)
+{
+#ifdef _WIN32
+	if (m_tb_progress)
+	{
+		m_tb_progress->setValue(std::clamp(value, m_tb_progress->minimum(), m_tb_progress->maximum()));
+	}
+#elif HAVE_QTDBUS
+	m_progress_value = std::clamp(value, 0, m_gauge_max);
+	UpdateProgress(m_progress_value);
+#endif
+}
+
 void gs_frame::progress_increment(int delta)
 {
 	if (delta == 0)
@@ -655,11 +668,10 @@ void gs_frame::progress_increment(int delta)
 #ifdef _WIN32
 	if (m_tb_progress)
 	{
-		m_tb_progress->setValue(std::clamp(m_tb_progress->value() + delta, m_tb_progress->minimum(), m_tb_progress->maximum()));
+		progress_set_value(m_tb_progress->value() + delta);
 	}
 #elif HAVE_QTDBUS
-	m_progress_value = std::clamp(m_progress_value + delta, 0, m_gauge_max);
-	UpdateProgress(m_progress_value);
+	progress_set_value(m_progress_value + delta);
 #endif
 }
 

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -58,6 +58,7 @@ public:
 
 	// taskbar progress
 	void progress_reset(bool reset_limit = false);
+	void progress_set_value(int value);
 	void progress_increment(int delta);
 	void progress_set_limit(int limit);
 

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -363,6 +363,7 @@ void gui_application::InitializeCallbacks()
 			case 0: static_cast<gs_frame*>(m_game_window)->progress_reset(value); break;
 			case 1: static_cast<gs_frame*>(m_game_window)->progress_increment(value); break;
 			case 2: static_cast<gs_frame*>(m_game_window)->progress_set_limit(value); break;
+			case 3: static_cast<gs_frame*>(m_game_window)->progress_set_value(value); break;
 			default: gui_log.fatal("Unknown type in handle_taskbar_progress(type=%d, value=%d)", type, value); break;
 			}
 		}


### PR DESCRIPTION
- Updates the native shader loading dialog at a much smoother 60fps instead of the jittery 10fps we currently have.
The smoother update feels much faster and the additional load should be neglectible, especially with multithreading.

- Implements and uses set_value for the native progress dialogs, following my earlier change to the Qt message dialog.
This will come in handy later on and also simplifies some existing code.