### PR TITLE
 Fix ppu progress dialog percentage

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -78,7 +78,7 @@ std::array<std::deque<std::string>, 16> g_tty_input;
 std::mutex g_tty_mutex;
 
 // Progress display server synchronization variables
-atomic_t<const char*> g_progr{nullptr};
+atomic_t<const char*> g_progr{""};
 atomic_t<u32> g_progr_ftotal{0};
 atomic_t<u32> g_progr_fdone{0};
 atomic_t<u32> g_progr_ptotal{0};

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -385,9 +385,10 @@ namespace
 						pdone  = pdone_new;
 
 						// Compute new progress in percents
-						const u32 total = ftotal + ptotal;
-						const u32 done = fdone + pdone;
-						const double value = double(done) * 100. / double(total ? total : 1);
+						// Assume not all programs were found if files were not compiled (as it may contain more)
+						const u64 total = std::max<u64>(ptotal, 1) * std::max<u64>(ftotal, 1);
+						const u64 done = pdone * std::max<u64>(fdone, 1);
+						const double value = std::fmin(done * 100. / total, 100.);
 
 						// Changes detected, send update
 						Emu.CallAfter([=]()

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -439,6 +439,14 @@ namespace
 			}
 		}
 
+		~progress_dialog_server()
+		{
+			g_progr_ftotal.release(0);
+			g_progr_fdone.release(0);
+			g_progr_ptotal.release(0);
+			g_progr_pdone.release(0);
+		}
+
 		static auto constexpr thread_name = "Progress Dialog Server"sv;
 	};
 }


### PR DESCRIPTION
Good example is MGS4's precompilation: most of the time it would stay on 90%+ when in reality it has much more time to compile.