### PR TITLE
Fix freezes in HLE Vdec and SPU LLVM precompilation.

### DIFF
--- a/Utilities/lockless.h
+++ b/Utilities/lockless.h
@@ -365,64 +365,6 @@ public:
 
 		return count;
 	}
-
-	// Iterator that enables direct endless range-for loop: for (auto* ptr : queue) ...
-	class iterator
-	{
-		lf_queue* _this = nullptr;
-
-		lf_queue_slice<T> m_data;
-
-	public:
-		constexpr iterator() = default;
-
-		explicit iterator(lf_queue* _this)
-			: _this(_this)
-		{
-			m_data = _this->pop_all();
-		}
-
-		bool operator !=(const iterator& rhs) const
-		{
-			return _this != rhs._this;
-		}
-
-		T* operator *() const
-		{
-			return m_data ? m_data.get() : nullptr;
-		}
-
-		iterator& operator ++()
-		{
-			if (m_data)
-			{
-				m_data.pop_front();
-			}
-
-			if (!m_data)
-			{
-				m_data = _this->pop_all();
-
-				if (!m_data)
-				{
-					_this->wait();
-					m_data = _this->pop_all();
-				}
-			}
-
-			return *this;
-		}
-	};
-
-	iterator begin()
-	{
-		return iterator{this};
-	}
-
-	iterator end()
-	{
-		return iterator{};
-	}
 };
 
 // Concurrent linked list, elements remain until destroyed.

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5,7 +5,6 @@
 #include "Crypto/unself.h"
 #include "Loader/ELF.h"
 #include "Loader/mself.hpp"
-#include "Loader/PSF.h"
 #include "Emu/perf_meter.hpp"
 #include "Emu/Memory/vm_reservation.h"
 #include "Emu/Memory/vm_locking.h"


### PR DESCRIPTION
Freezes could accidentally occur on close.
Deprecate range-for loop on lf_queue.
This is a part of PR #9208

Co-authored-by: Eladash <elad3356p@gmail.com>