### PR TITLE
Fixup for LLVM constraints

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -757,7 +757,7 @@ bool cpu_thread::check_state() noexcept
 				{
 					u64 ctr = g_suspend_counter;
 
-					if (ctr >> 2 == s_tls_sctr >> 2)
+					if (ctr >> 2 == s_tls_sctr >> 2 && state & cpu_flag::pause)
 					{
 						if (i < 20 || ctr & 1)
 						{
@@ -765,7 +765,8 @@ bool cpu_thread::check_state() noexcept
 						}
 						else
 						{
-							g_suspend_counter.wait(ctr, -4);
+							// TODO: fix the workaround
+							g_suspend_counter.wait(ctr, -4, atomic_wait_timeout{100});
 						}
 					}
 					else

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -534,7 +534,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry, u32 end)
 	// Assume first segment is executable
 	const u32 start = segs[0].addr;
 
-	if (end == umax)
+	if (!end)
 	{
 		end = segs[0].addr + segs[0].size;
 	}

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -89,7 +89,7 @@ struct ppu_module
 		secs = info.secs;
 	}
 
-	void analyse(u32 lib_toc, u32 entry, u32 end = -1);
+	void analyse(u32 lib_toc, u32 entry, u32 end = 0);
 	void validate(u32 reloc);
 };
 


### PR DESCRIPTION
1) Workaround for possible freezes on TSX path
2) Significantly reduced PPU LLVM compilation unit weight by using information from sections if available.