### PR TITLE
Allow BootGame with indirect paths

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -669,24 +669,29 @@ game_boot_result Emulator::BootGame(const std::string& path, const std::string& 
 	if (g_cfg.vfs.limit_cache_size)
 		LimitCacheSize();
 
-	static const char* boot_list[] =
+	if (!fs::exists(path))
 	{
-		"/eboot.bin",
-		"/EBOOT.BIN",
-		"/USRDIR/EBOOT.BIN",
-		"/USRDIR/ISO.BIN.EDAT",
-		"/PS3_GAME/USRDIR/EBOOT.BIN",
-	};
+		return game_boot_result::invalid_file_or_folder;
+	}
 
 	m_path_old = m_path;
 
-	if (direct && fs::exists(path))
+	if (direct || fs::is_file(path))
 	{
 		m_path = path;
 		return Load(title_id, add_only, force_global_config);
 	}
 
 	game_boot_result result = game_boot_result::nothing_to_boot;
+
+	static const char* boot_list[] =
+	{
+		"/EBOOT.BIN",
+		"/USRDIR/EBOOT.BIN",
+		"/USRDIR/ISO.BIN.EDAT",
+		"/PS3_GAME/USRDIR/EBOOT.BIN",
+	};
+
 	for (std::string elf : boot_list)
 	{
 		elf = path + elf;

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -577,7 +577,7 @@ int main(int argc, char** argv)
 			Emu.argv = std::move(argv);
 			Emu.SetForceBoot(true);
 
-			if (const game_boot_result error = Emu.BootGame(path, "", true); error != game_boot_result::no_errors)
+			if (const game_boot_result error = Emu.BootGame(path, ""); error != game_boot_result::no_errors)
 			{
 				sys_log.error("Booting '%s' with cli argument failed: reason: %s", path, error);
 


### PR DESCRIPTION
I don't remember if there was a reason to have it set to direct.
Maybe someone knows ?