### PR TITLE
PPU LLVM: properly compile patched instructions (need testing)

### DIFF
--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -129,15 +129,15 @@ public:
 	void append_title_patches(const std::string& title_id);
 
 	// Apply patch (returns the number of entries applied)
-	usz apply(const std::string& name, u8* dst);
+	std::basic_string<u32> apply(const std::string& name, u8* dst);
 
 	// Apply patch with a check that the address exists in SPU local storage
-	usz apply_with_ls_check(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
+	std::basic_string<u32> apply_with_ls_check(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
 
 private:
 	// Internal: Apply patch (returns the number of entries applied)
-	template <bool check_local_storage>
-	usz apply_patch(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
+	template <bool CheckLS>
+	std::basic_string<u32> apply_patch(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
 
 	// Database
 	patch_map m_map;

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -89,7 +89,7 @@ struct ppu_module
 		secs = info.secs;
 	}
 
-	void analyse(u32 lib_toc, u32 entry, u32 end = 0);
+	void analyse(u32 lib_toc, u32 entry, u32 end, const std::basic_string<u32>& applied);
 	void validate(u32 reloc);
 };
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1101,19 +1101,13 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 		applied += g_fxo->get<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
 	}
 
-	if (!applied.empty())
-	{
-		// TODO (invalidate constraints if patches were applied)
-		end = 0;
-	}
-
 	// Embedded SPU elf patching
 	for (const auto& seg : prx->segs)
 	{
 		ppu_check_patch_spu_images(seg);
 	}
 
-	prx->analyse(toc, 0, end);
+	prx->analyse(toc, 0, end, applied);
 
 	ppu_loader.success("PRX library hash: %s (<- %u)", hash, applied.size());
 
@@ -1558,14 +1552,8 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 	_main->name.clear();
 	_main->path = vfs::get(Emu.argv[0]);
 
-	if (!applied.empty())
-	{
-		// TODO (invalidate constraints if patches were applied)
-		end = 0;
-	}
-
 	// Analyse executable (TODO)
-	_main->analyse(0, static_cast<u32>(elf.header.e_entry), end);
+	_main->analyse(0, static_cast<u32>(elf.header.e_entry), end, applied);
 
 	// Validate analyser results (not required)
 	_main->validate(0);
@@ -1962,14 +1950,8 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 
 	ovlm->entry = static_cast<u32>(elf.header.e_entry);
 
-	if (!applied.empty())
-	{
-		// TODO (invalidate constraints if patches were applied)
-		end = 0;
-	}
-
 	// Analyse executable (TODO)
-	ovlm->analyse(0, ovlm->entry, end);
+	ovlm->analyse(0, ovlm->entry, end, applied);
 
 	// Validate analyser results (not required)
 	ovlm->validate(0);

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -717,7 +717,7 @@ static void ppu_check_patch_spu_images(const ppu_segment& seg)
 		std::string name;
 		std::string dump;
 
-		usz applied = 0;
+		std::basic_string<u32> applied;
 
 		// Executable hash
 		sha1_context sha2;
@@ -782,7 +782,7 @@ static void ppu_check_patch_spu_images(const ppu_segment& seg)
 			}
 		}
 
-		ppu_loader.success("SPU executable hash: %s (<- %u)%s", hash, applied, dump);
+		ppu_loader.success("SPU executable hash: %s (<- %u)%s", hash, applied.size(), dump);
 	}
 }
 
@@ -1107,7 +1107,7 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 		applied += g_fxo->get<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
 	}
 
-	if (applied)
+	if (!applied.empty())
 	{
 		// TODO (invalidate constraints if patches were applied)
 		end = 0;
@@ -1121,7 +1121,7 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 
 	prx->analyse(toc, 0, end);
 
-	ppu_loader.success("PRX library hash: %s (<- %u)", hash, applied);
+	ppu_loader.success("PRX library hash: %s (<- %u)", hash, applied.size());
 
 	try_spawn_ppu_if_exclusive_program(*prx);
 
@@ -1330,7 +1330,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		applied += g_fxo->get<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
 	}
 
-	ppu_loader.success("PPU executable hash: %s (<- %u)", hash, applied);
+	ppu_loader.success("PPU executable hash: %s (<- %u)", hash, applied.size());
 
 	// Initialize HLE modules
 	ppu_initialize_modules(link);
@@ -1570,7 +1570,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 	_main->name.clear();
 	_main->path = vfs::get(Emu.argv[0]);
 
-	if (applied)
+	if (!applied.empty())
 	{
 		// TODO (invalidate constraints if patches were applied)
 		end = 0;
@@ -1893,7 +1893,7 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 		ppu_check_patch_spu_images(seg);
 	}
 
-	ppu_loader.success("OVL executable hash: %s (<- %u)", hash, applied);
+	ppu_loader.success("OVL executable hash: %s (<- %u)", hash, applied.size());
 
 	// Load other programs
 	for (auto& prog : elf.progs)
@@ -1980,7 +1980,7 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 
 	ovlm->entry = static_cast<u32>(elf.header.e_entry);
 
-	if (applied)
+	if (!applied.empty())
 	{
 		// TODO (invalidate constraints if patches were applied)
 		end = 0;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -176,7 +176,7 @@ void sys_spu_image::deploy(u8* loc, sys_spu_segment* segs, u32 nsegs)
 		applied += g_fxo->get<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, loc);
 	}
 
-	spu_log.notice("Loaded SPU image: %s (<- %u)%s", hash, applied, dump);
+	spu_log.notice("Loaded SPU image: %s (<- %u)%s", hash, applied.size(), dump);
 }
 
 // Get spu thread ptr, returns group ptr as well for refcounting


### PR DESCRIPTION
Use some information exported from the patch engine.

Also possibly fix SPRX patching.