### PR TITLE
Tiny fix for zombie PPU threads

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1689,6 +1689,9 @@ void spu_thread::cleanup()
 
 	// Free range lock (and signals cleanup was called to the destructor)
 	vm::free_range_lock(range_lock);
+
+	// Signal the debugger about the termination
+	state += cpu_flag::exit;
 }
 
 spu_thread::~spu_thread()


### PR DESCRIPTION
## Bugfixes
* Fix termination wait for zombie PPU threads.
* Because debugger now relies on the combination of exit + wait flag to tell if thread has been terminated, wait for actual termination for zombie threads to add exit flag.
* Always signal the debugger about SPU termination.