### PR TITLE
Main: Stop logger on very early exit

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -127,6 +127,7 @@ void main_window::Init()
 
 		if (msg.exec() == QMessageBox::No)
 		{
+			logs::stop();
 			std::exit(EXIT_SUCCESS);
 		}
 	}

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -184,6 +184,11 @@ namespace logs
 		}
 	}
 
+	void stop()
+	{
+		get_logger()->~root_listener();
+	}
+
 	void set_level(const std::string& ch_name, level value)
 	{
 		std::lock_guard lock(g_mutex);

--- a/rpcs3/util/logs.hpp
+++ b/rpcs3/util/logs.hpp
@@ -122,6 +122,9 @@ namespace logs
 	// Log level control: set all channels to level::notice
 	void reset();
 
+	// Shut it down
+	void stop();
+
 	// Log level control: set all channels to level::always
 	void silence();
 


### PR DESCRIPTION
fixes #9720 

Just threw together a POC, feels kinda hacky. Would it make more sense to move the Init() calls to before the log is initialized? That would allow the exit() call to function normally. Or there's probably some known better way in this ocean of a codebase that I couldn't find.