### PR TITLE
Support logger stopping at std::exit

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -77,7 +77,7 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 	const bool local = s_qt_init.try_lock();
 
 	// Possibly created and assigned here
-	QScopedPointer<QCoreApplication> app;
+	static QScopedPointer<QCoreApplication> app;
 
 	if (local)
 	{
@@ -110,7 +110,6 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 		{
 			// Since we only show an error, we can hope for a graceful exit
 			show_report(text);
-			app.reset();
 			std::exit(0);
 		}
 		else
@@ -372,7 +371,7 @@ int main(int argc, char** argv)
 #endif
 
 	// Initialize thread pool finalizer (on first use)
-	static named_thread("", []{})();
+	named_thread("", []{})();
 
 	static std::unique_ptr<logs::listener> log_file;
 	{
@@ -451,12 +450,12 @@ int main(int argc, char** argv)
 	// but I haven't found an implicit way to check for style yet, so we naively check them both here for now.
 	const bool use_cli_style = find_arg(arg_style, argc, argv) || find_arg(arg_stylesheet, argc, argv);
 
-	QScopedPointer<QCoreApplication> app(createApplication(argc, argv));
+	static QScopedPointer<QCoreApplication> app(createApplication(argc, argv));
 	app->setApplicationVersion(QString::fromStdString(rpcs3::get_version().to_string()));
 	app->setApplicationName("RPCS3");
 
 	// Command line args
-	QCommandLineParser parser;
+	static QCommandLineParser parser;
 	parser.setApplicationDescription("Welcome to RPCS3 command line.");
 	parser.addPositionalArgument("(S)ELF", "Path for directly executing a (S)ELF");
 	parser.addPositionalArgument("[Args...]", "Optional args for the executable");

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -450,7 +450,7 @@ int main(int argc, char** argv)
 	// but I haven't found an implicit way to check for style yet, so we naively check them both here for now.
 	const bool use_cli_style = find_arg(arg_style, argc, argv) || find_arg(arg_stylesheet, argc, argv);
 
-	static QScopedPointer<QCoreApplication> app(createApplication(argc, argv));
+	QScopedPointer<QCoreApplication> app(createApplication(argc, argv));
 	app->setApplicationVersion(QString::fromStdString(rpcs3::get_version().to_string()));
 	app->setApplicationName("RPCS3");
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -325,7 +325,7 @@ int main(int argc, char** argv)
 
 	const std::string lock_name = fs::get_cache_dir() + "RPCS3.buf";
 
-	fs::file instance_lock;
+	static fs::file instance_lock;
 
 	// True if an argument --updating found
 	const bool is_updating = find_arg(arg_updating, argc, argv) != 0;
@@ -372,7 +372,7 @@ int main(int argc, char** argv)
 #endif
 
 	// Initialize thread pool finalizer (on first use)
-	named_thread("", []{})();
+	static named_thread("", []{})();
 
 	static std::unique_ptr<logs::listener> log_file;
 	{

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -374,7 +374,7 @@ int main(int argc, char** argv)
 	// Initialize thread pool finalizer (on first use)
 	named_thread("", []{})();
 
-	std::unique_ptr<logs::listener> log_file;
+	static std::unique_ptr<logs::listener> log_file;
 	{
 		// Check free space
 		fs::device_stat stats{};
@@ -388,7 +388,7 @@ int main(int argc, char** argv)
 		log_file = logs::make_file_listener(fs::get_cache_dir() + "RPCS3.log", stats.avail_free / 4);
 	}
 
-	std::unique_ptr<logs::listener> log_pauser = std::make_unique<pause_on_fatal>();
+	static std::unique_ptr<logs::listener> log_pauser = std::make_unique<pause_on_fatal>();
 	logs::listener::add(log_pauser.get());
 
 	{


### PR DESCRIPTION
Fixes #9720 , alternative to #9721.
Registers destructors for std::exit as if by std::atexit.