### PR TITLE
Fix tiny race in PPU breakpoints

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -454,12 +454,10 @@ extern void ppu_register_function_at(u32 addr, u32 size, ppu_function_t ptr)
 // Breakpoint entry point
 static bool ppu_break(ppu_thread& ppu, ppu_opcode_t op)
 {
-	// Pause and wait if necessary
-	bool status = ppu.state.test_and_set(cpu_flag::dbg_pause);
-
-	g_fxo->get<gdb_server>()->pause_from(&ppu);
-
-	if (!status && ppu.check_state())
+	// Pause
+	ppu.state += cpu_flag::dbg_pause;
+	
+	if (ppu.check_state())
 	{
 		return false;
 	}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -21,7 +21,6 @@
 #include "lv2/sys_overlay.h"
 #include "lv2/sys_process.h"
 #include "lv2/sys_memory.h"
-#include "Emu/GDB.h"
 
 #ifdef LLVM_AVAILABLE
 #ifdef _MSC_VER


### PR DESCRIPTION
If the PPU has just being paused by the debugger, before it entered the breakpoint handler, the PPU would continue onto the next instruction skipping the breakpoint but then being paused on it instead.