### PR TITLE
Fix firmware updating/reinstallation

### DIFF
--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -116,16 +116,6 @@ bool tar_object::extract(std::string path, std::string ignore)
 		{
 			auto data = get_file(header.name).release();
 
-			if (fs::file prev{result})
-			{
-				if (prev.to_vector<u8>() == static_cast<fs::container_stream<std::vector<u8>>*>(data.get())->obj)
-				{
-					// Workaround: avoid overwriting existing data if it's the same.
-					tar_log.notice("TAR Loader: skipped existing file %s", header.name);
-					break;
-				}
-			}
-
 			fs::file file(result, fs::rewrite);
 
 			if (file)

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -464,6 +464,9 @@ void gui_application::OnChangeStyleSheetRequest()
 		return;
 	}
 
+	// Remove old fonts
+	QFontDatabase::removeAllApplicationFonts();
+
 	const QString stylesheet_name = m_gui_settings->GetValue(gui::m_currentStylesheet).toString();
 
 	if (stylesheet_name.isEmpty() || stylesheet_name == gui::DefaultStylesheet)
@@ -505,9 +508,6 @@ void gui_application::OnChangeStyleSheetRequest()
 		if (QFile file(stylesheet_path); !stylesheet_path.isEmpty() && file.open(QIODevice::ReadOnly | QIODevice::Text))
 		{
 			const QString config_dir = qstr(fs::get_config_dir());
-
-			// Remove old fonts
-			QFontDatabase::removeAllApplicationFonts();
 
 			// Add PS3 fonts
 			QDirIterator ps3_font_it(qstr(g_cfg.vfs.get_dev_flash() + "data/font/"), QStringList() << "*.ttf", QDir::Files, QDirIterator::Subdirectories);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -35,6 +35,7 @@
 #include <QMimeData>
 #include <QMessageBox>
 #include <QFileDialog>
+#include <QFontDatabase>
 
 #include "rpcs3_version.h"
 #include "Emu/System.h"
@@ -855,6 +856,9 @@ void main_window::HandlePupInstallation(QString file_path)
 		return;
 	}
 
+	// Remove possibly PS3 fonts from database
+	QFontDatabase::removeAllApplicationFonts();
+
 	progress_dialog pdlg(tr("RPCS3 Firmware Installer"), tr("Installing firmware version %1\nPlease wait...").arg(qstr(version_string)), tr("Cancel"), 0, static_cast<int>(update_filenames.size()), false, this);
 	pdlg.show();
 
@@ -918,6 +922,9 @@ void main_window::HandlePupInstallation(QString file_path)
 			std::this_thread::sleep_for(100ms);
 		}
 	}
+
+	// Update with newly installed PS3 fonts
+	Q_EMIT RequestGlobalStylesheetChange();
 
 	if (progress > 0)
 	{


### PR DESCRIPTION
We forgot to close Qt's file descriptors of PS3 firmware fonts we use when they are present. So attempting to open another file descriptor for writing to the PS3 fonts' file in order to install the file failed with access violation error. Of course reinitialize the Qt fonts after installation has finished.
