### PR TITLE
Reimplement/fix PRX patches

### DIFF
--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -129,16 +129,9 @@ public:
 	void append_title_patches(const std::string& title_id);
 
 	// Apply patch (returns the number of entries applied)
-	std::basic_string<u32> apply(const std::string& name, u8* dst);
-
-	// Apply patch with a check that the address exists in SPU local storage
-	std::basic_string<u32> apply_with_ls_check(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
+	std::basic_string<u32> apply(const std::string& name, u8* dst, u32 filesz = UINT32_MAX, u32 min_addr = 0);
 
 private:
-	// Internal: Apply patch (returns the number of entries applied)
-	template <bool CheckLS>
-	std::basic_string<u32> apply_patch(const std::string& name, u8* dst, u32 filesz, u32 ls_addr);
-
 	// Database
 	patch_map m_map;
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -385,14 +385,15 @@ extern void ppu_register_range(u32 addr, u32 size)
 		return;
 	}
 
+	size = utils::align(size + addr % 0x10000, 0x10000);
+	addr &= -0x10000;
+
 	// Register executable range at
-	utils::memory_commit(&ppu_ref(addr), size * 2, utils::protection::rw);
-	vm::page_protect(addr, utils::align(size, 0x10000), 0, vm::page_executable);
+	utils::memory_commit(&ppu_ref(addr), u64{size} * 2, utils::protection::rw);
+	vm::page_protect(addr, size, 0, vm::page_executable);
 
 	const u64 fallback = reinterpret_cast<uptr>(ppu_fallback);
 	const u64 seg_base = addr;
-
-	size &= ~3; // Loop assumes `size = n * 4`, enforce that by rounding down
 
 	while (size)
 	{


### PR DESCRIPTION
What is a PRX file? PRX stands for "PPU Relocatable Executable". What "relocatable" means in this context you ask? it means that the data/code segments of the PRX file can be mapped at any given address as long as the address is free from another memory mapping. Because every single PS3 application has different memory layout (it can even change within different boots of the same application!) we need PRX patches to be able to exist at any address based on relative offsets from segments instead of hardcoded addresses. This is fixed by this pull request.

## Enhancements
* Make PRX patches relocatable as they should.
* Due to the changed control for PRX patches depending of knowing the segments addresses, I made them display in kernel explorer.
* Added patch validation checks for PRX segments bounds. (TODO: do it for PPU/OVL patches as well)

## Bugfixes
* Fix LE32, LE64 and BE64 patches on PPU LLVM.

What this allows?
This allows to patch SPRX files as for firmware's.

I ported rujkosto's Metal Gear Solid 4's hack build in cellSpurs to a patch file of the firmware instead.
Here is the entry (need to be manually added until pushed to main patches)
```
PRX-4tNTAV9Aoav79ZTFt2mKNvM8ZnaU-0:
  "cellSpurs urgent commands hack - Metal Gear Solid 4":
    Games:
      All:
        All: [ All ]
    Author: elad335
    Notes: [ "Workaround for freezes in Metal Gear Solid 4.\nThis patch applies to a firmware file for all games!\nUsage outside of Metal Gear Solid 4 is for debug purposes only.\nYou must have firmware version of exactly 4.87 in order to use it.\n\nKnown to affect:\nMetal Gear Solid 4" ]
    Patch Version: 1.0
    Patch:
      - [ be32, 0x182B8, 0x38000002 ]
```