### PR TITLE
Minor vm::block_t::peek() bugfix

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1336,7 +1336,7 @@ namespace vm
 
 		const auto upper = m_map.upper_bound(addr);
 
-		if (upper == m_map.begin())
+		if (upper == m_map.end() || upper == m_map.begin())
 		{
 			return {addr, nullptr};
 		}


### PR DESCRIPTION
Old bug, lowest m_map address does not have to be equal to block_t::addr, or if m_map is empty. upper_bound() returns an end iterator.