### PR TITLE
vk: Support incomplete lavapipe

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -306,6 +306,31 @@ namespace vk
 		enabled_features.textureCompressionBC = VK_TRUE;
 		enabled_features.shaderStorageBufferArrayDynamicIndexing = VK_TRUE;
 
+		// If we're on lavapipe / llvmpipe, disable unimplemented features:
+		// - samplerAnisotropy
+		// - shaderStorageBufferArrayDynamicIndexing
+		// - wideLines
+		// as of mesa 21.1.0-dev (aea36ee05e9, 2020-02-10)
+		// Several games work even if we disable these, testing purpose only
+		if (pgpu->get_name().find("llvmpipe") != umax)
+		{
+			if (!pgpu->features.samplerAnisotropy)
+			{
+				rsx_log.error("Running lavapipe without support for samplerAnisotropy");
+				enabled_features.samplerAnisotropy = VK_FALSE;
+			}
+			if (!pgpu->features.shaderStorageBufferArrayDynamicIndexing)
+			{
+				rsx_log.error("Running lavapipe without support for shaderStorageBufferArrayDynamicIndexing");
+				enabled_features.shaderStorageBufferArrayDynamicIndexing = VK_FALSE;
+			}
+			if (!pgpu->features.wideLines)
+			{
+				rsx_log.error("Running lavapipe without support for wideLines");
+				enabled_features.wideLines = VK_FALSE;
+			}
+		}
+
 		// Optionally disable unsupported stuff
 		if (!pgpu->features.shaderFloat64)
 		{


### PR DESCRIPTION
Disable features still unimplemented by lavapipe when using it:
- samplerAnisotropy
- shaderStorageBufferArrayDynamicIndexing
- wideLines

as of mesa 21.1.0-dev (aea36ee05e9, 2020-02-10)

Ideally we also need to disable Anisotropic Filtering on runtime in order to not violate Vulkan spec, but it works as is for now

Some games work such as Demon's Souls and Drakengard 3 (tested on mobile i7-6700HQ)

![image](https://user-images.githubusercontent.com/10283761/107578868-36c0f000-6bec-11eb-9cb2-45ec7d1c1fb4.png)

![image](https://user-images.githubusercontent.com/10283761/107578820-23ae2000-6bec-11eb-81b1-fd943e64e092.png)

![image](https://user-images.githubusercontent.com/10283761/107584877-282b0680-6bf5-11eb-8fb7-e640a3a1a50d.png)


Naturally, as lavapipe improves, so will performance

Partially solves #9642 as lavapipe is Mesa's software mode Vulkan driver