### PR TITLE
Fixup for multi-thread shader compilation (loading stage)

### DIFF
--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.h
@@ -214,14 +214,18 @@ protected:
 
 			lock.upgrade();
 			auto [it, inserted] = m_fragment_shader_cache.try_emplace(rsx_fp);
-			new_shader = &(it->second);
-			recompile = inserted;
+			new_shader          = &(it->second);
+			recompile           = inserted;
 
-			if (inserted)
+			if (recompile)
 			{
 				it->first.clone_data();
-				backend_traits::recompile_fragment_program(rsx_fp, *new_shader, m_next_id++);
 			}
+		}
+
+		if (recompile)
+		{
+			backend_traits::recompile_fragment_program(rsx_fp, *new_shader, m_next_id++);
 		}
 
 		return std::forward_as_tuple(*new_shader, false);


### PR DESCRIPTION
This offers a huge improvement in startup performance. With around 13,000 shaders we go from ~1:30 to under 10 seconds. It looks like this was the original intention of the author given the outer scope recompile variable.