### PR TITLE
PPU LLVM: Reduce PRX/OVL compilation memory usage a little

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -809,6 +809,11 @@ void try_spawn_ppu_if_exclusive_program(const ppu_module& m)
 
 std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::string& path)
 {
+	if (elf != elf_error::ok)
+	{
+		return nullptr;
+	}
+
 	// Create new PRX object
 	const auto prx = idm::make_ptr<lv2_obj, lv2_prx>();
 
@@ -1161,6 +1166,11 @@ void ppu_unload_prx(const lv2_prx& prx)
 
 bool ppu_load_exec(const ppu_exec_object& elf)
 {
+	if (elf != elf_error::ok)
+	{
+		return false;
+	}
+
 	// Check if it is a standalone executable first
 	for (const auto& prog : elf.progs)
 	{
@@ -1740,6 +1750,11 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 
 std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object& elf, const std::string& path)
 {
+	if (elf != elf_error::ok)
+	{
+		return {nullptr, CELL_ENOENT};
+	}
+
 	// Access linkage information object
 	const auto link = g_fxo->get<ppu_linkage_info>();
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2423,13 +2423,14 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_
 
 			elf_error prx_err{}, ovl_err{};
 
-			if (const ppu_prx_object obj = src; (prx_err = obj, obj == elf_error::ok))
+			if (ppu_prx_object obj = src; (prx_err = obj, obj == elf_error::ok))
 			{
 				std::unique_lock lock(sprx_mtx);
 
 				if (auto prx = ppu_load_prx(obj, path))
 				{
 					lock.unlock();
+					obj.clear(), src.close(); // Clear decrypted file and elf object memory
 					ppu_initialize(*prx);
 					idm::remove<lv2_obj, lv2_prx>(idm::last_id());
 					lock.lock();
@@ -2443,7 +2444,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_
 				prx_err = elf_error::header_type;
 			}
 
-			if (const ppu_exec_object obj = src; (ovl_err = obj, obj == elf_error::ok))
+			if (ppu_exec_object obj = src; (ovl_err = obj, obj == elf_error::ok))
 			{
 				while (ovl_err == elf_error::ok)
 				{
@@ -2458,6 +2459,8 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_
 						ovl_err = elf_error::header_type;
 						break;
 					}
+
+					obj.clear(), src.close(); // Clear decrypted file and elf object memory
 
 					ppu_initialize(*ovlm);
 

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -35,7 +35,7 @@ static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vp
 
 	u128 klic = g_fxo->get<loaded_npdrm_keys>()->devKlic.load();
 
-	const ppu_exec_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic));
+	ppu_exec_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic));
 
 	if (obj != elf_error::ok)
 	{
@@ -43,6 +43,8 @@ static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vp
 	}
 
 	const auto [ovlm, error] = ppu_load_overlay(obj, vfs::get(vpath));
+
+	obj.clear();
 
 	if (error)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -266,7 +266,7 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	u128 klic = g_fxo->get<loaded_npdrm_keys>()->devKlic.load();
 
-	const ppu_prx_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic));
+	ppu_prx_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic));
 
 	if (obj != elf_error::ok)
 	{
@@ -274,6 +274,8 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 	}
 
 	const auto prx = ppu_load_prx(obj, path);
+
+	obj.clear();
 
 	if (!prx)
 	{

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1597,7 +1597,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			// Overlay (OVL) executable (only load it)
 			else if (vm::map(0x3000'0000, 0x1000'0000, 0x200); !ppu_load_overlay(ppu_exec, m_path).first)
 			{
-				ppu_exec = fs::file{};
+				ppu_exec.set_error(elf_error::header_type);
 			}
 
 			if (ppu_exec != elf_error::ok)


### PR DESCRIPTION
## Enhancements
* Clear elf_object and decrypted file memory before compiling PPU LLVM cache.
* Set initial error of elf_object to "file not found" instead of no error as it makes more sense.