### PR TITLE
Even more emulation stopping bugfixes (GUI callbacks)

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -336,15 +336,8 @@ void _sys_process_exit(ppu_thread& ppu, s32 status, u32 arg2, u32 arg3)
 
 	sys_process.warning("_sys_process_exit(status=%d, arg2=0x%x, arg3=0x%x)", status, arg2, arg3);
 
-	// Get shared ptr to current PPU
-	Emu.CallAfter([s_ppu = idm::get<named_thread<ppu_thread>>(ppu.id)]()
+	Emu.CallAfter([]()
 	{
-		if (s_ppu->is_stopped())
-		{
-			// Stop() was already executed from a signal before
-			return;
-		}
-
 		sys_process.success("Process finished");
 		Emu.Stop();
 	});
@@ -408,14 +401,8 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 	if (disc.empty() && !Emu.GetTitleID().empty())
 		disc = vfs::get(Emu.GetDir());
 
-	Emu.CallAfter([s_ppu = idm::get<named_thread<ppu_thread>>(ppu.id), path = std::move(path), argv = std::move(argv), envp = std::move(envp), data = std::move(data), disc = std::move(disc), hdd1 = std::move(hdd1), klic = g_fxo->get<loaded_npdrm_keys>()->devKlic.load()]() mutable
+	Emu.CallAfter([path = std::move(path), argv = std::move(argv), envp = std::move(envp), data = std::move(data), disc = std::move(disc), hdd1 = std::move(hdd1), klic = g_fxo->get<loaded_npdrm_keys>()->devKlic.load()]() mutable
 	{
-		if (s_ppu->is_stopped())
-		{
-			// Stop() was already executed from a signal before
-			return;
-		}
-
 		sys_process.success("Process finished -> %s", argv[0]);
 		Emu.SetForceBoot(true);
 		Emu.Stop();

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1873,6 +1873,9 @@ void Emulator::Stop(bool restart)
 
 	sys_log.notice("Stopping emulator...");
 
+	m_stop_ctr++;
+	m_stop_ctr.notify_all();
+
 	GetCallbacks().on_stop();
 
 	if (auto rsx = g_fxo->get<rsx::thread>())

--- a/rpcs3/rpcs3qt/save_data_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_dialog.cpp
@@ -35,11 +35,12 @@ s32 save_data_dialog::ShowSaveDataList(std::vector<SaveDataEntry>& save_entries,
 		sdid.exec();
 		selection = sdid.GetSelection();
 		dlg_result = true;
+		dlg_result.notify_one();
 	});
 
-	while (!dlg_result)
+	while (!dlg_result && !Emu.IsStopped())
 	{
-		thread_ctrl::wait_for(1000);
+		thread_ctrl::wait_on(dlg_result, false);
 	}
 
 	input::SetIntercepted(false);


### PR DESCRIPTION
Most Emu.CallAfter usages were extremely wrong when ordered after Emu.Stop(). could result in anywhere from emulation stopping hangs to even segfaults. I implemented a condition to only call callback if Emu.Stop/Emu.Run were not called inbetween enqueuing the callback to the GUI thread actual execution.