### PR TITLE
Update log messages of PPU/SPU hashes and patches applied

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -782,7 +782,14 @@ static void ppu_check_patch_spu_images(const ppu_segment& seg)
 			}
 		}
 
-		ppu_loader.success("SPU executable hash: %s (<- %u)%s", hash, applied.size(), dump);
+		if (applied.empty())
+		{
+			ppu_loader.warning("SPU executable hash: %s%s", hash, dump);
+		}
+		else
+		{
+			ppu_loader.success("SPU executable hash: %s (<- %u)%s", hash, applied.size(), dump);
+		}
 	}
 }
 
@@ -1115,7 +1122,14 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 	
 		applied += _applied;
 
-		ppu_loader.success("PRX library hash: %s (<- %u)", hash_seg, _applied.size());
+		if (_applied.empty())
+		{
+			ppu_loader.warning("PRX hash of %s[%u]: %s", prx->name, i, hash_seg);
+		}
+		else
+		{
+			ppu_loader.success("PRX hash of %s[%u]: %s (<- %u)", prx->name, i, hash_seg, _applied.size());
+		}
 	}
 
 	// Embedded SPU elf patching
@@ -1332,7 +1346,14 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		applied += g_fxo->get<patch_engine>()->apply(Emu.GetTitleID() + '-' + hash, vm::g_base_addr);
 	}
 
-	ppu_loader.success("PPU executable hash: %s (<- %u)", hash, applied.size());
+	if (applied.empty())
+	{
+		ppu_loader.warning("PPU executable hash: %s", hash);
+	}
+	else
+	{
+		ppu_loader.success("PPU executable hash: %s (<- %u)", hash, applied.size());
+	}
 
 	// Initialize HLE modules
 	ppu_initialize_modules(link);
@@ -1781,6 +1802,10 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 
 	const auto ovlm = std::make_shared<lv2_overlay>();
 
+	// Set path (TODO)
+	ovlm->name = path.substr(path.find_last_of('/') + 1);
+	ovlm->path = path;
+
 	u32 end = 0;
 
 	// Allocate memory at fixed positions
@@ -1888,7 +1913,14 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 		ppu_check_patch_spu_images(seg);
 	}
 
-	ppu_loader.success("OVL executable hash: %s (<- %u)", hash, applied.size());
+	if (applied.empty())
+	{
+		ppu_loader.warning("OVL hash of %s: %s", ovlm->name, hash);
+	}
+	else
+	{
+		ppu_loader.success("OVL hash of %s: %s (<- %u)", ovlm->name, hash, applied.size());
+	}
 
 	// Load other programs
 	for (auto& prog : elf.progs)
@@ -1980,10 +2012,6 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 
 	// Validate analyser results (not required)
 	ovlm->validate(0);
-
-	// Set path (TODO)
-	ovlm->name = path.substr(path.find_last_of('/') + 1);
-	ovlm->path = path;
 
 	idm::import_existing<lv2_obj, lv2_overlay>(ovlm);
 


### PR DESCRIPTION
* Add SPRX/OVL filenames to the log messages.
* Make the log messages' level warning when no patches were applied. This makes the ones with patches applied much more noticeable as they should.

This should resolve all the confusion around it.

For example:
```
S {PPU[0x1000000] Thread (main_thread) [0x008a09ac]} PAT: Applied patch (hash='PRX-rbYkgZMgx8Prd7WUAA39oYAdWcNo-0', description='cellSpurs urgent commands hack - Metal Gear Solid 4', author='elad335', patch_version='1.0', file_version='1.2') (<- 1)
S {PPU[0x1000000] Thread (main_thread) [0x008a09ac]} ppu_loader: PRX hash of libsre.sprx[0]: PRX-rbYkgZMgx8Prd7WUAA39oYAdWcNo-0 (<- 1)
W {PPU[0x1000000] Thread (main_thread) [0x008a09ac]} ppu_loader: PRX hash of libsre.sprx[1]: PRX-rbYkgZMgx8Prd7WUAA39oYAdWcNo-1
```