### PR TITLE
Wait for longer before killing rpcs3 on slow game exit

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1852,14 +1852,14 @@ void Emulator::Stop(bool restart)
 		for (uint i = 0; thread_ctrl::state() != thread_state::aborting;)
 		{
 			// We don't need accurate timekeeping, using clocks may interfere with debugging
-			if (i >= 1000)
+			if (i >= 3000)
 			{
-				// Total amount of waiting: about 5s
+				// Total amount of waiting: about 30s
 				report_fatal_error("Stopping emulator took too long."
 					"\nSome thread has probably deadlocked. Aborting.");
 			}
 
-			thread_ctrl::wait_for(5'000);
+			thread_ctrl::wait_for(10'000);
 
 			if (!g_watchdog_hold_ctr)
 			{


### PR DESCRIPTION
Some games like TLOU take a while to exit (~15 seconds), so I bumped up the timeout to 30 seconds.