### PR TITLE
Add a new config-only option to prevent exclusive full screen mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ yaml-cpp.pc
 
 # ssl certificate
 cacert.pem
+
+_ReSharper.*/

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -56,8 +56,9 @@ namespace vk
 
 		stencil_export_support           = device_extensions.is_supported(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
 		conditional_render_support       = device_extensions.is_supported(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
-		external_memory_host_support = device_extensions.is_supported(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+		external_memory_host_support     = device_extensions.is_supported(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
 		unrestricted_depth_range_support = device_extensions.is_supported(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
+		surface_capabilities_2_support   = instance_extensions.is_supported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	}
 
 	void physical_device::create(VkInstance context, VkPhysicalDevice pdev, bool allow_extensions)
@@ -515,6 +516,11 @@ namespace vk
 	bool render_device::get_external_memory_host_support() const
 	{
 		return pgpu->external_memory_host_support;
+	}
+
+	bool render_device::get_surface_capabilities_2_support() const
+	{
+		return pgpu->surface_capabilities_2_support;
 	}
 
 	mem_allocator_base* render_device::get_allocator() const

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -51,6 +51,7 @@ namespace vk
 		bool conditional_render_support = false;
 		bool external_memory_host_support = false;
 		bool unrestricted_depth_range_support = false;
+		bool surface_capabilities_2_support = false;
 
 		friend class render_device;
 	private:
@@ -116,6 +117,7 @@ namespace vk
 		bool get_conditional_render_support() const;
 		bool get_unrestricted_depth_range_support() const;
 		bool get_external_memory_host_support() const;
+		bool get_surface_capabilities_2_support() const;
 
 		mem_allocator_base* get_allocator() const;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/instance.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/instance.hpp
@@ -154,6 +154,11 @@ namespace vk
 				{
 					extensions.push_back(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
 				}
+
+				if (support.is_supported(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME))
+				{
+					extensions.push_back(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+				}
 #ifdef _WIN32
 				extensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #elif defined(__APPLE__)

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -166,6 +166,7 @@ struct cfg_root : cfg::node
 			cfg::string adapter{ this, "Adapter" };
 			cfg::_bool force_fifo{ this, "Force FIFO present mode" };
 			cfg::_bool force_primitive_restart{ this, "Force primitive restart flag" };
+			cfg::_bool force_disable_exclusive_fullscreen_mode{this, "Force Disable Exclusive Fullscreen Mode"};
 
 		} vk{ this };
 


### PR DESCRIPTION
This is helpful for people streaming RPCS3, or to prevent disabling HDR mode in Windows.

Fixes #7975

New option is under `Vulkan` section of config.yml, it is disabled by default to maintain current behavior.
```yml
Video:
    Vulkan:
        Force Disable Exclusive Fullscreen Mode: false
```

People with multimonitor setup should test if switching to full screen works on different screens as expected.