### PR TITLE
Log "Missing Firmware" if firmware is missing

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -399,7 +399,7 @@ int main(int argc, char** argv)
 
 	{
 		const std::string firmware_version = utils::get_firmware_version();
-		const std::string firmware_string  = firmware_version.empty() ? "" : (" | Firmware version: " + firmware_version);
+		const std::string firmware_string  = firmware_version.empty() ? " | Missing Firmware" : (" | Firmware version: " + firmware_version);
 
 		// Write initial message
 		logs::stored_message ver;


### PR DESCRIPTION
In the intial log message, emphasize the fact that there is no firmware installed instead of not logging anything.