### PR TITLE
debugger: Fix single stepping (globally)

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -667,7 +667,8 @@ bool cpu_thread::check_state() noexcept
 				store = true;
 			}
 
-			if (flags & cpu_flag::dbg_step)
+			// Can't process dbg_step if we only paused temporarily
+			if (cpu_can_stop && flags & cpu_flag::dbg_step)
 			{
 				if (u32 pc = get_pc(), *pc2 = get_pc2(); pc != umax && pc2)
 				{

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -105,6 +105,7 @@ public:
 	}
 
 	u32 get_pc() const;
+	u32* get_pc2(); // Last PC before stepping for the debugger (may be null)
 
 	void notify();
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -455,7 +455,7 @@ extern void ppu_register_function_at(u32 addr, u32 size, ppu_function_t ptr)
 static bool ppu_break(ppu_thread& ppu, ppu_opcode_t op)
 {
 	// Pause
-	ppu.state += cpu_flag::dbg_pause;
+	ppu.state.atomic_op([](bs_t<cpu_flag>& state) { if (!(state & cpu_flag::dbg_step)) state += cpu_flag::dbg_pause; });
 	
 	if (ppu.check_state())
 	{

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -277,6 +277,8 @@ public:
 	u64 last_fail = 0;
 	u64 last_succ = 0;
 
+	u32 dbg_step_pc = 0;
+
 	be_t<u64>* get_stack_arg(s32 i, u64 align = alignof(u64));
 	void exec_task();
 	void fast_call(u32 addr, u32 rtoc);

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -643,6 +643,7 @@ public:
 	spu_thread(lv2_spu_group* group, u32 index, std::string_view name, u32 lv2_id, bool is_isolated = false, u32 option = 0);
 
 	u32 pc = 0;
+	u32 dbg_step_pc = 0;
 
 	// May be used internally by recompilers.
 	u32 base_pc = 0;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -648,6 +648,7 @@ namespace rsx
 		u32 dma_address{0};
 		rsx_iomap_table iomap_table;
 		u32 restore_point = 0;
+		u32 dbg_step_pc = 0;
 		atomic_t<u32> external_interrupt_lock{ 0 };
 		atomic_t<bool> external_interrupt_ack{ false };
 		bool is_fifo_idle() const;

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -825,7 +825,7 @@ void debugger_frame::DoStep(bool stepOver)
 	{
 		bool should_step_over = stepOver && cpu->id_type() == 1;
 
-		if (cpu->state & s_pause_flags)
+		if (auto _state = +cpu->state; _state & s_pause_flags && _state & cpu_flag::wait && !(_state & cpu_flag::dbg_step))
 		{
 			if (should_step_over)
 			{
@@ -849,7 +849,14 @@ void debugger_frame::DoStep(bool stepOver)
 			{
 				state -= s_pause_flags;
 
-				if (!should_step_over) state += cpu_flag::dbg_step;
+				if (!should_step_over)
+				{
+					if (u32* ptr = cpu->get_pc2())
+					{
+						state += cpu_flag::dbg_step;
+						*ptr = cpu->get_pc();
+					}
+				}
 			});
 
 			cpu->state.notify_one(s_pause_flags);


### PR DESCRIPTION
Fixes single stepping inside PPU syscalls, manually set PPU breakpoints, SPU stop opcodes, RSX idle modes and many more due to flawed single stepping mechanism globally.