### PR TITLE
Audio/AL: Request our default sampling rate (48kHz) from AL when crea…

### DIFF
--- a/rpcs3/Emu/Audio/AL/OpenALBackend.cpp
+++ b/rpcs3/Emu/Audio/AL/OpenALBackend.cpp
@@ -14,10 +14,12 @@ LOG_CHANNEL(OpenAL);
 OpenALBackend::OpenALBackend()
 	: AudioBackend()
 {
+	ALCint attribs[] = {ALC_FREQUENCY, DEFAULT_AUDIO_SAMPLING_RATE, 0, 0};
+
 	ALCdevice* m_device = alcOpenDevice(nullptr);
 	checkForAlcError("alcOpenDevice");
 
-	ALCcontext* m_context = alcCreateContext(m_device, nullptr);
+	ALCcontext* m_context = alcCreateContext(m_device, attribs);
 	checkForAlcError("alcCreateContext");
 
 	alcMakeContextCurrent(m_context);


### PR DESCRIPTION
…ting the

context.
Otherwise AL might downsample and output in 44.1kHz unnecessarily, which
happens at least on my system. Also tested on an audio device that
doesn't support 48kHz to makes sure that still works.