### PR TITLE
Some NP fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -401,6 +401,8 @@ error_code sceNpInit(u32 poolsize, vm::ptr<void> poolptr)
 
 	const auto nph = g_fxo->get<named_thread<np_handler>>();
 
+	std::lock_guard lock(nph->mutex_status);
+
 	if (nph->is_NP_init)
 	{
 		return SCE_NP_ERROR_ALREADY_INITIALIZED;
@@ -431,6 +433,8 @@ error_code sceNpTerm()
 	sceNp.warning("sceNpTerm()");
 
 	const auto nph = g_fxo->get<named_thread<np_handler>>();
+
+	std::lock_guard lock(nph->mutex_status);
 
 	if (!nph->is_NP_init)
 	{

--- a/rpcs3/Emu/Cell/Modules/sceNp2.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp2.cpp
@@ -209,9 +209,12 @@ error_code sceNp2Init(u32 poolsize, vm::ptr<void> poolptr)
 
 	const auto nph = g_fxo->get<named_thread<np_handler>>();
 
-	if (nph->is_NP2_init)
 	{
-		return SCE_NP_ERROR_ALREADY_INITIALIZED;
+		std::lock_guard lock(nph->mutex_status);
+		if (nph->is_NP2_init)
+		{
+			return SCE_NP_ERROR_ALREADY_INITIALIZED;
+		}
 	}
 
 	const u32 result = std::bit_cast<u32>(sceNpInit(poolsize, poolptr));
@@ -264,9 +267,12 @@ error_code sceNp2Term(ppu_thread& ppu)
 
 	const auto nph = g_fxo->get<named_thread<np_handler>>();
 
-	if (!nph->is_NP2_init)
 	{
-		return SCE_NP_ERROR_NOT_INITIALIZED;
+		std::lock_guard lock(nph->mutex_status);
+		if (!nph->is_NP2_init)
+		{
+			return SCE_NP_ERROR_NOT_INITIALIZED;
+		}
 	}
 
 	// TODO: does this return on error_code ?
@@ -291,19 +297,22 @@ error_code sceNpMatching2Term2()
 
 	const auto nph = g_fxo->get<named_thread<np_handler>>();
 
-	if (!nph->is_NP2_init)
 	{
-		return SCE_NP_ERROR_NOT_INITIALIZED;
-	}
+		std::lock_guard lock(nph->mutex_status);
+		if (!nph->is_NP2_init)
+		{
+			return SCE_NP_ERROR_NOT_INITIALIZED;
+		}
 
-	if (!nph->is_NP2_Match2_init)
-	{
-		return SCE_NP_MATCHING2_ERROR_NOT_INITIALIZED;
+		if (!nph->is_NP2_Match2_init)
+		{
+			return SCE_NP_MATCHING2_ERROR_NOT_INITIALIZED;
+		}
+
+		nph->is_NP2_Match2_init = false;
 	}
 
 	// TODO: for all contexts: sceNpMatching2DestroyContext
-
-	nph->is_NP2_Match2_init = false;
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -1558,7 +1558,6 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 	struct
 	{
 		alignas(16) char buf[sizeof(sys_net_sockaddr)];
-		bool changed = false;
 	} addr_buf;
 
 	const auto psa_in = reinterpret_cast<sys_net_sockaddr_in*>(addr_buf.buf);
@@ -1665,11 +1664,6 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 			name.sin_port        = std::bit_cast<u16, be_t<u16>>(53);
 			name.sin_addr.s_addr = nph->get_dns_ip();
 
-			// Overwrite arg (probably used to validate recvfrom addr)
-			psa_in->sin_family = SYS_NET_AF_INET;
-			psa_in->sin_port   = 53;
-			psa_in->sin_addr   = nph->get_dns_ip();
-			addr_buf.changed = true;
 			sys_net.notice("sys_net_bnet_connect: using DNS...");
 
 			nph->add_dns_spy(s);
@@ -1763,11 +1757,6 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 	if (!sock)
 	{
 		return -SYS_NET_EBADF;
-	}
-
-	if (addr_buf.changed)
-	{
-		std::memcpy(addr.get_ptr(), addr_buf.buf, sizeof(addr_buf.buf));
 	}
 
 	if (!sock.ret && result)

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -114,6 +114,9 @@ public:
 	// For signaling
 	void req_sign_infos(const std::string& npid, u32 conn_id);
 
+	// Mutex for NP status change
+	shared_mutex mutex_status;
+
 	static constexpr std::string_view thread_name = "NP Handler Thread";
 
 protected:


### PR DESCRIPTION
The code from sys_bnet_connect was a relic from a time when we didn't give the proper IP to the software when it requested DNS.

Added a lock to sceNpInit and other Init/Term functions to avoid concurrency(I feel some code should be pushed into np_handler for it to handle the concurrency rather than the sceNp code but for now it's still better than it was).