### PR TITLE
vk: Fix cyclic read-write in dma_block::load/flush

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -95,6 +95,13 @@ namespace vk
 
 	void dma_block::flush(const utils::address_range& range)
 	{
+		if (inheritance_info.parent)
+		{
+			// Parent may be a different type of block
+			inheritance_info.parent->flush(range);
+			return;
+		}
+
 		auto src = map_range(range);
 		auto dst = vm::get_super_ptr(range.start);
 		std::memcpy(dst, src, range.length());
@@ -105,6 +112,13 @@ namespace vk
 
 	void dma_block::load(const utils::address_range& range)
 	{
+		if (inheritance_info.parent)
+		{
+			// Parent may be a different type of block
+			inheritance_info.parent->load(range);
+			return;
+		}
+
 		auto src = vm::get_super_ptr(range.start);
 		auto dst = map_range(range);
 		std::memcpy(dst, src, range.length());


### PR DESCRIPTION
Some DMA block entries are stubs whose parents are DMA_block_EXT entries. Performing load() in this case becomes a memcpy(address, same_address_again, length) which wastes performance and introduces bugs.

Improves performance when using passthrough DMA. I've only tested on an AMD GPU, NV GPUs have other more complicated issues with passthrough that are still being worked on behind the scenes.