### PR TITLE
Atomic PARAM.SFO modifications

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -602,6 +602,22 @@ namespace fs
 	// Get common cache directory
 	const std::string& get_cache_dir();
 
+	// Unique pending file creation destined to be renamed to the destination file
+	struct pending_file
+	{
+		fs::file file;
+
+		// This is meant to modify files atomically, overwriting is likely 
+		bool commit(bool overwrite = true);
+
+		pending_file(const std::string& path);
+		~pending_file();
+
+	private:
+		std::string m_path; // Pending file path
+		std::string m_dest; // Destination file path
+	};
+
 	// Get real path for comparisons (TODO: investigate std::filesystem::path::compare implementation)
 	std::string escape_path(std::string_view path);
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -748,7 +748,7 @@ namespace fs
 		return result;
 	}
 
-	template <typename... Args>
+	template <bool Flush = false, typename... Args>
 	bool write_file(const std::string& path, bs_t<fs::open_mode> mode, const Args&... args)
 	{
 		// Always use write flag, remove read flag
@@ -758,14 +758,19 @@ namespace fs
 			{
 				// Specialization for [const void*, usz] args
 				f.write(args...);
-				return true;
 			}
 			else
 			{
 				// Write args sequentially
 				(f.write(args), ...);
-				return true;
 			}
+
+			if constexpr (Flush)
+			{
+				f.sync();
+			}
+
+			return true;
 		}
 
 		return false;

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -666,7 +666,9 @@ error_code cellGameContentPermit(vm::ptr<char[CELL_GAME_PATH_MAX]> contentInfoPa
 	if (!perm->temp.empty())
 	{
 		// Create PARAM.SFO
-		psf::save_object(fs::file(perm->temp + "/PARAM.SFO", fs::rewrite), perm->sfo);
+		fs::pending_file temp(perm->temp + "/PARAM.SFO");
+		temp.file.write(psf::save_object(perm->sfo));
+		ensure(temp.commit());
 
 		// Make temporary directory persistent (atomically)
 		if (vfs::host::rename(perm->temp, vfs::get(dir), &g_mp_sys_dev_hdd0, false))
@@ -684,7 +686,9 @@ error_code cellGameContentPermit(vm::ptr<char[CELL_GAME_PATH_MAX]> contentInfoPa
 	else if (perm->can_create)
 	{
 		// Update PARAM.SFO
-		psf::save_object(fs::file(vfs::get(dir + "/PARAM.SFO"), fs::rewrite), perm->sfo);
+		fs::pending_file temp(vfs::get(dir + "/PARAM.SFO"));
+		temp.file.write(psf::save_object(perm->sfo));
+		ensure(temp.commit());
 	}
 
 	// Cleanup
@@ -806,7 +810,9 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 				psf::assign(sfo, fmt::format("TITLE_%02d", i), psf::string(CELL_GAME_SYSP_TITLE_SIZE, setParam->titleLang[i]));
 			}
 
-			psf::save_object(fs::file(vfs::get(dir + "/PARAM.SFO"), fs::rewrite), sfo);
+			fs::pending_file temp(vfs::get(dir + "/PARAM.SFO"));
+			temp.file.write(psf::save_object(sfo));
+			ensure(temp.commit());
 		}
 
 		return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1306,7 +1306,12 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			if (!entry.is_directory)
 			{
-				if (entry.name == "PARAM.SFO" || entry.name == "PARAM.PFD")
+				if (entry.name == "."sv)
+				{
+					continue;
+				}
+
+				if (entry.name == "PARAM.SFO"sv || entry.name == "PARAM.PFD"sv)
 				{
 					continue; // system files are not included in the file list
 				}
@@ -1899,7 +1904,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		// Write all files in temporary directory
 		auto& fsfo = all_files["PARAM.SFO"];
 		fsfo = fs::make_stream<std::vector<uchar>>();
-		psf::save_object(fsfo, psf);
+		fsfo.write(psf::save_object(psf));
 
 		for (auto&& pair : all_files)
 		{

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1911,7 +1911,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			if (auto file = pair.second.release())
 			{
 				auto fvec = static_cast<fs::container_stream<std::vector<uchar>>&>(*file);
-				fs::file(new_path + vfs::escape(pair.first), fs::rewrite).write(fvec.obj);
+				ensure(fs::write_file<true>(new_path + vfs::escape(pair.first), fs::rewrite, fvec.obj));
 			}
 		}
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -765,8 +765,12 @@ static void ppu_check_patch_spu_images(const ppu_segment& seg)
 
 		if (g_cfg.core.spu_debug)
 		{
-			fs::file dump_file(fs::get_cache_dir() + "/spu_progs/" + vfs::escape(name.substr(name.find_last_of('/') + 1)) + '_' + hash.substr(4) + ".elf", fs::rewrite);
-			obj.save(dump_file);
+			fs::pending_file temp(fs::get_cache_dir() + "/spu_progs/" + vfs::escape(name.substr(name.find_last_of('/') + 1)) + '_' + hash.substr(4) + ".elf");
+
+			if (!temp.file || !(temp.file.write(obj.save()), temp.commit()))
+			{
+				ppu_loader.error("Failed to dump SPU program from PPU executable: name='%s', hash=%s", name, hash);
+			}
 		}
 
 		// Try to patch each segment, will only succeed if the address exists in SPU local storage

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -768,6 +768,13 @@ error_code sys_fs_opendir(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u32> fd)
 			// Preprocess entries
 			data.back().name = vfs::unescape(data.back().name);
 
+			if (!data.back().is_directory && data.back().name == "."sv)
+			{
+				// Files hidden from emulation
+				data.resize(data.size() - 1);
+				continue;
+			}
+
 			// Add additional entries for split file candidates (while ends with .66600)
 			while (data.back().name.ends_with(".66600"))
 			{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2889,10 +2889,13 @@ namespace rsx
 			capture_current_frame = false;
 
 			const std::string file_path = fs::get_config_dir() + "captures/" + Emu.GetTitleID() + "_" + date_time::current_time_narrow() + "_capture.rrc";
-			const std::string file_data = cereal_serialize(frame_capture);
 
 			// todo: may want to compress this data?
-			if (fs::write_file(file_path, fs::rewrite, file_data))
+			const std::string file_data = cereal_serialize(frame_capture);
+
+			fs::pending_file temp(file_path);
+
+			if (temp.file && (temp.file.write(file_data), temp.commit(false)))
 			{
 				rsx_log.success("Capture successful: %s", file_path);
 			}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1299,8 +1299,10 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			games[m_title_id] = bdvd_dir;
 			YAML::Emitter out;
 			out << games;
-			fs::file(fs::get_config_dir() + "/games.yml.tmp", fs::rewrite).write(out.c_str(), out.size());
-			fs::rename(fs::get_config_dir() + "/games.yml.tmp", fs::get_config_dir() + "/games.yml", true);
+
+			fs::pending_file temp(fs::get_config_dir() + "/games.yml");
+			temp.file.write(out.c_str(), out.size());
+			temp.commit();
 		}
 		else if (m_cat == "1P" && from_hdd0_game)
 		{

--- a/rpcs3/Loader/ELF.h
+++ b/rpcs3/Loader/ELF.h
@@ -278,8 +278,10 @@ public:
 		return m_error = elf_error::ok;
 	}
 
-	void save(const fs::file& stream) const
+	std::vector<u8> save(std::vector<u8>&& init = std::vector<u8>{}) const
 	{
+		fs::file stream = fs::make_stream<std::vector<u8>>(std::move(init));
+
 		// Write header
 		ehdr_t header{};
 		header.e_magic = "\177ELF"_u32;
@@ -322,6 +324,8 @@ public:
 		{
 			stream.write(prog.bin);
 		}
+
+		return std::move(static_cast<fs::container_stream<std::vector<u8>>*>(stream.release().get())->obj);
 	}
 
 	elf_object& clear()

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -113,6 +113,8 @@ namespace psf
 			return result;
 		}
 
+		stream.seek(0);
+
 		// Get header
 		header_t header;
 		ensure(stream.read(header));
@@ -186,8 +188,10 @@ namespace psf
 		return result;
 	}
 
-	void save_object(const fs::file& stream, const psf::registry& psf)
+	std::vector<u8> save_object(const psf::registry& psf, std::vector<u8>&& init)
 	{
+		fs::file stream = fs::make_stream<std::vector<u8>>(std::move(init));
+
 		std::vector<def_table_t> indices; indices.reserve(psf.size());
 
 		// Generate indices and calculate key table length
@@ -264,6 +268,8 @@ namespace psf
 				fmt::throw_exception("Invalid entry format (key='%s', fmt=0x%x)", entry.first, fmt);
 			}
 		}
+
+		return std::move(static_cast<fs::container_stream<std::vector<u8>>*>(stream.release().get())->obj);
 	}
 
 	std::string_view get_string(const registry& psf, const std::string& key, std::string_view def)

--- a/rpcs3/Loader/PSF.h
+++ b/rpcs3/Loader/PSF.h
@@ -53,7 +53,7 @@ namespace psf
 	registry load_object(const fs::file&);
 
 	// Convert PSF registry to SFO binary format
-	void save_object(const fs::file&, const registry&);
+	std::vector<u8> save_object(const registry&, std::vector<u8>&& init = std::vector<u8>{});
 
 	// Get string value or default value
 	std::string_view get_string(const registry& psf, const std::string& key, std::string_view def = ""sv);

--- a/rpcs3/Loader/TRP.cpp
+++ b/rpcs3/Loader/TRP.cpp
@@ -47,7 +47,7 @@ bool TRPLoader::Install(const std::string& dest, bool show)
 		}
 
 		// Create the file in the temporary directory
-		success = fs::write_file(temp + '/' + vfs::escape(entry.name), fs::create + fs::excl, buffer);
+		success = fs::write_file<true>(temp + '/' + vfs::escape(entry.name), fs::create + fs::excl, buffer);
 		if (!success)
 		{
 			break;

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -190,8 +190,9 @@ void emu_settings::SaveSettings()
 	}
 
 	// Save config atomically
-	fs::file(config_name + ".tmp", fs::rewrite).write(out.c_str(), out.size());
-	fs::rename(config_name + ".tmp", config_name, true);
+	fs::pending_file temp(config_name);
+	temp.file.write(out.c_str(), out.size());
+	temp.commit();
 
 	// Check if the running config/title is the same as the edited config/title.
 	if (config_name == g_cfg.name || m_title_id == Emu.GetTitleID())


### PR DESCRIPTION
* Fix all the Loader/PSF.cpp assertations for newly created/overwritten PARAM.SFO from this pr and on, old corrupted PARAM.SFO will still trigger assertations and should be deleted manually.
Example for the assertation: https://discord.com/channels/272035812277878785/277227681836302338/812657008779329537
* Fix atomicity of savedata/trophy data writes, add missing file buffers flushing.
* Write SPU and RSX captures attomically.