### PR TITLE
Do not require so much memory for RPCS3 at launch

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -389,7 +389,7 @@ extern void ppu_register_range(u32 addr, u32 size)
 	addr &= -0x10000;
 
 	// Register executable range at
-	utils::memory_commit(&ppu_ref(addr), u64{size} * 2, utils::protection::rw);
+	ensure(utils::memory_commit(&ppu_ref(addr), u64{size} * 2, utils::protection::rw));
 	vm::page_protect(addr, size, 0, vm::page_executable);
 
 	const u64 fallback = reinterpret_cast<uptr>(ppu_fallback);

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -741,12 +741,12 @@ namespace vm
 		if (flags & page_executable)
 		{
 			// TODO
-			utils::memory_commit(g_exec_addr + addr * 2, size * 2);
+			ensure(utils::memory_commit(g_exec_addr + addr * 2, size * 2));
 		}
 
 		if (g_cfg.core.ppu_debug)
 		{
-			utils::memory_commit(g_stat_addr + addr, size);
+			ensure(utils::memory_commit(g_stat_addr + addr, size));
 		}
 
 		for (u32 i = addr / 4096; i < addr / 4096 + size / 4096; i++)

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -370,7 +370,7 @@ int main(int argc, char** argv)
 	}
 
 #ifdef _WIN32
-	if (!SetProcessWorkingSetSize(GetCurrentProcess(), 0x80000000, 0xC0000000)) // 2-3 GiB
+	if (!SetProcessWorkingSetSize(GetCurrentProcess(), 0x40000000, 0x80000000)) // 1-2 GiB
 	{
 		report_fatal_error("Not enough memory for RPCS3 process.");
 		return 2;

--- a/rpcs3/util/vm.hpp
+++ b/rpcs3/util/vm.hpp
@@ -26,7 +26,7 @@ namespace utils
 	* That is, bake reserved memory with physical memory.
 	* pointer should belong to a range of reserved memory.
 	*/
-	void memory_commit(void* pointer, usz size, protection prot = protection::rw);
+	bool memory_commit(void* pointer, usz size, protection prot = protection::rw);
 
 	// Decommit all memory committed via commit_page_memory.
 	void memory_decommit(void* pointer, usz size);

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -162,14 +162,19 @@ namespace utils
 #endif
 	}
 
-	void memory_commit(void* pointer, usz size, protection prot)
+	bool memory_commit(void* pointer, usz size, protection prot)
 	{
 #ifdef _WIN32
-		ensure(::VirtualAlloc(pointer, size, MEM_COMMIT, +prot));
+		return ::VirtualAlloc(pointer, size, MEM_COMMIT, +prot);
 #else
 		const u64 ptr64 = reinterpret_cast<u64>(pointer);
-		ensure(::mprotect(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), +prot) != -1);
+		if (::mprotect(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), +prot) == -1)
+		{
+			return false;
+		}
+
 		ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), MADV_WILLNEED | c_madv_dump) != -1);
+		return true;
 #endif
 	}
 


### PR DESCRIPTION
Fix reckless allocations from RAM memory of 1GB on Windows and 2GB on linux from our LLVM/ASMJIT memory manager.
Test carefully the amount of memory we can actually use for it without out of memory failures.

This is how such an Out Of Memory error looked like:
https://cdn.discordapp.com/attachments/277227681836302338/813320970114433024/IMG20210222160654.jpg