### PR TITLE
fix no-gui crash if no firmware was installed

### DIFF
--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -185,8 +185,6 @@ std::shared_ptr<Device> hid_pad_handler<Device>::get_hid_device(const std::strin
 	if (!Init())
 		return nullptr;
 
-	std::shared_ptr<Device> device = nullptr;
-
 	// Controllers 1-n in GUI
 	for (auto& cur_control : m_controllers)
 	{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -358,6 +358,7 @@ void gui_application::InitializeCallbacks()
 
 	callbacks.on_missing_fw = [this]()
 	{
+		if (!m_main_window) return false;
 		return m_gui_settings->GetBootConfirmation(m_main_window, gui::ib_confirm_fw);
 	};
 


### PR DESCRIPTION
It's a bit mysterious, but the confirmation box doesn't like being called in this mode.
So let's just return false.