### PR TITLE
Fix rpcn registration

### DIFF
--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -295,7 +295,12 @@ bool rpcn_client::connect(const std::string& host)
 	connected = true;
 
 	while (!server_info_received && connected && !is_abort())
-		thread_ctrl::wait_for(5000);
+	{
+		if (in_config)
+			std::this_thread::sleep_for(5ms);
+		else
+			thread_ctrl::wait_for(5000);
+	}
 
 	if (received_version != RPCN_PROTOCOL_VERSION)
 	{
@@ -561,7 +566,11 @@ bool rpcn_client::get_reply(const u32 expected_id, std::vector<u8>& data)
 	{
 		if (check_for_reply())
 			return true;
-		thread_ctrl::wait_for(5000);
+
+		if (in_config)
+			std::this_thread::sleep_for(5ms);
+		else
+			thread_ctrl::wait_for(5000);
 	}
 
 	if (check_for_reply())


### PR DESCRIPTION
Closes https://github.com/RPCS3/rpcs3/issues/9821

Bug introduced by https://github.com/RPCS3/rpcs3/pull/9813 as rpcn_client is used outside game emulation when registering.