### PR TITLE
vk: Refactor device handling

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -157,7 +157,7 @@ namespace vk
 		return inheritance_info.parent->head();
 	}
 
-	void dma_block::set_parent(const command_buffer& cmd, dma_block* parent)
+	void dma_block::set_parent(dma_block* parent)
 	{
 		ensure(parent);
 		ensure(parent->base_address < base_address);
@@ -178,7 +178,7 @@ namespace vk
 		}
 	}
 
-	void dma_block::extend(const command_buffer& cmd, const render_device& dev, usz new_size)
+	void dma_block::extend(const render_device& dev, usz new_size)
 	{
 		ensure(allocated_memory);
 		if (new_size <= allocated_memory->size())
@@ -278,7 +278,7 @@ namespace vk
 		block->init(*g_render_device, base_address, expected_length);
 	}
 
-	std::pair<u32, vk::buffer*> map_dma(const command_buffer& cmd, u32 local_address, u32 length)
+	std::pair<u32, vk::buffer*> map_dma(u32 local_address, u32 length)
 	{
 		// Not much contention expected here, avoid searching twice
 		std::lock_guard lock(g_dma_mutex);
@@ -338,7 +338,7 @@ namespace vk
 			else if (entry)
 			{
 				ensure((entry->end() & s_dma_block_mask) <= last_block);
-				entry->set_parent(cmd, block_head);
+				entry->set_parent(block_head);
 			}
 			else
 			{

--- a/rpcs3/Emu/RSX/VK/VKDMA.h
+++ b/rpcs3/Emu/RSX/VK/VKDMA.h
@@ -4,7 +4,7 @@
 
 namespace vk
 {
-	std::pair<u32, vk::buffer*> map_dma(const command_buffer& cmd, u32 local_address, u32 length);
+	std::pair<u32, vk::buffer*> map_dma(u32 local_address, u32 length);
 	void load_dma(u32 local_address, u32 length);
 	void flush_dma(u32 local_address, u32 length);
 	void unmap_dma(u32 local_address, u32 length);
@@ -46,8 +46,8 @@ namespace vk
 
 		dma_block* head();
 		const dma_block* head() const;
-		virtual void set_parent(const command_buffer& cmd, dma_block* parent);
-		virtual void extend(const command_buffer& cmd, const render_device& dev, usz new_size);
+		virtual void set_parent(dma_block* parent);
+		virtual void extend(const render_device& dev, usz new_size);
 	};
 
 	class dma_block_EXT: public dma_block

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -518,7 +518,7 @@ VKGSRender::VKGSRender() : GSRender()
 
 	m_current_frame = &frame_context_storage[0];
 
-	m_texture_cache.initialize((*m_device), m_swapchain->get_graphics_queue(),
+	m_texture_cache.initialize((*m_device), m_device->get_graphics_queue(),
 			m_texture_upload_buffer_ring_info);
 
 	vk::get_overlay_pass<vk::ui_overlay_renderer>()->init(*m_current_command_buffer, m_texture_upload_buffer_ring_info);
@@ -1960,7 +1960,7 @@ void VKGSRender::close_and_submit_command_buffer(vk::fence* pFence, VkSemaphore 
 
 			m_secondary_command_buffer.end();
 
-			m_secondary_command_buffer.submit(m_swapchain->get_graphics_queue(),
+			m_secondary_command_buffer.submit(m_device->get_graphics_queue(),
 				VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, force_flush);
 		}
 
@@ -1992,7 +1992,7 @@ void VKGSRender::close_and_submit_command_buffer(vk::fence* pFence, VkSemaphore 
 	m_current_command_buffer->end();
 	m_current_command_buffer->tag();
 
-	m_current_command_buffer->submit(m_swapchain->get_graphics_queue(),
+	m_current_command_buffer->submit(m_device->get_graphics_queue(),
 		wait_semaphore, signal_semaphore, pFence, pipeline_stage_flags, force_flush);
 
 	if (force_flush)

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -906,7 +906,7 @@ namespace vk
 					src_address = uptr(base_addr) - uptr(vm::g_base_addr);
 				}
 
-				auto dma_mapping = vk::map_dma(cmd, static_cast<u32>(src_address), static_cast<u32>(data_length));
+				auto dma_mapping = vk::map_dma(static_cast<u32>(src_address), static_cast<u32>(data_length));
 
 				ensure(dma_mapping.second->size() >= (dma_mapping.first + data_length));
 				vk::load_dma(::narrow<u32>(src_address), data_length);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -45,7 +45,7 @@ namespace vk
 			const auto task_length = transfer_pitch * src_area.height();
 
 			auto working_buffer = vk::get_scratch_buffer(task_length);
-			auto final_mapping = vk::map_dma(cmd, valid_range.start, section_length);
+			auto final_mapping = vk::map_dma(valid_range.start, section_length);
 
 			VkBufferImageCopy region = {};
 			region.imageSubresource = { src->aspect(), 0, 0, 1 };
@@ -129,7 +129,7 @@ namespace vk
 			region.imageOffset = { src_area.x1, src_area.y1, 0 };
 			region.imageExtent = { transfer_width, transfer_height, 1 };
 
-			auto mapping = vk::map_dma(cmd, valid_range.start, valid_range.length());
+			auto mapping = vk::map_dma(valid_range.start, valid_range.length());
 			region.bufferOffset = mapping.first;
 			vkCmdCopyImageToBuffer(cmd, src->value, src->current_layout, mapping.second->value, 1, &region);
 		}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -911,7 +911,7 @@ namespace vk
 
 			if (memory_load)
 			{
-				vk::map_dma(cmd, rsx_range.start, rsx_range.length());
+				vk::map_dma(rsx_range.start, rsx_range.length());
 				vk::load_dma(rsx_range.start, rsx_range.length());
 			}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -228,18 +228,41 @@ namespace vk
 	}
 
 	// Render Device - The actual usable device
-	void render_device::create(vk::physical_device& pdev, u32 graphics_queue_idx)
+	void render_device::create(vk::physical_device& pdev, u32 graphics_queue_idx, u32 present_queue_idx, u32 transfer_queue_idx)
 	{
 		std::string message_on_error;
 		float queue_priorities[1] = { 0.f };
 		pgpu = &pdev;
 
-		VkDeviceQueueCreateInfo queue = {};
-		queue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-		queue.pNext = NULL;
-		queue.queueFamilyIndex = graphics_queue_idx;
-		queue.queueCount = 1;
-		queue.pQueuePriorities = queue_priorities;
+		ensure(graphics_queue_idx == present_queue_idx || present_queue_idx == UINT32_MAX); // TODO
+		m_graphics_queue_family = graphics_queue_idx;
+		m_present_queue_family = present_queue_idx;
+		m_transfer_queue_family = transfer_queue_idx;
+
+		std::vector<VkDeviceQueueCreateInfo> device_queues;
+		device_queues.push_back({});
+
+		auto & graphics_queue = device_queues.back();
+		graphics_queue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+		graphics_queue.pNext = NULL;
+		graphics_queue.flags = 0;
+		graphics_queue.queueFamilyIndex = graphics_queue_idx;
+		graphics_queue.queueCount = 1;
+		graphics_queue.pQueuePriorities = queue_priorities;
+
+		if (graphics_queue_idx != transfer_queue_idx)
+		{
+			ensure(transfer_queue_idx != UINT32_MAX);
+
+			device_queues.push_back({});
+			auto & transfer_queue = device_queues.back();
+			transfer_queue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+			transfer_queue.pNext = NULL;
+			transfer_queue.flags = 0;
+			transfer_queue.queueFamilyIndex = transfer_queue_idx;
+			transfer_queue.queueCount = 1;
+			transfer_queue.pQueuePriorities = queue_priorities;
+		}
 
 		// Set up instance information
 		std::vector<const char*> requested_extensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
@@ -361,8 +384,8 @@ namespace vk
 		VkDeviceCreateInfo device = {};
 		device.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 		device.pNext = nullptr;
-		device.queueCreateInfoCount = 1;
-		device.pQueueCreateInfos = &queue;
+		device.queueCreateInfoCount = ::size32(device_queues);
+		device.pQueueCreateInfos = device_queues.data();
 		device.enabledLayerCount = 0;
 		device.ppEnabledLayerNames = nullptr; // Deprecated
 		device.enabledExtensionCount = ::size32(requested_extensions);
@@ -385,6 +408,15 @@ namespace vk
 		}
 
 		CHECK_RESULT_EX(vkCreateDevice(*pgpu, &device, nullptr, &dev), message_on_error);
+
+		// Initialize queues
+		vkGetDeviceQueue(dev, graphics_queue_idx, 0, &m_graphics_queue);
+		vkGetDeviceQueue(dev, transfer_queue_idx, 0, &m_transfer_queue);
+
+		if (present_queue_idx != UINT32_MAX)
+		{
+			vkGetDeviceQueue(dev, present_queue_idx, 0, &m_present_queue);
+		}
 
 		// Import optional function endpoints
 		if (pgpu->conditional_render_support)
@@ -423,6 +455,36 @@ namespace vk
 			memory_map = {};
 			m_formats_support = {};
 		}
+	}
+
+	VkQueue render_device::get_present_queue() const
+	{
+		return m_present_queue;
+	}
+
+	VkQueue render_device::get_graphics_queue() const
+	{
+		return m_graphics_queue;
+	}
+
+	VkQueue render_device::get_transfer_queue() const
+	{
+		return m_transfer_queue;
+	}
+
+	u32 render_device::get_graphics_queue_family() const
+	{
+		return m_graphics_queue_family;
+	}
+
+	u32 render_device::get_present_queue_family() const
+	{
+		return m_graphics_queue_family;
+	}
+
+	u32 render_device::get_transfer_queue_family() const
+	{
+		return m_transfer_queue_family;
 	}
 
 	const VkFormatProperties render_device::get_format_properties(VkFormat format)

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -89,6 +89,14 @@ namespace vk
 		std::unique_ptr<mem_allocator_base> m_allocator;
 		VkDevice dev = VK_NULL_HANDLE;
 
+		VkQueue m_graphics_queue = VK_NULL_HANDLE;
+		VkQueue m_present_queue = VK_NULL_HANDLE;
+		VkQueue m_transfer_queue = VK_NULL_HANDLE;
+
+		u32 m_graphics_queue_family = 0;
+		u32 m_present_queue_family = 0;
+		u32 m_transfer_queue_family = 0;
+
 	public:
 		// Exported device endpoints
 		PFN_vkCmdBeginConditionalRenderingEXT cmdBeginConditionalRenderingEXT = nullptr;
@@ -98,7 +106,7 @@ namespace vk
 		render_device() = default;
 		~render_device() = default;
 
-		void create(vk::physical_device& pdev, u32 graphics_queue_idx);
+		void create(vk::physical_device& pdev, u32 graphics_queue_idx, u32 present_queue_idx, u32 transfer_queue_idx);
 		void destroy();
 
 		const VkFormatProperties get_format_properties(VkFormat format);
@@ -118,6 +126,13 @@ namespace vk
 		bool get_unrestricted_depth_range_support() const;
 		bool get_external_memory_host_support() const;
 		bool get_surface_capabilities_2_support() const;
+
+		VkQueue get_present_queue() const;
+		VkQueue get_graphics_queue() const;
+		VkQueue get_transfer_queue() const;
+		u32 get_graphics_queue_family() const;
+		u32 get_present_queue_family() const;
+		u32 get_transfer_queue_family() const;
 
 		mem_allocator_base* get_allocator() const;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
@@ -73,11 +73,6 @@ namespace vk
 	protected:
 		render_device dev;
 
-		u32 m_present_queue = UINT32_MAX;
-		u32 m_graphics_queue = UINT32_MAX;
-		VkQueue vk_graphics_queue = VK_NULL_HANDLE;
-		VkQueue vk_present_queue = VK_NULL_HANDLE;
-
 		display_handle_t window_handle{};
 		u32 m_width = 0;
 		u32 m_height = 0;
@@ -86,15 +81,9 @@ namespace vk
 		virtual void init_swapchain_images(render_device& dev, u32 count) = 0;
 
 	public:
-		swapchain_base(physical_device& gpu, u32 _present_queue, u32 _graphics_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
+		swapchain_base(physical_device& gpu, u32 present_queue, u32 graphics_queue, u32 transfer_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
 		{
-			dev.create(gpu, _graphics_queue);
-
-			if (_graphics_queue < UINT32_MAX) vkGetDeviceQueue(dev, _graphics_queue, 0, &vk_graphics_queue);
-			if (_present_queue < UINT32_MAX) vkGetDeviceQueue(dev, _present_queue, 0, &vk_present_queue);
-
-			m_present_queue = _present_queue;
-			m_graphics_queue = _graphics_queue;
+			dev.create(gpu, graphics_queue, present_queue, transfer_queue);
 			m_surface_format = format;
 		}
 
@@ -128,16 +117,6 @@ namespace vk
 			return dev;
 		}
 
-		const VkQueue& get_present_queue()
-		{
-			return vk_present_queue;
-		}
-
-		const VkQueue& get_graphics_queue()
-		{
-			return vk_graphics_queue;
-		}
-
 		const VkFormat get_surface_format()
 		{
 			return m_surface_format;
@@ -145,7 +124,7 @@ namespace vk
 
 		const bool is_headless() const
 		{
-			return (vk_present_queue == VK_NULL_HANDLE);
+			return (dev.get_present_queue() == VK_NULL_HANDLE);
 		}
 	};
 
@@ -156,8 +135,8 @@ namespace vk
 		std::vector<T> swapchain_images;
 
 	public:
-		abstract_swapchain_impl(physical_device& gpu, u32 _present_queue, u32 _graphics_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
-			: swapchain_base(gpu, _present_queue, _graphics_queue, format)
+		abstract_swapchain_impl(physical_device& gpu, u32 present_queue, u32 graphics_queue, u32 transfer_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
+			: swapchain_base(gpu, present_queue, graphics_queue, transfer_queue, format)
 		{}
 
 		~abstract_swapchain_impl() override = default;
@@ -183,8 +162,8 @@ namespace vk
 		LPVOID hPtr = NULL;
 
 	public:
-		swapchain_WIN32(physical_device& gpu, u32 _present_queue, u32 _graphics_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
-			: native_swapchain_base(gpu, _present_queue, _graphics_queue, format)
+		swapchain_WIN32(physical_device& gpu, u32 present_queue, u32 graphics_queue, u32 transfer_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
+			: native_swapchain_base(gpu, present_queue, graphics_queue, transfer_queue, format)
 		{}
 
 		~swapchain_WIN32() {}
@@ -266,8 +245,8 @@ namespace vk
 		void* nsView = nullptr;
 
 	public:
-		swapchain_MacOS(physical_device& gpu, u32 _present_queue, u32 _graphics_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
-			: native_swapchain_base(gpu, _present_queue, _graphics_queue, format)
+		swapchain_MacOS(physical_device& gpu, u32 present_queue, u32 graphics_queue, u32 transfer_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
+			: native_swapchain_base(gpu, present_queue, graphics_queue, transfer_queue, format)
 		{}
 
 		~swapchain_MacOS() {}
@@ -316,8 +295,8 @@ namespace vk
 		int bit_depth = 24;
 
 	public:
-		swapchain_X11(physical_device& gpu, u32 _present_queue, u32 _graphics_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
-			: native_swapchain_base(gpu, _present_queue, _graphics_queue, format)
+		swapchain_X11(physical_device& gpu, u32 present_queue, u32 graphics_queue, u32 transfer_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
+			: native_swapchain_base(gpu, present_queue, graphics_queue, transfer_queue, format)
 		{}
 
 		~swapchain_X11() override = default;
@@ -418,8 +397,8 @@ namespace vk
 	{
 
 	public:
-		swapchain_Wayland(physical_device& gpu, u32 _present_queue, u32 _graphics_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
-			: native_swapchain_base(gpu, _present_queue, _graphics_queue, format)
+		swapchain_Wayland(physical_device& gpu, u32 present_queue, u32 graphics_queue, u32 transfer_queue, VkFormat format = VK_FORMAT_B8G8R8A8_UNORM)
+			: native_swapchain_base(gpu, present_queue, graphics_queue, transfer_queue, format)
 		{}
 
 		~swapchain_Wayland() {}
@@ -524,8 +503,8 @@ namespace vk
 		}
 
 	public:
-		swapchain_WSI(vk::physical_device& gpu, u32 _present_queue, u32 _graphics_queue, VkFormat format, VkSurfaceKHR surface, VkColorSpaceKHR color_space, bool force_wm_reporting_off)
-			: WSI_swapchain_base(gpu, _present_queue, _graphics_queue, format)
+		swapchain_WSI(vk::physical_device& gpu, u32 present_queue, u32 graphics_queue, u32 transfer_queue, VkFormat format, VkSurfaceKHR surface, VkColorSpaceKHR color_space, bool force_wm_reporting_off)
+			: WSI_swapchain_base(gpu, present_queue, graphics_queue, transfer_queue, format)
 		{
 			createSwapchainKHR = reinterpret_cast<PFN_vkCreateSwapchainKHR>(vkGetDeviceProcAddr(dev, "vkCreateSwapchainKHR"));
 			destroySwapchainKHR = reinterpret_cast<PFN_vkDestroySwapchainKHR>(vkGetDeviceProcAddr(dev, "vkDestroySwapchainKHR"));
@@ -622,7 +601,7 @@ namespace vk
 		using WSI_swapchain_base::init;
 		bool init() override
 		{
-			if (vk_present_queue == VK_NULL_HANDLE)
+			if (dev.get_present_queue() == VK_NULL_HANDLE)
 			{
 				rsx_log.error("Cannot create WSI swapchain without a present queue");
 				return false;
@@ -791,7 +770,7 @@ namespace vk
 			present.waitSemaphoreCount = 1;
 			present.pWaitSemaphores = &semaphore;
 
-			return queuePresentKHR(vk_present_queue, &present);
+			return queuePresentKHR(dev.get_present_queue(), &present);
 		}
 
 		VkImage get_image(u32 index) override


### PR DESCRIPTION
This is part of the long series of upcoming PRs that lay the foundation for some features just coming out of development. This is part 2 of many, first part was already committed (DMA bugfix)
- Clean up some DMA leftovers
- Refactor device and swapchain handling to support creating separate hw transfer queue. Not used in this PR.