### PR TITLE
overlays: Fix frametime graph spikes

### DIFF
--- a/Utilities/CPUStats.h
+++ b/Utilities/CPUStats.h
@@ -137,7 +137,7 @@ public:
 		DWORD const id = GetCurrentProcessId();
 
 		// then get a process list snapshot.
-		HANDLE const snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0);
+		HANDLE const snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
 
 		// initialize the process entry structure.
 		PROCESSENTRY32 entry = {0};

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -233,6 +233,12 @@ namespace rsx
 			reset_transforms();
 			force_next_update();
 
+			if (m_is_initialised)
+			{
+				update();
+				return;
+			}
+
 			m_update_timer.Start();
 			m_frametime_timer.Start();
 
@@ -382,7 +388,7 @@ namespace rsx
 
 			if (m_is_initialised)
 			{
-				if (m_frametime_graph_enabled)
+				if (m_frametime_graph_enabled && !m_force_update)
 				{
 					const auto elapsed_frame = m_frametime_timer.GetElapsedTimeInMilliSec();
 					m_frametime_timer.Start();
@@ -402,98 +408,79 @@ namespace rsx
 
 			if (elapsed_update >= m_update_interval || m_force_update)
 			{
-				if (!m_force_update)
+				// 1. Fetch/calculate metrics we'll need
+				if (!m_is_initialised || !m_force_update)
 				{
 					m_update_timer.Start();
-				}
 
-				f32 fps{0};
-				f32 frametime{0};
+					const auto rsx_thread = g_fxo->get<rsx::thread>();
 
-				u64 ppu_cycles{0};
-				u64 spu_cycles{0};
-				u64 rsx_cycles{0};
-				u64 total_cycles{0};
-
-				u32 ppus{0};
-				u32 spus{0};
-
-				f32 cpu_usage{-1.f};
-				u32 total_threads{0};
-
-				f32 ppu_usage{0};
-				f32 spu_usage{0};
-				f32 rsx_usage{0};
-				u32 rsx_load{0};
-
-				const auto rsx_thread = g_fxo->get<rsx::thread>();
-
-				std::string perf_text;
-
-				// 1. Fetch/calculate metrics we'll need
-				switch (m_detail)
-				{
-				case detail_level::high:
-				{
-					frametime = m_force_update ? 0.f : std::max(0.f, static_cast<float>(elapsed_update / m_frames));
-
-					rsx_load = rsx_thread->get_load();
-
-					total_threads = CPUStats::get_thread_count();
-
-					[[fallthrough]];
-				}
-				case detail_level::medium:
-				{
-					ppus = idm::select<named_thread<ppu_thread>>([&ppu_cycles](u32, named_thread<ppu_thread>& ppu)
+					switch (m_detail)
 					{
-						ppu_cycles += thread_ctrl::get_cycles(ppu);
-					});
-
-					spus = idm::select<named_thread<spu_thread>>([&spu_cycles](u32, named_thread<spu_thread>& spu)
+					case detail_level::high:
 					{
-						spu_cycles += thread_ctrl::get_cycles(spu);
-					});
+						m_frametime = std::max(0.f, static_cast<float>(elapsed_update / m_frames));
 
-					rsx_cycles += rsx_thread->get_cycles();
+						m_rsx_load = rsx_thread->get_load();
 
-					total_cycles = std::max<u64>(1, ppu_cycles + spu_cycles + rsx_cycles);
-					cpu_usage = static_cast<f32>(m_cpu_stats.get_usage());
+						m_total_threads = CPUStats::get_thread_count();
 
-					ppu_usage = std::clamp(cpu_usage * ppu_cycles / total_cycles, 0.f, 100.f);
-					spu_usage = std::clamp(cpu_usage * spu_cycles / total_cycles, 0.f, 100.f);
-					rsx_usage = std::clamp(cpu_usage * rsx_cycles / total_cycles, 0.f, 100.f);
+						[[fallthrough]];
+					}
+					case detail_level::medium:
+					{
+						m_ppus = idm::select<named_thread<ppu_thread>>([this](u32, named_thread<ppu_thread>& ppu)
+						{
+							m_ppu_cycles += thread_ctrl::get_cycles(ppu);
+						});
 
-					[[fallthrough]];
-				}
-				case detail_level::low:
-				{
-					if (cpu_usage < 0.)
-						cpu_usage = static_cast<f32>(m_cpu_stats.get_usage());
+						m_spus = idm::select<named_thread<spu_thread>>([this](u32, named_thread<spu_thread>& spu)
+						{
+							m_spu_cycles += thread_ctrl::get_cycles(spu);
+						});
 
-					[[fallthrough]];
-				}
-				case detail_level::minimal:
-				{
-					fps = m_force_update ? 0.f : std::max(0.f, static_cast<f32>(m_frames / (elapsed_update / 1000)));
-					if (m_is_initialised && m_framerate_graph_enabled)
-						m_fps_graph.record_datapoint(fps);
-				}
+						m_rsx_cycles += rsx_thread->get_cycles();
+
+						m_total_cycles = std::max<u64>(1, m_ppu_cycles + m_spu_cycles + m_rsx_cycles);
+						m_cpu_usage    = static_cast<f32>(m_cpu_stats.get_usage());
+
+						m_ppu_usage = std::clamp(m_cpu_usage * m_ppu_cycles / m_total_cycles, 0.f, 100.f);
+						m_spu_usage = std::clamp(m_cpu_usage * m_spu_cycles / m_total_cycles, 0.f, 100.f);
+						m_rsx_usage = std::clamp(m_cpu_usage * m_rsx_cycles / m_total_cycles, 0.f, 100.f);
+
+						[[fallthrough]];
+					}
+					case detail_level::low:
+					{
+						if (m_cpu_usage < 0.)
+							m_cpu_usage = static_cast<f32>(m_cpu_stats.get_usage());
+
+						[[fallthrough]];
+					}
+					case detail_level::minimal:
+					{
+						m_fps = std::max(0.f, static_cast<f32>(m_frames / (elapsed_update / 1000)));
+						if (m_is_initialised && m_framerate_graph_enabled)
+							m_fps_graph.record_datapoint(m_fps);
+					}
+					}
 				}
 
 				// 2. Format output string
+				std::string perf_text;
+
 				switch (m_detail)
 				{
 				case detail_level::minimal:
 				{
-					perf_text += fmt::format("FPS : %05.2f", fps);
+					perf_text += fmt::format("FPS : %05.2f", m_fps);
 					break;
 				}
 				case detail_level::low:
 				{
 					perf_text += fmt::format("FPS : %05.2f\n"
 					                         "CPU : %04.1f %%",
-					    fps, cpu_usage);
+					    m_fps, m_cpu_usage);
 					break;
 				}
 				case detail_level::medium:
@@ -504,7 +491,7 @@ namespace rsx
 					                         " SPU   : %04.1f %%\n"
 					                         " RSX   : %04.1f %%\n"
 					                         " Total : %04.1f %%",
-					    fps, std::string(title1_medium.size(), ' '), ppu_usage, spu_usage, rsx_usage, cpu_usage, std::string(title2.size(), ' '));
+					    m_fps, std::string(title1_medium.size(), ' '), m_ppu_usage, m_spu_usage, m_rsx_usage, m_cpu_usage, std::string(title2.size(), ' '));
 					break;
 				}
 				case detail_level::high:
@@ -517,7 +504,7 @@ namespace rsx
 					                         " Total : %04.1f %% (%2u)\n\n"
 					                         "%s\n"
 					                         " RSX   : %02u %%",
-					    fps, frametime, std::string(title1_high.size(), ' '), ppu_usage, ppus, spu_usage, spus, rsx_usage, cpu_usage, total_threads, std::string(title2.size(), ' '), rsx_load);
+					    m_fps, m_frametime, std::string(title1_high.size(), ' '), m_ppu_usage, m_ppus, m_spu_usage, m_spus, m_rsx_usage, m_cpu_usage, m_total_threads, std::string(title2.size(), ' '), m_rsx_load);
 					break;
 				}
 				}
@@ -755,11 +742,7 @@ namespace rsx
 					perf_overlay->set_title_colors(perf_settings.color_title, perf_settings.background_title);
 					perf_overlay->set_framerate_graph_enabled(perf_settings.framerate_graph_enabled.get());
 					perf_overlay->set_frametime_graph_enabled(perf_settings.frametime_graph_enabled.get());
-
-					if (!existed)
-					{
-						perf_overlay->init();
-					}
+					perf_overlay->init();
 				}
 				else if (perf_overlay)
 				{

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -555,7 +555,12 @@ namespace rsx
 
 		compiled_resource perf_metrics_overlay::get_compiled()
 		{
-			auto compiled_resources = m_body.get_compiled();
+			if (!visible)
+			{
+				return {};
+			}
+
+			compiled_resource compiled_resources = m_body.get_compiled();
 
 			compiled_resources.add(m_titles.get_compiled());
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -165,7 +165,7 @@ namespace rsx
 			}
 
 			// Set body/titles transform
-			if (m_is_initialised && m_force_repaint)
+			if (m_force_repaint)
 			{
 				m_force_repaint = false;
 				reset_body(bottom_margin);

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -640,6 +640,8 @@ namespace rsx
 
 		void graph::record_datapoint(f32 datapoint)
 		{
+			ensure(datapoint >= 0.0f);
+
 			// std::dequeue is only faster for large sizes, so just use a std::vector and resize once in while
 
 			// Record datapoint
@@ -675,10 +677,10 @@ namespace rsx
 			refresh();
 			overlay_element::get_compiled();
 
-			const f32 normalize_factor = f32(h) / m_max;
+			const f32 normalize_factor = f32(h) / (m_max != 0.0f ? m_max : 1.0f);
 
 			// Don't show guide lines if they'd be more dense than 1 guide line every 3 pixels
-			const bool guides_too_dense = (m_max / m_guide_interval) > (h / 3);
+			const bool guides_too_dense = (m_max / m_guide_interval) > (h / 3.0f);
 
 			if (m_guide_interval > 0 && !guides_too_dense)
 			{
@@ -707,12 +709,12 @@ namespace rsx
 			auto& verts_graph = compiled_resources.draw_commands.back().verts;
 
 			const f32 x_stride = w * 1.f / m_datapoint_count;
-			const u32 tail_index_offset = ::size32(m_datapoints) - m_datapoint_count;
+			const usz tail_index_offset = m_datapoints.size() - m_datapoint_count;
 
 			for (u32 i = 0; i < m_datapoint_count; ++i)
 			{
 				const f32 x_line = x + i * x_stride;
-				const f32 y_line = y + h - (m_datapoints[tail_index_offset + i] * normalize_factor);
+				const f32 y_line = y + h - (m_datapoints[i + tail_index_offset] * normalize_factor);
 				verts_graph.emplace_back(x_line, y_line);
 			}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -385,6 +385,7 @@ namespace rsx
 				if (m_frametime_graph_enabled)
 				{
 					const auto elapsed_frame = m_frametime_timer.GetElapsedTimeInMilliSec();
+					m_frametime_timer.Start();
 					m_frametime_graph.record_datapoint(static_cast<float>(elapsed_frame));
 				}
 
@@ -549,7 +550,6 @@ namespace rsx
 			if (m_frametime_graph_enabled)
 			{
 				m_frametime_graph.update();
-				m_frametime_timer.Start();
 			}
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.h
@@ -48,13 +48,32 @@ namespace rsx
 			std::string m_color_title;
 			std::string m_background_title;
 
-			bool m_force_update{};
+			bool m_force_update{}; // Used to update the overlay metrics without changing the data
 			bool m_force_repaint{};
 			bool m_is_initialised{};
 
 			const std::string title1_medium{ "CPU Utilization:" };
 			const std::string title1_high{ "Host Utilization (CPU):" };
 			const std::string title2{ "Guest Utilization (PS3):" };
+
+			f32 m_fps{0};
+			f32 m_frametime{0};
+
+			u64 m_ppu_cycles{0};
+			u64 m_spu_cycles{0};
+			u64 m_rsx_cycles{0};
+			u64 m_total_cycles{0};
+
+			u32 m_ppus{0};
+			u32 m_spus{0};
+
+			f32 m_cpu_usage{-1.f};
+			u32 m_total_threads{0};
+
+			f32 m_ppu_usage{0};
+			f32 m_spu_usage{0};
+			f32 m_rsx_usage{0};
+			u32 m_rsx_load{0};
 
 			void reset_transform(label& elm, u16 bottom_margin = 0) const;
 			void reset_transforms();


### PR DESCRIPTION
- The frametime_timer was restarted at the end of the update method, instead of immediately after reading its value.
This means that the frametime was lower than expected when an expensive task was executed in-between.
The main culprit for the spikes is the `get_thread_count` method, which is very slow on windows at least.
It takes a couple of ms and therefore caused a decrease in elapsed_time for one cycle.

- The perf_metrics_overlay didn't handle the visible flag properly. So let's return an empty compiled_resource in get_compiled.

- Fixed a division by 0 that could cause some random inf to suddenly appear and mess up the graph.

- Fixed the body size. It was wrong for a brief period initially and after each detail level settings change.
The body was lagging behind the text. This was fixed by calling an updated version of init() on settings change.
This introduced spikes in the frametime graph, so the data had to become members and m_force_update was adjusted to not interfere with data aquisition.