### PR TITLE
Minor GUI fix for PPU interpreter at "precompilation"

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2222,6 +2222,11 @@ extern void ppu_finalize(const ppu_module& info)
 
 extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_prx*>* loaded_prx)
 {
+	if (g_cfg.core.ppu_decoder != ppu_decoder_type::llvm)
+	{
+		return;
+	}
+
 	// Make sure we only have one '/' at the end and remove duplicates.
 	for (std::string& dir : dir_queue)
 	{


### PR DESCRIPTION
If liblv2.sprx is HLEd, compile_fw is true in ppu_initialize(void) resulting in directories being scanned and the PPU progress dialog is being spuriously spawn and then closes pretty fast after because there's nothing to compile. Just add a condition to not attempt to call any precompilation related code when using interpreters.