### PR TITLE
vk: Fixup

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -835,7 +835,7 @@ void VKGSRender::emit_geometry(u32 sub_index)
 			info.sType = VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT;
 			info.buffer = m_cond_render_buffer->value;
 
-			m_device->cmdBeginConditionalRenderingEXT(*m_current_command_buffer, &info);
+			m_device->_vkCmdBeginConditionalRenderingEXT(*m_current_command_buffer, &info);
 			m_current_command_buffer->flags |= vk::command_buffer::cb_has_conditional_render;
 		}
 	}
@@ -1029,7 +1029,7 @@ void VKGSRender::end()
 
 	if (m_current_command_buffer->flags & vk::command_buffer::cb_has_conditional_render)
 	{
-		m_device->cmdEndConditionalRenderingEXT(*m_current_command_buffer);
+		m_device->_vkCmdEndConditionalRenderingEXT(*m_current_command_buffer);
 		m_current_command_buffer->flags &= ~(vk::command_buffer::cb_has_conditional_render);
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1971,7 +1971,7 @@ void VKGSRender::close_and_submit_command_buffer(vk::fence* pFence, VkSemaphore 
 	if (m_current_command_buffer->flags & vk::command_buffer::cb_has_conditional_render)
 	{
 		ensure(m_render_pass_open);
-		m_device->cmdEndConditionalRenderingEXT(*m_current_command_buffer);
+		m_device->_vkCmdEndConditionalRenderingEXT(*m_current_command_buffer);
 	}
 #endif
 

--- a/rpcs3/Emu/RSX/VK/vkutils/buffer_object.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/buffer_object.cpp
@@ -87,11 +87,11 @@ namespace vk
 			u32 memory_type_index = memory_map.host_visible_coherent;
 			VkFlags access_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
 
-			ensure(memory_map.getMemoryHostPointerPropertiesEXT);
+			ensure(memory_map._vkGetMemoryHostPointerPropertiesEXT);
 
 			VkMemoryHostPointerPropertiesEXT memory_properties{};
 			memory_properties.sType = VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT;
-			CHECK_RESULT(memory_map.getMemoryHostPointerPropertiesEXT(dev, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_pointer, &memory_properties));
+			CHECK_RESULT(memory_map._vkGetMemoryHostPointerPropertiesEXT(dev, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_pointer, &memory_properties));
 
 			VkMemoryRequirements memory_reqs;
 			vkGetBufferMemoryRequirements(m_device, value, &memory_reqs);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -235,10 +235,6 @@ namespace vk
 		pgpu = &pdev;
 
 		ensure(graphics_queue_idx == present_queue_idx || present_queue_idx == umax); // TODO
-		m_graphics_queue_family = graphics_queue_idx;
-		m_present_queue_family = present_queue_idx;
-		m_transfer_queue_family = transfer_queue_idx;
-
 		std::vector<VkDeviceQueueCreateInfo> device_queues;
 
 		auto& graphics_queue = device_queues.emplace_back();
@@ -249,7 +245,27 @@ namespace vk
 		graphics_queue.queueCount = 1;
 		graphics_queue.pQueuePriorities = queue_priorities;
 
-		if (graphics_queue_idx != transfer_queue_idx && transfer_queue_idx != umax)
+		u32 transfer_queue_sub_index = 0;
+		if (transfer_queue_idx == umax)
+		{
+			// Transfer queue must be a valid device queue
+			rsx_log.warning("Dedicated transfer+compute queue was not found on this GPU. Will use graphics queue instead.");
+			transfer_queue_idx = graphics_queue_idx;
+
+			// Check if we can at least get a second graphics queue
+			if (pdev.get_queue_properties(graphics_queue_idx).queueCount > 1)
+			{
+				rsx_log.notice("Will use a spare graphics queue to push transfer operations.");
+				graphics_queue.queueCount++;
+				transfer_queue_sub_index = 1;
+			}
+		}
+
+		m_graphics_queue_family = graphics_queue_idx;
+		m_present_queue_family = present_queue_idx;
+		m_transfer_queue_family = transfer_queue_idx;
+
+		if (graphics_queue_idx != transfer_queue_idx)
 		{
 			auto& transfer_queue = device_queues.emplace_back();
 			transfer_queue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
@@ -407,7 +423,7 @@ namespace vk
 
 		// Initialize queues
 		vkGetDeviceQueue(dev, graphics_queue_idx, 0, &m_graphics_queue);
-		vkGetDeviceQueue(dev, transfer_queue_idx, 0, &m_transfer_queue);
+		vkGetDeviceQueue(dev, transfer_queue_idx, transfer_queue_sub_index, &m_transfer_queue);
 
 		if (present_queue_idx != UINT32_MAX)
 		{

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -44,9 +44,9 @@ namespace vk
 				features2.pNext         = &driver_properties;
 			}
 
-			auto getPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(vkGetInstanceProcAddr(parent, "vkGetPhysicalDeviceFeatures2KHR"));
-			ensure(getPhysicalDeviceFeatures2KHR); // "vkGetInstanceProcAddress failed to find entry point!"
-			getPhysicalDeviceFeatures2KHR(dev, &features2);
+			auto _vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(vkGetInstanceProcAddr(parent, "vkGetPhysicalDeviceFeatures2KHR"));
+			ensure(_vkGetPhysicalDeviceFeatures2KHR); // "vkGetInstanceProcAddress failed to find entry point!"
+			_vkGetPhysicalDeviceFeatures2KHR(dev, &features2);
 
 			shader_types_support.allow_float64 = !!features2.features.shaderFloat64;
 			shader_types_support.allow_float16 = !!shader_support_info.shaderFloat16;
@@ -417,8 +417,8 @@ namespace vk
 		// Import optional function endpoints
 		if (pgpu->conditional_render_support)
 		{
-			cmdBeginConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdBeginConditionalRenderingEXT>(vkGetDeviceProcAddr(dev, "vkCmdBeginConditionalRenderingEXT"));
-			cmdEndConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdEndConditionalRenderingEXT>(vkGetDeviceProcAddr(dev, "vkCmdEndConditionalRenderingEXT"));
+			_vkCmdBeginConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdBeginConditionalRenderingEXT>(vkGetDeviceProcAddr(dev, "vkCmdBeginConditionalRenderingEXT"));
+			_vkCmdEndConditionalRenderingEXT = reinterpret_cast<PFN_vkCmdEndConditionalRenderingEXT>(vkGetDeviceProcAddr(dev, "vkCmdEndConditionalRenderingEXT"));
 		}
 
 		memory_map = vk::get_memory_mapping(pdev);
@@ -427,7 +427,7 @@ namespace vk
 
 		if (pgpu->external_memory_host_support)
 		{
-			memory_map.getMemoryHostPointerPropertiesEXT = reinterpret_cast<PFN_vkGetMemoryHostPointerPropertiesEXT>(vkGetDeviceProcAddr(dev, "vkGetMemoryHostPointerPropertiesEXT"));
+			memory_map._vkGetMemoryHostPointerPropertiesEXT = reinterpret_cast<PFN_vkGetMemoryHostPointerPropertiesEXT>(vkGetDeviceProcAddr(dev, "vkGetMemoryHostPointerPropertiesEXT"));
 		}
 
 		if (g_cfg.video.disable_vulkan_mem_allocator)

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -31,7 +31,7 @@ namespace vk
 		u32 host_visible_coherent;
 		u32 device_local;
 
-		PFN_vkGetMemoryHostPointerPropertiesEXT getMemoryHostPointerPropertiesEXT;
+		PFN_vkGetMemoryHostPointerPropertiesEXT _vkGetMemoryHostPointerPropertiesEXT;
 	};
 
 	class physical_device
@@ -99,8 +99,8 @@ namespace vk
 
 	public:
 		// Exported device endpoints
-		PFN_vkCmdBeginConditionalRenderingEXT cmdBeginConditionalRenderingEXT = nullptr;
-		PFN_vkCmdEndConditionalRenderingEXT cmdEndConditionalRenderingEXT = nullptr;
+		PFN_vkCmdBeginConditionalRenderingEXT _vkCmdBeginConditionalRenderingEXT = nullptr;
+		PFN_vkCmdEndConditionalRenderingEXT _vkCmdEndConditionalRenderingEXT = nullptr;
 
 	public:
 		render_device() = default;

--- a/rpcs3/Emu/RSX/VK/vkutils/instance.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/instance.hpp
@@ -59,8 +59,8 @@ namespace vk
 		VkInstance m_instance = VK_NULL_HANDLE;
 		VkSurfaceKHR m_surface = VK_NULL_HANDLE;
 
-		PFN_vkDestroyDebugReportCallbackEXT destroyDebugReportCallback = nullptr;
-		PFN_vkCreateDebugReportCallbackEXT createDebugReportCallback = nullptr;
+		PFN_vkDestroyDebugReportCallbackEXT _vkDestroyDebugReportCallback = nullptr;
+		PFN_vkCreateDebugReportCallbackEXT _vkCreateDebugReportCallback = nullptr;
 		VkDebugReportCallbackEXT m_debugger = nullptr;
 
 		bool extensions_loaded = false;
@@ -83,7 +83,7 @@ namespace vk
 
 			if (m_debugger)
 			{
-				destroyDebugReportCallback(m_instance, m_debugger, nullptr);
+				_vkDestroyDebugReportCallback(m_instance, m_debugger, nullptr);
 				m_debugger = nullptr;
 			}
 
@@ -103,15 +103,15 @@ namespace vk
 
 			PFN_vkDebugReportCallbackEXT callback = vk::dbgFunc;
 
-			createDebugReportCallback = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(vkGetInstanceProcAddr(m_instance, "vkCreateDebugReportCallbackEXT"));
-			destroyDebugReportCallback = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(vkGetInstanceProcAddr(m_instance, "vkDestroyDebugReportCallbackEXT"));
+			_vkCreateDebugReportCallback = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(vkGetInstanceProcAddr(m_instance, "vkCreateDebugReportCallbackEXT"));
+			_vkDestroyDebugReportCallback = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(vkGetInstanceProcAddr(m_instance, "vkDestroyDebugReportCallbackEXT"));
 
 			VkDebugReportCallbackCreateInfoEXT dbgCreateInfo = {};
 			dbgCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
 			dbgCreateInfo.pfnCallback = callback;
 			dbgCreateInfo.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
 
-			CHECK_RESULT(createDebugReportCallback(m_instance, &dbgCreateInfo, NULL, &m_debugger));
+			CHECK_RESULT(_vkCreateDebugReportCallback(m_instance, &dbgCreateInfo, NULL, &m_debugger));
 		}
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -217,7 +217,7 @@ namespace vk
 			// Register some global states
 			if (m_debugger)
 			{
-				destroyDebugReportCallback(m_instance, m_debugger, nullptr);
+				_vkDestroyDebugReportCallback(m_instance, m_debugger, nullptr);
 				m_debugger = nullptr;
 			}
 
@@ -315,9 +315,9 @@ namespace vk
 				vkGetPhysicalDeviceSurfaceSupportKHR(dev, index, m_surface, &supports_present[index]);
 			}
 
-			u32 graphicsQueueNodeIndex = UINT32_MAX;
-			u32 presentQueueNodeIndex = UINT32_MAX;
-			u32 transferQueueNodeIndex = UINT32_MAX;
+			u32 graphics_queue_idx = UINT32_MAX;
+			u32 present_queue_idx = UINT32_MAX;
+			u32 transfer_queue_idx = UINT32_MAX;
 
 			auto test_queue_family = [&](u32 index, u32 desired_flags)
 			{
@@ -333,37 +333,37 @@ namespace vk
 			for (u32 i = 0; i < device_queues; ++i)
 			{
 				// 1. Test for a present queue possibly one that also supports present
-				if (presentQueueNodeIndex == UINT32_MAX && supports_present[i])
+				if (present_queue_idx == UINT32_MAX && supports_present[i])
 				{
-					presentQueueNodeIndex = i;
+					present_queue_idx = i;
 					if (test_queue_family(i, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT))
 					{
-						graphicsQueueNodeIndex = i;
+						graphics_queue_idx = i;
 					}
 				}
 				// 2. Check for graphics support
-				else if (graphicsQueueNodeIndex == UINT32_MAX && test_queue_family(i, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT))
+				else if (graphics_queue_idx == UINT32_MAX && test_queue_family(i, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT))
 				{
-					graphicsQueueNodeIndex = i;
+					graphics_queue_idx = i;
 					if (supports_present[i])
 					{
-						presentQueueNodeIndex = i;
+						present_queue_idx = i;
 					}
 				}
 				// 3. Check if transfer + compute is available
-				else if (transferQueueNodeIndex == UINT32_MAX && test_queue_family(i, VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))
+				else if (transfer_queue_idx == UINT32_MAX && test_queue_family(i, VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))
 				{
-					transferQueueNodeIndex = i;
+					transfer_queue_idx = i;
 				}
 			}
 
-			if (graphicsQueueNodeIndex == UINT32_MAX)
+			if (graphics_queue_idx == UINT32_MAX)
 			{
 				rsx_log.fatal("Failed to find a suitable graphics queue");
 				return nullptr;
 			}
 
-			if (graphicsQueueNodeIndex != presentQueueNodeIndex)
+			if (graphics_queue_idx != present_queue_idx)
 			{
 				// Separate graphics and present, use headless fallback
 				present_possible = false;
@@ -374,7 +374,7 @@ namespace vk
 				//Native(sw) swapchain
 				rsx_log.error("It is not possible for the currently selected GPU to present to the window (Likely caused by NVIDIA driver running the current display)");
 				rsx_log.warning("Falling back to software present support (native windowing API)");
-				auto swapchain = new swapchain_NATIVE(dev, UINT32_MAX, graphicsQueueNodeIndex, transferQueueNodeIndex);
+				auto swapchain = new swapchain_NATIVE(dev, UINT32_MAX, graphics_queue_idx, transfer_queue_idx);
 				swapchain->create(window_handle);
 				return swapchain;
 			}
@@ -411,7 +411,7 @@ namespace vk
 
 			color_space = surfFormats[0].colorSpace;
 
-			return new swapchain_WSI(dev, presentQueueNodeIndex, graphicsQueueNodeIndex, transferQueueNodeIndex, format, m_surface, color_space, force_wm_reporting_off);
+			return new swapchain_WSI(dev, present_queue_idx, graphics_queue_idx, transfer_queue_idx, format, m_surface, color_space, force_wm_reporting_off);
 		}
 	};
 }


### PR DESCRIPTION
- Fix missing transfer queue on old hardware
- Rename API endpoint variables extracted via GetProcAddr. These are not values, but functions, so prepend with _vk to make it more clear. Also rename some old variables declared in wrong camelCase.

Fixes https://github.com/RPCS3/rpcs3/issues/9827