### PR TITLE
Fix cpu usage statistics

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -453,7 +453,7 @@ namespace rsx
 					}
 					case detail_level::low:
 					{
-						if (m_cpu_usage < 0.)
+						if (m_detail == detail_level::low) // otherwise already acquired in medium
 							m_cpu_usage = static_cast<f32>(m_cpu_stats.get_usage());
 
 						[[fallthrough]];


### PR DESCRIPTION
- Fixes updating cpu usage in performance overlay during low detail mode
- Fixes division by zero in cpu_stats::get_usage (maybe the logic is wrong anyway)