### PR TITLE
vk: More groundwork

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -399,7 +399,7 @@ VKGSRender::VKGSRender() : GSRender()
 	}
 
 	//create command buffer...
-	m_command_buffer_pool.create((*m_device));
+	m_command_buffer_pool.create((*m_device), m_device->get_graphics_queue_family());
 
 	for (auto &cb : m_primary_cb_list)
 	{
@@ -410,7 +410,7 @@ VKGSRender::VKGSRender() : GSRender()
 	m_current_command_buffer = &m_primary_cb_list[0];
 
 	//Create secondary command_buffer for parallel operations
-	m_secondary_command_buffer_pool.create((*m_device));
+	m_secondary_command_buffer_pool.create((*m_device), m_device->get_graphics_queue_family());
 	m_secondary_command_buffer.create(m_secondary_command_buffer_pool, true);
 	m_secondary_command_buffer.access_hint = vk::command_buffer::access_type_hint::all;
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -14,6 +14,7 @@
 #include "vkutils/chip_class.h"
 #include "Utilities/geometry.h"
 #include "Emu/RSX/Common/TextureUtils.h"
+#include "Emu/RSX/rsx_utils.h"
 
 #define DESCRIPTOR_MAX_DRAW_CALLS 16384
 #define OCCLUSION_MAX_POOL_SIZE   DESCRIPTOR_MAX_DRAW_CALLS
@@ -63,14 +64,20 @@ namespace vk
 	void destroy_global_resources();
 	void reset_global_resources();
 
-	/**
-	* Allocate enough space in upload_buffer and write all mipmap/layer data into the subbuffer.
-	* Then copy all layers into dst_image.
-	* dst_image must be in TRANSFER_DST_OPTIMAL layout and upload_buffer have TRANSFER_SRC_BIT usage flag.
-	*/
-	void copy_mipmaped_image_using_buffer(const vk::command_buffer& cmd, vk::image* dst_image,
+	enum image_upload_options
+	{
+		upload_contents_async = 1,
+		initialize_image_layout = 2,
+		preserve_image_layout = 3,
+
+		// meta-flags
+		upload_contents_inline = 0,
+		upload_heap_align_default = 0
+	};
+
+	void upload_image(const vk::command_buffer& cmd, vk::image* dst_image,
 		const std::vector<rsx::subresource_layout>& subresource_layout, int format, bool is_swizzled, u16 mipmap_count,
-		VkImageAspectFlags flags, vk::data_heap &upload_heap, u32 heap_align = 0);
+		VkImageAspectFlags flags, vk::data_heap &upload_heap, u32 heap_align, rsx::flags32_t image_setup_flags);
 
 	//Other texture management helpers
 	void copy_image_to_buffer(VkCommandBuffer cmd, const vk::image* src, const vk::buffer* dst, const VkBufferImageCopy& region, bool swap_bytes = false);

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -247,7 +247,7 @@ namespace vk
 			if (g_cfg.video.resolution_scale_percent == 100 && spp == 1) [[likely]]
 			{
 				push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-				vk::copy_mipmaped_image_using_buffer(cmd, this, { subres }, get_gcm_format(), is_swizzled, 1, aspect(), upload_heap, rsx_pitch);
+				vk::upload_image(cmd, this, { subres }, get_gcm_format(), is_swizzled, 1, aspect(), upload_heap, rsx_pitch, upload_contents_inline);
 				pop_layout(cmd);
 			}
 			else
@@ -272,7 +272,7 @@ namespace vk
 				}
 
 				// Load Cell data into temp buffer
-				vk::copy_mipmaped_image_using_buffer(cmd, content, { subres }, get_gcm_format(), is_swizzled, 1, aspect(), upload_heap, rsx_pitch);
+				vk::upload_image(cmd, content, { subres }, get_gcm_format(), is_swizzled, 1, aspect(), upload_heap, rsx_pitch, upload_contents_inline);
 
 				// Write into final image
 				if (content != final_dst)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -898,7 +898,7 @@ namespace vk
 			return &region;
 		}
 
-		cached_texture_section* create_nul_section(vk::command_buffer& cmd, const utils::address_range& rsx_range, bool memory_load) override
+		cached_texture_section* create_nul_section(vk::command_buffer& /*cmd*/, const utils::address_range& rsx_range, bool memory_load) override
 		{
 			auto& region = *find_cached_texture(rsx_range, { .gcm_format = RSX_GCM_FORMAT_IGNORED }, true, false, false);
 			ensure(!region.is_locked());
@@ -950,8 +950,8 @@ namespace vk
 				input_swizzled = false;
 			}
 
-			vk::copy_mipmaped_image_using_buffer(cmd, image, subresource_layout, gcm_format, input_swizzled, mipmaps, subres_range.aspectMask,
-				*m_texture_upload_heap);
+			vk::upload_image(cmd, image, subresource_layout, gcm_format, input_swizzled, mipmaps, subres_range.aspectMask,
+				*m_texture_upload_heap, upload_heap_align_default, upload_contents_inline);
 
 			vk::leave_uninterruptible();
 

--- a/rpcs3/Emu/RSX/VK/vkutils/commands.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/commands.cpp
@@ -8,12 +8,15 @@ namespace vk
 	// This queue flushing method to be implemented by the backend as behavior depends on config
 	void queue_submit(VkQueue queue, const VkSubmitInfo* info, fence* pfence, VkBool32 flush = VK_FALSE);
 
-	void command_pool::create(vk::render_device& dev)
+	void command_pool::create(vk::render_device& dev, u32 queue_family)
 	{
-		owner                         = &dev;
+		owner = &dev;
+		queue_family = queue_family;
+
 		VkCommandPoolCreateInfo infos = {};
-		infos.flags                   = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-		infos.sType                   = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+		infos.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+		infos.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+		infos.queueFamilyIndex = queue_family;
 
 		CHECK_RESULT(vkCreateCommandPool(dev, &infos, nullptr, &pool));
 	}
@@ -27,12 +30,17 @@ namespace vk
 		pool = nullptr;
 	}
 
-	vk::render_device& command_pool::get_owner()
+	vk::render_device& command_pool::get_owner() const
 	{
 		return (*owner);
 	}
 
-	command_pool::operator VkCommandPool()
+	u32 command_pool::get_queue_family() const
+	{
+		return queue_family;
+	}
+
+	command_pool::operator VkCommandPool() const
 	{
 		return pool;
 	}

--- a/rpcs3/Emu/RSX/VK/vkutils/commands.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/commands.h
@@ -10,17 +10,19 @@ namespace vk
 	{
 		vk::render_device* owner = nullptr;
 		VkCommandPool pool       = nullptr;
+		u32 queue_family         = 0;
 
 	public:
 		command_pool()  = default;
 		~command_pool() = default;
 
-		void create(vk::render_device& dev);
+		void create(vk::render_device& dev, u32 queue_family = 0);
 		void destroy();
 
-		vk::render_device& get_owner();
+		vk::render_device& get_owner() const;
+		u32 get_queue_family() const;
 
-		operator VkCommandPool();
+		operator VkCommandPool() const;
 	};
 
 	class command_buffer
@@ -68,6 +70,11 @@ namespace vk
 		command_pool& get_command_pool() const
 		{
 			return *pool;
+		}
+
+		u32 get_queue_family() const
+		{
+			return pool->get_queue_family();
 		}
 
 		void clear_flags()

--- a/rpcs3/Emu/RSX/VK/vkutils/commands.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/commands.h
@@ -16,7 +16,7 @@ namespace vk
 		command_pool()  = default;
 		~command_pool() = default;
 
-		void create(vk::render_device& dev, u32 queue_family = 0);
+		void create(vk::render_device& dev, u32 queue_family);
 		void destroy();
 
 		vk::render_device& get_owner() const;

--- a/rpcs3/Emu/RSX/VK/vkutils/image.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.h
@@ -39,6 +39,7 @@ namespace vk
 		VkImage value = VK_NULL_HANDLE;
 		VkComponentMapping native_component_map = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
 		VkImageLayout current_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+		u32 current_queue_family = VK_QUEUE_FAMILY_IGNORED;
 		VkImageCreateInfo info = {};
 		std::shared_ptr<vk::memory_block> memory;
 
@@ -77,7 +78,8 @@ namespace vk
 		void push_layout(VkCommandBuffer cmd, VkImageLayout layout);
 		void push_barrier(VkCommandBuffer cmd, VkImageLayout layout);
 		void pop_layout(VkCommandBuffer cmd);
-		void change_layout(command_buffer& cmd, VkImageLayout new_layout);
+		void change_layout(const command_buffer& cmd, VkImageLayout new_layout);
+		void change_layout(const command_buffer& cmd, VkImageLayout new_layout, u32 new_queue_family);
 
 	private:
 		VkDevice m_device;

--- a/rpcs3/Emu/RSX/VK/vkutils/image_helpers.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image_helpers.cpp
@@ -55,7 +55,8 @@ namespace vk
 		return{ final_mapping[1], final_mapping[2], final_mapping[3], final_mapping[0] };
 	}
 
-	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range)
+	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range,
+		u32 src_queue_family, u32 dst_queue_family)
 	{
 		if (vk::is_renderpass_open(cmd))
 		{
@@ -70,8 +71,8 @@ namespace vk
 		barrier.image = image;
 		barrier.srcAccessMask = 0;
 		barrier.dstAccessMask = 0;
-		barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-		barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		barrier.srcQueueFamilyIndex = src_queue_family;
+		barrier.dstQueueFamilyIndex = dst_queue_family;
 		barrier.subresourceRange = range;
 
 		VkPipelineStageFlags src_stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;

--- a/rpcs3/Emu/RSX/VK/vkutils/image_helpers.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/image_helpers.h
@@ -9,7 +9,8 @@ namespace vk
 	VkImageAspectFlags get_aspect_flags(VkFormat format);
 	VkComponentMapping apply_swizzle_remap(const std::array<VkComponentSwizzle, 4>& base_remap, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector);
 
-	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range);
+	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range,
+		u32 src_queue_family = VK_QUEUE_FAMILY_IGNORED, u32 dst_queue_family = VK_QUEUE_FAMILY_IGNORED);
 	void change_image_layout(VkCommandBuffer cmd, vk::image* image, VkImageLayout new_layout, const VkImageSubresourceRange& range);
 	void change_image_layout(VkCommandBuffer cmd, vk::image* image, VkImageLayout new_layout);
 }


### PR DESCRIPTION
Part 3 of many.
- Refactor some texture upload code to reduce size of some megafunctions
- Implement image queue family migration (acquire/release)
- Implement per-queue-family scratch buffers
- Implement explicit command pool queue family for non-graphics command buffer support.

Ideally there should be no difference compared to master, with the exception of potential very slight performance gains from the double-buffered scratch usage pattern.