### PR TITLE
Improve cellScreenshot

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
@@ -48,6 +48,11 @@ std::string screenshot_manager::get_game_title() const
 	return game;
 }
 
+std::string screenshot_manager::get_game_comment() const
+{
+	return game_comment;
+}
+
 std::string screenshot_manager::get_screenshot_path() const
 {
 	// TODO: make sure the file can be saved, add suffix and increase counter if file exists
@@ -73,6 +78,7 @@ error_code cellScreenShotSetParameter(vm::cptr<CellScreenShotSetParam> param)
 		return CELL_SCREENSHOT_ERROR_PARAM;
 
 	const auto manager = g_fxo->get<screenshot_manager>();
+	std::lock_guard<std::mutex> lock(manager->mtx);
 
 	if (param->photo_title && param->photo_title[0] != '\0')
 		manager->photo_title = std::string(param->photo_title.get_ptr());
@@ -110,6 +116,7 @@ error_code cellScreenShotSetOverlayImage(vm::cptr<char> srcDir, vm::cptr<char> s
 	}
 
 	const auto manager = g_fxo->get<screenshot_manager>();
+	std::lock_guard<std::mutex> lock(manager->mtx);
 
 	manager->overlay_dir_name = std::string(srcDir.get_ptr());
 	manager->overlay_file_name = std::string(srcFile.get_ptr());
@@ -124,6 +131,8 @@ error_code cellScreenShotEnable()
 	cellScreenshot.warning("cellScreenShotEnable()");
 
 	const auto manager = g_fxo->get<screenshot_manager>();
+	std::lock_guard<std::mutex> lock(manager->mtx);
+
 	manager->is_enabled = true;
 
 	return CELL_OK;
@@ -134,6 +143,8 @@ error_code cellScreenShotDisable()
 	cellScreenshot.warning("cellScreenShotDisable()");
 
 	const auto manager = g_fxo->get<screenshot_manager>();
+	std::lock_guard<std::mutex> lock(manager->mtx);
+
 	manager->is_enabled = false;
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
@@ -30,7 +30,7 @@ shared_mutex screenshot_mtx;
 
 std::string screenshot_manager::get_overlay_path() const
 {
-	return vfs::get(overlay_dir_name + overlay_file_name);
+	return vfs::get(overlay_dir_name + "/" + overlay_file_name);
 }
 
 std::string screenshot_manager::get_photo_title() const
@@ -57,7 +57,7 @@ std::string screenshot_manager::get_game_comment() const
 std::string screenshot_manager::get_screenshot_path(const std::string& date_path) const
 {
 	u32 counter = 0;
-	std::string path = vfs::get("/dev_hdd0/photo/") + date_path + "/" + get_photo_title();
+	std::string path = vfs::get("/dev_hdd0/photo/" + date_path + "/" + get_photo_title());
 	std::string suffix = ".png";
 
 	while (!Emu.IsStopped() && fs::is_file(path + suffix))

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
@@ -26,6 +26,7 @@ void fmt_class_string<CellScreenShotError>::format(std::string& out, u64 arg)
 	});
 }
 
+shared_mutex screenshot_mtx;
 
 std::string screenshot_manager::get_overlay_path() const
 {
@@ -85,7 +86,7 @@ error_code cellScreenShotSetParameter(vm::cptr<CellScreenShotSetParam> param)
 		return CELL_SCREENSHOT_ERROR_PARAM;
 
 	const auto manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard lock(manager->mtx);
+	std::lock_guard lock(screenshot_mtx);
 
 	if (param->photo_title && param->photo_title[0] != '\0')
 		manager->photo_title = std::string(param->photo_title.get_ptr());
@@ -123,7 +124,7 @@ error_code cellScreenShotSetOverlayImage(vm::cptr<char> srcDir, vm::cptr<char> s
 	}
 
 	const auto manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard lock(manager->mtx);
+	std::lock_guard lock(screenshot_mtx);
 
 	manager->overlay_dir_name = std::string(srcDir.get_ptr());
 	manager->overlay_file_name = std::string(srcFile.get_ptr());
@@ -138,7 +139,7 @@ error_code cellScreenShotEnable()
 	cellScreenshot.warning("cellScreenShotEnable()");
 
 	const auto manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard lock(manager->mtx);
+	std::lock_guard lock(screenshot_mtx);
 
 	manager->is_enabled = true;
 
@@ -150,7 +151,7 @@ error_code cellScreenShotDisable()
 	cellScreenshot.warning("cellScreenShotDisable()");
 
 	const auto manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard lock(manager->mtx);
+	std::lock_guard lock(screenshot_mtx);
 
 	manager->is_enabled = false;
 

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
@@ -53,11 +53,18 @@ std::string screenshot_manager::get_game_comment() const
 	return game_comment;
 }
 
-std::string screenshot_manager::get_screenshot_path() const
+std::string screenshot_manager::get_screenshot_path(const std::string& date_path) const
 {
-	// TODO: make sure the file can be saved, add suffix and increase counter if file exists
-	// TODO: maybe find a proper home for these
-	return fs::get_config_dir() + "/screenshots/cell/" + get_photo_title() + ".png";
+	u32 counter = 0;
+	std::string path = vfs::get("/dev_hdd0/photo/") + date_path + "/" + get_photo_title();
+	std::string suffix = ".png";
+
+	while (!Emu.IsStopped() && fs::is_file(path + suffix))
+	{
+		suffix = fmt::format("_%d.png", ++counter);
+	}
+
+	return path + suffix;
 }
 
 

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
@@ -85,7 +85,7 @@ error_code cellScreenShotSetParameter(vm::cptr<CellScreenShotSetParam> param)
 		return CELL_SCREENSHOT_ERROR_PARAM;
 
 	const auto manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard<std::mutex> lock(manager->mtx);
+	std::lock_guard lock(manager->mtx);
 
 	if (param->photo_title && param->photo_title[0] != '\0')
 		manager->photo_title = std::string(param->photo_title.get_ptr());
@@ -123,7 +123,7 @@ error_code cellScreenShotSetOverlayImage(vm::cptr<char> srcDir, vm::cptr<char> s
 	}
 
 	const auto manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard<std::mutex> lock(manager->mtx);
+	std::lock_guard lock(manager->mtx);
 
 	manager->overlay_dir_name = std::string(srcDir.get_ptr());
 	manager->overlay_file_name = std::string(srcFile.get_ptr());
@@ -138,7 +138,7 @@ error_code cellScreenShotEnable()
 	cellScreenshot.warning("cellScreenShotEnable()");
 
 	const auto manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard<std::mutex> lock(manager->mtx);
+	std::lock_guard lock(manager->mtx);
 
 	manager->is_enabled = true;
 
@@ -150,7 +150,7 @@ error_code cellScreenShotDisable()
 	cellScreenshot.warning("cellScreenShotDisable()");
 
 	const auto manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard<std::mutex> lock(manager->mtx);
+	std::lock_guard lock(manager->mtx);
 
 	manager->is_enabled = false;
 

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.h
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.h
@@ -29,16 +29,14 @@ struct CellScreenShotSetParam
 
 struct screenshot_manager
 {
-	shared_mutex mtx;
-
-	atomic_t<bool> is_enabled{false};
+	bool is_enabled{false};
 
 	std::string photo_title;
 	std::string game_title;
 	std::string game_comment;
 
-	atomic_t<s32> overlay_offset_x{0};
-	atomic_t<s32> overlay_offset_y{0};
+	s32 overlay_offset_x{0};
+	s32 overlay_offset_y{0};
 	std::string overlay_dir_name;
 	std::string overlay_file_name;
 
@@ -47,20 +45,4 @@ struct screenshot_manager
 	std::string get_game_title() const;
 	std::string get_game_comment() const;
 	std::string get_screenshot_path(const std::string& date_path) const;
-
-	screenshot_manager& operator=(const screenshot_manager& other)
-	{
-		is_enabled   = other.is_enabled.load();
-
-		photo_title  = other.photo_title;
-		game_title   = other.game_title;
-		game_comment = other.game_comment;
-
-		overlay_offset_x  = other.overlay_offset_x.load();
-		overlay_offset_y  = other.overlay_offset_y.load();
-		overlay_dir_name  = other.overlay_dir_name;
-		overlay_file_name = other.overlay_file_name;
-
-		return *this;
-	}
 };

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.h
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.h
@@ -46,7 +46,7 @@ struct screenshot_manager
 	std::string get_photo_title() const;
 	std::string get_game_title() const;
 	std::string get_game_comment() const;
-	std::string get_screenshot_path() const;
+	std::string get_screenshot_path(const std::string& date_path) const;
 
 	screenshot_manager& operator=(const screenshot_manager& other)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.h
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.h
@@ -27,6 +27,8 @@ struct CellScreenShotSetParam
 	vm::bptr<void> reserved;
 };
 
+extern shared_mutex screenshot_mtx;
+
 struct screenshot_manager
 {
 	bool is_enabled{false};

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.h
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.h
@@ -29,7 +29,7 @@ struct CellScreenShotSetParam
 
 struct screenshot_manager
 {
-	std::mutex mtx;
+	shared_mutex mtx;
 
 	atomic_t<bool> is_enabled{false};
 

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.h
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.h
@@ -29,19 +29,38 @@ struct CellScreenShotSetParam
 
 struct screenshot_manager
 {
-	atomic_t<bool> is_enabled{ false };
+	std::mutex mtx;
+
+	atomic_t<bool> is_enabled{false};
 
 	std::string photo_title;
 	std::string game_title;
 	std::string game_comment;
 
-	atomic_t<s32> overlay_offset_x{ 0 };
-	atomic_t<s32> overlay_offset_y{ 0 };
+	atomic_t<s32> overlay_offset_x{0};
+	atomic_t<s32> overlay_offset_y{0};
 	std::string overlay_dir_name;
 	std::string overlay_file_name;
 
 	std::string get_overlay_path() const;
 	std::string get_photo_title() const;
 	std::string get_game_title() const;
+	std::string get_game_comment() const;
 	std::string get_screenshot_path() const;
+
+	screenshot_manager& operator=(const screenshot_manager& other)
+	{
+		is_enabled   = other.is_enabled.load();
+
+		photo_title  = other.photo_title;
+		game_title   = other.game_title;
+		game_comment = other.game_comment;
+
+		overlay_offset_x  = other.overlay_offset_x.load();
+		overlay_offset_y  = other.overlay_offset_y.load();
+		overlay_dir_name  = other.overlay_dir_name;
+		overlay_file_name = other.overlay_file_name;
+
+		return *this;
+	}
 };

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -240,6 +240,7 @@ void Emulator::Init(bool add_only)
 		make_path_verbose(dev_hdd0 + "disc/");
 		make_path_verbose(dev_hdd0 + "savedata/");
 		make_path_verbose(dev_hdd0 + "savedata/vmc/");
+		make_path_verbose(dev_hdd0 + "photo/");
 		make_path_verbose(dev_hdd1 + "caches/");
 	}
 

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -493,7 +493,7 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 			int num_text = 0;
 
 			const QDateTime date_time       = QDateTime::currentDateTime();
-		    const std::string creation_time = date_time.toString("yyyy:MM:dd hh:mm:ss").toStdString();
+			const std::string creation_time = date_time.toString("yyyy:MM:dd hh:mm:ss").toStdString();
 			const std::string title_id      = Emu.GetTitleID();
 			const std::string photo_title   = manager.get_photo_title();
 			const std::string game_title    = manager.get_game_title();
@@ -552,7 +552,7 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 
 			if (manager.is_enabled)
 			{
-				const std::string cell_sshot_filename = manager.get_screenshot_path();
+				const std::string cell_sshot_filename = manager.get_screenshot_path(date_time.toString("yyyy/MM/dd").toStdString());
 				const std::string cell_sshot_dir      = fs::get_parent_dir(cell_sshot_filename);
 
 				screenshot_log.notice("Saving cell screenshot to %s", cell_sshot_filename);

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -435,6 +435,74 @@ void gs_frame::flip(draw_context_t, bool /*skip_frame*/)
 	}
 }
 
+bool read_png_file(const std::string& filename, u32& width, u32& height, std::vector<u8*>& row_pointers)
+{
+	png_structp png = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+	if (!png)
+		return false;
+
+	png_infop info = png_create_info_struct(png);
+	if (!info)
+		return false;
+
+	if (setjmp(png_jmpbuf(png)))
+		return false;
+
+	FILE* fp = fopen(filename.c_str(), "rb");
+	if (!fp)
+		return false;
+
+	png_init_io(png, fp);
+	png_read_info(png, info);
+
+	width  = png_get_image_width(png, info);
+	height = png_get_image_height(png, info);
+
+	png_byte color_type = png_get_color_type(png, info);
+	png_byte bit_depth  = png_get_bit_depth(png, info);
+
+	if (bit_depth == 16)
+		png_set_strip_16(png);
+
+	if (color_type == PNG_COLOR_TYPE_PALETTE)
+		png_set_palette_to_rgb(png);
+
+	// PNG_COLOR_TYPE_GRAY_ALPHA is always 8 or 16bit depth.
+	if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
+		png_set_expand_gray_1_2_4_to_8(png);
+
+	if (png_get_valid(png, info, PNG_INFO_tRNS))
+		png_set_tRNS_to_alpha(png);
+
+	// These color_type don't have an alpha channel then fill it with 0xff.
+	if (color_type == PNG_COLOR_TYPE_RGB ||
+	    color_type == PNG_COLOR_TYPE_GRAY ||
+	    color_type == PNG_COLOR_TYPE_PALETTE)
+		png_set_filler(png, 0xFF, PNG_FILLER_AFTER);
+
+	if (color_type == PNG_COLOR_TYPE_GRAY ||
+	    color_type == PNG_COLOR_TYPE_GRAY_ALPHA)
+		png_set_gray_to_rgb(png);
+
+	png_read_update_info(png, info);
+
+	row_pointers.resize(height, nullptr);
+
+	const size_t size = png_get_rowbytes(png, info);
+	for (int y = 0; y < height; y++)
+	{
+		row_pointers[y] = static_cast<u8*>(std::malloc(size));
+	}
+
+	png_read_image(png, &row_pointers[0]);
+
+	fclose(fp);
+
+	png_destroy_read_struct(&png, &info, nullptr);
+
+	return true;
+}
+
 void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot_width, const u32 sshot_height, bool is_bgra)
 {
 	std::thread(
@@ -532,6 +600,36 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 			for (usz y = 0; y < sshot_height; y++)
 				rows[y] = sshot_data_alpha.data() + y * sshot_width * 4;
 
+			if (manager.is_enabled)
+			{
+				const std::string cell_sshot_overlay_path = manager.get_overlay_path();
+				if (fs::is_file(cell_sshot_overlay_path))
+				{
+					screenshot_log.notice("Adding overlay to cell screenshot from %s", cell_sshot_overlay_path);
+
+					u32 overlay_width  = 0;
+					u32 overlay_height = 0;
+					std::vector<u8*> overlay_data;
+
+					if (!read_png_file(cell_sshot_overlay_path, overlay_width, overlay_height, overlay_data))
+					{
+						screenshot_log.error("Failed to read cell screenshot overlay '%s' : %s", cell_sshot_overlay_path, fs::g_tls_error);
+					}
+					else if (static_cast<u32>(abs(manager.overlay_offset_x)) < sshot_width &&
+					         static_cast<u32>(abs(manager.overlay_offset_y)) < sshot_height)
+					{
+						const usz max_width = manager.overlay_offset_x > 0 ? sshot_width - static_cast<u32>(manager.overlay_offset_x) : sshot_width;
+						const usz max_height = std::min<s64>(sshot_height, manager.overlay_offset_y + static_cast<s64>(overlay_height));
+						const usz line_size = 4 * std::min<usz>(overlay_width, max_width);
+
+						for (s64 y = std::max<s64>(0, manager.overlay_offset_y); y < max_height; y++)
+						{
+							std::memcpy(rows[y], overlay_data[y - manager.overlay_offset_y], line_size);
+						}
+					}
+				}
+			}
+
 			png_set_rows(write_ptr, info_ptr, &rows[0]);
 			png_set_write_fn(write_ptr, &encoded_png,
 				[](png_structp png_ptr, png_bytep data, png_size_t length)
@@ -543,14 +641,11 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 
 			png_write_png(write_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, nullptr);
 
-			png_free_data(write_ptr, info_ptr, PNG_FREE_ALL, -1);
-			png_destroy_write_struct(&write_ptr, nullptr);
-
 			sshot_file.write(encoded_png.data(), encoded_png.size());
 
 			screenshot_log.success("Successfully saved screenshot to %s", filename);
 
-			if (manager.is_enabled)
+			while (manager.is_enabled)
 			{
 				const std::string cell_sshot_filename = manager.get_screenshot_path(date_time.toString("yyyy/MM/dd").toStdString());
 				const std::string cell_sshot_dir      = fs::get_parent_dir(cell_sshot_filename);
@@ -560,27 +655,24 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 				if (!fs::create_path(cell_sshot_dir) && fs::g_tls_error != fs::error::exist)
 				{
 					screenshot_log.error("Failed to create cell screenshot dir \"%s\" : %s", cell_sshot_dir, fs::g_tls_error);
-					return;
+					break;
 				}
 
 				fs::file cell_sshot_file(cell_sshot_filename, fs::open_mode::create + fs::open_mode::write + fs::open_mode::excl);
 				if (!cell_sshot_file)
 				{
 					screenshot_log.error("Failed to save cell screenshot \"%s\" : %s", cell_sshot_filename, fs::g_tls_error);
-					return;
-				}
-
-				const std::string cell_sshot_overlay_path = manager.get_overlay_path();
-				if (fs::is_file(cell_sshot_overlay_path))
-				{
-					screenshot_log.notice("Adding overlay to cell screenshot from %s", cell_sshot_overlay_path);
-					// TODO: add overlay to screenshot
+					break;
 				}
 
 				cell_sshot_file.write(encoded_png.data(), encoded_png.size());
 
 				screenshot_log.success("Successfully saved cell screenshot to %s", cell_sshot_filename);
+				break;
 			}
+
+			png_free_data(write_ptr, info_ptr, PNG_FREE_ALL, -1);
+			png_destroy_write_struct(&write_ptr, &info_ptr);
 
 			return;
 		},

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -478,7 +478,12 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 				}
 			}
 
-			screenshot_manager manager = *g_fxo->get<screenshot_manager>();
+			screenshot_manager manager;
+			{
+				const auto fxo = g_fxo->get<screenshot_manager>();
+				std::lock_guard lock(screenshot_mtx);
+				manager = *fxo;
+			}
 
 			struct scoped_png_ptrs
 			{
@@ -567,6 +572,7 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 					{
 						screenshot_log.error("Failed to read cell screenshot overlay '%s' : %s", cell_sshot_overlay_path, fs::g_tls_error);
 					}
+					// TODO: the overlay and its offset need to be scaled based on image size, resolution scaling and video resolution
 					else if (manager.overlay_offset_x < static_cast<s64>(sshot_width)
 					      && manager.overlay_offset_y < static_cast<s64>(sshot_height)
 					      && manager.overlay_offset_x + overlay_img.width() > 0

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -40,7 +40,8 @@
 #include <QtDBus/QDBusConnection>
 #endif
 
-LOG_CHANNEL(screenshot);
+LOG_CHANNEL(screenshot_log, "SCREENSHOT");
+LOG_CHANNEL(mark_log, "MARK");
 
 extern atomic_t<bool> g_user_asked_for_frame_capture;
 
@@ -147,7 +148,7 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 		if (keyEvent->modifiers() == Qt::AltModifier)
 		{
 			static int count = 0;
-			screenshot.success("Made forced mark %d in log", ++count);
+			mark_log.success("Made forced mark %d in log", ++count);
 			return;
 		}
 		else if (keyEvent->modifiers() == Qt::ControlModifier)
@@ -442,7 +443,7 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 
 			if (!fs::create_dir(screen_path) && fs::g_tls_error != fs::error::exist)
 			{
-				screenshot.error("Failed to create screenshot path \"%s\" : %s", screen_path, fs::g_tls_error);
+				screenshot_log.error("Failed to create screenshot path \"%s\" : %s", screen_path, fs::g_tls_error);
 				return;
 			}
 
@@ -451,7 +452,7 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 			fs::file sshot_file(filename, fs::open_mode::create + fs::open_mode::write + fs::open_mode::excl);
 			if (!sshot_file)
 			{
-				screenshot.error("[Screenshot] Failed to save screenshot \"%s\" : %s", filename, fs::g_tls_error);
+				screenshot_log.error("Failed to save screenshot \"%s\" : %s", filename, fs::g_tls_error);
 				return;
 			}
 
@@ -500,7 +501,7 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 
 			sshot_file.write(encoded_png.data(), encoded_png.size());
 
-			screenshot.success("[Screenshot] Successfully saved screenshot to %s", filename);
+			screenshot_log.success("Successfully saved screenshot to %s", filename);
 
 			const auto fxo = g_fxo->get<screenshot_manager>();
 
@@ -509,25 +510,25 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 				const std::string cell_sshot_filename = fxo->get_screenshot_path();
 				const std::string cell_sshot_dir      = fs::get_parent_dir(cell_sshot_filename);
 
-				screenshot.notice("[Screenshot] Saving cell screenshot to %s", cell_sshot_filename);
+				screenshot_log.notice("Saving cell screenshot to %s", cell_sshot_filename);
 
 				if (!fs::create_path(cell_sshot_dir) && fs::g_tls_error != fs::error::exist)
 				{
-					screenshot.error("Failed to create cell screenshot dir \"%s\" : %s", cell_sshot_dir, fs::g_tls_error);
+					screenshot_log.error("Failed to create cell screenshot dir \"%s\" : %s", cell_sshot_dir, fs::g_tls_error);
 					return;
 				}
 
 				fs::file cell_sshot_file(cell_sshot_filename, fs::open_mode::create + fs::open_mode::write + fs::open_mode::excl);
 				if (!cell_sshot_file)
 				{
-					screenshot.error("[Screenshot] Failed to save cell screenshot \"%s\" : %s", cell_sshot_filename, fs::g_tls_error);
+					screenshot_log.error("Failed to save cell screenshot \"%s\" : %s", cell_sshot_filename, fs::g_tls_error);
 					return;
 				}
 
 				const std::string cell_sshot_overlay_path = fxo->get_overlay_path();
 				if (fs::is_file(cell_sshot_overlay_path))
 				{
-					screenshot.notice("[Screenshot] Adding overlay to cell screenshot from %s", cell_sshot_overlay_path);
+					screenshot_log.notice("Adding overlay to cell screenshot from %s", cell_sshot_overlay_path);
 					// TODO: add overlay to screenshot
 				}
 
@@ -536,7 +537,7 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 
 				cell_sshot_file.write(encoded_png.data(), encoded_png.size());
 
-				screenshot.success("[Screenshot] Successfully saved cell screenshot to %s", cell_sshot_filename);
+				screenshot_log.success("Successfully saved cell screenshot to %s", cell_sshot_filename);
 			}
 
 			return;

--- a/rpcs3/rpcs3qt/screenshot_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/screenshot_manager_dialog.cpp
@@ -3,6 +3,7 @@
 #include "qt_utils.h"
 #include "Utilities/File.h"
 #include "Emu/VFS.h"
+#include "Emu/System.h"
 
 #include <QApplication>
 #include <QDir>
@@ -26,6 +27,9 @@ screenshot_manager_dialog::screenshot_manager_dialog(QWidget* parent) : QDialog(
 	m_grid->setResizeMode(QListWidget::Adjust);
 	m_grid->setIconSize(m_icon_size);
 	m_grid->setGridSize(m_icon_size + QSize(10, 10));
+
+	// HACK: dev_hdd0 must be mounted for vfs to work for loading trophies.
+	vfs::mount("/dev_hdd0", Emulator::GetHddDir());
 
 	const std::string screenshot_path_qt   = fs::get_config_dir() + "screenshots/";
 	const std::string screenshot_path_cell = vfs::get("/dev_hdd0/photo/");


### PR DESCRIPTION
This PR adds all of the missing functionality of the cellScreenshot utility.

- Save cell screenshots in `/dev_hdd0/photo/<year>/<month>/<day>/` with inreasing file number.
- Add png metadata to all screenshots (if available).
- Apply the specified overlay image if possible.