### PR TITLE
Firmware installation bugfixes part 1

### DIFF
--- a/rpcs3/Loader/PUP.h
+++ b/rpcs3/Loader/PUP.h
@@ -33,7 +33,7 @@ struct PUPHashEntry
 class pup_object
 {
 	const fs::file& m_file;
-	bool isValid = true;
+	bool isValid = false;
 
 	std::vector<PUPFileEntry> m_file_tbl;
 	std::vector<PUPHashEntry> m_hash_tbl;

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -131,7 +131,12 @@ bool tar_object::extract(std::string path, std::string ignore)
 
 		case '5':
 		{
-			fs::create_dir(result);
+			if (!fs::create_path(result))
+			{
+				tar_log.error("TAR Loader: failed to create directory %s (%s)", header.name, fs::g_tls_error);
+				return false;
+			}
+
 			break;
 		}
 


### PR DESCRIPTION
* Fix race condition in PUP installation abortion.
* Fix freezes of emulator in case the PUP installation failed.
* Use fs::create_path as opposed to fs::create_dir as it is can create upper directories in case they are missing and is better in error handling.
* Report TAR errors on failure to create directories.
* Fix pup_object constructor to not crash on invalid PUP file header. (report an error)
* Fix pup_object::validate_hashes to not crash on invalid PUP file entries. (report an error)
* Do not call Qt functions inside a named_thread because it is wrong.