### PR TITLE
Report deadlocked thread names in failures to stop emulation

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2336,7 +2336,7 @@ bool thread_base::join(bool dtor) const
 	}
 
 	// Hacked for too sleepy threads (1ms) TODO: make sure it's unneeded and remove
-	const auto timeout = dtor && !thread_ctrl::get_current() ? atomic_wait_timeout{1'000'000} : atomic_wait_timeout::inf;
+	const auto timeout = dtor && Emu.IsStopped() ? atomic_wait_timeout{1'000'000} : atomic_wait_timeout::inf;
 
 	auto stamp0 = __rdtsc();
 

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2349,7 +2349,7 @@ bool thread_base::join(bool dtor) const
 			break;
 		}
 
-		if (i && (i % 20) == 0 && timeout != atomic_wait_timeout::inf)
+		if (i >= 16 && !(i & (i - 1)) && timeout != atomic_wait_timeout::inf)
 		{
 			sig_log.error(u8"Thread [%s] is too sleepy. Waiting for it %.3fµs already!", *m_tname.load(), (__rdtsc() - stamp0) / (utils::get_tsc_freq() / 1000000.));
 		}


### PR DESCRIPTION
Finally report which threads were failing to terminate at Emu.Stop().