### PR TITLE
Last boss warning fix

### DIFF
--- a/rpcs3/cmake_modules/ConfigureCompiler.cmake
+++ b/rpcs3/cmake_modules/ConfigureCompiler.cmake
@@ -40,7 +40,9 @@ else()
 	endif()
 
 	#TODO Clean the code so these are removed
-	add_compile_options(-Wno-attributes)
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.1 OR NOT CMAKE_COMPILER_IS_GNUCXX)
+		add_compile_options(-Wno-attributes)
+	endif()
 
 	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 		add_compile_options(-fconstexpr-steps=16777216)

--- a/rpcs3/rpcs3qt/config_adapter.h
+++ b/rpcs3/rpcs3qt/config_adapter.h
@@ -3,7 +3,7 @@
 #include <QStringList>
 
 #include "emu_settings_type.h"
-#include "yaml-cpp/yaml.h"
+#include "util/yaml.hpp"
 
 // Helper methods to interact with YAML and the config settings.
 namespace cfg_adapter
@@ -15,7 +15,7 @@ namespace cfg_adapter
 
 	/** Returns possible options for values for some particular setting.*/
 	QStringList get_options(cfg_location location);
-	
+
 	/** Returns dynamic property for some particular setting.*/
 	bool get_is_dynamic(emu_settings_type type);
 

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "util/types.hpp"
-
-#include "yaml-cpp/yaml.h"
+#include "util/yaml.hpp"
 
 #include "microphone_creator.h"
 #include "render_creator.h"

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -30,13 +30,13 @@ namespace stx
 		}
 		else if constexpr (std::is_convertible_v<U*, T*>)
 		{
-			const auto u = &sample<U>;
+			const auto u = std::addressof(sample<U>);
 			const volatile void* x = u;
 			return static_cast<T*>(u) == x;
 		}
 		else if constexpr (std::is_convertible_v<T*, U*>)
 		{
-			const auto t = &sample<T>;
+			const auto t = std::addressof(sample<T>);
 			const volatile void* x = t;
 			return static_cast<U*>(t) == x;
 		}

--- a/rpcs3/util/yaml.hpp
+++ b/rpcs3/util/yaml.hpp
@@ -12,6 +12,7 @@
 #pragma GCC diagnostic ignored "-Wall"
 #pragma GCC diagnostic ignored "-Wextra"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wattributes"
 #include "yaml-cpp/yaml.h"
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Enabled -Wattributes warnings for GCC 10+. It's incomplete since it needs Clang 12 also.