### PR TITLE
Add information about unnamed/main threads in logs and fatal dialog 

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -88,7 +88,7 @@ atomic_t<u32> g_progr_ptotal{0};
 atomic_t<u32> g_progr_pdone{0};
 
 // Report error and call std::abort(), defined in main.cpp
-[[noreturn]] void report_fatal_error(const std::string&);
+[[noreturn]] void report_fatal_error(std::string_view);
 
 namespace
 {

--- a/rpcs3/rpcs3qt/fatal_error_dialog.cpp
+++ b/rpcs3/rpcs3qt/fatal_error_dialog.cpp
@@ -3,9 +3,7 @@
 #include <QLayout>
 #include <QTextDocument>
 
-#include <string>
-
-fatal_error_dialog::fatal_error_dialog(const std::string& text) : QMessageBox()
+fatal_error_dialog::fatal_error_dialog(std::string_view text) : QMessageBox()
 {
 	setWindowTitle(tr("RPCS3: Fatal Error"));
 	setIcon(QMessageBox::Icon::Critical);
@@ -18,7 +16,7 @@ fatal_error_dialog::fatal_error_dialog(const std::string& text) : QMessageBox()
 				%3<br>
 			</p>
 			)")
-		.arg(Qt::convertFromPlainText(QString::fromStdString(text)))
+		.arg(Qt::convertFromPlainText(QString::fromUtf8(text.data(), text.size())))
 		.arg(tr("HOW TO REPORT ERRORS:"))
 		.arg(tr("Please, don't send incorrect reports. Thanks for understanding.")));
 	layout()->setSizeConstraint(QLayout::SetFixedSize);

--- a/rpcs3/rpcs3qt/fatal_error_dialog.h
+++ b/rpcs3/rpcs3qt/fatal_error_dialog.h
@@ -2,12 +2,12 @@
 
 #include <QMessageBox>
 
-#include <string>
+#include <string_view>
 
 class fatal_error_dialog : public QMessageBox
 {
 	Q_OBJECT
 
 public:
-	fatal_error_dialog(const std::string& text);
+	fatal_error_dialog(std::string_view text);
 };

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -2,6 +2,7 @@
 #include "Utilities/File.h"
 #include "Utilities/mutex.h"
 #include "Utilities/Thread.h"
+#include "Utilities/StrFmt.h"
 #include <cstring>
 #include <cstdarg>
 #include <string>
@@ -25,13 +26,18 @@ using namespace std::literals::chrono_literals;
 
 #include <zlib.h>
 
-static std::string empty_string()
+static std::string default_string()
 {
-	return {};
+	if (thread_ctrl::is_main())
+	{
+		return {};
+	}
+
+	return fmt::format("TID: %s", std::this_thread::get_id());
 }
 
 // Thread-specific log prefix provider
-thread_local std::string(*g_tls_log_prefix)() = &empty_string;
+thread_local std::string(*g_tls_log_prefix)() = &default_string;
 
 // Another thread-specific callback
 thread_local void(*g_tls_log_control)(const char* fmt, u64 progress) = [](const char*, u64){};


### PR DESCRIPTION
* If thread is unnamed, keep log name empty for main thread, otherwise print thread id. In fatal dialog, main thread is handled with special remark that it's main thread.
* Always print thread id in fatal dialog, regardless of thread type.