### PR TITLE
Fix Emulator::IsPaused()

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -614,6 +614,12 @@ cpu_thread::cpu_thread(u32 id)
 		break;
 	}
 
+	if (Emu.IsStopped())
+	{
+		// For similar race as above
+		state += cpu_flag::exit;
+	}
+
 	g_threads_created++;
 }
 

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -597,6 +597,23 @@ cpu_thread::~cpu_thread()
 cpu_thread::cpu_thread(u32 id)
 	: id(id)
 {
+	while (Emu.GetStatus() == system_state::paused)
+	{
+		// Solve race between Emulator::Pause and this construction of thread which most likely is guarded by IDM mutex
+		state += cpu_flag::dbg_global_pause;
+
+		if (Emu.GetStatus() != system_state::paused)
+		{
+			// Emulator::Resume was called inbetween
+			state -= cpu_flag::dbg_global_pause;
+
+			// Recheck if state is inconsistent
+			continue;
+		}
+
+		break;
+	}
+
 	g_threads_created++;
 }
 

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -741,7 +741,7 @@ bool gdb_thread::cmd_vcont(gdb_cmd& cmd)
 		}
 		ppu->state -= cpu_flag::dbg_pause;
 		//special case if app didn't start yet (only loaded)
-		if (!Emu.IsPaused() && !Emu.IsRunning()) {
+		if (Emu.IsReady()) {
 			Emu.Run(true);
 		}
 		if (Emu.IsPaused()) {

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1641,7 +1641,9 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			return game_boot_result::invalid_file_or_folder;
 		}
 
-		if ((m_force_boot || g_cfg.misc.autostart) && IsReady())
+		ensure(IsReady());
+
+		if (m_force_boot || g_cfg.misc.autostart)
 		{
 			if (ppu_exec == elf_error::ok)
 			{
@@ -1659,38 +1661,14 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 
 			m_force_boot = false;
 		}
-		else if (IsPaused())
-		{
-			m_state = system_state::ready;
-			GetCallbacks().on_ready();
-		}
+
 		return game_boot_result::no_errors;
 	}
 }
 
 void Emulator::Run(bool start_playtime)
 {
-	if (!IsReady())
-	{
-		// Reload with prior configuration.
-		Load(m_title_id, false, m_force_global_config);
-
-		if (!IsReady())
-		{
-			return;
-		}
-	}
-
-	if (IsRunning())
-	{
-		Stop();
-	}
-
-	if (IsPaused())
-	{
-		Resume();
-		return;
-	}
+	ensure(IsReady());
 
 	GetCallbacks().on_run(start_playtime);
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1188,6 +1188,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 				// Exit "process"
 				Emu.CallAfter([]
 				{
+					Emu.SetForceBoot(true);
 					Emu.Stop();
 				});
 			});

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -17,8 +17,8 @@ enum class video_renderer;
 enum class system_state : u32
 {
 	running,
-	paused,
 	stopped,
+	paused,
 	ready,
 };
 
@@ -238,7 +238,7 @@ public:
 	bool Quit(bool force_quit);
 
 	bool IsRunning() const { return m_state == system_state::running; }
-	bool IsPaused()  const { return m_state == system_state::paused; }
+	bool IsPaused()  const { return m_state >= system_state::paused; } // ready is also considered paused by this function
 	bool IsStopped() const { return m_state == system_state::stopped; }
 	bool IsReady()   const { return m_state == system_state::ready; }
 	auto GetStatus() const { return m_state.load(); }

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -199,15 +199,19 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 	case Qt::Key_E:
 		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
 		{
-			if (Emu.IsReady())
+			switch (Emu.GetStatus())
+			{
+			case system_state::ready:
 			{
 				Emu.Run(true);
 				return;
 			}
-			else if (Emu.IsPaused())
+			case system_state::paused:
 			{
 				Emu.Resume();
 				return;
+			}
+			default: break;
 			}
 		}
 		break;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -271,19 +271,12 @@ void main_window::ResizeIcons(int index)
 
 void main_window::OnPlayOrPause()
 {
-	if (Emu.IsReady())
+	switch (Emu.GetStatus())
 	{
-		Emu.Run(true);
-	}
-	else if (Emu.IsPaused())
-	{
-		Emu.Resume();
-	}
-	else if (Emu.IsRunning())
-	{
-		Emu.Pause();
-	}
-	else if (Emu.IsStopped())
+	case system_state::ready: Emu.Run(true); return;
+	case system_state::paused: Emu.Resume(); return;
+	case system_state::running: Emu.Pause(); return;
+	case system_state::stopped:
 	{
 		if (m_selected_game)
 		{
@@ -301,6 +294,10 @@ void main_window::OnPlayOrPause()
 		{
 			BootRecentAction(m_recent_game_acts.first());
 		}
+
+		return;
+	}
+	default: fmt::throw_exception("Unreachable");
 	}
 }
 
@@ -2388,7 +2385,15 @@ void main_window::keyPressEvent(QKeyEvent *keyEvent)
 	{
 		switch (keyEvent->key())
 		{
-		case Qt::Key_E: if (Emu.IsPaused()) Emu.Resume(); else if (Emu.IsReady()) Emu.Run(true); return;
+		case Qt::Key_E:
+		{
+			switch (Emu.GetStatus())
+			{
+			case system_state::paused: Emu.Resume(); return;
+			case system_state::ready: Emu.Run(true); return;
+			default: return;
+			}
+		}
 		case Qt::Key_P: if (Emu.IsRunning()) Emu.Pause(); return;
 		case Qt::Key_S: if (!Emu.IsStopped()) Emu.Stop(); return;
 		case Qt::Key_R: if (!Emu.GetBoot().empty()) Emu.Restart(); return;


### PR DESCRIPTION
## Bugfixes
* In ready state emulator threads such as of FXO were running due to flawed pause check, so check ready state as well.
* Solve minor race between IDM cpu_thread constructor and Emulator::Pause.
* Solve minor race between IDM cpu_thread constructor and Emulator::Stop.
* Do not obey auto-exit setting after creating firmware cache.