### PR TITLE
fixed_typemap.hpp: make it a bit fool-proof

### DIFF
--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -89,6 +89,10 @@ public:
 
 	patch_engine();
 
+	patch_engine(const patch_engine&) = delete;
+
+	patch_engine& operator=(const patch_engine&) = delete;
+
 	// Returns the directory in which patch_config.yml is located
 	static std::string get_patch_config_path();
 

--- a/rpcs3/Emu/Cell/Modules/StaticHLE.h
+++ b/rpcs3/Emu/Cell/Modules/StaticHLE.h
@@ -22,6 +22,9 @@ public:
 	statichle_handler(int);
 	~statichle_handler();
 
+	statichle_handler(const statichle_handler&) = delete;
+	statichle_handler& operator=(const statichle_handler&) = delete;
+
 	bool load_patterns();
 	bool check_against_patterns(vm::cptr<u8>& data, u32 size, u32 addr);
 

--- a/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
@@ -38,7 +38,12 @@ struct avconf_manager
 	std::vector<CellAudioInDeviceInfo> devices;
 
 	void copy_device_info(u32 num, vm::ptr<CellAudioInDeviceInfo> info);
+
 	avconf_manager();
+
+	avconf_manager(const avconf_manager&) = delete;
+
+	avconf_manager& operator=(const avconf_manager&) = delete;
 };
 
 avconf_manager::avconf_manager()

--- a/rpcs3/Emu/Cell/Modules/cellFs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellFs.cpp
@@ -938,6 +938,8 @@ struct fs_aio_thread : ppu_thread
 struct fs_aio_manager
 {
 	std::shared_ptr<fs_aio_thread> thread;
+
+	shared_mutex mutex;
 };
 
 s32 cellFsAioInit(vm::cptr<char> mount_point)

--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -63,8 +63,10 @@ void fmt_class_string<CellMusic2Error>::format(std::string& out, u64 arg)
 
 struct music_state
 {
-	vm::ptr<void(u32 event, vm::ptr<void> param, vm::ptr<void> userData)> func;
-	vm::ptr<void> userData;
+	shared_mutex mutex;
+
+	vm::ptr<void(u32 event, vm::ptr<void> param, vm::ptr<void> userData)> func{};
+	vm::ptr<void> userData{};
 };
 
 error_code cellMusicGetSelectionContext(vm::ptr<CellMusicSelectionContext> context)

--- a/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
@@ -85,14 +85,18 @@ using CellMusicDecode2Callback = void(u32, vm::ptr<void> param, vm::ptr<void> us
 
 struct music_decode
 {
-	vm::ptr<CellMusicDecodeCallback> func;
-	vm::ptr<void> userData;
+	vm::ptr<CellMusicDecodeCallback> func{};
+	vm::ptr<void> userData{};
+
+	shared_mutex mutex;
 };
 
 struct music_decode2
 {
-	vm::ptr<CellMusicDecode2Callback> func;
-	vm::ptr<void> userData;
+	vm::ptr<CellMusicDecode2Callback> func{};
+	vm::ptr<void> userData{};
+
+	shared_mutex mutex;
 };
 
 error_code cellMusicDecodeInitialize(s32 mode, u32 container, s32 spuPriority, vm::ptr<CellMusicDecodeCallback> func, vm::ptr<void> userData)

--- a/rpcs3/Emu/Cell/Modules/cellRec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRec.cpp
@@ -58,8 +58,10 @@ using CellRecCallback = void(s32 recStatus, s32 recError, vm::ptr<void> userdata
 
 struct rec_info
 {
-	vm::ptr<CellRecCallback> cb;
-	vm::ptr<void> cbUserData;
+	vm::ptr<CellRecCallback> cb{};
+	vm::ptr<void> cbUserData{};
+
+	shared_mutex mutex;
 };
 
 error_code cellRecOpen(vm::cptr<char> pDirName, vm::cptr<char> pFileName, vm::cptr<CellRecParam> pParam, u32 container, vm::ptr<CellRecCallback> cb, vm::ptr<void> cbUserData)

--- a/rpcs3/Emu/Cell/Modules/cellRudp.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRudp.cpp
@@ -65,7 +65,9 @@ struct rudp_info
 
 	// event handler function
 	vm::ptr<CellRudpEventHandler> handler = vm::null;
-	vm::ptr<void> handler_arg;
+	vm::ptr<void> handler_arg{};
+
+	shared_mutex mutex;
 };
 
 error_code cellRudpInit(vm::ptr<CellRudpAllocator> allocator)

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
@@ -26,14 +26,12 @@ void fmt_class_string<CellScreenShotError>::format(std::string& out, u64 arg)
 	});
 }
 
-shared_mutex screenshot_mtx;
-
-std::string screenshot_manager::get_overlay_path() const
+std::string screenshot_info::get_overlay_path() const
 {
 	return vfs::get(overlay_dir_name + "/" + overlay_file_name);
 }
 
-std::string screenshot_manager::get_photo_title() const
+std::string screenshot_info::get_photo_title() const
 {
 	std::string photo = photo_title;
 	if (photo.empty())
@@ -41,7 +39,7 @@ std::string screenshot_manager::get_photo_title() const
 	return photo;
 }
 
-std::string screenshot_manager::get_game_title() const
+std::string screenshot_info::get_game_title() const
 {
 	std::string game = game_title;
 	if (game.empty())
@@ -49,12 +47,12 @@ std::string screenshot_manager::get_game_title() const
 	return game;
 }
 
-std::string screenshot_manager::get_game_comment() const
+std::string screenshot_info::get_game_comment() const
 {
 	return game_comment;
 }
 
-std::string screenshot_manager::get_screenshot_path(const std::string& date_path) const
+std::string screenshot_info::get_screenshot_path(const std::string& date_path) const
 {
 	u32 counter = 0;
 	std::string path = vfs::get("/dev_hdd0/photo/" + date_path + "/" + get_photo_title());
@@ -86,7 +84,7 @@ error_code cellScreenShotSetParameter(vm::cptr<CellScreenShotSetParam> param)
 		return CELL_SCREENSHOT_ERROR_PARAM;
 
 	auto& manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard lock(screenshot_mtx);
+	std::lock_guard lock(manager.mutex);
 
 	if (param->photo_title && param->photo_title[0] != '\0')
 		manager.photo_title = std::string(param->photo_title.get_ptr());
@@ -124,7 +122,7 @@ error_code cellScreenShotSetOverlayImage(vm::cptr<char> srcDir, vm::cptr<char> s
 	}
 
 	auto& manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard lock(screenshot_mtx);
+	std::lock_guard lock(manager.mutex);
 
 	manager.overlay_dir_name = std::string(srcDir.get_ptr());
 	manager.overlay_file_name = std::string(srcFile.get_ptr());
@@ -139,7 +137,7 @@ error_code cellScreenShotEnable()
 	cellScreenshot.warning("cellScreenShotEnable()");
 
 	auto& manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard lock(screenshot_mtx);
+	std::lock_guard lock(manager.mutex);
 
 	manager.is_enabled = true;
 
@@ -151,7 +149,7 @@ error_code cellScreenShotDisable()
 	cellScreenshot.warning("cellScreenShotDisable()");
 
 	auto& manager = g_fxo->get<screenshot_manager>();
-	std::lock_guard lock(screenshot_mtx);
+	std::lock_guard lock(manager.mutex);
 
 	manager.is_enabled = false;
 

--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.h
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.h
@@ -27,9 +27,7 @@ struct CellScreenShotSetParam
 	vm::bptr<void> reserved;
 };
 
-extern shared_mutex screenshot_mtx;
-
-struct screenshot_manager
+struct screenshot_info
 {
 	bool is_enabled{false};
 
@@ -47,4 +45,9 @@ struct screenshot_manager
 	std::string get_game_title() const;
 	std::string get_game_comment() const;
 	std::string get_screenshot_path(const std::string& date_path) const;
+};
+
+struct screenshot_manager : public screenshot_info
+{
+	shared_mutex mutex;
 };

--- a/rpcs3/Emu/Cell/Modules/cellWebBrowser.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellWebBrowser.cpp
@@ -8,8 +8,10 @@ LOG_CHANNEL(cellSysutil);
 
 struct browser_info
 {
-	vm::ptr<CellWebBrowserSystemCallback> system_cb;
-	vm::ptr<void> userData;
+	vm::ptr<CellWebBrowserSystemCallback> system_cb{};
+	vm::ptr<void> userData{};
+
+	shared_mutex mutex;
 };
 
 error_code cellWebBrowserActivate()

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -69,6 +69,16 @@ struct ppu_segment
 // PPU Module Information
 struct ppu_module
 {
+	ppu_module() = default;
+
+	ppu_module(const ppu_module&) = delete;
+
+	ppu_module(ppu_module&&) = default;
+
+	ppu_module& operator=(const ppu_module&) = delete;
+
+	ppu_module& operator=(ppu_module&&) = default;
+
 	uchar sha1[20]{};
 	std::string name;
 	std::string path;

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -101,6 +101,12 @@ const ppu_static_module* ppu_module_manager::get_module(const std::string& name)
 // Global linkage information
 struct ppu_linkage_info
 {
+	ppu_linkage_info() = default;
+
+	ppu_linkage_info(const ppu_linkage_info&) = delete;
+
+	ppu_linkage_info& operator=(const ppu_linkage_info&) = delete;
+
 	struct module_data
 	{
 		struct info

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2597,6 +2597,13 @@ extern void ppu_initialize()
 	}
 }
 
+struct ppu_toc_manager
+{
+	std::unordered_map<u32, u32> toc_map;
+
+	shared_mutex mutex;
+};
+
 bool ppu_initialize(const ppu_module& info, bool check_only)
 {
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::llvm)
@@ -2607,7 +2614,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 		}
 
 		// Temporarily
-		s_ppu_toc = &g_fxo->get<std::unordered_map<u32, u32>>();
+		s_ppu_toc = &g_fxo->get<ppu_toc_manager>().toc_map;
 
 		for (const auto& func : info.funcs)
 		{
@@ -2994,7 +3001,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 				}
 
 				// Keep allocating workload
-				const auto [obj_name, part] = std::as_const(workload)[i];
+				const auto& [obj_name, part] = std::as_const(workload)[i];
 
 				// Allocate "core"
 				std::lock_guard jlock(g_fxo->get<jit_core_allocator>().sem);

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1665,6 +1665,12 @@ void spu_thread::cpu_task()
 
 struct raw_spu_cleanup
 {
+	raw_spu_cleanup() = default;
+
+	raw_spu_cleanup(const raw_spu_cleanup&) = delete;
+
+	raw_spu_cleanup& operator =(const raw_spu_cleanup&) = delete;
+
 	~raw_spu_cleanup()
 	{
 		std::memset(spu_thread::g_raw_spu_id, 0, sizeof(spu_thread::g_raw_spu_id));

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1777,7 +1777,7 @@ void Emulator::Resume()
 
 		std::string dump;
 
-		for (u32 i = 0x10000; i < 0x20000000;)
+		for (u32 i = 0x10000; i < 0xE0000000;)
 		{
 			if (vm::check_addr(i, vm::page_executable))
 			{

--- a/rpcs3/Input/pad_thread.h
+++ b/rpcs3/Input/pad_thread.h
@@ -17,6 +17,8 @@ class pad_thread
 {
 public:
 	pad_thread(void* _curthread, void* _curwindow, std::string_view title_id); // void * instead of QThread * and QWindow * because of include in emucore
+	pad_thread(const pad_thread&) = delete;
+	pad_thread& operator=(const pad_thread&) = delete;
 	~pad_thread();
 
 	PadInfo& GetInfo() { return m_info; }

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -481,11 +481,11 @@ void gs_frame::take_screenshot(const std::vector<u8> sshot_data, const u32 sshot
 				}
 			}
 
-			screenshot_manager manager;
+			screenshot_info manager;
 			{
-				auto& fxo = g_fxo->get<screenshot_manager>();
-				std::lock_guard lock(screenshot_mtx);
-				manager = fxo;
+				auto& s = g_fxo->get<screenshot_manager>();
+				std::lock_guard lock(s.mutex);
+				manager = s;
 			}
 
 			struct scoped_png_ptrs

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -49,6 +49,8 @@ namespace stx
 			template <typename T>
 			static typeinfo make_typeinfo()
 			{
+				static_assert(!std::is_copy_assignable_v<T> && !std::is_copy_constructible_v<T>, "Please make sure the object cannot be accidentally copied.");
+
 				typeinfo r;
 				r.create = &call_ctor<T>;
 				r.destroy = &call_dtor<T>;


### PR DESCRIPTION
Require objects in g_fxo (singletons with lifetime equalling emulated process) to be non-copyable (move is still allowed).

I noticed most of them are immovable anyway due to the presence of atomics and mutexes of sorts.
If accidental copy happends, it may be pretty bad with this design since it will be undesired but unnoticed.