### PR TITLE
SPUThread.cpp: remove "__attribute__((always_inline))"

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -133,8 +133,6 @@ static FORCE_INLINE bool cmp_rdata_avx(const __m256i* lhs, const __m256i* rhs)
 
 #ifdef _MSC_VER
 __forceinline
-#else
-__attribute__((always_inline))
 #endif
 extern bool cmp_rdata(const spu_rdata_t& _lhs, const spu_rdata_t& _rhs)
 {
@@ -189,8 +187,6 @@ static FORCE_INLINE void mov_rdata_avx(__m256i* dst, const __m256i* src)
 
 #ifdef _MSC_VER
 __forceinline
-#else
-__attribute__((always_inline))
 #endif
 extern void mov_rdata(spu_rdata_t& _dst, const spu_rdata_t& _src)
 {


### PR DESCRIPTION
cmp_rdata and mov_rdata are using `__attribute__((always_inline))`,
without inline, that is not supported on current g++ (see #1546).

Moreover `__attribute__((always_inline))` is a noop if used without inline so
just remove it.

A proper fix is to move the 2 functions in an header file as static
(with FORCE_INLINE) so it can be correctly inlined by the compiler.

```
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:195:13: warning: 'always_inline' function might not be inlinable [-Wattributes]
  195 | extern void mov_rdata(spu_rdata_t& _dst, const spu_rdata_t& _src)
      |             ^~~~~~~~~
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:139:13: warning: 'always_inline' function might not be inlinable [-Wattributes]
  139 | extern bool cmp_rdata(const spu_rdata_t& _lhs, const spu_rdata_t& _rhs)
      |             ^~~~~~~~~
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp: In member function 'spu_thread::do_putllc(spu_mfc_cmd const&)::{lambda()#1}::operator()() const::{lambda()#3}::operator()() const':
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:139:13: error: inlining failed in call to 'always_inline' 'cmp_rdata(std::byte const (&) [128], std::byte const (&) [128])': function body can be overwritten at link time
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:2842:17: note: called from here
 2842 |    if (cmp_rdata(rdata, super_data))
      |        ~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:195:13: error: inlining failed in call to 'always_inline' 'mov_rdata(std::byte (&) [128], std::byte const (&) [128])': function body can be overwritten at link time
  195 | extern void mov_rdata(spu_rdata_t& _dst, const spu_rdata_t& _src)
      |             ^~~~~~~~~
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:2844:14: note: called from here
 2844 |     mov_rdata(super_data, to_write);
      |     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:139:13: error: inlining failed in call to 'always_inline' 'cmp_rdata(std::byte const (&) [128], std::byte const (&) [128])': function body can be overwritten at link time
  139 | extern bool cmp_rdata(const spu_rdata_t& _lhs, const spu_rdata_t& _rhs)
      |             ^~~~~~~~~
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:2842:17: note: called from here
 2842 |    if (cmp_rdata(rdata, super_data))
      |        ~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:195:13: error: inlining failed in call to 'always_inline' 'mov_rdata(std::byte (&) [128], std::byte const (&) [128])': function body can be overwritten at link time
  195 | extern void mov_rdata(spu_rdata_t& _dst, const spu_rdata_t& _src)
      |             ^~~~~~~~~
/home/tredaell/dev/sources/fedora-copr/rpcs3/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:2844:14: note: called from here
 2844 |     mov_rdata(super_data, to_write);
      |     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/build.make:969: rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/Cell/SPUThread.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
```