### PR TITLE
SPU LLVM: Rearange FM instruction for better performance

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7749,9 +7749,9 @@ public:
 
 			const auto ma = eval(sext<s32[4]>(fcmp_uno(a != fsplat<f32[4]>(0.))));
 			const auto mb = eval(sext<s32[4]>(fcmp_uno(b != fsplat<f32[4]>(0.))));
-			const auto ca = eval(bitcast<f32[4]>(bitcast<s32[4]>(a) & mb));
-			const auto cb = eval(bitcast<f32[4]>(bitcast<s32[4]>(b) & ma));
-			set_vr(op.rt, fm(ca, cb));
+			const auto cx = eval(ma & mb);
+			const auto x = fm(a, b);
+			set_vr(op.rt, eval(bitcast<f32[4]>(bitcast<s32[4]>(x) & cx)));
 		}
 		else
 			set_vr(op.rt, get_vr<f32[4]>(op.ra) * get_vr<f32[4]>(op.rb));


### PR DESCRIPTION
Rearranges the FM instruction to allow the comparisons and the multiplication to be processed in parallel. This doesn't save any instructions, but still results in a speedup.

In the mandelbrot homebrew performance increased from 120 --> 122fps on my 7700K at 5ghz.

On a cpu with more out of order execution resources available, such as my i5-1135G7 at 2.6ghz performance was increased from 69 --> 74fps.