### PR TITLE
Input: DualSense battery level LED indicator and other fixes

### DIFF
--- a/rpcs3/Emu/Io/pad_config.h
+++ b/rpcs3/Emu/Io/pad_config.h
@@ -78,9 +78,9 @@ struct pad_config final : cfg::node
 	cfg::_int<0, 1000000> lpadsquircling{ this, "Left Pad Squircling Factor", 0 };
 	cfg::_int<0, 1000000> rpadsquircling{ this, "Right Pad Squircling Factor", 0 };
 
-	cfg::_int<0, 255> colorR{ this, "Color Value R", 0 };
-	cfg::_int<0, 255> colorG{ this, "Color Value G", 0 };
-	cfg::_int<0, 255> colorB{ this, "Color Value B", 0 };
+	cfg::uint<0, 255> colorR{ this, "Color Value R", 0 };
+	cfg::uint<0, 255> colorG{ this, "Color Value G", 0 };
+	cfg::uint<0, 255> colorB{ this, "Color Value B", 0 };
 
 	cfg::_bool led_low_battery_blink{ this, "Blink LED when battery is below 20%", true };
 	cfg::_bool led_battery_indicator{ this, "Use LED as a battery indicator", false };

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -590,6 +590,7 @@ void ds3_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, c
 		if (dev->last_battery_level != dev->battery_level)
 		{
 			dev->new_output_data = true;
+			dev->last_battery_level = dev->battery_level;
 		}
 	}
 

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -768,20 +768,6 @@ bool ds4_pad_handler::get_is_right_stick(u64 keyCode)
 	}
 }
 
-u32 ds4_pad_handler::get_battery_color(u8 battery_level, int brightness)
-{
-	static const std::array<u32, 12> battery_level_clr = {0xff00, 0xff33, 0xff66, 0xff99, 0xffcc, 0xffff, 0xccff, 0x99ff, 0x66ff, 0x33ff, 0x00ff, 0x00ff};
-	u32 combined_color = battery_level_clr[0];
-	// Check if we got a weird value
-	if (battery_level < battery_level_clr.size())
-	{
-		combined_color = battery_level_clr[battery_level];
-	}
-	const u32 red = (combined_color >> 8) * brightness / 100;
-	const u32 green = (combined_color & 0xff) * brightness / 100;
-	return ((red << 8) | green);
-}
-
 PadHandlerBase::connection ds4_pad_handler::update_connection(const std::shared_ptr<PadDevice>& device)
 {
 	DS4Device* ds4_dev = static_cast<DS4Device*>(device.get());

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -894,6 +894,7 @@ void ds4_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, c
 			config->colorG.set(combined_color & 0xff);
 			config->colorB.set(0);
 			ds4_dev->new_output_data = true;
+			ds4_dev->last_battery_level = ds4_dev->battery_level;
 		}
 	}
 

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -62,8 +62,6 @@ public:
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:
-	u32 get_battery_color(u8 battery_level, int brightness);
-
 	// This function gets us usuable buffer from the rawbuffer of padData
 	bool GetCalibrationData(DS4Device* ds4Device);
 

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -573,10 +573,10 @@ void dualsense_pad_handler::get_extended_info(const std::shared_ptr<PadDevice>& 
 	if (!dualsense_device || !pad)
 		return;
 
-	auto buf = dualsense_device->padData;
-
 	pad->m_battery_level = dualsense_device->battery_level;
 	pad->m_cable_state   = dualsense_device->cable_state;
+
+	auto& buf = dualsense_device->padData;
 
 	// these values come already calibrated, all we need to do is convert to ds3 range
 
@@ -709,13 +709,13 @@ std::unordered_map<u64, u16> dualsense_pad_handler::get_button_values(const std:
 		keyBuffer[DualSenseKeyCodes::L3]      = ((data & 0x40) != 0) ? 255 : 0;
 		keyBuffer[DualSenseKeyCodes::R3]      = ((data & 0x80) != 0) ? 255 : 0;
 
-		keyBuffer[DualSenseKeyCodes::L2] = buf[7];
-		keyBuffer[DualSenseKeyCodes::R2] = buf[8];
-
 		data = buf[6];
 		keyBuffer[DualSenseKeyCodes::PSButton] = ((data & 0x01) != 0) ? 255 : 0;
 		keyBuffer[DualSenseKeyCodes::TouchPad] = ((data & 0x02) != 0) ? 255 : 0;
 		keyBuffer[DualSenseKeyCodes::Mic]      = ((data & 0x04) != 0) ? 255 : 0;
+
+		keyBuffer[DualSenseKeyCodes::L2] = buf[7];
+		keyBuffer[DualSenseKeyCodes::R2] = buf[8];
 
 		return keyBuffer;
 	}
@@ -735,6 +735,9 @@ std::unordered_map<u64, u16> dualsense_pad_handler::get_button_values(const std:
 	// Right Stick Y Axis (Up is the negative for some reason)
 	keyBuffer[DualSenseKeyCodes::RSYNeg] = Clamp0To255((buf[3] - 127.5f) * 2.0f);
 	keyBuffer[DualSenseKeyCodes::RSYPos] = Clamp0To255((127.5f - buf[3]) * 2.0f);
+
+	keyBuffer[DualSenseKeyCodes::L2] = buf[4];
+	keyBuffer[DualSenseKeyCodes::R2] = buf[5];
 
 	u8 data = buf[7] & 0xf;
 	switch (data)
@@ -812,9 +815,6 @@ std::unordered_map<u64, u16> dualsense_pad_handler::get_button_values(const std:
 	keyBuffer[DualSenseKeyCodes::Options] = ((data & 0x20) != 0) ? 255 : 0;
 	keyBuffer[DualSenseKeyCodes::L3]      = ((data & 0x40) != 0) ? 255 : 0;
 	keyBuffer[DualSenseKeyCodes::R3]      = ((data & 0x80) != 0) ? 255 : 0;
-
-	keyBuffer[DualSenseKeyCodes::L2] = buf[4];
-	keyBuffer[DualSenseKeyCodes::R2] = buf[5];
 
 	data = buf[9];
 	keyBuffer[DualSenseKeyCodes::PSButton] = ((data & 0x01) != 0) ? 255 : 0;

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -66,6 +66,7 @@ public:
 	~dualsense_pad_handler();
 
 	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
+	u32 get_battery_level(const std::string& padId) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 
 private:

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -22,6 +22,11 @@ public:
 	bool init_lightbar{true};
 	bool update_lightbar{true};
 	bool update_player_leds{true};
+
+	// Controls for lightbar pulse. This seems somewhat hacky for now, as I haven't found out a nicer way.
+	bool lightbar_on{false};
+	bool lightbar_on_old{false};
+	steady_clock::time_point last_lightbar_time;
 };
 
 class dualsense_pad_handler final : public hid_pad_handler<DualSenseDevice>

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -207,12 +207,9 @@ template <class Device>
 u32 hid_pad_handler<Device>::get_battery_color(u8 battery_level, int brightness) const
 {
 	static const std::array<u32, 12> battery_level_clr = {0xff00, 0xff33, 0xff66, 0xff99, 0xffcc, 0xffff, 0xccff, 0x99ff, 0x66ff, 0x33ff, 0x00ff, 0x00ff};
-	u32 combined_color = battery_level_clr[0];
-	// Check if we got a weird value
-	if (battery_level < battery_level_clr.size())
-	{
-		combined_color = battery_level_clr[battery_level];
-	}
+
+	const u32 combined_color = battery_level_clr[battery_level < battery_level_clr.size() ? battery_level : 0];
+
 	const u32 red = (combined_color >> 8) * brightness / 100;
 	const u32 green = (combined_color & 0xff) * brightness / 100;
 	return ((red << 8) | green);

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -203,6 +203,21 @@ std::shared_ptr<PadDevice> hid_pad_handler<Device>::get_device(const std::string
 	return get_hid_device(device);
 }
 
+template <class Device>
+u32 hid_pad_handler<Device>::get_battery_color(u8 battery_level, int brightness) const
+{
+	static const std::array<u32, 12> battery_level_clr = {0xff00, 0xff33, 0xff66, 0xff99, 0xffcc, 0xffff, 0xccff, 0x99ff, 0x66ff, 0x33ff, 0x00ff, 0x00ff};
+	u32 combined_color = battery_level_clr[0];
+	// Check if we got a weird value
+	if (battery_level < battery_level_clr.size())
+	{
+		combined_color = battery_level_clr[battery_level];
+	}
+	const u32 red = (combined_color >> 8) * brightness / 100;
+	const u32 green = (combined_color & 0xff) * brightness / 100;
+	return ((red << 8) | green);
+}
+
 template class hid_pad_handler<ds3_device>;
 template class hid_pad_handler<DS4Device>;
 template class hid_pad_handler<DualSenseDevice>;

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -102,6 +102,8 @@ protected:
 		return *reinterpret_cast<const u32*>(buf);
 	}
 
+	u32 get_battery_color(u8 battery_level, int brightness) const;
+
 private:
 	std::shared_ptr<PadDevice> get_device(const std::string& device) override;
 };

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -412,10 +412,7 @@ void pad_settings_dialog::InitButtons()
 			}
 		}
 
-		if (m_enable_battery)
-		{
-			ui->pb_battery->setValue(battery_level);
-		}
+		ui->pb_battery->setValue(m_enable_battery ? battery_level : 0);
 
 		if (val <= 0)
 		{
@@ -436,14 +433,14 @@ void pad_settings_dialog::InitButtons()
 	const auto& fail_callback = [this](const std::string& pad_name)
 	{
 		SwitchPadInfo(pad_name, false);
+
 		if (m_enable_buttons)
 		{
 			SwitchButtons(false);
 		}
-		if (m_enable_battery)
-		{
-			ui->pb_battery->setValue(0);
-		}
+
+		ui->pb_battery->setValue(0);
+
 		if (m_handler->has_deadzones())
 		{
 			ui->preview_trigger_left->setValue(0);


### PR DESCRIPTION
Pad Settings Dialog:
- Fixed wrong battery indicator state under certain circumstances

DS3/DS4:
- Fix possible cause for input lag: Battery LED was always updated.
- fixes #9878 

DualSense:
- Read DualSense Firmware and Hardware versions.
- Read DualSense battery levels.
- Add DualSense Battery Level LED indicator

![image](https://user-images.githubusercontent.com/23019877/110174436-671d3800-7e00-11eb-9be5-5bfc62571879.png)
![image](https://user-images.githubusercontent.com/23019877/110174647-b2374b00-7e00-11eb-9717-f38ad88aeb52.png)
