### PR TITLE
GUI: Implement full extraction of PUP and improve installation error handling

### DIFF
--- a/rpcs3/Loader/PUP.h
+++ b/rpcs3/Loader/PUP.h
@@ -30,19 +30,37 @@ struct PUPHashEntry
 	u8 padding[4];
 };
 
+// PUP loading error
+enum class pup_error : u32
+{
+	ok,
+
+	stream,
+	header_read,
+	header_magic,
+	header_file_count,
+	expected_size,
+	file_entries,
+	hash_mismatch,
+};
+
 class pup_object
 {
-	const fs::file& m_file;
-	bool isValid = false;
+	fs::file m_file;
+
+	pup_error m_error{};
+	std::string m_formatted_error;
 
 	std::vector<PUPFileEntry> m_file_tbl;
 	std::vector<PUPHashEntry> m_hash_tbl;
 
+	pup_error validate_hashes();
+
 public:
-	pup_object(const fs::file& file);
+	pup_object(fs::file&& file);
 
-	explicit operator bool() const { return isValid; }
+	explicit operator pup_error() const { return m_error; }
+	const std::string& get_formatted_error() const { return m_formatted_error; }
 
-	fs::file get_file(u64 entry_id);
-	bool validate_hashes();
+	fs::file get_file(u64 entry_id) const;
 };

--- a/rpcs3/Loader/TAR.h
+++ b/rpcs3/Loader/TAR.h
@@ -33,5 +33,9 @@ public:
 
 	fs::file get_file(const std::string& path);
 
-	bool extract(std::string path, std::string ignore = ""); // extract all files in archive to path
+	// Extract all files in archive to destination as VFS
+	// Allow to optionally specify explicit mount point (which may be directory meant for extraction)
+	bool extract(std::string vfs_mp = {});
 };
+
+bool extract_tar(const std::string& file_path, const std::string& dir_path);

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -130,6 +130,7 @@ namespace gui
 	const gui_save fd_cg_disasm    = gui_save(main_window, "lastExplorePathCGD",  "");
 	const gui_save fd_log_viewer   = gui_save(main_window, "lastExplorePathLOG",  "");
 	const gui_save fd_ext_mself    = gui_save(main_window, "lastExplorePathExMSELF",  "");
+	const gui_save fd_ext_tar      = gui_save(main_window, "lastExplorePathExTAR",  "");
 
 	const gui_save mw_debugger         = gui_save(main_window, "debuggerVisible",  false);
 	const gui_save mw_logger           = gui_save(main_window, "loggerVisible",    true);

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -144,8 +144,10 @@ private:
 	void HandlePackageInstallation(QStringList file_paths);
 
 	void InstallPup(QString filePath = "");
-	void HandlePupInstallation(QString file_path = "");
+	void ExtractPup();
+	void HandlePupInstallation(QString file_path, QString dir_path = "");
 
+	void ExtractTar();
 	void ExtractMSELF();
 
 	drop_type IsValidFile(const QMimeData& md, QStringList* drop_paths = nullptr);

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -256,7 +256,10 @@
     <addaction name="toolsStringSearchAct"/>
     <addaction name="separator"/>
     <addaction name="toolsDecryptSprxLibsAct"/>
+    <addaction name="separator"/>
     <addaction name="toolsExtractMSELFAct"/>
+    <addaction name="toolsExtractPUPAct"/>
+    <addaction name="toolsExtractTARAct"/>
     <addaction name="separator"/>
     <addaction name="actionopen_rsx_capture"/>
     <addaction name="separator"/>
@@ -632,6 +635,19 @@
   <action name="toolsExtractMSELFAct">
    <property name="text">
     <string>Extract MSELF</string>
+   </property>
+  </action>
+  <action name="toolsExtractPUPAct">
+   <property name="text">
+    <string>Extract PUP</string>
+   </property>
+  </action>
+  <action name="toolsExtractTARAct">
+   <property name="text">
+    <string>Extract Encrypted TAR</string>
+   </property>
+   <property name="toolTip">
+    <string>Extract files from special .tar files inside PS3UPDAT.PUP</string>
    </property>
   </action>
   <action name="showDebuggerAct">


### PR DESCRIPTION
## Features
* Implement full extraction of PS3UPDAT.PUP.
* Implement TAR extraction via GUI.

## Bugfixes
* Use VFS to implement missing PS3 filesystem characters escaping.
* Use VFS to error on illegal paths. (illegal paths such as malware pointing to "/../../..and so on../C:/Windows")
* Do not crash on missing 0x100 and 0x300 PUP file entries.
* Fix overflow in file-size against header check.
## Misc
* Add new PUP error types and descriptions.
* Report an error on missing PUP package inner files.
* Move all header errors to pup_object class.
* Move verbose error descriptions to pup_object class.

Implements step 1 and 2 of #9905 