### PR TITLE
Fix updater bugs

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1977,10 +1977,15 @@ bool Emulator::Quit(bool force_quit)
 	// The callback is only used if we actually quit RPCS3
 	const auto on_exit = []()
 	{
-		// Deinitialize object manager to prevent any hanging objects at program exit
-		g_fxo->clear();
+		Emu.CleanUp();
 	};
 	return GetCallbacks().try_to_quit(force_quit, on_exit);
+}
+
+void Emulator::CleanUp()
+{
+	// Deinitialize object manager to prevent any hanging objects at program exit
+	g_fxo->clear();
 }
 
 std::string Emulator::GetFormattedTitle(double fps) const

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -236,6 +236,7 @@ public:
 	void Stop(bool restart = false);
 	void Restart() { Stop(true); }
 	bool Quit(bool force_quit);
+	void CleanUp();
 
 	bool IsRunning() const { return m_state == system_state::running; }
 	bool IsPaused()  const { return m_state == system_state::paused; }

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -194,15 +194,15 @@ constexpr auto arg_commit_db  = "get-commit-db";
 int find_arg(std::string arg, int& argc, char* argv[])
 {
 	arg = "--" + arg;
-	for (int i = 1; i < argc; ++i)
+	for (int i = 0; i < argc; ++i) // It's not guaranteed that argv 0 is the executable.
 		if (!strcmp(arg.c_str(), argv[i]))
 			return i;
-	return 0;
+	return -1;
 }
 
 QCoreApplication* createApplication(int& argc, char* argv[])
 {
-	if (find_arg(arg_headless, argc, argv))
+	if (find_arg(arg_headless, argc, argv) != -1)
 		return new headless_application(argc, argv);
 
 #ifdef __linux__
@@ -221,8 +221,8 @@ QCoreApplication* createApplication(int& argc, char* argv[])
 
 	bool use_high_dpi = true;
 
-	const auto i_hdpi = find_arg(arg_high_dpi, argc, argv);
-	if (i_hdpi)
+	const int i_hdpi = find_arg(arg_high_dpi, argc, argv);
+	if (i_hdpi != -1)
 	{
 		const std::string cmp_str = "0";
 		const auto i_hdpi_2 = (argc > (i_hdpi + 1)) ? (i_hdpi + 1) : 0;
@@ -240,11 +240,11 @@ QCoreApplication* createApplication(int& argc, char* argv[])
 		// Set QT_SCALE_FACTOR_ROUNDING_POLICY from environment. Defaults to cli argument, which defaults to RoundPreferFloor.
 		auto rounding_val = Qt::HighDpiScaleFactorRoundingPolicy::PassThrough;
 		auto rounding_str = std::to_string(static_cast<int>(rounding_val));
-		const auto i_rounding = find_arg(arg_rounding, argc, argv);
+		const int i_rounding = find_arg(arg_rounding, argc, argv);
 
-		if (i_rounding)
+		if (i_rounding != -1)
 		{
-			const auto i_rounding_2 = (argc > (i_rounding + 1)) ? (i_rounding + 1) : 0;
+			const int i_rounding_2 = (argc > (i_rounding + 1)) ? (i_rounding + 1) : 0;
 
 			if (i_rounding_2)
 			{
@@ -315,7 +315,7 @@ int main(int argc, char** argv)
 	s_argv0 = argv[0]; // Save for report_fatal_error
 
 	// Only run RPCS3 to display an error
-	if (int err_pos = find_arg(arg_error, argc, argv))
+	if (int err_pos = find_arg(arg_error, argc, argv); err_pos != -1)
 	{
 		// Reconstruction of the error from multiple args
 		std::string error;
@@ -334,7 +334,7 @@ int main(int argc, char** argv)
 	static fs::file instance_lock;
 
 	// True if an argument --updating found
-	const bool is_updating = find_arg(arg_updating, argc, argv) != 0;
+	const bool is_updating = find_arg(arg_updating, argc, argv) != -1;
 
 	// Keep trying to lock the file for ~2s normally, and for ~10s in the case of --updating
 	for (u32 num = 0; num < (is_updating ? 500u : 100u) && !instance_lock.open(lock_name, fs::rewrite + fs::lock); num++)
@@ -437,10 +437,10 @@ int main(int argc, char** argv)
 	std::string argument_str;
 	for (int i = 0; i < argc; i++)
 	{
-		argument_str += argv[i];
+		argument_str += "'" + std::string(argv[i]) + "'";
 		if (i != argc - 1) argument_str += " ";
 	}
-	sys_log.notice("argv: '%s'", argument_str);
+	sys_log.notice("argc: %d, argv: %s", argc, argument_str);
 
 #ifdef __linux__
 	struct ::rlimit rlim;
@@ -466,7 +466,7 @@ int main(int argc, char** argv)
 	// The constructor of QApplication eats the --style and --stylesheet arguments.
 	// By checking for stylesheet().isEmpty() we could implicitly know if a stylesheet was passed,
 	// but I haven't found an implicit way to check for style yet, so we naively check them both here for now.
-	const bool use_cli_style = find_arg(arg_style, argc, argv) || find_arg(arg_stylesheet, argc, argv);
+	const bool use_cli_style = find_arg(arg_style, argc, argv) != -1 || find_arg(arg_stylesheet, argc, argv) != -1;
 
 	QScopedPointer<QCoreApplication> app(createApplication(argc, argv));
 	app->setApplicationVersion(QString::fromStdString(rpcs3::get_version().to_string()));
@@ -749,7 +749,7 @@ int main(int argc, char** argv)
 		sys_log.notice("Option passed via command line: %s %s", opt.toStdString(), parser.value(opt).toStdString());
 	}
 
-	if (const QStringList args = parser.positionalArguments(); !args.isEmpty())
+	if (const QStringList args = parser.positionalArguments(); !args.isEmpty() && !is_updating)
 	{
 		sys_log.notice("Booting application from command line: %s", args.at(0).toStdString());
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1994,11 +1994,6 @@ void main_window::CreateConnects()
 		QMessageBox::warning(this, tr("Auto-updater"), tr("The auto-updater currently isn't available for your os."));
 		return;
 #endif
-		if(!Emu.IsStopped())
-		{
-			QMessageBox::warning(this, tr("Auto-updater"), tr("Please stop the emulation before trying to update."));
-			return;
-		}
 		m_updater.check_for_updates(false, false, this);
 	});
 

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -546,9 +546,9 @@ bool update_manager::handle_rpcs3(const QByteArray& data)
 	QMessageBox::information(m_parent, tr("Auto-updater"), tr("Update successful!\nRPCS3 will now restart."));
 
 #ifdef _WIN32
-	const int ret = _wexecl(wchar_orig_path.data(), wchar_orig_path.data(), L"--updating", nullptr);
+	const int ret = _wexecl(wchar_orig_path.data(), L"--updating", nullptr);
 #else
-	const int ret = execl(replace_path.c_str(), replace_path.c_str(), "--updating", nullptr);
+	const int ret = execl(replace_path.c_str(), "--updating", nullptr);
 #endif
 	if (ret == -1)
 	{

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -229,10 +229,19 @@ bool update_manager::handle_json(bool automatic, bool check_only, const QByteArr
 
 void update_manager::update()
 {
+	ensure(m_downloader);
+
 	if (m_update_message.isEmpty() ||
 		QMessageBox::question(m_downloader->get_progress_dialog(), tr("Update Available"), m_update_message, QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
 	{
 		m_downloader->close_progress_dialog();
+		return;
+	}
+
+	if (!Emu.IsStopped())
+	{
+		m_downloader->close_progress_dialog();
+		QMessageBox::warning(m_parent, tr("Auto-updater"), tr("Please stop the emulation before trying to update."));
 		return;
 	}
 

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -545,6 +545,10 @@ bool update_manager::handle_rpcs3(const QByteArray& data)
 
 	QMessageBox::information(m_parent, tr("Auto-updater"), tr("Update successful!\nRPCS3 will now restart."));
 
+	Emu.SetForceBoot(true);
+	Emu.Stop();
+	Emu.CleanUp();
+
 #ifdef _WIN32
 	const int ret = _wexecl(wchar_orig_path.data(), L"--updating", nullptr);
 #else


### PR DESCRIPTION
- If the .exe path contains spaces, execl does convert it to several args. So let's not pass the exe as arg0
- Clean up the emulator before rebooting during an update. This may fix some crashes.
- Don't allow updates while ingame.