### PR TITLE
patch_manager: expand first search results

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -919,7 +919,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	QAction* pad_configure = menu.addAction(gameinfo->hasCustomPadConfig
 		? tr("&Change Custom Gamepad Configuration")
 		: tr("&Create Custom Gamepad Configuration"));
-	QAction* configure_patches = menu.addAction(tr("&Configure Game Patches"));
+	QAction* configure_patches = menu.addAction(tr("&Manage Game Patches"));
 	QAction* create_ppu_cache = menu.addAction(tr("&Create PPU Cache"));
 	menu.addSeparator();
 	QAction* rename_title = menu.addAction(tr("&Rename In Game List"));
@@ -1099,7 +1099,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 			}
 		}
 	});
-	connect(configure_patches, &QAction::triggered, [this, current_game, gameinfo]()
+	connect(configure_patches, &QAction::triggered, [this, gameinfo]()
 	{
 		std::unordered_map<std::string, std::set<std::string>> games;
 		for (const auto& game : m_game_data)
@@ -1109,7 +1109,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 				games[game->info.serial].insert(game_list_frame::GetGameVersion(game));
 			}
 		}
-		patch_manager_dialog patch_manager(m_gui_settings, games, current_game.serial, this);
+		patch_manager_dialog patch_manager(m_gui_settings, games, gameinfo->info.serial, GetGameVersion(gameinfo), this);
 		patch_manager.exec();
 	});
 	connect(open_game_folder, &QAction::triggered, [current_game]()

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1880,7 +1880,7 @@ void main_window::CreateConnects()
 				}
 			}
 		}
-		patch_manager_dialog patch_manager(m_gui_settings, games, "", this);
+		patch_manager_dialog patch_manager(m_gui_settings, games, "", "", this);
 		patch_manager.exec();
  	});
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -37,7 +37,7 @@ class patch_manager_dialog : public QDialog
 	const QString tr_all_versions = tr("All versions");
 
 public:
-	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, const std::string& search_term, QWidget* parent = nullptr);
+	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, const std::string& title_id, const std::string& version, QWidget* parent = nullptr);
 	~patch_manager_dialog();
 
 	int exec() override;
@@ -60,6 +60,9 @@ private:
 	bool handle_json(const QByteArray& data);
 
 	std::shared_ptr<gui_settings> m_gui_settings;
+
+	bool m_expand_current_match = false;
+	QString m_search_version;
 
 	std::unordered_map<std::string, std::set<std::string>> m_owned_games;
 	bool m_show_owned_games_only = false;


### PR DESCRIPTION
implements #9919

- Changes "Configure Game Patches" to "Manage Game Patches"
- Expand the matching entry for the game version when you click "Manager Game Patches"
- Expand the "All Versions" entry if the version was not found