### PR TITLE
[TESTERS NEEDED] vk: Add remaining pieces

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -462,6 +462,7 @@ if(TARGET 3rdparty_vulkan)
 		RSX/VK/vkutils/device.cpp
 		RSX/VK/vkutils/sampler.cpp
 		RSX/VK/vkutils/shared.cpp
+		RSX/VK/VKAsyncScheduler.cpp
 		RSX/VK/VKCommandStream.cpp
 		RSX/VK/VKCommonDecompiler.cpp
 		RSX/VK/VKCompute.cpp

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
@@ -129,7 +129,7 @@ namespace vk
 		return std::exchange(m_sync_label, nullptr);
 	}
 
-	void AsyncTaskScheduler::flush(VkSemaphore wait_semaphore, VkPipelineStageFlags wait_dst_stage_mask)
+	void AsyncTaskScheduler::flush(VkBool32 force_flush, VkSemaphore wait_semaphore, VkPipelineStageFlags wait_dst_stage_mask)
 	{
 		if (!m_current_cb)
 		{
@@ -143,7 +143,7 @@ namespace vk
 		}
 
 		m_current_cb->end();
-		m_current_cb->submit(get_current_renderer()->get_transfer_queue(), wait_semaphore, VK_NULL_HANDLE, nullptr, wait_dst_stage_mask, VK_FALSE);
+		m_current_cb->submit(get_current_renderer()->get_transfer_queue(), wait_semaphore, VK_NULL_HANDLE, nullptr, wait_dst_stage_mask, force_flush);
 
 		m_last_used_cb = m_current_cb;
 		m_current_cb = nullptr;

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
@@ -1,0 +1,161 @@
+#include "VKAsyncScheduler.h"
+#include "VKHelpers.h"
+#include "VKResourceManager.h"
+
+#include "Emu/IdManager.h"
+#include "Utilities/lockless.h"
+#include "Utilities/mutex.h"
+
+#include <vector>
+
+namespace vk
+{
+	void AsyncTaskScheduler::operator()()
+	{
+		add_ref();
+
+		while (thread_ctrl::state() != thread_state::aborting)
+		{
+			for (auto&& job : m_event_queue.pop_all())
+			{
+				vk::wait_for_event(job->queue1_signal.get(), GENERAL_WAIT_TIMEOUT);
+				job->queue2_signal->host_signal();
+			}
+		}
+
+		release();
+	}
+
+	void AsyncTaskScheduler::delayed_init()
+	{
+		auto pdev = get_current_renderer();
+		m_command_pool.create(*const_cast<render_device*>(pdev), pdev->get_transfer_queue_family());
+
+		for (usz i = 0; i < events_pool_size; ++i)
+		{
+			auto ev1 = std::make_unique<event>(*get_current_renderer(), sync_domain::gpu);
+			auto ev2 = std::make_unique<event>(*get_current_renderer(), sync_domain::gpu);
+			m_events_pool.emplace_back(std::move(ev1), std::move(ev2), 0ull);
+		}
+	}
+
+	void AsyncTaskScheduler::insert_sync_event()
+	{
+		ensure(m_current_cb);
+
+		xqueue_event* sync_label;
+		ensure(m_next_event_id < events_pool_size);
+		sync_label = &m_events_pool[m_next_event_id];
+
+		if (++m_next_event_id == events_pool_size)
+		{
+			// Wrap
+			m_next_event_id = 0;
+		}
+
+		ensure(sync_label->completion_eid <= vk::last_completed_event_id());
+
+		sync_label->queue1_signal->reset();
+		sync_label->queue2_signal->reset();
+		sync_label->completion_eid = vk::current_event_id();
+
+		sync_label->queue1_signal->signal(*m_current_cb, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0);
+
+		m_event_queue.push(sync_label);
+		m_sync_label = sync_label->queue2_signal.get();
+	}
+
+	AsyncTaskScheduler::~AsyncTaskScheduler()
+	{
+		*g_fxo->get<async_scheduler_thread>() = thread_state::aborting;
+		while (has_refs()) _mm_pause();
+
+		for (auto& cb : m_async_command_queue)
+		{
+			cb.destroy();
+		}
+
+		m_async_command_queue.clear();
+		m_next_cb_index = 0;
+		m_command_pool.destroy();
+		m_events_pool.clear();
+	}
+
+	command_buffer* AsyncTaskScheduler::get_current()
+	{
+		std::lock_guard lock(m_submit_mutex);
+		m_sync_required = true;
+
+		// 0. Anything still active?
+		if (m_current_cb)
+		{
+			return m_current_cb;
+		}
+
+		// 1. Check if there is a 'next' entry
+		auto pdev = get_current_renderer();
+		if (m_async_command_queue.empty())
+		{
+			delayed_init();
+		}
+		else if (m_next_cb_index < m_async_command_queue.size())
+		{
+			m_current_cb = &m_async_command_queue[m_next_cb_index];
+		}
+
+		// 2. Create entry
+		if (!m_current_cb)
+		{
+			if (m_next_cb_index == VK_MAX_ASYNC_COMPUTE_QUEUES)
+			{
+				m_next_cb_index = 0;
+				m_current_cb = &m_async_command_queue[m_next_cb_index];
+			}
+			else
+			{
+				m_async_command_queue.push_back({});
+				m_current_cb = &m_async_command_queue.back();
+				m_current_cb->create(m_command_pool, true);
+			}
+		}
+
+		m_next_cb_index++;
+		return m_current_cb;
+	}
+
+	event* AsyncTaskScheduler::get_primary_sync_label()
+	{
+		std::lock_guard lock(m_submit_mutex);
+
+		if (m_sync_required)
+		{
+			ensure(m_current_cb);
+			insert_sync_event();
+			m_sync_required = false;
+		}
+
+		return std::exchange(m_sync_label, nullptr);
+	}
+
+	void AsyncTaskScheduler::flush(VkSemaphore wait_semaphore, VkPipelineStageFlags wait_dst_stage_mask)
+	{
+		std::lock_guard lock(m_submit_mutex);
+
+		if (!m_current_cb)
+		{
+			return;
+		}
+
+		if (m_sync_required)
+		{
+			insert_sync_event();
+		}
+
+		m_current_cb->end();
+		m_current_cb->submit(get_current_renderer()->get_transfer_queue(), wait_semaphore, VK_NULL_HANDLE, nullptr, wait_dst_stage_mask, VK_FALSE);
+
+		m_last_used_cb = m_current_cb;
+		m_current_cb = nullptr;
+		m_sync_required = false;
+	}
+}

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
@@ -152,7 +152,7 @@ namespace vk
 
 	void AsyncTaskScheduler::kill()
 	{
-		*g_fxo->get<async_scheduler_thread>() = thread_state::aborting;
+		g_fxo->get<async_scheduler_thread>() = thread_state::aborting;
 		while (has_refs()) _mm_pause();
 
 		for (auto& cb : m_async_command_queue)

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
@@ -29,7 +29,7 @@ namespace vk
 
 		// Sync
 		event* m_sync_label = nullptr;
-		bool m_sync_required = false;
+		atomic_t<bool> m_sync_required = false;
 
 		static constexpr u32 events_pool_size = 16384;
 		std::vector<xqueue_event> m_events_pool;

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
@@ -14,6 +14,11 @@ namespace vk
 		std::unique_ptr<event> queue1_signal;
 		std::unique_ptr<event> queue2_signal;
 		u64 completion_eid;
+
+		xqueue_event(): completion_eid(0) {}
+		xqueue_event(std::unique_ptr<event>& trigger, std::unique_ptr<event>& payload, u64 eid)
+			: queue1_signal(std::move(trigger)), queue2_signal(std::move(payload)), completion_eid(eid)
+		{}
 	};
 
 	class AsyncTaskScheduler : private rsx::ref_counted
@@ -28,6 +33,8 @@ namespace vk
 		usz m_next_cb_index = 0;
 
 		// Scheduler
+		shared_mutex m_config_mutex;
+		bool m_options_initialized = false;
 		bool m_use_host_scheduler = false;
 
 		// Sync
@@ -41,6 +48,7 @@ namespace vk
 		lf_queue<xqueue_event*> m_event_queue;
 		shared_mutex m_submit_mutex;
 
+		void init_config_options();
 		void delayed_init();
 		void insert_sync_event();
 

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
@@ -48,7 +48,7 @@ namespace vk
 		command_buffer* get_current();
 		event* get_primary_sync_label();
 
-		void flush(VkSemaphore wait_semaphore = VK_NULL_HANDLE, VkPipelineStageFlags wait_dst_stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+		void flush(VkBool32 force_flush, VkSemaphore wait_semaphore = VK_NULL_HANDLE, VkPipelineStageFlags wait_dst_stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
 		void kill();
 
 		// Thread entry-point

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
@@ -49,6 +49,7 @@ namespace vk
 		event* get_primary_sync_label();
 
 		void flush(VkSemaphore wait_semaphore = VK_NULL_HANDLE, VkPipelineStageFlags wait_dst_stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+		void kill();
 
 		// Thread entry-point
 		void operator()();

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
@@ -27,6 +27,9 @@ namespace vk
 		command_buffer* m_current_cb = nullptr;
 		usz m_next_cb_index = 0;
 
+		// Scheduler
+		bool m_use_host_scheduler = false;
+
 		// Sync
 		event* m_sync_label = nullptr;
 		atomic_t<bool> m_sync_required = false;

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "vkutils/commands.h"
+#include "vkutils/sync.h"
+
+#include "Utilities/Thread.h"
+
+#define VK_MAX_ASYNC_COMPUTE_QUEUES 256
+
+namespace vk
+{
+	struct xqueue_event
+	{
+		std::unique_ptr<event> queue1_signal;
+		std::unique_ptr<event> queue2_signal;
+		u64 completion_eid;
+	};
+
+	class AsyncTaskScheduler : private rsx::ref_counted
+	{
+		// Vulkan resources
+		std::vector<command_buffer> m_async_command_queue;
+		command_pool m_command_pool;
+
+		// Running state
+		command_buffer* m_last_used_cb = nullptr;
+		command_buffer* m_current_cb = nullptr;
+		usz m_next_cb_index = 0;
+
+		// Sync
+		event* m_sync_label = nullptr;
+		bool m_sync_required = false;
+
+		static constexpr u32 events_pool_size = 16384;
+		std::vector<xqueue_event> m_events_pool;
+		atomic_t<u32> m_next_event_id = 0;
+
+		lf_queue<xqueue_event*> m_event_queue;
+		shared_mutex m_submit_mutex;
+
+		void delayed_init();
+		void insert_sync_event();
+
+	public:
+		AsyncTaskScheduler() = default;
+		~AsyncTaskScheduler();
+
+		command_buffer* get_current();
+		event* get_primary_sync_label();
+
+		void flush(VkSemaphore wait_semaphore = VK_NULL_HANDLE, VkPipelineStageFlags wait_dst_stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+
+		// Thread entry-point
+		void operator()();
+
+		static constexpr auto thread_name = "Vulkan Async Scheduler"sv;
+	};
+
+	using async_scheduler_thread = named_thread<AsyncTaskScheduler>;
+}

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -262,9 +262,16 @@ namespace vk
 		bool allow_host_buffers;
 		if (vendor == driver_vendor::NVIDIA)
 		{
-			allow_host_buffers = (chip != chip_class::NV_mobile_kepler) ?
-				test_host_pointer(base_address, expected_length) :
-				false;
+			if (g_cfg.video.vk.asynchronous_texture_streaming)
+			{
+				allow_host_buffers = (chip != chip_class::NV_mobile_kepler) ?
+					test_host_pointer(base_address, expected_length) :
+					false;
+			}
+			else
+			{
+				allow_host_buffers = false;
+			}
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -263,7 +263,7 @@ namespace vk
 		if (vendor == driver_vendor::NVIDIA)
 		{
 			allow_host_buffers = (chip != chip_class::NV_mobile_kepler) ?
-				rsx::get_location(base_address) == CELL_GCM_LOCATION_LOCAL :
+				test_host_pointer(base_address, expected_length) :
 				false;
 		}
 		else

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "../Common/BufferUtils.h"
 #include "../rsx_methods.h"
+
+#include "VKAsyncScheduler.h"
 #include "VKGSRender.h"
 #include "vkutils/buffer_object.h"
 
@@ -959,6 +961,12 @@ void VKGSRender::end()
 	// Load program execution environment
 	load_program_env();
 	m_frame_stats.setup_time += m_profiler.duration();
+
+	// Sync any async scheduler tasks
+	if (auto ev = g_fxo->get<vk::async_scheduler_thread>()->get_primary_sync_label())
+	{
+		ev->gpu_wait(*m_current_command_buffer);
+	}
 
 	if (!m_shader_interpreter.is_interpreter(m_program)) [[likely]]
 	{

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -386,7 +386,7 @@ void VKGSRender::bind_texture_env()
 				//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
 					break;
 				case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
-					ensure(sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst);
+					//ensure(sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst);
 					raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 					break;
 				case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
@@ -526,7 +526,7 @@ void VKGSRender::bind_texture_env()
 		//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
 			break;
 		case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
-			ensure(sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst);
+			//ensure(sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst);
 			raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 			break;
 		case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
@@ -634,7 +634,7 @@ void VKGSRender::bind_interpreter_texture_env()
 					//case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
 					break;
 				case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
-					ensure(sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst);
+					//ensure(sampler_state->upload_context == rsx::texture_upload_context::blit_engine_dst);
 					raw->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 					break;
 				case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -963,7 +963,7 @@ void VKGSRender::end()
 	m_frame_stats.setup_time += m_profiler.duration();
 
 	// Sync any async scheduler tasks
-	if (auto ev = g_fxo->get<vk::async_scheduler_thread>()->get_primary_sync_label())
+	if (auto ev = g_fxo->get<vk::async_scheduler_thread>().get_primary_sync_label())
 	{
 		ev->gpu_wait(*m_current_command_buffer);
 	}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -559,7 +559,7 @@ VKGSRender::~VKGSRender()
 	}
 
 	// Globals. TODO: Refactor lifetime management
-	g_fxo->get<vk::async_scheduler_thread>()->kill();
+	g_fxo->get<vk::async_scheduler_thread>().kill();
 
 	//Wait for device to finish up with resources
 	vkDeviceWaitIdle(*m_device);
@@ -1939,7 +1939,7 @@ void VKGSRender::close_and_submit_command_buffer(vk::fence* pFence, VkSemaphore 
 	const VkBool32 force_flush = !sync_success;
 
 	// Flush any asynchronously scheduled jobs
-	g_fxo->get<vk::async_scheduler_thread>()->flush(force_flush);
+	g_fxo->get<vk::async_scheduler_thread>().flush(force_flush);
 
 	if (vk::test_status_interrupt(vk::heap_dirty))
 	{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1939,7 +1939,7 @@ void VKGSRender::close_and_submit_command_buffer(vk::fence* pFence, VkSemaphore 
 	const VkBool32 force_flush = !sync_success;
 
 	// Flush any asynchronously scheduled jobs
-	g_fxo->get<vk::async_scheduler_thread>()->flush();
+	g_fxo->get<vk::async_scheduler_thread>()->flush(force_flush);
 
 	if (vk::test_status_interrupt(vk::heap_dirty))
 	{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -558,6 +558,9 @@ VKGSRender::~VKGSRender()
 		return;
 	}
 
+	// Globals. TODO: Refactor lifetime management
+	g_fxo->get<vk::async_scheduler_thread>()->kill();
+
 	//Wait for device to finish up with resources
 	vkDeviceWaitIdle(*m_device);
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -68,7 +68,7 @@ namespace vk
 	{
 		upload_contents_async = 1,
 		initialize_image_layout = 2,
-		preserve_image_layout = 3,
+		preserve_image_layout = 4,
 
 		// meta-flags
 		upload_contents_inline = 0,

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -10,6 +10,7 @@ namespace vk
 
 	resource_manager g_resource_manager;
 	atomic_t<u64> g_event_ctr;
+	atomic_t<u64> g_last_completed_event;
 
 	constexpr u64 s_vmm_warn_threshold_size = 2000 * 0x100000; // Warn if allocation on a single heap exceeds this value
 
@@ -28,6 +29,11 @@ namespace vk
 		return g_event_ctr.load();
 	}
 
+	u64 last_completed_event_id()
+	{
+		return g_last_completed_event.load();
+	}
+
 	void on_event_completed(u64 event_id, bool flush)
 	{
 		if (!flush && g_cfg.video.multithreaded_rsx)
@@ -40,6 +46,7 @@ namespace vk
 		}
 
 		g_resource_manager.eid_completed(event_id);
+		g_last_completed_event = std::max(event_id, g_last_completed_event.load());
 	}
 
 	static constexpr f32 size_in_GiB(u64 size)

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -11,6 +11,7 @@ namespace vk
 {
 	u64 get_event_id();
 	u64 current_event_id();
+	u64 last_completed_event_id();
 	void on_event_completed(u64 event_id, bool flush = false);
 
 	struct eid_scope_t

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -1071,6 +1071,13 @@ namespace vk
 		vk::image* real_src = src;
 		vk::image* real_dst = dst;
 
+		if (dst->current_layout == VK_IMAGE_LAYOUT_UNDEFINED)
+		{
+			// Watch out for lazy init
+			ensure(src != dst);
+			dst->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+		}
+
 		// Optimization pass; check for pass-through data transfer
 		if (!xfer_info.flip_horizontal && !xfer_info.flip_vertical && src_area.height() == dst_area.height())
 		{

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -803,7 +803,7 @@ namespace vk
 		const vk::command_buffer* pcmd = nullptr;
 		if (flags & image_upload_options::upload_contents_async)
 		{
-			auto async_cmd = g_fxo->get<vk::async_scheduler_thread>()->get_current();
+			auto async_cmd = g_fxo->get<vk::async_scheduler_thread>().get_current();
 			async_cmd->begin();
 			pcmd = async_cmd;
 

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -1,8 +1,9 @@
 #include "stdafx.h"
-#include "VKHelpers.h"
-#include "VKFormats.h"
+#include "VKAsyncScheduler.h"
 #include "VKCompute.h"
 #include "VKDMA.h"
+#include "VKHelpers.h"
+#include "VKFormats.h"
 #include "VKRenderPass.h"
 #include "VKRenderTargets.h"
 
@@ -800,12 +801,11 @@ namespace vk
 	static const vk::command_buffer& prepare_for_transfer(const vk::command_buffer& primary_cb, vk::image* dst_image, rsx::flags32_t& flags)
 	{
 		const vk::command_buffer* pcmd = nullptr;
-#if 0
 		if (flags & image_upload_options::upload_contents_async)
 		{
-			auto cb = vk::async_transfer_get_current();
-			cb->begin();
-			pcmd = cb;
+			auto async_cmd = g_fxo->get<vk::async_scheduler_thread>()->get_current();
+			async_cmd->begin();
+			pcmd = async_cmd;
 
 			if (!(flags & image_upload_options::preserve_image_layout))
 			{
@@ -813,7 +813,6 @@ namespace vk
 			}
 		}
 		else
-#endif
 		{
 			if (vk::is_renderpass_open(primary_cb))
 			{

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -137,7 +137,7 @@ namespace vk
 		src->pop_layout(cmd);
 
 		// Create event object for this transfer and queue signal op
-		dma_fence = std::make_unique<vk::event>(*m_device);
+		dma_fence = std::make_unique<vk::event>(*m_device, sync_domain::any);
 		dma_fence->signal(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_WRITE_BIT);
 
 		// Set cb flag for queued dma operations

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "VKAsyncScheduler.h"
+#include "VKDMA.h"
 #include "VKRenderTargets.h"
 #include "VKResourceManager.h"
-#include "VKDMA.h"
 #include "vkutils/image_helpers.h"
 
 #include "../Common/texture_cache.h"
@@ -1062,6 +1063,10 @@ namespace vk
 
 			if (cmd.access_hint != vk::command_buffer::access_type_hint::all)
 			{
+				// Flush any pending async jobs in case of blockers
+				// TODO: Context-level manager should handle this logic
+				g_fxo->get<async_scheduler_thread>().flush(VK_TRUE);
+
 				// Primary access command queue, must restart it after
 				vk::fence submit_fence(*m_device);
 				cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, &submit_fence, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_TRUE);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -935,8 +935,11 @@ namespace vk
 				input_swizzled = false;
 			}
 
+			rsx::flags32_t upload_command_flags = initialize_image_layout |
+				(g_cfg.video.vk.asynchronous_texture_streaming? upload_contents_async : upload_contents_inline);
+
 			vk::upload_image(cmd, image, subresource_layout, gcm_format, input_swizzled, mipmaps, image->aspect(),
-				*m_texture_upload_heap, upload_heap_align_default, initialize_image_layout | upload_contents_async);
+				*m_texture_upload_heap, upload_heap_align_default, upload_command_flags);
 
 			vk::leave_uninterruptible();
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -936,7 +936,7 @@ namespace vk
 			}
 
 			vk::upload_image(cmd, image, subresource_layout, gcm_format, input_swizzled, mipmaps, image->aspect(),
-				*m_texture_upload_heap, upload_heap_align_default, initialize_image_layout | upload_contents_inline);
+				*m_texture_upload_heap, upload_heap_align_default, initialize_image_layout | upload_contents_async);
 
 			vk::leave_uninterruptible();
 

--- a/rpcs3/Emu/RSX/VK/vkutils/image.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.cpp
@@ -203,7 +203,7 @@ namespace vk
 		u32 dst_queue = new_queue_family;
 
 		if (current_queue_family == VK_QUEUE_FAMILY_IGNORED)
-		 {
+		{
 			// Implicit acquisition
 			dst_queue = VK_QUEUE_FAMILY_IGNORED;
 		}

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
@@ -122,6 +122,12 @@ namespace vk
 		vkSetEvent(m_device, m_vk_event);
 	}
 
+	void event::gpu_wait(const command_buffer& cmd) const
+	{
+		ensure(m_vk_event);
+		vkCmdWaitEvents(cmd, 1, &m_vk_event, 0, 0, 0, nullptr, 0, nullptr, 0, nullptr);
+	}
+
 	void event::reset() const
 	{
 		if (m_vk_event) [[likely]]

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
@@ -6,6 +6,7 @@
 #include "shared.h"
 
 #include "util/sysinfo.hpp"
+#include "util/asm.hpp"
 
 extern u64 get_system_time();
 
@@ -203,11 +204,11 @@ namespace vk
 			{
 				if (!start)
 				{
-					start = __rdtsc();
+					start = utils::get_tsc();
 					continue;
 				}
 
-				if (const auto now = __rdtsc();
+				if (const auto now = utils::get_tsc();
 					(now > start) &&
 					(now - start) > timeout)
 				{

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -10,6 +10,12 @@ namespace vk
 {
 	class command_buffer;
 
+	enum class sync_domain
+	{
+		any = 0,
+		gpu = 1
+	};
+
 	struct fence
 	{
 		atomic_t<bool> flushed = false;
@@ -35,10 +41,13 @@ namespace vk
 		volatile u32* m_value = nullptr;
 
 	public:
-		event(const render_device& dev);
+		event(const render_device& dev, sync_domain domain);
 		~event();
+
 		void signal(const command_buffer& cmd, VkPipelineStageFlags stages, VkAccessFlags access);
+		void host_signal() const;
 		VkResult status() const;
+		void reset() const;
 	};
 
 	VkResult wait_for_fence(fence* pFence, u64 timeout = 0ull);

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -46,6 +46,7 @@ namespace vk
 
 		void signal(const command_buffer& cmd, VkPipelineStageFlags stages, VkAccessFlags access);
 		void host_signal() const;
+		void gpu_wait(const command_buffer& cmd) const;
 		VkResult status() const;
 		void reset() const;
 	};

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -168,6 +168,8 @@ struct cfg_root : cfg::node
 			cfg::_bool force_fifo{ this, "Force FIFO present mode" };
 			cfg::_bool force_primitive_restart{ this, "Force primitive restart flag" };
 			cfg::_bool force_disable_exclusive_fullscreen_mode{this, "Force Disable Exclusive Fullscreen Mode"};
+			cfg::_bool asynchronous_texture_streaming{ this, "Asynchronous Texture Streaming Placeholder", false, true }; // Placeholder text because it'll have to be updated later
+			cfg::_enum<vk_gpu_scheduler_mode> asynchronous_scheduler{ this, "Asynchronous Queue Scheduler", vk_gpu_scheduler_mode::device };
 
 		} vk{ this };
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -168,7 +168,7 @@ struct cfg_root : cfg::node
 			cfg::_bool force_fifo{ this, "Force FIFO present mode" };
 			cfg::_bool force_primitive_restart{ this, "Force primitive restart flag" };
 			cfg::_bool force_disable_exclusive_fullscreen_mode{this, "Force Disable Exclusive Fullscreen Mode"};
-			cfg::_bool asynchronous_texture_streaming{ this, "Asynchronous Texture Streaming Placeholder", false, true }; // Placeholder text because it'll have to be updated later
+			cfg::_bool asynchronous_texture_streaming{ this, "Asynchronous Texture Streaming", true, true };
 			cfg::_enum<vk_gpu_scheduler_mode> asynchronous_scheduler{ this, "Asynchronous Queue Scheduler", vk_gpu_scheduler_mode::device };
 
 		} vk{ this };

--- a/rpcs3/Emu/system_config_types.cpp
+++ b/rpcs3/Emu/system_config_types.cpp
@@ -421,3 +421,18 @@ void fmt_class_string<audio_downmix>::format(std::string& out, u64 arg)
 		return unknown;
 	});
 }
+
+template <>
+void fmt_class_string<vk_gpu_scheduler_mode>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](vk_gpu_scheduler_mode value)
+	{
+		switch (value)
+		{
+		case vk_gpu_scheduler_mode::host: return "Host";
+		case vk_gpu_scheduler_mode::device: return "Device";
+		}
+
+		return unknown;
+	});
+}

--- a/rpcs3/Emu/system_config_types.h
+++ b/rpcs3/Emu/system_config_types.h
@@ -195,3 +195,9 @@ enum class shader_mode
 	async_with_interpreter,
 	interpreter_only
 };
+
+enum class vk_gpu_scheduler_mode
+{
+	host,
+	device
+};

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Emu\RSX\VK\VKAsyncScheduler.h" />
     <ClInclude Include="Emu\RSX\VK\VKCommandStream.h" />
     <ClInclude Include="Emu\RSX\VK\VKCommonDecompiler.h" />
     <ClInclude Include="Emu\RSX\VK\VKCompute.h" />
@@ -64,6 +65,7 @@
     <ClInclude Include="Emu\RSX\VK\VulkanAPI.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Emu\RSX\VK\VKAsyncScheduler.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKCommandStream.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKCommonDecompiler.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKCompute.cpp" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -64,6 +64,7 @@
     </ClCompile>
     <ClCompile Include="Emu\RSX\VK\VKOverlays.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKCompute.cpp" />
+    <ClCompile Include="Emu\RSX\VK\VKAsyncScheduler.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Emu\RSX\VK\VKCommonDecompiler.h" />
@@ -149,6 +150,7 @@
     <ClInclude Include="Emu\RSX\VK\vkutils\image_helpers.h">
       <Filter>vkutils</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\VKAsyncScheduler.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="vkutils">

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -76,6 +76,8 @@ enum class emu_settings_type
 	VBlankRate,
 	RelaxedZCULL,
 	DriverWakeUpDelay,
+	VulkanAsyncTextureUploads,
+	VulkanAsyncSchedulerDriver,
 
 	// Performance Overlay
 	PerfOverlayEnabled,
@@ -224,6 +226,10 @@ static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::VulkanAdapter,              { "Video", "Vulkan", "Adapter"}},
 	{ emu_settings_type::VBlankRate,                 { "Video", "Vblank Rate"}},
 	{ emu_settings_type::DriverWakeUpDelay,          { "Video", "Driver Wake-Up Delay"}},
+
+	// Vulkan
+	{ emu_settings_type::VulkanAsyncTextureUploads,        { "Video", "Vulkan", "Asynchronous Texture Streaming"}},
+	{ emu_settings_type::VulkanAsyncSchedulerDriver,       { "Video", "Vulkan", "Asynchronous Queue Scheduler"}},
 
 	// Performance Overlay
 	{ emu_settings_type::PerfOverlayEnabled,               { "Video", "Performance Overlay", "Enabled" } },

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -441,8 +441,12 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->gb_resolutionScale->setEnabled(!checked);
 		ui->gb_minimumScalableDimension->setEnabled(!checked);
 		ui->gb_anisotropicFilter->setEnabled(!checked);
+		ui->vulkansched->setEnabled(!checked);
 	};
 	connect(ui->strictModeRendering, &QCheckBox::clicked, this, onStrictRenderingMode);
+
+	m_emu_settings->EnhanceCheckBox(ui->asyncTextureStreaming, emu_settings_type::VulkanAsyncTextureUploads);
+	SubscribeTooltip(ui->asyncTextureStreaming, tooltips.settings.async_texture_streaming);
 
 	// Radio buttons
 
@@ -638,15 +642,20 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	connect(ui->graphicsAdapterBox, &QComboBox::currentTextChanged, set_adapter);
 	connect(ui->renderBox, &QComboBox::currentTextChanged, set_renderer);
 
-	auto fix_gl_legacy = [=, this](const QString& text)
+	auto apply_renderer_specific_options = [=, this](const QString& text)
 	{
+		// OpenGL-only
 		ui->glLegacyBuffers->setEnabled(text == r_creator->OpenGL.name);
+
+		// Vulkan-only
+		ui->asyncTextureStreaming->setEnabled(text == r_creator->Vulkan.name);
+		ui->vulkansched->setEnabled(text == r_creator->Vulkan.name);
 	};
 
 	// Handle connects to disable specific checkboxes that depend on GUI state.
 	onStrictRenderingMode(ui->strictModeRendering->isChecked());
-	fix_gl_legacy(ui->renderBox->currentText()); // Init
-	connect(ui->renderBox, &QComboBox::currentTextChanged, fix_gl_legacy);
+	apply_renderer_specific_options(ui->renderBox->currentText()); // Init
+	connect(ui->renderBox, &QComboBox::currentTextChanged, apply_renderer_specific_options);
 
 	//                      _ _         _______    _
 	//       /\            | (_)       |__   __|  | |
@@ -982,6 +991,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	m_emu_settings->EnhanceComboBox(ui->sleepTimersAccuracy, emu_settings_type::SleepTimersAccuracy);
 	SubscribeTooltip(ui->gb_sleep_timers_accuracy, tooltips.settings.sleep_timers_accuracy);
+
+	m_emu_settings->EnhanceComboBox(ui->vulkansched, emu_settings_type::VulkanAsyncSchedulerDriver);
+	SubscribeTooltip(ui->gb_vulkansched, tooltips.settings.vulkan_async_scheduler);
 
 	// Sliders
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>753</width>
-    <height>650</height>
+    <height>730</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -39,7 +39,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>6</number>
      </property>
      <widget class="QWidget" name="coreTab">
       <attribute name="title">
@@ -758,6 +758,13 @@
                <widget class="QCheckBox" name="multithreadedRSX">
                 <property name="text">
                  <string>Multithreaded RSX</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="asyncTextureStreaming">
+                <property name="text">
+                 <string>Asynchronous Texture Streaming</string>
                 </property>
                </widget>
               </item>
@@ -2061,6 +2068,25 @@
              </layout>
             </widget>
            </item>
+		   <item>
+		    <widget class="QGroupBox" name="gb_vulkansched">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="title">
+              <string>Vulkan Queue Scheduler</string>
+             </property>
+             <layout class="QVBoxLayout" name="gb_vksched_layout">
+              <item>
+               <widget class="QComboBox" name="vulkansched">
+               </widget>
+              </item>
+             </layout>
+            </widget>
+		   </item>
            <item>
             <widget class="QGroupBox" name="gb_wakeupDelay">
              <property name="sizePolicy">
@@ -2200,8 +2226,8 @@
              </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>0</width>
-               <height>0</height>
+               <width>13</width>
+               <height>13</height>
               </size>
              </property>
             </spacer>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -37,6 +37,7 @@ public:
 		const QString clocks_scale                 = tr("Changes the scale of emulated system time.\nAffects software which uses system time to calculate things such as dynamic timesteps.");
 		const QString wake_up_delay                = tr("Try fiddling with this setting when encountering unstable games. The higher value, the better stability it may provide.\nIncrements/Decrements for each test should be around 100μs to 200μs until finding the best value for optimal stability.\nValues above 1000μs may cause noticeable performance penalties, use with caution.");
 		const QString disabled_from_global         = tr("Do not change this setting globally.\nRight-click the game in game list and choose \"Configure\" instead.");
+		const QString vulkan_async_scheduler       = tr("Determines how to schedule GPU async compute jobs when using asynchronous streaming.\nUse 'Host' mode for more spec compliant behavior at the cost of CPU overhead.\nUse 'Device' to let your driver handle this. Beware that 'device' mode technically violates official spec but is the superior option.");
 
 		// audio
 
@@ -158,6 +159,8 @@ public:
 		const QString async_with_shader_interpreter   = tr("Hybrid rendering mode.\nIf a shader is not found in the cache, the interpreter will be used to render approximated graphics for this shader until it has compiled.");
 		const QString shader_interpreter_only         = tr("All rendering is handled by the interpreter with no attempt to compile native shaders.\nThis mode is very slow and experimental.");
 		const QString shader_compiler_threads         = tr("Number of threads to use for the shader compiler backend.\nOnly has an impact when shader mode is set to one of the asynchronous modes.");
+
+		const QString async_texture_streaming         = tr("Stream textures to GPU in parallel with 3D rendering.\nCan improve performance on more powerful GPUs that have spare headroom.\nOnly works with Vulkan renderer.");
 
 		// gui
 


### PR DESCRIPTION
Adds remaining pieces for separate upload path vs 3D rendering. Disabled by default as it still needs to be tuned.
Since passthrough DMA is fixed on NVIDIA when not using separate paths, this technically solves the NVIDIA DMA regressions but probably costs some performance.