### PR TITLE
stylesheets: fix debugger instr coloring (and then some)

### DIFF
--- a/bin/GuiConfigs/Envy.qss
+++ b/bin/GuiConfigs/Envy.qss
@@ -628,3 +628,12 @@ QLabel#tty_text {
 	color: #f8f8f8;
 }
 
+/* Debugger colors */
+QLabel#debugger_frame_breakpoint {
+	color: #000; /* Font Color: Black */
+	background-color: #ffff00; /* Yellow */
+}
+QLabel#debugger_frame_pc {
+	color: #000; /* Font Color: Black */
+	background-color: #00ff00; /* Green */
+}

--- a/bin/GuiConfigs/Skyline (Nightfall).qss
+++ b/bin/GuiConfigs/Skyline (Nightfall).qss
@@ -650,3 +650,12 @@ QLabel#thumbnail_icon_color {
 	color: #370048;
 }
 
+/* Debugger colors */
+QLabel#debugger_frame_breakpoint {
+	color: #000; /* Font Color: Black */
+	background-color: #ffff00; /* Yellow */
+}
+QLabel#debugger_frame_pc {
+	color: #000; /* Font Color: Black */
+	background-color: #00ff00; /* Green */
+}

--- a/bin/GuiConfigs/Skyline.qss
+++ b/bin/GuiConfigs/Skyline.qss
@@ -648,7 +648,7 @@ QLabel#log_level_warning {
 }
 
 QLabel#log_level_notice {
-	color: #FFFFFF;
+	color: #455971;
 }
 
 QLabel#log_level_trace {
@@ -669,3 +669,12 @@ QLabel#thumbnail_icon_color {
 	color: #8500ae;
 }
 
+/* Debugger colors */
+QLabel#debugger_frame_breakpoint {
+	color: #000; /* Font Color: Black */
+	background-color: #ffff00; /* Yellow */
+}
+QLabel#debugger_frame_pc {
+	color: #000; /* Font Color: Black */
+	background-color: #00ff00; /* Green */
+}


### PR DESCRIPTION
Corrects the missing color highlights from the currently executing instruction and the breakpoints. Affected stylesheets are `Envy`, `Skyline`, and `Skyline (Skyfall)`. Also fixes the notice-level log message color in the `Skyline` theme.

Fixes #9930