### PR TITLE
Workaround segfaults in Vulkan enumeration thread

### DIFF
--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -87,7 +87,7 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 	{
 		supports_vulkan = device_found;
 		vulkan_adapters = std::move(compatible_gpus);
-		enum_thread->join();
+		enum_thread->operator()();
 		delete enum_thread;
 	}
 #endif

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -61,7 +61,7 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 		cond.notify_all();
 	});
 
-	std::unique_ptr<decltype(enum_thread_v)> enum_thread(enum_thread_v);
+	std::unique_ptr<decltype(*enum_thread_v)> enum_thread(enum_thread_v);
 	{
 		std::unique_lock lck(mtx);
 		cond.wait_for(lck, std::chrono::seconds(10), [&] { return !thread_running; });

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -61,7 +61,7 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 		cond.notify_all();
 	});
 
-	std::unique_ptr<decltype(*enum_thread_v)> enum_thread(enum_thread_v);
+	std::unique_ptr<std::remove_pointer_t<decltype(enum_thread_v)>> enum_thread(enum_thread_v);
 	{
 		std::unique_lock lck(mtx);
 		cond.wait_for(lck, std::chrono::seconds(10), [&] { return !thread_running; });

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -36,7 +36,7 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 
 	static QStringList compatible_gpus;
 
-	std::thread enum_thread = std::thread([&]
+	auto enum_thread = new named_thread("Vulkan Device Enumeration Thread"sv, [&]()
 	{
 		thread_ctrl::scoped_priority low_prio(-1);
 
@@ -75,7 +75,6 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 				"Selecting ignore starts the emulator without Vulkan support."),
 			QMessageBox::Ignore | QMessageBox::Abort, QMessageBox::Abort);
 
-		enum_thread.detach();
 		if (button != QMessageBox::Ignore)
 		{
 			abort_requested = true;
@@ -88,7 +87,8 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 	{
 		supports_vulkan = device_found;
 		vulkan_adapters = std::move(compatible_gpus);
-		enum_thread.join();
+		enum_thread->join();
+		delete enum_thread;
 	}
 #endif
 

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -87,7 +87,7 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 	{
 		supports_vulkan = device_found;
 		vulkan_adapters = std::move(compatible_gpus);
-		enum_thread->operator()();
+		(*enum_thread)();
 		delete enum_thread;
 	}
 #endif

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -87,8 +87,7 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 	{
 		supports_vulkan = device_found;
 		vulkan_adapters = std::move(compatible_gpus);
-		(*enum_thread)();
-		delete enum_thread;
+		delete enum_thread; // Join thread
 	}
 #endif
 


### PR DESCRIPTION
Do not terminate RPCS3, set vulkan flag to unsupported state.
When Vulkan is not working properly due to faulty drivers a segfault can happen in Vulkan code, so fallback to openGL.
See https://discord.com/channels/272035812277878785/277227681836302338/818756194135048213