### PR TITLE
Overlays: Implement individual element pulse

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLOverlays.cpp
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.cpp
@@ -1,7 +1,5 @@
 #include "GLOverlays.h"
 
-extern u64 get_system_time();
-
 namespace gl
 {
 	void overlay_pass::create()
@@ -514,12 +512,11 @@ namespace gl
 	{
 		program_handle.uniforms["viewport"] = color4f(static_cast<f32>(viewport.width()), static_cast<f32>(viewport.height()), static_cast<f32>(viewport.x1), static_cast<f32>(viewport.y1));
 		program_handle.uniforms["ui_scale"] = color4f(static_cast<f32>(ui.virtual_width), static_cast<f32>(ui.virtual_height), 1.f, 1.f);
-		program_handle.uniforms["time"] = static_cast<f32>(get_system_time() / 1000) * 0.005f;
 
 		saved_sampler_state save_30(30, m_sampler);
 		saved_sampler_state save_31(31, m_sampler);
 
-		for (auto &cmd : ui.get_compiled().draw_commands)
+		for (auto& cmd : ui.get_compiled().draw_commands)
 		{
 			set_primitive_type(cmd.config.primitives);
 			upload_vertex_data(cmd.verts.data(), ::size32(cmd.verts));
@@ -530,7 +527,7 @@ namespace gl
 			{
 			case rsx::overlays::image_resource_id::game_icon:
 			case rsx::overlays::image_resource_id::backbuffer:
-				//TODO
+				// TODO
 			case rsx::overlays::image_resource_id::none:
 			{
 				texture_read = GL_FALSE;
@@ -557,6 +554,7 @@ namespace gl
 			}
 			}
 
+			program_handle.uniforms["time"] = cmd.config.get_sinus_value();
 			program_handle.uniforms["color"] = cmd.config.color;
 			program_handle.uniforms["sampler_mode"] = texture_read;
 			program_handle.uniforms["pulse_glow"] = static_cast<s32>(cmd.config.pulse_glow);

--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
@@ -31,6 +31,8 @@ namespace rsx
 
 		void edit_text::move_caret(direction dir)
 		{
+			m_reset_caret_pulse = true;
+
 			switch (dir)
 			{
 			case direction::left:
@@ -112,6 +114,7 @@ namespace rsx
 			}
 
 			caret_position += ::narrow<u16>(str.length());
+			m_reset_caret_pulse = true;
 			refresh();
 		}
 
@@ -136,6 +139,7 @@ namespace rsx
 			}
 
 			caret_position--;
+			m_reset_caret_pulse = true;
 			refresh();
 		}
 
@@ -154,6 +158,13 @@ namespace rsx
 				caret.fore_color           = fore_color;
 				caret.back_color           = fore_color;
 				caret.pulse_effect_enabled = true;
+
+				if (m_reset_caret_pulse)
+				{
+					// Reset the pulse slightly below 1 rising on each user interaction
+					caret.set_sinus_offset(1.6f);
+					m_reset_caret_pulse = false;
+				}
 
 				compiled.add(caret.get_compiled());
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_list_view.cpp
@@ -108,10 +108,17 @@ namespace rsx
 		{
 			const s32 max_entry = m_elements_count - 1;
 
+			// Reset the pulse slightly below 1 rising on each user interaction
+			m_highlight_box->set_sinus_offset(1.6f);
+
 			if (m_selected_entry != entry)
 			{
 				m_selected_entry = std::max(0, std::min(entry, max_entry));
 				update_selection();
+			}
+			else
+			{
+				refresh();
 			}
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -66,6 +66,9 @@ namespace rsx
 			// Fade in/out
 			animation_color_interpolate fade_animation;
 
+			bool m_reset_pulse = false;
+			overlay_element m_key_pulse_cache; // Let's use this to store the pulse offset of the key, since we don't seem to cache the keys themselves.
+
 			bool m_update = true;
 			compiled_resource m_cached_resource;
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -84,7 +84,6 @@ namespace rsx
 		public:
 			s32 return_code = 0; // CELL_OK
 
-		public:
 			void update() override {}
 
 			compiled_resource get_compiled() override = 0;

--- a/rpcs3/Emu/RSX/VK/VKOverlays.cpp
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.cpp
@@ -715,7 +715,6 @@ namespace vk
 			vk::data_heap& upload_heap, rsx::overlays::overlay& ui)
 	{
 		m_scale_offset = color4f(ui.virtual_width, ui.virtual_height, 1.f, 1.f);
-		m_time = static_cast<f32>(get_system_time() / 1000) * 0.005f;
 		m_viewport = { { static_cast<f32>(viewport.x1), static_cast<f32>(viewport.y1) }, { static_cast<f32>(viewport.width()), static_cast<f32>(viewport.height()) } };
 
 		std::vector<vk::image_view*> image_views
@@ -731,6 +730,7 @@ namespace vk
 			upload_vertex_data(command.verts.data(), num_drawable_elements);
 			set_primitive_type(command.config.primitives);
 
+			m_time = command.config.get_sinus_value();
 			m_skip_texture_read = false;
 			m_color = command.config.color;
 			m_pulse_glow = command.config.pulse_glow;


### PR DESCRIPTION
Currently, the pulse in the native UI is continuous and provides a rather bad user experience.
Sometimes it's hard to see that you selected a different element if the pulse glow is currently at 0.

This PR improves this behaviour by immediately highlighting the current element after a user interaction.

Technically this is achieved by resetting the sinus curve, using an individual offset for each element.
The offset is calculated with the current time and a hardcoded speed modifier.
The sinus reset values are kinda half assed and it would probably be easier to understand if we use cos.
Since the time is taken twice (once when setting the offset and once when drawing the elements) it won't be 100% accurate, but this should not be noticeable by any human being.

This affects the
- **OSK keys**
- **OSK cursor/caret**
- **Save dialog entries**