### PR TITLE
Move the chip var to the ifdef block

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -256,7 +256,7 @@ namespace vk
 	void create_dma_block(std::unique_ptr<dma_block>& block, u32 base_address, usz expected_length)
 	{
 		const auto vendor = g_render_device->gpu().get_driver_vendor();
-		const auto chip  = g_render_device->gpu().get_chip_class();
+		[[maybe_unused]] const auto chip  = g_render_device->gpu().get_chip_class();
 
 #ifdef _WIN32
 		bool allow_host_buffers;


### PR DESCRIPTION
Var chip is only used in the WIN32 ifdef block
move it there to silence the compiler warning 'bout
unused variable.