### PR TITLE
Fix sysutil_send_system_cmd at Emu.Stop()

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -57,13 +57,13 @@ extern void sysutil_register_cb(std::function<s32(ppu_thread&)>&& cb)
 
 extern void sysutil_send_system_cmd(u64 status, u64 param)
 {
-	if (auto& cbm = g_fxo->get<sysutil_cb_manager>(); g_fxo->is_init<sysutil_cb_manager>() && !Emu.IsStopped())
+	if (auto cbm = g_fxo->try_get<sysutil_cb_manager>())
 	{
-		for (sysutil_cb_manager::registered_cb cb : cbm.callbacks)
+		for (sysutil_cb_manager::registered_cb cb : cbm->callbacks)
 		{
 			if (cb.first)
 			{
-				cbm.registered.push([=](ppu_thread& ppu) -> s32
+				cbm->registered.push([=](ppu_thread& ppu) -> s32
 				{
 					// TODO: check it and find the source of the return value (void isn't equal to CELL_OK)
 					cb.first(ppu, status, param, cb.second);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1373,6 +1373,11 @@ void main_window::OnEmuStop()
 	}
 	ui->actionManage_Users->setEnabled(true);
 
+	if (std::exchange(m_sys_menu_opened, false))
+	{
+		ui->sysSendOpenMenuAct->setText(tr("Send open system menu cmd"));
+	}
+
 	// Refresh game list in order to update time played
 	if (m_game_list_frame)
 	{
@@ -1781,15 +1786,19 @@ void main_window::CreateConnects()
 	connect(ui->sysStopAct, &QAction::triggered, [this]() { Emu.Stop(); });
 	connect(ui->sysRebootAct, &QAction::triggered, [this]() { Emu.Restart(); });
 
-	connect(ui->sysSendOpenMenuAct, &QAction::triggered, [this]()
+	connect(ui->sysSendOpenMenuAct, &QAction::triggered, this, [this]()
 	{
+		if (Emu.IsStopped()) return;
+
 		sysutil_send_system_cmd(m_sys_menu_opened ? 0x0132 /* CELL_SYSUTIL_SYSTEM_MENU_CLOSE */ : 0x0131 /* CELL_SYSUTIL_SYSTEM_MENU_OPEN */, 0);
-		m_sys_menu_opened = !m_sys_menu_opened;
+		m_sys_menu_opened ^= true;
 		ui->sysSendOpenMenuAct->setText(tr("Send &%0 system menu cmd").arg(m_sys_menu_opened ? tr("close") : tr("open")));
 	});
 
-	connect(ui->sysSendExitAct, &QAction::triggered, [this]()
+	connect(ui->sysSendExitAct, &QAction::triggered, this, []()
 	{
+		if (Emu.IsStopped()) return;
+
 		sysutil_send_system_cmd(0x0101 /* CELL_SYSUTIL_REQUEST_EXITGAME */, 0);
 	});
 


### PR DESCRIPTION
## Bugfixes

* When Emu.Stop() is called by GUI thread, PPU threads should still be able to send sysutil events.
* Reset main_window::m_sys_menu_opened at Emu.Stop().
* When sysutil_cb_manager is not initialized in FXO, sysutil_send_system_cmd would invoke UB.