### PR TITLE
debugger: Fix PPU threads pausing

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1333,6 +1333,11 @@ bool lv2_obj::awake_unlocked(cpu_thread* cpu, s32 prio)
 		{
 			ppu_log.trace("suspend(): %s", target->id);
 			g_pending.emplace_back(target);
+
+			if (is_paused(target->state - cpu_flag::suspend))
+			{
+				target->state.notify_one(cpu_flag::suspend);
+			}
 		}
 	}
 


### PR DESCRIPTION
* Previously, when a PPU thread was paused by the debugger, it could not process PPU scheduler events properly. As a result when pausing a single PPU *which was running* all other PPUs were stopped as well which is not intended.