### PR TITLE
Make gamedata installation truly atomic as real PS3

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysCache.cpp
@@ -81,7 +81,7 @@ struct syscache_info
 		{
 			idm::select<lv2_fs_object, lv2_file>([](u32 /*id*/, lv2_file& file)
 			{
-				if (std::memcmp("/dev_hdd1", file.name.data(), 9) == 0)
+				if (file.file && std::memcmp("/dev_hdd1/", file.name.data(), 10) == 0)
 				{
 					file.lock = 2;
 				}

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -101,6 +101,13 @@ error_code sys_overlay_load_module_by_fd(vm::ptr<u32> ovlmid, u32 fd, u64 offset
 		return CELL_EBADF;
 	}
 
+	std::lock_guard lock(file->mp->mutex);
+
+	if (!file->file)
+	{
+		return CELL_EBADF;
+	}
+
 	return overlay_load_module(ovlmid, fmt::format("%s_x%x", file->name.data(), offset), flags, entry, lv2_file::make_view(file, offset));
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -311,6 +311,13 @@ error_code _sys_prx_load_module_by_fd(ppu_thread& ppu, s32 fd, u64 offset, u64 f
 		return CELL_EBADF;
 	}
 
+	std::lock_guard lock(file->mp->mutex);
+
+	if (!file->file)
+	{
+		return CELL_EBADF;
+	}
+
 	return prx_load_module(fmt::format("%s_x%x", file->name.data(), offset), flags, pOpt, lv2_file::make_view(file, offset));
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1989,7 +1989,7 @@ error_code raw_spu_destroy(ppu_thread& ppu, u32 id)
 
 	(*thread)();
 
-	if (idm::withdraw<named_thread<spu_thread>>(idm_id, [&](spu_thread& spu) -> CellError
+	if (auto ret = idm::withdraw<named_thread<spu_thread>>(idm_id, [&](spu_thread& spu) -> CellError
 	{
 		if (std::addressof(spu) != std::addressof(*thread))
 		{
@@ -1998,7 +1998,7 @@ error_code raw_spu_destroy(ppu_thread& ppu, u32 id)
 
 		spu.cleanup();
 		return {};
-	}).ret)
+	}); !ret || ret.ret)
 	{
 		// Other thread destroyed beforehead
 		return CELL_ESRCH;


### PR DESCRIPTION
## Bugfixes
* Much alike the fixes in #9819, commit gamedata directory creation with its contents atomically by flushing contents to disk before rename.
Just here there is a catch, in Win32 path I inserted the sync() inside sys_fs for gamedata write operations. I've read you can achieve similar action an POSIX's syncfs by passing a file handle to a volume to FlushFileBuffers but only with Admin rights. I wonder if we can workaround that in the future.

* ~~Fix sys_fs_fsync and sys_fs_fdatasync for read-only filesystems such as /dev_bdvd, do not crash, return an error as it should.~~
