### PR TITLE
GUI: Handle uppercase RAP file extension

### DIFF
--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -1335,7 +1335,12 @@ bool SELFDecrypter::GetKeyFromRap(u8* content_id, u8* npdrm_key)
 	}
 
 	self_log.notice("Loading RAP file %s.rap", ci_str);
-	rap_file.read(rap_key, 0x10);
+
+	if (rap_file.read(rap_key, 0x10) != 0x10)
+	{
+		self_log.fatal("Failed to load %s: RAP file exists but is invalid. Try reinstalling it.", rap_path);
+		return false;
+	}
 
 	// Convert the RAP key.
 	rap_to_rif(rap_key, npdrm_key);

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -557,7 +557,7 @@ error_code sceNpDrmVerifyUpgradeLicense(vm::cptr<char> content_id)
 
 	sceNp.warning(u8"sceNpDrmVerifyUpgradeLicense(): content_id=“%s”", content_id);
 
-	if (!fs::is_file(vfs::get("/dev_hdd0/home/" + Emu.GetUsr() + "/exdata/" + content_str + ".rap")))
+	if (fs::stat_t s{}; !fs::stat(vfs::get("/dev_hdd0/home/" + Emu.GetUsr() + "/exdata/" + content_str + ".rap"), s) || s.is_directory || s.size < 0x10)
 	{
 		// Game hasn't been purchased therefore no RAP file present
 		return SCE_NP_DRM_ERROR_LICENSE_NOT_FOUND;
@@ -580,7 +580,7 @@ error_code sceNpDrmVerifyUpgradeLicense2(vm::cptr<char> content_id)
 
 	sceNp.warning(u8"sceNpDrmVerifyUpgradeLicense2(): content_id=“%s”", content_id);
 
-	if (!fs::is_file(vfs::get("/dev_hdd0/home/" + Emu.GetUsr() + "/exdata/" + content_str + ".rap")))
+	if (fs::stat_t s{}; !fs::stat(vfs::get("/dev_hdd0/home/" + Emu.GetUsr() + "/exdata/" + content_str + ".rap"), s) || s.is_directory || s.size < 0x10)
 	{
 		// Game hasn't been purchased therefore no RAP file present
 		return SCE_NP_DRM_ERROR_LICENSE_NOT_FOUND;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -515,7 +515,8 @@ bool main_window::InstallRapFile(const QString& path, const std::string& filenam
 	{
 		return false;
 	}
-	return fs::copy_file(sstr(path), Emulator::GetHddDir() + "/home/" + Emu.GetUsr() + "/exdata/" + filename, true);
+
+	return fs::copy_file(sstr(path), Emulator::GetHddDir() + "/home/" + Emu.GetUsr() + "/exdata/" + filename.substr(0, filename.find_last_of('.')) + ".rap", true);
 }
 
 void main_window::InstallPackages(QStringList file_paths)
@@ -585,7 +586,7 @@ void main_window::InstallPackages(QStringList file_paths)
 	}
 
 	// Install rap files if available
-	for (const auto& rap : file_paths.filter(QRegExp(".*\\.rap")))
+	for (const auto& rap : file_paths.filter(QRegExp(".*\\.rap", Qt::CaseInsensitive)))
 	{
 		const QFileInfo file_info(rap);
 		const std::string rapname = sstr(file_info.fileName());
@@ -2566,7 +2567,7 @@ main_window::drop_type main_window::IsValidFile(const QMimeData& md, QStringList
 
 			drop_type = drop_type::drop_pkg;
 		}
-		else if (info.suffix() == "rap")
+		else if (info.suffix().toLower() == "rap")
 		{
 			if (drop_type != drop_type::drop_rap && drop_type != drop_type::drop_error)
 			{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2549,7 +2549,7 @@ main_window::drop_type main_window::IsValidFile(const QMimeData& md, QStringList
 
 			drop_type = drop_type::drop_dir;
 		}
-		else if (info.fileName() == "PS3UPDAT.PUP")
+		else if (info.suffix() == "PUP")
 		{
 			if (list.size() != 1)
 			{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2587,7 +2587,7 @@ main_window::drop_type main_window::IsValidFile(const QMimeData& md, QStringList
 		}
 		else if (info.suffix().toLower() == "rap")
 		{
-			if (drop_type != drop_type::drop_rap && drop_type != drop_type::drop_error)
+			if (info.size() < 0x10 || (drop_type != drop_type::drop_rap && drop_type != drop_type::drop_error))
 			{
 				return drop_type::drop_error;
 			}


### PR DESCRIPTION
* When attempting to either drap-and-drop or install uppercase RAP files from menu, detect it as RAP file (instead of trying to execute it as a PS3 executable) and rename extension to be lowercase ".rap" automatically.
This is a quality of life improvement. Especially on Windows which on atleast on my Windows 10 and exFAT does not let me rename files if the only difference with its new filename is its characters' case, probably a broken "optimization" of File Explorer which attempts to detect same name before rename and avoids rename is such case. FYI to workaround this bug of File Explorer you need to rename the file to something different (so characters case would not be the only difference) and only then rename it to the final name.

* Handle all PUP files in drag-and-drop, not just PS3UPFDAT.PUP. This is useful for when you have multiple PUP files in a folder (e.g. for different fw versions) such as "PS3UPDAT (1).PUP". There is no much sense in blocking other PUP files, even if its a file meant for other uses for other programs because our PUP loader's error checking is superb.

* Install RAP files atomically, ensure that its contents won't be corrupt if the source file was valid to begin with.

* Detect illegal RAP files, log an error about it as well. Such as if the user attempts to create an empty RAP file.