### PR TITLE
Qt: Import Custom Shader Loading Icons

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -71,6 +71,22 @@ namespace rsx
 						background_poster.set_size(1280, 720);
 						background_poster.set_raw_image(background_image.get());
 						background_poster.set_blur_strength(static_cast<u8>(g_cfg.video.shader_preloading_dialog.blur_strength));
+
+						ensure(background_image->w > 0);
+						ensure(background_image->h > 0);
+						ensure(background_poster.h > 0);
+
+						// Set padding in order to keep the aspect ratio
+						if ((background_image->w / static_cast<double>(background_image->h)) > (background_poster.w / static_cast<double>(background_poster.h)))
+						{
+							const int padding = (background_poster.h - (background_image->h * (background_poster.w / static_cast<double>(background_image->w)))) / 2;
+							background_poster.set_padding(0, 0, padding, padding);
+						}
+						else
+						{
+							const int padding = (background_poster.w - (background_image->w * (background_poster.h / static_cast<double>(background_image->h)))) / 2;
+							background_poster.set_padding(padding, padding, 0, 0);
+						}
 					}
 				}
 			}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1115,12 +1115,12 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 			if (QFile::exists(icon_path))
 			{
 				actions[static_cast<int>(icon_action::add)]->setVisible(false);
-				connect(actions[static_cast<int>(icon_action::replace)], &QAction::triggered, this, [handle_icon, icon_path, type] { handle_icon(icon_path, icon_action::replace, type); });
-				connect(actions[static_cast<int>(icon_action::remove)], &QAction::triggered, this, [handle_icon, icon_path, type] { handle_icon(icon_path, icon_action::remove, type); });
+				connect(actions[static_cast<int>(icon_action::replace)], &QAction::triggered, this, [handle_icon, icon_path, t = type] { handle_icon(icon_path, icon_action::replace, t); });
+				connect(actions[static_cast<int>(icon_action::remove)], &QAction::triggered, this, [handle_icon, icon_path, t = type] { handle_icon(icon_path, icon_action::remove, t); });
 			}
 			else
 			{
-				connect(actions[static_cast<int>(icon_action::add)], &QAction::triggered, this, [handle_icon, icon_path, type] { handle_icon(icon_path, icon_action::add, type); });
+				connect(actions[static_cast<int>(icon_action::add)], &QAction::triggered, this, [handle_icon, icon_path, t = type] { handle_icon(icon_path, icon_action::add, t); });
 				actions[static_cast<int>(icon_action::replace)]->setVisible(false);
 				actions[static_cast<int>(icon_action::remove)]->setEnabled(false);
 			}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1812,19 +1812,20 @@ QPixmap game_list_frame::PaintedPixmap(QPixmap icon, bool paint_config_icon, boo
 	// Calculate the centered size and position of the icon on our canvas.
 	if (icon.width() != 320 || icon.height() != 176)
 	{
+		ensure(icon.height() > 0);
 		constexpr double target_ratio = 320.0 / 176.0; // aspect ratio 20:11
 
-		if (canvas_size.width() > canvas_size.height())
+		if ((icon.width() / static_cast<double>(icon.height())) > target_ratio)
 		{
-			canvas_size.setHeight(icon.width() / target_ratio);
+			canvas_size.setHeight(std::ceil(icon.width() * target_ratio));
 		}
 		else
 		{
-			canvas_size.setWidth(icon.height() * target_ratio);
+			canvas_size.setWidth(std::ceil(icon.height() * target_ratio));
 		}
 
-		target_pos.setX((canvas_size.width() - icon.width()) / 2.0);
-		target_pos.setY((canvas_size.height() - icon.height()) / 2.0);
+		target_pos.setX(std::max<int>(0, (canvas_size.width() - icon.width()) / 2.0));
+		target_pos.setY(std::max<int>(0, (canvas_size.height() - icon.height()) / 2.0));
 	}
 
 	// Create a canvas large enough to fit our entire scaled icon


### PR DESCRIPTION
and refactor icon import.

- fixes aspect ratio of shader loading backgrounds
- fixes game icon canvas size. The calculations were wrong:

![image](https://user-images.githubusercontent.com/23019877/111063613-fa650600-84af-11eb-975c-f2db147de39f.png)
