### PR TITLE
Improve fs::container_stream::write

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -701,17 +701,23 @@ namespace fs
 				xovfl();
 			}
 
-			if (pos + size > old_size)
+			if (pos > old_size)
 			{
+			 	// Reserve memory
+				obj.reserve(pos + size);
+
 				// Fill gap if necessary (default-initialized)
-				obj.resize(pos + size);
+				obj.resize(pos);
 			}
 
 			const auto src = static_cast<const value_type*>(buffer);
 
 			// Overwrite existing part
-			std::copy(src, src + size, obj.begin() + pos);
+			const u64 overlap = pos >= old_size ? 0 : std::min<u64>(old_size - pos, size);
+			std::copy(src, src + overlap, obj.begin() + pos);
 
+			// Append new data
+			obj.insert(obj.end(), src + overlap, src + size);
 			pos += size;
 
 			return size;

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -713,7 +713,7 @@ namespace fs
 			const auto src = static_cast<const value_type*>(buffer);
 
 			// Overwrite existing part
-			const u64 overlap = pos >= old_size ? 0 : std::min<u64>(old_size - pos, size);
+			const u64 overlap = std::min<u64>(obj.size() - pos, size);
 			std::copy(src, src + overlap, obj.begin() + pos);
 
 			// Append new data

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -696,25 +696,22 @@ namespace fs
 		{
 			const u64 old_size = obj.size();
 
-			if (old_size + size < old_size)
+			if (old_size + size < old_size || pos + size < pos)
 			{
 				xovfl();
 			}
 
-			if (pos > old_size)
+			if (pos + size > old_size)
 			{
 				// Fill gap if necessary (default-initialized)
-				obj.resize(pos);
+				obj.resize(pos + size);
 			}
 
 			const auto src = static_cast<const value_type*>(buffer);
 
 			// Overwrite existing part
-			const u64 overlap = std::min<u64>(obj.size() - pos, size);
-			std::copy(src, src + overlap, obj.begin() + pos);
+			std::copy(src, src + size, obj.begin() + pos);
 
-			// Append new data
-			obj.insert(obj.end(), src + overlap, src + size);
 			pos += size;
 
 			return size;


### PR DESCRIPTION
* If pos() is greater than size at the time of writing, allocate new memory only once instead of twice.