### PR TITLE
Qt: Remove unused GUI entries when saving a config

### DIFF
--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -174,10 +174,12 @@ void emu_settings::LoadSettings(const std::string& title_id)
 	}
 }
 
-void emu_settings::ValidateSettings()
+bool emu_settings::ValidateSettings(bool cleanup)
 {
-	std::function<void(int, const YAML::Node&, std::vector<std::string>&, cfg::_base*)> search_level;
-	search_level = [&search_level](int level, const YAML::Node& yml_node, std::vector<std::string>& keys, cfg::_base* cfg_base)
+	bool is_clean = true;
+
+	std::function<void(int, YAML::Node&, std::vector<std::string>&, cfg::_base*)> search_level;
+	search_level = [&search_level, &is_clean, &cleanup, this](int level, YAML::Node& yml_node, std::vector<std::string>& keys, cfg::_base* cfg_base)
 	{
 		if (!yml_node || !yml_node.IsMap())
 		{
@@ -208,30 +210,59 @@ void emu_settings::ValidateSettings()
 
 			if (cfg_node)
 			{
-				search_level(next_level, yml_node[key], keys, cfg_node);
+				YAML::Node next_node = yml_node[key];
+				search_level(next_level, next_node, keys, cfg_node);
 			}
 			else
 			{
-				std::string key;
-				for (usz i = 0; i < keys.size(); i++)
+				const auto get_full_key = [&keys](const std::string& seperator) -> std::string
 				{
-					key += keys[i];
-					if (i < keys.size() - 1) key += ": ";
+					std::string full_key;
+					for (usz i = 0; i < keys.size(); i++)
+					{
+						full_key += keys[i];
+						if (i < keys.size() - 1) full_key += seperator;
+					}
+					return full_key;
+				};
+
+				is_clean = false;
+
+				if (cleanup)
+				{
+					if (!yml_node.remove(key))
+					{
+						cfg_log.error("Could not remove config entry: %s", get_full_key(": "));
+						is_clean = true; // abort
+						return;
+					}
+
+					// Let's only remove one entry at a time. I got some weird issues when doing all at once.
+					return;
 				}
-				cfg_log.warning("Unknown config entry found: %s", key);
+				else
+				{
+					cfg_log.warning("Unknown config entry found: %s", get_full_key(": "));
+				}
 			}
 		}
 	};
 
 	cfg_root root;
 	std::vector<std::string> keys;
-	search_level(0, m_current_settings, keys, &root);
+
+	do
+	{
+		is_clean = true;
+		search_level(0, m_current_settings, keys, &root);
+	}
+	while (cleanup && !is_clean);
+
+	return is_clean;
 }
 
 void emu_settings::SaveSettings()
 {
-	ValidateSettings();
-
 	YAML::Emitter out;
 	emit_data(out, m_current_settings);
 

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -90,12 +90,13 @@ public:
 	/** Get a localized and therefore freely adjustable version of the string used in config.yml.*/
 	QString GetLocalizedSetting(const QString& original, emu_settings_type type, int index) const;
 
+	/** Validates the settings and logs unused entries or cleans up the yaml*/
+	bool ValidateSettings(bool cleanup);
+
 public Q_SLOTS:
 	/** Writes the unsaved settings to file.  Used in settings dialog on accept.*/
 	void SaveSettings();
 private:
-	void ValidateSettings();
-
 	YAML::Node m_default_settings; // The default settings as a YAML node.
 	YAML::Node m_current_settings; // The current settings as a YAML node.
 	std::string m_title_id;

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -121,6 +121,7 @@ namespace gui
 	const gui_save ib_show_welcome = gui_save(main_window, "infoBoxEnabledWelcome",    true);
 	const gui_save ib_confirm_exit = gui_save(main_window, "confirmationBoxExitGame",  true);
 	const gui_save ib_confirm_boot = gui_save(main_window, "confirmationBoxBootGame",  true);
+	const gui_save ib_obsolete_cfg = gui_save(main_window, "confirmationObsoleteCfg",  true);
 
 	const gui_save fd_install_pkg  = gui_save(main_window, "lastExplorePathPKG",  "");
 	const gui_save fd_install_pup  = gui_save(main_window, "lastExplorePathPUP",  "");

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -39,7 +39,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>6</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="coreTab">
       <attribute name="title">
@@ -2068,8 +2068,8 @@
              </layout>
             </widget>
            </item>
-		   <item>
-		    <widget class="QGroupBox" name="gb_vulkansched">
+           <item>
+            <widget class="QGroupBox" name="gb_vulkansched">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                <horstretch>0</horstretch>
@@ -2081,12 +2081,11 @@
              </property>
              <layout class="QVBoxLayout" name="gb_vksched_layout">
               <item>
-               <widget class="QComboBox" name="vulkansched">
-               </widget>
+               <widget class="QComboBox" name="vulkansched"/>
               </item>
              </layout>
             </widget>
-		   </item>
+           </item>
            <item>
             <widget class="QGroupBox" name="gb_wakeupDelay">
              <property name="sizePolicy">
@@ -3300,6 +3299,13 @@
                <widget class="QCheckBox" name="cb_show_pup_install">
                 <property name="text">
                  <string>Show PUP Installation Dialog</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="cb_show_obsolete_cfg_dialog">
+                <property name="text">
+                 <string>Show Obsolete Settings Dialog</string>
                 </property>
                </widget>
               </item>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -173,6 +173,7 @@ public:
 		const QString show_boot_game     = tr("Shows a confirmation dialog when a game was booted while another game is running.");
 		const QString show_pkg_install   = tr("Shows a dialog when packages were installed successfully.");
 		const QString show_pup_install   = tr("Shows a dialog when firmware was installed successfully.");
+		const QString show_obsolete_cfg  = tr("Shows a dialog when obsolete settings were found.");
 		const QString check_update_start = tr("Checks if an update is available on startup and asks if you want to update.\nIf \"Background\" is selected, the check is done silently in the background and a new download option is shown in the top right corner of the menu if a new version was found.");
 		const QString use_rich_presence  = tr("Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to completely close the connection.");
 		const QString discord_state      = tr("Tell your friends what you are doing.");


### PR DESCRIPTION
Let's the user decide if they want to remove unused config entries from old builds. (Or maybe garbage)

I don't really like that it asks when saving.
Maybe it should ask when opening the dialog instead.

closes #9981