### PR TITLE
Improve ELF/Trophy loader's error checking

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1556,6 +1556,17 @@ bool fs::dir::open(const std::string& path)
 	return true;
 }
 
+bool fs::file::strict_read_check(u64 _size, u64 type_size) const
+{
+	if (usz pos0 = pos(), size0 = size(); pos0 >= size0 || (size0 - pos0) / type_size < _size)
+	{
+		fs::g_tls_error = fs::error::inval;
+		return false;
+	}
+
+	return true;
+}
+
 const std::string& fs::get_config_dir()
 {
 	// Use magic static

--- a/rpcs3/Loader/ELF.h
+++ b/rpcs3/Loader/ELF.h
@@ -241,17 +241,15 @@ public:
 
 		if (!(opts & elf_opt::no_programs))
 		{
-			_phdrs.resize(header.e_phnum);
 			stream.seek(offset + header.e_phoff);
-			if (!stream.read(_phdrs))
+			if (!stream.read<true>(_phdrs, header.e_phnum))
 				return set_error(elf_error::stream_phdrs);
 		}
 
 		if (!(opts & elf_opt::no_sections))
 		{
-			shdrs.resize(header.e_shnum);
 			stream.seek(offset + header.e_shoff);
-			if (!stream.read(shdrs))
+			if (!stream.read<true>(shdrs, header.e_shnum))
 				return set_error(elf_error::stream_shdrs);
 		}
 
@@ -265,9 +263,8 @@ public:
 
 			if (!(opts & elf_opt::no_data))
 			{
-				progs.back().bin.resize(hdr.p_filesz);
 				stream.seek(offset + hdr.p_offset);
-				if (!stream.read(progs.back().bin))
+				if (!stream.read<true>(progs.back().bin, hdr.p_filesz))
 					return set_error(elf_error::stream_data);
 			}
 		}

--- a/rpcs3/Loader/TROPUSR.cpp
+++ b/rpcs3/Loader/TROPUSR.cpp
@@ -52,12 +52,10 @@ bool TROPUSRLoader::LoadTableHeaders()
 
 	m_file.seek(0x30);
 	m_tableHeaders.clear();
-	m_tableHeaders.resize(m_header.tables_count);
 
-	for (TROPUSRTableHeader& tableHeader : m_tableHeaders)
+	if (!m_file.read<true>(m_tableHeaders, m_header.tables_count))
 	{
-		if (!m_file.read(tableHeader))
-			return false;
+		return false;
 	}
 
 	return true;
@@ -77,25 +75,17 @@ bool TROPUSRLoader::LoadTables()
 		if (tableHeader.type == 4u)
 		{
 			m_table4.clear();
-			m_table4.resize(tableHeader.entries_count);
 
-			for (auto& entry : m_table4)
-			{
-				if (!m_file.read(entry))
-					return false;
-			}
+			if (!m_file.read<true>(m_table4, tableHeader.entries_count))
+				return false;
 		}
 
 		if (tableHeader.type == 6u)
 		{
 			m_table6.clear();
-			m_table6.resize(tableHeader.entries_count);
 
-			for (auto& entry : m_table6)
-			{
-				if (!m_file.read(entry))
-					return false;
-			}
+			if (!m_file.read<true>(m_table6, tableHeader.entries_count))
+				return false;
 		}
 
 		// TODO: Other tables


### PR DESCRIPTION
* Do not crash if memory allocation size is too high in resize() because of an invalid argument in file header. This is especially important in ELF loader because we scan random memory unconditionally looking for SPU images to patch and the slightest corrupted image could crash the emulator. Same goes for TRP and TROPUSR loaders. Similar checking was implemented in PUP loader.