### PR TITLE
SPU LLVM: Use PMADDWD where possible

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -2804,6 +2804,16 @@ public:
 	}
 
 	template <typename T1, typename T2>
+	value_t<s32[4]> pmaddwd(T1 a, T2 b)
+	{
+		value_t<s32[4]> result;
+		const auto av = a.eval(m_ir);
+		const auto bv = b.eval(m_ir);		
+		result.value = m_ir->CreateCall(get_intrinsic(llvm::Intrinsic::x86_sse2_pmadd_wd), {av, bv});
+		return result;
+	}
+
+	template <typename T1, typename T2>
 	value_t<u8[16]> vpermb(T1 a, T2 b)
 	{
 		value_t<u8[16]> result;

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6931,7 +6931,9 @@ public:
 
 	void MPYHHA(spu_opcode_t op)
 	{
-		set_vr(op.rt, (get_vr<s32[4]>(op.ra) >> 16) * (get_vr<s32[4]>(op.rb) >> 16) + get_vr<s32[4]>(op.rt));
+		auto a = bitcast<s16[8]>(get_vr(op.ra) >> 16);
+		auto b = bitcast<s16[8]>(get_vr(op.rb) >> 16);
+		set_vr(op.rt, pmaddwd(a, b) + get_vr<s32[4]>(op.rt));
 	}
 
 	void MPYHHAU(spu_opcode_t op)
@@ -6941,7 +6943,9 @@ public:
 
 	void MPY(spu_opcode_t op)
 	{
-		set_vr(op.rt, (get_vr<s32[4]>(op.ra) << 16 >> 16) * (get_vr<s32[4]>(op.rb) << 16 >> 16));
+		auto a = bitcast<s16[8]>(get_vr(op.ra) << 16 >> 16);
+		auto b = bitcast<s16[8]>(get_vr(op.rb) << 16 >> 16);
+		set_vr(op.rt, pmaddwd(a, b));
 	}
 
 	void MPYH(spu_opcode_t op)
@@ -6951,7 +6955,9 @@ public:
 
 	void MPYHH(spu_opcode_t op)
 	{
-		set_vr(op.rt, (get_vr<s32[4]>(op.ra) >> 16) * (get_vr<s32[4]>(op.rb) >> 16));
+		auto a = bitcast<s16[8]>(get_vr(op.ra) >> 16);
+		auto b = bitcast<s16[8]>(get_vr(op.rb) >> 16);
+		set_vr(op.rt, pmaddwd(a, b));
 	}
 
 	void MPYS(spu_opcode_t op)
@@ -7434,7 +7440,9 @@ public:
 
 	void MPYA(spu_opcode_t op)
 	{
-		set_vr(op.rt4, (get_vr<s32[4]>(op.ra) << 16 >> 16) * (get_vr<s32[4]>(op.rb) << 16 >> 16) + get_vr<s32[4]>(op.rc));
+		auto a = bitcast<s16[8]>(get_vr(op.ra) << 16 >> 16);
+		auto b = bitcast<s16[8]>(get_vr(op.rb) << 16 >> 16);
+		set_vr(op.rt4, pmaddwd(a, b) + get_vr<s32[4]>(op.rc));
 	}
 
 	void FSCRRD(spu_opcode_t op) //


### PR DESCRIPTION
Speedup SPU integer performance by using PMADDWD where possible, which is faster than the alternative on skylake as well as zen1/2 cpus. 

On cpus with VNNI, such as icelake, there exists an instruction which fuses PMADDWD and VPADD into 1 instruction (VPDPWSSD), which should result in more speedups, since LLVM knows when to use this instruction.

On my 7700K the spu integer portion of the spurs_test.self is improved from about `4000ms` to about `3500ms`

Sadly the improvements in retail software are much smaller since the instructions improved are somewhat uncommon.