### PR TITLE
Improve trophy context loader

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -578,11 +578,11 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 		return SCE_NP_TROPHY_ERROR_ILLEGAL_UPDATE;
 	}
 
-	TROPUSRLoader* tropusr = new TROPUSRLoader();
+	const auto& tropusr = ctxt->tropusr = std::make_unique<TROPUSRLoader>();
 	const std::string trophyUsrPath = trophyPath + "/TROPUSR.DAT";
 	const std::string trophyConfPath = trophyPath + "/TROPCONF.SFM";
-	tropusr->Load(trophyUsrPath, trophyConfPath);
-	ctxt->tropusr.reset(tropusr);
+
+	ensure(tropusr->Load(trophyUsrPath, trophyConfPath).success);
 
 	// This emulates vsh sending the events and ensures that not 2 events are processed at once
 	const std::pair<u32, s32> statuses[] =

--- a/rpcs3/Loader/TROPUSR.cpp
+++ b/rpcs3/Loader/TROPUSR.cpp
@@ -132,21 +132,9 @@ bool TROPUSRLoader::Save(const std::string& filepath)
 	}
 
 	temp.file.write(m_header);
-
-	for (const TROPUSRTableHeader& tableHeader : m_tableHeaders)
-	{
-		temp.file.write(tableHeader);
-	}
-
-	for (const auto& entry : m_table4)
-	{
-		temp.file.write(entry);
-	}
-
-	for (const auto& entry : m_table6)
-	{
-		temp.file.write(entry);
-	}
+	temp.file.write(m_tableHeaders);
+	temp.file.write(m_table4);
+	temp.file.write(m_table6);
 
 	return temp.commit();
 }

--- a/rpcs3/Loader/TROPUSR.h
+++ b/rpcs3/Loader/TROPUSR.h
@@ -80,7 +80,13 @@ class TROPUSRLoader
 public:
 	virtual ~TROPUSRLoader() = default;
 
-	virtual bool Load(const std::string& filepath, const std::string& configpath);
+	struct load_result
+	{
+		bool discarded_existing;
+		bool success;
+	};
+
+	virtual load_result Load(const std::string& filepath, const std::string& configpath);
 	virtual bool Save(const std::string& filepath);
 
 	virtual u32 GetTrophiesCount();

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -358,7 +358,7 @@ bool trophy_manager_dialog::LoadTrophyFolderToDB(const std::string& trop_name)
 	game_trophy_data->trop_usr.reset(new TROPUSRLoader());
 	const std::string trophyUsrPath = trophyPath + "/TROPUSR.DAT";
 	const std::string trophyConfPath = trophyPath + "/TROPCONF.SFM";
-	const bool success = game_trophy_data->trop_usr->Load(trophyUsrPath, trophyConfPath);
+	const bool success = game_trophy_data->trop_usr->Load(trophyUsrPath, trophyConfPath).success;
 
 	fs::file config(vfs::get(trophyConfPath));
 


### PR DESCRIPTION
* Add magic test in TROPUSR.
* Optimize TROPUSR::Save.
* Replace invalid TROPUSR.DAT with empty new ones. (+report an error)
* Fix return code of Load whenever TROPUSR.DAT hadn't existed before.
* sceNpTrophyRegisterContext will abort if TROPUSR.DAT generation failed.