### PR TITLE
Qt: Allow package installation through cli

### DIFF
--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -305,6 +305,7 @@ public:
 	package_reader(const std::string& path);
 	~package_reader();
 
+	bool is_valid() const { return m_is_valid; }
 	package_error check_target_app_version();
 	bool extract_data(atomic_t<double>& sync);
 	psf::registry get_psf() const { return m_psf; }

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -247,14 +247,21 @@ compat::status game_compatibility::GetStatusData(const QString& status)
 
 compat::package_info game_compatibility::GetPkgInfo(const QString& pkg_path, game_compatibility* compat)
 {
+	compat::package_info info;
+
 	package_reader reader(pkg_path.toStdString());
+	if (!reader.is_valid())
+	{
+		info.is_valid = false;
+		return info;
+	}
+
 	psf::registry psf = reader.get_psf();
 
 	// TODO: localization of title and changelog
 	std::string title_key     = "TITLE";
 	std::string changelog_key = "paramhip";
 
-	compat::package_info info;
 	info.path     = pkg_path;
 	info.title    = qstr(std::string(psf::get_string(psf, title_key))); // Let's read this from the psf first
 	info.title_id = qstr(std::string(psf::get_string(psf, "TITLE_ID")));

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -100,6 +100,8 @@ namespace compat
 	/** Concicely represents a specific pkg's localized information for use in the GUI */
 	struct package_info
 	{
+		bool is_valid = true;
+
 		QString path;        // File path
 		QString title_id;    // TEST12345
 		QString title;       // Localized

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -557,11 +557,17 @@ void main_window::InstallPackages(QStringList file_paths)
 	}
 	else if (file_paths.count() == 1)
 	{
-		// This can currently only happen by drag and drop.
+		// This can currently only happen by drag and drop and cli arg.
 		const QString file_path = file_paths.front();
 		const QFileInfo file_info(file_path);
 
 		compat::package_info info = game_compatibility::GetPkgInfo(file_path, m_game_list_frame ? m_game_list_frame->GetGameCompatibility() : nullptr);
+
+		if (!info.is_valid)
+		{
+			QMessageBox::warning(this, QObject::tr("Invalid package!"), QObject::tr("The selected package is invalid!\n\nPath:\n%0").arg(file_path));
+			return;
+		}
 
 		if (info.type != compat::package_type::other)
 		{
@@ -634,6 +640,11 @@ void main_window::InstallPackages(QStringList file_paths)
 
 void main_window::HandlePackageInstallation(QStringList file_paths)
 {
+	if (file_paths.empty())
+	{
+		return;
+	}
+
 	std::vector<compat::package_info> packages;
 
 	game_compatibility* compat = m_game_list_frame ? m_game_list_frame->GetGameCompatibility() : nullptr;

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -85,7 +85,8 @@ public:
 	bool Init();
 	QIcon GetAppIcon();
 	bool OnMissingFw();
-	void HandlePupInstallation(QString file_path, QString dir_path = "");
+	void InstallPackages(QStringList file_paths = QStringList());
+	void InstallPup(QString filePath = "");
 
 Q_SIGNALS:
 	void RequestLanguageChange(const QString& language);
@@ -141,10 +142,9 @@ private:
 
 	static bool InstallRapFile(const QString& path, const std::string& filename);
 
-	void InstallPackages(QStringList file_paths = QStringList());
 	void HandlePackageInstallation(QStringList file_paths);
 
-	void InstallPup(QString filePath = "");
+	void HandlePupInstallation(QString file_path, QString dir_path = "");
 	void ExtractPup();
 
 	void ExtractTar();

--- a/rpcs3/rpcs3qt/pkg_install_dialog.cpp
+++ b/rpcs3/rpcs3qt/pkg_install_dialog.cpp
@@ -28,6 +28,11 @@ pkg_install_dialog::pkg_install_dialog(const QStringList& paths, game_compatibil
 	for (const QString& path : paths)
 	{
 		const compat::package_info info = game_compatibility::GetPkgInfo(path, compat);
+		if (!info.is_valid)
+		{
+			continue;
+		}
+
 		const QFileInfo file_info(path);
 
 		// We have to build our complicated localized string in some annoying manner


### PR DESCRIPTION
- Adds --installpkg cli option (can handle a single path).
- Adds a missing check when passing crap to the package installer

fixes #5374