### PR TITLE
rsx: Compile shaders when CELL is not running

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -10,6 +10,7 @@
 #include "Utilities/JIT.h"
 #include <thread>
 #include <sstream>
+#include <cfenv>
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -2081,6 +2082,8 @@ thread_base::native_entry thread_base::finalize(u64 _self) noexcept
 	thread_ctrl::set_native_priority(0);
 
 	thread_ctrl::set_thread_affinity_mask(0);
+
+	std::fesetround(FE_TONEAREST);
 
 	static constexpr u64 s_stop_bit = 0x8000'0000'0000'0000ull;
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -813,7 +813,6 @@ void try_spawn_ppu_if_exclusive_program(const ppu_module& m)
 
 		auto ppu = idm::make_ptr<named_thread<ppu_thread>>("PPU[0x1000000] Thread (test_thread)", p, "test_thread", 0);
 
-		ppu->cmd_push({ppu_cmd::initialize, 0});
 		ppu->cia = m.funcs[0].addr;
 
 		// For kernel explorer

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -943,7 +943,15 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::initialize:
 		{
-			cmd_pop(), ppu_initialize(), spu_cache::initialize();
+			cmd_pop();
+
+			while (!g_fxo->get<rsx::thread>().is_inited && !is_stopped())
+			{
+				// Wait for RSX to be initialized
+				thread_ctrl::wait_on(g_fxo->get<rsx::thread>().is_inited, false);
+			}
+
+			ppu_initialize(), spu_cache::initialize();
 			break;
 		}
 		case ppu_cmd::sleep:

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -506,27 +506,12 @@ namespace rsx
 
 	void thread::cpu_task()
 	{
+		while (Emu.IsReady())
 		{
-			// Wait for startup (TODO)
-			while (m_rsx_thread_exiting)
-			{
-				// Wait for external pause events
-				if (external_interrupt_lock)
-				{
-					wait_pause();
-				}
-
-				thread_ctrl::wait_for(1000);
-
-				if (is_stopped())
-				{
-					return;
-				}
-			}
-
-			on_task();
+			thread_ctrl::wait_for(1000);
 		}
 
+		on_task();
 		on_exit();
 	}
 
@@ -548,7 +533,7 @@ namespace rsx
 		g_tls_log_prefix = []
 		{
 			const auto rsx = get_current_renderer();
-			return fmt::format("RSX [0x%07x]", +rsx->ctrl->get);
+			return fmt::format("RSX [0x%07x]", rsx->ctrl ? +rsx->ctrl->get : 0);
 		};
 
 		method_registers.init();
@@ -558,11 +543,41 @@ namespace rsx
 		g_fxo->get<rsx::dma_manager>().init();
 		on_init_thread();
 
+		is_inited = true;
+		is_inited.notify_all();
+
 		if (!zcull_ctrl)
 		{
 			//Backend did not provide an implementation, provide NULL object
 			zcull_ctrl = std::make_unique<::rsx::reports::ZCULL_control>();
 		}
+
+		performance_counters.state = FIFO_state::empty;
+
+		// Wait for startup (TODO)
+		while (m_rsx_thread_exiting)
+		{
+			// Wait for external pause events
+			if (external_interrupt_lock)
+			{
+				wait_pause();
+			}
+
+			// Execute backend-local tasks first
+			do_local_task(performance_counters.state);
+
+			// Update sub-units
+			zcull_ctrl->update(this);
+
+			if (is_stopped())
+			{
+				return;
+			}
+
+			thread_ctrl::wait_for(1000);
+		}
+
+		performance_counters.state = FIFO_state::running;
 
 		fifo_ctrl = std::make_unique<::rsx::FIFO::FIFO_control>(this);
 
@@ -643,9 +658,6 @@ namespace rsx
 		{
 			thread_ctrl::set_thread_affinity_mask(thread_ctrl::get_affinity_mask(thread_class::rsx));
 		}
-
-		// Round to nearest to deal with forward/reverse scaling
-		fesetround(FE_TONEAREST);
 
 		while (!test_stopped())
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -649,6 +649,7 @@ namespace rsx
 		u32 dbg_step_pc = 0;
 		atomic_t<u32> external_interrupt_lock{ 0 };
 		atomic_t<bool> external_interrupt_ack{ false };
+		atomic_t<bool> is_inited{ false };
 		bool is_fifo_idle() const;
 		void flush_fifo();
 		void recover_fifo();


### PR DESCRIPTION
Previously RSX waited until PPU called sys_rsx syscalls to compile shaders, then it let SPU and PPU run at fullspeed when doing so which can choke CPUs with not many threads.
This is also a bug which can cause timeout assertations from CELL side at startup due to RSX not responding for long period of time at startup when compiling shaders. (emulation must not observe the time in which RSX compiles shaders)
To solve it compile shaders before CELL is running, do not wait for PPU to execute some syscall. In fact now PPU will wait until RSX has been fully initialized to execute any stuff.