### PR TITLE
Fix error message of RPCS3 directory with limited permissions

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -364,26 +364,19 @@ int main(int argc, char** argv)
 
 	if (!instance_lock)
 	{
-		if (fs::g_tls_error == fs::error::acces)
+		if (fs::g_tls_error == fs::error::access && fs::exists(lock_name) && !instance_lock.open(lock_name))
 		{
-			if (fs::exists(lock_name) && !instance_lock.open(lock_name))
-			{
-				report_fatal_error("Another instance of RPCS3 is running. Close it or kill its process, if necessary.");
-			}
-			else
-			{
-				report_fatal_error("Cannot create RPCS3.log (access denied)."
-#ifdef _WIN32
-				"\nNote that RPCS3 cannot be installed in Program Files or similar directories with limited permissions."
-#else
-				"\nPlease, check RPCS3 permissions in '~/.config/rpcs3'."
-#endif
-				);
-			}
+			report_fatal_error("Another instance of RPCS3 is running. Close it or kill its process, if necessary.");
 		}
 		else
 		{
-			report_fatal_error(fmt::format("Cannot create RPCS3.log (error %s)", fs::g_tls_error));
+			report_fatal_error(fmt::format("Cannot create RPCS3.log (error %s)."
+#ifdef _WIN32
+			"\nNote that RPCS3 cannot be installed in Program Files or similar directories with limited permissions."
+#else
+			"\nPlease, check RPCS3 permissions in '~/.config/rpcs3'."
+#endif
+			, fs::g_tls_error));
 		}
 
 		return 1;

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -357,7 +357,7 @@ int main(int argc, char** argv)
 	const bool is_updating = find_arg(arg_updating, argc, argv) != -1;
 
 	// Keep trying to lock the file for ~2s normally, and for ~10s in the case of --updating
-	for (u32 num = 0; num < (is_updating ? 500u : 100u) && !instance_lock.open(lock_name, fs::rewrite + fs::lock); num++)
+	for (u32 num = 0; num < (is_updating ? 500u : 100u) && !instance_lock.open(lock_name, fs::read + fs::create + fs::unread); num++)
 	{
 		std::this_thread::sleep_for(20ms);
 	}

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -364,7 +364,7 @@ int main(int argc, char** argv)
 
 	if (!instance_lock)
 	{
-		if (fs::g_tls_error == fs::error::access && fs::exists(lock_name) && !instance_lock.open(lock_name))
+		if (fs::g_tls_error == fs::error::acces && fs::exists(lock_name) && !instance_lock.open(lock_name))
 		{
 			report_fatal_error("Another instance of RPCS3 is running. Close it or kill its process, if necessary.");
 		}

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -357,7 +357,7 @@ int main(int argc, char** argv)
 	const bool is_updating = find_arg(arg_updating, argc, argv) != -1;
 
 	// Keep trying to lock the file for ~2s normally, and for ~10s in the case of --updating
-	for (u32 num = 0; num < (is_updating ? 500u : 100u) && !instance_lock.open(lock_name, fs::read + fs::create + fs::unread); num++)
+	for (u32 num = 0; num < (is_updating ? 500u : 100u) && !instance_lock.open(lock_name, fs::write + fs::create + fs::unread); num++)
 	{
 		std::this_thread::sleep_for(20ms);
 	}
@@ -366,7 +366,7 @@ int main(int argc, char** argv)
 	{
 		if (fs::g_tls_error == fs::error::acces)
 		{
-			if (fs::exists(lock_name))
+			if (fs::exists(lock_name) && !instance_lock.open(lock_name))
 			{
 				report_fatal_error("Another instance of RPCS3 is running. Close it or kill its process, if necessary.");
 			}

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -364,7 +364,7 @@ int main(int argc, char** argv)
 
 	if (!instance_lock)
 	{
-		if (fs::g_tls_error == fs::error::acces && fs::exists(lock_name) && !instance_lock.open(lock_name))
+		if (fs::error fs_err = fs::g_tls_error; fs_err == fs::error::acces && fs::exists(lock_name) && !instance_lock.open(lock_name))
 		{
 			report_fatal_error("Another instance of RPCS3 is running. Close it or kill its process, if necessary.");
 		}
@@ -376,7 +376,7 @@ int main(int argc, char** argv)
 #else
 			"\nPlease, check RPCS3 permissions in '~/.config/rpcs3'."
 #endif
-			, fs::g_tls_error));
+			, fs_err));
 		}
 
 		return 1;


### PR DESCRIPTION
See #5507. Should say "Cannot create RPCS3.log (access denied)." now.