### PR TITLE
Qt: prepare for removal of deprecated GUI settings

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -597,15 +597,18 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 				if (last_played.isEmpty())
 				{
 					last_played = m_gui_settings->GetValue(gui::persistent::last_played, serial, "").toString();
+					m_gui_settings->RemoveValue(gui::persistent::last_played, serial);
 				}
 				if (playtime <= 0)
 				{
 					playtime = m_gui_settings->GetValue(gui::persistent::playtime, serial, 0).toULongLong();
+					m_gui_settings->RemoveValue(gui::persistent::playtime, serial);
 				}
 				// Deprecated values older than August 2nd 2020
 				if (note.isEmpty())
 				{
 					note = m_gui_settings->GetValue(gui::persistent::notes, serial, "").toString();
+					m_gui_settings->RemoveValue(gui::persistent::notes, serial);
 
 					// Move to persistent settings
 					if (!note.isEmpty())
@@ -616,6 +619,7 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 				if (title.isEmpty())
 				{
 					title = m_gui_settings->GetValue(gui::persistent::titles, serial, "").toString().simplified();
+					m_gui_settings->RemoveValue(gui::persistent::titles, serial);
 
 					// Move to persistent settings
 					if (!title.isEmpty())

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -186,6 +186,7 @@ void save_data_list_dialog::UpdateList()
 	if (notes.isEmpty())
 	{
 		notes = m_gui_settings->GetValue(gui::m_saveNotes).toMap();
+		m_gui_settings->RemoveValue(gui::m_saveNotes);
 
 		// Move to persistent settings
 		if (!notes.isEmpty())

--- a/rpcs3/rpcs3qt/settings.cpp
+++ b/rpcs3/rpcs3qt/settings.cpp
@@ -39,14 +39,19 @@ void settings::RemoveValue(const QString& key, const QString& name)
 	}
 }
 
-QVariant settings::GetValue(const gui_save& entry) const
+void settings::RemoveValue(const gui_save& entry)
 {
-	return m_settings ? m_settings->value(entry.key + "/" + entry.name, entry.def) : entry.def;
+	RemoveValue(entry.key, entry.name);
 }
 
 QVariant settings::GetValue(const QString& key, const QString& name, const QVariant& def) const
 {
 	return m_settings ? m_settings->value(key + "/" + name, def) : def;
+}
+
+QVariant settings::GetValue(const gui_save& entry) const
+{
+	return GetValue(entry.key, entry.name, entry.def);
 }
 
 QVariant settings::List2Var(const q_pair_list& list)

--- a/rpcs3/rpcs3qt/settings.h
+++ b/rpcs3/rpcs3qt/settings.h
@@ -30,15 +30,16 @@ public:
 	~settings();
 
 	QString GetSettingsDir() const;
-
-	QVariant GetValue(const gui_save& entry) const;
+	
 	QVariant GetValue(const QString& key, const QString& name, const QVariant& def) const;
+	QVariant GetValue(const gui_save& entry) const;
 	static QVariant List2Var(const q_pair_list& list);
 	static q_pair_list Var2List(const QVariant& var);
 
 public Q_SLOTS:
 	/** Remove entry */
 	void RemoveValue(const QString& key, const QString& name);
+	void RemoveValue(const gui_save& entry);
 
 	/** Write value to entry */
 	void SetValue(const gui_save& entry, const QVariant& value);

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -131,6 +131,7 @@ void user_manager_dialog::Init()
 	if (m_active_user.empty())
 	{
 		m_active_user = m_gui_settings->GetValue(gui::um_active_user).toString().toStdString();
+		m_gui_settings->RemoveValue(gui::um_active_user);
 
 		if (!m_active_user.empty())
 		{


### PR DESCRIPTION
If you currently remove a custom name and already had a deprecated name before, you'll never get rid of it.
This applies to all of the deprecated settings.