### PR TITLE
Qt: don't show updater if booted with cli arg

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -720,6 +720,7 @@ int main(int argc, char** argv)
 
 		gui_app->SetShowGui(!s_no_gui);
 		gui_app->SetUseCliStyle(use_cli_style);
+		gui_app->SetWithCliBoot(parser.isSet(arg_installfw) || parser.isSet(arg_installpkg) || !parser.positionalArguments().isEmpty());
 
 		if (!gui_app->Init())
 		{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -96,7 +96,7 @@ bool gui_application::Init()
 		welcome->exec();
 	}
 
-	if (m_main_window && !m_main_window->Init())
+	if (m_main_window && !m_main_window->Init(m_with_cli_boot))
 	{
 		return false;
 	}

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -38,6 +38,11 @@ public:
 		m_use_cli_style = use_cli_style;
 	}
 
+	void SetWithCliBoot(bool with_cli_boot = false)
+	{
+		m_with_cli_boot = with_cli_boot;
+	}
+
 	/** Call this method before calling app.exec */
 	bool Init() override;
 
@@ -75,6 +80,7 @@ private:
 
 	bool m_show_gui = true;
 	bool m_use_cli_style = false;
+	bool m_with_cli_boot = false;
 
 private Q_SLOTS:
 	void OnChangeStyleSheetRequest();

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -87,7 +87,7 @@ main_window::~main_window()
 /* An init method is used so that RPCS3App can create the necessary connects before calling init (specifically the stylesheet connect).
  * Simplifies logic a bit.
  */
-bool main_window::Init()
+bool main_window::Init(bool with_cli_boot)
 {
 	setAcceptDrops(true);
 
@@ -229,7 +229,8 @@ bool main_window::Init()
 #if defined(_WIN32) || defined(__linux__)
 	if (const auto update_value = m_gui_settings->GetValue(gui::m_check_upd_start).toString(); update_value != "false")
 	{
-		m_updater.check_for_updates(true, update_value != "true", this);
+		const bool in_background = with_cli_boot || update_value != "true";
+		m_updater.check_for_updates(true, in_background, this);
 	}
 #endif
 

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -82,7 +82,7 @@ class main_window : public QMainWindow
 public:
 	explicit main_window(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget *parent = 0);
 	~main_window();
-	bool Init();
+	bool Init(bool with_cli_boot);
 	QIcon GetAppIcon();
 	bool OnMissingFw();
 	void InstallPackages(QStringList file_paths = QStringList());


### PR DESCRIPTION
The updater will be hidden if RPCS3 is booted with any command line argument that may invoke Emu.Boot

closes #6839