### PR TITLE
Qt: clean global cfg before adding custom cfgs

### DIFF
--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -139,6 +139,10 @@ void emu_settings::LoadSettings(const std::string& title_id)
 	// Add game config
 	if (!title_id.empty())
 	{
+		// Remove obsolete settings of the global config before adding the custom settings.
+		// Otherwise we'll always trigger the "obsolete settings dialog" when editing custom configs.
+		ValidateSettings(true);
+
 		const std::string config_path_new = Emulator::GetCustomConfigPath(m_title_id);
 		const std::string config_path_old = Emulator::GetCustomConfigPath(m_title_id, true);
 		std::string custom_config_path;


### PR DESCRIPTION
Fixes a bug that causes custom configs to inherit obsolete settings of the global config.
This should not affect its own existing obsolete settings.