### PR TITLE
Qt: add option to hide the log prefix

### DIFF
--- a/rpcs3/rpcs3qt/find_dialog.cpp
+++ b/rpcs3/rpcs3qt/find_dialog.cpp
@@ -38,6 +38,8 @@ find_dialog::find_dialog(QTextEdit* edit, QWidget *parent, Qt::WindowFlags f) : 
 	connect(m_find_next, &QPushButton::clicked, this, &find_dialog::find_next);
 	connect(m_find_previous, &QPushButton::clicked, this, &find_dialog::find_previous);
 
+	m_find_next->setDefault(true);
+
 	show();
 }
 

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -175,6 +175,7 @@ namespace gui
 
 	const gui_save l_tty       = gui_save(logger, "TTY",       true);
 	const gui_save l_level     = gui_save(logger, "level",     static_cast<uint>(logs::level::success));
+	const gui_save l_prefix    = gui_save(logger, "prefix_on", false);
 	const gui_save l_stack     = gui_save(logger, "stack",     true);
 	const gui_save l_stack_tty = gui_save(logger, "TTY_stack", false);
 	const gui_save l_limit     = gui_save(logger, "limit",     1000);

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -62,23 +62,25 @@ private:
 	QLineEdit* m_tty_input = nullptr;
 	int m_tty_channel = -1;
 
-	QAction* m_clearAct = nullptr;
-	QAction* m_clearTTYAct = nullptr;
+	QAction* m_clear_act = nullptr;
+	QAction* m_clear_tty_act = nullptr;
 
-	QActionGroup* m_logLevels = nullptr;
-	QAction* m_nothingAct = nullptr;
-	QAction* m_fatalAct = nullptr;
-	QAction* m_errorAct = nullptr;
-	QAction* m_todoAct = nullptr;
-	QAction* m_successAct = nullptr;
-	QAction* m_warningAct = nullptr;
-	QAction* m_noticeAct = nullptr;
-	QAction* m_traceAct = nullptr;
+	QActionGroup* m_log_level_acts = nullptr;
+	QAction* m_nothing_act = nullptr;
+	QAction* m_fatal_act = nullptr;
+	QAction* m_error_act = nullptr;
+	QAction* m_todo_act = nullptr;
+	QAction* m_success_act = nullptr;
+	QAction* m_warning_act = nullptr;
+	QAction* m_notice_act = nullptr;
+	QAction* m_trace_act = nullptr;
 
-	QAction* m_stackAct_log = nullptr;
-	QAction* m_stackAct_tty = nullptr;
+	QAction* m_stack_act_log = nullptr;
+	QAction* m_stack_act_tty = nullptr;
 
-	QAction* m_TTYAct = nullptr;
+	QAction* m_show_prefix_act = nullptr;
+
+	QAction* m_tty_act = nullptr;
 
 	QActionGroup* m_tty_channel_acts = nullptr;
 


### PR DESCRIPTION
Some informational messages kept spamming the log since we now have a bunch of multithreaded operations like shader generation.

Having the option to remove the log prefix from the view seems like the obvious choice to me, as it has several advantages:
1. Faster log_frame. The less text we write to the gui the less work our cpu needs to do.
2. Less visual clutter. Most people don't need to know the details that are present in the prefix.
3. Certain messages can stack up again. Previously they were unique due to their thread ID.

I defaulted this to hide the prefix. Developers or anyone who needs it can just enable it in the log frame (saved in GuiConfigs).

![image](https://user-images.githubusercontent.com/23019877/112834046-cc7ae680-9097-11eb-9101-42b3269dc376.png)
