### PR TITLE
Qt: add AppIcon to fatal_error_dialog

### DIFF
--- a/rpcs3/rpcs3qt/fatal_error_dialog.cpp
+++ b/rpcs3/rpcs3qt/fatal_error_dialog.cpp
@@ -2,9 +2,11 @@
 
 #include <QLayout>
 #include <QTextDocument>
+#include <QIcon>
 
 fatal_error_dialog::fatal_error_dialog(std::string_view text) : QMessageBox()
 {
+	setWindowIcon(QIcon(":/rpcs3.ico"));
 	setWindowTitle(tr("RPCS3: Fatal Error"));
 	setIcon(QMessageBox::Icon::Critical);
 	setTextFormat(Qt::TextFormat::RichText);


### PR DESCRIPTION
replaces this:
![image](https://user-images.githubusercontent.com/23019877/112897721-4040e180-90e0-11eb-8e9b-5cacfb8e747c.png)

with this:
![image](https://user-images.githubusercontent.com/23019877/112897772-4f279400-90e0-11eb-987f-379609cfe5f6.png)
