### PR TITLE
core: Move IDM to FXO

### DIFF
--- a/rpcs3/Emu/IdManager.cpp
+++ b/rpcs3/Emu/IdManager.cpp
@@ -5,22 +5,15 @@
 shared_mutex id_manager::g_mutex;
 
 thread_local DECLARE(idm::g_id);
-DECLARE(idm::g_map);
 
-id_manager::id_map::pointer idm::allocate_id(const id_manager::id_key& info, u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range)
+idm::map_data* idm::allocate_id(std::vector<map_data>& vec, u32 type_id,  u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range)
 {
-	// Base type id is stored in value
-	auto& vec = g_map[info.value()];
-
-	// Preallocate memory
-	vec.reserve(count);
-
 	if (vec.size() < count)
 	{
 		// Try to emplace back
 		const u32 _next = base + step * ::size32(vec);
 		g_id = _next;
-		vec.emplace_back(id_manager::id_key(_next, info.type()), nullptr);
+		vec.emplace_back(id_manager::id_key(_next, type_id), nullptr);
 		return &vec.back();
 	}
 
@@ -35,33 +28,11 @@ id_manager::id_map::pointer idm::allocate_id(const id_manager::id_key& info, u32
 			// Incremenet ID invalidation counter
 			const u32 id = next | ((ptr->first + (1u << invl_range.first)) & (invl_range.second ? (((1u << invl_range.second) - 1) << invl_range.first) : 0));
 			g_id = id;
-			ptr->first = id_manager::id_key(id, info.type());
+			ptr->first = id_manager::id_key(id, type_id);
 			return ptr;
 		}
 	}
 
 	// Out of IDs
 	return nullptr;
-}
-
-void idm::init()
-{
-	// Allocate
-	g_map.resize(id_manager::typeinfo::get_count());
-	idm::clear();
-}
-
-void idm::clear()
-{
-	// Call recorded finalization functions for all IDs
-	for (auto& map : g_map)
-	{
-		for (auto& pair : map)
-		{
-			pair.second.reset();
-			pair.first = {};
-		}
-
-		map.clear();
-	}
 }


### PR DESCRIPTION
Much simplifies multi-process and save-states support. In an ideal emulator state FXO will contain all information possible about a PS3 process.