### PR TITLE
Loader/cellGame: Do not crash on invalid PSF files

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -182,9 +182,9 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 
 	const std::string dir = "/dev_hdd0/game/" + game_dir;
 
-	psf::registry sfo = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
+	auto [sfo, psf_error] = psf::load(vfs::get(dir + "/PARAM.SFO"));
 
-	const u32 new_data = sfo.empty() && !fs::is_file(vfs::get(dir + "/PARAM.SFO")) ? CELL_GAMEDATA_ISNEWDATA_YES : CELL_GAMEDATA_ISNEWDATA_NO;
+	const u32 new_data = psf_error == psf::error::stream ? CELL_GAMEDATA_ISNEWDATA_YES : CELL_GAMEDATA_ISNEWDATA_NO;
 
 	if (!new_data)
 	{
@@ -586,7 +586,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 		return CELL_GAME_ERROR_BUSY;
 	}
 
-	auto sfo = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
+	auto [sfo, psf_error] = psf::load(vfs::get(dir + "/PARAM.SFO"));
 
 	if (psf::get_string(sfo, "CATEGORY") != [&]()
 	{
@@ -599,7 +599,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 		}
 	}())
 	{
-		if (fs::is_file(vfs::get(dir + "/PARAM.SFO")))
+		if (psf_error != psf::error::stream)
 		{
 			init.cancel();
 			return CELL_GAME_ERROR_BROKEN;
@@ -714,9 +714,9 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 	const std::string game_dir = dirName.get_ptr();
 	const std::string dir = "/dev_hdd0/game/"s + game_dir;
 
-	psf::registry sfo = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
+	auto [sfo, psf_error] = psf::load(vfs::get(dir + "/PARAM.SFO"));
 
-	const u32 new_data = sfo.empty() && !fs::is_file(vfs::get(dir + "/PARAM.SFO")) ? CELL_GAMEDATA_ISNEWDATA_YES : CELL_GAMEDATA_ISNEWDATA_NO;
+	const u32 new_data = psf_error == psf::error::stream ? CELL_GAMEDATA_ISNEWDATA_YES : CELL_GAMEDATA_ISNEWDATA_NO;
 
 	if (!new_data)
 	{
@@ -961,9 +961,9 @@ error_code cellGameDeleteGameData(vm::cptr<char> dirName)
 			return CELL_GAME_ERROR_NOTSUPPORTED;
 		}
 
-		psf::registry sfo = psf::load_object(fs::file(dir + "/PARAM.SFO"));
+		const auto [sfo, psf_error] = psf::load(dir + "/PARAM.SFO");
 
-		if (psf::get_string(sfo, "CATEGORY") != "GD" && fs::is_file(dir + "/PARAM.SFO"))
+		if (psf::get_string(sfo, "CATEGORY") != "GD" && psf_error != psf::error::stream)
 		{
 			return CELL_GAME_ERROR_NOTSUPPORTED;
 		}

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -59,7 +59,7 @@ namespace psf
 	};
 
 
-	entry::entry(format type, u32 max_size, const std::string& value)
+	entry::entry(format type, u32 max_size, std::string_view value)
 		: m_type(type)
 		, m_max_size(max_size)
 		, m_value_string(value)
@@ -91,7 +91,7 @@ namespace psf
 		return m_value_integer;
 	}
 
-	entry& entry::operator =(const std::string& value)
+	entry& entry::operator =(std::string_view value)
 	{
 		ensure(m_type == format::string || m_type == format::array);
 		m_value_string = value;

--- a/rpcs3/Loader/PSF.h
+++ b/rpcs3/Loader/PSF.h
@@ -19,6 +19,14 @@ namespace psf
 		integer = 0x0404,
 	};
 
+	enum class error
+	{
+		ok,
+		stream,
+		not_psf,
+		corrupt,
+	};
+
 	class entry final
 	{
 		format m_type{};
@@ -49,8 +57,21 @@ namespace psf
 	// Define PSF registry as a sorted map of entries:
 	using registry = std::map<std::string, entry>;
 
+	struct load_result_t
+	{
+		registry sfo;
+		error errc;
+
+		explicit operator bool() const
+		{
+			return !sfo.empty();
+		}
+	};
+
 	// Load PSF registry from SFO binary format
-	registry load_object(const fs::file&);
+	load_result_t load(const fs::file&);
+	load_result_t load(const std::string& filename);
+	inline registry load_object(const fs::file& f) { return load(f).sfo; }
 
 	// Convert PSF registry to SFO binary format
 	std::vector<u8> save_object(const registry&, std::vector<u8>&& init = std::vector<u8>{});

--- a/rpcs3/Loader/PSF.h
+++ b/rpcs3/Loader/PSF.h
@@ -36,7 +36,7 @@ namespace psf
 
 	public:
 		// Construct string entry, assign the value
-		entry(format type, u32 max_size, const std::string& value = {});
+		entry(format type, u32 max_size, std::string_view value);
 
 		// Construct integer entry, assign the value
 		entry(u32 value);
@@ -46,7 +46,7 @@ namespace psf
 		const std::string& as_string() const;
 		u32 as_integer() const;
 
-		entry& operator =(const std::string& value);
+		entry& operator =(std::string_view value);
 		entry& operator =(u32 value);
 
 		format type() const { return m_type; }
@@ -100,12 +100,12 @@ namespace psf
 	// Make string entry
 	inline entry string(u32 max_size, std::string_view value)
 	{
-		return {format::string, max_size, std::string(value)};
+		return {format::string, max_size, value};
 	}
 
 	// Make array entry
 	inline entry array(u32 max_size, std::string_view value)
 	{
-		return {format::array, max_size, std::string(value)};
+		return {format::array, max_size, value};
 	}
 }

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -550,17 +550,20 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 
 			{
 				const std::string sfo_dir = Emulator::GetSfoDirFromGamePath(dir, Emu.GetUsr());
-				const fs::file sfo_file(sfo_dir + "/PARAM.SFO");
-				if (!sfo_file)
+
+				const psf::registry psf = psf::load_object(fs::file(sfo_dir + "/PARAM.SFO"));
+
+				const std::string_view title_id = psf::get_string(psf, "TITLE_ID", "");
+
+				if (title_id.empty())
 				{
+					// Do not care about invalid entries
 					return;
 				}
 
-				const auto psf = psf::load_object(sfo_file);
-
 				GameInfo game;
 				game.path         = dir;
-				game.serial       = std::string(psf::get_string(psf, "TITLE_ID", ""));
+				game.serial       = std::string(title_id);
 				game.name         = std::string(psf::get_string(psf, "TITLE", cat_unknown_localized));
 				game.app_ver      = std::string(psf::get_string(psf, "APP_VER", cat_unknown_localized));
 				game.version      = std::string(psf::get_string(psf, "VERSION", cat_unknown_localized));

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -55,11 +55,11 @@ namespace
 			}
 
 			// PSF parameters
-			const auto& psf = psf::load_object(fs::file(base_dir + entry.name + "/PARAM.SFO"));
+			const auto [psf, errc] = psf::load(base_dir + entry.name + "/PARAM.SFO");
 
 			if (psf.empty())
 			{
-				gui_log.error("Failed to load savedata: %s", base_dir + "/" + entry.name);
+				gui_log.error("Failed to load savedata: %s (%s)", base_dir + "/" + entry.name, errc);
 				continue;
 			}
 


### PR DESCRIPTION
Previously it crashed the whole emulator if you renamed any random file to PARAM.SFO and place it inside the game/ELF directory.
Now even with hex editor modifying any bit from a valid PARAM.SFO you won't succeed in crashing the emulator. Includes checks from #9998 as well.
Reminder that games technically have permission to (over)write PARAM.SFO files bitwise in /dev_hdd0 game data directories for example so this is a fix for emulation as well. I have used this "feature" in hw tests in the past. cellGame already supports the appropriate error codes for invalid PARAM.SFO.