### PR TITLE
Remove "Use native user interface" setting

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -797,10 +797,10 @@ namespace rsx
 
 		void reset_performance_overlay()
 		{
-			if (!g_cfg.misc.use_native_interface)
+			if (!g_fxo->is_init<rsx::overlays::display_manager>())
 				return;
 
-			if (auto& manager = g_fxo->get<rsx::overlays::display_manager>(); g_fxo->is_init<rsx::overlays::display_manager>())
+			if (auto& manager = g_fxo->get<rsx::overlays::display_manager>(); true)
 			{
 				auto& perf_settings = g_cfg.video.perf_overlay;
 				auto perf_overlay = manager.get<rsx::overlays::perf_metrics_overlay>();

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -380,7 +380,7 @@ namespace rsx
 
 		g_user_asked_for_frame_capture = false;
 
-		if (g_cfg.misc.use_native_interface && (g_cfg.video.renderer == video_renderer::opengl || g_cfg.video.renderer == video_renderer::vulkan))
+		if (g_cfg.video.renderer == video_renderer::opengl || g_cfg.video.renderer == video_renderer::vulkan)
 		{
 			m_overlay_manager = g_fxo->init<rsx::overlays::display_manager>(0);
 		}

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -286,7 +286,6 @@ struct cfg_root : cfg::node
 		cfg::_bool prevent_display_sleep{ this, "Prevent display sleep while running games", true, true };
 		cfg::_bool show_trophy_popups{ this, "Show trophy popups", true, true };
 		cfg::_bool show_shader_compilation_hint{ this, "Show shader compilation hint", true, true };
-		cfg::_bool use_native_interface{ this, "Use native user interface", true };
 		cfg::string gdb_server{ this, "GDB Server", "127.0.0.1:2345" };
 		cfg::_bool silence_all_logs{ this, "Silence All Logs", false, true };
 		cfg::string title_format{ this, "Window Title Format", "FPS: %F | %R | %V | %T [%t]", true };

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -127,7 +127,6 @@ enum class emu_settings_type
 	StartGameFullscreen,
 	PreventDisplaySleep,
 	ShowTrophyPopups,
-	UseNativeInterface,
 	ShowShaderCompilationHint,
 	WindowTitleFormat,
 
@@ -279,7 +278,6 @@ static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::StartGameFullscreen,       { "Miscellaneous", "Start games in fullscreen mode"}},
 	{ emu_settings_type::PreventDisplaySleep,       { "Miscellaneous", "Prevent display sleep while running games"}},
 	{ emu_settings_type::ShowTrophyPopups,          { "Miscellaneous", "Show trophy popups"}},
-	{ emu_settings_type::UseNativeInterface,        { "Miscellaneous", "Use native user interface"}},
 	{ emu_settings_type::ShowShaderCompilationHint, { "Miscellaneous", "Show shader compilation hint"}},
 	{ emu_settings_type::SilenceAllLogs,            { "Miscellaneous", "Silence All Logs" }},
 	{ emu_settings_type::WindowTitleFormat,         { "Miscellaneous", "Window Title Format" }},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1202,9 +1202,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->showTrophyPopups, emu_settings_type::ShowTrophyPopups);
 	SubscribeTooltip(ui->showTrophyPopups, tooltips.settings.show_trophy_popups);
 
-	m_emu_settings->EnhanceCheckBox(ui->useNativeInterface, emu_settings_type::UseNativeInterface);
-	SubscribeTooltip(ui->useNativeInterface, tooltips.settings.use_native_interface);
-
 	m_emu_settings->EnhanceCheckBox(ui->showShaderCompilationHint, emu_settings_type::ShowShaderCompilationHint);
 	SubscribeTooltip(ui->showShaderCompilationHint, tooltips.settings.show_shader_compilation_hint);
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2340,13 +2340,6 @@
                </widget>
               </item>
               <item>
-               <widget class="QCheckBox" name="useNativeInterface">
-                <property name="text">
-                 <string>Use native user interface</string>
-                </property>
-               </widget>
-              </item>
-              <item>
                <widget class="QCheckBox" name="showShaderCompilationHint">
                 <property name="text">
                  <string>Show shader compilation hint</string>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -115,7 +115,6 @@ public:
 		const QString show_mouse_in_fullscreen     = tr("Shows the mouse cursor when the fullscreen mode is active.\nCurrently this may not work every time.");
 		const QString hide_mouse_on_idle           = tr("Hides the mouse cursor if no mouse movement is detected for the configured time.");
 		const QString show_shader_compilation_hint = tr("Shows 'Compiling shaders' hint using the native overlay.");
-		const QString use_native_interface         = tr("Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, the on-screen keyboard only supports the English key layout.");
 
 		const QString perf_overlay_enabled                 = tr("Enables or disables the performance overlay.");
 		const QString perf_overlay_framerate_graph_enabled = tr("Enables or disables the framerate graph.");


### PR DESCRIPTION
With #10003 that makes RSX always available to process native overlays, and #8386 that removes that last non-native qt dialog, there is no much need of this setting. Qt dialogs are used with null renderer though.