### PR TITLE
debugger: Implement ability to pause entire emulation on breakpoint

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -73,6 +73,7 @@ class debugger_frame : public custom_dock_widget
 
 	cpu_thread* get_cpu();
 	std::function<cpu_thread*()> make_check_cpu(cpu_thread* cpu);
+	void open_breakpoints_settings();
 
 public:
 	explicit debugger_frame(std::shared_ptr<gui_settings> settings, QWidget *parent = 0);


### PR DESCRIPTION
ctrl+B invokes new breakpoints settings window with a setting to alter default breakpoint behavior. When unchecked: only the hitted thread will be paused (previous breakpoints behavior). When checked (the new default): the emulatoion will paused entirely on such case.