### PR TITLE
cli: set user-id per command line

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -196,7 +196,9 @@ public:
 		return m_usrid;
 	}
 
-	bool SetUsr(const std::string& user);
+	static u32 CheckUsr(const std::string& user);
+
+	void SetUsr(const std::string& user);
 
 	std::string GetBackgroundPicturePath() const;
 

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -16,7 +16,7 @@ headless_application::headless_application(int& argc, char** argv) : QCoreApplic
 bool headless_application::Init()
 {
 	// Force init the emulator
-	InitializeEmulator("00000001", true, false); // TODO: get user from cli args if possible
+	InitializeEmulator(m_active_user.empty() ? "00000001" : m_active_user, false);
 
 	// Create callbacks from the emulator, which reference the handlers.
 	InitializeCallbacks();
@@ -24,7 +24,7 @@ bool headless_application::Init()
 	// Create connects to propagate events throughout Gui.
 	InitializeConnects();
 
-	// As per QT recommendations to avoid conflicts for POSIX functions
+	// As per Qt recommendations to avoid conflicts for POSIX functions
 	std::setlocale(LC_NUMERIC, "C");
 
 	return true;

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -33,21 +33,12 @@
 
 LOG_CHANNEL(sys_log, "SYS");
 
-/** Emu.Init() wrapper for user manager */
-bool main_application::InitializeEmulator(const std::string& user, bool force_init, bool show_gui)
+/** Emu.Init() wrapper for user management */
+void main_application::InitializeEmulator(const std::string& user, bool show_gui)
 {
 	Emu.SetHasGui(show_gui);
-
-	// try to set a new user
-	const bool user_was_set = Emu.SetUsr(user);
-
-	// only init the emulation if forced or a user was set
-	if (user_was_set || force_init)
-	{
-		Emu.Init();
-	}
-
-	return user_was_set;
+	Emu.SetUsr(user);
+	Emu.Init();
 }
 
 /** RPCS3 emulator has functions it desires to call from the GUI at times. Initialize them in here. */

--- a/rpcs3/main_application.h
+++ b/rpcs3/main_application.h
@@ -10,12 +10,18 @@ class main_application
 public:
 	virtual bool Init() = 0;
 
-	static bool InitializeEmulator(const std::string& user, bool force_init, bool show_gui);
+	static void InitializeEmulator(const std::string& user, bool show_gui);
+
+	void SetActiveUser(std::string user)
+	{
+		m_active_user = user;
+	}
 
 protected:
 	virtual QThread* get_thread() = 0;
 
 	EmuCallbacks CreateCallbacks();
 
+	std::string m_active_user;
 	QWindow* m_game_window = nullptr; // (Currently) only needed so that pad handlers have a valid target for event filtering.
 };

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -63,14 +63,18 @@ bool gui_application::Init()
 		return false;
 	}
 
-	// Get deprecated active user (before August 2nd 2020)
-	QString active_user = m_gui_settings->GetValue(gui::um_active_user).toString();
+	// The user might be set by cli arg. If not, set another user.
+	if (m_active_user.empty())
+	{
+		// Get deprecated active user (before August 2nd 2020)
+		const QString active_user = m_gui_settings->GetValue(gui::um_active_user).toString();
 
-	// Get active user with deprecated active user as fallback
-	active_user = m_persistent_settings->GetCurrentUser(active_user.isEmpty() ? "00000001" : active_user);
+		// Get active user with deprecated active user as fallback
+		m_active_user = m_persistent_settings->GetCurrentUser(active_user.isEmpty() ? "00000001" : active_user).toStdString();
+	}
 
 	// Force init the emulator
-	InitializeEmulator(active_user.toStdString(), true, m_show_gui);
+	InitializeEmulator(m_active_user, m_show_gui);
 
 	// Create the main window
 	if (m_show_gui)

--- a/rpcs3/rpcs3qt/user_account.cpp
+++ b/rpcs3/rpcs3qt/user_account.cpp
@@ -7,7 +7,7 @@
 
 LOG_CHANNEL(gui_log, "GUI");
 
-UserAccount::UserAccount(const std::string& user_id)
+user_account::user_account(const std::string& user_id)
 {
 	// Setting userId.
 	m_user_id = user_id;
@@ -16,8 +16,7 @@ UserAccount::UserAccount(const std::string& user_id)
 	m_user_dir = Emulator::GetHddDir() + "home/" + m_user_id + "/";
 
 	// Setting userName.
-	fs::file file;
-	if (file.open(m_user_dir + "localusername", fs::read))
+	if (fs::file file; file.open(m_user_dir + "localusername", fs::read))
 	{
 		m_username = file.to_string();
 		file.close();
@@ -25,15 +24,48 @@ UserAccount::UserAccount(const std::string& user_id)
 		if (m_username.length() > 16) // max of 16 chars on real PS3
 		{
 			m_username = m_username.substr(0, 16);
-			gui_log.warning("UserAccount: localusername of userId=%s was too long, cropped to: %s", m_user_id, m_username);
+			gui_log.warning("user_account: localusername of userId=%s was too long, cropped to: %s", m_user_id, m_username);
 		}
 	}
 	else
 	{
-		gui_log.error("UserAccount: localusername file read error (userId=%s, userDir=%s).", m_user_id, m_user_dir);
+		gui_log.error("user_account: localusername file read error (userId=%s, userDir=%s).", m_user_id, m_user_dir);
 	}
 }
 
-UserAccount::~UserAccount()
+user_account::~user_account()
 {
+}
+
+std::map<u32, user_account> user_account::GetUserAccounts(const std::string& base_dir)
+{
+	std::map<u32, user_account> user_list;
+
+	// I believe this gets the folder list sorted alphabetically by default,
+	// but I can't find proof of this always being true.
+	for (const auto& user_folder : fs::dir(base_dir))
+	{
+		if (!user_folder.is_directory)
+		{
+			continue;
+		}
+
+		// Is the folder name exactly 8 all-numerical characters long?
+		const u32 key = Emulator::CheckUsr(user_folder.name);
+
+		if (key == 0)
+		{
+			continue;
+		}
+
+		// Does the localusername file exist?
+		if (!fs::is_file(base_dir + "/" + user_folder.name + "/localusername"))
+		{
+			continue;
+		}
+
+		user_list.emplace(key, user_account(user_folder.name));
+	}
+
+	return user_list;
 }

--- a/rpcs3/rpcs3qt/user_account.h
+++ b/rpcs3/rpcs3qt/user_account.h
@@ -1,20 +1,25 @@
 #pragma once
 
+#include "util/types.hpp"
+
+#include <map>
 #include <string>
 
 // Do not confuse this with the "user" in Emu/System.h. 
 // That user is read from config.yml, and it only represents the currently "logged in" user.
-// The UserAccount class will represent all users in the home directory for the User Manager dialog.
+// The user_account class will represent all users in the home directory for the User Manager dialog.
 // Selecting a user account in this dialog and saving writes it to config.yml.
-class UserAccount
+class user_account
 {
 public:
-	explicit UserAccount(const std::string& user_id = "00000001");
+	explicit user_account(const std::string& user_id = "00000001");
 
-	std::string GetUserId() { return m_user_id; }
-	std::string GetUserDir() { return m_user_dir; }
-	std::string GetUsername() { return m_username; }
-	~UserAccount();
+	std::string GetUserId() const { return m_user_id; }
+	std::string GetUserDir() const { return m_user_dir; }
+	std::string GetUsername() const { return m_username; }
+	~user_account();
+
+	static std::map<u32, user_account> GetUserAccounts(const std::string& base_dir);
 
 private:
 	std::string m_user_id;

--- a/rpcs3/rpcs3qt/user_manager_dialog.h
+++ b/rpcs3/rpcs3qt/user_manager_dialog.h
@@ -40,7 +40,7 @@ private:
 
 	QTableWidget* m_table;
 	std::string m_active_user;
-	std::map<u32, UserAccount> m_user_list;
+	std::map<u32, user_account> m_user_list;
 
 	std::shared_ptr<gui_settings> m_gui_settings;
 	std::shared_ptr<persistent_settings> m_persistent_settings;


### PR DESCRIPTION
- Let the user boot RPCS3 with any valid user-id (will be created if necessary)
- Adds stricter error handling when setting a new user
- Fix a possible crash if the emulator is Quit before being initialized (usually unreachable code)

closes #10052