### PR TITLE
Fix vsh.self imports/exports and more improvements

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1546,6 +1546,12 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		load_libs.emplace("libsysmodule.sprx");
 	}
 
+	if (g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
+	{
+		// Cannot be used with vsh.self (it self-manages itself)
+		load_libs.clear();
+	}
+
 	const std::string lle_dir = vfs::get("/dev_flash/sys/external/");
 
 	if (!fs::is_file(lle_dir + "liblv2.sprx"))
@@ -1686,7 +1692,6 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 	}
 
 	// Initialize memory stats (according to sdk version)
-	// TODO: This is probably wrong with vsh.self
 	u32 mem_size;
 	if (sdk_version > 0x0021FFFF)
 	{
@@ -1719,11 +1724,18 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		mem_size += 0xC000000;
 	}
 
+	if (g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
+	{
+		// Because vsh.self comes before any generic application, more memory is available to it
+		// This is an estimation though (TODO)
+		mem_size += 0x800000;
+	}
+
 	g_fxo->init<lv2_memory_container>(mem_size)->used += primary_stacksize;
 
 	ppu->cmd_push({ppu_cmd::initialize, 0});
 
-	if (!entry)
+	if (!entry && g_ps3_process_info.get_cellos_appname() != "vsh.self"sv)
 	{
 		// Set TLS args, call sys_initialize_tls
 		ppu->cmd_list
@@ -1731,7 +1743,10 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 			{ ppu_cmd::set_args, 4 }, u64{ppu->id}, u64{tls_vaddr}, u64{tls_fsize}, u64{tls_vsize},
 			{ ppu_cmd::hle_call, FIND_FUNC(sys_initialize_tls) },
 		});
+	}
 
+	if (!entry)
+	{
 		entry = static_cast<u32>(elf.header.e_entry); // Run entry from elf
 	}
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -699,6 +699,16 @@ static auto ppu_load_imports(std::vector<ppu_reloc>& relocs, ppu_linkage_info* l
 	return result;
 }
 
+// For _sys_prx_register_module
+void ppu_manual_load_imports_exports(u32 imports_start, u32 imports_size, u32 exports_start, u32 exports_size)
+{
+	auto& _main = g_fxo->get<ppu_module>();
+	auto& link = g_fxo->get<ppu_linkage_info>();
+
+	ppu_load_exports(&link, exports_start, exports_start + exports_size);
+	ppu_load_imports(_main.relocs, &link, imports_start, imports_start + imports_size);
+}
+
 static void ppu_check_patch_spu_images(const ppu_segment& seg)
 {
 	const std::string_view seg_view{vm::get_super_ptr<char>(seg.addr), seg.size};

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -45,6 +45,17 @@ bool ps3_process_info_t::has_debug_perm() const
 	return (ctrl_flags1 & (0xa << 28)) != 0;
 }
 
+// If a SELF file is of CellOS return its filename, otheriwse return an empty string 
+std::string_view ps3_process_info_t::get_cellos_appname() const
+{
+	if (!has_root_perm() || !Emu.GetTitleID().empty())
+	{
+		return {};
+	}
+
+	return std::string_view(Emu.GetBoot()).substr(Emu.GetBoot().find_last_of('/') + 1);
+}
+
 LOG_CHANNEL(sys_process);
 
 ps3_process_info_t g_ps3_process_info;

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -48,6 +48,7 @@ struct ps3_process_info_t
 	bool has_root_perm() const;
 	bool has_debug_perm() const;
 	bool debug_or_root() const;
+	std::string_view get_cellos_appname() const;
 };
 
 extern ps3_process_info_t  g_ps3_process_info;

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -608,11 +608,64 @@ error_code _sys_prx_unload_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sy
 	return CELL_OK;
 }
 
-error_code _sys_prx_register_module(ppu_thread& ppu)
+void ppu_manual_load_imports_exports(u32 imports_start, u32 imports_size, u32 exports_start, u32 exports_size);
+
+error_code _sys_prx_register_module(ppu_thread& ppu, vm::cptr<char> name, vm::ptr<void> opt)
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_prx.todo("_sys_prx_register_module()");
+	sys_prx.todo("_sys_prx_register_module(name=%s, opt=*0x%x)", name, opt);
+
+	if (!opt)
+	{
+		return CELL_EINVAL;
+	}
+
+	sys_prx_register_module_0x30_type_1_t info{};
+
+	switch (const u64 size_struct = vm::read64(opt.addr()))
+	{
+	case 0x1c:
+	case 0x20:
+	{
+		const auto _info = vm::static_ptr_cast<sys_prx_register_module_0x20_t>(opt);
+
+		sys_prx.todo("_sys_prx_register_module(): opt size is 0x%x", size_struct);
+
+		// Rebuild info with corresponding members of old structures
+		// Weird that type is set to 0 because 0 means NO-OP in this syscall
+		info.size = 0x30;
+		info.lib_stub_size = _info->stubs_size;
+		info.lib_stub_ea = _info->stubs_ea;
+		info.error_handler = _info->error_handler;
+		info.type = 0;
+		break;
+	}
+	case 0x30:
+	{
+		std::memcpy(&info, opt.get_ptr(), sizeof(info));
+		break;
+	}
+	default: return CELL_EINVAL;
+	}
+
+	sys_prx.warning("opt: size=0x%x, type=0x%x, unk3=0x%x, unk4=0x%x, lib_entries_ea=%s, lib_entries_size=0x%x"
+		", lib_stub_ea=%s, lib_stub_size=0x%x, error_handler=%s", info.size, info.type, info.unk3, info.unk4
+		, info.lib_entries_ea, info.lib_entries_size, info.lib_stub_ea, info.lib_stub_size, info.error_handler);
+
+	if (info.type & 0x1)
+	{
+		if (g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
+		{
+			ppu_manual_load_imports_exports(info.lib_stub_ea.addr(), info.lib_stub_size, info.lib_entries_ea.addr(), info.lib_entries_size);
+		}
+		else
+		{
+			// Only VSH is allowed to load it manually
+			return not_an_error(CELL_PRX_ERROR_ELF_IS_REGISTERED);
+		}
+	}
+
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -118,6 +118,31 @@ struct sys_prx_get_module_list_option_t
 	be_t<u32> unk; // 0
 };
 
+struct sys_prx_register_module_0x20_t
+{
+	be_t<u64> size; // 0x0
+	be_t<u32> toc; // 0x8
+	be_t<u32> toc_size; // 0xC
+	vm::bptr<void> stubs_ea; // 0x10
+	be_t<u32> stubs_size; // 0x14
+	vm::bptr<void> error_handler; // 0x18
+	char pad[4]; // 0x1C
+};
+
+struct sys_prx_register_module_0x30_type_1_t
+{
+	be_t<u64> size; // 0x0
+	be_t<u64> type; // 0x8
+	be_t<u32> unk3; // 0x10
+	be_t<u32> unk4; // 0x14
+	vm::bptr<void> lib_entries_ea; // 0x18
+	be_t<u32> lib_entries_size; // 0x1C
+	vm::bptr<void> lib_stub_ea; // 0x20
+	be_t<u32> lib_stub_size; // 0x24
+	vm::bptr<void> error_handler; // 0x28
+	char pad[4]; // 0x2C
+};
+
 enum : u32
 {
 	SYS_PRX_RESIDENT = 0,
@@ -172,7 +197,7 @@ error_code _sys_prx_load_module(ppu_thread& ppu, vm::cptr<char> path, u64 flags,
 error_code _sys_prx_start_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sys_prx_start_stop_module_option_t> pOpt);
 error_code _sys_prx_stop_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sys_prx_start_stop_module_option_t> pOpt);
 error_code _sys_prx_unload_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sys_prx_unload_module_option_t> pOpt);
-error_code _sys_prx_register_module(ppu_thread& ppu);
+error_code _sys_prx_register_module(ppu_thread& ppu, vm::cptr<char> name, vm::ptr<void> opt);
 error_code _sys_prx_query_module(ppu_thread& ppu);
 error_code _sys_prx_register_library(ppu_thread& ppu, vm::ptr<void> library);
 error_code _sys_prx_unregister_library(ppu_thread& ppu, vm::ptr<void> library);

--- a/rpcs3/Emu/Cell/lv2/sys_sm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_sm.cpp
@@ -12,6 +12,11 @@ error_code sys_sm_get_params(vm::ptr<u8> a, vm::ptr<u8> b, vm::ptr<u32> c, vm::p
 {
 	sys_sm.todo("sys_sm_get_params(a=*0x%x, b=*0x%x, c=*0x%x, d=*0x%x)", a, b, c, d);
 
+	if (a) *a = 0; else return CELL_EFAULT;
+	if (b) *b = 0; else return CELL_EFAULT;
+	if (c) *c = 0x200; else return CELL_EFAULT;
+	if (d) *d = 7; else return CELL_EFAULT;
+
 	return CELL_OK;
 }
 


### PR DESCRIPTION
* Probably a limitation of vsh.self loader itself, it does not load imports/exports nor its information is recorded within its ELF sections. What vsh.self does is to load it manually via a previously unimplemented syscall.
* Do not require special settings to load VSH such as Debug Console Mode or HLE liblv2.sprx.

Gets it to further to execute sys_rsxaudio stuff. 