### PR TITLE
hotfix: skip progress dialogs if msg dialogs are open

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -311,7 +311,7 @@ namespace rsx
 			text_display.translate(0, -(text_h - 16));
 		}
 
-		u32 message_dialog::progress_bar_count()
+		u32 message_dialog::progress_bar_count() const
 		{
 			return num_progress_bars;
 		}

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
@@ -37,7 +37,7 @@ namespace rsx
 
 			void set_text(const std::string& text);
 
-			u32 progress_bar_count();
+			u32 progress_bar_count() const;
 			void progress_bar_set_taskbar_index(s32 index);
 			error_code progress_bar_set_message(u32 index, const std::string& msg);
 			error_code progress_bar_increment(u32 index, f32 value);


### PR DESCRIPTION
This is just a workaround, but we probably need kd to fix this properly.
fixes #10051