### PR TITLE
moved build options to options.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,17 +12,8 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
 	endif()
 endif()
 
-option(USE_NATIVE_INSTRUCTIONS "USE_NATIVE_INSTRUCTIONS makes rpcs3 compile with -march=native, which is useful for local builds, but not good for packages." ON)
-option(WITH_LLVM "Enable usage of LLVM library" ON)
-option(BUILD_LLVM_SUBMODULE "Build LLVM from git submodule" ON)
-option(USE_ALSA "ALSA audio backend" ON)
-option(USE_PULSE "PulseAudio audio backend" ON)
-option(USE_FAUDIO "FAudio audio backend" ON)
-option(USE_LIBEVDEV "libevdev-based joystick support" ON)
-option(USE_DISCORD_RPC "Discord rich presence integration" ON)
-option(USE_SYSTEM_ZLIB "Prefer system ZLIB instead of the builtin one" ON)
-option(USE_VULKAN "Vulkan render backend" ON)
-option(USE_PRECOMPILED_HEADERS "Use precompiled headers" OFF)
+# include build options
+include(options.cmake)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/rpcs3/cmake_modules")
 

--- a/options.cmake
+++ b/options.cmake
@@ -1,0 +1,78 @@
+# rpcs3 project build options
+#========================================================================
+
+
+# linker args
+#========================================================================
+
+option(
+    USE_SYSTEM_ZLIB
+    "Prefer system ZLIB instead of the builtin one"
+    ON
+)
+
+option(
+    USE_PRECOMPILED_HEADERS
+    "Use precompiled headers"
+    OFF
+)
+
+# build options
+#========================================================================
+
+
+# "USE_NATIVE_INSTRUCTIONS makes rpcs3 compile with -march=native,
+#  which is useful for local builds, but not good for packages.
+option(
+    USE_NATIVE_INSTRUCTIONS
+    "Enable march=native compatibility"
+    ON
+)
+
+option(
+    WITH_LLVM
+    "Enable usage of LLVM library"
+    ON
+)
+
+option(
+    BUILD_LLVM_SUBMODULE
+    "Build LLVM from git submodule"
+    ON
+)
+
+option(
+    USE_ALSA
+    "Use ALSA audio backend"
+    ON
+)
+
+option(
+    USE_PULSE
+    "Use PulseAudio audio backend"
+    ON
+)
+
+option(
+    USE_FAUDIO
+    "Use FAudio audio backend"
+    ON
+)
+
+option(
+    USE_LIBEVDEV
+    "Enable libevdev-based joystick support"
+    ON
+)
+
+option(
+    USE_DISCORD_RPC
+    "Enable Discord rich presence integration"
+    ON
+)
+
+option(
+    USE_VULKAN
+    "Enable Vulkan render backend"
+    ON
+)


### PR DESCRIPTION
Moved the CMake build options to a dedicated file. Makes
configuring build options easier when not using the CMake
GUI.  