### PR TITLE
Update OpenSUSE dependencies

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -86,7 +86,7 @@ sudo apt-get install cmake
 
 #### OpenSUSE
 
-    sudo zypper install git cmake libasound2 libpulse-devel openal-soft-devel glew-devel zlib-devel libedit-devel vulkan-devel libudev-devel libqt5-qtbase-devel libevdev-devel
+    sudo zypper install git cmake libasound2 libpulse-devel openal-soft-devel glew-devel zlib-devel libedit-devel vulkan-devel libudev-devel libqt5-qtbase-devel libqt5gui-private-headers-devel libevdev-devel
 
 ## Setup the project
 


### PR DESCRIPTION
Added `libqt5gui-private-headers-devel` dependency to fix `fatal error: qpa/qplatformnativeinterface.h: No such file or directory`