### PR TITLE
Log firmware after Emu was initialized

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -440,19 +440,16 @@ int main(int argc, char** argv)
 		log_file = logs::make_file_listener(fs::get_cache_dir() + "RPCS3.log", stats.avail_free / 4);
 	}
 
-	static std::unique_ptr<logs::listener> log_pauser = std::make_unique<fatal_error_listener>();
-	logs::listener::add(log_pauser.get());
+	static std::unique_ptr<logs::listener> fatal_listener = std::make_unique<fatal_error_listener>();
+	logs::listener::add(fatal_listener.get());
 
 	{
-		const std::string firmware_version = utils::get_firmware_version();
-		const std::string firmware_string  = firmware_version.empty() ? " | Missing Firmware" : (" | Firmware version: " + firmware_version);
-
 		// Write RPCS3 version
 		logs::stored_message ver;
 		ver.m.ch  = nullptr;
 		ver.m.sev = logs::level::always;
 		ver.stamp = 0;
-		ver.text  = fmt::format("RPCS3 v%s | %s%s", rpcs3::get_version().to_string(), rpcs3::get_branch(), firmware_string);
+		ver.text  = fmt::format("RPCS3 v%s | %s", rpcs3::get_version().to_string(), rpcs3::get_branch());
 
 		// Write System information
 		logs::stored_message sys;

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -2,6 +2,7 @@
 
 #include "util/types.hpp"
 #include "util/logs.hpp"
+#include "util/sysinfo.hpp"
 
 #include "Input/pad_thread.h"
 #include "Emu/System.h"
@@ -38,6 +39,11 @@ void main_application::InitializeEmulator(const std::string& user, bool show_gui
 	Emu.SetHasGui(show_gui);
 	Emu.SetUsr(user);
 	Emu.Init();
+
+	// Log Firmware Version after Emu was initialized
+	const std::string firmware_version = utils::get_firmware_version();
+	const std::string firmware_string  = firmware_version.empty() ? "Missing Firmware" : ("Firmware version: " + firmware_version);
+	sys_log.always("%s", firmware_string);
 }
 
 /** RPCS3 emulator has functions it desires to call from the GUI at times. Initialize them in here. */

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -67,11 +67,8 @@ bool gui_application::Init()
 	// The user might be set by cli arg. If not, set another user.
 	if (m_active_user.empty())
 	{
-		// Get deprecated active user (before August 2nd 2020)
-		const QString active_user = m_gui_settings->GetValue(gui::um_active_user).toString();
-
-		// Get active user with deprecated active user as fallback
-		m_active_user = m_persistent_settings->GetCurrentUser(active_user.isEmpty() ? "00000001" : active_user).toStdString();
+		// Get active user with standard user as fallback
+		m_active_user = m_persistent_settings->GetCurrentUser("00000001").toStdString();
 	}
 
 	// Force init the emulator

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -230,7 +230,6 @@ namespace gui
 	const gui_save sd_icon_color = gui_save(savedata, "icon_color", gl_icon_color);
 
 	const gui_save um_geometry    = gui_save(users, "geometry",    QByteArray());
-	const gui_save um_active_user = gui_save(users, "active_user", ""); // Deprecated
 
 	const gui_save loc_language = gui_save(localization, "language", "en");
 

--- a/rpcs3/rpcs3qt/persistent_settings.cpp
+++ b/rpcs3/rpcs3qt/persistent_settings.cpp
@@ -1,6 +1,7 @@
 #include "persistent_settings.h"
 
 #include "util/logs.hpp"
+#include "Emu/System.h"
 
 LOG_CHANNEL(cfg_log, "CFG");
 
@@ -47,15 +48,12 @@ QString persistent_settings::GetCurrentUser(const QString& fallback) const
 		user = fallback;
 	}
 
-	bool is_valid_user;
-	const u32 user_id = user.toInt(&is_valid_user);
-
 	// Set user if valid
-	if (is_valid_user && user_id > 0)
+	if (Emulator::CheckUsr(user.toStdString()) > 0)
 	{
 		return user;
 	}
 
-	cfg_log.fatal("Could not parse user setting: '%s' = '%d'.", user.toStdString(), user_id);
+	cfg_log.fatal("Could not parse user setting: '%s'.", user.toStdString());
 	return QString();
 }

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -88,19 +88,8 @@ void user_manager_dialog::Init()
 	vbox_main->addLayout(hbox_buttons);
 	setLayout(vbox_main);
 
-	m_active_user = m_persistent_settings->GetValue(gui::persistent::active_user).toString().toStdString();
-
-	// Handle deprecated value (before August 2nd 2020)
-	if (m_active_user.empty())
-	{
-		m_active_user = m_gui_settings->GetValue(gui::um_active_user).toString().toStdString();
-		m_gui_settings->RemoveValue(gui::um_active_user);
-
-		if (!m_active_user.empty())
-		{
-			m_persistent_settings->SetValue(gui::persistent::active_user, qstr(m_active_user));
-		}
-	}
+	// Get the active user
+	m_active_user = m_persistent_settings->GetCurrentUser("00000001").toStdString();
 
 	// Get the real active user (might differ, set by cli)
 	if (m_active_user != Emu.GetUsr())

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
@@ -11,7 +11,7 @@ inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 vfs_dialog_tab::vfs_dialog_tab(vfs_settings_info settingsInfo, std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent)
 	: QWidget(parent), m_info(std::move(settingsInfo)), m_gui_settings(std::move(guiSettings)), m_emu_settings(std::move(emuSettings))
 {
-	m_dirList = new QListWidget(this);
+	m_dir_dist = new QListWidget(this);
 
 	QStringList alldirs = m_gui_settings->GetValue(m_info.listLocation).toStringList();
 	const QString current_dir = qstr(m_info.cfg_node->to_string());
@@ -20,77 +20,70 @@ vfs_dialog_tab::vfs_dialog_tab(vfs_settings_info settingsInfo, std::shared_ptr<g
 
 	for (const QString& dir : alldirs)
 	{
-		QListWidgetItem* item = new QListWidgetItem(dir, m_dirList);
+		QListWidgetItem* item = new QListWidgetItem(dir, m_dir_dist);
 		if (dir == current_dir)
 			selected_item = item;
 	}
 
 	// We must show the currently selected config.
 	if (!selected_item)
-		selected_item = new QListWidgetItem(current_dir, m_dirList);
+		selected_item = new QListWidgetItem(current_dir, m_dir_dist);
 
 	selected_item->setSelected(true);
 
-	m_dirList->setMinimumWidth(m_dirList->sizeHintForColumn(0));
+	m_dir_dist->setMinimumWidth(m_dir_dist->sizeHintForColumn(0));
 
 	QPushButton* addDir = new QPushButton(QStringLiteral("+"));
 	addDir->setToolTip(tr("Add new directory"));
 	addDir->setFixedWidth(addDir->sizeHint().height()); // Make button square
 	connect(addDir, &QAbstractButton::clicked, this, &vfs_dialog_tab::AddNewDirectory);
 
-	QPushButton* removeDir = new QPushButton(QStringLiteral("-"));
-	removeDir->setToolTip(tr("Remove directory"));
-	removeDir->setFixedWidth(removeDir->sizeHint().height()); // Make button square
-	removeDir->setEnabled(false);
-	connect(removeDir, &QAbstractButton::clicked, this, &vfs_dialog_tab::RemoveDirectory);
+	QPushButton* button_remove_dir = new QPushButton(QStringLiteral("-"));
+	button_remove_dir->setToolTip(tr("Remove directory"));
+	button_remove_dir->setFixedWidth(button_remove_dir->sizeHint().height()); // Make button square
+	button_remove_dir->setEnabled(false);
+	connect(button_remove_dir, &QAbstractButton::clicked, this, &vfs_dialog_tab::RemoveDirectory);
 
-	QHBoxLayout* selectedConfigLayout = new QHBoxLayout;
-	m_selectedConfigLabel = new QLabel(current_dir.isEmpty() ? EmptyPath : current_dir);
-	selectedConfigLayout->addWidget(new QLabel(tr("%0 directory:").arg(m_info.name)));
-	selectedConfigLayout->addWidget(m_selectedConfigLabel);
-	selectedConfigLayout->addStretch();
-	selectedConfigLayout->addWidget(addDir);
-	selectedConfigLayout->addWidget(removeDir);
+	QHBoxLayout* selected_config_layout = new QHBoxLayout;
+	m_selected_config_label = new QLabel(current_dir.isEmpty() ? EmptyPath : current_dir);
+	selected_config_layout->addWidget(new QLabel(tr("%0 directory:").arg(m_info.name)));
+	selected_config_layout->addWidget(m_selected_config_label);
+	selected_config_layout->addStretch();
+	selected_config_layout->addWidget(addDir);
+	selected_config_layout->addWidget(button_remove_dir);
 
 	QVBoxLayout* vbox = new QVBoxLayout;
-	vbox->addWidget(m_dirList);
-	vbox->addLayout(selectedConfigLayout);
+	vbox->addWidget(m_dir_dist);
+	vbox->addLayout(selected_config_layout);
 
 	setLayout(vbox);
 
-	connect(m_dirList, &QListWidget::currentItemChanged, [this](QListWidgetItem* current, QListWidgetItem*)
+	connect(m_dir_dist, &QListWidget::currentRowChanged, button_remove_dir, [this, button_remove_dir](int row)
 	{
-		if (!current)
-			return;
-
-		m_selectedConfigLabel->setText(current->text().isEmpty() ? EmptyPath : current->text());
-	});
-
-	connect(m_dirList, &QListWidget::currentRowChanged, [this, removeDir](int row)
-	{
-		SetCurrentRow(row);
-		removeDir->setEnabled(row > 0);
+		QListWidgetItem* item = m_dir_dist->item(row);
+		m_selected_config_label->setText((item && !item->text().isEmpty()) ? item->text() : EmptyPath);
+		button_remove_dir->setEnabled(item && row > 0);
 	});
 }
 
 void vfs_dialog_tab::SetSettings() const
 {
 	QStringList allDirs;
-	for (int i = 0; i < m_dirList->count(); ++i)
+	for (int i = 0; i < m_dir_dist->count(); ++i)
 	{
-		allDirs += m_dirList->item(i)->text();
+		allDirs += m_dir_dist->item(i)->text();
 	}
 	m_gui_settings->SetValue(m_info.listLocation, allDirs);
 
-	const std::string new_dir = m_selectedConfigLabel->text() == EmptyPath ? "" : sstr(m_selectedConfigLabel->text());
+	const std::string new_dir = m_selected_config_label->text() == EmptyPath ? "" : sstr(m_selected_config_label->text());
 	m_info.cfg_node->from_string(new_dir);
 	m_emu_settings->SetSetting(m_info.settingLoc, new_dir);
 }
 
 void vfs_dialog_tab::Reset() const
 {
-	m_dirList->clear();
-	m_dirList->setCurrentItem(new QListWidgetItem(qstr(m_info.cfg_node->def), m_dirList));
+	m_dir_dist->clear();
+	m_dir_dist->setCurrentItem(new QListWidgetItem(qstr(m_info.cfg_node->def), m_dir_dist));
 }
 
 void vfs_dialog_tab::AddNewDirectory() const
@@ -103,11 +96,15 @@ void vfs_dialog_tab::AddNewDirectory() const
 	if (!dir.endsWith("/"))
 		dir += '/';
 
-	m_dirList->setCurrentItem(new QListWidgetItem(dir, m_dirList));
+	m_dir_dist->setCurrentItem(new QListWidgetItem(dir, m_dir_dist));
 }
 
 void vfs_dialog_tab::RemoveDirectory() const
 {
-	QListWidgetItem* item = m_dirList->takeItem(m_currentRow);
-	delete item;
+	const int row = m_dir_dist->currentRow();
+	if (row > 0)
+	{
+		QListWidgetItem* item = m_dir_dist->item(row);
+		delete item;
+	}
 }

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.h
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.h
@@ -39,16 +39,14 @@ public:
 private:
 	void AddNewDirectory() const;
 	void RemoveDirectory() const;
-	void SetCurrentRow(int row) { m_currentRow = row; }
 
 	const QString EmptyPath = tr("Empty Path");
 
 	vfs_settings_info m_info;
 	std::shared_ptr<gui_settings> m_gui_settings;
 	std::shared_ptr<emu_settings> m_emu_settings;
-	int m_currentRow = -1;
 
 	// UI variables needed in higher scope
-	QListWidget* m_dirList;
-	QLabel* m_selectedConfigLabel;
+	QListWidget* m_dir_dist;
+	QLabel* m_selected_config_label;
 };


### PR DESCRIPTION
- This fixes "Firmare missing" for users who use VFS for dev_flash
- Fixes some glitch with the VFS dir remove button. It was sometimes enabled but didn't work.
- Also removes some deprecated setting due to latest updates.