### PR TITLE
Cirrus warning fix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ env:
   SYSTEM_PULLREQUEST_SOURCEBRANCH: $CIRRUS_BRANCH
   SYSTEM_PULLREQUEST_PULLREQUESTID: $CIRRUS_PR
   BUILD_SOURCEVERSION: $CIRRUS_CHANGE_IN_REPO
-  RPCS3_TOKEN: ENCRYPTED[13a0f18de9285e6c880e3aecbb54258245a74872af7d0fcb92447fa1200ceb6a4dc8acc880ddbf5e653d46336563ca72] # Replace this when we're using Cirrus for master releases!!
+#  RPCS3_TOKEN: ENCRYPTED[13a0f18de9285e6c880e3aecbb54258245a74872af7d0fcb92447fa1200ceb6a4dc8acc880ddbf5e653d46336563ca72] # Replace this when we're using Cirrus for master releases!!
 
 windows_task:
   matrix:


### PR DESCRIPTION
Comment out the GitHub upload token for now, since we're not using Cirrus to upload master builds. Also Azure builds are still configured as required for PRs, someone should probably change that.
Avoids this:
![image](https://user-images.githubusercontent.com/1712979/114284789-fdc1c200-9a5a-11eb-8e01-42769725c2cc.png)