### PR TITLE
GL/VK: ReSharper findings

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -2,7 +2,6 @@
 #include "GLFragmentProgram.h"
 
 #include "Emu/system_config.h"
-#include "GLFragmentProgram.h"
 #include "GLCommonDecompiler.h"
 #include "../GCM.h"
 #include "../Common/GLSLCommon.h"

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
@@ -64,7 +64,6 @@ public:
 	/**
 	 * Decompile a fragment shader located in the PS3's Memory.  This function operates synchronously.
 	 * @param prog RSXShaderProgram specifying the location and size of the shader in memory
-	 * @param td texture dimensions of input textures
 	 */
 	void Decompile(const RSXFragmentProgram& prog);
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -3,13 +3,10 @@
 #include "../Overlays/Shaders/shader_loading_dialog_native.h"
 #include "GLGSRender.h"
 #include "GLCompute.h"
-#include "GLVertexProgram.h"
 #include "Emu/Memory/vm_locking.h"
 #include "Emu/RSX/rsx_methods.h"
 
 #include "../Common/program_state_cache2.hpp"
-
-#define DUMP_VERTEX_DATA 0
 
 u64 GLGSRender::get_cycles()
 {
@@ -588,7 +585,7 @@ void GLGSRender::clear_surface(u32 arg)
 		case rsx::surface_color_format::w16z16y16x16:
 		case rsx::surface_color_format::w32z32y32x32:
 		{
-			//Nop
+			// Nop
 			colormask = 0;
 			break;
 		}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -194,7 +194,4 @@ protected:
 	void on_invalidate_memory_range(const utils::address_range &range, rsx::invalidation_cause cause) override;
 	void notify_tile_unbound(u32 tile) override;
 	void on_semaphore_acquire_wait() override;
-
-	std::array<std::vector<std::byte>, 4> copy_render_targets_to_memory() override;
-	std::array<std::vector<std::byte>, 2> copy_depth_stencil_buffer_to_memory() override;
 };

--- a/rpcs3/Emu/RSX/GL/GLHelpers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.cpp
@@ -447,13 +447,10 @@ namespace gl
 
 	bool fbo::references_any(const std::vector<GLuint>& resources) const
 	{
-		for (const auto &e : m_resource_bindings)
+		return std::any_of(m_resource_bindings.cbegin(), m_resource_bindings.cend(), [&resources](const auto& e)
 		{
-			if (std::find(resources.begin(), resources.end(), e.second) != resources.end())
-				return true;
-		}
-
-		return false;
+			return std::find(resources.cbegin(), resources.cend(), e.second) != resources.cend();
+		});
 	}
 
 	bool is_primitive_native(rsx::primitive_type in)

--- a/rpcs3/Emu/RSX/GL/GLPipelineCompiler.h
+++ b/rpcs3/Emu/RSX/GL/GLPipelineCompiler.h
@@ -62,7 +62,7 @@ namespace gl
 	void initialize_pipe_compiler(
 		std::function<draw_context_t()> context_create_func,
 		std::function<void(draw_context_t)> context_bind_func,
-		std::function<void(draw_context_t)> contextdestroy_func,
+		std::function<void(draw_context_t)> context_destroy_func,
 		int num_worker_threads = -1);
 
 	void destroy_pipe_compiler();

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -394,16 +394,6 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool /*
 	}
 }
 
-std::array<std::vector<std::byte>, 4> GLGSRender::copy_render_targets_to_memory()
-{
-	return {};
-}
-
-std::array<std::vector<std::byte>, 2> GLGSRender::copy_depth_stencil_buffer_to_memory()
-{
-	return {};
-}
-
 // Render target helpers
 void gl::render_target::clear_memory(gl::command_context& cmd)
 {

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -95,8 +95,8 @@ u8 rsx::internals::get_pixel_size(rsx::surface_depth_format format)
 	{
 	case rsx::surface_depth_format::z16: return 2;
 	case rsx::surface_depth_format::z24s8: return 4;
+	default: fmt::throw_exception("Unknown depth format");
 	}
-	fmt::throw_exception("Unknown depth format");
 }
 
 void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool /*skip_reading*/)

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -47,8 +47,6 @@ namespace gl
 {
 	class render_target : public viewable_image, public rsx::ref_counted, public rsx::render_target_descriptor<texture*>
 	{
-		u16 surface_pixel_size = 0;
-
 		void clear_memory(gl::command_context& cmd);
 		void load_memory(gl::command_context& cmd);
 		void initialize_memory(gl::command_context& cmd, bool read_access);

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
@@ -194,11 +194,6 @@ namespace gl
 			}
 		}
 
-		[[maybe_unused]] ::glsl::shader_properties properties{};
-		properties.domain = ::glsl::program_domain::glsl_fragment_program;
-		properties.require_depth_conversion = true;
-		properties.require_wpos = true;
-
 		u32 len;
 		ParamArray arr;
 		std::string shader_str;

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -955,6 +955,7 @@ namespace gl
 					case GL_FLOAT:
 						pack_info.type = GL_HALF_FLOAT;
 						break;
+					default: break;
 					}
 				}
 			};

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -58,9 +58,6 @@ namespace
 
 	struct draw_command_visitor
 	{
-		using attribute_storage = std::vector<
-			std::variant<rsx::vertex_array_buffer, rsx::vertex_array_register, rsx::empty_vertex_array>>;
-
 		draw_command_visitor(gl::ring_buffer& index_ring_buffer, rsx::vertex_input_layout& vertex_layout)
 			: m_index_ring_buffer(index_ring_buffer)
 			, m_vertex_layout(vertex_layout)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2042,40 +2042,6 @@ namespace rsx
 		m_rsx_thread_exiting = false;
 	}
 
-	GcmTileInfo *thread::find_tile(u32 offset, u32 location)
-	{
-		for (GcmTileInfo &tile : tiles)
-		{
-			if (!tile.bound || (tile.location & 1) != (location & 1))
-			{
-				continue;
-			}
-
-			if (offset >= tile.offset && offset < tile.offset + tile.size)
-			{
-				return &tile;
-			}
-		}
-
-		return nullptr;
-	}
-
-	tiled_region thread::get_tiled_address(u32 offset, u32 location)
-	{
-		u32 address = get_address(offset, location);
-
-		GcmTileInfo *tile = find_tile(offset, location);
-		u32 base = 0;
-
-		if (tile)
-		{
-			base = offset - tile->offset;
-			address = get_address(tile->offset, location);
-		}
-
-		return{ address, base, tile, vm::_ptr<u8>(address) };
-	}
-
 	std::pair<u32, u32> thread::calculate_memory_requirements(const vertex_input_layout& layout, u32 first_vertex, u32 vertex_count)
 	{
 		u32 persistent_memory_size = 0;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -932,22 +932,6 @@ namespace rsx
 		 */
 		virtual void on_semaphore_acquire_wait() {}
 
-		/**
-		 * Copy rtt values to buffer.
-		 * TODO: It's more efficient to combine multiple call of this function into one.
-		 */
-		virtual std::array<std::vector<std::byte>, 4> copy_render_targets_to_memory() {
-			return std::array<std::vector<std::byte>, 4>();
-		}
-
-		/**
-		* Copy depth and stencil content to buffers.
-		* TODO: It's more efficient to combine multiple call of this function into one.
-		*/
-		virtual std::array<std::vector<std::byte>, 2> copy_depth_stencil_buffer_to_memory() {
-			return std::array<std::vector<std::byte>, 2>();
-		}
-
 		virtual std::pair<std::string, std::string> get_programs() const { return std::make_pair("", ""); }
 
 		virtual bool scaled_image_from_memory(blit_src_info& /*src_info*/, blit_dst_info& /*dst_info*/, bool /*interpolate*/) { return false; }

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -713,8 +713,8 @@ namespace rsx
 		bool m_framebuffer_state_contested = false;
 		rsx::framebuffer_creation_context m_current_framebuffer_context = rsx::framebuffer_creation_context::context_draw;
 
-		u32  m_graphics_state = 0;
-		u64  ROP_sync_timestamp = 0;
+		u32 m_graphics_state = 0;
+		u64 ROP_sync_timestamp = 0;
 
 		program_hash_util::fragment_program_utils::fragment_program_metadata current_fp_metadata = {};
 		program_hash_util::vertex_program_utils::vertex_program_metadata current_vp_metadata = {};
@@ -882,9 +882,6 @@ namespace rsx
 		void handle_invalidated_memory_range();
 
 	public:
-		//std::future<void> add_internal_task(std::function<bool()> callback);
-		//void invoke(std::function<bool()> callback);
-
 		/**
 		 * Fill buffer with 4x4 scale offset matrix.
 		 * Vertex shader's position is to be multiplied by this matrix.
@@ -939,9 +936,6 @@ namespace rsx
 	public:
 		void reset();
 		void init(u32 ctrlAddress);
-
-		tiled_region get_tiled_address(u32 offset, u32 location);
-		GcmTileInfo *find_tile(u32 offset, u32 location);
 
 		// Emu App/Game flip, only immediately flips when called from rsxthread
 		void request_emu_flip(u32 buffer);

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
@@ -154,7 +154,7 @@ namespace vk
 			}
 			else
 			{
-				m_async_command_queue.push_back({});
+				m_async_command_queue.emplace_back();
 				m_current_cb = &m_async_command_queue.back();
 				m_current_cb->create(m_command_pool, true);
 			}

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -21,7 +21,7 @@ namespace vk
 		case rsx::texture_dimension_extended::texture_dimension_3d:
 			return VK_IMAGE_VIEW_TYPE_3D;
 		default: fmt::throw_exception("Unreachable");
-		};
+		}
 	}
 
 	VkCompareOp get_compare_func(rsx::comparison_function op, bool reverse_direction = false)

--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -5,7 +5,7 @@
 
 namespace vk
 {
-	VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support, rsx::surface_depth_format2 format)
+	VkFormat get_compatible_depth_surface_format(const gpu_formats_support& support, rsx::surface_depth_format2 format)
 	{
 		switch (format)
 		{
@@ -42,10 +42,8 @@ namespace vk
 		case rsx::texture_minify_filter::linear_linear: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_LINEAR, true };
 		case rsx::texture_minify_filter::convolution_min: return { VK_FILTER_LINEAR, VK_SAMPLER_MIPMAP_MODE_NEAREST, false };
 		default:
-			break;
+			fmt::throw_exception("Invalid min filter");
 		}
-
-		fmt::throw_exception("Invalid min filter");
 	}
 
 	VkFilter get_mag_filter(rsx::texture_magnify_filter mag_filter)
@@ -80,19 +78,17 @@ namespace vk
 		}
 		default:
 		{
-			auto color4 = rsx::decode_border_color(color);
+			const auto color4 = rsx::decode_border_color(color);
 			if ((color4.r + color4.g + color4.b) > 1.35f)
 			{
 				//If color elements are brighter than roughly 0.5 average, use white border
 				return VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
 			}
-			else
-			{
-				if (color4.a > 0.5f)
-					return VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
-				else
-					return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
-			}
+
+			if (color4.a > 0.5f)
+				return VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+
+			return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
 		}
 		}
 	}
@@ -110,10 +106,8 @@ namespace vk
 		case rsx::texture_wrap_mode::mirror_once_border: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
 		case rsx::texture_wrap_mode::mirror_once_clamp: return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
 		default:
-			break;
+			fmt::throw_exception("Unhandled texture clamp mode");
 		}
-
-		fmt::throw_exception("Unhandled texture clamp mode");
 	}
 
 	float max_aniso(rsx::texture_max_anisotropy gcm_aniso)
@@ -207,7 +201,7 @@ namespace vk
 		return mapping;
 	}
 
-	VkFormat get_compatible_sampler_format(const gpu_formats_support &support, u32 format)
+	VkFormat get_compatible_sampler_format(const gpu_formats_support& support, u32 format)
 	{
 		switch (format)
 		{

--- a/rpcs3/Emu/RSX/VK/VKFormats.h
+++ b/rpcs3/Emu/RSX/VK/VKFormats.h
@@ -17,8 +17,8 @@ namespace vk
 
 	VkBorderColor get_border_color(u32 color);
 
-	VkFormat get_compatible_depth_surface_format(const gpu_formats_support &support, rsx::surface_depth_format2 format);
-	VkFormat get_compatible_sampler_format(const gpu_formats_support &support, u32 format);
+	VkFormat get_compatible_depth_surface_format(const gpu_formats_support& support, rsx::surface_depth_format2 format);
+	VkFormat get_compatible_sampler_format(const gpu_formats_support& support, u32 format);
 	VkFormat get_compatible_srgb_format(VkFormat rgb_format);
 	u8 get_format_texel_width(VkFormat format);
 	std::pair<u8, u8> get_format_element_size(VkFormat format);

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
@@ -70,7 +70,6 @@ public:
 	/**
 	 * Decompile a fragment shader located in the PS3's Memory.  This function operates synchronously.
 	 * @param prog RSXShaderProgram specifying the location and size of the shader in memory
-	 * @param td texture dimensions of input textures
 	 */
 	void Decompile(const RSXFragmentProgram& prog);
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -13,8 +13,6 @@
 #include "vkutils/scratch.h"
 #include "vkutils/device.h"
 #include "Emu/RSX/rsx_methods.h"
-#include "Utilities/mutex.h"
-#include "Utilities/lockless.h"
 #include <unordered_map>
 
 namespace vk

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -149,15 +149,13 @@ namespace vk
 			return *this;
 		}
 
-		bool program::has_uniform(program_input_type type, const std::string &uniform_name)
+		bool program::has_uniform(program_input_type type, const std::string& uniform_name)
 		{
-			for (const auto &uniform : uniforms[type])
+			const auto& uniform = uniforms[type];
+			return std::any_of(uniform.cbegin(), uniform.cend(), [&uniform_name](const auto& u)
 			{
-				if (uniform.name == uniform_name)
-					return true;
-			}
-
-			return false;
+				return u.name == uniform_name;
+			});
 		}
 
 		void program::bind_uniform(const VkDescriptorImageInfo &image_descriptor, const std::string& uniform_name, VkDescriptorType type, VkDescriptorSet &descriptor_set)

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -9,8 +9,8 @@ namespace vk
 {
 	struct cs_resolve_base : compute_task
 	{
-		vk::viewable_image* multisampled;
-		vk::viewable_image* resolve;
+		vk::viewable_image* multisampled = nullptr;
+		vk::viewable_image* resolve = nullptr;
 
 		u32 cs_wave_x = 1;
 		u32 cs_wave_y = 1;

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -53,7 +53,7 @@ namespace vk
 		const auto& binding_table = vk::get_current_renderer()->get_pipeline_binding_table();
 		vk::glsl::program_input in;
 
-		in.location = binding_table.vertex_params_bind_slot;;
+		in.location = binding_table.vertex_params_bind_slot;
 		in.domain = ::glsl::glsl_vertex_program;
 		in.name = "VertexContextBuffer";
 		in.type = vk::glsl::input_type_uniform_buffer;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -765,14 +765,13 @@ namespace vk
 			dst->pop_layout(cmd);
 		}
 
-		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps,  u16 pitch,
+		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch,
 			u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::texture_create_flags flags) override
 		{
 			const auto section_depth = depth;
 
 			// Define desirable attributes based on type
 			VkImageType image_type;
-			[[maybe_unused]] VkImageViewType image_view_type;
 			VkImageUsageFlags usage_flags = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 			u8 layer = 0;
 
@@ -780,26 +779,22 @@ namespace vk
 			{
 			case rsx::texture_dimension_extended::texture_dimension_1d:
 				image_type = VK_IMAGE_TYPE_1D;
-				image_view_type = VK_IMAGE_VIEW_TYPE_1D;
 				height = 1;
 				depth = 1;
 				layer = 1;
 				break;
 			case rsx::texture_dimension_extended::texture_dimension_2d:
 				image_type = VK_IMAGE_TYPE_2D;
-				image_view_type = VK_IMAGE_VIEW_TYPE_2D;
 				depth = 1;
 				layer = 1;
 				break;
 			case rsx::texture_dimension_extended::texture_dimension_cubemap:
 				image_type = VK_IMAGE_TYPE_2D;
-				image_view_type = VK_IMAGE_VIEW_TYPE_CUBE;
 				depth = 1;
 				layer = 6;
 				break;
 			case rsx::texture_dimension_extended::texture_dimension_3d:
 				image_type = VK_IMAGE_TYPE_3D;
-				image_view_type = VK_IMAGE_VIEW_TYPE_3D;
 				layer = 1;
 				break;
 			default:

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -66,7 +66,7 @@ void VKVertexDecompilerThread::insertHeader(std::stringstream &OS)
 	OS << "};\n\n";
 
 	vk::glsl::program_input in;
-	in.location = m_binding_table.vertex_params_bind_slot;;
+	in.location = m_binding_table.vertex_params_bind_slot;
 	in.domain = glsl::glsl_vertex_program;
 	in.name = "VertexContextBuffer";
 	in.type = vk::glsl::input_type_uniform_buffer;

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.h
@@ -22,7 +22,7 @@ struct VKVertexDecompilerThread : public VertexProgramDecompiler
 
 	struct
 	{
-		bool emulate_conditional_rendering;
+		bool emulate_conditional_rendering{false};
 	}
 	m_device_props;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/image_helpers.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image_helpers.cpp
@@ -120,9 +120,9 @@ namespace vk
 			barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
 			dst_stage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 			break;
-		default:
 		case VK_IMAGE_LAYOUT_UNDEFINED:
 		case VK_IMAGE_LAYOUT_PREINITIALIZED:
+		default:
 			fmt::throw_exception("Attempted to transition to an invalid layout");
 		}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
@@ -621,13 +621,7 @@ namespace vk
 				return false;
 			}
 
-			VkExtent2D swapchainExtent;
-			if (surface_descriptors.currentExtent.width == UINT32_MAX)
-			{
-				swapchainExtent.width = m_width;
-				swapchainExtent.height = m_height;
-			}
-			else
+			if (surface_descriptors.currentExtent.width != UINT32_MAX)
 			{
 				if (surface_descriptors.currentExtent.width == 0 || surface_descriptors.currentExtent.height == 0)
 				{
@@ -635,7 +629,6 @@ namespace vk
 					return false;
 				}
 
-				swapchainExtent = surface_descriptors.currentExtent;
 				m_width = surface_descriptors.currentExtent.width;
 				m_height = surface_descriptors.currentExtent.height;
 			}


### PR DESCRIPTION
- Fixes some ReSharper warnings (too lazy for const functions).
- Found some unused enum values that might be the cause for some bugs (kd-11 maybe you can defuse them)