### PR TITLE
overlays: fix osk placeholder and add password mode

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -1096,6 +1096,7 @@ namespace rsx
 			u16 vertical_scroll_offset = 0;
 
 			bool m_reset_caret_pulse = false;
+			bool password_mode = false;
 
 			std::u32string value;
 			std::u32string placeholder;

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -468,7 +468,7 @@ namespace rsx
 				is_compiled = false;
 			}
 
-			void set_text(const std::u32string& text)
+			virtual void set_unicode_text(const std::u32string& text)
 			{
 				this->text = text;
 				is_compiled = false;
@@ -476,7 +476,7 @@ namespace rsx
 
 			void set_text(localized_string_id id)
 			{
-				set_text(get_localized_u32string(id));
+				set_unicode_text(get_localized_u32string(id));
 			}
 
 			virtual void set_font(const char* font_name, u16 font_size)
@@ -1095,9 +1095,17 @@ namespace rsx
 			u16 caret_position = 0;
 			u16 vertical_scroll_offset = 0;
 
-			bool m_reset_caret_pulse = 0;
+			bool m_reset_caret_pulse = false;
+
+			std::u32string value;
+			std::u32string placeholder;
 
 			using label::label;
+
+			void set_text(const std::string& text) override;
+			void set_unicode_text(const std::u32string& text) override;
+
+			void set_placeholder(const std::u32string& placeholder_text);
 
 			void move_caret(direction dir);
 			void insert_text(const std::u32string& str);

--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
@@ -46,7 +46,7 @@ namespace rsx
 			}
 			case direction::right:
 			{
-				if (caret_position < text.length())
+				if (caret_position < value.length())
 				{
 					caret_position++;
 					refresh();
@@ -55,7 +55,7 @@ namespace rsx
 			}
 			case direction::up:
 			{
-				const usz current_line_start = get_line_start(text, caret_position);
+				const usz current_line_start = get_line_start(value, caret_position);
 				if (current_line_start == 0)
 				{
 					// This is the first line, so caret moves to the very beginning
@@ -65,7 +65,7 @@ namespace rsx
 				}
 				const usz caret_pos_in_line = caret_position - current_line_start;
 				const usz prev_line_end     = current_line_start - 1;
-				const usz prev_line_start   = get_line_start(text, prev_line_end);
+				const usz prev_line_start   = get_line_start(value, prev_line_end);
 				// TODO : Save caret position to some kind of buffer, so after switching back and forward, caret would be on initial position
 				caret_position = std::min(prev_line_end, prev_line_start + caret_pos_in_line);
 
@@ -74,18 +74,18 @@ namespace rsx
 			}
 			case direction::down:
 			{
-				const usz current_line_end = get_line_end(text, caret_position);
-				if (current_line_end == text.length())
+				const usz current_line_end = get_line_end(value, caret_position);
+				if (current_line_end == value.length())
 				{
 					// This is the last line, so caret moves to the very end
 					caret_position = current_line_end;
 					refresh();
 					break;
 				}
-				const usz current_line_start = get_line_start(text, caret_position);
+				const usz current_line_start = get_line_start(value, caret_position);
 				const usz caret_pos_in_line  = caret_position - current_line_start;
 				const usz next_line_start    = current_line_end + 1;
-				const usz next_line_end      = get_line_end(text, next_line_start);
+				const usz next_line_end      = get_line_end(value, next_line_start);
 				// TODO : Save caret position to some kind of buffer, so after switching back and forward, caret would be on initial position
 				caret_position = std::min(next_line_end, next_line_start + caret_pos_in_line);
 
@@ -95,26 +95,51 @@ namespace rsx
 			}
 		}
 
+		void edit_text::set_text(const std::string& text)
+		{
+			set_unicode_text(utf8_to_u32string(text));
+		}
+
+		void edit_text::set_unicode_text(const std::u32string& text)
+		{
+			value = text;
+
+			if (value.empty())
+			{
+				overlay_element::set_unicode_text(placeholder);
+			}
+			else
+			{
+				overlay_element::set_unicode_text(value);
+			}
+		}
+
+		void edit_text::set_placeholder(const std::u32string& placeholder_text)
+		{
+			placeholder = placeholder_text;
+		}
+
 		void edit_text::insert_text(const std::u32string& str)
 		{
 			if (caret_position == 0)
 			{
 				// Start
-				text = str + text;
+				value = str + text;
 			}
 			else if (caret_position == text.length())
 			{
 				// End
-				text += str;
+				value += str;
 			}
 			else
 			{
 				// Middle
-				text.insert(caret_position, str);
+				value.insert(caret_position, str);
 			}
 
 			caret_position += ::narrow<u16>(str.length());
 			m_reset_caret_pulse = true;
+			set_unicode_text(value);
 			refresh();
 		}
 
@@ -127,19 +152,20 @@ namespace rsx
 
 			if (caret_position == 1)
 			{
-				text = text.length() > 1 ? text.substr(1) : U"";
+				value = value.length() > 1 ? value.substr(1) : U"";
 			}
 			else if (caret_position == text.length())
 			{
-				text = text.substr(0, caret_position - 1);
+				value = value.substr(0, caret_position - 1);
 			}
 			else
 			{
-				text = text.substr(0, caret_position - 1) + text.substr(caret_position);
+				value = value.substr(0, caret_position - 1) + value.substr(caret_position);
 			}
 
 			caret_position--;
 			m_reset_caret_pulse = true;
+			set_unicode_text(value);
 			refresh();
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
@@ -108,6 +108,10 @@ namespace rsx
 			{
 				overlay_element::set_unicode_text(placeholder);
 			}
+			else if (password_mode)
+			{
+				overlay_element::set_unicode_text(std::u32string(value.size(), U"＊"[0]));
+			}
 			else
 			{
 				overlay_element::set_unicode_text(value);

--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
@@ -153,8 +153,8 @@ namespace rsx
 				auto renderer        = get_font();
 				const auto caret_loc = renderer->get_char_offset(text.c_str(), caret_position, clip_text ? w : UINT16_MAX, wrap_text);
 
-				caret.set_pos(u16(caret_loc.first + padding_left + x), u16(caret_loc.second + padding_top + y));
-				caret.set_size(1, u16(renderer->get_size_px() + 2));
+				caret.set_pos(static_cast<u16>(caret_loc.first) + padding_left + x, static_cast<u16>(caret_loc.second) + padding_top + y);
+				caret.set_size(1, static_cast<u16>(renderer->get_size_px() + 2));
 				caret.fore_color           = fore_color;
 				caret.back_color           = fore_color;
 				caret.pulse_effect_enabled = true;
@@ -172,7 +172,7 @@ namespace rsx
 				{
 					// TODO: Scrolling by using scroll offset
 					cmd.config.clip_region = true;
-					cmd.config.clip_rect   = {f32(x), f32(y), f32(x + w), f32(y + h)};
+					cmd.config.clip_rect   = {static_cast<f32>(x), static_cast<f32>(y), static_cast<f32>(x + w), static_cast<f32>(y + h)};
 				}
 
 				is_compiled = true;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -10,6 +10,15 @@ namespace rsx
 {
 	namespace overlays
 	{
+		osk_dialog::osk_dialog()
+		{
+			auto_repeat_buttons.insert(pad_button::L1);
+			auto_repeat_buttons.insert(pad_button::R1);
+			auto_repeat_buttons.insert(pad_button::cross);
+			auto_repeat_buttons.insert(pad_button::triangle);
+			auto_repeat_buttons.insert(pad_button::square);
+		}
+
 		void osk_dialog::Close(bool ok)
 		{
 			fade_animation.current = color4f(1.f);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -260,6 +260,7 @@ namespace rsx
 			m_title.set_unicode_text(title);
 			m_title.back_color.a = 0.f;
 
+			m_preview.password_mode = m_password_mode;
 			m_preview.set_placeholder(get_placeholder());
 			m_preview.set_unicode_text(initial_text);
 
@@ -813,8 +814,6 @@ namespace rsx
 				// first_view_panel can be ignored
 
 				add_panel(osk_panel_password(shift_cb, layer_cb, space_cb, delete_cb, enter_cb));
-
-				// TODO: hide entered text with *
 
 				m_password_mode = true;
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -131,11 +131,11 @@ namespace rsx
 
 						if (layer >= num_shift_layers_by_charset.size())
 						{
-							num_shift_layers_by_charset.push_back(u32(cell_shift_layers));
+							num_shift_layers_by_charset.push_back(static_cast<u32>(cell_shift_layers));
 						}
 						else
 						{
-							num_shift_layers_by_charset[layer] = std::max(num_shift_layers_by_charset[layer], u32(cell_shift_layers));
+							num_shift_layers_by_charset[layer] = std::max(num_shift_layers_by_charset[layer], static_cast<u32>(cell_shift_layers));
 						}
 					}
 
@@ -206,10 +206,10 @@ namespace rsx
 			const u16 preview_height = (flags & CELL_OSKDIALOG_NO_RETURN) ? 40 : 90;
 
 			// Place elements with absolute positioning
-			u16 frame_w = u16(num_columns * cell_size_x);
-			u16 frame_h = u16(num_rows * cell_size_y) + 30 + preview_height;
-			u16 frame_x = (1280 - frame_w) / 2;
-			u16 frame_y = (720 - frame_h) / 2;
+			const u16 frame_w = static_cast<u16>(num_columns * cell_size_x);
+			const u16 frame_h = static_cast<u16>(num_rows * cell_size_y) + 30 + preview_height;
+			const u16 frame_x = (1280 - frame_w) / 2;
+			const u16 frame_y = (720 - frame_h) / 2;
 
 			m_frame.set_pos(frame_x, frame_y);
 			m_frame.set_size(frame_w, frame_h);
@@ -358,9 +358,9 @@ namespace rsx
 
 		void osk_dialog::update_selection_by_index(u32 index)
 		{
-			auto select_cell = [&](u32 index, bool state)
+			auto select_cell = [&](u32 i, bool state)
 			{
-				const auto info = get_cell_geometry(index);
+				const auto info = get_cell_geometry(i);
 
 				// Tag all in range
 				for (u32 _index = info.first, _ctr = 0; _ctr < info.second; ++_index, ++_ctr)
@@ -719,8 +719,8 @@ namespace rsx
 
 				for (const auto& c : m_grid)
 				{
-					u16 x = u16(c.pos.x);
-					u16 y = u16(c.pos.y);
+					u16 x = static_cast<u16>(c.pos.x);
+					u16 y = static_cast<u16>(c.pos.y);
 					u16 w = cell_size_x;
 					u16 h = cell_size_y;
 
@@ -744,8 +744,8 @@ namespace rsx
 
 						if (output_count)
 						{
-							const u16 offset_x = u16(buffered_cell_count * cell_size_x);
-							const u16 full_width = u16(offset_x + cell_size_x);
+							const u16 offset_x = static_cast<u16>(buffered_cell_count * cell_size_x);
+							const u16 full_width = static_cast<u16>(offset_x + cell_size_x);
 
 							m_label.set_pos(x - offset_x, y);
 							m_label.set_size(full_width, cell_size_y);
@@ -806,11 +806,11 @@ namespace rsx
 			flags = prohibit_flags;
 			char_limit = charlimit;
 
-			callback_t shift_cb = std::bind(&osk_dialog::on_shift, this, std::placeholders::_1);
-			callback_t layer_cb = std::bind(&osk_dialog::on_layer, this, std::placeholders::_1);
-			callback_t space_cb = std::bind(&osk_dialog::on_space, this, std::placeholders::_1);
-			callback_t delete_cb = std::bind(&osk_dialog::on_backspace, this, std::placeholders::_1);
-			callback_t enter_cb = std::bind(&osk_dialog::on_enter, this, std::placeholders::_1);
+			const callback_t shift_cb  = [this](const std::u32string& text){ on_shift(text); };
+			const callback_t layer_cb  = [this](const std::u32string& text){ on_layer(text); };
+			const callback_t space_cb  = [this](const std::u32string& text){ on_space(text); };
+			const callback_t delete_cb = [this](const std::u32string& text){ on_backspace(text); };
+			const callback_t enter_cb  = [this](const std::u32string& text){ on_enter(text); };
 
 			if (panel_flag & CELL_OSKDIALOG_PANELMODE_PASSWORD)
 			{
@@ -1035,7 +1035,7 @@ namespace rsx
 			{
 				g_thread_bit = tbit;
 
-				if (auto error = run_input_loop())
+				if (const auto error = run_input_loop())
 				{
 					rsx_log.error("Osk input loop exited with error code=%d", error);
 				}

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -78,7 +78,7 @@ namespace rsx
 			std::vector<osk_panel> m_panels;
 			usz m_panel_index = 0;
 
-			osk_dialog() = default;
+			osk_dialog();
 			~osk_dialog() override = default;
 
 			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) override;

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -129,7 +129,7 @@ namespace rsx
 			default: break;
 			}
 
-			text_view.set_text(get_localized_u32string(string_id, trophy.name));
+			text_view.set_unicode_text(get_localized_u32string(string_id, trophy.name));
 			text_view.auto_resize();
 
 			// Resize background to cover the text

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -8,6 +8,7 @@
 #include "Utilities/Timer.h"
 
 #include <mutex>
+#include <set>
 
 
 // Definition of user interface implementations
@@ -69,6 +70,7 @@ namespace rsx
 
 		protected:
 			Timer input_timer;
+			std::set<u8> auto_repeat_buttons = { pad_button::dpad_up, pad_button::dpad_down, pad_button::dpad_left, pad_button::dpad_right };
 			atomic_t<bool> exit = false;
 			atomic_t<u64> thread_bits = 0;
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -300,10 +300,8 @@ void Emulator::Init(bool add_only)
 					sys_log.fatal("Failed to fix save data: %s (%s)", pending, fs::g_tls_error);
 					continue;
 				}
-				else
-				{
-					sys_log.success("Fixed save data: %s", desired);
-				}
+
+				sys_log.success("Fixed save data: %s", desired);
 			}
 
 			// Remove pending backup data

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -22,7 +22,7 @@ osk_dialog_frame::~osk_dialog_frame()
 	}
 }
 
-void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 /*panel_flag*/, u32 /*first_view_panel*/)
+void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 /*first_view_panel*/)
 {
 	state = OskDialogState::Open;
 
@@ -62,6 +62,11 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 		input->setMaxLength(charlimit);
 		input->setText(input_text);
 		input->setFocus();
+
+		if (panel_flag & CELL_OSKDIALOG_PANELMODE_PASSWORD)
+		{
+			input->setEchoMode(QLineEdit::Password); // Let's assume that games only use the password mode with single-line edit fields
+		}
 
 		if (prohibit_flags & CELL_OSKDIALOG_NO_SPACE)
 		{


### PR DESCRIPTION
fixes #10100

- Adds a value member to the overlay text edit in order to seperate the visible text from the actual text value
- Uses the new value member to implement a proper placeholder logic (when the text edit is empty)
- Uses the new value to implement the password mode (visible text is displayed as a string of ＊)
- Adds the password echo mode to the Qt version of the OSK dialog when single line input is used (doesn't make much sense on multi-line text edits anyway)
- Adds more auto-repeat buttons to the OSK
- Properly resets auto-repeat when a different button was pressed