### PR TITLE
overlays: update shader/ppu dialog backgrounds dynamically

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
@@ -17,7 +17,7 @@ namespace rsx
 		type.disable_cancel = true;
 		type.progress_bar_count = 2;
 
-		dlg = g_fxo->get<rsx::overlays::display_manager>().create<rsx::overlays::message_dialog>(!!g_cfg.video.shader_preloading_dialog.use_custom_background);
+		dlg = g_fxo->get<rsx::overlays::display_manager>().create<rsx::overlays::message_dialog>(true);
 		dlg->progress_bar_set_taskbar_index(-1);
 		dlg->show(false, msg, type, [](s32 status)
 		{

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -923,10 +923,16 @@ namespace rsx
 				external_ref = nullptr;
 			}
 
-			void set_raw_image(image_info *raw_image)
+			void set_raw_image(image_info* raw_image)
 			{
 				image_resource_ref = image_resource_id::raw_image;
 				external_ref = raw_image;
+			}
+
+			void clear_image()
+			{
+				image_resource_ref = image_resource_id::none;
+				external_ref = nullptr;
 			}
 
 			void set_blur_strength(u8 strength)

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -12,7 +12,8 @@ namespace rsx
 {
 	namespace overlays
 	{
-		message_dialog::message_dialog(bool use_custom_background)
+		message_dialog::message_dialog(bool allow_custom_background)
+			: custom_background_allowed(allow_custom_background)
 		{
 			background.set_size(1280, 720);
 			background.back_color.a = 0.85f;
@@ -54,42 +55,7 @@ namespace rsx
 				btn_cancel.set_image_resource(resource_config::standard_image_resource::circle);
 			}
 
-			if (use_custom_background)
-			{
-				const auto picture_path = Emu.GetBackgroundPicturePath();
-
-				if (fs::exists(picture_path))
-				{
-					background_image = std::make_unique<image_info>(picture_path.c_str());
-
-					if (background_image->data)
-					{
-						const f32 color              = (100 - g_cfg.video.shader_preloading_dialog.darkening_strength) / 100.f;
-						background_poster.fore_color = color4f(color, color, color, 1.);
-						background.back_color.a      = 0.f;
-
-						background_poster.set_size(1280, 720);
-						background_poster.set_raw_image(background_image.get());
-						background_poster.set_blur_strength(static_cast<u8>(g_cfg.video.shader_preloading_dialog.blur_strength));
-
-						ensure(background_image->w > 0);
-						ensure(background_image->h > 0);
-						ensure(background_poster.h > 0);
-
-						// Set padding in order to keep the aspect ratio
-						if ((background_image->w / static_cast<double>(background_image->h)) > (background_poster.w / static_cast<double>(background_poster.h)))
-						{
-							const int padding = (background_poster.h - static_cast<int>(background_image->h * (background_poster.w / static_cast<double>(background_image->w)))) / 2;
-							background_poster.set_padding(0, 0, padding, padding);
-						}
-						else
-						{
-							const int padding = (background_poster.w - static_cast<int>(background_image->w * (background_poster.h / static_cast<double>(background_image->h)))) / 2;
-							background_poster.set_padding(padding, padding, 0, 0);
-						}
-					}
-				}
-			}
+			update_custom_background();
 
 			return_code = CELL_MSGDIALOG_BUTTON_NONE;
 		}
@@ -102,6 +68,8 @@ namespace rsx
 			}
 
 			compiled_resource result;
+
+			update_custom_background();
 
 			if (background_image && background_image->data)
 			{
@@ -319,6 +287,60 @@ namespace rsx
 			text_display.set_text(text);
 			text_display.measure_text(text_w, text_h);
 			text_display.translate(0, -(text_h - 16));
+		}
+
+		void message_dialog::update_custom_background()
+		{
+			if (custom_background_allowed && g_cfg.video.shader_preloading_dialog.use_custom_background)
+			{
+				bool dirty = std::exchange(background_blur_strength, g_cfg.video.shader_preloading_dialog.blur_strength.get());
+				dirty     |= std::exchange(background_darkening_strength, g_cfg.video.shader_preloading_dialog.darkening_strength.get());
+
+				if (!background_image)
+				{
+					if (const auto picture_path = Emu.GetBackgroundPicturePath(); fs::exists(picture_path))
+					{
+						background_image = std::make_unique<image_info>(picture_path.c_str());
+						dirty |= !!background_image->data;
+					}
+				}
+
+				if (dirty && background_image && background_image->data)
+				{
+					const f32 color              = (100 - background_darkening_strength) / 100.f;
+					background_poster.fore_color = color4f(color, color, color, 1.);
+					background.back_color.a      = 0.f;
+
+					background_poster.set_size(1280, 720);
+					background_poster.set_raw_image(background_image.get());
+					background_poster.set_blur_strength(static_cast<u8>(background_blur_strength));
+
+					ensure(background_image->w > 0);
+					ensure(background_image->h > 0);
+					ensure(background_poster.h > 0);
+
+					// Set padding in order to keep the aspect ratio
+					if ((background_image->w / static_cast<double>(background_image->h)) > (background_poster.w / static_cast<double>(background_poster.h)))
+					{
+						const int padding = (background_poster.h - static_cast<int>(background_image->h * (background_poster.w / static_cast<double>(background_image->w)))) / 2;
+						background_poster.set_padding(0, 0, padding, padding);
+					}
+					else
+					{
+						const int padding = (background_poster.w - static_cast<int>(background_image->w * (background_poster.h / static_cast<double>(background_image->h)))) / 2;
+						background_poster.set_padding(padding, padding, 0, 0);
+					}
+				}
+			}
+			else
+			{
+				if (background_image)
+				{
+					background_poster.clear_image();
+					background_image.reset();
+				}
+				background.back_color.a = 0.85f;
+			}
 		}
 
 		u32 message_dialog::progress_bar_count() const

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
@@ -24,10 +24,13 @@ namespace rsx
 			bool ok_only = false;
 			bool cancel_only = false;
 
+			bool custom_background_allowed = false;
+			u32 background_blur_strength = 0;
+			u32 background_darkening_strength = 0;
 			std::unique_ptr<image_info> background_image;
 
 		public:
-			message_dialog(bool use_custom_background = false);
+			message_dialog(bool allow_custom_background = false);
 
 			compiled_resource get_compiled() override;
 
@@ -37,6 +40,7 @@ namespace rsx
 			error_code show(bool is_blocking, const std::string& text, const MsgDialogType& type, std::function<void(s32 status)> on_close);
 
 			void set_text(const std::string& text);
+			void update_custom_background();
 
 			u32 progress_bar_count() const;
 			void progress_bar_set_taskbar_index(s32 index);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -381,7 +381,7 @@ namespace
 						type.disable_cancel = true;
 						type.progress_bar_count = 1;
 
-						native_dlg = manager->create<rsx::overlays::progress_dialog>(!!g_cfg.video.shader_preloading_dialog.use_custom_background);
+						native_dlg = manager->create<rsx::overlays::progress_dialog>(true);
 						native_dlg->show(false, text0, type, nullptr);
 						native_dlg->progress_bar_set_message(0, "Please wait");
 					}

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -207,8 +207,8 @@ struct cfg_root : cfg::node
 			node_shader_preloading_dialog(cfg::node* _this) : cfg::node(_this, "Shader Loading Dialog") {}
 
 			cfg::_bool use_custom_background{ this, "Allow custom background", true, true };
-			cfg::_int<0, 100> darkening_strength{ this, "Darkening effect strength", 30, true };
-			cfg::_int<0, 100> blur_strength{ this, "Blur effect strength", 0, true };
+			cfg::uint<0, 100> darkening_strength{ this, "Darkening effect strength", 30, true };
+			cfg::uint<0, 100> blur_strength{ this, "Blur effect strength", 0, true };
 
 		} shader_preloading_dialog{ this };
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1251,6 +1251,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->perfOverlayCenterY->setEnabled(enabled);
 		ui->perfOverlayFramerateGraphEnabled->setEnabled(enabled);
 		ui->perfOverlayFrametimeGraphEnabled->setEnabled(enabled);
+		ui->perf_overlay_framerate_datapoints->setEnabled(enabled);
+		ui->perf_overlay_frametime_datapoints->setEnabled(enabled);
 	};
 	enable_perf_overlay_options(ui->perfOverlayEnabled->isChecked());
 	connect(ui->perfOverlayEnabled, &QCheckBox::clicked, enable_perf_overlay_options);


### PR DESCRIPTION
- Fixes the enabled state of some sliders in the GUI
- Update the shader loading background dynamically. The settings were just pseudo dynamic before.

This might give some of you guys a nice distraction while waiting for ppu modules.