### PR TITLE
SPU LLVM: add AVX-512 SPU verification

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -59,6 +59,7 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 		cpu == "tigerlake")
 	{
 		m_use_fma = true;
+		m_use_avx512 = true;
 	}
 
 	// Test AVX-512_icelake features (TODO)

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -2422,6 +2422,9 @@ protected:
 	// Allow FMA
 	bool m_use_fma = false;
 
+	// Allow skylake-x tier AVX-512
+	bool m_use_avx512 = false;
+
 	// Allow Icelake tier AVX-512
 	bool m_use_avx512_icl = false;
 

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -281,9 +281,9 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 			c->vzeroupper();
 		}
 	}
-	else if (utils::has_avx512() && false)
+	else if (utils::has_avx512() && g_cfg.core.full_width_avx512)
 	{
-		// AVX-512 optimized check using 512-bit registers (disabled)
+		// AVX-512 optimized check using 512-bit registers
 		words_align = 64;
 
 		const u32 starta = start & -64;

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -54,6 +54,7 @@ struct cfg_root : cfg::node
 		cfg::_int<-1, 14> ppu_128_reservations_loop_max_length{ this, "Accurate PPU 128-byte Reservation Op Max Length", 0, true }; // -1: Always accurate, 0: Never accurate, 1-14: max accurate loop length
 		cfg::_bool llvm_ppu_accurate_vector_nan{ this, "PPU LLVM Accurate Vector NaN values", false };
 		cfg::_int<-64, 64> stub_ppu_traps{ this, "Stub PPU Traps", 0, true }; // Hack, skip PPU traps for rare cases where the trap is continueable (specify relative instructions to skip)
+		cfg::_bool full_width_avx512{ this, "Full Width AVX-512", false};
 
 		cfg::_bool debug_console_mode{ this, "Debug Console Mode", false }; // Debug console emulation, not recommended
 		cfg::_bool hook_functions{ this, "Hook static functions" };

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -38,6 +38,7 @@ enum class emu_settings_type
 	SleepTimersAccuracy,
 	ClocksScale,
 	PerformanceReport,
+	FullWidthAVX512,
 
 	// Graphics
 	Renderer,
@@ -189,6 +190,7 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::ClocksScale,              { "Core", "Clocks scale"}},
 	{ emu_settings_type::AccuratePPU128Loop,       { "Core", "Accurate PPU 128-byte Reservation Op Max Length"}},
 	{ emu_settings_type::PerformanceReport,        { "Core", "Enable Performance Report"}},
+	{ emu_settings_type::FullWidthAVX512,          { "Core", "Full Width AVX-512"}},
 
 	// Graphics Tab
 	{ emu_settings_type::Renderer,                   { "Video", "Renderer"}},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -202,6 +202,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->accurateXFloat, emu_settings_type::AccurateXFloat);
 	SubscribeTooltip(ui->accurateXFloat, tooltips.settings.accurate_xfloat);
 
+	m_emu_settings->EnhanceCheckBox(ui->fullWidthAVX512, emu_settings_type::FullWidthAVX512);
+	SubscribeTooltip(ui->fullWidthAVX512, tooltips.settings.full_width_avx512);
+	ui->fullWidthAVX512->setEnabled(utils::has_avx512());
+
 	// Comboboxes
 
 	m_emu_settings->EnhanceComboBox(ui->spuBlockSize, emu_settings_type::SPUBlockSize);

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -171,6 +171,13 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QCheckBox" name="fullWidthAVX512">
+                <property name="text">
+                 <string>Full Width AVX-512</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -71,6 +71,7 @@ public:
 		const QString enable_tsx                = tr("Enable usage of TSX instructions.\nNeeds to be forced on some Haswell or Broadwell CPUs.\nForcing this on older Hardware can lead to system instability, use it with caution.");
 		const QString spu_block_size            = tr("This option controls the SPU analyser, particularly the size of compiled units. The Mega and Giga modes may improve performance by tying smaller units together, decreasing the number of compiled units but increasing their size.\nUse the Safe mode for maximum compatibility.");
 		const QString preferred_spu_threads     = tr("Some SPU stages are sensitive to race conditions and allowing a limited number at a time helps alleviate performance stalls.\nSetting this to a smaller value might improve performance and reduce stuttering in some games.\nLeave this on auto if performance is negatively affected when setting a small value.");
+		const QString full_width_avx512         = tr("Enables the use of code with full width AVX-512.\nThis code can be executed much faster, but may cause a loss in performance if your CPU model experiences downclocking on wide AVX-512 loads.\nNote that AVX-512 instructions will be used regardless of this option, just at 128 and 256 bit width.");
 
 		// debug
 


### PR DESCRIPTION
This PR adds a new setting, called "Full Width AVX-512". At the moment only 512 bit wide SPU verification is hidden behind this option, but in the future more code can be put behind it. 

This code needs to be hidden behind a setting thanks to some cpus that downclock upon executing 512 bit wide AVX-512 code. While newer cpus like the 11900K don't experience any downclocking (see https://travisdowns.github.io/blog/2020/08/19/icl-avx512-freq.html), older cpus based on skylake-x will aggressively downclock, and the setting is better off for these cpus. 

Users may also prefer this option disabled if they've overclocked their CPU with a negative AVX-512 offset.

This new setting is off by default and cannot be toggled if the users cpu doesn't support AVX-512.

For an example this reduces the code size of the largest .obj file in the mandelbrot homebrew from 29.5kb down to 27.1kb.