### PR TITLE
lv2: Remove flags from IPC-supported objects

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -30,7 +30,6 @@ error_code sys_cond_create(ppu_thread& ppu, vm::ptr<u32> cond_id, u32 mutex_id, 
 	{
 		return std::make_shared<lv2_cond>(
 			_attr.pshared,
-			_attr.flags,
 			_attr.ipc_key,
 			_attr.name_u64,
 			mutex_id,

--- a/rpcs3/Emu/Cell/lv2/sys_cond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.h
@@ -23,7 +23,6 @@ struct lv2_cond final : lv2_obj
 	static const u32 id_base = 0x86000000;
 
 	const u32 shared;
-	const s32 flags;
 	const u64 key;
 	const u64 name;
 	const u32 mtx_id;
@@ -32,9 +31,8 @@ struct lv2_cond final : lv2_obj
 	atomic_t<u32> waiters{0};
 	std::deque<cpu_thread*> sq;
 
-	lv2_cond(u32 shared, s32 flags, u64 key, u64 name, u32 mtx_id, std::shared_ptr<lv2_mutex> mutex)
+	lv2_cond(u32 shared, u64 key, u64 name, u32 mtx_id, std::shared_ptr<lv2_mutex> mutex)
 		: shared(shared)
-		, flags(flags)
 		, key(key)
 		, name(name)
 		, mtx_id(mtx_id)

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -48,7 +48,6 @@ error_code sys_event_flag_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<sys_e
 			_attr.protocol,
 			_attr.pshared,
 			_attr.ipc_key,
-			_attr.flags,
 			_attr.type,
 			_attr.name_u64,
 			init);

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.h
@@ -38,7 +38,6 @@ struct lv2_event_flag final : lv2_obj
 	const lv2_protocol protocol;
 	const u32 shared;
 	const u64 key;
-	const s32 flags;
 	const s32 type;
 	const u64 name;
 
@@ -47,11 +46,10 @@ struct lv2_event_flag final : lv2_obj
 	atomic_t<u64> pattern;
 	std::deque<cpu_thread*> sq;
 
-	lv2_event_flag(u32 protocol, u32 shared, u64 key, s32 flags, s32 type, u64 name, u64 pattern)
+	lv2_event_flag(u32 protocol, u32 shared, u64 key, s32 type, u64 name, u64 pattern)
 		: protocol{protocol}
 		, shared(shared)
 		, key(key)
-		, flags(flags)
 		, type(type)
 		, name(name)
 		, pattern(pattern)

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -62,7 +62,6 @@ error_code sys_mutex_create(ppu_thread& ppu, vm::ptr<u32> mutex_id, vm::ptr<sys_
 			_attr.pshared,
 			_attr.adaptive,
 			_attr.ipc_key,
-			_attr.flags,
 			_attr.name_u64);
 	}))
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -31,7 +31,6 @@ struct lv2_mutex final : lv2_obj
 	const u32 adaptive;
 	const u64 key;
 	const u64 name;
-	const s32 flags;
 
 	struct alignas(8) count_info
 	{
@@ -45,14 +44,13 @@ struct lv2_mutex final : lv2_obj
 	atomic_t<count_info> obj_count{};
 	std::deque<cpu_thread*> sq;
 
-	lv2_mutex(u32 protocol, u32 recursive, u32 shared, u32 adaptive, u64 key, s32 flags, u64 name)
+	lv2_mutex(u32 protocol, u32 recursive, u32 shared, u32 adaptive, u64 key, u64 name)
 		: protocol{protocol}
 		, recursive(recursive)
 		, shared(shared)
 		, adaptive(adaptive)
 		, key(key)
 		, name(name)
-		, flags(flags)
 	{
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -34,7 +34,7 @@ error_code sys_rwlock_create(ppu_thread& ppu, vm::ptr<u32> rw_lock_id, vm::ptr<s
 
 	if (auto error = lv2_obj::create<lv2_rwlock>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]
 	{
-		return std::make_shared<lv2_rwlock>(protocol, _attr.pshared, _attr.ipc_key, _attr.flags, _attr.name_u64);
+		return std::make_shared<lv2_rwlock>(protocol, _attr.pshared, _attr.ipc_key, _attr.name_u64);
 	}))
 	{
 		return error;

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.h
@@ -27,19 +27,17 @@ struct lv2_rwlock final : lv2_obj
 	const u32 shared;
 	const u64 key;
 	const u64 name;
-	const s32 flags;
 
 	shared_mutex mutex;
 	atomic_t<s64> owner{0};
 	std::deque<cpu_thread*> rq;
 	std::deque<cpu_thread*> wq;
 
-	lv2_rwlock(u32 protocol, u32 shared, u64 key, s32 flags, u64 name)
+	lv2_rwlock(u32 protocol, u32 shared, u64 key, u64 name)
 		: protocol{protocol}
 		, shared(shared)
 		, key(key)
 		, name(name)
-		, flags(flags)
 	{
 	}
 };

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -40,7 +40,7 @@ error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sy
 
 	if (auto error = lv2_obj::create<lv2_sema>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]
 	{
-		return std::make_shared<lv2_sema>(protocol, _attr.pshared, _attr.ipc_key, _attr.flags, _attr.name_u64, max_val, initial_val);
+		return std::make_shared<lv2_sema>(protocol, _attr.pshared, _attr.ipc_key, _attr.name_u64, max_val, initial_val);
 	}))
 	{
 		return error;

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.h
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.h
@@ -27,19 +27,17 @@ struct lv2_sema final : lv2_obj
 	const u32 shared;
 	const u64 key;
 	const u64 name;
-	const s32 flags;
 	const s32 max;
 
 	shared_mutex mutex;
 	atomic_t<s32> val;
 	std::deque<cpu_thread*> sq;
 
-	lv2_sema(u32 protocol, u32 shared, u64 key, s32 flags, u64 name, s32 max, s32 value)
+	lv2_sema(u32 protocol, u32 shared, u64 key, u64 name, s32 max, s32 value)
 		: protocol{protocol}
 		, shared(shared)
 		, key(key)
 		, name(name)
-		, flags(flags)
 		, max(max)
 		, val(value)
 	{


### PR DESCRIPTION
`flags` argument affects the construction process of the object, not the object itself. Saving it is futile and only represents the value at the first time at which the IPC object was constructed.