### PR TITLE
Add debug names for objects

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -1,6 +1,7 @@
 #pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
 #include "util/types.hpp"
+#include "util/shared_ptr.hpp"
 #include "bit_set.h"
 
 #include <memory>
@@ -124,16 +125,19 @@ namespace fs
 	// Virtual device
 	struct device_base
 	{
+		const std::string fs_prefix;
+
+		device_base();
 		virtual ~device_base();
 
 		virtual bool stat(const std::string& path, stat_t& info) = 0;
 		virtual bool statfs(const std::string& path, device_stat& info) = 0;
-		virtual bool remove_dir(const std::string& path) = 0;
-		virtual bool create_dir(const std::string& path) = 0;
-		virtual bool rename(const std::string& from, const std::string& to) = 0;
-		virtual bool remove(const std::string& path) = 0;
-		virtual bool trunc(const std::string& path, u64 length) = 0;
-		virtual bool utime(const std::string& path, s64 atime, s64 mtime) = 0;
+		virtual bool remove_dir(const std::string& path);
+		virtual bool create_dir(const std::string& path);
+		virtual bool rename(const std::string& from, const std::string& to);
+		virtual bool remove(const std::string& path);
+		virtual bool trunc(const std::string& path, u64 length);
+		virtual bool utime(const std::string& path, s64 atime, s64 mtime);
 
 		virtual std::unique_ptr<file_base> open(const std::string& path, bs_t<open_mode> mode) = 0;
 		virtual std::unique_ptr<dir_base> open_dir(const std::string& path) = 0;
@@ -146,10 +150,10 @@ namespace fs
 	constexpr struct pod_tag_t{} pod_tag;
 
 	// Get virtual device for specified path (nullptr for real path)
-	std::shared_ptr<device_base> get_virtual_device(const std::string& path);
+	shared_ptr<device_base> get_virtual_device(const std::string& path);
 
 	// Set virtual device with specified name (nullptr for deletion)
-	std::shared_ptr<device_base> set_virtual_device(const std::string& root_name, const std::shared_ptr<device_base>&);
+	shared_ptr<device_base> set_virtual_device(const std::string& name, shared_ptr<device_base> device);
 
 	// Try to get parent directory (returns empty string on failure)
 	std::string get_parent_dir(const std::string& path);

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -96,7 +96,6 @@ void fmt_class_string<lv2_socket_type>::format(std::string& out, u64 arg)
 		case SYS_NET_SOCK_RAW: return "RAW";
 		case SYS_NET_SOCK_DGRAM_P2P: return "DGRAM-P2P";
 		case SYS_NET_SOCK_STREAM_P2P: return "STREAM-P2P";
-		default: break;
 		}
 
 		return unknown;
@@ -114,7 +113,6 @@ void fmt_class_string<lv2_socket_family>::format(std::string& out, u64 arg)
 		case SYS_NET_AF_LOCAL: return "LOCAL";
 		case SYS_NET_AF_INET: return "INET";
 		case SYS_NET_AF_INET6: return "INET6";
-		default: break;
 		}
 
 		return unknown;

--- a/rpcs3/Emu/NP/signaling_handler.cpp
+++ b/rpcs3/Emu/NP/signaling_handler.cpp
@@ -20,7 +20,8 @@ s32 send_packet_from_p2p_port(const std::vector<u8>& data, const sockaddr_in& ad
 template <>
 void fmt_class_string<SignalingCommand>::format(std::string& out, u64 arg)
 {
-	format_enum(out, arg, [](auto value) {
+	format_enum(out, arg, [](auto value)
+	{
 		switch (value)
 		{
 		case signal_ping: return "PING";
@@ -30,7 +31,6 @@ void fmt_class_string<SignalingCommand>::format(std::string& out, u64 arg)
 		case signal_confirm: return "CONFIRM";
 		case signal_finished: return "FINISHED";
 		case signal_finished_ack: return "FINISHED_ACK";
-		default: break;
 		}
 
 		return unknown;

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -28,10 +28,10 @@ void fmt_class_string<psf::error>::format(std::string& out, u64 arg)
 	{
 		switch (fmt)
 		{
+		case psf::error::ok: return "OK";
 		case psf::error::stream: return "File doesn't exist";
 		case psf::error::not_psf: return "File is not of PSF format";
 		case psf::error::corrupt: return "PSF is truncated or corrupted";
-		default: break;
 		}
 
 		return unknown;


### PR DESCRIPTION
Example of a name (differs between compilers):
GCC:
``id_manager::id_map<named_thread<ppu_thread>>``
clang:
``id_manager::id_map<named_thread<ppu_thread> >``
MSVC:
``struct id_manager::id_map<class named_thread<class ppu_thread> >``
