### PR TITLE
Hover Gifs

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -1043,6 +1043,7 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\wolfssl" "-I.\..\3rdparty\curl\include" "-I.\..\3rdparty\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
     </CustomBuild>
+    <ClInclude Include="rpcs3qt\movie_item.h" />
     <ClInclude Include="rpcs3qt\numbered_widget_item.h" />
     <ClInclude Include="rpcs3qt\richtext_item_delegate.h" />
     <ClInclude Include="rpcs3qt\stylesheets.h" />

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -872,6 +872,9 @@
     <ClInclude Include="Input\hid_pad_handler.h">
       <Filter>Io</Filter>
     </ClInclude>
+    <ClInclude Include="rpcs3qt\movie_item.h">
+      <Filter>Gui\custom items</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="debug\moc_predefs.h.cbt">

--- a/rpcs3/rpcs3qt/custom_table_widget_item.cpp
+++ b/rpcs3/rpcs3qt/custom_table_widget_item.cpp
@@ -4,7 +4,7 @@
 #include <QDateTime>
 
 custom_table_widget_item::custom_table_widget_item(const std::string& text, int sort_role, const QVariant& sort_value)
-    : QTableWidgetItem(QString::fromStdString(text).simplified()) // simplified() forces single line text
+    : movie_item(QString::fromStdString(text).simplified()) // simplified() forces single line text
 {
 	if (sort_role != Qt::DisplayRole)
 	{
@@ -13,7 +13,7 @@ custom_table_widget_item::custom_table_widget_item(const std::string& text, int 
 }
 
 custom_table_widget_item::custom_table_widget_item(const QString& text, int sort_role, const QVariant& sort_value)
-    : QTableWidgetItem(text.simplified()) // simplified() forces single line text
+    : movie_item(text.simplified()) // simplified() forces single line text
 {
 	if (sort_role != Qt::DisplayRole)
 	{

--- a/rpcs3/rpcs3qt/custom_table_widget_item.h
+++ b/rpcs3/rpcs3qt/custom_table_widget_item.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QTableWidgetItem>
+#include "movie_item.h"
 
-class custom_table_widget_item : public QTableWidgetItem
+class custom_table_widget_item : public movie_item
 {
 private:
 	int m_sort_role = Qt::DisplayRole;

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -2,6 +2,26 @@
 
 #include <QTableWidget>
 #include <QMouseEvent>
+#include <QPixmap>
+
+#include "game_compatibility.h"
+#include "Emu/GameInfo.h"
+
+/* Having the icons associated with the game info simplifies logic internally */
+struct gui_game_info
+{
+	GameInfo info;
+	QString localized_category;
+	compat::status compat;
+	QPixmap icon;
+	QPixmap pxmap;
+	bool hasCustomConfig;
+	bool hasCustomPadConfig;
+	bool has_hover_gif;
+};
+
+typedef std::shared_ptr<gui_game_info> game_info;
+Q_DECLARE_METATYPE(game_info)
 
 /*
 	class used in order to get deselection
@@ -9,6 +29,10 @@
 */
 class game_list : public QTableWidget
 {
+public:
+	int m_last_entered_row = -1;
+	int m_last_entered_col = -1;
+
 private:
 	void mousePressEvent(QMouseEvent *event) override
 	{

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "Emu/GameInfo.h"
-
+#include "game_list.h"
 #include "custom_dock_widget.h"
-#include "game_compatibility.h"
 #include "gui_save.h"
 
 #include <QMainWindow>
@@ -14,26 +12,10 @@
 
 #include <memory>
 
-class game_list;
 class game_list_grid;
 class gui_settings;
 class emu_settings;
 class persistent_settings;
-
-/* Having the icons associated with the game info simplifies logic internally */
-struct gui_game_info
-{
-	GameInfo info;
-	QString localized_category;
-	compat::status compat;
-	QPixmap icon;
-	QPixmap pxmap;
-	bool hasCustomConfig;
-	bool hasCustomPadConfig;
-};
-
-typedef std::shared_ptr<gui_game_info> game_info;
-Q_DECLARE_METATYPE(game_info)
 
 class game_list_frame : public custom_dock_widget
 {
@@ -87,6 +69,7 @@ public Q_SLOTS:
 	void SetSearchText(const QString& text);
 	void SetShowCompatibilityInGrid(bool show);
 	void SetShowCustomIcons(bool show);
+	void SetPlayHoverGifs(bool play);
 
 private Q_SLOTS:
 	void OnColClicked(int col);
@@ -174,4 +157,5 @@ private:
 	qreal m_text_factor;
 	bool m_draw_compat_status_to_grid = false;
 	bool m_show_custom_icons = true;
+	bool m_play_hover_movies = true;
 };

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -73,7 +73,7 @@ void game_list_grid::setIconSize(const QSize& size) const
 	}
 }
 
-void game_list_grid::addItem(const game_info& app, const QString& name, const QString& movie_path, const int& row, const int& col)
+QTableWidgetItem* game_list_grid::addItem(const game_info& app, const QString& name, const QString& movie_path, const int& row, const int& col)
 {
 	// create item with expanded image, title and position
 	movie_item* item = new movie_item;
@@ -151,6 +151,7 @@ void game_list_grid::addItem(const game_info& app, const QString& name, const QS
 	}
 
 	setItem(row, col, item);
+	return item;
 }
 
 qreal game_list_grid::getMarginFactor() const

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -1,5 +1,6 @@
 #include "game_list_grid.h"
 #include "game_list_grid_delegate.h"
+#include "movie_item.h"
 #include "qt_utils.h"
 
 #include <QHeaderView>
@@ -38,6 +39,21 @@ game_list_grid::game_list_grid(const QSize& icon_size, QColor icon_color, const 
 	verticalHeader()->setVisible(false);
 	horizontalHeader()->setVisible(false);
 	setShowGrid(false);
+	setMouseTracking(true);
+
+	connect(this, &QTableWidget::cellEntered, this, [this](int row, int column)
+	{
+		if (auto old_item = dynamic_cast<movie_item*>(item(m_last_entered_row, m_last_entered_col)))
+		{
+			old_item->set_active(false);
+		}
+		if (auto new_item = dynamic_cast<movie_item*>(item(row, column)))
+		{
+			new_item->set_active(true);
+		}
+		m_last_entered_row = row;
+		m_last_entered_col = column;
+	});
 }
 
 void game_list_grid::enableText(const bool& enabled)
@@ -57,44 +73,77 @@ void game_list_grid::setIconSize(const QSize& size) const
 	}
 }
 
-void game_list_grid::addItem(const QPixmap& img, const QString& name, const int& row, const int& col)
+void game_list_grid::addItem(const game_info& app, const QString& name, const QString& movie_path, const int& row, const int& col)
 {
-	const qreal device_pixel_ratio = devicePixelRatioF();
-
-	// define size of expanded image, which is raw image size + margins
-	QSizeF exp_size;
-	if (m_text_enabled)
-	{
-		exp_size = m_icon_size + QSizeF(m_icon_size.width() * m_margin_factor * 2, m_icon_size.height() * m_margin_factor * (m_text_factor + 1));
-	}
-	else
-	{
-		exp_size = m_icon_size + m_icon_size * m_margin_factor * 2;
-	}
-
-	// define offset for raw image placement
-	const QPoint offset = QPoint(m_icon_size.width() * m_margin_factor, m_icon_size.height() * m_margin_factor);
-
-	// create empty canvas for expanded image
-	QImage exp_img = QImage((exp_size * device_pixel_ratio).toSize(), QImage::Format_ARGB32);
-	exp_img.setDevicePixelRatio(device_pixel_ratio);
-	exp_img.fill(Qt::transparent);
-
-	// create background for image
-	QImage bg_img = QImage(img.size(), QImage::Format_ARGB32);
-	bg_img.setDevicePixelRatio(device_pixel_ratio);
-	bg_img.fill(m_icon_color);
-
-	// place raw image inside expanded image
-	QPainter painter(&exp_img);
-	painter.setRenderHint(QPainter::SmoothPixmapTransform);
-	painter.drawImage(offset, bg_img);
-	painter.drawPixmap(offset, img);
-	painter.end();
-
 	// create item with expanded image, title and position
-	QTableWidgetItem* item = new QTableWidgetItem();
-	item->setData(Qt::ItemDataRole::DecorationRole, QPixmap::fromImage(exp_img));
+	movie_item* item = new movie_item;
+
+	item->set_icon_func([this, app, item](int)
+	{
+		ensure(item);
+
+		const qreal device_pixel_ratio = devicePixelRatioF();
+
+		// define size of expanded image, which is raw image size + margins
+		QSizeF exp_size_f;
+		if (m_text_enabled)
+		{
+			exp_size_f = m_icon_size + QSizeF(m_icon_size.width() * m_margin_factor * 2, m_icon_size.height() * m_margin_factor * (m_text_factor + 1));
+		}
+		else
+		{
+			exp_size_f = m_icon_size + m_icon_size * m_margin_factor * 2;
+		}
+
+		QMovie* movie = item->movie();
+		const bool draw_movie_frame = movie && movie->isValid() && item->get_active();
+		const QSize exp_size = (exp_size_f * device_pixel_ratio).toSize();
+
+		// create empty canvas for expanded image
+		QImage exp_img(exp_size, QImage::Format_ARGB32);
+		exp_img.setDevicePixelRatio(device_pixel_ratio);
+		exp_img.fill(Qt::transparent);
+
+		// define offset for raw image placement
+		QPoint offset(m_icon_size.width() * m_margin_factor, m_icon_size.height() * m_margin_factor);
+
+		// place raw image inside expanded image
+		QPainter painter(&exp_img);
+		painter.setRenderHint(QPainter::SmoothPixmapTransform);
+
+		if (draw_movie_frame)
+		{
+			const QPixmap scaled_movie_frame = movie->currentPixmap().scaled(m_icon_size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+			offset += QPoint(m_icon_size.width() / 2 - scaled_movie_frame.width() / 2,
+			                 m_icon_size.height() / 2 - scaled_movie_frame.height() / 2);
+			painter.drawPixmap(offset, scaled_movie_frame);
+		}
+		else
+		{
+			// create background for image
+			QImage bg_img(app->pxmap.size(), QImage::Format_ARGB32);
+			bg_img.setDevicePixelRatio(device_pixel_ratio);
+			bg_img.fill(m_icon_color);
+
+			painter.drawImage(offset, bg_img);
+			painter.drawPixmap(offset, app->pxmap);
+
+			if (movie)
+			{
+				movie->stop();
+			}
+		}
+
+		painter.end();
+
+		// create item with expanded image, title and position
+		item->setData(Qt::ItemDataRole::DecorationRole, QPixmap::fromImage(exp_img));
+	});
+
+	if (!movie_path.isEmpty())
+	{
+		item->init_movie(movie_path);
+	}
 
 	if (m_text_enabled)
 	{

--- a/rpcs3/rpcs3qt/game_list_grid.h
+++ b/rpcs3/rpcs3qt/game_list_grid.h
@@ -19,9 +19,9 @@ public:
 
 	void enableText(const bool& enabled);
 	void setIconSize(const QSize& size) const;
-	void addItem(const QPixmap& img, const QString& name, const int& row, const int& col);
+	void addItem(const game_info& app, const QString& name, const QString& movie_path, const int& row, const int& col);
 
-	qreal getMarginFactor() const;
+	[[nodiscard]] qreal getMarginFactor() const;
 
 private:
 	game_list_grid_delegate* grid_item_delegate; 

--- a/rpcs3/rpcs3qt/game_list_grid.h
+++ b/rpcs3/rpcs3qt/game_list_grid.h
@@ -19,7 +19,7 @@ public:
 
 	void enableText(const bool& enabled);
 	void setIconSize(const QSize& size) const;
-	void addItem(const game_info& app, const QString& name, const QString& movie_path, const int& row, const int& col);
+	QTableWidgetItem* addItem(const game_info& app, const QString& name, const QString& movie_path, const int& row, const int& col);
 
 	[[nodiscard]] qreal getMarginFactor() const;
 

--- a/rpcs3/rpcs3qt/game_list_grid_delegate.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid_delegate.cpp
@@ -5,7 +5,7 @@ game_list_grid_delegate::game_list_grid_delegate(const QSize& size, const qreal&
 {
 }
 
-void game_list_grid_delegate::initStyleOption(QStyleOptionViewItem * option, const QModelIndex & index) const
+void game_list_grid_delegate::initStyleOption(QStyleOptionViewItem* option, const QModelIndex& index) const
 {
 	Q_UNUSED(index)
 
@@ -16,7 +16,7 @@ void game_list_grid_delegate::initStyleOption(QStyleOptionViewItem * option, con
 	QStyledItemDelegate::initStyleOption(option, QModelIndex());
 }
 
-void game_list_grid_delegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+void game_list_grid_delegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
 	const QRect r = option.rect;
 
@@ -54,14 +54,14 @@ void game_list_grid_delegate::paint(QPainter *painter, const QStyleOptionViewIte
 	painter->drawText(QRect(r.left(), top, r.width(), height), +Qt::TextWordWrap | +Qt::AlignCenter, title);
 }
 
-QSize game_list_grid_delegate::sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const
+QSize game_list_grid_delegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
 {
 	Q_UNUSED(option)
 	Q_UNUSED(index)
 	return m_size;
 }
 
-void game_list_grid_delegate::setItemSize(const QSize & size)
+void game_list_grid_delegate::setItemSize(const QSize& size)
 {
 	m_size = size;
 }

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -167,6 +167,7 @@ namespace gui
 	const gui_save gl_hidden_list  = gui_save(game_list, "hidden_list",  QStringList());
 	const gui_save gl_draw_compat  = gui_save(game_list, "draw_compat",  false);
 	const gui_save gl_custom_icon  = gui_save(game_list, "custom_icon",  true);
+	const gui_save gl_hover_gifs   = gui_save(game_list, "hover_gifs",   true);
 
 	const gui_save fs_emulator_dir_list = gui_save(fs, "emulator_dir_list", QStringList());
 	const gui_save fs_dev_hdd0_list     = gui_save(fs, "dev_hdd0_list",     QStringList());

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2259,6 +2259,7 @@ void main_window::CreateConnects()
 	});
 
 	connect(ui->showCustomIconsAct, &QAction::triggered, m_game_list_frame, &game_list_frame::SetShowCustomIcons);
+	connect(ui->playHoverGifsAct, &QAction::triggered, m_game_list_frame, &game_list_frame::SetPlayHoverGifs);
 
 	connect(m_game_list_frame, &game_list_frame::RequestIconSizeChange, this, [this](const int& val)
 	{
@@ -2517,6 +2518,7 @@ void main_window::ConfigureGuiFromSettings(bool configure_all)
 
 	ui->showCompatibilityInGridAct->setChecked(m_gui_settings->GetValue(gui::gl_draw_compat).toBool());
 	ui->showCustomIconsAct->setChecked(m_gui_settings->GetValue(gui::gl_custom_icon).toBool());
+	ui->playHoverGifsAct->setChecked(m_gui_settings->GetValue(gui::gl_hover_gifs).toBool());
 
 	ui->showCatHDDGameAct->setChecked(m_gui_settings->GetCategoryVisibility(Category::HDD_Game));
 	ui->showCatDiscGameAct->setChecked(m_gui_settings->GetCategoryVisibility(Category::Disc_Game));

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -141,7 +141,7 @@
      <x>0</x>
      <y>0</y>
      <width>1058</width>
-     <height>30</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="contextMenuPolicy">
@@ -279,6 +279,7 @@
      <addaction name="setIconSizeLargeAct"/>
      <addaction name="separator"/>
      <addaction name="showCustomIconsAct"/>
+     <addaction name="playHoverGifsAct"/>
     </widget>
     <widget class="QMenu" name="menuGame_List_Mode">
      <property name="title">
@@ -1149,6 +1150,17 @@
    </property>
    <property name="text">
     <string>Show Custom Icons</string>
+   </property>
+  </action>
+  <action name="playHoverGifsAct">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Play Hover Gifs</string>
    </property>
   </action>
  </widget>

--- a/rpcs3/rpcs3qt/movie_item.h
+++ b/rpcs3/rpcs3qt/movie_item.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <QTableWidgetItem>
+#include <QMovie>
+#include <QObject>
+
+#include <functional>
+
+using icon_callback_t = std::function<void(int)>;
+
+class movie_item : public QTableWidgetItem
+{
+public:
+	movie_item() : QTableWidgetItem()
+	{
+	}
+	movie_item(const QString& text, int type = Type) : QTableWidgetItem(text, type)
+	{
+	}
+	movie_item(const QIcon& icon, const QString& text, int type = Type) : QTableWidgetItem(icon, text, type)
+	{
+	}
+
+	~movie_item()
+	{
+		if (m_movie)
+		{
+			m_movie->stop();
+			delete m_movie;
+		}
+	}
+
+	void set_active(bool active)
+	{
+		if (!std::exchange(m_active, active) && active && m_movie)
+		{
+			m_movie->jumpToFrame(1);
+			m_movie->start();
+		}
+	}
+
+	[[nodiscard]] bool get_active() const
+	{
+		return m_active;
+	}
+
+	[[nodiscard]] QMovie* movie() const
+	{
+		return m_movie;
+	}
+
+	void init_movie(const QString& path)
+	{
+		if (path.isEmpty() || !m_icon_callback) return;
+
+		if (QMovie* movie = new QMovie(path); movie && movie->isValid())
+		{
+			m_movie = movie;
+		}
+		else
+		{
+			delete movie;
+			return;
+		}
+
+		QObject::connect(m_movie, &QMovie::frameChanged, m_movie, m_icon_callback);
+	}
+
+	void set_icon_func(const icon_callback_t& func)
+	{
+		m_icon_callback = func;
+
+		if (m_icon_callback)
+		{
+			m_icon_callback(0);
+		}
+	}
+
+private:
+	QMovie* m_movie = nullptr;
+	bool m_active = false;
+	icon_callback_t m_icon_callback = nullptr;
+};

--- a/rpcs3/rpcs3qt/movie_item.h
+++ b/rpcs3/rpcs3qt/movie_item.h
@@ -66,14 +66,18 @@ public:
 		QObject::connect(m_movie, &QMovie::frameChanged, m_movie, m_icon_callback);
 	}
 
-	void set_icon_func(const icon_callback_t& func)
+	void call_icon_func() const
 	{
-		m_icon_callback = func;
-
 		if (m_icon_callback)
 		{
 			m_icon_callback(0);
 		}
+	}
+
+	void set_icon_func(const icon_callback_t& func)
+	{
+		m_icon_callback = func;
+		call_icon_func();
 	}
 
 private:


### PR DESCRIPTION
I finally transformed last year's april fools joke into a proper feature.
Since we can't have proper game videos for now, this seems like a nice workaround in the meantime.

- Allows the user to import, remove, replace, enable and disable "Hover Gifs" (Similar to the existing custom icons)
- The gifs will be played when you hover with the mouse on the gamelist icon

![giffers](https://user-images.githubusercontent.com/23019877/114943808-dac25400-9e46-11eb-92f6-c67652cc3826.gif)

