### PR TITLE
replaced CMAKE_COMPILER_IS_GNUCXX with CMAKE_CXX_COMPILER_ID

### DIFF
--- a/3rdparty/libusb_cmake/config.cmake
+++ b/3rdparty/libusb_cmake/config.cmake
@@ -2,7 +2,7 @@ include(CheckCXXCompilerFlag)
 include(CheckIncludeFiles)
 include(CheckTypeSize)
 
-if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 	if (NOT OS_WINDOWS)
 		# mingw appears to print a bunch of warnings about this
 		check_cxx_compiler_flag("-fvisibility=hidden" HAVE_VISIBILITY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14.1)
 
 project(rpcs3)
 
-if(CMAKE_COMPILER_IS_GNUCXX)
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
 		message(FATAL_ERROR "RPCS3 requires at least gcc-9.")
 	endif()

--- a/rpcs3/cmake_modules/ConfigureCompiler.cmake
+++ b/rpcs3/cmake_modules/ConfigureCompiler.cmake
@@ -50,7 +50,7 @@ else()
 
 	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 		add_compile_options(-Werror=inconsistent-missing-override)
-	elseif(CMAKE_COMPILER_IS_GNUCXX)
+	elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 		add_compile_options(-Werror=suggest-override)
 		add_compile_options(-Wclobbered)
 		add_compile_options(-Wcast-function-type)
@@ -59,7 +59,7 @@ else()
 	endif()
 
 	#TODO Clean the code so these are removed
-	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.1 OR NOT CMAKE_COMPILER_IS_GNUCXX)
+	if ((not ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") OR (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.1))
 		add_compile_options(-Wno-attributes)
 	endif()
 
@@ -69,7 +69,7 @@ else()
 		add_compile_options(-Wno-unused-private-field)
 		add_compile_options(-Wno-delete-non-virtual-dtor)
 		add_compile_options(-Wno-unused-command-line-argument)
-	elseif(CMAKE_COMPILER_IS_GNUCXX)
+	elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 		add_compile_options(-Wno-class-memaccess)
 	endif()
 


### PR DESCRIPTION
the `CMAKE_COMPILER_IS_GNUCXX` function is deprecated 
and should be replaced instead with `CMAKE_CXX_COMPILER_ID`.