### PR TITLE
Qt: remove uncritical deprecated notes and titles

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -596,8 +596,8 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 				const QString serial = qstr(game.serial);
 
 				// Read persistent_settings values
-				QString note        = m_persistent_settings->GetValue(gui::persistent::notes, serial, "").toString();
-				QString title       = m_persistent_settings->GetValue(gui::persistent::titles, serial, "").toString().simplified();
+				const QString note  = m_persistent_settings->GetValue(gui::persistent::notes, serial, "").toString();
+				const QString title = m_persistent_settings->GetValue(gui::persistent::titles, serial, "").toString().simplified();
 				QString last_played = m_persistent_settings->GetValue(gui::persistent::last_played, serial, "").toString();
 				quint64 playtime    = m_persistent_settings->GetValue(gui::persistent::playtime, serial, 0).toULongLong();
 
@@ -612,29 +612,6 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 				{
 					playtime = m_gui_settings->GetValue(gui::persistent::playtime, serial, 0).toULongLong();
 					m_gui_settings->RemoveValue(gui::persistent::playtime, serial);
-				}
-				// Deprecated values older than August 2nd 2020
-				if (note.isEmpty())
-				{
-					note = m_gui_settings->GetValue(gui::persistent::notes, serial, "").toString();
-					m_gui_settings->RemoveValue(gui::persistent::notes, serial);
-
-					// Move to persistent settings
-					if (!note.isEmpty())
-					{
-						m_persistent_settings->SetValue(gui::persistent::notes, serial, note);
-					}
-				}
-				if (title.isEmpty())
-				{
-					title = m_gui_settings->GetValue(gui::persistent::titles, serial, "").toString().simplified();
-					m_gui_settings->RemoveValue(gui::persistent::titles, serial);
-
-					// Move to persistent settings
-					if (!title.isEmpty())
-					{
-						m_persistent_settings->SetValue(gui::persistent::titles, serial, title);
-					}
 				}
 
 				// Set persistent_settings values if values exist

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -191,7 +191,6 @@ namespace gui
 
 	const gui_save m_currentConfig     = gui_save(meta, "currentConfig",     Settings);
 	const gui_save m_currentStylesheet = gui_save(meta, "currentStylesheet", DefaultStylesheet);
-	const gui_save m_saveNotes         = gui_save(meta, "saveNotes",         QVariantMap()); // Deprecated
 	const gui_save m_showDebugTab      = gui_save(meta, "showDebugTab",      false);
 	const gui_save m_enableUIColors    = gui_save(meta, "enableUIColors",    false);
 	const gui_save m_richPresence      = gui_save(meta, "useRichPresence",   true);

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -180,20 +180,7 @@ void save_data_list_dialog::UpdateList()
 	m_list->clearContents();
 	m_list->setRowCount(::narrow<int>(m_save_entries.size()));
 
-	QVariantMap notes = m_persistent_settings->GetValue(gui::persistent::save_notes).toMap();
-
-	// Find deprecated values (older than August 2nd 2020)
-	if (notes.isEmpty())
-	{
-		notes = m_gui_settings->GetValue(gui::m_saveNotes).toMap();
-		m_gui_settings->RemoveValue(gui::m_saveNotes);
-
-		// Move to persistent settings
-		if (!notes.isEmpty())
-		{
-			m_persistent_settings->SetValue(gui::persistent::save_notes, notes);
-		}
-	}
+	const QVariantMap notes = m_persistent_settings->GetValue(gui::persistent::save_notes).toMap();
 
 	int row = 0;
 	for (const SaveDataEntry& entry: m_save_entries)

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -239,7 +239,7 @@ void save_manager_dialog::UpdateList()
 	m_list->clearContents();
 	m_list->setRowCount(static_cast<int>(m_save_entries.size()));
 
-	QVariantMap notes = m_persistent_settings->GetValue(gui::persistent::save_notes).toMap();
+	const QVariantMap notes = m_persistent_settings->GetValue(gui::persistent::save_notes).toMap();
 
 	if (m_gui_settings->GetValue(gui::m_enableUIColors).toBool())
 	{
@@ -267,7 +267,7 @@ void save_manager_dialog::UpdateList()
 		return icon;
 	};
 
-	QList<QPixmap> icons = QtConcurrent::blockingMapped<QList<QPixmap>>(indices, get_icon);
+	const QList<QPixmap> icons = QtConcurrent::blockingMapped<QList<QPixmap>>(indices, get_icon);
 
 	for (int i = 0; i < icons.count(); ++i)
 	{
@@ -368,8 +368,7 @@ void save_manager_dialog::UpdateIcons()
 
 	for (int i = 0; i < m_list->rowCount() && i < scaled.count(); ++i)
 	{
-		QTableWidgetItem* icon_item = m_list->item(i, 0);
-		if (icon_item)
+		if (QTableWidgetItem* icon_item = m_list->item(i, 0))
 			icon_item->setData(Qt::DecorationRole, scaled[i]);
 	}
 
@@ -503,9 +502,7 @@ void save_manager_dialog::closeEvent(QCloseEvent *event)
 
 void save_manager_dialog::UpdateDetails()
 {
-	const int selected = m_list->selectionModel()->selectedRows().size();
-
-	if (selected != 1)
+	if (const int selected = m_list->selectionModel()->selectedRows().size(); selected != 1)
 	{
 		m_details_icon->setPixmap(QPixmap());
 		m_details_subtitle->setText("");
@@ -545,9 +542,11 @@ void save_manager_dialog::UpdateDetails()
 		m_details_modified->setText(tr("Last modified: %1").arg(FormatTimestamp(save.mtime)));
 		m_details_details->setText(tr("Details:\n").append(qstr(save.details)));
 		QString note = tr("Note:\n");
-		QVariantMap map = m_gui_settings->GetValue(gui::m_saveNotes).toMap();
-		if (map.contains(qstr(save.dirName)))
+		if (const QVariantMap map = m_persistent_settings->GetValue(gui::persistent::save_notes).toMap();
+			map.contains(qstr(save.dirName)))
+		{
 			note.append(map[qstr(save.dirName)].toString());
+		}
 		m_details_note->setText(note);
 
 		m_button_delete->setDisabled(false);

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -19,6 +19,7 @@
 #include <QDesktopServices>
 #include <QPainter>
 #include <QScreen>
+#include <QScrollBar>
 
 #include "Utilities/File.h"
 
@@ -119,6 +120,10 @@ void save_manager_dialog::Init()
 	m_list->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_list->setContextMenuPolicy(Qt::CustomContextMenu);
 	m_list->setColumnCount(5);
+	m_list->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_list->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+	m_list->verticalScrollBar()->setSingleStep(20);
+	m_list->horizontalScrollBar()->setSingleStep(10);
 	m_list->setHorizontalHeaderLabels(QStringList() << tr("Icon") << tr("Title & Subtitle") << tr("Last Modified") << tr("Save ID") << tr("Notes"));
 	m_list->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
 	m_list->horizontalHeader()->setStretchLastSection(true);


### PR DESCRIPTION
This also fixes a savedata notes bug.
The detail section notes were always taken from the deprecated settings.