### PR TITLE
Qt: lazy loading game list ("kinda")

### DIFF
--- a/rpcs3/rpcs3qt/game_list.cpp
+++ b/rpcs3/rpcs3qt/game_list.cpp
@@ -37,7 +37,7 @@ void game_list::mouseMoveEvent(QMouseEvent *event)
 	m_last_hover_item = new_item;
 }
 
-void game_list::leaveEvent(QEvent *event)
+void game_list::leaveEvent(QEvent */*event*/)
 {
 	if (m_last_hover_item)
 	{

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -7,6 +7,8 @@
 #include "game_compatibility.h"
 #include "Emu/GameInfo.h"
 
+class movie_item;
+
 /* Having the icons associated with the game info simplifies logic internally */
 struct gui_game_info
 {
@@ -18,12 +20,11 @@ struct gui_game_info
 	bool hasCustomConfig;
 	bool hasCustomPadConfig;
 	bool has_hover_gif;
+	movie_item* item;
 };
 
 typedef std::shared_ptr<gui_game_info> game_info;
 Q_DECLARE_METATYPE(game_info)
-
-class movie_item;
 
 /*
 	class used in order to get deselection and hover change

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -3,12 +3,14 @@
 #include "game_list.h"
 #include "custom_dock_widget.h"
 #include "gui_save.h"
+#include "Utilities/lockless.h"
 
 #include <QMainWindow>
 #include <QToolBar>
 #include <QStackedWidget>
 #include <QSet>
 #include <QTableWidgetItem>
+#include <QFutureWatcher>
 
 #include <memory>
 
@@ -72,10 +74,12 @@ public Q_SLOTS:
 	void SetPlayHoverGifs(bool play);
 
 private Q_SLOTS:
+	void OnRefreshFinished();
+	void OnRepaintFinished();
 	void OnColClicked(int col);
 	void ShowContextMenu(const QPoint &pos);
 	void doubleClickedSlot(QTableWidgetItem *item);
-	void itemSelectionChangedSlot();
+	void ItemSelectionChangedSlot();
 Q_SIGNALS:
 	void GameListFrameClosed();
 	void NotifyGameSelection(const game_info& game);
@@ -144,6 +148,12 @@ private:
 	std::shared_ptr<emu_settings> m_emu_settings;
 	std::shared_ptr<persistent_settings> m_persistent_settings;
 	QList<game_info> m_game_data;
+	std::vector<std::string> m_path_list;
+	QSet<QString> m_serials;
+	QMutex m_mutex_cat;
+	lf_queue<game_info> m_games;
+	QFutureWatcher<void> m_refresh_watcher;
+	QFutureWatcher<movie_item*> m_repaint_watcher;
 	QSet<QString> m_hidden_list;
 	bool m_show_hidden{false};
 


### PR DESCRIPTION
Makes the game list load games and icons asynchronously.
The Game window will be opened faster and then populated when all games were processed.
The Icons will be displayed first come first serve.
It takes some time to repaint icons, so this step is seperated from the prior game list initialization.

This might be more interesting for people with huge game collections.