### PR TITLE
vm_native: supply only one madvise flag at a time

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -923,7 +923,9 @@ namespace vm
 		else
 		{
 			shm->unmap_critical(g_base_addr + addr);
+#ifdef _WIN32
 			shm->unmap_critical(g_sudo_addr + addr);
+#endif
 		}
 
 		if (is_exec)
@@ -1148,7 +1150,9 @@ namespace vm
 			if (m_common)
 			{
 				m_common->unmap_critical(vm::base(addr));
+#ifdef _WIN32
 				m_common->unmap_critical(vm::get_super_ptr(addr));
+#endif
 			}
 		}
 	}

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -160,6 +160,10 @@ namespace utils
 		{
 			ensure(::madvise(ptr, orig_size, c_madv_no_dump) != -1);
 		}
+		else
+		{
+			ensure(::madvise(ptr, orig_size, c_madv_free) != -1);
+		}
 
 		return ptr;
 #endif
@@ -172,7 +176,15 @@ namespace utils
 #else
 		const u64 ptr64 = reinterpret_cast<u64>(pointer);
 		ensure(::mprotect(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), +prot) != -1);
-		ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), MADV_WILLNEED | c_madv_dump) != -1);
+
+		if constexpr (c_madv_dump != 0)
+		{
+			ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), c_madv_dump) != -1);
+		}
+		else
+		{
+			ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), MADV_WILLNEED) != -1);
+		}
 #endif
 	}
 
@@ -187,6 +199,10 @@ namespace utils
 		if constexpr (c_madv_no_dump != 0)
 		{
 			ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), c_madv_no_dump) != -1);
+		}
+		else
+		{
+			ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), c_madv_free) != -1);
 		}
 #endif
 	}
@@ -208,7 +224,14 @@ namespace utils
 			}
 		}
 
-		ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), MADV_WILLNEED | c_madv_dump) != -1);
+		if constexpr (c_madv_dump != 0)
+		{
+			ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), c_madv_dump) != -1);
+		}
+		else
+		{
+			ensure(::madvise(reinterpret_cast<void*>(ptr64 & -4096), size + (ptr64 & 4095), MADV_WILLNEED) != -1);
+		}
 #endif
 	}
 

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -511,6 +511,7 @@ namespace utils
 			return;
 		}
 #else
+		// This method is faster but leaves mapped remnants of the shm (until overwritten)
 		ensure(::mprotect(target, m_size, PROT_NONE) != -1);
 #endif
 	}


### PR DESCRIPTION
- Attempt to fix some issues on BSD.
- Document some specifics of unmap_critical on Linux/BSD/POSIX and don't call mprotect twice (for sudo mem).