### PR TITLE
Qt: Fix initial gs_frame position on multi-monitor

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -135,11 +135,13 @@ void gs_frame::paintEvent(QPaintEvent *event)
 
 void gs_frame::showEvent(QShowEvent *event)
 {
-	// we have to calculate new window positions, since the frame is only known once the window was created
+	// We have to calculate new window positions, since the frame is only known once the window was created
 	const QRect available_geometry = screen()->availableGeometry();
 	QPoint pos = m_initial_geometry.topLeft();
-	pos.setX(std::clamp(pos.x(), available_geometry.left(), available_geometry.width() - frameGeometry().width()));
-	pos.setY(std::clamp(pos.y(), available_geometry.top(), available_geometry.height() - frameGeometry().height()));
+	pos.setX(std::min(std::max(pos.x() - ((frameGeometry().width() - width()) / 2), available_geometry.left()),
+	                  available_geometry.left() + available_geometry.width() - frameGeometry().width()));
+	pos.setY(std::min(std::max(pos.y() - ((frameGeometry().height() - height()) / 2), available_geometry.top()),
+	                  available_geometry.top() + available_geometry.height() - frameGeometry().height()));
 	setFramePosition(pos);
 
 	QWindow::showEvent(event);

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -259,8 +259,8 @@ std::unique_ptr<gs_frame> gui_application::get_gs_frame()
 	}
 
 	const auto screen = m_main_window ? m_main_window->screen() : primaryScreen();
-	const auto source_geometry = m_main_window ? m_main_window->geometry() : primaryScreen()->geometry();
-	const auto frame_geometry  = gui::utils::create_centered_window_geometry(screen, source_geometry, w, h);
+	const auto base_geometry  = m_main_window ? m_main_window->frameGeometry() : primaryScreen()->geometry();
+	const auto frame_geometry = gui::utils::create_centered_window_geometry(screen, base_geometry, w, h);
 	const auto app_icon = m_main_window ? m_main_window->GetAppIcon() : gui::utils::get_app_icon_from_path(Emu.GetBoot(), Emu.GetTitleID());
 
 	gs_frame* frame = nullptr;

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -7,7 +7,6 @@
 #include <QProcess>
 #include <QScreen>
 #include <QUrl>
-#include <QDebug>
 
 #include "Emu/System.h"
 #include "Utilities/File.h"
@@ -19,7 +18,7 @@ namespace gui
 {
 	namespace utils
 	{
-		QRect create_centered_window_geometry(const QScreen* screen, const QRect& origin, s32 width, s32 height)
+		QRect create_centered_window_geometry(const QScreen* screen, const QRect& base, s32 target_width, s32 target_height)
 		{
 			ensure(screen);
 
@@ -28,17 +27,17 @@ namespace gui
 			// into account, so they don't go offscreen
 			const QRect screen_geometry = screen->availableGeometry();
 			const s32 min_screen_x = screen_geometry.x();
-			const s32 max_screen_x = screen_geometry.x() + screen_geometry.width() - width;
+			const s32 max_screen_x = screen_geometry.x() + screen_geometry.width() - target_width;
 			const s32 min_screen_y = screen_geometry.y();
-			const s32 max_screen_y = screen_geometry.y() + screen_geometry.height() - height;
+			const s32 max_screen_y = screen_geometry.y() + screen_geometry.height() - target_height;
 
-			const s32 frame_x_raw = origin.left() + ((origin.width() - width) / 2);
-			const s32 frame_y_raw = origin.top() + ((origin.height() - height) / 2);
+			const s32 frame_x_raw = base.left() + ((base.width() - target_width) / 2);
+			const s32 frame_y_raw = base.top() + ((base.height() - target_height) / 2);
 
 			const s32 frame_x = std::clamp(frame_x_raw, min_screen_x, max_screen_x);
 			const s32 frame_y = std::clamp(frame_y_raw, min_screen_y, max_screen_y);
 
-			return QRect(frame_x, frame_y, width, height);
+			return QRect(frame_x, frame_y, target_width, target_height);
 		}
 
 		QPixmap get_colorized_pixmap(const QPixmap& old_pixmap, const QColor& old_color, const QColor& new_color, bool use_special_masks, bool colorize_all)

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -23,9 +23,9 @@ namespace gui
 			return QSet<T>(list.begin(), list.end());
 		}
 
-		// Creates a frame geometry rectangle with given width height that's centered inside the origin,
+		// Creates a frame geometry rectangle with target width and height that's centered inside the base,
 		// while still considering screen boundaries.
-		QRect create_centered_window_geometry(const QScreen* screen, const QRect& origin, s32 width, s32 height);
+		QRect create_centered_window_geometry(const QScreen* screen, const QRect& base, s32 target_width, s32 target_height);
 
 		// Returns a custom colored QPixmap based on another QPixmap.
 		// use colorize_all to repaint every opaque pixel with the chosen color


### PR DESCRIPTION
Fix initial game window position calculations.

fixes #10136 (probably)