### PR TITLE
crypto light refactoring.

### DIFF
--- a/rpcs3/Crypto/md5.cpp
+++ b/rpcs3/Crypto/md5.cpp
@@ -27,18 +27,11 @@
  */
 
 #include "md5.h"
+#include "utils.h"
 
 #include <string.h>
 
 #if !defined(MBEDTLS_MD5_ALT)
-
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize(void* v, size_t n)
-{
-	auto p = const_cast<volatile char*>(static_cast<char*>(v));
-	while (n--)
-		*p++ = 0;
-}
 
 /*
  * 32-bit integer manipulation macros (little endian)

--- a/rpcs3/Crypto/sha1.cpp
+++ b/rpcs3/Crypto/sha1.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "sha1.h"
+#include "utils.h"
 
 /*
  * 32-bit integer manipulation macros (big endian)
@@ -313,7 +314,7 @@ void sha1( const unsigned char *input, size_t ilen, unsigned char output[20] )
     sha1_update( &ctx, input, ilen );
     sha1_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha1_context ) );
+    mbedtls_zeroize( &ctx, sizeof( sha1_context ) );
 }
 
 /*
@@ -343,7 +344,7 @@ void sha1_hmac_starts( sha1_context *ctx, const unsigned char *key, size_t keyle
     sha1_starts( ctx );
     sha1_update( ctx, ctx->ipad, 64 );
 
-    memset( sum, 0, sizeof( sum ) );
+    mbedtls_zeroize( sum, sizeof( sum ) );
 }
 
 /*

--- a/rpcs3/Crypto/sha256.cpp
+++ b/rpcs3/Crypto/sha256.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "sha256.h"
+#include "utils.h"
 
 #include <string.h>
 
@@ -70,14 +71,6 @@ do {                                                    \
 } while( 0 )
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize_sha256(void* v, size_t n)
-{
-	auto p = const_cast<volatile char*>(static_cast<char*>(v));
-	while (n--)
-		*p++ = 0;
-}
-
 void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
 {
     SHA256_VALIDATE( ctx != NULL );
@@ -90,7 +83,7 @@ void mbedtls_sha256_free( mbedtls_sha256_context *ctx )
     if( ctx == NULL )
         return;
 
-    mbedtls_zeroize_sha256(ctx, sizeof(mbedtls_sha256_context));
+    mbedtls_zeroize(ctx, sizeof(mbedtls_sha256_context));
 }
 
 void mbedtls_sha256_clone( mbedtls_sha256_context *dst,

--- a/rpcs3/Crypto/utils.cpp
+++ b/rpcs3/Crypto/utils.cpp
@@ -136,3 +136,9 @@ char* extract_file_name(const char* file_path, char real_file_name[CRYPTO_MAX_PA
 	strcpy_trunc(r, v);
 	return real_file_name;
 }
+
+void mbedtls_zeroize(void *v, size_t n)
+{
+	static void *(*const volatile unop_memset)(void *, int, size_t) = &memset;
+	(void)unop_memset(v, 0, n);
+}

--- a/rpcs3/Crypto/utils.h
+++ b/rpcs3/Crypto/utils.h
@@ -52,3 +52,4 @@ bool hmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, int i
 void hmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash);
 bool cmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash, int hash_len);
 void cmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash);
+void mbedtls_zeroize(void *v, size_t n);


### PR DESCRIPTION
using volatile f/p guaranting assembly will generate call* instruction on memset for secure buffer zeroing. usage in sha1 api as well.