### PR TITLE
fix null chars in hostname log message

### DIFF
--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -111,7 +111,7 @@ bool np_handler::discover_ip_address()
 		return false;
 	}
 
-	nph_log.notice("Hostname was determined to be %s", hostname);
+	nph_log.notice("Hostname was determined to be %s", hostname.c_str());
 
 	hostent *host = gethostbyname(hostname.data());
 	if (!host)


### PR DESCRIPTION
This line currently logs a thousand NUL characters.

Idk if this fix works. I just took RipleyTom's proposal and commited.