### PR TITLE
Fixups

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -42,7 +42,7 @@ class named_thread;
 
 class thread_base;
 
-template <typename Ctx, typename X = void, typename... Args>
+template <typename Ctx, typename... Args>
 struct result_storage
 {
 	static constexpr bool empty = true;
@@ -50,8 +50,8 @@ struct result_storage
 	using type = void;
 };
 
-template <typename Ctx, typename... Args>
-struct result_storage<Ctx, std::enable_if_t<!std::is_void_v<std::invoke_result_t<Ctx, Args&&...>>>, Args...>
+template <typename Ctx, typename... Args> requires (!std::is_void_v<std::invoke_result_t<Ctx, Args&&...>>)
+struct result_storage<Ctx, Args...>
 {
 	using T = std::invoke_result_t<Ctx, Args&&...>;
 
@@ -84,6 +84,12 @@ struct result_storage<Ctx, std::enable_if_t<!std::is_void_v<std::invoke_result_t
 	}
 };
 
+template <typename T>
+concept NamedThreadName = requires (T& t)
+{
+	std::string_view(t.thread_name);
+};
+
 // Base class for task queue (linked list)
 class thread_future
 {
@@ -109,12 +115,6 @@ public:
 		exec.wait<atomic_wait::op_ne>(nullptr);
 	}
 };
-
-template <typename T, typename = void>
-struct thread_thread_name : std::bool_constant<false> {};
-
-template <typename T>
-struct thread_thread_name<T, std::void_t<decltype(named_thread<T>::thread_name)>> : std::bool_constant<true> {};
 
 // Thread base class
 class thread_base
@@ -479,16 +479,17 @@ class named_thread final : public Context, result_storage<Context>, thread_base
 	friend class thread_ctrl;
 
 public:
-	// Default constructor
-	named_thread() requires (std::is_default_constructible_v<Context>) && (thread_thread_name<Context>::value)
-		: Context()
+	// Forwarding constructor with default name (also potentially the default constructor)
+	template <typename... Args> requires (std::is_constructible_v<Context, Args&&...>) && (NamedThreadName<Context>)
+	named_thread(Args&&... args)
+		: Context(std::forward<Args>(args)...)
 		, thread(trampoline, Context::thread_name)
 	{
 		thread::start();
 	}
 
 	// Normal forwarding constructor
-	template <typename... Args, typename = std::enable_if_t<std::is_constructible_v<Context, Args&&...>>>
+	template <typename... Args> requires (std::is_constructible_v<Context, Args&&...>) && (!NamedThreadName<Context>)
 	named_thread(std::string_view name, Args&&... args)
 		: Context(std::forward<Args>(args)...)
 		, thread(trampoline, name)

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7418,6 +7418,8 @@ public:
 		{
 			if (auto [ok, bs] = match_expr(b, byteswap(match<u8[16]>())); ok)
 			{
+				// Undo endian swapping, and rely on pshufb/vperm2b to re-reverse endianness
+
 				if (m_use_avx512_icl && (op.ra != op.rb))
 				{
 					const auto m = gf2p8affineqb(c, build<u8[16]>(0x40, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x40, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20), 0x7f);
@@ -7426,7 +7428,7 @@ public:
 					set_vr(op.rt4, select(noncast<s8[16]>(c) >= 0, ab, mm));
 					return;
 				}
-				
+
 				const auto x = avg(noncast<u8[16]>(sext<s8[16]>((c & 0xc0) == 0xc0)), noncast<u8[16]>(sext<s8[16]>((c & 0xe0) == 0xc0)));
 				const auto ax = pshufb(as, c);
 				const auto bx = pshufb(bs, c);


### PR DESCRIPTION
- Use concept NamedThreadName to detect default `thread_name` "property"
Concept tests whether the active object can convert its `thread_name` to `std::string_view` regardless of its type, which should allow wider range of thread name representation, including NSDM or even property-alike. Also replace some SFINAE tests with `requires (trait)`.