### PR TITLE
Fix emulation restart

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2064,6 +2064,8 @@ void Emulator::Stop(bool restart)
 
 	sys_log.notice("Atomic wait hashtable stats: [in_use=%u, used=%u, max_collision_weight=%u, total_collisions=%u]", aw_refs, aw_used, aw_colm, aw_colc);
 
+	stop_watchdog = thread_state::aborting;
+
 	m_stop_ctr++;
 	m_stop_ctr.notify_all();
 


### PR DESCRIPTION
Emulator::Load was incorrectly participating in the emulation stopping timeout detection, leading to possible "Stopping emulator took too long" errors.