### PR TITLE
kernel-explorer: Show bound queue to port information

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -441,6 +441,7 @@ error_code sys_event_port_connect_local(cpu_thread& cpu, u32 eport_id, u32 equeu
 	}
 
 	port->queue = idm::get_unlocked<lv2_obj, lv2_event_queue>(equeue_id);
+	port->queue_id = equeue_id;
 
 	return CELL_OK;
 }
@@ -467,7 +468,7 @@ error_code sys_event_port_connect_ipc(ppu_thread& ppu, u32 eport_id, u64 ipc_key
 		return CELL_ESRCH;
 	}
 
-	if (port->type != 3)
+	if (port->type != SYS_EVENT_PORT_IPC)
 	{
 		return CELL_EINVAL;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -29,6 +29,7 @@ enum : u64
 enum : s32
 {
 	SYS_EVENT_PORT_LOCAL = 1,
+	SYS_EVENT_PORT_IPC   = 3, // Unofficial name
 };
 
 // Event Port Name
@@ -124,8 +125,9 @@ struct lv2_event_port final : lv2_obj
 {
 	static const u32 id_base = 0x0e000000;
 
-	const s32 type; // Port type, must be SYS_EVENT_PORT_LOCAL
+	const s32 type; // Port type, either IPC or local
 	const u64 name; // Event source (generated from id and process id if not set)
+	u32 queue_id = 0; // Event queue ID (if IPC is used this value is meaningless)
 
 	std::weak_ptr<lv2_event_queue> queue; // Event queue this port is connected to
 

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -7,6 +7,7 @@
 #include <QTreeWidgetItem>
 
 #include "Emu/IdManager.h"
+#include "Emu/IPC.h"
 #include "Emu/Cell/PPUThread.h"
 #include "Emu/Cell/SPUThread.h"
 #include "Emu/Cell/lv2/sys_lwmutex.h"
@@ -360,7 +361,29 @@ void kernel_explorer::Update()
 		case SYS_EVENT_PORT_OBJECT:
 		{
 			auto& ep = static_cast<lv2_event_port&>(obj);
-			add_leaf(node, qstr(fmt::format("Event Port 0x%08x: Name: %#llx, Bound: %s", id, ep.name, lv2_event_queue::check(ep.queue))));
+			const auto queue = ep.queue.lock();
+			const auto type = ep.type == SYS_EVENT_PORT_LOCAL ? "LOCAL"sv : "IPC"sv;
+
+			if (lv2_event_queue::check(queue))
+			{
+				if (queue.get() == idm::check_unlocked<lv2_obj, lv2_event_queue>(ep.queue_id));
+				{
+					// Type must be LOCAL here, but refer to the note below for why it is showed
+					add_leaf(node, qstr(fmt::format("Event Port 0x%08x: %s, Name: %#llx, Event Queue (ID): 0x%08x", id, type, ep.name, ep.queue_id)));
+					break;
+				}
+
+				if (queue == lv2_event_queue::find(queue->key))
+				{
+					// There are cases in which the attached queue by ID also has an IPC
+					// And the ID was destroyed but another was created for that same IPC
+					// So show event port type as well here because it not guaranteed to be IPC 
+					add_leaf(node, qstr(fmt::format("Event Port 0x%08x: %s, Name: %#llx, Event Queue (IPC): %s", id, type, ep.name, queue->key)));
+					break;
+				}
+			}
+
+			add_leaf(node, qstr(fmt::format("Event Port 0x%08x: %s, Name: %#llx, Unbound", id, type, ep.name)));
 			break;
 		}
 		case SYS_TRACE_OBJECT:


### PR DESCRIPTION
Show its IPC key or ID, depends on the queue's type.
Example: `Event Port Ox0e007600: LOCAL, Name: 0, Event Queue (ID): 0x8d007500`