### PR TITLE
vk: Fix WDB when swizzled raster output is active

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2166,7 +2166,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 		const utils::address_range surface_range = m_depth_surface_info.get_memory_range();
 		if (g_cfg.video.write_depth_buffer)
 		{
-			const u32 gcm_format = (m_depth_surface_info.depth_format != rsx::surface_depth_format::z16) ? CELL_GCM_TEXTURE_DEPTH16 : CELL_GCM_TEXTURE_DEPTH24_D8;
+			const u32 gcm_format = (m_depth_surface_info.depth_format == rsx::surface_depth_format::z16) ? CELL_GCM_TEXTURE_DEPTH16 : CELL_GCM_TEXTURE_DEPTH24_D8;
 			m_texture_cache.lock_memory_region(
 				*m_current_command_buffer, m_rtts.m_bound_depth_stencil.second, surface_range, true,
 				m_depth_surface_info.width, m_depth_surface_info.height, m_framebuffer_layout.actual_zeta_pitch, gcm_format, true);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -263,7 +263,8 @@ namespace vk
 			// Synchronize, reset dma_fence after waiting
 			vk::wait_for_event(dma_fence.get(), GENERAL_WAIT_TIMEOUT);
 
-			const auto range = get_confirmed_range();
+			// Calculate smallest range to flush - for framebuffers, the raster region is enough
+			const auto range = (context == rsx::texture_upload_context::framebuffer_storage)? get_section_range() : get_confirmed_range();
 			vk::flush_dma(range.start, range.length());
 
 			if (is_swizzled())


### PR DESCRIPTION
Fixes broken FBO swizzle for depth textures. WDB was basically broken for these. With this fix R&C ACiT looks like a game when WDB is enabled.