### PR TITLE
Qt: Fix popup position of the update dialog

### DIFF
--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -75,14 +75,17 @@ void progress_dialog_server::operator()()
 			dlg->type.se_normal          = true;
 			dlg->type.bg_invisible       = true;
 			dlg->type.progress_bar_count = 1;
-			dlg->on_close                = [](s32 /*status*/) {
-                Emu.CallAfter([]() {
-                    // Abort everything
-                    Emu.Stop();
-                });
+			dlg->on_close = [](s32 /*status*/)
+			{
+				Emu.CallAfter([]()
+				{
+					// Abort everything
+					Emu.Stop();
+				});
 			};
 
-			Emu.CallAfter([dlg, text0]() {
+			Emu.CallAfter([dlg, text0]()
+			{
 				dlg->Create(text0, text0);
 			});
 		}
@@ -146,7 +149,8 @@ void progress_dialog_server::operator()()
 				}
 				else if (dlg)
 				{
-					Emu.CallAfter([=]() {
+					Emu.CallAfter([=]()
+					{
 						dlg->SetMsg(text_new);
 						dlg->ProgressBarSetMsg(0, progr);
 						dlg->ProgressBarSetValue(0, std::floor(value));
@@ -172,7 +176,8 @@ void progress_dialog_server::operator()()
 		}
 		else if (dlg)
 		{
-			Emu.CallAfter([=]() {
+			Emu.CallAfter([=]()
+			{
 				dlg->Close(true);
 			});
 		}

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -227,7 +227,7 @@ void update_manager::update()
 	ensure(m_downloader);
 
 	if (m_update_message.isEmpty() ||
-		QMessageBox::question(m_downloader->get_progress_dialog(), tr("Update Available"), m_update_message, QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+		QMessageBox::question(m_downloader->get_progress_dialog() ? m_downloader->get_progress_dialog() : m_parent, tr("Update Available"), m_update_message, QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
 	{
 		m_downloader->close_progress_dialog();
 		return;


### PR DESCRIPTION
The "update available" dialog currently pops up in the center of the primary screen.
This is not what I intended and is caused by the missing progress bar dialog during these automatic checks.
You can test this by checking manually on master. It should popup correctly on top of the download progress dialog.

fixes #8752