### PR TITLE
Toolchain upgrades

### DIFF
--- a/.ci/build-freebsd.sh
+++ b/.ci/build-freebsd.sh
@@ -7,10 +7,10 @@ git submodule -q update --init --depth 1 $(awk '/path/ && !/llvm/ { print $3 }' 
 
 # Prefer newer Clang than in base system (see also .ci/install-freebsd.sh)
 # libc++ isn't in llvm* packages, so download manually
-fetch https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/libcxx-11.0.0.src.tar.xz
-tar xf libcxx-11.0.0.src.tar.xz
-export CC=clang11 CXX=clang++11
-export CXXFLAGS="$CXXFLAGS -nostdinc++ -isystem $PWD/libcxx-11.0.0.src/include"
+fetch https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/libcxx-12.0.0.src.tar.xz
+tar xf libcxx-12.0.0.src.tar.xz
+export CC=clang12 CXX=clang++12
+export CXXFLAGS="$CXXFLAGS -nostdinc++ -D_LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS -isystem $PWD/libcxx-12.0.0.src/include"
 
 CONFIGURE_ARGS="
 	-DWITH_LLVM=OFF

--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -12,7 +12,6 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     ./squashfs-root/AppRun ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
     ls ./appdir/usr/lib/
     rm -r ./appdir/usr/share/doc
-    rm ./appdir/usr/lib/libxcb*
     cp "$(readlink -f /lib/x86_64-linux-gnu/libnsl.so.1)" ./appdir/usr/lib/libnsl.so.1
     export PATH=/rpcs3/build/squashfs-root/usr/bin/:${PATH}
 

--- a/.ci/install-freebsd.sh
+++ b/.ci/install-freebsd.sh
@@ -9,7 +9,7 @@ export ASSUME_ALWAYS_YES=true
 pkg info # debug
 
 # Prefer newer Clang than in base system (see also .ci/build-freebsd.sh)
-pkg install llvm11
+pkg install llvm12
 
 # Mandatory dependencies (qt5-dbus and qt5-gui are pulled via qt5-widgets)
 pkg install git ccache cmake ninja qt5-qmake qt5-buildtools qt5-widgets qt5-concurrent glew openal-soft ffmpeg

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,7 +60,7 @@ windows_task:
 
 linux_task:
   container:
-    image: rpcs3/rpcs3-travis-xenial:1.7
+    image: rpcs3/rpcs3-ci-bionic:1.0
     cpu: 4
     memory: 16G
   env:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,8 +19,8 @@ Other instructions may be found [here](https://wiki.rpcs3.net/index.php?title=Bu
 
 These are the essentials tools to build RPCS3 on Linux. Some of them can be installed through your favorite package manager.
 
-* Clang 11+ or GCC 9+
-* [CMake 3.14.1+](https://www.cmake.org/download/)
+* Clang 12+ or GCC 10+
+* [CMake 3.16.9+](https://www.cmake.org/download/)
 * [Qt 5.15.2](https://www.qt.io/download-qt-installer)
 * [Vulkan SDK 1.1.126+](https://vulkan.lunarg.com/sdk/home) (See "Install the SDK" [here](https://vulkan.lunarg.com/doc/sdk/latest/linux/getting_started.html))
 * [SDL2](https://www.libsdl.org/download-2.0.php) (for the FAudio backend)
@@ -47,16 +47,16 @@ sudo apt-get install qt515base qt515svg
 . /opt/qt515/bin/qt515-env.sh >/dev/null 2>&1
 ```
 
-##### GCC 9.x installation
+##### GCC 10.x installation
 
-If the `gcc-9` package is not available on your system, use the following commands
+If the `gcc-10` package is not available on your system, use the following commands
 ```
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
-sudo apt-get install gcc-9 g++-9
+sudo apt-get install gcc-10 g++-10
 ```
 
-You can either use `update-alternatives` to setup `gcc-9`/`g++-9` as your default compilers or prefix any `cmake` command by `CXX=g++-9 CC=gcc-9 ` to use it.
+You can either use `update-alternatives` to setup `gcc-10`/`g++-10` as your default compilers or prefix any `cmake` command by `CXX=g++-10 CC=gcc-10 ` to use it.
 
 ##### Vulkan SDK
 
@@ -126,7 +126,7 @@ Afterwards:
 While still in the project root:
 
 1) `cd .. && mkdir rpcs3_build && cd rpcs3_build`
-2) `cmake ../rpcs3/ && make` or `CXX=g++-9 CC=gcc-9 cmake ../rpcs3/ && make` to force these compilers
+2) `cmake ../rpcs3/ && make` or `CXX=g++-10 CC=gcc-10 cmake ../rpcs3/ && make` to force these compilers
 3) Run RPCS3 with `./bin/rpcs3`
 
 When using GDB, configure it to ignore SIGSEGV signal (`handle SIGSEGV nostop noprint`).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
-cmake_minimum_required(VERSION 3.14.1)
+cmake_minimum_required(VERSION 3.16.9)
 
 project(rpcs3)
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-        message(FATAL_ERROR "RPCS3 requires at least gcc-9.")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
+        message(FATAL_ERROR "RPCS3 requires at least gcc-10.")
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0)
-        message(FATAL_ERROR "RPCS3 requires at least clang-11.0.")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)
+        message(FATAL_ERROR "RPCS3 requires at least clang-12.0.")
     endif()
 endif()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,13 +35,13 @@ jobs:
     displayName: ccache
 
   - bash: |
-      docker pull --quiet rpcs3/rpcs3-travis-xenial:1.7
+      docker pull --quiet rpcs3/rpcs3-ci-bionic:1.0
       docker run                      \
         -v $(pwd):/rpcs3              \
         --env-file .ci/docker.env \
         -v $CCACHE_DIR:/root/.ccache  \
         -v $BUILD_ARTIFACTSTAGINGDIRECTORY:/root/artifacts \
-        rpcs3/rpcs3-travis-xenial:1.7 \
+        rpcs3/rpcs3-ci-bionic:1.0 \
         /rpcs3/.ci/build-linux.sh
     displayName: Docker setup and build
 


### PR DESCRIPTION
Switches to a Ubuntu 18.04 docker container for Linux builds. Now it uses GCC 10.3 and Clang 12 for compilation, CMake (minimum as well) and Ninja versions are also bumped. Also bumps the LLVM submodule to a later commit. Removes the xcb hack, bumps minimum compiler versions. Switches BSD to Clang 12.

~~edit: do not merge yet, waiting on hcorion to push a newer docker image.~~