### PR TITLE
CI: don't cache downloaded packages on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -109,7 +109,5 @@ freebsd_task:
     CCACHE_DIR: /tmp/ccache_dir
   ccache_cache:
     folder: /tmp/ccache_dir
-  packages_cache:
-    folder: /var/cache/pkg
   install_script: "sh -ex ./.ci/install-freebsd.sh"
   script: "./.ci/build-freebsd.sh"


### PR DESCRIPTION
Shaves ~1 minute of build time. In the past, caching failed to prevent https://github.com/RPCS3/rpcs3/issues/9518.