### PR TITLE
Simplify named_thread construction

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2316,9 +2316,9 @@ std::string thread_ctrl::get_name_cached()
 	return *name_cache;
 }
 
-thread_base::thread_base(native_entry entry, std::string_view name)
+thread_base::thread_base(native_entry entry, std::string name)
 	: entry_point(entry)
-	, m_tname(make_single<std::string>(name))
+	, m_tname(make_single_value(std::move(name)))
 {
 }
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -821,7 +821,7 @@ void try_spawn_ppu_if_exclusive_program(const ppu_module& m)
 			.stack_size = SYS_PROCESS_PARAM_STACK_SIZE_MAX,
 		};
 
-		auto ppu = idm::make_ptr<named_thread<ppu_thread>>("PPU[0x1000000] Thread (test_thread)", p, "test_thread", 0);
+		auto ppu = idm::make_ptr<named_thread<ppu_thread>>(p, "test_thread", 0);
 
 		ppu->cia = m.funcs[0].addr;
 
@@ -1694,7 +1694,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 	p.stack_addr = vm::cast(vm::alloc(primary_stacksize, vm::stack, 4096));
 	p.stack_size = primary_stacksize;
 
-	auto ppu = idm::make_ptr<named_thread<ppu_thread>>("PPU[0x1000000] main_thread ", p, "main_thread", primary_prio, 1);
+	auto ppu = idm::make_ptr<named_thread<ppu_thread>>(p, "main_thread", primary_prio, 1);
 
 	// Write initial data (exitspawn)
 	if (!Emu.data.empty())

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1133,6 +1133,18 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 	}
 }
 
+ppu_thread::thread_name_t::operator std::string() const
+{
+	std::string thread_name = fmt::format("PPU[0x%x]", _this->id);
+
+	if (const std::string name = *_this->ppu_tname.load(); !name.empty())
+	{
+		fmt::append(thread_name, " %s", name);
+	}
+
+	return thread_name;
+}
+
 void ppu_thread::cmd_push(cmd64 cmd)
 {
 	// Reserve queue space

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -282,6 +282,14 @@ public:
 
 	u32 dbg_step_pc = 0;
 
+	// For named_thread ctor
+	const struct thread_name_t
+	{
+		const ppu_thread* _this;
+
+		operator std::string() const;
+	} thread_name{ this };
+
 	be_t<u64>* get_stack_arg(s32 i, u64 align = alignof(u64));
 	void exec_task();
 	void fast_call(u32 addr, u32 rtoc);

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -321,7 +321,7 @@ void spu_load_exec(const spu_exec_object& elf)
 {
 	spu_thread::g_raw_spu_ctr++;
 
-	auto spu = idm::make_ptr<named_thread<spu_thread>>("TEST_SPU", nullptr, 0, "", 0);
+	auto spu = idm::make_ptr<named_thread<spu_thread>>(nullptr, 0, "test_spu", 0);
 
 	for (const auto& prog : elf.progs)
 	{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4793,6 +4793,27 @@ spu_function_logger::spu_function_logger(spu_thread& spu, const char* func)
 	spu.start_time = get_system_time();
 }
 
+spu_thread::thread_name_t::operator std::string() const
+{
+	std::string full_name = fmt::format("%s[0x%07x]", [](spu_type type) -> std::string_view
+	{
+		switch (type)
+		{
+		case spu_type::threaded: return "SPU"sv;
+		case spu_type::raw: return "RawSPU"sv;
+		case spu_type::isolated: return "Iso"sv;
+		default: fmt::throw_exception("Unreachable");
+		}
+	}(_this->get_type()), _this->lv2_id);
+
+	if (const std::string name = *_this->spu_tname.load(); !name.empty())
+	{
+		fmt::append(full_name, " %s", name);
+	}
+
+	return full_name;
+}
+
 template <>
 void fmt_class_string<spu_channel>::format(std::string& out, u64 arg)
 {

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -850,6 +850,14 @@ public:
 
 		return -1;
 	}
+
+	// For named_thread ctor
+	const struct thread_name_t
+	{
+		const spu_thread* _this;
+
+		operator std::string() const;
+	} thread_name{ this };
 };
 
 class spu_function_logger

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -459,18 +459,6 @@ error_code _sys_ppu_thread_create(ppu_thread& ppu, vm::ptr<u64> thread_id, vm::p
 
 	const u32 tid = idm::import<named_thread<ppu_thread>>([&]()
 	{
-		const u32 tid = idm::last_id();
-
-		std::string full_name = fmt::format("PPU[0x%x] ", tid);
-
-		if (threadname)
-		{
-			if (!ppu_name.empty())
-			{
-				fmt::append(full_name, "%s ", ppu_name);
-			}
-		}
-
 		ppu_thread_params p;
 		p.stack_addr = stack_base;
 		p.stack_size = stack_size;
@@ -479,7 +467,7 @@ error_code _sys_ppu_thread_create(ppu_thread& ppu, vm::ptr<u64> thread_id, vm::p
 		p.arg0 = arg;
 		p.arg1 = unk;
 
-		return std::make_shared<named_thread<ppu_thread>>(full_name, p, ppu_name, prio, 1 - static_cast<int>(flags & 3));
+		return std::make_shared<named_thread<ppu_thread>>(p, ppu_name, prio, 1 - static_cast<int>(flags & 3));
 	});
 
 	if (!tid)

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -408,14 +408,7 @@ error_code sys_spu_thread_initialize(ppu_thread& ppu, vm::ptr<u32> thread, u32 g
 
 	ensure(idm::import<named_thread<spu_thread>>([&]()
 	{
-		std::string full_name = fmt::format("SPU[0x%07x] ", tid);
-
-		if (!thread_name.empty())
-		{
-			fmt::append(full_name, "%s ", thread_name);
-		}
-
-		const auto spu = std::make_shared<named_thread<spu_thread>>(full_name, group.get(), spu_num, thread_name, tid, false, option);
+		const auto spu = std::make_shared<named_thread<spu_thread>>(group.get(), spu_num, thread_name, tid, false, option);
 		group->threads[inited] = spu;
 		group->threads_map[spu_num] = static_cast<s8>(inited);
 		return spu;
@@ -1849,7 +1842,7 @@ error_code sys_raw_spu_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<void> at
 			index = 0;
 	}
 
-	const u32 tid = idm::make<named_thread<spu_thread>>(fmt::format("RawSPU[0x%x] ", index), nullptr, index, "", index);
+	const u32 tid = idm::make<named_thread<spu_thread>>(nullptr, index, "", index);
 
 	spu_thread::g_raw_spu_id[index] = (ensure(tid));
 
@@ -1897,7 +1890,7 @@ error_code sys_isolated_spu_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<voi
 
 	const u32 ls_addr = RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * index;
 
-	const auto thread = idm::make_ptr<named_thread<spu_thread>>(fmt::format("IsoSPU[0x%x] ", index), nullptr, index, "", index, true);
+	const auto thread = idm::make_ptr<named_thread<spu_thread>>(nullptr, index, "", index, true);
 
 	thread->gpr[3] = v128::from64(0, arg1);
 	thread->gpr[4] = v128::from64(0, arg2);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -411,7 +411,7 @@ bool Emulator::BootRsxCapture(const std::string& path)
 	GetCallbacks().on_run(false);
 	m_state = system_state::running;
 
-	auto replay_thr = g_fxo->init<named_thread<rsx::rsx_replay_thread>>("RSX Replay"sv, std::move(frame));
+	auto replay_thr = g_fxo->init<named_thread<rsx::rsx_replay_thread>>("RSX Replay", std::move(frame));
 	replay_thr->state -= cpu_flag::stop;
 	replay_thr->state.notify_one(cpu_flag::stop);
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -674,7 +674,9 @@ void debugger_frame::UpdateUnitList()
 		if (emu_state == system_state::stopped) return;
 
 		const QVariant var_cpu = QVariant::fromValue<std::pair<cpu_thread*, u32>>(std::make_pair(&cpu, id));
-		m_choice_units->addItem(qstr(id >> 24 == 0x55 ? "RSX[0x55555555]" : cpu.get_name()), var_cpu);
+
+		// Space at the end is to pad a gap on the right
+		m_choice_units->addItem(qstr((id >> 24 == 0x55 ? "RSX[0x55555555]" : cpu.get_name()) + ' '), var_cpu);
 
 		if (!reselected && old_cpu == var_cpu)
 		{


### PR DESCRIPTION
Allowing for more flexible constructors without explicit name argument, matching the context's contructors.