### PR TITLE
Correct mismatched licenses in Crypto

### DIFF
--- a/rpcs3/Crypto/ec.h
+++ b/rpcs3/Crypto/ec.h
@@ -1,8 +1,8 @@
 #pragma once
 
 // Copyright (C) 2014       Hykem <hykem@hotmail.com>
-// Licensed under the terms of the GNU GPL, version 3
-// http://www.gnu.org/licenses/gpl-3.0.txt
+// Licensed under the terms of the GNU GPL, version 2.0 or later versions.
+// http://www.gnu.org/licenses/gpl-2.0.txt
 
 #include "util/types.hpp"
 

--- a/rpcs3/Crypto/lz.cpp
+++ b/rpcs3/Crypto/lz.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2014       Hykem <hykem@hotmail.com>
-// Licensed under the terms of the GNU GPL, version 3
-// http://www.gnu.org/licenses/gpl-3.0.txt
+// Licensed under the terms of the GNU GPL, version 2.0 or later versions.
+// http://www.gnu.org/licenses/gpl-2.0.txt
 
 #include "lz.h"
 

--- a/rpcs3/Crypto/lz.h
+++ b/rpcs3/Crypto/lz.h
@@ -1,8 +1,8 @@
 #pragma once
 
 // Copyright (C) 2014       Hykem <hykem@hotmail.com>
-// Licensed under the terms of the GNU GPL, version 3
-// http://www.gnu.org/licenses/gpl-3.0.txt
+// Licensed under the terms of the GNU GPL, version 2.0 or later versions.
+// http://www.gnu.org/licenses/gpl-2.0.txt
 
 // Reverse-engineered custom Lempel–Ziv–Markov based compression.
 

--- a/rpcs3/Crypto/utils.cpp
+++ b/rpcs3/Crypto/utils.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2014       Hykem <hykem@hotmail.com>
-// Licensed under the terms of the GNU GPL, version 3
-// http://www.gnu.org/licenses/gpl-3.0.txt
+// Licensed under the terms of the GNU GPL, version 2.0 or later versions.
+// http://www.gnu.org/licenses/gpl-2.0.txt
 
 #include "utils.h"
 #include "aes.h"

--- a/rpcs3/Crypto/utils.h
+++ b/rpcs3/Crypto/utils.h
@@ -1,8 +1,8 @@
 #pragma once
 
 // Copyright (C) 2014       Hykem <hykem@hotmail.com>
-// Licensed under the terms of the GNU GPL, version 3
-// http://www.gnu.org/licenses/gpl-3.0.txt
+// Licensed under the terms of the GNU GPL, version 2.0 or later versions.
+// http://www.gnu.org/licenses/gpl-2.0.txt
 
 #include "util/types.hpp"
 


### PR DESCRIPTION
5 files in Crypto were licensed under GPL-3.0-only which is incompatible with our project's GPL-2.0-only license. They have now been corrected to use GPL-2.0-or-later.

Approval from all contributors with copyrightable changes has been obtained.
