### PR TITLE
Digging for some features

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1131,7 +1131,6 @@ namespace vm
 			m_common = std::make_shared<utils::shm>(size, fs::get_cache_dir() + std::to_string(utils::get_unique_tsc()));
 			m_common->map_critical(vm::base(addr), utils::protection::no);
 			m_common->map_critical(vm::get_super_ptr(addr));
-			lock_sudo(addr, size);
 		}
 	}
 

--- a/rpcs3/util/v128.hpp
+++ b/rpcs3/util/v128.hpp
@@ -56,7 +56,7 @@ union alignas(16) v128
 	reversed_array_t<f64> dr;
 
 	u128 _u;
-	//s128 _s;
+	s128 _s;
 
 #ifdef _MSC_VER
 	template <typename T>

--- a/rpcs3/util/vm.hpp
+++ b/rpcs3/util/vm.hpp
@@ -65,13 +65,13 @@ namespace utils
 		~shm();
 
 		// Map shared memory
-		u8* map(void* ptr, protection prot = protection::rw) const;
+		u8* map(void* ptr, protection prot = protection::rw, bool cow = false) const;
 
 		// Attempt to map shared memory fix fixed pointer
-		u8* try_map(void* ptr, protection prot = protection::rw) const;
+		u8* try_map(void* ptr, protection prot = protection::rw, bool cow = false) const;
 
 		// Map shared memory over reserved memory region, which is unsafe (non-atomic) under Win32
-		u8* map_critical(void* ptr, protection prot = protection::rw);
+		u8* map_critical(void* ptr, protection prot = protection::rw, bool cow = false);
 
 		// Map shared memory into its own storage (not mapped by default)
 		u8* map_self(protection prot = protection::rw);

--- a/rpcs3/util/vm.hpp
+++ b/rpcs3/util/vm.hpp
@@ -51,12 +51,15 @@ namespace utils
 #else
 		int m_file{};
 #endif
-		u32 m_size{};
 		u32 m_flags{};
+		u64 m_size{};
 		atomic_t<void*> m_ptr{nullptr};
 
 	public:
 		explicit shm(u32 size, u32 flags = 0);
+
+		// Construct with specified path as sparse file storage
+		shm(u64 size, const std::string& storage);
 
 		shm(const shm&) = delete;
 
@@ -91,7 +94,7 @@ namespace utils
 			return static_cast<u8*>(+m_ptr);
 		}
 
-		u32 size() const
+		u64 size() const
 		{
 			return m_size;
 		}


### PR DESCRIPTION
- Implement s128 type (unused, maybe it's better to remove it completely)
- Add native API flag for CoW memory (copy-on-write)
- Dig for portable memory overcommitting technique. For now, try to map temporary sparse file (which is filled with zeros and doesn't occupy disk space) with mentioned cow flag. Try to get 32G of "writable" memory. There was an idea of implementing scalable breakpoint framework on base of it (interrupts, conditionals, memory access bp, etc).