### PR TITLE
LV2: Fixup for IPC

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -24,11 +24,12 @@ error_code sys_cond_create(ppu_thread& ppu, vm::ptr<u32> cond_id, u32 mutex_id, 
 
 	const auto _attr = *attr;
 
-	if (const auto error = lv2_obj::create<lv2_cond>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]
+	const u64 ipc_key = lv2_obj::get_key(_attr);
+
+	if (const auto error = lv2_obj::create<lv2_cond>(_attr.pshared, ipc_key, _attr.flags, [&]
 	{
 		return std::make_shared<lv2_cond>(
-			_attr.pshared,
-			_attr.ipc_key,
+			ipc_key,
 			_attr.name_u64,
 			mutex_id,
 			std::move(mutex));
@@ -57,7 +58,7 @@ error_code sys_cond_destroy(ppu_thread& ppu, u32 cond_id)
 		}
 
 		cond.mutex->cond_count--;
-		lv2_obj::on_id_destroy(cond, cond.shared, cond.key);
+		lv2_obj::on_id_destroy(cond, cond.key);
 		return {};
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_cond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.h
@@ -22,7 +22,6 @@ struct lv2_cond final : lv2_obj
 {
 	static const u32 id_base = 0x86000000;
 
-	const u32 shared;
 	const u64 key;
 	const u64 name;
 	const u32 mtx_id;
@@ -31,9 +30,8 @@ struct lv2_cond final : lv2_obj
 	atomic_t<u32> waiters{0};
 	std::deque<cpu_thread*> sq;
 
-	lv2_cond(u32 shared, u64 key, u64 name, u32 mtx_id, std::shared_ptr<lv2_mutex> mutex)
-		: shared(shared)
-		, key(key)
+	lv2_cond(u64 key, u64 name, u32 mtx_id, std::shared_ptr<lv2_mutex> mutex)
+		: key(key)
 		, name(name)
 		, mtx_id(mtx_id)
 		, mutex(std::move(mutex))

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -147,7 +147,7 @@ error_code sys_event_queue_destroy(ppu_thread& ppu, u32 equeue_id, s32 mode)
 			return CELL_EBUSY;
 		}
 
-		lv2_obj::on_id_destroy(queue, queue.key == SYS_EVENT_QUEUE_LOCAL ? SYS_SYNC_NOT_PROCESS_SHARED : SYS_SYNC_PROCESS_SHARED, queue.key);
+		lv2_obj::on_id_destroy(queue, queue.key);
 		return {};
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -40,12 +40,13 @@ error_code sys_event_flag_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<sys_e
 		return CELL_EINVAL;
 	}
 
-	if (const auto error = lv2_obj::create<lv2_event_flag>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]
+	const u64 ipc_key = lv2_obj::get_key(_attr);
+
+	if (const auto error = lv2_obj::create<lv2_event_flag>(_attr.pshared, ipc_key, _attr.flags, [&]
 	{
 		return std::make_shared<lv2_event_flag>(
 			_attr.protocol,
-			_attr.pshared,
-			_attr.ipc_key,
+			ipc_key,
 			_attr.type,
 			_attr.name_u64,
 			init);
@@ -71,7 +72,7 @@ error_code sys_event_flag_destroy(ppu_thread& ppu, u32 id)
 			return CELL_EBUSY;
 		}
 
-		lv2_obj::on_id_destroy(flag, flag.shared, flag.key);
+		lv2_obj::on_id_destroy(flag, flag.key);
 		return {};
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.h
@@ -36,7 +36,6 @@ struct lv2_event_flag final : lv2_obj
 	static const u32 id_base = 0x98000000;
 
 	const lv2_protocol protocol;
-	const u32 shared;
 	const u64 key;
 	const s32 type;
 	const u64 name;
@@ -46,9 +45,8 @@ struct lv2_event_flag final : lv2_obj
 	atomic_t<u64> pattern;
 	std::deque<cpu_thread*> sq;
 
-	lv2_event_flag(u32 protocol, u32 shared, u64 key, s32 type, u64 name, u64 pattern)
+	lv2_event_flag(u32 protocol, u64 key, s32 type, u64 name, u64 pattern)
 		: protocol{protocol}
-		, shared(shared)
 		, key(key)
 		, type(type)
 		, name(name)

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.h
@@ -22,13 +22,13 @@ struct lv2_memory : lv2_obj
 	const u32 align; // Alignment required
 	const u64 flags;
 	const u64 key; // IPC key
-	const u32 pshared;
+	const bool pshared; // Process shared flag
 	lv2_memory_container* const ct; // Associated memory container
 	const std::shared_ptr<utils::shm> shm;
 
 	atomic_t<u32> counter{0};
 
-	lv2_memory(u32 size, u32 align, u64 flags, u64 key, u32 pshared, lv2_memory_container* ct);
+	lv2_memory(u32 size, u32 align, u64 flags, u64 key, bool pshared, lv2_memory_container* ct);
 };
 
 enum : u64

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -57,7 +57,6 @@ error_code sys_mutex_create(ppu_thread& ppu, vm::ptr<u32> mutex_id, vm::ptr<sys_
 		return std::make_shared<lv2_mutex>(
 			_attr.protocol,
 			_attr.recursive,
-			_attr.pshared,
 			_attr.adaptive,
 			_attr.ipc_key,
 			_attr.name_u64);
@@ -90,7 +89,7 @@ error_code sys_mutex_destroy(ppu_thread& ppu, u32 mutex_id)
 			return CELL_EPERM;
 		}
 
-		lv2_obj::on_id_destroy(mutex, mutex.shared, mutex.key);
+		lv2_obj::on_id_destroy(mutex, mutex.key);
 		return {};
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -27,7 +27,6 @@ struct lv2_mutex final : lv2_obj
 
 	const lv2_protocol protocol;
 	const u32 recursive;
-	const u32 shared;
 	const u32 adaptive;
 	const u64 key;
 	const u64 name;
@@ -38,10 +37,9 @@ struct lv2_mutex final : lv2_obj
 	atomic_t<u32> lock_count{0}; // Recursive Locks
 	std::deque<cpu_thread*> sq;
 
-	lv2_mutex(u32 protocol, u32 recursive, u32 shared, u32 adaptive, u64 key, u64 name)
+	lv2_mutex(u32 protocol, u32 recursive,u32 adaptive, u64 key, u64 name)
 		: protocol{protocol}
 		, recursive(recursive)
-		, shared(shared)
 		, adaptive(adaptive)
 		, key(key)
 		, name(name)

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -30,9 +30,11 @@ error_code sys_rwlock_create(ppu_thread& ppu, vm::ptr<u32> rw_lock_id, vm::ptr<s
 		return CELL_EINVAL;
 	}
 
-	if (auto error = lv2_obj::create<lv2_rwlock>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]
+	const u64 ipc_key = lv2_obj::get_key(_attr);
+
+	if (auto error = lv2_obj::create<lv2_rwlock>(_attr.pshared, ipc_key, _attr.flags, [&]
 	{
-		return std::make_shared<lv2_rwlock>(protocol, _attr.pshared, _attr.ipc_key, _attr.name_u64);
+		return std::make_shared<lv2_rwlock>(protocol, ipc_key, _attr.name_u64);
 	}))
 	{
 		return error;
@@ -55,7 +57,7 @@ error_code sys_rwlock_destroy(ppu_thread& ppu, u32 rw_lock_id)
 			return CELL_EBUSY;
 		}
 
-		lv2_obj::on_id_destroy(rw, rw.shared, rw.key);
+		lv2_obj::on_id_destroy(rw, rw.key);
 		return {};
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.h
@@ -24,7 +24,6 @@ struct lv2_rwlock final : lv2_obj
 	static const u32 id_base = 0x88000000;
 
 	const lv2_protocol protocol;
-	const u32 shared;
 	const u64 key;
 	const u64 name;
 
@@ -33,9 +32,8 @@ struct lv2_rwlock final : lv2_obj
 	std::deque<cpu_thread*> rq;
 	std::deque<cpu_thread*> wq;
 
-	lv2_rwlock(u32 protocol, u32 shared, u64 key, u64 name)
+	lv2_rwlock(u32 protocol, u64 key, u64 name)
 		: protocol{protocol}
-		, shared(shared)
 		, key(key)
 		, name(name)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -36,9 +36,11 @@ error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sy
 		return CELL_EINVAL;
 	}
 
-	if (auto error = lv2_obj::create<lv2_sema>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]
+	const u64 ipc_key = lv2_obj::get_key(_attr);
+
+	if (auto error = lv2_obj::create<lv2_sema>(_attr.pshared, ipc_key, _attr.flags, [&]
 	{
-		return std::make_shared<lv2_sema>(protocol, _attr.pshared, _attr.ipc_key, _attr.name_u64, max_val, initial_val);
+		return std::make_shared<lv2_sema>(protocol, ipc_key, _attr.name_u64, max_val, initial_val);
 	}))
 	{
 		return error;
@@ -66,7 +68,7 @@ error_code sys_semaphore_destroy(ppu_thread& ppu, u32 sem_id)
 			return CELL_EBUSY;
 		}
 
-		lv2_obj::on_id_destroy(sema, sema.shared, sema.key);
+		lv2_obj::on_id_destroy(sema, sema.key);
 		return {};
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.h
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.h
@@ -24,7 +24,6 @@ struct lv2_sema final : lv2_obj
 	static const u32 id_base = 0x96000000;
 
 	const lv2_protocol protocol;
-	const u32 shared;
 	const u64 key;
 	const u64 name;
 	const s32 max;
@@ -33,9 +32,8 @@ struct lv2_sema final : lv2_obj
 	atomic_t<s32> val;
 	std::deque<cpu_thread*> sq;
 
-	lv2_sema(u32 protocol, u32 shared, u64 key, u64 name, s32 max, s32 value)
+	lv2_sema(u32 protocol, u64 key, u64 name, s32 max, s32 value)
 		: protocol{protocol}
-		, shared(shared)
 		, key(key)
 		, name(name)
 		, max(max)

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -314,7 +314,15 @@ void kernel_explorer::Update()
 		case SYS_MEM_OBJECT:
 		{
 			auto& mem = static_cast<lv2_memory&>(obj);
-			add_leaf(node, qstr(fmt::format("Shared Mem 0x%08x: Size: 0x%x (%0.2f MB), Granularity: %s, Mappings: %u", id, mem.size, mem.size * 1. / (1024 * 1024), mem.align == 0x10000u ? "64K" : "1MB", +mem.counter)));
+			const f64 size_mb = mem.size * 1. / (1024 * 1024);
+
+			if (mem.pshared)
+			{
+				add_leaf(node, qstr(fmt::format("Shared Mem 0x%08x: Size: 0x%x (%0.2f MB), Granularity: %s, Mappings: %u Key: %#llx", id, mem.size, size_mb, mem.align == 0x10000u ? "64K" : "1MB", +mem.counter, mem.key)));
+				break;
+			}
+
+			add_leaf(node, qstr(fmt::format("Shared Mem 0x%08x: Size: 0x%x (%0.2f MB), Granularity: %s, Mappings: %u", id, mem.size, size_mb, mem.align == 0x10000u ? "64K" : "1MB", +mem.counter)));
 			break;
 		}
 		case SYS_MUTEX_OBJECT:


### PR DESCRIPTION
* Fix typo in lv2_obj::create.
* Always save ipc_key as 0 for non-shared object creations, regardless of thbe value set by creation attribute.
* Show IPC key of shared memory (sys_mmapper) memory objects in kernel explorer.

Fixes #10248 