### PR TITLE
rsx: Surface cache improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -36,11 +36,59 @@ namespace rsx
 		bytes = 2
 	};
 
-	enum surface_access : u32
+	class surface_access // This is simply a modified enum class
 	{
-		read = 0,
-		write = 1,
-		transfer = 2
+	public:
+		// Publicly visible enumerators
+		enum
+		{
+			shader_read = 0,
+			shader_write = 1,
+			transfer_read = 2,
+			transfer_write = 4,
+		};
+
+	private:
+		// Meta
+		enum
+		{
+			all_writes = (shader_write | transfer_write),
+			all_reads = (shader_read | transfer_read),
+			all_transfer = (transfer_read | transfer_write)
+		};
+
+		u32 value_;
+
+	public:
+		// Ctor
+		surface_access(u32 value) : value_(value)
+		{}
+
+		// Quick helpers
+		inline bool is_read() const
+		{
+			return !(value_ & ~all_reads);
+		}
+
+		inline bool is_write() const
+		{
+			return !(value_ & ~all_writes);
+		}
+
+		inline bool is_transfer() const
+		{
+			return !(value_ & ~all_transfer);
+		}
+
+		bool operator == (const surface_access& other) const
+		{
+			return value_ == other.value_;
+		}
+
+		bool operator == (u32 other) const
+		{
+			return value_ == other;
+		}
 	};
 
 	// Defines how the underlying PS3-visible memory backed by a texture is accessed

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -837,8 +837,11 @@ namespace rsx
 						continue;
 
 					auto surface = tex_info.second.get();
-					if (access == rsx::surface_access::transfer && surface->write_through())
+					if (access.is_transfer() && access.is_read() && surface->write_through())
+					{
+						// The surface has no data other than what can be loaded from CPU
 						continue;
+					}
 
 					if (!rsx::pitch_compatible(surface, required_pitch, required_height))
 						continue;
@@ -1128,7 +1131,7 @@ namespace rsx
 					if (surface->dirty())
 					{
 						// Force memory barrier to release some resources
-						surface->memory_barrier(cmd, rsx::surface_access::read);
+						surface->memory_barrier(cmd, rsx::surface_access::shader_read);
 					}
 					else if (!surface->test())
 					{

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -623,7 +623,7 @@ namespace rsx
 			if (spp == 1 || sample_layout == rsx::surface_sample_layout::ps3)
 				return;
 
-			ensure(access_type != rsx::surface_access::write);
+			ensure(access_type.is_read() || access_type.is_transfer());
 			transform_samples_to_pixels(region);
 		}
 	};

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -317,7 +317,7 @@ namespace rsx
 
 				out.push_back
 				({
-					section.surface->get_surface(rsx::surface_access::read),
+					section.surface->get_surface(rsx::surface_access::shader_read),
 					surface_transform::identity,
 					0,
 					static_cast<u16>(src_x),
@@ -558,7 +558,7 @@ namespace rsx
 					const auto format_class = (force_convert) ? classify_format(attr2.gcm_format) : texptr->format_class();
 					const auto command = surface_is_rop_target ? deferred_request_command::copy_image_dynamic : deferred_request_command::copy_image_static;
 
-					return { texptr->get_surface(rsx::surface_access::read), command, attr2, {},
+					return { texptr->get_surface(rsx::surface_access::shader_read), command, attr2, {},
 							texture_upload_context::framebuffer_storage, format_class, scale,
 							extended_dimension, decoded_remap };
 				}
@@ -569,7 +569,7 @@ namespace rsx
 
 			if (extended_dimension == rsx::texture_dimension_extended::texture_dimension_3d)
 			{
-				return{ texptr->get_surface(rsx::surface_access::read), deferred_request_command::_3d_unwrap,
+				return{ texptr->get_surface(rsx::surface_access::shader_read), deferred_request_command::_3d_unwrap,
 						attr2, {},
 						texture_upload_context::framebuffer_storage, texptr->format_class(), scale,
 						rsx::texture_dimension_extended::texture_dimension_3d, decoded_remap };
@@ -577,7 +577,7 @@ namespace rsx
 
 			ensure(extended_dimension == rsx::texture_dimension_extended::texture_dimension_cubemap);
 
-			return{ texptr->get_surface(rsx::surface_access::read), deferred_request_command::cubemap_unwrap,
+			return{ texptr->get_surface(rsx::surface_access::shader_read), deferred_request_command::cubemap_unwrap,
 					attr2, {},
 					texture_upload_context::framebuffer_storage, texptr->format_class(), scale,
 					rsx::texture_dimension_extended::texture_dimension_cubemap, decoded_remap };

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -12,7 +12,7 @@ gl::texture* GLGSRender::get_present_source(gl::present_surface_info* info, cons
 	gl::command_context cmd = { gl_state };
 	const auto format_bpp = rsx::get_format_block_size_in_bytes(info->format);
 	const auto overlap_info = m_rtts.get_merged_texture_memory_region(cmd,
-		info->address, info->width, info->height, info->pitch, format_bpp, rsx::surface_access::read);
+		info->address, info->width, info->height, info->pitch, format_bpp, rsx::surface_access::shader_read);
 
 	if (!overlap_info.empty())
 	{
@@ -46,7 +46,7 @@ gl::texture* GLGSRender::get_present_source(gl::present_surface_info* info, cons
 			if (viable)
 			{
 				surface->read_barrier(cmd);
-				image = section.surface->get_surface(rsx::surface_access::read);
+				image = section.surface->get_surface(rsx::surface_access::shader_read);
 
 				std::tie(info->width, info->height) = rsx::apply_resolution_scale<true>(
 					std::min(surface_width, static_cast<u16>(info->width)),

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -111,8 +111,8 @@ namespace gl
 		}
 
 		void memory_barrier(gl::command_context& cmd, rsx::surface_access access);
-		void read_barrier(gl::command_context& cmd) { memory_barrier(cmd, rsx::surface_access::read); }
-		void write_barrier(gl::command_context& cmd) { memory_barrier(cmd, rsx::surface_access::write); }
+		void read_barrier(gl::command_context& cmd) { memory_barrier(cmd, rsx::surface_access::shader_read); }
+		void write_barrier(gl::command_context& cmd) { memory_barrier(cmd, rsx::surface_access::shader_write); }
 	};
 
 	struct framebuffer_holder : public gl::fbo, public rsx::ref_counted

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -281,7 +281,7 @@ vk::image* VKGSRender::get_present_source(vk::present_surface_info* info, const 
 	// Check the surface store first
 	const auto format_bpp = rsx::get_format_block_size_in_bytes(info->format);
 	const auto overlap_info = m_rtts.get_merged_texture_memory_region(*m_current_command_buffer,
-		info->address, info->width, info->height, info->pitch, format_bpp, rsx::surface_access::read);
+		info->address, info->width, info->height, info->pitch, format_bpp, rsx::surface_access::shader_read);
 
 	if (!overlap_info.empty())
 	{
@@ -315,7 +315,7 @@ vk::image* VKGSRender::get_present_source(vk::present_surface_info* info, const 
 			if (viable)
 			{
 				surface->read_barrier(*m_current_command_buffer);
-				image_to_flip = section.surface->get_surface(rsx::surface_access::read);
+				image_to_flip = section.surface->get_surface(rsx::surface_access::shader_read);
 
 				std::tie(info->width, info->height) = rsx::apply_resolution_scale<true>(
 					std::min(surface_width, static_cast<u16>(info->width)),

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -304,7 +304,7 @@ namespace vk
 
 	vk::viewable_image* render_target::get_surface(rsx::surface_access access_type)
 	{
-		if (samples() == 1 || access_type == rsx::surface_access::write)
+		if (samples() == 1 || access_type == rsx::surface_access::shader_write)
 		{
 			return this;
 		}
@@ -369,7 +369,7 @@ namespace vk
 
 	void render_target::memory_barrier(vk::command_buffer& cmd, rsx::surface_access access)
 	{
-		const bool read_access = (access != rsx::surface_access::write);
+		const bool read_access = access.is_read();
 		const bool is_depth = is_depth_surface();
 		const bool should_read_buffers = is_depth ? !!g_cfg.video.read_depth_buffer : !!g_cfg.video.read_color_buffers;
 
@@ -533,8 +533,8 @@ namespace vk
 
 			hw_blitter.scale_image(
 				cmd,
-				src_texture->get_surface(rsx::surface_access::read),
-				this->get_surface(rsx::surface_access::transfer),
+				src_texture->get_surface(rsx::surface_access::transfer_read),
+				this->get_surface(rsx::surface_access::transfer_write),
 				src_area,
 				dst_area,
 				/*linear?*/false, typeless_info);

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -53,8 +53,8 @@ namespace vk
 		// Synchronization
 		void texture_barrier(vk::command_buffer& cmd);
 		void memory_barrier(vk::command_buffer& cmd, rsx::surface_access access);
-		void read_barrier(vk::command_buffer& cmd) { memory_barrier(cmd, rsx::surface_access::read); }
-		void write_barrier(vk::command_buffer& cmd) { memory_barrier(cmd, rsx::surface_access::write); }
+		void read_barrier(vk::command_buffer& cmd) { memory_barrier(cmd, rsx::surface_access::shader_read); }
+		void write_barrier(vk::command_buffer& cmd) { memory_barrier(cmd, rsx::surface_access::shader_write); }
 	};
 
 	static inline vk::render_target* as_rtt(vk::image* t)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -197,7 +197,7 @@ namespace vk
 			{
 				auto surface = vk::as_rtt(vram_texture);
 				surface->read_barrier(cmd);
-				locked_resource = surface->get_surface(rsx::surface_access::read);
+				locked_resource = surface->get_surface(rsx::surface_access::shader_read);
 				transfer_width *= surface->samples_x;
 				transfer_height *= surface->samples_y;
 			}

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -441,6 +441,8 @@ namespace vk
 		if (pgpu->debug_utils_support)
 		{
 			_vkSetDebugUtilsObjectNameEXT = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(vkGetDeviceProcAddr(dev, "vkSetDebugUtilsObjectNameEXT"));
+			_vkQueueInsertDebugUtilsLabelEXT = reinterpret_cast<PFN_vkQueueInsertDebugUtilsLabelEXT>(vkGetDeviceProcAddr(dev, "vkQueueInsertDebugUtilsLabelEXT"));
+			_vkCmdInsertDebugUtilsLabelEXT = reinterpret_cast<PFN_vkCmdInsertDebugUtilsLabelEXT>(vkGetDeviceProcAddr(dev, "vkCmdInsertDebugUtilsLabelEXT"));
 		}
 
 		memory_map = vk::get_memory_mapping(pdev);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -103,6 +103,8 @@ namespace vk
 		PFN_vkCmdBeginConditionalRenderingEXT _vkCmdBeginConditionalRenderingEXT = nullptr;
 		PFN_vkCmdEndConditionalRenderingEXT _vkCmdEndConditionalRenderingEXT = nullptr;
 		PFN_vkSetDebugUtilsObjectNameEXT _vkSetDebugUtilsObjectNameEXT = nullptr;
+		PFN_vkQueueInsertDebugUtilsLabelEXT _vkQueueInsertDebugUtilsLabelEXT = nullptr;
+		PFN_vkCmdInsertDebugUtilsLabelEXT _vkCmdInsertDebugUtilsLabelEXT = nullptr;
 
 	public:
 		render_device() = default;

--- a/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
@@ -760,8 +760,12 @@ namespace vk
 			present.swapchainCount = 1;
 			present.pSwapchains = &m_vk_swapchain;
 			present.pImageIndices = &image;
-			present.waitSemaphoreCount = 1;
-			present.pWaitSemaphores = &semaphore;
+
+			if (semaphore != VK_NULL_HANDLE)
+			{
+				present.waitSemaphoreCount = 1;
+				present.pWaitSemaphores = &semaphore;
+			}
 
 			return _vkQueuePresentKHR(dev.get_present_queue(), &present);
 		}

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1143,6 +1143,16 @@ namespace rsx
 			const u32 src_address = get_address(src_offset, src_dma);
 			const u32 dst_address = get_address(dst_offset, dst_dma);
 
+			if (src_address == dst_address &&
+				in_w == clip_w && in_h == clip_h &&
+				in_pitch == out_pitch &&
+				rsx::fcmp(scale_x, 1.f) && rsx::fcmp(scale_y, 1.f))
+			{
+				// NULL operation
+				rsx_log.warning("NV3089_IMAGE_IN: Operation writes memory onto itself with no modification (move-to-self). Will ignore.");
+				return;
+			}
+
 			const u32 src_line_length = (in_w * in_bpp);
 
 			if (is_block_transfer && (clip_h == 1 || (in_pitch == out_pitch && src_line_length == in_pitch)))


### PR DESCRIPTION
Fixes a bunch of problems identified while looking into surface leak bug in Madden17. This doesn't contain all the fixes, but it introduces a subset of the patches that should be relatively safe:
- Ignore blit to self commands. This seems to be a game bug, but I found it to be very unusual.
- Separate transfer memory access into transfer_read and transfer_write. Writing has different coherency requirements than reading. This has consequences for performance and correctness at this stage.
- Add some vulkan convenience features. Adds label insertion to renderdoc compatibility mode. Very convenient when tracing large files. Also allows vulkan present without waiting for this same purpose. Not directly useful to users but reduces iteration time when debugging complex bugs.