### PR TITLE
Don't fatal on sparse file initialization failure

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1632,7 +1632,7 @@ namespace vm
 
 	inline namespace ps3_
 	{
-		static utils::shm s_hook{0x800000000, fmt::format("%s/rpcs3_vm_hook_%s", fs::get_temp_dir(), fmt::base57(utils::get_unique_tsc()))};
+		static utils::shm s_hook{0x800000000, ""};
 
 		void init()
 		{

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -330,17 +330,36 @@ namespace utils
 		: m_size(utils::align(size, 0x10000))
 	{
 #ifdef _WIN32
-		fs::file f = ensure(fs::file(storage, fs::read + fs::rewrite));
-		FILE_DISPOSITION_INFO disp{ .DeleteFileW = true };
-		ensure(SetFileInformationByHandle(f.get_handle(), FileDispositionInfo, &disp, sizeof(disp)));
-		ensure(DeviceIoControl(f.get_handle(), FSCTL_SET_SPARSE, nullptr, 0, nullptr, 0, nullptr, nullptr));
+		fs::file f;
+
+		if (!storage.empty())
+		{
+			ensure(f.open(storage, fs::read + fs::rewrite));
+		}
+		else if (!f.open(fs::get_temp_dir() + "rpcs3_vm", fs::read + fs::rewrite) || !DeviceIoControl(f.get_handle(), FSCTL_SET_SPARSE, nullptr, 0, nullptr, 0, nullptr, nullptr))
+		{
+			ensure(f.open(fs::get_cache_dir() + "rpcs3_vm", fs::read + fs::rewrite));
+		}
+
+		if (!DeviceIoControl(f.get_handle(), FSCTL_SET_SPARSE, nullptr, 0, nullptr, 0, nullptr, nullptr))
+		{
+			MessageBoxW(0, L"Failed to initialize sparse file.", L"RPCS3", MB_ICONERROR);
+		}
+
 		ensure(f.trunc(m_size));
 		m_handle = ensure(::CreateFileMappingW(f.get_handle(), nullptr, PAGE_READWRITE, 0, 0, nullptr));
 #else
-		m_file = ::open(storage.c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR);
+		if (!storage.empty())
+		{
+			m_file = ::open(storage.c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR);
+		}
+		else
+		{
+			m_file = ::open((fs::get_cache_dir() + "rpcs3_vm").c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR);
+		}
+
 		ensure(m_file >= 0);
 		ensure(::ftruncate(m_file, m_size) >= 0);
-		::unlink(storage.c_str());
 #endif
 	}
 


### PR DESCRIPTION
- Try two different locations on windows.
- Don't delete empty sparse file, try to overwrite instead. Something is going wrong here.
- If sparse file cannot be created, warn and fallback to empty 32G file.