### PR TITLE
gl: Intel GPU shader fix

### DIFF
--- a/rpcs3/Emu/RSX/Common/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.cpp
@@ -223,7 +223,7 @@ namespace glsl
 		"#define VTX_FMT_UINT8   6\n\n";
 
 		// For intel GPUs which cannot access vectors in indexed mode (driver bug? or glsl version too low?)
-		// Note: Tested on Mesa iris with HD 530 and compliant path works fine, may be a bug on Windows proprietary drivers
+		// Note: Tested on Mesa iris with HD 530 and compilant path works fine, may be a bug on Windows proprietary drivers
 		if (!glsl4_compliant)
 		{
 			OS <<

--- a/rpcs3/Emu/RSX/Common/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Common/GLSLCommon.cpp
@@ -223,11 +223,11 @@ namespace glsl
 		"#define VTX_FMT_UINT8   6\n\n";
 
 		// For intel GPUs which cannot access vectors in indexed mode (driver bug? or glsl version too low?)
-		// Note: Tested on Mesa iris with HD 530 and compilant path works fine, may be a bug on Windows proprietary drivers
+		// Note: Tested on Mesa iris with HD 530 and compliant path works fine, may be a bug on Windows proprietary drivers
 		if (!glsl4_compliant)
 		{
 			OS <<
-			"void mov(inout vec4 vector, const in int index, const in float scalar)\n"
+			"void mov(inout uvec4 vector, const in int index, const in uint scalar)\n"
 			"{\n"
 			"	switch(index)\n"
 			"	{\n"

--- a/rpcs3/Emu/RSX/GL/GLHelpers.h
+++ b/rpcs3/Emu/RSX/GL/GLHelpers.h
@@ -2340,7 +2340,7 @@ public:
 						error_msg = buf.get();
 					}
 
-					rsx_log.fatal("Compilation failed: %s", error_msg);
+					rsx_log.fatal("Compilation failed: %s\nsource: %s", error_msg, source);
 				}
 
 				m_compiled_fence.create();


### PR DESCRIPTION
Without this fix, I couldn't run anything with OpenGL on my Surface Pro 7 (i7 version), now it works.
