### PR TITLE
fs: Optimize/fix filesystem handle reconstruction

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -220,6 +220,7 @@ namespace fs
 		template <typename... Args>
 		bool open(Args&&... args)
 		{
+			m_file.reset();
 			*this = fs::file(std::forward<Args>(args)...);
 			return m_file.operator bool();
 		}


### PR DESCRIPTION
Avoid wasting resources if a handle has been opened before the call to *open*, so only one lives at a time at maximum.
This is also a bugfix in case the existence of the two handles contradict with each other such as if both refer to the same path and use a locking flag.