### PR TITLE
vk: Ensure MSAA surfaces are in RW state before attempting to transfer data.

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -531,6 +531,18 @@ namespace vk
 				resolve(cmd);
 			}
 
+			if (samples() > 1)
+			{
+				// Ensure a writable surface exists for this surface
+				get_resolve_target_safe(cmd);
+			}
+
+			if (src_texture->samples() > 1)
+			{
+				// Ensure a readable surface exists for the source
+				src_texture->get_resolve_target_safe(cmd);
+			}
+
 			hw_blitter.scale_image(
 				cmd,
 				src_texture->get_surface(rsx::surface_access::transfer_read),


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/9995