### PR TITLE
Fixup collection

### DIFF
--- a/cmake_modules/ConfigureCompiler.cmake
+++ b/cmake_modules/ConfigureCompiler.cmake
@@ -64,10 +64,6 @@ else()
 	endif()
 
 	#TODO Clean the code so these are removed
-	if (NOT (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") OR (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.1))
-		add_compile_options(-Wno-attributes)
-	endif()
-
 	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 		add_compile_options(-fconstexpr-steps=16777216)
 		add_compile_options(-Wno-unused-lambda-capture)

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -282,7 +282,7 @@ public:
 				return finalize_construct();
 			}
 
-			return std::move(result);
+			return result;
 		}))
 		{
 			return error;

--- a/rpcs3/util/logs.hpp
+++ b/rpcs3/util/logs.hpp
@@ -84,19 +84,19 @@ namespace logs
 
 #define GEN_LOG_METHOD(_sev)\
 		const message msg_##_sev{this, level::_sev};\
-		template <typename CharT, usz N, typename... Args>\
-		void _sev(const CharT(&fmt)[N], const Args&... args)\
+		template <typename... Args>\
+		void _sev(const const_str& fmt, const Args&... args)\
 		{\
 			if (level::_sev <= enabled.observe()) [[unlikely]]\
 			{\
 				if constexpr (sizeof...(Args) > 0)\
 				{\
 					static constexpr fmt_type_info type_list[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};\
-					msg_##_sev.broadcast(reinterpret_cast<const char*>(fmt), type_list, u64{fmt_unveil<Args>::get(args)}...);\
+					msg_##_sev.broadcast(fmt, type_list, u64{fmt_unveil<Args>::get(args)}...);\
 				}\
 				else\
 				{\
-					msg_##_sev.broadcast(reinterpret_cast<const char*>(fmt), nullptr);\
+					msg_##_sev.broadcast(fmt, nullptr);\
 				}\
 			}\
 		}\

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -670,6 +670,80 @@ constexpr unsigned __builtin_COLUMN()
 }
 #endif
 
+template <usz Size = usz(-1)>
+struct const_str_t
+{
+	static constexpr usz size = Size;
+
+	char8_t chars[Size + 1]{};
+
+	constexpr const_str_t(const char(&a)[Size + 1])
+	{
+		for (usz i = 0; i <= Size; i++)
+			chars[i] = a[i];
+	}
+
+	constexpr const_str_t(const char8_t(&a)[Size + 1])
+	{
+		for (usz i = 0; i <= Size; i++)
+			chars[i] = a[i];
+	}
+
+	operator const char*() const
+	{
+		return reinterpret_cast<const char*>(chars);
+	}
+
+	constexpr operator const char8_t*() const
+	{
+		return chars;
+	}
+};
+
+template <>
+struct const_str_t<usz(-1)>
+{
+	const usz size;
+
+	const union
+	{
+		const char8_t* chars;
+		const char* chars2;
+	};
+
+	template <usz N>
+	constexpr const_str_t(const char8_t(&a)[N])
+		: size(N - 1)
+		, chars(+a)
+	{
+	}
+
+	template <usz N>
+	constexpr const_str_t(const char(&a)[N])
+		: size(N - 1)
+		, chars2(+a)
+	{
+	}
+
+	operator const char*() const
+	{
+		return std::launder(chars2);
+	}
+
+	constexpr operator const char8_t*() const
+	{
+		return chars;
+	}
+};
+
+template <usz Size>
+const_str_t(const char(&a)[Size]) -> const_str_t<Size - 1>;
+
+template <usz Size>
+const_str_t(const char8_t(&a)[Size]) -> const_str_t<Size - 1>;
+
+using const_str = const_str_t<>;
+
 struct src_loc
 {
 	u32 line;


### PR DESCRIPTION
- Don't recreate rpcs3_vm sparse file every time.
- Try to verify sparse file support in portable way (Linux/Unix).
- Unconditionally re-enable warnings about attributes (became possible with newer compilers).
- Fix pessimising returning move in `lv2_obj::create`