### PR TITLE
Use the native std::span for gsl::span

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -60,10 +60,6 @@
 	path = 3rdparty/FAudio
 	url = https://github.com/FNA-XNA/FAudio.git
 	ignore = dirty
-[submodule "3rdparty/span"]
-	path = 3rdparty/span
-	url = https://github.com/tcbrindle/span
-	ignore = dirty
 [submodule "3rdparty/curl"]
 	path = 3rdparty/curl/curl
 	url = https://github.com/curl/curl.git

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -150,11 +150,6 @@ else()
 endif()
 
 
-# span
-add_library(3rdparty_span INTERFACE)
-target_include_directories(3rdparty_span INTERFACE span/include)
-
-
 # stblib
 add_library(3rdparty_stblib INTERFACE)
 target_include_directories(3rdparty_stblib INTERFACE stblib/include)
@@ -373,7 +368,6 @@ add_library(3rdparty::hidapi ALIAS 3rdparty_hidapi)
 add_library(3rdparty::libpng ALIAS ${LIBPNG_TARGET})
 add_library(3rdparty::cereal ALIAS 3rdparty_cereal)
 add_library(3rdparty::opengl ALIAS 3rdparty_opengl)
-add_library(3rdparty::span ALIAS 3rdparty_span)
 add_library(3rdparty::stblib ALIAS 3rdparty_stblib)
 add_library(3rdparty::discordRPC ALIAS 3rdparty_discordRPC)
 add_library(3rdparty::alsa ALIAS ${ALSA_TARGET})

--- a/Utilities/span.h
+++ b/Utilities/span.h
@@ -1,2 +1,6 @@
-#define TCB_SPAN_NAMESPACE_NAME gsl
-#include <tcb/span.hpp>
+#include <span>
+
+namespace gsl {
+	using std::span;
+	using std::byte;
+}

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -62,8 +62,7 @@ target_include_directories(rpcs3_emu PUBLIC "${CMAKE_SOURCE_DIR}")
 
 target_link_libraries(rpcs3_emu
     PUBLIC
-        3rdparty::pugixml
-        3rdparty::span)
+        3rdparty::pugixml)
 
 if(MSVC)
     set_source_files_properties("../../Utilities/JIT.cpp" PROPERTIES COMPILE_FLAGS /GR-)
@@ -504,7 +503,7 @@ target_link_libraries(rpcs3_emu
         3rdparty::vulkan 3rdparty::glew
         3rdparty::libusb 3rdparty::wolfssl
     PRIVATE
-        3rdparty::span 3rdparty::xxhash
+        3rdparty::xxhash
 )
 
 if(APPLE)

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2669,7 +2669,7 @@ namespace rsx
 					subres.height_in_block = subres.height_in_texel = image_height;
 					subres.pitch_in_block = full_width;
 					subres.depth = 1;
-					subres.data = { vm::_ptr<const std::byte>(image_base), static_cast<gsl::span<const std::byte>::index_type>(src.pitch * image_height) };
+					subres.data = { vm::_ptr<const std::byte>(image_base), static_cast<gsl::span<const std::byte>::size_type>(src.pitch * image_height) };
 					subresource_layout.push_back(subres);
 
 					const u32 gcm_format = helpers::get_sized_blit_format(src_is_argb8, dst_is_depth_surface, is_format_convert);
@@ -2801,7 +2801,7 @@ namespace rsx
 						subres.height_in_block = subres.height_in_texel = dst_dimensions.height;
 						subres.pitch_in_block = pitch_in_block;
 						subres.depth = 1;
-						subres.data = { vm::get_super_ptr<const std::byte>(dst_base_address), static_cast<gsl::span<const std::byte>::index_type>(dst.pitch * dst_dimensions.height) };
+						subres.data = { vm::get_super_ptr<const std::byte>(dst_base_address), static_cast<gsl::span<const std::byte>::size_type>(dst.pitch * dst_dimensions.height) };
 						subresource_layout.push_back(subres);
 
 						cached_dest = upload_image_from_cpu(cmd, rsx_range, dst_dimensions.width, dst_dimensions.height, 1, 1, dst.pitch,

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -418,7 +418,7 @@ void gl::render_target::load_memory(gl::command_context& cmd)
 	subres.height_in_block = subres.height_in_texel = surface_height * samples_y;
 	subres.pitch_in_block = rsx_pitch / get_bpp();
 	subres.depth = 1;
-	subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<gsl::span<const std::byte>::index_type>(rsx_pitch * surface_height * samples_y) };
+	subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<gsl::span<const std::byte>::size_type>(rsx_pitch * surface_height * samples_y) };
 
 	// TODO: MSAA support
 	if (g_cfg.video.resolution_scale_percent == 100 && spp == 1) [[likely]]

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -223,7 +223,7 @@ namespace vk
 		subres.height_in_block = subres.height_in_texel = surface_height * samples_y;
 		subres.pitch_in_block = rsx_pitch / get_bpp();
 		subres.depth = 1;
-		subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<gsl::span<const std::byte>::index_type>(rsx_pitch * surface_height * samples_y) };
+		subres.data = { vm::get_super_ptr<const std::byte>(base_addr), static_cast<gsl::span<const std::byte>::size_type>(rsx_pitch * surface_height * samples_y) };
 
 		if (g_cfg.video.resolution_scale_percent == 100 && spp == 1) [[likely]]
 		{


### PR DESCRIPTION
Since 1bc9fd2863d7fcd06e4bd2d9b1098f2da2c75da5 we are inconditionally compiling in C++20 mode, so we can drop the tcbrindle version and use the one from the stdlib.

The only change is due to [P1872R0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1872r0.pdf), which tcbrindle’s version hadn’t been updated for, aptly named “span should have size_type, not index_type”, also making it unsigned instead of signed.

A future commit could rename all of the `gsl::span` and `gsl::byte` into `std::span` and `std::byte`, and then `Utilities/span.h` could be dropped.