### PR TITLE
Maintenance

### DIFF
--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -249,15 +249,6 @@ namespace fmt
 	};
 
 	template <typename... Args>
-	FORCE_INLINE SAFE_BUFFERS(const fmt_type_info*) get_type_info()
-	{
-		// Constantly initialized null-terminated list of type-specific information
-		static constexpr fmt_type_info result[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};
-
-		return result;
-	}
-
-	template <typename... Args>
 	constexpr const fmt_type_info type_info_v[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};
 
 	// Internal formatting function
@@ -267,8 +258,7 @@ namespace fmt
 	template <typename CharT, usz N, typename... Args>
 	FORCE_INLINE SAFE_BUFFERS(void) append(std::string& out, const CharT(&fmt)[N], const Args&... args)
 	{
-		static constexpr fmt_type_info type_list[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};
-		raw_append(out, reinterpret_cast<const char*>(fmt), type_list, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...});
+		raw_append(out, reinterpret_cast<const char*>(fmt), type_info_v<Args...>, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...});
 	}
 
 	// Formatting function
@@ -293,8 +283,7 @@ namespace fmt
 			const char* file = __builtin_FILE(),
 			const char* func = __builtin_FUNCTION())
 		{
-			static constexpr fmt_type_info type_list[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};
-			raw_throw_exception({line, col, file, func}, reinterpret_cast<const char*>(fmt), type_list, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...});
+			raw_throw_exception({line, col, file, func}, reinterpret_cast<const char*>(fmt), type_info_v<Args...>, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...});
 		}
 
 #ifndef _MSC_VER

--- a/rpcs3/Emu/Cell/ErrorCodes.h
+++ b/rpcs3/Emu/Cell/ErrorCodes.h
@@ -12,20 +12,26 @@ public:
 	error_code() = default;
 
 	// Implementation must be provided independently
-	static s32 error_report(const fmt_type_info* sup, u64 arg, const fmt_type_info* sup2, u64 arg2);
+	static s32 error_report(s32 result, const char* fmt, const fmt_type_info* sup, const u64* args);
 
 	// Common constructor
 	template<typename ET>
 	error_code(const ET& value)
-		: value(static_cast<s32>(value))
+		: value(error_report(static_cast<s32>(value), " : %s", fmt::type_info_v<ET>, fmt_args_t<ET>{fmt_unveil<ET>::get(value)}))
 	{
-		this->value = error_report(fmt::get_type_info<fmt_unveil_t<ET>>(), fmt_unveil<ET>::get(value), nullptr, 0);
 	}
 
 	// Error constructor (2 args)
-	template<typename ET, typename T2>
-	error_code(const ET& value, const T2& value2)
-		: value(error_report(fmt::get_type_info<fmt_unveil_t<ET>>(), fmt_unveil<ET>::get(value), fmt::get_type_info<fmt_unveil_t<T2>>(), fmt_unveil<T2>::get(value2)))
+	template<typename ET, typename T>
+	error_code(const ET& value, const T& arg)
+		: value(error_report(static_cast<s32>(value), " : %s, %s", fmt::type_info_v<ET, T>, fmt_args_t<ET, T>{fmt_unveil<ET>::get(value), fmt_unveil<T>::get(arg)}))
+	{
+	}
+
+	// Formatting constructor (error, format string, variadic list)
+	template <typename ET, typename... Args> requires (sizeof...(Args) > 0)
+	error_code(const ET& value, const const_str& fmt, const Args&... args)
+		: value(error_report(static_cast<s32>(value), fmt, fmt::type_info_v<Args...>, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...}))
 	{
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -574,7 +574,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 	if (const auto ecode = savedata_check_args(operation, version, dirName, errDialog, setList, setBuf, funcList, funcFixed, funcStat,
 		funcFile, container, unk_op_flags, userdata, userId, funcDone))
 	{
-		return {CELL_SAVEDATA_ERROR_PARAM, std::to_string(ecode)};
+		return {CELL_SAVEDATA_ERROR_PARAM, " (error %d)", ecode};
 	}
 
 	std::unique_lock lock(g_fxo->get<savedata_manager>().mutex, std::try_to_lock);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -70,7 +70,7 @@ namespace vk
 		vkGetPhysicalDeviceMemoryProperties(pdev, &memory_properties);
 		get_physical_device_features(allow_extensions);
 
-		rsx_log.always("Found vulkan-compatible GPU: '%s' running on driver %s", get_name(), get_driver_version());
+		rsx_log.always()("Found vulkan-compatible GPU: '%s' running on driver %s", get_name(), get_driver_version());
 
 		if (get_driver_vendor() == driver_vendor::RADV && get_name().find("LLVM 8.0.0") != umax)
 		{

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -187,7 +187,7 @@ struct fatal_error_listener final : logs::listener
 
 	void log(u64 /*stamp*/, const logs::message& msg, const std::string& prefix, const std::string& text) override
 	{
-		if (msg.sev == logs::level::fatal)
+		if (msg == logs::level::fatal)
 		{
 			std::string _msg = "RPCS3: ";
 
@@ -197,9 +197,9 @@ struct fatal_error_listener final : logs::listener
 				_msg += ": ";
 			}
 
-			if (msg.ch && '\0' != *msg.ch->name)
+			if (msg->name && '\0' != *msg->name)
 			{
-				_msg += msg.ch->name;
+				_msg += msg->name;
 				_msg += ": ";
 			}
 
@@ -446,31 +446,19 @@ int main(int argc, char** argv)
 
 	{
 		// Write RPCS3 version
-		logs::stored_message ver;
-		ver.m.ch  = nullptr;
-		ver.m.sev = logs::level::always;
-		ver.stamp = 0;
+		logs::stored_message ver{sys_log.always()};
 		ver.text  = fmt::format("RPCS3 v%s | %s", rpcs3::get_version().to_string(), rpcs3::get_branch());
 
 		// Write System information
-		logs::stored_message sys;
-		sys.m.ch  = nullptr;
-		sys.m.sev = logs::level::always;
-		sys.stamp = 0;
+		logs::stored_message sys{sys_log.always()};
 		sys.text  = utils::get_system_info();
 
 		// Write OS version
-		logs::stored_message os;
-		os.m.ch  = nullptr;
-		os.m.sev = logs::level::always;
-		os.stamp = 0;
+		logs::stored_message os{sys_log.always()};
 		os.text  = utils::get_OS_version();
 
 		// Write Qt version
-		logs::stored_message qt;
-		qt.m.ch  = nullptr;
-		qt.m.sev = (strcmp(QT_VERSION_STR, qVersion()) != 0) ? logs::level::error : logs::level::notice;
-		qt.stamp = 0;
+		logs::stored_message qt{(strcmp(QT_VERSION_STR, qVersion()) != 0) ? sys_log.error : sys_log.notice};
 		qt.text  = fmt::format("Qt version: Compiled against Qt %s | Run-time uses Qt %s", QT_VERSION_STR, qVersion());
 
 		logs::set_init({std::move(ver), std::move(sys), std::move(os), std::move(qt)});

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -43,7 +43,7 @@ void main_application::InitializeEmulator(const std::string& user, bool show_gui
 	// Log Firmware Version after Emu was initialized
 	const std::string firmware_version = utils::get_firmware_version();
 	const std::string firmware_string  = firmware_version.empty() ? "Missing Firmware" : ("Firmware version: " + firmware_version);
-	sys_log.always("%s", firmware_string);
+	sys_log.always()("%s", firmware_string);
 }
 
 /** RPCS3 emulator has functions it desires to call from the GUI at times. Initialize them in here. */

--- a/rpcs3/rpcs3qt/about_dialog.ui
+++ b/rpcs3/rpcs3qt/about_dialog.ui
@@ -282,6 +282,11 @@
           &lt;br&gt;Comexzone
           &lt;br&gt;mapleglass
           &lt;br&gt;Liquidbings
+          &lt;br&gt;Dormant_Hero@0230
+          &lt;br&gt;Theodore Raney
+          &lt;br&gt;Morito
+          &lt;br&gt;Chaining Ten
+          &lt;br&gt;Xeropel
           &lt;/p&gt;</string>
          </property>
          <property name="alignment">

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -254,7 +254,7 @@ void gui_settings::SaveCurrentConfig(const QString& config_name)
 
 logs::level gui_settings::GetLogLevel() const
 {
-	return logs::level{GetValue(gui::l_level).toUInt()};
+	return logs::level(GetValue(gui::l_level).toUInt());
 }
 
 bool gui_settings::GetGamelistColVisibility(int col) const

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -178,7 +178,7 @@ namespace gui
 	const gui_save fs_dev_usb000_list   = gui_save(fs, "dev_usb000_list",   QStringList());
 
 	const gui_save l_tty       = gui_save(logger, "TTY",       true);
-	const gui_save l_level     = gui_save(logger, "level",     static_cast<uint>(logs::level::success));
+	const gui_save l_level     = gui_save(logger, "level",     static_cast<uchar>(logs::level::success));
 	const gui_save l_prefix    = gui_save(logger, "prefix_on", false);
 	const gui_save l_stack     = gui_save(logger, "stack",     true);
 	const gui_save l_stack_tty = gui_save(logger, "TTY_stack", false);

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -26,7 +26,7 @@ constexpr auto qstr = QString::fromStdString;
 
 struct gui_listener : logs::listener
 {
-	atomic_t<logs::level> enabled{logs::level{UINT_MAX}};
+	atomic_t<logs::level> enabled{logs::level{UCHAR_MAX}};
 
 	struct packet_t
 	{
@@ -55,10 +55,10 @@ struct gui_listener : logs::listener
 	{
 		Q_UNUSED(stamp)
 
-		if (msg.sev <= enabled)
+		if (msg <= enabled)
 		{
 			packet_t p,* _new = &p;
-			_new->sev = msg.sev;
+			_new->sev = msg;
 
 			if (show_prefix && !prefix.empty())
 			{
@@ -67,12 +67,12 @@ struct gui_listener : logs::listener
 				_new->msg += "} ";
 			}
 
-			if (msg.ch && '\0' != *msg.ch->name)
+			if (msg->name && '\0' != *msg->name)
 			{
-				_new->msg += msg.ch->name;
-				_new->msg += msg.sev == logs::level::todo ? " TODO: " : ": ";
+				_new->msg += msg->name;
+				_new->msg += msg == logs::level::todo ? " TODO: " : ": ";
 			}
-			else if (msg.sev == logs::level::todo)
+			else if (msg == logs::level::todo)
 			{
 				_new->msg += "TODO: ";
 			}

--- a/rpcs3/util/logs.hpp
+++ b/rpcs3/util/logs.hpp
@@ -91,8 +91,7 @@ namespace logs
 			{\
 				if constexpr (sizeof...(Args) > 0)\
 				{\
-					static constexpr fmt_type_info type_list[sizeof...(Args) + 1]{fmt_type_info::make<fmt_unveil_t<Args>>()...};\
-					msg_##_sev.broadcast(fmt, type_list, u64{fmt_unveil<Args>::get(args)}...);\
+					msg_##_sev.broadcast(fmt, fmt::type_info_v<Args...>, u64{fmt_unveil<Args>::get(args)}...);\
 				}\
 				else\
 				{\

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -73,6 +73,10 @@ namespace std
 }
 #endif
 
+#if defined(__INTELLISENSE__)
+#define consteval constexpr
+#endif
+
 using schar  = signed char;
 using uchar  = unsigned char;
 using ushort = unsigned short;

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -345,6 +345,16 @@ namespace utils
 
 			if (DeviceIoControl(h, FSCTL_SET_SPARSE, nullptr, 0, nullptr, 0, nullptr, nullptr))
 			{
+				FILE_STANDARD_INFO info;
+				ensure(GetFileInformationByHandleEx(h, FileStandardInfo, &info, sizeof(info)));
+
+				if (info.AllocationSize.QuadPart)
+				{
+					// Make sure the file is not "dirty"
+					FILE_END_OF_FILE_INFO _eof{};
+					ensure(SetFileInformationByHandle(h, FileEndOfFileInfo, &_eof, sizeof(_eof)));
+				}
+
 				return true;
 			}
 


### PR DESCRIPTION
Minor maintenance.

- Possible fix for a strange bug when my precious sparse file (which should occupy zero space) gained weight for unknown reason. Now make sure it doesn't, and if it does, reset it on startup, which is also foolproof since this file should be filled with zeros.
- Improved error_code. Removed internal trait for "not an error", used an explicit constructor specialization for basic error constructor.
- Added formatting constructor to supply desirable information in a more convenient way: 
  ``return {CELL_SAVEDATA_ERROR_PARAM, " (error %d)", ecode};``
- Improve logging. Now error/warning/etc objects are callable and addressable although still bound to the log channel. It makes possible to write, for example, 
  ``(x ? sys_rsx.error : sys_rsx.warning)("Happened %s (%d)", y, z);``
- Compressed log channels. Only 16 bytes instead of previous wasteful way of storing it.
- Made `always` severity harder to access, since it wasn't meant to be used lightly.