### PR TITLE
Fix bugs due to clocks scale setting being dynamic

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -65,7 +65,7 @@ struct cfg_root : cfg::node
 		cfg::uint64 tx_limit1_ns{this, "TSX Transaction First Limit", 800}; // In nanoseconds
 		cfg::uint64 tx_limit2_ns{this, "TSX Transaction Second Limit", 2000}; // In nanoseconds
 
-		cfg::_int<10, 3000> clocks_scale{ this, "Clocks scale", 100, true }; // Changing this from 100 (percentage) may affect game speed in unexpected ways
+		cfg::_int<10, 3000> clocks_scale{ this, "Clocks scale", 100 }; // Changing this from 100 (percentage) may affect game speed in unexpected ways
 		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy",
 #ifdef __linux__
 			sleep_timers_accuracy_level::_as_host, true };


### PR DESCRIPTION
This setting is NOT ready for dynamic modifications. Games can crash due to changing this setting dynamically as suddenly MFTB can returns values from hours ago or after relatively toe the time of changing the setting.
This is sad but I can't do anything until time resetting and restoration is implemented which is part of savestates.