### PR TITLE
Simplify PPU exit

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -154,8 +154,7 @@ error_code sys_cond_signal_to(ppu_thread& ppu, u32 cond_id, u32 thread_id)
 
 	const auto cond = idm::check<lv2_obj, lv2_cond>(cond_id, [&](lv2_cond& cond) -> int
 	{
-		if (const auto cpu = idm::check_unlocked<named_thread<ppu_thread>>(thread_id);
-			!cpu || cpu->joiner == ppu_join_status::exited)
+		if (!idm::check_unlocked<named_thread<ppu_thread>>(thread_id))
 		{
 			return -1;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -93,7 +93,7 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u6
 		{
 			cpu = idm::check_unlocked<named_thread<ppu_thread>>(static_cast<u32>(ppu_thread_id));
 
-			if (!cpu || cpu->joiner == ppu_join_status::exited)
+			if (!cpu)
 			{
 				return -1;
 			}

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -555,11 +555,8 @@ void kernel_explorer::Update()
 		const auto func = ppu.last_function;
 		const ppu_thread_status status = lv2_obj::ppu_state(&ppu, false);
 
-		if (status != PPU_THREAD_STATUS_DELETED)
-		{
-			add_leaf(find_node(root, additional_nodes::ppu_threads), qstr(fmt::format(u8"PPU 0x%07x: “%s”, PRIO: %d, Joiner: %s, Status: %s, State: %s, %s func: “%s”", id, *ppu.ppu_tname.load(), +ppu.prio, ppu.joiner.load(), status, ppu.state.load()
-				, ppu.current_function ? "In" : "Last", func ? func : "")));
-		}
+		add_leaf(find_node(root, additional_nodes::ppu_threads), qstr(fmt::format(u8"PPU 0x%07x: “%s”, PRIO: %d, Joiner: %s, Status: %s, State: %s, %s func: “%s”", id, *ppu.ppu_tname.load(), +ppu.prio, ppu.joiner.load(), status, ppu.state.load()
+			, ppu.current_function ? "In" : "Last", func ? func : "")));
 	});
 
 	idm::select<named_thread<spu_thread>>([&](u32 /*id*/, spu_thread& spu)


### PR DESCRIPTION
Move owning ptr from IDM in order to not trigger te thread handle destructor of the sane thread, but still remove PPU ID.