### PR TITLE
Bump gcc to 11, shellcheck and SDL2

### DIFF
--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -29,7 +29,7 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     # See https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/config/abi/pre/gnu.ver
     # for which definitions correlate to which CXXABI version.
     # Currently we target a minimum of GLIBCXX_3.4.26 and CXXABI_1.3.11
-    printf "#include <bits/stdc++.h>\nint main(){std::make_exception_ptr(0);std::pmr::get_default_resource();}" | $CXX -x c++ -std=c++2a -o ./appdir/usr/optional/checker -
+    printf "#include <exception>\n#include <memory_resource>\nint main(){std::make_exception_ptr(0);std::pmr::get_default_resource();}" | $CXX -x c++ -std=c++2a -o ./appdir/usr/optional/checker -
 
     # Package it up and send it off
     ./squashfs-root/usr/bin/appimagetool "$APPDIR"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,7 +60,7 @@ windows_task:
 
 linux_task:
   container:
-    image: rpcs3/rpcs3-ci-bionic:1.0
+    image: rpcs3/rpcs3-ci-bionic:1.1
     cpu: 4
     memory: 16G
   env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,13 +35,13 @@ jobs:
     displayName: ccache
 
   - bash: |
-      docker pull --quiet rpcs3/rpcs3-ci-bionic:1.0
+      docker pull --quiet rpcs3/rpcs3-ci-bionic:1.1
       docker run                      \
         -v $(pwd):/rpcs3              \
         --env-file .ci/docker.env \
         -v $CCACHE_DIR:/root/.ccache  \
         -v $BUILD_ARTIFACTSTAGINGDIRECTORY:/root/artifacts \
-        rpcs3/rpcs3-ci-bionic:1.0 \
+        rpcs3/rpcs3-ci-bionic:1.1 \
         /rpcs3/.ci/build-linux.sh
     displayName: Docker setup and build
 


### PR DESCRIPTION
Docker-side commit here: https://github.com/RPCS3/rpcs3-docker/commit/14ff5ad31d6b8ec5125798f069057005fe2a22c0
Summary of changes:
- GCC bumped to version 11
- SDL2 bumped to 2.0.14
- Shellcheck bumped to 0.7.2
- Qt patched to support GCC 11