### PR TITLE
kernel-explorer: Save self mem-container ID and use it

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -12,6 +12,12 @@
 
 LOG_CHANNEL(sys_memory);
 
+lv2_memory_container::lv2_memory_container(u32 size, bool from_idm) noexcept
+	: size(size)
+	, id{from_idm ? idm::last_id() : SYS_MEMORY_CONTAINER_ID_INVALID}
+{
+}
+
 //
 static shared_mutex s_memstats_mtx;
 
@@ -265,7 +271,7 @@ error_code sys_memory_container_create(cpu_thread& cpu, vm::ptr<u32> cid, u32 si
 	}
 
 	// Create the memory container
-	if (const u32 id = idm::make<lv2_memory_container>(size))
+	if (const u32 id = idm::make<lv2_memory_container>(size, true))
 	{
 		*cid = id;
 		return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_memory.h
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.h
@@ -5,7 +5,7 @@
 
 class cpu_thread;
 
-enum : u32
+enum lv2_mem_container_id : u32
 {
 	SYS_MEMORY_CONTAINER_ID_INVALID = 0xFFFFFFFF,
 };
@@ -67,12 +67,10 @@ struct lv2_memory_container
 	static const u32 id_count = 16;
 
 	const u32 size; // Amount of "physical" memory in this container
+	const lv2_mem_container_id id; // ID of the container in if placed at IDM, otherwise SYS_MEMORY_CONTAINER_ID_INVALID
 	atomic_t<u32> used{}; // Amount of "physical" memory currently used
 
-	lv2_memory_container(u32 size)
-		: size(size)
-	{
-	}
+	lv2_memory_container(u32 size, bool from_idm = false) noexcept;
 
 	// Try to get specified amount of "physical" memory
 	// Values greater than UINT32_MAX will fail

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -12,6 +12,21 @@
 
 LOG_CHANNEL(sys_mmapper);
 
+template <>
+void fmt_class_string<lv2_mem_container_id>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](auto value)
+	{
+		switch (value)
+		{
+		case SYS_MEMORY_CONTAINER_ID_INVALID: return "Global";
+		}
+
+		// Resort to hex formatting for other values
+		return unknown;
+	});
+}
+
 lv2_memory::lv2_memory(u32 size, u32 align, u64 flags, u64 key, bool pshared, lv2_memory_container* ct)
 	: size(size)
 	, align(align)

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -337,11 +337,11 @@ void kernel_explorer::Update()
 
 			if (mem.pshared)
 			{
-				add_leaf(node, qstr(fmt::format("Shared Mem 0x%08x: Size: 0x%x (%0.2f MB), Granularity: %s, Mappings: %u, Key: %#llx", id, mem.size, size_mb, mem.align == 0x10000u ? "64K" : "1MB", +mem.counter, mem.key)));
+				add_leaf(node, qstr(fmt::format("Shared Mem 0x%08x: Size: 0x%x (%0.2f MB), Chunk: %s, Mappings: %u, Mem Container: %s, Key: %#llx", id, mem.size, size_mb, mem.align == 0x10000u ? "64K" : "1MB", +mem.counter, mem.ct->id, mem.key)));
 				break;
 			}
 
-			add_leaf(node, qstr(fmt::format("Shared Mem 0x%08x: Size: 0x%x (%0.2f MB), Granularity: %s, Mappings: %u", id, mem.size, size_mb, mem.align == 0x10000u ? "64K" : "1MB", +mem.counter)));
+			add_leaf(node, qstr(fmt::format("Shared Mem 0x%08x: Size: 0x%x (%0.2f MB), Chunk: %s, Mem Container: %s, Mappings: %u", id, mem.size, size_mb, mem.align == 0x10000u ? "64K" : "1MB", mem.ct->id, +mem.counter)));
 			break;
 		}
 		case SYS_MUTEX_OBJECT:
@@ -535,8 +535,8 @@ void kernel_explorer::Update()
 	idm::select<sys_vm_t>([&](u32 /*id*/, sys_vm_t& vmo)
 	{
 		const u32 psize = vmo.psize;
-		add_leaf(find_node(root, additional_nodes::virtual_memory), qstr(fmt::format("Virtual Mem 0x%08x: Virtual Size: 0x%x (%0.2f MB), Physical Size: 0x%x (%0.2f MB)", vmo.addr
-			, vmo.size, vmo.size * 1. / (1024 * 1024), psize, psize * 1. / (1024 * 1024))));
+		add_leaf(find_node(root, additional_nodes::virtual_memory), qstr(fmt::format("Virtual Mem 0x%08x: Virtual Size: 0x%x (%0.2f MB), Physical Size: 0x%x (%0.2f MB), Mem Container: %s", vmo.addr
+			, vmo.size, vmo.size * 1. / (1024 * 1024), psize, psize * 1. / (1024 * 1024))), vmo.ct->id);
 	});
 
 	idm::select<lv2_socket>([&](u32 id, lv2_socket& sock)


### PR DESCRIPTION
* Show used memory conatiner ID for shared memory and sys_vm objects, "Global" means the global memory container instead of specific instances created with syys_memory_container_..
* May simplify state representation saving of memory container references.