### PR TITLE
Update performance overlay settings 

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -190,7 +190,7 @@ struct cfg_root : cfg::node
 			cfg::uint<2, 6000> framerate_datapoint_count{ this, "Framerate datapoints", 50, true };
 			cfg::uint<2, 6000> frametime_datapoint_count{ this, "Frametime datapoints", 170, true };
 			cfg::_enum<detail_level> level{ this, "Detail level", detail_level::medium, true };
-			cfg::uint<1, 5000> update_interval{ this, "Metrics update interval (ms)", 350, true };
+			cfg::uint<1, 1000> update_interval{ this, "Metrics update interval (ms)", 350, true };
 			cfg::uint<4, 36> font_size{ this, "Font size (px)", 10, true };
 			cfg::_enum<screen_quadrant> position{ this, "Position", screen_quadrant::top_left, true };
 			cfg::string font{ this, "Font", "n023055ms.ttf", true };

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>753</width>
+    <width>785</width>
     <height>730</height>
    </rect>
   </property>
@@ -39,7 +39,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>9</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="coreTab">
       <attribute name="title">

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -126,7 +126,7 @@ public:
 		const QString perf_overlay_frametime_datapoints    = tr("Sets the amount of datapoints used in the frametime graph.");
 		const QString perf_overlay_position                = tr("Sets the on-screen position (quadrant) of the performance overlay.");
 		const QString perf_overlay_detail_level            = tr("Controls the amount of information displayed on the performance overlay.");
-		const QString perf_overlay_update_interval         = tr("Sets the time interval in which the performance overlay is being updated (measured in milliseconds).");
+		const QString perf_overlay_update_interval         = tr("Sets the time interval in which the performance overlay is being updated (measured in milliseconds).\nSetting this to 16 milliseconds will refresh the performance overlay at roughly 60Hz.\nThe performance overlay refresh rate does not affect the frame graph statistics and can only be as fast as the current game allows.");
 		const QString perf_overlay_font_size               = tr("Sets the font size of the performance overlay (measured in pixels).");
 		const QString perf_overlay_opacity                 = tr("Sets the opacity of the performance overlay (measured in %).");
 		const QString perf_overlay_margin_x                = tr("Sets the horizontal distance to the screen border relative to the screen quadrant (measured in pixels).");


### PR DESCRIPTION
- Updates the performance overlay update interval tooltip.
- Reduces the maximum update interval from 5 seconds to 1 second.
   I don't think anyone uses a value that large and it also made it harder to configure the more common lower values in the GUI.