### PR TITLE
vm_native: improve Linux/BSD sparse check

### DIFF
--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -409,7 +409,7 @@ namespace utils
 
 		ensure(::ftruncate(m_file, 0x10000) >= 0);
 		ensure(::fstat(m_file, &stats) >= 0);
-		if (stats.st_blocks >= (0x8000 / stats.st_blksize) + 1)
+		if (stats.st_size < stats.st_blocks * 512)
 		{
 			fmt::throw_exception("Failed to initialize sparse file in '%s'\n"
 				"It seems this filesystem doesn't support sparse files.\n",


### PR DESCRIPTION
`du` calculates real size using user-defined block size, 512 bytes by default. `st_blocks` contains value in 512-byte units. Instead of approximating based on `st_blksize` (preferred/optimal block size) compare apparent and real sizes, aborting if real size is equal or larger.

Fixes #10334