### PR TITLE
perf_overlay: fix guide line locations

### DIFF
--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -157,7 +157,8 @@ protected:
 	void GetPingInfoResponse_to_SceNpMatching2SignalingGetPingInfoResponse(const GetPingInfoResponse* resp, SceNpMatching2SignalingGetPingInfoResponse* sce_resp);
 	void RoomMessageInfo_to_SceNpMatching2RoomMessageInfo(const RoomMessageInfo* mi, SceNpMatching2RoomMessageInfo* sce_mi);
 
-	struct callback_info {
+	struct callback_info
+	{
 		SceNpMatching2ContextId ctx_id;
 		vm::ptr<SceNpMatching2RequestCallback> cb;
 		vm::ptr<void> cb_arg;

--- a/rpcs3/Emu/RSX/GL/GLTextOut.h
+++ b/rpcs3/Emu/RSX/GL/GLTextOut.h
@@ -25,7 +25,7 @@ namespace gl
 		bool initialized = false;
 		bool enabled = false;
 
-		double m_scale = 1.0;
+		f32 m_scale = 1.0f;
 
 		void init_program()
 		{
@@ -140,7 +140,7 @@ namespace gl
 			char *s = const_cast<char *>(text.c_str());
 
 			//Y is in raster coordinates: convert to bottom-left origin
-			y = ((target_h / m_scale) - y - 16);
+			y = (static_cast<int>(target_h / m_scale) - y - 16);
 
 			//Compress [0, w] and [0, h] into range [-1, 1]
 			float scale_x = m_scale * 2.f / target_w;
@@ -213,7 +213,7 @@ namespace gl
 		void set_scale(double scale)
 		{
 			// Restrict scale to 2. The dots are gonna be too sparse otherwise.
-			m_scale = std::min(scale, 2.0);
+			m_scale = std::min(static_cast<f32>(scale), 2.0f);
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -841,7 +841,7 @@ namespace rsx
 
 				for (auto y_off = m_guide_interval; y_off < m_max; y_off += m_guide_interval)
 				{
-					const f32 guide_y = y + y_off * normalize_factor;
+					const f32 guide_y = y + h - y_off * normalize_factor;
 					verts_guides.emplace_back(x, guide_y);
 					verts_guides.emplace_back(static_cast<float>(x + w), guide_y);
 				}

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -33,7 +33,7 @@ namespace vk
 		u32 m_uniform_buffer_offset = 0;
 		u32 m_uniform_buffer_size = 0;
 
-		double m_scale = 1.0;
+		f32 m_scale = 1.0f;
 
 		bool initialized = false;
 		std::unordered_map<u8, std::pair<u32, u32>> m_offsets;
@@ -295,7 +295,7 @@ namespace vk
 			char *s = const_cast<char *>(text.c_str());
 
 			//Y is in raster coordinates: convert to bottom-left origin
-			y = ((target_h / m_scale) - y - 16);
+			y = (static_cast<int>(target_h / m_scale) - y - 16);
 
 			//Compress [0, w] and [0, h] into range [-1, 1]
 			//Flip Y scaling
@@ -372,7 +372,7 @@ namespace vk
 		void set_scale(double scale)
 		{
 			// Restrict scale to 2. The dots are gonna be too sparse otherwise.
-			m_scale = std::min(scale, 2.0);
+			m_scale = std::min(static_cast<f32>(scale), 2.0f);
 		}
 	};
 }

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -750,7 +750,7 @@
     <ClInclude Include="util\yaml.hpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\3rdparty\libpng.vcxproj">
+    <ProjectReference Include="..\3rdparty\libpng\libpng.vcxproj">
       <Project>{d6973076-9317-4ef2-a0b8-b7a18ac0713e}</Project>
     </ProjectReference>
     <ProjectReference Include="..\3rdparty\asmjit\asmjit.vcxproj">

--- a/rpcs3/rpcs3qt/memory_string_searcher.cpp
+++ b/rpcs3/rpcs3qt/memory_string_searcher.cpp
@@ -196,7 +196,7 @@ void memory_string_searcher::OnSearch()
 
 	vm::reader_lock rlock;
 
-	 const named_thread_group workers("String Searcher "sv, max_threads, [&]()
+	const named_thread_group workers("String Searcher "sv, max_threads, [&]()
 	{
 		u32 local_found = 0;
 


### PR DESCRIPTION
The guide lines falsely started from the top and not from the bottom, as all datapoints do.