### PR TITLE
Try to fix pad interception

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -72,6 +72,8 @@ namespace rsx
 			Timer input_timer;
 			std::set<u8> auto_repeat_buttons = { pad_button::dpad_up, pad_button::dpad_down, pad_button::dpad_left, pad_button::dpad_right };
 			atomic_t<bool> exit = false;
+			atomic_t<bool> m_interactive = false;
+			atomic_t<bool> m_stop_pad_interception = false;
 			atomic_t<u64> thread_bits = 0;
 
 			static thread_local u64 g_thread_bit;


### PR DESCRIPTION
The native user interface may currently cause deadlocks due to recursive locking of g_pad_mutex.

I couldn't find a better way to handle this right now and it could be possible that there still exists a similar recursion.

hopefully fixes #10366