### PR TITLE
cellVdec: silence "Unsupported time_base" error log spam

### DIFF
--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -221,9 +221,9 @@ public:
 		const QString ds4_windows = tr("If you have any issues with the DualShock 4 handler, it might be caused by third-party tools such as DS4Windows. It's recommended that you disable them while using this handler.");
 		const QString ds4_linux   = tr("In order to use the DualShock 4 handler, you might need to add udev rules to let RPCS3 access the controller.<br>See the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.");
 		const QString ds4_other   = tr("The DualShock 4 handler is recommended for official DualShock 4 controllers.");
-		const QString dualsense_windows = tr("The DualSense handler is recommended for official DualSense controllers.<br><br>Battery settings are not supported yet.");
-		const QString dualsense_linux   = tr("The DualSense handler is recommended for official DualSense controllers.<br><br>Battery settings are not supported yet.");
-		const QString dualsense_other   = tr("The DualSense handler is recommended for official DualSense controllers.<br><br>Battery settings are not supported yet.");
+		const QString dualsense_windows = tr("The DualSense handler is recommended for official DualSense controllers.");
+		const QString dualsense_linux   = tr("The DualSense handler is recommended for official DualSense controllers.");
+		const QString dualsense_other   = tr("The DualSense handler is recommended for official DualSense controllers.");
 		const QString xinput      = tr("The XInput handler will work with Xbox controllers and many third-party PC-compatible controllers. Pressure sensitive buttons from SCP are supported when SCP's XInput1_3.dll is placed in the main RPCS3 directory. For more details, see the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a>.");
 		const QString evdev       = tr("The evdev handler should work with any controller that has linux support.<br>If your joystick is not being centered properly, read the <a href=\"https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration\">RPCS3 Wiki</a> for instructions.");
 		const QString mmjoy       = tr("The MMJoystick handler should work with almost any controller recognized by Windows. However, it is recommended that you use the more specific handlers if you have a controller that supports them.");


### PR DESCRIPTION
- Only log time_base errors once per stream.
- Log framerate as well. Maybe it is useful in some cases. 

mitigates #2550