### PR TITLE
shared_ptr.hpp: improve compile-time pointer comparison

### DIFF
--- a/rpcs3/stdafx.cpp
+++ b/rpcs3/stdafx.cpp
@@ -11,3 +11,52 @@ static_assert(be_t<u16>(1) + be_t<u32>(2) + be_t<u64>(3) == 6);
 static_assert(le_t<u16>(1) + le_t<u32>(2) + le_t<u64>(3) == 6);
 
 static_assert(sizeof(nullptr) == sizeof(void*));
+
+static_assert(__cpp_constexpr_dynamic_alloc >= 201907L);
+
+namespace
+{
+	struct A
+	{
+		int a;
+	};
+
+	struct B : A
+	{
+		int b;
+	};
+
+	struct Z
+	{
+	};
+
+	struct C
+	{
+		virtual ~C() = 0;
+		int C;
+	};
+
+	struct D : Z, B
+	{
+		int d;
+	};
+
+	struct E : C, B
+	{
+		int e;
+	};
+
+	struct F : C
+	{
+		virtual ~F() = 0;
+	};
+
+	static_assert(is_same_ptr<B, A>());
+	static_assert(is_same_ptr<A, B>());
+	static_assert(is_same_ptr<D, B>());
+	static_assert(is_same_ptr<B, D>());
+	static_assert(!is_same_ptr<E, B>());
+	static_assert(!is_same_ptr<B, E>());
+	static_assert(is_same_ptr<F, C>());
+	static_assert(is_same_ptr<C, F>());
+}

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -25,12 +25,6 @@ namespace stx
 		static thread_local const
 #endif
 		fake_t<std::remove_cv_t<T>> sample{};
-
-		template <typename From, typename To, typename = void>
-		struct can_static_cast : std::false_type {};
-
-		template <typename From, typename To>
-		struct can_static_cast<From, To, std::void_t<decltype(static_cast<To>(std::declval<From>()))>> : std::true_type {};
 	}
 
 	// Classify compile-time information available for pointers
@@ -55,13 +49,13 @@ namespace stx
 		{
 			return same_ptr::yes;
 		}
-		else if constexpr (detail::can_static_cast<U*, T*>::value && !std::is_abstract_v<U>)
+		else if constexpr (PtrCastable<T, U> && !std::is_abstract_v<U>)
 		{
 			return is_same_ptr_test<T, U>() ? same_ptr::yes : same_ptr::no;
 		}
-		else if constexpr (detail::can_static_cast<T*, U*>::value && !std::is_abstract_v<T>)
+		else if constexpr (PtrCastable<T, U> && !std::is_abstract_v<T>)
 		{
-			return is_same_ptr_test<U, T>() ? same_ptr::yes : same_ptr::no;
+			return is_same_ptr_test<T, U>() ? same_ptr::yes : same_ptr::no;
 		}
 
 		return same_ptr::maybe;

--- a/rpcs3/util/typeindices.hpp
+++ b/rpcs3/util/typeindices.hpp
@@ -250,7 +250,7 @@ namespace stx
 		else
 		{
 			static_assert(sizeof(As) > 0);
-			static_assert(is_same_ptr<T, As>() == same_ptr::yes); // TODO
+			static_assert(PtrSame<T, As>);
 			return type_counter<Info>::template dyn_type<T, As>.index();
 		}
 	}
@@ -269,7 +269,7 @@ namespace stx
 	ATTR_PURE inline const Info& typedata() noexcept
 	{
 		static_assert(sizeof(T) > 0 && sizeof(As) > 0);
-		static_assert(is_same_ptr<T, As>() == same_ptr::yes); // TODO
+		static_assert(PtrSame<T, As>); // TODO
 
 		return type_counter<Info>::template dyn_type<T, As>;
 	}

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1010,3 +1010,10 @@ constexpr auto fill_array(const T&... args)
 {
 	return fill_array_t<T...>{{args...}};
 }
+
+template <typename X, typename Y>
+concept PtrCastable = requires(const volatile X* x, const volatile Y* y)
+{
+	static_cast<const volatile Y*>(x);
+	static_cast<const volatile X*>(y);
+};


### PR DESCRIPTION
Use constexpr allocator instead of fake static object. Fake static object can't be abstract.
It's required to compare numeric values of pointers at compile time, without actually knowing them. Knowing this, it becomes possible to put reference counter directly behind the object and still permit casting custom smart pointer between different types within the "main inheritance" line.
It's also used to preallocate space for "unknown set of objects" (see fxo and typeindices).