### PR TITLE
vk: Improve compatibility with sub-par drivers and hardware

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -70,7 +70,7 @@ void VKGSRender::update_draw_state()
 {
 	m_profiler.start();
 
-	float actual_line_width = rsx::method_registers.line_width();
+	const float actual_line_width = m_device->get_wide_lines_support()? rsx::method_registers.line_width() : 1.f;
 	vkCmdSetLineWidth(*m_current_command_buffer, actual_line_width);
 
 	if (rsx::method_registers.poly_offset_fill_enabled())

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -98,7 +98,7 @@ namespace vk
 			m_sampler_pool.clear();
 		}
 
-		vk::sampler* find_sampler(VkDevice dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
+		vk::sampler* find_sampler(const vk::render_device& dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
 			VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
 			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
 			VkBool32 depth_compare = VK_FALSE, VkCompareOp depth_compare_mode = VK_COMPARE_OP_NEVER)

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -73,9 +73,10 @@ namespace vk
 
 		u32 get_queue_count() const;
 
-		VkQueueFamilyProperties get_queue_properties(u32 queue);
-		VkPhysicalDeviceMemoryProperties get_memory_properties() const;
-		VkPhysicalDeviceLimits get_limits() const;
+		// Device properties. These structs can be large so use with care.
+		const VkQueueFamilyProperties& get_queue_properties(u32 queue);
+		const VkPhysicalDeviceMemoryProperties& get_memory_properties() const;
+		const VkPhysicalDeviceLimits& get_limits() const;
 
 		operator VkPhysicalDevice() const;
 		operator VkInstance() const;
@@ -126,6 +127,8 @@ namespace vk
 		bool get_shader_stencil_export_support() const;
 		bool get_depth_bounds_support() const;
 		bool get_alpha_to_one_support() const;
+		bool get_anisotropic_filtering_support() const;
+		bool get_wide_lines_support() const;
 		bool get_conditional_render_support() const;
 		bool get_unrestricted_depth_range_support() const;
 		bool get_external_memory_host_support() const;

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
@@ -3,7 +3,7 @@
 
 namespace vk
 {
-	sampler::sampler(VkDevice dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
+	sampler::sampler(const vk::render_device& dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
 		VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
 		VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
 		VkBool32 depth_compare, VkCompareOp depth_compare_mode)
@@ -13,7 +13,7 @@ namespace vk
 		info.addressModeU = clamp_u;
 		info.addressModeV = clamp_v;
 		info.addressModeW = clamp_w;
-		info.anisotropyEnable = VK_TRUE;
+		info.anisotropyEnable = dev.get_anisotropic_filtering_support();
 		info.compareEnable = depth_compare;
 		info.unnormalizedCoordinates = unnormalized_coordinates;
 		info.mipLodBias = mipLodBias;

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "device.h"
 #include "shared.h"
 
 namespace vk
@@ -9,7 +10,7 @@ namespace vk
 		VkSampler value;
 		VkSamplerCreateInfo info = {};
 
-		sampler(VkDevice dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
+		sampler(const vk::render_device& dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
 			VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
 			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
 			VkBool32 depth_compare = false, VkCompareOp depth_compare_mode = VK_COMPARE_OP_NEVER);


### PR DESCRIPTION
Features such as wide lines, anisotropic filtering, MSAA, etc that can be disabled without hurting too much can be optionally detected as unsupported and disabled quietly. They are not particularly critical to the emulation.
Fixes https://github.com/RPCS3/rpcs3/issues/6916