### PR TITLE
Fix some C++20 usage

### DIFF
--- a/buildfiles/cmake/ConfigureCompiler.cmake
+++ b/buildfiles/cmake/ConfigureCompiler.cmake
@@ -27,10 +27,6 @@ else()
 	add_compile_options(-fstack-protector)
 	add_compile_options(-msse -msse2 -mcx16)
 
-	if ((${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.1))
-		add_compile_options(-fconcepts)
-	endif()
-
 	add_compile_options(-Werror=old-style-cast)
 	add_compile_options(-Werror=sign-compare)
 	add_compile_options(-Werror=reorder)

--- a/rpcs3/Emu/Memory/vm_ref.h
+++ b/rpcs3/Emu/Memory/vm_ref.h
@@ -5,6 +5,11 @@
 
 #include "util/to_endian.hpp"
 
+#ifndef _MSC_VER
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+#endif
+
 namespace vm
 {
 	template <typename T, typename AT>
@@ -23,8 +28,6 @@ namespace vm
 	public:
 		using type = T;
 		using addr_type = std::remove_cv_t<AT>;
-
-		_ref_base() = default;
 
 		_ref_base(const _ref_base&) = default;
 
@@ -177,6 +180,10 @@ namespace vm
 		template<typename T, typename AT = u32> using bref = brefb<T, AT>;
 	}
 }
+
+#ifndef _MSC_VER
+#pragma GCC diagnostic pop
+#endif
 
 // Change AT endianness to BE/LE
 template<typename T, typename AT, bool Se>


### PR DESCRIPTION
* Don't use -fconcepts, was only required for older gcc.
* Remove vm::ref default constructor (was wrong).
* Replace as_span workarounds with utils::bless.