### PR TITLE
rsx: Fix support for gamma pack/unpack instructions

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -207,6 +207,8 @@ void GLFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	m_shader_props.require_texture_ops = properties.has_tex_op;
 	m_shader_props.require_shadow_ops = properties.shadow_sampler_mask != 0;
 	m_shader_props.require_texture_expand = properties.has_exp_tex_op;
+	m_shader_props.require_srgb_to_linear = properties.has_upg;
+	m_shader_props.require_linear_to_srgb = properties.has_pkg;
 	m_shader_props.emulate_coverage_tests = true; // g_cfg.video.antialiasing_level == msaa_level::none;
 	m_shader_props.emulate_shadow_compare = device_props.emulate_depth_compare;
 	m_shader_props.low_precision_tests = ::gl::get_driver_caps().vendor_NVIDIA;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -359,6 +359,8 @@ void GLGSRender::on_exit()
 		gl::g_typeless_transfer_buffer.remove();
 	}
 
+	gl::debug::g_vis_texture.reset(); // TODO
+
 	gl::destroy_pipe_compiler();
 
 	m_prog_buffer.clear();

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -10,6 +10,11 @@
 
 namespace gl
 {
+	namespace debug
+	{
+		extern void set_vis_texture(texture*);
+	}
+
 	buffer g_typeless_transfer_buffer;
 
 	GLenum get_target(rsx::texture_dimension_extended type)

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -119,5 +119,10 @@ namespace gl
 		void apply_defaults(GLenum default_filter = GL_NEAREST);
 	};
 
+	namespace debug
+	{
+		extern std::unique_ptr<texture> g_vis_texture;
+	}
+
 	extern buffer g_typeless_transfer_buffer;
 }

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
@@ -285,6 +285,8 @@ public:
 		bool has_clamp = false;
 		bool has_w_access = false;
 		bool has_exp_tex_op = false;
+		bool has_pkg = false;
+		bool has_upg = false;
 	}
 	properties;
 

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -673,7 +673,7 @@ namespace glsl
 			"}\n\n";
 		}
 
-		if (!props.fp32_outputs)
+		if (!props.fp32_outputs || props.require_linear_to_srgb)
 		{
 			OS <<
 			"vec4 linear_to_srgb(const in vec4 cl)\n"
@@ -682,6 +682,17 @@ namespace glsl
 			"	vec4 high = 1.055 * pow(cl, vec4(1. / 2.4)) - 0.055;\n"
 			"	bvec4 select = lessThan(cl, vec4(0.0031308));\n"
 			"	return clamp(mix(high, low, select), 0., 1.);\n"
+			"}\n\n";
+		}
+
+		if (props.require_texture_ops || props.require_srgb_to_linear)
+		{
+			OS <<
+			"vec4 srgb_to_linear(const in vec4 cs)\n"
+			"{\n"
+			"	vec4 a = cs / 12.92;\n"
+			"	vec4 b = pow((cs + 0.055) / 1.055, vec4(2.4));\n"
+			"	return _select(a, b, greaterThan(cs, vec4(0.04045)));\n"
 			"}\n\n";
 		}
 
@@ -763,12 +774,6 @@ namespace glsl
 			"	return mix(direct, indexed, choice);\n"
 			"}\n\n"
 #endif
-			"vec4 srgb_to_linear(const in vec4 cs)\n"
-			"{\n"
-			"	vec4 a = cs / 12.92;\n"
-			"	vec4 b = pow((cs + 0.055) / 1.055, vec4(2.4));\n"
-			"	return _select(a, b, greaterThan(cs, vec4(0.04045)));\n"
-			"}\n\n"
 
 			//TODO: Move all the texture read control operations here
 			"vec4 process_texel(in vec4 rgba, const in uint control_bits)\n"

--- a/rpcs3/Emu/RSX/Program/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Program/GLSLTypes.h
@@ -28,6 +28,8 @@ namespace glsl
 		bool require_texture_ops;
 		bool require_shadow_ops;
 		bool require_texture_expand;
+		bool require_srgb_to_linear;
+		bool require_linear_to_srgb;
 		bool emulate_coverage_tests;
 		bool emulate_shadow_compare;
 		bool emulate_zclip_transform;

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -244,6 +244,8 @@ void VKFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	m_shader_props.require_texture_ops = properties.has_tex_op;
 	m_shader_props.require_shadow_ops = properties.shadow_sampler_mask != 0;
 	m_shader_props.require_texture_expand = properties.has_exp_tex_op;
+	m_shader_props.require_srgb_to_linear = properties.has_upg;
+	m_shader_props.require_linear_to_srgb = properties.has_pkg;
 	m_shader_props.emulate_coverage_tests = g_cfg.video.antialiasing_level == msaa_level::none;
 	m_shader_props.emulate_shadow_compare = device_props.emulate_depth_compare;
 	m_shader_props.low_precision_tests = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;


### PR DESCRIPTION
PS3 gamma pack/unpack (PKG/UPG) are based on some obsolete nvidia-only instructions that were dropped from the published spec of NV_fragment_program. There are still references to them in some early Cg and CineFX manuals.
These instructions allow cheap and easy sRGB<->linear conversion which seems to be a trick some games are using.
e.g packGamma(value) ... unpackNoGamma(value2) will convert a value from sRGB to linear color space.
Fixes https://github.com/RPCS3/rpcs3/issues/7357

Additionally adds a debug view for OGL. This was crucial in debugging said problem because renderdoc has issues with some OpenGL commands. This is WIP, and will be migrated to use the overlay system when the debug text is being rewritten. It is only accessible programmatically for now until a proper debugging overlay is finished.
For those curious, here's what it looks like (linear depth buffer drawn at the bottom right):
![image](https://user-images.githubusercontent.com/15904127/120894663-4c867500-c622-11eb-8204-1f86b94e8800.png)
