### PR TITLE
Get rid of mobile Kepler class and add missing Kepler GPUs

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -565,7 +565,6 @@ VKGSRender::VKGSRender() : GSRender()
 		case vk::driver_vendor::NVIDIA:
 			if (auto chip_family = vk::get_chip_family();
 				chip_family == vk::chip_class::NV_kepler ||
-				chip_family == vk::chip_class::NV_mobile_kepler || // TODO: Deprecate this classification, it just complicates things
 				chip_family == vk::chip_class::NV_maxwell)
 			{
 				rsx_log.error("Older NVIDIA cards do not meet requirements for asynchronous compute due to some driver fakery.");

--- a/rpcs3/Emu/RSX/VK/vkutils/chip_class.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/chip_class.cpp
@@ -33,18 +33,10 @@ namespace vk
 
 		// NV cards. See https://envytools.readthedocs.io/en/latest/hw/pciid.html
 		// NOTE: Since NV device IDs are linearly incremented per generation, there is no need to carefully check all the ranges
-		table.add(0x1180, 0x1197, chip_class::NV_kepler);  // GK104, 106
-		table.add(0x1198, 0x11A9, chip_class::NV_mobile_kepler);  // Mobile GK104
-		table.add(0x11AA, 0x11DF, chip_class::NV_kepler);  // GK104, 106
-		table.add(0x11E0, 0x11E7, chip_class::NV_mobile_kepler);  // Mobile GK106
-		table.add(0x11E8, 0x11FA, chip_class::NV_kepler);  // GK104, 106
-		table.add(0x0FC0, 0x0FCC, chip_class::NV_kepler);  // GK107
-		table.add(0x0FCD, 0x0FEE, chip_class::NV_mobile_kepler);  // Mobile GK107
-		table.add(0x0FEF, 0x0FFF, chip_class::NV_kepler);  // GK107
-		table.add(0x1003, 0x1028, chip_class::NV_kepler);  // GK110
-		table.add(0x1280, 0x128F, chip_class::NV_kepler);  // GK208
-		table.add(0x1290, 0x129A, chip_class::NV_mobile_kepler);  // Mobile GK208
-		table.add(0x129B, 0x12BA, chip_class::NV_kepler);  // GK208
+		table.add(0x1180, 0x11FA, chip_class::NV_kepler);  // GK104, 106
+		table.add(0x0FC0, 0x0FFF, chip_class::NV_kepler);  // GK107
+		table.add(0x1003, 0x102F, chip_class::NV_kepler);  // GK110, GK210
+		table.add(0x1280, 0x12BA, chip_class::NV_kepler);  // GK208
 		table.add(0x1381, 0x13B0, chip_class::NV_maxwell); // GM107
 		table.add(0x1340, 0x134D, chip_class::NV_maxwell); // GM108
 		table.add(0x13C0, 0x13D9, chip_class::NV_maxwell); // GM204

--- a/rpcs3/Emu/RSX/VK/vkutils/chip_class.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/chip_class.h
@@ -16,7 +16,6 @@ namespace vk
 		AMD_navi2x,
 		NV_generic,
 		NV_kepler,
-		NV_mobile_kepler,
 		NV_maxwell,
 		NV_pascal,
 		NV_volta,


### PR DESCRIPTION
Not needed anymore since async compute is disabled for every Kepler GPU. Also adds missing IDs for GK210 (Tesla K80 and such).