### PR TITLE
rsx: Minor improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -968,7 +968,7 @@ namespace rsx
 
 			for (auto it = sections.crbegin(); it != sections.crend(); ++it)
 			{
-				if (it->base_address < range.start)
+				if (!it->surface->get_memory_range().inside(range))
 				{
 					continue;
 				}

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -529,12 +529,19 @@ namespace rsx
 			if (const bool gcm_format_is_depth = is_gcm_depth_format(attr2.gcm_format);
 				gcm_format_is_depth != is_depth)
 			{
-				if (force_convert)
+				if (force_convert || gcm_format_is_depth)
 				{
+					// If force_convert is set, we already know there is no simple workaround. Bitcast will be forced to resolve the issue.
+					// If the existing texture is a color texture but depth readout is requested, force bitcast
+					// Note that if only reading the depth value was needed from a depth surface, it would have been sampled as color due to Z comparison.
 					is_depth = gcm_format_is_depth;
+					force_convert = true;
 				}
 				else
 				{
+					// Existing texture is a depth texture, but RSX wants a color texture.
+					// Change the RSX request to a compatible depth texture to give same results in shader.
+					ensure(is_depth);
 					attr2.gcm_format = get_compatible_depth_format(attr2.gcm_format);
 				}
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1047,7 +1047,7 @@ namespace vk
 			case CELL_GCM_TEXTURE_X16:
 			case CELL_GCM_TEXTURE_DEPTH16:
 			case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-				return (vk_format == VK_FORMAT_D16_UNORM);
+				return (vk_format == VK_FORMAT_D16_UNORM || vk_format == VK_FORMAT_D32_SFLOAT);
 			}
 		}
 


### PR DESCRIPTION
Addresses some minor bugs identified while working on https://github.com/RPCS3/rpcs3/issues/9133
- Fix deduplication test range. This fixes https://github.com/RPCS3/rpcs3/issues/10079. Due to an unrelated issue this can ironically trigger some crashing with verification failed elsewhere. I have fixes for this second issue in the works together with some other restructuring efforts.
- Fix a random verification failure in texture cache due to depth/color render target hit mismatch. Only depth->color actions were defined, color->depth handling was not properly done.