### PR TITLE
[TESTERS NEEDED] rsx: Improve fragment attribute precision

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -357,6 +357,7 @@ void GLFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 	{
 		const auto driver_caps = gl::get_driver_caps();
 		decompiler.device_props.has_native_half_support = driver_caps.NV_gpu_shader5_supported || driver_caps.AMD_gpu_shader_half_float_supported;
+		decompiler.device_props.has_low_precision_rounding = driver_caps.vendor_NVIDIA;
 	}
 
 	decompiler.Task();

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
@@ -294,6 +294,7 @@ public:
 	{
 		bool has_native_half_support = false;
 		bool emulate_depth_compare = false;
+		bool has_low_precision_rounding = false;
 	}
 	device_props;
 

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -248,7 +248,7 @@ void VKFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	m_shader_props.require_linear_to_srgb = properties.has_pkg;
 	m_shader_props.emulate_coverage_tests = g_cfg.video.antialiasing_level == msaa_level::none;
 	m_shader_props.emulate_shadow_compare = device_props.emulate_depth_compare;
-	m_shader_props.low_precision_tests = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
+	m_shader_props.low_precision_tests = device_props.has_low_precision_rounding;
 	m_shader_props.disable_early_discard = vk::get_driver_vendor() != vk::driver_vendor::NVIDIA;
 	m_shader_props.supports_native_fp16 = device_props.has_native_half_support;
 
@@ -402,6 +402,7 @@ void VKFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 	}
 
 	decompiler.device_props.emulate_depth_compare = !pdev->get_formats_support().d24_unorm_s8;
+	decompiler.device_props.has_low_precision_rounding = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
 	decompiler.Task();
 
 	shader.create(::glsl::program_domain::glsl_fragment_program, source);


### PR DESCRIPTION
- ~~Actually obey the no perspective flag. Adds affine interpolation when requested by the shader.~~
- Add a workaround for NVIDIA gpus where there is some arithmetic drift interpolating primitive-constant attributes across the fragments. Maybe a bug? This is a known issue and seems to be hardware specific.

Fixes https://github.com/RPCS3/rpcs3/issues/9299