### PR TITLE
types.hpp: Improve ensure util, add fmt::tie

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -313,17 +313,10 @@ void fmt_class_string<src_loc>::format(std::string& out, u64 arg)
 
 namespace fmt
 {
-	[[noreturn]] void raw_verify_error(const src_loc& loc)
+	[[noreturn]] void raw_verify_error(const src_loc& loc, const char8_t* msg)
 	{
-		std::string out{"Verification failed"};
-		fmt::append(out, "%s", loc);
-		thread_ctrl::emergency_exit(out);
-	}
-
-	[[noreturn]] void raw_narrow_error(const src_loc& loc)
-	{
-		std::string out{"Narrowing error"};
-		fmt::append(out, "%s", loc);
+		std::string out;
+		fmt::append(out, "%s%s", msg ? msg : u8"Verification failed", loc);
 		thread_ctrl::emergency_exit(out);
 	}
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -419,7 +419,7 @@ int main(int argc, char** argv)
 	}
 #endif
 
-	ensure(thread_ctrl::is_main());
+	ensure(thread_ctrl::is_main(), "Not main thread");
 
 	// Initialize TSC freq (in case it isn't)
 	static_cast<void>(utils::get_tsc_freq());

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -802,6 +802,12 @@ struct const_str_t<umax>
 		const char* chars2;
 	};
 
+	const_str_t()
+		: size(0)
+		, chars(nullptr)
+	{
+	}
+
 	template <usz N>
 	constexpr const_str_t(const char8_t(&a)[N])
 		: size(N - 1)
@@ -845,12 +851,11 @@ struct src_loc
 
 namespace fmt
 {
-	[[noreturn]] void raw_verify_error(const src_loc& loc);
-	[[noreturn]] void raw_narrow_error(const src_loc& loc);
+	[[noreturn]] void raw_verify_error(const src_loc& loc, const char8_t* msg);
 }
 
 template <typename T>
-constexpr decltype(auto) ensure(T&& arg,
+constexpr decltype(auto) ensure(T&& arg, const_str msg = const_str(),
 	u32 line = __builtin_LINE(),
 	u32 col = __builtin_COLUMN(),
 	const char* file = __builtin_FILE(),
@@ -861,7 +866,7 @@ constexpr decltype(auto) ensure(T&& arg,
 		return std::forward<T>(arg);
 	}
 
-	fmt::raw_verify_error({line, col, file, func});
+	fmt::raw_verify_error({line, col, file, func}, msg);
 }
 
 // narrow() function details
@@ -946,8 +951,7 @@ template <typename To = void, typename From, typename = decltype(static_cast<To>
 	// Narrow check
 	if (narrow_impl<From, To>::test(value)) [[unlikely]]
 	{
-		// Pack value as formatting argument
-		fmt::raw_narrow_error({line, col, file, func});
+		fmt::raw_verify_error({line, col, file, func}, u8"Narrowing error");
 	}
 
 	return static_cast<To>(value);


### PR DESCRIPTION
- Add simple message to second argument of ensure()
- Minor cleanup (function duplication)
- Add ensure() with formatting support, requires fmt::tie
- Implement fmt::tie to pack multiple formatting arguments