### PR TITLE
serialization.hpp: Fixes

### DIFF
--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -29,6 +29,8 @@ namespace vm
 		using type = T;
 		using addr_type = std::remove_cv_t<AT>;
 
+		static constexpr bool enable_bitcopy = true;
+
 		_ptr_base() = default;
 
 		_ptr_base(vm::addr_t addr)
@@ -226,6 +228,7 @@ namespace vm
 
 	public:
 		using addr_type = std::remove_cv_t<AT>;
+		static constexpr bool enable_bitcopy = true;
 
 		_ptr_base() = default;
 

--- a/rpcs3/Emu/Memory/vm_var.h
+++ b/rpcs3/Emu/Memory/vm_var.h
@@ -46,6 +46,8 @@ namespace vm
 
 		_var_base& operator=(const _var_base&) = delete;
 
+		static constexpr bool enable_bitcopy = false;
+
 		_var_base()
 		    : pointer(A::alloc(sizeof(T), alignof(T)))
 		{
@@ -78,6 +80,8 @@ namespace vm
 		_var_base(const _var_base&) = delete;
 
 		_var_base& operator=(const _var_base&) = delete;
+
+		static constexpr bool enable_bitcopy = false;
 
 		_var_base(u32 count)
 		    : pointer(A::alloc(u32{sizeof(T)} * count, alignof(T)))

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -1112,6 +1112,7 @@ protected:
 
 public:
 	static constexpr usz align = Align;
+	static constexpr bool enable_bitcopy = true;
 
 	atomic_t() noexcept = default;
 

--- a/rpcs3/util/endian.hpp
+++ b/rpcs3/util/endian.hpp
@@ -180,6 +180,8 @@ namespace stx
 		using under = decltype(int_or_enum());
 
 	public:
+		static constexpr bool enable_bitcopy = true;
+
 		se_t() noexcept = default;
 
 		constexpr se_t(type value) noexcept

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -521,6 +521,9 @@ template <typename T>
 concept FPInt = std::is_floating_point_v<std::common_type_t<T>> || std::is_same_v<std::common_type_t<T>, f16>;
 
 template <typename T>
+concept Integral = std::is_integral_v<std::common_type_t<T>> || std::is_same_v<std::common_type_t<T>, u128> || std::is_same_v<std::common_type_t<T>, s128>;
+
+template <typename T>
 constexpr T min_v;
 
 template <UnsignedInt T>

--- a/rpcs3/util/v128.hpp
+++ b/rpcs3/util/v128.hpp
@@ -92,6 +92,8 @@ union alignas(16) v128
 	__m128d vd;
 #endif
 
+	static constexpr bool enable_bitcopy = true;
+
 	static v128 from64(u64 _0, u64 _1 = 0)
 	{
 		v128 ret;


### PR DESCRIPTION
* Fix serailization of objects viewed through const-lvalue-ref reference.
* Fix operator T(), do not not allow non-copyable types.
* Add support for v128, s128, u128, atomic_t<>, se_t<> and vm::_ptr_base<> types. 
* Move specialized size serialization pattern to its own function.

Fixes regression when using new serialization helper with my savestates work.