### PR TITLE
Improve bitwise serialization trait

### DIFF
--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -29,7 +29,7 @@ namespace vm
 		using type = T;
 		using addr_type = std::remove_cv_t<AT>;
 
-		static constexpr bool enable_bitcopy = true;
+		using enable_bitcopy = std::true_type;
 
 		_ptr_base() = default;
 
@@ -228,7 +228,7 @@ namespace vm
 
 	public:
 		using addr_type = std::remove_cv_t<AT>;
-		static constexpr bool enable_bitcopy = true;
+		using enable_bitcopy = std::true_type;
 
 		_ptr_base() = default;
 

--- a/rpcs3/Emu/Memory/vm_var.h
+++ b/rpcs3/Emu/Memory/vm_var.h
@@ -46,7 +46,7 @@ namespace vm
 
 		_var_base& operator=(const _var_base&) = delete;
 
-		static constexpr bool enable_bitcopy = false;
+		using enable_bitcopy = std::false_type; // Disable bitcopy inheritence
 
 		_var_base()
 		    : pointer(A::alloc(sizeof(T), alignof(T)))
@@ -81,7 +81,7 @@ namespace vm
 
 		_var_base& operator=(const _var_base&) = delete;
 
-		static constexpr bool enable_bitcopy = false;
+		using enable_bitcopy = std::false_type; // Disable bitcopy inheritence
 
 		_var_base(u32 count)
 		    : pointer(A::alloc(u32{sizeof(T)} * count, alignof(T)))

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.h
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.h
@@ -24,7 +24,7 @@ namespace rsx
 		// simple block to hold ps3 address and data
 		struct memory_block
 		{
-			static constexpr bool enable_bitcopy = true;
+			using enable_bitcopy = std::true_type;
 
 			u32 offset; // Offset in rsx address space
 			u32 location; // rsx memory location of the block
@@ -41,7 +41,7 @@ namespace rsx
 
 		struct tile_info
 		{
-			static constexpr bool enable_bitcopy = true;
+			using enable_bitcopy = std::true_type;
 
 			u32 tile;
 			u32 limit;
@@ -51,7 +51,7 @@ namespace rsx
 
 		struct zcull_info
 		{
-			static constexpr bool enable_bitcopy = true;
+			using enable_bitcopy = std::true_type;
 
 			u32 region;
 			u32 size;
@@ -64,7 +64,7 @@ namespace rsx
 		// bleh, may need to break these out, might be unnecessary to do both always
 		struct tile_state
 		{
-			static constexpr bool enable_bitcopy = true;
+			using enable_bitcopy = std::true_type;
 
 			tile_info tiles[15]{};
 			zcull_info zculls[8]{};
@@ -72,7 +72,7 @@ namespace rsx
 
 		struct buffer_state
 		{
-			static constexpr bool enable_bitcopy = true;
+			using enable_bitcopy = std::true_type;
 
 			u32 width{0};
 			u32 height{0};
@@ -82,7 +82,7 @@ namespace rsx
 
 		struct display_buffers_state
 		{
-			static constexpr bool enable_bitcopy = true;
+			using enable_bitcopy = std::true_type;
 
 			std::array<buffer_state, 8> buffers{};
 			u32 count{0};

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -1112,7 +1112,7 @@ protected:
 
 public:
 	static constexpr usz align = Align;
-	static constexpr bool enable_bitcopy = true;
+	using enable_bitcopy = std::true_type;
 
 	atomic_t() noexcept = default;
 

--- a/rpcs3/util/endian.hpp
+++ b/rpcs3/util/endian.hpp
@@ -180,7 +180,7 @@ namespace stx
 		using under = decltype(int_or_enum());
 
 	public:
-		static constexpr bool enable_bitcopy = true;
+		using enable_bitcopy = std::true_type;
 
 		se_t() noexcept = default;
 

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -33,9 +33,9 @@ namespace utils
 	};
 
 	template <typename T>
-	concept Bitcopy = (std::is_arithmetic_v<T>) || (std::is_enum_v<T>) || Integral<T> || requires (T& obj)
+	concept Bitcopy = (std::is_arithmetic_v<T>) || (std::is_enum_v<T>) || Integral<T> || requires ()
 	{
-		std::enable_if_t<static_cast<bool>(std::remove_cv_t<T>::enable_bitcopy)>();
+		std::enable_if_t<std::conjunction_v<typename T::enable_bitcopy>>();
 	};
 
 	template <typename T>

--- a/rpcs3/util/v128.hpp
+++ b/rpcs3/util/v128.hpp
@@ -92,7 +92,7 @@ union alignas(16) v128
 	__m128d vd;
 #endif
 
-	static constexpr bool enable_bitcopy = true;
+	using enable_bitcopy = std::true_type;
 
 	static v128 from64(u64 _0, u64 _1 = 0)
 	{


### PR DESCRIPTION
* Allows to declare bitcopy trait for locally defined class/union. (any static member is not allowed, even if constexpr)