### PR TITLE
lv2: Implement missing abort op for timer thread

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -110,18 +110,18 @@ public:
 
 	// Find and remove the object from the container (deque or vector)
 	template <typename T, typename E>
-	static T* unqueue(std::deque<T*>& queue, E* object)
+	static typename T::value_type unqueue(T& queue, E object)
 	{
 		for (auto found = queue.cbegin(), end = queue.cend(); found != end; found++)
 		{
 			if (*found == object)
 			{
 				queue.erase(found);
-				return static_cast<T*>(object);
+				return static_cast<typename T::value_type>(object);
 			}
 		}
 
-		return nullptr;
+		return {};
 	}
 
 	template <typename E, typename T>

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -108,16 +108,16 @@ public:
 		return str;
 	}
 
-	// Find and remove the object from the container (deque or vector)
+	// Find and remove the object from the deque container
 	template <typename T, typename E>
-	static typename T::value_type unqueue(T& queue, E object)
+	static T unqueue(std::deque<T>& queue, E object)
 	{
 		for (auto found = queue.cbegin(), end = queue.cend(); found != end; found++)
 		{
 			if (*found == object)
 			{
 				queue.erase(found);
-				return static_cast<typename T::value_type>(object);
+				return static_cast<T>(object);
 			}
 		}
 

--- a/rpcs3/Emu/Cell/lv2/sys_timer.h
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.h
@@ -21,11 +21,9 @@ struct sys_timer_information_t
 	be_t<u32> pad;
 };
 
-struct lv2_timer_context : lv2_obj
+struct lv2_timer : lv2_obj
 {
 	static const u32 id_base = 0x11000000;
-
-	void operator()();
 
 	shared_mutex mutex;
 	atomic_t<u32> state{SYS_TIMER_STATE_STOP};
@@ -37,6 +35,13 @@ struct lv2_timer_context : lv2_obj
 
 	atomic_t<u64> expire{0}; // Next expiration time
 	atomic_t<u64> period{0}; // Period (oneshot if 0)
+
+	u64 check();
+
+	lv2_timer() noexcept
+		: lv2_obj{1}
+	{
+	}
 
 	void get_information(sys_timer_information_t& info)
 	{
@@ -56,8 +61,6 @@ struct lv2_timer_context : lv2_obj
 		}
 	}
 };
-
-using lv2_timer = named_thread<lv2_timer_context>;
 
 class ppu_thread;
 


### PR DESCRIPTION
* Implement missing functionality of timer thread at Emu.Stop().
* Manage all sys_timer instances by one thread instead of thread for each.
* Simplify sys_timer instance construction.