### PR TITLE
IdManager.h: Improve idm::select

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_config.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_config.cpp
@@ -167,7 +167,7 @@ void lv2_config_service_listener::notify_all()
 		{
 			services.push_back(service.get_shared_ptr());
 		}
-	}, 0);
+	});
 
 	// Sort services by timestamp
 	sort(services.begin(), services.end(), [](const std::shared_ptr<lv2_config_service>& s1, const std::shared_ptr<lv2_config_service>& s2)

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -160,8 +160,6 @@ extern lv2_fs_mount_point g_mp_sys_dev_hdd1;
 
 struct lv2_fs_object
 {
-	using id_type = lv2_fs_object;
-
 	static const u32 id_base = 3;
 	static const u32 id_step = 1;
 	static const u32 id_count = 255 - id_base;

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -65,8 +65,6 @@ enum ppu_thread_status : u32;
 // Base class for some kernel objects (shared set of 8192 objects).
 struct lv2_obj
 {
-	using id_type = lv2_obj;
-
 	static const u32 id_step = 0x100;
 	static const u32 id_count = 8192;
 	static constexpr std::pair<u32, u32> id_invl_range = {0, 8};


### PR DESCRIPTION
* Allow to select multiple inherited object types for idm::select.
* Allow function reference types in idm::select. (they don't allow access to operator() directly, use deducing std::function constructor instead) 
* Ensure ::PtrSame<T, object_type> and  ::Ptr<T, Derived> are true.
* Allow id_base, id_step and id_count to be of enumeration type.
* Remove idm::remove, usage can be replaced with idm::withdraw.
* Changed return value of idm::check to bool.