### PR TITLE
Fix cellMouse/Keyboard initialization

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -37,13 +37,16 @@ error_code cellKbInit(u32 max_connect)
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
-	const auto init = handler.init.init();
+	auto init = handler.init.init();
 
 	if (!init)
 		return CELL_KB_ERROR_ALREADY_INITIALIZED;
 
 	if (max_connect == 0 || max_connect > CELL_KB_MAX_KEYBOARDS)
+	{
+		init.cancel();
 		return CELL_KB_ERROR_INVALID_PARAMETER;
+	}
 
 	libio_sys_config_init();
 	handler.Init(std::min(max_connect, 7u));

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -38,13 +38,14 @@ error_code cellMouseInit(u32 max_connect)
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
-	const auto init = handler.init.init();
+	auto init = handler.init.init();
 
 	if (!init)
 		return CELL_MOUSE_ERROR_ALREADY_INITIALIZED;
 
 	if (max_connect == 0 || max_connect > CELL_MAX_MICE)
 	{
+		init.cancel();
 		return CELL_MOUSE_ERROR_INVALID_PARAMETER;
 	}
 


### PR DESCRIPTION
When once the application passed incorrect information to initialization process the entirety of cellKb/cellMouse collapsed at once.