### PR TITLE
CELLFS: Fix file handle creation for non-writable partitions

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -307,14 +307,6 @@ lv2_file::open_raw_result_t lv2_file::open_raw(const std::string& local_path, s3
 	default: break;
 	}
 
-	if (mp->flags & lv2_mp_flag::read_only)
-	{
-		if (flags & CELL_FS_O_ACCMODE || flags & (CELL_FS_O_CREAT | CELL_FS_O_TRUNC))
-		{
-			return {CELL_EPERM};
-		}
-	}
-
 	if (flags & CELL_FS_O_CREAT)
 	{
 		open_mode += fs::create;


### PR DESCRIPTION
This function is much more relaxed on PS3 than rpcs3... real PS3 just errors on cellFsWrite instead.

Should fix #10460 needs confirmation.