### PR TITLE
rsx: Fix emulation stopping when at semaphore_acquire

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -38,7 +38,7 @@ constexpr bool is_stopped(bs_t<cpu_flag> state)
 // Test paused state
 constexpr bool is_paused(bs_t<cpu_flag> state)
 {
-	return !!(state & (cpu_flag::suspend + cpu_flag::dbg_global_pause + cpu_flag::dbg_pause));
+	return !!(state & (cpu_flag::suspend + cpu_flag::dbg_global_pause + cpu_flag::dbg_pause)) && !is_stopped(state);
 }
 
 class cpu_thread


### PR DESCRIPTION
This indirectly fixes GOW Ascension after emulation (or RSX) was paused then stopped when RSX was executing semaphore_acquire. See https://github.com/RPCS3/rpcs3/blob/c3415bcff263a22d4718da0b869af75373f2af03/rpcs3/Emu/RSX/rsx_methods.cpp#L91
Semantics of pause test should match Emu.IsPaused() which evaluates to false after emulation was stopped because pause flags lose their meaning in that situation.