### PR TITLE
Savestates

### DIFF
--- a/rpcs3/Crypto/unedat.h
+++ b/rpcs3/Crypto/unedat.h
@@ -26,11 +26,17 @@ struct loaded_npdrm_keys
 	}
 
 	// TODO: Check if correct for ELF files usage
-	u128 last_key() const
+	u128 last_key(usz backwards = 0) const
 	{
+		backwards++;
 		const usz pos = dec_keys_pos;
-		return pos ? dec_keys[(pos - 1) % std::size(dec_keys)].load() : u128{};
+		return pos >= backwards ? dec_keys[(pos - backwards) % std::size(dec_keys)].load() : u128{};
 	}
+
+	SAVESTATE_INIT_POS(2);
+	loaded_npdrm_keys() = default;
+	loaded_npdrm_keys(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 struct NPD_HEADER

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -49,6 +49,7 @@ void fmt_class_string<cpu_flag>::format(std::string& out, u64 arg)
 		case cpu_flag::pause: return "p";
 		case cpu_flag::suspend: return "s";
 		case cpu_flag::ret: return "ret";
+		case cpu_flag::again: return "a";
 		case cpu_flag::signal: return "sig";
 		case cpu_flag::memory: return "mem";
 		case cpu_flag::pending: return "pend";
@@ -720,7 +721,7 @@ bool cpu_thread::check_state() noexcept
 			}
 
 			// Atomically clean wait flag and escape
-			if (!(flags & (cpu_flag::exit + cpu_flag::ret + cpu_flag::stop)))
+			if (!is_stopped(flags) && flags.none_of(cpu_flag::ret))
 			{
 				// Check pause flags which hold thread inside check_state (ignore suspend/debug flags on cpu_flag::temp)
 				if (flags & (cpu_flag::pause + cpu_flag::memory) || (cpu_can_stop && flags & (cpu_flag::dbg_global_pause + cpu_flag::dbg_pause + cpu_flag::suspend)))

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -19,6 +19,7 @@ enum class cpu_flag : u32
 	pause, // Thread suspended by suspend_all technique
 	suspend, // Thread suspended
 	ret, // Callback return requested
+	again, // Thread must complete the syscall after deserialization
 	signal, // Thread received a signal (HLE)
 	memory, // Thread must unlock memory mutex
 	pending, // Thread has postponed work
@@ -34,7 +35,7 @@ enum class cpu_flag : u32
 // Test stopped state
 constexpr bool is_stopped(bs_t<cpu_flag> state)
 {
-	return !!(state & (cpu_flag::stop + cpu_flag::exit));
+	return !!(state & (cpu_flag::stop + cpu_flag::exit + cpu_flag::again));
 }
 
 // Test paused state

--- a/rpcs3/Emu/Cell/MFC.h
+++ b/rpcs3/Emu/Cell/MFC.h
@@ -88,6 +88,8 @@ enum : u32
 
 struct alignas(16) spu_mfc_cmd
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	MFC cmd;
 	u8 tag;
 	u16 size;

--- a/rpcs3/Emu/Cell/Modules/cellAudio.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.h
@@ -189,6 +189,16 @@ struct audio_port
 	f32 last_tag_value[PORT_BUFFER_TAG_COUNT] = { 0 };
 
 	void tag(s32 offset = 0);
+
+	audio_port() = default;
+
+	// Handle copy ctor of atomic var
+	audio_port(const audio_port& r)
+	{
+		std::memcpy(this, &r, sizeof(r));
+	}
+
+	ENABLE_BITWISE_SERIALIZATION;
 };
 
 struct cell_audio_config
@@ -366,7 +376,7 @@ public:
 	atomic_t<audio_backend_update> m_update_configuration = audio_backend_update::NONE;
 
 	shared_mutex mutex{};
-	atomic_t<u32> init = 0;
+	atomic_t<u8> init = 0;
 
 	u32 key_count = 0;
 	u8 event_period = 0;
@@ -390,9 +400,13 @@ public:
 	bool m_backend_failed = false;
 	bool m_audio_should_restart = false;
 
-	cell_audio_thread();
-
 	void operator()();
+
+	SAVESTATE_INIT_POS(9);
+
+	cell_audio_thread();
+	cell_audio_thread(utils::serial& ar);
+	void save(utils::serial& ar);
 
 	audio_port* open_port();
 

--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -131,6 +131,25 @@ static const char* get_camera_attr_name(s32 value)
 	return nullptr;
 }
 
+camera_context::camera_context(utils::serial& ar)
+{
+	save(ar);
+}
+
+void camera_context::save(utils::serial& ar)
+{
+	ar(init);
+
+	if (!init)
+	{
+		return;
+	}
+
+	USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellCamera);
+
+	ar(notify_data_map, start_timestamp, read_mode, is_streaming, is_attached, is_open, info, attr, frame_num);
+}
+
 static bool check_dev_num(s32 dev_num)
 {
 	return dev_num == 0;

--- a/rpcs3/Emu/Cell/Modules/cellCamera.h
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.h
@@ -375,6 +375,8 @@ struct CellCameraInfoEx
 	be_t<u32> container;
 	be_t<s32> read_mode;
 	vm::bptr<u8> pbuf[2];
+
+	ENABLE_BITWISE_SERIALIZATION;
 };
 
 struct CellCameraReadEx
@@ -392,6 +394,8 @@ class camera_context
 	{
 		u64 source;
 		u64 flag;
+
+		ENABLE_BITWISE_SERIALIZATION;
 	};
 
 public:
@@ -433,14 +437,23 @@ public:
 	struct attr_t
 	{
 		u32 v1, v2;
+
+		ENABLE_BITWISE_SERIALIZATION;
 	};
+
 	attr_t attr[500]{};
 	atomic_t<bool> has_new_frame = false;
 	atomic_t<u32> frame_num = 0;
 	atomic_t<u32> frame_timestamp = 0;
 	atomic_t<u32> bytes_read = 0;
 
-	atomic_t<u32> init = 0;
+	atomic_t<u8> init = 0;
+
+	SAVESTATE_INIT_POS(16);
+
+	camera_context() = default;
+	camera_context(utils::serial& ar);
+	void save(utils::serial& ar);
 
 	static constexpr auto thread_name = "Camera Thread"sv;
 

--- a/rpcs3/Emu/Cell/Modules/cellDmux.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellDmux.cpp
@@ -165,6 +165,7 @@ public:
 	static const u32 id_base = 1;
 	static const u32 id_step = 1;
 	static const u32 id_count = 1023;
+	SAVESTATE_INIT_POS(34);
 
 	ElementaryStream(Demuxer* dmux, u32 addr, u32 size, u32 fidMajor, u32 fidMinor, u32 sup1, u32 sup2, vm::ptr<CellDmuxCbEsMsg> cbFunc, u32 cbArg, u32 spec);
 

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -94,7 +94,7 @@ public:
 
 	static constexpr auto thread_name = "Gem Thread"sv;
 
-	atomic_t<u32> state = 0;
+	atomic_t<u8> state = 0;
 
 	struct gem_color
 	{
@@ -131,6 +131,8 @@ public:
 		u64 calibration_start_us{0};                       // The start timestamp of the calibration in microseconds
 
 		static constexpr u64 calibration_time_us = 500000; // The calibration supposedly takes 0.5 seconds (500000 microseconds)
+
+		ENABLE_BITWISE_SERIALIZATION;
 	};
 
 	CellGemAttribute attribute = {};
@@ -201,6 +203,30 @@ public:
 			controllers[gem_num].status = CELL_GEM_STATUS_READY;
 			controllers[gem_num].port = 7u - gem_num;
 		}
+	}
+
+	gem_config_data() = default;
+
+	SAVESTATE_INIT_POS(15);
+
+	void save(utils::serial& ar)
+	{
+		ar(state);
+
+		if (!state)
+		{
+			return;
+		}
+
+		USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellGem);
+
+		ar(attribute, vc_attribute, status_flags, enable_pitch_correction, inertial_counter, controllers
+			, connected_controllers, update_started, camera_frame, memory_ptr, start_timestamp);
+	}
+
+	gem_config_data(utils::serial& ar)
+	{
+		save(ar);
 	}
 };
 
@@ -854,7 +880,7 @@ error_code cellGemEnd(ppu_thread& ppu)
 
 	if (gem.state.compare_and_swap_test(1, 0))
 	{
-		if (u32 addr = gem.memory_ptr)
+		if (u32 addr = std::exchange(gem.memory_ptr, 0))
 		{
 			sys_memory_free(ppu, addr);
 		}

--- a/rpcs3/Emu/Cell/Modules/cellGem.h
+++ b/rpcs3/Emu/Cell/Modules/cellGem.h
@@ -171,6 +171,8 @@ struct CellGemAttribute
 	be_t<u32> memory_ptr;
 	be_t<u32> spurs_addr;
 	u8 spu_priorities[8];
+
+	ENABLE_BITWISE_SERIALIZATION;
 };
 
 struct CellGemCameraState
@@ -180,6 +182,8 @@ struct CellGemCameraState
 	be_t<f32> gain;
 	be_t<f32> pitch_angle;
 	be_t<f32> pitch_angle_estimate;
+
+	ENABLE_BITWISE_SERIALIZATION;
 };
 
 struct CellGemExtPortData
@@ -270,4 +274,6 @@ struct CellGemVideoConvertAttribute
 	vm::bptr<u8> buffer_memory;
 	vm::bptr<u8> video_data_out;
 	u8 alpha;
+
+	ENABLE_BITWISE_SERIALIZATION;
 };

--- a/rpcs3/Emu/Cell/Modules/cellJpgDec.h
+++ b/rpcs3/Emu/Cell/Modules/cellJpgDec.h
@@ -110,6 +110,7 @@ struct CellJpgDecSubHandle
 	static const u32 id_base = 1;
 	static const u32 id_step = 1;
 	static const u32 id_count = 1023;
+	SAVESTATE_INIT_POS(35);
 
 	u32 fd;
 	u64 fileSize;

--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Emu/IdManager.h"
+#include "Emu/System.h"
 #include "Emu/Cell/PPUModule.h"
 
 #include "Emu/Io/KeyboardHandler.h"
@@ -29,6 +30,33 @@ void fmt_class_string<CellKbError>::format(std::string& out, u64 arg)
 
 		return unknown;
 	});
+}
+
+
+KeyboardHandlerBase::KeyboardHandlerBase(utils::serial* ar)
+{
+	if (!ar)
+	{
+		return;
+	}
+
+	(*ar)(m_info.max_connect);
+
+	if (m_info.max_connect)
+	{
+		Emu.DeferDeserialization([this]()
+		{
+			Init(m_info.max_connect);
+			init.init();
+		});
+	}
+}
+
+void KeyboardHandlerBase::save(utils::serial& ar)
+{
+	const auto inited = init.access();
+
+	ar(inited ? m_info.max_connect : 0);
 }
 
 error_code cellKbInit(u32 max_connect)

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -356,7 +356,7 @@ public:
 	std::unordered_map<s32, microphone_device> mic_list;
 
 	shared_mutex mutex;
-	atomic_t<u32> init = 0;
+	atomic_t<u8> init = 0;
 
 	static constexpr auto thread_name = "Microphone Thread"sv;
 

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Emu/IdManager.h"
+#include "Emu/System.h"
 #include "Emu/Cell/PPUModule.h"
 
 #include "Emu/Io/MouseHandler.h"
@@ -30,6 +31,32 @@ void fmt_class_string<CellMouseError>::format(std::string& out, u64 arg)
 
 		return unknown;
 	});
+}
+
+MouseHandlerBase::MouseHandlerBase(utils::serial* ar)
+{
+	if (!ar)
+	{
+		return;
+	}
+
+	(*ar)(m_info.max_connect);
+
+	if (m_info.max_connect)
+	{
+		Emu.DeferDeserialization([this]()
+		{
+			Init(m_info.max_connect);
+			init.init();
+		});
+	}
+}
+
+void MouseHandlerBase::save(utils::serial& ar)
+{
+	const auto inited = init.access();
+
+	ar(inited ? m_info.max_connect : 0);
 }
 
 error_code cellMouseInit(u32 max_connect)

--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -74,9 +74,31 @@ struct music_state
 	std::shared_ptr<music_handler_base> handler;
 	music_selection_context current_selection_context;
 
+	SAVESTATE_INIT_POS(16);
+
 	music_state()
 	{
 		handler = Emu.GetCallbacks().get_music_handler();
+	}
+
+	music_state(utils::serial& ar)
+		: music_state()
+	{
+		save(ar);
+	}
+
+	void save(utils::serial& ar)
+	{
+		ar(func);
+
+		if (!func)
+		{
+			return;
+		}
+
+		USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellMusic);
+
+		ar(userData);
 	}
 };
 

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -50,6 +50,18 @@ void fmt_class_string<CellPadFilterError>::format(std::string& out, u64 arg)
 	});
 }
 
+pad_info::pad_info(utils::serial& ar)
+	: max_connect(ar)
+	, port_setting(ar)
+{
+}
+
+void pad_info::save(utils::serial& ar)
+{
+	ar(max_connect, port_setting);
+}
+
+
 error_code cellPadInit(u32 max_connect)
 {
 	sys_io.warning("cellPadInit(max_connect=%d)", max_connect);

--- a/rpcs3/Emu/Cell/Modules/cellPad.h
+++ b/rpcs3/Emu/Cell/Modules/cellPad.h
@@ -3,6 +3,7 @@
 #include "Emu/Io/pad_types.h"
 
 #include <array>
+#include "util/types.hpp"
 
 enum CellPadError : u32
 {
@@ -197,6 +198,12 @@ struct pad_info
 {
 	atomic_t<u32> max_connect = 0;
 	std::array<u32, CELL_PAD_MAX_PORT_NUM> port_setting{ 0 };
+
+	SAVESTATE_INIT_POS(11);
+
+	pad_info() = default;
+	pad_info(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data);

--- a/rpcs3/Emu/Cell/Modules/cellSearch.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSearch.cpp
@@ -81,6 +81,8 @@ struct search_content_t
 		CellSearchVideoListInfo video_list;
 		CellSearchVideoSceneInfo scene;
 	} data;
+
+	ENABLE_BITWISE_SERIALIZATION;
 };
 
 using content_id_type = std::pair<u64, std::shared_ptr<search_content_t>>;
@@ -90,6 +92,8 @@ struct content_id_map
 	std::unordered_map<u64, std::shared_ptr<search_content_t>> map;
 
 	shared_mutex mutex;
+
+	SAVESTATE_INIT_POS(36);
 };
 
 struct search_object_t
@@ -98,6 +102,7 @@ struct search_object_t
 	static const u32 id_base  = 1;
 	static const u32 id_step  = 1;
 	static const u32 id_count = 1024; // TODO
+	SAVESTATE_INIT_POS(36.1);
 
 	std::vector<content_id_type> content_ids;
 };

--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -68,6 +68,8 @@ struct sysutil_cb_manager
 
 	struct alignas(8) registered_cb
 	{
+		ENABLE_BITWISE_SERIALIZATION;
+
 		vm::ptr<CellSysutilCallback> callback;
 		vm::ptr<void> user_data;
 	};
@@ -78,6 +80,21 @@ struct sysutil_cb_manager
 
 	atomic_t<bool> draw_cb_started{};
 	atomic_t<u64> read_counter{0};
+
+	SAVESTATE_INIT_POS(13);
+
+	sysutil_cb_manager() = default;
+
+	sysutil_cb_manager(utils::serial& ar)
+	{
+		ar(callbacks);
+	}
+
+	void save(utils::serial& ar)
+	{
+		ensure(!registered);
+		ar(callbacks);
+	}
 };
 
 extern void sysutil_register_cb(std::function<s32(ppu_thread&)>&& cb)

--- a/rpcs3/Emu/Cell/Modules/cellVoice.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.cpp
@@ -46,6 +46,12 @@ void voice_manager::reset()
 	queue_keys.clear();
 }
 
+void voice_manager::save(utils::serial& ar)
+{
+	USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellVoice);
+	ar(id_ctr, port_source, ports, queue_keys, voice_service_started);
+}
+
 error_code cellVoiceConnectIPortToOPort(u32 ips, u32 ops)
 {
 	cellVoice.todo("cellVoiceConnectIPortToOPort(ips=%d, ops=%d)", ips, ops);

--- a/rpcs3/Emu/Cell/Modules/cellVoice.h
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.h
@@ -182,6 +182,8 @@ struct voice_manager
 	{
 		s32 state = CELLVOICE_PORTSTATE_NULL;
 		CellVoicePortParam info;
+
+		ENABLE_BITWISE_SERIALIZATION;
 	};
 
 	// See cellVoiceCreatePort
@@ -210,4 +212,10 @@ struct voice_manager
 	void reset();
 	shared_mutex mtx;
 	atomic_t<bool> is_init{ false };
+
+	SAVESTATE_INIT_POS(17);
+
+	voice_manager() = default;
+	voice_manager(utils::serial& ar) { save(ar); }
+	void save(utils::serial& ar);
 };

--- a/rpcs3/Emu/Cell/Modules/cellVpost.h
+++ b/rpcs3/Emu/Cell/Modules/cellVpost.h
@@ -340,6 +340,7 @@ public:
 	static const u32 id_base = 1;
 	static const u32 id_step = 1;
 	static const u32 id_count = 1023;
+	SAVESTATE_INIT_POS(23);
 
 	const bool to_rgba;
 

--- a/rpcs3/Emu/Cell/Modules/sceNpSns.h
+++ b/rpcs3/Emu/Cell/Modules/sceNpSns.h
@@ -47,6 +47,11 @@ struct sns_fb_handle_t
 	static const u32 id_step  = 1;
 	static const u32 id_count = SCE_NP_SNS_FB_HANDLE_SLOT_MAX + 1;
 	static const u32 invalid  = SCE_NP_SNS_FB_INVALID_HANDLE;
+
+	SAVESTATE_INIT_POS(20);
+	sns_fb_handle_t() = default;
+	sns_fb_handle_t(utils::serial&){}
+	void save(utils::serial&){}
 };
 
 // Initialization parameters for functionalities coordinated with Facebook

--- a/rpcs3/Emu/Cell/Modules/sys_heap.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_heap.cpp
@@ -11,6 +11,7 @@ struct HeapInfo
 	static const u32 id_base = 1;
 	static const u32 id_step = 1;
 	static const u32 id_count = 1023;
+	SAVESTATE_INIT_POS(22);
 
 	const std::string name;
 

--- a/rpcs3/Emu/Cell/Modules/sys_mempool.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_mempool.cpp
@@ -18,6 +18,7 @@ struct memory_pool_t
 	static const u32 id_base = 1;
 	static const u32 id_step = 1;
 	static const u32 id_count = 1023;
+	SAVESTATE_INIT_POS(21);
 
 	u32 mutexid;
 	u32 condid;

--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -1,8 +1,10 @@
 #include "stdafx.h"
 #include "PPUFunction.h"
 #include "Utilities/JIT.h"
+#include "util/serialization.hpp"
 
 #include "PPUModule.h"
+#include "PPUInterpreter.h"
 
 // Get function name by FNID
 extern std::string ppu_get_function_name(const std::string& _module, u32 fnid)
@@ -1942,6 +1944,16 @@ auto gen_ghc_cpp_trampoline(ppu_intrp_func_t fn_target)
 #else
 #error "Not implemented!"
 #endif
+
+ppu_function_manager::ppu_function_manager(utils::serial& ar)
+	: addr(ar)
+{
+}
+
+void ppu_function_manager::save(utils::serial& ar)
+{
+	ar(addr);
+}
 
 std::vector<ppu_intrp_func_t>& ppu_function_manager::access(bool ghc)
 {

--- a/rpcs3/Emu/Cell/PPUFunction.h
+++ b/rpcs3/Emu/Cell/PPUFunction.h
@@ -115,6 +115,7 @@ namespace ppu_func_detail
 
 		static FORCE_INLINE void put_result(ppu_thread& ppu, const T& result)
 		{
+			if (ppu.state & cpu_flag::again) return;
 			ppu.gpr[3] = ppu_gpr_cast(result);
 		}
 	};
@@ -126,6 +127,7 @@ namespace ppu_func_detail
 
 		static FORCE_INLINE void put_result(ppu_thread& ppu, const T& result)
 		{
+			if (ppu.state & cpu_flag::again) return;
 			ppu.fpr[1] = static_cast<T>(result);
 		}
 	};
@@ -137,6 +139,7 @@ namespace ppu_func_detail
 
 		static FORCE_INLINE void put_result(ppu_thread& ppu, const T& result)
 		{
+			if (ppu.state & cpu_flag::again) return;
 			ppu.vr[2] = result;
 		}
 	};
@@ -299,6 +302,9 @@ public:
 
 	// Allocation address
 	u32 addr = 0;
+
+	void save(utils::serial& ar);
+	ppu_function_manager(utils::serial& ar);
 };
 
 template<typename T, T Func>

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -4,6 +4,7 @@
 #include "Utilities/bin_patch.h"
 #include "Utilities/StrUtil.h"
 #include "Utilities/address_range.h"
+#include "util/serialization.hpp"
 #include "Crypto/sha1.h"
 #include "Crypto/unself.h"
 #include "Loader/ELF.h"
@@ -152,7 +153,7 @@ struct ppu_linkage_info
 };
 
 // Initialize static modules.
-static void ppu_initialize_modules(ppu_linkage_info* link)
+static void ppu_initialize_modules(ppu_linkage_info* link, utils::serial* ar = nullptr)
 {
 	if (!link->modules.empty())
 	{
@@ -280,7 +281,10 @@ static void ppu_initialize_modules(ppu_linkage_info* link)
 	u32& hle_funcs_addr = g_fxo->get<ppu_function_manager>().addr;
 
 	// Allocate memory for the array (must be called after fixed allocations)
-	hle_funcs_addr = vm::alloc(::size32(hle_funcs) * 8, vm::main);
+	if (!hle_funcs_addr)
+		hle_funcs_addr = vm::alloc(::size32(hle_funcs) * 8, vm::main);
+	else
+		vm::page_protect(hle_funcs_addr, utils::align(::size32(hle_funcs) * 8, 0x1000), 0, vm::page_writable);
 
 	// Initialize as PPU executable code
 	ppu_register_range(hle_funcs_addr, ::size32(hle_funcs) * 8);
@@ -319,6 +323,71 @@ static void ppu_initialize_modules(ppu_linkage_info* link)
 		ppu_loader.trace("Registered static module: %s", _module->name);
 	}
 
+	struct hle_vars_save
+	{
+		hle_vars_save() = default;
+
+		hle_vars_save(const hle_vars_save&) = delete;
+
+		hle_vars_save& operator =(const hle_vars_save&) = delete;
+
+		hle_vars_save(utils::serial& ar)
+		{
+			auto& manager = ppu_module_manager::get();
+
+			while (true)
+			{
+				const std::string name = ar.operator std::string();
+	
+				if (name.empty())
+				{
+					// Null termination
+					break;
+				}
+
+				const auto _module = manager.at(name);
+
+				auto& variable = _module->variables;
+	
+				for (u32 i = 0, end = ar.operator usz(); i < end; i++)
+				{
+					auto* ptr = &variable.at(ar.operator u32());
+					ptr->addr = ar.operator u32();
+					ensure(!!ptr->var);
+				}
+			}
+		}
+
+		void save(utils::serial& ar)
+		{
+			for (auto& pair : ppu_module_manager::get())
+			{
+				const auto _module = pair.second;
+
+				ar(_module->name);
+
+				ar(_module->variables.size());
+
+				for (auto& variable : _module->variables)
+				{
+					ar(variable.first, variable.second.addr);
+				}
+			}
+
+			// Null terminator
+			ar(std::string{});
+		}
+	};
+
+	if (ar)
+	{
+		g_fxo->init<hle_vars_save>(*ar);
+	}
+	else
+	{
+		g_fxo->init<hle_vars_save>();
+	}
+
 	for (auto& pair : ppu_module_manager::get())
 	{
 		const auto _module = pair.second;
@@ -345,7 +414,11 @@ static void ppu_initialize_modules(ppu_linkage_info* link)
 			ppu_loader.trace("** &0x%08X: %s (size=0x%x, align=0x%x)", variable.first, variable.second.name, variable.second.size, variable.second.align);
 
 			// Allocate HLE variable
-			if (variable.second.size >= 0x10000 || variable.second.align >= 0x10000)
+			if (ar)
+			{
+				// Already loaded
+			}
+			else if (variable.second.size >= 0x10000 || variable.second.align >= 0x10000)
 			{
 				variable.second.addr = vm::alloc(variable.second.size, vm::main, std::max<u32>(variable.second.align, 0x10000));
 			}
@@ -790,6 +863,49 @@ void ppu_manual_load_imports_exports(u32 imports_start, u32 imports_size, u32 ex
 	ppu_load_imports(_main.relocs, &link, imports_start, imports_start + imports_size);
 }
 
+// For savestates
+extern bool is_memory_read_only_of_executable(u32 addr)
+{
+	if (g_cfg.savestate.state_inspection_mode)
+	{
+		return false;
+	}
+
+	const auto _main = g_fxo->try_get<ppu_module>();
+	ensure(_main);
+
+	for (const auto& seg : _main->segs)
+	{
+		if (!seg.addr || (seg.flags & 0x2) /* W */)
+			continue;
+
+		if (addr >= seg.addr && addr < (seg.addr + seg.size))
+			return true;
+	}
+
+	return false;
+}
+
+void init_ppu_functions(utils::serial* ar, bool full = false)
+{
+	g_fxo->need<ppu_linkage_info>();
+
+	if (ar)
+	{
+		ensure(vm::check_addr(g_fxo->init<ppu_function_manager>(*ar)->addr));
+	}
+	else
+		g_fxo->init<ppu_function_manager>();
+
+	if (full)
+	{
+		ensure(ar);
+
+		// Initialize HLE modules
+		ppu_initialize_modules(&g_fxo->get<ppu_linkage_info>(), ar);
+	}
+}
+
 static void ppu_check_patch_spu_images(const ppu_segment& seg)
 {
 	const std::string_view seg_view{vm::get_super_ptr<char>(seg.addr), seg.size};
@@ -894,7 +1010,7 @@ static void ppu_check_patch_spu_images(const ppu_segment& seg)
 void try_spawn_ppu_if_exclusive_program(const ppu_module& m)
 {
 	// If only PRX/OVL has been loaded at Emu.BootGame(), launch a single PPU thread so its memory can be viewed
-	if (Emu.IsReady() && g_fxo->get<ppu_module>().segs.empty())
+	if (Emu.IsReady() && g_fxo->get<ppu_module>().segs.empty() && !Emu.DeserialManager())
 	{
 		ppu_thread_params p
 		{
@@ -911,7 +1027,7 @@ void try_spawn_ppu_if_exclusive_program(const ppu_module& m)
 	}
 }
 
-std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::string& path, s64 file_offset)
+std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::string& path, s64 file_offset, utils::serial* ar)
 {
 	if (elf != elf_error::ok)
 	{
@@ -919,7 +1035,7 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 	}
 
 	// Create new PRX object
-	const auto prx = idm::make_ptr<lv2_obj, lv2_prx>();
+	const auto prx = !ar ? idm::make_ptr<lv2_obj, lv2_prx>() : std::make_shared<lv2_prx>();
 
 	// Access linkage information object
 	auto& link = g_fxo->get<ppu_linkage_info>();
@@ -957,15 +1073,16 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 				//const u32 init_addr = ::narrow<u32>(prog.p_vaddr);
 
 				// Alloc segment memory
-				const u32 addr = vm::alloc(mem_size, vm::main);
+				// Or use saved address
+				const u32 addr = !ar ? vm::alloc(mem_size, vm::main) : ar->operator u32();
 
-				if (!addr)
+				if (!vm::check_addr(addr))
 				{
 					fmt::throw_exception("vm::alloc() failed (size=0x%x)", mem_size);
 				}
 
 				// Copy segment data
-				std::memcpy(vm::base(addr), prog.bin.data(), file_size);
+				if (!ar) std::memcpy(vm::base(addr), prog.bin.data(), file_size);
 				ppu_loader.warning("**** Loaded to 0x%x...0x%x (size=0x%x)", addr, addr + mem_size - 1, mem_size);
 
 				// Hash segment
@@ -1067,6 +1184,11 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 				const u32 rtype = _rel.type = rel.type;
 				const u64 rdata = _rel.data = data_base + rel.ptr.addr();
 				prx->relocs.emplace_back(_rel);
+
+				if (ar)
+				{
+					break;
+				}
 
 				switch (rtype)
 				{
@@ -1293,7 +1415,7 @@ void ppu_unload_prx(const lv2_prx& prx)
 	}
 }
 
-bool ppu_load_exec(const ppu_exec_object& elf)
+bool ppu_load_exec(const ppu_exec_object& elf, utils::serial* ar)
 {
 	if (elf != elf_error::ok)
 	{
@@ -1316,8 +1438,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		}
 	}
 
-	g_fxo->need<ppu_linkage_info>();
-	g_fxo->need<ppu_function_manager>();
+	init_ppu_functions(ar, false);
 
 	// Set for delayed initialization in ppu_initialize()
 	auto& _main = g_fxo->get<ppu_module>();
@@ -1390,7 +1511,17 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 				return false;
 			}
 
-			if (!vm::falloc(addr, size, vm::main))
+			const bool already_loaded = ar && (_seg.flags & 0x2);
+
+			if (already_loaded)
+			{
+				if (!vm::check_addr(addr, vm::page_readable, size))
+				{
+					ppu_loader.fatal("ppu_load_exec(): Archived PPU executable memory has not been found! (addr=0x%x, memsz=0x%x)", addr, size);
+					return false;
+				}
+			}
+			else if (!vm::falloc(addr, size, vm::main))
 			{
 				ppu_loader.error("vm::falloc(vm::main) failed (addr=0x%x, memsz=0x%x)", addr, size); // TODO
 
@@ -1402,7 +1533,18 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 			}
 
 			// Copy segment data, hash it
-			std::memcpy(vm::base(addr), prog.bin.data(), prog.bin.size());
+			if (!already_loaded)
+			{
+				std::memcpy(vm::base(addr), prog.bin.data(), prog.bin.size());
+			}
+			else
+			{
+				// For backwards compatibility: already loaded memory will always be writable
+				const u32 size0 = utils::align(size + addr % 0x10000, 0x10000);
+				const u32 addr0 = addr & -0x10000;
+				vm::page_protect(addr0, size0, 0, vm::page_writable | vm::page_readable, vm::page_executable);
+			}
+
 			sha1_update(&sha, reinterpret_cast<const uchar*>(&prog.p_vaddr), sizeof(prog.p_vaddr));
 			sha1_update(&sha, reinterpret_cast<const uchar*>(&prog.p_memsz), sizeof(prog.p_memsz));
 			sha1_update(&sha, prog.bin.data(), prog.bin.size());
@@ -1476,7 +1618,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 	}
 
 	// Initialize HLE modules
-	ppu_initialize_modules(&link);
+	ppu_initialize_modules(&link, ar);
 
 	// Embedded SPU elf patching
 	for (const auto& seg : _main.segs)
@@ -1641,6 +1783,46 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		}
 	}
 
+	// Initialize memory stats (according to sdk version)
+	u32 mem_size;
+	if (g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
+	{
+		// Because vsh.self comes before any generic application, more memory is available to it
+		mem_size = 0xF000000;
+	}
+	else if (sdk_version > 0x0021FFFF)
+	{
+		mem_size = 0xD500000;
+	}
+	else if (sdk_version > 0x00192FFF)
+	{
+		mem_size = 0xD300000;
+	}
+	else if (sdk_version > 0x0018FFFF)
+	{
+		mem_size = 0xD100000;
+	}
+	else if (sdk_version > 0x0017FFFF)
+	{
+		mem_size = 0xD000000;
+	}
+	else if (sdk_version > 0x00154FFF)
+	{
+		mem_size = 0xCC00000;
+	}
+	else
+	{
+		mem_size = 0xC800000;
+	}
+
+	if (g_cfg.core.debug_console_mode)
+	{
+		// TODO: Check for all sdk versions
+		mem_size += 0xC000000;
+	}
+
+	if (!ar) g_fxo->init<lv2_memory_container>(mem_size);
+
 	// Initialize process
 	std::vector<std::shared_ptr<lv2_prx>> loaded_modules;
 
@@ -1658,9 +1840,9 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		load_libs.emplace("libsysmodule.sprx");
 	}
 
-	if (g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
+	if (ar || g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
 	{
-		// Cannot be used with vsh.self (it self-manages itself)
+		// Cannot be used with vsh.self or savestates (they self-manage itself)
 		load_libs.clear();
 	}
 
@@ -1676,6 +1858,25 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 	// Program entry
 	u32 entry = 0;
 
+	// Set path (TODO)
+	_main.name.clear();
+	_main.path = vfs::get(Emu.argv[0]);
+
+	// Analyse executable (TODO)
+	_main.analyse(0, static_cast<u32>(elf.header.e_entry), end, applied);
+
+	// Validate analyser results (not required)
+	_main.validate(0);
+
+	// Set SDK version
+	g_ps3_process_info.sdk_ver = sdk_version;
+
+	// Set ppc fixed allocations segment permission
+	g_ps3_process_info.ppc_seg = ppc_seg;
+
+	void init_fxo_for_exec(utils::serial* ar, bool full);
+	init_fxo_for_exec(ar, false);
+
 	if (!load_libs.empty())
 	{
 		for (const auto& name : load_libs)
@@ -1686,7 +1887,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 			{
 				ppu_loader.warning("Loading library: %s", name);
 
-				auto prx = ppu_load_prx(obj, lle_dir + name, 0);
+				auto prx = ppu_load_prx(obj, lle_dir + name, 0, nullptr);
 
 				if (prx->funcs.empty())
 				{
@@ -1715,21 +1916,11 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		}
 	}
 
-	// Set path (TODO)
-	_main.name.clear();
-	_main.path = vfs::get(Emu.argv[0]);
-
-	// Analyse executable (TODO)
-	_main.analyse(0, static_cast<u32>(elf.header.e_entry), end, applied);
-
-	// Validate analyser results (not required)
-	_main.validate(0);
-
-	// Set SDK version
-	g_ps3_process_info.sdk_ver = sdk_version;
-
-	// Set ppc fixed allocations segment permission
-	g_ps3_process_info.ppc_seg = ppc_seg;
+	if (ar)
+	{
+		error_handler.errored = false;
+		return true;
+	}
 
 	if (ppc_seg != 0x0)
 	{
@@ -1804,44 +1995,6 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		ppu->gpr[1] -= Emu.data.size();
 	}
 
-	// Initialize memory stats (according to sdk version)
-	u32 mem_size;
-	if (g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
-	{
-		// Because vsh.self comes before any generic application, more memory is available to it
-		mem_size = 0xF000000;
-	}
-	else if (sdk_version > 0x0021FFFF)
-	{
-		mem_size = 0xD500000;
-	}
-	else if (sdk_version > 0x00192FFF)
-	{
-		mem_size = 0xD300000;
-	}
-	else if (sdk_version > 0x0018FFFF)
-	{
-		mem_size = 0xD100000;
-	}
-	else if (sdk_version > 0x0017FFFF)
-	{
-		mem_size = 0xD000000;
-	}
-	else if (sdk_version > 0x00154FFF)
-	{
-		mem_size = 0xCC00000;
-	}
-	else
-	{
-		mem_size = 0xC800000;
-	}
-
-	if (g_cfg.core.debug_console_mode)
-	{
-		// TODO: Check for all sdk versions
-		mem_size += 0xC000000;
-	}
-
 	if (Emu.init_mem_containers)
 	{
 		// Refer to sys_process_exit2 for explanation
@@ -1913,7 +2066,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 	return true;
 }
 
-std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object& elf, const std::string& path, s64 file_offset)
+std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object& elf, const std::string& path, s64 file_offset, utils::serial* ar)
 {
 	if (elf != elf_error::ok)
 	{
@@ -1975,7 +2128,17 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 			if (prog.bin.size() > size || prog.bin.size() != prog.p_filesz)
 				fmt::throw_exception("Invalid binary size (0x%llx, memsz=0x%x)", prog.bin.size(), size);
 
-			if (!vm::get(vm::any, 0x30000000)->falloc(addr, size))
+			const bool already_loaded = ar /*&& !!(_seg.flags & 0x2)*/;
+
+			if (already_loaded)
+			{
+				if (!vm::check_addr(addr, vm::page_readable, size))
+				{
+					ppu_loader.fatal("ppu_load_overlay(): Archived PPU overlay memory has not been found! (addr=0x%x, memsz=0x%x)", addr, size);
+					return {nullptr, CELL_EABORT};
+				}
+			}
+			else if (!vm::get(vm::any, 0x30000000)->falloc(addr, size))
 			{
 				ppu_loader.error("ppu_load_overlay(): vm::falloc() failed (addr=0x%x, memsz=0x%x)", addr, size);
 
@@ -1990,7 +2153,7 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 			}
 
 			// Copy segment data, hash it
-			std::memcpy(vm::base(addr), prog.bin.data(), prog.bin.size());
+			if (!already_loaded) std::memcpy(vm::base(addr), prog.bin.data(), prog.bin.size());
 			sha1_update(&sha, reinterpret_cast<const uchar*>(&prog.p_vaddr), sizeof(prog.p_vaddr));
 			sha1_update(&sha, reinterpret_cast<const uchar*>(&prog.p_memsz), sizeof(prog.p_memsz));
 			sha1_update(&sha, prog.bin.data(), prog.bin.size());
@@ -2158,9 +2321,11 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 	// Validate analyser results (not required)
 	ovlm->validate(0);
 
-	idm::import_existing<lv2_obj, lv2_overlay>(ovlm);
-
-	try_spawn_ppu_if_exclusive_program(*ovlm);
+	if (!ar)
+	{
+		idm::import_existing<lv2_obj, lv2_overlay>(ovlm);
+		try_spawn_ppu_if_exclusive_program(*ovlm);
+	}
 
 	return {std::move(ovlm), {}};
 }

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2461,7 +2461,7 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 				{
 					if (count > 20000 && g_cfg.core.perf_report) [[unlikely]]
 					{
-						perf_log.warning(u8"STCX: took too long: %.3fÂµs (%u c)", count / (utils::get_tsc_freq() / 1000'000.), count);
+						perf_log.warning(u8"STCX: took too long: %.3fµs (%u c)", count / (utils::get_tsc_freq() / 1000'000.), count);
 					}
 
 					break;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "Utilities/JIT.h"
 #include "Utilities/StrUtil.h"
+#include "util/serialization.hpp"
 #include "Crypto/sha1.h"
 #include "Crypto/unself.h"
 #include "Loader/ELF.h"
@@ -138,13 +139,28 @@ void fmt_class_string<typename ppu_thread::call_history_t>::format(std::string& 
 extern const ppu_decoder<ppu_itype> g_ppu_itype{};
 extern const ppu_decoder<ppu_iname> g_ppu_iname{};
 
+template <>
+bool serialize<ppu_thread::cr_bits>(utils::serial& ar, typename ppu_thread::cr_bits& o)
+{
+	if (ar.is_writing())
+	{
+		ar(o.pack());
+	}
+	else
+	{
+		o.unpack(ar);
+	}
+
+	return true;
+}
+
 extern void ppu_initialize();
 extern void ppu_finalize(const ppu_module& info);
 extern bool ppu_initialize(const ppu_module& info, bool = false);
 static void ppu_initialize2(class jit_compiler& jit, const ppu_module& module_part, const std::string& cache_path, const std::string& obj_name);
-extern std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object&, const std::string& path, s64 file_offset);
+extern std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object&, const std::string& path, s64 file_offset, utils::serial* = nullptr);
 extern void ppu_unload_prx(const lv2_prx&);
-extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, const std::string&, s64 file_offset);
+extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, const std::string&, s64 file_offset, utils::serial* = nullptr);
 extern void ppu_execute_syscall(ppu_thread& ppu, u64 code);
 static void ppu_break(ppu_thread&, ppu_opcode_t, be_t<u32>*, ppu_intrp_func*);
 
@@ -1351,6 +1367,12 @@ void ppu_thread::cpu_task()
 			cmd_pop(1), func(*this, {}, vm::_ptr<u32>(cia - 4), &ppu_ret);
 			break;
 		}
+		case ppu_cmd::cia_call:
+		{
+			loaded_from_savestate = true;
+			cmd_pop(), fast_call(std::exchange(cia, 0), gpr[2]);
+			break;
+		}
 		case ppu_cmd::initialize:
 		{
 #ifdef __APPLE__
@@ -1358,18 +1380,7 @@ void ppu_thread::cpu_task()
 #endif
 			cmd_pop();
 
-			while (!g_fxo->get<rsx::thread>().is_inited && !is_stopped())
-			{
-				// Wait for RSX to be initialized
-				thread_ctrl::wait_on(g_fxo->get<rsx::thread>().is_inited, false);
-			}
-
 			ppu_initialize(), spu_cache::initialize();
-
-			// Wait until the progress dialog is closed.
-			// We don't want to open a cell dialog while a native progress dialog is still open.
-			thread_ctrl::wait_on<atomic_wait::op_ne>(g_progr_ptotal, 0);
-			g_fxo->get<progress_dialog_workaround>().skip_the_progress_dialog = true;
 
 #ifdef __APPLE__
 			pthread_jit_write_protect_np(true);
@@ -1379,6 +1390,24 @@ void ppu_thread::cpu_task()
 			asm("ISB");
 			asm("DSB ISH");
 #endif
+
+			// Wait until the progress dialog is closed.
+			// We don't want to open a cell dialog while a native progress dialog is still open.
+			thread_ctrl::wait_on<atomic_wait::op_ne>(g_progr_ptotal, 0);
+			g_fxo->get<progress_dialog_workaround>().skip_the_progress_dialog = true;
+
+			// Sadly we can't postpone initializing guest time because we need ti run PPU threads
+			// (the farther it's postponed, the less accuracy of guest time has been lost)
+			Emu.FixGuestTime();
+
+			// Check if this is the only PPU left to initialize (savestates related)
+			if (lv2_obj::is_scheduler_ready())
+			{
+				if (Emu.IsStarting())
+				{
+					Emu.FinalizeRunRequest();
+				}
+			}
 
 			break;
 		}
@@ -1484,6 +1513,7 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 	, joiner(detached != 0 ? ppu_join_status::detached : ppu_join_status::joinable)
 	, entry_func(param.entry)
 	, start_time(get_guest_system_time())
+	, is_interrupt_thread(detached < 0)
 	, ppu_tname(make_single<std::string>(name))
 {
 	gpr[1] = stack_addr + stack_size - ppu_stack_start_offset;
@@ -1518,6 +1548,195 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 	asm("ISB");
 	asm("DSB ISH");
 #endif
+}
+
+struct disable_precomp_t
+{
+	atomic_t<bool> disable = false;
+};
+
+void vdecEntry(ppu_thread& ppu, u32 vid);
+
+bool ppu_thread::savable() const
+{
+	if (joiner == ppu_join_status::exited)
+	{
+		return false;
+	}
+
+	if (cia == g_fxo->get<ppu_function_manager>().func_addr(FIND_FUNC(vdecEntry)))
+	{
+		// Do not attempt to save the state of HLE VDEC threads
+		return false;
+	}
+
+	return true;
+}
+
+void ppu_thread::serialize_common(utils::serial& ar)
+{
+	ar(gpr, fpr, cr, fpscr.bits, lr, ctr, vrsave, cia, xer, sat, nj, prio, optional_syscall_state);
+
+	for (v128& reg : vr)
+		ar(reg._bytes);
+}
+
+ppu_thread::ppu_thread(utils::serial& ar)
+	: cpu_thread(idm::last_id()) // last_id() is showed to constructor on serialization
+	, stack_size(ar)
+	, stack_addr(ar)
+	, joiner(ar.operator ppu_join_status())
+	, entry_func(std::bit_cast<ppu_func_opd_t, u64>(ar))
+	, is_interrupt_thread(ar)
+{
+	struct init_pushed
+	{
+		bool pushed = false;
+		atomic_t<bool> inited = false;
+	};
+
+	serialize_common(ar);
+
+	// Restore jm_mask
+	jm_mask = nj ? 0x7F800000 : 0x7fff'ffff;
+
+	auto queue_intr_entry = [&]()
+	{
+		if (is_interrupt_thread)
+		{
+			void ppu_interrupt_thread_entry(ppu_thread&, ppu_opcode_t, be_t<u32>*, struct ppu_intrp_func*);
+
+			cmd_list
+			({
+				{ ppu_cmd::ptr_call, 0 },
+				std::bit_cast<u64>(&ppu_interrupt_thread_entry)
+			});
+		}
+	};
+
+	switch (const u32 status = ar.operator u32())
+	{
+	case PPU_THREAD_STATUS_IDLE:
+	{
+		stop_flag_removal_protection = true;
+		break;
+	}
+	case PPU_THREAD_STATUS_RUNNABLE:
+	case PPU_THREAD_STATUS_ONPROC:
+	{
+		lv2_obj::awake(this);
+		[[fallthrough]];
+	}
+	case PPU_THREAD_STATUS_SLEEP:
+	{
+		if (std::exchange(g_fxo->get<init_pushed>().pushed, true))
+		{
+			cmd_list
+			({
+				{ppu_cmd::ptr_call, 0}, +[](ppu_thread& ppu) -> bool
+				{
+					while (!Emu.IsStopped() && !g_fxo->get<init_pushed>().inited)
+					{
+						thread_ctrl::wait_on(g_fxo->get<init_pushed>().inited, false);
+					}
+					return false;
+				}
+			});
+		}
+		else
+		{
+			g_fxo->init<disable_precomp_t>();
+			g_fxo->get<disable_precomp_t>().disable = true;
+
+			cmd_push({ppu_cmd::initialize, 0});
+			cmd_list
+			({
+				{ppu_cmd::ptr_call, 0}, +[](ppu_thread&) -> bool
+				{
+					auto& inited = g_fxo->get<init_pushed>().inited;
+					inited = true;
+					inited.notify_all();
+					return true;
+				}
+			});
+		}
+
+		if (status == PPU_THREAD_STATUS_SLEEP)
+		{
+			cmd_list
+			({
+				{ppu_cmd::ptr_call, 0},
+
+				+[](ppu_thread& ppu) -> bool
+				{
+					ppu.loaded_from_savestate = true;
+					ppu_execute_syscall(ppu, ppu.gpr[11]);
+					ppu.loaded_from_savestate = false;
+					return true;
+				}
+			});
+
+			lv2_obj::set_future_sleep(this);
+		}
+
+		queue_intr_entry();
+		cmd_push({ppu_cmd::cia_call, 0});
+		break;
+	}
+	case PPU_THREAD_STATUS_ZOMBIE:
+	{
+		state += cpu_flag::exit;
+		break;
+	}
+	case PPU_THREAD_STATUS_STOP:
+	{
+		queue_intr_entry();
+		break;
+	}
+	}
+
+	// Trigger the scheduler
+	state += cpu_flag::suspend;
+
+	if (!g_use_rtm)
+	{
+		state += cpu_flag::memory;
+	}
+
+	ppu_tname = make_single<std::string>(ar.operator std::string());
+}
+
+void ppu_thread::save(utils::serial& ar)
+{
+	const u64 entry = std::bit_cast<u64>(entry_func);
+
+	ppu_join_status _joiner = joiner;
+	if (_joiner >= ppu_join_status::max)
+	{
+		// Joining thread should recover this member properly
+		_joiner = ppu_join_status::joinable; 
+	}
+
+	if (state & cpu_flag::again)
+	{
+		std::memcpy(&gpr[3], syscall_args, sizeof(syscall_args));
+		cia -= 4;
+	}
+
+	ar(stack_size, stack_addr, _joiner, entry, is_interrupt_thread);
+	serialize_common(ar);
+
+	ppu_thread_status status = lv2_obj::ppu_state(this, false);
+
+	if (status == PPU_THREAD_STATUS_SLEEP && cpu_flag::again - state)
+	{
+		// Hack for sys_fs
+		status = PPU_THREAD_STATUS_RUNNABLE;
+	}
+
+	ar(status);
+
+	ar(*ppu_tname.load());
 }
 
 ppu_thread::thread_name_t::operator std::string() const
@@ -1596,7 +1815,7 @@ be_t<u64>* ppu_thread::get_stack_arg(s32 i, u64 align)
 	return vm::_ptr<u64>(vm::cast((gpr[1] + 0x30 + 0x8 * (i - 1)) & (0 - align)));
 }
 
-void ppu_thread::fast_call(u32 addr, u32 rtoc)
+void ppu_thread::fast_call(u32 addr, u64 rtoc)
 {
 	const auto old_cia = cia;
 	const auto old_rtoc = gpr[2];
@@ -1604,10 +1823,16 @@ void ppu_thread::fast_call(u32 addr, u32 rtoc)
 	const auto old_func = current_function;
 	const auto old_fmt = g_tls_log_prefix;
 
+	interrupt_thread_executing = true;
 	cia = addr;
 	gpr[2] = rtoc;
 	lr = g_fxo->get<ppu_function_manager>().func_addr(1) + 4; // HLE stop address
 	current_function = nullptr;
+
+	if (std::exchange(loaded_from_savestate, false))
+	{
+		lr = old_lr;
+	}
 
 	g_tls_log_prefix = []
 	{
@@ -1643,15 +1868,21 @@ void ppu_thread::fast_call(u32 addr, u32 rtoc)
 			cpu_on_stop();
 			current_function = old_func;
 		}
-		else
+		else if (old_cia)
 		{
-			state -= cpu_flag::ret;
+			if (state & cpu_flag::exit)
+			{
+				ppu_log.error("HLE callstack savestate is not implemented!");
+			}
+
 			cia = old_cia;
 			gpr[2] = old_rtoc;
 			lr = old_lr;
-			current_function = old_func;
-			g_tls_log_prefix = old_fmt;
 		}
+
+		current_function = old_func;
+		g_tls_log_prefix = old_fmt;
+		state -= cpu_flag::ret;
 	};
 
 	exec_task();
@@ -2230,7 +2461,7 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 				{
 					if (count > 20000 && g_cfg.core.perf_report) [[unlikely]]
 					{
-						perf_log.warning(u8"STCX: took too long: %.3fµs (%u c)", count / (utils::get_tsc_freq() / 1000'000.), count);
+						perf_log.warning(u8"STCX: took too long: %.3fÂµs (%u c)", count / (utils::get_tsc_freq() / 1000'000.), count);
 					}
 
 					break;
@@ -2466,6 +2697,13 @@ namespace
 	};
 }
 
+extern fs::file make_file_view(fs::file&& _file, u64 offset)
+{
+	fs::file file;
+	file.reset(std::make_unique<file_view>(std::move(_file), offset));
+	return file;
+}
+
 extern void ppu_finalize(const ppu_module& info)
 {
 	// Get cache path for this executable
@@ -2503,9 +2741,14 @@ extern void ppu_finalize(const ppu_module& info)
 #endif
 }
 
-extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_prx*>* loaded_prx)
+extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_module*>* loaded_modules)
 {
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::llvm)
+	{
+		return;
+	}
+
+	if (auto dis = g_fxo->try_get<disable_precomp_t>(); dis && dis->disable)
 	{
 		return;
 	}
@@ -2560,53 +2803,48 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_
 
 			std::string upper = fmt::to_upper(entry.name);
 
+			// Skip already loaded modules or HLEd ones
+			auto is_ignored = [&](s64 offset) -> bool
+			{
+				if (dir_queue[i] != firmware_sprx_path)
+				{
+					return false;
+				}
+
+				if (loaded_modules)
+				{
+					if (std::any_of(loaded_modules->begin(), loaded_modules->end(), [&](ppu_module* obj)
+					{
+						return obj->name == entry.name;
+					}))
+					{
+						return true;
+					}
+				}
+
+				if (g_cfg.core.libraries_control.get_set().count(entry.name + ":lle"))
+				{
+					// Force LLE
+					return false;
+				}
+				else if (g_cfg.core.libraries_control.get_set().count(entry.name + ":hle"))
+				{
+					// Force HLE
+					return true;
+				}
+
+				extern const std::map<std::string_view, int> g_prx_list;
+
+				// Use list
+				return g_prx_list.count(entry.name) && g_prx_list.at(entry.name) != 0;
+			};
+
 			// Check .sprx filename
 			if (upper.ends_with(".SPRX") && entry.name != "libfs_utility_init.sprx"sv)
 			{
-				// Skip already loaded modules or HLEd ones
-				if (dir_queue[i] == firmware_sprx_path)
+				if (is_ignored(0))
 				{
-					bool ignore = false;
-
-					if (loaded_prx)
-					{
-						for (auto* obj : *loaded_prx)
-						{
-							if (obj->name == entry.name)
-							{
-								ignore = true;
-								break;
-							}
-						}
-
-						if (ignore)
-						{
-							continue;
-						}
-					}
-
-					if (g_cfg.core.libraries_control.get_set().count(entry.name + ":lle"))
-					{
-						// Force LLE
-						ignore = false;
-					}
-					else if (g_cfg.core.libraries_control.get_set().count(entry.name + ":hle"))
-					{
-						// Force HLE
-						ignore = true;
-					}
-					else
-					{
-						extern const std::map<std::string_view, int> g_prx_list;
-
-						// Use list
-						ignore = g_prx_list.count(entry.name) && g_prx_list.at(entry.name) != 0;
-					}
-
-					if (ignore)
-					{
-						continue;
-					}
+					continue;
 				}
 
 				// Get full path
@@ -2800,8 +3038,6 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_
 
 extern void ppu_initialize()
 {
-	auto& _main = g_fxo->get<ppu_module>();
-
 	if (!g_fxo->is_init<ppu_module>())
 	{
 		return;
@@ -2811,6 +3047,8 @@ extern void ppu_initialize()
 	{
 		return;
 	}
+
+	auto& _main = g_fxo->get<ppu_module>();
 
 	scoped_progress_dialog progr = "Scanning PPU modules...";
 
@@ -2822,20 +3060,39 @@ extern void ppu_initialize()
 		compile_main = ppu_initialize(_main, true);
 	}
 
-	std::vector<lv2_prx*> prx_list;
+	std::vector<ppu_module*> module_list;
 
-	idm::select<lv2_obj, lv2_prx>([&](u32, lv2_prx& prx)
+	const std::string firmware_sprx_path = vfs::get("/dev_flash/sys/external/");
+
+	// If empty we have no indication for firmware cache state, check everything
+	bool compile_fw = true;
+
+	idm::select<lv2_obj, lv2_prx>([&](u32, lv2_prx& _module)
 	{
-		prx_list.emplace_back(&prx);
+		if (_module.path.starts_with(firmware_sprx_path))
+		{
+			// Postpone testing
+			compile_fw = false;
+		}
+
+		module_list.emplace_back(&_module);
 	});
 
-	// If empty we have no indication for cache state, check everything
-	bool compile_fw = prx_list.empty();
+	idm::select<lv2_obj, lv2_overlay>([&](u32, lv2_overlay& _module)
+	{
+		module_list.emplace_back(&_module);
+	});
 
 	// Check preloaded libraries cache
-	for (auto ptr : prx_list)
+	if (!compile_fw)
 	{
-		compile_fw |= ppu_initialize(*ptr, true);
+		for (auto ptr : module_list)
+		{
+			if (ptr->path.starts_with(firmware_sprx_path))
+			{
+				compile_fw |= ppu_initialize(*ptr, true);
+			}
+		}
 	}
 
 	std::vector<std::string> dir_queue;
@@ -2871,7 +3128,7 @@ extern void ppu_initialize()
 		dir_queue.insert(std::end(dir_queue), std::begin(dirs), std::end(dirs));
 	}
 
-	ppu_precompile(dir_queue, &prx_list);
+	ppu_precompile(dir_queue, &module_list);
 
 	if (Emu.IsStopped())
 	{
@@ -2885,7 +3142,7 @@ extern void ppu_initialize()
 	}
 
 	// Initialize preloaded libraries
-	for (auto ptr : prx_list)
+	for (auto ptr : module_list)
 	{
 		if (Emu.IsStopped())
 		{

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -20,6 +20,7 @@ enum class ppu_cmd : u32
 	hle_call, // Execute function by index (arg)
 	ptr_call, // Execute function by pointer
 	opd_call, // Execute function by provided rtoc and address (unlike lle_call, does not read memory)
+	cia_call, // Execute from current CIA, mo GPR modification applied
 	initialize, // ppu_initialize()
 	sleep,
 	reset_stack, // resets stack address
@@ -140,10 +141,15 @@ public:
 	virtual void cpu_on_stop() override;
 	virtual ~ppu_thread() override;
 
-	ppu_thread(const ppu_thread_params&, std::string_view name, u32 prio, int detached = 0);
+	SAVESTATE_INIT_POS(3);
 
+	ppu_thread(const ppu_thread_params&, std::string_view name, u32 prio, int detached = 0);
+	ppu_thread(utils::serial& ar);
 	ppu_thread(const ppu_thread&) = delete;
 	ppu_thread& operator=(const ppu_thread&) = delete;
+	bool savable() const;
+	void serialize_common(utils::serial& ar);
+	void save(utils::serial& ar);
 
 	using cpu_thread::operator=;
 
@@ -180,8 +186,8 @@ public:
 		{
 			for (u8& b : bits)
 			{
-				b = value & 0x1;
-				value >>= 1;
+				b = !!(value & (1u << 31));
+				value <<= 1;
 			}
 		}
 	};
@@ -215,6 +221,8 @@ public:
 	// Fixed-Point Exception Register (abstract representation)
 	struct
 	{
+		ENABLE_BITWISE_SERIALIZATION;
+
 		bool so{}; // Summary Overflow
 		bool ov{}; // Overflow
 		bool ca{}; // Carry
@@ -266,6 +274,8 @@ public:
 	const char* current_function{}; // Current function name for diagnosis, optimized for speed.
 	const char* last_function{}; // Sticky copy of current_function, is not cleared on function return
 
+	const bool is_interrupt_thread; // True for interrupts-handler threads
+
 	// Thread name
 	atomic_ptr<std::string> ppu_tname;
 
@@ -307,9 +317,15 @@ public:
 		operator std::string() const;
 	} thread_name{ this };
 
+	// For savestates
+	bool stop_flag_removal_protection = false; // If set, Emulator::Run won't remove stop flag 
+	bool loaded_from_savestate = false; // Indicates the thread had just started straight from savestate load
+	u64 optional_syscall_state{};
+	bool interrupt_thread_executing = false;
+
 	be_t<u64>* get_stack_arg(s32 i, u64 align = alignof(u64));
 	void exec_task();
-	void fast_call(u32 addr, u32 rtoc);
+	void fast_call(u32 addr, u64 rtoc);
 
 	static std::pair<vm::addr_t, u32> stack_push(u32 size, u32 align_v);
 	static void stack_pop_verbose(u32 addr, u32 size) noexcept;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -27,11 +27,13 @@
 #include <cfenv>
 #include <thread>
 #include <shared_mutex>
+#include <span>
 #include "util/vm.hpp"
 #include "util/asm.hpp"
 #include "util/v128.hpp"
 #include "util/simd.hpp"
 #include "util/sysinfo.hpp"
+#include "util/serialization.hpp"
 
 using spu_rdata_t = decltype(spu_thread::rdata);
 
@@ -1623,63 +1625,28 @@ spu_thread::~spu_thread()
 	shm->unmap(ls + SPU_LS_SIZE);
 	shm->unmap(ls);
 	shm->unmap(ls - SPU_LS_SIZE);
+	utils::memory_release(ls - SPU_LS_SIZE * 2, SPU_LS_SIZE * 5);
 
 	perf_log.notice("Perf stats for transactions: success %u, failure %u", stx, ftx);
 	perf_log.notice("Perf stats for PUTLLC reload: successs %u, failure %u", last_succ, last_fail);
+}
+
+u8* spu_thread::map_ls(utils::shm& shm)
+{
+	vm::writer_lock mlock;
+
+	const auto ls = static_cast<u8*>(ensure(utils::memory_reserve(SPU_LS_SIZE * 5, nullptr, true))) + SPU_LS_SIZE * 2;
+	ensure(shm.map_critical(ls - SPU_LS_SIZE).first && shm.map_critical(ls).first && shm.map_critical(ls + SPU_LS_SIZE).first);
+	return ls;
 }
 
 spu_thread::spu_thread(lv2_spu_group* group, u32 index, std::string_view name, u32 lv2_id, bool is_isolated, u32 option)
 	: cpu_thread(idm::last_id())
 	, group(group)
 	, index(index)
-	, shm(std::make_shared<utils::shm>(SPU_LS_SIZE))
-	, ls([&]()
-	{
-		if (!group)
-		{
-			ensure(vm::get(vm::spu)->falloc(vm_offset(), SPU_LS_SIZE, &shm, vm::page_size_64k));
-		}
-		else
-		{
-			// alloc_hidden indicates falloc to allocate page with no access rights in base memory
-			ensure(vm::get(vm::spu)->falloc(vm_offset(), SPU_LS_SIZE, &shm, static_cast<u64>(vm::page_size_64k) | static_cast<u64>(vm::alloc_hidden)));
-		}
-
-		// Try to guess free area
-		const auto start = vm::g_free_addr + SPU_LS_SIZE * (cpu_thread::id & 0xffffff) * 12;
-
-		u32 total = 0;
-
-		// Map LS and its mirrors
-		for (u64 addr = reinterpret_cast<u64>(start); addr < 0x8000'0000'0000;)
-		{
-			if (auto ptr = shm->try_map(reinterpret_cast<u8*>(addr)))
-			{
-				if (++total == 3)
-				{
-					// Use the middle mirror
-					return ptr - SPU_LS_SIZE;
-				}
-
-				addr += SPU_LS_SIZE;
-			}
-			else
-			{
-				// Reset, cleanup and start again
-				for (u32 i = 1; i <= total; i++)
-				{
-					shm->unmap(reinterpret_cast<u8*>(addr - i * SPU_LS_SIZE));
-				}
-
-				total = 0;
-
-				addr += 0x10000;
-			}
-		}
-
-		fmt::throw_exception("Failed to map SPU LS memory");
-	}())
 	, thread_type(group ? spu_type::threaded : is_isolated ? spu_type::isolated : spu_type::raw)
+	, shm(std::make_shared<utils::shm>(SPU_LS_SIZE))
+	, ls(map_ls(*this->shm))
 	, option(option)
 	, lv2_id(lv2_id)
 	, spu_tname(make_single<std::string>(name))
@@ -1688,10 +1655,24 @@ spu_thread::spu_thread(lv2_spu_group* group, u32 index, std::string_view name, u
 	{
 		jit = spu_recompiler_base::make_asmjit_recompiler();
 	}
-
-	if (g_cfg.core.spu_decoder == spu_decoder_type::llvm)
+	else if (g_cfg.core.spu_decoder == spu_decoder_type::llvm)
 	{
 		jit = spu_recompiler_base::make_fast_llvm_recompiler();
+	}
+
+	if (g_cfg.core.mfc_debug)
+	{
+		utils::memory_commit(vm::g_stat_addr + vm_offset(), SPU_LS_SIZE);
+	}
+
+	if (!group)
+	{
+		ensure(vm::get(vm::spu)->falloc(vm_offset(), SPU_LS_SIZE, &shm, vm::page_size_64k));
+	}
+	else
+	{
+		// alloc_hidden indicates falloc to allocate page with no access rights in base memory
+		ensure(vm::get(vm::spu)->falloc(vm_offset(), SPU_LS_SIZE, &shm, static_cast<u64>(vm::page_size_64k) | static_cast<u64>(vm::alloc_hidden)));
 	}
 
 	if (g_cfg.core.spu_decoder == spu_decoder_type::asmjit || g_cfg.core.spu_decoder == spu_decoder_type::llvm)
@@ -1714,6 +1695,165 @@ spu_thread::spu_thread(lv2_spu_group* group, u32 index, std::string_view name, u
 	}
 
 	range_lock = vm::alloc_range_lock();
+}
+
+void spu_thread::serialize_common(utils::serial& ar)
+{
+	for (v128& reg : gpr)
+		ar(reg._bytes);
+	
+	ar(pc, ch_mfc_cmd, mfc_size, mfc_barrier, mfc_fence, mfc_prxy_cmd, mfc_prxy_mask, mfc_prxy_write_state.all
+	, srr0
+	, ch_tag_upd
+	, ch_tag_mask
+	, ch_tag_stat.data
+	, ch_stall_mask
+	, ch_stall_stat.data
+	, ch_atomic_stat.data
+	, ch_out_mbox.data
+	, ch_out_intr_mbox.data
+	, snr_config
+
+	, ch_snr1.data
+	, ch_snr2.data
+	, ch_events.raw().all
+	, interrupts_enabled
+	, run_ctrl
+	, exit_status.data
+	, status_npc.raw().status);
+
+	std::for_each_n(mfc_queue, mfc_size, [&](spu_mfc_cmd& cmd) { ar(cmd); });
+}
+
+spu_thread::spu_thread(utils::serial& ar, lv2_spu_group* group)
+	: cpu_thread(idm::last_id())
+	, group(group)
+	, index(ar)
+	, thread_type(group ? spu_type::threaded : ar.operator u8() ? spu_type::isolated : spu_type::raw)
+	, shm(ensure(vm::get(vm::spu)->peek(vm_offset()).second))
+	, ls(map_ls(*this->shm))
+	, option(ar)
+	, lv2_id(ar)
+	, spu_tname(make_single<std::string>(ar.operator std::string()))
+{
+	if (g_cfg.core.spu_decoder == spu_decoder_type::asmjit)
+	{
+		jit = spu_recompiler_base::make_asmjit_recompiler();
+	}
+	else if (g_cfg.core.spu_decoder == spu_decoder_type::llvm)
+	{
+		jit = spu_recompiler_base::make_fast_llvm_recompiler();
+	}
+
+	if (g_cfg.core.mfc_debug)
+	{
+		utils::memory_commit(vm::g_stat_addr + vm_offset(), SPU_LS_SIZE);
+	}
+
+	if (g_cfg.core.spu_decoder != spu_decoder_type::_static && g_cfg.core.spu_decoder != spu_decoder_type::dynamic)
+	{
+		if (g_cfg.core.spu_block_size != spu_block_size_type::safe)
+		{
+			// Initialize stack mirror
+			std::memset(stack_mirror.data(), 0xff, sizeof(stack_mirror));
+		}
+	}
+
+	if (get_type() >= spu_type::raw)
+	{
+		cpu_init();
+	}
+
+	range_lock = vm::alloc_range_lock();
+
+	serialize_common(ar);
+
+	{
+		u32 vals[4]{};
+		const u8 count = ar;
+		ar(std::span(vals, count));
+		ch_in_mbox.set_values(count, vals[0], vals[1], vals[2], vals[3]);
+	}
+
+	status_npc.raw().npc = pc | u8{interrupts_enabled};
+
+	if (get_type() == spu_type::threaded)
+	{
+		for (auto& pair : spuq)
+		{
+			ar(pair.first);
+			pair.second = idm::get_unlocked<lv2_obj, lv2_event_queue>(ar.operator u32());
+		}
+
+		for (auto& q : spup)
+		{
+			q = idm::get_unlocked<lv2_obj, lv2_event_queue>(ar.operator u32());
+		}
+	}
+	else
+	{
+		for (spu_int_ctrl_t& ctrl : int_ctrl)
+		{
+			ar(ctrl.mask, ctrl.stat);
+			ctrl.tag = idm::get_unlocked<lv2_obj, lv2_int_tag>(ar.operator u32());
+		}
+
+		g_raw_spu_ctr++;
+		g_raw_spu_id[index] = id;
+	}
+
+	ar(stop_flag_removal_protection);
+}
+
+void spu_thread::save(utils::serial& ar)
+{
+	USING_SERIALIZATION_VERSION(spu);
+
+	if (raddr)
+	{
+		// Lose reservation at savestate load with an event if one existed at savestate save
+		set_events(SPU_EVENT_LR);
+	}
+
+	ar(index);
+
+	if (get_type() != spu_type::threaded)
+	{
+		ar(u8{get_type() == spu_type::isolated});
+	}
+
+	ar(option, lv2_id, *spu_tname.load());
+
+	serialize_common(ar);
+
+	{
+		u32 vals[4]{};
+		const u8 count = ch_in_mbox.try_read(vals);
+		ar(count, std::span(vals, count));
+	}
+
+	if (get_type() == spu_type::threaded)
+	{
+		for (const auto& [key, q] : spuq)
+		{
+			ar(key);
+			ar(lv2_obj::check(q) ? q->id : 0);
+		}
+
+		for (auto& p : spup)
+		{
+			ar(lv2_obj::check(p) ? p->id : 0);
+		}
+	}
+	else
+	{
+		for (const spu_int_ctrl_t& ctrl : int_ctrl)
+		{
+			ar(ctrl.mask, ctrl.stat, lv2_obj::check(ctrl.tag) ? ctrl.tag->id : 0);
+		}
+	}
+
+	ar(!!(state & cpu_flag::stop));
 }
 
 void spu_thread::push_snr(u32 number, u32 value)
@@ -3408,7 +3548,8 @@ bool spu_thread::process_mfc_cmd()
 			std::memcpy(dump.data, _ptr<u8>(ch_mfc_cmd.lsa & 0x3ff80), 128);
 		}
 
-		return !test_stopped();
+		static_cast<void>(test_stopped());
+		return true;
 	}
 	case MFC_PUTLLUC_CMD:
 	{
@@ -3422,7 +3563,8 @@ bool spu_thread::process_mfc_cmd()
 
 		do_putlluc(ch_mfc_cmd);
 		ch_atomic_stat.set_value(MFC_PUTLLUC_SUCCESS);
-		return !test_stopped();
+		static_cast<void>(test_stopped());
+		return true;
 	}
 	case MFC_PUTQLLUC_CMD:
 	{
@@ -4161,6 +4303,11 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 					spu_log.warning("sys_spu_thread_send_event(spup=%d, data0=0x%x, data1=0x%x): error (%s)", spup, (value & 0x00ffffff), data, res);
 				}
 
+				if (res == CELL_EAGAIN)
+				{
+					return false;
+				}
+
 				ch_in_mbox.set_values(1, res);
 				return true;
 			}
@@ -4183,6 +4330,12 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 				// TODO: check passing spup value
 				if (auto res = queue ? queue->send(SYS_SPU_THREAD_EVENT_USER_KEY, lv2_id, (u64{spup} << 32) | (value & 0x00ffffff), data) : CELL_ENOTCONN)
 				{
+					if (res == CELL_EAGAIN)
+					{
+						ch_out_mbox.set_value(data);
+						return false;
+					}
+
 					spu_log.warning("sys_spu_thread_throw_event(spup=%d, data0=0x%x, data1=0x%x) failed (error=%s)", spup, (value & 0x00ffffff), data, res);
 				}
 
@@ -4207,6 +4360,12 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 				// Use the syscall to set flag
 				const auto res = ch_in_mbox.get_count() ? CELL_EBUSY : 0u + sys_event_flag_set(*this, data, 1ull << flag);
 
+				if (res == CELL_EAGAIN)
+				{
+					ch_out_mbox.set_value(data);
+					return false;
+				}
+
 				if (res == CELL_EBUSY)
 				{
 					spu_log.warning("sys_event_flag_set_bit(value=0x%x (flag=%d)): In_MBox is not empty (%d)", value, flag, ch_in_mbox.get_count());
@@ -4230,7 +4389,12 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 				spu_log.trace("sys_event_flag_set_bit_impatient(id=%d, value=0x%x (flag=%d))", data, value, flag);
 
 				// Use the syscall to set flag
-				sys_event_flag_set(*this, data, 1ull << flag);
+				if (sys_event_flag_set(*this, data, 1ull << flag) + 0u == CELL_EAGAIN)
+				{
+					ch_out_mbox.set_value(data);
+					return false;
+				}
+
 				return true;
 			}
 			else
@@ -4570,7 +4734,7 @@ bool spu_thread::stop_and_signal(u32 code)
 
 		u32 spuq = 0;
 
-		if (!ch_out_mbox.try_pop(spuq))
+		if (!ch_out_mbox.try_read(spuq))
 		{
 			fmt::throw_exception("sys_spu_thread_receive_event(): Out_MBox is empty");
 		}
@@ -4580,6 +4744,20 @@ bool spu_thread::stop_and_signal(u32 code)
 			spu_log.error("sys_spu_thread_receive_event(): In_MBox is not empty (%d)", count);
 			return ch_in_mbox.set_values(1, CELL_EBUSY), true;
 		}
+
+		struct clear_mbox
+		{
+			spu_thread& _this;
+
+			~clear_mbox() noexcept
+			{
+				if (cpu_flag::again - _this.state)
+				{
+					u32 val = 0;
+					_this.ch_out_mbox.try_pop(val);
+				}
+			}
+		} clear{*this};
 
 		spu_log.trace("sys_spu_thread_receive_event(spuq=0x%x)", spuq);
 
@@ -4606,6 +4784,7 @@ bool spu_thread::stop_and_signal(u32 code)
 
 				if (is_stopped(old))
 				{
+					state += cpu_flag::again;
 					return false;
 				}
 
@@ -4624,6 +4803,7 @@ bool spu_thread::stop_and_signal(u32 code)
 
 			if (is_stopped())
 			{
+				state += cpu_flag::again;
 				return false;
 			}
 
@@ -4675,14 +4855,24 @@ bool spu_thread::stop_and_signal(u32 code)
 
 		while (auto old = state.fetch_sub(cpu_flag::signal))
 		{
-			if (is_stopped(old))
-			{
-				return false;
-			}
-
 			if (old & cpu_flag::signal)
 			{
 				break;
+			}
+
+			if (is_stopped(old))
+			{
+				std::lock_guard qlock(queue->mutex);
+
+				old = state.fetch_sub(cpu_flag::signal);
+
+				if (old & cpu_flag::signal)
+				{
+					break;
+				}
+
+				state += cpu_flag::again;
+				return false;
 			}
 
 			thread_ctrl::wait_on(state, old);
@@ -4797,6 +4987,7 @@ bool spu_thread::stop_and_signal(u32 code)
 
 				if (is_stopped(old))
 				{
+					ch_out_mbox.set_value(value);
 					return false;
 				}
 

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1190,6 +1190,7 @@ DECLARE(lv2_obj::g_mutex);
 DECLARE(lv2_obj::g_ppu);
 DECLARE(lv2_obj::g_pending);
 DECLARE(lv2_obj::g_waiting);
+DECLARE(lv2_obj::g_to_sleep);
 
 thread_local DECLARE(lv2_obj::g_to_awake);
 
@@ -1256,6 +1257,32 @@ void lv2_obj::sleep_unlocked(cpu_thread& thread, u64 timeout)
 		// Find and remove the thread
 		if (!unqueue(g_ppu, ppu))
 		{
+			if (unqueue(g_to_sleep, ppu))
+			{
+				ppu->start_time = start_time;
+
+				std::string out = fmt::format("Threads (%d):", g_to_sleep.size());
+				for (auto thread : g_to_sleep)
+				{
+					fmt::append(out, " 0x%x,", thread->id);
+				}
+
+				ppu_log.warning("%s", out);
+
+				if (g_to_sleep.empty())
+				{
+					// All threads are ready, wake threads
+					Emu.CallFromMainThread([]
+					{
+						if (Emu.IsStarting())
+						{
+							// It uses lv2_obj::g_mutex, run it on main thread
+							Emu.FinalizeRunRequest();
+						}
+					});
+				}
+			}
+
 			// Already sleeping
 			ppu_log.trace("sleep(): called on already sleeping thread.");
 			return;
@@ -1438,11 +1465,12 @@ void lv2_obj::cleanup()
 	g_ppu.clear();
 	g_pending.clear();
 	g_waiting.clear();
+	g_to_sleep.clear();
 }
 
 void lv2_obj::schedule_all()
 {
-	if (g_pending.empty())
+	if (g_pending.empty() && g_to_sleep.empty())
 	{
 		// Wake up threads
 		for (usz i = 0, x = std::min<usz>(g_cfg.core.ppu_threads, g_ppu.size()); i < x; i++)
@@ -1486,7 +1514,7 @@ ppu_thread_status lv2_obj::ppu_state(ppu_thread* ppu, bool lock_idm, bool lock_l
 		opt_lock[0].emplace(id_manager::g_mutex);
 	}
 
-	if (ppu->state & cpu_flag::stop)
+	if (!Emu.IsReady() ? ppu->state.all_of(cpu_flag::stop) : ppu->stop_flag_removal_protection)
 	{
 		return PPU_THREAD_STATUS_IDLE;
 	}
@@ -1507,6 +1535,11 @@ ppu_thread_status lv2_obj::ppu_state(ppu_thread* ppu, bool lock_idm, bool lock_l
 
 	if (it == g_ppu.end())
 	{
+		if (!ppu->interrupt_thread_executing)
+		{
+			return PPU_THREAD_STATUS_STOP;
+		}
+
 		return PPU_THREAD_STATUS_SLEEP;
 	}
 
@@ -1516,4 +1549,15 @@ ppu_thread_status lv2_obj::ppu_state(ppu_thread* ppu, bool lock_idm, bool lock_l
 	}
 
 	return PPU_THREAD_STATUS_ONPROC;
+}
+
+void lv2_obj::set_future_sleep(ppu_thread* ppu)
+{
+	g_to_sleep.emplace_back(ppu);
+}
+
+bool lv2_obj::is_scheduler_ready()
+{
+	reader_lock lock(g_mutex);
+	return g_to_sleep.empty();
 }

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -1,13 +1,71 @@
 #include "stdafx.h"
 #include "sys_cond.h"
 
+#include "util/serialization.hpp"
 #include "Emu/IdManager.h"
 #include "Emu/IPC.h"
+#include "Emu/System.h"
 
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 
 LOG_CHANNEL(sys_cond);
+
+lv2_cond::lv2_cond(utils::serial& ar)
+	: key(ar)
+	, name(ar)
+	, mtx_id(ar)
+	, mutex(idm::get_unlocked<lv2_obj, lv2_mutex>(mtx_id)) // May be nullptr
+{
+}
+
+CellError lv2_cond::on_id_create()
+{
+	exists++;
+
+	static auto do_it = [](lv2_cond* _this) -> CellError
+	{
+		if (lv2_obj::check(_this->mutex))
+		{
+			_this->mutex->cond_count++;
+			return {};
+		}
+
+		// Mutex has been destroyed, cannot create conditional variable
+		return CELL_ESRCH;
+	};
+
+	if (mutex)
+	{
+		return do_it(this);
+	}
+
+	ensure(!!Emu.DeserialManager());
+
+	Emu.DeferDeserialization([this]()
+	{
+		if (!mutex)
+		{
+			mutex = ensure(idm::get_unlocked<lv2_obj, lv2_mutex>(mtx_id));
+		}
+
+		// Defer function
+		ensure(CellError{} == do_it(this));
+	});
+
+	return {};
+}
+
+std::shared_ptr<void> lv2_cond::load(utils::serial& ar)
+{
+	auto cond = std::make_shared<lv2_cond>(ar);
+	return lv2_obj::load(cond->key, cond);
+}
+
+void lv2_cond::save(utils::serial& ar)
+{
+	ar(key, name, mtx_id);
+}
 
 error_code sys_cond_create(ppu_thread& ppu, vm::ptr<u32> cond_id, u32 mutex_id, vm::ptr<sys_cond_attribute_t> attr)
 {
@@ -81,7 +139,7 @@ error_code sys_cond_signal(ppu_thread& ppu, u32 cond_id)
 
 	sys_cond.trace("sys_cond_signal(cond_id=0x%x)", cond_id);
 
-	const auto cond = idm::check<lv2_obj, lv2_cond>(cond_id, [](lv2_cond& cond)
+	const auto cond = idm::check<lv2_obj, lv2_cond>(cond_id, [&](lv2_cond& cond)
 	{
 		if (cond.waiters)
 		{
@@ -89,6 +147,12 @@ error_code sys_cond_signal(ppu_thread& ppu, u32 cond_id)
 
 			if (const auto cpu = cond.schedule<ppu_thread>(cond.sq, cond.mutex->protocol))
 			{
+				if (static_cast<ppu_thread*>(cpu)->state & cpu_flag::again)
+				{
+					ppu.state += cpu_flag::again;
+					return;
+				}
+
 				// TODO: Is EBUSY returned after reqeueing, on sys_cond_destroy?
 				cond.waiters--;
 
@@ -114,11 +178,20 @@ error_code sys_cond_signal_all(ppu_thread& ppu, u32 cond_id)
 
 	sys_cond.trace("sys_cond_signal_all(cond_id=0x%x)", cond_id);
 
-	const auto cond = idm::check<lv2_obj, lv2_cond>(cond_id, [](lv2_cond& cond)
+	const auto cond = idm::check<lv2_obj, lv2_cond>(cond_id, [&](lv2_cond& cond)
 	{
 		if (cond.waiters)
 		{
 			std::lock_guard lock(cond.mutex->mutex);
+
+			for (auto cpu : cond.sq)
+			{
+				if (static_cast<ppu_thread*>(cpu)->state & cpu_flag::again)
+				{
+					ppu.state += cpu_flag::again;
+					return;
+				}
+			}
 
 			cpu_thread* result = nullptr;
 			cond.waiters -= ::size32(cond.sq);
@@ -167,6 +240,12 @@ error_code sys_cond_signal_to(ppu_thread& ppu, u32 cond_id, u32 thread_id)
 			{
 				if (cpu->id == thread_id)
 				{
+					if (static_cast<ppu_thread*>(cpu)->state & cpu_flag::again)
+					{
+						ppu.state += cpu_flag::again;
+						return 0;
+					}
+
 					ensure(cond.unqueue(cond.sq, cpu));
 
 					cond.waiters--;
@@ -208,19 +287,33 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 
 	const auto cond = idm::get<lv2_obj, lv2_cond>(cond_id, [&](lv2_cond& cond) -> s64
 	{
-		if (cond.mutex->owner >> 1 != ppu.id)
+		if (!ppu.loaded_from_savestate && cond.mutex->owner >> 1 != ppu.id)
 		{
 			return -1;
 		}
 
 		std::lock_guard lock(cond.mutex->mutex);
 
-		// Register waiter
-		cond.sq.emplace_back(&ppu);
-		cond.waiters++;
+		if (ppu.loaded_from_savestate && ppu.optional_syscall_state & 1)
+		{
+			// Mutex sleep
+			ensure(!cond.mutex->try_own(ppu, ppu.id));
+		}
+		else
+		{
+			// Register waiter
+			cond.sq.emplace_back(&ppu);
+			cond.waiters++;
+		}	
+
+		if (ppu.loaded_from_savestate)
+		{
+			cond.sleep(ppu, timeout);
+			return static_cast<u32>(ppu.optional_syscall_state >> 32);
+		}
 
 		// Unlock the mutex
-		const auto count = cond.mutex->lock_count.exchange(0);
+		const u32 count = cond.mutex->lock_count.exchange(0);
 
 		if (const auto cpu = cond.mutex->reown<ppu_thread>())
 		{
@@ -246,14 +339,26 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 
 	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
 	{
-		if (is_stopped(state))
-		{
-			return {};
-		}
-
 		if (state & cpu_flag::signal)
 		{
 			break;
+		}
+
+		if (is_stopped(state))
+		{
+			std::lock_guard lock(cond->mutex->mutex);
+
+			const bool cond_sleep = std::find(cond->sq.begin(), cond->sq.end(), &ppu) != cond->sq.end();
+			const bool mutex_sleep = std::find(cond->mutex->sq.begin(), cond->mutex->sq.end(), &ppu) != cond->mutex->sq.end();
+
+			if (!cond_sleep && !mutex_sleep)
+			{
+				break;
+			}
+
+			ppu.optional_syscall_state = u32{mutex_sleep} | (u64{static_cast<u32>(cond.ret)} << 32);
+			ppu.state += cpu_flag::again;
+			return {};
 		}
 
 		if (timeout)
@@ -263,7 +368,7 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 				// Wait for rescheduling
 				if (ppu.check_state())
 				{
-					return {};
+					continue;
 				}
 
 				std::lock_guard lock(cond->mutex->mutex);

--- a/rpcs3/Emu/Cell/lv2/sys_cond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.h
@@ -38,18 +38,11 @@ struct lv2_cond final : lv2_obj
 	{
 	}
 
-	CellError on_id_create()
-	{
-		if (mutex->exists)
-		{
-			mutex->cond_count++;
-			exists++;
-			return {};
-		}
+	lv2_cond(utils::serial& ar);
+	static std::shared_ptr<void> load(utils::serial& ar);
+	void save(utils::serial& ar);
 
-		// Mutex has been destroyed, cannot create conditional variable
-		return CELL_ESRCH;
-	}
+	CellError on_id_create();
 };
 
 class ppu_thread;

--- a/rpcs3/Emu/Cell/lv2/sys_config.h
+++ b/rpcs3/Emu/Cell/lv2/sys_config.h
@@ -169,6 +169,7 @@ public:
 	static const u32 id_base = 0x41000000;
 	static const u32 id_step = 0x100;
 	static const u32 id_count = 2048;
+	SAVESTATE_INIT_POS(37);
 
 private:
 	u32 idm_id;
@@ -219,6 +220,7 @@ public:
 	static const u32 id_base = 0x43000000;
 	static const u32 id_step = 0x100;
 	static const u32 id_count = 2048;
+	SAVESTATE_INIT_POS(38);
 
 private:
 	// IDM data
@@ -283,6 +285,7 @@ public:
 	static const u32 id_base = 0x42000000;
 	static const u32 id_step = 0x100;
 	static const u32 id_count = 2048;
+	SAVESTATE_INIT_POS(39);
 
 private:
 	// IDM data

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -93,6 +93,12 @@ struct lv2_event_queue final : public lv2_obj
 
 	lv2_event_queue(u32 protocol, s32 type, s32 size, u64 name, u64 ipc_key) noexcept;
 
+	lv2_event_queue(utils::serial& ar) noexcept;
+	static std::shared_ptr<void> load(utils::serial& ar);
+	void save(utils::serial& ar);
+	static void save_ptr(utils::serial&, lv2_event_queue*);
+	static std::shared_ptr<lv2_event_queue> load_ptr(utils::serial& ar, std::shared_ptr<lv2_event_queue>& queue);
+
 	CellError send(lv2_event);
 
 	CellError send(u64 source, u64 d1, u64 d2, u64 d3)
@@ -102,10 +108,6 @@ struct lv2_event_queue final : public lv2_obj
 
 	// Get event queue by its global key
 	static std::shared_ptr<lv2_event_queue> find(u64 ipc_key);
-
-	// Check queue ptr validity (use 'exists' member)
-	static bool check(const std::weak_ptr<lv2_event_queue>&);
-	static bool check(const std::shared_ptr<lv2_event_queue>&);
 };
 
 struct lv2_event_port final : lv2_obj
@@ -122,6 +124,9 @@ struct lv2_event_port final : lv2_obj
 		, name(name)
 	{
 	}
+
+	lv2_event_port(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 class ppu_thread;

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.h
@@ -54,6 +54,10 @@ struct lv2_event_flag final : lv2_obj
 	{
 	}
 
+	lv2_event_flag(utils::serial& ar);
+	static std::shared_ptr<void> load(utils::serial& ar);
+	void save(utils::serial& ar);
+
 	// Check mode arg
 	static bool check_mode(u32 mode)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.h
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.h
@@ -6,7 +6,7 @@
 
 class ppu_thread;
 
-struct lv2_int_tag final : lv2_obj
+struct lv2_int_tag final : public lv2_obj
 {
 	static const u32 id_base = 0x0a000000;
 
@@ -14,9 +14,11 @@ struct lv2_int_tag final : lv2_obj
 	std::shared_ptr<struct lv2_int_serv> handler;
 
 	lv2_int_tag() noexcept;
+	lv2_int_tag(utils::serial& ar) noexcept;
+	void save(utils::serial& ar);
 };
 
-struct lv2_int_serv final : lv2_obj
+struct lv2_int_serv final : public lv2_obj
 {
 	static const u32 id_base = 0x0b000000;
 
@@ -26,6 +28,8 @@ struct lv2_int_serv final : lv2_obj
 	const u64 arg2;
 
 	lv2_int_serv(const std::shared_ptr<named_thread<ppu_thread>>& thread, u64 arg1, u64 arg2) noexcept;
+	lv2_int_serv(utils::serial& ar) noexcept;
+	void save(utils::serial& ar);
 
 	void exec() const;
 	void join() const;

--- a/rpcs3/Emu/Cell/lv2/sys_io.h
+++ b/rpcs3/Emu/Cell/lv2/sys_io.h
@@ -4,10 +4,10 @@
 
 struct lv2_io_buf
 {
-	using id_type = lv2_io_buf;
 	static const u32 id_base = 0x44000000;
 	static const u32 id_step = 1;
 	static const u32 id_count = 2048;
+	SAVESTATE_INIT_POS(41);
 
 	const u32 block_count;
 	const u32 block_size;

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.h
@@ -41,6 +41,9 @@ struct lv2_lwcond final : lv2_obj
 		, control(control)
 	{
 	}
+
+	lv2_lwcond(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 // Aux

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -71,6 +71,9 @@ struct lv2_lwmutex final : lv2_obj
 	{
 	}
 
+	lv2_lwmutex(utils::serial& ar);
+	void save(utils::serial& ar);
+
 	// Add a waiter
 	void add_waiter(cpu_thread* cpu)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -12,18 +12,77 @@
 
 LOG_CHANNEL(sys_memory);
 
+//
+static shared_mutex s_memstats_mtx;
+
 lv2_memory_container::lv2_memory_container(u32 size, bool from_idm) noexcept
 	: size(size)
 	, id{from_idm ? idm::last_id() : SYS_MEMORY_CONTAINER_ID_INVALID}
 {
 }
 
-//
-static shared_mutex s_memstats_mtx;
+lv2_memory_container::lv2_memory_container(utils::serial& ar, bool from_idm) noexcept
+	: size(ar)
+	, id{from_idm ? idm::last_id() : SYS_MEMORY_CONTAINER_ID_INVALID}
+	, used(ar)
+{
+}
+
+std::shared_ptr<void> lv2_memory_container::load(utils::serial& ar)
+{
+	// Use idm::last_id() only for the instances at IDM  
+	return std::make_shared<lv2_memory_container>(stx::exact_t<utils::serial&>(ar), true);
+}
+
+void lv2_memory_container::save(utils::serial& ar)
+{
+	ar(size, used);
+}
+
+lv2_memory_container* lv2_memory_container::search(u32 id)
+{
+	if (id != SYS_MEMORY_CONTAINER_ID_INVALID)
+	{
+		return idm::check<lv2_memory_container>(id);
+	}
+
+	return &g_fxo->get<lv2_memory_container>();
+}
 
 struct sys_memory_address_table
 {
 	atomic_t<lv2_memory_container*> addrs[65536]{};
+
+	sys_memory_address_table() = default;
+
+	SAVESTATE_INIT_POS(id_manager::id_map<lv2_memory_container>::savestate_init_pos + 0.1);
+
+	sys_memory_address_table(utils::serial& ar)
+	{
+		// First: address, second: conatiner ID (SYS_MEMORY_CONTAINER_ID_INVALID for global FXO memory container)
+		std::unordered_map<u16, u32> mm;
+		ar(mm);
+
+		for (const auto& [addr, id] : mm)
+		{
+			addrs[addr] = ensure(lv2_memory_container::search(id));
+		}
+	}
+
+	void save(utils::serial& ar)
+	{
+		std::unordered_map<u16, u32> mm;
+
+		for (auto& ctr : addrs)
+		{
+			if (const auto ptr = +ctr)
+			{
+				mm[static_cast<u16>(&ctr - addrs)] = ptr->id; 
+			}
+		}
+
+		ar(mm);
+	}
 };
 
 // Todo: fix order of error checks

--- a/rpcs3/Emu/Cell/lv2/sys_memory.h
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.h
@@ -70,7 +70,13 @@ struct lv2_memory_container
 	const lv2_mem_container_id id; // ID of the container in if placed at IDM, otherwise SYS_MEMORY_CONTAINER_ID_INVALID
 	atomic_t<u32> used{}; // Amount of "physical" memory currently used
 
+	SAVESTATE_INIT_POS(1);
+
 	lv2_memory_container(u32 size, bool from_idm = false) noexcept;
+	lv2_memory_container(utils::serial& ar, bool from_idm = false) noexcept;
+	static std::shared_ptr<void> load(utils::serial& ar);
+	void save(utils::serial& ar);
+	static lv2_memory_container* search(u32 id);
 
 	// Try to get specified amount of "physical" memory
 	// Values greater than UINT32_MAX will fail

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.h
@@ -30,6 +30,10 @@ struct lv2_memory : lv2_obj
 
 	lv2_memory(u32 size, u32 align, u64 flags, u64 key, bool pshared, lv2_memory_container* ct);
 
+	lv2_memory(utils::serial& ar);
+	static std::shared_ptr<void> load(utils::serial& ar);
+	void save(utils::serial& ar);
+
 	CellError on_id_create();
 };
 
@@ -54,6 +58,8 @@ enum : u64
 
 struct page_fault_notification_entry
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	u32 start_addr; // Starting address of region to monitor.
 	u32 event_queue_id; // Queue to be notified.
 	u32 port_id; // Port used to notify the queue.
@@ -64,6 +70,10 @@ struct page_fault_notification_entries
 {
 	std::vector<page_fault_notification_entry> entries;
 	shared_mutex mutex;
+
+	page_fault_notification_entries() = default;
+	page_fault_notification_entries(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 struct page_fault_event_entries

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -9,6 +9,27 @@
 
 LOG_CHANNEL(sys_mutex);
 
+lv2_mutex::lv2_mutex(utils::serial& ar)
+	: protocol(ar)
+	, recursive(ar)
+	, adaptive(ar)
+	, key(ar)
+	, name(ar)
+{
+	ar(lock_count, owner);
+}
+
+std::shared_ptr<void> lv2_mutex::load(utils::serial& ar)
+{
+	auto mtx = std::make_shared<lv2_mutex>(ar);
+	return lv2_obj::load(mtx->key, mtx);
+}
+
+void lv2_mutex::save(utils::serial& ar)
+{
+	ar(protocol, recursive, adaptive, key, name, lock_count, owner & -2);
+}
+
 error_code sys_mutex_create(ppu_thread& ppu, vm::ptr<u32> mutex_id, vm::ptr<sys_mutex_attribute_t> attr)
 {
 	ppu.state += cpu_flag::wait;
@@ -154,9 +175,22 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 
 	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
 	{
-		if (is_stopped(state) || state & cpu_flag::signal)
+		if (state & cpu_flag::signal)
 		{
 			break;
+		}
+
+		if (is_stopped(state))
+		{
+			std::lock_guard lock(mutex->mutex);
+
+			if (std::find(mutex->sq.begin(), mutex->sq.end(), &ppu) == mutex->sq.end())
+			{
+				break;
+			}
+
+			ppu.state += cpu_flag::again;
+			return {};
 		}
 
 		if (timeout)
@@ -166,7 +200,7 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 				// Wait for rescheduling
 				if (ppu.check_state())
 				{
-					return {};
+					continue;
 				}
 
 				std::lock_guard lock(mutex->mutex);

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -46,6 +46,10 @@ struct lv2_mutex final : lv2_obj
 	{
 	}
 
+	lv2_mutex(utils::serial& ar);
+	static std::shared_ptr<void> load(utils::serial& ar); 
+	void save(utils::serial& ar);
+
 	CellError try_lock(u32 id)
 	{
 		const u32 value = owner;

--- a/rpcs3/Emu/Cell/lv2/sys_net.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net.h
@@ -269,6 +269,8 @@ struct sys_net_pollfd
 // sockaddr prefixed with sys_net_
 struct sys_net_sockaddr
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	u8 sa_len;
 	u8 sa_family;
 	char sa_data[14];
@@ -277,6 +279,8 @@ struct sys_net_sockaddr
 // sockaddr_dl prefixed with sys_net_
 struct sys_net_sockaddr_dl
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	u8 sdl_len;
 	u8 sdl_family;
 	be_t<u16> sdl_index;
@@ -290,6 +294,8 @@ struct sys_net_sockaddr_dl
 // sockaddr_in prefixed with sys_net_
 struct sys_net_sockaddr_in
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	u8 sin_len;
 	u8 sin_family;
 	be_t<u16> sin_port;
@@ -300,6 +306,8 @@ struct sys_net_sockaddr_in
 // sockaddr_in_p2p prefixed with sys_net_
 struct sys_net_sockaddr_in_p2p
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	u8 sin_len;
 	u8 sin_family;
 	be_t<u16> sin_port;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
@@ -49,7 +49,13 @@ public:
 	};
 
 public:
+	SAVESTATE_INIT_POS(7); // Dependency on RPCN
+
 	lv2_socket(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
+	lv2_socket(utils::serial&){}
+	lv2_socket(utils::serial&, lv2_socket_type type);
+	static std::shared_ptr<lv2_socket> load(utils::serial& ar);
+	void save(utils::serial&, bool save_only_this_class = false);
 	virtual ~lv2_socket() = default;
 
 	std::unique_lock<shared_mutex> lock();
@@ -73,7 +79,7 @@ public:
 
 public:
 	virtual std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) = 0;
-	virtual s32 bind(const sys_net_sockaddr& addr, s32 ps3_id)                  = 0;
+	virtual s32 bind(const sys_net_sockaddr& addr) = 0;
 
 	virtual std::optional<s32> connect(const sys_net_sockaddr& addr) = 0;
 	virtual s32 connect_followup()                                   = 0;
@@ -102,6 +108,8 @@ public:
 	static const u32 id_count = 1000;
 
 protected:
+	lv2_socket(utils::serial&, bool);
+
 	shared_mutex mutex;
 	u32 lv2_id = 0;
 
@@ -130,4 +138,6 @@ protected:
 	// Tracks connect for WSAPoll workaround
 	bool connecting = false;
 #endif
+
+	sys_net_sockaddr last_bound_addr{};
 };

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
@@ -31,11 +31,13 @@ class lv2_socket_native final : public lv2_socket
 {
 public:
 	lv2_socket_native(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
+	lv2_socket_native(utils::serial& ar, lv2_socket_type type);
+	void save(utils::serial& ar);
 	~lv2_socket_native();
 	s32 create_socket();
 
 	std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
-	s32 bind(const sys_net_sockaddr& addr, s32 ps3_id) override;
+	s32 bind(const sys_net_sockaddr& addr) override;
 
 	std::optional<s32> connect(const sys_net_sockaddr& addr) override;
 	s32 connect_followup() override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.h
@@ -6,9 +6,11 @@ class lv2_socket_p2p : public lv2_socket
 {
 public:
 	lv2_socket_p2p(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
+	lv2_socket_p2p(utils::serial& ar, lv2_socket_type type);
+	void save(utils::serial& ar);
 
 	std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
-	s32 bind(const sys_net_sockaddr& addr, s32 ps3_id) override;
+	s32 bind(const sys_net_sockaddr& addr) override;
 
 	std::optional<s32> connect(const sys_net_sockaddr& addr) override;
 	s32 connect_followup() override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
@@ -59,6 +59,8 @@ class lv2_socket_p2ps final : public lv2_socket_p2p
 public:
 	lv2_socket_p2ps(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
 	lv2_socket_p2ps(socket_type socket, u16 port, u16 vport, u32 op_addr, u16 op_port, u16 op_vport, u64 cur_seq, u64 data_beg_seq);
+	lv2_socket_p2ps(utils::serial& ar, lv2_socket_type type);
+	void save(utils::serial& ar);
 
 	p2ps_stream_status get_status() const;
 	void set_status(p2ps_stream_status new_status);
@@ -67,7 +69,7 @@ public:
 	void send_u2s_packet(std::vector<u8> data, const ::sockaddr_in* dst, u32 seq, bool require_ack);
 
 	std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
-	s32 bind(const sys_net_sockaddr& addr, s32 ps3_id) override;
+	s32 bind(const sys_net_sockaddr& addr) override;
 
 	std::optional<s32> connect(const sys_net_sockaddr& addr) override;
 
@@ -90,7 +92,7 @@ protected:
 	p2ps_stream_status status = p2ps_stream_status::stream_closed;
 
 	usz max_backlog = 0; // set on listen
-	std::queue<s32> backlog;
+	std::deque<s32> backlog;
 
 	u16 op_port = 0, op_vport = 0;
 	u32 op_addr = 0;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
@@ -8,13 +8,23 @@ lv2_socket_raw::lv2_socket_raw(lv2_socket_family family, lv2_socket_type type, l
 {
 }
 
+lv2_socket_raw::lv2_socket_raw(utils::serial& ar, lv2_socket_type type)
+	: lv2_socket(ar, type)
+{
+}
+
+void lv2_socket_raw::save(utils::serial& ar)
+{
+	static_cast<lv2_socket*>(this)->save(ar, true);
+}
+
 std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_raw::accept([[maybe_unused]] bool is_lock)
 {
 	sys_net.todo("lv2_socket_raw::accept");
 	return {};
 }
 
-s32 lv2_socket_raw::bind([[maybe_unused]] const sys_net_sockaddr& addr, [[maybe_unused]] s32 ps3_id)
+s32 lv2_socket_raw::bind([[maybe_unused]] const sys_net_sockaddr& addr)
 {
 	sys_net.todo("lv2_socket_raw::bind");
 	return {};

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.h
@@ -6,9 +6,11 @@ class lv2_socket_raw final : public lv2_socket
 {
 public:
 	lv2_socket_raw(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
+	lv2_socket_raw(utils::serial& ar, lv2_socket_type type);
+	void save(utils::serial& ar);
 
 	std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
-	s32 bind(const sys_net_sockaddr& addr, s32 ps3_id) override;
+	s32 bind(const sys_net_sockaddr& addr) override;
 
 	std::optional<s32> connect(const sys_net_sockaddr& addr) override;
 	s32 connect_followup() override;

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.h
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.h
@@ -8,6 +8,11 @@ struct lv2_overlay final : lv2_obj, ppu_module
 	static const u32 id_base = 0x25000000;
 
 	u32 entry;
+
+	lv2_overlay() = default;
+	lv2_overlay(utils::serial& ar){}
+	static std::shared_ptr<void> load(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry);

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -192,9 +192,11 @@ error_code sys_ppu_thread_join(ppu_thread& ppu, u32 thread_id, vm::ptr<u64> vptr
 	if (thread->joiner != ppu_join_status::exited)
 	{
 		// Thread aborted, log it later
-		ppu.state += cpu_flag::exit;
+		ppu.state += cpu_flag::again;
 		return {};
 	}
+
+	static_cast<void>(ppu.test_stopped());
 
 	// Get the exit status from the register
 	const u64 vret = thread->gpr[3];

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -189,6 +189,11 @@ struct lv2_prx final : lv2_obj, ppu_module
 	char module_info_name[28];
 	u8 module_info_version[2];
 	be_t<u16> module_info_attributes;
+
+	lv2_prx() noexcept = default;
+	lv2_prx(utils::serial&) {}
+	static std::shared_ptr<void> load(utils::serial&);
+	void save(utils::serial& ar);
 };
 
 enum : u64

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.h
@@ -120,6 +120,8 @@ struct RsxDisplayInfo
 	be_t<u32> width{0};
 	be_t<u32> height{0};
 
+	ENABLE_BITWISE_SERIALIZATION;
+
 	bool valid() const
 	{
 		return height != 0u && width != 0u;

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.h
@@ -38,6 +38,10 @@ struct lv2_rwlock final : lv2_obj
 		, name(name)
 	{
 	}
+
+	lv2_rwlock(utils::serial& ar);
+	static std::shared_ptr<void> load(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 // Aux

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -9,6 +9,27 @@
 
 LOG_CHANNEL(sys_semaphore);
 
+lv2_sema::lv2_sema(utils::serial& ar)
+	: protocol(ar)
+	, key(ar)
+	, name(ar)
+	, max(ar)
+{
+	ar(val);
+}
+
+std::shared_ptr<void> lv2_sema::load(utils::serial& ar)
+{
+	auto sema = std::make_shared<lv2_sema>(ar);
+	return lv2_obj::load(sema->key, sema);
+}
+
+void lv2_sema::save(utils::serial& ar)
+{
+	USING_SERIALIZATION_VERSION(lv2_sync);
+	ar(protocol, key, name, max, std::max<s32>(+val, 0));
+}
+
 error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sys_semaphore_attribute_t> attr, s32 initial_val, s32 max_val)
 {
 	ppu.state += cpu_flag::wait;
@@ -46,10 +67,7 @@ error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sy
 		return error;
 	}
 
-	if (ppu.test_stopped())
-	{
-		return {};
-	}
+	static_cast<void>(ppu.test_stopped());
 
 	*sem_id = idm::last_id();
 	return CELL_OK;
@@ -129,14 +147,22 @@ error_code sys_semaphore_wait(ppu_thread& ppu, u32 sem_id, u64 timeout)
 
 	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
 	{
-		if (is_stopped(state))
-		{
-			return {};
-		}
-
 		if (state & cpu_flag::signal)
 		{
 			break;
+		}
+
+		if (is_stopped(state))
+		{
+			std::lock_guard lock(sem->mutex);
+
+			if (std::find(sem->sq.begin(), sem->sq.end(), &ppu) == sem->sq.end())
+			{
+				break;
+			}
+
+			ppu.state += cpu_flag::again;
+			return {};
 		}
 
 		if (timeout)
@@ -146,7 +172,7 @@ error_code sys_semaphore_wait(ppu_thread& ppu, u32 sem_id, u64 timeout)
 				// Wait for rescheduling
 				if (ppu.check_state())
 				{
-					return {};
+					continue;
 				}
 
 				std::lock_guard lock(sem->mutex);
@@ -240,6 +266,15 @@ error_code sys_semaphore_post(ppu_thread& ppu, u32 sem_id, s32 count)
 	{
 		std::lock_guard lock(sem->mutex);
 
+		for (auto cpu : sem->sq)
+		{
+			if (static_cast<ppu_thread*>(cpu)->state & cpu_flag::again)
+			{
+				ppu.state += cpu_flag::again;
+				return {};
+			}
+		}
+
 		const auto [val, ok] = sem->val.fetch_op([&](s32& val)
 		{
 			if (count + 0u <= sem->max + 0u - val)
@@ -294,10 +329,7 @@ error_code sys_semaphore_get_value(ppu_thread& ppu, u32 sem_id, vm::ptr<s32> cou
 		return CELL_EFAULT;
 	}
 
-	if (ppu.test_stopped())
-	{
-		return {};
-	}
+	static_cast<void>(ppu.test_stopped());
 
 	*count = sema.ret;
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.h
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.h
@@ -40,6 +40,10 @@ struct lv2_sema final : lv2_obj
 		, val(value)
 	{
 	}
+
+	lv2_sema(utils::serial& ar);
+	static std::shared_ptr<void> load(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 // Aux

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -114,6 +114,8 @@ struct sys_spu_thread_argument
 
 struct sys_spu_segment
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	be_t<s32> type; // copy, fill, info
 	be_t<u32> ls; // local storage address
 	be_t<u32> size;
@@ -248,6 +250,9 @@ struct lv2_spu_image : lv2_obj
 		, nsegs(nsegs)
 	{
 	}
+
+	lv2_spu_image(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 struct sys_spu_thread_group_syscall_253_info
@@ -283,8 +288,8 @@ struct lv2_spu_group
 	atomic_t<spu_group_status> run_state; // SPU Thread Group State
 	atomic_t<s32> exit_status; // SPU Thread Group Exit Status
 	atomic_t<u32> join_state; // flags used to detect exit cause and signal
-	atomic_t<u32> running; // Number of running threads
-	atomic_t<u64> stop_count;
+	atomic_t<u32> running = 0; // Number of running threads
+	atomic_t<u64> stop_count = 0;
 	class ppu_thread* waiter = nullptr;
 	bool set_terminate = false;
 
@@ -297,7 +302,7 @@ struct lv2_spu_group
 	std::shared_ptr<lv2_event_queue> ep_exception; // TODO: SYS_SPU_THREAD_GROUP_EVENT_EXCEPTION
 	std::shared_ptr<lv2_event_queue> ep_sysmodule; // TODO: SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE
 
-	lv2_spu_group(std::string name, u32 num, s32 prio, s32 type, lv2_memory_container* ct, bool uses_scheduler, u32 mem_size)
+	lv2_spu_group(std::string name, u32 num, s32 prio, s32 type, lv2_memory_container* ct, bool uses_scheduler, u32 mem_size) noexcept
 		: name(std::move(name))
 		, id(idm::last_id())
 		, max_num(num)
@@ -311,12 +316,15 @@ struct lv2_spu_group
 		, run_state(SPU_THREAD_GROUP_STATUS_NOT_INITIALIZED)
 		, exit_status(0)
 		, join_state(0)
-		, running(0)
-		, stop_count(0)
 		// TODO: args()
 	{
 		threads_map.fill(-1);
 	}
+
+	SAVESTATE_INIT_POS(8); // Dependency on SPUs
+
+	lv2_spu_group(utils::serial& ar) noexcept;
+	void save(utils::serial& ar);
 
 	CellError send_run_event(u64 data1, u64 data2, u64 data3) const
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_storage.h
+++ b/rpcs3/Emu/Cell/lv2/sys_storage.h
@@ -26,6 +26,7 @@ struct lv2_storage
 	static const u32 id_base = 0x45000000;
 	static const u32 id_step = 1;
 	static const u32 id_count = 2048;
+	SAVESTATE_INIT_POS(45);
 
 	const u64 device_id;
 	const fs::file file;

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -84,6 +84,7 @@ private:
 	}
 
 public:
+	SAVESTATE_INIT_POS(4); // Dependency on PPUs
 
 	// Existence validation (workaround for shared-ptr ref-counting)
 	atomic_t<u32> exists = 0;
@@ -133,7 +134,10 @@ public:
 		if (protocol == SYS_SYNC_FIFO)
 		{
 			const auto res = queue.front();
-			queue.pop_front();
+
+			if (res->state.none_of(cpu_flag::again))
+				queue.pop_front();
+
 			return res;
 		}
 
@@ -152,7 +156,10 @@ public:
 		}
 
 		const auto res = *it;
-		queue.erase(it);
+
+		if (res->state.none_of(cpu_flag::again))
+			queue.erase(it);
+
 		return res;
 	}
 
@@ -191,6 +198,10 @@ public:
 	{
 		g_to_awake.emplace_back(thread);
 	}
+
+	// Serialization related
+	static void set_future_sleep(ppu_thread* ppu);
+	static bool is_scheduler_ready();
 
 	static void cleanup();
 
@@ -314,6 +325,24 @@ public:
 		}
 	}
 
+	template <typename T>
+	static std::shared_ptr<T> load(u64 ipc_key, std::shared_ptr<T> make, u64 pshared = -1)
+	{
+		if (pshared == umax ? ipc_key != 0 : pshared != 0)
+		{
+			g_fxo->need<ipc_manager<T, u64>>();
+
+			make = g_fxo->get<ipc_manager<T, u64>>().add(ipc_key, [&]()
+			{
+				return make;
+			}, true).second;
+		}
+
+		// Ensure no error
+		ensure(!make->on_id_create());
+		return make;
+	}
+
 	template <bool IsUsleep = false, bool Scale = true>
 	static bool wait_timeout(u64 usec, cpu_thread* const cpu = {})
 	{
@@ -419,6 +448,9 @@ private:
 
 	// Scheduler queue for timeouts (wait until -> thread)
 	static std::deque<std::pair<u64, class cpu_thread*>> g_waiting;
+
+	// Threads which must call lv2_obj::sleep before the scheduler starts
+	static std::deque<class ppu_thread*> g_to_sleep;
 
 	static void schedule_all();
 };

--- a/rpcs3/Emu/Cell/lv2/sys_time.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_time.cpp
@@ -166,11 +166,24 @@ u64 get_timebased_time()
 }
 
 // Add an offset to get_timebased_time to avoid leaking PC's uptime into the game
-void initalize_timebased_time()
+// As if PS3 starts at value 0 (base time) when the game boots
+// If none-zero arg is specified it will become the base time (for savestates)
+void initialize_timebased_time(u64 timebased_init, bool reset)
 {
 	timebase_offset = 0;
-	timebase_offset = get_timebased_time();
-	systemtime_offset = timebase_offset / (g_timebase_freq / 1000000);
+
+	if (reset)
+	{
+		// We simply want to zero-out these values
+		systemtime_offset = 0;
+		return;
+	}
+
+	const u64 current = get_timebased_time();
+	timebased_init = get_timebased_time() - timebased_init;
+
+	timebase_offset = timebased_init;
+	systemtime_offset = timebased_init / (g_timebase_freq / 1000000);
 }
 
 // Returns some relative time in microseconds, don't change this fact
@@ -201,7 +214,6 @@ u64 get_system_time()
 u64 get_guest_system_time(u64 time)
 {
 	const u64 result = (time != umax ? time : get_system_time()) * g_cfg.core.clocks_scale / 100;
-	ensure(result >= systemtime_offset);
 	return result - systemtime_offset;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -6,6 +6,7 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 #include "Emu/Cell/timers.hpp"
+#include "Emu/System.h"
 #include "sys_event.h"
 #include "sys_process.h"
 
@@ -23,6 +24,24 @@ struct lv2_timer_thread
 	static constexpr auto thread_name = "Timer Thread"sv;
 };
 
+lv2_timer::lv2_timer(utils::serial& ar)
+	: lv2_obj{1}
+	, state(ar)
+	, port(lv2_event_queue::load_ptr(ar, port))
+	, source(ar)
+	, data1(ar)
+	, data2(ar)
+	, expire(ar)
+	, period(ar)
+{
+}
+
+void lv2_timer::save(utils::serial& ar)
+{
+	USING_SERIALIZATION_VERSION(lv2_sync);
+	ar(state), lv2_event_queue::save_ptr(ar, port.get()), ar(source, data1, data2, expire, period);
+}
+
 u64 lv2_timer::check()
 {
 	while (thread_ctrl::state() != thread_state::aborting)
@@ -34,6 +53,7 @@ u64 lv2_timer::check()
 			const u64 _now = get_guest_system_time();
 			u64 next = expire;
 
+			// If aborting, perform the last accurate check for event
 			if (_now >= next)
 			{
 				std::lock_guard lock(mutex);
@@ -73,7 +93,19 @@ u64 lv2_timer::check()
 
 void lv2_timer_thread::operator()()
 {
-	u64 sleep_time = umax;
+	{
+		decltype(timers) vec;
+
+		idm::select<lv2_obj, lv2_timer>([&vec](u32 id, lv2_timer&)
+		{
+			vec.emplace_back(idm::get_unlocked<lv2_obj, lv2_timer>(id));
+		});
+
+		std::lock_guard lock(mutex);
+		timers = std::move(vec);
+	}
+
+	u64 sleep_time = 0;
 
 	while (thread_ctrl::state() != thread_state::aborting)
 	{
@@ -86,6 +118,12 @@ void lv2_timer_thread::operator()()
 		thread_ctrl::wait_for(sleep_time);
 
 		sleep_time = umax;
+
+		if (Emu.IsPaused())
+		{
+			sleep_time = 10000;
+			continue;
+		}
 
 		reader_lock lock(mutex);
 
@@ -115,6 +153,7 @@ error_code sys_timer_create(ppu_thread& ppu, vm::ptr<u32> timer_id)
 		auto& thread = g_fxo->get<named_thread<lv2_timer_thread>>();
 		{
 			std::lock_guard lock(thread.mutex);
+			lv2_obj::unqueue(thread.timers, ptr);
 			thread.timers.emplace_back(std::move(ptr));
 		}
 
@@ -344,7 +383,7 @@ error_code sys_timer_sleep(ppu_thread& ppu, u32 sleep_time)
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_timer.trace("sys_timer_sleep(sleep_time=%d) -> sys_timer_usleep()", sleep_time);
+	sys_timer.warning("sys_timer_sleep(sleep_time=%d)", sleep_time);
 
 	return sys_timer_usleep(ppu, sleep_time * u64{1000000});
 }
@@ -359,7 +398,10 @@ error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 	{
 		lv2_obj::sleep(ppu, sleep_time);
 
-		lv2_obj::wait_timeout<true>(sleep_time);
+		if (!lv2_obj::wait_timeout<true>(sleep_time))
+		{
+			ppu.state += cpu_flag::again;
+		}
 	}
 	else
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_timer.h
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.h
@@ -60,6 +60,9 @@ struct lv2_timer : lv2_obj
 			info.period      = 0;
 		}
 	}
+
+	lv2_timer(utils::serial& ar);
+	void save(utils::serial& ar);
 };
 
 class ppu_thread;

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -17,6 +17,12 @@ sys_vm_t::sys_vm_t(u32 _addr, u32 vsize, lv2_memory_container* ct, u32 psize)
 	g_ids[addr >> 28].release(idm::last_id());
 }
 
+void sys_vm_t::save(utils::serial& ar)
+{
+	USING_SERIALIZATION_VERSION(lv2_vm);
+	ar(ct->id, addr, size, psize);
+}
+
 sys_vm_t::~sys_vm_t()
 {
 	// Free ID
@@ -29,6 +35,17 @@ struct sys_vm_global_t
 {
 	atomic_t<u32> total_vsize = 0;
 };
+
+sys_vm_t::sys_vm_t(utils::serial& ar)
+	: ct(lv2_memory_container::search(ar))
+	, addr(ar)
+	, size(ar)
+	, psize(ar)
+{
+	g_ids[addr >> 28].release(idm::last_id());
+	g_fxo->need<sys_vm_global_t>();
+	g_fxo->get<sys_vm_global_t>().total_vsize += size;
+}
 
 error_code sys_vm_memory_map(ppu_thread& ppu, u32 vsize, u32 psize, u32 cid, u64 flag, u64 policy, vm::ptr<u32> addr)
 {

--- a/rpcs3/Emu/Cell/lv2/sys_vm.h
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.h
@@ -41,6 +41,11 @@ struct sys_vm_t
 	sys_vm_t(u32 addr, u32 vsize, lv2_memory_container* ct, u32 psize);
 	~sys_vm_t();
 
+	SAVESTATE_INIT_POS(10);
+
+	sys_vm_t(utils::serial& ar);
+	void save(utils::serial& ar);
+
 	static std::array<atomic_t<u32>, id_count> g_ids;
 
 	static u32 find_id(u32 addr)

--- a/rpcs3/Emu/Cell/timers.hpp
+++ b/rpcs3/Emu/Cell/timers.hpp
@@ -4,6 +4,5 @@
 
 u64 convert_to_timebased_time(u64 time);
 u64 get_timebased_time();
-void initalize_timebased_time();
 u64 get_system_time();
 u64 get_guest_system_time(u64 time = umax);

--- a/rpcs3/Emu/IdManager.cpp
+++ b/rpcs3/Emu/IdManager.cpp
@@ -4,15 +4,40 @@
 
 shared_mutex id_manager::g_mutex;
 
-thread_local DECLARE(idm::g_id);
-
-idm::map_data* idm::allocate_id(std::vector<map_data>& vec, u32 type_id,  u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range)
+namespace id_manager
 {
+	thread_local u32 g_id = 0;
+}
+
+std::vector<std::pair<u128, id_manager::typeinfo>>& id_manager::get_typeinfo_map()
+{
+	// Magic static
+	static std::vector<std::pair<u128, id_manager::typeinfo>> s_map;
+	return s_map; 
+}
+
+idm::map_data* idm::allocate_id(std::vector<map_data>& vec, u32 type_id, u32 dst_id, u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range)
+{
+	if (const u32 index = id_manager::get_index(dst_id, base, step, count, invl_range); index < count)
+	{
+		// Fixed position construction
+		ensure(index < vec.size());
+
+		if (vec[index].second)
+		{
+			return nullptr;
+		}
+
+		id_manager::g_id = dst_id;
+		vec[index] = {id_manager::id_key(dst_id, type_id), nullptr};
+		return &vec[index];
+	}
+
 	if (vec.size() < count)
 	{
 		// Try to emplace back
 		const u32 _next = base + step * ::size32(vec);
-		g_id = _next;
+		id_manager::g_id = _next;
 		vec.emplace_back(id_manager::id_key(_next, type_id), nullptr);
 		return &vec.back();
 	}
@@ -27,7 +52,7 @@ idm::map_data* idm::allocate_id(std::vector<map_data>& vec, u32 type_id,  u32 ba
 		{
 			// Incremenet ID invalidation counter
 			const u32 id = next | ((ptr->first + (1u << invl_range.first)) & (invl_range.second ? (((1u << invl_range.second) - 1) << invl_range.first) : 0));
-			g_id = id;
+			id_manager::g_id = id;
 			ptr->first = id_manager::id_key(id, type_id);
 			return ptr;
 		}

--- a/rpcs3/Emu/IdManager.h
+++ b/rpcs3/Emu/IdManager.h
@@ -5,7 +5,10 @@
 
 #include <memory>
 #include <vector>
+#include <map>
+#include <typeinfo>
 
+#include "util/serialization.hpp"
 #include "util/fixed_typemap.hpp"
 
 extern stx::manual_typemap<void, 0x20'00000, 128> g_fixed_typemap;
@@ -35,6 +38,9 @@ namespace id_manager
 	template <typename T>
 	concept IdmCompatible = requires () { T::id_base, T::id_step, T::id_count; };
 
+	// Last allocated ID for constructors
+	extern thread_local u32 g_id;
+
 	// ID traits
 	template <typename T>
 	struct id_traits
@@ -57,53 +63,155 @@ namespace id_manager
 		static_assert(!invl_range.second || (u64{invl_range.second} + invl_range.first <= 32 /*....*/ ));
 	};
 
-	class typeinfo
+	static constexpr u32 get_index(u32 id, u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range)
 	{
-		// Global variable for each registered type
-		template <typename T>
-		struct registered
-		{
-			static const u32 index;
-		};
+		u32 mask_out = ((1u << invl_range.second) - 1) << invl_range.first;
 
-		// Increment type counter
-		static u32 add_type(u32 i)
-		{
-			static atomic_t<u32> g_next{0};
+		// Note: if id is lower than base, diff / step will be higher than count
+		u32 diff = (id & ~mask_out) - base;
 
-			return g_next.fetch_add(i);
+		if (diff % step)
+		{
+			// id is invalid, return invalid index
+			return count;
 		}
 
+		// Get actual index
+		return diff / step;
+	}
+
+	// ID traits
+	template <typename T, typename = void>
+	struct id_traits_load_func
+	{
+		static constexpr std::shared_ptr<void>(*load)(utils::serial&) = [](utils::serial& ar) -> std::shared_ptr<void> { return std::make_shared<T>(stx::exact_t<utils::serial&>(ar)); };
+	};
+
+	template <typename T>
+	struct id_traits_load_func<T, std::void_t<decltype(&T::load)>>
+	{
+		static constexpr std::shared_ptr<void>(*load)(utils::serial&) = &T::load;
+	};
+
+	template <typename T, typename = void>
+	struct id_traits_savable_func
+	{
+		static constexpr bool(*savable)(void*) = [](void*) -> bool { return true; };
+	};
+
+	template <typename T>
+	struct id_traits_savable_func<T, std::void_t<decltype(&T::savable)>>
+	{
+		static constexpr bool(*savable)(void* ptr) = [](void* ptr) -> bool { return static_cast<const T*>(ptr)->savable(); };
+	};
+
+	struct dummy_construct
+	{
+		dummy_construct() {}
+		dummy_construct(utils::serial&){}
+		void save(utils::serial&) {}
+
+		static constexpr u32 id_base = 1, id_step = 1, id_count = 1;
+		static constexpr double savestate_init_pos = 0;
+	};
+
+	struct typeinfo;
+
+	// Use a vector instead of map to reduce header dependencies in this commonly used header
+	std::vector<std::pair<u128, typeinfo>>& get_typeinfo_map();
+
+	struct typeinfo
+	{
 	public:
+		std::shared_ptr<void>(*load)(utils::serial&);
+		void(*save)(utils::serial&, void*);
+		bool(*savable)(void* ptr);
+
+		u32 base;
+		u32 step;
+		u32 count;
+		std::pair<u32, u32> invl_range;
+
 		// Get type index
 		template <typename T>
 		static inline u32 get_index()
 		{
-			return registered<T>::index;
+			return stx::typeindex<id_manager::typeinfo, T>();
 		}
 
-		// Get type count
-		static inline u32 get_count()
+		// Unique type ID within the same container: we use id_base if nothing else was specified
+		template <typename T>
+		static consteval u32 get_type()
 		{
-			return add_type(0);
+			return T::id_base;
+		}
+
+		// Specified type ID for containers which their types may be sharing an overlapping IDs range
+		template <typename T> requires requires () { u32{T::id_type}; }
+		static consteval u32 get_type()
+		{
+			return T::id_type;
+		}
+
+		template <typename T>
+		static typeinfo make_typeinfo()
+		{
+			typeinfo info{};
+
+			using C = std::conditional_t<IdmCompatible<T> && std::is_constructible_v<T, stx::exact_t<utils::serial&>>, T, dummy_construct>;
+			using Type = std::conditional_t<IdmCompatible<T>, T, dummy_construct>;
+
+			if constexpr (std::is_same_v<C, T>)
+			{
+				info =
+				{
+					+id_traits_load_func<C>::load,
+					+[](utils::serial& ar, void* obj) { static_cast<C*>(obj)->save(ar); },
+					+id_traits_savable_func<C>::savable,
+					id_traits<C>::base, id_traits<C>::step, id_traits<C>::count, id_traits<C>::invl_range,
+				};
+
+				const u128 key = u128{get_type<C>()} << 64 | std::bit_cast<u64>(C::savestate_init_pos);
+
+				for (const auto& tinfo : get_typeinfo_map())
+				{
+					if (!(tinfo.first ^ key))
+					{
+						ensure(!std::memcmp(&info, &tinfo.second, sizeof(info)));
+						return info;
+					}
+				}
+
+				// id_base must be unique within all the objects with the same initialization posistion by definition of id_map with multiple types
+				get_typeinfo_map().emplace_back(key, info);
+			}
+			else
+			{
+				info =
+				{
+					nullptr,
+					nullptr,
+					nullptr,
+					id_traits<Type>::base, id_traits<Type>::step, id_traits<Type>::count, id_traits<Type>::invl_range,
+				};
+			}
+
+			return info;
 		}
 	};
-
-	template <typename T>
-	const u32 typeinfo::registered<T>::index = typeinfo::add_type(1);
 
 	// ID value with additional type stored
 	class id_key
 	{
-		u32 m_value;           // ID value
-		u32 m_type;            // True object type
+		u32 m_value; // ID value
+		u32 m_base;  // ID base (must be unique for each type in the same container)
 
 	public:
 		id_key() = default;
 
 		id_key(u32 value, u32 type)
 			: m_value(value)
-			, m_type(type)
+			, m_base(type)
 		{
 		}
 
@@ -114,7 +222,7 @@ namespace id_manager
 
 		u32 type() const
 		{
-			return m_type;
+			return m_base;
 		}
 
 		operator u32() const
@@ -133,6 +241,86 @@ namespace id_manager
 		{
 			// Preallocate memory
 			vec.reserve(T::id_count);
+		}
+
+		// Order it directly afterward the source type's position
+		static constexpr double savestate_init_pos = std::bit_cast<double>(std::bit_cast<u64>(T::savestate_init_pos) + 1);
+
+		id_map(utils::serial& ar)
+		{
+			vec.resize(T::id_count);
+
+			u32 i = ar.operator u32();
+
+			ensure(i <= T::id_count);
+
+			while (--i != umax)
+			{
+				// ID, type hash
+				const u32 id = ar;
+
+				const u128 type_init_pos = u128{u32{ar}} << 64 | std::bit_cast<u64>(T::savestate_init_pos);
+				const typeinfo* info = nullptr;
+
+				// Search load functions for the one of this type (see make_typeinfo() for explenation about key composition reasoning)
+				for (const auto& typeinfo : get_typeinfo_map())
+				{
+					if (!(typeinfo.first ^ type_init_pos))
+					{
+						info = std::addressof(typeinfo.second);
+					}
+				}
+	
+				ensure(info);
+
+				// Construct each object from information collected
+
+				// Simulate construction semantics (idm::last_id() value)
+				g_id = id;
+
+				auto& obj = vec[get_index(id, info->base, info->step, info->count, info->invl_range)]; 
+				ensure(!obj.second);
+
+				obj.first = id_key(id, static_cast<u32>(static_cast<u64>(type_init_pos >> 64)));
+				obj.second = info->load(ar);
+			}
+		}
+
+		void save(utils::serial& ar)
+		{
+			u32 obj_count = 0;
+			usz obj_count_offs = ar.data.size();
+
+			// To be patched at the end of the function
+			ar(obj_count);
+
+			for (const auto& p : vec)
+			{
+				if (!p.second) continue;
+
+				const u128 type_init_pos = u128{p.first.type()} << 64 | std::bit_cast<u64>(T::savestate_init_pos);
+				const typeinfo* info = nullptr;
+
+				// Search load functions for the one of this type (see make_typeinfo() for explenation about key composition reasoning)
+				for (const auto& typeinfo : get_typeinfo_map())
+				{
+					if (!(typeinfo.first ^ type_init_pos))
+					{
+						ensure(!std::exchange(info, std::addressof(typeinfo.second)));
+					}
+				}
+
+				// Save each object with needed information
+				if (info && info->savable(p.second.get()))
+				{
+					ar(p.first.value(), p.first.type());
+					info->save(ar, p.second.get());
+					obj_count++;
+				}
+			}
+
+			// Patch object count
+			std::memcpy(ar.data.data() + obj_count_offs, &obj_count, sizeof(obj_count));
 		}
 
 		template <bool dummy = false> requires (std::is_assignable_v<T&, thread_state>)
@@ -163,33 +351,12 @@ namespace id_manager
 // Object manager for emulated process. Multiple objects of specified arbitrary type are given unique IDs.
 class idm
 {
-	// Last allocated ID for constructors
-	static thread_local u32 g_id;
-
-	template <typename T>
-	static inline u32 get_type()
-	{
-		return id_manager::typeinfo::get_index<T>();
-	}
-
 	template <typename T>
 	static constexpr u32 get_index(u32 id)
 	{
 		using traits = id_manager::id_traits<T>;
 
-		constexpr u32 mask_out = ((1u << traits::invl_range.second) - 1) << traits::invl_range.first;
-
-		// Note: if id is lower than base, diff / step will be higher than count
-		u32 diff = (id & ~mask_out) - traits::base;
-
-		if (diff % traits::step)
-		{
-			// id is invalid, return invalid index
-			return traits::count;
-		}
-
-		// Get actual index
-		return diff / traits::step;
+		return id_manager::get_index(id, traits::base, traits::step, traits::count, traits::invl_range);
 	}
 
 	// Helper
@@ -259,7 +426,7 @@ class idm
 	using map_data = std::pair<id_manager::id_key, std::shared_ptr<void>>;
 
 	// Prepare new ID (returns nullptr if out of resources)
-	static map_data* allocate_id(std::vector<map_data>& vec, u32 type_id, u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range);
+	static map_data* allocate_id(std::vector<map_data>& vec, u32 type_id, u32 dst_id, u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range);
 
 	// Find ID (additionally check type if types are not equal)
 	template <typename T, typename Type>
@@ -297,21 +464,24 @@ class idm
 		return nullptr;
 	}
 
-	// Allocate new ID and assign the object from the provider()
+	// Allocate new ID (or use fixed ID) and assign the object from the provider()
 	template <typename T, typename Type, typename F>
-	static map_data* create_id(F&& provider)
+	static map_data* create_id(F&& provider, u32 id = id_manager::id_traits<Type>::invalid)
 	{
 		static_assert(PtrSame<T, Type>, "Invalid ID type combination");
 
 		// ID traits
 		using traits = id_manager::id_traits<Type>;
 
+		// Ensure make_typeinfo() is used for this type
+		stx::typedata<id_manager::typeinfo, Type>();
+
 		// Allocate new id
 		std::lock_guard lock(id_manager::g_mutex);
 
 		auto& map = g_fxo->get<id_manager::id_map<T>>();
 
-		if (auto* place = allocate_id(map.vec, get_type<Type>(), traits::base, traits::step, traits::count, traits::invl_range))
+		if (auto* place = allocate_id(map.vec, get_type<Type>(), id, traits::base, traits::step, traits::count, traits::invl_range))
 		{
 			// Get object, store it
 			place->second = provider();
@@ -338,7 +508,14 @@ public:
 	// Get last ID (updated in create_id/allocate_id)
 	static inline u32 last_id()
 	{
-		return g_id;
+		return id_manager::g_id;
+	}
+
+	// Get type ID that is meant to be unique within the same container
+	template <typename T>
+	static consteval u32 get_type()
+	{
+		return id_manager::typeinfo::get_type<T>();
 	}
 
 	// Add a new ID of specified type with specified constructor arguments (returns object or nullptr)
@@ -367,9 +544,9 @@ public:
 
 	// Add a new ID for an object returned by provider()
 	template <typename T, typename Made = T, typename F> requires (std::is_invocable_v<F&&>)
-	static inline u32 import(F&& provider)
+	static inline u32 import(F&& provider, u32 id = id_manager::id_traits<Made>::invalid)
 	{
-		if (auto pair = create_id<T, Made>(std::forward<F>(provider)))
+		if (auto pair = create_id<T, Made>(std::forward<F>(provider), id))
 		{
 			return pair->first;
 		}
@@ -379,9 +556,9 @@ public:
 
 	// Add a new ID for an existing object provided (returns new id)
 	template <typename T, typename Made = T>
-	static inline u32 import_existing(std::shared_ptr<T> ptr)
+	static inline u32 import_existing(std::shared_ptr<T> ptr, u32 id = id_manager::id_traits<Made>::invalid)
 	{
-		return import<T, Made>([&] { return std::move(ptr); });
+		return import<T, Made>([&] { return std::move(ptr); }, id);
 	}
 
 	// Access the ID record without locking (unsafe)

--- a/rpcs3/Emu/Io/KeyboardHandler.h
+++ b/rpcs3/Emu/Io/KeyboardHandler.h
@@ -77,6 +77,11 @@ public:
 	virtual void Init(const u32 max_connect) = 0;
 
 	virtual ~KeyboardHandlerBase() = default;
+	KeyboardHandlerBase(utils::serial* ar);
+	KeyboardHandlerBase(utils::serial& ar) : KeyboardHandlerBase(&ar) {}
+	void save(utils::serial& ar);
+
+	SAVESTATE_INIT_POS(19);
 
 	void Key(u32 code, bool pressed);
 	void SetIntercepted(bool intercepted);

--- a/rpcs3/Emu/Io/MouseHandler.h
+++ b/rpcs3/Emu/Io/MouseHandler.h
@@ -129,6 +129,13 @@ public:
 	virtual void Init(const u32 max_connect) = 0;
 	virtual ~MouseHandlerBase() = default;
 
+	SAVESTATE_INIT_POS(18);
+
+	MouseHandlerBase(const MouseHandlerBase&) = delete;
+	MouseHandlerBase(utils::serial* ar);
+	MouseHandlerBase(utils::serial& ar) : MouseHandlerBase(&ar) {}
+	void save(utils::serial& ar);
+
 	void Button(u8 button, bool pressed)
 	{
 		std::lock_guard lock(mutex);

--- a/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
+++ b/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
@@ -4,6 +4,8 @@
 
 class NullKeyboardHandler final : public KeyboardHandlerBase
 {
+	using KeyboardHandlerBase::KeyboardHandlerBase;
+
 public:
 	void Init(const u32 max_connect) override
 	{

--- a/rpcs3/Emu/Io/Null/NullMouseHandler.h
+++ b/rpcs3/Emu/Io/Null/NullMouseHandler.h
@@ -4,6 +4,8 @@
 
 class NullMouseHandler final : public MouseHandlerBase
 {
+	using MouseHandlerBase::MouseHandlerBase;
+
 public:
 	void Init(const u32 max_connect) override
 	{

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -13,13 +13,17 @@
 #include "Emu/Cell/SPURecompiler.h"
 #include "Emu/perf_meter.hpp"
 #include <deque>
+#include <span>
 
 #include "util/vm.hpp"
 #include "util/asm.hpp"
+#include "util/simd.hpp"
+#include "util/serialization.hpp"
 
 LOG_CHANNEL(vm_log, "VM");
 
 void ppu_remove_hle_instructions(u32 addr, u32 size);
+extern bool is_memory_read_only_of_executable(u32 addr);
 
 namespace vm
 {
@@ -883,7 +887,7 @@ namespace vm
 		// Notify rsx to invalidate range
 		// Note: This must be done *before* memory gets unmapped while holding the vm lock, otherwise
 		//       the RSX might try to call VirtualProtect on memory that is already unmapped
-		if (auto& rsxthr = g_fxo->get<rsx::thread>(); g_fxo->is_init<rsx::thread>())
+		if (auto& rsxthr = g_fxo->get<rsx::thread>(); !Emu.IsPaused() && g_fxo->is_init<rsx::thread>())
 		{
 			rsxthr.on_notify_memory_unmapped(addr, size);
 		}
@@ -1145,8 +1149,14 @@ namespace vm
 		return flags;
 	}
 
+	static u64 init_block_id()
+	{
+		static atomic_t<u64> s_id = 1;
+		return s_id++;
+	}
+
 	block_t::block_t(u32 addr, u32 size, u64 flags)
-		: m_id([](){ static atomic_t<u64> s_id = 1; return s_id++; }())
+		: m_id(init_block_id())
 		, addr(addr)
 		, size(size)
 		, flags(process_block_flags(flags))
@@ -1450,6 +1460,210 @@ namespace vm
 		return imp_used(lock);
 	}
 
+	void block_t::get_shared_memory(std::vector<std::pair<utils::shm*, u32>>& shared)
+	{
+		auto& m_map = (m.*block_map)();
+
+		if (!(flags & preallocated))
+		{
+			shared.reserve(shared.size() + m_map.size());
+
+			for (const auto& [addr, shm] : m_map)
+			{
+				shared.emplace_back(shm.second.get(), addr);
+			}
+		}
+	}
+
+	u32 block_t::get_shm_addr(const std::shared_ptr<utils::shm>& shared)
+	{
+		auto& m_map = (m.*block_map)();
+
+		if (!(flags & preallocated))
+		{
+			for (auto& [addr, pair] : m_map)
+			{
+				if (pair.second == shared)
+				{
+					return addr;
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	static bool check_cache_line_zero(const void* ptr)
+	{
+		const auto p = reinterpret_cast<const v128*>(ptr);
+		const v128 _1 = p[0] | p[1];
+		const v128 _2 = p[2] | p[3];
+		const v128 _3 = p[4] | p[5];
+		const v128 _4 = p[6] | p[7];
+		const v128 _5 = _1 | _2;
+		const v128 _6 = _3 | _4;
+		const v128 _7 = _5 | _6; 
+		return _7 == v128{};
+	}
+
+	static void save_memory_bytes(utils::serial& ar, const u8* ptr, usz size)
+	{
+		AUDIT(ar.is_writing() && !(size % 1024));
+
+		for (; size; ptr += 128 * 8, size -= 128 * 8)
+		{
+			ar(u8{}); // bitmap of 1024 bytes (bit is 128-byte)
+			u8 bitmap = 0, count = 0;
+
+			for (usz i = 0, end = std::min<usz>(size, 128 * 8); i < end; i += 128)
+			{
+				if (!check_cache_line_zero(ptr + i))
+				{
+					bitmap |= 1u << (i / 128);
+					count++;
+					ar(std::span(ptr + i, 128));
+				}
+			}
+
+			// Patch bitmap with correct value
+			*std::prev(&ar.data.back(), count * 128) = bitmap;
+		}
+	}
+
+	static void load_memory_bytes(utils::serial& ar, u8* ptr, usz size)
+	{
+		AUDIT(ar.is_writing() && !(size % 128));
+
+		for (; size; ptr += 128 * 8, size -= 128 * 8)
+		{
+			const u8 bitmap{ar};
+
+			for (usz i = 0, end = std::min<usz>(size, 128 * 8); i < end; i += 128)
+			{
+				if (bitmap & (1u << (i / 128)))
+				{
+					ar(std::span(ptr + i, 128));
+				}
+			}
+		}
+	}
+
+	void block_t::save(utils::serial& ar, std::map<utils::shm*, usz>& shared)
+	{
+		auto& m_map = (m.*block_map)();
+
+		ar(addr, size, flags);
+
+		for (const auto& [addr, shm] : m_map)
+		{
+			// Assume first page flags represent all the map
+			ar(g_pages[addr / 4096 + !!(flags & stack_guarded)]);
+
+			ar(addr);
+			ar(shm.first);
+
+			if (flags & preallocated)
+			{
+				// Do not save read-only memory which comes from the executable
+				// Because it couldn't have changed
+				if (!(ar.data.back() & page_writable) && is_memory_read_only_of_executable(addr))
+				{
+					// Revert changes
+					ar.data.resize(ar.data.size() - (sizeof(u32) * 2 + sizeof(memory_page)));
+					vm_log.success("Removed read-only memory block of the executable from savestate. (addr=0x%x, size=0x%x)", addr, shm.first);
+					continue;
+				}
+
+				// Save raw binary image
+				const u32 guard_size = flags & stack_guarded ? 0x1000 : 0;
+				save_memory_bytes(ar, vm::get_super_ptr<const u8>(addr + guard_size), shm.first - guard_size * 2);
+			}
+			else
+			{
+				// Save index of shm
+				ar(shared[shm.second.get()]);
+			}
+		}
+
+		// Terminator
+		ar(u8{0});
+	}
+
+	block_t::block_t(utils::serial& ar, std::vector<std::shared_ptr<utils::shm>>& shared)
+		: m_id(init_block_id())
+		, addr(ar)
+		, size(ar)
+		, flags(ar)
+	{
+		if (flags & preallocated)
+		{
+			m_common = std::make_shared<utils::shm>(size);
+			m_common->map_critical(vm::base(addr), utils::protection::no);
+			m_common->map_critical(vm::get_super_ptr(addr));
+			lock_sudo(addr, size);
+		}
+
+		auto& m_map = (m.*block_map)();
+
+		std::shared_ptr<utils::shm> null_shm;
+
+		while (true)
+		{
+			const u8 flags0 = ar;
+
+			if (!(flags0 & page_allocated))
+			{
+				// Terminator found
+				break;
+			}
+
+			const u32 addr0 = ar;
+			const u32 size0 = ar;
+
+			u64 pflags = 0;
+
+			if (flags0 & page_executable)
+			{
+				pflags |= alloc_executable;
+			}
+
+			if (~flags0 & page_writable)
+			{
+				pflags |= alloc_unwritable;
+			}
+
+			if (~flags0 & page_readable)
+			{
+				pflags |= alloc_hidden;
+			}
+
+			if ((flags & page_size_64k) == page_size_64k)
+			{
+				pflags |= page_64k_size;
+			}
+			else if (!(flags & (page_size_mask & ~page_size_1m)))
+			{
+				pflags |= page_1m_size;
+			}
+
+			// Map the memory through the same method as alloc() and falloc() 
+			// Copy the shared handle unconditionally
+			ensure(try_alloc(addr0, pflags, size0, ::as_rvalue(flags & preallocated ? null_shm : shared[ar.operator usz()])));
+
+			if (flags & preallocated)
+			{
+				// Load binary image
+				const u32 guard_size = flags & stack_guarded ? 0x1000 : 0;
+				load_memory_bytes(ar, vm::get_super_ptr<u8>(addr0 + guard_size), size0 - guard_size * 2);
+			}
+		}
+	}
+
+	bool _unmap_block(const std::shared_ptr<block_t>& block)
+	{
+		return block->unmap();
+	}
+
 	static bool _test_map(u32 addr, u32 size)
 	{
 		const auto range = utils::address_range::start_length(addr, size);
@@ -1623,7 +1837,7 @@ namespace vm
 
 				result.first = std::move(*it);
 				g_locations.erase(it);
-				ensure(result.first->unmap());
+				ensure(_unmap_block(result.first));
 				result.second = true;
 				return result;
 			}
@@ -1764,7 +1978,7 @@ namespace vm
 
 			for (auto& block : g_locations)
 			{
-				if (block) block->unmap();
+				if (block) _unmap_block(block);
 			}
 
 			g_locations.clear();
@@ -1782,6 +1996,106 @@ namespace vm
 
 		std::memset(g_range_lock_set, 0, sizeof(g_range_lock_set));
 		g_range_lock_bits = 0;
+	}
+
+	void save(utils::serial& ar)
+	{
+		// Shared memory lookup, sample address is saved for easy memory copy
+		// Just need one address for this optimization 
+		std::vector<std::pair<utils::shm*, u32>> shared;
+
+		for (auto& loc : g_locations)
+		{
+			if (loc) loc->get_shared_memory(shared);
+		}
+
+		shared.erase(std::unique(shared.begin(), shared.end(), [](auto& a, auto& b) { return a.first == b.first; }), shared.end());
+
+		std::map<utils::shm*, usz> shared_map;
+
+		for (auto& p : shared)
+		{
+			shared_map.emplace(p.first, &p - shared.data());
+		}
+
+		// TODO: proper serialization of std::map
+		ar(static_cast<usz>(shared_map.size()));
+
+		for (const auto& [shm, addr] : shared)
+		{
+			//  Save shared memory
+			ar(shm->flags());
+
+			// TODO: string_view serialization (even with load function, so the loaded address points to a position of the stream's buffer)
+			ar(shm->size());
+			save_memory_bytes(ar, vm::get_super_ptr<u8>(addr), shm->size());
+		}
+
+		// TODO: Serialize std::vector direcly
+		ar(g_locations.size());
+
+		for (auto& loc : g_locations)
+		{
+			const u8 has = loc.operator bool();
+			ar(has);
+
+			if (loc)
+			{
+				loc->save(ar, shared_map);
+			}
+		}
+	}
+
+	void load(utils::serial& ar)
+	{
+		std::vector<std::shared_ptr<utils::shm>> shared;
+		shared.resize(ar.operator usz());
+
+		for (auto& shm : shared)
+		{
+			// Load shared memory
+
+			const u32 flags = ar;
+			const u64 size = ar;
+			shm = std::make_shared<utils::shm>(size, flags);
+
+			// Load binary image
+			// elad335: I'm not proud about it as well.. (ideal situation is to not call map_self())
+			load_memory_bytes(ar, shm->map_self(), shm->size());
+		}
+
+		for (auto& block : g_locations)
+		{
+			if (block) _unmap_block(block);
+		}
+
+		g_locations.clear();
+		g_locations.resize(ar.operator usz());
+
+		for (auto& loc : g_locations)
+		{
+			const u8 has = ar;
+
+			if (has)
+			{
+				loc = std::make_shared<block_t>(ar, shared);
+			}
+		}
+
+		g_range_lock = 0;
+	}
+
+	u32 get_shm_addr(const std::shared_ptr<utils::shm>& shared)
+	{
+		for (auto& loc : g_locations)
+		{
+			if (u32 addr = loc ? loc->get_shm_addr(shared) : 0)
+			{
+				return addr;
+			}
+		}
+
+		return 0;
 	}
 }
 

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <map>
 #include "util/types.hpp"
 #include "util/atomic.hpp"
 #include "util/auto_typemap.hpp"
@@ -11,6 +12,7 @@
 namespace utils
 {
 	class shm;
+	class address_range;
 }
 
 namespace vm
@@ -129,6 +131,7 @@ namespace vm
 
 		// Unmap block
 		bool unmap();
+		friend bool _unmap_block(const std::shared_ptr<block_t>&);
 
 	public:
 		block_t(u32 addr, u32 size, u64 flags);
@@ -167,8 +170,15 @@ namespace vm
 			return m_id;
 		}
 
-		friend std::pair<std::shared_ptr<block_t>, bool> unmap(u32, bool, const std::shared_ptr<block_t>*);
-		friend void close();
+		// Serialization helper for shared memory
+		void get_shared_memory(std::vector<std::pair<utils::shm*, u32>>& shared);
+
+		// Returns sample address for shared memory, 0 on failure
+		u32 get_shm_addr(const std::shared_ptr<utils::shm>& shared);
+
+		// Serialization
+		void save(utils::serial& ar, std::map<utils::shm*, usz>& shared);
+		block_t(utils::serial& ar, std::vector<std::shared_ptr<utils::shm>>& shared);
 	};
 
 	// Create new memory block with specified parameters and return it
@@ -335,6 +345,12 @@ namespace vm
 	}
 
 	void close();
+
+	void load(utils::serial& ar);
+	void save(utils::serial& ar);
+
+	// Returns sample address for shared memory, 0 on failure (wraps block_t::get_shm_addr)
+	u32 get_shm_addr(const std::shared_ptr<utils::shm>& shared);
 
 	template <typename T, typename AT>
 	class _ptr_base;

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -29,7 +29,7 @@ namespace vm
 		using type = T;
 		using addr_type = std::remove_cv_t<AT>;
 
-		using enable_bitcopy = std::true_type;
+		ENABLE_BITWISE_SERIALIZATION;
 
 		_ptr_base() = default;
 
@@ -240,7 +240,7 @@ namespace vm
 
 	public:
 		using addr_type = std::remove_cv_t<AT>;
-		using enable_bitcopy = std::true_type;
+		ENABLE_BITWISE_SERIALIZATION;
 
 		_ptr_base() = default;
 

--- a/rpcs3/Emu/NP/np_allocator.h
+++ b/rpcs3/Emu/NP/np_allocator.h
@@ -15,8 +15,11 @@ namespace np
 	{
 	public:
 		memory_allocator() = default;
+		memory_allocator(utils::serial& ar) noexcept { save(ar); }
 		memory_allocator(const memory_allocator&) = delete;
 		memory_allocator& operator=(const memory_allocator&) = delete;
+
+		void save(utils::serial& ar);
 
 		void setup(vm::ptr<void> ptr_pool, u32 size)
 		{

--- a/rpcs3/Emu/NP/np_contexts.h
+++ b/rpcs3/Emu/NP/np_contexts.h
@@ -13,6 +13,7 @@ struct score_ctx
 	static const u32 id_base  = 1;
 	static const u32 id_step  = 1;
 	static const u32 id_count = 32;
+	SAVESTATE_INIT_POS(25);
 
 	SceNpCommunicationId communicationId{};
 	SceNpCommunicationPassphrase passphrase{};
@@ -27,6 +28,7 @@ struct score_transaction_ctx
 	static const u32 id_base  = 1;
 	static const u32 id_step  = 1;
 	static const u32 id_count = 32;
+	SAVESTATE_INIT_POS(26);
 
 	s32 score_context_id      = 0;
 };
@@ -41,6 +43,7 @@ struct match2_ctx
 	static const u32 id_base  = 1;
 	static const u32 id_step  = 1;
 	static const u32 id_count = 255;
+	SAVESTATE_INIT_POS(27);
 
 	SceNpCommunicationId communicationId{};
 	SceNpCommunicationPassphrase passphrase{};
@@ -62,6 +65,7 @@ struct lookup_title_ctx
 	static const u32 id_base  = 1;
 	static const u32 id_step  = 1;
 	static const u32 id_count = 32;
+	SAVESTATE_INIT_POS(28);
 
 	SceNpCommunicationId communicationId{};
 	SceNpCommunicationPassphrase passphrase{};
@@ -76,6 +80,7 @@ struct lookup_transaction_ctx
 	static const u32 id_base  = 1;
 	static const u32 id_step  = 1;
 	static const u32 id_count = 32;
+	SAVESTATE_INIT_POS(29);
 
 	s32 lt_ctx = 0;
 };
@@ -89,6 +94,7 @@ struct commerce2_ctx
 	static const u32 id_base  = 1;
 	static const u32 id_step  = 1;
 	static const u32 id_count = 32;
+	SAVESTATE_INIT_POS(30);
 
 	u32 version{};
 	SceNpId npid{};
@@ -106,6 +112,7 @@ struct signaling_ctx
 	static const u32 id_base  = 1;
 	static const u32 id_step  = 1;
 	static const u32 id_count = 32;
+	SAVESTATE_INIT_POS(31);
 
 	SceNpId npid{};
 	vm::ptr<SceNpSignalingHandler> handler{};

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -66,7 +66,11 @@ namespace np
 	class np_handler
 	{
 	public:
+		SAVESTATE_INIT_POS(5);
+
 		np_handler();
+		np_handler(utils::serial& ar);
+		void save(utils::serial& ar);
 
 		const std::array<u8, 6>& get_ether_addr() const;
 		const std::string& get_hostname() const;

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.h
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.h
@@ -24,7 +24,7 @@ namespace rsx
 		// simple block to hold ps3 address and data
 		struct memory_block
 		{
-			using enable_bitcopy = std::true_type;
+			ENABLE_BITWISE_SERIALIZATION;
 
 			u32 offset; // Offset in rsx address space
 			u32 location; // rsx memory location of the block
@@ -41,7 +41,7 @@ namespace rsx
 
 		struct tile_info
 		{
-			using enable_bitcopy = std::true_type;
+			ENABLE_BITWISE_SERIALIZATION;
 
 			u32 tile;
 			u32 limit;
@@ -51,7 +51,7 @@ namespace rsx
 
 		struct zcull_info
 		{
-			using enable_bitcopy = std::true_type;
+			ENABLE_BITWISE_SERIALIZATION;
 
 			u32 region;
 			u32 size;
@@ -64,7 +64,7 @@ namespace rsx
 		// bleh, may need to break these out, might be unnecessary to do both always
 		struct tile_state
 		{
-			using enable_bitcopy = std::true_type;
+			ENABLE_BITWISE_SERIALIZATION;
 
 			tile_info tiles[15]{};
 			zcull_info zculls[8]{};
@@ -72,7 +72,7 @@ namespace rsx
 
 		struct buffer_state
 		{
-			using enable_bitcopy = std::true_type;
+			ENABLE_BITWISE_SERIALIZATION;
 
 			u32 width{0};
 			u32 height{0};
@@ -82,7 +82,7 @@ namespace rsx
 
 		struct display_buffers_state
 		{
-			using enable_bitcopy = std::true_type;
+			ENABLE_BITWISE_SERIALIZATION;
 
 			std::array<buffer_state, 8> buffers{};
 			u32 count{0};

--- a/rpcs3/Emu/RSX/GCM.h
+++ b/rpcs3/Emu/RSX/GCM.h
@@ -98,6 +98,8 @@ struct CellGcmTileInfo
 
 struct GcmZcullInfo
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	u32 offset;
 	u32 width;
 	u32 height;
@@ -128,6 +130,8 @@ struct GcmZcullInfo
 
 struct GcmTileInfo
 {
+	ENABLE_BITWISE_SERIALIZATION;
+
 	u32 location;
 	u32 offset;
 	u32 size;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -13,7 +13,7 @@ u64 GLGSRender::get_cycles()
 	return thread_ctrl::get_cycles(static_cast<named_thread<GLGSRender>&>(*this));
 }
 
-GLGSRender::GLGSRender() : GSRender()
+GLGSRender::GLGSRender(utils::serial* ar) noexcept : GSRender(ar)
 {
 	m_shaders_cache = std::make_unique<gl::shader_cache>(m_prog_buffer, "opengl", "v1.93");
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -70,8 +70,6 @@ namespace gl
 
 class GLGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 {
-private:
-
 	gl::sampler_state m_fs_sampler_states[rsx::limits::fragment_textures_count];         // Fragment textures
 	gl::sampler_state m_fs_sampler_mirror_states[rsx::limits::fragment_textures_count];  // Alternate views of fragment textures with different format (e.g Depth vs Stencil for D24S8)
 	gl::sampler_state m_vs_sampler_states[rsx::limits::vertex_textures_count];           // Vertex textures
@@ -146,7 +144,9 @@ private:
 
 public:
 	u64 get_cycles() final;
-	GLGSRender();
+
+	GLGSRender(utils::serial* ar) noexcept;
+	GLGSRender() noexcept : GLGSRender(nullptr) {}
 
 private:
 

--- a/rpcs3/Emu/RSX/GSRender.cpp
+++ b/rpcs3/Emu/RSX/GSRender.cpp
@@ -2,8 +2,7 @@
 
 #include "GSRender.h"
 
-GSRender::GSRender()
-	: m_context(nullptr)
+GSRender::GSRender(utils::serial* ar) noexcept : rsx::thread(ar)
 {
 	if (auto gs_frame = Emu.GetCallbacks().get_gs_frame())
 	{
@@ -36,13 +35,13 @@ void GSRender::on_init_thread()
 
 void GSRender::on_exit()
 {
+	rsx::thread::on_exit();
+
 	if (m_frame)
 	{
 		m_frame->delete_context(m_context);
 		m_context = nullptr;
 	}
-
-	rsx::thread::on_exit();
 }
 
 void GSRender::flip(const rsx::display_flip_info_t&)

--- a/rpcs3/Emu/RSX/GSRender.h
+++ b/rpcs3/Emu/RSX/GSRender.h
@@ -20,11 +20,12 @@ class GSRender : public rsx::thread
 {
 protected:
 	GSFrameBase* m_frame;
-	draw_context_t m_context;
+	draw_context_t m_context = nullptr;
 
 public:
-	GSRender();
 	~GSRender() override;
+
+	GSRender(utils::serial* ar) noexcept;
 
 	void on_init_thread() override;
 	void on_exit() override;

--- a/rpcs3/Emu/RSX/Null/NullGSRender.cpp
+++ b/rpcs3/Emu/RSX/Null/NullGSRender.cpp
@@ -6,7 +6,7 @@ u64 NullGSRender::get_cycles()
 	return thread_ctrl::get_cycles(static_cast<named_thread<NullGSRender>&>(*this));
 }
 
-NullGSRender::NullGSRender() : GSRender()
+NullGSRender::NullGSRender(utils::serial* ar) noexcept : GSRender(ar)
 {
 }
 

--- a/rpcs3/Emu/RSX/Null/NullGSRender.h
+++ b/rpcs3/Emu/RSX/Null/NullGSRender.h
@@ -5,7 +5,9 @@ class NullGSRender : public GSRender
 {
 public:
 	u64 get_cycles() final;
-	NullGSRender();
+
+	NullGSRender(utils::serial* ar) noexcept;
+	NullGSRender() noexcept : NullGSRender(nullptr) {}
 
 private:
 	void end() override;

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -810,6 +810,9 @@ namespace rsx
 		}
 		while (fifo_ctrl->read_unsafe(command));
 
-		fifo_ctrl->sync_get();
+		if (cpu_flag::again - state)
+		{
+			fifo_ctrl->sync_get();
+		}
 	}
 }

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -45,7 +45,7 @@ extern thread_local std::string(*g_tls_log_prefix)();
 template <>
 bool serialize<rsx::rsx_state>(utils::serial& ar, rsx::rsx_state& o)
 {
-	return ar(o.transform_program, /*o.transform_constants,*/ o.registers);
+	return ar(o.transform_program, o.transform_constants, o.registers);
 }
 
 template <>
@@ -71,6 +71,29 @@ template <>
 bool serialize<rsx::frame_capture_data::replay_command>(utils::serial& ar, rsx::frame_capture_data::replay_command& o)
 {
 	return ar(o.rsx_command, o.memory_state, o.tile_state, o.display_buffer_state);
+}
+
+template <>
+bool serialize<rsx::rsx_iomap_table>(utils::serial& ar, rsx::rsx_iomap_table& o)
+{
+	// We do not need more than that
+	ar(std::span(o.ea.data(), 512));
+
+	if (!ar.is_writing())
+	{
+		// Populate o.io
+		for (const atomic_t<u32>& ea_addr : o.ea)
+		{
+			const u32& addr = ea_addr.raw();
+
+			if (addr != umax)
+			{
+				o.io[addr >> 20].raw() = static_cast<u32>(&ea_addr - o.ea.data()) << 20;
+			}
+		}
+	}
+
+	return true;
 }
 
 namespace rsx
@@ -413,7 +436,26 @@ namespace rsx
 		g_access_violation_handler = nullptr;
 	}
 
-	thread::thread()
+	void thread::save(utils::serial& ar)
+	{
+		USING_SERIALIZATION_VERSION_COND(ar.is_writing(), rsx);
+ 
+		ar(rsx::method_registers);
+	
+		for (auto& v : vertex_push_buffers)
+		{
+			ar(v.attr, v.size, v.type, v.vertex_count, v.dword_count, v.data);
+		}
+
+		ar(element_push_buffer, fifo_ret_addr, saved_fifo_ret, zcull_surface_active, m_surface_info, m_depth_surface_info, m_framebuffer_layout);
+		ar(dma_address, iomap_table, restore_point, tiles, zculls, display_buffers, display_buffers_count, current_display_buffer);
+		ar(enable_second_vhandler, requested_vsync);
+		ar(device_addr, label_addr, main_mem_size, local_mem_size, rsx_event_port, driver_info);
+		ar(in_begin_end, zcull_stats_enabled, zcull_rendering_enabled, zcull_pixel_cnt_enabled);
+		ar(display_buffers, display_buffers_count, current_display_buffer);
+	}
+
+	thread::thread(utils::serial* _ar)
 		: cpu_thread(0x5555'5555)
 	{
 		g_access_violation_handler = [this](u32 address, bool is_writing)
@@ -435,6 +477,35 @@ namespace rsx
 		}
 
 		state -= cpu_flag::stop + cpu_flag::wait; // TODO: Remove workaround
+
+		if (!_ar)
+		{
+			return;
+		}
+
+		serialized = true;
+		save(*_ar);
+
+		if (dma_address)
+		{
+			ctrl = vm::_ptr<RsxDmaControl>(dma_address);
+			m_rsx_thread_exiting = false;
+		}
+
+		if (g_cfg.savestate.start_paused)
+		{
+			m_pause_on_first_flip = true;
+		}
+	}
+
+	avconf::avconf(utils::serial& ar)
+	{
+		ar(*this);
+	}
+
+	void avconf::save(utils::serial& ar)
+	{
+		ar(*this);
 	}
 
 	void thread::capture_frame(const std::string &name)
@@ -628,7 +699,7 @@ namespace rsx
 			return fmt::format("RSX [0x%07x]", rsx->ctrl ? +rsx->ctrl->get : 0);
 		};
 
-		method_registers.init();
+		if (!serialized) method_registers.init();
 
 		rsx::overlays::reset_performance_overlay();
 
@@ -646,8 +717,10 @@ namespace rsx
 
 		performance_counters.state = FIFO_state::empty;
 
+		Emu.CallFromMainThread([]{ Emu.RunPPU(); });
+
 		// Wait for startup (TODO)
-		while (m_rsx_thread_exiting)
+		while (m_rsx_thread_exiting || Emu.IsPaused())
 		{
 			// Wait for external pause events
 			if (external_interrupt_lock)
@@ -669,9 +742,15 @@ namespace rsx
 			thread_ctrl::wait_for(1000);
 		}
 
+		if (is_stopped())
+		{
+			return;
+		}
+
 		performance_counters.state = FIFO_state::running;
 
 		fifo_ctrl = std::make_unique<::rsx::FIFO::FIFO_control>(this);
+		fifo_ctrl->set_get(ctrl->get);
 
 		last_guest_flip_timestamp = rsx::uclock() - 1000000;
 
@@ -796,6 +875,11 @@ namespace rsx
 
 	void thread::on_exit()
 	{
+		if (zcull_ctrl)
+		{
+			zcull_ctrl->sync(this);
+		}
+
 		// Deregister violation handler
 		g_access_violation_handler = nullptr;
 
@@ -803,7 +887,6 @@ namespace rsx
 		std::this_thread::sleep_for(10ms);
 		do_local_task(rsx::FIFO_state::lock_wait);
 
-		m_rsx_thread_exiting = true;
 		g_fxo->get<rsx::dma_manager>().join();
 		state += cpu_flag::exit;
 	}
@@ -1087,6 +1170,14 @@ namespace rsx
 		if (m_eng_interrupt_mask & rsx::pipe_flush_interrupt)
 		{
 			sync();
+		}
+
+		if (is_stopped())
+		{
+			std::lock_guard lock(m_mtx_task);
+
+			m_invalidated_memory_range = utils::address_range::start_end(0x2 << 28, 0xdu << 28);
+			handle_invalidated_memory_range();
 		}
 	}
 
@@ -2519,6 +2610,12 @@ namespace rsx
 		if (info.emu_flip)
 		{
 			performance_counters.sampled_frames++;
+
+			if (m_pause_on_first_flip)
+			{
+				Emu.Pause();
+				m_pause_on_first_flip = false;
+			}
 		}
 
 		last_host_flip_timestamp = rsx::uclock();
@@ -2958,6 +3055,12 @@ namespace rsx
 		if (!m_invalidated_memory_range.valid())
 			return;
 
+		if (is_stopped())
+		{
+			on_invalidate_memory_range(m_invalidated_memory_range, rsx::invalidation_cause::read);
+			on_invalidate_memory_range(m_invalidated_memory_range, rsx::invalidation_cause::write);
+		}
+
 		on_invalidate_memory_range(m_invalidated_memory_range, rsx::invalidation_cause::unmap);
 		m_invalidated_memory_range.invalidate();
 	}
@@ -3123,7 +3226,7 @@ namespace rsx
 		m_profiler.enabled = !!g_cfg.video.overlay;
 	}
 
-	void thread::request_emu_flip(u32 buffer)
+	bool thread::request_emu_flip(u32 buffer)
 	{
 		if (is_current_thread()) // requested through command buffer
 		{
@@ -3135,13 +3238,22 @@ namespace rsx
 			if (async_flip_requested & flip_request::emu_requested)
 			{
 				// ignore multiple requests until previous happens
-				return;
+				return true;
 			}
 
 			async_flip_buffer = buffer;
 			async_flip_requested |= flip_request::emu_requested;
+
 			m_eng_interrupt_mask |= rsx::display_interrupt;
+	
+			if (state & cpu_flag::exit)
+			{
+				// Resubmit possibly-ignored flip on savestate load
+				return false;
+			}
 		}
+
+		return true;
 	}
 
 	void thread::handle_emu_flip(u32 buffer)
@@ -3196,12 +3308,6 @@ namespace rsx
 				{
 					const auto delay_us = target_rsx_flip_time - time;
 					lv2_obj::wait_timeout<false, false>(delay_us);
-
-					if (thread_ctrl::state() == thread_state::aborting)
-					{
-						return;
-					}
-
 					performance_counters.idle_time += delay_us;
 				}
 			}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1176,7 +1176,7 @@ namespace rsx
 		{
 			std::lock_guard lock(m_mtx_task);
 
-			m_invalidated_memory_range = utils::address_range::start_end(0x2 << 28, 0xdu << 28);
+			m_invalidated_memory_range = utils::address_range::start_end(0x2 << 28, constants::local_mem_base + local_mem_size - 1);
 			handle_invalidated_memory_range();
 		}
 	}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -362,6 +362,8 @@ namespace rsx
 
 	struct framebuffer_layout
 	{
+		ENABLE_BITWISE_SERIALIZATION;
+
 		u16 width;
 		u16 height;
 		std::array<u32, 4> color_addresses;
@@ -498,6 +500,9 @@ namespace rsx
 		rsx::profiling_timer m_profiler;
 		frame_statistics_t m_frame_stats;
 
+		// Savestates vrelated
+		bool m_pause_on_first_flip = false;
+
 	public:
 		RsxDmaControl* ctrl = nullptr;
 		u32 dma_address{0};
@@ -561,6 +566,7 @@ namespace rsx
 
 		// I hate this flag, but until hle is closer to lle, its needed
 		bool isHLE{ false };
+		bool serialized = false;
 
 		u32 flip_status;
 		int debug_level;
@@ -579,6 +585,7 @@ namespace rsx
 		u32 local_mem_size{0};
 		u32 rsx_event_port{0};
 		u32 driver_info{0};
+		bool gcm_intr_thread_offline = false; // Hack for savestates
 
 		void send_event(u64, u64, u64) const;
 
@@ -676,7 +683,10 @@ namespace rsx
 		static constexpr auto thread_name = "rsx::thread"sv;
 
 	protected:
-		thread();
+		thread(utils::serial* ar);
+
+		thread() : thread(static_cast<utils::serial*>(nullptr)) {}
+
 		virtual void on_task();
 		virtual void on_exit();
 
@@ -692,6 +702,7 @@ namespace rsx
 	public:
 		thread(const thread&) = delete;
 		thread& operator=(const thread&) = delete;
+		void save(utils::serial& ar);
 
 		virtual void clear_surface(u32 /*arg*/) {}
 		virtual void begin();
@@ -820,7 +831,7 @@ namespace rsx
 		void init(u32 ctrlAddress);
 
 		// Emu App/Game flip, only immediately flips when called from rsxthread
-		void request_emu_flip(u32 buffer);
+		bool request_emu_flip(u32 buffer);
 
 		void pause();
 		void unpause();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -332,7 +332,7 @@ u64 VKGSRender::get_cycles()
 	return thread_ctrl::get_cycles(static_cast<named_thread<VKGSRender>&>(*this));
 }
 
-VKGSRender::VKGSRender() : GSRender()
+VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 {
 	if (m_instance.create("RPCS3"))
 	{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -197,8 +197,10 @@ private:
 
 public:
 	u64 get_cycles() final;
-	VKGSRender();
 	~VKGSRender() override;
+
+	VKGSRender(utils::serial* ar) noexcept;
+	VKGSRender() noexcept : VKGSRender(nullptr) {}
 
 private:
 	void prepare_rtts(rsx::framebuffer_creation_context context);

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -128,6 +128,8 @@ namespace rsx
 
 		gcm_framebuffer_info() = default;
 
+		ENABLE_BITWISE_SERIALIZATION;
+
 		void calculate_memory_range(u32 aa_factor_u, u32 aa_factor_v)
 		{
 			// Account for the last line of the block not reaching the end
@@ -161,8 +163,13 @@ namespace rsx
 		u32 resolution_y = 720;    // Y RES
 		atomic_t<u32> state = 0;   // 1 after cellVideoOutConfigure was called
 
+		ENABLE_BITWISE_SERIALIZATION;
+		SAVESTATE_INIT_POS(12);
+
 		avconf() noexcept;
 		~avconf() = default;
+		avconf(utils::serial& ar);
+		void save(utils::serial& ar);
 
 		u32 get_compatible_gcm_format() const;
 		u8 get_bpp() const;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -10,6 +10,8 @@
 
 #include "Emu/Cell/timers.hpp"
 
+void init_fxo_for_exec(utils::serial*, bool);
+
 struct progress_dialog_workaround
 {
 	// WORKAROUND:
@@ -28,6 +30,7 @@ enum class system_state : u32
 	paused,
 	frozen, // paused but cannot resume
 	ready,
+	starting,
 };
 
 enum class game_boot_result : u32
@@ -41,8 +44,15 @@ enum class game_boot_result : u32
 	decryption_error,
 	file_creation_error,
 	firmware_missing,
-	unsupported_disc_type
+	unsupported_disc_type,
+	savestate_corrupted,
+	savestate_version_unsupported,
 };
+
+constexpr bool is_error(game_boot_result res)
+{
+	return res != game_boot_result::no_errors;
+}
 
 enum class cfg_mode
 {
@@ -71,9 +81,9 @@ struct EmuCallbacks
 	std::function<void()> init_mouse_handler;
 	std::function<void(std::string_view title_id)> init_pad_handler;
 	std::function<std::unique_ptr<class GSFrameBase>()> get_gs_frame;
-	std::function<void()> init_gs_render;
 	std::function<std::shared_ptr<class camera_handler_base>()> get_camera_handler;
 	std::function<std::shared_ptr<class music_handler_base>()> get_music_handler;
+	std::function<void(utils::serial*)> init_gs_render;
 	std::function<std::shared_ptr<class AudioBackend>()> get_audio;
 	std::function<std::shared_ptr<class MsgDialogBase>()> get_msg_dialog;
 	std::function<std::shared_ptr<class OskDialogBase>()> get_osk_dialog;
@@ -84,7 +94,12 @@ struct EmuCallbacks
 	std::function<std::string(localized_string_id, const char*)> get_localized_string;
 	std::function<std::u32string(localized_string_id, const char*)> get_localized_u32string;
 	std::function<void(const std::string&)> play_sound;
-	std::string(*resolve_path)(std::string_view) = nullptr; // Resolve path using Qt
+	std::string(*resolve_path)(std::string_view) = [](std::string_view arg){ return std::string{arg}; }; // Resolve path using Qt
+};
+
+namespace utils
+{
+	struct serial;
 };
 
 class Emulator final
@@ -114,6 +129,7 @@ class Emulator final
 	std::string m_game_dir{"PS3_GAME"};
 	std::string m_usr{"00000001"};
 	u32 m_usrid{1};
+	std::shared_ptr<utils::serial> m_ar;
 
 	// This flag should be adjusted before each Kill() or each BootGame() and similar because:
 	// 1. It forces an application to boot immediately by calling Run() in Load().
@@ -121,6 +137,18 @@ class Emulator final
 	bool m_force_boot = false;
 
 	bool m_has_gui = true;
+
+	bool m_state_inspection_savestate = false;
+
+	std::vector<std::function<void()>> deferred_deserialization;
+
+	void ExecDeserializationRemnants()
+	{
+		for (auto&& func : ::as_rvalue(std::move(deferred_deserialization)))
+		{
+			func();
+		}
+	}
 
 public:
 	Emulator() = default;
@@ -151,6 +179,11 @@ public:
 	void CallFromMainThread(std::function<void()>&& func, stop_counter_t counter) const
 	{
 		CallFromMainThread(std::move(func), nullptr, true, static_cast<u64>(counter));
+	}
+
+	void DeferDeserialization(std::function<void()>&& func)
+	{
+		deferred_deserialization.emplace_back(std::move(func));
 	}
 
 	/** Set emulator mode to running unconditionnaly.
@@ -230,6 +263,9 @@ public:
 		return m_usr;
 	}
 
+	// Get deserialization manager
+	utils::serial* DeserialManager() const;
+
 	// u32 for cell.
 	u32 GetUsrId() const
 	{
@@ -257,18 +293,23 @@ public:
 
 	game_boot_result Load(const std::string& title_id = "", bool add_only = false, bool is_disc_patch = false);
 	void Run(bool start_playtime);
+	void RunPPU();
+	void FixGuestTime();
+	void FinalizeRunRequest();
+
 	bool Pause(bool freeze_emulation = false);
 	void Resume();
-	void GracefulShutdown(bool allow_autoexit = true, bool async_op = false);
-	void Kill(bool allow_autoexit = true);
-	game_boot_result Restart();
+	void GracefulShutdown(bool allow_autoexit = true, bool async_op = false, bool savestate = false);
+	void Kill(bool allow_autoexit = true, bool savestate = false);
+	game_boot_result Restart(bool savestate = false);
 	bool Quit(bool force_quit);
 	static void CleanUp();
 
 	bool IsRunning() const { return m_state == system_state::running; }
-	bool IsPaused()  const { return m_state >= system_state::paused; } // ready is also considered paused by this function
+	bool IsPaused()  const { return m_state >= system_state::paused; } // ready/starting are also considered paused by this function
 	bool IsStopped() const { return m_state == system_state::stopped; }
 	bool IsReady()   const { return m_state == system_state::ready; }
+	bool IsStarting() const { return m_state == system_state::starting; }
 	auto GetStatus() const { system_state state = m_state; return state == system_state::frozen ? system_state::paused : state; }
 
 	bool HasGui() const { return m_has_gui; }
@@ -291,6 +332,7 @@ public:
 
 	static game_boot_result GetElfPathFromDir(std::string& elf_path, const std::string& path);
 	static void GetBdvdDir(std::string& bdvd_dir, std::string& sfb_dir, std::string& game_dir, const std::string& elf_dir);
+	friend void init_fxo_for_exec(utils::serial*, bool);
 };
 
 extern Emulator Emu;

--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -5,6 +5,7 @@
 #include <string_view>
 
 struct lv2_fs_mount_point;
+struct vfs_directory;
 
 namespace vfs
 {
@@ -16,6 +17,9 @@ namespace vfs
 
 	// Convert VFS path to fs path, optionally listing directories mounted in it
 	std::string get(std::string_view vpath, std::vector<std::string>* out_dir = nullptr, std::string* out_path = nullptr);
+
+	// Convert fs path to VFS path
+	std::string retrieve(std::string_view path, const vfs_directory* node = nullptr, std::vector<std::string_view>* mount_path = nullptr);
 
 	// Escape VFS name by replacing non-portable characters with surrogates
 	std::string escape(std::string_view name, bool escape_slash = false);

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -305,6 +305,16 @@ struct cfg_root : cfg::node
 		cfg::_enum<np_psn_status> psn_status{this, "PSN status", np_psn_status::disabled};
 	} net{this};
 
+	struct node_savestate : cfg::node
+	{
+		node_savestate(cfg::node* _this) : cfg::node(_this, "Savestate") {}
+
+		cfg::_bool start_paused{ this, "Start Paused" }; // Pause on first frame
+		cfg::_bool suspend_emu{ this, "Suspend Emulation Savestate Mode", false }; // Close emulation when saving, delete save after loading
+		cfg::_bool state_inspection_mode{ this, "Inspection Mode Savestates" }; // Save memory stored in executable files, thus allowing to view state without any files (for debugging)
+		cfg::_bool save_disc_game_data{ this, "Save Disc Game Data", false };
+	} savestate{this};
+
 	struct node_misc : cfg::node
 	{
 		node_misc(cfg::node* _this) : cfg::node(_this, "Miscellaneous") {}

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -33,10 +33,6 @@ void basic_keyboard_handler::Init(const u32 max_connect)
 	m_info.status[0]   = CELL_KB_STATUS_CONNECTED; // (TODO: Support for more keyboards)
 }
 
-basic_keyboard_handler::basic_keyboard_handler() : QObject()
-{
-}
-
 /* Sets the target window for the event handler, and also installs an event filter on the target. */
 void basic_keyboard_handler::SetTargetWindow(QWindow* target)
 {

--- a/rpcs3/Input/basic_keyboard_handler.h
+++ b/rpcs3/Input/basic_keyboard_handler.h
@@ -8,10 +8,10 @@
 
 class basic_keyboard_handler final : public KeyboardHandlerBase, public QObject
 {
+	using KeyboardHandlerBase::KeyboardHandlerBase;
+
 public:
 	void Init(const u32 max_connect) override;
-
-	explicit basic_keyboard_handler();
 
 	void SetTargetWindow(QWindow* target);
 	bool eventFilter(QObject* watched, QEvent* event) override;

--- a/rpcs3/Input/basic_mouse_handler.cpp
+++ b/rpcs3/Input/basic_mouse_handler.cpp
@@ -28,9 +28,6 @@ void basic_mouse_handler::Init(const u32 max_connect)
 	m_info.product_id[0] = 0x1234;
 }
 
-basic_mouse_handler::basic_mouse_handler() : QObject()
-{}
-
 /* Sets the target window for the event handler, and also installs an event filter on the target. */
 void basic_mouse_handler::SetTargetWindow(QWindow* target)
 {

--- a/rpcs3/Input/basic_mouse_handler.h
+++ b/rpcs3/Input/basic_mouse_handler.h
@@ -9,10 +9,10 @@
 
 class basic_mouse_handler final : public MouseHandlerBase, public QObject
 {
+	using MouseHandlerBase::MouseHandlerBase;
+
 public:
 	void Init(const u32 max_connect) override;
-
-	basic_mouse_handler();
 
 	void SetTargetWindow(QWindow* target);
 	void MouseButtonDown(QMouseEvent* event);

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -42,6 +42,7 @@ pad_thread::pad_thread(void *_curthread, void *_curwindow, std::string_view titl
 {
 	pad::g_title_id = title_id;
 	pad::g_current = this;
+	pad::g_reset = true;
 }
 
 pad_thread::~pad_thread()
@@ -212,7 +213,8 @@ void pad_thread::SetIntercepted(bool intercepted)
 
 void pad_thread::operator()()
 {
-	pad::g_reset = true;
+	Init();
+	pad::g_reset = false;
 
 	atomic_t<pad_handler_mode> pad_mode{g_cfg.io.pad_mode.get()};
 	std::vector<std::unique_ptr<named_thread<std::function<void()>>>> threads;

--- a/rpcs3/Loader/TAR.h
+++ b/rpcs3/Loader/TAR.h
@@ -40,9 +40,9 @@ public:
 
 	using process_func = std::function<bool(const fs::file&, std::string&, std::vector<u8>&&)>;
 
-	// Extract all files in archive to destination as VFS
+	// Extract all files in archive to destination (as VFS if is_vfs is true)
 	// Allow to optionally specify explicit mount point (which may be directory meant for extraction)
-	bool extract(std::string vfs_mp = {});
+	bool extract(std::string prefix_path = {}, bool is_vfs = false);
 
 	static std::vector<u8> save_directory(const std::string& src_dir, std::vector<u8>&& init = std::vector<u8>{}, const process_func& func = {}, std::string append_path = {});
 };

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -63,13 +63,13 @@ void headless_application::InitializeCallbacks()
 		RequestCallFromMainThread(std::move(func), wake_up);
 	};
 
-	callbacks.init_gs_render = []()
+	callbacks.init_gs_render = [](utils::serial* ar)
 	{
 		switch (const video_renderer type = g_cfg.video.renderer)
 		{
 		case video_renderer::null:
 		{
-			g_fxo->init<rsx::thread, named_thread<NullGSRender>>();
+			g_fxo->init<rsx::thread, named_thread<NullGSRender>>(ar);
 			break;
 		}
 		case video_renderer::opengl:

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -80,6 +80,7 @@ static atomic_t<bool> s_no_gui = false;
 static atomic_t<char*> s_argv0;
 
 extern thread_local std::string(*g_tls_log_prefix)();
+extern thread_local std::string_view g_tls_serialize_name;
 
 #ifndef _WIN32
 extern char **environ;
@@ -100,6 +101,17 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 
 		// Always print thread id
 		fmt::append(buf, "\n\nThread id = %s.", std::this_thread::get_id());
+	}
+
+	if (!g_tls_serialize_name.empty())
+	{
+		// Copy only when needed
+		if (!buf.empty())
+		{
+			buf = std::string(_text);
+		}
+
+		fmt::append(buf, "\nSerialized Object: %s", g_tls_serialize_name);
 	}
 
 	std::string_view text = buf.empty() ? _text : buf;
@@ -262,6 +274,7 @@ constexpr auto arg_updating     = "updating";
 constexpr auto arg_user_id      = "user-id";
 constexpr auto arg_installfw    = "installfw";
 constexpr auto arg_installpkg   = "installpkg";
+constexpr auto arg_savestate    = "savestate";
 constexpr auto arg_timer        = "high-res-timer";
 constexpr auto arg_verbose_curl = "verbose-curl";
 constexpr auto arg_any_location = "allow-any-location";
@@ -385,7 +398,6 @@ void fmt_class_string<std::chrono::sys_time<typename std::chrono::system_clock::
 	ss << std::put_time(&tm, "%Y-%m-%eT%H:%M:%S");
  	out += ss.str();
 }
-
 
 
 int main(int argc, char** argv)
@@ -601,6 +613,8 @@ int main(int argc, char** argv)
 	parser.addOption(decrypt_option);
 	const QCommandLineOption user_id_option(arg_user_id, "Start RPCS3 as this user.", "user id", "");
 	parser.addOption(user_id_option);
+	const QCommandLineOption savestate_option(arg_savestate, "Path for directly loading a savestate.", "path", "");
+	parser.addOption(savestate_option);
 	parser.addOption(QCommandLineOption(arg_q_debug, "Log qDebug to RPCS3.log."));
 	parser.addOption(QCommandLineOption(arg_error, "For internal usage."));
 	parser.addOption(QCommandLineOption(arg_updating, "For internal usage."));
@@ -1064,7 +1078,32 @@ int main(int argc, char** argv)
 		sys_log.notice("Option passed via command line: %s %s", opt.toStdString(), parser.value(opt).toStdString());
 	}
 
-	if (const QStringList args = parser.positionalArguments(); !args.isEmpty() && !is_updating && !parser.isSet(arg_installfw) && !parser.isSet(arg_installpkg))
+	if (parser.isSet(arg_savestate))
+	{
+		const std::string savestate_path = parser.value(savestate_option).toStdString();
+		sys_log.notice("Booting savestate from command line: %s", savestate_path);
+
+		if (!fs::is_file(savestate_path))
+		{
+			report_fatal_error(fmt::format("No savestate file found: %s", savestate_path));
+		}
+
+		Emu.CallFromMainThread([path = savestate_path]()
+		{
+			Emu.SetForceBoot(true);
+
+			if (const game_boot_result error = Emu.BootGame(path); error != game_boot_result::no_errors)
+			{
+				sys_log.error("Booting savestate '%s' failed: reason: %s", path, error);
+
+				if (s_headless || s_no_gui)
+				{
+					report_fatal_error(fmt::format("Booting savestate '%s' failed!\n\nReason: %s", path, error));
+				}
+			}
+		});
+	}
+	else if (const QStringList args = parser.positionalArguments(); !args.isEmpty() && !is_updating && !parser.isSet(arg_installfw) && !parser.isSet(arg_installpkg))
 	{
 		sys_log.notice("Booting application from command line: %s", args.at(0).toStdString());
 
@@ -1132,6 +1171,7 @@ int main(int argc, char** argv)
 		Emu.Quit(true);
 		return 0;
 	}
+
 
 	// run event loop (maybe only needed for the gui application)
 	return app->exec();

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <QFileInfo> // This shouldn't be outside rpcs3qt...
+#include <thread>
 
 LOG_CHANNEL(sys_log, "SYS");
 
@@ -54,12 +55,12 @@ EmuCallbacks main_application::CreateCallbacks()
 		{
 		case keyboard_handler::null:
 		{
-			g_fxo->init<KeyboardHandlerBase, NullKeyboardHandler>();
+			g_fxo->init<KeyboardHandlerBase, NullKeyboardHandler>(Emu.DeserialManager());
 			break;
 		}
 		case keyboard_handler::basic:
 		{
-			basic_keyboard_handler* ret = g_fxo->init<KeyboardHandlerBase, basic_keyboard_handler>();
+			basic_keyboard_handler* ret = g_fxo->init<KeyboardHandlerBase, basic_keyboard_handler>(Emu.DeserialManager());
 			ret->moveToThread(get_thread());
 			ret->SetTargetWindow(m_game_window);
 			break;
@@ -75,18 +76,18 @@ EmuCallbacks main_application::CreateCallbacks()
 		{
 			if (g_cfg.io.move == move_handler::mouse)
 			{
-				basic_mouse_handler* ret = g_fxo->init<MouseHandlerBase, basic_mouse_handler>();
+				basic_mouse_handler* ret = g_fxo->init<MouseHandlerBase, basic_mouse_handler>(Emu.DeserialManager());
 				ret->moveToThread(get_thread());
 				ret->SetTargetWindow(m_game_window);
 			}
 			else
-				g_fxo->init<MouseHandlerBase, NullMouseHandler>();
+				g_fxo->init<MouseHandlerBase, NullMouseHandler>(Emu.DeserialManager());
 
 			break;
 		}
 		case mouse_handler::basic:
 		{
-			basic_mouse_handler* ret = g_fxo->init<MouseHandlerBase, basic_mouse_handler>();
+			basic_mouse_handler* ret = g_fxo->init<MouseHandlerBase, basic_mouse_handler>(Emu.DeserialManager());
 			ret->moveToThread(get_thread());
 			ret->SetTargetWindow(m_game_window);
 			break;
@@ -96,7 +97,8 @@ EmuCallbacks main_application::CreateCallbacks()
 
 	callbacks.init_pad_handler = [this](std::string_view title_id)
 	{
-		g_fxo->init<named_thread<pad_thread>>(get_thread(), m_game_window, title_id);
+		ensure(g_fxo->init<named_thread<pad_thread>>(get_thread(), m_game_window, title_id));
+		while (pad::g_reset) std::this_thread::yield();
 	};
 
 	callbacks.get_audio = []() -> std::shared_ptr<AudioBackend>

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -971,6 +971,18 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		});
 	}
 
+	if (const std::string sstate = fs::get_cache_dir() + "/savestates/" + current_game.serial + ".SAVESTAT"; fs::is_file(sstate))
+	{
+		QAction* boot_state = menu.addAction(is_current_running_game
+			? tr("&Reboot with savestate")
+			: tr("&Boot with savestate"));
+		connect(boot_state, &QAction::triggered, [this, gameinfo, sstate]
+		{
+			sys_log.notice("Booting savestate from gamelist per context menu...");
+			Q_EMIT RequestBoot(gameinfo, cfg_mode::custom, "", sstate);
+		});
+	}
+
 	menu.addSeparator();
 
 	QAction* configure = menu.addAction(gameinfo->hasCustomConfig

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -85,7 +85,7 @@ private Q_SLOTS:
 Q_SIGNALS:
 	void GameListFrameClosed();
 	void NotifyGameSelection(const game_info& game);
-	void RequestBoot(const game_info& game, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "");
+	void RequestBoot(const game_info& game, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "", const std::string& savestate = "");
 	void RequestIconSizeChange(const int& val);
 	void NotifyEmuSettingsChange();
 protected:

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -245,6 +245,13 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 			return;
 		}
 		break;
+	case Qt::Key_S:
+		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
+		{
+			Emu.Restart(true);
+			return;
+		}
+		break;
 	case Qt::Key_R:
 		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
 		{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -343,26 +343,26 @@ void gui_application::InitializeCallbacks()
 		RequestCallFromMainThread(std::move(func), wake_up);
 	};
 
-	callbacks.init_gs_render = []()
+	callbacks.init_gs_render = [](utils::serial* ar)
 	{
 		switch (g_cfg.video.renderer.get())
 		{
 		case video_renderer::null:
 		{
-			g_fxo->init<rsx::thread, named_thread<NullGSRender>>();
+			g_fxo->init<rsx::thread, named_thread<NullGSRender>>(ar);
 			break;
 		}
 		case video_renderer::opengl:
 		{
 #if not defined(__APPLE__)
-			g_fxo->init<rsx::thread, named_thread<GLGSRender>>();
+			g_fxo->init<rsx::thread, named_thread<GLGSRender>>(ar);
 #endif
 			break;
 		}
 		case video_renderer::vulkan:
 		{
 #if defined(HAVE_VULKAN)
-			g_fxo->init<rsx::thread, named_thread<VKGSRender>>();
+			g_fxo->init<rsx::thread, named_thread<VKGSRender>>(ar);
 #endif
 			break;
 		}

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -768,7 +768,7 @@ void kernel_explorer::update()
 		decltype(rsx->display_buffers) dbs;
 		decltype(rsx->zculls) zcs;
 		{
-			std::lock_guard lock(rsx->sys_rsx_mtx);
+			reader_lock lock(rsx->sys_rsx_mtx);
 			std::memcpy(&table, &rsx->iomap_table, sizeof(table));
 			std::memcpy(&dbs, rsx->display_buffers, sizeof(dbs));
 			std::memcpy(&zcs, &rsx->zculls, sizeof(zcs));

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -357,6 +357,7 @@ void main_window::OnPlayOrPause()
 
 		return;
 	}
+	case system_state::starting: break;
 	default: fmt::throw_exception("Unreachable");
 	}
 }
@@ -386,6 +387,12 @@ void main_window::show_boot_error(game_boot_result status)
 		break;
 	case game_boot_result::unsupported_disc_type:
 		message = tr("This disc type is not supported yet.");
+		break;
+	case game_boot_result::savestate_corrupted:
+		message = tr("Savestate data is corrupted or it's not an RPCS3 savestate.");
+		break;
+	case game_boot_result::savestate_version_unsupported:
+		message = tr("Savestate versioning data differes from your RPCS3 build.");
 		break;
 	case game_boot_result::firmware_missing: // Handled elsewhere
 	case game_boot_result::no_errors:
@@ -493,8 +500,7 @@ void main_window::BootTest()
 	const QString file_path = QFileDialog::getOpenFileName(this, tr("Select (S)ELF To Boot"), path_tests, tr(
 		"(S)ELF files (*.elf *.self);;"
 		"ELF files (*.elf);;"
-		"SELF files (*.self);;"
-		"All files (*.*)"),
+		"SELF files (*.self);;"),
 		Q_NULLPTR, QFileDialog::DontResolveSymlinks);
 
 	if (file_path.isEmpty())
@@ -509,6 +515,36 @@ void main_window::BootTest()
 	const std::string path = sstr(QFileInfo(file_path).absoluteFilePath());
 
 	gui_log.notice("Booting from BootTest...");
+	Boot(path, "", true);
+}
+
+void main_window::BootSavestate()
+{
+	bool stopped = false;
+
+	if (Emu.IsRunning())
+	{
+		Emu.Pause();
+		stopped = true;
+	}
+
+	const QString file_path = QFileDialog::getOpenFileName(this, tr("Select Savestate To Boot"), qstr(fs::get_cache_dir() + "/savestates/"), tr(
+		"Savestate files (*.SAVESTAT);;"
+		"All files (*.*)"),
+		Q_NULLPTR, QFileDialog::DontResolveSymlinks);
+
+	if (file_path.isEmpty())
+	{
+		if (stopped)
+		{
+			Emu.Resume();
+		}
+		return;
+	}
+
+	const std::string path = sstr(QFileInfo(file_path).absoluteFilePath());
+
+	gui_log.notice("Booting from BootSavestate...");
 	Boot(path, "", true);
 }
 
@@ -1153,7 +1189,7 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 			return;
 		}
 
-		if (!update_files.extract("/pup_extract"))
+		if (!update_files.extract("/pup_extract", true))
 		{
 			gui_log.error("Error while installing firmware: TAR contents are invalid.");
 			critical(tr("Firmware installation failed: Firmware contents could not be extracted."));
@@ -1413,7 +1449,7 @@ void main_window::RepaintThumbnailIcons()
 	m_icon_thumb_stop = icon(":/Icons/stop.png");
 	m_icon_thumb_restart = icon(":/Icons/restart.png");
 
-	m_thumb_playPause->setIcon(Emu.IsRunning() ? m_icon_thumb_pause : m_icon_thumb_play);
+	m_thumb_playPause->setIcon(Emu.IsRunning() || Emu.IsStarting() ? m_icon_thumb_pause : m_icon_thumb_play);
 	m_thumb_stop->setIcon(m_icon_thumb_stop);
 	m_thumb_restart->setIcon(m_icon_thumb_restart);
 #endif
@@ -1982,6 +2018,8 @@ void main_window::CreateConnects()
 	{
 		g_user_asked_for_frame_capture = true;
 	});
+
+	connect(ui->bootSavestateAct, &QAction::triggered, this, &main_window::BootSavestate);
 
 	connect(ui->addGamesAct, &QAction::triggered, this, [this]()
 	{
@@ -2577,9 +2615,9 @@ void main_window::CreateDockWindows()
 		m_selected_game = game;
 	});
 
-	connect(m_game_list_frame, &game_list_frame::RequestBoot, this, [this](const game_info& game, cfg_mode config_mode, const std::string& config_path)
+	connect(m_game_list_frame, &game_list_frame::RequestBoot, this, [this](const game_info& game, cfg_mode config_mode, const std::string& config_path, const std::string& savestate)
 	{
-		Boot(game->info.path, game->info.serial, false, false, config_mode, config_path);
+		Boot(savestate.empty() ? game->info.path : savestate, game->info.serial, false, false, config_mode, config_path);
 	});
 
 	connect(m_game_list_frame, &game_list_frame::NotifyEmuSettingsChange, this, &main_window::NotifyEmuSettingsChange);

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -113,6 +113,7 @@ private Q_SLOTS:
 	void BootTest();
 	void BootGame();
 	void BootVSH();
+	void BootSavestate();
 	void BootRsxCapture(std::string path = "");
 	void DecryptSPRXLibraries();
 	static void show_boot_error(game_boot_result status);

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -202,6 +202,7 @@
     <addaction name="bootGameAct"/>
     <addaction name="bootVSHAct"/>
     <addaction name="bootElfMenu"/>
+    <addaction name="bootSavestateAct"/>
     <addaction name="bootRecentMenu"/>
     <addaction name="separator"/>
     <addaction name="addGamesAct"/>
@@ -424,6 +425,11 @@
   <action name="bootGameAct">
    <property name="text">
     <string>Boot Game</string>
+   </property>
+  </action>
+  <action name="bootSavestateAct">
+   <property name="text">
+    <string>Boot Savestate</string>
    </property>
   </action>
   <action name="bootInstallPkgAct">

--- a/rpcs3/rpcs3qt/memory_string_searcher.h
+++ b/rpcs3/rpcs3qt/memory_string_searcher.h
@@ -42,6 +42,7 @@ struct memory_searcher_handle
 	static constexpr u32 id_base = 1;
 	static constexpr u32 id_step = 1;
 	static constexpr u32 id_count = 2048;
+	SAVESTATE_INIT_POS(32); // Of course not really used
 
 	template <typename... Args> requires (std::is_constructible_v<memory_string_searcher, Args&&...>)
 	memory_searcher_handle(Args&&... args)

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -86,6 +86,7 @@ struct memory_viewer_handle
 	static constexpr u32 id_base = 1;
 	static constexpr u32 id_step = 1;
 	static constexpr u32 id_count = 2048;
+	SAVESTATE_INIT_POS(33); // Of course not really used
 
 	template <typename... Args> requires (std::is_constructible_v<memory_viewer_panel, Args&&...>)
 	memory_viewer_handle(Args&&... args)

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -1214,7 +1214,7 @@ protected:
 
 public:
 	static constexpr usz align = Align;
-	using enable_bitcopy = std::true_type;
+	ENABLE_BITWISE_SERIALIZATION;
 
 	atomic_t() noexcept = default;
 

--- a/rpcs3/util/endian.hpp
+++ b/rpcs3/util/endian.hpp
@@ -180,7 +180,7 @@ namespace stx
 		using under = decltype(int_or_enum());
 
 	public:
-		using enable_bitcopy = std::true_type;
+		ENABLE_BITWISE_SERIALIZATION;
 
 		se_t() noexcept = default;
 

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -7,8 +7,11 @@
 
 #include <utility>
 #include <type_traits>
+#include <algorithm>
 
 enum class thread_state : u32;
+
+extern thread_local std::string_view g_tls_serialize_name;
 
 namespace stx
 {
@@ -58,14 +61,32 @@ namespace stx
 		// Save default constructor and destructor and optional joining operation
 		struct typeinfo
 		{
-			bool(*create)(uchar* ptr, manual_typemap&) noexcept = nullptr;
+			bool(*create)(uchar* ptr, manual_typemap&, utils::serial*, std::string_view) noexcept = nullptr;
 			void(*stop)(void* ptr, thread_state) noexcept = nullptr;
+			void(*save)(void* ptr, utils::serial&) noexcept = nullptr;
 			void(*destroy)(void* ptr) noexcept = nullptr;
-			std::string_view name{};
+			std::string_view name;
 
 			template <typename T>
-			static bool call_ctor(uchar* ptr, manual_typemap& _this) noexcept
+			static bool call_ctor(uchar* ptr, manual_typemap& _this, utils::serial* ar, std::string_view name) noexcept
 			{
+				if (ar)
+				{
+					if constexpr (std::is_constructible_v<T, manual_typemap&, exact_t<utils::serial&>>)
+					{
+						g_tls_serialize_name = name;
+						new (ptr) T(_this, exact_t<utils::serial&>(*ar));
+						return true;
+					}
+
+					if constexpr (std::is_constructible_v<T, exact_t<utils::serial&>>)
+					{
+						g_tls_serialize_name = name;
+						new (ptr) T(exact_t<utils::serial&>(*ar));
+						return true;
+					}
+				}
+
 				// Allow passing reference to "this"
 				if constexpr (std::is_constructible_v<T, manual_typemap&>)
 				{
@@ -96,6 +117,19 @@ namespace stx
 				*std::launder(static_cast<T*>(ptr)) = state;
 			}
 
+#ifdef _MSC_VER
+			template <typename T>
+			static void call_save(void*, utils::serial&) noexcept
+			{
+			}
+#endif
+
+			template <typename T> requires requires (T& a) { a.save(std::declval<stx::exact_t<utils::serial&>>()); }
+			static void call_save(void* ptr, utils::serial& ar) noexcept
+			{
+				std::launder(static_cast<T*>(ptr))->save(stx::exact_t<utils::serial&>(ar));
+			}
+
 			template <typename T>
 			static typeinfo make_typeinfo()
 			{
@@ -110,6 +144,13 @@ namespace stx
 					r.stop = &call_stop<T>;
 				}
 
+				// TODO: Unconnement and remove call_save overload when MSVC implements it
+#ifndef _MSC_VER
+				if constexpr (!!(requires (T& a) { a.save(std::declval<stx::exact_t<utils::serial&>>()); }))
+#endif
+				{
+					r.save = &call_save<T>;
+				}
 #ifdef _MSC_VER
 				constexpr std::string_view name = parse_type(__FUNCSIG__);
 #else
@@ -181,15 +222,31 @@ namespace stx
 			*m_info++ = nullptr;
 		}
 
-		void init(bool reset = true)
+		void init(bool reset = true, utils::serial* ar = nullptr)
 		{
 			if (reset)
 			{
 				this->reset();
 			}
 
+			// Use unique_ptr to reduce header dependencies in this commonly used header
+			const auto order = std::make_unique<std::pair<double, const type_info<typeinfo>*>[]>(stx::typelist<typeinfo>().count());
+
+			usz pos = 0;
 			for (const auto& type : stx::typelist<typeinfo>())
 			{
+				order[pos++] = {type.init_pos(), std::addressof(type)};
+			}
+
+			std::stable_sort(order.get(), order.get() + stx::typelist<typeinfo>().count(), [](auto a, auto b)
+			{
+				return a.first < b.first;
+			});
+
+			for (pos = 0; pos < stx::typelist<typeinfo>().count(); pos++)
+			{	
+				const auto& type = *order[pos].second;
+
 				const u32 id = type.index();
 				uchar* data = (Size ? +m_data : m_list) + type.pos();
 
@@ -199,13 +256,15 @@ namespace stx
 					continue;
 				}
 
-				if (type.create(data, *this))
+				if (type.create(data, *this, ar, type.name))
 				{
 					*m_order++ = data;
 					*m_info++ = &type;
 					m_init[id] = true;
 				}
 			}
+
+			g_tls_serialize_name = {};
 		}
 
 		void clear()
@@ -262,6 +321,32 @@ namespace stx
 			}
 		}
 
+		void save(utils::serial& ar)
+		{
+			if (!m_init)
+			{
+				return;
+			}
+
+			// Get actual number of created objects
+			u32 _max = 0;
+
+			for (const auto& type : stx::typelist<typeinfo>())
+			{
+				if (m_init[type.index()])
+				{
+					// Skip object if not created
+					_max++;
+				}
+			}
+
+			// Save data in forward order
+			for (u32 i = _max; i; i--)
+			{
+				if (auto save = (*std::prev(m_info, i))->save) save(*std::prev(m_order, i), ar);
+			}
+		}
+
 		// Check if object is not initialized but shall be initialized first (to use in initializing other objects)
 		template <typename T>
 		void need() noexcept
@@ -294,6 +379,8 @@ namespace stx
 
 			As* obj = nullptr;
 
+			g_tls_serialize_name = get_name<T, As>();
+
 			if constexpr (Size != 0)
 			{
 				obj = new (m_data + stx::typeoffset<typeinfo, std::decay_t<T>>()) std::decay_t<As>(std::forward<Args>(args)...);
@@ -302,6 +389,8 @@ namespace stx
 			{
 				obj = new (m_list + stx::typeoffset<typeinfo, std::decay_t<T>>()) std::decay_t<As>(std::forward<Args>(args)...);
 			}
+
+			g_tls_serialize_name = {};
 
 			*m_order++ = obj;
 			*m_info++ = &stx::typedata<typeinfo, std::decay_t<T>, std::decay_t<As>>();
@@ -335,6 +424,12 @@ namespace stx
 			{
 				return *std::launder(reinterpret_cast<T*>(m_list + stx::typeoffset<typeinfo, std::decay_t<T>>()));
 			}
+		}
+
+		template <typename T, typename As = T>
+		static std::string_view get_name() noexcept
+		{
+			return stx::typedata<typeinfo, std::decay_t<T>, std::decay_t<As>>().name;
 		}
 
 		// Obtain object pointer if initialized

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -3,21 +3,6 @@
 #include "util/types.hpp"
 #include <vector>
 
-namespace stx
-{
-	template <typename T>
-	struct exact_t
-	{
-		T obj;
-
-		exact_t(T&& _obj) : obj(std::forward<T>(_obj)) {}
-
-		// TODO: More conversions
-		template <typename U> requires (std::is_same_v<U&, T>)
-		operator U&() const { return obj; };
-	};
-}
-
 namespace utils
 {
 	template <typename T>
@@ -51,6 +36,10 @@ namespace utils
 	{
 		std::vector<u8> data;
 		usz pos = umax;
+
+		serial() = default;
+		serial(const serial&) = delete;
+		~serial() = default;
 
 		// Checks if this instance is currently used for serialization
 		bool is_writing() const
@@ -299,7 +288,7 @@ namespace utils
 		}
 
 		// Convert serialization manager to deserializion manager (can't go the other way)
-		// If no arg provided reuse saved buffer
+		// If no arg is provided reuse saved buffer
 		void set_reading_state(std::vector<u8>&& _data = std::vector<u8>{})
 		{
 			if (!_data.empty())

--- a/rpcs3/util/typeindices.hpp
+++ b/rpcs3/util/typeindices.hpp
@@ -3,6 +3,8 @@
 #include "util/types.hpp"
 #include "util/shared_ptr.hpp"
 
+#include <string_view>
+
 #ifndef _MSC_VER
 #define ATTR_PURE __attribute__((pure))
 #else
@@ -24,6 +26,7 @@ namespace stx
 		u32 size = 1;
 		u32 align = 1;
 		u32 begin = 0;
+		double order;
 
 		// Next typeinfo in linked list
 		type_info* next = nullptr;
@@ -31,7 +34,7 @@ namespace stx
 		// Auxiliary pointer to base type
 		const type_info* base = nullptr;
 
-		type_info(Info info, u32 size, u32 align, const type_info* base = nullptr) noexcept;
+		type_info(Info info, u32 size, u32 align, double order, const type_info* base = nullptr) noexcept;
 
 		friend type_counter<Info>;
 
@@ -54,6 +57,11 @@ namespace stx
 		ATTR_PURE u32 end() const
 		{
 			return begin + size;
+		}
+
+		ATTR_PURE double init_pos() const
+		{
+			return order;
 		}
 	};
 
@@ -177,14 +185,25 @@ namespace stx
 		return typelist_v;
 	}
 
+	template <typename T> requires requires () { T::savestate_init_pos + 0.; }
+	constexpr double get_savestate_init_pos()
+	{
+		return T::savestate_init_pos;
+	}
+	template <typename T> requires (!(requires () { T::savestate_init_pos + 0.; }))
+	constexpr double get_savestate_init_pos()
+	{
+		return {};
+	}
+
 	template <typename Info> template <typename T>
-	const type_info<Info> type_counter<Info>::type{Info::template make_typeinfo<T>(), sizeof(T), alignof(T)};
+	const type_info<Info> type_counter<Info>::type{Info::template make_typeinfo<T>(), sizeof(T), alignof(T), get_savestate_init_pos<T>()};
 
 	template <typename Info> template <typename T, typename As>
-	const type_info<Info> type_counter<Info>::dyn_type{Info::template make_typeinfo<As>(), sizeof(As), alignof(As), &type_counter<Info>::template type<T>};
+	const type_info<Info> type_counter<Info>::dyn_type{Info::template make_typeinfo<As>(), sizeof(As), alignof(As), get_savestate_init_pos<T>(), &type_counter<Info>::template type<T>};
 
 	template <typename Info>
-	type_info<Info>::type_info(Info info, u32 _size, u32 _align, const type_info<Info>* cbase) noexcept
+	type_info<Info>::type_info(Info info, u32 _size, u32 _align, double order, const type_info<Info>* cbase) noexcept
 		: Info(info)
 	{
 		auto& tl = typelist<Info>();
@@ -193,6 +212,7 @@ namespace stx
 		this->size = _size > this->size ? _size : this->size;
 		this->align = _align > this->align ? _align : this->align;
 		this->base = cbase;
+		this->order = order;
 
 		// Update global max alignment
 		tl.first.align = _align > tl.first.align ? _align : tl.first.align;

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1081,6 +1081,21 @@ constexpr bool is_same_ptr(const volatile Y* ptr)
 template <typename X, typename Y>
 concept PtrSame = (is_same_ptr<X, Y>());
 
+namespace stx
+{
+	template <typename T>
+	struct exact_t
+	{
+		T obj;
+
+		exact_t(T&& _obj) : obj(std::forward<T>(_obj)) {}
+
+		// TODO: More conversions
+		template <typename U> requires (std::is_same_v<U&, T>)
+		operator U&() const { return obj; };
+	};
+}
+
 namespace utils
 {
 	struct serial;
@@ -1088,3 +1103,24 @@ namespace utils
 
 template <typename T>
 extern bool serialize(utils::serial& ar, T& obj);
+
+#define USING_SERIALIZATION_VERSION(name) []()\
+{\
+	extern void using_##name##_serialization();\
+	using_##name##_serialization();\
+}()
+
+#define USING_SERIALIZATION_VERSION_COND(cond, name) [&]()\
+{\
+	extern void using_##name##_serialization();\
+	if (static_cast<bool>(cond)) using_##name##_serialization();\
+}()
+
+#define GET_SERIALIZATION_VERSION(name) []()\
+{\
+	extern u32 get_##name##_serialization_version();\
+	return get_##name##_serialization_version();\
+}()
+
+#define ENABLE_BITWISE_SERIALIZATION using enable_bitcopy = std::true_type;
+#define SAVESTATE_INIT_POS(x) static constexpr double savestate_init_pos = (x)

--- a/rpcs3/util/v128.hpp
+++ b/rpcs3/util/v128.hpp
@@ -79,7 +79,7 @@ union alignas(16) v128
 		return std::bit_cast<T>(*this);
 	}
 
-	using enable_bitcopy = std::true_type;
+	ENABLE_BITWISE_SERIALIZATION;
 
 	static v128 from64(u64 _0, u64 _1 = 0)
 	{

--- a/rpcs3/util/vm.hpp
+++ b/rpcs3/util/vm.hpp
@@ -73,7 +73,7 @@ namespace utils
 		atomic_t<void*> m_ptr{nullptr};
 
 	public:
-		explicit shm(u32 size, u32 flags = 0);
+		explicit shm(u64 size, u32 flags = 0);
 
 		// Construct with specified path as sparse file storage
 		shm(u64 size, const std::string& storage);

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -395,8 +395,8 @@ namespace utils
 	void memory_release(void* pointer, usz size)
 	{
 #ifdef _WIN32
-		ensure(::VirtualFree(pointer, 0, MEM_RELEASE));
 		unmap_mappping_memory(reinterpret_cast<u64>(pointer), size);
+		ensure(::VirtualFree(pointer, 0, MEM_RELEASE));
 #else
 		ensure(::munmap(pointer, size) != -1);
 #endif
@@ -457,7 +457,7 @@ namespace utils
 #endif
 	}
 
-	shm::shm(u32 size, u32 flags)
+	shm::shm(u64 size, u32 flags)
 		: m_flags(flags)
 		, m_size(utils::align(size, 0x10000))
 	{


### PR DESCRIPTION
## Restrictions (most will be lifted as this work progresses):
- [x] Select **libvdec.sprx** in firmware libraries setting. (advanced tab) (well now it simply won't allow saving if HLE libvdec data is loaded in the background)
- [ ] WCB+force CPU blit may improve compatibility.
- [ ] PSN/Network - Offline.
* Don't savestate while a message/save dialog is shown.
- [ ] Do not save when the game itself is saving or installing game data (applies to disc games).
- [x] Do not delete or move game files.
- [x] Do not erase /dev_hdd1 contents.
- [x] Sharing savestates between people is not supported.
- [ ] Do not HLE lwmutex or firmware libraries that aren't HLE'd by default. (the opposite is allowed as long as it's compatible with the game)

## How to savestate
Ctrl+S savestates, savestate will be bootable from the game context menu later.

## Versioning System
Because RPCS3 is one of the most complex emulators ever made (if not the most complex) and it is still in rapid development state, the need to update the emulation every now and then in a way which will affect savestates is inevitable.
So, while the rest of the emulators use a global version for their savestate for all components of the emulation, RPCS3 savestates will work in a smarter way which allows both rapid development of the emulation and high compatibility of old savestates.
The following actions has been taken:
* Individual components of the emulation will use individual pair of "current" version and "supported" versions: what this means? 
 "supported" versions are versions listed which are known to be compatible with current RPCS3 build. Code can support more than one version at a time! how? this is where "current" version kicks in, the "current" version is read from the savestate file itself and by its value the code knows how to use the savestates file. 
* Not all emulation components are being used all the time. When updating the emulation for let's say X component, savestates which do not make use of this X component will still be compatible. (take for example PSN features)
In case the component is unused, its version won't even be saved to the savestate file!
  
## Savestates modes (config.yml exclusives at the moment)
* "Start Paused": When true, the emulation will be paused after first frame is being rendered. (note that this actually runs the emulation up to the next frame for it only then pauses it)
This setting is currently off by default but let me know if you want it on by default!
* "Suspend Emulation Savestate Mode": Savestates use does not have to enforce cheating-alike attidude! When this mode is on, emulation exits when saving and the savestate file is deleted after loading it. This mode is like hibernation of emulation, if you don't want your exprience of hard games to be ruined by savestates, consider use this mode!
* Experimental and unused yet: "Inspection Mode Savestates":  This mode is meant for debugging, it allows the saved savestate to be loaded without any game files in order to view the threads/memory state. It will not allow starting the emulation from that point.

## Additional TODO list: (besides lifting restrictions)
- [ ] Multi-savestates slots, currently each game ID has only one savestate slot at path rpcs3/savestates/[TITLE ID].SAVESTAT
If you want to simulate multiple slots, you can move and restore the savestate file at that path, or you can load savestate files directly via main RPCS3 context menu.

Fixes #4218 