### PR TITLE
fs: alternative fs::pending_file implementation (Win32)

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -649,6 +649,8 @@ namespace fs
 		bool commit(bool overwrite = true);
 
 		pending_file(const std::string& path);
+		pending_file(const pending_file&) = delete;
+		pending_file& operator=(const pending_file&) = delete;
 		~pending_file();
 
 	private:

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1946,7 +1946,9 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			if (auto file = pair.second.release())
 			{
 				auto&& fvec = static_cast<fs::container_stream<std::vector<uchar>>&>(*file);
-				ensure(fs::write_file<true>(new_path + vfs::escape(pair.first), fs::rewrite, fvec.obj));
+				fs::pending_file f(new_path + vfs::escape(pair.first));
+				f.file.write(fvec.obj);
+				ensure(f.commit());
 			}
 		}
 


### PR DESCRIPTION
May affect #9857 for savedata.
Default sync operation is very expensive on windows for some reasons, something is documented and can be found online.
MoveFileEx supports a writethrough flag which seems to have similar effect, but whether it's equally expensive I don't know.
I recommend to test it.