### PR TITLE
Trophy notification improvements

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -34,17 +34,20 @@ namespace rsx
 
 		trophy_notification::trophy_notification()
 		{
-			frame.set_pos(0, 0);
-			frame.set_size(300, 80);
-			frame.back_color.a = 0.85f;
+			frame.set_pos(68.24, 55.34);
+			frame.set_size(425, 72);
+			frame.back_color.r = 0.247059f;
+			frame.back_color.g = 0.250980f;
+			frame.back_color.b = 0.247059f;
+			frame.back_color.a = 0.88f;
 
-			image.set_pos(8, 8);
-			image.set_size(64, 64);
+			image.set_pos(78, 64);
+			image.set_size(53.333, 53.333);
 			image.back_color.a = 0.f;
 
-			text_view.set_pos(85, 0);
-			text_view.set_padding(0, 0, 24, 0);
-			text_view.set_font("Arial", 9);
+			text_view.set_pos(139.14, 69.30);
+			text_view.set_padding(0, 0, 0, 0);
+			text_view.set_font("Arial", 14);
 			text_view.align_text(overlay_element::text_align::center);
 			text_view.back_color.a = 0.f;
 
@@ -71,11 +74,11 @@ namespace rsx
 				return;
 			}
 
-			if (((t - creation_time) / 1000) > 7500)
+			if (((t - creation_time) / 1000) > 5000)
 			{
 				if (!sliding_animation.active)
 				{
-					sliding_animation.end = { -f32(frame.w), 0, 0 };
+					sliding_animation.end = { -f32(frame.w*1.25), 0, 0 };
 					sliding_animation.on_finish = [this]
 					{
 						s_trophy_semaphore.release();
@@ -133,8 +136,8 @@ namespace rsx
 			text_view.auto_resize();
 
 			// Resize background to cover the text
-			u16 margin_sz = text_view.x - image.w - image.x;
-			frame.w       = text_view.x + text_view.w + margin_sz;
+			u16 margin_sz = 9;
+			frame.w       = 72 + text_view.w + margin_sz;
 
 			visible = true;
 			return CELL_OK;

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -34,7 +34,7 @@ namespace rsx
 
 		trophy_notification::trophy_notification()
 		{
-			frame.set_pos(68.24, 55.34);
+			frame.set_pos(68, 55);
 			frame.set_size(425, 72);
 			frame.back_color.r = 0.247059f;
 			frame.back_color.g = 0.250980f;
@@ -42,20 +42,20 @@ namespace rsx
 			frame.back_color.a = 0.88f;
 
 			image.set_pos(78, 64);
-			image.set_size(53.333, 53.333);
+			image.set_size(53, 53);
 			image.back_color.a = 0.f;
 
-			text_view.set_pos(139.14, 69.30);
+			text_view.set_pos(139, 69);
 			text_view.set_padding(0, 0, 0, 0);
 			text_view.set_font("Arial", 14);
 			text_view.align_text(overlay_element::text_align::center);
 			text_view.back_color.a = 0.f;
 
 			sliding_animation.duration = 1.5f;
-			sliding_animation.type = animation_type::ease_in_out_cubic;
-			sliding_animation.current = { -f32(frame.w), 0, 0 };
-			sliding_animation.end = { 0, 0, 0};
-			sliding_animation.active = true;
+			sliding_animation.type     = animation_type::ease_in_out_cubic;
+			sliding_animation.current  = {-f32(frame.w), 0, 0};
+			sliding_animation.end      = {0, 0, 0};
+			sliding_animation.active   = true;
 		}
 
 		void trophy_notification::update()
@@ -78,9 +78,8 @@ namespace rsx
 			{
 				if (!sliding_animation.active)
 				{
-					sliding_animation.end = { -f32(frame.w*1.25), 0, 0 };
-					sliding_animation.on_finish = [this]
-					{
+					sliding_animation.end       = {-f32(frame.w * 1.25), 0, 0};
+					sliding_animation.on_finish = [this] {
 						s_trophy_semaphore.release();
 						close(false, false);
 					};
@@ -114,7 +113,7 @@ namespace rsx
 		{
 			// Schedule to display this trophy
 			display_sched_id = s_trophy_semaphore.enqueue();
-			visible = false;
+			visible          = false;
 
 			if (!trophy_icon_buffer.empty())
 			{
@@ -137,7 +136,7 @@ namespace rsx
 
 			// Resize background to cover the text
 			u16 margin_sz = 9;
-			frame.w       = 72 + text_view.w + margin_sz;
+			frame.w       = margin_sz * 3 + image.w + text_view.w;
 
 			visible = true;
 			return CELL_OK;

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -35,11 +35,12 @@ namespace rsx
 		trophy_notification::trophy_notification()
 		{
 			frame.set_pos(68, 55);
-			frame.set_size(425, 72);
+			frame.set_size(300, 72);
 			frame.back_color.r = 0.247059f;
 			frame.back_color.g = 0.250980f;
 			frame.back_color.b = 0.247059f;
 			frame.back_color.a = 0.88f;
+			
 
 			image.set_pos(78, 64);
 			image.set_size(53, 53);
@@ -52,10 +53,10 @@ namespace rsx
 			text_view.back_color.a = 0.f;
 
 			sliding_animation.duration = 1.5f;
-			sliding_animation.type     = animation_type::ease_in_out_cubic;
-			sliding_animation.current  = {-f32(frame.w), 0, 0};
-			sliding_animation.end      = {0, 0, 0};
-			sliding_animation.active   = true;
+			sliding_animation.type = animation_type::ease_in_out_cubic;
+			sliding_animation.current = { -f32(frame.w), 0, 0 };
+			sliding_animation.end = { 0, 0, 0};
+			sliding_animation.active = true;
 		}
 
 		void trophy_notification::update()
@@ -78,8 +79,9 @@ namespace rsx
 			{
 				if (!sliding_animation.active)
 				{
-					sliding_animation.end       = {-f32(frame.w * 1.25), 0, 0};
-					sliding_animation.on_finish = [this] {
+					sliding_animation.end = { -f32(frame.w), 0, 0 };
+					sliding_animation.on_finish = [this]
+					{
 						s_trophy_semaphore.release();
 						close(false, false);
 					};
@@ -113,7 +115,7 @@ namespace rsx
 		{
 			// Schedule to display this trophy
 			display_sched_id = s_trophy_semaphore.enqueue();
-			visible          = false;
+			visible = false;
 
 			if (!trophy_icon_buffer.empty())
 			{

--- a/rpcs3/rpcs3qt/localized_emu.h
+++ b/rpcs3/rpcs3qt/localized_emu.h
@@ -34,10 +34,10 @@ private:
 	{
 		switch (id)
 		{
-		case localized_string_id::RSX_OVERLAYS_TROPHY_BRONZE: return tr("You have earned the bronze trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
-		case localized_string_id::RSX_OVERLAYS_TROPHY_SILVER: return tr("You have earned the silver trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
-		case localized_string_id::RSX_OVERLAYS_TROPHY_GOLD: return tr("You have earned the gold trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
-		case localized_string_id::RSX_OVERLAYS_TROPHY_PLATINUM: return tr("You have earned the platinum trophy\n%0", "Trophy text").arg(std::forward<Args>(args)...);
+		case localized_string_id::RSX_OVERLAYS_TROPHY_BRONZE: return tr("You have earned a bronze trophy.\n%0", "Trophy text").arg(std::forward<Args>(args)...);
+		case localized_string_id::RSX_OVERLAYS_TROPHY_SILVER: return tr("You have earned a silver trophy.\n%0", "Trophy text").arg(std::forward<Args>(args)...);
+		case localized_string_id::RSX_OVERLAYS_TROPHY_GOLD: return tr("You have earned a gold trophy.\n%0", "Trophy text").arg(std::forward<Args>(args)...);
+		case localized_string_id::RSX_OVERLAYS_TROPHY_PLATINUM: return tr("You have earned a platinum trophy.\n%0", "Trophy text").arg(std::forward<Args>(args)...);
 		case localized_string_id::RSX_OVERLAYS_COMPILING_SHADERS: return tr("Compiling shaders");
 		case localized_string_id::RSX_OVERLAYS_MSG_DIALOG_YES: return tr("Yes", "Message Dialog");
 		case localized_string_id::RSX_OVERLAYS_MSG_DIALOG_NO: return tr("No", "Message Dialog");


### PR DESCRIPTION
Same trophy notification, but better. The notification is no longer squished in the corner and readability has been improved a lot. 
Size, color, transparency, spacing, position and duration are now the same as the original PS3 trophy notification.

![better](https://user-images.githubusercontent.com/16064499/122832821-4bac3f00-d2c2-11eb-9257-e3f5468d8b41.png)


What is still missing:
- Icon indicating the type of trophy
- Sound
- Rounded edges
- Fade-in and fade-out animation
- Font

Comparison:
After / Original
Before

https://user-images.githubusercontent.com/16064499/122832011-1e12c600-d2c1-11eb-9719-f32eba3b1450.mp4

