### PR TITLE
kernel-explorer/lv2: Make lv2_fs_object an abstract structure

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -166,17 +166,17 @@ struct lv2_fs_object
 	// File Name (max 1055)
 	const std::array<char, 0x420> name;
 
+protected:
 	lv2_fs_object(lv2_fs_mount_point* mp, std::string_view filename)
 		: mp(mp)
 		, name(get_name(filename))
 	{
 	}
 
+public:
 	lv2_fs_object(const lv2_fs_object&) = delete;
 
 	lv2_fs_object& operator=(const lv2_fs_object&) = delete;
-
-	virtual ~lv2_fs_object() = default;
 
 	static lv2_fs_mount_point* get_mp(std::string_view filename);
 
@@ -193,8 +193,6 @@ struct lv2_fs_object
 		name[filename.size()] = 0;
 		return name;
 	}
-
-	virtual std::string to_string() const { return {}; }
 };
 
 struct lv2_file final : lv2_fs_object
@@ -276,19 +274,6 @@ struct lv2_file final : lv2_fs_object
 
 	// Make file view from lv2_file object (for MSELF support)
 	static fs::file make_view(const std::shared_ptr<lv2_file>& _file, u64 offset);
-
-	virtual std::string to_string() const override
-	{
-		std::string_view type_s;
-		switch (type)
-		{
-		case lv2_file_type::regular: type_s = "Regular file"; break;
-		case lv2_file_type::sdata: type_s = "SDATA"; break;
-		case lv2_file_type::edata: type_s = "EDATA"; break;
-		}
-
-		return fmt::format(u8"%s, “%s”, Mode: 0x%x, Flags: 0x%x", type_s, name.data(), mode, flags);
-	}
 };
 
 struct lv2_dir final : lv2_fs_object
@@ -313,11 +298,6 @@ struct lv2_dir final : lv2_fs_object
 		}
 
 		return nullptr;
-	}
-
-	virtual std::string to_string() const override
-	{
-		return fmt::format(u8"Directory, “%s”, Entries: %u/%u", name.data(), std::min<u64>(pos, entries.size()), entries.size());
 	}
 };
 

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -813,7 +813,22 @@ void kernel_explorer::Update()
 
 	idm::select<lv2_fs_object>([&](u32 id, lv2_fs_object& fo)
 	{
-		add_leaf(find_node(root, additional_nodes::file_descriptors), qstr(fmt::format("FD %u: %s", id, fo.to_string())));
+		const std::string str = fmt::format("FD %u: %s", id, [&]() -> std::string
+		{
+			if (idm::check_unlocked<lv2_fs_object, lv2_file>(id))
+			{
+				return fmt::format("%s", static_cast<lv2_file&>(fo));
+			}
+
+			if (idm::check_unlocked<lv2_fs_object, lv2_dir>(id))
+			{
+				return fmt::format("%s", static_cast<lv2_dir&>(fo));
+			}
+
+			return "Unknown object!";
+		}());
+
+		add_leaf(find_node(root, additional_nodes::file_descriptors), qstr(str));
 	});
 
 	std::function<int(QTreeWidgetItem*)> final_touches;


### PR DESCRIPTION
* Make lv2_fs_object an abstract structure.
* Improve kernel-explorer information for filesystem objects.