### PR TITLE
VFS: Fix paths override

### DIFF
--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -262,11 +262,9 @@ bool emu_settings::ValidateSettings(bool cleanup)
 	return is_clean;
 }
 
-void emu_settings::SaveSettings() const
+void emu_settings::SaveSettings()
 {
 	YAML::Emitter out;
-	emit_data(out, m_current_settings);
-
 	std::string config_name;
 
 	if (m_title_id.empty())
@@ -275,8 +273,12 @@ void emu_settings::SaveSettings() const
 	}
 	else
 	{
+		// VFS paths are being controlled mainly by the main config (needs manual modification for customization of custom configs)
+		m_current_settings.remove("VFS");
 		config_name = rpcs3::utils::get_custom_config_path(m_title_id);
 	}
+
+	emit_data(out, m_current_settings);
 
 	// Save config atomically
 	fs::pending_file temp(config_name);

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -94,7 +94,7 @@ public:
 
 public Q_SLOTS:
 	/** Writes the unsaved settings to file.  Used in settings dialog on accept.*/
-	void SaveSettings() const;
+	void SaveSettings();
 private:
 	YAML::Node m_default_settings; // The default settings as a YAML node.
 	YAML::Node m_current_settings; // The current settings as a YAML node.


### PR DESCRIPTION
It turned out that if config of games exists before VFS manager saved modified paths, new paths set from VFS manager will be ignored completely by the game! 