### PR TITLE
Qt: apply gui settings on regular apply and save

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -41,9 +41,10 @@ private:
 	void SnapSlider(QSlider* slider, int interval);
 	QSlider* m_current_slider = nullptr;
 
-	// Emulator tab
+	// Gui tab
 	void AddGuiConfigs();
 	void AddStylesheets();
+	void ApplyGuiOptions(bool reset);
 	QString m_current_stylesheet;
 	QString m_current_gui_config;
 	// Gpu tab


### PR DESCRIPTION
This fixes the annoying issue of accidentally clicking the settings dialog's save or apply buttons after changing stylesheets, 
and the stylesheet doesn't apply