### PR TITLE
Improve ppu_thread::stack_push, use concepts in vm_ptr.h, PPU HLE callbacks fix

### DIFF
--- a/rpcs3/Emu/Cell/PPUCallback.h
+++ b/rpcs3/Emu/Cell/PPUCallback.h
@@ -170,10 +170,12 @@ namespace ppu_cb_detail
 	{
 		FORCE_INLINE static void call(ppu_thread& CPU, u32 pc, u32 rtoc, T... args)
 		{
+			const u64 old_r1 = CPU.gpr[1];
+			CPU.gpr[1] &= -16; // Ensure 16-byte alignment
 			const bool stack = _bind_func_args<0, 0, 0, T...>(CPU, args...);
 			CPU.gpr[1] -= stack ? FIXED_STACK_FRAME_SIZE : 0x70; // create reserved area
 			CPU.fast_call(pc, rtoc);
-			CPU.gpr[1] += stack ? FIXED_STACK_FRAME_SIZE : 0x70;
+			CPU.gpr[1] = old_r1;
 		}
 	};
 }

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -308,7 +308,7 @@ public:
 	void exec_task();
 	void fast_call(u32 addr, u32 rtoc);
 
-	static u32 stack_push(u32 size, u32 align_v);
+	static std::pair<vm::addr_t, u32> stack_push(u32 size, u32 align_v);
 	static void stack_pop_verbose(u32 addr, u32 size) noexcept;
 };
 


### PR DESCRIPTION
* Fix stack alignment of PPU HLE callbacks within context of HLE PPU stack variables.
* HLE PPU stack variables: save some guest (PS3) memory by saving allocation size locally. (instead in PS3 memory)
* Use c++20 concepts in vm_ptr.h