### PR TITLE
Fixup for regression from #10490

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 template <typename Derived, typename Base>
-concept derived_from = std::is_base_of_v<Base, Derived> &&
+concept DerivedFrom = std::is_base_of_v<Base, Derived> &&
 	std::is_convertible_v<const volatile Derived*, const volatile Base*>;
 
 // Thread state flags
@@ -111,7 +111,7 @@ public:
 		return id >> 24;
 	}
 
-	template <derived_from<cpu_thread> T> 
+	template <DerivedFrom<cpu_thread> T>
 	T* try_get()
 	{
 		if constexpr (std::is_same_v<std::remove_const_t<T>, cpu_thread>)
@@ -129,7 +129,7 @@ public:
 		}
 	}
 
-	template <derived_from<cpu_thread> T> 
+	template <DerivedFrom<cpu_thread> T>
 	const T* try_get() const
 	{
 		return const_cast<cpu_thread*>(this)->try_get<const T>();
@@ -270,7 +270,7 @@ public:
 	// Send signal to the profiler(s) to flush results
 	static void flush_profilers() noexcept;
 
-	template <derived_from<cpu_thread> T = cpu_thread> 
+	template <DerivedFrom<cpu_thread> T = cpu_thread>
 	static inline T* get_current() noexcept
 	{
 		if (const auto cpu = g_tls_this_thread)
@@ -285,7 +285,7 @@ private:
 	static thread_local cpu_thread* g_tls_this_thread;
 };
 
-template <derived_from<cpu_thread> T = cpu_thread> 
+template <DerivedFrom<cpu_thread> T = cpu_thread>
 inline T* get_current_cpu_thread() noexcept
 {
 	return cpu_thread::get_current<T>();

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -144,6 +144,8 @@ public:
 	ppu_thread(const ppu_thread&) = delete;
 	ppu_thread& operator=(const ppu_thread&) = delete;
 
+	using cpu_thread::operator=;
+
 	u64 gpr[32] = {}; // General-Purpose Registers
 	f64 fpr[32] = {}; // Floating Point Registers
 	v128 vr[32] = {}; // Vector Registers

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -644,6 +644,8 @@ public:
 	spu_thread(const spu_thread&) = delete;
 	spu_thread& operator=(const spu_thread&) = delete;
 
+	using cpu_thread::operator=;
+
 	u32 pc = 0;
 	u32 dbg_step_pc = 0;
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1535,6 +1535,11 @@ void Emulator::Stop(bool restart)
 	});
 
 	// Signal threads
+	if (auto rsx = g_fxo->try_get<rsx::thread>())
+	{
+		*static_cast<cpu_thread*>(rsx) = thread_state::aborting;
+	}
+
 	for (const auto& [type, data] : *g_fxo)
 	{
 		if (type.stop)


### PR DESCRIPTION
Inheritance is a bit more annoying, it disables operator= implicitly.
Should fix #10499 