### PR TITLE
Improve PlayTV

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -189,7 +189,7 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 	if (!new_data)
 	{
 		const auto cat = psf::get_string(sfo, "CATEGORY", "");
-		if (cat != "HG")
+		if (cat != "HG"sv && cat != "AM"sv && cat != "AP"sv && cat != "AT"sv && cat != "AV"sv && cat != "BV"sv && cat != "WT"sv)
 		{
 			return { CELL_GAMEDATA_ERROR_BROKEN, fmt::format("CATEGORY='%s'", cat) };
 		}
@@ -592,7 +592,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 	{
 		switch (type)
 		{
-		case CELL_GAME_GAMETYPE_HDD: return cat != "HG"sv;
+		case CELL_GAME_GAMETYPE_HDD: return cat != "HG"sv && cat != "AM"sv && cat != "AP"sv && cat != "AT"sv && cat != "AV"sv && cat != "BV"sv && cat != "WT"sv;
 		case CELL_GAME_GAMETYPE_GAMEDATA: return cat != "GD"sv;
 		case CELL_GAME_GAMETYPE_DISC: return cat != "DG"sv;
 		default: fmt::throw_exception("Unreachable");

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -167,6 +167,7 @@ usb_handler_thread::usb_handler_thread()
 		};
 		// clang-format on
 
+		// Portals
 		if (check_device(0x1430, 0x0150, 0x0150, "Skylanders Portal"))
 		{
 			found_skylander = true;
@@ -175,7 +176,12 @@ usb_handler_thread::usb_handler_thread()
 		check_device(0x0E6F, 0x0241, 0x0241, "Lego Dimensions Portal");
 		check_device(0x0E6F, 0x0129, 0x0129, "Disney Infinity Portal");
 
-		check_device(0x1415, 0x0000, 0x0000, "Singstar Microphone");
+		// Cameras
+		//check_device(0x1415, 0x0020, 0x2000, "Sony Playstation Eye"); // TODO: verifiy
+
+		// Music devices
+		check_device(0x1415, 0x0000, 0x0000, "SingStar Microphone");
+		//check_device(0x1415, 0x0020, 0x0020, "SingStar Microphone Wireless"); // TODO: verifiy
 		check_device(0x12BA, 0x0100, 0x0100, "Guitar Hero Guitar");
 		check_device(0x12BA, 0x0120, 0x0120, "Guitar Hero Drums");
 		if (check_device(0x12BA, 0x074B, 0x074B, "Guitar Hero Live Guitar"))
@@ -216,6 +222,9 @@ usb_handler_thread::usb_handler_thread()
 
 		// uDraw GameTablet
 		check_device(0x20D6, 0xCB17, 0xCB17, "uDraw GameTablet");
+
+		// DVB-T
+		check_device(0x1415, 0x0003, 0x0003, " PlayTV SCEH-0036");
 	}
 
 	libusb_free_device_list(list, 1);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -880,7 +880,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		}
 
 		// Booting patch data
-		if (m_cat == "GD" && bdvd_dir.empty() && disc.empty())
+		if ((is_disc_patch || m_cat == "GD") && bdvd_dir.empty() && disc.empty())
 		{
 			// Load /dev_bdvd/ from game list if available
 			if (auto node = games[m_title_id])

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -748,7 +748,7 @@ void game_list_frame::OnRefreshFinished()
 					return false;
 				};
 
-				if (entry->info.serial == other->info.serial && other->info.category == "GD" && other->info.app_ver != cat_unknown_localized)
+				if (entry->info.serial == other->info.serial && other->info.category != "DG" && other->info.app_ver != cat_unknown_localized)
 				{
 					// Update the app version if it's higher than the disc's version (old games may not have an app version)
 					if (entry->info.app_ver == cat_unknown_localized || version_is_bigger(other->info.app_ver, entry->info.app_ver, entry->info.serial, true))


### PR DESCRIPTION
- Fixes the error during game data installation of PlayTV by treating all app categories as HDD_GAME in cellGame
- Fixes an issue that causes disc games to show the old version even though patches were installed, if the patch category was something other than "GD" (for example AT for APP TV)
- Fixes an issue where the virtual bluray drive wasn't mounted if the loaded patch was not of type GD (This might not have any effect or even be wrong though)

PlayTV only seems to "work" if you first boot the game version 01.00 and install its game data.
You can then install version 02.04 and it will still boot with the same result.
If you install 02.04 before letting the 01.00 game install its data, then it will fail with a mem access violation.

I don't know if this is a bug on PS3 as well or if we are still doing something wrong.