### PR TITLE
Improve kernel explorer

### DIFF
--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -170,10 +170,10 @@ static QTreeWidgetItem* add_solid_node(QTreeWidget* tree, QTreeWidgetItem *paren
 kernel_explorer::kernel_explorer(QWidget* parent)
 	: QDialog(parent)
 {
-	setWindowTitle(tr("Kernel Explorer"));
+	setWindowTitle(tr("Kernel Explorer | %1").arg(qstr(Emu.GetTitleAndTitleID())));
 	setObjectName("kernel_explorer");
 	setAttribute(Qt::WA_DeleteOnClose);
-	setMinimumSize(QSize(700, 450));
+	setMinimumSize(QSize(800, 600));
 
 	QVBoxLayout* vbox_panel = new QVBoxLayout();
 	QHBoxLayout* hbox_buttons = new QHBoxLayout();
@@ -182,7 +182,7 @@ kernel_explorer::kernel_explorer(QWidget* parent)
 	hbox_buttons->addStretch();
 
 	m_tree = new QTreeWidget(this);
-	m_tree->setBaseSize(QSize(600, 300));
+	m_tree->setBaseSize(QSize(700, 450));
 	m_tree->setWindowTitle(tr("Kernel"));
 	m_tree->header()->close();
 

--- a/rpcs3/rpcs3qt/kernel_explorer.h
+++ b/rpcs3/rpcs3qt/kernel_explorer.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <QDialog>
+#include <QString>
 
 #include "util/types.hpp"
 
 class QTreeWidget;
+class QTreeWidgetItem;
 
 class kernel_explorer : public QDialog
 {
@@ -30,7 +32,10 @@ public:
 
 private:
 	QTreeWidget* m_tree;
+	QString m_log_buf;
+
+	void log(u32 level = 0, QTreeWidgetItem* node = nullptr);
 
 private Q_SLOTS:
-	void Update();
+	void update();
 };


### PR DESCRIPTION
* Default width of dialog has been increased to fit PPU, SPURS and filesystem objects' description length.
* Height has been increased as well to allow viwwing more objects at once.
* Added title of the game to the kernel explorer's windows' title.
* Added the ability to log all of what's currently viewed in kernel explorer.