### PR TITLE
kernel_explorer: Atomic PPU state updates

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1390,13 +1390,13 @@ void lv2_obj::schedule_all()
 	}
 }
 
-ppu_thread_status lv2_obj::ppu_state(ppu_thread* ppu, bool lock_idm)
+ppu_thread_status lv2_obj::ppu_state(ppu_thread* ppu, bool lock_idm, bool lock_lv2)
 {
-	std::optional<reader_lock> opt_lock;
+	std::optional<reader_lock> opt_lock[2];
 
 	if (lock_idm)
 	{
-		opt_lock.emplace(id_manager::g_mutex);
+		opt_lock[0].emplace(id_manager::g_mutex);
 	}
 
 	if (ppu->state & cpu_flag::stop)
@@ -1411,7 +1411,10 @@ ppu_thread_status lv2_obj::ppu_state(ppu_thread* ppu, bool lock_idm)
 	default: break;
 	}
 
-	reader_lock lock(g_mutex);
+	if (lock_lv2)
+	{
+		opt_lock[1].emplace(lv2_obj::g_mutex);
+	}
 
 	const auto it = std::find(g_ppu.begin(), g_ppu.end(), ppu);
 

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -187,7 +187,7 @@ public:
 		g_to_awake.clear();
 	}
 
-	static ppu_thread_status ppu_state(ppu_thread* ppu, bool lock_idm = true);
+	static ppu_thread_status ppu_state(ppu_thread* ppu, bool lock_idm = true, bool lock_lv2 = true);
 
 	static inline void append(cpu_thread* const thread)
 	{
@@ -406,10 +406,10 @@ public:
 		return true;
 	}
 
-private:
 	// Scheduler mutex
 	static shared_mutex g_mutex;
 
+private:
 	// Pending list of threads to run
 	static thread_local std::vector<class cpu_thread*> g_to_awake;
 


### PR DESCRIPTION
Lock PPU state mutex once for all PPUs so the information reported is accurate for global threads state. Previously it could have reported non-existing states such as 3 running PPUs etc because it was not atomic.