### PR TITLE
fmt: implement char8_t string support

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -153,6 +153,27 @@ void fmt_class_string<std::vector<char>>::format(std::string& out, u64 arg)
 }
 
 template <>
+void fmt_class_string<std::u8string>::format(std::string& out, u64 arg)
+{
+	const std::u8string& obj = get_object(arg);
+	out.append(obj.cbegin(), obj.cend());
+}
+
+template <>
+void fmt_class_string<std::u8string_view>::format(std::string& out, u64 arg)
+{
+	const std::u8string_view& obj = get_object(arg);
+	out.append(obj.cbegin(), obj.cend());
+}
+
+template <>
+void fmt_class_string<std::vector<char8_t>>::format(std::string& out, u64 arg)
+{
+	const std::vector<char8_t>& obj = get_object(arg);
+	out.append(obj.cbegin(), obj.cend());
+}
+
+template <>
 void fmt_class_string<char>::format(std::string& out, u64 arg)
 {
 	fmt::append(out, "%#hhx", static_cast<char>(arg));

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -205,6 +205,16 @@ struct fmt_class_string<char*, void> : fmt_class_string<const char*>
 	// Classify char* as const char*
 };
 
+template <>
+struct fmt_class_string<const char8_t*, void> : fmt_class_string<const char*>
+{
+};
+
+template <>
+struct fmt_class_string<char8_t*, void> : fmt_class_string<const char8_t*>
+{
+};
+
 struct fmt_type_info
 {
 	decltype(&fmt_class_string<int>::format) fmt_string;


### PR DESCRIPTION
char8_t is a new fundamental integral type for UTF-8 characters. Adding missing pieces to allow formatting.