### PR TITLE
[TESTERS NEEDED] rsx/vk: Rewrite memory management

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -49,7 +49,10 @@ namespace rsx
 
 			// Arbitrary r/w flags, use with caution.
 			memory_write = 8,
-			memory_read = 16
+			memory_read = 16,
+
+			// Not r/w but signifies a GPU reference to this object.
+			gpu_reference = 32
 		};
 
 	private:

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -106,7 +106,7 @@ namespace rsx
 	// Defines how the underlying PS3-visible memory backed by a texture is accessed
 	namespace format_class_
 	{
-		// TODO: Remove when enum import is supported by GCC
+		// TODO: Remove when enum import is supported by clang
 		enum format_class : u8
 		{
 			RSX_FORMAT_CLASS_UNDEFINED = 0,

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -1092,7 +1092,7 @@ namespace rsx
 			return true;
 		}
 
-		virtual bool handle_memory_pressure(command_list_type cmd, problem_severity severity)
+		virtual bool handle_memory_pressure(command_list_type cmd, problem_severity /*severity*/)
 		{
 			auto process_list_function = [&](std::unordered_map<u32, surface_storage_type>& data)
 			{

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1429,7 +1429,7 @@ namespace rsx
 			m_storage.purge_unreleased_sections();
 		}
 
-		bool handle_memory_pressure(problem_severity severity)
+		virtual bool handle_memory_pressure(problem_severity severity)
 		{
 			if (m_storage.m_unreleased_texture_objects)
 			{

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -67,7 +67,8 @@ namespace vk
 
 		allocated_memory = std::make_unique<vk::buffer>(dev, size,
 			dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-			VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
+			VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0,
+			VMM_ALLOCATION_POOL_UNDEFINED);
 
 		s_allocated_dma_pool_size += allocated_memory->size();
 	}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -481,7 +481,7 @@ VKGSRender::VKGSRender() : GSRender()
 	}
 
 	const auto& memory_map = m_device->get_memory_mapping();
-	null_buffer = std::make_unique<vk::buffer>(*m_device, 32, memory_map.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, 0);
+	null_buffer = std::make_unique<vk::buffer>(*m_device, 32, memory_map.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
 	null_buffer_view = std::make_unique<vk::buffer_view>(*m_device, null_buffer->value, VK_FORMAT_R8_UINT, 0, 32);
 
 	vk::initialize_compiler_context();
@@ -2461,7 +2461,7 @@ void VKGSRender::begin_conditional_rendering(const std::vector<rsx::reports::occ
 		m_cond_render_buffer = std::make_unique<vk::buffer>(
 			*m_device, 4,
 			memory_props.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-			usage_flags, 0);
+			usage_flags, 0, VMM_ALLOCATION_POOL_UNDEFINED);
 	}
 
 	VkPipelineStageFlags dst_stage;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -511,7 +511,7 @@ private:
 		VkSemaphore signal_semaphore = VK_NULL_HANDLE,
 		VkPipelineStageFlags pipeline_stage_flags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 
-	void flush_command_queue(bool hard_sync = false);
+	void flush_command_queue(bool hard_sync = false, bool do_not_switch = false);
 	void queue_swap_request();
 	void frame_context_cleanup(vk::frame_context_t *ctx, bool free_resources = false);
 	void advance_queued_frames();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -365,6 +365,8 @@ private:
 		deadlock = 2
 	};
 
+	using enum vk::vmm_allocation_pool;
+
 private:
 	VKFragmentProgram m_fragment_prog;
 	VKVertexProgram m_vertex_prog;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -374,7 +374,7 @@ private:
 	vk::pipeline_props m_pipeline_properties;
 
 	vk::texture_cache m_texture_cache;
-	rsx::vk_render_targets m_rtts;
+	vk::surface_cache m_rtts;
 
 	std::unique_ptr<vk::buffer> null_buffer;
 	std::unique_ptr<vk::buffer_view> null_buffer_view;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -335,6 +335,8 @@ namespace vk
 	};
 }
 
+using namespace vk::vmm_allocation_pool_; // clang workaround.
+
 class VKGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 {
 private:
@@ -364,8 +366,6 @@ private:
 		flushing = 1,
 		deadlock = 2
 	};
-
-	using enum vk::vmm_allocation_pool;
 
 private:
 	VKFragmentProgram m_fragment_prog;

--- a/rpcs3/Emu/RSX/VK/VKOverlays.cpp
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.cpp
@@ -514,7 +514,7 @@ namespace vk
 		auto tex = std::make_unique<vk::image>(dev, dev.get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 			VK_IMAGE_TYPE_2D, format, std::max(w, 1u), std::max(h, 1u), 1, 1, layers, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-			0);
+			0, VMM_ALLOCATION_POOL_UNDEFINED);
 
 		if (pixel_src && data_size)
 			std::memcpy(addr, pixel_src, data_size);

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -112,7 +112,7 @@ void VKGSRender::advance_queued_frames()
 	vk::vmm_check_memory_usage();
 
 	// m_rtts storage is double buffered and should be safe to tag on frame boundary
-	m_rtts.free_invalidated(*m_current_command_buffer);
+	m_rtts.free_invalidated(*m_current_command_buffer, vk::vmm_determine_memory_load_severity());
 
 	// Texture cache is also double buffered to prevent use-after-free
 	m_texture_cache.on_frame_end();

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -655,8 +655,8 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 
 			const usz sshot_size = buffer_height * buffer_width * 4;
 
-			vk::buffer sshot_vkbuf(*m_device, utils::align(sshot_size, 0x100000), m_device->get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-				VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
+			vk::buffer sshot_vkbuf(*m_device, utils::align(sshot_size, 0x100000), m_device->get_memory_mapping().host_visible_coherent,
+				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
 
 			VkBufferImageCopy copy_info;
 			copy_info.bufferOffset                    = 0;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -483,6 +483,7 @@ namespace vk
 			break;
 		default:
 			element_size = get_format_texel_width(fmt);
+			break;
 		}
 
 		vk::image* src = nullptr;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -52,7 +52,59 @@ namespace vk
 
 		if (severity >= rsx::problem_severity::fatal)
 		{
-			// TODO
+			// Drop MSAA resolve/unresolve caches. Only trigger when a hard sync is guaranteed to follow else it will cause even more problems!
+			auto relieve_memory_pressure = [&](const auto& list)
+			{
+				// 2-pass to ensure resources are available where they are most needed
+				std::vector<std::unique_ptr<vk::viewable_image>> resolve_target_cache;
+				std::vector<vk::render_target*> deferred_spills;
+				auto gc = vk::get_resource_manager();
+
+				// 1. Scan the list and spill resources that can be spilled immediately if requested. Also gather resources from those that don't need it.
+				for (auto& surface : list)
+				{
+					auto& rtt = surface.second;
+					if (!rtt->spill_request_tag || rtt->spill_request_tag < surface.second->last_rw_access_tag)
+					{
+						// We're not going to be spilling into system RAM. If a MSAA resolve target exists, remove it to save memory.
+						if (rtt->resolve_surface)
+						{
+							resolve_target_cache.emplace_back(std::move(rtt->resolve_surface));
+							rtt->msaa_flags |= rsx::surface_state_flags::require_resolve;
+							any_released |= true;
+						}
+
+						rtt->spill_request_tag = 0;
+						continue;
+					}
+
+					if (rtt->resolve_surface || rtt->samples() == 1)
+					{
+						// Can spill immediately. Do it.
+						rtt->spill(cmd, resolve_target_cache);
+						any_released |= true;
+						continue;
+					}
+
+					deferred_spills.push_back(rtt.get());
+				}
+
+				// 2. We should have enough discarded reusable memory for the second pass.
+				for (auto& surface : deferred_spills)
+				{
+					surface->spill(cmd, resolve_target_cache);
+					any_released |= true;
+				}
+
+				// 3. Discard the now-useless resolve cache memory
+				for (auto& data : resolve_target_cache)
+				{
+					gc->dispose(data);
+				}
+			};
+
+			relieve_memory_pressure(m_render_targets_storage);
+			relieve_memory_pressure(m_depth_stencil_storage);
 		}
 
 		return any_released;
@@ -121,6 +173,63 @@ namespace vk
 		const auto surface_cache_vram_load = vmm_get_application_pool_usage(VMM_ALLOCATION_POOL_SURFACE_CACHE);
 		const auto surface_cache_allocation_quota = get_surface_cache_memory_quota(get_current_renderer()->get_memory_mapping().device_local_total_bytes);
 		return (surface_cache_vram_load > surface_cache_allocation_quota);
+	}
+
+	bool surface_cache::spill_unused_memory()
+	{
+		// Determine how much memory we need to save to system RAM if any
+		const u64 current_surface_cache_memory = vk::vmm_get_application_pool_usage(VMM_ALLOCATION_POOL_SURFACE_CACHE);
+		const u64 total_device_memory = vk::get_current_renderer()->get_memory_mapping().device_local_total_bytes;
+		const u64 target_memory = get_surface_cache_memory_quota(total_device_memory);
+
+		rsx_log.warning("Surface cache memory usage is %lluM", current_surface_cache_memory / 0x100000);
+		if (current_surface_cache_memory < target_memory)
+		{
+			rsx_log.warning("Surface cache memory usage is very low. Will not spill contents to RAM");
+			return false;
+		}
+
+		// Very slow, but should only be called when the situation is dire
+		std::vector<render_target*> sorted_list;
+		sorted_list.reserve(m_render_targets_storage.size() + m_depth_stencil_storage.size());
+
+		auto process_list_function = [&](const auto& list)
+		{
+			for (auto& surface : list)
+			{
+				if (surface.second->value && !surface.second->is_bound)
+				{
+					sorted_list.push_back(surface.second.get());
+				}
+			}
+		};
+
+		process_list_function(m_render_targets_storage);
+		process_list_function(m_depth_stencil_storage);
+
+		std::sort(sorted_list.begin(), sorted_list.end(), [](const auto& a, const auto& b)
+		{
+			return a->last_rw_access_tag < b->last_rw_access_tag;
+		});
+
+		// Remove upto target_memory bytes from VRAM
+		u64 bytes_spilled = 0;
+		const u64 bytes_to_remove = current_surface_cache_memory - target_memory;
+		const u64 spill_time = rsx::get_shared_tag();
+
+		for (auto& surface : sorted_list)
+		{
+			bytes_spilled += surface->memory->size();
+			surface->spill_request_tag = spill_time;
+
+			if (bytes_spilled >= bytes_to_remove)
+			{
+				break;
+			}
+		}
+
+		rsx_log.warning("Surface cache will attempt to spill %llu bytes.", bytes_spilled);
+		return (bytes_spilled > 0);
 	}
 
 	// Get the linear resolve target bound to this surface. Initialize if none exists
@@ -334,6 +443,156 @@ namespace vk
 		}
 	}
 
+	std::vector<VkBufferImageCopy> render_target::build_spill_transfer_descriptors(vk::image* target)
+	{
+		std::vector<VkBufferImageCopy> result;
+		result.reserve(2);
+
+		result.push_back({});
+		auto& rgn = result.back();
+		rgn.imageExtent.width = target->width();
+		rgn.imageExtent.height = target->height();
+		rgn.imageExtent.depth = 1;
+		rgn.imageSubresource.aspectMask = target->aspect();
+		rgn.imageSubresource.layerCount = 1;
+
+		if (aspect() == (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+		{
+			result.push_back(rgn);
+			rgn.imageSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+			result.back().imageSubresource.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+			result.back().bufferOffset = target->width() * target->height() * 4;
+		}
+
+		return result;
+	}
+
+	void render_target::spill(vk::command_buffer& cmd, std::vector<std::unique_ptr<vk::viewable_image>>& resolve_cache)
+	{
+		ensure(value);
+
+		u64 element_size;
+		switch (const auto fmt = format())
+		{
+		case VK_FORMAT_D32_SFLOAT:
+			element_size = 4;
+			break;
+		case VK_FORMAT_D32_SFLOAT_S8_UINT:
+		case VK_FORMAT_D24_UNORM_S8_UINT:
+			element_size = 5;
+			break;
+		default:
+			element_size = get_format_texel_width(fmt);
+		}
+
+		vk::image* src = nullptr;
+		if (samples() == 1) [[likely]]
+		{
+			src = this;
+		}
+		else if (resolve_surface)
+		{
+			src = resolve_surface.get();
+		}
+		else
+		{
+			const auto transfer_w = width() * samples_x;
+			const auto transfer_h = height() * samples_y;
+
+			for (auto& surface : resolve_cache)
+			{
+				if (surface->format() == format() &&
+					surface->width() == transfer_w &&
+					surface->height() == transfer_h)
+				{
+					src = surface.get();
+					break;
+				}
+			}
+
+			if (!src)
+			{
+				if (vmm_determine_memory_load_severity() <= rsx::problem_severity::moderate)
+				{
+					// We have some freedom to allocate something. Add to the shared cache
+					src = get_resolve_target_safe(cmd);
+				}
+				else
+				{
+					// TODO: Spill to DMA buf
+					// For now, just skip this one if we don't have the capacity for it
+					rsx_log.warning("Could not spill memory due to resolve failure. Will ignore spilling for the moment.");
+					return;
+				}
+			}
+
+			msaa_flags |= rsx::surface_state_flags::require_resolve;
+		}
+
+		// If a resolve is requested, move data to the target
+		if (msaa_flags & rsx::surface_state_flags::require_resolve)
+		{
+			ensure(samples() > 1);
+			resolve(cmd);
+		}
+
+		const auto pdev = vk::get_current_renderer();
+		const auto alloc_size = element_size * src->width() * src->height();
+
+		m_spilled_mem = std::make_unique<vk::buffer>(*pdev, alloc_size, pdev->get_memory_mapping().host_visible_coherent,
+			0, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
+
+		const auto regions = build_spill_transfer_descriptors(src);
+		src->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+		vkCmdCopyImageToBuffer(cmd, src->value, src->current_layout, m_spilled_mem->value, ::size32(regions), regions.data());
+
+		// Destroy this object through a cloned object
+		auto obj = std::unique_ptr<viewable_image>(clone());
+		vk::get_resource_manager()->dispose(obj);
+
+		if (resolve_surface)
+		{
+			// Just add to the resolve cache and move on
+			resolve_cache.emplace_back(std::move(resolve_surface));
+		}
+
+		ensure(!memory && !value && views.empty() && !resolve_surface);
+		spill_request_tag = 0ull;
+	}
+
+	void render_target::unspill(vk::command_buffer& cmd)
+	{
+		// Recreate the image
+		const auto pdev = vk::get_current_renderer();
+		create_impl(*pdev, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, pdev->get_memory_mapping().device_local, VMM_ALLOCATION_POOL_SURFACE_CACHE);
+		change_layout(cmd, is_depth_surface() ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+
+		// Load image from host-visible buffer
+		ensure(m_spilled_mem);
+
+		// Data transfer can be skipped if an erase command is being served
+		if (!(state_flags & rsx::surface_state_flags::erase_bkgnd))
+		{
+			// Warn. Ideally this should never happen if you have enough resources
+			rsx_log.warning("[PERFORMANCE WARNING] Loading spilled memory back to the GPU. You may want to lower your resolution scaling.");
+
+			vk::image* dst = (samples() > 1) ? get_resolve_target_safe(cmd) : this;
+			const auto regions = build_spill_transfer_descriptors(dst);
+
+			dst->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+			vkCmdCopyBufferToImage(cmd, m_spilled_mem->value, dst->value, dst->current_layout, ::size32(regions), regions.data());
+
+			if (samples() > 1)
+			{
+				msaa_flags &= ~rsx::surface_state_flags::require_resolve;
+				msaa_flags |= rsx::surface_state_flags::require_unresolve;
+			}
+		}
+
+		// Delete host-visible buffer
+		vk::get_resource_manager()->dispose(m_spilled_mem);
+	}
+
 	// Load memory from cell and use to initialize the surface
 	void render_target::load_memory(vk::command_buffer& cmd)
 	{
@@ -426,6 +685,8 @@ namespace vk
 
 	vk::viewable_image* render_target::get_surface(rsx::surface_access access_type)
 	{
+		last_rw_access_tag = rsx::get_shared_tag();
+
 		if (samples() == 1 || access_type == rsx::surface_access::shader_write)
 		{
 			return this;
@@ -491,6 +752,18 @@ namespace vk
 
 	void render_target::memory_barrier(vk::command_buffer& cmd, rsx::surface_access access)
 	{
+		if (access == rsx::surface_access::gpu_reference)
+		{
+			// This barrier only requires that an object is made available for GPU usage.
+			if (!value)
+			{
+				unspill(cmd);
+			}
+
+			spill_request_tag = 0;
+			return;
+		}
+
 		const bool is_depth = is_depth_surface();
 		const bool should_read_buffers = is_depth ? !!g_cfg.video.read_depth_buffer : !!g_cfg.video.read_color_buffers;
 
@@ -504,6 +777,12 @@ namespace vk
 				// The result should have been the same either way
 				state_flags |= rsx::surface_state_flags::erase_bkgnd;
 			}
+		}
+
+		// Unspill here, because erase flag may have been set above.
+		if (!value)
+		{
+			unspill(cmd);
 		}
 
 		if (access == rsx::surface_access::shader_write && write_barrier_sync_tag != 0)

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -16,7 +16,7 @@ namespace vk
 
 		if (total_device_memory >= 2048)
 		{
-			quota = std::min(6144ull, (total_device_memory * 40) / 100);
+			quota = std::min<u64>(6144, (total_device_memory * 40) / 100);
 		}
 		else if (total_device_memory >= 1024)
 		{
@@ -29,7 +29,7 @@ namespace vk
 		else
 		{
 			// Remove upto 128MB but at least aim for half of available VRAM
-			quota = std::min(128ull, total_device_memory / 2);
+			quota = std::min<u64>(128, total_device_memory / 2);
 		}
 
 		return quota * 0x100000;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -26,6 +26,7 @@ namespace vk
 				VK_IMAGE_TILING_OPTIMAL,
 				usage,
 				0,
+				VMM_ALLOCATION_POOL_SURFACE_CACHE,
 				format_class()));
 
 			resolve_surface->native_component_map = native_component_map;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -9,6 +9,7 @@
 #include "vkutils/data_heap.h"
 #include "vkutils/device.h"
 #include "vkutils/image.h"
+#include "vkutils/memory.h"
 #include "vkutils/scratch.h"
 
 #include <span>
@@ -120,7 +121,7 @@ namespace rsx
 				VK_IMAGE_LAYOUT_UNDEFINED,
 				VK_IMAGE_TILING_OPTIMAL,
 				usage_flags,
-				0, RSX_FORMAT_CLASS_COLOR);
+				0, vk::VMM_ALLOCATION_POOL_SURFACE_CACHE, RSX_FORMAT_CLASS_COLOR);
 
 			rtt->set_debug_name(fmt::format("RTV @0x%x", address));
 			rtt->change_layout(cmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -181,7 +182,7 @@ namespace rsx
 				VK_IMAGE_LAYOUT_UNDEFINED,
 				VK_IMAGE_TILING_OPTIMAL,
 				usage_flags,
-				0, rsx::classify_format(format));
+				0, vk::VMM_ALLOCATION_POOL_SURFACE_CACHE, rsx::classify_format(format));
 
 			ds->set_debug_name(fmt::format("DSV @0x%x", address));
 			ds->change_layout(cmd, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
@@ -223,6 +224,7 @@ namespace rsx
 					VK_IMAGE_TILING_OPTIMAL,
 					ref->info.usage,
 					ref->info.flags,
+					vk::VMM_ALLOCATION_POOL_SURFACE_CACHE,
 					ref->format_class());
 
 				sink->add_ref();

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -64,11 +64,8 @@ namespace vk
 	{
 		return ensure(dynamic_cast<vk::render_target*>(t));
 	}
-}
 
-namespace rsx
-{
-	struct vk_render_target_traits
+	struct surface_cache_traits
 	{
 		using surface_storage_type = std::unique_ptr<vk::render_target>;
 		using surface_type = vk::render_target*;
@@ -78,7 +75,7 @@ namespace rsx
 
 		static std::unique_ptr<vk::render_target> create_new_surface(
 			u32 address,
-			surface_color_format format,
+			rsx::surface_color_format format,
 			usz width, usz height, usz pitch,
 			rsx::surface_antialiasing antialias,
 			vk::render_device &device, vk::command_buffer& cmd)
@@ -87,16 +84,16 @@ namespace rsx
 			VkFormat requested_format = fmt.first;
 
 			u8 samples;
-			surface_sample_layout sample_layout;
+			rsx::surface_sample_layout sample_layout;
 			if (g_cfg.video.antialiasing_level == msaa_level::_auto)
 			{
 				samples = get_format_sample_count(antialias);
-				sample_layout = surface_sample_layout::ps3;
+				sample_layout = rsx::surface_sample_layout::ps3;
 			}
 			else
 			{
 				samples = 1;
-				sample_layout = surface_sample_layout::null;
+				sample_layout = rsx::surface_sample_layout::null;
 			}
 
 			VkImageUsageFlags usage_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
@@ -144,7 +141,7 @@ namespace rsx
 
 		static std::unique_ptr<vk::render_target> create_new_surface(
 			u32 address,
-			surface_depth_format2 format,
+			rsx::surface_depth_format2 format,
 			usz width, usz height, usz pitch,
 			rsx::surface_antialiasing antialias,
 			vk::render_device &device, vk::command_buffer& cmd)
@@ -153,16 +150,16 @@ namespace rsx
 			VkImageUsageFlags usage_flags = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 
 			u8 samples;
-			surface_sample_layout sample_layout;
+			rsx::surface_sample_layout sample_layout;
 			if (g_cfg.video.antialiasing_level == msaa_level::_auto)
 			{
 				samples = get_format_sample_count(antialias);
-				sample_layout = surface_sample_layout::ps3;
+				sample_layout = rsx::surface_sample_layout::ps3;
 			}
 			else
 			{
 				samples = 1;
-				sample_layout = surface_sample_layout::null;
+				sample_layout = rsx::surface_sample_layout::null;
 			}
 
 			if (samples == 1) [[likely]]
@@ -353,7 +350,7 @@ namespace rsx
 
 		static bool surface_matches_properties(
 			const std::unique_ptr<vk::render_target> &surface,
-			surface_color_format format,
+			rsx::surface_color_format format,
 			usz width, usz height,
 			rsx::surface_antialiasing antialias,
 			bool check_refs = false)
@@ -364,7 +361,7 @@ namespace rsx
 
 		static bool surface_matches_properties(
 			const std::unique_ptr<vk::render_target> &surface,
-			surface_depth_format2 format,
+			rsx::surface_depth_format2 format,
 			usz width, usz height,
 			rsx::surface_antialiasing antialias,
 			bool check_refs = false)
@@ -380,7 +377,7 @@ namespace rsx
 		}
 	};
 
-	struct vk_render_targets : public rsx::surface_store<vk_render_target_traits>
+	struct surface_cache : public rsx::surface_store<vk::surface_cache_traits>
 	{
 		void destroy()
 		{

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -5,8 +5,20 @@
 
 namespace vk
 {
-	std::unordered_map<uptr, vmm_allocation_t> g_vmm_allocations;
-	std::unordered_map<uptr, atomic_t<u64>> g_vmm_memory_usage;
+	struct vmm_memory_stats
+	{
+		std::unordered_map<uptr, vmm_allocation_t> allocations;
+		std::unordered_map<uptr, atomic_t<u64>> memory_usage;
+		std::unordered_map<vmm_allocation_pool, atomic_t<u64>> pool_usage;
+
+		void clear()
+		{
+			allocations.clear();
+			memory_usage.clear();
+			pool_usage.clear();
+		}
+	}
+	g_vmm_stats;
 
 	resource_manager g_resource_manager;
 	atomic_t<u64> g_event_ctr;
@@ -57,20 +69,22 @@ namespace vk
 	void vmm_notify_memory_allocated(void* handle, u32 memory_type, u64 memory_size, vmm_allocation_pool pool)
 	{
 		auto key = reinterpret_cast<uptr>(handle);
-		const vmm_allocation_t info = { memory_size, memory_type };
+		const vmm_allocation_t info = { memory_size, memory_type, pool };
 
-		if (const auto ins = g_vmm_allocations.insert_or_assign(key, info);
+		if (const auto ins = g_vmm_stats.allocations.insert_or_assign(key, info);
 			!ins.second)
 		{
 			rsx_log.error("Duplicate vmm entry with memory handle 0x%llx", key);
 		}
 
-		auto& vmm_size = g_vmm_memory_usage[memory_type];
+		g_vmm_stats.pool_usage[pool] += memory_size;
+
+		auto& vmm_size = g_vmm_stats.memory_usage[memory_type];
 		vmm_size += memory_size;
 
 		if (vmm_size > s_vmm_warn_threshold_size && (vmm_size - memory_size) <= s_vmm_warn_threshold_size)
 		{
-			rsx_log.warning("Memory type 0x%x has allocated more than %.2fG. Currently allocated %.2fG",
+			rsx_log.warning("Memory type 0x%x has allocated more than %04.2fG. Currently allocated %04.2fG",
 				memory_type, size_in_GiB(s_vmm_warn_threshold_size), size_in_GiB(vmm_size));
 		}
 	}
@@ -78,19 +92,90 @@ namespace vk
 	void vmm_notify_memory_freed(void* handle)
 	{
 		auto key = reinterpret_cast<uptr>(handle);
-		if (auto found = g_vmm_allocations.find(key);
-			found != g_vmm_allocations.end())
+		if (auto found = g_vmm_stats.allocations.find(key);
+			found != g_vmm_stats.allocations.end())
 		{
 			const auto& info = found->second;
-			g_vmm_memory_usage[info.type_index] -= info.size;
-			g_vmm_allocations.erase(found);
+			g_vmm_stats.memory_usage[info.type_index] -= info.size;
+			g_vmm_stats.pool_usage[info.pool] -= info.size;
+			g_vmm_stats.allocations.erase(found);
 		}
 	}
 
 	void vmm_reset()
 	{
-		g_vmm_memory_usage.clear();
-		g_vmm_allocations.clear();
+		g_vmm_stats.clear();
+		g_event_ctr = 0;
+		g_last_completed_event = 0;
+	}
+
+	u64 vmm_get_application_memory_usage(u32 memory_type)
+	{
+		return g_vmm_stats.memory_usage[memory_type];
+	}
+
+	u64 vmm_get_application_pool_usage(vmm_allocation_pool pool)
+	{
+		return g_vmm_stats.pool_usage[pool];
+	}
+
+	rsx::problem_severity vmm_determine_memory_load_severity()
+	{
+		const auto vmm_load = get_current_mem_allocator()->get_memory_usage();
+		rsx::problem_severity load_severity = rsx::problem_severity::low;
+
+		// Fragmentation tuning
+		if (vmm_load < 50.f)
+		{
+			get_current_mem_allocator()->set_fastest_allocation_flags();
+		}
+		else if (vmm_load > 75.f)
+		{
+			// Avoid fragmentation if we can
+			get_current_mem_allocator()->set_safest_allocation_flags();
+
+			if (vmm_load > 95.f)
+			{
+				// Drivers will often crash long before returning OUT_OF_DEVICE_MEMORY errors.
+				load_severity = rsx::problem_severity::fatal;
+			}
+			else if (vmm_load > 90.f)
+			{
+				load_severity = rsx::problem_severity::severe;
+			}
+			else
+			{
+				load_severity = rsx::problem_severity::moderate;
+			}
+
+			// Query actual usage for comparison. Maybe we just have really fragmented memory...
+			const auto mem_info = get_current_renderer()->get_memory_mapping();
+			const auto local_memory_usage = vmm_get_application_memory_usage(mem_info.device_local);
+
+			constexpr u64 _1GB = (1024 * 0x100000);
+			if (local_memory_usage < (mem_info.device_local_total_bytes / 2) ||    // Less than 50% VRAM usage OR
+				(mem_info.device_local_total_bytes - local_memory_usage) > _1GB)   // More than 1GiB of unallocated memory
+			{
+				// Lower severity to avoid slowing performance too much
+				load_severity = rsx::problem_severity::low;
+			}
+			else if ((mem_info.device_local_total_bytes - local_memory_usage) > 512 * 0x100000)
+			{
+				// At least 512MB left, do not overreact
+				load_severity = rsx::problem_severity::moderate;
+			}
+
+			if (load_severity >= rsx::problem_severity::moderate)
+			{
+				// NOTE: For some reason fmt::format with a sized float followed by percentage sign causes random crashing.
+				// This is a bug unrelated to this, but explains why we're going with integral percentages here.
+				const auto application_memory_load = (local_memory_usage * 100) / mem_info.device_local_total_bytes;
+				rsx_log.warning("Actual device memory used by internal allocations is %lluM (%llu%%)", local_memory_usage / 0x100000, application_memory_load);
+				rsx_log.warning("Video memory usage is at %d%%. Will attempt to reclaim some resources.", static_cast<int>(vmm_load));
+			}
+		}
+
+		return load_severity;
 	}
 
 	bool vmm_handle_memory_pressure(rsx::problem_severity severity)
@@ -105,21 +190,8 @@ namespace vk
 
 	void vmm_check_memory_usage()
 	{
-		const auto vmm_load = get_current_mem_allocator()->get_memory_usage();
-		rsx::problem_severity load_severity = rsx::problem_severity::low;
-
-		if (vmm_load > 90.f)
-		{
-			rsx_log.warning("Video memory usage exceeding 90%. Will attempt to reclaim resources.");
-			load_severity = rsx::problem_severity::severe;
-		}
-		else if (vmm_load > 75.f)
-		{
-			rsx_log.notice("Video memory usage exceeding 75%. Will attempt to reclaim resources.");
-			load_severity = rsx::problem_severity::moderate;
-		}
-
-		if (load_severity >= rsx::problem_severity::moderate)
+		if (const auto load_severity = vmm_determine_memory_load_severity();
+			load_severity >= rsx::problem_severity::moderate)
 		{
 			vmm_handle_memory_pressure(load_severity);
 		}

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -54,7 +54,7 @@ namespace vk
 		return size / (1024.f * 1024.f * 1024.f);
 	}
 
-	void vmm_notify_memory_allocated(void* handle, u32 memory_type, u64 memory_size)
+	void vmm_notify_memory_allocated(void* handle, u32 memory_type, u64 memory_size, vmm_allocation_pool pool)
 	{
 		auto key = reinterpret_cast<uptr>(handle);
 		const vmm_allocation_t info = { memory_size, memory_type };

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -183,6 +183,7 @@ namespace vk
 	{
 		u64 size;
 		u32 type_index;
+		vmm_allocation_pool pool;
 	};
 
 	resource_manager* get_resource_manager();

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -264,8 +264,10 @@ namespace vk
 
 			//At worst case, 1 char = 16*16*8 bytes (average about 24*8), so ~256K for 128 chars. Allocating 512k for verts
 			//uniform params are 8k in size, allocating for 120 lines (max lines at 4k, one column per row. Can be expanded
-			m_vertex_buffer = std::make_unique<vk::buffer>(dev, 524288, dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
-			m_uniforms_buffer = std::make_unique<vk::buffer>(dev, 983040, dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
+			m_vertex_buffer = std::make_unique<vk::buffer>(dev, 524288, dev.get_memory_mapping().host_visible_coherent,
+					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
+			m_uniforms_buffer = std::make_unique<vk::buffer>(dev, 983040, dev.get_memory_mapping().host_visible_coherent,
+					VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
 
 			m_render_pass = render_pass;
 			m_uniform_buffer_size = 983040;

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -264,8 +264,8 @@ namespace vk
 
 			//At worst case, 1 char = 16*16*8 bytes (average about 24*8), so ~256K for 128 chars. Allocating 512k for verts
 			//uniform params are 8k in size, allocating for 120 lines (max lines at 4k, one column per row. Can be expanded
-			m_vertex_buffer = std::make_unique<vk::buffer>(dev, 524288, dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0);
-			m_uniforms_buffer = std::make_unique<vk::buffer>(dev, 983040, dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0);
+			m_vertex_buffer = std::make_unique<vk::buffer>(dev, 524288, dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
+			m_uniforms_buffer = std::make_unique<vk::buffer>(dev, 983040, dev.get_memory_mapping().host_visible_coherent, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
 
 			m_render_pass = render_pass;
 			m_uniform_buffer_size = 983040;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -58,7 +58,7 @@ namespace vk
 			{
 				const auto texel_layout = vk::get_format_element_size(src->format());
 				const auto elem_size = texel_layout.first;
-				vk::cs_shuffle_base *shuffle_kernel;
+				vk::cs_shuffle_base* shuffle_kernel;
 
 				if (elem_size == 2)
 				{
@@ -162,12 +162,28 @@ namespace vk
 		sync_timestamp = get_system_time();
 	}
 
+	void texture_cache::on_section_destroyed(cached_texture_section& tex)
+	{
+		if (tex.is_managed())
+		{
+			vk::get_resource_manager()->dispose(tex.get_texture());
+		}
+	}
+
+	void texture_cache::clear()
+	{
+		baseclass::clear();
+
+		m_temporary_storage.clear();
+		m_temporary_memory_size = 0;
+	}
+
 	void texture_cache::copy_transfer_regions_impl(vk::command_buffer& cmd, vk::image* dst, const std::vector<copy_region_descriptor>& sections_to_transfer) const
 	{
 		const auto dst_aspect = dst->aspect();
 		const auto dst_bpp = vk::get_format_texel_width(dst->format());
 
-		for (const auto &section : sections_to_transfer)
+		for (const auto& section : sections_to_transfer)
 		{
 			if (!section.src)
 				continue;
@@ -324,11 +340,11 @@ namespace vk
 							dst_y = src_h;
 						}
 
-						vk::copy_scaled_image(cmd, tmp, _dst,
-							areai{ 0, 0, src_w, static_cast<s32>(src_h) },
-							coordi{ { dst_x, dst_y }, { section.dst_w, section.dst_h } },
-							1, tmp->info.format == _dst->info.format,
-							VK_FILTER_NEAREST);
+							vk::copy_scaled_image(cmd, tmp, _dst,
+								areai{ 0, 0, src_w, static_cast<s32>(src_h) },
+								coordi{ { dst_x, dst_y }, { section.dst_w, section.dst_h } },
+								1, tmp->info.format == _dst->info.format,
+								VK_FILTER_NEAREST);
 					}
 					else
 					{
@@ -357,5 +373,845 @@ namespace vk
 
 			section.src->pop_layout(cmd);
 		}
+	}
+
+	VkComponentMapping texture_cache::apply_component_mapping_flags(u32 gcm_format, rsx::component_order flags, const rsx::texture_channel_remap_t& remap_vector) const
+	{
+		switch (gcm_format)
+		{
+		case CELL_GCM_TEXTURE_DEPTH24_D8:
+		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
+		case CELL_GCM_TEXTURE_DEPTH16:
+		case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
+			//Dont bother letting this propagate
+			return{ VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
+		default:
+			break;
+		}
+
+		VkComponentMapping mapping = {};
+		switch (flags)
+		{
+		case rsx::component_order::default_:
+		{
+			mapping = vk::apply_swizzle_remap(vk::get_component_mapping(gcm_format), remap_vector);
+			break;
+		}
+		case rsx::component_order::native:
+		{
+			mapping = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
+			break;
+		}
+		case rsx::component_order::swapped_native:
+		{
+			mapping = { VK_COMPONENT_SWIZZLE_A, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B };
+			break;
+		}
+		default:
+			break;
+		}
+
+		return mapping;
+	}
+
+	vk::image* texture_cache::get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const
+	{
+		if (sections_to_transfer.size() == 1) [[likely]]
+		{
+			return sections_to_transfer.front().src;
+		}
+
+		vk::image* result = nullptr;
+		for (const auto& section : sections_to_transfer)
+		{
+			if (!section.src)
+				continue;
+
+			if (!result)
+			{
+				result = section.src;
+			}
+			else
+			{
+				if (section.src->native_component_map.a != result->native_component_map.a ||
+					section.src->native_component_map.r != result->native_component_map.r ||
+					section.src->native_component_map.g != result->native_component_map.g ||
+					section.src->native_component_map.b != result->native_component_map.b)
+				{
+					// TODO
+					// This requires a far more complex setup as its not always possible to mix and match without compute assistance
+					return nullptr;
+				}
+			}
+		}
+
+		return result;
+	}
+
+	std::unique_ptr<vk::viewable_image> texture_cache::find_temporary_image(VkFormat format, u16 w, u16 h, u16 d, u8 mipmaps)
+	{
+		//const auto current_frame = vk::get_current_frame_id();
+		for (auto& e : m_temporary_storage)
+		{
+			if (e.can_reuse && e.matches(format, w, h, d, mipmaps, 0))
+			{
+				m_temporary_memory_size -= e.block_size;
+				e.block_size = 0;
+				return std::move(e.combined_image);
+			}
+		}
+
+		return {};
+	}
+
+	std::unique_ptr<vk::viewable_image> texture_cache::find_temporary_cubemap(VkFormat format, u16 size)
+	{
+		//const auto current_frame = vk::get_current_frame_id();
+		for (auto& e : m_temporary_storage)
+		{
+			if (e.can_reuse && e.matches(format, size, size, 1, 1, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT))
+			{
+				m_temporary_memory_size -= e.block_size;
+				e.block_size = 0;
+				return std::move(e.combined_image);
+			}
+		}
+
+		return {};
+	}
+
+	vk::image_view* texture_cache::create_temporary_subresource_view_impl(vk::command_buffer& cmd, vk::image* source, VkImageType image_type, VkImageViewType view_type,
+		u32 gcm_format, u16 x, u16 y, u16 w, u16 h, u16 d, u8 mips, const rsx::texture_channel_remap_t& remap_vector, bool copy)
+	{
+		std::unique_ptr<vk::viewable_image> image;
+
+		VkImageCreateFlags image_flags = (view_type == VK_IMAGE_VIEW_TYPE_CUBE) ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT : 0;
+		VkFormat dst_format = vk::get_compatible_sampler_format(m_formats_support, gcm_format);
+		u16 layers = 1;
+
+		if (!image_flags) [[likely]]
+		{
+			image = find_temporary_image(dst_format, w, h, 1, mips);
+		}
+		else
+		{
+			image = find_temporary_cubemap(dst_format, w);
+			layers = 6;
+		}
+
+		if (!image)
+		{
+			image = std::make_unique<vk::viewable_image>(*vk::get_current_renderer(), m_memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+				image_type,
+				dst_format,
+				w, h, d, mips, layers, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
+				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, image_flags,
+				VMM_ALLOCATION_POOL_TEXTURE_CACHE, rsx::classify_format(gcm_format));
+		}
+
+		//This method is almost exclusively used to work on framebuffer resources
+		//Keep the original swizzle layout unless there is data format conversion
+		VkComponentMapping view_swizzle;
+		if (!source || dst_format != source->info.format)
+		{
+			// This is a data cast operation
+			// Use native mapping for the new type
+			// TODO: Also simulate the readback+reupload step (very tricky)
+			const auto remap = get_component_mapping(gcm_format);
+			view_swizzle = { remap[1], remap[2], remap[3], remap[0] };
+		}
+		else
+		{
+			view_swizzle = source->native_component_map;
+		}
+
+		image->set_native_component_layout(view_swizzle);
+		auto view = image->get_view(rsx::get_remap_encoding(remap_vector), remap_vector);
+
+		if (copy)
+		{
+			std::vector<copy_region_descriptor> region =
+			{ {
+				source,
+				rsx::surface_transform::coordinate_transform,
+				0,
+				x, y, 0, 0, 0,
+				w, h, w, h
+			} };
+
+			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+			copy_transfer_regions_impl(cmd, image.get(), region);
+			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		}
+
+		const u32 resource_memory = w * h * 4; //Rough approximate
+		m_temporary_storage.emplace_back(image);
+		m_temporary_storage.back().block_size = resource_memory;
+		m_temporary_memory_size += resource_memory;
+
+		return view;
+	}
+
+	vk::image_view* texture_cache::create_temporary_subresource_view(vk::command_buffer& cmd, vk::image* source, u32 gcm_format,
+		u16 x, u16 y, u16 w, u16 h, const rsx::texture_channel_remap_t& remap_vector)
+	{
+		return create_temporary_subresource_view_impl(cmd, source, source->info.imageType, VK_IMAGE_VIEW_TYPE_2D,
+			gcm_format, x, y, w, h, 1, 1, remap_vector, true);
+	}
+
+	vk::image_view* texture_cache::create_temporary_subresource_view(vk::command_buffer& cmd, vk::image** source, u32 gcm_format,
+		u16 x, u16 y, u16 w, u16 h, const rsx::texture_channel_remap_t& remap_vector)
+	{
+		return create_temporary_subresource_view(cmd, *source, gcm_format, x, y, w, h, remap_vector);
+	}
+
+	vk::image_view* texture_cache::generate_cubemap_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 size,
+		const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
+	{
+		auto _template = get_template_from_collection_impl(sections_to_copy);
+		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
+			VK_IMAGE_VIEW_TYPE_CUBE, gcm_format, 0, 0, size, size, 1, 1, remap_vector, false);
+
+		const auto image = result->image();
+		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
+		VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 6 };
+		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
+
+		if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
+		{
+			VkClearColorValue clear = {};
+			vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
+		}
+		else
+		{
+			VkClearDepthStencilValue clear = { 1.f, 0 };
+			vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
+		}
+
+		copy_transfer_regions_impl(cmd, image, sections_to_copy);
+
+		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
+		return result;
+	}
+
+	vk::image_view* texture_cache::generate_3d_from_2d_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height, u16 depth,
+		const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
+	{
+		auto _template = get_template_from_collection_impl(sections_to_copy);
+		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_3D,
+			VK_IMAGE_VIEW_TYPE_3D, gcm_format, 0, 0, width, height, depth, 1, remap_vector, false);
+
+		const auto image = result->image();
+		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
+		VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 1 };
+		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
+
+		if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
+		{
+			VkClearColorValue clear = {};
+			vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
+		}
+		else
+		{
+			VkClearDepthStencilValue clear = { 1.f, 0 };
+			vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
+		}
+
+		copy_transfer_regions_impl(cmd, image, sections_to_copy);
+
+		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
+		return result;
+	}
+
+	vk::image_view* texture_cache::generate_atlas_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
+		const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
+	{
+		auto _template = get_template_from_collection_impl(sections_to_copy);
+		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
+			VK_IMAGE_VIEW_TYPE_2D, gcm_format, 0, 0, width, height, 1, 1, remap_vector, false);
+
+		const auto image = result->image();
+		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
+		VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 1 };
+		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
+
+		if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
+		{
+			VkClearColorValue clear = {};
+			vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
+		}
+		else
+		{
+			VkClearDepthStencilValue clear = { 1.f, 0 };
+			vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
+		}
+
+		copy_transfer_regions_impl(cmd, image, sections_to_copy);
+
+		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
+		return result;
+	}
+
+	vk::image_view* texture_cache::generate_2d_mipmaps_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
+		const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
+	{
+		const auto mipmaps = ::narrow<u8>(sections_to_copy.size());
+		auto _template = get_template_from_collection_impl(sections_to_copy);
+		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
+			VK_IMAGE_VIEW_TYPE_2D, gcm_format, 0, 0, width, height, 1, mipmaps, remap_vector, false);
+
+		const auto image = result->image();
+		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
+		VkImageSubresourceRange dst_range = { dst_aspect, 0, mipmaps, 0, 1 };
+		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
+
+		if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
+		{
+			VkClearColorValue clear = {};
+			vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
+		}
+		else
+		{
+			VkClearDepthStencilValue clear = { 1.f, 0 };
+			vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
+		}
+
+		copy_transfer_regions_impl(cmd, image, sections_to_copy);
+
+		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
+		return result;
+	}
+
+	void texture_cache::release_temporary_subresource(vk::image_view* view)
+	{
+		auto handle = dynamic_cast<vk::viewable_image*>(view->image());
+		for (auto& e : m_temporary_storage)
+		{
+			if (e.combined_image.get() == handle)
+			{
+				e.can_reuse = true;
+				return;
+			}
+		}
+	}
+
+	void texture_cache::update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, vk::image* src, u16 width, u16 height)
+	{
+		std::vector<copy_region_descriptor> region =
+		{ {
+			src,
+			rsx::surface_transform::identity,
+			0,
+			0, 0, 0, 0, 0,
+			width, height, width, height
+		} };
+
+		auto dst = dst_view->image();
+		dst->push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+		copy_transfer_regions_impl(cmd, dst, region);
+		dst->pop_layout(cmd);
+	}
+
+	cached_texture_section* texture_cache::create_new_texture(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch,
+		u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t flags)
+	{
+		const auto section_depth = depth;
+
+		// Define desirable attributes based on type
+		VkImageType image_type;
+		VkImageUsageFlags usage_flags = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+		u8 layer = 0;
+
+		switch (type)
+		{
+		case rsx::texture_dimension_extended::texture_dimension_1d:
+			image_type = VK_IMAGE_TYPE_1D;
+			height = 1;
+			depth = 1;
+			layer = 1;
+			break;
+		case rsx::texture_dimension_extended::texture_dimension_2d:
+			image_type = VK_IMAGE_TYPE_2D;
+			depth = 1;
+			layer = 1;
+			break;
+		case rsx::texture_dimension_extended::texture_dimension_cubemap:
+			image_type = VK_IMAGE_TYPE_2D;
+			depth = 1;
+			layer = 6;
+			break;
+		case rsx::texture_dimension_extended::texture_dimension_3d:
+			image_type = VK_IMAGE_TYPE_3D;
+			layer = 1;
+			break;
+		default:
+			fmt::throw_exception("Unreachable");
+		}
+
+		// Check what actually exists at that address
+		const rsx::image_section_attributes_t search_desc = { .gcm_format = gcm_format, .width = width, .height = height, .depth = section_depth, .mipmaps = mipmaps };
+		const bool allow_dirty = (context != rsx::texture_upload_context::framebuffer_storage);
+		cached_texture_section& region = *find_cached_texture(rsx_range, search_desc, true, true, allow_dirty);
+		ensure(!region.is_locked());
+
+		vk::viewable_image* image = nullptr;
+		if (region.exists())
+		{
+			image = dynamic_cast<vk::viewable_image*>(region.get_raw_texture());
+			if (!image || region.get_image_type() != type || image->depth() != depth) // TODO
+			{
+				// Incompatible view/type
+				region.destroy();
+				image = nullptr;
+			}
+			else
+			{
+				ensure(region.is_managed());
+
+				// Reuse
+				region.set_rsx_pitch(pitch);
+
+				if (flags & texture_create_flags::initialize_image_contents)
+				{
+					// Wipe memory
+					image->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+					VkImageSubresourceRange range{ image->aspect(), 0, image->mipmaps(), 0, image->layers() };
+					if (image->aspect() & VK_IMAGE_ASPECT_COLOR_BIT)
+					{
+						VkClearColorValue color = { {0.f, 0.f, 0.f, 1.f} };
+						vkCmdClearColorImage(cmd, image->value, image->current_layout, &color, 1, &range);
+					}
+					else
+					{
+						VkClearDepthStencilValue clear{ 1.f, 255 };
+						vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &range);
+					}
+				}
+			}
+		}
+
+		if (!image)
+		{
+			const bool is_cubemap = type == rsx::texture_dimension_extended::texture_dimension_cubemap;
+			const VkFormat vk_format = get_compatible_sampler_format(m_formats_support, gcm_format);
+
+			image = new vk::viewable_image(*m_device,
+				m_memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+				image_type, vk_format,
+				width, height, depth, mipmaps, layer, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
+				VK_IMAGE_TILING_OPTIMAL, usage_flags, is_cubemap ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT : 0,
+				VMM_ALLOCATION_POOL_TEXTURE_CACHE, rsx::classify_format(gcm_format));
+
+			// New section, we must prepare it
+			region.reset(rsx_range);
+			region.set_gcm_format(gcm_format);
+			region.set_image_type(type);
+			region.create(width, height, section_depth, mipmaps, image, pitch, true, gcm_format);
+		}
+
+		region.set_view_flags(swizzle_flags);
+		region.set_context(context);
+		region.set_swizzled(swizzled);
+		region.set_dirty(false);
+
+		image->native_component_map = apply_component_mapping_flags(gcm_format, swizzle_flags, rsx::default_remap_vector);
+
+		// Its not necessary to lock blit dst textures as they are just reused as necessary
+		switch (context)
+		{
+		case rsx::texture_upload_context::shader_read:
+		case rsx::texture_upload_context::blit_engine_src:
+			region.protect(utils::protection::ro);
+			read_only_range = region.get_min_max(read_only_range, rsx::section_bounds::locked_range);
+			break;
+		case rsx::texture_upload_context::blit_engine_dst:
+			region.set_unpack_swap_bytes(true);
+			no_access_range = region.get_min_max(no_access_range, rsx::section_bounds::locked_range);
+			break;
+		case rsx::texture_upload_context::dma:
+		case rsx::texture_upload_context::framebuffer_storage:
+			// Should not initialized with this method
+		default:
+			fmt::throw_exception("Unexpected upload context 0x%x", u32(context));
+		}
+
+		update_cache_tag();
+		return &region;
+	}
+
+	cached_texture_section* texture_cache::create_nul_section(vk::command_buffer& /*cmd*/, const utils::address_range& rsx_range, bool memory_load)
+	{
+		auto& region = *find_cached_texture(rsx_range, { .gcm_format = RSX_GCM_FORMAT_IGNORED }, true, false, false);
+		ensure(!region.is_locked());
+
+		// Prepare section
+		region.reset(rsx_range);
+		region.set_context(rsx::texture_upload_context::dma);
+		region.set_dirty(false);
+		region.set_unpack_swap_bytes(true);
+
+		if (memory_load)
+		{
+			vk::map_dma(rsx_range.start, rsx_range.length());
+			vk::load_dma(rsx_range.start, rsx_range.length());
+		}
+
+		no_access_range = region.get_min_max(no_access_range, rsx::section_bounds::locked_range);
+		update_cache_tag();
+		return &region;
+	}
+
+	cached_texture_section* texture_cache::upload_image_from_cpu(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format,
+		rsx::texture_upload_context context, const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool swizzled)
+	{
+		if (context != rsx::texture_upload_context::shader_read)
+		{
+			if (vk::is_renderpass_open(cmd))
+			{
+				vk::end_renderpass(cmd);
+			}
+		}
+		auto section = create_new_texture(cmd, rsx_range, width, height, depth, mipmaps, pitch, gcm_format, context, type, swizzled,
+			rsx::component_order::default_, 0);
+
+		auto image = section->get_raw_texture();
+		image->set_debug_name(fmt::format("Raw Texture @0x%x", rsx_range.start));
+
+		vk::enter_uninterruptible();
+
+		bool input_swizzled = swizzled;
+		if (context == rsx::texture_upload_context::blit_engine_src)
+		{
+			// Swizzling is ignored for blit engine copy and emulated using remapping
+			input_swizzled = false;
+		}
+
+		rsx::flags32_t upload_command_flags = initialize_image_layout |
+			(rsx::get_current_renderer()->get_backend_config().supports_asynchronous_compute ? upload_contents_async : upload_contents_inline);
+
+		vk::upload_image(cmd, image, subresource_layout, gcm_format, input_swizzled, mipmaps, image->aspect(),
+			*m_texture_upload_heap, upload_heap_align_default, upload_command_flags);
+
+		vk::leave_uninterruptible();
+
+		if (context != rsx::texture_upload_context::shader_read)
+		{
+			// Insert appropriate barrier depending on use. Shader read resources should be lazy-initialized before consuming.
+			// TODO: All texture resources should be initialized on use, this is wasteful
+
+			VkImageLayout preferred_layout;
+			switch (context)
+			{
+			default:
+				preferred_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+				break;
+			case rsx::texture_upload_context::blit_engine_dst:
+				preferred_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+				break;
+			case rsx::texture_upload_context::blit_engine_src:
+				preferred_layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+				break;
+			}
+
+			if (preferred_layout != image->current_layout)
+			{
+				image->change_layout(cmd, preferred_layout);
+			}
+			else
+			{
+				// Insert ordering barrier
+				ensure(preferred_layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+				insert_image_memory_barrier(cmd, image->value, image->current_layout, preferred_layout,
+					VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+					VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_WRITE_BIT,
+					{ image->aspect(), 0, image->mipmaps(), 0, image->layers() });
+			}
+		}
+
+		section->last_write_tag = rsx::get_shared_tag();
+		return section;
+	}
+
+	void texture_cache::set_component_order(cached_texture_section& section, u32 gcm_format, rsx::component_order expected_flags)
+	{
+		if (expected_flags == section.get_view_flags())
+			return;
+
+		const VkComponentMapping mapping = apply_component_mapping_flags(gcm_format, expected_flags, rsx::default_remap_vector);
+		auto image = static_cast<vk::viewable_image*>(section.get_raw_texture());
+
+		ensure(image);
+		image->set_native_component_layout(mapping);
+
+		section.set_view_flags(expected_flags);
+	}
+
+	void texture_cache::insert_texture_barrier(vk::command_buffer& cmd, vk::image* tex, bool strong_ordering)
+	{
+		if (!strong_ordering && tex->current_layout == VK_IMAGE_LAYOUT_GENERAL)
+		{
+			// A previous barrier already exists, do nothing
+			return;
+		}
+
+		vk::as_rtt(tex)->texture_barrier(cmd);
+	}
+
+	bool texture_cache::render_target_format_is_compatible(vk::image* tex, u32 gcm_format)
+	{
+		auto vk_format = tex->info.format;
+		switch (gcm_format)
+		{
+		default:
+			//TODO
+			warn_once("Format incompatibility detected, reporting failure to force data copy (VK_FORMAT=0x%X, GCM_FORMAT=0x%X)", static_cast<u32>(vk_format), gcm_format);
+			return false;
+		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
+			return (vk_format == VK_FORMAT_R16G16B16A16_SFLOAT);
+		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
+			return (vk_format == VK_FORMAT_R32G32B32A32_SFLOAT);
+		case CELL_GCM_TEXTURE_X32_FLOAT:
+			return (vk_format == VK_FORMAT_R32_SFLOAT);
+		case CELL_GCM_TEXTURE_R5G6B5:
+			return (vk_format == VK_FORMAT_R5G6B5_UNORM_PACK16);
+		case CELL_GCM_TEXTURE_A8R8G8B8:
+		case CELL_GCM_TEXTURE_D8R8G8B8:
+			return (vk_format == VK_FORMAT_B8G8R8A8_UNORM || vk_format == VK_FORMAT_D24_UNORM_S8_UINT || vk_format == VK_FORMAT_D32_SFLOAT_S8_UINT);
+		case CELL_GCM_TEXTURE_B8:
+			return (vk_format == VK_FORMAT_R8_UNORM);
+		case CELL_GCM_TEXTURE_G8B8:
+			return (vk_format == VK_FORMAT_R8G8_UNORM);
+		case CELL_GCM_TEXTURE_DEPTH24_D8:
+		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
+			return (vk_format == VK_FORMAT_D24_UNORM_S8_UINT || vk_format == VK_FORMAT_D32_SFLOAT_S8_UINT);
+		case CELL_GCM_TEXTURE_X16:
+		case CELL_GCM_TEXTURE_DEPTH16:
+		case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
+			return (vk_format == VK_FORMAT_D16_UNORM || vk_format == VK_FORMAT_D32_SFLOAT);
+		}
+	}
+
+	void texture_cache::prepare_for_dma_transfers(vk::command_buffer& cmd)
+	{
+		if (!cmd.is_recording())
+		{
+			cmd.begin();
+		}
+	}
+
+	void texture_cache::cleanup_after_dma_transfers(vk::command_buffer& cmd)
+	{
+		bool occlusion_query_active = !!(cmd.flags & vk::command_buffer::cb_has_open_query);
+		if (occlusion_query_active)
+		{
+			// We really stepped in it
+			vk::do_query_cleanup(cmd);
+		}
+
+		// End recording
+		cmd.end();
+
+		if (cmd.access_hint != vk::command_buffer::access_type_hint::all)
+		{
+			// Flush any pending async jobs in case of blockers
+			// TODO: Context-level manager should handle this logic
+			g_fxo->get<async_scheduler_thread>().flush(VK_TRUE);
+
+			// Primary access command queue, must restart it after
+			vk::fence submit_fence(*m_device);
+			cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, &submit_fence, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_TRUE);
+
+			vk::wait_for_fence(&submit_fence, GENERAL_WAIT_TIMEOUT);
+
+			CHECK_RESULT(vkResetCommandBuffer(cmd, 0));
+			cmd.begin();
+		}
+		else
+		{
+			// Auxilliary command queue with auto-restart capability
+			cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_TRUE);
+		}
+
+		ensure(cmd.flags == 0);
+
+		if (occlusion_query_active)
+		{
+			ensure(cmd.is_recording());
+			cmd.flags |= vk::command_buffer::cb_load_occluson_task;
+		}
+	}
+
+	void texture_cache::initialize(vk::render_device& device, VkQueue submit_queue, vk::data_heap& upload_heap)
+	{
+		m_device = &device;
+		m_memory_types = device.get_memory_mapping();
+		m_formats_support = device.get_formats_support();
+		m_submit_queue = submit_queue;
+		m_texture_upload_heap = &upload_heap;
+	}
+
+	void texture_cache::destroy()
+	{
+		clear();
+	}
+
+	bool texture_cache::is_depth_texture(u32 rsx_address, u32 rsx_size)
+	{
+		reader_lock lock(m_cache_mutex);
+
+		auto& block = m_storage.block_for(rsx_address);
+
+		if (block.get_locked_count() == 0)
+			return false;
+
+		for (auto& tex : block)
+		{
+			if (tex.is_dirty())
+				continue;
+
+			if (!tex.overlaps(rsx_address, rsx::section_bounds::full_range))
+				continue;
+
+			if ((rsx_address + rsx_size - tex.get_section_base()) <= tex.get_section_size())
+			{
+				switch (tex.get_format())
+				{
+				case VK_FORMAT_D16_UNORM:
+				case VK_FORMAT_D32_SFLOAT:
+				case VK_FORMAT_D32_SFLOAT_S8_UINT:
+				case VK_FORMAT_D24_UNORM_S8_UINT:
+					return true;
+				default:
+					return false;
+				}
+			}
+		}
+
+		//Unreachable; silence compiler warning anyway
+		return false;
+	}
+
+	void texture_cache::on_frame_end()
+	{
+		trim_sections();
+
+		if (m_storage.m_unreleased_texture_objects >= m_max_zombie_objects ||
+			m_temporary_memory_size > 0x4000000) //If already holding over 64M in discardable memory, be frugal with memory resources
+		{
+			purge_unreleased_sections();
+		}
+
+		const u64 last_complete_frame = vk::get_last_completed_frame_id();
+		m_temporary_storage.remove_if([&](const temporary_storage& o)
+		{
+			if (!o.block_size || o.test(last_complete_frame))
+			{
+				m_temporary_memory_size -= o.block_size;
+				return true;
+			}
+			return false;
+		});
+
+		m_temporary_subresource_cache.clear();
+		reset_frame_statistics();
+
+		baseclass::on_frame_end();
+	}
+
+	vk::image* texture_cache::upload_image_simple(vk::command_buffer& cmd, VkFormat format, u32 address, u32 width, u32 height, u32 pitch)
+	{
+		bool linear_format_supported = false;
+
+		switch (format)
+		{
+		case VK_FORMAT_B8G8R8A8_UNORM:
+			linear_format_supported = m_formats_support.bgra8_linear;
+			break;
+		case VK_FORMAT_R8G8B8A8_UNORM:
+			linear_format_supported = m_formats_support.argb8_linear;
+			break;
+		default:
+			rsx_log.error("Unsupported VkFormat 0x%x", static_cast<u32>(format));
+			return nullptr;
+		}
+
+		if (!linear_format_supported)
+		{
+			return nullptr;
+		}
+
+		// Uploads a linear memory range as a BGRA8 texture
+		auto image = std::make_unique<vk::viewable_image>(*m_device, m_memory_types.host_visible_coherent,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+			VK_IMAGE_TYPE_2D,
+			format,
+			width, height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_PREINITIALIZED,
+			VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0,
+			VMM_ALLOCATION_POOL_UNDEFINED);
+
+		VkImageSubresource subresource{};
+		subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+
+		VkSubresourceLayout layout{};
+		vkGetImageSubresourceLayout(*m_device, image->value, &subresource, &layout);
+
+		void* mem = image->memory->map(0, layout.rowPitch * height);
+
+		auto src = vm::_ptr<const char>(address);
+		auto dst = static_cast<char*>(mem);
+
+		//TODO: SSE optimization
+		for (u32 row = 0; row < height; ++row)
+		{
+			auto casted_src = reinterpret_cast<const be_t<u32>*>(src);
+			auto casted_dst = reinterpret_cast<u32*>(dst);
+
+			for (u32 col = 0; col < width; ++col)
+				casted_dst[col] = casted_src[col];
+
+			src += pitch;
+			dst += layout.rowPitch;
+		}
+
+		image->memory->unmap();
+
+		vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+
+		auto result = image.get();
+		const u32 resource_memory = width * height * 4; //Rough approximate
+		m_temporary_storage.emplace_back(image);
+		m_temporary_storage.back().block_size = resource_memory;
+		m_temporary_memory_size += resource_memory;
+
+		return result;
+	}
+
+	bool texture_cache::blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, vk::surface_cache& m_rtts, vk::command_buffer& cmd)
+	{
+		blitter helper;
+		auto reply = upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper);
+
+		if (reply.succeeded)
+		{
+			if (reply.real_dst_size)
+			{
+				flush_if_cache_miss_likely(cmd, reply.to_address_range());
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	u32 texture_cache::get_unreleased_textures_count() const
+	{
+		return baseclass::get_unreleased_textures_count() + ::size32(m_temporary_storage);
+	}
+
+	u32 texture_cache::get_temporary_memory_in_use() const
+	{
+		return m_temporary_memory_size;
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -1258,7 +1258,7 @@ namespace vk
 
 		if (total_device_memory >= 1024)
 		{
-			quota = std::min(3072ull, (total_device_memory * 40) / 100);
+			quota = std::min<u64>(3072, (total_device_memory * 40) / 100);
 		}
 		else if (total_device_memory >= 768)
 		{
@@ -1266,7 +1266,7 @@ namespace vk
 		}
 		else
 		{
-			quota = std::min(128ull, total_device_memory / 2);
+			quota = std::min<u64>(128, total_device_memory / 2);
 		}
 
 		quota *= 0x100000;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -383,7 +383,7 @@ namespace vk
 		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
 		case CELL_GCM_TEXTURE_DEPTH16:
 		case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-			//Dont bother letting this propagate
+			// Dont bother letting this propagate
 			return{ VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
 		default:
 			break;
@@ -509,8 +509,8 @@ namespace vk
 				VMM_ALLOCATION_POOL_TEXTURE_CACHE, rsx::classify_format(gcm_format));
 		}
 
-		//This method is almost exclusively used to work on framebuffer resources
-		//Keep the original swizzle layout unless there is data format conversion
+		// This method is almost exclusively used to work on framebuffer resources
+		// Keep the original swizzle layout unless there is data format conversion
 		VkComponentMapping view_swizzle;
 		if (!source || dst_format != source->info.format)
 		{
@@ -831,7 +831,7 @@ namespace vk
 			break;
 		case rsx::texture_upload_context::dma:
 		case rsx::texture_upload_context::framebuffer_storage:
-			// Should not initialized with this method
+			// Should not be initialized with this method
 		default:
 			fmt::throw_exception("Unexpected upload context 0x%x", u32(context));
 		}
@@ -1197,7 +1197,7 @@ namespace vk
 		auto src = vm::_ptr<const char>(address);
 		auto dst = static_cast<char*>(mem);
 
-		//TODO: SSE optimization
+		// TODO: SSE optimization
 		for (u32 row = 0; row < height; ++row)
 		{
 			auto casted_src = reinterpret_cast<const be_t<u32>*>(src);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -340,11 +340,11 @@ namespace vk
 							dst_y = src_h;
 						}
 
-							vk::copy_scaled_image(cmd, tmp, _dst,
-								areai{ 0, 0, src_w, static_cast<s32>(src_h) },
-								coordi{ { dst_x, dst_y }, { section.dst_w, section.dst_h } },
-								1, tmp->info.format == _dst->info.format,
-								VK_FILTER_NEAREST);
+						vk::copy_scaled_image(cmd, tmp, _dst,
+							areai{ 0, 0, src_w, static_cast<s32>(src_h) },
+							coordi{ { dst_x, dst_y }, { section.dst_w, section.dst_h } },
+							1, tmp->info.format == _dst->info.format,
+							VK_FILTER_NEAREST);
 					}
 					else
 					{

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -1260,7 +1260,7 @@ namespace vk
 			return result;
 		}
 
-		bool blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, rsx::vk_render_targets& m_rtts, vk::command_buffer& cmd)
+		bool blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, vk::surface_cache& m_rtts, vk::command_buffer& cmd)
 		{
 			blitter helper;
 			auto reply = upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -40,12 +40,12 @@ namespace vk
 		//DMA relevant data
 		std::unique_ptr<vk::event> dma_fence;
 		vk::render_device* m_device = nullptr;
-		vk::viewable_image *vram_texture = nullptr;
+		vk::viewable_image* vram_texture = nullptr;
 
 	public:
 		using baseclass::cached_texture_section;
 
-		void create(u16 w, u16 h, u16 depth, u16 mipmaps, vk::image *image, u32 rsx_pitch, bool managed, u32 gcm_format, bool pack_swap_bytes = false)
+		void create(u16 w, u16 h, u16 depth, u16 mipmaps, vk::image* image, u32 rsx_pitch, bool managed, u32 gcm_format, bool pack_swap_bytes = false)
 		{
 			auto new_texture = static_cast<vk::viewable_image*>(image);
 			ensure(!exists() || !is_managed() || vram_texture == new_texture);
@@ -189,7 +189,7 @@ namespace vk
 				m_device = &cmd.get_command_pool().get_owner();
 			}
 
-			vk::image *locked_resource = vram_texture;
+			vk::image* locked_resource = vram_texture;
 			u32 transfer_width = width;
 			u32 transfer_height = height;
 			u32 transfer_x = 0, transfer_y = 0;
@@ -265,7 +265,7 @@ namespace vk
 			vk::wait_for_event(dma_fence.get(), GENERAL_WAIT_TIMEOUT);
 
 			// Calculate smallest range to flush - for framebuffers, the raster region is enough
-			const auto range = (context == rsx::texture_upload_context::framebuffer_storage)? get_section_range() : get_confirmed_range();
+			const auto range = (context == rsx::texture_upload_context::framebuffer_storage) ? get_section_range() : get_confirmed_range();
 			vk::flush_dma(range.start, range.length());
 
 			if (is_swizzled())
@@ -301,8 +301,10 @@ namespace vk
 			}
 		}
 
-		void *map_synchronized(u32, u32)
-		{ return nullptr; }
+		void* map_synchronized(u32, u32)
+		{
+			return nullptr;
+		}
 
 		void finish_flush()
 		{}
@@ -413,13 +415,7 @@ namespace vk
 			initialize_image_contents = 1,
 		};
 
-		void on_section_destroyed(cached_texture_section& tex) override
-		{
-			if (tex.is_managed())
-			{
-				vk::get_resource_manager()->dispose(tex.get_texture());
-			}
-		}
+		void on_section_destroyed(cached_texture_section& tex) override;
 
 	private:
 
@@ -434,858 +430,79 @@ namespace vk
 		std::list<temporary_storage> m_temporary_storage;
 		atomic_t<u32> m_temporary_memory_size = { 0 };
 
-		void clear()
-		{
-			baseclass::clear();
+		void clear();
 
-			m_temporary_storage.clear();
-			m_temporary_memory_size = 0;
-		}
-
-		VkComponentMapping apply_component_mapping_flags(u32 gcm_format, rsx::component_order flags, const rsx::texture_channel_remap_t& remap_vector) const
-		{
-			switch (gcm_format)
-			{
-			case CELL_GCM_TEXTURE_DEPTH24_D8:
-			case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
-			case CELL_GCM_TEXTURE_DEPTH16:
-			case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-				//Dont bother letting this propagate
-				return{ VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
-			default:
-				break;
-			}
-
-			VkComponentMapping mapping = {};
-			switch (flags)
-			{
-			case rsx::component_order::default_:
-			{
-				mapping = vk::apply_swizzle_remap(vk::get_component_mapping(gcm_format), remap_vector);
-				break;
-			}
-			case rsx::component_order::native:
-			{
-				mapping = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
-				break;
-			}
-			case rsx::component_order::swapped_native:
-			{
-				mapping = { VK_COMPONENT_SWIZZLE_A, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B };
-				break;
-			}
-			default:
-				break;
-			}
-
-			return mapping;
-		}
+		VkComponentMapping apply_component_mapping_flags(u32 gcm_format, rsx::component_order flags, const rsx::texture_channel_remap_t& remap_vector) const;
 
 		void copy_transfer_regions_impl(vk::command_buffer& cmd, vk::image* dst, const std::vector<copy_region_descriptor>& sections_to_transfer) const;
 
-		vk::image* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const
-		{
-			if (sections_to_transfer.size() == 1) [[likely]]
-			{
-				return sections_to_transfer.front().src;
-			}
+		vk::image* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const;
 
-			vk::image* result = nullptr;
-			for (const auto &section : sections_to_transfer)
-			{
-				if (!section.src)
-					continue;
+		std::unique_ptr<vk::viewable_image> find_temporary_image(VkFormat format, u16 w, u16 h, u16 d, u8 mipmaps);
 
-				if (!result)
-				{
-					result = section.src;
-				}
-				else
-				{
-					if (section.src->native_component_map.a != result->native_component_map.a ||
-						section.src->native_component_map.r != result->native_component_map.r ||
-						section.src->native_component_map.g != result->native_component_map.g ||
-						section.src->native_component_map.b != result->native_component_map.b)
-					{
-						// TODO
-						// This requires a far more complex setup as its not always possible to mix and match without compute assistance
-						return nullptr;
-					}
-				}
-			}
-
-			return result;
-		}
-
-		std::unique_ptr<vk::viewable_image> find_temporary_image(VkFormat format, u16 w, u16 h, u16 d, u8 mipmaps)
-		{
-			//const auto current_frame = vk::get_current_frame_id();
-			for (auto &e : m_temporary_storage)
-			{
-				if (e.can_reuse && e.matches(format, w, h, d, mipmaps, 0))
-				{
-					m_temporary_memory_size -= e.block_size;
-					e.block_size = 0;
-					return std::move(e.combined_image);
-				}
-			}
-
-			return {};
-		}
-
-		std::unique_ptr<vk::viewable_image> find_temporary_cubemap(VkFormat format, u16 size)
-		{
-			//const auto current_frame = vk::get_current_frame_id();
-			for (auto &e : m_temporary_storage)
-			{
-				if (e.can_reuse && e.matches(format, size, size, 1, 1, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT))
-				{
-					m_temporary_memory_size -= e.block_size;
-					e.block_size = 0;
-					return std::move(e.combined_image);
-				}
-			}
-
-			return {};
-		}
+		std::unique_ptr<vk::viewable_image> find_temporary_cubemap(VkFormat format, u16 size);
 
 	protected:
 		vk::image_view* create_temporary_subresource_view_impl(vk::command_buffer& cmd, vk::image* source, VkImageType image_type, VkImageViewType view_type,
-			u32 gcm_format, u16 x, u16 y, u16 w, u16 h, u16 d, u8 mips, const rsx::texture_channel_remap_t& remap_vector, bool copy)
-		{
-			std::unique_ptr<vk::viewable_image> image;
-
-			VkImageCreateFlags image_flags = (view_type == VK_IMAGE_VIEW_TYPE_CUBE) ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT : 0;
-			VkFormat dst_format = vk::get_compatible_sampler_format(m_formats_support, gcm_format);
-			u16 layers = 1;
-
-			if (!image_flags) [[likely]]
-			{
-				image = find_temporary_image(dst_format, w, h, 1, mips);
-			}
-			else
-			{
-				image = find_temporary_cubemap(dst_format, w);
-				layers = 6;
-			}
-
-			if (!image)
-			{
-				image = std::make_unique<vk::viewable_image>(*vk::get_current_renderer(), m_memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-					image_type,
-					dst_format,
-					w, h, d, mips, layers, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-					VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, image_flags,
-					VMM_ALLOCATION_POOL_TEXTURE_CACHE, rsx::classify_format(gcm_format));
-			}
-
-			//This method is almost exclusively used to work on framebuffer resources
-			//Keep the original swizzle layout unless there is data format conversion
-			VkComponentMapping view_swizzle;
-			if (!source || dst_format != source->info.format)
-			{
-				// This is a data cast operation
-				// Use native mapping for the new type
-				// TODO: Also simulate the readback+reupload step (very tricky)
-				const auto remap = get_component_mapping(gcm_format);
-				view_swizzle = { remap[1], remap[2], remap[3], remap[0] };
-			}
-			else
-			{
-				view_swizzle = source->native_component_map;
-			}
-
-			image->set_native_component_layout(view_swizzle);
-			auto view = image->get_view(rsx::get_remap_encoding(remap_vector), remap_vector);
-
-			if (copy)
-			{
-				std::vector<copy_region_descriptor> region =
-				{{
-					source,
-					rsx::surface_transform::coordinate_transform,
-					0,
-					x, y, 0, 0, 0,
-					w, h, w, h
-				}};
-
-				vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-				copy_transfer_regions_impl(cmd, image.get(), region);
-				vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-			}
-
-			const u32 resource_memory = w * h * 4; //Rough approximate
-			m_temporary_storage.emplace_back(image);
-			m_temporary_storage.back().block_size = resource_memory;
-			m_temporary_memory_size += resource_memory;
-
-			return view;
-		}
+			u32 gcm_format, u16 x, u16 y, u16 w, u16 h, u16 d, u8 mips, const rsx::texture_channel_remap_t& remap_vector, bool copy);
 
 		vk::image_view* create_temporary_subresource_view(vk::command_buffer& cmd, vk::image* source, u32 gcm_format,
-				u16 x, u16 y, u16 w, u16 h, const rsx::texture_channel_remap_t& remap_vector) override
-		{
-			return create_temporary_subresource_view_impl(cmd, source, source->info.imageType, VK_IMAGE_VIEW_TYPE_2D,
-					gcm_format, x, y, w, h, 1, 1, remap_vector, true);
-		}
+			u16 x, u16 y, u16 w, u16 h, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* create_temporary_subresource_view(vk::command_buffer& cmd, vk::image** source, u32 gcm_format,
-				u16 x, u16 y, u16 w, u16 h, const rsx::texture_channel_remap_t& remap_vector) override
-		{
-			return create_temporary_subresource_view(cmd, *source, gcm_format, x, y, w, h, remap_vector);
-		}
+			u16 x, u16 y, u16 w, u16 h, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* generate_cubemap_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 size,
-				const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override
-		{
-			auto _template = get_template_from_collection_impl(sections_to_copy);
-			auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
-				VK_IMAGE_VIEW_TYPE_CUBE, gcm_format, 0, 0, size, size, 1, 1, remap_vector, false);
-
-			const auto image = result->image();
-			VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
-			VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 6 };
-			vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
-
-			if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
-			{
-				VkClearColorValue clear = {};
-				vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
-			}
-			else
-			{
-				VkClearDepthStencilValue clear = { 1.f, 0 };
-				vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
-			}
-
-			copy_transfer_regions_impl(cmd, image, sections_to_copy);
-
-			vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
-			return result;
-		}
+			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* generate_3d_from_2d_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height, u16 depth,
-			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override
-		{
-			auto _template = get_template_from_collection_impl(sections_to_copy);
-			auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_3D,
-				VK_IMAGE_VIEW_TYPE_3D, gcm_format, 0, 0, width, height, depth, 1, remap_vector, false);
-
-			const auto image = result->image();
-			VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
-			VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 1 };
-			vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
-
-			if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
-			{
-				VkClearColorValue clear = {};
-				vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
-			}
-			else
-			{
-				VkClearDepthStencilValue clear = { 1.f, 0 };
-				vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
-			}
-
-			copy_transfer_regions_impl(cmd, image, sections_to_copy);
-
-			vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
-			return result;
-		}
+			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* generate_atlas_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
-				const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override
-		{
-			auto _template = get_template_from_collection_impl(sections_to_copy);
-			auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
-					VK_IMAGE_VIEW_TYPE_2D, gcm_format, 0, 0, width, height, 1, 1, remap_vector, false);
-
-			const auto image = result->image();
-			VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
-			VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 1 };
-			vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
-
-			if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
-			{
-				VkClearColorValue clear = {};
-				vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
-			}
-			else
-			{
-				VkClearDepthStencilValue clear = { 1.f, 0 };
-				vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
-			}
-
-			copy_transfer_regions_impl(cmd, image, sections_to_copy);
-
-			vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
-			return result;
-		}
+			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* generate_2d_mipmaps_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
-			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override
-		{
-			const auto mipmaps = ::narrow<u8>(sections_to_copy.size());
-			auto _template = get_template_from_collection_impl(sections_to_copy);
-			auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
-				VK_IMAGE_VIEW_TYPE_2D, gcm_format, 0, 0, width, height, 1, mipmaps, remap_vector, false);
+			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
 
-			const auto image = result->image();
-			VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
-			VkImageSubresourceRange dst_range = { dst_aspect, 0, mipmaps, 0, 1 };
-			vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
+		void release_temporary_subresource(vk::image_view* view) override;
 
-			if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))
-			{
-				VkClearColorValue clear = {};
-				vkCmdClearColorImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
-			}
-			else
-			{
-				VkClearDepthStencilValue clear = { 1.f, 0 };
-				vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &dst_range);
-			}
+		void update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, vk::image* src, u16 width, u16 height) override;
 
-			copy_transfer_regions_impl(cmd, image, sections_to_copy);
+		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch,
+			u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t flags) override;
 
-			vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dst_range);
-			return result;
-		}
-
-		void release_temporary_subresource(vk::image_view* view) override
-		{
-			auto handle = dynamic_cast<vk::viewable_image*>(view->image());
-			for (auto& e : m_temporary_storage)
-			{
-				if (e.combined_image.get() == handle)
-				{
-					e.can_reuse = true;
-					return;
-				}
-			}
-		}
-
-		void update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, vk::image* src, u16 width, u16 height) override
-		{
-			std::vector<copy_region_descriptor> region =
-			{ {
-				src,
-				rsx::surface_transform::identity,
-				0,
-				0, 0, 0, 0, 0,
-				width, height, width, height
-			}};
-
-			auto dst = dst_view->image();
-			dst->push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-			copy_transfer_regions_impl(cmd, dst, region);
-			dst->pop_layout(cmd);
-		}
-
-		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch,
-			u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t flags) override
-		{
-			const auto section_depth = depth;
-
-			// Define desirable attributes based on type
-			VkImageType image_type;
-			VkImageUsageFlags usage_flags = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-			u8 layer = 0;
-
-			switch (type)
-			{
-			case rsx::texture_dimension_extended::texture_dimension_1d:
-				image_type = VK_IMAGE_TYPE_1D;
-				height = 1;
-				depth = 1;
-				layer = 1;
-				break;
-			case rsx::texture_dimension_extended::texture_dimension_2d:
-				image_type = VK_IMAGE_TYPE_2D;
-				depth = 1;
-				layer = 1;
-				break;
-			case rsx::texture_dimension_extended::texture_dimension_cubemap:
-				image_type = VK_IMAGE_TYPE_2D;
-				depth = 1;
-				layer = 6;
-				break;
-			case rsx::texture_dimension_extended::texture_dimension_3d:
-				image_type = VK_IMAGE_TYPE_3D;
-				layer = 1;
-				break;
-			default:
-				fmt::throw_exception("Unreachable");
-			}
-
-			// Check what actually exists at that address
-			const rsx::image_section_attributes_t search_desc = { .gcm_format = gcm_format, .width = width, .height = height, .depth = section_depth, .mipmaps = mipmaps };
-			const bool allow_dirty = (context != rsx::texture_upload_context::framebuffer_storage);
-			cached_texture_section& region = *find_cached_texture(rsx_range, search_desc, true, true, allow_dirty);
-			ensure(!region.is_locked());
-
-			vk::viewable_image* image = nullptr;
-			if (region.exists())
-			{
-				image = dynamic_cast<vk::viewable_image*>(region.get_raw_texture());
-				if (!image || region.get_image_type() != type || image->depth() != depth) // TODO
-				{
-					// Incompatible view/type
-					region.destroy();
-					image = nullptr;
-				}
-				else
-				{
-					ensure(region.is_managed());
-
-					// Reuse
-					region.set_rsx_pitch(pitch);
-
-					if (flags & texture_create_flags::initialize_image_contents)
-					{
-						// Wipe memory
-						image->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-
-						VkImageSubresourceRange range{ image->aspect(), 0, image->mipmaps(), 0, image->layers() };
-						if (image->aspect() & VK_IMAGE_ASPECT_COLOR_BIT)
-						{
-							VkClearColorValue color = { {0.f, 0.f, 0.f, 1.f} };
-							vkCmdClearColorImage(cmd, image->value, image->current_layout, &color, 1, &range);
-						}
-						else
-						{
-							VkClearDepthStencilValue clear{ 1.f, 255 };
-							vkCmdClearDepthStencilImage(cmd, image->value, image->current_layout, &clear, 1, &range);
-						}
-					}
-				}
-			}
-
-			if (!image)
-			{
-				const bool is_cubemap = type == rsx::texture_dimension_extended::texture_dimension_cubemap;
-				const VkFormat vk_format = get_compatible_sampler_format(m_formats_support, gcm_format);
-
-				image = new vk::viewable_image(*m_device, m_memory_types.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-					image_type,
-					vk_format,
-					width, height, depth, mipmaps, layer, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-					VK_IMAGE_TILING_OPTIMAL, usage_flags, is_cubemap ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT : 0,
-					VMM_ALLOCATION_POOL_TEXTURE_CACHE, rsx::classify_format(gcm_format));
-
-				// New section, we must prepare it
-				region.reset(rsx_range);
-				region.set_gcm_format(gcm_format);
-				region.set_image_type(type);
-				region.create(width, height, section_depth, mipmaps, image, pitch, true, gcm_format);
-			}
-
-			region.set_view_flags(swizzle_flags);
-			region.set_context(context);
-			region.set_swizzled(swizzled);
-			region.set_dirty(false);
-
-			image->native_component_map = apply_component_mapping_flags(gcm_format, swizzle_flags, rsx::default_remap_vector);
-
-			// Its not necessary to lock blit dst textures as they are just reused as necessary
-			switch (context)
-			{
-			case rsx::texture_upload_context::shader_read:
-			case rsx::texture_upload_context::blit_engine_src:
-				region.protect(utils::protection::ro);
-				read_only_range = region.get_min_max(read_only_range, rsx::section_bounds::locked_range);
-				break;
-			case rsx::texture_upload_context::blit_engine_dst:
-				region.set_unpack_swap_bytes(true);
-				no_access_range = region.get_min_max(no_access_range, rsx::section_bounds::locked_range);
-				break;
-			case rsx::texture_upload_context::dma:
-			case rsx::texture_upload_context::framebuffer_storage:
-				// Should not initialized with this method
-			default:
-				fmt::throw_exception("Unexpected upload context 0x%x", u32(context));
-			}
-
-			update_cache_tag();
-			return &region;
-		}
-
-		cached_texture_section* create_nul_section(vk::command_buffer& /*cmd*/, const utils::address_range& rsx_range, bool memory_load) override
-		{
-			auto& region = *find_cached_texture(rsx_range, { .gcm_format = RSX_GCM_FORMAT_IGNORED }, true, false, false);
-			ensure(!region.is_locked());
-
-			// Prepare section
-			region.reset(rsx_range);
-			region.set_context(rsx::texture_upload_context::dma);
-			region.set_dirty(false);
-			region.set_unpack_swap_bytes(true);
-
-			if (memory_load)
-			{
-				vk::map_dma(rsx_range.start, rsx_range.length());
-				vk::load_dma(rsx_range.start, rsx_range.length());
-			}
-
-			no_access_range = region.get_min_max(no_access_range, rsx::section_bounds::locked_range);
-			update_cache_tag();
-			return &region;
-		}
+		cached_texture_section* create_nul_section(vk::command_buffer& /*cmd*/, const utils::address_range& rsx_range, bool memory_load) override;
 
 		cached_texture_section* upload_image_from_cpu(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format,
-			rsx::texture_upload_context context, const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool swizzled) override
-		{
-			if (context != rsx::texture_upload_context::shader_read)
-			{
-				if (vk::is_renderpass_open(cmd))
-				{
-					vk::end_renderpass(cmd);
-				}
-			}
-			auto section = create_new_texture(cmd, rsx_range, width, height, depth, mipmaps, pitch, gcm_format, context, type, swizzled,
-					rsx::component_order::default_, 0);
+			rsx::texture_upload_context context, const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool swizzled) override;
 
-			auto image = section->get_raw_texture();
-			image->set_debug_name(fmt::format("Raw Texture @0x%x", rsx_range.start));
+		void set_component_order(cached_texture_section& section, u32 gcm_format, rsx::component_order expected_flags) override;
 
-			vk::enter_uninterruptible();
+		void insert_texture_barrier(vk::command_buffer& cmd, vk::image* tex, bool strong_ordering) override;
 
-			bool input_swizzled = swizzled;
-			if (context == rsx::texture_upload_context::blit_engine_src)
-			{
-				// Swizzling is ignored for blit engine copy and emulated using remapping
-				input_swizzled = false;
-			}
+		bool render_target_format_is_compatible(vk::image* tex, u32 gcm_format) override;
 
-			rsx::flags32_t upload_command_flags = initialize_image_layout |
-				(rsx::get_current_renderer()->get_backend_config().supports_asynchronous_compute ? upload_contents_async : upload_contents_inline);
+		void prepare_for_dma_transfers(vk::command_buffer& cmd) override;
 
-			vk::upload_image(cmd, image, subresource_layout, gcm_format, input_swizzled, mipmaps, image->aspect(),
-				*m_texture_upload_heap, upload_heap_align_default, upload_command_flags);
-
-			vk::leave_uninterruptible();
-
-			if (context != rsx::texture_upload_context::shader_read)
-			{
-				// Insert appropriate barrier depending on use. Shader read resources should be lazy-initialized before consuming.
-				// TODO: All texture resources should be initialized on use, this is wasteful
-
-				VkImageLayout preferred_layout;
-				switch (context)
-				{
-				default:
-					preferred_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-					break;
-				case rsx::texture_upload_context::blit_engine_dst:
-					preferred_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-					break;
-				case rsx::texture_upload_context::blit_engine_src:
-					preferred_layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-					break;
-				}
-
-				if (preferred_layout != image->current_layout)
-				{
-					image->change_layout(cmd, preferred_layout);
-				}
-				else
-				{
-					// Insert ordering barrier
-					ensure(preferred_layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-					insert_image_memory_barrier(cmd, image->value, image->current_layout, preferred_layout,
-						VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-						VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_WRITE_BIT,
-						{ image->aspect(), 0, image->mipmaps(), 0, image->layers() });
-				}
-			}
-
-			section->last_write_tag = rsx::get_shared_tag();
-			return section;
-		}
-
-		void set_component_order(cached_texture_section& section, u32 gcm_format, rsx::component_order expected_flags) override
-		{
-			if (expected_flags == section.get_view_flags())
-				return;
-
-			const VkComponentMapping mapping = apply_component_mapping_flags(gcm_format, expected_flags, rsx::default_remap_vector);
-			auto image = static_cast<vk::viewable_image*>(section.get_raw_texture());
-
-			ensure(image);
-			image->set_native_component_layout(mapping);
-
-			section.set_view_flags(expected_flags);
-		}
-
-		void insert_texture_barrier(vk::command_buffer& cmd, vk::image* tex, bool strong_ordering) override
-		{
-			if (!strong_ordering && tex->current_layout == VK_IMAGE_LAYOUT_GENERAL)
-			{
-				// A previous barrier already exists, do nothing
-				return;
-			}
-
-			vk::as_rtt(tex)->texture_barrier(cmd);
-		}
-
-		bool render_target_format_is_compatible(vk::image* tex, u32 gcm_format) override
-		{
-			auto vk_format = tex->info.format;
-			switch (gcm_format)
-			{
-			default:
-				//TODO
-				warn_once("Format incompatibility detected, reporting failure to force data copy (VK_FORMAT=0x%X, GCM_FORMAT=0x%X)", static_cast<u32>(vk_format), gcm_format);
-				return false;
-			case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
-				return (vk_format == VK_FORMAT_R16G16B16A16_SFLOAT);
-			case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
-				return (vk_format == VK_FORMAT_R32G32B32A32_SFLOAT);
-			case CELL_GCM_TEXTURE_X32_FLOAT:
-				return (vk_format == VK_FORMAT_R32_SFLOAT);
-			case CELL_GCM_TEXTURE_R5G6B5:
-				return (vk_format == VK_FORMAT_R5G6B5_UNORM_PACK16);
-			case CELL_GCM_TEXTURE_A8R8G8B8:
-			case CELL_GCM_TEXTURE_D8R8G8B8:
-				return (vk_format == VK_FORMAT_B8G8R8A8_UNORM || vk_format == VK_FORMAT_D24_UNORM_S8_UINT || vk_format == VK_FORMAT_D32_SFLOAT_S8_UINT);
-			case CELL_GCM_TEXTURE_B8:
-				return (vk_format == VK_FORMAT_R8_UNORM);
-			case CELL_GCM_TEXTURE_G8B8:
-				return (vk_format == VK_FORMAT_R8G8_UNORM);
-			case CELL_GCM_TEXTURE_DEPTH24_D8:
-			case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
-				return (vk_format == VK_FORMAT_D24_UNORM_S8_UINT || vk_format == VK_FORMAT_D32_SFLOAT_S8_UINT);
-			case CELL_GCM_TEXTURE_X16:
-			case CELL_GCM_TEXTURE_DEPTH16:
-			case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-				return (vk_format == VK_FORMAT_D16_UNORM || vk_format == VK_FORMAT_D32_SFLOAT);
-			}
-		}
-
-		void prepare_for_dma_transfers(vk::command_buffer& cmd) override
-		{
-			if (!cmd.is_recording())
-			{
-				cmd.begin();
-			}
-		}
-
-		void cleanup_after_dma_transfers(vk::command_buffer& cmd) override
-		{
-			bool occlusion_query_active = !!(cmd.flags & vk::command_buffer::cb_has_open_query);
-			if (occlusion_query_active)
-			{
-				// We really stepped in it
-				vk::do_query_cleanup(cmd);
-			}
-
-			// End recording
-			cmd.end();
-
-			if (cmd.access_hint != vk::command_buffer::access_type_hint::all)
-			{
-				// Flush any pending async jobs in case of blockers
-				// TODO: Context-level manager should handle this logic
-				g_fxo->get<async_scheduler_thread>().flush(VK_TRUE);
-
-				// Primary access command queue, must restart it after
-				vk::fence submit_fence(*m_device);
-				cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, &submit_fence, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_TRUE);
-
-				vk::wait_for_fence(&submit_fence, GENERAL_WAIT_TIMEOUT);
-
-				CHECK_RESULT(vkResetCommandBuffer(cmd, 0));
-				cmd.begin();
-			}
-			else
-			{
-				// Auxilliary command queue with auto-restart capability
-				cmd.submit(m_submit_queue, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_TRUE);
-			}
-
-			ensure(cmd.flags == 0);
-
-			if (occlusion_query_active)
-			{
-				ensure(cmd.is_recording());
-				cmd.flags |= vk::command_buffer::cb_load_occluson_task;
-			}
-		}
+		void cleanup_after_dma_transfers(vk::command_buffer& cmd) override;
 
 	public:
 		using baseclass::texture_cache;
 
-		void initialize(vk::render_device& device, VkQueue submit_queue, vk::data_heap& upload_heap)
-		{
-			m_device = &device;
-			m_memory_types = device.get_memory_mapping();
-			m_formats_support = device.get_formats_support();
-			m_submit_queue = submit_queue;
-			m_texture_upload_heap = &upload_heap;
-		}
+		void initialize(vk::render_device& device, VkQueue submit_queue, vk::data_heap& upload_heap);
 
-		void destroy() override
-		{
-			clear();
-		}
+		void destroy() override;
 
-		bool is_depth_texture(u32 rsx_address, u32 rsx_size) override
-		{
-			reader_lock lock(m_cache_mutex);
+		bool is_depth_texture(u32 rsx_address, u32 rsx_size) override;
 
-			auto &block = m_storage.block_for(rsx_address);
+		void on_frame_end() override;
 
-			if (block.get_locked_count() == 0)
-				return false;
+		vk::image* upload_image_simple(vk::command_buffer& cmd, VkFormat format, u32 address, u32 width, u32 height, u32 pitch);
 
-			for (auto& tex : block)
-			{
-				if (tex.is_dirty())
-					continue;
+		bool blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, vk::surface_cache& m_rtts, vk::command_buffer& cmd);
 
-				if (!tex.overlaps(rsx_address, rsx::section_bounds::full_range))
-					continue;
+		u32 get_unreleased_textures_count() const override;
 
-				if ((rsx_address + rsx_size - tex.get_section_base()) <= tex.get_section_size())
-				{
-					switch (tex.get_format())
-					{
-					case VK_FORMAT_D16_UNORM:
-					case VK_FORMAT_D32_SFLOAT:
-					case VK_FORMAT_D32_SFLOAT_S8_UINT:
-					case VK_FORMAT_D24_UNORM_S8_UINT:
-						return true;
-					default:
-						return false;
-					}
-				}
-			}
-
-			//Unreachable; silence compiler warning anyway
-			return false;
-		}
-
-		void on_frame_end() override
-		{
-			trim_sections();
-
-			if (m_storage.m_unreleased_texture_objects >= m_max_zombie_objects ||
-				m_temporary_memory_size > 0x4000000) //If already holding over 64M in discardable memory, be frugal with memory resources
-			{
-				purge_unreleased_sections();
-			}
-
-			const u64 last_complete_frame = vk::get_last_completed_frame_id();
-			m_temporary_storage.remove_if([&](const temporary_storage& o)
-			{
-				if (!o.block_size || o.test(last_complete_frame))
-				{
-					m_temporary_memory_size -= o.block_size;
-					return true;
-				}
-				return false;
-			});
-
-			m_temporary_subresource_cache.clear();
-			reset_frame_statistics();
-
-			baseclass::on_frame_end();
-		}
-
-		vk::image *upload_image_simple(vk::command_buffer& cmd, VkFormat format, u32 address, u32 width, u32 height, u32 pitch)
-		{
-			bool linear_format_supported = false;
-
-			switch (format)
-			{
-			case VK_FORMAT_B8G8R8A8_UNORM:
-				linear_format_supported = m_formats_support.bgra8_linear;
-				break;
-			case VK_FORMAT_R8G8B8A8_UNORM:
-				linear_format_supported = m_formats_support.argb8_linear;
-				break;
-			default:
-				rsx_log.error("Unsupported VkFormat 0x%x", static_cast<u32>(format));
-				return nullptr;
-			}
-
-			if (!linear_format_supported)
-			{
-				return nullptr;
-			}
-
-			// Uploads a linear memory range as a BGRA8 texture
-			auto image = std::make_unique<vk::viewable_image>(*m_device, m_memory_types.host_visible_coherent,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
-				VK_IMAGE_TYPE_2D,
-				format,
-				width, height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_PREINITIALIZED,
-				VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-				0, VMM_ALLOCATION_POOL_TEXTURE_CACHE);
-
-			VkImageSubresource subresource{};
-			subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-
-			VkSubresourceLayout layout{};
-			vkGetImageSubresourceLayout(*m_device, image->value, &subresource, &layout);
-
-			void* mem = image->memory->map(0, layout.rowPitch * height);
-
-			auto src = vm::_ptr<const char>(address);
-			auto dst = static_cast<char*>(mem);
-
-			//TODO: SSE optimization
-			for (u32 row = 0; row < height; ++row)
-			{
-				auto casted_src = reinterpret_cast<const be_t<u32>*>(src);
-				auto casted_dst = reinterpret_cast<u32*>(dst);
-
-				for (u32 col = 0; col < width; ++col)
-					casted_dst[col] = casted_src[col];
-
-				src += pitch;
-				dst += layout.rowPitch;
-			}
-
-			image->memory->unmap();
-
-			vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
-
-			auto result = image.get();
-			const u32 resource_memory = width * height * 4; //Rough approximate
-			m_temporary_storage.emplace_back(image);
-			m_temporary_storage.back().block_size = resource_memory;
-			m_temporary_memory_size += resource_memory;
-
-			return result;
-		}
-
-		bool blit(rsx::blit_src_info& src, rsx::blit_dst_info& dst, bool interpolate, vk::surface_cache& m_rtts, vk::command_buffer& cmd)
-		{
-			blitter helper;
-			auto reply = upload_scaled_image(src, dst, interpolate, cmd, m_rtts, helper);
-
-			if (reply.succeeded)
-			{
-				if (reply.real_dst_size)
-				{
-					flush_if_cache_miss_likely(cmd, reply.to_address_range());
-				}
-
-				return true;
-			}
-
-			return false;
-		}
-
-		u32 get_unreleased_textures_count() const override
-		{
-			return baseclass::get_unreleased_textures_count() + ::size32(m_temporary_storage);
-		}
-
-		u32 get_temporary_memory_in_use()
-		{
-			return m_temporary_memory_size;
-		}
+		u32 get_temporary_memory_in_use() const;
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -504,5 +504,7 @@ namespace vk
 		u32 get_unreleased_textures_count() const override;
 
 		u32 get_temporary_memory_in_use() const;
+
+		bool is_overallocated() const;
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -576,7 +576,7 @@ namespace vk
 					dst_format,
 					w, h, d, mips, layers, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 					VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, image_flags,
-					rsx::classify_format(gcm_format));
+					VMM_ALLOCATION_POOL_TEXTURE_CACHE, rsx::classify_format(gcm_format));
 			}
 
 			//This method is almost exclusively used to work on framebuffer resources
@@ -871,7 +871,7 @@ namespace vk
 					vk_format,
 					width, height, depth, mipmaps, layer, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 					VK_IMAGE_TILING_OPTIMAL, usage_flags, is_cubemap ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT : 0,
-					rsx::classify_format(gcm_format));
+					VMM_ALLOCATION_POOL_TEXTURE_CACHE, rsx::classify_format(gcm_format));
 
 				// New section, we must prepare it
 				region.reset(rsx_range);
@@ -1220,7 +1220,8 @@ namespace vk
 				VK_IMAGE_TYPE_2D,
 				format,
 				width, height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_PREINITIALIZED,
-				VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, 0);
+				VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+				0, VMM_ALLOCATION_POOL_TEXTURE_CACHE);
 
 			VkImageSubresource subresource{};
 			subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -503,6 +503,8 @@ namespace vk
 
 		u32 get_unreleased_textures_count() const override;
 
+		bool handle_memory_pressure(rsx::problem_severity severity) override;
+
 		u32 get_temporary_memory_in_use() const;
 
 		bool is_overallocated() const;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -471,7 +471,7 @@ namespace vk
 		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch,
 			u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t flags) override;
 
-		cached_texture_section* create_nul_section(vk::command_buffer& /*cmd*/, const utils::address_range& rsx_range, bool memory_load) override;
+		cached_texture_section* create_nul_section(vk::command_buffer& cmd, const utils::address_range& rsx_range, bool memory_load) override;
 
 		cached_texture_section* upload_image_from_cpu(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format,
 			rsx::texture_upload_context context, const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool swizzled) override;

--- a/rpcs3/Emu/RSX/VK/vkutils/buffer_object.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/buffer_object.cpp
@@ -5,7 +5,7 @@
 namespace vk
 {
 	buffer_view::buffer_view(VkDevice dev, VkBuffer buffer, VkFormat format, VkDeviceSize offset, VkDeviceSize size)
-	    : m_device(dev)
+		: m_device(dev)
 	{
 		info.buffer = buffer;
 		info.format = format;
@@ -39,97 +39,97 @@ namespace vk
 		return false;
 	}
 
-		buffer::buffer(const vk::render_device& dev, u64 size, u32 memory_type_index, u32 access_flags, VkBufferUsageFlags usage, VkBufferCreateFlags flags)
-			: m_device(dev)
+	buffer::buffer(const vk::render_device& dev, u64 size, u32 memory_type_index, u32 access_flags, VkBufferUsageFlags usage, VkBufferCreateFlags flags, vmm_allocation_pool allocation_pool)
+		: m_device(dev)
+	{
+		info.size = size;
+		info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+		info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		info.flags = flags;
+		info.usage = usage;
+
+		CHECK_RESULT(vkCreateBuffer(m_device, &info, nullptr, &value));
+
+		// Allocate vram for this buffer
+		VkMemoryRequirements memory_reqs;
+		vkGetBufferMemoryRequirements(m_device, value, &memory_reqs);
+
+		if (!(memory_reqs.memoryTypeBits & (1 << memory_type_index)))
 		{
-			info.size = size;
-			info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-			info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			info.flags = flags;
-			info.usage = usage;
-
-			CHECK_RESULT(vkCreateBuffer(m_device, &info, nullptr, &value));
-
-			//Allocate vram for this buffer
-			VkMemoryRequirements memory_reqs;
-			vkGetBufferMemoryRequirements(m_device, value, &memory_reqs);
-
-			if (!(memory_reqs.memoryTypeBits & (1 << memory_type_index)))
-			{
-				//Suggested memory type is incompatible with this memory type.
-				//Go through the bitset and test for requested props.
-				if (!dev.get_compatible_memory_type(memory_reqs.memoryTypeBits, access_flags, &memory_type_index))
-					fmt::throw_exception("No compatible memory type was found!");
-			}
-
-			memory = std::make_unique<memory_block>(m_device, memory_reqs.size, memory_reqs.alignment, memory_type_index);
-			vkBindBufferMemory(dev, value, memory->get_vk_device_memory(), memory->get_vk_device_memory_offset());
-		}
-
-		buffer::buffer(const vk::render_device& dev, VkBufferUsageFlags usage, void* host_pointer, u64 size)
-			: m_device(dev)
-		{
-			info.size = size;
-			info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-			info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			info.flags = 0;
-			info.usage = usage;
-
-			VkExternalMemoryBufferCreateInfoKHR ex_info;
-			ex_info.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO_KHR;
-			ex_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT;
-			ex_info.pNext = nullptr;
-
-			info.pNext = &ex_info;
-			CHECK_RESULT(vkCreateBuffer(m_device, &info, nullptr, &value));
-
-			auto& memory_map = dev.get_memory_mapping();
-			u32 memory_type_index = memory_map.host_visible_coherent;
-			VkFlags access_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-
-			ensure(memory_map._vkGetMemoryHostPointerPropertiesEXT);
-
-			VkMemoryHostPointerPropertiesEXT memory_properties{};
-			memory_properties.sType = VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT;
-			CHECK_RESULT(memory_map._vkGetMemoryHostPointerPropertiesEXT(dev, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_pointer, &memory_properties));
-
-			VkMemoryRequirements memory_reqs;
-			vkGetBufferMemoryRequirements(m_device, value, &memory_reqs);
-
-			auto required_memory_type_bits = memory_reqs.memoryTypeBits & memory_properties.memoryTypeBits;
-			if (!required_memory_type_bits)
-			{
-				// AMD driver bug. Buffers created with external memory extension return type bits of 0
-				rsx_log.warning("Could not match buffer requirements and host pointer properties.");
-				required_memory_type_bits = memory_properties.memoryTypeBits;
-			}
-
-			if (!dev.get_compatible_memory_type(required_memory_type_bits, access_flags, &memory_type_index))
-			{
+			// Suggested memory type is incompatible with this memory type.
+			// Go through the bitset and test for requested props.
+			if (!dev.get_compatible_memory_type(memory_reqs.memoryTypeBits, access_flags, &memory_type_index))
 				fmt::throw_exception("No compatible memory type was found!");
-			}
-
-			memory = std::make_unique<memory_block_host>(m_device, host_pointer, size, memory_type_index);
-			CHECK_RESULT(vkBindBufferMemory(dev, value, memory->get_vk_device_memory(), memory->get_vk_device_memory_offset()));
 		}
 
-		buffer::~buffer()
+		memory = std::make_unique<memory_block>(m_device, memory_reqs.size, memory_reqs.alignment, memory_type_index, allocation_pool);
+		vkBindBufferMemory(dev, value, memory->get_vk_device_memory(), memory->get_vk_device_memory_offset());
+	}
+
+	buffer::buffer(const vk::render_device& dev, VkBufferUsageFlags usage, void* host_pointer, u64 size)
+		: m_device(dev)
+	{
+		info.size = size;
+		info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+		info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		info.flags = 0;
+		info.usage = usage;
+
+		VkExternalMemoryBufferCreateInfoKHR ex_info;
+		ex_info.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO_KHR;
+		ex_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT;
+		ex_info.pNext = nullptr;
+
+		info.pNext = &ex_info;
+		CHECK_RESULT(vkCreateBuffer(m_device, &info, nullptr, &value));
+
+		auto& memory_map = dev.get_memory_mapping();
+		u32 memory_type_index = memory_map.host_visible_coherent;
+		VkFlags access_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+
+		ensure(memory_map._vkGetMemoryHostPointerPropertiesEXT);
+
+		VkMemoryHostPointerPropertiesEXT memory_properties{};
+		memory_properties.sType = VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT;
+		CHECK_RESULT(memory_map._vkGetMemoryHostPointerPropertiesEXT(dev, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_pointer, &memory_properties));
+
+		VkMemoryRequirements memory_reqs;
+		vkGetBufferMemoryRequirements(m_device, value, &memory_reqs);
+
+		auto required_memory_type_bits = memory_reqs.memoryTypeBits & memory_properties.memoryTypeBits;
+		if (!required_memory_type_bits)
 		{
-			vkDestroyBuffer(m_device, value, nullptr);
+			// AMD driver bug. Buffers created with external memory extension return type bits of 0
+			rsx_log.warning("Could not match buffer requirements and host pointer properties.");
+			required_memory_type_bits = memory_properties.memoryTypeBits;
 		}
 
-		void* buffer::map(u64 offset, u64 size)
+		if (!dev.get_compatible_memory_type(required_memory_type_bits, access_flags, &memory_type_index))
 		{
-			return memory->map(offset, size);
+			fmt::throw_exception("No compatible memory type was found!");
 		}
 
-		void buffer::unmap()
-		{
-			memory->unmap();
-		}
+		memory = std::make_unique<memory_block_host>(m_device, host_pointer, size, memory_type_index);
+		CHECK_RESULT(vkBindBufferMemory(dev, value, memory->get_vk_device_memory(), memory->get_vk_device_memory_offset()));
+	}
 
-		u32 buffer::size() const
-		{
-			return static_cast<u32>(info.size);
-		}
+	buffer::~buffer()
+	{
+		vkDestroyBuffer(m_device, value, nullptr);
+	}
+
+	void* buffer::map(u64 offset, u64 size)
+	{
+		return memory->map(offset, size);
+	}
+
+	void buffer::unmap()
+	{
+		memory->unmap();
+	}
+
+	u32 buffer::size() const
+	{
+		return static_cast<u32>(info.size);
+	}
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/buffer_object.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/buffer_object.h
@@ -29,7 +29,7 @@ namespace vk
 		VkBufferCreateInfo info = {};
 		std::unique_ptr<vk::memory_block> memory;
 
-		buffer(const vk::render_device& dev, u64 size, u32 memory_type_index, u32 access_flags, VkBufferUsageFlags usage, VkBufferCreateFlags flags);
+		buffer(const vk::render_device& dev, u64 size, u32 memory_type_index, u32 access_flags, VkBufferUsageFlags usage, VkBufferCreateFlags flags, vmm_allocation_pool allocation_pool);
 		buffer(const vk::render_device& dev, VkBufferUsageFlags usage, void* host_pointer, u64 size);
 		~buffer();
 

--- a/rpcs3/Emu/RSX/VK/vkutils/data_heap.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/data_heap.cpp
@@ -26,13 +26,13 @@ namespace vk
 		{
 			rsx_log.warning("Buffer usage %u is not heap-compatible using this driver, explicit staging buffer in use", usage);
 
-			shadow = std::make_unique<buffer>(*g_render_device, size, memory_index, memory_flags, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0);
+			shadow = std::make_unique<buffer>(*g_render_device, size, memory_index, memory_flags, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0, VMM_ALLOCATION_POOL_SYSTEM);
 			usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 			memory_flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 			memory_index = memory_map.device_local;
 		}
 
-		heap = std::make_unique<buffer>(*g_render_device, size, memory_index, memory_flags, usage, 0);
+		heap = std::make_unique<buffer>(*g_render_device, size, memory_index, memory_flags, usage, 0, VMM_ALLOCATION_POOL_SYSTEM);
 
 		initial_size = size;
 		notify_on_grow = bool(notify);
@@ -87,7 +87,7 @@ namespace vk
 
 		// Discard old heap and create a new one. Old heap will be garbage collected when no longer needed
 		get_resource_manager()->dispose(heap);
-		heap = std::make_unique<buffer>(*g_render_device, aligned_new_size, memory_index, memory_flags, usage, 0);
+		heap = std::make_unique<buffer>(*g_render_device, aligned_new_size, memory_index, memory_flags, usage, 0, VMM_ALLOCATION_POOL_SYSTEM);
 
 		if (notify_on_grow)
 		{

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -647,10 +647,9 @@ namespace vk
 		memory_type_mapping result;
 		result.device_local = VK_MAX_MEMORY_TYPES;
 		result.host_visible_coherent = VK_MAX_MEMORY_TYPES;
-
+		result.device_local_total_bytes = 0;
+		result.host_visible_total_bytes = 0;
 		bool host_visible_cached = false;
-		VkDeviceSize host_visible_vram_size = 0;
-		VkDeviceSize device_local_vram_size = 0;
 
 		for (u32 i = 0; i < memory_properties.memoryTypeCount; i++)
 		{
@@ -659,10 +658,10 @@ namespace vk
 			bool is_device_local = !!(memory_properties.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 			if (is_device_local)
 			{
-				if (device_local_vram_size < heap.size)
+				if (result.device_local_total_bytes < heap.size)
 				{
 					result.device_local = i;
-					device_local_vram_size = heap.size;
+					result.device_local_total_bytes = heap.size;
 				}
 			}
 
@@ -672,10 +671,10 @@ namespace vk
 
 			if (is_host_coherent && is_host_visible)
 			{
-				if ((is_cached && !host_visible_cached) || (host_visible_vram_size < heap.size))
+				if ((is_cached && !host_visible_cached) || (result.host_visible_total_bytes < heap.size))
 				{
 					result.host_visible_coherent = i;
-					host_visible_vram_size = heap.size;
+					result.host_visible_total_bytes = heap.size;
 					host_visible_cached = is_cached;
 				}
 			}

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -31,6 +31,9 @@ namespace vk
 		u32 host_visible_coherent;
 		u32 device_local;
 
+		u64 device_local_total_bytes;
+		u64 host_visible_total_bytes;
+
 		PFN_vkGetMemoryHostPointerPropertiesEXT _vkGetMemoryHostPointerPropertiesEXT;
 	};
 

--- a/rpcs3/Emu/RSX/VK/vkutils/image.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.cpp
@@ -107,8 +107,8 @@ namespace vk
 
 		if (!(memory_req.memoryTypeBits & (1 << memory_type_index)))
 		{
-			//Suggested memory type is incompatible with this memory type.
-			//Go through the bitset and test for requested props.
+			// Suggested memory type is incompatible with this memory type.
+			// Go through the bitset and test for requested props.
 			if (!dev.get_compatible_memory_type(memory_req.memoryTypeBits, access_flags, &memory_type_index))
 				fmt::throw_exception("No compatible memory type was found!");
 		}

--- a/rpcs3/Emu/RSX/VK/vkutils/image.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.cpp
@@ -53,9 +53,9 @@ namespace vk
 		VkImageTiling tiling,
 		VkImageUsageFlags usage,
 		VkImageCreateFlags image_flags,
+		vmm_allocation_pool allocation_pool,
 		rsx::format_class format_class)
-		: current_layout(initial_layout)
-		, m_device(dev)
+		: m_device(dev)
 	{
 		info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
 		info.imageType = image_type;
@@ -70,23 +70,7 @@ namespace vk
 		info.initialLayout = initial_layout;
 		info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-		validate(dev, info);
-		CHECK_RESULT(vkCreateImage(m_device, &info, nullptr, &value));
-
-		VkMemoryRequirements memory_req;
-		vkGetImageMemoryRequirements(m_device, value, &memory_req);
-
-		if (!(memory_req.memoryTypeBits & (1 << memory_type_index)))
-		{
-			//Suggested memory type is incompatible with this memory type.
-			//Go through the bitset and test for requested props.
-			if (!dev.get_compatible_memory_type(memory_req.memoryTypeBits, access_flags, &memory_type_index))
-				fmt::throw_exception("No compatible memory type was found!");
-		}
-
-		memory = std::make_shared<vk::memory_block>(m_device, memory_req.size, memory_req.alignment, memory_type_index);
-		CHECK_RESULT(vkBindImageMemory(m_device, value, memory->get_vk_device_memory(), memory->get_vk_device_memory_offset()));
-
+		create_impl(dev, access_flags, memory_type_index, allocation_pool);
 		m_storage_aspect = get_aspect_flags(format);
 
 		if (format_class == RSX_FORMAT_CLASS_UNDEFINED)
@@ -109,6 +93,30 @@ namespace vk
 	image::~image()
 	{
 		vkDestroyImage(m_device, value, nullptr);
+	}
+
+	void image::create_impl(const vk::render_device& dev, u32 access_flags, u32 memory_type_index, vmm_allocation_pool allocation_pool)
+	{
+		ensure(!value && !memory);
+		validate(dev, info);
+
+		CHECK_RESULT(vkCreateImage(m_device, &info, nullptr, &value));
+
+		VkMemoryRequirements memory_req;
+		vkGetImageMemoryRequirements(m_device, value, &memory_req);
+
+		if (!(memory_req.memoryTypeBits & (1 << memory_type_index)))
+		{
+			//Suggested memory type is incompatible with this memory type.
+			//Go through the bitset and test for requested props.
+			if (!dev.get_compatible_memory_type(memory_req.memoryTypeBits, access_flags, &memory_type_index))
+				fmt::throw_exception("No compatible memory type was found!");
+		}
+
+		memory = std::make_shared<vk::memory_block>(m_device, memory_req.size, memory_req.alignment, memory_type_index, allocation_pool);
+		CHECK_RESULT(vkBindImageMemory(m_device, value, memory->get_vk_device_memory(), memory->get_vk_device_memory_offset()));
+
+		current_layout = info.initialLayout;
 	}
 
 	u32 image::width() const
@@ -328,6 +336,20 @@ namespace vk
 		// Restore requested mapping
 		info.components = mapping;
 #endif
+	}
+
+	viewable_image* viewable_image::clone()
+	{
+		// Destructive cloning. The clone grabs the GPU objects owned by this instance.
+		// This instance can be rebuilt in-place by calling create_impl() which will create a duplicate now owned by this.
+		auto result = new viewable_image();
+		result->m_device = this->m_device;
+		result->info = this->info;
+		result->value = this->value;
+		result->memory = std::move(this->memory);
+		result->views = std::move(this->views);
+		this->value = VK_NULL_HANDLE;
+		return result;
 	}
 
 	image_view* viewable_image::get_view(u32 remap_encoding, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap, VkImageAspectFlags mask)

--- a/rpcs3/Emu/RSX/VK/vkutils/image.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.h
@@ -35,6 +35,10 @@ namespace vk
 
 		void validate(const vk::render_device& dev, const VkImageCreateInfo& info) const;
 
+	protected:
+		image() = default;
+		void create_impl(const vk::render_device& dev, u32 access_flags, u32 memory_type_index, vmm_allocation_pool allocation_pool);
+
 	public:
 		VkImage value = VK_NULL_HANDLE;
 		VkComponentMapping native_component_map = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A };
@@ -55,6 +59,7 @@ namespace vk
 			VkImageTiling tiling,
 			VkImageUsageFlags usage,
 			VkImageCreateFlags image_flags,
+			vmm_allocation_pool allocation_pool,
 			rsx::format_class format_class = RSX_FORMAT_CLASS_UNDEFINED);
 
 		virtual ~image();
@@ -84,7 +89,7 @@ namespace vk
 		// Debug utils
 		void set_debug_name(const std::string& name);
 
-	private:
+	protected:
 		VkDevice m_device;
 	};
 
@@ -118,8 +123,9 @@ namespace vk
 
 	class viewable_image : public image
 	{
-	private:
+	protected:
 		std::unordered_multimap<u32, std::unique_ptr<vk::image_view>> views;
+		viewable_image* clone();
 
 	public:
 		using image::image;

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -8,15 +8,20 @@
 
 namespace vk
 {
-	enum vmm_allocation_pool
+	namespace vmm_allocation_pool_ // Workaround for clang < 13 not supporting enum imports
 	{
-		VMM_ALLOCATION_POOL_UNDEFINED = 0,
-		VMM_ALLOCATION_POOL_SYSTEM,
-		VMM_ALLOCATION_POOL_SURFACE_CACHE,
-		VMM_ALLOCATION_POOL_TEXTURE_CACHE,
-		VMM_ALLOCATION_POOL_SWAPCHAIN,
-		VMM_ALLOCATION_POOL_SCRATCH,
-	};
+		enum vmm_allocation_pool
+		{
+			VMM_ALLOCATION_POOL_UNDEFINED = 0,
+			VMM_ALLOCATION_POOL_SYSTEM,
+			VMM_ALLOCATION_POOL_SURFACE_CACHE,
+			VMM_ALLOCATION_POOL_TEXTURE_CACHE,
+			VMM_ALLOCATION_POOL_SWAPCHAIN,
+			VMM_ALLOCATION_POOL_SCRATCH,
+		};
+	}
+
+	using namespace vk::vmm_allocation_pool_;
 
 	class mem_allocator_base
 	{

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -8,17 +8,27 @@
 
 namespace vk
 {
+	enum vmm_allocation_pool
+	{
+		VMM_ALLOCATION_POOL_UNDEFINED = 0,
+		VMM_ALLOCATION_POOL_SYSTEM,
+		VMM_ALLOCATION_POOL_SURFACE_CACHE,
+		VMM_ALLOCATION_POOL_TEXTURE_CACHE,
+		VMM_ALLOCATION_POOL_SWAPCHAIN,
+		VMM_ALLOCATION_POOL_SCRATCH,
+	};
+
 	class mem_allocator_base
 	{
 	public:
 		using mem_handle_t = void*;
 
-		mem_allocator_base(VkDevice dev, VkPhysicalDevice /*pdev*/) : m_device(dev) {}
+		mem_allocator_base(VkDevice dev, VkPhysicalDevice /*pdev*/) : m_device(dev), m_allocation_flags(0) {}
 		virtual ~mem_allocator_base() = default;
 
 		virtual void destroy() = 0;
 
-		virtual mem_handle_t alloc(u64 block_sz, u64 alignment, u32 memory_type_index) = 0;
+		virtual mem_handle_t alloc(u64 block_sz, u64 alignment, u32 memory_type_index, vmm_allocation_pool pool) = 0;
 		virtual void free(mem_handle_t mem_handle) = 0;
 		virtual void* map(mem_handle_t mem_handle, u64 offset, u64 size) = 0;
 		virtual void unmap(mem_handle_t mem_handle) = 0;
@@ -26,8 +36,12 @@ namespace vk
 		virtual u64 get_vk_device_memory_offset(mem_handle_t mem_handle) = 0;
 		virtual f32 get_memory_usage() = 0;
 
+		virtual void set_safest_allocation_flags() {}
+		virtual void set_fastest_allocation_flags() {}
+
 	protected:
 		VkDevice m_device;
+		VkFlags  m_allocation_flags;
 	};
 
 
@@ -42,7 +56,7 @@ namespace vk
 
 		void destroy() override;
 
-		mem_handle_t alloc(u64 block_sz, u64 alignment, u32 memory_type_index) override;
+		mem_handle_t alloc(u64 block_sz, u64 alignment, u32 memory_type_index, vmm_allocation_pool pool) override;
 
 		void free(mem_handle_t mem_handle) override;
 		void* map(mem_handle_t mem_handle, u64 offset, u64 /*size*/) override;
@@ -51,6 +65,9 @@ namespace vk
 		VkDeviceMemory get_vk_device_memory(mem_handle_t mem_handle) override;
 		u64 get_vk_device_memory_offset(mem_handle_t mem_handle) override;
 		f32 get_memory_usage() override;
+
+		void set_safest_allocation_flags() override;
+		void set_fastest_allocation_flags() override;
 
 	private:
 		VmaAllocator m_allocator;
@@ -68,7 +85,7 @@ namespace vk
 
 		void destroy() override {}
 
-		mem_handle_t alloc(u64 block_sz, u64 /*alignment*/, u32 memory_type_index) override;
+		mem_handle_t alloc(u64 block_sz, u64 /*alignment*/, u32 memory_type_index, vmm_allocation_pool pool) override;
 
 		void free(mem_handle_t mem_handle) override;
 		void* map(mem_handle_t mem_handle, u64 offset, u64 size) override;
@@ -81,7 +98,7 @@ namespace vk
 
 	struct memory_block
 	{
-		memory_block(VkDevice dev, u64 block_sz, u64 alignment, u32 memory_type_index);
+		memory_block(VkDevice dev, u64 block_sz, u64 alignment, u32 memory_type_index, vmm_allocation_pool pool);
 		virtual ~memory_block();
 
 		virtual VkDeviceMemory get_vk_device_memory();
@@ -89,6 +106,8 @@ namespace vk
 
 		virtual void* map(u64 offset, u64 size);
 		virtual void unmap();
+
+		u64 size() const;
 
 		memory_block(const memory_block&) = delete;
 		memory_block(memory_block&&)      = delete;
@@ -100,6 +119,7 @@ namespace vk
 		VkDevice m_device;
 		vk::mem_allocator_base* m_mem_allocator = nullptr;
 		mem_allocator_base::mem_handle_t m_mem_handle;
+		u64 m_size;
 	};
 
 	struct memory_block_host : public memory_block
@@ -122,11 +142,14 @@ namespace vk
 		void* m_host_pointer;
 	};
 
-	void vmm_notify_memory_allocated(void* handle, u32 memory_type, u64 memory_size);
+	void vmm_notify_memory_allocated(void* handle, u32 memory_type, u64 memory_size, vmm_allocation_pool pool);
 	void vmm_notify_memory_freed(void* handle);
 	void vmm_reset();
 	void vmm_check_memory_usage();
+	u64  vmm_get_application_memory_usage(u32 memory_type);
+	u64  vmm_get_application_pool_usage(vmm_allocation_pool pool);
 	bool vmm_handle_memory_pressure(rsx::problem_severity severity);
+	rsx::problem_severity vmm_determine_memory_load_severity();
 
 	mem_allocator_base* get_current_mem_allocator();
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
@@ -97,7 +97,7 @@ namespace vk
 		auto& tex = g_null_image_views[type];
 		tex = std::make_unique<viewable_image>(*g_render_device, g_render_device->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 			image_type, VK_FORMAT_B8G8R8A8_UNORM, size, size, 1, 1, num_layers, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, flags);
+			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, flags, VMM_ALLOCATION_POOL_SCRATCH);
 
 		// Initialize memory to transparent black
 		tex->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
@@ -122,7 +122,7 @@ namespace vk
 
 			return new vk::image(*g_render_device, g_render_device->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 				VK_IMAGE_TYPE_2D, format, new_width, new_height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, 0);
+				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, 0, VMM_ALLOCATION_POOL_SCRATCH);
 		};
 
 		const u32 key = (format_class << 24u) | format;
@@ -160,7 +160,7 @@ namespace vk
 
 			scratch_buffer = std::make_unique<vk::buffer>(*g_render_device, alloc_size,
 				g_render_device->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-				VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, 0);
+				VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_SCRATCH);
 		}
 
 		return scratch_buffer.get();

--- a/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
@@ -27,14 +27,14 @@ namespace vk
 		swapchain_image_RPCS3(render_device& dev, const memory_type_mapping& memory_map, u32 width, u32 height)
 			:image(dev, memory_map.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_IMAGE_TYPE_2D, VK_FORMAT_B8G8R8A8_UNORM, width, height, 1, 1, 1,
 				VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_TILING_OPTIMAL,
-				VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0)
+				VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0, VMM_ALLOCATION_POOL_SWAPCHAIN)
 		{
 			m_width = width;
 			m_height = height;
 			current_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 
 			m_dma_buffer = std::make_unique<buffer>(dev, m_width * m_height * 4, memory_map.host_visible_coherent,
-				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
+				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0, VMM_ALLOCATION_POOL_SWAPCHAIN);
 		}
 
 		void do_dma_transfer(command_buffer& cmd)

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
@@ -84,7 +84,8 @@ namespace vk
 				dev.get_memory_mapping().host_visible_coherent,
 				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
 				VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-				0
+				0,
+				VMM_ALLOCATION_POOL_SYSTEM
 			);
 
 			m_value = reinterpret_cast<u32*>(m_buffer->map(0, 4));


### PR DESCRIPTION
This PR adds a lot of stuff I've been working on the past few weeks that tries to keep the emulator from dying when we run out of video memory. Due to rpcs3's architecture, some applications can trigger runaway conditions where all the video memory can be consumed in seconds sometimes even with a RTX 3090.

**Changes**
Multiple strategies are used here to handle out of memory situations:
1. Track memory allocations in coarse "pools". This will help track which part of the emulator is using too much memory and take appropriate actions based on this.
2. Adds improved heurestics to avoid false positives. Sometimes the memory is there, just fragmented. If we keep panicking in such situation and deleting everything, performance can be very bad.
3. Allow emergency texture cache eviction if we're holding onto too much unused crap in the texture cache.
4. Implement VRAM spilling for extreme situations where the surface cache has a sudden load that cannot be dealt with by immediately dumping everything. In this case, copy the data over to system memory and load it back in when it is actually needed.

**Results**
With this patchset it is possible to run some crazy demanding games such as Heavenly Sword or some Insomniac Games titles on PS3 can be ran with decent resolution scaling (150-200%) and even with MSAA enabled on a 4GB VRAM card and the video memory manager can handle overcommit conditions when needed successfully without crashing outright. Note that due to some corner cases with MSAA, it is still possible to run out of memory when MSAA is enabled, but I have plans to work on this in the future.

**TODO before merge:** 
- [x] Texture cache temporary storage should also be dumped during cache eviction routine. This is an oversight on my part, I only just remembered this is a thing.
- [x] Check devices with very low reported video memory (IGP systems) which may over-detect low memory conditions and be in a panicked state triggering poor performance.

**Future work:**
- [ ] Spill MSAA blocks without requiring a temporary medium per-object. This requires specialized compute shaders that are not supported on all platforms unfortunately. An alternative method is possible and I have planned it out, but it will take some time. I decided not to lump this in with this set due to the size of the changeset being already unmanageable.