### PR TITLE
Formatting Library: Implement byte arrays formatting

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -173,6 +173,37 @@ void fmt_class_string<std::vector<char8_t>>::format(std::string& out, u64 arg)
 	out.append(obj.cbegin(), obj.cend());
 }
 
+void format_byte_array(std::string& out, const uchar* data, usz size)
+{
+	if (!size)
+	{
+		out += "{ EMPTY }";
+		return;
+	}
+
+	out += "{ ";
+
+	for (usz i = 0;; i++)
+	{
+		if (i == size - 1)
+		{
+			fmt::append(out, "%02X", data[i]);
+			break;
+		}
+
+		if (i % 4)
+		{
+			// Place a comma each 4 bytes for ease of byte placement finding
+			fmt::append(out, "%02X ", data[i]);
+			continue;
+		}
+
+		fmt::append(out, "%02X, ", data[i]);
+	}
+
+	out += " }";
+}
+
 template <>
 void fmt_class_string<char>::format(std::string& out, u64 arg)
 {

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -86,7 +86,13 @@ struct fmt_unveil<T*, void>
 	}
 };
 
-template <typename T, usz N>
+namespace fmt
+{
+	template <typename T>
+	concept CharT = (std::is_same_v<const T, const char> || std::is_same_v<const T, const char8_t>);
+}
+
+template <fmt::CharT T, usz N>
 struct fmt_unveil<T[N], void>
 {
 	using type = std::add_const_t<T>*;
@@ -213,6 +219,30 @@ struct fmt_class_string<const char8_t*, void> : fmt_class_string<const char*>
 template <>
 struct fmt_class_string<char8_t*, void> : fmt_class_string<const char8_t*>
 {
+};
+
+namespace fmt
+{
+	// Both uchar and std::byte are allowed
+	template <typename T>
+	concept ByteArray = requires (T& t) { static_cast<const std::conditional_t<std::is_same_v<decltype(std::as_const(t[0])), const std::byte&>, std::byte, uchar>&>(std::data(t)[0]); };
+}
+
+template <fmt::ByteArray T>
+struct fmt_class_string<T, void>
+{
+	static FORCE_INLINE SAFE_BUFFERS(const T&) get_object(u64 arg)
+	{
+		return *reinterpret_cast<const T*>(static_cast<uptr>(arg));
+	}
+
+	static void format(std::string& out, u64 arg)
+	{
+		const auto& obj = get_object(arg);
+	
+		void format_byte_array(std::string&, const uchar*, usz);
+		format_byte_array(out, reinterpret_cast<const uchar*>(std::data(obj)), std::size(obj));
+	}
 };
 
 struct fmt_type_info

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -160,21 +160,7 @@ void fmt_class_string<SceNpCommunicationSignature>::format(std::string& out, u64
 {
 	const auto& sign = get_object(arg);
 
-	// Format as a C byte array for ease of use
-	fmt::append(out, "{ ");
-
-	for (usz i = 0;; i++)
-	{
-		if (i == std::size(sign.data) - 1)
-		{
-			fmt::append(out, "0x%02X", sign.data[i]);
-			break;
-		}
-
-		fmt::append(out, "0x%02X, ", sign.data[i]);
-	}
-
-	fmt::append(out, " }");
+	fmt::append(out, "%s", sign.data);
 }
 
 // Helpers


### PR DESCRIPTION
T = std::byte or unsigned char.
`std::vector<T>, T[N], std::span<T, N>, std::basic_string<T>, std::basic_string_view<T>` are all compatible.
