### PR TITLE
PPU debugger: Implement function names at the starting instruction

### DIFF
--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -4,6 +4,7 @@
 #include "Emu/IdManager.h"
 
 const ppu_decoder<PPUDisAsm> s_ppu_disasm;
+extern const std::unordered_map<u32, std::string_view>& get_exported_function_names_as_addr_indexed_map();
 
 u32 PPUDisAsm::disasm(u32 pc)
 {
@@ -12,6 +13,15 @@ u32 PPUDisAsm::disasm(u32 pc)
 	std::memcpy(&op, m_offset + pc, 4);
 	m_op = op;
 	(this->*(s_ppu_disasm.decode(m_op)))({ m_op });
+
+	const auto& map = get_exported_function_names_as_addr_indexed_map();
+
+	if (auto it = map.find(pc); it != map.end())
+	{
+		last_opcode += " #";
+		last_opcode += it->second;
+	}
+
 	return 4;
 }
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -307,7 +307,7 @@ static void ppu_initialize_modules(ppu_linkage_info* link)
 
 			if (is_first)
 			{
-				g_ppu_function_names[function.second.index] = fmt::format("%s.%s", _module->name, function.second.name);
+				g_ppu_function_names[function.second.index] = fmt::format("%s:%s", function.second.name, _module->name);
 			}
 
 			if ((function.second.flags & MFF_HIDDEN) == 0)
@@ -366,6 +366,59 @@ static void ppu_initialize_modules(ppu_linkage_info* link)
 			}
 		}
 	}
+}
+
+// For the debugger (g_ppu_function_names shouldn't change, string_view should suffice)
+extern const std::unordered_map<u32, std::string_view>& get_exported_function_names_as_addr_indexed_map()
+{
+	static std::unordered_map<u32, std::string_view> res;
+	static u64 update_time = 0;
+
+	const auto link = g_fxo->try_get<ppu_linkage_info>();
+	const auto hle_funcs = g_fxo->try_get<ppu_function_manager>();
+
+	if (!link || !hle_funcs)
+	{
+		res.clear();
+		return res;
+	}
+
+	const u64 current_time = get_system_time();
+
+	// Update list every >=0.1 seconds
+	if (current_time - update_time < 100'000)
+	{
+		return res;
+	}
+
+	update_time = current_time;
+
+	res.clear();
+	res.reserve(ppu_module_manager::get().size());
+
+	for (auto& pair : ppu_module_manager::get())
+	{
+		const auto _module = pair.second;
+		auto& linkage = link->modules[_module->name];
+
+		for (auto& function : _module->functions)
+		{
+			auto& flink = linkage.functions[function.first];
+			u32 addr = flink.export_addr;
+
+			if (vm::check_addr<4>(addr, vm::page_readable) && addr != hle_funcs->func_addr(function.second.index))
+			{
+				addr = vm::read32(addr);
+
+				if (!(addr % 4) && vm::check_addr<4>(addr, vm::page_executable))
+				{
+					res.try_emplace(addr, g_ppu_function_names[function.second.index]);
+				}
+			}
+		}
+	}
+
+	return res;
 }
 
 // Resolve relocations for variable/function linkage.

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -494,10 +494,13 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 
 				std::string ret;
 
+				PPUDisAsm dis_asm(cpu_disasm_mode::normal, vm::g_sudo_addr);
 				u32 i = 0;
+
 				for (auto it = copy.rbegin(); it != copy.rend(); it++, i++)
 				{
-					fmt::append(ret, "\n(%u) 0x%08x", i, *it);
+					dis_asm.disasm(*it);
+					fmt::append(ret, "\n(%u) 0x%08x: %s", i, *it, dis_asm.last_opcode);
 				}
 	
 				if (ret.empty())


### PR DESCRIPTION
* Display the LLE function name at the first instruction an an ASM style comment.
* Add disasm of first instruction in PPU calling history logging. With this feature seeing LLE functions history!

![image](https://user-images.githubusercontent.com/18193363/126062489-b33201e2-1b99-40c9-8e19-8d9bd2d97ba0.png)
