### PR TITLE
sys_ppu: Implement sys_ppu_thread_rename

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -224,16 +224,22 @@ public:
 	}
 
 	// Set current thread name (not recommended)
-	static void set_name(std::string_view name)
+	static void set_name(std::string name)
 	{
 		g_tls_this_thread->m_tname.store(make_single<std::string>(name));
+		g_tls_this_thread->set_name(std::move(name));
 	}
 
 	// Set thread name (not recommended)
 	template <typename T>
-	static void set_name(named_thread<T>& thread, std::string_view name)
+	static void set_name(named_thread<T>& thread, std::string name)
 	{
 		static_cast<thread_base&>(thread).m_tname.store(make_single<std::string>(name));
+
+		if (g_tls_this_thread == std::addressof(static_cast<thread_base&>(thread)))
+		{
+			g_tls_this_thread->set_name(std::move(name));
+		}
 	}
 
 	template <typename T>

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -545,6 +545,8 @@ error_code sys_ppu_thread_rename(ppu_thread& ppu, u32 thread_id, vm::cptr<char> 
 	// thread_ctrl name is not changed (TODO)
 	sys_ppu_thread.warning(u8"sys_ppu_thread_rename(): Thread renamed to “%s”", *_name);
 	thread->ppu_tname.store(std::move(_name));
+	thread_ctrl::set_name(*thread, thread->thread_name); // TODO: Currently sets debugger thread name only for local thread
+
 	return CELL_OK;
 }
 


### PR DESCRIPTION
NOTE: Operating system thread renaming only works for current thread. But name associated with logging and RPCS3 debugger area always changed.
Used by VSH.