### PR TITLE
Stub rsxaudio for vsh

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
@@ -8,7 +8,9 @@ LOG_CHANNEL(sys_rsxaudio);
 
 error_code sys_rsxaudio_initialize(vm::ptr<u32> handle)
 {
+	// Creates a lv2 object for rsxaudio, returns handle
 	sys_rsxaudio.todo("sys_rsxaudio_initialize(handle=*0x%x)", handle);
+	*handle = 0xcacad0d0;
 
 	return CELL_OK;
 }
@@ -23,6 +25,8 @@ error_code sys_rsxaudio_finalize(u32 handle)
 error_code sys_rsxaudio_import_shared_memory(u32 handle, vm::ptr<u64> addr)
 {
 	sys_rsxaudio.todo("sys_rsxaudio_import_shared_memory(handle=0x%x, addr=*0x%x)", handle, addr);
+
+	*addr = vm::alloc(0x40000, vm::main);
 
 	return CELL_OK;
 }


### PR DESCRIPTION
Will be replaced with Vestrel's implementation, but required to not crash vsh currently.