### PR TITLE
PPU debugger: Make calling history detect common LLE functions trampolines

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -123,9 +123,13 @@ void fmt_class_string<typename ppu_thread::call_history_t>::format(std::string& 
 {
 	const auto& history = get_object(arg);
 
+	PPUDisAsm dis_asm(cpu_disasm_mode::normal, vm::g_sudo_addr);
+
 	for (u64 count = 0, idx = history.index - 1; idx != umax && count < ppu_thread::call_history_max_size; count++, idx--)
 	{
-		fmt::append(out, "\n(%u) 0x%08x", count, history.data[idx % ppu_thread::call_history_max_size]);
+		const u32 pc = history.data[idx % ppu_thread::call_history_max_size];
+		dis_asm.disasm(pc);
+		fmt::append(out, "\n(%u) 0x%08x: %s", count, pc, dis_asm.last_opcode);
 	}
 }
 

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -301,6 +301,8 @@ public:
 	{
 		std::vector<u32> data;
 		u64 index = 0;
+		u64 last_r1 = umax;
+		u64 last_r2 = umax;
 	} call_history;
 
 	static constexpr u32 call_history_max_size = 4096;


### PR DESCRIPTION
Only BCTRL based wrappers to exported functions were working before. (they are rare)
BCTR based exported functions trampolines were not detected as a call because non-link variant is more tricky to detect than old implmentation could.

![image](https://user-images.githubusercontent.com/18193363/126070914-104db7a3-bda2-435e-8ec3-9e31ce14f3b4.png)
