### PR TITLE
Add VSH to GUI

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -16,6 +16,7 @@
 
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
+#include "Emu/system_config.h"
 #include "Emu/system_utils.hpp"
 #include "Loader/PSF.h"
 #include "util/types.hpp"
@@ -1386,19 +1387,24 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	menu.exec(global_pos);
 }
 
-bool game_list_frame::CreatePPUCache(const game_info& game)
+bool game_list_frame::CreatePPUCache(const std::string& path, const std::string& serial)
 {
 	Emu.SetForceBoot(true);
 	Emu.Stop();
 	Emu.SetForceBoot(true);
 
-	if (const auto error = Emu.BootGame(game->info.path, game->info.serial, true); error != game_boot_result::no_errors)
+	if (const auto error = Emu.BootGame(path, serial, true); error != game_boot_result::no_errors)
 	{
-		game_list_log.error("Could not create PPU Cache for %s, error: %s", game->info.path, error);
+		game_list_log.error("Could not create PPU Cache for %s, error: %s", path, error);
 		return false;
 	}
-	game_list_log.warning("Creating PPU Cache for %s", game->info.path);
+	game_list_log.warning("Creating PPU Cache for %s", path);
 	return true;
+}
+
+bool game_list_frame::CreatePPUCache(const game_info& game)
+{
+	return game && CreatePPUCache(game->info.path, game->info.serial);
 }
 
 bool game_list_frame::RemoveCustomConfiguration(const std::string& title_id, const game_info& game, bool is_interactive)
@@ -1607,7 +1613,9 @@ bool game_list_frame::RemoveSPUCache(const std::string& base_dir, bool is_intera
 
 void game_list_frame::BatchCreatePPUCaches()
 {
-	const u32 total = m_game_data.size();
+	const std::string vsh_path = g_cfg.vfs.get_dev_flash() + "/vsh/module/vsh.self";
+	const bool vsh_exists = fs::is_file(vsh_path);
+	const u32 total = m_game_data.size() + (vsh_exists ? 1 : 0);
 
 	if (total == 0)
 	{
@@ -1626,6 +1634,12 @@ void game_list_frame::BatchCreatePPUCaches()
 	pdlg->show();
 
 	u32 created = 0;
+
+	if (vsh_exists && CreatePPUCache(vsh_path))
+	{
+		pdlg->SetValue(++created);
+	}
+
 	for (const auto& game : m_game_data)
 	{
 		if (pdlg->wasCanceled())

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1632,6 +1632,7 @@ void game_list_frame::BatchCreatePPUCaches()
 	pdlg->setAutoClose(false);
 	pdlg->setAutoReset(false);
 	pdlg->show();
+	QApplication::processEvents();
 
 	u32 created = 0;
 
@@ -1644,7 +1645,6 @@ void game_list_frame::BatchCreatePPUCaches()
 	{
 		if (pdlg->wasCanceled())
 		{
-			game_list_log.notice("PPU Cache Batch Creation was canceled");
 			break;
 		}
 		QApplication::processEvents();
@@ -1653,10 +1653,26 @@ void game_list_frame::BatchCreatePPUCaches()
 		{
 			while (!Emu.IsStopped())
 			{
+				if (pdlg->wasCanceled())
+				{
+					break;
+				}
 				QApplication::processEvents();
 			}
 			pdlg->SetValue(++created);
 		}
+	}
+
+	if (pdlg->wasCanceled())
+	{
+		game_list_log.notice("PPU Cache Batch Creation was canceled");
+
+		if (!Emu.IsStopped())
+		{
+			QApplication::processEvents();
+			Emu.Stop();
+		}
+		return;
 	}
 
 	pdlg->setLabelText(tr("Created PPU Caches for %n title(s)", "", created));

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -109,6 +109,7 @@ private:
 	bool RemoveShadersCache(const std::string& base_dir, bool is_interactive = false);
 	bool RemovePPUCache(const std::string& base_dir, bool is_interactive = false);
 	bool RemoveSPUCache(const std::string& base_dir, bool is_interactive = false);
+	static bool CreatePPUCache(const std::string& path, const std::string& serial = {});
 	static bool CreatePPUCache(const game_info& game);
 
 	QString GetLastPlayedBySerial(const QString& serial) const;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -468,6 +468,12 @@ void main_window::BootGame()
 	Boot(sstr(dir_path));
 }
 
+void main_window::BootVSH()
+{
+	gui_log.notice("Booting from BootVSH...");
+	Boot(g_cfg.vfs.get_dev_flash() + "/vsh/module/vsh.self");
+}
+
 void main_window::BootRsxCapture(std::string path)
 {
 	if (path.empty())
@@ -1914,6 +1920,7 @@ void main_window::CreateConnects()
 {
 	connect(ui->bootElfAct, &QAction::triggered, this, &main_window::BootElf);
 	connect(ui->bootGameAct, &QAction::triggered, this, &main_window::BootGame);
+	connect(ui->bootVSHAct, &QAction::triggered, this, &main_window::BootVSH);
 	connect(ui->actionopen_rsx_capture, &QAction::triggered, this, [this](){ BootRsxCapture(); });
 	connect(ui->actionCreate_RSX_Capture, &QAction::triggered, this, []()
 	{

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -109,6 +109,7 @@ private Q_SLOTS:
 	void Boot(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, bool force_global_config = false);
 	void BootElf();
 	void BootGame();
+	void BootVSH();
 	void BootRsxCapture(std::string path = "");
 	void DecryptSPRXLibraries();
 	static void show_boot_error(game_boot_result status);

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -188,6 +188,7 @@
     </widget>
     <addaction name="bootElfAct"/>
     <addaction name="bootGameAct"/>
+    <addaction name="bootVSHAct"/>
     <addaction name="bootRecentMenu"/>
     <addaction name="separator"/>
     <addaction name="addGamesAct"/>
@@ -1161,6 +1162,11 @@
    </property>
    <property name="text">
     <string>Play Hover Gifs</string>
+   </property>
+  </action>
+  <action name="bootVSHAct">
+   <property name="text">
+    <string>Boot VSH/XMB</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
- Add "Boot VSH/XMB" option to the main menu
- Add VSH to "All Titles -> Create PPU Caches"
- Fix a bug that occasionally crashed RPCS3 after the "Create PPU Caches" dialog was canceled
- Fix a bug that didn't properly kill the current PPU compilation when the "Create PPU Caches" dialog was canceled