### PR TITLE
vk: Disable async texture streaming on all NVIDIA cards

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -570,6 +570,12 @@ VKGSRender::VKGSRender() : GSRender()
 				rsx_log.error("Older NVIDIA cards do not meet requirements for asynchronous compute due to some driver fakery.");
 				backend_config.supports_asynchronous_compute = false;
 			}
+			else // Workaround. Remove once the async decoder is re-written
+			{
+				// NVIDIA 471 and newer are completely borked. Queue priority is not observed and any queue waiting on another just causes deadlock.
+				rsx_log.error("NVIDIA GPUs are incompatible with the current implementation of asynchronous texture decoding.");
+				backend_config.supports_asynchronous_compute = false;
+			}
 			break;
 #if !defined(_WIN32)
 			// Anything running on AMDGPU kernel driver will not work due to the check for fd-backed memory allocations


### PR DESCRIPTION
Unfortunately there is no way on NVIDIA GPUs after driver 470 to schedule work on two queues with dependency without going through a vkQueueSubmit. This is because queue priority is not observed and attempting to park one queue with a vkEvent and signal based on completion of another task on another queue leads to deadlock. It seems the queue is not unscheduled when reaching a sync point and other queues do not actually run concurrently. This is true for all card generations since this new driver released. Unfortunately going through vkQueueSubmit is horrendously slow. A fallback path will be experimented with later on, although given the submit overhead, it may not really end up amounting to much in terms of tangible performance benefits. Simply removing the feature on affected cards makes more sense right now while other more severe problems take precedent.

Fixes https://github.com/RPCS3/rpcs3/issues/10486