### PR TITLE
Qt: Add option to automatically update RPCS3

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -111,6 +111,11 @@ namespace gui
 	const QString patches      = "Patches";
 	const QString localization = "Localization";
 	const QString pad_settings = "PadSettings";
+	
+	const QString update_on   = "true";
+	const QString update_off  = "false";
+	const QString update_auto = "auto";
+	const QString update_bkg  = "background";
 
 	const QColor gl_icon_color = QColor(240, 240, 240, 255);
 
@@ -197,7 +202,7 @@ namespace gui
 	const gui_save m_enableUIColors    = gui_save(meta, "enableUIColors",    false);
 	const gui_save m_richPresence      = gui_save(meta, "useRichPresence",   true);
 	const gui_save m_discordState      = gui_save(meta, "discordState",      "");
-	const gui_save m_check_upd_start   = gui_save(meta, "checkUpdateStart",  true);
+	const gui_save m_check_upd_start   = gui_save(meta, "checkUpdateStart",  update_on);
 
 	const gui_save gs_disableMouse      = gui_save(gs_frame, "disableMouse",          false);
 	const gui_save gs_disableKbHotkeys  = gui_save(gs_frame, "disableKbHotkeys",      false);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -196,7 +196,7 @@ bool main_window::Init(bool with_cli_boot)
 	QAction *download_action = new QAction(tr("Download Update"), download_menu);
 	connect(download_action, &QAction::triggered, this, [this]
 	{
-		m_updater.update();
+		m_updater.update(false);
 	});
 
 	download_menu->addAction(download_action);
@@ -229,10 +229,11 @@ bool main_window::Init(bool with_cli_boot)
 	});
 
 #if defined(_WIN32) || defined(__linux__)
-	if (const auto update_value = m_gui_settings->GetValue(gui::m_check_upd_start).toString(); update_value != "false")
+	if (const auto update_value = m_gui_settings->GetValue(gui::m_check_upd_start).toString(); update_value != gui::update_off)
 	{
-		const bool in_background = with_cli_boot || update_value != "true";
-		m_updater.check_for_updates(true, in_background, this);
+		const bool in_background = with_cli_boot || update_value == gui::update_bkg;
+		const bool auto_accept   = !in_background && update_value == gui::update_auto;
+		m_updater.check_for_updates(true, in_background, auto_accept, this);
 	}
 #endif
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1595,13 +1595,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->cb_show_pup_install->setChecked(m_gui_settings->GetValue(gui::ib_pup_success).toBool());
 		ui->cb_show_obsolete_cfg_dialog->setChecked(m_gui_settings->GetValue(gui::ib_obsolete_cfg).toBool());
 
-		const QString updates_yes        = tr("Yes", "Updates");
-		const QString updates_background = tr("Background", "Updates");
-		const QString updates_no         = tr("No", "Updates");
-
-		ui->combo_updates->addItem(updates_yes, "true");
-		ui->combo_updates->addItem(updates_background, "background");
-		ui->combo_updates->addItem(updates_no, "false");
+		ui->combo_updates->addItem(tr("Yes", "Updates"), gui::update_on);
+		ui->combo_updates->addItem(tr("Background", "Updates"), gui::update_bkg);
+		ui->combo_updates->addItem(tr("Automatic", "Updates"), gui::update_auto);
+		ui->combo_updates->addItem(tr("No", "Updates"), gui::update_off);
 		ui->combo_updates->setCurrentIndex(ui->combo_updates->findData(m_gui_settings->GetValue(gui::m_check_upd_start).toString()));
 		connect(ui->combo_updates, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index)
 		{

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -178,7 +178,7 @@ public:
 		const QString show_pkg_install   = tr("Shows a dialog when packages were installed successfully.");
 		const QString show_pup_install   = tr("Shows a dialog when firmware was installed successfully.");
 		const QString show_obsolete_cfg  = tr("Shows a dialog when obsolete settings were found.");
-		const QString check_update_start = tr("Checks if an update is available on startup and asks if you want to update.\nIf \"Background\" is selected, the check is done silently in the background and a new download option is shown in the top right corner of the menu if a new version was found.");
+		const QString check_update_start = tr("Checks if an update is available on startup and asks if you want to update.\nIf \"Automatic\" is selected, the update will run automatically without user confirmation.\nIf \"Background\" is selected, the check is done silently in the background and a new download option is shown in the top right corner of the menu if a new version was found.");
 		const QString use_rich_presence  = tr("Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to completely close the connection.");
 		const QString discord_state      = tr("Tell your friends what you are doing.");
 		const QString custom_colors      = tr("Prioritize custom user interface colors over properties set in stylesheet.");

--- a/rpcs3/rpcs3qt/update_manager.h
+++ b/rpcs3/rpcs3qt/update_manager.h
@@ -23,13 +23,13 @@ private:
 	std::string m_expected_hash;
 	u64 m_expected_size = 0;
 
-	bool handle_json(bool automatic, bool check_only, const QByteArray& data);
-	bool handle_rpcs3(const QByteArray& data);
+	bool handle_json(bool automatic, bool check_only, bool auto_accept, const QByteArray& data);
+	bool handle_rpcs3(const QByteArray& data, bool auto_accept);
 
 public:
 	update_manager() = default;
-	void check_for_updates(bool automatic, bool check_only, QWidget* parent = nullptr);
-	void update();
+	void check_for_updates(bool automatic, bool check_only, bool auto_accept, QWidget* parent = nullptr);
+	void update(bool auto_accept);
 
 Q_SIGNALS:
 	void signal_update_available(bool update_available);

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -115,8 +115,8 @@ namespace utils
 		}
 
 		// Abort if there is no natching stream or if the stream isn't the first one
-		if (av_media_type == AVMEDIA_TYPE_AUDIO && audio_stream_index != 0 ||
-			av_media_type == AVMEDIA_TYPE_VIDEO && video_stream_index != 0)
+		if ((av_media_type == AVMEDIA_TYPE_AUDIO && audio_stream_index != 0) ||
+			(av_media_type == AVMEDIA_TYPE_VIDEO && video_stream_index != 0))
 		{
 			// Failed to find a stream
 			avformat_close_input(&av_format_ctx);


### PR DESCRIPTION
- Add option "Automatic" to automatically update RPCS3
- Doesn't ask for user confirmation on startup
- Does still ask for confirmation if you click the update button manually
- Does still show the progress bar which can still be aborted
- Does not happen if you boot a game from the command line