### PR TITLE
rsx/vk: Video memory manager improvements [2]

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -164,14 +164,18 @@ namespace vk
 			const auto mem_info = get_current_renderer()->get_memory_mapping();
 			const auto local_memory_usage = vmm_get_application_memory_usage(mem_info.device_local);
 
-			constexpr u64 _1GB = (1024 * 0x100000);
-			if (local_memory_usage < (mem_info.device_local_total_bytes / 2) ||    // Less than 50% VRAM usage OR
-				(mem_info.device_local_total_bytes - local_memory_usage) > _1GB)   // More than 1GiB of unallocated memory
+			constexpr u64 _1M = 0x100000;
+			const auto res_scale = rsx::get_resolution_scale();
+			const auto mem_threshold_1 = static_cast<u64>(256 * res_scale * res_scale) * _1M;
+			const auto mem_threshold_2 = static_cast<u64>(64 * res_scale * res_scale) * _1M;
+
+			if (local_memory_usage < (mem_info.device_local_total_bytes / 2) ||                   // Less than 50% VRAM usage OR
+				(mem_info.device_local_total_bytes - local_memory_usage) > mem_threshold_1)       // Enough to hold all required resources left
 			{
 				// Lower severity to avoid slowing performance too much
 				load_severity = rsx::problem_severity::low;
 			}
-			else if ((mem_info.device_local_total_bytes - local_memory_usage) > 512 * 0x100000)
+			else if ((mem_info.device_local_total_bytes - local_memory_usage) > mem_threshold_2)  // Enough to hold basic resources like textures, buffers, etc
 			{
 				// At least 512MB left, do not overreact
 				load_severity = rsx::problem_severity::moderate;

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -109,9 +109,21 @@ namespace vk
 		g_last_completed_event = 0;
 	}
 
-	u64 vmm_get_application_memory_usage(u32 memory_type)
+	u64 vmm_get_application_memory_usage(const memory_type_info& memory_type)
 	{
-		return g_vmm_stats.memory_usage[memory_type];
+		u64 result = 0;
+		for (const auto& memory_type_index : memory_type)
+		{
+			auto it = g_vmm_stats.memory_usage.find(memory_type_index);
+			if (it == g_vmm_stats.memory_usage.end())
+			{
+				continue;
+			}
+
+			result += it->second.observe();
+		}
+
+		return result;
 	}
 
 	u64 vmm_get_application_pool_usage(vmm_allocation_pool pool)

--- a/rpcs3/Emu/RSX/VK/vkutils/buffer_object.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/buffer_object.h
@@ -29,7 +29,7 @@ namespace vk
 		VkBufferCreateInfo info = {};
 		std::unique_ptr<vk::memory_block> memory;
 
-		buffer(const vk::render_device& dev, u64 size, u32 memory_type_index, u32 access_flags, VkBufferUsageFlags usage, VkBufferCreateFlags flags, vmm_allocation_pool allocation_pool);
+		buffer(const vk::render_device& dev, u64 size, const memory_type_info& memory_type, u32 access_flags, VkBufferUsageFlags usage, VkBufferCreateFlags flags, vmm_allocation_pool allocation_pool);
 		buffer(const vk::render_device& dev, VkBufferUsageFlags usage, void* host_pointer, u64 size);
 		~buffer();
 

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -28,8 +28,8 @@ namespace vk
 
 	struct memory_type_mapping
 	{
-		u32 host_visible_coherent;
-		u32 device_local;
+		memory_type_info host_visible_coherent;
+		memory_type_info device_local;
 
 		u64 device_local_total_bytes;
 		u64 host_visible_total_bytes;

--- a/rpcs3/Emu/RSX/VK/vkutils/image.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.h
@@ -37,7 +37,7 @@ namespace vk
 
 	protected:
 		image() = default;
-		void create_impl(const vk::render_device& dev, u32 access_flags, u32 memory_type_index, vmm_allocation_pool allocation_pool);
+		void create_impl(const vk::render_device& dev, u32 access_flags, const memory_type_info& memory_type, vmm_allocation_pool allocation_pool);
 
 	public:
 		VkImage value = VK_NULL_HANDLE;
@@ -48,7 +48,7 @@ namespace vk
 		std::shared_ptr<vk::memory_block> memory;
 
 		image(const vk::render_device& dev,
-			u32 memory_type_index,
+			const memory_type_info& memory_type,
 			u32 access_flags,
 			VkImageType image_type,
 			VkFormat format,

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -23,10 +23,10 @@ namespace vk
 
 	using namespace vk::vmm_allocation_pool_;
 
+	class render_device;
 	class memory_type_info
 	{
-		std::array<u32, 4> pools;
-		u32 num_entries = 0;
+		std::vector<u32> type_ids;
 
 	public:
 		memory_type_info() = default;
@@ -37,8 +37,11 @@ namespace vk
 		using const_iterator = const u32*;
 		const_iterator begin() const;
 		const_iterator end() const;
+		u32 first() const;
 
 		operator bool() const;
+
+		memory_type_info get(const render_device& dev, u32 access_flags, u32 type_mask) const;
 	};
 
 	class mem_allocator_base
@@ -121,7 +124,7 @@ namespace vk
 
 	struct memory_block
 	{
-		memory_block(VkDevice dev, u64 block_sz, u64 alignment, u32 memory_type_index, vmm_allocation_pool pool);
+		memory_block(VkDevice dev, u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool);
 		virtual ~memory_block();
 
 		virtual VkDeviceMemory get_vk_device_memory();
@@ -147,7 +150,7 @@ namespace vk
 
 	struct memory_block_host : public memory_block
 	{
-		memory_block_host(VkDevice dev, void* host_pointer, u64 size, u32 memory_type_index);
+		memory_block_host(VkDevice dev, void* host_pointer, u64 size, const memory_type_info& memory_type);
 		~memory_block_host();
 
 		VkDeviceMemory get_vk_device_memory() override;

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -23,6 +23,24 @@ namespace vk
 
 	using namespace vk::vmm_allocation_pool_;
 
+	class memory_type_info
+	{
+		std::array<u32, 4> pools;
+		u32 num_entries = 0;
+
+	public:
+		memory_type_info() = default;
+		memory_type_info(u32 index);
+		void push(u32 index);
+
+		using iterator = u32*;
+		using const_iterator = const u32*;
+		const_iterator begin() const;
+		const_iterator end() const;
+
+		operator bool() const;
+	};
+
 	class mem_allocator_base
 	{
 	public:
@@ -33,7 +51,7 @@ namespace vk
 
 		virtual void destroy() = 0;
 
-		virtual mem_handle_t alloc(u64 block_sz, u64 alignment, u32 memory_type_index, vmm_allocation_pool pool) = 0;
+		virtual mem_handle_t alloc(u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool) = 0;
 		virtual void free(mem_handle_t mem_handle) = 0;
 		virtual void* map(mem_handle_t mem_handle, u64 offset, u64 size) = 0;
 		virtual void unmap(mem_handle_t mem_handle) = 0;
@@ -61,7 +79,7 @@ namespace vk
 
 		void destroy() override;
 
-		mem_handle_t alloc(u64 block_sz, u64 alignment, u32 memory_type_index, vmm_allocation_pool pool) override;
+		mem_handle_t alloc(u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool) override;
 
 		void free(mem_handle_t mem_handle) override;
 		void* map(mem_handle_t mem_handle, u64 offset, u64 /*size*/) override;
@@ -90,7 +108,7 @@ namespace vk
 
 		void destroy() override {}
 
-		mem_handle_t alloc(u64 block_sz, u64 /*alignment*/, u32 memory_type_index, vmm_allocation_pool pool) override;
+		mem_handle_t alloc(u64 block_sz, u64 /*alignment*/, const memory_type_info& memory_type, vmm_allocation_pool pool) override;
 
 		void free(mem_handle_t mem_handle) override;
 		void* map(mem_handle_t mem_handle, u64 offset, u64 size) override;
@@ -151,7 +169,7 @@ namespace vk
 	void vmm_notify_memory_freed(void* handle);
 	void vmm_reset();
 	void vmm_check_memory_usage();
-	u64  vmm_get_application_memory_usage(u32 memory_type);
+	u64  vmm_get_application_memory_usage(const memory_type_info& memory_type);
 	u64  vmm_get_application_pool_usage(vmm_allocation_pool pool);
 	bool vmm_handle_memory_pressure(rsx::problem_severity severity);
 	rsx::problem_severity vmm_determine_memory_load_severity();

--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
@@ -156,7 +156,7 @@ namespace vk
 		if (!scratch_buffer)
 		{
 			// Choose optimal size
-			const u64 alloc_size = std::max<u64>(64 * 0x100000, utils::align(min_required_size, 0x100000));
+			const u64 alloc_size = utils::align(min_required_size, 0x100000);
 
 			scratch_buffer = std::make_unique<vk::buffer>(*g_render_device, alloc_size,
 				g_render_device->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,


### PR DESCRIPTION
Improves the video memory manager a bit more:
1. Pool similar memory types into one virtual type. Video memory budget checks do not properly respect this behaviour due to how the vma code works, but I decided to handle it separately in another PR.
2. Tries to be smart about the action boundaries by taking resolution scale into account. It is no secret that higher resolutions require more memory and therefore the boundaries need to be moved around a bit.
3. Do not waste memory when building scratch resources. This is to cater to devices where the amount of video memory may be low. In most games, we do not need more than 4MB of scratch anyway.
4. Fix some crashes caused by use-after-free in texture cache code.

This improves stability of the memory manager while under pressure. There still remains some other crashes, but they are not silly application bugs anymore. You're now more likely to hit a designed failure (i.e verification failed) instead of emulator closing without error which usually is a sign we're doing something illegal in the code (such as use-after-free).

Improves https://github.com/RPCS3/rpcs3/issues/10568