### PR TITLE
FW installer: Fix firmware downgrading/upgrading/repair

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1103,7 +1103,7 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 	{
 		gui_log.warning("Reinstalling firmware: old=%s, new=%s", installed, version_string);
 
-		if (QMessageBox::question(this, tr("RPCS3 Firmware Installer"), tr("Firmware of version %1 has already been installed.\nOverwrite current installation with version %2?").arg(qstr(installed), qstr(version_string)),
+		if (QMessageBox::question(this, tr("RPCS3 Firmware Installer"), tr("Firmware of version %1 has already been installed.\nOverwrite current installation with version %2?\nNote that this will empty its directory first!").arg(qstr(installed), qstr(version_string)),
 			QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No)
 		{
 			gui_log.warning("Reinstallation of firmware aborted.");

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1120,6 +1120,9 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 	// Used by tar_object::extract() as destination directory
 	vfs::mount("/dev_flash", g_cfg.vfs.get_dev_flash());
 
+	// Empty directory for clean installation
+	fs::remove_all(g_cfg.vfs.get_dev_flash(), false);
+
 	// Synchronization variable
 	atomic_t<uint> progress(0);
 	{


### PR DESCRIPTION
Empty directory before installing firmware, this ensures accurate firmware representation.
This fixes firmware in case there are unexpected previous files in there preventing correct behaviour by the PS3 application, such as from newer or older firmware or simply put in an accident by the user.