### PR TITLE
vk: Video memory management improvements [3]

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -656,6 +656,7 @@ namespace rsx
 			// If this method was called, there is no easy solution, likely means atlas gather is needed
 			const auto [scaled_w, scaled_h] = rsx::apply_resolution_scale(attr2.width, attr2.height);
 			const auto format_class = classify_format(attr2.gcm_format);
+			const auto upload_context = (fbos.empty()) ? texture_upload_context::shader_read : texture_upload_context::framebuffer_storage;
 
 			if (extended_dimension == rsx::texture_dimension_extended::texture_dimension_cubemap)
 			{
@@ -665,7 +666,7 @@ namespace rsx
 
 				sampled_image_descriptor desc = { nullptr, deferred_request_command::cubemap_gather,
 						attr2, {},
-						texture_upload_context::framebuffer_storage, format_class, scale,
+						upload_context, format_class, scale,
 						rsx::texture_dimension_extended::texture_dimension_cubemap, decoded_remap };
 
 				gather_texture_slices(desc.external_subresource_desc.sections_to_copy, fbos, local, attr, 6, is_depth);
@@ -678,7 +679,7 @@ namespace rsx
 
 				sampled_image_descriptor desc = { nullptr, deferred_request_command::_3d_gather,
 					attr2, {},
-					texture_upload_context::framebuffer_storage, format_class, scale,
+					upload_context, format_class, scale,
 					rsx::texture_dimension_extended::texture_dimension_3d, decoded_remap };
 
 				gather_texture_slices(desc.external_subresource_desc.sections_to_copy, fbos, local, attr, attr.depth, is_depth);
@@ -697,7 +698,7 @@ namespace rsx
 			}
 
 			sampled_image_descriptor result = { nullptr, deferred_request_command::atlas_gather,
-					attr2, {}, texture_upload_context::framebuffer_storage, format_class,
+					attr2, {}, upload_context, format_class,
 					scale, rsx::texture_dimension_extended::texture_dimension_2d, decoded_remap };
 
 			gather_texture_slices(result.external_subresource_desc.sections_to_copy, fbos, local, attr, 1, is_depth);

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -157,6 +157,7 @@ void VKGSRender::load_texture_env()
 		return false;
 	};
 
+	vk::clear_status_interrupt(vk::out_of_memory);
 	std::lock_guard lock(m_sampler_mutex);
 
 	for (u32 textures_ref = current_fp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
@@ -382,7 +383,10 @@ void VKGSRender::bind_texture_env()
 			if (view = sampler_state->image_handle; !view)
 			{
 				//Requires update, copy subresource
-				view = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
+				if (!(view = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc)))
+				{
+					vk::raise_status_interrupt(vk::out_of_memory);
+				}
 			}
 			else
 			{
@@ -509,8 +513,10 @@ void VKGSRender::bind_texture_env()
 
 		if (!image_ptr && sampler_state->validate())
 		{
-			image_ptr = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
-			m_vertex_textures_dirty[i] = true;
+			if (!(image_ptr = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc)))
+			{
+				vk::raise_status_interrupt(vk::out_of_memory);
+			}
 		}
 
 		if (!image_ptr)
@@ -630,7 +636,10 @@ void VKGSRender::bind_interpreter_texture_env()
 			if (view = sampler_state->image_handle; !view)
 			{
 				//Requires update, copy subresource
-				view = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc);
+				if (!(view = m_texture_cache.create_temporary_subresource(*m_current_command_buffer, sampler_state->external_subresource_desc)))
+				{
+					vk::raise_status_interrupt(vk::out_of_memory);
+				}
 			}
 			else
 			{
@@ -975,13 +984,40 @@ void VKGSRender::end()
 		ev->gpu_wait(*m_current_command_buffer);
 	}
 
-	if (!m_shader_interpreter.is_interpreter(m_program)) [[likely]]
+	int binding_attempts = 0;
+	while (binding_attempts++ < 3)
 	{
-		bind_texture_env();
-	}
-	else
-	{
-		bind_interpreter_texture_env();
+		if (!m_shader_interpreter.is_interpreter(m_program)) [[likely]]
+		{
+			bind_texture_env();
+		}
+		else
+		{
+			bind_interpreter_texture_env();
+		}
+
+		// TODO: Replace OOO tracking with ref-counting to simplify the logic
+		if (!vk::test_status_interrupt(vk::out_of_memory))
+		{
+			break;
+		}
+
+		if (!on_vram_exhausted(rsx::problem_severity::fatal))
+		{
+			// It is not possible to free memory. Just use placeholder textures. Can cause graphics glitches but shouldn't crash otherwise
+			break;
+		}
+
+		if (m_samplers_dirty)
+		{
+			// Reload texture env if referenced objects were invalidated during OOO handling.
+			load_texture_env();
+		}
+		else
+		{
+			// Nothing to reload, only texture cache references held. Simply attempt to bind again.
+			vk::clear_status_interrupt(vk::out_of_memory);
+		}
 	}
 
 	m_texture_cache.release_uncached_temporary_subresources();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1955,7 +1955,7 @@ void VKGSRender::load_program_env()
 
 	if (vk::emulate_conditional_rendering())
 	{
-		auto predicate = m_cond_render_buffer ? m_cond_render_buffer->value : vk::get_scratch_buffer()->value;
+		auto predicate = m_cond_render_buffer ? m_cond_render_buffer->value : vk::get_scratch_buffer(4)->value;
 		m_program->bind_buffer({ predicate, 0, 4 }, binding_table.conditional_render_predicate_slot, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_current_frame->descriptor_set);
 	}
 
@@ -2558,7 +2558,7 @@ void VKGSRender::begin_conditional_rendering(const std::vector<rsx::reports::occ
 		}
 	}
 
-	auto scratch = vk::get_scratch_buffer();
+	auto scratch = vk::get_scratch_buffer(OCCLUSION_MAX_POOL_SIZE * 4);
 	u32 dst_offset = 0;
 	usz first = 0;
 	usz last;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -38,7 +38,8 @@ namespace vk
 	{
 		uninterruptible = 1,
 		heap_dirty = 2,
-		heap_changed = 3
+		heap_changed = 3,
+		out_of_memory = 4
 	};
 
 	const vk::render_device *get_current_renderer();

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -109,6 +109,7 @@ void VKGSRender::advance_queued_frames()
 	check_present_status();
 
 	// Run video memory balancer
+	m_device->rebalance_memory_type_usage();
 	vk::vmm_check_memory_usage();
 
 	// m_rtts storage is double buffered and should be safe to tag on frame boundary

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -968,7 +968,9 @@ namespace vk
 			{
 				if (!scratch_buf)
 				{
-					scratch_buf = vk::get_scratch_buffer(image_linear_size * 2);
+					// Calculate enough scratch memory. We need 2x the size of layer 0 to fit all the mip levels and an extra 128 bytes per level as alignment overhead.
+					const auto scratch_buf_size = 128u * ::size32(subresource_layout) + image_linear_size + image_linear_size;
+					scratch_buf = vk::get_scratch_buffer(scratch_buf_size);
 					buffer_copies.reserve(subresource_layout.size());
 				}
 

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -544,7 +544,7 @@ namespace vk
 					const auto dst_w = dst_rect.width();
 					const auto dst_h = dst_rect.height();
 
-					auto scratch_buf = vk::get_scratch_buffer();
+					auto scratch_buf = vk::get_scratch_buffer(std::max(src_w, dst_w) * std::max(src_h, dst_h) * 4);
 
 					//1. Copy unscaled to typeless surface
 					VkBufferImageCopy info{};

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -505,8 +505,14 @@ namespace vk
 				image_type,
 				dst_format,
 				w, h, d, mips, layers, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, image_flags,
+				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, image_flags | VK_IMAGE_CREATE_ALLOW_NULL,
 				VMM_ALLOCATION_POOL_TEXTURE_CACHE, rsx::classify_format(gcm_format));
+
+			if (!image->value)
+			{
+				// OOM, bail
+				return nullptr;
+			}
 		}
 
 		// This method is almost exclusively used to work on framebuffer resources
@@ -572,6 +578,12 @@ namespace vk
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
 			VK_IMAGE_VIEW_TYPE_CUBE, gcm_format, 0, 0, size, size, 1, 1, remap_vector, false);
 
+		if (!result)
+		{
+			// Failed to create temporary object, bail
+			return nullptr;
+		}
+
 		const auto image = result->image();
 		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
 		VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 6 };
@@ -600,6 +612,12 @@ namespace vk
 		auto _template = get_template_from_collection_impl(sections_to_copy);
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_3D,
 			VK_IMAGE_VIEW_TYPE_3D, gcm_format, 0, 0, width, height, depth, 1, remap_vector, false);
+
+		if (!result)
+		{
+			// Failed to create temporary object, bail
+			return nullptr;
+		}
 
 		const auto image = result->image();
 		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
@@ -630,6 +648,12 @@ namespace vk
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
 			VK_IMAGE_VIEW_TYPE_2D, gcm_format, 0, 0, width, height, 1, 1, remap_vector, false);
 
+		if (!result)
+		{
+			// Failed to create temporary object, bail
+			return nullptr;
+		}
+
 		const auto image = result->image();
 		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
 		VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 1 };
@@ -659,6 +683,12 @@ namespace vk
 		auto _template = get_template_from_collection_impl(sections_to_copy);
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
 			VK_IMAGE_VIEW_TYPE_2D, gcm_format, 0, 0, width, height, 1, mipmaps, remap_vector, false);
+
+		if (!result)
+		{
+			// Failed to create temporary object, bail
+			return nullptr;
+		}
 
 		const auto image = result->image();
 		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -637,6 +637,12 @@ namespace vk
 		return dev;
 	}
 
+	void render_device::rebalance_memory_type_usage()
+	{
+		// Rebalance device local memory types
+		memory_map.device_local.rebalance();
+	}
+
 	// Shared Util
 	memory_type_mapping get_memory_mapping(const vk::physical_device& dev)
 	{
@@ -657,7 +663,7 @@ namespace vk
 			if (is_device_local)
 			{
 				// Allow multiple device_local heaps
-				result.device_local.push(i);
+				result.device_local.push(i, heap.size);
 				result.device_local_total_bytes += heap.size;
 			}
 
@@ -670,7 +676,7 @@ namespace vk
 				if ((is_cached && !host_visible_cached) || (result.host_visible_total_bytes < heap.size))
 				{
 					// Allow only a single host_visible heap. It makes no sense to have multiple of these otherwise
-					result.host_visible_coherent = i;
+					result.host_visible_coherent = { i, heap.size };
 					result.host_visible_total_bytes = heap.size;
 					host_visible_cached = is_cached;
 				}

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -120,6 +120,7 @@ namespace vk
 		const VkFormatProperties get_format_properties(VkFormat format);
 
 		bool get_compatible_memory_type(u32 typeBits, u32 desired_mask, u32* type_index) const;
+		void rebalance_memory_type_usage();
 
 		const physical_device& gpu() const;
 		const memory_type_mapping& get_memory_mapping() const;

--- a/rpcs3/Emu/RSX/VK/vkutils/image.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.h
@@ -23,7 +23,8 @@ namespace vk
 	enum : u32// special remap_encoding enums
 	{
 		VK_REMAP_IDENTITY = 0xCAFEBABE,             // Special view encoding to return an identity image view
-		VK_REMAP_VIEW_MULTISAMPLED = 0xDEADBEEF     // Special encoding for multisampled images; returns a multisampled image view
+		VK_REMAP_VIEW_MULTISAMPLED = 0xDEADBEEF,    // Special encoding for multisampled images; returns a multisampled image view
+		VK_IMAGE_CREATE_ALLOW_NULL = 0x80000000,    // Special flag that allows null images to be created if there is no memory
 	};
 
 	class image

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
@@ -49,6 +49,32 @@ namespace vk
 		return !type_ids.empty();
 	}
 
+	bool memory_type_info::operator == (const memory_type_info& other) const
+	{
+		if (type_ids.size() != other.type_ids.size())
+		{
+			return false;
+		}
+
+		switch (type_ids.size())
+		{
+		case 1:
+			return type_ids[0] == other.type_ids[0];
+		case 2:
+			return ((type_ids[0] == other.type_ids[0] && type_ids[1] == other.type_ids[1]) ||
+					(type_ids[0] == other.type_ids[1] && type_ids[1] == other.type_ids[0]));
+		default:
+			for (const auto& id : other.type_ids)
+			{
+				if (std::find(type_ids.begin(), type_ids.end(), id) == type_ids.end())
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+
 	memory_type_info memory_type_info::get(const render_device& dev, u32 access_flags, u32 type_mask) const
 	{
 		memory_type_info result{};

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -58,7 +58,7 @@ namespace vk
 
 		virtual void destroy() = 0;
 
-		virtual mem_handle_t alloc(u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool) = 0;
+		virtual mem_handle_t alloc(u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool, bool throw_on_fail) = 0;
 		virtual void free(mem_handle_t mem_handle) = 0;
 		virtual void* map(mem_handle_t mem_handle, u64 offset, u64 size) = 0;
 		virtual void unmap(mem_handle_t mem_handle) = 0;
@@ -86,7 +86,7 @@ namespace vk
 
 		void destroy() override;
 
-		mem_handle_t alloc(u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool) override;
+		mem_handle_t alloc(u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool, bool throw_on_fail) override;
 
 		void free(mem_handle_t mem_handle) override;
 		void* map(mem_handle_t mem_handle, u64 offset, u64 /*size*/) override;
@@ -115,7 +115,7 @@ namespace vk
 
 		void destroy() override {}
 
-		mem_handle_t alloc(u64 block_sz, u64 /*alignment*/, const memory_type_info& memory_type, vmm_allocation_pool pool) override;
+		mem_handle_t alloc(u64 block_sz, u64 /*alignment*/, const memory_type_info& memory_type, vmm_allocation_pool pool, bool throw_on_fail) override;
 
 		void free(mem_handle_t mem_handle) override;
 		void* map(mem_handle_t mem_handle, u64 offset, u64 size) override;
@@ -128,7 +128,7 @@ namespace vk
 
 	struct memory_block
 	{
-		memory_block(VkDevice dev, u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool);
+		memory_block(VkDevice dev, u64 block_sz, u64 alignment, const memory_type_info& memory_type, vmm_allocation_pool pool, bool nullable = false);
 		virtual ~memory_block();
 
 		virtual VkDeviceMemory get_vk_device_memory();

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -27,21 +27,25 @@ namespace vk
 	class memory_type_info
 	{
 		std::vector<u32> type_ids;
+		std::vector<u64> type_sizes;
 
 	public:
 		memory_type_info() = default;
-		memory_type_info(u32 index);
-		void push(u32 index);
+		memory_type_info(u32 index, u64 size);
+		void push(u32 index, u64 size);
 
 		using iterator = u32*;
 		using const_iterator = const u32*;
 		const_iterator begin() const;
 		const_iterator end() const;
 		u32 first() const;
+		size_t count() const;
 
 		operator bool() const;
 
 		memory_type_info get(const render_device& dev, u32 access_flags, u32 type_mask) const;
+
+		void rebalance();
 	};
 
 	class mem_allocator_base

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -42,6 +42,7 @@ namespace vk
 		size_t count() const;
 
 		operator bool() const;
+		bool operator == (const memory_type_info& other) const;
 
 		memory_type_info get(const render_device& dev, u32 access_flags, u32 type_mask) const;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
@@ -129,7 +129,8 @@ namespace vk
 
 			return new vk::image(*g_render_device, g_render_device->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 				VK_IMAGE_TYPE_2D, format, new_width, new_height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, 0, VMM_ALLOCATION_POOL_SCRATCH);
+				VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, 0, VMM_ALLOCATION_POOL_SCRATCH,
+				format_class);
 		};
 
 		const u32 key = (format_class << 24u) | format;

--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
@@ -97,7 +97,14 @@ namespace vk
 		auto& tex = g_null_image_views[type];
 		tex = std::make_unique<viewable_image>(*g_render_device, g_render_device->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 			image_type, VK_FORMAT_B8G8R8A8_UNORM, size, size, 1, 1, num_layers, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, flags, VMM_ALLOCATION_POOL_SCRATCH);
+			VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, flags | VK_IMAGE_CREATE_ALLOW_NULL, VMM_ALLOCATION_POOL_SCRATCH);
+
+		if (!tex->value)
+		{
+			// If we cannot create a 1x1 placeholder, things are truly hopeless.
+			// The null view is 'nullable' because it is meant for use in emergency situations and we do not wish to invalidate any handles.
+			fmt::throw_exception("Renderer is out of memory. We could not even squeeze in a 1x1 texture, things are bad.");
+		}
 
 		// Initialize memory to transparent black
 		tex->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);

--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.h
@@ -6,7 +6,7 @@ namespace vk
 	VkSampler null_sampler();
 	image_view* null_image_view(command_buffer&, VkImageViewType type);
 	image* get_typeless_helper(VkFormat format, rsx::format_class format_class, u32 requested_width, u32 requested_height);
-	buffer* get_scratch_buffer(u32 min_required_size = 0);
+	buffer* get_scratch_buffer(u32 min_required_size);
 
 	void clear_scratch_resources();
 }


### PR DESCRIPTION
Implements several critical fixes to the video memory manager which is partly broken:
- Avoids running into budget constraints by spreading out memory allocations within pooled types.
- Allows creating 'null' textures which can signal that we could not create something due to running out of memory.
- Fix out of bounds access for scratch buffers after the last PR (VMM improvements 2)
- Properly initialize scratch images with correct format class. Fixes some error spam.
- Fixes a bug with memory type comparison that caused memory spilling to not work at all since the last PR (VMM improvements 2)
- Gracefully handle OOM situations which occur during texture binding. If we cannot create the texture, do not invoke spilling or any destructive restructuring of the surface cache. Instead, handle this just before rendering to avoid modifying a working set and optionally provide fallback to use 1x1 placeholder textures.

With these fixes, the memory manager finally behaves as it was designed during internal development. It is possible to use system memory as VRAM until the driver's shared memory is reached. This approach is also much more robust even with constraints such as MSAA as it is not always critical to handle every single OOM interrupt with fatal severity.

Fixes https://github.com/RPCS3/rpcs3/issues/10568
Fixes https://github.com/RPCS3/rpcs3/issues/10612