### PR TITLE
Qt/System: VSH fixes

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -31,8 +31,6 @@ extern std::string ppu_get_function_name(const std::string& _module, u32 fnid);
 extern std::string ppu_get_variable_name(const std::string& _module, u32 vnid);
 extern void ppu_register_range(u32 addr, u32 size);
 extern void ppu_register_function_at(u32 addr, u32 size, ppu_function_t ptr);
-extern bool ppu_initialize(const ppu_module& info, bool = false);
-extern void ppu_initialize();
 
 extern void sys_initialize_tls(ppu_thread&, u64, u32, u32, u32);
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -799,23 +799,17 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			return game_boot_result::no_errors;
 		}
 
-		// Check if path is inside the specified directory
-		auto is_path_inside_path = [this](std::string_view path, std::string_view dir)
-		{
-			return (GetCallbacks().resolve_path(path) + '/').starts_with(GetCallbacks().resolve_path(dir) + '/');
-		};
-
 		// Detect boot location
 		constexpr usz game_dir_size = 8; // size of PS3_GAME and PS3_GMXX
 		const std::string hdd0_game = vfs::get("/dev_hdd0/game/");
 		const std::string hdd0_disc = vfs::get("/dev_hdd0/disc/");
-		const bool from_hdd0_game   = is_path_inside_path(m_path, hdd0_game);
-		const bool from_dev_flash   = is_path_inside_path(m_path, g_cfg.vfs.get_dev_flash());
+		const bool from_hdd0_game   = IsPathInsideDir(m_path, hdd0_game);
+		const bool from_dev_flash   = IsPathInsideDir(m_path, g_cfg.vfs.get_dev_flash());
 
 #ifdef _WIN32
 		// m_path might be passed from command line with differences in uppercase/lowercase on windows.
-		if ((!from_hdd0_game && is_path_inside_path(fmt::to_lower(m_path), fmt::to_lower(hdd0_game))) ||
-			(!from_dev_flash && is_path_inside_path(fmt::to_lower(m_path), fmt::to_lower(g_cfg.vfs.get_dev_flash()))))
+		if ((!from_hdd0_game && IsPathInsideDir(fmt::to_lower(m_path), fmt::to_lower(hdd0_game))) ||
+			(!from_dev_flash && IsPathInsideDir(fmt::to_lower(m_path), fmt::to_lower(g_cfg.vfs.get_dev_flash()))))
 		{
 			// Let's just abort to prevent errors down the line.
 			sys_log.error("The boot path seems to contain incorrectly cased characters. Please adjust the path and try again.");
@@ -1795,5 +1789,10 @@ std::set<std::string> Emulator::GetGameDirs() const
 
 	return dirs;
 }
+
+bool Emulator::IsPathInsideDir(std::string_view path, std::string_view dir) const
+{
+	return (GetCallbacks().resolve_path(path) + '/').starts_with(GetCallbacks().resolve_path(dir) + '/');
+};
 
 Emulator Emu;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -801,6 +801,8 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 
 				if (IsStopped())
 				{
+					m_path = m_path_old; // Reset m_path to fix boot from gui
+					GetCallbacks().on_stop(); // Call on_stop to refresh gui
 					return;
 				}
 
@@ -812,6 +814,9 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 					Emu.SetForceBoot(true);
 					Emu.Stop();
 				});
+
+				m_path = m_path_old; // Reset m_path to fix boot from gui
+				GetCallbacks().on_stop(); // Call on_stop to refresh gui
 			});
 
 			return game_boot_result::no_errors;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -246,6 +246,9 @@ public:
 	void ConfigurePPUCache() const;
 
 	std::set<std::string> GetGameDirs() const;
+
+	// Check if path is inside the specified directory
+	bool IsPathInsideDir(std::string_view path, std::string_view dir) const;
 };
 
 extern Emulator Emu;

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -12,6 +12,9 @@ atomic_t<u32> g_progr_fdone{0};
 atomic_t<u32> g_progr_ptotal{0};
 atomic_t<u32> g_progr_pdone{0};
 
+// For Batch PPU Compilation
+atomic_t<bool> g_system_progress_canceled{false};
+
 namespace rsx::overlays
 {
 	class progress_dialog : public message_dialog
@@ -43,6 +46,8 @@ void progress_dialog_server::operator()()
 		{
 			break;
 		}
+
+		g_system_progress_canceled = false;
 
 		// Initialize message dialog
 		bool skip_this_one = false; // Workaround: do not open a progress dialog if there is already a cell message dialog open.
@@ -82,6 +87,8 @@ void progress_dialog_server::operator()()
 					// Abort everything
 					Emu.Stop();
 				});
+
+				g_system_progress_canceled = true;
 			};
 
 			Emu.CallAfter([dlg, text0]()

--- a/rpcs3/Emu/system_progress.hpp
+++ b/rpcs3/Emu/system_progress.hpp
@@ -8,6 +8,7 @@ extern atomic_t<u32> g_progr_ftotal;
 extern atomic_t<u32> g_progr_fdone;
 extern atomic_t<u32> g_progr_ptotal;
 extern atomic_t<u32> g_progr_pdone;
+extern atomic_t<bool> g_system_progress_canceled;
 
 // Initialize progress dialog (can be recursive)
 class scoped_progress_dialog final

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1613,8 +1613,8 @@ bool game_list_frame::RemoveSPUCache(const std::string& base_dir, bool is_intera
 
 void game_list_frame::BatchCreatePPUCaches()
 {
-	const std::string vsh_path = g_cfg.vfs.get_dev_flash() + "vsh/module/vsh.self";
-	const bool vsh_exists = fs::is_file(vsh_path);
+	const std::string vsh_path = g_cfg.vfs.get_dev_flash() + "vsh/module/";
+	const bool vsh_exists = fs::is_file(vsh_path + "vsh.self");
 	const u32 total = m_game_data.size() + (vsh_exists ? 1 : 0);
 
 	if (total == 0)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1613,7 +1613,7 @@ bool game_list_frame::RemoveSPUCache(const std::string& base_dir, bool is_intera
 
 void game_list_frame::BatchCreatePPUCaches()
 {
-	const std::string vsh_path = g_cfg.vfs.get_dev_flash() + "/vsh/module/vsh.self";
+	const std::string vsh_path = g_cfg.vfs.get_dev_flash() + "vsh/module/vsh.self";
 	const bool vsh_exists = fs::is_file(vsh_path);
 	const u32 total = m_game_data.size() + (vsh_exists ? 1 : 0);
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -44,6 +44,8 @@
 LOG_CHANNEL(game_list_log, "GameList");
 LOG_CHANNEL(sys_log, "SYS");
 
+extern atomic_t<bool> g_system_progress_canceled;
+
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget* parent)
@@ -1664,7 +1666,7 @@ void game_list_frame::BatchCreatePPUCaches()
 
 	for (const auto& game : m_game_data)
 	{
-		if (pdlg->wasCanceled())
+		if (pdlg->wasCanceled() || g_system_progress_canceled)
 		{
 			break;
 		}
@@ -1678,7 +1680,7 @@ void game_list_frame::BatchCreatePPUCaches()
 		}
 	}
 
-	if (pdlg->wasCanceled())
+	if (pdlg->wasCanceled() || g_system_progress_canceled)
 	{
 		game_list_log.notice("PPU Cache Batch Creation was canceled");
 
@@ -1686,6 +1688,11 @@ void game_list_frame::BatchCreatePPUCaches()
 		{
 			QApplication::processEvents();
 			Emu.Stop();
+		}
+
+		if (!pdlg->wasCanceled())
+		{
+			pdlg->close();
 		}
 		return;
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -237,6 +237,9 @@ bool main_window::Init(bool with_cli_boot)
 	}
 #endif
 
+	// Disable vsh if not present.
+	ui->bootVSHAct->setEnabled(fs::is_file(g_cfg.vfs.get_dev_flash() + "vsh/module/vsh.self"));
+
 	return true;
 }
 
@@ -1198,6 +1201,8 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 
 	if (progress == update_filenames.size())
 	{
+		ui->bootVSHAct->setEnabled(fs::is_file(g_cfg.vfs.get_dev_flash() + "/vsh/module/vsh.self"));
+
 		gui_log.success("Successfully installed PS3 firmware version %s.", version_string);
 		m_gui_settings->ShowInfoBox(tr("Success!"), tr("Successfully installed PS3 firmware and LLE Modules!"), gui::ib_pup_success, this);
 
@@ -2059,7 +2064,8 @@ void main_window::CreateConnects()
 	{
 		vfs_dialog dlg(m_gui_settings, m_emu_settings, this);
 		dlg.exec();
-		m_game_list_frame->Refresh(true); // dev-hdd0 may have changed. Refresh just in case.
+		ui->bootVSHAct->setEnabled(fs::is_file(g_cfg.vfs.get_dev_flash() + "vsh/module/vsh.self")); // dev_flash may have changed. Disable vsh if not present.
+		m_game_list_frame->Refresh(true); // dev_hdd0 may have changed. Refresh just in case.
 	});
 
 	connect(ui->confSavedataManagerAct, &QAction::triggered, this, [this]

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2659,7 +2659,7 @@ void main_window::CreateFirmwareCache()
 
 	Emu.SetForceBoot(true);
 
-	if (const game_boot_result error = Emu.BootGame(g_cfg.vfs.get_dev_flash() + "sys/external/", "", true);
+	if (const game_boot_result error = Emu.BootGame(g_cfg.vfs.get_dev_flash() + "sys", "", true);
 		error != game_boot_result::no_errors)
 	{
 		gui_log.error("Creating firmware cache failed: reason: %s", error);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1566,7 +1566,7 @@ void main_window::OnEmuStop()
 
 	EnableMenus(false);
 
-	if (Emu.GetBoot().empty())
+	if (title.isEmpty())
 	{
 		ui->toolbar_start->setIcon(m_icon_play);
 		ui->toolbar_start->setText(tr("Play"));

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -101,14 +101,14 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 		connect(m_button_yes, &QAbstractButton::clicked, [this]()
 		{
 			g_last_user_response = CELL_MSGDIALOG_BUTTON_YES;
-			on_close(CELL_MSGDIALOG_BUTTON_YES);
+			if (on_close) on_close(CELL_MSGDIALOG_BUTTON_YES);
 			m_dialog->accept();
 		});
 
 		connect(m_button_no, &QAbstractButton::clicked, [this]()
 		{
 			g_last_user_response = CELL_MSGDIALOG_BUTTON_NO;
-			on_close(CELL_MSGDIALOG_BUTTON_NO);
+			if (on_close) on_close(CELL_MSGDIALOG_BUTTON_NO);
 			m_dialog->accept();
 		});
 	}
@@ -133,7 +133,7 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 		connect(m_button_ok, &QAbstractButton::clicked, [this]()
 		{
 			g_last_user_response = CELL_MSGDIALOG_BUTTON_OK;
-			on_close(CELL_MSGDIALOG_BUTTON_OK);
+			if (on_close) on_close(CELL_MSGDIALOG_BUTTON_OK);
 			m_dialog->accept();
 		});
 	}
@@ -145,7 +145,7 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 		if (!type.disable_cancel)
 		{
 			g_last_user_response = CELL_MSGDIALOG_BUTTON_ESCAPE;
-			on_close(CELL_MSGDIALOG_BUTTON_ESCAPE);
+			if (on_close) on_close(CELL_MSGDIALOG_BUTTON_ESCAPE);
 		}
 	});
 


### PR DESCRIPTION
GUI:
- Disable "Boot VSH/XMB" if there is no vsh.self.
- Batch PPU compilation: Adds current state as "Progress: x/y. Compiling PPU caches for BLUS12345...".
- Batch PPU compilation: Fixes VSH compilation. It was hilarously skipped cuz I forgot that the initial call is not blocking.
- Batch PPU compilation: Compile the entire vsh/module folder instead of only vsh.self.
- Batch PPU compilation: Also abort batch compilation if the top dialog is closed.
- Firmware compilation: Compile the entire sys folder instead of only sys/external

Boot process:
- Scanner/Compiler: Compile vsh.self first when scanning vsh/module
- Scanner/Compiler: Skip searching for games if the title ID is empty
- Scanner/Compiler: Reset boot path to m_path_old after compilation. This fixes the "Play" button in the GUI