### PR TITLE
vm_native: enable memfd_create on FreeBSD

### DIFF
--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -31,7 +31,13 @@ static int memfd_create_(const char *name, uint flags)
 	return syscall(__NR_memfd_create, name, flags);
 }
 #elif defined(__FreeBSD__)
+# if __FreeBSD__ < 13
+// XXX Drop after FreeBSD 12.* reaches EOL on 2024-06-30
+#define MFD_CLOEXEC O_CLOEXEC
+#define memfd_create_(name, flags) shm_open(SHM_ANON, O_RDWR | flags, 0600)
+# else
 #define memfd_create_ memfd_create
+# endif
 #endif
 
 namespace utils

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -30,6 +30,8 @@ static int memfd_create_(const char *name, uint flags)
 {
 	return syscall(__NR_memfd_create, name, flags);
 }
+#elif defined(__FreeBSD__)
+#define memfd_create_ memfd_create
 #endif
 
 namespace utils
@@ -289,7 +291,7 @@ namespace utils
 	{
 #ifdef _WIN32
 		m_handle = ensure(::CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_EXECUTE_READWRITE, 0, m_size, nullptr));
-#elif __linux__
+#elif defined(__linux__) || defined(__FreeBSD__)
 		m_file = -1;
 
 		// Try to use 2MB pages for 2M-aligned shm


### PR DESCRIPTION
FreeBSD >= 13.0 has [memfd_create(3)](https://man.freebsd.org/memfd_create/3) and [MFD_HUGETLB](https://github.com/freebsd/freebsd-src/commit/3ef55e8f254c), [implemented](https://reviews.freebsd.org/D21393) via `SHM_ANON`.

Similar to https://github.com/yuzu-emu/yuzu/pull/6758