### PR TITLE
vm_ptr.h: Improve try_read()

### DIFF
--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -210,7 +210,8 @@ namespace vm
 		std::pair<bool, std::conditional_t<std::is_void_v<T>, char, std::remove_const_t<T>>> try_read() const
 		{
 			alignas(16) char buf[sizeof(T)]{};
-			return { vm::try_access(vm::cast(m_addr), buf, sizeof(T), false), std::bit_cast<decltype(try_read().second)>(buf) };
+			const bool ok = vm::try_access(vm::cast(m_addr), buf, sizeof(T), false);
+			return { ok, std::bit_cast<decltype(try_read().second)>(buf) };
 		}
 
 		template <bool = false> requires (!std::is_void_v<T> && !std::is_const_v<T>)

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -214,6 +214,12 @@ namespace vm
 			return { ok, std::bit_cast<decltype(try_read().second)>(buf) };
 		}
 
+		template <bool = false> requires (!std::is_void_v<T>)
+		bool try_read(std::conditional_t<std::is_void_v<T>, char, std::remove_const_t<T>>& out) const
+		{
+			return vm::try_access(vm::cast(m_addr), &out, sizeof(T), false);
+		}
+
 		template <bool = false> requires (!std::is_void_v<T> && !std::is_const_v<T>)
 		bool try_write(const std::conditional_t<std::is_void_v<T>, char, T>& _in) const
 		{

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -209,7 +209,7 @@ namespace vm
 		template <bool = false> requires (!std::is_void_v<T>)
 		std::pair<bool, std::conditional_t<std::is_void_v<T>, char, std::remove_const_t<T>>> try_read() const
 		{
-			alignas(16) char buf[sizeof(T)]{};
+			alignas(sizeof(T) >= 16 ? 16 : 8) char buf[sizeof(T)]{};
 			const bool ok = vm::try_access(vm::cast(m_addr), buf, sizeof(T), false);
 			return { ok, std::bit_cast<decltype(try_read().second)>(buf) };
 		}

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -217,7 +217,7 @@ namespace vm
 		template <bool = false> requires (!std::is_void_v<T>)
 		bool try_read(std::conditional_t<std::is_void_v<T>, char, std::remove_const_t<T>>& out) const
 		{
-			return vm::try_access(vm::cast(m_addr), &out, sizeof(T), false);
+			return vm::try_access(vm::cast(m_addr), std::addressof(out), sizeof(T), false);
 		}
 
 		template <bool = false> requires (!std::is_void_v<T> && !std::is_const_v<T>)

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -207,15 +207,16 @@ namespace vm
 		}
 
 		template <bool = false> requires (!std::is_void_v<T>)
-		bool try_read(std::conditional_t<std::is_void_v<T>, char, std::remove_const_t<T>>& out) const
+		std::pair<bool, std::conditional_t<std::is_void_v<T>, char, std::remove_const_t<T>>> try_read() const
 		{
-			return vm::try_access(vm::cast(m_addr), &out, sizeof(T), false);
+			alignas(16) char buf[sizeof(T)]{};
+			return { vm::try_access(vm::cast(m_addr), buf, sizeof(T), false), std::bit_cast<decltype(try_read().second)>(buf) };
 		}
 
 		template <bool = false> requires (!std::is_void_v<T> && !std::is_const_v<T>)
 		bool try_write(const std::conditional_t<std::is_void_v<T>, char, T>& _in) const
 		{
-			return vm::try_access(vm::cast(m_addr), const_cast<T*>(&_in), sizeof(T), true);
+			return vm::try_access(vm::cast(m_addr), const_cast<T*>(std::addressof(_in)), sizeof(T), true);
 		}
 
 		// Don't use

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -206,7 +206,7 @@ namespace vm
 			return *this;
 		}
 
-		template <bool = false> requires (!std::is_void_v<T>)
+		template <bool = false> requires (std::is_copy_constructible_v<T>)
 		std::pair<bool, std::conditional_t<std::is_void_v<T>, char, std::remove_const_t<T>>> try_read() const
 		{
 			alignas(sizeof(T) >= 16 ? 16 : 8) char buf[sizeof(T)]{};


### PR DESCRIPTION
* Allow if T is not a default constructible type, use bit cast to construct it. Fixes reading vm::ptr<vm::ptr<T, const u32>> for example.
* Simplify usage, no longer needing to manually construct the destination data and thus always spelling its type. (f.e. `if (CellSaveDataSetList list{}; setList.try_read(list))` can become `if (auto [ok, list] = setList.try_read(); ok)`
* Use std::addressof where needed.