### PR TITLE
System: add progress update on existing modules

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "Utilities/JIT.h"
 #include "Utilities/StrUtil.h"
 #include "Crypto/sha1.h"
@@ -3041,6 +3041,12 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 			if (!jit && !check_only)
 			{
 				ppu_log.success("LLVM: Module exists: %s", obj_name);
+			}
+
+			if (!check_only)
+			{
+				// Update progress dialog
+				g_progr_pdone++;
 			}
 
 			continue;


### PR DESCRIPTION
This could cause dialogs to seemingly finish at e.g. 50/100 modules because the existing modules weren't accounted for.