### PR TITLE
Debugger: Add some error pop-ups for invalid operations

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -513,57 +513,45 @@ static bool ppu_break(ppu_thread& ppu, ppu_opcode_t)
 }
 
 // Set or remove breakpoint
-extern void ppu_breakpoint(u32 addr, bool is_adding)
+extern bool ppu_breakpoint(u32 addr, bool is_adding)
 {
-	if (g_cfg.core.ppu_decoder == ppu_decoder_type::llvm)
+	if (!vm::check_addr(addr, vm::page_executable) || g_cfg.core.ppu_decoder == ppu_decoder_type::llvm)
 	{
-		return;
+		return false;
 	}
 
 	const u64 _break = reinterpret_cast<uptr>(&ppu_break);
+
+	// Remove breakpoint parameters
+	u64 to_set = 0;
+	u64 expected = _break;
+
+	if (u32 hle_addr{}; g_fxo->is_init<ppu_function_manager>() && (hle_addr = g_fxo->get<ppu_function_manager>().addr))
+	{
+		// HLE function index
+		const u32 index = (addr - hle_addr) / 8;
+
+		if (addr % 8 == 4 && index < ppu_function_manager::get().size())
+		{
+			// HLE function placement
+			to_set = reinterpret_cast<uptr>(ppu_function_manager::get()[index]);
+		}
+	}
+
+	if (!to_set)
+	{
+		// If not an HLE function use regular instruction function
+		to_set = ppu_cache(addr);
+	}
 
 	if (is_adding)
 	{
-		// Set breakpoint
-		ppu_ref(addr) = _break;
-	}
-	else
-	{
-		// Remove breakpoint
-		ppu_ref(addr) = ppu_cache(addr);
-	}
-}
-
-//sets breakpoint, does nothing if there is a breakpoint there already
-extern void ppu_set_breakpoint(u32 addr)
-{
-	if (g_cfg.core.ppu_decoder == ppu_decoder_type::llvm)
-	{
-		return;
+		// Swap if adding
+		std::swap(to_set, expected);
 	}
 
-	const u64 _break = reinterpret_cast<uptr>(&ppu_break);
-
-	if (ppu_ref(addr) != _break)
-	{
-		ppu_ref(addr) = _break;
-	}
-}
-
-//removes breakpoint, does nothing if there is no breakpoint at location
-extern void ppu_remove_breakpoint(u32 addr)
-{
-	if (g_cfg.core.ppu_decoder == ppu_decoder_type::llvm)
-	{
-		return;
-	}
-
-	const auto _break = reinterpret_cast<uptr>(&ppu_break);
-
-	if (ppu_ref(addr) == _break)
-	{
-		ppu_ref(addr) = ppu_cache(addr);
-	}
+	auto& ref = reinterpret_cast<atomic_t<u64>&>(ppu_ref(addr));
+	return ref.compare_and_swap_test(expected, to_set);
 }
 
 extern bool ppu_patch(u32 addr, u32 value)

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -30,8 +30,7 @@
 #include <regex>
 #include <charconv>
 
-extern void ppu_set_breakpoint(u32 addr);
-extern void ppu_remove_breakpoint(u32 addr);
+extern bool ppu_breakpoint(u32 addr, bool is_adding);
 
 LOG_CHANNEL(GDB);
 
@@ -776,7 +775,7 @@ bool gdb_thread::cmd_set_breakpoint(gdb_cmd& cmd)
 			GDB.warning("Can't parse breakpoint request, data: '%s'.", cmd.data);
 			return send_cmd_ack("E02");
 		}
-		ppu_set_breakpoint(addr);
+		ppu_breakpoint(addr, true);
 		return send_cmd_ack("OK");
 	}
 	//other breakpoint types are not supported
@@ -794,7 +793,7 @@ bool gdb_thread::cmd_remove_breakpoint(gdb_cmd& cmd)
 			GDB.warning("Can't parse breakpoint remove request, data: '%s'.", cmd.data);
 			return send_cmd_ack("E01");
 		}
-		ppu_remove_breakpoint(addr);
+		ppu_breakpoint(addr, false);
 		return send_cmd_ack("OK");
 	}
 	//other breakpoint types are not supported

--- a/rpcs3/rpcs3qt/breakpoint_handler.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_handler.cpp
@@ -1,6 +1,6 @@
 #include "breakpoint_handler.h"
 
-extern void ppu_breakpoint(u32 loc, bool is_adding);
+extern bool ppu_breakpoint(u32 loc, bool is_adding);
 
 bool breakpoint_handler::HasBreakpoint(u32 loc) const
 {
@@ -9,14 +9,22 @@ bool breakpoint_handler::HasBreakpoint(u32 loc) const
 
 bool breakpoint_handler::AddBreakpoint(u32 loc)
 {
-	m_breakpoints.insert(loc);
-	ppu_breakpoint(loc, true);
+	if (!ppu_breakpoint(loc, true))
+	{
+		return false;
+	}
+
+	ensure(m_breakpoints.insert(loc).second);
 	return true;
 }
 
 bool breakpoint_handler::RemoveBreakpoint(u32 loc)
 {
-	m_breakpoints.erase(loc);
-	ppu_breakpoint(loc, false);
+	if (m_breakpoints.erase(loc) == 0)
+	{
+		return false;
+	}
+
+	ensure(ppu_breakpoint(loc, false));
 	return true;
 }

--- a/rpcs3/rpcs3qt/breakpoint_list.h
+++ b/rpcs3/rpcs3qt/breakpoint_list.h
@@ -16,7 +16,7 @@ public:
 	breakpoint_list(QWidget* parent, breakpoint_handler* handler);
 	void UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm);
 	void ClearBreakpoints();
-	void AddBreakpoint(u32 pc);
+	bool AddBreakpoint(u32 pc);
 	void RemoveBreakpoint(u32 addr);
 
 	QColor m_text_color_bp;


### PR DESCRIPTION
* Show error window when setting breakpoints on these conditions
  * SPU/RSX are selected. (not supported)
  * When using non-interpreters decoders.
  * Non-executable memory is specified.

* Do not allow instruction stepping for non-interpreters decoders.
* Clear breakpoints when the game is stopped.
* Fix setting breakpoints on HLE functions.