### PR TITLE
Fix counting of exisitng ppu modules

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3029,10 +3029,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 			if (!jit && !check_only)
 			{
 				ppu_log.success("LLVM: Module exists: %s", obj_name);
-			}
 
-			if (!check_only)
-			{
 				// Update progress dialog
 				g_progr_pdone++;
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -594,7 +594,7 @@ error_code _sys_prx_unload_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sy
 		return {prx.ret, "%s (id=%s)", prx->name, id};
 	}
 
-	sys_prx.success("_sys_prx_unload_module(id=0x%x, flags=0x%x, pOpt=*0x%x): name='%s'", id, flags, pOpt);
+	sys_prx.success("_sys_prx_unload_module(id=0x%x, flags=0x%x, pOpt=*0x%x): name='%s'", id, flags, pOpt, prx->name);
 
 	ppu_unload_prx(*prx);
 


### PR DESCRIPTION
- Fixes "regression"... some modules weren't counted before the offending commit. Afterwards they were counted twice.
- log name in _sys_prx_unload_module