### PR TITLE
SPU/event queue: Atomically resume SPU group, Fix sys_spu_thread_group_resume

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4278,6 +4278,9 @@ extern void resume_spu_thread_group_from_waiting(spu_thread& spu)
 	else if (group->run_state == SPU_THREAD_GROUP_STATUS_WAITING_AND_SUSPENDED)
 	{
 		group->run_state = SPU_THREAD_GROUP_STATUS_SUSPENDED;
+		spu.state += cpu_flag::signal;
+		spu.state.notify_one(cpu_flag::signal);
+		return;
 	}
 
 	for (auto& thread : group->threads)

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -32,6 +32,8 @@ std::shared_ptr<lv2_event_queue> lv2_event_queue::find(u64 ipc_key)
 	return g_fxo->get<ipc_manager<lv2_event_queue, u64>>().get(ipc_key);
 }
 
+extern void resume_spu_thread_group_from_waiting(spu_thread& spu);
+
 CellError lv2_event_queue::send(lv2_event event)
 {
 	std::lock_guard lock(mutex);
@@ -74,9 +76,7 @@ CellError lv2_event_queue::send(lv2_event event)
 		const u32 data2 = static_cast<u32>(std::get<2>(event));
 		const u32 data3 = static_cast<u32>(std::get<3>(event));
 		spu.ch_in_mbox.set_values(4, CELL_OK, data1, data2, data3);
-
-		spu.state += cpu_flag::signal;
-		spu.state.notify_one(cpu_flag::signal);
+		resume_spu_thread_group_from_waiting(spu);
 	}
 
 	return {};
@@ -161,11 +161,15 @@ error_code sys_event_queue_destroy(ppu_thread& ppu, u32 equeue_id, s32 mode)
 
 	if (mode == SYS_EVENT_QUEUE_DESTROY_FORCE)
 	{
+		std::deque<cpu_thread*> sq;
+
 		std::lock_guard lock(queue->mutex);
 
+		sq = std::move(queue->sq);
+	
 		if (queue->type == SYS_PPU_QUEUE)
 		{
-			for (auto cpu : queue->sq)
+			for (auto cpu : sq)
 			{
 				static_cast<ppu_thread&>(*cpu).gpr[3] = CELL_ECANCELED;
 				queue->append(cpu);
@@ -178,11 +182,10 @@ error_code sys_event_queue_destroy(ppu_thread& ppu, u32 equeue_id, s32 mode)
 		}
 		else
 		{
-			for (auto cpu : queue->sq)
+			for (auto cpu : sq)
 			{
 				static_cast<spu_thread&>(*cpu).ch_in_mbox.set_values(1, CELL_ECANCELED);
-				cpu->state += cpu_flag::signal;
-				cpu->state.notify_one(cpu_flag::signal);
+				resume_spu_thread_group_from_waiting(static_cast<spu_thread&>(*cpu));
 			}
 		}
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -958,6 +958,8 @@ error_code sys_spu_thread_group_resume(ppu_thread& ppu, u32 id)
 		else if (state == SPU_THREAD_GROUP_STATUS_WAITING_AND_SUSPENDED)
 		{
 			state = SPU_THREAD_GROUP_STATUS_WAITING;
+			error = CellError{};
+			return true;
 		}
 		else
 		{
@@ -971,7 +973,12 @@ error_code sys_spu_thread_group_resume(ppu_thread& ppu, u32 id)
 
 	if (error != CELL_CANCEL + 0u)
 	{
-		return error;
+		if (error)
+		{
+			return error;
+		}
+
+		return CELL_OK;
 	}
 
 	for (auto& thread : group->threads)


### PR DESCRIPTION
* Fixes race condition due to doing SPU group state transition asnyc instead of immediate as it should.
* Fix sys_spu_thread_group_resume: Do not remove suspend flag when SPU group state is not SPU_THREAD_GROUP_STATUS_RUNNING after operation!
No idea if it fixes some games random crashes.