### PR TITLE
ui: fix spacing on gpu tab

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -39,7 +39,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="coreTab">
       <attribute name="title">
@@ -345,7 +345,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="gpuTab_layout" stretch="0,1,0">
        <item>
-        <layout class="QHBoxLayout" name="gpuTabLayout" stretch="1,0,1">
+        <layout class="QHBoxLayout" name="gpuTabLayout" stretch="1,1,1">
          <item>
           <layout class="QVBoxLayout" name="gpuTabLayoutLeft">
            <item>


### PR DESCRIPTION
just changed back what didn't seem important from kd's changes lol

before:
![image](https://user-images.githubusercontent.com/16805474/128539068-7c6cf6eb-21fd-4ae4-9161-c41af8fec4df.png)

after:
![image](https://user-images.githubusercontent.com/16805474/128539084-e261383f-b7cf-4e5c-8673-e4223ca2c9d3.png)
