### PR TITLE
[HOTFIX] vk: Do not force check for successful texture cache load

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -335,7 +335,6 @@ vk::viewable_image* VKGSRender::get_present_source(vk::present_surface_info* inf
 		// Hack - this should be the first location to check for output
 		// The render might have been done offscreen or in software and a blit used to display
 		image_to_flip = dynamic_cast<vk::viewable_image*>(surface->get_raw_texture());
-		ensure(image_to_flip);
 	}
 
 	if (!image_to_flip)


### PR DESCRIPTION
The following set of conditions can fail
1. We hit a RTT owned texture
2. The texture is invalidated (failed memory integrity test) and set to write/read-through

In this situation, RTT overlap check will skip this surface, and a match can be found in texture cache if WCB/WDB is enabled.
The incoming hit however has no managed payload. This is expected behavior, the search should load from CPU.