### PR TITLE
rsx: Fix coordinate scaling for shadow access

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2010,11 +2010,18 @@ namespace rsx
 
 			if (is_unnormalized)
 			{
-				if (extended_dimension <= rsx::texture_dimension_extended::texture_dimension_2d)
+				switch (extended_dimension)
 				{
-					scale.width /= attributes.width;
-					scale.height /= attributes.height;
+				case rsx::texture_dimension_extended::texture_dimension_3d:
+				case rsx::texture_dimension_extended::texture_dimension_cubemap:
 					scale.depth /= attributes.depth;
+					[[ fallthrough ]];
+				case rsx::texture_dimension_extended::texture_dimension_2d:
+					scale.height /= attributes.height;
+					[[ fallthrough ]];
+				default:
+					scale.width /= attributes.width;
+					break;
 				}
 			}
 

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -881,7 +881,7 @@ namespace glsl
 				OS <<
 				"#define TEX2D_SHADOW(index, coord3) texture(TEX_NAME(index), vec3(COORD_SCALE2(index, coord3.xy), coord3.z))\n"
 				"#define TEX2D_SHADOWCUBE(index, coord4) texture(TEX_NAME(index), vec4(COORD_SCALE3(index, coord4.xyz), coord4.w))\n"
-				"#define TEX2D_SHADOWPROJ(index, coord4) textureProj(TEX_NAME(index), vec4(COORD_SCALE3(index, coord4.xyz), coord4.w))\n";
+				"#define TEX2D_SHADOWPROJ(index, coord4) textureProj(TEX_NAME(index), vec4(COORD_SCALE2(index, coord4.xy), coord4.zw))\n";
 			}
 
 			OS <<


### PR DESCRIPTION
- Do not scale Z values for 2D proj shadows.
- Fix unnormalized sampling for 3D textures. Previously it was blocked by a silly check.

Fixes https://github.com/RPCS3/rpcs3/issues/10662