### PR TITLE
rsx: Significantly reduce the applied subpixel bias when handling unnormalized access

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1907,8 +1907,9 @@ namespace rsx
 					if (tex.min_filter() == rsx::texture_minify_filter::nearest ||
 						tex.mag_filter() == rsx::texture_magnify_filter::nearest)
 					{
-						// Subpixel offset so that (X + bias) * scale will round correctly
-						current_fragment_program.texture_params[i].subpixel_bias = 0.5f;
+						// Subpixel offset so that (X + bias) * scale will round correctly.
+						// This is done to work around fdiv precision issues in some GPUs (NVIDIA)
+						current_fragment_program.texture_params[i].subpixel_bias = 0.01f;
 					}
 				}
 


### PR DESCRIPTION
If a large value is set (e.g 0.5) rounding will sample 'up' and we can read the wrong texel. In most cases this does not matter but sometimes this can be the difference between sampling NaN and a valid input.

Fixes https://github.com/RPCS3/rpcs3/issues/10673