### PR TITLE
input: fix player ID/LED if handler has 2 or more pads

### DIFF
--- a/rpcs3/Emu/Io/Null/NullPadHandler.h
+++ b/rpcs3/Emu/Io/Null/NullPadHandler.h
@@ -62,7 +62,7 @@ public:
 		return nulllist;
 	}
 
-	bool bindPadToDevice(std::shared_ptr<Pad> /*pad*/, const std::string& /*device*/) override
+	bool bindPadToDevice(std::shared_ptr<Pad> /*pad*/, const std::string& /*device*/, u8 /*player_id*/) override
 	{
 		return true;
 	}

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -451,7 +451,7 @@ void PadHandlerBase::TranslateButtonPress(const std::shared_ptr<PadDevice>& devi
 	}
 }
 
-bool PadHandlerBase::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device)
+bool PadHandlerBase::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id)
 {
 	std::shared_ptr<PadDevice> pad_device = get_device(device);
 	if (!pad_device)
@@ -463,6 +463,7 @@ bool PadHandlerBase::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string
 	const int index = static_cast<int>(bindings.size());
 	m_pad_configs[index].load();
 	pad_device->config = &m_pad_configs[index];
+	pad_device->player_id = player_id;
 	pad_config* profile = pad_device->config;
 	if (profile == nullptr)
 	{

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -16,6 +16,7 @@ class PadDevice
 {
 public:
 	pad_config* config{ nullptr };
+	u8 player_id{0};
 };
 
 using pad_preview_values = std::array<int, 6>;
@@ -71,7 +72,6 @@ protected:
 	std::array<bool, MAX_GAMEPADS> last_connection_status{{ false, false, false, false, false, false, false }};
 
 	std::string m_name_string;
-	u32 m_player_id = 0;
 	usz m_max_devices = 0;
 	int m_trigger_threshold = 0;
 	int m_thumb_threshold = 0;
@@ -153,8 +153,6 @@ public:
 	bool has_battery() const;
 	bool has_pressure_intensity_button() const;
 
-	void set_player(u32 player_id) { m_player_id = player_id; }
-
 	static std::string get_config_dir(pad_handler type, const std::string& title_id = "");
 	static std::string get_config_filename(int i, const std::string& title_id = "");
 
@@ -165,14 +163,14 @@ public:
 	PadHandlerBase(pad_handler type = pad_handler::null);
 	virtual ~PadHandlerBase() = default;
 	// Sets window to config the controller(optional)
-	virtual void SetPadData(const std::string& /*padId*/, u32 /*largeMotor*/, u32 /*smallMotor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/) {}
+	virtual void SetPadData(const std::string& /*padId*/, u8 /*player_id*/, u32 /*largeMotor*/, u32 /*smallMotor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/) {}
 	virtual u32 get_battery_level(const std::string& /*padId*/) { return 0; }
 	// Return list of devices for that handler
 	virtual std::vector<std::string> ListDevices() = 0;
 	// Callback called during pad_thread::ThreadFunc
 	virtual void ThreadProc();
 	// Binds a Pad to a device
-	virtual bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device);
+	virtual bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id);
 	virtual void init_config(pad_config* /*cfg*/, const std::string& /*name*/) = 0;
 	virtual void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons = {});
 

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -119,7 +119,7 @@ u32 ds3_pad_handler::get_battery_level(const std::string& padId)
 	return std::clamp<u32>(device->battery_level, 0, 100);
 }
 
-void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 /* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
+void ds3_pad_handler::SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 /* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
 	std::shared_ptr<ds3_device> device = get_hid_device(padId);
 	if (device == nullptr || device->hidDevice == nullptr)
@@ -128,6 +128,7 @@ void ds3_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 s
 	// Set the device's motor speeds to our requested values 0-255
 	device->large_motor = largeMotor;
 	device->small_motor = smallMotor;
+	device->player_id = player_id;
 
 	int index = 0;
 	for (uint i = 0; i < MAX_GAMEPADS; i++)
@@ -172,7 +173,7 @@ int ds3_pad_handler::send_output_report(ds3_device* ds3dev)
 	}
 	else
 	{
-		switch (m_player_id)
+		switch (ds3dev->player_id)
 		{
 		case 0: output_report.led_enabled = 0b00000010; break;
 		case 1: output_report.led_enabled = 0b00000100; break;
@@ -182,7 +183,7 @@ int ds3_pad_handler::send_output_report(ds3_device* ds3dev)
 		case 5: output_report.led_enabled = 0b00010100; break;
 		case 6: output_report.led_enabled = 0b00011000; break;
 		default:
-			fmt::throw_exception("DS3 is using forbidden player id %d", m_player_id);
+			fmt::throw_exception("DS3 is using forbidden player id %d", ds3dev->player_id);
 		}
 	}
 

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -80,7 +80,7 @@ public:
 	ds3_pad_handler();
 	~ds3_pad_handler();
 
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -197,7 +197,7 @@ u32 ds4_pad_handler::get_battery_level(const std::string& padId)
 	return std::min<u32>(device->battery_level * 10, 100);
 }
 
-void ds4_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness)
+void ds4_pad_handler::SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness)
 {
 	std::shared_ptr<DS4Device> device = get_hid_device(padId);
 	if (!device || !device->hidDevice || !device->config)
@@ -206,6 +206,7 @@ void ds4_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 s
 	// Set the device's motor speeds to our requested values 0-255
 	device->large_motor = largeMotor;
 	device->small_motor = smallMotor;
+	device->player_id = player_id;
 
 	int index = 0;
 	for (uint i = 0; i < MAX_GAMEPADS; i++)

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -56,7 +56,7 @@ public:
 	ds4_pad_handler();
 	~ds4_pad_handler();
 
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -955,7 +955,7 @@ int dualsense_pad_handler::send_output_report(DualSenseDevice* device)
 			// Use OR with 0x1, 0x2, 0x4, 0x8 and 0x10 to enable the LEDs (from leftmost to rightmost).
 			common.valid_flag_1 |= VALID_FLAG_1_PLAYER_INDICATOR_CONTROL_ENABLE;
 
-			switch (m_player_id)
+			switch (device->player_id)
 			{
 			case 0: common.player_leds = 0b00100; break;
 			case 1: common.player_leds = 0b01010; break;
@@ -965,7 +965,7 @@ int dualsense_pad_handler::send_output_report(DualSenseDevice* device)
 			case 5: common.player_leds = 0b10111; break;
 			case 6: common.player_leds = 0b11101; break;
 			default:
-				fmt::throw_exception("Dualsense is using forbidden player id %d", m_player_id);
+				fmt::throw_exception("Dualsense is using forbidden player id %d", device->player_id);
 			}
 		}
 	}
@@ -1086,7 +1086,7 @@ void dualsense_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& dev
 	}
 }
 
-void dualsense_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness)
+void dualsense_pad_handler::SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness)
 {
 	std::shared_ptr<DualSenseDevice> device = get_hid_device(padId);
 	if (device == nullptr || device->hidDevice == nullptr)
@@ -1095,6 +1095,7 @@ void dualsense_pad_handler::SetPadData(const std::string& padId, u32 largeMotor,
 	// Set the device's motor speeds to our requested values 0-255
 	device->large_motor = largeMotor;
 	device->small_motor = smallMotor;
+	device->player_id = player_id;
 
 	int index = 0;
 	for (uint i = 0; i < MAX_GAMEPADS; i++)

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -69,7 +69,7 @@ public:
 	dualsense_pad_handler();
 	~dualsense_pad_handler();
 
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -509,7 +509,7 @@ void evdev_joystick_handler::SetRumble(EvdevDevice* device, u16 large, u16 small
 	device->force_small = small;
 }
 
-void evdev_joystick_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 /* r*/, s32 /* g*/, s32 /* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
+void evdev_joystick_handler::SetPadData(const std::string& padId, u8 /*player_id*/, u32 largeMotor, u32 smallMotor, s32 /* r*/, s32 /* g*/, s32 /* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
 	// Get our evdev device
 	auto dev = get_evdev_device(padId);
@@ -893,7 +893,7 @@ int evdev_joystick_handler::FindAxisDirection(const std::unordered_map<int, bool
 	return -1;
 }
 
-bool evdev_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device)
+bool evdev_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id)
 {
 	if (!pad)
 		return false;
@@ -904,7 +904,8 @@ bool evdev_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std
 
 	const int index = static_cast<int>(bindings.size());
 	m_pad_configs[index].load();
-	m_dev->config         = &m_pad_configs[index];
+	m_dev->config = &m_pad_configs[index];
+	m_dev->player_id = player_id;
 	pad_config* p_profile = m_dev->config;
 	if (p_profile == nullptr)
 		return false;

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -362,10 +362,10 @@ public:
 	void init_config(pad_config* cfg, const std::string& name) override;
 	bool Init() override;
 	std::vector<std::string> ListDevices() override;
-	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
+	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id) override;
 	void Close();
 	void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 
 private:
 	std::shared_ptr<EvdevDevice> get_evdev_device(const std::string& device);

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -690,7 +690,7 @@ std::string keyboard_pad_handler::native_scan_code_to_string(int native_scan_cod
 	}
 }
 
-bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device)
+bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 /*player_id*/)
 {
 	if (device != pad::keyboard_device_name)
 		return false;

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -85,7 +85,7 @@ public:
 	void init_config(pad_config* cfg, const std::string& name) override;
 	std::vector<std::string> ListDevices() override;
 	void get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) override {}
-	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device) override;
+	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id) override;
 	void ThreadProc() override;
 
 	std::string GetMouseName(const QMouseEvent* event) const;

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -145,7 +145,6 @@ void pad_thread::Init()
 			}
 			handlers.emplace(handler_type, cur_pad_handler);
 		}
-		cur_pad_handler->set_player(i);
 		cur_pad_handler->Init();
 
 		m_pads[i] = std::make_shared<Pad>(CELL_PAD_STATUS_DISCONNECTED, pad_settings[i].device_capability, pad_settings[i].device_type);
@@ -154,11 +153,11 @@ void pad_thread::Init()
 		{
 			InitLddPad(pad_settings[i].ldd_handle);
 		}
-		else if (cur_pad_handler->bindPadToDevice(m_pads[i], g_cfg_input.player[i]->device.to_string()) == false)
+		else if (!cur_pad_handler->bindPadToDevice(m_pads[i], g_cfg_input.player[i]->device.to_string(), i))
 		{
 			// Failed to bind the device to cur_pad_handler so binds to NullPadHandler
 			input_log.error("Failed to bind device %s to handler %s", g_cfg_input.player[i]->device.to_string(), handler_type);
-			nullpad->bindPadToDevice(m_pads[i], g_cfg_input.player[i]->device.to_string());
+			nullpad->bindPadToDevice(m_pads[i], g_cfg_input.player[i]->device.to_string(), i);
 		}
 
 		m_pads_interface[i] = std::make_shared<Pad>(CELL_PAD_STATUS_DISCONNECTED, pad_settings[i].device_capability, pad_settings[i].device_type);

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -131,7 +131,7 @@ void xinput_pad_handler::init_config(pad_config* cfg, const std::string& name)
 	cfg->from_default();
 }
 
-void xinput_pad_handler::SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32/* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
+void xinput_pad_handler::SetPadData(const std::string& padId, u8 /*player_id*/, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32/* b*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
 	const int device_number = GetDeviceNumber(padId);
 	if (device_number < 0)

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -110,7 +110,7 @@ public:
 	bool Init() override;
 
 	std::vector<std::string> ListDevices() override;
-	void SetPadData(const std::string& padId, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(pad_config* cfg, const std::string& name) override;
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -161,7 +161,7 @@ private:
 	void CancelExit();
 
 	// Set vibrate data while keeping the current color
-	void SetPadData(u32 large_motor, u32 small_motor);
+	void SetPadData(u32 large_motor, u32 small_motor, bool led_battery_indicator = false);
 
 	/** Update all the Button Labels with current button mapping */
 	void UpdateLabels(bool is_reset = false);


### PR DESCRIPTION
I noticed that the player id - which is used to indicate the player on DS3 and DualSense - was unique per handler instead of unique per device.

- Fixes player LEDs if 2 or more DS3 are used
- Fixes player LEDs if 2 or more DualSense are used