### PR TITLE
Removes warnings about using deprecated inet function

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -556,7 +556,9 @@ struct nt_p2p_port
 
 	static void send_u2s_packet(lv2_socket &sock, s32 sock_id, std::vector<u8> data, const ::sockaddr_in* dst, u32 seq = 0, bool require_ack = true)
 	{
-		sys_net.trace("Sending U2S packet on socket %d(id:%d): data(%d, seq %d, require_ack %d) to %s:%d", sock.socket, sock_id, data.size(), seq, require_ack, inet_ntoa(dst->sin_addr), std::bit_cast<u16, be_t<u16>>(dst->sin_port));
+		char ip_str[16];
+		inet_ntop(AF_INET, &dst->sin_addr, ip_str, sizeof(ip_str));
+		sys_net.trace("Sending U2S packet on socket %d(id:%d): data(%d, seq %d, require_ack %d) to %s:%d", sock.socket, sock_id, data.size(), seq, require_ack, ip_str, std::bit_cast<u16, be_t<u16>>(dst->sin_port));
 		if (sendto(sock.socket, reinterpret_cast<char *>(data.data()), data.size(), 0, reinterpret_cast<const sockaddr*>(dst), sizeof(sockaddr_in)) == -1)
 		{
 			sys_net.error("Attempting to send a u2s packet failed(%s), closing socket!", get_last_error(false));
@@ -1496,7 +1498,9 @@ error_code sys_net_bnet_bind(ppu_thread& ppu, s32 s, vm::cptr<sys_net_sockaddr> 
 				p2p_vport = psa_in_p2p->sin_port;
 			}
 
-			sys_net.notice("[P2P] %s, Socket bind to %s:%d:%d", sock.type, inet_ntoa(name.sin_addr), p2p_port, p2p_vport);
+			char ip_str[16];
+			inet_ntop(AF_INET, &name.sin_addr, ip_str, sizeof(ip_str));
+			sys_net.notice("[P2P] %s, Socket bind to %s:%d:%d", sock.type, ip_str, p2p_port, p2p_vport);
 
 			if (p2p_port != 3658)
 			{
@@ -2604,7 +2608,9 @@ error_code sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 l
 		name.sin_port        = std::bit_cast<u16>(psa_in->sin_port);
 		name.sin_addr.s_addr = std::bit_cast<u32>(psa_in->sin_addr);
 
-		sys_net.trace("Sending to %s:%d", inet_ntoa(name.sin_addr), psa_in->sin_port);
+		char ip_str[16];
+		inet_ntop(AF_INET, &name.sin_addr, ip_str, sizeof(ip_str));
+		sys_net.trace("Sending to %s:%d", ip_str, psa_in->sin_port);
 	}
 
 	::socklen_t namelen = sizeof(name);
@@ -2633,7 +2639,9 @@ error_code sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 l
 			const u16 p2p_port  = reinterpret_cast<const sys_net_sockaddr_in*>(addr.get_ptr())->sin_port;
 			const u16 p2p_vport = reinterpret_cast<const sys_net_sockaddr_in_p2p*>(addr.get_ptr())->sin_vport;
 
-			sys_net.trace("[P2P] Sending a packet to %s:%d:%d", inet_ntoa(name.sin_addr), p2p_port, p2p_vport);
+			char ip_str[16];
+			inet_ntop(AF_INET, &name.sin_addr, ip_str, sizeof(ip_str));
+			sys_net.trace("[P2P] Sending a packet to %s:%d:%d", ip_str, p2p_port, p2p_vport);
 
 			p2p_data.resize(len + sizeof(u16));
 			reinterpret_cast<le_t<u16>&>(p2p_data[0]) = p2p_vport;

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -277,10 +277,10 @@ const SceNpAvatarUrl& np_handler::get_avatar_url() const
 
 std::string np_handler::ip_to_string(u32 ip_addr)
 {
-	in_addr addr;
-	addr.s_addr = ip_addr;
+	char ip_str[16];
 
-	return inet_ntoa(addr);
+	inet_ntop(AF_INET, &ip_addr, ip_str, sizeof(ip_str));
+	return std::string(ip_str);
 }
 
 std::string np_handler::ether_to_string(std::array<u8, 6>& ether)

--- a/rpcs3/Emu/NP/signaling_handler.cpp
+++ b/rpcs3/Emu/NP/signaling_handler.cpp
@@ -4,10 +4,10 @@
 #include "Emu/IdManager.h"
 #include "Emu/Cell/Modules/cellSysutil.h"
 #include "np_handler.h"
-#include <ws2tcpip.h>
 
 #ifdef _WIN32
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #else
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/rpcs3/Emu/NP/signaling_handler.cpp
+++ b/rpcs3/Emu/NP/signaling_handler.cpp
@@ -4,6 +4,7 @@
 #include "Emu/IdManager.h"
 #include "Emu/Cell/Modules/cellSysutil.h"
 #include "np_handler.h"
+#include <ws2tcpip.h>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -202,11 +203,18 @@ void signaling_handler::process_incoming_messages()
 				char npid_buf[17]{};
 				memcpy(npid_buf, sp->V1.npid.handle.data, 16);
 				std::string npid(npid_buf);
-				sign_log.trace("sig1 %s from %s:%d(%s)", sp->command, inet_ntoa(addr), op_port, npid);
+
+				char ip_str[16];
+				inet_ntop(AF_INET, &addr, ip_str, sizeof(ip_str));
+
+				sign_log.trace("sig1 %s from %s:%d(%s)", sp->command, ip_str, op_port, npid);
 			}
 			else
 			{
-				sign_log.trace("sig2 %s from %s:%d(%d:%d)", sp->command, inet_ntoa(addr), op_port, sp->V2.room_id, sp->V2.member_id);
+				char inet_addr[16];
+				const char* inet_addr_string = inet_ntop(AF_INET, &addr, inet_addr, sizeof(inet_addr));
+
+				sign_log.trace("sig2 %s from %s:%d(%d:%d)", sp->command, inet_addr_string, op_port, sp->V2.room_id, sp->V2.member_id);
 			}
 		}
 
@@ -399,7 +407,12 @@ void signaling_handler::update_si_addr(std::shared_ptr<signaling_info>& si, u32 
 		addr_old.s_addr = si->addr;
 		addr_new.s_addr = new_addr;
 
-		sign_log.trace("Updated Address from %s:%d to %s:%d", inet_ntoa(addr_old), si->port, inet_ntoa(addr_new), new_port);
+		char ip_str_old[16];
+		char ip_str_new[16];
+		inet_ntop(AF_INET, &addr_old, ip_str_old, sizeof(ip_str_old));
+		inet_ntop(AF_INET, &addr_new, ip_str_new, sizeof(ip_str_new));
+
+		sign_log.trace("Updated Address from %s:%d to %s:%d", ip_str_old, si->port, ip_str_new, new_port);
 		si->addr = new_addr;
 		si->port = new_port;
 	}
@@ -467,11 +480,14 @@ void signaling_handler::send_signaling_packet(signaling_packet& sp, u32 addr, u1
 	dest.sin_addr.s_addr = addr;
 	dest.sin_port        = std::bit_cast<u16, be_t<u16>>(port);
 
-	sign_log.trace("Sending %s packet to %s:%d", sp.command, inet_ntoa(dest.sin_addr), port);
+	char ip_str[16];
+	inet_ntop(AF_INET, &dest.sin_addr, ip_str, sizeof(ip_str));
+
+	sign_log.trace("Sending %s packet to %s:%d", sp.command, ip_str, port);
 
 	if (send_packet_from_p2p_port(packet, dest) == -1)
 	{
-		sign_log.error("Failed to send signaling packet to %s:%d", inet_ntoa(dest.sin_addr), port);
+		sign_log.error("Failed to send signaling packet to %s:%d", ip_str, port);
 	}
 }
 

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -42,6 +42,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <AdditionalIncludeDirectories>..\3rdparty\wolfssl\;..\3rdparty\flatbuffers\include;..\3rdparty\libusb\libusb\libusb;..\3rdparty\zlib\zlib;..\llvm\include;..\llvm_build\include;$(VULKAN_SDK)\Include</AdditionalIncludeDirectories>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <PreprocessorDefinitions>_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <PreBuildEvent>
       <Command>cmd.exe /c "$(SolutionDir)\Utilities\git-version-gen.cmd"</Command>

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -42,7 +42,6 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <AdditionalIncludeDirectories>..\3rdparty\wolfssl\;..\3rdparty\flatbuffers\include;..\3rdparty\libusb\libusb\libusb;..\3rdparty\zlib\zlib;..\llvm\include;..\llvm_build\include;$(VULKAN_SDK)\Include</AdditionalIncludeDirectories>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
-      <PreprocessorDefinitions>_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <PreBuildEvent>
       <Command>cmd.exe /c "$(SolutionDir)\Utilities\git-version-gen.cmd"</Command>


### PR DESCRIPTION
The warning in question is: "Warning	C4996	'inet_ntoa': Use
inet_ntop() or InetNtop() instead or define
_WINSOCK_DEPRECATED_NO_WARNINGS"

Simply adding the _WINSOCK_DEPRECATED_NO_WARNINGS preprocessor silences
the warnings.