### PR TITLE
SPU: Remove outdated assertation, Implement protocol for SPU event queue

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4476,8 +4476,6 @@ bool spu_thread::stop_and_signal(u32 code)
 		{
 			if (is_stopped(old))
 			{
-				// The thread group cannot be stopped while waiting for an event
-				ensure(!(old & cpu_flag::stop));
 				return false;
 			}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4835,6 +4835,16 @@ spu_thread::thread_name_t::operator std::string() const
 	return full_name;
 }
 
+spu_thread::priority_t::operator s32() const
+{
+	if (_this->get_type() != spu_type::threaded || !_this->group->has_scheduler_context)
+	{
+		return s32{smax};
+	}
+
+	return _this->group->prio;
+}
+
 template <>
 void fmt_class_string<spu_channel>::format(std::string& out, u64 arg)
 {

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -857,6 +857,14 @@ public:
 
 		operator std::string() const;
 	} thread_name{ this };
+
+	// For lv2_obj::schedule<spu_thread>
+	const struct priority_t
+	{
+		const spu_thread* _this;
+
+		operator s32() const;
+	} prio{ this };
 };
 
 class spu_function_logger

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -67,10 +67,7 @@ CellError lv2_event_queue::send(lv2_event event)
 	else
 	{
 		// Store event in In_MBox
-		auto& spu = static_cast<spu_thread&>(*sq.front());
-
-		// TODO: use protocol?
-		sq.pop_front();
+		auto& spu = static_cast<spu_thread&>(*schedule<spu_thread>(sq, protocol));
 
 		const u32 data1 = static_cast<u32>(std::get<1>(event));
 		const u32 data2 = static_cast<u32>(std::get<2>(event));


### PR DESCRIPTION
* First commit should fix regressions, SPU resume is no longer async hence other SPUs could have called exit by the time the thread called receive event wakes up.
* Implement protocol for SPU event queue.
