### PR TITLE
Redesign pad profiles

### DIFF
--- a/Utilities/Config.h
+++ b/Utilities/Config.h
@@ -36,6 +36,7 @@ namespace cfg
 		uint, // cfg::uint type
 		string, // cfg::string type
 		set, // cfg::set_entry type
+		map, // cfg::map_entry type
 		log,
 	};
 
@@ -471,6 +472,29 @@ namespace cfg
 
 			return true;
 		}
+	};
+
+	class map_entry final : public _base
+	{
+		std::map<std::string, std::string> m_map{};
+
+	public:
+		map_entry(node* owner, const std::string& name)
+			: _base(type::map, owner, name, true)
+		{
+		}
+
+		const std::map<std::string, std::string>& get_map() const
+		{
+			return m_map;
+		}
+
+		std::string get_value(const std::string& key);
+
+		void set_value(const std::string& key, const std::string& value);
+		void set_map(std::map<std::string, std::string>&& map);
+
+		void from_default() override;
 	};
 
 	class log_entry final : public _base

--- a/rpcs3/Emu/Io/Null/NullPadHandler.h
+++ b/rpcs3/Emu/Io/Null/NullPadHandler.h
@@ -15,12 +15,9 @@ public:
 		return true;
 	}
 
-	void init_config(pad_config* cfg, const std::string& /*name*/) override
+	void init_config(cfg_pad* cfg) override
 	{
 		if (!cfg) return;
-
-		// This profile does not need a save location
-		cfg->cfg_name = "";
 
 		// Reset default button mapping
 		cfg->ls_left.def  = "";

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -299,39 +299,11 @@ bool PadHandlerBase::has_pressure_intensity_button() const
 	return b_has_pressure_intensity_button;
 }
 
-std::string PadHandlerBase::get_config_dir(pad_handler type, const std::string& title_id)
-{
-	if (!title_id.empty())
-	{
-		return rpcs3::utils::get_custom_input_config_dir(title_id) + fmt::format("%s", type) + "/";
-	}
-	return fs::get_config_dir() + "/InputConfigs/" + fmt::format("%s", type) + "/";
-}
-
-std::string PadHandlerBase::get_config_filename(int i, const std::string& title_id)
-{
-	if (!title_id.empty() && fs::is_file(rpcs3::utils::get_custom_input_config_path(title_id)))
-	{
-		const std::string path = rpcs3::utils::get_custom_input_config_dir(title_id) + g_cfg_input.player[i]->handler.to_string() + "/" + g_cfg_input.player[i]->profile.to_string() + ".yml";
-		if (fs::is_file(path))
-		{
-			return path;
-		}
-	}
-	return fs::get_config_dir() + "/InputConfigs/" + g_cfg_input.player[i]->handler.to_string() + "/" + g_cfg_input.player[i]->profile.to_string() + ".yml";
-}
-
 void PadHandlerBase::init_configs()
 {
-	int index = 0;
-
 	for (u32 i = 0; i < MAX_GAMEPADS; i++)
 	{
-		if (g_cfg_input.player[i]->handler == m_type)
-		{
-			init_config(&m_pad_configs[index], get_config_filename(i, pad::g_title_id));
-			index++;
-		}
+		init_config(&m_pad_configs[i]);
 	}
 }
 
@@ -460,24 +432,23 @@ bool PadHandlerBase::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string
 		return false;
 	}
 
-	const int index = static_cast<int>(bindings.size());
-	m_pad_configs[index].load();
-	pad_device->config = &m_pad_configs[index];
+	m_pad_configs[player_id].from_string(g_cfg_input.player[player_id]->config.to_string());
+	pad_device->config = &m_pad_configs[player_id];
 	pad_device->player_id = player_id;
-	pad_config* profile = pad_device->config;
-	if (profile == nullptr)
+	cfg_pad* config = pad_device->config;
+	if (config == nullptr)
 	{
-		input_log.error("PadHandlerBase::bindPadToDevice: no profile found for device %d '%s'", index, device);
+		input_log.error("PadHandlerBase::bindPadToDevice: no profile found for device %d '%s'", bindings.size(), device);
 		return false;
 	}
 
-	std::array<u32, button::button_count> mapping = get_mapped_key_codes(pad_device, profile);
+	std::array<u32, button::button_count> mapping = get_mapped_key_codes(pad_device, config);
 
 	u32 pclass_profile = 0x0;
 
-	for (const auto& product : input::get_products_by_class(profile->device_class_type))
+	for (const auto& product : input::get_products_by_class(config->device_class_type))
 	{
-		if (product.vendor_id == profile->vendor_id && product.product_id == profile->product_id)
+		if (product.vendor_id == config->vendor_id && product.product_id == config->product_id)
 		{
 			pclass_profile = product.pclass_profile;
 		}
@@ -488,11 +459,11 @@ bool PadHandlerBase::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string
 		CELL_PAD_STATUS_DISCONNECTED,
 		CELL_PAD_CAPABILITY_PS3_CONFORMITY | CELL_PAD_CAPABILITY_PRESS_MODE | CELL_PAD_CAPABILITY_HP_ANALOG_STICK | CELL_PAD_CAPABILITY_ACTUATOR | CELL_PAD_CAPABILITY_SENSOR_MODE,
 		CELL_PAD_DEV_TYPE_STANDARD,
-		profile->device_class_type,
+		config->device_class_type,
 		pclass_profile,
-		profile->vendor_id,
-		profile->product_id,
-		profile->pressure_intensity
+		config->vendor_id,
+		config->product_id,
+		config->pressure_intensity
 	);
 
 	pad->m_buttons.emplace_back(special_button_offset, mapping[button::pressure_intensity_button], special_button_value::pressure_intensity);
@@ -535,37 +506,39 @@ bool PadHandlerBase::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string
 	return true;
 }
 
-std::array<u32, PadHandlerBase::button::button_count> PadHandlerBase::get_mapped_key_codes(const std::shared_ptr<PadDevice>& /*device*/, const pad_config* profile)
+std::array<u32, PadHandlerBase::button::button_count> PadHandlerBase::get_mapped_key_codes(const std::shared_ptr<PadDevice>& /*device*/, const cfg_pad* cfg)
 {
-	std::array<u32, button::button_count> mapping;
+	std::array<u32, button::button_count> mapping{};
+	if (!cfg)
+		return mapping;
 
-	mapping[button::up]       = FindKeyCode(button_list, profile->up);
-	mapping[button::down]     = FindKeyCode(button_list, profile->down);
-	mapping[button::left]     = FindKeyCode(button_list, profile->left);
-	mapping[button::right]    = FindKeyCode(button_list, profile->right);
-	mapping[button::cross]    = FindKeyCode(button_list, profile->cross);
-	mapping[button::square]   = FindKeyCode(button_list, profile->square);
-	mapping[button::circle]   = FindKeyCode(button_list, profile->circle);
-	mapping[button::triangle] = FindKeyCode(button_list, profile->triangle);
-	mapping[button::start]    = FindKeyCode(button_list, profile->start);
-	mapping[button::select]   = FindKeyCode(button_list, profile->select);
-	mapping[button::l1]       = FindKeyCode(button_list, profile->l1);
-	mapping[button::l2]       = FindKeyCode(button_list, profile->l2);
-	mapping[button::l3]       = FindKeyCode(button_list, profile->l3);
-	mapping[button::r1]       = FindKeyCode(button_list, profile->r1);
-	mapping[button::r2]       = FindKeyCode(button_list, profile->r2);
-	mapping[button::r3]       = FindKeyCode(button_list, profile->r3);
-	mapping[button::ls_left]  = FindKeyCode(button_list, profile->ls_left);
-	mapping[button::ls_right] = FindKeyCode(button_list, profile->ls_right);
-	mapping[button::ls_down]  = FindKeyCode(button_list, profile->ls_down);
-	mapping[button::ls_up]    = FindKeyCode(button_list, profile->ls_up);
-	mapping[button::rs_left]  = FindKeyCode(button_list, profile->rs_left);
-	mapping[button::rs_right] = FindKeyCode(button_list, profile->rs_right);
-	mapping[button::rs_down]  = FindKeyCode(button_list, profile->rs_down);
-	mapping[button::rs_up]    = FindKeyCode(button_list, profile->rs_up);
-	mapping[button::ps]       = FindKeyCode(button_list, profile->ps);
+	mapping[button::up]       = FindKeyCode(button_list, cfg->up);
+	mapping[button::down]     = FindKeyCode(button_list, cfg->down);
+	mapping[button::left]     = FindKeyCode(button_list, cfg->left);
+	mapping[button::right]    = FindKeyCode(button_list, cfg->right);
+	mapping[button::cross]    = FindKeyCode(button_list, cfg->cross);
+	mapping[button::square]   = FindKeyCode(button_list, cfg->square);
+	mapping[button::circle]   = FindKeyCode(button_list, cfg->circle);
+	mapping[button::triangle] = FindKeyCode(button_list, cfg->triangle);
+	mapping[button::start]    = FindKeyCode(button_list, cfg->start);
+	mapping[button::select]   = FindKeyCode(button_list, cfg->select);
+	mapping[button::l1]       = FindKeyCode(button_list, cfg->l1);
+	mapping[button::l2]       = FindKeyCode(button_list, cfg->l2);
+	mapping[button::l3]       = FindKeyCode(button_list, cfg->l3);
+	mapping[button::r1]       = FindKeyCode(button_list, cfg->r1);
+	mapping[button::r2]       = FindKeyCode(button_list, cfg->r2);
+	mapping[button::r3]       = FindKeyCode(button_list, cfg->r3);
+	mapping[button::ls_left]  = FindKeyCode(button_list, cfg->ls_left);
+	mapping[button::ls_right] = FindKeyCode(button_list, cfg->ls_right);
+	mapping[button::ls_down]  = FindKeyCode(button_list, cfg->ls_down);
+	mapping[button::ls_up]    = FindKeyCode(button_list, cfg->ls_up);
+	mapping[button::rs_left]  = FindKeyCode(button_list, cfg->rs_left);
+	mapping[button::rs_right] = FindKeyCode(button_list, cfg->rs_right);
+	mapping[button::rs_down]  = FindKeyCode(button_list, cfg->rs_down);
+	mapping[button::rs_up]    = FindKeyCode(button_list, cfg->rs_up);
+	mapping[button::ps]       = FindKeyCode(button_list, cfg->ps);
 
-	mapping[button::pressure_intensity_button] = FindKeyCode(button_list, profile->pressure_intensity_button);
+	mapping[button::pressure_intensity_button] = FindKeyCode(button_list, cfg->pressure_intensity_button);
 
 	return mapping;
 }

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -15,7 +15,7 @@
 class PadDevice
 {
 public:
-	pad_config* config{ nullptr };
+	cfg_pad* config{ nullptr };
 	u8 player_id{0};
 };
 
@@ -83,7 +83,7 @@ protected:
 	bool b_has_rumble = false;
 	bool b_has_config = false;
 	bool b_has_pressure_intensity_button = true;
-	std::array<pad_config, MAX_GAMEPADS> m_pad_configs;
+	std::array<cfg_pad, MAX_GAMEPADS> m_pad_configs;
 	std::vector<std::pair<std::shared_ptr<PadDevice>, std::shared_ptr<Pad>>> bindings;
 	std::unordered_map<u32, std::string> button_list;
 	std::vector<u32> blacklist;
@@ -153,9 +153,6 @@ public:
 	bool has_battery() const;
 	bool has_pressure_intensity_button() const;
 
-	static std::string get_config_dir(pad_handler type, const std::string& title_id = "");
-	static std::string get_config_filename(int i, const std::string& title_id = "");
-
 	u16 NormalizeStickInput(u16 raw_value, int threshold, int multiplier, bool ignore_threshold = false) const;
 	void convert_stick_values(u16& x_out, u16& y_out, const s32& x_in, const s32& y_in, const s32& deadzone, const s32& padsquircling) const;
 
@@ -171,7 +168,7 @@ public:
 	virtual void ThreadProc();
 	// Binds a Pad to a device
 	virtual bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id);
-	virtual void init_config(pad_config* /*cfg*/, const std::string& /*name*/) = 0;
+	virtual void init_config(cfg_pad* /*cfg*/) = 0;
 	virtual void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons = {});
 
 private:
@@ -187,7 +184,7 @@ private:
 	virtual pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& /*data*/) { return {}; }
 
 protected:
-	virtual std::array<u32, PadHandlerBase::button::button_count> get_mapped_key_codes(const std::shared_ptr<PadDevice>& /*device*/, const pad_config* profile);
+	virtual std::array<u32, PadHandlerBase::button::button_count> get_mapped_key_codes(const std::shared_ptr<PadDevice>& device, const cfg_pad* cfg);
 	virtual void get_mapping(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad);
 	void TranslateButtonPress(const std::shared_ptr<PadDevice>& device, u64 keyCode, bool& pressed, u16& val, bool ignore_stick_threshold = false, bool ignore_trigger_threshold = false);
 	void init_configs();

--- a/rpcs3/Emu/Io/pad_config.cpp
+++ b/rpcs3/Emu/Io/pad_config.cpp
@@ -2,64 +2,103 @@
 #include "pad_config.h"
 #include "Emu/system_utils.hpp"
 
-cfg_input::cfg_input()
-	: cfg_name(fs::get_config_dir() + "/config_input.yml")
+LOG_CHANNEL(input_log, "Input");
+
+bool cfg_input::load(const std::string& title_id, const std::string& profile, bool strict)
 {
-}
+	// Check custom config first
+	std::string cfg_name;
 
-bool cfg_input::load(const std::string& title_id)
-{
-	cfg_name = rpcs3::utils::get_custom_input_config_path(title_id);
-
-	if (!fs::is_file(cfg_name))
-	{
-		cfg_name = fs::get_config_dir() + "/config_input.yml";
-	}
-
-	if (fs::file cfg_file{ cfg_name, fs::read })
-	{
-		return from_string(cfg_file.to_string());
-	}
-	else
-	{
-		// Add keyboard by default
-		player[0]->handler.from_string(fmt::format("%s", pad_handler::keyboard));
-		player[0]->device.from_string(pad::keyboard_device_name.data());
-	}
-
-	return false;
-}
-
-void cfg_input::save(const std::string& title_id)
-{
 	if (title_id.empty())
 	{
-		cfg_name = fs::get_config_dir() + "/config_input.yml";
+		cfg_name = rpcs3::utils::get_input_config_dir() + profile + ".yml";
 	}
 	else
 	{
 		cfg_name = rpcs3::utils::get_custom_input_config_path(title_id);
 	}
-	fs::file(cfg_name, fs::rewrite).write(to_string());
-}
 
+	if (!strict && !fs::is_file(cfg_name))
+	{
+		cfg_name = rpcs3::utils::get_input_config_dir() + g_cfg_profile.default_profile + ".yml";
+	}
 
-bool pad_config::exist() const
-{
-	return fs::is_file(cfg_name);
-}
+	from_default();
 
-bool pad_config::load()
-{
 	if (fs::file cfg_file{ cfg_name, fs::read })
 	{
-		return from_string(cfg_file.to_string());
+		input_log.notice("Loading pad profile: '%s'", cfg_name);
+
+		if (std::string content = cfg_file.to_string(); !content.empty())
+		{
+			return from_string(content);
+		}
 	}
+
+	// Add keyboard by default
+	input_log.notice("Pad profile empty. Adding default keyboard pad handler");
+	player[0]->handler.from_string(fmt::format("%s", pad_handler::keyboard));
+	player[0]->device.from_string(pad::keyboard_device_name.data());
 
 	return false;
 }
 
-void pad_config::save() const
+void cfg_input::save(const std::string& title_id, const std::string& profile) const
 {
-	fs::file(cfg_name, fs::rewrite).write(to_string());
+	std::string cfg_name;
+
+	if (title_id.empty())
+	{
+		cfg_name = rpcs3::utils::get_input_config_dir() + profile + ".yml";
+		input_log.notice("Saving pad config profile '%s' to '%s'", profile, cfg_name);
+	}
+	else
+	{
+		cfg_name = rpcs3::utils::get_custom_input_config_path(title_id);
+		input_log.notice("Saving custom pad config for '%s' to '%s'", title_id, cfg_name);
+	}
+
+	if (!fs::create_path(fs::get_parent_dir(cfg_name)))
+	{
+		input_log.fatal("Failed to create path: %s (%s)", cfg_name, fs::g_tls_error);
+	}
+
+	if (auto cfg_file = fs::file(cfg_name, fs::rewrite))
+	{
+		cfg_file.write(to_string());
+	}
+	else
+	{
+		input_log.error("Failed to save pad config to '%s'", cfg_name);
+	}
+}
+
+cfg_profile::cfg_profile()
+	: path(rpcs3::utils::get_input_config_root() + "/active_profiles.yml")
+{
+}
+
+bool cfg_profile::load()
+{
+	if (fs::file cfg_file{ path, fs::read })
+	{
+		return from_string(cfg_file.to_string());
+	}
+
+	from_default();
+	return false;
+}
+
+void cfg_profile::save() const
+{
+	input_log.notice("Saving pad profile config to '%s'", path);
+
+	if (auto cfg_file = fs::file(path, fs::rewrite))
+	{
+		cfg_file.write(to_string());
+	}
+	else
+	{
+		input_log.error("Failed to save pad profile config to '%s'", path);
+	}
 }

--- a/rpcs3/Emu/Io/pad_config.h
+++ b/rpcs3/Emu/Io/pad_config.h
@@ -4,44 +4,17 @@
 
 #include "Utilities/Config.h"
 
+#include <array>
+
 namespace pad
 {
 	constexpr static std::string_view keyboard_device_name = "Keyboard";
 }
 
-struct cfg_player final : cfg::node
+struct cfg_pad final : cfg::node
 {
-	pad_handler def_handler = pad_handler::null;
-	cfg_player(node* owner, const std::string& name, pad_handler type) : cfg::node(owner, name), def_handler(type) {}
-
-	cfg::_enum<pad_handler> handler{ this, "Handler", def_handler };
-	cfg::string device{ this, "Device", handler.to_string() };
-	cfg::string profile{ this, "Profile", "Default Profile" };
-};
-
-struct cfg_input final : cfg::node
-{
-	cfg_input();
-
-	std::string cfg_name;
-
-	cfg_player player1{ this, "Player 1 Input", pad_handler::null };
-	cfg_player player2{ this, "Player 2 Input", pad_handler::null };
-	cfg_player player3{ this, "Player 3 Input", pad_handler::null };
-	cfg_player player4{ this, "Player 4 Input", pad_handler::null };
-	cfg_player player5{ this, "Player 5 Input", pad_handler::null };
-	cfg_player player6{ this, "Player 6 Input", pad_handler::null };
-	cfg_player player7{ this, "Player 7 Input", pad_handler::null };
-
-	cfg_player* player[7]{ &player1, &player2, &player3, &player4, &player5, &player6, &player7 }; // Thanks gcc!
-
-	bool load(const std::string& title_id = "");
-	void save(const std::string& title_id = "");
-};
-
-struct pad_config final : cfg::node
-{
-	std::string cfg_name{};
+	cfg_pad() {};
+	cfg_pad(node* owner, const std::string& name) : cfg::node(owner, name) {}
 
 	cfg::string ls_left{ this, "Left Stick Left", "" };
 	cfg::string ls_down{ this, "Left Stick Down", "" };
@@ -106,10 +79,46 @@ struct pad_config final : cfg::node
 	cfg::uint<0, 5> device_class_type{ this, "Device Class Type", 0 };
 	cfg::uint<0, 65535> vendor_id{ this, "Vendor ID", 0 };
 	cfg::uint<0, 65535> product_id{ this, "Product ID", 0 };
+};
 
-	bool exist() const;
+struct cfg_player final : cfg::node
+{
+	pad_handler def_handler = pad_handler::null;
+	cfg_player(node* owner, const std::string& name, pad_handler type) : cfg::node(owner, name), def_handler(type) {}
+
+	cfg::_enum<pad_handler> handler{ this, "Handler", def_handler };
+	cfg::string device{ this, "Device", handler.to_string() };
+	cfg_pad config{ this, "Config" };
+};
+
+struct cfg_input final : cfg::node
+{
+	cfg_player player1{ this, "Player 1 Input", pad_handler::null };
+	cfg_player player2{ this, "Player 2 Input", pad_handler::null };
+	cfg_player player3{ this, "Player 3 Input", pad_handler::null };
+	cfg_player player4{ this, "Player 4 Input", pad_handler::null };
+	cfg_player player5{ this, "Player 5 Input", pad_handler::null };
+	cfg_player player6{ this, "Player 6 Input", pad_handler::null };
+	cfg_player player7{ this, "Player 7 Input", pad_handler::null };
+
+	std::array<cfg_player*, 7> player{ &player1, &player2, &player3, &player4, &player5, &player6, &player7 }; // Thanks gcc!
+
+	bool load(const std::string& title_id = "", const std::string& profile = "", bool strict = false);
+	void save(const std::string& title_id, const std::string& profile = "") const;
+};
+
+struct cfg_profile final : cfg::node
+{
+	cfg_profile();
 	bool load();
 	void save() const;
+
+	const std::string path;
+	const std::string global_key = "global";
+	const std::string default_profile = "Default";
+
+	cfg::map_entry active_profiles{ this, "Active Profiles" };
 };
 
 extern cfg_input g_cfg_input;
+extern cfg_profile g_cfg_profile;

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "system_utils.hpp"
 #include "system_config.h"
+#include "Emu/Io/pad_config.h"
 #include "util/sysinfo.hpp"
 #include "Utilities/File.h"
 #include "Utilities/StrUtil.h"
@@ -225,19 +226,23 @@ namespace rpcs3::utils
 		return path;
 	}
 
-	std::string get_custom_input_config_dir(const std::string& title_id)
+	std::string get_input_config_root()
 	{
-		// Notice: the extra folder for each title id may be removed at a later stage
-		// Warning: make sure to change any function that removes this directory as well
 #ifdef _WIN32
-		return fs::get_config_dir() + "config/custom_input_configs/" + title_id + "/";
+		return fs::get_config_dir() + "config/input_configs/";
 #else
-		return fs::get_config_dir() + "custom_input_configs/" + title_id + "/";
+		return fs::get_config_dir() + "input_configs/";
 #endif
+	}
+
+	std::string get_input_config_dir(const std::string& title_id)
+	{
+		return get_input_config_root() + (title_id.empty() ? "global" : title_id) + "/";
 	}
 
 	std::string get_custom_input_config_path(const std::string& title_id)
 	{
-		return get_custom_input_config_dir(title_id) + "/config_input_" + title_id + ".yml";
+		if (title_id.empty()) return "";
+		return get_input_config_dir(title_id) + g_cfg_profile.default_profile + ".yml";
 	}
 }

--- a/rpcs3/Emu/system_utils.hpp
+++ b/rpcs3/Emu/system_utils.hpp
@@ -27,6 +27,8 @@ namespace rpcs3::utils
 
 	std::string get_custom_config_dir();
 	std::string get_custom_config_path(const std::string& title_id, bool get_deprecated_path = false);
-	std::string get_custom_input_config_dir(const std::string& title_id);
+
+	std::string get_input_config_root();
+	std::string get_input_config_dir(const std::string& title_id = "");
 	std::string get_custom_input_config_path(const std::string& title_id);
 }

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -137,7 +137,7 @@ void ds3_pad_handler::SetPadData(const std::string& padId, u8 player_id, u32 lar
 		{
 			if (g_cfg_input.player[i]->device.to_string() == padId)
 			{
-				m_pad_configs[index].load();
+				m_pad_configs[index].from_string(g_cfg_input.player[i]->config.to_string());
 				device->config = &m_pad_configs[index];
 				break;
 			}
@@ -197,12 +197,9 @@ int ds3_pad_handler::send_output_report(ds3_device* ds3dev)
 	return hid_write(ds3dev->hidDevice, &output_report.report_id, sizeof(output_report));
 }
 
-void ds3_pad_handler::init_config(pad_config* cfg, const std::string& name)
+void ds3_pad_handler::init_config(cfg_pad* cfg)
 {
 	if (!cfg) return;
-
-	// Set this profile's save location
-	cfg->cfg_name = name;
 
 	// Set default button mapping
 	cfg->ls_left.def = button_list.at(DS3KeyCodes::LSXNeg);
@@ -560,7 +557,7 @@ void ds3_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, c
 	if (!dev || !dev->hidDevice || !dev->config || !pad)
 		return;
 
-	pad_config* config = dev->config;
+	cfg_pad* config = dev->config;
 
 	const int idx_l = config->switch_vibration_motors ? 1 : 0;
 	const int idx_s = config->switch_vibration_motors ? 0 : 1;

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -82,7 +82,7 @@ public:
 
 	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
-	void init_config(pad_config* cfg, const std::string& name) override;
+	void init_config(cfg_pad* cfg) override;
 
 private:
 	ds3_pad_handler::DataStatus get_data(ds3_device* ds3dev) override;

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -129,12 +129,9 @@ ds4_pad_handler::ds4_pad_handler()
 	m_thumb_threshold = thumb_max / 2;
 }
 
-void ds4_pad_handler::init_config(pad_config* cfg, const std::string& name)
+void ds4_pad_handler::init_config(cfg_pad* cfg)
 {
 	if (!cfg) return;
-
-	// Set this profile's save location
-	cfg->cfg_name = name;
 
 	// Set default button mapping
 	cfg->ls_left.def  = button_list.at(DS4KeyCodes::LSXNeg);
@@ -215,7 +212,7 @@ void ds4_pad_handler::SetPadData(const std::string& padId, u8 player_id, u32 lar
 		{
 			if (g_cfg_input.player[i]->device.to_string() == padId)
 			{
-				m_pad_configs[index].load();
+				m_pad_configs[index].from_string(g_cfg_input.player[i]->config.to_string());
 				device->config = &m_pad_configs[index];
 				break;
 			}
@@ -855,7 +852,7 @@ void ds4_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device, c
 	if (!ds4_dev || !ds4_dev->hidDevice || !ds4_dev->config || !pad)
 		return;
 
-	pad_config* config = ds4_dev->config;
+	cfg_pad* config = ds4_dev->config;
 
 	// Attempt to send rumble no matter what
 	const int idx_l = config->switch_vibration_motors ? 1 : 0;

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -58,7 +58,7 @@ public:
 
 	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
-	void init_config(pad_config* cfg, const std::string& name) override;
+	void init_config(cfg_pad* cfg) override;
 
 private:
 	// This function gets us usuable buffer from the rawbuffer of padData

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -240,12 +240,9 @@ void dualsense_pad_handler::check_add_device(hid_device* hidDevice, std::string_
 	dualsense_log.notice("Added device: bluetooth=%d, data_mode=%s, serial='%s', hw_version: 0x%x, fw_version: 0x%x, path='%s'", device->bt_controller, device->data_mode, serial, hw_version, fw_version, device->path);
 }
 
-void dualsense_pad_handler::init_config(pad_config* cfg, const std::string& name)
+void dualsense_pad_handler::init_config(cfg_pad* cfg)
 {
 	if (!cfg) return;
-
-	// Set this profile's save location
-	cfg->cfg_name = name;
 
 	// Set default button mapping
 	cfg->ls_left.def  = button_list.at(DualSenseKeyCodes::LSXNeg);
@@ -1008,7 +1005,7 @@ void dualsense_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& dev
 	if (!dualsense_dev || !dualsense_dev->hidDevice || !dualsense_dev->config || !pad)
 		return;
 
-	pad_config* config = dualsense_dev->config;
+	cfg_pad* config = dualsense_dev->config;
 
 	// Attempt to send rumble no matter what
 	const int idx_l = config->switch_vibration_motors ? 1 : 0;
@@ -1104,7 +1101,7 @@ void dualsense_pad_handler::SetPadData(const std::string& padId, u8 player_id, u
 		{
 			if (g_cfg_input.player[i]->device.to_string() == padId)
 			{
-				m_pad_configs[index].load();
+				m_pad_configs[index].from_string(g_cfg_input.player[i]->config.to_string());
 				device->config = &m_pad_configs[index];
 				break;
 			}

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -71,7 +71,7 @@ public:
 
 	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
-	void init_config(pad_config* cfg, const std::string& name) override;
+	void init_config(cfg_pad* cfg) override;
 
 private:
 	bool get_calibration_data(DualSenseDevice* dualsense_device) const;

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -359,7 +359,7 @@ public:
 	evdev_joystick_handler();
 	~evdev_joystick_handler();
 
-	void init_config(pad_config* cfg, const std::string& name) override;
+	void init_config(cfg_pad* cfg) override;
 	bool Init() override;
 	std::vector<std::string> ListDevices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id) override;

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -127,7 +127,7 @@ void hid_pad_handler<Device>::enumerate_devices()
 		if (controller.second && !controller.second->path.empty() && !device_paths.contains(controller.second->path))
 		{
 			hid_close(controller.second->hidDevice);
-			pad_config* config = controller.second->config;
+			cfg_pad* config = controller.second->config;
 			controller.second.reset(new Device());
 			controller.second->config = config;
 		}

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -82,7 +82,7 @@ public:
 
 	bool eventFilter(QObject* target, QEvent* ev) override;
 
-	void init_config(pad_config* cfg, const std::string& name) override;
+	void init_config(cfg_pad* cfg) override;
 	std::vector<std::string> ListDevices() override;
 	void get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) override {}
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id) override;

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -26,12 +26,9 @@ mm_joystick_handler::mm_joystick_handler() : PadHandlerBase(pad_handler::mm)
 	m_thumb_threshold = thumb_max / 2;
 }
 
-void mm_joystick_handler::init_config(pad_config* cfg, const std::string& name)
+void mm_joystick_handler::init_config(cfg_pad* cfg)
 {
 	if (!cfg) return;
-
-	// Set this profile's save location
-	cfg->cfg_name = name;
 
 	// Set default button mapping
 	cfg->ls_left.def  = axis_list.at(mmjoy_axis::joy_x_neg);
@@ -129,42 +126,42 @@ u64 mm_joystick_handler::find_key(const std::string& name) const
 	return static_cast<u64>(key);
 }
 
-std::array<u32, PadHandlerBase::button::button_count> mm_joystick_handler::get_mapped_key_codes(const std::shared_ptr<PadDevice>& device, const pad_config* profile)
+std::array<u32, PadHandlerBase::button::button_count> mm_joystick_handler::get_mapped_key_codes(const std::shared_ptr<PadDevice>& device, const cfg_pad* cfg)
 {
-	std::array<u32, button::button_count> mapping{ 0 };
+	std::array<u32, button::button_count> mapping{};
 
 	MMJOYDevice* joy_device = static_cast<MMJOYDevice*>(device.get());
-	if (!joy_device)
+	if (!joy_device || !cfg)
 		return mapping;
 
-	joy_device->trigger_left  = find_key(profile->l2);
-	joy_device->trigger_right = find_key(profile->r2);
-	joy_device->axis_left[0]  = find_key(profile->ls_left);
-	joy_device->axis_left[1]  = find_key(profile->ls_right);
-	joy_device->axis_left[2]  = find_key(profile->ls_down);
-	joy_device->axis_left[3]  = find_key(profile->ls_up);
-	joy_device->axis_right[0] = find_key(profile->rs_left);
-	joy_device->axis_right[1] = find_key(profile->rs_right);
-	joy_device->axis_right[2] = find_key(profile->rs_down);
-	joy_device->axis_right[3] = find_key(profile->rs_up);
+	joy_device->trigger_left  = find_key(cfg->l2);
+	joy_device->trigger_right = find_key(cfg->r2);
+	joy_device->axis_left[0]  = find_key(cfg->ls_left);
+	joy_device->axis_left[1]  = find_key(cfg->ls_right);
+	joy_device->axis_left[2]  = find_key(cfg->ls_down);
+	joy_device->axis_left[3]  = find_key(cfg->ls_up);
+	joy_device->axis_right[0] = find_key(cfg->rs_left);
+	joy_device->axis_right[1] = find_key(cfg->rs_right);
+	joy_device->axis_right[2] = find_key(cfg->rs_down);
+	joy_device->axis_right[3] = find_key(cfg->rs_up);
 
-	mapping[button::up]       = static_cast<u32>(find_key(profile->up));
-	mapping[button::down]     = static_cast<u32>(find_key(profile->down));
-	mapping[button::left]     = static_cast<u32>(find_key(profile->left));
-	mapping[button::right]    = static_cast<u32>(find_key(profile->right));
-	mapping[button::cross]    = static_cast<u32>(find_key(profile->cross));
-	mapping[button::square]   = static_cast<u32>(find_key(profile->square));
-	mapping[button::circle]   = static_cast<u32>(find_key(profile->circle));
-	mapping[button::triangle] = static_cast<u32>(find_key(profile->triangle));
-	mapping[button::l1]       = static_cast<u32>(find_key(profile->l1));
+	mapping[button::up]       = static_cast<u32>(find_key(cfg->up));
+	mapping[button::down]     = static_cast<u32>(find_key(cfg->down));
+	mapping[button::left]     = static_cast<u32>(find_key(cfg->left));
+	mapping[button::right]    = static_cast<u32>(find_key(cfg->right));
+	mapping[button::cross]    = static_cast<u32>(find_key(cfg->cross));
+	mapping[button::square]   = static_cast<u32>(find_key(cfg->square));
+	mapping[button::circle]   = static_cast<u32>(find_key(cfg->circle));
+	mapping[button::triangle] = static_cast<u32>(find_key(cfg->triangle));
+	mapping[button::l1]       = static_cast<u32>(find_key(cfg->l1));
 	mapping[button::l2]       = static_cast<u32>(joy_device->trigger_left);
-	mapping[button::l3]       = static_cast<u32>(find_key(profile->l3));
-	mapping[button::r1]       = static_cast<u32>(find_key(profile->r1));
+	mapping[button::l3]       = static_cast<u32>(find_key(cfg->l3));
+	mapping[button::r1]       = static_cast<u32>(find_key(cfg->r1));
 	mapping[button::r2]       = static_cast<u32>(joy_device->trigger_right);
-	mapping[button::r3]       = static_cast<u32>(find_key(profile->r3));
-	mapping[button::start]    = static_cast<u32>(find_key(profile->start));
-	mapping[button::select]   = static_cast<u32>(find_key(profile->select));
-	mapping[button::ps]       = static_cast<u32>(find_key(profile->ps));
+	mapping[button::r3]       = static_cast<u32>(find_key(cfg->r3));
+	mapping[button::start]    = static_cast<u32>(find_key(cfg->start));
+	mapping[button::select]   = static_cast<u32>(find_key(cfg->select));
+	mapping[button::ps]       = static_cast<u32>(find_key(cfg->ps));
 	mapping[button::ls_left]  = static_cast<u32>(joy_device->axis_left[0]);
 	mapping[button::ls_right] = static_cast<u32>(joy_device->axis_left[1]);
 	mapping[button::ls_down]  = static_cast<u32>(joy_device->axis_left[2]);
@@ -174,7 +171,7 @@ std::array<u32, PadHandlerBase::button::button_count> mm_joystick_handler::get_m
 	mapping[button::rs_down]  = static_cast<u32>(joy_device->axis_right[2]);
 	mapping[button::rs_up]    = static_cast<u32>(joy_device->axis_right[3]);
 
-	mapping[button::pressure_intensity_button] = static_cast<u32>(find_key(profile->pressure_intensity_button));
+	mapping[button::pressure_intensity_button] = static_cast<u32>(find_key(cfg->pressure_intensity_button));
 
 	return mapping;
 }

--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -118,7 +118,7 @@ public:
 
 	std::vector<std::string> ListDevices() override;
 	void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
-	void init_config(pad_config* cfg, const std::string& name) override;
+	void init_config(cfg_pad* cfg) override;
 
 private:
 	std::unordered_map<u64, u16> GetButtonValues(const JOYINFOEX& js_info, const JOYCAPS& js_caps);
@@ -133,7 +133,7 @@ private:
 
 	u64 find_key(const std::string& name) const;
 
-	std::array<u32, PadHandlerBase::button::button_count> get_mapped_key_codes(const std::shared_ptr<PadDevice>& device, const pad_config* profile) override;
+	std::array<u32, PadHandlerBase::button::button_count> get_mapped_key_codes(const std::shared_ptr<PadDevice>& device, const cfg_pad* cfg) override;
 	std::shared_ptr<PadDevice> get_device(const std::string& device) override;
 	bool get_is_left_trigger(u64 keyCode) override;
 	bool get_is_right_trigger(u64 keyCode) override;

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -89,7 +89,8 @@ void pad_thread::Init()
 
 	handlers.clear();
 
-	g_cfg_input.load(pad::g_title_id);
+	g_cfg_profile.load();
+	g_cfg_input.load(pad::g_title_id, g_cfg_profile.active_profiles.get_value(pad::g_title_id));
 
 	std::shared_ptr<keyboard_pad_handler> keyptr;
 
@@ -162,6 +163,8 @@ void pad_thread::Init()
 
 		m_pads_interface[i] = std::make_shared<Pad>(CELL_PAD_STATUS_DISCONNECTED, pad_settings[i].device_capability, pad_settings[i].device_type);
 		*m_pads_interface[i] = *m_pads[i];
+
+		input_log.notice("Pad %d: %s", i, g_cfg_input.player[i]->device.to_string());
 	}
 }
 
@@ -286,6 +289,8 @@ void pad_thread::InitLddPad(u32 handle)
 	{
 		return;
 	}
+
+	input_log.notice("Pad %d: LDD", handle);
 
 	static const auto product = input::get_product_info(input::product_type::playstation_3_controller);
 

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -83,12 +83,9 @@ xinput_pad_handler::~xinput_pad_handler()
 	}
 }
 
-void xinput_pad_handler::init_config(pad_config* cfg, const std::string& name)
+void xinput_pad_handler::init_config(cfg_pad* cfg)
 {
 	if (!cfg) return;
-
-	// Set this profile's save location
-	cfg->cfg_name = name;
 
 	// Set default button mapping
 	cfg->ls_left.def  = button_list.at(XInputKeyCodes::LSXNeg);

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -112,7 +112,7 @@ public:
 	std::vector<std::string> ListDevices() override;
 	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
-	void init_config(pad_config* cfg, const std::string& name) override;
+	void init_config(cfg_pad* cfg) override;
 
 private:
 	typedef DWORD (WINAPI * PFN_XINPUTGETEXTENDED)(DWORD, SCP_EXTN *);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1453,7 +1453,10 @@ bool game_list_frame::RemoveCustomConfiguration(const std::string& title_id, con
 
 bool game_list_frame::RemoveCustomPadConfiguration(const std::string& title_id, const game_info& game, bool is_interactive)
 {
-	const std::string config_dir = rpcs3::utils::get_custom_input_config_dir(title_id);
+	if (title_id.empty())
+		return true;
+
+	const std::string config_dir = rpcs3::utils::get_input_config_dir(title_id);
 
 	if (!fs::is_dir(config_dir))
 		return true;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -81,7 +81,7 @@ class pad_settings_dialog : public QDialog
 
 	struct pad_button
 	{
-		cfg::string* cfg_name = nullptr;
+		cfg::string* cfg_text = nullptr;
 		std::string key;
 		QString text;
 	};
@@ -98,11 +98,14 @@ public Q_SLOTS:
 private Q_SLOTS:
 	void OnPadButtonClicked(int id);
 	void OnTabChanged(int index);
-	void RefreshInputTypes();
-	void ChangeInputType();
+	void RefreshHandlers();
+	void ChangeHandler();
+	void ChangeProfile(const QString& profile);
+	void ChangeDevice(int index);
 	void HandleDeviceClassChange(int index) const;
-	/** Save the Pad Configuration to the current Pad Handler Config File */
-	void SaveProfile();
+	void AddProfile();
+	/** Update the current player config with the GUI values. */
+	void ApplyCurrentPlayerConfig(int new_player_id);
 
 private:
 	Ui::pad_settings_dialog *ui;
@@ -141,10 +144,10 @@ private:
 
 	// Pad Handlers
 	std::shared_ptr<PadHandlerBase> m_handler;
-	pad_config m_handler_cfg;
 	std::string m_device_name;
 	std::string m_profile;
 	QTimer m_timer_pad_refresh;
+	int m_last_player_id = 0;
 
 	// Remap Timer
 	const int MAX_SECONDS = 5;
@@ -176,7 +179,7 @@ private:
 	void InitButtons();
 	void ReloadButtons();
 
-	void ChangeProfile();
+	void InitPadConfig(cfg_pad& cfg, pad_handler type);
 
 	/** Repaints a stick deadzone preview label */
 	void RepaintPreviewLabel(QLabel* l, int deadzone, int desired_width, int x, int y, int squircle, double multiplier) const;
@@ -186,7 +189,13 @@ private:
 	QString GetLocalizedPadHandler(const QString& original, pad_handler handler);
 
 	/** Checks if the port at the given index is already reserved by the application as custom controller (ldd pad) */
-	bool GetIsLddPad(int index) const;
+	bool GetIsLddPad(u32 index) const;
+
+	/** Returns the current player index */
+	u32 GetPlayerIndex() const;
+
+	/** Returns the current player config */
+	cfg_pad& GetPlayerConfig() const;
 
 	/** Resizes the dialog. We need to do this because the main scroll area can't determine the size on its own. */
 	void ResizeDialog();


### PR DESCRIPTION
### Current/Old behavior:
(I'll use the XInput handler as an example, but this applies to all handlers)
- A pad profile is always tied to a handler.
So there can be multiple "Default Profiles" that each are meant for XInput, DS3 ... and so on.
- The original idea was that you could just make an Xinput profile for yourself and for example a different Xinput profile for each family member. Then everyone just had to select their profile in the correct player tab in the pad dialog and everyone would be happy...
- Changing the second Xinput pad's button mapping will also change all others unless you select a different profile for each.
- The resulting folder structure is a mess... There are a huge amount of files per handler in multiple directories (InputConfigs for example)

Since this turned out to be super unintuitive I changed it to a hopefully less confusing method.

### New Behavior:
- Each profile is now responsible for all 7 players. There are no more explicit "Xinput Profiles" etc.
So you can now for example create 7 XInput pads with different button mappings in the same profile.
- You can create new profiles as before.
- The new files are always located in "/config/input_configs/global/" or "/config/input_configs/<TITLE_ID>/"
Except for "active_configs.yml" which saves the currently chosen profiles
- You can still create one custom pad config per game.
For now there is no way to create multiple profiles for a game, but it should be relatively easy to add if necessary




fixes #10410