### PR TITLE
vk: Properly calculate cubemap memory size

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -75,7 +75,7 @@ namespace vk
 	};
 
 	void upload_image(const vk::command_buffer& cmd, vk::image* dst_image,
-		const std::vector<rsx::subresource_layout>& subresource_layout, int format, bool is_swizzled, u16 mipmap_count,
+		const std::vector<rsx::subresource_layout>& subresource_layout, int format, bool is_swizzled, u16 layer_count,
 		VkImageAspectFlags flags, vk::data_heap &upload_heap, u32 heap_align, rsx::flags32_t image_setup_flags);
 
 	//Other texture management helpers

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -921,7 +921,8 @@ namespace vk
 		rsx::flags32_t upload_command_flags = initialize_image_layout |
 			(rsx::get_current_renderer()->get_backend_config().supports_asynchronous_compute ? upload_contents_async : upload_contents_inline);
 
-		vk::upload_image(cmd, image, subresource_layout, gcm_format, input_swizzled, mipmaps, image->aspect(),
+		const u16 layer_count = (type == rsx::texture_dimension_extended::texture_dimension_cubemap) ? 6 : 1;
+		vk::upload_image(cmd, image, subresource_layout, gcm_format, input_swizzled, layer_count, image->aspect(),
 			*m_texture_upload_heap, upload_heap_align_default, upload_command_flags);
 
 		vk::leave_uninterruptible();

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
@@ -181,7 +181,7 @@ namespace vk
 		VmaAllocation vma_alloc;
 		VkMemoryRequirements mem_req = {};
 		VmaAllocationCreateInfo create_info = {};
-		VkResult error_code;
+		VkResult error_code = VK_ERROR_UNKNOWN;
 
 		auto do_vma_alloc = [&]() -> std::tuple<VkResult, u32>
 		{
@@ -309,7 +309,7 @@ namespace vk
 
 	mem_allocator_vk::mem_handle_t mem_allocator_vk::alloc(u64 block_sz, u64 /*alignment*/, const memory_type_info& memory_type, vmm_allocation_pool pool, bool throw_on_fail)
 	{
-		VkResult error_code;
+		VkResult error_code = VK_ERROR_UNKNOWN;
 		VkDeviceMemory memory;
 
 		VkMemoryAllocateInfo info = {};

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
@@ -120,7 +120,7 @@ namespace vk
 			const auto type_id = type_ids[i];
 			ensure(heap_size > 0);
 
-			const u64 used_mem = vmm_get_application_memory_usage({ type_ids[i], 0ull });
+			const u64 used_mem = vmm_get_application_memory_usage({ type_id, 0ull });
 			const u64 free_mem = (used_mem >= heap_size) ? 0ull : (heap_size - used_mem);
 
 			to_reorder |= (free_mem > last_free);


### PR DESCRIPTION
With cubemaps, each mip0 is repeated 6 times, so we need 6x the memory to get things done.

Fixes https://github.com/RPCS3/rpcs3/issues/10612