### PR TITLE
GUI: Display PKG information & installation confirmation from main menu

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -567,9 +567,9 @@ void main_window::InstallPackages(QStringList file_paths)
 		const QFileInfo file_info(file_paths[0]);
 		m_gui_settings->SetValue(gui::fd_install_pkg, file_info.path());
 	}
-	else if (file_paths.count() == 1)
+
+	if (file_paths.count() == 1 && file_paths.front().endsWith(".pkg", Qt::CaseInsensitive))
 	{
-		// This can currently only happen by drag and drop and cli arg.
 		const QString file_path = file_paths.front();
 		const QFileInfo file_info(file_path);
 
@@ -612,11 +612,13 @@ void main_window::InstallPackages(QStringList file_paths)
 			info.changelog = tr("\n\nChangelog:\n%0", "Block for Changelog").arg(info.changelog);
 		}
 
-		if (QMessageBox::question(this, tr("PKG Decrypter / Installer"), tr("Do you want to install this package?\n\n%0\n\n%1%2%3%4%5")
-			.arg(file_info.fileName()).arg(info.title).arg(info.local_cat).arg(info.title_id).arg(info.version).arg(info.changelog),
+		const QString info_string = QStringLiteral("%0\n\n%1%2%3%4%5").arg(file_info.fileName()).arg(info.title).arg(info.local_cat)
+			.arg(info.title_id).arg(info.version).arg(info.changelog);
+
+		if (QMessageBox::question(this, tr("PKG Decrypter / Installer"), tr("Do you want to install this package?\n\n%0").arg(info_string), 
 			QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
 		{
-			gui_log.notice("PKG: Cancelled installation from drop. File: %s", sstr(file_paths.front()));
+			gui_log.notice("PKG: Cancelled installation from drop.\n%s", sstr(info_string));
 			return;
 		}
 	}


### PR DESCRIPTION
QoL change, from now on you can see the package information before installing when installing from main menu. This feature used to be hidden in drag-and-drop.
This feature allows to view package information without installing it.

EDIT: + Log the information even when the package installation has been cancelled.