### PR TITLE
Fix input if the pad config file was empty

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -95,8 +95,8 @@ struct gem_config
 		u8 rumble = 0;                                     // Rumble intensity
 		gem_color sphere_rgb = {};                         // RGB color of the sphere LED
 		u32 hue = 0;                                       // Tracking hue of the motion controller
-		u32 distance{1500};                                // Distance from the camera in mm
-		u32 radius{10};                                    // Radius of the sphere in camera pixels
+		f32 distance{1500.0f};                             // Distance from the camera in mm
+		f32 radius{10.0f};                                 // Radius of the sphere in camera pixels
 
 		bool is_calibrating{false};                        // Whether or not we are currently calibrating
 		u64 calibration_start_us{0};                       // The start timestamp of the calibration in microseconds
@@ -380,7 +380,7 @@ static bool mouse_pos_to_gem_image_state(const u32 mouse_no, const gem_config::g
 	if (mouse_height <= 0) mouse_height = shared_data.height;
 	const f32 scaling_width = mouse_width / static_cast<f32>(shared_data.width);
 	const f32 scaling_height = mouse_height / static_cast<f32>(shared_data.height);
-	const f32 mmPerPixel = CELL_GEM_SPHERE_RADIUS_MM / static_cast<f32>(controller.radius);
+	const f32 mmPerPixel = CELL_GEM_SPHERE_RADIUS_MM / controller.radius;
 
 	// Image coordinates in pixels
 	const f32 image_x = static_cast<f32>(mouse.x_pos) / scaling_width;
@@ -425,7 +425,7 @@ static bool mouse_pos_to_gem_state(const u32 mouse_no, const gem_config::gem_con
 	if (mouse_height <= 0) mouse_height = shared_data.height;
 	const f32 scaling_width = mouse_width / static_cast<f32>(shared_data.width);
 	const f32 scaling_height = mouse_height / static_cast<f32>(shared_data.height);
-	const f32 mmPerPixel = CELL_GEM_SPHERE_RADIUS_MM / static_cast<f32>(controller.radius);
+	const f32 mmPerPixel = CELL_GEM_SPHERE_RADIUS_MM / controller.radius;
 
 	// Image coordinates in pixels
 	const f32 image_x = static_cast<f32>(mouse.x_pos) / scaling_width;

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -467,7 +467,7 @@ bool PadHandlerBase::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string
 	);
 
 	pad->m_buttons.emplace_back(special_button_offset, mapping[button::pressure_intensity_button], special_button_value::pressure_intensity);
-	pad->m_pressure_intensity_button_index = pad->m_buttons.size() - 1;
+	pad->m_pressure_intensity_button_index = static_cast<s32>(pad->m_buttons.size()) - 1;
 
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, mapping[button::up], CELL_PAD_CTRL_UP);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, mapping[button::down], CELL_PAD_CTRL_DOWN);

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -963,7 +963,7 @@ bool evdev_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std
 	);
 
 	pad->m_buttons.emplace_back(special_button_offset, evdevbutton(cfg->pressure_intensity_button).code, special_button_value::pressure_intensity);
-	pad->m_pressure_intensity_button_index = pad->m_buttons.size() - 1;
+	pad->m_pressure_intensity_button_index = static_cast<s32>(pad->m_buttons.size()) - 1;
 
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, evdevbutton(cfg->triangle).code, CELL_PAD_CTRL_TRIANGLE);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL2, evdevbutton(cfg->circle).code,   CELL_PAD_CTRL_CIRCLE);

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -746,7 +746,7 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::
 	);
 
 	pad->m_buttons.emplace_back(special_button_offset, find_key(cfg->pressure_intensity_button), special_button_value::pressure_intensity);
-	pad->m_pressure_intensity_button_index = pad->m_buttons.size() - 1;
+	pad->m_pressure_intensity_button_index = static_cast<s32>(pad->m_buttons.size()) - 1;
 
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(cfg->left),     CELL_PAD_CTRL_LEFT);
 	pad->m_buttons.emplace_back(CELL_PAD_BTN_OFFSET_DIGITAL1, find_key(cfg->down),     CELL_PAD_CTRL_DOWN);

--- a/rpcs3/Input/pad_thread.h
+++ b/rpcs3/Input/pad_thread.h
@@ -3,6 +3,7 @@
 #include "util/types.hpp"
 #include "util/atomic.hpp"
 #include "Emu/Io/pad_types.h"
+#include "Emu/Io/pad_config.h"
 #include "Emu/Io/pad_config_types.h"
 #include "Utilities/mutex.h"
 
@@ -30,6 +31,9 @@ public:
 
 	s32 AddLddPad();
 	void UnregisterLddPad(u32 handle);
+
+	static std::shared_ptr<PadHandlerBase> GetHandler(pad_handler type);
+	static void InitPadConfig(cfg_pad& cfg, pad_handler type, std::shared_ptr<PadHandlerBase>& handler);
 
 protected:
 	void InitLddPad(u32 handle);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -179,12 +179,8 @@ private:
 	void InitButtons();
 	void ReloadButtons();
 
-	void InitPadConfig(cfg_pad& cfg, pad_handler type);
-
 	/** Repaints a stick deadzone preview label */
 	void RepaintPreviewLabel(QLabel* l, int deadzone, int desired_width, int x, int y, int squircle, double multiplier) const;
-
-	std::shared_ptr<PadHandlerBase> GetHandler(pad_handler type) const;
 
 	QString GetLocalizedPadHandler(const QString& original, pad_handler handler);
 


### PR DESCRIPTION
- fixes some warnings
- fixes loading pad configs in the pad_thread when the file was empty (use same double load approach as in the dialog)