### PR TITLE
vk: Compatibility improvements

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -245,7 +245,7 @@ namespace vk
 		renderpass_key_blob key(renderpass_key);
 		VkSampleCountFlagBits samples = static_cast<VkSampleCountFlagBits>(key.sample_count);
 		std::vector<VkImageLayout> rtv_layouts;
-		VkImageLayout dsv_layout;
+		VkImageLayout dsv_layout = VK_IMAGE_LAYOUT_UNDEFINED;
 
 		VkFormat color_format = static_cast<VkFormat>(key.color_format);
 		VkFormat depth_format = static_cast<VkFormat>(key.depth_format);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -524,7 +524,7 @@ namespace vk
 		return m_transfer_queue_family;
 	}
 
-	const VkFormatProperties render_device::get_format_properties(VkFormat format)
+	const VkFormatProperties render_device::get_format_properties(VkFormat format) const
 	{
 		auto found = pgpu->format_properties.find(format);
 		if (found != pgpu->format_properties.end())

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -46,7 +46,7 @@ namespace vk
 		VkPhysicalDeviceMemoryProperties memory_properties;
 		std::vector<VkQueueFamilyProperties> queue_props;
 
-		std::unordered_map<VkFormat, VkFormatProperties> format_properties;
+		mutable std::unordered_map<VkFormat, VkFormatProperties> format_properties;
 		gpu_shader_types_support shader_types_support{};
 		VkPhysicalDeviceDriverPropertiesKHR driver_properties{};
 
@@ -117,7 +117,7 @@ namespace vk
 		void create(vk::physical_device& pdev, u32 graphics_queue_idx, u32 present_queue_idx, u32 transfer_queue_idx);
 		void destroy();
 
-		const VkFormatProperties get_format_properties(VkFormat format);
+		const VkFormatProperties get_format_properties(VkFormat format) const;
 
 		bool get_compatible_memory_type(u32 typeBits, u32 desired_mask, u32* type_index) const;
 		void rebalance_memory_type_usage();

--- a/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
@@ -521,10 +521,10 @@ namespace vk
 				{
 				case driver_vendor::AMD:
 				case driver_vendor::INTEL:
+				case driver_vendor::RADV:
 					break;
 				case driver_vendor::ANV:
 				case driver_vendor::NVIDIA:
-				case driver_vendor::RADV:
 					m_wm_reports_flag = true;
 					break;
 				default:


### PR DESCRIPTION
- Move RADV to unreliable OUT_OF_DATE category. This event doesn't always trigger, so just use polling as a fallback.
- Add support for fallback FSR formats. Fixes issues with some drivers like ANV not supporting BGRA8.
- Adds a workaround to disable compression as much as possible on AMD cards. This is a temporary measure until I get the required hardware. Performance is worse with this workaround in place, but at least the cards are usable for now.

Fixes https://github.com/RPCS3/rpcs3/issues/10726
Fixes https://github.com/RPCS3/rpcs3/issues/10709