### PR TITLE
Offset get_timebased_time at game boot

### DIFF
--- a/rpcs3/Emu/Cell/timers.hpp
+++ b/rpcs3/Emu/Cell/timers.hpp
@@ -3,5 +3,6 @@
 #include "util/types.hpp"
 
 u64 get_timebased_time();
+void initalize_timebased_time();
 u64 get_system_time();
 u64 get_guest_system_time();

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -642,6 +642,8 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			}
 		}
 
+		initalize_timebased_time();
+
 		// Set RTM usage
 		g_use_rtm = utils::has_rtm() && ((utils::has_mpx() && g_cfg.core.enable_TSX == tsx_usage::enabled) || g_cfg.core.enable_TSX == tsx_usage::forced);
 


### PR DESCRIPTION
Adds an offset to get_timebased_time at the time of booting a game in the emulator. This can fix some issues that appeared at very high uptime, due to games misusing floating point math.

Problematic games used a pattern of:
```
read_clock();
convert_to_float();
calculate_delta();
```
instead of:
```
read_clock();
calculate_delta();
convert_to_float();
```

which caused problems with floating point rounding at extreme values of PC uptime.



fixes: https://github.com/RPCS3/rpcs3/issues/10632

Also fixes some issues with elder scrolls and fallout games