### PR TITLE
mmjoy: fix pressure sensitivity button

### DIFF
--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -16,7 +16,7 @@
 
 class mm_joystick_handler final : public PadHandlerBase
 {
-	static constexpr u64 NO_BUTTON = 0;
+	static constexpr u64 NO_BUTTON = u64{umax};
 
 	// Unique names for the config files and our pad settings dialog
 	const std::unordered_map<u64, std::string> button_list =


### PR DESCRIPTION
It defaulted to JOY_POVFORWARD (same dumb facepalm bug as with XInput earlier)