### PR TITLE
fsr: Mark output images explicitly as nonreadable

### DIFF
--- a/rpcs3/Emu/RSX/VK/upscalers/fsr1/fsr_ubershader.glsl
+++ b/rpcs3/Emu/RSX/VK/upscalers/fsr1/fsr_ubershader.glsl
@@ -22,7 +22,7 @@ R"(
 %FFX_A_IMPORT%
 
 layout(set=0,binding=0) uniform sampler2D InputTexture;
-layout(set=0,binding=1,rgba8) uniform image2D OutputTexture;
+layout(set=0,binding=1,rgba8) uniform writeonly image2D OutputTexture;
 
 #if A_HALF
 	#if SAMPLE_EASU


### PR DESCRIPTION
Works around a hardware limitation on intel + ANV when using BGRA8 output.

Fixes https://github.com/RPCS3/rpcs3/issues/10726