### PR TITLE
vm: Fix vm::page_protect error checking

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -784,12 +784,9 @@ namespace vm
 		flags_set   &= ~flags_both;
 		flags_clear &= ~flags_both;
 
-		for (u32 i = addr / 4096; i < addr / 4096 + size / 4096; i++)
+		if (!check_addr(addr, flags_test, size))
 		{
-			if ((g_pages[i] & flags_test) != (flags_test | page_allocated))
-			{
-				return false;
-			}
+			return false;
 		}
 
 		if (!flags_set && !flags_clear)


### PR DESCRIPTION
Not only check_addr is more optimized, but is also overflow-proof (returns false for amy corner case). May be needed for #10747.