### PR TITLE
input: revert stupid ideas

### DIFF
--- a/rpcs3/Input/pad_thread.h
+++ b/rpcs3/Input/pad_thread.h
@@ -24,7 +24,7 @@ public:
 	~pad_thread();
 
 	PadInfo& GetInfo() { return m_info; }
-	auto& GetPads() { return m_pads_interface; }
+	auto& GetPads() { return m_pads; }
 	void SetRumble(const u32 pad, u8 largeMotor, bool smallMotor);
 	void Init();
 	void SetIntercepted(bool intercepted);
@@ -48,7 +48,6 @@ protected:
 
 	PadInfo m_info{ 0, 0, false };
 	std::array<std::shared_ptr<Pad>, CELL_PAD_MAX_PORT_NUM> m_pads;
-	std::array<std::shared_ptr<Pad>, CELL_PAD_MAX_PORT_NUM> m_pads_interface;
 
 	std::shared_ptr<std::thread> thread;
 


### PR DESCRIPTION
In order to make input more "atomic" I added man in the middle interfaces to decrease the delay between input and cellPad.
But I failed to notice that this introduced a data race between both ends of the pipeline.
I hope the new mutex location doesn't cause any noticeable input lag.

The internal keyboard stuff needs to stay though, since it's based on events. We would have to sprinkle the code with tons of mutex locks otherwise.   