### PR TITLE
Pad Settings: Detect duplicate buttons and show warning dialog

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -763,7 +763,7 @@ bool gs_frame::event(QEvent* ev)
 			Emu.CallAfter([this, &result, &called]()
 			{
 				m_gui_settings->ShowConfirmationBox(tr("Exit Game?"),
-					tr("Do you really want to exit the game?\n\nAny unsaved progress will be lost!\n"),
+					tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>"),
 					gui::ib_confirm_exit, &result, nullptr);
 
 				called = true;

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -160,16 +160,16 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 	if (!Emu.IsStopped())
 	{
 		QString title = tr("Close Running Game?");
-		QString message = tr("Performing this action will close the current game.\nDo you really want to continue?\n\nAny unsaved progress will be lost!\n");
+		QString message = tr("Performing this action will close the current game.<br>Do you really want to continue?<br><br>Any unsaved progress will be lost!<br>");
 
 		if (gui_save_entry == gui::ib_confirm_boot)
 		{
-			message = tr("Booting another game will close the current game.\nDo you really want to boot another game?\n\nAny unsaved progress will be lost!\n");
+			message = tr("Booting another game will close the current game.<br>Do you really want to boot another game?<br><br>Any unsaved progress will be lost!<br>");
 		}
 		else if (gui_save_entry == gui::ib_confirm_exit)
 		{
 			title = tr("Exit RPCS3?");
-			message = tr("A game is currently running. Do you really want to close RPCS3?\n\nAny unsaved progress will be lost!\n");
+			message = tr("A game is currently running. Do you really want to close RPCS3?<br><br>Any unsaved progress will be lost!<br>");
 		}
 
 		int result = QMessageBox::Yes;

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -128,6 +128,7 @@ namespace gui
 	const gui_save ib_confirm_exit = gui_save(main_window, "confirmationBoxExitGame",  true);
 	const gui_save ib_confirm_boot = gui_save(main_window, "confirmationBoxBootGame",  true);
 	const gui_save ib_obsolete_cfg = gui_save(main_window, "confirmationObsoleteCfg",  true);
+	const gui_save ib_same_buttons = gui_save(main_window, "confirmationSameButtons",  true);
 
 	const gui_save fd_install_pkg  = gui_save(main_window, "lastExplorePathPKG",  "");
 	const gui_save fd_install_pup  = gui_save(main_window, "lastExplorePathPUP",  "");

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1037,6 +1037,11 @@ void pad_settings_dialog::SwitchButtons(bool is_enabled)
 {
 	m_enable_buttons = is_enabled;
 
+	ui->chb_show_emulated_values->setEnabled(is_enabled);
+	ui->stick_multi_left->setEnabled(is_enabled);
+	ui->stick_multi_right->setEnabled(is_enabled);
+	ui->squircle_left->setEnabled(is_enabled);
+	ui->squircle_right->setEnabled(is_enabled);
 	ui->gb_pressure_intensity->setEnabled(is_enabled && m_enable_pressure_intensity_button);
 	ui->gb_vibration->setEnabled(is_enabled && m_enable_rumble);
 	ui->gb_sticks->setEnabled(is_enabled && m_enable_deadzones);
@@ -1047,6 +1052,8 @@ void pad_settings_dialog::SwitchButtons(bool is_enabled)
 	ui->gb_mouse_accel->setEnabled(is_enabled && m_handler->m_type == pad_handler::keyboard);
 	ui->gb_mouse_dz->setEnabled(is_enabled && m_handler->m_type == pad_handler::keyboard);
 	ui->gb_stick_lerp->setEnabled(is_enabled && m_handler->m_type == pad_handler::keyboard);
+	ui->chooseClass->setEnabled(is_enabled && ui->chooseClass->count() > 0);
+	ui->chooseProduct->setEnabled(is_enabled && ui->chooseProduct->count() > 0);
 	ui->buttonBox->button(QDialogButtonBox::Reset)->setEnabled(is_enabled && m_handler->m_type != pad_handler::keyboard);
 
 	for (int i = button_ids::id_pad_begin + 1; i < button_ids::id_pad_end; i++)
@@ -1317,8 +1324,6 @@ void pad_settings_dialog::ChangeHandler()
 
 	ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(!is_ldd_pad);
 	ui->chooseDevice->setEnabled(config_enabled && ui->chooseDevice->count() > 0);
-	ui->chooseClass->setEnabled(config_enabled && ui->chooseClass->count() > 0);
-	ui->chooseProduct->setEnabled(config_enabled && ui->chooseProduct->count() > 0);
 	ui->chooseHandler->setEnabled(!is_ldd_pad && ui->chooseHandler->count() > 0);
 
 	// Re-enable input timer

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -128,6 +128,7 @@ private:
 	QButtonGroup* m_pad_buttons = nullptr;
 	u32 m_button_id = id_pad_begin;
 	std::map<int /*id*/, pad_button /*info*/> m_cfg_entries;
+	std::map<int /*id*/, std::string> m_duplicate_buttons;
 
 	// Real time stick values
 	int m_lx = 0;

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1539,6 +1539,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		SubscribeTooltip(ui->cb_show_pkg_install, tooltips.settings.show_pkg_install);
 		SubscribeTooltip(ui->cb_show_pup_install, tooltips.settings.show_pup_install);
 		SubscribeTooltip(ui->cb_show_obsolete_cfg_dialog, tooltips.settings.show_obsolete_cfg);
+		SubscribeTooltip(ui->cb_show_same_buttons_dialog, tooltips.settings.show_same_buttons);
 		SubscribeTooltip(ui->gb_updates, tooltips.settings.check_update_start);
 
 		// Discord:
@@ -1612,6 +1613,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->cb_show_pkg_install->setChecked(m_gui_settings->GetValue(gui::ib_pkg_success).toBool());
 		ui->cb_show_pup_install->setChecked(m_gui_settings->GetValue(gui::ib_pup_success).toBool());
 		ui->cb_show_obsolete_cfg_dialog->setChecked(m_gui_settings->GetValue(gui::ib_obsolete_cfg).toBool());
+		ui->cb_show_same_buttons_dialog->setChecked(m_gui_settings->GetValue(gui::ib_same_buttons).toBool());
 
 		ui->combo_updates->addItem(tr("Yes", "Updates"), gui::update_on);
 		ui->combo_updates->addItem(tr("Background", "Updates"), gui::update_bkg);
@@ -1654,6 +1656,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		connect(ui->cb_show_obsolete_cfg_dialog, &QCheckBox::clicked, [this](bool val)
 		{
 			m_gui_settings->SetValue(gui::ib_obsolete_cfg, val);
+		});
+		connect(ui->cb_show_same_buttons_dialog, &QCheckBox::clicked, [this](bool val)
+		{
+			m_gui_settings->SetValue(gui::ib_same_buttons, val);
 		});
 
 		connect(ui->cb_custom_colors, &QCheckBox::clicked, [this](bool val)

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1909,10 +1909,10 @@ int settings_dialog::exec()
 			m_gui_settings->ShowConfirmationBox(
 				tr("Remove obsolete settings?"),
 				tr(
-					"Your config file contains one or more obsolete entries.\n"
-					"Consider that a removal might render them invalid for other versions of RPCS3.\n"
-					"\n"
-					"Do you wish to let the program remove them for you now?\n"
+					"Your config file contains one or more obsolete entries.<br>"
+					"Consider that a removal might render them invalid for other versions of RPCS3.<br>"
+					"<br>"
+					"Do you wish to let the program remove them for you now?<br>"
 					"This change will only be final when you save the config."
 				), gui::ib_obsolete_cfg, &result, this);
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1578,7 +1578,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		});
 
 		// colorize preview icons
-		auto add_colored_icon = [this](QPushButton *button, const QColor& color, const QIcon& icon = QIcon(), const QColor& iconColor = QColor())
+		const auto add_colored_icon = [this](QPushButton *button, const QColor& color, const QIcon& icon = QIcon(), const QColor& iconColor = QColor())
 		{
 			QLabel* text = new QLabel(button->text());
 			text->setObjectName("color_button");
@@ -1602,13 +1602,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 			button->layout()->addWidget(text);
 		};
 
-		auto add_colored_icons = [add_colored_icon, this]()
-		{
-			add_colored_icon(ui->pb_gl_icon_color, m_gui_settings->GetValue(gui::gl_iconColor).value<QColor>());
-			add_colored_icon(ui->pb_sd_icon_color, m_gui_settings->GetValue(gui::sd_icon_color).value<QColor>());
-			add_colored_icon(ui->pb_tr_icon_color, m_gui_settings->GetValue(gui::tr_icon_color).value<QColor>());
-		};
-		add_colored_icons();
+		add_colored_icon(ui->pb_gl_icon_color, m_gui_settings->GetValue(gui::gl_iconColor).value<QColor>());
+		add_colored_icon(ui->pb_sd_icon_color, m_gui_settings->GetValue(gui::sd_icon_color).value<QColor>());
+		add_colored_icon(ui->pb_tr_icon_color, m_gui_settings->GetValue(gui::tr_icon_color).value<QColor>());
 
 		ui->cb_show_welcome->setChecked(m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
 		ui->cb_show_exit_game->setChecked(m_gui_settings->GetValue(gui::ib_confirm_exit).toBool());

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -3396,6 +3396,13 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="cb_show_same_buttons_dialog">
+                <property name="text">
+                 <string>Show Duplicate Buttons Dialog</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <spacer name="guiTabSpacerRight">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -181,6 +181,7 @@ public:
 		const QString show_pkg_install   = tr("Shows a dialog when packages were installed successfully.");
 		const QString show_pup_install   = tr("Shows a dialog when firmware was installed successfully.");
 		const QString show_obsolete_cfg  = tr("Shows a dialog when obsolete settings were found.");
+		const QString show_same_buttons  = tr("Shows a dialog in the game pad configuration when the same button was assigned twice.");
 		const QString check_update_start = tr("Checks if an update is available on startup and asks if you want to update.\nIf \"Automatic\" is selected, the update will run automatically without user confirmation.\nIf \"Background\" is selected, the check is done silently in the background and a new download option is shown in the top right corner of the menu if a new version was found.");
 		const QString use_rich_presence  = tr("Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to completely close the connection.");
 		const QString discord_state      = tr("Tell your friends what you are doing.");


### PR DESCRIPTION
- Adds a confirmation dialog that notifies about duplicate button assignments when saving the pad settings.
- Adds a config entry for skipping the dialog to GUI tab in the settings dialog
- Disables more checkboxes and dropdowns in the pad settings dialog during key input (only low hanging fruits. others are sus)
- Fixes some newlines after the info box code was changed to use rich text
- Removes some obsolete code

fixes #7479