### PR TITLE
Fix DualShock stutter

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -552,12 +552,25 @@ void PadHandlerBase::get_mapping(const std::shared_ptr<PadDevice>& device, const
 
 	auto button_values = get_button_values(device);
 
+	// Find out if special buttons are pressed (introduced by RPCS3).
+	// These buttons will have a delay of one cycle, but whatever.
+	const bool adjust_pressure = pad->m_pressure_intensity_button_index >= 0 && pad->m_buttons[pad->m_pressure_intensity_button_index].m_pressed;
+
 	// Translate any corresponding keycodes to our normal DS3 buttons and triggers
 	for (auto& btn : pad->m_buttons)
 	{
-		Button tmp = btn; // Using a buffer because the values can change during translation
+		// Using a temporary buffer because the values can change during translation
+		Button tmp = btn;
 		tmp.m_value = button_values[btn.m_keyCode];
+
 		TranslateButtonPress(device, tmp.m_keyCode, tmp.m_pressed, tmp.m_value);
+
+		// Modify pressure if necessary if the button was pressed
+		if (adjust_pressure && tmp.m_pressed)
+		{
+			tmp.m_value = pad->m_pressure_intensity;
+		}
+
 		btn = tmp;
 	}
 

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -548,7 +548,7 @@ void PadHandlerBase::get_mapping(const std::shared_ptr<PadDevice>& device, const
 	if (!device || !pad)
 		return;
 
-	auto profile = device->config;
+	auto cfg = device->config;
 
 	auto button_values = get_button_values(device);
 
@@ -584,8 +584,8 @@ void PadHandlerBase::get_mapping(const std::shared_ptr<PadDevice>& device, const
 	u16 lx, ly, rx, ry;
 
 	// Normalize and apply pad squircling
-	convert_stick_values(lx, ly, stick_val[0], stick_val[1], profile->lstickdeadzone, profile->lpadsquircling);
-	convert_stick_values(rx, ry, stick_val[2], stick_val[3], profile->rstickdeadzone, profile->rpadsquircling);
+	convert_stick_values(lx, ly, stick_val[0], stick_val[1], cfg->lstickdeadzone, cfg->lpadsquircling);
+	convert_stick_values(rx, ry, stick_val[2], stick_val[3], cfg->rstickdeadzone, cfg->rpadsquircling);
 
 	if (m_type == pad_handler::ds4)
 	{

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -555,8 +555,10 @@ void PadHandlerBase::get_mapping(const std::shared_ptr<PadDevice>& device, const
 	// Translate any corresponding keycodes to our normal DS3 buttons and triggers
 	for (auto& btn : pad->m_buttons)
 	{
-		btn.m_value = button_values[btn.m_keyCode];
-		TranslateButtonPress(device, btn.m_keyCode, btn.m_pressed, btn.m_value);
+		Button tmp = btn; // Using a buffer because the values can change during translation
+		tmp.m_value = button_values[btn.m_keyCode];
+		TranslateButtonPress(device, tmp.m_keyCode, tmp.m_pressed, tmp.m_value);
+		btn = tmp;
 	}
 
 	// used to get the absolute value of an axis

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -848,13 +848,13 @@ void evdev_joystick_handler::get_mapping(const std::shared_ptr<PadDevice>& devic
 		m_dev->stick_val[idx] = m_dev->val_max[idx] - m_dev->val_min[idx];
 	}
 
-	const auto profile = m_dev->config;
+	const auto cfg = m_dev->config;
 
 	u16 lx, ly, rx, ry;
 
 	// Normalize and apply pad squircling
-	convert_stick_values(lx, ly, m_dev->stick_val[0], m_dev->stick_val[1], profile->lstickdeadzone, profile->lpadsquircling);
-	convert_stick_values(rx, ry, m_dev->stick_val[2], m_dev->stick_val[3], profile->rstickdeadzone, profile->rpadsquircling);
+	convert_stick_values(lx, ly, m_dev->stick_val[0], m_dev->stick_val[1], cfg->lstickdeadzone, cfg->lpadsquircling);
+	convert_stick_values(rx, ry, m_dev->stick_val[2], m_dev->stick_val[3], cfg->rstickdeadzone, cfg->rpadsquircling);
 
 	pad->m_sticks[0].m_value = lx;
 	pad->m_sticks[1].m_value = 255 - ly;
@@ -870,13 +870,13 @@ void evdev_joystick_handler::apply_pad_data(const std::shared_ptr<PadDevice>& de
 	if (!evdev_device)
 		return;
 
-	auto profile = device->config;
+	auto cfg = device->config;
 
 	// Handle vibration
-	const int idx_l       = profile->switch_vibration_motors ? 1 : 0;
-	const int idx_s       = profile->switch_vibration_motors ? 0 : 1;
-	const u16 force_large = profile->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value * 257 : vibration_min;
-	const u16 force_small = profile->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value * 257 : vibration_min;
+	const int idx_l       = cfg->switch_vibration_motors ? 1 : 0;
+	const int idx_s       = cfg->switch_vibration_motors ? 0 : 1;
+	const u16 force_large = cfg->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value * 257 : vibration_min;
+	const u16 force_small = cfg->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value * 257 : vibration_min;
 	SetRumble(evdev_device, force_large, force_small);
 }
 

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -782,8 +782,10 @@ void evdev_joystick_handler::get_mapping(const std::shared_ptr<PadDevice>& devic
 			}
 		}
 
-		button.m_value = static_cast<u16>(value);
-		TranslateButtonPress(m_dev, button_code, button.m_pressed, button.m_value);
+		Button tmp = button; // Using a buffer because the values can change during translation
+		tmp.m_value = static_cast<u16>(value);
+		TranslateButtonPress(m_dev, button_code, tmp.m_pressed, tmp.m_value);
+		button = tmp;
 	}
 
 	// Translate any corresponding keycodes to our two sticks. (ignoring thresholds for now)

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -244,11 +244,8 @@ void pad_thread::ThreadFunc()
 		{
 			const auto& pad = m_pads[i];
 
-			// I guess this is the best place to add pressure sensitivity without too much code duplication.
 			if (pad->m_port_status & CELL_PAD_STATUS_CONNECTED)
 			{
-				const bool adjust_pressure = pad->m_pressure_intensity_button_index >= 0 && pad->m_buttons[pad->m_pressure_intensity_button_index].m_pressed;
-
 				for (auto& button : pad->m_buttons)
 				{
 					if (button.m_pressed)
@@ -261,11 +258,6 @@ void pad_thread::ThreadFunc()
 							button.m_outKeyCode == CELL_PAD_CTRL_SELECT)
 						{
 							any_button_pressed = true;
-						}
-
-						if (adjust_pressure)
-						{
-							button.m_value = pad->m_pressure_intensity;
 						}
 					}
 				}

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -519,15 +519,15 @@ void xinput_pad_handler::apply_pad_data(const std::shared_ptr<PadDevice>& device
 		return;
 
 	const auto padnum = dev->deviceNumber;
-	const auto profile = dev->config;
+	const auto cfg = dev->config;
 
 	// The left motor is the low-frequency rumble motor. The right motor is the high-frequency rumble motor.
 	// The two motors are not the same, and they create different vibration effects. Values range between 0 to 65535.
-	const usz idx_l = profile->switch_vibration_motors ? 1 : 0;
-	const usz idx_s = profile->switch_vibration_motors ? 0 : 1;
+	const usz idx_l = cfg->switch_vibration_motors ? 1 : 0;
+	const usz idx_s = cfg->switch_vibration_motors ? 0 : 1;
 
-	const u16 speed_large = profile->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : static_cast<u16>(vibration_min);
-	const u16 speed_small = profile->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : static_cast<u16>(vibration_min);
+	const u16 speed_large = cfg->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : static_cast<u16>(vibration_min);
+	const u16 speed_small = cfg->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : static_cast<u16>(vibration_min);
 
 	dev->newVibrateData |= dev->largeVibrate != speed_large || dev->smallVibrate != speed_small;
 

--- a/rpcs3/rpcs3qt/downloader.cpp
+++ b/rpcs3/rpcs3qt/downloader.cpp
@@ -34,6 +34,8 @@ downloader::~downloader()
 
 void downloader::start(const std::string& url, bool follow_location, bool show_progress_dialog, const QString& progress_dialog_title, bool keep_progress_dialog_open, int expected_size)
 {
+	network_log.notice("Starting download from URL: %s", url);
+
 	if (m_thread)
 	{
 		if (m_thread->isRunning())


### PR DESCRIPTION
- Removes a mutex that was added for seamless input data consistency.
It caused stutter due to some handlers taking too much time.
- Adds buffers to the button value translations in the handlers for a more atomic single assignment.
This might fix some "noise" in the button values, or even unwanted button presses, caused by assigning the values twice.
This also paves the way for the next change:
- Moves pressure sensitivity button code to the handlers.
This fixes a data race, e.g. when you keep pressing that button but it might sometimes "slip" during gameplay,
causing another button to be fully pressed instead of half pressed.

fixes #10786