### PR TITLE
rsx: Fix surface access bit flags

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -42,17 +42,17 @@ namespace rsx
 		// Publicly visible enumerators
 		enum
 		{
-			shader_read = 0,
-			shader_write = 1,
-			transfer_read = 2,
-			transfer_write = 4,
+			shader_read    = (1 << 0),
+			shader_write   = (1 << 1),
+			transfer_read  = (1 << 2),
+			transfer_write = (1 << 3),
 
 			// Arbitrary r/w flags, use with caution.
-			memory_write = 8,
-			memory_read = 16,
+			memory_write   = (1 << 4),
+			memory_read    = (1 << 5),
 
 			// Not r/w but signifies a GPU reference to this object.
-			gpu_reference = 32
+			gpu_reference  = (1 << 6),
 		};
 
 	private:


### PR DESCRIPTION
- The previous enumeration was a holdover from older access management.
- A bitflag of 0 seriously messes up the mask tests as it passes all the if_xxxx tests

Fixes https://github.com/RPCS3/rpcs3/issues/10775