### PR TITLE
Patch cooperate with system SPU group creation

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -635,7 +635,9 @@ error_code sys_spu_thread_group_create(ppu_thread& ppu, vm::ptr<u32> id, u32 num
 	default: return CELL_EINVAL;
 	}
 
-	if (type & SYS_SPU_THREAD_GROUP_TYPE_COOPERATE_WITH_SYSTEM)
+	const bool is_system_coop = type & SYS_SPU_THREAD_GROUP_TYPE_COOPERATE_WITH_SYSTEM;
+
+	if (is_system_coop)
 	{
 		// Constant size, unknown what it means
 		mem_size = SPU_LS_SIZE;
@@ -653,7 +655,7 @@ error_code sys_spu_thread_group_create(ppu_thread& ppu, vm::ptr<u32> id, u32 num
 	}
 
 	if (num < min_threads || num > max_threads ||
-		(needs_root && min_prio == 0x10) || (use_scheduler && (prio > 255 || prio < min_prio)))
+		(needs_root && min_prio == 0x10) || (use_scheduler && !is_system_coop && && (prio > 255 || prio < min_prio)))
 	{
 		return CELL_EINVAL;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -655,7 +655,7 @@ error_code sys_spu_thread_group_create(ppu_thread& ppu, vm::ptr<u32> id, u32 num
 	}
 
 	if (num < min_threads || num > max_threads ||
-		(needs_root && min_prio == 0x10) || (use_scheduler && !is_system_coop && && (prio > 255 || prio < min_prio)))
+		(needs_root && min_prio == 0x10) || (use_scheduler && !is_system_coop && (prio > 255 || prio < min_prio)))
 	{
 		return CELL_EINVAL;
 	}


### PR DESCRIPTION
'Cooperate with system' SPU groups are special, should fix #10772 

TODO afterwards:
* Hwtest get priority syscall with it.
* Test this on realhw.
* There can be only one of this group type at a time on realhw, implement this behavior.

