### PR TITLE
SPU LLVM: Assorted optimizations

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -63,14 +63,24 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 		m_use_avx512 = true;
 	}
 
+	// Test VNNI feature (TODO)
+	if (cpu == "cascadelake" ||
+		cpu == "cooperlake" ||
+		cpu == "alderlake")
+	{
+		m_use_vnni = true;
+	}
+
 	// Test AVX-512_icelake features (TODO)
 	if (cpu == "icelake" ||
 		cpu == "icelake-client" ||
 		cpu == "icelake-server" ||
 		cpu == "tigerlake" ||
-		cpu == "rocketlake")
+		cpu == "rocketlake" ||
+		cpu == "sapphirerapids")
 	{
 		m_use_avx512_icl = true;
+		m_use_vnni = true;
 	}
 }
 

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -2451,6 +2451,9 @@ protected:
 	// Allow skylake-x tier AVX-512
 	bool m_use_avx512 = false;
 
+	// Allow VNNI
+	bool m_use_vnni = false;
+
 	// Allow Icelake tier AVX-512
 	bool m_use_avx512_icl = false;
 

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -2828,6 +2828,18 @@ public:
 		return result;
 	}
 
+	template <typename T1, typename T2, typename T3>
+	value_t<u32[4]> vpdpbusd(T1 a, T2 b, T3 c)
+	{
+		value_t<u32[4]> result;
+
+		const auto data0 = a.eval(m_ir);
+		const auto data1 = b.eval(m_ir);
+		const auto data2 = c.eval(m_ir);
+		result.value = m_ir->CreateCall(get_intrinsic(llvm::Intrinsic::x86_avx512_vpdpbusd_128), {data0, data1, data2});
+		return result;
+	}
+
 	template <typename T1, typename T2>
 	value_t<u8[16]> vpermb(T1 a, T2 b)
 	{

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7032,6 +7032,18 @@ public:
 
 	void SUMB(spu_opcode_t op)
 	{
+		// TODO: Some future CPUS will support VNNI but not avx512
+		if (m_use_avx512_icl)
+		{
+			const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);
+			const auto zeroes = splat<u32[4]>(0);
+			const auto ones = splat<u32[4]>(0x01010101);
+			const auto ax = bitcast<u16[8]>(vpdpbusd(zeroes, a, ones));
+			const auto bx = bitcast<u16[8]>(vpdpbusd(zeroes, b, ones));
+			set_vr(op.rt, shuffle2(ax, bx, 0, 8, 2, 10, 4, 12, 6, 14));
+			return;
+		}
+
 		const auto [a, b] = get_vrs<u16[8]>(op.ra, op.rb);
 		const auto ahs = eval((a >> 8) + (a & 0xff));
 		const auto bhs = eval((b >> 8) + (b & 0xff));

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7032,8 +7032,7 @@ public:
 
 	void SUMB(spu_opcode_t op)
 	{
-		// TODO: Some future CPUS will support VNNI but not avx512
-		if (m_use_avx512_icl)
+		if (m_use_vnni)
 		{
 			const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);
 			const auto zeroes = splat<u32[4]>(0);

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6696,16 +6696,40 @@ public:
 
 	void ROTQMBYBI(spu_opcode_t op)
 	{
+		const auto a = get_vr<u8[16]>(op.ra);
+		const auto b = get_vr<u8[16]>(op.rb);
+
+		// Data with swapped endian from a load instruction
+		if (auto [ok, as] = match_expr(a, byteswap(match<u8[16]>())); ok)
+		{
+			const auto sc = build<u8[16]>(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+			const auto sh = sc - (-(splat_scalar(b) >> 3) & 0x1f);
+			set_vr(op.rt, pshufb(as, sh));
+			return;
+		}
+
 		const auto sc = build<u8[16]>(112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127);
-		const auto sh = sc + (-(splat_scalar(get_vr<u8[16]>(op.rb)) >> 3) & 0x1f);
-		set_vr(op.rt, pshufb(get_vr<u8[16]>(op.ra), sh));
+		const auto sh = sc + (-(splat_scalar(b) >> 3) & 0x1f);
+		set_vr(op.rt, pshufb(a, sh));
 	}
 
 	void SHLQBYBI(spu_opcode_t op)
 	{
+		const auto a = get_vr<u8[16]>(op.ra);
+		const auto b = get_vr<u8[16]>(op.rb);
+
+		// Data with swapped endian from a load instruction
+		if (auto [ok, as] = match_expr(a, byteswap(match<u8[16]>())); ok)
+		{
+			const auto sc = build<u8[16]>(127, 126, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116, 115, 114, 113, 112);
+			const auto sh = sc + (splat_scalar(b) >> 3);
+			set_vr(op.rt, pshufb(as, sh));
+			return;
+		}
+
 		const auto sc = build<u8[16]>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-		const auto sh = sc - (splat_scalar(get_vr<u8[16]>(op.rb)) >> 3);
-		set_vr(op.rt, pshufb(get_vr<u8[16]>(op.ra), sh));
+		const auto sh = sc - (splat_scalar(b) >> 3);
+		set_vr(op.rt, pshufb(a, sh));
 	}
 
 	template <typename RT, typename T>
@@ -6841,6 +6865,16 @@ public:
 	{
 		const auto a = get_vr<u8[16]>(op.ra);
 		const auto b = get_vr<u8[16]>(op.rb);
+
+		// Data with swapped endian from a load instruction
+		if (auto [ok, as] = match_expr(a, byteswap(match<u8[16]>())); ok)
+		{
+			const auto sc = build<u8[16]>(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+			const auto sh = sc - (-splat_scalar(b) & 0x1f);
+			set_vr(op.rt, pshufb(as, sh));
+			return;
+		}
+
 		const auto sc = build<u8[16]>(112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127);
 		const auto sh = sc + (-splat_scalar(b) & 0x1f);
 		set_vr(op.rt, pshufb(a, sh));
@@ -6850,6 +6884,16 @@ public:
 	{
 		const auto a = get_vr<u8[16]>(op.ra);
 		const auto b = get_vr<u8[16]>(op.rb);
+
+		// Data with swapped endian from a load instruction
+		if (auto [ok, as] = match_expr(a, byteswap(match<u8[16]>())); ok)
+		{
+			const auto sc = build<u8[16]>(127, 126, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116, 115, 114, 113, 112);
+			const auto sh = sc + (splat_scalar(b) & 0x1f);
+			set_vr(op.rt, pshufb(as, sh));
+			return;
+		}
+
 		const auto sc = build<u8[16]>(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
 		const auto sh = sc - (splat_scalar(b) & 0x1f);
 		set_vr(op.rt, pshufb(a, sh));


### PR DESCRIPTION
Expands the byteswap elimination to work with more of the rotate family instructions. These instructions are rarer but may also be used to rotate recently loaded values.

Optimizes SUMB with a special VNNI path. This path uses VPDPBUSD with a multiplied value of 1 and an added value of 0 to horizontally add twice from 8 bit to 16 bit and from 16 bit to 32 bit. This instruction is only a single uop, and is the fastest way to horizontally add on x86, despite needing to multiply with 1 and add with 0.