### PR TITLE
rsx/fp: Handle signed operator precedence

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.h
@@ -9,10 +9,10 @@ namespace rsx
 	// TODO: Move this somewhere else once more compilers are supported other than glsl
 	enum texture_control_bits
 	{
-		GAMMA_R = 0,
+		GAMMA_A = 0,
+		GAMMA_R,
 		GAMMA_G,
 		GAMMA_B,
-		GAMMA_A,
 		ALPHAKILL,
 		RENORMALIZE,
 		EXPAND_A,

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -107,7 +107,9 @@ namespace rsx
 
 	u8 fragment_texture::gamma() const
 	{
-		return ((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 20) & 0xf);
+		// Converts gamma mask from RGBA to ARGB for compatibility with other per-channel mask registers
+		const u32 rgba8_ctrl = ((registers[NV4097_SET_TEXTURE_ADDRESS + (m_index * 8)] >> 20) & 0xf);
+		return ((rgba8_ctrl << 1) & 0xF) | (rgba8_ctrl >> 3);
 	}
 
 	u8 fragment_texture::aniso_bias() const


### PR DESCRIPTION
This was marked TODO for a long time since we fixed remapping for UE3
- Unsigned remap seems to be overriden by gamma mask (Resistance 3)
- We already know sign mask overrides gamma mask from UE3 titles

Fixes https://github.com/RPCS3/rpcs3/issues/10789