### PR TITLE
Removes need for sys/sysctl.h on linux

### DIFF
--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -13,6 +13,9 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
+#endif
+
+#if !defined(__linux__) && !defined(_WIN32)
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
sys/sysctl.h was removed from glibc starting with 2.32 on linux:

> * The deprecated <sys/sysctl.h> header and the sysctl function have been
>   removed.  To support old binaries, the sysctl function continues to
>   exist as a compatibility symbol (on those architectures which had it),
>   but always fails with ENOSYS.  This reflects the removal of the system
>   call from all architectures, starting with Linux 5.5.

(see https://sourceware.org/pipermail/libc-announce/2020/000029.html )