### PR TITLE
Do not allow to unpause after fatal error occured in emulation

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1580,7 +1580,7 @@ bool handle_access_violation(u32 addr, bool is_writing, x64_context* context) no
 		}
 	}
 
-	Emu.Pause();
+	Emu.Pause(true);
 
 	if (!g_tls_access_violation_recovered)
 	{

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9489,7 +9489,6 @@ struct spu_llvm_worker
 			else
 			{
 				spu_log.fatal("[0x%05x] Compilation failed.", func.entry_point);
-				Emu.Pause();
 				return;
 			}
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1404,16 +1404,26 @@ void Emulator::Run(bool start_playtime)
 	}
 }
 
-bool Emulator::Pause()
+bool Emulator::Pause(bool freeze_emulation)
 {
 	const u64 start = get_system_time();
 
+	const system_state pause_state = freeze_emulation ? system_state::frozen : system_state::paused;
+
 	// Try to pause
-	if (!m_state.compare_and_swap_test(system_state::running, system_state::paused))
+	if (!m_state.compare_and_swap_test(system_state::running, pause_state))
 	{
-		if (!m_state.compare_and_swap_test(system_state::ready, system_state::paused))
+		if (!freeze_emulation)
 		{
 			return false;
+		}
+
+		if (!m_state.compare_and_swap_test(system_state::ready, pause_state))
+		{
+			if (!m_state.compare_and_swap_test(system_state::paused, pause_state))
+			{
+				return false;
+			}
 		}
 	}
 
@@ -1424,7 +1434,14 @@ bool Emulator::Pause()
 
 	static atomic_t<u32> pause_mark = 0;
 
-	sys_log.success("Emulation is being paused... (mark=%u)", pause_mark++);
+	if (freeze_emulation)
+	{
+		sys_log.warning("Emulation has been frozen! You can either use debugger tools to inspect current emulation state or terminate it.");
+	}
+	else
+	{
+		sys_log.success("Emulation is being paused... (mark=%u)", pause_mark++);
+	}
 
 	// Update pause start time
 	if (m_pause_start_time.exchange(start))

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1289,6 +1289,11 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			{
 				ppu_exec.set_error(elf_error::header_type);
 			}
+			else
+			{
+				// Preserve emulation state for OVL excutable
+				Pause(true);
+			}
 
 			if (ppu_exec != elf_error::ok)
 			{
@@ -1306,6 +1311,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			GetCallbacks().on_ready();
 			g_fxo->init(false);
 			ppu_load_prx(ppu_prx, m_path);
+			Pause(true);
 		}
 		else if (spu_exec.open(elf_file) == elf_error::ok)
 		{
@@ -1313,6 +1319,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			GetCallbacks().on_ready();
 			g_fxo->init(false);
 			spu_load_exec(spu_exec);
+			Pause(true);
 		}
 		else
 		{

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -26,6 +26,7 @@ enum class system_state : u32
 	running,
 	stopped,
 	paused,
+	frozen, // paused but cannot resume
 	ready,
 };
 
@@ -221,7 +222,7 @@ public:
 
 	game_boot_result Load(const std::string& title_id = "", bool add_only = false, bool force_global_config = false, bool is_disc_patch = false);
 	void Run(bool start_playtime);
-	bool Pause();
+	bool Pause(bool freeze_emulation = false);
 	void Resume();
 	void Stop(bool restart = false);
 	void Restart() { Stop(true); }
@@ -232,7 +233,7 @@ public:
 	bool IsPaused()  const { return m_state >= system_state::paused; } // ready is also considered paused by this function
 	bool IsStopped() const { return m_state == system_state::stopped; }
 	bool IsReady()   const { return m_state == system_state::ready; }
-	auto GetStatus() const { return m_state.load(); }
+	auto GetStatus() const { system_state state = m_state; return state == system_state::frozen ? system_state::paused : state; }
 
 	bool HasGui() const { return m_has_gui; }
 	void SetHasGui(bool has_gui) { m_has_gui = has_gui; }

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -221,7 +221,7 @@ struct fatal_error_listener final : logs::listener
 			}
 #endif
 			// Pause emulation if fatal error encountered
-			Emu.Pause();
+			Emu.Pause(true);
 		}
 	}
 };


### PR DESCRIPTION
Added a "fatal" paused state which cannot be resumed from, used with fatal errors. Previously the user could resume emulation after a fatal error occured, but it used to be a top secret flaw only developer knew. After #10830 it became less of a secret...
+ Fixes #10590