### PR TITLE
Input: pad_thread optimizations

### DIFF
--- a/rpcs3/Emu/system_progress.hpp
+++ b/rpcs3/Emu/system_progress.hpp
@@ -37,5 +37,5 @@ struct progress_dialog_server
 	void operator()();
 	~progress_dialog_server();
 
-	static auto constexpr thread_name = "Progress Dialog Server"sv;
+	static constexpr auto thread_name = "Progress Dialog Server"sv;
 };

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -4,6 +4,7 @@
 #include "util/logs.hpp"
 #include "util/sysinfo.hpp"
 
+#include "Utilities/Thread.h"
 #include "Input/pad_thread.h"
 #include "Emu/System.h"
 #include "Emu/system_config.h"
@@ -99,7 +100,7 @@ EmuCallbacks main_application::CreateCallbacks()
 
 	callbacks.init_pad_handler = [this](std::string_view title_id)
 	{
-		g_fxo->init<pad_thread>(get_thread(), m_game_window, title_id);
+		g_fxo->init<named_thread<pad_thread>>(get_thread(), m_game_window, title_id);
 	};
 
 	callbacks.get_audio = []() -> std::shared_ptr<AudioBackend>

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1938,6 +1938,11 @@ void main_window::CreateConnects()
 
 	connect(ui->addGamesAct, &QAction::triggered, this, [this]()
 	{
+		if (!m_gui_settings->GetBootConfirmation(this))
+		{
+			return;
+		}
+
 		QStringList paths;
 
 		// Only select one folder for now
@@ -2662,6 +2667,8 @@ void main_window::CreateFirmwareCache()
 	}
 
 	Emu.SetForceBoot(true);
+	Emu.Stop();
+	Emu.SetForceBoot(true);
 
 	if (const game_boot_result error = Emu.BootGame(g_cfg.vfs.get_dev_flash() + "sys", "", true);
 		error != game_boot_result::no_errors)
@@ -2888,6 +2895,10 @@ void main_window::dropEvent(QDropEvent* event)
 		{
 			return;
 		}
+
+		Emu.SetForceBoot(true);
+		Emu.Stop();
+
 		if (const auto error = Emu.BootGame(sstr(drop_paths.first()), "", true); error != game_boot_result::no_errors)
 		{
 			gui_log.error("Boot failed: reason: %s, path: %s", error, sstr(drop_paths.first()));


### PR DESCRIPTION
- Transforms pad_thread into a named_thread
- Adds a missing loop optimization that got lost during the last refactoring
- Increases sleep times while the thread is inactive and also adds sleep during emulation pause,
this reduces CPU usage while paused