### PR TITLE
RSX: wait when emulation is paused (reduces CPU usage)

### DIFF
--- a/rpcs3/Emu/Audio/audio_device_listener.h
+++ b/rpcs3/Emu/Audio/audio_device_listener.h
@@ -18,11 +18,11 @@ private:
 
 		IFACEMETHODIMP_(ULONG) AddRef() override { return 1; };
 		IFACEMETHODIMP_(ULONG) Release() override { return 1; };
-		IFACEMETHODIMP QueryInterface(REFIID iid, void** object) override { return S_OK; };
-		IFACEMETHODIMP OnPropertyValueChanged(LPCWSTR device_id, const PROPERTYKEY key) override { return S_OK; };
-		IFACEMETHODIMP OnDeviceAdded(LPCWSTR device_id) override { return S_OK; };
-		IFACEMETHODIMP OnDeviceRemoved(LPCWSTR device_id) override { return S_OK; };
-		IFACEMETHODIMP OnDeviceStateChanged(LPCWSTR device_id, DWORD new_state) override { return S_OK; };
+		IFACEMETHODIMP QueryInterface(REFIID /*iid*/, void** /*object*/) override { return S_OK; };
+		IFACEMETHODIMP OnPropertyValueChanged(LPCWSTR /*device_id*/, const PROPERTYKEY /*key*/) override { return S_OK; };
+		IFACEMETHODIMP OnDeviceAdded(LPCWSTR /*device_id*/) override { return S_OK; };
+		IFACEMETHODIMP OnDeviceRemoved(LPCWSTR /*device_id*/) override { return S_OK; };
+		IFACEMETHODIMP OnDeviceStateChanged(LPCWSTR /*device_id*/, DWORD /*new_state*/) override { return S_OK; };
 		IFACEMETHODIMP OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR new_default_device_id) override;
 	} m_listener;
 


### PR DESCRIPTION
This decreases my cpu usage in GMPADTEST from ~9% to <1% during Emu.Pause() (together with the other pad_thread PR)