### PR TITLE
System: skip unnecessary fxo initializations

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -64,12 +64,6 @@ void fmt_class_string<patch_type>::format(std::string& out, u64 arg)
 
 patch_engine::patch_engine()
 {
-	const std::string patches_path = get_patches_path();
-
-	if (!fs::create_path(patches_path))
-	{
-		patch_log.fatal("Failed to create path: %s (%s)", patches_path, fs::g_tls_error);
-	}
 }
 
 std::string patch_engine::get_patch_config_path()


### PR DESCRIPTION
The progress_dialog and patch system aren't needed unless a game is started.

Before, the progress_dialog was initialized everytime we added a single game to the game list or even when we simply started RPCS3. This means that a thread was needlessly idling all the time.

The patch.yml was also read every time when we didn't need it, e.g. when changing the user.