### PR TITLE
Qt: release more memory when possible

### DIFF
--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -17,10 +17,10 @@ struct gui_game_info
 	compat::status compat;
 	QPixmap icon;
 	QPixmap pxmap;
-	bool hasCustomConfig;
-	bool hasCustomPadConfig;
-	bool has_hover_gif;
-	movie_item* item;
+	bool hasCustomConfig = false;
+	bool hasCustomPadConfig = false;
+	bool has_hover_gif = false;
+	movie_item* item = nullptr;
 };
 
 typedef std::shared_ptr<gui_game_info> game_info;

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2255,7 +2255,10 @@ void game_list_frame::PopulateGameList()
 
 	const std::string selected_item = CurrentSelectionPath();
 
+	// Release old data
+	m_game_grid->clear_list();
 	m_game_list->clear_list();
+
 	m_game_list->setRowCount(m_game_data.size());
 
 	// Default locale. Uses current Qt application language.
@@ -2401,6 +2404,8 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 
 	const std::string selected_item = CurrentSelectionPath();
 
+	// Release old data
+	m_game_list->clear_list();
 	m_game_grid->deleteLater();
 
 	const bool show_text = m_icon_size_index > gui::gl_max_slider_pos * 2 / 5;
@@ -2516,7 +2521,7 @@ std::string game_list_frame::CurrentSelectionPath()
 			item = m_game_list->item(m_game_list->currentRow(), 0);
 		}
 	}
-	else
+	else if (m_game_grid)
 	{
 		if (!m_game_grid->selectedItems().isEmpty())
 		{

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2289,7 +2289,7 @@ void game_list_frame::PopulateGameList()
 
 		icon_item->set_icon_func([this, icon_item, game](int)
 		{
-			ensure(icon_item);
+			ensure(icon_item && game);
 
 			if (QMovie* movie = icon_item->movie(); movie && icon_item->get_active())
 			{
@@ -2298,6 +2298,12 @@ void game_list_frame::PopulateGameList()
 			else
 			{
 				icon_item->setData(Qt::DecorationRole, game->pxmap);
+
+				if (!game->has_hover_gif)
+				{
+					game->pxmap = {};
+				}
+
 				if (movie)
 				{
 					movie->stop();

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -114,6 +114,11 @@ movie_item* game_list_grid::addItem(const game_info& app, const QString& name, c
 			painter.drawImage(offset, bg_img);
 			painter.drawPixmap(offset, app->pxmap);
 
+			if (!app->has_hover_gif)
+			{
+				app->pxmap = {};
+			}
+
 			if (movie)
 			{
 				movie->stop();


### PR DESCRIPTION
- The scaled icons were permamently kept in memory, even when they were already drawn (and thus duplicated into Qt memory).
By using shared pointers we can make sure that all icons are released from both contexts after they were drawn.
- Release old list data when switching list modes.