### PR TITLE
Remove some deprecated stuff

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -601,36 +601,24 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 
 		if (!add_only && !force_global_config && m_config_override_path.empty())
 		{
-			const std::string config_path_new = rpcs3::utils::get_custom_config_path(m_title_id);
-			const std::string config_path_old = rpcs3::utils::get_custom_config_path(m_title_id, true);
+			const std::string config_path = rpcs3::utils::get_custom_config_path(m_title_id);
 
 			// Load custom config-1
-			if (fs::file cfg_file{ config_path_old })
+			if (fs::file cfg_file{ config_path })
 			{
-				sys_log.notice("Applying custom config: %s", config_path_old);
+				sys_log.notice("Applying custom config: %s", config_path);
 
-				if (!g_cfg.from_string(cfg_file.to_string()))
+				if (g_cfg.from_string(cfg_file.to_string()))
 				{
-					sys_log.fatal("Failed to apply custom config: %s", config_path_old);
+					g_cfg.name = config_path;
+				}
+				else
+				{
+					sys_log.fatal("Failed to apply custom config: %s", config_path);
 				}
 			}
 
 			// Load custom config-2
-			if (fs::file cfg_file{ config_path_new })
-			{
-				sys_log.notice("Applying custom config: %s", config_path_new);
-
-				if (g_cfg.from_string(cfg_file.to_string()))
-				{
-					g_cfg.name = config_path_new;
-				}
-				else
-				{
-					sys_log.fatal("Failed to apply custom config: %s", config_path_new);
-				}
-			}
-
-			// Load custom config-3
 			if (fs::file cfg_file{ m_path + ".yml" })
 			{
 				sys_log.notice("Applying custom config: %s.yml", m_path);

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -214,16 +214,9 @@ namespace rpcs3::utils
 #endif
 	}
 
-	std::string get_custom_config_path(const std::string& title_id, bool get_deprecated_path)
+	std::string get_custom_config_path(const std::string& title_id)
 	{
-		std::string path;
-
-		if (get_deprecated_path)
-			path = fs::get_config_dir() + "data/" + title_id + "/config.yml";
-		else
-			path = get_custom_config_dir() + "config_" + title_id + ".yml";
-
-		return path;
+		return get_custom_config_dir() + "config_" + title_id + ".yml";
 	}
 
 	std::string get_input_config_root()

--- a/rpcs3/Emu/system_utils.hpp
+++ b/rpcs3/Emu/system_utils.hpp
@@ -26,7 +26,7 @@ namespace rpcs3::utils
 	std::string get_sfo_dir_from_game_path(const std::string& game_path, const std::string& title_id = "");
 
 	std::string get_custom_config_dir();
-	std::string get_custom_config_path(const std::string& title_id, bool get_deprecated_path = false);
+	std::string get_custom_config_path(const std::string& title_id);
 
 	std::string get_input_config_root();
 	std::string get_input_config_dir(const std::string& title_id = "");

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -140,17 +140,12 @@ void emu_settings::LoadSettings(const std::string& title_id)
 		// Otherwise we'll always trigger the "obsolete settings dialog" when editing custom configs.
 		ValidateSettings(true);
 
-		const std::string config_path_new = rpcs3::utils::get_custom_config_path(m_title_id);
-		const std::string config_path_old = rpcs3::utils::get_custom_config_path(m_title_id, true);
+		const std::string config_path = rpcs3::utils::get_custom_config_path(m_title_id);
 		std::string custom_config_path;
 
-		if (fs::is_file(config_path_new))
+		if (fs::is_file(config_path))
 		{
-			custom_config_path = config_path_new;
-		}
-		else if (fs::is_file(config_path_old))
-		{
-			custom_config_path = config_path_old;
+			custom_config_path = config_path;
 		}
 
 		if (!custom_config_path.empty())

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -621,19 +621,6 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 			QString last_played = m_persistent_settings->GetValue(gui::persistent::last_played, serial, "").toString();
 			quint64 playtime    = m_persistent_settings->GetValue(gui::persistent::playtime, serial, 0).toULongLong();
 
-			// Read deprecated gui_setting values first for backwards compatibility (older than January 12th 2020).
-			// Restrict this to empty persistent settings to keep continuity.
-			if (last_played.isEmpty())
-			{
-				last_played = m_gui_settings->GetValue(gui::persistent::last_played, serial, "").toString();
-				m_gui_settings->RemoveValue(gui::persistent::last_played, serial);
-			}
-			if (playtime <= 0)
-			{
-				playtime = m_gui_settings->GetValue(gui::persistent::playtime, serial, 0).toULongLong();
-				m_gui_settings->RemoveValue(gui::persistent::playtime, serial);
-			}
-
 			// Set persistent_settings values if values exist
 			if (!last_played.isEmpty())
 			{


### PR DESCRIPTION
- Removes reading custom configs from the /data directory which we removed a long time ago.
- Removes reading playtime info from the gui settings. We've switched to persistent_settings almost 2 years ago.
The data was already silently moved to the newer settings and removed from the gui settings if you opened the emulator at least once in that timeframe.