### PR TITLE
Improve config selection options for game startup

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -411,7 +411,8 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 	if (disc.empty() && !Emu.GetTitleID().empty())
 		disc = vfs::get(Emu.GetDir());
 
-	Emu.CallAfter([path = std::move(path), argv = std::move(argv), envp = std::move(envp), data = std::move(data), disc = std::move(disc), hdd1 = std::move(hdd1), klic = g_fxo->get<loaded_npdrm_keys>().devKlic.load()]() mutable
+	Emu.CallAfter([path = std::move(path), argv = std::move(argv), envp = std::move(envp), data = std::move(data), disc = std::move(disc)
+		, hdd1 = std::move(hdd1), klic = g_fxo->get<loaded_npdrm_keys>().devKlic.load(), old_config = Emu.GetUsedConfig()]() mutable
 	{
 		sys_process.success("Process finished -> %s", argv[0]);
 		Emu.SetForceBoot(true);
@@ -429,7 +430,7 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 
 		Emu.SetForceBoot(true);
 
-		auto res = Emu.BootGame(path, "", true);
+		auto res = Emu.BootGame(path, "", true, false, old_config);
 
 		if (res != game_boot_result::no_errors)
 		{

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -121,6 +121,7 @@ void Emulator::Init(bool add_only)
 
 	// Reset defaults, cache them
 	g_cfg.from_default();
+	g_cfg.name = cfg_keys::_default;
 
 	// Not all renderers are known at compile time, so set a provided default if possible
 	if (m_default_renderer == video_renderer::vulkan && !m_default_graphics_adapter.empty())
@@ -131,31 +132,31 @@ void Emulator::Init(bool add_only)
 
 	g_cfg_defaults = g_cfg.to_string();
 
-	// Reload override configuration set via command line
-	if (!m_config_override_path.empty())
+	// Load config file
+	if (m_config_path.find_first_of('/') != umax)
 	{
-		if (const fs::file cfg_file{m_config_override_path, fs::read + fs::create})
+		if (const fs::file cfg_file{m_config_path, fs::read + fs::create})
 		{
 			if (!g_cfg.from_string(cfg_file.to_string()))
 			{
-				sys_log.fatal("Failed to apply config override: %s. Proceeding with regular configuration.", m_config_override_path);
-				m_config_override_path.clear();
+				sys_log.fatal("Failed to apply config: %s. Proceeding with regular configuration.", m_config_path);
+				m_config_path = cfg_keys::title_id;
 			}
 			else
 			{
-				sys_log.success("Applied config override: %s", m_config_override_path);
-				g_cfg.name = m_config_override_path;
+				sys_log.success("Applied config override: %s", m_config_path);
+				g_cfg.name = m_config_path;
 			}
 		}
 		else
 		{
-			sys_log.fatal("Failed to access config override: %s (%s). Proceeding with regular configuration.", m_config_override_path, fs::g_tls_error);
-			m_config_override_path.clear();
+			sys_log.fatal("Failed to access config: %s (%s). Proceeding with regular configuration.", m_config_path, fs::g_tls_error);
+			m_config_path = cfg_keys::title_id;
 		}
 	}
 
 	// Reload global configuration
-	if (m_config_override_path.empty())
+	if (m_config_path == cfg_keys::global || m_config_path == cfg_keys::title_id)
 	{
 		const auto cfg_path = fs::get_config_dir() + "/config.yml";
 
@@ -431,7 +432,7 @@ bool Emulator::BootRsxCapture(const std::string& path)
 	return true;
 }
 
-game_boot_result Emulator::BootGame(const std::string& path, const std::string& title_id, bool direct, bool add_only, bool force_global_config)
+game_boot_result Emulator::BootGame(const std::string& path, const std::string& title_id, bool direct, bool add_only, const std::string& config_path)
 {
 	if (!fs::exists(path))
 	{
@@ -440,10 +441,12 @@ game_boot_result Emulator::BootGame(const std::string& path, const std::string& 
 
 	m_path_old = m_path;
 
+	m_config_path = config_path;
+
 	if (direct || fs::is_file(path))
 	{
 		m_path = path;
-		return Load(title_id, add_only, force_global_config);
+		return Load(title_id, add_only);
 	}
 
 	game_boot_result result = game_boot_result::nothing_to_boot;
@@ -463,7 +466,7 @@ game_boot_result Emulator::BootGame(const std::string& path, const std::string& 
 		if (fs::is_file(elf))
 		{
 			m_path = elf;
-			result = Load(title_id, add_only, force_global_config);
+			result = Load(title_id, add_only);
 			break;
 		}
 	}
@@ -484,7 +487,7 @@ game_boot_result Emulator::BootGame(const std::string& path, const std::string& 
 				if (fs::is_file(elf))
 				{
 					m_path = elf;
-					if (const auto err = Load(title_id, add_only, force_global_config); err != game_boot_result::no_errors)
+					if (const auto err = Load(title_id, add_only); err != game_boot_result::no_errors)
 					{
 						result = err;
 					}
@@ -500,9 +503,8 @@ void Emulator::SetForceBoot(bool force_boot)
 	m_force_boot = force_boot;
 }
 
-game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool force_global_config, bool is_disc_patch)
+game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool is_disc_patch)
 {
-	m_force_global_config = force_global_config;
 	const std::string resolved_path = GetCallbacks().resolve_path(m_path);
 
 	if (!IsStopped())
@@ -599,7 +601,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		sys_log.notice("Category: %s", GetCat());
 		sys_log.notice("Version: APP_VER=%s VERSION=%s", version_app, version_disc);
 
-		if (!add_only && !force_global_config && m_config_override_path.empty())
+		if (!add_only && m_config_path == cfg_keys::title_id)
 		{
 			const std::string config_path = rpcs3::utils::get_custom_config_path(m_title_id);
 
@@ -611,6 +613,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 				if (g_cfg.from_string(cfg_file.to_string()))
 				{
 					g_cfg.name = config_path;
+					m_config_path = config_path;
 				}
 				else
 				{
@@ -623,7 +626,12 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			{
 				sys_log.notice("Applying custom config: %s.yml", m_path);
 
-				if (!g_cfg.from_string(cfg_file.to_string()))
+				if (g_cfg.from_string(cfg_file.to_string()))
+				{
+					g_cfg.name = m_path + ".yml";
+					m_config_path = g_cfg.name;
+				}
+				else
 				{
 					sys_log.fatal("Failed to apply custom config: %s.yml", m_path);
 				}
@@ -854,7 +862,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 						if (fs::rename(elf_dir + "/../../", hdd0_disc + elf_dir.substr(hdd0_game.size()) + "/../../", false))
 						{
 							sys_log.success("Disc game %s moved to special location /dev_hdd0/disc/", m_title_id);
-							return m_path = hdd0_disc + m_path.substr(hdd0_game.size()), Load(m_title_id, add_only, force_global_config);
+							return m_path = hdd0_disc + m_path.substr(hdd0_game.size()), Load(m_title_id, add_only);
 						}
 
 						sys_log.error("Failed to move disc game %s to /dev_hdd0/disc/ (%s)", m_title_id, fs::g_tls_error);
@@ -1106,7 +1114,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		{
 			// Booting game update
 			sys_log.success("Updates found at /dev_hdd0/game/%s/", m_title_id);
-			return m_path = hdd0_boot, Load(m_title_id, false, force_global_config, true);
+			return m_path = hdd0_boot, Load(m_title_id, false, true);
 		}
 
 		if (!disc_psf_obj.empty())
@@ -1536,7 +1544,7 @@ void Emulator::Stop(bool restart)
 		if (restart)
 		{
 			// Reload with prior configs.
-			if (const auto error = Load(m_title_id, false, m_force_global_config); error != game_boot_result::no_errors)
+			if (const auto error = Load(m_title_id); error != game_boot_result::no_errors)
 				sys_log.error("Restart failed: %s", error);
 			return;
 		}
@@ -1646,7 +1654,7 @@ void Emulator::Stop(bool restart)
 	if (restart)
 	{
 		// Reload with prior configs.
-		if (const auto error = Load(m_title_id, false, m_force_global_config); error != game_boot_result::no_errors)
+		if (const auto error = Load(m_title_id); error != game_boot_result::no_errors)
 			sys_log.error("Restart failed: %s", error);
 		return;
 	}
@@ -1658,6 +1666,7 @@ void Emulator::Stop(bool restart)
 	disc.clear();
 	klic.clear();
 	hdd1.clear();
+	m_config_path = cfg_keys::global;
 
 	// Always Enable display sleep, not only if it was prevented.
 	enable_display_sleep();

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -43,6 +43,13 @@ enum class game_boot_result : u32
 	unsupported_disc_type
 };
 
+namespace cfg_keys
+{
+	inline const std::string title_id = "title_id"; // No config override mode
+	inline const std::string global = "global"; // Force global config
+	inline const std::string _default = "default"; // Force virtual default constructed config.yml
+}
+
 struct EmuCallbacks
 {
 	std::function<void(std::function<void()>)> call_after;
@@ -82,7 +89,7 @@ class Emulator final
 	video_renderer m_default_renderer;
 	std::string m_default_graphics_adapter;
 
-	std::string m_config_override_path;
+	std::string m_config_path;
 	std::string m_path;
 	std::string m_path_old;
 	std::string m_title_id;
@@ -94,8 +101,6 @@ class Emulator final
 	std::string m_game_dir{"PS3_GAME"};
 	std::string m_usr{"00000001"};
 	u32 m_usrid{1};
-
-	bool m_force_global_config = false;
 
 	// This flag should be adjusted before each Stop() or each BootGame() and similar because:
 	// 1. It forces an application to boot immediately by calling Run() in Load().
@@ -214,12 +219,17 @@ public:
 		return m_pause_amend_time;
 	}
 
-	game_boot_result BootGame(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, bool force_global_config = false);
+	const std::string& GetUsedConfig() const
+	{
+		return m_config_path;
+	}
+
+	game_boot_result BootGame(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, const std::string& config_path = cfg_keys::title_id);
 	bool BootRsxCapture(const std::string& path);
 
 	void SetForceBoot(bool force_boot);
 
-	game_boot_result Load(const std::string& title_id = "", bool add_only = false, bool force_global_config = false, bool is_disc_patch = false);
+	game_boot_result Load(const std::string& title_id = "", bool add_only = false, bool is_disc_patch = false);
 	void Run(bool start_playtime);
 	bool Pause();
 	void Resume();
@@ -239,7 +249,6 @@ public:
 
 	void SetDefaultRenderer(video_renderer renderer) { m_default_renderer = renderer; }
 	void SetDefaultGraphicsAdapter(std::string adapter) { m_default_graphics_adapter = std::move(adapter); }
-	void SetConfigOverride(std::string path) { m_config_override_path = std::move(path); }
 
 	std::string GetFormattedTitle(double fps) const;
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -941,6 +941,36 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	}
 
 	menu.addAction(boot);
+
+	{
+		QAction* boot_default = menu.addAction(is_current_running_game
+			? tr("&Reboot with default configuration")
+			: tr("&Boot with default configuration"));
+
+		connect(boot_default, &QAction::triggered, [this, gameinfo]
+		{
+			sys_log.notice("Booting from gamelist per context menu...");
+			Q_EMIT RequestBoot(gameinfo, cfg_keys::_default);
+		});
+
+		QAction* boot_manual = menu.addAction(is_current_running_game
+			? tr("&Reboot with manually selected configuration")
+			: tr("&Boot with manually selected configuration"));
+
+		connect(boot_manual, &QAction::triggered, [this, gameinfo]
+		{
+			if (std::string file_path = sstr(QFileDialog::getOpenFileName(this, "Select Config File", "", tr("Config Files (*.yml);;All files (*.*)"))); !file_path.empty())
+			{
+				sys_log.notice("Booting from gamelist per context menu...");
+				Q_EMIT RequestBoot(gameinfo, file_path);
+			}
+			else
+			{
+				sys_log.notice("Manual config selection aborted.");
+			}
+		});
+	}
+
 	menu.addSeparator();
 
 	QAction* configure = menu.addAction(gameinfo->hasCustomConfig
@@ -1191,7 +1221,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	connect(boot, &QAction::triggered, this, [this, gameinfo]()
 	{
 		sys_log.notice("Booting from gamelist per context menu...");
-		Q_EMIT RequestBoot(gameinfo, gameinfo->hasCustomConfig);
+		Q_EMIT RequestBoot(gameinfo, cfg_keys::global);
 	});
 	connect(configure, &QAction::triggered, this, [this, current_game, gameinfo]()
 	{

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -83,7 +83,7 @@ private Q_SLOTS:
 Q_SIGNALS:
 	void GameListFrameClosed();
 	void NotifyGameSelection(const game_info& game);
-	void RequestBoot(const game_info& game, bool force_global_config = false);
+	void RequestBoot(const game_info& game, const std::string& config_path = "title_id"); // "title_id" is cfg_keys::title_id
 	void RequestIconSizeChange(const int& val);
 	void NotifyEmuSettingsChange();
 protected:

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -312,7 +312,7 @@ void main_window::OnPlayOrPause()
 	{
 		if (m_selected_game)
 		{
-			Boot(m_selected_game->info.path, m_selected_game->info.serial, false, false, false);
+			Boot(m_selected_game->info.path, m_selected_game->info.serial);
 		}
 		else if (const auto path = Emu.GetBoot(); !path.empty())
 		{
@@ -377,7 +377,7 @@ void main_window::show_boot_error(game_boot_result status)
 	msg.exec();
 }
 
-void main_window::Boot(const std::string& path, const std::string& title_id, bool direct, bool add_only, bool force_global_config)
+void main_window::Boot(const std::string& path, const std::string& title_id, bool direct, bool add_only, const std::string& config_path)
 {
 	if (!m_gui_settings->GetBootConfirmation(this, gui::ib_confirm_boot))
 	{
@@ -389,7 +389,7 @@ void main_window::Boot(const std::string& path, const std::string& title_id, boo
 	Emu.SetForceBoot(true);
 	Emu.Stop();
 
-	if (const auto error = Emu.BootGame(path, title_id, direct, add_only, force_global_config); error != game_boot_result::no_errors)
+	if (const auto error = Emu.BootGame(path, title_id, direct, add_only, config_path); error != game_boot_result::no_errors)
 	{
 		gui_log.error("Boot failed: reason: %s, path: %s", error, path);
 		show_boot_error(error);
@@ -2482,9 +2482,9 @@ void main_window::CreateDockWindows()
 		m_selected_game = game;
 	});
 
-	connect(m_game_list_frame, &game_list_frame::RequestBoot, this, [this](const game_info& game, bool force_global_config)
+	connect(m_game_list_frame, &game_list_frame::RequestBoot, this, [this](const game_info& game, const std::string& config_path)
 	{
-		Boot(game->info.path, game->info.serial, false, false, force_global_config);
+		Boot(game->info.path, game->info.serial, false, false, config_path);
 	});
 
 	connect(m_game_list_frame, &game_list_frame::NotifyEmuSettingsChange, this, &main_window::NotifyEmuSettingsChange);

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -106,7 +106,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
 	void OnPlayOrPause();
-	void Boot(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, bool force_global_config = false);
+	void Boot(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, const std::string& config_path = "title_id"); // "title_id" is cfg_keys::title_id
 	void BootElf();
 	void BootGame();
 	void BootVSH();


### PR DESCRIPTION
* ❗❗ **Extremely useful feature for tweaking/testing config options: Implement forced default config option.** ❗❗
This simulates the config that is made when you first use the emulator.
* Implement manual selection of config file: opens a file selection dialog which is used to select used config file.
* Fix a bug which led to 'force global config' to not work for some games. (any game using process relaunch such most game collections, RDR, MGS4 etc)
* Relax CLI config purpose - instead the emulator forever ignoring any other config except for the one provided in arg, use it only for the CLI-booted game.

This is how the new context menu for it looks like:
![image](https://user-images.githubusercontent.com/18193363/132524424-924b7a33-8b43-4790-a741-cc47e2e64f0e.png)
