### PR TITLE
Fix user_interface::alloc_thread_bit() usage

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -1034,9 +1034,17 @@ namespace rsx
 
 			update_panel();
 
-			g_fxo->get<named_thread<osk_dialog_thread>>()([this, tbit = alloc_thread_bit()]
+			auto& osk_thread = g_fxo->get<named_thread<osk_dialog_thread>>();
+
+			const auto notify = std::make_shared<atomic_t<bool>>(false);
+
+			osk_thread([&, notify]()
 			{
+				const u64 tbit = alloc_thread_bit();
 				g_thread_bit = tbit;
+
+				*notify = true;
+				notify->notify_one();
 
 				if (const auto error = run_input_loop())
 				{
@@ -1046,6 +1054,11 @@ namespace rsx
 				thread_bits &= ~tbit;
 				thread_bits.notify_all();
 			});
+
+			while (osk_thread < thread_state::errored && !*notify)
+			{
+				notify->wait(false, atomic_wait_timeout{1'000'000});
+			}
 		}
 	}
 }


### PR DESCRIPTION
The reason it crashed is because enqueued task which releases thread bits never executed in RSX overlays code, user_interface class.
Aims to fix #10845 