### PR TITLE
Qt: Game Configs Sub-Menu

### DIFF
--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -17,6 +17,7 @@ struct gui_game_info
 	compat::status compat;
 	QPixmap icon;
 	QPixmap pxmap;
+	std::string selected_config = "title_id";
 	bool hasCustomConfig = false;
 	bool hasCustomPadConfig = false;
 	bool has_hover_gif = false;

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -83,7 +83,7 @@ private Q_SLOTS:
 Q_SIGNALS:
 	void GameListFrameClosed();
 	void NotifyGameSelection(const game_info& game);
-	void RequestBoot(const game_info& game, const std::string& config_path = "title_id"); // "title_id" is cfg_keys::title_id
+	void RequestBoot(const game_info& game);
 	void RequestIconSizeChange(const int& val);
 	void NotifyEmuSettingsChange();
 protected:

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2482,9 +2482,9 @@ void main_window::CreateDockWindows()
 		m_selected_game = game;
 	});
 
-	connect(m_game_list_frame, &game_list_frame::RequestBoot, this, [this](const game_info& game, const std::string& config_path)
+	connect(m_game_list_frame, &game_list_frame::RequestBoot, this, [this](const game_info& game)
 	{
-		Boot(game->info.path, game->info.serial, false, false, config_path);
+		Boot(game->info.path, game->info.serial, false, false, game->selected_config);
 	});
 
 	connect(m_game_list_frame, &game_list_frame::NotifyEmuSettingsChange, this, &main_window::NotifyEmuSettingsChange);


### PR DESCRIPTION
When config is selected from list the game won't auto-boot anymore, but will remember the choosen config. (until RPCS3 closes)
I think about this approach for savestates as well.

![image](https://user-images.githubusercontent.com/18193363/132826380-fb83d212-c68e-4516-95c2-7448dee64952.png)
