### PR TITLE
vm: Fix vm::unmap

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -558,9 +558,7 @@ void unmap_vm_area(std::shared_ptr<vm::block_t>& ptr)
 {
 	if (ptr && ptr->flags & (1ull << 62))
 	{
-		const u32 addr = ptr->addr;
-		ptr.reset();
-		vm::unmap(addr, true);
+		vm::unmap(0, true, &ptr);
 	}
 }
 
@@ -679,7 +677,7 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 			const u32 out_branch = vm::try_get_addr(dst + (offset & -4)).first;
 
 			// Allow only if points to a PPU executable instruction
-			if (out_branch < 0x10000 || out_branch >= 0x4000'0000 || !vm::check_addr<4>(out_branch, vm::alloc_executable))
+			if (out_branch < 0x10000 || out_branch >= 0x4000'0000 || !vm::check_addr<4>(out_branch, vm::page_executable))
 			{
 				continue;
 			}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2688,7 +2688,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<lv2_
 
 	if (!had_ovl)
 	{
-		ensure(vm::unmap(0x3000'0000));
+		ensure(vm::unmap(0x3000'0000).second);
 	}
 
 	g_ps3_process_info.ppc_seg = ppc_seg;

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -116,7 +116,7 @@ error_code sys_vm_unmap(ppu_thread& ppu, u32 addr)
 	const auto vmo = idm::withdraw<sys_vm_t>(sys_vm_t::find_id(addr), [&](sys_vm_t& vmo)
 	{
 		// Free block
-		ensure(vm::unmap(addr));
+		ensure(vm::unmap(addr).second);
 
 		// Return memory
 		vmo.ct->used -= vmo.psize;

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -123,7 +123,12 @@ namespace vm
 		// Common mapped region for special cases
 		std::shared_ptr<utils::shm> m_common;
 
+		atomic_t<u64> m_id = 0;
+
 		bool try_alloc(u32 addr, u64 bflags, u32 size, std::shared_ptr<utils::shm>&&) const;
+
+		// Unmap block
+		bool unmap();
 
 	public:
 		block_t(u32 addr, u32 size, u64 flags);
@@ -155,6 +160,15 @@ namespace vm
 
 		// Internal
 		u32 imp_used(const vm::writer_lock&) const;
+
+		// Returns 0 if invalid, none-zero unique id if valid
+		u64 is_valid() const
+		{
+			return m_id;
+		}
+
+		friend std::pair<std::shared_ptr<block_t>, bool> unmap(u32, bool, const std::shared_ptr<block_t>*);
+		friend void close();
 	};
 
 	// Create new memory block with specified parameters and return it
@@ -163,8 +177,8 @@ namespace vm
 	// Create new memory block with at arbitrary position with specified alignment
 	std::shared_ptr<block_t> find_map(u32 size, u32 align, u64 flags = 0);
 
-	// Delete existing memory block with specified start address, return it
-	std::shared_ptr<block_t> unmap(u32 addr, bool must_be_empty = false);
+	// Delete existing memory block with specified start address, .first=its ptr, .second=success
+	std::pair<std::shared_ptr<block_t>, bool> unmap(u32 addr, bool must_be_empty = false, const std::shared_ptr<block_t>* ptr = nullptr);
 
 	// Get memory block associated with optionally specified memory location or optionally specified address
 	std::shared_ptr<block_t> get(memory_location_t location, u32 addr = 0);


### PR DESCRIPTION
* Make vm::unmap atomic, squash the memory unmapping process inside this function while still using the same VM mutex ownership. (previously the unmapping process was executed in the block destructor after this function finishes, if the last shared_ptr went out of scope)
* Make vm::unmap not fail due to random vm::get calls, shared_ptr reference count is no longer a condition.
* Fix sys_mmapper_free_address spuriously failing with EBUSY due to random vm::get calls.
* Fix sys_vm_unmap race condition due to non-atomic vm::unmap.
* Add an optional verification block ptr arg to vm::unmap, used by patches.