### PR TITLE
Patches/PPU: Implement HLE/LLE/With-TOC function call patches

### DIFF
--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -30,6 +30,7 @@ enum class patch_type
 	code_alloc,// Allocate memory somewhere, saves branch to memory at specfied address (filled with PPU NOP and branch for returning)
 	jump, // Install special 32-bit jump instruction (PPU only atm)
 	jump_link, // jump + set link (PPU only atm)
+	jump_func, // jump to exported function (PPU only, forever)
 	byte,
 	le16,
 	le32,

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -1570,5 +1570,5 @@ DECLARE(ppu_module_manager::cellGcmSys)("cellGcmSys", []()
 	REG_FUNC(cellGcmSys, cellGcmGpadCaptureSnapshot);
 
 	// Special
-	REG_FUNC(cellGcmSys, cellGcmCallback).flag(MFF_HIDDEN);
+	REG_HIDDEN_FUNC(cellGcmCallback);
 });

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -618,5 +618,5 @@ void cellSysutil_MsgDialog_init()
 	REG_FUNC(cellSysutil, cellMsgDialogAbort);
 
 	// Helper Function
-	REG_FUNC(cellSysutil, exit_game).flag(MFF_HIDDEN);
+	REG_HIDDEN_FUNC(exit_game);
 }

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -1250,5 +1250,5 @@ DECLARE(ppu_module_manager::cellVdec)("libvdec", []()
 	REG_FUNC(libvdec, cellVdecSetFrameRateExt); // 0xcffc42a5
 	REG_FUNC(libvdec, cellVdecSetPts); // 0x3ce2e4f8
 
-	REG_FUNC(libvdec, vdecEntry).flag(MFF_HIDDEN);
+	REG_HIDDEN_FUNC(vdecEntry);
 });

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -307,6 +307,15 @@ public:
 
 	static constexpr u32 call_history_max_size = 4096;
 
+	struct hle_func_call_with_toc_info_t
+	{
+		u32 cia;
+		u64 saved_lr;
+		u64 saved_r2;
+	};
+
+	std::vector<hle_func_call_with_toc_info_t> hle_func_calls_with_toc_info;
+
 	// For named_thread ctor
 	const struct thread_name_t
 	{


### PR DESCRIPTION
This new patch type allows to insert function calls to exported functions and custom HLE functions. Not only this extends greatly the potential of functionality patches can do by itself by providing access to all PS3 firmware functions and custom PRX ones - you can register custom HLE functions in RPCS3 code with custom module name and use that in patches. In other words you can inject real C++ code into games! The downside of that is that you need to use a custom RPCS3 build which those functions exist in it, but @isJuhn had an idea a while ago that real DLL files can be used to inject such code without the need to use custom RPCS3 builds. So in the future we might see an "HLE" function loading DLL functions and injecting to games. Potential is basically endless here.

Ideas for such C++ patches for example:
* Allow you to write code in a high level language which increases productivity x10. Access to standard library and other dependencies + logging and HLE things decrease headaches 10x
* Allow access to host system which in turn can allow things like custom multiplayer implementations.
* Due to complete RSX access, replace textures and shaders in real time.

Example patches:
***
     -  [ jumpf, 0x12340, "cellGcmSys:cellGcmSetFlip"] # Places a call to cellGcmSetFlip at 0x12340
     -  [ jumpf, 0x12340, "cellGcmSys:0xDC09357E"] # Same, using FNID
***

In addition, you can specify direct address of function OPD for calls with TOC by only specifying its addres, example:
Not to be confused with jumpl, even if changing R2 is not needed do not use it as jumpl.

***
        -  [ jumpf, 0x12340, 0x2345678 ] # Function OPD based call eading OPD at 0x2345678
      # -  [ jumpl, 0x12340, 0x2345678 ] # Places a direct call to an instruction at 0x2345678 with setting LR to CIA + 4. 
***

Notes:

1. Function can be specified as either hexadecimal FNID (with '0x' prefix) or as raw string which the FNID will be generated from.
2. The order of module/function is the opposite from what's used in our PPU disassembler by the debugger. Take that into account when making patches using the disassmbler information.
3. You must always return to the caller with these patches in the right order so saved registers memory is cleaned. (unless thread execution is finished such as after sys_ppu_thread_exit)