### PR TITLE
Qt: Pad settings dialog fixes

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -137,6 +137,8 @@ void Emulator::Init(bool add_only)
 	{
 		if (const fs::file cfg_file{m_config_path, fs::read + fs::create})
 		{
+			sys_log.notice("Applying config override: %s", m_config_path);
+
 			if (!g_cfg.from_string(cfg_file.to_string()))
 			{
 				sys_log.fatal("Failed to apply config: %s. Proceeding with regular configuration.", m_config_path);
@@ -162,6 +164,8 @@ void Emulator::Init(bool add_only)
 
 		if (const fs::file cfg_file{cfg_path, fs::read + fs::create})
 		{
+			sys_log.notice("Applying global config: %s", cfg_path);
+
 			if (!g_cfg.from_string(cfg_file.to_string()))
 			{
 				sys_log.fatal("Failed to apply global config: %s", cfg_path);
@@ -516,6 +520,8 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 	{
 		m_title_id = title_id;
 	}
+
+	sys_log.notice("Selected config: %s", m_config_path);
 
 	{
 		Init(add_only);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -915,7 +915,7 @@ void pad_settings_dialog::UpdateLabels(bool is_reset)
 {
 	if (is_reset)
 	{
-		const auto& cfg = GetPlayerConfig();
+		const cfg_pad& cfg = GetPlayerConfig();
 
 		// Update device class
 		ui->chooseClass->setCurrentIndex(cfg.device_class_type);
@@ -1518,7 +1518,7 @@ void pad_settings_dialog::RefreshHandlers()
 
 void pad_settings_dialog::ApplyCurrentPlayerConfig(int new_player_id)
 {
-	if (!m_handler || new_player_id < 0)
+	if (!m_handler || new_player_id < 0 || static_cast<u32>(new_player_id) >= g_cfg_input.player.size())
 	{
 		return;
 	}
@@ -1527,17 +1527,6 @@ void pad_settings_dialog::ApplyCurrentPlayerConfig(int new_player_id)
 
 	auto& player = g_cfg_input.player[m_last_player_id];
 	m_last_player_id = new_player_id;
-
-	// Check for invalid selection
-	if (!ui->chooseDevice->isEnabled() || ui->chooseDevice->currentIndex() < 0)
-	{
-		const u32 played_id = GetPlayerIndex();
-		g_cfg_input.player[played_id]->handler.from_default();
-		g_cfg_input.player[played_id]->device.from_default();
-		g_cfg_input.player[played_id]->config.from_default();
-
-		return;
-	}
 
 	// Check for duplicate button choices
 	if (m_handler->m_type != pad_handler::null)

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -558,18 +558,6 @@ void pad_settings_dialog::ReloadButtons()
 
 	updateButton(button_ids::id_pressure_intensity, ui->b_pressure_intensity, &cfg.pressure_intensity_button);
 
-	m_min_force = m_handler->vibration_min;
-	m_max_force = m_handler->vibration_max;
-
-	// Enable Vibration Checkboxes
-	m_enable_rumble = m_handler->has_rumble();
-
-	// Enable Deadzone Settings
-	m_enable_deadzones = m_handler->has_deadzones();
-
-	// Enable Pressure Sensitivity Settings
-	m_enable_pressure_intensity_button = m_handler->has_pressure_intensity_button();
-
 	UpdateLabels(true);
 }
 
@@ -1216,6 +1204,19 @@ void pad_settings_dialog::ChangeHandler()
 #endif
 	}
 	ui->l_description->setText(m_description);
+
+	// Update parameters
+	m_min_force = m_handler->vibration_min;
+	m_max_force = m_handler->vibration_max;
+
+	// Enable Vibration Checkboxes
+	m_enable_rumble = m_handler->has_rumble();
+
+	// Enable Deadzone Settings
+	m_enable_deadzones = m_handler->has_deadzones();
+
+	// Enable Pressure Sensitivity Settings
+	m_enable_pressure_intensity_button = m_handler->has_pressure_intensity_button();
 
 	// Change our contextual widgets
 	ui->left_stack->setCurrentIndex((m_handler->m_type == pad_handler::keyboard) ? 1 : 0);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1209,6 +1209,12 @@ void pad_settings_dialog::ChangeHandler()
 	m_min_force = m_handler->vibration_min;
 	m_max_force = m_handler->vibration_max;
 
+	// Reset parameters
+	m_lx = 0;
+	m_ly = 0;
+	m_rx = 0;
+	m_ry = 0;
+
 	// Enable Vibration Checkboxes
 	m_enable_rumble = m_handler->has_rumble();
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1176,6 +1176,7 @@ void pad_settings_dialog::ChangeHandler()
 	switch (m_handler->m_type)
 	{
 	case pad_handler::null:
+		GetPlayerConfig().from_default();
 		if (is_ldd_pad)
 			m_description = tooltips.gamepad_settings.ldd_pad;
 		else


### PR DESCRIPTION
- Adds more logging to Emu.Init and Emu.Load
- Fixes pad settings dialog. Switching to Player 2 null handler and then back to Player 1 resulted in a reset of player 1.
- Reset config and GUI parameters when changing handlers. This fixes some visual inconsistencies in the dialog.