### PR TITLE
RSX fixes

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.cpp
@@ -11,7 +11,7 @@ namespace
 		switch (format)
 		{
 			case VK_FORMAT_R5G6B5_UNORM_PACK16:
-				return "r16ui";
+				return "r16";
 			case VK_FORMAT_R8G8B8A8_UNORM:
 			case VK_FORMAT_B8G8R8A8_UNORM:
 				return "rgba8";
@@ -20,7 +20,7 @@ namespace
 			case VK_FORMAT_R32G32B32A32_SFLOAT:
 				return "rgba32f";
 			case VK_FORMAT_A1R5G5B5_UNORM_PACK16:
-				return "r16ui";
+				return "r16";
 			case VK_FORMAT_R8_UNORM:
 				return "r8";
 			case VK_FORMAT_R8G8_UNORM:

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -332,6 +332,11 @@ namespace vk
 			enabled_features.shaderStorageImageWriteWithoutFormat = VK_TRUE;
 		}
 
+		if (g_cfg.video.precise_zpass_count)
+		{
+			enabled_features.occlusionQueryPrecise = VK_TRUE;
+		}
+
 		// enabled_features.shaderSampledImageArrayDynamicIndexing = TRUE;  // Unused currently but will be needed soon
 		enabled_features.shaderClipDistance = VK_TRUE;
 		// enabled_features.shaderCullDistance = VK_TRUE;  // Alt notation of clip distance
@@ -404,6 +409,12 @@ namespace vk
 			// AMD proprietary drivers do not expose alphaToOne support
 			rsx_log.error("Your GPU does not support alpha-to-one for multisampling. Graphics may be inaccurate when MSAA is enabled.");
 			enabled_features.alphaToOne = VK_FALSE;
+		}
+
+		if (!pgpu->features.occlusionQueryPrecise && enabled_features.occlusionQueryPrecise)
+		{
+			rsx_log.error("Your GPU does not support precise occlusion queries. Graphics may not render correctly.");
+			enabled_features.occlusionQueryPrecise = VK_FALSE;
 		}
 
 		VkDeviceCreateInfo device = {};


### PR DESCRIPTION
Fixes spam while debug output is enabled on precise zcull.
`RSX: ERROR: [Validation] Code 0 : Validation Error: [ VUID-vkCmdBeginQuery-queryType-00800 ] Object 0: handle = 0x12f21020, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xdf111ec0 | vkCmdBeginQuery(): VK_QUERY_CONTROL_PRECISE_BIT provided, but precise occlusion queries not enabled on the device. The Vulkan spec states: If the precise occlusion queries feature is not enabled, or the queryType used to create queryPool was not VK_QUERY_TYPE_OCCLUSION, flags must not contain VK_QUERY_CONTROL_PRECISE_BIT (https://vulkan.lunarg.com/doc/view/1.2.154.1/windows/1.2-extensions/vkspec.html#VUID-vkCmdBeginQuery-queryType-00800)`
Every desktop GPU supports this, so there's no need to check if the GPU supports this feature.