### PR TITLE
CPUThread: Prevent recursive check_state calls (fixup after #8514)

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -469,7 +469,7 @@ void cpu_thread::operator()()
 		cpu_thread* _cpu = get_current_cpu_thread();
 
 		// Wait flag isn't set asynchronously so this should be thread-safe
-		if (progress == 0 && cpu_flag::wait - _cpu->state)
+		if (progress == 0 && _cpu->state.none_of(cpu_flag::wait + cpu_flag::temp))
 		{
 			// Operation just started and syscall is imminent
 			_cpu->state += cpu_flag::wait + cpu_flag::temp;
@@ -739,7 +739,7 @@ bool cpu_thread::check_state() noexcept
 				cpu_counter::add(this);
 			}
 
-			if (state & cpu_flag::pending)
+			if ((state0 & (cpu_flag::pending + cpu_flag::temp)) == cpu_flag::pending)
 			{
 				// Execute pending work
 				cpu_work();

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -3172,7 +3172,7 @@ bool spu_thread::process_mfc_cmd()
 		mfc_last_timestamp = 0;
 
 		// Process MFC commands
-		if (!test_stopped())
+		if (test_stopped())
 		{
 			return false;
 		}


### PR DESCRIPTION
In accurate SPU DMA mode notify_all() is used in do_mfc() thus check_state is called within it. Also adds an option to explicitly disable check_state() calls in atomic wait callback by using flag cpu_flag::temp.