### PR TITLE
Improve cellOskDialog. Partially fixes some more games that use it (mostly online games)

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -70,6 +70,31 @@ struct osk_info
 	atomic_t<vm::ptr<cellOskDialogConfirmWordFilterCallback>> osk_confirm_callback{};
 
 	stx::init_mutex init;
+
+	void reset()
+	{
+		dlg.reset();
+		use_separate_windows = false;
+		lock_ext_input = false;
+		device_mask = 0;
+		key_layout = CELL_OSKDIALOG_10KEY_PANEL;
+		initial_key_layout = CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_SYSTEM;
+		initial_input_device = CELL_OSKDIALOG_INPUT_DEVICE_PAD;
+		clipboard_enabled = false;
+		half_byte_kana_enabled = false;
+		supported_languages = 0;
+		dimmer_enabled = true;
+		base_color_red = 1.0f;
+		base_color_blue = 1.0f;
+		base_color_green = 1.0f;
+		base_color_alpha = 1.0f;
+		pointer_enabled = false;
+		pointer_pos = {0.0f, 0.0f};
+		initial_scale = 1.0f;
+		layout_mode = CELL_OSKDIALOG_LAYOUTMODE_X_ALIGN_LEFT | CELL_OSKDIALOG_LAYOUTMODE_Y_ALIGN_TOP;
+		osk_continuous_mode = CELL_OSKDIALOG_CONTINUOUS_MODE_NONE;
+		osk_confirm_callback.store({});
+	}
 };
 
 // TODO: don't use this function
@@ -370,8 +395,7 @@ error_code getText(vm::ptr<CellOskDialogCallbackReturnParam> OutputInfo, bool is
 		// Unload should be called last, so remove the dialog here
 		if (const auto reset_lock = g_fxo->get<osk_info>().init.reset())
 		{
-			// TODO
-			g_fxo->get<osk_info>().dlg.reset();
+			g_fxo->get<osk_info>().reset();
 		}
 
 		sysutil_send_system_cmd(CELL_SYSUTIL_OSKDIALOG_UNLOADED, 0);

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -123,17 +123,15 @@ std::shared_ptr<OskDialogBase> _get_osk_dialog(bool create = false)
 
 		return osk.dlg;
 	}
-	else
+
+	const auto init = osk.init.access();
+
+	if (!init)
 	{
-		const auto init = osk.init.access();
-
-		if (!init)
-		{
-			return nullptr;
-		}
-
-		return osk.dlg;
+		return nullptr;
 	}
+
+	return osk.dlg;
 }
 
 error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dialogParam, vm::ptr<CellOskDialogInputFieldInfo> inputFieldInfo)
@@ -301,16 +299,6 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 		input::SetIntercepted(false);
 	};
 
-	osk->on_osk_input_entered = [wptr = std::weak_ptr<OskDialogBase>(osk)]()
-	{
-		const auto osk = wptr.lock();
-
-		if (g_fxo->get<osk_info>().use_separate_windows.load() && (g_fxo->get<osk_info>().osk_continuous_mode.load() != CELL_OSKDIALOG_CONTINUOUS_MODE_NONE))
-		{
-			sysutil_send_system_cmd(CELL_SYSUTIL_OSKDIALOG_INPUT_ENTERED, 0);
-		}
-	};
-
 	input::SetIntercepted(true);
 
 	Emu.CallAfter([=, &result]()
@@ -332,7 +320,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 error_code cellOskDialogLoadAsyncExt()
 {
-	UNIMPLEMENTED_FUNC(cellOskDialog);
+	cellOskDialog.todo("cellOskDialogLoadAsyncExt()");
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -43,6 +43,28 @@ struct osk_info
 
 	atomic_t<bool> use_separate_windows = false;
 
+	atomic_t<bool> lock_ext_input = false;
+	atomic_t<u32> device_mask = 0; // 0 means all devices can influence the OSK
+	atomic_t<u32> key_layout = CELL_OSKDIALOG_10KEY_PANEL;
+	atomic_t<CellOskDialogInitialKeyLayout> initial_key_layout = CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_SYSTEM;
+	atomic_t<CellOskDialogInputDevice> initial_input_device = CELL_OSKDIALOG_INPUT_DEVICE_PAD;
+
+	atomic_t<bool> clipboard_enabled = false; // For copy and paste
+	atomic_t<bool> half_byte_kana_enabled = false;
+	atomic_t<u32> supported_languages = 0; // Used to enable non-default languages in the OSK
+
+	atomic_t<bool> dimmer_enabled = true;
+	atomic_t<f32> base_color_red = 1.0f;
+	atomic_t<f32> base_color_blue = 1.0f;
+	atomic_t<f32> base_color_green = 1.0f;
+	atomic_t<f32> base_color_alpha = 1.0f;
+
+	atomic_t<bool> pointer_enabled = false;
+	CellOskDialogPoint pointer_pos{0.0f, 0.0f};
+	atomic_t<f32> initial_scale = 1.0f;
+
+	atomic_t<u32> layout_mode = CELL_OSKDIALOG_LAYOUTMODE_X_ALIGN_LEFT | CELL_OSKDIALOG_LAYOUTMODE_Y_ALIGN_TOP;
+
 	atomic_t<CellOskDialogContinuousMode> osk_continuous_mode = CELL_OSKDIALOG_CONTINUOUS_MODE_NONE;
 
 	atomic_t<vm::ptr<cellOskDialogConfirmWordFilterCallback>> osk_confirm_callback{};
@@ -431,6 +453,13 @@ error_code cellOskDialogAbort()
 error_code cellOskDialogSetDeviceMask(u32 deviceMask)
 {
 	cellOskDialog.todo("cellOskDialogSetDeviceMask(deviceMask=0x%x)", deviceMask);
+
+	// TODO: error checks. It probably checks for use_separate_windows
+
+	g_fxo->get<osk_info>().device_mask = deviceMask;
+
+	// TODO: change osk device input
+
 	return CELL_OK;
 }
 
@@ -443,30 +472,50 @@ error_code cellOskDialogSetSeparateWindowOption(vm::ptr<CellOskDialogSeparateWin
 		return CELL_OSKDIALOG_ERROR_PARAM;
 	}
 
-	if (auto& osk = g_fxo->get<osk_info>(); true)
-	{
-		osk.use_separate_windows = true;
-		osk.osk_continuous_mode  = static_cast<CellOskDialogContinuousMode>(+windowOption->continuousMode);
-	}
+	auto& osk = g_fxo->get<osk_info>();
+	osk.use_separate_windows = true;
+	osk.osk_continuous_mode  = static_cast<CellOskDialogContinuousMode>(+windowOption->continuousMode);
+	// TODO: rest
 
 	return CELL_OK;
 }
 
-error_code cellOskDialogSetInitialInputDevice(vm::ptr<CellOskDialogInputDevice> inputDevice)
+error_code cellOskDialogSetInitialInputDevice(u32 inputDevice)
 {
-	cellOskDialog.todo("cellOskDialogSetInitialInputDevice(inputDevice=*0x%x)", inputDevice);
+	cellOskDialog.todo("cellOskDialogSetInitialInputDevice(inputDevice=%d)", inputDevice);
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().initial_input_device = static_cast<CellOskDialogInputDevice>(inputDevice);
+
+	// TODO: use value
+
 	return CELL_OK;
 }
 
-error_code cellOskDialogSetInitialKeyLayout(vm::ptr<CellOskDialogInitialKeyLayout> initialKeyLayout)
+error_code cellOskDialogSetInitialKeyLayout(u32 initialKeyLayout)
 {
-	cellOskDialog.todo("cellOskDialogSetInitialKeyLayout(initialKeyLayout=*0x%x)", initialKeyLayout);
+	cellOskDialog.todo("cellOskDialogSetInitialKeyLayout(initialKeyLayout=%d)", initialKeyLayout);
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().initial_key_layout = static_cast<CellOskDialogInitialKeyLayout>(initialKeyLayout);
+
+	// TODO: use value
+
 	return CELL_OK;
 }
 
 error_code cellOskDialogDisableDimmer()
 {
 	cellOskDialog.todo("cellOskDialogDisableDimmer()");
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().dimmer_enabled = false;
+
+	// TODO: use value
+
 	return CELL_OK;
 }
 
@@ -479,18 +528,47 @@ error_code cellOskDialogSetKeyLayoutOption(u32 option)
 		return CELL_OSKDIALOG_ERROR_PARAM;
 	}
 
+	g_fxo->get<osk_info>().key_layout = option;
+
+	// TODO: use value
+
 	return CELL_OK;
 }
 
 error_code cellOskDialogAddSupportLanguage(u32 supportLanguage)
 {
 	cellOskDialog.todo("cellOskDialogAddSupportLanguage(supportLanguage=0x%x)", supportLanguage);
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().supported_languages = supportLanguage;
+
+	// TODO: disable extra languages unless they were enabled here
+	// Extra languages are:
+	// CELL_OSKDIALOG_PANELMODE_POLISH
+	// CELL_OSKDIALOG_PANELMODE_KOREAN
+	// CELL_OSKDIALOG_PANELMODE_TURKEY
+	// CELL_OSKDIALOG_PANELMODE_TRADITIONAL_CHINESE
+	// CELL_OSKDIALOG_PANELMODE_SIMPLIFIED_CHINESE
+	// CELL_OSKDIALOG_PANELMODE_PORTUGUESE_BRAZIL
+	// CELL_OSKDIALOG_PANELMODE_DANISH
+	// CELL_OSKDIALOG_PANELMODE_SWEDISH
+	// CELL_OSKDIALOG_PANELMODE_NORWEGIAN
+	// CELL_OSKDIALOG_PANELMODE_FINNISH
+
 	return CELL_OK;
 }
 
 error_code cellOskDialogSetLayoutMode(s32 layoutMode)
 {
 	cellOskDialog.todo("cellOskDialogSetLayoutMode(layoutMode=%d)", layoutMode);
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().layout_mode = layoutMode;
+
+	// TODO: use layout mode
+
 	return CELL_OK;
 }
 
@@ -498,12 +576,6 @@ error_code cellOskDialogGetInputText(vm::ptr<CellOskDialogCallbackReturnParam> O
 {
 	cellOskDialog.warning("cellOskDialogGetInputText(OutputInfo=*0x%x)", OutputInfo);
 	return getText(OutputInfo, false);
-}
-
-error_code cellOskDialogExtInputDeviceUnlock()
-{
-	cellOskDialog.todo("cellOskDialogExtInputDeviceUnlock()");
-	return CELL_OK;
 }
 
 error_code register_keyboard_event_hook_callback(u16 hookEventMode, vm::ptr<cellOskDialogHardwareKeyboardEventHookCallback> pCallback)
@@ -514,6 +586,8 @@ error_code register_keyboard_event_hook_callback(u16 hookEventMode, vm::ptr<cell
 	{
 		return CELL_OSKDIALOG_ERROR_PARAM;
 	}
+
+	// TODO: register callback and and use it
 
 	return CELL_OK;
 }
@@ -551,6 +625,13 @@ error_code cellOskDialogExtAddJapaneseOptionDictionary(vm::cpptr<char> filePath)
 error_code cellOskDialogExtEnableClipboard()
 {
 	cellOskDialog.todo("cellOskDialogExtEnableClipboard()");
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().clipboard_enabled = true;
+
+	// TODO: implement copy paste
+
 	return CELL_OK;
 }
 
@@ -580,18 +661,56 @@ error_code cellOskDialogExtAddOptionDictionary(vm::cptr<CellOskDialogImeDictiona
 error_code cellOskDialogExtSetInitialScale(f32 initialScale)
 {
 	cellOskDialog.todo("cellOskDialogExtSetInitialScale(initialScale=%f)", initialScale);
+
+	// TODO: error checks (CELL_OSKDIALOG_SCALE_MIN, CELL_OSKDIALOG_SCALE_MAX)
+
+	g_fxo->get<osk_info>().initial_scale = initialScale;
+
+	// TODO: implement overlay scaling
+
 	return CELL_OK;
 }
 
 error_code cellOskDialogExtInputDeviceLock()
 {
 	cellOskDialog.todo("cellOskDialogExtInputDeviceLock()");
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().lock_ext_input = true;
+
+	// TODO: change osk device input
+
+	return CELL_OK;
+}
+
+error_code cellOskDialogExtInputDeviceUnlock()
+{
+	cellOskDialog.todo("cellOskDialogExtInputDeviceUnlock()");
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().lock_ext_input = false;
+
+	// TODO: change osk device input
+
 	return CELL_OK;
 }
 
 error_code cellOskDialogExtSetBaseColor(f32 red, f32 blue, f32 green, f32 alpha)
 {
 	cellOskDialog.todo("cellOskDialogExtSetBaseColor(red=%f, blue=%f, green=%f, alpha=%f)", red, blue, green, alpha);
+
+	// TODO: error checks
+
+	auto& osk = g_fxo->get<osk_info>();
+	osk.base_color_red = red;
+	osk.base_color_blue = blue;
+	osk.base_color_green = green;
+	osk.base_color_alpha = alpha;
+
+	// TODO: use osk base color
+
 	return CELL_OK;
 }
 
@@ -604,10 +723,7 @@ error_code cellOskDialogExtRegisterConfirmWordFilterCallback(vm::ptr<cellOskDial
 		return CELL_OSKDIALOG_ERROR_PARAM;
 	}
 
-	if (auto& osk = g_fxo->get<osk_info>(); true)
-	{
-		osk.osk_confirm_callback = pCallback;
-	}
+	g_fxo->get<osk_info>().osk_confirm_callback = pCallback;
 
 	return CELL_OK;
 }
@@ -618,27 +734,58 @@ error_code cellOskDialogExtUpdateInputText()
 	return CELL_OK;
 }
 
-error_code cellOskDialogExtDisableHalfByteKana()
-{
-	cellOskDialog.todo("cellOskDialogExtDisableHalfByteKana()");
-	return CELL_OK;
-}
-
 error_code cellOskDialogExtSetPointerEnable(b8 enable)
 {
 	cellOskDialog.todo("cellOskDialogExtSetPointerEnable(enable=%d)", enable);
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().pointer_enabled = enable;
+
+	// TODO: use new value in osk
+
 	return CELL_OK;
 }
 
-error_code cellOskDialogExtUpdatePointerDisplayPos(/*const CellOskDialogPoint pos*/)
+error_code cellOskDialogExtUpdatePointerDisplayPos(vm::cptr<CellOskDialogPoint> pos)
 {
-	cellOskDialog.todo("cellOskDialogExtUpdatePointerDisplayPos(posX=%f, posY=%f)"/*, pos.x, pos.y*/);
+	cellOskDialog.todo("cellOskDialogExtUpdatePointerDisplayPos(pos=0x%x, posX=%f, posY=%f)", pos->x, pos->y);
+
+	// TODO: error checks
+
+	if (pos)
+	{
+		g_fxo->get<osk_info>().pointer_pos = *pos;
+	}
+
+	// TODO: use new value in osk
+
 	return CELL_OK;
 }
 
 error_code cellOskDialogExtEnableHalfByteKana()
 {
 	cellOskDialog.todo("cellOskDialogExtEnableHalfByteKana()");
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().half_byte_kana_enabled = true;
+
+	// TODO: use new value in osk
+
+	return CELL_OK;
+}
+
+error_code cellOskDialogExtDisableHalfByteKana()
+{
+	cellOskDialog.todo("cellOskDialogExtDisableHalfByteKana()");
+
+	// TODO: error checks
+
+	g_fxo->get<osk_info>().half_byte_kana_enabled = false;
+
+	// TODO: use new value in osk
+
 	return CELL_OK;
 }
 
@@ -650,6 +797,8 @@ error_code cellOskDialogExtRegisterForceFinishCallback(vm::ptr<cellOskDialogForc
 	{
 		return CELL_OSKDIALOG_ERROR_PARAM;
 	}
+
+	// TODO: register and use force finish callback (PS button during continuous mode)
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -238,7 +238,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 	{
 		const auto osk = wptr.lock();
 
-		if (g_fxo->get<osk_info>().use_separate_windows.load())
+		if (g_fxo->get<osk_info>().use_separate_windows.load() && (g_fxo->get<osk_info>().osk_continuous_mode.load() != CELL_OSKDIALOG_CONTINUOUS_MODE_NONE))
 		{
 			sysutil_send_system_cmd(CELL_SYSUTIL_OSKDIALOG_INPUT_ENTERED, 0);
 		}

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -262,5 +262,4 @@ public:
 
 	atomic_t<CellOskDialogInputFieldResult> osk_input_result{ CellOskDialogInputFieldResult::CELL_OSKDIALOG_INPUT_FIELD_RESULT_OK };
 	char16_t osk_text[CELL_OSKDIALOG_STRING_SIZE]{};
-	char16_t osk_text_old[CELL_OSKDIALOG_STRING_SIZE]{};
 };

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -83,6 +83,11 @@ enum CellOskDialogFinishReason
 	CELL_OSKDIALOG_CLOSE_CANCEL = 1,
 };
 
+enum CellOskDialogFinishReasonFake // Helper. Must be negative values.
+{
+	FAKE_CELL_OSKDIALOG_CLOSE_ABORT = -1,
+};
+
 enum CellOskDialogType
 {
 	CELL_OSKDIALOG_TYPE_SINGLELINE_OSK = 0,
@@ -239,9 +244,10 @@ using cellOskDialogForceFinishCallback = class b8();
 
 enum class OskDialogState
 {
+	Unloaded,
 	Open,
 	Abort,
-	Close,
+	Closed
 };
 
 class OskDialogBase
@@ -258,7 +264,7 @@ public:
 	std::function<void(s32 status)> on_osk_close;
 	std::function<void()> on_osk_input_entered;
 
-	atomic_t<OskDialogState> state{ OskDialogState::Close };
+	atomic_t<OskDialogState> state{ OskDialogState::Unloaded };
 
 	atomic_t<CellOskDialogInputFieldResult> osk_input_result{ CellOskDialogInputFieldResult::CELL_OSKDIALOG_INPUT_FIELD_RESULT_OK };
 	char16_t osk_text[CELL_OSKDIALOG_STRING_SIZE]{};

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -248,7 +248,11 @@ class OskDialogBase
 {
 public:
 	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) = 0;
-	virtual void Close(bool accepted) = 0;
+
+	// Closes the dialog.
+	// Set status to CELL_OSKDIALOG_CLOSE_CONFIRM or CELL_OSKDIALOG_CLOSE_CANCEL for user input.
+	// Set status to -1 if closed by the game or system.
+	virtual void Close(s32 status) = 0;
 	virtual ~OskDialogBase();
 
 	std::function<void(s32 status)> on_osk_close;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -19,19 +19,19 @@ namespace rsx
 			auto_repeat_buttons.insert(pad_button::square);
 		}
 
-		void osk_dialog::Close(bool ok)
+		void osk_dialog::Close(s32 status)
 		{
 			fade_animation.current = color4f(1.f);
 			fade_animation.end = color4f(0.f);
 			fade_animation.duration = 0.5f;
 
-			fade_animation.on_finish = [this, ok]
+			fade_animation.on_finish = [this, status]
 			{
 				if (on_osk_close)
 				{
-					Emu.CallAfter([this, ok]()
+					Emu.CallAfter([this, status]()
 					{
-						on_osk_close(ok ? CELL_MSGDIALOG_BUTTON_OK : CELL_MSGDIALOG_BUTTON_ESCAPE);
+						on_osk_close(status);
 					});
 				}
 
@@ -522,7 +522,7 @@ namespace rsx
 			}
 			case pad_button::start:
 			{
-				Close(true);
+				Close(CELL_OSKDIALOG_CLOSE_CONFIRM);
 				break;
 			}
 			case pad_button::triangle:
@@ -543,7 +543,7 @@ namespace rsx
 			}
 			case pad_button::circle:
 			{
-				Close(false);
+				Close(CELL_OSKDIALOG_CLOSE_CANCEL);
 				break;
 			}
 			case pad_button::L2:

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -83,7 +83,7 @@ namespace rsx
 			~osk_dialog() override = default;
 
 			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) override;
-			void Close(bool ok) override;
+			void Close(s32 status) override;
 
 			void initialize_layout(const std::u32string& title, const std::u32string& initial_text);
 			void add_panel(const osk_panel& panel);

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -159,14 +159,20 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 	// Events
 	connect(button_box, &QDialogButtonBox::accepted, m_dialog, &QDialog::accept);
 
-	connect(m_dialog, &QDialog::accepted, [this]()
+	connect(m_dialog, &QDialog::finished, [this](int result)
 	{
-		on_osk_close(CELL_MSGDIALOG_BUTTON_OK);
-	});
-
-	connect(m_dialog, &QDialog::rejected, [this]()
-	{
-		on_osk_close(CELL_MSGDIALOG_BUTTON_ESCAPE);
+		switch (result)
+		{
+		case QDialog::Accepted:
+			on_osk_close(CELL_OSKDIALOG_CLOSE_CONFIRM);
+			break;
+		case QDialog::Rejected:
+			on_osk_close(CELL_OSKDIALOG_CLOSE_CANCEL);
+			break;
+		default:
+			on_osk_close(-1);
+			break;
+		}
 	});
 
 	// Fix size
@@ -179,10 +185,21 @@ void osk_dialog_frame::SetOskText(const QString& text)
 	std::memcpy(osk_text, utils::bless<char16_t>(text.constData()), (text.size() + 1u) * sizeof(char16_t));
 }
 
-void osk_dialog_frame::Close(bool accepted)
+void osk_dialog_frame::Close(s32 status)
 {
 	if (m_dialog)
 	{
-		m_dialog->done(accepted ? QDialog::Accepted : QDialog::Rejected);
+		switch (status)
+		{
+		case CELL_OSKDIALOG_CLOSE_CONFIRM:
+			m_dialog->done(QDialog::Accepted);
+			break;
+		case CELL_OSKDIALOG_CLOSE_CANCEL:
+			m_dialog->done(QDialog::Rejected);
+			break;
+		default:
+			m_dialog->done(-1);
+			break;
+		}
 	}
 }

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -170,7 +170,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 			on_osk_close(CELL_OSKDIALOG_CLOSE_CANCEL);
 			break;
 		default:
-			on_osk_close(-1);
+			on_osk_close(result);
 			break;
 		}
 	});
@@ -198,7 +198,7 @@ void osk_dialog_frame::Close(s32 status)
 			m_dialog->done(QDialog::Rejected);
 			break;
 		default:
-			m_dialog->done(-1);
+			m_dialog->done(status);
 			break;
 		}
 	}

--- a/rpcs3/rpcs3qt/osk_dialog_frame.h
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.h
@@ -17,7 +17,7 @@ public:
 	osk_dialog_frame() = default;
 	~osk_dialog_frame();
 	void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) override;
-	void Close(bool accepted) override;
+	void Close(s32 status) override;
 
 private:
 	void SetOskText(const QString& text);


### PR DESCRIPTION
- Fixes an issue where CELL_SYSUTIL_OSKDIALOG_INPUT_ENTERED was sent even if the seperate window wasn't set to "keep open"
- Fixes an issue where dialog abort by game or system was treated as user abort
- Adds some parameters in preparation for further implementations (which I still had on another branch)

maybe fixes #10894