### PR TITLE
sys_fs: SDATA/EDATA fixes and more

### DIFF
--- a/rpcs3/Crypto/unedat.h
+++ b/rpcs3/Crypto/unedat.h
@@ -86,13 +86,9 @@ public:
 
 	fs::stat_t stat() override
 	{
-		fs::stat_t stats;
-		stats.is_directory = false;
-		stats.is_writable = false;
+		fs::stat_t stats = edata_file.stat();
+		stats.is_writable = false; // TODO
 		stats.size = file_size;
-		stats.atime = -1;
-		stats.ctime = -1;
-		stats.mtime = -1;
 		return stats;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1467,7 +1467,7 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 				return nullptr;
 			}
 
-			return std::make_shared<lv2_file>(file, std::move(stream), file.mode, file.flags, file.real_path, lv2_file_type::sdata);
+			return std::make_shared<lv2_file>(file, std::move(stream), file.mode, CELL_FS_O_RDONLY, file.real_path, lv2_file_type::sdata);
 		}))
 		{
 			arg->out_code = CELL_OK;


### PR DESCRIPTION
* cellFsSdataOpenByFd only ever uses read-only flag, even if the original FD has read-write proerty.
* Fix EDATADecrypter::stat() timestamps (use the original file's), fixes sys_fs_fstat for SDATA/EDATA descriptors.
* Skip error checking of sys_fs_read/write (and remove specific side-effect of sys_fs_write when using APPEND mode) if nbytes is 0. The only things that are checked is if FD exists at all and if locked by file stream API. (EBADF/EBUSY respectively)
     - This does not seem to affect cellFsRead/WriteWithOffset.
     - This was also confirmed by looking at syscalls disasm which explicitly checks if size==0 then skips the entire execution.
* Add noticable log messages for when trying to write onto SDATA/EDATA file descriptors.

Testcase: https://github.com/elad335/myps3tests/commit/d10e1f78ed16197c330a1ef428c396c2470748c3

RPCS3's earlier results:
[RPCS3.txt](https://github.com/RPCS3/rpcs3/files/7202474/RPCS3.txt)