### PR TITLE
Implement fs::file::get_id()

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -84,6 +84,16 @@ namespace fs
 		usz iov_len;
 	};
 
+	struct file_id
+	{
+		std::string type;
+		std::vector<u8> data;
+
+		explicit operator bool() const;
+		bool is_mirror_of(const file_id&) const;
+		bool is_coherent_with(const file_id&) const;
+	};
+
 	// File handle base
 	struct file_base
 	{
@@ -98,6 +108,7 @@ namespace fs
 		virtual u64 seek(s64 offset, seek_mode whence) = 0;
 		virtual u64 size() = 0;
 		virtual native_handle get_handle();
+		virtual file_id get_id();
 		virtual u64 write_gather(const iovec_clone* buffers, u64 buf_count);
 	};
 
@@ -504,6 +515,9 @@ namespace fs
 
 		// Get native handle if available
 		native_handle get_handle() const;
+
+		// Get file ID information (custom ID)
+		file_id get_id() const;
 
 		// Gathered write
 		u64 write_gather(const iovec_clone* buffers, u64 buf_count,

--- a/rpcs3/Crypto/unedat.h
+++ b/rpcs3/Crypto/unedat.h
@@ -143,4 +143,11 @@ public:
 	}
 
 	u64 size() override { return file_size; }
+
+	fs::file_id get_id() override
+	{
+		fs::file_id id = edata_file.get_id();
+		id.type.insert(0, "EDATADecrypter: "sv);
+		return id;
+	}
 };

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -499,13 +499,10 @@ void lv2_file::save(utils::serial& ar)
 			return true;
 		}
 
-		fs::stat_t test_s = test.get_stat();
-		fs::stat_t file_s = file.get_stat();
+		fs::file_id test_s = test.get_id();
+		fs::file_id file_s = file.get_id();
 
-		// They don't matter for comparison and only create problems with encrypted files
-		test_s.is_writable = file_s.is_writable;
-		test_s.size = file_s.size;
-		return test_s != file_s;
+		return test_s.is_coherent_with(file_s);
 	}();
 
 	if (in_mem)

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -641,6 +641,18 @@ struct lv2_file::file_view : fs::file_base
 	{
 		return m_file->file.size();
 	}
+
+	fs::file_id get_id() override
+	{
+		fs::file_id id = m_file->file.get_id();
+
+		be_t<u64> off = m_off;
+		const auto ptr = reinterpret_cast<u8*>(&off);
+
+		id.data.insert(id.data.end(), ptr, ptr + sizeof(off));
+		id.type.insert(0, "lv2_file::file_view: "sv);
+		return id;
+	}
 };
 
 fs::file lv2_file::make_view(const std::shared_ptr<lv2_file>& _file, u64 offset)


### PR DESCRIPTION
Mimicking std::filesystem::equivalent() when comparing two file IDs, also adds readable information about the types of the overriding classes.
This feature is needed for savestates.
