### PR TITLE
Fix initial perf overlay graph positions when the detail level is set to none

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -267,6 +267,9 @@ namespace rsx
 
 			update();
 
+			// The text might have changed during the initial update. Recalculate positions.
+			reset_transforms();
+
 			m_is_initialised = true;
 			visible = true;
 		}


### PR DESCRIPTION
follow up to #10893