### PR TITLE
Fix VFS regression

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -7,6 +7,7 @@
     system_config_types.cpp
     system_progress.cpp
     system_utils.cpp
+    vfs_config.cpp
     VFS.cpp
     GDB.cpp
     title.cpp

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1500,7 +1500,7 @@ void ppu_trap(ppu_thread& ppu, u64 addr)
 	ppu.cia += add; // Skip instructions, hope for valid code (interprter may be invoked temporarily)
 }
 
-static void ppu_error(ppu_thread& ppu, u64 addr, u32 op)
+static void ppu_error(ppu_thread& ppu, u64 addr, u32 /*op*/)
 {
 	ppu.cia = ::narrow<u32>(addr);
 	ppu_recompiler_fallback(ppu);

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -430,7 +430,7 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 
 		Emu.SetForceBoot(true);
 
-		auto res = Emu.BootGame(path, "", true, false, old_config);
+		auto res = Emu.BootGame(path, "", true, false, cfg_mode::continuous, old_config);
 
 		if (res != game_boot_result::no_errors)
 		{

--- a/rpcs3/Emu/NP/rpcn_config.cpp
+++ b/rpcs3/Emu/NP/rpcn_config.cpp
@@ -28,7 +28,7 @@ void cfg_rpcn::save() const
 	fs::file cfg_file(cfg_rpcn::get_path(), fs::rewrite);
 	if (cfg_file)
 	{
-		cfg_file.write(to_string());	
+		cfg_file.write(to_string());
 	}
 	else
 	{

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "overlay_controls.h"
-#include "Emu/system_config.h"
+#include "Emu/vfs_config.h"
 
 #ifndef _WIN32
 #include <unistd.h>
@@ -121,8 +121,8 @@ namespace rsx
 				result.lookup_font_dirs[0] += "/.fonts/";
 #endif
 			// Search dev_flash for the font too
-			result.lookup_font_dirs.push_back(g_cfg.vfs.get_dev_flash() + "data/font/");
-			result.lookup_font_dirs.push_back(g_cfg.vfs.get_dev_flash() + "data/font/SONY-CC/");
+			result.lookup_font_dirs.push_back(g_cfg_vfs.get_dev_flash() + "data/font/");
+			result.lookup_font_dirs.push_back(g_cfg_vfs.get_dev_flash() + "data/font/SONY-CC/");
 
 			switch (class_)
 			{

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "overlay_user_list_dialog.h"
-#include "Emu/system_config.h"
+#include "Emu/vfs_config.h"
 #include "Emu/system_utils.hpp"
 #include "Utilities/StrUtil.h"
 #include "Utilities/Thread.h"
@@ -170,7 +170,7 @@ namespace rsx
 					}
 
 					// Let's assume there are 26 avatar pngs (like in my installation)
-					const std::string avatar_path = g_cfg.vfs.get_dev_flash() + fmt::format("vsh/resource/explore/user/%03d.png", id % 26);
+					const std::string avatar_path = g_cfg_vfs.get_dev_flash() + fmt::format("vsh/resource/explore/user/%03d.png", id % 26);
 					const std::string username = file.to_string();
 					std::unique_ptr<overlay_element> entry = std::make_unique<user_list_entry>(username, user_id, avatar_path);
 					entries.emplace_back(std::move(entry));

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -44,12 +44,15 @@ enum class game_boot_result : u32
 	unsupported_disc_type
 };
 
-namespace cfg_keys
+enum class cfg_mode
 {
-	inline const std::string title_id = "title_id"; // No config override mode
-	inline const std::string global = "global"; // Force global config
-	inline const std::string _default = "default"; // Force virtual default constructed config.yml
-}
+	custom,           // Prefer regular custom config. Fall back to global config.
+	custom_selection, // Use user-selected custom config. Fall back to global config.
+	global,           // Use global config.
+	config_override,  // Use config override. This does not use the global VFS settings! Fall back to global config.
+	continuous,       // Use same config as on last boot. Fall back to global config.
+	default_config    // Use the default values of the config entries.
+};
 
 struct EmuCallbacks
 {
@@ -90,7 +93,8 @@ class Emulator final
 	video_renderer m_default_renderer;
 	std::string m_default_graphics_adapter;
 
-	std::string m_config_path = cfg_keys::title_id;
+	cfg_mode m_config_mode = cfg_mode::custom;
+	std::string m_config_path;
 	std::string m_path;
 	std::string m_path_old;
 	std::string m_title_id;
@@ -227,7 +231,7 @@ public:
 		return m_config_path;
 	}
 
-	game_boot_result BootGame(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, const std::string& config_path = cfg_keys::title_id);
+	game_boot_result BootGame(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "");
 	bool BootRsxCapture(const std::string& path);
 
 	void SetForceBoot(bool force_boot);

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -14,6 +14,8 @@
 
 #include <thread>
 
+LOG_CHANNEL(vfs_log, "VFS");
+
 struct vfs_directory
 {
 	// Real path (empty if root or not exists)
@@ -45,8 +47,11 @@ bool vfs::mount(std::string_view vpath, std::string_view path)
 	if (vpath.empty())
 	{
 		// Empty relative path, should set relative path base; unsupported
+		vfs_log.error("Cannot mount empty path to \"%s\"", path);
 		return false;
 	}
+
+	const std::string_view vpath_backup = vpath;
 
 	for (std::vector<vfs_directory*> list{&table.root};;)
 	{
@@ -56,6 +61,7 @@ bool vfs::mount(std::string_view vpath, std::string_view path)
 		if (pos == 0)
 		{
 			// Mounting relative path is not supported
+			vfs_log.error("Cannot mount relative path \"%s\" to \"%s\"", vpath_backup, path);
 			return false;
 		}
 
@@ -63,6 +69,7 @@ bool vfs::mount(std::string_view vpath, std::string_view path)
 		{
 			// Mounting completed
 			list.back()->path = path;
+			vfs_log.notice("Mounted path \"%s\" to \"%s\"", vpath_backup, path);
 			return true;
 		}
 

--- a/rpcs3/Emu/system_config.cpp
+++ b/rpcs3/Emu/system_config.cpp
@@ -1,7 +1,5 @@
 #include "stdafx.h"
 #include "system_config.h"
-#include "Utilities/StrUtil.h"
-#include "Utilities/StrFmt.h"
 
 #include "util/sysinfo.hpp"
 
@@ -10,45 +8,4 @@ cfg_root g_cfg{};
 bool cfg_root::node_core::has_rtm()
 {
 	return utils::has_rtm();
-}
-
-std::string cfg_root::node_vfs::get(const cfg::string& _cfg, std::string_view emu_dir) const
-{
-	std::string _emu_dir; // Storage only
-
-	if (emu_dir.empty())
-	{
-		// Optimization if provided arg
-		_emu_dir = emulator_dir;
-
-		if (_emu_dir.empty())
-		{
-			_emu_dir = fs::get_config_dir() + '/';
-		}
-		// Check if path does not end with a delimiter
-		else if (_emu_dir.back() != fs::delim[0] && _emu_dir.back() != fs::delim[1])
-		{
-			_emu_dir += '/';
-		}
-
-		emu_dir = _emu_dir;
-	}
-
-	std::string path = _cfg.to_string();
-
-	if (path.empty())
-	{
-		// Fallback
-		path = _cfg.def;
-	}
-
-	path = fmt::replace_all(path, "$(EmulatorDir)", emu_dir);
-
-	// Check if path does not end with a delimiter
-	if (path.back() != fs::delim[0] && path.back() != fs::delim[1])
-	{
-		path += '/';
-	}
-
-	return path;
 }

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -85,33 +85,6 @@ struct cfg_root : cfg::node
 	{
 		node_vfs(cfg::node* _this) : cfg::node(_this, "VFS") {}
 
-		std::string get(const cfg::string&, std::string_view emu_dir = {}) const;
-
-		cfg::string emulator_dir{ this, "$(EmulatorDir)" }; // Default (empty): taken from fs::get_config_dir()
-		cfg::string dev_hdd0{ this, "/dev_hdd0/", "$(EmulatorDir)dev_hdd0/" };
-		cfg::string dev_hdd1{ this, "/dev_hdd1/", "$(EmulatorDir)dev_hdd1/" };
-		cfg::string dev_flash{ this, "/dev_flash/", "$(EmulatorDir)dev_flash/" };
-		cfg::string dev_flash2{ this, "/dev_flash2/", "$(EmulatorDir)dev_flash2/" };
-		cfg::string dev_flash3{ this, "/dev_flash3/", "$(EmulatorDir)dev_flash3/" };
-		cfg::string dev_usb000{ this, "/dev_usb000/", "$(EmulatorDir)dev_usb000/" };
-		cfg::string dev_bdvd{ this, "/dev_bdvd/" }; // Not mounted
-		cfg::string app_home{ this, "/app_home/" }; // Not mounted
-
-		std::string get_dev_flash() const
-		{
-			return get(dev_flash);
-		}
-
-		std::string get_dev_flash2() const
-		{
-			return get(dev_flash2);
-		}
-
-		std::string get_dev_flash3() const
-		{
-			return get(dev_flash3);
-		}
-
 		cfg::_bool host_root{ this, "Enable /host_root/" };
 		cfg::_bool init_dirs{ this, "Initialize Directories", true };
 

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "system_utils.hpp"
 #include "system_config.h"
+#include "vfs_config.h"
 #include "Emu/Io/pad_config.h"
 #include "util/sysinfo.hpp"
 #include "Utilities/File.h"
@@ -116,18 +117,18 @@ namespace rpcs3::utils
 
 	std::string get_emu_dir()
 	{
-		const std::string& emu_dir_ = g_cfg.vfs.emulator_dir;
+		const std::string& emu_dir_ = g_cfg_vfs.emulator_dir;
 		return emu_dir_.empty() ? fs::get_config_dir() : emu_dir_;
 	}
 
 	std::string get_hdd0_dir()
 	{
-		return g_cfg.vfs.get(g_cfg.vfs.dev_hdd0, get_emu_dir());
+		return g_cfg_vfs.get(g_cfg_vfs.dev_hdd0, get_emu_dir());
 	}
 
 	std::string get_hdd1_dir()
 	{
-		return g_cfg.vfs.get(g_cfg.vfs.dev_hdd1, get_emu_dir());
+		return g_cfg_vfs.get(g_cfg_vfs.dev_hdd1, get_emu_dir());
 	}
 
 	std::string get_cache_dir()

--- a/rpcs3/Emu/vfs_config.cpp
+++ b/rpcs3/Emu/vfs_config.cpp
@@ -1,0 +1,93 @@
+#include "stdafx.h"
+#include "vfs_config.h"
+#include "Utilities/StrUtil.h"
+#include "Utilities/StrFmt.h"
+#include "util/yaml.hpp"
+
+LOG_CHANNEL(vfs_log, "VFS");
+
+cfg_vfs g_cfg_vfs{};
+
+std::string cfg_vfs::get(const cfg::string& _cfg, std::string_view emu_dir) const
+{
+	std::string _emu_dir; // Storage only
+
+	if (emu_dir.empty())
+	{
+		// Optimization if provided arg
+		_emu_dir = emulator_dir;
+
+		if (_emu_dir.empty())
+		{
+			_emu_dir = fs::get_config_dir() + '/';
+		}
+		// Check if path does not end with a delimiter
+		else if (_emu_dir.back() != fs::delim[0] && _emu_dir.back() != fs::delim[1])
+		{
+			_emu_dir += '/';
+		}
+
+		emu_dir = _emu_dir;
+	}
+
+	std::string path = _cfg.to_string();
+
+	if (path.empty())
+	{
+		// Fallback
+		path = _cfg.def;
+	}
+
+	path = fmt::replace_all(path, "$(EmulatorDir)", emu_dir);
+
+	// Check if path does not end with a delimiter
+	if (path.back() != fs::delim[0] && path.back() != fs::delim[1])
+	{
+		path += '/';
+	}
+
+	return path;
+}
+
+void cfg_vfs::load()
+{
+	if (fs::file cfg_file{cfg_vfs::get_path(), fs::read})
+	{
+		from_string(cfg_file.to_string());
+	}
+}
+
+void cfg_vfs::save() const
+{
+#ifdef _WIN32
+	const std::string path_to_cfg = fs::get_config_dir() + "config/";
+	if (!fs::create_path(path_to_cfg))
+	{
+		vfs_log.error("Could not create path: %s", path_to_cfg);
+	}
+#endif
+
+	fs::pending_file temp(cfg_vfs::get_path());
+
+	if (!temp.file)
+	{
+		vfs_log.error("Could not save config: \"%s\"", cfg_vfs::get_path());
+		return;
+	}
+
+	temp.file.write(to_string());
+
+	if (!temp.commit())
+	{
+		vfs_log.error("Could not save config: \"%s\" (error=%s)", cfg_vfs::get_path(), fs::g_tls_error);
+	}
+}
+
+std::string cfg_vfs::get_path()
+{
+#ifdef _WIN32
+	return fs::get_config_dir() + "config/vfs.yml";
+#else
+	return fs::get_config_dir() + "vfs.yml";
+#endif
+}

--- a/rpcs3/Emu/vfs_config.h
+++ b/rpcs3/Emu/vfs_config.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Utilities/Config.h"
+
+struct cfg_vfs : cfg::node
+{
+	std::string get(const cfg::string&, std::string_view emu_dir = {}) const;
+	void load();
+	void save() const;
+	static std::string get_path();
+
+	cfg::string emulator_dir{ this, "$(EmulatorDir)" }; // Default (empty): taken from fs::get_config_dir()
+	cfg::string dev_hdd0{ this, "/dev_hdd0/", "$(EmulatorDir)dev_hdd0/" };
+	cfg::string dev_hdd1{ this, "/dev_hdd1/", "$(EmulatorDir)dev_hdd1/" };
+	cfg::string dev_flash{ this, "/dev_flash/", "$(EmulatorDir)dev_flash/" };
+	cfg::string dev_flash2{ this, "/dev_flash2/", "$(EmulatorDir)dev_flash2/" };
+	cfg::string dev_flash3{ this, "/dev_flash3/", "$(EmulatorDir)dev_flash3/" };
+	cfg::string dev_usb000{ this, "/dev_usb000/", "$(EmulatorDir)dev_usb000/" };
+	cfg::string dev_bdvd{ this, "/dev_bdvd/" }; // Not mounted
+	cfg::string app_home{ this, "/app_home/" }; // Not mounted
+
+	std::string get_dev_flash() const
+	{
+		return get(dev_flash);
+	}
+
+	std::string get_dev_flash2() const
+	{
+		return get(dev_flash2);
+	}
+
+	std::string get_dev_flash3() const
+	{
+		return get(dev_flash3);
+	}
+};
+
+extern cfg_vfs g_cfg_vfs;

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="Emu\NP\signaling_handler.cpp" />
     <ClCompile Include="Emu\NP\np_structs_extra.cpp" />
     <ClCompile Include="Emu\NP\rpcn_client.cpp" />
+    <ClCompile Include="Emu\vfs_config.cpp" />
     <ClCompile Include="util\atomic.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
@@ -489,6 +490,7 @@
     <ClInclude Include="Emu\title.h" />
     <ClInclude Include="Emu\system_config.h" />
     <ClInclude Include="Emu\system_config_types.h" />
+    <ClInclude Include="Emu\vfs_config.h" />
     <ClInclude Include="Loader\mself.hpp" />
     <ClInclude Include="util\atomic.hpp" />
     <ClInclude Include="util\media_utils.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1006,6 +1006,9 @@
     <ClCompile Include="Emu\Audio\audio_device_listener.cpp">
       <Filter>Emu\Audio</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\vfs_config.cpp">
+      <Filter>Emu</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -1983,6 +1986,9 @@
     </ClInclude>
     <ClInclude Include="Emu\Audio\audio_device_listener.h">
       <Filter>Emu\Audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\vfs_config.h">
+      <Filter>Emu</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -920,7 +920,7 @@ int main(int argc, char** argv)
 			}
 		}
 
-		std::string config_path = cfg_keys::title_id;
+		std::string config_path;
 
 		if (parser.isSet(arg_config))
 		{
@@ -938,7 +938,9 @@ int main(int argc, char** argv)
 			Emu.argv = std::move(rpcs3_argv);
 			Emu.SetForceBoot(true);
 
-			if (const game_boot_result error = Emu.BootGame(path, "", false, false, config_path); error != game_boot_result::no_errors)
+			const cfg_mode config_mode = config_path.empty() ? cfg_mode::custom : cfg_mode::config_override;
+
+			if (const game_boot_result error = Emu.BootGame(path, "", false, false, config_mode, config_path); error != game_boot_result::no_errors)
 			{
 				sys_log.error("Booting '%s' with cli argument failed: reason: %s", path, error);
 

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -268,8 +268,6 @@ void emu_settings::SaveSettings()
 	}
 	else
 	{
-		// VFS paths are being controlled mainly by the main config (needs manual modification for customization of custom configs)
-		m_current_settings.remove("VFS");
 		config_name = rpcs3::utils::get_custom_config_path(m_title_id);
 	}
 

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -154,15 +154,6 @@ enum class emu_settings_type
 	LimitCacheSize,
 	MaximumCacheSize,
 	ConsoleTimeOffset,
-
-	// Virtual File System
-	emulatorLocation,
-	dev_hdd0Location,
-	dev_hdd1Location,
-	dev_flashLocation,
-	dev_flash2Location,
-	dev_flash3Location,
-	dev_usb000Location,
 };
 
 /** A helper map that keeps track of where a given setting type is located*/
@@ -317,13 +308,4 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::LimitCacheSize,        { "VFS", "Limit disk cache size"}},
 	{ emu_settings_type::MaximumCacheSize,      { "VFS", "Disk cache maximum size (MB)"}},
 	{ emu_settings_type::ConsoleTimeOffset,     { "System", "Console time offset (s)"}},
-
-	// Virtual File System
-	{ emu_settings_type::emulatorLocation,   { "VFS", "$(EmulatorDir)"}},
-	{ emu_settings_type::dev_hdd0Location,   { "VFS", "/dev_hdd0/" }},
-	{ emu_settings_type::dev_hdd1Location,   { "VFS", "/dev_hdd1/" }},
-	{ emu_settings_type::dev_flashLocation,  { "VFS", "/dev_flash/"}},
-	{ emu_settings_type::dev_flash2Location, { "VFS", "/dev_flash2/"}},
-	{ emu_settings_type::dev_flash3Location, { "VFS", "/dev_flash3/"}},
-	{ emu_settings_type::dev_usb000Location, { "VFS", "/dev_usb000/"}},
 };

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -16,7 +16,7 @@
 
 #include "Emu/Memory/vm.h"
 #include "Emu/System.h"
-#include "Emu/system_config.h"
+#include "Emu/vfs_config.h"
 #include "Emu/system_utils.hpp"
 #include "Loader/PSF.h"
 #include "util/types.hpp"
@@ -1630,7 +1630,7 @@ bool game_list_frame::RemoveSPUCache(const std::string& base_dir, bool is_intera
 
 void game_list_frame::BatchCreatePPUCaches()
 {
-	const std::string vsh_path = g_cfg.vfs.get_dev_flash() + "vsh/module/";
+	const std::string vsh_path = g_cfg_vfs.get_dev_flash() + "vsh/module/";
 	const bool vsh_exists = fs::is_file(vsh_path + "vsh.self");
 	const u32 total = m_game_data.size() + (vsh_exists ? 1 : 0);
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -950,7 +950,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		connect(boot_default, &QAction::triggered, [this, gameinfo]
 		{
 			sys_log.notice("Booting from gamelist per context menu...");
-			Q_EMIT RequestBoot(gameinfo, cfg_keys::_default);
+			Q_EMIT RequestBoot(gameinfo, cfg_mode::default_config);
 		});
 
 		QAction* boot_manual = menu.addAction(is_current_running_game
@@ -962,7 +962,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 			if (std::string file_path = sstr(QFileDialog::getOpenFileName(this, "Select Config File", "", tr("Config Files (*.yml);;All files (*.*)"))); !file_path.empty())
 			{
 				sys_log.notice("Booting from gamelist per context menu...");
-				Q_EMIT RequestBoot(gameinfo, file_path);
+				Q_EMIT RequestBoot(gameinfo, cfg_mode::custom_selection, file_path);
 			}
 			else
 			{
@@ -1221,7 +1221,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	connect(boot, &QAction::triggered, this, [this, gameinfo]()
 	{
 		sys_log.notice("Booting from gamelist per context menu...");
-		Q_EMIT RequestBoot(gameinfo, cfg_keys::global);
+		Q_EMIT RequestBoot(gameinfo, cfg_mode::global);
 	});
 	connect(configure, &QAction::triggered, this, [this, current_game, gameinfo]()
 	{

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -4,6 +4,7 @@
 #include "custom_dock_widget.h"
 #include "gui_save.h"
 #include "Utilities/lockless.h"
+#include "Emu/System.h"
 
 #include <QMainWindow>
 #include <QToolBar>
@@ -83,7 +84,7 @@ private Q_SLOTS:
 Q_SIGNALS:
 	void GameListFrameClosed();
 	void NotifyGameSelection(const game_info& game);
-	void RequestBoot(const game_info& game, const std::string& config_path = "title_id"); // "title_id" is cfg_keys::title_id
+	void RequestBoot(const game_info& game, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "");
 	void RequestIconSizeChange(const int& val);
 	void NotifyEmuSettingsChange();
 protected:

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -18,6 +18,7 @@
 #include "Emu/Cell/Modules/cellAudio.h"
 #include "Emu/RSX/Overlays/overlay_perf_metrics.h"
 #include "Emu/system_utils.hpp"
+#include "Emu/vfs_config.h"
 #include "trophy_notification_helper.h"
 #include "save_data_dialog.h"
 #include "msg_dialog_frame.h"
@@ -513,7 +514,7 @@ void gui_application::OnChangeStyleSheetRequest()
 			const QString config_dir = qstr(fs::get_config_dir());
 
 			// Add PS3 fonts
-			QDirIterator ps3_font_it(qstr(g_cfg.vfs.get_dev_flash() + "data/font/"), QStringList() << "*.ttf", QDir::Files, QDirIterator::Subdirectories);
+			QDirIterator ps3_font_it(qstr(g_cfg_vfs.get_dev_flash() + "data/font/"), QStringList() << "*.ttf", QDir::Files, QDirIterator::Subdirectories);
 			while (ps3_font_it.hasNext())
 				QFontDatabase::addApplicationFont(ps3_font_it.next());
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -40,7 +40,6 @@
 #include <QFontDatabase>
 
 #include "rpcs3_version.h"
-#include "Emu/System.h"
 #include "Emu/IdManager.h"
 #include "Emu/VFS.h"
 #include "Emu/system_config.h"
@@ -378,7 +377,7 @@ void main_window::show_boot_error(game_boot_result status)
 	msg.exec();
 }
 
-void main_window::Boot(const std::string& path, const std::string& title_id, bool direct, bool add_only, const std::string& config_path)
+void main_window::Boot(const std::string& path, const std::string& title_id, bool direct, bool add_only, cfg_mode config_mode, const std::string& config_path)
 {
 	if (!m_gui_settings->GetBootConfirmation(this, gui::ib_confirm_boot))
 	{
@@ -390,7 +389,7 @@ void main_window::Boot(const std::string& path, const std::string& title_id, boo
 	Emu.SetForceBoot(true);
 	Emu.Stop();
 
-	if (const auto error = Emu.BootGame(path, title_id, direct, add_only, config_path); error != game_boot_result::no_errors)
+	if (const auto error = Emu.BootGame(path, title_id, direct, add_only, config_mode, config_path); error != game_boot_result::no_errors)
 	{
 		gui_log.error("Boot failed: reason: %s, path: %s", error, path);
 		show_boot_error(error);
@@ -2492,9 +2491,9 @@ void main_window::CreateDockWindows()
 		m_selected_game = game;
 	});
 
-	connect(m_game_list_frame, &game_list_frame::RequestBoot, this, [this](const game_info& game, const std::string& config_path)
+	connect(m_game_list_frame, &game_list_frame::RequestBoot, this, [this](const game_info& game, cfg_mode config_mode, const std::string& config_path)
 	{
-		Boot(game->info.path, game->info.serial, false, false, config_path);
+		Boot(game->info.path, game->info.serial, false, false, config_mode, config_path);
 	});
 
 	connect(m_game_list_frame, &game_list_frame::NotifyEmuSettingsChange, this, &main_window::NotifyEmuSettingsChange);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -42,7 +42,7 @@
 #include "rpcs3_version.h"
 #include "Emu/IdManager.h"
 #include "Emu/VFS.h"
-#include "Emu/system_config.h"
+#include "Emu/vfs_config.h"
 #include "Emu/system_utils.hpp"
 
 #include "Crypto/unpkg.h"
@@ -239,7 +239,7 @@ bool main_window::Init(bool with_cli_boot)
 #endif
 
 	// Disable vsh if not present.
-	ui->bootVSHAct->setEnabled(fs::is_file(g_cfg.vfs.get_dev_flash() + "vsh/module/vsh.self"));
+	ui->bootVSHAct->setEnabled(fs::is_file(g_cfg_vfs.get_dev_flash() + "vsh/module/vsh.self"));
 
 	return true;
 }
@@ -476,7 +476,7 @@ void main_window::BootGame()
 void main_window::BootVSH()
 {
 	gui_log.notice("Booting from BootVSH...");
-	Boot(g_cfg.vfs.get_dev_flash() + "/vsh/module/vsh.self");
+	Boot(g_cfg_vfs.get_dev_flash() + "/vsh/module/vsh.self");
 }
 
 void main_window::BootRsxCapture(std::string path)
@@ -1133,7 +1133,7 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 	pdlg.show();
 
 	// Used by tar_object::extract() as destination directory
-	vfs::mount("/dev_flash", g_cfg.vfs.get_dev_flash());
+	vfs::mount("/dev_flash", g_cfg_vfs.get_dev_flash());
 
 	// Synchronization variable
 	atomic_t<uint> progress(0);
@@ -1213,7 +1213,7 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 
 	if (progress == update_filenames.size())
 	{
-		ui->bootVSHAct->setEnabled(fs::is_file(g_cfg.vfs.get_dev_flash() + "/vsh/module/vsh.self"));
+		ui->bootVSHAct->setEnabled(fs::is_file(g_cfg_vfs.get_dev_flash() + "/vsh/module/vsh.self"));
 
 		gui_log.success("Successfully installed PS3 firmware version %s.", version_string);
 		m_gui_settings->ShowInfoBox(tr("Success!"), tr("Successfully installed PS3 firmware and LLE Modules!"), gui::ib_pup_success, this);
@@ -1232,7 +1232,7 @@ void main_window::DecryptSPRXLibraries()
 	if (!fs::is_dir(sstr(path_last_sprx)))
 	{
 		// Default: redirect to userland firmware SPRX directory
-		path_last_sprx = qstr(g_cfg.vfs.get_dev_flash() + "sys/external");
+		path_last_sprx = qstr(g_cfg_vfs.get_dev_flash() + "sys/external");
 	}
 
 	const QStringList modules = QFileDialog::getOpenFileNames(this, tr("Select binary files"), path_last_sprx, tr("All Binaries (*.bin *.BIN *.self *.SELF *.sprx *.SPRX);;BIN files (*.bin *.BIN);;SELF files (*.self *.SELF);;SPRX files (*.sprx *.SPRX);;All files (*.*)"));
@@ -2079,7 +2079,7 @@ void main_window::CreateConnects()
 	{
 		vfs_dialog dlg(m_gui_settings, m_emu_settings, this);
 		dlg.exec();
-		ui->bootVSHAct->setEnabled(fs::is_file(g_cfg.vfs.get_dev_flash() + "vsh/module/vsh.self")); // dev_flash may have changed. Disable vsh if not present.
+		ui->bootVSHAct->setEnabled(fs::is_file(g_cfg_vfs.get_dev_flash() + "vsh/module/vsh.self")); // dev_flash may have changed. Disable vsh if not present.
 		m_game_list_frame->Refresh(true); // dev_hdd0 may have changed. Refresh just in case.
 	});
 
@@ -2679,7 +2679,7 @@ void main_window::CreateFirmwareCache()
 	Emu.Stop();
 	Emu.SetForceBoot(true);
 
-	if (const game_boot_result error = Emu.BootGame(g_cfg.vfs.get_dev_flash() + "sys", "", true);
+	if (const game_boot_result error = Emu.BootGame(g_cfg_vfs.get_dev_flash() + "sys", "", true);
 		error != game_boot_result::no_errors)
 	{
 		gui_log.error("Creating firmware cache failed: reason: %s", error);

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -12,6 +12,7 @@
 
 #include "update_manager.h"
 #include "settings.h"
+#include "Emu/System.h"
 
 #include <memory>
 
@@ -107,7 +108,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
 	void OnPlayOrPause();
-	void Boot(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, const std::string& config_path = "title_id"); // "title_id" is cfg_keys::title_id
+	void Boot(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "");
 	void BootElf();
 	void BootGame();
 	void BootVSH();

--- a/rpcs3/rpcs3qt/patch_creator_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.cpp
@@ -267,11 +267,6 @@ void patch_creator_dialog::move_instructions(int src_row, int rows_to_move, int 
 		return patch_type::invalid;
 	};
 
-	const auto set_row_type_widget = [this](int i, patch_type type) -> void
-	{
-		ui->instructionTable->setCellWidget(i, patch_column::type, create_patch_type_bombo_box(type));
-	};
-
 	for (int i = 0; i < rows_to_move; i++)
 	{
 		moving_types[i] = get_row_type(src_row + i);

--- a/rpcs3/rpcs3qt/vfs_dialog.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog.cpp
@@ -1,7 +1,6 @@
 #include "vfs_dialog.h"
 #include "vfs_dialog_tab.h"
 #include "gui_settings.h"
-#include "emu_settings_type.h"
 
 #include <QTabWidget>
 #include <QDialogButtonBox>
@@ -10,7 +9,7 @@
 #include <QVBoxLayout>
 
 #include "Emu/System.h"
-#include "Emu/system_config.h"
+#include "Emu/vfs_config.h"
 
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
@@ -20,29 +19,29 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_pt
 	QTabWidget* tabs = new QTabWidget();
 	tabs->setUsesScrollButtons(false);
 
-	m_emu_settings->LoadSettings();
+	g_cfg_vfs.load();
 
 	// Create tabs
-	vfs_dialog_tab* emulator_tab = new vfs_dialog_tab({ "$(EmulatorDir)", emu_settings_type::emulatorLocation, gui::fs_emulator_dir_list, &g_cfg.vfs.emulator_dir },
-		m_gui_settings, m_emu_settings, this);
+	vfs_dialog_tab* emulator_tab = new vfs_dialog_tab({ "$(EmulatorDir)", gui::fs_emulator_dir_list, &g_cfg_vfs.emulator_dir },
+		m_gui_settings, this);
 
-	vfs_dialog_tab* dev_hdd0_tab = new vfs_dialog_tab({ "dev_hdd0", emu_settings_type::dev_hdd0Location, gui::fs_dev_hdd0_list, &g_cfg.vfs.dev_hdd0 },
-		m_gui_settings, m_emu_settings, this);
+	vfs_dialog_tab* dev_hdd0_tab = new vfs_dialog_tab({ "dev_hdd0", gui::fs_dev_hdd0_list, &g_cfg_vfs.dev_hdd0 },
+		m_gui_settings, this);
 
-	vfs_dialog_tab* dev_hdd1_tab = new vfs_dialog_tab({ "dev_hdd1", emu_settings_type::dev_hdd1Location, gui::fs_dev_hdd1_list, &g_cfg.vfs.dev_hdd1 },
-		m_gui_settings, m_emu_settings, this);
+	vfs_dialog_tab* dev_hdd1_tab = new vfs_dialog_tab({ "dev_hdd1", gui::fs_dev_hdd1_list, &g_cfg_vfs.dev_hdd1 },
+		m_gui_settings, this);
 
-	vfs_dialog_tab* dev_flash_tab = new vfs_dialog_tab({ "dev_flash", emu_settings_type::dev_flashLocation, gui::fs_dev_flash_list, &g_cfg.vfs.dev_flash },
-		m_gui_settings, m_emu_settings, this);
+	vfs_dialog_tab* dev_flash_tab = new vfs_dialog_tab({ "dev_flash", gui::fs_dev_flash_list, &g_cfg_vfs.dev_flash },
+		m_gui_settings, this);
 
-	vfs_dialog_tab* dev_flash2_tab = new vfs_dialog_tab({ "dev_flash2", emu_settings_type::dev_flash2Location, gui::fs_dev_flash2_list, &g_cfg.vfs.dev_flash2 },
-		m_gui_settings, m_emu_settings, this);
+	vfs_dialog_tab* dev_flash2_tab = new vfs_dialog_tab({ "dev_flash2", gui::fs_dev_flash2_list, &g_cfg_vfs.dev_flash2 },
+		m_gui_settings, this);
 
-	vfs_dialog_tab* dev_flash3_tab = new vfs_dialog_tab({ "dev_flash3", emu_settings_type::dev_flash3Location, gui::fs_dev_flash3_list, &g_cfg.vfs.dev_flash3 },
-		m_gui_settings, m_emu_settings, this);
+	vfs_dialog_tab* dev_flash3_tab = new vfs_dialog_tab({ "dev_flash3", gui::fs_dev_flash3_list, &g_cfg_vfs.dev_flash3 },
+		m_gui_settings, this);
 
-	vfs_dialog_tab* dev_usb000_tab = new vfs_dialog_tab({ "dev_usb000", emu_settings_type::dev_usb000Location, gui::fs_dev_usb000_list, &g_cfg.vfs.dev_usb000 },
-		m_gui_settings, m_emu_settings, this);
+	vfs_dialog_tab* dev_usb000_tab = new vfs_dialog_tab({ "dev_usb000", gui::fs_dev_usb000_list, &g_cfg_vfs.dev_usb000 },
+		m_gui_settings, this);
 
 	tabs->addTab(emulator_tab, "$(EmulatorDir)");
 	tabs->addTab(dev_hdd0_tab, "dev_hdd0");
@@ -75,7 +74,8 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> guiSettings, std::shared_pt
 			{
 				static_cast<vfs_dialog_tab*>(tabs->widget(i))->SetSettings();
 			}
-			m_emu_settings->SaveSettings();
+
+			g_cfg_vfs.save();
 
 			// Recreate folder structure for new VFS paths
 			if (Emu.IsStopped())

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.cpp
@@ -6,10 +6,11 @@
 #include <QHBoxLayout>
 #include <QPushButton>
 
+constexpr auto qstr = QString::fromStdString;
 inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
-vfs_dialog_tab::vfs_dialog_tab(vfs_settings_info settingsInfo, std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent)
-	: QWidget(parent), m_info(std::move(settingsInfo)), m_gui_settings(std::move(guiSettings)), m_emu_settings(std::move(emuSettings))
+vfs_dialog_tab::vfs_dialog_tab(vfs_settings_info settingsInfo, std::shared_ptr<gui_settings> guiSettings, QWidget* parent)
+	: QWidget(parent), m_info(std::move(settingsInfo)), m_gui_settings(std::move(guiSettings))
 {
 	m_dir_dist = new QListWidget(this);
 
@@ -77,7 +78,6 @@ void vfs_dialog_tab::SetSettings() const
 
 	const std::string new_dir = m_selected_config_label->text() == EmptyPath ? "" : sstr(m_selected_config_label->text());
 	m_info.cfg_node->from_string(new_dir);
-	m_emu_settings->SetSetting(m_info.settingLoc, new_dir);
 }
 
 void vfs_dialog_tab::Reset() const

--- a/rpcs3/rpcs3qt/vfs_dialog_tab.h
+++ b/rpcs3/rpcs3qt/vfs_dialog_tab.h
@@ -3,8 +3,6 @@
 #include "util/types.hpp"
 
 #include "gui_settings.h"
-#include "emu_settings.h"
-#include "emu_settings_type.h"
 
 #include <QListWidget>
 #include <QLabel>
@@ -19,7 +17,6 @@ namespace cfg
 struct vfs_settings_info
 {
 	QString name; // name of tab
-	emu_settings_type settingLoc; // Where the setting is saved in emu_settings
 	gui_save listLocation; // Where the list of dir options are saved
 	cfg::string* cfg_node; // Needed since emu_settings overrides settings file and doesn't touch g_cfg currently.
 };
@@ -29,7 +26,7 @@ class vfs_dialog_tab : public QWidget
 	Q_OBJECT
 
 public:
-	explicit vfs_dialog_tab(vfs_settings_info info, std::shared_ptr<gui_settings> guiSettings, std::shared_ptr<emu_settings> emuSettings, QWidget* parent = nullptr);
+	explicit vfs_dialog_tab(vfs_settings_info info, std::shared_ptr<gui_settings> guiSettings, QWidget* parent = nullptr);
 
 	void SetSettings() const;
 
@@ -44,7 +41,6 @@ private:
 
 	vfs_settings_info m_info;
 	std::shared_ptr<gui_settings> m_gui_settings;
-	std::shared_ptr<emu_settings> m_emu_settings;
 
 	// UI variables needed in higher scope
 	QListWidget* m_dir_dist;

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -1,7 +1,7 @@
 #include "util/sysinfo.hpp"
 #include "Utilities/StrFmt.h"
 #include "Utilities/File.h"
-#include "Emu/system_config.h"
+#include "Emu/vfs_config.h"
 #include "Utilities/Thread.h"
 
 #ifdef _WIN32
@@ -241,7 +241,7 @@ std::string utils::get_system_info()
 
 std::string utils::get_firmware_version()
 {
-	const std::string file_path = g_cfg.vfs.get_dev_flash() + "vsh/etc/version.txt";
+	const std::string file_path = g_cfg_vfs.get_dev_flash() + "vsh/etc/version.txt";
 	if (fs::file version_file{file_path})
 	{
 		const std::string version_str = version_file.to_string();


### PR DESCRIPTION
A recent PR introduced a new config path emu member.

- This new logic that solely relied on the path introduced a bug that caused games, which primarily use loaders, to skip loading the global config which contains the crucial VFS settings.
- The second issue was that manually selected shared configs also acted as an override, which also skipped the VFS settings. This obviously isn't what the user wants.

In the future we should detach VFS and similar global settings from the regular config file to prevent this issue from happening.
But for now this shall act as an alternative (and hotfix as is).

Hopefully fixes #10862
Fixes #10867 (at least the idea behind it)