### PR TITLE
Debugger: Implement editing instruction for entire SPU group

### DIFF
--- a/rpcs3/rpcs3qt/instruction_editor_dialog.h
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.h
@@ -8,6 +8,7 @@
 
 class CPUDisAsm;
 class cpu_thread;
+class QCheckBox;
 
 class instruction_editor_dialog : public QDialog
 {
@@ -19,6 +20,7 @@ private:
 	CPUDisAsm* m_disasm;
 	QLineEdit* m_instr;
 	QLabel* m_preview;
+	QCheckBox* m_apply_for_spu_group = nullptr;
 
 	const std::function<cpu_thread*()> m_get_cpu;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18193363/134558943-b2c0bb4a-fe96-4bab-8d2f-bfb42ba91140.png)

When option is enabled, the edited instruction will be applied for all SPUs in the group at the same address. This checkbox appears only for a threaded SPU thread and if its group contains more than one thread.