### PR TITLE
SPU: Implement interrupts handling for remaining events

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1642,6 +1642,8 @@ void spu_thread::cpu_task()
 	{
 		ensure(spu_runtime::g_interpreter);
 
+		allow_interrupts_in_cpu_work = true;
+
 		while (true)
 		{
 			if (state) [[unlikely]]
@@ -1652,6 +1654,8 @@ void spu_thread::cpu_task()
 
 			spu_runtime::g_interpreter(*this, _ptr<u8>(0), nullptr);
 		}
+
+		allow_interrupts_in_cpu_work = false;
 	}
 }
 
@@ -1662,15 +1666,57 @@ void spu_thread::cpu_work()
 		return;
 	}
 
+	const u32 old_iter_count = cpu_work_iteration_count++;
+
 	const auto timeout = +g_cfg.core.mfc_transfers_timeout;
 
-	// If either MFC size exceeds limit or timeout has been reached execute pending MFC commands
-	if (mfc_size > g_cfg.core.mfc_transfers_shuffling || (timeout && get_system_time() - mfc_last_timestamp >= timeout))
+	bool work_left = false;
+
+	if (u32 shuffle_count = g_cfg.core.mfc_transfers_shuffling)
 	{
-		do_mfc(false, false);
+		// If either MFC size exceeds limit or timeout has been reached execute pending MFC commands
+		if (mfc_size > shuffle_count || (timeout && get_system_time() - mfc_last_timestamp >= timeout))
+		{
+			work_left = do_mfc(false, false);
+		}
+		else
+		{
+			work_left = mfc_size != 0; // TODO: Optimize
+		}
 	}
 
+	bool gen_interrupt = false;
+
+	// Check interrupts every 16 iterations
+	if (!(old_iter_count % 16) && allow_interrupts_in_cpu_work)
+	{
+		if (u32 mask = ch_events.load().mask & SPU_EVENT_INTR_BUSY_CHECK)
+		{
+			// LR check is expensive, do it once in a while
+			if (old_iter_count /*% 256*/)
+			{
+				mask &= ~SPU_EVENT_LR;
+			}
+
+			get_events(mask);
+		}
+
+		gen_interrupt = check_mfc_interrupts(pc);
+		work_left |= interrupts_enabled;
+	}
+	
 	in_cpu_work = false;
+
+	if (!work_left)
+	{
+		state -= cpu_flag::pending;
+	}
+
+	if (gen_interrupt)
+	{
+		// Interrupt! escape everything and restart execution
+		spu_runtime::g_escape(this);
+	}
 }
 
 struct raw_spu_cleanup
@@ -2966,7 +3012,7 @@ void spu_thread::do_putlluc(const spu_mfc_cmd& args)
 	vm::reservation_notifier(addr).notify_all(-128);
 }
 
-void spu_thread::do_mfc(bool can_escape, bool must_finish)
+bool spu_thread::do_mfc(bool can_escape, bool must_finish)
 {
 	u32 removed = 0;
 	u32 barrier = 0;
@@ -3118,15 +3164,11 @@ void spu_thread::do_mfc(bool can_escape, bool must_finish)
 			// Exit early, not all pending commands have to be executed at a single iteration
 			// Update last timestamp so the next MFC timeout check will use the current time
 			mfc_last_timestamp = get_system_time();
-			return;
+			return true;
 		}
 	}
 
-	if (state & cpu_flag::pending)
-	{
-		// No more pending work
-		state -= cpu_flag::pending;
-	}
+	return false;
 }
 
 bool spu_thread::check_mfc_interrupts(u32 next_pc)
@@ -3751,9 +3793,20 @@ void spu_thread::set_interrupt_status(bool enable)
 	if (enable)
 	{
 		// Detect enabling interrupts with events masked
-		if (auto mask = ch_events.load().mask; mask & ~SPU_EVENT_INTR_IMPLEMENTED)
+		if (auto mask = ch_events.load().mask; mask & SPU_EVENT_INTR_BUSY_CHECK)
 		{
-			fmt::throw_exception("SPU Interrupts not implemented (mask=0x%x)", mask);
+			if (g_cfg.core.spu_decoder != spu_decoder_type::precise && g_cfg.core.spu_decoder != spu_decoder_type::fast)
+			{
+				fmt::throw_exception("SPU Interrupts not implemented (mask=0x%x): Use interpreterts", mask);
+			}
+
+			spu_log.trace("SPU Interrupts (mask=0x%x) are using CPU busy checking mode", mask);
+
+			// Process interrupts in cpu_work()
+			if (state.none_of(cpu_flag::pending))
+			{
+				state += cpu_flag::pending;
+			}
 		}
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -82,8 +82,7 @@ enum : u32
 
 	SPU_EVENT_IMPLEMENTED  = SPU_EVENT_LR | SPU_EVENT_TM | SPU_EVENT_SN | SPU_EVENT_S1 | SPU_EVENT_S2, // Mask of implemented events
 	SPU_EVENT_INTR_IMPLEMENTED = SPU_EVENT_SN,
-
-	SPU_EVENT_INTR_TEST = SPU_EVENT_INTR_IMPLEMENTED,
+	SPU_EVENT_INTR_BUSY_CHECK = SPU_EVENT_IMPLEMENTED & ~SPU_EVENT_INTR_IMPLEMENTED,
 };
 
 // SPU Class 0 Interrupts
@@ -779,6 +778,8 @@ public:
 	static constexpr u32 max_mfc_dump_idx = 2048;
 
 	bool in_cpu_work = false;
+	bool allow_interrupts_in_cpu_work = false;
+	u8 cpu_work_iteration_count = 0;
 
 	std::array<v128, 0x4000> stack_mirror; // Return address information
 
@@ -793,7 +794,7 @@ public:
 	bool do_list_transfer(spu_mfc_cmd& args);
 	void do_putlluc(const spu_mfc_cmd& args);
 	bool do_putllc(const spu_mfc_cmd& args);
-	void do_mfc(bool can_escape = true, bool must_finish = true);
+	bool do_mfc(bool can_escape = true, bool must_finish = true);
 	u32 get_mfc_completed() const;
 
 	bool process_mfc_cmd();


### PR DESCRIPTION
Implement all the missing SPU interrupts, use SPU interpreter with this pull request.

What took so long to fix this? Well, the games in need of this pull request are using a special hw timer interrupts. On real ps3 when SPU timer interrupts are efficient as the inner hw timer knows when it encounters an underflow to automatically raise the timer event bit. This process can be done at any given location in code between every single instruction.
But on an emulator... this either means implementing a thread to "interrupt" the SPU once an underflow is reached or merging the timer checks inside the SPU thread execution itself every now and then, I chose the second option.
But wait, isn't this going to decrease performance significantly? That's the best part, I used a special SPU flag I added in #8514 to indicate the SPU has "work" it needs to do every now and then. Thus when timer interrupt is disabled, no additional checks will be perfomed, and no performance hit will be encountered for when thhe interrupt is unsued.
I've also implemented this for reservation, S1 and S2 interrupts.
 
![image](https://user-images.githubusercontent.com/18193363/134607450-0d8a37d4-8ac6-43a5-88a6-f3f8b0b14cb5.png)

Fixes #5591.