### PR TITLE
Taskbar progressbar fixes for Windows and Linux (Unity Launcher)

### DIFF
--- a/rpcs3/rpcs3qt/downloader.cpp
+++ b/rpcs3/rpcs3qt/downloader.cpp
@@ -106,7 +106,7 @@ void downloader::start(const std::string& url, bool follow_location, bool show_p
 		{
 			m_progress_dialog->setWindowTitle(progress_dialog_title);
 			m_progress_dialog->setAutoClose(!m_keep_progress_dialog_open);
-			m_progress_dialog->setMaximum(maximum);
+			m_progress_dialog->SetRange(0, maximum);
 		}
 		else
 		{
@@ -209,8 +209,8 @@ void downloader::handle_buffer_update(int size, int max) const
 
 	if (m_progress_dialog)
 	{
-		m_progress_dialog->setMaximum(max > 0 ? max : m_progress_dialog->maximum());
-		m_progress_dialog->setValue(size);
+		m_progress_dialog->SetRange(0, max > 0 ? max : m_progress_dialog->maximum());
+		m_progress_dialog->SetValue(size);
 		QApplication::processEvents();
 	}
 }

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -124,7 +124,7 @@ gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon,
 	m_tb_progress->setVisible(false);
 
 #elif HAVE_QTDBUS
-	UpdateProgress(0);
+	UpdateProgress(0, false);
 	m_progress_value = 0;
 #endif
 }
@@ -801,7 +801,7 @@ void gs_frame::progress_reset(bool reset_limit)
 		m_tb_progress->reset();
 	}
 #elif HAVE_QTDBUS
-	UpdateProgress(0);
+	UpdateProgress(0, false);
 #endif
 
 	if (reset_limit)
@@ -819,7 +819,7 @@ void gs_frame::progress_set_value(int value)
 	}
 #elif HAVE_QTDBUS
 	m_progress_value = std::clamp(value, 0, m_gauge_max);
-	UpdateProgress(m_progress_value);
+	UpdateProgress(m_progress_value, true);
 #endif
 }
 
@@ -853,7 +853,7 @@ void gs_frame::progress_set_limit(int limit)
 }
 
 #ifdef HAVE_QTDBUS
-void gs_frame::UpdateProgress(int progress, bool disable)
+void gs_frame::UpdateProgress(int progress, bool progress_visible)
 {
 	QDBusMessage message = QDBusMessage::createSignal
 	(
@@ -862,12 +862,9 @@ void gs_frame::UpdateProgress(int progress, bool disable)
 		QStringLiteral("Update")
 	);
 	QVariantMap properties;
-	if (disable)
-		properties.insert(QStringLiteral("progress-visible"), false);
-	else
-		properties.insert(QStringLiteral("progress-visible"), true);
-	//Progress takes a value from 0.0 to 0.1
+	// Progress takes a value from 0.0 to 0.1
 	properties.insert(QStringLiteral("progress"), 1. * progress / m_gauge_max);
+	properties.insert(QStringLiteral("progress-visible"), progress_visible);
 	message << QStringLiteral("application://rpcs3.desktop") << properties;
 	QDBusConnection::sessionBus().send(message);
 }

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -30,7 +30,7 @@ private:
 	QWinTaskbarProgress* m_tb_progress = nullptr;
 #elif HAVE_QTDBUS
 	int m_progress_value = 0;
-	void UpdateProgress(int progress, bool disable = false);
+	void UpdateProgress(int progress, bool progress_visible);
 #endif
 
 	QRect m_initial_geometry;

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -372,12 +372,10 @@ void msg_dialog_frame::ProgressBarSetLimit(u32 index, u32 limit)
 #ifdef HAVE_QTDBUS
 void msg_dialog_frame::UpdateProgress(int progress, bool disable)
 {
-	QDBusMessage message = QDBusMessage::createSignal
-	(
+	QDBusMessage message = QDBusMessage::createSignal(
 		QStringLiteral("/"),
 		QStringLiteral("com.canonical.Unity.LauncherEntry"),
-		QStringLiteral("Update")
-	);
+		QStringLiteral("Update"));
 	QVariantMap properties;
 	if (disable)
 		properties.insert(QStringLiteral("progress-visible"), false);

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -66,7 +66,7 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 		m_tb_progress->setRange(0, 100);
 		m_tb_progress->setVisible(true);
 #elif HAVE_QTDBUS
-		UpdateProgress(0);
+		UpdateProgress(0, true);
 		m_progress_value = 0;
 #endif
 	}
@@ -249,7 +249,7 @@ void msg_dialog_frame::ProgressBarReset(u32 index)
 			m_tb_progress->reset();
 		}
 #elif HAVE_QTDBUS
-		UpdateProgress(0);
+		UpdateProgress(0, false);
 #endif
 	}
 }
@@ -285,7 +285,7 @@ void msg_dialog_frame::ProgressBarInc(u32 index, u32 delta)
 		}
 #elif HAVE_QTDBUS
 		m_progress_value = std::min(m_progress_value + static_cast<int>(delta), m_gauge_max);
-		UpdateProgress(m_progress_value);
+		UpdateProgress(m_progress_value, true);
 #endif
 	}
 }
@@ -321,7 +321,7 @@ void msg_dialog_frame::ProgressBarSetValue(u32 index, u32 value)
 		}
 #elif HAVE_QTDBUS
 		m_progress_value = std::min(static_cast<int>(value), m_gauge_max);
-		UpdateProgress(m_progress_value);
+		UpdateProgress(m_progress_value, true);
 #endif
 	}
 }
@@ -370,19 +370,16 @@ void msg_dialog_frame::ProgressBarSetLimit(u32 index, u32 limit)
 }
 
 #ifdef HAVE_QTDBUS
-void msg_dialog_frame::UpdateProgress(int progress, bool disable)
+void msg_dialog_frame::UpdateProgress(int progress, bool progress_visible)
 {
 	QDBusMessage message = QDBusMessage::createSignal(
 		QStringLiteral("/"),
 		QStringLiteral("com.canonical.Unity.LauncherEntry"),
 		QStringLiteral("Update"));
 	QVariantMap properties;
-	if (disable)
-		properties.insert(QStringLiteral("progress-visible"), false);
-	else
-		properties.insert(QStringLiteral("progress-visible"), true);
 	// Progress takes a value from 0.0 to 0.1
-	properties.insert(QStringLiteral("progress"), 1.* progress / m_gauge_max);
+	properties.insert(QStringLiteral("progress"), 1. * progress / m_gauge_max);
+	properties.insert(QStringLiteral("progress-visible"), progress_visible);
 	message << QStringLiteral("application://rpcs3.desktop") << properties;
 	QDBusConnection::sessionBus().send(message);
 }

--- a/rpcs3/rpcs3qt/msg_dialog_frame.h
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.h
@@ -48,6 +48,6 @@ public:
 	void ProgressBarSetLimit(u32 index, u32 limit) override;
 #ifdef HAVE_QTDBUS
 private:
-	void UpdateProgress(int progress, bool disable = false);
+	void UpdateProgress(int progress, bool progress_visible);
 #endif
 };

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -41,7 +41,7 @@ progress_dialog::progress_dialog(const QString& windowTitle, const QString& labe
 	m_tb_progress->setRange(minimum, maximum);
 	m_tb_progress->show();
 #elif HAVE_QTDBUS
-	UpdateProgress(0);
+	UpdateProgress(0, true);
 #endif
 }
 
@@ -60,8 +60,8 @@ progress_dialog::~progress_dialog()
 		QStringLiteral("Update"));
 	QVariantMap properties;
 	properties.insert(QStringLiteral("urgent"), false);
-	properties.insert(QStringLiteral("progress-visible"), false);
 	properties.insert(QStringLiteral("progress"), 0);
+	properties.insert(QStringLiteral("progress-visible"), false);
 	message << QStringLiteral("application://rpcs3.desktop") << properties;
 	QDBusConnection::sessionBus().send(message);
 #endif
@@ -83,7 +83,7 @@ void progress_dialog::SetValue(int progress)
 #ifdef _WIN32
 	m_tb_progress->setValue(value);
 #elif HAVE_QTDBUS
-	UpdateProgress(value);
+	UpdateProgress(value, true);
 #endif
 
 	QProgressDialog::setValue(value);
@@ -108,19 +108,16 @@ void progress_dialog::SignalFailure() const
 }
 
 #ifdef HAVE_QTDBUS
-void progress_dialog::UpdateProgress(int progress, bool disable)
+void progress_dialog::UpdateProgress(int progress, bool progress_visible)
 {
 	QDBusMessage message = QDBusMessage::createSignal(
 		QStringLiteral("/"),
 		QStringLiteral("com.canonical.Unity.LauncherEntry"),
 		QStringLiteral("Update"));
 	QVariantMap properties;
-	if (disable)
-		properties.insert(QStringLiteral("progress-visible"), false);
-	else
-		properties.insert(QStringLiteral("progress-visible"), true);
-	//Progress takes a value from 0.0 to 0.1
+	// Progress takes a value from 0.0 to 0.1
 	properties.insert(QStringLiteral("progress"), 1. * progress / maximum());
+	properties.insert(QStringLiteral("progress-visible"), progress_visible);
 	message << QStringLiteral("application://rpcs3.desktop") << properties;
 	QDBusConnection::sessionBus().send(message);
 }

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -54,7 +54,16 @@ progress_dialog::~progress_dialog()
 		m_tb_progress->hide();
 	}
 #elif HAVE_QTDBUS
-	UpdateProgress(0);
+	QDBusMessage message = QDBusMessage::createSignal(
+		QStringLiteral("/"),
+		QStringLiteral("com.canonical.Unity.LauncherEntry"),
+		QStringLiteral("Update"));
+	QVariantMap properties;
+	properties.insert(QStringLiteral("urgent"), false);
+	properties.insert(QStringLiteral("progress-visible"), false);
+	properties.insert(QStringLiteral("progress"), 0);
+	message << QStringLiteral("application://rpcs3.desktop") << properties;
+	QDBusConnection::sessionBus().send(message);
 #endif
 }
 
@@ -84,8 +93,16 @@ void progress_dialog::SignalFailure() const
 {
 #ifdef _WIN32
 	m_tb_progress->stop();
+#elif HAVE_QTDBUS
+	QDBusMessage message = QDBusMessage::createSignal(
+		QStringLiteral("/"),
+		QStringLiteral("com.canonical.Unity.LauncherEntry"),
+		QStringLiteral("Update"));
+	QVariantMap properties;
+	properties.insert(QStringLiteral("urgent"), true);
+	message << QStringLiteral("application://rpcs3.desktop") << properties;
+	QDBusConnection::sessionBus().send(message);
 #endif
-	// TODO: Implement an equivalent for Linux, if possible
 
 	QApplication::beep();
 }

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -1,6 +1,6 @@
 #include "progress_dialog.h"
 
-#include <QCoreApplication>
+#include <QApplication>
 #include <QLabel>
 
 #ifdef _WIN32
@@ -86,6 +86,8 @@ void progress_dialog::SignalFailure() const
 	m_tb_progress->stop();
 #endif
 	// TODO: Implement an equivalent for Linux, if possible
+
+	QApplication::beep();
 }
 
 #ifdef HAVE_QTDBUS

--- a/rpcs3/rpcs3qt/progress_dialog.h
+++ b/rpcs3/rpcs3qt/progress_dialog.h
@@ -10,8 +10,9 @@
 class progress_dialog : public QProgressDialog
 {
 public:
-	progress_dialog(const QString &windowTitle, const QString &labelText, const QString &cancelButtonText, int minimum, int maximum, bool delete_on_close, QWidget *parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
+	progress_dialog(const QString& windowTitle, const QString& labelText, const QString& cancelButtonText, int minimum, int maximum, bool delete_on_close, QWidget* parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
 	~progress_dialog();
+	void SetRange(int min, int max);
 	void SetValue(int progress);
 	void SignalFailure() const;
 

--- a/rpcs3/rpcs3qt/progress_dialog.h
+++ b/rpcs3/rpcs3qt/progress_dialog.h
@@ -21,6 +21,6 @@ private:
 	std::unique_ptr<QWinTaskbarButton> m_tb_button = nullptr;
 	QWinTaskbarProgress* m_tb_progress = nullptr;
 #elif HAVE_QTDBUS
-	void UpdateProgress(int progress, bool disable = false);
+	void UpdateProgress(int progress, bool progress_visible);
 #endif
 };


### PR DESCRIPTION
Windows:
- fixes taskbar progress of the downloader's progress dialog

Linux:
- Should fix an issue where the taskbar progress would stay at 0 after the dialogs are finished
- May add error notifications (needs testing)