### PR TITLE
Qt: Fix SnapSlider in settings

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -34,6 +34,7 @@ private:
 	// Snapping of sliders when moved with mouse
 	void SnapSlider(QSlider* slider, int interval);
 	QSlider* m_current_slider = nullptr;
+	std::set<QObject*> m_snap_sliders;
 
 	// Gui tab
 	void AddStylesheets();


### PR DESCRIPTION
The SnapSlider function is used to snap the current slider to certain values if modified with the mouse.
But it only triggered if the user was dragging the handle of the slider and not if the bar itself was clicked.

This is fixed by using an eventFilter that listens for mousepress and mouserelease events instead of the sliderPressed and sliderReleased signals.
Maybe this is a Qt bug, but I don't want to bother with reporting this right now.

fixed #10932