### PR TITLE
GUI Utilities: Implement PS3 SDAT/EDAT decryption

### DIFF
--- a/rpcs3/Crypto/unedat.h
+++ b/rpcs3/Crypto/unedat.h
@@ -27,7 +27,7 @@ struct NPD_HEADER
 	s32 version;
 	s32 license;
 	s32 type;
-	u8 content_id[0x30];
+	char content_id[0x30];
 	u8 digest[0x10];
 	u8 title_hash[0x10];
 	u8 dev_hash[0x10];
@@ -43,7 +43,7 @@ struct EDAT_HEADER
 };
 
 // Decrypts full file, or null/empty file
-extern fs::file DecryptEDAT(const fs::file& input, const std::string& input_file_name, int mode, const std::string& rap_file_name, u8 *custom_klic, bool verbose);
+extern fs::file DecryptEDAT(const fs::file& input, const std::string& input_file_name, int mode, u8 *custom_klic, bool verbose);
 
 extern bool VerifyEDATHeaderWithKLicense(const fs::file& input, const std::string& input_file_name, const u8* custom_klic, std::string* contentID);
 

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -686,7 +686,7 @@ package_error package_reader::check_target_app_version() const
 	return package_error::app_version;
 }
 
-fs::file DecryptEDAT(const fs::file& input, const std::string& input_file_name, int mode, const std::string& rap_file_name, u8 *custom_klic, bool verbose = false);
+fs::file DecryptEDAT(const fs::file& input, const std::string& input_file_name, int mode, u8 *custom_klic, bool verbose = false);
 
 bool package_reader::extract_data(atomic_t<double>& sync)
 {
@@ -839,7 +839,7 @@ bool package_reader::extract_data(atomic_t<double>& sync)
 
 				if (is_buffered)
 				{
-					out = DecryptEDAT(out, name, 1, "", reinterpret_cast<u8*>(&m_header.klicensee), true);
+					out = DecryptEDAT(out, name, 1, reinterpret_cast<u8*>(&m_header.klicensee), true);
 					if (!out || !fs::write_file(path, fs::rewrite, static_cast<fs::container_stream<std::vector<u8>>*>(out.release().get())->obj))
 					{
 						num_failures++;

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -185,13 +185,14 @@ namespace rpcs3::utils
 		const std::string edat_path = rpcs3::utils::get_c00_unlock_edat_path(content_id);
 
 		// Check if user has unlock EDAT installed
-		if (!fs::is_file(edat_path))
+		fs::file enc_file(edat_path);
+
+		if (!enc_file)
 		{
 			sys_log.notice("verify_c00_unlock_edat(): '%s' not found", edat_path);
 			return false;
 		}
 
-		const fs::file enc_file(edat_path);
 		u128 k_licensee = get_default_self_klic();
 		std::string edat_content_id;
 
@@ -207,18 +208,8 @@ namespace rpcs3::utils
 			return false;
 		}
 
-		// Check if required RAP is present
-		std::string rap_path = rpcs3::utils::get_rap_file_path(content_id);
-
-		if (!fs::is_file(rap_path))
-		{
-			// Not necessarily an error
-			sys_log.warning("verify_c00_unlock_edat(): RAP file not found: '%s'", rap_path);
-			rap_path.clear();
-		}
-
 		// Decrypt EDAT and verify its contents
-		fs::file dec_file = DecryptEDAT(enc_file, edat_path, 8, rap_path, reinterpret_cast<u8*>(&k_licensee), false);
+		fs::file dec_file = DecryptEDAT(enc_file, edat_path, 8, reinterpret_cast<u8*>(&k_licensee), false);
 		if (!dec_file)
 		{
 			sys_log.error("verify_c00_unlock_edat(): Failed to decrypt '%s'", edat_path);


### PR DESCRIPTION
In addition to PPU SELF/SPRX/OVL decryption, the tool "Decrypt PS3 Binaries" will now be able to decrypt SDAT and EDAT files.
Note that EDAT files may require KLIC and RAP file, I've added logging of the needed licence file (NPD content_id) for such cases.