### PR TITLE
SPU LLVM: Use VDBPSADBW in SUMB

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3367,6 +3367,21 @@ public:
 	}
 
 	template <typename T1, typename T2>
+	value_t<u8[16]> vdbpsadbw(T1 a, T2 b, u8 c)
+	{
+		value_t<u8[16]> result;
+
+		const auto data0 = a.eval(m_ir);
+		const auto data1 = b.eval(m_ir);
+
+		const auto immediate = (llvm_const_int<u32>{c});
+		const auto imm8 = immediate.eval(m_ir);
+
+		result.value = m_ir->CreateCall(get_intrinsic(llvm::Intrinsic::x86_avx512_dbpsadbw_128), {data0, data1, imm8});
+		return result;
+	}
+
+	template <typename T1, typename T2>
 	value_t<u8[16]> vpermb(T1 a, T2 b)
 	{
 		value_t<u8[16]> result;

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3367,21 +3367,6 @@ public:
 	}
 
 	template <typename T1, typename T2>
-	value_t<u8[16]> vdbpsadbw(T1 a, T2 b, u8 c)
-	{
-		value_t<u8[16]> result;
-
-		const auto data0 = a.eval(m_ir);
-		const auto data1 = b.eval(m_ir);
-
-		const auto immediate = (llvm_const_int<u32>{c});
-		const auto imm8 = immediate.eval(m_ir);
-
-		result.value = m_ir->CreateCall(get_intrinsic(llvm::Intrinsic::x86_avx512_dbpsadbw_128), {data0, data1, imm8});
-		return result;
-	}
-
-	template <typename T1, typename T2>
 	value_t<u8[16]> vpermb(T1 a, T2 b)
 	{
 		value_t<u8[16]> result;
@@ -3578,6 +3563,12 @@ public:
 	static auto fmin(T&& a, U&& b)
 	{
 		return llvm_calli<f32[4], T, U>{"llvm.x86.sse.min.ps", {std::forward<T>(a), std::forward<U>(b)}};
+	}
+
+	template <typename T, typename U, typename = std::enable_if_t<std::is_same_v<llvm_common_t<T, U>, u8[16]>>>
+	static auto vdbpsadbw(T&& a, U&& b, u8 c)
+	{
+		return llvm_calli<u8[16], T, U, llvm_const_int<u32>>{"llvm.x86.avx512.dbpsadbw.128", {std::forward<T>(a), std::forward<U>(b), llvm_const_int<u32>{c}}};
 	}
 };
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7022,6 +7022,23 @@ public:
 
 	void SUMB(spu_opcode_t op)
 	{
+		if (m_use_avx512)
+		{
+			const auto [a, b] = get_vrs<u8[16]>(op.ra, op.rb);
+			const auto zeroes = splat<u8[16]>(0);
+
+			if (op.ra == op.rb && !m_interp_magn)
+			{
+				set_vr(op.rt, vdbpsadbw(a, zeroes, 0));
+				return;
+			}
+
+			const auto ax = vdbpsadbw(a, zeroes, 0);
+			const auto bx = vdbpsadbw(b, zeroes, 0);
+			set_vr(op.rt, shuffle2(ax, bx, 0, 8, 2, 10, 4, 12, 6, 14));
+			return;
+		}
+
 		if (m_use_vnni)
 		{
 			const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);


### PR DESCRIPTION
I overlooked this instruction earlier when optimizing the VNNI path for SUMB.

This AVX-512 instruction first calculates the absolute difference between 2 vectors before summing bytes horizontally. By using a vector of all zeroes, we can effectively use the instruction to just sum bytes horizontally.

This instruction should be faster than the VNNI alternative since we don't need to zero out the destination register, and we don't need to load a vector full of the constant 0x01. Additionally, when op.ra == op.rb, we only need a single instruction for the correct behavior.
