### PR TITLE
Debugger/Disasm: Name PPU Syscalls

### DIFF
--- a/rpcs3/Emu/Cell/PPUDisAsm.h
+++ b/rpcs3/Emu/Cell/PPUDisAsm.h
@@ -287,6 +287,7 @@ private:
 
 public:
 	u32 disasm(u32 pc) override;
+	std::pair<bool, u64> try_get_const_gpr_value(u32 reg, u32 pc = -1) const;
 
 	void MFVSCR(ppu_opcode_t op);
 	void MTVSCR(ppu_opcode_t op);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -641,7 +641,6 @@ bool ppu_form_branch_to_code(u32 entry, u32 target, bool link, bool with_toc, st
 		return false;
 	}
 
-	if (module_name.empty())
 	g_fxo->init<ppu_far_jumps_t>();
 
 	if (!module_name.empty())

--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -22,7 +22,7 @@ u32 SPUDisAsm::disasm(u32 pc)
 
 std::pair<bool, v128> SPUDisAsm::try_get_const_value(u32 reg, u32 pc) const
 {
-	if (m_mode != cpu_disasm_mode::interpreter)
+	if (m_mode != cpu_disasm_mode::interpreter && m_mode != cpu_disasm_mode::normal)
 	{
 		return {};
 	}


### PR DESCRIPTION
For example: https://user-images.githubusercontent.com/18193363/134966023-593dadb9-19ef-41dd-86b4-c65e30bd1f88.png
Previously it just displayed "sc" and nothing more.

This is done by trying to get a constant value of r11 from the point of the syscall backwards, by analysing previous instructions. This process is called constant folding.
If r11 is not a constant (as far as we know), simply "sc" will be printed.