### PR TITLE
[TESTERS NEEDED] vk: Use a dynamic number of descriptor allocations

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -16,7 +16,6 @@
 #include "Emu/RSX/Common/TextureUtils.h"
 #include "Emu/RSX/rsx_utils.h"
 
-#define DESCRIPTOR_MAX_DRAW_CALLS 16384
 #define OCCLUSION_MAX_POOL_SIZE   DESCRIPTOR_MAX_DRAW_CALLS
 
 #define FRAME_PRESENT_TIMEOUT 10000000ull // 10 seconds

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -373,13 +373,15 @@ namespace vk
 
 	void shader_interpreter::create_descriptor_pools(const vk::render_device& dev)
 	{
-		std::vector<VkDescriptorPoolSize> sizes;
-		sizes.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER , 6 * DESCRIPTOR_MAX_DRAW_CALLS });
-		sizes.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER , 3 * DESCRIPTOR_MAX_DRAW_CALLS });
-		sizes.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER , 68 * DESCRIPTOR_MAX_DRAW_CALLS });
-		sizes.push_back({ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 3 * DESCRIPTOR_MAX_DRAW_CALLS });
+		const auto max_draw_calls = dev.get_descriptor_max_draw_calls();
 
-		m_descriptor_pool.create(dev, sizes.data(), ::size32(sizes), DESCRIPTOR_MAX_DRAW_CALLS, 2);
+		std::vector<VkDescriptorPoolSize> sizes;
+		sizes.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER , 6 * max_draw_calls });
+		sizes.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER , 3 * max_draw_calls });
+		sizes.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER , 68 * max_draw_calls });
+		sizes.push_back({ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 3 * max_draw_calls });
+
+		m_descriptor_pool.create(dev, sizes.data(), ::size32(sizes), max_draw_calls, 2);
 	}
 
 	void shader_interpreter::init(const vk::render_device& dev)
@@ -513,7 +515,7 @@ namespace vk
 
 	VkDescriptorSet shader_interpreter::allocate_descriptor_set()
 	{
-		if (m_used_descriptors == DESCRIPTOR_MAX_DRAW_CALLS)
+		if (!m_descriptor_pool.can_allocate(1u, m_used_descriptors))
 		{
 			m_descriptor_pool.reset(0);
 			m_used_descriptors = 0;

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -109,7 +109,7 @@ namespace vk
 	{
 		ensure(subpool_count);
 
-		info.flags = dev.get_descriptor_indexing_support() ? VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT : 0;
+		info.flags = dev.get_descriptor_update_after_bind_support() ? VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT : 0;
 		info.maxSets = max_sets;
 		info.poolSizeCount = size_descriptors_count;
 		info.pPoolSizes = sizes;
@@ -137,16 +137,6 @@ namespace vk
 		}
 
 		m_owner = nullptr;
-	}
-
-	bool descriptor_pool::valid() const
-	{
-		return (!m_device_pools.empty());
-	}
-
-	descriptor_pool::operator VkDescriptorPool()
-	{
-		return m_current_pool_handle;
 	}
 
 	void descriptor_pool::reset(VkDescriptorPoolResetFlags flags)
@@ -194,11 +184,10 @@ namespace vk
 
 		if (use_cache)
 		{
+			ensure(used_count < info.maxSets);
 			const auto alloc_size = std::min<u32>(info.maxSets - used_count, max_cache_size);
 
-			ensure(alloc_size);
 			ensure(m_descriptor_set_cache.empty());
-
 			alloc_info.descriptorSetCount = alloc_size;
 			alloc_info.pSetLayouts = m_allocation_request_cache.data();
 

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -20,10 +20,12 @@ namespace vk
 		void destroy();
 		void reset(VkDescriptorPoolResetFlags flags);
 
-		bool valid() const;
-		operator VkDescriptorPool();
-
 		VkDescriptorSet allocate(VkDescriptorSetLayout layout, VkBool32 use_cache, u32 used_count);
+
+		operator VkDescriptorPool() { return m_current_pool_handle; }
+		FORCE_INLINE bool valid() const { return (!m_device_pools.empty()); }
+		FORCE_INLINE u32 max_sets() const { return info.maxSets; }
+		FORCE_INLINE bool can_allocate(u32 required_count, u32 used_count) const { return (used_count + required_count) <= info.maxSets; };
 
 	private:
 		const vk::render_device* m_owner = nullptr;

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -9,6 +9,8 @@
 #include <vector>
 #include <unordered_map>
 
+#define DESCRIPTOR_MAX_DRAW_CALLS 16384
+
 namespace vk
 {
 	struct gpu_formats_support
@@ -62,10 +64,12 @@ namespace vk
 		bool descriptor_indexing_support = false;
 
 		u64 descriptor_update_after_bind_mask = 0;
+		u32 descriptor_max_draw_calls = DESCRIPTOR_MAX_DRAW_CALLS;
 
 		friend class render_device;
 	private:
 		void get_physical_device_features(bool allow_extensions);
+		void get_physical_device_properties(bool allow_extensions);
 
 	public:
 
@@ -147,6 +151,7 @@ namespace vk
 		bool get_descriptor_indexing_support() const;
 
 		u64 get_descriptor_update_after_bind_support() const;
+		u32 get_descriptor_max_draw_calls() const;
 
 		VkQueue get_present_queue() const;
 		VkQueue get_graphics_queue() const;


### PR DESCRIPTION
Attempts to adjust number of pre-allocated descriptors based on device limits. This solely exists because of intel's windows drivers which advertises a relatively tiny sized pool. A small performance hit (~1-2%) is expected.

Should fix https://github.com/RPCS3/rpcs3/issues/10941

I do not have an intel iGPU system, we need testers with this hardware to verify if games run for them without crashing. Preferably graphically intensive applications tested over at least 5-10 minutes.