### PR TITLE
Qt: Add "Restore Defaults" Button to Settings Dialog

### DIFF
--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -369,7 +369,7 @@ void emu_settings::EnhanceComboBox(QComboBox* combobox, emu_settings_type type, 
 
 		if (is_ranged)
 		{
-			index = combobox->findData(selected_q);
+			index = combobox->findData(qstr(def));
 		}
 		else
 		{

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -92,9 +92,16 @@ public:
 	/** Validates the settings and logs unused entries or cleans up the yaml*/
 	bool ValidateSettings(bool cleanup);
 
+	/** Resets the current settings to the global default. This includes all connected widgets. */
+	void RestoreDefaults();
+
+Q_SIGNALS:
+	void RestoreDefaultsSignal();
+
 public Q_SLOTS:
 	/** Writes the unsaved settings to file.  Used in settings dialog on accept.*/
 	void SaveSettings();
+
 private:
 	YAML::Node m_default_settings; // The default settings as a YAML node.
 	YAML::Node m_current_settings; // The current settings as a YAML node.

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -578,7 +578,7 @@ void main_window::InstallPackages(QStringList file_paths)
 
 		if (!info.is_valid)
 		{
-			QMessageBox::warning(this, QObject::tr("Invalid package!"), QObject::tr("The selected package is invalid!\n\nPath:\n%0").arg(file_path));
+			QMessageBox::warning(this, tr("Invalid package!"), tr("The selected package is invalid!\n\nPath:\n%0").arg(file_path));
 			return;
 		}
 

--- a/rpcs3/rpcs3qt/microphone_creator.cpp
+++ b/rpcs3/rpcs3qt/microphone_creator.cpp
@@ -57,10 +57,12 @@ std::array<std::string, 4> microphone_creator::get_selection_list() const
 
 std::string microphone_creator::set_device(u32 num, const QString& text)
 {
+	ensure(num < m_sel_list.size());
+
 	if (text == get_none())
-		m_sel_list[num - 1] = "";
+		m_sel_list[num].clear();
 	else
-		m_sel_list[num - 1] = text.toStdString();
+		m_sel_list[num] = text.toStdString();
 
 	return m_sel_list[0] + "@@@" + m_sel_list[1] + "@@@" + m_sel_list[2] + "@@@" + m_sel_list[3] + "@@@";
 }

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -28,6 +28,7 @@ Q_SIGNALS:
 	void GuiStylesheetRequest();
 	void GuiRepaintRequest();
 	void EmuSettingsApplied();
+	void signal_restore_dependant_defaults();
 private:
 	void EnhanceSlider(emu_settings_type settings_type, QSlider* slider, QLabel* label, const QString& label_text) const;
 
@@ -43,7 +44,7 @@ private:
 	// Gpu tab
 	QString m_old_renderer;
 	// Audio tab
-	QComboBox *m_mics_combo[4];
+	std::array<QComboBox*, 4> m_mics_combo;
 
 	int m_tab_index;
 	Ui::settings_dialog *ui;

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -3852,7 +3852,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Close|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Close|QDialogButtonBox::RestoreDefaults|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
- Adds a "Restore Defaults" button to the settings dialog.
When pressed, the current emu settings will be reset and all GUI toggles will be adjusted accordingly.
The settings will not be applied immediately. You still have to press "Apply" or "Save".
**The GUI settings won't be touched for now since they are applied immediately, which could turn out to be annoying.**
- Fixes the default value of RadioButtons in the settings, which was previously only properly found under certain conditions.
- Fixes the default value of ranged ComboBoxes in the settings.