### PR TITLE
Fix clang-format for new ugly lambda indentations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 ﻿Standard: c++20
-UseTab: ForIndentation
+UseTab: AlignWithSpaces
 TabWidth: 4
 IndentWidth: 4
 AccessModifierOffset: -4
@@ -16,6 +16,7 @@ AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortLoopsOnASingleLine: false
+AllowShortLambdasOnASingleLine: Inline
 Cpp11BracedListStyle: true
 IndentCaseLabels: false
 SortIncludes: false


### PR DESCRIPTION
There has been some update that causes some ugly spaces to appear when formatting function argument lambdas.
Changing the UseTab value should help resolve this problem. I didn't test every possibility though,

Before:
![image](https://user-images.githubusercontent.com/23019877/135174401-a25b44c1-8dd2-4334-91bd-4f0355abddc0.png)

After:
![image](https://user-images.githubusercontent.com/23019877/135174426-fbbe1a21-1e11-4a7f-89da-58eaba51ade9.png)
