### PR TITLE
Overlays: fix small performance overlay font sizes

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -92,7 +92,7 @@ namespace rsx
 		void perf_metrics_overlay::reset_transform(label& elm) const
 		{
 			// left, top, right, bottom
-			const areau padding { m_padding, m_padding - 4, m_padding, m_padding };
+			const areau padding { m_padding, m_padding - std::min<u32>(4, m_padding), m_padding, m_padding };
 			const positionu margin { m_margin_x, m_margin_y };
 			positionu pos;
 


### PR DESCRIPTION
Fixes padding underflow when setting font_sizes smaller than 8.
The padding is half the font size and the top padding is set to padding-4.
So everything smaller than 8 would go below 0 which would increase the top padding to u32 max, causing the text to get rendered off-screen.