### PR TITLE
PPU/SPU LLVM: Emulate VPERM2B with a 256 bit wide VPERMB (AVX512 optimization)

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1374,7 +1374,7 @@ void PPUTranslator::VPERM(ppu_opcode_t op)
 	if (m_use_avx512_icl && op.ra != op.rb)
 	{
 		const auto i = eval(~c);
-		set_vr(op.vd, vperm2b(b, a, i));
+		set_vr(op.vd, vperm2b256to128(b, a, i));
 		return;
 	}
 

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7645,13 +7645,13 @@ public:
 				{
 					if (perm_only)
 					{
-						set_vr(op.rt4, vperm2b(as, bs, c));
+						set_vr(op.rt4, vperm2b256to128(as, bs, c));
 						return;
 					}
 
 					const auto m = gf2p8affineqb(c, build<u8[16]>(0x40, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x40, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20), 0x7f);
 					const auto mm = select(noncast<s8[16]>(m) >= 0, splat<u8[16]>(0), m);
-					const auto ab = vperm2b(as, bs, c);
+					const auto ab = vperm2b256to128(as, bs, c);
 					set_vr(op.rt4, select(noncast<s8[16]>(c) >= 0, ab, mm));
 					return;
 				}
@@ -7707,14 +7707,14 @@ public:
 		{
 			if (perm_only)
 			{
-				set_vr(op.rt4, vperm2b(b, a, eval(~c)));
+				set_vr(op.rt4, vperm2b256to128(b, a, eval(~c)));
 				return;
 			}
 
 			const auto m = gf2p8affineqb(c, build<u8[16]>(0x40, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x40, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20), 0x7f);
 			const auto mm = select(noncast<s8[16]>(m) >= 0, splat<u8[16]>(0), m);
 			const auto cr = eval(~c);
-			const auto ab = vperm2b(b, a, cr);
+			const auto ab = vperm2b256to128(b, a, cr);
 			set_vr(op.rt4, select(noncast<s8[16]>(cr) >= 0, mm, ab));
 			return;
 		}


### PR DESCRIPTION
Saves 1 uop by using 256 wide VPERMB instead of VPERM2B. (Compiles down to a vinserti128 and vpermb)

On my tigerlake laptop the AVX2 path has a throughput of one shufb per 4 cycles. The old AVX512 path has a throughput of 1 per 3 cycles, and the new AVX512 path has a throughput of 1 per 2.3 cycles. (tested in a little benchmark I wrote in asm before I rewrote it in LLVM IR.)
