### PR TITLE
RSX: Don't initialize cache if the emulation was already stopped

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -550,7 +550,11 @@ namespace rsx
 			thread_ctrl::wait_for(1000);
 		}
 
-		on_task();
+		if (!Emu.IsStopped())
+		{
+			on_task();
+		}
+
 		on_exit();
 	}
 


### PR DESCRIPTION
This omits some unexpected useless initializations that happen after you stopped emulation from a Ready state.
The current code naively expects that the emulation is started after the ready state.

should fix #10848