### PR TITLE
Defaults to 127.0.0.1 when failing to discover IP

### DIFF
--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -136,7 +136,7 @@ public:
 
 private:
 	// Various generic helpers
-	bool discover_ip_address();
+	void discover_ip_address();
 	bool discover_ether_address();
 	bool error_and_disconnect(const std::string& error_msg);
 


### PR DESCRIPTION
IP discovery is not critical and defaulting to 127.0.0.1 should be fine.