### PR TITLE
RPCN: Enables resend token button

### DIFF
--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -285,6 +285,7 @@ namespace rpcn
 		void remove_friend_cb(friend_cb_func, void* cb_param);
 
 		ErrorType create_user(const std::string& npid, const std::string& password, const std::string& online_name, const std::string& avatar_url, const std::string& email);
+		ErrorType resend_token(const std::string& npid, const std::string& password);
 		bool add_friend(const std::string& friend_username);
 		bool remove_friend(const std::string& friend_username);
 

--- a/rpcs3/rpcs3qt/rpcn_settings_dialog.h
+++ b/rpcs3/rpcs3qt/rpcn_settings_dialog.h
@@ -21,8 +21,12 @@ class rpcn_account_dialog : public QDialog
 public:
 	rpcn_account_dialog(QWidget* parent = nullptr);
 
+private:
 	bool save_config();
-	bool create_account();
+
+private Q_SLOTS:	
+	void create_account();
+	void resend_token();
 
 protected:
 	QLineEdit *m_edit_host, *m_edit_npid, *m_edit_token;


### PR DESCRIPTION
Activates the "Resend Token" button to resend the token to the email associated with that account.
This can only be done once every 24 hours(not counting initial send when account creation happens) and still requires a valid login/password.