### PR TITLE
rsx: Restore registers partially in FIFO recovery

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -71,7 +71,7 @@ bool serialize<rsx::frame_capture_data::replay_command>(utils::serial& ar, rsx::
 
 // Flags indicating which registers to restore in context restoration
 // Each flag covers 128 registers
-static constexpr std::array<bool, 0x10000 / 4 / 128> saved_registers_mask
+static constexpr std::array<bool, 0x10000 / 4 / 128> saved_registers_mask = []()
 {
 	std::array<bool, 0x10000 / 4 / 128> values{};
 	values[NV4097_SET_CONTEXT_DMA_REPORT / 128] = true;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -655,6 +655,8 @@ namespace rsx
 		bool is_fifo_idle() const;
 		void flush_fifo();
 
+		alignas(32) std::array<u32, 0x10000 / 4> saved_registers{};
+
 		void recover_fifo(u32 line = __builtin_LINE(),
 			u32 col = __builtin_COLUMN(),
 			const char* file = __builtin_FILE(),

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -574,7 +574,7 @@ namespace rsx
 				return vm::addr_t(0);
 			}
 
-			return vm::cast(get_address(offset, location));
+			return vm::cast(get_address(offset, location, 1));
 		}
 
 		void get_report(thread* rsx, u32 /*reg*/, u32 arg)
@@ -586,6 +586,7 @@ namespace rsx
 			if (!address_ptr)
 			{
 				rsx_log.error("Bad argument passed to NV4097_GET_REPORT, arg=0x%X", arg);
+				rsx->recover_fifo();
 				return;
 			}
 
@@ -646,6 +647,7 @@ namespace rsx
 			if (!address_ptr)
 			{
 				rsx_log.error("Bad argument passed to NV4097_SET_RENDER_ENABLE, arg=0x%X", arg);
+				rsx->recover_fifo();
 				return;
 			}
 

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -421,7 +421,7 @@ namespace rsx
 	struct rsx_state
 	{
 	public:
-		std::array<u32, 0x10000 / 4> registers{};
+		alignas(32) std::array<u32, 0x10000 / 4> registers{};
 		u32 register_previous_value{};
 
 		template<u32 opcode>


### PR DESCRIPTION
Attempts to address issues with conflicting register values after recovery, a common one is:
`rsx::get_address(offset=0x14ee0, location=0x66626660): Local RSX REPORT offset out of range!`
This happens because offset was provided just before this command and it relies on previous set REPORT location to be MAIN in the past, but the improper recovery caused it to use LOCAL, which has a very limited range of allowed offsets caused the crash.
May improve other issues as well.