### PR TITLE
rsx: Implement NTSC fixup mode, improve VBLANK accuracy

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -732,13 +732,20 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 
 	case 0xFED: // hack: vblank command
 	{
+		if (get_current_cpu_thread())
+		{
+			// VBLANK thread only
+			return CELL_EINVAL;
+		}
+
 		// NOTE: There currently seem to only be 2 active heads on PS3
 		ensure(a3 < 2);
 
 		// todo: this is wrong and should be 'second' vblank handler and freq, but since currently everything is reported as being 59.94, this should be fine
 		vm::_ref<u32>(render->device_addr + 0x30) = 1;
 
-		const u64 current_time = rsxTimeStamp();
+		// Time point is supplied in argument 4
+		const u64 current_time = a4;
 
 		driverInfo.head[a3].lastSecondVTime = current_time;
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -696,7 +696,7 @@ namespace rsx
 						}
 						else
 						{
-							sys_rsx_context_attribute(0x55555555, 0xFED, 1, 0, 0, 0);
+							sys_rsx_context_attribute(0x55555555, 0xFED, 1, post_event_time, 0, 0);
 						}
 					}
 				}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -716,7 +716,7 @@ namespace rsx
 
 					while (Emu.IsPaused() && !is_stopped())
 					{
-						thread_ctrl::wait_for(wait_sleep);
+						thread_ctrl::wait_for(5'000);
 					}
 
 					// Restore difference

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -142,6 +142,7 @@ struct cfg_root : cfg::node
 		cfg::_int<0, 30000000> driver_recovery_timeout{ this, "Driver Recovery Timeout", 1000000, true };
 		cfg::_int<0, 16667> driver_wakeup_delay{ this, "Driver Wake-Up Delay", 1, true };
 		cfg::_int<1, 1800> vblank_rate{ this, "Vblank Rate", 60, true }; // Changing this from 60 may affect game speed in unexpected ways
+		cfg::_bool vblank_ntsc{ this, "Vblank NTSC Fixup", false, true };
 		cfg::_bool decr_memory_layout{ this, "DECR memory layout", false}; // Force enable increased allowed main memory range as DECR console
 
 		struct node_vk : cfg::node


### PR DESCRIPTION
Added a setting called "VBlank NTSC Fixup" in config.yml, off by default.
What this setting does is to multiply the rate of VBLANK by 1000/1001.
For this to work with such "hard to measure" ratio, I have fixed rounding errors with the previous implementation ~~using accurate 128-bit integer based multiplication~~. This is also applied even the setting is turned off.

Fixes #11039, needs this setting turned on.