### PR TITLE
SPU DisAsm: Print SPU floats

### DIFF
--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -121,6 +121,10 @@ std::pair<bool, v128> SPUDisAsm::try_get_const_value(u32 reg, u32 pc, u32 TTL) c
 			{
 				return { true, v128::from32p(op0.i16 << 16) };
 			}
+			case spu_itype::ILH:
+			{
+				return { true, v128::from16p(op0.i16) };
+			}
 			case spu_itype::CBD:
 			case spu_itype::CHD:
 			case spu_itype::CWD:

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -74,7 +74,7 @@ namespace utils
 	class shm;
 }
 
-void comment_constant(std::string& last_opocde, u64 value);
+void comment_constant(std::string& last_opocde, u64 value, bool print_float = true);
 
 class SPUDisAsm final : public PPCDisAsm
 {
@@ -872,10 +872,12 @@ public:
 	void ILHU(spu_opcode_t op)
 	{
 		DisAsm("ilhu", spu_reg_name[op.rt], op.i16);
+		comment_constant(last_opcode, op.i16 << 16);
 	}
 	void ILH(spu_opcode_t op)
 	{
 		DisAsm("ilh", spu_reg_name[op.rt], op.i16);
+		comment_constant(last_opcode, (op.i16 << 16) | op.i16);
 	}
 
 	void IOHL(spu_opcode_t op);


### PR DESCRIPTION
SPU constant floats, unlike PPU floats, are not kept in memory as raw data. Instead they are formed with constant formation. Most commonly with ILHU or ILHU+IOHL pattern.
This pr allows to search for specific SPU floats usages as well as print them in the disassembly.
In the future I plan to be able to search SPU floats in embedded SPU images in PPU memory, so you can search for contants floats within SPU code as well (matters for FPS patches for example).

Have an SPU pie for dessert:
![image](https://user-images.githubusercontent.com/18193363/139452375-01656060-78a1-412d-a13b-188afd8c61f8.png)

I also added the suffixes 'h' (for hexadecimal) and 'f' (for float) after commented constants for easier search of them.