### PR TITLE
Improve trophy pop-up

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -40,7 +40,6 @@ namespace rsx
 			frame.back_color.g = 0.250980f;
 			frame.back_color.b = 0.247059f;
 			frame.back_color.a = 0.88f;
-			
 
 			image.set_pos(78, 64);
 			image.set_size(53, 53);
@@ -54,9 +53,6 @@ namespace rsx
 
 			sliding_animation.duration = 1.5f;
 			sliding_animation.type = animation_type::ease_in_out_cubic;
-			sliding_animation.current = { -f32(frame.w), 0, 0 };
-			sliding_animation.end = { 0, 0, 0};
-			sliding_animation.active = true;
 		}
 
 		void trophy_notification::update()
@@ -79,7 +75,7 @@ namespace rsx
 			{
 				if (!sliding_animation.active)
 				{
-					sliding_animation.end = { -f32(frame.w), 0, 0 };
+					sliding_animation.end = { -f32(frame.x + frame.w), 0, 0 };
 					sliding_animation.on_finish = [this]
 					{
 						s_trophy_semaphore.release();
@@ -139,6 +135,10 @@ namespace rsx
 			// Resize background to cover the text
 			u16 margin_sz = 9;
 			frame.w       = margin_sz * 3 + image.w + text_view.w;
+
+			sliding_animation.current = { -f32(frame.x + frame.w), 0, 0 };
+			sliding_animation.end = { 0, 0, 0 };
+			sliding_animation.active = true;
 
 			visible = true;
 			return CELL_OK;

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -175,6 +175,9 @@ namespace rsx
 			fade_animation.active = true;
 
 			visible = true;
+
+			Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/trophy.wav");
+
 			return CELL_OK;
 		}
 	} // namespace overlays

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.h
@@ -19,6 +19,7 @@ namespace rsx
 			std::unique_ptr<image_info> icon_info;
 
 			animation_translate sliding_animation;
+			animation_color_interpolate fade_animation;
 
 		public:
 			trophy_notification();

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -80,6 +80,7 @@ struct EmuCallbacks
 	std::function<std::unique_ptr<class TrophyNotificationBase>()> get_trophy_notification_dialog;
 	std::function<std::string(localized_string_id, const char*)> get_localized_string;
 	std::function<std::u32string(localized_string_id, const char*)> get_localized_u32string;
+	std::function<void(const std::string&)> play_sound;
 	std::string(*resolve_path)(std::string_view) = nullptr; // Resolve path using Qt
 };
 

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -110,6 +110,8 @@ void headless_application::InitializeCallbacks()
 	callbacks.get_localized_string    = [](localized_string_id, const char*) -> std::string { return {}; };
 	callbacks.get_localized_u32string = [](localized_string_id, const char*) -> std::u32string { return {}; };
 
+	callbacks.play_sound = [](const std::string&){};
+
 	callbacks.resolve_path = [](std::string_view sv)
 	{
 		return QFileInfo(QString::fromUtf8(sv.data(), static_cast<int>(sv.size()))).canonicalFilePath().toStdString();

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -39,6 +39,7 @@
 #include <QLibraryInfo>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QSound>
 
 #include <clocale>
 
@@ -410,6 +411,17 @@ void gui_application::InitializeCallbacks()
 	callbacks.get_localized_u32string = [](localized_string_id id, const char* args) -> std::u32string
 	{
 		return localized_emu::get_u32string(id, args);
+	};
+
+	callbacks.play_sound = [](const std::string& path)
+	{
+		Emu.CallAfter([path]()
+		{
+			if (fs::is_file(path))
+			{
+				QSound::play(qstr(path));
+			}
+		});
 	};
 
 	callbacks.resolve_path = [](std::string_view sv)

--- a/rpcs3/rpcs3qt/trophy_notification_helper.cpp
+++ b/rpcs3/rpcs3qt/trophy_notification_helper.cpp
@@ -5,6 +5,8 @@
 #include "../Emu/System.h"
 #include "../Emu/RSX/Overlays/overlay_trophy_notification.h"
 
+#include "Utilities/File.h"
+
 s32 trophy_notification_helper::ShowTrophyNotification(const SceNpTrophyDetails& trophy, const std::vector<uchar>& trophy_icon_buffer)
 {
 	if (auto manager = g_fxo->try_get<rsx::overlays::display_manager>())
@@ -26,6 +28,8 @@ s32 trophy_notification_helper::ShowTrophyNotification(const SceNpTrophyDetails&
 		// Move notification to upper lefthand corner
 		trophy_notification->move(m_game_window->mapToGlobal(QPoint(0, 0)));
 		trophy_notification->show();
+
+		Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/trophy.wav");
 	});
 
 	return 0;


### PR DESCRIPTION
- Fixes start and end positions of the trophy pop-up slide animation
- Adds a fade in/out animation
- Adds an optional sound-effect to the popup. It looks for the file "/sounds/trophy.wav"

Before:
![ttropyhy](https://user-images.githubusercontent.com/23019877/139491028-0133ac7b-c295-4231-95bf-028a4bbc3713.gif)

After:
![ttropyhyac](https://user-images.githubusercontent.com/23019877/139491077-afd56b29-1a9b-496a-b91d-80602e878bbb.gif)

