### PR TITLE
SPU: Use REP MOVSB in do_dma_transfer

### DIFF
--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -138,6 +138,38 @@ bool utils::has_fma4()
 	return g_value;
 }
 
+bool utils::has_erms()
+{
+	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && (get_cpuid(7, 0)[1] & 0x200) == 0x200;
+	return g_value;
+}
+
+bool utils::has_fsrm()
+{
+	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && (get_cpuid(7, 0)[3] & 0x10) == 0x10;
+	return g_value;
+}
+
+u32 utils::get_rep_movsb_threshold()
+{
+	static const u32 g_value = []()
+	{
+		u32 thresh_value = 0xFFFFFFFF;
+		if (has_fsrm())
+		{
+			thresh_value = 2047;
+		}
+		else if (has_erms())
+		{
+			thresh_value = 4095;
+		}
+
+		return thresh_value;
+	}();
+
+	return g_value;
+}
+
 std::string utils::get_cpu_brand()
 {
 	std::string brand;

--- a/rpcs3/util/sysinfo.hpp
+++ b/rpcs3/util/sysinfo.hpp
@@ -39,6 +39,10 @@ namespace utils
 
 	bool has_fma4();
 
+	bool has_erms();
+
+	bool has_fsrm();
+
 	std::string get_cpu_brand();
 
 	std::string get_system_info();
@@ -56,6 +60,9 @@ namespace utils
 	u32 get_cpu_family();
 
 	u32 get_cpu_model();
+
+	// A threshold of 0xFFFFFFFF means that the rep movsb is expected to be slow on this platform
+	u32 get_rep_movsb_threshold();
 
 	extern const u64 main_tid;
 }


### PR DESCRIPTION
Modern implementations of memcpy will use the REP MOVSB instruction when the size of the copy is large, and when the CPU is known to have a fast implementation of the instruction. The speed of the instruction is checked through 2 bits on cpuid, ERMS (enhanced rep movsb) and FSRM (fast short rep movsb). Support for detecting these flags has been added, and you will see in your log whether your CPU supports these flags or not.

On intel ERMS is supported as far back as ivy bridge, while FSRM is supported on icelake and up.
On amd, only the latest zen3 cpus have either (zen3 has both ERMS and FSRM)

Because I don't have access to every cpu out there, I based the thresholds for when rep movsb is preferred over simd copies roughly off of glibc.

On my 7700K, I couldn't measure any positive or negative performance impact.
On my 1135G7, there was a small performance uplift, and measurably less time spent in do_dma_transfer according to profiling.

<s>Need testing to determine:
- That it doesn't nuke performance on any cpus which don't support either ERMS or FSRM
- That it doesn't nuke performance on any cpus which do support either ERMS or FSRM
- That it improves performance on anything other than my tigerlake laptop
- That it doesn't break anything</s>

If it doesn't seem to really help anything outside of my laptop, then we can just close the PR. If I didn't have access to this laptop then I probably wouldn't have PR'd this in the first place.