### PR TITLE
rsx: Fix sampling in X when 0 pitch is given

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -580,7 +580,7 @@ std::vector<rsx::subresource_layout> get_subresources_layout_impl(const RsxTextu
 		}
 		else
 		{
-			w = h = depth = 1;
+			h = depth = 1;
 		}
 	}
 
@@ -1161,7 +1161,7 @@ namespace rsx
 			if (width > 1 || height > 1)
 			{
 				// If width == 1, the scanning just returns texel 0, so it is a valid setup
-				rsx_log.error("Invalid texture pitch setup, width=%d, height=%d, format=0x%x(0x%x)",
+				rsx_log.warning("Invalid texture pitch setup, width=%d, height=%d, format=0x%x(0x%x)",
 					width, height, format, gcm_format);
 			}
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2031,7 +2031,7 @@ namespace rsx
 				if (attributes.pitch = tex.pitch(); !attributes.pitch)
 				{
 					attributes.pitch = packed_pitch;
-					scale = { 0.f, 0.f, 0.f };
+					scale = { 1.f, 0.f, 0.f };
 				}
 				else if (packed_pitch > attributes.pitch && !options.is_compressed_format)
 				{


### PR DESCRIPTION
- A pitch of 0 still allows 1-dimensional addressing.

Fixes https://github.com/RPCS3/rpcs3/issues/8377