### PR TITLE
PS3 String Searcher: Implement instruction searching in embedded SPU images (as well as SPU floats)

### DIFF
--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -18,7 +18,7 @@ class CPUDisAsm
 {
 protected:
 	cpu_disasm_mode m_mode{};
-	const std::add_pointer_t<const u8> m_offset{};
+	const u8* m_offset{};
 	const u32 m_start_pc;
 	const std::add_pointer_t<const cpu_thread> m_cpu{};
 	u32 m_op = 0;
@@ -64,10 +64,14 @@ public:
 	std::string last_opcode{};
 	u32 dump_pc{};
 
-	CPUDisAsm& change_mode(cpu_disasm_mode mode)
+	cpu_disasm_mode change_mode(cpu_disasm_mode mode)
 	{
-		m_mode = mode;
-		return *this;
+		return std::exchange(m_mode, mode);
+	}
+
+	const u8* change_ptr(const u8* ptr)
+	{
+		return std::exchange(m_offset, ptr);
 	}
 
 protected:

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -356,7 +356,15 @@ void comment_constant(std::string& last_opcode, u64 value, bool print_float = fa
 
 		if (std::isfinite(float_val))
 		{
+			const usz old_size = last_opcode.size();
+
 			fmt::append(last_opcode, " (%.6gf)", float_val);
+
+			if (usz pos = last_opcode.find_first_of('.', old_size); pos == umax)
+			{
+				// No decimal point has been inserted, force insertion
+				last_opcode.insert(last_opcode.size() - 2, ".0"sv);
+			}
 		}
 		else
 		{

--- a/rpcs3/rpcs3qt/memory_string_searcher.h
+++ b/rpcs3/rpcs3qt/memory_string_searcher.h
@@ -7,8 +7,11 @@
 class QLineEdit;
 class QCheckBox;
 class QComboBox;
+class QLabel;
 
 class CPUDisAsm;
+
+enum search_mode : int;
 
 class memory_string_searcher : public QDialog
 {
@@ -17,17 +20,20 @@ class memory_string_searcher : public QDialog
 	QLineEdit* m_addr_line = nullptr;
 	QCheckBox* m_chkbox_case_insensitive = nullptr;
 	QComboBox* m_cbox_input_mode = nullptr;
+	QLabel* m_modes_label = nullptr;
 
 	std::shared_ptr<CPUDisAsm> m_disasm;
 
 	const void* m_ptr;
 	usz m_size;
 
+	search_mode m_modes{};
+
 public:
 	explicit memory_string_searcher(QWidget* parent, std::shared_ptr<CPUDisAsm> disasm, std::string_view title = {});
 
-private Q_SLOTS:
-	void OnSearch();
+private:
+	u64 OnSearch(std::string wstr, int mode);
 };
 
 // Lifetime management with IDM


### PR DESCRIPTION
* Allow to combine modes of search, such as "Float" + "Double" + "SPU Instruction". Mode list is cleared after a click on "Select search mode(s)..".
* Implement a mode to search SPU instructions within PPU memory such as at SPU embedded images, as well as searching withing all SPU threads at once. Along with #11077 allows to search SPU floating point numbers.