### PR TITLE
Rpcn 0.5.0

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -375,7 +375,9 @@ target_sources(rpcs3_emu PRIVATE
 # Np
 target_sources(rpcs3_emu PRIVATE
     NP/fb_helpers.cpp
+    NP/np_cache.cpp
     NP/np_contexts.cpp
+    NP/np_dnshook.cpp
     NP/np_handler.cpp
     NP/np_helpers.cpp
     NP/np_notifications.cpp

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -377,6 +377,9 @@ target_sources(rpcs3_emu PRIVATE
     NP/fb_helpers.cpp
     NP/np_contexts.cpp
     NP/np_handler.cpp
+    NP/np_helpers.cpp
+    NP/np_notifications.cpp
+    NP/np_requests.cpp
     NP/signaling_handler.cpp
     NP/np_structs_extra.cpp
     NP/rpcn_client.cpp

--- a/rpcs3/Emu/Cell/Modules/cellNetCtl.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellNetCtl.cpp
@@ -11,6 +11,7 @@
 #include "Utilities/StrUtil.h"
 
 #include "Emu/NP/np_handler.h"
+#include "Emu/NP/np_helpers.h"
 
 LOG_CHANNEL(cellNetCtl);
 

--- a/rpcs3/Emu/Cell/Modules/cellNetCtl.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellNetCtl.cpp
@@ -93,7 +93,7 @@ error_code cellNetCtlInit()
 {
 	cellNetCtl.warning("cellNetCtlInit()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (nph.is_netctl_init)
 	{
@@ -109,7 +109,7 @@ void cellNetCtlTerm()
 {
 	cellNetCtl.warning("cellNetCtlTerm()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	nph.is_netctl_init = false;
 }
@@ -118,7 +118,7 @@ error_code cellNetCtlGetState(vm::ptr<s32> state)
 {
 	cellNetCtl.trace("cellNetCtlGetState(state=*0x%x)", state);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_netctl_init)
 	{
@@ -139,7 +139,7 @@ error_code cellNetCtlAddHandler(vm::ptr<cellNetCtlHandler> handler, vm::ptr<void
 {
 	cellNetCtl.todo("cellNetCtlAddHandler(handler=*0x%x, arg=*0x%x, hid=*0x%x)", handler, arg, hid);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_netctl_init)
 	{
@@ -158,7 +158,7 @@ error_code cellNetCtlDelHandler(s32 hid)
 {
 	cellNetCtl.todo("cellNetCtlDelHandler(hid=0x%x)", hid);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_netctl_init)
 	{
@@ -177,7 +177,7 @@ error_code cellNetCtlGetInfo(s32 code, vm::ptr<CellNetCtlInfo> info)
 {
 	cellNetCtl.warning("cellNetCtlGetInfo(code=0x%x (%s), info=*0x%x)", code, InfoCodeToName(code), info);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_netctl_init)
 	{
@@ -209,9 +209,9 @@ error_code cellNetCtlGetInfo(s32 code, vm::ptr<CellNetCtlInfo> info)
 	case CELL_NET_CTL_INFO_LINK_TYPE: info->link_type = CELL_NET_CTL_LINK_TYPE_10BASE_FULL; break;
 	case CELL_NET_CTL_INFO_IP_CONFIG: info->ip_config = CELL_NET_CTL_IP_STATIC; break;
 	case CELL_NET_CTL_INFO_DEFAULT_ROUTE: strcpy_trunc(info->default_route, "192.168.1.1"); break;
-	case CELL_NET_CTL_INFO_PRIMARY_DNS: strcpy_trunc(info->primary_dns, np_handler::ip_to_string(nph.get_dns_ip())); break;
-	case CELL_NET_CTL_INFO_SECONDARY_DNS: strcpy_trunc(info->secondary_dns, np_handler::ip_to_string(nph.get_dns_ip())); break;
-	case CELL_NET_CTL_INFO_IP_ADDRESS: strcpy_trunc(info->ip_address, np_handler::ip_to_string(nph.get_local_ip_addr())); break;
+	case CELL_NET_CTL_INFO_PRIMARY_DNS: strcpy_trunc(info->primary_dns, np::ip_to_string(nph.get_dns_ip())); break;
+	case CELL_NET_CTL_INFO_SECONDARY_DNS: strcpy_trunc(info->secondary_dns, np::ip_to_string(nph.get_dns_ip())); break;
+	case CELL_NET_CTL_INFO_IP_ADDRESS: strcpy_trunc(info->ip_address, np::ip_to_string(nph.get_local_ip_addr())); break;
 	case CELL_NET_CTL_INFO_NETMASK: strcpy_trunc(info->netmask, "255.255.255.255"); break;
 	case CELL_NET_CTL_INFO_HTTP_PROXY_CONFIG: info->http_proxy_config = 0; break;
 	case CELL_NET_CTL_INFO_DHCP_HOSTNAME: strcpy_trunc(info->dhcp_hostname, nph.get_hostname()); break;
@@ -238,7 +238,7 @@ error_code cellNetCtlNetStartDialogLoadAsync(vm::cptr<CellNetCtlNetStartDialogPa
 {
 	cellNetCtl.error("cellNetCtlNetStartDialogLoadAsync(param=*0x%x)", param);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_netctl_init)
 	{
@@ -270,7 +270,7 @@ error_code cellNetCtlNetStartDialogAbortAsync()
 {
 	cellNetCtl.error("cellNetCtlNetStartDialogAbortAsync()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_netctl_init)
 	{
@@ -284,7 +284,7 @@ error_code cellNetCtlNetStartDialogUnloadAsync(vm::ptr<CellNetCtlNetStartDialogR
 {
 	cellNetCtl.warning("cellNetCtlNetStartDialogUnloadAsync(result=*0x%x)", result);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_netctl_init)
 	{
@@ -311,7 +311,7 @@ error_code cellNetCtlGetNatInfo(vm::ptr<CellNetCtlNatInfo> natInfo)
 {
 	cellNetCtl.warning("cellNetCtlGetNatInfo(natInfo=*0x%x)", natInfo);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_netctl_init)
 	{

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -408,7 +408,7 @@ error_code sceNpInit(u32 poolsize, vm::ptr<void> poolptr)
 {
 	sceNp.warning("sceNpInit(poolsize=0x%x, poolptr=*0x%x)", poolsize, poolptr);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	std::lock_guard lock(nph.mutex_status);
 
@@ -437,7 +437,7 @@ error_code sceNpTerm()
 {
 	sceNp.warning("sceNpTerm()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	std::lock_guard lock(nph.mutex_status);
 
@@ -652,7 +652,7 @@ error_code sceNpBasicRegisterHandler(vm::cptr<SceNpCommunicationId> context, vm:
 {
 	sceNp.warning("sceNpBasicRegisterHandler(context=*0x%x(%s), handler=*0x%x, arg=*0x%x)", context, context ? static_cast<const char *>(context->data) : "", handler, arg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -682,7 +682,7 @@ error_code sceNpBasicRegisterContextSensitiveHandler(vm::cptr<SceNpCommunication
 {
 	sceNp.todo("sceNpBasicRegisterContextSensitiveHandler(context=*0x%x, handler=*0x%x, arg=*0x%x)", context, handler, arg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -712,7 +712,7 @@ error_code sceNpBasicUnregisterHandler()
 {
 	sceNp.todo("sceNpBasicUnregisterHandler()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -733,7 +733,7 @@ error_code sceNpBasicSetPresence(vm::cptr<u8> data, u64 size)
 {
 	sceNp.todo("sceNpBasicSetPresence(data=*0x%x, size=%d)", data, size);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -763,7 +763,7 @@ error_code sceNpBasicSetPresenceDetails(vm::cptr<SceNpBasicPresenceDetails> pres
 {
 	sceNp.todo("sceNpBasicSetPresenceDetails(pres=*0x%x, options=0x%x)", pres, options);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -792,7 +792,7 @@ error_code sceNpBasicSetPresenceDetails2(vm::cptr<SceNpBasicPresenceDetails2> pr
 {
 	sceNp.todo("sceNpBasicSetPresenceDetails2(pres=*0x%x, options=0x%x)", pres, options);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -821,7 +821,7 @@ error_code sceNpBasicSendMessage(vm::cptr<SceNpId> to, vm::cptr<void> data, u64 
 {
 	sceNp.todo("sceNpBasicSendMessage(to=*0x%x, data=*0x%x, size=%d)", to, data, size);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -861,7 +861,7 @@ error_code sceNpBasicSendMessageGui(vm::cptr<SceNpBasicMessageDetails> msg, sys_
 		sceNp.notice("sceNpBasicSendMessageGui: body: %s", msg->body);
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -974,7 +974,7 @@ error_code sceNpBasicSendMessageAttachment(vm::cptr<SceNpId> to, vm::cptr<char> 
 {
 	sceNp.todo("sceNpBasicSendMessageAttachment(to=*0x%x, subject=%s, body=%s, data=%s, size=%d, containerId=%d)", to, subject, body, data, size, containerId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1010,7 +1010,7 @@ error_code sceNpBasicRecvMessageAttachment(sys_memory_container_t containerId)
 {
 	sceNp.todo("sceNpBasicRecvMessageAttachment(containerId=%d)", containerId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1029,7 +1029,7 @@ error_code sceNpBasicRecvMessageAttachmentLoad(u32 id, vm::ptr<void> buffer, vm:
 {
 	sceNp.warning("sceNpBasicRecvMessageAttachmentLoad(id=%d, buffer=*0x%x, size=*0x%x)", id, buffer, size);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1072,7 +1072,7 @@ error_code sceNpBasicRecvMessageCustom(u16 mainType, u32 recvOptions, sys_memory
 {
 	sceNp.warning("sceNpBasicRecvMessageCustom(mainType=%d, recvOptions=%d, containerId=%d)", mainType, recvOptions, containerId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1123,7 +1123,7 @@ error_code sceNpBasicRecvMessageCustom(u16 mainType, u32 recvOptions, sys_memory
 	const auto& msg     = msg_pair->second;
 
 	const u32 event_to_send = (mainType == SCE_NP_BASIC_MESSAGE_MAIN_TYPE_INVITE) ? SCE_NP_BASIC_EVENT_RECV_INVITATION_RESULT : SCE_NP_BASIC_EVENT_RECV_CUSTOM_DATA_RESULT;
-	np_handler::basic_event to_add{};
+	np::basic_event to_add{};
 	to_add.event = event_to_send;
 	strcpy_trunc(to_add.from.userId.handle.data, msg_pair->first);
 	strcpy_trunc(to_add.from.name.data, msg_pair->first);
@@ -1146,7 +1146,7 @@ error_code sceNpBasicMarkMessageAsUsed(SceNpBasicMessageId msgId)
 {
 	sceNp.todo("sceNpBasicMarkMessageAsUsed(msgId=%d)", msgId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1170,7 +1170,7 @@ error_code sceNpBasicAbortGui()
 {
 	sceNp.todo("sceNpBasicAbortGui()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1191,7 +1191,7 @@ error_code sceNpBasicAddFriend(vm::cptr<SceNpId> contact, vm::cptr<char> body, s
 {
 	sceNp.todo("sceNpBasicAddFriend(contact=*0x%x, body=%s, containerId=%d)", contact, body, containerId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1227,7 +1227,7 @@ error_code sceNpBasicGetFriendListEntryCount(vm::ptr<u32> count)
 {
 	sceNp.todo("sceNpBasicGetFriendListEntryCount(count=*0x%x)", count);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1254,7 +1254,7 @@ error_code sceNpBasicGetFriendListEntry(u32 index, vm::ptr<SceNpId> npid)
 {
 	sceNp.todo("sceNpBasicGetFriendListEntry(index=%d, npid=*0x%x)", index, npid);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1285,7 +1285,7 @@ error_code sceNpBasicGetFriendPresenceByIndex(u32 index, vm::ptr<SceNpUserInfo> 
 		return SCE_NP_BASIC_ERROR_INVALID_ARGUMENT;
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1310,7 +1310,7 @@ error_code sceNpBasicGetFriendPresenceByIndex2(u32 index, vm::ptr<SceNpUserInfo>
 		return SCE_NP_BASIC_ERROR_INVALID_ARGUMENT;
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1330,7 +1330,7 @@ error_code sceNpBasicGetFriendPresenceByNpId(vm::cptr<SceNpId> npid, vm::ptr<Sce
 {
 	sceNp.todo("sceNpBasicGetFriendPresenceByNpId(npid=*0x%x, pres=*0x%x, options=%d)", npid, pres, options);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!pres)
 	{
@@ -1355,7 +1355,7 @@ error_code sceNpBasicGetFriendPresenceByNpId2(vm::cptr<SceNpId> npid, vm::ptr<Sc
 {
 	sceNp.todo("sceNpBasicGetFriendPresenceByNpId2(npid=*0x%x, pres=*0x%x, options=%d)", npid, pres, options);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!pres)
 	{
@@ -1380,7 +1380,7 @@ error_code sceNpBasicAddPlayersHistory(vm::cptr<SceNpId> npid, vm::ptr<char> des
 {
 	sceNp.todo("sceNpBasicAddPlayersHistory(npid=*0x%x, description=*0x%x)", npid, description);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1404,7 +1404,7 @@ error_code sceNpBasicAddPlayersHistoryAsync(vm::cptr<SceNpId> npids, u32 count, 
 {
 	sceNp.todo("sceNpBasicAddPlayersHistoryAsync(npids=*0x%x, count=%d, description=*0x%x, reqId=*0x%x)", npids, count, description, reqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1458,7 +1458,7 @@ error_code sceNpBasicGetPlayersHistoryEntryCount(u32 options, vm::ptr<u32> count
 		return SCE_NP_BASIC_ERROR_INVALID_ARGUMENT;
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1496,7 +1496,7 @@ error_code sceNpBasicGetPlayersHistoryEntry(u32 options, u32 index, vm::ptr<SceN
 		return SCE_NP_BASIC_ERROR_INVALID_ARGUMENT;
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1527,7 +1527,7 @@ error_code sceNpBasicAddBlockListEntry(vm::cptr<SceNpId> npid)
 {
 	sceNp.warning("sceNpBasicAddBlockListEntry(npid=*0x%x)", npid);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1556,7 +1556,7 @@ error_code sceNpBasicGetBlockListEntryCount(vm::ptr<u32> count)
 {
 	sceNp.warning("sceNpBasicGetBlockListEntryCount(count=*0x%x)", count);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1584,7 +1584,7 @@ error_code sceNpBasicGetBlockListEntry(u32 index, vm::ptr<SceNpId> npid)
 {
 	sceNp.todo("sceNpBasicGetBlockListEntry(index=%d, npid=*0x%x)", index, npid);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1610,7 +1610,7 @@ error_code sceNpBasicGetMessageAttachmentEntryCount(vm::ptr<u32> count)
 {
 	sceNp.todo("sceNpBasicGetMessageAttachmentEntryCount(count=*0x%x)", count);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1643,7 +1643,7 @@ error_code sceNpBasicGetMessageAttachmentEntry(u32 index, vm::ptr<SceNpUserInfo>
 {
 	sceNp.todo("sceNpBasicGetMessageAttachmentEntry(index=%d, from=*0x%x)", index, from);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1674,7 +1674,7 @@ error_code sceNpBasicGetCustomInvitationEntryCount(vm::ptr<u32> count)
 {
 	sceNp.todo("sceNpBasicGetCustomInvitationEntryCount(count=*0x%x)", count);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1707,7 +1707,7 @@ error_code sceNpBasicGetCustomInvitationEntry(u32 index, vm::ptr<SceNpUserInfo> 
 {
 	sceNp.todo("sceNpBasicGetCustomInvitationEntry(index=%d, from=*0x%x)", index, from);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1738,7 +1738,7 @@ error_code sceNpBasicGetMatchingInvitationEntryCount(vm::ptr<u32> count)
 {
 	sceNp.todo("sceNpBasicGetMatchingInvitationEntryCount(count=*0x%x)", count);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1771,7 +1771,7 @@ error_code sceNpBasicGetMatchingInvitationEntry(u32 index, vm::ptr<SceNpUserInfo
 {
 	sceNp.todo("sceNpBasicGetMatchingInvitationEntry(index=%d, from=*0x%x)", index, from);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1802,7 +1802,7 @@ error_code sceNpBasicGetClanMessageEntryCount(vm::ptr<u32> count)
 {
 	sceNp.todo("sceNpBasicGetClanMessageEntryCount(count=*0x%x)", count);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1835,7 +1835,7 @@ error_code sceNpBasicGetClanMessageEntry(u32 index, vm::ptr<SceNpUserInfo> from)
 {
 	sceNp.todo("sceNpBasicGetClanMessageEntry(index=%d, from=*0x%x)", index, from);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1872,7 +1872,7 @@ error_code sceNpBasicGetMessageEntryCount(u32 type, vm::ptr<u32> count)
 		return SCE_NP_BASIC_ERROR_INVALID_ARGUMENT;
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1906,7 +1906,7 @@ error_code sceNpBasicGetMessageEntry(u32 type, u32 index, vm::ptr<SceNpUserInfo>
 		return SCE_NP_BASIC_ERROR_INVALID_ARGUMENT;
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -1932,7 +1932,7 @@ error_code sceNpBasicGetEvent(vm::ptr<s32> event, vm::ptr<SceNpUserInfo> from, v
 {
 	sceNp.warning("sceNpBasicGetEvent(event=*0x%x, from=*0x%x, data=*0x%x, size=*0x%x)", event, from, data, size);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2172,7 +2172,7 @@ error_code sceNpCustomMenuRegisterActions(vm::cptr<SceNpCustomMenu> menu, vm::pt
 {
 	sceNp.todo("sceNpCustomMenuRegisterActions(menu=*0x%x, handler=*0x%x, userArg=*0x%x, options=0x%x)", menu, handler, userArg, options);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2209,7 +2209,7 @@ error_code sceNpCustomMenuActionSetActivation(vm::cptr<SceNpCustomMenuIndexArray
 {
 	sceNp.todo("sceNpCustomMenuActionSetActivation(array=*0x%x, options=0x%x)", array, options);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2230,7 +2230,7 @@ error_code sceNpCustomMenuRegisterExceptionList(vm::cptr<SceNpCustomMenuActionEx
 {
 	sceNp.todo("sceNpCustomMenuRegisterExceptionList(items=*0x%x, numItems=%d, options=0x%x)", items, numItems, options);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2256,7 +2256,7 @@ error_code sceNpFriendlist(vm::ptr<SceNpFriendlistResultHandler> resultHandler, 
 {
 	sceNp.warning("sceNpFriendlist(resultHandler=*0x%x, userArg=*0x%x, containerId=%d)", resultHandler, userArg, containerId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2277,7 +2277,7 @@ error_code sceNpFriendlistCustom(SceNpFriendlistCustomOptions options, vm::ptr<S
 {
 	sceNp.warning("sceNpFriendlistCustom(options=0x%x, resultHandler=*0x%x, userArg=*0x%x, containerId=%d)", options, resultHandler, userArg, containerId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2298,7 +2298,7 @@ error_code sceNpFriendlistAbortGui()
 {
 	sceNp.todo("sceNpFriendlistAbortGui()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2314,7 +2314,7 @@ error_code sceNpLookupInit()
 {
 	sceNp.warning("sceNpLookupInit()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (nph.is_NP_Lookup_init)
 	{
@@ -2335,7 +2335,7 @@ error_code sceNpLookupTerm()
 {
 	sceNp.todo("sceNpLookupTerm()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2356,7 +2356,7 @@ error_code sceNpLookupCreateTitleCtx(vm::cptr<SceNpCommunicationId> communicatio
 {
 	sceNp.warning("sceNpLookupCreateTitleCtx(communicationId=*0x%x(%s), selfNpId=0x%x)", communicationId, communicationId->data, selfNpId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2375,7 +2375,7 @@ error_code sceNpLookupDestroyTitleCtx(s32 titleCtxId)
 {
 	sceNp.warning("sceNpLookupDestroyTitleCtx(titleCtxId=%d)", titleCtxId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2392,7 +2392,7 @@ error_code sceNpLookupCreateTransactionCtx(s32 titleCtxId)
 {
 	sceNp.warning("sceNpLookupCreateTransactionCtx(titleCtxId=%d)", titleCtxId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2411,7 +2411,7 @@ error_code sceNpLookupDestroyTransactionCtx(s32 transId)
 {
 	sceNp.warning("sceNpLookupDestroyTransactionCtx(transId=%d)", transId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2430,7 +2430,7 @@ error_code sceNpLookupSetTimeout(s32 ctxId, usecond_t timeout)
 {
 	sceNp.todo("sceNpLookupSetTimeout(ctxId=%d, timeout=%d)", ctxId, timeout);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2449,7 +2449,7 @@ error_code sceNpLookupAbortTransaction(s32 transId)
 {
 	sceNp.todo("sceNpLookupAbortTransaction(transId=%d)", transId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2463,7 +2463,7 @@ error_code sceNpLookupWaitAsync(s32 transId, vm::ptr<s32> result)
 {
 	sceNp.todo("sceNpLookupWaitAsync(transId=%d, result=%d)", transId, result);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2477,7 +2477,7 @@ error_code sceNpLookupPollAsync(s32 transId, vm::ptr<s32> result)
 {
 	sceNp.todo("sceNpLookupPollAsync(transId=%d, result=*0x%x)", transId, result);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2493,7 +2493,7 @@ error_code sceNpLookupNpId(s32 transId, vm::cptr<SceNpOnlineId> onlineId, vm::pt
 {
 	sceNp.todo("sceNpLookupNpId(transId=%d, onlineId=*0x%x, npId=*0x%x, option=*0x%x)", transId, onlineId, npId, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2522,7 +2522,7 @@ error_code sceNpLookupNpIdAsync(s32 transId, vm::ptr<SceNpOnlineId> onlineId, vm
 {
 	sceNp.todo("sceNpLookupNpIdAsync(transId=%d, onlineId=*0x%x, npId=*0x%x, prio=%d, option=*0x%x)", transId, onlineId, npId, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2553,7 +2553,7 @@ error_code sceNpLookupUserProfile(s32 transId, vm::cptr<SceNpId> npId, vm::ptr<S
 	sceNp.todo("sceNpLookupUserProfile(transId=%d, npId=*0x%x, userInfo=*0x%x, aboutMe=*0x%x, languages=*0x%x, countryCode=*0x%x, avatarImage=*0x%x, option=*0x%x)", transId, npId, userInfo, aboutMe,
 	    languages, countryCode, avatarImage, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2584,7 +2584,7 @@ error_code sceNpLookupUserProfileAsync(s32 transId, vm::cptr<SceNpId> npId, vm::
 	sceNp.todo("sceNpLookupUserProfile(transId=%d, npId=*0x%x, userInfo=*0x%x, aboutMe=*0x%x, languages=*0x%x, countryCode=*0x%x, avatarImage=*0x%x, prio=%d, option=*0x%x)", transId, npId, userInfo,
 	    aboutMe, languages, countryCode, avatarImage, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2616,7 +2616,7 @@ error_code sceNpLookupUserProfileWithAvatarSize(s32 transId, s32 avatarSizeType,
 	           "avatarImageDataMaxSize=%d, avatarImageDataSize=*0x%x, option=*0x%x)",
 	    transId, avatarSizeType, npId, userInfo, aboutMe, languages, countryCode, avatarImageData, avatarImageDataMaxSize, avatarImageDataSize, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2649,7 +2649,7 @@ error_code sceNpLookupUserProfileWithAvatarSizeAsync(s32 transId, s32 avatarSize
 	           "avatarImageDataMaxSize=%d, avatarImageDataSize=*0x%x, prio=%d, option=*0x%x)",
 	    transId, avatarSizeType, npId, userInfo, aboutMe, languages, countryCode, avatarImageData, avatarImageDataMaxSize, avatarImageDataSize, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2678,7 +2678,7 @@ error_code sceNpLookupAvatarImage(s32 transId, vm::ptr<SceNpAvatarUrl> avatarUrl
 {
 	sceNp.todo("sceNpLookupAvatarImage(transId=%d, avatarUrl=*0x%x, avatarImage=*0x%x, option=*0x%x)", transId, avatarUrl, avatarImage, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2707,7 +2707,7 @@ error_code sceNpLookupAvatarImageAsync(s32 transId, vm::ptr<SceNpAvatarUrl> avat
 {
 	sceNp.todo("sceNpLookupAvatarImageAsync(transId=%d, avatarUrl=*0x%x, avatarImage=*0x%x, prio=%d, option=*0x%x)", transId, avatarUrl, avatarImage, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2736,7 +2736,7 @@ error_code sceNpLookupTitleStorage()
 {
 	UNIMPLEMENTED_FUNC(sceNp);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2750,7 +2750,7 @@ error_code sceNpLookupTitleStorageAsync()
 {
 	UNIMPLEMENTED_FUNC(sceNp);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2764,7 +2764,7 @@ error_code sceNpLookupTitleSmallStorage(s32 transId, vm::ptr<void> data, u64 max
 {
 	sceNp.todo("sceNpLookupTitleSmallStorage(transId=%d, data=*0x%x, maxSize=%d, contentLength=*0x%x, option=*0x%x)", transId, data, maxSize, contentLength, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2798,7 +2798,7 @@ error_code sceNpLookupTitleSmallStorageAsync(s32 transId, vm::ptr<void> data, u6
 {
 	sceNp.todo("sceNpLookupTitleSmallStorageAsync(transId=%d, data=*0x%x, maxSize=%d, contentLength=*0x%x, prio=%d, option=*0x%x)", transId, data, maxSize, contentLength, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Lookup_init)
 	{
@@ -2836,7 +2836,7 @@ error_code sceNpManagerRegisterCallback(vm::ptr<SceNpManagerCallback> callback, 
 {
 	sceNp.warning("sceNpManagerRegisterCallback(callback=*0x%x, arg=*0x%x)", callback, arg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2858,7 +2858,7 @@ error_code sceNpManagerUnregisterCallback()
 {
 	sceNp.warning("sceNpManagerUnregisterCallback()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2874,7 +2874,7 @@ error_code sceNpManagerGetStatus(vm::ptr<s32> status)
 {
 	sceNp.trace("sceNpManagerGetStatus(status=*0x%x)", status);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2895,7 +2895,7 @@ error_code sceNpManagerGetNetworkTime(vm::ptr<CellRtcTick> pTick)
 {
 	sceNp.warning("sceNpManagerGetNetworkTime(pTick=*0x%x)", pTick);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2937,7 +2937,7 @@ error_code sceNpManagerGetOnlineId(vm::ptr<SceNpOnlineId> onlineId)
 {
 	sceNp.warning("sceNpManagerGetOnlineId(onlineId=*0x%x)", onlineId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -2968,7 +2968,7 @@ error_code sceNpManagerGetNpId(ppu_thread&, vm::ptr<SceNpId> npId)
 {
 	sceNp.warning("sceNpManagerGetNpId(npId=*0x%x)", npId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	// if (!nph.is_NP_init)
 	// {
@@ -2999,7 +2999,7 @@ error_code sceNpManagerGetOnlineName(vm::ptr<SceNpOnlineName> onlineName)
 {
 	sceNp.warning("sceNpManagerGetOnlineName(onlineName=*0x%x)", onlineName);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3030,7 +3030,7 @@ error_code sceNpManagerGetAvatarUrl(vm::ptr<SceNpAvatarUrl> avatarUrl)
 {
 	sceNp.warning("sceNpManagerGetAvatarUrl(avatarUrl=*0x%x)", avatarUrl);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3061,7 +3061,7 @@ error_code sceNpManagerGetMyLanguages(vm::ptr<SceNpMyLanguages> myLanguages)
 {
 	sceNp.warning("sceNpManagerGetMyLanguages(myLanguages=*0x%x)", myLanguages);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3090,7 +3090,7 @@ error_code sceNpManagerGetAccountRegion(vm::ptr<SceNpCountryCode> countryCode, v
 {
 	sceNp.warning("sceNpManagerGetAccountRegion(countryCode=*0x%x, language=*0x%x)", countryCode, language);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3125,7 +3125,7 @@ error_code sceNpManagerGetAccountAge(vm::ptr<s32> age)
 {
 	sceNp.warning("sceNpManagerGetAccountAge(age=*0x%x)", age);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3156,7 +3156,7 @@ error_code sceNpManagerGetContentRatingFlag(vm::ptr<s32> isRestricted, vm::ptr<s
 {
 	sceNp.warning("sceNpManagerGetContentRatingFlag(isRestricted=*0x%x, age=*0x%x)", isRestricted, age);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3189,7 +3189,7 @@ error_code sceNpManagerGetChatRestrictionFlag(vm::ptr<s32> isRestricted)
 {
 	sceNp.trace("sceNpManagerGetChatRestrictionFlag(isRestricted=*0x%x)", isRestricted);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3221,7 +3221,7 @@ error_code sceNpManagerGetCachedInfo(CellSysutilUserId userId, vm::ptr<SceNpMana
 {
 	sceNp.todo("sceNpManagerGetCachedInfo(userId=%d, param=*0x%x)", userId, param);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3246,7 +3246,7 @@ error_code sceNpManagerRequestTicket(vm::cptr<SceNpId> npId, vm::cptr<char> serv
 {
 	sceNp.error("sceNpManagerRequestTicket(npId=*0x%x, serviceId=%s, cookie=*0x%x, cookieSize=%d, entitlementId=%s, consumedCount=%d)", npId, serviceId, cookie, cookieSize, entitlementId, consumedCount);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3279,7 +3279,7 @@ error_code sceNpManagerRequestTicket2(vm::cptr<SceNpId> npId, vm::cptr<SceNpTick
 	sceNp.todo("sceNpManagerRequestTicket2(npId=*0x%x, version=*0x%x, serviceId=%s, cookie=*0x%x, cookieSize=%d, entitlementId=%s, consumedCount=%d)", npId, version, serviceId, cookie, cookieSize,
 	    entitlementId, consumedCount);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3310,7 +3310,7 @@ error_code sceNpManagerGetTicket(vm::ptr<void> buffer, vm::ptr<u32> bufferSize)
 {
 	sceNp.error("sceNpManagerGetTicket(buffer=*0x%x, bufferSize=*0x%x)", buffer, bufferSize);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3344,7 +3344,7 @@ error_code sceNpManagerGetTicketParam(s32 paramId, vm::ptr<SceNpTicketParam> par
 {
 	sceNp.todo("sceNpManagerGetTicketParam(paramId=%d, param=*0x%x)", paramId, param);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3364,7 +3364,7 @@ error_code sceNpManagerGetEntitlementIdList(vm::ptr<SceNpEntitlementId> entIdLis
 {
 	sceNp.todo("sceNpManagerGetEntitlementIdList(entIdList=*0x%x, entIdListNum=%d)", entIdList, entIdListNum);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3378,7 +3378,7 @@ error_code sceNpManagerGetEntitlementById(vm::cptr<char> entId, vm::ptr<SceNpEnt
 {
 	sceNp.todo("sceNpManagerGetEntitlementById(entId=%s, ent=*0x%x)", entId, ent);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3403,7 +3403,7 @@ error_code sceNpManagerSubSignin(CellSysutilUserId userId, vm::ptr<SceNpManagerS
 {
 	sceNp.todo("sceNpManagerSubSignin(userId=%d, cb_func=*0x%x, cb_arg=*0x%x, flag=%d)", userId, cb_func, cb_arg, flag);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3423,7 +3423,7 @@ error_code sceNpManagerSubSignout(vm::ptr<SceNpId> npId)
 {
 	sceNp.todo("sceNpManagerSubSignout(npId=*0x%x)", npId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3597,7 +3597,7 @@ error_code sceNpProfileCallGui(vm::cptr<SceNpId> npid, vm::ptr<SceNpProfileResul
 {
 	sceNp.todo("sceNpProfileCallGui(npid=*0x%x, handler=*0x%x, userArg=*0x%x, options=0x%x)", npid, handler, userArg, options);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3616,7 +3616,7 @@ error_code sceNpProfileAbortGui()
 {
 	sceNp.todo("sceNpProfileAbortGui()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -3630,7 +3630,7 @@ error_code sceNpScoreInit()
 {
 	sceNp.warning("sceNpScoreInit()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (nph.is_NP_Score_init)
 	{
@@ -3651,7 +3651,7 @@ error_code sceNpScoreTerm()
 {
 	sceNp.warning("sceNpScoreTerm()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3672,7 +3672,7 @@ error_code sceNpScoreCreateTitleCtx(vm::cptr<SceNpCommunicationId> communication
 {
 	sceNp.todo("sceNpScoreCreateTitleCtx(communicationId=*0x%x, passphrase=*0x%x, selfNpId=*0x%x)", communicationId, passphrase, selfNpId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3691,7 +3691,7 @@ error_code sceNpScoreDestroyTitleCtx(s32 titleCtxId)
 {
 	sceNp.todo("sceNpScoreDestroyTitleCtx(titleCtxId=%d)", titleCtxId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3708,7 +3708,7 @@ error_code sceNpScoreCreateTransactionCtx(s32 titleCtxId)
 {
 	sceNp.todo("sceNpScoreCreateTransactionCtx(titleCtxId=%d)", titleCtxId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3727,7 +3727,7 @@ error_code sceNpScoreDestroyTransactionCtx(s32 transId)
 {
 	sceNp.todo("sceNpScoreDestroyTransactionCtx(transId=%d)", transId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3741,7 +3741,7 @@ error_code sceNpScoreSetTimeout(s32 ctxId, usecond_t timeout)
 {
 	sceNp.todo("sceNpScoreSetTimeout(ctxId=%d, timeout=%d)", ctxId, timeout);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3760,7 +3760,7 @@ error_code sceNpScoreSetPlayerCharacterId(s32 ctxId, SceNpScorePcId pcId)
 {
 	sceNp.todo("sceNpScoreSetPlayerCharacterId(ctxId=%d, pcId=%d)", ctxId, pcId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3779,7 +3779,7 @@ error_code sceNpScoreWaitAsync(s32 transId, vm::ptr<s32> result)
 {
 	sceNp.todo("sceNpScoreWaitAsync(transId=%d, result=*0x%x)", transId, result);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3798,7 +3798,7 @@ error_code sceNpScorePollAsync(s32 transId, vm::ptr<s32> result)
 {
 	sceNp.todo("sceNpScorePollAsync(transId=%d, result=*0x%x)", transId, result);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3817,7 +3817,7 @@ error_code sceNpScoreGetBoardInfo(s32 transId, SceNpScoreBoardId boardId, vm::pt
 {
 	sceNp.todo("sceNpScoreGetBoardInfo(transId=%d, boardId=%d, boardInfo=*0x%x, option=*0x%x)", transId, boardId, boardInfo, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3846,7 +3846,7 @@ error_code sceNpScoreGetBoardInfoAsync(s32 transId, SceNpScoreBoardId boardId, v
 {
 	sceNp.todo("sceNpScoreGetBoardInfo(transId=%d, boardId=%d, boardInfo=*0x%x, prio=%d, option=*0x%x)", transId, boardId, boardInfo, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3867,7 +3867,7 @@ error_code sceNpScoreRecordScore(s32 transId, SceNpScoreBoardId boardId, SceNpSc
 	sceNp.todo(
 	    "sceNpScoreRecordScore(transId=%d, boardId=%d, score=%d, scoreComment=*0x%x, gameInfo=*0x%x, tmpRank=*0x%x, option=*0x%x)", transId, boardId, score, scoreComment, gameInfo, tmpRank, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3893,7 +3893,7 @@ error_code sceNpScoreRecordScoreAsync(s32 transId, SceNpScoreBoardId boardId, Sc
 	sceNp.todo("sceNpScoreRecordScoreAsync(transId=%d, boardId=%d, score=%d, scoreComment=*0x%x, gameInfo=*0x%x, tmpRank=*0x%x, prio=%d, option=*0x%x)", transId, boardId, score, scoreComment, gameInfo,
 	    tmpRank, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3912,7 +3912,7 @@ error_code sceNpScoreRecordGameData(s32 transId, SceNpScoreBoardId boardId, SceN
 {
 	sceNp.todo("sceNpScoreRecordGameData(transId=%d, boardId=%d, score=%d, totalSize=%d, sendSize=%d, data=*0x%x, option=*0x%x)", transId, boardId, score, totalSize, sendSize, data, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3942,7 +3942,7 @@ error_code sceNpScoreRecordGameDataAsync(s32 transId, SceNpScoreBoardId boardId,
 	sceNp.todo(
 	    "sceNpScoreRecordGameDataAsync(transId=%d, boardId=%d, score=%d, totalSize=%d, sendSize=%d, data=*0x%x, prio=%d, option=*0x%x)", transId, boardId, score, totalSize, sendSize, data, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3961,7 +3961,7 @@ error_code sceNpScoreGetGameData(s32 transId, SceNpScoreBoardId boardId, vm::cpt
 {
 	sceNp.todo("sceNpScoreGetGameDataAsync(transId=%d, boardId=%d, npId=*0x%x, totalSize=*0x%x, recvSize=%d, data=*0x%x, option=*0x%x)", transId, boardId, npId, totalSize, recvSize, data, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -3991,7 +3991,7 @@ error_code sceNpScoreGetGameDataAsync(s32 transId, SceNpScoreBoardId boardId, vm
 	sceNp.todo("sceNpScoreGetGameDataAsync(transId=%d, boardId=%d, npId=*0x%x, totalSize=*0x%x, recvSize=%d, data=*0x%x, prio=%d, option=*0x%x)", transId, boardId, npId, totalSize, recvSize, data, prio,
 	    option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4014,7 +4014,7 @@ error_code sceNpScoreGetRankingByNpId(s32 transId, SceNpScoreBoardId boardId, vm
 	           "infoArraySize=%d, arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, option=*0x%x)",
 	    transId, boardId, npIdArray, npIdArraySize, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, arrayNum, lastSortDate, totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4052,7 +4052,7 @@ error_code sceNpScoreGetRankingByNpIdAsync(s32 transId, SceNpScoreBoardId boardI
 	           "infoArraySize=%d, arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, prio=%d, option=*0x%x)",
 	    transId, boardId, npIdArray, npIdArraySize, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, arrayNum, lastSortDate, totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4080,7 +4080,7 @@ error_code sceNpScoreGetRankingByRange(s32 transId, SceNpScoreBoardId boardId, S
 	           "arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, option=*0x%x)",
 	    transId, boardId, startSerialRank, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, arrayNum, lastSortDate, totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4118,7 +4118,7 @@ error_code sceNpScoreGetRankingByRangeAsync(s32 transId, SceNpScoreBoardId board
 	           "infoArraySize=%d, arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, prio=%d, option=*0x%x)",
 	    transId, boardId, startSerialRank, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, arrayNum, lastSortDate, totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4145,7 +4145,7 @@ error_code sceNpScoreGetFriendsRanking(s32 transId, SceNpScoreBoardId boardId, s
 	           "arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, option=*0x%x)",
 	    transId, boardId, includeSelf, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, arrayNum, lastSortDate, totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4173,7 +4173,7 @@ error_code sceNpScoreGetFriendsRankingAsync(s32 transId, SceNpScoreBoardId board
 	           "arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, prio=%d, option=*0x%x)",
 	    transId, boardId, includeSelf, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, arrayNum, lastSortDate, totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4197,7 +4197,7 @@ error_code sceNpScoreCensorComment(s32 transId, vm::cptr<char> comment, vm::ptr<
 {
 	sceNp.todo("sceNpScoreCensorComment(transId=%d, comment=%s, option=*0x%x)", transId, comment, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4227,7 +4227,7 @@ error_code sceNpScoreCensorCommentAsync(s32 transId, vm::cptr<char> comment, s32
 {
 	sceNp.todo("sceNpScoreCensorCommentAsync(transId=%d, comment=%s, prio=%d, option=*0x%x)", transId, comment, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4252,7 +4252,7 @@ error_code sceNpScoreSanitizeComment(s32 transId, vm::cptr<char> comment, vm::pt
 {
 	sceNp.todo("sceNpScoreSanitizeComment(transId=%d, comment=%s, sanitizedComment=*0x%x, option=*0x%x)", transId, comment, sanitizedComment, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4282,7 +4282,7 @@ error_code sceNpScoreSanitizeCommentAsync(s32 transId, vm::cptr<char> comment, v
 {
 	sceNp.todo("sceNpScoreSanitizeCommentAsync(transId=%d, comment=%s, sanitizedComment=*0x%x, prio=%d, option=*0x%x)", transId, comment, sanitizedComment, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4311,7 +4311,7 @@ error_code sceNpScoreGetRankingByNpIdPcId(s32 transId, SceNpScoreBoardId boardId
 	           "infoArraySize=%d, arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, option=*0x%x)",
 	    transId, boardId, idArray, idArraySize, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, arrayNum, lastSortDate, totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4349,7 +4349,7 @@ error_code sceNpScoreGetRankingByNpIdPcIdAsync(s32 transId, SceNpScoreBoardId bo
 	           "infoArraySize=%d, arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, prio=%d, option=*0x%x)",
 	    transId, boardId, idArray, idArraySize, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, arrayNum, lastSortDate, totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4373,7 +4373,7 @@ error_code sceNpScoreAbortTransaction(s32 transId)
 {
 	sceNp.todo("sceNpScoreAbortTransaction(transId=%d)", transId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4392,7 +4392,7 @@ error_code sceNpScoreGetClansMembersRankingByNpId(s32 transId, SceNpClanId clanI
 	    transId, clanId, boardId, idArray, idArraySize, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, descriptArray, descriptArraySize, arrayNum, clanInfo,
 	    lastSortDate, totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4432,7 +4432,7 @@ error_code sceNpScoreGetClansMembersRankingByNpIdAsync(s32 transId, SceNpClanId 
 	    transId, clanId, boardId, idArray, idArraySize, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, descriptArray, descriptArraySize, arrayNum, clanInfo,
 	    lastSortDate, totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4462,7 +4462,7 @@ error_code sceNpScoreGetClansMembersRankingByNpIdPcId(s32 transId, SceNpClanId c
 	    transId, clanId, boardId, idArray, idArraySize, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, descriptArray, descriptArraySize, arrayNum, clanInfo,
 	    lastSortDate, totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4503,7 +4503,7 @@ error_code sceNpScoreGetClansMembersRankingByNpIdPcIdAsync(s32 transId, SceNpCla
 	    transId, clanId, boardId, idArray, idArraySize, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, descriptArray, descriptArraySize, arrayNum, clanInfo,
 	    lastSortDate, totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4531,7 +4531,7 @@ error_code sceNpScoreGetClansRankingByRange(s32 transId, SceNpScoreClansBoardId 
 	           "arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, option=*0x%x)",
 	    transId, clanBoardId, startSerialRank, rankArray, rankArraySize, reserved1, reservedSize1, reserved2, reservedSize2, arrayNum, lastSortDate, totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4569,7 +4569,7 @@ error_code sceNpScoreGetClansRankingByRangeAsync(s32 transId, SceNpScoreClansBoa
 	           "reservedSize2=%d, arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, prio=%d, option=*0x%x)",
 	    transId, clanBoardId, startSerialRank, rankArray, rankArraySize, reserved1, reservedSize1, reserved2, reservedSize2, arrayNum, lastSortDate, totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4595,7 +4595,7 @@ error_code sceNpScoreGetClanMemberGameData(
 	sceNp.todo("sceNpScoreGetClanMemberGameData(transId=%d, boardId=%d, clanId=%d, npId=*0x%x, totalSize=*0x%x, recvSize=%d, data=*0x%x, option=*0x%x)", transId, boardId, clanId, npId, totalSize,
 	    recvSize, data, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4626,7 +4626,7 @@ error_code sceNpScoreGetClanMemberGameDataAsync(
 	sceNp.todo("sceNpScoreGetClanMemberGameDataAsync(transId=%d, boardId=%d, clanId=%d, npId=*0x%x, totalSize=*0x%x, recvSize=%d, data=*0x%x, prio=%d, option=*0x%x)", transId, boardId, clanId, npId,
 	    totalSize, recvSize, data, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4649,7 +4649,7 @@ error_code sceNpScoreGetClansRankingByClanId(s32 transId, SceNpScoreClansBoardId
 	           "reserved2=*0x%x, reservedSize2=%d, arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, option=*0x%x)",
 	    transId, clanBoardId, clanIdArray, clanIdArraySize, rankArray, rankArraySize, reserved1, reservedSize1, reserved2, reservedSize2, arrayNum, lastSortDate, totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4687,7 +4687,7 @@ error_code sceNpScoreGetClansRankingByClanIdAsync(s32 transId, SceNpScoreClansBo
 	           "reserved2=*0x%x, reservedSize2=%d, arrayNum=%d, lastSortDate=*0x%x, totalRecord=*0x%x, prio=%d, option=*0x%x)",
 	    transId, clanBoardId, clanIdArray, clanIdArraySize, rankArray, rankArraySize, reserved1, reservedSize1, reserved2, reservedSize2, arrayNum, lastSortDate, totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4716,7 +4716,7 @@ error_code sceNpScoreGetClansMembersRankingByRange(s32 transId, SceNpClanId clan
 	    transId, clanId, boardId, startSerialRank, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, descriptArray, descriptArraySize, arrayNum, clanInfo, lastSortDate,
 	    totalRecord, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4755,7 +4755,7 @@ error_code sceNpScoreGetClansMembersRankingByRangeAsync(s32 transId, SceNpClanId
 	    transId, clanId, boardId, startSerialRank, rankArray, rankArraySize, commentArray, commentArraySize, infoArray, infoArraySize, descriptArray, descriptArraySize, arrayNum, clanInfo, lastSortDate,
 	    totalRecord, prio, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Score_init)
 	{
@@ -4779,7 +4779,7 @@ error_code sceNpSignalingCreateCtx(vm::ptr<SceNpId> npId, vm::ptr<SceNpSignaling
 {
 	sceNp.todo("sceNpSignalingCreateCtx(npId=*0x%x, handler=*0x%x, arg=*0x%x, ctx_id=*0x%x)", npId, handler, arg, ctx_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4808,7 +4808,7 @@ error_code sceNpSignalingDestroyCtx(u32 ctx_id)
 {
 	sceNp.todo("sceNpSignalingDestroyCtx(ctx_id=%d)", ctx_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4827,7 +4827,7 @@ error_code sceNpSignalingAddExtendedHandler(u32 ctx_id, vm::ptr<SceNpSignalingHa
 {
 	sceNp.warning("sceNpSignalingAddExtendedHandler(ctx_id=%d, handler=*0x%x, arg=*0x%x)", ctx_id, handler, arg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4844,7 +4844,7 @@ error_code sceNpSignalingSetCtxOpt(u32 ctx_id, s32 optname, s32 optval)
 {
 	sceNp.todo("sceNpSignalingSetCtxOpt(ctx_id=%d, optname=%d, optval=%d)", ctx_id, optname, optval);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4863,7 +4863,7 @@ error_code sceNpSignalingGetCtxOpt(u32 ctx_id, s32 optname, vm::ptr<s32> optval)
 {
 	sceNp.todo("sceNpSignalingGetCtxOpt(ctx_id=%d, optname=%d, optval=*0x%x)", ctx_id, optname, optval);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4882,7 +4882,7 @@ error_code sceNpSignalingActivateConnection(u32 ctx_id, vm::ptr<SceNpId> npId, v
 {
 	sceNp.warning("sceNpSignalingActivateConnection(ctx_id=%d, npId=*0x%x, conn_id=*0x%x)", ctx_id, npId, conn_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4907,7 +4907,7 @@ error_code sceNpSignalingDeactivateConnection(u32 ctx_id, u32 conn_id)
 {
 	sceNp.todo("sceNpSignalingDeactivateConnection(ctx_id=%d, conn_id=%d)", ctx_id, conn_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4921,7 +4921,7 @@ error_code sceNpSignalingTerminateConnection(u32 ctx_id, u32 conn_id)
 {
 	sceNp.todo("sceNpSignalingTerminateConnection(ctx_id=%d, conn_id=%d)", ctx_id, conn_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4935,7 +4935,7 @@ error_code sceNpSignalingGetConnectionStatus(u32 ctx_id, u32 conn_id, vm::ptr<s3
 {
 	sceNp.warning("sceNpSignalingGetConnectionStatus(ctx_id=%d, conn_id=%d, conn_status=*0x%x, peer_addr=*0x%x, peer_port=*0x%x)", ctx_id, conn_id, conn_status, peer_addr, peer_port);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4964,7 +4964,7 @@ error_code sceNpSignalingGetConnectionInfo(u32 ctx_id, u32 conn_id, s32 code, vm
 {
 	sceNp.todo("sceNpSignalingGetConnectionInfo(ctx_id=%d, conn_id=%d, code=%d, info=*0x%x)", ctx_id, conn_id, code, info);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -4983,7 +4983,7 @@ error_code sceNpSignalingGetConnectionFromNpId(u32 ctx_id, vm::ptr<SceNpId> npId
 {
 	sceNp.todo("sceNpSignalingGetConnectionFromNpId(ctx_id=%d, npId=*0x%x, conn_id=*0x%x)", ctx_id, npId, conn_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -5002,7 +5002,7 @@ error_code sceNpSignalingGetConnectionFromPeerAddress(u32 ctx_id, vm::ptr<np_in_
 {
 	sceNp.todo("sceNpSignalingGetConnectionFromPeerAddress(ctx_id=%d, peer_addr=*0x%x, peer_port=%d, conn_id=*0x%x)", ctx_id, peer_addr, peer_port, conn_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -5021,7 +5021,7 @@ error_code sceNpSignalingGetLocalNetInfo(u32 ctx_id, vm::ptr<SceNpSignalingNetIn
 {
 	sceNp.warning("sceNpSignalingGetLocalNetInfo(ctx_id=%d, info=*0x%x)", ctx_id, info);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -5049,7 +5049,7 @@ error_code sceNpSignalingGetPeerNetInfo(u32 ctx_id, vm::ptr<SceNpId> npId, vm::p
 {
 	sceNp.todo("sceNpSignalingGetPeerNetInfo(ctx_id=%d, npId=*0x%x, req_id=*0x%x)", ctx_id, npId, req_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -5068,7 +5068,7 @@ error_code sceNpSignalingCancelPeerNetInfo(u32 ctx_id, u32 req_id)
 {
 	sceNp.todo("sceNpSignalingCancelPeerNetInfo(ctx_id=%d, req_id=%d)", ctx_id, req_id);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{
@@ -5082,7 +5082,7 @@ error_code sceNpSignalingGetPeerNetInfoResult(u32 ctx_id, u32 req_id, vm::ptr<Sc
 {
 	sceNp.todo("sceNpSignalingGetPeerNetInfoResult(ctx_id=%d, req_id=%d, info=*0x%x)", ctx_id, req_id, info);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_init)
 	{

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -710,7 +710,7 @@ error_code sceNpBasicRegisterContextSensitiveHandler(vm::cptr<SceNpCommunication
 
 error_code sceNpBasicUnregisterHandler()
 {
-	sceNp.todo("sceNpBasicUnregisterHandler()");
+	sceNp.notice("sceNpBasicUnregisterHandler()");
 
 	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -680,7 +680,7 @@ error_code sceNpBasicRegisterHandler(vm::cptr<SceNpCommunicationId> context, vm:
 
 error_code sceNpBasicRegisterContextSensitiveHandler(vm::cptr<SceNpCommunicationId> context, vm::ptr<SceNpBasicEventHandler> handler, vm::ptr<void> arg)
 {
-	sceNp.todo("sceNpBasicRegisterContextSensitiveHandler(context=*0x%x, handler=*0x%x, arg=*0x%x)", context, handler, arg);
+	sceNp.notice("sceNpBasicRegisterContextSensitiveHandler(context=*0x%x, handler=*0x%x, arg=*0x%x)", context, handler, arg);
 
 	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 

--- a/rpcs3/Emu/Cell/Modules/sceNp2.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp2.cpp
@@ -1299,13 +1299,20 @@ error_code sceNpMatching2SignalingSetCtxOpt(SceNpMatching2ContextId ctxId, s32 o
 error_code sceNpMatching2DeleteServerContext(
     SceNpMatching2ContextId ctxId, vm::cptr<SceNpMatching2DeleteServerContextRequest> reqParam, vm::cptr<SceNpMatching2RequestOptParam> optParam, vm::ptr<SceNpMatching2RequestId> assignedReqId)
 {
-	sceNp2.todo("sceNpMatching2DeleteServerContext(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
+	sceNp2.warning("sceNpMatching2DeleteServerContext(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
 	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
 	}
+
+	if (reqParam->serverId == 0)
+	{
+		return SCE_NP_MATCHING2_ERROR_INVALID_SERVER_ID;
+	}
+
+	*assignedReqId = nph.delete_server_context(ctxId, optParam, reqParam->serverId);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/sceNp2.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp2.cpp
@@ -178,7 +178,7 @@ error_code sceNpMatching2Init2(u64 stackSize, s32 priority, vm::ptr<SceNpMatchin
 error_code sceNpMatching2Term(ppu_thread& ppu);
 error_code sceNpMatching2Term2();
 
-error_code generic_match2_error_check(const named_thread<np_handler>& nph, SceNpMatching2ContextId ctxId, vm::cptr<void> reqParam, vm::ptr<SceNpMatching2RequestId> assignedReqId)
+error_code generic_match2_error_check(const named_thread<np::np_handler>& nph, SceNpMatching2ContextId ctxId, vm::cptr<void> reqParam, vm::ptr<SceNpMatching2RequestId> assignedReqId)
 {
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -207,7 +207,7 @@ error_code sceNp2Init(u32 poolsize, vm::ptr<void> poolptr)
 {
 	sceNp2.warning("sceNp2Init(poolsize=0x%x, poolptr=*0x%x)", poolsize, poolptr);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	{
 		std::lock_guard lock(nph.mutex_status);
@@ -239,7 +239,7 @@ error_code sceNpMatching2Init2(u64 stackSize, s32 priority, vm::ptr<SceNpMatchin
 {
 	sceNp2.todo("sceNpMatching2Init2(stackSize=0x%x, priority=%d, param=*0x%x)", stackSize, priority, param);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_init)
 	{
@@ -265,7 +265,7 @@ error_code sceNp2Term(ppu_thread& ppu)
 {
 	sceNp2.warning("sceNp2Term()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	{
 		std::lock_guard lock(nph.mutex_status);
@@ -295,7 +295,7 @@ error_code sceNpMatching2Term2()
 {
 	sceNp2.warning("sceNpMatching2Term2()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	{
 		std::lock_guard lock(nph.mutex_status);
@@ -321,7 +321,7 @@ error_code sceNpMatching2DestroyContext(SceNpMatching2ContextId ctxId)
 {
 	sceNp2.todo("sceNpMatching2DestroyContext(ctxId=%d)", ctxId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -339,7 +339,7 @@ error_code sceNpMatching2LeaveLobby(
 {
 	sceNp2.todo("sceNpMatching2LeaveLobby(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -352,7 +352,7 @@ error_code sceNpMatching2RegisterLobbyMessageCallback(SceNpMatching2ContextId ct
 {
 	sceNp2.todo("sceNpMatching2RegisterLobbyMessageCallback(ctxId=%d, cbFunc=*0x%x, cbFuncArg=*0x%x)", ctxId, cbFunc, cbFuncArg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -367,7 +367,7 @@ error_code sceNpMatching2GetWorldInfoList(
 {
 	sceNp2.warning("sceNpMatching2GetWorldInfoList(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -387,7 +387,7 @@ error_code sceNpMatching2RegisterLobbyEventCallback(SceNpMatching2ContextId ctxI
 {
 	sceNp2.todo("sceNpMatching2RegisterLobbyEventCallback(ctxId=%d, cbFunc=*0x%x, cbFuncArg=*0x%x)", ctxId, cbFunc, cbFuncArg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -402,7 +402,7 @@ error_code sceNpMatching2GetLobbyMemberDataInternalList(SceNpMatching2ContextId 
 {
 	sceNp2.todo("sceNpMatching2GetLobbyMemberDataInternalList(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -416,7 +416,7 @@ error_code sceNpMatching2SearchRoom(
 {
 	sceNp2.warning("sceNpMatching2SearchRoom(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -432,7 +432,7 @@ error_code sceNpMatching2SignalingGetConnectionStatus(
 {
 	sceNp2.warning("sceNpMatching2SignalingGetConnectionStatus(ctxId=%d, roomId=%d, memberId=%d, connStatus=*0x%x, peerAddr=*0x%x, peerPort=*0x%x)", ctxId, roomId, memberId, connStatus, peerAddr, peerPort);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -468,7 +468,7 @@ error_code sceNpMatching2SetUserInfo(
 {
 	sceNp2.todo("sceNpMatching2SetUserInfo(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -481,7 +481,7 @@ error_code sceNpMatching2GetClanLobbyId(SceNpMatching2ContextId ctxId, SceNpClan
 {
 	sceNp2.todo("sceNpMatching2GetClanLobbyId(ctxId=%d, clanId=%d, lobbyId=*0x%x)", ctxId, clanId, lobbyId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -496,7 +496,7 @@ error_code sceNpMatching2GetLobbyMemberDataInternal(
 {
 	sceNp2.todo("sceNpMatching2GetLobbyMemberDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -509,7 +509,7 @@ error_code sceNpMatching2ContextStart(SceNpMatching2ContextId ctxId)
 {
 	sceNp2.warning("sceNpMatching2ContextStart(ctxId=%d)", ctxId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -537,7 +537,7 @@ error_code sceNpMatching2CreateServerContext(
 {
 	sceNp2.warning("sceNpMatching2CreateServerContext(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -557,7 +557,7 @@ error_code sceNpMatching2GetMemoryInfo(vm::ptr<SceNpMatching2MemoryInfo> memInfo
 {
 	sceNp2.todo("sceNpMatching2GetMemoryInfo(memInfo=*0x%x)", memInfo);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -572,7 +572,7 @@ error_code sceNpMatching2LeaveRoom(
 {
 	sceNp2.warning("sceNpMatching2LeaveRoom(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -588,7 +588,7 @@ error_code sceNpMatching2SetRoomDataExternal(
 {
 	sceNp2.warning("sceNpMatching2SetRoomDataExternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -604,7 +604,7 @@ error_code sceNpMatching2SignalingGetConnectionInfo(
 {
 	sceNp2.todo("sceNpMatching2SignalingGetConnectionInfo(ctxId=%d, roomId=%d, memberId=%d, code=%d, connInfo=*0x%x)", ctxId, roomId, memberId, code, connInfo);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -665,7 +665,7 @@ error_code sceNpMatching2SendRoomMessage(
 {
 	sceNp2.warning("sceNpMatching2SendRoomMessage(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -681,7 +681,7 @@ error_code sceNpMatching2JoinLobby(
 {
 	sceNp2.todo("sceNpMatching2JoinLobby(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -695,7 +695,7 @@ error_code sceNpMatching2GetRoomMemberDataExternalList(SceNpMatching2ContextId c
 {
 	sceNp2.todo("sceNpMatching2GetRoomMemberDataExternalList(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -708,7 +708,7 @@ error_code sceNpMatching2AbortRequest(SceNpMatching2ContextId ctxId, SceNpMatchi
 {
 	sceNp2.todo("sceNpMatching2AbortRequest(ctxId=%d, reqId=%d)", ctxId, reqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -723,7 +723,7 @@ error_code sceNpMatching2GetServerInfo(
 {
 	sceNp2.warning("sceNpMatching2GetServerInfo(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -738,7 +738,7 @@ error_code sceNpMatching2GetEventData(SceNpMatching2ContextId ctxId, SceNpMatchi
 {
 	sceNp2.notice("sceNpMatching2GetEventData(ctxId=%d, eventKey=%d, buf=*0x%x, bufLen=%d)", ctxId, eventKey, buf, bufLen);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -750,14 +750,14 @@ error_code sceNpMatching2GetEventData(SceNpMatching2ContextId ctxId, SceNpMatchi
 		return SCE_NP_MATCHING2_ERROR_INVALID_ARGUMENT;
 	}
 
-	return not_an_error(nph.get_match2_event(eventKey, static_cast<u8 *>(buf.get_ptr()), bufLen));
+	return not_an_error(nph.get_match2_event(eventKey, buf.addr(), bufLen));
 }
 
 error_code sceNpMatching2GetRoomSlotInfoLocal(SceNpMatching2ContextId ctxId, const SceNpMatching2RoomId roomId, vm::ptr<SceNpMatching2RoomSlotInfo> roomSlotInfo)
 {
 	sceNp2.todo("sceNpMatching2GetRoomSlotInfoLocal(ctxId=%d, roomId=%d, roomSlotInfo=*0x%x)", ctxId, roomId, roomSlotInfo);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -772,7 +772,7 @@ error_code sceNpMatching2SendLobbyChatMessage(
 {
 	sceNp2.todo("sceNpMatching2SendLobbyChatMessage(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -785,7 +785,7 @@ error_code sceNpMatching2AbortContextStart(SceNpMatching2ContextId ctxId)
 {
 	sceNp2.todo("sceNpMatching2AbortContextStart(ctxId=%d)", ctxId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -799,7 +799,7 @@ error_code sceNpMatching2GetRoomMemberIdListLocal(SceNpMatching2ContextId ctxId,
 {
 	sceNp2.todo("sceNpMatching2GetRoomMemberIdListLocal(ctxId=%d, roomId=%d, sortMethod=%d, memberId=*0x%x, memberIdNum=%d)", ctxId, roomId, sortMethod, memberId, memberIdNum);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -814,7 +814,7 @@ error_code sceNpMatching2JoinRoom(
 {
 	sceNp2.warning("sceNpMatching2JoinRoom(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -831,7 +831,7 @@ error_code sceNpMatching2GetRoomMemberDataInternalLocal(SceNpMatching2ContextId 
 	sceNp2.todo("sceNpMatching2GetRoomMemberDataInternalLocal(ctxId=%d, roomId=%d, memberId=%d, attrId=*0x%x, attrIdNum=%d, member=*0x%x, buf=*0x%x, bufLen=%d)", ctxId, roomId, memberId, attrId,
 	    attrIdNum, member, buf, bufLen);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -845,7 +845,7 @@ error_code sceNpMatching2GetCbQueueInfo(SceNpMatching2ContextId ctxId, vm::ptr<S
 {
 	sceNp2.todo("sceNpMatching2GetCbQueueInfo(ctxId=%d, queueInfo=*0x%x)", ctxId, queueInfo);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -860,7 +860,7 @@ error_code sceNpMatching2KickoutRoomMember(
 {
 	sceNp2.todo("sceNpMatching2KickoutRoomMember(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -873,7 +873,7 @@ error_code sceNpMatching2ContextStartAsync(SceNpMatching2ContextId ctxId, u32 ti
 {
 	sceNp2.warning("sceNpMatching2ContextStartAsync(ctxId=%d, timeout=%d)", ctxId, timeout);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -906,7 +906,7 @@ error_code sceNpMatching2SetSignalingOptParam(
 {
 	sceNp2.todo("sceNpMatching2SetSignalingOptParam(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -919,7 +919,7 @@ error_code sceNpMatching2RegisterContextCallback(SceNpMatching2ContextId ctxId, 
 {
 	sceNp2.warning("sceNpMatching2RegisterContextCallback(ctxId=%d, cbFunc=*0x%x, cbFuncArg=*0x%x)", ctxId, cbFunc, cbFuncArg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -946,7 +946,7 @@ error_code sceNpMatching2SendRoomChatMessage(
 {
 	sceNp2.todo("sceNpMatching2SendRoomChatMessage(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -960,7 +960,7 @@ error_code sceNpMatching2SetRoomDataInternal(
 {
 	sceNp2.warning("sceNpMatching2SetRoomDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -976,7 +976,7 @@ error_code sceNpMatching2GetRoomDataInternal(
 {
 	sceNp2.warning("sceNpMatching2GetRoomDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -992,7 +992,7 @@ error_code sceNpMatching2SignalingGetPingInfo(
 {
 	sceNp2.warning("sceNpMatching2SignalingGetPingInfo(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1007,7 +1007,7 @@ error_code sceNpMatching2GetServerIdListLocal(SceNpMatching2ContextId ctxId, vm:
 {
 	sceNp2.todo("sceNpMatching2GetServerIdListLocal(ctxId=%d, serverId=*0x%x, serverIdNum=%d)", ctxId, serverId, serverIdNum);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1057,7 +1057,7 @@ error_code sceNpMatching2GrantRoomOwner(
 {
 	sceNp2.todo("sceNpMatching2GrantRoomOwner(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1071,7 +1071,7 @@ error_code sceNpMatching2CreateContext(
 {
 	sceNp2.warning("sceNpMatching2CreateContext(npId=*0x%x, commId=*0x%x(%s), passPhrase=*0x%x, ctxId=*0x%x, option=%d)", npId, commId, commId ? commId->data : "", ctxId, option);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1092,7 +1092,7 @@ error_code sceNpMatching2GetSignalingOptParamLocal(SceNpMatching2ContextId ctxId
 {
 	sceNp2.todo("sceNpMatching2GetSignalingOptParamLocal(ctxId=%d, roomId=%d, signalingOptParam=*0x%x)", ctxId, roomId, signalingOptParam);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1106,7 +1106,7 @@ error_code sceNpMatching2RegisterSignalingCallback(SceNpMatching2ContextId ctxId
 {
 	sceNp2.notice("sceNpMatching2RegisterSignalingCallback(ctxId=%d, cbFunc=*0x%x, cbFuncArg=*0x%x)", ctxId, cbFunc, cbFuncArg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1123,7 +1123,7 @@ error_code sceNpMatching2ClearEventData(SceNpMatching2ContextId ctxId, SceNpMatc
 {
 	sceNp2.todo("sceNpMatching2ClearEventData(ctxId=%d, eventKey=%d)", ctxId, eventKey);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1138,7 +1138,7 @@ error_code sceNpMatching2GetUserInfoList(
 {
 	sceNp2.todo("sceNpMatching2GetUserInfoList(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1152,7 +1152,7 @@ error_code sceNpMatching2GetRoomMemberDataInternal(
 {
 	sceNp2.todo("sceNpMatching2GetRoomMemberDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1166,7 +1166,7 @@ error_code sceNpMatching2SetRoomMemberDataInternal(
 {
 	sceNp2.warning("sceNpMatching2SetRoomMemberDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1182,7 +1182,7 @@ error_code sceNpMatching2JoinProhibitiveRoom(
 {
 	sceNp2.warning("sceNpMatching2JoinProhibitiveRoom(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1198,7 +1198,7 @@ error_code sceNpMatching2SignalingSetCtxOpt(SceNpMatching2ContextId ctxId, s32 o
 {
 	sceNp2.todo("sceNpMatching2SignalingSetCtxOpt(ctxId=%d, optname=%d, optval=%d)", ctxId, optname, optval);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1213,7 +1213,7 @@ error_code sceNpMatching2DeleteServerContext(
 {
 	sceNp2.todo("sceNpMatching2DeleteServerContext(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1226,7 +1226,7 @@ error_code sceNpMatching2SetDefaultRequestOptParam(SceNpMatching2ContextId ctxId
 {
 	sceNp2.warning("sceNpMatching2SetDefaultRequestOptParam(ctxId=%d, optParam=*0x%x)", ctxId, optParam);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1251,7 +1251,7 @@ error_code sceNpMatching2RegisterRoomEventCallback(SceNpMatching2ContextId ctxId
 {
 	sceNp2.todo("sceNpMatching2RegisterRoomEventCallback(ctxId=%d, cbFunc=*0x%x, cbFuncArg=*0x%x)", ctxId, cbFunc, cbFuncArg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1269,7 +1269,7 @@ error_code sceNpMatching2GetRoomPasswordLocal(SceNpMatching2ContextId ctxId, Sce
 {
 	sceNp2.todo("sceNpMatching2GetRoomPasswordLocal(ctxId=%d, roomId=%d, withPassword=*0x%x, roomPassword=*0x%x)", ctxId, roomId, withPassword, roomPassword);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1284,7 +1284,7 @@ error_code sceNpMatching2GetRoomDataExternalList(
 {
 	sceNp2.warning("sceNpMatching2GetRoomDataExternalList(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1300,7 +1300,7 @@ error_code sceNpMatching2CreateJoinRoom(
 {
 	sceNp2.warning("sceNpMatching2CreateJoinRoom(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1315,7 +1315,7 @@ error_code sceNpMatching2SignalingGetCtxOpt(SceNpMatching2ContextId ctxId, s32 o
 {
 	sceNp2.todo("sceNpMatching2SignalingGetCtxOpt(ctxId=%d, optname=%d, optval=*0x%x)", ctxId, optname, optval);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1330,7 +1330,7 @@ error_code sceNpMatching2GetLobbyInfoList(
 {
 	sceNp2.todo("sceNpMatching2GetLobbyInfoList(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1344,7 +1344,7 @@ error_code sceNpMatching2GetLobbyMemberIdListLocal(
 {
 	sceNp2.todo("sceNpMatching2GetLobbyMemberIdListLocal(ctxId=%d, lobbyId=%d, memberId=*0x%x, memberIdNum=%d, me=*0x%x)", ctxId, lobbyId, memberId, memberIdNum, me);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1359,7 +1359,7 @@ error_code sceNpMatching2SendLobbyInvitation(
 {
 	sceNp2.todo("sceNpMatching2SendLobbyInvitation(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1372,7 +1372,7 @@ error_code sceNpMatching2ContextStop(SceNpMatching2ContextId ctxId)
 {
 	sceNp2.todo("sceNpMatching2ContextStop(ctxId=%d)", ctxId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1403,7 +1403,7 @@ error_code sceNpMatching2SetLobbyMemberDataInternal(
 {
 	sceNp2.todo("sceNpMatching2SetLobbyMemberDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
@@ -1416,7 +1416,7 @@ error_code sceNpMatching2RegisterRoomMessageCallback(SceNpMatching2ContextId ctx
 {
 	sceNp2.todo("sceNpMatching2RegisterRoomMessageCallback(ctxId=%d, cbFunc=*0x%x, cbFuncArg=*0x%x)", ctxId, cbFunc, cbFuncArg);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1434,7 +1434,7 @@ error_code sceNpMatching2SignalingCancelPeerNetInfo(SceNpMatching2ContextId ctxI
 {
 	sceNp2.todo("sceNpMatching2SignalingCancelPeerNetInfo(ctxId=%d, reqId=%d)", ctxId, reqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1448,7 +1448,7 @@ error_code sceNpMatching2SignalingGetLocalNetInfo(vm::ptr<SceNpMatching2Signalin
 {
 	sceNp2.todo("sceNpMatching2SignalingGetLocalNetInfo(netinfo=*0x%x)", netinfo);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1468,7 +1468,7 @@ error_code sceNpMatching2SignalingGetPeerNetInfo(SceNpMatching2ContextId ctxId, 
 {
 	sceNp2.todo("sceNpMatching2SignalingGetPeerNetInfo(ctxId=%d, roomId=%d, roomMemberId=%d, reqId=*0x%x)", ctxId, roomId, roomMemberId, reqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1487,7 +1487,7 @@ error_code sceNpMatching2SignalingGetPeerNetInfoResult(SceNpMatching2ContextId c
 {
 	sceNp2.todo("sceNpMatching2SignalingGetPeerNetInfoResult(ctxId=%d, reqId=%d, netinfo=*0x%x)", ctxId, reqId, netinfo);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP2_Match2_init)
 	{
@@ -1507,7 +1507,7 @@ error_code sceNpAuthOAuthInit()
 {
 	sceNp2.todo("sceNpAuthOAuthInit()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (nph.is_NP_Auth_init)
 	{
@@ -1523,7 +1523,7 @@ error_code sceNpAuthOAuthTerm()
 {
 	sceNp2.todo("sceNpAuthOAuthTerm()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	// TODO: check if this might throw SCE_NP_OAUTH_ERROR_NOT_INITIALIZED
 	nph.is_NP_Auth_init = false;
@@ -1535,7 +1535,7 @@ error_code sceNpAuthCreateOAuthRequest()
 {
 	sceNp2.todo("sceNpAuthCreateOAuthRequest()");
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Auth_init)
 	{
@@ -1549,7 +1549,7 @@ error_code sceNpAuthDeleteOAuthRequest(SceNpAuthOAuthRequestId reqId)
 {
 	sceNp2.todo("sceNpAuthDeleteOAuthRequest(reqId=%d)", reqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Auth_init)
 	{
@@ -1563,7 +1563,7 @@ error_code sceNpAuthAbortOAuthRequest(SceNpAuthOAuthRequestId reqId)
 {
 	sceNp2.todo("sceNpAuthAbortOAuthRequest(reqId=%d)", reqId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Auth_init)
 	{
@@ -1577,7 +1577,7 @@ error_code sceNpAuthGetAuthorizationCode(SceNpAuthOAuthRequestId reqId, vm::cptr
 {
 	sceNp2.todo("sceNpAuthGetAuthorizationCode(reqId=%d, param=*0x%x, authCode=*0x%x, issuerId=%d)", reqId, param, authCode, issuerId);
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (!nph.is_NP_Auth_init)
 	{

--- a/rpcs3/Emu/Cell/Modules/sceNp2.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp2.cpp
@@ -663,7 +663,7 @@ error_code sceNpMatching2SignalingGetConnectionInfo(
 error_code sceNpMatching2SendRoomMessage(
     SceNpMatching2ContextId ctxId, vm::cptr<SceNpMatching2SendRoomMessageRequest> reqParam, vm::cptr<SceNpMatching2RequestOptParam> optParam, vm::ptr<SceNpMatching2RequestId> assignedReqId)
 {
-	sceNp2.todo("sceNpMatching2SendRoomMessage(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
+	sceNp2.warning("sceNpMatching2SendRoomMessage(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
 	auto& nph = g_fxo->get<named_thread<np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
@@ -958,7 +958,7 @@ error_code sceNpMatching2SendRoomChatMessage(
 error_code sceNpMatching2SetRoomDataInternal(
     SceNpMatching2ContextId ctxId, vm::cptr<SceNpMatching2SetRoomDataInternalRequest> reqParam, vm::cptr<SceNpMatching2RequestOptParam> optParam, vm::ptr<SceNpMatching2RequestId> assignedReqId)
 {
-	sceNp2.todo("sceNpMatching2SetRoomDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
+	sceNp2.warning("sceNpMatching2SetRoomDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
 	auto& nph = g_fxo->get<named_thread<np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
@@ -974,7 +974,7 @@ error_code sceNpMatching2SetRoomDataInternal(
 error_code sceNpMatching2GetRoomDataInternal(
     SceNpMatching2ContextId ctxId, vm::cptr<SceNpMatching2GetRoomDataInternalRequest> reqParam, vm::cptr<SceNpMatching2RequestOptParam> optParam, vm::ptr<SceNpMatching2RequestId> assignedReqId)
 {
-	sceNp2.todo("sceNpMatching2GetRoomDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
+	sceNp2.warning("sceNpMatching2GetRoomDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
 	auto& nph = g_fxo->get<named_thread<np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
@@ -1164,13 +1164,15 @@ error_code sceNpMatching2GetRoomMemberDataInternal(
 error_code sceNpMatching2SetRoomMemberDataInternal(
     SceNpMatching2ContextId ctxId, vm::cptr<SceNpMatching2SetRoomMemberDataInternalRequest> reqParam, vm::cptr<SceNpMatching2RequestOptParam> optParam, vm::ptr<SceNpMatching2RequestId> assignedReqId)
 {
-	sceNp2.todo("sceNpMatching2SetRoomMemberDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
+	sceNp2.warning("sceNpMatching2SetRoomMemberDataInternal(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
 	auto& nph = g_fxo->get<named_thread<np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)
 	{
 		return res;
 	}
+
+	*assignedReqId = nph.set_roommemberdata_internal(ctxId, optParam, reqParam.get_ptr());
 
 	return CELL_OK;
 }
@@ -1280,7 +1282,7 @@ error_code sceNpMatching2GetRoomPasswordLocal(SceNpMatching2ContextId ctxId, Sce
 error_code sceNpMatching2GetRoomDataExternalList(
     SceNpMatching2ContextId ctxId, vm::cptr<SceNpMatching2GetRoomDataExternalListRequest> reqParam, vm::cptr<SceNpMatching2RequestOptParam> optParam, vm::ptr<SceNpMatching2RequestId> assignedReqId)
 {
-	sceNp2.todo("sceNpMatching2GetRoomDataExternalList(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
+	sceNp2.warning("sceNpMatching2GetRoomDataExternalList(ctxId=%d, reqParam=*0x%x, optParam=*0x%x, assignedReqId=*0x%x)", ctxId, reqParam, optParam, assignedReqId);
 
 	auto& nph = g_fxo->get<named_thread<np_handler>>();
 	if (auto res = generic_match2_error_check(nph, ctxId, reqParam, assignedReqId); res != CELL_OK)

--- a/rpcs3/Emu/Cell/Modules/sceNp2.h
+++ b/rpcs3/Emu/Cell/Modules/sceNp2.h
@@ -1388,9 +1388,9 @@ struct SceNpMatching2RoomDataInternalUpdateInfo
 	vm::bptr<SceNpMatching2FlagAttr> prevFlagAttr;
 	vm::bptr<SceNpMatching2RoomPasswordSlotMask> newRoomPasswordSlotMask;
 	vm::bptr<SceNpMatching2RoomPasswordSlotMask> prevRoomPasswordSlotMask;
-	vm::pptr<SceNpMatching2RoomGroup> newRoomGroup;
+	vm::bpptr<SceNpMatching2RoomGroup> newRoomGroup;
 	be_t<u32> newRoomGroupNum;
-	vm::pptr<SceNpMatching2RoomBinAttrInternal> newRoomBinAttrInternal;
+	vm::bpptr<SceNpMatching2RoomBinAttrInternal> newRoomBinAttrInternal;
 	be_t<u32> newRoomBinAttrInternalNum;
 };
 
@@ -1401,7 +1401,7 @@ struct SceNpMatching2RoomMemberDataInternalUpdateInfo
 	vm::bptr<SceNpMatching2FlagAttr> newFlagAttr;
 	vm::bptr<SceNpMatching2FlagAttr> prevFlagAttr;
 	vm::bptr<SceNpMatching2TeamId> newTeamId;
-	vm::pptr<SceNpMatching2RoomMemberBinAttrInternal> newRoomMemberBinAttrInternal;
+	vm::bpptr<SceNpMatching2RoomMemberBinAttrInternal> newRoomMemberBinAttrInternal;
 	be_t<u32> newRoomMemberBinAttrInternalNum;
 };
 

--- a/rpcs3/Emu/Cell/Modules/sceNp2.h
+++ b/rpcs3/Emu/Cell/Modules/sceNp2.h
@@ -1413,7 +1413,7 @@ struct SceNpMatching2RoomMessageInfo
 	u8 padding[2];
 	vm::bptr<SceNpMatching2RoomMessageDestination> dst;
 	vm::bptr<SceNpUserInfo2> srcMember;
-	vm::bcptr<void> msg;
+	vm::bptr<void> msg;
 	be_t<u32> msgLen;
 };
 

--- a/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
@@ -179,7 +179,7 @@ error_code sceNpSnsFbGetAccessToken(u32 handle, vm::cptr<SceNpSnsFbAccessTokenPa
 		return SCE_NP_SNS_FB_ERROR_UNKNOWN_HANDLE;
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (nph.get_psn_status() == SCE_NP_MANAGER_STATUS_OFFLINE)
 	{
@@ -306,7 +306,7 @@ error_code sceNpSnsFbGetLongAccessToken(u32 handle, vm::cptr<SceNpSnsFbAccessTok
 		return SCE_NP_SNS_FB_ERROR_UNKNOWN_HANDLE;
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 	if (nph.get_psn_status() == SCE_NP_MANAGER_STATUS_OFFLINE)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -2255,7 +2255,7 @@ error_code sys_net_bnet_recvfrom(ppu_thread& ppu, s32 s, vm::ptr<void> buf, u32 
 		return -SYS_NET_EINVAL;
 	}
 
-	if (flags & ~(SYS_NET_MSG_PEEK | SYS_NET_MSG_DONTWAIT | SYS_NET_MSG_WAITALL))
+	if (flags & ~(SYS_NET_MSG_PEEK | SYS_NET_MSG_DONTWAIT | SYS_NET_MSG_WAITALL | SYS_NET_MSG_USECRYPTO | SYS_NET_MSG_USESIGNATURE))
 	{
 		fmt::throw_exception("sys_net_bnet_recvfrom(s=%d): unknown flags (0x%x)", flags);
 	}
@@ -2580,7 +2580,7 @@ error_code sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 l
 
 	sys_net.warning("sys_net_bnet_sendto(s=%d, buf=*0x%x, len=%u, flags=0x%x, addr=*0x%x, addrlen=%u)", s, buf, len, flags, addr, addrlen);
 
-	if (flags & ~(SYS_NET_MSG_DONTWAIT | SYS_NET_MSG_WAITALL))
+	if (flags & ~(SYS_NET_MSG_DONTWAIT | SYS_NET_MSG_WAITALL | SYS_NET_MSG_USECRYPTO | SYS_NET_MSG_USESIGNATURE))
 	{
 		fmt::throw_exception("sys_net_bnet_sendto(s=%d): unknown flags (0x%x)", flags);
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -1695,7 +1695,7 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 
 		if (psa_in->sin_port == 53)
 		{
-			auto& nph = g_fxo->get<named_thread<np_handler>>();
+			auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 			// Hack for DNS
 			name.sin_port        = std::bit_cast<u16, be_t<u16>>(53);
@@ -2286,7 +2286,7 @@ error_code sys_net_bnet_recvfrom(ppu_thread& ppu, s32 s, vm::ptr<void> buf, u32 
 
 		//if (!(sock.events & lv2_socket::poll::read))
 		{
-			auto& nph = g_fxo->get<named_thread<np_handler>>();
+			auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 			if (nph.is_dns(s) && nph.is_dns_queue(s))
 			{
 				const auto packet = nph.get_dns_packet(s);
@@ -2708,7 +2708,7 @@ error_code sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 l
 
 		//if (!(sock.events & lv2_socket::poll::write))
 		{
-			auto& nph = g_fxo->get<named_thread<np_handler>>();
+			auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 			if (addr && type == SYS_NET_SOCK_DGRAM && psa_in->sin_port == 53)
 			{
 				nph.add_dns_spy(s);
@@ -3217,7 +3217,7 @@ error_code sys_net_bnet_close(ppu_thread& ppu, s32 s)
 		}
 	}
 
-	auto& nph = g_fxo->get<named_thread<np_handler>>();
+	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 	nph.remove_dns_spy(s);
 
 	return CELL_OK;
@@ -3309,7 +3309,7 @@ error_code sys_net_bnet_poll(ppu_thread& ppu, vm::ptr<sys_net_pollfd> fds, s32 n
 				else
 				{
 					// Check for fake packet for dns interceptions
-					auto& nph = g_fxo->get<named_thread<np_handler>>();
+					auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 					if (fds_buf[i].events & SYS_NET_POLLIN && nph.is_dns(fds_buf[i].fd) && nph.is_dns_queue(fds_buf[i].fd))
 						fds_buf[i].revents |= SYS_NET_POLLIN;
 
@@ -3754,8 +3754,8 @@ error_code sys_net_infoctl(ppu_thread& ppu, s32 cmd, vm::ptr<void> arg)
 		char buffer[nameserver.size() + 80]{};
 		std::memcpy(buffer, nameserver.data(), nameserver.size());
 
-		auto& nph = g_fxo->get<named_thread<np_handler>>();
-		const auto dns_str = np_handler::ip_to_string(nph.get_dns_ip());
+		auto& nph = g_fxo->get<named_thread<np::np_handler>>();
+		const auto dns_str = np::ip_to_string(nph.get_dns_ip());
 		std::memcpy(buffer + nameserver.size() - 1, dns_str.data(), dns_str.size());
 
 		std::string_view name{buffer};

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include "Emu/NP/np_handler.h"
+#include "Emu/NP/np_helpers.h"
 #include "Emu/NP/np_dnshook.h"
 
 #include <chrono>

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include "Emu/NP/np_handler.h"
+#include "Emu/NP/np_dnshook.h"
 
 #include <chrono>
 #include <shared_mutex>
@@ -1695,6 +1696,7 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 
 		if (psa_in->sin_port == 53)
 		{
+			auto& dnshook = g_fxo->get<np::dnshook>();
 			auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 
 			// Hack for DNS
@@ -1703,7 +1705,7 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 
 			sys_net.notice("sys_net_bnet_connect: using DNS...");
 
-			nph.add_dns_spy(s);
+			dnshook.add_dns_spy(s);
 		}
 		else if (_addr->sa_family != SYS_NET_AF_INET)
 		{
@@ -2286,10 +2288,12 @@ error_code sys_net_bnet_recvfrom(ppu_thread& ppu, s32 s, vm::ptr<void> buf, u32 
 
 		//if (!(sock.events & lv2_socket::poll::read))
 		{
-			auto& nph = g_fxo->get<named_thread<np::np_handler>>();
-			if (nph.is_dns(s) && nph.is_dns_queue(s))
+			auto& dnshook = g_fxo->get<np::dnshook>();
+			if (dnshook.is_dns(s) && dnshook.is_dns_queue(s))
 			{
-				const auto packet = nph.get_dns_packet(s);
+				auto& nph = g_fxo->get<named_thread<np::np_handler>>();
+
+				const auto packet = dnshook.get_dns_packet(s);
 				ensure(packet.size() < len);
 
 				memcpy(buf.get_ptr(), packet.data(), packet.size());
@@ -2708,17 +2712,18 @@ error_code sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 l
 
 		//if (!(sock.events & lv2_socket::poll::write))
 		{
-			auto& nph = g_fxo->get<named_thread<np::np_handler>>();
+			auto& dnshook = g_fxo->get<np::dnshook>();
 			if (addr && type == SYS_NET_SOCK_DGRAM && psa_in->sin_port == 53)
 			{
-				nph.add_dns_spy(s);
+				dnshook.add_dns_spy(s);
 			}
 
-			if (nph.is_dns(s))
+			if (dnshook.is_dns(s))
 			{
-				const s32 ret_analyzer = nph.analyze_dns_packet(s, reinterpret_cast<const u8*>(_buf.data()), len);
+				const s32 ret_analyzer = dnshook.analyze_dns_packet(s, reinterpret_cast<const u8*>(_buf.data()), len);
 
 				// If we're not connected just never send the packet and pretend we did
+				auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 				if (!nph.get_net_status())
 				{
 					native_result = data_len;
@@ -3217,8 +3222,8 @@ error_code sys_net_bnet_close(ppu_thread& ppu, s32 s)
 		}
 	}
 
-	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
-	nph.remove_dns_spy(s);
+	auto& dnshook = g_fxo->get<np::dnshook>();
+	dnshook.remove_dns_spy(s);
 
 	return CELL_OK;
 }
@@ -3309,8 +3314,8 @@ error_code sys_net_bnet_poll(ppu_thread& ppu, vm::ptr<sys_net_pollfd> fds, s32 n
 				else
 				{
 					// Check for fake packet for dns interceptions
-					auto& nph = g_fxo->get<named_thread<np::np_handler>>();
-					if (fds_buf[i].events & SYS_NET_POLLIN && nph.is_dns(fds_buf[i].fd) && nph.is_dns_queue(fds_buf[i].fd))
+					auto& dnshook = g_fxo->get<np::dnshook>();
+					if (fds_buf[i].events & SYS_NET_POLLIN && dnshook.is_dns(fds_buf[i].fd) && dnshook.is_dns_queue(fds_buf[i].fd))
 						fds_buf[i].revents |= SYS_NET_POLLIN;
 
 					if (fds_buf[i].events & ~(SYS_NET_POLLIN | SYS_NET_POLLOUT | SYS_NET_POLLERR))

--- a/rpcs3/Emu/NP/fb_helpers.cpp
+++ b/rpcs3/Emu/NP/fb_helpers.cpp
@@ -3,529 +3,489 @@
 
 LOG_CHANNEL(rpcn_log, "rpcn");
 
-void np_handler::BinAttr_to_SceNpMatching2BinAttr(const BinAttr* bin_attr, SceNpMatching2BinAttr* binattr_info)
+namespace np
 {
-	binattr_info->id   = bin_attr->id();
-	binattr_info->size = bin_attr->data()->size();
-	binattr_info->ptr  = allocate(binattr_info->size);
-	for (flatbuffers::uoffset_t i = 0; i < bin_attr->data()->size(); i++)
+	void np_handler::BinAttr_to_SceNpMatching2BinAttr(event_data& edata, const BinAttr* bin_attr, SceNpMatching2BinAttr* binattr_info)
 	{
-		binattr_info->ptr[i] = bin_attr->data()->Get(i);
-	}
-}
-
-void np_handler::BinAttrs_to_SceNpMatching2BinAttr(const flatbuffers::Vector<flatbuffers::Offset<BinAttr>>* fb_attr, vm::ptr<SceNpMatching2BinAttr> binattr_info)
-{
-	for (flatbuffers::uoffset_t i = 0; i < fb_attr->size(); i++)
-	{
-		auto fb_attr_this      = fb_attr->Get(i);
-		auto binattr_info_this = binattr_info + i;
-
-		BinAttr_to_SceNpMatching2BinAttr(fb_attr_this, binattr_info_this.get_ptr());
-	}
-}
-
-void np_handler::RoomMemberBinAttrInternal_to_SceNpMatching2RoomMemberBinAttrInternal(const RoomMemberBinAttrInternal* fb_attr, vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info)
-{
-	binattr_info->updateDate.tick = fb_attr->updateDate();
-	BinAttr_to_SceNpMatching2BinAttr(fb_attr->data(), &binattr_info->data);
-}
-
-void np_handler::RoomBinAttrInternal_to_SceNpMatching2RoomBinAttrInternal(const BinAttrInternal* fb_attr, vm::ptr<SceNpMatching2RoomBinAttrInternal> binattr_info)
-{
-	binattr_info->updateDate.tick = fb_attr->updateDate();
-	binattr_info->updateMemberId  = fb_attr->updateMemberId();
-	BinAttr_to_SceNpMatching2BinAttr(fb_attr->data(), &binattr_info->data);
-}
-
-void np_handler::RoomGroups_to_SceNpMatching2RoomGroup(const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>* fb_group, vm::ptr<SceNpMatching2RoomGroup> group_info)
-{
-	for (flatbuffers::uoffset_t i = 0; i < fb_group->size(); i++)
-	{
-		auto group                 = fb_group->Get(i);
-		group_info[i].groupId      = group->groupId();
-		group_info[i].withPassword = group->withPassword();
-		group_info[i].withLabel    = group->withLabel();
-		if (group->label())
+		binattr_info->id   = bin_attr->id();
+		binattr_info->size = bin_attr->data()->size();
+		auto* ptr          = edata.allocate<u8>(binattr_info->size, binattr_info->ptr);
+		for (flatbuffers::uoffset_t i = 0; i < bin_attr->data()->size(); i++)
 		{
-			for (flatbuffers::uoffset_t l_index = 0; l_index < group->label()->size(); l_index++)
+			ptr[i] = bin_attr->data()->Get(i);
+		}
+	}
+
+	void np_handler::BinAttrs_to_SceNpMatching2BinAttrs(event_data& edata, const flatbuffers::Vector<flatbuffers::Offset<BinAttr>>* fb_attr, SceNpMatching2BinAttr* binattr_info)
+	{
+		for (flatbuffers::uoffset_t i = 0; i < fb_attr->size(); i++)
+		{
+			auto cur_fb_attr = fb_attr->Get(i);
+			auto cur_binattr = binattr_info + i;
+
+			BinAttr_to_SceNpMatching2BinAttr(edata, cur_fb_attr, cur_binattr);
+		}
+	}
+
+	void np_handler::RoomMemberBinAttrInternal_to_SceNpMatching2RoomMemberBinAttrInternal(event_data& edata, const RoomMemberBinAttrInternal* fb_attr, SceNpMatching2RoomMemberBinAttrInternal* binattr_info)
+	{
+		binattr_info->updateDate.tick = fb_attr->updateDate();
+		BinAttr_to_SceNpMatching2BinAttr(edata, fb_attr->data(), &binattr_info->data);
+	}
+
+	void np_handler::RoomBinAttrInternal_to_SceNpMatching2RoomBinAttrInternal(event_data& edata, const BinAttrInternal* fb_attr, SceNpMatching2RoomBinAttrInternal* binattr_info)
+	{
+		binattr_info->updateDate.tick = fb_attr->updateDate();
+		binattr_info->updateMemberId  = fb_attr->updateMemberId();
+		BinAttr_to_SceNpMatching2BinAttr(edata, fb_attr->data(), &binattr_info->data);
+	}
+
+	void np_handler::RoomGroup_to_SceNpMatching2RoomGroup(const RoomGroup* fb_group, SceNpMatching2RoomGroup* sce_group)
+	{
+		sce_group->groupId      = fb_group->groupId();
+		sce_group->withPassword = fb_group->withPassword();
+		sce_group->withLabel    = fb_group->withLabel();
+		if (fb_group->label())
+		{
+			for (flatbuffers::uoffset_t l_index = 0; l_index < fb_group->label()->size(); l_index++)
 			{
-				group_info[i].label.data[l_index] = group->label()->Get(l_index);
+				sce_group->label.data[l_index] = fb_group->label()->Get(l_index);
 			}
 		}
-		group_info[i].slotNum           = group->slotNum();
-		group_info[i].curGroupMemberNum = group->curGroupMemberNum();
-	}
-}
-
-void np_handler::UserInfo2_to_SceNpUserInfo2(const UserInfo2* user, SceNpUserInfo2* user_info)
-{
-	if (user->npId())
-		std::memcpy(user_info->npId.handle.data, user->npId()->c_str(), std::min<usz>(16, user->npId()->size()));
-
-	if (user->onlineName())
-	{
-		user_info->onlineName.set(allocate(sizeof(SceNpOnlineName)));
-		std::memcpy(user_info->onlineName->data, user->onlineName()->c_str(), std::min<usz>(48, user->onlineName()->size()));
-	}
-	if (user->avatarUrl())
-	{
-		user_info->avatarUrl.set(allocate(sizeof(SceNpAvatarUrl)));
-		std::memcpy(user_info->avatarUrl->data, user->avatarUrl()->c_str(), std::min<usz>(127, user->avatarUrl()->size()));
-	}
-}
-
-void np_handler::RoomDataExternal_to_SceNpMatching2RoomDataExternal(const RoomDataExternal* room, SceNpMatching2RoomDataExternal* room_info)
-{
-	room_info->serverId           = room->serverId();
-	room_info->worldId            = room->worldId();
-	room_info->publicSlotNum      = room->publicSlotNum();
-	room_info->privateSlotNum     = room->privateSlotNum();
-	room_info->lobbyId            = room->lobbyId();
-	room_info->roomId             = room->roomId();
-	room_info->openPublicSlotNum  = room->openPublicSlotNum();
-	room_info->maxSlot            = room->maxSlot();
-	room_info->openPrivateSlotNum = room->openPrivateSlotNum();
-	room_info->curMemberNum       = room->curMemberNum();
-	room_info->passwordSlotMask   = room->passwordSlotMask();
-
-	if (auto owner = room->owner())
-	{
-		vm::ptr<SceNpUserInfo2> owner_info(allocate(sizeof(SceNpUserInfo2)));
-		UserInfo2_to_SceNpUserInfo2(owner, owner_info.get_ptr());
-		room_info->owner = owner_info;
+		sce_group->slotNum           = fb_group->slotNum();
+		sce_group->curGroupMemberNum = fb_group->curGroupMemberNum();
 	}
 
-	if (room->roomGroup() && room->roomGroup()->size() != 0)
+	void np_handler::RoomGroups_to_SceNpMatching2RoomGroups(const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>* fb_groups, SceNpMatching2RoomGroup* sce_groups)
 	{
-		room_info->roomGroupNum = room->roomGroup()->size();
-		vm::ptr<SceNpMatching2RoomGroup> group_info(allocate(sizeof(SceNpMatching2RoomGroup) * room_info->roomGroupNum));
-		RoomGroups_to_SceNpMatching2RoomGroup(room->roomGroup(), group_info);
-		room_info->roomGroup = group_info;
-	}
-
-	room_info->flagAttr = room->flagAttr();
-
-	if (room->roomSearchableIntAttrExternal() && room->roomSearchableIntAttrExternal()->size() != 0)
-	{
-		room_info->roomSearchableIntAttrExternalNum = room->roomSearchableIntAttrExternal()->size();
-		vm::ptr<SceNpMatching2IntAttr> intattr_info(allocate(sizeof(SceNpMatching2IntAttr) * room_info->roomSearchableIntAttrExternalNum));
-		for (flatbuffers::uoffset_t a_index = 0; a_index < room->roomSearchableIntAttrExternal()->size(); a_index++)
+		for (flatbuffers::uoffset_t i = 0; i < fb_groups->size(); i++)
 		{
-			auto int_attr             = room->roomSearchableIntAttrExternal()->Get(a_index);
-			intattr_info[a_index].id  = int_attr->id();
-			intattr_info[a_index].num = int_attr->num();
+			const auto* fb_group               = fb_groups->Get(i);
+			SceNpMatching2RoomGroup* sce_group = &sce_groups[i];
+			RoomGroup_to_SceNpMatching2RoomGroup(fb_group, sce_group);
 		}
-		room_info->roomSearchableIntAttrExternal = intattr_info;
 	}
 
-	if (room->roomSearchableBinAttrExternal() && room->roomSearchableBinAttrExternal()->size() != 0)
+	void np_handler::UserInfo2_to_SceNpUserInfo2(event_data& edata, const UserInfo2* user, SceNpUserInfo2* user_info)
 	{
-		room_info->roomSearchableBinAttrExternalNum = room->roomSearchableBinAttrExternal()->size();
-		vm::ptr<SceNpMatching2BinAttr> binattr_info(allocate(sizeof(SceNpMatching2BinAttr) * room_info->roomSearchableBinAttrExternalNum));
-		BinAttrs_to_SceNpMatching2BinAttr(room->roomSearchableBinAttrExternal(), binattr_info);
-		room_info->roomSearchableBinAttrExternal = binattr_info;
-	}
+		if (user->npId())
+			std::memcpy(user_info->npId.handle.data, user->npId()->c_str(), std::min<usz>(16, user->npId()->size()));
 
-	if (room->roomBinAttrExternal() && room->roomBinAttrExternal()->size() != 0)
-	{
-		room_info->roomBinAttrExternalNum = room->roomBinAttrExternal()->size();
-		vm::ptr<SceNpMatching2BinAttr> binattr_info(allocate(sizeof(SceNpMatching2BinAttr) * room_info->roomBinAttrExternalNum));
-		BinAttrs_to_SceNpMatching2BinAttr(room->roomBinAttrExternal(), binattr_info);
-		room_info->roomBinAttrExternal = binattr_info;
-	}
-}
-
-void np_handler::SearchRoomResponse_to_SceNpMatching2SearchRoomResponse(const SearchRoomResponse* resp, SceNpMatching2SearchRoomResponse* search_resp)
-{
-	search_resp->range.size       = resp->size();
-	search_resp->range.startIndex = resp->startIndex();
-	search_resp->range.total      = resp->total();
-
-	if (resp->rooms() && resp->rooms()->size() != 0)
-	{
-		vm::addr_t previous_next = vm::cast<u32>(0);
-		for (flatbuffers::uoffset_t i = 0; i < resp->rooms()->size(); i++)
+		if (user->onlineName())
 		{
-			auto* room = resp->rooms()->Get(i);
-			vm::ptr<SceNpMatching2RoomDataExternal> room_info(allocate(sizeof(SceNpMatching2RoomDataExternal)));
+			auto* ptr = edata.allocate<SceNpOnlineName>(sizeof(SceNpOnlineName), user_info->onlineName);
+			std::memcpy(ptr->data, user->onlineName()->c_str(), std::min<usz>(48, user->onlineName()->size()));
+		}
+		if (user->avatarUrl())
+		{
+			auto* ptr = edata.allocate<SceNpAvatarUrl>(sizeof(SceNpAvatarUrl), user_info->avatarUrl);
+			std::memcpy(ptr->data, user->avatarUrl()->c_str(), std::min<usz>(127, user->avatarUrl()->size()));
+		}
+	}
 
-			if (i > 0)
+	void np_handler::RoomDataExternal_to_SceNpMatching2RoomDataExternal(event_data& edata, const RoomDataExternal* room, SceNpMatching2RoomDataExternal* room_info)
+	{
+		room_info->serverId           = room->serverId();
+		room_info->worldId            = room->worldId();
+		room_info->publicSlotNum      = room->publicSlotNum();
+		room_info->privateSlotNum     = room->privateSlotNum();
+		room_info->lobbyId            = room->lobbyId();
+		room_info->roomId             = room->roomId();
+		room_info->openPublicSlotNum  = room->openPublicSlotNum();
+		room_info->maxSlot            = room->maxSlot();
+		room_info->openPrivateSlotNum = room->openPrivateSlotNum();
+		room_info->curMemberNum       = room->curMemberNum();
+		room_info->passwordSlotMask   = room->passwordSlotMask();
+
+		if (auto owner = room->owner())
+		{
+			auto* ptr_owner = edata.allocate<SceNpUserInfo2>(sizeof(SceNpUserInfo2), room_info->owner);
+			UserInfo2_to_SceNpUserInfo2(edata, owner, ptr_owner);
+		}
+
+		if (room->roomGroup() && room->roomGroup()->size() != 0)
+		{
+			room_info->roomGroupNum = room->roomGroup()->size();
+			auto* ptr_groups        = edata.allocate<SceNpMatching2RoomGroup>(sizeof(SceNpMatching2RoomGroup) * room_info->roomGroupNum, room_info->roomGroup);
+			RoomGroups_to_SceNpMatching2RoomGroups(room->roomGroup(), ptr_groups);
+		}
+
+		room_info->flagAttr = room->flagAttr();
+
+		if (room->roomSearchableIntAttrExternal() && room->roomSearchableIntAttrExternal()->size() != 0)
+		{
+			room_info->roomSearchableIntAttrExternalNum = room->roomSearchableIntAttrExternal()->size();
+			auto* ptr_int_attr                          = edata.allocate<SceNpMatching2IntAttr>(sizeof(SceNpMatching2IntAttr) * room_info->roomSearchableIntAttrExternalNum, room_info->roomSearchableIntAttrExternal);
+			for (flatbuffers::uoffset_t a_index = 0; a_index < room->roomSearchableIntAttrExternal()->size(); a_index++)
 			{
-				vm::ptr<SceNpMatching2RoomDataExternal> prev_room(previous_next);
-				prev_room->next.set(room_info.addr());
+				auto fb_int_attr          = room->roomSearchableIntAttrExternal()->Get(a_index);
+				ptr_int_attr[a_index].id  = fb_int_attr->id();
+				ptr_int_attr[a_index].num = fb_int_attr->num();
+			}
+		}
+
+		if (room->roomSearchableBinAttrExternal() && room->roomSearchableBinAttrExternal()->size() != 0)
+		{
+			room_info->roomSearchableBinAttrExternalNum = room->roomSearchableBinAttrExternal()->size();
+			auto* ptr_bin_attr                          = edata.allocate<SceNpMatching2BinAttr>(sizeof(SceNpMatching2BinAttr) * room_info->roomSearchableBinAttrExternalNum, room_info->roomSearchableBinAttrExternal);
+			BinAttrs_to_SceNpMatching2BinAttrs(edata, room->roomSearchableBinAttrExternal(), ptr_bin_attr);
+		}
+
+		if (room->roomBinAttrExternal() && room->roomBinAttrExternal()->size() != 0)
+		{
+			room_info->roomBinAttrExternalNum = room->roomBinAttrExternal()->size();
+			auto* ptr_bin_attr                = edata.allocate<SceNpMatching2BinAttr>(sizeof(SceNpMatching2BinAttr) * room_info->roomBinAttrExternalNum, room_info->roomBinAttrExternal);
+			BinAttrs_to_SceNpMatching2BinAttrs(edata, room->roomBinAttrExternal(), ptr_bin_attr);
+		}
+	}
+
+	void np_handler::SearchRoomResponse_to_SceNpMatching2SearchRoomResponse(event_data& edata, const SearchRoomResponse* resp, SceNpMatching2SearchRoomResponse* search_resp)
+	{
+		search_resp->range.size       = resp->size();
+		search_resp->range.startIndex = resp->startIndex();
+		search_resp->range.total      = resp->total();
+
+		if (resp->rooms() && resp->rooms()->size() != 0)
+		{
+			SceNpMatching2RoomDataExternal* prev_room = nullptr;
+			for (flatbuffers::uoffset_t i = 0; i < resp->rooms()->size(); i++)
+			{
+				auto* fb_room = resp->rooms()->Get(i);
+				SceNpMatching2RoomDataExternal* cur_room;
+
+				cur_room = (i > 0) ? edata.allocate<SceNpMatching2RoomDataExternal>(sizeof(SceNpMatching2RoomDataExternal), prev_room->next) :
+                                     edata.allocate<SceNpMatching2RoomDataExternal>(sizeof(SceNpMatching2RoomDataExternal), search_resp->roomDataExternal);
+
+				RoomDataExternal_to_SceNpMatching2RoomDataExternal(edata, fb_room, cur_room);
+				prev_room = cur_room;
+			}
+		}
+	}
+
+	void np_handler::GetRoomDataExternalListResponse_to_SceNpMatching2GetRoomDataExternalListResponse(event_data& edata, const GetRoomDataExternalListResponse* resp, SceNpMatching2GetRoomDataExternalListResponse* get_resp)
+	{
+		get_resp->roomDataExternalNum = resp->rooms() ? resp->rooms()->size() : 0;
+
+		SceNpMatching2RoomDataExternal* prev_room = nullptr;
+		for (std::size_t i = 0; i < get_resp->roomDataExternalNum; i++)
+		{
+			auto* fb_room = resp->rooms()->Get(i);
+			SceNpMatching2RoomDataExternal* cur_room;
+
+			cur_room = (i > 0) ? edata.allocate<SceNpMatching2RoomDataExternal>(sizeof(SceNpMatching2RoomDataExternal), prev_room->next) :
+                                 edata.allocate<SceNpMatching2RoomDataExternal>(sizeof(SceNpMatching2RoomDataExternal), get_resp->roomDataExternal);
+
+			RoomDataExternal_to_SceNpMatching2RoomDataExternal(edata, fb_room, cur_room);
+			prev_room = cur_room;
+		}
+	}
+
+	u16 np_handler::RoomDataInternal_to_SceNpMatching2RoomDataInternal(event_data& edata, const RoomDataInternal* resp, SceNpMatching2RoomDataInternal* room_info, const SceNpId& npid)
+	{
+		u16 member_id                    = 0;
+		room_info->serverId              = resp->serverId();
+		room_info->worldId               = resp->worldId();
+		room_info->lobbyId               = resp->lobbyId();
+		room_info->roomId                = resp->roomId();
+		room_info->passwordSlotMask      = resp->passwordSlotMask();
+		room_info->maxSlot               = resp->maxSlot();
+		room_info->memberList.membersNum = resp->memberList()->size();
+
+		if (resp->roomGroup() && resp->roomGroup()->size() != 0)
+		{
+			room_info->roomGroupNum = resp->roomGroup()->size();
+			auto* ptr_groups        = edata.allocate<SceNpMatching2RoomGroup>(sizeof(SceNpMatching2RoomGroup) * room_info->roomGroupNum, room_info->roomGroup);
+			RoomGroups_to_SceNpMatching2RoomGroups(resp->roomGroup(), ptr_groups);
+		}
+
+		room_info->memberList.membersNum = static_cast<u32>(resp->memberList()->size());
+
+		SceNpMatching2RoomMemberDataInternal* prev_member = nullptr;
+		for (flatbuffers::uoffset_t i = 0; i < resp->memberList()->size(); i++)
+		{
+			auto fb_member = resp->memberList()->Get(i);
+			SceNpMatching2RoomMemberDataInternal* member_info;
+
+			member_info = (i > 0) ? edata.allocate<SceNpMatching2RoomMemberDataInternal>(sizeof(SceNpMatching2RoomMemberDataInternal), prev_member->next) :
+                                    edata.allocate<SceNpMatching2RoomMemberDataInternal>(sizeof(SceNpMatching2RoomMemberDataInternal), room_info->memberList.members);
+
+			RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(edata, fb_member, room_info, member_info);
+
+			if (strcmp(member_info->userInfo.npId.handle.data, npid.handle.data) == 0)
+			{
+				room_info->memberList.me = (i > 0) ? prev_member->next : room_info->memberList.members;
+				edata.add_relocation<SceNpMatching2RoomMemberDataInternal>(room_info->memberList.me);
+				member_id = member_info->memberId;
+			}
+
+			if (member_info->memberId == resp->ownerId())
+			{
+				room_info->memberList.owner = (i > 0) ? prev_member->next : room_info->memberList.members;
+				edata.add_relocation<SceNpMatching2RoomMemberDataInternal>(room_info->memberList.owner);
+			}
+
+			prev_member = member_info;
+		}
+
+		room_info->flagAttr = resp->flagAttr();
+
+		if (resp->roomBinAttrInternal() && resp->roomBinAttrInternal()->size() != 0)
+		{
+			room_info->roomBinAttrInternalNum = resp->roomBinAttrInternal()->size();
+			auto* ptr_bin_attr                = edata.allocate<SceNpMatching2RoomBinAttrInternal>(sizeof(SceNpMatching2RoomBinAttrInternal) * room_info->roomBinAttrInternalNum, room_info->roomBinAttrInternal);
+
+			for (u32 b_index = 0; b_index < room_info->roomBinAttrInternalNum; b_index++)
+			{
+				auto fb_bin_attr                      = resp->roomBinAttrInternal()->Get(b_index);
+				ptr_bin_attr[b_index].updateDate.tick = fb_bin_attr->updateDate();
+				ptr_bin_attr[b_index].updateMemberId  = fb_bin_attr->updateMemberId();
+
+				ptr_bin_attr[b_index].data.id   = fb_bin_attr->data()->id();
+				ptr_bin_attr[b_index].data.size = fb_bin_attr->data()->data()->size();
+				auto* ptr_bin_attr_data         = edata.allocate<u8>(ptr_bin_attr[b_index].data.size, ptr_bin_attr[b_index].data.ptr);
+				for (flatbuffers::uoffset_t tmp_index = 0; tmp_index < ptr_bin_attr[b_index].data.size; tmp_index++)
+				{
+					ptr_bin_attr_data[tmp_index] = fb_bin_attr->data()->data()->Get(tmp_index);
+				}
+			}
+		}
+
+		return member_id;
+	}
+
+	void np_handler::RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(event_data& edata, const RoomMemberDataInternal* member_data, const SceNpMatching2RoomDataInternal* room_info, SceNpMatching2RoomMemberDataInternal* sce_member_data)
+	{
+		UserInfo2_to_SceNpUserInfo2(edata, member_data->userInfo(), &sce_member_data->userInfo);
+		sce_member_data->joinDate.tick = member_data->joinDate();
+		sce_member_data->memberId      = member_data->memberId();
+		sce_member_data->teamId        = member_data->teamId();
+
+		if (const auto* fb_roomgroup = member_data->roomGroup())
+		{
+			if (room_info)
+			{
+				// If we have SceNpMatching2RoomDataInternal available we point the pointers to the group there
+				sce_member_data->roomGroup = room_info->roomGroup + (fb_roomgroup->groupId() - 1);
+				edata.add_relocation<SceNpMatching2RoomGroup>(sce_member_data->roomGroup);
 			}
 			else
 			{
-				search_resp->roomDataExternal = room_info;
-			}
-
-			previous_next = vm::cast(room_info.addr());
-
-			RoomDataExternal_to_SceNpMatching2RoomDataExternal(room, room_info.get_ptr());
-		}
-	}
-	else
-	{
-		search_resp->roomDataExternal.set(0);
-	}
-}
-
-void np_handler::GetRoomDataExternalListResponse_to_SceNpMatching2GetRoomDataExternalListResponse(const GetRoomDataExternalListResponse* resp, SceNpMatching2GetRoomDataExternalListResponse* get_resp)
-{
-	get_resp->roomDataExternalNum = resp->rooms() ? resp->rooms()->size() : 0;
-	get_resp->roomDataExternal.set(0);
-
-	vm::addr_t previous_next = vm::cast<u32>(0);
-	for (std::size_t i = 0; i < get_resp->roomDataExternalNum; i++)
-	{
-		auto* room = resp->rooms()->Get(i);
-		vm::ptr<SceNpMatching2RoomDataExternal> room_info(allocate(sizeof(SceNpMatching2RoomDataExternal)));
-
-		if (i > 0)
-		{
-			vm::ptr<SceNpMatching2RoomDataExternal> prev_room(previous_next);
-			prev_room->next.set(room_info.addr());
-		}
-		else
-		{
-			get_resp->roomDataExternal = room_info;
-		}
-
-		previous_next = vm::cast(room_info.addr());
-
-		RoomDataExternal_to_SceNpMatching2RoomDataExternal(room, room_info.get_ptr());
-	}
-}
-
-u16 np_handler::RoomDataInternal_to_SceNpMatching2RoomDataInternal(const RoomDataInternal* resp, SceNpMatching2RoomDataInternal* room_info, const SceNpId& npid)
-{
-	u16 member_id                    = 0;
-	room_info->serverId              = resp->serverId();
-	room_info->worldId               = resp->worldId();
-	room_info->lobbyId               = resp->lobbyId();
-	room_info->roomId                = resp->roomId();
-	room_info->passwordSlotMask      = resp->passwordSlotMask();
-	room_info->maxSlot               = resp->maxSlot();
-	room_info->memberList.membersNum = resp->memberList()->size();
-
-	if (resp->roomGroup() && resp->roomGroup()->size() != 0)
-	{
-		room_info->roomGroupNum = resp->roomGroup()->size();
-		vm::ptr<SceNpMatching2RoomGroup> group_info(allocate(sizeof(SceNpMatching2RoomGroup) * room_info->roomGroupNum));
-		RoomGroups_to_SceNpMatching2RoomGroup(resp->roomGroup(), group_info);
-		room_info->roomGroup = group_info;
-	}
-
-	vm::ptr<SceNpMatching2RoomMemberDataInternal> prev_member;
-	for (flatbuffers::uoffset_t i = 0; i < resp->memberList()->size(); i++)
-	{
-		auto member = resp->memberList()->Get(i);
-		vm::ptr<SceNpMatching2RoomMemberDataInternal> member_info(allocate(sizeof(SceNpMatching2RoomMemberDataInternal)));
-
-		if (i > 0)
-		{
-			prev_member->next = member_info;
-		}
-		else
-		{
-			room_info->memberList.members    = member_info;
-			room_info->memberList.membersNum = static_cast<u32>(resp->memberList()->size());
-		}
-
-		prev_member = member_info;
-		RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(member, room_info, member_info.get_ptr());
-	}
-
-	vm::ptr<SceNpMatching2RoomMemberDataInternal> ptr = room_info->memberList.members;
-	while (ptr)
-	{
-		if (strcmp(ptr->userInfo.npId.handle.data, npid.handle.data) == 0)
-		{
-			room_info->memberList.me = ptr;
-			member_id                = ptr->memberId;
-			break;
-		}
-		ptr = ptr->next;
-	}
-
-	ptr = room_info->memberList.members;
-	while (ptr)
-	{
-		if (ptr->memberId == resp->ownerId())
-		{
-			room_info->memberList.owner = ptr;
-			break;
-		}
-		ptr = ptr->next;
-	}
-
-	room_info->flagAttr = resp->flagAttr();
-
-	if (resp->roomBinAttrInternal() && resp->roomBinAttrInternal()->size() != 0)
-	{
-		room_info->roomBinAttrInternalNum = resp->roomBinAttrInternal()->size();
-		vm::ptr<SceNpMatching2RoomBinAttrInternal> binattrint_info(allocate(sizeof(SceNpMatching2RoomBinAttrInternal) * room_info->roomBinAttrInternalNum));
-
-		for (u32 b_index = 0; b_index < room_info->roomBinAttrInternalNum; b_index++)
-		{
-			auto battr                               = resp->roomBinAttrInternal()->Get(b_index);
-			binattrint_info[b_index].updateDate.tick = battr->updateDate();
-			binattrint_info[b_index].updateMemberId  = battr->updateMemberId();
-
-			binattrint_info[b_index].data.id   = battr->data()->id();
-			binattrint_info[b_index].data.size = battr->data()->data()->size();
-			binattrint_info[b_index].data.ptr  = allocate(binattrint_info[b_index].data.size);
-			for (flatbuffers::uoffset_t tmp_index = 0; tmp_index < binattrint_info[b_index].data.size; tmp_index++)
-			{
-				binattrint_info[b_index].data.ptr[tmp_index] = battr->data()->data()->Get(tmp_index);
+				// Otherwise we allocate for it
+				auto* ptr_group = edata.allocate<SceNpMatching2RoomGroup>(sizeof(SceNpMatching2RoomGroup), sce_member_data->roomGroup);
+				RoomGroup_to_SceNpMatching2RoomGroup(fb_roomgroup, ptr_group);
 			}
 		}
 
-		room_info->roomBinAttrInternal = binattrint_info;
-	}
+		sce_member_data->natType  = member_data->natType();
+		sce_member_data->flagAttr = member_data->flagAttr();
 
-	return member_id;
-}
-
-void np_handler::RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(const RoomMemberDataInternal* member_data, const SceNpMatching2RoomDataInternal* room_info, SceNpMatching2RoomMemberDataInternal* sce_member_data)
-{
-	UserInfo2_to_SceNpUserInfo2(member_data->userInfo(), &sce_member_data->userInfo);
-	sce_member_data->joinDate.tick = member_data->joinDate();
-	sce_member_data->memberId      = member_data->memberId();
-	sce_member_data->teamId        = member_data->teamId();
-
-	// Look for id
-	if (member_data->roomGroup() != 0 && room_info)
-	{
-		bool found = false;
-		for (u32 g_index = 0; g_index < room_info->roomGroupNum; g_index++)
+		if (member_data->roomMemberBinAttrInternal() && member_data->roomMemberBinAttrInternal()->size() != 0)
 		{
-			if (room_info->roomGroup[g_index].groupId == member_data->roomGroup())
+			sce_member_data->roomMemberBinAttrInternalNum = member_data->roomMemberBinAttrInternal()->size();
+			auto* sce_binattrs                            = edata.allocate<SceNpMatching2RoomMemberBinAttrInternal>(sizeof(SceNpMatching2RoomMemberBinAttrInternal) * sce_member_data->roomMemberBinAttrInternalNum, sce_member_data->roomMemberBinAttrInternal);
+			for (u32 b_index = 0; b_index < sce_member_data->roomMemberBinAttrInternalNum; b_index++)
 			{
-				sce_member_data->roomGroup = vm::cast(room_info->roomGroup.addr() + (u32{sizeof(SceNpMatching2RoomGroup)} * g_index));
-				found                      = true;
-				break;
-			}
-		}
-		ensure(found);
-	}
+				const auto fb_battr                   = member_data->roomMemberBinAttrInternal()->Get(b_index);
+				sce_binattrs[b_index].updateDate.tick = fb_battr->updateDate();
 
-	sce_member_data->natType  = member_data->natType();
-	sce_member_data->flagAttr = member_data->flagAttr();
-
-	if (member_data->roomMemberBinAttrInternal() && member_data->roomMemberBinAttrInternal()->size() != 0)
-	{
-		sce_member_data->roomMemberBinAttrInternalNum = member_data->roomMemberBinAttrInternal()->size();
-		vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info(allocate(sizeof(SceNpMatching2RoomMemberBinAttrInternal) * sce_member_data->roomMemberBinAttrInternalNum));
-		for (u32 b_index = 0; b_index < sce_member_data->roomMemberBinAttrInternalNum; b_index++)
-		{
-			const auto battr                      = member_data->roomMemberBinAttrInternal()->Get(b_index);
-			binattr_info[b_index].updateDate.tick = battr->updateDate();
-
-			binattr_info[b_index].data.id   = battr->data()->id();
-			binattr_info[b_index].data.size = battr->data()->data()->size();
-			binattr_info[b_index].data.ptr  = allocate(binattr_info[b_index].data.size);
-			for (flatbuffers::uoffset_t tmp_index = 0; tmp_index < binattr_info[b_index].data.size; tmp_index++)
-			{
-				binattr_info[b_index].data.ptr[tmp_index] = battr->data()->data()->Get(tmp_index);
-			}
-		}
-		sce_member_data->roomMemberBinAttrInternal = binattr_info;
-	}
-}
-
-void np_handler::RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(const RoomMemberUpdateInfo* update_info, SceNpMatching2RoomMemberUpdateInfo* sce_update_info)
-{
-	sce_update_info->eventCause = 0;
-	if (update_info->optData())
-	{
-		sce_update_info->optData.length = update_info->optData()->data()->size();
-		for (usz i = 0; i < 16; i++)
-		{
-			sce_update_info->optData.data[i] = update_info->optData()->data()->Get(i);
-		}
-	}
-
-	if (update_info->roomMemberDataInternal())
-	{
-		auto member = update_info->roomMemberDataInternal();
-		vm::ptr<SceNpMatching2RoomMemberDataInternal> member_info(allocate(sizeof(SceNpMatching2RoomMemberDataInternal)));
-		sce_update_info->roomMemberDataInternal = member_info;
-
-		// TODO: Pass room_info
-		RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(member, nullptr, member_info.get_ptr());
-	}
-}
-
-void np_handler::RoomUpdateInfo_to_SceNpMatching2RoomUpdateInfo(const RoomUpdateInfo* update_info, SceNpMatching2RoomUpdateInfo* sce_update_info)
-{
-	sce_update_info->errorCode  = 0;
-	sce_update_info->eventCause = 0;
-	if (update_info->optData())
-	{
-		sce_update_info->optData.length = update_info->optData()->data()->size();
-		for (usz i = 0; i < 16; i++)
-		{
-			sce_update_info->optData.data[i] = update_info->optData()->data()->Get(i);
-		}
-	}
-}
-
-void np_handler::RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(const RoomDataInternalUpdateInfo* update_info, SceNpMatching2RoomDataInternalUpdateInfo* sce_update_info, const SceNpId& npid)
-{
-	vm::ptr<SceNpMatching2RoomDataInternal> room_data(allocate(sizeof(SceNpMatching2RoomDataInternal)));
-	sce_update_info->newRoomDataInternal = room_data;
-	RoomDataInternal_to_SceNpMatching2RoomDataInternal(update_info->newRoomDataInternal(), sce_update_info->newRoomDataInternal.get_ptr(), npid);
-
-	if (sce_update_info->newRoomDataInternal->flagAttr != update_info->prevFlagAttr())
-	{
-		sce_update_info->newFlagAttr = sce_update_info->newRoomDataInternal.ptr(&SceNpMatching2RoomDataInternal::flagAttr);
-
-		vm::ptr<SceNpMatching2FlagAttr> prev_flag_attr(allocate(sizeof(SceNpMatching2FlagAttr)));
-		*prev_flag_attr               = update_info->prevFlagAttr();
-		sce_update_info->prevFlagAttr = prev_flag_attr;
-	}
-
-	if (sce_update_info->newRoomDataInternal->passwordSlotMask != update_info->prevRoomPasswordSlotMask())
-	{
-		sce_update_info->newRoomPasswordSlotMask = sce_update_info->newRoomDataInternal.ptr(&SceNpMatching2RoomDataInternal::passwordSlotMask);
-
-		vm::ptr<SceNpMatching2RoomPasswordSlotMask> prev_room_password_slot_mask(allocate(sizeof(SceNpMatching2RoomPasswordSlotMask)));
-		*prev_room_password_slot_mask             = update_info->prevRoomPasswordSlotMask();
-		sce_update_info->prevRoomPasswordSlotMask = prev_room_password_slot_mask;
-	}
-
-	if (update_info->newRoomGroup() && update_info->newRoomGroup()->size() != 0)
-	{
-		rpcn_log.todo("RoomDataInternalUpdateInfo::newRoomGroup");
-		// TODO
-		//sce_update_info->newRoomGroupNum = update_info->newRoomGroup()->size();
-		//vm::ptr<SceNpMatching2RoomGroup> group_info(allocate(sizeof(SceNpMatching2RoomGroup) * sce_update_info->newRoomGroupNum));
-		//RoomGroups_to_SceNpMatching2RoomGroup(update_info->newRoomGroup(), group_info);
-		//sce_update_info->newRoomGroup = group_info;
-	}
-
-	if (update_info->newRoomBinAttrInternal() && update_info->newRoomBinAttrInternal()->size() != 0)
-	{
-		const auto get_ptr_for_binattr = [&](u16 binattr_id) -> vm::ptr<SceNpMatching2RoomBinAttrInternal> {
-			vm::ptr<SceNpMatching2RoomBinAttrInternal> ret_ptr = sce_update_info->newRoomDataInternal->roomBinAttrInternal;
-			while (ret_ptr->data.id != binattr_id)
-			{
-				ret_ptr++;
-			}
-			return ret_ptr;
-		};
-
-		sce_update_info->newRoomBinAttrInternalNum = update_info->newRoomBinAttrInternal()->size();
-		vm::bpptr<SceNpMatching2RoomBinAttrInternal> binattr_info_array(allocate(4 * sce_update_info->newRoomBinAttrInternalNum));
-		for (uint i = 0; i < sce_update_info->newRoomBinAttrInternalNum; ++i)
-		{
-			binattr_info_array[i] = get_ptr_for_binattr(update_info->newRoomBinAttrInternal()->Get(i));
-		}
-		sce_update_info->newRoomBinAttrInternal = binattr_info_array;
-	}
-}
-
-void np_handler::RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(const RoomMemberDataInternalUpdateInfo* update_info, SceNpMatching2RoomMemberDataInternalUpdateInfo* sce_update_info)
-{
-	vm::ptr<SceNpMatching2RoomMemberDataInternal> room_member_data(allocate(sizeof(SceNpMatching2RoomMemberDataInternal)));
-	sce_update_info->newRoomMemberDataInternal = room_member_data;
-	RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(update_info->newRoomMemberDataInternal(), nullptr, sce_update_info->newRoomMemberDataInternal.get_ptr());
-
-	if (sce_update_info->newRoomMemberDataInternal->flagAttr != update_info->prevFlagAttr())
-	{
-		sce_update_info->newFlagAttr = sce_update_info->newRoomMemberDataInternal.ptr(&SceNpMatching2RoomMemberDataInternal::flagAttr);
-
-		vm::ptr<SceNpMatching2FlagAttr> prev_flag_attr(allocate(sizeof(SceNpMatching2FlagAttr)));
-		*prev_flag_attr               = update_info->prevFlagAttr();
-		sce_update_info->prevFlagAttr = prev_flag_attr;
-	}
-
-	if (sce_update_info->newRoomMemberDataInternal->teamId != update_info->prevTeamId())
-	{
-		sce_update_info->newTeamId = sce_update_info->newRoomMemberDataInternal.ptr(&SceNpMatching2RoomMemberDataInternal::teamId);
-	}
-	
-	if (update_info->newRoomMemberBinAttrInternal() && update_info->newRoomMemberBinAttrInternal()->size() != 0)
-	{
-		sce_update_info->newRoomMemberBinAttrInternalNum = update_info->newRoomMemberBinAttrInternal()->size();
-		vm::bpptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info_array(allocate(4 * sce_update_info->newRoomMemberBinAttrInternalNum));
-
-		auto get_binattr_vmptr = [&](u16 wanted_id) -> vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> {
-			for (u32 i = 0; i < sce_update_info->newRoomMemberDataInternal->roomMemberBinAttrInternalNum; i++)
-			{
-				if (sce_update_info->newRoomMemberDataInternal->roomMemberBinAttrInternal[i].data.id == wanted_id)
+				sce_binattrs[b_index].data.id   = fb_battr->data()->id();
+				sce_binattrs[b_index].data.size = fb_battr->data()->data()->size();
+				auto* sce_binattr_data          = edata.allocate<u8>(sce_binattrs[b_index].data.size, sce_binattrs[b_index].data.ptr);
+				for (flatbuffers::uoffset_t tmp_index = 0; tmp_index < sce_binattrs[b_index].data.size; tmp_index++)
 				{
-					return sce_update_info->newRoomMemberDataInternal->roomMemberBinAttrInternal + i;
+					sce_binattr_data[tmp_index] = fb_battr->data()->data()->Get(tmp_index);
 				}
 			}
-
-			rpcn_log.fatal("RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo: Invalid data from server!");
-			return vm::null;
-		};
-
-		for (uint i = 0; i < sce_update_info->newRoomMemberBinAttrInternalNum; ++i)
-		{
-			binattr_info_array[i] = get_binattr_vmptr(update_info->newRoomMemberBinAttrInternal()->Get(i));
 		}
-		sce_update_info->newRoomMemberBinAttrInternal = binattr_info_array;
-	}
-}
-
-void np_handler::GetPingInfoResponse_to_SceNpMatching2SignalingGetPingInfoResponse(const GetPingInfoResponse* resp, SceNpMatching2SignalingGetPingInfoResponse* sce_resp)
-{
-	sce_resp->serverId = resp->serverId();
-	sce_resp->worldId  = resp->worldId();
-	sce_resp->roomId   = resp->roomId();
-	sce_resp->rtt      = resp->rtt();
-}
-
-void np_handler::RoomMessageInfo_to_SceNpMatching2RoomMessageInfo(const RoomMessageInfo* mi, SceNpMatching2RoomMessageInfo* sce_mi)
-{
-	sce_mi->filtered = mi->filtered();
-	sce_mi->castType = mi->castType();
-
-	if (sce_mi->castType != SCE_NP_MATCHING2_CASTTYPE_BROADCAST)
-	{
-		vm::ptr<SceNpMatching2RoomMessageDestination> dst_info(allocate(sizeof(SceNpMatching2RoomMessageDestination)));
-		sce_mi->dst = dst_info;
 	}
 
-	switch (sce_mi->castType)
+	void np_handler::RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(event_data& edata, const RoomMemberUpdateInfo* update_info, SceNpMatching2RoomMemberUpdateInfo* sce_update_info)
 	{
-	case SCE_NP_MATCHING2_CASTTYPE_BROADCAST: break;
-	case SCE_NP_MATCHING2_CASTTYPE_UNICAST: sce_mi->dst->unicastTarget = mi->dst()->Get(0); break;
-	case SCE_NP_MATCHING2_CASTTYPE_MULTICAST:
-	{
-		sce_mi->dst->multicastTarget.memberIdNum = mi->dst()->size();
-		vm::ptr<be_t<u16>> member_list(allocate(sizeof(u16) * mi->dst()->size()));
-		sce_mi->dst->multicastTarget.memberId = member_list;
-		for (u32 i = 0; i < mi->dst()->size(); i++)
+		sce_update_info->eventCause = 0;
+		if (update_info->optData())
 		{
-			sce_mi->dst->multicastTarget.memberId[i] = mi->dst()->Get(i);
+			sce_update_info->optData.length = update_info->optData()->data()->size();
+			for (usz i = 0; i < 16; i++)
+			{
+				sce_update_info->optData.data[i] = update_info->optData()->data()->Get(i);
+			}
 		}
-		break;
-	}
-	case SCE_NP_MATCHING2_CASTTYPE_MULTICAST_TEAM: sce_mi->dst->multicastTargetTeamId = mi->dst()->Get(0); break;
-	default: ensure(false);
-	}
 
-	if (auto src_member = mi->srcMember())
-	{
-		vm::ptr<SceNpUserInfo2> src_info(allocate(sizeof(SceNpUserInfo2)));
-		UserInfo2_to_SceNpUserInfo2(src_member, src_info.get_ptr());
-		sce_mi->srcMember = src_info;
-	}
-
-	if (auto msg = mi->msg())
-	{
-		sce_mi->msgLen = msg->size();
-		vm::ptr<u8> msg_data(allocate(msg->size()));
-		for (u32 i = 0; i < msg->size(); i++)
+		if (update_info->roomMemberDataInternal())
 		{
-			msg_data[i] = msg->Get(i);
+			auto fb_member              = update_info->roomMemberDataInternal();
+			auto* ptr_roomemberinternal = edata.allocate<SceNpMatching2RoomMemberDataInternal>(sizeof(SceNpMatching2RoomMemberDataInternal), sce_update_info->roomMemberDataInternal);
+
+			// TODO: Pass room_info
+			RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(edata, fb_member, nullptr, ptr_roomemberinternal);
 		}
-		sce_mi->msg = msg_data;
 	}
-}
+
+	void np_handler::RoomUpdateInfo_to_SceNpMatching2RoomUpdateInfo(const RoomUpdateInfo* update_info, SceNpMatching2RoomUpdateInfo* sce_update_info)
+	{
+		sce_update_info->errorCode  = 0;
+		sce_update_info->eventCause = 0;
+		if (update_info->optData())
+		{
+			sce_update_info->optData.length = update_info->optData()->data()->size();
+			for (usz i = 0; i < 16; i++)
+			{
+				sce_update_info->optData.data[i] = update_info->optData()->data()->Get(i);
+			}
+		}
+	}
+
+	void np_handler::RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(event_data& edata, const RoomDataInternalUpdateInfo* update_info, SceNpMatching2RoomDataInternalUpdateInfo* sce_update_info, const SceNpId& npid)
+	{
+		auto* sce_room_data = edata.allocate<SceNpMatching2RoomDataInternal>(sizeof(SceNpMatching2RoomDataInternal), sce_update_info->newRoomDataInternal);
+		RoomDataInternal_to_SceNpMatching2RoomDataInternal(edata, update_info->newRoomDataInternal(), sce_room_data, npid);
+
+		if (sce_room_data->flagAttr != update_info->prevFlagAttr())
+		{
+			sce_update_info->newFlagAttr = sce_update_info->newRoomDataInternal.ptr(&SceNpMatching2RoomDataInternal::flagAttr);
+			edata.add_relocation<u32>(sce_update_info->newFlagAttr);
+			auto* ptr_sce_prevflag = edata.allocate<SceNpMatching2FlagAttr>(sizeof(SceNpMatching2FlagAttr), sce_update_info->prevFlagAttr);
+			*ptr_sce_prevflag      = update_info->prevFlagAttr();
+		}
+
+		if (sce_room_data->passwordSlotMask != update_info->prevRoomPasswordSlotMask())
+		{
+			sce_update_info->newRoomPasswordSlotMask = sce_update_info->newRoomDataInternal.ptr(&SceNpMatching2RoomDataInternal::passwordSlotMask);
+			edata.add_relocation<u64>(sce_update_info->newRoomPasswordSlotMask);
+			auto* ptr_sce_prevpass = edata.allocate<SceNpMatching2RoomPasswordSlotMask>(sizeof(SceNpMatching2RoomPasswordSlotMask), sce_update_info->prevRoomPasswordSlotMask);
+			*ptr_sce_prevpass      = update_info->prevRoomPasswordSlotMask();
+		}
+
+		if (update_info->newRoomGroup() && update_info->newRoomGroup()->size() != 0)
+		{
+			rpcn_log.todo("RoomDataInternalUpdateInfo::newRoomGroup");
+			// TODO
+			//sce_update_info->newRoomGroupNum = update_info->newRoomGroup()->size();
+			//vm::ptr<SceNpMatching2RoomGroup> group_info(allocate(sizeof(SceNpMatching2RoomGroup) * sce_update_info->newRoomGroupNum));
+			//RoomGroups_to_SceNpMatching2RoomGroup(update_info->newRoomGroup(), group_info);
+			//sce_update_info->newRoomGroup = group_info;
+		}
+
+		if (update_info->newRoomBinAttrInternal() && update_info->newRoomBinAttrInternal()->size() != 0)
+		{
+			const auto get_ptr_for_binattr = [&](u16 binattr_id) -> vm::bptr<SceNpMatching2RoomBinAttrInternal>
+			{
+				vm::bptr<SceNpMatching2RoomBinAttrInternal> ret_ptr = sce_room_data->roomBinAttrInternal;
+				for (u32 i = 0; i < sce_room_data->roomBinAttrInternalNum; i++)
+				{
+					if (ret_ptr->data.id == binattr_id)
+						return ret_ptr;
+					
+					ret_ptr++;
+				}
+				rpcn_log.fatal("RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo: Couldn't find matching roomBinAttrInternal!");
+				return vm::null;
+			};
+
+			sce_update_info->newRoomBinAttrInternalNum = update_info->newRoomBinAttrInternal()->size();
+			edata.allocate_ptr_array<SceNpMatching2RoomBinAttrInternal>(sce_update_info->newRoomBinAttrInternalNum, sce_update_info->newRoomBinAttrInternal);
+			for (u32 i = 0; i < sce_update_info->newRoomBinAttrInternalNum; i++)
+			{
+				sce_update_info->newRoomBinAttrInternal[i] = get_ptr_for_binattr(update_info->newRoomBinAttrInternal()->Get(i));
+			}
+		}
+	}
+
+	void np_handler::RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(event_data &edata, const RoomMemberDataInternalUpdateInfo* update_info, SceNpMatching2RoomMemberDataInternalUpdateInfo* sce_update_info)
+	{
+		auto* sce_room_member_data = edata.allocate<SceNpMatching2RoomMemberDataInternal>(sizeof(SceNpMatching2RoomMemberDataInternal), sce_update_info->newRoomMemberDataInternal);
+		RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(edata, update_info->newRoomMemberDataInternal(), nullptr, sce_room_member_data);
+
+		if (sce_update_info->newRoomMemberDataInternal->flagAttr != update_info->prevFlagAttr())
+		{
+			sce_update_info->newFlagAttr = sce_update_info->newRoomMemberDataInternal.ptr(&SceNpMatching2RoomMemberDataInternal::flagAttr);
+			edata.add_relocation<u32>(sce_update_info->newFlagAttr);
+			auto* ptr_sce_prevflag = edata.allocate<SceNpMatching2FlagAttr>(sizeof(SceNpMatching2FlagAttr), sce_update_info->prevFlagAttr);
+			*ptr_sce_prevflag      = update_info->prevFlagAttr();
+		}
+
+		if (sce_update_info->newRoomMemberDataInternal->teamId != update_info->prevTeamId())
+		{
+			sce_update_info->newTeamId = sce_update_info->newRoomMemberDataInternal.ptr(&SceNpMatching2RoomMemberDataInternal::teamId);
+			edata.add_relocation<u8>(sce_update_info->newTeamId);
+		}
+
+		if (update_info->newRoomMemberBinAttrInternal() && update_info->newRoomMemberBinAttrInternal()->size() != 0)
+		{
+			const auto get_ptr_for_binattr = [&](u16 binattr_id) -> vm::bptr<SceNpMatching2RoomMemberBinAttrInternal>
+			{
+				vm::bptr<SceNpMatching2RoomMemberBinAttrInternal> ret_ptr = sce_room_member_data->roomMemberBinAttrInternal;
+				for (u32 i = 0; i < sce_room_member_data->roomMemberBinAttrInternalNum; i++)
+				{
+					if (ret_ptr->data.id == binattr_id)
+						return ret_ptr;
+					
+					ret_ptr++;
+				}
+				rpcn_log.fatal("RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo: Couldn't find matching roomMemberBinAttrInternal!");
+				return vm::null;
+			};
+
+			sce_update_info->newRoomMemberBinAttrInternalNum = update_info->newRoomMemberBinAttrInternal()->size();
+			edata.allocate_ptr_array<SceNpMatching2RoomMemberBinAttrInternal>(sce_update_info->newRoomMemberBinAttrInternalNum, sce_update_info->newRoomMemberBinAttrInternal);
+			for (u32 i = 0; i < sce_update_info->newRoomMemberBinAttrInternalNum; i++)
+			{
+				sce_update_info->newRoomMemberBinAttrInternal[i] = get_ptr_for_binattr(update_info->newRoomMemberBinAttrInternal()->Get(i));
+			}
+		}
+	}
+
+	void np_handler::GetPingInfoResponse_to_SceNpMatching2SignalingGetPingInfoResponse(const GetPingInfoResponse* resp, SceNpMatching2SignalingGetPingInfoResponse* sce_resp)
+	{
+		sce_resp->serverId = resp->serverId();
+		sce_resp->worldId  = resp->worldId();
+		sce_resp->roomId   = resp->roomId();
+		sce_resp->rtt      = resp->rtt();
+	}
+
+	void np_handler::RoomMessageInfo_to_SceNpMatching2RoomMessageInfo(event_data& edata, const RoomMessageInfo* mi, SceNpMatching2RoomMessageInfo* sce_mi)
+	{
+		sce_mi->filtered = mi->filtered();
+		sce_mi->castType = mi->castType();
+
+		if (sce_mi->castType != SCE_NP_MATCHING2_CASTTYPE_BROADCAST)
+		{
+			edata.allocate<SceNpMatching2RoomMessageDestination>(sizeof(SceNpMatching2RoomMessageDestination), sce_mi->dst);
+		}
+
+		switch (sce_mi->castType)
+		{
+		case SCE_NP_MATCHING2_CASTTYPE_BROADCAST: break;
+		case SCE_NP_MATCHING2_CASTTYPE_UNICAST: sce_mi->dst->unicastTarget = mi->dst()->Get(0); break;
+		case SCE_NP_MATCHING2_CASTTYPE_MULTICAST:
+		{
+			sce_mi->dst->multicastTarget.memberIdNum = mi->dst()->size();
+			edata.allocate<u16>(sizeof(u16) * mi->dst()->size(), sce_mi->dst->multicastTarget.memberId);
+			for (u32 i = 0; i < mi->dst()->size(); i++)
+			{
+				sce_mi->dst->multicastTarget.memberId[i] = mi->dst()->Get(i);
+			}
+			break;
+		}
+		case SCE_NP_MATCHING2_CASTTYPE_MULTICAST_TEAM: sce_mi->dst->multicastTargetTeamId = mi->dst()->Get(0); break;
+		default: ensure(false);
+		}
+
+		if (auto src_member = mi->srcMember())
+		{
+			auto* ptr_sce_userinfo = edata.allocate<SceNpUserInfo2>(sizeof(SceNpUserInfo2), sce_mi->srcMember);
+			UserInfo2_to_SceNpUserInfo2(edata, src_member, ptr_sce_userinfo);
+		}
+
+		if (auto msg = mi->msg())
+		{
+			sce_mi->msgLen = msg->size();
+			auto* ptr_msg_data = static_cast<u8 *>(edata.allocate<void>(msg->size(), sce_mi->msg));
+			for (u32 i = 0; i < msg->size(); i++)
+			{
+				ptr_msg_data[i] = msg->Get(i);
+			}
+		}
+	}
+
+} // namespace np

--- a/rpcs3/Emu/NP/fb_helpers.cpp
+++ b/rpcs3/Emu/NP/fb_helpers.cpp
@@ -3,22 +3,42 @@
 
 LOG_CHANNEL(rpcn_log, "rpcn");
 
-void np_handler::BinAttr_to_SceNpMatching2BinAttr(const flatbuffers::Vector<flatbuffers::Offset<BinAttr>>* fb_attr, vm::ptr<SceNpMatching2BinAttr> binattr_info)
+void np_handler::BinAttr_to_SceNpMatching2BinAttr(const BinAttr* bin_attr, SceNpMatching2BinAttr* binattr_info)
 {
-	for (flatbuffers::uoffset_t i = 0; i < fb_attr->size(); i++)
+	binattr_info->id   = bin_attr->id();
+	binattr_info->size = bin_attr->data()->size();
+	binattr_info->ptr  = allocate(binattr_info->size);
+	for (flatbuffers::uoffset_t i = 0; i < bin_attr->data()->size(); i++)
 	{
-		auto bin_attr        = fb_attr->Get(i);
-		binattr_info[i].id   = bin_attr->id();
-		binattr_info[i].size = bin_attr->data()->size();
-		binattr_info[i].ptr  = allocate(binattr_info[i].size);
-		for (flatbuffers::uoffset_t tmp_index = 0; tmp_index < bin_attr->data()->size(); tmp_index++)
-		{
-			binattr_info[i].ptr[tmp_index] = bin_attr->data()->Get(tmp_index);
-		}
+		binattr_info->ptr[i] = bin_attr->data()->Get(i);
 	}
 }
 
-void np_handler::RoomGroup_to_SceNpMatching2RoomGroup(const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>* fb_group, vm::ptr<SceNpMatching2RoomGroup> group_info)
+void np_handler::BinAttrs_to_SceNpMatching2BinAttr(const flatbuffers::Vector<flatbuffers::Offset<BinAttr>>* fb_attr, vm::ptr<SceNpMatching2BinAttr> binattr_info)
+{
+	for (flatbuffers::uoffset_t i = 0; i < fb_attr->size(); i++)
+	{
+		auto fb_attr_this      = fb_attr->Get(i);
+		auto binattr_info_this = binattr_info + i;
+
+		BinAttr_to_SceNpMatching2BinAttr(fb_attr_this, binattr_info_this.get_ptr());
+	}
+}
+
+void np_handler::RoomMemberBinAttrInternal_to_SceNpMatching2RoomMemberBinAttrInternal(const RoomMemberBinAttrInternal* fb_attr, vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info)
+{
+	binattr_info->updateDate.tick = fb_attr->updateDate();
+	BinAttr_to_SceNpMatching2BinAttr(fb_attr->data(), &binattr_info->data);
+}
+
+void np_handler::RoomBinAttrInternal_to_SceNpMatching2RoomBinAttrInternal(const BinAttrInternal* fb_attr, vm::ptr<SceNpMatching2RoomBinAttrInternal> binattr_info)
+{
+	binattr_info->updateDate.tick = fb_attr->updateDate();
+	binattr_info->updateMemberId  = fb_attr->updateMemberId();
+	BinAttr_to_SceNpMatching2BinAttr(fb_attr->data(), &binattr_info->data);
+}
+
+void np_handler::RoomGroups_to_SceNpMatching2RoomGroup(const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>* fb_group, vm::ptr<SceNpMatching2RoomGroup> group_info)
 {
 	for (flatbuffers::uoffset_t i = 0; i < fb_group->size(); i++)
 	{
@@ -68,7 +88,7 @@ void np_handler::RoomDataExternal_to_SceNpMatching2RoomDataExternal(const RoomDa
 	room_info->openPrivateSlotNum = room->openPrivateSlotNum();
 	room_info->curMemberNum       = room->curMemberNum();
 	room_info->passwordSlotMask   = room->passwordSlotMask();
-	
+
 	if (auto owner = room->owner())
 	{
 		vm::ptr<SceNpUserInfo2> owner_info(allocate(sizeof(SceNpUserInfo2)));
@@ -80,7 +100,7 @@ void np_handler::RoomDataExternal_to_SceNpMatching2RoomDataExternal(const RoomDa
 	{
 		room_info->roomGroupNum = room->roomGroup()->size();
 		vm::ptr<SceNpMatching2RoomGroup> group_info(allocate(sizeof(SceNpMatching2RoomGroup) * room_info->roomGroupNum));
-		RoomGroup_to_SceNpMatching2RoomGroup(room->roomGroup(), group_info);
+		RoomGroups_to_SceNpMatching2RoomGroup(room->roomGroup(), group_info);
 		room_info->roomGroup = group_info;
 	}
 
@@ -103,7 +123,7 @@ void np_handler::RoomDataExternal_to_SceNpMatching2RoomDataExternal(const RoomDa
 	{
 		room_info->roomSearchableBinAttrExternalNum = room->roomSearchableBinAttrExternal()->size();
 		vm::ptr<SceNpMatching2BinAttr> binattr_info(allocate(sizeof(SceNpMatching2BinAttr) * room_info->roomSearchableBinAttrExternalNum));
-		BinAttr_to_SceNpMatching2BinAttr(room->roomSearchableBinAttrExternal(), binattr_info);
+		BinAttrs_to_SceNpMatching2BinAttr(room->roomSearchableBinAttrExternal(), binattr_info);
 		room_info->roomSearchableBinAttrExternal = binattr_info;
 	}
 
@@ -111,7 +131,7 @@ void np_handler::RoomDataExternal_to_SceNpMatching2RoomDataExternal(const RoomDa
 	{
 		room_info->roomBinAttrExternalNum = room->roomBinAttrExternal()->size();
 		vm::ptr<SceNpMatching2BinAttr> binattr_info(allocate(sizeof(SceNpMatching2BinAttr) * room_info->roomBinAttrExternalNum));
-		BinAttr_to_SceNpMatching2BinAttr(room->roomBinAttrExternal(), binattr_info);
+		BinAttrs_to_SceNpMatching2BinAttr(room->roomBinAttrExternal(), binattr_info);
 		room_info->roomBinAttrExternal = binattr_info;
 	}
 }
@@ -193,7 +213,7 @@ u16 np_handler::RoomDataInternal_to_SceNpMatching2RoomDataInternal(const RoomDat
 	{
 		room_info->roomGroupNum = resp->roomGroup()->size();
 		vm::ptr<SceNpMatching2RoomGroup> group_info(allocate(sizeof(SceNpMatching2RoomGroup) * room_info->roomGroupNum));
-		RoomGroup_to_SceNpMatching2RoomGroup(resp->roomGroup(), group_info);
+		RoomGroups_to_SceNpMatching2RoomGroup(resp->roomGroup(), group_info);
 		room_info->roomGroup = group_info;
 	}
 
@@ -214,49 +234,7 @@ u16 np_handler::RoomDataInternal_to_SceNpMatching2RoomDataInternal(const RoomDat
 		}
 
 		prev_member = member_info;
-
-		UserInfo2_to_SceNpUserInfo2(member->userInfo(), &member_info->userInfo);
-		member_info->joinDate.tick = member->joinDate();
-		member_info->memberId      = member->memberId();
-		member_info->teamId        = member->teamId();
-
-		// Look for id
-		if (member->roomGroup() != 0)
-		{
-			bool found = false;
-			for (u32 g_index = 0; g_index < room_info->roomGroupNum; g_index++)
-			{
-				if (room_info->roomGroup[g_index].groupId == member->roomGroup())
-				{
-					member_info->roomGroup = vm::cast(room_info->roomGroup.addr() + (u32{sizeof(SceNpMatching2RoomGroup)} * g_index));
-					found                  = true;
-				}
-			}
-			ensure(found);
-		}
-
-		member_info->natType  = member->natType();
-		member_info->flagAttr = member->flagAttr();
-
-		if (member->roomMemberBinAttrInternal() && member->roomMemberBinAttrInternal()->size() != 0)
-		{
-			member_info->roomMemberBinAttrInternalNum = member->roomMemberBinAttrInternal()->size();
-			vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info(allocate(sizeof(SceNpMatching2RoomMemberBinAttrInternal) * member_info->roomMemberBinAttrInternalNum));
-			for (u32 b_index = 0; b_index < member_info->roomMemberBinAttrInternalNum; b_index++)
-			{
-				const auto battr                      = member->roomMemberBinAttrInternal()->Get(b_index);
-				binattr_info[b_index].updateDate.tick = battr->updateDate();
-
-				binattr_info[b_index].data.id   = battr->data()->id();
-				binattr_info[b_index].data.size = battr->data()->data()->size();
-				binattr_info[b_index].data.ptr  = allocate(binattr_info[b_index].data.size);
-				for (flatbuffers::uoffset_t tmp_index = 0; tmp_index < binattr_info[b_index].data.size; tmp_index++)
-				{
-					binattr_info[b_index].data.ptr[tmp_index] = battr->data()->data()->Get(tmp_index);
-				}
-			}
-			member_info->roomMemberBinAttrInternal = binattr_info;
-		}
+		RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(member, room_info, member_info.get_ptr());
 	}
 
 	vm::ptr<SceNpMatching2RoomMemberDataInternal> ptr = room_info->memberList.members;
@@ -310,6 +288,53 @@ u16 np_handler::RoomDataInternal_to_SceNpMatching2RoomDataInternal(const RoomDat
 	return member_id;
 }
 
+void np_handler::RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(const RoomMemberDataInternal* member_data, const SceNpMatching2RoomDataInternal* room_info, SceNpMatching2RoomMemberDataInternal* sce_member_data)
+{
+	UserInfo2_to_SceNpUserInfo2(member_data->userInfo(), &sce_member_data->userInfo);
+	sce_member_data->joinDate.tick = member_data->joinDate();
+	sce_member_data->memberId      = member_data->memberId();
+	sce_member_data->teamId        = member_data->teamId();
+
+	// Look for id
+	if (member_data->roomGroup() != 0 && room_info)
+	{
+		bool found = false;
+		for (u32 g_index = 0; g_index < room_info->roomGroupNum; g_index++)
+		{
+			if (room_info->roomGroup[g_index].groupId == member_data->roomGroup())
+			{
+				sce_member_data->roomGroup = vm::cast(room_info->roomGroup.addr() + (u32{sizeof(SceNpMatching2RoomGroup)} * g_index));
+				found                      = true;
+				break;
+			}
+		}
+		ensure(found);
+	}
+
+	sce_member_data->natType  = member_data->natType();
+	sce_member_data->flagAttr = member_data->flagAttr();
+
+	if (member_data->roomMemberBinAttrInternal() && member_data->roomMemberBinAttrInternal()->size() != 0)
+	{
+		sce_member_data->roomMemberBinAttrInternalNum = member_data->roomMemberBinAttrInternal()->size();
+		vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info(allocate(sizeof(SceNpMatching2RoomMemberBinAttrInternal) * sce_member_data->roomMemberBinAttrInternalNum));
+		for (u32 b_index = 0; b_index < sce_member_data->roomMemberBinAttrInternalNum; b_index++)
+		{
+			const auto battr                      = member_data->roomMemberBinAttrInternal()->Get(b_index);
+			binattr_info[b_index].updateDate.tick = battr->updateDate();
+
+			binattr_info[b_index].data.id   = battr->data()->id();
+			binattr_info[b_index].data.size = battr->data()->data()->size();
+			binattr_info[b_index].data.ptr  = allocate(binattr_info[b_index].data.size);
+			for (flatbuffers::uoffset_t tmp_index = 0; tmp_index < binattr_info[b_index].data.size; tmp_index++)
+			{
+				binattr_info[b_index].data.ptr[tmp_index] = battr->data()->data()->Get(tmp_index);
+			}
+		}
+		sce_member_data->roomMemberBinAttrInternal = binattr_info;
+	}
+}
+
 void np_handler::RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(const RoomMemberUpdateInfo* update_info, SceNpMatching2RoomMemberUpdateInfo* sce_update_info)
 {
 	sce_update_info->eventCause = 0;
@@ -328,36 +353,8 @@ void np_handler::RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(cons
 		vm::ptr<SceNpMatching2RoomMemberDataInternal> member_info(allocate(sizeof(SceNpMatching2RoomMemberDataInternal)));
 		sce_update_info->roomMemberDataInternal = member_info;
 
-		UserInfo2_to_SceNpUserInfo2(member->userInfo(), &member_info->userInfo);
-		member_info->joinDate.tick = member->joinDate();
-		member_info->memberId      = member->memberId();
-		member_info->teamId        = member->teamId();
-
-		// Look for id
-		// TODO
-
-		member_info->natType  = member->natType();
-		member_info->flagAttr = member->flagAttr();
-
-		if (member->roomMemberBinAttrInternal() && member->roomMemberBinAttrInternal()->size() != 0)
-		{
-			member_info->roomMemberBinAttrInternalNum = member->roomMemberBinAttrInternal()->size();
-			vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info(allocate(sizeof(SceNpMatching2RoomMemberBinAttrInternal) * member_info->roomMemberBinAttrInternalNum));
-			for (u32 b_index = 0; b_index < member_info->roomMemberBinAttrInternalNum; b_index++)
-			{
-				const auto battr                      = member->roomMemberBinAttrInternal()->Get(b_index);
-				binattr_info[b_index].updateDate.tick = battr->updateDate();
-
-				binattr_info[b_index].data.id   = battr->data()->id();
-				binattr_info[b_index].data.size = battr->data()->data()->size();
-				binattr_info[b_index].data.ptr  = allocate(binattr_info[b_index].data.size);
-				for (flatbuffers::uoffset_t tmp_index = 0; tmp_index < binattr_info[b_index].data.size; tmp_index++)
-				{
-					binattr_info[b_index].data.ptr[tmp_index] = battr->data()->data()->Get(tmp_index);
-				}
-			}
-			member_info->roomMemberBinAttrInternal = binattr_info;
-		}
+		// TODO: Pass room_info
+		RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(member, nullptr, member_info.get_ptr());
 	}
 }
 
@@ -372,6 +369,100 @@ void np_handler::RoomUpdateInfo_to_SceNpMatching2RoomUpdateInfo(const RoomUpdate
 		{
 			sce_update_info->optData.data[i] = update_info->optData()->data()->Get(i);
 		}
+	}
+}
+
+void np_handler::RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(const RoomDataInternalUpdateInfo* update_info, SceNpMatching2RoomDataInternalUpdateInfo* sce_update_info, const SceNpId& npid)
+{
+	vm::ptr<SceNpMatching2RoomDataInternal> room_data(allocate(sizeof(SceNpMatching2RoomDataInternal)));
+	sce_update_info->newRoomDataInternal = room_data;
+	RoomDataInternal_to_SceNpMatching2RoomDataInternal(update_info->newRoomDataInternal(), sce_update_info->newRoomDataInternal.get_ptr(), npid);
+
+	if (update_info->newFlagAttr() == update_info->prevFlagAttr())
+	{
+		sce_update_info->newFlagAttr.set(0);
+		sce_update_info->prevFlagAttr.set(0);
+	}
+	else
+	{
+		sce_update_info->newFlagAttr = sce_update_info->newRoomDataInternal.ptr(&SceNpMatching2RoomDataInternal::flagAttr);
+
+		vm::ptr<SceNpMatching2FlagAttr> prev_flag_attr(allocate(sizeof(SceNpMatching2FlagAttr)));
+		*prev_flag_attr               = update_info->prevFlagAttr();
+		sce_update_info->prevFlagAttr = prev_flag_attr;
+	}
+
+	if (update_info->newRoomPasswordSlotMask() == update_info->prevRoomPasswordSlotMask())
+	{
+		sce_update_info->newRoomPasswordSlotMask.set(0);
+		sce_update_info->prevRoomPasswordSlotMask.set(0);
+	}
+	else
+	{
+		sce_update_info->newRoomPasswordSlotMask = sce_update_info->newRoomDataInternal.ptr(&SceNpMatching2RoomDataInternal::passwordSlotMask);
+
+		vm::ptr<SceNpMatching2RoomPasswordSlotMask> prev_room_password_slot_mask(allocate(sizeof(SceNpMatching2RoomPasswordSlotMask)));
+		*prev_room_password_slot_mask             = update_info->prevRoomPasswordSlotMask();
+		sce_update_info->prevRoomPasswordSlotMask = prev_room_password_slot_mask;
+	}
+
+	if (update_info->newRoomGroup() && update_info->newRoomGroup()->size() != 0)
+	{
+		rpcn_log.todo("RoomDataInternalUpdateInfo::newRoomGroup");
+		// TODO
+		//sce_update_info->newRoomGroupNum = update_info->newRoomGroup()->size();
+		//vm::ptr<SceNpMatching2RoomGroup> group_info(allocate(sizeof(SceNpMatching2RoomGroup) * sce_update_info->newRoomGroupNum));
+		//RoomGroups_to_SceNpMatching2RoomGroup(update_info->newRoomGroup(), group_info);
+		//sce_update_info->newRoomGroup = group_info;
+	}
+
+	if (update_info->newRoomBinAttrInternal() && update_info->newRoomBinAttrInternal()->size() != 0)
+	{
+		sce_update_info->newRoomBinAttrInternalNum = update_info->newRoomBinAttrInternal()->size();
+		vm::bpptr<SceNpMatching2RoomBinAttrInternal> binattr_info_array(allocate(4 * sce_update_info->newRoomBinAttrInternalNum));
+		for (uint i = 0; i < sce_update_info->newRoomBinAttrInternalNum; ++i)
+		{
+			vm::ptr<SceNpMatching2RoomBinAttrInternal> binattr_info = allocate(sizeof(SceNpMatching2RoomBinAttrInternal) * sce_update_info->newRoomBinAttrInternalNum);
+			binattr_info_array[i]                                   = binattr_info;
+			RoomBinAttrInternal_to_SceNpMatching2RoomBinAttrInternal(update_info->newRoomBinAttrInternal()->Get(i), binattr_info);
+		}
+		sce_update_info->newRoomBinAttrInternal = binattr_info_array;
+	}
+}
+
+void np_handler::RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(const RoomMemberDataInternalUpdateInfo* update_info, SceNpMatching2RoomMemberDataInternalUpdateInfo* sce_update_info)
+{
+	vm::ptr<SceNpMatching2RoomMemberDataInternal> room_member_data(allocate(sizeof(SceNpMatching2RoomMemberDataInternal)));
+	sce_update_info->newRoomMemberDataInternal = room_member_data;
+	RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(update_info->newRoomMemberDataInternal(), nullptr, sce_update_info->newRoomMemberDataInternal.get_ptr());
+
+	if (update_info->newFlagAttr() == update_info->prevFlagAttr())
+	{
+		sce_update_info->newFlagAttr.set(0);
+		sce_update_info->prevFlagAttr.set(0);
+	}
+	else
+	{
+		sce_update_info->newFlagAttr = sce_update_info->newRoomMemberDataInternal.ptr(&SceNpMatching2RoomMemberDataInternal::flagAttr);
+
+		vm::ptr<SceNpMatching2FlagAttr> prev_flag_attr(allocate(sizeof(SceNpMatching2FlagAttr)));
+		*prev_flag_attr               = update_info->prevFlagAttr();
+		sce_update_info->prevFlagAttr = prev_flag_attr;
+	}
+
+	sce_update_info->newTeamId = sce_update_info->newRoomMemberDataInternal.ptr(&SceNpMatching2RoomMemberDataInternal::teamId);
+
+	if (update_info->newRoomMemberBinAttrInternal() && update_info->newRoomMemberBinAttrInternal()->size() != 0)
+	{
+		sce_update_info->newRoomMemberBinAttrInternalNum = update_info->newRoomMemberBinAttrInternal()->size();
+		vm::bpptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info_array(allocate(4 * sce_update_info->newRoomMemberBinAttrInternalNum));
+		for (uint i = 0; i < sce_update_info->newRoomMemberBinAttrInternalNum; ++i)
+		{
+			vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info = allocate(sizeof(SceNpMatching2RoomMemberBinAttrInternal) * sce_update_info->newRoomMemberBinAttrInternalNum);
+			binattr_info_array[i]                                         = binattr_info;
+			RoomMemberBinAttrInternal_to_SceNpMatching2RoomMemberBinAttrInternal(update_info->newRoomMemberBinAttrInternal()->Get(i), binattr_info);
+		}
+		sce_update_info->newRoomMemberBinAttrInternal = binattr_info_array;
 	}
 }
 

--- a/rpcs3/Emu/NP/generated/np2_structs.fbs
+++ b/rpcs3/Emu/NP/generated/np2_structs.fbs
@@ -43,7 +43,7 @@ table RoomMemberDataInternal {
     joinDate:uint64;
     memberId:uint16;
     teamId:uint8;
-    roomGroup:uint8;
+    roomGroup:RoomGroup;
     natType:uint8;
     flagAttr:uint32;
     roomMemberBinAttrInternal:[RoomMemberBinAttrInternal];

--- a/rpcs3/Emu/NP/generated/np2_structs.fbs
+++ b/rpcs3/Emu/NP/generated/np2_structs.fbs
@@ -8,7 +8,7 @@ table IntAttr {
     num:uint32;
 }
 
-table MemberBinAttrInternal {
+table RoomMemberBinAttrInternal {
     updateDate:uint64;
     data:BinAttr;
 }
@@ -46,7 +46,7 @@ table RoomMemberDataInternal {
     roomGroup:uint8;
     natType:uint8;
     flagAttr:uint32;
-    roomMemberBinAttrInternal:[MemberBinAttrInternal];
+    roomMemberBinAttrInternal:[RoomMemberBinAttrInternal];
 }
 
 table RoomGroup {
@@ -193,6 +193,15 @@ table SetRoomDataInternalRequest {
     ownerPrivilegeRank:[uint16];
 }
 
+table SetRoomMemberDataInternalRequest {
+    roomId:uint64;
+    memberId:uint16;
+    teamId:uint8;
+    flagFilter:uint32;
+    flagAttr:uint32;
+    roomMemberBinAttrInternal:[BinAttr];
+}
+
 table GetRoomDataInternalRequest {
     roomId:uint64;
     attrId:[uint16];
@@ -208,6 +217,24 @@ table RoomUpdateInfo {
     eventCause:uint8;
     errorCode:int32;
     optData:PresenceOptionData;
+}
+
+table RoomDataInternalUpdateInfo {
+    newRoomDataInternal:RoomDataInternal;
+    newFlagAttr:uint32;
+    prevFlagAttr:uint32;
+    newRoomPasswordSlotMask:uint64;
+    prevRoomPasswordSlotMask:uint64;
+    newRoomGroup:[RoomGroup];
+    newRoomBinAttrInternal:[BinAttrInternal];
+}
+
+table RoomMemberDataInternalUpdateInfo {
+    newRoomMemberDataInternal:RoomMemberDataInternal;
+    newFlagAttr:uint32;
+    prevFlagAttr:uint32;
+    newTeamId:uint8;
+    newRoomMemberBinAttrInternal:[RoomMemberBinAttrInternal];
 }
 
 table GetPingInfoResponse {

--- a/rpcs3/Emu/NP/generated/np2_structs.fbs
+++ b/rpcs3/Emu/NP/generated/np2_structs.fbs
@@ -197,8 +197,6 @@ table SetRoomMemberDataInternalRequest {
     roomId:uint64;
     memberId:uint16;
     teamId:uint8;
-    flagFilter:uint32;
-    flagAttr:uint32;
     roomMemberBinAttrInternal:[BinAttr];
 }
 
@@ -221,20 +219,17 @@ table RoomUpdateInfo {
 
 table RoomDataInternalUpdateInfo {
     newRoomDataInternal:RoomDataInternal;
-    newFlagAttr:uint32;
     prevFlagAttr:uint32;
-    newRoomPasswordSlotMask:uint64;
     prevRoomPasswordSlotMask:uint64;
-    newRoomGroup:[RoomGroup];
-    newRoomBinAttrInternal:[BinAttrInternal];
+    newRoomGroup:[uint8];
+    newRoomBinAttrInternal:[uint16];
 }
 
 table RoomMemberDataInternalUpdateInfo {
     newRoomMemberDataInternal:RoomMemberDataInternal;
-    newFlagAttr:uint32;
     prevFlagAttr:uint32;
-    newTeamId:uint8;
-    newRoomMemberBinAttrInternal:[RoomMemberBinAttrInternal];
+    prevTeamId:uint8;
+    newRoomMemberBinAttrInternal:[uint16];
 }
 
 table GetPingInfoResponse {

--- a/rpcs3/Emu/NP/generated/np2_structs_generated.h
+++ b/rpcs3/Emu/NP/generated/np2_structs_generated.h
@@ -2514,9 +2514,7 @@ struct SetRoomMemberDataInternalRequest FLATBUFFERS_FINAL_CLASS : private flatbu
     VT_ROOMID = 4,
     VT_MEMBERID = 6,
     VT_TEAMID = 8,
-    VT_FLAGFILTER = 10,
-    VT_FLAGATTR = 12,
-    VT_ROOMMEMBERBINATTRINTERNAL = 14
+    VT_ROOMMEMBERBINATTRINTERNAL = 10
   };
   uint64_t roomId() const {
     return GetField<uint64_t>(VT_ROOMID, 0);
@@ -2527,12 +2525,6 @@ struct SetRoomMemberDataInternalRequest FLATBUFFERS_FINAL_CLASS : private flatbu
   uint8_t teamId() const {
     return GetField<uint8_t>(VT_TEAMID, 0);
   }
-  uint32_t flagFilter() const {
-    return GetField<uint32_t>(VT_FLAGFILTER, 0);
-  }
-  uint32_t flagAttr() const {
-    return GetField<uint32_t>(VT_FLAGATTR, 0);
-  }
   const flatbuffers::Vector<flatbuffers::Offset<BinAttr>> *roomMemberBinAttrInternal() const {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<BinAttr>> *>(VT_ROOMMEMBERBINATTRINTERNAL);
   }
@@ -2541,8 +2533,6 @@ struct SetRoomMemberDataInternalRequest FLATBUFFERS_FINAL_CLASS : private flatbu
            VerifyField<uint64_t>(verifier, VT_ROOMID) &&
            VerifyField<uint16_t>(verifier, VT_MEMBERID) &&
            VerifyField<uint8_t>(verifier, VT_TEAMID) &&
-           VerifyField<uint32_t>(verifier, VT_FLAGFILTER) &&
-           VerifyField<uint32_t>(verifier, VT_FLAGATTR) &&
            VerifyOffset(verifier, VT_ROOMMEMBERBINATTRINTERNAL) &&
            verifier.VerifyVector(roomMemberBinAttrInternal()) &&
            verifier.VerifyVectorOfTables(roomMemberBinAttrInternal()) &&
@@ -2563,12 +2553,6 @@ struct SetRoomMemberDataInternalRequestBuilder {
   void add_teamId(uint8_t teamId) {
     fbb_.AddElement<uint8_t>(SetRoomMemberDataInternalRequest::VT_TEAMID, teamId, 0);
   }
-  void add_flagFilter(uint32_t flagFilter) {
-    fbb_.AddElement<uint32_t>(SetRoomMemberDataInternalRequest::VT_FLAGFILTER, flagFilter, 0);
-  }
-  void add_flagAttr(uint32_t flagAttr) {
-    fbb_.AddElement<uint32_t>(SetRoomMemberDataInternalRequest::VT_FLAGATTR, flagAttr, 0);
-  }
   void add_roomMemberBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<BinAttr>>> roomMemberBinAttrInternal) {
     fbb_.AddOffset(SetRoomMemberDataInternalRequest::VT_ROOMMEMBERBINATTRINTERNAL, roomMemberBinAttrInternal);
   }
@@ -2588,14 +2572,10 @@ inline flatbuffers::Offset<SetRoomMemberDataInternalRequest> CreateSetRoomMember
     uint64_t roomId = 0,
     uint16_t memberId = 0,
     uint8_t teamId = 0,
-    uint32_t flagFilter = 0,
-    uint32_t flagAttr = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<BinAttr>>> roomMemberBinAttrInternal = 0) {
   SetRoomMemberDataInternalRequestBuilder builder_(_fbb);
   builder_.add_roomId(roomId);
   builder_.add_roomMemberBinAttrInternal(roomMemberBinAttrInternal);
-  builder_.add_flagAttr(flagAttr);
-  builder_.add_flagFilter(flagFilter);
   builder_.add_memberId(memberId);
   builder_.add_teamId(teamId);
   return builder_.Finish();
@@ -2606,8 +2586,6 @@ inline flatbuffers::Offset<SetRoomMemberDataInternalRequest> CreateSetRoomMember
     uint64_t roomId = 0,
     uint16_t memberId = 0,
     uint8_t teamId = 0,
-    uint32_t flagFilter = 0,
-    uint32_t flagAttr = 0,
     const std::vector<flatbuffers::Offset<BinAttr>> *roomMemberBinAttrInternal = nullptr) {
   auto roomMemberBinAttrInternal__ = roomMemberBinAttrInternal ? _fbb.CreateVector<flatbuffers::Offset<BinAttr>>(*roomMemberBinAttrInternal) : 0;
   return CreateSetRoomMemberDataInternalRequest(
@@ -2615,8 +2593,6 @@ inline flatbuffers::Offset<SetRoomMemberDataInternalRequest> CreateSetRoomMember
       roomId,
       memberId,
       teamId,
-      flagFilter,
-      flagAttr,
       roomMemberBinAttrInternal__);
 }
 
@@ -2812,48 +2788,36 @@ struct RoomDataInternalUpdateInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers:
   typedef RoomDataInternalUpdateInfoBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NEWROOMDATAINTERNAL = 4,
-    VT_NEWFLAGATTR = 6,
-    VT_PREVFLAGATTR = 8,
-    VT_NEWROOMPASSWORDSLOTMASK = 10,
-    VT_PREVROOMPASSWORDSLOTMASK = 12,
-    VT_NEWROOMGROUP = 14,
-    VT_NEWROOMBINATTRINTERNAL = 16
+    VT_PREVFLAGATTR = 6,
+    VT_PREVROOMPASSWORDSLOTMASK = 8,
+    VT_NEWROOMGROUP = 10,
+    VT_NEWROOMBINATTRINTERNAL = 12
   };
   const RoomDataInternal *newRoomDataInternal() const {
     return GetPointer<const RoomDataInternal *>(VT_NEWROOMDATAINTERNAL);
   }
-  uint32_t newFlagAttr() const {
-    return GetField<uint32_t>(VT_NEWFLAGATTR, 0);
-  }
   uint32_t prevFlagAttr() const {
     return GetField<uint32_t>(VT_PREVFLAGATTR, 0);
-  }
-  uint64_t newRoomPasswordSlotMask() const {
-    return GetField<uint64_t>(VT_NEWROOMPASSWORDSLOTMASK, 0);
   }
   uint64_t prevRoomPasswordSlotMask() const {
     return GetField<uint64_t>(VT_PREVROOMPASSWORDSLOTMASK, 0);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>> *newRoomGroup() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>> *>(VT_NEWROOMGROUP);
+  const flatbuffers::Vector<uint8_t> *newRoomGroup() const {
+    return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_NEWROOMGROUP);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<BinAttrInternal>> *newRoomBinAttrInternal() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<BinAttrInternal>> *>(VT_NEWROOMBINATTRINTERNAL);
+  const flatbuffers::Vector<uint16_t> *newRoomBinAttrInternal() const {
+    return GetPointer<const flatbuffers::Vector<uint16_t> *>(VT_NEWROOMBINATTRINTERNAL);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_NEWROOMDATAINTERNAL) &&
            verifier.VerifyTable(newRoomDataInternal()) &&
-           VerifyField<uint32_t>(verifier, VT_NEWFLAGATTR) &&
            VerifyField<uint32_t>(verifier, VT_PREVFLAGATTR) &&
-           VerifyField<uint64_t>(verifier, VT_NEWROOMPASSWORDSLOTMASK) &&
            VerifyField<uint64_t>(verifier, VT_PREVROOMPASSWORDSLOTMASK) &&
            VerifyOffset(verifier, VT_NEWROOMGROUP) &&
            verifier.VerifyVector(newRoomGroup()) &&
-           verifier.VerifyVectorOfTables(newRoomGroup()) &&
            VerifyOffset(verifier, VT_NEWROOMBINATTRINTERNAL) &&
            verifier.VerifyVector(newRoomBinAttrInternal()) &&
-           verifier.VerifyVectorOfTables(newRoomBinAttrInternal()) &&
            verifier.EndTable();
   }
 };
@@ -2865,22 +2829,16 @@ struct RoomDataInternalUpdateInfoBuilder {
   void add_newRoomDataInternal(flatbuffers::Offset<RoomDataInternal> newRoomDataInternal) {
     fbb_.AddOffset(RoomDataInternalUpdateInfo::VT_NEWROOMDATAINTERNAL, newRoomDataInternal);
   }
-  void add_newFlagAttr(uint32_t newFlagAttr) {
-    fbb_.AddElement<uint32_t>(RoomDataInternalUpdateInfo::VT_NEWFLAGATTR, newFlagAttr, 0);
-  }
   void add_prevFlagAttr(uint32_t prevFlagAttr) {
     fbb_.AddElement<uint32_t>(RoomDataInternalUpdateInfo::VT_PREVFLAGATTR, prevFlagAttr, 0);
-  }
-  void add_newRoomPasswordSlotMask(uint64_t newRoomPasswordSlotMask) {
-    fbb_.AddElement<uint64_t>(RoomDataInternalUpdateInfo::VT_NEWROOMPASSWORDSLOTMASK, newRoomPasswordSlotMask, 0);
   }
   void add_prevRoomPasswordSlotMask(uint64_t prevRoomPasswordSlotMask) {
     fbb_.AddElement<uint64_t>(RoomDataInternalUpdateInfo::VT_PREVROOMPASSWORDSLOTMASK, prevRoomPasswordSlotMask, 0);
   }
-  void add_newRoomGroup(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>> newRoomGroup) {
+  void add_newRoomGroup(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> newRoomGroup) {
     fbb_.AddOffset(RoomDataInternalUpdateInfo::VT_NEWROOMGROUP, newRoomGroup);
   }
-  void add_newRoomBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<BinAttrInternal>>> newRoomBinAttrInternal) {
+  void add_newRoomBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<uint16_t>> newRoomBinAttrInternal) {
     fbb_.AddOffset(RoomDataInternalUpdateInfo::VT_NEWROOMBINATTRINTERNAL, newRoomBinAttrInternal);
   }
   explicit RoomDataInternalUpdateInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2897,19 +2855,15 @@ struct RoomDataInternalUpdateInfoBuilder {
 inline flatbuffers::Offset<RoomDataInternalUpdateInfo> CreateRoomDataInternalUpdateInfo(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<RoomDataInternal> newRoomDataInternal = 0,
-    uint32_t newFlagAttr = 0,
     uint32_t prevFlagAttr = 0,
-    uint64_t newRoomPasswordSlotMask = 0,
     uint64_t prevRoomPasswordSlotMask = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>> newRoomGroup = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<BinAttrInternal>>> newRoomBinAttrInternal = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<uint8_t>> newRoomGroup = 0,
+    flatbuffers::Offset<flatbuffers::Vector<uint16_t>> newRoomBinAttrInternal = 0) {
   RoomDataInternalUpdateInfoBuilder builder_(_fbb);
   builder_.add_prevRoomPasswordSlotMask(prevRoomPasswordSlotMask);
-  builder_.add_newRoomPasswordSlotMask(newRoomPasswordSlotMask);
   builder_.add_newRoomBinAttrInternal(newRoomBinAttrInternal);
   builder_.add_newRoomGroup(newRoomGroup);
   builder_.add_prevFlagAttr(prevFlagAttr);
-  builder_.add_newFlagAttr(newFlagAttr);
   builder_.add_newRoomDataInternal(newRoomDataInternal);
   return builder_.Finish();
 }
@@ -2917,20 +2871,16 @@ inline flatbuffers::Offset<RoomDataInternalUpdateInfo> CreateRoomDataInternalUpd
 inline flatbuffers::Offset<RoomDataInternalUpdateInfo> CreateRoomDataInternalUpdateInfoDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<RoomDataInternal> newRoomDataInternal = 0,
-    uint32_t newFlagAttr = 0,
     uint32_t prevFlagAttr = 0,
-    uint64_t newRoomPasswordSlotMask = 0,
     uint64_t prevRoomPasswordSlotMask = 0,
-    const std::vector<flatbuffers::Offset<RoomGroup>> *newRoomGroup = nullptr,
-    const std::vector<flatbuffers::Offset<BinAttrInternal>> *newRoomBinAttrInternal = nullptr) {
-  auto newRoomGroup__ = newRoomGroup ? _fbb.CreateVector<flatbuffers::Offset<RoomGroup>>(*newRoomGroup) : 0;
-  auto newRoomBinAttrInternal__ = newRoomBinAttrInternal ? _fbb.CreateVector<flatbuffers::Offset<BinAttrInternal>>(*newRoomBinAttrInternal) : 0;
+    const std::vector<uint8_t> *newRoomGroup = nullptr,
+    const std::vector<uint16_t> *newRoomBinAttrInternal = nullptr) {
+  auto newRoomGroup__ = newRoomGroup ? _fbb.CreateVector<uint8_t>(*newRoomGroup) : 0;
+  auto newRoomBinAttrInternal__ = newRoomBinAttrInternal ? _fbb.CreateVector<uint16_t>(*newRoomBinAttrInternal) : 0;
   return CreateRoomDataInternalUpdateInfo(
       _fbb,
       newRoomDataInternal,
-      newFlagAttr,
       prevFlagAttr,
-      newRoomPasswordSlotMask,
       prevRoomPasswordSlotMask,
       newRoomGroup__,
       newRoomBinAttrInternal__);
@@ -2940,36 +2890,30 @@ struct RoomMemberDataInternalUpdateInfo FLATBUFFERS_FINAL_CLASS : private flatbu
   typedef RoomMemberDataInternalUpdateInfoBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NEWROOMMEMBERDATAINTERNAL = 4,
-    VT_NEWFLAGATTR = 6,
-    VT_PREVFLAGATTR = 8,
-    VT_NEWTEAMID = 10,
-    VT_NEWROOMMEMBERBINATTRINTERNAL = 12
+    VT_PREVFLAGATTR = 6,
+    VT_PREVTEAMID = 8,
+    VT_NEWROOMMEMBERBINATTRINTERNAL = 10
   };
   const RoomMemberDataInternal *newRoomMemberDataInternal() const {
     return GetPointer<const RoomMemberDataInternal *>(VT_NEWROOMMEMBERDATAINTERNAL);
   }
-  uint32_t newFlagAttr() const {
-    return GetField<uint32_t>(VT_NEWFLAGATTR, 0);
-  }
   uint32_t prevFlagAttr() const {
     return GetField<uint32_t>(VT_PREVFLAGATTR, 0);
   }
-  uint8_t newTeamId() const {
-    return GetField<uint8_t>(VT_NEWTEAMID, 0);
+  uint8_t prevTeamId() const {
+    return GetField<uint8_t>(VT_PREVTEAMID, 0);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *newRoomMemberBinAttrInternal() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *>(VT_NEWROOMMEMBERBINATTRINTERNAL);
+  const flatbuffers::Vector<uint16_t> *newRoomMemberBinAttrInternal() const {
+    return GetPointer<const flatbuffers::Vector<uint16_t> *>(VT_NEWROOMMEMBERBINATTRINTERNAL);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_NEWROOMMEMBERDATAINTERNAL) &&
            verifier.VerifyTable(newRoomMemberDataInternal()) &&
-           VerifyField<uint32_t>(verifier, VT_NEWFLAGATTR) &&
            VerifyField<uint32_t>(verifier, VT_PREVFLAGATTR) &&
-           VerifyField<uint8_t>(verifier, VT_NEWTEAMID) &&
+           VerifyField<uint8_t>(verifier, VT_PREVTEAMID) &&
            VerifyOffset(verifier, VT_NEWROOMMEMBERBINATTRINTERNAL) &&
            verifier.VerifyVector(newRoomMemberBinAttrInternal()) &&
-           verifier.VerifyVectorOfTables(newRoomMemberBinAttrInternal()) &&
            verifier.EndTable();
   }
 };
@@ -2981,16 +2925,13 @@ struct RoomMemberDataInternalUpdateInfoBuilder {
   void add_newRoomMemberDataInternal(flatbuffers::Offset<RoomMemberDataInternal> newRoomMemberDataInternal) {
     fbb_.AddOffset(RoomMemberDataInternalUpdateInfo::VT_NEWROOMMEMBERDATAINTERNAL, newRoomMemberDataInternal);
   }
-  void add_newFlagAttr(uint32_t newFlagAttr) {
-    fbb_.AddElement<uint32_t>(RoomMemberDataInternalUpdateInfo::VT_NEWFLAGATTR, newFlagAttr, 0);
-  }
   void add_prevFlagAttr(uint32_t prevFlagAttr) {
     fbb_.AddElement<uint32_t>(RoomMemberDataInternalUpdateInfo::VT_PREVFLAGATTR, prevFlagAttr, 0);
   }
-  void add_newTeamId(uint8_t newTeamId) {
-    fbb_.AddElement<uint8_t>(RoomMemberDataInternalUpdateInfo::VT_NEWTEAMID, newTeamId, 0);
+  void add_prevTeamId(uint8_t prevTeamId) {
+    fbb_.AddElement<uint8_t>(RoomMemberDataInternalUpdateInfo::VT_PREVTEAMID, prevTeamId, 0);
   }
-  void add_newRoomMemberBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>>> newRoomMemberBinAttrInternal) {
+  void add_newRoomMemberBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<uint16_t>> newRoomMemberBinAttrInternal) {
     fbb_.AddOffset(RoomMemberDataInternalUpdateInfo::VT_NEWROOMMEMBERBINATTRINTERNAL, newRoomMemberBinAttrInternal);
   }
   explicit RoomMemberDataInternalUpdateInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -3007,33 +2948,29 @@ struct RoomMemberDataInternalUpdateInfoBuilder {
 inline flatbuffers::Offset<RoomMemberDataInternalUpdateInfo> CreateRoomMemberDataInternalUpdateInfo(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<RoomMemberDataInternal> newRoomMemberDataInternal = 0,
-    uint32_t newFlagAttr = 0,
     uint32_t prevFlagAttr = 0,
-    uint8_t newTeamId = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>>> newRoomMemberBinAttrInternal = 0) {
+    uint8_t prevTeamId = 0,
+    flatbuffers::Offset<flatbuffers::Vector<uint16_t>> newRoomMemberBinAttrInternal = 0) {
   RoomMemberDataInternalUpdateInfoBuilder builder_(_fbb);
   builder_.add_newRoomMemberBinAttrInternal(newRoomMemberBinAttrInternal);
   builder_.add_prevFlagAttr(prevFlagAttr);
-  builder_.add_newFlagAttr(newFlagAttr);
   builder_.add_newRoomMemberDataInternal(newRoomMemberDataInternal);
-  builder_.add_newTeamId(newTeamId);
+  builder_.add_prevTeamId(prevTeamId);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<RoomMemberDataInternalUpdateInfo> CreateRoomMemberDataInternalUpdateInfoDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<RoomMemberDataInternal> newRoomMemberDataInternal = 0,
-    uint32_t newFlagAttr = 0,
     uint32_t prevFlagAttr = 0,
-    uint8_t newTeamId = 0,
-    const std::vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *newRoomMemberBinAttrInternal = nullptr) {
-  auto newRoomMemberBinAttrInternal__ = newRoomMemberBinAttrInternal ? _fbb.CreateVector<flatbuffers::Offset<RoomMemberBinAttrInternal>>(*newRoomMemberBinAttrInternal) : 0;
+    uint8_t prevTeamId = 0,
+    const std::vector<uint16_t> *newRoomMemberBinAttrInternal = nullptr) {
+  auto newRoomMemberBinAttrInternal__ = newRoomMemberBinAttrInternal ? _fbb.CreateVector<uint16_t>(*newRoomMemberBinAttrInternal) : 0;
   return CreateRoomMemberDataInternalUpdateInfo(
       _fbb,
       newRoomMemberDataInternal,
-      newFlagAttr,
       prevFlagAttr,
-      newTeamId,
+      prevTeamId,
       newRoomMemberBinAttrInternal__);
 }
 

--- a/rpcs3/Emu/NP/generated/np2_structs_generated.h
+++ b/rpcs3/Emu/NP/generated/np2_structs_generated.h
@@ -590,8 +590,8 @@ struct RoomMemberDataInternal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
   uint8_t teamId() const {
     return GetField<uint8_t>(VT_TEAMID, 0);
   }
-  uint8_t roomGroup() const {
-    return GetField<uint8_t>(VT_ROOMGROUP, 0);
+  const RoomGroup *roomGroup() const {
+    return GetPointer<const RoomGroup *>(VT_ROOMGROUP);
   }
   uint8_t natType() const {
     return GetField<uint8_t>(VT_NATTYPE, 0);
@@ -609,7 +609,8 @@ struct RoomMemberDataInternal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
            VerifyField<uint64_t>(verifier, VT_JOINDATE) &&
            VerifyField<uint16_t>(verifier, VT_MEMBERID) &&
            VerifyField<uint8_t>(verifier, VT_TEAMID) &&
-           VerifyField<uint8_t>(verifier, VT_ROOMGROUP) &&
+           VerifyOffset(verifier, VT_ROOMGROUP) &&
+           verifier.VerifyTable(roomGroup()) &&
            VerifyField<uint8_t>(verifier, VT_NATTYPE) &&
            VerifyField<uint32_t>(verifier, VT_FLAGATTR) &&
            VerifyOffset(verifier, VT_ROOMMEMBERBINATTRINTERNAL) &&
@@ -635,8 +636,8 @@ struct RoomMemberDataInternalBuilder {
   void add_teamId(uint8_t teamId) {
     fbb_.AddElement<uint8_t>(RoomMemberDataInternal::VT_TEAMID, teamId, 0);
   }
-  void add_roomGroup(uint8_t roomGroup) {
-    fbb_.AddElement<uint8_t>(RoomMemberDataInternal::VT_ROOMGROUP, roomGroup, 0);
+  void add_roomGroup(flatbuffers::Offset<RoomGroup> roomGroup) {
+    fbb_.AddOffset(RoomMemberDataInternal::VT_ROOMGROUP, roomGroup);
   }
   void add_natType(uint8_t natType) {
     fbb_.AddElement<uint8_t>(RoomMemberDataInternal::VT_NATTYPE, natType, 0);
@@ -664,7 +665,7 @@ inline flatbuffers::Offset<RoomMemberDataInternal> CreateRoomMemberDataInternal(
     uint64_t joinDate = 0,
     uint16_t memberId = 0,
     uint8_t teamId = 0,
-    uint8_t roomGroup = 0,
+    flatbuffers::Offset<RoomGroup> roomGroup = 0,
     uint8_t natType = 0,
     uint32_t flagAttr = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>>> roomMemberBinAttrInternal = 0) {
@@ -672,10 +673,10 @@ inline flatbuffers::Offset<RoomMemberDataInternal> CreateRoomMemberDataInternal(
   builder_.add_joinDate(joinDate);
   builder_.add_roomMemberBinAttrInternal(roomMemberBinAttrInternal);
   builder_.add_flagAttr(flagAttr);
+  builder_.add_roomGroup(roomGroup);
   builder_.add_userInfo(userInfo);
   builder_.add_memberId(memberId);
   builder_.add_natType(natType);
-  builder_.add_roomGroup(roomGroup);
   builder_.add_teamId(teamId);
   return builder_.Finish();
 }
@@ -686,7 +687,7 @@ inline flatbuffers::Offset<RoomMemberDataInternal> CreateRoomMemberDataInternalD
     uint64_t joinDate = 0,
     uint16_t memberId = 0,
     uint8_t teamId = 0,
-    uint8_t roomGroup = 0,
+    flatbuffers::Offset<RoomGroup> roomGroup = 0,
     uint8_t natType = 0,
     uint32_t flagAttr = 0,
     const std::vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *roomMemberBinAttrInternal = nullptr) {

--- a/rpcs3/Emu/NP/generated/np2_structs_generated.h
+++ b/rpcs3/Emu/NP/generated/np2_structs_generated.h
@@ -12,8 +12,8 @@ struct BinAttrBuilder;
 struct IntAttr;
 struct IntAttrBuilder;
 
-struct MemberBinAttrInternal;
-struct MemberBinAttrInternalBuilder;
+struct RoomMemberBinAttrInternal;
+struct RoomMemberBinAttrInternalBuilder;
 
 struct BinAttrInternal;
 struct BinAttrInternalBuilder;
@@ -78,6 +78,9 @@ struct SetRoomDataExternalRequestBuilder;
 struct SetRoomDataInternalRequest;
 struct SetRoomDataInternalRequestBuilder;
 
+struct SetRoomMemberDataInternalRequest;
+struct SetRoomMemberDataInternalRequestBuilder;
+
 struct GetRoomDataInternalRequest;
 struct GetRoomDataInternalRequestBuilder;
 
@@ -86,6 +89,12 @@ struct RoomMemberUpdateInfoBuilder;
 
 struct RoomUpdateInfo;
 struct RoomUpdateInfoBuilder;
+
+struct RoomDataInternalUpdateInfo;
+struct RoomDataInternalUpdateInfoBuilder;
+
+struct RoomMemberDataInternalUpdateInfo;
+struct RoomMemberDataInternalUpdateInfoBuilder;
 
 struct GetPingInfoResponse;
 struct GetPingInfoResponseBuilder;
@@ -216,8 +225,8 @@ inline flatbuffers::Offset<IntAttr> CreateIntAttr(
   return builder_.Finish();
 }
 
-struct MemberBinAttrInternal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
-  typedef MemberBinAttrInternalBuilder Builder;
+struct RoomMemberBinAttrInternal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef RoomMemberBinAttrInternalBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_UPDATEDATE = 4,
     VT_DATA = 6
@@ -237,32 +246,32 @@ struct MemberBinAttrInternal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
   }
 };
 
-struct MemberBinAttrInternalBuilder {
-  typedef MemberBinAttrInternal Table;
+struct RoomMemberBinAttrInternalBuilder {
+  typedef RoomMemberBinAttrInternal Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_updateDate(uint64_t updateDate) {
-    fbb_.AddElement<uint64_t>(MemberBinAttrInternal::VT_UPDATEDATE, updateDate, 0);
+    fbb_.AddElement<uint64_t>(RoomMemberBinAttrInternal::VT_UPDATEDATE, updateDate, 0);
   }
   void add_data(flatbuffers::Offset<BinAttr> data) {
-    fbb_.AddOffset(MemberBinAttrInternal::VT_DATA, data);
+    fbb_.AddOffset(RoomMemberBinAttrInternal::VT_DATA, data);
   }
-  explicit MemberBinAttrInternalBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+  explicit RoomMemberBinAttrInternalBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
   }
-  flatbuffers::Offset<MemberBinAttrInternal> Finish() {
+  flatbuffers::Offset<RoomMemberBinAttrInternal> Finish() {
     const auto end = fbb_.EndTable(start_);
-    auto o = flatbuffers::Offset<MemberBinAttrInternal>(end);
+    auto o = flatbuffers::Offset<RoomMemberBinAttrInternal>(end);
     return o;
   }
 };
 
-inline flatbuffers::Offset<MemberBinAttrInternal> CreateMemberBinAttrInternal(
+inline flatbuffers::Offset<RoomMemberBinAttrInternal> CreateRoomMemberBinAttrInternal(
     flatbuffers::FlatBufferBuilder &_fbb,
     uint64_t updateDate = 0,
     flatbuffers::Offset<BinAttr> data = 0) {
-  MemberBinAttrInternalBuilder builder_(_fbb);
+  RoomMemberBinAttrInternalBuilder builder_(_fbb);
   builder_.add_updateDate(updateDate);
   builder_.add_data(data);
   return builder_.Finish();
@@ -590,8 +599,8 @@ struct RoomMemberDataInternal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
   uint32_t flagAttr() const {
     return GetField<uint32_t>(VT_FLAGATTR, 0);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<MemberBinAttrInternal>> *roomMemberBinAttrInternal() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<MemberBinAttrInternal>> *>(VT_ROOMMEMBERBINATTRINTERNAL);
+  const flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *roomMemberBinAttrInternal() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *>(VT_ROOMMEMBERBINATTRINTERNAL);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -635,7 +644,7 @@ struct RoomMemberDataInternalBuilder {
   void add_flagAttr(uint32_t flagAttr) {
     fbb_.AddElement<uint32_t>(RoomMemberDataInternal::VT_FLAGATTR, flagAttr, 0);
   }
-  void add_roomMemberBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<MemberBinAttrInternal>>> roomMemberBinAttrInternal) {
+  void add_roomMemberBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>>> roomMemberBinAttrInternal) {
     fbb_.AddOffset(RoomMemberDataInternal::VT_ROOMMEMBERBINATTRINTERNAL, roomMemberBinAttrInternal);
   }
   explicit RoomMemberDataInternalBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -658,7 +667,7 @@ inline flatbuffers::Offset<RoomMemberDataInternal> CreateRoomMemberDataInternal(
     uint8_t roomGroup = 0,
     uint8_t natType = 0,
     uint32_t flagAttr = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<MemberBinAttrInternal>>> roomMemberBinAttrInternal = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>>> roomMemberBinAttrInternal = 0) {
   RoomMemberDataInternalBuilder builder_(_fbb);
   builder_.add_joinDate(joinDate);
   builder_.add_roomMemberBinAttrInternal(roomMemberBinAttrInternal);
@@ -680,8 +689,8 @@ inline flatbuffers::Offset<RoomMemberDataInternal> CreateRoomMemberDataInternalD
     uint8_t roomGroup = 0,
     uint8_t natType = 0,
     uint32_t flagAttr = 0,
-    const std::vector<flatbuffers::Offset<MemberBinAttrInternal>> *roomMemberBinAttrInternal = nullptr) {
-  auto roomMemberBinAttrInternal__ = roomMemberBinAttrInternal ? _fbb.CreateVector<flatbuffers::Offset<MemberBinAttrInternal>>(*roomMemberBinAttrInternal) : 0;
+    const std::vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *roomMemberBinAttrInternal = nullptr) {
+  auto roomMemberBinAttrInternal__ = roomMemberBinAttrInternal ? _fbb.CreateVector<flatbuffers::Offset<RoomMemberBinAttrInternal>>(*roomMemberBinAttrInternal) : 0;
   return CreateRoomMemberDataInternal(
       _fbb,
       userInfo,
@@ -2499,6 +2508,118 @@ inline flatbuffers::Offset<SetRoomDataInternalRequest> CreateSetRoomDataInternal
       ownerPrivilegeRank__);
 }
 
+struct SetRoomMemberDataInternalRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef SetRoomMemberDataInternalRequestBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_ROOMID = 4,
+    VT_MEMBERID = 6,
+    VT_TEAMID = 8,
+    VT_FLAGFILTER = 10,
+    VT_FLAGATTR = 12,
+    VT_ROOMMEMBERBINATTRINTERNAL = 14
+  };
+  uint64_t roomId() const {
+    return GetField<uint64_t>(VT_ROOMID, 0);
+  }
+  uint16_t memberId() const {
+    return GetField<uint16_t>(VT_MEMBERID, 0);
+  }
+  uint8_t teamId() const {
+    return GetField<uint8_t>(VT_TEAMID, 0);
+  }
+  uint32_t flagFilter() const {
+    return GetField<uint32_t>(VT_FLAGFILTER, 0);
+  }
+  uint32_t flagAttr() const {
+    return GetField<uint32_t>(VT_FLAGATTR, 0);
+  }
+  const flatbuffers::Vector<flatbuffers::Offset<BinAttr>> *roomMemberBinAttrInternal() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<BinAttr>> *>(VT_ROOMMEMBERBINATTRINTERNAL);
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint64_t>(verifier, VT_ROOMID) &&
+           VerifyField<uint16_t>(verifier, VT_MEMBERID) &&
+           VerifyField<uint8_t>(verifier, VT_TEAMID) &&
+           VerifyField<uint32_t>(verifier, VT_FLAGFILTER) &&
+           VerifyField<uint32_t>(verifier, VT_FLAGATTR) &&
+           VerifyOffset(verifier, VT_ROOMMEMBERBINATTRINTERNAL) &&
+           verifier.VerifyVector(roomMemberBinAttrInternal()) &&
+           verifier.VerifyVectorOfTables(roomMemberBinAttrInternal()) &&
+           verifier.EndTable();
+  }
+};
+
+struct SetRoomMemberDataInternalRequestBuilder {
+  typedef SetRoomMemberDataInternalRequest Table;
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_roomId(uint64_t roomId) {
+    fbb_.AddElement<uint64_t>(SetRoomMemberDataInternalRequest::VT_ROOMID, roomId, 0);
+  }
+  void add_memberId(uint16_t memberId) {
+    fbb_.AddElement<uint16_t>(SetRoomMemberDataInternalRequest::VT_MEMBERID, memberId, 0);
+  }
+  void add_teamId(uint8_t teamId) {
+    fbb_.AddElement<uint8_t>(SetRoomMemberDataInternalRequest::VT_TEAMID, teamId, 0);
+  }
+  void add_flagFilter(uint32_t flagFilter) {
+    fbb_.AddElement<uint32_t>(SetRoomMemberDataInternalRequest::VT_FLAGFILTER, flagFilter, 0);
+  }
+  void add_flagAttr(uint32_t flagAttr) {
+    fbb_.AddElement<uint32_t>(SetRoomMemberDataInternalRequest::VT_FLAGATTR, flagAttr, 0);
+  }
+  void add_roomMemberBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<BinAttr>>> roomMemberBinAttrInternal) {
+    fbb_.AddOffset(SetRoomMemberDataInternalRequest::VT_ROOMMEMBERBINATTRINTERNAL, roomMemberBinAttrInternal);
+  }
+  explicit SetRoomMemberDataInternalRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  flatbuffers::Offset<SetRoomMemberDataInternalRequest> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<SetRoomMemberDataInternalRequest>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<SetRoomMemberDataInternalRequest> CreateSetRoomMemberDataInternalRequest(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    uint64_t roomId = 0,
+    uint16_t memberId = 0,
+    uint8_t teamId = 0,
+    uint32_t flagFilter = 0,
+    uint32_t flagAttr = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<BinAttr>>> roomMemberBinAttrInternal = 0) {
+  SetRoomMemberDataInternalRequestBuilder builder_(_fbb);
+  builder_.add_roomId(roomId);
+  builder_.add_roomMemberBinAttrInternal(roomMemberBinAttrInternal);
+  builder_.add_flagAttr(flagAttr);
+  builder_.add_flagFilter(flagFilter);
+  builder_.add_memberId(memberId);
+  builder_.add_teamId(teamId);
+  return builder_.Finish();
+}
+
+inline flatbuffers::Offset<SetRoomMemberDataInternalRequest> CreateSetRoomMemberDataInternalRequestDirect(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    uint64_t roomId = 0,
+    uint16_t memberId = 0,
+    uint8_t teamId = 0,
+    uint32_t flagFilter = 0,
+    uint32_t flagAttr = 0,
+    const std::vector<flatbuffers::Offset<BinAttr>> *roomMemberBinAttrInternal = nullptr) {
+  auto roomMemberBinAttrInternal__ = roomMemberBinAttrInternal ? _fbb.CreateVector<flatbuffers::Offset<BinAttr>>(*roomMemberBinAttrInternal) : 0;
+  return CreateSetRoomMemberDataInternalRequest(
+      _fbb,
+      roomId,
+      memberId,
+      teamId,
+      flagFilter,
+      flagAttr,
+      roomMemberBinAttrInternal__);
+}
+
 struct GetRoomDataInternalRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef GetRoomDataInternalRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
@@ -2685,6 +2806,235 @@ inline flatbuffers::Offset<RoomUpdateInfo> CreateRoomUpdateInfo(
   builder_.add_errorCode(errorCode);
   builder_.add_eventCause(eventCause);
   return builder_.Finish();
+}
+
+struct RoomDataInternalUpdateInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef RoomDataInternalUpdateInfoBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_NEWROOMDATAINTERNAL = 4,
+    VT_NEWFLAGATTR = 6,
+    VT_PREVFLAGATTR = 8,
+    VT_NEWROOMPASSWORDSLOTMASK = 10,
+    VT_PREVROOMPASSWORDSLOTMASK = 12,
+    VT_NEWROOMGROUP = 14,
+    VT_NEWROOMBINATTRINTERNAL = 16
+  };
+  const RoomDataInternal *newRoomDataInternal() const {
+    return GetPointer<const RoomDataInternal *>(VT_NEWROOMDATAINTERNAL);
+  }
+  uint32_t newFlagAttr() const {
+    return GetField<uint32_t>(VT_NEWFLAGATTR, 0);
+  }
+  uint32_t prevFlagAttr() const {
+    return GetField<uint32_t>(VT_PREVFLAGATTR, 0);
+  }
+  uint64_t newRoomPasswordSlotMask() const {
+    return GetField<uint64_t>(VT_NEWROOMPASSWORDSLOTMASK, 0);
+  }
+  uint64_t prevRoomPasswordSlotMask() const {
+    return GetField<uint64_t>(VT_PREVROOMPASSWORDSLOTMASK, 0);
+  }
+  const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>> *newRoomGroup() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>> *>(VT_NEWROOMGROUP);
+  }
+  const flatbuffers::Vector<flatbuffers::Offset<BinAttrInternal>> *newRoomBinAttrInternal() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<BinAttrInternal>> *>(VT_NEWROOMBINATTRINTERNAL);
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyOffset(verifier, VT_NEWROOMDATAINTERNAL) &&
+           verifier.VerifyTable(newRoomDataInternal()) &&
+           VerifyField<uint32_t>(verifier, VT_NEWFLAGATTR) &&
+           VerifyField<uint32_t>(verifier, VT_PREVFLAGATTR) &&
+           VerifyField<uint64_t>(verifier, VT_NEWROOMPASSWORDSLOTMASK) &&
+           VerifyField<uint64_t>(verifier, VT_PREVROOMPASSWORDSLOTMASK) &&
+           VerifyOffset(verifier, VT_NEWROOMGROUP) &&
+           verifier.VerifyVector(newRoomGroup()) &&
+           verifier.VerifyVectorOfTables(newRoomGroup()) &&
+           VerifyOffset(verifier, VT_NEWROOMBINATTRINTERNAL) &&
+           verifier.VerifyVector(newRoomBinAttrInternal()) &&
+           verifier.VerifyVectorOfTables(newRoomBinAttrInternal()) &&
+           verifier.EndTable();
+  }
+};
+
+struct RoomDataInternalUpdateInfoBuilder {
+  typedef RoomDataInternalUpdateInfo Table;
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_newRoomDataInternal(flatbuffers::Offset<RoomDataInternal> newRoomDataInternal) {
+    fbb_.AddOffset(RoomDataInternalUpdateInfo::VT_NEWROOMDATAINTERNAL, newRoomDataInternal);
+  }
+  void add_newFlagAttr(uint32_t newFlagAttr) {
+    fbb_.AddElement<uint32_t>(RoomDataInternalUpdateInfo::VT_NEWFLAGATTR, newFlagAttr, 0);
+  }
+  void add_prevFlagAttr(uint32_t prevFlagAttr) {
+    fbb_.AddElement<uint32_t>(RoomDataInternalUpdateInfo::VT_PREVFLAGATTR, prevFlagAttr, 0);
+  }
+  void add_newRoomPasswordSlotMask(uint64_t newRoomPasswordSlotMask) {
+    fbb_.AddElement<uint64_t>(RoomDataInternalUpdateInfo::VT_NEWROOMPASSWORDSLOTMASK, newRoomPasswordSlotMask, 0);
+  }
+  void add_prevRoomPasswordSlotMask(uint64_t prevRoomPasswordSlotMask) {
+    fbb_.AddElement<uint64_t>(RoomDataInternalUpdateInfo::VT_PREVROOMPASSWORDSLOTMASK, prevRoomPasswordSlotMask, 0);
+  }
+  void add_newRoomGroup(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>> newRoomGroup) {
+    fbb_.AddOffset(RoomDataInternalUpdateInfo::VT_NEWROOMGROUP, newRoomGroup);
+  }
+  void add_newRoomBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<BinAttrInternal>>> newRoomBinAttrInternal) {
+    fbb_.AddOffset(RoomDataInternalUpdateInfo::VT_NEWROOMBINATTRINTERNAL, newRoomBinAttrInternal);
+  }
+  explicit RoomDataInternalUpdateInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  flatbuffers::Offset<RoomDataInternalUpdateInfo> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<RoomDataInternalUpdateInfo>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<RoomDataInternalUpdateInfo> CreateRoomDataInternalUpdateInfo(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    flatbuffers::Offset<RoomDataInternal> newRoomDataInternal = 0,
+    uint32_t newFlagAttr = 0,
+    uint32_t prevFlagAttr = 0,
+    uint64_t newRoomPasswordSlotMask = 0,
+    uint64_t prevRoomPasswordSlotMask = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>> newRoomGroup = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<BinAttrInternal>>> newRoomBinAttrInternal = 0) {
+  RoomDataInternalUpdateInfoBuilder builder_(_fbb);
+  builder_.add_prevRoomPasswordSlotMask(prevRoomPasswordSlotMask);
+  builder_.add_newRoomPasswordSlotMask(newRoomPasswordSlotMask);
+  builder_.add_newRoomBinAttrInternal(newRoomBinAttrInternal);
+  builder_.add_newRoomGroup(newRoomGroup);
+  builder_.add_prevFlagAttr(prevFlagAttr);
+  builder_.add_newFlagAttr(newFlagAttr);
+  builder_.add_newRoomDataInternal(newRoomDataInternal);
+  return builder_.Finish();
+}
+
+inline flatbuffers::Offset<RoomDataInternalUpdateInfo> CreateRoomDataInternalUpdateInfoDirect(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    flatbuffers::Offset<RoomDataInternal> newRoomDataInternal = 0,
+    uint32_t newFlagAttr = 0,
+    uint32_t prevFlagAttr = 0,
+    uint64_t newRoomPasswordSlotMask = 0,
+    uint64_t prevRoomPasswordSlotMask = 0,
+    const std::vector<flatbuffers::Offset<RoomGroup>> *newRoomGroup = nullptr,
+    const std::vector<flatbuffers::Offset<BinAttrInternal>> *newRoomBinAttrInternal = nullptr) {
+  auto newRoomGroup__ = newRoomGroup ? _fbb.CreateVector<flatbuffers::Offset<RoomGroup>>(*newRoomGroup) : 0;
+  auto newRoomBinAttrInternal__ = newRoomBinAttrInternal ? _fbb.CreateVector<flatbuffers::Offset<BinAttrInternal>>(*newRoomBinAttrInternal) : 0;
+  return CreateRoomDataInternalUpdateInfo(
+      _fbb,
+      newRoomDataInternal,
+      newFlagAttr,
+      prevFlagAttr,
+      newRoomPasswordSlotMask,
+      prevRoomPasswordSlotMask,
+      newRoomGroup__,
+      newRoomBinAttrInternal__);
+}
+
+struct RoomMemberDataInternalUpdateInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef RoomMemberDataInternalUpdateInfoBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_NEWROOMMEMBERDATAINTERNAL = 4,
+    VT_NEWFLAGATTR = 6,
+    VT_PREVFLAGATTR = 8,
+    VT_NEWTEAMID = 10,
+    VT_NEWROOMMEMBERBINATTRINTERNAL = 12
+  };
+  const RoomMemberDataInternal *newRoomMemberDataInternal() const {
+    return GetPointer<const RoomMemberDataInternal *>(VT_NEWROOMMEMBERDATAINTERNAL);
+  }
+  uint32_t newFlagAttr() const {
+    return GetField<uint32_t>(VT_NEWFLAGATTR, 0);
+  }
+  uint32_t prevFlagAttr() const {
+    return GetField<uint32_t>(VT_PREVFLAGATTR, 0);
+  }
+  uint8_t newTeamId() const {
+    return GetField<uint8_t>(VT_NEWTEAMID, 0);
+  }
+  const flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *newRoomMemberBinAttrInternal() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *>(VT_NEWROOMMEMBERBINATTRINTERNAL);
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyOffset(verifier, VT_NEWROOMMEMBERDATAINTERNAL) &&
+           verifier.VerifyTable(newRoomMemberDataInternal()) &&
+           VerifyField<uint32_t>(verifier, VT_NEWFLAGATTR) &&
+           VerifyField<uint32_t>(verifier, VT_PREVFLAGATTR) &&
+           VerifyField<uint8_t>(verifier, VT_NEWTEAMID) &&
+           VerifyOffset(verifier, VT_NEWROOMMEMBERBINATTRINTERNAL) &&
+           verifier.VerifyVector(newRoomMemberBinAttrInternal()) &&
+           verifier.VerifyVectorOfTables(newRoomMemberBinAttrInternal()) &&
+           verifier.EndTable();
+  }
+};
+
+struct RoomMemberDataInternalUpdateInfoBuilder {
+  typedef RoomMemberDataInternalUpdateInfo Table;
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_newRoomMemberDataInternal(flatbuffers::Offset<RoomMemberDataInternal> newRoomMemberDataInternal) {
+    fbb_.AddOffset(RoomMemberDataInternalUpdateInfo::VT_NEWROOMMEMBERDATAINTERNAL, newRoomMemberDataInternal);
+  }
+  void add_newFlagAttr(uint32_t newFlagAttr) {
+    fbb_.AddElement<uint32_t>(RoomMemberDataInternalUpdateInfo::VT_NEWFLAGATTR, newFlagAttr, 0);
+  }
+  void add_prevFlagAttr(uint32_t prevFlagAttr) {
+    fbb_.AddElement<uint32_t>(RoomMemberDataInternalUpdateInfo::VT_PREVFLAGATTR, prevFlagAttr, 0);
+  }
+  void add_newTeamId(uint8_t newTeamId) {
+    fbb_.AddElement<uint8_t>(RoomMemberDataInternalUpdateInfo::VT_NEWTEAMID, newTeamId, 0);
+  }
+  void add_newRoomMemberBinAttrInternal(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>>> newRoomMemberBinAttrInternal) {
+    fbb_.AddOffset(RoomMemberDataInternalUpdateInfo::VT_NEWROOMMEMBERBINATTRINTERNAL, newRoomMemberBinAttrInternal);
+  }
+  explicit RoomMemberDataInternalUpdateInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  flatbuffers::Offset<RoomMemberDataInternalUpdateInfo> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<RoomMemberDataInternalUpdateInfo>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<RoomMemberDataInternalUpdateInfo> CreateRoomMemberDataInternalUpdateInfo(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    flatbuffers::Offset<RoomMemberDataInternal> newRoomMemberDataInternal = 0,
+    uint32_t newFlagAttr = 0,
+    uint32_t prevFlagAttr = 0,
+    uint8_t newTeamId = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<RoomMemberBinAttrInternal>>> newRoomMemberBinAttrInternal = 0) {
+  RoomMemberDataInternalUpdateInfoBuilder builder_(_fbb);
+  builder_.add_newRoomMemberBinAttrInternal(newRoomMemberBinAttrInternal);
+  builder_.add_prevFlagAttr(prevFlagAttr);
+  builder_.add_newFlagAttr(newFlagAttr);
+  builder_.add_newRoomMemberDataInternal(newRoomMemberDataInternal);
+  builder_.add_newTeamId(newTeamId);
+  return builder_.Finish();
+}
+
+inline flatbuffers::Offset<RoomMemberDataInternalUpdateInfo> CreateRoomMemberDataInternalUpdateInfoDirect(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    flatbuffers::Offset<RoomMemberDataInternal> newRoomMemberDataInternal = 0,
+    uint32_t newFlagAttr = 0,
+    uint32_t prevFlagAttr = 0,
+    uint8_t newTeamId = 0,
+    const std::vector<flatbuffers::Offset<RoomMemberBinAttrInternal>> *newRoomMemberBinAttrInternal = nullptr) {
+  auto newRoomMemberBinAttrInternal__ = newRoomMemberBinAttrInternal ? _fbb.CreateVector<flatbuffers::Offset<RoomMemberBinAttrInternal>>(*newRoomMemberBinAttrInternal) : 0;
+  return CreateRoomMemberDataInternalUpdateInfo(
+      _fbb,
+      newRoomMemberDataInternal,
+      newFlagAttr,
+      prevFlagAttr,
+      newTeamId,
+      newRoomMemberBinAttrInternal__);
 }
 
 struct GetPingInfoResponse FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {

--- a/rpcs3/Emu/NP/np_allocator.h
+++ b/rpcs3/Emu/NP/np_allocator.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <map>
+
+#include "Emu/Memory/vm_ptr.h"
+#include "Utilities/mutex.h"
+#include "util/asm.hpp"
+#include "util/logs.hpp"
+
+LOG_CHANNEL(np_mem_allocator);
+
+namespace np
+{
+	class memory_allocator
+	{
+	public:
+		memory_allocator() = default;
+		memory_allocator(const memory_allocator&) = delete;
+		memory_allocator& operator=(const memory_allocator&) = delete;
+
+		void setup(vm::ptr<void> ptr_pool, u32 size)
+		{
+			std::lock_guard lock(m_mutex);
+			m_pool  = ptr_pool;
+			m_size  = size;
+			m_avail = size;
+			m_allocs.clear();
+		}
+
+		void release()
+		{
+			std::lock_guard lock(m_mutex);
+			m_pool  = vm::null;
+			m_size  = 0;
+			m_avail = 0;
+			m_allocs.clear();
+		}
+
+		u32 allocate(u32 size)
+		{
+			std::lock_guard lock(m_mutex);
+			if (!size)
+			{
+				np_mem_allocator.error("Can't allocate 0 size buffer!");
+				return 0;
+			}
+
+			// Align allocs
+			const u32 alloc_size = utils::align(size, 4);
+			if (alloc_size > m_avail)
+			{
+				np_mem_allocator.error("Not enough memory available in NP pool!");
+				return 0;
+			}
+
+			u32 last_free    = 0;
+			bool found_space = false;
+
+			for (auto& a : m_allocs)
+			{
+				if ((a.first - last_free) >= alloc_size)
+				{
+					found_space = true;
+					break;
+				}
+
+				last_free = a.first + a.second;
+			}
+
+			if (!found_space)
+			{
+				if ((m_size - last_free) < alloc_size)
+				{
+					np_mem_allocator.error("Not enough memory available in NP pool(continuous block)!");
+					return 0;
+				}
+			}
+
+			m_allocs.emplace(last_free, alloc_size);
+			m_avail -= alloc_size;
+
+			memset((static_cast<u8*>(m_pool.get_ptr())) + last_free, 0, alloc_size);
+
+			np_mem_allocator.trace("Allocation off:%d size:%d psize:%d, pavail:%d", last_free, alloc_size, m_size, m_avail);
+
+			return m_pool.addr() + last_free;
+		}
+
+		void free(u32 addr)
+		{
+			ensure(addr >= m_pool.addr() && addr < (m_pool.addr() + m_size), "memory_allocator::free: addr is out of bounds!");
+
+			const u32 offset = addr - m_pool.addr();
+			ensure(m_allocs.contains(offset), "memory_allocator::free: m_allocs doesn't contain the allocation!");
+
+			m_allocs.erase(offset);
+		}
+
+		void shrink_allocation(u32 addr, u32 new_size)
+		{
+			std::lock_guard lock(m_mutex);
+
+			ensure(addr >= m_pool.addr() && addr < (m_pool.addr() + m_size), "memory_allocator::reduce_allocation: addr is out of bounds!");
+
+			const u32 offset = addr - m_pool.addr();
+			ensure(m_allocs.contains(offset), "memory_allocator::reduce_allocation: m_allocs doesn't contain the allocation!");
+			ensure(m_allocs[offset] >= new_size, "memory_allocator::reduce_allocation: New size is bigger than current allocation!");
+
+			m_allocs[offset] = new_size;
+		}
+
+	private:
+		shared_mutex m_mutex;
+		vm::ptr<void> m_pool{};
+		u32 m_size  = 0;
+		u32 m_avail = 0;
+		std::map<u32, u32> m_allocs{}; // offset/size
+	};
+} // namespace np

--- a/rpcs3/Emu/NP/np_allocator.h
+++ b/rpcs3/Emu/NP/np_allocator.h
@@ -88,11 +88,14 @@ namespace np
 
 		void free(u32 addr)
 		{
+			std::lock_guard lock(m_mutex);
+
 			ensure(addr >= m_pool.addr() && addr < (m_pool.addr() + m_size), "memory_allocator::free: addr is out of bounds!");
 
 			const u32 offset = addr - m_pool.addr();
 			ensure(m_allocs.contains(offset), "memory_allocator::free: m_allocs doesn't contain the allocation!");
 
+			m_avail += m_allocs.at(offset);
 			m_allocs.erase(offset);
 		}
 
@@ -106,6 +109,7 @@ namespace np
 			ensure(m_allocs.contains(offset), "memory_allocator::reduce_allocation: m_allocs doesn't contain the allocation!");
 			ensure(m_allocs[offset] >= new_size, "memory_allocator::reduce_allocation: New size is bigger than current allocation!");
 
+			m_avail += (m_allocs.at(offset) - new_size);
 			m_allocs[offset] = new_size;
 		}
 

--- a/rpcs3/Emu/NP/np_cache.cpp
+++ b/rpcs3/Emu/NP/np_cache.cpp
@@ -1,8 +1,8 @@
 #include "stdafx.h"
 #include <bit>
 
-#include "np_allocator.h"
-#include "np_cache.h"
+#include "Emu/NP/np_allocator.h"
+#include "Emu/NP/np_cache.h"
 
 namespace np
 {

--- a/rpcs3/Emu/NP/np_cache.cpp
+++ b/rpcs3/Emu/NP/np_cache.cpp
@@ -1,0 +1,302 @@
+#include "stdafx.h"
+#include <bit>
+
+#include "np_allocator.h"
+#include "np_cache.h"
+
+namespace np
+{
+	memberbin_cache::memberbin_cache(SceNpMatching2RoomMemberBinAttrInternal* sce_memberbin)
+	{
+		id              = sce_memberbin->data.id;
+		updateDate.tick = sce_memberbin->updateDate.tick;
+		data.resize(sce_memberbin->data.size);
+		memcpy(data.data(), sce_memberbin->data.ptr.get_ptr(), sce_memberbin->data.size);
+	}
+
+	member_cache::member_cache(const SceNpMatching2RoomMemberDataInternal* sce_member)
+	{
+		userInfo.npId = sce_member->userInfo.npId;
+		if (sce_member->userInfo.onlineName)
+		{
+			userInfo.onlineName = *sce_member->userInfo.onlineName;
+		}
+		if (sce_member->userInfo.avatarUrl)
+		{
+			userInfo.avatarUrl = *sce_member->userInfo.avatarUrl;
+		}
+
+		joinDate.tick = sce_member->joinDate.tick;
+		memberId      = sce_member->memberId;
+		teamId        = sce_member->teamId;
+		if (sce_member->roomGroup)
+		{
+			group_id = sce_member->roomGroup->groupId;
+		}
+		else
+		{
+			group_id = 0;
+		}
+
+		natType  = sce_member->natType;
+		flagAttr = sce_member->flagAttr;
+
+		for (u32 i = 0; i < sce_member->roomMemberBinAttrInternalNum; i++)
+		{
+			bins.insert_or_assign(sce_member->roomMemberBinAttrInternal[i].data.id, memberbin_cache(&sce_member->roomMemberBinAttrInternal[i]));
+		}
+	}
+
+	void room_cache::update(const SceNpMatching2RoomDataInternal* sce_roomdata)
+	{
+		num_slots     = sce_roomdata->maxSlot;
+		mask_password = sce_roomdata->passwordSlotMask;
+
+		groups.clear();
+		for (u32 i = 0; i < sce_roomdata->roomGroupNum; i++)
+		{
+			const SceNpMatching2RoomGroup* sce_group = &sce_roomdata->roomGroup[i];
+			memcpy(&groups[sce_group->groupId], sce_group, sizeof(SceNpMatching2RoomGroup));
+		}
+
+		members.clear();
+		vm::bptr<SceNpMatching2RoomMemberDataInternal> sce_member = sce_roomdata->memberList.members;
+		while (sce_member)
+		{
+			members.insert_or_assign(sce_member->memberId, member_cache(sce_member.get_ptr()));
+			sce_member = sce_member->next;
+		}
+
+		if (sce_roomdata->memberList.me == sce_roomdata->memberList.owner)
+		{
+			owner = true;
+		}
+	}
+
+	void cache_manager::insert_room(const SceNpMatching2RoomDataInternal* sce_roomdata)
+	{
+		std::lock_guard lock(mutex);
+
+		rooms[sce_roomdata->roomId].update(sce_roomdata);
+	}
+
+	void cache_manager::add_member(SceNpMatching2RoomId room_id, const SceNpMatching2RoomMemberDataInternal* sce_roommemberdata)
+	{
+		std::lock_guard lock(mutex);
+
+		ensure(rooms.contains(room_id), "cache_manager::add_member: Room not cached!");
+		rooms[room_id].members.insert_or_assign(sce_roommemberdata->memberId, member_cache(sce_roommemberdata));
+	}
+
+	void cache_manager::del_member(SceNpMatching2RoomId room_id, SceNpMatching2RoomMemberId member_id)
+	{
+		std::lock_guard lock(mutex);
+
+		ensure(rooms.contains(room_id), "cache_manager::del_member: Room not cached!");
+		rooms.erase(member_id);
+	}
+
+	void cache_manager::update_password(SceNpMatching2RoomId room_id, const std::optional<SceNpMatching2SessionPassword>& password)
+	{
+		std::lock_guard lock(mutex);
+
+		rooms[room_id].password = password;
+	}
+
+	std::pair<error_code, std::optional<SceNpMatching2RoomSlotInfo>> cache_manager::get_slots(SceNpMatching2RoomId room_id)
+	{
+		std::lock_guard lock(mutex);
+
+		if (!rooms.contains(room_id))
+		{
+			return {SCE_NP_MATCHING2_ERROR_ROOM_NOT_FOUND, {}};
+		}
+
+		const auto& room = rooms[room_id];
+
+		SceNpMatching2RoomSlotInfo slots;
+
+		slots.roomId = room_id;
+
+		SceNpMatching2RoomJoinedSlotMask join_mask = 0;
+		for (const auto& member : room.members)
+		{
+			join_mask |= (1 << (member.first - 1));
+		}
+		slots.joinedSlotMask   = join_mask;
+		slots.passwordSlotMask = room.mask_password;
+
+		u64 joinable_slot_mask = (static_cast<u64>(1) << room.num_slots) - 1;
+		u16 num_private_slots  = std::popcount(room.mask_password & joinable_slot_mask);
+		u16 num_public_slots   = room.num_slots - num_private_slots;
+
+		slots.publicSlotNum  = num_public_slots;
+		slots.privateSlotNum = num_private_slots;
+
+		u16 open_private_slots = num_private_slots - std::popcount(join_mask & room.mask_password);
+		u16 open_public_slots  = num_public_slots - std::popcount(join_mask & (~room.mask_password));
+
+		slots.openPublicSlotNum  = open_public_slots;
+		slots.openPrivateSlotNum = open_private_slots;
+
+		return {CELL_OK, slots};
+	}
+
+	std::pair<error_code, std::vector<SceNpMatching2RoomMemberId>> cache_manager::get_memberids(u64 room_id, s32 sort_method)
+	{
+		std::lock_guard lock(mutex);
+
+		if (!rooms.contains(room_id))
+		{
+			return {SCE_NP_MATCHING2_ERROR_ROOM_NOT_FOUND, {}};
+		}
+
+		const auto& room = rooms[room_id];
+
+		std::vector<SceNpMatching2RoomMemberId> vec_memberids;
+
+		switch (sort_method)
+		{
+		case SCE_NP_MATCHING2_SORT_METHOD_SLOT_NUMBER:
+		{
+			for (const auto& member : room.members)
+			{
+				vec_memberids.push_back(member.first);
+			}
+			break;
+		}
+		case SCE_NP_MATCHING2_SORT_METHOD_JOIN_DATE:
+		{
+			std::map<u64, u16> map_joindate_id;
+
+			for (const auto& member : room.members)
+			{
+				map_joindate_id.insert(std::make_pair(member.second.joinDate.tick, member.first));
+			}
+
+			for (const auto& member : map_joindate_id)
+			{
+				vec_memberids.push_back(member.second);
+			}
+
+			break;
+		}
+		default: fmt::throw_exception("Unreachable");
+		}
+
+		return {CELL_OK, vec_memberids};
+	}
+
+	std::pair<error_code, std::optional<SceNpMatching2SessionPassword>> cache_manager::get_password(SceNpMatching2RoomId room_id)
+	{
+		std::lock_guard lock(mutex);
+
+		if (!rooms.contains(room_id))
+		{
+			return {SCE_NP_MATCHING2_ERROR_ROOM_NOT_FOUND, {}};
+		}
+
+		if (!rooms[room_id].owner)
+		{
+			return {SCE_NP_MATCHING2_ERROR_NOT_ALLOWED, {}};
+		}
+
+		return {CELL_OK, rooms[room_id].password};
+	}
+
+	error_code cache_manager::get_member_and_attrs(SceNpMatching2RoomId room_id, SceNpMatching2RoomMemberId member_id, const std::vector<SceNpMatching2AttributeId>& binattrs_list, SceNpMatching2RoomMemberDataInternal* ptr_member, u32 addr_data, u32 size_data)
+	{
+		std::lock_guard lock(mutex);
+
+		if (!rooms.contains(room_id))
+		{
+			return SCE_NP_MATCHING2_ERROR_ROOM_NOT_FOUND;
+		}
+
+		if (!rooms[room_id].members.contains(member_id))
+		{
+			return SCE_NP_MATCHING2_ERROR_ROOM_MEMBER_NOT_FOUND;
+		}
+
+		const auto& room = rooms.at(room_id);
+		const auto& member = room.members.at(member_id);
+
+		if (ptr_member)
+		{
+			memset(ptr_member, 0, sizeof(SceNpMatching2RoomMemberDataInternal));
+			memcpy(&ptr_member->userInfo.npId, &member.userInfo.npId, sizeof(SceNpId));
+			ptr_member->joinDate.tick = member.joinDate.tick;
+			ptr_member->memberId      = member.memberId;
+			ptr_member->teamId        = member.teamId;
+			ptr_member->natType       = member.natType;
+			ptr_member->flagAttr      = member.flagAttr;
+		}
+
+		const u32 needed_data_size = sizeof(SceNpOnlineName) + sizeof(SceNpAvatarUrl) + sizeof(SceNpMatching2RoomGroup) +
+		                             (binattrs_list.size() * (sizeof(SceNpMatching2RoomMemberBinAttrInternal) + SCE_NP_MATCHING2_ROOMMEMBER_BIN_ATTR_INTERNAL_MAX_SIZE));
+
+		if (!addr_data || !ptr_member)
+		{
+			return needed_data_size;
+		}
+
+		if (size_data < needed_data_size)
+		{
+			return SCE_NP_MATCHING2_ERROR_INSUFFICIENT_BUFFER;
+		}
+
+		memory_allocator mem;
+		mem.setup(vm::ptr<void>(vm::cast(addr_data)), size_data);
+
+		if (member.userInfo.onlineName)
+		{
+			ptr_member->userInfo.onlineName.set(mem.allocate(sizeof(SceNpOnlineName)));
+			memcpy(ptr_member->userInfo.onlineName.get_ptr(), &member.userInfo.onlineName.value(), sizeof(SceNpOnlineName));
+		}
+
+		if (member.userInfo.avatarUrl)
+		{
+			ptr_member->userInfo.avatarUrl.set(mem.allocate(sizeof(SceNpAvatarUrl)));
+			memcpy(ptr_member->userInfo.avatarUrl.get_ptr(), &member.userInfo.avatarUrl.value(), sizeof(SceNpAvatarUrl));
+		}
+
+		if (member.group_id)
+		{
+			ptr_member->roomGroup.set(mem.allocate(sizeof(SceNpMatching2RoomGroup)));
+			memcpy(ptr_member->roomGroup.get_ptr(), &room.groups.at(member.group_id), sizeof(SceNpMatching2RoomGroup));
+		}
+
+		u32 num_binattrs = 0;
+		for (u32 i = 0; i < binattrs_list.size(); i++)
+		{
+			if (member.bins.contains(binattrs_list[i]))
+			{
+				num_binattrs++;
+			}
+		}
+
+		if (num_binattrs)
+		{
+			ptr_member->roomMemberBinAttrInternal.set(mem.allocate(sizeof(SceNpMatching2RoomMemberBinAttrInternal) * num_binattrs));
+			ptr_member->roomMemberBinAttrInternalNum = num_binattrs;
+			SceNpMatching2RoomMemberBinAttrInternal* bin_ptr = ptr_member->roomMemberBinAttrInternal.get_ptr();
+
+			u32 actual_cnt = 0;
+			for (u32 i = 0; i < binattrs_list.size(); i++)
+			{
+				if (member.bins.contains(binattrs_list[i]))
+				{
+					const auto& bin = member.bins.at(binattrs_list[i]);
+					bin_ptr[actual_cnt].updateDate.tick = bin.updateDate.tick;
+					bin_ptr[actual_cnt].data.id = bin.id;
+					bin_ptr[actual_cnt].data.size = bin.data.size();
+					bin_ptr[actual_cnt].data.ptr.set(mem.allocate(bin.data.size()));
+					memcpy(bin_ptr[actual_cnt].data.ptr.get_ptr(), bin.data.data(), bin.data.size());
+					actual_cnt++;
+				}
+			}
+		}
+
+		return needed_data_size;
+	}
+} // namespace np

--- a/rpcs3/Emu/NP/np_cache.h
+++ b/rpcs3/Emu/NP/np_cache.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <map>
+#include <optional>
+
+#include "Utilities/mutex.h"
+
+#include "Emu/Cell/Modules/sceNp.h"
+#include "Emu/Cell/Modules/sceNp2.h"
+
+namespace np
+{
+	struct userinfo_cache
+	{
+		SceNpId npId;
+		std::optional<SceNpOnlineName> onlineName;
+		std::optional<SceNpAvatarUrl> avatarUrl;
+	};
+
+	struct memberbin_cache
+	{
+		memberbin_cache(SceNpMatching2RoomMemberBinAttrInternal* sce_memberbin);
+
+		SceNpMatching2AttributeId id;
+		CellRtcTick updateDate;
+		std::vector<u8> data;
+	};
+
+	struct member_cache
+	{
+		member_cache(const SceNpMatching2RoomMemberDataInternal* sce_member);
+
+		userinfo_cache userInfo;
+		CellRtcTick joinDate;
+		SceNpMatching2RoomMemberId memberId;
+		SceNpMatching2TeamId teamId;
+		SceNpMatching2RoomGroupId group_id;
+		SceNpMatching2NatType natType;
+		SceNpMatching2FlagAttr flagAttr;
+
+		std::map<SceNpMatching2AttributeId, memberbin_cache> bins;
+	};
+
+	struct password_info_cache
+	{
+		bool with_password = false;
+		SceNpMatching2SessionPassword password{};
+	};
+
+	struct room_cache
+	{
+		void update(const SceNpMatching2RoomDataInternal* sce_roomdata);
+
+		u32 num_slots                                    = 0;
+		SceNpMatching2RoomPasswordSlotMask mask_password = 0;
+		std::optional<SceNpMatching2SessionPassword> password;
+
+		std::map<SceNpMatching2RoomGroupId, SceNpMatching2RoomGroup> groups;
+		std::map<SceNpMatching2RoomMemberId, member_cache> members;
+
+		bool owner = false;
+	};
+
+	class cache_manager
+	{
+	public:
+		cache_manager() = default;
+
+		void insert_room(const SceNpMatching2RoomDataInternal* sce_roomdata);
+		void add_member(SceNpMatching2RoomId room_id, const SceNpMatching2RoomMemberDataInternal* sce_roommemberdata);
+		void del_member(SceNpMatching2RoomId room_id, SceNpMatching2RoomMemberId member_id);
+		void update_password(SceNpMatching2RoomId room_id, const std::optional<SceNpMatching2SessionPassword>& password);
+
+		std::pair<error_code, std::optional<SceNpMatching2RoomSlotInfo>> get_slots(SceNpMatching2RoomId room_id);
+		std::pair<error_code, std::vector<SceNpMatching2RoomMemberId>> get_memberids(u64 room_id, s32 sort_method);
+		std::pair<error_code, std::optional<SceNpMatching2SessionPassword>> get_password(SceNpMatching2RoomId room_id);
+		error_code get_member_and_attrs(SceNpMatching2RoomId room_id, SceNpMatching2RoomMemberId member_id, const std::vector<SceNpMatching2AttributeId>& binattrs_list, SceNpMatching2RoomMemberDataInternal* ptr_member, u32 addr_data, u32 size_data);
+
+	private:
+		shared_mutex mutex;
+		std::map<SceNpMatching2RoomId, room_cache> rooms;
+	};
+} // namespace np

--- a/rpcs3/Emu/NP/np_dnshook.cpp
+++ b/rpcs3/Emu/NP/np_dnshook.cpp
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include "np_dnshook.h"
+#include "Emu/NP/np_dnshook.h"
 
 #include "Emu/system_config.h"
 #include "Utilities/StrUtil.h"

--- a/rpcs3/Emu/NP/np_dnshook.cpp
+++ b/rpcs3/Emu/NP/np_dnshook.cpp
@@ -1,0 +1,174 @@
+#include "stdafx.h"
+#include "np_dnshook.h"
+
+#include "Emu/system_config.h"
+#include "Utilities/StrUtil.h"
+#include "util/logs.hpp"
+
+#ifdef _WIN32
+#include <WS2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#endif
+
+LOG_CHANNEL(dnshook_log, "DnsHook");
+
+namespace np
+{
+	dnshook::dnshook()
+	{
+		// Init switch map for dns
+		auto swaps = fmt::split(g_cfg.net.swap_list.to_string(), {"&&"});
+		for (usz i = 0; i < swaps.size(); i++)
+		{
+			auto host_and_ip = fmt::split(swaps[i], {"="});
+			if (host_and_ip.size() != 2)
+			{
+				dnshook_log.error("Pattern <%s> contains more than one '='", swaps[i]);
+				continue;
+			}
+
+			in_addr conv;
+			if (!inet_pton(AF_INET, host_and_ip[1].c_str(), &conv))
+			{
+				dnshook_log.error("IP(%s) provided for %s in the switch list is invalid!", host_and_ip[1], host_and_ip[0]);
+			}
+			else
+			{
+				switch_map[host_and_ip[0]] = conv.s_addr;
+			}
+		}
+	}
+
+	void dnshook::add_dns_spy(u32 sock)
+	{
+		std::lock_guard lock(mutex);
+		dns_spylist.emplace(std::make_pair(sock, std::queue<std::vector<u8>>()));
+	}
+
+	void dnshook::remove_dns_spy(u32 sock)
+	{
+		std::lock_guard lock(mutex);
+		dns_spylist.erase(sock);
+	}
+
+	bool dnshook::is_dns(u32 sock)
+	{
+		std::lock_guard lock(mutex);
+		return dns_spylist.contains(sock);
+	}
+
+	bool dnshook::is_dns_queue(u32 sock)
+	{
+		std::lock_guard lock(mutex);
+		return !dns_spylist.at(sock).empty();
+	}
+
+	std::vector<u8> dnshook::get_dns_packet(u32 sock)
+	{
+		std::lock_guard lock(mutex);
+		auto ret_vec = std::move(dns_spylist.at(sock).front());
+		dns_spylist.at(sock).pop();
+
+		return ret_vec;
+	}
+
+	s32 dnshook::analyze_dns_packet(s32 s, const u8* buf, u32 len)
+	{
+		std::lock_guard lock(mutex);
+		if (dnshook_log.enabled == logs::level::trace)
+		{
+			std::string datrace;
+			const char hex[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+			for (u32 index = 0; index < len; index++)
+			{
+				if ((index % 16) == 0)
+					datrace += '\n';
+
+				datrace += hex[(buf[index] >> 4) & 15];
+				datrace += hex[(buf[index]) & 15];
+				datrace += ' ';
+			}
+			dnshook_log.trace("DNS REQUEST: %s", datrace);
+		}
+
+		struct dns_header
+		{
+			u16 id; // identification number
+
+			u8 rd : 1;     // recursion desired
+			u8 tc : 1;     // truncated message
+			u8 aa : 1;     // authoritive answer
+			u8 opcode : 4; // purpose of message
+			u8 qr : 1;     // query/response flag
+
+			u8 rcode : 4; // response code
+			u8 cd : 1;    // checking disabled
+			u8 ad : 1;    // authenticated data
+			u8 z : 1;     // its z! reserved
+			u8 ra : 1;    // recursion available
+
+			be_t<u16> q_count;    // number of question entries
+			be_t<u16> ans_count;  // number of answer entries
+			be_t<u16> auth_count; // number of authority entries
+			be_t<u16> add_count;  // number of resource entries
+		};
+
+		if (len < sizeof(dns_header))
+			return -1;
+
+		const dns_header* dhead = reinterpret_cast<const dns_header*>(buf);
+		// We are only looking for queries not truncated(todo?), only handle one dns query at a time(todo?)
+		if (dhead->qr != 0 || dhead->tc != 0 || dhead->q_count != 1 || dhead->ans_count != 0 || dhead->auth_count != 0 || dhead->add_count != 0)
+			return -1;
+
+		// Get the actual address
+		u8 count = 0;
+		std::string host{};
+		for (u32 i = sizeof(dns_header); (i < len) && buf[i] != 0; i++)
+		{
+			if (count == 0)
+			{
+				count = buf[i];
+				if (i != sizeof(dns_header))
+				{
+					host += '.';
+				}
+			}
+			else
+			{
+				host += static_cast<char>(buf[i]);
+				count--;
+			}
+		}
+
+		dnshook_log.warning("DNS query for %s", host);
+
+		if (switch_map.contains(host))
+		{
+			// design fake packet
+			std::vector<u8> fake(len);
+			memcpy(fake.data(), buf, len);
+			dns_header* fake_header = reinterpret_cast<dns_header*>(fake.data());
+			fake_header->qr         = 1;
+			fake_header->ra         = 1;
+			fake_header->ans_count  = 1;
+			fake.insert(fake.end(), {0xC0, 0x0C});             // Ref to name in header
+			fake.insert(fake.end(), {0x00, 0x01});             // IPv4
+			fake.insert(fake.end(), {0x00, 0x01});             // Class?
+			fake.insert(fake.end(), {0x00, 0x00, 0x00, 0x3B}); // TTL
+			fake.insert(fake.end(), {0x00, 0x04});             // Size of data
+			u32 ip     = switch_map[host];
+			u8* ptr_ip = reinterpret_cast<u8*>(&ip);
+			fake.insert(fake.end(), ptr_ip, ptr_ip + 4); // IP
+
+			dnshook_log.warning("Solving %s to %d.%d.%d.%d", host, ptr_ip[0], ptr_ip[1], ptr_ip[2], ptr_ip[3]);
+
+			dns_spylist[s].push(std::move(fake));
+			return len;
+		}
+		return -1;
+	}
+} // namespace np

--- a/rpcs3/Emu/NP/np_dnshook.h
+++ b/rpcs3/Emu/NP/np_dnshook.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <map>
+#include <queue>
+#include <vector>
+
+#include "util/types.hpp"
+#include "Utilities/mutex.h"
+
+namespace np
+{
+	class dnshook
+	{
+	public:
+		dnshook();
+
+		void add_dns_spy(u32 sock);
+		void remove_dns_spy(u32 sock);
+
+		bool is_dns(u32 sock);
+		bool is_dns_queue(u32 sock);
+
+		std::vector<u8> get_dns_packet(u32 sock);
+		s32 analyze_dns_packet(s32 s, const u8* buf, u32 len);
+
+	private:
+		shared_mutex mutex;
+		std::map<s32, std::queue<std::vector<u8>>> dns_spylist{};
+		std::map<std::string, u32> switch_map{};
+	};
+} // namespace np

--- a/rpcs3/Emu/NP/np_event_data.h
+++ b/rpcs3/Emu/NP/np_event_data.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "Emu/Memory/vm_ptr.h"
+#include "util/asm.hpp"
+
+namespace np
+{
+	class event_data
+	{
+	public:
+		event_data(u32 vm_addr, u32 initial_size, u32 max_size)
+			: m_max_size(max_size), m_cur_size(utils::align(initial_size, 4))
+		{
+			m_data_ptr.set(vm_addr);
+		}
+
+		u8* data()
+		{
+			return m_data_ptr.get_ptr();
+		}
+
+		const u8* data() const
+		{
+			return m_data_ptr.get_ptr();
+		}
+
+		u32 size() const
+		{
+			return m_cur_size;
+		}
+
+		u32 addr() const
+		{
+			return m_data_ptr.addr();
+		}
+
+		template <typename T>
+		void add_relocation(vm::bptr<T>& dest)
+		{
+			u8* dest_ptr = reinterpret_cast<u8*>(&dest);
+			ensure(dest_ptr >= m_data_ptr.get_ptr() && dest_ptr < (m_data_ptr.get_ptr() + m_cur_size), "event_data::allocate: dest is out of bounds!");
+
+			m_relocs.push_back(static_cast<u32>(dest_ptr - m_data_ptr.get_ptr()));
+		}
+
+		template <typename T>
+		T* allocate(u32 size, vm::bptr<T>& dest)
+		{
+			const u32 to_alloc = utils::align(size, 4);
+			ensure((m_cur_size + to_alloc) <= m_max_size, "event_data::allocate: size would overflow the allocated buffer!");
+
+			u8* dest_ptr = reinterpret_cast<u8*>(&dest);
+			ensure(dest_ptr >= m_data_ptr.get_ptr() && dest_ptr < (m_data_ptr.get_ptr() + m_cur_size), "event_data::allocate: dest is out of bounds!");
+
+			const u32 offset_alloc = m_cur_size;
+
+			// Set the vm::bptr to new allocated portion of memory
+			dest.set(m_data_ptr.addr() + offset_alloc);
+			// Save the relocation offset
+			m_relocs.push_back(static_cast<u32>(dest_ptr - m_data_ptr.get_ptr()));
+			// Update currently allocated space
+			m_cur_size += to_alloc;
+			// Return actual pointer to allocated
+			return reinterpret_cast<T*>(m_data_ptr.get_ptr() + offset_alloc);
+		}
+
+		template <typename T>
+		void allocate_ptr_array(u32 num_pointers, vm::bpptr<T>& dest)
+		{
+			const u32 to_alloc = num_pointers * sizeof(u32);
+			ensure((m_cur_size + to_alloc) <= m_max_size, "event_data::allocate: size would overflow the allocated buffer!");
+
+			u8* dest_ptr = reinterpret_cast<u8*>(&dest);
+			ensure(dest_ptr >= m_data_ptr.get_ptr() && dest_ptr < (m_data_ptr.get_ptr() + m_cur_size), "event_data::allocate_ptr_array: dest is out of bounds!");
+
+			const u32 offset_alloc = m_cur_size;
+
+			// Set the vm::bpptr to relative offset
+			dest.set(m_data_ptr.addr() + offset_alloc);
+			// Save the relocation offset
+			m_relocs.push_back(static_cast<u32>(dest_ptr - m_data_ptr.get_ptr()));
+			// Add all the pointers to the relocation
+			for (u32 i = 0; i < num_pointers; i++)
+			{
+				m_relocs.push_back(offset_alloc + (i * 4));
+			}
+			// Update currently allocated space
+			m_cur_size += to_alloc;
+		}
+
+		void apply_relocations(u32 new_addr)
+		{
+			u32 diff_offset = new_addr - m_data_ptr.addr();
+			for (const auto offset : m_relocs)
+			{
+				auto* ptr = reinterpret_cast<be_t<u32>*>(m_data_ptr.get_ptr() + offset);
+				*ptr += diff_offset;
+			}
+		}
+
+	private:
+		vm::bptr<u8> m_data_ptr;
+		u32 m_max_size, m_cur_size;
+		std::vector<u32> m_relocs;
+	};
+} // namespace np

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -40,1597 +40,715 @@ LOG_CHANNEL(sceNp);
 LOG_CHANNEL(rpcn_log, "rpcn");
 LOG_CHANNEL(nph_log, "NPHandler");
 
-np_handler::np_handler()
+namespace np
 {
-	g_fxo->need<named_thread<signaling_handler>>();
-
-	std::lock_guard lock(mutex_rpcn);
-	rpcn = rpcn::rpcn_client::get_instance();
-
-	is_connected  = (g_cfg.net.net_active == np_internet_status::enabled);
-	is_psn_active = (g_cfg.net.psn_status >= np_psn_status::psn_fake);
-
-	if (get_net_status() == CELL_NET_CTL_STATE_IPObtained)
+	np_handler::np_handler()
 	{
-		discover_ip_address();
-
-		if (!discover_ether_address())
-		{
-			nph_log.error("Failed to discover ethernet address!");
-			is_connected  = false;
-			is_psn_active = false;
-		}
-
-		// Convert dns address
-		// TODO: recover actual user dns through OS specific API
-		in_addr conv{};
-		if (!inet_pton(AF_INET, g_cfg.net.dns.to_string().c_str(), &conv))
-		{
-			// Do not set to disconnected on invalid IP just error and continue using default(google's 8.8.8.8)
-			nph_log.error("Provided IP(%s) address for DNS is invalid!", g_cfg.net.dns.to_string());
-		}
-		else
-		{
-			dns_ip = conv.s_addr;
-		}
-
-		// Init switch map for dns
-		auto swaps = fmt::split(g_cfg.net.swap_list.to_string(), {"&&"});
-		for (usz i = 0; i < swaps.size(); i++)
-		{
-			auto host_and_ip = fmt::split(swaps[i], {"="});
-			if (host_and_ip.size() != 2)
-			{
-				nph_log.error("Pattern <%s> contains more than one '='", swaps[i]);
-				continue;
-			}
-
-			in_addr conv;
-			if (!inet_pton(AF_INET, host_and_ip[1].c_str(), &conv))
-			{
-				nph_log.error("IP(%s) provided for %s in the switch list is invalid!", host_and_ip[1], host_and_ip[0]);
-			}
-			else
-			{
-				switch_map[host_and_ip[0]] = conv.s_addr;
-			}
-		}
-	}
-}
-
-void np_handler::discover_ip_address()
-{
-	hostname.clear();
-	hostname.resize(1024);
-
-	const auto use_default_ip_addr = [this](const std::string_view error_msg)
-	{
-		nph_log.error("discover_ip_address: %s", error_msg);
-		nph_log.error("discover_ip_address: Defaulting to 127.0.0.1!");
-		local_ip_addr  = 0x0100007f;
-		public_ip_addr = local_ip_addr;
-	};
-
-	if (gethostname(hostname.data(), hostname.size()) == -1)
-	{
-		use_default_ip_addr("gethostname failed!");
-		return;
-	}
-
-	nph_log.notice("discover_ip_address: Hostname was determined to be %s", hostname.c_str());
-
-	hostent* host = gethostbyname(hostname.data());
-	if (!host)
-	{
-		use_default_ip_addr("gethostbyname failed!");
-		return;
-	}
-
-	if (host->h_addrtype != AF_INET)
-	{
-		use_default_ip_addr("Could only find IPv6 addresses for current host!");
-		return;
-	}
-
-	// First address is used for now, (TODO combobox with possible local addresses to use?)
-	local_ip_addr = *reinterpret_cast<u32*>(host->h_addr_list[0]);
-
-	// Set public address to local discovered address for now, may be updated later;
-	public_ip_addr = local_ip_addr;
-
-	nph_log.notice("discover_ip_address: IP was determined to be %s", ip_to_string(local_ip_addr));
-}
-
-bool np_handler::discover_ether_address()
-{
-#if defined(__FreeBSD__) || defined(__APPLE__)
-	ifaddrs* ifap;
-
-	if (getifaddrs(&ifap) == 0)
-	{
-		ifaddrs* p;
-		for (p = ifap; p; p = p->ifa_next)
-		{
-			if (p->ifa_addr->sa_family == AF_LINK)
-			{
-				sockaddr_dl* sdp = reinterpret_cast<sockaddr_dl*>(p->ifa_addr);
-				memcpy(ether_address.data(), sdp->sdl_data + sdp->sdl_nlen, 6);
-				freeifaddrs(ifap);
-				nph_log.notice("Determined Ethernet address to be %s", ether_to_string(ether_address));
-				return true;
-			}
-		}
-		freeifaddrs(ifap);
-	}
-#elif defined(_WIN32)
-	std::vector<u8> adapter_infos(sizeof(IP_ADAPTER_INFO));
-	ULONG size_infos = sizeof(IP_ADAPTER_INFO);
-
-	if (GetAdaptersInfo(reinterpret_cast<PIP_ADAPTER_INFO>(adapter_infos.data()), &size_infos) == ERROR_BUFFER_OVERFLOW)
-		adapter_infos.resize(size_infos);
-
-	if (GetAdaptersInfo(reinterpret_cast<PIP_ADAPTER_INFO>(adapter_infos.data()), &size_infos) == NO_ERROR && size_infos)
-	{
-		PIP_ADAPTER_INFO info = reinterpret_cast<PIP_ADAPTER_INFO>(adapter_infos.data());
-		memcpy(ether_address.data(), info[0].Address, 6);
-		nph_log.notice("Determined Ethernet address to be %s", ether_to_string(ether_address));
-		return true;
-	}
-#else
-	ifreq ifr;
-	ifconf ifc;
-	char buf[1024];
-	int success = 0;
-
-	int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
-	if (sock == -1)
-		return false;
-
-	ifc.ifc_len = sizeof(buf);
-	ifc.ifc_buf = buf;
-	if (ioctl(sock, SIOCGIFCONF, &ifc) == -1)
-		return false;
-
-	ifreq* it              = ifc.ifc_req;
-	const ifreq* const end = it + (ifc.ifc_len / sizeof(ifreq));
-
-	for (; it != end; ++it)
-	{
-		strcpy(ifr.ifr_name, it->ifr_name);
-		if (ioctl(sock, SIOCGIFFLAGS, &ifr) == 0)
-		{
-			if (!(ifr.ifr_flags & IFF_LOOPBACK))
-			{
-				if (ioctl(sock, SIOCGIFHWADDR, &ifr) == 0)
-				{
-					success = 1;
-					break;
-				}
-			}
-		}
-	}
-
-	if (success)
-	{
-		memcpy(ether_address.data(), ifr.ifr_hwaddr.sa_data, 6);
-		nph_log.notice("Determined Ethernet address to be %s", ether_to_string(ether_address));
-
-		return true;
-	}
-#endif
-
-	return false;
-}
-
-const std::array<u8, 6>& np_handler::get_ether_addr() const
-{
-	return ether_address;
-}
-
-const std::string& np_handler::get_hostname() const
-{
-	return hostname;
-}
-
-u32 np_handler::get_local_ip_addr() const
-{
-	return local_ip_addr;
-}
-
-u32 np_handler::get_public_ip_addr() const
-{
-	return public_ip_addr;
-}
-
-u32 np_handler::get_dns_ip() const
-{
-	return dns_ip;
-}
-
-s32 np_handler::get_net_status() const
-{
-	return is_connected ? CELL_NET_CTL_STATE_IPObtained : CELL_NET_CTL_STATE_Disconnected;
-}
-
-s32 np_handler::get_psn_status() const
-{
-	return is_psn_active ? SCE_NP_MANAGER_STATUS_ONLINE : SCE_NP_MANAGER_STATUS_OFFLINE;
-}
-
-const SceNpId& np_handler::get_npid() const
-{
-	return npid;
-}
-
-const SceNpOnlineId& np_handler::get_online_id() const
-{
-	return npid.handle;
-}
-
-const SceNpOnlineName& np_handler::get_online_name() const
-{
-	return online_name;
-}
-
-const SceNpAvatarUrl& np_handler::get_avatar_url() const
-{
-	return avatar_url;
-}
-
-std::string np_handler::ip_to_string(u32 ip_addr)
-{
-	char ip_str[16];
-
-	inet_ntop(AF_INET, &ip_addr, ip_str, sizeof(ip_str));
-	return std::string(ip_str);
-}
-
-std::string np_handler::ether_to_string(std::array<u8, 6>& ether)
-{
-	return fmt::format("%02X:%02X:%02X:%02X:%02X:%02X", ether[0], ether[1], ether[2], ether[3], ether[4], ether[5]);
-}
-
-void np_handler::string_to_npid(const std::string& str, SceNpId* npid)
-{
-	memset(npid, 0, sizeof(SceNpId));
-	strcpy_trunc(npid->handle.data, str);
-	// npid->reserved[0] = 1;
-}
-
-void np_handler::string_to_online_name(const std::string& str, SceNpOnlineName* online_name)
-{
-	strcpy_trunc(online_name->data, str);
-}
-
-void np_handler::string_to_avatar_url(const std::string& str, SceNpAvatarUrl* avatar_url)
-{
-	strcpy_trunc(avatar_url->data, str);
-}
-
-void np_handler::string_to_communication_id(const std::string& str, SceNpCommunicationId* comm_id)
-{
-	strcpy_trunc(comm_id->data, str);
-}
-
-void np_handler::init_NP(u32 poolsize, vm::ptr<void> poolptr)
-{
-	// Init memory pool
-	mpool       = poolptr;
-	mpool_size  = poolsize;
-	mpool_avail = poolsize;
-	mpool_allocs.clear();
-
-	memset(&npid, 0, sizeof(npid));
-	memset(&online_name, 0, sizeof(online_name));
-	memset(&avatar_url, 0, sizeof(avatar_url));
-
-	if (g_cfg.net.psn_status >= np_psn_status::psn_fake)
-	{
-		std::string s_npid = g_cfg_rpcn.get_npid();
-		ensure(!s_npid.empty()); // It should have been generated before this
-
-		np_handler::string_to_npid(s_npid, &npid);
-		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-		sigh.set_self_sig_info(npid);
-	}
-
-	switch (g_cfg.net.psn_status)
-	{
-	case np_psn_status::disabled:
-		break;
-	case np_psn_status::psn_fake:
-	{
-		np_handler::string_to_online_name("RPCS3's user", &online_name);
-		np_handler::string_to_avatar_url("https://rpcs3.net/cdn/netplay/DefaultAvatar.png", &avatar_url);
-		break;
-	}
-	case np_psn_status::psn_rpcn:
-	{
-		if (!is_psn_active)
-			break;
+		g_fxo->need<named_thread<signaling_handler>>();
 
 		std::lock_guard lock(mutex_rpcn);
 		rpcn = rpcn::rpcn_client::get_instance();
 
-		// Make sure we're connected
+		is_connected  = (g_cfg.net.net_active == np_internet_status::enabled);
+		is_psn_active = (g_cfg.net.psn_status >= np_psn_status::psn_fake);
 
-		if (auto state = rpcn->wait_for_connection(); state != rpcn::rpcn_state::failure_no_failure)
+		if (get_net_status() == CELL_NET_CTL_STATE_IPObtained)
 		{
-			rpcn_log.error("Connection to RPCN Failed!");
-			is_psn_active = false;
+			discover_ip_address();
+
+			if (!discover_ether_address())
+			{
+				nph_log.error("Failed to discover ethernet address!");
+				is_connected  = false;
+				is_psn_active = false;
+			}
+
+			// Convert dns address
+			// TODO: recover actual user dns through OS specific API
+			in_addr conv{};
+			if (!inet_pton(AF_INET, g_cfg.net.dns.to_string().c_str(), &conv))
+			{
+				// Do not set to disconnected on invalid IP just error and continue using default(google's 8.8.8.8)
+				nph_log.error("Provided IP(%s) address for DNS is invalid!", g_cfg.net.dns.to_string());
+			}
+			else
+			{
+				dns_ip = conv.s_addr;
+			}
+
+			// Init switch map for dns
+			auto swaps = fmt::split(g_cfg.net.swap_list.to_string(), {"&&"});
+			for (usz i = 0; i < swaps.size(); i++)
+			{
+				auto host_and_ip = fmt::split(swaps[i], {"="});
+				if (host_and_ip.size() != 2)
+				{
+					nph_log.error("Pattern <%s> contains more than one '='", swaps[i]);
+					continue;
+				}
+
+				in_addr conv;
+				if (!inet_pton(AF_INET, host_and_ip[1].c_str(), &conv))
+				{
+					nph_log.error("IP(%s) provided for %s in the switch list is invalid!", host_and_ip[1], host_and_ip[0]);
+				}
+				else
+				{
+					switch_map[host_and_ip[0]] = conv.s_addr;
+				}
+			}
+		}
+	}
+
+	void np_handler::discover_ip_address()
+	{
+		hostname.clear();
+		hostname.resize(1024);
+
+		const auto use_default_ip_addr = [this](const std::string_view error_msg)
+		{
+			nph_log.error("discover_ip_address: %s", error_msg);
+			nph_log.error("discover_ip_address: Defaulting to 127.0.0.1!");
+			local_ip_addr  = 0x0100007f;
+			public_ip_addr = local_ip_addr;
+		};
+
+		if (gethostname(hostname.data(), hostname.size()) == -1)
+		{
+			use_default_ip_addr("gethostname failed!");
 			return;
 		}
 
-		if (auto state = rpcn->wait_for_authentified(); state != rpcn::rpcn_state::failure_no_failure)
+		nph_log.notice("discover_ip_address: Hostname was determined to be %s", hostname.c_str());
+
+		hostent* host = gethostbyname(hostname.data());
+		if (!host)
 		{
-			rpcn_log.error("RPCN login attempt failed!");
-			is_psn_active = false;
+			use_default_ip_addr("gethostbyname failed!");
 			return;
 		}
 
-		np_handler::string_to_online_name(rpcn->get_online_name(), &online_name);
-		np_handler::string_to_avatar_url(rpcn->get_avatar_url(), &avatar_url);
-		public_ip_addr = rpcn->get_addr_sig();
-
-		break;
-	}
-	default:
-		break;
-	}
-}
-
-void np_handler::terminate_NP()
-{
-	// TODO: proper cleanup of everything here
-
-	// Unregister basic handler
-	basic_handler.registered = false;
-
-	// Reset memory pool
-	mpool.set(0);
-	mpool_size  = 0;
-	mpool_avail = 0;
-	mpool_allocs.clear();
-
-	if (g_cfg.net.psn_status == np_psn_status::psn_rpcn)
-	{
-		rpcn_log.notice("Disconnecting from RPCN!");
-		std::lock_guard lock(mutex_rpcn);
-		rpcn.reset();
-	}
-}
-
-vm::addr_t np_handler::allocate(u32 size)
-{
-	if (!size)
-		return vm::cast(static_cast<u64>(0));
-
-	// Align allocs
-	const u32 alloc_size = utils::align(size, 4);
-	if (alloc_size > mpool_avail)
-	{
-		sceNp.error("Not enough memory available in NP pool!");
-		return vm::cast<u32>(0);
-	}
-
-	u32 last_free    = 0;
-	bool found_space = false;
-
-	for (auto& a : mpool_allocs)
-	{
-		if ((a.first - last_free) >= alloc_size)
+		if (host->h_addrtype != AF_INET)
 		{
-			found_space = true;
+			use_default_ip_addr("Could only find IPv6 addresses for current host!");
+			return;
+		}
+
+		// First address is used for now, (TODO combobox with possible local addresses to use?)
+		local_ip_addr = *reinterpret_cast<u32*>(host->h_addr_list[0]);
+
+		// Set public address to local discovered address for now, may be updated later;
+		public_ip_addr = local_ip_addr;
+
+		nph_log.notice("discover_ip_address: IP was determined to be %s", ip_to_string(local_ip_addr));
+	}
+
+	bool np_handler::discover_ether_address()
+	{
+#if defined(__FreeBSD__) || defined(__APPLE__)
+		ifaddrs* ifap;
+
+		if (getifaddrs(&ifap) == 0)
+		{
+			ifaddrs* p;
+			for (p = ifap; p; p = p->ifa_next)
+			{
+				if (p->ifa_addr->sa_family == AF_LINK)
+				{
+					sockaddr_dl* sdp = reinterpret_cast<sockaddr_dl*>(p->ifa_addr);
+					memcpy(ether_address.data(), sdp->sdl_data + sdp->sdl_nlen, 6);
+					freeifaddrs(ifap);
+					nph_log.notice("Determined Ethernet address to be %s", ether_to_string(ether_address));
+					return true;
+				}
+			}
+			freeifaddrs(ifap);
+		}
+#elif defined(_WIN32)
+		std::vector<u8> adapter_infos(sizeof(IP_ADAPTER_INFO));
+		ULONG size_infos = sizeof(IP_ADAPTER_INFO);
+
+		if (GetAdaptersInfo(reinterpret_cast<PIP_ADAPTER_INFO>(adapter_infos.data()), &size_infos) == ERROR_BUFFER_OVERFLOW)
+			adapter_infos.resize(size_infos);
+
+		if (GetAdaptersInfo(reinterpret_cast<PIP_ADAPTER_INFO>(adapter_infos.data()), &size_infos) == NO_ERROR && size_infos)
+		{
+			PIP_ADAPTER_INFO info = reinterpret_cast<PIP_ADAPTER_INFO>(adapter_infos.data());
+			memcpy(ether_address.data(), info[0].Address, 6);
+			nph_log.notice("Determined Ethernet address to be %s", ether_to_string(ether_address));
+			return true;
+		}
+#else
+		ifreq ifr;
+		ifconf ifc;
+		char buf[1024];
+		int success = 0;
+
+		int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+		if (sock == -1)
+			return false;
+
+		ifc.ifc_len = sizeof(buf);
+		ifc.ifc_buf = buf;
+		if (ioctl(sock, SIOCGIFCONF, &ifc) == -1)
+			return false;
+
+		ifreq* it              = ifc.ifc_req;
+		const ifreq* const end = it + (ifc.ifc_len / sizeof(ifreq));
+
+		for (; it != end; ++it)
+		{
+			strcpy(ifr.ifr_name, it->ifr_name);
+			if (ioctl(sock, SIOCGIFFLAGS, &ifr) == 0)
+			{
+				if (!(ifr.ifr_flags & IFF_LOOPBACK))
+				{
+					if (ioctl(sock, SIOCGIFHWADDR, &ifr) == 0)
+					{
+						success = 1;
+						break;
+					}
+				}
+			}
+		}
+
+		if (success)
+		{
+			memcpy(ether_address.data(), ifr.ifr_hwaddr.sa_data, 6);
+			nph_log.notice("Determined Ethernet address to be %s", ether_to_string(ether_address));
+
+			return true;
+		}
+#endif
+
+		return false;
+	}
+
+	const std::array<u8, 6>& np_handler::get_ether_addr() const
+	{
+		return ether_address;
+	}
+
+	const std::string& np_handler::get_hostname() const
+	{
+		return hostname;
+	}
+
+	u32 np_handler::get_local_ip_addr() const
+	{
+		return local_ip_addr;
+	}
+
+	u32 np_handler::get_public_ip_addr() const
+	{
+		return public_ip_addr;
+	}
+
+	u32 np_handler::get_dns_ip() const
+	{
+		return dns_ip;
+	}
+
+	s32 np_handler::get_net_status() const
+	{
+		return is_connected ? CELL_NET_CTL_STATE_IPObtained : CELL_NET_CTL_STATE_Disconnected;
+	}
+
+	s32 np_handler::get_psn_status() const
+	{
+		return is_psn_active ? SCE_NP_MANAGER_STATUS_ONLINE : SCE_NP_MANAGER_STATUS_OFFLINE;
+	}
+
+	const SceNpId& np_handler::get_npid() const
+	{
+		return npid;
+	}
+
+	const SceNpOnlineId& np_handler::get_online_id() const
+	{
+		return npid.handle;
+	}
+
+	const SceNpOnlineName& np_handler::get_online_name() const
+	{
+		return online_name;
+	}
+
+	const SceNpAvatarUrl& np_handler::get_avatar_url() const
+	{
+		return avatar_url;
+	}
+
+	void np_handler::init_NP(u32 poolsize, vm::ptr<void> poolptr)
+	{
+		// Init memory pool
+		np_memory.setup(poolptr, poolsize);
+
+		memset(&npid, 0, sizeof(npid));
+		memset(&online_name, 0, sizeof(online_name));
+		memset(&avatar_url, 0, sizeof(avatar_url));
+
+		if (g_cfg.net.psn_status >= np_psn_status::psn_fake)
+		{
+			std::string s_npid = g_cfg_rpcn.get_npid();
+			ensure(!s_npid.empty()); // It should have been generated before this
+
+			string_to_npid(s_npid, &npid);
+			auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
+			sigh.set_self_sig_info(npid);
+		}
+
+		switch (g_cfg.net.psn_status)
+		{
+		case np_psn_status::disabled:
+			break;
+		case np_psn_status::psn_fake:
+		{
+			string_to_online_name("RPCS3's user", &online_name);
+			string_to_avatar_url("https://rpcs3.net/cdn/netplay/DefaultAvatar.png", &avatar_url);
 			break;
 		}
-
-		last_free = a.first + a.second;
-	}
-
-	if (!found_space)
-	{
-		if ((mpool_size - last_free) < alloc_size)
+		case np_psn_status::psn_rpcn:
 		{
-			sceNp.error("Not enough memory available in NP pool(continuous block)!");
-			return vm::cast<u32>(0);
+			if (!is_psn_active)
+				break;
+
+			std::lock_guard lock(mutex_rpcn);
+			rpcn = rpcn::rpcn_client::get_instance();
+
+			// Make sure we're connected
+
+			if (auto state = rpcn->wait_for_connection(); state != rpcn::rpcn_state::failure_no_failure)
+			{
+				rpcn_log.error("Connection to RPCN Failed!");
+				is_psn_active = false;
+				return;
+			}
+
+			if (auto state = rpcn->wait_for_authentified(); state != rpcn::rpcn_state::failure_no_failure)
+			{
+				rpcn_log.error("RPCN login attempt failed!");
+				is_psn_active = false;
+				return;
+			}
+
+			string_to_online_name(rpcn->get_online_name(), &online_name);
+			string_to_avatar_url(rpcn->get_avatar_url(), &avatar_url);
+			public_ip_addr = rpcn->get_addr_sig();
+
+			break;
+		}
+		default:
+			break;
 		}
 	}
 
-	mpool_allocs.emplace(last_free, alloc_size);
-	mpool_avail -= alloc_size;
-
-	memset((static_cast<u8*>(mpool.get_ptr())) + last_free, 0, alloc_size);
-
-	sceNp.trace("Allocation off:%d size:%d psize:%d, pavail:%d", last_free, alloc_size, mpool_size, mpool_avail);
-
-	return vm::cast(mpool.addr() + last_free);
-}
-
-std::vector<SceNpMatching2ServerId> np_handler::get_match2_server_list(SceNpMatching2ContextId ctx_id)
-{
-	std::vector<SceNpMatching2ServerId> server_list{};
-
-	if (g_cfg.net.psn_status != np_psn_status::psn_rpcn)
+	void np_handler::terminate_NP()
 	{
-		return server_list;
-	}
+		np_memory.release();
 
-	if (!rpcn->get_server_list(get_req_id(0), get_match2_context(ctx_id)->communicationId, server_list))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return server_list;
-}
-
-u32 np_handler::get_server_status(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id)
-{
-	// TODO: actually implement interaction with server for this?
-	u32 req_id    = generate_callback_info(ctx_id, optParam);
-	u32 event_key = get_event_key();
-
-	SceNpMatching2GetServerInfoResponse* serv_info = reinterpret_cast<SceNpMatching2GetServerInfoResponse*>(allocate_req_result(event_key, sizeof(SceNpMatching2GetServerInfoResponse)));
-	serv_info->server.serverId                     = server_id;
-	serv_info->server.status                       = SCE_NP_MATCHING2_SERVER_STATUS_AVAILABLE;
-
-	const auto cb_info = take_pending_request(req_id);
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+		if (g_cfg.net.psn_status == np_psn_status::psn_rpcn)
 		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_GetServerInfo, event_key, 0, sizeof(SceNpMatching2GetServerInfoResponse), cb_info.cb_arg);
+			rpcn_log.notice("Disconnecting from RPCN!");
+			std::lock_guard lock(mutex_rpcn);
+			rpcn.reset();
+		}
+	}
+
+	u32 np_handler::get_match2_event(SceNpMatching2EventKey event_key, u32 dest_addr, u32 size)
+	{
+		std::lock_guard lock(mutex_match2_req_results);
+
+		if (!match2_req_results.contains(event_key))
 			return 0;
-		});
 
-	return req_id;
-}
+		auto& data = match2_req_results.at(event_key);
+		data.apply_relocations(dest_addr);
 
-u32 np_handler::create_server_context(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 /*server_id*/)
-{
-	u32 req_id    = generate_callback_info(ctx_id, optParam);
-	u32 event_key = get_event_key();
+		vm::ptr<void> dest = vm::cast(dest_addr);
 
-	const auto cb_info = take_pending_request(req_id);
+		u32 size_copied = std::min(size, data.size());
+		memcpy(dest.get_ptr(), data.data(), size_copied);
 
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+		np_memory.free(data.addr());
+		match2_req_results.erase(event_key);
+
+		return size_copied;
+	}
+
+	bool np_handler::send_basic_event(s32 event, s32 retCode, u32 reqId)
+	{
+		if (basic_handler.registered)
 		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_CreateServerContext, event_key, 0, 0, cb_info.cb_arg);
-			return 0;
-		});
+			sysutil_register_cb([handler_func = this->basic_handler.handler_func, handler_arg = this->basic_handler.handler_arg, event, retCode, reqId](ppu_thread& cb_ppu) -> s32
+				{
+					handler_func(cb_ppu, event, retCode, reqId, handler_arg);
+					return 0;
+				});
 
-	return req_id;
-}
+			return true;
+		}
 
-u32 np_handler::get_world_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->get_world_list(req_id, get_match2_context(ctx_id)->communicationId, server_id))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
+		return false;
 	}
 
-	return req_id;
-}
-
-u32 np_handler::create_join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2CreateJoinRoomRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->createjoin_room(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2JoinRoomRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->join_room(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::leave_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2LeaveRoomRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->leave_room(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::search_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SearchRoomRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->search_room(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::get_roomdata_external_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataExternalListRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->get_roomdata_external_list(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::set_roomdata_external(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataExternalRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	extra_nps::print_set_roomdata_ext_req(req);
-
-	if (!rpcn->set_roomdata_external(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::get_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataInternalRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->get_roomdata_internal(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::set_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataInternalRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	extra_nps::print_set_roomdata_int_req(req);
-
-	if (!rpcn->set_roomdata_internal(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::set_roommemberdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomMemberDataInternalRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->set_roommemberdata_internal(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::get_ping_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SignalingGetPingInfoRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->ping_room_owner(req_id, get_match2_context(ctx_id)->communicationId, req->roomId))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-u32 np_handler::send_room_message(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SendRoomMessageRequest* req)
-{
-	u32 req_id = generate_callback_info(ctx_id, optParam);
-
-	if (!rpcn->send_room_message(req_id, get_match2_context(ctx_id)->communicationId, req))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return req_id;
-}
-
-void np_handler::req_sign_infos(const std::string& npid, u32 conn_id)
-{
-	u32 req_id = get_req_id(0x3333);
-	{
-		std::lock_guard lock(mutex_pending_sign_infos_requests);
-		pending_sign_infos_requests[req_id] = conn_id;
-	}
-
-	if (!rpcn->req_sign_infos(req_id, npid))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return;
-}
-
-void np_handler::req_ticket(u32 /*version*/, const SceNpId* /*npid*/, const char* service_id, const u8* /*cookie*/, u32 /*cookie_size*/, const char* /*entitlement_id*/, u32 /*consumed_count*/)
-{
-	u32 req_id = get_req_id(0x3333);
-
-	std::string service_id_str(service_id);
-
-	if (!rpcn->req_ticket(req_id, service_id_str))
-	{
-		rpcn_log.error("Disconnecting from RPCN!");
-		is_psn_active = false;
-	}
-
-	return;
-}
-
-u32 np_handler::get_match2_event(SceNpMatching2EventKey event_key, u8* dest, u32 size)
-{
-	std::lock_guard lock(mutex_req_results);
-
-	if (!match2_req_results.contains(event_key))
-		return 0;
-
-	u32 size_copied = std::min(size, static_cast<u32>(match2_req_results.at(event_key).size()));
-	memcpy(dest, match2_req_results.at(event_key).data(), size_copied);
-
-	return size_copied;
-}
-
-bool np_handler::send_basic_event(s32 event, s32 retCode, u32 reqId)
-{
-	if (basic_handler.registered)
-	{
-		sysutil_register_cb([handler_func = this->basic_handler.handler_func, handler_arg = this->basic_handler.handler_arg, event, retCode, reqId](ppu_thread& cb_ppu) -> s32
-			{
-				handler_func(cb_ppu, event, retCode, reqId, handler_arg);
-				return 0;
-			});
-
-		return true;
-	}
-
-	return false;
-}
-
-void np_handler::queue_basic_event(basic_event to_queue)
-{
-	std::lock_guard lock(mutex_queue_basic_events);
-	queue_basic_events.push(std::move(to_queue));
-}
-
-error_code np_handler::get_basic_event(vm::ptr<s32> event, vm::ptr<SceNpUserInfo> from, vm::ptr<s32> data, vm::ptr<u32> size)
-{
-	basic_event cur_event;
+	void np_handler::queue_basic_event(basic_event to_queue)
 	{
 		std::lock_guard lock(mutex_queue_basic_events);
-		if (queue_basic_events.empty())
+		queue_basic_events.push(std::move(to_queue));
+	}
+
+	error_code np_handler::get_basic_event(vm::ptr<s32> event, vm::ptr<SceNpUserInfo> from, vm::ptr<s32> data, vm::ptr<u32> size)
+	{
+		basic_event cur_event;
 		{
-			return not_an_error(SCE_NP_BASIC_ERROR_NO_EVENT);
+			std::lock_guard lock(mutex_queue_basic_events);
+			if (queue_basic_events.empty())
+			{
+				return not_an_error(SCE_NP_BASIC_ERROR_NO_EVENT);
+			}
+
+			cur_event = std::move(queue_basic_events.front());
+			queue_basic_events.pop();
 		}
 
-		cur_event = std::move(queue_basic_events.front());
-		queue_basic_events.pop();
-	}
+		const u32 size_avail = *size;
+		u32 res_size         = std::min(static_cast<u32>(cur_event.data.size()), size_avail);
 
-	const u32 size_avail = *size;
-	u32 res_size         = std::min(static_cast<u32>(cur_event.data.size()), size_avail);
+		*event = cur_event.event;
+		memcpy(from.get_ptr(), &cur_event.from, sizeof(cur_event.from));
+		memcpy(data.get_ptr(), cur_event.data.data(), res_size);
+		*size = res_size;
 
-	*event = cur_event.event;
-	memcpy(from.get_ptr(), &cur_event.from, sizeof(cur_event.from));
-	memcpy(data.get_ptr(), cur_event.data.data(), res_size);
-	*size = res_size;
-
-	if (res_size < cur_event.data.size())
-	{
-		return SCE_NP_BASIC_ERROR_DATA_LOST;
-	}
-
-	return CELL_OK;
-}
-
-std::optional<std::shared_ptr<std::pair<std::string, message_data>>> np_handler::get_message(u64 id)
-{
-	return rpcn->get_message(id);
-}
-
-void np_handler::operator()()
-{
-	if (g_cfg.net.psn_status != np_psn_status::psn_rpcn)
-		return;
-
-	while (thread_ctrl::state() != thread_state::aborting && !Emu.IsStopped())
-	{
-		bool sleep = true;
-		if (rpcn)
+		if (res_size < cur_event.data.size())
 		{
-			std::lock_guard lock(mutex_rpcn);
-			if (!rpcn)
-			{
-				continue;
-			}
+			return SCE_NP_BASIC_ERROR_DATA_LOST;
+		}
 
-			auto replies = rpcn->get_replies();
-			for (auto& reply : replies)
-			{
-				const u16 command     = reply.second.first;
-				const u32 req_id      = reply.first;
-				std::vector<u8>& data = reply.second.second;
+		return CELL_OK;
+	}
 
-				switch (command)
+	std::optional<std::shared_ptr<std::pair<std::string, message_data>>> np_handler::get_message(u64 id)
+	{
+		return rpcn->get_message(id);
+	}
+
+	void np_handler::operator()()
+	{
+		if (g_cfg.net.psn_status != np_psn_status::psn_rpcn)
+			return;
+
+		while (thread_ctrl::state() != thread_state::aborting && !Emu.IsStopped())
+		{
+			bool sleep = true;
+			if (rpcn)
+			{
+				std::lock_guard lock(mutex_rpcn);
+				if (!rpcn)
 				{
-				case rpcn::CommandType::GetWorldList: reply_get_world_list(req_id, data); break;
-				case rpcn::CommandType::CreateRoom: reply_create_join_room(req_id, data); break;
-				case rpcn::CommandType::JoinRoom: reply_join_room(req_id, data); break;
-				case rpcn::CommandType::LeaveRoom: reply_leave_room(req_id, data); break;
-				case rpcn::CommandType::SearchRoom: reply_search_room(req_id, data); break;
-				case rpcn::CommandType::GetRoomDataExternalList: reply_get_roomdata_external_list(req_id, data); break;
-				case rpcn::CommandType::SetRoomDataExternal: reply_set_roomdata_external(req_id, data); break;
-				case rpcn::CommandType::GetRoomDataInternal: reply_get_roomdata_internal(req_id, data); break;
-				case rpcn::CommandType::SetRoomDataInternal: reply_set_roomdata_internal(req_id, data); break;
-				case rpcn::CommandType::SetRoomMemberDataInternal: reply_set_roommemberdata_internal(req_id, data); break;
-				case rpcn::CommandType::PingRoomOwner: reply_get_ping_info(req_id, data); break;
-				case rpcn::CommandType::SendRoomMessage: reply_send_room_message(req_id, data); break;
-				case rpcn::CommandType::RequestSignalingInfos: reply_req_sign_infos(req_id, data); break;
-				case rpcn::CommandType::RequestTicket: reply_req_ticket(req_id, data); break;
-				default: rpcn_log.error("Unknown reply(%d) received!", command); break;
+					continue;
 				}
-			}
 
-			auto notifications = rpcn->get_notifications();
-			for (auto& notif : notifications)
-			{
-				switch (notif.first)
+				auto replies = rpcn->get_replies();
+				for (auto& reply : replies)
 				{
-				case rpcn::NotificationType::UserJoinedRoom: notif_user_joined_room(notif.second); break;
-				case rpcn::NotificationType::UserLeftRoom: notif_user_left_room(notif.second); break;
-				case rpcn::NotificationType::RoomDestroyed: notif_room_destroyed(notif.second); break;
-				case rpcn::NotificationType::UpdatedRoomDataInternal: notif_updated_room_data_internal(notif.second); break;
-				case rpcn::NotificationType::UpdatedRoomMemberDataInternal: notif_updated_room_member_data_internal(notif.second); break;
-				case rpcn::NotificationType::SignalP2PConnect: notif_p2p_connect(notif.second); break;
-				case rpcn::NotificationType::RoomMessageReceived: notif_room_message_received(notif.second); break;
-				default: rpcn_log.error("Unknown notification(%d) received!", notif.first); break;
-				}
-			}
+					const u16 command     = reply.second.first;
+					const u32 req_id      = reply.first;
+					std::vector<u8>& data = reply.second.second;
 
-			auto messages = rpcn->get_new_messages();
-			if (basic_handler.registered)
-			{
-				for (const auto msg_id : messages)
-				{
-					const auto opt_msg = rpcn->get_message(msg_id);
-					if (!opt_msg)
+					switch (command)
 					{
-						continue;
+					case rpcn::CommandType::GetWorldList: reply_get_world_list(req_id, data); break;
+					case rpcn::CommandType::CreateRoom: reply_create_join_room(req_id, data); break;
+					case rpcn::CommandType::JoinRoom: reply_join_room(req_id, data); break;
+					case rpcn::CommandType::LeaveRoom: reply_leave_room(req_id, data); break;
+					case rpcn::CommandType::SearchRoom: reply_search_room(req_id, data); break;
+					case rpcn::CommandType::GetRoomDataExternalList: reply_get_roomdata_external_list(req_id, data); break;
+					case rpcn::CommandType::SetRoomDataExternal: reply_set_roomdata_external(req_id, data); break;
+					case rpcn::CommandType::GetRoomDataInternal: reply_get_roomdata_internal(req_id, data); break;
+					case rpcn::CommandType::SetRoomDataInternal: reply_set_roomdata_internal(req_id, data); break;
+					case rpcn::CommandType::SetRoomMemberDataInternal: reply_set_roommemberdata_internal(req_id, data); break;
+					case rpcn::CommandType::PingRoomOwner: reply_get_ping_info(req_id, data); break;
+					case rpcn::CommandType::SendRoomMessage: reply_send_room_message(req_id, data); break;
+					case rpcn::CommandType::RequestSignalingInfos: reply_req_sign_infos(req_id, data); break;
+					case rpcn::CommandType::RequestTicket: reply_req_ticket(req_id, data); break;
+					default: rpcn_log.error("Unknown reply(%d) received!", command); break;
 					}
-					const auto& msg = opt_msg.value();
-					if (strncmp(msg->second.commId.data, basic_handler.context.data, sizeof(basic_handler.context.data) - 1) == 0)
+				}
+
+				auto notifications = rpcn->get_notifications();
+				for (auto& notif : notifications)
+				{
+					switch (notif.first)
 					{
-						u32 event;
-						switch (msg->second.mainType)
+					case rpcn::NotificationType::UserJoinedRoom: notif_user_joined_room(notif.second); break;
+					case rpcn::NotificationType::UserLeftRoom: notif_user_left_room(notif.second); break;
+					case rpcn::NotificationType::RoomDestroyed: notif_room_destroyed(notif.second); break;
+					case rpcn::NotificationType::UpdatedRoomDataInternal: notif_updated_room_data_internal(notif.second); break;
+					case rpcn::NotificationType::UpdatedRoomMemberDataInternal: notif_updated_room_member_data_internal(notif.second); break;
+					case rpcn::NotificationType::SignalP2PConnect: notif_p2p_connect(notif.second); break;
+					case rpcn::NotificationType::RoomMessageReceived: notif_room_message_received(notif.second); break;
+					default: rpcn_log.error("Unknown notification(%d) received!", notif.first); break;
+					}
+				}
+
+				auto messages = rpcn->get_new_messages();
+				if (basic_handler.registered)
+				{
+					for (const auto msg_id : messages)
+					{
+						const auto opt_msg = rpcn->get_message(msg_id);
+						if (!opt_msg)
 						{
-						case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_DATA_ATTACHMENT:
-							event = SCE_NP_BASIC_EVENT_INCOMING_ATTACHMENT;
-							break;
-						case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_INVITE:
-							event = (msg->second.msgFeatures & SCE_NP_BASIC_MESSAGE_FEATURES_BOOTABLE) ? SCE_NP_BASIC_EVENT_INCOMING_BOOTABLE_INVITATION : SCE_NP_BASIC_EVENT_INCOMING_INVITATION;
-							break;
-						case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_CUSTOM_DATA:
-							event = (msg->second.msgFeatures & SCE_NP_BASIC_MESSAGE_FEATURES_BOOTABLE) ? SCE_NP_BASIC_EVENT_INCOMING_BOOTABLE_CUSTOM_DATA_MESSAGE : SCE_NP_BASIC_EVENT_INCOMING_CUSTOM_DATA_MESSAGE;
-							break;
-						case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_GENERAL:
-						case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_ADD_FRIEND:
-						case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_URL_ATTACHMENT:
-							event = SCE_NP_BASIC_EVENT_MESSAGE;
-						default:
 							continue;
 						}
+						const auto& msg = opt_msg.value();
+						if (strncmp(msg->second.commId.data, basic_handler.context.data, sizeof(basic_handler.context.data) - 1) == 0)
+						{
+							u32 event;
+							switch (msg->second.mainType)
+							{
+							case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_DATA_ATTACHMENT:
+								event = SCE_NP_BASIC_EVENT_INCOMING_ATTACHMENT;
+								break;
+							case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_INVITE:
+								event = (msg->second.msgFeatures & SCE_NP_BASIC_MESSAGE_FEATURES_BOOTABLE) ? SCE_NP_BASIC_EVENT_INCOMING_BOOTABLE_INVITATION : SCE_NP_BASIC_EVENT_INCOMING_INVITATION;
+								break;
+							case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_CUSTOM_DATA:
+								event = (msg->second.msgFeatures & SCE_NP_BASIC_MESSAGE_FEATURES_BOOTABLE) ? SCE_NP_BASIC_EVENT_INCOMING_BOOTABLE_CUSTOM_DATA_MESSAGE : SCE_NP_BASIC_EVENT_INCOMING_CUSTOM_DATA_MESSAGE;
+								break;
+							case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_GENERAL:
+							case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_ADD_FRIEND:
+							case SCE_NP_BASIC_MESSAGE_MAIN_TYPE_URL_ATTACHMENT:
+								event = SCE_NP_BASIC_EVENT_MESSAGE;
+							default:
+								continue;
+							}
 
-						basic_event to_add{};
-						to_add.event = event;
-						strcpy_trunc(to_add.from.userId.handle.data, msg->first);
-						strcpy_trunc(to_add.from.name.data, msg->first);
+							basic_event to_add{};
+							to_add.event = event;
+							strcpy_trunc(to_add.from.userId.handle.data, msg->first);
+							strcpy_trunc(to_add.from.name.data, msg->first);
 
-						queue_basic_event(std::move(to_add));
-						send_basic_event(event, 0, 0);
+							queue_basic_event(std::move(to_add));
+							send_basic_event(event, 0, 0);
+						}
 					}
+				}
+
+				if (!replies.empty() || !notifications.empty())
+				{
+					sleep = false;
 				}
 			}
 
-			if (!replies.empty() || !notifications.empty())
+			// TODO: replace with an appropriate semaphore
+			if (sleep)
 			{
-				sleep = false;
+				thread_ctrl::wait_for(200'000);
+				continue;
+			}
+		}
+	}
+
+	void np_handler::add_dns_spy(u32 sock)
+	{
+		dns_spylist.emplace(std::make_pair(sock, std::queue<std::vector<u8>>()));
+	}
+
+	void np_handler::remove_dns_spy(u32 sock)
+	{
+		dns_spylist.erase(sock);
+	}
+
+	bool np_handler::is_dns(u32 sock) const
+	{
+		return dns_spylist.contains(sock);
+	}
+
+	bool np_handler::is_dns_queue(u32 sock) const
+	{
+		return !dns_spylist.at(sock).empty();
+	}
+
+	std::vector<u8> np_handler::get_dns_packet(u32 sock)
+	{
+		auto ret_vec = std::move(dns_spylist.at(sock).front());
+		dns_spylist.at(sock).pop();
+
+		return ret_vec;
+	}
+
+	s32 np_handler::analyze_dns_packet(s32 s, const u8* buf, u32 len)
+	{
+		if (sys_net.enabled == logs::level::trace)
+		{
+			std::string datrace;
+			const char hex[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+			for (u32 index = 0; index < len; index++)
+			{
+				if ((index % 16) == 0)
+					datrace += '\n';
+
+				datrace += hex[(buf[index] >> 4) & 15];
+				datrace += hex[(buf[index]) & 15];
+				datrace += ' ';
+			}
+			sys_net.trace("DNS REQUEST: %s", datrace);
+		}
+
+		struct dns_header
+		{
+			u16 id; // identification number
+
+			u8 rd : 1;     // recursion desired
+			u8 tc : 1;     // truncated message
+			u8 aa : 1;     // authoritive answer
+			u8 opcode : 4; // purpose of message
+			u8 qr : 1;     // query/response flag
+
+			u8 rcode : 4; // response code
+			u8 cd : 1;    // checking disabled
+			u8 ad : 1;    // authenticated data
+			u8 z : 1;     // its z! reserved
+			u8 ra : 1;    // recursion available
+
+			be_t<u16> q_count;    // number of question entries
+			be_t<u16> ans_count;  // number of answer entries
+			be_t<u16> auth_count; // number of authority entries
+			be_t<u16> add_count;  // number of resource entries
+		};
+
+		if (len < sizeof(dns_header))
+			return -1;
+
+		const dns_header* dhead = reinterpret_cast<const dns_header*>(buf);
+		// We are only looking for queries not truncated(todo?), only handle one dns query at a time(todo?)
+		if (dhead->qr != 0 || dhead->tc != 0 || dhead->q_count != 1 || dhead->ans_count != 0 || dhead->auth_count != 0 || dhead->add_count != 0)
+			return -1;
+
+		// Get the actual address
+		u8 count = 0;
+		std::string host{};
+		for (u32 i = sizeof(dns_header); (i < len) && buf[i] != 0; i++)
+		{
+			if (count == 0)
+			{
+				count = buf[i];
+				if (i != sizeof(dns_header))
+				{
+					host += '.';
+				}
+			}
+			else
+			{
+				host += static_cast<char>(buf[i]);
+				count--;
 			}
 		}
 
-		// TODO: replace with an appropriate semaphore
-		if (sleep)
+		sys_net.warning("DNS query for %s", host);
+
+		if (switch_map.contains(host))
 		{
-			thread_ctrl::wait_for(200'000);
-			continue;
+			// design fake packet
+			std::vector<u8> fake(len);
+			memcpy(fake.data(), buf, len);
+			dns_header* fake_header = reinterpret_cast<dns_header*>(fake.data());
+			fake_header->qr         = 1;
+			fake_header->ra         = 1;
+			fake_header->ans_count  = 1;
+			fake.insert(fake.end(), {0xC0, 0x0C});             // Ref to name in header
+			fake.insert(fake.end(), {0x00, 0x01});             // IPv4
+			fake.insert(fake.end(), {0x00, 0x01});             // Class?
+			fake.insert(fake.end(), {0x00, 0x00, 0x00, 0x3B}); // TTL
+			fake.insert(fake.end(), {0x00, 0x04});             // Size of data
+			u32 ip     = switch_map[host];
+			u8* ptr_ip = reinterpret_cast<u8*>(&ip);
+			fake.insert(fake.end(), ptr_ip, ptr_ip + 4); // IP
+
+			sys_net.warning("Solving %s to %d.%d.%d.%d", host, ptr_ip[0], ptr_ip[1], ptr_ip[2], ptr_ip[3]);
+
+			dns_spylist[s].push(std::move(fake));
+			return len;
 		}
-	}
-}
 
-bool np_handler::reply_get_world_list(u32 req_id, std::vector<u8>& reply_data)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	vec_stream reply(reply_data, 1);
-
-	std::vector<u32> world_list;
-	u32 num_worlds = reply.get<u32>();
-	for (u32 i = 0; i < num_worlds; i++)
-	{
-		world_list.push_back(reply.get<u32>());
-	}
-
-	if (reply.is_error())
-	{
-		world_list.clear();
-		return error_and_disconnect("Malformed reply to GetWorldList command");
-	}
-
-	u32 event_key = get_event_key();
-
-	SceNpMatching2GetWorldInfoListResponse* world_info = reinterpret_cast<SceNpMatching2GetWorldInfoListResponse*>(allocate_req_result(event_key, sizeof(SceNpMatching2GetWorldInfoListResponse)));
-	world_info->worldNum                               = world_list.size();
-
-	if (!world_list.empty())
-	{
-		world_info->world.set(allocate(sizeof(SceNpMatching2World) * world_list.size()));
-		for (usz i = 0; i < world_list.size(); i++)
-		{
-			world_info->world[i].worldId                  = world_list[i];
-			world_info->world[i].numOfLobby               = 1; // TODO
-			world_info->world[i].maxNumOfTotalLobbyMember = 10000;
-			world_info->world[i].curNumOfTotalLobbyMember = 1;
-			world_info->world[i].curNumOfRoom             = 1;
-			world_info->world[i].curNumOfTotalRoomMember  = 1;
-		}
-	}
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_GetWorldInfoList, event_key, 0, sizeof(SceNpMatching2GetWorldInfoListResponse), cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_create_join_room(u32 req_id, std::vector<u8>& reply_data)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	vec_stream reply(reply_data, 1);
-	auto create_room_resp = reply.get_rawdata();
-
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to CreateRoom command");
-
-	u32 event_key = get_event_key();
-
-	auto resp = flatbuffers::GetRoot<RoomDataInternal>(create_room_resp.data());
-
-	SceNpMatching2CreateJoinRoomResponse* room_resp = reinterpret_cast<SceNpMatching2CreateJoinRoomResponse*>(allocate_req_result(event_key, sizeof(SceNpMatching2CreateJoinRoomResponse)));
-	vm::ptr<SceNpMatching2RoomDataInternal> room_info(allocate(sizeof(SceNpMatching2RoomDataInternal)));
-	room_resp->roomDataInternal = room_info;
-
-	RoomDataInternal_to_SceNpMatching2RoomDataInternal(resp, room_info.get_ptr(), npid);
-
-	// Establish Matching2 self signaling info
-	auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-	sigh.set_self_sig2_info(room_info->roomId, 1);
-	sigh.set_sig2_infos(room_info->roomId, 1, SCE_NP_SIGNALING_CONN_STATUS_ACTIVE, rpcn->get_addr_sig(), rpcn->get_port_sig(), true);
-	// TODO? Should this send a message to Signaling CB? Is this even necessary?
-
-	extra_nps::print_create_room_resp(room_resp);
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_CreateJoinRoom, event_key, 0, sizeof(SceNpMatching2CreateJoinRoomResponse), cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_join_room(u32 req_id, std::vector<u8>& reply_data)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	vec_stream reply(reply_data, 1);
-
-	auto join_room_resp = reply.get_rawdata();
-
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to JoinRoom command");
-
-	u32 event_key = get_event_key();
-
-	auto resp = flatbuffers::GetRoot<RoomDataInternal>(join_room_resp.data());
-
-	SceNpMatching2JoinRoomResponse* room_resp = reinterpret_cast<SceNpMatching2JoinRoomResponse*>(allocate_req_result(event_key, sizeof(SceNpMatching2JoinRoomResponse)));
-	vm::ptr<SceNpMatching2RoomDataInternal> room_info(allocate(sizeof(SceNpMatching2RoomDataInternal)));
-	room_resp->roomDataInternal = room_info;
-
-	u16 member_id = RoomDataInternal_to_SceNpMatching2RoomDataInternal(resp, room_info.get_ptr(), npid);
-
-	extra_nps::print_room_data_internal(room_resp->roomDataInternal.get_ptr());
-
-	// Establish Matching2 self signaling info
-	auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-	sigh.set_self_sig2_info(room_info->roomId, member_id);
-	sigh.set_sig2_infos(room_info->roomId, member_id, SCE_NP_SIGNALING_CONN_STATUS_ACTIVE, rpcn->get_addr_sig(), rpcn->get_port_sig(), true);
-	// TODO? Should this send a message to Signaling CB? Is this even necessary?
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_JoinRoom, event_key, 0, sizeof(SceNpMatching2JoinRoomResponse), cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_leave_room(u32 req_id, std::vector<u8>& reply_data)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	vec_stream reply(reply_data, 1);
-	u64 room_id = reply.get<u64>();
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to LeaveRoom command");
-
-	u32 event_key = get_event_key(); // Unsure if necessary if there is no data
-
-	// Disconnect all users from that room
-	auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-	sigh.disconnect_sig2_users(room_id);
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_LeaveRoom, event_key, 0, 0, cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_search_room(u32 req_id, std::vector<u8>& reply_data)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	vec_stream reply(reply_data, 1);
-	auto search_room_resp = reply.get_rawdata();
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to SearchRoom command");
-
-	u32 event_key = get_event_key();
-
-	auto resp                                     = flatbuffers::GetRoot<SearchRoomResponse>(search_room_resp.data());
-	SceNpMatching2SearchRoomResponse* search_resp = reinterpret_cast<SceNpMatching2SearchRoomResponse*>(allocate_req_result(event_key, sizeof(SceNpMatching2SearchRoomResponse)));
-
-	SearchRoomResponse_to_SceNpMatching2SearchRoomResponse(resp, search_resp);
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SearchRoom, event_key, 0, sizeof(SceNpMatching2SearchRoomResponse), cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_get_roomdata_external_list(u32 req_id, std::vector<u8>& reply_data)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	vec_stream reply(reply_data, 1);
-	auto get_room_ext_resp = reply.get_rawdata();
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to GetRoomDataExternalList command");
-
-	u32 event_key = get_event_key();
-
-	auto resp                                                           = flatbuffers::GetRoot<GetRoomDataExternalListResponse>(get_room_ext_resp.data());
-	SceNpMatching2GetRoomDataExternalListResponse* np_get_room_ext_resp = reinterpret_cast<SceNpMatching2GetRoomDataExternalListResponse*>(allocate_req_result(event_key, sizeof(SceNpMatching2GetRoomDataExternalListResponse)));
-
-	GetRoomDataExternalListResponse_to_SceNpMatching2GetRoomDataExternalListResponse(resp, np_get_room_ext_resp);
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SearchRoom, event_key, 0, sizeof(SceNpMatching2SearchRoomResponse), cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_set_roomdata_external(u32 req_id, std::vector<u8>& /*reply_data*/)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	u32 event_key = get_event_key(); // Unsure if necessary if there is no data
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SetRoomDataExternal, event_key, 0, 0, cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_get_roomdata_internal(u32 req_id, std::vector<u8>& reply_data)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	vec_stream reply(reply_data, 1);
-
-	auto internal_data = reply.get_rawdata();
-
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to GetRoomDataInternal command");
-
-	u32 event_key = get_event_key();
-
-	auto resp                                            = flatbuffers::GetRoot<RoomDataInternal>(internal_data.data());
-	SceNpMatching2GetRoomDataInternalResponse* room_resp = reinterpret_cast<SceNpMatching2GetRoomDataInternalResponse*>(allocate_req_result(event_key, sizeof(SceNpMatching2GetRoomDataInternalResponse)));
-	vm::ptr<SceNpMatching2RoomDataInternal> room_info(allocate(sizeof(SceNpMatching2RoomDataInternal)));
-	room_resp->roomDataInternal = room_info;
-	RoomDataInternal_to_SceNpMatching2RoomDataInternal(resp, room_info.get_ptr(), npid);
-
-	extra_nps::print_room_data_internal(room_resp->roomDataInternal.get_ptr());
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_GetRoomDataInternal, event_key, 0, sizeof(SceNpMatching2GetRoomDataInternalResponse), cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_set_roomdata_internal(u32 req_id, std::vector<u8>& /*reply_data*/)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	u32 event_key = get_event_key(); // Unsure if necessary if there is no data
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SetRoomDataInternal, event_key, 0, 0, cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_set_roommemberdata_internal(u32 req_id, std::vector<u8>& /*reply_data*/)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	u32 event_key = get_event_key(); // Unsure if necessary if there is no data
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SetRoomMemberDataInternal, event_key, 0, 0, cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_get_ping_info(u32 req_id, std::vector<u8>& reply_data)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	vec_stream reply(reply_data, 1);
-
-	auto ping_resp = reply.get_rawdata();
-
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to PingRoomOwner command");
-
-	u32 event_key = get_event_key();
-
-	auto resp                                                   = flatbuffers::GetRoot<GetPingInfoResponse>(ping_resp.data());
-	SceNpMatching2SignalingGetPingInfoResponse* final_ping_resp = reinterpret_cast<SceNpMatching2SignalingGetPingInfoResponse*>(allocate_req_result(event_key, sizeof(SceNpMatching2SignalingGetPingInfoResponse)));
-	GetPingInfoResponse_to_SceNpMatching2SignalingGetPingInfoResponse(resp, final_ping_resp);
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SignalingGetPingInfo, event_key, 0, sizeof(SceNpMatching2SignalingGetPingInfoResponse), cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_send_room_message(u32 req_id, std::vector<u8>& /*reply_data*/)
-{
-	const auto cb_info = take_pending_request(req_id);
-
-	sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
-		{
-			cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SendRoomMessage, 0, 0, 0, cb_info.cb_arg);
-			return 0;
-		});
-
-	return true;
-}
-
-bool np_handler::reply_req_sign_infos(u32 req_id, std::vector<u8>& reply_data)
-{
-	u32 conn_id;
-	{
-		std::lock_guard lock(mutex_pending_sign_infos_requests);
-		conn_id = pending_sign_infos_requests.at(req_id);
-		pending_sign_infos_requests.erase(req_id);
-	}
-
-	vec_stream reply(reply_data, 1);
-	u32 addr = reply.get<u32>();
-	u16 port = reply.get<u16>();
-
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to RequestSignalingInfos command");
-
-	auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-	sigh.start_sig(conn_id, addr, port);
-
-	return true;
-}
-
-bool np_handler::reply_req_ticket(u32 /*req_id*/, std::vector<u8>& reply_data)
-{
-	vec_stream reply(reply_data, 1);
-	auto ticket_raw = reply.get_rawdata();
-
-	if (reply.is_error())
-		return error_and_disconnect("Malformed reply to RequestTicket command");
-
-	current_ticket   = std::move(ticket_raw);
-	auto ticket_size = static_cast<s32>(current_ticket.size());
-
-	if (manager_cb)
-	{
-		sysutil_register_cb([manager_cb = this->manager_cb, ticket_size, manager_cb_arg = this->manager_cb_arg](ppu_thread& cb_ppu) -> s32
-			{
-				manager_cb(cb_ppu, SCE_NP_MANAGER_EVENT_GOT_TICKET, ticket_size, manager_cb_arg);
-				return 0;
-			});
-	}
-
-	return true;
-}
-
-void np_handler::notif_user_joined_room(std::vector<u8>& data)
-{
-	vec_stream noti(data);
-	u64 room_id          = noti.get<u64>();
-	auto update_info_raw = noti.get_rawdata();
-
-	if (noti.is_error())
-	{
-		rpcn_log.error("Received faulty UserJoinedRoom notification");
-		return;
-	}
-
-	u32 event_key = get_event_key();
-
-	auto update_info                               = flatbuffers::GetRoot<RoomMemberUpdateInfo>(update_info_raw.data());
-	SceNpMatching2RoomMemberUpdateInfo* notif_data = reinterpret_cast<SceNpMatching2RoomMemberUpdateInfo*>(allocate_req_result(event_key, sizeof(SceNpMatching2RoomMemberUpdateInfo)));
-	RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(update_info, notif_data);
-
-	rpcn_log.notice("Received notification that user %s(%d) joined the room(%d)", notif_data->roomMemberDataInternal->userInfo.npId.handle.data, notif_data->roomMemberDataInternal->memberId, room_id);
-	extra_nps::print_room_member_data_internal(notif_data->roomMemberDataInternal.get_ptr());
-
-	sysutil_register_cb([room_event_cb = this->room_event_cb, room_id, event_key, room_event_cb_ctx = this->room_event_cb_ctx, room_event_cb_arg = this->room_event_cb_arg](ppu_thread& cb_ppu) -> s32
-		{
-			room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_MemberJoined, event_key, 0, sizeof(SceNpMatching2RoomMemberUpdateInfo), room_event_cb_arg);
-			return 0;
-		});
-}
-
-void np_handler::notif_user_left_room(std::vector<u8>& data)
-{
-	vec_stream noti(data);
-	u64 room_id          = noti.get<u64>();
-	auto update_info_raw = noti.get_rawdata();
-
-	if (noti.is_error())
-	{
-		rpcn_log.error("Received faulty UserLeftRoom notification");
-		return;
-	}
-
-	u32 event_key = get_event_key();
-
-	auto update_info                               = flatbuffers::GetRoot<RoomMemberUpdateInfo>(update_info_raw.data());
-	SceNpMatching2RoomMemberUpdateInfo* notif_data = reinterpret_cast<SceNpMatching2RoomMemberUpdateInfo*>(allocate_req_result(event_key, sizeof(SceNpMatching2RoomMemberUpdateInfo)));
-	RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(update_info, notif_data);
-
-	rpcn_log.notice("Received notification that user %s(%d) left the room(%d)", notif_data->roomMemberDataInternal->userInfo.npId.handle.data, notif_data->roomMemberDataInternal->memberId, room_id);
-	extra_nps::print_room_member_data_internal(notif_data->roomMemberDataInternal.get_ptr());
-
-	sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg](ppu_thread& cb_ppu) -> s32
-		{
-			room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_MemberLeft, event_key, 0, sizeof(SceNpMatching2RoomMemberUpdateInfo), room_event_cb_arg);
-			return 0;
-		});
-}
-
-void np_handler::notif_room_destroyed(std::vector<u8>& data)
-{
-	vec_stream noti(data);
-	u64 room_id          = noti.get<u64>();
-	auto update_info_raw = noti.get_rawdata();
-
-	if (noti.is_error())
-	{
-		rpcn_log.error("Received faulty RoomDestroyed notification");
-		return;
-	}
-
-	u32 event_key = get_event_key();
-
-	auto update_info                         = flatbuffers::GetRoot<RoomUpdateInfo>(update_info_raw.data());
-	SceNpMatching2RoomUpdateInfo* notif_data = reinterpret_cast<SceNpMatching2RoomUpdateInfo*>(allocate_req_result(event_key, sizeof(SceNpMatching2RoomUpdateInfo)));
-	RoomUpdateInfo_to_SceNpMatching2RoomUpdateInfo(update_info, notif_data);
-
-	rpcn_log.notice("Received notification that room(%d) was destroyed", room_id);
-
-	auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-	sigh.disconnect_sig2_users(room_id);
-
-	sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg](ppu_thread& cb_ppu) -> s32
-		{
-			room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_RoomDestroyed, event_key, 0, sizeof(SceNpMatching2RoomUpdateInfo), room_event_cb_arg);
-			return 0;
-		});
-}
-
-void np_handler::notif_updated_room_data_internal(std::vector<u8>& data)
-{
-	vec_stream noti(data);
-	SceNpMatching2RoomId room_id = noti.get<u64>();
-	auto update_info_raw         = noti.get_rawdata();
-
-	if (noti.is_error())
-	{
-		rpcn_log.error("Received faulty UpdatedRoomDataInternal notification");
-		return;
-	}
-
-	u32 event_key = get_event_key();
-
-	auto update_info                                     = flatbuffers::GetRoot<RoomDataInternalUpdateInfo>(update_info_raw.data());
-	SceNpMatching2RoomDataInternalUpdateInfo* notif_data = reinterpret_cast<SceNpMatching2RoomDataInternalUpdateInfo*>(allocate_req_result(event_key, sizeof(SceNpMatching2RoomDataInternalUpdateInfo)));
-
-	RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(update_info, notif_data, npid);
-
-	extra_nps::print_room_data_internal(notif_data->newRoomDataInternal.get_ptr());
-
-	rpcn_log.notice("Received notification that room(%d)'s data was updated", room_id);
-
-	auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-	sigh.disconnect_sig2_users(room_id);
-
-	sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg](ppu_thread& cb_ppu) -> s32
-		{
-			room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_UpdatedRoomDataInternal, event_key, 0, sizeof(SceNpMatching2RoomDataInternalUpdateInfo), room_event_cb_arg);
-			return 0;
-		});
-}
-
-void np_handler::notif_updated_room_member_data_internal(std::vector<u8>& data)
-{
-	vec_stream noti(data);
-	SceNpMatching2RoomId room_id = noti.get<u64>();
-	auto update_info_raw         = noti.get_rawdata();
-
-	if (noti.is_error())
-	{
-		rpcn_log.error("Received faulty UpdatedRoomMemberDataInternal notification");
-		return;
-	}
-
-	u32 event_key = get_event_key();
-
-	auto update_info                                           = flatbuffers::GetRoot<RoomMemberDataInternalUpdateInfo>(update_info_raw.data());
-	SceNpMatching2RoomMemberDataInternalUpdateInfo* notif_data = reinterpret_cast<SceNpMatching2RoomMemberDataInternalUpdateInfo*>(allocate_req_result(event_key, sizeof(SceNpMatching2RoomMemberDataInternalUpdateInfo)));
-	RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(update_info, notif_data);
-
-	rpcn_log.notice("Received notification that user's %s(%d) room (%d) data was updated", notif_data->newRoomMemberDataInternal->userInfo.npId.handle.data, notif_data->newRoomMemberDataInternal->memberId, room_id);
-	extra_nps::print_room_member_data_internal(notif_data->newRoomMemberDataInternal.get_ptr());
-
-	sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg](ppu_thread& cb_ppu) -> s32
-		{
-			room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_UpdatedRoomMemberDataInternal, event_key, 0, sizeof(SceNpMatching2RoomMemberDataInternalUpdateInfo), room_event_cb_arg);
-			return 0;
-		});
-}
-
-void np_handler::notif_p2p_connect(std::vector<u8>& data)
-{
-	if (data.size() != 16)
-	{
-		rpcn_log.error("Notification data for SignalP2PConnect != 14");
-		return;
-	}
-
-	const u64 room_id   = reinterpret_cast<le_t<u64>&>(data[0]);
-	const u16 member_id = reinterpret_cast<le_t<u16>&>(data[8]);
-	const u16 port_p2p  = reinterpret_cast<be_t<u16>&>(data[10]);
-	const u32 addr_p2p  = reinterpret_cast<le_t<u32>&>(data[12]);
-
-	rpcn_log.notice("Received notification to connect to member(%d) of room(%d): %s:%d", member_id, room_id, ip_to_string(addr_p2p), port_p2p);
-
-	// Attempt Signaling
-	auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-	sigh.set_sig2_infos(room_id, member_id, SCE_NP_SIGNALING_CONN_STATUS_PENDING, addr_p2p, port_p2p);
-	sigh.start_sig2(room_id, member_id);
-}
-
-void np_handler::notif_room_message_received(std::vector<u8>& data)
-{
-	vec_stream noti(data);
-	u64 room_id           = noti.get<u64>();
-	u16 member_id         = noti.get<u16>();
-	auto message_info_raw = noti.get_rawdata();
-
-	if (noti.is_error())
-	{
-		rpcn_log.error("Received faulty RoomMessageReceived notification");
-		return;
-	}
-
-	u32 event_key = get_event_key();
-
-	auto message_info                         = flatbuffers::GetRoot<RoomMessageInfo>(message_info_raw.data());
-	SceNpMatching2RoomMessageInfo* notif_data = reinterpret_cast<SceNpMatching2RoomMessageInfo*>(allocate_req_result(event_key, sizeof(SceNpMatching2RoomMessageInfo)));
-	RoomMessageInfo_to_SceNpMatching2RoomMessageInfo(message_info, notif_data);
-
-	rpcn_log.notice("Received notification of a room message from member(%d) in room(%d)", member_id, room_id);
-
-	if (room_msg_cb)
-	{
-		sysutil_register_cb([room_msg_cb = this->room_msg_cb, room_msg_cb_ctx = this->room_msg_cb_ctx, room_id, member_id, event_key, room_msg_cb_arg = this->room_msg_cb_arg](ppu_thread& cb_ppu) -> s32
-			{
-				room_msg_cb(cb_ppu, room_msg_cb_ctx, room_id, member_id, SCE_NP_MATCHING2_ROOM_MSG_EVENT_Message, event_key, 0, sizeof(SceNpMatching2RoomUpdateInfo), room_msg_cb_arg);
-				return 0;
-			});
-	}
-}
-
-void np_handler::add_dns_spy(u32 sock)
-{
-	dns_spylist.emplace(std::make_pair(sock, std::queue<std::vector<u8>>()));
-}
-
-void np_handler::remove_dns_spy(u32 sock)
-{
-	dns_spylist.erase(sock);
-}
-
-bool np_handler::is_dns(u32 sock) const
-{
-	return dns_spylist.contains(sock);
-}
-
-bool np_handler::is_dns_queue(u32 sock) const
-{
-	return !dns_spylist.at(sock).empty();
-}
-
-std::vector<u8> np_handler::get_dns_packet(u32 sock)
-{
-	auto ret_vec = std::move(dns_spylist.at(sock).front());
-	dns_spylist.at(sock).pop();
-
-	return ret_vec;
-}
-
-s32 np_handler::analyze_dns_packet(s32 s, const u8* buf, u32 len)
-{
-	if (sys_net.enabled == logs::level::trace)
-	{
-		std::string datrace;
-		const char hex[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
-
-		for (u32 index = 0; index < len; index++)
-		{
-			if ((index % 16) == 0)
-				datrace += '\n';
-
-			datrace += hex[(buf[index] >> 4) & 15];
-			datrace += hex[(buf[index]) & 15];
-			datrace += ' ';
-		}
-		sys_net.trace("DNS REQUEST: %s", datrace);
-	}
-
-	struct dns_header
-	{
-		u16 id; // identification number
-
-		u8 rd : 1;     // recursion desired
-		u8 tc : 1;     // truncated message
-		u8 aa : 1;     // authoritive answer
-		u8 opcode : 4; // purpose of message
-		u8 qr : 1;     // query/response flag
-
-		u8 rcode : 4; // response code
-		u8 cd : 1;    // checking disabled
-		u8 ad : 1;    // authenticated data
-		u8 z : 1;     // its z! reserved
-		u8 ra : 1;    // recursion available
-
-		be_t<u16> q_count;    // number of question entries
-		be_t<u16> ans_count;  // number of answer entries
-		be_t<u16> auth_count; // number of authority entries
-		be_t<u16> add_count;  // number of resource entries
-	};
-
-	if (len < sizeof(dns_header))
 		return -1;
-
-	const dns_header* dhead = reinterpret_cast<const dns_header*>(buf);
-	// We are only looking for queries not truncated(todo?), only handle one dns query at a time(todo?)
-	if (dhead->qr != 0 || dhead->tc != 0 || dhead->q_count != 1 || dhead->ans_count != 0 || dhead->auth_count != 0 || dhead->add_count != 0)
-		return -1;
-
-	// Get the actual address
-	u8 count = 0;
-	std::string host{};
-	for (u32 i = sizeof(dns_header); (i < len) && buf[i] != 0; i++)
-	{
-		if (count == 0)
-		{
-			count = buf[i];
-			if (i != sizeof(dns_header))
-			{
-				host += '.';
-			}
-		}
-		else
-		{
-			host += static_cast<char>(buf[i]);
-			count--;
-		}
 	}
 
-	sys_net.warning("DNS query for %s", host);
-
-	if (switch_map.contains(host))
+	bool np_handler::error_and_disconnect(const std::string& error_msg)
 	{
-		// design fake packet
-		std::vector<u8> fake(len);
-		memcpy(fake.data(), buf, len);
-		dns_header* fake_header = reinterpret_cast<dns_header*>(fake.data());
-		fake_header->qr         = 1;
-		fake_header->ra         = 1;
-		fake_header->ans_count  = 1;
-		fake.insert(fake.end(), {0xC0, 0x0C});             // Ref to name in header
-		fake.insert(fake.end(), {0x00, 0x01});             // IPv4
-		fake.insert(fake.end(), {0x00, 0x01});             // Class?
-		fake.insert(fake.end(), {0x00, 0x00, 0x00, 0x3B}); // TTL
-		fake.insert(fake.end(), {0x00, 0x04});             // Size of data
-		u32 ip     = switch_map[host];
-		u8* ptr_ip = reinterpret_cast<u8*>(&ip);
-		fake.insert(fake.end(), ptr_ip, ptr_ip + 4); // IP
+		rpcn_log.error("%s", error_msg);
+		rpcn.reset();
 
-		sys_net.warning("Solving %s to %d.%d.%d.%d", host, ptr_ip[0], ptr_ip[1], ptr_ip[2], ptr_ip[3]);
-
-		dns_spylist[s].push(std::move(fake));
-		return len;
+		return false;
 	}
 
-	return -1;
-}
+	u32 np_handler::generate_callback_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam)
+	{
+		callback_info ret;
 
-bool np_handler::error_and_disconnect(const std::string& error_msg)
-{
-	rpcn_log.error("%s", error_msg);
-	rpcn.reset();
+		const auto ctx = get_match2_context(ctx_id);
+		ensure(ctx);
 
-	return false;
-}
+		const u32 req_id = get_req_id(optParam ? optParam->appReqId : ctx->default_match2_optparam.appReqId);
 
-u32 np_handler::generate_callback_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam)
-{
-	callback_info ret;
+		ret.ctx_id = ctx_id;
+		ret.cb     = optParam ? optParam->cbFunc : ctx->default_match2_optparam.cbFunc;
+		ret.cb_arg = optParam ? optParam->cbFuncArg : ctx->default_match2_optparam.cbFuncArg;
 
-	const auto ctx = get_match2_context(ctx_id);
-	ensure(ctx);
+		nph_log.warning("Callback used is 0x%x", ret.cb);
 
-	const u32 req_id = get_req_id(optParam ? optParam->appReqId : ctx->default_match2_optparam.appReqId);
+		{
+			std::lock_guard lock(mutex_pending_requests);
+			pending_requests[req_id] = std::move(ret);
+		}
 
-	ret.ctx_id = ctx_id;
-	ret.cb     = optParam ? optParam->cbFunc : ctx->default_match2_optparam.cbFunc;
-	ret.cb_arg = optParam ? optParam->cbFuncArg : ctx->default_match2_optparam.cbFuncArg;
+		return req_id;
+	}
 
-	nph_log.warning("Callback used is 0x%x", ret.cb);
-
+	np_handler::callback_info np_handler::take_pending_request(u32 req_id)
 	{
 		std::lock_guard lock(mutex_pending_requests);
-		pending_requests[req_id] = std::move(ret);
+
+		const auto cb_info = std::move(pending_requests.at(req_id));
+		pending_requests.erase(req_id);
+
+		return cb_info;
 	}
 
-	return req_id;
-}
+	event_data& np_handler::allocate_req_result(u32 event_key, u32 max_size, u32 initial_size)
+	{
+		std::lock_guard lock(mutex_match2_req_results);
+		match2_req_results.emplace(std::piecewise_construct, std::forward_as_tuple(event_key), std::forward_as_tuple(np_memory.allocate(max_size), initial_size, max_size));
+		return match2_req_results.at(event_key);
+	}
 
-np_handler::callback_info np_handler::take_pending_request(u32 req_id)
-{
-	std::lock_guard lock(mutex_pending_requests);
+	u32 np_handler::add_players_to_history(vm::cptr<SceNpId> /*npids*/, u32 /*count*/)
+	{
+		const u32 req_id = get_req_id(0);
 
-	const auto cb_info = std::move(pending_requests.at(req_id));
-	pending_requests.erase(req_id);
+		// if (basic_handler)
+		// {
+		// 	sysutil_register_cb([basic_handler = this->basic_handler, req_id, basic_handler_arg = this->basic_handler_arg](ppu_thread& cb_ppu) -> s32
+		// 	{
+		// 		basic_handler(cb_ppu, SCE_NP_BASIC_EVENT_ADD_PLAYERS_HISTORY_RESULT, 0, req_id, basic_handler_arg);
+		// 		return 0;
+		// 	});
+		// }
 
-	return cb_info;
-}
+		return req_id;
+	}
 
-u8* np_handler::allocate_req_result(u32 event_key, usz size)
-{
-	std::lock_guard lock(mutex_req_results);
-	match2_req_results[event_key] = std::vector<u8>(size, 0);
-	return match2_req_results[event_key].data();
-}
+	u32 np_handler::get_num_friends()
+	{
+		return rpcn->get_num_friends();
+	}
 
-u32 np_handler::add_players_to_history(vm::cptr<SceNpId> /*npids*/, u32 /*count*/)
-{
-	const u32 req_id = get_req_id(0);
+	u32 np_handler::get_num_blocks()
+	{
+		return rpcn->get_num_blocks();
+	}
 
-	// if (basic_handler)
-	// {
-	// 	sysutil_register_cb([basic_handler = this->basic_handler, req_id, basic_handler_arg = this->basic_handler_arg](ppu_thread& cb_ppu) -> s32
-	// 	{
-	// 		basic_handler(cb_ppu, SCE_NP_BASIC_EVENT_ADD_PLAYERS_HISTORY_RESULT, 0, req_id, basic_handler_arg);
-	// 		return 0;
-	// 	});
-	// }
-
-	return req_id;
-}
-
-u32 np_handler::get_num_friends()
-{
-	return rpcn->get_num_friends();
-}
-
-u32 np_handler::get_num_blocks()
-{
-	return rpcn->get_num_blocks();
-}
+} // namespace np

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "Emu/system_config.h"
-#include "np_handler.h"
+#include "Emu/NP/np_handler.h"
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/Cell/Modules/sceNp.h"
 #include "Emu/Cell/Modules/sceNp2.h"
@@ -8,10 +8,11 @@
 #include "Utilities/StrUtil.h"
 #include "Emu/Cell/Modules/cellSysutil.h"
 #include "Emu/IdManager.h"
-#include "np_structs_extra.h"
+#include "Emu/NP/np_structs_extra.h"
 #include "Emu/System.h"
 #include "Emu/NP/rpcn_config.h"
 #include "Emu/NP/np_contexts.h"
+#include "Emu/NP/np_helpers.h"
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -601,6 +602,21 @@ namespace np
 	u32 np_handler::get_num_blocks()
 	{
 		return rpcn->get_num_blocks();
+	}
+
+	std::pair<error_code, std::optional<SceNpId>> np_handler::get_friend_by_index(u32 index)
+	{
+		auto str_friend = rpcn->get_friend_by_index(index);
+
+		if (!str_friend)
+		{
+			return {SCE_NP_ERROR_ID_NOT_FOUND, {}};
+		}
+
+		SceNpId npid_friend;
+		string_to_npid(str_friend.value(), &npid_friend);
+
+		return {CELL_OK, npid_friend};
 	}
 
 	std::pair<error_code, std::optional<SceNpMatching2SessionPassword>> np_handler::local_get_room_password(SceNpMatching2RoomId room_id)

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -11,242 +11,246 @@
 #include "Emu/NP/rpcn_client.h"
 #include "generated/np2_structs_generated.h"
 #include "signaling_handler.h"
+#include "np_event_data.h"
+#include "np_allocator.h"
 
-class np_handler
+namespace np
 {
-public:
-	np_handler();
-
-	const std::array<u8, 6>& get_ether_addr() const;
-	const std::string& get_hostname() const;
-	u32 get_local_ip_addr() const;
-	u32 get_public_ip_addr() const;
-	u32 get_dns_ip() const;
-
-	s32 get_psn_status() const;
-	s32 get_net_status() const;
-
-	const SceNpId& get_npid() const;
-	const SceNpOnlineId& get_online_id() const;
-	const SceNpOnlineName& get_online_name() const;
-	const SceNpAvatarUrl& get_avatar_url() const;
-
-	// Public helpers
-	static std::string ip_to_string(u32 addr);
-	static std::string ether_to_string(std::array<u8, 6>& ether);
-	// Helpers for setting various structures from string
-	static void string_to_npid(const std::string& str, SceNpId* npid);
-	static void string_to_online_name(const std::string& str, SceNpOnlineName* online_name);
-	static void string_to_avatar_url(const std::string& str, SceNpAvatarUrl* avatar_url);
-	static void string_to_communication_id(const std::string& str, SceNpCommunicationId* comm_id);
-
-	// DNS hooking functions
-	void add_dns_spy(u32 sock);
-	void remove_dns_spy(u32 sock);
-	bool is_dns(u32 sock) const;
-	bool is_dns_queue(u32 sock) const;
-	std::vector<u8> get_dns_packet(u32 sock);
-	s32 analyze_dns_packet(s32 s, const u8* buf, u32 len);
-
-	// handles async messages from server(only needed for RPCN)
-	void operator()();
-
-	void init_NP(u32 poolsize, vm::ptr<void> poolptr);
-	void terminate_NP();
-
-	bool is_netctl_init     = false;
-	bool is_NP_init         = false;
-	bool is_NP_Lookup_init  = false;
-	bool is_NP_Score_init   = false;
-	bool is_NP2_init        = false;
-	bool is_NP2_Match2_init = false;
-	bool is_NP_Auth_init    = false;
-
-	// NP Handlers/Callbacks
-	// Seems to be global
-	vm::ptr<SceNpManagerCallback> manager_cb{}; // Connection status and tickets
-	vm::ptr<void> manager_cb_arg{};
-
-	// Basic event handler;
-	struct
-	{
-		SceNpCommunicationId context{};
-		vm::ptr<SceNpBasicEventHandler> handler_func;
-		vm::ptr<void> handler_arg;
-		bool registered        = false;
-		bool context_sensitive = false;
-	} basic_handler;
 	struct basic_event
 	{
 		s32 event = 0;
 		SceNpUserInfo from{};
 		std::vector<u8> data;
 	};
-	void queue_basic_event(basic_event to_queue);
-	bool send_basic_event(s32 event, s32 retCode, u32 reqId);
-	error_code get_basic_event(vm::ptr<s32> event, vm::ptr<SceNpUserInfo> from, vm::ptr<s32> data, vm::ptr<u32> size);
-	std::optional<std::shared_ptr<std::pair<std::string, message_data>>> get_message(u64 id);
 
-	// Those should probably be under match2 ctx
-	vm::ptr<SceNpMatching2RoomEventCallback> room_event_cb{}; // Room events
-	u16 room_event_cb_ctx = 0;
-	vm::ptr<void> room_event_cb_arg{};
-	vm::ptr<SceNpMatching2RoomMessageCallback> room_msg_cb{};
-	u16 room_msg_cb_ctx = 0;
-	vm::ptr<void> room_msg_cb_arg{};
+	// Helper functions
+	std::string ip_to_string(u32 addr);
+	std::string ether_to_string(std::array<u8, 6>& ether);
 
-	// Synchronous requests
-	std::vector<SceNpMatching2ServerId> get_match2_server_list(SceNpMatching2ContextId);
-	// Asynchronous requests
-	u32 get_server_status(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
-	u32 create_server_context(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
-	u32 get_world_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
-	u32 create_join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2CreateJoinRoomRequest* req);
-	u32 join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2JoinRoomRequest* req);
-	u32 leave_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2LeaveRoomRequest* req);
-	u32 search_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SearchRoomRequest* req);
-	u32 get_roomdata_external_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataExternalListRequest* req);
-	u32 set_roomdata_external(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataExternalRequest* req);
-	u32 get_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataInternalRequest* req);
-	u32 set_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataInternalRequest* req);
-	u32 set_roommemberdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomMemberDataInternalRequest* req);
-	u32 get_ping_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SignalingGetPingInfoRequest* req);
-	u32 send_room_message(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SendRoomMessageRequest* req);
+	void string_to_npid(const std::string& str, SceNpId* npid);
+	void string_to_online_name(const std::string& str, SceNpOnlineName* online_name);
+	void string_to_avatar_url(const std::string& str, SceNpAvatarUrl* avatar_url);
+	void string_to_communication_id(const std::string& str, SceNpCommunicationId* comm_id);
 
-	u32 get_match2_event(SceNpMatching2EventKey event_key, u8* dest, u32 size);
-
-	// Friend stuff
-	u32 get_num_friends();
-	u32 get_num_blocks();
-
-	// Misc stuff
-	void req_ticket(u32 version, const SceNpId* npid, const char* service_id, const u8* cookie, u32 cookie_size, const char* entitlement_id, u32 consumed_count);
-	const std::vector<u8>& get_ticket() const
+	class np_handler
 	{
-		return current_ticket;
-	}
-	u32 add_players_to_history(vm::cptr<SceNpId> npids, u32 count);
+	public:
+		np_handler();
 
-	// For signaling
-	void req_sign_infos(const std::string& npid, u32 conn_id);
+		const std::array<u8, 6>& get_ether_addr() const;
+		const std::string& get_hostname() const;
+		u32 get_local_ip_addr() const;
+		u32 get_public_ip_addr() const;
+		u32 get_dns_ip() const;
 
-	// Mutex for NP status change
-	shared_mutex mutex_status;
+		s32 get_psn_status() const;
+		s32 get_net_status() const;
 
-	static constexpr std::string_view thread_name = "NP Handler Thread";
+		const SceNpId& get_npid() const;
+		const SceNpOnlineId& get_online_id() const;
+		const SceNpOnlineName& get_online_name() const;
+		const SceNpAvatarUrl& get_avatar_url() const;
 
-private:
-	// Various generic helpers
-	void discover_ip_address();
-	bool discover_ether_address();
-	bool error_and_disconnect(const std::string& error_msg);
+		// DNS hooking functions
+		void add_dns_spy(u32 sock);
+		void remove_dns_spy(u32 sock);
+		bool is_dns(u32 sock) const;
+		bool is_dns_queue(u32 sock) const;
+		std::vector<u8> get_dns_packet(u32 sock);
+		s32 analyze_dns_packet(s32 s, const u8* buf, u32 len);
 
-	// Notification handlers
-	void notif_user_joined_room(std::vector<u8>& data);
-	void notif_user_left_room(std::vector<u8>& data);
-	void notif_room_destroyed(std::vector<u8>& data);
-	void notif_updated_room_data_internal(std::vector<u8>& data);
-	void notif_updated_room_member_data_internal(std::vector<u8>& data);
-	void notif_p2p_connect(std::vector<u8>& data);
-	void notif_room_message_received(std::vector<u8>& data);
+		// handles async messages from server(only needed for RPCN)
+		void operator()();
 
-	// Reply handlers
-	bool reply_get_world_list(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_create_join_room(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_join_room(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_leave_room(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_search_room(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_get_roomdata_external_list(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_set_roomdata_external(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_get_roomdata_internal(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_set_roomdata_internal(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_set_roommemberdata_internal(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_get_ping_info(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_send_room_message(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_req_sign_infos(u32 req_id, std::vector<u8>& reply_data);
-	bool reply_req_ticket(u32 req_id, std::vector<u8>& reply_data);
+		void init_NP(u32 poolsize, vm::ptr<void> poolptr);
+		void terminate_NP();
 
-	// Helper functions(fb=>np2)
-	void BinAttr_to_SceNpMatching2BinAttr(const BinAttr* bin_attr, SceNpMatching2BinAttr* binattr_info);
-	void BinAttrs_to_SceNpMatching2BinAttr(const flatbuffers::Vector<flatbuffers::Offset<BinAttr>>* fb_attr, vm::ptr<SceNpMatching2BinAttr> binattr_info);
-	void RoomMemberBinAttrInternal_to_SceNpMatching2RoomMemberBinAttrInternal(const RoomMemberBinAttrInternal* fb_attr, vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info);
-	void RoomBinAttrInternal_to_SceNpMatching2RoomBinAttrInternal(const BinAttrInternal* fb_attr, vm::ptr<SceNpMatching2RoomBinAttrInternal> binattr_info);
-	void RoomGroups_to_SceNpMatching2RoomGroup(const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>* fb_group, vm::ptr<SceNpMatching2RoomGroup> group_info);
-	void UserInfo2_to_SceNpUserInfo2(const UserInfo2* user, SceNpUserInfo2* user_info);
-	void RoomDataExternal_to_SceNpMatching2RoomDataExternal(const RoomDataExternal* room, SceNpMatching2RoomDataExternal* room_info);
-	void SearchRoomResponse_to_SceNpMatching2SearchRoomResponse(const SearchRoomResponse* resp, SceNpMatching2SearchRoomResponse* search_resp);
-	void GetRoomDataExternalListResponse_to_SceNpMatching2GetRoomDataExternalListResponse(const GetRoomDataExternalListResponse* resp, SceNpMatching2GetRoomDataExternalListResponse* get_resp);
-	u16 RoomDataInternal_to_SceNpMatching2RoomDataInternal(const RoomDataInternal* resp, SceNpMatching2RoomDataInternal* room_resp, const SceNpId& npid);
-	void RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(const RoomMemberDataInternal* member_data, const SceNpMatching2RoomDataInternal* room_info, SceNpMatching2RoomMemberDataInternal* sce_member_data);
-	void RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(const RoomMemberUpdateInfo* resp, SceNpMatching2RoomMemberUpdateInfo* room_info);
-	void RoomUpdateInfo_to_SceNpMatching2RoomUpdateInfo(const RoomUpdateInfo* update_info, SceNpMatching2RoomUpdateInfo* sce_update_info);
-	void GetPingInfoResponse_to_SceNpMatching2SignalingGetPingInfoResponse(const GetPingInfoResponse* resp, SceNpMatching2SignalingGetPingInfoResponse* sce_resp);
-	void RoomMessageInfo_to_SceNpMatching2RoomMessageInfo(const RoomMessageInfo* mi, SceNpMatching2RoomMessageInfo* sce_mi);
-	void RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(const RoomDataInternalUpdateInfo* update_info, SceNpMatching2RoomDataInternalUpdateInfo* sce_update_info, const SceNpId& npid);
-	void RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(const RoomMemberDataInternalUpdateInfo* update_info, SceNpMatching2RoomMemberDataInternalUpdateInfo* sce_update_info);
+		bool is_netctl_init     = false;
+		bool is_NP_init         = false;
+		bool is_NP_Lookup_init  = false;
+		bool is_NP_Score_init   = false;
+		bool is_NP2_init        = false;
+		bool is_NP2_Match2_init = false;
+		bool is_NP_Auth_init    = false;
 
-	struct callback_info
-	{
-		SceNpMatching2ContextId ctx_id;
-		vm::ptr<SceNpMatching2RequestCallback> cb;
-		vm::ptr<void> cb_arg;
+		// NP Handlers/Callbacks
+		// Seems to be global
+		vm::ptr<SceNpManagerCallback> manager_cb{}; // Connection status and tickets
+		vm::ptr<void> manager_cb_arg{};
+
+		// Basic event handler;
+		struct
+		{
+			SceNpCommunicationId context{};
+			vm::ptr<SceNpBasicEventHandler> handler_func;
+			vm::ptr<void> handler_arg;
+			bool registered        = false;
+			bool context_sensitive = false;
+		} basic_handler;
+
+		void queue_basic_event(basic_event to_queue);
+		bool send_basic_event(s32 event, s32 retCode, u32 reqId);
+		error_code get_basic_event(vm::ptr<s32> event, vm::ptr<SceNpUserInfo> from, vm::ptr<s32> data, vm::ptr<u32> size);
+		std::optional<std::shared_ptr<std::pair<std::string, message_data>>> get_message(u64 id);
+
+		// Those should probably be under match2 ctx
+		vm::ptr<SceNpMatching2RoomEventCallback> room_event_cb{}; // Room events
+		u16 room_event_cb_ctx = 0;
+		vm::ptr<void> room_event_cb_arg{};
+		vm::ptr<SceNpMatching2RoomMessageCallback> room_msg_cb{};
+		u16 room_msg_cb_ctx = 0;
+		vm::ptr<void> room_msg_cb_arg{};
+
+		// Synchronous requests
+		std::vector<SceNpMatching2ServerId> get_match2_server_list(SceNpMatching2ContextId);
+		// Asynchronous requests
+		u32 get_server_status(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
+		u32 create_server_context(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
+		u32 get_world_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
+		u32 create_join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2CreateJoinRoomRequest* req);
+		u32 join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2JoinRoomRequest* req);
+		u32 leave_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2LeaveRoomRequest* req);
+		u32 search_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SearchRoomRequest* req);
+		u32 get_roomdata_external_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataExternalListRequest* req);
+		u32 set_roomdata_external(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataExternalRequest* req);
+		u32 get_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataInternalRequest* req);
+		u32 set_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataInternalRequest* req);
+		u32 set_roommemberdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomMemberDataInternalRequest* req);
+		u32 get_ping_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SignalingGetPingInfoRequest* req);
+		u32 send_room_message(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SendRoomMessageRequest* req);
+
+		u32 get_match2_event(SceNpMatching2EventKey event_key, u32 dest_addr, u32 size);
+
+		// Friend stuff
+		u32 get_num_friends();
+		u32 get_num_blocks();
+
+		// Misc stuff
+		void req_ticket(u32 version, const SceNpId* npid, const char* service_id, const u8* cookie, u32 cookie_size, const char* entitlement_id, u32 consumed_count);
+		const std::vector<u8>& get_ticket() const
+		{
+			return current_ticket;
+		}
+		u32 add_players_to_history(vm::cptr<SceNpId> npids, u32 count);
+
+		// For signaling
+		void req_sign_infos(const std::string& npid, u32 conn_id);
+
+		// Mutex for NP status change
+		shared_mutex mutex_status;
+
+		static constexpr std::string_view thread_name = "NP Handler Thread";
+
+	private:
+		// Various generic helpers
+		void discover_ip_address();
+		bool discover_ether_address();
+		bool error_and_disconnect(const std::string& error_msg);
+
+		// Notification handlers
+		void notif_user_joined_room(std::vector<u8>& data);
+		void notif_user_left_room(std::vector<u8>& data);
+		void notif_room_destroyed(std::vector<u8>& data);
+		void notif_updated_room_data_internal(std::vector<u8>& data);
+		void notif_updated_room_member_data_internal(std::vector<u8>& data);
+		void notif_p2p_connect(std::vector<u8>& data);
+		void notif_room_message_received(std::vector<u8>& data);
+
+		// Reply handlers
+		bool reply_get_world_list(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_create_join_room(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_join_room(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_leave_room(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_search_room(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_get_roomdata_external_list(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_set_roomdata_external(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_get_roomdata_internal(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_set_roomdata_internal(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_set_roommemberdata_internal(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_get_ping_info(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_send_room_message(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_req_sign_infos(u32 req_id, std::vector<u8>& reply_data);
+		bool reply_req_ticket(u32 req_id, std::vector<u8>& reply_data);
+
+		// Helper functions(fb=>np2)
+		void BinAttr_to_SceNpMatching2BinAttr(event_data& edata, const BinAttr* bin_attr, SceNpMatching2BinAttr* binattr_info);
+		void BinAttrs_to_SceNpMatching2BinAttrs(event_data& edata, const flatbuffers::Vector<flatbuffers::Offset<BinAttr>>* fb_attr, SceNpMatching2BinAttr* binattr_info);
+		void RoomMemberBinAttrInternal_to_SceNpMatching2RoomMemberBinAttrInternal(event_data& edata, const RoomMemberBinAttrInternal* fb_attr, SceNpMatching2RoomMemberBinAttrInternal* binattr_info);
+		void RoomBinAttrInternal_to_SceNpMatching2RoomBinAttrInternal(event_data& edata, const BinAttrInternal* fb_attr, SceNpMatching2RoomBinAttrInternal* binattr_info);
+		void RoomGroup_to_SceNpMatching2RoomGroup(const RoomGroup* fb_group, SceNpMatching2RoomGroup* sce_group);
+		void RoomGroups_to_SceNpMatching2RoomGroups(const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>* fb_groups, SceNpMatching2RoomGroup* sce_groups);
+		void UserInfo2_to_SceNpUserInfo2(event_data& edata, const UserInfo2* user, SceNpUserInfo2* user_info);
+		void RoomDataExternal_to_SceNpMatching2RoomDataExternal(event_data& edata, const RoomDataExternal* room, SceNpMatching2RoomDataExternal* room_info);
+		void SearchRoomResponse_to_SceNpMatching2SearchRoomResponse(event_data& edata, const SearchRoomResponse* resp, SceNpMatching2SearchRoomResponse* search_resp);
+		void GetRoomDataExternalListResponse_to_SceNpMatching2GetRoomDataExternalListResponse(event_data& edata, const GetRoomDataExternalListResponse* resp, SceNpMatching2GetRoomDataExternalListResponse* get_resp);
+		u16 RoomDataInternal_to_SceNpMatching2RoomDataInternal(event_data& edata, const RoomDataInternal* resp, SceNpMatching2RoomDataInternal* room_resp, const SceNpId& npid);
+		void RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(event_data& edata, const RoomMemberDataInternal* member_data, const SceNpMatching2RoomDataInternal* room_info, SceNpMatching2RoomMemberDataInternal* sce_member_data);
+		void RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(event_data& edata, const RoomMemberUpdateInfo* resp, SceNpMatching2RoomMemberUpdateInfo* room_info);
+		void RoomUpdateInfo_to_SceNpMatching2RoomUpdateInfo(const RoomUpdateInfo* update_info, SceNpMatching2RoomUpdateInfo* sce_update_info);
+		void GetPingInfoResponse_to_SceNpMatching2SignalingGetPingInfoResponse(const GetPingInfoResponse* resp, SceNpMatching2SignalingGetPingInfoResponse* sce_resp);
+		void RoomMessageInfo_to_SceNpMatching2RoomMessageInfo(event_data& edata, const RoomMessageInfo* mi, SceNpMatching2RoomMessageInfo* sce_mi);
+		void RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(event_data& edata, const RoomDataInternalUpdateInfo* update_info, SceNpMatching2RoomDataInternalUpdateInfo* sce_update_info, const SceNpId& npid);
+		void RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(event_data& edata, const RoomMemberDataInternalUpdateInfo* update_info, SceNpMatching2RoomMemberDataInternalUpdateInfo* sce_update_info);
+
+		struct callback_info
+		{
+			SceNpMatching2ContextId ctx_id;
+			vm::ptr<SceNpMatching2RequestCallback> cb;
+			vm::ptr<void> cb_arg;
+		};
+		u32 generate_callback_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam);
+		callback_info take_pending_request(u32 req_id);
+
+		shared_mutex mutex_pending_requests;
+		std::unordered_map<u32, callback_info> pending_requests;
+		shared_mutex mutex_pending_sign_infos_requests;
+		std::unordered_map<u32, u32> pending_sign_infos_requests;
+
+		shared_mutex mutex_queue_basic_events;
+		std::queue<basic_event> queue_basic_events;
+
+	private:
+		bool is_connected  = false;
+		bool is_psn_active = false;
+
+		std::vector<u8> current_ticket;
+
+		// IP & DNS info
+		std::string hostname = "localhost";
+		std::array<u8, 6> ether_address{};
+		be_t<u32> local_ip_addr{};
+		be_t<u32> public_ip_addr{};
+		be_t<u32> dns_ip = 0x08080808;
+
+		// User infos
+		SceNpId npid{};
+		SceNpOnlineName online_name{};
+		SceNpAvatarUrl avatar_url{};
+
+		// DNS related
+		std::map<s32, std::queue<std::vector<u8>>> dns_spylist{};
+		std::map<std::string, u32> switch_map{};
+
+		// Memory pool for sceNp/sceNp2
+		memory_allocator np_memory;
+
+		// Requests(reqEventKey : data)
+		shared_mutex mutex_match2_req_results;
+		std::unordered_map<u32, event_data> match2_req_results;
+		atomic_t<u16> match2_low_reqid_cnt = 1;
+		atomic_t<u32> match2_event_cnt     = 1;
+		u32 get_req_id(u16 app_req)
+		{
+			return ((app_req << 16) | match2_low_reqid_cnt.fetch_add(1));
+		}
+		u32 get_event_key()
+		{
+			return match2_event_cnt.fetch_add(1);
+		}
+		event_data& allocate_req_result(u32 event_key, u32 max_size, u32 initial_size);
+
+		// RPCN
+		shared_mutex mutex_rpcn;
+		std::shared_ptr<rpcn::rpcn_client> rpcn;
 	};
-	u32 generate_callback_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam);
-	callback_info take_pending_request(u32 req_id);
-
-	shared_mutex mutex_pending_requests;
-	std::unordered_map<u32, callback_info> pending_requests;
-	shared_mutex mutex_pending_sign_infos_requests;
-	std::unordered_map<u32, u32> pending_sign_infos_requests;
-
-	shared_mutex mutex_queue_basic_events;
-	std::queue<basic_event> queue_basic_events;
-
-private:
-	bool is_connected  = false;
-	bool is_psn_active = false;
-
-	std::vector<u8> current_ticket;
-
-	// IP & DNS info
-	std::string hostname = "localhost";
-	std::array<u8, 6> ether_address{};
-	be_t<u32> local_ip_addr{};
-	be_t<u32> public_ip_addr{};
-	be_t<u32> dns_ip = 0x08080808;
-
-	// User infos
-	SceNpId npid{};
-	SceNpOnlineName online_name{};
-	SceNpAvatarUrl avatar_url{};
-
-	// DNS related
-	std::map<s32, std::queue<std::vector<u8>>> dns_spylist{};
-	std::map<std::string, u32> switch_map{};
-
-	// Memory pool for sceNp/sceNp2
-	vm::ptr<void> mpool{};
-	u32 mpool_size  = 0;
-	u32 mpool_avail = 0;
-	std::map<u32, u32> mpool_allocs{}; // offset/size
-	vm::addr_t allocate(u32 size);
-
-	// Requests(reqEventKey : data)
-	std::unordered_map<u32, std::vector<u8>> match2_req_results{};
-	atomic_t<u16> match2_low_reqid_cnt = 1;
-	atomic_t<u32> match2_event_cnt     = 1;
-	u32 get_req_id(u16 app_req)
-	{
-		return ((app_req << 16) | match2_low_reqid_cnt.fetch_add(1));
-	}
-	u32 get_event_key()
-	{
-		return match2_event_cnt.fetch_add(1);
-	}
-	shared_mutex mutex_req_results;
-	u8* allocate_req_result(u32 event_key, usz size);
-
-	// RPCN
-	shared_mutex mutex_rpcn;
-	std::shared_ptr<rpcn::rpcn_client> rpcn;
-};
+} // namespace np

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -109,6 +109,7 @@ public:
 	u32 set_roomdata_external(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataExternalRequest* req);
 	u32 get_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataInternalRequest* req);
 	u32 set_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataInternalRequest* req);
+	u32 set_roommemberdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomMemberDataInternalRequest* req);
 	u32 get_ping_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SignalingGetPingInfoRequest* req);
 	u32 send_room_message(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SendRoomMessageRequest* req);
 
@@ -144,6 +145,8 @@ private:
 	void notif_user_joined_room(std::vector<u8>& data);
 	void notif_user_left_room(std::vector<u8>& data);
 	void notif_room_destroyed(std::vector<u8>& data);
+	void notif_updated_room_data_internal(std::vector<u8>& data);
+	void notif_updated_room_member_data_internal(std::vector<u8>& data);
 	void notif_p2p_connect(std::vector<u8>& data);
 	void notif_room_message_received(std::vector<u8>& data);
 
@@ -157,23 +160,30 @@ private:
 	bool reply_set_roomdata_external(u32 req_id, std::vector<u8>& reply_data);
 	bool reply_get_roomdata_internal(u32 req_id, std::vector<u8>& reply_data);
 	bool reply_set_roomdata_internal(u32 req_id, std::vector<u8>& reply_data);
+	bool reply_set_roommemberdata_internal(u32 req_id, std::vector<u8>& reply_data);
 	bool reply_get_ping_info(u32 req_id, std::vector<u8>& reply_data);
 	bool reply_send_room_message(u32 req_id, std::vector<u8>& reply_data);
 	bool reply_req_sign_infos(u32 req_id, std::vector<u8>& reply_data);
 	bool reply_req_ticket(u32 req_id, std::vector<u8>& reply_data);
 
 	// Helper functions(fb=>np2)
-	void BinAttr_to_SceNpMatching2BinAttr(const flatbuffers::Vector<flatbuffers::Offset<BinAttr>>* fb_attr, vm::ptr<SceNpMatching2BinAttr> binattr_info);
-	void RoomGroup_to_SceNpMatching2RoomGroup(const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>* fb_group, vm::ptr<SceNpMatching2RoomGroup> group_info);
+	void BinAttr_to_SceNpMatching2BinAttr(const BinAttr* bin_attr, SceNpMatching2BinAttr* binattr_info);
+	void BinAttrs_to_SceNpMatching2BinAttr(const flatbuffers::Vector<flatbuffers::Offset<BinAttr>>* fb_attr, vm::ptr<SceNpMatching2BinAttr> binattr_info);
+	void RoomMemberBinAttrInternal_to_SceNpMatching2RoomMemberBinAttrInternal(const RoomMemberBinAttrInternal* fb_attr, vm::ptr<SceNpMatching2RoomMemberBinAttrInternal> binattr_info);
+	void RoomBinAttrInternal_to_SceNpMatching2RoomBinAttrInternal(const BinAttrInternal* fb_attr, vm::ptr<SceNpMatching2RoomBinAttrInternal> binattr_info);
+	void RoomGroups_to_SceNpMatching2RoomGroup(const flatbuffers::Vector<flatbuffers::Offset<RoomGroup>>* fb_group, vm::ptr<SceNpMatching2RoomGroup> group_info);
 	void UserInfo2_to_SceNpUserInfo2(const UserInfo2* user, SceNpUserInfo2* user_info);
 	void RoomDataExternal_to_SceNpMatching2RoomDataExternal(const RoomDataExternal* room, SceNpMatching2RoomDataExternal* room_info);
 	void SearchRoomResponse_to_SceNpMatching2SearchRoomResponse(const SearchRoomResponse* resp, SceNpMatching2SearchRoomResponse* search_resp);
 	void GetRoomDataExternalListResponse_to_SceNpMatching2GetRoomDataExternalListResponse(const GetRoomDataExternalListResponse* resp, SceNpMatching2GetRoomDataExternalListResponse* get_resp);
 	u16 RoomDataInternal_to_SceNpMatching2RoomDataInternal(const RoomDataInternal* resp, SceNpMatching2RoomDataInternal* room_resp, const SceNpId& npid);
+	void RoomMemberDataInternal_to_SceNpMatching2RoomMemberDataInternal(const RoomMemberDataInternal* member_data, const SceNpMatching2RoomDataInternal* room_info, SceNpMatching2RoomMemberDataInternal* sce_member_data);
 	void RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(const RoomMemberUpdateInfo* resp, SceNpMatching2RoomMemberUpdateInfo* room_info);
 	void RoomUpdateInfo_to_SceNpMatching2RoomUpdateInfo(const RoomUpdateInfo* update_info, SceNpMatching2RoomUpdateInfo* sce_update_info);
 	void GetPingInfoResponse_to_SceNpMatching2SignalingGetPingInfoResponse(const GetPingInfoResponse* resp, SceNpMatching2SignalingGetPingInfoResponse* sce_resp);
 	void RoomMessageInfo_to_SceNpMatching2RoomMessageInfo(const RoomMessageInfo* mi, SceNpMatching2RoomMessageInfo* sce_mi);
+	void RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(const RoomDataInternalUpdateInfo* update_info, SceNpMatching2RoomDataInternalUpdateInfo* sce_update_info, const SceNpId& npid);
+	void RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(const RoomMemberDataInternalUpdateInfo* update_info, SceNpMatching2RoomMemberDataInternalUpdateInfo* sce_update_info);
 
 	struct callback_info
 	{

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -92,6 +92,7 @@ namespace np
 		// Asynchronous requests
 		u32 get_server_status(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
 		u32 create_server_context(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
+		u32 delete_server_context(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
 		u32 get_world_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id);
 		u32 create_join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2CreateJoinRoomRequest* req);
 		u32 join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2JoinRoomRequest* req);

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -9,11 +9,11 @@
 #include "Emu/Cell/Modules/sceNp2.h"
 
 #include "Emu/NP/rpcn_client.h"
-#include "generated/np2_structs_generated.h"
-#include "signaling_handler.h"
-#include "np_allocator.h"
-#include "np_cache.h"
-#include "np_event_data.h"
+#include "Emu/NP/generated/np2_structs_generated.h"
+#include "Emu/NP/signaling_handler.h"
+#include "Emu/NP/np_allocator.h"
+#include "Emu/NP/np_cache.h"
+#include "Emu/NP/np_event_data.h"
 
 namespace np
 {
@@ -23,15 +23,6 @@ namespace np
 		SceNpUserInfo from{};
 		std::vector<u8> data;
 	};
-
-	// Helper functions
-	std::string ip_to_string(u32 addr);
-	std::string ether_to_string(std::array<u8, 6>& ether);
-
-	void string_to_npid(const std::string& str, SceNpId* npid);
-	void string_to_online_name(const std::string& str, SceNpOnlineName* online_name);
-	void string_to_avatar_url(const std::string& str, SceNpAvatarUrl* avatar_url);
-	void string_to_communication_id(const std::string& str, SceNpCommunicationId* comm_id);
 
 	class np_handler
 	{
@@ -125,6 +116,7 @@ namespace np
 		// Friend stuff
 		u32 get_num_friends();
 		u32 get_num_blocks();
+		std::pair<error_code, std::optional<SceNpId>> get_friend_by_index(u32 index);
 
 		// Misc stuff
 		void req_ticket(u32 version, const SceNpId* npid, const char* service_id, const u8* cookie, u32 cookie_size, const char* entitlement_id, u32 consumed_count);

--- a/rpcs3/Emu/NP/np_helpers.cpp
+++ b/rpcs3/Emu/NP/np_helpers.cpp
@@ -1,0 +1,46 @@
+#include "stdafx.h"
+#include "util/types.hpp"
+#include "Utilities/StrUtil.h"
+#include "np_handler.h"
+
+#ifdef _WIN32
+#include <WS2tcpip.h>
+#endif
+
+namespace np
+{
+	std::string ip_to_string(u32 ip_addr)
+	{
+		char ip_str[16];
+
+		inet_ntop(AF_INET, &ip_addr, ip_str, sizeof(ip_str));
+		return std::string(ip_str);
+	}
+
+	std::string ether_to_string(std::array<u8, 6>& ether)
+	{
+		return fmt::format("%02X:%02X:%02X:%02X:%02X:%02X", ether[0], ether[1], ether[2], ether[3], ether[4], ether[5]);
+	}
+
+	void string_to_npid(const std::string& str, SceNpId* npid)
+	{
+		memset(npid, 0, sizeof(SceNpId));
+		strcpy_trunc(npid->handle.data, str);
+		// npid->reserved[0] = 1;
+	}
+
+	void string_to_online_name(const std::string& str, SceNpOnlineName* online_name)
+	{
+		strcpy_trunc(online_name->data, str);
+	}
+
+	void string_to_avatar_url(const std::string& str, SceNpAvatarUrl* avatar_url)
+	{
+		strcpy_trunc(avatar_url->data, str);
+	}
+
+	void string_to_communication_id(const std::string& str, SceNpCommunicationId* comm_id)
+	{
+		strcpy_trunc(comm_id->data, str);
+	}
+}

--- a/rpcs3/Emu/NP/np_helpers.h
+++ b/rpcs3/Emu/NP/np_helpers.h
@@ -1,0 +1,14 @@
+#include "util/types.hpp"
+#include "Emu/Cell/Modules/sceNp.h"
+#include "Emu/Cell/Modules/sceNp2.h"
+
+namespace np
+{
+	std::string ip_to_string(u32 addr);
+	std::string ether_to_string(std::array<u8, 6>& ether);
+
+	void string_to_npid(const std::string& str, SceNpId* npid);
+	void string_to_online_name(const std::string& str, SceNpOnlineName* online_name);
+	void string_to_avatar_url(const std::string& str, SceNpAvatarUrl* avatar_url);
+	void string_to_communication_id(const std::string& str, SceNpCommunicationId* comm_id);
+}

--- a/rpcs3/Emu/NP/np_notifications.cpp
+++ b/rpcs3/Emu/NP/np_notifications.cpp
@@ -2,8 +2,9 @@
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/Cell/Modules/cellSysutil.h"
 #include "Emu/IdManager.h"
-#include "np_handler.h"
-#include "np_structs_extra.h"
+#include "Emu/NP/np_handler.h"
+#include "Emu/NP/np_helpers.h"
+#include "Emu/NP/np_structs_extra.h"
 
 LOG_CHANNEL(rpcn_log, "rpcn");
 

--- a/rpcs3/Emu/NP/np_notifications.cpp
+++ b/rpcs3/Emu/NP/np_notifications.cpp
@@ -1,0 +1,221 @@
+#include "stdafx.h"
+#include "Emu/Cell/PPUModule.h"
+#include "Emu/Cell/Modules/cellSysutil.h"
+#include "Emu/IdManager.h"
+#include "np_handler.h"
+#include "np_structs_extra.h"
+
+LOG_CHANNEL(rpcn_log, "rpcn");
+
+namespace np
+{
+	void np_handler::notif_user_joined_room(std::vector<u8>& data)
+	{
+		vec_stream noti(data);
+		u64 room_id          = noti.get<u64>();
+		auto update_info_raw = noti.get_rawdata();
+
+		if (noti.is_error())
+		{
+			rpcn_log.error("Received faulty UserJoinedRoom notification");
+			return;
+		}
+
+		u32 event_key = get_event_key();
+
+		auto* update_info = flatbuffers::GetRoot<RoomMemberUpdateInfo>(update_info_raw.data());
+		auto& edata       = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_RoomMemberUpdateInfo, sizeof(SceNpMatching2RoomMemberUpdateInfo));
+		auto* notif_data  = reinterpret_cast<SceNpMatching2RoomMemberUpdateInfo*>(edata.data());
+		RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(edata, update_info, notif_data);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		rpcn_log.notice("Received notification that user %s(%d) joined the room(%d)", notif_data->roomMemberDataInternal->userInfo.npId.handle.data, notif_data->roomMemberDataInternal->memberId, room_id);
+		extra_nps::print_room_member_data_internal(notif_data->roomMemberDataInternal.get_ptr());
+
+		sysutil_register_cb([room_event_cb = this->room_event_cb, room_id, event_key, room_event_cb_ctx = this->room_event_cb_ctx, room_event_cb_arg = this->room_event_cb_arg, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_MemberJoined, event_key, 0, size, room_event_cb_arg);
+				return 0;
+			});
+	}
+
+	void np_handler::notif_user_left_room(std::vector<u8>& data)
+	{
+		vec_stream noti(data);
+		u64 room_id          = noti.get<u64>();
+		auto update_info_raw = noti.get_rawdata();
+
+		if (noti.is_error())
+		{
+			rpcn_log.error("Received faulty UserLeftRoom notification");
+			return;
+		}
+
+		u32 event_key = get_event_key();
+
+		auto* update_info = flatbuffers::GetRoot<RoomMemberUpdateInfo>(update_info_raw.data());
+		auto& edata       = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_RoomMemberUpdateInfo, sizeof(SceNpMatching2RoomMemberUpdateInfo));
+		auto* notif_data  = reinterpret_cast<SceNpMatching2RoomMemberUpdateInfo*>(edata.data());
+		RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(edata, update_info, notif_data);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		rpcn_log.notice("Received notification that user %s(%d) left the room(%d)", notif_data->roomMemberDataInternal->userInfo.npId.handle.data, notif_data->roomMemberDataInternal->memberId, room_id);
+		extra_nps::print_room_member_data_internal(notif_data->roomMemberDataInternal.get_ptr());
+
+		sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_MemberLeft, event_key, 0, size, room_event_cb_arg);
+				return 0;
+			});
+	}
+
+	void np_handler::notif_room_destroyed(std::vector<u8>& data)
+	{
+		vec_stream noti(data);
+		u64 room_id          = noti.get<u64>();
+		auto update_info_raw = noti.get_rawdata();
+
+		if (noti.is_error())
+		{
+			rpcn_log.error("Received faulty RoomDestroyed notification");
+			return;
+		}
+
+		u32 event_key = get_event_key();
+
+		auto* update_info = flatbuffers::GetRoot<RoomUpdateInfo>(update_info_raw.data());
+		auto& edata       = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_RoomUpdateInfo, sizeof(SceNpMatching2RoomUpdateInfo));
+		auto* notif_data  = reinterpret_cast<SceNpMatching2RoomUpdateInfo*>(edata.data());
+		RoomUpdateInfo_to_SceNpMatching2RoomUpdateInfo(update_info, notif_data);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		rpcn_log.notice("Received notification that room(%d) was destroyed", room_id);
+
+		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
+		sigh.disconnect_sig2_users(room_id);
+
+		sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_RoomDestroyed, event_key, 0, size, room_event_cb_arg);
+				return 0;
+			});
+	}
+
+	void np_handler::notif_updated_room_data_internal(std::vector<u8>& data)
+	{
+		vec_stream noti(data);
+		SceNpMatching2RoomId room_id = noti.get<u64>();
+		auto update_info_raw         = noti.get_rawdata();
+
+		if (noti.is_error())
+		{
+			rpcn_log.error("Received faulty UpdatedRoomDataInternal notification");
+			return;
+		}
+
+		u32 event_key = get_event_key();
+
+		auto* update_info = flatbuffers::GetRoot<RoomDataInternalUpdateInfo>(update_info_raw.data());
+		auto& edata       = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_RoomDataInternalUpdateInfo, sizeof(SceNpMatching2RoomDataInternalUpdateInfo));
+		auto* notif_data  = reinterpret_cast<SceNpMatching2RoomDataInternalUpdateInfo*>(edata.data());
+		RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(edata, update_info, notif_data, npid);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		extra_nps::print_room_data_internal(notif_data->newRoomDataInternal.get_ptr());
+
+		rpcn_log.notice("Received notification that room(%d)'s data was updated", room_id);
+
+		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
+		sigh.disconnect_sig2_users(room_id);
+
+		sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_UpdatedRoomDataInternal, event_key, 0, size, room_event_cb_arg);
+				return 0;
+			});
+	}
+
+	void np_handler::notif_updated_room_member_data_internal(std::vector<u8>& data)
+	{
+		vec_stream noti(data);
+		SceNpMatching2RoomId room_id = noti.get<u64>();
+		auto update_info_raw         = noti.get_rawdata();
+
+		if (noti.is_error())
+		{
+			rpcn_log.error("Received faulty UpdatedRoomMemberDataInternal notification");
+			return;
+		}
+
+		u32 event_key = get_event_key();
+
+		auto* update_info = flatbuffers::GetRoot<RoomMemberDataInternalUpdateInfo>(update_info_raw.data());
+		auto& edata       = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_RoomMemberDataInternalUpdateInfo, sizeof(SceNpMatching2RoomMemberDataInternalUpdateInfo));
+		auto* notif_data  = reinterpret_cast<SceNpMatching2RoomMemberDataInternalUpdateInfo*>(edata.data());
+		RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(edata, update_info, notif_data);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		rpcn_log.notice("Received notification that user's %s(%d) room (%d) data was updated", notif_data->newRoomMemberDataInternal->userInfo.npId.handle.data, notif_data->newRoomMemberDataInternal->memberId, room_id);
+		extra_nps::print_room_member_data_internal(notif_data->newRoomMemberDataInternal.get_ptr());
+
+		sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				room_event_cb(cb_ppu, room_event_cb_ctx, room_id, SCE_NP_MATCHING2_ROOM_EVENT_UpdatedRoomMemberDataInternal, event_key, 0, size, room_event_cb_arg);
+				return 0;
+			});
+	}
+
+	void np_handler::notif_room_message_received(std::vector<u8>& data)
+	{
+		vec_stream noti(data);
+		u64 room_id           = noti.get<u64>();
+		u16 member_id         = noti.get<u16>();
+		auto message_info_raw = noti.get_rawdata();
+
+		if (noti.is_error())
+		{
+			rpcn_log.error("Received faulty RoomMessageReceived notification");
+			return;
+		}
+
+		u32 event_key = get_event_key();
+
+		auto* message_info = flatbuffers::GetRoot<RoomMessageInfo>(message_info_raw.data());
+		auto& edata        = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_RoomMessageInfo, sizeof(SceNpMatching2RoomMessageInfo));
+		auto* notif_data   = reinterpret_cast<SceNpMatching2RoomMessageInfo*>(edata.data());
+		RoomMessageInfo_to_SceNpMatching2RoomMessageInfo(edata, message_info, notif_data);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		rpcn_log.notice("Received notification of a room message from member(%d) in room(%d)", member_id, room_id);
+
+		if (room_msg_cb)
+		{
+			sysutil_register_cb([room_msg_cb = this->room_msg_cb, room_msg_cb_ctx = this->room_msg_cb_ctx, room_id, member_id, event_key, room_msg_cb_arg = this->room_msg_cb_arg, size = edata.size()](ppu_thread& cb_ppu) -> s32
+				{
+					room_msg_cb(cb_ppu, room_msg_cb_ctx, room_id, member_id, SCE_NP_MATCHING2_ROOM_MSG_EVENT_Message, event_key, 0, size, room_msg_cb_arg);
+					return 0;
+				});
+		}
+	}
+
+	void np_handler::notif_p2p_connect(std::vector<u8>& data)
+	{
+		if (data.size() != 16)
+		{
+			rpcn_log.error("Notification data for SignalP2PConnect != 14");
+			return;
+		}
+
+		const u64 room_id   = reinterpret_cast<le_t<u64>&>(data[0]);
+		const u16 member_id = reinterpret_cast<le_t<u16>&>(data[8]);
+		const u16 port_p2p  = reinterpret_cast<be_t<u16>&>(data[10]);
+		const u32 addr_p2p  = reinterpret_cast<le_t<u32>&>(data[12]);
+
+		rpcn_log.notice("Received notification to connect to member(%d) of room(%d): %s:%d", member_id, room_id, ip_to_string(addr_p2p), port_p2p);
+
+		// Attempt Signaling
+		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
+		sigh.set_sig2_infos(room_id, member_id, SCE_NP_SIGNALING_CONN_STATUS_PENDING, addr_p2p, port_p2p);
+		sigh.start_sig2(room_id, member_id);
+	}
+} // namespace np

--- a/rpcs3/Emu/NP/np_notifications.cpp
+++ b/rpcs3/Emu/NP/np_notifications.cpp
@@ -29,6 +29,8 @@ namespace np
 		RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(edata, update_info, notif_data);
 		np_memory.shrink_allocation(edata.addr(), edata.size());
 
+		np_cache.add_member(room_id, notif_data->roomMemberDataInternal.get_ptr());
+
 		rpcn_log.notice("Received notification that user %s(%d) joined the room(%d)", notif_data->roomMemberDataInternal->userInfo.npId.handle.data, notif_data->roomMemberDataInternal->memberId, room_id);
 		extra_nps::print_room_member_data_internal(notif_data->roomMemberDataInternal.get_ptr());
 
@@ -58,6 +60,8 @@ namespace np
 		auto* notif_data  = reinterpret_cast<SceNpMatching2RoomMemberUpdateInfo*>(edata.data());
 		RoomMemberUpdateInfo_to_SceNpMatching2RoomMemberUpdateInfo(edata, update_info, notif_data);
 		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		np_cache.del_member(room_id, notif_data->roomMemberDataInternal->memberId);
 
 		rpcn_log.notice("Received notification that user %s(%d) left the room(%d)", notif_data->roomMemberDataInternal->userInfo.npId.handle.data, notif_data->roomMemberDataInternal->memberId, room_id);
 		extra_nps::print_room_member_data_internal(notif_data->roomMemberDataInternal.get_ptr());
@@ -121,12 +125,11 @@ namespace np
 		RoomDataInternalUpdateInfo_to_SceNpMatching2RoomDataInternalUpdateInfo(edata, update_info, notif_data, npid);
 		np_memory.shrink_allocation(edata.addr(), edata.size());
 
+		np_cache.insert_room(notif_data->newRoomDataInternal.get_ptr());
+
 		extra_nps::print_room_data_internal(notif_data->newRoomDataInternal.get_ptr());
 
 		rpcn_log.notice("Received notification that room(%d)'s data was updated", room_id);
-
-		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
-		sigh.disconnect_sig2_users(room_id);
 
 		sysutil_register_cb([room_event_cb = this->room_event_cb, room_event_cb_ctx = this->room_event_cb_ctx, room_id, event_key, room_event_cb_arg = this->room_event_cb_arg, size = edata.size()](ppu_thread& cb_ppu) -> s32
 			{
@@ -154,6 +157,8 @@ namespace np
 		auto* notif_data  = reinterpret_cast<SceNpMatching2RoomMemberDataInternalUpdateInfo*>(edata.data());
 		RoomMemberDataInternalUpdateInfo_to_SceNpMatching2RoomMemberDataInternalUpdateInfo(edata, update_info, notif_data);
 		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		np_cache.add_member(room_id, notif_data->newRoomMemberDataInternal.get_ptr());
 
 		rpcn_log.notice("Received notification that user's %s(%d) room (%d) data was updated", notif_data->newRoomMemberDataInternal->userInfo.npId.handle.data, notif_data->newRoomMemberDataInternal->memberId, room_id);
 		extra_nps::print_room_member_data_internal(notif_data->newRoomMemberDataInternal.get_ptr());

--- a/rpcs3/Emu/NP/np_requests.cpp
+++ b/rpcs3/Emu/NP/np_requests.cpp
@@ -1,0 +1,625 @@
+#include "stdafx.h"
+#include "Emu/Cell/PPUModule.h"
+#include "Emu/system_config.h"
+#include "Emu/Cell/Modules/cellSysutil.h"
+#include "Emu/Memory/vm_ptr.h"
+#include "Emu/IdManager.h"
+#include "np_handler.h"
+#include "np_contexts.h"
+#include "np_structs_extra.h"
+
+LOG_CHANNEL(rpcn_log, "rpcn");
+
+namespace np
+{
+	std::vector<SceNpMatching2ServerId> np_handler::get_match2_server_list(SceNpMatching2ContextId ctx_id)
+	{
+		std::vector<SceNpMatching2ServerId> server_list{};
+
+		if (g_cfg.net.psn_status != np_psn_status::psn_rpcn)
+		{
+			return server_list;
+		}
+
+		if (!rpcn->get_server_list(get_req_id(0), get_match2_context(ctx_id)->communicationId, server_list))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return server_list;
+	}
+
+	u32 np_handler::get_server_status(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id)
+	{
+		// TODO: actually implement interaction with server for this?
+		u32 req_id    = generate_callback_info(ctx_id, optParam);
+		u32 event_key = get_event_key();
+
+		auto& edata                                    = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_GetServerInfo, sizeof(SceNpMatching2GetServerInfoResponse));
+		SceNpMatching2GetServerInfoResponse* serv_info = reinterpret_cast<SceNpMatching2GetServerInfoResponse*>(edata.data());
+		serv_info->server.serverId                     = server_id;
+		serv_info->server.status                       = SCE_NP_MATCHING2_SERVER_STATUS_AVAILABLE;
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		const auto cb_info = take_pending_request(req_id);
+
+		sysutil_register_cb([=, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_GetServerInfo, event_key, 0, size, cb_info.cb_arg);
+				return 0;
+			});
+
+		return req_id;
+	}
+
+	u32 np_handler::create_server_context(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 /*server_id*/)
+	{
+		u32 req_id    = generate_callback_info(ctx_id, optParam);
+		u32 event_key = get_event_key();
+
+		const auto cb_info = take_pending_request(req_id);
+
+		sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_CreateServerContext, event_key, 0, 0, cb_info.cb_arg);
+				return 0;
+			});
+
+		return req_id;
+	}
+
+	u32 np_handler::get_world_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->get_world_list(req_id, get_match2_context(ctx_id)->communicationId, server_id))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_get_world_list(u32 req_id, std::vector<u8>& reply_data)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		vec_stream reply(reply_data, 1);
+
+		std::vector<u32> world_list;
+		u32 num_worlds = reply.get<u32>();
+		for (u32 i = 0; i < num_worlds; i++)
+		{
+			world_list.push_back(reply.get<u32>());
+		}
+
+		if (reply.is_error())
+		{
+			world_list.clear();
+			return error_and_disconnect("Malformed reply to GetWorldList command");
+		}
+
+		u32 event_key = get_event_key();
+
+		auto& edata          = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_GetWorldInfoList, sizeof(SceNpMatching2GetWorldInfoListResponse));
+		auto* world_info     = reinterpret_cast<SceNpMatching2GetWorldInfoListResponse*>(edata.data());
+		world_info->worldNum = world_list.size();
+
+		if (!world_list.empty())
+		{
+			auto* worlds = edata.allocate<SceNpMatching2World>(sizeof(SceNpMatching2World) * world_list.size(), world_info->world);
+			for (usz i = 0; i < world_list.size(); i++)
+			{
+				worlds[i].worldId                  = world_list[i];
+				worlds[i].numOfLobby               = 1; // TODO
+				worlds[i].maxNumOfTotalLobbyMember = 10000;
+				worlds[i].curNumOfTotalLobbyMember = 1;
+				worlds[i].curNumOfRoom             = 1;
+				worlds[i].curNumOfTotalRoomMember  = 1;
+			}
+		}
+
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		sysutil_register_cb([=, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_GetWorldInfoList, event_key, 0, size, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::create_join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2CreateJoinRoomRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->createjoin_room(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_create_join_room(u32 req_id, std::vector<u8>& reply_data)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		vec_stream reply(reply_data, 1);
+		auto create_room_resp = reply.get_rawdata();
+
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to CreateRoom command");
+
+		u32 event_key = get_event_key();
+
+		auto* resp      = flatbuffers::GetRoot<RoomDataInternal>(create_room_resp.data());
+		auto& edata     = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_CreateJoinRoom, sizeof(SceNpMatching2CreateJoinRoomResponse));
+		auto* room_resp = reinterpret_cast<SceNpMatching2CreateJoinRoomResponse*>(edata.data());
+		auto* room_info = edata.allocate<SceNpMatching2RoomDataInternal>(sizeof(SceNpMatching2RoomDataInternal), room_resp->roomDataInternal);
+		RoomDataInternal_to_SceNpMatching2RoomDataInternal(edata, resp, room_info, npid);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		// Establish Matching2 self signaling info
+		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
+		sigh.set_self_sig2_info(room_info->roomId, 1);
+		sigh.set_sig2_infos(room_info->roomId, 1, SCE_NP_SIGNALING_CONN_STATUS_ACTIVE, rpcn->get_addr_sig(), rpcn->get_port_sig(), true);
+		// TODO? Should this send a message to Signaling CB? Is this even necessary?
+
+		extra_nps::print_create_room_resp(room_resp);
+
+		sysutil_register_cb([=, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_CreateJoinRoom, event_key, 0, size, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::join_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2JoinRoomRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->join_room(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_join_room(u32 req_id, std::vector<u8>& reply_data)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		vec_stream reply(reply_data, 1);
+
+		auto join_room_resp = reply.get_rawdata();
+
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to JoinRoom command");
+
+		u32 event_key = get_event_key();
+
+		auto resp       = flatbuffers::GetRoot<RoomDataInternal>(join_room_resp.data());
+		auto& edata     = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_JoinRoom, sizeof(SceNpMatching2JoinRoomResponse));
+		auto* room_resp = reinterpret_cast<SceNpMatching2JoinRoomResponse*>(edata.data());
+		auto* room_info = edata.allocate<SceNpMatching2RoomDataInternal>(sizeof(SceNpMatching2RoomDataInternal), room_resp->roomDataInternal);
+		u16 member_id   = RoomDataInternal_to_SceNpMatching2RoomDataInternal(edata, resp, room_info, npid);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		extra_nps::print_room_data_internal(room_resp->roomDataInternal.get_ptr());
+
+		// Establish Matching2 self signaling info
+		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
+		sigh.set_self_sig2_info(room_info->roomId, member_id);
+		sigh.set_sig2_infos(room_info->roomId, member_id, SCE_NP_SIGNALING_CONN_STATUS_ACTIVE, rpcn->get_addr_sig(), rpcn->get_port_sig(), true);
+		// TODO? Should this send a message to Signaling CB? Is this even necessary?
+
+		sysutil_register_cb([=, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_JoinRoom, event_key, 0, size, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::leave_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2LeaveRoomRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->leave_room(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_leave_room(u32 req_id, std::vector<u8>& reply_data)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		vec_stream reply(reply_data, 1);
+		u64 room_id = reply.get<u64>();
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to LeaveRoom command");
+
+		u32 event_key = get_event_key(); // Unsure if necessary if there is no data
+
+		// Disconnect all users from that room
+		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
+		sigh.disconnect_sig2_users(room_id);
+
+		sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_LeaveRoom, event_key, 0, 0, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::search_room(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SearchRoomRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->search_room(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_search_room(u32 req_id, std::vector<u8>& reply_data)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		vec_stream reply(reply_data, 1);
+		auto search_room_resp = reply.get_rawdata();
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to SearchRoom command");
+
+		u32 event_key = get_event_key();
+
+		auto* resp        = flatbuffers::GetRoot<SearchRoomResponse>(search_room_resp.data());
+		auto& edata       = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_SearchRoom, sizeof(SceNpMatching2SearchRoomResponse));
+		auto* search_resp = reinterpret_cast<SceNpMatching2SearchRoomResponse*>(edata.data());
+		SearchRoomResponse_to_SceNpMatching2SearchRoomResponse(edata, resp, search_resp);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		sysutil_register_cb([=, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SearchRoom, event_key, 0, size, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::get_roomdata_external_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataExternalListRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->get_roomdata_external_list(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_get_roomdata_external_list(u32 req_id, std::vector<u8>& reply_data)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		vec_stream reply(reply_data, 1);
+		auto get_room_ext_resp = reply.get_rawdata();
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to GetRoomDataExternalList command");
+
+		u32 event_key = get_event_key();
+
+		auto* resp                  = flatbuffers::GetRoot<GetRoomDataExternalListResponse>(get_room_ext_resp.data());
+		auto& edata                 = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_GetRoomDataExternalList, sizeof(SceNpMatching2GetRoomDataExternalListResponse));
+		auto* sce_get_room_ext_resp = reinterpret_cast<SceNpMatching2GetRoomDataExternalListResponse*>(edata.data());
+		GetRoomDataExternalListResponse_to_SceNpMatching2GetRoomDataExternalListResponse(edata, resp, sce_get_room_ext_resp);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		sysutil_register_cb([=, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SearchRoom, event_key, 0, size, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::set_roomdata_external(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataExternalRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		extra_nps::print_set_roomdata_ext_req(req);
+
+		if (!rpcn->set_roomdata_external(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_set_roomdata_external(u32 req_id, std::vector<u8>& /*reply_data*/)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		u32 event_key = get_event_key(); // Unsure if necessary if there is no data
+
+		sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SetRoomDataExternal, event_key, 0, 0, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::get_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2GetRoomDataInternalRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->get_roomdata_internal(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_get_roomdata_internal(u32 req_id, std::vector<u8>& reply_data)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		vec_stream reply(reply_data, 1);
+
+		auto internal_data = reply.get_rawdata();
+
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to GetRoomDataInternal command");
+
+		u32 event_key = get_event_key();
+
+		auto* resp      = flatbuffers::GetRoot<RoomDataInternal>(internal_data.data());
+		auto& edata     = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_GetRoomDataInternal, sizeof(SceNpMatching2GetRoomDataInternalResponse));
+		auto* room_resp = reinterpret_cast<SceNpMatching2GetRoomDataInternalResponse*>(edata.data());
+		auto* room_info = edata.allocate<SceNpMatching2RoomDataInternal>(sizeof(SceNpMatching2RoomDataInternal), room_resp->roomDataInternal);
+		RoomDataInternal_to_SceNpMatching2RoomDataInternal(edata, resp, room_info, npid);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		extra_nps::print_room_data_internal(room_resp->roomDataInternal.get_ptr());
+
+		sysutil_register_cb([=, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_GetRoomDataInternal, event_key, 0, size, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::set_roomdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomDataInternalRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		extra_nps::print_set_roomdata_int_req(req);
+
+		if (!rpcn->set_roomdata_internal(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_set_roomdata_internal(u32 req_id, std::vector<u8>& /*reply_data*/)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		u32 event_key = get_event_key(); // Unsure if necessary if there is no data
+
+		sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SetRoomDataInternal, event_key, 0, 0, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::set_roommemberdata_internal(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SetRoomMemberDataInternalRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->set_roommemberdata_internal(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_set_roommemberdata_internal(u32 req_id, std::vector<u8>& /*reply_data*/)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		u32 event_key = get_event_key(); // Unsure if necessary if there is no data
+
+		sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SetRoomMemberDataInternal, event_key, 0, 0, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::get_ping_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SignalingGetPingInfoRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->ping_room_owner(req_id, get_match2_context(ctx_id)->communicationId, req->roomId))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_get_ping_info(u32 req_id, std::vector<u8>& reply_data)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		vec_stream reply(reply_data, 1);
+
+		auto ping_resp = reply.get_rawdata();
+
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to PingRoomOwner command");
+
+		u32 event_key = get_event_key();
+
+		auto* resp            = flatbuffers::GetRoot<GetPingInfoResponse>(ping_resp.data());
+		auto& edata           = allocate_req_result(event_key, SCE_NP_MATCHING2_EVENT_DATA_MAX_SIZE_SignalingGetPingInfo, sizeof(SceNpMatching2SignalingGetPingInfoResponse));
+		auto* final_ping_resp = reinterpret_cast<SceNpMatching2SignalingGetPingInfoResponse*>(edata.data());
+		GetPingInfoResponse_to_SceNpMatching2SignalingGetPingInfoResponse(resp, final_ping_resp);
+		np_memory.shrink_allocation(edata.addr(), edata.size());
+
+		sysutil_register_cb([=, size = edata.size()](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SignalingGetPingInfo, event_key, 0, size, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	u32 np_handler::send_room_message(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, const SceNpMatching2SendRoomMessageRequest* req)
+	{
+		u32 req_id = generate_callback_info(ctx_id, optParam);
+
+		if (!rpcn->send_room_message(req_id, get_match2_context(ctx_id)->communicationId, req))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return req_id;
+	}
+
+	bool np_handler::reply_send_room_message(u32 req_id, std::vector<u8>& /*reply_data*/)
+	{
+		const auto cb_info = take_pending_request(req_id);
+
+		sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_SendRoomMessage, 0, 0, 0, cb_info.cb_arg);
+				return 0;
+			});
+
+		return true;
+	}
+
+	void np_handler::req_sign_infos(const std::string& npid, u32 conn_id)
+	{
+		u32 req_id = get_req_id(0x3333);
+		{
+			std::lock_guard lock(mutex_pending_sign_infos_requests);
+			pending_sign_infos_requests[req_id] = conn_id;
+		}
+
+		if (!rpcn->req_sign_infos(req_id, npid))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return;
+	}
+
+	bool np_handler::reply_req_sign_infos(u32 req_id, std::vector<u8>& reply_data)
+	{
+		u32 conn_id;
+		{
+			std::lock_guard lock(mutex_pending_sign_infos_requests);
+			conn_id = pending_sign_infos_requests.at(req_id);
+			pending_sign_infos_requests.erase(req_id);
+		}
+
+		vec_stream reply(reply_data, 1);
+		u32 addr = reply.get<u32>();
+		u16 port = reply.get<u16>();
+
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to RequestSignalingInfos command");
+
+		auto& sigh = g_fxo->get<named_thread<signaling_handler>>();
+		sigh.start_sig(conn_id, addr, port);
+
+		return true;
+	}
+
+	void np_handler::req_ticket(u32 /*version*/, const SceNpId* /*npid*/, const char* service_id, const u8* /*cookie*/, u32 /*cookie_size*/, const char* /*entitlement_id*/, u32 /*consumed_count*/)
+	{
+		u32 req_id = get_req_id(0x3333);
+
+		std::string service_id_str(service_id);
+
+		if (!rpcn->req_ticket(req_id, service_id_str))
+		{
+			rpcn_log.error("Disconnecting from RPCN!");
+			is_psn_active = false;
+		}
+
+		return;
+	}
+
+	bool np_handler::reply_req_ticket(u32 /*req_id*/, std::vector<u8>& reply_data)
+	{
+		vec_stream reply(reply_data, 1);
+		auto ticket_raw = reply.get_rawdata();
+
+		if (reply.is_error())
+			return error_and_disconnect("Malformed reply to RequestTicket command");
+
+		current_ticket   = std::move(ticket_raw);
+		auto ticket_size = static_cast<s32>(current_ticket.size());
+
+		if (manager_cb)
+		{
+			sysutil_register_cb([manager_cb = this->manager_cb, ticket_size, manager_cb_arg = this->manager_cb_arg](ppu_thread& cb_ppu) -> s32
+				{
+					manager_cb(cb_ppu, SCE_NP_MANAGER_EVENT_GOT_TICKET, ticket_size, manager_cb_arg);
+					return 0;
+				});
+		}
+
+		return true;
+	}
+
+} // namespace np

--- a/rpcs3/Emu/NP/np_requests.cpp
+++ b/rpcs3/Emu/NP/np_requests.cpp
@@ -69,6 +69,22 @@ namespace np
 		return req_id;
 	}
 
+	u32 np_handler::delete_server_context(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 /*server_id*/)
+	{
+		u32 req_id    = generate_callback_info(ctx_id, optParam);
+		u32 event_key = get_event_key();
+
+		const auto cb_info = take_pending_request(req_id);
+
+		sysutil_register_cb([=](ppu_thread& cb_ppu) -> s32
+			{
+				cb_info.cb(cb_ppu, cb_info.ctx_id, req_id, SCE_NP_MATCHING2_REQUEST_EVENT_DeleteServerContext, event_key, 0, 0, cb_info.cb_arg);
+				return 0;
+			});
+
+		return req_id;
+	}
+
 	u32 np_handler::get_world_list(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, u16 server_id)
 	{
 		u32 req_id = generate_callback_info(ctx_id, optParam);

--- a/rpcs3/Emu/NP/np_structs_extra.cpp
+++ b/rpcs3/Emu/NP/np_structs_extra.cpp
@@ -182,11 +182,11 @@ namespace extra_nps
 			print_bin_attr_internal(&room->roomBinAttrInternal[i]);
 	}
 
-	void print_create_room_resp(const SceNpMatching2CreateJoinRoomResponse *resp)
+	void print_create_room_resp(const SceNpMatching2CreateJoinRoomResponse* resp)
 	{
 		sceNp2.warning("SceNpMatching2CreateJoinRoomResponse:");
 		sceNp2.warning("roomDataInternal: *0x%x", resp->roomDataInternal);
-		if(resp->roomDataInternal)
+		if (resp->roomDataInternal)
 			print_room_data_internal(resp->roomDataInternal.get_ptr());
 	}
 
@@ -215,6 +215,20 @@ namespace extra_nps
 		sceNp2.warning("passwordSlotMask: *0x%x", req->passwordSlotMask);
 		sceNp2.warning("ownerPrivilegeRank: *0x%x", req->ownerPrivilegeRank);
 		sceNp2.warning("ownerPrivilegeRankNum: %d", req->ownerPrivilegeRankNum);
+	}
+
+	void print_set_roommemberdata_int_req(const SceNpMatching2SetRoomMemberDataInternalRequest* req)
+	{
+		sceNp2.warning("SceNpMatching2SetRoomMemberDataInternalRequest:");
+		sceNp2.warning("roomId: %d", req->roomId);
+		sceNp2.warning("memberId: %d", req->memberId);
+		sceNp2.warning("teamId: %d", req->teamId);
+		sceNp2.warning("flagFilter: 0x%x", req->flagFilter);
+		sceNp2.warning("flagAttr: 0x%x", req->flagAttr);
+		sceNp2.warning("roomMemberBinAttrInternal: *0x%x", req->roomMemberBinAttrInternal);
+		sceNp2.warning("roomMemberBinAttrInternalNum: %d", req->roomMemberBinAttrInternalNum);
+		for (u32 i = 0; i < req->roomMemberBinAttrInternalNum; i++)
+			print_bin_attr(&req->roomMemberBinAttrInternal[i]);
 	}
 
 } // namespace extra_nps

--- a/rpcs3/Emu/NP/np_structs_extra.h
+++ b/rpcs3/Emu/NP/np_structs_extra.h
@@ -17,4 +17,5 @@ namespace extra_nps
 	void print_search_room(const SceNpMatching2SearchRoomRequest* req);
 	void print_set_roomdata_ext_req(const SceNpMatching2SetRoomDataExternalRequest* req);
 	void print_set_roomdata_int_req(const SceNpMatching2SetRoomDataInternalRequest* req);
+	void print_set_roommemberdata_int_req(const SceNpMatching2SetRoomMemberDataInternalRequest* req);
 } // namespace extra_nps

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -1490,7 +1490,7 @@ namespace rpcn
 			final_binattrinternal_vec = builder.CreateVector(davec);
 		}
 
-		auto req_finished = CreateSetRoomMemberDataInternalRequest(builder, req->roomId, req->memberId, req->teamId, req->flagFilter, req->flagAttr, final_binattrinternal_vec);
+		auto req_finished = CreateSetRoomMemberDataInternalRequest(builder, req->roomId, req->memberId, req->teamId, final_binattrinternal_vec);
 
 		builder.Finish(req_finished);
 		u8* buf     = builder.GetBufferPointer();
@@ -1667,6 +1667,7 @@ namespace rpcn
 		case CreationBannedEmailProvider: rpcn_log.error("Error creating an account: banned email provider!"); break;
 		case CreationExistingEmail: rpcn_log.error("Error creating an account: an account with that email already exist!"); break;
 		case AlreadyJoined: rpcn_log.error("User has already joined!"); break;
+		case Unauthorized: rpcn_log.error("User attempted an unauthorized operation!");
 		case DbFail: rpcn_log.error("A db query failed on the server!"); break;
 		case EmailFail: rpcn_log.error("An email action failed on the server!"); break;
 		case NotFound: rpcn_log.error("A request replied not found!"); break;

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -1667,7 +1667,7 @@ namespace rpcn
 		case CreationBannedEmailProvider: rpcn_log.error("Error creating an account: banned email provider!"); break;
 		case CreationExistingEmail: rpcn_log.error("Error creating an account: an account with that email already exist!"); break;
 		case AlreadyJoined: rpcn_log.error("User has already joined!"); break;
-		case Unauthorized: rpcn_log.error("User attempted an unauthorized operation!");
+		case Unauthorized: rpcn_log.error("User attempted an unauthorized operation!"); break;
 		case DbFail: rpcn_log.error("A db query failed on the server!"); break;
 		case EmailFail: rpcn_log.error("An email action failed on the server!"); break;
 		case NotFound: rpcn_log.error("A request replied not found!"); break;

--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -293,8 +293,9 @@ namespace rpcn
 		bool add_friend(const std::string& friend_username);
 		bool remove_friend(const std::string& friend_username);
 
-		u32 get_num_friends() const;
-		u32 get_num_blocks() const;
+		u32 get_num_friends();
+		u32 get_num_blocks();
+		std::optional<std::string> get_friend_by_index(u32 index);
 
 		std::vector<std::pair<u16, std::vector<u8>>> get_notifications();
 		std::unordered_map<u32, std::pair<u16, std::vector<u8>>> get_replies();

--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -124,6 +124,7 @@ namespace rpcn
 		SetRoomDataExternal,
 		GetRoomDataInternal,
 		SetRoomDataInternal,
+		SetRoomMemberDataInternal,
 		PingRoomOwner,
 		SendRoomMessage,
 		RequestSignalingInfos,
@@ -136,6 +137,8 @@ namespace rpcn
 		UserJoinedRoom,
 		UserLeftRoom,
 		RoomDestroyed,
+		UpdatedRoomDataInternal,
+		UpdatedRoomMemberDataInternal,
 		SignalP2PConnect,
 		_SignalP2PDisconnect,
 		FriendQuery,  // Other user sent a friend request
@@ -328,6 +331,7 @@ namespace rpcn
 		bool set_roomdata_external(u32 req_id, const SceNpCommunicationId& communication_id, const SceNpMatching2SetRoomDataExternalRequest* req);
 		bool get_roomdata_internal(u32 req_id, const SceNpCommunicationId& communication_id, const SceNpMatching2GetRoomDataInternalRequest* req);
 		bool set_roomdata_internal(u32 req_id, const SceNpCommunicationId& communication_id, const SceNpMatching2SetRoomDataInternalRequest* req);
+		bool set_roommemberdata_internal(u32 req_id, const SceNpCommunicationId& communication_id, const SceNpMatching2SetRoomMemberDataInternalRequest* req);
 		bool ping_room_owner(u32 req_id, const SceNpCommunicationId& communication_id, u64 room_id);
 		bool send_room_message(u32 req_id, const SceNpCommunicationId& communication_id, const SceNpMatching2SendRoomMessageRequest* req);
 		bool req_sign_infos(u32 req_id, const std::string& npid);

--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -190,6 +190,7 @@ namespace rpcn
 		CreationBannedEmailProvider, // Specific to Account Creation: the email provider is banned
 		CreationExistingEmail,       // Specific to Account Creation: that email is already registered to an account
 		AlreadyJoined,               // User tried to join a room he's already part of
+		Unauthorized,                // User attempted an unauthorized operation
 		DbFail,                      // Generic failure on db side
 		EmailFail,                   // Generic failure related to email
 		NotFound,                    // Object of the query was not found(room, user, etc)

--- a/rpcs3/Emu/NP/signaling_handler.cpp
+++ b/rpcs3/Emu/NP/signaling_handler.cpp
@@ -648,7 +648,7 @@ u32 signaling_handler::init_sig_infos(const SceNpId* npid)
 
 		// Request peer infos from RPCN
 		std::string npid_str(reinterpret_cast<const char*>(npid->handle.data));
-		auto& nph = g_fxo->get<named_thread<np_handler>>();
+		auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 		nph.req_sign_infos(npid_str, conn_id);
 	}
 	else

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -91,7 +91,9 @@
     <ClCompile Include="Emu\title.cpp" />
     <ClCompile Include="Emu\system_config.cpp" />
     <ClCompile Include="Emu\NP\fb_helpers.cpp" />
+    <ClCompile Include="Emu\NP\np_cache.cpp" />
     <ClCompile Include="Emu\NP\np_contexts.cpp" />
+    <ClCompile Include="Emu\NP\np_dnshook.cpp" />
     <ClCompile Include="Emu\NP\np_handler.cpp" />
     <ClCompile Include="Emu\NP\np_helpers.cpp" />
     <ClCompile Include="Emu\NP\np_notifications.cpp" />
@@ -466,6 +468,8 @@
     <ClInclude Include="Emu\NP\np_handler.h" />
     <ClInclude Include="Emu\NP\signaling_handler.h" />
     <ClInclude Include="Emu\NP\np_allocator.h" />
+    <ClInclude Include="Emu\NP\np_cache.h" />
+    <ClInclude Include="Emu\NP\np_dnshook.h" />
     <ClInclude Include="Emu\NP\np_event_data.h" />
     <ClInclude Include="Emu\NP\np_structs_extra.h" />
     <ClInclude Include="Emu\NP\rpcn_client.h" />

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -471,6 +471,7 @@
     <ClInclude Include="Emu\NP\np_cache.h" />
     <ClInclude Include="Emu\NP\np_dnshook.h" />
     <ClInclude Include="Emu\NP\np_event_data.h" />
+    <ClInclude Include="Emu\NP\np_helpers.h" />
     <ClInclude Include="Emu\NP\np_structs_extra.h" />
     <ClInclude Include="Emu\NP\rpcn_client.h" />
     <ClInclude Include="Emu\NP\rpcn_config.h" />

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -93,6 +93,9 @@
     <ClCompile Include="Emu\NP\fb_helpers.cpp" />
     <ClCompile Include="Emu\NP\np_contexts.cpp" />
     <ClCompile Include="Emu\NP\np_handler.cpp" />
+    <ClCompile Include="Emu\NP\np_helpers.cpp" />
+    <ClCompile Include="Emu\NP\np_notifications.cpp" />
+    <ClCompile Include="Emu\NP\np_requests.cpp" />
     <ClCompile Include="Emu\NP\signaling_handler.cpp" />
     <ClCompile Include="Emu\NP\np_structs_extra.cpp" />
     <ClCompile Include="Emu\NP\rpcn_client.cpp" />
@@ -462,6 +465,8 @@
     <ClInclude Include="Emu\NP\generated\np2_structs_generated.h" />
     <ClInclude Include="Emu\NP\np_handler.h" />
     <ClInclude Include="Emu\NP\signaling_handler.h" />
+    <ClInclude Include="Emu\NP\np_allocator.h" />
+    <ClInclude Include="Emu\NP\np_event_data.h" />
     <ClInclude Include="Emu\NP\np_structs_extra.h" />
     <ClInclude Include="Emu\NP\rpcn_client.h" />
     <ClInclude Include="Emu\NP\rpcn_config.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -897,6 +897,15 @@
     <ClCompile Include="Emu\NP\np_handler.cpp">
       <Filter>Emu\NP</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\NP\np_helpers.cpp">
+      <Filter>Emu\NP</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\NP\np_notifications.cpp">
+      <Filter>Emu\NP</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\NP\np_requests.cpp">
+      <Filter>Emu\NP</Filter>
+    </ClCompile>
     <ClCompile Include="Emu\NP\signaling_handler.cpp">
       <Filter>Emu\NP</Filter>
     </ClCompile>

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -891,7 +891,13 @@
     <ClCompile Include="Emu\NP\fb_helpers.cpp">
       <Filter>Emu\NP</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\NP\np_cache.cpp">
+      <Filter>Emu\NP</Filter>
+    </ClCompile>
     <ClCompile Include="Emu\NP\np_contexts.cpp">
+      <Filter>Emu\NP</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\NP\np_dnshook.cpp">
       <Filter>Emu\NP</Filter>
     </ClCompile>
     <ClCompile Include="Emu\NP\np_handler.cpp">


### PR DESCRIPTION
-Contains the changes from Velocity's PR: https://github.com/RPCS3/rpcs3/pull/10547 rebased on Rpcn 0.4.0.
-Refactored np_handler(now everything is under a "np" namespace, the class implementation has been split into several files and a few header only objects have been added).
-Huge rework of the memory allocator for the match2 events data with an allocator that manages relocations when copying to game memory. This means that SceNp out of memory errors after playing a lot shouldn't happen anymore.
-Added a cache manager and an implementation of most *Local( np functions

Test server is: test-np.rpcs3.net (doesn't require email validation/token).