### PR TITLE
Add more logging for Emulator Stop events

### DIFF
--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -715,6 +715,7 @@ bool gdb_thread::cmd_attached_to_what(gdb_cmd&)
 
 bool gdb_thread::cmd_kill(gdb_cmd&)
 {
+	GDB.notice("Kill command issued");
 	Emu.Stop();
 	return true;
 }

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog.cpp
@@ -16,7 +16,14 @@ namespace rsx
 			dlg->type.bg_invisible = true;
 			dlg->type.progress_bar_count = 2;
 			dlg->ProgressBarSetTaskbarIndex(-1); // -1 to combine all progressbars in the taskbar progress
-			dlg->on_close = [](s32 /*status*/) { Emu.CallAfter([]() { Emu.Stop(); }); };
+			dlg->on_close = [](s32 /*status*/)
+			{
+				Emu.CallAfter([]()
+				{
+					rsx_log.notice("Aborted shader loading dialog");
+					Emu.Stop();
+				});
+			};
 
 			ref_cnt++;
 

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
@@ -22,7 +22,10 @@ namespace rsx
 		dlg->show(false, msg, type, [](s32 status)
 		{
 			if (status != CELL_OK)
+			{
+				rsx_log.notice("Aborted shader loading dialog");
 				Emu.Stop();
+			}
 		});
 	}
 

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -5,6 +5,8 @@
 #include "Emu/RSX/Overlays/overlay_message_dialog.h"
 #include "Emu/System.h"
 
+LOG_CHANNEL(sys_log, "SYS");
+
 // Progress display server synchronization variables
 atomic_t<const char*> g_progr{nullptr};
 atomic_t<u32> g_progr_ftotal{0};
@@ -90,6 +92,7 @@ void progress_dialog_server::operator()()
 				Emu.CallAfter([]()
 				{
 					// Abort everything
+					sys_log.notice("Aborted progress dialog");
 					Emu.Stop();
 				});
 

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -48,6 +48,7 @@
 
 LOG_CHANNEL(screenshot_log, "SCREENSHOT");
 LOG_CHANNEL(mark_log, "MARK");
+LOG_CHANNEL(gui_log, "GUI");
 
 extern atomic_t<bool> g_user_asked_for_frame_capture;
 
@@ -348,6 +349,8 @@ bool gs_frame::get_mouse_lock_state()
 
 void gs_frame::close()
 {
+	gui_log.notice("Closing game window");
+
 	Emu.CallAfter([this]()
 	{
 		if (!(+g_progr))
@@ -808,6 +811,8 @@ bool gs_frame::event(QEvent* ev)
 				return true;
 			}
 		}
+
+		gui_log.notice("Game window close event issued");
 		close();
 	}
 	else if (ev->type() == QEvent::MouseMove && (!m_show_mouse || m_mousehide_timer.isActive()))

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -180,6 +180,8 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 		{
 			return false;
 		}
+
+		cfg_log.notice("User accepted to stop the current emulation.");
 	}
 
 	return true;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -186,8 +186,16 @@ bool main_window::Init(bool with_cli_boot)
 
 	RepaintThumbnailIcons();
 
-	connect(m_thumb_stop, &QWinThumbnailToolButton::clicked, this, []() { Emu.Stop(); });
-	connect(m_thumb_restart, &QWinThumbnailToolButton::clicked, this, []() { Emu.Restart(); });
+	connect(m_thumb_stop, &QWinThumbnailToolButton::clicked, this, []()
+	{
+		gui_log.notice("User clicked stop button on thumbnail toolbar");
+		Emu.Stop();
+	});
+	connect(m_thumb_restart, &QWinThumbnailToolButton::clicked, this, []()
+	{
+		gui_log.notice("User clicked restart button on thumbnail toolbar");
+		Emu.Restart();
+	});
 	connect(m_thumb_playPause, &QWinThumbnailToolButton::clicked, this, &main_window::OnPlayOrPause);
 #endif
 
@@ -307,6 +315,8 @@ void main_window::ResizeIcons(int index)
 
 void main_window::OnPlayOrPause()
 {
+	gui_log.notice("User triggered OnPlayOrPause");
+
 	switch (Emu.GetStatus())
 	{
 	case system_state::ready: Emu.Run(true); return;
@@ -316,6 +326,7 @@ void main_window::OnPlayOrPause()
 	{
 		if (m_selected_game)
 		{
+			gui_log.notice("Booting from OnPlayOrPause...");
 			Boot(m_selected_game->info.path, m_selected_game->info.serial);
 		}
 		else if (const auto path = Emu.GetBoot(); !path.empty())
@@ -2073,13 +2084,22 @@ void main_window::CreateConnects()
 	connect(ui->createFirmwareCacheAct, &QAction::triggered, this, &main_window::CreateFirmwareCache);
 
 	connect(ui->sysPauseAct, &QAction::triggered, this, &main_window::OnPlayOrPause);
-	connect(ui->sysStopAct, &QAction::triggered, this, []() { Emu.Stop(); });
-	connect(ui->sysRebootAct, &QAction::triggered, this, []() { Emu.Restart(); });
+	connect(ui->sysStopAct, &QAction::triggered, this, []()
+	{
+		gui_log.notice("User triggered stop action in menu bar");
+		Emu.Stop();
+	});
+	connect(ui->sysRebootAct, &QAction::triggered, this, []()
+	{
+		gui_log.notice("User triggered restart action in menu bar");
+		Emu.Restart();
+	});
 
 	connect(ui->sysSendOpenMenuAct, &QAction::triggered, this, [this]()
 	{
 		if (Emu.IsStopped()) return;
 
+		gui_log.notice("User triggered \"Send %s system menu command\" action in menu bar", m_sys_menu_opened ? "close" : "open");
 		sysutil_send_system_cmd(m_sys_menu_opened ? 0x0132 /* CELL_SYSUTIL_SYSTEM_MENU_CLOSE */ : 0x0131 /* CELL_SYSUTIL_SYSTEM_MENU_OPEN */, 0);
 		m_sys_menu_opened ^= true;
 		ui->sysSendOpenMenuAct->setText(tr("Send &%0 system menu cmd").arg(m_sys_menu_opened ? tr("close") : tr("open")));
@@ -2089,6 +2109,7 @@ void main_window::CreateConnects()
 	{
 		if (Emu.IsStopped()) return;
 
+		gui_log.notice("User triggered \"Send exit command\" action in menu bar");
 		sysutil_send_system_cmd(0x0101 /* CELL_SYSUTIL_REQUEST_EXITGAME */, 0);
 	});
 
@@ -2391,7 +2412,11 @@ void main_window::CreateConnects()
 
 	connect(ui->toolbar_open, &QAction::triggered, this, &main_window::BootGame);
 	connect(ui->toolbar_refresh, &QAction::triggered, this, [this]() { m_game_list_frame->Refresh(true); });
-	connect(ui->toolbar_stop, &QAction::triggered, this, []() { Emu.Stop(); });
+	connect(ui->toolbar_stop, &QAction::triggered, this, []()
+	{
+		gui_log.notice("User triggered stop action in toolbar");
+		Emu.Stop();
+	});
 	connect(ui->toolbar_start, &QAction::triggered, this, &main_window::OnPlayOrPause);
 
 	connect(ui->toolbar_fullscreen, &QAction::triggered, this, [this]

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -351,14 +351,18 @@ void user_manager_dialog::OnUserCreate()
 
 void user_manager_dialog::OnUserLogin()
 {
-	if (!Emu.IsStopped() && QMessageBox::question(this, tr("Stop emulator?"),
-		tr("In order to change the user you have to stop the emulator first.\n\nStop the emulator now?"),
-		QMessageBox::Yes | QMessageBox::Abort) != QMessageBox::Yes)
+	if (!Emu.IsStopped())
 	{
-		return;
-	}
+		if (QMessageBox::question(this, tr("Stop emulator?"),
+			tr("In order to change the user you have to stop the emulator first.\n\nStop the emulator now?"),
+			QMessageBox::Yes | QMessageBox::Abort) != QMessageBox::Yes)
+		{
+			return;
+		}
 
-	Emu.Stop();
+		gui_log.notice("Stopping current emulation in order to change the current user.");
+		Emu.Stop();
+	}
 
 	const u32 key = GetUserKey();
 	const std::string new_user = m_user_list[key].GetUserId();


### PR DESCRIPTION
This should give us more insight into the conditions that cause emulation stops.
This may also help find false issue reports.