### PR TITLE
Performance overlay position fixes

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -96,9 +96,6 @@ namespace rsx
 			const positionu margin { m_margin_x, m_margin_y };
 			positionu pos;
 
-			const auto overlay_width = m_body.w + margin.x;
-			const auto overlay_height = m_body.h + margin.y;
-
 			u16 graph_width = 0;
 			u16 graph_height = 0;
 
@@ -126,16 +123,16 @@ namespace rsx
 				pos.y = margin.y;
 				break;
 			case screen_quadrant::top_right:
-				pos.x = virtual_width - overlay_width;
+				pos.x = virtual_width - std::max(m_body.w, graph_width) - margin.x;
 				pos.y = margin.y;
 				break;
 			case screen_quadrant::bottom_left:
 				pos.x = margin.x;
-				pos.y = virtual_height - overlay_height - graph_height;
+				pos.y = virtual_height - m_body.h - graph_height - margin.y;
 				break;
 			case screen_quadrant::bottom_right:
-				pos.x = virtual_width - overlay_width;
-				pos.y = virtual_height - overlay_height - graph_height;
+				pos.x = virtual_width - std::max(m_body.w, graph_width) - margin.x;
+				pos.y = virtual_height - m_body.h - graph_height - margin.y;
 				break;
 			}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -253,18 +253,15 @@ namespace rsx
 			reset_transforms();
 			force_next_update();
 
-			if (m_is_initialised)
+			if (!m_is_initialised)
 			{
-				update();
-				return;
+				m_update_timer.Start();
+				m_frametime_timer.Start();
 			}
-
-			m_update_timer.Start();
-			m_frametime_timer.Start();
 
 			update();
 
-			// The text might have changed during the initial update. Recalculate positions.
+			// The text might have changed during the update. Recalculate positions.
 			reset_transforms();
 
 			m_is_initialised = true;


### PR DESCRIPTION
- Fixes an issue where the framerate graphs would halfway disappear at the right edge of the screen in detail level none
- Fixes an issue where the framerate graphs would appear at the old origin of the detail body if you toggle from any detail level to detail level none, when they instead should be centered.