### PR TITLE
SPU ASMJIT: Disable 512 wide spu verification

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -281,9 +281,9 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 			c->vzeroupper();
 		}
 	}
-	else if (utils::has_avx512() && g_cfg.core.full_width_avx512)
+	else if (utils::has_avx512() && false)
 	{
-		// AVX-512 optimized check using 512-bit registers
+		// AVX-512 optimized check using 512-bit registers (disabled)
 		words_align = 64;
 
 		const u32 starta = start & -64;


### PR DESCRIPTION
According to @Yahfz this setting with asmjit crashes every game.