### PR TITLE
SPU/SYSINFO: Disable TSX by default for TSX-FA cpus

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -713,7 +713,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		initalize_timebased_time();
 
 		// Set RTM usage
-		g_use_rtm = utils::has_rtm() && ((utils::has_mpx() && g_cfg.core.enable_TSX == tsx_usage::enabled) || g_cfg.core.enable_TSX == tsx_usage::forced);
+		g_use_rtm = utils::has_rtm() && (((utils::has_mpx() && !utils::has_tsx_force_abort()) && g_cfg.core.enable_TSX == tsx_usage::enabled) || g_cfg.core.enable_TSX == tsx_usage::forced);
 
 		if (!add_only)
 		{
@@ -726,7 +726,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 #endif
 			sys_log.notice("Used configuration:\n%s\n", g_cfg.to_string());
 
-			if (g_use_rtm && !utils::has_mpx())
+			if (g_use_rtm && (!utils::has_mpx() || utils::has_tsx_force_abort()))
 			{
 				sys_log.warning("TSX forced by User");
 			}

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -82,6 +82,12 @@ bool utils::has_tsx_force_abort()
 	return g_value;
 }
 
+bool utils::has_rtm_always_abort()
+{
+	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && (get_cpuid(7, 0)[3] & 0x800) == 0x800;
+	return g_value;
+}
+
 bool utils::has_mpx()
 {
 	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && (get_cpuid(7, 0)[1] & 0x4000) == 0x4000;
@@ -230,10 +236,14 @@ std::string utils::get_system_info()
 			result += "-FA";
 		}
 
-		if (!has_mpx())
+		if (!has_mpx() || has_tsx_force_abort())
 		{
 			result += " disabled by default";
 		}
+	}
+	else if (has_rtm_always_abort())
+	{
+		result += " | TSX disabled via microcode";
 	}
 
 	return result;

--- a/rpcs3/util/sysinfo.hpp
+++ b/rpcs3/util/sysinfo.hpp
@@ -20,6 +20,8 @@ namespace utils
 	bool has_rtm();
 
 	bool has_tsx_force_abort();
+	
+	bool has_rtm_always_abort();
 
 	bool has_mpx();
 


### PR DESCRIPTION
Since stability and performance aren't ideal on cpus with TSX-FA, let's just disable it by default. It can be force enabled via the forced option, just like with haswell and TSX.

Additionally, support detecting the new RTM_ALWAYS_ABORT bit in cpuid. This is a new bit that only appears in new microcodes with disabled TSX. (see this commit for details https://github.com/torvalds/linux/commit/1348924ba8169f35cedfd0a0087872b81a632b8e)

When TSX is disabled via this new microcode it can be re-enabled by writing 0x4 to the msr 0x0000010F. When enabled in this way, the performance of TSX seems to be the same as the pre TSX-FA microcodes. Intel has also removed the need for TSX to clobber the perfomance counters when TSX is in use (which perhaps indicates that intel removed their "workaround" for TSX bugs in this microcode?)

Intel says ```This bit is intended to
  be used on developer systems. If this bit is set, transactional
  atomicity correctness is not certain.``` So, expect bugs, and don't use it unless you're a "Developer".