### PR TITLE
rsx: Restore shader disassembler to working state

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLExecutionState.h
+++ b/rpcs3/Emu/RSX/GL/GLExecutionState.h
@@ -48,6 +48,13 @@ namespace gl
 			int find_count = 14;
 			int ext_count = 0;
 			glGetIntegerv(GL_NUM_EXTENSIONS, &ext_count);
+
+			if (!ext_count)
+			{
+				rsx_log.error("Coult not initialize GL driver capabilities. Is OpenGL initialized?");
+				return;
+			}
+
 			std::string vendor_string = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
 			std::string version_string = reinterpret_cast<const char*>(glGetString(GL_VERSION));
 			std::string renderer_string = reinterpret_cast<const char*>(glGetString(GL_RENDERER));

--- a/rpcs3/Emu/RSX/Program/CgBinaryFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/Program/CgBinaryFragmentProgram.cpp
@@ -232,11 +232,6 @@ void CgBinaryDisasm::TaskFP()
 	m_size = 0;
 	u32* data = reinterpret_cast<u32*>(&m_buffer[m_offset]);
 	ensure((m_buffer_size - m_offset) % sizeof(u32) == 0);
-	for (u32 i = 0; i < (m_buffer_size - m_offset) / sizeof(u32); i++)
-	{
-		// Get BE data
-		data[i] = std::bit_cast<u32, be_t<u32>>(data[i]);
-	}
 
 	enum
 	{


### PR DESCRIPTION
CGdisasm is now only used to process data from the host system where there is no mismatch in endianness. Restores the disassembler to working state.