### PR TITLE
NP: add signaling_handler wakeup on connect queue

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNp2.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp2.cpp
@@ -602,7 +602,7 @@ error_code sceNpMatching2SetRoomDataExternal(
 error_code sceNpMatching2SignalingGetConnectionInfo(
     SceNpMatching2ContextId ctxId, SceNpMatching2RoomId roomId, SceNpMatching2RoomMemberId memberId, s32 code, vm::ptr<SceNpSignalingConnectionInfo> connInfo)
 {
-	sceNp2.todo("sceNpMatching2SignalingGetConnectionInfo(ctxId=%d, roomId=%d, memberId=%d, code=%d, connInfo=*0x%x)", ctxId, roomId, memberId, code, connInfo);
+	sceNp2.warning("sceNpMatching2SignalingGetConnectionInfo(ctxId=%d, roomId=%d, memberId=%d, code=%d, connInfo=*0x%x)", ctxId, roomId, memberId, code, connInfo);
 
 	auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 

--- a/rpcs3/Emu/NP/signaling_handler.cpp
+++ b/rpcs3/Emu/NP/signaling_handler.cpp
@@ -575,6 +575,7 @@ void signaling_handler::start_sig_nl(u32 conn_id, u32 addr, u16 port)
 
 	send_signaling_packet(sent_packet, si->addr, si->port);
 	queue_signaling_packet(sent_packet, si, steady_clock::now() + REPEAT_CONNECT_DELAY);
+	wake_up();
 }
 
 void signaling_handler::start_sig2(u64 room_id, u16 member_id)
@@ -592,6 +593,7 @@ void signaling_handler::start_sig2(u64 room_id, u16 member_id)
 
 	send_signaling_packet(sent_packet, si->addr, si->port);
 	queue_signaling_packet(sent_packet, si, steady_clock::now() + REPEAT_CONNECT_DELAY);
+	wake_up();
 }
 
 void signaling_handler::disconnect_sig2_users(u64 room_id)


### PR DESCRIPTION
Signaling thread would fail to send more than one signal_connect packet if the thread is never woken up.
Subsequent packets result in scheduling before going back to wait so no wakeup needed anywhere else.