### PR TITLE
rsx: Fix immediate-mode rendering

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -401,6 +401,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/GSRender.cpp
     RSX/RSXFIFO.cpp
     RSX/rsx_methods.cpp
+    RSX/rsx_vertex_data.cpp
     RSX/RSXOffload.cpp
     RSX/RSXTexture.cpp
     RSX/RSXThread.cpp

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -745,7 +745,7 @@ namespace rsx
 		/**
 		 * Analyze vertex inputs and group all interleaved blocks
 		 */
-		void analyse_inputs_interleaved(vertex_input_layout&) const;
+		void analyse_inputs_interleaved(vertex_input_layout&);
 
 		RSXVertexProgram current_vertex_program = {};
 		RSXFragmentProgram current_fragment_program = {};

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -281,10 +281,10 @@ namespace rsx
 			if (rsx->in_begin_end)
 			{
 				// Update to immediate mode register/array
+				// NOTE: Push buffers still behave like register writes.
+				// You do not need to specify each attribute for each vertex, the register is referenced instead.
+				// This is classic OpenGL 1.x behavior as I remember.
 				rsx->append_to_push_buffer(attribute_index, count, vertex_subreg, vtype, arg);
-
-				// NOTE: one can update the register to update constant across primitive. Needs verification.
-				// Fall through
 			}
 
 			auto& info = rsx::method_registers.register_vertex_info[attribute_index];

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1736,6 +1736,8 @@ namespace rsx
 		registers.fill(0);
 		transform_program.fill(0);
 		transform_constants = {};
+		current_draw_clause = {};
+		register_vertex_info = {};
 
 		// Special values set at initialization, these are not set by a context reset
 		registers[NV4097_SET_SHADER_PROGRAM] = (0 << 2) | (CELL_GCM_LOCATION_LOCAL + 1);

--- a/rpcs3/Emu/RSX/rsx_vertex_data.cpp
+++ b/rpcs3/Emu/RSX/rsx_vertex_data.cpp
@@ -1,0 +1,101 @@
+#include "stdafx.h"
+#include "rsx_vertex_data.h"
+#include "rsx_methods.h"
+
+namespace rsx
+{
+	void push_buffer_vertex_info::clear()
+	{
+		if (size)
+		{
+			data.clear();
+			vertex_count = 0;
+			dword_count = 0;
+			size = 0;
+		}
+	}
+
+	u8 push_buffer_vertex_info::get_vertex_size_in_dwords() const
+	{
+		// NOTE: Types are always provided to fit into 32-bits
+		// i.e no less than 4 8-bit values and no less than 2 16-bit values
+
+		switch (type)
+		{
+		case vertex_base_type::f:
+			return size;
+		case vertex_base_type::ub:
+		case vertex_base_type::ub256:
+			return 1;
+		case vertex_base_type::s1:
+		case vertex_base_type::s32k:
+			return size / 2;
+		default:
+			fmt::throw_exception("Unsupported vertex base type %d", static_cast<u8>(type));
+		}
+	}
+
+	u32 push_buffer_vertex_info::get_vertex_id() const
+	{
+		ensure(attr == 0);    // Only ask ATTR0 for vertex ID
+
+		// Which is the current vertex ID to be written to?
+		// NOTE: Fully writing to ATTR0 closes the current block
+		return size ? (dword_count / get_vertex_size_in_dwords()) : 0;
+	}
+
+	void push_buffer_vertex_info::set_vertex_data(u32 attribute_id, u32 vertex_id, u32 sub_index, vertex_base_type type, u32 size, u32 arg)
+	{
+		if (vertex_count && (type != this->type || size != this->size))
+		{
+			// TODO: Should forcefully break the draw call on this step using an execution barrier.
+			// While RSX can handle this behavior without problem, it can only be the product of nonsensical game design.
+			rsx_log.error("Vertex attribute %u was respecced mid-draw (type = %d vs %d, size = %u vs %u). Indexed execution barrier required. Report this to developers.",
+				attribute_id, static_cast<int>(type), static_cast<int>(this->type), size, this->size);
+		}
+
+		this->type = type;
+		this->size = size;
+		this->attr = attribute_id;
+
+		const auto required_vertex_count = (vertex_id + 1);
+		const auto vertex_size = get_vertex_size_in_dwords();
+
+		if (vertex_count != required_vertex_count)
+		{
+			pad_to(required_vertex_count, true);
+			ensure(vertex_count == required_vertex_count);
+		}
+
+		auto current_vertex = data.data() + ((vertex_count - 1) * vertex_size);
+		current_vertex[sub_index] = arg;
+		++dword_count;
+	}
+
+	void push_buffer_vertex_info::pad_to(u32 required_vertex_count, bool skip_last)
+	{
+		if (vertex_count >= required_vertex_count)
+		{
+			return;
+		}
+
+		const auto vertex_size = get_vertex_size_in_dwords();
+		data.resize(vertex_size * required_vertex_count);
+
+		// For all previous verts, copy over the register contents duplicated over the stream.
+		// Internally it appears RSX actually executes the draw commands as they are encountered.
+		// You can change register data contents mid-way for example and it will pick up for the next N draws.
+		// This is how immediate mode is implemented internally.
+		u32* src = rsx::method_registers.register_vertex_info[attr].data.data();
+		u32* dst = data.data() + (vertex_count * vertex_size);
+		u32* end = data.data() + ((required_vertex_count - (skip_last ? 1 : 0)) * vertex_size);
+
+		while (dst < end)
+		{
+			std::memcpy(dst, src, vertex_size * sizeof(u32));
+			dst += vertex_size;
+		}
+
+		vertex_count = required_vertex_count;
+	}
+}

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="Emu\RSX\Program\ProgramStateCache.cpp" />
     <ClCompile Include="Emu\RSX\Program\program_util.cpp" />
     <ClCompile Include="Emu\RSX\RSXDisAsm.cpp" />
+    <ClCompile Include="Emu\RSX\rsx_vertex_data.cpp" />
     <ClCompile Include="Emu\system_config_types.cpp" />
     <ClCompile Include="Emu\perf_meter.cpp" />
     <ClCompile Include="Emu\system_progress.cpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1027,6 +1027,9 @@
     <ClCompile Include="Emu\Io\camera_config.cpp">
       <Filter>Emu\Io</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\rsx_vertex_data.cpp">
+      <Filter>Emu\GPU\RSX</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">


### PR DESCRIPTION
Fixes behaviour of the classic glBegin/glEnd style of command streams.
- Just like classic GL, ATTR0 is the provoking attribute.
- Missing updates are carried forward from previous writes.

As this is a feature that has always been broken (and very sensitive to any changes), please test if any games break. Many engines use this unbuffered mode for elements where performance is not critical, such as game HUD, menus or billboarded ingame effects (fog, fire, halos/coronas, etc)

Fixes https://github.com/RPCS3/rpcs3/issues/7076