### PR TITLE
Qt: only show prefix for fatal messages

### DIFF
--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -60,7 +60,7 @@ struct gui_listener : logs::listener
 			packet_t p,* _new = &p;
 			_new->sev = msg;
 
-			if ((msg <= logs::level::fatal || show_prefix) && !prefix.empty())
+			if ((msg == logs::level::fatal || show_prefix) && !prefix.empty())
 			{
 				_new->msg += "{";
 				_new->msg += prefix;


### PR DESCRIPTION
"Always" messages are supposed to be humanly readable