### PR TITLE
Memory Searcher: Peek full string in log, fix case-insensitive search

### DIFF
--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -628,7 +628,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>String Search</string>
+    <string>Memory Searcher</string>
    </property>
   </action>
   <action name="toolsDecryptSprxLibsAct">

--- a/rpcs3/rpcs3qt/memory_string_searcher.cpp
+++ b/rpcs3/rpcs3qt/memory_string_searcher.cpp
@@ -83,11 +83,11 @@ memory_string_searcher::memory_string_searcher(QWidget* parent, std::shared_ptr<
 {
 	if (title.empty())
 	{
-		setWindowTitle(tr("String Searcher"));
+		setWindowTitle(tr("Memory Searcher"));
 	}
 	else
 	{
-		setWindowTitle(tr("String Searcher Of %1").arg(title.data()));
+		setWindowTitle(tr("Memory Searcher Of %1").arg(title.data()));
 	}
 
 	setObjectName("memory_string_searcher");
@@ -316,7 +316,7 @@ u64 memory_string_searcher::OnSearch(std::string wstr, int mode)
 
 	vm::reader_lock rlock;
 
-	const named_thread_group workers("String Searcher "sv, max_threads, [&]()
+	const named_thread_group workers("Memory Searcher "sv, max_threads, [&]()
 	{
 		if (mode == as_inst || mode == as_fake_spu_inst)
 		{


### PR DESCRIPTION
This tool has been renamed to "Memory Searcher". If one-to-one string is found, there will be no peek of it because it is basically the same as the inputted string. Turned out case-insensitive string search caused a log buffer overflow, fixed that.
![image](https://user-images.githubusercontent.com/18193363/142668147-225d9b05-ee29-4a79-994d-05d4caafe7f9.png)