### PR TITLE
fs: Reimplement path resolving using std::filesystem::weakly_canonical

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -4,6 +4,7 @@
 #include "Crypto/sha1.h"
 
 #include <unordered_map>
+#include <filesystem>
 #include <algorithm>
 #include <cstring>
 #include <map>
@@ -1819,6 +1820,20 @@ bool fs::remove_all(const std::string& path, bool remove_root)
 	}
 
 	return true;
+}
+
+std::string fs::resolve_path(std::string_view path)
+{
+	std::error_code ec{};
+	const auto result = std::filesystem::weakly_canonical(std::filesystem::path(path), ec);
+
+	if (ec)
+	{
+		g_tls_error = error::inval;
+		return {};
+	}
+
+	return result.string();
 }
 
 u64 fs::get_dir_size(const std::string& path, u64 rounding_alignment)

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -659,6 +659,9 @@ namespace fs
 		std::string m_dest{}; // Destination file path
 	};
 
+	// Get real path for comparisons
+	std::string resolve_path(std::string_view path);
+
 	// Delete directory and all its contents recursively
 	bool remove_all(const std::string& path, bool remove_root = true);
 

--- a/rpcs3/Crypto/aes.cpp
+++ b/rpcs3/Crypto/aes.cpp
@@ -32,6 +32,8 @@
 #include "aes.h"
 #include "aesni.h"
 
+#include <algorithm>
+
 /*
  * 32-bit integer manipulation macros (little endian)
  */
@@ -593,7 +595,8 @@ int aes_setkey_dec( aes_context *ctx, const unsigned char *key, unsigned int key
     *RK++ = *SK++;
 
 done:
-    memset( &cty, 0, sizeof( aes_context ) );
+    // Wipe the stack buffer clean
+    std::fill_n(reinterpret_cast<volatile char*>(&cty), sizeof(cty), 0);
 
     return( 0 );
 }

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -4234,8 +4234,13 @@ void PPUTranslator::MTFSB0(ppu_opcode_t op)
 void PPUTranslator::MTFSFI(ppu_opcode_t op)
 {
 	SetFPSCRBit(op.crfd * 4 + 0, m_ir->getInt1((op.i & 8) != 0), false);
-	if (op.crfd != 0) SetFPSCRBit(op.crfd * 4 + 1, m_ir->getInt1((op.i & 4) != 0), false);
-	if (op.crfd != 0) SetFPSCRBit(op.crfd * 4 + 2, m_ir->getInt1((op.i & 2) != 0), false);
+
+	if (op.crfd != 0)
+	{
+		SetFPSCRBit(op.crfd * 4 + 1, m_ir->getInt1((op.i & 4) != 0), false);
+		SetFPSCRBit(op.crfd * 4 + 2, m_ir->getInt1((op.i & 2) != 0), false);
+	}
+
 	SetFPSCRBit(op.crfd * 4 + 3, m_ir->getInt1((op.i & 1) != 0), false);
 
 	if (op.rc) SetCrFieldFPCC(1);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -554,7 +554,7 @@ void Emulator::SetForceBoot(bool force_boot)
 
 game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool is_disc_patch)
 {
-	const std::string resolved_path = GetCallbacks().resolve_path(m_path);
+	const std::string resolved_path = fs::resolve_path(m_path);
 
 	if (!IsStopped())
 	{
@@ -1213,7 +1213,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		// Check game updates
 		const std::string hdd0_boot = hdd0_game + m_title_id + "/USRDIR/EBOOT.BIN";
 
-		if (disc.empty() && !bdvd_dir.empty() && GetCallbacks().resolve_path(m_path) != GetCallbacks().resolve_path(hdd0_boot) && fs::is_file(hdd0_boot))
+		if (disc.empty() && !bdvd_dir.empty() && fs::resolve_path(m_path) != fs::resolve_path(hdd0_boot) && fs::is_file(hdd0_boot))
 		{
 			// Booting game update
 			sys_log.success("Updates found at /dev_hdd0/game/%s/", m_title_id);
@@ -1333,7 +1333,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 					return fmt::merge(result, "/");
 				};
 
-				const std::string resolved_hdd0 = GetCallbacks().resolve_path(hdd0_game) + '/';
+				const std::string resolved_hdd0 = fs::resolve_path(hdd0_game) + '/';
 
 				if (from_hdd0_game && m_cat == "DG")
 				{
@@ -1357,7 +1357,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 				else if (from_dev_flash)
 				{
 					// Firmware executables
-					argv[0] = "/dev_flash" + resolved_path.substr(GetCallbacks().resolve_path(g_cfg_vfs.get_dev_flash()).size());
+					argv[0] = "/dev_flash" + resolved_path.substr(fs::resolve_path(g_cfg_vfs.get_dev_flash()).size());
 					m_dir = fs::get_parent_dir(argv[0]) + '/';
 				}
 				else if (g_cfg.vfs.host_root)
@@ -1975,9 +1975,9 @@ std::set<std::string> Emulator::GetGameDirs() const
 
 bool Emulator::IsPathInsideDir(std::string_view path, std::string_view dir) const
 {
-	const std::string dir_path = GetCallbacks().resolve_path(dir);
+	const std::string dir_path = fs::resolve_path(dir);
 
-	return !dir_path.empty() && (GetCallbacks().resolve_path(path) + '/').starts_with(dir_path + '/');
+	return !dir_path.empty() && (fs::resolve_path(path) + '/').starts_with(dir_path + '/');
 };
 
 const std::string& Emulator::GetFakeCat() const

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -931,7 +931,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 					break;
 				}
 
-				if (fs::file sfb_file{parent_dir + "/PS3_DISC.SFB"}; sfb_file && sfb_file.size() >= 4 && sfb_file.read<u32>() == ".SFB"_u32)
+				if (fs::file sfb_file{parent_dir + "/PS3_DISC.SFB"}; sfb_file && !sfb_file.stat().is_directory && sfb_file.size() >= 4 && sfb_file.read<u32>() == ".SFB"_u32)
 				{
 					main_dir_name = std::string_view{search_dir}.substr(search_dir.find_last_of(fs::delim) + 1);
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -81,7 +81,6 @@ struct EmuCallbacks
 	std::function<std::string(localized_string_id, const char*)> get_localized_string;
 	std::function<std::u32string(localized_string_id, const char*)> get_localized_u32string;
 	std::function<void(const std::string&)> play_sound;
-	std::string(*resolve_path)(std::string_view) = nullptr; // Resolve path using Qt
 };
 
 class Emulator final

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -26,8 +26,6 @@
 #include "Emu/Audio/FAudio/FAudioBackend.h"
 #endif
 
-#include <QFileInfo> // This shouldn't be outside rpcs3qt...
-
 LOG_CHANNEL(sys_log, "SYS");
 
 /** Emu.Init() wrapper for user management */
@@ -121,11 +119,6 @@ EmuCallbacks main_application::CreateCallbacks()
 			result = std::make_shared<NullAudioBackend>();
 		}
 		return result;
-	};
-
-	callbacks.resolve_path = [](std::string_view sv)
-	{
-		return QFileInfo(QString::fromUtf8(sv.data(), static_cast<int>(sv.size()))).canonicalFilePath().toStdString();
 	};
 
 	return callbacks;

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -1128,21 +1128,6 @@ namespace atomic_wait
 	}
 }
 
-namespace std
-{
-	template <typename T>
-	void swap(stx::single_ptr<T>& lhs, stx::single_ptr<T>& rhs) noexcept
-	{
-		lhs.swap(rhs);
-	}
-
-	template <typename T>
-	void swap(stx::shared_ptr<T>& lhs, stx::shared_ptr<T>& rhs) noexcept
-	{
-		lhs.swap(rhs);
-	}
-}
-
 using stx::null_ptr;
 using stx::single_ptr;
 using stx::shared_ptr;


### PR DESCRIPTION
Removed the the dependency on QT initialization, use it for vfs::mount. `weakly_canonical` allows resolving of paths that do not exist, unlike `canonical` which returns an empty string for it which is not intended. Didn't test.