### PR TITLE
lv2: Add missing PPU reservation disowning in lv2_obj::yield

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1210,6 +1210,12 @@ bool lv2_obj::awake(cpu_thread* const thread, s32 prio)
 bool lv2_obj::yield(cpu_thread& thread)
 {
 	vm::temporary_unlock(thread);
+
+	if (auto ppu = thread.try_get<ppu_thread>())
+	{
+		ppu->raddr = 0; // Clear reservation
+	}
+
 	return awake(&thread, yield_cmd);
 }
 


### PR DESCRIPTION
Continuation of [#8137](https://github.com/RPCS3/rpcs3/pull/8137/commits/2bc05ab216dcad314fd8c40dea75b8c24f527b72).