### PR TITLE
cmake: Use GNUInstalldirs

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -3,6 +3,9 @@ if(USE_PRECOMPILED_HEADERS AND NOT COMMAND target_precompile_headers)
     include(cotire)
 endif()
 
+# Define GNU standard installation directories
+include(GNUInstallDirs)
+
 # Generate git-version.h at build time.
 include(${CMAKE_CURRENT_SOURCE_DIR}/git-version.cmake)
 
@@ -23,6 +26,7 @@ elseif(NOT MSVC AND NOT CMAKE_CXX_FLAGS MATCHES "LIBICONV_PLUG")
 endif()
 
 if(UNIX AND NOT APPLE)
+    add_definitions(-DDATADIR="${CMAKE_INSTALL_FULL_DATADIR}/rpcs3")
     # Optionally enable X11 for window management
     find_package(X11)
     if(X11_FOUND)
@@ -198,21 +202,21 @@ endif()
 # Unix installation
 if(UNIX AND NOT APPLE)
     # Install the binary
-    install(TARGETS rpcs3 RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+    install(TARGETS rpcs3 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     # Install the application icon and menu item
     install(FILES rpcs3.svg
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps)
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps)
     install(FILES rpcs3.png
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/48x48/apps)
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps)
     install(FILES rpcs3.desktop
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
     install(FILES rpcs3.metainfo.xml
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo)
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
     # Install other files
     install(DIRECTORY ../bin/Icons
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rpcs3)
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/rpcs3)
     install(DIRECTORY ../bin/GuiConfigs
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rpcs3)
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/rpcs3)
     install(DIRECTORY ../bin/git
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rpcs3)
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/rpcs3)
 endif()

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
@@ -116,7 +116,10 @@ namespace rsx
 						if (success)
 						{
 							std::string executablePath = dirname(result);
-#ifdef __APPLE__
+#if defined(DATADIR)
+							const std::string dataPath (DATADIR);
+							src = dataPath + "/Icons/ui/" + res;
+#elif defined(__APPLE__)
 							src = executablePath + "/../Resources/Icons/ui/" + res;
 #else
 							src = executablePath + "/../share/rpcs3/Icons/ui/" + res;

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -518,7 +518,10 @@ void gui_application::OnChangeStyleSheetRequest()
 		locs << m_gui_settings->GetSettingsDir();
 
 #if !defined(_WIN32)
-#ifdef __APPLE__
+#if defined(DATADIR)
+		const QString dataPath = (DATADIR);
+		locs << dataPath + "/GuiConfigs/";
+#elif defined(__APPLE__)
 		locs << QCoreApplication::applicationDirPath() + "/../Resources/GuiConfigs/";
 #else
 		locs << QCoreApplication::applicationDirPath() + "/../share/rpcs3/GuiConfigs/";

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -218,7 +218,10 @@ QStringList gui_settings::GetStylesheetEntries() const
 	QStringList res = gui::utils::get_dir_entries(m_settings_dir, name_filter);
 #if !defined(_WIN32)
 	// Makes stylesheets load if using AppImage (App Bundle) or installed to /usr/bin
-#ifdef __APPLE__
+#if defined(DATADIR)
+	const QString dataPath = (DATADIR);
+	QDir platformStylesheetDir = dataPath + "/GuiConfigs/";
+#elif defined(__APPLE__)
 	QDir platformStylesheetDir = QCoreApplication::applicationDirPath() + "/../Resources/GuiConfigs/";
 #else
 	QDir platformStylesheetDir = QCoreApplication::applicationDirPath() + "/../share/rpcs3/GuiConfigs/";


### PR DESCRIPTION
This is helpful for distros and for other users that may install rpcs3 to a non-standard path. For example a distro may want `/usr/games/rpcs3`, `/usr/share/games/rpcs3/` or another arbitrary path.

Reference: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html