### PR TITLE
rpcs3: Fix the DATADIR path for AppImage

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
@@ -77,9 +77,19 @@ namespace rsx
 				const std::string image_path = fs::get_config_dir() + "Icons/ui/" + res;
 				auto info = std::make_unique<image_info>(image_path.c_str());
 
+#if !defined(_WIN32) && !defined(__APPLE__) && defined(DATADIR)
+				// Check the DATADIR if defined
 				if (info->data == nullptr)
 				{
-					// Resource was not found in config dir, try and grab from relative path (linux)
+					const std::string data_dir (DATADIR);
+					const std::string image_data = data_dir + "/Icons/ui/" + res;
+					info = std::make_unique<image_info>(image_data.c_str());
+				}
+#endif
+
+				if (info->data == nullptr)
+				{
+					// Resource was not found in the DATADIR or config dir, try and grab from relative path (linux)
 					std::string src = "Icons/ui/" + res;
 					info = std::make_unique<image_info>(src.c_str());
 #ifndef _WIN32
@@ -116,10 +126,7 @@ namespace rsx
 						if (success)
 						{
 							std::string executablePath = dirname(result);
-#if defined(DATADIR)
-							const std::string dataPath (DATADIR);
-							src = dataPath + "/Icons/ui/" + res;
-#elif defined(__APPLE__)
+#ifdef __APPLE__
 							src = executablePath + "/../Resources/Icons/ui/" + res;
 #else
 							src = executablePath + "/../share/rpcs3/Icons/ui/" + res;

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -518,12 +518,13 @@ void gui_application::OnChangeStyleSheetRequest()
 		locs << m_gui_settings->GetSettingsDir();
 
 #if !defined(_WIN32)
-#if defined(DATADIR)
-		const QString dataPath = (DATADIR);
-		locs << dataPath + "/GuiConfigs/";
-#elif defined(__APPLE__)
+#ifdef __APPLE__
 		locs << QCoreApplication::applicationDirPath() + "/../Resources/GuiConfigs/";
 #else
+#ifdef DATADIR
+		const QString data_dir = (DATADIR);
+		locs << data_dir + "/GuiConfigs/";
+#endif
 		locs << QCoreApplication::applicationDirPath() + "/../share/rpcs3/GuiConfigs/";
 #endif
 		locs << QCoreApplication::applicationDirPath() + "/GuiConfigs/";

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -218,13 +218,14 @@ QStringList gui_settings::GetStylesheetEntries() const
 	QStringList res = gui::utils::get_dir_entries(m_settings_dir, name_filter);
 #if !defined(_WIN32)
 	// Makes stylesheets load if using AppImage (App Bundle) or installed to /usr/bin
-#if defined(DATADIR)
-	const QString dataPath = (DATADIR);
-	QDir platformStylesheetDir = dataPath + "/GuiConfigs/";
-#elif defined(__APPLE__)
+#ifdef __APPLE__
 	QDir platformStylesheetDir = QCoreApplication::applicationDirPath() + "/../Resources/GuiConfigs/";
 #else
 	QDir platformStylesheetDir = QCoreApplication::applicationDirPath() + "/../share/rpcs3/GuiConfigs/";
+#ifdef DATADIR
+	const QString data_dir = (DATADIR);
+	res.append(gui::utils::get_dir_entries(data_dir + "/GuiConfigs/", name_filter));
+#endif
 #endif
 	res.append(gui::utils::get_dir_entries(QCoreApplication::applicationDirPath() + "/GuiConfigs/", name_filter));
 	res.append(gui::utils::get_dir_entries(platformStylesheetDir, name_filter));


### PR DESCRIPTION
Even when DATADIR is defined the other paths may still be correct.

NOTE: I did not test AppImage, but I think this should work, please confirm.

See: https://github.com/RPCS3/rpcs3/pull/11189#issuecomment-977515204

Edit:

Fixes: https://github.com/RPCS3/rpcs3/issues/11195