### PR TITLE
sys_usbd improvements

### DIFF
--- a/rpcs3/Emu/Io/usb_device.cpp
+++ b/rpcs3/Emu/Io/usb_device.cpp
@@ -57,10 +57,33 @@ usb_device_passthrough::usb_device_passthrough(libusb_device* _device, libusb_de
 usb_device_passthrough::~usb_device_passthrough()
 {
 	if (lusb_handle)
+	{
+		libusb_release_interface(lusb_handle, 0);
 		libusb_close(lusb_handle);
+	}
 
 	if (lusb_device)
+	{
 		libusb_unref_device(lusb_device);
+	}
+}
+
+void usb_device_passthrough::send_libusb_transfer(libusb_transfer* transfer)
+{
+	while (true)
+	{
+		auto res = libusb_submit_transfer(transfer);
+		switch (res)
+		{
+		case LIBUSB_SUCCESS: return;
+		case LIBUSB_ERROR_BUSY: continue;
+		default:
+		{
+			sys_usbd.error("Unexpected error from libusb_submit_transfer: %d", res);
+			return;
+		}
+		}
+	}
 }
 
 bool usb_device_passthrough::open_device()
@@ -120,13 +143,13 @@ void usb_device_passthrough::control_transfer(u8 bmRequestType, u8 bRequest, u16
 	libusb_fill_control_setup(transfer->setup_buf.data(), bmRequestType, bRequest, wValue, wIndex, buf_size);
 	memcpy(transfer->setup_buf.data() + 8, buf, buf_size);
 	libusb_fill_control_transfer(transfer->transfer, lusb_handle, transfer->setup_buf.data(), callback_transfer, transfer, 0);
-	libusb_submit_transfer(transfer->transfer);
+	send_libusb_transfer(transfer->transfer);
 }
 
 void usb_device_passthrough::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer)
 {
 	libusb_fill_interrupt_transfer(transfer->transfer, lusb_handle, endpoint, buf, buf_size, callback_transfer, transfer, 0);
-	libusb_submit_transfer(transfer->transfer);
+	send_libusb_transfer(transfer->transfer);
 }
 
 void usb_device_passthrough::isochronous_transfer(UsbTransfer* transfer)
@@ -140,7 +163,7 @@ void usb_device_passthrough::isochronous_transfer(UsbTransfer* transfer)
 		transfer->transfer->iso_packet_desc[index].length = transfer->iso_request.packets[index];
 	}
 
-	libusb_submit_transfer(transfer->transfer);
+	send_libusb_transfer(transfer->transfer);
 }
 
 //////////////////////////////////////////////////////////////////

--- a/rpcs3/Emu/Io/usb_device.h
+++ b/rpcs3/Emu/Io/usb_device.h
@@ -111,7 +111,8 @@ struct UsbDescriptorNode
 	u8 bLength;
 	u8 bDescriptorType;
 
-	union {
+	union
+	{
 		UsbDeviceDescriptor _device;
 		UsbDeviceConfiguration _configuration;
 		UsbDeviceInterface _interface;
@@ -122,17 +123,15 @@ struct UsbDescriptorNode
 
 	std::vector<UsbDescriptorNode> subnodes;
 
-	UsbDescriptorNode(){}
+	UsbDescriptorNode() {}
 	template <typename T>
 	UsbDescriptorNode(u8 _bDescriptorType, const T& _data)
-	    : bLength(sizeof(T) + 2)
-	    , bDescriptorType(_bDescriptorType)
+		: bLength(sizeof(T) + 2), bDescriptorType(_bDescriptorType)
 	{
 		memcpy(data, &_data, sizeof(T));
 	}
 	UsbDescriptorNode(u8 _bLength, u8 _bDescriptorType, u8* _data)
-	    : bLength(_bLength)
-	    , bDescriptorType(_bDescriptorType)
+		: bLength(_bLength), bDescriptorType(_bDescriptorType)
 	{
 		memcpy(data, _data, _bLength - 2);
 	}
@@ -209,6 +208,9 @@ public:
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 	void isochronous_transfer(UsbTransfer* transfer) override;
+
+protected:
+	void send_libusb_transfer(libusb_transfer* transfer);
 
 protected:
 	libusb_device* lusb_device        = nullptr;


### PR DESCRIPTION
Change from a global locking to a mutex for the transfers(mutex_transfers) and reliance on sys_usbd internal locking(which changes some transfer into busy loops for passthroughs), also adds a mutex specifically for the ppu dequeue.

All the internal locks are moved into functions and only the global usb_handler_thread lock is accessible to sys_usbd functions.
Fixes https://github.com/RPCS3/rpcs3/issues/11201 and https://github.com/RPCS3/rpcs3/issues/8666.