### PR TITLE
CI: upgrade FreeBSD to Clang 13

### DIFF
--- a/.ci/install-freebsd.sh
+++ b/.ci/install-freebsd.sh
@@ -9,7 +9,7 @@ export ASSUME_ALWAYS_YES=true
 pkg info # debug
 
 # Prefer newer Clang than in base system (see also .ci/build-freebsd.sh)
-pkg install llvm12
+pkg install llvm13
 
 # Mandatory dependencies (qt5-dbus and qt5-gui are pulled via qt5-widgets)
 pkg install git ccache cmake ninja qt5-qmake qt5-buildtools qt5-widgets qt5-concurrent qt5-multimedia qt5-svg glew openal-soft ffmpeg


### PR DESCRIPTION
Downstream made a [similar change](https://github.com/freebsd/freebsd-ports/commit/11e15e9fac67). To be simplified once [llvm13 includes libc++](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=260139).

Now building libc++ as using only headers is [error-prone](https://github.com/freebsd/freebsd-ports/commit/6551900e74bb). Hopefully, the whole build isn't too slow.
