### PR TITLE
Qt: show time of day in 'last played' game info, log current time when RPCS3 boots

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -2,6 +2,8 @@
 // by Sacha Refshauge, Megamouse and flash-fire
 
 #include <iostream>
+#include <chrono>
+#include <sstream>
 
 #include <QApplication>
 #include <QCommandLineParser>
@@ -362,6 +364,14 @@ void log_q_debug(QtMsgType type, const QMessageLogContext& context, const QStrin
 	}
 }
 
+template <>
+void fmt_class_string<std::chrono::sys_time<typename std::chrono::system_clock::duration>>::format(std::string& out, u64 arg)
+{
+	std::ostringstream ss;
+	ss << get_object(arg);
+	out += ss.str();
+}
+
 
 
 int main(int argc, char** argv)
@@ -474,7 +484,10 @@ int main(int argc, char** argv)
 		logs::stored_message qt{(strcmp(QT_VERSION_STR, qVersion()) != 0) ? sys_log.error : sys_log.notice};
 		qt.text  = fmt::format("Qt version: Compiled against Qt %s | Run-time uses Qt %s", QT_VERSION_STR, qVersion());
 
-		logs::set_init({std::move(ver), std::move(sys), std::move(os), std::move(qt)});
+		logs::stored_message time{sys_log.always()};
+		time.text  = fmt::format("Current Time: %s", std::chrono::system_clock::now());
+
+		logs::set_init({std::move(ver), std::move(sys), std::move(os), std::move(qt), std::move(time)});
 	}
 
 #ifdef _WIN32

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -371,7 +371,7 @@ void fmt_class_string<std::chrono::sys_time<typename std::chrono::system_clock::
 	std::ostringstream ss;
 	const std::time_t dateTime = std::chrono::system_clock::to_time_t(get_object(arg));
  	const std::tm tm = *std::localtime(&dateTime);
-	ss << std::put_time(&tm, "%Y-%m-%e");
+	ss << std::put_time(&tm, "%Y-%m-%e-%H-%0M");
  	out += ss.str();
 }
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -371,7 +371,7 @@ void fmt_class_string<std::chrono::sys_time<typename std::chrono::system_clock::
 	std::ostringstream ss;
 	const std::time_t dateTime = std::chrono::system_clock::to_time_t(get_object(arg));
  	const std::tm tm = *std::localtime(&dateTime);
-	ss << std::put_time(&tm, "%Y-%m-%e-%H-%0M");
+	ss << std::put_time(&tm, "%Y-%m-%eT%H:%M:%S");
  	out += ss.str();
 }
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -473,22 +473,22 @@ int main(int argc, char** argv)
 	{
 		// Write RPCS3 version
 		logs::stored_message ver{sys_log.always()};
-		ver.text  = fmt::format("RPCS3 v%s | %s", rpcs3::get_version().to_string(), rpcs3::get_branch());
+		ver.text = fmt::format("RPCS3 v%s | %s", rpcs3::get_version().to_string(), rpcs3::get_branch());
 
 		// Write System information
 		logs::stored_message sys{sys_log.always()};
-		sys.text  = utils::get_system_info();
+		sys.text = utils::get_system_info();
 
 		// Write OS version
 		logs::stored_message os{sys_log.always()};
-		os.text  = utils::get_OS_version();
+		os.text = utils::get_OS_version();
 
 		// Write Qt version
 		logs::stored_message qt{(strcmp(QT_VERSION_STR, qVersion()) != 0) ? sys_log.error : sys_log.notice};
-		qt.text  = fmt::format("Qt version: Compiled against Qt %s | Run-time uses Qt %s", QT_VERSION_STR, qVersion());
+		qt.text = fmt::format("Qt version: Compiled against Qt %s | Run-time uses Qt %s", QT_VERSION_STR, qVersion());
 
 		logs::stored_message time{sys_log.always()};
-		time.text  = fmt::format("Current Time: %s", std::chrono::system_clock::now());
+		time.text = fmt::format("Current Time: %s", std::chrono::system_clock::now());
 
 		logs::set_init({std::move(ver), std::move(sys), std::move(os), std::move(qt), std::move(time)});
 	}

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <chrono>
 #include <sstream>
+#include <iomanip>
 
 #include <QApplication>
 #include <QCommandLineParser>

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -368,8 +368,10 @@ template <>
 void fmt_class_string<std::chrono::sys_time<typename std::chrono::system_clock::duration>>::format(std::string& out, u64 arg)
 {
 	std::ostringstream ss;
-	ss << get_object(arg);
-	out += ss.str();
+	const std::time_t dateTime = std::chrono::system_clock::to_time_t(get_object(arg));
+ 	const std::tm tm = *std::localtime(&dateTime);
+	ss << std::put_time(&tm, "%Y-%m-%e");
+ 	out += ss.str();
 }
 
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2397,16 +2397,16 @@ void game_list_frame::PopulateGameList()
 		const quint64 elapsed_ms = m_persistent_settings->GetPlaytime(serial);
 
 		// Last played (support outdated values)
-		QDate last_played;
+		QDateTime last_played;
 		const QString last_played_str = GetLastPlayedBySerial(serial);
 
 		if (!last_played_str.isEmpty())
 		{
-			last_played = QDate::fromString(last_played_str, gui::persistent::last_played_date_format);
+			last_played = QDateTime::fromString(last_played_str, gui::persistent::last_played_date_format);
 
 			if (!last_played.isValid())
 			{
-				last_played = QDate::fromString(last_played_str, gui::persistent::last_played_date_format_old);
+				last_played = QDateTime::fromString(last_played_str, gui::persistent::last_played_date_format_old);
 			}
 		}
 
@@ -2421,7 +2421,7 @@ void game_list_frame::PopulateGameList()
 		m_game_list->setItem(row, gui::column_resolution, new custom_table_widget_item(GetStringFromU32(game->info.resolution, localized.resolution.mode, true)));
 		m_game_list->setItem(row, gui::column_sound,      new custom_table_widget_item(GetStringFromU32(game->info.sound_format, localized.sound.format, true)));
 		m_game_list->setItem(row, gui::column_parental,   new custom_table_widget_item(GetStringFromU32(game->info.parental_lvl, localized.parental.level), Qt::UserRole, game->info.parental_lvl));
-		m_game_list->setItem(row, gui::column_last_play,  new custom_table_widget_item(locale.toString(last_played, gui::persistent::last_played_date_format_new), Qt::UserRole, last_played));
+		m_game_list->setItem(row, gui::column_last_play,  new custom_table_widget_item(locale.toString(last_played, last_played >= QDateTime::currentDateTime().addDays(-7) ? gui::persistent::last_played_date_with_time_of_day_format : gui::persistent::last_played_date_format_new), Qt::UserRole, last_played));
 		m_game_list->setItem(row, gui::column_playtime,   new custom_table_widget_item(elapsed_ms == 0 ? tr("Never played") : localized.GetVerboseTimeByMs(elapsed_ms), Qt::UserRole, elapsed_ms));
 		m_game_list->setItem(row, gui::column_compat,     compat_item);
 

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -449,7 +449,7 @@ void gui_application::StartPlaytime(bool start_playtime = true)
 		return;
 	}
 
-	m_persistent_settings->SetLastPlayed(serial, QDate::currentDate().toString(gui::persistent::last_played_date_format));
+	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format));
 	m_timer_playtime.start();
 	m_timer.start(10000); // Update every 10 seconds in case the emulation crashes
 }
@@ -471,7 +471,7 @@ void gui_application::UpdatePlaytime()
 	}
 
 	m_persistent_settings->AddPlaytime(serial, m_timer_playtime.restart());
-	m_persistent_settings->SetLastPlayed(serial, QDate::currentDate().toString(gui::persistent::last_played_date_format));
+	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format));
 }
 
 void gui_application::StopPlaytime()
@@ -489,7 +489,7 @@ void gui_application::StopPlaytime()
 	}
 
 	m_persistent_settings->AddPlaytime(serial, m_timer_playtime.restart());
-	m_persistent_settings->SetLastPlayed(serial, QDate::currentDate().toString(gui::persistent::last_played_date_format));
+	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format));
 	m_timer_playtime.invalidate();
 }
 

--- a/rpcs3/rpcs3qt/persistent_settings.h
+++ b/rpcs3/rpcs3qt/persistent_settings.h
@@ -16,9 +16,10 @@ namespace gui
 		const QString titles      = "Titles";
 
 		// Date format
-		const QString last_played_date_format_old    = "MMMM d yyyy";
-		const QString last_played_date_format_new    = "MMMM d, yyyy";
-		const Qt::DateFormat last_played_date_format = Qt::DateFormat::ISODate;
+		const QString last_played_date_format_old                  = "MMMM d yyyy";
+		const QString last_played_date_format_new                  = "MMMM d, yyyy";
+		const QString last_played_date_with_time_of_day_format     = "MMMM d, yyyy HH:mm";
+		const Qt::DateFormat last_played_date_format               = Qt::DateFormat::ISODate;
 
 		// GUI Saves
 		const gui_save save_notes  = gui_save(savedata, "notes",       QVariantMap());


### PR DESCRIPTION
1. This should simplify testing many games (for example for PR testing) by looking at the time of day of the 'last played' section and checking if it occurs after the time point that you booted RPCS3. I.e. Simplifying the process of knowing which games you have already tested from a large list.
2. By knowing current time with date when RPCS3 boots viewers/recipients of the log can attest early the provided logs from users such as the of PR testers or of users on forums instead of wasting time reading irrelevant logs.