### PR TITLE
macOS patches

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -17,17 +17,11 @@ git submodule init
 git submodule update
 
 # 3rdparty fixes
+ln -s "$VULKAN_SDK/lib/libMoltenVK.dylib" "$VULKAN_SDK/lib/libvulkan.dylib"
 sed -i '' "s/if(APPLE)/if(CMAKE_C_COMPILER_ID MATCHES \"AppleClang\")/g" 3rdparty/wolfssl/wolfssl/CMakeLists.txt
-#cd 3rdparty/ffmpeg
-#git pull origin master
-#cd ../hidapi/hidapi/mac
 cd 3rdparty/hidapi/hidapi/mac
 sed -i '' "s/extern const double NSAppKitVersionNumber;/const double NSAppKitVersionNumber = 1343;/g" hid.c
 cd ../../../..
-#cd llvm
-#git pull origin master
-#cd ..
-ln -s "$VULKAN_SDK/lib/libMoltenVK.dylib" "$VULKAN_SDK/lib/libvulkan.dylib"
 
 cd ..
 mkdir build && cd build || exit 1
@@ -55,14 +49,24 @@ rm -rf "rpcs3.app/Contents/Frameworks/QtPdf.framework" \
 "rpcs3.app/Contents/Plugins/platforminputcontexts" \
 "rpcs3.app/Contents/Plugins/virtualkeyboard"
 
+mv rpcs3.app RPCS3_.app
+mv RPCS3_.app RPCS3.app
+
+echo "[InternetShortcut]" > Quickstart.url
+echo "URL=https://rpcs3.net/quickstart" >> Quickstart.url
+echo "IconIndex=0" >> Quickstart.url
+
 create-dmg --volname RPCS3 \
 --window-size 800 400 \
 --icon-size 100 \
 --icon rpcs3.app 200 190 \
+--add-file Quickstart.url Quickstart.url 400 20 \
 --hide-extension rpcs3.app \
+--hide-extension Quickstart.url \
 --app-drop-link 600 185 \
+--skip-jenkins \
 "$ARTDIR/rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}_macos.dmg" \
-rpcs3.app
+RPCS3.app
 
-7z a -mx9 rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z rpcs3.app
+7z a -mx9 rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z RPCS3.app
 mv rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z "$ARTDIR"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,6 +130,4 @@ macos_task:
     CI_HAS_ARTIFACTS: true
   artifacts:
     name: Artifact
-    path: "artifacts/*.7z"
-    name: Artifact-DMG
-    path: "artifacts/*.dmg"
+    path: "artifacts/rpcs3-*_macos.*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,3 +111,25 @@ freebsd_task:
     folder: /tmp/ccache_dir
   install_script: "sh -ex ./.ci/install-freebsd.sh"
   script: "./.ci/build-freebsd.sh"
+
+macos_task:
+  timeout_in: 120m
+  ccache_cache:
+    folder: /tmp/ccache_dir
+  matrix:
+    - name: Cirrus macOS
+      osx_instance:
+        image: big-sur-base
+      mac_script:
+        - mkdir artifacts
+        - ".ci/build-mac.sh"
+  env:
+    ARTDIR: ${CIRRUS_WORKING_DIR}/artifacts/
+    CCACHE_DIR: "/tmp/ccache_dir"
+    CCACHE_MAXSIZE: 300M
+    CI_HAS_ARTIFACTS: true
+  artifacts:
+    name: Artifact
+    path: "artifacts/*.7z"
+    name: Artifact-DMG
+    path: "artifacts/*.dmg"

--- a/3rdparty/hidapi/CMakeLists.txt
+++ b/3rdparty/hidapi/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(3rdparty_hidapi INTERFACE)
 add_subdirectory(hidapi EXCLUDE_FROM_ALL)
 
 if(APPLE)
-	target_link_libraries(3rdparty_hidapi INTERFACE hidapi-mac "-framework CoreFoundation" "-framework IOKit")
+	target_link_libraries(3rdparty_hidapi INTERFACE hidapi_darwin "-framework CoreFoundation" "-framework IOKit")
 elseif(CMAKE_SYSTEM MATCHES "Linux")
 	target_link_libraries(3rdparty_hidapi INTERFACE hidapi-hidraw udev)
 elseif(WIN32)


### PR DESCRIPTION
The macOS patches we've been working on on Discord.
This fork:branch is for reference — the actual patches will be uploaded as separate pull requests.

~~- [x] Building with GCC 11 (requires patching a couple of Qt libraries: [qcoreapplication.h](https://cdn.discordapp.com/attachments/272083901277667342/913925397333291018/qcoreapplication.h), [qtconcurrentthreadengine.h](https://cdn.discordapp.com/attachments/272083901277667342/913925397488496690/qtconcurrentthreadengine.h); and a couple of [3rdparty libraries](https://github.com/RPCS3/rpcs3/issues/5361#issuecomment-986430965); ffmpeg needs to be rebuilt)~~ I recommend using Homebrew clang/llvm instead, it's much more reliable
- [x] Building with Homebrew clang/llvm (``brew install llvm`` — it doesn't even need most of the patches in this fork, so you can build master instead; tested with and without the patched Qt libraries above)
- [x] Fast interpreter
- [x] SPU ASMJIT
- [x] FAudio
- [x] Keyboard input (arrows keys not working)
- [x] DS4 controller input (USB)
- [x] Threaded downloader (linker errors when building with GCC, but works fine with brew clang/llvm — currently patched not to use Thread on macOS in this fork, so it's recommended to build master instead)
- [x] Cubeb (``-DUSE_AUDIOUNIT=ON``, not working with GCC)
- [ ] SPU LLVM (unstable)
- [x] PPU LLVM (generates huge logs, for some reason)
- [x] Bluetooth controller input
- [x] CI
- [ ] DS3 controller input (USB; keeps flashing)
- [ ] Generic controller handler (USB)
- [ ] Discord integration (linker errors — untested with brew clang/llvm)
- [ ] Building with clang/Xcode SDK (some semaphore functions required by RPCN are not available, and Vulkan fails with "Unknown context dma 0x%x")

Graphics:
- [x] Vulkan via moltenVK (currently requires "select" to be renamed "sel":rmacs3/"selection":master due to a bug in SPIRV-Cross, and existing Apple patches for correct colour rendering)
- [x] Unsupported texture/colour surface format conversion (mostly done)
- [ ] VkLogicOp emulation
- [ ] On-Disk Shader Cache (must be disabled in Config -> Advanced)
- [ ] OpenGL (will probably never work — should probably be removed from macOS builds)

Games:
- [x] Project DIVA F
- [x] Project DIVA Dreamy Theater (missing projected shadows)
- [x] The Simpsons Game (minor graphical errors)
- [x] P****** 5 (~~only boots sometimes, maybe due to a race condition~~ seems to work reliably with brew clang/llvm)
- [x] Kingdom Hearts 2.5
- [x] Tekken Tag Tournament 2 (requires "Write Color Buffers" for some textures)

## Building
Build instructions are for x64. aarch64 may work with some changes once support for it is added to the emulator.
Install Homebrew.
Note that on M1, x64 Homebrew is required. Run the following command to install it:
```
arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```
Afterwards, the following script can be used to install any x64 dependencies. Copy the following text to TextEdit or nano:
```
eval "$(/usr/local/Homebrew/bin/brew shellenv)"
arch -x86_64 brew "$@"
```
save it as ``~/brewx64.sh`` and run it like this to install the dependencies (one or two may be missing):
```
sh brewx64.sh install llvm sdl2 nasm molten-vk vulkan-headers qt@5 ninja glew cmake git
```
Env for building with Homebrew clang/llvm:
```
export CXX=clang++
export CC=clang
export Qt5_DIR="/usr/local/Cellar/qt@5/5.15.2_1/lib/cmake/Qt5"
export PATH="/usr/local/opt/llvm/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Library/Apple/usr/bin"
export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
export CPPFLAGS="-I/usr/local/opt/llvm/include -msse -msse2 -mcx16"
export CXXFLAGS="-I/usr/local/opt/llvm/include -msse -msse2 -mcx16"
export VULKAN_SDK="$HOME/VulkanSDK/1.2.198.1/macOS" # change the version if yours is different
export VK_ICD_FILENAMES="$VULKAN_SDK/share/vulkan/icd.d/MoltenVK_icd.json"
```
Clone the repository:
```
git clone --recursive -b rmacs3 https://github.com/nastys/rpcs3.git
```
Fix dependencies:
```
sed -i '' "s/if(APPLE)/if(CMAKE_C_COMPILER_ID MATCHES \"AppleClang\")/g" rpcs3/3rdparty/wolfssl/wolfssl/CMakeLists.txt
sed -i '' "s/extern const double NSAppKitVersionNumber;/const double NSAppKitVersionNumber = 1343;/g" rpcs3/3rdparty/hidapi/hidapi/mac/hid.c
```
Copy ``libc++abi.1.0.dylib`` from ``/usr/local/Cellar/llvm/13.0.0_2/lib`` to ``bin/rpcs3.app/Contents/Frameworks/libc++abi.1.dylib`` after building (if RPCS3 crashes).
Vulkan requires the [Vulkan SDK](https://vulkan.lunarg.com/) (if you get an error when you install it, just ignore it).
Finally:
```
mkdir rpcs3_build
cd rpcs3_build
cmake -DUSE_DISCORD_RPC=OFF -DUSE_VULKAN=ON -DUSE_ALSA=OFF -DUSE_PULSE=OFF -DUSE_AUDIOUNIT=ON -DCXXFLAGS="-msse -msse2 -mcx16" -G Ninja -DLLVM_CCACHE_BUILD=OFF -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_BUILD_RUNTIME=OFF -DLLVM_BUILD_TOOLS=OFF -DLLVM_INCLUDE_DOCS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_TOOLS=OFF -DLLVM_INCLUDE_UTILS=OFF -DLLVM_USE_PERF=OFF -DLLVM_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=20 ../rpcs3/
ninja
```
Use LLVM for PPU and ASMJIT for SPU until LLVM is fixed; disable On-Disk Shader Cache until fixed.
If you've previously attempted to use PPU LLVM (before it was fixed), you'll need to clear the old cache or it'll crash.
Also check the wiki for game-specific settings.