### PR TITLE
SPU: Cache reservation memory direct access handle (optimization)

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -276,8 +276,8 @@ public:
 	}
 
 	// Wait for both thread sync var and provided atomic var
-	template <atomic_wait::op Op = atomic_wait::op::eq, typename T, typename U>
-	static inline void wait_on(T& wait, U old, u64 usec = -1)
+	template <uint Max, typename Func>
+	static inline void wait_on_custom(Func&& setter, u64 usec = -1)
 	{
 		auto _this = g_tls_this_thread;
 
@@ -286,11 +286,17 @@ public:
 			return;
 		}
 
-		atomic_wait::list<3> list{};
-		list.set<0, Op>(wait, old);
-		list.set<1>(_this->m_sync, 0, 4 + 1);
-		list.set<2>(_this->m_taskq, nullptr);
+		atomic_wait::list<Max + 2> list{};
+		list.template set<Max>(_this->m_sync, 0, 4 + 1);
+		list.template set<Max + 1>(_this->m_taskq, nullptr);
+		setter(list);
 		list.wait(atomic_wait_timeout{usec <= 0xffff'ffff'ffff'ffff / 1000 ? usec * 1000 : 0xffff'ffff'ffff'ffff});
+	}
+
+	template <atomic_wait::op Op = atomic_wait::op::eq, typename T, typename U>
+	static inline void wait_on(T& wait, U old, u64 usec = -1)
+	{
+		wait_on_custom<1>([&](atomic_wait::list<3>& list){ list.set<0, Op>(wait, old); }, usec);
 	}
 
 	// Exit.


### PR DESCRIPTION
* Optimize resevation validation while waiting for events by prefetching shared memory handle of reservation in order to needing not lock VM mutex each iteration.
* It's now possible to wait for any combination of implemented events, instead of crashing with few.
* Allow diverse combinations of events mask whenever reading events, previously some were not allowed and had had terminated thread execution.