### PR TITLE
rsx: Improve vertex program analyzer

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -76,15 +76,7 @@ namespace gl
 
 		bool is_depth_surface() const override
 		{
-			switch (get_internal_format())
-			{
-			case gl::texture::internal_format::depth16:
-			case gl::texture::internal_format::depth24_stencil8:
-			case gl::texture::internal_format::depth32f_stencil8:
-				return true;
-			default:
-				return false;
-			}
+			return !!(aspect() & gl::image_aspect::depth);
 		}
 
 		void release_ref(texture* t) const override

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -413,15 +413,7 @@ namespace gl
 
 		bool is_depth_texture() const
 		{
-			switch (vram_texture->get_internal_format())
-			{
-			case gl::texture::internal_format::depth16:
-			case gl::texture::internal_format::depth24_stencil8:
-			case gl::texture::internal_format::depth32f_stencil8:
-				return true;
-			default:
-				return false;
-			}
+			return !!(vram_texture->aspect() & gl::image_aspect::depth);
 		}
 
 		bool has_compatible_format(gl::texture* tex) const

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
@@ -78,6 +78,7 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 
 			const auto instruction = v128::loadu(&data[current_instruction * 4]);
 			d1.HEX = instruction._u32[1];
+			d2.HEX = instruction._u32[2];
 			d3.HEX = instruction._u32[3];
 
 			// Touch current instruction
@@ -86,20 +87,52 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 			instruction_range.second = std::max(current_instruction, instruction_range.second);
 
 			// Whether to check if the current instruction references an input stream
-			bool test_input_read = false;
+			auto input_attribute_ref = [&]()
+			{
+				if (!d1.input_src)
+				{
+					// It is possible to reference ATTR0, but this is mandatory anyway. No need to explicitly test for it
+					return;
+				}
+
+				const auto ref_mask = (1u << d1.input_src);
+				if ((result.referenced_inputs_mask & ref_mask) == 0)
+				{
+					// Type is encoded in the first 2 bits of each block
+					const auto src0 = d2.src0l & 0x3;
+					const auto src1 = d2.src1  & 0x3;
+					const auto src2 = d3.src2l & 0x3;
+
+					if ((src0 == RSX_VP_REGISTER_TYPE_INPUT) ||
+						(src1 == RSX_VP_REGISTER_TYPE_INPUT) ||
+						(src2 == RSX_VP_REGISTER_TYPE_INPUT))
+					{
+						result.referenced_inputs_mask |= ref_mask;
+					}
+				}
+			};
+
+			auto branch_to = [&](const u32 target)
+			{
+				input_attribute_ref();
+				current_instruction = target;
+			};
 
 			// Basic vec op analysis, must be done before flow analysis
 			switch (d1.vec_opcode)
 			{
+			case RSX_VEC_OPCODE_NOP:
+			{
+				break;
+			}
 			case RSX_VEC_OPCODE_TXL:
 			{
-				d2.HEX = instruction._u32[2];
 				result.referenced_textures_mask |= (1 << d2.tex_num);
 				break;
 			}
 			default:
 			{
-				test_input_read = !!d1.input_src;
+				input_attribute_ref();
 				break;
 			}
 			}
@@ -109,6 +142,10 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 
 			switch (d1.sca_opcode)
 			{
+			case RSX_SCA_OPCODE_NOP:
+			{
+				break;
+			}
 			case RSX_SCA_OPCODE_BRI:
 			{
 				d0.HEX = instruction._u32[0];
@@ -129,19 +166,18 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 				has_branch_instruction = true;
 
 				d0.HEX = instruction._u32[0];
-				d2.HEX = instruction._u32[2];
 				const u32 jump_address = (d0.iaddrh2 << 9) | (d2.iaddrh << 3) | d3.iaddrl;
 
 				if (function_call)
 				{
 					call_stack.push(current_instruction + 1);
-					current_instruction = jump_address;
+					branch_to(jump_address);
 					continue;
 				}
 				else if (static_jump)
 				{
 					// NOTE: This will skip potential jump target blocks between current->target
-					current_instruction = jump_address;
+					branch_to(jump_address);
 					continue;
 				}
 				else
@@ -161,7 +197,7 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 				}
 				else
 				{
-					current_instruction = call_stack.top();
+					branch_to(call_stack.top());
 					call_stack.pop();
 					continue;
 				}
@@ -170,24 +206,9 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 			}
 			default:
 			{
-				test_input_read = !!d1.input_src;
+				input_attribute_ref();
 				break;
 			}
-			}
-
-			if (test_input_read)
-			{
-				// Type is encoded in the first 2 bits of each block
-				d2.HEX = instruction._u32[2];
-
-				const auto src0 = d2.src0l;
-				const auto src1 = d2.src1;
-				const auto src2 = d3.src2l;
-
-				if ((src0 | src1 | src2) & RSX_VP_REGISTER_TYPE_INPUT)
-				{
-					result.referenced_inputs_mask |= (1 << d1.input_src);
-				}
 			}
 
 			if ((d3.end && (fast_exit || current_instruction >= instruction_range.second)) ||

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -346,16 +346,7 @@ namespace vk
 
 		bool is_depth_texture() const
 		{
-			switch (vram_texture->info.format)
-			{
-			case VK_FORMAT_D16_UNORM:
-			case VK_FORMAT_D32_SFLOAT:
-			case VK_FORMAT_D32_SFLOAT_S8_UINT:
-			case VK_FORMAT_D24_UNORM_S8_UINT:
-				return true;
-			default:
-				return false;
-			}
+			return !!(vram_texture->aspect() & VK_IMAGE_ASPECT_DEPTH_BIT);
 		}
 	};
 


### PR DESCRIPTION
- Ignore all processing for NOP instructions, it is legal to contain garbage in other fields.
- Fix static flow instructions jumping over the input scanning block.
- Add missing depth32f format for ogl.

Fixes https://github.com/RPCS3/rpcs3/issues/11235