### PR TITLE
Remove unnecessary define

### DIFF
--- a/rpcs3/display_sleep_control.cpp
+++ b/rpcs3/display_sleep_control.cpp
@@ -1,7 +1,6 @@
 #include "display_sleep_control.h"
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #elif defined(__APPLE__)


### PR DESCRIPTION
Warnings are bad, mkay? It's already defined in the vcxproj.
`6>D:\GitHub\rpcs3\rpcs3\display_sleep_control.cpp(4,1): warning C4005: 'WIN32_LEAN_AND_MEAN': macro redefinition
6>D:\GitHub\rpcs3\rpcs3\display_sleep_control.cpp : message : see previous definition of 'WIN32_LEAN_AND_MEAN'`