### PR TITLE
cellSaveData: prevent some potential crashes due to corrupt files

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -230,13 +230,13 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 		const auto& psf = psf::load_object(fs::file(local_dir +"/PARAM.SFO"));
 
 		// Some following fields may be zero in old FW 1.00 version PARAM.SFO
-		if (psf.count("PARENTAL_LEVEL") != 0) get->getParam.parentalLevel = psf.at("PARENTAL_LEVEL").as_integer();
-		if (psf.count("ATTRIBUTE") != 0) get->getParam.attribute = psf.at("ATTRIBUTE").as_integer();
-		if (psf.count("RESOLUTION") != 0) get->getParam.resolution = psf.at("RESOLUTION").as_integer();
-		if (psf.count("SOUND_FORMAT") != 0) get->getParam.soundFormat = psf.at("SOUND_FORMAT").as_integer();
-		if (psf.count("TITLE") != 0) strcpy_trunc(get->getParam.title, psf.at("TITLE").as_string());
-		if (psf.count("APP_VER") != 0) strcpy_trunc(get->getParam.dataVersion, psf.at("APP_VER").as_string());
-		if (psf.count("TITLE_ID") != 0) strcpy_trunc(get->getParam.titleId, psf.at("TITLE_ID").as_string());
+		if (psf.contains("PARENTAL_LEVEL")) get->getParam.parentalLevel = psf.at("PARENTAL_LEVEL").as_integer();
+		if (psf.contains("ATTRIBUTE")) get->getParam.attribute = psf.at("ATTRIBUTE").as_integer();
+		if (psf.contains("RESOLUTION")) get->getParam.resolution = psf.at("RESOLUTION").as_integer();
+		if (psf.contains("SOUND_FORMAT")) get->getParam.soundFormat = psf.at("SOUND_FORMAT").as_integer();
+		if (psf.contains("TITLE")) strcpy_trunc(get->getParam.title, psf.at("TITLE").as_string());
+		if (psf.contains("APP_VER")) strcpy_trunc(get->getParam.dataVersion, psf.at("APP_VER").as_string());
+		if (psf.contains("TITLE_ID")) strcpy_trunc(get->getParam.titleId, psf.at("TITLE_ID").as_string());
 
 		for (u32 i = 0; i < CELL_HDDGAME_SYSP_LANGUAGE_NUM; i++)
 		{
@@ -1356,10 +1356,10 @@ error_code cellDiscGameGetBootDiscInfo(vm::ptr<CellDiscGameSystemFileParam> getP
 		return CELL_DISCGAME_ERROR_NOT_DISCBOOT;
 	}
 
-	const auto& psf = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
+	const psf::registry psf = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
 
-	if (psf.count("PARENTAL_LEVEL") != 0) getParam->parentalLevel = psf.at("PARENTAL_LEVEL").as_integer();
-	if (psf.count("TITLE_ID") != 0) strcpy_trunc(getParam->titleId, psf.at("TITLE_ID").as_string());
+	if (psf.contains("PARENTAL_LEVEL")) getParam->parentalLevel = psf.at("PARENTAL_LEVEL").as_integer();
+	if (psf.contains("TITLE_ID")) strcpy_trunc(getParam->titleId, psf.at("TITLE_ID").as_string());
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -151,11 +151,11 @@ static std::vector<SaveDataEntry> get_save_entries(const std::string& base_dir, 
 		}
 
 		SaveDataEntry save_entry;
-		save_entry.dirName   = psf.at("SAVEDATA_DIRECTORY").as_string();
-		save_entry.listParam = psf.at("SAVEDATA_LIST_PARAM").as_string();
-		save_entry.title     = psf.at("TITLE").as_string();
-		save_entry.subtitle  = psf.at("SUB_TITLE").as_string();
-		save_entry.details   = psf.at("DETAIL").as_string();
+		save_entry.dirName   = psf::get_string(psf, "SAVEDATA_DIRECTORY");
+		save_entry.listParam = psf::get_string(psf, "SAVEDATA_LIST_PARAM");
+		save_entry.title     = psf::get_string(psf, "TITLE");
+		save_entry.subtitle  = psf::get_string(psf, "SUB_TITLE");
+		save_entry.details   = psf::get_string(psf, "DETAIL");
 
 		for (const auto& entry2 : fs::dir(base_dir + entry.name))
 		{
@@ -678,11 +678,11 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 						}
 
 						SaveDataEntry save_entry2;
-						save_entry2.dirName = psf.at("SAVEDATA_DIRECTORY").as_string();
-						save_entry2.listParam = psf.at("SAVEDATA_LIST_PARAM").as_string();
-						save_entry2.title = psf.at("TITLE").as_string();
-						save_entry2.subtitle = psf.at("SUB_TITLE").as_string();
-						save_entry2.details = psf.at("DETAIL").as_string();
+						save_entry2.dirName   = psf::get_string(psf, "SAVEDATA_DIRECTORY");
+						save_entry2.listParam = psf::get_string(psf, "SAVEDATA_LIST_PARAM");
+						save_entry2.title     = psf::get_string(psf, "TITLE");
+						save_entry2.subtitle  = psf::get_string(psf, "SUB_TITLE");
+						save_entry2.details   = psf::get_string(psf, "DETAIL");
 
 						for (const auto& entry2 : fs::dir(base_dir + entry.name))
 						{
@@ -1291,8 +1291,8 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 	// This section contains the list of files in the save ordered as they would be in BSD filesystem
 	std::vector<std::string> blist;
 
-	if (psf.count("RPCS3_BLIST"))
-		blist = fmt::split(psf.at("RPCS3_BLIST").as_string(), {"/"}, false);
+	if (const auto it = psf.find("RPCS3_BLIST"); it != psf.cend())
+		blist = fmt::split(it->second.as_string(), {"/"}, false);
 
 	// Get save stats
 	{
@@ -1318,12 +1318,12 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 		if (!psf.empty())
 		{
-			statGet->getParam.parental_level = psf.at("PARENTAL_LEVEL").as_integer();
-			statGet->getParam.attribute = psf.at("ATTRIBUTE").as_integer(); // ???
-			strcpy_trunc(statGet->getParam.title, save_entry.title = psf.at("TITLE").as_string());
-			strcpy_trunc(statGet->getParam.subTitle, save_entry.subtitle = psf.at("SUB_TITLE").as_string());
-			strcpy_trunc(statGet->getParam.detail, save_entry.details = psf.at("DETAIL").as_string());
-			strcpy_trunc(statGet->getParam.listParam, save_entry.listParam = psf.at("SAVEDATA_LIST_PARAM").as_string());
+			statGet->getParam.parental_level = psf::get_integer(psf, "PARENTAL_LEVEL");
+			statGet->getParam.attribute = psf::get_integer(psf, "ATTRIBUTE"); // ???
+			strcpy_trunc(statGet->getParam.title, save_entry.title = psf::get_string(psf, "TITLE"));
+			strcpy_trunc(statGet->getParam.subTitle, save_entry.subtitle = psf::get_string(psf, "SUB_TITLE"));
+			strcpy_trunc(statGet->getParam.detail, save_entry.details = psf::get_string(psf, "DETAIL"));
+			strcpy_trunc(statGet->getParam.listParam, save_entry.listParam = psf::get_string(psf, "SAVEDATA_LIST_PARAM"));
 		}
 
 		statGet->bind = 0;
@@ -2056,14 +2056,14 @@ static NEVER_INLINE error_code savedata_get_list_item(vm::cptr<char> dirName, vm
 		return CELL_SAVEDATA_ERROR_NODATA;
 	}
 
-	auto psf = psf::load_object(fs::file(sfo));
+	const psf::registry psf = psf::load_object(fs::file(sfo));
 
 	if (sysFileParam)
 	{
-		strcpy_trunc(sysFileParam->listParam, psf.at("SAVEDATA_LIST_PARAM").as_string());
-		strcpy_trunc(sysFileParam->title, psf.at("TITLE").as_string());
-		strcpy_trunc(sysFileParam->subTitle, psf.at("SUB_TITLE").as_string());
-		strcpy_trunc(sysFileParam->detail, psf.at("DETAIL").as_string());
+		strcpy_trunc(sysFileParam->listParam, psf::get_string(psf, "SAVEDATA_LIST_PARAM"));
+		strcpy_trunc(sysFileParam->title, psf::get_string(psf, "TITLE"));
+		strcpy_trunc(sysFileParam->subTitle, psf::get_string(psf, "SUB_TITLE"));
+		strcpy_trunc(sysFileParam->detail, psf::get_string(psf, "DETAIL"));
 	}
 
 	if (dir)


### PR DESCRIPTION
Proof (from Discord):
```

0x00000000006f190e in s_terminate_handler_set::{lambda()#1}::operator()() const::{lambda()#1}::_FUN() ()
(gdb) bt
#0  0x00000000006f190e in s_terminate_handler_set::{lambda()#1}::operator()() const::{lambda()#1}::_FUN() ()
#1  0x00007f4a401e529c in __cxxabiv1::__terminate(void (*)()) (handler=<optimized out>)
    at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
#2  0x00007f4a401e5307 in std::terminate() () at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:58
#3  0x00007f4a401e55a9 in __cxxabiv1::__cxa_throw(void*, std::type_info*, void (*)(void*))
    (obj=<optimized out>, tinfo=0x7f4a40349208 <typeinfo for std::out_of_range>, dest=0x7f4a401fb2c0 <std::out_of_range::~out_of_range()>) at ../../../../libstdc++-v3/libsupc++/eh_throw.cc:95
#4  0x00007f4a401dc47f in std::__throw_out_of_range(char const*) (__s=0x30ea8d4 "map::at")
    at ../../../../../libstdc++-v3/src/c++11/functexcept.cc:86
#5  0x000000000093db2e in  ()
#6  0x00000000009d8475 in savedata_op(ppu_thread&, unsigned int, unsigned int, vm::_ptr_base<char const, unsigned int>, unsigned int, vm::_ptr_base<CellSaveDataSetList, unsigned int>, vm::_ptr_base<CellSaveDataSetBuf, unsigned int>, vm::_ptr_base<void (vm::_ptr_base<CellSaveDataCBResult, unsigned int>, vm::_ptr_base<CellSaveDataListGet, unsigned int>, vm::_ptr_base<CellSaveDataListSet, unsigned int>), unsigned int>, vm::_ptr_base<void (vm::_ptr_base<CellSaveDataCBResult, unsigned int>, vm::_ptr_base<CellSaveDataListGet, unsigned int>, vm::_ptr_base<CellSaveDataFixedSet, unsigned int>), unsigned int>, vm::_ptr_base<void (vm::_ptr_base<CellSaveDataCBResult, unsigned int>, vm::_ptr_base<CellSaveDataStatGet, unsigned int>, vm::_ptr_base<CellSaveDataStatSet, unsigned int>), unsigned int>, vm::_ptr_base<void (vm::_ptr_base<CellSaveDataCBResult, unsigned int>, vm::_ptr_base<CellSaveDataFileGet, unsigned int>, vm::_ptr_base<CellSaveDataFileSet, unsigned int>), unsigned int>, unsigned int, unsigned int, vm::_ptr_base<void, unsigned int>, unsigned int, vm::_ptr_base<void (vm::_ptr_base<CellSaveDataCBResult, unsigned int>, vm::_ptr_base<CellSaveDataDoneGet, unsigned int>), unsigned int>) [clone .isra.0] ()
#7  0x00000000009dd09a in cellSysutil_SaveData_init()::{lambda(ppu_thread&)#20}::_FUN(ppu_thread&) ()
#8  0x0000000009009057 in  ()
#9  0x0000000000000000 in  ()

```