### PR TITLE
Input: Add stick multipliers to the keyboard pad handler

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -105,6 +105,12 @@ long PadHandlerBase::FindKeyCodeByString(const std::unordered_map<u64, std::stri
 	return -1;
 }
 
+// Get new multiplied value based on the multiplier
+s32 PadHandlerBase::MultipliedInput(s32 raw_value, s32 multiplier)
+{
+	return (multiplier * raw_value) / 100;
+}
+
 // Get new scaled value between 0 and 255 based on its minimum and maximum
 float PadHandlerBase::ScaledInput(s32 raw_value, int minimum, int maximum)
 {
@@ -163,7 +169,7 @@ u16 PadHandlerBase::NormalizeDirectedInput(s32 raw_value, s32 threshold, s32 max
 
 u16 PadHandlerBase::NormalizeStickInput(u16 raw_value, int threshold, int multiplier, bool ignore_threshold) const
 {
-	const s32 scaled_value = (multiplier * raw_value) / 100;
+	const s32 scaled_value = MultipliedInput(raw_value, multiplier);
 
 	if (ignore_threshold)
 	{

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -101,6 +101,9 @@ protected:
 	// Search an unordered map for a string value and return found keycode
 	static long FindKeyCodeByString(const std::unordered_map<u64, std::string>& map, const std::string& name, bool fallback = true);
 
+	// Get new multiplied value based on the multiplier
+	static s32 MultipliedInput(s32 raw_value, s32 multiplier);
+
 	// Get new scaled value between 0 and 255 based on its minimum and maximum
 	static float ScaledInput(s32 raw_value, int minimum, int maximum);
 

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -150,13 +150,13 @@ void keyboard_pad_handler::Key(const u32 code, bool pressed, u16 value)
 				value = MultipliedInput(value, is_left_stick ? m_l_stick_multiplier : m_r_stick_multiplier);
 			}
 
-			const u16 normalized_value = std::max<u16>(1, static_cast<u16>(std::floor(value / 2.0)));
+			const u16 normalized_value = std::ceil(value / 2.0);
 
 			if (is_max)
-				m_stick_max[i] = pressed ? 128 + normalized_value : 128;
+				m_stick_max[i] = pressed ? std::min<int>(128 + normalized_value, 255) : 128;
 
 			if (is_min)
-				m_stick_min[i] = pressed ? normalized_value : 0;
+				m_stick_min[i] = pressed ? std::min<u8>(normalized_value, 128) : 0;
 
 			m_stick_val[i] = m_stick_max[i] - m_stick_min[i];
 

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -121,6 +121,8 @@ private:
 	steady_clock::time_point m_stick_time;
 	f32 m_l_stick_lerp_factor = 1.0f;
 	f32 m_r_stick_lerp_factor = 1.0f;
+	u32 m_l_stick_multiplier = 100;
+	u32 m_r_stick_multiplier = 100;
 	u8 m_stick_min[4] = { 0, 0, 0, 0 };
 	u8 m_stick_max[4] = { 128, 128, 128, 128 };
 	u8 m_stick_val[4] = { 128, 128, 128, 128 };

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -975,10 +975,14 @@ void pad_settings_dialog::UpdateLabels(bool is_reset)
 		range = cfg.lstickmultiplier.to_list();
 		ui->stick_multi_left->setRange(std::stod(range.front()) / 100.0, std::stod(range.back()) / 100.0);
 		ui->stick_multi_left->setValue(cfg.lstickmultiplier / 100.0);
+		ui->kb_stick_multi_left->setRange(std::stod(range.front()) / 100.0, std::stod(range.back()) / 100.0);
+		ui->kb_stick_multi_left->setValue(cfg.lstickmultiplier / 100.0);
 
 		range = cfg.rstickmultiplier.to_list();
 		ui->stick_multi_right->setRange(std::stod(range.front()) / 100.0, std::stod(range.back()) / 100.0);
 		ui->stick_multi_right->setValue(cfg.rstickmultiplier / 100.0);
+		ui->kb_stick_multi_right->setRange(std::stod(range.front()) / 100.0, std::stod(range.back()) / 100.0);
+		ui->kb_stick_multi_right->setValue(cfg.rstickmultiplier / 100.0);
 
 		// Update Squircle Factors
 		range = cfg.lpadsquircling.to_list();
@@ -1026,6 +1030,8 @@ void pad_settings_dialog::SwitchButtons(bool is_enabled)
 	ui->chb_show_emulated_values->setEnabled(is_enabled);
 	ui->stick_multi_left->setEnabled(is_enabled);
 	ui->stick_multi_right->setEnabled(is_enabled);
+	ui->kb_stick_multi_left->setEnabled(is_enabled);
+	ui->kb_stick_multi_right->setEnabled(is_enabled);
 	ui->squircle_left->setEnabled(is_enabled);
 	ui->squircle_right->setEnabled(is_enabled);
 	ui->gb_pressure_intensity->setEnabled(is_enabled && m_enable_pressure_intensity_button);
@@ -1563,8 +1569,17 @@ void pad_settings_dialog::ApplyCurrentPlayerConfig(int new_player_id)
 	// Apply rest of config
 	auto& cfg = player->config;
 
-	cfg.lstickmultiplier.set(ui->stick_multi_left->value() * 100);
-	cfg.rstickmultiplier.set(ui->stick_multi_right->value() * 100);
+	if (m_handler->m_type == pad_handler::keyboard)
+	{
+		cfg.lstickmultiplier.set(ui->kb_stick_multi_left->value() * 100);
+		cfg.rstickmultiplier.set(ui->kb_stick_multi_right->value() * 100);
+	}
+	else
+	{
+		cfg.lstickmultiplier.set(ui->stick_multi_left->value() * 100);
+		cfg.rstickmultiplier.set(ui->stick_multi_right->value() * 100);
+	}
+
 	cfg.lpadsquircling.set(ui->squircle_left->value());
 	cfg.rpadsquircling.set(ui->squircle_right->value());
 
@@ -1727,6 +1742,7 @@ void pad_settings_dialog::SubscribeTooltips()
 	SubscribeTooltip(ui->gb_pressure_intensity, tooltips.gamepad_settings.pressure_intensity);
 	SubscribeTooltip(ui->gb_squircle, tooltips.gamepad_settings.squircle_factor);
 	SubscribeTooltip(ui->gb_stick_multi, tooltips.gamepad_settings.stick_multiplier);
+	SubscribeTooltip(ui->gb_kb_stick_multi, tooltips.gamepad_settings.stick_multiplier);
 	SubscribeTooltip(ui->gb_vibration, tooltips.gamepad_settings.vibration);
 	SubscribeTooltip(ui->gb_sticks, tooltips.gamepad_settings.stick_deadzones);
 	SubscribeTooltip(ui->gb_stick_preview, tooltips.gamepad_settings.emulated_preview);

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -2369,8 +2369,8 @@
                 </item>
                </layout>
               </widget>
-              <widget class="QWidget" name="smooth_page">
-               <layout class="QVBoxLayout" name="smooth_page_layout">
+              <widget class="QWidget" name="keyboard_page">
+               <layout class="QVBoxLayout" name="keyboard_page_layout">
                 <property name="leftMargin">
                  <number>0</number>
                 </property>
@@ -2383,6 +2383,81 @@
                 <property name="bottomMargin">
                  <number>0</number>
                 </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_kb_stick_multi">
+                  <property name="title">
+                   <string>Stick Multipliers</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="gb_kb_stick_multi_layout">
+                   <property name="leftMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>5</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>5</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="label_kb_stick_multi_left">
+                     <property name="text">
+                      <string>Left</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QDoubleSpinBox" name="kb_stick_multi_left">
+                     <property name="singleStep">
+                      <double>0.100000000000000</double>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="spacer_kb_stick_multi_left">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_kb_stick_multi_right">
+                     <property name="text">
+                      <string>Right</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QDoubleSpinBox" name="kb_stick_multi_right">
+                     <property name="singleStep">
+                      <double>0.100000000000000</double>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="spacer_kb_stick_multi_right">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
                 <item>
                  <widget class="QGroupBox" name="gb_stick_lerp">
                   <property name="title">
@@ -2465,7 +2540,7 @@
                  </widget>
                 </item>
                 <item>
-                 <spacer name="smooth_page_spacer">
+                 <spacer name="keyboard_page_spacer">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
                   </property>


### PR DESCRIPTION
- Adds the stick multipliers to the keyboard pad handler. It works basically the same as in other pad handlers.
- Fixes a bug that caused the stick values of the keyboard pad handler to be always at least 1.
This means that there was no way to fully reach the maximum value for up or left with the keyboard.
I doubt that this changes anything for anyone, but it was wrong nonetheless.