### PR TITLE
Drop libwayland-client from official appimages

### DIFF
--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -18,6 +18,11 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     # Embed newer libstdc++ for distros that don't come with it (ubuntu 16.04)
     mkdir -p appdir/usr/optional/ ; mkdir -p appdir/usr/optional/libstdc++/
     cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/
+    
+    # Remove libwayland-client because it has platform-dependent exports and breaks other OSes
+    rm -f ./appdir/usr/lib/libwayland-client.so*
+    
+    # Install latest appimage runner
     rm ./appdir/AppRun
     curl -sL https://github.com/RPCS3/AppImageKit-checkrt/releases/download/continuous2/AppRun-patched-x86_64 -o ./appdir/AppRun
     chmod a+x ./appdir/AppRun


### PR DESCRIPTION
Fixes a serious problem with non-debian *nix OSes.
The wayland client library is different (so exports are not 1:1) on arch based distros at the very least and since the windowing APIs are linked to the graphics drivers, this leads to a hilarious situation where the appimage (which is ubuntu) cannot run on arch with mesa drivers. Well, technically it runs but no vulkan capable GPU can be enumerated.