### PR TITLE
Fedora (35): Adjust to Pipewire adoption ++QT deps

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -82,7 +82,7 @@ sudo apt-get install cmake
 
 #### Fedora
 
-    sudo dnf install alsa-lib-devel cmake glew glew-devel libatomic libevdev-devel libudev-devel openal-devel qt5-qtbase-devel qt5-qtbase-private-devel vulkan-devel jack-audio-connection-kit-devel
+    sudo dnf install alsa-lib-devel cmake glew glew-devel libatomic libevdev-devel libudev-devel openal-devel qt5-qtbase-devel qt5-qtbase-private-devel vulkan-devel pipewire-jack-audio-connection-kit-devel qt5-qtmultimedia-devel qt5-qtsvg-devel
 
 #### OpenSUSE
 


### PR DESCRIPTION
Provided build steps didn't work on Fedora 35, these packages seem to settle things 😄

Fedora defaults to Pipewire... with Wireplumber as a session manager - or the 'basic' one built into Pipewire.

(Context: this may change by DE/WM as they may tend to launch this on login.  eg: `i3`, `sway`.  Other times with systemd user services)

Through dependency resolution we find a conflict with `jack-audio-connection-kit-devel` (pre-change).

This wants to pull in `jack-audio-connection-kit` that conflicts with `pipewire-jack-audio-connection-kit`.  We want `pipewire-jack-audio-connection-kit-devel` instead!  

Aside from that, some QT dependencies: 
 - `qt5-qtmultimedia-devel`
 - `qt5-qtsvg-devel`