### PR TITLE
Handle SYS_NET_IPPROTO_IP get/setsockopt

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net.h
@@ -70,7 +70,7 @@ enum lv2_socket_type : s32
 };
 
 // Socket options (prefixed with SYS_NET_)
-enum
+enum lv2_socket_option : s32
 {
 	SYS_NET_SO_SNDBUF       = 0x1001,
 	SYS_NET_SO_RCVBUF       = 0x1002,
@@ -94,6 +94,22 @@ enum
 	SYS_NET_SO_USESIGNATURE = 0x2000,
 
 	SYS_NET_SOL_SOCKET      = 0xffff,
+};
+
+// IP options (prefixed with SYS_NET_)
+enum lv2_ip_option : s32
+{
+	SYS_NET_IP_HDRINCL         = 2,
+	SYS_NET_IP_TOS             = 3,
+	SYS_NET_IP_TTL             = 4,
+	SYS_NET_IP_MULTICAST_IF    = 9,
+	SYS_NET_IP_MULTICAST_TTL   = 10,
+	SYS_NET_IP_MULTICAST_LOOP  = 11,
+	SYS_NET_IP_ADD_MEMBERSHIP  = 12,
+	SYS_NET_IP_DROP_MEMBERSHIP = 13,
+	SYS_NET_IP_TTLCHK          = 23,
+	SYS_NET_IP_MAXTTL          = 24,
+	SYS_NET_IP_DONTFRAG        = 26
 };
 
 // Family (prefixed with SYS_NET_)
@@ -132,7 +148,7 @@ enum
 };
 
 // TCP options (prefixed with SYS_NET_)
-enum
+enum lv2_tcp_option : s32
 {
 	SYS_NET_TCP_NODELAY          = 1,
 	SYS_NET_TCP_MAXSEG           = 2,
@@ -140,7 +156,7 @@ enum
 };
 
 // IP protocols (prefixed with SYS_NET_)
-enum
+enum lv2_ip_protocol : s32
 {
 	SYS_NET_IPPROTO_IP     = 0,
 	SYS_NET_IPPROTO_ICMP   = 1,
@@ -447,7 +463,7 @@ error_code sys_net_bnet_sendmsg(ppu_thread&, s32 s, vm::cptr<sys_net_msghdr> msg
 error_code sys_net_bnet_sendto(ppu_thread&, s32 s, vm::cptr<void> buf, u32 len, s32 flags, vm::cptr<sys_net_sockaddr> addr, u32 addrlen);
 error_code sys_net_bnet_setsockopt(ppu_thread&, s32 s, s32 level, s32 optname, vm::cptr<void> optval, u32 optlen);
 error_code sys_net_bnet_shutdown(ppu_thread&, s32 s, s32 how);
-error_code sys_net_bnet_socket(ppu_thread&, s32 family, s32 type, s32 protocol);
+error_code sys_net_bnet_socket(ppu_thread&, lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
 error_code sys_net_bnet_close(ppu_thread&, s32 s);
 error_code sys_net_bnet_poll(ppu_thread&, vm::ptr<sys_net_pollfd> fds, s32 nfds, s32 ms);
 error_code sys_net_bnet_select(ppu_thread&, s32 nfds, vm::ptr<sys_net_fd_set> readfds, vm::ptr<sys_net_fd_set> writefds, vm::ptr<sys_net_fd_set> exceptfds, vm::ptr<sys_net_timeval> timeout);


### PR DESCRIPTION
Improve net logging.

Should allow latest vsh to load (Depending on windows version apparently..)
Seems to work on 19043.1415, but not on 22000.348 - https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse ?

```
[0x0001b1e0] sys_net: sys_net_bnet_socket(family=INET, type=DGRAM, protocol=IPPROTO_IP)
[0x0001b3c4] sys_net: sys_net_bnet_setsockopt(s=54, level=SYS_NET_IPPROTO_IP, optname=IP_TTL, optval=*0xd00b1130, optlen=4)
[0x0001b3c4] sys_net: optval: 0x00000001
[0x0001b3c4] sys_net: sys_net_bnet_setsockopt(s=54, level=SYS_NET_SOL_SOCKET, optname=SO_RCVTIMEO, optval=*0xd00b1138, optlen=16)
[0x0001be74] sys_net: sys_net_bnet_bind(s=54, addr=*0x13e0c64, addrlen=16)
[0x0001be74] sys_net: Trying to bind 0.0.0.0:9309

[0x0001b1e0] sys_net: sys_net_bnet_socket(family=INET, type=STREAM, protocol=IPPROTO_IP)
[0x0001b3c4] sys_net: sys_net_bnet_setsockopt(s=55, level=SYS_NET_SOL_SOCKET, optname=SO_REUSEADDR, optval=*0xd00b1140, optlen=4)
[0x0001b3c4] sys_net: optval: 0x00000001
[0x0001be74] sys_net: sys_net_bnet_bind(s=55, addr=*0xd00b1144, addrlen=16)
[0x0001be74] sys_net: Trying to bind 0.0.0.0:9309
[0x0001be74] sys_net: Socket error EACCES
[0x0001be74] SYS: 'sys_net_bnet_bind' failed with 0xfffffff3 : -SYS_NET_EACCES [1]
```