### PR TITLE
Add macOS CI builds

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -1,27 +1,69 @@
 #!/bin/sh -ex
 
-export CCACHE_SLOPPINESS=pch_defines,time_macros
-export CMAKE_PREFIX_PATH=/usr/local/opt/qt5/
-export PATH="/usr/local/opt/ccache/libexec:$PATH"
+brew update
+brew install llvm@13 molten-vk vulkan-headers sdl2 nasm qt@5 ninja cmake glew git p7zip create-dmg ccache
 
-# Setup vulkan and gfx-rs/portability
-curl -sLO https://github.com/gfx-rs/portability/releases/download/latest/gfx-portability-macos-latest.zip
-unzip -: gfx-portability-macos-latest.zip
-curl -sLO https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.106.0.zip
-unzip -: sdk-*.zip
-mkdir vulkan-sdk
-ln -s "${PWD}"/Vulkan-Headers*/include vulkan-sdk/include
-mkdir vulkan-sdk/lib
-cp target/release/libportability.dylib vulkan-sdk/lib/libVulkan.dylib
-# Let macdeployqt locate and install Vulkan library
-install_name_tool -id "${PWD}"/vulkan-sdk/lib/libVulkan.dylib vulkan-sdk/lib/libVulkan.dylib
-export VULKAN_SDK="${PWD}/vulkan-sdk"
+export CXX=clang++
+export CC=clang
+export Qt5_DIR="/usr/local/Cellar/qt@5/5.15.2_1/lib/cmake/Qt5"
+export PATH="/usr/local/opt/llvm/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Library/Apple/usr/bin"
+export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+export CPPFLAGS="-I/usr/local/opt/llvm/include -msse -msse2 -mcx16 -no-pie"
+export CXXFLAGS="-I/usr/local/opt/llvm/include -msse -msse2 -mcx16 -no-pie"
+export VULKAN_SDK="/usr/local/Cellar/molten-vk/1.1.6"
+export VK_ICD_FILENAMES="$VULKAN_SDK/share/vulkan/icd.d/MoltenVK_icd.json"
 
-# Pull all the submodules except llvm
-# Note: Tried to use git submodule status, but it takes over 20 seconds
-# shellcheck disable=SC2046
-git submodule -q update --init $(awk '/path/ && !/llvm/ { print $3 }' .gitmodules)
+git submodule update --init --recursive --depth 1
 
+# 3rdparty fixes
+ln -s "$VULKAN_SDK/lib/libMoltenVK.dylib" "$VULKAN_SDK/lib/libvulkan.dylib"
+sed -i '' "s/if(APPLE)/if(CMAKE_C_COMPILER_ID MATCHES \"AppleClang\")/g" 3rdparty/wolfssl/wolfssl/CMakeLists.txt
+sed -i '' "s/extern const double NSAppKitVersionNumber;/const double NSAppKitVersionNumber = 1343;/g" 3rdparty/hidapi/hidapi/mac/hid.c
+
+cd ..
 mkdir build && cd build || exit 1
-cmake .. -DWITH_LLVM=OFF -DUSE_NATIVE_INSTRUCTIONS=OFF -G Ninja
+cmake -DUSE_DISCORD_RPC=OFF -DUSE_VULKAN=ON -DUSE_ALSA=OFF -DUSE_PULSE=OFF -DUSE_AUDIOUNIT=ON \
+-G Ninja -DLLVM_CCACHE_BUILD=OFF -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_BUILD_RUNTIME=OFF -DLLVM_BUILD_TOOLS=OFF \
+-DLLVM_INCLUDE_DOCS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_TOOLS=OFF \
+-DLLVM_INCLUDE_UTILS=OFF -DLLVM_USE_PERF=OFF -DLLVM_ENABLE_Z3_SOLVER=OFF \
+-DCMAKE_CXX_STANDARD=20 -DUSE_NATIVE_INSTRUCTIONS=OFF \
+../cirrus-ci-build/
 ninja
+
+cd ../cirrus-ci-build/
+COMM_TAG="$(grep 'version{.*}' rpcs3/rpcs3_version.cpp | awk -F[\{,] '{printf "%d.%d.%d", $2, $3, $4}')"
+COMM_COUNT="$(git rev-list --count HEAD)"
+COMM_HASH="$(git rev-parse --short=8 HEAD)"
+cd ../build/bin
+
+mkdir "rpcs3.app/Contents/lib/"
+cp "/usr/local/Cellar/llvm/13.0.0_2/lib/libc++abi.1.0.dylib" "rpcs3.app/Contents/lib/libc++abi.1.dylib"
+rm -rf "rpcs3.app/Contents/Frameworks/QtPdf.framework" \
+"rpcs3.app/Contents/Frameworks/QtQml.framework" \
+"rpcs3.app/Contents/Frameworks/QtQmlModels.framework" \
+"rpcs3.app/Contents/Frameworks/QtQuick.framework" \
+"rpcs3.app/Contents/Frameworks/QtVirtualKeyboard.framework" \
+"rpcs3.app/Contents/Plugins/platforminputcontexts" \
+"rpcs3.app/Contents/Plugins/virtualkeyboard"
+
+mv rpcs3.app RPCS3_.app
+mv RPCS3_.app RPCS3.app
+
+echo "[InternetShortcut]" > Quickstart.url
+echo "URL=https://rpcs3.net/quickstart" >> Quickstart.url
+echo "IconIndex=0" >> Quickstart.url
+
+create-dmg --volname RPCS3 \
+--window-size 800 400 \
+--icon-size 100 \
+--icon rpcs3.app 200 190 \
+--add-file Quickstart.url Quickstart.url 400 20 \
+--hide-extension rpcs3.app \
+--hide-extension Quickstart.url \
+--app-drop-link 600 185 \
+--skip-jenkins \
+"$ARTDIR/rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}_macos.dmg" \
+RPCS3.app
+
+7z a -mx9 rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z RPCS3.app
+mv rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z "$ARTDIR"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,3 +111,23 @@ freebsd_task:
     folder: /tmp/ccache_dir
   install_script: "sh -ex ./.ci/install-freebsd.sh"
   script: "./.ci/build-freebsd.sh"
+
+macos_task:
+  timeout_in: 120m
+  ccache_cache:
+    folder: /tmp/ccache_dir
+  matrix:
+    - name: Cirrus macOS
+      osx_instance:
+        image: big-sur-base
+      mac_script:
+        - mkdir artifacts
+        - ".ci/build-mac.sh"
+  env:
+    ARTDIR: ${CIRRUS_WORKING_DIR}/artifacts/
+    CCACHE_DIR: "/tmp/ccache_dir"
+    CCACHE_MAXSIZE: 300M
+    CI_HAS_ARTIFACTS: true
+  artifacts:
+    name: Artifact
+    path: "artifacts/rpcs3-*_macos.*"

--- a/3rdparty/hidapi/CMakeLists.txt
+++ b/3rdparty/hidapi/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(3rdparty_hidapi INTERFACE)
 add_subdirectory(hidapi EXCLUDE_FROM_ALL)
 
 if(APPLE)
-	target_link_libraries(3rdparty_hidapi INTERFACE hidapi-mac "-framework CoreFoundation" "-framework IOKit")
+	target_link_libraries(3rdparty_hidapi INTERFACE hidapi_darwin "-framework CoreFoundation" "-framework IOKit")
 elseif(CMAKE_SYSTEM MATCHES "Linux")
 	target_link_libraries(3rdparty_hidapi INTERFACE hidapi-hidraw udev)
 elseif(WIN32)


### PR DESCRIPTION
Fixes hidapi/CMakeLists.txt (thanks to xddxd, who also helped me with ccache) and adds a Cirrus task for macOS builds.
The task generates both a .7z and a .dmg (which also includes a link to the Applications folder and a link to the Quickstart page).
Since RPCS3.app is not signed, the user must right-click on it and select "Open" when attempting to run it for the first time.