### PR TITLE
USB: Improve SingStar emulation

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
@@ -81,8 +81,8 @@ avconf_manager::avconf_manager()
 			devices[curindex].portType                  = CELL_AUDIO_IN_PORT_USB;
 			devices[curindex].availableModeCount        = 1;
 			devices[curindex].state                     = CELL_AUDIO_IN_DEVICE_STATE_AVAILABLE;
-			devices[curindex].deviceId                  = 0x57A3C0DE;
-			devices[curindex].type                      = 0xC0DE57A3;
+			devices[curindex].deviceId                  = 0x00000001;
+			devices[curindex].type                      = 0x14150000;
 			devices[curindex].availableModes[0].type    = CELL_AUDIO_IN_CODING_TYPE_LPCM;
 			devices[curindex].availableModes[0].channel = CELL_AUDIO_IN_CHNUM_2;
 			devices[curindex].availableModes[0].fs      = CELL_AUDIO_IN_FS_8KHZ | CELL_AUDIO_IN_FS_12KHZ | CELL_AUDIO_IN_FS_16KHZ | CELL_AUDIO_IN_FS_24KHZ | CELL_AUDIO_IN_FS_32KHZ | CELL_AUDIO_IN_FS_48KHZ;


### PR DESCRIPTION
Improve SingStar emulation for the games which use cellAudioInGetAvailableDeviceInfo. Partial fix for #7739.
- SingStar MegaHits (playable, but everything is green/blue)
- SingStar Ultimate Party (playable, but everything is green/blue)
- SingStar Frozen (playable, but everything is green/blue)
- SingStar ABBA (detects the microphone, but then freezes)
- SingStar Vol 2 (detects the microphone, but then freezes)
- SingStar Vol 3 (detects the microphone, but then freezes)

Other games are not fixed: 
- SingStar Back to the 80s

![singstar](https://user-images.githubusercontent.com/2995486/148080222-df2d411c-399d-49e6-b656-8a5253dbf924.png)
