### PR TITLE
Wipe clean VSH's temporary directory of choice, remove game install cache at boot

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1788,7 +1788,7 @@ const std::string& fs::get_temp_dir()
 	return s_dir;
 }
 
-bool fs::remove_all(const std::string& path, bool remove_root)
+bool fs::remove_all(const std::string& path, bool remove_root, bool is_no_dir_ok)
 {
 	if (const auto root_dir = dir(path))
 	{
@@ -1817,7 +1817,7 @@ bool fs::remove_all(const std::string& path, bool remove_root)
 	}
 	else
 	{
-		return false;
+		return is_no_dir_ok;
 	}
 
 	if (remove_root)

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -648,7 +648,7 @@ namespace fs
 	};
 
 	// Delete directory and all its contents recursively
-	bool remove_all(const std::string& path, bool remove_root = true);
+	bool remove_all(const std::string& path, bool remove_root = true, bool is_no_dir_ok = false);
 
 	// Get size of all files recursively
 	u64 get_dir_size(const std::string& path, u64 rounding_alignment = 1);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -204,6 +204,8 @@ void Emulator::Init(bool add_only)
 		sys_log.notice("Hdd1: %s", vfs::get("/dev_hdd1"));
 	}
 
+	const bool is_exitspawn = m_config_mode == cfg_mode::continuous;
+
 	// Load config file
 	if (m_config_mode == cfg_mode::config_override)
 	{
@@ -378,7 +380,7 @@ void Emulator::Init(bool add_only)
 	}
 
 	// Limit cache size
-	if (g_cfg.vfs.limit_cache_size)
+	if (!is_exitspawn && g_cfg.vfs.limit_cache_size)
 		rpcs3::cache::limit_cache_size();
 }
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -381,7 +381,15 @@ void Emulator::Init(bool add_only)
 
 	// Limit cache size
 	if (!is_exitspawn && g_cfg.vfs.limit_cache_size)
+	{
 		rpcs3::cache::limit_cache_size();
+	}
+
+	// Wipe clean VSH's temporary directory of choice
+	if (g_cfg.vfs.empty_hdd0_tmp && !is_exitspawn && !fs::remove_all(dev_hdd0 + "tmp/", false, true))
+	{
+		sys_log.error("Could not clean /dev_hdd0/tmp/ (%s)", fs::g_tls_error);
+	}
 }
 
 void Emulator::SetUsr(const std::string& user)

--- a/rpcs3/Emu/cache_utils.cpp
+++ b/rpcs3/Emu/cache_utils.cpp
@@ -96,7 +96,7 @@ namespace rpcs3::cache
 				break;
 			}
 
-			if (is_dir ? !fs::remove_all(name, true) : !fs::remove_file(name))
+			if (is_dir ? !fs::remove_all(name, true, true) : !fs::remove_file(name))
 			{
 				sys_log.error("Could not remove cache directory '%s' item '%s' (%s)", cache_location, item.name, fs::g_tls_error);
 				break;

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -94,6 +94,7 @@ struct cfg_root : cfg::node
 
 		cfg::_bool limit_cache_size{ this, "Limit disk cache size", false };
 		cfg::_int<0, 10240> cache_max_size{ this, "Disk cache maximum size (MB)", 5120 };
+		cfg::_bool empty_hdd0_tmp{ this, "Empty /dev_hdd0/tmp/", true };
 
 	} vfs{ this };
 

--- a/rpcs3/Loader/TRP.cpp
+++ b/rpcs3/Loader/TRP.cpp
@@ -56,7 +56,7 @@ bool TRPLoader::Install(std::string_view dest, bool /*show*/)
 
 	if (success)
 	{
-		success = fs::remove_all(local_path) || !fs::is_dir(local_path);
+		success = fs::remove_all(local_path, true, true);
 
 		if (success)
 		{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2602,7 +2602,7 @@ void main_window::RemoveDiskCache()
 {
 	const std::string cache_dir = rpcs3::utils::get_hdd1_dir() + "/caches";
 
-	if (fs::is_dir(cache_dir) && fs::remove_all(cache_dir, false))
+	if (fs::remove_all(cache_dir, false))
 	{
 		QMessageBox::information(this, tr("Cache Cleared"), tr("Disk cache was cleared successfully"));
 	}


### PR DESCRIPTION
Furthermore:
* Discontinue the harmful cleaning of HDD1 cache during game process respawn. Cache should remain intact during so.
* Attempt to remove all HDD0's temporary game data created by cellGame, at boot - It may persist if RPCS3 has been closed unexpectedly.

Fixes https://github.com/RPCS3/rpcs3/issues/11330