### PR TITLE
rsx: Fix pitch bit-width in texture+surface cache

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -754,7 +754,7 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 
 	cbGet->getParam.attribute = CELL_GAMEDATA_ATTR_NORMAL;
 	cbGet->getParam.parentalLevel = psf::get_integer(sfo, "PARENTAL_LEVEL", 0);
-	strcpy_trunc(cbGet->getParam.dataVersion, psf::get_string(sfo, "APP_VER", ""));
+	strcpy_trunc(cbGet->getParam.dataVersion, psf::get_string(sfo, "APP_VER", psf::get_string(sfo, "VERSION", ""))); // Old games do not have APP_VER key
 	strcpy_trunc(cbGet->getParam.titleId, psf::get_string(sfo, "TITLE_ID", ""));
 	strcpy_trunc(cbGet->getParam.title, psf::get_string(sfo, "TITLE", ""));
 	for (u32 i = 0; i < CELL_HDDGAME_SYSP_LANGUAGE_NUM; i++)

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -139,8 +139,8 @@ namespace rsx
 		std::vector<deferred_clipped_region<image_storage_type>> old_contents;
 
 		// Surface properties
-		u16 rsx_pitch = 0;
-		u16 native_pitch = 0;
+		u32 rsx_pitch = 0;
+		u32 native_pitch = 0;
 		u16 surface_width = 0;
 		u16 surface_height = 0;
 		u8  spp = 1;
@@ -178,7 +178,7 @@ namespace rsx
 		virtual bool is_depth_surface() const = 0;
 		virtual void release_ref(image_storage_type) const = 0;
 
-		virtual u16 get_surface_width(rsx::surface_metrics metrics = rsx::surface_metrics::pixels) const
+		virtual u32 get_surface_width(rsx::surface_metrics metrics = rsx::surface_metrics::pixels) const
 		{
 			switch (metrics)
 			{
@@ -193,7 +193,7 @@ namespace rsx
 			}
 		}
 
-		virtual u16 get_surface_height(rsx::surface_metrics metrics = rsx::surface_metrics::pixels) const
+		virtual u32 get_surface_height(rsx::surface_metrics metrics = rsx::surface_metrics::pixels) const
 		{
 			switch (metrics)
 			{
@@ -207,12 +207,12 @@ namespace rsx
 			}
 		}
 
-		virtual u16 get_rsx_pitch() const
+		virtual u32 get_rsx_pitch() const
 		{
 			return rsx_pitch;
 		}
 
-		virtual u16 get_native_pitch() const
+		virtual u32 get_native_pitch() const
 		{
 			return native_pitch;
 		}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -354,9 +354,9 @@ namespace rsx
 		virtual image_view_type create_temporary_subresource_view(commandbuffer_type&, image_resource_type* src, u32 gcm_format, u16 x, u16 y, u16 w, u16 h, const texture_channel_remap_t& remap_vector) = 0;
 		virtual image_view_type create_temporary_subresource_view(commandbuffer_type&, image_storage_type* src, u32 gcm_format, u16 x, u16 y, u16 w, u16 h, const texture_channel_remap_t& remap_vector) = 0;
 		virtual void release_temporary_subresource(image_view_type rsc) = 0;
-		virtual section_storage_type* create_new_texture(commandbuffer_type&, const address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format,
+		virtual section_storage_type* create_new_texture(commandbuffer_type&, const address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch, u32 gcm_format,
 			rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, component_order swizzle_flags, rsx::flags32_t flags) = 0;
-		virtual section_storage_type* upload_image_from_cpu(commandbuffer_type&, const address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format, texture_upload_context context,
+		virtual section_storage_type* upload_image_from_cpu(commandbuffer_type&, const address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch, u32 gcm_format, texture_upload_context context,
 			const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool swizzled) = 0;
 		virtual section_storage_type* create_nul_section(commandbuffer_type&, const address_range &rsx_range, bool memory_load) = 0;
 		virtual void set_component_order(section_storage_type& section, u32 gcm_format, component_order expected) = 0;
@@ -1019,7 +1019,7 @@ namespace rsx
 		}
 
 		template <bool check_unlocked = false>
-		std::vector<section_storage_type*> find_texture_from_range(const address_range &test_range, u16 required_pitch = 0, u32 context_mask = 0xFF)
+		std::vector<section_storage_type*> find_texture_from_range(const address_range &test_range, u32 required_pitch = 0, u32 context_mask = 0xFF)
 		{
 			std::vector<section_storage_type*> results;
 
@@ -1177,7 +1177,7 @@ namespace rsx
 		}
 
 		template <typename ...FlushArgs, typename ...Args>
-		void lock_memory_region(commandbuffer_type& cmd, image_storage_type* image, const address_range &rsx_range, bool is_active_surface, u16 width, u16 height, u16 pitch, Args&&... extras)
+		void lock_memory_region(commandbuffer_type& cmd, image_storage_type* image, const address_range &rsx_range, bool is_active_surface, u16 width, u16 height, u32 pitch, Args&&... extras)
 		{
 			AUDIT(g_cfg.video.write_color_buffers || g_cfg.video.write_depth_buffer); // this method is only called when either WCB or WDB are enabled
 
@@ -2534,7 +2534,7 @@ namespace rsx
 			areai src_area = { 0, 0, src_w, src_h };
 			areai dst_area = { 0, 0, dst_w, dst_h };
 
-			size2i dst_dimensions = { dst.pitch / dst_bpp, dst.height };
+			size2i dst_dimensions = { static_cast<s32>(dst.pitch / dst_bpp), dst.height };
 			position2i dst_offset = { dst.offset_x, dst.offset_y };
 			u32 dst_base_address = dst.rsx_address;
 
@@ -2657,9 +2657,9 @@ namespace rsx
 					if (const auto this_address = surface->get_section_base();
 						const u32 address_offset = dst_address - this_address)
 					{
-						const u16 offset_y = address_offset / dst.pitch;
-						const u16 offset_x = address_offset % dst.pitch;
-						const u16 offset_x_in_block = offset_x / dst_bpp;
+						const u32 offset_y = address_offset / dst.pitch;
+						const u32 offset_x = address_offset % dst.pitch;
+						const u32 offset_x_in_block = offset_x / dst_bpp;
 
 						dst_area.x1 += offset_x_in_block;
 						dst_area.x2 += offset_x_in_block;
@@ -2787,9 +2787,9 @@ namespace rsx
 
 					if (const u32 address_offset = src_address - this_address)
 					{
-						const u16 offset_y = address_offset / src.pitch;
-						const u16 offset_x = address_offset % src.pitch;
-						const u16 offset_x_in_block = offset_x / src_bpp;
+						const u32 offset_y = address_offset / src.pitch;
+						const u32 offset_x = address_offset % src.pitch;
+						const u32 offset_x_in_block = offset_x / src_bpp;
 
 						src_area.x1 += offset_x_in_block;
 						src_area.x2 += offset_x_in_block;
@@ -2968,7 +2968,7 @@ namespace rsx
 						const auto prot_range = dst_range.to_page_range();
 						utils::memory_protect(vm::base(prot_range.start), prot_range.length(), utils::protection::no);
 
-						const u16 pitch_in_block = dst.pitch / dst_bpp;
+						const auto pitch_in_block = dst.pitch / dst_bpp;
 						std::vector<rsx::subresource_layout> subresource_layout;
 						rsx::subresource_layout subres = {};
 						subres.width_in_block = subres.width_in_texel = dst_dimensions.width;

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -50,11 +50,11 @@ namespace rsx
 	{
 		u32 address;
 		u32 gcm_format;
+		u32 pitch;
 		u16 width;
 		u16 height;
 		u16 depth;
 		u16 mipmaps;
-		u16 pitch;
 		u16 slice_h;
 		u8  bpp;
 		bool swizzled;
@@ -487,9 +487,9 @@ namespace rsx
 			case rsx::texture_dimension_extended::texture_dimension_2d:
 				return (surface_width >= attr.width && surface_height >= attr.height);
 			case rsx::texture_dimension_extended::texture_dimension_3d:
-				return (surface_width >= attr.width && surface_height >= (attr.slice_h * attr.depth));
+				return (surface_width >= attr.width && surface_height >= u32{attr.slice_h} * attr.depth);
 			case rsx::texture_dimension_extended::texture_dimension_cubemap:
-				return (surface_width == attr.height && surface_width >= attr.width && surface_height >= (attr.slice_h * 6));
+				return (surface_width == attr.height && surface_width >= attr.width && surface_height >= (u32{attr.slice_h} * 6));
 			}
 
 			return false;

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1079,8 +1079,8 @@ namespace rsx
 		u16 depth;
 		u16 mipmaps;
 
-		u16 real_pitch;
-		u16 rsx_pitch;
+		u32 real_pitch;
+		u32 rsx_pitch;
 
 		u32 gcm_format = 0;
 		bool pack_unpack_swap_bytes = false;
@@ -1704,7 +1704,7 @@ namespace rsx
 			return mipmaps;
 		}
 
-		u16 get_rsx_pitch() const
+		u32 get_rsx_pitch() const
 		{
 			return rsx_pitch;
 		}

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -65,8 +65,8 @@ gl::texture* GLGSRender::get_present_source(gl::present_surface_info* info, cons
 				image = section.surface->get_surface(rsx::surface_access::shader_read);
 
 				std::tie(info->width, info->height) = rsx::apply_resolution_scale<true>(
-					std::min(surface_width, static_cast<u16>(info->width)),
-					std::min(surface_height, static_cast<u16>(info->height)));
+					std::min(surface_width, info->width),
+					std::min(surface_height, info->height));
 			}
 		}
 	}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -57,19 +57,19 @@ namespace gl
 		{}
 
 		// Internal pitch is the actual row length in bytes of the openGL texture
-		void set_native_pitch(u16 pitch)
+		void set_native_pitch(u32 pitch)
 		{
 			native_pitch = pitch;
 		}
 
-		void set_surface_dimensions(u16 w, u16 h, u16 pitch)
+		void set_surface_dimensions(u16 w, u16 h, u32 pitch)
 		{
 			surface_width = w;
 			surface_height = h;
 			rsx_pitch = pitch;
 		}
 
-		void set_rsx_pitch(u16 pitch)
+		void set_rsx_pitch(u32 pitch)
 		{
 			rsx_pitch = pitch;
 		}
@@ -141,8 +141,8 @@ struct gl_render_target_traits
 			static_cast<GLenum>(format.internal_format), RSX_FORMAT_CLASS_COLOR));
 
 		result->set_aa_mode(antialias);
-		result->set_native_pitch(static_cast<u16>(width) * get_format_block_size_in_bytes(surface_color_format) * result->samples_x);
-		result->set_surface_dimensions(static_cast<u16>(width), static_cast<u16>(height), static_cast<u16>(pitch));
+		result->set_native_pitch(static_cast<u32>(width) * get_format_block_size_in_bytes(surface_color_format) * result->samples_x);
+		result->set_surface_dimensions(static_cast<u16>(width), static_cast<u16>(height), static_cast<u32>(pitch));
 		result->set_format(surface_color_format);
 
 		std::array<GLenum, 4> native_layout = { static_cast<GLenum>(format.swizzle.a), static_cast<GLenum>(format.swizzle.r), static_cast<GLenum>(format.swizzle.g), static_cast<GLenum>(format.swizzle.b) };
@@ -170,9 +170,9 @@ struct gl_render_target_traits
 			static_cast<GLenum>(format.internal_format), rsx::classify_format(surface_depth_format)));
 
 		result->set_aa_mode(antialias);
-		result->set_surface_dimensions(static_cast<u16>(width), static_cast<u16>(height), static_cast<u16>(pitch));
+		result->set_surface_dimensions(static_cast<u16>(width), static_cast<u16>(height), static_cast<u32>(pitch));
 		result->set_format(surface_depth_format);
-		result->set_native_pitch(static_cast<u16>(width) * get_format_block_size_in_bytes(surface_depth_format) * result->samples_x);
+		result->set_native_pitch(static_cast<u32>(width) * get_format_block_size_in_bytes(surface_depth_format) * result->samples_x);
 
 		std::array<GLenum, 4> native_layout = { GL_RED, GL_RED, GL_RED, GL_RED };
 		result->set_native_component_layout(native_layout);
@@ -204,7 +204,7 @@ struct gl_render_target_traits
 			sink->format_info = ref->format_info;
 
 			sink->set_spp(ref->get_spp());
-			sink->set_native_pitch(prev.width * ref->get_bpp() * ref->samples_x);
+			sink->set_native_pitch(static_cast<u32>(prev.width) * ref->get_bpp() * ref->samples_x);
 			sink->set_rsx_pitch(ref->get_rsx_pitch());
 			sink->set_surface_dimensions(prev.width, prev.height, ref->get_rsx_pitch());
 			sink->set_native_component_layout(ref->get_native_component_layout());
@@ -260,7 +260,7 @@ struct gl_render_target_traits
 	static
 	void invalidate_surface_contents(gl::command_context&, gl::render_target *surface, u32 address, usz pitch)
 	{
-		surface->set_rsx_pitch(static_cast<u16>(pitch));
+		surface->set_rsx_pitch(static_cast<u32>(pitch));
 		surface->queue_tag(address);
 		surface->last_use_tag = 0;
 		surface->stencil_init_flags = 0;

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -626,7 +626,7 @@ namespace gl
 			copy_transfer_regions_impl(cmd, dst->image(), region);
 		}
 
-		cached_texture_section* create_new_texture(gl::command_context &cmd, const utils::address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch,
+		cached_texture_section* create_new_texture(gl::command_context &cmd, const utils::address_range &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch,
 			u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t /*flags*/) override
 		{
 			const rsx::image_section_attributes_t search_desc = { .gcm_format = gcm_format, .width = width, .height = height, .depth = depth, .mipmaps = mipmaps };
@@ -747,7 +747,7 @@ namespace gl
 			return &cached;
 		}
 
-		cached_texture_section* upload_image_from_cpu(gl::command_context &cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format,
+		cached_texture_section* upload_image_from_cpu(gl::command_context &cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch, u32 gcm_format,
 			rsx::texture_upload_context context, const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool input_swizzled) override
 		{
 			auto section = create_new_texture(cmd, rsx_range, width, height, depth, mipmaps, pitch, gcm_format, context, type, input_swizzled,

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -324,8 +324,8 @@ vk::viewable_image* VKGSRender::get_present_source(vk::present_surface_info* inf
 				image_to_flip = section.surface->get_surface(rsx::surface_access::shader_read);
 
 				std::tie(info->width, info->height) = rsx::apply_resolution_scale<true>(
-					std::min(surface_width, static_cast<u16>(info->width)),
-					std::min(surface_height, static_cast<u16>(info->height)));
+					std::min(surface_width, info->width),
+					std::min(surface_height, info->height));
 			}
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -181,8 +181,8 @@ namespace vk
 			rtt->memory_usage_flags = rsx::surface_usage_flags::attachment;
 			rtt->state_flags = rsx::surface_state_flags::erase_bkgnd;
 			rtt->native_component_map = fmt.second;
-			rtt->rsx_pitch = static_cast<u16>(pitch);
-			rtt->native_pitch = static_cast<u16>(width) * get_format_block_size_in_bytes(format) * rtt->samples_x;
+			rtt->rsx_pitch = static_cast<u32>(pitch);
+			rtt->native_pitch = static_cast<u32>(width) * get_format_block_size_in_bytes(format) * rtt->samples_x;
 			rtt->surface_width = static_cast<u16>(width);
 			rtt->surface_height = static_cast<u16>(height);
 			rtt->queue_tag(address);
@@ -246,8 +246,8 @@ namespace vk
 			ds->memory_usage_flags = rsx::surface_usage_flags::attachment;
 			ds->state_flags = rsx::surface_state_flags::erase_bkgnd;
 			ds->native_component_map = { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R };
-			ds->native_pitch = static_cast<u16>(width) * get_format_block_size_in_bytes(format) * ds->samples_x;
-			ds->rsx_pitch = static_cast<u16>(pitch);
+			ds->native_pitch = static_cast<u32>(width) * get_format_block_size_in_bytes(format) * ds->samples_x;
+			ds->rsx_pitch = static_cast<u32>(pitch);
 			ds->surface_width = static_cast<u16>(width);
 			ds->surface_height = static_cast<u16>(height);
 			ds->queue_tag(address);
@@ -288,7 +288,7 @@ namespace vk
 				sink->native_component_map = ref->native_component_map;
 				sink->sample_layout = ref->sample_layout;
 				sink->stencil_init_flags = ref->stencil_init_flags;
-				sink->native_pitch = u16(prev.width * ref->get_bpp() * ref->samples_x);
+				sink->native_pitch = static_cast<u32>(prev.width) * ref->get_bpp() * ref->samples_x;
 				sink->rsx_pitch = ref->get_rsx_pitch();
 				sink->surface_width = prev.width;
 				sink->surface_height = prev.height;
@@ -361,7 +361,7 @@ namespace vk
 
 		static void invalidate_surface_contents(vk::command_buffer& /*cmd*/, vk::render_target* surface, u32 address, usz pitch)
 		{
-			surface->rsx_pitch = static_cast<u16>(pitch);
+			surface->rsx_pitch = static_cast<u32>(pitch);
 			surface->queue_tag(address);
 			surface->last_use_tag = 0;
 			surface->stencil_init_flags = 0;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -743,7 +743,7 @@ namespace vk
 		dst->pop_layout(cmd);
 	}
 
-	cached_texture_section* texture_cache::create_new_texture(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch,
+	cached_texture_section* texture_cache::create_new_texture(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch,
 		u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t flags)
 	{
 		const auto section_depth = depth;
@@ -893,7 +893,7 @@ namespace vk
 		return &region;
 	}
 
-	cached_texture_section* texture_cache::upload_image_from_cpu(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format,
+	cached_texture_section* texture_cache::upload_image_from_cpu(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch, u32 gcm_format,
 		rsx::texture_upload_context context, const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool swizzled)
 	{
 		if (context != rsx::texture_upload_context::shader_read)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -317,7 +317,7 @@ namespace vk
 			pack_unpack_swap_bytes = swap_bytes;
 		}
 
-		void set_rsx_pitch(u16 pitch)
+		void set_rsx_pitch(u32 pitch)
 		{
 			ensure(!is_locked());
 			rsx_pitch = pitch;
@@ -459,12 +459,12 @@ namespace vk
 
 		void update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, vk::image* src, u16 width, u16 height) override;
 
-		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch,
+		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch,
 			u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t flags) override;
 
 		cached_texture_section* create_nul_section(vk::command_buffer& cmd, const utils::address_range& rsx_range, bool memory_load) override;
 
-		cached_texture_section* upload_image_from_cpu(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u16 pitch, u32 gcm_format,
+		cached_texture_section* upload_image_from_cpu(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch, u32 gcm_format,
 			rsx::texture_upload_context context, const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool swizzled) override;
 
 		void set_component_order(cached_texture_section& section, u32 gcm_format, rsx::component_order expected_flags) override;

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -180,7 +180,7 @@ namespace rsx
 		u16 offset_y;
 		u16 width;
 		u16 height;
-		u16 pitch;
+		u32 pitch;
 		u32 rsx_address;
 		void *pixels;
 	};
@@ -192,14 +192,14 @@ namespace rsx
 		u16 offset_y;
 		u16 width;
 		u16 height;
-		u16 pitch;
 		u16 clip_x;
 		u16 clip_y;
 		u16 clip_width;
 		u16 clip_height;
 		f32 scale_x;
 		f32 scale_y;
-		u32  rsx_address;
+		u32 pitch;
+		u32 rsx_address;
 		void *pixels;
 		bool swizzled;
 	};
@@ -442,7 +442,7 @@ namespace rsx
 	 * TODO: Variable src/dst and optional se conversion
 	 */
 	template <typename T>
-	void shuffle_texel_data_wzyx(void* data, u16 row_pitch_in_bytes, u16 row_length_in_texels, u16 num_rows)
+	void shuffle_texel_data_wzyx(void* data, u32 row_pitch_in_bytes, u16 row_length_in_texels, u16 num_rows)
 	{
 		char* raw_src = static_cast<char*>(data);
 		T tmp[4];
@@ -649,7 +649,7 @@ namespace rsx
 	}
 
 	template <bool __is_surface = true, typename SurfaceType>
-	inline bool pitch_compatible(const SurfaceType* surface, u16 pitch_required, u16 height_required)
+	inline bool pitch_compatible(const SurfaceType* surface, u32 pitch_required, u16 height_required)
 	{
 		if constexpr (__is_surface)
 		{


### PR DESCRIPTION
- Max RSX pitch is 17 bits (65536) so use 32-bit integers for that. It is possible for wide 1D textures to hit this limit. 4096-length RGBA32F data can be used as a compute SSBO and will consume pitch greater than UINT16_MAX.
- Also adds a fallback for cellGameDataCheckCreate2, old SFOs do not contain a APP_VER key, only a VERSION key. This allows old titles to boot without any patches applied if they rely on matching application version with data version (e.g verify HDD installed data)

Fixes https://github.com/RPCS3/rpcs3/issues/9100