### PR TITLE
Update wolfssl

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -17,7 +17,6 @@ git submodule update --init --recursive --depth 1
 
 # 3rdparty fixes
 ln -s "$VULKAN_SDK/lib/libMoltenVK.dylib" "$VULKAN_SDK/lib/libvulkan.dylib"
-sed -i '' "s/if(APPLE)/if(CMAKE_C_COMPILER_ID MATCHES \"AppleClang\")/g" 3rdparty/wolfssl/wolfssl/CMakeLists.txt
 sed -i '' "s/extern const double NSAppKitVersionNumber;/const double NSAppKitVersionNumber = 1343;/g" 3rdparty/hidapi/hidapi/mac/hid.c
 
 cd ..

--- a/3rdparty/wolfssl/wolfssl.vcxproj
+++ b/3rdparty/wolfssl/wolfssl.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -105,6 +105,7 @@
     <ClCompile Include="wolfssl\wolfcrypt\src\hmac.c" />
     <ClCompile Include="wolfssl\wolfcrypt\src\idea.c" />
     <ClCompile Include="wolfssl\wolfcrypt\src\integer.c" />
+    <ClCompile Include="wolfssl\wolfcrypt\src\kdf.c" />
     <ClCompile Include="wolfssl\wolfcrypt\src\logging.c" />
     <ClCompile Include="wolfssl\wolfcrypt\src\md2.c" />
     <ClCompile Include="wolfssl\wolfcrypt\src\md4.c" />


### PR DESCRIPTION
Fully fixes a bug that prevents RPCS3 from being built with Homebrew Clang on macOS.