### PR TITLE
Fix macOS maxfiles/Shader Cache/SPU LLVM, and log maxfiles on *NIX

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1908,7 +1908,7 @@ void thread_base::start()
 #elif defined(__APPLE__)
 	pthread_attr_t stack_size_attr;
 	pthread_attr_init(&stack_size_attr);
-	pthread_attr_setstacksize(&stack_size_attr, 0x200000);
+	pthread_attr_setstacksize(&stack_size_attr, 0x800000);
 	ensure(pthread_create(reinterpret_cast<pthread_t*>(&m_thread.raw()), &stack_size_attr, entry_point, this) == 0);
 #else
 	ensure(pthread_create(reinterpret_cast<pthread_t*>(&m_thread.raw()), nullptr, entry_point, this) == 0);

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1905,6 +1905,11 @@ void thread_base::start()
 	m_thread = ::_beginthreadex(nullptr, 0, entry_point, this, CREATE_SUSPENDED, nullptr);
 	ensure(m_thread);
 	ensure(::ResumeThread(reinterpret_cast<HANDLE>(+m_thread)) != -1);
+#elif defined(__APPLE__)
+	pthread_attr_t stack_size_attr;
+	pthread_attr_init(&stack_size_attr);
+	pthread_attr_setstacksize(&stack_size_attr, 0x200000);
+	ensure(pthread_create(reinterpret_cast<pthread_t*>(&m_thread.raw()), &stack_size_attr, entry_point, this) == 0);
 #else
 	ensure(pthread_create(reinterpret_cast<pthread_t*>(&m_thread.raw()), nullptr, entry_point, this) == 0);
 #endif

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -508,6 +508,19 @@ int main(int argc, char** argv)
 	setenv( "KDE_DEBUG", "1", 0 );
 #endif
 
+#ifdef __APPLE__
+	struct ::rlimit rlim;
+	::getrlimit(RLIMIT_NOFILE, &rlim);
+	rlim.rlim_cur = OPEN_MAX;
+	if (::setrlimit(RLIMIT_NOFILE, &rlim) != 0)
+		std::cerr << "Failed to set max open file limit (" << OPEN_MAX << ").\n";
+#endif
+
+#ifndef _WIN32
+	// Write file limits
+	sys_log.notice("Maximum open file descriptors: %i", utils::get_maxfiles());
+#endif
+
 	std::lock_guard qt_init(s_qt_init);
 
 	// The constructor of QApplication eats the --style and --stylesheet arguments.

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -35,6 +35,7 @@
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QSound>
+#include <QMessageBox>
 
 #include <clocale>
 
@@ -103,6 +104,17 @@ bool gui_application::Init()
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings);
 		welcome->exec();
+	}
+
+	// Check maxfiles
+	if (utils::get_maxfiles() < 4096)
+	{
+		QMessageBox::warning(nullptr,
+							 tr("Warning"),
+							 tr("The current limit of maximum file descriptors is too low.\n"
+								"Some games will crash.\n"
+								"\n"
+								"Please increase the limit before running RPCS3."));
 	}
 
 	if (m_main_window && !m_main_window->Init(m_with_cli_boot))

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -11,6 +11,7 @@
 #include "stringapiset.h"
 #else
 #include <unistd.h>
+#include <sys/resource.h>
 #include <sys/utsname.h>
 #include <errno.h>
 #endif
@@ -356,6 +357,19 @@ std::string utils::get_OS_version()
 	}
 #endif
 	return output;
+}
+
+int utils::get_maxfiles()
+{
+#ifdef _WIN32
+	// Virtually unlimited on Windows
+	return INT_MAX;
+#else
+	struct rlimit limits;
+	ensure(getrlimit(RLIMIT_NOFILE, &limits) == 0);
+
+	return limits.rlim_cur;
+#endif
 }
 
 static constexpr ullong round_tsc(ullong val)

--- a/rpcs3/util/sysinfo.hpp
+++ b/rpcs3/util/sysinfo.hpp
@@ -51,6 +51,8 @@ namespace utils
 
 	std::string get_OS_version();
 
+	int get_maxfiles();
+
 	ullong get_tsc_freq();
 
 	u64 get_total_memory();


### PR DESCRIPTION
On macOS, this sets maxfiles to 4096, as well as thread stack size to 2M (fixes shader cache and SPU LLVM).

maxfiles are logged to both file and stderr on macOS/Linux/BSD.