### PR TITLE
Disable OpenGL on macOS

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -96,7 +96,11 @@ struct cfg_root : cfg::node
 	{
 		node_video(cfg::node* _this) : cfg::node(_this, "Video") {}
 
+#ifdef __APPLE__
+		cfg::_enum<video_renderer> renderer{ this, "Renderer", video_renderer::vulkan };
+#else
 		cfg::_enum<video_renderer> renderer{ this, "Renderer", video_renderer::opengl };
+#endif
 
 		cfg::_enum<video_resolution> resolution{ this, "Resolution", video_resolution::_720 };
 		cfg::_enum<video_aspect> aspect_ratio{ this, "Aspect ratio", video_aspect::_16_9 };

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -71,7 +71,9 @@ void headless_application::InitializeCallbacks()
 			g_fxo->init<rsx::thread, named_thread<NullGSRender>>();
 			break;
 		}
+#if not defined(__APPLE__)
 		case video_renderer::opengl:
+#endif
 #if defined(HAVE_VULKAN)
 		case video_renderer::vulkan:
 #endif

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -332,11 +332,13 @@ void gui_application::InitializeCallbacks()
 			g_fxo->init<rsx::thread, named_thread<NullGSRender>>();
 			break;
 		}
+#if not defined(__APPLE__)
 		case video_renderer::opengl:
 		{
 			g_fxo->init<rsx::thread, named_thread<GLGSRender>>();
 			break;
 		}
+#endif
 #if defined(HAVE_VULKAN)
 		case video_renderer::vulkan:
 		{

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -106,6 +106,14 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 
 #ifdef __APPLE__
 	OpenGL.supported = false;
+
+	if (!Vulkan.supported)
+	{
+		QMessageBox::warning(nullptr,
+							 tr("Warning"),
+							 tr("Vulkan is not supported on this Mac.\n"
+								"No graphics will be rendered."));
+	}
 #endif
 
 	renderers = { &Vulkan, &OpenGL, &NullRender };

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -104,6 +104,10 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 	OpenGL = render_info();
 	NullRender = render_info();
 
+#ifdef __APPLE__
+	OpenGL.supported = false;
+#endif
+
 	renderers = { &Vulkan, &OpenGL, &NullRender };
 }
 


### PR DESCRIPTION
macOS only supports OpenGL 2.1 / 4.1 core, which is not enough for RPCS3.
This PR effectively makes Vulkan (moltenVK) mandatory.
OpenGL is disabled on macOS like Vulkan is disabled on unusupported GPUs, and as such, it is not removed completely (as that would require major changes to the code).