### PR TITLE
rsx: add boost mode shortcut

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -32,6 +32,7 @@ class GSRender;
 #define CMD_DEBUG 0
 
 atomic_t<bool> g_user_asked_for_frame_capture = false;
+atomic_t<bool> g_disable_frame_limit = false;
 rsx::frame_trace_data frame_debug;
 rsx::frame_capture_data frame_capture;
 
@@ -3071,7 +3072,7 @@ namespace rsx
 		}
 
 		double limit = 0.;
-		switch (g_cfg.video.frame_limit)
+		switch (g_disable_frame_limit ? frame_limit_type::none : g_cfg.video.frame_limit)
 		{
 		case frame_limit_type::none: limit = 0.; break;
 		case frame_limit_type::_59_94: limit = 59.94; break;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -28,6 +28,7 @@
 #include "Emu/system_config.h"
 
 extern atomic_t<bool> g_user_asked_for_frame_capture;
+extern atomic_t<bool> g_disable_frame_limit; 
 extern rsx::frame_trace_data frame_debug;
 extern rsx::frame_capture_data frame_capture;
 

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -299,6 +299,7 @@ void keyboard_pad_handler::processKeyEvent(QKeyEvent* event, bool pressed)
 	case Qt::Key_S:
 	case Qt::Key_R:
 	case Qt::Key_E:
+	case Qt::Key_0:
 		if (event->modifiers() != Qt::ControlModifier)
 			handle_key();
 		break;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -52,6 +52,7 @@ LOG_CHANNEL(mark_log, "MARK");
 LOG_CHANNEL(gui_log, "GUI");
 
 extern atomic_t<bool> g_user_asked_for_frame_capture;
+extern atomic_t<bool> g_disable_frame_limit;
 
 constexpr auto qstr = QString::fromStdString;
 
@@ -266,6 +267,14 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 		if (keyEvent->modifiers() == Qt::AltModifier && !m_disable_kb_hotkeys)
 		{
 			g_user_asked_for_frame_capture = true;
+			return;
+		}
+		break;
+	case Qt::Key_F10:
+		if (keyEvent->modifiers() == Qt::ControlModifier)
+		{
+			g_disable_frame_limit = !g_disable_frame_limit;
+			gui_log.warning("%s boost mode", g_disable_frame_limit.load() ? "Enabled" : "Disabled");
 			return;
 		}
 		break;


### PR DESCRIPTION
I've had this lying around for ages but never added it because I wanted to implement the shortcut manager first (which never happened).
So I'll just make a draft and see what happens.