### PR TITLE
Remove macOS swizzling workarounds, initial support for Apple GPUs

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -770,26 +770,9 @@ namespace glsl
 		{
 			OS <<
 
-#ifdef __APPLE__
-			"vec4 remap_vector_m(const in vec4 rgba, const in uint remap_bits)\n"
-			"{\n"
-			"	uvec4 selector = (uvec4(remap_bits) >> uvec4(3, 6, 9, 0)) & 0x7;\n"
-			"	bvec4 choice = greaterThan(selector, uvec4(1));\n"
-			"\n"
-			"	vec4 direct = vec4(selector);\n"
-			"	selector = min(selector - 2, selector);\n"
-			"	vec4 indexed = vec4(rgba[selector.r], rgba[selector.g], rgba[selector.b], rgba[selector.a]);\n"
-			"	return mix(direct, indexed, choice);\n"
-			"}\n\n"
-#endif
-
 			//TODO: Move all the texture read control operations here
 			"vec4 process_texel(in vec4 rgba, const in uint control_bits)\n"
 			"{\n"
-#ifdef __APPLE__
-			"	uint remap_bits = (control_bits >> 16) & 0xFFFF;\n"
-			"	if (remap_bits != 0x8D5) rgba = remap_vector_m(rgba, remap_bits);\n\n"
-#endif
 			"	if (control_bits == 0)\n"
 			"	{\n"
 			"		return rgba;\n"

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2086,9 +2086,6 @@ namespace rsx
 					}
 				}
 
-#ifdef __APPLE__
-				texture_control |= (sampler_descriptors[i]->encoded_component_map() << 16);
-#endif
 				current_fragment_program.texture_params[i].control = texture_control;
 			}
 		}

--- a/rpcs3/Emu/RSX/VK/VKCompute.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCompute.cpp
@@ -79,8 +79,8 @@ namespace vk
 			case vk::driver_vendor::NVIDIA:
 				// Warps are multiples of 32. Increasing kernel depth seems to hurt performance (Nier, Big Duck sample)
 				unroll_loops = true;
-				optimal_group_size = 32;
 				optimal_kernel_size = 1;
+				optimal_group_size = 32;
 				break;
 			case vk::driver_vendor::AMD:
 			case vk::driver_vendor::RADV:
@@ -88,6 +88,11 @@ namespace vk
 				unroll_loops = false;
 				optimal_kernel_size = 1;
 				optimal_group_size = 64;
+				break;
+			case vk::driver_vendor::MVK:
+				unroll_loops = true;
+				optimal_kernel_size = 1;
+				optimal_group_size = 256;
 				break;
 			}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -603,6 +603,11 @@ VKGSRender::VKGSRender() : GSRender()
 			}
 			break;
 #endif
+		case vk::driver_vendor::MVK:
+			// Async compute crashes immediately on Apple GPUs
+			rsx_log.error("Apple GPUs are incompatible with the current implementation of asynchronous texture decoding.");
+			backend_config.supports_asynchronous_compute = false;
+			break;
 		default: break;
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -124,6 +124,9 @@ namespace vk
 		case driver_vendor::ANV:
 			// INTEL vulkan drivers are mostly OK, workarounds are applied when creating the device
 			break;
+		case driver_vendor::MVK:
+			// Apple GPUs / moltenVK need more testing
+			break;
 		default:
 			rsx_log.warning("Unsupported device: %s", gpu_name);
 		}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -115,6 +115,7 @@ namespace vk
 				[[ fallthrough ]];
 			case driver_vendor::NVIDIA:
 			case driver_vendor::INTEL:
+			case driver_vendor::MVK:
 				break;
 			}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/chip_class.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/chip_class.h
@@ -20,7 +20,8 @@ namespace vk
 		NV_pascal,
 		NV_volta,
 		NV_turing,
-		NV_ampere
+		NV_ampere,
+		MVK_apple
 	};
 
 	enum class driver_vendor
@@ -30,7 +31,8 @@ namespace vk
 		NVIDIA,
 		RADV,
 		INTEL,
-		ANV
+		ANV,
+		MVK
 	};
 
 	driver_vendor get_driver_vendor();

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -183,9 +183,16 @@ namespace vk
 
 	driver_vendor physical_device::get_driver_vendor() const
 	{
+#ifdef __APPLE__
+		// moltenVK currently returns DRIVER_ID_MOLTENVK (0).
+		// For now, assume the vendor is moltenVK on Apple devices.
+		return driver_vendor::MVK;
+#endif
+
 		if (!driver_properties.driverID)
 		{
 			const auto gpu_name = get_name();
+
 			if (gpu_name.find("Radeon") != umax)
 			{
 				return driver_vendor::AMD;

--- a/rpcs3/Emu/RSX/VK/vkutils/image.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.h
@@ -12,11 +12,7 @@
 //using enum rsx::format_class;
 using namespace ::rsx::format_class_;
 
-#ifdef __APPLE__
-#define VK_DISABLE_COMPONENT_SWIZZLE 1
-#else
 #define VK_DISABLE_COMPONENT_SWIZZLE 0
-#endif
 
 namespace vk
 {

--- a/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/swapchain.hpp
@@ -522,6 +522,7 @@ namespace vk
 				case driver_vendor::AMD:
 				case driver_vendor::INTEL:
 				case driver_vendor::RADV:
+				case driver_vendor::MVK:
 					break;
 				case driver_vendor::ANV:
 				case driver_vendor::NVIDIA:

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -73,11 +73,10 @@ struct cfg_root : cfg::node
 		cfg::uint64 tx_limit2_ns{this, "TSX Transaction Second Limit", 2000}; // In nanoseconds
 
 		cfg::_int<10, 3000> clocks_scale{ this, "Clocks scale", 100 }; // Changing this from 100 (percentage) may affect game speed in unexpected ways
-		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy",
-#ifdef __linux__
-			sleep_timers_accuracy_level::_as_host, true };
+#if defined (__linux__) || defined (__APPLE__)
+		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy", sleep_timers_accuracy_level::_as_host, true };
 #else
-			sleep_timers_accuracy_level::_usleep, true };
+		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy", sleep_timers_accuracy_level::_usleep, true };
 #endif
 
 		cfg::uint64 perf_report_threshold{this, "Performance Report Threshold", 500, true}; // In µs, 0.5ms = default, 0 = everything
@@ -134,7 +133,11 @@ struct cfg_root : cfg::node
 		cfg::_bool disable_vulkan_mem_allocator{ this, "Disable Vulkan Memory Allocator", false };
 		cfg::_bool full_rgb_range_output{ this, "Use full RGB output range", true, true }; // Video out dynamic range
 		cfg::_bool strict_texture_flushing{ this, "Strict Texture Flushing", false };
+#ifdef __APPLE__
+		cfg::_bool disable_native_float16{ this, "Disable native float16 support", true };
+#else
 		cfg::_bool disable_native_float16{ this, "Disable native float16 support", false };
+#endif
 		cfg::_bool multithreaded_rsx{ this, "Multithreaded RSX", false };
 		cfg::_bool relaxed_zcull_sync{ this, "Relaxed ZCULL Sync", false };
 		cfg::_bool enable_3d{ this, "Enable 3D", false };


### PR DESCRIPTION
Fixes various black screens in games such as Life is Strange (might fix #11363), and projected shadows in Project DIVA Dreamy Theater.
Also adds a code path for Apple GPUs in case driver-specific workaround are needed in the future.
By default, native float16 is now disabled (fixes NieR), and timer accuracy is set to "as host" by default (partially fixes The Last of Us and other games, with no side effects so far, although technically none of the options currently provides very accurate timers).