### PR TITLE
Ensures socket is closed in sys_net_bnet_close

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -3497,6 +3497,9 @@ error_code sys_net_bnet_close(ppu_thread& ppu, s32 s)
 	auto& dnshook = g_fxo->get<np::dnshook>();
 	dnshook.remove_dns_spy(s);
 
+	// Ensures the socket has no lingering copy from network thread
+	g_fxo->get<network_context>().s_nw_mutex.lock_unlock();
+
 	return CELL_OK;
 }
 


### PR DESCRIPTION
Quick fix for https://github.com/RPCS3/rpcs3/issues/11386.

Lingering shared_ptr in network thread meant the socket wasn't actually closed and trying to rebind immediately after closing the ps3 socket didn't work as it was still bound on host.