### PR TITLE
vk: Fix VK_ERROR_DEVICE_LOST crashes

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -829,6 +829,7 @@ void VKGSRender::emit_geometry(u32 sub_index)
 	{
 		// Need to update descriptors; make a copy for the next draw
 		VkDescriptorSet previous_set = m_current_frame->descriptor_set.value();
+		m_current_frame->descriptor_set.flush();
 		m_current_frame->descriptor_set = allocate_descriptor_set();
 		rsx::simple_array<VkCopyDescriptorSet> copy_cmds(binding_table.total_descriptor_bindings);
 

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -285,8 +285,14 @@ void VKGSRender::load_texture_env()
 
 				if (replace)
 				{
-					fs_sampler_handles[i] = vk::get_resource_manager()->find_sampler(*m_device, wrap_s, wrap_t, wrap_r, false, lod_bias, af_level, min_lod, max_lod,
-						min_filter.filter, mag_filter, min_filter.mipmap_mode, border_color, compare_enabled, depth_compare_mode);
+					fs_sampler_handles[i] = vk::get_resource_manager()->get_sampler(
+						*m_device,
+						fs_sampler_handles[i],
+						wrap_s, wrap_t, wrap_r,
+						false,
+						lod_bias, af_level, min_lod, max_lod,
+						min_filter.filter, mag_filter, min_filter.mipmap_mode,
+						border_color, compare_enabled, depth_compare_mode);
 				}
 			}
 			else
@@ -338,8 +344,9 @@ void VKGSRender::load_texture_env()
 
 				if (replace)
 				{
-					vs_sampler_handles[i] = vk::get_resource_manager()->find_sampler(
+					vs_sampler_handles[i] = vk::get_resource_manager()->get_sampler(
 						*m_device,
+						vs_sampler_handles[i],
 						VK_SAMPLER_ADDRESS_MODE_REPEAT, VK_SAMPLER_ADDRESS_MODE_REPEAT, VK_SAMPLER_ADDRESS_MODE_REPEAT,
 						unnormalized_coords,
 						0.f, 1.f, min_lod, max_lod,

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -223,6 +223,8 @@ void VKGSRender::frame_context_cleanup(vk::frame_context_t *ctx, bool free_resou
 			m_overlay_manager->dispose(uids_to_dispose);
 		}
 
+		vk::get_resource_manager()->trim();
+
 		vk::reset_global_resources();
 
 		ctx->buffer_views_to_clean.clear();

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -346,8 +346,10 @@ namespace vk
 		vkUpdateDescriptorSets(*g_render_device, 1, &writer, 0, nullptr);
 	}
 
-	void descriptor_set::push(rsx::simple_array<VkCopyDescriptorSet>& copy_cmd)
+	void descriptor_set::push(rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask)
 	{
+		m_push_type_mask |= type_mask;
+
 		if (m_pending_copies.empty()) [[likely]]
 		{
 			m_pending_copies = std::move(copy_cmd);

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -65,7 +65,7 @@ namespace vk
 		void push(const VkDescriptorBufferInfo& buffer_info, VkDescriptorType type, u32 binding);
 		void push(const VkDescriptorImageInfo& image_info, VkDescriptorType type, u32 binding);
 		void push(const VkDescriptorImageInfo* image_info, u32 count, VkDescriptorType type, u32 binding);
-		void push(rsx::simple_array<VkCopyDescriptorSet>& copy_cmd);
+		void push(rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask = umax);
 
 		void bind(VkCommandBuffer cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout);
 		void bind(const command_buffer& cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout);

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -18,6 +18,7 @@ namespace vk
 			VMM_ALLOCATION_POOL_TEXTURE_CACHE,
 			VMM_ALLOCATION_POOL_SWAPCHAIN,
 			VMM_ALLOCATION_POOL_SCRATCH,
+			VMM_ALLOCATION_POOL_SAMPLER,
 		};
 	}
 
@@ -173,6 +174,7 @@ namespace vk
 		void* m_host_pointer;
 	};
 
+	// Tracking for memory usage. Constrained largely by amount of VRAM + shared video memory.
 	void vmm_notify_memory_allocated(void* handle, u32 memory_type, u64 memory_size, vmm_allocation_pool pool);
 	void vmm_notify_memory_freed(void* handle);
 	void vmm_reset();
@@ -181,6 +183,10 @@ namespace vk
 	u64  vmm_get_application_pool_usage(vmm_allocation_pool pool);
 	bool vmm_handle_memory_pressure(rsx::problem_severity severity);
 	rsx::problem_severity vmm_determine_memory_load_severity();
+
+	// Tracking for host memory objects. Allocated count is more important than actual memory amount.
+	void vmm_notify_object_allocated(vmm_allocation_pool pool);
+	void vmm_notify_object_freed(vmm_allocation_pool pool);
 
 	mem_allocator_base* get_current_mem_allocator();
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
@@ -1,3 +1,4 @@
+#include "memory.h"
 #include "sampler.h"
 #include "../../rsx_utils.h"
 
@@ -27,11 +28,13 @@ namespace vk
 		info.borderColor = border_color;
 
 		CHECK_RESULT(vkCreateSampler(m_device, &info, nullptr, &value));
+		vmm_notify_object_allocated(VMM_ALLOCATION_POOL_SAMPLER);
 	}
 
 	sampler::~sampler()
 	{
 		vkDestroySampler(m_device, value, nullptr);
+		vmm_notify_object_freed(VMM_ALLOCATION_POOL_SAMPLER);
 	}
 
 	bool sampler::matches(VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,


### PR DESCRIPTION
Multiple fixes are going to be added to this. Highlights:
- Keep maximum number of samplers allowed under control. This should solve a lot of VK_ERROR_DEVICE_LOST errors experienced on nvidia hardware. NV cards can only keep 4000 (actually 4096) sampler objects while other vendors can handle more than 1 million. This change attempts to keep the allocated number under 75% of max capacity and also tries to never exceed 2048 allocated samplers at any given time. In practice we will go over this limit, but we have enough headroom to avoid maxing out the driver.
- Fix lost descriptor updates when pushing copy operations. The previous CB may have queued writes that then need to be copied after the fact, and also if all we do is make a copy without push or make a copy but only push 'incompatible' record type, then the copies will never be submitted due to a mask check failing on flush.

Fixes https://github.com/RPCS3/rpcs3/issues/11391