### PR TITLE
Unbreak build with FFmpeg 5.0

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAdec.cpp
@@ -270,7 +270,11 @@ public:
 	bool just_finished = false;
 
 	const AVCodec* codec = nullptr;
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 0, 0)
+	const AVInputFormat* input_format = nullptr;
+#else
 	AVInputFormat* input_format = nullptr;
+#endif
 	AVCodecContext* ctx = nullptr;
 	AVFormatContext* fmt = nullptr;
 	u8* io_buf;

--- a/rpcs3/Emu/Cell/Modules/cellAdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAdec.cpp
@@ -269,7 +269,7 @@ public:
 	bool just_started = false;
 	bool just_finished = false;
 
-	AVCodec* codec = nullptr;
+	const AVCodec* codec = nullptr;
 	AVInputFormat* input_format = nullptr;
 	AVCodecContext* ctx = nullptr;
 	AVFormatContext* fmt = nullptr;

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -102,7 +102,7 @@ struct vdec_context final
 	static const u32 id_step = 0x00000100;
 	static const u32 id_count = 1024;
 
-	AVCodec* codec{};
+	const AVCodec* codec{};
 	AVCodecContext* ctx{};
 	SwsContext* sws{};
 


### PR DESCRIPTION
Regressed by https://github.com/ffmpeg/ffmpeg/commit/626535f6a169 + https://github.com/ffmpeg/ffmpeg/commit/56450a0ee4fd. From [error log](https://github.com/RPCS3/rpcs3/files/7914663/rpcs3-0.0.20.13190.log):
```c++
rpcs3/Emu/Cell/Modules/cellAdec.cpp:325:12: error: assigning to 'AVCodec *' from 'const AVCodec *' discards qualifiers
                        codec = avcodec_find_decoder(AV_CODEC_ID_ATRAC3P);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rpcs3/Emu/Cell/Modules/cellAdec.cpp:326:19: error: assigning to 'AVInputFormat *' from 'const AVInputFormat *' discards qualifiers
                        input_format = av_find_input_format("oma");
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
rpcs3/Emu/Cell/Modules/cellAdec.cpp:331:12: error: assigning to 'AVCodec *' from 'const AVCodec *' discards qualifiers
                        codec = avcodec_find_decoder(AV_CODEC_ID_MP3);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rpcs3/Emu/Cell/Modules/cellAdec.cpp:332:19: error: assigning to 'AVInputFormat *' from 'const AVInputFormat *' discards qualifiers
                        input_format = av_find_input_format("mp3");
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
rpcs3/Emu/Cell/Modules/cellVdec.cpp:143:12: error: assigning to 'AVCodec *' from 'const AVCodec *' discards qualifiers
                        codec = avcodec_find_decoder(AV_CODEC_ID_MPEG2VIDEO);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rpcs3/Emu/Cell/Modules/cellVdec.cpp:148:12: error: assigning to 'AVCodec *' from 'const AVCodec *' discards qualifiers
                        codec = avcodec_find_decoder(AV_CODEC_ID_H264);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rpcs3/Emu/Cell/Modules/cellVdec.cpp:153:12: error: assigning to 'AVCodec *' from 'const AVCodec *' discards qualifiers
                        codec = avcodec_find_decoder(AV_CODEC_ID_MPEG4);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Runtime tested on [FreeBSD](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=261302): Persona 5 (intro) works fine, Aquapazza (intro) fails:
```
RPCS3: PPU[0x1000025] Thread (_libsail-control) [HLE:0x0084514c, LR:0x00c72cd0]: SIG: Thread terminated due to fatal error: avcodec_open2() failed (err=0x0, opts=1)
(in file rpcs3/Emu/Cell/Modules/cellVdec.cpp:183[:4], in function vdec_context) (errno=17)
```
but works fine with FFmpeg 4.4.1, so should be safe to merge.
