### PR TITLE
vk: Improve sanity checks around subresource gathers

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -226,7 +226,7 @@ namespace rsx
 				if (external_subresource_desc.op != deferred_request_command::atlas_gather)
 					return true;
 
-				const int target_area = (external_subresource_desc.width * external_subresource_desc.height * threshold) / 100;
+				const int target_area = (external_subresource_desc.width * external_subresource_desc.height * external_subresource_desc.depth * threshold) / 100;
 				int covered_area = 0;
 				areai bbox{smax, smax, 0, 0};
 

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -360,7 +360,7 @@ namespace rsx
 
 				const u16 dst_w = static_cast<u16>(std::get<2>(clipped).width);
 				const u16 src_w = static_cast<u16>(dst_w * attr.bpp) / section_bpp;
-				const u16 height = static_cast<u16>(dst_h);
+				const u16 height = std::min(slice_end, section_end) - dst_y;
 
 				if (scaling)
 				{

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -658,7 +658,6 @@ namespace rsx
 			{
 				attr2.width = scaled_w;
 				attr2.height = scaled_h;
-				attr2.depth = 1;
 
 				sampled_image_descriptor desc = { nullptr, deferred_request_command::cubemap_gather,
 						attr2, {},


### PR DESCRIPTION
- Do not write out of bounds when loading resources in system memory
- Take subresource Z into account when calculating coverage. It is possible to have the first slice covered but have the rest missing, we can just reupload in such a case.

Fixes device lost crash in MLB series and maybe other titles.