### PR TITLE
rsx: Minor texture fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2868,7 +2868,7 @@ namespace rsx
 
 					typeless_info.src_gcm_format = gcm_format;
 				}
-				else if (cached_src->is_depth_texture() != dst_is_depth_surface)
+				else
 				{
 					typeless_info.src_gcm_format = cached_src->get_gcm_format();
 				}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -507,9 +507,9 @@ void gl::render_target::memory_barrier(gl::command_context& cmd, rsx::surface_ac
 		else
 		{
 			// Mem cast, generate typeless xfer info
-			if (!formats_are_bitcast_compatible(static_cast<GLenum>(get_internal_format()), static_cast<GLenum>(src_texture->get_internal_format())) ||
-				aspect() != src_texture->aspect())
+			if (!formats_are_bitcast_compatible(this, src_texture))
 			{
+				ensure(aspect() != src_texture->aspect());
 				typeless_info.src_is_typeless = true;
 				typeless_info.src_context = rsx::texture_upload_context::framebuffer_storage;
 				typeless_info.src_native_format_override = static_cast<u32>(get_internal_format());

--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -838,6 +838,7 @@ namespace gl
 		case GL_RGBA32F:
 			return 16;
 		case GL_DEPTH_COMPONENT16:
+		case GL_DEPTH_COMPONENT32F:
 			return 2;
 		case GL_DEPTH24_STENCIL8:
 		case GL_DEPTH32F_STENCIL8:
@@ -869,6 +870,7 @@ namespace gl
 		case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
 			return { false, 4 };
 		case GL_DEPTH_COMPONENT16:
+		case GL_DEPTH_COMPONENT32F:
 			return { true, 2 };
 		case GL_DEPTH24_STENCIL8:
 		case GL_DEPTH32F_STENCIL8:
@@ -904,6 +906,18 @@ namespace gl
 		}
 
 		return false;
+	}
+
+	bool formats_are_bitcast_compatible(const texture* texture1, const texture* texture2)
+	{
+		if (const u32 transfer_class = texture1->format_class() | texture2->format_class();
+			transfer_class & RSX_FORMAT_CLASS_DEPTH_FLOAT_MASK)
+		{
+			// If any one of the two images is a depth float, the other must match exactly or bust
+			return (texture1->format_class() == texture2->format_class());
+		}
+
+		return formats_are_bitcast_compatible(static_cast<GLenum>(texture1->get_internal_format()), static_cast<GLenum>(texture2->get_internal_format()));
 	}
 
 	void copy_typeless(texture * dst, const texture * src, const coord3u& dst_region, const coord3u& src_region)

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -40,7 +40,7 @@ namespace gl
 
 	viewable_image* create_texture(u32 gcm_format, u16 width, u16 height, u16 depth, u16 mipmaps, rsx::texture_dimension_extended type);
 
-	bool formats_are_bitcast_compatible(GLenum format1, GLenum format2);
+	bool formats_are_bitcast_compatible(const texture* texture1, const texture* texture2);
 	void copy_typeless(texture* dst, const texture* src, const coord3u& dst_region, const coord3u& src_region);
 	void copy_typeless(texture* dst, const texture* src);
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
@@ -145,8 +145,8 @@ namespace gl
 			if (!slice.src)
 				continue;
 
-			const bool typeless = dst_aspect != slice.src->aspect() ||
-				!formats_are_bitcast_compatible(static_cast<GLenum>(slice.src->get_internal_format()), static_cast<GLenum>(dst_image->get_internal_format()));
+			const bool typeless = !formats_are_bitcast_compatible(slice.src, dst_image);
+			ensure(typeless || dst_aspect == slice.src->aspect());
 
 			std::unique_ptr<gl::texture> tmp;
 			auto src_image = slice.src;

--- a/rpcs3/Emu/RSX/VK/VKFormats.h
+++ b/rpcs3/Emu/RSX/VK/VKFormats.h
@@ -23,7 +23,6 @@ namespace vk
 	u8 get_format_texel_width(VkFormat format);
 	std::pair<u8, u8> get_format_element_size(VkFormat format);
 	std::pair<bool, u32> get_format_convert_flags(VkFormat format);
-	bool formats_are_bitcast_compatible(VkFormat format1, VkFormat format2);
 	bool formats_are_bitcast_compatible(image* image1, image* image2);
 
 	minification_filter get_min_filter(rsx::texture_minify_filter min_filter);


### PR DESCRIPTION
- Remove a check that stopped the src_gcm_format field from the typeless_info structure from being filled. We rely on this structure to determine whether to do assisted transfers later - keeping it blank can cause unexpected aspect mismatch further down the pipe.
- Properly implement bitcast compatibility checks for OpenGL.
- Register missing R32F format class for OpenGL

Fixes https://github.com/RPCS3/rpcs3/issues/11441
Fixes https://github.com/RPCS3/rpcs3/issues/11434