### PR TITLE
Input: Improve pad latency

### DIFF
--- a/Utilities/Timer.h
+++ b/Utilities/Timer.h
@@ -12,7 +12,7 @@ private:
 	steady_clock::time_point m_end;
 
 public:
-	Timer() : m_stopped(false)
+	Timer() : m_stopped(false), m_start(steady_clock::now())
 	{
 	}
 

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -431,6 +431,11 @@ void PadHandlerBase::TranslateButtonPress(const std::shared_ptr<PadDevice>& devi
 
 bool PadHandlerBase::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id)
 {
+	if (!pad)
+	{
+		return false;
+	}
+
 	std::shared_ptr<PadDevice> pad_device = get_device(device);
 	if (!pad_device)
 	{

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -2,6 +2,7 @@
 
 #include "Emu/Io/PadHandler.h"
 #include "Utilities/CRC.h"
+#include "Utilities/Thread.h"
 
 #include "hidapi.h"
 
@@ -77,10 +78,14 @@ protected:
 	std::map<std::string, std::shared_ptr<Device>> m_controllers;
 
 	bool m_is_init = false;
-	std::chrono::system_clock::time_point m_last_enumeration;
 	std::set<std::string> m_last_enumerated_devices;
+	std::set<std::string> m_new_enumerated_devices;
+	std::map<std::string, std::wstring_view> m_enumerated_serials;
+	std::mutex m_enumeration_mutex;
+	std::unique_ptr<named_thread<std::function<void()>>> m_enumeration_thread;
 
 	void enumerate_devices();
+	void update_devices();
 	std::shared_ptr<Device> get_hid_device(const std::string& padId);
 
 	virtual void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view serial) = 0;

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -750,7 +750,7 @@ std::string keyboard_pad_handler::native_scan_code_to_string(int native_scan_cod
 
 bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, const std::string& device, u8 player_id)
 {
-	if (device != pad::keyboard_device_name)
+	if (!pad || device != pad::keyboard_device_name)
 		return false;
 
 	m_pad_configs[player_id].from_string(g_cfg_input.player[player_id]->config.to_string());


### PR DESCRIPTION
DRAFT: multithreaded pad handlers (1 thread each + hid enumeration threads).

I only had a couple of USB ports free, so I could only test with 3 controllers (1 XInput, 1 DS4, 1 MMJOY) and the keyboard.

The following timings represent the averages and the maxima of each handler, gathered over 1 second each.

**Old timings (current master):**
```
E Input: Timings (ms): Keyboard: avg=0.000004, max=0.002000 / DualShock 4: avg=0.005743, max=0.014000 / XInput: avg=0.041130, max=0.080000 / MMJoystick: avg=0.005774, max=0.062000 / Total: avg=0.055034, max=0.117000
E Input: Timings (ms): Keyboard: avg=0.000006, max=0.001000 / DualShock 4: avg=0.010601, max=3.781000 / XInput: avg=0.041367, max=0.106000 / MMJoystick: avg=0.005719, max=0.028000 / Total: avg=0.060065, max=3.827000
E Input: Timings (ms): Keyboard: avg=0.000008, max=0.002000 / DualShock 4: avg=0.005911, max=0.018000 / XInput: avg=0.041734, max=0.076000 / MMJoystick: avg=0.005781, max=0.013000 / Total: avg=0.055839, max=0.106000
E Input: Timings (ms): Keyboard: avg=0.000013, max=0.003000 / DualShock 4: avg=0.093476, max=64.842000 / XInput: avg=0.042050, max=0.085000 / MMJoystick: avg=0.005884, max=0.018000 / Total: avg=0.143930, max=64.897000
E Input: Timings (ms): Keyboard: avg=0.000001, max=0.001000 / DualShock 4: avg=0.005847, max=0.040000 / XInput: avg=0.041064, max=0.084000 / MMJoystick: avg=0.005750, max=0.016000 / Total: avg=0.055036, max=0.099000
E Input: Timings (ms): Keyboard: avg=0.000013, max=0.001000 / DualShock 4: avg=0.011045, max=3.904000 / XInput: avg=0.042100, max=0.102000 / MMJoystick: avg=0.005996, max=0.117000 / Total: avg=0.061602, max=3.951000
E Input: Timings (ms): Keyboard: avg=0.000006, max=0.001000 / DualShock 4: avg=0.005918, max=0.031000 / XInput: avg=0.041386, max=0.097000 / MMJoystick: avg=0.005790, max=0.012000 / Total: avg=0.055516, max=0.114000
E Input: Timings (ms): Keyboard: avg=0.000011, max=0.001000 / DualShock 4: avg=0.095209, max=64.888000 / XInput: avg=0.042025, max=0.133000 / MMJoystick: avg=0.005940, max=0.042000 / Total: avg=0.145632, max=64.941000
E Input: Timings (ms): Keyboard: avg=0.000005, max=0.001000 / DualShock 4: avg=0.005960, max=0.019000 / XInput: avg=0.041832, max=0.087000 / MMJoystick: avg=0.006003, max=0.071000 / Total: avg=0.056271, max=0.157000
E Input: Timings (ms): Keyboard: avg=0.000015, max=0.005000 / DualShock 4: avg=0.011149, max=3.989000 / XInput: avg=0.042306, max=0.274000 / MMJoystick: avg=0.006048, max=0.135000 / Total: avg=0.062013, max=4.036000
```

**New timings with multi-threaded hid enumeration:**

```
E Input: Timings (ms): Keyboard: avg=0.000018, max=0.002000 / DualShock 4: avg=0.006181, max=0.018000 / XInput: avg=0.008293, max=0.039000 / MMJoystick: avg=0.005190, max=0.022000 / Total: avg=0.021965, max=0.051000
E Input: Timings (ms): Keyboard: avg=0.000014, max=0.001000 / DualShock 4: avg=0.006425, max=0.019000 / XInput: avg=0.008621, max=0.047000 / MMJoystick: avg=0.005382, max=0.047000 / Total: avg=0.022753, max=0.069000
E Input: Timings (ms): Keyboard: avg=0.000008, max=0.001000 / DualShock 4: avg=0.005945, max=0.015000 / XInput: avg=0.008018, max=0.022000 / MMJoystick: avg=0.005115, max=0.077000 / Total: avg=0.021319, max=0.093000
E Input: Timings (ms): Keyboard: avg=0.000006, max=0.001000 / DualShock 4: avg=0.006189, max=0.123000 / XInput: avg=0.008065, max=0.038000 / MMJoystick: avg=0.005159, max=0.072000 / Total: avg=0.021632, max=0.141000
E Input: Timings (ms): Keyboard: avg=0.000006, max=0.001000 / DualShock 4: avg=0.005982, max=0.014000 / XInput: avg=0.008113, max=0.038000 / MMJoystick: avg=0.005113, max=0.014000 / Total: avg=0.021472, max=0.051000
E Input: Timings (ms): Keyboard: avg=0.000014, max=0.001000 / DualShock 4: avg=0.005911, max=0.017000 / XInput: avg=0.008053, max=0.030000 / MMJoystick: avg=0.004999, max=0.015000 / Total: avg=0.021175, max=0.046000
E Input: Timings (ms): Keyboard: avg=0.000008, max=0.001000 / DualShock 4: avg=0.005893, max=0.012000 / XInput: avg=0.008054, max=0.028000 / MMJoystick: avg=0.005081, max=0.059000 / Total: avg=0.021266, max=0.076000
E Input: Timings (ms): Keyboard: avg=0.000010, max=0.001000 / DualShock 4: avg=0.006004, max=0.018000 / XInput: avg=0.008110, max=0.038000 / MMJoystick: avg=0.005082, max=0.014000 / Total: avg=0.021445, max=0.052000
E Input: Timings (ms): Keyboard: avg=0.000006, max=0.001000 / DualShock 4: avg=0.005892, max=0.016000 / XInput: avg=0.007901, max=0.015000 / MMJoystick: avg=0.004955, max=0.012000 / Total: avg=0.020940, max=0.043000
E Input: Timings (ms): Keyboard: avg=0.000008, max=0.001000 / DualShock 4: avg=0.006131, max=0.051000 / XInput: avg=0.008222, max=0.051000 / MMJoystick: avg=0.005088, max=0.011000 / Total: avg=0.021687, max=0.069000
E Input: Timings (ms): Keyboard: avg=0.000007, max=0.002000 / DualShock 4: avg=0.006059, max=0.034000 / XInput: avg=0.008171, max=0.053000 / MMJoystick: avg=0.005122, max=0.045000 / Total: avg=0.021566, max=0.068000
```

**New timings with multi-threaded hid enumeration AND multi-threaded pad handlers (No Total, because not sequential):**
```
E Input: Timings (ms): Keyboard: avg=0.000016, max=0.001000 / DualShock 4: avg=0.008728, max=1.319000 / XInput: avg=0.043141, max=0.095000 / MMJoystick: avg=0.007852, max=0.054000 / 
E Input: Timings (ms): Keyboard: avg=0.000006, max=0.001000 / DualShock 4: avg=0.006146, max=0.013000 / XInput: avg=0.041561, max=0.104000 / MMJoystick: avg=0.007975, max=0.033000 / 
E Input: Timings (ms): Keyboard: avg=0.000007, max=0.001000 / DualShock 4: avg=0.006406, max=0.015000 / XInput: avg=0.042272, max=0.084000 / MMJoystick: avg=0.008133, max=0.031000 / 
E Input: Timings (ms): Keyboard: avg=0.000012, max=0.001000 / DualShock 4: avg=0.006348, max=0.015000 / XInput: avg=0.041648, max=0.071000 / MMJoystick: avg=0.007996, max=0.018000 / 
E Input: Timings (ms): Keyboard: avg=0.000004, max=0.001000 / DualShock 4: avg=0.006426, max=0.015000 / XInput: avg=0.041801, max=0.097000 / MMJoystick: avg=0.007996, max=0.019000 / 
E Input: Timings (ms): Keyboard: avg=0.000006, max=0.001000 / DualShock 4: avg=0.006142, max=0.014000 / XInput: avg=0.041183, max=0.136000 / MMJoystick: avg=0.007845, max=0.026000 / 
E Input: Timings (ms): Keyboard: avg=0.000012, max=0.001000 / DualShock 4: avg=0.006471, max=0.014000 / XInput: avg=0.041816, max=0.078000 / MMJoystick: avg=0.008151, max=0.079000 / 
E Input: Timings (ms): Keyboard: avg=0.000018, max=0.001000 / DualShock 4: avg=0.006895, max=0.018000 / XInput: avg=0.044020, max=0.166000 / MMJoystick: avg=0.008673, max=0.019000 / 
E Input: Timings (ms): Keyboard: avg=0.000012, max=0.001000 / DualShock 4: avg=0.006484, max=0.015000 / XInput: avg=0.041966, max=0.074000 / MMJoystick: avg=0.008196, max=0.050000 / 
E Input: Timings (ms): Keyboard: avg=0.000015, max=0.002000 / DualShock 4: avg=0.006709, max=0.016000 / XInput: avg=0.043045, max=0.096000 / MMJoystick: avg=0.008499, max=0.017000 / 
E Input: Timings (ms): Keyboard: avg=0.000006, max=0.001000 / DualShock 4: avg=0.006385, max=0.017000 / XInput: avg=0.042256, max=0.080000 / MMJoystick: avg=0.008120, max=0.018000 / 
```

As you can see in the old timings, there are huge spikes in the DS4 handler on every other log message.
This happens because we search for new controllers every 2 seconds, leading to 3ms - 65ms hickups.
The same issue exists on DS3 and DualSense, although I didn't investigate the delay for those.

In the new code, those spikes are gone, because we enumerate the devices in the background.
The actual device list will only be updated if we detect a change, which is unchanged from the old master code.

The timings for the individual handlers stay similar in both new approaches.

Obviously there will be a tiny benefit from more threads, but the total time spent in all handlers in the sequential approach is still way below 1ms, so I'm tempted to just keep it that way in order to prevent regressions.