### PR TITLE
vk: Improve working buffer behavior

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -41,7 +41,7 @@ namespace vk
 		}
 		else if (aspect & VK_IMAGE_ASPECT_DEPTH_BIT)
 		{
-			return base_size * 2;
+			return (base_size * 6) / 2;
 		}
 		else
 		{


### PR DESCRIPTION
- Fix scratch memory calculations for D16F (emulated with D32F)
- Fix grow behaviour when the max heap limit is reached.

Fixes https://github.com/RPCS3/rpcs3/issues/11451
Fixes https://github.com/RPCS3/rpcs3/issues/11450