### PR TITLE
Fix linkage error on debug build with clang-13

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -172,10 +172,10 @@ struct spu_channel
 	atomic_t<u64> data;
 
 public:
-	static const u32 off_wait = 32;
-	static const u32 off_count = 63;
-	static const u64 bit_wait = 1ull << off_wait;
-	static const u64 bit_count = 1ull << off_count;
+	static constexpr u32 off_wait  = 32;
+	static constexpr u32 off_count = 63;
+	static constexpr u64 bit_wait  = 1ull << off_wait;
+	static constexpr u64 bit_count = 1ull << off_count;
 
 	// Returns true on success
 	bool try_push(u32 value)


### PR DESCRIPTION
Debug build with clang-13 fails with "undefined references" to the
static const members in `spu_channel` class. This patch replaces the const
definitions with `constexpr` constants.

The following is the output when the build fails:
```
$ CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Debug ../rpcs3 && make
...
[100%] Building CXX object rpcs3/CMakeFiles/rpcs3.dir/Input/mm_joystick_handler.cpp.o
[100%] Building CXX object rpcs3/CMakeFiles/rpcs3.dir/Input/pad_thread.cpp.o
[100%] Building CXX object rpcs3/CMakeFiles/rpcs3.dir/Input/xinput_pad_handler.cpp.o
[100%] Linking CXX executable ../bin/rpcs3
/usr/bin/x86_64-pc-linux-gnu-ld: Emu/librpcs3_emu.a(SPUASMJITRecompiler.cpp.o): in function `operator()':
/home/hyogi/workspace/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp:1358: undefined reference to `spu_channel::off_count'
/usr/bin/x86_64-pc-linux-gnu-ld: /home/hyogi/workspace/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp:1531: undefined reference to `spu_channel::off_count'
/usr/bin/x86_64-pc-linux-gnu-ld: Emu/librpcs3_emu.a(SPUASMJITRecompiler.cpp.o): in function `spu_recompiler::WRCH(spu_opcode_t)':
/home/hyogi/workspace/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp:2309: undefined reference to `spu_channel::off_count'
/usr/bin/x86_64-pc-linux-gnu-ld: /home/hyogi/workspace/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp:2324: undefined reference to `spu_channel::off_count'
/usr/bin/x86_64-pc-linux-gnu-ld: /home/hyogi/workspace/rpcs3/rpcs3/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp:2391: undefined reference to `spu_channel::off_count'
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [rpcs3/CMakeFiles/rpcs3.dir/build.make:479: bin/rpcs3] Error 1
make[1]: *** [CMakeFiles/Makefile2:28936: rpcs3/CMakeFiles/rpcs3.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```