### PR TITLE
RSX: Fix rsx capture stop

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1755,6 +1755,12 @@ void Emulator::Kill(bool allow_autoexit)
 	});
 
 	// Signal threads
+
+	if (auto thr = g_fxo->try_get<named_thread<rsx::rsx_replay_thread>>())
+	{
+		*static_cast<cpu_thread*>(thr) = thread_state::aborting;
+	}
+
 	if (auto rsx = g_fxo->try_get<rsx::thread>())
 	{
 		*static_cast<cpu_thread*>(rsx) = thread_state::aborting;


### PR DESCRIPTION
RSX captures froze on stop, at least with Vulkan.
This is probably a bit overkill, but it seems to work.
I have no idea if this is correct.

I'd say this also fixes remaining shenanigans in the following issue:
fixes #8259