### PR TITLE
rpcn: add cookie impl to tickets

### DIFF
--- a/rpcs3/Emu/NP/np_requests.cpp
+++ b/rpcs3/Emu/NP/np_requests.cpp
@@ -609,13 +609,19 @@ namespace np
 		return true;
 	}
 
-	void np_handler::req_ticket(u32 /*version*/, const SceNpId* /*npid*/, const char* service_id, const u8* /*cookie*/, u32 /*cookie_size*/, const char* /*entitlement_id*/, u32 /*consumed_count*/)
+	void np_handler::req_ticket([[maybe_unused]] u32 version, [[maybe_unused]] const SceNpId* npid, const char* service_id, const u8* cookie, u32 cookie_size, [[maybe_unused]] const char* entitlement_id, [[maybe_unused]] u32 consumed_count)
 	{
 		u32 req_id = get_req_id(0x3333);
 
 		std::string service_id_str(service_id);
 
-		if (!rpcn->req_ticket(req_id, service_id_str))
+		std::vector<u8> cookie_vec;
+		if (cookie && cookie_size)
+		{
+			cookie_vec.assign(cookie, cookie + cookie_size);
+		}
+
+		if (!rpcn->req_ticket(req_id, service_id_str, cookie_vec))
 		{
 			rpcn_log.error("Disconnecting from RPCN!");
 			is_psn_active = false;

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -49,7 +49,7 @@ std::vector<std::vector<u8>> get_rpcn_msgs();
 
 namespace rpcn
 {
-	constexpr u32 RPCN_PROTOCOL_VERSION = 14;
+	constexpr u32 RPCN_PROTOCOL_VERSION = 15;
 	constexpr usz RPCN_HEADER_SIZE      = 13;
 	constexpr usz COMMUNICATION_ID_SIZE = 9;
 
@@ -1590,11 +1590,14 @@ namespace rpcn
 		return true;
 	}
 
-	bool rpcn_client::req_ticket(u32 req_id, const std::string& service_id)
+	bool rpcn_client::req_ticket(u32 req_id, const std::string& service_id, const std::vector<u8>& cookie)
 	{
 		std::vector<u8> data;
 		std::copy(service_id.begin(), service_id.end(), std::back_inserter(data));
 		data.push_back(0);
+		const le_t<u32> size = cookie.size();
+		std::copy(reinterpret_cast<const u8 *>(&size), reinterpret_cast<const u8 *>(&size) + sizeof(le_t<u32>), std::back_inserter(data));
+		std::copy(cookie.begin(), cookie.end(), std::back_inserter(data));
 
 		if (!forge_send(CommandType::RequestTicket, req_id, data))
 			return false;

--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -344,7 +344,7 @@ namespace rpcn
 		bool ping_room_owner(u32 req_id, const SceNpCommunicationId& communication_id, u64 room_id);
 		bool send_room_message(u32 req_id, const SceNpCommunicationId& communication_id, const SceNpMatching2SendRoomMessageRequest* req);
 		bool req_sign_infos(u32 req_id, const std::string& npid);
-		bool req_ticket(u32 req_id, const std::string& service_id);
+		bool req_ticket(u32 req_id, const std::string& service_id, const std::vector<u8>& cookie);
 		bool sendmessage(const message_data& msg_data, const std::set<std::string>& npids);
 
 		const std::string& get_online_name() const


### PR DESCRIPTION
Adds support for cookies to be included in the ticket(not 1:1 with ps3 but no information could be found about cookie encoding in the ticket).

Merge needs to be synced with rpcn update.