### PR TITLE
Input: multithreaded handlers

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -253,6 +253,8 @@ struct cfg_root : cfg::node
 		cfg::_enum<buzz_handler> buzz{ this, "Buzz emulated controller", buzz_handler::null };
 		cfg::_enum<turntable_handler> turntable{this, "Turntable emulated controller", turntable_handler::null};
 		cfg::_enum<ghltar_handler> ghltar{this, "GHLtar emulated controller", ghltar_handler::null};
+		cfg::_enum<pad_handler_mode> pad_mode{this, "Pad handler mode", pad_handler_mode::single_threaded, true};
+		cfg::uint<0, 100'000> pad_sleep{this, "Pad handler sleep (microseconds)", 1'000, true};
 	} io{ this };
 
 	struct node_sys : cfg::node

--- a/rpcs3/Emu/system_config_types.cpp
+++ b/rpcs3/Emu/system_config_types.cpp
@@ -386,6 +386,21 @@ void fmt_class_string<move_handler>::format(std::string& out, u64 arg)
 }
 
 template <>
+void fmt_class_string<pad_handler_mode>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](auto value)
+	{
+		switch (value)
+		{
+		case pad_handler_mode::single_threaded: return "Single-threaded";
+		case pad_handler_mode::multi_threaded: return "Multi-threaded";
+		}
+
+		return unknown;
+	});
+}
+
+template <>
 void fmt_class_string<buzz_handler>::format(std::string& out, u64 arg)
 {
 	format_enum(out, arg, [](auto value)

--- a/rpcs3/Emu/system_config_types.h
+++ b/rpcs3/Emu/system_config_types.h
@@ -135,6 +135,12 @@ enum class microphone_handler
 	rocksmith,
 };
 
+enum class pad_handler_mode
+{
+	single_threaded, // All pad handlers run on the same thread sequentially.
+	multi_threaded   // Each pad handler has its own thread.
+};
+
 enum class video_resolution
 {
 	_1080,

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -1027,6 +1027,13 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 		case camera_handler::qt: return tr("Qt", "Camera handler");
 		}
 		break;
+	case emu_settings_type::PadHandlerMode:
+		switch (static_cast<pad_handler_mode>(index))
+		{
+		case pad_handler_mode::single_threaded: return tr("Single-threaded", "Pad handler mode");
+		case pad_handler_mode::multi_threaded: return tr("Multi-threaded", "Pad handler mode");
+		}
+		break;
 	case emu_settings_type::Move:
 		switch (static_cast<move_handler>(index))
 		{

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -126,6 +126,7 @@ enum class emu_settings_type
 	MicrophoneDevices,
 
 	// Input / Output
+	PadHandlerMode,
 	KeyboardHandler,
 	MouseHandler,
 	Camera,
@@ -287,6 +288,7 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::MicrophoneDevices,       { "Audio", "Microphone Devices" }},
 
 	// Input / Output
+	{ emu_settings_type::PadHandlerMode,  { "Input/Output", "Pad handler mode"}},
 	{ emu_settings_type::KeyboardHandler, { "Input/Output", "Keyboard"}},
 	{ emu_settings_type::MouseHandler,    { "Input/Output", "Mouse"}},
 	{ emu_settings_type::Camera,          { "Input/Output", "Camera"}},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1063,6 +1063,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		SubscribeTooltip(ui->gb_camera_id, tooltips.settings.camera_id);
 	}
 
+	m_emu_settings->EnhanceComboBox(ui->padModeBox, emu_settings_type::PadHandlerMode);
+	SubscribeTooltip(ui->gb_pad_mode, tooltips.settings.pad_mode);
+
 	m_emu_settings->EnhanceComboBox(ui->moveBox, emu_settings_type::Move);
 	SubscribeTooltip(ui->gb_move_handler, tooltips.settings.move);
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -53,6 +53,9 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
       <widget class="QWidget" name="coreTab">
        <attribute name="title">
         <string>CPU</string>
@@ -1568,6 +1571,18 @@
             <layout class="QVBoxLayout" name="camera_id_layout">
              <item>
               <widget class="QComboBox" name="cameraIdBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QGroupBox" name="gb_pad_mode">
+            <property name="title">
+             <string>Pad Handler Mode</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_pad_mode_layout">
+             <item>
+              <widget class="QComboBox" name="padModeBox"/>
              </item>
             </layout>
            </widget>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -193,8 +193,7 @@ public:
 
 		// input
 
-		const QString pad_handler       = tr("If you want to use the keyboard to control, select the Keyboard option.\nIf you have a DualShock 4, select DualShock 4.\nIf you have an Xbox controller, or another compatible device, use XInput.\nOlder controllers such as PS2 controllers with an adapter usually work fine with MMJoystick.\nCheck button mappings in the Windows control panel.");
-		const QString pad_handler_linux = tr("If you want to use the keyboard to control, select the Keyboard option.\nIf you have a DualShock 4, select DualShock 4.");
+		const QString pad_mode          = tr("Single-threaded: All pad handlers run on the same thread sequentially.\nMulti-threaded: Each pad handler has its own thread.\nOnly use multi-threaded if you can spare the extra threads.");
 		const QString keyboard_handler  = tr("Some games support native keyboard input.\nBasic will work in these cases.");
 		const QString mouse_handler     = tr("Some games support native mouse input.\nBasic will work in these cases.");
 		const QString camera            = tr("Select Qt Camera to use the default camera device of your operating system.");


### PR DESCRIPTION
Implements naive multithreading for input handlers.
Adds the option to choose between single-threaded and multi-threaded pad handlers.

This may improve latency if you play with 2 or more different pad handlers.
It probably won't make a difference if you only play with 2 or more pads of the same type (e.g. only DualShock3).

But I also added a config only option "Pad handler sleep (microseconds)" for the hardcore input latency fanatics.
This setting can be used in both single and multithreaded modes.
By fiddling with that value (0-100000), you may notice faster response times.
I observed a theoretical decrease in latency by 700-800 microseconds in the best case scenario.
Keep in mind that setting this value to something close to 0 will increase your cpu usage on each used core drastically and will probably drain your pad battery rather quickly.
I'd like to emphasize that I don't know if this might result in damaged pads if used over extended periods of time.