### PR TITLE
vk: Use image hot-cache for faster allocation times

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1021,6 +1021,12 @@ namespace rsx
 
 		virtual void on_frame_end()
 		{
+			// Must manually release each cached entry
+			for (auto& entry : m_temporary_subresource_cache)
+			{
+				release_temporary_subresource(entry.second.second);
+			}
+
 			m_temporary_subresource_cache.clear();
 			m_predictor.on_frame_end();
 			reset_frame_statistics();

--- a/rpcs3/Emu/RSX/VK/VKOverlays.cpp
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.cpp
@@ -589,6 +589,13 @@ namespace vk
 
 		for (const auto& _key : keys_to_remove)
 		{
+			auto& img_data = temp_image_cache[_key];
+			auto& view_data = temp_view_cache[_key];
+
+			auto gc = vk::get_resource_manager();
+			gc->dispose(img_data.second);
+			gc->dispose(view_data);
+
 			temp_image_cache.erase(_key);
 			temp_view_cache.erase(_key);
 		}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -467,9 +467,9 @@ namespace vk
 		return result;
 	}
 
-	std::unique_ptr<vk::viewable_image> texture_cache::find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u8 mipmaps, VkFlags flags)
+	std::unique_ptr<vk::viewable_image> texture_cache::find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkFlags flags)
 	{
-		auto hash_properties = [](VkFormat format, u16 w, u16 h, u16 d, u8 mipmaps, VkFlags flags)
+		auto hash_properties = [](VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkFlags flags)
 		{
 			ensure(static_cast<u32>(format) < 0xFF);
 			return (static_cast<u64>(format) & 0xFF) |
@@ -1286,7 +1286,7 @@ namespace vk
 		vk::change_image_layout(cmd, image.get(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 
 		auto result = image.get();
-		const u32 resource_memory = image->memory->size();
+		const auto resource_memory = image->memory->size();
 		auto disposable = std::unique_ptr<vk::disposable_t>(new cached_image_reference_t(this, image));
 		vk::get_resource_manager()->dispose(disposable);
 
@@ -1316,8 +1316,9 @@ namespace vk
 		return baseclass::get_unreleased_textures_count() + ::size32(m_cached_images);
 	}
 
-	u32 texture_cache::get_temporary_memory_in_use() const
+	u64 texture_cache::get_temporary_memory_in_use() const
 	{
+		// TODO: Technically incorrect, we should have separate metrics for cached evictable resources (this value) and temporary active resources.
 		return m_cached_memory_size;
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -9,6 +9,8 @@ namespace vk
 {
 	texture_cache::cached_image_reference_t::cached_image_reference_t(texture_cache* parent, std::unique_ptr<vk::viewable_image>& previous)
 	{
+		ensure(previous);
+
 		this->parent = parent;
 		this->data = std::move(previous);
 	}
@@ -182,7 +184,7 @@ namespace vk
 
 	void texture_cache::on_section_destroyed(cached_texture_section& tex)
 	{
-		if (tex.is_managed())
+		if (tex.is_managed() && tex.exists())
 		{
 			auto disposable = std::unique_ptr<vk::disposable_t>(new cached_image_reference_t(this, tex.get_texture()));
 			vk::get_resource_manager()->dispose(disposable);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -385,7 +385,7 @@ namespace vk
 		//Stuff that has been dereferenced goes into these
 		const u32 max_cached_image_pool_size = 256;
 		std::deque<std::unique_ptr<vk::viewable_image>> m_cached_images;
-		atomic_t<u32> m_cached_memory_size = { 0 };
+		atomic_t<u64> m_cached_memory_size = { 0 };
 		shared_mutex m_cached_pool_lock;
 
 		void clear();
@@ -396,7 +396,7 @@ namespace vk
 
 		vk::image* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const;
 
-		std::unique_ptr<vk::viewable_image> find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u8 mipmaps, VkFlags flags);
+		std::unique_ptr<vk::viewable_image> find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkFlags flags);
 
 		std::unique_ptr<vk::viewable_image> find_cached_cubemap(VkFormat format, u16 size);
 
@@ -463,7 +463,7 @@ namespace vk
 
 		bool handle_memory_pressure(rsx::problem_severity severity) override;
 
-		u32 get_temporary_memory_in_use() const;
+		u64 get_temporary_memory_in_use() const;
 
 		bool is_overallocated() const;
 	};

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -365,6 +365,16 @@ namespace vk
 			void dispose() override;
 		};
 
+		struct cached_image_t
+		{
+			u64 key;
+			std::unique_ptr<vk::viewable_image> data;
+
+			cached_image_t() = default;
+			cached_image_t(u64 key_, std::unique_ptr<vk::viewable_image>& data_) :
+				key(key_), data(std::move(data_)) {}
+		};
+
 	public:
 		enum texture_create_flags : u32
 		{
@@ -384,7 +394,7 @@ namespace vk
 
 		//Stuff that has been dereferenced goes into these
 		const u32 max_cached_image_pool_size = 256;
-		std::deque<std::unique_ptr<vk::viewable_image>> m_cached_images;
+		std::deque<cached_image_t> m_cached_images;
 		atomic_t<u64> m_cached_memory_size = { 0 };
 		shared_mutex m_cached_pool_lock;
 


### PR DESCRIPTION
- Creating new images is expensive. We can keep around a set of images that have been recently discarded and use them instead of creating new ones from scratch each time. Gives a slight 2-5% performance boost in tested scenarios.
- Also fixes several bugs in the texture cache. An image cache existed before, but it was completely useless as the core did not dereference resources properly. The new mechanism introduces an ordered eviction queue, with oldest resources getting removed first to improve the hit-rate.
- Adds the disposable_t wrapper for the garbage collector which will be used to manage resources going forward. This migration will take place in the future, the old arrays of unique_ptr remain.
- Fixes a use-after-free inside the driver when closing native UI dialogs. Not sure how this managed to stay hidden for so long, I would have expected horrible crashes every time a save dialog was terminated.