### PR TITLE
rsx: Fix duplicate data removal checks in surface cache

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -772,7 +772,7 @@ namespace rsx
 
 				if (!valid)
 				{
-					rsx_log.error("Stale surface at address 0x%x will be deleted", it->base_address);
+					rsx_log.warning("Stale surface at address 0x%x will be deleted", it->base_address);
 					invalidate_surface_address(it->base_address, it->is_depth);
 				}
 			}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1928,7 +1928,7 @@ namespace rsx
 								if (const auto coverage_ratio = (coverage_size * 100ull) / memory_range.length();
 									coverage_ratio > max_overdraw_ratio)
 								{
-									rsx_log.error("[Performance warning] Texture gather routine encountered too many objects! Operation=%d, Mipmaps=%d, Depth=%d, Sections=%zu, Ratio=%llu%",
+									rsx_log.warning("[Performance warning] Texture gather routine encountered too many objects! Operation=%d, Mipmaps=%d, Depth=%d, Sections=%zu, Ratio=%llu%",
 										static_cast<int>(result.external_subresource_desc.op), attr.mipmaps, attr.depth, overlapping_fbos.size(), coverage_ratio);
 									m_rtts.check_for_duplicates(overlapping_fbos, memory_range);
 								}

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -786,7 +786,7 @@ void VKGSRender::emit_geometry(u32 sub_index)
 		if (occlusion_id == umax)
 		{
 			// Force flush
-			rsx_log.error("[Performance Warning] Out of free occlusion slots. Forcing hard sync.");
+			rsx_log.warning("[Performance Warning] Out of free occlusion slots. Forcing hard sync.");
 			ZCULL_control::sync(this);
 
 			occlusion_id = m_occlusion_query_manager->allocate_query(*m_current_command_buffer);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2473,7 +2473,7 @@ void VKGSRender::get_occlusion_query_result(rsx::reports::occlusion_query_info* 
 				m_flush_requests.clear_pending_flag();
 			}
 
-			rsx_log.error("[Performance warning] Unexpected ZCULL read caused a hard sync");
+			rsx_log.warning("[Performance warning] Unexpected ZCULL read caused a hard sync");
 			busy_wait();
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -303,7 +303,7 @@ namespace vk
 		{
 			if (src->format_class() == dst->format_class())
 			{
-				rsx_log.error("[Performance warning] Image copy requested incorrectly for matching formats.");
+				rsx_log.warning("[Performance warning] Image copy requested incorrectly for matching formats.");
 				copy_image(cmd, src, dst, src_rect, dst_rect, mipmaps, src_transfer_mask, dst_transfer_mask);
 				return;
 			}
@@ -417,7 +417,7 @@ namespace vk
 			src->format() != dst->format())
 		{
 			// Copying between two depth formats must match exactly or crashes will happen
-			rsx_log.error("[Performance warning] Image copy was requested incorrectly for mismatched depth formats");
+			rsx_log.warning("[Performance warning] Image copy was requested incorrectly for mismatched depth formats");
 			copy_image_typeless(cmd, src, dst, src_rect, dst_rect, mipmaps);
 			return;
 		}


### PR DESCRIPTION
Fix out-of-bounds access when tagging memory for duplicate removal. The algorithm needs to be moved to the GPU down the line to make use of hardware occlusion queries, but for now, let's also add some overrun cookie to ensure we're not corrupting the heap.

Fixes https://github.com/RPCS3/rpcs3/issues/11495
Fixes https://github.com/RPCS3/rpcs3/issues/11435