### PR TITLE
cellSaveData: Check filename format of savedata files

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -2102,7 +2102,7 @@ static NEVER_INLINE error_code savedata_get_list_item(vm::cptr<char> dirName, vm
 			size_kbytes += ::narrow<u32>((entry.size + 1023) / 1024); // firmware rounds this value up
 		}
 
-		*sizeKB = size_kbytes + 53;
+		*sizeKB = size_kbytes + 35;
 	}
 
 	if (bind)

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -651,6 +651,12 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			return 70;
 		}
 
+		if (file_path == "PARAM.SFO"sv || file_path == "PARAM.PFD"sv)
+		{
+			// ****** sysutil savedata parameter error : 70 ******
+			return 70;
+		}
+
 		char name[CELL_SAVEDATA_FILENAME_SIZE - 3];
 
 		if (dotpos)
@@ -668,11 +674,10 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				name[0] = '-';
 			}
 
-			if (disallow_system_files ? ((dotpos >= 5u && std::memcmp(name, "PARAM", 5) == 0) ||
+			if (disallow_system_files && ((dotpos >= 5u && std::memcmp(name, "PARAM", 5) == 0) ||
 				(dotpos >= 4u && std::memcmp(name, "ICON", 4) == 0) ||
 				(dotpos >= 3u && std::memcmp(name, "PIC", 3) == 0) ||
-				(dotpos >= 3u && std::memcmp(name, "SND", 3) == 0)) :
-				(entry.name == "PARAM.SFO"sv || entry.name == "PARAM.PFD"sv))
+				(dotpos >= 3u && std::memcmp(name, "SND", 3) == 0)))
 			{
 				// ****** sysutil savedata parameter error : 70 ******
 				return 70;

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -142,7 +142,7 @@ int check_filename(std::string_view file_path, bool disallow_system_files)
 		return 70;
 	}
 
-	if (file_path == "PARAM.SFO"sv || file_path == "PARAM.PFD"sv)
+	if (file_path == "."sv || file_path == "PARAM.SFO"sv || file_path == "PARAM.PFD"sv)
 	{
 		// ****** sysutil savedata parameter error : 70 ******
 		return 70;
@@ -1435,11 +1435,6 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			if (!entry.is_directory)
 			{
-				if (entry.name == "."sv)
-				{
-					continue;
-				}
-
 				if (check_filename(entry.name, false))
 				{
 					continue; // system files are not included in the file list
@@ -1660,7 +1655,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			// Read file into a vector and make a memory file
 			entry.name = vfs::unescape(entry.name);
 
-			if (entry.name == "." || check_filename(entry.name, false))
+			if (check_filename(entry.name, false))
 			{
 				continue;
 			}

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -120,7 +120,7 @@ struct savedata_manager
 	atomic_t<s32> last_cbresult_error_dialog{0}; // CBRESULT errors are negative
 };
 
-int check_filename(std::string_view file_path, bool disallow_system_files, account_sfo_pfd)
+int check_filename(std::string_view file_path, bool disallow_system_files, bool account_sfo_pfd)
 {
 	if (file_path.size() >= CELL_SAVEDATA_FILENAME_SIZE)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1729,7 +1729,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			if (int error = check_filename(file_path, true))
 			{
-				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "%d" ,error};
+				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "%d", error};
 				break;
 			}
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -2102,6 +2102,7 @@ static NEVER_INLINE error_code savedata_get_list_item(vm::cptr<char> dirName, vm
 			size_kbytes += ::narrow<u32>((entry.size + 1023) / 1024); // firmware rounds this value up
 		}
 
+		// Add a seemingly constant allocation disk space of PARAM.SFO + PARAM.PFD
 		*sizeKB = size_kbytes + 35;
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -695,7 +695,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		{
 			// Copy file extension
 			std::span dst(name, file_path.size() - dotpos);
-			strcpy_trunc(dst, file_path.operator std::string_view().substr(dotpos + 1));
+			strcpy_trunc(dst, file_path.substr(dotpos + 1));
 
 			// Allow '_' at start even though sysutil_check_name_string does not
 			if (name[0] == '_')

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1727,7 +1727,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 				break;
 			}
 
-			if (int error = check_filename(file_path, true))
+			if (int error = check_filename(file_path, true, false))
 			{
 				savedata_result = {CELL_SAVEDATA_ERROR_PARAM, "%d", error};
 				break;

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1440,7 +1440,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 					continue;
 				}
 
-				if (check_filename(vfs::unescape(entry.name), false))
+				if (check_filename(entry.name, false))
 				{
 					continue; // system files are not included in the file list
 				}
@@ -1660,7 +1660,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			// Read file into a vector and make a memory file
 			entry.name = vfs::unescape(entry.name);
 
-			if (entry.name == ".")
+			if (entry.name == "." || check_filename(entry.name, false))
 			{
 				continue;
 			}
@@ -2099,7 +2099,7 @@ static NEVER_INLINE error_code savedata_get_list_item(vm::cptr<char> dirName, vm
 
 		for (const auto& entry : fs::dir(save_path))
 		{
-			if (entry.is_directory)
+			if (entry.is_directory || check_filename(vfs::unescape(entry.name), false))
 			{
 				continue;
 			}


### PR DESCRIPTION
Offhanded yet loyal to proper PS3 emulation semantics fix for the problem mentioned in #11501. 
PS3 savedata filenaming format is fortunately pretty limited. Only uppercase A-Z, `_`, space, dot and `-` are allowed. And only if fitting the notorious 8.3 naming length constraints.