### PR TITLE
Don't define march=native for arm

### DIFF
--- a/buildfiles/cmake/ConfigureCompiler.cmake
+++ b/buildfiles/cmake/ConfigureCompiler.cmake
@@ -78,7 +78,7 @@ else()
 		add_compile_options(-Wno-class-memaccess)
 	endif()
 
-	if(USE_NATIVE_INSTRUCTIONS AND COMPILER_SUPPORTS_MARCH_NATIVE)
+	if(USE_NATIVE_INSTRUCTIONS AND COMPILER_SUPPORTS_MARCH_NATIVE AND NOT COMPILER_ARM)
 		add_compile_options(-march=native)
 	endif()
 


### PR DESCRIPTION
Atm cmake generates both -march=armv8.1-a and -march=native after which overrides the first and seems to limit the instruction set(neon intrinsics don't compile).