### PR TITLE
vk/dma: Initialize COW DMA block contents to avoid leaks

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -70,6 +70,14 @@ namespace vk
 			VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0,
 			VMM_ALLOCATION_POOL_UNDEFINED);
 
+		// Initialize memory contents. This isn't something that happens often.
+		// Pre-loading the contents helps to avoid leakage when mixed types of allocations are in use (NVIDIA)
+		// TODO: Fix memory lost when old object goes out of use with in-flight data.
+		auto dst = allocated_memory->map(0, size);
+		auto src = vm::get_super_ptr(base_address);
+		std::memcpy(dst, src, size);
+		allocated_memory->unmap();
+
 		s_allocated_dma_pool_size += allocated_memory->size();
 	}
 


### PR DESCRIPTION
It is possible to lose data when uploading since the result of map_dma can change types and handles. Not a problem when using passthrough DMA, but this extension does not work properly on NVIDIA + windows forcing us to fall back to mixed mode. When a copy-based slice takes over for a passthrough slice, leakage can occur. Simply initialize the block memory on creation instead of using uninitialized contents. It costs almost nothing and new blocks are spawned so rarely that it really shouldn't be a problem.

Fixes random weirdness on NVIDIA cards when running async texture streaming.