### PR TITLE
macOS: Add MoltenVK Semaphore setting and fix performance regression

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -9,7 +9,7 @@ export Qt5_DIR="/usr/local/Cellar/qt@5/5.15.2_1/lib/cmake/Qt5"
 export PATH="/usr/local/opt/llvm/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Library/Apple/usr/bin"
 export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
 export CPPFLAGS="-I/usr/local/opt/llvm/include -msse -msse2 -mcx16 -no-pie"
-export CXXFLAGS="-I/usr/local/opt/llvm/include -msse -msse2 -mcx16 -no-pie"
+export CPLUS_INCLUDE_PATH="/usr/local/opt/molten-vk/include"
 export VULKAN_SDK="/usr/local/opt/molten-vk"
 export VK_ICD_FILENAMES="$VULKAN_SDK/share/vulkan/icd.d/MoltenVK_icd.json"
 

--- a/rpcs3/Emu/RSX/VK/vkutils/instance.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/instance.hpp
@@ -150,6 +150,14 @@ namespace vk
 					extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 				}
 
+#ifdef __APPLE__
+				#define VK_MVK_MOLTENVK_EXTENSION_NAME "VK_MVK_moltenvk"
+				if (support.is_supported(VK_MVK_MOLTENVK_EXTENSION_NAME))
+				{
+					extensions.push_back(VK_MVK_MOLTENVK_EXTENSION_NAME);
+				}
+#endif
+
 				if (support.is_supported(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME))
 				{
 					extensions.push_back(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -169,6 +169,7 @@ struct cfg_root : cfg::node
 			cfg::_bool fsr_upscaling{ this, "Enable FidelityFX Super Resolution Upscaling", false, true };
 			cfg::uint<0, 100> rcas_sharpening_intensity{ this, "FidelityFX CAS Sharpening Intensity", 50, true };
 			cfg::_enum<vk_gpu_scheduler_mode> asynchronous_scheduler{ this, "Asynchronous Queue Scheduler", vk_gpu_scheduler_mode::safe };
+			cfg::_enum<vk_metal_semaphore_mode> metal_semaphore{ this, "Metal Semaphore", vk_metal_semaphore_mode::mtlevent_preferred };
 
 		} vk{ this };
 

--- a/rpcs3/Emu/system_config_types.cpp
+++ b/rpcs3/Emu/system_config_types.cpp
@@ -530,6 +530,23 @@ void fmt_class_string<vk_gpu_scheduler_mode>::format(std::string& out, u64 arg)
 }
 
 template <>
+void fmt_class_string<vk_metal_semaphore_mode>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](vk_metal_semaphore_mode value)
+	{
+		switch (value)
+		{
+		case vk_metal_semaphore_mode::software: return "Software emulation";
+		case vk_metal_semaphore_mode::mtlevent_preferred: return "MTLEvent preferred";
+		case vk_metal_semaphore_mode::mtlevent: return "MTLEvent";
+		case vk_metal_semaphore_mode::mtlfence: return "MTLFence";
+		}
+
+		return unknown;
+	});
+}
+
+template <>
 void fmt_class_string<thread_scheduler_mode>::format(std::string& out, u64 arg)
 {
 	format_enum(out, arg, [](thread_scheduler_mode value)

--- a/rpcs3/Emu/system_config_types.h
+++ b/rpcs3/Emu/system_config_types.h
@@ -232,6 +232,14 @@ enum class vk_gpu_scheduler_mode
 	fast
 };
 
+enum class vk_metal_semaphore_mode
+{
+	software,
+	mtlevent_preferred,
+	mtlevent,
+	mtlfence
+};
+
 enum class thread_scheduler_mode
 {
 	os,

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -1160,6 +1160,15 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 		case vk_gpu_scheduler_mode::fast: return tr("Fast");
 		}
 		break;
+	case emu_settings_type::MetalSemaphore:
+		switch (static_cast<vk_metal_semaphore_mode>(index))
+		{
+		case vk_metal_semaphore_mode::software: return tr("Software emulation");
+		case vk_metal_semaphore_mode::mtlevent_preferred: return tr("MTLEvent preferred");
+		case vk_metal_semaphore_mode::mtlevent: return tr("MTLEvent");
+		case vk_metal_semaphore_mode::mtlfence: return tr("MTLFence");
+		}
+		break;
 	default:
 		break;
 	}

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -90,6 +90,7 @@ enum class emu_settings_type
 	DriverWakeUpDelay,
 	VulkanAsyncTextureUploads,
 	VulkanAsyncSchedulerDriver,
+	MetalSemaphore,
 
 	// Performance Overlay
 	PerfOverlayEnabled,
@@ -252,6 +253,7 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::VulkanAsyncSchedulerDriver,       { "Video", "Vulkan", "Asynchronous Queue Scheduler"}},
 	{ emu_settings_type::FsrUpscalingEnable,               { "Video", "Vulkan", "Enable FidelityFX Super Resolution Upscaling"}},
 	{ emu_settings_type::FsrSharpeningStrength,            { "Video", "Vulkan", "FidelityFX CAS Sharpening Intensity"}},
+	{ emu_settings_type::MetalSemaphore,                   { "Video", "Vulkan", "Metal Semaphore"}},
 
 	// Performance Overlay
 	{ emu_settings_type::PerfOverlayEnabled,               { "Video", "Performance Overlay", "Enabled" } },

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1232,6 +1232,13 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceComboBox(ui->vulkansched, emu_settings_type::VulkanAsyncSchedulerDriver);
 	SubscribeTooltip(ui->gb_vulkansched, tooltips.settings.vulkan_async_scheduler);
 
+	m_emu_settings->EnhanceComboBox(ui->metalsemaphore, emu_settings_type::MetalSemaphore);
+#ifdef __APPLE__
+	SubscribeTooltip(ui->gb_metalsemaphore, tooltips.settings.metal_semaphore);
+#else
+	ui->metalsemaphore->setVisible(false);
+#endif
+
 	// Sliders
 
 	EnhanceSlider(emu_settings_type::DriverWakeUpDelay, ui->wakeupDelay, ui->wakeupText, tr(reinterpret_cast<const char*>(u8"%0 µs"), "Driver wake up delay"));

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -3905,6 +3905,24 @@
               </widget>
              </item>
              <item>
+              <widget class="QGroupBox" name="gb_metalsemaphore">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="title">
+                <string>Metal Semaphore</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_metalsemaphore_layout">
+                <item>
+                 <widget class="QComboBox" name="metalsemaphore"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
               <spacer name="verticalSpacerDebugMore">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -107,6 +107,7 @@ public:
 		const QString accurate_ppu_128_loop        = tr("When enabled, PPU atomic operations will operate on entire cache line data, as opposed to a single 64bit block of memory when disabled.\nNumerical values control whether or not to enable the accurate version based on the atomic operation's length.");
 		const QString enable_performance_report    = tr("Measure certain events and print a chart after the emulator is stopped. Don't enable if not asked to.");
 		const QString num_ppu_threads              = tr("Affects maximum amount of PPU threads running concurrently, the value of 1 has very low compatibility with games.\n2 is the default, if unsure do not modify this setting.");
+		const QString metal_semaphore              = tr("Determines how MoltenVK will simulate vkSemaphore on the Metal API.\nSoftware emulation is the slowest, but most accurate option. However, it can cause tearing.\nMTLEvent is faster, but not available under Rosetta (if MTLEvent preferred is selected, MTLFence is used; otherwise, emulation is used).\nMTLFence is faster than emulation, but can randomly cause synchronization issues.");
 
 		// emulator
 


### PR DESCRIPTION
Since MoltenVK 1.1.7, due to synchronization issues making API calls randomly inaccurate, software emulation is used to simulate vkSemaphore, rather than MTLFence, when running under Rosetta or on NVIDIA. Software emulation causes screen tearing and a huge performance loss compared to MTLFence, with no real benefits for RPCS3.

This PR changes the default behaviour to MTLEvent + MTLFence (the former takes priority when not running under Rosetta or on NVIDIA), and adds a new option in the Debug tab to let developers change it at runtime.

Note that when using the loader library (libvulkan.1.dylib) instead of directly loading MoltenVK (libMoltenVK.dylib), the configuration cannot be set at runtime and the ``MVK_ALLOW_METAL_EVENTS`` and/or ``MVK_ALLOW_METAL_FENCES`` environment variables must be manually set instead.