### PR TITLE
vk: Do not enable passthrough DMA unconditionally (yet)

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -641,6 +641,14 @@ VKGSRender::VKGSRender() : GSRender()
 			backend_config.supports_host_gpu_labels = false;
 		}
 	}
+
+	if (!backend_config.supports_host_gpu_labels &&
+		!backend_config.supports_asynchronous_compute)
+	{
+		// Disable passthrough DMA unless we enable a feature that requires it.
+		// I'm avoiding an explicit checkbox for this until I figure out why host labels don't fix all problems with passthrough.
+		backend_config.supports_passthrough_dma = false;
+	}
 }
 
 VKGSRender::~VKGSRender()


### PR DESCRIPTION
There are still some kinks to work out. Host labels do not fix all the bugs which means I missed something. Revert to old behavior for now.

Fixes https://github.com/RPCS3/rpcs3/issues/11571
Fixes https://github.com/RPCS3/rpcs3/issues/11573
Fixes https://github.com/RPCS3/rpcs3/issues/11574