### PR TITLE
Improve logging of LV2 objects creation

### DIFF
--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -10,6 +10,7 @@ enum class cpu_disasm_mode
 	normal,
 	compiler_elf,
 	list, // RSX exclusive
+	survey_cmd_size, // RSX exclusive
 };
 
 class cpu_thread;

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -892,6 +892,8 @@ u32* cpu_thread::get_pc2()
 	return nullptr;
 }
 
+std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu);
+
 std::string cpu_thread::dump_all() const
 {
 	std::string ret = cpu_thread::dump_misc();
@@ -901,6 +903,24 @@ std::string cpu_thread::dump_all() const
 	ret += dump_regs();
 	ret += '\n';
 	ret += dump_callstack();
+	ret += '\n';
+
+	if (u32 cur_pc = get_pc(); cur_pc != umax)
+	{
+		// Dump a snippet of currently executed code (may be unreliable with non-static-interpreter decoders)
+		auto disasm = make_disasm(this);
+
+		auto rsx = try_get<rsx::thread>();
+
+		for (u32 i = (rsx ? rsx->try_get_pc_of_x_cmds_backwards(10, cur_pc).second : cur_pc - 4 * 10), count = 0; count < 20; count++)
+		{
+			u32 advance = disasm->disasm(i);
+			ret += disasm->last_opcode;
+			i += std::max(advance, 4u);
+			disasm->dump_pc = i;
+			ret += '\n';
+		}
+	}
 
 	return ret;
 }

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -1146,7 +1146,7 @@ error_code cellGameGetParamString(s32 id, vm::ptr<char> buf, u32 bufsize)
 		return CELL_GAME_ERROR_NOTSUPPORTED;
 	}
 
-	const auto value = psf::get_string(perm.sfo, std::string(key.name));
+	const auto value = psf::get_string(perm.sfo, key.name);
 
 	if (value.empty() && !perm.sfo.count(std::string(key.name)))
 	{
@@ -1189,7 +1189,7 @@ error_code cellGameSetParamString(s32 id, vm::cptr<char> buf)
 		return CELL_GAME_ERROR_NOTSUPPORTED;
 	}
 
-	psf::assign(perm.sfo, std::string(key.name), psf::string(key.max_size, buf.get_ptr()));
+	psf::assign(perm.sfo, key.name, psf::string(key.max_size, buf.get_ptr()));
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -433,6 +433,7 @@ error_code sys_rsx_context_attribute(u32 context_id, u32 package_id, u64 a3, u64
 		const u64 get = static_cast<u32>(a3);
 		const u64 put = static_cast<u32>(a4);
 		vm::_ref<atomic_be_t<u64>>(render->dma_address + ::offset32(&RsxDmaControl::put)).release(put << 32 | get);
+		render->last_known_code_start = get;
 		render->sync_point_request.release(true);
 		render->unpause();
 		break;

--- a/rpcs3/Emu/RSX/RSXDisAsm.cpp
+++ b/rpcs3/Emu/RSX/RSXDisAsm.cpp
@@ -109,7 +109,7 @@ u32 RSXDisAsm::disasm(u32 pc)
 
 		pc += 4;
 
-		for (u32 i = 0; i < (m_mode == cpu_disasm_mode::list ? count : 1); i++, pc += 4)
+		for (u32 i = 0; i < count; i++, pc += 4)
 		{
 			if (!try_read_op(pc))
 			{
@@ -125,6 +125,16 @@ u32 RSXDisAsm::disasm(u32 pc)
 				last_opcode.clear();
 				Write("?? ??", -1);
 				return 4;
+			}
+
+			if (m_mode == cpu_disasm_mode::survey_cmd_size)
+			{
+				continue;
+			}
+
+			if (m_mode != cpu_disasm_mode::list && !last_opcode.empty())
+			{
+				continue;
 			}
 
 			std::string str = rsx::get_pretty_printing_function(id)(id, m_op);
@@ -145,7 +155,7 @@ std::unique_ptr<CPUDisAsm> RSXDisAsm::copy_type_erased() const
 	return std::make_unique<RSXDisAsm>(*this);
 }
 
-void RSXDisAsm::Write(const std::string& str, s32 count, bool is_non_inc, u32 id)
+void RSXDisAsm::Write(std::string_view str, s32 count, bool is_non_inc, u32 id)
 {
 	switch (m_mode)
 	{
@@ -156,8 +166,7 @@ void RSXDisAsm::Write(const std::string& str, s32 count, bool is_non_inc, u32 id
 
 		auto& res = last_opcode;
 
-		res.resize(7 + 11);
-		std::replace(res.begin(), res.end(), '\0', ' ');
+		res.resize(7 + 11, ' ');
 
 		res += str;
 		break;

--- a/rpcs3/Emu/RSX/RSXDisAsm.h
+++ b/rpcs3/Emu/RSX/RSXDisAsm.h
@@ -10,7 +10,7 @@ public:
 	}
 
 private:
-	void Write(const std::string& str, s32 count, bool is_non_inc = false, u32 id = 0);
+	void Write(std::string_view str, s32 count, bool is_non_inc = false, u32 id = 0);
 
 public:
 	u32 disasm(u32 pc) override;

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -6,6 +6,8 @@
 #include "Common/time.hpp"
 #include "Emu/Cell/lv2/sys_rsx.h"
 
+#include <bitset>
+
 namespace rsx
 {
 	namespace FIFO
@@ -38,10 +40,10 @@ namespace rsx
 			}
 		}
 
-		template <bool full>
+		template <bool Full>
 		inline u32 FIFO_control::read_put() const
 		{
-			if constexpr (!full)
+			if constexpr (!Full)
 			{
 				return m_ctrl->put & ~3;
 			}
@@ -56,9 +58,10 @@ namespace rsx
 			}
 		}
 
+		template <bool TestEqual>
 		void FIFO_control::set_get(u32 get)
 		{
-			if (m_ctrl->get == get)
+			if (TestEqual && m_ctrl->get == get)
 			{
 				if (const u32 addr = m_iotable->get_addr(m_memwatch_addr); addr + 1)
 				{
@@ -72,9 +75,6 @@ namespace rsx
 			// Update ctrl registers
 			m_ctrl->get.release(m_internal_get = get);
 			m_remaining_commands = 0;
-
-			// Clear memwatch spinner
-			m_memwatch_addr = 0;
 		}
 
 		bool FIFO_control::read_unsafe(register_pair& data)
@@ -430,9 +430,12 @@ namespace rsx
 			}
 
 			// Check for flow control
-			if ((cmd & RSX_METHOD_OLD_JUMP_CMD_MASK) == RSX_METHOD_OLD_JUMP_CMD)
+			if (std::bitset<2> jump_type; jump_type
+				.set(0, (cmd & RSX_METHOD_OLD_JUMP_CMD_MASK) == RSX_METHOD_OLD_JUMP_CMD)
+				.set(1, (cmd & RSX_METHOD_NEW_JUMP_CMD_MASK) == RSX_METHOD_NEW_JUMP_CMD)
+				.any())
 			{
-				const u32 offs = cmd & RSX_METHOD_OLD_JUMP_OFFSET_MASK;
+				const u32 offs = cmd & (jump_type.test(0) ? RSX_METHOD_OLD_JUMP_OFFSET_MASK : RSX_METHOD_NEW_JUMP_OFFSET_MASK);
 				if (offs == fifo_ctrl->get_pos())
 				{
 					//Jump to self. Often preceded by NOP
@@ -444,28 +447,13 @@ namespace rsx
 
 					performance_counters.state = FIFO_state::spinning;
 				}
-
-				//rsx_log.warning("rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", offs, m_ioAddress + get, cmd, get, put);
-				fifo_ctrl->set_get(offs);
-				return;
-			}
-			if ((cmd & RSX_METHOD_NEW_JUMP_CMD_MASK) == RSX_METHOD_NEW_JUMP_CMD)
-			{
-				const u32 offs = cmd & RSX_METHOD_NEW_JUMP_OFFSET_MASK;
-				if (offs == fifo_ctrl->get_pos())
+				else
 				{
-					//Jump to self. Often preceded by NOP
-					if (performance_counters.state == FIFO_state::running)
-					{
-						performance_counters.FIFO_idle_timestamp = rsx::uclock();
-						sync_point_request.release(true);
-					}
-
-					performance_counters.state = FIFO_state::spinning;
+					last_known_code_start = offs;
 				}
 
 				//rsx_log.warning("rsx jump(0x%x) #addr=0x%x, cmd=0x%x, get=0x%x, put=0x%x", offs, m_ioAddress + get, cmd, get, put);
-				fifo_ctrl->set_get(offs);
+				fifo_ctrl->set_get<true>(offs);
 				return;
 			}
 			if ((cmd & RSX_METHOD_CALL_CMD_MASK) == RSX_METHOD_CALL_CMD)
@@ -481,6 +469,7 @@ namespace rsx
 				const u32 offs = cmd & RSX_METHOD_CALL_OFFSET_MASK;
 				fifo_ret_addr = fifo_ctrl->get_pos() + 4;
 				fifo_ctrl->set_get(offs);
+				last_known_code_start = offs;
 				return;
 			}
 			if ((cmd & RSX_METHOD_RETURN_MASK) == RSX_METHOD_RETURN_CMD)
@@ -493,6 +482,7 @@ namespace rsx
 				}
 
 				fifo_ctrl->set_get(std::exchange(fifo_ret_addr, RSX_CALL_STACK_EMPTY));
+				last_known_code_start = ctrl->get;
 				return;
 			}
 

--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -134,6 +134,8 @@ namespace rsx
 			u32 get_current_arg_ptr() const { return m_args_ptr; }
 			u32 get_remaining_args_count() const { return m_remaining_commands; }
 			void inc_get(bool wait);
+
+			template <bool = false>
 			void set_get(u32 get);
 			void abort();
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -11,6 +11,7 @@
 #include "Capture/rsx_capture.h"
 #include "rsx_methods.h"
 #include "gcm_printing.h"
+#include "RSXDisAsm.h"
 #include "Emu/Cell/lv2/sys_event.h"
 #include "Emu/Cell/lv2/sys_time.h"
 #include "Emu/Cell/Modules/cellGcmSys.h"
@@ -2622,6 +2623,63 @@ namespace rsx
 	{
 		// Make sure GET value is exposed before sync points
 		fifo_ctrl->sync_get();
+	}
+
+	std::pair<u32, u32> thread::try_get_pc_of_x_cmds_backwards(u32 count, u32 get) const
+	{
+		if (!ctrl)
+		{
+			return {0, umax};
+		}
+
+		if (!count)
+		{
+			return {0, get};
+		}
+
+		u32 true_get = ctrl->get;
+		u32 start = last_known_code_start;
+
+		RSXDisAsm disasm(cpu_disasm_mode::survey_cmd_size, vm::g_sudo_addr, 0, this);
+
+		std::vector<u32> pcs_of_valid_cmds;
+		pcs_of_valid_cmds.reserve(std::min<u32>((get - start) / 16, 0x4000)); // Rough estimation of final array size
+
+		auto probe_code_region = [&](u32 probe_start) -> std::pair<u32, u32>
+		{
+			pcs_of_valid_cmds.clear();
+			pcs_of_valid_cmds.push_back(probe_start);
+
+			while (pcs_of_valid_cmds.back() < get)
+			{
+				if (u32 advance = disasm.disasm(pcs_of_valid_cmds.back()))
+				{
+					pcs_of_valid_cmds.push_back(pcs_of_valid_cmds.back() + advance);
+				}
+				else
+				{
+					return {0, umax};
+				}
+			}
+
+			if (pcs_of_valid_cmds.size() == 1u || pcs_of_valid_cmds.back() != get)
+			{
+				return {0, umax};
+			}
+
+			u32 found_cmds_count = std::min(count, ::size32(pcs_of_valid_cmds) - 1);
+
+			return {found_cmds_count, *(pcs_of_valid_cmds.end() - 1 - found_cmds_count)};
+		};
+
+		auto pair = probe_code_region(start);
+
+		if (!pair.first)
+		{
+			pair = probe_code_region(true_get);
+		}
+
+		return pair;
 	}
 
 	void thread::recover_fifo(u32 line, u32 col, const char* file, const char* func)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2658,13 +2658,13 @@ namespace rsx
 				}
 				else
 				{
-					return {0, umax};
+					return {0, get};
 				}
 			}
 
 			if (pcs_of_valid_cmds.size() == 1u || pcs_of_valid_cmds.back() != get)
 			{
-				return {0, umax};
+				return {0, get};
 			}
 
 			u32 found_cmds_count = std::min(count, ::size32(pcs_of_valid_cmds) - 1);

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -654,11 +654,15 @@ namespace rsx
 		rsx_iomap_table iomap_table;
 		u32 restore_point = 0;
 		u32 dbg_step_pc = 0;
+		u32 last_known_code_start = 0;
 		atomic_t<u32> external_interrupt_lock{ 0 };
 		atomic_t<bool> external_interrupt_ack{ false };
 		atomic_t<bool> is_inited{ false };
 		bool is_fifo_idle() const;
 		void flush_fifo();
+
+		// Returns [count of found commands, PC of their start]
+		std::pair<u32, u32> try_get_pc_of_x_cmds_backwards(u32 count, u32 get) const;
 
 		void recover_fifo(u32 line = __builtin_LINE(),
 			u32 col = __builtin_COLUMN(),

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -339,7 +339,7 @@ namespace psf
 		return std::move(static_cast<fs::container_stream<std::vector<u8>>*>(stream.release().get())->obj);
 	}
 
-	std::string_view get_string(const registry& psf, const std::string& key, std::string_view def)
+	std::string_view get_string(const registry& psf, std::string_view key, std::string_view def)
 	{
 		const auto found = psf.find(key);
 
@@ -351,7 +351,7 @@ namespace psf
 		return found->second.as_string();
 	}
 
-	u32 get_integer(const registry& psf, const std::string& key, u32 def)
+	u32 get_integer(const registry& psf, std::string_view key, u32 def)
 	{
 		const auto found = psf.find(key);
 

--- a/rpcs3/Loader/PSF.h
+++ b/rpcs3/Loader/PSF.h
@@ -55,7 +55,7 @@ namespace psf
 	};
 
 	// Define PSF registry as a sorted map of entries:
-	using registry = std::map<std::string, entry>;
+	using registry = std::map<std::string, entry, std::less<>>;
 
 	struct load_result_t
 	{
@@ -77,13 +77,13 @@ namespace psf
 	std::vector<u8> save_object(const registry&, std::vector<u8>&& init = std::vector<u8>{});
 
 	// Get string value or default value
-	std::string_view get_string(const registry& psf, const std::string& key, std::string_view def = ""sv);
+	std::string_view get_string(const registry& psf, std::string_view key, std::string_view def = ""sv);
 
 	// Get integer value or default value
-	u32 get_integer(const registry& psf, const std::string& key, u32 def = 0);
+	u32 get_integer(const registry& psf, std::string_view key, u32 def = 0);
 
 	// Assign new entry
-	inline void assign(registry& psf, const std::string& key, entry&& _entry)
+	inline void assign(registry& psf, std::string_view key, entry&& _entry)
 	{
 		const auto found = psf.find(key);
 

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -50,6 +50,17 @@ extern bool is_using_interpreter(u32 id_type)
 	}
 }
 
+extern std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu)
+{
+	switch (cpu->id_type())
+	{
+	case 1: return std::make_shared<PPUDisAsm>(cpu_disasm_mode::interpreter, vm::g_sudo_addr);
+	case 2: return std::make_shared<SPUDisAsm>(cpu_disasm_mode::interpreter, static_cast<const spu_thread*>(cpu)->ls);
+	case 0x55: return std::make_shared<RSXDisAsm>(cpu_disasm_mode::interpreter, vm::g_sudo_addr, 0, cpu);
+	default: return nullptr;
+	}
+}
+
 debugger_frame::debugger_frame(std::shared_ptr<gui_settings> gui_settings, QWidget *parent)
 	: custom_dock_widget(tr("Debugger"), parent)
 	, m_gui_settings(std::move(gui_settings))
@@ -895,7 +906,7 @@ void debugger_frame::OnSelectUnit()
 
 			if (selected == m_cpu.get())
 			{
-				m_disasm = std::make_shared<PPUDisAsm>(cpu_disasm_mode::interpreter, vm::g_sudo_addr);
+				m_disasm = make_disasm(selected);
 			}
 			else
 			{
@@ -911,7 +922,7 @@ void debugger_frame::OnSelectUnit()
 
 			if (selected == m_cpu.get())
 			{
-				m_disasm = std::make_shared<SPUDisAsm>(cpu_disasm_mode::interpreter, static_cast<const spu_thread*>(m_cpu.get())->ls);
+				m_disasm = make_disasm(selected);
 			}
 			else
 			{
@@ -927,7 +938,7 @@ void debugger_frame::OnSelectUnit()
 
 			if (get_cpu())
 			{
-				m_disasm = std::make_shared<RSXDisAsm>(cpu_disasm_mode::interpreter, vm::g_sudo_addr, 0, m_rsx);
+				m_disasm = make_disasm(m_rsx);
 			}
 
 			break;

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -8,6 +8,7 @@
 #include "Emu/CPU/CPUDisAsm.h"
 #include "Emu/CPU/CPUThread.h"
 #include "Emu/RSX/RSXDisAsm.h"
+#include "Emu/RSX/RSXThread.h"
 #include "Emu/System.h"
 
 #include <QMouseEvent>
@@ -162,6 +163,16 @@ void debugger_list::scroll(s32 steps)
 		// Backwards is impossible though
 		m_pc += std::max<u32>(m_disasm->disasm(m_pc), 4);
 		steps--;
+	}
+
+	if (m_cpu && m_cpu->id_type() == 0x55 && steps < 0)
+	{
+		// If scrolling backwards (upwards), try to obtain the start of commands tail 
+		if (auto [count, res] = static_cast<rsx::thread*>(m_cpu)->try_get_pc_of_x_cmds_backwards(-steps, m_pc); count == -steps)
+		{
+			steps = 0;
+			m_pc = res;
+		}
 	}
 
 	ShowAddress(m_pc + (steps * 4), false, true);


### PR DESCRIPTION
Append the IDs of the created LV2 objects to the syscall which constructs them.
