### PR TITLE
rsx: Downgrade depth-1 3D images to 2D

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2092,20 +2092,6 @@ namespace rsx
 
 			switch (extended_dimension)
 			{
-			case rsx::texture_dimension_extended::texture_dimension_1d:
-				attributes.depth = 1;
-				attributes.height = 1;
-				attributes.slice_h = 1;
-				scale.height = scale.depth = 0.f;
-				subsurface_count = 1;
-				required_surface_height = 1;
-				break;
-			case rsx::texture_dimension_extended::texture_dimension_2d:
-				attributes.depth = 1;
-				scale.depth = 0.f;
-				subsurface_count = options.is_compressed_format? 1 : tex.get_exact_mipmap_count();
-				attributes.slice_h = required_surface_height = attributes.height;
-				break;
 			case rsx::texture_dimension_extended::texture_dimension_cubemap:
 				attributes.depth = 6;
 				subsurface_count = 1;
@@ -2115,10 +2101,33 @@ namespace rsx
 				break;
 			case rsx::texture_dimension_extended::texture_dimension_3d:
 				attributes.depth = tex.depth();
+				if (attributes.depth > 1)
+				{
+					subsurface_count = 1;
+					tex_size = static_cast<u32>(get_texture_size(tex));
+					required_surface_height = tex_size / attributes.pitch;
+					attributes.slice_h = required_surface_height / attributes.depth;
+					break;
+				}
+				else
+				{
+					// Downgrade to 2D
+					extended_dimension = rsx::texture_dimension_extended::texture_dimension_2d;
+					[[ fallthrough ]];
+				}
+			case rsx::texture_dimension_extended::texture_dimension_2d:
+				attributes.depth = 1;
+				scale.depth = 0.f;
+				subsurface_count = options.is_compressed_format? 1 : tex.get_exact_mipmap_count();
+				attributes.slice_h = required_surface_height = attributes.height;
+				break;
+			case rsx::texture_dimension_extended::texture_dimension_1d:
+				attributes.depth = 1;
+				attributes.height = 1;
+				attributes.slice_h = 1;
+				scale.height = scale.depth = 0.f;
 				subsurface_count = 1;
-				tex_size = static_cast<u32>(get_texture_size(tex));
-				required_surface_height = tex_size / attributes.pitch;
-				attributes.slice_h = required_surface_height / attributes.depth;
+				required_surface_height = 1;
 				break;
 			default:
 				fmt::throw_exception("Unsupported texture dimension %d", static_cast<int>(extended_dimension));

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2109,12 +2109,9 @@ namespace rsx
 					attributes.slice_h = required_surface_height / attributes.depth;
 					break;
 				}
-				else
-				{
-					// Downgrade to 2D
-					extended_dimension = rsx::texture_dimension_extended::texture_dimension_2d;
-					[[ fallthrough ]];
-				}
+				// Downgrade to 2D
+				extended_dimension = rsx::texture_dimension_extended::texture_dimension_2d;
+				[[ fallthrough ]];
 			case rsx::texture_dimension_extended::texture_dimension_2d:
 				attributes.depth = 1;
 				scale.depth = 0.f;

--- a/rpcs3/Emu/RSX/VK/vkutils/image.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.cpp
@@ -24,6 +24,7 @@ namespace vk
 			dim_limit = (info.flags == VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ? gpu_limits.maxImageDimensionCube : gpu_limits.maxImageDimension2D;
 			break;
 		case VK_IMAGE_TYPE_3D:
+			ensure(info.extent.depth > 1);
 			longest_dim = std::max({ info.extent.width, info.extent.height, info.extent.depth });
 			dim_limit = gpu_limits.maxImageDimension3D;
 			break;


### PR DESCRIPTION
Fixes problems with implicit view types derived from image dimensions.