### PR TITLE
vk: Encode view type when caching images

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2092,6 +2092,20 @@ namespace rsx
 
 			switch (extended_dimension)
 			{
+			case rsx::texture_dimension_extended::texture_dimension_1d:
+				attributes.depth = 1;
+				attributes.height = 1;
+				attributes.slice_h = 1;
+				scale.height = scale.depth = 0.f;
+				subsurface_count = 1;
+				required_surface_height = 1;
+				break;
+			case rsx::texture_dimension_extended::texture_dimension_2d:
+				attributes.depth = 1;
+				scale.depth = 0.f;
+				subsurface_count = options.is_compressed_format? 1 : tex.get_exact_mipmap_count();
+				attributes.slice_h = required_surface_height = attributes.height;
+				break;
 			case rsx::texture_dimension_extended::texture_dimension_cubemap:
 				attributes.depth = 6;
 				subsurface_count = 1;
@@ -2101,30 +2115,10 @@ namespace rsx
 				break;
 			case rsx::texture_dimension_extended::texture_dimension_3d:
 				attributes.depth = tex.depth();
-				if (attributes.depth > 1)
-				{
-					subsurface_count = 1;
-					tex_size = static_cast<u32>(get_texture_size(tex));
-					required_surface_height = tex_size / attributes.pitch;
-					attributes.slice_h = required_surface_height / attributes.depth;
-					break;
-				}
-				// Downgrade to 2D
-				extended_dimension = rsx::texture_dimension_extended::texture_dimension_2d;
-				[[ fallthrough ]];
-			case rsx::texture_dimension_extended::texture_dimension_2d:
-				attributes.depth = 1;
-				scale.depth = 0.f;
-				subsurface_count = options.is_compressed_format? 1 : tex.get_exact_mipmap_count();
-				attributes.slice_h = required_surface_height = attributes.height;
-				break;
-			case rsx::texture_dimension_extended::texture_dimension_1d:
-				attributes.depth = 1;
-				attributes.height = 1;
-				attributes.slice_h = 1;
-				scale.height = scale.depth = 0.f;
 				subsurface_count = 1;
-				required_surface_height = 1;
+				tex_size = static_cast<u32>(get_texture_size(tex));
+				required_surface_height = tex_size / attributes.pitch;
+				attributes.slice_h = required_surface_height / attributes.depth;
 				break;
 			default:
 				fmt::throw_exception("Unsupported texture dimension %d", static_cast<int>(extended_dimension));

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -7,14 +7,25 @@
 
 namespace vk
 {
-	u64 hash_image_properties(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkImageCreateFlags create_flags)
+	u64 hash_image_properties(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkImageType type, VkImageCreateFlags create_flags)
 	{
+		/**
+		* Key layout:
+		* 00-08: Format  (Max 255)
+		* 08-24: Width   (Max 64K)
+		* 24-40: Height  (Max 64K)
+		* 40-48: Depth   (Max 255)
+		* 48-54: Mipmaps (Max 63)   <- We have some room here, it is not possible to have more than 12 mip levels on PS3 and 16 on PC is pushing it.
+		* 54-56: Type    (Max 3)
+		* 56-64: Flags   (Max 255)  <- We have some room here, we only care about a small subset of create flags.
+		*/
 		ensure(static_cast<u32>(format) < 0xFF);
 		return (static_cast<u64>(format) & 0xFF) |
 			(static_cast<u64>(w) << 8) |
 			(static_cast<u64>(h) << 24) |
 			(static_cast<u64>(d) << 40) |
 			(static_cast<u64>(mipmaps) << 48) |
+			(static_cast<u64>(type) << 54) |
 			(static_cast<u64>(create_flags) << 56);
 	}
 
@@ -33,7 +44,7 @@ namespace vk
 		data->current_queue_family = VK_QUEUE_FAMILY_IGNORED;
 
 		// Move this object to the cached image pool
-		const auto key = hash_image_properties(data->format(), data->width(), data->height(), data->depth(), data->mipmaps(), data->info.flags);
+		const auto key = hash_image_properties(data->format(), data->width(), data->height(), data->depth(), data->mipmaps(), data->info.imageType, data->info.flags);
 		std::lock_guard lock(parent->m_cached_pool_lock);
 
 		if (!parent->m_cache_is_exiting)
@@ -495,13 +506,13 @@ namespace vk
 		return result;
 	}
 
-	std::unique_ptr<vk::viewable_image> texture_cache::find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkImageCreateFlags create_flags, VkImageUsageFlags usage)
+	std::unique_ptr<vk::viewable_image> texture_cache::find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkImageType type, VkImageCreateFlags create_flags, VkImageUsageFlags usage)
 	{
 		reader_lock lock(m_cached_pool_lock);
 
 		if (!m_cached_images.empty())
 		{
-			const u64 desired_key = hash_image_properties(format, w, h, d, mipmaps, create_flags);
+			const u64 desired_key = hash_image_properties(format, w, h, d, mipmaps, type, create_flags);
 			lock.upgrade();
 
 			for (auto it = m_cached_images.begin(); it != m_cached_images.end(); ++it)
@@ -527,7 +538,7 @@ namespace vk
 		const VkFormat dst_format = vk::get_compatible_sampler_format(m_formats_support, gcm_format);
 		const u16 layers = (view_type == VK_IMAGE_VIEW_TYPE_CUBE) ? 6 : 1;
 
-		auto image = find_cached_image(dst_format, w, h, d, mips, image_flags, usage_flags);
+		auto image = find_cached_image(dst_format, w, h, d, mips, image_type, image_flags, usage_flags);
 
 		if (!image)
 		{
@@ -851,7 +862,7 @@ namespace vk
 			const VkFormat vk_format = get_compatible_sampler_format(m_formats_support, gcm_format);
 			const VkImageCreateFlags create_flags = is_cubemap ? VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT : 0;
 
-			if (auto found = find_cached_image(vk_format, width, height, depth, mipmaps, create_flags, usage_flags))
+			if (auto found = find_cached_image(vk_format, width, height, depth, mipmaps, image_type, create_flags, usage_flags))
 			{
 				image = found.release();
 			}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -410,7 +410,7 @@ namespace vk
 
 		vk::image* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const;
 
-		std::unique_ptr<vk::viewable_image> find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkImageCreateFlags create_flags, VkImageUsageFlags usage);
+		std::unique_ptr<vk::viewable_image> find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkImageType type, VkImageCreateFlags create_flags, VkImageUsageFlags usage);
 
 	protected:
 		vk::image_view* create_temporary_subresource_view_impl(vk::command_buffer& cmd, vk::image* source, VkImageType image_type, VkImageViewType view_type,

--- a/rpcs3/Emu/RSX/VK/vkutils/image.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.cpp
@@ -24,7 +24,6 @@ namespace vk
 			dim_limit = (info.flags == VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ? gpu_limits.maxImageDimensionCube : gpu_limits.maxImageDimension2D;
 			break;
 		case VK_IMAGE_TYPE_3D:
-			ensure(info.extent.depth > 1);
 			longest_dim = std::max({ info.extent.width, info.extent.height, info.extent.depth });
 			dim_limit = gpu_limits.maxImageDimension3D;
 			break;


### PR DESCRIPTION
Fixes mismatched image type lookups that can cause flickering. While auto-downgrading also works, it may break games that rely on bad behavior on real hardware, so let's just let the games decide what they want to do.