### PR TITLE
rsx: Surface cache optimizations and other improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/profiling_timer.hpp
+++ b/rpcs3/Emu/RSX/Common/profiling_timer.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <util/types.hpp>
+#include "time.hpp"
 
 namespace rsx
 {
 	struct profiling_timer
 	{
 		bool enabled = false;
-		steady_clock::time_point last;
+		u64 last;
 
 		profiling_timer() = default;
 
@@ -15,7 +16,7 @@ namespace rsx
 		{
 			if (enabled) [[unlikely]]
 			{
-				last = steady_clock::now();
+				last = rsx::uclock();
 			}
 		}
 
@@ -27,8 +28,8 @@ namespace rsx
 			}
 
 			auto old = last;
-			last = steady_clock::now();
-			return std::chrono::duration_cast<std::chrono::microseconds>(last - old).count();
+			last = rsx::uclock();
+			return static_cast<s64>(last - old);
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -721,9 +721,9 @@ namespace rsx
 				auto this_range = it->surface->get_memory_range();
 				ensure(this_range.overlaps(range));
 
-				const auto native_pitch = it->surface->get_surface_width(rsx::surface_metrics::bytes);
+				const auto native_pitch = it->surface->get_surface_width<rsx::surface_metrics::bytes>();
 				const auto rsx_pitch = it->surface->get_rsx_pitch();
-				auto num_rows = it->surface->get_surface_height(rsx::surface_metrics::samples);
+				auto num_rows = it->surface->get_surface_height<rsx::surface_metrics::samples>();
 				bool valid = false;
 
 				if (this_range.start < range.start)
@@ -1002,8 +1002,8 @@ namespace rsx
 					info.base_address = range.start;
 					info.is_depth = is_depth;
 
-					const u32 normalized_surface_width = surface->get_surface_width(rsx::surface_metrics::bytes) / required_bpp;
-					const u32 normalized_surface_height = surface->get_surface_height(rsx::surface_metrics::samples);
+					const u32 normalized_surface_width = surface->get_surface_width<rsx::surface_metrics::bytes>() / required_bpp;
+					const u32 normalized_surface_height = surface->get_surface_height<rsx::surface_metrics::samples>();
 
 					if (range.start >= texaddr) [[likely]]
 					{

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -190,7 +190,7 @@ namespace rsx
 				copy.dst_x = 0;
 				copy.dst_y = 0;
 				copy.width = std::max<u16>((old.width - _new.width) / bytes_to_texels_x, 1);
-				copy.height = prev_surface->template get_surface_height();
+				copy.height = prev_surface->template get_surface_height<>();
 				copy.transfer_scale_x = 1.f;
 				copy.transfer_scale_y = 1.f;
 				copy.target = nullptr;
@@ -612,7 +612,7 @@ namespace rsx
 				}
 
 				if (it->surface->get_rsx_pitch() != it->surface->get_native_pitch() &&
-					it->surface->template get_surface_height() != 1)
+					it->surface->template get_surface_height<>() != 1)
 				{
 					// Memory gap in descriptor
 					continue;

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -190,7 +190,7 @@ namespace rsx
 				copy.dst_x = 0;
 				copy.dst_y = 0;
 				copy.width = std::max<u16>((old.width - _new.width) / bytes_to_texels_x, 1);
-				copy.height = prev_surface->get_surface_height();
+				copy.height = prev_surface->template get_surface_height();
 				copy.transfer_scale_x = 1.f;
 				copy.transfer_scale_y = 1.f;
 				copy.target = nullptr;
@@ -612,7 +612,7 @@ namespace rsx
 				}
 
 				if (it->surface->get_rsx_pitch() != it->surface->get_native_pitch() &&
-					it->surface->get_surface_height() != 1)
+					it->surface->template get_surface_height() != 1)
 				{
 					// Memory gap in descriptor
 					continue;
@@ -721,9 +721,9 @@ namespace rsx
 				auto this_range = it->surface->get_memory_range();
 				ensure(this_range.overlaps(range));
 
-				const auto native_pitch = it->surface->get_surface_width<rsx::surface_metrics::bytes>();
+				const auto native_pitch = it->surface->template get_surface_width<rsx::surface_metrics::bytes>();
 				const auto rsx_pitch = it->surface->get_rsx_pitch();
-				auto num_rows = it->surface->get_surface_height<rsx::surface_metrics::samples>();
+				auto num_rows = it->surface->template get_surface_height<rsx::surface_metrics::samples>();
 				bool valid = false;
 
 				if (this_range.start < range.start)
@@ -1002,8 +1002,8 @@ namespace rsx
 					info.base_address = range.start;
 					info.is_depth = is_depth;
 
-					const u32 normalized_surface_width = surface->get_surface_width<rsx::surface_metrics::bytes>() / required_bpp;
-					const u32 normalized_surface_height = surface->get_surface_height<rsx::surface_metrics::samples>();
+					const u32 normalized_surface_width = surface->template get_surface_width<rsx::surface_metrics::bytes>() / required_bpp;
+					const u32 normalized_surface_height = surface->template get_surface_height<rsx::surface_metrics::samples>();
 
 					if (range.start >= texaddr) [[likely]]
 					{

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -94,12 +94,12 @@ namespace rsx
 					auto src = static_cast<T>(source);
 
 					std::tie(src_w, src_h) = rsx::apply_resolution_scale<true>(src_w, src_h,
-						src->get_surface_width<rsx::surface_metrics::pixels>(),
-						src->get_surface_height<rsx::surface_metrics::pixels>());
+						src->template get_surface_width<rsx::surface_metrics::pixels>(),
+						src->template get_surface_height<rsx::surface_metrics::pixels>());
 
 					std::tie(dst_w, dst_h) = rsx::apply_resolution_scale<true>(dst_w, dst_h,
-						target_surface->get_surface_width<rsx::surface_metrics::pixels>()),
-						target_surface->get_surface_height<rsx::surface_metrics::pixels>()));
+						target_surface->template get_surface_width<rsx::surface_metrics::pixels>(),
+						target_surface->template get_surface_height<rsx::surface_metrics::pixels>());
 				}
 
 				width = src_w;
@@ -181,27 +181,42 @@ namespace rsx
 		template<rsx::surface_metrics Metrics = rsx::surface_metrics::pixels>
 		u32 get_surface_width() const
 		{
-			switch constexpr (Metrics)
+			if constexpr (Metrics == rsx::surface_metrics::samples)
 			{
-				case rsx::surface_metrics::samples:
-					return surface_width * samples_x;
-				case rsx::surface_metrics::pixels:
-					return surface_width;
-				case rsx::surface_metrics::bytes:
-					return native_pitch;
+				return surface_width * samples_x;
+			}
+			else if constexpr (Metrics == rsx::surface_metrics::pixels)
+			{
+				return surface_width;
+			}
+			else if constexpr (Metrics == rsx::surface_metrics::bytes)
+			{
+				return native_pitch;
+			}
+			else
+			{
+				static_assert(false);
 			}
 		}
 
 		template<rsx::surface_metrics Metrics = rsx::surface_metrics::pixels>
 		u32 get_surface_height() const
 		{
-			switch constexpr (Metrics)
+			if constexpr (Metrics == rsx::surface_metrics::samples)
 			{
-				case rsx::surface_metrics::samples:
-				case rsx::surface_metrics::bytes:
-					return surface_height * samples_y;
-				case rsx::surface_metrics::pixels:
-					return surface_height;
+				return surface_height * samples_y;
+			}
+			else if constexpr (Metrics == rsx::surface_metrics::pixels)
+			{
+				return surface_height;
+			}
+			else if constexpr (Metrics == rsx::surface_metrics::bytes)
+			{
+				return surface_height * samples_y;
+			}
+			else
+			{
+				static_assert(false);
 			}
 		}
 
@@ -614,7 +629,7 @@ namespace rsx
 
 		inline rsx::address_range get_memory_range() const
 		{
-			const u32 internal_height = get_surface_height<rsx::surface_metrics::samples>());
+			const u32 internal_height = get_surface_height<rsx::surface_metrics::samples>();
 			const u32 excess = (rsx_pitch - native_pitch);
 			return rsx::address_range::start_length(base_addr, internal_height * rsx_pitch - excess);
 		}

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -178,7 +178,7 @@ namespace rsx
 		virtual bool is_depth_surface() const = 0;
 		virtual void release_ref(image_storage_type) const = 0;
 
-		virtual u32 get_surface_width(rsx::surface_metrics metrics = rsx::surface_metrics::pixels) const
+		inline u32 get_surface_width(rsx::surface_metrics metrics = rsx::surface_metrics::pixels) const
 		{
 			switch (metrics)
 			{
@@ -193,7 +193,7 @@ namespace rsx
 			}
 		}
 
-		virtual u32 get_surface_height(rsx::surface_metrics metrics = rsx::surface_metrics::pixels) const
+		inline u32 get_surface_height(rsx::surface_metrics metrics = rsx::surface_metrics::pixels) const
 		{
 			switch (metrics)
 			{
@@ -207,22 +207,22 @@ namespace rsx
 			}
 		}
 
-		virtual u32 get_rsx_pitch() const
+		inline u32 get_rsx_pitch() const
 		{
 			return rsx_pitch;
 		}
 
-		virtual u32 get_native_pitch() const
+		inline u32 get_native_pitch() const
 		{
 			return native_pitch;
 		}
 
-		u8 get_bpp() const
+		inline u8 get_bpp() const
 		{
 			return u8(get_native_pitch() / get_surface_width(rsx::surface_metrics::samples));
 		}
 
-		u8 get_spp() const
+		inline u8 get_spp() const
 		{
 			return spp;
 		}
@@ -278,17 +278,17 @@ namespace rsx
 			format_info.gcm_depth_format = format;
 		}
 
-		rsx::surface_color_format get_surface_color_format() const
+		inline rsx::surface_color_format get_surface_color_format() const
 		{
 			return format_info.gcm_color_format;
 		}
 
-		rsx::surface_depth_format2 get_surface_depth_format() const
+		inline rsx::surface_depth_format2 get_surface_depth_format() const
 		{
 			return format_info.gcm_depth_format;
 		}
 
-		u32 get_gcm_format() const
+		inline u32 get_gcm_format() const
 		{
 			return
 			(
@@ -298,12 +298,12 @@ namespace rsx
 			);
 		}
 
-		bool dirty() const
+		inline bool dirty() const
 		{
 			return (state_flags != rsx::surface_state_flags::ready) || !old_contents.empty();
 		}
 
-		bool write_through() const
+		inline bool write_through() const
 		{
 			return (state_flags & rsx::surface_state_flags::erase_bkgnd) && old_contents.empty();
 		}

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -197,7 +197,7 @@ namespace rsx
 			}
 			else
 			{
-				static_assert(false);
+				fmt::throw_exception("Unreachable");
 			}
 		}
 
@@ -218,7 +218,7 @@ namespace rsx
 			}
 			else
 			{
-				static_assert(false);
+				fmt::throw_exception("Unreachable");
 			}
 		}
 
@@ -543,8 +543,8 @@ namespace rsx
 			const auto child_w = get_surface_width<rsx::surface_metrics::bytes>();
 			const auto child_h = get_surface_height<rsx::surface_metrics::bytes>();
 
-			const auto parent_w = surface->get_surface_width<rsx::surface_metrics::bytes>();
-			const auto parent_h = surface->get_surface_height<rsx::surface_metrics::bytes>();
+			const auto parent_w = surface->template get_surface_width<rsx::surface_metrics::bytes>();
+			const auto parent_h = surface->template get_surface_height<rsx::surface_metrics::bytes>();
 
 			const auto rect = rsx::intersect_region(surface->base_addr, parent_w, parent_h, 1, base_addr, child_w, child_h, 1, get_rsx_pitch());
 			const auto src_offset = std::get<0>(rect);

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1952,7 +1952,7 @@ namespace rsx
 								u32 coverage_size = 0;
 								for (const auto& section : overlapping_fbos)
 								{
-									const auto area = section.surface->get_native_pitch() * section.surface->get_surface_height<rsx::surface_metrics::bytes>();
+									const auto area = section.surface->get_native_pitch() * section.surface->template get_surface_height<rsx::surface_metrics::bytes>();
 									coverage_size += area;
 								}
 
@@ -2509,8 +2509,8 @@ namespace rsx
 					typeless_info.src_gcm_format = helpers::get_sized_blit_format(src_is_argb8, false, is_format_convert);
 				}
 
-				if (surf->get_surface_width<rsx::surface_metrics::pixels>() != surf->width() ||
-					surf->get_surface_height<rsx::surface_metrics::pixels>() != surf->height())
+				if (surf->template get_surface_width<rsx::surface_metrics::pixels>() != surf->width() ||
+					surf->template get_surface_height<rsx::surface_metrics::pixels>() != surf->height())
 				{
 					// Must go through a scaling operation due to resolution scaling being present
 					ensure(g_cfg.video.resolution_scale_percent != 100);
@@ -2606,8 +2606,8 @@ namespace rsx
 				size2u src_dimensions = { 0, 0 };
 				if (src_is_render_target)
 				{
-					src_dimensions.width = src_subres.surface->get_surface_width<rsx::surface_metrics::samples>();
-					src_dimensions.height = src_subres.surface->get_surface_height<rsx::surface_metrics::samples>();
+					src_dimensions.width = src_subres.surface->template get_surface_width<rsx::surface_metrics::samples>();
+					src_dimensions.height = src_subres.surface->template get_surface_height<rsx::surface_metrics::samples>();
 				}
 
 				const auto props = texture_cache_helpers::get_optimal_blit_target_properties(
@@ -2761,8 +2761,8 @@ namespace rsx
 				typeless_info.dst_context = texture_upload_context::framebuffer_storage;
 				dst_is_depth_surface = typeless_info.dst_is_typeless ? false : dst_subres.is_depth;
 
-				max_dst_width = static_cast<u16>(dst_subres.surface->get_surface_width<rsx::surface_metrics::samples>() * typeless_info.dst_scaling_hint);
-				max_dst_height = dst_subres.surface->get_surface_height<rsx::surface_metrics::samples>();
+				max_dst_width = static_cast<u16>(dst_subres.surface->template get_surface_width<rsx::surface_metrics::samples>() * typeless_info.dst_scaling_hint);
+				max_dst_height = dst_subres.surface->template get_surface_height<rsx::surface_metrics::samples>();
 			}
 
 			// Create source texture if does not exist
@@ -3109,8 +3109,8 @@ namespace rsx
 
 			if (src_is_render_target)
 			{
-				const auto surface_width = src_subres.surface->get_surface_width<rsx::surface_metrics::pixels>();
-				const auto surface_height = src_subres.surface->get_surface_height<rsx::surface_metrics::pixels>();
+				const auto surface_width = src_subres.surface->template get_surface_width<rsx::surface_metrics::pixels>();
+				const auto surface_height = src_subres.surface->template get_surface_height<rsx::surface_metrics::pixels>();
 				std::tie(src_area.x1, src_area.y1) = rsx::apply_resolution_scale<false>(src_area.x1, src_area.y1, surface_width, surface_height);
 				std::tie(src_area.x2, src_area.y2) = rsx::apply_resolution_scale<true>(src_area.x2, src_area.y2, surface_width, surface_height);
 
@@ -3120,8 +3120,8 @@ namespace rsx
 
 			if (dst_is_render_target)
 			{
-				const auto surface_width = dst_subres.surface->get_surface_width<rsx::surface_metrics::pixels>();
-				const auto surface_height = dst_subres.surface->get_surface_height<rsx::surface_metrics::pixels>();
+				const auto surface_width = dst_subres.surface->template get_surface_width<rsx::surface_metrics::pixels>();
+				const auto surface_height = dst_subres.surface->template get_surface_height<rsx::surface_metrics::pixels>();
 				std::tie(dst_area.x1, dst_area.y1) = rsx::apply_resolution_scale<false>(dst_area.x1, dst_area.y1, surface_width, surface_height);
 				std::tie(dst_area.x2, dst_area.y2) = rsx::apply_resolution_scale<true>(dst_area.x2, dst_area.y2, surface_width, surface_height);
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -309,7 +309,8 @@ namespace rsx
 				if (!ref_image || surface->get_surface(rsx::surface_access::gpu_reference) == ref_image)
 				{
 					// Same image, so configuration did not change.
-					if (surface->last_use_tag <= surface_cache_tag)
+					if (surface_cache.cache_tag <= surface_cache_tag &&
+						surface->last_use_tag <= surface_cache_tag)
 					{
 						external_subresource_desc.do_not_cache = false;
 						return {};

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1952,7 +1952,7 @@ namespace rsx
 								u32 coverage_size = 0;
 								for (const auto& section : overlapping_fbos)
 								{
-									const auto area = section.surface->get_native_pitch() * section.surface->get_surface_height(rsx::surface_metrics::bytes);
+									const auto area = section.surface->get_native_pitch() * section.surface->get_surface_height<rsx::surface_metrics::bytes>();
 									coverage_size += area;
 								}
 
@@ -2509,8 +2509,8 @@ namespace rsx
 					typeless_info.src_gcm_format = helpers::get_sized_blit_format(src_is_argb8, false, is_format_convert);
 				}
 
-				if (surf->get_surface_width(rsx::surface_metrics::pixels) != surf->width() ||
-					surf->get_surface_height(rsx::surface_metrics::pixels) != surf->height())
+				if (surf->get_surface_width<rsx::surface_metrics::pixels>() != surf->width() ||
+					surf->get_surface_height<rsx::surface_metrics::pixels>() != surf->height())
 				{
 					// Must go through a scaling operation due to resolution scaling being present
 					ensure(g_cfg.video.resolution_scale_percent != 100);
@@ -2606,8 +2606,8 @@ namespace rsx
 				size2u src_dimensions = { 0, 0 };
 				if (src_is_render_target)
 				{
-					src_dimensions.width = src_subres.surface->get_surface_width(rsx::surface_metrics::samples);
-					src_dimensions.height = src_subres.surface->get_surface_height(rsx::surface_metrics::samples);
+					src_dimensions.width = src_subres.surface->get_surface_width<rsx::surface_metrics::samples>();
+					src_dimensions.height = src_subres.surface->get_surface_height<rsx::surface_metrics::samples>();
 				}
 
 				const auto props = texture_cache_helpers::get_optimal_blit_target_properties(
@@ -2761,8 +2761,8 @@ namespace rsx
 				typeless_info.dst_context = texture_upload_context::framebuffer_storage;
 				dst_is_depth_surface = typeless_info.dst_is_typeless ? false : dst_subres.is_depth;
 
-				max_dst_width = static_cast<u16>(dst_subres.surface->get_surface_width(rsx::surface_metrics::samples) * typeless_info.dst_scaling_hint);
-				max_dst_height = dst_subres.surface->get_surface_height(rsx::surface_metrics::samples);
+				max_dst_width = static_cast<u16>(dst_subres.surface->get_surface_width<rsx::surface_metrics::samples>() * typeless_info.dst_scaling_hint);
+				max_dst_height = dst_subres.surface->get_surface_height<rsx::surface_metrics::samples>();
 			}
 
 			// Create source texture if does not exist
@@ -3109,8 +3109,8 @@ namespace rsx
 
 			if (src_is_render_target)
 			{
-				const auto surface_width = src_subres.surface->get_surface_width(rsx::surface_metrics::pixels);
-				const auto surface_height = src_subres.surface->get_surface_height(rsx::surface_metrics::pixels);
+				const auto surface_width = src_subres.surface->get_surface_width<rsx::surface_metrics::pixels>();
+				const auto surface_height = src_subres.surface->get_surface_height<rsx::surface_metrics::pixels>();
 				std::tie(src_area.x1, src_area.y1) = rsx::apply_resolution_scale<false>(src_area.x1, src_area.y1, surface_width, surface_height);
 				std::tie(src_area.x2, src_area.y2) = rsx::apply_resolution_scale<true>(src_area.x2, src_area.y2, surface_width, surface_height);
 
@@ -3120,8 +3120,8 @@ namespace rsx
 
 			if (dst_is_render_target)
 			{
-				const auto surface_width = dst_subres.surface->get_surface_width(rsx::surface_metrics::pixels);
-				const auto surface_height = dst_subres.surface->get_surface_height(rsx::surface_metrics::pixels);
+				const auto surface_width = dst_subres.surface->get_surface_width<rsx::surface_metrics::pixels>();
+				const auto surface_height = dst_subres.surface->get_surface_height<rsx::surface_metrics::pixels>();
 				std::tie(dst_area.x1, dst_area.y1) = rsx::apply_resolution_scale<false>(dst_area.x1, dst_area.y1, surface_width, surface_height);
 				std::tie(dst_area.x2, dst_area.y2) = rsx::apply_resolution_scale<true>(dst_area.x2, dst_area.y2, surface_width, surface_height);
 

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -303,8 +303,8 @@ namespace rsx
 				const auto h = std::min(section_end, slice_end) - dst_y;
 				dst_y = (dst_y - slice_begin);
 
-				const auto surface_width = section.surface->get_surface_width<rsx::surface_metrics::pixels>();
-				const auto surface_height = section.surface->get_surface_height<rsx::surface_metrics::pixels>();
+				const auto surface_width = section.surface->template get_surface_width<rsx::surface_metrics::pixels>();
+				const auto surface_height = section.surface->template get_surface_height<rsx::surface_metrics::pixels>();
 				const auto [src_width, src_height] = rsx::apply_resolution_scale<true>(section.src_area.width, h, surface_width, surface_height);
 				const auto [dst_width, dst_height] = rsx::apply_resolution_scale<true>(section.dst_area.width, h, attr.width, attr.height);
 
@@ -477,8 +477,8 @@ namespace rsx
 				return false;
 			}
 
-			const auto surface_width = texptr->get_surface_width<rsx::surface_metrics::samples>();
-			const auto surface_height = texptr->get_surface_height<rsx::surface_metrics::samples>();
+			const auto surface_width = texptr->template get_surface_width<rsx::surface_metrics::samples>();
+			const auto surface_height = texptr->template get_surface_height<rsx::surface_metrics::samples>();
 
 			switch (extended_dimension)
 			{
@@ -507,8 +507,8 @@ namespace rsx
 		{
 			texptr->read_barrier(cmd);
 
-			const auto surface_width = texptr->get_surface_width<rsx::surface_metrics::samples>();
-			const auto surface_height = texptr->get_surface_height<rsx::surface_metrics::samples>();
+			const auto surface_width = texptr->template get_surface_width<rsx::surface_metrics::samples>();
+			const auto surface_height = texptr->template get_surface_height<rsx::surface_metrics::samples>();
 
 			bool is_depth = texptr->is_depth_surface();
 			auto attr2 = attr;

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -303,8 +303,8 @@ namespace rsx
 				const auto h = std::min(section_end, slice_end) - dst_y;
 				dst_y = (dst_y - slice_begin);
 
-				const auto surface_width = section.surface->get_surface_width(rsx::surface_metrics::pixels);
-				const auto surface_height = section.surface->get_surface_height(rsx::surface_metrics::pixels);
+				const auto surface_width = section.surface->get_surface_width<rsx::surface_metrics::pixels>();
+				const auto surface_height = section.surface->get_surface_height<rsx::surface_metrics::pixels>();
 				const auto [src_width, src_height] = rsx::apply_resolution_scale<true>(section.src_area.width, h, surface_width, surface_height);
 				const auto [dst_width, dst_height] = rsx::apply_resolution_scale<true>(section.dst_area.width, h, attr.width, attr.height);
 
@@ -477,8 +477,8 @@ namespace rsx
 				return false;
 			}
 
-			const auto surface_width = texptr->get_surface_width(rsx::surface_metrics::samples);
-			const auto surface_height = texptr->get_surface_height(rsx::surface_metrics::samples);
+			const auto surface_width = texptr->get_surface_width<rsx::surface_metrics::samples>();
+			const auto surface_height = texptr->get_surface_height<rsx::surface_metrics::samples>();
 
 			switch (extended_dimension)
 			{
@@ -507,8 +507,8 @@ namespace rsx
 		{
 			texptr->read_barrier(cmd);
 
-			const auto surface_width = texptr->get_surface_width(rsx::surface_metrics::samples);
-			const auto surface_height = texptr->get_surface_height(rsx::surface_metrics::samples);
+			const auto surface_width = texptr->get_surface_width<rsx::surface_metrics::samples>();
+			const auto surface_height = texptr->get_surface_height<rsx::surface_metrics::samples>();
 
 			bool is_depth = texptr->is_depth_surface();
 			auto attr2 = attr;

--- a/rpcs3/Emu/RSX/Common/time.hpp
+++ b/rpcs3/Emu/RSX/Common/time.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <util/asm.hpp>
+#include <util/sysinfo.hpp>
+
+extern u64 get_system_time();
+
+namespace rsx
+{
+	static inline u64 uclock()
+	{
+		if (const u64 freq = (utils::get_tsc_freq() / 1000000))
+		{
+			return utils::get_tsc() / freq;
+		}
+		else
+		{
+			return get_system_time();
+		}
+	}
+}

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -677,7 +677,7 @@ void GLGSRender::end()
 	}
 	while (rsx::method_registers.current_draw_clause.next());
 
-	m_rtts.on_write(m_framebuffer_layout.color_write_enabled.data(), m_framebuffer_layout.zeta_write_enabled);
+	m_rtts.on_write(m_framebuffer_layout.color_write_enabled, m_framebuffer_layout.zeta_write_enabled);
 
 	m_attrib_ring_buffer->notify();
 	m_index_ring_buffer->notify();

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -662,8 +662,7 @@ void GLGSRender::clear_surface(u32 arg)
 
 	if (update_color || update_z)
 	{
-		const bool write_all_mask[] = { true, true, true, true };
-		m_rtts.on_write(update_color ? write_all_mask : nullptr, update_z);
+		m_rtts.on_write({ update_color, update_color, update_color, update_color }, update_z);
 	}
 
 	glClear(mask);

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -38,8 +38,8 @@ gl::texture* GLGSRender::get_present_source(gl::present_surface_info* info, cons
 
 		if (section.base_address >= info->address)
 		{
-			const auto surface_width = surface->get_surface_width(rsx::surface_metrics::samples);
-			const auto surface_height = surface->get_surface_height(rsx::surface_metrics::samples);
+			const auto surface_width = surface->get_surface_width<rsx::surface_metrics::samples>();
+			const auto surface_height = surface->get_surface_height<rsx::surface_metrics::samples>();
 
 			if (section.base_address == info->address)
 			{

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -382,7 +382,7 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool /*
 
 			m_gl_texture_cache.lock_memory_region(
 				cmd, surface, surface->get_memory_range(), false,
-				surface->get_surface_width(rsx::surface_metrics::pixels), surface->get_surface_height(rsx::surface_metrics::pixels), surface->get_rsx_pitch(),
+				surface->get_surface_width<rsx::surface_metrics::pixels>(), surface->get_surface_height<rsx::surface_metrics::pixels>(), surface->get_rsx_pitch(),
 				format, type, swap_bytes);
 		}
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -194,7 +194,7 @@ struct gl_render_target_traits
 		{
 			auto internal_format = static_cast<GLenum>(ref->get_internal_format());
 			const auto [new_w, new_h] = rsx::apply_resolution_scale<true>(prev.width, prev.height,
-				ref->get_surface_width(rsx::surface_metrics::pixels), ref->get_surface_height(rsx::surface_metrics::pixels));
+				ref->get_surface_width<rsx::surface_metrics::pixels>(), ref->get_surface_height<rsx::surface_metrics::pixels>());
 
 			sink = std::make_unique<gl::render_target>(new_w, new_h, internal_format, ref->format_class());
 			sink->add_ref();
@@ -237,8 +237,8 @@ struct gl_render_target_traits
 	{
 		return (surface->get_internal_format() == ref->get_internal_format() &&
 				surface->get_spp() == sample_count &&
-				surface->get_surface_width(rsx::surface_metrics::pixels) >= width &&
-				surface->get_surface_height(rsx::surface_metrics::pixels) >= height);
+				surface->get_surface_width<rsx::surface_metrics::pixels>() >= width &&
+				surface->get_surface_height<rsx::surface_metrics::pixels>() >= height);
 	}
 
 	static

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -3,6 +3,7 @@
 #include "RSXFIFO.h"
 #include "RSXThread.h"
 #include "Capture/rsx_capture.h"
+#include "Common/time.hpp"
 #include "Emu/Cell/lv2/sys_rsx.h"
 
 namespace rsx
@@ -395,7 +396,7 @@ namespace rsx
 			{
 				if (performance_counters.state == FIFO_state::running)
 				{
-					performance_counters.FIFO_idle_timestamp = get_system_time();
+					performance_counters.FIFO_idle_timestamp = rsx::uclock();
 					performance_counters.state = FIFO_state::nop;
 				}
 
@@ -405,7 +406,7 @@ namespace rsx
 			{
 				if (performance_counters.state == FIFO_state::running)
 				{
-					performance_counters.FIFO_idle_timestamp = get_system_time();
+					performance_counters.FIFO_idle_timestamp = rsx::uclock();
 					performance_counters.state = FIFO_state::empty;
 				}
 				else
@@ -437,7 +438,7 @@ namespace rsx
 					//Jump to self. Often preceded by NOP
 					if (performance_counters.state == FIFO_state::running)
 					{
-						performance_counters.FIFO_idle_timestamp = get_system_time();
+						performance_counters.FIFO_idle_timestamp = rsx::uclock();
 						sync_point_request.release(true);
 					}
 
@@ -456,7 +457,7 @@ namespace rsx
 					//Jump to self. Often preceded by NOP
 					if (performance_counters.state == FIFO_state::running)
 					{
-						performance_counters.FIFO_idle_timestamp = get_system_time();
+						performance_counters.FIFO_idle_timestamp = rsx::uclock();
 						sync_point_request.release(true);
 					}
 
@@ -513,7 +514,7 @@ namespace rsx
 			}
 
 			// Update performance counters with time spent in idle mode
-			performance_counters.idle_time += (get_system_time() - performance_counters.FIFO_idle_timestamp);
+			performance_counters.idle_time += (rsx::uclock() - performance_counters.FIFO_idle_timestamp);
 		}
 
 		do

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -7,6 +7,7 @@
 #include "Common/BufferUtils.h"
 #include "Common/texture_cache.h"
 #include "Common/surface_store.h"
+#include "Common/time.hpp"
 #include "Capture/rsx_capture.h"
 #include "rsx_methods.h"
 #include "gcm_printing.h"
@@ -483,6 +484,7 @@ namespace rsx
 		// This whole thing becomes a mess if we don't have a provoking attribute.
 		const auto vertex_id = vertex_push_buffers[0].get_vertex_id();
 		vertex_push_buffers[attribute].set_vertex_data(attribute, vertex_id, subreg_index, type, size, value);
+		m_graphics_state |= rsx::pipeline_state::push_buffer_arrays_dirty;
 	}
 
 	u32 thread::get_push_buffer_vertex_count() const
@@ -507,7 +509,9 @@ namespace rsx
 	void thread::end()
 	{
 		if (capture_current_frame)
+		{
 			capture::capture_draw_memory(this);
+		}
 
 		in_begin_end = false;
 		m_frame_stats.draw_calls++;
@@ -517,12 +521,17 @@ namespace rsx
 		m_graphics_state |= rsx::pipeline_state::framebuffer_reads_dirty;
 		ROP_sync_timestamp = rsx::get_shared_tag();
 
-		for (auto & push_buf : vertex_push_buffers)
+		if (m_graphics_state & rsx::pipeline_state::push_buffer_arrays_dirty)
 		{
-			//Disabled, see https://github.com/RPCS3/rpcs3/issues/1932
-			//rsx::method_registers.register_vertex_info[index].size = 0;
+			for (auto& push_buf : vertex_push_buffers)
+			{
+				//Disabled, see https://github.com/RPCS3/rpcs3/issues/1932
+				//rsx::method_registers.register_vertex_info[index].size = 0;
 
-			push_buf.clear();
+				push_buf.clear();
+			}
+
+			m_graphics_state &= ~rsx::pipeline_state::push_buffer_arrays_dirty;
 		}
 
 		element_push_buffer.clear();
@@ -630,7 +639,7 @@ namespace rsx
 
 		fifo_ctrl = std::make_unique<::rsx::FIFO::FIFO_control>(this);
 
-		last_flip_time = get_system_time() - 1000000;
+		last_flip_time = rsx::uclock() - 1000000;
 
 		vblank_count = 0;
 
@@ -642,7 +651,7 @@ namespace rsx
 #else
 			constexpr u32 host_min_quantum = 500;
 #endif
-			u64 start_time = get_system_time();
+			u64 start_time = rsx::uclock();
 
 			u64 vblank_rate = g_cfg.video.vblank_rate;
 			u64 vblank_period = 1'000'000 + u64{g_cfg.video.vblank_ntsc.get()} * 1000;
@@ -653,7 +662,7 @@ namespace rsx
 			while (!is_stopped())
 			{
 				// Get current time
-				const u64 current = get_system_time();
+				const u64 current = rsx::uclock();
 
 				// Calculate the time at which we need to send a new VBLANK signal
 				const u64 post_event_time = start_time + (local_vblank_count + 1) * vblank_period / vblank_rate;
@@ -715,7 +724,7 @@ namespace rsx
 				if (Emu.IsPaused())
 				{
 					// Save the difference before pause
-					start_time = get_system_time() - start_time;
+					start_time = rsx::uclock() - start_time;
 
 					while (Emu.IsPaused() && !is_stopped())
 					{
@@ -723,7 +732,7 @@ namespace rsx
 					}
 
 					// Restore difference
-					start_time = get_system_time() - start_time;
+					start_time = rsx::uclock() - start_time;
 				}
 			}
 		});
@@ -2602,7 +2611,7 @@ namespace rsx
 
 	void thread::recover_fifo(u32 line, u32 col, const char* file, const char* func)
 	{
-		const u64 current_time = get_system_time();
+		const u64 current_time = rsx::uclock();
 
 		if (recovered_fifo_cmds_history.size() == 20u)
 		{
@@ -2659,7 +2668,7 @@ namespace rsx
 
 		// Some cases do not need full delay
 		remaining = utils::aligned_div(remaining, div);
-		const u64 until = get_system_time() + remaining;
+		const u64 until = rsx::uclock() + remaining;
 
 		while (true)
 		{
@@ -2691,7 +2700,7 @@ namespace rsx
 				busy_wait(100);
 			}
 
-			const u64 current = get_system_time();
+			const u64 current = rsx::uclock();
 
 			if (current >= until)
 			{
@@ -2922,7 +2931,7 @@ namespace rsx
 		//Average load over around 30 frames
 		if (!performance_counters.last_update_timestamp || performance_counters.sampled_frames > 30)
 		{
-			const auto timestamp = get_system_time();
+			const auto timestamp = rsx::uclock();
 			const auto idle = performance_counters.idle_time.load();
 			const auto elapsed = timestamp - performance_counters.last_update_timestamp;
 
@@ -3086,7 +3095,7 @@ namespace rsx
 
 		if (limit)
 		{
-			const u64 time = get_system_time() - Emu.GetPauseTime();
+			const u64 time = rsx::uclock() - Emu.GetPauseTime();
 			const u64 needed_us = static_cast<u64>(1000000 / limit);
 
 			if (int_flip_index == 0)
@@ -3124,7 +3133,7 @@ namespace rsx
 
 		flip(m_queued_flip);
 
-		last_flip_time = get_system_time() - 1000000;
+		last_flip_time = rsx::uclock() - 1000000;
 		flip_status = CELL_GCM_DISPLAY_FLIP_STATUS_DONE;
 		m_queued_flip.in_progress = false;
 
@@ -3630,7 +3639,7 @@ namespace rsx
 					}
 				}
 
-				if (m_tsc = get_system_time(); m_tsc < m_next_tsc)
+				if (m_tsc = rsx::uclock(); m_tsc < m_next_tsc)
 				{
 					return;
 				}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -129,6 +129,8 @@ namespace rsx
 		polygon_stipple_pattern_dirty = 0x8000,  // Rasterizer stippling pattern changed
 		line_stipple_pattern_dirty = 0x10000,    // Line stippling pattern changed
 
+		push_buffer_arrays_dirty = 0x20000,   // Push buffers have data written to them (immediate mode vertex buffers)
+
 		fragment_program_dirty = fragment_program_ucode_dirty | fragment_program_state_dirty,
 		vertex_program_dirty = vertex_program_ucode_dirty | vertex_program_state_dirty,
 		invalidate_pipeline_bits = fragment_program_dirty | vertex_program_dirty,

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -1116,7 +1116,7 @@ void VKGSRender::end()
 		m_current_command_buffer->flags &= ~(vk::command_buffer::cb_has_conditional_render);
 	}
 
-	m_rtts.on_write(m_framebuffer_layout.color_write_enabled.data(), m_framebuffer_layout.zeta_write_enabled);
+	m_rtts.on_write(m_framebuffer_layout.color_write_enabled, m_framebuffer_layout.zeta_write_enabled);
 
 	rsx::thread::end();
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1449,8 +1449,7 @@ void VKGSRender::clear_surface(u32 mask)
 
 	if (update_color || update_z)
 	{
-		const bool write_all_mask[] = { true, true, true, true };
-		m_rtts.on_write(update_color ? write_all_mask : nullptr, update_z);
+		m_rtts.on_write({ update_color, update_color, update_color, update_color }, update_z);
 	}
 
 	if (!clear_descriptors.empty())

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2463,7 +2463,7 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 
 			m_texture_cache.lock_memory_region(
 				*m_current_command_buffer, surface, surface->get_memory_range(), false,
-				surface->get_surface_width(rsx::surface_metrics::pixels), surface->get_surface_height(rsx::surface_metrics::pixels), surface->get_rsx_pitch(),
+				surface->get_surface_width<rsx::surface_metrics::pixels>(), surface->get_surface_height<rsx::surface_metrics::pixels>(), surface->get_rsx_pitch(),
 				gcm_format, swap_bytes);
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1085,7 +1085,7 @@ void VKGSRender::check_heap_status(u32 flags)
 			m_texture_upload_buffer_ring_info.reset_allocation_stats();
 			m_raster_env_ring_info.reset_allocation_stats();
 			m_current_frame->reset_heap_ptrs();
-			m_last_heap_sync_time = get_system_time();
+			m_last_heap_sync_time = rsx::get_shared_tag();
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
@@ -244,7 +244,7 @@ namespace vk
 			texture_upload_heap_ptr = texture_loc;
 			rasterizer_env_heap_ptr = rasterizer_loc;
 
-			last_frame_sync_time = get_system_time();
+			last_frame_sync_time = rsx::get_shared_tag();
 		}
 
 		void reset_heap_ptrs()

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -288,8 +288,8 @@ vk::viewable_image* VKGSRender::get_present_source(vk::present_surface_info* inf
 
 		if (section.base_address >= info->address)
 		{
-			const auto surface_width = surface->get_surface_width(rsx::surface_metrics::samples);
-			const auto surface_height = surface->get_surface_height(rsx::surface_metrics::samples);
+			const auto surface_width = surface->get_surface_width<rsx::surface_metrics::samples>();
+			const auto surface_height = surface->get_surface_height<rsx::surface_metrics::samples>();
 
 			if (section.base_address == info->address)
 			{

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -271,7 +271,7 @@ namespace vk
 			if (!sink)
 			{
 				const auto [new_w, new_h] = rsx::apply_resolution_scale<true>(prev.width, prev.height,
-					ref->get_surface_width(rsx::surface_metrics::pixels), ref->get_surface_height(rsx::surface_metrics::pixels));
+					ref->get_surface_width<rsx::surface_metrics::pixels>(), ref->get_surface_height<rsx::surface_metrics::pixels>());
 
 				auto& dev = cmd.get_command_pool().get_owner();
 				sink = std::make_unique<vk::render_target>(dev, dev.get_memory_mapping().device_local,

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -3,6 +3,7 @@
 #include "RSXThread.h"
 #include "rsx_utils.h"
 #include "rsx_decode.h"
+#include "Common/time.hpp"
 #include "Emu/Cell/PPUCallback.h"
 #include "Emu/Cell/lv2/sys_rsx.h"
 #include "Emu/RSX/Common/BufferUtils.h"
@@ -106,7 +107,7 @@ namespace rsx
 				rsx->flush_fifo();
 			}
 
-			u64 start = get_system_time();
+			u64 start = rsx::uclock();
 			while (sema != arg)
 			{
 				if (rsx->is_stopped())
@@ -118,7 +119,7 @@ namespace rsx
 				{
 					if (rsx->is_paused())
 					{
-						const u64 start0 = get_system_time();
+						const u64 start0 = rsx::uclock();
 
 						while (rsx->is_paused())
 						{
@@ -126,11 +127,11 @@ namespace rsx
 						}
 
 						// Reset
-						start += get_system_time() - start0;
+						start += rsx::uclock() - start0;
 					}
 					else
 					{
-						if ((get_system_time() - start) > tdr)
+						if ((rsx::uclock() - start) > tdr)
 						{
 							// If longer than driver timeout force exit
 							rsx_log.error("nv406e::semaphore_acquire has timed out. semaphore_address=0x%X", addr);
@@ -143,7 +144,7 @@ namespace rsx
 			}
 
 			rsx->fifo_wake_delay();
-			rsx->performance_counters.idle_time += (get_system_time() - start);
+			rsx->performance_counters.idle_time += (rsx::uclock() - start);
 		}
 
 		void semaphore_release(thread* rsx, u32 /*reg*/, u32 arg)

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -479,6 +479,7 @@
     <ClInclude Include="Emu\RSX\Common\bitfield.hpp" />
     <ClInclude Include="Emu\RSX\Common\profiling_timer.hpp" />
     <ClInclude Include="Emu\RSX\Common\simple_array.hpp" />
+    <ClInclude Include="Emu\RSX\Common\time.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_edit_text.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_list_view.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_media_list_dialog.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2053,6 +2053,9 @@
     <ClInclude Include="Emu\RSX\Overlays\overlay_media_list_dialog.h">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\Common\time.hpp">
+      <Filter>Emu\GPU\RSX\Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Emu\RSX\Common\Interpreter\FragmentInterpreter.glsl">


### PR DESCRIPTION
Mostly fixes some consistency issues with the texture cache, which are easier to notice when MSAA is active. During this investigation I also realized some surface util methods are being called millions of times per second, so I converted them to templates which improves performance a bit. Also removed excessive calls to get_system_time() which reduces zcull latency significantly in some titles.

Needs performance and crash testing. Hopefully no regressions (I tested this quite a bit)

 Fixes https://github.com/RPCS3/rpcs3/issues/9339