### PR TITLE
evdev: fix latency issues

### DIFF
--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -392,6 +392,8 @@ private:
 	bool check_button(const EvdevButton& b, const u32 code);
 	bool check_buttons(const std::vector<EvdevButton>& b, const u32 code);
 
+	void handle_input_event(const input_event& evt, const std::shared_ptr<Pad>& pad);
+
 protected:
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
 	void get_mapping(const std::shared_ptr<PadDevice>& device, const std::shared_ptr<Pad>& pad) override;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -362,7 +362,7 @@ void pad_settings_dialog::InitButtons()
 	});
 
 	// Enable Button Remapping
-	const auto& callback = [this](u16 val, std::string name, std::string pad_name, u32 battery_level, pad_preview_values preview_values)
+	const auto callback = [this](u16 val, std::string name, std::string pad_name, u32 battery_level, pad_preview_values preview_values)
 	{
 		SwitchPadInfo(pad_name, true);
 
@@ -408,7 +408,7 @@ void pad_settings_dialog::InitButtons()
 	};
 
 	// Disable Button Remapping
-	const auto& fail_callback = [this](const std::string& pad_name)
+	const auto fail_callback = [this](const std::string& pad_name)
 	{
 		SwitchPadInfo(pad_name, false);
 


### PR DESCRIPTION
Turns out we only handled ONE evdev event per loop...
That means the theoretical max was 1000 events per second per default due to the 1ms sleep of the pad thread.
Extensive movement of all sticks and triggers can easily cause a congestion and thus a "rubber banding" delay of the input.

It's very easy to repoduce and kinda funny to watch if you increase the pad thread sleep to 10ms.

To fix this, I now fetch all new events at once on each iteration.
The issue is now completely resolved on my slow laptop, no matter how long the thread sleeps.

fixes #11609