### PR TITLE
Warning Fixes

### DIFF
--- a/rpcs3/Emu/Audio/FAudio/FAudioBackend.cpp
+++ b/rpcs3/Emu/Audio/FAudio/FAudioBackend.cpp
@@ -90,7 +90,7 @@ void FAudioBackend::Pause()
 			FAudio_.error("FAudioSourceVoice_Stop() failed(0x%08x)", res);
 		}
 
-		if (res = FAudioSourceVoice_FlushSourceBuffers(m_source_voice))
+		if ((res = FAudioSourceVoice_FlushSourceBuffers(m_source_voice)))
 		{
 			FAudio_.error("FAudioSourceVoice_FlushSourceBuffers() failed(0x%08x)", res);
 		}

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -967,7 +967,7 @@ error_code cellGemGetCameraState(vm::ptr<CellGemCameraState> camera_state)
 {
 	cellGem.todo("cellGemGetCameraState(camera_state=0x%x)", camera_state);
 
-	auto& gem = g_fxo->get<gem_config>();
+	[[maybe_unused]] auto& gem = g_fxo->get<gem_config>();
 
 	if (!camera_state)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -1642,7 +1642,7 @@ s32 cellSpursFinalize(vm::ptr<CellSpurs> spurs)
 		return CELL_SPURS_CORE_ERROR_STAT;
 	}
 
-	u32 wklEnabled = spurs->wklEnabled.load();
+	[[maybe_unused]] u32 wklEnabled = spurs->wklEnabled.load();
 
 	if (spurs->flags1 & SF1_32_WORKLOADS)
 	{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1602,7 +1602,7 @@ spu_thread::spu_thread(lv2_spu_group* group, u32 index, std::string_view name, u
 		else
 		{
 			// alloc_hidden indicates falloc to allocate page with no access rights in base memory
-			ensure(vm::get(vm::spu)->falloc(vm_offset(), SPU_LS_SIZE, &shm, vm::page_size_64k | vm::alloc_hidden));
+			ensure(vm::get(vm::spu)->falloc(vm_offset(), SPU_LS_SIZE, &shm, static_cast<u64>(vm::page_size_64k) | static_cast<u64>(vm::alloc_hidden)));
 		}
 
 		// Try to guess free area

--- a/rpcs3/Emu/Cell/lv2/sys_tty.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_tty.cpp
@@ -88,7 +88,9 @@ error_code sys_tty_read(s32 ch, vm::ptr<char> buf, u32 len, vm::ptr<u32> preadle
 	return CELL_OK;
 }
 
-error_code sys_tty_write(ppu_thread& ppu, s32 ch, vm::cptr<char> buf, u32 len, vm::ptr<u32> pwritelen)
+std::string dump_useful_thread_info();
+
+error_code sys_tty_write([[maybe_unused]] ppu_thread& ppu, s32 ch, vm::cptr<char> buf, u32 len, vm::ptr<u32> pwritelen)
 {
 	sys_tty.notice("sys_tty_write(ch=%d, buf=*0x%x, len=%d, pwritelen=*0x%x)", ch, buf, len, pwritelen);
 
@@ -113,7 +115,6 @@ error_code sys_tty_write(ppu_thread& ppu, s32 ch, vm::cptr<char> buf, u32 len, v
 		return current - last_write.exchange(current) >= 500'000;
 	}())
 	{
-		std::string dump_useful_thread_info();
 		ppu_log.notice("\n%s", dump_useful_thread_info());
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_uart.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_uart.cpp
@@ -978,12 +978,12 @@ private:
 		return commit_param(rsxaudio_port, avport_idx, avport_src, freq, bit_cnt, spdif_use_serial_buf, pkt.audio_cs_info);
 	}
 
-	bool commit_param(u8 rsxaudio_port, RsxaudioAvportIdx avport, u8 avport_src, u32 freq,
-						UartAudioSampleSize bit_cnt, bool spdif_use_serial_buf, const u8 *cs_data)
+	bool commit_param(u8 rsxaudio_port, RsxaudioAvportIdx avport, [[maybe_unused]] u8 avport_src, [[maybe_unused]] u32 freq,
+						UartAudioSampleSize bit_cnt, [[maybe_unused]] bool spdif_use_serial_buf, [[maybe_unused]] const u8 *cs_data)
 	{
 		// TBA
-		const auto avport_idx = static_cast<std::underlying_type_t<decltype(avport)>>(avport);
-		const auto rsxaudio_word_depth = bit_cnt == UartAudioSampleSize::_16BIT ? RsxaudioSampleSize::_16BIT : RsxaudioSampleSize::_32BIT;
+		[[maybe_unused]] const auto avport_idx = static_cast<std::underlying_type_t<decltype(avport)>>(avport);
+		[[maybe_unused]] const auto rsxaudio_word_depth = bit_cnt == UartAudioSampleSize::_16BIT ? RsxaudioSampleSize::_16BIT : RsxaudioSampleSize::_32BIT;
 
 		switch (rsxaudio_port)
 		{
@@ -995,7 +995,7 @@ private:
 		case SYS_RSXAUDIO_PORT_SPDIF_0:
 		case SYS_RSXAUDIO_PORT_SPDIF_1:
 		{
-			const u8 spdif_idx = rsxaudio_port == SYS_RSXAUDIO_PORT_SPDIF_1;
+			[[maybe_unused]] const u8 spdif_idx = rsxaudio_port == SYS_RSXAUDIO_PORT_SPDIF_1;
 
 			// TBA
 			break;
@@ -1067,7 +1067,7 @@ struct audio_set_active_cmd : public ps3av_cmd
 			return;
 		}
 
-		const bool requested_avports[SYS_RSXAUDIO_AVPORT_CNT] =
+		[[maybe_unused]] const bool requested_avports[SYS_RSXAUDIO_AVPORT_CNT] =
 		{
 			(pkt->audio_port & PS3AV_AUDIO_PORT_HDMI_0) != 0U,
 			(pkt->audio_port & PS3AV_AUDIO_PORT_HDMI_1) != 0U,
@@ -1122,7 +1122,7 @@ struct audio_spdif_bit_cmd : public ps3av_cmd
 			return;
 		}
 
-		const bool requested_avports[SYS_RSXAUDIO_AVPORT_CNT] =
+		[[maybe_unused]] const bool requested_avports[SYS_RSXAUDIO_AVPORT_CNT] =
 		{
 			(pkt->audio_port & PS3AV_AUDIO_PORT_HDMI_0) != 0U,
 			(pkt->audio_port & PS3AV_AUDIO_PORT_HDMI_1) != 0U,
@@ -1301,7 +1301,7 @@ struct inc_avset_cmd : public ps3av_cmd
 					break;
 				}
 
-				const u8 hdmi_idx = av_audio_pkt->avport == static_cast<u16>(UartAudioAvport::HDMI_1);
+				[[maybe_unused]] const u8 hdmi_idx = av_audio_pkt->avport == static_cast<u16>(UartAudioAvport::HDMI_1);
 
 				// TBA
 			}

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -56,35 +56,35 @@ SSE4_1_FUNC static inline u16 sse41_hmax_epu16(__m128i x)
 }
 
 #if defined(__AVX512F__) && defined(__AVX512VL__) && defined(__AVX512DQ__) && defined(__AVX512CD__) && defined(__AVX512BW__)
-constexpr bool s_use_ssse3 = true;
+[[maybe_unused]] constexpr bool s_use_ssse3 = true;
 constexpr bool s_use_sse4_1 = true;
 constexpr bool s_use_avx2 = true;
-constexpr bool s_use_avx3 = true;
+[[maybe_unused]] constexpr bool s_use_avx3 = true;
 #elif defined(__AVX2__)
-constexpr bool s_use_ssse3 = true;
+[[maybe_unused]] constexpr bool s_use_ssse3 = true;
 constexpr bool s_use_sse4_1 = true;
 constexpr bool s_use_avx2 = true;
-constexpr bool s_use_avx3 = false;
+[[maybe_unused]] constexpr bool s_use_avx3 = false;
 #elif defined(__SSE4_1__)
-constexpr bool s_use_ssse3 = true;
+[[maybe_unused]] constexpr bool s_use_ssse3 = true;
 constexpr bool s_use_sse4_1 = true;
 constexpr bool s_use_avx2 = false;
-constexpr bool s_use_avx3 = false;
+[[maybe_unused]] constexpr bool s_use_avx3 = false;
 #elif defined(__SSSE3__)
-constexpr bool s_use_ssse3 = true;
+[[maybe_unused]] constexpr bool s_use_ssse3 = true;
 constexpr bool s_use_sse4_1 = false;
 constexpr bool s_use_avx2 = false;
-constexpr bool s_use_avx3 = false;
+[[maybe_unused]] constexpr bool s_use_avx3 = false;
 #elif defined(ARCH_X64)
-const bool s_use_ssse3 = utils::has_ssse3();
+[[maybe_unused]] const bool s_use_ssse3 = utils::has_ssse3();
 const bool s_use_sse4_1 = utils::has_sse41();
 const bool s_use_avx2 = utils::has_avx2();
-const bool s_use_avx3 = utils::has_avx512();
+[[maybe_unused]] const bool s_use_avx3 = utils::has_avx512();
 #else
-constexpr bool s_use_ssse3 = true; // Non x86
+[[maybe_unused]] constexpr bool s_use_ssse3 = true; // Non x86
 constexpr bool s_use_sse4_1 = true; // Non x86
 constexpr bool s_use_avx2 = false;
-constexpr bool s_use_avx3 = false;
+[[maybe_unused]] constexpr bool s_use_avx3 = false;
 #endif
 
 const __m128i s_bswap_u32_mask = _mm_set_epi8(

--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp
@@ -10,7 +10,7 @@
 
 namespace vk
 {
-	AsyncTaskScheduler::AsyncTaskScheduler(vk_gpu_scheduler_mode mode)
+	AsyncTaskScheduler::AsyncTaskScheduler([[maybe_unused]] vk_gpu_scheduler_mode mode)
 	{
 		if (g_cfg.video.renderer != video_renderer::vulkan || !g_cfg.video.vk.asynchronous_texture_streaming)
 		{

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -89,7 +89,7 @@ namespace vk
 		using download_buffer_object = void*;
 		using barrier_descriptor_t = rsx::deferred_clipped_region<vk::render_target*>;
 
-		static std::pair<VkImageUsageFlags, VkImageCreateFlags> get_attachment_create_flags(VkFormat format, u8 /*samples*/)
+		static std::pair<VkImageUsageFlags, VkImageCreateFlags> get_attachment_create_flags(VkFormat format, [[maybe_unused]] u8 samples)
 		{
 			if (g_cfg.video.strict_rendering_mode)
 			{

--- a/rpcs3/Emu/RSX/gcm_enums.cpp
+++ b/rpcs3/Emu/RSX/gcm_enums.cpp
@@ -390,9 +390,8 @@ void fmt_class_string<blit_engine::transfer_operation>::format(std::string& out,
 		case blit_engine::transfer_operation::srccopy: return "srccopy";
 		case blit_engine::transfer_operation::srccopy_and: return "srccopy_and";
 		case blit_engine::transfer_operation::srccopy_premult: return "srccopy_premult";
+		default: return unknown;
 		}
-
-		return unknown;
 	});
 }
 
@@ -416,9 +415,8 @@ void fmt_class_string<blit_engine::transfer_source_format>::format(std::string& 
 		case blit_engine::transfer_source_format::x8r8g8b8: return "x8r8g8b8";
 		case blit_engine::transfer_source_format::y8: return "y8";
 		case blit_engine::transfer_source_format::yb8cr8ya8cb8: return "yb8cr8ya8cb8";
+		default: return unknown;
 		}
-
-		return unknown;
 	});
 }
 
@@ -447,9 +445,8 @@ void fmt_class_string<blit_engine::transfer_destination_format>::format(std::str
 		case blit_engine::transfer_destination_format::a8r8g8b8: return "a8r8g8b8";
 		case blit_engine::transfer_destination_format::r5g6b5: return "r5g6b5";
 		case blit_engine::transfer_destination_format::y32: return "y32";
+		default: return unknown;
 		}
-
-		return unknown;
 	});
 }
 

--- a/rpcs3/rpcs3qt/camera_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/camera_settings_dialog.cpp
@@ -52,9 +52,8 @@ void fmt_class_string<QVideoFrame::PixelFormat>::format(std::string& out, u64 ar
 		case QVideoFrame::Format_ABGR32: return "ABGR32";
 		case QVideoFrame::Format_YUV422P: return "YUV422P";
 		case QVideoFrame::Format_User: return "User";
+		default: return unknown;
 		}
-
-		return unknown;
 	});
 }
 

--- a/rpcs3/util/atomic.cpp
+++ b/rpcs3/util/atomic.cpp
@@ -933,7 +933,7 @@ template <typename F>
 FORCE_INLINE auto root_info::slot_search(uptr iptr, u128 mask, F func) noexcept
 {
 	u32 index = 0;
-	u32 total = 0;
+	[[maybe_unused]] u32 total = 0;
 
 	for (hash_engine _this(iptr);; _this.advance())
 	{


### PR DESCRIPTION
Fixes the following clang warnings(gcc issues 3 additional warnings but they seem to be gcc miswarnings):

```
/Repos/rpcs3/rpcs3/util/atomic.cpp:936:6: warning: variable 'total' set but not used [-Wunused-but-set-variable]
        u32 total = 0;
            ^
--
/Repos/rpcs3/rpcs3/Emu/Audio/FAudio/FAudioBackend.cpp:93:11: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                if (res = FAudioSourceVoice_FlushSourceBuffers(m_source_voice))
                    ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
/Repos/rpcs3/rpcs3/Emu/Cell/SPUThread.cpp:1605:86: warning: bitwise operation between different enumeration types ('vm::block_flags_3' and 'vm::alloc_flags') is deprecated [-Wdeprecated-enum-enum-conversion]
                        ensure(vm::get(vm::spu)->falloc(vm_offset(), SPU_LS_SIZE, &shm, vm::page_size_64k | vm::alloc_hidden));
                                                                                        ~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~
--
/Repos/rpcs3/rpcs3/Emu/Cell/lv2/sys_tty.cpp:116:38: warning: empty parentheses interpreted as a function declaration [-Wvexing-parse]
                std::string dump_useful_thread_info();
                                                   ^~
--
/Repos/rpcs3/rpcs3/Emu/Cell/lv2/sys_tty.cpp:91:38: warning: unused parameter 'ppu' [-Wunused-parameter]
error_code sys_tty_write(ppu_thread& ppu, s32 ch, vm::cptr<char> buf, u32 len, vm::ptr<u32> pwritelen)
                                     ^
--
A bunch of unused vars in sys_uart.cpp
--
/Repos/rpcs3/rpcs3/Emu/Cell/Modules/cellGem.cpp:970:8: warning: unused variable 'gem' [-Wunused-variable]
        auto& gem = g_fxo->get<gem_config>();
--
/Repos/rpcs3/rpcs3/Emu/RSX/gcm_enums.cpp:385:11: warning: enumeration value 'invalid' not handled in switch [-Wswitch]
                switch (value)
                        ^
/Repos/rpcs3/rpcs3/Emu/RSX/gcm_enums.cpp:404:11: warning: enumeration value 'invalid' not handled in switch [-Wswitch]
                switch (value)
                        ^
/Repos/rpcs3/rpcs3/Emu/RSX/gcm_enums.cpp:445:11: warning: enumeration value 'invalid' not handled in switch [-Wswitch]
                switch (value)
                        ^
--
s_use_ssse3 and s_use_avx3 unused in BufferUtils.cpp
--
/Repos/rpcs3/rpcs3/Emu/RSX/VK/VKAsyncScheduler.cpp:13:63: warning: unused parameter 'mode' [-Wunused-parameter]
        AsyncTaskScheduler::AsyncTaskScheduler(vk_gpu_scheduler_mode mode)
                                                                     ^
--
/Repos/rpcs3/rpcs3/Emu/RSX/VK/VKRenderTargets.h:92:107: warning: unused parameter 'samples' [-Wunused-parameter]
                static std::pair<VkImageUsageFlags, VkImageCreateFlags> get_attachment_create_flags(VkFormat format, u8 samples)
                                                                                                                        ^

```