### PR TITLE
rsx: Implement relocatable vertex program constants for static programs [optimization]

### DIFF
--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -87,6 +87,33 @@ namespace fmt
 		return src;
 	}
 
+	static inline
+	std::string replace_all(std::string src, const std::vector<std::pair<std::string, std::string>>& list)
+	{
+		for (usz pos = 0; pos < src.length(); ++pos)
+		{
+			for (usz i = 0; i < list.size(); ++i)
+			{
+				const usz comp_length = list[i].first.length();
+
+				if (src.length() - pos < comp_length)
+				{
+					continue;
+				}
+
+				if (src.substr(pos, comp_length) == list[i].first)
+				{
+					src.erase(pos, comp_length);
+					src.insert(pos, list[i].second);
+					pos += list[i].second.length() - 1;
+					break;
+				}
+			}
+		}
+
+		return src;
+	}
+
 	std::vector<std::string> split(std::string_view source, std::initializer_list<std::string_view> separators, bool is_skip_empty = true);
 	std::string trim(const std::string& source, const std::string& values = " \t");
 

--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -869,19 +869,3 @@ std::tuple<u32, u32, u32> write_index_array_data_to_buffer(std::span<std::byte> 
 		fmt::throw_exception("Unreachable");
 	}
 }
-
-void stream_vector(void *dst, u32 x, u32 y, u32 z, u32 w)
-{
-	const __m128i vector = _mm_set_epi32(w, z, y, x);
-	_mm_stream_si128(reinterpret_cast<__m128i*>(dst), vector);
-}
-
-void stream_vector(void *dst, f32 x, f32 y, f32 z, f32 w)
-{
-	stream_vector(dst, std::bit_cast<u32>(x), std::bit_cast<u32>(y), std::bit_cast<u32>(z), std::bit_cast<u32>(w));
-}
-void stream_vector_from_memory(void *dst, void *src)
-{
-	const __m128i vector = _mm_loadu_si128(reinterpret_cast<__m128i*>(src));
-	_mm_stream_si128(reinterpret_cast<__m128i*>(dst), vector);
-}

--- a/rpcs3/Emu/RSX/Common/BufferUtils.h
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.h
@@ -38,17 +38,6 @@ std::tuple<u32, u32, u32> write_index_array_data_to_buffer(std::span<std::byte> 
  */
 void write_index_array_for_non_indexed_non_native_primitive_to_buffer(char* dst, rsx::primitive_type draw_mode, unsigned count);
 
-/**
- * Stream a 128 bits vector to dst.
- */
-void stream_vector(void *dst, f32 x, f32 y, f32 z, f32 w);
-void stream_vector(void *dst, u32 x, u32 y, u32 z, u32 w);
-
-/**
- * Stream a 128 bits vector from src to dst.
- */
-void stream_vector_from_memory(void *dst, void *src);
-
 // Copy and swap data in 32-bit units
 extern void(*const copy_data_swap_u32)(u32*, const u32*, u32);
 

--- a/rpcs3/Emu/RSX/Common/buffer_stream.hpp
+++ b/rpcs3/Emu/RSX/Common/buffer_stream.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "util/types.hpp"
+#include "util/asm.hpp"
+
+#if defined(ARCH_X64)
+#include "emmintrin.h"
+#include "immintrin.h"
+#endif
+
+#ifdef ARCH_ARM64
+#if !defined(_MSC_VER)
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+#undef FORCE_INLINE
+#include "Emu/CPU/sse2neon.h"
+#endif
+
+namespace utils
+{
+	/**
+	 * Stream a 128 bits vector to dst.
+	 */
+	static inline
+		void stream_vector(void* dst, u32 x, u32 y, u32 z, u32 w)
+	{
+		const __m128i vector = _mm_set_epi32(w, z, y, x);
+		_mm_stream_si128(reinterpret_cast<__m128i*>(dst), vector);
+	}
+
+	static inline
+		void stream_vector(void* dst, f32 x, f32 y, f32 z, f32 w)
+	{
+		stream_vector(dst, std::bit_cast<u32>(x), std::bit_cast<u32>(y), std::bit_cast<u32>(z), std::bit_cast<u32>(w));
+	}
+
+	/**
+	 * Stream a 128 bits vector from src to dst.
+	 */
+	static inline
+		void stream_vector_from_memory(void* dst, void* src)
+	{
+		const __m128i vector = _mm_loadu_si128(reinterpret_cast<__m128i*>(src));
+		_mm_stream_si128(reinterpret_cast<__m128i*>(dst), vector);
+	}
+}

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -619,7 +619,18 @@ void GLGSRender::end()
 		return;
 	}
 
-	analyse_current_rsx_pipeline();
+	if (m_graphics_state & (rsx::pipeline_state::fragment_program_ucode_dirty | rsx::pipeline_state::vertex_program_ucode_dirty))
+	{
+		// TODO: Move to shared code
+		if ((m_graphics_state & rsx::pipeline_state::vertex_program_ucode_dirty) &&
+			m_vertex_prog && !m_vertex_prog->has_indexed_constants)
+		{
+			m_graphics_state |= rsx::pipeline_state::transform_constants_dirty;
+		}
+
+		analyse_current_rsx_pipeline();
+	}
+
 	m_frame_stats.setup_time += m_profiler.duration();
 
 	// Active texture environment is used to decode shaders

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -621,13 +621,6 @@ void GLGSRender::end()
 
 	if (m_graphics_state & (rsx::pipeline_state::fragment_program_ucode_dirty | rsx::pipeline_state::vertex_program_ucode_dirty))
 	{
-		// TODO: Move to shared code
-		if ((m_graphics_state & rsx::pipeline_state::vertex_program_ucode_dirty) &&
-			m_vertex_prog && !m_vertex_prog->has_indexed_constants)
-		{
-			m_graphics_state |= rsx::pipeline_state::transform_constants_dirty;
-		}
-
 		analyse_current_rsx_pipeline();
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -807,7 +807,7 @@ void GLGSRender::load_program_env()
 			auto buf = static_cast<u8*>(mapping.first);
 
 			const std::vector<u16>& constant_ids = (transform_constants_size == 8192) ? std::vector<u16>{} : m_vertex_prog->constant_ids;
-			fill_vertex_program_constants_data(buf, m_vertex_prog ? m_vertex_prog->constant_ids : std::vector<u16>{});
+			fill_vertex_program_constants_data(buf, constant_ids);
 
 			m_transform_constants_buffer->bind_range(GL_VERTEX_CONSTANT_BUFFERS_BIND_SLOT, mapping.second, transform_constants_size);
 		}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -800,11 +800,14 @@ void GLGSRender::load_program_env()
 	if (update_transform_constants)
 	{
 		// Vertex constants
-		auto mapping = m_transform_constants_buffer->alloc_from_heap(8192, m_uniform_buffer_offset_align);
+		const std::vector<u16>& constant_ids = m_vertex_prog ? m_vertex_prog->constant_ids : std::vector<u16>{};
+		const usz transform_constants_size = constant_ids.empty() ? 8192 : constant_ids.size() * 16;
+
+		auto mapping = m_transform_constants_buffer->alloc_from_heap(transform_constants_size, m_uniform_buffer_offset_align);
 		auto buf = static_cast<u8*>(mapping.first);
 		fill_vertex_program_constants_data(buf, m_vertex_prog ? m_vertex_prog->constant_ids : std::vector<u16>{});
 
-		m_transform_constants_buffer->bind_range(GL_VERTEX_CONSTANT_BUFFERS_BIND_SLOT, mapping.second, 8192);
+		m_transform_constants_buffer->bind_range(GL_VERTEX_CONSTANT_BUFFERS_BIND_SLOT, mapping.second, transform_constants_size);
 	}
 
 	if (update_fragment_constants && !update_instruction_buffers)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -800,14 +800,17 @@ void GLGSRender::load_program_env()
 	if (update_transform_constants)
 	{
 		// Vertex constants
-		const std::vector<u16>& constant_ids = m_vertex_prog ? m_vertex_prog->constant_ids : std::vector<u16>{};
-		const usz transform_constants_size = constant_ids.empty() ? 8192 : constant_ids.size() * 16;
+		const usz transform_constants_size = (!m_vertex_prog || m_vertex_prog->has_indexed_constants) ? 8192 : m_vertex_prog->constant_ids.size() * 16;
+		if (transform_constants_size)
+		{
+			auto mapping = m_transform_constants_buffer->alloc_from_heap(transform_constants_size, m_uniform_buffer_offset_align);
+			auto buf = static_cast<u8*>(mapping.first);
 
-		auto mapping = m_transform_constants_buffer->alloc_from_heap(transform_constants_size, m_uniform_buffer_offset_align);
-		auto buf = static_cast<u8*>(mapping.first);
-		fill_vertex_program_constants_data(buf, m_vertex_prog ? m_vertex_prog->constant_ids : std::vector<u16>{});
+			const std::vector<u16>& constant_ids = (transform_constants_size == 8192) ? std::vector<u16>{} : m_vertex_prog->constant_ids;
+			fill_vertex_program_constants_data(buf, m_vertex_prog ? m_vertex_prog->constant_ids : std::vector<u16>{});
 
-		m_transform_constants_buffer->bind_range(GL_VERTEX_CONSTANT_BUFFERS_BIND_SLOT, mapping.second, transform_constants_size);
+			m_transform_constants_buffer->bind_range(GL_VERTEX_CONSTANT_BUFFERS_BIND_SLOT, mapping.second, transform_constants_size);
+		}
 	}
 
 	if (update_fragment_constants && !update_instruction_buffers)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -69,14 +69,14 @@ namespace gl
 class GLGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 {
 private:
-	GLFragmentProgram m_fragment_prog;
-	GLVertexProgram m_vertex_prog;
 
 	gl::sampler_state m_fs_sampler_states[rsx::limits::fragment_textures_count];         // Fragment textures
 	gl::sampler_state m_fs_sampler_mirror_states[rsx::limits::fragment_textures_count];  // Alternate views of fragment textures with different format (e.g Depth vs Stencil for D24S8)
 	gl::sampler_state m_vs_sampler_states[rsx::limits::vertex_textures_count];           // Vertex textures
 
 	gl::glsl::program *m_program = nullptr;
+	const GLFragmentProgram *m_fragment_prog = nullptr;
+	const GLVertexProgram *m_vertex_prog = nullptr;
 
 	u32 m_interpreter_state = 0;
 	gl::shader_interpreter m_shader_interpreter;

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
@@ -127,12 +127,15 @@ namespace gl
 		ParamArray arr;
 		GLVertexDecompilerThread comp(null_prog, shader_str, arr);
 
+		ParamType uniforms = { PF_PARAM_UNIFORM, "vec4" };
+		uniforms.items.emplace_back("vc[468]", -1);
+
 		std::stringstream builder;
 		comp.insertHeader(builder);
 
 		builder << "#define Z_NEGATIVE_ONE_TO_ONE\n\n";
 
-		comp.insertConstants(builder, {});
+		comp.insertConstants(builder, { uniforms });
 		comp.insertInputs(builder, {});
 
 		// Insert vp stream input

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -276,11 +276,8 @@ void GLVertexProgram::Decompile(const RSXVertexProgram& prog)
 	GLVertexDecompilerThread decompiler(prog, source, parr);
 	decompiler.Task();
 
-	if (has_indexed_constants = decompiler.properties.has_indexed_constants;
-		!has_indexed_constants)
-	{
-		constant_ids = std::vector<u16>(decompiler.m_constant_ids.begin(), decompiler.m_constant_ids.end());
-	}
+	has_indexed_constants = decompiler.properties.has_indexed_constants;
+	constant_ids = std::vector<u16>(decompiler.m_constant_ids.begin(), decompiler.m_constant_ids.end());
 
 	shader.create(::glsl::program_domain::glsl_vertex_program, source);
 	id = shader.id();

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -274,6 +274,8 @@ void GLVertexProgram::Decompile(const RSXVertexProgram& prog)
 
 	shader.create(::glsl::program_domain::glsl_vertex_program, source);
 	id = shader.id();
+	has_indexed_constants = decompiler.properties.has_indexed_constants;
+	constant_ids = std::move(decompiler.m_constant_ids);
 }
 
 void GLVertexProgram::Delete()

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -58,17 +58,21 @@ void GLVertexDecompilerThread::insertInputs(std::stringstream& OS, const std::ve
 
 void GLVertexDecompilerThread::insertConstants(std::stringstream& OS, const std::vector<ParamType>& constants)
 {
-	OS << "layout(std140, binding = 2) uniform VertexConstantsBuffer\n";
-	OS << "{\n";
-	OS << "	vec4 vc[468];\n";
-	OS << "};\n\n";
+
 
 	for (const ParamType &PT: constants)
 	{
 		for (const ParamItem &PI : PT.items)
 		{
-			if (PI.name == "vc[468]")
+			if (PI.name.starts_with("vc["))
+			{
+				OS << "layout(std140, binding = 2) uniform VertexConstantsBuffer\n";
+				OS << "{\n";
+				OS << "	vec4 " << PI.name << ";\n";
+				OS << "};\n\n";
+
 				continue;
+			}
 
 			OS << "uniform " << PT.type << " " << PI.name << ";\n";
 		}
@@ -272,10 +276,14 @@ void GLVertexProgram::Decompile(const RSXVertexProgram& prog)
 	GLVertexDecompilerThread decompiler(prog, source, parr);
 	decompiler.Task();
 
+	if (has_indexed_constants = decompiler.properties.has_indexed_constants;
+		!has_indexed_constants)
+	{
+		constant_ids = std::vector<u16>(decompiler.m_constant_ids.begin(), decompiler.m_constant_ids.end());
+	}
+
 	shader.create(::glsl::program_domain::glsl_vertex_program, source);
 	id = shader.id();
-	has_indexed_constants = decompiler.properties.has_indexed_constants;
-	constant_ids = std::move(decompiler.m_constant_ids);
 }
 
 void GLVertexProgram::Delete()

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.h
@@ -58,6 +58,8 @@ public:
 	ParamArray parr;
 	u32 id;
 	gl::glsl::shader shader;
+	std::vector<u16> constant_ids;
+	bool has_indexed_constants;
 
 	void Decompile(const RSXVertexProgram& prog);
 

--- a/rpcs3/Emu/RSX/Program/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Program/ShaderParam.h
@@ -130,12 +130,36 @@ struct ParamType
 	{
 	}
 
-	bool SearchName(const std::string& name) const
+	bool HasItem(const std::string& name) const
 	{
 		return std::any_of(items.cbegin(), items.cend(), [&name](const auto& item)
 		{
 			return item.name == name;
 		});
+	}
+
+	bool ReplaceOrInsert(const std::string& name, const ParamItem& item)
+	{
+		if (HasItem(name))
+		{
+			std::vector<ParamItem> new_list;
+			for (const auto& it : items)
+			{
+				if (it.name != item.name)
+				{
+					new_list.emplace_back(it.name, it.location, it.value);
+				}
+				else
+				{
+					new_list.emplace_back(item.name, item.location, item.value);
+				}
+			}
+
+			std::swap(items, new_list);
+		}
+
+		items.push_back(item);
+		return false;
 	}
 };
 
@@ -159,14 +183,14 @@ struct ParamArray
 		const auto& p = params[flag];
 		return std::any_of(p.cbegin(), p.cend(), [&name](const auto& param)
 		{
-			return param.SearchName(name);
+			return param.HasItem(name);
 		});
 	}
 
 	bool HasParam(const ParamFlag flag, const std::string& type, const std::string& name)
 	{
 		ParamType* t = SearchParam(flag, type);
-		return t && t->SearchName(name);
+		return t && t->HasItem(name);
 	}
 
 	std::string AddParam(const ParamFlag flag, const std::string& type, const std::string& name, const std::string& value)
@@ -175,7 +199,7 @@ struct ParamArray
 
 		if (t)
 		{
-			if (!t->SearchName(name)) t->items.emplace_back(name, -1, value);
+			if (!t->HasItem(name)) t->items.emplace_back(name, -1, value);
 		}
 		else
 		{
@@ -192,7 +216,7 @@ struct ParamArray
 
 		if (t)
 		{
-			if (!t->SearchName(name)) t->items.emplace_back(name, location);
+			if (!t->HasItem(name)) t->items.emplace_back(name, location);
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/Program/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Program/ShaderParam.h
@@ -145,7 +145,7 @@ struct ParamType
 			std::vector<ParamItem> new_list;
 			for (const auto& it : items)
 			{
-				if (it.name != item.name)
+				if (it.name != name)
 				{
 					new_list.emplace_back(it.name, it.location, it.value);
 				}
@@ -156,6 +156,7 @@ struct ParamType
 			}
 
 			std::swap(items, new_list);
+			return true;
 		}
 
 		items.push_back(item);

--- a/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.cpp
@@ -126,6 +126,8 @@ std::string VertexProgramDecompiler::GetSRC(const u32 n)
 		break;
 	case RSX_VP_REGISTER_TYPE_CONSTANT:
 		m_parr.AddParam(PF_PARAM_UNIFORM, getFloatTypeName(4), std::string("vc[468]"));
+		properties.has_indexed_constants |= !!d3.index_const;
+		m_constant_ids.push_back(d1.const_src);
 		ret += std::string("vc[") + std::to_string(d1.const_src) + (d3.index_const ? " + " + AddAddrReg() : "") + "]";
 		break;
 
@@ -389,6 +391,30 @@ std::string VertexProgramDecompiler::BuildCode()
 
 		// Initialize vertex output register to all 0, GPU hw does not always clear position register
 		m_parr.AddParam(PF_PARAM_OUT, float4_type, "dst_reg0", float4_type + "(0., 0., 0., 1.)");
+	}
+
+	if (!properties.has_indexed_constants && !m_constant_ids.empty())
+	{
+		// Relocate transform constants
+		std::vector<std::pair<std::string, std::string>> reloc_table;
+		reloc_table.reserve(m_constant_ids.size());
+
+		// First sort the data in ascending order
+		std::sort(m_constant_ids.begin(), m_constant_ids.end());
+
+		// Build the string lookup table
+		for (const auto& index : m_constant_ids)
+		{
+			reloc_table.emplace_back(fmt::format("vc[%d]", index), fmt::format("vc[%llu]", reloc_table.size()));
+		}
+
+		// One-time patch
+		main_body = fmt::replace_all(main_body, reloc_table);
+
+		// Rename the array type
+		auto type_list = ensure(m_parr.SearchParam(PF_PARAM_CONST, getFloatTypeName(4)));
+		const auto item = ParamItem(fmt::format("vc[%llu]", m_constant_ids.size()), -1);
+		type_list->ReplaceOrInsert("vc[468]", item);
 	}
 
 	std::stringstream OS;

--- a/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.h
@@ -63,7 +63,7 @@ struct VertexProgramDecompiler
 	const RSXVertexProgram& m_prog;
 	ParamArray m_parr;
 
-	std::vector<u16> m_constant_ids;
+	std::set<u16> m_constant_ids;
 
 	static std::string NotZeroPositive(const std::string& code);
 	std::string GetMask(bool is_sca) const;

--- a/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.h
@@ -63,6 +63,8 @@ struct VertexProgramDecompiler
 	const RSXVertexProgram& m_prog;
 	ParamArray m_parr;
 
+	std::vector<u16> m_constant_ids;
+
 	static std::string NotZeroPositive(const std::string& code);
 	std::string GetMask(bool is_sca) const;
 	std::string GetVecMask();
@@ -131,6 +133,7 @@ public:
 	struct
 	{
 		bool has_lit_op = false;
+		bool has_indexed_constants = false;
 	}
 	properties;
 

--- a/rpcs3/Emu/RSX/Program/program_state_cache2.hpp
+++ b/rpcs3/Emu/RSX/Program/program_state_cache2.hpp
@@ -9,19 +9,15 @@
 #endif
 
 template <typename Traits>
-void program_state_cache<Traits>::fill_fragment_constants_buffer(std::span<f32> dst_buffer, const RSXFragmentProgram &fragment_program, bool sanitize) const
+void program_state_cache<Traits>::fill_fragment_constants_buffer(std::span<f32> dst_buffer, const typename Traits::fragment_program_type& fragment_program, const RSXFragmentProgram& rsx_prog, bool sanitize) const
 {
-	const auto I = m_fragment_shader_cache.find(fragment_program);
-	if (I == m_fragment_shader_cache.end())
-		return;
-
-	ensure((dst_buffer.size_bytes() >= ::narrow<int>(I->second.FragmentConstantOffsetCache.size()) * 16u));
+	ensure((dst_buffer.size_bytes() >= ::narrow<int>(fragment_program.FragmentConstantOffsetCache.size()) * 16u));
 
 	f32* dst = dst_buffer.data();
 	alignas(16) f32 tmp[4];
-	for (usz offset_in_fragment_program : I->second.FragmentConstantOffsetCache)
+	for (usz offset_in_fragment_program : fragment_program.FragmentConstantOffsetCache)
 	{
-		char* data = static_cast<char*>(fragment_program.get_data()) + offset_in_fragment_program;
+		char* data = static_cast<char*>(rsx_prog.get_data()) + offset_in_fragment_program;
 
 #if defined(ARCH_X64)
 		const __m128i vector = _mm_loadu_si128(reinterpret_cast<__m128i*>(data));

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1649,6 +1649,9 @@ namespace rsx
 
 		m_graphics_state &= ~rsx::pipeline_state::fragment_program_ucode_dirty;
 
+		// Request for update of fragment constants if the program block is invalidated
+		m_graphics_state |= rsx::pipeline_state::fragment_constants_dirty;
+
 		const auto [program_offset, program_location] = method_registers.shader_program_address();
 		const auto prev_textures_reference_mask = current_fp_metadata.referenced_textures_mask;
 
@@ -1693,6 +1696,9 @@ namespace rsx
 
 		m_graphics_state &= ~rsx::pipeline_state::vertex_program_ucode_dirty;
 
+		// Reload transform constants unconditionally for now
+		m_graphics_state |= rsx::pipeline_state::transform_constants_dirty;
+
 		const u32 transform_program_start = rsx::method_registers.transform_program_start();
 		current_vertex_program.data.reserve(512 * 4);
 		current_vertex_program.jump_table.clear();
@@ -1724,12 +1730,6 @@ namespace rsx
 
 	void thread::analyse_current_rsx_pipeline()
 	{
-		if (m_graphics_state & rsx::pipeline_state::fragment_program_ucode_dirty)
-		{
-			// Request for update of fragment constants if the program block is invalidated
-			m_graphics_state |= rsx::pipeline_state::fragment_constants_dirty;
-		}
-
 		prefetch_vertex_program();
 		prefetch_fragment_program();
 	}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -864,16 +864,16 @@ namespace rsx
 	{
 		if (!reloc_table.empty()) [[ likely ]]
 		{
-			memcpy(buffer, rsx::method_registers.transform_constants.data(), 468 * 4 * sizeof(float));
-		}
-		else
-		{
 			char* dst = reinterpret_cast<char*>(buffer);
 			for (const auto& index : reloc_table)
 			{
 				utils::stream_vector_from_memory(dst, &rsx::method_registers.transform_constants[index]);
 				dst += 16;
 			}
+		}
+		else
+		{
+			memcpy(buffer, rsx::method_registers.transform_constants.data(), 468 * 4 * sizeof(float));
 		}
 	}
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -921,9 +921,9 @@ namespace rsx
 
 		/**
 		* Fill buffer with vertex program constants.
-		* Buffer must be at least 512 float4 wide.
+		* Relocation table allows to do a partial fill with only selected registers.
 		*/
-		void fill_vertex_program_constants_data(void* buffer);
+		void fill_vertex_program_constants_data(void* buffer, const std::vector<u16>& reloc_table);
 
 		/**
 		 * Fill buffer with fragment rasterization state.

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -1030,13 +1030,6 @@ void VKGSRender::end()
 
 	if (m_graphics_state & (rsx::pipeline_state::fragment_program_ucode_dirty | rsx::pipeline_state::vertex_program_ucode_dirty))
 	{
-		// TODO: Move to shared code
-		if ((m_graphics_state & rsx::pipeline_state::vertex_program_ucode_dirty) &&
-			m_vertex_prog && !m_vertex_prog->has_indexed_constants)
-		{
-			m_graphics_state |= rsx::pipeline_state::transform_constants_dirty;
-		}
-
 		analyse_current_rsx_pipeline();
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -1028,7 +1028,18 @@ void VKGSRender::end()
 		m_current_frame->flags &= ~frame_context_state::dirty;
 	}
 
-	analyse_current_rsx_pipeline();
+	if (m_graphics_state & (rsx::pipeline_state::fragment_program_ucode_dirty | rsx::pipeline_state::vertex_program_ucode_dirty))
+	{
+		// TODO: Move to shared code
+		if ((m_graphics_state & rsx::pipeline_state::vertex_program_ucode_dirty) &&
+			m_vertex_prog && !m_vertex_prog->has_indexed_constants)
+		{
+			m_graphics_state |= rsx::pipeline_state::transform_constants_dirty;
+		}
+
+		analyse_current_rsx_pipeline();
+	}
+
 	m_frame_stats.setup_time += m_profiler.duration();
 
 	load_texture_env();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1958,7 +1958,8 @@ void VKGSRender::load_program_env()
 		{
 			check_heap_status(VK_HEAP_CHECK_TRANSFORM_CONSTANTS_STORAGE);
 
-			auto mem = m_transform_constants_ring_info.alloc<1>(transform_constants_size);
+			const auto alignment = m_device->gpu().get_limits().minUniformBufferOffsetAlignment;
+			auto mem = m_transform_constants_ring_info.alloc<1>(utils::align(transform_constants_size, alignment));
 			auto buf = m_transform_constants_ring_info.map(mem, transform_constants_size);
 
 			const std::vector<u16>& constant_ids = (transform_constants_size == 8192) ? std::vector<u16>{} : m_vertex_prog->constant_ids;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -60,8 +60,8 @@ private:
 	};
 
 private:
-	VKFragmentProgram m_fragment_prog;
-	VKVertexProgram m_vertex_prog;
+	const VKFragmentProgram *m_fragment_prog = nullptr;
+	const VKVertexProgram *m_vertex_prog = nullptr;
 	vk::glsl::program *m_program = nullptr;
 	vk::pipeline_props m_pipeline_properties;
 

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -24,9 +24,12 @@ namespace vk
 		VKVertexProgram vk_prog;
 		VKVertexDecompilerThread comp(null_prog, shader_str, arr, vk_prog);
 
+		ParamType uniforms = { PF_PARAM_UNIFORM, "vec4" };
+		uniforms.items.emplace_back("vc[468]", -1);
+
 		std::stringstream builder;
 		comp.insertHeader(builder);
-		comp.insertConstants(builder, {});
+		comp.insertConstants(builder, { uniforms });
 		comp.insertInputs(builder, {});
 
 		// Insert vp stream input

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -350,11 +350,8 @@ void VKVertexProgram::Decompile(const RSXVertexProgram& prog)
 	VKVertexDecompilerThread decompiler(prog, source, parr, *this);
 	decompiler.Task();
 
-	if (has_indexed_constants = decompiler.properties.has_indexed_constants;
-		!has_indexed_constants)
-	{
-		constant_ids = std::vector<u16>(decompiler.m_constant_ids.begin(), decompiler.m_constant_ids.end());
-	}
+	has_indexed_constants = decompiler.properties.has_indexed_constants;
+	constant_ids = std::vector<u16>(decompiler.m_constant_ids.begin(), decompiler.m_constant_ids.end());
 
 	shader.create(::glsl::program_domain::glsl_vertex_program, source);
 }

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -101,27 +101,28 @@ void VKVertexDecompilerThread::insertInputs(std::stringstream& OS, const std::ve
 
 void VKVertexDecompilerThread::insertConstants(std::stringstream & OS, const std::vector<ParamType> & constants)
 {
-	OS << "layout(std140, set=0, binding = 1) uniform VertexConstantsBuffer\n";
-	OS << "{\n";
-	OS << "	vec4 vc[468];\n";
-	OS << "};\n\n";
-
 	vk::glsl::program_input in;
-	in.location = m_binding_table.vertex_constant_buffers_bind_slot;
-	in.domain = glsl::glsl_vertex_program;
-	in.name = "VertexConstantsBuffer";
-	in.type = vk::glsl::input_type_uniform_buffer;
-
-	inputs.push_back(in);
-
-
 	u32 location = m_binding_table.vertex_textures_first_bind_slot;
+
 	for (const ParamType &PT : constants)
 	{
 		for (const ParamItem &PI : PT.items)
 		{
-			if (PI.name == "vc[468]")
+			if (PI.name.starts_with("vc["))
+			{
+				OS << "layout(std140, set=0, binding = " << static_cast<int>(m_binding_table.vertex_constant_buffers_bind_slot) << ") uniform VertexConstantsBuffer\n";
+				OS << "{\n";
+				OS << "	vec4 " << PI.name << ";\n";
+				OS << "};\n\n";
+
+				in.location = m_binding_table.vertex_constant_buffers_bind_slot;
+				in.domain = glsl::glsl_vertex_program;
+				in.name = "VertexConstantsBuffer";
+				in.type = vk::glsl::input_type_uniform_buffer;
+
+				inputs.push_back(in);
 				continue;
+			}
 
 			if (PT.type == "sampler2D" ||
 				PT.type == "samplerCube" ||
@@ -349,9 +350,13 @@ void VKVertexProgram::Decompile(const RSXVertexProgram& prog)
 	VKVertexDecompilerThread decompiler(prog, source, parr, *this);
 	decompiler.Task();
 
+	if (has_indexed_constants = decompiler.properties.has_indexed_constants;
+		!has_indexed_constants)
+	{
+		constant_ids = std::vector<u16>(decompiler.m_constant_ids.begin(), decompiler.m_constant_ids.end());
+	}
+
 	shader.create(::glsl::program_domain::glsl_vertex_program, source);
-	has_indexed_constants = decompiler.properties.has_indexed_constants;
-	constant_ids = std::move(decompiler.m_constant_ids);
 }
 
 void VKVertexProgram::Compile()

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -350,6 +350,8 @@ void VKVertexProgram::Decompile(const RSXVertexProgram& prog)
 	decompiler.Task();
 
 	shader.create(::glsl::program_domain::glsl_vertex_program, source);
+	has_indexed_constants = decompiler.properties.has_indexed_constants;
+	constant_ids = std::move(decompiler.m_constant_ids);
 }
 
 void VKVertexProgram::Compile()

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.h
@@ -63,6 +63,8 @@ public:
 	u32 id;
 	vk::glsl::shader shader;
 	std::vector<vk::glsl::program_input> uniforms;
+	std::vector<u16> constant_ids;
+	bool has_indexed_constants;
 
 	void Decompile(const RSXVertexProgram& prog);
 	void Compile();

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -450,6 +450,7 @@
     <ClInclude Include="Emu\Cell\Modules\cellStorage.h" />
     <ClInclude Include="Emu\Cell\Modules\libfs_utility_init.h" />
     <ClInclude Include="Emu\Cell\Modules\sys_crashdump.h" />
+    <ClInclude Include="Emu\CPU\sse2neon.h" />
     <ClInclude Include="Emu\Io\camera_config.h" />
     <ClInclude Include="Emu\Io\camera_handler_base.h" />
     <ClInclude Include="Emu\Io\music_handler_base.h" />
@@ -479,6 +480,7 @@
     <ClInclude Include="Emu\NP\rpcn_config.h" />
     <ClInclude Include="Emu\perf_monitor.hpp" />
     <ClInclude Include="Emu\RSX\Common\bitfield.hpp" />
+    <ClInclude Include="Emu\RSX\Common\buffer_stream.hpp" />
     <ClInclude Include="Emu\RSX\Common\profiling_timer.hpp" />
     <ClInclude Include="Emu\RSX\Common\ranged_map.hpp" />
     <ClInclude Include="Emu\RSX\Common\simple_array.hpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2065,6 +2065,12 @@
     <ClInclude Include="Emu\RSX\Common\ranged_map.hpp">
       <Filter>Emu\GPU\RSX\Common</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\CPU\sse2neon.h">
+      <Filter>Emu\CPU</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Common\buffer_stream.hpp">
+      <Filter>Emu\GPU\RSX\Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Emu\RSX\Common\Interpreter\FragmentInterpreter.glsl">


### PR DESCRIPTION
For non-skinning shaders, there is rarely any use of dynamic memory indexing (using a variable to calculate address). Instead, in most cases the non-uniform input comes in from the vertex attributes and the vertex program has a simple memory access pattern after compilation. Vertex programs have about 8KB of program memory we need to update every time the program is changed, but if the program has static memory addressing, the actual bits that will be consumed are known beforehand. We can therefore relocate the addresses and "pack" the data for each vertex program instead of updating a huge 8KB block each time. With this setup, the 8KB of updates shrinks down to a few dozen bytes per program which is significantly faster. Gives upto ~10% performance uplift in RSX-constrained scenarios.