### PR TITLE
rsx: Misc fixes

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -874,6 +874,12 @@ namespace rsx
 							tex.set_dirty(true);
 							result.invalidate_samplers = true;
 						}
+
+						if (tex.is_dirty() && tex.get_context() == rsx::texture_upload_context::framebuffer_storage)
+						{
+							// Make sure the region is not going to get immediately reprotected
+							m_flush_always_cache.erase(tex.get_section_range());
+						}
 					}
 				}
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1329,11 +1329,17 @@ namespace rsx
 		{
 			std::lock_guard lock(m_cache_mutex);
 
-			auto* region_ptr = find_cached_texture(memory_range, { .gcm_format = RSX_GCM_FORMAT_IGNORED }, false, false, false);
+			auto* region_ptr = find_cached_texture(memory_range, { .gcm_format = RSX_GCM_FORMAT_IGNORED }, false, false, true);
 			if (region_ptr == nullptr)
 			{
 				AUDIT(m_flush_always_cache.find(memory_range) == m_flush_always_cache.end());
 				rsx_log.error("set_memory_flags(0x%x, 0x%x, %d): region_ptr == nullptr", memory_range.start, memory_range.end, static_cast<u32>(flags));
+				return;
+			}
+
+			if (region_ptr->is_dirty())
+			{
+				// Previously invalidated
 				return;
 			}
 

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -459,8 +459,8 @@ namespace rsx
 			{
 				if (found_slices > 0)
 				{
-					//TODO: Gather remaining sides from the texture cache or upload from cpu (too slow?)
-					rsx_log.error("Could not gather all required slices for cubemap/3d generation");
+					// TODO: Gather remaining sides from the texture cache or upload from cpu (too slow?)
+					rsx_log.warning("Could not gather all required slices for cubemap/3d generation");
 				}
 				else
 				{

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1353,9 +1353,28 @@ namespace rsx
 
 				set_dirty(false);
 			}
+
+			if (context == rsx::texture_upload_context::framebuffer_storage)
+			{
+				// Lock, unlock
+				if (prot == utils::protection::no && old_prot != utils::protection::no)
+				{
+					// Locked memory. We have to take ownership of the object in the surface cache as well
+					auto surface = derived()->get_render_target();
+					surface->add_ref();
+				}
+				else if (old_prot == utils::protection::no && prot != utils::protection::no)
+				{
+					// Release the surface, the cache can remove it if needed
+					ensure(prot == utils::protection::rw);
+					auto surface = derived()->get_render_target();
+					surface->release();
+				}
+			}
 		}
 
 	public:
+
 		inline void protect(utils::protection prot)
 		{
 			utils::protection old_prot = get_protection();
@@ -1442,6 +1461,11 @@ namespace rsx
 			}
 
 			flush_exclusions.clear();
+
+			if (context == rsx::texture_upload_context::framebuffer_storage)
+			{
+				derived()->get_render_target()->sync_tag();
+			}
 		}
 
 		void on_speculative_flush()

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1354,7 +1354,7 @@ namespace rsx
 				set_dirty(false);
 			}
 
-			if (context == rsx::texture_upload_context::framebuffer_storage)
+			if (context == rsx::texture_upload_context::framebuffer_storage && !Emu.IsStopped())
 			{
 				// Lock, unlock
 				if (prot == utils::protection::no && old_prot != utils::protection::no)

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
@@ -81,12 +81,6 @@ namespace gl
 				rsx_log.error("Unexpected swizzled texture format 0x%x", static_cast<u32>(format));
 			}
 		}
-
-		if (context == rsx::texture_upload_context::framebuffer_storage)
-		{
-			// Update memory tag
-			static_cast<gl::render_target*>(vram_texture)->sync_tag();
-		}
 	}
 
 	gl::texture_view* texture_cache::create_temporary_subresource_impl(gl::command_context& cmd, gl::texture* src, GLenum sized_internal_fmt, GLenum dst_type,

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -406,6 +406,11 @@ namespace gl
 			return managed_texture.get();
 		}
 
+		gl::render_target* get_render_target()
+		{
+			return gl::as_rtt(vram_texture);
+		}
+
 		gl::texture_view* get_raw_view()
 		{
 			return vram_texture->get_view(0xAAE4, rsx::default_remap_vector);

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -97,7 +97,11 @@ void VKGSRender::present(vk::frame_context_t *ctx)
 			swapchain_unavailable = true;
 			break;
 		default:
-			vk::die_with_error(error);
+			// Other errors not part of rpcs3. This can be caused by 3rd party injectors with bad code, of which we have no control over.
+			// Let the application attempt to recover instead of crashing outright.
+			rsx_log.error("VkPresent returned unexpected error code %lld. Will attempt to recreate the swapchain. Please disable 3rd party injector tools.", static_cast<s64>(error));
+			swapchain_unavailable = true;
+			break;
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -910,7 +910,7 @@ namespace vk
 
 			if (msaa_flags & rsx::surface_state_flags::require_resolve)
 			{
-				if (access.is_transfer() && access.is_read())
+				if (access.is_transfer())
 				{
 					// Only do this step when read access is required
 					get_resolve_target_safe(cmd);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -151,6 +151,11 @@ namespace vk
 			return managed_texture;
 		}
 
+		vk::render_target* get_render_target()
+		{
+			return vk::as_rtt(vram_texture);
+		}
+
 		VkFormat get_format() const
 		{
 			if (context == rsx::texture_upload_context::dma)
@@ -292,12 +297,6 @@ namespace vk
 				default:
 					rsx_log.error("Unexpected swizzled texture format 0x%x", gcm_format);
 				}
-			}
-
-			if (context == rsx::texture_upload_context::framebuffer_storage)
-			{
-				// Update memory tag
-				static_cast<vk::render_target*>(vram_texture)->sync_tag();
 			}
 		}
 


### PR DESCRIPTION
Fixes multiple smaller bugs.
- Hardens vulkan against crashing due to broken 3rd party injectors. https://github.com/RPCS3/rpcs3/issues/11521
- Fix MSAA causing a crash in transfer-write situations after the last rewrite. https://github.com/RPCS3/rpcs3/issues/11680
- Fix some ref leaks in texture cache w.r.t surface cache data. https://github.com/RPCS3/rpcs3/issues/11643, https://github.com/RPCS3/rpcs3/issues/10168

Fixes https://github.com/RPCS3/rpcs3/issues/11521
Fixes https://github.com/RPCS3/rpcs3/issues/11680
Fixes https://github.com/RPCS3/rpcs3/issues/11643
Fixes https://github.com/RPCS3/rpcs3/issues/10168