### PR TITLE
rsx: Fix possible crashing after surface cache refs PR

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.cpp
+++ b/rpcs3/Emu/RSX/Common/texture_cache.cpp
@@ -96,6 +96,9 @@ namespace rsx
 			tex_cache_checker.remove(locked_range, protection);
 #endif
 
+		// Save previous state to compare for changes
+		const auto prev_confirmed_range = confirmed_range;
+
 		if (prot != utils::protection::rw)
 		{
 			if (confirmed_range.valid())
@@ -113,7 +116,7 @@ namespace rsx
 			init_lockable_range(confirmed_range);
 		}
 
-		protect(prot, true);
+		protect(prot, confirmed_range != prev_confirmed_range);
 	}
 
 	void buffered_section::unprotect()

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -67,14 +67,26 @@ namespace gl
 	public:
 		using baseclass::cached_texture_section;
 
-		void create(u16 w, u16 h, u16 depth, u16 mipmaps, gl::texture* image, u32 rsx_pitch, bool read_only,
+		void create(u16 w, u16 h, u16 depth, u16 mipmaps, gl::texture* image, u32 rsx_pitch, bool managed,
 				gl::texture::format gl_format = gl::texture::format::rgba, gl::texture::type gl_type = gl::texture::type::ubyte, bool swap_bytes = false)
 		{
+			if (vram_texture && !managed_texture && get_protection() == utils::protection::no)
+			{
+				// In-place image swap, still locked. Likely a color buffer that got rebound as depth buffer or vice-versa.
+				gl::as_rtt(vram_texture)->release();
+
+				if (!managed)
+				{
+					// Incoming is also an external resource, reference it immediately
+					gl::as_rtt(image)->add_ref();
+				}
+			}
+
 			auto new_texture = static_cast<gl::viewable_image*>(image);
 			ensure(!exists() || !is_managed() || vram_texture == new_texture);
 			vram_texture = new_texture;
 
-			if (read_only)
+			if (managed)
 			{
 				managed_texture.reset(vram_texture);
 			}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -47,6 +47,18 @@ namespace vk
 
 		void create(u16 w, u16 h, u16 depth, u16 mipmaps, vk::image* image, u32 rsx_pitch, bool managed, u32 gcm_format, bool pack_swap_bytes = false)
 		{
+			if (vram_texture && !managed_texture && get_protection() == utils::protection::no)
+			{
+				// In-place image swap, still locked. Likely a color buffer that got rebound as depth buffer or vice-versa.
+				vk::as_rtt(vram_texture)->release();
+
+				if (!managed)
+				{
+					// Incoming is also an external resource, reference it immediately
+					vk::as_rtt(image)->add_ref();
+				}
+			}
+
 			auto new_texture = static_cast<vk::viewable_image*>(image);
 			ensure(!exists() || !is_managed() || vram_texture == new_texture);
 			vram_texture = new_texture;


### PR DESCRIPTION
- Fixes DeS crashing on loading levels. Fromsoft engine has some quirky PS3 behavior that is well known regarding dynamic image usage to get around some hw limitations. This can cause in-place swapping of locked regions, with no change to the underlying protection.
- Check for page holes when initializing DMA layer to fix games that use segfault handlers to initialize data.
- Skip unnecessary protect syscalls. They are not cheap.

Fixes https://github.com/RPCS3/rpcs3/issues/11549
Fixes https://github.com/RPCS3/rpcs3/issues/11703