### PR TITLE
Fix RPCS3 crash caused by double free of the game window

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1690,7 +1690,7 @@ void Emulator::GracefulShutdown(bool allow_autoexit, bool async_op)
 
 	auto perform_kill = [allow_autoexit, this, info = ProcureCurrentEmulationCourseInformation()]()
 	{
-		for (u32 i = 0; i < 50; i++)
+		for (u32 i = 0; i < 100; i++)
 		{
 			std::this_thread::sleep_for(50ms);
 			Resume(); // TODO: Prevent pausing by other threads while in this loop

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -357,21 +357,34 @@ bool gs_frame::get_mouse_lock_state()
 	return isActive() && m_mouse_hide_and_lock;
 }
 
+void gs_frame::hide_on_close()
+{
+	if (!(+g_progr))
+	{
+		// Hide the dialog before stopping if no progress bar is being shown.
+		// Otherwise users might think that the game softlocked if stopping takes too long.
+		QWindow::hide();
+	}
+}
+
 void gs_frame::close()
 {
+	if (m_is_closing.exchange(true))
+	{
+		gui_log.notice("Closing game window (ignored, already closing)");
+		return;
+	}
+
 	gui_log.notice("Closing game window");
 
 	Emu.CallFromMainThread([this]()
 	{
-		if (!(+g_progr))
-		{
-			// Hide the dialog before stopping if no progress bar is being shown.
-			// Otherwise users might think that the game softlocked if stopping takes too long.
-			QWindow::hide();
-		}
+		// Hide window if necessary
+		hide_on_close();
 
 		if (!Emu.IsStopped())
 		{
+			// Blocking shutdown request. Obsolete, but I'm keeping it here as last resort.
 			Emu.GracefulShutdown(true, false);
 		}
 
@@ -838,7 +851,23 @@ bool gs_frame::event(QEvent* ev)
 		}
 
 		gui_log.notice("Game window close event issued");
-		close();
+
+		if (Emu.IsStopped())
+		{
+			// This should be unreachable, but never say never. Properly close the window anyway.
+			close();
+		}
+		else
+		{
+			// Issue async shutdown
+			Emu.GracefulShutdown(true, true);
+
+			// Hide window if necessary
+			hide_on_close();
+
+			// Do not propagate the close event. It will be closed by the rsx_thread.
+			return true;
+		}
 	}
 	else if (ev->type() == QEvent::MouseMove && (!m_show_mouse || m_mousehide_timer.isActive()))
 	{

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -830,19 +830,9 @@ bool gs_frame::event(QEvent* ev)
 			}
 
 			int result = QMessageBox::Yes;
-			atomic_t<bool> called = false;
-
-			Emu.CallFromMainThread([this, &result, &called]()
-			{
-				m_gui_settings->ShowConfirmationBox(tr("Exit Game?"),
-					tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>"),
-					gui::ib_confirm_exit, &result, nullptr);
-
-				called = true;
-				called.notify_one();
-			});
-
-			called.wait(false);
+			m_gui_settings->ShowConfirmationBox(tr("Exit Game?"),
+				tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>"),
+				gui::ib_confirm_exit, &result, nullptr);
 
 			if (result != QMessageBox::Yes)
 			{

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -41,6 +41,7 @@ private:
 	u64 m_frames = 0;
 	std::string m_window_title;
 	QWindow::Visibility m_last_visibility = Visibility::Windowed;
+	atomic_t<bool> m_is_closing = false;
 	atomic_t<bool> m_show_mouse = true;
 	bool m_disable_mouse = false;
 	bool m_disable_kb_hotkeys = false;
@@ -97,6 +98,7 @@ protected:
 	bool event(QEvent* ev) override;
 
 private:
+	void hide_on_close();
 	void toggle_mouselock();
 	void update_cursor();
 	void handle_cursor(QWindow::Visibility visibility, bool from_event, bool start_idle_timer);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -73,6 +73,10 @@ extern void process_qt_events()
 {
 	if (thread_ctrl::is_main())
 	{
+		// NOTE:
+		// I noticed that calling this from an Emu callback can cause the
+		// caller to get stuck for a while during newly opened Qt dialogs.
+		// Adding a timeout here doesn't seem to do anything in that case.
 		QApplication::processEvents();
 	}
 }


### PR DESCRIPTION
Should fix #11694 

To explain:
What happened was that if you opened the settings dialog directly after terminating the game, then waited until it was finished, and finally closed the dialog, RPCS3 would crash.

The immediate cause of the crash was a duplicate call to deleteLater of gs_frame, after the gs_frame was already destroyed.
By replacing Emu.Stop() with GracefulShutdown() in gs_frame::close(), the game window was now unknowingly closed recursively, causing RPCS3 to crash in some cases.

The reason as to why this is only an issue after opening and closing the settings dialog lies in the fact that we call QApplication::processEvents while we wait for the game to finish. Somehow the code does not return from one of the processEvents calls while the dialog is open, suggesting that the whole dialog is now processed inside that call.
After finally closing the dialog we return to the original closing emu callback which finally deletes the object.
The only problem is that the Vulkan/OpenGl renderers already closed the game window a second time while we were waiting. The Qt garbage collector had enough time to delete the gs_frame already, resulting in a crash.

If the dialog is not being opened by the user immediately, then the time between the 2 calls to deleteLater is not long enough for the dialog to get destroyed, so it wasn't an issue, at least not that I know of.

In the past, this wouldn't have happened, because Emu.Stop() and Emu.Quit() were designed in a way that only allowed a single call to gs_frame::close().

Let's just ignore any consecutive calls to gs_frame::close() from now on.
The only weird things that remain are the processEvents shenanigans and the fact that the gs_frame will now be destroyed after the settings dialog was closed, which both seem to be fine for now.

Finally let's also increase the shutdown time to 5 seconds, as was mentioned in the associated comment anyway.

Edit:
Instead of having the weird recursion, we now issue a shutdown request, meaning that the only way to actually close the game window during emulation is to call close() from the rsx_thread (or destroy the object).