### PR TITLE
Revert "gs_frame: remove unnecessary CallFromMainThread"

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -830,9 +830,19 @@ bool gs_frame::event(QEvent* ev)
 			}
 
 			int result = QMessageBox::Yes;
-			m_gui_settings->ShowConfirmationBox(tr("Exit Game?"),
-				tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>"),
-				gui::ib_confirm_exit, &result, nullptr);
+			atomic_t<bool> called = false;
+
+			Emu.CallFromMainThread([this, &result, &called]()
+			{
+				m_gui_settings->ShowConfirmationBox(tr("Exit Game?"),
+					tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>"),
+					gui::ib_confirm_exit, &result, nullptr);
+
+				called = true;
+				called.notify_one();
+			});
+
+			called.wait(false);
 
 			if (result != QMessageBox::Yes)
 			{


### PR DESCRIPTION
This reverts commit 3002e592c367c9414fafc3df6cefddcaab32cf71.
I think it was necessary after all.
I'll test this later, unless someone can confirm.