### PR TITLE
[TESTERS NEEDED] cellVdec overhaul -> fixes broken videos in Uncharted 2

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -268,6 +268,8 @@ struct vdec_context final
 			fmt::throw_exception("avcodec_open2() failed (err=0x%x='%s', opts=%s)", err, utils::av_error_to_string(err), dict_content);
 		}
 
+		av_dict_free(&opts);
+
 		seq_state = sequence_state::dormant;
 	}
 
@@ -412,12 +414,10 @@ struct vdec_context final
 							{
 								break;
 							}
-							else
-							{
-								char av_error[AV_ERROR_MAX_STRING_SIZE];
-								av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, ret);
-								fmt::throw_exception("AU decoding error(0x%x): %s", ret, av_error);
-							}
+
+							char av_error[AV_ERROR_MAX_STRING_SIZE]{};
+							av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, ret);
+							fmt::throw_exception("AU decoding error(0x%x): %s", ret, av_error);
 						}
 
 						if (frame->interlaced_frame)

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -388,15 +388,14 @@ struct vdec_context final
 
 				cellVdec.trace("AU decoding: size=0x%x, pts=0x%llx, dts=0x%llx, userdata=0x%llx", au_size, au_pts, au_dts, au_usrd);
 
-				while (thread_ctrl::state() != thread_state::aborting && !abort_decode)
+				if (int ret = avcodec_send_packet(ctx, &packet); ret < 0)
 				{
-					if (int ret = avcodec_send_packet(ctx, &packet); ret < 0)
-					{
-						char av_error[AV_ERROR_MAX_STRING_SIZE]{};
-						av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, ret);
-						fmt::throw_exception("AU queuing error(0x%x): %s", ret, av_error);
-					}
-
+					char av_error[AV_ERROR_MAX_STRING_SIZE]{};
+					av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, ret);
+					fmt::throw_exception("AU queuing error(0x%x): %s", ret, av_error);
+				}
+				else
+				{
 					while (!abort_decode)
 					{
 						// Keep receiving frames
@@ -555,8 +554,6 @@ struct vdec_context final
 							}
 						}
 					}
-
-					break;
 				}
 
 				if (thread_ctrl::state() != thread_state::aborting && !abort_decode)

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -719,9 +719,39 @@ static error_code vdecQueryAttr(s32 type, u32 profile, u32 spec_addr /* may be 0
 	{
 		cellVdec.warning("cellVdecQueryAttr: DivX (profile=%d)", profile);
 
-		//const vm::ptr<CellVdecDivxSpecificInfo2> sinfo = vm::cast(spec_addr);
+		const vm::ptr<CellVdecDivxSpecificInfo2> sinfo = vm::cast(spec_addr);
+
+		if (sinfo)
+		{
+			if (sinfo->thisSize != sizeof(CellVdecDivxSpecificInfo2))
+			{
+				return CELL_VDEC_ERROR_ARG;
+			}
+		}
 
 		// TODO: sinfo
+
+		//const u32 maxDecH = sinfo ? +sinfo->maxDecodedFrameHeight : 0;
+		//const u32 maxDecW = sinfo ? +sinfo->maxDecodedFrameWidth : 0;
+		u32 nrOfBuf       = sinfo ? +sinfo->numberOfDecodedFrameBuffer : 0;
+
+		if (nrOfBuf == 0)
+		{
+			nrOfBuf = 4;
+		}
+		else if (nrOfBuf == 2)
+		{
+			if (profile != CELL_VDEC_DIVX_QMOBILE && profile != CELL_VDEC_DIVX_MOBILE)
+			{
+				return CELL_VDEC_ERROR_ARG;
+			}
+		}
+		else if (nrOfBuf != 4 && nrOfBuf != 3)
+		{
+			return CELL_VDEC_ERROR_ARG;
+		}
+
+		// TODO: change memSize based on buffercount.
 
 		switch (profile)
 		{

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -390,9 +390,7 @@ struct vdec_context final
 
 				if (int ret = avcodec_send_packet(ctx, &packet); ret < 0)
 				{
-					char av_error[AV_ERROR_MAX_STRING_SIZE]{};
-					av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, ret);
-					fmt::throw_exception("AU queuing error(0x%x): %s", ret, av_error);
+					fmt::throw_exception("AU queuing error(0x%x): %s", ret, utils::av_error_to_string(ret));
 				}
 				else
 				{
@@ -414,9 +412,7 @@ struct vdec_context final
 								break;
 							}
 
-							char av_error[AV_ERROR_MAX_STRING_SIZE]{};
-							av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, ret);
-							fmt::throw_exception("AU decoding error(0x%x): %s", ret, av_error);
+							fmt::throw_exception("AU decoding error(0x%x): %s", ret, utils::av_error_to_string(ret));
 						}
 
 						if (frame->interlaced_frame)
@@ -1209,9 +1205,7 @@ error_code cellVdecGetPictureExt(u32 handle, vm::cptr<CellVdecPicFormat2> format
 
 			if (const int ret = av_image_fill_linesizes(out_line, out_f, w); ret < 0)
 			{
-				char av_error[AV_ERROR_MAX_STRING_SIZE]{};
-				av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, ret);
-				fmt::throw_exception("cellVdecGetPicture: av_image_fill_linesizes failed (ret=0x%x): %s", ret, av_error);
+				fmt::throw_exception("cellVdecGetPicture: av_image_fill_linesizes failed (ret=0x%x): %s", ret, utils::av_error_to_string(ret));
 			}
 		}
 

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -1243,12 +1243,12 @@ error_code cellVdecGetPicItem(u32 handle, vm::pptr<CellVdecPicItem> picItem)
 	info->auNum = 1;
 	info->auPts[0].lower = static_cast<u32>(pts);
 	info->auPts[0].upper = static_cast<u32>(pts >> 32);
-	info->auPts[1].lower = -1;
-	info->auPts[1].upper = -1;
+	info->auPts[1].lower = CELL_CODEC_PTS_INVALID;
+	info->auPts[1].upper = CELL_CODEC_PTS_INVALID;
 	info->auDts[0].lower = static_cast<u32>(dts);
 	info->auDts[0].upper = static_cast<u32>(dts >> 32);
-	info->auDts[1].lower = -1;
-	info->auDts[1].upper = -1;
+	info->auDts[1].lower = CELL_CODEC_DTS_INVALID;
+	info->auDts[1].upper = CELL_CODEC_DTS_INVALID;
 	info->auUserData[0] = usrd;
 	info->auUserData[1] = 0;
 	info->status = CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -977,7 +977,7 @@ error_code cellVdecDecodeAu(u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVd
 
 	if (!vdec || !auInfo || !auInfo->pts.upper || !auInfo->startAddr)
 	{
-		return CELL_VDEC_ERROR_ARG;
+		return { CELL_VDEC_ERROR_ARG, fmt::format("vdec=%d, auInfo=%d, upper=%d, startAddr=0x%x", !!vdec, !!auInfo, auInfo ? auInfo->pts.upper.value() : 0, auInfo ? auInfo->startAddr.value() : 0) };
 	}
 
 	{
@@ -991,7 +991,7 @@ error_code cellVdecDecodeAu(u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVd
 
 	if (mode < 0 || mode > CELL_VDEC_DEC_MODE_PB_SKIP)
 	{
-		return CELL_VDEC_ERROR_ARG;
+		return { CELL_VDEC_ERROR_ARG, fmt::format("mode=%d", +mode) };
 	}
 
 	// TODO:

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -1023,17 +1023,17 @@ error_code cellVdecDecodeAu(u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVd
 		}
 	}
 
-	if (mode < 0 || mode > CELL_VDEC_DEC_MODE_PB_SKIP)
+	if (mode < 0 || mode > (CELL_VDEC_DEC_MODE_B_SKIP | CELL_VDEC_DEC_MODE_PB_SKIP))
 	{
 		return { CELL_VDEC_ERROR_ARG, fmt::format("mode=%d", +mode) };
 	}
 
-	// TODO:
-	//if ((mode == (CELL_VDEC_DEC_MODE_B_SKIP | CELL_VDEC_DEC_MODE_PB_SKIP) && something != 3) ||
-	//	(mode == CELL_VDEC_DEC_MODE_PB_SKIP && something != 1))
-	//{
-	//	return CELL_VDEC_ERROR_ARG;
-	//}
+	// TODO: what does the 3 stand for ?
+	if ((mode == CELL_VDEC_CODEC_TYPE_MAX && vdec->type != 3) ||
+		(mode == CELL_VDEC_DEC_MODE_PB_SKIP && vdec->type != CELL_VDEC_CODEC_TYPE_AVC))
+	{
+		return { CELL_VDEC_ERROR_ARG, fmt::format("mode=%d, type=%d", +mode, vdec->type) };
+	}
 
 	if (!vdec->au_count.try_inc(4))
 	{

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -1009,9 +1009,9 @@ error_code cellVdecDecodeAu(u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVd
 
 	const auto vdec = idm::get<vdec_context>(handle);
 
-	if (!vdec || !auInfo || !auInfo->pts.upper || !auInfo->startAddr)
+	if (!vdec || !auInfo || !auInfo->size || !auInfo->startAddr)
 	{
-		return { CELL_VDEC_ERROR_ARG, fmt::format("vdec=%d, auInfo=%d, upper=%d, startAddr=0x%x", !!vdec, !!auInfo, auInfo ? auInfo->pts.upper.value() : 0, auInfo ? auInfo->startAddr.value() : 0) };
+		return { CELL_VDEC_ERROR_ARG, fmt::format("vdec=%d, auInfo=%d, size=%d, startAddr=0x%x", !!vdec, !!auInfo, auInfo ? auInfo->size.value() : 0, auInfo ? auInfo->startAddr.value() : 0) };
 	}
 
 	{
@@ -1051,9 +1051,9 @@ error_code cellVdecDecodeAuEx2(u32 handle, CellVdecDecodeMode mode, vm::cptr<Cel
 
 	const auto vdec = idm::get<vdec_context>(handle);
 
-	if (!vdec || !auInfo || !auInfo->pts.upper || !auInfo->startAddr)
+	if (!vdec || !auInfo || !auInfo->size || !auInfo->startAddr)
 	{
-		return { CELL_VDEC_ERROR_ARG, fmt::format("vdec=%d, auInfo=%d, upper=%d, startAddr=0x%x", !!vdec, !!auInfo, auInfo ? auInfo->pts.upper.value() : 0, auInfo ? auInfo->startAddr.value() : 0) };
+		return { CELL_VDEC_ERROR_ARG, fmt::format("vdec=%d, auInfo=%d, size=%d, startAddr=0x%x", !!vdec, !!auInfo, auInfo ? auInfo->size.value() : 0, auInfo ? auInfo->startAddr.value() : 0) };
 	}
 
 	{

--- a/rpcs3/Emu/Cell/Modules/cellVdec.h
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.h
@@ -71,6 +71,12 @@ enum CellVdecFrameRate : s32
 	CELL_VDEC_FRC_60           = 0x87,
 };
 
+enum
+{
+	CELL_CODEC_PTS_INVALID = 0xffffffff,
+	CELL_CODEC_DTS_INVALID = 0xffffffff,
+};
+
 // Codec Type Information
 struct CellVdecType
 {

--- a/rpcs3/Emu/Cell/Modules/cellVdec.h
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.h
@@ -17,6 +17,7 @@ enum CellVdecCodecType : s32
 	CELL_VDEC_CODEC_TYPE_MPEG2 = 0,
 	CELL_VDEC_CODEC_TYPE_AVC   = 1,
 	CELL_VDEC_CODEC_TYPE_DIVX  = 5,
+	CELL_VDEC_CODEC_TYPE_MAX
 };
 
 // Callback Messages

--- a/rpcs3/Emu/Cell/Modules/cellVdec.h
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.h
@@ -144,6 +144,19 @@ struct CellVdecAuInfo
 	be_t<u64> codecSpecificData;
 };
 
+// Access Unit Information
+struct CellVdecAuInfoEx2 // Speculative name
+{
+	be_t<u32> startAddr;
+	be_t<u32> unk1; // Speculative
+	be_t<u32> size;
+	be_t<u32> unk2; // Speculative
+	CellCodecTimeStamp pts;
+	CellCodecTimeStamp dts;
+	be_t<u64> userData;
+	be_t<u64> codecSpecificData;
+};
+
 // Output Picture Information
 struct CellVdecPicItem
 {

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -57,7 +57,7 @@ namespace utils
 
 	std::string av_error_to_string(int error)
 	{
-		char av_error[AV_ERROR_MAX_STRING_SIZE];
+		char av_error[AV_ERROR_MAX_STRING_SIZE]{};
 		av_make_error_string(av_error, AV_ERROR_MAX_STRING_SIZE, error);
 		return av_error;
 	}


### PR DESCRIPTION
- Implemented a missing error CELL_VDEC_ERROR_SEQ in cellVdec.
The error is returned whenever a function is called during the wrong state of the sequence decode.
This could have an impact on all games and might break some (hopefully none) while fixing others.
- Fixed the output line offsets for YUV formats (which fixes video output issues in Uncharted 2)
- Added lots of error handling that was missing before. This might or might not impact some games.
- Added a bunch of other random stuff that's probably not gonna change anything

Apparently also fixes #4167
Also seems to fix #8394