### PR TITLE
rsx: Implement Z value snapping to account for precision errors

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -634,7 +634,9 @@ namespace glsl
 				"		const float real_f = max(far_plane, near_plane);\n"
 				"		const double depth_range = double(real_f - real_n);\n"
 				"		const double inv_range = (depth_range > 0.000001) ? (1.0 / (depth_range * pos.w)) : 0.0;\n"
-				"		const double d = (double(pos.z) - double(real_n * pos.w)) * inv_range;\n"
+				"		const double actual_d = (double(pos.z) - double(real_n * pos.w)) * inv_range;\n"
+				"		const double nearest_d = floor(actual_d + 0.5);\n"
+				"		const double d = _select(actual_d, nearest_d, abs(actual_d - nearest_d) < 0.000002);\n"  // Epsilon value settled on empirically
 				"		return vec4(pos.xy, float(d * pos.w), pos.w);\n"
 				"	}\n"
 				"	else\n"

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -636,7 +636,8 @@ namespace glsl
 				"		const double inv_range = (depth_range > 0.000001) ? (1.0 / (depth_range * pos.w)) : 0.0;\n"
 				"		const double actual_d = (double(pos.z) - double(real_n * pos.w)) * inv_range;\n"
 				"		const double nearest_d = floor(actual_d + 0.5);\n"
-				"		const double d = _select(actual_d, nearest_d, abs(actual_d - nearest_d) < 0.000002);\n"  // Epsilon value settled on empirically
+				"		const double epsilon = (inv_range * pos.w) / 16777215.;\n"     // Epsilon value is the minimum discernable change in Z that should affect the stored Z
+				"		const double d = _select(actual_d, nearest_d, abs(actual_d - nearest_d) < epsilon);\n"
 				"		return vec4(pos.xy, float(d * pos.w), pos.w);\n"
 				"	}\n"
 				"	else\n"


### PR DESCRIPTION
Snap resulting Z values to integral stops to try and account for precision errors.
The cause of the errors is actually the inversion of w. Large w values will give very small results that have tiny precision loss. The computed NDC Z is then very slightly outside the range we want (e.g 1.0000001 in a Z range of 0.99-1.0)

Fixes https://github.com/RPCS3/rpcs3/issues/11669
Fixes https://github.com/RPCS3/rpcs3/issues/11765