### PR TITLE
Log viewer: add thread options

### DIFF
--- a/rpcs3/rpcs3qt/log_viewer.h
+++ b/rpcs3/rpcs3qt/log_viewer.h
@@ -22,6 +22,7 @@ private Q_SLOTS:
 	void show_context_menu(const QPoint& pos);
 
 private:
+	void set_text_and_keep_position(const QString& text);
 	void filter_log();
 	bool is_valid_file(const QMimeData& md, bool save = false);
 
@@ -34,6 +35,7 @@ private:
 	std::unique_ptr<find_dialog> m_find_dialog;
 	std::bitset<32> m_log_levels = std::bitset<32>(0b11111111u);
 	bool m_show_threads = true;
+	bool m_last_actions_only = false;
 
 protected:
 	void dropEvent(QDropEvent* ev) override;

--- a/rpcs3/rpcs3qt/log_viewer.h
+++ b/rpcs3/rpcs3qt/log_viewer.h
@@ -33,6 +33,7 @@ private:
 	LogHighlighter* m_log_highlighter;
 	std::unique_ptr<find_dialog> m_find_dialog;
 	std::bitset<32> m_log_levels = std::bitset<32>(0b11111111u);
+	bool m_show_threads = true;
 
 protected:
 	void dropEvent(QDropEvent* ev) override;


### PR DESCRIPTION
- Adds the ability to hide thread names
- Adds the ability to only show the last 10 lines of each thread since the last boot