### PR TITLE
Windows: Version display fixes

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -478,7 +478,7 @@ int main(int argc, char** argv)
 	{
 		// Write RPCS3 version
 		logs::stored_message ver{sys_log.always()};
-		ver.text = fmt::format("RPCS3 v%s | %s", rpcs3::get_version().to_string(), rpcs3::get_branch());
+		ver.text = fmt::format("RPCS3 v%s", rpcs3::get_verbose_version());
 
 		// Write System information
 		logs::stored_message sys{sys_log.always()};

--- a/rpcs3/rpcs3_version.cpp
+++ b/rpcs3/rpcs3_version.cpp
@@ -34,22 +34,40 @@ namespace rpcs3
 
 	std::string get_version_and_branch()
 	{
-		// Get version by substringing VersionNumber-buildnumber-commithash to get just the part before the dash
-		std::string version = rpcs3::get_version().to_string();
-		const auto last_minus = version.find_last_of('-');
-
 		// Add branch and commit hash to version on frame unless it's master.
 		if (rpcs3::get_branch() != "master"sv && rpcs3::get_branch() != "HEAD"sv)
 		{
-			version = version.substr(0, ~last_minus ? last_minus + 9 : last_minus);
-			version += '-';
-			version += rpcs3::get_branch();
-		}
-		else
-		{
-			version = version.substr(0, last_minus);
+			return get_verbose_version();
 		}
 
+		// Get version by substringing VersionNumber-buildnumber-commithash to get just the part before the dash
+		std::string version = rpcs3::get_version().to_string();
+
+		const auto last_minus = version.find_last_of('-');
+		version = version.substr(0, last_minus);
+
 		return version;
+	}
+
+	std::string get_verbose_version()
+	{
+		std::string version = fmt::format("%s | %s", rpcs3::get_version().to_string(), get_branch());
+		if (is_local_build())
+		{
+			fmt::append(version, " | local_build");
+		}
+		return version;
+	}
+
+	bool is_release_build()
+	{
+		static constexpr bool is_release_build = std::string_view(RPCS3_GIT_FULL_BRANCH) == "RPCS3/rpcs3/master"sv;
+		return is_release_build;
+	}
+
+	bool is_local_build()
+	{
+		static constexpr bool is_local_build = std::string_view(RPCS3_GIT_FULL_BRANCH) == "local_build"sv;
+		return is_local_build;
 	}
 }

--- a/rpcs3/rpcs3_version.h
+++ b/rpcs3/rpcs3_version.h
@@ -9,4 +9,7 @@ namespace rpcs3
 	std::pair<std::string, std::string> get_commit_and_hash();
 	const utils::version& get_version();
 	std::string get_version_and_branch();
+	std::string get_verbose_version();
+	bool is_release_build();
+	bool is_local_build();
 }

--- a/rpcs3/rpcs3qt/about_dialog.cpp
+++ b/rpcs3/rpcs3qt/about_dialog.cpp
@@ -13,7 +13,7 @@ about_dialog::about_dialog(QWidget* parent) : QDialog(parent), ui(new Ui::about_
 
 	ui->close->setDefault(true);
 	ui->icon->load(QStringLiteral(":/rpcs3.svg"));
-	ui->version->setText(tr("RPCS3 Version: %1").arg(QString::fromStdString(rpcs3::get_version().to_string())));
+	ui->version->setText(tr("RPCS3 Version: %1").arg(QString::fromStdString(rpcs3::get_verbose_version())));
 
 	// Events
 	connect(ui->gitHub, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://www.github.com/RPCS3")); });

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -120,13 +120,14 @@ bool main_window::Init(bool with_cli_boot)
 	CreateConnects();
 
 	setMinimumSize(350, minimumSizeHint().height());    // seems fine on win 10
-	setWindowTitle(QString::fromStdString("RPCS3 " + rpcs3::get_version().to_string()));
+	setWindowTitle(QString::fromStdString("RPCS3 " + rpcs3::get_verbose_version()));
 
 	Q_EMIT RequestGlobalStylesheetChange();
 	ConfigureGuiFromSettings();
 
-	if (const std::string_view branch_name = rpcs3::get_full_branch(); branch_name != "RPCS3/rpcs3/master" && branch_name != "local_build")
+	if (!rpcs3::is_release_build() && !rpcs3::is_local_build())
 	{
+		const std::string_view branch_name = rpcs3::get_full_branch();
 		gui_log.warning("Experimental Build Warning! Build origin: %s", branch_name);
 
 		QMessageBox msg;


### PR DESCRIPTION
- Adjust git version script to cirrus ci logic
- Unify GUI version displays
The only version that is different is the game window due to some formatting.
And the update message is left unchanged due to some checks with upstream.

Local builds:
RPCS3 0.0.21-d2fed339 Alpha | da_branch | local_build

PR/Fork builds:
RPCS3 0.0.21-d2fed339 Alpha | da_branch

Master:
RPCS3 0.0.21-13444-d2fed339 Alpha
Ain the window title:
RPCS3 0.0.21-13444 Alpha
