### PR TITLE
sys_net: SYS_NET_ENETDOWN for offline dns rqsts

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
@@ -869,11 +869,11 @@ std::optional<s32> lv2_socket_native::sendto(s32 flags, const std::vector<u8>& b
 	{
 		const s32 ret_analyzer = dnshook.analyze_dns_packet(lv2_id, reinterpret_cast<const u8*>(buf.data()), buf.size());
 
-		// If we're not connected just never send the packet and pretend we did
+		// If we're offline return ENETDOWN for dns requests
 		auto& nph = g_fxo->get<named_thread<np::np_handler>>();
 		if (!nph.get_net_status())
 		{
-			return {::narrow<s32>(buf.size())};
+			return -SYS_NET_ENETDOWN;
 		}
 
 		// Check if the packet is intercepted


### PR DESCRIPTION
Atm we pretend we send the packets but don't, instead return -SYS_NET_ENETDOWN.

Fixes https://github.com/RPCS3/rpcs3/issues/9293
Fixes https://github.com/RPCS3/rpcs3/issues/9360
