### PR TITLE
sys_net: Fix race between dnshook and nc

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
@@ -15,7 +15,15 @@ lv2_socket_native::lv2_socket_native(lv2_socket_family family, lv2_socket_type t
 
 lv2_socket_native::~lv2_socket_native()
 {
-	close();
+	std::lock_guard lock(mutex);
+	if (socket)
+	{
+#ifdef _WIN32
+		::closesocket(socket);
+#else
+		::close(socket);
+#endif
+	}
 }
 
 s32 lv2_socket_native::create_socket()


### PR DESCRIPTION
On closing dnshook was destroyed before network_context which could still hold shared_ptr of lv2_socket_native objects.
Upon nc termination destructor was called which called close() which called a dnshook method and crashed.

Now just closing the socket if necessary and ignore dnshook in the destructor(this doesn't affect in-game behaviour as the socket can be removed from idm only through close() ).