### PR TITLE
Add signed integer support for game patches

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -496,6 +496,11 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 	default:
 	{
 		p_data.value.long_value = get_yaml_node_value<u64>(value_node, error_message);
+		if (error_message.find("bad conversion") != std::string::npos)
+		{
+			error_message           = "";
+			p_data.value.long_value = get_yaml_node_value<s64>(value_node, error_message);
+		}
 		break;
 	}
 	}

--- a/rpcs3/util/yaml.cpp
+++ b/rpcs3/util/yaml.cpp
@@ -78,5 +78,6 @@ std::string get_yaml_node_location(YAML::Node node)
 
 template u32 get_yaml_node_value<u32>(YAML::Node, std::string&);
 template u64 get_yaml_node_value<u64>(YAML::Node, std::string&);
+template s64 get_yaml_node_value<s64>(YAML::Node, std::string&);
 template f64 get_yaml_node_value<f64>(YAML::Node, std::string&);
 template cheat_info get_yaml_node_value<cheat_info>(YAML::Node, std::string&);


### PR DESCRIPTION
In older versions of RPCS3, you were able to use negative values for unsigned integers. However, with the yaml-cpp update in #10961 this was no longer possible, as yaml-cpp cannot read negative values as unsigned integer anymore.

This PR makes it so negative values can be used again. If a value fails with u64 read (default), then it will try s64 instead.