### PR TITLE
cellOskDialog: Implement keyboard input support

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -98,7 +98,7 @@ error_code cellKbClearBuf(u32 port_no)
 
 	for (int i = 0; i < CELL_KB_MAX_KEYCODES; i++)
 	{
-		current_data.keycode[i] = { 0, 0 };
+		current_data.buttons[i] = KbButton(CELL_KEYC_NO_EVENT, 0, false);
 	}
 
 	return CELL_OK;
@@ -312,7 +312,7 @@ error_code cellKbRead(u32 port_no, vm::ptr<CellKbData> data)
 	{
 		for (s32 i = 0; i < current_data.len; i++)
 		{
-			data->keycode[i] = current_data.keycode[i].first;
+			data->keycode[i] = current_data.buttons[i].m_keyCode;
 		}
 
 		KbConfig& current_config = handler.GetConfig(port_no);

--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -304,9 +304,19 @@ error_code cellKbRead(u32 port_no, vm::ptr<CellKbData> data)
 		return CELL_KB_ERROR_NO_DEVICE;
 
 	KbData& current_data = handler.GetData(port_no);
-	data->led = current_data.led;
-	data->mkey = current_data.mkey;
-	data->len = std::min<s32>(CELL_KB_MAX_KEYCODES, current_data.len);
+
+	if (current_info.is_null_handler || (current_info.info & CELL_KB_INFO_INTERCEPTED))
+	{
+		data->led = 0;
+		data->mkey = 0;
+		data->len = 0;
+	}
+	else
+	{
+		data->led = current_data.led;
+		data->mkey = current_data.mkey;
+		data->len = std::min<s32>(CELL_KB_MAX_KEYCODES, current_data.len);
+	}
 
 	if (current_data.len > 0)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellKb.h
+++ b/rpcs3/Emu/Cell/Modules/cellKb.h
@@ -56,3 +56,5 @@ struct CellKbConfig
 	be_t<u32> read_mode;
 	be_t<u32> code_type;
 };
+
+u16 cellKbCnvRawCode(u32 arrange, u32 mkey, u32 led, u16 rawcode);

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -209,8 +209,9 @@ error_code cellMouseGetData(u32 port_no, vm::ptr<CellMouseData> data)
 
 	MouseDataList& data_list = handler.GetDataList(port_no);
 
-	if (data_list.empty())
+	if (data_list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED))
 	{
+		data_list.clear();
 		return CELL_OK;
 	}
 
@@ -252,9 +253,18 @@ error_code cellMouseGetDataList(u32 port_no, vm::ptr<CellMouseDataList> data)
 		return CELL_MOUSE_ERROR_NO_DEVICE;
 	}
 
+	std::memset(data.get_ptr(), 0, data.size());
+
 	// TODO: check if (current_info.mode[port_no] != CELL_MOUSE_INFO_TABLET_MOUSE_MODE) has any impact
 
 	auto& list = handler.GetDataList(port_no);
+
+	if (list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED))
+	{
+		list.clear();
+		return CELL_OK;
+	}
+
 	data->list_num = std::min<u32>(CELL_MOUSE_MAX_DATA_LIST_NUM, static_cast<u32>(list.size()));
 
 	int i = 0;
@@ -332,10 +342,19 @@ error_code cellMouseGetTabletDataList(u32 port_no, vm::ptr<CellMouseTabletDataLi
 		return CELL_MOUSE_ERROR_NO_DEVICE;
 	}
 
+	std::memset(data.get_ptr(), 0, data.size());
+
 	// TODO: decr tests show that CELL_MOUSE_ERROR_DATA_READ_FAILED is returned when a mouse is connected
 	// TODO: check if (current_info.mode[port_no] != CELL_MOUSE_INFO_TABLET_TABLET_MODE) has any impact
 
 	auto& list = handler.GetTabletDataList(port_no);
+
+	if (list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED))
+	{
+		list.clear();
+		return CELL_OK;
+	}
+
 	data->list_num = std::min<u32>(CELL_MOUSE_MAX_DATA_LIST_NUM, static_cast<u32>(list.size()));
 
 	int i = 0;
@@ -350,6 +369,8 @@ error_code cellMouseGetTabletDataList(u32 port_no, vm::ptr<CellMouseTabletDataLi
 			it->data[k] = 0;
 		}
 	}
+
+	list.clear();
 
 	return CELL_OK;
 }
@@ -377,10 +398,19 @@ error_code cellMouseGetRawData(u32 port_no, vm::ptr<CellMouseRawData> data)
 		return CELL_MOUSE_ERROR_NO_DEVICE;
 	}
 
+	std::memset(data.get_ptr(), 0, data.size());
+
 	// TODO: decr tests show that CELL_MOUSE_ERROR_DATA_READ_FAILED is returned when a mouse is connected
 	// TODO: check if (current_info.mode[port_no] != CELL_MOUSE_INFO_TABLET_MOUSE_MODE) has any impact
 
 	MouseRawData& current_data = handler.GetRawData(port_no);
+
+	if (current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED))
+	{
+		current_data = {};
+		return CELL_OK;
+	}
+
 	data->len = current_data.len;
 	current_data.len = 0;
 

--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -168,7 +168,7 @@ error_code cellMusicSetSelectionContext2(vm::ptr<CellMusicSelectionContext> cont
 
 error_code cellMusicSetVolume2(f32 level)
 {
-	cellMusic.todo("cellMusicSetVolume2(level=%f)", level);
+	cellMusic.warning("cellMusicSetVolume2(level=%f)", level);
 
 	level = std::clamp(level, 0.0f, 1.0f);
 
@@ -260,7 +260,7 @@ error_code cellMusicInitialize2SystemWorkload(s32 mode, vm::ptr<CellMusic2Callba
 
 error_code cellMusicGetPlaybackStatus2(vm::ptr<s32> status)
 {
-	cellMusic.todo("cellMusicGetPlaybackStatus2(status=*0x%x)", status);
+	cellMusic.warning("cellMusicGetPlaybackStatus2(status=*0x%x)", status);
 
 	if (!status)
 		return CELL_MUSIC2_ERROR_PARAM;
@@ -389,7 +389,7 @@ error_code cellMusicGetSelectionContext2(vm::ptr<CellMusicSelectionContext> cont
 
 error_code cellMusicGetVolume(vm::ptr<f32> level)
 {
-	cellMusic.todo("cellMusicGetVolume(level=*0x%x)", level);
+	cellMusic.warning("cellMusicGetVolume(level=*0x%x)", level);
 
 	if (!level)
 		return CELL_MUSIC_ERROR_PARAM;
@@ -402,7 +402,7 @@ error_code cellMusicGetVolume(vm::ptr<f32> level)
 
 error_code cellMusicGetPlaybackStatus(vm::ptr<s32> status)
 {
-	cellMusic.todo("cellMusicGetPlaybackStatus(status=*0x%x)", status);
+	cellMusic.warning("cellMusicGetPlaybackStatus(status=*0x%x)", status);
 
 	if (!status)
 		return CELL_MUSIC_ERROR_PARAM;
@@ -567,7 +567,7 @@ error_code cellMusicInitialize2(s32 mode, s32 spuPriority, vm::ptr<CellMusic2Cal
 
 error_code cellMusicSetVolume(f32 level)
 {
-	cellMusic.todo("cellMusicSetVolume(level=%f)", level);
+	cellMusic.warning("cellMusicSetVolume(level=%f)", level);
 
 	level = std::clamp(level, 0.0f, 1.0f);
 
@@ -589,7 +589,7 @@ error_code cellMusicSetVolume(f32 level)
 
 error_code cellMusicGetVolume2(vm::ptr<f32> level)
 {
-	cellMusic.todo("cellMusicGetVolume2(level=*0x%x)", level);
+	cellMusic.warning("cellMusicGetVolume2(level=*0x%x)", level);
 
 	if (!level)
 		return CELL_MUSIC2_ERROR_PARAM;

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -612,6 +612,7 @@ error_code cellOskDialogSetInitialInputDevice(u32 inputDevice)
 	g_fxo->get<osk_info>().initial_input_device = static_cast<CellOskDialogInputDevice>(inputDevice);
 
 	// TODO: use value
+	// TODO: Signal CELL_SYSUTIL_OSKDIALOG_INPUT_DEVICE_CHANGED if the input device changed (probably only when the dialog is already open)
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -507,7 +507,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 	Emu.CallFromMainThread([=, &result, &info]()
 	{
-		osk->Create(get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE), message, osk->osk_text, maxLength, prohibitFlgs, allowOskPanelFlg, firstViewPanel, info.base_color.load());
+		osk->Create(get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE), message, osk->osk_text, maxLength, prohibitFlgs, allowOskPanelFlg, firstViewPanel, info.base_color.load(), info.dimmer_enabled.load());
 		result = true;
 		result.notify_one();
 
@@ -698,7 +698,7 @@ error_code cellOskDialogAbort()
 
 error_code cellOskDialogSetDeviceMask(u32 deviceMask)
 {
-	cellOskDialog.todo("cellOskDialogSetDeviceMask(deviceMask=0x%x)", deviceMask);
+	cellOskDialog.warning("cellOskDialogSetDeviceMask(deviceMask=0x%x)", deviceMask);
 
 	// TODO: It might also return an error if use_separate_windows is not enabled
 	if (deviceMask > CELL_OSKDIALOG_DEVICE_MASK_PAD)
@@ -782,11 +782,9 @@ error_code cellOskDialogSetInitialKeyLayout(u32 initialKeyLayout)
 
 error_code cellOskDialogDisableDimmer()
 {
-	cellOskDialog.todo("cellOskDialogDisableDimmer()");
+	cellOskDialog.warning("cellOskDialogDisableDimmer()");
 
 	g_fxo->get<osk_info>().dimmer_enabled = false;
-
-	// TODO: use value
 
 	return CELL_OK;
 }
@@ -852,7 +850,7 @@ error_code cellOskDialogGetInputText(vm::ptr<CellOskDialogCallbackReturnParam> O
 
 error_code register_keyboard_event_hook_callback(u16 hookEventMode, vm::ptr<cellOskDialogHardwareKeyboardEventHookCallback> pCallback)
 {
-	cellOskDialog.todo("register_keyboard_event_hook_callback(hookEventMode=%u, pCallback=*0x%x)", hookEventMode, pCallback);
+	cellOskDialog.warning("register_keyboard_event_hook_callback(hookEventMode=%u, pCallback=*0x%x)", hookEventMode, pCallback);
 
 	if (!pCallback)
 	{
@@ -867,7 +865,7 @@ error_code register_keyboard_event_hook_callback(u16 hookEventMode, vm::ptr<cell
 
 error_code cellOskDialogExtRegisterKeyboardEventHookCallback(u16 hookEventMode, vm::ptr<cellOskDialogHardwareKeyboardEventHookCallback> pCallback)
 {
-	cellOskDialog.todo("cellOskDialogExtRegisterKeyboardEventHookCallback(hookEventMode=%u, pCallback=*0x%x)", hookEventMode, pCallback);
+	cellOskDialog.warning("cellOskDialogExtRegisterKeyboardEventHookCallback(hookEventMode=%u, pCallback=*0x%x)", hookEventMode, pCallback);
 
 	if (hookEventMode == 0 || hookEventMode > (CELL_OSKDIALOG_EVENT_HOOK_TYPE_FUNCTION_KEY | CELL_OSKDIALOG_EVENT_HOOK_TYPE_ASCII_KEY))
 	{
@@ -879,7 +877,7 @@ error_code cellOskDialogExtRegisterKeyboardEventHookCallback(u16 hookEventMode, 
 
 error_code cellOskDialogExtRegisterKeyboardEventHookCallbackEx(u16 hookEventMode, vm::ptr<cellOskDialogHardwareKeyboardEventHookCallback> pCallback)
 {
-	cellOskDialog.todo("cellOskDialogExtRegisterKeyboardEventHookCallbackEx(hookEventMode=%u, pCallback=*0x%x)", hookEventMode, pCallback);
+	cellOskDialog.warning("cellOskDialogExtRegisterKeyboardEventHookCallbackEx(hookEventMode=%u, pCallback=*0x%x)", hookEventMode, pCallback);
 
 	if (hookEventMode == 0 || hookEventMode > (CELL_OSKDIALOG_EVENT_HOOK_TYPE_FUNCTION_KEY | CELL_OSKDIALOG_EVENT_HOOK_TYPE_ASCII_KEY | CELL_OSKDIALOG_EVENT_HOOK_TYPE_ONLY_MODIFIER))
 	{
@@ -949,7 +947,7 @@ error_code cellOskDialogExtSetInitialScale(f32 initialScale)
 
 error_code cellOskDialogExtInputDeviceLock()
 {
-	cellOskDialog.todo("cellOskDialogExtInputDeviceLock()");
+	cellOskDialog.warning("cellOskDialogExtInputDeviceLock()");
 
 	// TODO: error checks
 
@@ -965,7 +963,7 @@ error_code cellOskDialogExtInputDeviceLock()
 
 error_code cellOskDialogExtInputDeviceUnlock()
 {
-	cellOskDialog.todo("cellOskDialogExtInputDeviceUnlock()");
+	cellOskDialog.warning("cellOskDialogExtInputDeviceUnlock()");
 
 	// TODO: error checks
 
@@ -981,7 +979,7 @@ error_code cellOskDialogExtInputDeviceUnlock()
 
 error_code cellOskDialogExtSetBaseColor(f32 red, f32 green, f32 blue, f32 alpha)
 {
-	cellOskDialog.todo("cellOskDialogExtSetBaseColor(red=%f, blue=%f, green=%f, alpha=%f)", red, blue, green, alpha);
+	cellOskDialog.warning("cellOskDialogExtSetBaseColor(red=%f, blue=%f, green=%f, alpha=%f)", red, blue, green, alpha);
 
 	if (red < 0.0f || red > 1.0f || green < 0.0f || green > 1.0f || blue < 0.0f || blue > 1.0f || alpha < 0.0f || alpha > 1.0f)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -75,10 +75,7 @@ struct osk_info
 	atomic_t<u32> supported_languages = 0; // Used to enable non-default languages in the OSK
 
 	atomic_t<bool> dimmer_enabled = true;
-	atomic_t<f32> base_color_red = 1.0f;
-	atomic_t<f32> base_color_green = 1.0f;
-	atomic_t<f32> base_color_blue = 1.0f;
-	atomic_t<f32> base_color_alpha = 1.0f;
+	atomic_t<OskDialogBase::color> base_color = OskDialogBase::color{ 0.2f, 0.2f, 0.2f, 1.0f };
 
 	atomic_t<bool> pointer_enabled = false;
 	CellOskDialogPoint pointer_pos{0.0f, 0.0f};
@@ -112,10 +109,7 @@ struct osk_info
 		half_byte_kana_enabled = false;
 		supported_languages = 0;
 		dimmer_enabled = true;
-		base_color_red = 1.0f;
-		base_color_blue = 1.0f;
-		base_color_green = 1.0f;
-		base_color_alpha = 1.0f;
+		base_color = OskDialogBase::color{ 0.2f, 0.2f, 0.2f, 1.0f };
 		pointer_enabled = false;
 		pointer_pos = {0.0f, 0.0f};
 		initial_scale = 1.0f;
@@ -511,9 +505,9 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 		return CELL_OK;
 	}
 
-	Emu.CallFromMainThread([=, &result]()
+	Emu.CallFromMainThread([=, &result, &info]()
 	{
-		osk->Create(get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE), message, osk->osk_text, maxLength, prohibitFlgs, allowOskPanelFlg, firstViewPanel);
+		osk->Create(get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE), message, osk->osk_text, maxLength, prohibitFlgs, allowOskPanelFlg, firstViewPanel, info.base_color.load());
 		result = true;
 		result.notify_one();
 
@@ -995,12 +989,7 @@ error_code cellOskDialogExtSetBaseColor(f32 red, f32 green, f32 blue, f32 alpha)
 	}
 
 	auto& osk = g_fxo->get<osk_info>();
-	osk.base_color_red = red;
-	osk.base_color_green = green;
-	osk.base_color_blue = blue;
-	osk.base_color_alpha = alpha;
-
-	// TODO: use osk base color
+	osk.base_color = OskDialogBase::color{ red, green, blue, alpha };
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -253,7 +253,15 @@ enum class OskDialogState
 class OskDialogBase
 {
 public:
-	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) = 0;
+	struct color
+	{
+		f32 r = 1.0f;
+		f32 g = 1.0f;
+		f32 b = 1.0f;
+		f32 a = 1.0f;
+	};
+
+	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color) = 0;
 
 	// Closes the dialog.
 	// Set status to CELL_OSKDIALOG_CLOSE_CONFIRM or CELL_OSKDIALOG_CLOSE_CANCEL for user input.

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -261,7 +261,7 @@ public:
 		f32 a = 1.0f;
 	};
 
-	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color) = 0;
+	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled) = 0;
 
 	// Closes the dialog.
 	// Set status to CELL_OSKDIALOG_CLOSE_CONFIRM or CELL_OSKDIALOG_CLOSE_CANCEL for user input.

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -262,7 +262,7 @@ public:
 	virtual ~OskDialogBase();
 
 	std::function<void(s32 status)> on_osk_close;
-	std::function<void()> on_osk_input_entered;
+	std::function<void(CellOskDialogKeyMessage key_message)> on_osk_key_input_entered;
 
 	atomic_t<OskDialogState> state{ OskDialogState::Unloaded };
 	atomic_t<bool> pad_input_enabled{ true };      // Determines if the OSK consumes the device's events.

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -265,6 +265,10 @@ public:
 	std::function<void()> on_osk_input_entered;
 
 	atomic_t<OskDialogState> state{ OskDialogState::Unloaded };
+	atomic_t<bool> pad_input_enabled{ true };      // Determines if the OSK consumes the device's events.
+	atomic_t<bool> mouse_input_enabled{ true };    // Determines if the OSK consumes the device's events.
+	atomic_t<bool> keyboard_input_enabled{ true }; // Determines if the OSK consumes the device's events.
+	atomic_t<bool> ignore_input_events{ false };   // Determines if the OSK ignores all consumed events.
 
 	atomic_t<CellOskDialogInputFieldResult> osk_input_result{ CellOskDialogInputFieldResult::CELL_OSKDIALOG_INPUT_FIELD_RESULT_OK };
 	char16_t osk_text[CELL_OSKDIALOG_STRING_SIZE]{};

--- a/rpcs3/Emu/Io/KeyboardHandler.cpp
+++ b/rpcs3/Emu/Io/KeyboardHandler.cpp
@@ -71,7 +71,7 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed)
 
 			if (pressed)
 			{
-				if (data.len == 1 && data.keycode[0].first == CELL_KEYC_NO_EVENT)
+				if (data.len == 1 && data.buttons[0].m_keyCode == CELL_KEYC_NO_EVENT)
 				{
 					data.len = 0;
 				}
@@ -83,11 +83,11 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed)
 
 					if (config.read_mode == CELL_KB_RMODE_INPUTCHAR)
 					{
-						data.keycode[0] = { CELL_KEYC_NO_EVENT, button.m_outKeyCode };
+						data.buttons[0] = KbButton(CELL_KEYC_NO_EVENT, button.m_outKeyCode, true);
 					}
 					else
 					{
-						data.keycode[data.len % CELL_KB_MAX_KEYCODES] = { CELL_KEYC_NO_EVENT, button.m_outKeyCode };
+						data.buttons[data.len % CELL_KB_MAX_KEYCODES] = KbButton(CELL_KEYC_NO_EVENT, button.m_outKeyCode, true);
 					}
 				}
 				else
@@ -101,11 +101,11 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed)
 
 					if (config.read_mode == CELL_KB_RMODE_INPUTCHAR)
 					{
-						data.keycode[0] = { kcode, 0 };
+						data.buttons[0] = KbButton(kcode, button.m_outKeyCode, true);
 					}
 					else
 					{
-						data.keycode[data.len % CELL_KB_MAX_KEYCODES] = { kcode, 0 };
+						data.buttons[data.len % CELL_KB_MAX_KEYCODES] = KbButton(kcode, button.m_outKeyCode, true);
 					}
 				}
 
@@ -122,7 +122,7 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed)
 				// Needed to indicate key releases. Without this you have to tap another key before using the same key again
 				if (config.read_mode == CELL_KB_RMODE_INPUTCHAR)
 				{
-					data.keycode[0] = { CELL_KEYC_NO_EVENT, 0 };
+					data.buttons[0] = KbButton(CELL_KEYC_NO_EVENT, button.m_outKeyCode, false);
 					data.len = 1;
 				}
 				else
@@ -131,7 +131,7 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed)
 
 					for (s32 i = 0; i < data.len; i++)
 					{
-						if (data.keycode[i].first == kcode && (!is_meta_key || data.keycode[i].second == button.m_outKeyCode))
+						if (data.buttons[i].m_keyCode == kcode && (!is_meta_key || data.buttons[i].m_outKeyCode == button.m_outKeyCode))
 						{
 							index = i;
 							break;
@@ -140,12 +140,12 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed)
 
 					for (s32 i = index; i < data.len - 1; i++)
 					{
-						data.keycode[i] = data.keycode[i + 1];
+						data.buttons[i] = data.buttons[i + 1];
 					}
 
 					if (data.len <= 1)
 					{
-						data.keycode[0] = { CELL_KEYC_NO_EVENT, 0 };
+						data.buttons[0] = KbButton(CELL_KEYC_NO_EVENT, button.m_outKeyCode, false);
 					}
 
 					data.len = std::max(1, data.len - 1);
@@ -177,9 +177,9 @@ void KeyboardHandlerBase::SetIntercepted(bool intercepted)
 			keyboard.m_data.mkey = 0;
 			keyboard.m_data.len  = 0;
 
-			for (auto& keycode : keyboard.m_data.keycode)
+			for (auto& button : keyboard.m_data.buttons)
 			{
-				keycode.first = CELL_KEYC_NO_EVENT;
+				button.m_keyCode = CELL_KEYC_NO_EVENT;
 			}
 		}
 	}

--- a/rpcs3/Emu/Io/KeyboardHandler.h
+++ b/rpcs3/Emu/Io/KeyboardHandler.h
@@ -24,10 +24,25 @@ enum QtKeys
 
 struct KbInfo
 {
-	u32 max_connect;
-	u32 now_connect;
-	u32 info;
-	u8 status[CELL_KB_MAX_KEYBOARDS];
+	u32 max_connect = 0;
+	u32 now_connect = 0;
+	u32 info = 0;
+	std::array<u8, CELL_KB_MAX_KEYBOARDS> status{};
+};
+
+struct KbButton
+{
+	u32 m_keyCode = 0;
+	u32 m_outKeyCode = 0;
+	bool m_pressed = false;
+	
+	KbButton() = default;
+	KbButton(u32 keyCode, u32 outKeyCode, bool pressed = false)
+		: m_keyCode(keyCode)
+		, m_outKeyCode(outKeyCode)
+		, m_pressed(pressed)
+	{
+	}
 };
 
 struct KbData
@@ -35,7 +50,7 @@ struct KbData
 	u32 led;  // Active led lights
 	u32 mkey; // Active key modifiers
 	s32 len;  // Number of key codes (0 means no data available)
-	std::pair<u16, u32> keycode[CELL_KB_MAX_KEYCODES];
+	std::array<KbButton, CELL_KB_MAX_KEYCODES> buttons{};
 
 	KbData()
 		: led(0)
@@ -59,24 +74,11 @@ struct KbConfig
 	}
 };
 
-struct KbButton
-{
-	u32 m_keyCode;
-	u32 m_outKeyCode;
-	bool m_pressed = false;
-
-	KbButton(u32 keyCode, u32 outKeyCode)
-		: m_keyCode(keyCode)
-		, m_outKeyCode(outKeyCode)
-	{
-	}
-};
-
 struct Keyboard
 {
 	bool m_key_repeat = false;
-	KbData m_data;
-	KbConfig m_config;
+	KbData m_data{};
+	KbConfig m_config{};
 	std::vector<KbButton> m_buttons;
 
 	Keyboard()
@@ -109,6 +111,6 @@ public:
 protected:
 	void ReleaseAllKeys();
 
-	KbInfo m_info;
+	KbInfo m_info{};
 	std::vector<Keyboard> m_keyboards;
 };

--- a/rpcs3/Emu/Io/KeyboardHandler.h
+++ b/rpcs3/Emu/Io/KeyboardHandler.h
@@ -27,6 +27,7 @@ struct KbInfo
 	u32 max_connect = 0;
 	u32 now_connect = 0;
 	u32 info = 0;
+	bool is_null_handler = false;
 	std::array<u8, CELL_KB_MAX_KEYBOARDS> status{};
 };
 
@@ -47,31 +48,17 @@ struct KbButton
 
 struct KbData
 {
-	u32 led;  // Active led lights
-	u32 mkey; // Active key modifiers
-	s32 len;  // Number of key codes (0 means no data available)
+	u32 led = 0;  // Active led lights     TODO: Set initial state of led
+	u32 mkey = 0; // Active key modifiers
+	s32 len = 0;  // Number of key codes (0 means no data available)
 	std::array<KbButton, CELL_KB_MAX_KEYCODES> buttons{};
-
-	KbData()
-		: led(0)
-		, mkey(0)
-		, len(0)
-	{ // (TODO: Set initial state of led)
-	}
 };
 
 struct KbConfig
 {
-	u32 arrange;
-	u32 read_mode;
-	u32 code_type;
-
-	KbConfig()
-		: arrange(CELL_KB_MAPPING_101)
-		, read_mode(CELL_KB_RMODE_INPUTCHAR)
-		, code_type(CELL_KB_CODETYPE_ASCII)
-	{
-	}
+	u32 arrange = CELL_KB_MAPPING_101;
+	u32 read_mode = CELL_KB_RMODE_INPUTCHAR;
+	u32 code_type = CELL_KB_CODETYPE_ASCII;
 };
 
 struct Keyboard
@@ -80,10 +67,6 @@ struct Keyboard
 	KbData m_data{};
 	KbConfig m_config{};
 	std::vector<KbButton> m_buttons;
-
-	Keyboard()
-	{
-	}
 };
 
 class KeyboardHandlerBase

--- a/rpcs3/Emu/Io/MouseHandler.h
+++ b/rpcs3/Emu/Io/MouseHandler.h
@@ -54,58 +54,37 @@ static const u32 MOUSE_MAX_CODES = 64;
 
 struct MouseInfo
 {
-	u32 max_connect;
-	u32 now_connect;
-	u32 info;
-	u32 mode[MAX_MICE]; // TODO: tablet support
-	u32 tablet_is_supported[MAX_MICE]; // TODO: tablet support
-	u16 vendor_id[MAX_MICE];
-	u16 product_id[MAX_MICE];
-	u8 status[MAX_MICE];
+	u32 max_connect = 0;
+	u32 now_connect = 0;
+	u32 info = 0;
+	u32 mode[MAX_MICE]{}; // TODO: tablet support
+	u32 tablet_is_supported[MAX_MICE]{}; // TODO: tablet support
+	u16 vendor_id[MAX_MICE]{};
+	u16 product_id[MAX_MICE]{};
+	u8 status[MAX_MICE]{};
+	bool is_null_handler = false;
 };
 
 struct MouseRawData
 {
-	s32 len;
-	u8 data[MOUSE_MAX_CODES];
-
-	MouseRawData()
-		: len(0)
-		, data()
-	{
-	}
+	s32 len = 0;
+	u8 data[MOUSE_MAX_CODES]{};
 };
 
 struct MouseData
 {
-	u8 update;
-	u8 buttons;
-	s8 x_axis;
-	s8 y_axis;
-	s8 wheel;
-	s8 tilt;  // (TODO)
-
-	MouseData()
-		: update(0)
-		, buttons(0)
-		, x_axis(0)
-		, y_axis(0)
-		, wheel(0)
-		, tilt(0)
-	{
-	}
+	u8 update = 0;
+	u8 buttons = 0;
+	s8 x_axis = 0;
+	s8 y_axis = 0;
+	s8 wheel = 0;
+	s8 tilt = 0; // (TODO)
 };
 
 struct MouseTabletData
 {
-	s32 len;
-	u8 data[MOUSE_MAX_CODES];
-
-	MouseTabletData()
-		: len(0)
-		, data()
-	{
-	}
+	s32 len = 0;
+	u8 data[MOUSE_MAX_CODES]{};
 };
 
 using MouseTabletDataList = std::list<MouseTabletData>;
@@ -113,32 +92,23 @@ using MouseDataList = std::list<MouseData>;
 
 struct Mouse
 {
-	s32 x_pos;
-	s32 y_pos;
-	s32 x_max;
-	s32 y_max;
-	u8 buttons; // actual mouse button positions
+	s32 x_pos = 0;
+	s32 y_pos = 0;
+	s32 x_max = 0;
+	s32 y_max = 0;
+	u8 buttons = 0; // actual mouse button positions
 
-	MouseTabletDataList m_tablet_datalist;
-	MouseDataList m_datalist;
-	MouseRawData m_rawdata;
-
-	Mouse()
-		: x_pos(0)
-		, y_pos(0)
-		, x_max(0)
-		, y_max(0)
-		, buttons(0)
-	{
-	}
+	MouseTabletDataList m_tablet_datalist{};
+	MouseDataList m_datalist{};
+	MouseRawData m_rawdata{};
 };
 
 class MouseHandlerBase
 {
 protected:
-	MouseInfo m_info;
+	MouseInfo m_info{};
 	std::vector<Mouse> m_mice;
-	steady_clock::time_point last_update;
+	steady_clock::time_point last_update{};
 
 	bool is_time_for_update(double elapsed_time = 10.0) // 4-10 ms, let's use 10 for now
 	{

--- a/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
+++ b/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
@@ -9,6 +9,7 @@ public:
 	{
 		m_info = {};
 		m_info.max_connect = max_connect;
+		m_info.is_null_handler = true;
 		m_keyboards.clear();
 		for (u32 i = 0; i < max_connect; i++)
 		{

--- a/rpcs3/Emu/Io/Null/NullMouseHandler.h
+++ b/rpcs3/Emu/Io/Null/NullMouseHandler.h
@@ -9,6 +9,7 @@ public:
 	{
 		m_info = {};
 		m_info.max_connect = max_connect;
+		m_info.is_null_handler = true;
 		m_mice.clear();
 	}
 };

--- a/rpcs3/Emu/Io/interception.cpp
+++ b/rpcs3/Emu/Io/interception.cpp
@@ -7,22 +7,31 @@
 
 namespace input
 {
-	atomic_t<bool> g_intercepted{false};
+	atomic_t<bool> g_pads_intercepted{false};
+	atomic_t<bool> g_keyboards_intercepted{false};
+	atomic_t<bool> g_mice_intercepted{false};
 
-	void SetIntercepted(bool intercepted)
+	void SetIntercepted(bool pads_intercepted, bool keyboards_intercepted, bool mice_intercepted)
 	{
-		g_intercepted = intercepted;
+		g_pads_intercepted = pads_intercepted;
+		g_keyboards_intercepted = keyboards_intercepted;
+		g_mice_intercepted = mice_intercepted;
 
-		pad::SetIntercepted(intercepted);
+		pad::SetIntercepted(pads_intercepted);
 
 		if (const auto handler = g_fxo->try_get<KeyboardHandlerBase>())
 		{
-			handler->SetIntercepted(intercepted);
+			handler->SetIntercepted(keyboards_intercepted);
 		}
 
 		if (const auto handler = g_fxo->try_get<MouseHandlerBase>())
 		{
-			handler->SetIntercepted(intercepted);
+			handler->SetIntercepted(mice_intercepted);
 		}
+	}
+
+	void SetIntercepted(bool all_intercepted)
+	{
+		SetIntercepted(all_intercepted, all_intercepted, all_intercepted);
 	}
 }

--- a/rpcs3/Emu/Io/interception.h
+++ b/rpcs3/Emu/Io/interception.h
@@ -4,7 +4,10 @@
 
 namespace input
 {
-	extern atomic_t<bool> g_intercepted;
+	extern atomic_t<bool> g_pads_intercepted;
+	extern atomic_t<bool> g_keyboards_intercepted;
+	extern atomic_t<bool> g_mice_intercepted;
 
-	void SetIntercepted(bool intercepted);
+	void SetIntercepted(bool pads_intercepted, bool keyboards_intercepted, bool mice_intercepted);
+	void SetIntercepted(bool all_intercepted);
 }

--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "util/types.hpp"
+#include "Emu/Io/pad_config_types.h"
 
 #include <vector>
 
@@ -250,6 +251,8 @@ struct VibrateMotor
 
 struct Pad
 {
+	const pad_handler m_pad_handler;
+
 	bool m_buffer_cleared{true};
 	u32 m_port_status{0};
 	u32 m_device_capability{0};
@@ -308,8 +311,9 @@ struct Pad
 	bool ldd{false};
 	u8 ldd_data[132] = {};
 
-	explicit Pad(u32 port_status, u32 device_capability, u32 device_type)
-		: m_port_status(port_status)
+	explicit Pad(pad_handler handler, u32 port_status, u32 device_capability, u32 device_type)
+		: m_pad_handler(handler)
+		, m_port_status(port_status)
 		, m_device_capability(device_capability)
 		, m_device_type(device_type)
 	{

--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
@@ -218,7 +218,10 @@ namespace rsx
 
 			if (const auto error = run_input_loop())
 			{
-				rsx_log.error("Media dialog input loop exited with error code=%d", error);
+				if (error != selection_code::canceled)
+				{
+					rsx_log.error("Media list dialog input loop exited with error code=%d", error);
+				}
 				return error;
 			}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -259,7 +259,10 @@ namespace rsx
 				{
 					if (const auto error = run_input_loop())
 					{
-						rsx_log.error("Dialog input loop exited with error code=%d", error);
+						if (error != selection_code::canceled)
+						{
+							rsx_log.error("Message dialog input loop exited with error code=%d", error);
+						}
 						return error;
 					}
 				}
@@ -296,7 +299,10 @@ namespace rsx
 
 							if (const auto error = run_input_loop())
 							{
-								rsx_log.error("Dialog input loop exited with error code=%d", error);
+								if (error != selection_code::canceled)
+								{
+									rsx_log.error("Message dialog input loop exited with error code=%d", error);
+								}
 							}
 						}
 						else

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -681,18 +681,28 @@ namespace rsx
 			}
 
 			// Handle special input
-			if (!found_key && !out_key_string.empty())
+			if (!found_key)
 			{
-				switch (out_key_string[0])
+				switch (out_key_code)
 				{
-				case ' ':
+				case CELL_KEYC_SPACE:
 					on_space(u32_string);
 					break;
-				case '\b':
+				case CELL_KEYC_BS:
 					on_backspace(u32_string);
 					break;
-				case '\n':
-					on_enter(u32_string);
+				case CELL_KEYC_ESCAPE:
+					Close(CELL_OSKDIALOG_CLOSE_CANCEL);
+					break;
+				case CELL_KEYC_ENTER:
+					if ((flags & CELL_OSKDIALOG_NO_RETURN))
+					{
+						Close(CELL_OSKDIALOG_CLOSE_CONFIRM);
+					}
+					else
+					{
+						on_enter(u32_string);
+					}
 					break;
 				default:
 					break;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -265,7 +265,6 @@ namespace rsx
 		void osk_dialog::initialize_layout(const std::u32string& title, const std::u32string& initial_text)
 		{
 			m_background.set_size(1280, 720);
-			m_background.back_color.a = 0.8f;
 
 			m_title.set_unicode_text(title);
 			m_title.back_color.a = 0.7f; // Uses the dimmed color of the frame background
@@ -944,7 +943,7 @@ namespace rsx
 			static constexpr auto thread_name = "OSK Thread"sv;
 		};
 
-		void osk_dialog::Create(const std::string& /*title*/, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color)
+		void osk_dialog::Create(const std::string& /*title*/, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled)
 		{
 			state = OskDialogState::Open;
 			flags = prohibit_flags;
@@ -953,6 +952,7 @@ namespace rsx
 			m_frame.back_color.g = base_color.g;
 			m_frame.back_color.b = base_color.b;
 			m_frame.back_color.a = base_color.a;
+			m_background.back_color.a = dimmer_enabled ? 0.8f : 0.0f;
 
 			const callback_t shift_cb  = [this](const std::u32string& text){ on_shift(text); };
 			const callback_t layer_cb  = [this](const std::u32string& text){ on_layer(text); };

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -393,6 +393,9 @@ namespace rsx
 
 		void osk_dialog::on_button_pressed(pad_button button_press)
 		{
+			if (!pad_input_enabled || ignore_input_events)
+				return;
+
 			const auto index_limit = (num_columns * num_rows) - 1;
 
 			const auto on_accept = [this]()
@@ -588,7 +591,7 @@ namespace rsx
 
 		void osk_dialog::on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed)
 		{
-			if (!pressed)
+			if (!pressed || !keyboard_input_enabled || ignore_input_events)
 				return;
 
 			osk.notice("osk_dialog::on_key_pressed(led=%d, mkey=%d, key_code=%d, out_key_code=%d, pressed=%d)", led, mkey, key_code, out_key_code, pressed);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -1191,7 +1191,10 @@ namespace rsx
 
 				if (const auto error = run_input_loop())
 				{
-					rsx_log.error("Osk input loop exited with error code=%d", error);
+					if (error != selection_code::canceled)
+					{
+						rsx_log.error("Osk input loop exited with error code=%d", error);
+					}
 				}
 
 				thread_bits &= ~tbit;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -267,10 +267,8 @@ namespace rsx
 			m_background.set_size(1280, 720);
 			m_background.back_color.a = 0.8f;
 
-			m_frame.back_color = { 0.2f, 0.2f, 0.2f, 1.f };
-
 			m_title.set_unicode_text(title);
-			m_title.back_color.a = 0.f;
+			m_title.back_color.a = 0.7f; // Uses the dimmed color of the frame background
 
 			m_preview.password_mode = m_password_mode;
 			m_preview.set_placeholder(get_placeholder());
@@ -946,11 +944,15 @@ namespace rsx
 			static constexpr auto thread_name = "OSK Thread"sv;
 		};
 
-		void osk_dialog::Create(const std::string& /*title*/, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel)
+		void osk_dialog::Create(const std::string& /*title*/, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color)
 		{
 			state = OskDialogState::Open;
 			flags = prohibit_flags;
 			char_limit = charlimit;
+			m_frame.back_color.r = base_color.r;
+			m_frame.back_color.g = base_color.g;
+			m_frame.back_color.b = base_color.b;
+			m_frame.back_color.a = base_color.a;
 
 			const callback_t shift_cb  = [this](const std::u32string& text){ on_shift(text); };
 			const callback_t layer_cb  = [this](const std::u32string& text){ on_layer(text); };

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -82,7 +82,7 @@ namespace rsx
 			osk_dialog();
 			~osk_dialog() override = default;
 
-			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) override;
+			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color) override;
 			void Close(s32 status) override;
 
 			void initialize_layout(const std::u32string& title, const std::u32string& initial_text);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -96,6 +96,7 @@ namespace rsx
 			void update_selection_by_index(u32 index);
 
 			void on_button_pressed(pad_button button_press) override;
+			void on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed) override;
 			void on_text_changed();
 
 			void on_default_callback(const std::u32string& str);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -82,7 +82,7 @@ namespace rsx
 			osk_dialog();
 			~osk_dialog() override = default;
 
-			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color) override;
+			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled) override;
 			void Close(s32 status) override;
 
 			void initialize_layout(const std::u32string& title, const std::u32string& initial_text);

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -307,8 +307,14 @@ namespace rsx
 
 			visible = true;
 
-			if (const auto err = run_input_loop())
-				return err;
+			if (const auto error = run_input_loop())
+			{
+				if (error != selection_code::canceled)
+				{
+					rsx_log.error("Save dialog input loop exited with error code=%d", error);
+				}
+				return error;
+			}
 
 			if (return_code >= 0)
 			{

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
@@ -259,7 +259,10 @@ namespace rsx
 
 				if (const auto error = run_input_loop())
 				{
-					rsx_log.error("Dialog input loop exited with error code=%d", error);
+					if (error != selection_code::canceled)
+					{
+						rsx_log.error("User list dialog input loop exited with error code=%d", error);
+					}
 				}
 
 				thread_bits &= ~tbit;

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -125,7 +125,7 @@ namespace rsx
 					continue;
 
 				// Get keyboard input
-				if (m_keyboard_input_enabled)
+				if (m_keyboard_input_enabled && input::g_keyboards_intercepted)
 				{
 					auto& handler = g_fxo->get<KeyboardHandlerBase>();
 					std::lock_guard<std::mutex> lock(handler.m_mutex);
@@ -173,7 +173,7 @@ namespace rsx
 				const auto handler = pad::get_current_handler();
 				const PadInfo& rinfo = handler->GetInfo();
 
-				if (!rinfo.now_connect)
+				if (!rinfo.now_connect || !input::g_pads_intercepted)
 				{
 					refresh();
 					continue;

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -130,9 +130,7 @@ namespace rsx
 					auto& handler = g_fxo->get<KeyboardHandlerBase>();
 					std::lock_guard<std::mutex> lock(handler.m_mutex);
 
-					const KbInfo& current_info = handler.GetInfo();
-
-					if (!handler.GetKeyboards().empty() && current_info.status[0] == CELL_KB_STATUS_CONNECTED)
+					if (!handler.GetKeyboards().empty() && handler.GetInfo().status[0] == CELL_KB_STATUS_CONNECTED)
 					{
 						KbData& current_data = handler.GetData(0);
 
@@ -144,16 +142,8 @@ namespace rsx
 								on_key_pressed(current_data.led, current_data.mkey, key.m_keyCode, key.m_outKeyCode, key.m_pressed);
 							}
 
-							// TODO: is the following step necessary in the overlays?
-							KbConfig& current_config = handler.GetConfig(0);
-
-							// For single character mode to work properly we need to "flush" the buffer after reading or else we'll constantly get the same key presses with each call.
-							// Actual key repeats are handled by adding a new key code to the buffer periodically. Key releases are handled in a similar fashion.
-							// Warning: Don't do this in packet mode, which is basically the mouse and keyboard gaming mode. Otherwise games like Unreal Tournament will be unplayable.
-							if (current_config.read_mode == CELL_KB_RMODE_INPUTCHAR)
-							{
-								current_data.len = 0;
-							}
+							// Flush buffer unconditionally. Otherwise we get a flood of key events.
+							current_data.len = 0;
 
 							// Ignore gamepad input if a key was recognized
 							refresh();

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -155,6 +155,11 @@ namespace rsx
 					{
 						// Workaround if cellKb did not init the keyboard handler.
 						handler.Init(1);
+
+						// Enable key repeat
+						std::vector<Keyboard>& keyboards = handler.GetKeyboards();
+						ensure(!keyboards.empty());
+						keyboards.at(0).m_key_repeat = true;
 					}
 				}
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -154,6 +154,10 @@ namespace rsx
 							{
 								current_data.len = 0;
 							}
+
+							// Ignore gamepad input if a key was recognized
+							refresh();
+							continue;
 						}
 					}
 					else
@@ -171,6 +175,7 @@ namespace rsx
 
 				if (!rinfo.now_connect)
 				{
+					refresh();
 					continue;
 				}
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -97,6 +97,7 @@ namespace rsx
 			atomic_t<bool> m_stop_pad_interception = false;
 			atomic_t<u64> thread_bits = 0;
 			bool m_keyboard_input_enabled = false; // Allow keyboard events
+			bool m_keyboard_pad_handler_active = true; // Initialized as true to prevent keyboard input until proven otherwise.
 
 			static thread_local u64 g_thread_bit;
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -112,7 +112,7 @@ namespace rsx
 			compiled_resource get_compiled() override = 0;
 
 			virtual void on_button_pressed(pad_button /*button_press*/) {}
-			virtual void on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed) {}
+			virtual void on_key_pressed(u32 /*led*/, u32 /*mkey*/, u32 /*key_code*/, u32 /*out_key_code*/, bool /*pressed*/) {}
 
 			virtual void close(bool use_callback, bool stop_pad_interception);
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -96,7 +96,7 @@ namespace rsx
 			atomic_t<bool> m_interactive = false;
 			atomic_t<bool> m_stop_pad_interception = false;
 			atomic_t<u64> thread_bits = 0;
-			bool m_keyboard_input_enabled = false;
+			bool m_keyboard_input_enabled = false; // Allow keyboard events
 
 			static thread_local u64 g_thread_bit;
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -81,8 +81,8 @@ namespace rsx
 			};
 
 		protected:
-			Timer input_timer;
-			std::set<u8> auto_repeat_buttons = {
+			Timer m_input_timer;
+			std::set<u8> m_auto_repeat_buttons = {
 				pad_button::dpad_up,
 				pad_button::dpad_down,
 				pad_button::dpad_left,
@@ -96,12 +96,13 @@ namespace rsx
 			atomic_t<bool> m_interactive = false;
 			atomic_t<bool> m_stop_pad_interception = false;
 			atomic_t<u64> thread_bits = 0;
+			bool m_keyboard_input_enabled = false;
 
 			static thread_local u64 g_thread_bit;
 
 			u64 alloc_thread_bit();
 
-			std::function<void(s32 status)> on_close;
+			std::function<void(s32 status)> on_close = nullptr;
 
 		public:
 			s32 return_code = 0; // CELL_OK
@@ -111,6 +112,7 @@ namespace rsx
 			compiled_resource get_compiled() override = 0;
 
 			virtual void on_button_pressed(pad_button /*button_press*/) {}
+			virtual void on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed) {}
 
 			virtual void close(bool use_callback, bool stop_pad_interception);
 

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -13,6 +13,9 @@ LOG_CHANNEL(input_log, "Input");
 
 void basic_keyboard_handler::Init(const u32 max_connect)
 {
+	m_keyboards.clear();
+	m_info = {};
+
 	for (u32 i = 0; i < max_connect; i++)
 	{
 		Keyboard kb{};
@@ -23,7 +26,7 @@ void basic_keyboard_handler::Init(const u32 max_connect)
 	}
 
 	LoadSettings();
-	memset(&m_info, 0, sizeof(KbInfo));
+
 	m_info.max_connect = max_connect;
 	m_info.now_connect = std::min(::size32(m_keyboards), max_connect);
 	m_info.info        = input::g_keyboards_intercepted ? CELL_KB_INFO_INTERCEPTED : 0; // Ownership of keyboard data: 0=Application, 1=System

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -15,7 +15,7 @@ void basic_keyboard_handler::Init(const u32 max_connect)
 {
 	for (u32 i = 0; i < max_connect; i++)
 	{
-		Keyboard kb;
+		Keyboard kb{};
 
 		kb.m_config.arrange = g_cfg.sys.keyboard_type;
 
@@ -53,7 +53,7 @@ void basic_keyboard_handler::SetTargetWindow(QWindow* target)
 
 bool basic_keyboard_handler::eventFilter(QObject* watched, QEvent* event)
 {
-	if (!event || input::g_keyboards_intercepted)
+	if (!event)
 	{
 		return false;
 	}

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -26,7 +26,7 @@ void basic_keyboard_handler::Init(const u32 max_connect)
 	memset(&m_info, 0, sizeof(KbInfo));
 	m_info.max_connect = max_connect;
 	m_info.now_connect = std::min(::size32(m_keyboards), max_connect);
-	m_info.info        = input::g_intercepted ? CELL_KB_INFO_INTERCEPTED : 0; // Ownership of keyboard data: 0=Application, 1=System
+	m_info.info        = input::g_keyboards_intercepted ? CELL_KB_INFO_INTERCEPTED : 0; // Ownership of keyboard data: 0=Application, 1=System
 	m_info.status[0]   = CELL_KB_STATUS_CONNECTED; // (TODO: Support for more keyboards)
 }
 
@@ -53,7 +53,7 @@ void basic_keyboard_handler::SetTargetWindow(QWindow* target)
 
 bool basic_keyboard_handler::eventFilter(QObject* watched, QEvent* event)
 {
-	if (!event || input::g_intercepted)
+	if (!event || input::g_keyboards_intercepted)
 	{
 		return false;
 	}

--- a/rpcs3/Input/basic_mouse_handler.cpp
+++ b/rpcs3/Input/basic_mouse_handler.cpp
@@ -50,7 +50,7 @@ void basic_mouse_handler::SetTargetWindow(QWindow* target)
 
 bool basic_mouse_handler::eventFilter(QObject* target, QEvent* ev)
 {
-	if (!ev || input::g_mice_intercepted)
+	if (!ev)
 	{
 		return false;
 	}

--- a/rpcs3/Input/basic_mouse_handler.cpp
+++ b/rpcs3/Input/basic_mouse_handler.cpp
@@ -16,7 +16,7 @@ void basic_mouse_handler::Init(const u32 max_connect)
 	memset(&m_info, 0, sizeof(MouseInfo));
 	m_info.max_connect = max_connect;
 	m_info.now_connect = std::min(::size32(m_mice), max_connect);
-	m_info.info = input::g_intercepted ? CELL_MOUSE_INFO_INTERCEPTED : 0; // Ownership of mouse data: 0=Application, 1=System
+	m_info.info = input::g_mice_intercepted ? CELL_MOUSE_INFO_INTERCEPTED : 0; // Ownership of mouse data: 0=Application, 1=System
 	for (u32 i = 1; i < max_connect; i++)
 	{
 		m_info.status[i] = CELL_MOUSE_STATUS_DISCONNECTED;
@@ -50,7 +50,7 @@ void basic_mouse_handler::SetTargetWindow(QWindow* target)
 
 bool basic_mouse_handler::eventFilter(QObject* target, QEvent* ev)
 {
-	if (!ev || input::g_intercepted)
+	if (!ev || input::g_mice_intercepted)
 	{
 		return false;
 	}

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -168,7 +168,7 @@ void pad_thread::Init()
 		}
 		cur_pad_handler->Init();
 
-		m_pads[i] = std::make_shared<Pad>(CELL_PAD_STATUS_DISCONNECTED, pad_settings[i].device_capability, pad_settings[i].device_type);
+		m_pads[i] = std::make_shared<Pad>(handler_type, CELL_PAD_STATUS_DISCONNECTED, pad_settings[i].device_capability, pad_settings[i].device_type);
 
 		if (is_ldd_pad)
 		{

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -22,7 +22,7 @@ osk_dialog_frame::~osk_dialog_frame()
 	}
 }
 
-void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 /*first_view_panel*/)
+void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 /*first_view_panel*/, color /*base_color*/)
 {
 	state = OskDialogState::Open;
 

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -22,7 +22,7 @@ osk_dialog_frame::~osk_dialog_frame()
 	}
 }
 
-void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 /*first_view_panel*/, color /*base_color*/)
+void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 /*first_view_panel*/, color /*base_color*/, bool /*dimmer_enabled*/)
 {
 	state = OskDialogState::Open;
 

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -77,7 +77,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 		{
 			input_count_label->setText(QString("%1/%2").arg(text.length()).arg(charlimit));
 			SetOskText(text);
-			on_osk_input_entered();
+			// if (on_osk_key_input_entered) on_osk_key_input_entered({}); // Not applicable
 		});
 		connect(input, &QLineEdit::returnPressed, m_dialog, &QDialog::accept);
 
@@ -141,7 +141,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 
 			input_count_label->setText(QString("%1/%2").arg(text.length()).arg(charlimit));
 			SetOskText(text);
-			on_osk_input_entered();
+			// if (on_osk_key_input_entered) on_osk_key_input_entered({}); // Not applicable
 		});
 
 		inputLayout->addWidget(input);

--- a/rpcs3/rpcs3qt/osk_dialog_frame.h
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.h
@@ -16,7 +16,7 @@ class osk_dialog_frame : public QObject, public OskDialogBase
 public:
 	osk_dialog_frame() = default;
 	~osk_dialog_frame();
-	void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel) override;
+	void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color) override;
 	void Close(s32 status) override;
 
 private:

--- a/rpcs3/rpcs3qt/osk_dialog_frame.h
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.h
@@ -16,7 +16,7 @@ class osk_dialog_frame : public QObject, public OskDialogBase
 public:
 	osk_dialog_frame() = default;
 	~osk_dialog_frame();
-	void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color) override;
+	void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled) override;
 	void Close(s32 status) override;
 
 private:


### PR DESCRIPTION
- Adds keyboard support to the On-Screen-Keyboard of the native user interface
- Implements some missing error checks in cellOskDialog
- Implements a pseudo consumer logic for the pad/keyboard/mouse events during loaded OSK dialogs
- Adds some more TODOs for cellOskDialog. I'll implement some of them for MGSO later if needed.
- Some minor keyboard refactoring

Disclaimer:
- Needs basic keyboard handler.
- The OSK will only recognize characters that are supported by the current keyboard layout.
So if you need other characters, you can try to toggle the layouts with L2 and R2, as always.

TODO
- [x] Enter button
- [x] Handle keyboard pad handler