### PR TITLE
Qt: fix access to uninitialized Pad object

### DIFF
--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1694,7 +1694,12 @@ bool pad_settings_dialog::GetIsLddPad(u32 index) const
 		std::lock_guard lock(pad::g_pad_mutex);
 		if (const auto handler = pad::get_current_handler(true))
 		{
-			return handler->GetPads().at(index)->ldd;
+			ensure(index < handler->GetPads().size());
+
+			if (const std::shared_ptr<Pad> pad = handler->GetPads().at(index))
+			{
+				return pad->ldd;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes a crash when opening the pad settings before the pad handlers are initialized.

fixes #11844