### PR TITLE
[Need test] CPU optimizations

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -446,7 +446,7 @@ void cpu_thread::operator()()
 	// Register thread in g_cpu_array
 	s_cpu_counter++;
 
-	atomic_wait_engine::set_notify_callback([](const void*, u64 progress)
+	atomic_wait_engine::set_notify_callback(g_use_rtm || id_type() != 1 /* PPU */ ? nullptr : +[](const void*, u64 progress)
 	{
 		static thread_local bool wait_set = false;
 

--- a/rpcs3/util/atomic.cpp
+++ b/rpcs3/util/atomic.cpp
@@ -1310,14 +1310,10 @@ void atomic_wait_engine::notify_one(const void* data, u32 size, u128 mask)
 	if (s_tls_notify_cb)
 		s_tls_notify_cb(data, 0);
 
-	u64 progress = 0;
-
 	root_info::slot_search(iptr, mask, [&](u32 cond_id)
 	{
 		if (alert_sema(cond_id, size, mask))
 		{
-			if (s_tls_notify_cb)
-				s_tls_notify_cb(data, ++progress);
 			return true;
 		}
 
@@ -1334,8 +1330,6 @@ SAFE_BUFFERS(void) atomic_wait_engine::notify_all(const void* data, u32 size, u1
 
 	if (s_tls_notify_cb)
 		s_tls_notify_cb(data, 0);
-
-	u64 progress = 0;
 
 	// Array count for batch notification
 	u32 count = 0;
@@ -1378,8 +1372,6 @@ SAFE_BUFFERS(void) atomic_wait_engine::notify_all(const void* data, u32 size, u1
 			{
 				if (s_cond_list[cond_id].try_alert_native())
 				{
-					if (s_tls_notify_cb)
-						s_tls_notify_cb(data, ++progress);
 					*(std::end(cond_ids) - i - 1) = ~cond_id;
 				}
 			}
@@ -1394,8 +1386,6 @@ SAFE_BUFFERS(void) atomic_wait_engine::notify_all(const void* data, u32 size, u1
 		if (cond_id <= u16{umax})
 		{
 			s_cond_list[cond_id].alert_native();
-			if (s_tls_notify_cb)
-				s_tls_notify_cb(data, ++progress);
 			*(std::end(cond_ids) - i - 1) = ~cond_id;
 		}
 	}


### PR DESCRIPTION
* Notify callback in wait engine was implemented with theoretical optimization in mind. It is necessary for PPU threads (no-TSX). However it seems that removing it actually improves performance in some cases. Please report testing results, especially for TSX-FA if possible.