### PR TITLE
[TESTERS NEEDED] Fix cellVdec Sequence Restart regression

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -944,7 +944,7 @@ error_code cellVdecClose(ppu_thread& ppu, u32 handle)
 
 error_code cellVdecStartSeq(u32 handle)
 {
-	cellVdec.trace("cellVdecStartSeq(handle=0x%x)", handle);
+	cellVdec.warning("cellVdecStartSeq(handle=0x%x)", handle);
 
 	const auto vdec = idm::get<vdec_context>(handle);
 


### PR DESCRIPTION
- Do not send any packets to av while the decode process was restarted by the game.
- Send AU_DONE before PICOUT
- Add some more logging

fixes #11853