### PR TITLE
[NVIDIA TESTERS NEEDED] rsx: Improve lowered precision comparison emulation

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -130,6 +130,7 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	properties2.require_lit_emulation = properties.has_lit_op;
 	properties2.emulate_zclip_transform = true;
 	properties2.emulate_depth_clip_only = dev_caps.NV_depth_buffer_float_supported;
+	properties2.low_precision_tests = dev_caps.vendor_NVIDIA;
 
 	insert_glsl_legacy_function(OS, properties2);
 	glsl::insert_vertex_input_fetch(OS, glsl::glsl_rules_opengl4, dev_caps.vendor_INTEL == false);

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -5,55 +5,24 @@
 
 namespace program_common
 {
-	void insert_compare_op(std::ostream& OS, bool low_precision)
+	void insert_compare_op(std::ostream& OS)
 	{
-		if (low_precision)
-		{
-			OS <<
-				"int compare(const in float a, const in float b)\n"
-				"{\n"
-				"	if (abs(a - b) < 0.000001) return 2;\n"
-				"	return (a > b)? 4 : 1;\n"
-				"}\n\n"
-
-				"bool comparison_passes(const in float a, const in float b, const in uint func)\n"
-				"{\n"
-				"	if (func == 0) return false; // never\n"
-				"	if (func == 7) return true;  // always\n\n"
-
-				"	int op = compare(a, b);\n"
-				"	switch (func)\n"
-				"	{\n"
-				"		case 1: return op == 1; // less\n"
-				"		case 2: return op == 2; // equal\n"
-				"		case 3: return op <= 2; // lequal\n"
-				"		case 4: return op == 4; // greater\n"
-				"		case 5: return op != 2; // nequal\n"
-				"		case 6: return (op == 4 || op == 2); // gequal\n"
-				"	}\n\n"
-
-				"	return false; // unreachable\n"
-				"}\n\n";
-		}
-		else
-		{
-			OS <<
-			"bool comparison_passes(const in float a, const in float b, const in uint func)\n"
-			"{\n"
-			"	switch (func)\n"
-			"	{\n"
-			"		default:\n"
-			"		case 0: return false; //never\n"
-			"		case 1: return (a < b); //less\n"
-			"		case 2: return (a == b); //equal\n"
-			"		case 3: return (a <= b); //lequal\n"
-			"		case 4: return (a > b); //greater\n"
-			"		case 5: return (a != b); //nequal\n"
-			"		case 6: return (a >= b); //gequal\n"
-			"		case 7: return true; //always\n"
-			"	}\n"
-			"}\n\n";
-		}
+		OS <<
+		"bool comparison_passes(const in float a, const in float b, const in uint func)\n"
+		"{\n"
+		"	switch (func)\n"
+		"	{\n"
+		"		default:\n"
+		"		case 0: return false; //never\n"
+		"		case 1: return (CMP_FIXUP(a) < CMP_FIXUP(b)); //less\n"
+		"		case 2: return (CMP_FIXUP(a) == CMP_FIXUP(b)); //equal\n"
+		"		case 3: return (CMP_FIXUP(a) <= CMP_FIXUP(b)); //lequal\n"
+		"		case 4: return (CMP_FIXUP(a) > CMP_FIXUP(b)); //greater\n"
+		"		case 5: return (CMP_FIXUP(a) != CMP_FIXUP(b)); //nequal\n"
+		"		case 6: return (CMP_FIXUP(a) >= CMP_FIXUP(b)); //gequal\n"
+		"		case 7: return true; //always\n"
+		"	}\n"
+		"}\n\n";
 	}
 
 	void insert_compare_op_vector(std::ostream& OS)
@@ -65,12 +34,12 @@ namespace program_common
 		"	{\n"
 		"		default:\n"
 		"		case 0: return bvec4(false); //never\n"
-		"		case 1: return lessThan(a, b); //less\n"
-		"		case 2: return equal(a, b); //equal\n"
-		"		case 3: return lessThanEqual(a, b); //lequal\n"
-		"		case 4: return greaterThan(a, b); //greater\n"
-		"		case 5: return notEqual(a, b); //nequal\n"
-		"		case 6: return greaterThanEqual(a, b); //gequal\n"
+		"		case 1: return lessThan(CMP_FIXUP(a), CMP_FIXUP(b)); //less\n"
+		"		case 2: return equal(CMP_FIXUP(a), CMP_FIXUP(b)); //equal\n"
+		"		case 3: return lessThanEqual(CMP_FIXUP(a), CMP_FIXUP(b)); //lequal\n"
+		"		case 4: return greaterThan(CMP_FIXUP(a), CMP_FIXUP(b)); //greater\n"
+		"		case 5: return notEqual(CMP_FIXUP(a), CMP_FIXUP(b)); //nequal\n"
+		"		case 6: return greaterThanEqual(CMP_FIXUP(a), CMP_FIXUP(b)); //gequal\n"
 		"		case 7: return bvec4(true); //always\n"
 		"	}\n"
 		"}\n\n";
@@ -173,15 +142,15 @@ namespace glsl
 			switch (f)
 			{
 			case COMPARE::SEQ:
-				return Op0 + " == " + Op1;
+				return fmt::format("CMP_FIXUP(%s) == CMP_FIXUP(%s)", Op0, Op1);
 			case COMPARE::SGE:
-				return Op0 + " >= " + Op1;
+				return fmt::format("CMP_FIXUP(%s) >= CMP_FIXUP(%s)", Op0, Op1);
 			case COMPARE::SGT:
-				return Op0 + " > " + Op1;
+				return fmt::format("CMP_FIXUP(%s) > CMP_FIXUP(%s)", Op0, Op1);
 			case COMPARE::SLE:
-				return Op0 + " <= " + Op1;
+				return fmt::format("CMP_FIXUP(%s) <= CMP_FIXUP(%s)", Op0, Op1);
 			case COMPARE::SLT:
-				return Op0 + " < " + Op1;
+				fmt::format("CMP_FIXUP(%s) < CMP_FIXUP(%s)", Op0, Op1);
 			case COMPARE::SNE:
 				return Op0 + " != " + Op1;
 			}
@@ -191,17 +160,17 @@ namespace glsl
 			switch (f)
 			{
 			case COMPARE::SEQ:
-				return "equal(" + Op0 + ", " + Op1 + ")";
+				return fmt::format("equal(CMP_FIXUP(%s), CMP_FIXUP(%s))", Op0, Op1);
 			case COMPARE::SGE:
-				return "greaterThanEqual(" + Op0 + ", " + Op1 + ")";
+				return fmt::format("greaterThanEqual(CMP_FIXUP(%s), CMP_FIXUP(%s))", Op0, Op1);
 			case COMPARE::SGT:
-				return "greaterThan(" + Op0 + ", " + Op1 + ")";
+				return fmt::format("greaterThan(CMP_FIXUP(%s), CMP_FIXUP(%s))", Op0, Op1);
 			case COMPARE::SLE:
-				return "lessThanEqual(" + Op0 + ", " + Op1 + ")";
+				return fmt::format("lessThanEqual(CMP_FIXUP(%s), CMP_FIXUP(%s))", Op0, Op1);
 			case COMPARE::SLT:
-				return "lessThan(" + Op0 + ", " + Op1 + ")";
+				return fmt::format("lessThan(CMP_FIXUP(%s), CMP_FIXUP(%s))", Op0, Op1);
 			case COMPARE::SNE:
-				return "notEqual(" + Op0 + ", " + Op1 + ")";
+				return fmt::format("notEqual(CMP_FIXUP(%s), CMP_FIXUP(%s))", Op0, Op1);
 			}
 		}
 
@@ -547,6 +516,15 @@ namespace glsl
 		OS << "#define _test_bit(x, y) (_get_bits(x, y, 1) != 0)\n";
 		OS << "#define _rand(seed) fract(sin(dot(seed.xy, vec2(12.9898f, 78.233f))) * 43758.5453f)\n\n";
 
+		if (props.low_precision_tests)
+		{
+			OS << "#define CMP_FIXUP(a) (sign(a) * 16. + a)\n\n";
+		}
+		else
+		{
+			OS << "#define CMP_FIXUP(a) (a)\n\n";
+		}
+
 		if (props.domain == glsl::program_domain::glsl_fragment_program)
 		{
 			OS << "// Workaround for broken early discard in some drivers\n";
@@ -674,7 +652,7 @@ namespace glsl
 			return;
 		}
 
-		program_common::insert_compare_op(OS, props.low_precision_tests);
+		program_common::insert_compare_op(OS);
 
 		if (props.emulate_coverage_tests)
 		{

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -150,9 +150,9 @@ namespace glsl
 			case COMPARE::SLE:
 				return fmt::format("CMP_FIXUP(%s) <= CMP_FIXUP(%s)", Op0, Op1);
 			case COMPARE::SLT:
-				fmt::format("CMP_FIXUP(%s) < CMP_FIXUP(%s)", Op0, Op1);
+				return fmt::format("CMP_FIXUP(%s) < CMP_FIXUP(%s)", Op0, Op1);
 			case COMPARE::SNE:
-				return Op0 + " != " + Op1;
+				return fmt::format("CMP_FIXUP(%s) != CMP_FIXUP(%s)", Op0, Op1);
 			}
 		}
 		else

--- a/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.cpp
@@ -81,8 +81,8 @@ std::string VertexProgramDecompiler::GetDST(bool is_sca)
 		}
 
 		const std::string reg_type = (is_address_reg) ? getIntTypeName(4) : getFloatTypeName(4);
-		const std::string reg_sel = (is_address_reg) ? "a" : "tmp";
-		ret += m_parr.AddParam(PF_PARAM_NONE, reg_type, reg_sel + std::to_string(tmp_index)) + mask;
+		const std::string reg_sel = (is_address_reg) ? "a" : "r";
+		ret += m_parr.AddParam(PF_PARAM_NONE, reg_type, reg_sel + std::to_string(tmp_index), reg_type + "(0.)") + mask;
 	}
 	else if (!is_result)
 	{
@@ -107,25 +107,26 @@ std::string VertexProgramDecompiler::GetSRC(const u32 n)
 	};
 
 	std::string ret;
+	const auto float4 = getFloatTypeName(4);
 
 	switch (src[n].reg_type)
 	{
 	case RSX_VP_REGISTER_TYPE_TEMP:
-		ret += m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), "tmp" + std::to_string(src[n].tmp_src));
+		ret += m_parr.AddParam(PF_PARAM_NONE, float4, "r" + std::to_string(src[n].tmp_src), float4 + "(0.)");
 		break;
 	case RSX_VP_REGISTER_TYPE_INPUT:
 		if (d1.input_src < std::size(reg_table))
 		{
-			ret += m_parr.AddParam(PF_PARAM_IN, getFloatTypeName(4), reg_table[d1.input_src], d1.input_src);
+			ret += m_parr.AddParam(PF_PARAM_IN, float4, reg_table[d1.input_src], d1.input_src);
 		}
 		else
 		{
 			rsx_log.error("Bad input src num: %d", u32{ d1.input_src });
-			ret += m_parr.AddParam(PF_PARAM_IN, getFloatTypeName(4), "in_unk", d1.input_src);
+			ret += m_parr.AddParam(PF_PARAM_IN, float4, "in_unk", d1.input_src);
 		}
 		break;
 	case RSX_VP_REGISTER_TYPE_CONSTANT:
-		m_parr.AddParam(PF_PARAM_UNIFORM, getFloatTypeName(4), std::string("vc[468]"));
+		m_parr.AddParam(PF_PARAM_UNIFORM, float4, std::string("vc[468]"));
 		properties.has_indexed_constants |= !!d3.index_const;
 		m_constant_ids.insert(static_cast<u16>(d1.const_src));
 		ret += std::string("vc[") + std::to_string(d1.const_src) + (d3.index_const ? " + " + AddAddrReg() : "") + "]";

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -207,6 +207,7 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	properties2.require_lit_emulation = properties.has_lit_op;
 	properties2.emulate_zclip_transform = true;
 	properties2.emulate_depth_clip_only = vk::g_render_device->get_shader_types_support().allow_float64;
+	properties2.low_precision_tests = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
 
 	glsl::insert_glsl_legacy_function(OS, properties2);
 	glsl::insert_vertex_input_fetch(OS, glsl::glsl_rules_spirv);


### PR DESCRIPTION
Introduces a consistent error of about 7.81E-7 which matches RSX behavior when using NVIDIA hardware. Adding a flat constant of 16.0 manipulates the bits just right so that values around the [-1,+1] range compare correctly.
This fixup only applies to NVIDIA hardware.

Fixes https://github.com/RPCS3/rpcs3/issues/10955
Fixes https://github.com/RPCS3/rpcs3/issues/10923

I need help testing "SRW Dark prison" as this fix replaces the workaround I devised for that game. See the old bug here: https://github.com/RPCS3/rpcs3/issues/4799
If you have that title, please update so that we can proceed with this one.

- [x] SRW dark prison is not broken
- [x] Investigate SR: Gat out of hell problem