### PR TITLE
CellError log improvements

### DIFF
--- a/Utilities/cfmt.h
+++ b/Utilities/cfmt.h
@@ -15,6 +15,8 @@ C-style format parser. Appends formatted string to `out`, returns number of char
 template<typename Dst, typename Char, typename Src>
 usz cfmt_append(Dst& out, const Char* fmt, Src&& src)
 {
+	ensure(fmt);
+
 	const usz start_pos = out.size();
 
 	struct cfmt_context

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2003,6 +2003,11 @@ s32 error_code::error_report(s32 result, const char* fmt, const fmt_type_info* s
 	// Format log message (use preallocated buffer)
 	g_tls_error_str.clear();
 	fmt::append(g_tls_error_str, "'%s' failed with 0x%08x", func, result);
+
+	// Add spacer between error and fmt if necessary
+	if (fmt[0] != ' ')
+		g_tls_error_str += " : ";
+
 	fmt::raw_append(g_tls_error_str, fmt, sup, args);
 
 	// Update stats and check log threshold

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1989,6 +1989,8 @@ s32 error_code::error_report(s32 result, const char* fmt, const fmt_type_info* s
 		}
 	}
 
+	ensure(fmt);
+
 	logs::channel* channel = &sys_log;
 	const char* func = "Unknown function";
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -52,6 +52,8 @@ LOG_CHANNEL(sys_log, "SYS");
 // Preallocate 32 MiB
 stx::manual_typemap<void, 0x20'00000, 128> g_fixed_typemap;
 
+bool g_log_all_errors = false;
+
 bool g_use_rtm = false;
 u64 g_rtm_tx_limit1 = 0;
 u64 g_rtm_tx_limit2 = 0;
@@ -1976,6 +1978,13 @@ s32 error_code::error_report(s32 result, const char* fmt, const fmt_type_info* s
 		if (!fmt)
 		{
 			// Report and clean error state
+
+			if (g_log_all_errors) [[unlikely]]
+			{
+				g_tls_error_stats.clear();
+				return 0;
+			}
+
 			for (auto&& pair : g_tls_error_stats)
 			{
 				if (pair.second > 3)
@@ -2013,11 +2022,19 @@ s32 error_code::error_report(s32 result, const char* fmt, const fmt_type_info* s
 	fmt::raw_append(g_tls_error_str, fmt, sup, args);
 
 	// Update stats and check log threshold
-	const auto stat = ++g_tls_error_stats[g_tls_error_str];
 
-	if (stat <= 3)
+	if (g_log_all_errors) [[unlikely]]
 	{
-		channel->error("%s [%u]", g_tls_error_str, stat);
+		channel->error("%s", g_tls_error_str);
+	}
+	else
+	{
+		const auto stat = ++g_tls_error_stats[g_tls_error_str];
+
+		if (stat <= 3)
+		{
+			channel->error("%s [%u]", g_tls_error_str, stat);
+		}
 	}
 
 	return result;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -294,6 +294,8 @@ public:
 
 extern Emulator Emu;
 
+extern bool g_log_all_errors;
+
 extern bool g_use_rtm;
 extern u64 g_rtm_tx_limit1;
 extern u64 g_rtm_tx_limit2;

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -187,6 +187,7 @@ namespace gui
 	const gui_save l_tty       = gui_save(logger, "TTY",       true);
 	const gui_save l_level     = gui_save(logger, "level",     static_cast<uchar>(logs::level::success));
 	const gui_save l_prefix    = gui_save(logger, "prefix_on", false);
+	const gui_save l_stack_err = gui_save(logger, "ERR_stack", true);
 	const gui_save l_stack     = gui_save(logger, "stack",     true);
 	const gui_save l_stack_tty = gui_save(logger, "TTY_stack", false);
 	const gui_save l_limit     = gui_save(logger, "limit",     1000);

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -21,6 +21,7 @@ extern fs::file g_tty;
 extern atomic_t<s64> g_tty_size;
 extern std::array<std::deque<std::string>, 16> g_tty_input;
 extern std::mutex g_tty_mutex;
+extern bool g_log_all_errors;
 
 constexpr auto qstr = QString::fromStdString;
 
@@ -292,6 +293,14 @@ void log_frame::CreateAndConnectActions()
 		m_stack_log = checked;
 	});
 
+	m_stack_act_err = new QAction(tr("Stack Cell Errors"), this);
+	m_stack_act_err->setCheckable(true);
+	connect(m_stack_act_err, &QAction::toggled, [this](bool checked)
+	{
+		m_gui_settings->SetValue(gui::l_stack_err, checked);
+		g_log_all_errors = !checked;
+	});
+
 	m_show_prefix_act = new QAction(tr("Show Thread Prefix"), this);
 	m_show_prefix_act->setCheckable(true);
 	connect(m_show_prefix_act, &QAction::toggled, [this](bool checked)
@@ -324,6 +333,7 @@ void log_frame::CreateAndConnectActions()
 		menu->addActions(m_log_level_acts->actions());
 		menu->addSeparator();
 		menu->addAction(m_stack_act_log);
+		menu->addAction(m_stack_act_err);
 		menu->addAction(m_show_prefix_act);
 		menu->exec(m_log->viewport()->mapToGlobal(pos));
 	});
@@ -397,6 +407,7 @@ void log_frame::LoadSettings()
 	m_stack_tty = m_gui_settings->GetValue(gui::l_stack_tty).toBool();
 	m_stack_act_log->setChecked(m_stack_log);
 	m_stack_act_tty->setChecked(m_stack_tty);
+	m_stack_act_err->setChecked(!g_log_all_errors);
 
 	s_gui_listener.show_prefix = m_gui_settings->GetValue(gui::l_prefix).toBool();
 	m_show_prefix_act->setChecked(s_gui_listener.show_prefix);

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -77,6 +77,7 @@ private:
 
 	QAction* m_stack_act_log = nullptr;
 	QAction* m_stack_act_tty = nullptr;
+	QAction* m_stack_act_err = nullptr;
 
 	QAction* m_show_prefix_act = nullptr;
 


### PR DESCRIPTION
- Adds an option to the log frame to enable/disable the cell error aggregation
- Adds a missing space to cell error messages
- Check if the fmt exists