### PR TITLE
cellOskDialog: fix input interception

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -533,7 +533,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 	Emu.CallFromMainThread([=, &result, &info]()
 	{
-		osk->Create(get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE), message, osk->osk_text, maxLength, prohibitFlgs, allowOskPanelFlg, firstViewPanel, info.base_color.load(), info.dimmer_enabled.load());
+		osk->Create(get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE), message, osk->osk_text, maxLength, prohibitFlgs, allowOskPanelFlg, firstViewPanel, info.base_color.load(), info.dimmer_enabled.load(), false);
 		result = true;
 		result.notify_one();
 

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -768,7 +768,7 @@ error_code cellOskDialogSetSeparateWindowOption(vm::ptr<CellOskDialogSeparateWin
 	// inputFieldLayoutInfo;
 	// inputPanelLayoutInfo;
 
-	cellOskDialog.warning("cellOskDialogSetSeparateWindowOption: continuousMode=%s)", osk.osk_continuous_mode.load());
+	cellOskDialog.warning("cellOskDialogSetSeparateWindowOption: use_separate_windows=true, continuous_mode=%s, device_mask=0x%x)", osk.osk_continuous_mode.load(), osk.device_mask.load());
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -522,14 +522,14 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 		osk->mouse_input_enabled = (info.device_mask != CELL_OSKDIALOG_DEVICE_MASK_PAD);
 	}
 
-	input::SetIntercepted(osk->pad_input_enabled, osk->keyboard_input_enabled, osk->mouse_input_enabled);
-
 	if (info.osk_continuous_mode == CELL_OSKDIALOG_CONTINUOUS_MODE_HIDE)
 	{
 		info.last_dialog_state = CELL_SYSUTIL_OSKDIALOG_LOADED;
 		sysutil_send_system_cmd(CELL_SYSUTIL_OSKDIALOG_LOADED, 0);
 		return CELL_OK;
 	}
+
+	input::SetIntercepted(osk->pad_input_enabled, osk->keyboard_input_enabled, osk->mouse_input_enabled);
 
 	Emu.CallFromMainThread([=, &result, &info]()
 	{

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -261,7 +261,7 @@ public:
 		f32 a = 1.0f;
 	};
 
-	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled) = 0;
+	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled, bool intercept_input) = 0;
 
 	// Closes the dialog.
 	// Set status to CELL_OSKDIALOG_CLOSE_CONFIRM or CELL_OSKDIALOG_CLOSE_CANCEL for user input.

--- a/rpcs3/Emu/Io/interception.cpp
+++ b/rpcs3/Emu/Io/interception.cpp
@@ -5,14 +5,18 @@
 #include "Input/pad_thread.h"
 #include "Emu/IdManager.h"
 
+LOG_CHANNEL(input_log, "Input");
+
 namespace input
 {
 	atomic_t<bool> g_pads_intercepted{false};
 	atomic_t<bool> g_keyboards_intercepted{false};
 	atomic_t<bool> g_mice_intercepted{false};
 
-	void SetIntercepted(bool pads_intercepted, bool keyboards_intercepted, bool mice_intercepted)
+	void SetIntercepted(bool pads_intercepted, bool keyboards_intercepted, bool mice_intercepted, const char* func)
 	{
+		input_log.warning("SetIntercepted: pads=%d, keyboards=%d, mice=%d, src=%s)", pads_intercepted, keyboards_intercepted, mice_intercepted, func);
+
 		g_pads_intercepted = pads_intercepted;
 		g_keyboards_intercepted = keyboards_intercepted;
 		g_mice_intercepted = mice_intercepted;
@@ -30,8 +34,8 @@ namespace input
 		}
 	}
 
-	void SetIntercepted(bool all_intercepted)
+	void SetIntercepted(bool all_intercepted, const char* func)
 	{
-		SetIntercepted(all_intercepted, all_intercepted, all_intercepted);
+		SetIntercepted(all_intercepted, all_intercepted, all_intercepted, func);
 	}
 }

--- a/rpcs3/Emu/Io/interception.h
+++ b/rpcs3/Emu/Io/interception.h
@@ -8,6 +8,6 @@ namespace input
 	extern atomic_t<bool> g_keyboards_intercepted;
 	extern atomic_t<bool> g_mice_intercepted;
 
-	void SetIntercepted(bool pads_intercepted, bool keyboards_intercepted, bool mice_intercepted);
-	void SetIntercepted(bool all_intercepted);
+	void SetIntercepted(bool pads_intercepted, bool keyboards_intercepted, bool mice_intercepted, const char* func = __builtin_FUNCTION());
+	void SetIntercepted(bool all_intercepted, const char* func = __builtin_FUNCTION());
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -953,7 +953,7 @@ namespace rsx
 			static constexpr auto thread_name = "OSK Thread"sv;
 		};
 
-		void osk_dialog::Create(const std::string& /*title*/, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled)
+		void osk_dialog::Create(const std::string& /*title*/, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled, bool intercept_input)
 		{
 			state = OskDialogState::Open;
 			flags = prohibit_flags;
@@ -963,6 +963,7 @@ namespace rsx
 			m_frame.back_color.b = base_color.b;
 			m_frame.back_color.a = base_color.a;
 			m_background.back_color.a = dimmer_enabled ? 0.8f : 0.0f;
+			m_start_pad_interception = intercept_input;
 
 			const callback_t shift_cb  = [this](const std::u32string& text){ on_shift(text); };
 			const callback_t layer_cb  = [this](const std::u32string& text){ on_layer(text); };

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -82,7 +82,7 @@ namespace rsx
 			osk_dialog();
 			~osk_dialog() override = default;
 
-			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled) override;
+			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled, bool intercept_input) override;
 			void Close(s32 status) override;
 
 			void initialize_layout(const std::u32string& title, const std::u32string& initial_text);

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -67,7 +67,11 @@ namespace rsx
 
 			m_input_timer.Start();
 
-			input::SetIntercepted(true);
+			// Only start intercepting input if the the overlay allows it (enabled by default)
+			if (m_start_pad_interception)
+			{
+				input::SetIntercepted(true);
+			}
 
 			const auto handle_button_press = [&](u8 button_id, bool pressed, int pad_index)
 			{

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -94,6 +94,7 @@ namespace rsx
 			};
 			atomic_t<bool> exit = false;
 			atomic_t<bool> m_interactive = false;
+			bool m_start_pad_interception = true;
 			atomic_t<bool> m_stop_pad_interception = false;
 			atomic_t<u64> thread_bits = 0;
 			bool m_keyboard_input_enabled = false; // Allow keyboard events

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -22,7 +22,7 @@ osk_dialog_frame::~osk_dialog_frame()
 	}
 }
 
-void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 /*first_view_panel*/, color /*base_color*/, bool /*dimmer_enabled*/)
+void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 /*first_view_panel*/, color /*base_color*/, bool /*dimmer_enabled*/, bool /*intercept_input*/)
 {
 	state = OskDialogState::Open;
 

--- a/rpcs3/rpcs3qt/osk_dialog_frame.h
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.h
@@ -16,7 +16,7 @@ class osk_dialog_frame : public QObject, public OskDialogBase
 public:
 	osk_dialog_frame() = default;
 	~osk_dialog_frame();
-	void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled) override;
+	void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled, bool intercept_input) override;
 	void Close(s32 status) override;
 
 private:


### PR DESCRIPTION
- Fixes a regression in PS-Home that makes it impossible to enter keyboard input in the debug console
- Fixes a bug that might have disabled intentional pad input to the background game while an OSK dialog was open
- Properly log pad interception