### PR TITLE
Update buid instructions for Arch

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -29,7 +29,7 @@ These are the essentials tools to build RPCS3 on Linux. Some of them can be inst
 
 #### Arch Linux
 
-    sudo pacman -S glew openal cmake vulkan-validation-layers qt5-base qt5-declarative sdl2 sndio jack2
+    sudo pacman -S glew openal cmake vulkan-validation-layers qt5-base qt5-declarative qt5-multimedia sdl2 sndio jack2
 
 #### Debian & Ubuntu
 


### PR DESCRIPTION
The qt5-multimedia dependency is required for compilation on Arch Linux, otherwise you will receive the following error.

```
CMake Error at 3rdparty/qt5.cmake:12 (target_link_libraries):
  The link interface of target "3rdparty_qt5" contains:

    Qt5::Multimedia
```