### PR TITLE
Debugger: Keep instruction's panel up-to-date with memory changes

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -743,6 +743,7 @@ std::function<cpu_thread*()> debugger_frame::make_check_cpu(cpu_thread* cpu)
 void debugger_frame::UpdateUI()
 {
 	UpdateUnitList();
+	ShowPC();
 
 	const auto cpu = get_cpu();
 
@@ -964,7 +965,6 @@ void debugger_frame::DoUpdate()
 		m_last_step_over_breakpoint = -1;
 	}
 
-	ShowPC();
 	WritePanels();
 }
 


### PR DESCRIPTION
This fixes:
* RSX code not being updated with newly inserted code by PPU. Especially after a sync point.
* Editing instruction does not show the new contents of the edited instruction. 