### PR TITLE
Debugger: Fix instruction pointer for good

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -160,7 +160,7 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> gui_settings, QWidg
 	setWidget(body);
 
 	connect(m_go_to_addr, &QAbstractButton::clicked, this, &debugger_frame::ShowGotoAddressDialog);
-	connect(m_go_to_pc, &QAbstractButton::clicked, this, &debugger_frame::ShowPC);
+	connect(m_go_to_pc, &QAbstractButton::clicked, this, [this]() { ShowPC(true); });
 
 	connect(m_btn_step, &QAbstractButton::clicked, this, &debugger_frame::DoStep);
 	connect(m_btn_step_over, &QAbstractButton::clicked, [this]() { DoStep(true); });
@@ -193,6 +193,7 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> gui_settings, QWidg
 				}
 
 				cpu->state.notify_one(s_pause_flags);
+				m_debugger_list->EnableThreadFollowing();
 			}
 		}
 		UpdateUI();
@@ -213,7 +214,7 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> gui_settings, QWidg
 	connect(this, &debugger_frame::CallStackUpdateRequested, m_call_stack_list, &call_stack_list::HandleUpdate);
 	connect(m_call_stack_list, &call_stack_list::RequestShowAddress, m_debugger_list, &debugger_list::ShowAddress);
 
-	m_debugger_list->ShowAddress(m_debugger_list->m_pc, false);
+	m_debugger_list->RefreshView();
 	UpdateUnitList();
 }
 
@@ -952,6 +953,7 @@ void debugger_frame::OnSelectUnit()
 
 	m_debugger_list->UpdateCPUData(get_cpu(), m_disasm.get());
 	m_breakpoint_list->UpdateCPUData(get_cpu(), m_disasm.get());
+	ShowPC(true);
 	DoUpdate();
 	UpdateUI();
 }
@@ -1077,13 +1079,18 @@ void debugger_frame::ClearCallStack()
 	Q_EMIT CallStackUpdateRequested({});
 }
 
-void debugger_frame::ShowPC()
+void debugger_frame::ShowPC(bool user_requested)
 {
 	const auto cpu0 = get_cpu();
 
 	const u32 pc = (cpu0 ? cpu0->get_pc() : 0);
 
-	m_debugger_list->ShowAddress(pc, true);
+	if (user_requested)
+	{
+		m_debugger_list->EnableThreadFollowing();
+	}
+
+	m_debugger_list->ShowAddress(pc, false);
 }
 
 void debugger_frame::DoStep(bool step_over)
@@ -1091,6 +1098,15 @@ void debugger_frame::DoStep(bool step_over)
 	if (const auto cpu = get_cpu())
 	{
 		bool should_step_over = step_over && cpu->id_type() == 1;
+
+		// If stepping over, lay at the same spot and wait for the thread to finish the call
+		// If not, fixate on the current pointed instruction
+		m_debugger_list->EnableThreadFollowing(!should_step_over);
+
+		if (should_step_over)
+		{
+			m_debugger_list->ShowAddress(cpu->get_pc() + 4, false);
+		}
 
 		if (const auto _state = +cpu->state; _state & s_pause_flags && _state & cpu_flag::wait && !(_state & cpu_flag::dbg_step))
 		{

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -110,7 +110,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
 	void OnSelectUnit();
-	void ShowPC();
+	void ShowPC(bool user_requested = false);
 	void EnableUpdateTimer(bool enable) const;
 };
 

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -20,6 +20,7 @@ public:
 	u32 m_pc = 0;
 	u32 m_item_count = 30;
 	bool m_follow_thread = true; // If true, follow the selected thread to wherever it goes in code
+	u32 m_selected_instruction = -1;
 	QColor m_color_bp;
 	QColor m_color_pc;
 	QColor m_text_color_bp;

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -19,6 +19,7 @@ class debugger_list : public QListWidget
 public:
 	u32 m_pc = 0;
 	u32 m_item_count = 30;
+	bool m_follow_thread = true; // If true, follow the selected thread to wherever it goes in code
 	QColor m_color_bp;
 	QColor m_color_pc;
 	QColor m_text_color_bp;
@@ -29,8 +30,10 @@ Q_SIGNALS:
 public:
 	debugger_list(QWidget* parent, std::shared_ptr<gui_settings> settings, breakpoint_handler* handler);
 	void UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm);
+	void EnableThreadFollowing(bool enable = true);
 public Q_SLOTS:
 	void ShowAddress(u32 addr, bool select_addr = true, bool force = false);
+	void RefreshView();
 protected:
 	void keyPressEvent(QKeyEvent* event) override;
 	void mouseDoubleClickEvent(QMouseEvent* event) override;


### PR DESCRIPTION
Although #11893 made this problem consistent as ShowPC() is called in master unconditionally. But this has always used to be a problem - when wandering in memory, sometimes most unexpectedly, the instruction pointer of the debugger went to thread PC. Once thread state has been changed (reasons vary greatly), ShowPC() has been called and the debugger bounded back to PC.
This PR makes the debugger able to distinguish when we want to stroll in memory and when we want to view the current code the thread executes by disabling auto-branching to PC when the user has scrolled or clicked on "Go To Addresss". This is re-enabled whenever the user pauses the thread, requested an instruction stepping or clicked "Go To PC".