### PR TITLE
Fix Emulator::argv state after failed PS3 exitspawn

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -698,7 +698,7 @@ namespace vm
 		{
 			utils::memory_protect(g_base_addr + addr, size, prot);
 		}
-		else if (shm->map_critical(g_base_addr + addr, prot) != g_base_addr + addr || shm->map_critical(g_sudo_addr + addr) != g_sudo_addr + addr)
+		else if (shm->map_critical(g_base_addr + addr, prot) != g_base_addr + addr || shm->map_critical(g_sudo_addr + addr) != g_sudo_addr + addr || !shm->map_self())
 		{
 			fmt::throw_exception("Memory mapping failed - blame Windows (addr=0x%x, size=0x%x, flags=0x%x)", addr, size, flags);
 		}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1771,6 +1771,15 @@ void Emulator::Kill(bool allow_autoexit)
 {
 	if (m_state.exchange(system_state::stopped) == system_state::stopped)
 	{
+		// Ensure clean state
+		argv.clear();
+		envp.clear();
+		data.clear();
+		disc.clear();
+		klic.clear();
+		hdd1.clear();
+		m_config_path.clear();
+		m_config_mode = cfg_mode::custom;
 		return;
 	}
 


### PR DESCRIPTION
This is actually the result of testing something completely different, but it turns out if exitspawn failed to launch a new PS3 process  (https://github.com/RPCS3/rpcs3/blob/master/rpcs3/Emu/Cell/lv2/sys_process.cpp#L436)
argv and other members of `Emu` are not resetted as they normally do in `Emulator::Kill`. Which causes weird bugs such as wrong argv[0] with succeeding boots because it didn't fix itself at https://github.com/RPCS3/rpcs3/blob/master/rpcs3/Emu/System.cpp#L1354 