### PR TITLE
Workaround: Force audio provider

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -597,6 +597,9 @@ void cell_audio_thread::reset_counters()
 
 cell_audio_thread::cell_audio_thread()
 {
+	// Initialize loop variables (regardless of provider in order to initialize timestamps)
+	reset_counters();
+
 	if (cfg.raw.provider != audio_provider::cell_audio)
 	{
 		return;
@@ -607,9 +610,6 @@ cell_audio_thread::cell_audio_thread()
 
 	// Allocate ringbuffer
 	ringbuffer.reset(new audio_ringbuffer(cfg));
-
-	// Initialize loop variables
-	reset_counters();
 }
 
 void cell_audio_thread::operator()()

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -741,6 +741,16 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 					}
 				}
 			}
+
+			// Force audio provider
+			if (m_path.ends_with("vsh.self"sv))
+			{
+				g_cfg.audio.provider.set(audio_provider::rsxaudio);
+			}
+			else
+			{
+				g_cfg.audio.provider.set(audio_provider::cell_audio);
+			}
 		}
 
 		initalize_timebased_time();

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -21,6 +21,7 @@
 #include "Emu/Io/Null/null_music_handler.h"
 #include "Emu/Cell/Modules/cellAudio.h"
 #include "Emu/Cell/lv2/sys_rsxaudio.h"
+#include "Emu/Cell/lv2/sys_process.h"
 #include "Emu/RSX/Overlays/overlay_perf_metrics.h"
 #include "Emu/system_utils.hpp"
 #include "Emu/vfs_config.h"
@@ -629,6 +630,20 @@ void gui_application::OnEmuSettingsChange()
 	}
 
 	rpcs3::utils::configure_logs();
+
+	if (!Emu.IsStopped())
+	{
+		// Force audio provider
+		if (g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
+		{
+			g_cfg.audio.provider.set(audio_provider::rsxaudio);
+		}
+		else
+		{
+			g_cfg.audio.provider.set(audio_provider::cell_audio);
+		}
+	}
+
 	audio::configure_audio();
 	audio::configure_rsxaudio();
 	rsx::overlays::reset_performance_overlay();

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -881,16 +881,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		enable_buffering_options(enabled && ui->enableBuffering->isChecked());
 	};
 
-	const auto enable_avport_option = [this](int index)
-	{
-		if (index < 0) return;
-		const QVariantList var_list = ui->audioProviderBox->itemData(index).toList();
-		ensure(var_list.size() == 2 && var_list[0].canConvert<QString>());
-		const QString text = var_list[0].toString();
-		const bool enabled = text == "RSXAudio";
-		ui->audioAvportBox->setEnabled(enabled);
-	};
-
 	const QString mic_none = m_emu_settings->m_microphone_creator.get_none();
 
 	const auto change_microphone_type = [mic_none, this](int index)
@@ -972,7 +962,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	m_emu_settings->EnhanceComboBox(ui->audioProviderBox, emu_settings_type::AudioProvider);
 	SubscribeTooltip(ui->gb_audio_provider, tooltips.settings.audio_provider);
-	connect(ui->audioProviderBox, QOverload<int>::of(&QComboBox::currentIndexChanged), enable_avport_option);
+	ui->gb_audio_provider->setVisible(false); // Hidden for now. This option is forced on boot.
 
 	m_emu_settings->EnhanceComboBox(ui->audioAvportBox, emu_settings_type::AudioAvport);
 	SubscribeTooltip(ui->gb_audio_avport, tooltips.settings.audio_avport);
@@ -1033,7 +1023,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	connect(ui->enableTimeStretching, &QCheckBox::toggled, enable_time_stretching_options);
 
 	enable_buffering(ui->audioOutBox->currentIndex());
-	enable_avport_option(ui->audioProviderBox->currentIndex());
 
 	// Sliders
 


### PR DESCRIPTION
This hides the audio_provider box in the settings and forces the proper provider based on boot path.
Stop-gap solution until we decided what to do with vsh settings.

- Fixed the exception in get_guest_system_time. The timestamp in cellAudio wasn't properly initialized.