### PR TITLE
Debugger: Show constant-formed attribute of register value

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -848,7 +848,15 @@ std::string ppu_thread::dump_regs() const
 		// Fixup for syscall arguments
 		if (current_function && i >= 3 && i <= 10) reg = syscall_args[i - 3];
 
-		fmt::append(ret, "r%d%s: 0x%-8llx", i, i <= 9 ? " " : "", reg);
+		auto [is_const, const_value] = dis_asm.try_get_const_gpr_value(i, cia);
+
+		if (const_value != reg)
+		{
+			// Expectation of pretictable code path has not been met (such as a branch directly to the instruction)
+			is_const = false;
+		}
+
+		fmt::append(ret, "r%d%s%s 0x%-8llx", i, i <= 9 ? " " : "", is_const ? "©" : ":", reg);
 
 		constexpr u32 max_str_len = 32;
 		constexpr u32 hex_count = 8;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1040,9 +1040,17 @@ std::string spu_thread::dump_regs() const
 
 	for (u32 i = 0; i < 128; i++, ret += '\n')
 	{
-		fmt::append(ret, "%s: ", spu_reg_name[i]);
-
 		const auto r = gpr[i];
+
+		auto [is_const, const_value] = dis_asm.try_get_const_value(i, pc);
+
+		if (const_value != r)
+		{
+			// Expectation of pretictable code path has not been met (such as a branch directly to the instruction)
+			is_const = false;
+		}
+
+		fmt::append(ret, "%s%s ", spu_reg_name[i], is_const ? "©" : ":");
 
 		if (auto [size, dst, src] = SPUDisAsm::try_get_insert_mask_info(r); size)
 		{


### PR DESCRIPTION
Mark registers whom value has been originated in a PPU-LI alike instructrion with the copyright character, it does not affect spacing.