### PR TITLE
Allow building game and system firmware cache separately

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1271,7 +1271,7 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 		gui_log.success("Successfully installed PS3 firmware version %s.", version_string);
 		m_gui_settings->ShowInfoBox(tr("Success!"), tr("Successfully installed PS3 firmware and LLE Modules!"), gui::ib_pup_success, this);
 
-		CreateFirmwareCache();
+		CreateFirmwareCache(false);
 	}
 }
 
@@ -2105,7 +2105,8 @@ void main_window::CreateConnects()
 	connect(ui->removeDiskCacheAct, &QAction::triggered, this, &main_window::RemoveDiskCache);
 
 	connect(ui->removeFirmwareCacheAct, &QAction::triggered, this, &main_window::RemoveFirmwareCache);
-	connect(ui->createFirmwareCacheAct, &QAction::triggered, this, &main_window::CreateFirmwareCache);
+	connect(ui->createFirmwareCacheAct, &QAction::triggered, this, [this] {CreateFirmwareCache(false); });
+	connect(ui->createFullFirmwareCacheAct, &QAction::triggered, this, [this] {CreateFirmwareCache(true); });
 
 	connect(ui->sysPauseAct, &QAction::triggered, this, &main_window::OnPlayOrPause);
 	connect(ui->sysStopAct, &QAction::triggered, this, []()
@@ -2779,7 +2780,7 @@ void main_window::RemoveFirmwareCache()
 	return;
 }
 
-void main_window::CreateFirmwareCache()
+void main_window::CreateFirmwareCache(bool full)
 {
 	if (!m_gui_settings->GetBootConfirmation(this))
 	{
@@ -2789,7 +2790,7 @@ void main_window::CreateFirmwareCache()
 	Emu.GracefulShutdown(false);
 	Emu.SetForceBoot(true);
 
-	if (const game_boot_result error = Emu.BootGame(g_cfg_vfs.get_dev_flash(), "", true);
+	if (const game_boot_result error = Emu.BootGame(g_cfg_vfs.get_dev_flash() + (full ? "" : "sys"), "", true);
 		error != game_boot_result::no_errors)
 	{
 		gui_log.error("Creating firmware cache failed: reason: %s", error);

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -122,7 +122,7 @@ private Q_SLOTS:
 
 	void RemoveDiskCache();
 	void RemoveFirmwareCache();
-	void CreateFirmwareCache();
+	void CreateFirmwareCache(bool full);
 
 protected:
 	void closeEvent(QCloseEvent *event) override;

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -183,6 +183,7 @@
      <property name="title">
       <string>Firmware</string>
      </property>
+     <addaction name="createFullFirmwareCacheAct"/>
      <addaction name="createFirmwareCacheAct"/>
      <addaction name="removeFirmwareCacheAct"/>
     </widget>
@@ -1116,6 +1117,11 @@
   <action name="createFirmwareCacheAct">
    <property name="text">
     <string>Create Firmware Cache</string>
+   </property>
+  </action>
+  <action name="createFullFirmwareCacheAct">
+   <property name="text">
+    <string>Create Full Firmware Cache</string>
    </property>
   </action>
   <action name="actionCreate_RSX_Capture">


### PR DESCRIPTION
Adds new entry to menu. By default only build game firmware cache.

Closes #11979