### PR TITLE
SPU: Fix race on SPU Mailbox last value reading

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -369,7 +369,7 @@ struct spu_channel_4_t
 	{
 		u8 waiting;
 		u8 count;
-		u8 _pad[2];
+		u16 value3_inval;
 		u32 value0;
 		u32 value1;
 		u32 value2;
@@ -396,7 +396,12 @@ public:
 			case 0: data.value0 = value; break;
 			case 1: data.value1 = value; break;
 			case 2: data.value2 = value; break;
-			default: data.count = 4;
+			default:
+			{
+				data.count = 4;
+				data.value3_inval++; // Ensure the SPU reads the most recent value3 write in try_pop by re-loading
+				break;
+			}
 			}
 
 			if (data.waiting)


### PR DESCRIPTION
Ensure the most recent value written to the mailbox is the one the SPU reads by making try_pop reiterate (as compare-exchange fails) upon value3_inval update thus reloading value3 if an update occured.