### PR TITLE
LV2: Memory state post-exitspawn fixes

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1840,7 +1840,17 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 		mem_size += 0xC000000;
 	}
 
-	g_fxo->init<lv2_memory_container>(mem_size)->used += primary_stacksize;
+	if (Emu.init_mem_containers)
+	{
+		// Refer to sys_process_exit2 for explanation
+		Emu.init_mem_containers(mem_size);
+	}
+	else
+	{
+		g_fxo->init<lv2_memory_container>(mem_size);
+	}
+
+	g_fxo->get<lv2_memory_container>().used += primary_stacksize;
 
 	ppu->cmd_push({ppu_cmd::initialize, 0});
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1806,6 +1806,7 @@ void Emulator::Kill(bool allow_autoexit)
 		disc.clear();
 		klic.clear();
 		hdd1.clear();
+		init_mem_containers = nullptr;
 		m_config_path.clear();
 		m_config_mode = cfg_mode::custom;
 		return;
@@ -1951,6 +1952,7 @@ void Emulator::Kill(bool allow_autoexit)
 	disc.clear();
 	klic.clear();
 	hdd1.clear();
+	init_mem_containers = nullptr;
 	m_config_path.clear();
 	m_config_mode = cfg_mode::custom;
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -179,6 +179,7 @@ public:
 	std::vector<u128> klic;
 	std::string disc;
 	std::string hdd1;
+	std::function<void(u32)> init_mem_containers;
 
 	u32 m_boot_source_type = 0; // CELL_GAME_GAMETYPE_SYS
 


### PR DESCRIPTION
* Fix memory capacity if SDK version of the following executable differs from the original process'.
* Keep user memory containers, they are not freed at exitspawn!

Hw test https://github.com/elad335/myps3tests/commit/4bf60023ee3779a221da968732fc622b85266c5b