### PR TITLE
Loader: Fix out-of-bounds access of string

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1749,7 +1749,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 
 	for (const auto& arg : Emu.argv)
 	{
-		const u32 arg_size = utils::align(::size32(arg) + 1, 0x10);
+		const u32 arg_size = ::size32(arg) + 1;
 		const u32 arg_addr = vm::alloc(arg_size, vm::main);
 
 		std::memcpy(vm::base(arg_addr), arg.data(), arg_size);
@@ -1762,7 +1762,7 @@ bool ppu_load_exec(const ppu_exec_object& elf)
 
 	for (const auto& arg : Emu.envp)
 	{
-		const u32 arg_size = utils::align(::size32(arg) + 1, 0x10);
+		const u32 arg_size = ::size32(arg) + 1;
 		const u32 arg_addr = vm::alloc(arg_size, vm::main);
 
 		std::memcpy(vm::base(arg_addr), arg.data(), arg_size);


### PR DESCRIPTION
There was no need to manually align size, it only creates a bug with memcpy usage.