### PR TITLE
SPU: Implement timer freezing ability

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1461,7 +1461,7 @@ void spu_recompiler::RDCH(spu_opcode_t op)
 
 		auto sub2 = [](spu_thread* _spu, v128* _res)
 		{
-			const u32 out = _spu->ch_dec_value - static_cast<u32>(get_timebased_time() - _spu->ch_dec_start_timestamp);
+			const u32 out = _spu->read_dec().first;
 
 			*_res = v128::from32r(out);
 		};
@@ -2467,6 +2467,7 @@ void spu_recompiler::WRCH(spu_opcode_t op)
 	{
 		auto sub = [](spu_thread* _spu)
 		{
+			_spu->get_events(SPU_EVENT_TM);
 			_spu->ch_dec_start_timestamp = get_timebased_time();
 		};
 
@@ -2474,6 +2475,7 @@ void spu_recompiler::WRCH(spu_opcode_t op)
 		c->call(+sub);
 		c->mov(qw0->r32(), SPU_OFF_32(gpr, op.rt, &v128::_u32, 3));
 		c->mov(SPU_OFF_32(ch_dec_value), qw0->r32());
+		c->mov(SPU_OFF_8(is_dec_frozen), 0);
 		return;
 	}
 	case SPU_WrEventMask:

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -5579,7 +5579,7 @@ public:
 
 	static u32 exec_read_dec(spu_thread* _spu)
 	{
-		const u32 res = _spu->ch_dec_value - static_cast<u32>(get_timebased_time() - _spu->ch_dec_start_timestamp);
+		const u32 res = _spu->read_dec().first;
 
 		if (res > 1500 && g_cfg.core.spu_loop_detection)
 		{
@@ -6331,6 +6331,7 @@ public:
 			call("spu_get_events", &exec_get_events, m_thread, m_ir->getInt32(SPU_EVENT_TM));
 			m_ir->CreateStore(call("get_timebased_time", &get_timebased_time), spu_ptr<u64>(&spu_thread::ch_dec_start_timestamp));
 			m_ir->CreateStore(val.value, spu_ptr<u32>(&spu_thread::ch_dec_value));
+			m_ir->CreateStore(m_ir->getInt8(0), spu_ptr<u8>(&spu_thread::is_dec_frozen));
 			return;
 		}
 		case SPU_Set_Bkmk_Tag:

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -733,6 +733,8 @@ public:
 
 	u64 ch_dec_start_timestamp; // timestamp of writing decrementer value
 	u32 ch_dec_value; // written decrementer value
+	bool is_dec_frozen = false;
+	std::pair<u32, u32> read_dec() const; // Read decrementer
 
 	atomic_t<u32> run_ctrl; // SPU Run Control register (only provided to get latest data written)
 	shared_mutex run_ctrl_mtx;


### PR DESCRIPTION
SPU decrementer freezes when writing TM bit to SPU_WrEventAck and the events mask bit TM is off, resumes when writing to WrDec.