### PR TITLE
Fix recursion crash in the debugger

### DIFF
--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -26,11 +26,14 @@ debugger_list::debugger_list(QWidget* parent, std::shared_ptr<gui_settings> gui_
 	, m_breakpoint_handler(handler)
 {
 	setWindowTitle(tr("ASM"));
+
 	for (uint i = 0; i < m_item_count; ++i)
 	{
 		insertItem(i, new QListWidgetItem(""));
 	}
+
 	setSizeAdjustPolicy(QListWidget::AdjustToContents);
+	setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 }
 
 void debugger_list::UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm)
@@ -329,7 +332,7 @@ void debugger_list::wheelEvent(QWheelEvent* event)
 
 void debugger_list::resizeEvent(QResizeEvent* event)
 {
-	Q_UNUSED(event)
+	QListWidget::resizeEvent(event);
 
 	if (count() < 1 || visualItemRect(item(0)).height() < 1)
 	{
@@ -338,12 +341,8 @@ void debugger_list::resizeEvent(QResizeEvent* event)
 
 	const u32 old_size = m_item_count;
 
-	m_item_count = (rect().height() - frameWidth() * 2) / visualItemRect(item(0)).height();
-
-	if (horizontalScrollBar())
-	{
-		m_item_count--;
-	}
+	// It is fine if the QWidgetList is a tad bit larger than the frame 
+	m_item_count = utils::aligned_div<u32>(rect().height() - frameWidth() * 2, visualItemRect(item(0)).height());
 
 	if (old_size <= m_item_count)
 	{

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -336,20 +336,27 @@ void debugger_list::resizeEvent(QResizeEvent* event)
 		return;
 	}
 
+	const u32 old_size = m_item_count;
+
 	m_item_count = (rect().height() - frameWidth() * 2) / visualItemRect(item(0)).height();
-
-	clear();
-
-	for (u32 i = 0; i < m_item_count; ++i)
-	{
-		insertItem(i, new QListWidgetItem(""));
-	}
 
 	if (horizontalScrollBar())
 	{
 		m_item_count--;
-		delete item(m_item_count);
 	}
 
-	ShowAddress(m_pc, false);
+	if (old_size <= m_item_count)
+	{
+		for (u32 i = old_size; i < m_item_count; ++i)
+		{
+			insertItem(i, new QListWidgetItem(""));
+		}
+	}
+	else
+	{
+		for (u32 i = old_size - 1; i >= m_item_count; --i)
+		{
+			delete takeItem(i);
+		}
+	}
 }


### PR DESCRIPTION
Not sure why, but in some random go-to or scrolling with the debugger, QListWidgetItem::setSelected caused a resizeEvent to trigger internally, in resizeEvent we called showAddress again and the recursion continued until it crashed.
Removed showAddress completely from resizeEvent as it is not needed anyways. (as #11893 refreshes the view all the time)

Additionally, fix instructions "pop-in" when resizing. IMO it is more natural to allow displaying incomplete elements without blank space as if it's a window to an infinite view of instructions.