### PR TITLE
rsx: Implement HW accurate frame limiter

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3188,7 +3188,7 @@ namespace rsx
 		case frame_limit_type::_50: limit = 50.; break;
 		case frame_limit_type::_60: limit = 60.; break;
 		case frame_limit_type::_30: limit = 30.; break;
-		case frame_limit_type::_auto: limit = static_cast<double>(g_cfg.video.vblank_rate); break;
+		case frame_limit_type::_auto: limit = 0.; break; // Handled in RSX semaphore_acquire
 		default:
 			break;
 		}


### PR DESCRIPTION
Reimplement the current frame limiter to use mechanisms which had been used on PS3.
Most curiously fixes https://github.com/RPCS3/rpcs3/issues/3020, perhaps it does something sneaky with this mechanism. Also fix debugger RSX single stepping in semaphore_acquire.