### PR TITLE
rsx: Deadlock avoidance of accurate RSX reservations

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1070,6 +1070,11 @@ namespace rsx
 				}
 			}
 		}
+
+		if (m_eng_interrupt_mask & rsx::pipe_flush_interrupt)
+		{
+			sync();
+		}
 	}
 
 	std::array<u32, 4> thread::get_color_surface_addresses() const
@@ -2612,6 +2617,8 @@ namespace rsx
 
 	void thread::sync()
 	{
+		m_eng_interrupt_mask.clear(rsx::pipe_flush_interrupt);
+
 		if (zcull_ctrl->has_pending())
 		{
 			zcull_ctrl->sync(this);

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -168,8 +168,9 @@ namespace rsx
 		backend_interrupt       = 0x0001,        // Backend-related interrupt
 		memory_config_interrupt = 0x0002,        // Memory configuration changed
 		display_interrupt       = 0x0004,        // Display handling
+		pipe_flush_interrupt    = 0x0008,        // Flush pipelines
 
-		all_interrupt_bits = memory_config_interrupt | backend_interrupt | display_interrupt
+		all_interrupt_bits = memory_config_interrupt | backend_interrupt | display_interrupt | pipe_flush_interrupt
 	};
 
 	enum FIFO_state : u8

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -60,20 +60,42 @@ namespace rsx
 		}
 
 		template<bool IsFullLock>
-		bool lock(u32 addr, u32 len) noexcept
+		bool lock(u32 addr, u32 len, cpu_thread* self = nullptr) noexcept
 		{
 			if (len <= 1) return false;
 			const u32 end = addr + len - 1;
 
 			for (u32 block = (addr >> 20); block <= (end >> 20); ++block)
 			{
+				auto& mutex_ = rs[block];
+
 				if constexpr (IsFullLock)
 				{
-					rs[block].lock();
+					if (self) [[ likely ]]
+					{
+						while (!mutex_.try_lock())
+						{
+							self->cpu_wait({});
+						}
+					}
+					else
+					{
+						mutex_.lock();
+					}
 				}
 				else
 				{
-					rs[block].lock_shared();
+					if (!self) [[ likely ]]
+					{
+						mutex_.lock_shared();
+					}
+					else
+					{
+						while (!mutex_.try_lock_shared())
+						{
+							self->cpu_wait({});
+						}
+					}
 				}
 			}
 
@@ -833,7 +855,8 @@ namespace rsx
 			this->length = length;
 
 			auto renderer = get_current_renderer();
-			this->locked = renderer->iomap_table.lock<IsFullLock>(addr, length);
+			cpu_thread* lock_owner = renderer->is_current_thread() ? renderer : nullptr;
+			this->locked = renderer->iomap_table.lock<IsFullLock>(addr, length, lock_owner);
 		}
 
 	public:

--- a/rpcs3/Emu/RSX/RSXZCULL.cpp
+++ b/rpcs3/Emu/RSX/RSXZCULL.cpp
@@ -836,11 +836,6 @@ namespace rsx
 			rsx_log.warning("Reports area at location %s was accessed. ZCULL optimizations will be disabled.", location_tostring(location));
 			m_pages_accessed[location] = true;
 
-			// Flush all pending writes
-			m_critical_reports_in_flight += 0x100000;
-			ptimer->sync();
-			m_critical_reports_in_flight -= 0x100000;
-
 			// Unlock pages
 			for (auto& p : m_locked_pages[location])
 			{
@@ -911,6 +906,8 @@ namespace rsx
 				rsx::eng_lock rlock(thr);
 				std::scoped_lock lock(m_pages_mutex);
 				disable_optimizations(thr, location);
+
+				thr->m_eng_interrupt_mask |= rsx::pipe_flush_interrupt;
 				return true;
 			}
 


### PR DESCRIPTION
Fixes games randomly hard-locking when the "Accurate RSX reservations" option is enabled.