### PR TITLE
rsx: Fix second VBlank, add setting to control its frequency

### DIFF
--- a/rpcs3/Emu/RSX/Core/RSXDisplay.h
+++ b/rpcs3/Emu/RSX/Core/RSXDisplay.h
@@ -69,13 +69,16 @@ namespace rsx
 
 	class vblank_thread
 	{
-		std::shared_ptr<named_thread<std::function<void()>>> m_thread;
+		using thread_t = std::shared_ptr<named_thread<std::function<void()>>>;
+
+		std::shared_ptr<named_thread<std::function<void()>>> m_thread1;
+		std::shared_ptr<named_thread<std::function<void()>>> m_thread2;
 
 	public:
 		vblank_thread() = default;
 		vblank_thread(const vblank_thread&) = delete;
 
-		void set_thread(std::shared_ptr<named_thread<std::function<void()>>> thread);
+		void set_thread(thread_t thread1, thread_t thread2);
 
 		vblank_thread& operator=(thread_state);
 		vblank_thread& operator=(const vblank_thread&) = delete;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -270,6 +270,7 @@ namespace rsx
 
 		atomic_t<bool> requested_vsync{true};
 		atomic_t<bool> enable_second_vhandler{false};
+		std::array<atomic_t<u32>, 2> display_frequency{};
 
 		bool send_event(u64, u64, u64);
 

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -1144,6 +1144,14 @@ namespace gcm
 		RSX_VERTEX_BASE_TYPE_CMP32,
 		RSX_VERTEX_BASE_TYPE_UINT8,
 	};
+
+	// VBlank frequancy types
+	enum rsx_freq_t : u32
+	{
+		GCM_DISPLAY_FREQUENCY_SCANOUT = 2,
+		GCM_DISPLAY_FREQUENCY_59_94HZ = 3,
+		GCM_DISPLAY_FREQUENCY_DISABLE = 4,
+	};
 }
 
 // Public export

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -174,6 +174,7 @@ struct cfg_root : cfg::node
 		cfg::_int<0, 30000000> driver_recovery_timeout{ this, "Driver Recovery Timeout", 1000000, true };
 		cfg::uint<0, 16667> driver_wakeup_delay{ this, "Driver Wake-Up Delay", 1, true };
 		cfg::_int<1, 1800> vblank_rate{ this, "Vblank Rate", 60, true }; // Changing this from 60 may affect game speed in unexpected ways
+		cfg::_int<0, 1800> second_vblank_rate{ this, "Second Vblank Rate", 0, true }; // 0 means equal to vblank_rate
 		cfg::_bool vblank_ntsc{ this, "Vblank NTSC Fixup", false, true };
 		cfg::_bool decr_memory_layout{ this, "DECR memory layout", false}; // Force enable increased allowed main memory range as DECR console
 		cfg::_bool host_label_synchronization{ this, "Allow Host GPU Labels", false };


### PR DESCRIPTION
There are 2 vblank signals, the first is meant to update at the rate of video output.
The second is a software interrupt usually fixated at 59.94hz, most commonly used to convert logic meant for 59.94hz displays to the real display such as 59.94hz encoded videoes, gameplay logic etc. On real ps3 this had a meaningful use with displays that only output at odd rates such as 50hz for example.
I have added a setting to control it in config.yml

* Bugfixes include a fix to its enabling, it no longer conflicts with the first VBlank configuration.
* Implemented fixed 59.94hz mode for both signal types (as if VBlank NTSC fixup is enabled if configured by the game application).
* Fix Second VBlank timestamps by not overriding it in the first VBLank signal.
* Another bugfix is enabling by default VSYNC in PS3 Native frame limiter mode.
* Fix second VBLank time to respect Clocks Scaling.

To users: added a setting to control its frequency in config.yml called "Second Vblank Rate". If 0 (default), it synchronizes with the first VBlank rate, otherwise the value set controls it.
It may help override games' frame cap that is dependent on the first VBlank rate, but their game logic is dependent on the second. 