### PR TITLE
[Experimental][Testers Needed] rsx: Implement atomic FIFO fetching

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -124,9 +124,15 @@ namespace rsx
 			u32 m_args_ptr = 0;
 			u32 m_cmd = ~0u;
 
+			u32 m_cache_addr = 0;
+			u32 m_cache_size = 0;
+			alignas(64) std::byte m_cache[8][128];
 		public:
 			FIFO_control(rsx::thread* pctrl);
 			~FIFO_control() = default;
+
+			u32 fetch_u32(u32 addr);
+			void invalidate_cache() { m_cache_addr = 0; }
 
 			u32 get_pos() const { return m_internal_get; }
 			u32 last_cmd() const { return m_cmd; }

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2649,6 +2649,7 @@ namespace rsx
 	{
 		// Make sure GET value is exposed before sync points
 		fifo_ctrl->sync_get();
+		fifo_ctrl->invalidate_cache();
 	}
 
 	std::pair<u32, u32> thread::try_get_pc_of_x_cmds_backwards(u32 count, u32 get) const


### PR DESCRIPTION
We already know when the conditions suffice CELL always uses atomic cache line loads and stores when it can because it is actually cheaper for it.
Even stuff that is not required to be atomic such as aligned SPU GET/PUT 128-byte commands are actually atomic.
We know real RSX caches up to 1024 bytes of FIFO buffer.
So, this logic suggests that FIFO prefetch may also be atomic.
I've seen in the RSX code of some games that they are actually shaped to be exactly 128-byte aligned and padded with NOPs so all code insertions can be done by SPU commands cheaply and atomically.
So that got me thinking that it is actually possible to insert RSX code atomically by SPU without proper RSX FIFO PUT register control and still remain race-free.

This pr aims to aid RSX-FIFO-induced race conditions, for full effect enable SPU Accurate DMA in debug tab, depending on if the game uses PUT or PUTLLUC/PUTQLLUC commands for RSX code insertion. (the latter does not need this setting enabled)

TODO:
- [ ] Accurate DMA has yet to be optimized for it
- [ ] Currently, there is no setting for it for testing.