### PR TITLE
sys_spu: Fix spu_thread_group_terminate deadlock

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1138,6 +1138,7 @@ error_code sys_spu_thread_group_terminate(ppu_thread& ppu, u32 id, s32 value)
 		lv2_obj::sleep(ppu);
 		busy_wait(3000);
 		ppu.check_state();
+		ppu.state += cpu_flag::wait;
 	};
 
 	if (auto state = +group->run_state;


### PR DESCRIPTION
PPU has refused to acknowledge it does not use memory, leading the SPU to wait for it in PUTLLC infinitely while the PPU waits for  the SPU itself to terminate.