### PR TITLE
SPU LLVM: Fixup for inline MFC transfers

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6208,7 +6208,7 @@ public:
 							}
 							else
 							{
-								m_ir->CreateAlignedStore(m_ir->CreateLoad(m_ir->CreateBitCast(_src, vtype), false), m_ir->CreateBitCast(_dst, vtype), llvm::MaybeAlign{16});
+								m_ir->CreateAlignedStore(m_ir->CreateAlignedLoad(m_ir->CreateBitCast(_src, vtype), llvm::MaybeAlign{16}), m_ir->CreateBitCast(_dst, vtype), llvm::MaybeAlign{16});
 							}
 						}
 					}


### PR DESCRIPTION
The code previously emitted aligned loads when LS was constant and 32 byte aligned. This worked just fine, except when dst and src were swapped.

Just use unaligned instructions instead, since they're the same speed on anything that supports AVX anyways.

Fixes: https://github.com/RPCS3/rpcs3/issues/12122