### PR TITLE
rsx: Fix deadlock in vm::_page_unmap

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2949,13 +2949,13 @@ namespace rsx
 				}
 			}
 
+			// Pause RSX thread momentarily to handle unmapping
+			eng_lock elock(this);
+
 			// Queue up memory invalidation
 			std::lock_guard lock(m_mtx_task);
 			const bool existing_range_valid = m_invalidated_memory_range.valid();
 			const auto unmap_range = address_range::start_length(address, size);
-
-			// Pause RSX thread momentarily to handle unmapping
-			eng_lock elock(this);
 
 			if (existing_range_valid && m_invalidated_memory_range.touches(unmap_range))
 			{


### PR DESCRIPTION
PPU is the owner of m_mtx_task, it is possible for RSX to wait on it and meanwhile not acknowledge PPU pause resulting in a deadlock.