### PR TITLE
Obtain system memory page size

### DIFF
--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1740,7 +1740,7 @@ namespace rsx
 		template<u32 index>
 		struct driver_flip
 		{
-			static void impl(thread* rsx, u32 /*reg*/, u32 arg)
+			static void impl(thread*, u32 /*reg*/, u32 arg)
 			{
 				sys_rsx_context_attribute(0x55555555, 0x102, index, arg, 0, 0);
 			}
@@ -1749,7 +1749,7 @@ namespace rsx
 		template<u32 index>
 		struct queue_flip
 		{
-			static void impl(thread* rsx, u32 /*reg*/, u32 arg)
+			static void impl(thread*, u32 /*reg*/, u32 arg)
 			{
 				sys_rsx_context_attribute(0x55555555, 0x103, index, arg, 0, 0);
 			}

--- a/rpcs3/util/vm.hpp
+++ b/rpcs3/util/vm.hpp
@@ -11,6 +11,12 @@ namespace utils
 	using native_handle = int;
 #endif
 
+	// Obtain system page size
+	long get_page_size();
+
+	// System page size
+	inline const long c_page_size = get_page_size();
+
 	// Memory protection type
 	enum class protection
 	{


### PR DESCRIPTION
System vm allocation granularity, previously assumed to be 4096, should be obtained at runtime.