### PR TITLE
feat: add boot test menu entry

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -210,4 +210,6 @@ if(UNIX AND NOT APPLE)
         DESTINATION ${CMAKE_INSTALL_DATADIR}/rpcs3)
     install(DIRECTORY ../bin/git
         DESTINATION ${CMAKE_INSTALL_DATADIR}/rpcs3)
+    install(DIRECTORY ../bin/test
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/rpcs3)
 endif()

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -472,6 +472,46 @@ void main_window::BootElf()
 	Boot(path, "", true);
 }
 
+void main_window::BootTest()
+{
+	bool stopped = false;
+
+	if (Emu.IsRunning())
+	{
+		Emu.Pause();
+		stopped = true;
+	}
+
+#ifdef _WIN32
+	const QString path_tests = QString::fromStdString(fs::get_config_dir()) + "/test/";
+#elif defined(__linux__)
+	const QString path_tests = QCoreApplication::applicationDirPath() + "/../share/rpcs3/test/";
+#else
+	const QString path_tests = QCoreApplication::applicationDirPath() + "/../Resources/test/";
+#endif
+
+	const QString file_path = QFileDialog::getOpenFileName(this, tr("Select (S)ELF To Boot"), path_tests, tr(
+		"(S)ELF files (*.elf *.self);;"
+		"ELF files (*.elf);;"
+		"SELF files (*.self);;"
+		"All files (*.*)"),
+		Q_NULLPTR, QFileDialog::DontResolveSymlinks);
+
+	if (file_path.isEmpty())
+	{
+		if (stopped)
+		{
+			Emu.Resume();
+		}
+		return;
+	}
+
+	const std::string path = sstr(QFileInfo(file_path).absoluteFilePath());
+
+	gui_log.notice("Booting from BootTest...");
+	Boot(path, "", true);
+}
+
 void main_window::BootGame()
 {
 	bool stopped = false;
@@ -1903,6 +1943,7 @@ void main_window::CreateActions()
 void main_window::CreateConnects()
 {
 	connect(ui->bootElfAct, &QAction::triggered, this, &main_window::BootElf);
+	connect(ui->bootTestAct, &QAction::triggered, this, &main_window::BootTest);
 	connect(ui->bootGameAct, &QAction::triggered, this, &main_window::BootGame);
 	connect(ui->bootVSHAct, &QAction::triggered, this, &main_window::BootVSH);
 	connect(ui->actionopen_rsx_capture, &QAction::triggered, this, [this](){ BootRsxCapture(); });

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -109,6 +109,7 @@ private Q_SLOTS:
 	void OnPlayOrPause();
 	void Boot(const std::string& path, const std::string& title_id = "", bool direct = false, bool add_only = false, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "");
 	void BootElf();
+	void BootTest();
 	void BootGame();
 	void BootVSH();
 	void BootRsxCapture(std::string path = "");

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -151,6 +151,19 @@
     <property name="title">
      <string>File</string>
     </property>
+    <widget class="QMenu" name="bootElfMenu">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="title">
+      <string>Boot (S)Elf</string>
+     </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
+     </property>
+     <addaction name="bootElfAct"/>
+     <addaction name="bootTestAct"/>
+    </widget>
     <widget class="QMenu" name="bootRecentMenu">
      <property name="enabled">
       <bool>true</bool>
@@ -186,9 +199,9 @@
      <addaction name="createFirmwareCacheAct"/>
      <addaction name="removeFirmwareCacheAct"/>
     </widget>
-    <addaction name="bootElfAct"/>
     <addaction name="bootGameAct"/>
     <addaction name="bootVSHAct"/>
+    <addaction name="bootElfMenu"/>
     <addaction name="bootRecentMenu"/>
     <addaction name="separator"/>
     <addaction name="addGamesAct"/>
@@ -398,6 +411,11 @@
   <action name="bootElfAct">
    <property name="text">
     <string>Boot SELF/ELF</string>
+   </property>
+  </action>
+  <action name="bootTestAct">
+   <property name="text">
+    <string>Boot Test</string>
    </property>
   </action>
   <action name="bootGameAct">


### PR DESCRIPTION
Adds the tests to the AppImage and adds a "Boot Test" option to the menu which point to relevant directories depending on OS.
![image](https://user-images.githubusercontent.com/6031700/171749431-3d3b1a65-958b-4fb1-8229-60fa4b44f1f7.png)
