### PR TITLE
SPU LLVM: Optimize LQR/STQR

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9011,10 +9011,15 @@ public:
 		set_vr(op.rt, make_load_ls(addr));
 	}
 
+	llvm::Value* get_pc_as_u64(u32 addr)
+	{
+		return m_ir->CreateAdd(m_ir->CreateZExt(m_base_pc, get_type<u64>()), m_ir->getInt64(addr - m_base));
+	}
+
 	void STQR(spu_opcode_t op) //
 	{
 		value_t<u64> addr;
-		addr.value = m_ir->CreateZExt(m_interp_magn ? m_interp_pc : get_pc(m_pos), get_type<u64>());
+		addr.value = m_interp_magn ? m_ir->CreateZExt(m_interp_pc, get_type<u64>()) : get_pc_as_u64(m_pos);
 		addr = eval(((get_imm<u64>(op.i16, false) << 2) + addr) & (m_interp_magn ? 0x3fff0 : ~0xf));
 		make_store_ls(addr, get_vr<u8[16]>(op.rt));
 	}
@@ -9022,7 +9027,7 @@ public:
 	void LQR(spu_opcode_t op) //
 	{
 		value_t<u64> addr;
-		addr.value = m_ir->CreateZExt(m_interp_magn ? m_interp_pc : get_pc(m_pos), get_type<u64>());
+		addr.value = m_interp_magn ? m_ir->CreateZExt(m_interp_pc, get_type<u64>()) : get_pc_as_u64(m_pos);
 		addr = eval(((get_imm<u64>(op.i16, false) << 2) + addr) & (m_interp_magn ? 0x3fff0 : ~0xf));
 		set_vr(op.rt, make_load_ls(addr));
 	}


### PR DESCRIPTION
Zero extend the pc to u64 before doing any arithmetic. This helps llvm combine operations which it previously failed to do so due to type mismatches between u32 and u64.
<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/26352541/171774118-85cd104d-f226-490c-8ee7-a8bce7b3f50c.png)
</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/26352541/171774039-d6833667-3cc4-4be2-a501-5c47739e3cc5.png)

</details>



