### PR TITLE
cellAudioOut: Improve sound mode enumeration

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -331,15 +331,12 @@ error_code cellAudioOutConfigure(u32 audioOut, vm::ptr<CellAudioOutConfiguration
 
 		audio_out_configuration::audio_out& out = cfg.out.at(audioOut);
 
-		if (out.sound_modes.cend() == std::find_if(out.sound_modes.cbegin(), out.sound_modes.cend(), [&config](const CellAudioOutSoundMode& mode)
-			{
-				return mode.channel == config->channel && mode.type == config->encoder && config->downMixer <= CELL_AUDIO_OUT_DOWNMIXER_TYPE_B;
-			}))
+		const bool found_mode = (out.sound_modes.cend() != std::find_if(out.sound_modes.cbegin(), out.sound_modes.cend(), [&config](const CellAudioOutSoundMode& mode)
 		{
-			return CELL_AUDIO_OUT_ERROR_ILLEGAL_CONFIGURATION; // TODO: confirm
-		}
+			return mode.channel == config->channel && mode.type == config->encoder && config->downMixer <= CELL_AUDIO_OUT_DOWNMIXER_TYPE_B;
+		}));
 
-		if (out.channels != config->channel || out.encoder != config->encoder || out.downmixer != config->downMixer)
+		if (found_mode && (out.channels != config->channel || out.encoder != config->encoder || out.downmixer != config->downMixer))
 		{
 			out.channels = config->channel;
 			out.encoder = config->encoder;

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -39,7 +39,7 @@ audio_out_configuration::audio_out_configuration()
 	std::vector<CellAudioOutSoundMode>& primary_modes = primary_output.sound_modes;
 	std::vector<CellAudioOutSoundMode>& secondary_modes = secondary_output.sound_modes;
 
-	const psf::registry sfo = psf::load_object(fs::file(Emu.GetSfoDir() + "/PARAM.SFO"));
+	const psf::registry sfo = psf::load_object(fs::file(Emu.GetSfoDir(true) + "/PARAM.SFO"));
 	const s32 sound_format = psf::get_integer(sfo, "SOUND_FORMAT", psf::sound_format_flag::lpcm_2); // Default to Linear PCM 2 Ch.
 
 	const bool supports_lpcm_2   = (sound_format & psf::sound_format_flag::lpcm_2);   // Linear PCM 2 Ch.

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -478,7 +478,7 @@ error_code cellAudioOutGetDeviceInfo(u32 audioOut, u32 deviceIndex, vm::ptr<Cell
 	_info.portType = CELL_AUDIO_OUT_PORT_HDMI;
 	_info.availableModeCount = ::narrow<u8>(out.sound_modes.size());
 	_info.state = CELL_AUDIO_OUT_DEVICE_STATE_AVAILABLE;
-	_info.latency = 1000;
+	_info.latency = 13;
 
 	for (usz i = 0; i < out.sound_modes.size(); i++)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -321,7 +321,7 @@ error_code cellAudioOutConfigure(u32 audioOut, vm::ptr<CellAudioOutConfiguration
 	case CELL_AUDIO_OUT_PRIMARY:
 		break;
 	case CELL_AUDIO_OUT_SECONDARY:
-		return CELL_AUDIO_OUT_ERROR_UNSUPPORTED_AUDIO_OUT; // TODO: enable if we ever actually support peripheral output
+		return CELL_AUDIO_OUT_ERROR_UNSUPPORTED_AUDIO_OUT; // The secondary output only supports one format and can't be reconfigured
 	default:
 		return CELL_AUDIO_OUT_ERROR_ILLEGAL_PARAMETER;
 	}
@@ -400,7 +400,7 @@ error_code cellAudioOutGetConfiguration(u32 audioOut, vm::ptr<CellAudioOutConfig
 	case CELL_AUDIO_OUT_PRIMARY:
 		break;
 	case CELL_AUDIO_OUT_SECONDARY:
-		return CELL_AUDIO_OUT_ERROR_UNSUPPORTED_AUDIO_OUT; // TODO: enable if we ever actually support peripheral output
+		return CELL_AUDIO_OUT_ERROR_UNSUPPORTED_AUDIO_OUT; // The secondary output only supports one format and can't be reconfigured
 	default:
 		return CELL_AUDIO_OUT_ERROR_ILLEGAL_PARAMETER;
 	}

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.h
@@ -66,8 +66,10 @@ enum CellAudioOutCodingType
 	CELL_AUDIO_OUT_CODING_TYPE_AAC                = 5,
 	CELL_AUDIO_OUT_CODING_TYPE_DTS                = 6,
 	CELL_AUDIO_OUT_CODING_TYPE_ATRAC              = 7,
-	// ...
+	CELL_AUDIO_OUT_CODING_TYPE_DOLBY_TRUE_HD      = 8, // Speculative name
 	CELL_AUDIO_OUT_CODING_TYPE_DOLBY_DIGITAL_PLUS = 9,
+	CELL_AUDIO_OUT_CODING_TYPE_DTS_HD_HIGHRES     = 10, // Speculative name
+	CELL_AUDIO_OUT_CODING_TYPE_DTS_HD_MASTER      = 11, // Speculative name
 	CELL_AUDIO_OUT_CODING_TYPE_BITSTREAM          = 0xff,
 };
 

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.h
@@ -202,6 +202,7 @@ struct audio_out_configuration
 		u32 downmixer = CELL_AUDIO_OUT_DOWNMIXER_NONE;
 		u32 copy_control = CELL_AUDIO_OUT_COPY_CONTROL_COPY_FREE;
 		std::vector<CellAudioOutSoundMode> sound_modes;
+		CellAudioOutConfiguration config{}; // Selected by the game. Does not necessarily mean the active config.
 	};
 
 	std::array<audio_out, 2> out;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -83,7 +83,7 @@ std::mutex g_tty_mutex;
 
 namespace atomic_wait
 {
-	extern void parse_hashtable(bool(*cb)(u64 id, u32 refs, u64 ptr, u32 stats));
+	extern void parse_hashtable(bool(*cb)(u64 id, u32 refs, u64 ptr, u32 max_coll));
 }
 
 template<>

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2222,4 +2222,19 @@ const std::string& Emulator::GetFakeCat() const
 	return m_cat;
 };
 
+const std::string Emulator::GetSfoDir(bool prefer_disc_sfo) const
+{
+	if (prefer_disc_sfo)
+	{
+		const std::string sfo_dir = vfs::get("/dev_bdvd/PS3_GAME");
+
+		if (!sfo_dir.empty())
+		{
+			return sfo_dir;
+		}
+	}
+
+	return m_sfo_dir;
+}
+
 Emulator Emu;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -225,10 +225,7 @@ public:
 		return m_dir;
 	}
 
-	const std::string& GetSfoDir() const
-	{
-		return m_sfo_dir;
-	}
+	const std::string GetSfoDir(bool prefer_disc_sfo) const;
 
 	// String for GUI dialogs.
 	const std::string& GetUsr() const


### PR DESCRIPTION
Follow-up to #12112 . Based on hardware tests in the comments.

- Load PARAM.SFO from disc if possible, as game data SFOs do not contain info about SOUND_FORMAT
- Pre-select the first available format based on SFO and config.yml in the following order:
LPCM 7.1 > LPCM 5.1 > AC3 > DTS > LPCM 2
- Only report LPCM 2ch. for the secondary outport
- Don't return speculative error in cellAudioOutConfigure
- Seperate active config from set config in cellAudioOutConfigure.
cellAudioOutGetConfiguration seems to return the set config and not the active config.
- Set latency to 13
- Add some unknown 8 channel enum values