### PR TITLE
[Testers Needed] vm_native.cpp: Remove the blame from Windows

### DIFF
--- a/Utilities/lockless.h
+++ b/Utilities/lockless.h
@@ -3,7 +3,7 @@
 #include "util/types.hpp"
 #include "util/atomic.hpp"
 
-//! Simple sizeless array base for concurrent access. Cannot shrink, only growths automatically.
+//! Simple unshrinkable array base for concurrent access. Only growths automatically.
 //! There is no way to know the current size. The smaller index is, the faster it's accessed.
 //!
 //! T is the type of elements. Currently, default constructor of T shall be constexpr.
@@ -46,6 +46,18 @@ public:
 
 		// Access recursively
 		return (*m_next)[index - N];
+	}
+
+	u64 size() const
+	{
+		u64 size_n = 0;
+
+		for (auto ptr = this; ptr; ptr = ptr->m_next)
+		{
+			size_n += N;
+		}
+
+		return size_n;
 	}
 };
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -23,11 +23,11 @@ void ppu_remove_hle_instructions(u32 addr, u32 size);
 
 namespace vm
 {
-	static u8* memory_reserve_4GiB(void* _addr, u64 size = 0x100000000)
+	static u8* memory_reserve_4GiB(void* _addr, u64 size = 0x100000000, bool is_memory_mapping = false)
 	{
 		for (u64 addr = reinterpret_cast<u64>(_addr) + 0x100000000; addr < 0x8000'0000'0000; addr += 0x100000000)
 		{
-			if (auto ptr = utils::memory_reserve(size, reinterpret_cast<void*>(addr)))
+			if (auto ptr = utils::memory_reserve(size, reinterpret_cast<void*>(addr), is_memory_mapping))
 			{
 				return static_cast<u8*>(ptr);
 			}
@@ -37,7 +37,7 @@ namespace vm
 	}
 
 	// Emulated virtual memory
-	u8* const g_base_addr = memory_reserve_4GiB(reinterpret_cast<void*>(0x2'0000'0000), 0x2'0000'0000);
+	u8* const g_base_addr = memory_reserve_4GiB(reinterpret_cast<void*>(0x2'0000'0000), 0x2'0000'0000, true);
 
 	// Unprotected virtual memory mirror
 	u8* const g_sudo_addr = g_base_addr + 0x1'0000'0000;
@@ -697,6 +697,21 @@ namespace vm
 		if (~flags & page_readable)
 			prot = utils::protection::no;
 
+		std::string map_error;
+
+		auto map_critical = [&](u8* ptr, utils::protection prot)
+		{
+			auto [res, error] = shm->map_critical(ptr, prot);
+
+			if (res != ptr)
+			{
+				map_error = std::move(error);
+				return false;
+			}
+
+			return true;
+		};
+
 		if (is_noop)
 		{
 		}
@@ -704,9 +719,9 @@ namespace vm
 		{
 			utils::memory_protect(g_base_addr + addr, size, prot);
 		}
-		else if (shm->map_critical(g_base_addr + addr, prot) != g_base_addr + addr || shm->map_critical(g_sudo_addr + addr) != g_sudo_addr + addr || !shm->map_self())
+		else if (!map_critical(g_base_addr + addr, prot) || !map_critical(g_sudo_addr + addr, utils::protection::rw) || (map_error = "map_self()", !shm->map_self()))
 		{
-			fmt::throw_exception("Memory mapping failed - blame Windows (addr=0x%x, size=0x%x, flags=0x%x)", addr, size, flags);
+			fmt::throw_exception("Memory mapping failed (addr=0x%x, size=0x%x, flags=0x%x): %s", addr, size, flags, map_error);
 		}
 
 		if (flags & page_executable && !is_noop)
@@ -1138,10 +1153,28 @@ namespace vm
 	{
 		if (this->flags & preallocated)
 		{
+			std::string map_error;
+
+			auto map_critical = [&](u8* ptr, utils::protection prot)
+			{
+				auto [res, error] = m_common->map_critical(ptr, prot);
+	
+				if (res != ptr)
+				{
+					map_error = std::move(error);
+					return false;
+				}
+	
+				return true;
+			};
+
 			// Special path for whole-allocated areas allowing 4k granularity
 			m_common = std::make_shared<utils::shm>(size);
-			m_common->map_critical(vm::base(addr), this->flags & page_size_4k && utils::c_page_size > 4096 ? utils::protection::rw : utils::protection::no);
-			m_common->map_critical(vm::get_super_ptr(addr));
+
+			if (!map_critical(vm::_ptr<u8>(addr), this->flags & page_size_4k && utils::c_page_size > 4096 ? utils::protection::rw : utils::protection::no) || !map_critical(vm::get_super_ptr(addr), utils::protection::rw))
+			{
+				fmt::throw_exception("Memory mapping failed (addr=0x%x, size=0x%x, flags=0x%x): %s", addr, size, flags, map_error);
+			}
 		}
 	}
 
@@ -1737,7 +1770,6 @@ namespace vm
 			g_locations.clear();
 		}
 
-		utils::memory_decommit(g_base_addr, 0x200000000);
 		utils::memory_decommit(g_exec_addr, 0x200000000);
 		utils::memory_decommit(g_stat_addr, 0x100000000);
 

--- a/rpcs3/util/dyn_lib.hpp
+++ b/rpcs3/util/dyn_lib.hpp
@@ -109,4 +109,4 @@ namespace utils
 	};
 }
 
-#define DYNAMIC_IMPORT(lib, name, ...) inline utils::dynamic_import<__VA_ARGS__> name(lib, #name);
+#define DYNAMIC_IMPORT(lib, name, ...) inline constinit utils::dynamic_import<__VA_ARGS__> name(lib, #name);

--- a/rpcs3/util/vm.hpp
+++ b/rpcs3/util/vm.hpp
@@ -3,6 +3,8 @@
 #include "util/types.hpp"
 #include "util/atomic.hpp"
 
+#include <string>
+
 namespace utils
 {
 #ifdef _WIN32
@@ -31,7 +33,7 @@ namespace utils
 	* Reserve `size` bytes of virtual memory and returns it.
 	* The memory should be committed before usage.
 	*/
-	void* memory_reserve(usz size, void* use_addr = nullptr);
+	void* memory_reserve(usz size, void* use_addr = nullptr, bool is_memory_mapping = false);
 
 	/**
 	* Commit `size` bytes of virtual memory starting at pointer.
@@ -89,7 +91,7 @@ namespace utils
 		u8* try_map(void* ptr, protection prot = protection::rw, bool cow = false) const;
 
 		// Map shared memory over reserved memory region, which is unsafe (non-atomic) under Win32
-		u8* map_critical(void* ptr, protection prot = protection::rw, bool cow = false);
+		std::pair<u8*, std::string> map_critical(void* ptr, protection prot = protection::rw, bool cow = false);
 
 		// Map shared memory into its own storage (not mapped by default)
 		u8* map_self(protection prot = protection::rw);

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -807,7 +807,7 @@ namespace utils
 
 			if (cow)
 			{
-				// TODO
+				// TODO: Implement it
 			}
 	
 			if (MapViewOfFile3(m_handle, GetCurrentProcess(), target, 0, m_size, MEM_REPLACE_PLACEHOLDER, PAGE_EXECUTE_READWRITE, nullptr, 0))


### PR DESCRIPTION
Use the Windows 10 memory mapping API which has the functionality required for preserving memory space for mappings.
Previously RPCS3 hacked it by releasing the reserved memory space temporarily and then mapping file mapping. But this induces a horrible race in which another memory reserving call in another thread can take the placement of the file mapping when the memory space is completely free for everyone to take possession of.
Fixes this error: "**Memory mapping failed - blame Windows**" on Windows 10+.