### PR TITLE
DualSense: Fix firmware report on newer versions

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_rsxaudio.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsxaudio.h
@@ -2,7 +2,6 @@
 
 #include "sys_sync.h"
 #include "sys_event.h"
-#include "Utilities/Timer.h"
 #include "Utilities/simple_ringbuf.h"
 #include "Utilities/transactional_storage.h"
 #include "Utilities/cond.h"

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -327,8 +327,11 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const pad_
 			fail_callback(pad_id);
 		return;
 	}
-	else if (status == connection::no_data)
+
+	if (status == connection::no_data)
+	{
 		return;
+	}
 
 	// Get the current button values
 	auto data = get_button_values(device);
@@ -337,10 +340,9 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const pad_
 	// Return the new value if the button was pressed (aka. its value was bigger than 0 or the defined threshold)
 	// Use a pair to get all the legally pressed buttons and use the one with highest value (prioritize first)
 	std::pair<u16, std::string> pressed_button = { 0, "" };
-	for (const auto& button : button_list)
+	for (const auto& [keycode, name] : button_list)
 	{
-		const u32 keycode = button.first;
-		const u16 value = data[keycode];
+		const u16& value = data[keycode];
 
 		if (!get_blacklist && std::find(blacklist.begin(), blacklist.end(), keycode) != blacklist.end())
 			continue;
@@ -354,10 +356,10 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const pad_
 			if (get_blacklist)
 			{
 				blacklist.emplace_back(keycode);
-				input_log.error("%s Calibration: Added key [ %d = %s ] to blacklist. Value = %d", m_type, keycode, button.second, value);
+				input_log.error("%s Calibration: Added key [ %d = %s ] to blacklist. Value = %d", m_type, keycode, name, value);
 			}
 			else if (value > pressed_button.first)
-				pressed_button = { value, button.second };
+				pressed_button = { value, name };
 		}
 	}
 
@@ -638,8 +640,8 @@ void PadHandlerBase::ThreadProc()
 {
 	for (usz i = 0; i < bindings.size(); ++i)
 	{
-		auto device = bindings[i].first;
-		auto pad    = bindings[i].second;
+		auto& device = bindings[i].first;
+		auto& pad    = bindings[i].second;
 
 		if (!device || !pad)
 			continue;

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -377,11 +377,13 @@ bool ds4_pad_handler::GetCalibrationData(DS4Device* ds4Dev) const
 		return false;
 	}
 
-	std::array<u8, 64> buf;
+	std::array<u8, 64> buf{};
+
 	if (ds4Dev->bt_controller)
 	{
 		for (int tries = 0; tries < 3; ++tries)
 		{
+			buf = {};
 			buf[0] = 0x05;
 
 			if (int res = hid_get_feature_report(ds4Dev->hidDevice, buf.data(), DS4_FEATURE_REPORT_0x05_SIZE); res <= 0)
@@ -541,8 +543,8 @@ void ds4_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 			ds4_log.warning("check_add_device: DS4 controller may not be genuine. Workaround enabled.");
 
 			// Read feature report 0x12 instead which is what the console uses.
+			buf = {};
 			buf[0] = 0x12;
-			buf[1] = 0;
 			if (res = hid_get_feature_report(hidDevice, buf.data(), DS4_FEATURE_REPORT_0x12_SIZE); res < 0)
 			{
 				ds4_log.error("check_add_device: hid_get_feature_report 0x12 failed! result=%d, error=%s", res, hid_error(hidDevice));
@@ -572,6 +574,7 @@ void ds4_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 	u32 hw_version{};
 	u32 fw_version{};
 
+	buf = {};
 	buf[0] = 0xA3;
 
 	res = hid_get_feature_report(hidDevice, buf.data(), DS4_FEATURE_REPORT_0xA3_SIZE);

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -386,7 +386,7 @@ bool ds4_pad_handler::GetCalibrationData(DS4Device* ds4Dev) const
 			buf = {};
 			buf[0] = 0x05;
 
-			if (int res = hid_get_feature_report(ds4Dev->hidDevice, buf.data(), DS4_FEATURE_REPORT_0x05_SIZE); res <= 0)
+			if (int res = hid_get_feature_report(ds4Dev->hidDevice, buf.data(), DS4_FEATURE_REPORT_0x05_SIZE); res != DS4_FEATURE_REPORT_0x05_SIZE || buf[0] != 0x05)
 			{
 				ds4_log.error("GetCalibrationData: hid_get_feature_report 0x05 for bluetooth controller failed! result=%d, error=%s", res, hid_error(ds4Dev->hidDevice));
 				return false;
@@ -412,7 +412,7 @@ bool ds4_pad_handler::GetCalibrationData(DS4Device* ds4Dev) const
 	else
 	{
 		buf[0] = 0x02;
-		if (int res = hid_get_feature_report(ds4Dev->hidDevice, buf.data(), DS4_FEATURE_REPORT_0x02_SIZE); res <= 0)
+		if (int res = hid_get_feature_report(ds4Dev->hidDevice, buf.data(), DS4_FEATURE_REPORT_0x02_SIZE); res != DS4_FEATURE_REPORT_0x02_SIZE || buf[0] != 0x02)
 		{
 			ds4_log.error("GetCalibrationData: hid_get_feature_report 0x02 for wired controller failed! result=%d, error=%s", res, hid_error(ds4Dev->hidDevice));
 			return false;
@@ -537,17 +537,17 @@ void ds4_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 	int res = hid_get_feature_report(hidDevice, buf.data(), DS4_FEATURE_REPORT_0x81_SIZE);
 	if (res > 0)
 	{
-		if (res != DS4_FEATURE_REPORT_0x81_SIZE)
+		if (res != DS4_FEATURE_REPORT_0x81_SIZE || buf[0] != 0x81)
 		{
 			// Controller may not be genuine. These controllers do not have feature 0x81 implemented and calibration data is in bluetooth format even in USB mode!
-			ds4_log.warning("check_add_device: DS4 controller may not be genuine. Workaround enabled.");
+			ds4_log.warning("check_add_device: DS4 controller may not be genuine. Workaround enabled. (result=%d, buf[0]=0x%x)", res, buf[0]);
 
 			// Read feature report 0x12 instead which is what the console uses.
 			buf = {};
 			buf[0] = 0x12;
-			if (res = hid_get_feature_report(hidDevice, buf.data(), DS4_FEATURE_REPORT_0x12_SIZE); res < 0)
+			if (res = hid_get_feature_report(hidDevice, buf.data(), DS4_FEATURE_REPORT_0x12_SIZE); res != DS4_FEATURE_REPORT_0x12_SIZE || buf[0] != 0x12)
 			{
-				ds4_log.error("check_add_device: hid_get_feature_report 0x12 failed! result=%d, error=%s", res, hid_error(hidDevice));
+				ds4_log.error("check_add_device: hid_get_feature_report 0x12 failed! result=%d, buf[0]=0x%x, error=%s", res, buf[0], hid_error(hidDevice));
 			}
 		}
 
@@ -555,7 +555,7 @@ void ds4_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 	}
 	else
 	{
-		ds4_log.warning("check_add_device: DS4 Bluetooth controller detected. (hid_get_feature_report 0x81 failed, result=%d, error=%s)", res, hid_error(hidDevice));
+		ds4_log.warning("check_add_device: DS4 Bluetooth controller detected. (hid_get_feature_report 0x81 failed, result=%d, buf[0]=0x%x, error=%s)", res, buf[0], hid_error(hidDevice));
 		device->bt_controller = true;
 		for (wchar_t ch : wide_serial)
 			serial += static_cast<uchar>(ch);
@@ -578,9 +578,9 @@ void ds4_pad_handler::check_add_device(hid_device* hidDevice, std::string_view p
 	buf[0] = 0xA3;
 
 	res = hid_get_feature_report(hidDevice, buf.data(), DS4_FEATURE_REPORT_0xA3_SIZE);
-	if (res <= 0)
+	if (res != DS4_FEATURE_REPORT_0xA3_SIZE || buf[0] != 0xA3)
 	{
-		ds4_log.error("check_add_device: hid_get_feature_report 0xA3 failed! Could not retrieve firmware version! result=%d, error=%s", res, hid_error(hidDevice));
+		ds4_log.error("check_add_device: hid_get_feature_report 0xA3 failed! Could not retrieve firmware version! result=%d, buf[0]=0x%x, error=%s", res, buf[0], hid_error(hidDevice));
 	}
 	else
 	{
@@ -682,7 +682,7 @@ ds4_pad_handler::DataStatus ds4_pad_handler::get_data(DS4Device* device)
 
 	std::array<u8, 78> buf{};
 
-	const int res = hid_read(device->hidDevice, buf.data(), device->bt_controller ? 78 : 64);
+	const int res = hid_read(device->hidDevice, buf.data(), device->bt_controller ? DS4_INPUT_REPORT_0x11_SIZE : 64);
 	if (res == -1)
 	{
 		// looks like controller disconnected or read error
@@ -699,16 +699,16 @@ ds4_pad_handler::DataStatus ds4_pad_handler::get_data(DS4Device* device)
 		// tells controller to send 0x11 reports
 		std::array<u8, 64> buf_error{};
 		buf_error[0] = 0x2;
-		if (int res = hid_get_feature_report(device->hidDevice, buf_error.data(), buf_error.size()); res < 0)
+		if (int res = hid_get_feature_report(device->hidDevice, buf_error.data(), buf_error.size()); res != static_cast<int>(buf_error.size()) || buf_error[0] != 0x2)
 		{
-			ds4_log.error("GetRawData: hid_get_feature_report 0x2 failed! result=%d, error=%s", res, hid_error(device->hidDevice));
+			ds4_log.error("GetRawData: hid_get_feature_report 0x2 failed! result=%d, buf[0]=0x%x, error=%s", res, buf[0], hid_error(device->hidDevice));
 		}
 		return DataStatus::NoNewData;
 	}
 
 	int offset;
 	// check report and set offset
-	if (device->bt_controller && buf[0] == 0x11 && res == 78)
+	if (device->bt_controller && buf[0] == 0x11 && res == DS4_INPUT_REPORT_0x11_SIZE)
 	{
 		offset = 2;
 

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -176,16 +176,16 @@ void dualsense_pad_handler::check_add_device(hid_device* hidDevice, std::string_
 
 	std::string serial;
 
-	std::array<u8, 65> buf{};
+	std::array<u8, 64> buf{};
 	buf[0] = 0x09;
 
 	// This will give us the bluetooth mac address of the device, regardless if we are on wired or bluetooth.
 	// So we can't use this to determine if it is a bluetooth device or not.
 	// Will also enable enhanced feature reports for bluetooth.
-	int res = hid_get_feature_report(hidDevice, buf.data(), 64);
-	if (res < 0)
+	int res = hid_get_feature_report(hidDevice, buf.data(), buf.size());
+	if (res < 0 || buf[0] != 0x09)
 	{
-		dualsense_log.error("check_add_device: hid_get_feature_report 0x09 failed! result=%d, error=%s", res, hid_error(hidDevice));
+		dualsense_log.error("check_add_device: hid_get_feature_report 0x09 failed! result=%d, buf[0]=0x%x, error=%s", res, buf[0], hid_error(hidDevice));
 		return;
 	}
 
@@ -222,14 +222,14 @@ void dualsense_pad_handler::check_add_device(hid_device* hidDevice, std::string_
 	buf[0] = 0x20;
 
 	res = hid_get_feature_report(hidDevice, buf.data(), DUALSENSE_VERSION_REPORT_SIZE);
-	if (res > 0) // Old versions return 65, newer versions return 64
+	if (res != DUALSENSE_VERSION_REPORT_SIZE || buf[0] != 0x20) // Old versions return 65, newer versions return 64
 	{
-		hw_version = read_u32(&buf[24]);
-		fw_version = read_u32(&buf[28]);
+		dualsense_log.error("check_add_device: hid_get_feature_report 0x20 failed! Could not retrieve firmware version! result=%d, buf[0]=0x%x, error=%s", res, buf[0], hid_error(hidDevice));
 	}
 	else
 	{
-		dualsense_log.error("check_add_device: hid_get_feature_report 0x20 failed! Could not retrieve firmware version! result=%d, error=%s", res, hid_error(hidDevice));
+		hw_version = read_u32(&buf[24]);
+		fw_version = read_u32(&buf[28]);
 	}
 
 	if (hid_set_nonblocking(hidDevice, 1) == -1)
@@ -427,9 +427,9 @@ bool dualsense_pad_handler::get_calibration_data(DualSenseDevice* dualsense_devi
 			buf = {};
 			buf[0] = 0x05;
 
-			if (int res = hid_get_feature_report(dualsense_device->hidDevice, buf.data(), DUALSENSE_CALIBRATION_REPORT_SIZE); res <= 0)
+			if (int res = hid_get_feature_report(dualsense_device->hidDevice, buf.data(), DUALSENSE_CALIBRATION_REPORT_SIZE); res != DUALSENSE_CALIBRATION_REPORT_SIZE || buf[0] != 0x05)
 			{
-				dualsense_log.error("get_calibration_data: hid_get_feature_report 0x05 for bluetooth controller failed! result=%d, error=%s", res, hid_error(dualsense_device->hidDevice));
+				dualsense_log.error("get_calibration_data: hid_get_feature_report 0x05 for bluetooth controller failed! result=%d, buf[0]=0x%x, error=%s", res, buf[0], hid_error(dualsense_device->hidDevice));
 				return false;
 			}
 
@@ -454,9 +454,9 @@ bool dualsense_pad_handler::get_calibration_data(DualSenseDevice* dualsense_devi
 	{
 		buf[0] = 0x05;
 
-		if (int res = hid_get_feature_report(dualsense_device->hidDevice, buf.data(), DUALSENSE_CALIBRATION_REPORT_SIZE); res <= 0)
+		if (int res = hid_get_feature_report(dualsense_device->hidDevice, buf.data(), DUALSENSE_CALIBRATION_REPORT_SIZE); res != DUALSENSE_CALIBRATION_REPORT_SIZE || buf[0] != 0x05)
 		{
-			dualsense_log.error("get_calibration_data: hid_get_feature_report 0x05 for wired controller failed! result=%d, error=%s", res, hid_error(dualsense_device->hidDevice));
+			dualsense_log.error("get_calibration_data: hid_get_feature_report 0x05 for wired controller failed! result=%d, buf[0]=0x%x, error=%s", res, buf[0], hid_error(dualsense_device->hidDevice));
 			return false;
 		}
 	}

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -218,10 +218,11 @@ void dualsense_pad_handler::check_add_device(hid_device* hidDevice, std::string_
 	u32 hw_version{};
 	u32 fw_version{};
 
+	buf = {};
 	buf[0] = 0x20;
 
 	res = hid_get_feature_report(hidDevice, buf.data(), DUALSENSE_VERSION_REPORT_SIZE);
-	if (res == 65)
+	if (res > 0) // Old versions return 65, newer versions return 64
 	{
 		hw_version = read_u32(&buf[24]);
 		fw_version = read_u32(&buf[28]);
@@ -417,7 +418,8 @@ bool dualsense_pad_handler::get_calibration_data(DualSenseDevice* dualsense_devi
 		return false;
 	}
 
-	std::array<u8, 64> buf;
+	std::array<u8, 64> buf{};
+
 	if (dualsense_device->bt_controller)
 	{
 		for (int tries = 0; tries < 3; ++tries)

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -424,6 +424,7 @@ bool dualsense_pad_handler::get_calibration_data(DualSenseDevice* dualsense_devi
 	{
 		for (int tries = 0; tries < 3; ++tries)
 		{
+			buf = {};
 			buf[0] = 0x05;
 
 			if (int res = hid_get_feature_report(dualsense_device->hidDevice, buf.data(), DUALSENSE_CALIBRATION_REPORT_SIZE); res <= 0)

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -217,12 +217,9 @@ std::shared_ptr<Device> hid_pad_handler<Device>::get_hid_device(const std::strin
 		return nullptr;
 
 	// Controllers 1-n in GUI
-	for (auto& cur_control : m_controllers)
+	if (auto it = m_controllers.find(padId); it != m_controllers.end())
 	{
-		if (padId == cur_control.first)
-		{
-			return cur_control.second;
-		}
+		return it->second;
 	}
 
 	return nullptr;

--- a/rpcs3/rpcs3qt/about_dialog.cpp
+++ b/rpcs3/rpcs3qt/about_dialog.cpp
@@ -25,5 +25,4 @@ about_dialog::about_dialog(QWidget* parent) : QDialog(parent), ui(new Ui::about_
 
 about_dialog::~about_dialog()
 {
-	delete ui;
 }

--- a/rpcs3/rpcs3qt/about_dialog.h
+++ b/rpcs3/rpcs3qt/about_dialog.h
@@ -16,5 +16,5 @@ public:
 	~about_dialog();
 
 private:
-	Ui::about_dialog *ui;
+	std::unique_ptr<Ui::about_dialog> ui;
 };

--- a/rpcs3/rpcs3qt/camera_settings_dialog.h
+++ b/rpcs3/rpcs3qt/camera_settings_dialog.h
@@ -24,6 +24,6 @@ private:
 	void load_config();
 	void save_config();
 
-	Ui::camera_settings_dialog* ui;
+	std::unique_ptr<Ui::camera_settings_dialog> ui;
 	std::shared_ptr<QCamera> m_camera;
 };

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -99,7 +99,6 @@ main_window::main_window(std::shared_ptr<gui_settings> gui_settings, std::shared
 main_window::~main_window()
 {
 	SaveWindowState();
-	delete ui;
 }
 
 /* An init method is used so that RPCS3App can create the necessary connects before calling init (specifically the stylesheet connect).

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -42,7 +42,7 @@ class main_window : public QMainWindow
 {
 	Q_OBJECT
 
-	Ui::main_window *ui;
+	std::unique_ptr<Ui::main_window> ui;
 
 	bool m_sys_menu_opened = false;
 	bool m_is_list_mode = true;

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp
@@ -71,7 +71,6 @@ pad_led_settings_dialog::pad_led_settings_dialog(QDialog* parent, int colorR, in
 
 pad_led_settings_dialog::~pad_led_settings_dialog()
 {
-	delete ui;
 }
 
 void pad_led_settings_dialog::redraw_color_sample() const

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.h
@@ -27,7 +27,7 @@ private Q_SLOTS:
 private:
 	void redraw_color_sample() const;
 	void read_form_values();
-	Ui::pad_led_settings_dialog *ui;
+	std::unique_ptr<Ui::pad_led_settings_dialog> ui;
 	struct led_settings
 	{
 		int cR = 255;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -208,8 +208,6 @@ pad_settings_dialog::~pad_settings_dialog()
 {
 	m_gui_settings->SetValue(gui::pads_geometry, saveGeometry());
 
-	delete ui;
-
 	if (!Emu.IsStopped())
 	{
 		pad::reset(Emu.GetTitleID());

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -108,7 +108,7 @@ private Q_SLOTS:
 	void ApplyCurrentPlayerConfig(int new_player_id);
 
 private:
-	Ui::pad_settings_dialog *ui;
+	std::unique_ptr<Ui::pad_settings_dialog> ui;
 	std::string m_title_id;
 	std::shared_ptr<gui_settings> m_gui_settings;
 

--- a/rpcs3/rpcs3qt/patch_creator_dialog.h
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.h
@@ -20,7 +20,7 @@ public:
 	~patch_creator_dialog();
 
 private:
-	Ui::patch_creator_dialog* ui;
+	std::unique_ptr<Ui::patch_creator_dialog> ui;
 	QFont mMonoFont;
 	QColor mValidColor;
 	QColor mInvalidColor;

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -127,8 +127,6 @@ patch_manager_dialog::~patch_manager_dialog()
 	// Save gui settings
 	m_gui_settings->SetValue(gui::pm_geometry, saveGeometry());
 	m_gui_settings->SetValue(gui::pm_splitter_state, ui->splitter->saveState());
-
-	delete ui;
 }
 
 int patch_manager_dialog::exec()

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -73,7 +73,7 @@ private:
 	bool m_download_automatic = false;
 	bool m_download_auto_accept = false;
 
-	Ui::patch_manager_dialog *ui;
+	std::unique_ptr<Ui::patch_manager_dialog> ui;
 
 protected:
 	void dropEvent(QDropEvent* event) override;

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -2126,8 +2126,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 settings_dialog::~settings_dialog()
 {
 	m_gui_settings->SetValue(gui::cfg_geometry, saveGeometry());
-
-	delete ui;
 }
 
 void settings_dialog::EnhanceSlider(emu_settings_type settings_type, QSlider* slider, QLabel* label, const QString& label_text) const

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -47,7 +47,7 @@ private:
 	std::array<QComboBox*, 4> m_mics_combo;
 
 	int m_tab_index;
-	Ui::settings_dialog *ui;
+	std::unique_ptr<Ui::settings_dialog> ui;
 	std::shared_ptr<gui_settings> m_gui_settings;
 	std::shared_ptr<emu_settings> m_emu_settings;
 

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -36,5 +36,4 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, QWidg
 
 welcome_dialog::~welcome_dialog()
 {
-	delete ui;
 }

--- a/rpcs3/rpcs3qt/welcome_dialog.h
+++ b/rpcs3/rpcs3qt/welcome_dialog.h
@@ -18,6 +18,6 @@ public:
 	~welcome_dialog();
 
 private:
-	Ui::welcome_dialog *ui;
+	std::unique_ptr<Ui::welcome_dialog> ui;
 	std::shared_ptr<gui_settings> m_gui_settings;
 };


### PR DESCRIPTION
Newer versions of the DualSense return 64, while old versions return 65.

fixes #12007