### PR TITLE
cellGame: Make stats storage non-temporary, fix cbSet->setParam

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.h
+++ b/rpcs3/Emu/Cell/Modules/cellGame.h
@@ -226,7 +226,9 @@ struct CellGameDataSystemFileParam
 	char reserved1[2];
 	be_t<u32> parentalLevel;
 	be_t<u32> attribute;
-	char reserved2[256];
+	be_t<u32> resolution; // cellHddGameCheck member: GD doesn't have this value
+	be_t<u32> soundFormat; // cellHddGameCheck member: GD doesn't have this value
+	char reserved2[248];
 };
 
 struct CellDiscGameSystemFileParam
@@ -307,50 +309,10 @@ enum
 	CELL_HDDGAME_SIZEKB_NOTCALC        = -1,
 };
 
-struct CellHddGameSystemFileParam
-{
-	char title[CELL_HDDGAME_SYSP_TITLE_SIZE];
-	char titleLang[CELL_HDDGAME_SYSP_LANGUAGE_NUM][CELL_HDDGAME_SYSP_TITLE_SIZE];
-	char titleId[CELL_HDDGAME_SYSP_TITLEID_SIZE];
-	char reserved0[2];
-	char dataVersion[CELL_HDDGAME_SYSP_VERSION_SIZE];
-	char reserved1[2];
-	be_t<u32> attribute;
-	be_t<u32> parentalLevel;
-	be_t<u32> resolution;
-	be_t<u32> soundFormat;
-	char reserved2[256];
-};
-
-struct CellHddGameCBResult
-{
-	be_t<s32> result;
-	be_t<s32> errNeedSizeKB;
-	vm::bptr<char> invalidMsg;
-	vm::bptr<void> reserved;
-};
-
-struct CellHddGameStatGet
-{
-	be_t<s32> hddFreeSizeKB;
-	be_t<u32> isNewData;
-	char contentInfoPath[CELL_HDDGAME_PATH_MAX];
-	char hddGamePath[CELL_HDDGAME_PATH_MAX];
-	char reserved0[2];
-	be_t<s64> atime;
-	be_t<s64> mtime;
-	be_t<s64> ctime;
-	CellHddGameSystemFileParam getParam;
-	be_t<s32> sizeKB;
-	be_t<s32> sysSizeKB;
-	char reserved1[68];
-};
-
-struct CellHddGameStatSet
-{
-	vm::bptr<CellHddGameSystemFileParam> setParam;
-	vm::bptr<void> reserved;
-};
+using CellHddGameStatGet = CellGameDataStatGet;
+using CellHddGameStatSet = CellGameDataStatSet;
+using CellHddGameSystemFileParam = CellGameDataSystemFileParam;
+using CellHddGameCBResult = CellGameDataCBResult;
 
 typedef void(CellHddGameStatCallback)(vm::ptr<CellHddGameCBResult> cbResult, vm::ptr<CellHddGameStatGet> get, vm::ptr<CellHddGameStatSet> set);
 typedef void(CellGameThemeInstallCallback)(u32 fileOffset, u32 readSize, vm::ptr<void> buf);

--- a/rpcs3/Emu/Memory/vm_var.h
+++ b/rpcs3/Emu/Memory/vm_var.h
@@ -172,7 +172,7 @@ namespace vm
 		struct gvar final : ptr<T>
 		{
 			static constexpr u32 alloc_size{sizeof(T) * Count};
-			static constexpr u32 alloc_align{alignof(T)};
+			static constexpr u32 alloc_align{std::max<u32>(alignof(T), 16)};
 		};
 	} // namespace ps3_
 } // namespace vm


### PR DESCRIPTION
* Use non-temporary storage for stats, I noticed on Wall-E it actually saves the pointer to stats instead of saving its data. After some time the stack data got corrupted and messed up the filesystem calls. proof: passed funcStat callback of cellHddGameCheck 
![image](https://user-images.githubusercontent.com/18193363/172062885-7746af5d-dd34-470c-9329-48dc55fd32df.png)

* Add missing default cbSet->setParam in cellGameDataCheckCreate2, this function si basically the same as cellHddGameCheck internally so it's needed as https://github.com/RPCS3/rpcs3/pull/4539.
* Ensure 16-bytes alignment of vm::gvar to make it compatible with vector PPU instructions. We do not know which are ensured to be aligned so may as well align them all. 

Fixes [Wall-E [NPUB90129]](https://forums.rpcs3.net/thread-178974.html) from loadable to ingame.
![image](https://user-images.githubusercontent.com/18193363/172062593-23fd8b98-24ba-4ce9-a76d-534d259025ba.png)
