### PR TITLE
SPU LLVM: Use vrangeps in clamp_smax

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3666,6 +3666,12 @@ public:
 	{
 		return llvm_calli<u16[8], T, U, llvm_const_int<u32>>{"llvm.x86.avx512.dbpsadbw.128", {std::forward<T>(a), std::forward<U>(b), llvm_const_int<u32>{c}}};
 	}
+
+	template <typename T, typename U, typename = std::enable_if_t<std::is_same_v<llvm_common_t<T, U>, f32[4]>>>
+	static auto vrangeps(T&& a, U&& b, u8 c, u8 d)
+	{
+		return llvm_calli<f32[4], T, U, llvm_const_int<u32>, T, llvm_const_int<u8>>{"llvm.x86.avx512.mask.range.ps.128", {std::forward<T>(a), std::forward<U>(b), llvm_const_int<u32>{c}, std::forward<T>(a), llvm_const_int<u8>{d}}};
+	}
 };
 
 // Format llvm::SizeType

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7908,6 +7908,22 @@ public:
 
 	value_t<f32[4]> clamp_smax(value_t<f32[4]> v)
 	{
+		if (m_use_avx512)
+		{
+			if (is_input_positive(v))
+			{
+				return eval(clamp_positive_smax(v));
+			}
+			
+			if (auto [ok, data] = get_const_vector(v.value, m_pos); ok)
+			{
+				// Avoid pessimation when input is constant
+				return eval(clamp_positive_smax(clamp_negative_smax(v)));
+			}
+
+			return eval(vrangeps(v, fsplat<f32[4]>(0x7f7fffff), 0x2, 0Xff));
+		}
+
 		return eval(clamp_positive_smax(clamp_negative_smax(v)));
 	}
 


### PR DESCRIPTION
This AVX-512 instruction can perform a min/max while ignoring the sign bit of the first source operand, then later copy the sign bit from the first source to the result. This allows us to clamp both negative and positive values down to normalized floating point values for x86 in one instruction. 

On my tigerlake laptop, brings the spu float perf test down from 1147ms to 1041ms. (approx xfloat). Also grants 2-3 fps in the mandelbrot test.