### PR TITLE
rsx: Fix NV406E semaphore_acquire timeout detection

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -667,21 +667,11 @@ namespace rsx
 
 			u64 local_vblank_count = 0;
 
-			u64 last_system_time = start_time;
-
 			// TODO: exit condition
 			while (!is_stopped())
 			{
 				// Get current time
 				const u64 current = get_system_time();
-
-				if (current - last_system_time >= 20'000u)
-				{
-					// Suspicious amount of time has passed
-					// External pause such as debuggers' pause or operating system sleep may have taken place
-					// Ignore it
-					start_time += current - last_system_time;
-				}
 
 				// Calculate the time at which we need to send a new VBLANK signal
 				const u64 post_event_time = start_time + (local_vblank_count + 1) * vblank_period / vblank_rate;
@@ -741,11 +731,18 @@ namespace rsx
 					std::this_thread::yield();
 				}
 
-				last_system_time = current + wait_sleep;
-
-				while (!is_stopped() && Emu.IsPaused())
+				if (Emu.IsPaused())
 				{
-					thread_ctrl::wait_for(5'000);
+					// Save the difference before pause
+					start_time = rsx::uclock() - start_time;
+
+					while (Emu.IsPaused() && !is_stopped())
+					{
+						thread_ctrl::wait_for(5'000);
+					}
+
+					// Restore difference
+					start_time = rsx::uclock() - start_time;
 				}
 			}
 		});

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -144,7 +144,7 @@ namespace rsx
 
 					last_check_val = current;
 
-					if ((last_check_val - start) > tdr)
+					if ((current - start) > tdr)
 					{
 						// If longer than driver timeout force exit
 						rsx_log.error("nv406e::semaphore_acquire has timed out. semaphore_address=0x%X", addr);


### PR DESCRIPTION
Fixes timeout in situations in which the RSX is paused such as Visual Studio Debugger pause, RPCS3 debugger pause, Steam Deck sleep and more.