### PR TITLE
Qt: remove "Send Exit CMD" menu option

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1665,7 +1665,6 @@ void main_window::EnableMenus(bool enabled) const
 
 	// PS3 Commands
 	ui->sysSendOpenMenuAct->setEnabled(enabled);
-	ui->sysSendExitAct->setEnabled(enabled);
 
 	// Tools
 	ui->toolskernel_explorerAct->setEnabled(enabled);
@@ -2044,14 +2043,6 @@ void main_window::CreateConnects()
 		sysutil_send_system_cmd(m_sys_menu_opened ? 0x0132 /* CELL_SYSUTIL_SYSTEM_MENU_CLOSE */ : 0x0131 /* CELL_SYSUTIL_SYSTEM_MENU_OPEN */, 0);
 		m_sys_menu_opened ^= true;
 		ui->sysSendOpenMenuAct->setText(tr("Send &%0 system menu cmd").arg(m_sys_menu_opened ? tr("close") : tr("open")));
-	});
-
-	connect(ui->sysSendExitAct, &QAction::triggered, this, []()
-	{
-		if (Emu.IsStopped()) return;
-
-		gui_log.notice("User triggered \"Send exit command\" action in menu bar");
-		sysutil_send_system_cmd(0x0101 /* CELL_SYSUTIL_REQUEST_EXITGAME */, 0);
 	});
 
 	const auto open_settings = [this](int tabIndex)

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -223,7 +223,6 @@
     <addaction name="sysRebootAct"/>
     <addaction name="separator"/>
     <addaction name="sysSendOpenMenuAct"/>
-    <addaction name="sysSendExitAct"/>
    </widget>
    <widget class="QMenu" name="menuConfiguration">
     <property name="title">
@@ -475,14 +474,6 @@
    </property>
    <property name="text">
     <string>Send Open System Menu CMD</string>
-   </property>
-  </action>
-  <action name="sysSendExitAct">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Send Exit CMD</string>
    </property>
   </action>
   <action name="confCPUAct">


### PR DESCRIPTION
This is pointless now, since we always exit games with this command.