### PR TITLE
SPUAnalyzer.h: Add missing category check functions

### DIFF
--- a/rpcs3/Emu/Cell/SPUAnalyser.h
+++ b/rpcs3/Emu/Cell/SPUAnalyser.h
@@ -69,13 +69,9 @@ struct spu_itype
 		STQR, // memory_tag last
 
 		CBD, // constant_tag first
-		CBX,
 		CHD,
-		CHX,
 		CWD,
-		CWX,
 		CDD,
-		CDX,
 		ILH,
 		ILHU,
 		IL,
@@ -106,6 +102,10 @@ struct spu_itype
 		MPYHHA,
 		MPYHHU,
 		MPYHHAU,
+		CBX,
+		CHX,
+		CWX,
+		CDX,
 		CLZ,
 		CNTB,
 		FSMB,

--- a/rpcs3/Emu/Cell/SPUAnalyser.h
+++ b/rpcs3/Emu/Cell/SPUAnalyser.h
@@ -68,11 +68,7 @@ struct spu_itype
 		STQA,
 		STQR, // memory_tag last
 
-		CBD, // constant_tag first
-		CHD,
-		CWD,
-		CDD,
-		ILH,
+		ILH, // constant_tag_first
 		ILHU,
 		IL,
 		ILA,
@@ -102,6 +98,10 @@ struct spu_itype
 		MPYHHA,
 		MPYHHU,
 		MPYHHAU,
+		CBD,
+		CHD,
+		CWD,
+		CDD,
 		CBX,
 		CHX,
 		CWX,

--- a/rpcs3/Emu/Cell/SPUAnalyser.h
+++ b/rpcs3/Emu/Cell/SPUAnalyser.h
@@ -80,7 +80,6 @@ struct spu_itype
 		ILHU,
 		IL,
 		ILA,
-		IOHL,
 		FSMBI, // constant_tag last
 
 		AH, // integer_tag first
@@ -130,6 +129,7 @@ struct spu_itype
 		ORC,
 		ORBI,
 		ORHI,
+		IOHL,
 		ORI,
 		ORX,
 		XOR,
@@ -262,6 +262,36 @@ struct spu_itype
 	friend constexpr bool operator &(type value, xfloat_tag)
 	{
 		return value >= FMA && value <= FRDS;
+	}
+
+	// Test for memory instruction
+	friend constexpr bool operator &(type value, memory_tag)
+	{
+		return value >= LQD && value <= STQR;
+	}
+
+	// Test for compare instruction
+	friend constexpr bool operator &(type value, compare_tag)
+	{
+		return value >= CEQB && value <= CLGTI;
+	}
+
+	// Test for integer instruction
+	friend constexpr bool operator &(type value, integer_tag)
+	{
+		return value >= AH && value <= SHUFB;
+	}
+
+	// Test for shift or rotate instruction
+	friend constexpr bool operator &(type value, shiftrot_tag)
+	{
+		return value >= SHLH && value <= ROTMAI;
+	}
+
+	// Test for constant loading instruction
+	friend constexpr bool operator &(type value, constant_tag)
+	{
+		return value >= CBD && value <= FSMBI;
 	}
 };
 


### PR DESCRIPTION
Moved IOHL to integer instructions.