### PR TITLE
[ppu] Fix arm64 trampoline

### DIFF
--- a/3rdparty/SoundTouch/CMakeLists.txt
+++ b/3rdparty/SoundTouch/CMakeLists.txt
@@ -27,6 +27,8 @@ target_compile_definitions(soundtouch PUBLIC
 	SOUNDTOUCH_FLOAT_SAMPLES;
 )
 
+target_compile_options(soundtouch PUBLIC "-w")
+
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86|X86|amd64|AMD64|em64t|EM64T)")
 	target_compile_definitions(soundtouch PUBLIC
 		SOUNDTOUCH_ALLOW_SSE

--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -871,6 +871,10 @@ jit_compiler::jit_compiler(const std::unordered_map<std::string, u64>& _link, co
 	std::string result;
 
 	auto null_mod = std::make_unique<llvm::Module> ("null_", *m_context);
+#if defined(__APPLE__) && defined(ARCH_ARM64)
+	// Force override triple on Apple arm64 or we'll get linking errors.
+	null_mod->setTargetTriple(llvm::Triple::normalize(utils::c_llvm_default_triple));
+#endif
 
 	if (_link.empty())
 	{

--- a/rpcs3/Emu/Cell/PPUFunction.cpp
+++ b/rpcs3/Emu/Cell/PPUFunction.cpp
@@ -1889,6 +1889,60 @@ extern std::string ppu_get_variable_name(const std::string& _module, u32 vnid)
 	return fmt::format("0x%08X", vnid);
 }
 
+#if defined(ARCH_X64)
+
+auto gen_ghc_cpp_trampoline(ppu_intrp_func_t fn_target)
+{
+	return [fn_target] (native_asm& c, auto& args)
+	{
+		using namespace asmjit;
+
+		// Take second ghc arg
+		c.mov(args[0], x86::rbp);
+		c.mov(args[2].r32(), x86::dword_ptr(args[0], ::offset32(&ppu_thread::cia)));
+		c.add(args[2], x86::qword_ptr(reinterpret_cast<u64>(&vm::g_base_addr)));
+		c.jmp(fn_target);
+	};
+}
+
+#elif defined(ARCH_ARM64)
+
+auto gen_ghc_cpp_trampoline(ppu_intrp_func_t fn_target)
+{
+	return [fn_target] (native_asm& c, auto& args)
+	{
+		using namespace asmjit;
+
+		// Take second ghc arg
+		c.mov(args[0], a64::x20);
+
+		Label cia_offset = c.newLabel();
+		c.ldr(a64::x11, arm::Mem(cia_offset));
+		c.ldr(a64::x26, arm::Mem(args[0], a64::x11));
+
+		Label base_addr = c.newLabel();
+		c.ldr(a64::x22, arm::Mem(base_addr));
+		c.ldr(a64::x22, arm::Mem(a64::x22));
+
+		c.add(args[2], a64::x22, a64::x26);
+
+		Label jmp_target = c.newLabel();
+		c.ldr(a64::x22, arm::Mem(jmp_target));
+		c.br(a64::x22);
+
+		c.bind(base_addr);
+		c.embedUInt64(reinterpret_cast<u64>(&vm::g_base_addr));
+		c.bind(cia_offset);
+		c.embedUInt64(static_cast<u64>(::offset32(&ppu_thread::cia)));
+		c.bind(jmp_target);
+		c.embedUInt64(reinterpret_cast<u64>(fn_target));
+	};
+}
+
+#else
+#error "Not implemented!"
+#endif
+
 std::vector<ppu_intrp_func_t>& ppu_function_manager::access(bool ghc)
 {
 	static std::vector<ppu_intrp_func_t> list
@@ -1907,33 +1961,11 @@ std::vector<ppu_intrp_func_t>& ppu_function_manager::access(bool ghc)
 		},
 	};
 
-#if defined(ARCH_X64)
 	static std::vector<ppu_intrp_func_t> list_ghc
 	{
-		build_function_asm<ppu_intrp_func_t>("ppu_unregistered", [](native_asm& c, auto& args)
-		{
-			using namespace asmjit;
-
-			// Take second ghc arg
-			c.mov(args[0], x86::rbp);
-			c.mov(args[2].r32(), x86::dword_ptr(args[0], ::offset32(&ppu_thread::cia)));
-			c.add(args[2], x86::qword_ptr(reinterpret_cast<u64>(&vm::g_base_addr)));
-			c.jmp(list[0]);
-		}),
-		build_function_asm<ppu_intrp_func_t>("ppu_return", [](native_asm& c, auto& args)
-		{
-			using namespace asmjit;
-
-			// Take second ghc arg
-			c.mov(args[0], x86::rbp);
-			c.mov(args[2].r32(), x86::dword_ptr(args[0], ::offset32(&ppu_thread::cia)));
-			c.add(args[2], x86::qword_ptr(reinterpret_cast<u64>(&vm::g_base_addr)));
-			c.jmp(list[1]);
-		}),
+		build_function_asm<ppu_intrp_func_t>("ppu_unregistered", gen_ghc_cpp_trampoline(list[0])),
+		build_function_asm<ppu_intrp_func_t>("ppu_return", gen_ghc_cpp_trampoline(list[1])),
 	};
-#elif defined(ARCH_ARM64)
-	static std::vector<ppu_intrp_func_t> list_ghc(list);
-#endif
 
 	return ghc ? list_ghc : list;
 }
@@ -1945,23 +1977,7 @@ u32 ppu_function_manager::add_function(ppu_intrp_func_t function)
 
 	list.push_back(function);
 
-	// Generate trampoline
-#if defined(ARCH_X64)
-	list2.push_back(build_function_asm<ppu_intrp_func_t>("", [&](native_asm& c, auto& args)
-	{
-		using namespace asmjit;
-
-		// Take second ghc arg
-		c.mov(args[0], x86::rbp);
-		c.mov(args[2].r32(), x86::dword_ptr(args[0], ::offset32(&ppu_thread::cia)));
-		c.add(args[2], x86::qword_ptr(reinterpret_cast<u64>(&vm::g_base_addr)));
-		c.jmp(function);
-	}));
-#elif defined(ARCH_ARM64)
-	list2.push_back(function);
-#else
-#error "Not implemented"
-#endif
+	list2.push_back(build_function_asm<ppu_intrp_func_t>("", gen_ghc_cpp_trampoline(function)));
 
 	return ::size32(list) - 1;
 }

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1330,6 +1330,9 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::lle_call:
 		{
+#ifdef __APPLE__
+			pthread_jit_write_protect_np(true);
+#endif
 			const vm::ptr<u32> opd(arg < 32 ? vm::cast(gpr[arg]) : vm::cast(arg));
 			cmd_pop(), fast_call(opd[0], opd[1]);
 			break;
@@ -1341,6 +1344,9 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::opd_call:
 		{
+#ifdef __APPLE__
+			pthread_jit_write_protect_np(true);
+#endif
 			const ppu_func_opd_t opd = cmd_get(1).as<ppu_func_opd_t>();
 			cmd_pop(1), fast_call(opd.addr, opd.rtoc);
 			break;


### PR DESCRIPTION
Always override the LLVM triple on macOS arm64 to prevent linking errors. This line was removed in https://github.com/RPCS3/rpcs3/pull/12228

Fixes the function manager trampoline with a proper arm64 implementation, and clean up the code a bit.

Disables warnings on soundtouch dependency to allow Clang debug builds to work.

This gets LLVM PPU w/SPU interpreter on arm64 Mac to start a game with no segfaults, but it fails with `id 101 is not supported in the current check mode: content_permission::check_mode::disc_game`. Currently working on figuring out if this is caused by arm64 or if it's macOS because it works just fine in Rosetta.

Build instructions same as https://github.com/RPCS3/rpcs3/pull/12115