### PR TITLE
Reset audio renderer after cellAudioOutConfigure() was called

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -527,13 +527,12 @@ namespace audio
 			.time_stretching_threshold = g_cfg.audio.time_stretching_threshold,
 			.convert_to_s16 = static_cast<bool>(g_cfg.audio.convert_to_s16),
 			.dump_to_file = static_cast<bool>(g_cfg.audio.dump_to_file),
-			.format = g_cfg.audio.format,
 			.renderer = g_cfg.audio.renderer,
 			.provider = g_cfg.audio.provider
 		};
 	}
 
-	void configure_audio()
+	void configure_audio(bool force_reset)
 	{
 		if (g_cfg.audio.provider != audio_provider::cell_audio)
 		{
@@ -546,12 +545,12 @@ namespace audio
 			const auto new_raw = get_raw_config();
 
 			if (const auto raw = g_audio.cfg.raw;
+				force_reset ||
 				raw.desired_buffer_duration != new_raw.desired_buffer_duration ||
 				raw.buffering_enabled != new_raw.buffering_enabled ||
 				raw.time_stretching_threshold != new_raw.time_stretching_threshold ||
 				raw.enable_time_stretching != new_raw.enable_time_stretching ||
 				raw.convert_to_s16 != new_raw.convert_to_s16 ||
-				raw.format != new_raw.format ||
 				raw.renderer != new_raw.renderer ||
 				raw.dump_to_file != new_raw.dump_to_file)
 			{

--- a/rpcs3/Emu/Cell/Modules/cellAudio.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.h
@@ -201,7 +201,6 @@ struct cell_audio_config
 		s64 time_stretching_threshold = 0;
 		bool convert_to_s16 = false;
 		bool dump_to_file = false;
-		audio_format format = audio_format::stereo;
 		audio_renderer renderer = audio_renderer::null;
 		audio_provider provider = audio_provider::none;
 	};
@@ -405,5 +404,5 @@ using cell_audio = named_thread<cell_audio_thread>;
 namespace audio
 {
 	cell_audio_config::raw_config get_raw_config();
-	void configure_audio();
+	void configure_audio(bool force_reset = false);
 }

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -366,7 +366,7 @@ error_code cellAudioOutConfigure(u32 audioOut, vm::ptr<CellAudioOutConfiguration
 				cfg.out.at(audioOut).state = CELL_AUDIO_OUT_OUTPUT_STATE_DISABLED;
 			}
 
-			audio::configure_audio();
+			audio::configure_audio(true);
 			audio::configure_rsxaudio();
 
 			{


### PR DESCRIPTION
The audio output format configured with cellAudioOutConfigure() never actually went into effect because audio::configure_audio() in cellAudio didn't detect any changes.
I simply added an argument to configure_audio() to force a reset of the audio renderer, I hope this is ok.
I also removed "format" from the raw_config struct because configuring the output format is handled in cellAudioOut and it wasn't used anywhere anymore.

This probably shouldn't be merged until #12245 is fixed.