### PR TITLE
SPU: Implement "double" SNR storage

### DIFF
--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -337,6 +337,25 @@ void SPUDisAsm::WRCH(spu_opcode_t op)
 			fmt::append(last_opcode, " #%s", upd == "empty" ? "IMMEDIATE" : upd);
 			return;
 		}
+		case SPU_WrOutIntrMbox:
+		{
+			const u32 code = value._u32[3] >> 24;
+
+			if (code == 128u)
+			{
+				last_opcode += " #sys_event_flag_set_bit";
+			}
+			else if (code == 192u)
+			{
+				last_opcode += " #sys_event_flag_set_bit_impatient";
+			}
+			else
+			{
+				fmt::append(last_opcode, " #%s", SignedHex(value._u32[3]));
+			}
+
+			return;
+		}
 		default:
 		{
 			fmt::append(last_opcode, " #%s", SignedHex(value._u32[3]));


### PR DESCRIPTION
What Sonic The Hedgehog does is to send a pair of succeeding values to the SPU SNR. If the SPU does not wait on SNR reading, the first value should be overwritten by the second and this is what RPCS3 does.
On real hw however concluded by reversing this game, If the SPU currently reads from the empty SNR channel, the insertion of the first value keeps the channel empty and the SPU quits reading SNR, the SNR is available the obtain the second value freely.
This implements this mechanism and allows Sonic The Hedgehog to display some images and fixes the random crashes with its loading, but it is still not the same as the hacked build of mine which also waits for SNR to empty and thus ensuring values are not overwritten. Because on real hw the SPU finished its execution path faster than PPU and is already executing SPU SNR read instruction when the PPU writes the pair of values allowing it to work on real hw. 