### PR TITLE
Qt: add optional states to toolbar icons

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1421,11 +1421,27 @@ void main_window::RepaintThumbnailIcons()
 
 void main_window::RepaintToolBarIcons()
 {
-	const QColor new_color = gui::utils::get_label_color("toolbar_icon_color");
+	std::map<QIcon::Mode, QColor> new_colors{};
+	new_colors[QIcon::Normal] = gui::utils::get_label_color("toolbar_icon_color");
 
-	const auto icon = [&new_color](const QString& path)
+	const QString sheet = static_cast<QApplication *>(QCoreApplication::instance())->styleSheet();
+
+	if (sheet.contains("toolbar_icon_color_disabled"))
 	{
-		return gui::utils::get_colorized_icon(QIcon(path), Qt::black, new_color);
+		new_colors[QIcon::Disabled] = gui::utils::get_label_color("toolbar_icon_color_disabled");
+	}
+	if (sheet.contains("toolbar_icon_color_active"))
+	{
+		new_colors[QIcon::Active] = gui::utils::get_label_color("toolbar_icon_color_active");
+	}
+	if (sheet.contains("toolbar_icon_color_selected"))
+	{
+		new_colors[QIcon::Selected] = gui::utils::get_label_color("toolbar_icon_color_selected");
+	}
+
+	const auto icon = [&new_colors](const QString& path)
+	{
+		return gui::utils::get_colorized_icon(QIcon(path), Qt::black, new_colors);
 	};
 
 	m_icon_play           = icon(":/Icons/play.png");
@@ -1465,6 +1481,7 @@ void main_window::RepaintToolBarIcons()
 		ui->toolbar_fullscreen->setIcon(m_icon_fullscreen_on);
 	}
 
+	const QColor& new_color = new_colors[QIcon::Normal];
 	ui->sizeSlider->setStyleSheet(ui->sizeSlider->styleSheet().append("QSlider::handle:horizontal{ background: rgba(%1, %2, %3, %4); }")
 		.arg(new_color.red()).arg(new_color.green()).arg(new_color.blue()).arg(new_color.alpha()));
 

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -150,6 +150,17 @@ namespace gui
 			return QIcon(get_colorized_pixmap(old_icon.pixmap(old_icon.availableSizes().at(0)), old_color, new_color, use_special_masks, colorize_all));
 		}
 
+		QIcon get_colorized_icon(const QIcon& old_icon, const QColor& old_color, const std::map<QIcon::Mode, QColor>& new_colors, bool use_special_masks, bool colorize_all)
+		{
+			QIcon icon{};
+			const QPixmap old_pixmap = old_icon.pixmap(old_icon.availableSizes().at(0));
+			for (const auto& [mode, color] : new_colors)
+			{
+				icon.addPixmap(get_colorized_pixmap(old_pixmap, old_color, color, use_special_masks, colorize_all), mode);
+			}
+			return icon;
+		}
+
 		QStringList get_dir_entries(const QDir& dir, const QStringList& name_filters)
 		{
 			QFileInfoList entries = dir.entryInfoList(name_filters, QDir::Files);

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -13,6 +13,7 @@
 #include <QPainter>
 
 #include <string>
+#include <map>
 
 namespace gui
 {
@@ -57,6 +58,7 @@ namespace gui
 		// use colorize_all to repaint every opaque pixel with the chosen color
 		// use_special_masks is only used for icons with multiple predefined colors
 		QIcon get_colorized_icon(const QIcon& old_icon, const QColor& old_color, const QColor& new_color, bool use_special_masks = false, bool colorize_all = false);
+		QIcon get_colorized_icon(const QIcon& old_icon, const QColor& old_color, const std::map<QIcon::Mode, QColor>& new_colors, bool use_special_masks = false, bool colorize_all = false);
 
 		// Returns a list of all base names of files in dir whose complete file names contain one of the given name_filters
 		QStringList get_dir_entries(const QDir& dir, const QStringList& name_filters);


### PR DESCRIPTION
Adds 3 optional states to the toolbar icons, which can be customized in the stylesheets.
The normal and already used color is
- toolbar_icon_color

The optional new states are:
- toolbar_icon_color_disabled
- toolbar_icon_color_active
- toolbar_icon_color_selected

Although I don't think we use "selected", since the buttons do not have such a state, I added it anyway.

Nothing should change in existing stylesheets, but it makes it possible to improve them.

In case you didn't know, you can set the colors like this:
```
QLabel#toolbar_icon_color {
	color: #FFFFFF;
}
QLabel#toolbar_icon_color_disabled {
	color: #FF0000;
}
QLabel#toolbar_icon_color_active {
	color: #00FF00;
}
QLabel#toolbar_icon_color_selected {
	color: #0000FF;
}
```

![test](https://user-images.githubusercontent.com/23019877/174662917-6bd50f8b-6777-40f0-8824-ef44e7a67c91.gif)
