### PR TITLE
Aarch64 fixes for RSX

### DIFF
--- a/Utilities/address_range.h
+++ b/Utilities/address_range.h
@@ -6,9 +6,9 @@
 #include <algorithm>
 
 #if defined(ARCH_X64)
-#define HOST_PAGE_SIZE() 4096u
+#define HOST_PAGE_SIZE 4096u
 #else
-#define HOST_PAGE_SIZE get_page_size
+#define HOST_PAGE_SIZE get_page_size()
 #endif
 
 namespace utils
@@ -22,12 +22,12 @@ namespace utils
 	 */
 	static inline u32 page_start(u32 addr)
 	{
-		return addr & ~(HOST_PAGE_SIZE() - 1);
+		return addr & ~(HOST_PAGE_SIZE - 1);
 	}
 
 	static inline u32 next_page(u32 addr)
 	{
-		return page_start(addr) + HOST_PAGE_SIZE();
+		return page_start(addr) + HOST_PAGE_SIZE;
 	}
 
 	static inline u32 page_end(u32 addr)
@@ -37,7 +37,7 @@ namespace utils
 
 	static inline u32 is_page_aligned(u32 val)
 	{
-		return (val & (HOST_PAGE_SIZE() - 1)) == 0;
+		return (val & (HOST_PAGE_SIZE - 1)) == 0;
 	}
 
 

--- a/Utilities/address_range.h
+++ b/Utilities/address_range.h
@@ -1,33 +1,26 @@
 #pragma once
 
 #include "util/types.hpp"
+#include "util/vm.hpp"
 #include "StrFmt.h"
 #include <vector>
 #include <algorithm>
 
-#if defined(ARCH_X64)
-#define HOST_PAGE_SIZE 4096u
-#else
-#define HOST_PAGE_SIZE get_page_size()
-#endif
-
 namespace utils
 {
 	class address_range_vector;
-
-	long get_page_size();
 
 	/**
 	 * Helpers
 	 */
 	static inline u32 page_start(u32 addr)
 	{
-		return addr & ~(HOST_PAGE_SIZE - 1);
+		return addr & ~(c_page_size - 1);
 	}
 
 	static inline u32 next_page(u32 addr)
 	{
-		return page_start(addr) + HOST_PAGE_SIZE;
+		return page_start(addr) + c_page_size;
 	}
 
 	static inline u32 page_end(u32 addr)
@@ -37,7 +30,7 @@ namespace utils
 
 	static inline u32 is_page_aligned(u32 val)
 	{
-		return (val & (HOST_PAGE_SIZE - 1)) == 0;
+		return (val & (c_page_size - 1)) == 0;
 	}
 
 

--- a/Utilities/address_range.h
+++ b/Utilities/address_range.h
@@ -5,33 +5,39 @@
 #include <vector>
 #include <algorithm>
 
+#if defined(ARCH_X64)
+#define HOST_PAGE_SIZE() 4096u
+#else
+#define HOST_PAGE_SIZE get_page_size
+#endif
 
 namespace utils
 {
 	class address_range_vector;
 
+	long get_page_size();
 
 	/**
-	 * Constexprs
+	 * Helpers
 	 */
-	constexpr inline u32 page_start(u32 addr)
+	static inline u32 page_start(u32 addr)
 	{
-		return addr & ~4095u;
+		return addr & ~(HOST_PAGE_SIZE() - 1);
 	}
 
-	constexpr inline u32 next_page(u32 addr)
+	static inline u32 next_page(u32 addr)
 	{
-		return page_start(addr + 4096u);
+		return page_start(addr) + HOST_PAGE_SIZE();
 	}
 
-	constexpr inline u32 page_end(u32 addr)
+	static inline u32 page_end(u32 addr)
 	{
 		return next_page(addr) - 1;
 	}
 
-	constexpr inline u32 is_page_aligned(u32 addr)
+	static inline u32 is_page_aligned(u32 val)
 	{
-		return page_start(addr) == addr;
+		return (val & (HOST_PAGE_SIZE() - 1)) == 0;
 	}
 
 
@@ -186,7 +192,7 @@ namespace utils
 
 		bool is_page_range() const
 		{
-			return (valid() && start % 4096u == 0 && length() % 4096u == 0);
+			return (valid() && is_page_aligned(start) && is_page_aligned(length()));
 		}
 
 		address_range to_page_range() const

--- a/rpcs3/Emu/RSX/Common/texture_cache.cpp
+++ b/rpcs3/Emu/RSX/Common/texture_cache.cpp
@@ -5,6 +5,8 @@
 
 namespace rsx
 {
+	constexpr u32 min_lockable_data_size = 4096; // Increasing this value has worse results even on systems with pages > 4k
+
 	void buffered_section::init_lockable_range(const address_range& range)
 	{
 		locked_range = range.to_page_range();
@@ -27,7 +29,7 @@ namespace rsx
 
 		init_lockable_range(cpu_range);
 
-		if (memory_range.length() < 4096)
+		if (memory_range.length() < min_lockable_data_size)
 		{
 			protection_strat = section_protection_strategy::hash;
 			mem_hash = 0;

--- a/rpcs3/Emu/RSX/RSXZCULL.cpp
+++ b/rpcs3/Emu/RSX/RSXZCULL.cpp
@@ -23,7 +23,7 @@ namespace rsx
 				{
 					if (p.second.prot != utils::protection::rw)
 					{
-						utils::memory_protect(vm::base(p.first), utils::get_page_size(), utils::protection::rw);
+						utils::memory_protect(vm::base(p.first), utils::c_page_size, utils::protection::rw);
 					}
 				}
 
@@ -796,7 +796,7 @@ namespace rsx
 
 				if (page.prot == utils::protection::rw)
 				{
-					utils::memory_protect(vm::base(page_address), utils::get_page_size(), utils::protection::no);
+					utils::memory_protect(vm::base(page_address), utils::c_page_size, utils::protection::no);
 					page.prot = utils::protection::no;
 				}
 			}
@@ -844,7 +844,7 @@ namespace rsx
 
 				if (page.prot != utils::protection::rw)
 				{
-					utils::memory_protect(vm::base(this_address), utils::get_page_size(), utils::protection::rw);
+					utils::memory_protect(vm::base(this_address), utils::c_page_size, utils::protection::rw);
 					page.prot = utils::protection::rw;
 				}
 
@@ -890,7 +890,7 @@ namespace rsx
 						else
 						{
 							// R/W to stale block, unload it and move on
-							utils::memory_protect(vm::base(page_address), utils::get_page_size(), utils::protection::rw);
+							utils::memory_protect(vm::base(page_address), utils::c_page_size, utils::protection::rw);
 							m_locked_pages[location].erase(page_address);
 
 							return true;


### PR DESCRIPTION
Trivial fixes to get commercial games running on arm64. I only tested with a few simple titles as I'm using Asahi Linux for this and there is no GPU driver. With PPU LLVM working now, performance is much better, although SPU LLVM still doesn't run. Games technically worked before the recent LLVM improvements, but performance was awful. This PR only addresses the hangs caused by page misalignments in RSX which is the primary (ab)user of the memory locking system.

With this PR, arkedo 01 is playable, although I need to use 50% res scale to get 60fps with the software rendering offered by llvmpipe. Vulkan doesn't work for some reason, but OpenGL is ok.

![image](https://user-images.githubusercontent.com/15904127/176544858-532d19ca-bad8-4328-bf1f-b21def6b157d.png)
