### PR TITLE
Qt: add UUID reset button

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -15,6 +15,7 @@
 #include "gui_settings.h"
 #include "display_sleep_control.h"
 #include "qt_utils.h"
+#include "uuid.h"
 #include "settings_dialog.h"
 #include "ui_settings_dialog.h"
 #include "tooltips.h"
@@ -1853,6 +1854,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		SubscribeTooltip(ui->cb_show_obsolete_cfg_dialog, tooltips.settings.show_obsolete_cfg);
 		SubscribeTooltip(ui->cb_show_same_buttons_dialog, tooltips.settings.show_same_buttons);
 		SubscribeTooltip(ui->gb_updates, tooltips.settings.check_update_start);
+		SubscribeTooltip(ui->gb_uuid, tooltips.settings.uuid);
 
 		// Discord:
 		SubscribeTooltip(ui->useRichPresence, tooltips.settings.use_rich_presence);
@@ -1873,6 +1875,20 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		{
 			m_discord_state = ui->discordState->text();
 		});
+
+		connect(ui->pb_uuid, &QAbstractButton::clicked, [this]()
+		{
+			std::string uuid;
+			if (!gui::utils::create_new_uuid(uuid))
+			{
+				QMessageBox::critical(this, tr("Error"), tr("Failed to create new installation ID!"), QMessageBox::Ok);
+				return;
+			}
+
+			ui->label_uuid->setText(QString::fromStdString(uuid));
+			gui::utils::log_uuid();
+		});
+		ui->label_uuid->setText(QString::fromStdString(gui::utils::load_uuid()));
 
 		// Log and TTY:
 		SubscribeTooltip(ui->log_limit, tooltips.settings.log_limit);

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -54,7 +54,7 @@
        </sizepolicy>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="coreTab">
        <attribute name="title">
@@ -3735,6 +3735,32 @@
                  </property>
                  <property name="maxLength">
                   <number>128</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="gb_uuid">
+              <property name="title">
+               <string>Installation ID</string>
+              </property>
+              <layout class="QVBoxLayout" name="gb_uuid_layout">
+               <item>
+                <widget class="QLabel" name="label_uuid">
+                 <property name="text">
+                  <string>UUID-placeholder</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pb_uuid">
+                 <property name="text">
+                  <string>Create new ID</string>
                  </property>
                 </widget>
                </item>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -198,6 +198,7 @@ public:
 		const QString use_rich_presence  = tr("Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to completely close the connection.");
 		const QString discord_state      = tr("Tell your friends what you are doing.");
 		const QString custom_colors      = tr("Prioritize custom user interface colors over properties set in stylesheet.");
+		const QString uuid               = tr("This is the ID used for hardware statistics.\nIt should only be reset if you change your hardware configuration or if you copied RPCS3 to another PC.");
 
 		// input
 


### PR DESCRIPTION
Shows the current UUID and adds a button to create a new one.

implements #12293

![image](https://user-images.githubusercontent.com/23019877/177209040-7602d484-2fe0-4a9b-87c5-54e85d3bee09.png)
