### PR TITLE
Input: Add background input option and fix some horrible code

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -9,6 +9,8 @@
 extern void libio_sys_config_init();
 extern void libio_sys_config_end();
 
+extern bool is_input_allowed();
+
 LOG_CHANNEL(sys_io);
 
 template<>
@@ -333,7 +335,7 @@ error_code cellKbRead(u32 port_no, vm::ptr<CellKbData> data)
 
 	KbData& current_data = handler.GetData(port_no);
 
-	if (current_info.is_null_handler || (current_info.info & CELL_KB_INFO_INTERCEPTED))
+	if (current_info.is_null_handler || (current_info.info & CELL_KB_INFO_INTERCEPTED) || !is_input_allowed())
 	{
 		data->led = 0;
 		data->mkey = 0;

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -10,6 +10,8 @@
 extern void libio_sys_config_init();
 extern void libio_sys_config_end();
 
+extern bool is_input_allowed();
+
 LOG_CHANNEL(sys_io);
 
 template<>
@@ -236,7 +238,7 @@ error_code cellMouseGetData(u32 port_no, vm::ptr<CellMouseData> data)
 
 	MouseDataList& data_list = handler.GetDataList(port_no);
 
-	if (data_list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED))
+	if (data_list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED) || !is_input_allowed())
 	{
 		data_list.clear();
 		return CELL_OK;
@@ -284,9 +286,9 @@ error_code cellMouseGetDataList(u32 port_no, vm::ptr<CellMouseDataList> data)
 
 	// TODO: check if (current_info.mode[port_no] != CELL_MOUSE_INFO_TABLET_MOUSE_MODE) has any impact
 
-	auto& list = handler.GetDataList(port_no);
+	MouseDataList& list = handler.GetDataList(port_no);
 
-	if (list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED))
+	if (list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED) || !is_input_allowed())
 	{
 		list.clear();
 		return CELL_OK;
@@ -374,9 +376,9 @@ error_code cellMouseGetTabletDataList(u32 port_no, vm::ptr<CellMouseTabletDataLi
 	// TODO: decr tests show that CELL_MOUSE_ERROR_DATA_READ_FAILED is returned when a mouse is connected
 	// TODO: check if (current_info.mode[port_no] != CELL_MOUSE_INFO_TABLET_TABLET_MODE) has any impact
 
-	auto& list = handler.GetTabletDataList(port_no);
+	MouseTabletDataList& list = handler.GetTabletDataList(port_no);
 
-	if (list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED))
+	if (list.empty() || current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED) || !is_input_allowed())
 	{
 		list.clear();
 		return CELL_OK;
@@ -432,7 +434,7 @@ error_code cellMouseGetRawData(u32 port_no, vm::ptr<CellMouseRawData> data)
 
 	MouseRawData& current_data = handler.GetRawData(port_no);
 
-	if (current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED))
+	if (current_info.is_null_handler || (current_info.info & CELL_MOUSE_INFO_INTERCEPTED) || !is_input_allowed())
 	{
 		current_data = {};
 		return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -1,8 +1,8 @@
 #include "stdafx.h"
 #include "Emu/IdManager.h"
+#include "Emu/system_config.h"
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/Cell/lv2/sys_process.h"
-
 #include "Emu/Io/pad_types.h"
 #include "Input/pad_thread.h"
 #include "Input/product_info.h"
@@ -10,6 +10,8 @@
 
 extern void libio_sys_config_init();
 extern void libio_sys_config_end();
+
+extern bool is_input_allowed();
 
 LOG_CHANNEL(sys_io);
 
@@ -197,7 +199,7 @@ void pad_get_data(u32 port_no, CellPadData* data)
 	const auto setting = config.port_setting[port_no];
 	bool btnChanged = false;
 
-	if (rinfo.ignore_input)
+	if (rinfo.ignore_input || !is_input_allowed())
 	{
 		// Needed for Hotline Miami and Ninja Gaiden Sigma after dialogs were closed and buttons are still pressed.
 		// Gran Turismo 6 would keep registering the Start button during OSK Dialogs if this wasn't cleared and if we'd return with len as CELL_PAD_LEN_NO_CHANGE.

--- a/rpcs3/Emu/Io/Buzz.cpp
+++ b/rpcs3/Emu/Io/Buzz.cpp
@@ -43,6 +43,8 @@ void usb_device_buzz::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue
 	}
 }
 
+extern bool is_input_allowed();
+
 void usb_device_buzz::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint*/, UsbTransfer* transfer)
 {
 	transfer->fake            = true;
@@ -59,6 +61,11 @@ void usb_device_buzz::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint*/
 	buf[2] = 0x00;
 	buf[3] = 0x00;
 	buf[4] = 0xf0;
+
+	if (!is_input_allowed())
+	{
+		return;
+	}
 
 	std::lock_guard lock(pad::g_pad_mutex);
 	const auto handler = pad::get_current_handler();

--- a/rpcs3/Emu/Io/Buzz.cpp
+++ b/rpcs3/Emu/Io/Buzz.cpp
@@ -31,15 +31,15 @@ void usb_device_buzz::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue
 	// Control transfers are nearly instant
 	switch (bmRequestType)
 	{
-		case 0x01:
-		case 0x21:
-		case 0x80:
-			buzz_log.error("Unhandled Query Len: 0x%02X", buf_size);
-			buzz_log.error("Unhandled Query Type: 0x%02X", (buf_size > 0) ? buf[0] : -1);
-			break;
-		default:
-			usb_device_emulated::control_transfer(bmRequestType, bRequest, wValue, wIndex, wLength, buf_size, buf, transfer);
-			break;
+	case 0x01:
+	case 0x21:
+	case 0x80:
+		buzz_log.error("Unhandled Query Len: 0x%02X", buf_size);
+		buzz_log.error("Unhandled Query Type: 0x%02X", (buf_size > 0) ? buf[0] : -1);
+		break;
+	default:
+		usb_device_emulated::control_transfer(bmRequestType, bRequest, wValue, wIndex, wLength, buf_size, buf, transfer);
+		break;
 	}
 }
 
@@ -76,36 +76,38 @@ void usb_device_buzz::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint*/
 		const auto& pad = pads[first_controller + index];
 
 		if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
+		{
 			continue;
+		}
 
 		for (Button& button : pad->m_buttons)
 		{
+			if (!button.m_pressed)
+			{
+				continue;
+			}
+
 			if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL2)
 			{
 				switch (button.m_outKeyCode)
 				{
-					case CELL_PAD_CTRL_R1:
-						if (button.m_pressed)
-							buf[2 + (0 + 5 * index) / 8] |= 1 << ((0 + 5 * index) % 8); // Red
-						break;
-					case CELL_PAD_CTRL_TRIANGLE:
-						if (button.m_pressed)
-							buf[2 + (4 + 5 * index) / 8] |= 1 << ((4 + 5 * index) % 8); // Blue
-						break;
-					case CELL_PAD_CTRL_SQUARE:
-						if (button.m_pressed)
-							buf[2 + (3 + 5 * index) / 8] |= 1 << ((3 + 5 * index) % 8); // Orange
-						break;
-					case CELL_PAD_CTRL_CIRCLE:
-						if (button.m_pressed)
-							buf[2 + (2 + 5 * index) / 8] |= 1 << ((2 + 5 * index) % 8); // Green
-						break;
-					case CELL_PAD_CTRL_CROSS:
-						if (button.m_pressed)
-							buf[2 + (1 + 5 * index) / 8] |= 1 << ((1 + 5 * index) % 8); // Yellow
-						break;
-					default:
-						break;
+				case CELL_PAD_CTRL_R1:
+					buf[2 + (0 + 5 * index) / 8] |= 1 << ((0 + 5 * index) % 8); // Red
+					break;
+				case CELL_PAD_CTRL_TRIANGLE:
+					buf[2 + (4 + 5 * index) / 8] |= 1 << ((4 + 5 * index) % 8); // Blue
+					break;
+				case CELL_PAD_CTRL_SQUARE:
+					buf[2 + (3 + 5 * index) / 8] |= 1 << ((3 + 5 * index) % 8); // Orange
+					break;
+				case CELL_PAD_CTRL_CIRCLE:
+					buf[2 + (2 + 5 * index) / 8] |= 1 << ((2 + 5 * index) % 8); // Green
+					break;
+				case CELL_PAD_CTRL_CROSS:
+					buf[2 + (1 + 5 * index) / 8] |= 1 << ((1 + 5 * index) % 8); // Yellow
+					break;
+				default:
+					break;
 				}
 			}
 		}

--- a/rpcs3/Emu/Io/GHLtar.cpp
+++ b/rpcs3/Emu/Io/GHLtar.cpp
@@ -46,6 +46,8 @@ void usb_device_ghltar::control_transfer(u8 bmRequestType, u8 bRequest, u16 wVal
 	}
 }
 
+extern bool is_input_allowed();
+
 void usb_device_ghltar::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint*/, UsbTransfer* transfer)
 {
 	transfer->fake            = true;
@@ -98,12 +100,19 @@ void usb_device_ghltar::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint
 	// buf[7] through buf[18] are always 0x00
 	// buf[21]/[23]/[25] are also always 0x00
 
+	if (!is_input_allowed())
+	{
+		return;
+	}
+
 	std::lock_guard lock(pad::g_pad_mutex);
 	const auto handler = pad::get_current_handler();
 	const auto& pad    = handler->GetPads()[m_controller_index];
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
+	{
 		return;
+	}
 
 	for (Button& button : pad->m_buttons)
 	{

--- a/rpcs3/Emu/Io/GHLtar.cpp
+++ b/rpcs3/Emu/Io/GHLtar.cpp
@@ -107,101 +107,73 @@ void usb_device_ghltar::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint
 
 	std::lock_guard lock(pad::g_pad_mutex);
 	const auto handler = pad::get_current_handler();
-	const auto& pad    = handler->GetPads()[m_controller_index];
+	const auto& pad    = handler->GetPads().at(m_controller_index);
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
 	{
 		return;
 	}
 
-	for (Button& button : pad->m_buttons)
+	for (const Button& button : pad->m_buttons)
 	{
+		if (!button.m_pressed)
+		{
+			continue;
+		}
+
 		if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL2)
 		{
-			if (button.m_pressed)
-				pad->m_digital_2 |= button.m_outKeyCode;
-			else
-				pad->m_digital_2 &= ~button.m_outKeyCode;
-
 			switch (button.m_outKeyCode)
 			{
-				case CELL_PAD_CTRL_SQUARE:
-					pad->m_press_square = button.m_value;
-					if (button.m_pressed)
-						buf[0] += 0x01; // W1
-					break;
-				case CELL_PAD_CTRL_CROSS:
-					pad->m_press_cross = button.m_value;
-					if (button.m_pressed)
-						buf[0] += 0x02; // B1
-					break;
-				case CELL_PAD_CTRL_CIRCLE:
-					pad->m_press_circle = button.m_value;
-					if (button.m_pressed)
-						buf[0] += 0x04; // B2
-					break;
-				case CELL_PAD_CTRL_TRIANGLE:
-					pad->m_press_triangle = button.m_value;
-					if (button.m_pressed)
-						buf[0] += 0x08; // B3
-					break;
-				case CELL_PAD_CTRL_R1:
-					pad->m_press_R1 = button.m_value;
-					if (button.m_pressed)
-						buf[0] += 0x20; // W3
-					break;
-				case CELL_PAD_CTRL_L1:
-					pad->m_press_L1 = button.m_value;
-					if (button.m_pressed)
-						buf[0] += 0x10; // W2
-					break;
-				default:
-					break;
+			case CELL_PAD_CTRL_SQUARE:
+				buf[0] += 0x01; // W1
+				break;
+			case CELL_PAD_CTRL_CROSS:
+				buf[0] += 0x02; // B1
+				break;
+			case CELL_PAD_CTRL_CIRCLE:
+				buf[0] += 0x04; // B2
+				break;
+			case CELL_PAD_CTRL_TRIANGLE:
+				buf[0] += 0x08; // B3
+				break;
+			case CELL_PAD_CTRL_R1:
+				buf[0] += 0x20; // W3
+				break;
+			case CELL_PAD_CTRL_L1:
+				buf[0] += 0x10; // W2
+				break;
+			default:
+				break;
 			}
 		}
 		else if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL1)
 		{
-			if (button.m_pressed)
-				pad->m_digital_1 |= button.m_outKeyCode;
-			else
-				pad->m_digital_1 &= ~button.m_outKeyCode;
-
 			switch (button.m_outKeyCode)
 			{
-				case CELL_PAD_CTRL_DOWN:
-					pad->m_press_down = button.m_value;
-					if (button.m_pressed)
-						buf[4] = 0xFF; // Strum Down
-					break;
-				case CELL_PAD_CTRL_UP:
-					pad->m_press_up = button.m_value;
-					if (button.m_pressed)
-						buf[4] = 0x00; // Strum Up
-					break;
-				case CELL_PAD_CTRL_LEFT:
-					pad->m_press_down = button.m_value;
-					if (button.m_pressed)
-						buf[2] = 0x02; // Left D-Pad (Unused)
-					break;
-				case CELL_PAD_CTRL_RIGHT:
-					pad->m_press_up = button.m_value;
-					if (button.m_pressed)
-						buf[2] = 0x06; // Right D-Pad (Unused)
-					break;
-				case CELL_PAD_CTRL_START:
-					if (button.m_pressed)
-						buf[1] += 0x02; // Pause
-					break;
-				case CELL_PAD_CTRL_SELECT:
-					if (button.m_pressed)
-						buf[1] += 0x01; // Hero Power
-					break;
-				case CELL_PAD_CTRL_L3:
-					if (button.m_pressed)
-						buf[1] += 0x04; // GHTV Button
-					break;
-				default:
-					break;
+			case CELL_PAD_CTRL_DOWN:
+				buf[4] = 0xFF; // Strum Down
+				break;
+			case CELL_PAD_CTRL_UP:
+				buf[4] = 0x00; // Strum Up
+				break;
+			case CELL_PAD_CTRL_LEFT:
+				buf[2] = 0x02; // Left D-Pad (Unused)
+				break;
+			case CELL_PAD_CTRL_RIGHT:
+				buf[2] = 0x06; // Right D-Pad (Unused)
+				break;
+			case CELL_PAD_CTRL_START:
+				buf[1] += 0x02; // Pause
+				break;
+			case CELL_PAD_CTRL_SELECT:
+				buf[1] += 0x01; // Hero Power
+				break;
+			case CELL_PAD_CTRL_L3:
+				buf[1] += 0x04; // GHTV Button
+				break;
+			default:
+				break;
 			}
 		}
 	}
@@ -209,20 +181,18 @@ void usb_device_ghltar::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint
 	{
 		switch (stick.m_offset)
 		{
-			case CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_Y:
-				buf[6]                = ~(stick.m_value) + 0x01; // Whammy
-				pad->m_analog_right_x = stick.m_value;
-				break;
-			case CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_X:
-				buf[19] = static_cast<u8>(stick.m_value); // Tilt
-				if (buf[19] >= 0xF0)
-					buf[5] = 0xFF;
-				if (buf[19] <= 0x10)
-					buf[5] = 0x00;
-				pad->m_analog_right_y = stick.m_value;
-				break;
-			default:
-				break;
+		case CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_Y:
+			buf[6] = ~(stick.m_value) + 0x01; // Whammy
+			break;
+		case CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_X:
+			buf[19] = static_cast<u8>(stick.m_value); // Tilt
+			if (buf[19] >= 0xF0)
+				buf[5] = 0xFF;
+			if (buf[19] <= 0x10)
+				buf[5] = 0x00;
+			break;
+		default:
+			break;
 		}
 	}
 }

--- a/rpcs3/Emu/Io/pad_config_types.h
+++ b/rpcs3/Emu/Io/pad_config_types.h
@@ -26,7 +26,7 @@ enum class mouse_movement_mode : s32
 
 struct PadInfo
 {
-	u32 now_connect;
-	u32 system_info;
-	bool ignore_input;
+	u32 now_connect = 0;
+	u32 system_info = 0;
+	bool ignore_input = false;
 };

--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -87,6 +87,8 @@ void usb_device_usio::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue
 	}
 }
 
+extern bool is_input_allowed();
+
 void usb_device_usio::translate_input()
 {
 	std::lock_guard lock(pad::g_pad_mutex);
@@ -98,6 +100,11 @@ void usb_device_usio::translate_input()
 
 	auto translate_from_pad = [&](u8 pad_number, u8 player)
 	{
+		if (!is_input_allowed())
+		{
+			return;
+		}
+
 		const auto& pad = handler->GetPads()[pad_number];
 		if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
 		{

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -9,6 +9,8 @@
 
 LOG_CHANNEL(overlays);
 
+extern bool is_input_allowed();
+
 namespace rsx
 {
 	namespace overlays
@@ -120,13 +122,24 @@ namespace rsx
 
 			while (!exit)
 			{
-				std::this_thread::sleep_for(1ms);
-
 				if (Emu.IsStopped())
+				{
 					return selection_code::canceled;
+				}
 
 				if (Emu.IsPaused())
+				{
+					thread_ctrl::wait_for(10000);
 					continue;
+				}
+
+				thread_ctrl::wait_for(1000);
+
+				if (!is_input_allowed())
+				{
+					refresh();
+					continue;
+				}
 
 				// Get keyboard input if supported by the overlay and activated by the game.
 				// Ignored if a keyboard pad handler is active in order to prevent double input.

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -279,6 +279,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<ghltar_handler> ghltar{this, "GHLtar emulated controller", ghltar_handler::null};
 		cfg::_enum<pad_handler_mode> pad_mode{this, "Pad handler mode", pad_handler_mode::single_threaded, true};
 		cfg::uint<0, 100'000> pad_sleep{this, "Pad handler sleep (microseconds)", 1'000, true};
+		cfg::_bool background_input_enabled{this, "Background input enabled", true, true};
 	} io{ this };
 
 	struct node_sys : cfg::node

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -273,7 +273,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<fake_camera_type> camera_type{ this, "Camera type", fake_camera_type::unknown };
 		cfg::_enum<camera_flip> camera_flip_option{ this, "Camera flip", camera_flip::none, true };
 		cfg::string camera_id{ this, "Camera ID", "Default", true };
-		cfg::_enum<move_handler> move{ this, "Move", move_handler::null };
+		cfg::_enum<move_handler> move{ this, "Move", move_handler::null, true };
 		cfg::_enum<buzz_handler> buzz{ this, "Buzz emulated controller", buzz_handler::null };
 		cfg::_enum<turntable_handler> turntable{this, "Turntable emulated controller", turntable_handler::null};
 		cfg::_enum<ghltar_handler> ghltar{this, "GHLtar emulated controller", ghltar_handler::null};

--- a/rpcs3/Input/basic_mouse_handler.cpp
+++ b/rpcs3/Input/basic_mouse_handler.cpp
@@ -12,8 +12,15 @@ LOG_CHANNEL(input_log, "Input");
 
 void basic_mouse_handler::Init(const u32 max_connect)
 {
+	if (m_info.max_connect > 0)
+	{
+		// Already initialized
+		return;
+	}
+
+	m_mice.clear();
 	m_mice.emplace_back(Mouse());
-	memset(&m_info, 0, sizeof(MouseInfo));
+	m_info = {};
 	m_info.max_connect = max_connect;
 	m_info.now_connect = std::min(::size32(m_mice), max_connect);
 	m_info.info = input::g_mice_intercepted ? CELL_MOUSE_INFO_INTERCEPTED : 0; // Ownership of mouse data: 0=Application, 1=System

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -21,6 +21,8 @@
 
 LOG_CHANNEL(input_log, "Input");
 
+extern bool is_input_allowed();
+
 namespace pad
 {
 	atomic_t<pad_thread*> g_current = nullptr;
@@ -251,7 +253,7 @@ void pad_thread::operator()()
 			{
 				while (thread_ctrl::state() != thread_state::aborting)
 				{
-					if (!pad::g_enabled || Emu.IsPaused())
+					if (!pad::g_enabled || Emu.IsPaused() || !is_input_allowed())
 					{
 						thread_ctrl::wait_for(10'000);
 						continue;
@@ -267,7 +269,7 @@ void pad_thread::operator()()
 
 	while (thread_ctrl::state() != thread_state::aborting)
 	{
-		if (!pad::g_enabled || Emu.IsPaused())
+		if (!pad::g_enabled || Emu.IsPaused() || !is_input_allowed())
 		{
 			thread_ctrl::wait_for(10000);
 			continue;

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -81,7 +81,9 @@ EmuCallbacks main_application::CreateCallbacks()
 				ret->SetTargetWindow(m_game_window);
 			}
 			else
+			{
 				g_fxo->init<MouseHandlerBase, NullMouseHandler>(Emu.DeserialManager());
+			}
 
 			break;
 		}

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -137,6 +137,7 @@ enum class emu_settings_type
 	MusicHandler,
 
 	// Input / Output
+	BackgroundInput,
 	PadHandlerMode,
 	KeyboardHandler,
 	MouseHandler,
@@ -310,6 +311,7 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::MusicHandler,            { "Audio", "Music Handler"}},
 
 	// Input / Output
+	{ emu_settings_type::BackgroundInput, { "Input/Output", "Background input enabled"}},
 	{ emu_settings_type::PadHandlerMode,  { "Input/Output", "Pad handler mode"}},
 	{ emu_settings_type::KeyboardHandler, { "Input/Output", "Keyboard"}},
 	{ emu_settings_type::MouseHandler,    { "Input/Output", "Mouse"}},

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -55,6 +55,13 @@ LOG_CHANNEL(gui_log, "GUI");
 extern atomic_t<bool> g_user_asked_for_frame_capture;
 extern atomic_t<bool> g_disable_frame_limit;
 
+atomic_t<bool> g_game_window_focused = false;
+
+bool is_input_allowed()
+{
+	return g_game_window_focused || g_cfg.io.background_input_enabled;
+}
+
 constexpr auto qstr = QString::fromStdString;
 
 gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings)
@@ -115,6 +122,7 @@ gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon,
 	// Change cursor when this window gets or loses focus.
 	connect(this, &QWindow::activeChanged, this, [this]()
 	{
+		g_game_window_focused = isActive();
 		handle_cursor(visibility(), false, true);
 	});
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1176,6 +1176,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceComboBox(ui->ghltarBox, emu_settings_type::GHLtar);
 	SubscribeTooltip(ui->gb_ghltar_emulated, tooltips.settings.ghltar);
 
+	m_emu_settings->EnhanceCheckBox(ui->backgroundInputBox, emu_settings_type::BackgroundInput);
+	SubscribeTooltip(ui->backgroundInputBox, tooltips.settings.background_input);
+
 	//     _____           _                   _______    _
 	//    / ____|         | |                 |__   __|  | |
 	//   | (___  _   _ ___| |_ ___ _ __ ___      | | __ _| |__

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1540,6 +1540,42 @@
        <layout class="QVBoxLayout" name="inputTab_layout">
         <item>
          <layout class="QGridLayout" name="ioGridLayout">
+          <item row="0" column="2">
+           <widget class="QGroupBox" name="gb_buzz_emulated">
+            <property name="title">
+             <string>Buzz! emulated controller</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_buzz_emulated_layout">
+             <item>
+              <widget class="QComboBox" name="buzzBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QGroupBox" name="gb_ghltar_emulated">
+            <property name="title">
+             <string>Guitar Hero Live emulated guitar</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_ghltar_emulated_layout">
+             <item>
+              <widget class="QComboBox" name="ghltarBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QGroupBox" name="gb_camera_flip">
+            <property name="title">
+             <string>Camera Flip</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_camera_flip_layout">
+             <item>
+              <widget class="QComboBox" name="cameraFlipBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
           <item row="1" column="2">
            <widget class="QGroupBox" name="gb_turntable_emulated">
             <property name="title">
@@ -1552,6 +1588,30 @@
             </layout>
            </widget>
           </item>
+          <item row="0" column="0">
+           <widget class="QGroupBox" name="gb_keyboard_handler">
+            <property name="title">
+             <string>Keyboard Handler</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_keyboard_handler_layout">
+             <item>
+              <widget class="QComboBox" name="keyboardHandlerBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QGroupBox" name="gb_pad_mode">
+            <property name="title">
+             <string>Pad Handler Mode</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_pad_mode_layout">
+             <item>
+              <widget class="QComboBox" name="padModeBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
           <item row="1" column="0">
            <widget class="QGroupBox" name="gb_mouse_handler">
             <property name="title">
@@ -1560,6 +1620,18 @@
             <layout class="QVBoxLayout" name="gb_mouse_handler_layout">
              <item>
               <widget class="QComboBox" name="mouseHandlerBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QGroupBox" name="gb_camera_id">
+            <property name="title">
+             <string>Camera</string>
+            </property>
+            <layout class="QVBoxLayout" name="camera_id_layout">
+             <item>
+              <widget class="QComboBox" name="cameraIdBox"/>
              </item>
             </layout>
            </widget>
@@ -1588,42 +1660,6 @@
             </layout>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QGroupBox" name="gb_keyboard_handler">
-            <property name="title">
-             <string>Keyboard Handler</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_keyboard_handler_layout">
-             <item>
-              <widget class="QComboBox" name="keyboardHandlerBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QGroupBox" name="gb_buzz_emulated">
-            <property name="title">
-             <string>Buzz! emulated controller</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_buzz_emulated_layout">
-             <item>
-              <widget class="QComboBox" name="buzzBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QGroupBox" name="gb_camera_flip">
-            <property name="title">
-             <string>Camera Flip</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_camera_flip_layout">
-             <item>
-              <widget class="QComboBox" name="cameraFlipBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
           <item row="1" column="1">
            <widget class="QGroupBox" name="gb_camera_setting">
             <property name="title">
@@ -1636,38 +1672,18 @@
             </layout>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QGroupBox" name="gb_ghltar_emulated">
+          <item row="4" column="0">
+           <widget class="QGroupBox" name="gb_additional_io_settings">
             <property name="title">
-             <string>Guitar Hero Live emulated guitar</string>
+             <string>Additional Settings</string>
             </property>
-            <layout class="QVBoxLayout" name="gb_ghltar_emulated_layout">
+            <layout class="QVBoxLayout" name="layout_gb_additional_io_settings">
              <item>
-              <widget class="QComboBox" name="ghltarBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QGroupBox" name="gb_camera_id">
-            <property name="title">
-             <string>Camera</string>
-            </property>
-            <layout class="QVBoxLayout" name="camera_id_layout">
-             <item>
-              <widget class="QComboBox" name="cameraIdBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QGroupBox" name="gb_pad_mode">
-            <property name="title">
-             <string>Pad Handler Mode</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_pad_mode_layout">
-             <item>
-              <widget class="QComboBox" name="padModeBox"/>
+              <widget class="QCheckBox" name="backgroundInputBox">
+               <property name="text">
+                <string>Enable Background Input</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -214,6 +214,7 @@ public:
 		const QString buzz              = tr("Buzz! support.\nSelect 1 or 2 controllers if the game requires Buzz! controllers and you don't have real controllers.\nSelect Null if the game has support for DualShock or if you have real Buzz! controllers.");
 		const QString turntable         = tr("DJ Hero Turntable controller support.\nSelect 1 or 2 controllers if the game requires DJ Hero Turntable controllers and you don't have real turntable controllers.\nSelect Null if the game has support for DualShock or if you have real turntable controllers.\nA real turntable controller can be used at the same time as an emulated turntable controller.");
 		const QString ghltar            = tr("Guitar Hero Live (GHL) Guitar controller support.\nSelect 1 or 2 controllers if the game requires GHL Guitar controllers and you don't have real guitar controllers.\nSelect Null if the game has support for DualShock or if you have real guitar controllers.\nA real guitar controller can be used at the same time as an emulated guitar controller.");
+		const QString background_input  = tr("Allows pad and keyboard input while the game window is unfocused.");
 
 		// network
 


### PR DESCRIPTION
- Adds an option to disable background input to the IO tab in the settings dialog.
This will disable pad, keyboard and mouse input as well as ps move and overlays input while the game window is not in focus.
- Fixes some horrible input emulation code that was modifying pad members for no reason.
- Implemented Left Stick position for PS Move fake handler
- Made PS Move handler dynamic

fixes #11950
probably fixes #9837