### PR TITLE
Savestates: Compatibilty improvements

### DIFF
--- a/rpcs3/Emu/Cell/ErrorCodes.h
+++ b/rpcs3/Emu/Cell/ErrorCodes.h
@@ -39,6 +39,8 @@ public:
 	{
 		return value;
 	}
+
+	ENABLE_BITWISE_SERIALIZATION;
 };
 
 enum CellNotAnError : s32

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -178,6 +178,23 @@ audio_out_configuration::audio_out_configuration()
 	cellSysutil.notice("cellAudioOut: initial secondary output configuration: channels=%d, encoder=%d, downmixer=%d", secondary_output.channels, secondary_output.encoder, secondary_output.downmixer);
 }
 
+audio_out_configuration::audio_out_configuration(utils::serial& ar)
+	: audio_out_configuration()
+{
+	// Load configuartion (ar is reading)
+	save(ar);
+}
+
+void audio_out_configuration::save(utils::serial& ar)
+{
+	USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellAudioOut);
+
+	for (auto& state : out)
+	{
+		ar(state.state, state.channels, state.encoder, state.downmixer, state.copy_control, state.sound_modes, state.sound_mode);
+	}
+}
+
 std::pair<AudioChannelCnt, AudioChannelCnt> audio_out_configuration::audio_out::get_channel_count_and_downmixer() const
 {
 	std::pair<AudioChannelCnt, AudioChannelCnt> ret;

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.h
@@ -135,6 +135,8 @@ struct CellAudioOutSoundMode
 	u8 fs;
 	u8 reserved;
 	be_t<u32> layout;
+
+	ENABLE_BITWISE_SERIALIZATION;
 };
 
 struct CellAudioOutDeviceInfo
@@ -217,5 +219,8 @@ struct audio_out_configuration
 
 	std::array<audio_out, 2> out;
 
+	SAVESTATE_INIT_POS(8.9); // Is a dependency of cellAudio
 	audio_out_configuration();
+	audio_out_configuration(utils::serial& ar);
+	void save(utils::serial& ar);
 };

--- a/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
@@ -69,10 +69,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 		// call the syscall
 		if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, u32{umax}, 1))
 		{
-			if (ppu.test_stopped())
-			{
-				return 0;
-			}
+			static_cast<void>(ppu.test_stopped());
 
 			lwmutex->all_info--;
 
@@ -108,10 +105,7 @@ error_code sys_lwcond_signal(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 	// call the syscall
 	if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, u32{umax}, 3))
 	{
-		if (ppu.test_stopped())
-		{
-			return 0;
-		}
+		static_cast<void>(ppu.test_stopped());
 
 		lwmutex->lock_var.atomic_op([&](sys_lwmutex_t::sync_var_t& var)
 		{
@@ -158,10 +152,7 @@ error_code sys_lwcond_signal_all(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 			return res;
 		}
 
-		if (ppu.test_stopped())
-		{
-			return 0;
-		}
+		static_cast<void>(ppu.test_stopped());
 
 		lwmutex->all_info += +res;
 		return CELL_OK;
@@ -183,10 +174,7 @@ error_code sys_lwcond_signal_all(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond)
 	// if locking succeeded, call the syscall
 	error_code res = _sys_lwcond_signal_all(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, 1);
 
-	if (ppu.test_stopped())
-	{
-		return 0;
-	}
+	static_cast<void>(ppu.test_stopped());
 
 	if (res > 0)
 	{
@@ -225,10 +213,7 @@ error_code sys_lwcond_signal_to(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u
 		// call the syscall
 		if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, ppu_thread_id, 1))
 		{
-			if (ppu.test_stopped())
-			{
-				return 0;
-			}
+			static_cast<void>(ppu.test_stopped());
 
 			lwmutex->all_info--;
 
@@ -261,10 +246,7 @@ error_code sys_lwcond_signal_to(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u
 	// call the syscall
 	if (error_code res = _sys_lwcond_signal(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, ppu_thread_id, 3))
 	{
-		if (ppu.test_stopped())
-		{
-			return 0;
-		}
+		static_cast<void>(ppu.test_stopped());
 
 		lwmutex->lock_var.atomic_op([&](sys_lwmutex_t::sync_var_t& var)
 		{
@@ -290,6 +272,9 @@ error_code sys_lwcond_wait(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u64 ti
 		return sys_cond_wait(ppu, lwcond->lwcond_queue, timeout);
 	}
 
+	auto& sstate = *ppu.optional_savestate_state;
+	const auto lwcond_ec = sstate.try_read<error_code>().second;
+
 	const be_t<u32> tid(ppu.id);
 
 	const vm::ptr<sys_lwmutex_t> lwmutex = lwcond->lwmutex;
@@ -301,18 +286,22 @@ error_code sys_lwcond_wait(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u64 ti
 	}
 
 	// save old recursive value
-	const be_t<u32> recursive_value = lwmutex->recursive_count;
+	const be_t<u32> recursive_value = !lwcond_ec ? lwmutex->recursive_count : sstate.operator be_t<u32>();
 
 	// set special value
 	lwmutex->vars.owner = lwmutex_reserved;
 	lwmutex->recursive_count = 0;
 
 	// call the syscall
-	const error_code res = _sys_lwcond_queue_wait(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, timeout);
+	const error_code res = !lwcond_ec ? _sys_lwcond_queue_wait(ppu, lwcond->lwcond_queue, lwmutex->sleep_queue, timeout) : lwcond_ec;
 
-	if (ppu.test_stopped())
+	static_cast<void>(ppu.test_stopped());
+
+	if (ppu.state & cpu_flag::again)
 	{
-		return 0;
+		sstate.pos = 0;
+		sstate(error_code{}, recursive_value); // Not aborted on mutex sleep
+		return {};
 	}
 
 	if (res == CELL_OK || res + 0u == CELL_ESRCH)
@@ -339,6 +328,13 @@ error_code sys_lwcond_wait(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u64 ti
 		if (error_code res2 = sys_lwmutex_lock(ppu, lwmutex, 0))
 		{
 			return res2;
+		}
+
+		if (ppu.state & cpu_flag::again)
+		{
+			sstate.pos = 0;
+			sstate(res, recursive_value);
+			return {};
 		}
 
 		// if successfully locked, restore recursive value

--- a/rpcs3/Emu/Cell/Modules/sys_spinlock.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_spinlock.cpp
@@ -24,7 +24,8 @@ error_code sys_spinlock_lock(ppu_thread& ppu, vm::ptr<atomic_be_t<u32>> lock)
 	{
 		if (ppu.test_stopped())
 		{
-			return 0;
+			ppu.state += cpu_flag::again;
+			return {};
 		}
 	}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1577,10 +1577,7 @@ bool ppu_thread::savable() const
 
 void ppu_thread::serialize_common(utils::serial& ar)
 {
-	ar(gpr, fpr, cr, fpscr.bits, lr, ctr, vrsave, cia, xer, sat, nj, prio, optional_savestate_state);
-
-	for (v128& reg : vr)
-		ar(reg._bytes);
+	ar(gpr, fpr, cr, fpscr.bits, lr, ctr, vrsave, cia, xer, sat, nj, prio, optional_savestate_state, vr);
 
 	if (optional_savestate_state->data.empty())
 	{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1396,7 +1396,7 @@ void ppu_thread::cpu_task()
 			thread_ctrl::wait_on<atomic_wait::op_ne>(g_progr_ptotal, 0);
 			g_fxo->get<progress_dialog_workaround>().skip_the_progress_dialog = true;
 
-			// Sadly we can't postpone initializing guest time because we need ti run PPU threads
+			// Sadly we can't postpone initializing guest time because we need to run PPU threads
 			// (the farther it's postponed, the less accuracy of guest time has been lost)
 			Emu.FixGuestTime();
 
@@ -1527,6 +1527,8 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 		gpr[4] = param.arg1;
 	}
 
+	optional_savestate_state = std::make_shared<utils::serial>();
+
 	// Trigger the scheduler
 	state += cpu_flag::suspend;
 
@@ -1575,10 +1577,15 @@ bool ppu_thread::savable() const
 
 void ppu_thread::serialize_common(utils::serial& ar)
 {
-	ar(gpr, fpr, cr, fpscr.bits, lr, ctr, vrsave, cia, xer, sat, nj, prio, optional_syscall_state);
+	ar(gpr, fpr, cr, fpscr.bits, lr, ctr, vrsave, cia, xer, sat, nj, prio, optional_savestate_state);
 
 	for (v128& reg : vr)
 		ar(reg._bytes);
+
+	if (optional_savestate_state->data.empty())
+	{
+		optional_savestate_state->clear();
+	}
 }
 
 ppu_thread::ppu_thread(utils::serial& ar)
@@ -1669,8 +1676,12 @@ ppu_thread::ppu_thread(utils::serial& ar)
 
 				+[](ppu_thread& ppu) -> bool
 				{
+					const u32 op = vm::read32(ppu.cia);
+					const auto& table = g_fxo->get<ppu_interpreter_rt>();
 					ppu.loaded_from_savestate = true;
-					ppu_execute_syscall(ppu, ppu.gpr[11]);
+					table.decode(op)(ppu, {op}, vm::_ptr<u32>(ppu.cia), &ppu_ret);
+
+					ppu.optional_savestate_state->clear(); // Reset to writing state
 					ppu.loaded_from_savestate = false;
 					return true;
 				}
@@ -1708,6 +1719,8 @@ ppu_thread::ppu_thread(utils::serial& ar)
 
 void ppu_thread::save(utils::serial& ar)
 {
+	USING_SERIALIZATION_VERSION(ppu);
+
 	const u64 entry = std::bit_cast<u64>(entry_func);
 
 	ppu_join_status _joiner = joiner;
@@ -1870,7 +1883,7 @@ void ppu_thread::fast_call(u32 addr, u64 rtoc)
 		}
 		else if (old_cia)
 		{
-			if (state & cpu_flag::exit)
+			if (state & cpu_flag::again)
 			{
 				ppu_log.error("HLE callstack savestate is not implemented!");
 			}

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -318,9 +318,9 @@ public:
 	} thread_name{ this };
 
 	// For savestates
-	bool stop_flag_removal_protection = false; // If set, Emulator::Run won't remove stop flag 
+	bool stop_flag_removal_protection = false; // If set, Emulator::Run won't remove stop flag
 	bool loaded_from_savestate = false; // Indicates the thread had just started straight from savestate load
-	u64 optional_syscall_state{};
+	std::shared_ptr<utils::serial> optional_savestate_state;
 	bool interrupt_thread_executing = false;
 
 	be_t<u64>* get_stack_arg(s32 i, u64 align = alignof(u64));

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -1256,7 +1256,7 @@ void spu_recompiler::UNK(spu_opcode_t op)
 
 void spu_stop(spu_thread* _spu, u32 code)
 {
-	if (!_spu->stop_and_signal(code))
+	if (!_spu->stop_and_signal(code) || _spu->state & cpu_flag::again)
 	{
 		spu_runtime::g_escape(_spu);
 	}
@@ -1328,8 +1328,9 @@ static u32 spu_rdch(spu_thread* _spu, u32 ch)
 {
 	const s64 result = _spu->get_ch_value(ch);
 
-	if (result < 0)
+	if (result < 0 || _spu->state & cpu_flag::again)
 	{
+		_spu->state += cpu_flag::again;
 		spu_runtime::g_escape(_spu);
 	}
 
@@ -2252,7 +2253,7 @@ void spu_recompiler::MTSPR(spu_opcode_t)
 
 static void spu_wrch(spu_thread* _spu, u32 ch, u32 value)
 {
-	if (!_spu->set_ch_value(ch, value))
+	if (!_spu->set_ch_value(ch, value) || _spu->state & cpu_flag::again)
 	{
 		spu_runtime::g_escape(_spu);
 	}
@@ -2266,8 +2267,9 @@ static void spu_wrch(spu_thread* _spu, u32 ch, u32 value)
 
 static void spu_wrch_mfc(spu_thread* _spu)
 {
-	if (!_spu->process_mfc_cmd())
+	if (!_spu->process_mfc_cmd() || _spu->state & cpu_flag::again)
 	{
+		_spu->state += cpu_flag::again;
 		spu_runtime::g_escape(_spu);
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1699,28 +1699,10 @@ spu_thread::spu_thread(lv2_spu_group* group, u32 index, std::string_view name, u
 
 void spu_thread::serialize_common(utils::serial& ar)
 {
-	for (v128& reg : gpr)
-		ar(reg._bytes);
-	
-	ar(pc, ch_mfc_cmd, mfc_size, mfc_barrier, mfc_fence, mfc_prxy_cmd, mfc_prxy_mask, mfc_prxy_write_state.all
-	, srr0
-	, ch_tag_upd
-	, ch_tag_mask
-	, ch_tag_stat.data
-	, ch_stall_mask
-	, ch_stall_stat.data
-	, ch_atomic_stat.data
-	, ch_out_mbox.data
-	, ch_out_intr_mbox.data
-	, snr_config
-
-	, ch_snr1.data
-	, ch_snr2.data
-	, ch_events.raw().all
-	, interrupts_enabled
-	, run_ctrl
-	, exit_status.data
-	, status_npc.raw().status);
+	ar(gpr, pc, ch_mfc_cmd, mfc_size, mfc_barrier, mfc_fence, mfc_prxy_cmd, mfc_prxy_mask, mfc_prxy_write_state.all
+		, srr0, ch_tag_upd, ch_tag_mask, ch_tag_stat.data, ch_stall_mask, ch_stall_stat.data, ch_atomic_stat.data
+		, ch_out_mbox.data, ch_out_intr_mbox.data, snr_config, ch_snr1.data, ch_snr2.data, ch_events.raw().all, interrupts_enabled
+		, run_ctrl, exit_status.data, status_npc.raw().status);
 
 	if (GET_SERIALIZATION_VERSION(spu) != 1u)
 	{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1722,6 +1722,11 @@ void spu_thread::serialize_common(utils::serial& ar)
 	, exit_status.data
 	, status_npc.raw().status);
 
+	if (GET_SERIALIZATION_VERSION(spu) != 1u)
+	{
+		ar(ch_dec_start_timestamp, ch_dec_value, is_dec_frozen);
+	}
+
 	std::for_each_n(mfc_queue, mfc_size, [&](spu_mfc_cmd& cmd) { ar(cmd); });
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -225,7 +225,7 @@ error_code _sys_timer_start(ppu_thread& ppu, u32 timer_id, u64 base_time, u64 pe
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_timer.trace("_sys_timer_start(timer_id=0x%x, base_time=0x%llx, period=0x%llx)", timer_id, base_time, period);
+	(period ? sys_timer.warning : sys_timer.trace)("_sys_timer_start(timer_id=0x%x, base_time=0x%llx, period=0x%llx)", timer_id, base_time, period);
 
 	const u64 start_time = get_guest_system_time();
 

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -21,6 +21,8 @@ struct lv2_timer_thread
 
 	void operator()();
 
+	SAVESTATE_INIT_POS(46); // Dependency ion LV2 objects (lv2_timer)
+
 	static constexpr auto thread_name = "Timer Thread"sv;
 };
 

--- a/rpcs3/Emu/IdManager.cpp
+++ b/rpcs3/Emu/IdManager.cpp
@@ -9,6 +9,19 @@ namespace id_manager
 	thread_local u32 g_id = 0;
 }
 
+template <>
+bool serialize<std::shared_ptr<utils::serial>>(utils::serial& ar, std::shared_ptr<utils::serial>& o)
+{
+	if (!o || !ar.is_writing())
+	{
+		o.reset();
+		o = std::make_shared<utils::serial>();
+	}
+
+	ar(o->data);
+	return true;
+}
+
 std::vector<std::pair<u128, id_manager::typeinfo>>& id_manager::get_typeinfo_map()
 {
 	// Magic static

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1569,7 +1569,7 @@ namespace vm
 				if (!(ar.data.back() & page_writable) && is_memory_read_only_of_executable(addr))
 				{
 					// Revert changes
-					ar.data.resize(ar.data.size() - (sizeof(u32) * 2 + sizeof(memory_page)));
+					ar.data.resize(ar.seek_end(sizeof(u32) * 2 + sizeof(memory_page)));
 					vm_log.success("Removed read-only memory block of the executable from savestate. (addr=0x%x, size=0x%x)", addr, shm.first);
 					continue;
 				}

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -23,7 +23,7 @@
 LOG_CHANNEL(vm_log, "VM");
 
 void ppu_remove_hle_instructions(u32 addr, u32 size);
-extern bool is_memory_read_only_of_executable(u32 addr);
+extern bool is_memory_compatible_for_copy_from_executable_optimization(u32 addr, u32 size);
 
 namespace vm
 {
@@ -1564,13 +1564,12 @@ namespace vm
 
 			if (flags & preallocated)
 			{
-				// Do not save read-only memory which comes from the executable
-				// Because it couldn't have changed
-				if (!(ar.data.back() & page_writable) && is_memory_read_only_of_executable(addr))
+				// Do not save memory which matches the memory found in the executable (we can use it instead)
+				if (is_memory_compatible_for_copy_from_executable_optimization(addr, shm.first))
 				{
 					// Revert changes
 					ar.data.resize(ar.seek_end(sizeof(u32) * 2 + sizeof(memory_page)));
-					vm_log.success("Removed read-only memory block of the executable from savestate. (addr=0x%x, size=0x%x)", addr, shm.first);
+					vm_log.success("Removed memory block matching the memory of the executable from savestate. (addr=0x%x, size=0x%x)", addr, shm.first);
 					continue;
 				}
 
@@ -2044,6 +2043,8 @@ namespace vm
 				loc->save(ar, shared_map);
 			}
 		}
+
+		is_memory_compatible_for_copy_from_executable_optimization(0, 0); // Cleanup internal data
 	}
 
 	void load(utils::serial& ar)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -71,7 +71,7 @@ struct serial_ver_t
 	std::set<u32> compatible_versions;
 };
 
-static std::array<serial_ver_t, 22> s_serial_versions;
+static std::array<serial_ver_t, 23> s_serial_versions;
 
 #define SERIALIZATION_VER(name, identifier, ...) \
 \
@@ -125,6 +125,7 @@ SERIALIZATION_VER(cellVoice, 18,                                1)
 SERIALIZATION_VER(cellGcm, 19,                                  1)
 SERIALIZATION_VER(sysPrxForUser, 20,                            1)
 SERIALIZATION_VER(cellSaveData, 21,                             1)
+SERIALIZATION_VER(cellAudioOut, 22,                             1)
 
 #undef SERIALIZATION_VER
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -500,7 +500,8 @@ void main_window::BootTest()
 	const QString file_path = QFileDialog::getOpenFileName(this, tr("Select (S)ELF To Boot"), path_tests, tr(
 		"(S)ELF files (*.elf *.self);;"
 		"ELF files (*.elf);;"
-		"SELF files (*.self);;"),
+		"SELF files (*.self);;"
+		"All files (*.*)"),
 		Q_NULLPTR, QFileDialog::DontResolveSymlinks);
 
 	if (file_path.isEmpty())


### PR DESCRIPTION
* Fix LV2 timers reloading, fixing audio and freezes in many games with savestates.
* Save cellAudioOut.
* Save SPU timer state.
* Initial HLE saving API implemented. (currently only POC in sys_lwmutex HLE)
* Fixes HLE VDEC contexts detection in savestates.
* Optimize SPU LLVM register value store insurence for savestates.
* Fix SPU instruction address in savestate if aborted on a WRCH instruction. (fixes random SPU crashes on savestate load)
* Replace bugged read-only block optimization with an optimization compatible with PPU patches and savestate inspection mode, not to mention it had a bugged check which made some executables not able to load.