### PR TITLE
PS Move: add "show cursor" option

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -430,6 +430,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/Null/NullGSRender.cpp
     RSX/Overlays/overlay_animation.cpp
     RSX/Overlays/overlay_controls.cpp
+    RSX/Overlays/overlay_cursor.cpp
     RSX/Overlays/overlay_edit_text.cpp
     RSX/Overlays/overlay_fonts.cpp
     RSX/Overlays/overlay_list_view.cpp

--- a/rpcs3/Emu/RSX/Overlays/overlay_cursor.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_cursor.cpp
@@ -1,0 +1,150 @@
+#include "stdafx.h"
+#include "overlay_cursor.h"
+#include "Emu/RSX/RSXThread.h"
+
+namespace rsx
+{
+	namespace overlays
+	{
+		cursor_item::cursor_item()
+		{
+			m_cross_h.set_size(15, 1);
+			m_cross_v.set_size(1, 15);
+		}
+
+		bool cursor_item::set_position(u16 x, u16 y)
+		{
+			if (m_x == x && m_y == y)
+			{
+				return false;
+			}
+
+			m_x = x;
+			m_y = y;
+
+			m_cross_h.set_pos(m_x - m_cross_h.w / 2, m_y - m_cross_h.h / 2);
+			m_cross_v.set_pos(m_x - m_cross_v.w / 2, m_y - m_cross_v.h / 2);
+
+			return true;
+		}
+
+		bool cursor_item::set_color(color4f color)
+		{
+			if (m_cross_h.back_color == color && m_cross_v.back_color == color)
+			{
+				return false;
+			}
+
+			m_cross_h.back_color = color;
+			m_cross_h.refresh();
+
+			m_cross_v.back_color = color;
+			m_cross_v.refresh();
+
+			return true;
+		}
+
+		void cursor_item::set_expiration(u64 expiration_time)
+		{
+			m_expiration_time = expiration_time;
+		}
+
+		bool cursor_item::update_visibility(u64 time)
+		{
+			m_visible = time <= m_expiration_time;
+
+			return m_visible;
+		}
+
+		compiled_resource cursor_item::get_compiled()
+		{
+			if (!m_visible)
+			{
+				return {};
+			}
+
+			compiled_resource cr = m_cross_h.get_compiled();
+			cr.add(m_cross_v.get_compiled());
+
+			return cr;
+		}
+
+		void cursor_manager::update()
+		{
+			if (!visible)
+			{
+				return;
+			}
+
+			std::lock_guard lock(m_mutex);
+
+			const u64 cur_time = get_system_time();
+			bool any_cursor_visible = false;
+
+			for (auto& entry : m_cursors)
+			{
+				any_cursor_visible |= entry.second.update_visibility(cur_time);
+			}
+
+			if (!any_cursor_visible)
+			{
+				visible = false;
+			}
+		}
+
+		compiled_resource cursor_manager::get_compiled()
+		{
+			if (!visible)
+			{
+				return {};
+			}
+
+			std::lock_guard lock(m_mutex);
+
+			compiled_resource cr{};
+
+			for (auto& entry : m_cursors)
+			{
+				cr.add(entry.second.get_compiled());
+			}
+
+			return cr;
+		}
+
+		void cursor_manager::update_cursor(u32 id, u16 x, u16 y, const color4f& color, u64 duration_us, bool force_update)
+		{
+			std::lock_guard lock(m_mutex);
+
+			cursor_item& cursor = m_cursors[id];
+
+			bool is_dirty = cursor.set_position(x, y);
+			is_dirty |= cursor.set_color(color);
+
+			if (is_dirty || force_update)
+			{
+				const u64 expiration_time = get_system_time() + duration_us;
+				cursor.set_expiration(expiration_time);
+
+				if (cursor.update_visibility(expiration_time))
+				{
+					visible = true;
+				}
+			}
+		}
+
+		void set_cursor(u32 id, u16 x, u16 y, const color4f& color, u64 duration_us, bool force_update)
+		{
+			if (auto manager = g_fxo->try_get<rsx::overlays::display_manager>())
+			{
+				auto cursor_overlay = manager->get<rsx::overlays::cursor_manager>();
+				if (!cursor_overlay)
+				{
+					cursor_overlay = std::make_shared<rsx::overlays::cursor_manager>();
+					cursor_overlay = manager->add(cursor_overlay);
+				}
+				cursor_overlay->update_cursor(id, x, y, color, duration_us, force_update);
+			}
+		}
+
+	} // namespace overlays
+} // namespace rsx

--- a/rpcs3/Emu/RSX/Overlays/overlay_cursor.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_cursor.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "overlays.h"
+#include <map>
+
+namespace rsx
+{
+	namespace overlays
+	{
+		enum cursor_offset : u32
+		{
+			cell_gem = 0, // CELL_GEM_MAX_NUM = 4 Move controllers
+			last = 4
+		};
+
+		class cursor_item
+		{
+		public:
+			cursor_item();
+
+			void set_expiration(u64 expiration_time);
+			bool set_position(u16 x, u16 y);
+			bool set_color(color4f color);
+
+			bool update_visibility(u64 time);
+
+			compiled_resource get_compiled();
+
+		private:
+			bool m_visible = false;
+			overlay_element m_cross_h{};
+			overlay_element m_cross_v{};
+			u64 m_expiration_time = 0;
+			u16 m_x = 0;
+			u16 m_y = 0;
+		};
+
+		class cursor_manager final : public overlay
+		{
+		public:
+			void update() override;
+			compiled_resource get_compiled() override;
+
+			void update_cursor(u32 id, u16 x, u16 y, const color4f& color, u64 duration_us, bool force_update);
+
+		private:
+			shared_mutex m_mutex;
+			std::map<u32, cursor_item> m_cursors;
+		};
+
+		void set_cursor(u32 id, u16 x, u16 y, const color4f& color, u64 duration_us, bool force_update);
+
+	} // namespace overlays
+} // namespace rsx

--- a/rpcs3/Emu/RSX/Overlays/overlay_message.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message.h
@@ -26,7 +26,7 @@ namespace rsx
 			usz m_cur_pos         = umax;
 		};
 
-		class message final : public user_interface
+		class message final : public overlay
 		{
 		public:
 			void update() override;

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -22,8 +22,8 @@ namespace rsx
 			u32 uid = umax;
 			u32 type_index = umax;
 
-			u16 virtual_width = 1280;
-			u16 virtual_height = 720;
+			static const u16 virtual_width = 1280;
+			static const u16 virtual_height = 720;
 
 			u32 min_refresh_duration_us = 16600;
 			atomic_t<bool> visible = false;

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -280,6 +280,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<pad_handler_mode> pad_mode{this, "Pad handler mode", pad_handler_mode::single_threaded, true};
 		cfg::uint<0, 100'000> pad_sleep{this, "Pad handler sleep (microseconds)", 1'000, true};
 		cfg::_bool background_input_enabled{this, "Background input enabled", true, true};
+		cfg::_bool show_move_cursor{this, "Show move cursor", false, true};
 	} io{ this };
 
 	struct node_sys : cfg::node

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="Emu\perf_monitor.cpp" />
     <ClCompile Include="Emu\RSX\Common\texture_cache.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_controls.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\overlay_cursor.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_media_list_dialog.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_osk_panel.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_user_list_dialog.cpp" />
@@ -506,6 +507,7 @@
     <ClInclude Include="Emu\RSX\Common\ranged_map.hpp" />
     <ClInclude Include="Emu\RSX\Common\simple_array.hpp" />
     <ClInclude Include="Emu\RSX\Common\time.hpp" />
+    <ClInclude Include="Emu\RSX\Overlays\overlay_cursor.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_edit_text.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_list_view.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_media_list_dialog.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1081,6 +1081,9 @@
     <ClCompile Include="Loader\disc.cpp">
       <Filter>Loader</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\overlay_cursor.cpp">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -2148,6 +2151,9 @@
     </ClInclude>
     <ClInclude Include="Loader\disc.h">
       <Filter>Loader</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\overlay_cursor.h">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -138,6 +138,7 @@ enum class emu_settings_type
 
 	// Input / Output
 	BackgroundInput,
+	ShowMoveCursor,
 	PadHandlerMode,
 	KeyboardHandler,
 	MouseHandler,
@@ -312,6 +313,7 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 
 	// Input / Output
 	{ emu_settings_type::BackgroundInput, { "Input/Output", "Background input enabled"}},
+	{ emu_settings_type::ShowMoveCursor,  { "Input/Output", "Show move cursor"}},
 	{ emu_settings_type::PadHandlerMode,  { "Input/Output", "Pad handler mode"}},
 	{ emu_settings_type::KeyboardHandler, { "Input/Output", "Keyboard"}},
 	{ emu_settings_type::MouseHandler,    { "Input/Output", "Mouse"}},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1179,6 +1179,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->backgroundInputBox, emu_settings_type::BackgroundInput);
 	SubscribeTooltip(ui->backgroundInputBox, tooltips.settings.background_input);
 
+	m_emu_settings->EnhanceCheckBox(ui->showMoveCursorBox, emu_settings_type::ShowMoveCursor);
+	SubscribeTooltip(ui->showMoveCursorBox, tooltips.settings.show_move_cursor);
+
 	//     _____           _                   _______    _
 	//    / ____|         | |                 |__   __|  | |
 	//   | (___  _   _ ___| |_ ___ _ __ ___      | | __ _| |__

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1685,6 +1685,13 @@
                </property>
               </widget>
              </item>
+             <item>
+              <widget class="QCheckBox" name="showMoveCursorBox">
+               <property name="text">
+                <string>Show PS Move Cursor</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -215,6 +215,7 @@ public:
 		const QString turntable         = tr("DJ Hero Turntable controller support.\nSelect 1 or 2 controllers if the game requires DJ Hero Turntable controllers and you don't have real turntable controllers.\nSelect Null if the game has support for DualShock or if you have real turntable controllers.\nA real turntable controller can be used at the same time as an emulated turntable controller.");
 		const QString ghltar            = tr("Guitar Hero Live (GHL) Guitar controller support.\nSelect 1 or 2 controllers if the game requires GHL Guitar controllers and you don't have real guitar controllers.\nSelect Null if the game has support for DualShock or if you have real guitar controllers.\nA real guitar controller can be used at the same time as an emulated guitar controller.");
 		const QString background_input  = tr("Allows pad and keyboard input while the game window is unfocused.");
+		const QString show_move_cursor  = tr("Shows the raw position of the PS Move input.\nThis can be very helpful during calibration screens.");
 
 		// network
 


### PR DESCRIPTION
- Adds a new dynamic option "Show PS Move Cursor"
This will display a cursor for two seconds whenever the PS Move (Fake or Mouse) position is changed.
The cursor will depict the raw screen position, not the actual ingame values.
- Adds a simple new cursor overlay system inspired by the message queue overlay
This can obviously be updated with other cursors in the future.
- Fixes a minor issue with the newly added cursor position of the Fake move handler


In my experience this can be very useful if you need to calibrate the controller and no ingame cursor is visible.


Notice the green crosshair in the target:
![image](https://user-images.githubusercontent.com/23019877/177657354-54357dba-4429-467b-b467-ef63b661694c.png)
