### PR TITLE
Savestates/Not Savestates: Fix exitspawn to HDD0 executable with mounted disc

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1475,7 +1475,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 		{
 			// Don't need /dev_bdvd
 		}
-		else if (m_cat == "DG" && from_hdd0_game)
+		else if (m_cat == "DG" && from_hdd0_game && disc.empty())
 		{
 			// Disc game located in dev_hdd0/game
 			vfs::mount("/dev_bdvd/PS3_GAME", hdd0_game + m_path.substr(hdd0_game.size(), 10));


### PR DESCRIPTION
It redirected the disc path to an invalid one, it affected savestates because I use the same mechanism as exitspawn to boot executables.