### PR TITLE
Mount custom dev_bdvd if a disc game was mounted from dev_hdd0

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -40,6 +40,7 @@ enum class game_boot_result : u32
 	nothing_to_boot,
 	wrong_disc_location,
 	invalid_file_or_folder,
+	invalid_bdvd_folder,
 	install_failed,
 	decryption_error,
 	file_creation_error,

--- a/rpcs3/Emu/vfs_config.h
+++ b/rpcs3/Emu/vfs_config.h
@@ -15,7 +15,7 @@ struct cfg_vfs : cfg::node
 	cfg::string dev_flash{ this, "/dev_flash/", "$(EmulatorDir)dev_flash/" };
 	cfg::string dev_flash2{ this, "/dev_flash2/", "$(EmulatorDir)dev_flash2/" };
 	cfg::string dev_flash3{ this, "/dev_flash3/", "$(EmulatorDir)dev_flash3/" };
-	cfg::string dev_bdvd{ this, "/dev_bdvd/" }; // Not mounted
+	cfg::string dev_bdvd{ this, "/dev_bdvd/", "$(EmulatorDir)dev_bdvd/" }; // Only mounted in some special cases
 	cfg::string app_home{ this, "/app_home/" }; // Not mounted
 
 	cfg::device_entry dev_usb{ this, "/dev_usb***/",

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -183,6 +183,7 @@ namespace gui
 	const gui_save fs_dev_flash_list    = gui_save(fs, "dev_flash_list",    QStringList());
 	const gui_save fs_dev_flash2_list   = gui_save(fs, "dev_flash2_list",   QStringList());
 	const gui_save fs_dev_flash3_list   = gui_save(fs, "dev_flash3_list",   QStringList());
+	const gui_save fs_dev_bdvd_list     = gui_save(fs, "dev_bdvd_list",     QStringList());
 	const gui_save fs_dev_usb_list      = gui_save(fs, "dev_usb00X_list",   QStringList()); // Used as a template for all usb paths
 
 	const gui_save l_tty       = gui_save(logger, "TTY",       true);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -376,6 +376,9 @@ void main_window::show_boot_error(game_boot_result status)
 	case game_boot_result::invalid_file_or_folder:
 		message = tr("The selected file or folder is invalid or corrupted.");
 		break;
+	case game_boot_result::invalid_bdvd_folder:
+		message = tr("The virtual dev_bdvd folder does not exist or is not empty.");
+		break;
 	case game_boot_result::install_failed:
 		message = tr("Additional content could not be installed.");
 		break;

--- a/rpcs3/rpcs3qt/vfs_dialog.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog.cpp
@@ -32,6 +32,7 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> _gui_settings, QWidget* par
 	vfs_dialog_tab* dev_flash_tab = new vfs_dialog_tab("dev_flash", gui::fs_dev_flash_list, &g_cfg_vfs.dev_flash, m_gui_settings, this);
 	vfs_dialog_tab* dev_flash2_tab = new vfs_dialog_tab("dev_flash2", gui::fs_dev_flash2_list, &g_cfg_vfs.dev_flash2, m_gui_settings, this);
 	vfs_dialog_tab* dev_flash3_tab = new vfs_dialog_tab("dev_flash3", gui::fs_dev_flash3_list, &g_cfg_vfs.dev_flash3, m_gui_settings, this);
+	vfs_dialog_tab* dev_bdvd_tab = new vfs_dialog_tab("dev_bdvd", gui::fs_dev_bdvd_list, &g_cfg_vfs.dev_bdvd, m_gui_settings, this);
 	vfs_dialog_usb_tab* dev_usb_tab = new vfs_dialog_usb_tab(&g_cfg_vfs.dev_usb, m_gui_settings, this);
 
 	tabs->addTab(emulator_tab, "$(EmulatorDir)");
@@ -40,6 +41,7 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> _gui_settings, QWidget* par
 	tabs->addTab(dev_flash_tab, "dev_flash");
 	tabs->addTab(dev_flash2_tab, "dev_flash2");
 	tabs->addTab(dev_flash3_tab, "dev_flash3");
+	tabs->addTab(dev_bdvd_tab, "dev_bdvd");
 	tabs->addTab(dev_usb_tab, "dev_usb");
 
 	// Create buttons


### PR DESCRIPTION
- Adds dev_bdvd back to vfs dialog
- Mounts empty dev_bdvd if a disc game in HDD game disguise is booted

Should fix White Knight Chronicles II, one of the loadable games (needs game data cleared).
The game sees the data as corrupt if it can't find "/dev_bdvd", so by mounting an empty dir, we can circumvent this.