### PR TITLE
Refactor thread id printing, drop std::thread::id

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -8,7 +8,6 @@
 #include "Thread.h"
 #include "Utilities/JIT.h"
 #include <thread>
-#include <sstream>
 #include <cfenv>
 
 #ifdef _WIN32
@@ -17,6 +16,7 @@
 #include <process.h>
 #include <sysinfoapi.h>
 #else
+#define _GNU_SOURCE
 #ifdef __APPLE__
 #define _XOPEN_SOURCE
 #define __USE_GNU
@@ -95,14 +95,6 @@ extern thread_local std::string(*g_tls_log_prefix)();
 
 // Report error and call std::abort(), defined in main.cpp
 [[noreturn]] void report_fatal_error(std::string_view);
-
-template <>
-void fmt_class_string<std::thread::id>::format(std::string& out, u64 arg)
-{
-	std::ostringstream ss;
-	ss << get_object(arg);
-	out += ss.str();
-}
 
 std::string dump_useful_thread_info()
 {
@@ -1644,7 +1636,7 @@ static void append_thread_name(std::string& msg)
 	}
 	else
 	{
-		fmt::append(msg, "Thread id = %s.\n", std::this_thread::get_id());
+		fmt::append(msg, "Thread id = %u.\n", thread_ctrl::get_tid());
 	}
 }
 
@@ -3139,6 +3131,8 @@ u64 thread_ctrl::get_tid()
 {
 #ifdef _WIN32
 	return GetCurrentThreadId();
+#elif defined(__linux__)
+	return syscall(SYS_gettid);
 #else
 	return reinterpret_cast<u64>(pthread_self());
 #endif

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -101,7 +101,7 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 		buf = std::string(_text);
 
 		// Always print thread id
-		fmt::append(buf, "\n\nThread id = %s.", std::this_thread::get_id());
+		fmt::append(buf, "\n\nThread id = %u.", thread_ctrl::get_tid());
 	}
 
 	if (!g_tls_serialize_name.empty())

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -33,7 +33,7 @@ static std::string default_string()
 		return {};
 	}
 
-	return fmt::format("TID: %s", std::this_thread::get_id());
+	return fmt::format("TID: %u", thread_ctrl::get_tid());
 }
 
 // Thread-specific log prefix provider

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -652,12 +652,8 @@ u32 utils::get_cpu_model()
 
 namespace utils
 {
-	extern const u64 main_tid = []() -> u64
+	u64 _get_main_tid()
 	{
-#ifdef _WIN32
-		return GetCurrentThreadId();
-#else
-		return reinterpret_cast<u64>(pthread_self());
-#endif
-	}();
+		return thread_ctrl::get_tid();
+	}
 }

--- a/rpcs3/util/sysinfo.hpp
+++ b/rpcs3/util/sysinfo.hpp
@@ -66,7 +66,9 @@ namespace utils
 	// A threshold of 0xFFFFFFFF means that the rep movsb is expected to be slow on this platform
 	u32 get_rep_movsb_threshold();
 
-	extern const u64 main_tid;
+	u64 _get_main_tid();
+
+	inline const u64 main_tid = _get_main_tid();
 
 #ifdef LLVM_AVAILABLE
 


### PR DESCRIPTION
pthread_self() usually returns a big opaque pointer type such as 0x7ffd7d7fa700, we can do better than this. On Linux there is a gettid() syscall which returns much shorter PID-alike number such as 12345.
Windows should be unaffected.